### PR TITLE
feat: timed quests with day deadlines

### DIFF
--- a/src/app/tap-tap-adventure/__tests__/questGenerator.test.ts
+++ b/src/app/tap-tap-adventure/__tests__/questGenerator.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from 'vitest'
+
+import { checkQuestProgress, generateTimedQuest } from '@/app/tap-tap-adventure/lib/questGenerator'
+import { FantasyCharacter } from '@/app/tap-tap-adventure/models/character'
+
+const baseChar: FantasyCharacter = {
+  id: '1',
+  playerId: 'p1',
+  name: 'Test',
+  race: 'Human',
+  class: 'Warrior',
+  level: 2,
+  abilities: [],
+  locationId: 'loc1',
+  gold: 50,
+  reputation: 10,
+  distance: 200,
+  status: 'active',
+  strength: 7,
+  intelligence: 6,
+  luck: 6,
+  hp: 100,
+  maxHp: 100,
+  inventory: [],
+  deathCount: 0,
+}
+
+describe('Quest Generator', () => {
+  describe('generateTimedQuest', () => {
+    it('generates a quest with valid fields', () => {
+      const quest = generateTimedQuest(baseChar)
+      expect(quest.id).toBeTruthy()
+      expect(quest.title).toBeTruthy()
+      expect(quest.description).toBeTruthy()
+      expect(quest.status).toBe('active')
+      expect(['reach_distance', 'collect_gold', 'win_combat', 'gain_reputation']).toContain(quest.type)
+      expect(quest.target).toBeGreaterThan(0)
+      expect(quest.deadlineDay).toBeGreaterThan(quest.startDay)
+      expect(quest.rewards.gold).toBeGreaterThan(0)
+    })
+
+    it('sets deadline in the future', () => {
+      const quest = generateTimedQuest(baseChar)
+      expect(quest.deadlineDay).toBeGreaterThan(quest.startDay)
+    })
+  })
+
+  describe('checkQuestProgress', () => {
+    it('marks reach_distance quest as completed when target reached', () => {
+      const quest = generateTimedQuest(baseChar)
+      const distanceQuest = { ...quest, type: 'reach_distance' as const, target: 250 }
+      const advancedChar = { ...baseChar, distance: 260 }
+      const result = checkQuestProgress(distanceQuest, advancedChar)
+      expect(result.status).toBe('completed')
+    })
+
+    it('marks collect_gold quest as completed', () => {
+      const quest = generateTimedQuest(baseChar)
+      const goldQuest = { ...quest, type: 'collect_gold' as const, target: 100 }
+      const richChar = { ...baseChar, gold: 150 }
+      const result = checkQuestProgress(goldQuest, richChar)
+      expect(result.status).toBe('completed')
+    })
+
+    it('marks win_combat quest as completed when combatWon is true', () => {
+      const quest = generateTimedQuest(baseChar)
+      const combatQuest = { ...quest, type: 'win_combat' as const, target: 1 }
+      const result = checkQuestProgress(combatQuest, baseChar, true)
+      expect(result.status).toBe('completed')
+    })
+
+    it('does not complete win_combat quest without combat', () => {
+      const quest = generateTimedQuest(baseChar)
+      const combatQuest = { ...quest, type: 'win_combat' as const, target: 1 }
+      const result = checkQuestProgress(combatQuest, baseChar, false)
+      expect(result.status).toBe('active')
+    })
+
+    it('marks quest as failed when deadline passes', () => {
+      const quest = generateTimedQuest(baseChar)
+      const expiredQuest = { ...quest, deadlineDay: 1 }
+      // Character at distance 200 is on day 5 (200/50 + 1)
+      const result = checkQuestProgress(expiredQuest, baseChar)
+      expect(result.status).toBe('failed')
+    })
+
+    it('does not change completed quests', () => {
+      const quest = generateTimedQuest(baseChar)
+      const completedQuest = { ...quest, status: 'completed' as const }
+      const result = checkQuestProgress(completedQuest, baseChar)
+      expect(result.status).toBe('completed')
+    })
+
+    it('marks gain_reputation quest as completed', () => {
+      const quest = generateTimedQuest(baseChar)
+      const repQuest = { ...quest, type: 'gain_reputation' as const, target: 15 }
+      const repChar = { ...baseChar, reputation: 20 }
+      const result = checkQuestProgress(repQuest, repChar)
+      expect(result.status).toBe('completed')
+    })
+  })
+})

