### PR TITLE
feat: death consequences system

### DIFF
--- a/src/app/api/v1/tap-tap-adventure/combat/action/route.ts
+++ b/src/app/api/v1/tap-tap-adventure/combat/action/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 
 import { processPlayerAction, getCombatRewards } from '@/app/tap-tap-adventure/lib/combatEngine'
+import { applyDeathPenalty } from '@/app/tap-tap-adventure/lib/deathPenalty'
 import { CombatActionRequestSchema } from '@/app/tap-tap-adventure/models/combat'
 
 export async function POST(req: NextRequest) {
@@ -13,6 +14,7 @@ export async function POST(req: NextRequest) {
 
     let rewards = undefined
     let updatedCharacter = character
+    let deathPenalty = undefined
 
     if (updatedCombat.status === 'victory') {
       rewards = getCombatRewards(updatedCombat, character)
@@ -21,12 +23,10 @@ export async function POST(req: NextRequest) {
         gold: character.gold + rewards.gold,
       }
     } else if (updatedCombat.status === 'defeat') {
-      const goldLoss = Math.floor(character.gold * 0.1)
-      updatedCharacter = {
-        ...character,
-        gold: Math.max(0, character.gold - goldLoss),
-      }
-      rewards = { gold: -goldLoss, loot: [] }
+      const penaltyResult = applyDeathPenalty(character)
+      updatedCharacter = penaltyResult.updatedCharacter
+      deathPenalty = penaltyResult.penalty
+      rewards = { gold: -penaltyResult.penalty.goldLost, loot: [] }
     } else if (updatedCombat.status === 'fled') {
       const goldLoss = Math.floor(character.gold * 0.05)
       updatedCharacter = {
@@ -41,6 +41,7 @@ export async function POST(req: NextRequest) {
       rewards,
       updatedCharacter,
       consumedItemId: result.consumedItemId,
+      deathPenalty,
     })
   } catch (err) {
     console.error('Error processing combat action', err)

--- a/src/app/tap-tap-adventure/__tests__/deathConsequences.test.ts
+++ b/src/app/tap-tap-adventure/__tests__/deathConsequences.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from 'vitest'
+
+import { applyDeathPenalty } from '@/app/tap-tap-adventure/lib/deathPenalty'
+import { FantasyCharacter } from '@/app/tap-tap-adventure/models/character'
+
+function makeCharacter(overrides: Partial<FantasyCharacter> = {}): FantasyCharacter {
+  return {
+    id: 'test-char',
+    playerId: 'player-1',
+    name: 'Test Hero',
+    race: 'Human',
+    class: 'Warrior',
+    level: 5,
+    abilities: [],
+    locationId: 'village',
+    gold: 100,
+    reputation: 20,
+    distance: 10,
+    status: 'active',
+    strength: 10,
+    intelligence: 8,
+    luck: 7,
+    inventory: [],
+    deathCount: 0,
+    ...overrides,
+  }
+}
+
+describe('Death Consequences - applyDeathPenalty', () => {
+  it('should deduct 25% of gold', () => {
+    const character = makeCharacter({ gold: 200 })
+    const { updatedCharacter, penalty } = applyDeathPenalty(character)
+
+    expect(penalty.goldLost).toBe(50)
+    expect(updatedCharacter.gold).toBe(150)
+  })
+
+  it('should floor the gold loss calculation', () => {
+    const character = makeCharacter({ gold: 33 })
+    const { updatedCharacter, penalty } = applyDeathPenalty(character)
+
+    expect(penalty.goldLost).toBe(8) // Math.floor(33 * 0.25) = 8
+    expect(updatedCharacter.gold).toBe(25)
+  })
+
+  it('should handle zero gold', () => {
+    const character = makeCharacter({ gold: 0 })
+    const { updatedCharacter, penalty } = applyDeathPenalty(character)
+
+    expect(penalty.goldLost).toBe(0)
+    expect(updatedCharacter.gold).toBe(0)
+  })
+
+  it('should clear all inventory items', () => {
+    const character = makeCharacter({
+      inventory: [
+        { id: 'item-1', name: 'Potion', description: 'Heals', quantity: 3 },
+        { id: 'item-2', name: 'Scroll', description: 'Magic', quantity: 1 },
+      ],
+    })
+    const { updatedCharacter, penalty } = applyDeathPenalty(character)
+
+    expect(updatedCharacter.inventory).toEqual([])
+    expect(penalty.itemsLost).toBe(2)
+  })
+
+  it('should not count deleted items as lost', () => {
+    const character = makeCharacter({
+      inventory: [
+        { id: 'item-1', name: 'Potion', description: 'Heals', quantity: 1 },
+        { id: 'item-2', name: 'Old Scroll', description: 'Faded', quantity: 1, status: 'deleted' },
+      ],
+    })
+    const { penalty } = applyDeathPenalty(character)
+
+    expect(penalty.itemsLost).toBe(1)
+  })
+
+  it('should reduce reputation by 5', () => {
+    const character = makeCharacter({ reputation: 20 })
+    const { updatedCharacter, penalty } = applyDeathPenalty(character)
+
+    expect(penalty.reputationLost).toBe(5)
+    expect(updatedCharacter.reputation).toBe(15)
+  })
+
+  it('should allow reputation to go negative', () => {
+    const character = makeCharacter({ reputation: 2 })
+    const { updatedCharacter } = applyDeathPenalty(character)
+
+    expect(updatedCharacter.reputation).toBe(-3)
+  })
+
+  it('should increment death count', () => {
+    const character = makeCharacter({ deathCount: 0 })
+    const { updatedCharacter, penalty } = applyDeathPenalty(character)
+
+    expect(penalty.newDeathCount).toBe(1)
+    expect(updatedCharacter.deathCount).toBe(1)
+  })
+
+  it('should increment death count from existing value', () => {
+    const character = makeCharacter({ deathCount: 3 })
+    const { updatedCharacter, penalty } = applyDeathPenalty(character)
+
+    expect(penalty.newDeathCount).toBe(4)
+    expect(updatedCharacter.deathCount).toBe(4)
+  })
+
+  it('should handle undefined deathCount (migration case)', () => {
+    const character = makeCharacter()
+    // Simulate a character that hasn't been migrated yet
+    delete (character as Record<string, unknown>).deathCount
+    const { updatedCharacter, penalty } = applyDeathPenalty(character)
+
+    expect(penalty.newDeathCount).toBe(1)
+    expect(updatedCharacter.deathCount).toBe(1)
+  })
+
+  it('should keep character status as active (not permadeath)', () => {
+    const character = makeCharacter({ status: 'active' })
+    const { updatedCharacter } = applyDeathPenalty(character)
+
+    expect(updatedCharacter.status).toBe('active')
+  })
+
+  it('should apply all penalties together correctly', () => {
+    const character = makeCharacter({
+      gold: 400,
+      reputation: 50,
+      deathCount: 2,
+      inventory: [
+        { id: 'item-1', name: 'Gem', description: 'Shiny', quantity: 1 },
+        { id: 'item-2', name: 'Ring', description: 'Gold', quantity: 1 },
+        { id: 'item-3', name: 'Potion', description: 'Red', quantity: 5 },
+      ],
+    })
+    const { updatedCharacter, penalty } = applyDeathPenalty(character)
+
+    expect(updatedCharacter.gold).toBe(300)
+    expect(updatedCharacter.reputation).toBe(45)
+    expect(updatedCharacter.deathCount).toBe(3)
+    expect(updatedCharacter.inventory).toEqual([])
+    expect(penalty.goldLost).toBe(100)
+    expect(penalty.itemsLost).toBe(3)
+    expect(penalty.reputationLost).toBe(5)
+    expect(penalty.newDeathCount).toBe(3)
+  })
+})

--- a/src/app/tap-tap-adventure/components/CharacterCard.tsx
+++ b/src/app/tap-tap-adventure/components/CharacterCard.tsx
@@ -39,6 +39,9 @@ export default function CharacterCard({
         <span>STR: {character.strength}</span>
         <span>INT: {character.intelligence}</span>
         <span>LUCK: {character.luck}</span>
+        {(character.deathCount ?? 0) > 0 && (
+          <span className="text-red-400">Deaths: {character.deathCount}</span>
+        )}
       </div>
       {onDelete && (
         <button

--- a/src/app/tap-tap-adventure/components/CombatUI.tsx
+++ b/src/app/tap-tap-adventure/components/CombatUI.tsx
@@ -236,6 +236,15 @@ interface CombatResultProps {
 
 export function CombatResult({ combatState, onContinue }: CombatResultProps) {
   const { status, enemy } = combatState
+  const { getSelectedCharacter } = useGameStore()
+  const character = getSelectedCharacter()
+
+  // Find the most recent defeat story event to extract penalty info
+  const lastStoryEvents = useGameStore(s => s.gameState.storyEvents)
+  const lastDefeatEvent =
+    status === 'defeat'
+      ? [...lastStoryEvents].reverse().find(e => e.type === 'combat_defeat')
+      : null
 
   const config = {
     victory: {
@@ -244,13 +253,15 @@ export function CombatResult({ combatState, onContinue }: CombatResultProps) {
       borderColor: 'border-yellow-900/50',
       bgColor: 'bg-yellow-900/20',
       message: `You defeated ${enemy.name}!`,
+      buttonText: 'Continue',
     },
     defeat: {
       title: 'Defeated',
       color: 'text-red-400',
       borderColor: 'border-red-900/50',
       bgColor: 'bg-red-900/20',
-      message: `You were defeated by ${enemy.name}...`,
+      message: `You were slain by ${enemy.name}...`,
+      buttonText: 'Rise Again',
     },
     fled: {
       title: 'Escaped',
@@ -258,8 +269,16 @@ export function CombatResult({ combatState, onContinue }: CombatResultProps) {
       borderColor: 'border-slate-600',
       bgColor: 'bg-slate-800',
       message: `You fled from ${enemy.name}.`,
+      buttonText: 'Continue',
     },
-    active: { title: '', color: '', borderColor: '', bgColor: '', message: '' },
+    active: {
+      title: '',
+      color: '',
+      borderColor: '',
+      bgColor: '',
+      message: '',
+      buttonText: 'Continue',
+    },
   }
 
   const c = config[status]
@@ -268,11 +287,26 @@ export function CombatResult({ combatState, onContinue }: CombatResultProps) {
     <div className={`${c.bgColor} border ${c.borderColor} rounded-lg p-6 text-center space-y-4`}>
       <h4 className={`text-xl font-bold ${c.color}`}>{c.title}</h4>
       <p className="text-slate-300">{c.message}</p>
+      {status === 'defeat' && lastDefeatEvent && (
+        <div className="text-sm text-red-300 space-y-1 bg-red-950/30 rounded p-3">
+          <p className="font-semibold">Penalties suffered:</p>
+          {lastDefeatEvent.resourceDelta?.gold && (
+            <p>{Math.abs(lastDefeatEvent.resourceDelta.gold)} gold lost</p>
+          )}
+          {lastDefeatEvent.resourceDelta?.reputation && (
+            <p>{Math.abs(lastDefeatEvent.resourceDelta.reputation)} reputation lost</p>
+          )}
+          <p>Inventory scattered and lost</p>
+          {character && (character.deathCount ?? 0) > 0 && (
+            <p className="text-xs text-red-400 mt-2">Total deaths: {character.deathCount}</p>
+          )}
+        </div>
+      )}
       <Button
         className="bg-[#2a2b3f] border border-[#3a3c56] hover:bg-[#3a3c56] text-white px-6 py-2 rounded-md"
         onClick={onContinue}
       >
-        Continue
+        {c.buttonText}
       </Button>
     </div>
   )

--- a/src/app/tap-tap-adventure/config/gameDefaults.ts
+++ b/src/app/tap-tap-adventure/config/gameDefaults.ts
@@ -37,4 +37,5 @@ export const DEFAULT_CHARACTER = {
   strength: DEFAULT_STAT_MIN,
   intelligence: DEFAULT_STAT_MIN,
   luck: DEFAULT_STAT_MIN,
+  deathCount: 0,
 }

--- a/src/app/tap-tap-adventure/hooks/useCombatActionMutation.ts
+++ b/src/app/tap-tap-adventure/hooks/useCombatActionMutation.ts
@@ -1,6 +1,7 @@
 'use client'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 
+import { DeathPenalty } from '@/app/tap-tap-adventure/lib/deathPenalty'
 import { inferItemTypeAndEffects } from '@/app/tap-tap-adventure/lib/itemPostProcessor'
 import { CombatAction, CombatState } from '@/app/tap-tap-adventure/models/combat'
 import { FantasyCharacter, Item } from '@/app/tap-tap-adventure/models/types'
@@ -15,6 +16,7 @@ interface CombatActionResponse {
   }
   updatedCharacter: FantasyCharacter
   consumedItemId?: string
+  deathPenalty?: DeathPenalty
 }
 
 export function useCombatActionMutation() {
@@ -100,14 +102,30 @@ export function useCombatActionMutation() {
             },
           })
         } else if (data.combatState.status === 'defeat') {
+          const penalty = data.deathPenalty
+          const penaltyParts: string[] = []
+          if (penalty) {
+            if (penalty.goldLost > 0) penaltyParts.push(`${penalty.goldLost} gold`)
+            if (penalty.itemsLost > 0)
+              penaltyParts.push(
+                `${penalty.itemsLost} item${penalty.itemsLost !== 1 ? 's' : ''} from your inventory`
+              )
+            penaltyParts.push('some of your reputation')
+          }
+          const lossDescription =
+            penaltyParts.length > 0 ? ` You lost ${penaltyParts.join(', ')}.` : ''
+
           addStoryEvent({
             id: `combat-defeat-${Date.now()}`,
             type: 'combat_defeat',
             characterId: character.id,
             locationId: character.locationId,
             timestamp: new Date().toISOString(),
-            outcomeDescription: `You were defeated by ${enemy.name}. You lost some gold fleeing the battle.`,
-            resourceDelta: { gold: data.rewards?.gold },
+            outcomeDescription: `You were defeated by ${enemy.name}.${lossDescription} (Death #${penalty?.newDeathCount ?? '?'})`,
+            resourceDelta: {
+              gold: data.rewards?.gold,
+              reputation: penalty ? -penalty.reputationLost : undefined,
+            },
           })
         } else if (data.combatState.status === 'fled') {
           addStoryEvent({

--- a/src/app/tap-tap-adventure/hooks/useGameStore.ts
+++ b/src/app/tap-tap-adventure/hooks/useGameStore.ts
@@ -33,6 +33,7 @@ const defaultCharacter: FantasyCharacter = {
   intelligence: 0,
   luck: 0,
   inventory: [],
+  deathCount: 0,
 }
 
 export interface GameStore {
@@ -267,7 +268,7 @@ export const useGameStore = create<GameStore>()(
     }),
     {
       name: 'fantasy-tycoon-storage', // localStorage key (kept for backward compat)
-      version: 3,
+      version: 4,
       migrate: (persistedState: unknown) => {
         const state = persistedState as GameStore
         if (state?.gameState && !('combatState' in state.gameState)) {
@@ -275,6 +276,14 @@ export const useGameStore = create<GameStore>()(
         }
         if (state?.gameState && !('shopState' in state.gameState)) {
           (state.gameState as GameState).shopState = null
+        }
+        // v4: Add deathCount to all characters
+        if (state?.gameState?.characters) {
+          for (const char of state.gameState.characters) {
+            if (char.deathCount === undefined) {
+              (char as FantasyCharacter).deathCount = 0
+            }
+          }
         }
         return state
       },

--- a/src/app/tap-tap-adventure/lib/deathPenalty.ts
+++ b/src/app/tap-tap-adventure/lib/deathPenalty.ts
@@ -1,0 +1,42 @@
+import { FantasyCharacter } from '@/app/tap-tap-adventure/models/character'
+
+export interface DeathPenalty {
+  goldLost: number
+  itemsLost: number
+  reputationLost: number
+  newDeathCount: number
+}
+
+/**
+ * Calculate and apply death penalties when a character is defeated in combat.
+ * - 25% gold loss
+ * - All non-equipped inventory items cleared
+ * - 5 reputation lost
+ * - Death count incremented
+ */
+export function applyDeathPenalty(character: FantasyCharacter): {
+  updatedCharacter: FantasyCharacter
+  penalty: DeathPenalty
+} {
+  const goldLost = Math.floor(character.gold * 0.25)
+  const itemsLost = character.inventory.filter(i => i.status !== 'deleted').length
+  const newDeathCount = (character.deathCount ?? 0) + 1
+
+  const updatedCharacter: FantasyCharacter = {
+    ...character,
+    gold: Math.max(0, character.gold - goldLost),
+    inventory: [], // Clear all inventory (equipped items would be in equipment slots if that system exists)
+    reputation: character.reputation - 5,
+    deathCount: newDeathCount,
+  }
+
+  return {
+    updatedCharacter,
+    penalty: {
+      goldLost,
+      itemsLost,
+      reputationLost: 5,
+      newDeathCount,
+    },
+  }
+}

--- a/src/app/tap-tap-adventure/models/character.ts
+++ b/src/app/tap-tap-adventure/models/character.ts
@@ -30,6 +30,7 @@ export const FantasyCharacterSchema = z.object({
   intelligence: z.number(),
   luck: z.number(),
   inventory: z.array(ItemSchema),
+  deathCount: z.number().default(0),
 })
 export type FantasyCharacter = z.infer<typeof FantasyCharacterSchema>
 


### PR DESCRIPTION
## Summary
- **Death penalty system**: Combat defeat now applies harsh (but non-permadeath) consequences -- 25% gold loss, all inventory items cleared, -5 reputation, and a death counter increment
- **Enhanced defeat UI**: CombatResult screen shows detailed penalty breakdown (gold lost, reputation lost, items scattered) and uses "Rise Again" button text
- **Character tracking**: CharacterCard displays death count in red when > 0; store migration v4 adds `deathCount` field to existing characters
- **12 unit tests** covering gold calculation, inventory clearing, reputation penalty, death count increment, migration edge cases, and combined penalties

## Changed files
- `models/character.ts` -- added `deathCount` to schema
- `config/gameDefaults.ts` -- added `deathCount: 0` default
- `lib/deathPenalty.ts` -- new utility with `applyDeathPenalty()` and `DeathPenalty` type
- `api/v1/tap-tap-adventure/combat/action/route.ts` -- defeat handler uses `applyDeathPenalty`, returns `deathPenalty` object
- `hooks/useCombatActionMutation.ts` -- rich defeat story event with penalty details
- `hooks/useGameStore.ts` -- store v4 migration, `deathCount` in default character
- `components/CharacterCard.tsx` -- shows death count
- `components/CombatUI.tsx` -- enhanced CombatResult with penalty breakdown and "Rise Again" button

## Test plan
- [x] `npx vitest run` -- all 153 tests pass (12 new death consequence tests)
- [ ] Manual: trigger combat defeat and verify gold/inventory/reputation penalties apply
- [ ] Manual: verify CharacterCard shows death count after defeat
- [ ] Manual: verify CombatResult shows penalty breakdown and "Rise Again" button

Generated with [Claude Code](https://claude.com/claude-code)