### PR TITLE
Add reputation-affects-events feature

### DIFF
--- a/src/app/api/v1/tap-tap-adventure/move-forward/services/moveForwardService.ts
+++ b/src/app/api/v1/tap-tap-adventure/move-forward/services/moveForwardService.ts
@@ -20,8 +20,13 @@ export async function moveForwardService(
   try {
     const context = buildStoryContext(character, storyEvents)
 
-    // 20% chance of combat encounter (increases slightly with level)
-    const combatChance = 0.15 + character.level * 0.01
+    // Combat chance: base 15% + level scaling, modified by reputation
+    let combatChance = 0.15 + character.level * 0.01
+    if (character.reputation >= 50) {
+      combatChance -= 0.05 // High reputation: fewer hostile encounters
+    } else if (character.reputation <= -20) {
+      combatChance += 0.05 // Low reputation: more hostile encounters
+    }
     if (Math.random() < combatChance) {
       const encounter = await generateCombatEncounter(character, context)
       combatEncounter = encounter

--- a/src/app/tap-tap-adventure/__tests__/contextBuilder.test.ts
+++ b/src/app/tap-tap-adventure/__tests__/contextBuilder.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { buildStoryContext } from '@/app/tap-tap-adventure/lib/contextBuilder'
+import { buildStoryContext, getReputationTier } from '@/app/tap-tap-adventure/lib/contextBuilder'
 import { FantasyCharacter } from '@/app/tap-tap-adventure/models/character'
 import { FantasyStoryEvent } from '@/app/tap-tap-adventure/models/story'
 
@@ -94,6 +94,20 @@ describe('buildStoryContext', () => {
     expect(context).toContain('Event number 18')
     expect(context).toContain('Event number 19')
     expect(context).not.toContain('Event number 0')
+  })
+
+  it('includes reputation tier in context', () => {
+    const context = buildStoryContext(baseChar, [])
+    expect(context).toContain('Respected')
+    expect(context).toContain('Reputation: 25 (Respected)')
+    expect(context).toContain('Reputation implications:')
+  })
+
+  it('includes reputation tier for negative reputation', () => {
+    const negRepChar = { ...baseChar, reputation: -25 }
+    const context = buildStoryContext(negRepChar, [])
+    expect(context).toContain('Infamous')
+    expect(context).toContain('Bounty hunters')
   })
 
   it('caps context string length', () => {

--- a/src/app/tap-tap-adventure/__tests__/eventResolution.test.ts
+++ b/src/app/tap-tap-adventure/__tests__/eventResolution.test.ts
@@ -49,7 +49,7 @@ describe('Decision Resolution', () => {
       relevantAttributes: ['strength', 'luck'],
       attributeModifiers: { strength: 0.05, luck: 0.1 },
     }
-    // 0.2 + (2*0.05) + (1*0.1) = 0.4
-    expect(calculateEffectiveProbability(option, baseChar)).toBeCloseTo(0.4)
+    // 0.2 + (2*0.05) + (1*0.1) + (5*0.001 reputation modifier) = 0.405
+    expect(calculateEffectiveProbability(option, baseChar)).toBeCloseTo(0.405)
   })
 })

--- a/src/app/tap-tap-adventure/__tests__/reputationTier.test.ts
+++ b/src/app/tap-tap-adventure/__tests__/reputationTier.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vitest'
+
+import { getReputationTier } from '@/app/tap-tap-adventure/lib/contextBuilder'
+import { calculateEffectiveProbability } from '@/app/tap-tap-adventure/lib/eventResolution'
+import { FantasyCharacter } from '@/app/tap-tap-adventure/models/character'
+
+describe('getReputationTier', () => {
+  it('returns Infamous for reputation below -20', () => {
+    expect(getReputationTier(-21)).toBe('Infamous')
+    expect(getReputationTier(-100)).toBe('Infamous')
+  })
+
+  it('returns Disreputable for reputation -20 to -1', () => {
+    expect(getReputationTier(-20)).toBe('Disreputable')
+    expect(getReputationTier(-1)).toBe('Disreputable')
+  })
+
+  it('returns Unknown for reputation 0 to 19', () => {
+    expect(getReputationTier(0)).toBe('Unknown')
+    expect(getReputationTier(19)).toBe('Unknown')
+  })
+
+  it('returns Respected for reputation 20 to 49', () => {
+    expect(getReputationTier(20)).toBe('Respected')
+    expect(getReputationTier(49)).toBe('Respected')
+  })
+
+  it('returns Renowned for reputation 50 to 99', () => {
+    expect(getReputationTier(50)).toBe('Renowned')
+    expect(getReputationTier(99)).toBe('Renowned')
+  })
+
+  it('returns Legendary for reputation 100+', () => {
+    expect(getReputationTier(100)).toBe('Legendary')
+    expect(getReputationTier(500)).toBe('Legendary')
+  })
+
+  it('handles boundary values correctly', () => {
+    expect(getReputationTier(-21)).toBe('Infamous')
+    expect(getReputationTier(-20)).toBe('Disreputable')
+    expect(getReputationTier(-1)).toBe('Disreputable')
+    expect(getReputationTier(0)).toBe('Unknown')
+    expect(getReputationTier(19)).toBe('Unknown')
+    expect(getReputationTier(20)).toBe('Respected')
+    expect(getReputationTier(49)).toBe('Respected')
+    expect(getReputationTier(50)).toBe('Renowned')
+    expect(getReputationTier(99)).toBe('Renowned')
+    expect(getReputationTier(100)).toBe('Legendary')
+  })
+})
+
+describe('reputation modifier on probability', () => {
+  const baseChar: FantasyCharacter = {
+    id: 'char-1',
+    playerId: 'p1',
+    name: 'Tester',
+    race: 'Human',
+    class: 'Fighter',
+    level: 1,
+    abilities: [],
+    locationId: 'loc1',
+    gold: 0,
+    reputation: 0,
+    distance: 0,
+    status: 'active',
+    strength: 10,
+    intelligence: 10,
+    luck: 5,
+    inventory: [],
+  }
+
+  const optionWithAttrs = {
+    id: 'opt-1',
+    text: 'Test option',
+    successProbability: 0.5,
+    relevantAttributes: ['strength'],
+    attributeModifiers: { strength: 0.01 },
+    successDescription: '',
+    successEffects: {},
+    failureDescription: '',
+    failureEffects: {},
+    resultDescription: '',
+  }
+
+  it('positive reputation increases effective probability', () => {
+    const highRepChar = { ...baseChar, reputation: 100 }
+    const probBase = calculateEffectiveProbability(optionWithAttrs, baseChar)
+    const probHigh = calculateEffectiveProbability(optionWithAttrs, highRepChar)
+    expect(probHigh).toBeGreaterThan(probBase)
+  })
+
+  it('negative reputation decreases effective probability', () => {
+    const lowRepChar = { ...baseChar, reputation: -100 }
+    const probBase = calculateEffectiveProbability(optionWithAttrs, baseChar)
+    const probLow = calculateEffectiveProbability(optionWithAttrs, lowRepChar)
+    expect(probLow).toBeLessThan(probBase)
+  })
+
+  it('reputation modifier is capped at +0.1', () => {
+    const extremeRepChar = { ...baseChar, reputation: 500 }
+    const prob = calculateEffectiveProbability(optionWithAttrs, extremeRepChar)
+    // base 0.5 + strength modifier (10 * 0.01 = 0.1) + rep modifier (capped at 0.1) = 0.7
+    expect(prob).toBeCloseTo(0.7, 5)
+  })
+
+  it('reputation modifier is capped at -0.1', () => {
+    const extremeNegRepChar = { ...baseChar, reputation: -500 }
+    const prob = calculateEffectiveProbability(optionWithAttrs, extremeNegRepChar)
+    // base 0.5 + strength modifier (10 * 0.01 = 0.1) + rep modifier (capped at -0.1) = 0.5
+    expect(prob).toBeCloseTo(0.5, 5)
+  })
+})

--- a/src/app/tap-tap-adventure/components/HudBar.tsx
+++ b/src/app/tap-tap-adventure/components/HudBar.tsx
@@ -8,6 +8,7 @@ import {
   TooltipTrigger,
 } from '@/app/tap-tap-adventure/components/ui/tooltip'
 import { useGameStore } from '@/app/tap-tap-adventure/hooks/useGameStore'
+import { getReputationTier } from '@/app/tap-tap-adventure/lib/contextBuilder'
 import { levelProgress, stepsToNextLevel, stepsRequiredForLevel } from '@/app/tap-tap-adventure/lib/leveling'
 import { FantasyCharacter } from '@/app/tap-tap-adventure/models/character'
 
@@ -117,7 +118,9 @@ export function HudBar() {
               <TooltipContent>
                 {key === 'fireIcon'
                   ? `Level ${level} — ${stepsIntoLevel}/${stepsNeeded} steps to next`
-                  : STAT_LABELS[key]}
+                  : key === 'waterDropIcon'
+                    ? `Reputation: ${getReputationTier(stats[key])} (${stats[key]})`
+                    : STAT_LABELS[key]}
               </TooltipContent>
             </Tooltip>
           ))}

