### PR TITLE
Add mount daily upkeep cost and release UI

### DIFF
--- a/src/app/tap-tap-adventure/__tests__/mounts.test.ts
+++ b/src/app/tap-tap-adventure/__tests__/mounts.test.ts
@@ -61,6 +61,7 @@ describe('Mount Definitions', () => {
     expect(horse!.name).toBe('Horse')
     expect(horse!.bonuses.strength).toBe(1)
     expect(horse!.bonuses.autoWalkSpeed).toBe(1.5)
+    expect(horse!.dailyCost).toBe(1)
   })
 
   it('should return undefined for unknown mount id', () => {
@@ -193,6 +194,38 @@ describe('Mount Heal Rate', () => {
     })
 
     expect(updated.hp).toBe(51)
+  })
+})
+
+describe('Mount Daily Cost', () => {
+  it('common mounts cost 1 gp/day', () => {
+    for (const m of getMountsByRarity('common')) {
+      expect(m.dailyCost).toBe(1)
+    }
+  })
+
+  it('uncommon mounts cost 2 gp/day', () => {
+    for (const m of getMountsByRarity('uncommon')) {
+      expect(m.dailyCost).toBe(2)
+    }
+  })
+
+  it('rare mounts cost 3 gp/day', () => {
+    for (const m of getMountsByRarity('rare')) {
+      expect(m.dailyCost).toBe(3)
+    }
+  })
+
+  it('legendary mounts cost 5 gp/day', () => {
+    for (const m of getMountsByRarity('legendary')) {
+      expect(m.dailyCost).toBe(5)
+    }
+  })
+
+  it('all mounts have a dailyCost property', () => {
+    for (const m of MOUNT_DEFINITIONS) {
+      expect(m.dailyCost).toBeGreaterThan(0)
+    }
   })
 })
 

--- a/src/app/tap-tap-adventure/components/HudBar.tsx
+++ b/src/app/tap-tap-adventure/components/HudBar.tsx
@@ -1,6 +1,7 @@
 'use client'
 import { useCallback, useMemo, useState } from 'react'
 
+import { Mount } from '@/app/tap-tap-adventure/models/mount'
 import { useGameStore } from '@/app/tap-tap-adventure/hooks/useGameStore'
 import { getReputationTier } from '@/app/tap-tap-adventure/lib/contextBuilder'
 import { levelProgress, stepsToNextLevel, stepsRequiredForLevel, calculateDay } from '@/app/tap-tap-adventure/lib/leveling'
