### PR TITLE
fix: mobile game layout — hide header/footer, enable scroll

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -16,6 +16,24 @@ body {
   }
 }
 
+/* When game is active on mobile, hide site chrome and fix scrolling */
+@media (max-width: 767px) {
+  body.game-active header,
+  body.game-active footer {
+    display: none !important;
+  }
+
+  /* Remove overflow-hidden that prevents scrolling */
+  body.game-active #site-wrapper {
+    overflow: visible !important;
+  }
+
+  body.game-active main {
+    padding: 0.5rem !important;
+    max-width: 100% !important;
+  }
+}
+
 @layer base {
   :root {
     --background: 0 0% 100%;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -27,7 +27,7 @@ export default function RootLayout({
     <Providers>
       <html lang="en">
         <body className={spaceGrotesk.className}>
-          <div className="min-h-screen flex flex-col bg-space-black text-cream-white relative overflow-hidden">
+          <div id="site-wrapper" className="min-h-screen flex flex-col bg-space-black text-cream-white relative overflow-hidden">
             <StarField />
             <header className="p-4 z-10 relative">
               <div className="container mx-auto flex justify-between items-center flex-col md:flex-row">

--- a/src/app/tap-tap-adventure/layout.tsx
+++ b/src/app/tap-tap-adventure/layout.tsx
@@ -1,16 +1,17 @@
+'use client'
+
+import { useEffect } from 'react'
+
 export default function TapTapAdventureLayout({ children }: { children: React.ReactNode }) {
+  // On mobile, hide site header/footer and make body scrollable
+  useEffect(() => {
+    document.body.classList.add('game-active')
+    return () => document.body.classList.remove('game-active')
+  }, [])
+
   return (
-    <>
-      {/* Mobile: fullscreen overlay that covers everything */}
-      <div className="md:hidden fixed inset-0 z-[100] bg-space-black overflow-y-auto">
-        <div className="min-h-full px-4 pt-4 pb-8">
-          {children}
-        </div>
-      </div>
-      {/* Desktop: normal layout */}
-      <div className="hidden md:block w-full min-h-[700px] shadow-2xl">
-        {children}
-      </div>
-    </>
+    <div className="w-full md:min-h-[700px] md:shadow-2xl">
+      {children}
+    </div>
   )
 }


### PR DESCRIPTION
## Summary
Third attempt at fixing mobile game layout. Previous overlay approaches failed because the root layout's \`overflow-hidden\` prevents scrolling.

### New approach
- Game layout adds \`game-active\` class to \`<body>\` on mount (removed on unmount)
- CSS \`@media (max-width: 767px)\` hides \`header\` and \`footer\` when class is present
- Overrides \`overflow-hidden\` on \`#site-wrapper\` to \`overflow: visible\`
- Content scrolls naturally — no overlay, no fixed positioning

### Changes
- \`layout.tsx\`: \`useEffect\` to toggle body class
- \`globals.css\`: media query rules for \`body.game-active\`
- \`layout.tsx\` (root): added \`id="site-wrapper"\` to target div

## Test plan
- [x] 281 tests pass
- [ ] Mobile: header/footer hidden, content scrolls
- [ ] Mobile: class selection cards visible and scrollable
- [ ] Desktop: unchanged
- [ ] Navigating away from game restores header/footer

🤖 Generated with [Claude Code](https://claude.com/claude-code)