### PR TITLE
Add Character Legacy system with heirloom inheritance

### DIFF
--- a/src/app/tap-tap-adventure/__tests__/heirloomGenerator.test.ts
+++ b/src/app/tap-tap-adventure/__tests__/heirloomGenerator.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, it } from 'vitest'
+
+import { generateHeirloom } from '@/app/tap-tap-adventure/lib/heirloomGenerator'
+import { FantasyCharacter } from '@/app/tap-tap-adventure/models/character'
+
+function makeCharacter(overrides: Partial<FantasyCharacter> = {}): FantasyCharacter {
+  return {
+    id: 'test-char-1',
+    playerId: 'player-1',
+    name: 'Aldric',
+    race: 'Human',
+    class: 'Warrior',
+    level: 5,
+    abilities: [],
+    locationId: 'village',
+    gold: 100,
+    reputation: 20,
+    distance: 50,
+    status: 'active',
+    strength: 15,
+    intelligence: 8,
+    luck: 7,
+    inventory: [],
+    deathCount: 0,
+    pendingStatPoints: 0,
+    ...overrides,
+  }
+}
+
+describe('Heirloom Generator', () => {
+  it('should generate an heirloom item from a character', () => {
+    const character = makeCharacter()
+    const heirloom = generateHeirloom(character)
+
+    expect(heirloom).toBeDefined()
+    expect(heirloom.id).toContain('heirloom-')
+    expect(heirloom.quantity).toBe(1)
+    expect(heirloom.isHeirloom).toBe(true)
+  })
+
+  it('should include the character name in the heirloom name', () => {
+    const character = makeCharacter({ name: 'Zara' })
+    const heirloom = generateHeirloom(character)
+
+    expect(heirloom.name).toContain('Zara')
+  })
+
+  it('should produce equipment or consumable type heirlooms', () => {
+    const character = makeCharacter()
+    const heirloom = generateHeirloom(character)
+
+    expect(['equipment', 'consumable', 'spell_scroll']).toContain(heirloom.type)
+  })
+
+  it('should generate higher quality heirlooms for higher level characters', () => {
+    const lowLevel = makeCharacter({ id: 'low', level: 1, distance: 10 })
+    const highLevel = makeCharacter({ id: 'high', level: 20, distance: 1000 })
+
+    const lowHeirloom = generateHeirloom(lowLevel)
+    const highHeirloom = generateHeirloom(highLevel)
+
+    // Both should be valid items
+    expect(lowHeirloom.isHeirloom).toBe(true)
+    expect(highHeirloom.isHeirloom).toBe(true)
+
+    // High level heirloom should have the character name
+    expect(highHeirloom.name).toContain('Aldric')
+    expect(lowHeirloom.name).toContain('Aldric')
+
+    // If both are equipment, high level should have better stats
+    if (lowHeirloom.type === 'equipment' && highHeirloom.type === 'equipment') {
+      const lowTotal = Object.values(lowHeirloom.effects ?? {}).reduce((a, b) => (a ?? 0) + (b ?? 0), 0) ?? 0
+      const highTotal = Object.values(highHeirloom.effects ?? {}).reduce((a, b) => (a ?? 0) + (b ?? 0), 0) ?? 0
+      expect(highTotal).toBeGreaterThan(lowTotal)
+    }
+
+    // If both are consumable, high level should have better heal
+    if (lowHeirloom.type === 'consumable' && highHeirloom.type === 'consumable') {
+      expect(highHeirloom.effects!.heal).toBeGreaterThan(lowHeirloom.effects!.heal!)
+    }
+  })
+
+  it('should generate equipment with stats based on strongest stat (strength)', () => {
+    const character = makeCharacter({
+      id: 'str-char',
+      strength: 20,
+      intelligence: 5,
+      luck: 5,
+      spellbook: [],
+    })
+
+    const heirloom = generateHeirloom(character)
+    expect(heirloom.isHeirloom).toBe(true)
+
+    if (heirloom.type === 'equipment') {
+      expect(heirloom.effects).toBeDefined()
+      expect(heirloom.effects!.strength).toBeGreaterThan(0)
+    }
+  })
+
+  it('should generate equipment with stats based on strongest stat (intelligence)', () => {
+    const character = makeCharacter({
+      id: 'int-char',
+      strength: 5,
+      intelligence: 20,
+      luck: 5,
+      spellbook: [],
+    })
+    const heirloom = generateHeirloom(character)
+    expect(heirloom.isHeirloom).toBe(true)
+
+    if (heirloom.type === 'equipment') {
+      expect(heirloom.effects).toBeDefined()
+      expect(heirloom.effects!.intelligence).toBeGreaterThan(0)
+    }
+  })
+
+  it('should generate consumable heirlooms with heal effects', () => {
+    const character = makeCharacter({ id: 'cons-char' })
+    const heirloom = generateHeirloom(character)
+
+    if (heirloom.type === 'consumable') {
+      expect(heirloom.effects).toBeDefined()
+      expect(heirloom.effects!.heal).toBeGreaterThan(0)
+      expect(heirloom.name).toContain('Blessing')
+    }
+  })
+
+  it('should generate spell scroll heirlooms for characters with spells', () => {
+    const character = makeCharacter({
+      id: 'spell-char',
+      spellbook: [
+        {
+          id: 'spell-1',
+          name: 'Fireball',
+          description: 'A ball of fire',
+          school: 'arcane',
+          manaCost: 15,
+          cooldown: 2,
+          target: 'enemy',
+          effects: [{ type: 'damage', value: 30 }],
+          tags: ['fire'],
+        },
+      ],
+    })
+    const heirloom = generateHeirloom(character)
+
+    if (heirloom.type === 'spell_scroll') {
+      expect(heirloom.spell).toBeDefined()
+      expect(heirloom.name).toContain('Spell Scroll')
+    }
+  })
+
+  it('should scale heirloom quality with distance traveled', () => {
+    const nearChar = makeCharacter({ id: 'near', level: 5, distance: 10 })
+    const farChar = makeCharacter({ id: 'far', level: 5, distance: 1500 })
+
+    const nearHeirloom = generateHeirloom(nearChar)
+    const farHeirloom = generateHeirloom(farChar)
+
+    expect(nearHeirloom.isHeirloom).toBe(true)
+    expect(farHeirloom.isHeirloom).toBe(true)
+
+    // For equipment type heirlooms, far traveler should have higher stat bonuses
+    if (nearHeirloom.type === 'equipment' && farHeirloom.type === 'equipment') {
+      const nearTotal = Object.values(nearHeirloom.effects ?? {}).reduce((a, b) => (a ?? 0) + (b ?? 0), 0) ?? 0
+      const farTotal = Object.values(farHeirloom.effects ?? {}).reduce((a, b) => (a ?? 0) + (b ?? 0), 0) ?? 0
+      expect(farTotal).toBeGreaterThanOrEqual(nearTotal)
+    }
+  })
+
+  it('should produce deterministic results for the same character', () => {
+    const character = makeCharacter()
+    const h1 = generateHeirloom(character)
+    const h2 = generateHeirloom(character)
+
+    expect(h1.type).toBe(h2.type)
+    expect(h1.name).toBe(h2.name)
+  })
+})