--- a/src/app/tap-tap-adventure/components/GameUI.tsx
+++ b/src/app/tap-tap-adventure/components/GameUI.tsx
@@ -14,6 +14,7 @@ import { CombatUI, CombatResult } from './CombatUI'
 import { EquipmentPanel } from './EquipmentPanel'
 import { InventoryPanel } from './InventoryPanel'
 import { LevelUpCelebration } from './LevelUpCelebration'
+import { QuestPanel } from './QuestPanel'
 import { ShopUI } from './ShopUI'
 import { StoryFeed } from './StoryFeed'
 
@@ -166,8 +167,9 @@ export default function GameUI() {
               </>
             )}
           </div>
-          {/* Right column: Equipment & Inventory Panel */}
+          {/* Right column: Quest, Equipment & Inventory Panel */}
           <div className="p-4 bg-[#161723] border border-[#3a3c56] rounded-lg space-y-4 h-fit md:sticky md:top-8">
+            <QuestPanel />
             <EquipmentPanel
               equipment={getSelectedCharacter()?.equipment ?? { weapon: null, armor: null, accessory: null }}
             />

--- a/src/app/tap-tap-adventure/components/QuestPanel.tsx
+++ b/src/app/tap-tap-adventure/components/QuestPanel.tsx
@@ -1,0 +1,142 @@
+'use client'
+
+import { useCallback } from 'react'
+
+import { Button } from '@/app/tap-tap-adventure/components/ui/button'
+import { useGameStore } from '@/app/tap-tap-adventure/hooks/useGameStore'
+import { calculateDay } from '@/app/tap-tap-adventure/lib/leveling'
+import { TimedQuest } from '@/app/tap-tap-adventure/models/quest'
+
+export function QuestPanel() {
+  const { gameState, getSelectedCharacter, setActiveQuest } = useGameStore()
+  const quest = gameState.activeQuest
+  const character = getSelectedCharacter()
+
+  const handleDismiss = useCallback(() => {
+    if (!quest) return
+    if (quest.status === 'completed' && character) {
+      // Apply rewards
+      const rewards = quest.rewards
+      const updatedGold = character.gold + (rewards.gold ?? 0)
+      const updatedRep = character.reputation + (rewards.reputation ?? 0)
+
+      // Update character with rewards via store
+      const { gameState: gs, setGameState } = useGameStore.getState()
+      const updatedChars = gs.characters.map(c => {
+        if (c.id !== character.id) return c
+        const updatedInventory = [...c.inventory, ...(rewards.items ?? [])]
+        return { ...c, gold: updatedGold, reputation: updatedRep, inventory: updatedInventory }
+      })
+      setGameState({ ...gs, characters: updatedChars, activeQuest: null })
+    } else {
+      setActiveQuest(null)
+    }
+  }, [quest, character, setActiveQuest])
+
+  if (!quest || !character) return null
+
+  const currentDay = calculateDay(character.distance)
+  const daysLeft = Math.max(0, quest.deadlineDay - currentDay)
+
+  // Progress calculation
+  let progress = 0
+  let progressText = ''
+  switch (quest.type) {
+    case 'reach_distance': {
+      const needed = quest.target - quest.startValue
+      const done = Math.max(0, character.distance - quest.startValue)
+      progress = Math.min(1, done / needed)
+      progressText = `${character.distance} / ${quest.target} steps`
+      break
+    }
+    case 'collect_gold': {
+      const needed = quest.target - quest.startValue
+      const done = Math.max(0, character.gold - quest.startValue)
+      progress = Math.min(1, done / needed)
+      progressText = `${character.gold} / ${quest.target} gold`
+      break
+    }
+    case 'win_combat':
+      progress = quest.status === 'completed' ? 1 : 0
+      progressText = quest.status === 'completed' ? 'Completed!' : 'Win a fight'
+      break
+    case 'gain_reputation': {
+      const needed = quest.target - quest.startValue
+      const done = Math.max(0, character.reputation - quest.startValue)
+      progress = Math.min(1, done / needed)
+      progressText = `${character.reputation} / ${quest.target} reputation`
+      break
+    }
+  }
+
+  if (quest.status === 'completed') {
+    return (
+      <div className="bg-emerald-950/30 border border-emerald-700/50 rounded-lg p-3 space-y-2">
+        <div className="flex justify-between items-center">
+          <span className="text-sm font-bold text-emerald-400">Quest Complete!</span>
+        </div>
+        <p className="text-xs text-emerald-300">{quest.title}</p>
+        <div className="text-xs text-slate-300 space-y-0.5">
+          {quest.rewards.gold && <div>+{quest.rewards.gold} Gold</div>}
+          {quest.rewards.reputation && <div>+{quest.rewards.reputation} Reputation</div>}
+          {quest.rewards.items?.map(item => (
+            <div key={item.id}>+ {item.name}</div>
+          ))}
+        </div>
+        <Button
+          className="w-full bg-emerald-700 hover:bg-emerald-600 text-white text-xs py-1.5 rounded"
+          onClick={handleDismiss}
+        >
+          Claim Rewards
+        </Button>
+      </div>
+    )
+  }
+
+  if (quest.status === 'failed') {
+    return (
+      <div className="bg-red-950/30 border border-red-700/50 rounded-lg p-3 space-y-2">
+        <div className="flex justify-between items-center">
+          <span className="text-sm font-bold text-red-400">Quest Failed</span>
+        </div>
+        <p className="text-xs text-red-300">{quest.title}</p>
+        <p className="text-xs text-slate-400">The deadline has passed.</p>
+        <Button
+          className="w-full bg-red-900 hover:bg-red-800 text-white text-xs py-1.5 rounded"
+          onClick={handleDismiss}
+        >
+          Dismiss
+        </Button>
+      </div>
+    )
+  }
+
+  // Active quest
+  return (
+    <div className="bg-[#1e1f30] border border-amber-700/30 rounded-lg p-3 space-y-2">
+      <div className="flex justify-between items-center">
+        <span className="text-sm font-bold text-amber-400">Active Quest</span>
+        <span className={`text-[10px] px-1.5 py-0.5 rounded ${
+          daysLeft <= 1 ? 'bg-red-900/50 text-red-400' : 'bg-amber-900/50 text-amber-400'
+        }`}>
+          {daysLeft} day{daysLeft !== 1 ? 's' : ''} left
+        </span>
+      </div>
+      <p className="text-xs text-white font-semibold">{quest.title}</p>
+      <p className="text-[10px] text-slate-400">{quest.description}</p>
+      {/* Progress bar */}
+      <div className="space-y-1">
+        <div className="flex justify-between text-[10px] text-slate-400">
+          <span>{progressText}</span>
+          <span>{Math.round(progress * 100)}%</span>
+        </div>
+        <div className="h-1.5 bg-slate-700 rounded-full overflow-hidden">
+          <div
+            className="h-full bg-amber-500 rounded-full transition-all duration-300"
+            style={{ width: `${progress * 100}%` }}
+          />
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/app/tap-tap-adventure/hooks/useCombatActionMutation.ts
+++ b/src/app/tap-tap-adventure/hooks/useCombatActionMutation.ts
@@ -3,6 +3,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query'
 
 import { DeathPenalty } from '@/app/tap-tap-adventure/lib/deathPenalty'
 import { inferItemTypeAndEffects } from '@/app/tap-tap-adventure/lib/itemPostProcessor'
+import { checkQuestProgress } from '@/app/tap-tap-adventure/lib/questGenerator'
 import { CombatAction, CombatState } from '@/app/tap-tap-adventure/models/combat'
 import { FantasyCharacter, Item } from '@/app/tap-tap-adventure/models/types'
 
@@ -146,6 +147,14 @@ export function useCombatActionMutation() {
         }
 
         setCombatState(null)
+
+        // Check quest progress after combat ends
+        const { gameState: gs } = useGameStore.getState()
+        if (gs.activeQuest?.status === 'active') {
+          const combatWon = data.combatState.status === 'victory'
+          const updatedQuest = checkQuestProgress(gs.activeQuest, data.updatedCharacter, combatWon)
+          useGameStore.getState().setActiveQuest(updatedQuest)
+        }
       }
 
       commit()

--- a/src/app/tap-tap-adventure/hooks/useGameStore.ts
+++ b/src/app/tap-tap-adventure/hooks/useGameStore.ts
@@ -6,9 +6,11 @@ import { persist } from 'zustand/middleware'
 import { defaultGameState } from '@/app/tap-tap-adventure/lib/defaultGameState'
 import { useItem as applyItemUse } from '@/app/tap-tap-adventure/lib/itemEffects'
 import { applyLevelFromDistance } from '@/app/tap-tap-adventure/lib/leveling'
+import { checkQuestProgress } from '@/app/tap-tap-adventure/lib/questGenerator'
 import { FantasyCharacter } from '@/app/tap-tap-adventure/models/character'
 import { CombatState } from '@/app/tap-tap-adventure/models/combat'
 import { getEquipmentSlot, EquipmentSlotType } from '@/app/tap-tap-adventure/models/equipment'
+import { TimedQuest } from '@/app/tap-tap-adventure/models/quest'
 import {
   FantasyDecisionPoint,
   FantasyStoryEvent,
@@ -54,6 +56,7 @@ export interface GameStore {
   setGameState: (gameState: GameState) => void
   setGenericMessage: (message: string) => void
   useItem: (itemId: string) => { message: string; consumed: boolean } | null
+  setActiveQuest: (quest: TimedQuest | null) => void
   discardItem: (itemId: string) => void
   restoreItem: (itemId: string) => void
   equipItem: (itemId: string, slot?: EquipmentSlotType) => void
@@ -112,6 +115,20 @@ export const useGameStore = create<GameStore>()(
             state.gameState.characters = state.gameState.characters.map(char =>
               char.id === selectedCharacter.id ? updatedCharacter : char
             )
+            // Check quest progress on each step
+            if (state.gameState.activeQuest?.status === 'active') {
+              state.gameState.activeQuest = checkQuestProgress(
+                state.gameState.activeQuest,
+                updatedCharacter
+              )
+            }
+          })
+        )
+      },
+      setActiveQuest: (quest: TimedQuest | null) => {
+        set(
+          produce((state: GameStore) => {
+            state.gameState.activeQuest = quest
           })
         )
       },
