### PR TITLE
adjust: 95/5 event rate

### DIFF
--- a/src/app/tap-tap-adventure/components/GameUI.tsx
+++ b/src/app/tap-tap-adventure/components/GameUI.tsx
@@ -76,7 +76,7 @@ export default function GameUI() {
   }
 
   const handleMoveForward = () => {
-    const shouldDoNothing = flipCoin(0.75, 0.25)
+    const shouldDoNothing = flipCoin(0.05, 0.95)
     if (shouldDoNothing) {
       const genericMessage = getGenericTravelMessage()
       setGenericMessage(genericMessage)


### PR DESCRIPTION
## Summary
Changed event rate from 75/25 to 95/5. Most taps are travel, encounters are rare.

`flipCoin(0.75, 0.25)` → `flipCoin(0.05, 0.95)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)