### PR TITLE
fix: mobile overlay scroll and footer overlap (take 2)

### DIFF
--- a/src/app/tap-tap-adventure/layout.tsx
+++ b/src/app/tap-tap-adventure/layout.tsx
@@ -1,7 +1,16 @@
 export default function TapTapAdventureLayout({ children }: { children: React.ReactNode }) {
   return (
-    <div className="w-full md:min-h-[700px] md:shadow-2xl fixed md:relative inset-0 md:inset-auto z-[100] md:z-auto bg-space-black md:bg-transparent overflow-y-auto pt-4 md:pt-0">
-      {children}
-    </div>
+    <>
+      {/* Mobile: fullscreen overlay that covers everything */}
+      <div className="md:hidden fixed inset-0 z-[100] bg-space-black overflow-y-auto">
+        <div className="min-h-full px-4 pt-4 pb-8">
+          {children}
+        </div>
+      </div>
+      {/* Desktop: normal layout */}
+      <div className="hidden md:block w-full min-h-[700px] shadow-2xl">
+        {children}
+      </div>
+    </>
   )
 }


### PR DESCRIPTION
## Summary
Follow-up to PR #71 — the overlay still wasn't scrolling or covering the footer properly.

Split into two separate renderings instead of responsive classes:
- **Mobile**: `fixed inset-0 z-[100]` with inner `min-h-full` scrollable div + padding (px-4, pt-4, pb-8)
- **Desktop**: normal `block` layout, no overlay

The single-div responsive approach failed because `overflow-y-auto` on a `fixed` element needs proper inner content structure to scroll.

🤖 Generated with [Claude Code](https://claude.com/claude-code)