### PR TITLE
feat: tactical combat — combos, telegraphing, boss battles

### DIFF
--- a/src/app/api/v1/tap-tap-adventure/combat/start/route.ts
+++ b/src/app/api/v1/tap-tap-adventure/combat/start/route.ts
@@ -2,17 +2,20 @@ import { NextRequest, NextResponse } from 'next/server'
 
 import { buildStoryContext } from '@/app/tap-tap-adventure/lib/contextBuilder'
 import { initializePlayerCombatState } from '@/app/tap-tap-adventure/lib/combatEngine'
-import { generateCombatEncounter } from '@/app/tap-tap-adventure/lib/combatGenerator'
+import { generateCombatEncounter, generateBossEncounter } from '@/app/tap-tap-adventure/lib/combatGenerator'
 import { CombatState } from '@/app/tap-tap-adventure/models/combat'
 
 export async function POST(req: NextRequest) {
   try {
-    const { character, storyEvents = [], eventContext } = await req.json()
+    const { character, storyEvents = [], eventContext, isBoss = false } = await req.json()
     const storyContext = buildStoryContext(character, storyEvents)
     const fullContext = eventContext
       ? `The player chose to fight in this situation: "${eventContext}"\n\nGenerate an enemy that matches this encounter. The enemy should be the creature or opponent described in the event above.\n\n${storyContext}`
       : storyContext
-    const { enemy, scenario } = await generateCombatEncounter(character, fullContext)
+
+    const { enemy, scenario } = isBoss
+      ? await generateBossEncounter(character, fullContext)
+      : await generateCombatEncounter(character, fullContext)
     const playerState = initializePlayerCombatState(character)
 
     const combatState: CombatState = {
@@ -24,6 +27,7 @@ export async function POST(req: NextRequest) {
       combatLog: [],
       status: 'active',
       scenario,
+      isBoss,
     }
 
     return NextResponse.json({ combatState })

--- a/src/app/api/v1/tap-tap-adventure/move-forward/services/moveForwardService.ts
+++ b/src/app/api/v1/tap-tap-adventure/move-forward/services/moveForwardService.ts
@@ -16,6 +16,51 @@ export async function moveForwardService(
   const newLevel = calculateLevel(newDistance)
   const updatedCharacter = { ...character, distance: newDistance }
 
+  // Trigger boss event every 5 levels
+  if (newLevel > oldLevel && newLevel % 5 === 0) {
+    const bossEventId = `boss-event-${Date.now()}`
+    return {
+      character: updatedCharacter,
+      event: {
+        id: bossEventId,
+        type: 'boss_available',
+        characterId: character.id,
+        locationId: character.locationId,
+        timestamp: new Date().toISOString(),
+      },
+      decisionPoint: {
+        id: `decision-${bossEventId}`,
+        eventId: bossEventId,
+        prompt: `You sense a powerful presence ahead. A formidable guardian blocks the path forward. You are now level ${newLevel} — do you feel ready to face this challenge?`,
+        options: [
+          {
+            id: `boss-fight-${bossEventId}`,
+            text: 'Challenge the boss!',
+            triggersCombat: true,
+            isBoss: true,
+            successProbability: 0.5,
+            successDescription: 'You prepare for an epic battle!',
+            successEffects: {},
+            failureDescription: 'You prepare for an epic battle!',
+            failureEffects: {},
+            resultDescription: 'You prepare for an epic battle!',
+          },
+          {
+            id: `boss-skip-${bossEventId}`,
+            text: 'Not yet — keep traveling and grow stronger',
+            successProbability: 1.0,
+            successDescription: 'You wisely decide to prepare more before facing this challenge. The boss will still be here when you return.',
+            successEffects: { reputation: 0 },
+            failureDescription: 'You continue your journey.',
+            failureEffects: {},
+            resultDescription: 'You wisely decide to prepare more before facing this challenge.',
+          },
+        ],
+        resolved: false,
+      },
+    }
+  }
+
   // Trigger shop event on level up
   if (newLevel > oldLevel) {
     return {
@@ -28,7 +73,6 @@ export async function moveForwardService(
         timestamp: new Date().toISOString(),
       },
       decisionPoint: null,
-      combatEncounter: null,
       shopEvent: true,
     }
   }

--- a/src/app/tap-tap-adventure/__tests__/combatEngine.test.ts
+++ b/src/app/tap-tap-adventure/__tests__/combatEngine.test.ts
@@ -62,6 +62,7 @@ function makeActiveCombat(overrides: Partial<CombatState> = {}): CombatState {
       defense: 11,
       isDefending: false,
       activeBuffs: [],
+      comboCount: 0,
     },
     turnNumber: 0,
     combatLog: [],

--- a/src/app/tap-tap-adventure/__tests__/combatTactics.test.ts
+++ b/src/app/tap-tap-adventure/__tests__/combatTactics.test.ts
@@ -1,0 +1,199 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+  checkBossPhaseChange,
+  getComboMultiplier,
+  generateEnemyTelegraph,
+  initializePlayerCombatState,
+  processPlayerAction,
+} from '@/app/tap-tap-adventure/lib/combatEngine'
+import { FantasyCharacter } from '@/app/tap-tap-adventure/models/character'
+import { CombatState } from '@/app/tap-tap-adventure/models/combat'
+
+const baseChar: FantasyCharacter = {
+  id: '1',
+  playerId: 'p1',
+  name: 'Test',
+  race: 'Human',
+  class: 'Warrior',
+  level: 3,
+  abilities: [],
+  locationId: 'loc1',
+  gold: 50,
+  reputation: 10,
+  distance: 55,
+  status: 'active',
+  strength: 8,
+  intelligence: 5,
+  luck: 6,
+  inventory: [],
+}
+
+function makeActiveCombat(overrides: Partial<CombatState> = {}): CombatState {
+  return {
+    id: 'combat-1',
+    eventId: 'event-1',
+    enemy: {
+      id: 'enemy-1',
+      name: 'Goblin',
+      description: 'A nasty goblin',
+      hp: 30,
+      maxHp: 30,
+      attack: 8,
+      defense: 3,
+      level: 2,
+      goldReward: 15,
+    },
+    playerState: {
+      hp: 90,
+      maxHp: 90,
+      attack: 24,
+      defense: 11,
+      isDefending: false,
+      activeBuffs: [],
+      comboCount: 0,
+    },
+    turnNumber: 0,
+    combatLog: [],
+    status: 'active',
+    scenario: 'A goblin appears!',
+    enemyTelegraph: null,
+    ...overrides,
+  }
+}
+
+describe('Combat Tactics', () => {
+  describe('Combo System', () => {
+    it('returns 1x multiplier for 0 combo', () => {
+      expect(getComboMultiplier(0)).toBe(1)
+    })
+
+    it('returns 1.25x for 1 combo', () => {
+      expect(getComboMultiplier(1)).toBe(1.25)
+    })
+
+    it('returns 1.5x for 2 combo', () => {
+      expect(getComboMultiplier(2)).toBe(1.5)
+    })
+
+    it('caps at 1.75x', () => {
+      expect(getComboMultiplier(3)).toBe(1.75)
+      expect(getComboMultiplier(10)).toBe(1.75)
+    })
+
+    it('increments combo on attack', () => {
+      const combat = makeActiveCombat()
+      vi.spyOn(Math, 'random').mockReturnValue(0.5)
+      const { combatState: result } = processPlayerAction(combat, { action: 'attack' }, baseChar)
+      expect(result.playerState.comboCount).toBe(1)
+      vi.restoreAllMocks()
+    })
+
+    it('resets combo on defend', () => {
+      const combat = makeActiveCombat({
+        playerState: { ...makeActiveCombat().playerState, comboCount: 3 },
+      })
+      vi.spyOn(Math, 'random').mockReturnValue(0.5)
+      const { combatState: result } = processPlayerAction(combat, { action: 'defend' }, baseChar)
+      expect(result.playerState.comboCount).toBe(0)
+      vi.restoreAllMocks()
+    })
+
+    it('resets combo on use_item', () => {
+      const combat = makeActiveCombat({
+        playerState: { ...makeActiveCombat().playerState, comboCount: 2 },
+      })
+      vi.spyOn(Math, 'random').mockReturnValue(0.5)
+      const { combatState: result } = processPlayerAction(
+        combat,
+        { action: 'use_item', itemId: 'nonexistent' },
+        baseChar
+      )
+      expect(result.playerState.comboCount).toBe(0)
+      vi.restoreAllMocks()
+    })
+  })
+
+  describe('Enemy Telegraphing', () => {
+    it('generates a telegraph with valid action', () => {
+      vi.spyOn(Math, 'random').mockReturnValue(0.5)
+      const telegraph = generateEnemyTelegraph(
+        makeActiveCombat().enemy,
+        1,
+        false
+      )
+      expect(['heavy_attack', 'special', 'defend', 'normal_attack']).toContain(telegraph.action)
+      expect(telegraph.description).toBeTruthy()
+      vi.restoreAllMocks()
+    })
+
+    it('telegraphs special ability when cooldown matches', () => {
+      const enemy = {
+        ...makeActiveCombat().enemy,
+        specialAbility: { name: 'Fire Breath', description: 'Breathes fire', damage: 15, cooldown: 3 },
+      }
+      // Turn 2 + 1 = 3, which is divisible by cooldown 3
+      const telegraph = generateEnemyTelegraph(enemy, 2, false)
+      expect(telegraph.action).toBe('special')
+      expect(telegraph.description).toContain('Fire Breath')
+    })
+
+    it('returns next telegraph after processing action', () => {
+      const combat = makeActiveCombat()
+      vi.spyOn(Math, 'random').mockReturnValue(0.5)
+      const { combatState: result } = processPlayerAction(combat, { action: 'attack' }, baseChar)
+      expect(result.enemyTelegraph).not.toBeNull()
+      expect(result.enemyTelegraph?.description).toBeTruthy()
+      vi.restoreAllMocks()
+    })
+
+    it('clears telegraph on victory', () => {
+      const combat = makeActiveCombat({
+        enemy: { ...makeActiveCombat().enemy, hp: 1, defense: 0 },
+        enemyTelegraph: { action: 'heavy_attack', description: 'Winding up!' },
+      })
+      vi.spyOn(Math, 'random').mockReturnValue(0.5)
+      const { combatState: result } = processPlayerAction(combat, { action: 'attack' }, baseChar)
+      expect(result.status).toBe('victory')
+      expect(result.enemyTelegraph).toBeNull()
+      vi.restoreAllMocks()
+    })
+  })
+
+  describe('Boss Phase Change', () => {
+    it('does not trigger for non-boss', () => {
+      const enemy = { ...makeActiveCombat().enemy, hp: 10, maxHp: 100 }
+      const { phaseChanged } = checkBossPhaseChange(enemy, false, false)
+      expect(phaseChanged).toBe(false)
+    })
+
+    it('does not trigger when boss HP above 50%', () => {
+      const enemy = { ...makeActiveCombat().enemy, hp: 60, maxHp: 100 }
+      const { phaseChanged } = checkBossPhaseChange(enemy, true, false)
+      expect(phaseChanged).toBe(false)
+    })
+
+    it('triggers when boss HP drops below 50%', () => {
+      const enemy = { ...makeActiveCombat().enemy, hp: 49, maxHp: 100 }
+      const { enemy: enraged, phaseChanged, log } = checkBossPhaseChange(enemy, true, false)
+      expect(phaseChanged).toBe(true)
+      expect(enraged.name).toContain('Enraged')
+      expect(enraged.attack).toBeGreaterThan(enemy.attack)
+      expect(enraged.defense).toBeGreaterThan(enemy.defense)
+      expect(log?.description).toContain('enraged')
+    })
+
+    it('does not trigger twice', () => {
+      const enemy = { ...makeActiveCombat().enemy, hp: 30, maxHp: 100, name: 'Boss (Enraged)' }
+      const { phaseChanged } = checkBossPhaseChange(enemy, true, true)
+      expect(phaseChanged).toBe(false)
+    })
+  })
+
+  describe('Player state initialization', () => {
+    it('initializes comboCount to 0', () => {
+      const state = initializePlayerCombatState(baseChar)
+      expect(state.comboCount).toBe(0)
+    })
+  })
+})

--- a/src/app/tap-tap-adventure/components/CombatUI.tsx
+++ b/src/app/tap-tap-adventure/components/CombatUI.tsx
@@ -75,8 +75,12 @@ export function CombatUI({ combatState }: CombatUIProps) {
     <div className="space-y-4">
       {/* Header */}
       <div className="text-center">
-        <h4 className="font-semibold uppercase text-red-400 border-b border-red-900/50 pb-2 mb-2">
-          Combat
+        <h4 className="font-semibold uppercase border-b border-red-900/50 pb-2 mb-2">
+          {combatState.isBoss ? (
+            <span className="text-yellow-400">Boss Battle</span>
+          ) : (
+            <span className="text-red-400">Combat</span>
+          )}
         </h4>
         <p className="text-sm text-slate-300 italic">{scenario}</p>
       </div>
@@ -98,15 +102,35 @@ export function CombatUI({ combatState }: CombatUIProps) {
         <HpBar current={enemy.hp} max={enemy.maxHp} label="Enemy" color="text-red-400" />
       </div>
 
+      {/* Enemy telegraph warning */}
+      {combatState.enemyTelegraph && (
+        <div className={`border rounded-lg p-2 text-center text-sm animate-pulse ${
+          combatState.enemyTelegraph.action === 'heavy_attack' || combatState.enemyTelegraph.action === 'special'
+            ? 'bg-red-950/50 border-red-700/50 text-red-300'
+            : combatState.enemyTelegraph.action === 'defend'
+              ? 'bg-blue-950/50 border-blue-700/50 text-blue-300'
+              : 'bg-slate-800 border-slate-600 text-slate-300'
+        }`}>
+          {combatState.enemyTelegraph.description}
+        </div>
+      )}
+
       {/* Player info */}
       <div className="bg-[#1e1f30] border border-blue-900/30 rounded-lg p-3 space-y-2">
         <div className="flex justify-between items-center">
           <span className="font-bold text-blue-400">{character?.name ?? 'You'}</span>
-          {playerState.isDefending && (
-            <span className="text-[10px] px-1.5 py-0.5 bg-blue-900/50 text-blue-400 rounded">
-              Defending
-            </span>
-          )}
+          <div className="flex gap-2">
+            {(playerState.comboCount ?? 0) > 0 && (
+              <span className="text-[10px] px-1.5 py-0.5 bg-orange-900/50 text-orange-400 rounded font-bold">
+                {playerState.comboCount}x Combo
+              </span>
+            )}
+            {playerState.isDefending && (
+              <span className="text-[10px] px-1.5 py-0.5 bg-blue-900/50 text-blue-400 rounded">
+                Defending
+              </span>
+            )}
+          </div>
         </div>
         <HpBar current={playerState.hp} max={playerState.maxHp} label="You" color="text-blue-400" />
         {playerState.activeBuffs && playerState.activeBuffs.length > 0 && (

--- a/src/app/tap-tap-adventure/hooks/useResolveDecisionMutation.ts
+++ b/src/app/tap-tap-adventure/hooks/useResolveDecisionMutation.ts
@@ -92,6 +92,8 @@ export function useResolveDecisionMutation() {
       // Pass the event description so the enemy matches the narrative
       if (data.triggersCombat) {
         const { gameState } = useGameStore.getState()
+        const chosenOption = decisionPoint.options.find(o => o.id === optionId)
+        const isBoss = (chosenOption as Record<string, unknown>)?.isBoss === true
         const combatRes = await fetch('/api/v1/tap-tap-adventure/combat/start', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
@@ -99,6 +101,7 @@ export function useResolveDecisionMutation() {
             character: data.updatedCharacter,
             storyEvents: gameState.storyEvents,
             eventContext: decisionPoint.prompt,
+            isBoss,
           }),
         })
         if (combatRes.ok) {

--- a/src/app/tap-tap-adventure/lib/combatEngine.ts
+++ b/src/app/tap-tap-adventure/lib/combatEngine.ts
@@ -5,6 +5,7 @@ import {
   CombatLogEntry,
   CombatPlayerState,
   CombatState,
+  EnemyTelegraph,
 } from '@/app/tap-tap-adventure/models/combat'
 import { Item } from '@/app/tap-tap-adventure/models/item'
 
@@ -19,12 +20,21 @@ export function initializePlayerCombatState(character: FantasyCharacter): Combat
     defense: 3 + character.intelligence + character.level,
     isDefending: false,
     activeBuffs: [],
+    comboCount: 0,
   }
 }
 
 function randomVariance(base: number, pct: number = 0.2): number {
   const variance = base * pct
   return base + (Math.random() * 2 - 1) * variance
+}
+
+/**
+ * Combo multiplier: consecutive attacks build damage.
+ * 0 combo = 1x, 1 = 1.25x, 2 = 1.5x, 3+ = 1.75x (capped)
+ */
+function getComboMultiplier(comboCount: number): number {
+  return Math.min(1.75, 1 + comboCount * 0.25)
 }
 
 export function calculatePlayerDamage(
@@ -36,13 +46,15 @@ export function calculatePlayerDamage(
     (playerState.activeBuffs ?? [])
       .filter(b => b.stat === 'attack')
       .reduce((sum, b) => sum + b.value, 0)
-  const raw = randomVariance(buffedAttack) - enemy.defense / 2
+  const comboMultiplier = getComboMultiplier(playerState.comboCount)
+  const raw = randomVariance(buffedAttack) * comboMultiplier - enemy.defense / 2
   return Math.max(1, Math.round(raw))
 }
 
 export function calculateEnemyDamage(
   enemy: CombatEnemy,
-  playerState: CombatPlayerState
+  playerState: CombatPlayerState,
+  isHeavyAttack: boolean = false
 ): number {
   const effectiveDefense = playerState.isDefending
     ? playerState.defense * 2
@@ -52,7 +64,8 @@ export function calculateEnemyDamage(
     (playerState.activeBuffs ?? [])
       .filter(b => b.stat === 'defense')
       .reduce((sum, b) => sum + b.value, 0)
-  const raw = randomVariance(enemy.attack) - buffedDefense / 2
+  const attackPower = isHeavyAttack ? enemy.attack * 1.5 : enemy.attack
+  const raw = randomVariance(attackPower) - buffedDefense / 2
   return Math.max(1, Math.round(raw))
 }
 
@@ -71,10 +84,148 @@ function tickBuffs(playerState: CombatPlayerState): CombatPlayerState {
   return { ...playerState, activeBuffs }
 }
 
-function shouldUseSpecialAbility(enemy: CombatEnemy, turnNumber: number): boolean {
-  if (!enemy.specialAbility) return false
-  if (enemy.specialAbility.cooldown <= 0) return Math.random() < 0.3
-  return turnNumber > 0 && turnNumber % enemy.specialAbility.cooldown === 0
+/**
+ * Generate a telegraph for the enemy's NEXT action.
+ * This lets the player see what's coming and react.
+ */
+function generateEnemyTelegraph(enemy: CombatEnemy, turnNumber: number, isBoss: boolean): EnemyTelegraph {
+  const hasSpecial = !!enemy.specialAbility
+  const specialReady = hasSpecial && enemy.specialAbility!.cooldown > 0
+    ? turnNumber > 0 && (turnNumber + 1) % enemy.specialAbility!.cooldown === 0
+    : hasSpecial && Math.random() < 0.3
+
+  if (specialReady) {
+    return {
+      action: 'special',
+      description: `${enemy.name} is preparing ${enemy.specialAbility!.name}!`,
+    }
+  }
+
+  // Bosses and stronger enemies telegraph heavy attacks more often
+  const heavyChance = isBoss ? 0.35 : 0.2
+  if (Math.random() < heavyChance) {
+    return {
+      action: 'heavy_attack',
+      description: `${enemy.name} winds up for a powerful strike!`,
+    }
+  }
+
+  // Rare enemy defend (boss only)
+  if (isBoss && Math.random() < 0.15) {
+    return {
+      action: 'defend',
+      description: `${enemy.name} braces and raises their guard.`,
+    }
+  }
+
+  return {
+    action: 'normal_attack',
+    description: `${enemy.name} readies an attack.`,
+  }
+}
+
+/**
+ * Execute the enemy's telegraphed action.
+ */
+function executeEnemyTelegraph(
+  telegraph: EnemyTelegraph,
+  enemy: CombatEnemy,
+  playerState: CombatPlayerState,
+  turnNumber: number
+): { playerState: CombatPlayerState; logs: CombatLogEntry[]; enemyDefenseBoost: boolean } {
+  const logs: CombatLogEntry[] = []
+  let updatedPlayer = { ...playerState }
+  let enemyDefenseBoost = false
+
+  switch (telegraph.action) {
+    case 'heavy_attack': {
+      const dmg = calculateEnemyDamage(enemy, updatedPlayer, true)
+      updatedPlayer.hp = Math.max(0, updatedPlayer.hp - dmg)
+      logs.push({
+        turn: turnNumber,
+        actor: 'enemy',
+        action: 'heavy_attack',
+        damage: dmg,
+        description: `${enemy.name} unleashes a powerful blow for ${dmg} damage!`,
+      })
+      break
+    }
+    case 'special': {
+      if (enemy.specialAbility) {
+        const specialDmg = Math.max(
+          1,
+          Math.round(
+            randomVariance(enemy.specialAbility.damage) -
+            (updatedPlayer.isDefending ? updatedPlayer.defense : updatedPlayer.defense / 2)
+          )
+        )
+        updatedPlayer.hp = Math.max(0, updatedPlayer.hp - specialDmg)
+        logs.push({
+          turn: turnNumber,
+          actor: 'enemy',
+          action: 'special',
+          damage: specialDmg,
+          description: `${enemy.name} uses ${enemy.specialAbility.name}! You take ${specialDmg} damage!`,
+        })
+      }
+      break
+    }
+    case 'defend': {
+      enemyDefenseBoost = true
+      logs.push({
+        turn: turnNumber,
+        actor: 'enemy',
+        action: 'defend',
+        description: `${enemy.name} takes a defensive stance, reducing incoming damage.`,
+      })
+      break
+    }
+    case 'normal_attack':
+    default: {
+      const dmg = calculateEnemyDamage(enemy, updatedPlayer)
+      updatedPlayer.hp = Math.max(0, updatedPlayer.hp - dmg)
+      logs.push({
+        turn: turnNumber,
+        actor: 'enemy',
+        action: 'attack',
+        damage: dmg,
+        description: `${enemy.name} attacks you for ${dmg} damage!`,
+      })
+      break
+    }
+  }
+
+  return { playerState: updatedPlayer, logs, enemyDefenseBoost }
+}
+
+/**
+ * Boss phase change: when a boss drops below 50% HP, boost their stats.
+ */
+function checkBossPhaseChange(
+  enemy: CombatEnemy,
+  isBoss: boolean,
+  alreadyPhased: boolean
+): { enemy: CombatEnemy; phaseChanged: boolean; log?: CombatLogEntry } {
+  if (!isBoss || alreadyPhased) return { enemy, phaseChanged: false }
+  if (enemy.hp > enemy.maxHp * 0.5) return { enemy, phaseChanged: false }
+
+  const enragedEnemy = {
+    ...enemy,
+    attack: Math.round(enemy.attack * 1.4),
+    defense: Math.round(enemy.defense * 1.3),
+    name: `${enemy.name} (Enraged)`,
+  }
+
+  return {
+    enemy: enragedEnemy,
+    phaseChanged: true,
+    log: {
+      turn: 0,
+      actor: 'enemy',
+      action: 'phase_change',
+      description: `${enemy.name} becomes enraged! Attack and defense increased!`,
+    },
+  }
 }
 
 export function processPlayerAction(
@@ -82,9 +233,10 @@ export function processPlayerAction(
   action: CombatActionRequest,
   character: FantasyCharacter
 ): { combatState: CombatState; consumedItemId?: string } {
-  let { enemy, playerState, turnNumber, combatLog, status } = structuredClone(combatState)
+  let { enemy, playerState, turnNumber, combatLog, status, enemyTelegraph, isBoss } = structuredClone(combatState)
   const newLogs: CombatLogEntry[] = []
   let consumedItemId: string | undefined
+  const bossAlreadyPhased = isBoss ? enemy.name.includes('(Enraged)') : false
 
   if (status !== 'active') {
     return { combatState }
@@ -93,22 +245,32 @@ export function processPlayerAction(
   turnNumber += 1
   playerState.isDefending = false
 
+  // Track if enemy is defending this turn (from telegraph)
+  let enemyDefending = false
+
   // Process player action
   switch (action.action) {
     case 'attack': {
-      const damage = calculatePlayerDamage(playerState, enemy)
+      // Apply enemy defense boost if they telegraphed defend
+      const effectiveEnemy = enemyDefending
+        ? { ...enemy, defense: enemy.defense * 2 }
+        : enemy
+      const damage = calculatePlayerDamage(playerState, effectiveEnemy)
       enemy.hp = Math.max(0, enemy.hp - damage)
+      playerState.comboCount = (playerState.comboCount ?? 0) + 1
+      const comboText = playerState.comboCount > 1 ? ` (${playerState.comboCount}x combo!)` : ''
       newLogs.push({
         turn: turnNumber,
         actor: 'player',
         action: 'attack',
         damage,
-        description: `You strike ${enemy.name} for ${damage} damage!`,
+        description: `You strike ${enemy.name} for ${damage} damage!${comboText}`,
       })
       break
     }
     case 'defend': {
       playerState.isDefending = true
+      playerState.comboCount = 0 // defending breaks combo
       newLogs.push({
         turn: turnNumber,
         actor: 'player',
@@ -118,6 +280,7 @@ export function processPlayerAction(
       break
     }
     case 'use_item': {
+      playerState.comboCount = 0 // using item breaks combo
       if (!action.itemId) {
         newLogs.push({
           turn: turnNumber,
@@ -151,6 +314,7 @@ export function processPlayerAction(
       break
     }
     case 'flee': {
+      playerState.comboCount = 0
       const fleeChance = calculateFleeChance(character, enemy)
       if (Math.random() < fleeChance) {
         status = 'fled'
@@ -168,6 +332,7 @@ export function processPlayerAction(
             turnNumber,
             combatLog: [...combatLog, ...newLogs],
             status,
+            enemyTelegraph: null,
           },
         }
       }
@@ -178,6 +343,17 @@ export function processPlayerAction(
         description: `You try to flee but ${enemy.name} blocks your escape!`,
       })
       break
+    }
+  }
+
+  // Check boss phase change
+  if (enemy.hp > 0) {
+    const phase = checkBossPhaseChange(enemy, !!isBoss, bossAlreadyPhased)
+    if (phase.phaseChanged) {
+      enemy = phase.enemy
+      if (phase.log) {
+        newLogs.push({ ...phase.log, turn: turnNumber })
+      }
     }
   }
 
@@ -198,27 +374,20 @@ export function processPlayerAction(
         turnNumber,
         combatLog: [...combatLog, ...newLogs],
         status,
+        enemyTelegraph: null,
       },
       consumedItemId,
     }
   }
 
-  // Enemy turn
-  const useSpecial = shouldUseSpecialAbility(enemy, turnNumber)
-  if (useSpecial && enemy.specialAbility) {
-    const specialDmg = Math.max(
-      1,
-      Math.round(randomVariance(enemy.specialAbility.damage) - (playerState.isDefending ? playerState.defense : playerState.defense / 2))
-    )
-    playerState.hp = Math.max(0, playerState.hp - specialDmg)
-    newLogs.push({
-      turn: turnNumber,
-      actor: 'enemy',
-      action: 'special',
-      damage: specialDmg,
-      description: `${enemy.name} uses ${enemy.specialAbility.name}! You take ${specialDmg} damage!`,
-    })
+  // Execute enemy's telegraphed action (or normal attack if no telegraph)
+  if (enemyTelegraph) {
+    const result = executeEnemyTelegraph(enemyTelegraph, enemy, playerState, turnNumber)
+    playerState = result.playerState
+    newLogs.push(...result.logs)
+    enemyDefending = result.enemyDefenseBoost
   } else {
+    // First turn or no telegraph — normal attack
     const enemyDmg = calculateEnemyDamage(enemy, playerState)
     playerState.hp = Math.max(0, playerState.hp - enemyDmg)
     newLogs.push({
@@ -244,6 +413,11 @@ export function processPlayerAction(
   // Tick buffs
   playerState = tickBuffs(playerState)
 
+  // Generate telegraph for enemy's NEXT action
+  const nextTelegraph = status === 'active'
+    ? generateEnemyTelegraph(enemy, turnNumber, !!isBoss)
+    : null
+
   return {
     combatState: {
       ...combatState,
@@ -252,6 +426,8 @@ export function processPlayerAction(
       turnNumber,
       combatLog: [...combatLog, ...newLogs],
       status,
+      enemyTelegraph: nextTelegraph,
+      isBoss,
     },
     consumedItemId,
   }
@@ -269,11 +445,11 @@ export function getCombatRewards(
   const { enemy } = combatState
   const gold = enemy.goldReward
 
-  // Select loot based on luck
+  // Select loot based on luck. Boss loot always drops.
   const loot: Item[] = []
   if (enemy.lootTable) {
     for (const item of enemy.lootTable) {
-      const dropChance = 0.3 + character.luck * 0.03
+      const dropChance = combatState.isBoss ? 1.0 : 0.3 + character.luck * 0.03
       if (Math.random() < dropChance) {
         loot.push(item)
       }
@@ -282,3 +458,6 @@ export function getCombatRewards(
 
   return { gold, loot }
 }
+
+// Re-export for tests
+export { getComboMultiplier, generateEnemyTelegraph, checkBossPhaseChange }

--- a/src/app/tap-tap-adventure/lib/combatGenerator.ts
+++ b/src/app/tap-tap-adventure/lib/combatGenerator.ts
@@ -146,6 +146,114 @@ ${context || 'A wandering adventurer encounters danger on the road.'}`,
   }
 }
 
+export async function generateBossEncounter(
+  character: FantasyCharacter,
+  context: string
+): Promise<{ enemy: CombatEnemy; scenario: string }> {
+  try {
+    const response = await openai.chat.completions.create({
+      model: 'gpt-4o',
+      messages: [
+        {
+          role: 'user',
+          content: `Generate a BOSS combat encounter for this fantasy character. This is a major battle — the boss should be powerful, intimidating, and memorable.
+
+This is a level ${character.level} character facing a boss fight. The boss should be significantly stronger than normal enemies:
+- Boss HP: ${Math.round((30 + character.level * 15) * 2.5)} (2.5x normal)
+- Boss attack: ${Math.round((3 + character.level * 2) * 1.8)} (1.8x normal)
+- Boss defense: ${Math.round((2 + character.level) * 1.5)} (1.5x normal)
+- Gold reward: ${Math.round((5 + character.level * 5) * 3)} (3x normal)
+- Include 2-3 high-quality loot items (rare potions, powerful scrolls, gems)
+- MUST include a special ability with cooldown of 2-3 turns — this is a boss!
+- Give the boss an imposing, unique name
+
+Character:
+${JSON.stringify(character, null, 2)}
+
+Context:
+${context}`,
+        },
+      ],
+      tools: [
+        {
+          type: 'function',
+          function: {
+            name: 'generate_combat',
+            description: 'Generate a boss combat encounter.',
+            parameters: enemySchemaForOpenAI,
+          },
+        },
+      ],
+      tool_choice: { type: 'function', function: { name: 'generate_combat' } },
+      temperature: 0.8,
+      max_tokens: 800,
+    })
+
+    const toolCall = response.choices[0]?.message?.tool_calls?.[0]
+    if (toolCall && toolCall.function?.name === 'generate_combat') {
+      const parsed = JSON.parse(toolCall.function.arguments)
+      const validated = combatResponseSchema.parse(parsed)
+      if (validated.enemy.lootTable) {
+        validated.enemy.lootTable = validated.enemy.lootTable.map(inferItemTypeAndEffects)
+      }
+      return validated
+    }
+    throw new Error('No tool call in response')
+  } catch (err) {
+    console.error('Boss generation failed, using fallback', err)
+    return getDefaultBossEncounter(character)
+  }
+}
+
+function getDefaultBossEncounter(
+  character: FantasyCharacter
+): { enemy: CombatEnemy; scenario: string } {
+  const level = character.level
+  const suffix = `${Date.now()}-${Math.floor(Math.random() * 10000)}`
+
+  const bosses = [
+    { name: 'The Iron Warden', desc: 'A colossal animated suit of armor, its eyes burning with ancient fury.', special: 'Crushing Blow', specialDesc: 'Slams the ground, sending shockwaves.' },
+    { name: 'Vexara the Cursed', desc: 'A spectral sorceress wreathed in dark flame, whispering words of ruin.', special: 'Soul Drain', specialDesc: 'Drains life force from her victims.' },
+    { name: 'Grimfang the Devourer', desc: 'A massive beast with razor teeth and impenetrable scales.', special: 'Rending Fury', specialDesc: 'Unleashes a devastating multi-strike attack.' },
+  ]
+  const boss = bosses[level % bosses.length]
+
+  return {
+    scenario: `A powerful presence blocks your path. ${boss.name} emerges — a fearsome foe that will test everything you have. This is a boss battle!`,
+    enemy: {
+      id: `boss-${suffix}`,
+      name: boss.name,
+      description: boss.desc,
+      hp: Math.round((30 + level * 15) * 2.5),
+      maxHp: Math.round((30 + level * 15) * 2.5),
+      attack: Math.round((3 + level * 2) * 1.8),
+      defense: Math.round((2 + level) * 1.5),
+      level: level + 2,
+      goldReward: Math.round((5 + level * 5) * 3),
+      lootTable: [
+        inferItemTypeAndEffects({
+          id: `boss-loot-1-${suffix}`,
+          name: 'Greater Healing Potion',
+          description: 'A potent restorative brew.',
+          quantity: 1,
+        }),
+        inferItemTypeAndEffects({
+          id: `boss-loot-2-${suffix}`,
+          name: 'Tome of Power',
+          description: 'An ancient book radiating magical energy.',
+          quantity: 1,
+        }),
+      ],
+      specialAbility: {
+        name: boss.special,
+        description: boss.specialDesc,
+        damage: Math.round((5 + level * 2) * 1.8),
+        cooldown: 2,
+      },
+    },
+  }
+}
+
 function getDefaultCombatEncounter(
   character: FantasyCharacter
 ): { enemy: CombatEnemy; scenario: string } {

--- a/src/app/tap-tap-adventure/models/combat.ts
+++ b/src/app/tap-tap-adventure/models/combat.ts
@@ -38,6 +38,7 @@ export const CombatPlayerStateSchema = z.object({
   defense: z.number(),
   isDefending: z.boolean(),
   activeBuffs: z.array(CombatBuffSchema).optional(),
+  comboCount: z.number().default(0),
 })
 export type CombatPlayerState = z.infer<typeof CombatPlayerStateSchema>
 
@@ -62,6 +63,12 @@ export type CombatLogEntry = z.infer<typeof CombatLogEntrySchema>
 export const CombatStatusSchema = z.enum(['active', 'victory', 'defeat', 'fled'])
 export type CombatStatus = z.infer<typeof CombatStatusSchema>
 
+export const EnemyTelegraphSchema = z.object({
+  action: z.enum(['heavy_attack', 'special', 'defend', 'normal_attack']),
+  description: z.string(),
+})
+export type EnemyTelegraph = z.infer<typeof EnemyTelegraphSchema>
+
 export const CombatStateSchema = z.object({
   id: z.string(),
   eventId: z.string(),
@@ -71,5 +78,7 @@ export const CombatStateSchema = z.object({
   combatLog: z.array(CombatLogEntrySchema),
   status: CombatStatusSchema,
   scenario: z.string(),
+  enemyTelegraph: EnemyTelegraphSchema.optional().nullable(),
+  isBoss: z.boolean().optional(),
 })
 export type CombatState = z.infer<typeof CombatStateSchema>


### PR DESCRIPTION
## Summary
Combat is no longer an auto-win. Three new systems make every turn a real decision:

### Combo System
- Consecutive attacks build damage: 1x → 1.25x → 1.5x → 1.75x (capped)
- Defending, using items, or fleeing **resets your combo**
- Creates risk/reward: keep attacking for big damage, or break combo to heal?
- UI shows combo counter badge on player info

### Enemy Telegraphing
- After each turn, the enemy **telegraphs their next action**
- Heavy attack: "winds up for a powerful strike!" — deals 1.5x damage
- Special: "preparing [ability name]!" — big damage, worth defending against
- Defend (boss only): "raises their guard" — your attacks do less
- Normal: "readies an attack" — standard damage
- Shown as a pulsing alert between enemy and player info, color-coded by severity

### Boss Battles
- **Every 5 levels**, a boss event appears
- Player chooses: "Challenge the boss!" or "Not yet — keep grinding"
- Bosses are **2.5x HP, 1.8x attack, 1.5x defense** vs normal enemies
- **Phase change at 50% HP**: boss becomes Enraged (+40% attack, +30% defense)
- **3x gold reward**, 100% loot drop rate, 2-3 high-quality items
- LLM generates unique bosses; fallback pool of 3 named bosses
- UI shows "Boss Battle" header in gold instead of red "Combat"

### Changes (9 files, 609 lines)
- `models/combat.ts` — `comboCount` on player state, `EnemyTelegraph` schema, `isBoss` flag
- `lib/combatEngine.ts` — combo multiplier, telegraph generation/execution, boss phase changes
- `lib/combatGenerator.ts` — `generateBossEncounter` with scaled stats and fallbacks
- `components/CombatUI.tsx` — combo badge, telegraph warning, boss header
- `combat/start/route.ts` — accepts `isBoss` flag, routes to boss generator
- `moveForwardService.ts` — boss events every 5 levels with fight/skip options
- `useResolveDecisionMutation.ts` — passes `isBoss` to combat start
- Tests: 16 new tests for combo, telegraphing, and boss phases

## Test plan
- [x] 141 tests pass (15 test files)
- [ ] Build combo by attacking multiple turns, verify multiplier
- [ ] Verify telegraph appears and matches enemy's actual action
- [ ] Defend against a telegraphed heavy attack, verify reduced damage
- [ ] Reach level 5, verify boss event appears with fight/skip options
- [ ] Fight a boss, verify phase change at 50% HP
- [ ] Skip boss and verify you can continue traveling

🤖 Generated with [Claude Code](https://claude.com/claude-code)