### PR TITLE
feat(fantasy-tycoon): combat system + item reliability fix

### DIFF
--- a/src/app/api/v1/fantasy-tycoon/combat/action/route.ts
+++ b/src/app/api/v1/fantasy-tycoon/combat/action/route.ts
@@ -1,0 +1,60 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+import { processPlayerAction, getCombatRewards } from '@/app/fantasy-tycoon/lib/combatEngine'
+import { applyXpGain } from '@/app/fantasy-tycoon/lib/leveling'
+import { CombatActionRequestSchema } from '@/app/fantasy-tycoon/models/combat'
+
+export async function POST(req: NextRequest) {
+  try {
+    const { combatState, action, character } = await req.json()
+
+    const actionParsed = CombatActionRequestSchema.parse(action)
+    const result = processPlayerAction(combatState, actionParsed, character)
+    const updatedCombat = result.combatState
+
+    let rewards = undefined
+    let updatedCharacter = character
+
+    if (updatedCombat.status === 'victory') {
+      rewards = getCombatRewards(updatedCombat, character)
+      updatedCharacter = {
+        ...character,
+        gold: character.gold + rewards.gold,
+      }
+      const levelResult = applyXpGain(updatedCharacter, rewards.xp)
+      updatedCharacter = levelResult.character
+      rewards = {
+        ...rewards,
+        leveledUp: levelResult.leveledUp,
+        newLevel: levelResult.character.level,
+      }
+    } else if (updatedCombat.status === 'defeat') {
+      const goldLoss = Math.floor(character.gold * 0.1)
+      updatedCharacter = {
+        ...character,
+        gold: Math.max(0, character.gold - goldLoss),
+      }
+      rewards = { xp: 0, gold: -goldLoss, loot: [] }
+    } else if (updatedCombat.status === 'fled') {
+      const goldLoss = Math.floor(character.gold * 0.05)
+      updatedCharacter = {
+        ...character,
+        gold: Math.max(0, character.gold - goldLoss),
+      }
+      rewards = { xp: 0, gold: -goldLoss, loot: [] }
+    }
+
+    return NextResponse.json({
+      combatState: updatedCombat,
+      rewards,
+      updatedCharacter,
+      consumedItemId: result.consumedItemId,
+    })
+  } catch (err) {
+    console.error('Error processing combat action', err)
+    return NextResponse.json(
+      { error: 'Failed to process combat action', details: (err as Error).message },
+      { status: 500 }
+    )
+  }
+}

--- a/src/app/api/v1/fantasy-tycoon/combat/start/route.ts
+++ b/src/app/api/v1/fantasy-tycoon/combat/start/route.ts
@@ -1,0 +1,34 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+import { buildStoryContext } from '@/app/fantasy-tycoon/lib/contextBuilder'
+import { initializePlayerCombatState } from '@/app/fantasy-tycoon/lib/combatEngine'
+import { generateCombatEncounter } from '@/app/fantasy-tycoon/lib/combatGenerator'
+import { CombatState } from '@/app/fantasy-tycoon/models/combat'
+
+export async function POST(req: NextRequest) {
+  try {
+    const { character, storyEvents = [] } = await req.json()
+    const context = buildStoryContext(character, storyEvents)
+    const { enemy, scenario } = await generateCombatEncounter(character, context)
+    const playerState = initializePlayerCombatState(character)
+
+    const combatState: CombatState = {
+      id: `combat-${Date.now()}-${Math.floor(Math.random() * 10000)}`,
+      eventId: `event-combat-${Date.now()}`,
+      enemy,
+      playerState,
+      turnNumber: 0,
+      combatLog: [],
+      status: 'active',
+      scenario,
+    }
+
+    return NextResponse.json({ combatState })
+  } catch (err) {
+    console.error('Error starting combat', err)
+    return NextResponse.json(
+      { error: 'Failed to start combat', details: (err as Error).message },
+      { status: 500 }
+    )
+  }
+}

--- a/src/app/api/v1/fantasy-tycoon/move-forward/schemas.ts
+++ b/src/app/api/v1/fantasy-tycoon/move-forward/schemas.ts
@@ -14,6 +14,7 @@ export const MoveForwardResponseSchema = z.object({
   character: z.any(),
   event: z.any().optional().nullable(),
   decisionPoint: z.any().optional().nullable(),
+  combatEncounter: z.any().optional().nullable(),
   genericMessage: z.string().optional().nullable(),
 })
 

--- a/src/app/api/v1/fantasy-tycoon/move-forward/services/moveForwardService.ts
+++ b/src/app/api/v1/fantasy-tycoon/move-forward/services/moveForwardService.ts
@@ -1,5 +1,6 @@
 import { MoveForwardResponse } from '@/app/api/v1/fantasy-tycoon/move-forward/schemas'
 import { buildStoryContext } from '@/app/fantasy-tycoon/lib/contextBuilder'
+import { generateCombatEncounter } from '@/app/fantasy-tycoon/lib/combatGenerator'
 import { generateLLMEvents } from '@/app/fantasy-tycoon/lib/llmEventGenerator'
 import { FantasyCharacter } from '@/app/fantasy-tycoon/models/character'
 import { FantasyDecisionPoint, FantasyStoryEvent } from '@/app/fantasy-tycoon/models/story'
@@ -14,9 +15,31 @@ export async function moveForwardService(
 
   let event: FantasyStoryEvent | null = null
   let decisionPoint: FantasyDecisionPoint | null = null
+  let combatEncounter = null
 
   try {
     const context = buildStoryContext(character, storyEvents)
+
+    // 20% chance of combat encounter (increases slightly with level)
+    const combatChance = 0.15 + character.level * 0.01
+    if (Math.random() < combatChance) {
+      const encounter = await generateCombatEncounter(character, context)
+      combatEncounter = encounter
+      event = {
+        id: `combat-event-${Date.now()}`,
+        type: 'combat_start',
+        characterId: character.id,
+        locationId: character.locationId,
+        timestamp: new Date().toISOString(),
+      }
+      return {
+        character: updatedCharacter,
+        event,
+        decisionPoint: null,
+        combatEncounter,
+      }
+    }
+
     const llmEvents = await generateLLMEvents(character, context)
     const llmEvent = llmEvents[0]
 
@@ -53,5 +76,6 @@ export async function moveForwardService(
     character: updatedCharacter,
     event,
     decisionPoint,
+    combatEncounter,
   }
 }

--- a/src/app/fantasy-tycoon/__tests__/combatEngine.test.ts
+++ b/src/app/fantasy-tycoon/__tests__/combatEngine.test.ts
@@ -1,0 +1,217 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+  calculateFleeChance,
+  getCombatRewards,
+  initializePlayerCombatState,
+  processPlayerAction,
+} from '@/app/fantasy-tycoon/lib/combatEngine'
+import { FantasyCharacter } from '@/app/fantasy-tycoon/models/character'
+import { CombatState } from '@/app/fantasy-tycoon/models/combat'
+
+const baseChar: FantasyCharacter = {
+  id: '1',
+  playerId: 'p1',
+  name: 'Test',
+  race: 'Human',
+  class: 'Warrior',
+  level: 3,
+  xp: 0,
+  xpToNextLevel: 225,
+  abilities: [],
+  locationId: 'loc1',
+  gold: 50,
+  reputation: 10,
+  distance: 5,
+  status: 'active',
+  strength: 8,
+  intelligence: 5,
+  luck: 6,
+  inventory: [
+    {
+      id: 'potion-1',
+      name: 'Healing Potion',
+      description: 'Heals',
+      quantity: 2,
+      type: 'consumable',
+      effects: { strength: 2 },
+    },
+  ],
+}
+
+function makeActiveCombat(overrides: Partial<CombatState> = {}): CombatState {
+  return {
+    id: 'combat-1',
+    eventId: 'event-1',
+    enemy: {
+      id: 'enemy-1',
+      name: 'Goblin',
+      description: 'A nasty goblin',
+      hp: 30,
+      maxHp: 30,
+      attack: 8,
+      defense: 3,
+      level: 2,
+      xpReward: 40,
+      goldReward: 15,
+      lootTable: [
+        { id: 'loot-1', name: 'Gold Coin', description: 'Shiny', quantity: 1 },
+      ],
+    },
+    playerState: {
+      hp: 90,
+      maxHp: 90,
+      attack: 24,
+      defense: 11,
+      isDefending: false,
+      activeBuffs: [],
+    },
+    turnNumber: 0,
+    combatLog: [],
+    status: 'active',
+    scenario: 'A goblin appears!',
+    ...overrides,
+  }
+}
+
+describe('Combat Engine', () => {
+  describe('initializePlayerCombatState', () => {
+    it('derives stats from character', () => {
+      const state = initializePlayerCombatState(baseChar)
+      // HP: 50 + 8*5 + 3*10 = 120
+      expect(state.maxHp).toBe(120)
+      expect(state.hp).toBe(120)
+      // Attack: 5 + 8*2 + 3 = 24
+      expect(state.attack).toBe(24)
+      // Defense: 3 + 5 + 3 = 11
+      expect(state.defense).toBe(11)
+      expect(state.isDefending).toBe(false)
+    })
+  })
+
+  describe('calculateFleeChance', () => {
+    it('returns base + luck bonus - enemy level penalty', () => {
+      // 0.3 + 6*0.02 - 2*0.05 = 0.3 + 0.12 - 0.1 = 0.32
+      const chance = calculateFleeChance(baseChar, makeActiveCombat().enemy)
+      expect(chance).toBeCloseTo(0.32, 1)
+    })
+
+    it('clamps between 0.1 and 0.9', () => {
+      const weakChar = { ...baseChar, luck: 0 }
+      const strongEnemy = { ...makeActiveCombat().enemy, level: 100 }
+      expect(calculateFleeChance(weakChar, strongEnemy)).toBe(0.1)
+
+      const luckyChar = { ...baseChar, luck: 50 }
+      const weakEnemy = { ...makeActiveCombat().enemy, level: 0 }
+      expect(calculateFleeChance(luckyChar, weakEnemy)).toBe(0.9)
+    })
+  })
+
+  describe('processPlayerAction', () => {
+    it('processes attack and reduces enemy HP', () => {
+      const combat = makeActiveCombat()
+      vi.spyOn(Math, 'random').mockReturnValue(0.5) // neutral variance
+      const { combatState: result } = processPlayerAction(combat, { action: 'attack' }, baseChar)
+
+      expect(result.enemy.hp).toBeLessThan(30)
+      expect(result.combatLog.length).toBeGreaterThanOrEqual(2) // player attack + enemy attack
+      expect(result.turnNumber).toBe(1)
+      vi.restoreAllMocks()
+    })
+
+    it('processes defend and sets isDefending', () => {
+      const combat = makeActiveCombat()
+      vi.spyOn(Math, 'random').mockReturnValue(0.5)
+      const { combatState: result } = processPlayerAction(combat, { action: 'defend' }, baseChar)
+
+      // isDefending gets set then enemy attacks with doubled player defense
+      // The log should show defend action
+      const playerLog = result.combatLog.find(
+        l => l.actor === 'player' && l.action === 'defend'
+      )
+      expect(playerLog).toBeTruthy()
+      vi.restoreAllMocks()
+    })
+
+    it('processes flee successfully', () => {
+      const combat = makeActiveCombat()
+      vi.spyOn(Math, 'random').mockReturnValue(0.1) // below flee chance
+      const { combatState: result } = processPlayerAction(combat, { action: 'flee' }, baseChar)
+
+      expect(result.status).toBe('fled')
+      vi.restoreAllMocks()
+    })
+
+    it('processes flee failure', () => {
+      const combat = makeActiveCombat()
+      vi.spyOn(Math, 'random').mockReturnValue(0.99) // above flee chance
+      const { combatState: result } = processPlayerAction(combat, { action: 'flee' }, baseChar)
+
+      expect(result.status).toBe('active')
+      const fleeLog = result.combatLog.find(l => l.action === 'flee')
+      expect(fleeLog?.description).toContain('blocks your escape')
+      vi.restoreAllMocks()
+    })
+
+    it('sets victory when enemy HP reaches 0', () => {
+      const combat = makeActiveCombat({
+        enemy: { ...makeActiveCombat().enemy, hp: 1, defense: 0 },
+      })
+      vi.spyOn(Math, 'random').mockReturnValue(0.5)
+      const { combatState: result } = processPlayerAction(combat, { action: 'attack' }, baseChar)
+
+      expect(result.enemy.hp).toBe(0)
+      expect(result.status).toBe('victory')
+      vi.restoreAllMocks()
+    })
+
+    it('sets defeat when player HP reaches 0', () => {
+      const combat = makeActiveCombat({
+        playerState: { ...makeActiveCombat().playerState, hp: 1 },
+        enemy: { ...makeActiveCombat().enemy, attack: 100 },
+      })
+      vi.spyOn(Math, 'random').mockReturnValue(0.5)
+      const { combatState: result } = processPlayerAction(combat, { action: 'defend' }, baseChar)
+
+      expect(result.playerState.hp).toBe(0)
+      expect(result.status).toBe('defeat')
+      vi.restoreAllMocks()
+    })
+
+    it('processes use_item and returns consumedItemId', () => {
+      const combat = makeActiveCombat({
+        playerState: { ...makeActiveCombat().playerState, hp: 50 },
+      })
+      vi.spyOn(Math, 'random').mockReturnValue(0.5)
+      const { combatState: result, consumedItemId } = processPlayerAction(
+        combat,
+        { action: 'use_item', itemId: 'potion-1' },
+        baseChar
+      )
+
+      expect(consumedItemId).toBe('potion-1')
+      // Healing potion with strength: 2 heals 10 HP (2 * 5)
+      expect(result.playerState.hp).toBeGreaterThan(50)
+      vi.restoreAllMocks()
+    })
+
+    it('does nothing if combat is not active', () => {
+      const combat = makeActiveCombat({ status: 'victory' })
+      const { combatState: result } = processPlayerAction(combat, { action: 'attack' }, baseChar)
+      expect(result.combatLog.length).toBe(0)
+    })
+  })
+
+  describe('getCombatRewards', () => {
+    it('returns xp and gold from enemy', () => {
+      const combat = makeActiveCombat()
+      vi.spyOn(Math, 'random').mockReturnValue(0.1) // high loot chance
+      const rewards = getCombatRewards(combat, baseChar)
+
+      expect(rewards.xp).toBe(40)
+      expect(rewards.gold).toBe(15)
+      expect(rewards.loot.length).toBeGreaterThanOrEqual(0)
+      vi.restoreAllMocks()
+    })
+  })
+})