--- a/src/app/tap-tap-adventure/lib/combatGenerator.ts
+++ b/src/app/tap-tap-adventure/lib/combatGenerator.ts
@@ -4,6 +4,7 @@ import { z } from 'zod'
 import { FantasyCharacter } from '@/app/tap-tap-adventure/models/character'
 import { CombatEnemy, CombatEnemySchema } from '@/app/tap-tap-adventure/models/combat'
 
+import { getReputationTier } from './contextBuilder'
 import { inferItemTypeAndEffects } from './itemPostProcessor'
 
 const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY })
@@ -99,6 +100,9 @@ Stat guidelines for a level ${character.level} character:
 - Gold reward: ${5 + character.level * 5}
 - Include 1-2 loot items (potions, scrolls, gems, etc.)
 - Optionally include a special ability with cooldown of 2-4 turns
+
+Reputation context: This character's reputation is ${character.reputation} (${getReputationTier(character.reputation)}).
+${character.reputation >= 50 ? 'High reputation: the enemy might offer to surrender or parley before fighting. Consider less aggressive enemies like misguided guards or territorial creatures rather than outright villains.' : ''}${character.reputation <= -20 ? 'Low reputation: enemies are more aggressive. Consider bounty hunters, rival adventurers seeking the bounty on this character, or vengeful NPCs.' : ''}
 
 Character:
 ${JSON.stringify(character, null, 2)}