@@ -131,6 +148,7 @@ export const useGameStore = create<GameStore>()(
                 decisionPoint: null,
                 combatState: null,
                 shopState: null,
+                activeQuest: null,
                 genericMessage: null,
               },
             }
@@ -341,7 +359,7 @@ export const useGameStore = create<GameStore>()(
     }),
     {
       name: 'fantasy-tycoon-storage', // localStorage key (kept for backward compat)
-      version: 5,
+      version: 6,
       migrate: (persistedState: unknown) => {
         const state = persistedState as GameStore
         if (state?.gameState && !('combatState' in state.gameState)) {
@@ -365,6 +383,10 @@ export const useGameStore = create<GameStore>()(
               ;(char as FantasyCharacter).maxHp = maxHp
             }
           }
+        }
+        // v6: Add activeQuest
+        if (state?.gameState && !('activeQuest' in state.gameState)) {
+          (state.gameState as GameState).activeQuest = null
         }
         return state
       },
@@ -407,6 +429,10 @@ export function useGameStateBuilder() {
     gameStateClone.shopState = shopState
   }
 
+  const setActiveQuest = (quest: TimedQuest | null) => {
+    gameStateClone.activeQuest = quest
+  }
+
   const setDecisionPoint = (decisionPoint: FantasyDecisionPoint | null) => {
     gameStateClone.decisionPoint = decisionPoint
   }
