### PR TITLE
fix: lazy-initialize OpenAI to fix Vercel build

### DIFF
--- a/src/app/api/interpret-reading/route.ts
+++ b/src/app/api/interpret-reading/route.ts
@@ -4,9 +4,11 @@ import OpenAI from 'openai'
 import { hexagramDescriptions } from '@/app/oracle/library'
 import { getHexagramTrigrams } from '@/app/oracle/trigrams'
 
-const openai = new OpenAI({
-  apiKey: process.env.OPENAI_API_KEY,
-})
+function getOpenAI() {
+  return new OpenAI({
+    apiKey: process.env.OPENAI_API_KEY,
+  })
+}
 
 interface InterpretationRequest {
   question: string
@@ -71,7 +73,7 @@ Please provide a comprehensive interpretation that:
 
 Write in a warm, wise, and accessible tone. Be specific to the question and context, weaving together the symbolism, traditional meanings, and practical guidance. Aim for 3-5 paragraphs.`
 
-    const completion = await openai.chat.completions.create({
+    const completion = await getOpenAI().chat.completions.create({
       model: 'gpt-4o',
       messages: [
         {

--- a/src/app/tap-tap-adventure/lib/combatGenerator.ts
+++ b/src/app/tap-tap-adventure/lib/combatGenerator.ts
@@ -8,7 +8,9 @@ import { getReputationTier } from './contextBuilder'
 import { inferItemTypeAndEffects } from './itemPostProcessor'
 import { generateSpellForLevel } from './spellGenerator'
 
-const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY })
+function getOpenAI() {
+  return new OpenAI({ apiKey: process.env.OPENAI_API_KEY })
+}
 
 const combatResponseSchema = z.object({
   enemy: CombatEnemySchema,
@@ -88,7 +90,7 @@ export async function generateCombatEncounter(
   context: string
 ): Promise<{ enemy: CombatEnemy; scenario: string }> {
   try {
-    const response = await openai.chat.completions.create({
+    const response = await getOpenAI().chat.completions.create({
       model: 'gpt-4o',
       messages: [
         {
@@ -153,7 +155,7 @@ export async function generateBossEncounter(
   context: string
 ): Promise<{ enemy: CombatEnemy; scenario: string }> {
   try {
-    const response = await openai.chat.completions.create({
+    const response = await getOpenAI().chat.completions.create({
       model: 'gpt-4o',
       messages: [
         {

--- a/src/app/tap-tap-adventure/lib/llmEventGenerator.ts
+++ b/src/app/tap-tap-adventure/lib/llmEventGenerator.ts
@@ -93,7 +93,9 @@ const eventSchema = z.object({
 
 const eventsArraySchema = z.array(eventSchema).length(3)
 
-const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY })
+function getOpenAI() {
+  return new OpenAI({ apiKey: process.env.OPENAI_API_KEY })
+}
 
 // Function calling schema for event generation
 const spellEffectSchemaForOpenAI = {
@@ -227,7 +229,7 @@ export async function generateLLMEvents(
     context
   )
   try {
-    const response = await openai.chat.completions.create({
+    const response = await getOpenAI().chat.completions.create({
       model,
       messages,
       tools,


### PR DESCRIPTION
## Summary
Vercel builds were failing because OpenAI clients were instantiated at module level, crashing when OPENAI_API_KEY isn't available at build time.

Changed to lazy initialization via `getOpenAI()` functions in 3 files. Build now passes completely.

This unblocks all PR merges that were blocked by the required Vercel check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)