### PR TITLE
feat: level-up celebration overlay

### DIFF
--- a/src/app/tap-tap-adventure/components/GameUI.tsx
+++ b/src/app/tap-tap-adventure/components/GameUI.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { LoaderCircle } from 'lucide-react'
-import { useEffect } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 
 import { Button } from '@/app/tap-tap-adventure/components/ui/button'
 import { useGameStore } from '@/app/tap-tap-adventure/hooks/useGameStore'
@@ -12,6 +12,7 @@ import { flipCoin } from '@/app/utils'
 
 import { CombatUI, CombatResult } from './CombatUI'
 import { InventoryPanel } from './InventoryPanel'
+import { LevelUpCelebration } from './LevelUpCelebration'
 import { ShopUI } from './ShopUI'
 import { StoryFeed } from './StoryFeed'
 
@@ -40,10 +41,20 @@ export default function GameUI() {
   const { mutate: resolveDecisionMutation, isPending: resolveDecisionPending } =
     useResolveDecisionMutation()
 
+  const [levelUpLevel, setLevelUpLevel] = useState<number | null>(null)
+  const prevLevelRef = useRef<number | null>(null)
+  const character = getSelectedCharacter()
+
   useEffect(() => {
-    if (typeof window !== 'undefined' && gameState) {
+    if (!character) return
+    const currentLevel = character.level
+    if (prevLevelRef.current !== null && currentLevel > prevLevelRef.current) {
+      setLevelUpLevel(currentLevel)
     }
-  }, [gameState])
+    prevLevelRef.current = currentLevel
+  }, [character?.level])
+
+  const dismissLevelUp = useCallback(() => setLevelUpLevel(null), [])
 
   const handleResolveDecision = (optionId: string) => {
     resolveDecisionMutation({
@@ -75,6 +86,10 @@ export default function GameUI() {
   }
 
   return (
+    <>
+      {levelUpLevel !== null && (
+        <LevelUpCelebration level={levelUpLevel} onDismiss={dismissLevelUp} />
+      )}
     <div className="flex flex-col select-none">
       <div className="relative z-10 mx-auto w-full">
         <div className="grid grid-cols-1 md:grid-cols-2 gap-6 pt-6">
@@ -162,5 +177,6 @@ export default function GameUI() {
       </div>
       {/* Main content wrapper END */}
     </div>
+    </>
   )
 }

--- a/src/app/tap-tap-adventure/components/LevelUpCelebration.tsx
+++ b/src/app/tap-tap-adventure/components/LevelUpCelebration.tsx
@@ -1,0 +1,76 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+
+interface LevelUpCelebrationProps {
+  level: number
+  onDismiss: () => void
+}
+
+export function LevelUpCelebration({ level, onDismiss }: LevelUpCelebrationProps) {
+  const [isVisible, setIsVisible] = useState(false)
+
+  useEffect(() => {
+    // Trigger entrance animation
+    requestAnimationFrame(() => setIsVisible(true))
+
+    // Auto-dismiss after 4 seconds
+    const timer = setTimeout(() => {
+      setIsVisible(false)
+      setTimeout(onDismiss, 300) // wait for fade-out
+    }, 4000)
+
+    return () => clearTimeout(timer)
+  }, [onDismiss])
+
+  return (
+    <div
+      className={`fixed inset-0 z-50 flex items-center justify-center pointer-events-none transition-opacity duration-300 ${
+        isVisible ? 'opacity-100' : 'opacity-0'
+      }`}
+    >
+      {/* Backdrop */}
+      <div className="absolute inset-0 bg-black/40" />
+
+      {/* Content */}
+      <div
+        className={`relative pointer-events-auto transition-all duration-500 ${
+          isVisible ? 'scale-100 translate-y-0' : 'scale-75 translate-y-8'
+        }`}
+        onClick={() => {
+          setIsVisible(false)
+          setTimeout(onDismiss, 300)
+        }}
+      >
+        <div className="bg-gradient-to-b from-[#1e1f30] to-[#161723] border-2 border-yellow-500/50 rounded-2xl px-10 py-8 text-center shadow-2xl shadow-yellow-500/20">
+          {/* Stars */}
+          <div className="text-4xl mb-2">
+            <span className="inline-block animate-bounce" style={{ animationDelay: '0ms' }}>
+              *
+            </span>
+            <span className="inline-block animate-bounce mx-2" style={{ animationDelay: '150ms' }}>
+              *
+            </span>
+            <span className="inline-block animate-bounce" style={{ animationDelay: '300ms' }}>
+              *
+            </span>
+          </div>
+
+          {/* Title */}
+          <h2 className="text-3xl font-bold text-yellow-400 mb-1">Level Up!</h2>
+
+          {/* Level */}
+          <div className="text-6xl font-black text-white my-3">{level}</div>
+
+          {/* Stats message */}
+          <p className="text-slate-300 text-sm mb-4">
+            +1 Strength, +1 Intelligence, +1 Luck
+          </p>
+
+          {/* Dismiss hint */}
+          <p className="text-slate-500 text-xs">Tap to continue</p>
+        </div>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
Shows a celebratory overlay when the player levels up while traveling.

### How it works
- `GameUI` tracks the character's level via `useRef`
- When level increases, a `LevelUpCelebration` overlay appears
- Animated entrance: scale up + fade in
- Shows bouncing stars, the new level number, and stat gains (+1 STR/INT/LCK)
- Auto-dismisses after 4 seconds, or tap anywhere to continue
- Smooth fade-out on dismiss

### Files
- New: `LevelUpCelebration.tsx` — self-contained overlay component
- Modified: `GameUI.tsx` — level change detection + renders overlay

## Test plan
- [x] 125 tests pass
- [ ] Travel until level-up, verify celebration appears
- [ ] Verify auto-dismiss after 4 seconds
- [ ] Verify tap to dismiss works

🤖 Generated with [Claude Code](https://claude.com/claude-code)