### PR TITLE
Add elemental weaknesses system to combat

### DIFF
--- a/src/app/tap-tap-adventure/__tests__/elements.test.ts
+++ b/src/app/tap-tap-adventure/__tests__/elements.test.ts
@@ -1,0 +1,207 @@
+import { describe, expect, it } from 'vitest'
+
+import { getElementalMultiplier, getEffectivenessText } from '@/app/tap-tap-adventure/config/elements'
+import { getClassElement } from '@/app/tap-tap-adventure/config/characterOptions'
+import { SpellElement } from '@/app/tap-tap-adventure/models/spell'
+
+describe('getElementalMultiplier', () => {
+  describe('weakness matchups (2x)', () => {
+    it('fire vs nature = 2x', () => {
+      expect(getElementalMultiplier('fire', 'nature')).toBe(2.0)
+    })
+
+    it('ice vs fire = 2x', () => {
+      expect(getElementalMultiplier('ice', 'fire')).toBe(2.0)
+    })
+
+    it('lightning vs ice = 2x', () => {
+      expect(getElementalMultiplier('lightning', 'ice')).toBe(2.0)
+    })
+
+    it('shadow vs arcane = 2x', () => {
+      expect(getElementalMultiplier('shadow', 'arcane')).toBe(2.0)
+    })
+
+    it('nature vs lightning = 2x', () => {
+      expect(getElementalMultiplier('nature', 'lightning')).toBe(2.0)
+    })
+
+    it('nature vs shadow = 2x', () => {
+      expect(getElementalMultiplier('nature', 'shadow')).toBe(2.0)
+    })
+
+    it('arcane vs shadow = 2x', () => {
+      expect(getElementalMultiplier('arcane', 'shadow')).toBe(2.0)
+    })
+  })
+
+  describe('resistance matchups (0.5x)', () => {
+    it('fire vs ice = 0.5x', () => {
+      expect(getElementalMultiplier('fire', 'ice')).toBe(0.5)
+    })
+
+    it('ice vs lightning = 0.5x', () => {
+      expect(getElementalMultiplier('ice', 'lightning')).toBe(0.5)
+    })
+
+    it('lightning vs nature = 0.5x', () => {
+      expect(getElementalMultiplier('lightning', 'nature')).toBe(0.5)
+    })
+
+    it('shadow vs nature = 0.5x', () => {
+      expect(getElementalMultiplier('shadow', 'nature')).toBe(0.5)
+    })
+
+    it('nature vs fire = 0.5x', () => {
+      expect(getElementalMultiplier('nature', 'fire')).toBe(0.5)
+    })
+  })
+
+  describe('neutral matchups (1x)', () => {
+    it('fire vs fire = 1x', () => {
+      expect(getElementalMultiplier('fire', 'fire')).toBe(1.0)
+    })
+
+    it('fire vs lightning = 1x', () => {
+      expect(getElementalMultiplier('fire', 'lightning')).toBe(1.0)
+    })
+
+    it('arcane vs fire = 1x (arcane resists nothing)', () => {
+      expect(getElementalMultiplier('arcane', 'fire')).toBe(1.0)
+    })
+
+    it('none vs fire = 1x', () => {
+      expect(getElementalMultiplier('none', 'fire')).toBe(1.0)
+    })
+
+    it('fire vs none = 1x', () => {
+      expect(getElementalMultiplier('fire', 'none')).toBe(1.0)
+    })
+
+    it('none vs none = 1x', () => {
+      expect(getElementalMultiplier('none', 'none')).toBe(1.0)
+    })
+  })
+
+  describe('undefined/missing elements', () => {
+    it('undefined attack = 1x', () => {
+      expect(getElementalMultiplier(undefined, 'fire')).toBe(1.0)
+    })
+
+    it('undefined defense = 1x', () => {
+      expect(getElementalMultiplier('fire', undefined)).toBe(1.0)
+    })
+
+    it('both undefined = 1x', () => {
+      expect(getElementalMultiplier(undefined, undefined)).toBe(1.0)
+    })
+  })
+})
+
+describe('getEffectivenessText', () => {
+  it('returns "Super effective!" for 2x', () => {
+    expect(getEffectivenessText(2.0)).toBe('Super effective!')
+  })
+
+  it('returns "Resisted!" for 0.5x', () => {
+    expect(getEffectivenessText(0.5)).toBe('Resisted!')
+  })
+
+  it('returns null for 1x', () => {
+    expect(getEffectivenessText(1.0)).toBeNull()
+  })
+})
+
+describe('getClassElement', () => {
+  it('warrior = none', () => {
+    expect(getClassElement('Warrior')).toBe('none')
+  })
+
+  it('mage = arcane', () => {
+    expect(getClassElement('Mage')).toBe('arcane')
+  })
+
+  it('rogue = shadow', () => {
+    expect(getClassElement('Rogue')).toBe('shadow')
+  })
+
+  it('ranger = nature', () => {
+    expect(getClassElement('Ranger')).toBe('nature')
+  })
+
+  it('unknown class = none', () => {
+    expect(getClassElement('Bard')).toBe('none')
+  })
+
+  it('generated class with fire modifier = fire', () => {
+    const classData = {
+      id: 'pyromancer',
+      name: 'Pyromancer',
+      description: 'A master of fire',
+      combatStyle: 'ranged',
+      modifier: 'fire',
+      statDistribution: { strength: 4, intelligence: 8, luck: 5 },
+      favoredSchool: 'arcane' as const,
+      manaMultiplier: 1.2,
+      spellSlots: 5,
+      startingAbility: {
+        name: 'Fireball',
+        description: 'Throws a fireball',
+        manaCost: 10,
+        cooldown: 2,
+        target: 'enemy' as const,
+        effects: [],
+        tags: [],
+      },
+    }
+    expect(getClassElement('Pyromancer', classData)).toBe('fire')
+  })
+
+  it('generated class with frost modifier = ice', () => {
+    const classData = {
+      id: 'frost-mage',
+      name: 'Frost Mage',
+      description: 'A master of frost',
+      combatStyle: 'ranged',
+      modifier: 'frost',
+      statDistribution: { strength: 4, intelligence: 8, luck: 5 },
+      favoredSchool: 'arcane' as const,
+      manaMultiplier: 1.2,
+      spellSlots: 5,
+      startingAbility: {
+        name: 'Ice Shard',
+        description: 'Launches ice',
+        manaCost: 10,
+        cooldown: 2,
+        target: 'enemy' as const,
+        effects: [],
+        tags: [],
+      },
+    }
+    expect(getClassElement('Frost Mage', classData)).toBe('ice')
+  })
+
+  it('generated class with unrecognized modifier falls back to class name', () => {
+    const classData = {
+      id: 'paladin',
+      name: 'Paladin',
+      description: 'A holy warrior',
+      combatStyle: 'melee',
+      modifier: 'holy',
+      statDistribution: { strength: 7, intelligence: 5, luck: 5 },
+      favoredSchool: 'war' as const,
+      manaMultiplier: 0.8,
+      spellSlots: 3,
+      startingAbility: {
+        name: 'Smite',
+        description: 'Holy strike',
+        manaCost: 8,
+        cooldown: 3,
+        target: 'enemy' as const,
+        effects: [],
+        tags: [],
+      },
+    }
+    expect(getClassElement('Paladin', classData)).toBe('none')
+  })
+})

