### PR TITLE
fix: mobile scroll — overflow-y: auto instead of visible

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -23,17 +23,12 @@ body {
     display: none !important;
   }
 
-  /* Remove overflow-hidden and flex constraints that prevent scrolling */
   body.game-active #site-wrapper {
-    overflow: visible !important;
-    min-height: auto !important;
-    height: auto !important;
+    overflow-y: auto !important;
   }
 
   body.game-active main {
     padding: 0.5rem !important;
-    max-width: 100% !important;
-    flex: none !important;
   }
 }
 


### PR DESCRIPTION
## Summary
Simplify the mobile scroll fix. Previous attempts broke the layout by removing min-height/flex constraints.

The correct fix: just change \`overflow-hidden\` to \`overflow-y: auto\` on \`#site-wrapper\`. Keeps the full-viewport layout but allows scrolling when content overflows (class selection cards, etc.).

Removed the \`min-height: auto\`, \`height: auto\`, \`flex: none\`, and \`max-width: 100%\` overrides that were causing the layout to not fill the viewport.

🤖 Generated with [Claude Code](https://claude.com/claude-code)