### PR TITLE
feat: class-specific combat abilities

### DIFF
--- a/src/app/tap-tap-adventure/__tests__/classAbilities.test.ts
+++ b/src/app/tap-tap-adventure/__tests__/classAbilities.test.ts
@@ -1,0 +1,342 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { processPlayerAction } from '@/app/tap-tap-adventure/lib/combatEngine'
+import { FantasyCharacter } from '@/app/tap-tap-adventure/models/character'
+import { CombatState } from '@/app/tap-tap-adventure/models/combat'
+
+function makeChar(classId: string): FantasyCharacter {
+  return {
+    id: '1',
+    playerId: 'p1',
+    name: 'Test',
+    race: 'Human',
+    class: classId,
+    level: 3,
+    abilities: [],
+    locationId: 'loc1',
+    gold: 50,
+    reputation: 10,
+    distance: 5,
+    status: 'active',
+    strength: 8,
+    intelligence: 5,
+    luck: 6,
+    inventory: [],
+  }
+}
+
+function makeCombat(overrides: Partial<CombatState> = {}): CombatState {
+  return {
+    id: 'combat-1',
+    eventId: 'event-1',
+    enemy: {
+      id: 'enemy-1',
+      name: 'Goblin',
+      description: 'A nasty goblin',
+      hp: 200,
+      maxHp: 200,
+      attack: 8,
+      defense: 10,
+      level: 2,
+      goldReward: 15,
+    },
+    playerState: {
+      hp: 100,
+      maxHp: 100,
+      attack: 20,
+      defense: 10,
+      isDefending: false,
+      activeBuffs: [],
+      comboCount: 0,
+      abilityCooldown: 0,
+      enemyStunned: false,
+    },
+    turnNumber: 0,
+    combatLog: [],
+    status: 'active',
+    scenario: 'A goblin appears!',
+    ...overrides,
+  }
+}
+
+// Seed Math.random for deterministic tests
+function mockRandomReturning(value: number) {
+  return vi.spyOn(Math, 'random').mockReturnValue(value)
+}
+
+describe('Class Abilities', () => {
+  describe('Warrior - Shield Bash', () => {
+    it('deals damage and stuns the enemy (enemy skips next attack)', () => {
+      const randomSpy = mockRandomReturning(0.5) // variance = 0 at 0.5
+      const combat = makeCombat()
+      const character = makeChar('Warrior')
+
+      const result = processPlayerAction(combat, { action: 'class_ability' }, character)
+      const { combatState } = result
+
+      // Should have dealt damage (0.8x multiplier)
+      expect(combatState.enemy.hp).toBeLessThan(200)
+
+      // The log should mention stunning
+      const abilityLog = combatState.combatLog.find(
+        l => l.actor === 'player' && l.action === 'class_ability'
+      )
+      expect(abilityLog).toBeDefined()
+      expect(abilityLog!.description).toContain('stunning')
+      expect(abilityLog!.damage).toBeDefined()
+      expect(abilityLog!.damage!).toBeGreaterThan(0)
+
+      // Enemy should have been stunned (skipped attack)
+      const enemyLog = combatState.combatLog.find(l => l.actor === 'enemy')
+      expect(enemyLog).toBeDefined()
+      expect(enemyLog!.action).toBe('stunned')
+      expect(enemyLog!.description).toContain('stunned')
+
+      // Player should not have taken damage from enemy
+      // (stunned enemies don't attack)
+      // Player HP should be 100 (unchanged since enemy was stunned)
+      expect(combatState.playerState.hp).toBe(100)
+
+      randomSpy.mockRestore()
+    })
+  })
+
+  describe('Mage - Arcane Blast', () => {
+    it('deals 2x damage and takes 20% max HP recoil', () => {
+      const randomSpy = mockRandomReturning(0.5)
+      const combat = makeCombat()
+      const character = makeChar('Mage')
+
+      const result = processPlayerAction(combat, { action: 'class_ability' }, character)
+      const { combatState } = result
+
+      // Should have dealt 2x damage
+      const abilityLog = combatState.combatLog.find(
+        l => l.actor === 'player' && l.action === 'class_ability'
+      )
+      expect(abilityLog).toBeDefined()
+      expect(abilityLog!.description).toContain('Arcane Blast')
+
+      // Recoil: 20% of 100 maxHp = 20
+      // Player HP should be reduced by recoil (and possibly enemy damage)
+      // With stunned=false, enemy will attack too, but we check recoil happened
+      expect(abilityLog!.description).toContain('recoil')
+
+      randomSpy.mockRestore()
+    })
+
+    it('recoil is 20% of max HP', () => {
+      const randomSpy = mockRandomReturning(0.5)
+      const combat = makeCombat({
+        playerState: {
+          hp: 100,
+          maxHp: 100,
+          attack: 20,
+          defense: 10,
+          isDefending: false,
+          activeBuffs: [],
+          comboCount: 0,
+          abilityCooldown: 0,
+          enemyStunned: true, // stun enemy so we can isolate recoil
+        },
+      })
+      const character = makeChar('Mage')
+
+      const result = processPlayerAction(combat, { action: 'class_ability' }, character)
+      const { combatState } = result
+
+      // Recoil = 20% of 100 = 20. Player starts at 100 - 20 = 80
+      // Min 1 HP from recoil logic
+      expect(combatState.playerState.hp).toBe(80)
+
+      randomSpy.mockRestore()
+    })
+  })
+
+  describe('Rogue - Backstab', () => {
+    it('deals 3x damage and resets combo when combo >= 2', () => {
+      const randomSpy = mockRandomReturning(0.5)
+      const combat = makeCombat({
+        playerState: {
+          hp: 100,
+          maxHp: 100,
+          attack: 20,
+          defense: 10,
+          isDefending: false,
+          activeBuffs: [],
+          comboCount: 3,
+          abilityCooldown: 0,
+          enemyStunned: true, // stun enemy to isolate backstab
+        },
+      })
+      const character = makeChar('Rogue')
+
+      const result = processPlayerAction(combat, { action: 'class_ability' }, character)
+      const { combatState } = result
+
+      // Should deal 3x damage
+      const abilityLog = combatState.combatLog.find(
+        l => l.actor === 'player' && l.action === 'class_ability'
+      )
+      expect(abilityLog).toBeDefined()
+      expect(abilityLog!.description).toContain('devastating Backstab')
+
+      // Combo should be reset to 0
+      expect(combatState.playerState.comboCount).toBe(0)
+
+      randomSpy.mockRestore()
+    })
+
+    it('deals normal damage when combo < 2', () => {
+      const randomSpy = mockRandomReturning(0.5)
+      const combat = makeCombat({
+        playerState: {
+          hp: 100,
+          maxHp: 100,
+          attack: 20,
+          defense: 10,
+          isDefending: false,
+          activeBuffs: [],
+          comboCount: 1,
+          abilityCooldown: 0,
+          enemyStunned: true,
+        },
+      })
+      const character = makeChar('Rogue')
+
+      const result = processPlayerAction(combat, { action: 'class_ability' }, character)
+      const { combatState } = result
+
+      const abilityLog = combatState.combatLog.find(
+        l => l.actor === 'player' && l.action === 'class_ability'
+      )
+      expect(abilityLog).toBeDefined()
+      expect(abilityLog!.description).toContain('lacks setup')
+
+      // Combo should increment (not reset)
+      expect(combatState.playerState.comboCount).toBe(2)
+
+      randomSpy.mockRestore()
+    })
+  })
+
+  describe('Ranger - Precise Shot', () => {
+    it('ignores enemy defense entirely', () => {
+      const randomSpy = mockRandomReturning(0.5)
+      // High defense enemy
+      const combat = makeCombat({
+        enemy: {
+          id: 'enemy-1',
+          name: 'Tank',
+          description: 'Very tanky',
+          hp: 200,
+          maxHp: 200,
+          attack: 8,
+          defense: 100, // very high defense
+          level: 2,
+          goldReward: 15,
+        },
+        playerState: {
+          hp: 100,
+          maxHp: 100,
+          attack: 20,
+          defense: 10,
+          isDefending: false,
+          activeBuffs: [],
+          comboCount: 0,
+          abilityCooldown: 0,
+          enemyStunned: true,
+        },
+      })
+      const character = makeChar('Ranger')
+
+      const result = processPlayerAction(combat, { action: 'class_ability' }, character)
+      const { combatState } = result
+
+      const abilityLog = combatState.combatLog.find(
+        l => l.actor === 'player' && l.action === 'class_ability'
+      )
+      expect(abilityLog).toBeDefined()
+      expect(abilityLog!.description).toContain('Precise Shot')
+      // Damage should be exactly equal to attack (20) since defense is ignored
+      expect(abilityLog!.damage).toBe(20)
+
+      randomSpy.mockRestore()
+    })
+  })
+
+  describe('Cooldown mechanics', () => {
+    it('ability is unavailable when on cooldown', () => {
+      const randomSpy = mockRandomReturning(0.5)
+      const combat = makeCombat({
+        playerState: {
+          hp: 100,
+          maxHp: 100,
+          attack: 20,
+          defense: 10,
+          isDefending: false,
+          activeBuffs: [],
+          comboCount: 0,
+          abilityCooldown: 2,
+          enemyStunned: true,
+        },
+      })
+      const character = makeChar('Warrior')
+
+      const result = processPlayerAction(combat, { action: 'class_ability' }, character)
+      const { combatState } = result
+
+      const abilityLog = combatState.combatLog.find(
+        l => l.actor === 'player' && l.action === 'class_ability'
+      )
+      expect(abilityLog).toBeDefined()
+      expect(abilityLog!.description).toContain('not ready')
+
+      // Enemy HP should be unchanged (no damage dealt)
+      expect(combatState.enemy.hp).toBe(200)
+
+      randomSpy.mockRestore()
+    })
+
+    it('cooldown ticks down each turn', () => {
+      const randomSpy = mockRandomReturning(0.5)
+      const combat = makeCombat({
+        playerState: {
+          hp: 100,
+          maxHp: 100,
+          attack: 20,
+          defense: 10,
+          isDefending: false,
+          activeBuffs: [],
+          comboCount: 0,
+          abilityCooldown: 0,
+          enemyStunned: false,
+        },
+      })
+      const character = makeChar('Warrior')
+
+      // Use the ability to set cooldown
+      const result1 = processPlayerAction(combat, { action: 'class_ability' }, character)
+      // Warrior cooldown is 3, then ticked once at end of turn = 2
+      expect(result1.combatState.playerState.abilityCooldown).toBe(2)
+
+      // Next turn: attack to tick cooldown
+      const result2 = processPlayerAction(
+        result1.combatState,
+        { action: 'attack' },
+        character
+      )
+      expect(result2.combatState.playerState.abilityCooldown).toBe(1)
+
+      // Next turn: attack again
+      const result3 = processPlayerAction(
+        result2.combatState,
+        { action: 'attack' },
+        character
+      )
+      expect(result3.combatState.playerState.abilityCooldown).toBe(0)
+
+      randomSpy.mockRestore()
+    })
+  })
+})

