### PR TITLE
fix: event rates + combat from narrative events

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+.claude/worktrees/

--- a/src/app/api/v1/tap-tap-adventure/move-forward/services/moveForwardService.ts
+++ b/src/app/api/v1/tap-tap-adventure/move-forward/services/moveForwardService.ts
@@ -1,6 +1,5 @@
 import { MoveForwardResponse } from '@/app/api/v1/tap-tap-adventure/move-forward/schemas'
 import { buildStoryContext } from '@/app/tap-tap-adventure/lib/contextBuilder'
-import { generateCombatEncounter } from '@/app/tap-tap-adventure/lib/combatGenerator'
 import { generateLLMEvents } from '@/app/tap-tap-adventure/lib/llmEventGenerator'
 import { calculateLevel } from '@/app/tap-tap-adventure/lib/leveling'
 import { FantasyCharacter } from '@/app/tap-tap-adventure/models/character'
@@ -36,36 +35,9 @@ export async function moveForwardService(
 
   let event: FantasyStoryEvent | null = null
   let decisionPoint: FantasyDecisionPoint | null = null
-  let combatEncounter = null
 
   try {
     const context = buildStoryContext(character, storyEvents)
-
-    // Combat chance: base 15% + level scaling, modified by reputation
-    let combatChance = 0.15 + character.level * 0.01
-    if (character.reputation >= 50) {
-      combatChance -= 0.05 // High reputation: fewer hostile encounters
-    } else if (character.reputation <= -20) {
-      combatChance += 0.05 // Low reputation: more hostile encounters
-    }
-    if (Math.random() < combatChance) {
-      const encounter = await generateCombatEncounter(character, context)
-      combatEncounter = encounter
-      event = {
-        id: `combat-event-${Date.now()}`,
-        type: 'combat_start',
-        characterId: character.id,
-        locationId: character.locationId,
-        timestamp: new Date().toISOString(),
-      }
-      return {
-        character: updatedCharacter,
-        event,
-        decisionPoint: null,
-        combatEncounter,
-      }
-    }
-
     const llmEvents = await generateLLMEvents(character, context)
     const llmEvent = llmEvents[0]
 
@@ -88,7 +60,8 @@ export async function moveForwardService(
         successEffects: opt.successEffects,
         failureDescription: opt.failureDescription,
         failureEffects: opt.failureEffects,
-        resultDescription: opt.successDescription, // Default to success description
+        resultDescription: opt.successDescription,
+        triggersCombat: opt.triggersCombat,
       })),
       resolved: false,
     }
@@ -102,6 +75,5 @@ export async function moveForwardService(
     character: updatedCharacter,
     event,
     decisionPoint,
-    combatEncounter,
   }
 }

--- a/src/app/api/v1/tap-tap-adventure/resolve-decision/route.ts
+++ b/src/app/api/v1/tap-tap-adventure/resolve-decision/route.ts
@@ -86,7 +86,7 @@ export async function POST(req: NextRequest) {
       rewardItems = [...rewardItems, ...typedOption.rewardItems]
     }
 