@@ -85,7 +86,7 @@ const STATS_LEFT: IconType[] = ['heartIcon', 'sunIcon', 'waterDropIcon', 'leafIc
 const STATS_RIGHT: IconType[] = ['purpleCircleIcon', 'blueCircleIcon', 'yellowMoonIcon']
 
 export function HudBar() {
-  const { gameState } = useGameStore()
+  const { gameState, setMount } = useGameStore()
   const character = gameState?.characters?.find(
     (char: FantasyCharacter) => char.id === gameState?.selectedCharacterId
   )
@@ -175,6 +176,17 @@ export function HudBar() {
 
   const activeMount = character?.activeMount
 
+  const getMountTooltip = (mount: Mount): string => {
+    const bonusParts: string[] = []
+    if (mount.bonuses.strength) bonusParts.push(`+${mount.bonuses.strength} STR`)
+    if (mount.bonuses.intelligence) bonusParts.push(`+${mount.bonuses.intelligence} INT`)
+    if (mount.bonuses.luck) bonusParts.push(`+${mount.bonuses.luck} LCK`)
+    if (mount.bonuses.autoWalkSpeed) bonusParts.push(`${mount.bonuses.autoWalkSpeed}x speed`)
+    if (mount.bonuses.healRate) bonusParts.push(`+${mount.bonuses.healRate} heal`)
+    const bonusStr = bonusParts.length > 0 ? bonusParts.join(', ') : 'no bonuses'
+    return `${mount.name} — ${bonusStr} (${mount.dailyCost} gp/day)`
+  }
+
   const mountRarityColor: Record<string, string> = {
     common: 'border-slate-400',
     uncommon: 'border-green-400',
@@ -189,13 +201,20 @@ export function HudBar() {
       </div>
       <div className="flex items-center gap-2 sm:gap-4">
         {activeMount && (
-          <div className="relative">
+          <div className="relative flex items-center gap-1">
             <button
               className={`flex items-center gap-1 text-xs sm:text-sm font-semibold border rounded px-1.5 py-0.5 ${mountRarityColor[activeMount.rarity] ?? 'border-slate-400'} bg-[#2a2b3f]`}
-              title={`${activeMount.name} -- ${activeMount.description}`}
+              title={getMountTooltip(activeMount)}
             >
               <span>{activeMount.icon}</span>
               <span className="hidden sm:inline text-[10px]">{activeMount.name}</span>
+            </button>
+            <button
+              className="text-[10px] text-red-400 hover:text-red-300 border border-red-400/30 rounded px-1 py-0.5 bg-[#2a2b3f] hover:bg-[#3a3c56]"
+              title="Release mount"
+              onClick={() => setMount(null)}
+            >
+              Release
             </button>
           </div>
         )}

--- a/src/app/tap-tap-adventure/config/mounts.ts
+++ b/src/app/tap-tap-adventure/config/mounts.ts
@@ -1,15 +1,15 @@
 import { Mount } from '@/app/tap-tap-adventure/models/mount'
 
 export const MOUNT_DEFINITIONS: Mount[] = [
-  { id: 'horse', name: 'Horse', description: 'A reliable steed.', rarity: 'common', bonuses: { strength: 1, autoWalkSpeed: 1.5 }, icon: '🐴' },
-  { id: 'mule', name: 'Mule', description: 'Slow but lucky.', rarity: 'common', bonuses: { luck: 2 }, icon: '🫏' },
-  { id: 'war-horse', name: 'War Horse', description: 'Trained for battle.', rarity: 'uncommon', bonuses: { strength: 2, autoWalkSpeed: 1.3 }, icon: '🐎' },
-  { id: 'owl', name: 'Owl', description: 'Sees all, knows all.', rarity: 'uncommon', bonuses: { intelligence: 2, autoWalkSpeed: 1.2 }, icon: '🦉' },
-  { id: 'wolf', name: 'Wolf', description: 'Fast and fierce.', rarity: 'uncommon', bonuses: { strength: 1, luck: 1, autoWalkSpeed: 1.4 }, icon: '🐺' },
-  { id: 'griffin', name: 'Griffin', description: 'Majestic and swift.', rarity: 'rare', bonuses: { strength: 2, intelligence: 1, autoWalkSpeed: 2 }, icon: '🦅' },
-  { id: 'phoenix', name: 'Phoenix', description: 'Burns with restorative fire.', rarity: 'rare', bonuses: { intelligence: 2, healRate: 1 }, icon: '🔥' },
-  { id: 'shadow-steed', name: 'Shadow Steed', description: 'Moves between shadows.', rarity: 'rare', bonuses: { luck: 2, strength: 1, autoWalkSpeed: 1.5 }, icon: '🌑' },
-  { id: 'dragon', name: 'Dragon', description: 'The ultimate mount.', rarity: 'legendary', bonuses: { strength: 3, intelligence: 2, luck: 1, autoWalkSpeed: 2 }, icon: '🐉' },
+  { id: 'horse', name: 'Horse', description: 'A reliable steed.', rarity: 'common', bonuses: { strength: 1, autoWalkSpeed: 1.5 }, icon: '🐴', dailyCost: 1 },
+  { id: 'mule', name: 'Mule', description: 'Slow but lucky.', rarity: 'common', bonuses: { luck: 2 }, icon: '🫏', dailyCost: 1 },
+  { id: 'war-horse', name: 'War Horse', description: 'Trained for battle.', rarity: 'uncommon', bonuses: { strength: 2, autoWalkSpeed: 1.3 }, icon: '🐎', dailyCost: 2 },
+  { id: 'owl', name: 'Owl', description: 'Sees all, knows all.', rarity: 'uncommon', bonuses: { intelligence: 2, autoWalkSpeed: 1.2 }, icon: '🦉', dailyCost: 2 },
+  { id: 'wolf', name: 'Wolf', description: 'Fast and fierce.', rarity: 'uncommon', bonuses: { strength: 1, luck: 1, autoWalkSpeed: 1.4 }, icon: '🐺', dailyCost: 2 },
+  { id: 'griffin', name: 'Griffin', description: 'Majestic and swift.', rarity: 'rare', bonuses: { strength: 2, intelligence: 1, autoWalkSpeed: 2 }, icon: '🦅', dailyCost: 3 },
+  { id: 'phoenix', name: 'Phoenix', description: 'Burns with restorative fire.', rarity: 'rare', bonuses: { intelligence: 2, healRate: 1 }, icon: '🔥', dailyCost: 3 },
+  { id: 'shadow-steed', name: 'Shadow Steed', description: 'Moves between shadows.', rarity: 'rare', bonuses: { luck: 2, strength: 1, autoWalkSpeed: 1.5 }, icon: '🌑', dailyCost: 3 },
+  { id: 'dragon', name: 'Dragon', description: 'The ultimate mount.', rarity: 'legendary', bonuses: { strength: 3, intelligence: 2, luck: 1, autoWalkSpeed: 2 }, icon: '🐉', dailyCost: 5 },
 ]
 
 export function getMountById(id: string): Mount | undefined {

--- a/src/app/tap-tap-adventure/hooks/useGameStore.ts
+++ b/src/app/tap-tap-adventure/hooks/useGameStore.ts
@@ -7,7 +7,7 @@ import { checkAchievements } from '@/app/tap-tap-adventure/lib/achievementTracke
 import { computeUnlockedSkillIds } from '@/app/tap-tap-adventure/lib/skillTracker'
 import { defaultGameState } from '@/app/tap-tap-adventure/lib/defaultGameState'
 import { useItem as applyItemUse } from '@/app/tap-tap-adventure/lib/itemEffects'
-import { applyLevelFromDistance, calculateMaxHp, calculateMaxMana } from '@/app/tap-tap-adventure/lib/leveling'
+import { applyLevelFromDistance, calculateDay, calculateMaxHp, calculateMaxMana } from '@/app/tap-tap-adventure/lib/leveling'
 import { checkQuestProgress } from '@/app/tap-tap-adventure/lib/questGenerator'
 import { getSpellConfigForCharacter } from '@/app/tap-tap-adventure/config/characterOptions'
 import { FantasyCharacter } from '@/app/tap-tap-adventure/models/character'
@@ -161,10 +161,27 @@ export const useGameStore = create<GameStore>()(
           produce((state: GameStore) => {
             const selectedCharacter = get().getSelectedCharacter()
             if (!selectedCharacter) return
-            const updatedCharacter = applyLevelFromDistance({
+            const oldDistance = selectedCharacter.distance || 0
+            const newDistance = oldDistance + 1
+            let updatedCharacter = applyLevelFromDistance({
               ...selectedCharacter,
-              distance: (selectedCharacter.distance || 0) + 1,
+              distance: newDistance,
             })
+
+            // Mount daily upkeep: deduct gold when a new day boundary is crossed
+            const oldDay = calculateDay(oldDistance)
+            const newDay = calculateDay(newDistance)
+            if (newDay > oldDay && updatedCharacter.activeMount) {
+              const cost = updatedCharacter.activeMount.dailyCost ?? 0
+              const newGold = updatedCharacter.gold - cost
+              if (newGold < 0) {
+                // Can't afford upkeep — auto-release mount
+                updatedCharacter = { ...updatedCharacter, gold: updatedCharacter.gold, activeMount: null }
+              } else {
+                updatedCharacter = { ...updatedCharacter, gold: newGold }
+              }
+            }
+
             state.gameState.characters = state.gameState.characters.map(char =>
               char.id === selectedCharacter.id ? updatedCharacter : char
             )

--- a/src/app/tap-tap-adventure/models/mount.ts
+++ b/src/app/tap-tap-adventure/models/mount.ts
@@ -20,6 +20,7 @@ export const MountSchema = z.object({
   rarity: MountRaritySchema,
   bonuses: MountBonusesSchema,
   icon: z.string(),
+  dailyCost: z.number(),
 })
 
 export type Mount = z.infer<typeof MountSchema>


### PR DESCRIPTION
## Summary
- **B9 — Mount Daily Cost**: Added `dailyCost` field to the Mount model and all mount definitions (common: 1 gp/day, uncommon: 2 gp/day, rare: 3 gp/day, legendary: 5 gp/day). Mount upkeep is deducted each time a new day boundary is crossed during walking. If the player can't afford it, the mount is auto-released. Added a "Release Mount" button in the HUD and updated the mount tooltip to show bonuses and daily cost.
- **B10 — Verify Sell Items**: Reviewed ShopUI (sell tab), sell API endpoint, and sellPrice calculation. All working correctly — no fixes needed.

## Test plan
- [x] All 401 existing tests pass (`npx vitest run`)
- [x] Build succeeds with no TypeScript errors (`npx next build`)
- [x] New mount daily cost tests added and passing
- [ ] Manual: verify mount tooltip shows cost info
- [ ] Manual: verify "Release" button removes mount
- [ ] Manual: verify gold is deducted on day boundary with a mount
- [ ] Manual: verify mount auto-releases when gold runs out

🤖 Generated with [Claude Code](https://claude.com/claude-code)