### PR TITLE
fix: UI improvements — button, text selection, mobile

### DIFF
--- a/src/app/tap-tap-adventure/components/GameUI.tsx
+++ b/src/app/tap-tap-adventure/components/GameUI.tsx
@@ -73,7 +73,7 @@ export default function GameUI() {
   }
 
   return (
-    <div className="flex flex-col">
+    <div className="flex flex-col select-none">
       <div className="relative z-10 mx-auto w-full">
         <div className="grid grid-cols-1 md:grid-cols-2 gap-6 pt-6">
           <div className={'p-4 bg-[#161723] border border-[#3a3c56] rounded-lg space-y-4'}>
@@ -104,7 +104,6 @@ export default function GameUI() {
                           <Button
                             key={option.id}
                             className="block w-full text-left border border-[#3a3c56] bg-[#2a2b3f] hover:bg-[#3a3c56] text-white px-3 py-2 mt-2 rounded disabled:opacity-60"
-                            style={{ userSelect: 'none' }}
                             disabled={resolveDecisionPending}
                             onClick={() => {
                               handleResolveDecision(option.id)
@@ -124,8 +123,7 @@ export default function GameUI() {
             ) : (
               <>
                 <Button
-                  className="w-full bg-[#2a2b3f] border border-[#3a3c56] hover:bg-[#3a3c56] text-white hover:shadow-md transition-all duration-300 active:translate-y-1/8 active:ring-1 active:ring-[#515375]"
-                  style={{ userSelect: 'none' }}
+                  className="w-full bg-gradient-to-r from-indigo-600 to-purple-600 hover:from-indigo-500 hover:to-purple-500 border border-indigo-400/30 text-white font-bold text-lg py-6 rounded-lg shadow-lg shadow-indigo-500/20 hover:shadow-indigo-500/40 transition-all duration-300 active:translate-y-0.5 active:shadow-none select-none"
                   onClick={handleMoveForward}
                   disabled={moveForwardPending || resolveDecisionPending}
                 >
@@ -137,7 +135,9 @@ export default function GameUI() {
                 {gameState.genericMessage && (
                   <div className="text-sm">{gameState.genericMessage}</div>
                 )}
-                <StoryFeed events={storyEvents} filterCharacterId={selectedCharacterId} />
+                <div className="select-text">
+                  <StoryFeed events={storyEvents} filterCharacterId={selectedCharacterId} />
+                </div>
               </>
             )}
           </div>

--- a/src/app/tap-tap-adventure/components/HudBar.tsx
+++ b/src/app/tap-tap-adventure/components/HudBar.tsx
@@ -98,15 +98,15 @@ export function HudBar() {
 
   return (
     <TooltipProvider>
-      <div className="w-full flex justify-between items-center gap-4 px-4 py-2 rounded-lg shadow-md bg-[#161723] border border-[#3a3c56] text-white">
-        <div className="flex items-center gap-4">
+      <div className="w-full flex flex-wrap justify-between items-center gap-x-3 gap-y-2 px-3 py-2 rounded-lg shadow-md bg-[#161723] border border-[#3a3c56] text-white select-none">
+        <div className="flex items-center gap-2 sm:gap-4 flex-wrap">
           {STATS_LEFT.map(key => (
             <Tooltip key={key}>
-              <TooltipTrigger className="flex items-center gap-1 text-sm font-semibold">
-                <span className="inline-block align-middle">{ICONS[key]}</span>
+              <TooltipTrigger className="flex items-center gap-1 text-xs sm:text-sm font-semibold">
+                <span className="inline-block align-middle shrink-0">{ICONS[key]}</span>
                 <span>{stats[key]}</span>
                 {key === 'fireIcon' && (
-                  <span className="w-12 h-1.5 bg-slate-700 rounded-full overflow-hidden ml-1">
+                  <span className="w-8 sm:w-12 h-1.5 bg-slate-700 rounded-full overflow-hidden ml-1">
                     <span
                       className="block h-full bg-orange-400 rounded-full transition-all duration-300"
                       style={{ width: `${progress * 100}%` }}
@@ -123,11 +123,11 @@ export function HudBar() {
           ))}
         </div>
 
-        <div className="flex items-center gap-4">
+        <div className="flex items-center gap-2 sm:gap-4">
           {STATS_RIGHT.map((key: IconType) => (
             <Tooltip key={key}>
-              <TooltipTrigger className="flex items-center gap-1 text-sm font-semibold">
-                <span className="inline-block align-middle">{ICONS[key]}</span>
+              <TooltipTrigger className="flex items-center gap-1 text-xs sm:text-sm font-semibold">
+                <span className="inline-block align-middle shrink-0">{ICONS[key]}</span>
                 <span>{stats[key]}</span>
               </TooltipTrigger>
               <TooltipContent>{STAT_LABELS[key]}</TooltipContent>


### PR DESCRIPTION
## Summary
Three targeted UI fixes:

- **Travel button stands out**: gradient indigo-to-purple background, larger text (`text-lg py-6`), glow shadow. Clearly the primary action now.
- **Text not selectable**: `select-none` on game container prevents accidental text selection on buttons/stats. Story feed text remains selectable.
- **HudBar responsive on mobile**: `flex-wrap` allows stats to wrap on small screens instead of overflowing. Smaller text (`text-xs`) and gaps (`gap-2`) on mobile, normal size (`sm:text-sm`, `sm:gap-4`) on larger screens.

Only 2 files changed, pure CSS/class changes.

## Test plan
- [x] 96 tests pass
- [ ] Check travel button visual on desktop and mobile
- [ ] Verify text is not selectable on buttons/stats but is selectable in story feed
- [ ] Verify HudBar doesn't overflow on narrow screens

🤖 Generated with [Claude Code](https://claude.com/claude-code)