### PR TITLE
feat: persistent HP, day counter, rebalanced step economy

### DIFF
--- a/src/app/api/v1/tap-tap-adventure/move-forward/services/moveForwardService.ts
+++ b/src/app/api/v1/tap-tap-adventure/move-forward/services/moveForwardService.ts
@@ -1,7 +1,12 @@
 import { MoveForwardResponse } from '@/app/api/v1/tap-tap-adventure/move-forward/schemas'
 import { buildStoryContext } from '@/app/tap-tap-adventure/lib/contextBuilder'
 import { generateLLMEvents } from '@/app/tap-tap-adventure/lib/llmEventGenerator'
-import { calculateLevel } from '@/app/tap-tap-adventure/lib/leveling'
+import {
+  crossedMilestone,
+  BOSS_MILESTONE_INTERVAL,
+  SHOP_MILESTONE_INTERVAL,
+  calculateDay,
+} from '@/app/tap-tap-adventure/lib/leveling'
 import { FantasyCharacter } from '@/app/tap-tap-adventure/models/character'
 import { FantasyDecisionPoint, FantasyStoryEvent } from '@/app/tap-tap-adventure/models/story'
 
@@ -12,12 +17,11 @@ export async function moveForwardService(
   storyEvents: FantasyStoryEvent[] = []
 ): Promise<MoveForwardResponse> {
   const newDistance = character.distance + BASE_DISTANCE
-  const oldLevel = calculateLevel(character.distance)
-  const newLevel = calculateLevel(newDistance)
   const updatedCharacter = { ...character, distance: newDistance }
+  const day = calculateDay(newDistance)
 
-  // Trigger boss event every 5 levels
-  if (newLevel > oldLevel && newLevel % 5 === 0) {
+  // Trigger boss event every BOSS_MILESTONE_INTERVAL steps (500)
+  if (crossedMilestone(character.distance, newDistance, BOSS_MILESTONE_INTERVAL)) {
     const bossEventId = `boss-event-${Date.now()}`
     return {
       character: updatedCharacter,
@@ -31,7 +35,7 @@ export async function moveForwardService(
       decisionPoint: {
         id: `decision-${bossEventId}`,
         eventId: bossEventId,
-        prompt: `You sense a powerful presence ahead. A formidable guardian blocks the path forward. You are now level ${newLevel} — do you feel ready to face this challenge?`,
+        prompt: `You sense a powerful presence ahead. A formidable guardian blocks the path forward. You have traveled ${newDistance} steps on day ${day} — do you feel ready to face this challenge?`,
         options: [
           {
             id: `boss-fight-${bossEventId}`,
@@ -61,8 +65,8 @@ export async function moveForwardService(
     }
   }
 
-  // Trigger shop event on level up
-  if (newLevel > oldLevel) {
+  // Trigger shop event every SHOP_MILESTONE_INTERVAL steps (100)
+  if (crossedMilestone(character.distance, newDistance, SHOP_MILESTONE_INTERVAL)) {
     return {
       character: updatedCharacter,
       event: {
@@ -77,8 +81,8 @@ export async function moveForwardService(
     }
   }
 
-  // Periodic merchant: ~10% chance every step after distance 15, but not within 10 steps of last shop
-  const merchantChance = newDistance > 15 ? 0.10 : 0
+  // Periodic merchant: ~3% chance every step after distance 50
+  const merchantChance = newDistance > 50 ? 0.03 : 0
   if (merchantChance > 0 && Math.random() < merchantChance) {
     return {
       character: updatedCharacter,

--- a/src/app/tap-tap-adventure/__tests__/itemEffects.test.ts
+++ b/src/app/tap-tap-adventure/__tests__/itemEffects.test.ts
@@ -20,7 +20,10 @@ const baseChar: FantasyCharacter = {
   strength: 5,
   intelligence: 5,
   luck: 5,
+  hp: 50,
+  maxHp: 100,
   inventory: [],
+  deathCount: 0,
 }
 
 function makeConsumable(overrides: Partial<Item> = {}): Item {
@@ -42,9 +45,10 @@ describe('Item Effects', () => {
     const result = useItem(char, item)
 
     expect(result.consumed).toBe(true)
-    expect(result.character.strength).toBe(7) // 5 + 2
+    // Strength effect now heals HP (2 * 5 = 10 HP)
+    expect(result.character.hp).toBe(60) // 50 + 10
     expect(result.character.luck).toBe(6) // 5 + 1
-    expect(result.message).toContain('+2 Strength')
+    expect(result.message).toContain('+10 HP')
     expect(result.message).toContain('+1 Luck')
   })
 
@@ -115,7 +119,8 @@ describe('Item Effects', () => {
 
     expect(result.character.gold).toBe(60)
     expect(result.character.reputation).toBe(15)
-    expect(result.character.strength).toBe(6)
+    // Strength heals HP now (1 * 5 = 5 HP)
+    expect(result.character.hp).toBe(55) // 50 + 5
     expect(result.character.intelligence).toBe(7)
     expect(result.character.luck).toBe(8)
     expect(result.consumed).toBe(true)

--- a/src/app/tap-tap-adventure/__tests__/leveling.test.ts
+++ b/src/app/tap-tap-adventure/__tests__/leveling.test.ts
@@ -2,10 +2,15 @@ import { describe, expect, it } from 'vitest'
 
 import {
   applyLevelFromDistance,
+  calculateDay,
   calculateLevel,
+  crossedMilestone,
   levelProgress,
   stepsRequiredForLevel,
   stepsToNextLevel,
+  BOSS_MILESTONE_INTERVAL,
+  SHOP_MILESTONE_INTERVAL,
+  STEPS_PER_DAY,
 } from '@/app/tap-tap-adventure/lib/leveling'
 import { FantasyCharacter } from '@/app/tap-tap-adventure/models/character'
 
@@ -25,25 +30,22 @@ const baseChar: FantasyCharacter = {
   strength: 5,
   intelligence: 5,
   luck: 5,
+  hp: 100,
+  maxHp: 100,
   inventory: [],
+  deathCount: 0,
 }
 
-describe('Distance-Based Leveling', () => {
+describe('Distance-Based Leveling (rebalanced)', () => {
   describe('stepsToNextLevel', () => {
-    it('returns 25 steps for level 1 -> 2', () => {
-      // 20 + 1*5 = 25
-      expect(stepsToNextLevel(1)).toBe(25)
+    it('returns 250 steps for level 1 -> 2', () => {
+      // 200 + 1*50 = 250
+      expect(stepsToNextLevel(1)).toBe(250)
     })
 
-    it('returns 30 steps for level 2 -> 3', () => {
-      // 20 + 2*5 = 30
-      expect(stepsToNextLevel(2)).toBe(30)
-    })
-
-    it('increases with level', () => {
-      expect(stepsToNextLevel(3)).toBe(35)
-      expect(stepsToNextLevel(5)).toBe(45)
-      expect(stepsToNextLevel(10)).toBe(70)
+    it('returns 300 steps for level 2 -> 3', () => {
+      // 200 + 2*50 = 300
+      expect(stepsToNextLevel(2)).toBe(300)
     })
   })
 
@@ -52,18 +54,13 @@ describe('Distance-Based Leveling', () => {
       expect(stepsRequiredForLevel(1)).toBe(0)
     })
 
-    it('returns 25 for level 2', () => {
-      expect(stepsRequiredForLevel(2)).toBe(25)
+    it('returns 250 for level 2', () => {
+      expect(stepsRequiredForLevel(2)).toBe(250)
     })
 
-    it('returns 55 for level 3', () => {
-      // 25 + 30 = 55
-      expect(stepsRequiredForLevel(3)).toBe(55)
-    })
-
-    it('returns 90 for level 4', () => {
-      // 25 + 30 + 35 = 90
-      expect(stepsRequiredForLevel(4)).toBe(90)
+    it('returns 550 for level 3', () => {
+      // 250 + 300 = 550
+      expect(stepsRequiredForLevel(3)).toBe(550)
     })
   })
 
@@ -72,76 +69,91 @@ describe('Distance-Based Leveling', () => {
       expect(calculateLevel(0)).toBe(1)
     })
 
-    it('returns 1 at 24 distance', () => {
-      expect(calculateLevel(24)).toBe(1)
+    it('returns 1 at 249 distance', () => {
+      expect(calculateLevel(249)).toBe(1)
     })
 
-    it('returns 2 at 25 distance', () => {
-      expect(calculateLevel(25)).toBe(2)
+    it('returns 2 at 250 distance', () => {
+      expect(calculateLevel(250)).toBe(2)
     })
 
-    it('returns 2 at 54 distance', () => {
-      expect(calculateLevel(54)).toBe(2)
-    })
-
-    it('returns 3 at 55 distance', () => {
-      expect(calculateLevel(55)).toBe(3)
-    })
-
-    it('returns 4 at 90 distance', () => {
-      expect(calculateLevel(90)).toBe(4)
-    })
-
-    it('handles high distances', () => {
-      expect(calculateLevel(500)).toBeGreaterThan(5)
+    it('returns 3 at 550 distance', () => {
+      expect(calculateLevel(550)).toBe(3)
     })
   })
 
   describe('levelProgress', () => {
     it('returns 0 at start of level', () => {
       expect(levelProgress(0)).toBe(0)
-      expect(levelProgress(25)).toBe(0)
     })
 
-    it('returns ~0.5 at midpoint', () => {
-      // Level 1 needs 25 steps. At 12 steps: 12/25 ≈ 0.48
-      expect(levelProgress(12)).toBeCloseTo(0.48, 1)
+    it('returns ~0.5 at midpoint of level 1', () => {
+      expect(levelProgress(125)).toBeCloseTo(0.5, 1)
+    })
+  })
+
+  describe('calculateDay', () => {
+    it('returns 1 at distance 0', () => {
+      expect(calculateDay(0)).toBe(1)
     })
 
-    it('returns close to 1 near end of level', () => {
-      // Level 1 needs 25 steps. At 24: 24/25 = 0.96
-      expect(levelProgress(24)).toBeCloseTo(0.96, 1)
+    it('returns 1 at distance 49', () => {
+      expect(calculateDay(49)).toBe(1)
+    })
+
+    it('returns 2 at distance 50', () => {
+      expect(calculateDay(50)).toBe(2)
+    })
+
+    it('returns 3 at distance 100', () => {
+      expect(calculateDay(100)).toBe(3)
+    })
+  })
+
+  describe('crossedMilestone', () => {
+    it('detects shop milestone at 100', () => {
+      expect(crossedMilestone(99, 100, SHOP_MILESTONE_INTERVAL)).toBe(true)
+    })
+
+    it('does not trigger between milestones', () => {
+      expect(crossedMilestone(50, 51, SHOP_MILESTONE_INTERVAL)).toBe(false)
+    })
+
+    it('detects boss milestone at 500', () => {
+      expect(crossedMilestone(499, 500, BOSS_MILESTONE_INTERVAL)).toBe(true)
+    })
+  })
+
+  describe('constants', () => {
+    it('has expected milestone values', () => {
+      expect(STEPS_PER_DAY).toBe(50)
+      expect(SHOP_MILESTONE_INTERVAL).toBe(100)
+      expect(BOSS_MILESTONE_INTERVAL).toBe(500)
     })
   })
 
   describe('applyLevelFromDistance', () => {
-    it('does not change character if level matches', () => {
-      const char = { ...baseChar, distance: 10, level: 1 }
-      const result = applyLevelFromDistance(char)
-      expect(result).toBe(char) // same reference, no change
+    it('heals 1 HP per step', () => {
+      const char = { ...baseChar, distance: 10, hp: 50, maxHp: 100 }
+      const result = applyLevelFromDistance(char, 1)
+      expect(result.hp).toBe(51)
     })
 
-    it('levels up and adds stats when distance crosses threshold', () => {
-      const char = { ...baseChar, distance: 25, level: 1 }
+    it('does not heal past maxHp', () => {
+      // maxHp for level 1, strength 5 = 50 + 25 + 10 = 85
+      const char = { ...baseChar, distance: 10, hp: 84, maxHp: 85 }
+      const result = applyLevelFromDistance(char, 5)
+      expect(result.hp).toBe(85) // capped at maxHp
+    })
+
+    it('levels up and updates maxHp', () => {
+      // At distance 250, level goes from 1 to 2, strength 5->6
+      // maxHp = 50 + 6*5 + 2*10 = 100
+      const char = { ...baseChar, distance: 250, level: 1 }
       const result = applyLevelFromDistance(char)
       expect(result.level).toBe(2)
-      expect(result.strength).toBe(6) // 5 + 1
-      expect(result.intelligence).toBe(6)
-      expect(result.luck).toBe(6)
-    })
-
-    it('handles multiple level jumps', () => {
-      const char = { ...baseChar, distance: 55, level: 1 }
-      const result = applyLevelFromDistance(char)
-      expect(result.level).toBe(3)
-      expect(result.strength).toBe(7) // 5 + 2
-    })
-
-    it('does not reduce stats if level somehow decreases', () => {
-      const char = { ...baseChar, distance: 10, level: 3, strength: 10 }
-      const result = applyLevelFromDistance(char)
-      expect(result.level).toBe(1)
-      expect(result.strength).toBe(10) // unchanged, no negative adjustment
+      expect(result.strength).toBe(6)
+      expect(result.maxHp).toBe(100)
     })
   })
 })

--- a/src/app/tap-tap-adventure/components/HudBar.tsx
+++ b/src/app/tap-tap-adventure/components/HudBar.tsx
@@ -9,19 +9,26 @@ import {
 } from '@/app/tap-tap-adventure/components/ui/tooltip'
 import { useGameStore } from '@/app/tap-tap-adventure/hooks/useGameStore'
 import { getReputationTier } from '@/app/tap-tap-adventure/lib/contextBuilder'
-import { levelProgress, stepsToNextLevel, stepsRequiredForLevel } from '@/app/tap-tap-adventure/lib/leveling'
+import { levelProgress, stepsToNextLevel, stepsRequiredForLevel, calculateDay } from '@/app/tap-tap-adventure/lib/leveling'
 import { FantasyCharacter } from '@/app/tap-tap-adventure/models/character'
 
 type IconType =
+  | 'heartIcon'
   | 'sunIcon'
   | 'waterDropIcon'
   | 'leafIcon'
   | 'fireIcon'
+  | 'dayIcon'
   | 'purpleCircleIcon'
   | 'blueCircleIcon'
   | 'yellowMoonIcon'
 
 const ICONS: Record<IconType, React.ReactNode> = {
+  heartIcon: (
+    <svg width="20" height="20" fill="#EF4444" viewBox="0 0 20 20">
+      <path d="M10 18l-1.45-1.32C3.4 12.36 0 9.28 0 5.5 0 2.42 2.42 0 5.5 0 7.24 0 8.91.81 10 2.09 11.09.81 12.76 0 14.5 0 17.58 0 20 2.42 20 5.5c0 3.78-3.4 6.86-8.55 11.18L10 18z" />
+    </svg>
+  ),
   sunIcon: (
     <svg width="20" height="20" fill="#FACC15" viewBox="0 0 20 20">
       <circle cx="10" cy="10" r="8" />
@@ -42,6 +49,15 @@ const ICONS: Record<IconType, React.ReactNode> = {
       <path d="M10.5 0C7.286.057 4.536 2.018 4.536 5.714 4.536 9.07 7.071 11.25 7.071 12.5c0 .964-1.071 3.75-1.071 3.75s1.071.893 3.5.893c2.679 0 3.5-1.25 3.5-1.25s-1.071-2.679-1.071-3.75C12.429 11.25 15 9.07 15 5.714 15 2.018 12.714.057 10.5 0z" />
     </svg>
   ),
+  dayIcon: (
+    <svg width="20" height="20" fill="#FB923C" viewBox="0 0 20 20">
+      <circle cx="10" cy="10" r="5" />
+      <line x1="10" y1="1" x2="10" y2="4" stroke="#FB923C" strokeWidth="2" />
+      <line x1="10" y1="16" x2="10" y2="19" stroke="#FB923C" strokeWidth="2" />
+      <line x1="1" y1="10" x2="4" y2="10" stroke="#FB923C" strokeWidth="2" />
+      <line x1="16" y1="10" x2="19" y2="10" stroke="#FB923C" strokeWidth="2" />
+    </svg>
+  ),
   purpleCircleIcon: (
     <svg width="20" height="20" fill="#A78BFA" viewBox="0 0 20 20">
       <circle cx="10" cy="10" r="8" />
@@ -60,16 +76,18 @@ const ICONS: Record<IconType, React.ReactNode> = {
 } as const
 
 const STAT_LABELS: Record<IconType, string> = {
+  heartIcon: 'HP',
   sunIcon: 'Gold',
   waterDropIcon: 'Reputation',
-  leafIcon: 'Distance',
+  leafIcon: 'Steps',
   fireIcon: 'Level',
+  dayIcon: 'Day',
   purpleCircleIcon: 'Strength',
   blueCircleIcon: 'Intelligence',
   yellowMoonIcon: 'Luck',
 } as const
 
-const STATS_LEFT: IconType[] = ['sunIcon', 'waterDropIcon', 'leafIcon', 'fireIcon']
+const STATS_LEFT: IconType[] = ['heartIcon', 'sunIcon', 'waterDropIcon', 'leafIcon', 'fireIcon', 'dayIcon']
 const STATS_RIGHT: IconType[] = ['purpleCircleIcon', 'blueCircleIcon', 'yellowMoonIcon']
 
 export function HudBar() {
@@ -83,19 +101,25 @@ export function HudBar() {
   const progress = character ? levelProgress(distance) : 0
   const stepsNeeded = stepsToNextLevel(level)
   const stepsIntoLevel = distance - stepsRequiredForLevel(level)
+  const day = calculateDay(distance)
+  const hp = character?.hp ?? character?.maxHp ?? 100
+  const maxHp = character?.maxHp ?? 100
+  const hpPct = Math.round((hp / maxHp) * 100)
 
   const stats = useMemo(
     () => ({
+      heartIcon: `${character?.hp ?? character?.maxHp ?? 100}`,
       sunIcon: character?.gold ?? 0,
       waterDropIcon: character?.reputation ?? 0,
       leafIcon: character?.distance ?? 0,
       fireIcon: character?.level ?? 1,
+      dayIcon: calculateDay(character?.distance ?? 0),
       purpleCircleIcon: character?.strength ?? 0,
       blueCircleIcon: character?.intelligence ?? 0,
       yellowMoonIcon: character?.luck ?? 0,
     }),
     [character]
-  ) as Record<IconType, number>
+  ) as Record<IconType, number | string>
 
   return (
     <TooltipProvider>
@@ -106,6 +130,16 @@ export function HudBar() {
               <TooltipTrigger className="flex items-center gap-1 text-xs sm:text-sm font-semibold">
                 <span className="inline-block align-middle shrink-0">{ICONS[key]}</span>
                 <span>{stats[key]}</span>
+                {key === 'heartIcon' && (
+                  <span className="w-8 sm:w-12 h-1.5 bg-slate-700 rounded-full overflow-hidden ml-1">
+                    <span
+                      className={`block h-full rounded-full transition-all duration-300 ${
+                        hpPct > 50 ? 'bg-green-500' : hpPct > 25 ? 'bg-yellow-500' : 'bg-red-500'
+                      }`}
+                      style={{ width: `${hpPct}%` }}
+                    />
+                  </span>
+                )}
                 {key === 'fireIcon' && (
                   <span className="w-8 sm:w-12 h-1.5 bg-slate-700 rounded-full overflow-hidden ml-1">
                     <span
@@ -116,10 +150,14 @@ export function HudBar() {
                 )}
               </TooltipTrigger>
               <TooltipContent>
-                {key === 'fireIcon'
+                {key === 'heartIcon'
+                  ? `HP: ${hp}/${maxHp}`
+                  : key === 'fireIcon'
                   ? `Level ${level} — ${stepsIntoLevel}/${stepsNeeded} steps to next`
                   : key === 'waterDropIcon'
-                    ? `Reputation: ${getReputationTier(stats[key])} (${stats[key]})`
+                    ? `Reputation: ${getReputationTier(stats[key] as number)} (${stats[key]})`
+                    : key === 'dayIcon'
+                    ? `Day ${day} (${50 - (distance % 50)} steps to next day)`
                     : STAT_LABELS[key]}
               </TooltipContent>
             </Tooltip>

--- a/src/app/tap-tap-adventure/config/gameDefaults.ts
+++ b/src/app/tap-tap-adventure/config/gameDefaults.ts
@@ -37,6 +37,8 @@ export const DEFAULT_CHARACTER = {
   strength: DEFAULT_STAT_MIN,
   intelligence: DEFAULT_STAT_MIN,
   luck: DEFAULT_STAT_MIN,
+  hp: 100,
+  maxHp: 100,
   equipment: { weapon: null, armor: null, accessory: null },
   deathCount: 0,
 }

--- a/src/app/tap-tap-adventure/hooks/useCombatActionMutation.ts
+++ b/src/app/tap-tap-adventure/hooks/useCombatActionMutation.ts
@@ -77,6 +77,12 @@ export function useCombatActionMutation() {
         updateSelectedCharacter({ inventory: updatedInventory })
       }
 
+      // Persist HP back to character after every combat turn
+      updateSelectedCharacter({
+        hp: data.combatState.playerState.hp,
+        maxHp: data.combatState.playerState.maxHp,
+      })
+
       if (data.combatState.status === 'active') {
         // Combat continues
         setCombatState(data.combatState)

--- a/src/app/tap-tap-adventure/hooks/useGameStore.ts
+++ b/src/app/tap-tap-adventure/hooks/useGameStore.ts
@@ -33,6 +33,8 @@ const defaultCharacter: FantasyCharacter = {
   strength: 0,
   intelligence: 0,
   luck: 0,
+  hp: 100,
+  maxHp: 100,
   inventory: [],
   equipment: { weapon: null, armor: null, accessory: null },
   deathCount: 0,
@@ -339,7 +341,7 @@ export const useGameStore = create<GameStore>()(
     }),
     {
       name: 'fantasy-tycoon-storage', // localStorage key (kept for backward compat)
-      version: 4,
+      version: 5,
       migrate: (persistedState: unknown) => {
         const state = persistedState as GameStore
         if (state?.gameState && !('combatState' in state.gameState)) {
@@ -348,7 +350,6 @@ export const useGameStore = create<GameStore>()(
         if (state?.gameState && !('shopState' in state.gameState)) {
           (state.gameState as GameState).shopState = null
         }
-        // v4: Add equipment slots and deathCount to all characters
         if (state?.gameState?.characters) {
           for (const char of state.gameState.characters) {
             if (!char.equipment) {
@@ -356,6 +357,12 @@ export const useGameStore = create<GameStore>()(
             }
             if (char.deathCount === undefined) {
               (char as FantasyCharacter).deathCount = 0
+            }
+            // v5: Add persistent HP
+            if (char.hp === undefined || char.maxHp === undefined) {
+              const maxHp = 50 + (char.strength ?? 5) * 5 + (char.level ?? 1) * 10
+              ;(char as FantasyCharacter).hp = maxHp
+              ;(char as FantasyCharacter).maxHp = maxHp
             }
           }
         }

--- a/src/app/tap-tap-adventure/lib/combatEngine.ts
+++ b/src/app/tap-tap-adventure/lib/combatEngine.ts
@@ -19,9 +19,11 @@ export function initializePlayerCombatState(character: FantasyCharacter): Combat
   const armorBonus = equipment.armor?.effects?.intelligence ?? 0
   const accessoryLuckBonus = equipment.accessory?.effects?.luck ?? 0
 
-  const maxHp = 50 + character.strength * 5 + character.level * 10
+  // Use persistent HP from character, falling back to max if not set
+  const maxHp = character.maxHp ?? (50 + character.strength * 5 + character.level * 10)
+  const currentHp = character.hp ?? maxHp
   return {
-    hp: maxHp,
+    hp: currentHp,
     maxHp,
     attack: 5 + character.strength * 2 + character.level + weaponBonus * 2,
     defense: 3 + character.intelligence + character.level + armorBonus,

--- a/src/app/tap-tap-adventure/lib/itemEffects.ts
+++ b/src/app/tap-tap-adventure/lib/itemEffects.ts
@@ -37,8 +37,15 @@ export function useItem(character: FantasyCharacter, item: Item): UseItemResult 
     effectMessages.push(`${effects.reputation > 0 ? '+' : ''}${effects.reputation} Reputation`)
   }
   if (effects.strength) {
-    updatedCharacter.strength += effects.strength
-    effectMessages.push(`${effects.strength > 0 ? '+' : ''}${effects.strength} Strength`)
+    // Strength potions heal HP (strength * 5) instead of boosting stat permanently
+    const healAmount = effects.strength * 5
+    const maxHp = updatedCharacter.maxHp ?? 100
+    const oldHp = updatedCharacter.hp ?? maxHp
+    updatedCharacter.hp = Math.min(maxHp, oldHp + healAmount)
+    const actualHeal = (updatedCharacter.hp ?? 0) - oldHp
+    if (actualHeal > 0) {
+      effectMessages.push(`+${actualHeal} HP`)
+    }
   }
   if (effects.intelligence) {
     updatedCharacter.intelligence += effects.intelligence

--- a/src/app/tap-tap-adventure/lib/leveling.ts
+++ b/src/app/tap-tap-adventure/lib/leveling.ts
@@ -1,12 +1,16 @@
 import { FantasyCharacter } from '@/app/tap-tap-adventure/models/character'
 
-const BASE_STEPS = 20
-const STEPS_PER_LEVEL_INCREMENT = 5
+const BASE_STEPS = 200
+const STEPS_PER_LEVEL_INCREMENT = 50
+
+// Milestone constants
+export const STEPS_PER_DAY = 50
+export const SHOP_MILESTONE_INTERVAL = 100
+export const BOSS_MILESTONE_INTERVAL = 500
 
 /**
  * Steps required to reach a given level from level 1.
- * Formula: sum of (BASE_STEPS + level * STEPS_PER_LEVEL_INCREMENT) for each level.
- * Level 2 at 25 steps, Level 3 at 55, Level 4 at 90, etc.
+ * Level 2 at 250 steps, Level 3 at 550, Level 4 at 900, etc.
  */
 export function stepsRequiredForLevel(level: number): number {
   if (level <= 1) return 0
@@ -50,24 +54,61 @@ export function levelProgress(distance: number): number {
   return Math.min(1, Math.max(0, progress / needed))
 }
 
+/**
+ * Calculate current day from distance.
+ */
+export function calculateDay(distance: number): number {
+  return Math.floor(distance / STEPS_PER_DAY) + 1
+}
+
+/**
+ * Calculate max HP for a character based on stats.
+ */
+export function calculateMaxHp(character: FantasyCharacter): number {
+  return 50 + character.strength * 5 + character.level * 10
+}
+
+/**
+ * Check if a step milestone was just crossed.
+ */
+export function crossedMilestone(oldDistance: number, newDistance: number, interval: number): boolean {
+  return Math.floor(newDistance / interval) > Math.floor(oldDistance / interval)
+}
+
 const STAT_BONUS_PER_LEVEL = 1
 
 /**
- * Apply level-derived stat bonuses to a character.
- * Returns a new character with updated level and stats.
+ * Apply level-derived stat bonuses and update maxHp.
+ * Also heals 1 HP per step (called on distance change).
  */
-export function applyLevelFromDistance(character: FantasyCharacter): FantasyCharacter {
+export function applyLevelFromDistance(
+  character: FantasyCharacter,
+  stepsGained: number = 1
+): FantasyCharacter {
   const newLevel = calculateLevel(character.distance)
-  if (newLevel === character.level) return character
+  let updated = { ...character }
 
-  const levelsGained = newLevel - character.level
-  if (levelsGained <= 0) return { ...character, level: newLevel }
+  if (newLevel > character.level) {
+    const levelsGained = newLevel - character.level
+    updated = {
+      ...updated,
+      level: newLevel,
+      strength: character.strength + levelsGained * STAT_BONUS_PER_LEVEL,
+      intelligence: character.intelligence + levelsGained * STAT_BONUS_PER_LEVEL,
+      luck: character.luck + levelsGained * STAT_BONUS_PER_LEVEL,
+    }
+  } else if (newLevel < character.level) {
+    updated.level = newLevel
+  }
+
+  // Update maxHp and heal
+  const maxHp = calculateMaxHp(updated)
+  const currentHp = updated.hp ?? maxHp
+  const healed = Math.min(maxHp, currentHp + stepsGained)
 
   return {
-    ...character,
-    level: newLevel,
-    strength: character.strength + levelsGained * STAT_BONUS_PER_LEVEL,
-    intelligence: character.intelligence + levelsGained * STAT_BONUS_PER_LEVEL,
-    luck: character.luck + levelsGained * STAT_BONUS_PER_LEVEL,
+    ...updated,
+    hp: healed,
+    maxHp,
   }
 }

--- a/src/app/tap-tap-adventure/models/character.ts
+++ b/src/app/tap-tap-adventure/models/character.ts
@@ -29,6 +29,8 @@ export const FantasyCharacterSchema = z.object({
   strength: z.number(),
   intelligence: z.number(),
   luck: z.number(),
+  hp: z.number().optional(),
+  maxHp: z.number().optional(),
   inventory: z.array(ItemSchema),
   equipment: z.object({
     weapon: ItemSchema.nullable(),


### PR DESCRIPTION
## Summary
Three interconnected changes that make HP meaningful and steps valuable:

### Step Economy Rebalance (10x)
| Metric | Before | After |
|--------|--------|-------|
| Level 2 | 25 steps | 250 steps |
| Level 3 | 55 steps | 550 steps |
| Formula | 20 + level*5 | 200 + level*50 |

### Persistent HP
- HP stored on character model, persists between combats
- Heals **1 HP per step** — full heal takes 100-200 steps (2-4 days)
- Combat starts with your **current HP**, not full
- Strength potions now **heal HP** (strength * 5) instead of permanent stat boost
- HP bar in HUD with green/yellow/red color coding

### Day Counter
- **1 day = 50 steps**, shown in HUD with sun icon
- Tooltip shows steps remaining in current day
- Foundation for future timed quests

### Step-Based Milestones
- **Shops**: every 100 steps (was every level-up)
- **Bosses**: every 500 steps (was every 5 levels)
- **Random merchants**: 3% chance after 50 steps (was 10% after 15)

### Files changed (11)
- `leveling.ts` — new constants, `calculateDay`, `crossedMilestone`, `calculateMaxHp`, HP healing in `applyLevelFromDistance`
- `character.ts` — added `hp`, `maxHp` fields
- `combatEngine.ts` — uses character's persistent HP
- `moveForwardService.ts` — step-based milestones
- `itemEffects.ts` — strength heals HP
- `HudBar.tsx` — HP bar + day counter
- `useCombatActionMutation.ts` — persists HP after combat
- `useGameStore.ts` — v5 migration, HP in defaults
- Tests updated

## Test plan
- [x] 178 tests pass
- [ ] Travel and verify HP heals slowly (1/step)
- [ ] Enter combat wounded, verify you start with current HP
- [ ] Verify day counter increments every 50 steps
- [ ] Verify shops at step 100, 200, 300...
- [ ] Verify boss at step 500, 1000...

🤖 Generated with [Claude Code](https://claude.com/claude-code)