@@ -437,6 +463,7 @@ export function useGameStateBuilder() {
     addStoryEvent,
     setCombatState,
     setShopState,
+    setActiveQuest,
     setDecisionPoint,
     setGenericMessage,
     updateSelectedCharacter,

--- a/src/app/tap-tap-adventure/hooks/useMoveForwardMutation.ts
+++ b/src/app/tap-tap-adventure/hooks/useMoveForwardMutation.ts
@@ -2,6 +2,7 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 
 import { inferItemTypeAndEffects } from '@/app/tap-tap-adventure/lib/itemPostProcessor'
+import { generateTimedQuest, checkQuestProgress } from '@/app/tap-tap-adventure/lib/questGenerator'
 import {
   FantasyCharacter,
   FantasyDecisionPoint,
@@ -28,6 +29,7 @@ export function useMoveForwardMutation() {
     setDecisionPoint,
     setGenericMessage,
     setShopState,
+    setActiveQuest,
   } = useGameStateBuilder()
 
   return useMutation({
@@ -79,6 +81,20 @@ export function useMoveForwardMutation() {
         setGenericMessage(null)
         setDecisionPoint(data.decisionPoint)
       }
+
+      // Check quest progress
+      const { gameState: currentState } = useGameStore.getState()
+      if (currentState.activeQuest?.status === 'active') {
+        const updatedQuest = checkQuestProgress(currentState.activeQuest, data.character)
+        setActiveQuest(updatedQuest)
+      }
+
+      // Offer a new quest if none active (5% chance after 50 steps)
+      if (!currentState.activeQuest && data.character.distance > 50 && Math.random() < 0.05) {
+        const quest = generateTimedQuest(data.character)
+        setActiveQuest(quest)
+      }
+
       commit()
     },
     onSuccess: () => {

--- a/src/app/tap-tap-adventure/lib/defaultGameState.ts
+++ b/src/app/tap-tap-adventure/lib/defaultGameState.ts
@@ -14,5 +14,6 @@ export const defaultGameState: GameState = {
   decisionPoint: null,
   combatState: null,
   shopState: null,
+  activeQuest: null,
   genericMessage: null,
 }

--- a/src/app/tap-tap-adventure/lib/questGenerator.ts
+++ b/src/app/tap-tap-adventure/lib/questGenerator.ts
@@ -1,0 +1,127 @@
+import { FantasyCharacter } from '@/app/tap-tap-adventure/models/character'
+import { TimedQuest } from '@/app/tap-tap-adventure/models/quest'
+
+import { calculateDay } from './leveling'
+import { inferItemTypeAndEffects } from './itemPostProcessor'
+
+type QuestType = 'reach_distance' | 'collect_gold' | 'win_combat' | 'gain_reputation'
+
+interface QuestTemplate {
+  type: QuestType
+  getTitle: (target: number) => string
+  getDescription: (target: number, daysLeft: number) => string
+  getTarget: (character: FantasyCharacter) => number
+  getDaysAllowed: (character: FantasyCharacter) => number
+  getStartValue: (character: FantasyCharacter) => number
+}
+
+const QUEST_TEMPLATES: QuestTemplate[] = [
+  {
+    type: 'reach_distance',
+    getTitle: (target) => `Journey to Step ${target}`,
+    getDescription: (target, days) => `Travel to step ${target} within ${days} days. Keep moving!`,
+    getTarget: (char) => char.distance + 75 + Math.floor(Math.random() * 50),
+    getDaysAllowed: (char) => 3 + Math.floor(char.level / 2),
+    getStartValue: (char) => char.distance,
+  },
+  {
+    type: 'collect_gold',
+    getTitle: (target) => `Amass ${target} Gold`,
+    getDescription: (target, days) => `Accumulate at least ${target} gold within ${days} days. Trade, fight, and loot!`,
+    getTarget: (char) => char.gold + 30 + char.level * 10 + Math.floor(Math.random() * 20),
+    getDaysAllowed: () => 4 + Math.floor(Math.random() * 2),
+    getStartValue: (char) => char.gold,
+  },
+  {
+    type: 'win_combat',
+    getTitle: () => 'Prove Your Valor',
+    getDescription: (_target, days) => `Win a combat encounter within ${days} days. Seek out a fight!`,
+    getTarget: () => 1,
+    getDaysAllowed: () => 3,
+    getStartValue: () => 0,
+  },
+  {
+    type: 'gain_reputation',
+    getTitle: (target) => `Earn ${target} Reputation`,
+    getDescription: (target, days) => `Increase your reputation by ${target} within ${days} days. Make good choices!`,
+    getTarget: (char) => char.reputation + 5 + Math.floor(Math.random() * 5),
+    getDaysAllowed: () => 4 + Math.floor(Math.random() * 2),
+    getStartValue: (char) => char.reputation,
+  },
+]
+
+export function generateTimedQuest(character: FantasyCharacter): TimedQuest {
+  const template = QUEST_TEMPLATES[Math.floor(Math.random() * QUEST_TEMPLATES.length)]
+  const target = template.getTarget(character)
+  const daysAllowed = template.getDaysAllowed(character)
+  const currentDay = calculateDay(character.distance)
+  const deadlineDay = currentDay + daysAllowed
+
+  const goldReward = 15 + character.level * 10 + Math.floor(Math.random() * 10)
+  const repReward = 3 + Math.floor(Math.random() * 5)
+
+  return {
+    id: `quest-${Date.now()}-${Math.floor(Math.random() * 10000)}`,
+    title: template.getTitle(target),
+    description: template.getDescription(target, daysAllowed),
+    status: 'active',
+    type: template.type,
+    target,
+    startValue: template.getStartValue(character),
+    deadlineDay,
+    startDay: currentDay,
+    rewards: {
+      gold: goldReward,
+      reputation: repReward,
+      items: [
+        inferItemTypeAndEffects({
+          id: `quest-reward-${Date.now()}`,
+          name: character.level >= 3 ? 'Greater Healing Potion' : 'Healing Potion',
+          description: 'A reward for completing your quest.',
+          quantity: 1,
+        }),
+      ],
+    },
+  }
+}
+
+/**
+ * Check quest progress and return updated quest status.
+ */
+export function checkQuestProgress(
+  quest: TimedQuest,
+  character: FantasyCharacter,
+  combatWon: boolean = false
+): TimedQuest {
+  if (quest.status !== 'active') return quest
+
+  const currentDay = calculateDay(character.distance)
+
+  // Check completion
+  let completed = false
+  switch (quest.type) {
+    case 'reach_distance':
+      completed = character.distance >= quest.target
+      break
+    case 'collect_gold':
+      completed = character.gold >= quest.target
+      break
+    case 'win_combat':
+      completed = combatWon
+      break
+    case 'gain_reputation':
+      completed = character.reputation >= quest.target
+      break
+  }
+
+  if (completed) {
+    return { ...quest, status: 'completed' }
+  }
+
+  // Check deadline
+  if (currentDay > quest.deadlineDay) {
+    return { ...quest, status: 'failed' }
+  }
+
+  return quest
+}

--- a/src/app/tap-tap-adventure/models/quest.ts
+++ b/src/app/tap-tap-adventure/models/quest.ts
@@ -1,20 +1,26 @@
 import { z } from 'zod'
 
-/** FantasyQuestSchema is the single source of truth for both runtime validation and static typing. */
-export const FantasyQuestSchema = z.object({
+import { ItemSchema } from './item'
+
+export const TimedQuestSchema = z.object({
   id: z.string(),
   title: z.string(),
   description: z.string(),
-  status: z.enum(['available', 'active', 'completed', 'failed']),
-  giverNpcId: z.string(),
-  locationId: z.string(),
-  objectives: z.array(z.string()),
+  status: z.enum(['active', 'completed', 'failed']),
+  type: z.enum(['reach_distance', 'collect_gold', 'win_combat', 'gain_reputation']),
+  // Target value to reach
+  target: z.number(),
+  // Starting value when quest was accepted
+  startValue: z.number(),
+  // Day deadline (quest fails if current day exceeds this)
+  deadlineDay: z.number(),
+  // Day quest was accepted
+  startDay: z.number(),
+  // Rewards
   rewards: z.object({
     gold: z.number().optional(),
     reputation: z.number().optional(),
-    items: z.array(z.string()).optional(),
+    items: z.array(ItemSchema).optional(),
   }),
-  expiration: z.string().optional(),
 })
-
-export type FantasyQuest = z.infer<typeof FantasyQuestSchema>
+export type TimedQuest = z.infer<typeof TimedQuestSchema>

--- a/src/app/tap-tap-adventure/models/types.ts
+++ b/src/app/tap-tap-adventure/models/types.ts
@@ -27,7 +27,6 @@ export type {
   FantasyLocationChoiceSchema,
 } from './location'
 export type { FantasyPlayer, FantasyPlayerSchema } from './player'
-export type { FantasyQuest, FantasyQuestSchema } from './quest'
 export type {
   FantasyStoryEvent,
   FantasyStoryEventSchema,

--- a/src/app/tap-tap-adventure/models/types.ts
+++ b/src/app/tap-tap-adventure/models/types.ts
@@ -4,6 +4,7 @@ import { FantasyCharacter } from './character'
 import { CombatState } from './combat'
 import { Item } from './item'
 import { FantasyLocation } from './location'
+import { TimedQuest } from './quest'
 import { FantasyDecisionPoint, FantasyStoryEvent } from './story'
 
 export type ShopState = {
@@ -36,6 +37,7 @@ export type {
   FantasyDecisionPointSchema,
 } from './story'
 export type { Item, ItemSchema, ItemEffects, ItemEffectsSchema } from './item'
+export type { TimedQuest, TimedQuestSchema } from './quest'
 export type {
   CombatState,
   CombatEnemy,
@@ -67,6 +69,7 @@ type GameState = {
   decisionPoint: FantasyDecisionPoint | null
   combatState: CombatState | null
   shopState: ShopState | null
+  activeQuest: TimedQuest | null
   genericMessage: string | null
 }
 export type { GameState }


### PR DESCRIPTION
## Summary
Quests with time pressure that create real strategic tradeoffs — rush forward (risk combat wounded) or play safe (miss the deadline)?

### Quest Types
- **Reach Distance**: "Travel to step 275 within 3 days"
- **Collect Gold**: "Accumulate 80 gold within 4 days"
- **Win Combat**: "Win a fight within 3 days"
- **Gain Reputation**: "Reach 15 reputation within 4 days"

### How It Works
- 5% chance of quest offer per server event (after 50 steps)
- Only one active quest at a time
- Progress auto-tracked on each step and after combat
- Deadline = start day + allowed days
- Rewards: gold, reputation, and items scaled to level

### Quest Panel (right sidebar)
- **Active**: amber panel with progress bar, percentage, days-left badge (turns red at 1 day)
- **Completed**: green "Claim Rewards" panel showing what you earned
- **Failed**: red "Dismiss" panel

### Files (10 changed, 447 lines)
- New: `models/quest.ts` — `TimedQuest` schema
- New: `lib/questGenerator.ts` — generation + progress checking
- New: `components/QuestPanel.tsx` — quest display UI
- New: `__tests__/questGenerator.test.ts` — 9 tests
- Modified: `models/types.ts`, `defaultGameState.ts`, `useGameStore.ts`, `useMoveForwardMutation.ts`, `useCombatActionMutation.ts`, `GameUI.tsx`

## Test plan
- [x] 187 tests pass (19 test files)
- [ ] Travel past 50 steps, verify quest appears
- [ ] Complete a reach_distance quest, claim rewards
- [ ] Let a quest deadline expire, verify failure
- [ ] Win combat with active win_combat quest

🤖 Generated with [Claude Code](https://claude.com/claude-code)