--- a/src/app/tap-tap-adventure/lib/contextBuilder.ts
+++ b/src/app/tap-tap-adventure/lib/contextBuilder.ts
@@ -3,6 +3,26 @@ import { FantasyStoryEvent } from '@/app/tap-tap-adventure/models/story'
 
 const MAX_CONTEXT_LENGTH = 1500
 
+export type ReputationTier = 'Infamous' | 'Disreputable' | 'Unknown' | 'Respected' | 'Renowned' | 'Legendary'
+
+const REPUTATION_TIER_IMPLICATIONS: Record<ReputationTier, string> = {
+  Infamous: 'NPCs are hostile or fearful. Bounty hunters pursue the character. Prices are much higher. Few will offer aid.',
+  Disreputable: 'NPCs are suspicious and distrustful. Prices are higher. Fewer friendly encounters.',
+  Unknown: 'NPCs are neutral. Standard pricing and interactions.',
+  Respected: 'NPCs are friendly and helpful. Better deals available. Some share useful information.',
+  Renowned: 'NPCs eagerly offer help, share secrets, and propose important quests. Excellent prices.',
+  Legendary: 'NPCs revere the character. The best deals, exclusive quests, and powerful allies seek them out.',
+}
+
+export function getReputationTier(reputation: number): ReputationTier {
+  if (reputation < -20) return 'Infamous'
+  if (reputation < 0) return 'Disreputable'
+  if (reputation < 20) return 'Unknown'
+  if (reputation < 50) return 'Respected'
+  if (reputation < 100) return 'Renowned'
+  return 'Legendary'
+}
+
 export function buildStoryContext(
   character: FantasyCharacter,
   storyEvents: FantasyStoryEvent[],
@@ -15,11 +35,13 @@ export function buildStoryContext(
   const parts: string[] = []
 
   // Character summary
+  const tier = getReputationTier(character.reputation)
   parts.push(
     `Character: ${character.name}, Level ${character.level} ${character.race} ${character.class}. ` +
-    `Gold: ${character.gold}, Reputation: ${character.reputation}, Distance: ${character.distance}. ` +
+    `Gold: ${character.gold}, Reputation: ${character.reputation} (${tier}), Distance: ${character.distance}. ` +
     `Stats: STR ${character.strength}, INT ${character.intelligence}, LCK ${character.luck}.`
   )
+  parts.push(`Reputation implications: ${REPUTATION_TIER_IMPLICATIONS[tier]}`)
 
   // Inventory highlights
   const activeItems = character.inventory.filter(i => i.status !== 'deleted')

--- a/src/app/tap-tap-adventure/lib/eventResolution.ts
+++ b/src/app/tap-tap-adventure/lib/eventResolution.ts
@@ -43,5 +43,10 @@ export function calculateEffectiveProbability(
     const attrMod = Number(typedOption.attributeModifiers?.[attr] ?? 0.01)
     modifier += value * attrMod
   }
+
+  // Reputation modifier: +0.01 per 10 reputation, capped at +/-0.1
+  const reputationModifier = Math.max(-0.1, Math.min(0.1, character.reputation * 0.001))
+  modifier += reputationModifier
+
   return Math.max(0, Math.min(1, Number(base) + modifier))
 }

--- a/src/app/tap-tap-adventure/lib/llmEventGenerator.ts
+++ b/src/app/tap-tap-adventure/lib/llmEventGenerator.ts
@@ -4,6 +4,7 @@ import { z } from 'zod'
 import { FantasyCharacter } from '@/app/tap-tap-adventure/models/character'
 import { Item } from '@/app/tap-tap-adventure/models/item'
 
+import { getReputationTier } from './contextBuilder'
 import { inferItemTypeAndEffects } from './itemPostProcessor'
 
 const processFallbackRewardItems = (
@@ -212,10 +213,29 @@ export async function generateLLMEvents(
 
 function getCompletionsConfig(character: FantasyCharacter, context: string) {
   const model = 'gpt-4o'
+  const reputationTier = getReputationTier(character.reputation)
+
+  let reputationGuidance = ''
+  if (character.reputation >= 50) {
+    reputationGuidance = `This character has a ${reputationTier} reputation (${character.reputation}). NPCs should be friendly and welcoming. Offer better deals, share secrets, and present important quests. Some NPCs may recognize the character by name and ask for help with critical tasks.`
+  } else if (character.reputation >= 20) {
+    reputationGuidance = `This character has a ${reputationTier} reputation (${character.reputation}). NPCs should be generally positive and willing to help. Fair deals and occasional bonus opportunities.`
+  } else if (character.reputation >= 0) {
+    reputationGuidance = `This character has an ${reputationTier} reputation (${character.reputation}). NPCs are neutral — standard interactions and pricing.`
+  } else if (character.reputation >= -20) {
+    reputationGuidance = `This character has a ${reputationTier} reputation (${character.reputation}). NPCs should be suspicious and wary. Prices are higher, information is harder to obtain, and some may refuse to deal with the character.`
+  } else {
+    reputationGuidance = `This character has an ${reputationTier} reputation (${character.reputation}). NPCs are hostile or fearful. Bounty hunters or rival adventurers may appear. Prices are much higher. Very few friendly encounters — most NPCs want nothing to do with this character.`
+  }
+
   const messages: OpenAI.Chat.Completions.ChatCompletionMessageParam[] = [
     {
       role: 'user',
       content: `Generate 3 fantasy adventure events for this character. Reference their past adventures and current state when creating events. Events should feel like a continuation of their story, not random encounters.
+
+IMPORTANT — Reputation guidance:
+${reputationGuidance}
+Tailor the tone, NPC attitudes, and available opportunities to reflect the character's reputation tier.
 
 When rewarding items, sometimes include consumable items (type: "consumable") with effects like stat boosts or gold. Examples: potions that grant +2 strength, scrolls that grant +2 intelligence, lucky coins that grant +1 luck.
 


### PR DESCRIPTION
## Summary
- Adds a reputation tier system (Infamous, Disreputable, Unknown, Respected, Renowned, Legendary) that shapes how LLM-generated events and combat encounters respond to the player's reputation
- Enhances LLM prompts in both event and combat generators with reputation-aware guidance so NPCs react differently based on the player's standing
- Adds a small reputation-based probability modifier to event resolution and adjusts combat encounter frequency based on reputation tier
- Updates the HudBar tooltip to display the reputation tier name alongside the numeric value

## Changes
- **contextBuilder.ts**: New `getReputationTier()` function and tier implications included in context string
- **llmEventGenerator.ts**: Reputation guidance section added to the LLM prompt
- **combatGenerator.ts**: Reputation context added to combat encounter prompt
- **eventResolution.ts**: Reputation modifier (+/-0.1 cap) applied to probability calculations
- **moveForwardService.ts**: Combat chance adjusted by +/-5% based on reputation tier
- **HudBar.tsx**: Reputation tooltip shows tier name (e.g., "Reputation: Renowned (75)")
- **Tests**: New `reputationTier.test.ts` with 11 tests, updated `contextBuilder.test.ts` and `eventResolution.test.ts`

## Test plan
- [x] All 109 tests pass (`npx vitest run`)
- [ ] Verify in-game that HudBar tooltip shows reputation tier
- [ ] Play through events with high/low reputation characters to confirm LLM generates appropriately themed encounters

Generated with [Claude Code](https://claude.com/claude-code)