-    const response: ResolveDecisionResponse & { rewardItems?: Item[] } = {
+    const response: ResolveDecisionResponse & { rewardItems?: Item[]; triggersCombat?: boolean } = {
       updatedCharacter,
       resultDescription: resultDescription,
       appliedEffects,
@@ -95,6 +95,7 @@ export async function POST(req: NextRequest) {
       outcomeDescription: resultDescription,
       resourceDelta: appliedEffects,
       rewardItems: rewardItems.length > 0 ? rewardItems : undefined,
+      triggersCombat: typedOption.triggersCombat,
     }
 
     return NextResponse.json(response)

--- a/src/app/tap-tap-adventure/components/GameUI.tsx
+++ b/src/app/tap-tap-adventure/components/GameUI.tsx
@@ -64,7 +64,7 @@ export default function GameUI() {
   }
 
   const handleMoveForward = () => {
-    const shouldDoNothing = flipCoin(0.05, 0.95)
+    const shouldDoNothing = flipCoin(0.95, 0.05)
     if (shouldDoNothing) {
       const genericMessage = getGenericTravelMessage()
       setGenericMessage(genericMessage)

--- a/src/app/tap-tap-adventure/hooks/useMoveForwardMutation.ts
+++ b/src/app/tap-tap-adventure/hooks/useMoveForwardMutation.ts
@@ -15,7 +15,6 @@ export interface MoveForwardResponse {
   character: FantasyCharacter
   event?: FantasyStoryEvent | null
   decisionPoint?: FantasyDecisionPoint | null
-  combatEncounter?: { enemy: unknown; scenario: string } | null
   shopEvent?: boolean | null
   genericMessage?: string | null
 }
@@ -28,7 +27,6 @@ export function useMoveForwardMutation() {
     commit,
     setDecisionPoint,
     setGenericMessage,
-    setCombatState,
     setShopState,
   } = useGameStateBuilder()
 
@@ -75,24 +73,7 @@ export function useMoveForwardMutation() {
           const shopData = await shopRes.json()
           setGenericMessage(null)
           setDecisionPoint(null)
-          setCombatState(null)
           setShopState({ items: shopData.shopItems, isOpen: true })
-        }
-      } else if (data.combatEncounter) {
-        // Start combat - fetch combat state from server
-        const combatRes = await fetch('/api/v1/tap-tap-adventure/combat/start', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({
-            character: currentCharacter,
-            storyEvents: gameState.storyEvents,
-          }),
-        })
-        if (combatRes.ok) {
-          const combatData = await combatRes.json()
-          setGenericMessage(null)
-          setDecisionPoint(null)
-          setCombatState(combatData.combatState)
         }
       } else if (data.decisionPoint) {
         setGenericMessage(null)

--- a/src/app/tap-tap-adventure/hooks/useResolveDecisionMutation.ts
+++ b/src/app/tap-tap-adventure/hooks/useResolveDecisionMutation.ts
@@ -20,11 +20,12 @@ export interface ResolveDecisionResponse {
     statusChange?: string
   }
   rewardItems?: Item[]
+  triggersCombat?: boolean
 }
 
 export function useResolveDecisionMutation() {
   const { getSelectedCharacter } = useGameStore()
-  const { addItem, addStoryEvent, commit, updateSelectedCharacter } = useGameStateBuilder()
+  const { addItem, addStoryEvent, commit, setCombatState, updateSelectedCharacter } = useGameStateBuilder()
   const queryClient = useQueryClient()
   return useMutation({
     mutationFn: async ({
@@ -73,17 +74,37 @@ export function useResolveDecisionMutation() {
       const newStoryEvent = {
         decisionPoint,
         id: `result-${Date.now()}`,
-        type: 'decision_result',
+        type: data.triggersCombat ? 'combat_start' : 'decision_result',
         characterId: data.updatedCharacter.id,
         locationId: data.updatedCharacter.locationId,
         timestamp: new Date().toISOString(),
         selectedOptionId: data.selectedOptionId,
         selectedOptionText: data.selectedOptionText,
-        outcomeDescription: data.outcomeDescription ?? '',
+        outcomeDescription: data.triggersCombat
+          ? `You chose to fight: ${data.selectedOptionText}`
+          : (data.outcomeDescription ?? ''),
         resourceDelta: data.resourceDelta,
       }
 
       addStoryEvent(newStoryEvent)
+
+      // If the chosen option triggers combat, start a combat encounter
+      if (data.triggersCombat) {
+        const { gameState } = useGameStore.getState()
+        const combatRes = await fetch('/api/v1/tap-tap-adventure/combat/start', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            character: data.updatedCharacter,
+            storyEvents: gameState.storyEvents,
+          }),
+        })
+        if (combatRes.ok) {
+          const combatData = await combatRes.json()
+          setCombatState(combatData.combatState)
+        }
+      }
+
       commit()
       onSuccess?.()
     },

--- a/src/app/tap-tap-adventure/lib/llmEventGenerator.ts
+++ b/src/app/tap-tap-adventure/lib/llmEventGenerator.ts
@@ -37,6 +37,7 @@ export interface LLMEventOption {
     statusChange?: string
     rewardItems?: Item[]
   }
+  triggersCombat?: boolean
 }
 
 export interface LLMGeneratedEvent {
@@ -78,6 +79,7 @@ const eventOptionSchema = z.object({
     statusChange: z.string().optional(),
     rewardItems: z.array(rewardItemSchema).optional(),
   }),
+  triggersCombat: z.boolean().optional(),
 })
 
 const eventSchema = z.object({
@@ -145,6 +147,7 @@ const eventOptionSchemaForOpenAI = {
         },
       },
     },
+    triggersCombat: { type: 'boolean', description: 'Set to true if this option leads to a fight' },
   },
   required: [
     'id',
@@ -238,6 +241,8 @@ ${reputationGuidance}
 Tailor the tone, NPC attitudes, and available opportunities to reflect the character's reputation tier.
 
 When rewarding items, sometimes include consumable items (type: "consumable") with effects like stat boosts or gold. Examples: potions that grant +2 strength, scrolls that grant +2 intelligence, lucky coins that grant +1 luck.
+
+IMPORTANT: About 1 in 3 events should involve a potential confrontation (bandits, monsters, rivals, etc.). For these events, include at least one option with "triggersCombat": true — this represents the character choosing to fight. Other options can be peaceful alternatives (negotiate, flee, pay a toll, sneak past). This gives the player agency over whether to fight.
 
 Character:
 ${JSON.stringify(character, null, 2)}
@@ -400,33 +405,44 @@ function getDefaultEvents() {
     },
     {
       id: `default-3-${uniqueSuffix}`,
-      description: 'You find a wounded animal on the road.',
+      description: 'A band of thieves blocks the road ahead, demanding you hand over your gold.',
       options: [
         {
-          id: `help-3-${uniqueSuffix}`,
-          text: 'Help the animal',
-          successProbability: 0.8,
-          successDescription: 'The animal recovers and you gain reputation.',
+          id: `fight-3-${uniqueSuffix}`,
+          text: 'Draw your weapon and fight',
+          triggersCombat: true,
+          successProbability: 0.5,
+          successDescription: 'You prepare for battle!',
+          successEffects: {},
+          failureDescription: 'You prepare for battle!',
+          failureEffects: {},
+        },
+        {
+          id: `pay-3-${uniqueSuffix}`,
+          text: 'Pay the toll and pass safely',
+          successProbability: 0.9,
+          successDescription: 'You hand over some gold and the thieves let you pass.',
           successEffects: {
-            reputation: 3,
+            gold: -10,
           },
-          failureDescription: 'The animal was more dangerous than it appeared.',
+          failureDescription: 'They take your gold and shove you aside.',
           failureEffects: {
-            gold: -5,
+            gold: -15,
             reputation: -2,
           },
         },
         {
-          id: `ignore-3-${uniqueSuffix}`,
-          text: 'Ignore it',
-          successProbability: 0.2,
-          successDescription: 'You made the right choice - it was a trap!',
+          id: `sneak-3-${uniqueSuffix}`,
+          text: 'Try to sneak around them',
+          successProbability: 0.4,
+          successDescription: 'You slip past unnoticed!',
           successEffects: {
-            gold: 5,
+            reputation: 1,
           },
-          failureDescription: 'You walk on, feeling a bit guilty.',
+          failureDescription: 'They spot you and take your gold by force.',
           failureEffects: {
-            reputation: -1,
+            gold: -15,
+            reputation: -3,
           },
         },
       ],

--- a/src/app/tap-tap-adventure/models/story.ts
+++ b/src/app/tap-tap-adventure/models/story.ts
@@ -35,6 +35,7 @@ export const FantasyDecisionOptionSchema = z.object({
   resultDescription: z.string().optional(),
   effects: EffectsSchema.optional(),
   rewardItems: z.array(ItemSchema).optional(),
+  triggersCombat: z.boolean().optional(),
 })
 export type FantasyDecisionOption = z.infer<typeof FantasyDecisionOptionSchema>
 


### PR DESCRIPTION
## Summary
Two critical fixes:

### 1. Event rate bug (the big one)
`flipCoin(0.05, 0.95)` was returning `true` (do nothing) **95% of the time** — the arguments were swapped. This meant only ~5% of taps actually generated events from the server. Combat and shop encounters were nearly impossible to trigger.

**Fix**: Swapped to `flipCoin(0.95, 0.05)` — now 95% of taps generate real events, 5% are generic travel messages.

### 2. Combat now starts from narrative events
Instead of random combat encounters with no story, combat is now triggered through LLM-generated events. The LLM creates ~1/3 events with confrontations (bandits, monsters, rivals) where one option has `triggersCombat: true`. The player **chooses** whether to fight — other options like negotiating, paying, or sneaking are available.

**Flow**: Event → player picks "Fight" option → resolve-decision detects `triggersCombat` → starts combat encounter

**Removed**: Random combat trigger from `moveForwardService` (the 15-20% random chance)

### Changes
- `GameUI.tsx`: Fixed `flipCoin` arguments
- `llmEventGenerator.ts`: Added `triggersCombat` to schemas and LLM prompt
- `story.ts`: Added `triggersCombat` to decision option schema
- `moveForwardService.ts`: Removed random combat trigger, passes `triggersCombat` through
- `resolve-decision/route.ts`: Returns `triggersCombat` flag in response
- `useResolveDecisionMutation.ts`: Starts combat when `triggersCombat` is true
- `useMoveForwardMutation.ts`: Removed `combatEncounter` handling
- Default events: Third fallback event is now a bandit confrontation with fight/pay/sneak options

## Test plan
- [x] 125 tests pass
- [ ] Verify events trigger on most taps (not just 5%)
- [ ] Verify shops appear on level-up
- [ ] Verify combat starts from "fight" options in events
- [ ] Verify non-fight options resolve normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)