### PR TITLE
Add stat point allocation on level up

### DIFF
--- a/src/app/tap-tap-adventure/__tests__/leveling.test.ts
+++ b/src/app/tap-tap-adventure/__tests__/leveling.test.ts
@@ -34,6 +34,7 @@ const baseChar: FantasyCharacter = {
   maxHp: 100,
   inventory: [],
   deathCount: 0,
+  pendingStatPoints: 0,
 }
 
 describe('Distance-Based Leveling (rebalanced)', () => {
@@ -146,14 +147,16 @@ describe('Distance-Based Leveling (rebalanced)', () => {
       expect(result.hp).toBe(85) // capped at maxHp
     })
 
-    it('levels up and updates maxHp', () => {
-      // At distance 250, level goes from 1 to 2, strength 5->6
-      // maxHp = 50 + 6*5 + 2*10 = 100
+    it('levels up and adds pending stat points instead of auto-applying stats', () => {
+      // At distance 250, level goes from 1 to 2
+      // Stats stay the same, pendingStatPoints increases by 3
+      // maxHp = 50 + 5*5 + 2*10 = 95
       const char = { ...baseChar, distance: 250, level: 1 }
       const result = applyLevelFromDistance(char)
       expect(result.level).toBe(2)
-      expect(result.strength).toBe(6)
-      expect(result.maxHp).toBe(100)
+      expect(result.strength).toBe(5) // unchanged
+      expect(result.pendingStatPoints).toBe(3)
+      expect(result.maxHp).toBe(95)
     })
   })
 })