--- a/src/app/fantasy-tycoon/__tests__/combatItemEffects.test.ts
+++ b/src/app/fantasy-tycoon/__tests__/combatItemEffects.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  applyCombatItemEffect,
+  isUsableInCombat,
+} from '@/app/fantasy-tycoon/lib/combatItemEffects'
+import { CombatPlayerState } from '@/app/fantasy-tycoon/models/combat'
+import { Item } from '@/app/fantasy-tycoon/models/item'
+
+const basePlayerState: CombatPlayerState = {
+  hp: 50,
+  maxHp: 100,
+  attack: 15,
+  defense: 10,
+  isDefending: false,
+  activeBuffs: [],
+}
+
+describe('combatItemEffects', () => {
+  describe('isUsableInCombat', () => {
+    it('returns true for consumable with strength effect', () => {
+      const item: Item = {
+        id: '1',
+        name: 'Potion',
+        description: 'test',
+        quantity: 1,
+        type: 'consumable',
+        effects: { strength: 2 },
+      }
+      expect(isUsableInCombat(item)).toBe(true)
+    })
+
+    it('returns true for consumable with luck effect', () => {
+      const item: Item = {
+        id: '1',
+        name: 'Lucky Charm',
+        description: 'test',
+        quantity: 1,
+        type: 'consumable',
+        effects: { luck: 1 },
+      }
+      expect(isUsableInCombat(item)).toBe(true)
+    })
+
+    it('returns false for consumable with only gold effect', () => {
+      const item: Item = {
+        id: '1',
+        name: 'Gold Coin',
+        description: 'test',
+        quantity: 1,
+        type: 'consumable',
+        effects: { gold: 10 },
+      }
+      expect(isUsableInCombat(item)).toBe(false)
+    })
+
+    it('returns false for non-consumable items', () => {
+      const item: Item = {
+        id: '1',
+        name: 'Sword',
+        description: 'test',
+        quantity: 1,
+        type: 'equipment',
+        effects: { strength: 5 },
+      }
+      expect(isUsableInCombat(item)).toBe(false)
+    })
+
+    it('returns false for items without effects', () => {
+      const item: Item = {
+        id: '1',
+        name: 'Potion',
+        description: 'test',
+        quantity: 1,
+        type: 'consumable',
+      }
+      expect(isUsableInCombat(item)).toBe(false)
+    })
+  })
+
+  describe('applyCombatItemEffect', () => {
+    it('heals HP from strength effect', () => {
+      const item: Item = {
+        id: '1',
+        name: 'Healing Potion',
+        description: 'test',
+        quantity: 1,
+        type: 'consumable',
+        effects: { strength: 3 },
+      }
+      const { playerState, description } = applyCombatItemEffect(item, basePlayerState)
+      // strength: 3 -> heals 15 HP
+      expect(playerState.hp).toBe(65)
+      expect(description).toContain('restored 15 HP')
+    })
+
+    it('does not heal past maxHp', () => {
+      const fullHpState = { ...basePlayerState, hp: 95 }
+      const item: Item = {
+        id: '1',
+        name: 'Healing Potion',
+        description: 'test',
+        quantity: 1,
+        type: 'consumable',
+        effects: { strength: 10 },
+      }
+      const { playerState } = applyCombatItemEffect(item, fullHpState)
+      expect(playerState.hp).toBe(100)
+    })
+
+    it('adds defense buff from intelligence effect', () => {
+      const item: Item = {
+        id: '1',
+        name: 'Shield Scroll',
+        description: 'test',
+        quantity: 1,
+        type: 'consumable',
+        effects: { intelligence: 3 },
+      }
+      const { playerState, description } = applyCombatItemEffect(item, basePlayerState)
+      expect(playerState.activeBuffs).toHaveLength(1)
+      expect(playerState.activeBuffs![0].stat).toBe('defense')
+      expect(playerState.activeBuffs![0].value).toBe(6) // 3 * 2
+      expect(playerState.activeBuffs![0].turnsRemaining).toBe(3)
+      expect(description).toContain('+6 defense')
+    })
+
+    it('adds attack buff from luck effect', () => {
+      const item: Item = {
+        id: '1',
+        name: 'Lucky Charm',
+        description: 'test',
+        quantity: 1,
+        type: 'consumable',
+        effects: { luck: 2 },
+      }
+      const { playerState, description } = applyCombatItemEffect(item, basePlayerState)
+      expect(playerState.activeBuffs).toHaveLength(1)
+      expect(playerState.activeBuffs![0].stat).toBe('attack')
+      expect(playerState.activeBuffs![0].value).toBe(4) // 2 * 2
+      expect(description).toContain('+4 attack')
+    })
+
+    it('applies multiple effects simultaneously', () => {
+      const item: Item = {
+        id: '1',
+        name: 'Super Potion',
+        description: 'test',
+        quantity: 1,
+        type: 'consumable',
+        effects: { strength: 2, intelligence: 1, luck: 1 },
+      }
+      const { playerState } = applyCombatItemEffect(item, basePlayerState)
+      expect(playerState.hp).toBe(60) // healed 10
+      expect(playerState.activeBuffs).toHaveLength(2) // defense + attack buffs
+    })
+  })
+})

