### PR TITLE
fix: class selection modal scrolls on overflow

### DIFF
--- a/src/app/tap-tap-adventure/components/CharacterList.tsx
+++ b/src/app/tap-tap-adventure/components/CharacterList.tsx
@@ -55,8 +55,9 @@ export default function CharacterList() {
         {characters.length < 5 && <AddCharacterCard onClick={handleNewCharacter} />}
       </div>
       {showCreation && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 backdrop-blur-sm">
-          <div className="bg-[#161723] border border-[#3a3c56] rounded-lg p-6 shadow-2xl w-full max-w-md relative">
+        <div className="fixed inset-0 z-50 overflow-y-auto bg-black/70 backdrop-blur-sm">
+          <div className="min-h-full flex items-center justify-center py-8 px-4">
+            <div className="bg-[#161723] border border-[#3a3c56] rounded-lg p-6 shadow-2xl w-full max-w-md relative">
             <button
               type="button"
               className="absolute top-3 right-3 text-slate-400 hover:text-slate-200 transition-colors text-3xl leading-none font-semibold"
@@ -66,6 +67,7 @@ export default function CharacterList() {
               &times;
             </button>
             <CharacterCreation onComplete={handleCloseCreation} />
+            </div>
           </div>
         </div>
       )}


### PR DESCRIPTION
## Summary
The character creation modal (class selection step) couldn't scroll because the \`fixed\` container used \`items-center justify-center\` which clipped content taller than the viewport.

Restructured the modal:
- **Outer**: \`fixed inset-0 overflow-y-auto\` — the scrollable layer
- **Middle**: \`min-h-full flex items-center justify-center py-8\` — centers when content fits
- **Inner**: the modal card itself

Centers when content fits viewport, scrolls when it overflows. This is the standard scrollable modal pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)