### PR TITLE
fix: 97/3 event rate + fullscreen game on mobile

### DIFF
--- a/src/app/tap-tap-adventure/components/GameUI.tsx
+++ b/src/app/tap-tap-adventure/components/GameUI.tsx
@@ -63,7 +63,7 @@ export default function GameUI() {
   }
 
   const handleMoveForward = () => {
-    const shouldDoNothing = flipCoin(0.05, 0.95)
+    const shouldDoNothing = flipCoin(0.03, 0.97)
     if (shouldDoNothing) {
       const genericMessage = getGenericTravelMessage()
       setGenericMessage(genericMessage)

--- a/src/app/tap-tap-adventure/components/ui/Navigation.tsx
+++ b/src/app/tap-tap-adventure/components/ui/Navigation.tsx
@@ -11,7 +11,13 @@ export const Navigation = ({ pageId }: { pageId: string }) => {
     `${baseClasses} ${pageId === id ? activeClasses : inactiveClasses}`
 
   return (
-    <div className="flex space-x-2">
+    <div className="flex space-x-2 items-center">
+      <Link
+        href="/"
+        className="md:hidden rounded-md border border-[#3a3c56] px-3 py-2 text-gray-400 hover:text-white hover:bg-[#2a2b3f] transition-colors text-sm"
+      >
+        Home
+      </Link>
       <Link href="/tap-tap-adventure/characters" className={className('characters')}>
         Characters
       </Link>

--- a/src/app/tap-tap-adventure/layout.tsx
+++ b/src/app/tap-tap-adventure/layout.tsx
@@ -1,3 +1,7 @@
 export default function TapTapAdventureLayout({ children }: { children: React.ReactNode }) {
-  return <div className="w-full min-h-[700px] shadow-2xl">{children}</div>
+  return (
+    <div className="w-full md:min-h-[700px] md:shadow-2xl fixed md:relative inset-0 md:inset-auto z-40 md:z-auto bg-space-black md:bg-transparent overflow-y-auto">
+      {children}
+    </div>
+  )
 }


### PR DESCRIPTION
## Summary
Two fixes:

### Event Rate
97% travel / 3% encounters (was 95/5).

### Mobile Fullscreen
Game layout is `fixed inset-0` on mobile — covers header/footer entirely. Normal layout on desktop. Added "Home" link to in-game nav (mobile only).

## Test plan
- [x] 257 tests pass
- [ ] Mobile: no footer overlap
- [ ] Desktop: layout unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)