--- a/src/app/tap-tap-adventure/components/CharacterCard.tsx
+++ b/src/app/tap-tap-adventure/components/CharacterCard.tsx
@@ -9,6 +9,7 @@ interface CharacterCardProps {
   selected?: boolean
   onSelect?: (character: FantasyCharacter) => void
   onDelete?: (e: React.MouseEvent, id: string) => void
+  onRetire?: (e: React.MouseEvent, id: string) => void
 }
 
 export default function CharacterCard({
@@ -16,7 +17,9 @@ export default function CharacterCard({
   selected,
   onSelect,
   onDelete,
+  onRetire,
 }: CharacterCardProps) {
+  const canRetire = character.status === 'active' && (character.distance ?? 0) >= 100
   return (
     <motion.div
       whileHover={{ scale: 1.04 }}
@@ -43,6 +46,25 @@ export default function CharacterCard({
           <span className="text-red-400">Deaths: {character.deathCount}</span>
         )}
       </div>
+      {character.status === 'retired' && (
+        <span className="text-xs text-amber-400 mt-1">Retired</span>
+      )}
+      {character.status === 'dead' && (
+        <span className="text-xs text-red-400 mt-1">Dead</span>
+      )}
+      {onRetire && canRetire && (
+        <button
+          type="button"
+          onClick={e => {
+            e.stopPropagation()
+            onRetire(e, character.id)
+          }}
+          className="mt-2 text-xs px-3 py-1 bg-amber-700/50 hover:bg-amber-600/60 text-amber-200 rounded transition-colors focus:outline-none border border-amber-600/40"
+          aria-label={`Retire ${character.name}`}
+        >
+          Retire
+        </button>
+      )}
       {onDelete && (
         <button
           type="button"

--- a/src/app/tap-tap-adventure/components/CharacterCreation.tsx
+++ b/src/app/tap-tap-adventure/components/CharacterCreation.tsx
@@ -9,7 +9,7 @@ import {
 } from '@/app/tap-tap-adventure/config/characterOptions'
 import { useCharacterCreation } from '@/app/tap-tap-adventure/hooks/useCharacterCreation'
 import { GeneratedClass } from '@/app/tap-tap-adventure/models/generatedClass'
-import { FantasyCharacter } from '@/app/tap-tap-adventure/models/types'
+import { FantasyCharacter, Item } from '@/app/tap-tap-adventure/models/types'
 
 function StatBadge({ label, value }: { label: string; value: number }) {
   const sign = value > 0 ? '+' : ''
@@ -96,8 +96,49 @@ function GeneratedClassCard({
   )
 }
 
-function StepIndicator({ currentStep }: { currentStep: number }) {
-  const steps = ['Name', 'Race', 'Class']
+function HeirloomCard({
+  item,
+  selected,
+  onSelect,
+}: {
+  item: Item
+  selected: boolean
+  onSelect: (item: Item) => void
+}) {
+  return (
+    <button
+      type="button"
+      onClick={() => onSelect(item)}
+      className={`text-left p-4 rounded-lg border transition-all cursor-pointer focus:outline-none ${
+        selected
+          ? 'border-amber-500 bg-amber-500/10 ring-1 ring-amber-500'
+          : 'border-amber-700/40 bg-[#2a2b3f] hover:border-amber-600/60'
+      }`}
+    >
+      <div className="flex items-center gap-2">
+        <span className="text-amber-400 text-sm">&#9733;</span>
+        <span className="text-slate-200 font-semibold text-sm">{item.name}</span>
+        {item.type && (
+          <span className="text-[10px] px-1.5 py-0.5 bg-amber-900/50 text-amber-300 rounded">
+            {item.type === 'spell_scroll' ? 'Spell Scroll' : item.type.charAt(0).toUpperCase() + item.type.slice(1)}
+          </span>
+        )}
+      </div>
+      <div className="text-xs text-slate-400 mt-1">{item.description}</div>
+      {item.effects && (
+        <div className="text-xs text-emerald-400 mt-1">
+          {Object.entries(item.effects)
+            .filter(([, v]) => v !== undefined && v !== 0)
+            .map(([k, v]) => `+${v} ${k.charAt(0).toUpperCase() + k.slice(1)}`)
+            .join(', ')}
+        </div>
+      )}
+    </button>
+  )
+}
+
+function StepIndicator({ currentStep, hasHeirlooms }: { currentStep: number; hasHeirlooms: boolean }) {
+  const steps = hasHeirlooms ? ['Name', 'Race', 'Class', 'Heirloom'] : ['Name', 'Race', 'Class']
   return (
     <div className="flex items-center justify-center gap-2 mb-6">
       {steps.map((label, i) => {
@@ -151,6 +192,10 @@ export default function CharacterCreation({
     selectGeneratedClass,
     fetchGeneratedClasses,
     completeCreation,
+    legacyHeirlooms,
+    hasHeirlooms,
+    selectedHeirloom,
+    setSelectedHeirloom,
   } = useCharacterCreation()
 
   const [step, setStep] = useState(1)
@@ -176,7 +221,7 @@ export default function CharacterCreation({
 
   return (
     <form className="space-y-6 p-1" onSubmit={handleSubmit}>
-      <StepIndicator currentStep={step} />
+      <StepIndicator currentStep={step} hasHeirlooms={hasHeirlooms} />
 
       {/* Step 1: Name */}
       {step === 1 && (
@@ -302,12 +347,61 @@ export default function CharacterCreation({
             >
               Back
             </button>
+            {hasHeirlooms ? (
+              <button
+                type="button"
+                disabled={!isValid}
+                onClick={() => setStep(4)}
+                className="flex-1 bg-indigo-600 hover:bg-indigo-700 disabled:bg-slate-700 disabled:text-slate-500 text-white font-semibold px-4 py-3 rounded-md transition-colors focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 focus:ring-offset-[#161723] shadow-md"
+              >
+                Next: Choose Heirloom
+              </button>
+            ) : (
+              <button
+                type="submit"
+                disabled={!isValid}
+                className="flex-1 bg-indigo-600 hover:bg-indigo-700 disabled:bg-slate-700 disabled:text-slate-500 text-white font-semibold px-4 py-3 rounded-md transition-colors focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 focus:ring-offset-[#161723] shadow-md"
+              >
+                Create Character
+              </button>
+            )}
+          </div>
+        </div>
+      )}
+
+      {/* Step 4: Heirloom Selection */}
+      {step === 4 && hasHeirlooms && (
+        <div>
+          <label className="block text-sm font-medium text-slate-300 mb-3">Choose an Heirloom (Optional)</label>
+          <p className="text-xs text-slate-400 mb-4">
+            Previous characters left behind these items. Pick one to start your journey with, or skip to begin without one.
+          </p>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+            {legacyHeirlooms.map((item: Item) => (
+              <HeirloomCard
+                key={item.id}
+                item={item}
+                selected={selectedHeirloom?.id === item.id}
+                onSelect={(heirloom) => {
+                  setSelectedHeirloom(selectedHeirloom?.id === heirloom.id ? null : heirloom)
+                }}
+              />
+            ))}
+          </div>
+          <div className="flex gap-3 mt-4">
+            <button
+              type="button"
+              onClick={() => setStep(3)}
+              className="flex-1 bg-[#2a2b3f] hover:bg-[#3a3c56] text-slate-300 font-semibold px-4 py-3 rounded-md transition-colors focus:outline-none border border-[#3a3c56]"
+            >
+              Back
+            </button>
             <button
               type="submit"
               disabled={!isValid}
               className="flex-1 bg-indigo-600 hover:bg-indigo-700 disabled:bg-slate-700 disabled:text-slate-500 text-white font-semibold px-4 py-3 rounded-md transition-colors focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 focus:ring-offset-[#161723] shadow-md"
             >
-              Create Character
+              {selectedHeirloom ? 'Create with Heirloom' : 'Create without Heirloom'}
             </button>
           </div>
         </div>

--- a/src/app/tap-tap-adventure/components/CharacterList.tsx
+++ b/src/app/tap-tap-adventure/components/CharacterList.tsx
@@ -14,12 +14,16 @@ const selectCharacters = (s: GameStore) => s.gameState?.characters ?? EMPTY_ARRA
 const selectSelectedCharacterId = (s: GameStore) => s.gameState?.selectedCharacterId
 const selectSelectCharacter = (s: GameStore) => s.selectCharacter
 const selectDeleteCharacter = (s: GameStore) => s.deleteCharacter
+const selectRetireCharacter = (s: GameStore) => s.retireCharacter
+const selectLegacyHeirlooms = (s: GameStore) => s.gameState?.legacyHeirlooms ?? EMPTY_ARRAY
 
 export default function CharacterList() {
   const characters = useGameStore(selectCharacters)
   const selectedCharacterId = useGameStore(selectSelectedCharacterId)
   const selectCharacter = useGameStore(selectSelectCharacter)
   const deleteCharacter = useGameStore(selectDeleteCharacter)
+  const retireCharacter = useGameStore(selectRetireCharacter)
+  const legacyHeirlooms = useGameStore(selectLegacyHeirlooms)
   const [showCreation, setShowCreation] = useState(false)
 
   const handleSelect = (character: FantasyCharacter) => {
@@ -29,6 +33,13 @@ export default function CharacterList() {
   const handleDelete = (e: React.MouseEvent, id: string) => {
     e.stopPropagation()
     deleteCharacter(id)
+  }
+
+  const handleRetire = (e: React.MouseEvent, id: string) => {
+    e.stopPropagation()
+    if (window.confirm('Are you sure you want to retire this character? They will leave behind an heirloom for future characters.')) {
+      retireCharacter(id)
+    }
   }
 
   const handleNewCharacter = () => {
@@ -41,7 +52,14 @@ export default function CharacterList() {
 
   return (
     <div className="w-full mx-auto p-6 p-4 bg-[#161723] border border-[#3a3c56] rounded-lg mt-6">
-      <h2 className="text-2xl font-semibold mb-6 text-slate-200">Your Characters</h2>
+      <div className="flex items-center justify-between mb-6">
+        <h2 className="text-2xl font-semibold text-slate-200">Your Characters</h2>
+        {legacyHeirlooms.length > 0 && (
+          <span className="text-sm text-amber-400 bg-amber-900/30 border border-amber-600/40 px-3 py-1 rounded-full">
+            Legacy Items: {legacyHeirlooms.length}
+          </span>
+        )}
+      </div>
       <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
         {characters.map((char: FantasyCharacter) => (
           <CharacterCard
@@ -50,6 +68,7 @@ export default function CharacterList() {
             selected={selectedCharacterId === char.id}
             onSelect={handleSelect}
             onDelete={handleDelete}
+            onRetire={handleRetire}
           />
         ))}
         {characters.length < 5 && <AddCharacterCard onClick={handleNewCharacter} />}

--- a/src/app/tap-tap-adventure/components/InventoryPanel.tsx
+++ b/src/app/tap-tap-adventure/components/InventoryPanel.tsx
@@ -82,9 +82,12 @@ export function InventoryPanel({ inventory }: InventoryPanelProps) {
             items={itemsToDisplay}
             className="space-y-0 w-full"
             renderItem={(item: Item) => (
-              <div className="bg-[#1e1f30] border border-[#3a3c56] p-4 rounded-lg space-y-2 mb-3 w-full">
+              <div className={`bg-[#1e1f30] border ${item.isHeirloom ? 'border-amber-500/60 ring-1 ring-amber-500/30' : 'border-[#3a3c56]'} p-4 rounded-lg space-y-2 mb-3 w-full`}>
                 <div className="flex-1">
                   <div className="flex items-center gap-2">
+                    {item.isHeirloom && (
+                      <span className="text-amber-400 text-sm" title="Heirloom">&#9733;</span>
+                    )}
                     <div className="font-bold text-white">{item.name}</div>
                     {item.type === 'consumable' && (
                       <span className="text-[10px] px-1.5 py-0.5 bg-green-900/50 text-green-400 rounded">

--- a/src/app/tap-tap-adventure/hooks/useCharacterCreation.ts
+++ b/src/app/tap-tap-adventure/hooks/useCharacterCreation.ts
@@ -17,12 +17,13 @@ import {
 import { getStartingSpell } from '@/app/tap-tap-adventure/config/startingSpells'
 import { calculateMaxMana } from '@/app/tap-tap-adventure/lib/leveling'
 import { useGameStore } from '@/app/tap-tap-adventure/hooks/useGameStore'
+import { Item } from '@/app/tap-tap-adventure/models/item'
 import { GeneratedClass } from '@/app/tap-tap-adventure/models/generatedClass'
 import { Spell } from '@/app/tap-tap-adventure/models/spell'
 import { FantasyAbility, FantasyCharacter } from '@/app/tap-tap-adventure/models/types'
 
 export function useCharacterCreation() {
-  const { addCharacter } = useGameStore()
+  const { addCharacter, claimHeirloom, gameState } = useGameStore()
   const [character, setCharacter] = useState<Partial<FantasyCharacter>>({})
   const [selectedRace, setSelectedRace] = useState<RaceOption | null>(null)
   const [selectedClass, setSelectedClass] = useState<ClassOption | null>(null)
@@ -30,6 +31,10 @@ export function useCharacterCreation() {
   const [generatedClasses, setGeneratedClasses] = useState<GeneratedClass[]>([])
   const [isLoadingClasses, setIsLoadingClasses] = useState(false)
   const [isComplete, setIsComplete] = useState(false)
+  const [selectedHeirloom, setSelectedHeirloom] = useState<Item | null>(null)
+
+  const legacyHeirlooms = gameState?.legacyHeirlooms ?? []
+  const hasHeirlooms = legacyHeirlooms.length > 0
 
   const stats = useMemo(() => {
     if (selectedRace && selectedGeneratedClass) {
@@ -166,6 +171,16 @@ export function useCharacterCreation() {
     }
     const maxMana = calculateMaxMana(tempChar)
 
+    const startingInventory: Item[] = []
+
+    // Claim selected heirloom if any
+    if (selectedHeirloom) {
+      const claimed = claimHeirloom(selectedHeirloom.id)
+      if (claimed) {
+        startingInventory.push(claimed)
+      }
+    }
+
     const updatedCharacter = {
       ...character,
       id: charId,
@@ -180,6 +195,7 @@ export function useCharacterCreation() {
       maxMana: maxMana,
       spellbook,
       classData,
+      inventory: startingInventory,
     }
 
     addCharacter(updatedCharacter)
@@ -202,5 +218,9 @@ export function useCharacterCreation() {
     fetchGeneratedClasses,
     isComplete,
     completeCreation,
+    legacyHeirlooms,
+    hasHeirlooms,
+    selectedHeirloom,
+    setSelectedHeirloom,
   }
 }

--- a/src/app/tap-tap-adventure/hooks/useCombatActionMutation.ts
+++ b/src/app/tap-tap-adventure/hooks/useCombatActionMutation.ts
@@ -2,6 +2,7 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 
 import { DeathPenalty } from '@/app/tap-tap-adventure/lib/deathPenalty'
+import { generateHeirloom } from '@/app/tap-tap-adventure/lib/heirloomGenerator'
 import { inferItemTypeAndEffects } from '@/app/tap-tap-adventure/lib/itemPostProcessor'
 import { checkQuestProgress } from '@/app/tap-tap-adventure/lib/questGenerator'
 import { CombatAction, CombatState } from '@/app/tap-tap-adventure/models/combat'
@@ -24,7 +25,7 @@ interface CombatActionResponse {
 
 export function useCombatActionMutation() {
   const queryClient = useQueryClient()
-  const { getSelectedCharacter, setMount } = useGameStore()
+  const { getSelectedCharacter, setMount, addHeirloom } = useGameStore()
   const {
     addItem,
     addStoryEvent,
@@ -148,6 +149,10 @@ export function useCombatActionMutation() {
               reputation: penalty ? -penalty.reputationLost : undefined,
             },
           })
+
+          // Generate an heirloom from the defeated character
+          const heirloom = generateHeirloom(character)
+          addHeirloom(heirloom)
         } else if (data.combatState.status === 'fled') {
           addStoryEvent({
             id: `combat-fled-${Date.now()}`,

--- a/src/app/tap-tap-adventure/hooks/useGameStore.ts
+++ b/src/app/tap-tap-adventure/hooks/useGameStore.ts
@@ -4,6 +4,7 @@ import { create } from 'zustand'
 import { persist } from 'zustand/middleware'
 
 import { checkAchievements } from '@/app/tap-tap-adventure/lib/achievementTracker'
+import { generateHeirloom } from '@/app/tap-tap-adventure/lib/heirloomGenerator'
 import { computeUnlockedSkillIds } from '@/app/tap-tap-adventure/lib/skillTracker'
 import { defaultGameState } from '@/app/tap-tap-adventure/lib/defaultGameState'
 import { useItem as applyItemUse } from '@/app/tap-tap-adventure/lib/itemEffects'
@@ -76,6 +77,9 @@ export interface GameStore {
   learnSpell: (itemId: string) => { message: string; learned: boolean } | null
   updateAchievements: (achievements: PlayerAchievement[]) => void
   setMount: (mount: Mount | null) => void
+  addHeirloom: (item: Item) => void
+  claimHeirloom: (itemId: string) => Item | null
+  retireCharacter: (characterId: string) => void
 }
 
 export const useGameStore = create<GameStore>()(
@@ -526,10 +530,53 @@ export const useGameStore = create<GameStore>()(
           })
         )
       },
+      addHeirloom: (item: Item) => {
+        set(
+          produce((state: GameStore) => {
+            if (!state.gameState.legacyHeirlooms) {
+              state.gameState.legacyHeirlooms = []
+            }
+            state.gameState.legacyHeirlooms.push(item)
+          })
+        )
+      },
+      claimHeirloom: (itemId: string) => {
+        const heirloom = get().gameState.legacyHeirlooms?.find(i => i.id === itemId) ?? null
+        if (!heirloom) return null
+        set(
+          produce((state: GameStore) => {
+            state.gameState.legacyHeirlooms = (state.gameState.legacyHeirlooms ?? []).filter(
+              i => i.id !== itemId
+            )
+          })
+        )
+        return heirloom
+      },
+      retireCharacter: (characterId: string) => {
+        set(
+          produce((state: GameStore) => {
+            const character = state.gameState.characters.find(c => c.id === characterId)
+            if (!character || character.status !== 'active') return
+            if ((character.distance ?? 0) < 100) return
+
+            character.status = 'retired'
+            const heirloom = generateHeirloom(character)
+            if (!state.gameState.legacyHeirlooms) {
+              state.gameState.legacyHeirlooms = []
+            }
+            state.gameState.legacyHeirlooms.push(heirloom)
+
+            // Deselect if this was the active character
+            if (state.gameState.selectedCharacterId === characterId) {
+              state.gameState.selectedCharacterId = null
+            }
+          })
+        )
+      },
     }),
     {
       name: 'fantasy-tycoon-storage', // localStorage key (kept for backward compat)
-      version: 9,
+      version: 10,
       migrate: (persistedState: unknown) => {
         const state = persistedState as GameStore
         if (state?.gameState && !('combatState' in state.gameState)) {
@@ -586,6 +633,10 @@ export const useGameStore = create<GameStore>()(
         // v9: Add achievements
         if (state?.gameState && !('achievements' in state.gameState)) {
           (state.gameState as GameState).achievements = []
+        }
+        // v10: Add legacyHeirlooms
+        if (state?.gameState && !('legacyHeirlooms' in state.gameState)) {
+          (state.gameState as GameState).legacyHeirlooms = []
         }
         return state
       },

--- a/src/app/tap-tap-adventure/lib/defaultGameState.ts
+++ b/src/app/tap-tap-adventure/lib/defaultGameState.ts
@@ -17,4 +17,5 @@ export const defaultGameState: GameState = {
   activeQuest: null,
   genericMessage: null,
   achievements: [],
+  legacyHeirlooms: [],
 }

--- a/src/app/tap-tap-adventure/lib/heirloomGenerator.ts
+++ b/src/app/tap-tap-adventure/lib/heirloomGenerator.ts
@@ -1,0 +1,140 @@
+import { FantasyCharacter } from '@/app/tap-tap-adventure/models/character'
+import { Item } from '@/app/tap-tap-adventure/models/item'
+
+/**
+ * Generates an heirloom item from a dead or retired character.
+ * Heirloom quality scales with character level and distance traveled.
+ */
+export function generateHeirloom(character: FantasyCharacter): Item {
+  const heirloomType = pickHeirloomType(character)
+
+  switch (heirloomType) {
+    case 'spell_scroll':
+      return generateSpellScrollHeirloom(character)
+    case 'consumable':
+      return generateConsumableHeirloom(character)
+    case 'equipment':
+    default:
+      return generateEquipmentHeirloom(character)
+  }
+}
+
+type HeirloomKind = 'equipment' | 'consumable' | 'spell_scroll'
+
+function pickHeirloomType(character: FantasyCharacter): HeirloomKind {
+  const spells = character.spellbook ?? []
+  if (spells.length > 0) {
+    // 40% spell scroll, 30% equipment, 30% consumable
+    const roll = hashRandom(character.id + 'heirloom-type')
+    if (roll < 0.4) return 'spell_scroll'
+    if (roll < 0.7) return 'equipment'
+    return 'consumable'
+  }
+  // No spells: 60% equipment, 40% consumable
+  const roll = hashRandom(character.id + 'heirloom-type')
+  if (roll < 0.6) return 'equipment'
+  return 'consumable'
+}
+
+function qualityTier(character: FantasyCharacter): { tier: string; multiplier: number } {
+  const score = character.level + Math.floor((character.distance ?? 0) / 50)
+  if (score >= 20) return { tier: 'Legendary', multiplier: 3 }
+  if (score >= 12) return { tier: 'Epic', multiplier: 2.2 }
+  if (score >= 6) return { tier: 'Rare', multiplier: 1.5 }
+  return { tier: 'Common', multiplier: 1 }
+}
+
+function strongestStat(character: FantasyCharacter): 'strength' | 'intelligence' | 'luck' {
+  const stats = {
+    strength: character.strength ?? 0,
+    intelligence: character.intelligence ?? 0,
+    luck: character.luck ?? 0,
+  }
+  if (stats.strength >= stats.intelligence && stats.strength >= stats.luck) return 'strength'
+  if (stats.intelligence >= stats.luck) return 'intelligence'
+  return 'luck'
+}
+
+function generateEquipmentHeirloom(character: FantasyCharacter): Item {
+  const { tier, multiplier } = qualityTier(character)
+  const stat = strongestStat(character)
+  const baseBonus = Math.max(1, Math.floor(character.level * multiplier))
+
+  const nameTemplates = [
+    `${character.name}'s Lucky Charm`,
+    `${character.name}'s Blade`,
+    `${character.name}'s Shield`,
+    `${character.name}'s Ring`,
+  ]
+  const nameIndex = Math.abs(simpleHash(character.id + 'name')) % nameTemplates.length
+  const name = nameTemplates[nameIndex]
+
+  const effects: Record<string, number> = {}
+  effects[stat] = baseBonus
+
+  // Higher tiers get a secondary stat bonus
+  if (multiplier >= 1.5) {
+    const secondaryStat = stat === 'strength' ? 'intelligence' : stat === 'intelligence' ? 'luck' : 'strength'
+    effects[secondaryStat] = Math.max(1, Math.floor(baseBonus * 0.5))
+  }
+
+  return {
+    id: `heirloom-${character.id}-${Date.now()}`,
+    name,
+    description: `A ${tier.toLowerCase()} heirloom left behind by ${character.name}, a level ${character.level} ${character.class}. It radiates with the memory of past adventures.`,
+    quantity: 1,
+    type: 'equipment',
+    effects,
+    isHeirloom: true,
+  }
+}
+
+function generateConsumableHeirloom(character: FantasyCharacter): Item {
+  const { tier, multiplier } = qualityTier(character)
+  const healAmount = Math.floor(30 * multiplier + character.level * 5)
+
+  return {
+    id: `heirloom-${character.id}-${Date.now()}`,
+    name: `${character.name}'s Final Blessing`,
+    description: `A ${tier.toLowerCase()} restorative keepsake imbued with ${character.name}'s lingering spirit. Use it in times of great need.`,
+    quantity: 1,
+    type: 'consumable',
+    effects: {
+      heal: healAmount,
+    },
+    isHeirloom: true,
+  }
+}
+
+function generateSpellScrollHeirloom(character: FantasyCharacter): Item {
+  const spells = character.spellbook ?? []
+  // Pick the "best" spell (highest mana cost generally = strongest)
+  const spell = [...spells].sort((a, b) => b.manaCost - a.manaCost)[0]
+
+  return {
+    id: `heirloom-${character.id}-${Date.now()}`,
+    name: `${character.name}'s Spell Scroll`,
+    description: `A spell scroll containing ${spell.name}, preserved by ${character.name} before their journey ended.`,
+    quantity: 1,
+    type: 'spell_scroll',
+    spell,
+    isHeirloom: true,
+  }
+}
+
+/** Simple deterministic hash for consistent results given the same character */
+function simpleHash(str: string): number {
+  let hash = 0
+  for (let i = 0; i < str.length; i++) {
+    const char = str.charCodeAt(i)
+    hash = ((hash << 5) - hash) + char
+    hash = hash & hash // Convert to 32bit integer
+  }
+  return hash
+}
+
+/** Returns a deterministic float 0..1 for the given seed string */
+function hashRandom(seed: string): number {
+  const h = Math.abs(simpleHash(seed))
+  return (h % 10000) / 10000
+}

--- a/src/app/tap-tap-adventure/models/item.ts
+++ b/src/app/tap-tap-adventure/models/item.ts
@@ -24,6 +24,7 @@ export const ItemSchema = z.object({
   effects: ItemEffectsSchema.optional(),
   price: z.number().optional(),
   spell: SpellSchema.optional(),
+  isHeirloom: z.boolean().optional(),
 })
 
 export type Item = z.infer<typeof ItemSchema>

--- a/src/app/tap-tap-adventure/models/types.ts
+++ b/src/app/tap-tap-adventure/models/types.ts
@@ -89,6 +89,7 @@ type GameState = {
   activeQuest: TimedQuest | null
   genericMessage: string | null
   achievements: PlayerAchievement[]
+  legacyHeirlooms: Item[]
 }
 export type { GameState }
 export type { PlayerAchievement, Achievement, AchievementCategory } from './achievement'


### PR DESCRIPTION
## Summary
- When characters die in combat or are retired (100+ distance traveled), they leave behind an heirloom item that future characters can inherit during creation
- Heirloom quality scales with character level and distance traveled across Common/Rare/Epic/Legendary tiers
- Three heirloom types: equipment (stat bonuses based on strongest stat), consumables (large heal), and spell scrolls (containing a known spell)

## Changes
- **`lib/heirloomGenerator.ts`** -- Pure function to generate heirlooms from characters with deterministic type selection
- **`models/types.ts` + `defaultGameState.ts`** -- Added `legacyHeirlooms: Item[]` to GameState
- **`models/item.ts`** -- Added `isHeirloom` boolean flag to Item schema
- **`hooks/useGameStore.ts`** -- Added `addHeirloom`, `claimHeirloom`, `retireCharacter` actions + migration v10
- **`hooks/useCombatActionMutation.ts`** -- Generates heirloom on combat defeat
- **`components/CharacterCard.tsx`** -- Retire button (visible at 100+ distance), retired/dead status labels
- **`components/CharacterList.tsx`** -- Legacy items count indicator, retirement handler
- **`hooks/useCharacterCreation.ts` + `components/CharacterCreation.tsx`** -- Step 4 heirloom selection during character creation
- **`components/InventoryPanel.tsx`** -- Gold border and star icon for heirloom items
- **`__tests__/heirloomGenerator.test.ts`** -- 10 unit tests covering generation, naming, scaling, and determinism

## Test plan
- [x] All 411 tests pass (`npx vitest run`)
- [x] `npx next build` succeeds
- [ ] Create a character, travel 100+ steps, retire -- verify heirloom appears
- [ ] Die in combat -- verify heirloom is generated
- [ ] Create new character with heirlooms available -- verify step 4 appears and heirloom can be claimed
- [ ] Verify heirloom items show gold border in inventory

Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>