### PR TITLE
fix: walking heal bug — single taps never healed

### DIFF
--- a/src/app/tap-tap-adventure/__tests__/leveling.test.ts
+++ b/src/app/tap-tap-adventure/__tests__/leveling.test.ts
@@ -134,22 +134,21 @@ describe('Distance-Based Leveling (rebalanced)', () => {
   })
 
   describe('applyLevelFromDistance', () => {
-    it('heals 1 HP every 10 steps', () => {
-      const char = { ...baseChar, distance: 10, hp: 40, maxHp: 53 }
-      // 1 step = no heal
-      const result1 = applyLevelFromDistance(char, 1)
-      expect(result1.hp).toBe(40)
-      // 9 steps = no heal
-      const result9 = applyLevelFromDistance(char, 9)
-      expect(result9.hp).toBe(40)
-      // 10 steps = 1 heal
-      const result10 = applyLevelFromDistance(char, 10)
-      expect(result10.hp).toBe(41)
+    it('heals 1 HP every 10 steps using distance thresholds', () => {
+      // Distance 10, stepped from 9: crosses 10-step boundary → heals
+      const charCrossing = { ...baseChar, distance: 10, hp: 40, maxHp: 53 }
+      const result1 = applyLevelFromDistance(charCrossing, 1)
+      expect(result1.hp).toBe(41)
+
+      // Distance 12, stepped from 11: no boundary → no heal
+      const charNoCross = { ...baseChar, distance: 12, hp: 40, maxHp: 53 }
+      const result2 = applyLevelFromDistance(charNoCross, 1)
+      expect(result2.hp).toBe(40)
     })
 
     it('does not heal past maxHp', () => {
-      const char = { ...baseChar, distance: 10, hp: 52, maxHp: 53 }
-      const result = applyLevelFromDistance(char, 30) // would heal 3, but capped at 53
+      const char = { ...baseChar, distance: 20, hp: 53, maxHp: 53 }
+      const result = applyLevelFromDistance(char, 1)
       expect(result.hp).toBe(53)
     })
 

--- a/src/app/tap-tap-adventure/lib/leveling.ts
+++ b/src/app/tap-tap-adventure/lib/leveling.ts
@@ -130,17 +130,19 @@ export function applyLevelFromDistance(
     }
   }
 
-  // Normal walking: slow regen
+  // Normal walking: slow regen using distance-based thresholds
+  // Uses floor(newDist/rate) - floor(oldDist/rate) so single-step increments work
+  const oldDistance = updated.distance - stepsGained
   const currentHp = updated.hp ?? maxHp
-  const healAmount = Math.floor(stepsGained / HEAL_RATE)
-  const healed = Math.min(maxHp, currentHp + healAmount)
+  const healTicks = Math.floor(updated.distance / HEAL_RATE) - Math.floor(oldDistance / HEAL_RATE)
+  const healed = Math.min(maxHp, currentHp + Math.max(0, healTicks))
 
   const classConfig = CLASS_SPELL_CONFIG[updated.class.toLowerCase()]
   const regenMultiplier = classConfig?.regenMultiplier ?? 1
   const effectiveRegenRate = Math.max(1, Math.floor(MANA_REGEN_BASE_RATE / regenMultiplier))
   const currentMana = updated.mana ?? maxMana
-  const manaRegenAmount = Math.floor(stepsGained / effectiveRegenRate)
-  const regenedMana = Math.min(maxMana, currentMana + manaRegenAmount)
+  const manaTicks = Math.floor(updated.distance / effectiveRegenRate) - Math.floor(oldDistance / effectiveRegenRate)
+  const regenedMana = Math.min(maxMana, currentMana + Math.max(0, manaTicks))
 
   return {
     ...updated,


### PR DESCRIPTION
## Summary
Walking heal was broken: `Math.floor(1 / 10) = 0` meant single-step taps never healed. Fixed to use distance-based thresholds.

**Before**: `Math.floor(stepsGained / HEAL_RATE)` → always 0 for single steps
**After**: `floor(distance / 10) - floor((distance-1) / 10)` → ticks to 1 every 10th step

Same fix applied to mana regen.

## Test plan
- [x] 257 tests pass
- [ ] Walk 10 steps and verify HP increases by 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)