### PR TITLE
feat: distance-based leveling

### DIFF
--- a/src/app/tap-tap-adventure/__tests__/leveling.test.ts
+++ b/src/app/tap-tap-adventure/__tests__/leveling.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  applyLevelFromDistance,
+  calculateLevel,
+  levelProgress,
+  stepsRequiredForLevel,
+  stepsToNextLevel,
+} from '@/app/tap-tap-adventure/lib/leveling'
+import { FantasyCharacter } from '@/app/tap-tap-adventure/models/character'
+
+const baseChar: FantasyCharacter = {
+  id: '1',
+  playerId: 'p1',
+  name: 'Test',
+  race: 'Human',
+  class: 'Warrior',
+  level: 1,
+  abilities: [],
+  locationId: 'loc1',
+  gold: 10,
+  reputation: 5,
+  distance: 0,
+  status: 'active',
+  strength: 5,
+  intelligence: 5,
+  luck: 5,
+  inventory: [],
+}
+
+describe('Distance-Based Leveling', () => {
+  describe('stepsToNextLevel', () => {
+    it('returns 25 steps for level 1 -> 2', () => {
+      // 20 + 1*5 = 25
+      expect(stepsToNextLevel(1)).toBe(25)
+    })
+
+    it('returns 30 steps for level 2 -> 3', () => {
+      // 20 + 2*5 = 30
+      expect(stepsToNextLevel(2)).toBe(30)
+    })
+
+    it('increases with level', () => {
+      expect(stepsToNextLevel(3)).toBe(35)
+      expect(stepsToNextLevel(5)).toBe(45)
+      expect(stepsToNextLevel(10)).toBe(70)
+    })
+  })
+
+  describe('stepsRequiredForLevel', () => {
+    it('returns 0 for level 1', () => {
+      expect(stepsRequiredForLevel(1)).toBe(0)
+    })
+
+    it('returns 25 for level 2', () => {
+      expect(stepsRequiredForLevel(2)).toBe(25)
+    })
+
+    it('returns 55 for level 3', () => {
+      // 25 + 30 = 55
+      expect(stepsRequiredForLevel(3)).toBe(55)
+    })
+
+    it('returns 90 for level 4', () => {
+      // 25 + 30 + 35 = 90
+      expect(stepsRequiredForLevel(4)).toBe(90)
+    })
+  })
+
+  describe('calculateLevel', () => {
+    it('returns 1 at 0 distance', () => {
+      expect(calculateLevel(0)).toBe(1)
+    })
+
+    it('returns 1 at 24 distance', () => {
+      expect(calculateLevel(24)).toBe(1)
+    })
+
+    it('returns 2 at 25 distance', () => {
+      expect(calculateLevel(25)).toBe(2)
+    })
+
+    it('returns 2 at 54 distance', () => {
+      expect(calculateLevel(54)).toBe(2)
+    })
+
+    it('returns 3 at 55 distance', () => {
+      expect(calculateLevel(55)).toBe(3)
+    })
+
+    it('returns 4 at 90 distance', () => {
+      expect(calculateLevel(90)).toBe(4)
+    })
+
+    it('handles high distances', () => {
+      expect(calculateLevel(500)).toBeGreaterThan(5)
+    })
+  })
+
+  describe('levelProgress', () => {
+    it('returns 0 at start of level', () => {
+      expect(levelProgress(0)).toBe(0)
+      expect(levelProgress(25)).toBe(0)
+    })
+
+    it('returns ~0.5 at midpoint', () => {
+      // Level 1 needs 25 steps. At 12 steps: 12/25 ≈ 0.48
+      expect(levelProgress(12)).toBeCloseTo(0.48, 1)
+    })
+
+    it('returns close to 1 near end of level', () => {
+      // Level 1 needs 25 steps. At 24: 24/25 = 0.96
+      expect(levelProgress(24)).toBeCloseTo(0.96, 1)
+    })
+  })
+
+  describe('applyLevelFromDistance', () => {
+    it('does not change character if level matches', () => {
+      const char = { ...baseChar, distance: 10, level: 1 }
+      const result = applyLevelFromDistance(char)
+      expect(result).toBe(char) // same reference, no change
+    })
+
+    it('levels up and adds stats when distance crosses threshold', () => {
+      const char = { ...baseChar, distance: 25, level: 1 }
+      const result = applyLevelFromDistance(char)
+      expect(result.level).toBe(2)
+      expect(result.strength).toBe(6) // 5 + 1
+      expect(result.intelligence).toBe(6)
+      expect(result.luck).toBe(6)
+    })
+
+    it('handles multiple level jumps', () => {
+      const char = { ...baseChar, distance: 55, level: 1 }
+      const result = applyLevelFromDistance(char)
+      expect(result.level).toBe(3)
+      expect(result.strength).toBe(7) // 5 + 2
+    })
+
+    it('does not reduce stats if level somehow decreases', () => {
+      const char = { ...baseChar, distance: 10, level: 3, strength: 10 }
+      const result = applyLevelFromDistance(char)
+      expect(result.level).toBe(1)
+      expect(result.strength).toBe(10) // unchanged, no negative adjustment
+    })
+  })
+})

