### PR TITLE
fix: auto-walk stops during event loading

### DIFF
--- a/src/app/tap-tap-adventure/components/GameUI.tsx
+++ b/src/app/tap-tap-adventure/components/GameUI.tsx
@@ -90,12 +90,12 @@ export default function GameUI() {
     setIsAutoWalking(false)
   }, [])
 
-  // Stop auto-walking when an event triggers
+  // Stop auto-walking when an event triggers or server call is pending
   useEffect(() => {
-    if (gameState.decisionPoint || gameState.combatState || gameState.shopState) {
+    if (gameState.decisionPoint || gameState.combatState || gameState.shopState || moveForwardPending) {
       clearAutoWalk()
     }
-  }, [gameState.decisionPoint, gameState.combatState, gameState.shopState, clearAutoWalk])
+  }, [gameState.decisionPoint, gameState.combatState, gameState.shopState, moveForwardPending, clearAutoWalk])
 
   // Clean up on unmount
   useEffect(() => {


### PR DESCRIPTION
## Summary
Auto-walk kept stepping while a server event was loading. Added \`moveForwardPending\` to the useEffect that clears the auto-walk interval.

One line change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)