--- a/src/app/tap-tap-adventure/components/CombatUI.tsx
+++ b/src/app/tap-tap-adventure/components/CombatUI.tsx
@@ -8,6 +8,7 @@ import { CLASS_ABILITIES } from '@/app/tap-tap-adventure/config/characterOptions
 import { useCombatActionMutation } from '@/app/tap-tap-adventure/hooks/useCombatActionMutation'
 import { useGameStore } from '@/app/tap-tap-adventure/hooks/useGameStore'
 import { isUsableInCombat } from '@/app/tap-tap-adventure/lib/combatItemEffects'
+import { ELEMENT_COLORS } from '@/app/tap-tap-adventure/config/elements'
 import { CombatAction, CombatState, StatusEffect } from '@/app/tap-tap-adventure/models/combat'
 import { Spell } from '@/app/tap-tap-adventure/models/spell'
 import { Item } from '@/app/tap-tap-adventure/models/types'
@@ -161,9 +162,14 @@ export function CombatUI({ combatState }: CombatUIProps) {
       {/* Enemy info */}
       <div className="bg-[#1e1f30] border border-red-900/30 rounded-lg p-3 space-y-2">
         <div className="flex justify-between items-center">
-          <div>
+          <div className="flex items-center gap-2">
             <span className="font-bold text-red-400">{enemy.name}</span>
-            <span className="text-xs text-slate-400 ml-2">Lv.{enemy.level}</span>
+            <span className="text-xs text-slate-400">Lv.{enemy.level}</span>
+            {enemy.element && enemy.element !== 'none' && (
+              <span className={`text-[10px] px-1.5 py-0.5 rounded capitalize ${ELEMENT_COLORS[enemy.element]}`}>
+                {enemy.element}
+              </span>
+            )}
           </div>
           {enemy.specialAbility && (
             <span className="text-[10px] px-1.5 py-0.5 bg-purple-900/50 text-purple-400 rounded">

--- a/src/app/tap-tap-adventure/config/characterOptions.ts
+++ b/src/app/tap-tap-adventure/config/characterOptions.ts
@@ -1,4 +1,5 @@
 import { GeneratedClass } from '@/app/tap-tap-adventure/models/generatedClass'
+import { SpellElement } from '@/app/tap-tap-adventure/models/spell'
 
 import { DEFAULT_STAT_MIN } from './gameDefaults'
 
@@ -144,6 +145,56 @@ export function getSpellConfigForCharacter(
     favoredSchool: 'arcane',
     schoolBonus: 0.2,
   }
+}
+
+/**
+ * Primary element for each built-in class's basic attacks.
+ */
+export const CLASS_ELEMENTS: Record<string, SpellElement> = {
+  warrior: 'none',
+  mage: 'arcane',
+  rogue: 'shadow',
+  ranger: 'nature',
+}
+
+const MODIFIER_ELEMENT_MAP: Record<string, SpellElement> = {
+  fire: 'fire',
+  flame: 'fire',
+  inferno: 'fire',
+  ice: 'ice',
+  frost: 'ice',
+  frozen: 'ice',
+  lightning: 'lightning',
+  thunder: 'lightning',
+  storm: 'lightning',
+  shadow: 'shadow',
+  dark: 'shadow',
+  void: 'shadow',
+  nature: 'nature',
+  earth: 'nature',
+  life: 'nature',
+  arcane: 'arcane',
+  magic: 'arcane',
+  mystic: 'arcane',
+}
+
+/**
+ * Get the primary attack element for a character based on their class.
+ * For generated classes, infer from the classData modifier.
+ */
+export function getClassElement(
+  className: string,
+  classData?: GeneratedClass
+): SpellElement {
+  if (classData?.modifier) {
+    const modLower = classData.modifier.toLowerCase()
+    for (const [keyword, element] of Object.entries(MODIFIER_ELEMENT_MAP)) {
+      if (modLower.includes(keyword)) {
+        return element
+      }
+    }
+  }
+  return CLASS_ELEMENTS[className.toLowerCase()] ?? 'none'
 }
 
 export interface StartingStats {

--- a/src/app/tap-tap-adventure/config/elements.ts
+++ b/src/app/tap-tap-adventure/config/elements.ts
@@ -1,0 +1,83 @@
+import { SpellElement } from '@/app/tap-tap-adventure/models/spell'
+
+/**
+ * Elemental weakness/resistance chart.
+ *
+ * Each element maps to the set of elements it is strong against (2x damage)
+ * and the set of elements that resist it (0.5x damage).
+ *
+ * - Fire beats Nature, weak to Ice
+ * - Ice beats Fire, weak to Lightning
+ * - Lightning beats Ice, weak to Nature
+ * - Shadow beats Arcane, weak to Nature
+ * - Nature beats Lightning/Shadow, weak to Fire
+ * - Arcane beats Shadow, weak to none (neutral)
+ * - None is always neutral
+ */
+
+const WEAKNESSES: Partial<Record<SpellElement, SpellElement[]>> = {
+  fire: ['nature'],
+  ice: ['fire'],
+  lightning: ['ice'],
+  shadow: ['arcane'],
+  nature: ['lightning', 'shadow'],
+  arcane: ['shadow'],
+}
+
+const RESISTANCES: Partial<Record<SpellElement, SpellElement[]>> = {
+  fire: ['ice'],
+  ice: ['lightning'],
+  lightning: ['nature'],
+  shadow: ['nature'],
+  nature: ['fire'],
+}
+
+/**
+ * Returns the elemental multiplier when `attackElement` strikes a target
+ * whose element is `defenseElement`.
+ *
+ * - 2.0 if the defender is weak to the attacker's element
+ * - 0.5 if the defender resists the attacker's element
+ * - 1.0 otherwise (neutral)
+ */
+export function getElementalMultiplier(
+  attackElement: SpellElement | undefined,
+  defenseElement: SpellElement | undefined
+): number {
+  if (!attackElement || !defenseElement) return 1.0
+  if (attackElement === 'none' || defenseElement === 'none') return 1.0
+
+  const weakTo = WEAKNESSES[attackElement]
+  if (weakTo && weakTo.includes(defenseElement)) {
+    return 2.0
+  }
+
+  const resistedBy = RESISTANCES[attackElement]
+  if (resistedBy && resistedBy.includes(defenseElement)) {
+    return 0.5
+  }
+
+  return 1.0
+}
+
+/**
+ * Returns a human-readable description of the elemental effectiveness.
+ */
+export function getEffectivenessText(multiplier: number): string | null {
+  if (multiplier >= 2.0) return 'Super effective!'
+  if (multiplier <= 0.5) return 'Resisted!'
+  return null
+}
+
+/**
+ * Color mapping for element badges in the UI.
+ */
+export const ELEMENT_COLORS: Record<SpellElement, string> = {
+  fire: 'bg-red-900/50 text-red-400',
+  ice: 'bg-sky-900/50 text-sky-400',
+  lightning: 'bg-yellow-900/50 text-yellow-400',
+  shadow: 'bg-purple-900/50 text-purple-400',
+  nature: 'bg-green-900/50 text-green-400',
+  arcane: 'bg-indigo-900/50 text-indigo-400',
+  none: 'bg-slate-700/50 text-slate-400',
+}

--- a/src/app/tap-tap-adventure/lib/combatEngine.ts
+++ b/src/app/tap-tap-adventure/lib/combatEngine.ts
@@ -1,4 +1,5 @@
-import { CLASS_ABILITIES, getSpellConfigForCharacter } from '@/app/tap-tap-adventure/config/characterOptions'
+import { CLASS_ABILITIES, getClassElement, getSpellConfigForCharacter } from '@/app/tap-tap-adventure/config/characterOptions'
+import { getElementalMultiplier, getEffectivenessText } from '@/app/tap-tap-adventure/config/elements'
 import { SKILLS } from '@/app/tap-tap-adventure/config/skills'
 import { FantasyCharacter } from '@/app/tap-tap-adventure/models/character'
 import { Skill } from '@/app/tap-tap-adventure/models/skill'
@@ -108,8 +109,9 @@ function getComboMultiplier(comboCount: number): number {
 
 export function calculatePlayerDamage(
   playerState: CombatPlayerState,
-  enemy: CombatEnemy
-): number {
+  enemy: CombatEnemy,
+  character?: FantasyCharacter
+): { damage: number; elementalMultiplier: number } {
   const buffedAttack =
     playerState.attack +
     (playerState.activeBuffs ?? [])
@@ -118,15 +120,22 @@ export function calculatePlayerDamage(
   const comboMultiplier = getComboMultiplier(playerState.comboCount)
   const berserkMultiplier = getBerserkAttackMultiplier(playerState.statusEffects)
   const enemyDefense = enemy.defense * getBurnDefenseMultiplier(enemy.statusEffects)
-  const raw = randomVariance(buffedAttack) * comboMultiplier * berserkMultiplier - enemyDefense
-  return Math.max(1, Math.round(raw))
+
+  const attackElement = character
+    ? getClassElement(character.class, character.classData)
+    : undefined
+  const elementalMultiplier = getElementalMultiplier(attackElement, enemy.element)
+
+  const raw = randomVariance(buffedAttack) * comboMultiplier * berserkMultiplier * elementalMultiplier - enemyDefense
+  return { damage: Math.max(1, Math.round(raw)), elementalMultiplier }
 }
 
 export function calculateEnemyDamage(
   enemy: CombatEnemy,
   playerState: CombatPlayerState,
-  isHeavyAttack: boolean = false
-): number {
+  isHeavyAttack: boolean = false,
+  character?: FantasyCharacter
+): { damage: number; elementalMultiplier: number } {
   const effectiveDefense = playerState.isDefending
     ? playerState.defense * 2
     : playerState.defense
@@ -138,9 +147,15 @@ export function calculateEnemyDamage(
       .filter(b => b.stat === 'defense')
       .reduce((sum, b) => sum + b.value, 0)
   const slowMultiplier = getSlowMultiplier(enemy.statusEffects)
-  const attackPower = (isHeavyAttack ? enemy.attack * 1.5 : enemy.attack) * slowMultiplier
+
+  const defenseElement = character
+    ? getClassElement(character.class, character.classData)
+    : undefined
+  const elementalMultiplier = getElementalMultiplier(enemy.element, defenseElement)
+
+  const attackPower = (isHeavyAttack ? enemy.attack * 1.5 : enemy.attack) * slowMultiplier * elementalMultiplier
   const raw = randomVariance(attackPower) - buffedDefense
-  return Math.max(1, Math.round(raw))
+  return { damage: Math.max(1, Math.round(raw)), elementalMultiplier }
 }
 
 export function calculateFleeChance(
@@ -224,7 +239,8 @@ function executeEnemyTelegraph(
   telegraph: EnemyTelegraph,
   enemy: CombatEnemy,
   playerState: CombatPlayerState,
-  turnNumber: number
+  turnNumber: number,
+  character?: FantasyCharacter
 ): { playerState: CombatPlayerState; logs: CombatLogEntry[]; enemyDefenseBoost: boolean } {
   const logs: CombatLogEntry[] = []
   let updatedPlayer = { ...playerState }
@@ -232,14 +248,15 @@ function executeEnemyTelegraph(
 
   switch (telegraph.action) {
     case 'heavy_attack': {
-      const dmg = calculateEnemyDamage(enemy, updatedPlayer, true)
+      const { damage: dmg, elementalMultiplier } = calculateEnemyDamage(enemy, updatedPlayer, true, character)
       updatedPlayer.hp = Math.max(0, updatedPlayer.hp - dmg)
+      const elemText = getEffectivenessText(elementalMultiplier)
       logs.push({
         turn: turnNumber,
         actor: 'enemy',
         action: 'heavy_attack',
         damage: dmg,
-        description: `${enemy.name} unleashes a powerful blow for ${dmg} damage!`,
+        description: `${enemy.name} unleashes a powerful blow for ${dmg} damage!${elemText ? ` ${elemText}` : ''}`,
       })
       break
     }
@@ -275,14 +292,15 @@ function executeEnemyTelegraph(
     }
     case 'normal_attack':
     default: {
-      const dmg = calculateEnemyDamage(enemy, updatedPlayer)
+      const { damage: dmg, elementalMultiplier } = calculateEnemyDamage(enemy, updatedPlayer, false, character)
       updatedPlayer.hp = Math.max(0, updatedPlayer.hp - dmg)
+      const elemText = getEffectivenessText(elementalMultiplier)
       logs.push({
         turn: turnNumber,
         actor: 'enemy',
         action: 'attack',
         damage: dmg,
-        description: `${enemy.name} attacks you for ${dmg} damage!`,
+        description: `${enemy.name} attacks you for ${dmg} damage!${elemText ? ` ${elemText}` : ''}`,
       })
       break
     }
@@ -347,16 +365,17 @@ export function processPlayerAction(
       const effectiveEnemy = enemyDefending
         ? { ...enemy, defense: enemy.defense * 2 }
         : enemy
-      const damage = calculatePlayerDamage(playerState, effectiveEnemy)
+      const { damage, elementalMultiplier } = calculatePlayerDamage(playerState, effectiveEnemy, character)
       enemy.hp = Math.max(0, enemy.hp - damage)
       playerState.comboCount = (playerState.comboCount ?? 0) + 1
       const comboText = playerState.comboCount > 1 ? ` (${playerState.comboCount}x combo!)` : ''
+      const elemText = getEffectivenessText(elementalMultiplier)
       newLogs.push({
         turn: turnNumber,
         actor: 'player',
         action: 'attack',
         damage,
-        description: `You strike ${enemy.name} for ${damage} damage!${comboText}`,
+        description: `You strike ${enemy.name} for ${damage} damage!${comboText}${elemText ? ` ${elemText}` : ''}`,
       })
       break
     }
@@ -462,60 +481,64 @@ export function processPlayerAction(
 
       switch (classId) {
         case 'warrior': {
-          const baseDmg = calculatePlayerDamage(playerState, enemy)
+          const { damage: baseDmg, elementalMultiplier } = calculatePlayerDamage(playerState, enemy, character)
           const damage = Math.max(1, Math.round(baseDmg * 0.8))
           enemy.hp = Math.max(0, enemy.hp - damage)
           playerState.enemyStunned = true
           playerState.comboCount = (playerState.comboCount ?? 0) + 1
+          const elemText = getEffectivenessText(elementalMultiplier)
           newLogs.push({
             turn: turnNumber,
             actor: 'player',
             action: 'class_ability',
             damage,
-            description: `You bash ${enemy.name} with your shield for ${damage} damage, stunning them!`,
+            description: `You bash ${enemy.name} with your shield for ${damage} damage, stunning them!${elemText ? ` ${elemText}` : ''}`,
           })
           break
         }
         case 'mage': {
-          const baseDmg = calculatePlayerDamage(playerState, enemy)
+          const { damage: baseDmg, elementalMultiplier } = calculatePlayerDamage(playerState, enemy, character)
           const damage = Math.max(1, Math.round(baseDmg * 2))
           const recoil = Math.max(1, Math.round(playerState.maxHp * 0.2))
           enemy.hp = Math.max(0, enemy.hp - damage)
           playerState.hp = Math.max(1, playerState.hp - recoil)
           playerState.comboCount = 0
+          const elemText = getEffectivenessText(elementalMultiplier)
           newLogs.push({
             turn: turnNumber,
             actor: 'player',
             action: 'class_ability',
             damage,
-            description: `You unleash an Arcane Blast for ${damage} damage! The magical recoil deals ${recoil} damage to you.`,
+            description: `You unleash an Arcane Blast for ${damage} damage! The magical recoil deals ${recoil} damage to you.${elemText ? ` ${elemText}` : ''}`,
           })
           break
         }
         case 'rogue': {
           const combo = playerState.comboCount ?? 0
           if (combo >= 2) {
-            const baseDmg = calculatePlayerDamage(playerState, enemy)
+            const { damage: baseDmg, elementalMultiplier } = calculatePlayerDamage(playerState, enemy, character)
             const damage = Math.max(1, Math.round(baseDmg * 3))
             enemy.hp = Math.max(0, enemy.hp - damage)
             playerState.comboCount = 0
+            const elemText = getEffectivenessText(elementalMultiplier)
             newLogs.push({
               turn: turnNumber,
               actor: 'player',
               action: 'class_ability',
               damage,
-              description: `You exploit your ${combo}x combo with a devastating Backstab for ${damage} damage!`,
+              description: `You exploit your ${combo}x combo with a devastating Backstab for ${damage} damage!${elemText ? ` ${elemText}` : ''}`,
             })
           } else {
-            const damage = calculatePlayerDamage(playerState, enemy)
+            const { damage, elementalMultiplier } = calculatePlayerDamage(playerState, enemy, character)
             enemy.hp = Math.max(0, enemy.hp - damage)
             playerState.comboCount = (playerState.comboCount ?? 0) + 1
+            const elemText = getEffectivenessText(elementalMultiplier)
             newLogs.push({
               turn: turnNumber,
               actor: 'player',
               action: 'class_ability',
               damage,
-              description: `Your Backstab lacks setup and deals ${damage} normal damage.`,
+              description: `Your Backstab lacks setup and deals ${damage} normal damage.${elemText ? ` ${elemText}` : ''}`,
             })
           }
           break
@@ -636,7 +659,7 @@ export function processPlayerAction(
       description: `${enemy.name} is paralyzed with fear and cannot act!`,
     })
   } else if (enemyTelegraph) {
-    const result = executeEnemyTelegraph(enemyTelegraph, enemy, playerState, turnNumber)
+    const result = executeEnemyTelegraph(enemyTelegraph, enemy, playerState, turnNumber, character)
     playerState = result.playerState
     const enemyDmgLog = result.logs.find(l => l.damage && l.damage > 0)
     let actualDamageDealt = 0
@@ -702,7 +725,7 @@ export function processPlayerAction(
       }
     }
   } else {
-    const enemyDmg = calculateEnemyDamage(enemy, playerState)
+    const { damage: enemyDmg, elementalMultiplier: enemyElemMult } = calculateEnemyDamage(enemy, playerState, false, character)
     const dmgReduction = getActiveDamageReduction(playerState)
     const reducedDmg = Math.max(1, Math.round(enemyDmg * (1 - dmgReduction / 100)))
     const shieldResult = applyShieldAbsorption(playerState, reducedDmg)
@@ -722,10 +745,11 @@ export function processPlayerAction(
       }
     }
 
+    const enemyElemText = getEffectivenessText(enemyElemMult)
     playerState.hp = Math.max(0, playerState.hp - actualDmg)
     newLogs.push({
       turn: turnNumber, actor: 'enemy', action: 'attack', damage: actualDmg,
-      description: `${enemy.name} attacks you for ${actualDmg} damage!${dmgReduction > 0 ? ` (${dmgReduction}% reduced)` : ''}${(playerState.shield ?? 0) > 0 || reducedDmg !== actualDmg ? ' (shield absorbed some)' : ''}`,
+      description: `${enemy.name} attacks you for ${actualDmg} damage!${dmgReduction > 0 ? ` (${dmgReduction}% reduced)` : ''}${(playerState.shield ?? 0) > 0 || reducedDmg !== actualDmg ? ' (shield absorbed some)' : ''}${enemyElemText ? ` ${enemyElemText}` : ''}`,
     })
 
     // Apply thorns damage back to enemy

--- a/src/app/tap-tap-adventure/lib/combatGenerator.ts
+++ b/src/app/tap-tap-adventure/lib/combatGenerator.ts
@@ -77,6 +77,11 @@ const enemySchemaForOpenAI = {
           },
           required: ['type', 'value', 'duration', 'chance'],
         },
+        element: {
+          type: 'string',
+          enum: ['fire', 'ice', 'lightning', 'shadow', 'nature', 'arcane', 'none'],
+          description: 'The elemental affinity of the enemy. Determines weaknesses/resistances in combat.',
+        },
       },
       required: [
         'id',
@@ -115,6 +120,7 @@ Stat guidelines for a level ${character.level} character:
 - Include 1-2 loot items (potions, scrolls, gems, etc.). For healing items, use the 'heal' effect (e.g., heal: 15 restores 15 HP). The 'strength' effect permanently increases the strength stat.
 - Optionally include a special ability with cooldown of 2-4 turns
 - Some enemies can inflict status effects (poison, burn, slow, curse, fear). Include a statusAbility field with type, value (damage per turn or effect strength), duration (2-4 turns), and chance (0-1 probability of inflicting)
+- Assign an element to the enemy (fire, ice, lightning, shadow, nature, arcane, or none). Choose an element that fits the enemy's theme. For example: wolves = nature, fire elementals = fire, undead = shadow, golems = none.
 
 Reputation context: This character's reputation is ${character.reputation} (${getReputationTier(character.reputation)}).
 ${character.reputation >= 50 ? 'High reputation: the enemy might offer to surrender or parley before fighting. Consider less aggressive enemies like misguided guards or territorial creatures rather than outright villains.' : ''}${character.reputation <= -20 ? 'Low reputation: enemies are more aggressive. Consider bounty hunters, rival adventurers seeking the bounty on this character, or vengeful NPCs.' : ''}
@@ -226,10 +232,10 @@ function getDefaultBossEncounter(
   const level = character.level
   const suffix = `${Date.now()}-${Math.floor(Math.random() * 10000)}`
 
-  const bosses = [
-    { name: 'The Iron Warden', desc: 'A colossal animated suit of armor, its eyes burning with ancient fury.', special: 'Crushing Blow', specialDesc: 'Slams the ground, sending shockwaves.' },
-    { name: 'Vexara the Cursed', desc: 'A spectral sorceress wreathed in dark flame, whispering words of ruin.', special: 'Soul Drain', specialDesc: 'Drains life force from her victims.' },
-    { name: 'Grimfang the Devourer', desc: 'A massive beast with razor teeth and impenetrable scales.', special: 'Rending Fury', specialDesc: 'Unleashes a devastating multi-strike attack.' },
+  const bosses: Array<{ name: string; desc: string; special: string; specialDesc: string; element: 'none' | 'shadow' | 'nature' }> = [
+    { name: 'The Iron Warden', desc: 'A colossal animated suit of armor, its eyes burning with ancient fury.', special: 'Crushing Blow', specialDesc: 'Slams the ground, sending shockwaves.', element: 'none' },
+    { name: 'Vexara the Cursed', desc: 'A spectral sorceress wreathed in dark flame, whispering words of ruin.', special: 'Soul Drain', specialDesc: 'Drains life force from her victims.', element: 'shadow' },
+    { name: 'Grimfang the Devourer', desc: 'A massive beast with razor teeth and impenetrable scales.', special: 'Rending Fury', specialDesc: 'Unleashes a devastating multi-strike attack.', element: 'nature' },
   ]
   const boss = bosses[level % bosses.length]
 
@@ -276,6 +282,7 @@ function getDefaultBossEncounter(
         damage: Math.round((5 + level * 2) * 1.8),
         cooldown: 2,
       },
+      element: boss.element,
     },
   }
 }
@@ -332,6 +339,7 @@ function getDefaultCombatEncounter(
           : level <= 5
             ? { type: 'poison' as const, value: 3 + level, duration: 3, chance: 0.4 }
             : { type: 'curse' as const, value: 0, duration: 3, chance: 0.3 },
+      element: level <= 2 ? 'none' as const : level <= 5 ? 'nature' as const : 'shadow' as const,
     },
   }
 }

--- a/src/app/tap-tap-adventure/lib/spellEngine.ts
+++ b/src/app/tap-tap-adventure/lib/spellEngine.ts
@@ -1,4 +1,5 @@
 import { CLASS_SPELL_CONFIG } from '@/app/tap-tap-adventure/config/characterOptions'
+import { getElementalMultiplier, getEffectivenessText } from '@/app/tap-tap-adventure/config/elements'
 import { FantasyCharacter } from '@/app/tap-tap-adventure/models/character'
 import {
   ActiveSpellEffect,
@@ -163,15 +164,17 @@ export function castSpell(
 
     switch (effect.type) {
       case 'damage': {
-        const baseDmg = effect.value * damageMultiplier
+        const elemMultiplier = getElementalMultiplier(effect.element, updatedEnemy.element)
+        const baseDmg = effect.value * damageMultiplier * elemMultiplier
         const dmg = Math.max(1, Math.round(baseDmg - (trueDamageBonus ? 0 : updatedEnemy.defense * 0.3)))
         updatedEnemy = { ...updatedEnemy, hp: Math.max(0, updatedEnemy.hp - dmg) }
+        const elemText = getEffectivenessText(elemMultiplier)
         logs.push({
           turn: turnNumber,
           actor: 'player',
           action: 'cast_spell',
           damage: dmg,
-          description: `${spell.name} hits ${updatedEnemy.name} for ${dmg} ${effect.element ?? ''} damage!${conditionText}`,
+          description: `${spell.name} hits ${updatedEnemy.name} for ${dmg} ${effect.element ?? ''} damage!${conditionText}${elemText ? ` ${elemText}` : ''}`,
         })
         break
       }
@@ -322,7 +325,8 @@ export function castSpell(
         break
       }
       case 'lifesteal': {
-        const lstDmg = Math.max(1, Math.round(effect.value * damageMultiplier - updatedEnemy.defense * 0.3))
+        const lstElemMultiplier = getElementalMultiplier(effect.element, updatedEnemy.element)
+        const lstDmg = Math.max(1, Math.round(effect.value * damageMultiplier * lstElemMultiplier - updatedEnemy.defense * 0.3))
         const healPct = (effect.percentage ?? 50) / 100
         const lstHeal = Math.max(1, Math.round(lstDmg * healPct))
         updatedEnemy = { ...updatedEnemy, hp: Math.max(0, updatedEnemy.hp - lstDmg) }
@@ -330,12 +334,13 @@ export function castSpell(
           ...playerState,
           hp: Math.min(playerState.maxHp, playerState.hp + lstHeal),
         }
+        const lstElemText = getEffectivenessText(lstElemMultiplier)
         logs.push({
           turn: turnNumber,
           actor: 'player',
           action: 'cast_spell',
           damage: lstDmg,
-          description: `${spell.name} drains ${lstDmg} from ${updatedEnemy.name}, healing you for ${lstHeal}!`,
+          description: `${spell.name} drains ${lstDmg} from ${updatedEnemy.name}, healing you for ${lstHeal}!${lstElemText ? ` ${lstElemText}` : ''}`,
         })
         break
       }

--- a/src/app/tap-tap-adventure/models/combat.ts
+++ b/src/app/tap-tap-adventure/models/combat.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod'
 
 import { ItemSchema } from './item'
+import { SpellElementSchema } from './spell'
 
 export const StatusEffectTypeSchema = z.enum([
   'poison',
@@ -53,6 +54,7 @@ export const CombatEnemySchema = z.object({
     .optional(),
   statusEffects: z.array(StatusEffectSchema).optional(),
   statusAbility: StatusAbilitySchema.optional(),
+  element: SpellElementSchema.optional(),
 })
 export type CombatEnemy = z.infer<typeof CombatEnemySchema>
 


### PR DESCRIPTION
## Summary
- Adds an elemental damage type system to combat: fire, ice, lightning, shadow, nature, arcane, none
- Each class has a primary element (Warrior=none, Mage=arcane, Rogue=shadow, Ranger=nature); generated classes infer element from their modifier
- Enemies can now have an `element` field on `CombatEnemySchema`
- Hitting a weakness deals 2x damage, hitting a resistance deals 0.5x damage
- Elemental multipliers apply to basic attacks, class abilities, spell damage, and lifesteal
- Combat log shows "Super effective!" and "Resisted!" messages
- Enemy element displayed as a colored badge in the combat UI
- LLM prompt updated to assign elements to generated enemies; fallback enemies have elements
- 32 unit tests covering all matchups, effectiveness text, and class element mapping

## Element Chart
| Attack | Strong vs (2x) | Weak vs (0.5x) |
|--------|----------------|-----------------|
| Fire | Nature | Ice |
| Ice | Fire | Lightning |
| Lightning | Ice | Nature |
| Shadow | Arcane | Nature |
| Nature | Lightning, Shadow | Fire |
| Arcane | Shadow | (none) |

## Test plan
- [x] `npx vitest run` -- all 433 tests pass (30 test files)
- [x] `npx next build` -- builds successfully
- [x] New `elements.test.ts` covers all weakness, resistance, and neutral matchups
- [x] Existing combat balance, combat engine, class ability, spell, and status effect tests all pass

Generated with [Claude Code](https://claude.com/claude-code)