### PR TITLE
fix: slower heal rate + full heal on level up

### DIFF
--- a/src/app/tap-tap-adventure/__tests__/leveling.test.ts
+++ b/src/app/tap-tap-adventure/__tests__/leveling.test.ts
@@ -134,33 +134,34 @@ describe('Distance-Based Leveling (rebalanced)', () => {
   })
 
   describe('applyLevelFromDistance', () => {
-    it('heals 1 HP every 3 steps', () => {
-      const char = { ...baseChar, distance: 10, hp: 50, maxHp: 53 }
-      // 1 step = no heal (1/3 = 0)
+    it('heals 1 HP every 10 steps', () => {
+      const char = { ...baseChar, distance: 10, hp: 40, maxHp: 53 }
+      // 1 step = no heal
       const result1 = applyLevelFromDistance(char, 1)
-      expect(result1.hp).toBe(50)
-      // 3 steps = 1 heal
-      const result3 = applyLevelFromDistance(char, 3)
-      expect(result3.hp).toBe(51)
+      expect(result1.hp).toBe(40)
+      // 9 steps = no heal
+      const result9 = applyLevelFromDistance(char, 9)
+      expect(result9.hp).toBe(40)
+      // 10 steps = 1 heal
+      const result10 = applyLevelFromDistance(char, 10)
+      expect(result10.hp).toBe(41)
     })
 
     it('does not heal past maxHp', () => {
-      // maxHp for level 1, strength 5 = 30 + 15 + 8 = 53
       const char = { ...baseChar, distance: 10, hp: 52, maxHp: 53 }
-      const result = applyLevelFromDistance(char, 6) // would heal 2, but capped
+      const result = applyLevelFromDistance(char, 30) // would heal 3, but capped at 53
       expect(result.hp).toBe(53)
     })
 
-    it('levels up and adds pending stat points instead of auto-applying stats', () => {
+    it('fully heals HP and mana on level up', () => {
       // At distance 250, level goes from 1 to 2
-      // Stats stay the same, pendingStatPoints increases by 3
-      // maxHp = 30 + 5*3 + 2*8 = 61
-      const char = { ...baseChar, distance: 250, level: 1 }
+      const char = { ...baseChar, distance: 250, level: 1, hp: 10, mana: 5 }
       const result = applyLevelFromDistance(char)
       expect(result.level).toBe(2)
-      expect(result.strength).toBe(5) // unchanged
       expect(result.pendingStatPoints).toBe(3)
-      expect(result.maxHp).toBe(61)
+      // Should be fully healed
+      expect(result.hp).toBe(result.maxHp)
+      expect(result.mana).toBe(result.maxMana)
     })
   })
 })

--- a/src/app/tap-tap-adventure/lib/leveling.ts
+++ b/src/app/tap-tap-adventure/lib/leveling.ts
@@ -79,7 +79,7 @@ export function calculateMaxMana(character: FantasyCharacter): number {
 }
 
 const MANA_REGEN_BASE_RATE = 5 // base: 1 mana every 5 steps
-const HEAL_RATE = 3 // heal 1 HP every N steps
+const HEAL_RATE = 10 // heal 1 HP every N steps
 
 /**
  * Check if a step milestone was just crossed.
@@ -102,7 +102,9 @@ export function applyLevelFromDistance(
   const newLevel = calculateLevel(character.distance)
   let updated = { ...character }
 
-  if (newLevel > character.level) {
+  const leveledUp = newLevel > character.level
+
+  if (leveledUp) {
     const levelsGained = newLevel - character.level
     updated = {
       ...updated,
@@ -113,14 +115,26 @@ export function applyLevelFromDistance(
     updated.level = newLevel
   }
 
-  // Update maxHp and heal (1 HP every HEAL_RATE steps)
+  // Update maxHp and maxMana
   const maxHp = calculateMaxHp(updated)
+  const maxMana = calculateMaxMana(updated)
+
+  // Level up: full heal HP and mana
+  if (leveledUp) {
+    return {
+      ...updated,
+      hp: maxHp,
+      maxHp,
+      mana: maxMana,
+      maxMana,
+    }
+  }
+
+  // Normal walking: slow regen
   const currentHp = updated.hp ?? maxHp
   const healAmount = Math.floor(stepsGained / HEAL_RATE)
   const healed = Math.min(maxHp, currentHp + healAmount)
 
-  // Update maxMana and regen mana
-  const maxMana = calculateMaxMana(updated)
   const classConfig = CLASS_SPELL_CONFIG[updated.class.toLowerCase()]
   const regenMultiplier = classConfig?.regenMultiplier ?? 1
   const effectiveRegenRate = Math.max(1, Math.floor(MANA_REGEN_BASE_RATE / regenMultiplier))


### PR DESCRIPTION
## Summary
Two balance fixes:

- **B4**: Full HP and mana restore on level-up
- **B5**: Walking heal slowed from 1 HP/3 steps to 1 HP/10 steps

Full heal at ~53 HP now takes ~530 steps instead of ~159. Healing potions are genuinely valuable now. But leveling up is a full reset — a satisfying milestone.

## Test plan
- [x] 257 tests pass
- [ ] Walk and verify slow heal rate
- [ ] Level up and verify full HP/mana restore

🤖 Generated with [Claude Code](https://claude.com/claude-code)