--- a/src/app/tap-tap-adventure/components/CombatUI.tsx
+++ b/src/app/tap-tap-adventure/components/CombatUI.tsx
@@ -4,10 +4,11 @@ import { LoaderCircle } from 'lucide-react'
 import { useCallback, useRef, useEffect, useState } from 'react'
 
 import { Button } from '@/app/tap-tap-adventure/components/ui/button'
+import { CLASS_ABILITIES } from '@/app/tap-tap-adventure/config/characterOptions'
 import { useCombatActionMutation } from '@/app/tap-tap-adventure/hooks/useCombatActionMutation'
 import { useGameStore } from '@/app/tap-tap-adventure/hooks/useGameStore'
 import { isUsableInCombat } from '@/app/tap-tap-adventure/lib/combatItemEffects'
-import { CombatState } from '@/app/tap-tap-adventure/models/combat'
+import { CombatAction, CombatState } from '@/app/tap-tap-adventure/models/combat'
 import { Item } from '@/app/tap-tap-adventure/models/types'
 
 function HpBar({ current, max, label, color }: { current: number; max: number; label: string; color: string }) {
@@ -47,8 +48,12 @@ export function CombatUI({ combatState }: CombatUIProps) {
     (i: Item) => i.status !== 'deleted' && isUsableInCombat(i)
   )
 
+  const classId = character?.class?.toLowerCase() ?? ''
+  const classAbility = CLASS_ABILITIES[classId]
+  const abilityCooldown = playerState.abilityCooldown ?? 0
+
   const handleAction = useCallback(
-    (action: 'attack' | 'defend' | 'flee', itemId?: string) => {
+    (action: CombatAction, itemId?: string) => {
       setShowItemMenu(false)
       combatAction({ action, itemId })
     },
@@ -165,6 +170,27 @@ export function CombatUI({ combatState }: CombatUIProps) {
 
       {/* Actions */}
       <div className="space-y-2">
+        {/* Class Ability */}
+        {classAbility && (
+          <Button
+            className={`w-full text-sm py-2 rounded-md transition-colors border ${
+              abilityCooldown > 0
+                ? 'bg-slate-800 border-slate-600 text-slate-500 cursor-not-allowed'
+                : 'bg-purple-900/50 border-purple-700 hover:bg-purple-800 text-white'
+            }`}
+            onClick={() => handleAction('class_ability')}
+            disabled={isPending || abilityCooldown > 0}
+            title={classAbility.description}
+          >
+            {isPending ? (
+              <LoaderCircle className="animate-spin h-4 w-4" />
+            ) : abilityCooldown > 0 ? (
+              `${classAbility.name} (${abilityCooldown} turns)`
+            ) : (
+              `${classAbility.name} - Ready!`
+            )}
+          </Button>
+        )}
         <div className="grid grid-cols-2 gap-2">
           <Button
             className="bg-red-900/50 border border-red-800 hover:bg-red-800 text-white text-sm py-2 rounded-md transition-colors"

--- a/src/app/tap-tap-adventure/config/characterOptions.ts
+++ b/src/app/tap-tap-adventure/config/characterOptions.ts
@@ -74,6 +74,36 @@ export const CLASSES: ClassOption[] = [
   },
 ]
 
+
+export interface ClassAbility {
+  name: string
+  description: string
+  cooldown: number
+}
+
+export const CLASS_ABILITIES: Record<string, ClassAbility> = {
+  warrior: {
+    name: 'Shield Bash',
+    description: 'Deals 0.8x damage and stuns the enemy, skipping their next attack.',
+    cooldown: 3,
+  },
+  mage: {
+    name: 'Arcane Blast',
+    description: 'Deals 2x damage but takes 20% of max HP as recoil.',
+    cooldown: 3,
+  },
+  rogue: {
+    name: 'Backstab',
+    description: 'If combo >= 2, deals 3x damage and resets combo. Otherwise deals normal damage.',
+    cooldown: 2,
+  },
+  ranger: {
+    name: 'Precise Shot',
+    description: 'Ignores enemy defense entirely, dealing full base attack damage.',
+    cooldown: 3,
+  },
+}
+
 export interface StartingStats {
   strength: number
   intelligence: number

--- a/src/app/tap-tap-adventure/lib/combatEngine.ts
+++ b/src/app/tap-tap-adventure/lib/combatEngine.ts
@@ -1,3 +1,4 @@
+import { CLASS_ABILITIES } from '@/app/tap-tap-adventure/config/characterOptions'
 import { FantasyCharacter } from '@/app/tap-tap-adventure/models/character'
 import {
   CombatActionRequest,
@@ -21,6 +22,8 @@ export function initializePlayerCombatState(character: FantasyCharacter): Combat
     isDefending: false,
     activeBuffs: [],
     comboCount: 0,
+    abilityCooldown: 0,
+    enemyStunned: false,
   }
 }
 
@@ -101,7 +104,6 @@ function generateEnemyTelegraph(enemy: CombatEnemy, turnNumber: number, isBoss: 
     }
   }
 
-  // Bosses and stronger enemies telegraph heavy attacks more often
   const heavyChance = isBoss ? 0.35 : 0.2
   if (Math.random() < heavyChance) {
     return {
@@ -110,7 +112,6 @@ function generateEnemyTelegraph(enemy: CombatEnemy, turnNumber: number, isBoss: 
     }
   }
 
-  // Rare enemy defend (boss only)
   if (isBoss && Math.random() < 0.15) {
     return {
       action: 'defend',
@@ -251,7 +252,6 @@ export function processPlayerAction(
   // Process player action
   switch (action.action) {
     case 'attack': {
-      // Apply enemy defense boost if they telegraphed defend
       const effectiveEnemy = enemyDefending
         ? { ...enemy, defense: enemy.defense * 2 }
         : enemy
@@ -270,7 +270,7 @@ export function processPlayerAction(
     }
     case 'defend': {
       playerState.isDefending = true
-      playerState.comboCount = 0 // defending breaks combo
+      playerState.comboCount = 0
       newLogs.push({
         turn: turnNumber,
         actor: 'player',
@@ -280,7 +280,7 @@ export function processPlayerAction(
       break
     }
     case 'use_item': {
-      playerState.comboCount = 0 // using item breaks combo
+      playerState.comboCount = 0
       if (!action.itemId) {
         newLogs.push({
           turn: turnNumber,
@@ -344,6 +344,110 @@ export function processPlayerAction(
       })
       break
     }
+    case 'class_ability': {
+      const classId = character.class.toLowerCase()
+      const ability = CLASS_ABILITIES[classId]
+      if (!ability) {
+        newLogs.push({
+          turn: turnNumber,
+          actor: 'player',
+          action: 'class_ability',
+          description: 'You have no class ability available.',
+        })
+        break
+      }
+      if ((playerState.abilityCooldown ?? 0) > 0) {
+        newLogs.push({
+          turn: turnNumber,
+          actor: 'player',
+          action: 'class_ability',
+          description: `${ability.name} is not ready yet! (${playerState.abilityCooldown} turns remaining)`,
+        })
+        break
+      }
+
+      switch (classId) {
+        case 'warrior': {
+          const baseDmg = calculatePlayerDamage(playerState, enemy)
+          const damage = Math.max(1, Math.round(baseDmg * 0.8))
+          enemy.hp = Math.max(0, enemy.hp - damage)
+          playerState.enemyStunned = true
+          playerState.comboCount = (playerState.comboCount ?? 0) + 1
+          newLogs.push({
+            turn: turnNumber,
+            actor: 'player',
+            action: 'class_ability',
+            damage,
+            description: `You bash ${enemy.name} with your shield for ${damage} damage, stunning them!`,
+          })
+          break
+        }
+        case 'mage': {
+          const baseDmg = calculatePlayerDamage(playerState, enemy)
+          const damage = Math.max(1, Math.round(baseDmg * 2))
+          const recoil = Math.max(1, Math.round(playerState.maxHp * 0.2))
+          enemy.hp = Math.max(0, enemy.hp - damage)
+          playerState.hp = Math.max(1, playerState.hp - recoil)
+          playerState.comboCount = 0
+          newLogs.push({
+            turn: turnNumber,
+            actor: 'player',
+            action: 'class_ability',
+            damage,
+            description: `You unleash an Arcane Blast for ${damage} damage! The magical recoil deals ${recoil} damage to you.`,
+          })
+          break
+        }
+        case 'rogue': {
+          const combo = playerState.comboCount ?? 0
+          if (combo >= 2) {
+            const baseDmg = calculatePlayerDamage(playerState, enemy)
+            const damage = Math.max(1, Math.round(baseDmg * 3))
+            enemy.hp = Math.max(0, enemy.hp - damage)
+            playerState.comboCount = 0
+            newLogs.push({
+              turn: turnNumber,
+              actor: 'player',
+              action: 'class_ability',
+              damage,
+              description: `You exploit your ${combo}x combo with a devastating Backstab for ${damage} damage!`,
+            })
+          } else {
+            const damage = calculatePlayerDamage(playerState, enemy)
+            enemy.hp = Math.max(0, enemy.hp - damage)
+            playerState.comboCount = (playerState.comboCount ?? 0) + 1
+            newLogs.push({
+              turn: turnNumber,
+              actor: 'player',
+              action: 'class_ability',
+              damage,
+              description: `Your Backstab lacks setup and deals ${damage} normal damage.`,
+            })
+          }
+          break
+        }
+        case 'ranger': {
+          const buffedAttack =
+            playerState.attack +
+            (playerState.activeBuffs ?? [])
+              .filter(b => b.stat === 'attack')
+              .reduce((sum, b) => sum + b.value, 0)
+          const damage = Math.max(1, Math.round(buffedAttack))
+          enemy.hp = Math.max(0, enemy.hp - damage)
+          playerState.comboCount = (playerState.comboCount ?? 0) + 1
+          newLogs.push({
+            turn: turnNumber,
+            actor: 'player',
+            action: 'class_ability',
+            damage,
+            description: `Your Precise Shot pierces through all defenses for ${damage} damage!`,
+          })
+          break
+        }
+      }
+      playerState.abilityCooldown = ability.cooldown
+      break
+    }
   }
 
   // Check boss phase change
@@ -381,13 +485,21 @@ export function processPlayerAction(
   }
 
   // Execute enemy's telegraphed action (or normal attack if no telegraph)
-  if (enemyTelegraph) {
+  // If enemy is stunned, they skip their action
+  if (playerState.enemyStunned) {
+    playerState.enemyStunned = false
+    newLogs.push({
+      turn: turnNumber,
+      actor: 'enemy',
+      action: 'stunned',
+      description: `${enemy.name} is stunned and cannot act!`,
+    })
+  } else if (enemyTelegraph) {
     const result = executeEnemyTelegraph(enemyTelegraph, enemy, playerState, turnNumber)
     playerState = result.playerState
     newLogs.push(...result.logs)
     enemyDefending = result.enemyDefenseBoost
   } else {
-    // First turn or no telegraph — normal attack
     const enemyDmg = calculateEnemyDamage(enemy, playerState)
     playerState.hp = Math.max(0, playerState.hp - enemyDmg)
     newLogs.push({
@@ -412,6 +524,11 @@ export function processPlayerAction(
 
   // Tick buffs
   playerState = tickBuffs(playerState)
+
+  // Tick ability cooldown
+  if ((playerState.abilityCooldown ?? 0) > 0) {
+    playerState = { ...playerState, abilityCooldown: playerState.abilityCooldown! - 1 }
+  }
 
   // Generate telegraph for enemy's NEXT action
   const nextTelegraph = status === 'active'
@@ -445,7 +562,6 @@ export function getCombatRewards(
   const { enemy } = combatState
   const gold = enemy.goldReward
 
-  // Select loot based on luck. Boss loot always drops.
   const loot: Item[] = []
   if (enemy.lootTable) {
     for (const item of enemy.lootTable) {

--- a/src/app/tap-tap-adventure/models/combat.ts
+++ b/src/app/tap-tap-adventure/models/combat.ts
@@ -39,10 +39,12 @@ export const CombatPlayerStateSchema = z.object({
   isDefending: z.boolean(),
   activeBuffs: z.array(CombatBuffSchema).optional(),
   comboCount: z.number().default(0),
+  abilityCooldown: z.number().default(0),
+  enemyStunned: z.boolean().default(false),
 })
 export type CombatPlayerState = z.infer<typeof CombatPlayerStateSchema>
 
-export const CombatActionSchema = z.enum(['attack', 'defend', 'use_item', 'flee'])
+export const CombatActionSchema = z.enum(['attack', 'defend', 'use_item', 'flee', 'class_ability'])
 export type CombatAction = z.infer<typeof CombatActionSchema>
 
 export const CombatActionRequestSchema = z.object({


### PR DESCRIPTION
## Summary
- Adds unique combat abilities for each class: Warrior (Shield Bash - stun), Mage (Arcane Blast - high damage + recoil), Rogue (Backstab - combo-dependent burst), Ranger (Precise Shot - ignores defense)
- Introduces `class_ability` action to the combat system with cooldown tracking and stun mechanics
- Adds a prominent ability button to the combat UI that shows readiness and cooldown state
- Includes 8 tests covering all four abilities, cooldown mechanics, and edge cases

## Test plan
- [x] All 8 class ability tests pass (Warrior stun, Mage recoil, Rogue combo/no-combo, Ranger defense bypass, cooldown unavailable, cooldown ticking)
- [x] All 12 existing combat engine tests pass (no regressions)
- [x] All 16 combat tactics tests pass
- [x] All 7 character options tests pass
- [ ] Manual: verify ability button appears in combat UI with correct class name
- [ ] Manual: verify cooldown countdown displays correctly after using ability
- [ ] Manual: verify stunned enemy skips their turn

🤖 Generated with [Claude Code](https://claude.com/claude-code)