### PR TITLE
fix: fullscreen overlay z-index, scroll, padding

### DIFF
--- a/src/app/tap-tap-adventure/layout.tsx
+++ b/src/app/tap-tap-adventure/layout.tsx
@@ -1,6 +1,6 @@
 export default function TapTapAdventureLayout({ children }: { children: React.ReactNode }) {
   return (
-    <div className="w-full md:min-h-[700px] md:shadow-2xl fixed md:relative inset-0 md:inset-auto z-40 md:z-auto bg-space-black md:bg-transparent overflow-y-auto">
+    <div className="w-full md:min-h-[700px] md:shadow-2xl fixed md:relative inset-0 md:inset-auto z-[100] md:z-auto bg-space-black md:bg-transparent overflow-y-auto pt-4 md:pt-0">
       {children}
     </div>
   )


### PR DESCRIPTION
## Summary
The fullscreen mobile overlay was behind the footer and lacked padding.

- `z-40` → `z-[100]` — above all site elements
- Added `pt-4 md:pt-0` — top padding on mobile only
- `overflow-y-auto` + `inset-0` already enables scroll

🤖 Generated with [Claude Code](https://claude.com/claude-code)