--- a/src/app/tap-tap-adventure/__tests__/statAllocation.test.ts
+++ b/src/app/tap-tap-adventure/__tests__/statAllocation.test.ts
@@ -1,0 +1,180 @@
+import { describe, it, expect } from 'vitest'
+
+import {
+  applyLevelFromDistance,
+  calculateMaxHp,
+  stepsRequiredForLevel,
+  STAT_POINTS_PER_LEVEL,
+} from '@/app/tap-tap-adventure/lib/leveling'
+import { FantasyCharacter } from '@/app/tap-tap-adventure/models/character'
+
+function makeCharacter(overrides: Partial<FantasyCharacter> = {}): FantasyCharacter {
+  return {
+    id: 'test-char',
+    playerId: 'player-1',
+    name: 'Test Hero',
+    race: 'Human',
+    class: 'Warrior',
+    level: 1,
+    abilities: [],
+    locationId: 'starting-village',
+    gold: 10,
+    reputation: 0,
+    distance: 0,
+    status: 'active',
+    strength: 5,
+    intelligence: 5,
+    luck: 5,
+    hp: 100,
+    maxHp: 100,
+    inventory: [],
+    equipment: { weapon: null, armor: null, accessory: null },
+    deathCount: 0,
+    pendingStatPoints: 0,
+    ...overrides,
+  }
+}
+
+describe('Stat Allocation on Level Up', () => {
+  it('should add 3 pending stat points per level gained instead of auto-applying stats', () => {
+    const distanceForLevel2 = stepsRequiredForLevel(2)
+    const character = makeCharacter({ distance: distanceForLevel2 })
+
+    const result = applyLevelFromDistance(character)
+
+    expect(result.level).toBe(2)
+    expect(result.pendingStatPoints).toBe(STAT_POINTS_PER_LEVEL)
+    // Stats should NOT have been auto-incremented
+    expect(result.strength).toBe(5)
+    expect(result.intelligence).toBe(5)
+    expect(result.luck).toBe(5)
+  })
+
+  it('should accumulate pending stat points for multiple levels gained', () => {
+    const distanceForLevel3 = stepsRequiredForLevel(3)
+    const character = makeCharacter({ distance: distanceForLevel3 })
+
+    const result = applyLevelFromDistance(character)
+
+    expect(result.level).toBe(3)
+    expect(result.pendingStatPoints).toBe(2 * STAT_POINTS_PER_LEVEL)
+    // Stats should remain unchanged
+    expect(result.strength).toBe(5)
+    expect(result.intelligence).toBe(5)
+    expect(result.luck).toBe(5)
+  })
+
+  it('should add to existing pending stat points', () => {
+    const distanceForLevel2 = stepsRequiredForLevel(2)
+    const character = makeCharacter({
+      distance: distanceForLevel2,
+      pendingStatPoints: 3,
+    })
+
+    const result = applyLevelFromDistance(character)
+
+    expect(result.level).toBe(2)
+    expect(result.pendingStatPoints).toBe(3 + STAT_POINTS_PER_LEVEL)
+  })
+
+  it('should not add points when no level is gained', () => {
+    const character = makeCharacter({ level: 1, distance: 10 })
+
+    const result = applyLevelFromDistance(character)
+
+    expect(result.level).toBe(1)
+    expect(result.pendingStatPoints).toBe(0)
+  })
+})
+
+describe('Stat Point Allocation Application', () => {
+  it('should correctly increase stats when allocating points', () => {
+    const character = makeCharacter({
+      pendingStatPoints: 3,
+      strength: 5,
+      intelligence: 5,
+      luck: 5,
+    })
+
+    // Simulate what the store's allocateStatPoints does
+    const strAlloc = 2
+    const intAlloc = 1
+    const lckAlloc = 0
+    const totalAllocated = strAlloc + intAlloc + lckAlloc
+
+    const updated = {
+      ...character,
+      strength: character.strength + strAlloc,
+      intelligence: character.intelligence + intAlloc,
+      luck: character.luck + lckAlloc,
+      pendingStatPoints: character.pendingStatPoints - totalAllocated,
+    }
+
+    expect(updated.strength).toBe(7)
+    expect(updated.intelligence).toBe(6)
+    expect(updated.luck).toBe(5)
+    expect(updated.pendingStatPoints).toBe(0)
+  })
+
+  it('should decrease pendingStatPoints correctly', () => {
+    const character = makeCharacter({ pendingStatPoints: 6 })
+
+    const allocated = 3
+    const remaining = character.pendingStatPoints - allocated
+
+    expect(remaining).toBe(3)
+  })
+
+  it('should not allow allocating more points than available', () => {
+    const character = makeCharacter({ pendingStatPoints: 2 })
+
+    const strAlloc = 1
+    const intAlloc = 1
+    const lckAlloc = 1
+    const totalAllocated = strAlloc + intAlloc + lckAlloc
+
+    expect(totalAllocated).toBeGreaterThan(character.pendingStatPoints)
+  })
+})
+
+describe('maxHp recalculation after STR allocation', () => {
+  it('should increase maxHp when strength is increased', () => {
+    const character = makeCharacter({
+      strength: 5,
+      level: 2,
+    })
+
+    const hpBefore = calculateMaxHp(character)
+
+    const afterAllocation = {
+      ...character,
+      strength: character.strength + 2,
+    }
+
+    const hpAfter = calculateMaxHp(afterAllocation)
+
+    // Each point of STR adds 5 HP
+    expect(hpAfter - hpBefore).toBe(10)
+  })
+
+  it('should not change maxHp when only INT or LCK are increased', () => {
+    const character = makeCharacter({
+      strength: 5,
+      intelligence: 5,
+      luck: 5,
+      level: 2,
+    })
+
+    const hpBefore = calculateMaxHp(character)
+
+    const afterAllocation = {
+      ...character,
+      intelligence: character.intelligence + 2,
+      luck: character.luck + 1,
+    }
+
+    const hpAfter = calculateMaxHp(afterAllocation)
+
+    expect(hpAfter).toBe(hpBefore)
+  })
+})

--- a/src/app/tap-tap-adventure/components/GameUI.tsx
+++ b/src/app/tap-tap-adventure/components/GameUI.tsx
@@ -1,8 +1,6 @@
 'use client'
 
 import { LoaderCircle } from 'lucide-react'
-import { useCallback, useEffect, useRef, useState } from 'react'
-
 import { Button } from '@/app/tap-tap-adventure/components/ui/button'
 import { useGameStore } from '@/app/tap-tap-adventure/hooks/useGameStore'
 import { useMoveForwardMutation } from '@/app/tap-tap-adventure/hooks/useMoveForwardMutation'
@@ -13,7 +11,7 @@ import { flipCoin } from '@/app/utils'
 import { CombatUI, CombatResult } from './CombatUI'
 import { EquipmentPanel } from './EquipmentPanel'
 import { InventoryPanel } from './InventoryPanel'
-import { LevelUpCelebration } from './LevelUpCelebration'
+import { StatAllocationScreen } from './StatAllocationScreen'
 import { ShopUI } from './ShopUI'
 import { StoryFeed } from './StoryFeed'
 
@@ -36,26 +34,14 @@ export default function GameUI() {
     incrementDistance,
     setDecisionPoint,
     setCombatState,
+    allocateStatPoints,
   } = useGameStore()
 
   const { mutate: moveForwardMutation, isPending: moveForwardPending } = useMoveForwardMutation()
   const { mutate: resolveDecisionMutation, isPending: resolveDecisionPending } =
     useResolveDecisionMutation()
 
