### PR TITLE
fix: reset game state when switching characters

### DIFF
--- a/src/app/tap-tap-adventure/hooks/useGameStore.ts
+++ b/src/app/tap-tap-adventure/hooks/useGameStore.ts
@@ -121,13 +121,17 @@ export const useGameStore = create<GameStore>()(
               (char: FantasyCharacter) => char.id === id
             )
             if (!matchingCharacter) return {}
-            const updatedState = {
+            return {
               gameState: {
                 ...state.gameState,
                 selectedCharacterId: id,
+                storyEvents: [],
+                decisionPoint: null,
+                combatState: null,
+                shopState: null,
+                genericMessage: null,
               },
             }
-            return updatedState
           })
         )
       },


### PR DESCRIPTION
## Summary
When creating a new character or switching characters, the previous character's story events, decision points, combat state, shop state, and generic messages carried over. Now `selectCharacter` clears all session state.

One file, one function changed.

## Test plan
- [x] 177 tests pass
- [ ] Create character A, travel, then create character B — verify B starts fresh
- [ ] Switch back to A — verify A's state is also clean (story events cleared)

🤖 Generated with [Claude Code](https://claude.com/claude-code)