### PR TITLE
fix: add dedicated heal effect for healing items

### DIFF
--- a/src/app/tap-tap-adventure/__tests__/combatEngine.test.ts
+++ b/src/app/tap-tap-adventure/__tests__/combatEngine.test.ts
@@ -32,7 +32,7 @@ const baseChar: FantasyCharacter = {
       description: 'Heals',
       quantity: 2,
       type: 'consumable',
-      effects: { strength: 2 },
+      effects: { heal: 10 },
     },
   ],
 }
@@ -188,7 +188,7 @@ describe('Combat Engine', () => {
       )
 
       expect(consumedItemId).toBe('potion-1')
-      // Healing potion with strength: 2 heals 10 HP (2 * 5)
+      // Healing potion with heal: 10 restores 10 HP directly
       expect(result.playerState.hp).toBeGreaterThan(50)
       vi.restoreAllMocks()
     })

--- a/src/app/tap-tap-adventure/__tests__/combatItemEffects.test.ts
+++ b/src/app/tap-tap-adventure/__tests__/combatItemEffects.test.ts
@@ -42,6 +42,18 @@ describe('combatItemEffects', () => {
       expect(isUsableInCombat(item)).toBe(true)
     })
 
+    it('returns true for consumable with heal effect', () => {
+      const item: Item = {
+        id: '1',
+        name: 'Healing Potion',
+        description: 'test',
+        quantity: 1,
+        type: 'consumable',
+        effects: { heal: 15 },
+      }
+      expect(isUsableInCombat(item)).toBe(true)
+    })
+
     it('returns false for consumable with only gold effect', () => {
       const item: Item = {
         id: '1',
@@ -79,17 +91,16 @@ describe('combatItemEffects', () => {
   })
 
   describe('applyCombatItemEffect', () => {
-    it('heals HP from strength effect', () => {
+    it('heals HP from heal effect', () => {
       const item: Item = {
         id: '1',
         name: 'Healing Potion',
         description: 'test',
         quantity: 1,
         type: 'consumable',
-        effects: { strength: 3 },
+        effects: { heal: 15 },
       }
       const { playerState, description } = applyCombatItemEffect(item, basePlayerState)
-      // strength: 3 -> heals 15 HP
       expect(playerState.hp).toBe(65)
       expect(description).toContain('restored 15 HP')
     })
@@ -102,10 +113,27 @@ describe('combatItemEffects', () => {
         description: 'test',
         quantity: 1,
         type: 'consumable',
-        effects: { strength: 10 },
+        effects: { heal: 50 },
       }
       const { playerState } = applyCombatItemEffect(item, fullHpState)
       expect(playerState.hp).toBe(100)
+    })
+
+    it('adds attack buff from strength effect', () => {
+      const item: Item = {
+        id: '1',
+        name: 'Strength Potion',
+        description: 'test',
+        quantity: 1,
+        type: 'consumable',
+        effects: { strength: 3 },
+      }
+      const { playerState, description } = applyCombatItemEffect(item, basePlayerState)
+      expect(playerState.hp).toBe(50) // HP unchanged
+      expect(playerState.activeBuffs).toHaveLength(1)
+      expect(playerState.activeBuffs![0].stat).toBe('attack')
+      expect(playerState.activeBuffs![0].value).toBe(6) // 3 * 2
+      expect(description).toContain('+6 attack for 3 turns')
     })
 
     it('adds defense buff from intelligence effect', () => {
@@ -148,11 +176,11 @@ describe('combatItemEffects', () => {
         description: 'test',
         quantity: 1,
         type: 'consumable',
-        effects: { strength: 2, intelligence: 1, luck: 1 },
+        effects: { heal: 10, strength: 2, intelligence: 1, luck: 1 },
       }
       const { playerState } = applyCombatItemEffect(item, basePlayerState)
       expect(playerState.hp).toBe(60) // healed 10
-      expect(playerState.activeBuffs).toHaveLength(2) // defense + attack buffs
+      expect(playerState.activeBuffs).toHaveLength(3) // strength attack + defense + luck attack buffs
     })
   })
 })

--- a/src/app/tap-tap-adventure/__tests__/itemEffects.test.ts
+++ b/src/app/tap-tap-adventure/__tests__/itemEffects.test.ts
@@ -33,7 +33,7 @@ function makeConsumable(overrides: Partial<Item> = {}): Item {
     description: 'Restores health',
     quantity: 3,
     type: 'consumable',
-    effects: { strength: 2, luck: 1 },
+    effects: { heal: 10, luck: 1 },
     ...overrides,
   }
 }
@@ -45,7 +45,7 @@ describe('Item Effects', () => {
     const result = useItem(char, item)
 
     expect(result.consumed).toBe(true)
-    // Strength effect now heals HP (2 * 5 = 10 HP)
+    // Heal effect restores 10 HP directly
     expect(result.character.hp).toBe(60) // 50 + 10
     expect(result.character.luck).toBe(6) // 5 + 1
     expect(result.message).toContain('+10 HP')
@@ -112,18 +112,47 @@ describe('Item Effects', () => {
 
   it('applies multiple effects simultaneously', () => {
     const item = makeConsumable({
-      effects: { gold: 10, reputation: 5, strength: 1, intelligence: 2, luck: 3 },
+      effects: { gold: 10, reputation: 5, heal: 15, strength: 1, intelligence: 2, luck: 3 },
     })
     const char = { ...baseChar, inventory: [item] }
     const result = useItem(char, item)
 
     expect(result.character.gold).toBe(60)
     expect(result.character.reputation).toBe(15)
-    // Strength heals HP now (1 * 5 = 5 HP)
-    expect(result.character.hp).toBe(55) // 50 + 5
+    expect(result.character.hp).toBe(65) // 50 + 15 heal
+    expect(result.character.strength).toBe(6) // 5 + 1 strength
     expect(result.character.intelligence).toBe(7)
     expect(result.character.luck).toBe(8)
     expect(result.consumed).toBe(true)
+  })
+
+  it('strength effect adds to strength stat (not HP)', () => {
+    const item = makeConsumable({ effects: { strength: 3 } })
+    const char = { ...baseChar, inventory: [item] }
+    const result = useItem(char, item)
+
+    expect(result.character.strength).toBe(8) // 5 + 3
+    expect(result.character.hp).toBe(50) // unchanged
+    expect(result.message).toContain('+3 Strength')
+  })
+
+  it('heal effect restores HP directly', () => {
+    const item = makeConsumable({ effects: { heal: 20 } })
+    const char = { ...baseChar, inventory: [item] }
+    const result = useItem(char, item)
+
+    expect(result.character.hp).toBe(70) // 50 + 20
+    expect(result.character.strength).toBe(5) // unchanged
+    expect(result.message).toContain('+20 HP')
+  })
+
+  it('heal effect does not exceed maxHp', () => {
+    const item = makeConsumable({ effects: { heal: 100 } })
+    const char = { ...baseChar, hp: 90, inventory: [item] }
+    const result = useItem(char, item)
+
+    expect(result.character.hp).toBe(100) // capped at maxHp
+    expect(result.message).toContain('+10 HP')
   })
 
   it('rejects deleted items', () => {

--- a/src/app/tap-tap-adventure/__tests__/itemPostProcessor.test.ts
+++ b/src/app/tap-tap-adventure/__tests__/itemPostProcessor.test.ts
@@ -15,11 +15,11 @@ function makeItem(overrides: Partial<Item> = {}): Item {
 
 describe('itemPostProcessor', () => {
   describe('potions', () => {
-    it('infers healing potion as consumable with strength effect', () => {
+    it('infers healing potion as consumable with heal effect', () => {
       const item = makeItem({ name: 'Healing Potion' })
       const result = inferItemTypeAndEffects(item)
       expect(result.type).toBe('consumable')
-      expect(result.effects?.strength).toBe(2)
+      expect(result.effects?.heal).toBe(10)
     })
 
     it('infers strength potion', () => {
@@ -43,11 +43,11 @@ describe('itemPostProcessor', () => {
       expect(result.effects?.luck).toBe(2)
     })
 
-    it('defaults unknown potion to strength+intelligence', () => {
+    it('defaults unknown potion to heal+intelligence', () => {
       const item = makeItem({ name: 'Mysterious Potion' })
       const result = inferItemTypeAndEffects(item)
       expect(result.type).toBe('consumable')
-      expect(result.effects?.strength).toBe(1)
+      expect(result.effects?.heal).toBe(5)
       expect(result.effects?.intelligence).toBe(1)
     })
   })
@@ -69,11 +69,11 @@ describe('itemPostProcessor', () => {
   })
 
   describe('food', () => {
-    it('infers bread as consumable', () => {
+    it('infers bread as consumable with heal', () => {
       const item = makeItem({ name: 'Loaf of Bread' })
       const result = inferItemTypeAndEffects(item)
       expect(result.type).toBe('consumable')
-      expect(result.effects?.strength).toBe(1)
+      expect(result.effects?.heal).toBe(5)
     })
   })
 

--- a/src/app/tap-tap-adventure/lib/combatGenerator.ts
+++ b/src/app/tap-tap-adventure/lib/combatGenerator.ts
@@ -48,6 +48,7 @@ const enemySchemaForOpenAI = {
                   strength: { type: 'number' },
                   intelligence: { type: 'number' },
                   luck: { type: 'number' },
+                  heal: { type: 'number', description: 'Directly restores this amount of HP. Use for healing items instead of strength.' },
                 },
               },
             },
@@ -99,7 +100,7 @@ Stat guidelines for a level ${character.level} character:
 - Enemy attack: ${6 + character.level * 3} (±20%)
 - Enemy defense: ${2 + character.level} (±20%)
 - Gold reward: ${5 + character.level * 5}
-- Include 1-2 loot items (potions, scrolls, gems, etc.)
+- Include 1-2 loot items (potions, scrolls, gems, etc.). For healing items, use the 'heal' effect (e.g., heal: 15 restores 15 HP). The 'strength' effect permanently increases the strength stat.
 - Optionally include a special ability with cooldown of 2-4 turns
 
 Reputation context: This character's reputation is ${character.reputation} (${getReputationTier(character.reputation)}).

--- a/src/app/tap-tap-adventure/lib/combatItemEffects.ts
+++ b/src/app/tap-tap-adventure/lib/combatItemEffects.ts
@@ -3,8 +3,8 @@ import { Item } from '@/app/tap-tap-adventure/models/item'
 
 export function isUsableInCombat(item: Item): boolean {
   if (item.type !== 'consumable' || !item.effects) return false
-  const { strength, intelligence, luck } = item.effects
-  return !!(strength || intelligence || luck)
+  const { strength, intelligence, luck, heal } = item.effects
+  return !!(strength || intelligence || luck || heal)
 }
 
 export function applyCombatItemEffect(
@@ -18,15 +18,24 @@ export function applyCombatItemEffect(
   const updated = { ...playerState, activeBuffs: [...(playerState.activeBuffs ?? [])] }
   const parts: string[] = []
 
-  // Strength effect → heal HP
-  if (item.effects.strength) {
-    const healAmount = item.effects.strength * 5
+  // Heal effect → restore HP directly
+  if (item.effects.heal) {
     const oldHp = updated.hp
-    updated.hp = Math.min(updated.maxHp, updated.hp + healAmount)
+    updated.hp = Math.min(updated.maxHp, updated.hp + item.effects.heal)
     const actualHeal = updated.hp - oldHp
     if (actualHeal > 0) {
       parts.push(`restored ${actualHeal} HP`)
     }
+  }
+
+  // Strength effect → attack buff
+  if (item.effects.strength) {
+    updated.activeBuffs.push({
+      stat: 'attack',
+      value: item.effects.strength * 2,
+      turnsRemaining: 3,
+    })
+    parts.push(`+${item.effects.strength * 2} attack for 3 turns`)
   }
 
   // Intelligence effect → defense buff

--- a/src/app/tap-tap-adventure/lib/itemEffects.ts
+++ b/src/app/tap-tap-adventure/lib/itemEffects.ts
@@ -36,16 +36,18 @@ export function useItem(character: FantasyCharacter, item: Item): UseItemResult 
     updatedCharacter.reputation += effects.reputation
     effectMessages.push(`${effects.reputation > 0 ? '+' : ''}${effects.reputation} Reputation`)
   }
-  if (effects.strength) {
-    // Strength potions heal HP (strength * 5) instead of boosting stat permanently
-    const healAmount = effects.strength * 5
+  if (effects.heal) {
     const maxHp = updatedCharacter.maxHp ?? 100
     const oldHp = updatedCharacter.hp ?? maxHp
-    updatedCharacter.hp = Math.min(maxHp, oldHp + healAmount)
+    updatedCharacter.hp = Math.min(maxHp, oldHp + effects.heal)
     const actualHeal = (updatedCharacter.hp ?? 0) - oldHp
     if (actualHeal > 0) {
       effectMessages.push(`+${actualHeal} HP`)
     }
+  }
+  if (effects.strength) {
+    updatedCharacter.strength += effects.strength
+    effectMessages.push(`${effects.strength > 0 ? '+' : ''}${effects.strength} Strength`)
   }
   if (effects.intelligence) {
     updatedCharacter.intelligence += effects.intelligence

--- a/src/app/tap-tap-adventure/lib/itemPostProcessor.ts
+++ b/src/app/tap-tap-adventure/lib/itemPostProcessor.ts
@@ -6,7 +6,7 @@ interface KeywordRule {
 }
 
 const POTION_SUBRULES: KeywordRule[] = [
-  { keywords: ['healing', 'health', 'life', 'restore', 'recovery'], effects: { strength: 2 } },
+  { keywords: ['healing', 'health', 'life', 'restore', 'recovery'], effects: { heal: 10 } },
   { keywords: ['intelligence', 'wisdom', 'mind', 'knowledge', 'insight'], effects: { intelligence: 2 } },
   { keywords: ['luck', 'fortune', 'lucky', 'chance'], effects: { luck: 2 } },
   { keywords: ['strength', 'power', 'might', 'vigor', 'brawn'], effects: { strength: 3 } },
@@ -56,7 +56,7 @@ export function inferItemTypeAndEffects(item: Item): Item {
     return {
       ...item,
       type: 'consumable',
-      effects: item.effects ?? findMatchingEffects(name, POTION_SUBRULES, { strength: 1, intelligence: 1 }),
+      effects: item.effects ?? findMatchingEffects(name, POTION_SUBRULES, { heal: 5, intelligence: 1 }),
     }
   }
 
@@ -74,7 +74,7 @@ export function inferItemTypeAndEffects(item: Item): Item {
     return {
       ...item,
       type: 'consumable',
-      effects: item.effects ?? { strength: 1 },
+      effects: item.effects ?? { heal: 5 },
     }
   }
 
@@ -139,7 +139,7 @@ export function inferItemTypeAndEffects(item: Item): Item {
   if (item.type === 'consumable') {
     return {
       ...item,
-      effects: { strength: 1, luck: 1 },
+      effects: { heal: 5, luck: 1 },
     }
   }
 

--- a/src/app/tap-tap-adventure/lib/llmEventGenerator.ts
+++ b/src/app/tap-tap-adventure/lib/llmEventGenerator.ts
@@ -59,6 +59,7 @@ const rewardItemSchema = z.object({
     strength: z.number().optional(),
     intelligence: z.number().optional(),
     luck: z.number().optional(),
+    heal: z.number().optional(),
   }).optional(),
   spell: SpellSchema.optional(),
 })
@@ -140,6 +141,7 @@ const rewardItemSchemaForOpenAI = {
         strength: { type: 'number' },
         intelligence: { type: 'number' },
         luck: { type: 'number' },
+        heal: { type: 'number', description: 'Directly restores this amount of HP. Use for healing items instead of strength.' },
       },
     },
     spell: spellSchemaForOpenAI,
@@ -272,7 +274,7 @@ IMPORTANT — Reputation guidance:
 ${reputationGuidance}
 Tailor the tone, NPC attitudes, and available opportunities to reflect the character's reputation tier.
 
-When rewarding items, sometimes include consumable items (type: "consumable") with effects like stat boosts or gold. Examples: potions that grant +2 strength, scrolls that grant +2 intelligence, lucky coins that grant +1 luck.
+When rewarding items, sometimes include consumable items (type: "consumable") with effects like stat boosts or gold. For healing items, use the 'heal' effect (e.g., heal: 15 restores 15 HP). The 'strength' effect permanently increases the strength stat. Examples: healing potions with heal: 10, scrolls that grant +2 intelligence, lucky coins that grant +1 luck, strength potions with +2 strength.
 Sometimes include equipment items (type: "equipment") like weapons, armor, or accessories with stat-boosting effects. Examples: a steel sword with +2 strength, iron armor with +2 intelligence, or a lucky charm with +1 luck.
 Sometimes reward spell scrolls — items with type "spell_scroll" containing a spell with a creative name, 2-3 effects, optional conditions, and tags. The spell field should have: id, name, description, school (arcane/nature/shadow/war), manaCost, cooldown, target (enemy/self), effects array, optional conditions array, and tags array.
 
@@ -360,7 +362,7 @@ function getDefaultEvents(): LLMGeneratedEvent[] {
       options: [
         { id: `open-${s}`, text: 'Pry it open', successProbability: 0.6,
           successDescription: 'Inside you find a handful of coins and a small vial.',
-          successEffects: { gold: 8, rewardItems: processFallbackRewardItems([{ id: `vial-${s}`, name: 'Small Healing Vial', description: 'Restores a bit of vigor', quantity: 1, type: 'consumable', effects: { strength: 1 } }]) },
+          successEffects: { gold: 8, rewardItems: processFallbackRewardItems([{ id: `vial-${s}`, name: 'Small Healing Vial', description: 'Restores a bit of vigor', quantity: 1, type: 'consumable', effects: { heal: 10 } }]) },
           failureDescription: 'The chest is empty save for dust and cobwebs.',
           failureEffects: {} },
         { id: `leave-${s}`, text: 'Leave it alone', successProbability: 1.0,
@@ -394,7 +396,7 @@ function getDefaultEvents(): LLMGeneratedEvent[] {
           failureDescription: '', failureEffects: {} },
         { id: `scavenge-${s}`, text: 'Search the camp for supplies', successProbability: 0.6,
           successDescription: 'You find a potion and a few coins.',
-          successEffects: { gold: 5, rewardItems: processFallbackRewardItems([{ id: `camp-potion-${s}`, name: 'Traveler\'s Brew', description: 'A simple restorative drink', quantity: 1, type: 'consumable', effects: { strength: 1 } }]) },
+          successEffects: { gold: 5, rewardItems: processFallbackRewardItems([{ id: `camp-potion-${s}`, name: 'Traveler\'s Brew', description: 'A simple restorative drink', quantity: 1, type: 'consumable', effects: { heal: 10 } }]) },
           failureDescription: 'The camp has already been picked clean.',
           failureEffects: {} },
       ],
@@ -514,7 +516,7 @@ function getDefaultEvents(): LLMGeneratedEvent[] {
       options: [
         { id: `gather-${s}`, text: 'Gather herbs', successProbability: 0.7,
           successDescription: 'You collect useful herbs and berries.',
-          successEffects: { rewardItems: processFallbackRewardItems([{ id: `herbs-${s}`, name: 'Wild Herbs', description: 'Fresh herbs with restorative properties', quantity: 1, type: 'consumable', effects: { strength: 2 } }]) },
+          successEffects: { rewardItems: processFallbackRewardItems([{ id: `herbs-${s}`, name: 'Wild Herbs', description: 'Fresh herbs with restorative properties', quantity: 1, type: 'consumable', effects: { heal: 10 } }]) },
           failureDescription: 'Most of the plants are wilted or inedible.',
           failureEffects: {} },
         { id: `admire-${s}`, text: 'Simply admire the beauty', successProbability: 1.0,

--- a/src/app/tap-tap-adventure/lib/shopGenerator.ts
+++ b/src/app/tap-tap-adventure/lib/shopGenerator.ts
@@ -37,6 +37,7 @@ const shopSchemaForOpenAI = {
               strength: { type: 'number' },
               intelligence: { type: 'number' },
               luck: { type: 'number' },
+              heal: { type: 'number', description: 'Directly restores this amount of HP. Use for healing items instead of strength.' },
             },
           },
         },
@@ -64,7 +65,7 @@ Price guidelines for level ${character.level}:
 - Expensive items: ${Math.round(basePrice * 2)}-${Math.round(basePrice * 3)} gold
 
 Include a mix of:
-- Healing potions/consumables
+- Healing potions/consumables (use the 'heal' effect for HP restoration, e.g., heal: 15 restores 15 HP. The 'strength' effect permanently increases the strength stat.)
 - Stat-boosting items (strength, intelligence, luck)
 - Interesting thematic items that fit the fantasy setting
 - Occasionally a spell scroll (type: "spell_scroll") with a spell object containing id, name, description, school, manaCost, cooldown, target, effects, and tags
@@ -116,7 +117,7 @@ export function getFallbackShopItems(level: number): Item[] {
       quantity: 1,
       type: 'consumable',
       price: Math.round(basePrice * 0.8),
-      effects: { strength: 1 + Math.floor(level / 3) },
+      effects: { heal: 10 + level * 5 },
     },
     {
       id: `shop-str-${suffix}`,

--- a/src/app/tap-tap-adventure/models/item.ts
+++ b/src/app/tap-tap-adventure/models/item.ts
@@ -10,6 +10,7 @@ export const ItemEffectsSchema = z.object({
   strength: z.number().optional(),
   intelligence: z.number().optional(),
   luck: z.number().optional(),
+  heal: z.number().optional(),
 })
 export type ItemEffects = z.infer<typeof ItemEffectsSchema>
 


### PR DESCRIPTION
## Summary
- Adds a dedicated `heal` effect to the item effects schema so healing items directly restore HP (e.g., `heal: 15` restores 15 HP)
- Reverts `strength` on consumables back to being a permanent stat boost instead of secretly healing HP
- Updates all LLM prompts and OpenAI function-calling schemas so the LLM knows to use `heal` for healing items
- Updates the item post-processor, fallback items, and shop/combat/event generators to use the new `heal` effect
- Updates all related tests (itemEffects, combatItemEffects, itemPostProcessor, combatEngine)

## Test plan
- [x] All 286 tests pass (`npx vitest run`)
- [ ] Verify in-game that healing potions show "restored X HP" instead of "+X STR"
- [ ] Verify strength potions correctly boost the strength stat
- [ ] Verify LLM-generated items use `heal` for healing and `strength` for stat boosts

🤖 Generated with [Claude Code](https://claude.com/claude-code)