### PR TITLE
Character creation overhaul: race and class selection

### DIFF
--- a/src/app/tap-tap-adventure/__tests__/characterOptions.test.ts
+++ b/src/app/tap-tap-adventure/__tests__/characterOptions.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  calculateStartingStats,
+  CLASSES,
+  RACES,
+} from '@/app/tap-tap-adventure/config/characterOptions'
+
+const getRace = (name: string) => RACES.find(r => r.name === name)!
+const getClass = (name: string) => CLASSES.find(c => c.name === name)!
+
+describe('calculateStartingStats', () => {
+  it('Human Warrior gets STR 9, INT 6, LCK 6', () => {
+    const stats = calculateStartingStats(getRace('Human'), getClass('Warrior'))
+    expect(stats.strength).toBe(9)
+    expect(stats.intelligence).toBe(6)
+    expect(stats.luck).toBe(6)
+  })
+
+  it('Elf Mage gets STR 5, INT 10, LCK 6', () => {
+    const stats = calculateStartingStats(getRace('Elf'), getClass('Mage'))
+    expect(stats.strength).toBe(5)
+    expect(stats.intelligence).toBe(10)
+    expect(stats.luck).toBe(6)
+  })
+
+  it('Dwarf Rogue gets STR 8, INT 6, LCK 7', () => {
+    const stats = calculateStartingStats(getRace('Dwarf'), getClass('Rogue'))
+    expect(stats.strength).toBe(8)
+    expect(stats.intelligence).toBe(6)
+    expect(stats.luck).toBe(7)
+  })
+
+  it('Halfling Ranger gets STR 6, INT 7, LCK 8', () => {
+    const stats = calculateStartingStats(getRace('Halfling'), getClass('Ranger'))
+    expect(stats.strength).toBe(6)
+    expect(stats.intelligence).toBe(7)
+    expect(stats.luck).toBe(8)
+  })
+
+  it('calculates correctly for all race/class combinations', () => {
+    for (const race of RACES) {
+      for (const cls of CLASSES) {
+        const stats = calculateStartingStats(race, cls)
+        expect(stats.strength).toBe(5 + race.modifiers.strength + cls.modifiers.strength)
+        expect(stats.intelligence).toBe(
+          5 + race.modifiers.intelligence + cls.modifiers.intelligence
+        )
+        expect(stats.luck).toBe(5 + race.modifiers.luck + cls.modifiers.luck)
+      }
+    }
+  })
+
+  it('never produces a stat below the base minimum of 5', () => {
+    for (const race of RACES) {
+      for (const cls of CLASSES) {
+        const stats = calculateStartingStats(race, cls)
+        expect(stats.strength).toBeGreaterThanOrEqual(5)
+        expect(stats.intelligence).toBeGreaterThanOrEqual(5)
+        expect(stats.luck).toBeGreaterThanOrEqual(5)
+      }
+    }
+  })
+
+  it('never produces a stat above the maximum of 10', () => {
+    for (const race of RACES) {
+      for (const cls of CLASSES) {
+        const stats = calculateStartingStats(race, cls)
+        expect(stats.strength).toBeLessThanOrEqual(10)
+        expect(stats.intelligence).toBeLessThanOrEqual(10)
+        expect(stats.luck).toBeLessThanOrEqual(10)
+      }
+    }
+  })
+})

--- a/src/app/tap-tap-adventure/components/CharacterCreation.tsx
+++ b/src/app/tap-tap-adventure/components/CharacterCreation.tsx
@@ -1,15 +1,116 @@
 'use client'
-import React, { useCallback } from 'react'
+import React, { useCallback, useState } from 'react'
 
+import {
+  ClassOption,
+  CLASSES,
+  RaceOption,
+  RACES,
+  StatModifiers,
+} from '@/app/tap-tap-adventure/config/characterOptions'
 import { useCharacterCreation } from '@/app/tap-tap-adventure/hooks/useCharacterCreation'
 import { FantasyCharacter } from '@/app/tap-tap-adventure/models/types'
