### PR TITLE
fix: combat enemy matches triggering event

### DIFF
--- a/src/app/api/v1/tap-tap-adventure/combat/start/route.ts
+++ b/src/app/api/v1/tap-tap-adventure/combat/start/route.ts
@@ -7,9 +7,12 @@ import { CombatState } from '@/app/tap-tap-adventure/models/combat'
 
 export async function POST(req: NextRequest) {
   try {
-    const { character, storyEvents = [] } = await req.json()
-    const context = buildStoryContext(character, storyEvents)
-    const { enemy, scenario } = await generateCombatEncounter(character, context)
+    const { character, storyEvents = [], eventContext } = await req.json()
+    const storyContext = buildStoryContext(character, storyEvents)
+    const fullContext = eventContext
+      ? `The player chose to fight in this situation: "${eventContext}"\n\nGenerate an enemy that matches this encounter. The enemy should be the creature or opponent described in the event above.\n\n${storyContext}`
+      : storyContext
+    const { enemy, scenario } = await generateCombatEncounter(character, fullContext)
     const playerState = initializePlayerCombatState(character)
 
     const combatState: CombatState = {

--- a/src/app/tap-tap-adventure/hooks/useResolveDecisionMutation.ts
+++ b/src/app/tap-tap-adventure/hooks/useResolveDecisionMutation.ts
@@ -89,6 +89,7 @@ export function useResolveDecisionMutation() {
       addStoryEvent(newStoryEvent)
 
       // If the chosen option triggers combat, start a combat encounter
+      // Pass the event description so the enemy matches the narrative
       if (data.triggersCombat) {
         const { gameState } = useGameStore.getState()
         const combatRes = await fetch('/api/v1/tap-tap-adventure/combat/start', {
@@ -97,6 +98,7 @@ export function useResolveDecisionMutation() {
           body: JSON.stringify({
             character: data.updatedCharacter,
             storyEvents: gameState.storyEvents,
+            eventContext: decisionPoint.prompt,
           }),
         })
         if (combatRes.ok) {


### PR DESCRIPTION
## Summary
When choosing to fight in a narrative event, the combat enemy now matches the event description. Previously, picking "fight the bandits" could spawn a random goblin.

### Changes
- `useResolveDecisionMutation.ts`: passes `eventContext: decisionPoint.prompt` to combat start API
- `combat/start/route.ts`: prepends event context to the LLM prompt with "Generate an enemy that matches this encounter"

Two files, ~5 lines changed.

## Test plan
- [ ] Trigger a combat event (e.g., bandits) and verify the enemy matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)