--- a/src/app/fantasy-tycoon/__tests__/itemPostProcessor.test.ts
+++ b/src/app/fantasy-tycoon/__tests__/itemPostProcessor.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it } from 'vitest'
+
+import { inferItemTypeAndEffects } from '@/app/fantasy-tycoon/lib/itemPostProcessor'
+import { Item } from '@/app/fantasy-tycoon/models/item'
+
+function makeItem(overrides: Partial<Item> = {}): Item {
+  return {
+    id: 'item-1',
+    name: 'Unknown Item',
+    description: 'A mysterious item',
+    quantity: 1,
+    ...overrides,
+  }
+}
+
+describe('itemPostProcessor', () => {
+  describe('potions', () => {
+    it('infers healing potion as consumable with strength effect', () => {
+      const item = makeItem({ name: 'Healing Potion' })
+      const result = inferItemTypeAndEffects(item)
+      expect(result.type).toBe('consumable')
+      expect(result.effects?.strength).toBe(2)
+    })
+
+    it('infers strength potion', () => {
+      const item = makeItem({ name: 'Potion of Strength' })
+      const result = inferItemTypeAndEffects(item)
+      expect(result.type).toBe('consumable')
+      expect(result.effects?.strength).toBe(3)
+    })
+
+    it('infers wisdom elixir', () => {
+      const item = makeItem({ name: 'Elixir of Wisdom' })
+      const result = inferItemTypeAndEffects(item)
+      expect(result.type).toBe('consumable')
+      expect(result.effects?.intelligence).toBe(2)
+    })
+
+    it('infers luck tonic', () => {
+      const item = makeItem({ name: 'Lucky Tonic' })
+      const result = inferItemTypeAndEffects(item)
+      expect(result.type).toBe('consumable')
+      expect(result.effects?.luck).toBe(2)
+    })
+
+    it('defaults unknown potion to strength+intelligence', () => {
+      const item = makeItem({ name: 'Mysterious Potion' })
+      const result = inferItemTypeAndEffects(item)
+      expect(result.type).toBe('consumable')
+      expect(result.effects?.strength).toBe(1)
+      expect(result.effects?.intelligence).toBe(1)
+    })
+  })
+
+  describe('scrolls', () => {
+    it('infers scroll as consumable with XP', () => {
+      const item = makeItem({ name: 'Mysterious Scroll' })
+      const result = inferItemTypeAndEffects(item)
+      expect(result.type).toBe('consumable')
+      expect(result.effects?.xp).toBe(30)
+    })
+
+    it('infers knowledge tome with bonus XP and intelligence', () => {
+      const item = makeItem({ name: 'Tome of Knowledge' })
+      const result = inferItemTypeAndEffects(item)
+      expect(result.type).toBe('consumable')
+      expect(result.effects?.xp).toBe(50)
+      expect(result.effects?.intelligence).toBe(1)
+    })
+  })
+
+  describe('food', () => {
+    it('infers bread as consumable', () => {
+      const item = makeItem({ name: 'Loaf of Bread' })
+      const result = inferItemTypeAndEffects(item)
+      expect(result.type).toBe('consumable')
+      expect(result.effects?.strength).toBe(1)
+    })
+  })
+
+  describe('gems and coins', () => {
+    it('infers ruby as high-value gold consumable', () => {
+      const item = makeItem({ name: 'Ruby Gemstone' })
+      const result = inferItemTypeAndEffects(item)
+      expect(result.type).toBe('consumable')
+      expect(result.effects?.gold).toBe(50)
+    })
+
+    it('infers gold coin', () => {
+      const item = makeItem({ name: 'Gold Coin' })
+      const result = inferItemTypeAndEffects(item)
+      expect(result.type).toBe('consumable')
+      expect(result.effects?.gold).toBe(15)
+    })
+  })
+
+  describe('charms', () => {
+    it('infers amulet as luck consumable', () => {
+      const item = makeItem({ name: 'Ancient Amulet' })
+      const result = inferItemTypeAndEffects(item)
+      expect(result.type).toBe('consumable')
+      expect(result.effects?.luck).toBe(2)
+    })
+  })
+
+  describe('already complete items', () => {
+    it('does not modify items with type and effects', () => {
+      const item = makeItem({
+        name: 'Custom Potion',
+        type: 'consumable',
+        effects: { gold: 100 },
+      })
+      const result = inferItemTypeAndEffects(item)
+      expect(result.effects?.gold).toBe(100)
+      expect(result.effects?.strength).toBeUndefined()
+    })
+  })
+
+  describe('unrecognized items', () => {
+    it('leaves unrecognized items as misc', () => {
+      const item = makeItem({ name: 'Wooden Plank' })
+      const result = inferItemTypeAndEffects(item)
+      expect(result.type).toBeUndefined()
+      expect(result.effects).toBeUndefined()
+    })
+  })
+
+  describe('edge cases', () => {
+    it('handles items with effects but no type', () => {
+      const item = makeItem({ name: 'Magic Thing', effects: { strength: 5 } })
+      const result = inferItemTypeAndEffects(item)
+      expect(result.type).toBe('consumable')
+    })
+
+    it('handles consumable type with no effects', () => {
+      const item = makeItem({ name: 'Magic Thing', type: 'consumable' })
+      const result = inferItemTypeAndEffects(item)
+      expect(result.effects).toBeDefined()
+    })
+  })
+})