-  const [levelUpLevel, setLevelUpLevel] = useState<number | null>(null)
-  const prevLevelRef = useRef<number | null>(null)
   const character = getSelectedCharacter()
-
-  useEffect(() => {
-    if (!character) return
-    const currentLevel = character.level
-    if (prevLevelRef.current !== null && currentLevel > prevLevelRef.current) {
-      setLevelUpLevel(currentLevel)
-    }
-    prevLevelRef.current = currentLevel
-  }, [character?.level])
-
-  const dismissLevelUp = useCallback(() => setLevelUpLevel(null), [])
 
   const handleResolveDecision = (optionId: string) => {
     resolveDecisionMutation({
@@ -88,8 +74,11 @@ export default function GameUI() {
 
   return (
     <>
-      {levelUpLevel !== null && (
-        <LevelUpCelebration level={levelUpLevel} onDismiss={dismissLevelUp} />
+      {character && (character.pendingStatPoints ?? 0) > 0 && (
+        <StatAllocationScreen
+          character={character}
+          onConfirm={(str, int, lck) => allocateStatPoints(str, int, lck)}
+        />
       )}
     <div className="flex flex-col select-none">
       <div className="relative z-10 mx-auto w-full">

--- a/src/app/tap-tap-adventure/components/StatAllocationScreen.tsx
+++ b/src/app/tap-tap-adventure/components/StatAllocationScreen.tsx
@@ -1,0 +1,132 @@
+'use client'
+
+import { useState } from 'react'
+
+import { FantasyCharacter } from '@/app/tap-tap-adventure/models/character'
+
+interface StatAllocationScreenProps {
+  character: FantasyCharacter
+  onConfirm: (strength: number, intelligence: number, luck: number) => void
+}
+
+const STAT_DESCRIPTIONS: Record<string, string> = {
+  strength: 'Attack power, HP',
+  intelligence: 'Defense',
+  luck: 'Flee chance, loot drops',
+}
+
+const STAT_LABELS: Record<string, string> = {
+  strength: 'STR',
+  intelligence: 'INT',
+  luck: 'LCK',
+}
+
+export function StatAllocationScreen({ character, onConfirm }: StatAllocationScreenProps) {
+  const [allocation, setAllocation] = useState({ strength: 0, intelligence: 0, luck: 0 })
+
+  const totalAllocated = allocation.strength + allocation.intelligence + allocation.luck
+  const remaining = (character.pendingStatPoints ?? 0) - totalAllocated
+  const allSpent = remaining === 0
+
+  const addPoint = (stat: keyof typeof allocation) => {
+    if (remaining <= 0) return
+    setAllocation(prev => ({ ...prev, [stat]: prev[stat] + 1 }))
+  }
+
+  const removePoint = (stat: keyof typeof allocation) => {
+    if (allocation[stat] <= 0) return
+    setAllocation(prev => ({ ...prev, [stat]: prev[stat] - 1 }))
+  }
+
+  const handleConfirm = () => {
+    if (!allSpent) return
+    onConfirm(allocation.strength, allocation.intelligence, allocation.luck)
+  }
+
+  const stats = ['strength', 'intelligence', 'luck'] as const
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center">
+      {/* Backdrop */}
+      <div className="absolute inset-0 bg-black/60" />
+
+      {/* Content */}
+      <div className="relative w-full max-w-sm mx-4">
+        <div className="bg-gradient-to-b from-[#1e1f30] to-[#161723] border-2 border-yellow-500/50 rounded-2xl px-6 py-8 text-center shadow-2xl shadow-yellow-500/20">
+          {/* Stars */}
+          <div className="text-4xl mb-2">
+            <span className="inline-block animate-bounce" style={{ animationDelay: '0ms' }}>
+              *
+            </span>
+            <span className="inline-block animate-bounce mx-2" style={{ animationDelay: '150ms' }}>
+              *
+            </span>
+            <span className="inline-block animate-bounce" style={{ animationDelay: '300ms' }}>
+              *
+            </span>
+          </div>
+
+          {/* Title */}
+          <h2 className="text-3xl font-bold text-yellow-400 mb-1">Level Up!</h2>
+          <div className="text-5xl font-black text-white my-2">{character.level}</div>
+
+          {/* Remaining points */}
+          <p className="text-slate-300 text-sm mb-6">
+            {remaining} point{remaining !== 1 ? 's' : ''} remaining
+          </p>
+
+          {/* Stat rows */}
+          <div className="space-y-3 mb-6">
+            {stats.map(stat => (
+              <div key={stat} className="flex items-center justify-between gap-2">
+                <div className="text-left flex-1">
+                  <div className="text-white font-semibold text-sm">
+                    {STAT_LABELS[stat]}{' '}
+                    <span className="text-slate-400 font-normal">
+                      {character[stat]}
+                      {allocation[stat] > 0 && (
+                        <span className="text-green-400"> +{allocation[stat]}</span>
+                      )}
+                    </span>
+                  </div>
+                  <div className="text-slate-500 text-xs">{STAT_DESCRIPTIONS[stat]}</div>
+                </div>
+                <div className="flex items-center gap-1">
+                  <button
+                    className="w-8 h-8 rounded bg-[#2a2b3f] border border-[#3a3c56] text-white font-bold hover:bg-[#3a3c56] disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+                    onClick={() => removePoint(stat)}
+                    disabled={allocation[stat] <= 0}
+                    aria-label={`Remove point from ${STAT_LABELS[stat]}`}
+                  >
+                    -
+                  </button>
+                  <button
+                    className="w-8 h-8 rounded bg-[#2a2b3f] border border-[#3a3c56] text-white font-bold hover:bg-[#3a3c56] disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+                    onClick={() => addPoint(stat)}
+                    disabled={remaining <= 0}
+                    aria-label={`Add point to ${STAT_LABELS[stat]}`}
+                  >
+                    +
+                  </button>
+                </div>
+              </div>
+            ))}
+          </div>
+
+          {/* Confirm button */}
+          <button
+            className={`w-full py-3 rounded-xl font-bold text-lg transition-all duration-200 ${
+              allSpent
+                ? 'bg-gradient-to-r from-yellow-500 to-amber-500 text-black hover:from-yellow-400 hover:to-amber-400 shadow-lg shadow-yellow-500/20'
+                : 'bg-[#2a2b3f] text-slate-500 cursor-not-allowed border border-[#3a3c56]'
+            }`}
+            onClick={handleConfirm}
+            disabled={!allSpent}
+          >
+            {allSpent ? 'Confirm' : `Allocate ${remaining} more point${remaining !== 1 ? 's' : ''}`}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/app/tap-tap-adventure/config/gameDefaults.ts
+++ b/src/app/tap-tap-adventure/config/gameDefaults.ts
@@ -41,4 +41,5 @@ export const DEFAULT_CHARACTER = {
   maxHp: 100,
   equipment: { weapon: null, armor: null, accessory: null },
   deathCount: 0,
+  pendingStatPoints: 0,
 }

--- a/src/app/tap-tap-adventure/hooks/useGameStore.ts
+++ b/src/app/tap-tap-adventure/hooks/useGameStore.ts
@@ -5,7 +5,7 @@ import { persist } from 'zustand/middleware'
 
 import { defaultGameState } from '@/app/tap-tap-adventure/lib/defaultGameState'
 import { useItem as applyItemUse } from '@/app/tap-tap-adventure/lib/itemEffects'
-import { applyLevelFromDistance } from '@/app/tap-tap-adventure/lib/leveling'
+import { applyLevelFromDistance, calculateMaxHp } from '@/app/tap-tap-adventure/lib/leveling'
 import { FantasyCharacter } from '@/app/tap-tap-adventure/models/character'
 import { CombatState } from '@/app/tap-tap-adventure/models/combat'
 import { getEquipmentSlot, EquipmentSlotType } from '@/app/tap-tap-adventure/models/equipment'
@@ -38,11 +38,13 @@ const defaultCharacter: FantasyCharacter = {
   inventory: [],
   equipment: { weapon: null, armor: null, accessory: null },
   deathCount: 0,
+  pendingStatPoints: 0,
 }
 
 export interface GameStore {
   gameState: GameState
   addCharacter: (c: Partial<FantasyCharacter>) => void
+  allocateStatPoints: (strength: number, intelligence: number, luck: number) => void
   clearGameState: () => void
   deleteCharacter: (id: string) => void
   getSelectedCharacter: () => FantasyCharacter | null
@@ -71,6 +73,38 @@ export const useGameStore = create<GameStore>()(
             const characters = state.gameState.characters || []
             if (characters.length >= 5) return
             state.gameState.characters = [...characters, { ...defaultCharacter, ...c }]
+          })
+        )
+      },
+      allocateStatPoints: (strength: number, intelligence: number, luck: number) => {
+        set(
+          produce((state: GameStore) => {
+            const selectedCharacter = get().getSelectedCharacter()
+            if (!selectedCharacter) return
+
+            const totalAllocated = strength + intelligence + luck
+            const pending = selectedCharacter.pendingStatPoints ?? 0
+            if (totalAllocated > pending || totalAllocated <= 0) return
+
+            const characterIndex = state.gameState.characters.findIndex(
+              char => char.id === selectedCharacter.id
+            )
+            if (characterIndex === -1) return
+
+            const updatedCharacter = {
+              ...selectedCharacter,
+              strength: selectedCharacter.strength + strength,
+              intelligence: selectedCharacter.intelligence + intelligence,
+              luck: selectedCharacter.luck + luck,
+              pendingStatPoints: pending - totalAllocated,
+            }
+            const maxHp = calculateMaxHp(updatedCharacter)
+            updatedCharacter.maxHp = maxHp
+            // Also increase current HP by the same amount maxHp increased
+            const oldMaxHp = selectedCharacter.maxHp ?? maxHp
+            updatedCharacter.hp = Math.min(maxHp, (selectedCharacter.hp ?? oldMaxHp) + (maxHp - oldMaxHp))
+
+            state.gameState.characters[characterIndex] = updatedCharacter
           })
         )
       },
@@ -341,7 +375,7 @@ export const useGameStore = create<GameStore>()(
     }),
     {
       name: 'fantasy-tycoon-storage', // localStorage key (kept for backward compat)
-      version: 5,
+      version: 6,
       migrate: (persistedState: unknown) => {
         const state = persistedState as GameStore
         if (state?.gameState && !('combatState' in state.gameState)) {
@@ -363,6 +397,10 @@ export const useGameStore = create<GameStore>()(
               const maxHp = 50 + (char.strength ?? 5) * 5 + (char.level ?? 1) * 10
               ;(char as FantasyCharacter).hp = maxHp
               ;(char as FantasyCharacter).maxHp = maxHp
+            }
+            // v6: Add pending stat points
+            if (char.pendingStatPoints === undefined) {
+              ;(char as FantasyCharacter).pendingStatPoints = 0
             }
           }
         }

--- a/src/app/tap-tap-adventure/lib/leveling.ts
+++ b/src/app/tap-tap-adventure/lib/leveling.ts
@@ -75,10 +75,11 @@ export function crossedMilestone(oldDistance: number, newDistance: number, inter
   return Math.floor(newDistance / interval) > Math.floor(oldDistance / interval)
 }
 
-const STAT_BONUS_PER_LEVEL = 1
+export const STAT_POINTS_PER_LEVEL = 3
 
 /**
  * Apply level-derived stat bonuses and update maxHp.
+ * Instead of auto-applying stat increases, accumulates pending stat points.
  * Also heals 1 HP per step (called on distance change).
  */
 export function applyLevelFromDistance(
@@ -93,9 +94,7 @@ export function applyLevelFromDistance(
     updated = {
       ...updated,
       level: newLevel,
-      strength: character.strength + levelsGained * STAT_BONUS_PER_LEVEL,
-      intelligence: character.intelligence + levelsGained * STAT_BONUS_PER_LEVEL,
-      luck: character.luck + levelsGained * STAT_BONUS_PER_LEVEL,
+      pendingStatPoints: (character.pendingStatPoints ?? 0) + levelsGained * STAT_POINTS_PER_LEVEL,
     }
   } else if (newLevel < character.level) {
     updated.level = newLevel

--- a/src/app/tap-tap-adventure/models/character.ts
+++ b/src/app/tap-tap-adventure/models/character.ts
@@ -38,6 +38,7 @@ export const FantasyCharacterSchema = z.object({
     accessory: ItemSchema.nullable(),
   }).optional(),
   deathCount: z.number().default(0),
+  pendingStatPoints: z.number().default(0),
 })
 export type FantasyCharacter = z.infer<typeof FantasyCharacterSchema>
 


### PR DESCRIPTION
## Summary
- Replace auto-stat increases (+1 STR/INT/LCK per level) with a pending stat points system that grants 3 allocatable points per level
- Add interactive `StatAllocationScreen` overlay with +/- buttons for each stat, replacing the old auto-dismiss `LevelUpCelebration`
- Add `allocateStatPoints` store action with maxHp recalculation, store migration v6, and comprehensive tests

## Test plan
- [x] All 198 existing + new tests pass (`npx vitest run`)
- [ ] Verify leveling up shows the stat allocation screen instead of the old celebration overlay
- [ ] Verify all 3 points must be allocated before confirming
- [ ] Verify stats increase correctly after allocation
- [ ] Verify HP increases when STR points are allocated
- [ ] Verify existing saved games migrate correctly (pendingStatPoints defaults to 0)

Generated with [Claude Code](https://claude.com/claude-code)