--- a/src/app/tap-tap-adventure/components/HudBar.tsx
+++ b/src/app/tap-tap-adventure/components/HudBar.tsx
@@ -8,6 +8,7 @@ import {
   TooltipTrigger,
 } from '@/app/tap-tap-adventure/components/ui/tooltip'
 import { useGameStore } from '@/app/tap-tap-adventure/hooks/useGameStore'
+import { levelProgress, stepsToNextLevel, stepsRequiredForLevel } from '@/app/tap-tap-adventure/lib/leveling'
 import { FantasyCharacter } from '@/app/tap-tap-adventure/models/character'
 
 type IconType =
@@ -76,6 +77,12 @@ export function HudBar() {
     (char: FantasyCharacter) => char.id === gameState?.selectedCharacterId
   )
 
+  const distance = character?.distance ?? 0
+  const level = character?.level ?? 1
+  const progress = character ? levelProgress(distance) : 0
+  const stepsNeeded = stepsToNextLevel(level)
+  const stepsIntoLevel = distance - stepsRequiredForLevel(level)
+
   const stats = useMemo(
     () => ({
       sunIcon: character?.gold ?? 0,
@@ -98,8 +105,20 @@ export function HudBar() {
               <TooltipTrigger className="flex items-center gap-1 text-sm font-semibold">
                 <span className="inline-block align-middle">{ICONS[key]}</span>
                 <span>{stats[key]}</span>
+                {key === 'fireIcon' && (
+                  <span className="w-12 h-1.5 bg-slate-700 rounded-full overflow-hidden ml-1">
+                    <span
+                      className="block h-full bg-orange-400 rounded-full transition-all duration-300"
+                      style={{ width: `${progress * 100}%` }}
+                    />
+                  </span>
+                )}
               </TooltipTrigger>
-              <TooltipContent>{STAT_LABELS[key]}</TooltipContent>
+              <TooltipContent>
+                {key === 'fireIcon'
+                  ? `Level ${level} — ${stepsIntoLevel}/${stepsNeeded} steps to next`
+                  : STAT_LABELS[key]}
+              </TooltipContent>
             </Tooltip>
           ))}
         </div>

--- a/src/app/tap-tap-adventure/hooks/useGameStore.ts
+++ b/src/app/tap-tap-adventure/hooks/useGameStore.ts
@@ -5,6 +5,7 @@ import { persist } from 'zustand/middleware'
 
 import { defaultGameState } from '@/app/tap-tap-adventure/lib/defaultGameState'
 import { useItem as applyItemUse } from '@/app/tap-tap-adventure/lib/itemEffects'
+import { applyLevelFromDistance } from '@/app/tap-tap-adventure/lib/leveling'
 import { FantasyCharacter } from '@/app/tap-tap-adventure/models/character'
 import { CombatState } from '@/app/tap-tap-adventure/models/combat'
 import {
@@ -95,10 +96,10 @@ export const useGameStore = create<GameStore>()(
           produce((state: GameStore) => {
             const selectedCharacter = get().getSelectedCharacter()
             if (!selectedCharacter) return
-            const updatedCharacter = {
+            const updatedCharacter = applyLevelFromDistance({
               ...selectedCharacter,
               distance: (selectedCharacter.distance || 0) + 1,
-            }
+            })
             state.gameState.characters = state.gameState.characters.map(char =>
               char.id === selectedCharacter.id ? updatedCharacter : char
             )
@@ -310,11 +311,12 @@ export function useGameStateBuilder() {
     const charIndex = gameStateClone.characters.findIndex(c => c.id === selectedCharacterId)
     if (charIndex === -1) return
 
-    // Create a new character object to ensure reactivity
-    gameStateClone.characters[charIndex] = {
+    // Create a new character object and recalculate level from distance
+    const merged = {
       ...gameStateClone.characters[charIndex],
       ...characterUpdate,
     }
+    gameStateClone.characters[charIndex] = applyLevelFromDistance(merged)
   }
 
   return {

--- a/src/app/tap-tap-adventure/lib/leveling.ts
+++ b/src/app/tap-tap-adventure/lib/leveling.ts
@@ -1,0 +1,73 @@
+import { FantasyCharacter } from '@/app/tap-tap-adventure/models/character'
+
+const BASE_STEPS = 20
+const STEPS_PER_LEVEL_INCREMENT = 5
+
+/**
+ * Steps required to reach a given level from level 1.
+ * Formula: sum of (BASE_STEPS + level * STEPS_PER_LEVEL_INCREMENT) for each level.
+ * Level 2 at 25 steps, Level 3 at 55, Level 4 at 90, etc.
+ */
+export function stepsRequiredForLevel(level: number): number {
+  if (level <= 1) return 0
+  let total = 0
+  for (let l = 1; l < level; l++) {
+    total += BASE_STEPS + l * STEPS_PER_LEVEL_INCREMENT
+  }
+  return total
+}
+
+/**
+ * Steps needed to go from current level to next level.
+ */
+export function stepsToNextLevel(level: number): number {
+  return BASE_STEPS + level * STEPS_PER_LEVEL_INCREMENT
+}
+
+/**
+ * Derive level from total distance traveled.
+ */
+export function calculateLevel(distance: number): number {
+  let level = 1
+  let stepsUsed = 0
+  while (true) {
+    const needed = stepsToNextLevel(level)
+    if (stepsUsed + needed > distance) break
+    stepsUsed += needed
+    level++
+  }
+  return level
+}
+
+/**
+ * Progress toward next level as a fraction (0 to 1).
+ */
+export function levelProgress(distance: number): number {
+  const level = calculateLevel(distance)
+  const currentLevelStart = stepsRequiredForLevel(level)
+  const needed = stepsToNextLevel(level)
+  const progress = distance - currentLevelStart
+  return Math.min(1, Math.max(0, progress / needed))
+}
+
+const STAT_BONUS_PER_LEVEL = 1
+
+/**
+ * Apply level-derived stat bonuses to a character.
+ * Returns a new character with updated level and stats.
+ */
+export function applyLevelFromDistance(character: FantasyCharacter): FantasyCharacter {
+  const newLevel = calculateLevel(character.distance)
+  if (newLevel === character.level) return character
+
+  const levelsGained = newLevel - character.level
+  if (levelsGained <= 0) return { ...character, level: newLevel }
+
+  return {
+    ...character,
+    level: newLevel,
+    strength: character.strength + levelsGained * STAT_BONUS_PER_LEVEL,
+    intelligence: character.intelligence + levelsGained * STAT_BONUS_PER_LEVEL,
+    luck: character.luck + levelsGained * STAT_BONUS_PER_LEVEL,
+  }
+}


### PR DESCRIPTION
## Summary
Level is now derived from steps traveled using a gentle curve. Each level requires more steps than the last: `20 + level * 5`.

| Level | Steps to reach | Steps for this level |
|-------|---------------|---------------------|
| 1 | 0 | — |
| 2 | 25 | 25 |
| 3 | 55 | 30 |
| 4 | 90 | 35 |
| 5 | 130 | 40 |
| 10 | 395 | 70 |

- Each level grants **+1 to STR, INT, and LCK**
- HUD shows a **progress bar** next to level with tooltip: "Level 3 — 12/35 steps to next"
- Level recalculated automatically whenever distance changes (travel, events, combat)
- Combat and LLM events already scale difficulty with `character.level`, so harder enemies appear naturally as you travel further

### Changes
- New `leveling.ts` with `calculateLevel`, `stepsToNextLevel`, `levelProgress`, `applyLevelFromDistance`
- `useGameStore`: `incrementDistance` and `updateSelectedCharacter` both apply leveling
- `HudBar`: level progress bar + detailed tooltip
- 21 new tests for the leveling system

## Test plan
- [x] 96 tests pass (11 test files)
- [ ] Manual: travel and verify level increases at correct thresholds
- [ ] Manual: verify stats increase on level-up
- [ ] Manual: verify combat difficulty scales with level

🤖 Generated with [Claude Code](https://claude.com/claude-code)