--- a/src/app/fantasy-tycoon/components/CombatUI.tsx
+++ b/src/app/fantasy-tycoon/components/CombatUI.tsx
@@ -1,0 +1,255 @@
+'use client'
+
+import { LoaderCircle } from 'lucide-react'
+import { useCallback, useRef, useEffect, useState } from 'react'
+
+import { Button } from '@/app/fantasy-tycoon/components/ui/button'
+import { useCombatActionMutation } from '@/app/fantasy-tycoon/hooks/useCombatActionMutation'
+import { useGameStore } from '@/app/fantasy-tycoon/hooks/useGameStore'
+import { isUsableInCombat } from '@/app/fantasy-tycoon/lib/combatItemEffects'
+import { CombatState } from '@/app/fantasy-tycoon/models/combat'
+import { Item } from '@/app/fantasy-tycoon/models/types'
+
+function HpBar({ current, max, label, color }: { current: number; max: number; label: string; color: string }) {
+  const pct = Math.max(0, Math.min(100, (current / max) * 100))
+  const barColor = pct > 50 ? 'bg-green-500' : pct > 25 ? 'bg-yellow-500' : 'bg-red-500'
+
+  return (
+    <div className="space-y-1">
+      <div className="flex justify-between text-xs">
+        <span className="text-slate-300">{label}</span>
+        <span className={color}>{current}/{max} HP</span>
+      </div>
+      <div className="h-2 bg-slate-700 rounded-full overflow-hidden">
+        <div
+          className={`h-full ${barColor} rounded-full transition-all duration-300`}
+          style={{ width: `${pct}%` }}
+        />
+      </div>
+    </div>
+  )
+}
+
+interface CombatUIProps {
+  combatState: CombatState
+}
+
+export function CombatUI({ combatState }: CombatUIProps) {
+  const { getSelectedCharacter } = useGameStore()
+  const { mutate: combatAction, isPending } = useCombatActionMutation()
+  const [showItemMenu, setShowItemMenu] = useState(false)
+  const logRef = useRef<HTMLDivElement>(null)
+
+  const character = getSelectedCharacter()
+  const { enemy, playerState, combatLog, scenario, status } = combatState
+
+  const combatItems = (character?.inventory ?? []).filter(
+    (i: Item) => i.status !== 'deleted' && isUsableInCombat(i)
+  )
+
+  const handleAction = useCallback(
+    (action: 'attack' | 'defend' | 'flee', itemId?: string) => {
+      setShowItemMenu(false)
+      combatAction({ action, itemId })
+    },
+    [combatAction]
+  )
+
+  const handleUseItem = useCallback(
+    (itemId: string) => {
+      setShowItemMenu(false)
+      combatAction({ action: 'use_item', itemId })
+    },
+    [combatAction]
+  )
+
+  useEffect(() => {
+    if (logRef.current) {
+      logRef.current.scrollTop = logRef.current.scrollHeight
+    }
+  }, [combatLog.length])
+
+  if (status !== 'active') return null
+
+  return (
+    <div className="space-y-4">
+      {/* Header */}
+      <div className="text-center">
+        <h4 className="font-semibold uppercase text-red-400 border-b border-red-900/50 pb-2 mb-2">
+          Combat
+        </h4>
+        <p className="text-sm text-slate-300 italic">{scenario}</p>
+      </div>
+
+      {/* Enemy info */}
+      <div className="bg-[#1e1f30] border border-red-900/30 rounded-lg p-3 space-y-2">
+        <div className="flex justify-between items-center">
+          <div>
+            <span className="font-bold text-red-400">{enemy.name}</span>
+            <span className="text-xs text-slate-400 ml-2">Lv.{enemy.level}</span>
+          </div>
+          {enemy.specialAbility && (
+            <span className="text-[10px] px-1.5 py-0.5 bg-purple-900/50 text-purple-400 rounded">
+              {enemy.specialAbility.name}
+            </span>
+          )}
+        </div>
+        <p className="text-xs text-slate-400">{enemy.description}</p>
+        <HpBar current={enemy.hp} max={enemy.maxHp} label="Enemy" color="text-red-400" />
+      </div>
+
+      {/* Player info */}
+      <div className="bg-[#1e1f30] border border-blue-900/30 rounded-lg p-3 space-y-2">
+        <div className="flex justify-between items-center">
+          <span className="font-bold text-blue-400">{character?.name ?? 'You'}</span>
+          {playerState.isDefending && (
+            <span className="text-[10px] px-1.5 py-0.5 bg-blue-900/50 text-blue-400 rounded">
+              Defending
+            </span>
+          )}
+        </div>
+        <HpBar current={playerState.hp} max={playerState.maxHp} label="You" color="text-blue-400" />
+        {playerState.activeBuffs && playerState.activeBuffs.length > 0 && (
+          <div className="flex gap-2 flex-wrap">
+            {playerState.activeBuffs.map((buff, i) => (
+              <span key={i} className="text-[10px] px-1.5 py-0.5 bg-emerald-900/50 text-emerald-400 rounded">
+                +{buff.value} {buff.stat} ({buff.turnsRemaining}t)
+              </span>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Combat Log */}
+      {combatLog.length > 0 && (
+        <div
+          ref={logRef}
+          className="bg-slate-900 border border-slate-700 rounded-lg p-2 max-h-40 overflow-y-auto space-y-1"
+        >
+          {combatLog.map((entry, i) => (
+            <div
+              key={i}
+              className={`text-xs ${
+                entry.actor === 'player' ? 'text-blue-300' : 'text-red-300'
+              }`}
+            >
+              <span className="text-slate-500">T{entry.turn}:</span> {entry.description}
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* Actions */}
+      <div className="space-y-2">
+        <div className="grid grid-cols-2 gap-2">
+          <Button
+            className="bg-red-900/50 border border-red-800 hover:bg-red-800 text-white text-sm py-2 rounded-md transition-colors"
+            onClick={() => handleAction('attack')}
+            disabled={isPending}
+          >
+            {isPending ? <LoaderCircle className="animate-spin h-4 w-4" /> : 'Attack'}
+          </Button>
+          <Button
+            className="bg-blue-900/50 border border-blue-800 hover:bg-blue-800 text-white text-sm py-2 rounded-md transition-colors"
+            onClick={() => handleAction('defend')}
+            disabled={isPending}
+          >
+            Defend
+          </Button>
+          <Button
+            className="bg-emerald-900/50 border border-emerald-800 hover:bg-emerald-800 text-white text-sm py-2 rounded-md transition-colors relative"
+            onClick={() => setShowItemMenu(!showItemMenu)}
+            disabled={isPending || combatItems.length === 0}
+          >
+            Use Item {combatItems.length > 0 && `(${combatItems.length})`}
+          </Button>
+          <Button
+            className="bg-slate-700 border border-slate-600 hover:bg-slate-600 text-white text-sm py-2 rounded-md transition-colors"
+            onClick={() => handleAction('flee')}
+            disabled={isPending}
+          >
+            Flee
+          </Button>
+        </div>
+
+        {/* Item selection dropdown */}
+        {showItemMenu && combatItems.length > 0 && (
+          <div className="bg-[#1e1f30] border border-[#3a3c56] rounded-lg p-2 space-y-1">
+            {combatItems.map((item: Item) => (
+              <Button
+                key={item.id}
+                className="w-full text-left bg-[#2a2b3f] border border-[#3a3c56] hover:bg-[#3a3c56] text-white text-xs py-2 px-3 rounded-md"
+                onClick={() => handleUseItem(item.id)}
+                disabled={isPending}
+              >
+                <span className="font-semibold">{item.name}</span>
+                {item.quantity > 1 && <span className="text-slate-400 ml-1">x{item.quantity}</span>}
+                {item.effects && (
+                  <span className="text-emerald-400 ml-2 text-[10px]">
+                    {Object.entries(item.effects)
+                      .filter(([, v]) => v && v !== 0)
+                      .map(([k, v]) => `+${v} ${k}`)
+                      .join(', ')}
+                  </span>
+                )}
+              </Button>
+            ))}
+          </div>
+        )}
+      </div>
+
+      <div className="text-center text-xs text-slate-500">
+        Turn {combatState.turnNumber}
+      </div>
+    </div>
+  )
+}
+
+interface CombatResultProps {
+  combatState: CombatState
+  onContinue: () => void
+}
+
+export function CombatResult({ combatState, onContinue }: CombatResultProps) {
+  const { status, enemy } = combatState
+
+  const config = {
+    victory: {
+      title: 'Victory!',
+      color: 'text-yellow-400',
+      borderColor: 'border-yellow-900/50',
+      bgColor: 'bg-yellow-900/20',
+      message: `You defeated ${enemy.name}!`,
+    },
+    defeat: {
+      title: 'Defeated',
+      color: 'text-red-400',
+      borderColor: 'border-red-900/50',
+      bgColor: 'bg-red-900/20',
+      message: `You were defeated by ${enemy.name}...`,
+    },
+    fled: {
+      title: 'Escaped',
+      color: 'text-slate-300',
+      borderColor: 'border-slate-600',
+      bgColor: 'bg-slate-800',
+      message: `You fled from ${enemy.name}.`,
+    },
+    active: { title: '', color: '', borderColor: '', bgColor: '', message: '' },
+  }
+
+  const c = config[status]
+
+  return (
+    <div className={`${c.bgColor} border ${c.borderColor} rounded-lg p-6 text-center space-y-4`}>
+      <h4 className={`text-xl font-bold ${c.color}`}>{c.title}</h4>
+      <p className="text-slate-300">{c.message}</p>
+      <Button
+        className="bg-[#2a2b3f] border border-[#3a3c56] hover:bg-[#3a3c56] text-white px-6 py-2 rounded-md"
+        onClick={onContinue}
+      >
+        Continue
+      </Button>
+    </div>
+  )
+}

--- a/src/app/fantasy-tycoon/components/GameUI.tsx
+++ b/src/app/fantasy-tycoon/components/GameUI.tsx
@@ -10,6 +10,7 @@ import { useResolveDecisionMutation } from '@/app/fantasy-tycoon/hooks/useResolv
 import { getGenericTravelMessage } from '@/app/fantasy-tycoon/lib/getGenericTravelMessage'
 import { flipCoin } from '@/app/utils'
 
+import { CombatUI, CombatResult } from './CombatUI'
 import { InventoryPanel } from './InventoryPanel'
 import { StoryFeed } from './StoryFeed'
 
@@ -30,6 +31,7 @@ export default function GameUI() {
     setGenericMessage,
     incrementDistance,
     setDecisionPoint,
+    setCombatState,
   } = useGameStore()
 
   const { mutate: moveForwardMutation, isPending: moveForwardPending } = useMoveForwardMutation()
@@ -75,58 +77,68 @@ export default function GameUI() {
       <div className="relative z-10 mx-auto w-full">
         <div className="grid grid-cols-1 md:grid-cols-2 gap-6 pt-6">
           <div className={'p-4 bg-[#161723] border border-[#3a3c56] rounded-lg space-y-4'}>
-            {gameState.decisionPoint ? (
-              <h4 className="font-semibold w-full text-center uppercase border-b border-[#3a3c56] pb-2 mb-4">
-                Event
-              </h4>
-            ) : (
-              <Button
-                className="w-full bg-[#2a2b3f] border border-[#3a3c56] hover:bg-[#3a3c56] text-white hover:shadow-md transition-all duration-300 active:translate-y-1/8 active:ring-1 active:ring-[#515375]"
-                style={{ userSelect: 'none' }}
-                onClick={handleMoveForward}
-                disabled={moveForwardPending || resolveDecisionPending}
-              >
-                {getTravelButtonMessage({
-                  isLoading: moveForwardPending,
-                  distance: getSelectedCharacter()?.distance ?? 0,
-                })}
-              </Button>
-            )}
-            {resolveDecisionPending && (
-              <div className="text-xs text-gray-500 mt-2">Resolving...</div>
-            )}
-            {gameState.decisionPoint && !gameState.decisionPoint.resolved && (
-              <div>
-                <div className="font-semibold mb-6">{gameState.decisionPoint.prompt}</div>
-                <div className="space-y-2 mt-2">
-                  {gameState.decisionPoint.options.map((option: { id: string; text: string }) => {
-                    if (!option) return null
-                    if (!gameState.decisionPoint) return null
-                    return (
-                      <Button
-                        key={option.id}
-                        className="block w-full text-left border border-[#3a3c56] bg-[#2a2b3f] hover:bg-[#3a3c56] text-white px-3 py-2 mt-2 rounded disabled:opacity-60"
-                        style={{ userSelect: 'none' }}
-                        disabled={resolveDecisionPending}
-                        onClick={() => {
-                          handleResolveDecision(option.id)
-                        }}
-                      >
-                        {option.text}
-                      </Button>
-                    )
-                  })}
-                </div>
+            {/* Combat UI takes priority */}
+            {gameState.combatState && gameState.combatState.status === 'active' ? (
+              <CombatUI combatState={gameState.combatState} />
+            ) : gameState.combatState && gameState.combatState.status !== 'active' ? (
+              <CombatResult
+                combatState={gameState.combatState}
+                onContinue={() => setCombatState(null)}
+              />
+            ) : gameState.decisionPoint ? (
+              <>
+                <h4 className="font-semibold w-full text-center uppercase border-b border-[#3a3c56] pb-2 mb-4">
+                  Event
+                </h4>
                 {resolveDecisionPending && (
                   <div className="text-xs text-gray-500 mt-2">Resolving...</div>
                 )}
-              </div>
-            )}
-            {gameState.genericMessage && !gameState.decisionPoint && (
-              <div className="text-sm">{gameState.genericMessage}</div>
-            )}
-            {!gameState.decisionPoint && (
-              <StoryFeed events={storyEvents} filterCharacterId={selectedCharacterId} />
+                {!gameState.decisionPoint.resolved && (
+                  <div>
+                    <div className="font-semibold mb-6">{gameState.decisionPoint.prompt}</div>
+                    <div className="space-y-2 mt-2">
+                      {gameState.decisionPoint.options.map((option: { id: string; text: string }) => {
+                        if (!option) return null
+                        if (!gameState.decisionPoint) return null
+                        return (
+                          <Button
+                            key={option.id}
+                            className="block w-full text-left border border-[#3a3c56] bg-[#2a2b3f] hover:bg-[#3a3c56] text-white px-3 py-2 mt-2 rounded disabled:opacity-60"
+                            style={{ userSelect: 'none' }}
+                            disabled={resolveDecisionPending}
+                            onClick={() => {
+                              handleResolveDecision(option.id)
+                            }}
+                          >
+                            {option.text}
+                          </Button>
+                        )
+                      })}
+                    </div>
+                    {resolveDecisionPending && (
+                      <div className="text-xs text-gray-500 mt-2">Resolving...</div>
+                    )}
+                  </div>
+                )}
+              </>
+            ) : (
+              <>
+                <Button
+                  className="w-full bg-[#2a2b3f] border border-[#3a3c56] hover:bg-[#3a3c56] text-white hover:shadow-md transition-all duration-300 active:translate-y-1/8 active:ring-1 active:ring-[#515375]"
+                  style={{ userSelect: 'none' }}
+                  onClick={handleMoveForward}
+                  disabled={moveForwardPending || resolveDecisionPending}
+                >
+                  {getTravelButtonMessage({
+                    isLoading: moveForwardPending,
+                    distance: getSelectedCharacter()?.distance ?? 0,
+                  })}
+                </Button>
+                {gameState.genericMessage && (
+                  <div className="text-sm">{gameState.genericMessage}</div>
+                )}
+                <StoryFeed events={storyEvents} filterCharacterId={selectedCharacterId} />
+              </>
             )}
           </div>
           {/* Right column: Inventory Panel */}

--- a/src/app/fantasy-tycoon/hooks/useCombatActionMutation.ts
+++ b/src/app/fantasy-tycoon/hooks/useCombatActionMutation.ts
@@ -1,0 +1,141 @@
+'use client'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+
+import { inferItemTypeAndEffects } from '@/app/fantasy-tycoon/lib/itemPostProcessor'
+import { CombatAction, CombatState } from '@/app/fantasy-tycoon/models/combat'
+import { FantasyCharacter, Item } from '@/app/fantasy-tycoon/models/types'
+
+import { useGameStateBuilder, useGameStore } from './useGameStore'
+
+interface CombatActionResponse {
+  combatState: CombatState
+  rewards?: {
+    xp: number
+    gold: number
+    loot: Item[]
+    leveledUp?: boolean
+    newLevel?: number
+  }
+  updatedCharacter: FantasyCharacter
+  consumedItemId?: string
+}
+
+export function useCombatActionMutation() {
+  const queryClient = useQueryClient()
+  const { getSelectedCharacter } = useGameStore()
+  const {
+    addItem,
+    addStoryEvent,
+    commit,
+    setCombatState,
+    updateSelectedCharacter,
+  } = useGameStateBuilder()
+
+  return useMutation({
+    mutationFn: async ({
+      action,
+      itemId,
+    }: {
+      action: CombatAction
+      itemId?: string
+    }) => {
+      const character = getSelectedCharacter()
+      if (!character) throw new Error('No character found')
+
+      const { gameState } = useGameStore.getState()
+      const combatState = gameState.combatState
+      if (!combatState) throw new Error('No active combat')
+
+      const res = await fetch('/api/v1/fantasy-tycoon/combat/action', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          combatState,
+          action: { action, itemId },
+          character,
+        }),
+      })
+
+      if (!res.ok) throw new Error('Failed to process combat action')
+
+      const data: CombatActionResponse = await res.json()
+
+      // Update character with server state
+      if (data.updatedCharacter) {
+        updateSelectedCharacter(data.updatedCharacter)
+      }
+
+      // Handle consumed item - decrement from inventory
+      if (data.consumedItemId) {
+        const updatedInventory = character.inventory
+          .map(i => {
+            if (i.id !== data.consumedItemId) return i
+            const newQty = i.quantity - 1
+            if (newQty <= 0) return { ...i, quantity: 0, status: 'deleted' as const }
+            return { ...i, quantity: newQty }
+          })
+          .filter(i => i.quantity > 0 || i.status === 'deleted')
+        updateSelectedCharacter({ inventory: updatedInventory })
+      }
+
+      if (data.combatState.status === 'active') {
+        // Combat continues
+        setCombatState(data.combatState)
+      } else {
+        // Combat ended
+        const enemy = combatState.enemy
+
+        if (data.combatState.status === 'victory' && data.rewards) {
+          // Add loot items
+          for (const lootItem of data.rewards.loot) {
+            addItem(inferItemTypeAndEffects(lootItem))
+          }
+
+          const levelMsg = data.rewards.leveledUp
+            ? ` Level up! You are now level ${data.rewards.newLevel}!`
+            : ''
+
+          addStoryEvent({
+            id: `combat-victory-${Date.now()}`,
+            type: 'combat_victory',
+            characterId: character.id,
+            locationId: character.locationId,
+            timestamp: new Date().toISOString(),
+            outcomeDescription: `You defeated ${enemy.name}! +${data.rewards.xp} XP, +${data.rewards.gold} Gold.${levelMsg}`,
+            resourceDelta: {
+              gold: data.rewards.gold,
+            },
+          })
+        } else if (data.combatState.status === 'defeat') {
+          addStoryEvent({
+            id: `combat-defeat-${Date.now()}`,
+            type: 'combat_defeat',
+            characterId: character.id,
+            locationId: character.locationId,
+            timestamp: new Date().toISOString(),
+            outcomeDescription: `You were defeated by ${enemy.name}. You lost some gold fleeing the battle.`,
+            resourceDelta: { gold: data.rewards?.gold },
+          })
+        } else if (data.combatState.status === 'fled') {
+          addStoryEvent({
+            id: `combat-fled-${Date.now()}`,
+            type: 'combat_fled',
+            characterId: character.id,
+            locationId: character.locationId,
+            timestamp: new Date().toISOString(),
+            outcomeDescription: `You fled from ${enemy.name}, losing some gold in your haste.`,
+            resourceDelta: { gold: data.rewards?.gold },
+          })
+        }
+
+        setCombatState(null)
+      }
+
+      commit()
+      return data
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['fantasy-tycoon', 'game-state'] })
+    },
+  })
+}

--- a/src/app/fantasy-tycoon/hooks/useGameStore.ts
+++ b/src/app/fantasy-tycoon/hooks/useGameStore.ts
@@ -6,6 +6,7 @@ import { persist } from 'zustand/middleware'
 import { defaultGameState } from '@/app/fantasy-tycoon/lib/defaultGameState'
 import { useItem as applyItemUse } from '@/app/fantasy-tycoon/lib/itemEffects'
 import { FantasyCharacter } from '@/app/fantasy-tycoon/models/character'
+import { CombatState } from '@/app/fantasy-tycoon/models/combat'
 import {
   FantasyDecisionPoint,
   FantasyStoryEvent,
@@ -42,6 +43,7 @@ export interface GameStore {
   getSelectedCharacter: () => FantasyCharacter | null
   incrementDistance: () => void
   selectCharacter: (id: string) => void
+  setCombatState: (combatState: CombatState | null) => void
   setDecisionPoint: (decisionPoint: FantasyDecisionPoint | null) => void
   setGameState: (gameState: GameState) => void
   setGenericMessage: (message: string) => void
@@ -133,6 +135,18 @@ export const useGameStore = create<GameStore>()(
               },
             }
             return updatedState
+          })
+        )
+      },
+      setCombatState: (combatState: CombatState | null) => {
+        set(
+          produce((state: GameStore) => {
+            return {
+              gameState: {
+                ...state.gameState,
+                combatState,
+              },
+            }
           })
         )
       },
@@ -241,7 +255,7 @@ export const useGameStore = create<GameStore>()(
     }),
     {
       name: 'fantasy-tycoon-storage', // localStorage key
-      version: 1,
+      version: 2,
       migrate: (persistedState: unknown) => {
         const state = persistedState as GameStore
         if (state?.gameState?.characters) {
@@ -250,6 +264,9 @@ export const useGameStore = create<GameStore>()(
             xp: char.xp ?? 0,
             xpToNextLevel: char.xpToNextLevel ?? 100,
           }))
+        }
+        if (state?.gameState && !('combatState' in state.gameState)) {
+          (state.gameState as GameState).combatState = null
         }
         return state
       },
@@ -284,6 +301,10 @@ export function useGameStateBuilder() {
     gameStateClone.storyEvents.push(event)
   }
 
+  const setCombatState = (combatState: CombatState | null) => {
+    gameStateClone.combatState = combatState
+  }
+
   const setDecisionPoint = (decisionPoint: FantasyDecisionPoint | null) => {
     gameStateClone.decisionPoint = decisionPoint
   }
@@ -311,6 +332,7 @@ export function useGameStateBuilder() {
     commit,
     addItem,
     addStoryEvent,
+    setCombatState,
     setDecisionPoint,
     setGenericMessage,
     updateSelectedCharacter,

--- a/src/app/fantasy-tycoon/hooks/useMoveForwardMutation.ts
+++ b/src/app/fantasy-tycoon/hooks/useMoveForwardMutation.ts
@@ -1,6 +1,7 @@
 'use client'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 
+import { inferItemTypeAndEffects } from '@/app/fantasy-tycoon/lib/itemPostProcessor'
 import {
   FantasyCharacter,
   FantasyDecisionPoint,
@@ -14,13 +15,14 @@ export interface MoveForwardResponse {
   character: FantasyCharacter
   event?: FantasyStoryEvent | null
   decisionPoint?: FantasyDecisionPoint | null
+  combatEncounter?: { enemy: unknown; scenario: string } | null
   genericMessage?: string | null
 }
 
 export function useMoveForwardMutation() {
   const queryClient = useQueryClient()
   const { getSelectedCharacter } = useGameStore()
-  const { addItem, commit, setDecisionPoint, setGenericMessage } = useGameStateBuilder()
+  const { addItem, commit, setDecisionPoint, setGenericMessage, setCombatState } = useGameStateBuilder()
 
   return useMutation({
     mutationFn: async () => {
@@ -45,15 +47,32 @@ export function useMoveForwardMutation() {
 
       const rewardItems: Item[] = data.event?.resourceDelta?.rewardItems ?? []
       for (const reward of rewardItems) {
-        const item: Item = {
+        const item: Item = inferItemTypeAndEffects({
           id: reward.id,
           name: reward.name ?? '',
           description: reward.description ?? '',
           quantity: reward.quantity,
-        }
+        })
         addItem(item)
       }
-      if (data.decisionPoint) {
+
+      if (data.combatEncounter) {
+        // Start combat - fetch combat state from server
+        const combatRes = await fetch('/api/v1/fantasy-tycoon/combat/start', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            character: currentCharacter,
+            storyEvents: gameState.storyEvents,
+          }),
+        })
+        if (combatRes.ok) {
+          const combatData = await combatRes.json()
+          setGenericMessage(null)
+          setDecisionPoint(null)
+          setCombatState(combatData.combatState)
+        }
+      } else if (data.decisionPoint) {
         setGenericMessage(null)
         setDecisionPoint(data.decisionPoint)
       }

--- a/src/app/fantasy-tycoon/hooks/useResolveDecisionMutation.ts
+++ b/src/app/fantasy-tycoon/hooks/useResolveDecisionMutation.ts
@@ -1,6 +1,7 @@
 'use client'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 
+import { inferItemTypeAndEffects } from '@/app/fantasy-tycoon/lib/itemPostProcessor'
 import { FantasyCharacter, FantasyDecisionPoint, Item } from '@/app/fantasy-tycoon/models/types'
 
 import { useGameStateBuilder, useGameStore } from './useGameStore'
@@ -63,12 +64,12 @@ export function useResolveDecisionMutation() {
       const rewardItems = data.rewardItems ?? []
 
       for (const reward of rewardItems) {
-        const item = {
+        const item = inferItemTypeAndEffects({
           id: reward.id,
           name: reward.name,
           description: reward.description,
           quantity: 1,
-        }
+        })
         addItem(item)
       }
 

--- a/src/app/fantasy-tycoon/lib/combatEngine.ts
+++ b/src/app/fantasy-tycoon/lib/combatEngine.ts
@@ -1,0 +1,286 @@
+import { FantasyCharacter } from '@/app/fantasy-tycoon/models/character'
+import {
+  CombatActionRequest,
+  CombatEnemy,
+  CombatLogEntry,
+  CombatPlayerState,
+  CombatState,
+} from '@/app/fantasy-tycoon/models/combat'
+import { Item } from '@/app/fantasy-tycoon/models/item'
+
+import { applyCombatItemEffect, isUsableInCombat } from './combatItemEffects'
+
+export function initializePlayerCombatState(character: FantasyCharacter): CombatPlayerState {
+  const maxHp = 50 + character.strength * 5 + character.level * 10
+  return {
+    hp: maxHp,
+    maxHp,
+    attack: 5 + character.strength * 2 + character.level,
+    defense: 3 + character.intelligence + character.level,
+    isDefending: false,
+    activeBuffs: [],
+  }
+}
+
+function randomVariance(base: number, pct: number = 0.2): number {
+  const variance = base * pct
+  return base + (Math.random() * 2 - 1) * variance
+}
+
+export function calculatePlayerDamage(
+  playerState: CombatPlayerState,
+  enemy: CombatEnemy
+): number {
+  const buffedAttack =
+    playerState.attack +
+    (playerState.activeBuffs ?? [])
+      .filter(b => b.stat === 'attack')
+      .reduce((sum, b) => sum + b.value, 0)
+  const raw = randomVariance(buffedAttack) - enemy.defense / 2
+  return Math.max(1, Math.round(raw))
+}
+
+export function calculateEnemyDamage(
+  enemy: CombatEnemy,
+  playerState: CombatPlayerState
+): number {
+  const effectiveDefense = playerState.isDefending
+    ? playerState.defense * 2
+    : playerState.defense
+  const buffedDefense =
+    effectiveDefense +
+    (playerState.activeBuffs ?? [])
+      .filter(b => b.stat === 'defense')
+      .reduce((sum, b) => sum + b.value, 0)
+  const raw = randomVariance(enemy.attack) - buffedDefense / 2
+  return Math.max(1, Math.round(raw))
+}
+
+export function calculateFleeChance(
+  character: FantasyCharacter,
+  enemy: CombatEnemy
+): number {
+  const chance = 0.3 + character.luck * 0.02 - enemy.level * 0.05
+  return Math.max(0.1, Math.min(0.9, chance))
+}
+
+function tickBuffs(playerState: CombatPlayerState): CombatPlayerState {
+  const activeBuffs = (playerState.activeBuffs ?? [])
+    .map(b => ({ ...b, turnsRemaining: b.turnsRemaining - 1 }))
+    .filter(b => b.turnsRemaining > 0)
+  return { ...playerState, activeBuffs }
+}
+
+function shouldUseSpecialAbility(enemy: CombatEnemy, turnNumber: number): boolean {
+  if (!enemy.specialAbility) return false
+  if (enemy.specialAbility.cooldown <= 0) return Math.random() < 0.3
+  return turnNumber > 0 && turnNumber % enemy.specialAbility.cooldown === 0
+}
+
+export function processPlayerAction(
+  combatState: CombatState,
+  action: CombatActionRequest,
+  character: FantasyCharacter
+): { combatState: CombatState; consumedItemId?: string } {
+  let { enemy, playerState, turnNumber, combatLog, status } = structuredClone(combatState)
+  const newLogs: CombatLogEntry[] = []
+  let consumedItemId: string | undefined
+
+  if (status !== 'active') {
+    return { combatState }
+  }
+
+  turnNumber += 1
+  playerState.isDefending = false
+
+  // Process player action
+  switch (action.action) {
+    case 'attack': {
+      const damage = calculatePlayerDamage(playerState, enemy)
+      enemy.hp = Math.max(0, enemy.hp - damage)
+      newLogs.push({
+        turn: turnNumber,
+        actor: 'player',
+        action: 'attack',
+        damage,
+        description: `You strike ${enemy.name} for ${damage} damage!`,
+      })
+      break
+    }
+    case 'defend': {
+      playerState.isDefending = true
+      newLogs.push({
+        turn: turnNumber,
+        actor: 'player',
+        action: 'defend',
+        description: 'You brace yourself, doubling your defense for this turn.',
+      })
+      break
+    }
+    case 'use_item': {
+      if (!action.itemId) {
+        newLogs.push({
+          turn: turnNumber,
+          actor: 'player',
+          action: 'use_item',
+          description: 'You fumble with your pack but find nothing to use.',
+        })
+        break
+      }
+      const item = character.inventory.find(
+        i => i.id === action.itemId && i.status !== 'deleted' && isUsableInCombat(i)
+      )
+      if (!item) {
+        newLogs.push({
+          turn: turnNumber,
+          actor: 'player',
+          action: 'use_item',
+          description: 'That item cannot be used in combat.',
+        })
+        break
+      }
+      const result = applyCombatItemEffect(item, playerState)
+      playerState = result.playerState
+      consumedItemId = item.id
+      newLogs.push({
+        turn: turnNumber,
+        actor: 'player',
+        action: 'use_item',
+        description: result.description,
+      })
+      break
+    }
+    case 'flee': {
+      const fleeChance = calculateFleeChance(character, enemy)
+      if (Math.random() < fleeChance) {
+        status = 'fled'
+        newLogs.push({
+          turn: turnNumber,
+          actor: 'player',
+          action: 'flee',
+          description: 'You successfully escape from combat!',
+        })
+        return {
+          combatState: {
+            ...combatState,
+            enemy,
+            playerState,
+            turnNumber,
+            combatLog: [...combatLog, ...newLogs],
+            status,
+          },
+        }
+      }
+      newLogs.push({
+        turn: turnNumber,
+        actor: 'player',
+        action: 'flee',
+        description: `You try to flee but ${enemy.name} blocks your escape!`,
+      })
+      break
+    }
+  }
+
+  // Check victory
+  if (enemy.hp <= 0) {
+    status = 'victory'
+    newLogs.push({
+      turn: turnNumber,
+      actor: 'player',
+      action: 'victory',
+      description: `You defeated ${enemy.name}!`,
+    })
+    return {
+      combatState: {
+        ...combatState,
+        enemy,
+        playerState: tickBuffs(playerState),
+        turnNumber,
+        combatLog: [...combatLog, ...newLogs],
+        status,
+      },
+      consumedItemId,
+    }
+  }
+
+  // Enemy turn
+  const useSpecial = shouldUseSpecialAbility(enemy, turnNumber)
+  if (useSpecial && enemy.specialAbility) {
+    const specialDmg = Math.max(
+      1,
+      Math.round(randomVariance(enemy.specialAbility.damage) - (playerState.isDefending ? playerState.defense : playerState.defense / 2))
+    )
+    playerState.hp = Math.max(0, playerState.hp - specialDmg)
+    newLogs.push({
+      turn: turnNumber,
+      actor: 'enemy',
+      action: 'special',
+      damage: specialDmg,
+      description: `${enemy.name} uses ${enemy.specialAbility.name}! You take ${specialDmg} damage!`,
+    })
+  } else {
+    const enemyDmg = calculateEnemyDamage(enemy, playerState)
+    playerState.hp = Math.max(0, playerState.hp - enemyDmg)
+    newLogs.push({
+      turn: turnNumber,
+      actor: 'enemy',
+      action: 'attack',
+      damage: enemyDmg,
+      description: `${enemy.name} attacks you for ${enemyDmg} damage!`,
+    })
+  }
+
+  // Check defeat
+  if (playerState.hp <= 0) {
+    status = 'defeat'
+    newLogs.push({
+      turn: turnNumber,
+      actor: 'enemy',
+      action: 'defeat',
+      description: `You have been defeated by ${enemy.name}...`,
+    })
+  }
+
+  // Tick buffs
+  playerState = tickBuffs(playerState)
+
+  return {
+    combatState: {
+      ...combatState,
+      enemy,
+      playerState,
+      turnNumber,
+      combatLog: [...combatLog, ...newLogs],
+      status,
+    },
+    consumedItemId,
+  }
+}
+
+export interface CombatRewards {
+  xp: number
+  gold: number
+  loot: Item[]
+}
+
+export function getCombatRewards(
+  combatState: CombatState,
+  character: FantasyCharacter
+): CombatRewards {
+  const { enemy } = combatState
+  const xp = enemy.xpReward
+  const gold = enemy.goldReward
+
+  // Select loot based on luck
+  const loot: Item[] = []
+  if (enemy.lootTable) {
+    for (const item of enemy.lootTable) {
+      const dropChance = 0.3 + character.luck * 0.03
+      if (Math.random() < dropChance) {
+        loot.push(item)
+      }
+    }
+  }
+
+  return { xp, gold, loot }
+}

--- a/src/app/fantasy-tycoon/lib/combatGenerator.ts
+++ b/src/app/fantasy-tycoon/lib/combatGenerator.ts
@@ -1,0 +1,192 @@
+import { OpenAI } from 'openai'
+import { z } from 'zod'
+
+import { FantasyCharacter } from '@/app/fantasy-tycoon/models/character'
+import { CombatEnemy, CombatEnemySchema } from '@/app/fantasy-tycoon/models/combat'
+
+import { inferItemTypeAndEffects } from './itemPostProcessor'
+
+const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY })
+
+const combatResponseSchema = z.object({
+  enemy: CombatEnemySchema,
+  scenario: z.string(),
+})
+
+const enemySchemaForOpenAI = {
+  type: 'object',
+  properties: {
+    enemy: {
+      type: 'object',
+      properties: {
+        id: { type: 'string' },
+        name: { type: 'string' },
+        description: { type: 'string' },
+        hp: { type: 'number' },
+        maxHp: { type: 'number' },
+        attack: { type: 'number' },
+        defense: { type: 'number' },
+        level: { type: 'number' },
+        xpReward: { type: 'number' },
+        goldReward: { type: 'number' },
+        lootTable: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              id: { type: 'string' },
+              name: { type: 'string' },
+              description: { type: 'string' },
+              quantity: { type: 'number' },
+              type: { type: 'string', enum: ['consumable', 'equipment', 'quest', 'misc'] },
+              effects: {
+                type: 'object',
+                properties: {
+                  gold: { type: 'number' },
+                  reputation: { type: 'number' },
+                  strength: { type: 'number' },
+                  intelligence: { type: 'number' },
+                  luck: { type: 'number' },
+                  xp: { type: 'number' },
+                },
+              },
+            },
+            required: ['id', 'name', 'description', 'quantity'],
+          },
+        },
+        specialAbility: {
+          type: 'object',
+          properties: {
+            name: { type: 'string' },
+            description: { type: 'string' },
+            damage: { type: 'number' },
+            cooldown: { type: 'number' },
+          },
+          required: ['name', 'description', 'damage', 'cooldown'],
+        },
+      },
+      required: [
+        'id',
+        'name',
+        'description',
+        'hp',
+        'maxHp',
+        'attack',
+        'defense',
+        'level',
+        'xpReward',
+        'goldReward',
+      ],
+    },
+    scenario: { type: 'string' },
+  },
+  required: ['enemy', 'scenario'],
+}
+
+export async function generateCombatEncounter(
+  character: FantasyCharacter,
+  context: string
+): Promise<{ enemy: CombatEnemy; scenario: string }> {
+  try {
+    const response = await openai.chat.completions.create({
+      model: 'gpt-4o',
+      messages: [
+        {
+          role: 'user',
+          content: `Generate a combat encounter for this fantasy character. Create an enemy appropriate for the character's level with a vivid scenario description.
+
+Stat guidelines for a level ${character.level} character:
+- Enemy HP: ${30 + character.level * 15} (±20%)
+- Enemy attack: ${3 + character.level * 2} (±20%)
+- Enemy defense: ${2 + character.level} (±20%)
+- XP reward: ${20 + character.level * 15}
+- Gold reward: ${5 + character.level * 5}
+- Include 1-2 loot items (potions, scrolls, gems, etc.)
+- Optionally include a special ability with cooldown of 2-4 turns
+
+Character:
+${JSON.stringify(character, null, 2)}
+
+Context:
+${context || 'A wandering adventurer encounters danger on the road.'}`,
+        },
+      ],
+      tools: [
+        {
+          type: 'function',
+          function: {
+            name: 'generate_combat',
+            description: 'Generate a combat encounter with an enemy and scenario.',
+            parameters: enemySchemaForOpenAI,
+          },
+        },
+      ],
+      tool_choice: { type: 'function', function: { name: 'generate_combat' } },
+      temperature: 0.8,
+      max_tokens: 800,
+    })
+
+    const toolCall = response.choices[0]?.message?.tool_calls?.[0]
+    if (toolCall && toolCall.function?.name === 'generate_combat') {
+      const parsed = JSON.parse(toolCall.function.arguments)
+      const validated = combatResponseSchema.parse(parsed)
+
+      // Post-process loot items
+      if (validated.enemy.lootTable) {
+        validated.enemy.lootTable = validated.enemy.lootTable.map(inferItemTypeAndEffects)
+      }
+
+      return validated
+    }
+
+    throw new Error('No tool call in response')
+  } catch (err) {
+    console.error('Combat generation failed, using fallback', err)
+    return getDefaultCombatEncounter(character)
+  }
+}
+
+function getDefaultCombatEncounter(
+  character: FantasyCharacter
+): { enemy: CombatEnemy; scenario: string } {
+  const level = character.level
+  const suffix = `${Date.now()}-${Math.floor(Math.random() * 10000)}`
+
+  return {
+    scenario: 'A hostile creature emerges from the shadows, blocking your path. You must fight or flee!',
+    enemy: {
+      id: `enemy-${suffix}`,
+      name: level <= 2 ? 'Wild Goblin' : level <= 5 ? 'Dark Wolf' : 'Shadow Knight',
+      description:
+        level <= 2
+          ? 'A snarling goblin wielding a rusty dagger.'
+          : level <= 5
+            ? 'A massive wolf with glowing red eyes.'
+            : 'An armored knight wreathed in dark energy.',
+      hp: 30 + level * 15,
+      maxHp: 30 + level * 15,
+      attack: 3 + level * 2,
+      defense: 2 + level,
+      level,
+      xpReward: 20 + level * 15,
+      goldReward: 5 + level * 5,
+      lootTable: [
+        inferItemTypeAndEffects({
+          id: `loot-potion-${suffix}`,
+          name: 'Healing Potion',
+          description: 'A small vial of restorative liquid.',
+          quantity: 1,
+        }),
+      ],
+      specialAbility:
+        level >= 3
+          ? {
+              name: level <= 5 ? 'Savage Bite' : 'Shadow Strike',
+              description: level <= 5 ? 'A vicious lunging bite.' : 'A devastating blow from the shadows.',
+              damage: 5 + level * 2,
+              cooldown: 3,
+            }
+          : undefined,
+    },
+  }
+}

--- a/src/app/fantasy-tycoon/lib/combatItemEffects.ts
+++ b/src/app/fantasy-tycoon/lib/combatItemEffects.ts
@@ -1,0 +1,58 @@
+import { CombatPlayerState } from '@/app/fantasy-tycoon/models/combat'
+import { Item } from '@/app/fantasy-tycoon/models/item'
+
+export function isUsableInCombat(item: Item): boolean {
+  if (item.type !== 'consumable' || !item.effects) return false
+  const { strength, intelligence, luck } = item.effects
+  return !!(strength || intelligence || luck)
+}
+
+export function applyCombatItemEffect(
+  item: Item,
+  playerState: CombatPlayerState
+): { playerState: CombatPlayerState; description: string } {
+  if (!item.effects) {
+    return { playerState, description: `${item.name} has no effect in combat.` }
+  }
+
+  const updated = { ...playerState, activeBuffs: [...(playerState.activeBuffs ?? [])] }
+  const parts: string[] = []
+
+  // Strength effect → heal HP
+  if (item.effects.strength) {
+    const healAmount = item.effects.strength * 5
+    const oldHp = updated.hp
+    updated.hp = Math.min(updated.maxHp, updated.hp + healAmount)
+    const actualHeal = updated.hp - oldHp
+    if (actualHeal > 0) {
+      parts.push(`restored ${actualHeal} HP`)
+    }
+  }
+
+  // Intelligence effect → defense buff
+  if (item.effects.intelligence) {
+    updated.activeBuffs.push({
+      stat: 'defense',
+      value: item.effects.intelligence * 2,
+      turnsRemaining: 3,
+    })
+    parts.push(`+${item.effects.intelligence * 2} defense for 3 turns`)
+  }
+
+  // Luck effect → attack buff (critical hit boost)
+  if (item.effects.luck) {
+    updated.activeBuffs.push({
+      stat: 'attack',
+      value: item.effects.luck * 2,
+      turnsRemaining: 3,
+    })
+    parts.push(`+${item.effects.luck * 2} attack for 3 turns`)
+  }
+
+  const description =
+    parts.length > 0
+      ? `You use ${item.name}: ${parts.join(', ')}!`
+      : `You use ${item.name}, but it has no combat effect.`
+
+  return { playerState: updated, description }
+}

--- a/src/app/fantasy-tycoon/lib/defaultGameState.ts
+++ b/src/app/fantasy-tycoon/lib/defaultGameState.ts
@@ -12,5 +12,6 @@ export const defaultGameState: GameState = {
   locations: [],
   storyEvents: [],
   decisionPoint: null,
+  combatState: null,
   genericMessage: null,
 }

--- a/src/app/fantasy-tycoon/lib/itemPostProcessor.ts
+++ b/src/app/fantasy-tycoon/lib/itemPostProcessor.ts
@@ -1,0 +1,103 @@
+import { Item, ItemEffects } from '@/app/fantasy-tycoon/models/item'
+
+interface KeywordRule {
+  keywords: string[]
+  effects: ItemEffects
+}
+
+const POTION_SUBRULES: KeywordRule[] = [
+  { keywords: ['healing', 'health', 'life', 'restore', 'recovery'], effects: { strength: 2 } },
+  { keywords: ['intelligence', 'wisdom', 'mind', 'knowledge', 'insight'], effects: { intelligence: 2 } },
+  { keywords: ['luck', 'fortune', 'lucky', 'chance'], effects: { luck: 2 } },
+  { keywords: ['strength', 'power', 'might', 'vigor', 'brawn'], effects: { strength: 3 } },
+  { keywords: ['gold', 'wealth', 'rich', 'greed'], effects: { gold: 20 } },
+]
+
+const SCROLL_SUBRULES: KeywordRule[] = [
+  { keywords: ['knowledge', 'wisdom', 'ancient'], effects: { xp: 50, intelligence: 1 } },
+  { keywords: ['power', 'might', 'war', 'battle'], effects: { xp: 30, strength: 1 } },
+]
+
+function matchesAny(name: string, keywords: string[]): boolean {
+  return keywords.some(k => name.includes(k))
+}
+
+function findMatchingEffects(name: string, rules: KeywordRule[], fallback: ItemEffects): ItemEffects {
+  for (const rule of rules) {
+    if (matchesAny(name, rule.keywords)) {
+      return rule.effects
+    }
+  }
+  return fallback
+}
+
+export function inferItemTypeAndEffects(item: Item): Item {
+  // Already fully specified
+  if (item.type === 'consumable' && item.effects && Object.keys(item.effects).length > 0) {
+    return item
+  }
+
+  const name = item.name.toLowerCase()
+
+  // Potions / Elixirs
+  if (matchesAny(name, ['potion', 'elixir', 'brew', 'tonic', 'vial', 'draught', 'flask'])) {
+    return {
+      ...item,
+      type: 'consumable',
+      effects: item.effects ?? findMatchingEffects(name, POTION_SUBRULES, { strength: 1, intelligence: 1 }),
+    }
+  }
+
+  // Scrolls / Tomes
+  if (matchesAny(name, ['scroll', 'tome', 'manuscript', 'codex', 'grimoire'])) {
+    return {
+      ...item,
+      type: 'consumable',
+      effects: item.effects ?? findMatchingEffects(name, SCROLL_SUBRULES, { xp: 30 }),
+    }
+  }
+
+  // Food
+  if (matchesAny(name, ['bread', 'meat', 'cheese', 'stew', 'ration', 'fruit', 'pie', 'cake', 'apple', 'berry', 'berries', 'mushroom', 'herb'])) {
+    return {
+      ...item,
+      type: 'consumable',
+      effects: item.effects ?? { strength: 1 },
+    }
+  }
+
+  // Coins / Gems
+  if (matchesAny(name, ['diamond', 'emerald', 'sapphire', 'ruby'])) {
+    return { ...item, type: 'consumable', effects: item.effects ?? { gold: 50 } }
+  }
+  if (matchesAny(name, ['gem', 'jewel'])) {
+    return { ...item, type: 'consumable', effects: item.effects ?? { gold: 25 } }
+  }
+  if (matchesAny(name, ['coin', 'gold piece', 'gold pouch'])) {
+    return { ...item, type: 'consumable', effects: item.effects ?? { gold: 15 } }
+  }
+
+  // Charms / Amulets
+  if (matchesAny(name, ['charm', 'amulet', 'talisman', 'trinket', 'lucky'])) {
+    return {
+      ...item,
+      type: 'consumable',
+      effects: item.effects ?? { luck: 2 },
+    }
+  }
+
+  // Has effects but missing type
+  if (item.effects && Object.keys(item.effects).length > 0) {
+    return { ...item, type: 'consumable' }
+  }
+
+  // Has consumable type but missing effects — try to infer
+  if (item.type === 'consumable') {
+    return {
+      ...item,
+      effects: { strength: 1, luck: 1 },
+    }
+  }
+
+  return item
+}

--- a/src/app/fantasy-tycoon/lib/llmEventGenerator.ts
+++ b/src/app/fantasy-tycoon/lib/llmEventGenerator.ts
@@ -4,10 +4,12 @@ import { z } from 'zod'
 import { FantasyCharacter } from '@/app/fantasy-tycoon/models/character'
 import { Item } from '@/app/fantasy-tycoon/models/item'
 
+import { inferItemTypeAndEffects } from './itemPostProcessor'
+
 const processFallbackRewardItems = (
   items?: { id: string; name?: string; description?: string; quantity: number; type?: string; effects?: Record<string, number> }[]
 ): Item[] | undefined =>
-  items?.map(item => ({
+  items?.map(item => inferItemTypeAndEffects({
     id: item.id,
     quantity: item.quantity,
     name: item.name || 'Unknown Item',

--- a/src/app/fantasy-tycoon/models/combat.ts
+++ b/src/app/fantasy-tycoon/models/combat.ts
@@ -1,0 +1,76 @@
+import { z } from 'zod'
+
+import { ItemSchema } from './item'
+
+export const CombatEnemySchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  description: z.string(),
+  hp: z.number(),
+  maxHp: z.number(),
+  attack: z.number(),
+  defense: z.number(),
+  level: z.number(),
+  xpReward: z.number(),
+  goldReward: z.number(),
+  lootTable: z.array(ItemSchema).optional(),
+  specialAbility: z
+    .object({
+      name: z.string(),
+      description: z.string(),
+      damage: z.number(),
+      cooldown: z.number(),
+    })
+    .optional(),
+})
+export type CombatEnemy = z.infer<typeof CombatEnemySchema>
+
+export const CombatBuffSchema = z.object({
+  stat: z.string(),
+  value: z.number(),
+  turnsRemaining: z.number(),
+})
+export type CombatBuff = z.infer<typeof CombatBuffSchema>
+
+export const CombatPlayerStateSchema = z.object({
+  hp: z.number(),
+  maxHp: z.number(),
+  attack: z.number(),
+  defense: z.number(),
+  isDefending: z.boolean(),
+  activeBuffs: z.array(CombatBuffSchema).optional(),
+})
+export type CombatPlayerState = z.infer<typeof CombatPlayerStateSchema>
+
+export const CombatActionSchema = z.enum(['attack', 'defend', 'use_item', 'flee'])
+export type CombatAction = z.infer<typeof CombatActionSchema>
+
+export const CombatActionRequestSchema = z.object({
+  action: CombatActionSchema,
+  itemId: z.string().optional(),
+})
+export type CombatActionRequest = z.infer<typeof CombatActionRequestSchema>
+
+export const CombatLogEntrySchema = z.object({
+  turn: z.number(),
+  actor: z.enum(['player', 'enemy']),
+  action: z.string(),
+  damage: z.number().optional(),
+  description: z.string(),
+})
+export type CombatLogEntry = z.infer<typeof CombatLogEntrySchema>
+
+export const CombatStatusSchema = z.enum(['active', 'victory', 'defeat', 'fled'])
+export type CombatStatus = z.infer<typeof CombatStatusSchema>
+
+export const CombatStateSchema = z.object({
+  id: z.string(),
+  eventId: z.string(),
+  enemy: CombatEnemySchema,
+  playerState: CombatPlayerStateSchema,
+  turnNumber: z.number(),
+  combatLog: z.array(CombatLogEntrySchema),
+  status: CombatStatusSchema,
+  scenario: z.string(),
+})
+export type CombatState = z.infer<typeof CombatStateSchema>

--- a/src/app/fantasy-tycoon/models/types.ts
+++ b/src/app/fantasy-tycoon/models/types.ts
@@ -1,6 +1,7 @@
 // Central re-export for all Fantasy Tycoon models and schemas (Zod-first, single source of truth)
 
 import { FantasyCharacter } from './character'
+import { CombatState } from './combat'
 import { FantasyLocation } from './location'
 import { FantasyDecisionPoint, FantasyStoryEvent } from './story'
 
@@ -29,6 +30,24 @@ export type {
   FantasyDecisionPointSchema,
 } from './story'
 export type { Item, ItemSchema, ItemEffects, ItemEffectsSchema } from './item'
+export type {
+  CombatState,
+  CombatEnemy,
+  CombatPlayerState,
+  CombatAction,
+  CombatActionRequest,
+  CombatLogEntry,
+  CombatBuff,
+  CombatStatus,
+  CombatStateSchema,
+  CombatEnemySchema,
+  CombatPlayerStateSchema,
+  CombatActionSchema,
+  CombatActionRequestSchema,
+  CombatLogEntrySchema,
+  CombatBuffSchema,
+  CombatStatusSchema,
+} from './combat'
 
 type GameState = {
   player: {
@@ -40,6 +59,7 @@ type GameState = {
   locations: FantasyLocation[]
   storyEvents: FantasyStoryEvent[]
   decisionPoint: FantasyDecisionPoint | null
+  combatState: CombatState | null
   genericMessage: string | null
 }
 export type { GameState }


### PR DESCRIPTION
## Summary
Two major improvements to Fantasy Tycoon:

- **Turn-based combat system**: ~20% chance of combat encounters when traveling. LLM generates enemies with stats, abilities, and loot scaled to character level. Players can attack, defend, use items, or flee. Combat uses character STR/INT/LCK for damage/defense/flee calculations. Victories award XP, gold, and loot drops.
- **Item reliability fix**: Server-side post-processor that infers item type and effects from keywords (potions, scrolls, gems, food, etc.). Items generated by the LLM now reliably work as consumables even when the LLM omits the type/effects fields.

### Key Changes

**Combat System (new)**
- `models/combat.ts` — Enemy, player state, action, and combat state schemas
- `lib/combatEngine.ts` — Turn processing, damage calculation, rewards
- `lib/combatGenerator.ts` — LLM-powered enemy generation with fallbacks
- `lib/combatItemEffects.ts` — In-combat item usage (potions heal HP, scrolls buff stats)
- `components/CombatUI.tsx` — Full combat interface with HP bars, combat log, action buttons, item selection
- `api/v1/fantasy-tycoon/combat/start/` and `combat/action/` — Server-side combat routes
- `hooks/useCombatActionMutation.ts` — Client-side combat action handling

**Item Post-Processor (new)**
- `lib/itemPostProcessor.ts` — Keyword-based inference for item types and effects
- Integrated into LLM event generator, move-forward mutation, and resolve-decision mutation

**Integration**
- Combat triggers through existing move-forward flow (~20% chance)
- GameUI conditionally renders CombatUI when combat is active
- Game store updated with combatState + localStorage migration (v1→v2)

### Testing
- 87 tests passing (37 new) across 11 test files
- New test files: `combatEngine.test.ts`, `combatItemEffects.test.ts`, `itemPostProcessor.test.ts`
- TypeScript compilation clean

## Test plan
- [x] All 87 tests pass
- [x] TypeScript compiles
- [ ] Manual: travel until combat triggers, fight enemy to victory
- [ ] Manual: use items during combat (potions heal, scrolls buff)
- [ ] Manual: flee from combat, verify gold loss
- [ ] Manual: verify items from events have correct types/effects

🤖 Generated with [Claude Code](https://claude.com/claude-code)