### PR TITLE
fix: enable mobile scroll (min-height + flex override)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -23,14 +23,17 @@ body {
     display: none !important;
   }
 
-  /* Remove overflow-hidden that prevents scrolling */
+  /* Remove overflow-hidden and flex constraints that prevent scrolling */
   body.game-active #site-wrapper {
     overflow: visible !important;
+    min-height: auto !important;
+    height: auto !important;
   }
 
   body.game-active main {
     padding: 0.5rem !important;
     max-width: 100% !important;
+    flex: none !important;
   }
 }
 


### PR DESCRIPTION
## Summary
Follow-up to PR #73. Header/footer hiding works but content still can't scroll.

Root cause: `min-h-screen` + `flex-1` constrain content within the viewport even after removing `overflow-hidden`.

Fix: override `min-height`, `height` to `auto` on `#site-wrapper`, and `flex: none` on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)