+
+function StatBadge({ label, value }: { label: string; value: number }) {
+  const sign = value > 0 ? '+' : ''
+  return (
+    <span className="text-xs text-slate-400">
+      {label} {sign}
+      {value}
+    </span>
+  )
+}
+
+function ModifierBadges({ modifiers }: { modifiers: StatModifiers }) {
+  return (
+    <div className="flex gap-2 mt-2">
+      <StatBadge label="STR" value={modifiers.strength} />
+      <StatBadge label="INT" value={modifiers.intelligence} />
+      <StatBadge label="LCK" value={modifiers.luck} />
+    </div>
+  )
+}
+
+function OptionCard<T extends RaceOption | ClassOption>({
+  option,
+  selected,
+  onSelect,
+}: {
+  option: T
+  selected: boolean
+  onSelect: (option: T) => void
+}) {
+  return (
+    <button
+      type="button"
+      onClick={() => onSelect(option)}
+      className={`text-left p-4 rounded-lg border transition-all cursor-pointer focus:outline-none ${
+        selected
+          ? 'border-indigo-500 bg-indigo-500/10 ring-1 ring-indigo-500'
+          : 'border-[#3a3c56] bg-[#2a2b3f] hover:border-[#5a5c76]'
+      }`}
+    >
+      <div className="text-slate-200 font-semibold text-sm">{option.name}</div>
+      <div className="text-xs text-slate-400 mt-1">{option.description}</div>
+      <ModifierBadges modifiers={option.modifiers} />
+    </button>
+  )
+}
+
+function StepIndicator({ currentStep }: { currentStep: number }) {
+  const steps = ['Name', 'Race', 'Class']
+  return (
+    <div className="flex items-center justify-center gap-2 mb-6">
+      {steps.map((label, i) => {
+        const stepNum = i + 1
+        const isActive = stepNum === currentStep
+        const isCompleted = stepNum < currentStep
+        return (
+          <React.Fragment key={label}>
+            {i > 0 && <div className="w-8 h-px bg-[#3a3c56]" />}
+            <div className="flex items-center gap-1.5">
+              <div
+                className={`w-6 h-6 rounded-full flex items-center justify-center text-xs font-semibold ${
+                  isActive
+                    ? 'bg-indigo-500 text-white'
+                    : isCompleted
+                      ? 'bg-indigo-500/30 text-indigo-300'
+                      : 'bg-[#2a2b3f] text-slate-500 border border-[#3a3c56]'
+                }`}
+              >
+                {stepNum}
+              </div>
+              <span
+                className={`text-xs ${isActive ? 'text-slate-200' : isCompleted ? 'text-indigo-300' : 'text-slate-500'}`}
+              >
+                {label}
+              </span>
+            </div>
+          </React.Fragment>
+        )
+      })}
+    </div>
+  )
+}
 
 export default function CharacterCreation({
   onComplete,
 }: {
   onComplete?: (character: Partial<FantasyCharacter>) => void
 }) {
-  const { character, updateCharacter, completeCreation } = useCharacterCreation()
+  const {
+    character,
+    selectedRace,
+    selectedClass,
+    stats,
+    isValid,
+    updateCharacter,
+    setSelectedRace,
+    setSelectedClass,
+    completeCreation,
+  } = useCharacterCreation()
+
+  const [step, setStep] = useState(1)
 
   const handleSubmit = useCallback(
     (e: React.FormEvent<HTMLFormElement>) => {
@@ -20,48 +121,130 @@ export default function CharacterCreation({
     [completeCreation, character, onComplete]
   )
 
+  const canProceedFromStep1 = Boolean(character.name?.trim())
+  const canProceedFromStep2 = selectedRace !== null
+
   return (
     <form className="space-y-6 p-1" onSubmit={handleSubmit}>
-      <div>
-        <label htmlFor="characterName" className="block text-sm font-medium text-slate-300 mb-1">
-          Character Name
-        </label>
-        <input
-          id="characterName"
-          type="text"
-          className="w-full p-3 bg-slate-800/60 border border-[#3a3c56] rounded-md text-slate-200 placeholder-slate-500 focus:ring-2 focus:ring-sky-500 focus:border-sky-500 outline-none transition-colors shadow-sm"
-          placeholder="E.g., Aragorn, Gandalf"
-          value={character.name || ''}
-          onChange={e => updateCharacter({ name: e.target.value })}
-          required
-          autoFocus
-        />
-      </div>
-      {/* Placeholder for potential future fields like race/class selection */}
-      {/* <div className="grid grid-cols-2 gap-4">
+      <StepIndicator currentStep={step} />
+
+      {/* Step 1: Name */}
+      {step === 1 && (
         <div>
-          <label htmlFor="characterRace" className="block text-sm font-medium text-slate-300 mb-1">Race</label>
-          <select id="characterRace" className="w-full p-3 bg-slate-800/60 border border-[#3a3c56] rounded-md text-slate-200 focus:ring-2 focus:ring-sky-500 focus:border-sky-500 outline-none transition-colors">
-            <option>Human</option>
-            <option>Elf</option>
-            <option>Dwarf</option>
-          </select>
+          <label htmlFor="characterName" className="block text-sm font-medium text-slate-300 mb-1">
+            Character Name
+          </label>
+          <input
+            id="characterName"
+            type="text"
+            className="w-full p-3 bg-slate-800/60 border border-[#3a3c56] rounded-md text-slate-200 placeholder-slate-500 focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500 outline-none transition-colors shadow-sm"
+            placeholder="E.g., Aragorn, Gandalf"
+            value={character.name || ''}
+            onChange={e => updateCharacter({ name: e.target.value })}
+            autoFocus
+          />
+          <button
+            type="button"
+            disabled={!canProceedFromStep1}
+            onClick={() => setStep(2)}
+            className="w-full mt-4 bg-indigo-600 hover:bg-indigo-700 disabled:bg-slate-700 disabled:text-slate-500 text-white font-semibold px-4 py-3 rounded-md transition-colors focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 focus:ring-offset-[#161723] shadow-md"
+          >
+            Next: Choose Race
+          </button>
         </div>
+      )}
+
+      {/* Step 2: Race */}
+      {step === 2 && (
         <div>
-          <label htmlFor="characterClass" className="block text-sm font-medium text-slate-300 mb-1">Class</label>
-          <select id="characterClass" className="w-full p-3 bg-slate-800/60 border border-[#3a3c56] rounded-md text-slate-200 focus:ring-2 focus:ring-sky-500 focus:border-sky-500 outline-none transition-colors">
-            <option>Warrior</option>
-            <option>Mage</option>
-            <option>Rogue</option>
-          </select>
+          <label className="block text-sm font-medium text-slate-300 mb-3">Choose Your Race</label>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+            {RACES.map(race => (
+              <OptionCard
+                key={race.id}
+                option={race}
+                selected={selectedRace?.id === race.id}
+                onSelect={setSelectedRace}
+              />
+            ))}
+          </div>
+          <div className="flex gap-3 mt-4">
+            <button
+              type="button"
+              onClick={() => setStep(1)}
+              className="flex-1 bg-[#2a2b3f] hover:bg-[#3a3c56] text-slate-300 font-semibold px-4 py-3 rounded-md transition-colors focus:outline-none border border-[#3a3c56]"
+            >
+              Back
+            </button>
+            <button
+              type="button"
+              disabled={!canProceedFromStep2}
+              onClick={() => setStep(3)}
+              className="flex-1 bg-indigo-600 hover:bg-indigo-700 disabled:bg-slate-700 disabled:text-slate-500 text-white font-semibold px-4 py-3 rounded-md transition-colors focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 focus:ring-offset-[#161723] shadow-md"
+            >
+              Next: Choose Class
+            </button>
+          </div>
         </div>
-      </div> */}
-      <button
-        type="submit"
-        className="w-full bg-sky-600 hover:bg-sky-700 text-white font-semibold px-4 py-3 rounded-md transition-colors focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-2 focus:ring-offset-[#161723] shadow-md"
-      >
-        Create Character
-      </button>
+      )}
+
+      {/* Step 3: Class */}
+      {step === 3 && (
+        <div>
+          <label className="block text-sm font-medium text-slate-300 mb-3">Choose Your Class</label>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+            {CLASSES.map(cls => (
+              <OptionCard
+                key={cls.id}
+                option={cls}
+                selected={selectedClass?.id === cls.id}
+                onSelect={setSelectedClass}
+              />
+            ))}
+          </div>
+
+          {/* Stat Preview */}
+          <div className="mt-4 p-4 bg-[#1e1f33] border border-[#3a3c56] rounded-lg">
+            <div className="text-sm font-medium text-slate-300 mb-2">Stat Preview</div>
+            <div className="grid grid-cols-3 gap-4 text-center">
+              <div>
+                <div className="text-xs text-slate-500 uppercase">Strength</div>
+                <div className="text-lg font-bold text-amber-400">{stats.strength}</div>
+              </div>
+              <div>
+                <div className="text-xs text-slate-500 uppercase">Intelligence</div>
+                <div className="text-lg font-bold text-sky-400">{stats.intelligence}</div>
+              </div>
+              <div>
+                <div className="text-xs text-slate-500 uppercase">Luck</div>
+                <div className="text-lg font-bold text-emerald-400">{stats.luck}</div>
+              </div>
+            </div>
+            {selectedRace && selectedClass && (
+              <div className="text-xs text-slate-500 mt-2 text-center">
+                Base (5) + {selectedRace.name} bonuses + {selectedClass.name} bonuses
+              </div>
+            )}
+          </div>
+
+          <div className="flex gap-3 mt-4">
+            <button
+              type="button"
+              onClick={() => setStep(2)}
+              className="flex-1 bg-[#2a2b3f] hover:bg-[#3a3c56] text-slate-300 font-semibold px-4 py-3 rounded-md transition-colors focus:outline-none border border-[#3a3c56]"
+            >
+              Back
+            </button>
+            <button
+              type="submit"
+              disabled={!isValid}
+              className="flex-1 bg-indigo-600 hover:bg-indigo-700 disabled:bg-slate-700 disabled:text-slate-500 text-white font-semibold px-4 py-3 rounded-md transition-colors focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 focus:ring-offset-[#161723] shadow-md"
+            >
+              Create Character
+            </button>
+          </div>
+        </div>
+      )}
     </form>
   )
 }

--- a/src/app/tap-tap-adventure/config/characterOptions.ts
+++ b/src/app/tap-tap-adventure/config/characterOptions.ts
@@ -1,0 +1,93 @@
+import { DEFAULT_STAT_MIN } from './gameDefaults'
+
+export interface StatModifiers {
+  strength: number
+  intelligence: number
+  luck: number
+}
+
+export interface RaceOption {
+  id: string
+  name: string
+  description: string
+  modifiers: StatModifiers
+}
+
+export interface ClassOption {
+  id: string
+  name: string
+  description: string
+  modifiers: StatModifiers
+}
+
+export const RACES: RaceOption[] = [
+  {
+    id: 'human',
+    name: 'Human',
+    description: 'Versatile and adaptable, humans excel in any role with balanced abilities.',
+    modifiers: { strength: 1, intelligence: 1, luck: 1 },
+  },
+  {
+    id: 'elf',
+    name: 'Elf',
+    description: 'Ancient and wise, elves possess keen intellect and a touch of fortune.',
+    modifiers: { strength: 0, intelligence: 2, luck: 1 },
+  },
+  {
+    id: 'dwarf',
+    name: 'Dwarf',
+    description: 'Stout and resilient, dwarves are unmatched in raw physical power.',
+    modifiers: { strength: 2, intelligence: 1, luck: 0 },
+  },
+  {
+    id: 'halfling',
+    name: 'Halfling',
+    description: 'Small but remarkably lucky, halflings have an uncanny knack for survival.',
+    modifiers: { strength: 0, intelligence: 1, luck: 2 },
+  },
+]
+
+export const CLASSES: ClassOption[] = [
+  {
+    id: 'warrior',
+    name: 'Warrior',
+    description: 'A master of arms who relies on brute strength to overcome any obstacle.',
+    modifiers: { strength: 3, intelligence: 0, luck: 0 },
+  },
+  {
+    id: 'mage',
+    name: 'Mage',
+    description: 'A wielder of arcane forces, channeling intellect into devastating spells.',
+    modifiers: { strength: 0, intelligence: 3, luck: 0 },
+  },
+  {
+    id: 'rogue',
+    name: 'Rogue',
+    description: 'A cunning trickster who strikes from the shadows with deadly precision.',
+    modifiers: { strength: 1, intelligence: 0, luck: 2 },
+  },
+  {
+    id: 'ranger',
+    name: 'Ranger',
+    description: 'A resourceful survivor equally skilled with bow, blade, and wits.',
+    modifiers: { strength: 1, intelligence: 1, luck: 1 },
+  },
+]
+
+export interface StartingStats {
+  strength: number
+  intelligence: number
+  luck: number
+}
+
+export function calculateStartingStats(
+  race: RaceOption,
+  characterClass: ClassOption
+): StartingStats {
+  return {
+    strength: DEFAULT_STAT_MIN + race.modifiers.strength + characterClass.modifiers.strength,
+    intelligence:
+      DEFAULT_STAT_MIN + race.modifiers.intelligence + characterClass.modifiers.intelligence,
+    luck: DEFAULT_STAT_MIN + race.modifiers.luck + characterClass.modifiers.luck,
+  }
+}

--- a/src/app/tap-tap-adventure/hooks/useCharacterCreation.ts
+++ b/src/app/tap-tap-adventure/hooks/useCharacterCreation.ts
@@ -1,12 +1,18 @@
 'use client'
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 
+import {
+  calculateStartingStats,
+  ClassOption,
+  RaceOption,
+} from '@/app/tap-tap-adventure/config/characterOptions'
 import {
   DEFAULT_ABILITY_COOLDOWN,
   DEFAULT_ABILITY_DESCRIPTION,
   DEFAULT_ABILITY_NAME,
   DEFAULT_ABILITY_POWER,
   DEFAULT_CHARACTER_NAME,
+  DEFAULT_STAT_MIN,
 } from '@/app/tap-tap-adventure/config/gameDefaults'
 import { useGameStore } from '@/app/tap-tap-adventure/hooks/useGameStore'
 import { FantasyAbility, FantasyCharacter } from '@/app/tap-tap-adventure/models/types'
@@ -14,13 +20,30 @@ import { FantasyAbility, FantasyCharacter } from '@/app/tap-tap-adventure/models
 export function useCharacterCreation() {
   const { addCharacter } = useGameStore()
   const [character, setCharacter] = useState<Partial<FantasyCharacter>>({})
+  const [selectedRace, setSelectedRace] = useState<RaceOption | null>(null)
+  const [selectedClass, setSelectedClass] = useState<ClassOption | null>(null)
   const [isComplete, setIsComplete] = useState(false)
+
+  const stats = useMemo(() => {
+    if (selectedRace && selectedClass) {
+      return calculateStartingStats(selectedRace, selectedClass)
+    }
+    return {
+      strength: DEFAULT_STAT_MIN,
+      intelligence: DEFAULT_STAT_MIN,
+      luck: DEFAULT_STAT_MIN,
+    }
+  }, [selectedRace, selectedClass])
 
   const updateCharacter = (fields: Partial<FantasyCharacter>) => {
     setCharacter(prev => ({ ...prev, ...fields }))
   }
 
+  const isValid = Boolean(character.name?.trim()) && selectedRace !== null && selectedClass !== null
+
   const completeCreation = () => {
+    if (!isValid || !selectedRace || !selectedClass) return
+
     const charId = crypto.randomUUID()
     const abilityId = crypto.randomUUID()
 
@@ -32,10 +55,17 @@ export function useCharacterCreation() {
       cooldown: DEFAULT_ABILITY_COOLDOWN,
     }
 
+    const finalStats = calculateStartingStats(selectedRace, selectedClass)
+
     const updatedCharacter = {
       ...character,
       id: charId,
       name: character.name || DEFAULT_CHARACTER_NAME,
+      race: selectedRace.name,
+      class: selectedClass.name,
+      strength: finalStats.strength,
+      intelligence: finalStats.intelligence,
+      luck: finalStats.luck,
       abilities: [defaultAbility],
     }
 
@@ -45,7 +75,13 @@ export function useCharacterCreation() {
 
   return {
     character,
+    selectedRace,
+    selectedClass,
+    stats,
+    isValid,
     updateCharacter,
+    setSelectedRace,
+    setSelectedClass,
     isComplete,
     completeCreation,
   }


### PR DESCRIPTION
## Summary
- Add a 3-step character creation wizard (Name -> Race -> Class) replacing the name-only form
- Define 4 races (Human, Elf, Dwarf, Halfling) and 4 classes (Warrior, Mage, Rogue, Ranger) with distinct stat modifiers
- Starting stats are calculated as base (5) + race bonuses + class bonuses, with a live stat preview on the class selection step
- Add comprehensive tests for `calculateStartingStats` covering all 16 race/class combinations

## Test plan
- [x] All 103 tests pass (`npx vitest run`) including 7 new tests for stat calculations
- [ ] Verify character creation UI renders the 3-step wizard correctly
- [ ] Verify stat preview updates dynamically when race/class are selected
- [ ] Verify created characters show correct race, class, and computed stats on the character card
- [ ] Verify "Create Character" button is disabled until name, race, and class are all selected

🤖 Generated with [Claude Code](https://claude.com/claude-code)