### PR TITLE
Add Daily Rewards system

### DIFF
--- a/src/app/tap-tap-adventure/__tests__/dailyRewards.test.ts
+++ b/src/app/tap-tap-adventure/__tests__/dailyRewards.test.ts
@@ -1,0 +1,202 @@
+import { describe, expect, it } from 'vitest'
+
+import { DAILY_REWARDS } from '@/app/tap-tap-adventure/config/dailyRewards'
+import {
+  canClaimDailyReward,
+  claimDailyReward,
+  getDailyReward,
+  getTodayDateString,
+} from '@/app/tap-tap-adventure/lib/dailyRewardTracker'
+import { FantasyCharacter } from '@/app/tap-tap-adventure/models/character'
+import { GameState } from '@/app/tap-tap-adventure/models/types'
+
+const baseChar: FantasyCharacter = {
+  id: '1',
+  playerId: 'p1',
+  name: 'Test',
+  race: 'Human',
+  class: 'Warrior',
+  level: 1,
+  abilities: [],
+  locationId: 'loc1',
+  gold: 10,
+  reputation: 5,
+  distance: 0,
+  status: 'active',
+  strength: 5,
+  intelligence: 3,
+  luck: 2,
+  hp: 100,
+  maxHp: 100,
+  inventory: [],
+  equipment: { weapon: null, armor: null, accessory: null },
+  deathCount: 0,
+  pendingStatPoints: 0,
+  mana: 20,
+  maxMana: 20,
+  spellbook: [],
+  classData: undefined,
+}
+
+function makeState(dailyReward: GameState['dailyReward'] = null): GameState {
+  return {
+    player: { id: 'p1', settings: {} },
+    selectedCharacterId: '1',
+    characters: [baseChar],
+    locations: [],
+    storyEvents: [],
+    decisionPoint: null,
+    combatState: null,
+    shopState: null,
+    activeQuest: null,
+    genericMessage: null,
+    achievements: [],
+    legacyHeirlooms: [],
+    dailyReward,
+  }
+}
+
+describe('Daily Rewards', () => {
+  describe('canClaimDailyReward', () => {
+    it('returns true when never claimed', () => {
+      const state = makeState(null)
+      expect(canClaimDailyReward(state)).toBe(true)
+    })
+
+    it('returns true when dailyReward exists but lastClaimedDate is null', () => {
+      const state = makeState({ lastClaimedDate: null, streak: 0, totalDaysClaimed: 0 })
+      expect(canClaimDailyReward(state)).toBe(true)
+    })
+
+    it('returns false if already claimed today', () => {
+      const now = new Date('2026-04-12T14:00:00')
+      const state = makeState({ lastClaimedDate: '2026-04-12', streak: 0, totalDaysClaimed: 1 })
+      expect(canClaimDailyReward(state, now)).toBe(false)
+    })
+
+    it('returns true if last claimed yesterday', () => {
+      const now = new Date('2026-04-12T10:00:00')
+      const state = makeState({ lastClaimedDate: '2026-04-11', streak: 0, totalDaysClaimed: 1 })
+      expect(canClaimDailyReward(state, now)).toBe(true)
+    })
+  })
+
+  describe('getDailyReward', () => {
+    it('returns the correct reward for each day', () => {
+      for (let i = 0; i < 7; i++) {
+        const reward = getDailyReward(i)
+        expect(reward.day).toBe(DAILY_REWARDS[i].day)
+      }
+    })
+
+    it('cycles back after 7 days', () => {
+      expect(getDailyReward(7).day).toBe(DAILY_REWARDS[0].day)
+      expect(getDailyReward(8).day).toBe(DAILY_REWARDS[1].day)
+      expect(getDailyReward(14).day).toBe(DAILY_REWARDS[0].day)
+    })
+  })
+
+  describe('claimDailyReward', () => {
+    it('succeeds when never claimed before', () => {
+      const now = new Date('2026-04-12T12:00:00')
+      const state = makeState(null)
+      const result = claimDailyReward(state, baseChar, now)
+
+      expect(result).not.toBeNull()
+      expect(result!.updatedState.dailyReward).toEqual({
+        lastClaimedDate: '2026-04-12',
+        streak: 0,
+        totalDaysClaimed: 1,
+      })
+      // Day 1 reward is 10 gold
+      expect(result!.goldAwarded).toBe(10)
+      expect(result!.reward.day).toBe(1)
+    })
+
+    it('returns null when already claimed today', () => {
+      const now = new Date('2026-04-12T15:00:00')
+      const state = makeState({ lastClaimedDate: '2026-04-12', streak: 0, totalDaysClaimed: 1 })
+      const result = claimDailyReward(state, baseChar, now)
+      expect(result).toBeNull()
+    })
+
+    it('increments streak on consecutive days', () => {
+      const now = new Date('2026-04-13T10:00:00')
+      const state = makeState({ lastClaimedDate: '2026-04-12', streak: 0, totalDaysClaimed: 1 })
+      const result = claimDailyReward(state, baseChar, now)
+
+      expect(result).not.toBeNull()
+      expect(result!.updatedState.dailyReward!.streak).toBe(1)
+      expect(result!.updatedState.dailyReward!.totalDaysClaimed).toBe(2)
+      // Day 2 reward is a healing potion
+      expect(result!.reward.day).toBe(2)
+    })
+
+    it('resets streak after missing a day', () => {
+      const now = new Date('2026-04-15T10:00:00')
+      const state = makeState({ lastClaimedDate: '2026-04-12', streak: 2, totalDaysClaimed: 3 })
+      const result = claimDailyReward(state, baseChar, now)
+
+      expect(result).not.toBeNull()
+      // Missed 2 days, so streak resets to 0
+      expect(result!.updatedState.dailyReward!.streak).toBe(0)
+      expect(result!.updatedState.dailyReward!.totalDaysClaimed).toBe(4)
+      // Back to Day 1 reward
+      expect(result!.reward.day).toBe(1)
+    })
+
+    it('reward cycle repeats after 7 days', () => {
+      // Streak 6 (day 7) -> next consecutive day -> streak 7 which maps to day 1 again
+      const now = new Date('2026-04-20T10:00:00')
+      const state = makeState({ lastClaimedDate: '2026-04-19', streak: 6, totalDaysClaimed: 7 })
+      const result = claimDailyReward(state, baseChar, now)
+
+      expect(result).not.toBeNull()
+      expect(result!.updatedState.dailyReward!.streak).toBe(7)
+      // streak 7 % 7 = 0, which is day 1
+      expect(result!.reward.day).toBe(1)
+      expect(result!.goldAwarded).toBe(10)
+    })
+
+    it('awards gold to the character', () => {
+      const now = new Date('2026-04-12T12:00:00')
+      const state = makeState(null)
+      const result = claimDailyReward(state, baseChar, now)
+
+      expect(result).not.toBeNull()
+      const updatedChar = result!.updatedState.characters.find(c => c.id === '1')
+      expect(updatedChar!.gold).toBe(baseChar.gold + 10)
+    })
+
+    it('awards reputation on day 5', () => {
+      const now = new Date('2026-04-17T12:00:00')
+      const state = makeState({ lastClaimedDate: '2026-04-16', streak: 3, totalDaysClaimed: 4 })
+      const result = claimDailyReward(state, baseChar, now)
+
+      expect(result).not.toBeNull()
+      // streak 4 = day 5
+      expect(result!.reward.day).toBe(5)
+      expect(result!.reputationAwarded).toBe(3)
+      expect(result!.goldAwarded).toBe(30)
+    })
+
+    it('generates items for item-type rewards', () => {
+      // streak 1 = day 2 (healing potion)
+      const now = new Date('2026-04-13T12:00:00')
+      const state = makeState({ lastClaimedDate: '2026-04-12', streak: 0, totalDaysClaimed: 1 })
+      const result = claimDailyReward(state, baseChar, now)
+
+      expect(result).not.toBeNull()
+      expect(result!.items.length).toBeGreaterThan(0)
+      expect(result!.items[0].name).toBe('Daily Healing Potion')
+      expect(result!.items[0].effects?.heal).toBe(15)
+    })
+  })
+
+  describe('getTodayDateString', () => {
+    it('formats correctly', () => {
+      const d = new Date('2026-01-05T15:30:00')
+      expect(getTodayDateString(d)).toBe('2026-01-05')
+    })
+  })
+})

--- a/src/app/tap-tap-adventure/components/DailyRewardPopup.tsx
+++ b/src/app/tap-tap-adventure/components/DailyRewardPopup.tsx
@@ -1,0 +1,124 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { Button } from '@/app/tap-tap-adventure/components/ui/button'
+import { DailyReward } from '@/app/tap-tap-adventure/config/dailyRewards'
+import { ClaimResult } from '@/app/tap-tap-adventure/lib/dailyRewardTracker'
+
+interface DailyRewardPopupProps {
+  streak: number
+  reward: DailyReward
+  onClaim: () => ClaimResult | null
+  onDismiss: () => void
+}
+
+export function DailyRewardPopup({ streak, reward, onClaim, onDismiss }: DailyRewardPopupProps) {
+  const [isVisible, setIsVisible] = useState(false)
+  const [claimed, setClaimed] = useState(false)
+  const [claimResult, setClaimResult] = useState<ClaimResult | null>(null)
+
+  useEffect(() => {
+    requestAnimationFrame(() => setIsVisible(true))
+  }, [])
+
+  // Auto-dismiss after claiming
+  useEffect(() => {
+    if (!claimed) return
+    const timer = setTimeout(() => {
+      setIsVisible(false)
+      setTimeout(onDismiss, 300)
+    }, 3000)
+    return () => clearTimeout(timer)
+  }, [claimed, onDismiss])
+
+  const dayInCycle = (streak % 7) + 1
+
+  const handleClaim = () => {
+    const result = onClaim()
+    if (result) {
+      setClaimResult(result)
+      setClaimed(true)
+    }
+  }
+
+  return (
+    <div
+      className={`fixed inset-0 z-50 flex items-center justify-center transition-opacity duration-300 ${
+        isVisible ? 'opacity-100' : 'opacity-0'
+      }`}
+    >
+      {/* Backdrop */}
+      <div className="absolute inset-0 bg-black/60" onClick={claimed ? () => { setIsVisible(false); setTimeout(onDismiss, 300) } : undefined} />
+
+      {/* Content */}
+      <div
+        className={`relative transition-all duration-500 ${
+          isVisible ? 'scale-100 translate-y-0' : 'scale-75 translate-y-8'
+        }`}
+      >
+        <div className="bg-gradient-to-b from-[#1e1f30] to-[#161723] border-2 border-amber-500/50 rounded-2xl px-8 py-6 text-center shadow-2xl shadow-amber-500/20 max-w-sm mx-4">
+          {!claimed ? (
+            <>
+              {/* Title */}
+              <h2 className="text-2xl font-bold text-amber-400 mb-1">Daily Reward</h2>
+              <p className="text-slate-400 text-sm mb-4">
+                Day {dayInCycle} of 7
+              </p>
+
+              {/* Streak indicator */}
+              <div className="flex justify-center gap-1.5 mb-4">
+                {Array.from({ length: 7 }).map((_, i) => (
+                  <div
+                    key={i}
+                    className={`w-6 h-6 rounded-full flex items-center justify-center text-xs font-bold ${
+                      i < dayInCycle
+                        ? 'bg-amber-500 text-black'
+                        : 'bg-[#2a2b3f] text-slate-500 border border-[#3a3c56]'
+                    } ${i === dayInCycle - 1 ? 'ring-2 ring-amber-300 ring-offset-1 ring-offset-[#161723]' : ''}`}
+                  >
+                    {i + 1}
+                  </div>
+                ))}
+              </div>
+
+              {/* Reward description */}
+              <div className="bg-[#2a2b3f] border border-[#3a3c56] rounded-lg p-4 mb-4">
+                <p className="text-lg font-semibold text-white mb-1">{reward.label}</p>
+                <p className="text-sm text-slate-300">{reward.description}</p>
+              </div>
+
+              {/* Claim button */}
+              <Button
+                className="w-full bg-gradient-to-r from-amber-600 to-yellow-600 hover:from-amber-500 hover:to-yellow-500 text-white font-bold py-3 rounded-lg text-lg"
+                onClick={handleClaim}
+              >
+                Claim Reward
+              </Button>
+            </>
+          ) : (
+            <>
+              {/* Claimed state */}
+              <h2 className="text-2xl font-bold text-green-400 mb-3">Reward Claimed!</h2>
+
+              <div className="bg-[#2a2b3f] border border-[#3a3c56] rounded-lg p-4 mb-3 space-y-1">
+                {claimResult && claimResult.goldAwarded > 0 && (
+                  <p className="text-amber-300 text-sm">+{claimResult.goldAwarded} Gold</p>
+                )}
+                {claimResult && claimResult.reputationAwarded > 0 && (
+                  <p className="text-blue-300 text-sm">+{claimResult.reputationAwarded} Reputation</p>
+                )}
+                {claimResult && claimResult.items.map(item => (
+                  <p key={item.id} className="text-green-300 text-sm">
+                    Received: {item.name}
+                  </p>
+                ))}
+              </div>
+
+              <p className="text-slate-500 text-xs">Auto-dismissing...</p>
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/app/tap-tap-adventure/components/GameUI.tsx
+++ b/src/app/tap-tap-adventure/components/GameUI.tsx
@@ -8,11 +8,13 @@ import { useMoveForwardMutation } from '@/app/tap-tap-adventure/hooks/useMoveFor
 import { useResolveDecisionMutation } from '@/app/tap-tap-adventure/hooks/useResolveDecisionMutation'
 import { getGenericTravelMessage } from '@/app/tap-tap-adventure/lib/getGenericTravelMessage'
 import { checkAchievements } from '@/app/tap-tap-adventure/lib/achievementTracker'
+import { canClaimDailyReward, getDailyReward } from '@/app/tap-tap-adventure/lib/dailyRewardTracker'
 import { flipCoin } from '@/app/utils'
 
 import { SKILLS } from '@/app/tap-tap-adventure/config/skills'
 import { getSkillBonus } from '@/app/tap-tap-adventure/lib/skillTracker'
 
+import { DailyRewardPopup } from './DailyRewardPopup'
 import { AchievementPanel } from './AchievementPanel'
 import { AchievementToastContainer } from './AchievementToast'
 import { CombatUI, CombatResult } from './CombatUI'
@@ -45,9 +47,19 @@ export default function GameUI() {
     setCombatState,
     allocateStatPoints,
     updateAchievements,
+    claimDailyReward,
   } = useGameStore()
 
   const [newlyCompletedIds, setNewlyCompletedIds] = useState<string[]>([])
+  const [showDailyReward, setShowDailyReward] = useState(false)
+
+  // Check for daily reward on mount
+  useEffect(() => {
+    if (gameState && canClaimDailyReward(gameState)) {
+      setShowDailyReward(true)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
 
   const { mutate: moveForwardMutation, isPending: moveForwardPending } = useMoveForwardMutation()
   const { mutate: resolveDecisionMutation, isPending: resolveDecisionPending } =
@@ -160,6 +172,14 @@ export default function GameUI() {
   return (
     <>
       <AchievementToastContainer achievementIds={newlyCompletedIds} />
+      {showDailyReward && character && (
+        <DailyRewardPopup
+          streak={gameState.dailyReward?.streak ?? 0}
+          reward={getDailyReward(gameState.dailyReward?.streak ?? 0)}
+          onClaim={() => claimDailyReward()}
+          onDismiss={() => setShowDailyReward(false)}
+        />
+      )}
       {character && (character.pendingStatPoints ?? 0) > 0 && (
         <StatAllocationScreen
           character={character}

--- a/src/app/tap-tap-adventure/config/dailyRewards.ts
+++ b/src/app/tap-tap-adventure/config/dailyRewards.ts
@@ -1,0 +1,144 @@
+import { Item } from '@/app/tap-tap-adventure/models/item'
+import { generateSpellForLevel } from '@/app/tap-tap-adventure/lib/spellGenerator'
+
+export type DailyRewardType = 'gold' | 'item' | 'gold_and_reputation' | 'spell_scroll' | 'gold_and_rare_item'
+
+export interface DailyReward {
+  day: number
+  label: string
+  description: string
+  type: DailyRewardType
+  gold?: number
+  reputation?: number
+  /** Called at claim time to generate any items for this reward. */
+  generateItems?: (characterLevel: number) => Item[]
+}
+
+function makeId(): string {
+  return `daily-${Date.now()}-${Math.floor(Math.random() * 100000)}`
+}
+
+const EQUIPMENT_NAMES = [
+  'Traveler\'s Blade',
+  'Iron Shield',
+  'Worn Leather Armor',
+  'Lucky Charm',
+  'Silver Ring',
+  'Hunter\'s Bow',
+]
+
+const RARE_ITEM_NAMES = [
+  'Phoenix Feather Amulet',
+  'Dragon Scale Armor',
+  'Enchanted Crystal Staff',
+  'Shadow Cloak of Stealth',
+  'Ancient Hero\'s Blade',
+]
+
+function pickRandom<T>(arr: T[]): T {
+  return arr[Math.floor(Math.random() * arr.length)]
+}
+
+export const DAILY_REWARDS: DailyReward[] = [
+  {
+    day: 1,
+    label: '10 Gold',
+    description: 'A small purse of gold to start your week.',
+    type: 'gold',
+    gold: 10,
+  },
+  {
+    day: 2,
+    label: 'Healing Potion',
+    description: 'A restorative potion that mends wounds.',
+    type: 'item',
+    generateItems: () => [
+      {
+        id: makeId(),
+        name: 'Daily Healing Potion',
+        description: 'A healing potion received as a daily reward.',
+        quantity: 1,
+        type: 'consumable' as const,
+        effects: { heal: 15 },
+      },
+    ],
+  },
+  {
+    day: 3,
+    label: '20 Gold',
+    description: 'A decent haul of gold for a faithful adventurer.',
+    type: 'gold',
+    gold: 20,
+  },
+  {
+    day: 4,
+    label: 'Random Equipment',
+    description: 'A piece of equipment found on the road.',
+    type: 'item',
+    generateItems: () => {
+      const name = pickRandom(EQUIPMENT_NAMES)
+      return [
+        {
+          id: makeId(),
+          name,
+          description: `Equipment received as a daily reward: ${name}.`,
+          quantity: 1,
+          type: 'equipment' as const,
+          effects: {
+            strength: Math.floor(Math.random() * 3) + 1,
+          },
+        },
+      ]
+    },
+  },
+  {
+    day: 5,
+    label: '30 Gold + Reputation',
+    description: 'Gold and a boost to your standing among the people.',
+    type: 'gold_and_reputation',
+    gold: 30,
+    reputation: 3,
+  },
+  {
+    day: 6,
+    label: 'Spell Scroll',
+    description: 'A magical scroll containing a random spell.',
+    type: 'spell_scroll',
+    generateItems: (characterLevel: number) => {
+      const spell = generateSpellForLevel(characterLevel)
+      return [
+        {
+          id: makeId(),
+          name: `Scroll of ${spell.name}`,
+          description: `A spell scroll received as a daily reward. Contains: ${spell.name}.`,
+          quantity: 1,
+          type: 'spell_scroll' as const,
+          spell,
+        },
+      ]
+    },
+  },
+  {
+    day: 7,
+    label: '50 Gold + Rare Item',
+    description: 'The grand prize! Riches and a rare treasure.',
+    type: 'gold_and_rare_item',
+    gold: 50,
+    generateItems: () => {
+      const name = pickRandom(RARE_ITEM_NAMES)
+      return [
+        {
+          id: makeId(),
+          name,
+          description: `A rare item received as a daily reward: ${name}.`,
+          quantity: 1,
+          type: 'equipment' as const,
+          effects: {
+            strength: Math.floor(Math.random() * 3) + 2,
+            luck: Math.floor(Math.random() * 3) + 1,
+          },
+        },
+      ]
+    },
+  },
+]

--- a/src/app/tap-tap-adventure/hooks/useGameStore.ts
+++ b/src/app/tap-tap-adventure/hooks/useGameStore.ts
@@ -24,6 +24,7 @@ import {
   Item,
   ShopState,
 } from '@/app/tap-tap-adventure/models/types'
+import { claimDailyReward as processDailyRewardClaim } from '@/app/tap-tap-adventure/lib/dailyRewardTracker'
 
 const defaultCharacter: FantasyCharacter = {
   id: '',
@@ -80,6 +81,7 @@ export interface GameStore {
   addHeirloom: (item: Item) => void
   claimHeirloom: (itemId: string) => Item | null
   retireCharacter: (characterId: string) => void
+  claimDailyReward: () => import('@/app/tap-tap-adventure/lib/dailyRewardTracker').ClaimResult | null
 }
 
 export const useGameStore = create<GameStore>()(
@@ -552,6 +554,17 @@ export const useGameStore = create<GameStore>()(
         )
         return heirloom
       },
+      claimDailyReward: () => {
+        const state = get().gameState
+        const selectedCharacter = get().getSelectedCharacter()
+        if (!selectedCharacter) return null
+
+        const result = processDailyRewardClaim(state, selectedCharacter)
+        if (!result) return null
+
+        set({ gameState: result.updatedState })
+        return result
+      },
       retireCharacter: (characterId: string) => {
         set(
           produce((state: GameStore) => {
@@ -576,7 +589,7 @@ export const useGameStore = create<GameStore>()(
     }),
     {
       name: 'fantasy-tycoon-storage', // localStorage key (kept for backward compat)
-      version: 10,
+      version: 11,
       migrate: (persistedState: unknown) => {
         const state = persistedState as GameStore
         if (state?.gameState && !('combatState' in state.gameState)) {
@@ -637,6 +650,10 @@ export const useGameStore = create<GameStore>()(
         // v10: Add legacyHeirlooms
         if (state?.gameState && !('legacyHeirlooms' in state.gameState)) {
           (state.gameState as GameState).legacyHeirlooms = []
+        }
+        // v11: Add dailyReward
+        if (state?.gameState && !('dailyReward' in state.gameState)) {
+          (state.gameState as GameState).dailyReward = null
         }
         return state
       },

--- a/src/app/tap-tap-adventure/lib/dailyRewardTracker.ts
+++ b/src/app/tap-tap-adventure/lib/dailyRewardTracker.ts
@@ -1,0 +1,132 @@
+import { DAILY_REWARDS, DailyReward } from '@/app/tap-tap-adventure/config/dailyRewards'
+import { FantasyCharacter } from '@/app/tap-tap-adventure/models/character'
+import { GameState } from '@/app/tap-tap-adventure/models/types'
+import { Item } from '@/app/tap-tap-adventure/models/item'
+
+export interface DailyRewardState {
+  lastClaimedDate: string | null // ISO date string (YYYY-MM-DD)
+  streak: number // consecutive days claimed
+  totalDaysClaimed: number
+}
+
+/**
+ * Get today's date as YYYY-MM-DD in the local timezone.
+ * Accepts an optional override for testing.
+ */
+export function getTodayDateString(now?: Date): string {
+  const d = now ?? new Date()
+  const year = d.getFullYear()
+  const month = String(d.getMonth() + 1).padStart(2, '0')
+  const day = String(d.getDate()).padStart(2, '0')
+  return `${year}-${month}-${day}`
+}
+
+/**
+ * Calculate the difference in calendar days between two YYYY-MM-DD strings.
+ */
+function daysBetween(dateA: string, dateB: string): number {
+  const a = new Date(dateA + 'T00:00:00')
+  const b = new Date(dateB + 'T00:00:00')
+  const diffMs = b.getTime() - a.getTime()
+  return Math.round(diffMs / (1000 * 60 * 60 * 24))
+}
+
+/**
+ * Check whether the player can claim their daily reward right now.
+ */
+export function canClaimDailyReward(state: GameState, now?: Date): boolean {
+  const today = getTodayDateString(now)
+  const dr = state.dailyReward
+
+  if (!dr || !dr.lastClaimedDate) {
+    return true // never claimed before
+  }
+
+  return dr.lastClaimedDate < today
+}
+
+/**
+ * Get the reward definition for a given streak value.
+ * Streak is 0-indexed internally but maps to day 1-7.
+ */
+export function getDailyReward(streak: number): DailyReward {
+  const dayIndex = streak % DAILY_REWARDS.length
+  return DAILY_REWARDS[dayIndex]
+}
+
+export interface ClaimResult {
+  updatedState: GameState
+  reward: DailyReward
+  items: Item[]
+  goldAwarded: number
+  reputationAwarded: number
+}
+
+/**
+ * Process claiming the daily reward. Returns updated state and reward details.
+ */
+export function claimDailyReward(
+  state: GameState,
+  character: FantasyCharacter,
+  now?: Date
+): ClaimResult | null {
+  if (!canClaimDailyReward(state, now)) {
+    return null
+  }
+
+  const today = getTodayDateString(now)
+  const dr = state.dailyReward ?? { lastClaimedDate: null, streak: 0, totalDaysClaimed: 0 }
+
+  // Determine new streak
+  let newStreak: number
+  if (!dr.lastClaimedDate) {
+    newStreak = 0
+  } else {
+    const diff = daysBetween(dr.lastClaimedDate, today)
+    if (diff === 1) {
+      // Consecutive day
+      newStreak = dr.streak + 1
+    } else {
+      // Missed a day (or more) — reset streak
+      newStreak = 0
+    }
+  }
+
+  const reward = getDailyReward(newStreak)
+
+  // Generate items if the reward has them
+  const items: Item[] = reward.generateItems ? reward.generateItems(character.level) : []
+  const goldAwarded = reward.gold ?? 0
+  const reputationAwarded = reward.reputation ?? 0
+
+  // Build updated character
+  const updatedCharacter: FantasyCharacter = {
+    ...character,
+    gold: character.gold + goldAwarded,
+    reputation: character.reputation + reputationAwarded,
+    inventory: [...character.inventory, ...items],
+  }
+
+  // Build updated state
+  const updatedCharacters = state.characters.map(c =>
+    c.id === character.id ? updatedCharacter : c
+  )
+
+  const updatedState: GameState = {
+    ...state,
+    characters: updatedCharacters,
+    dailyReward: {
+      lastClaimedDate: today,
+      streak: newStreak,
+      totalDaysClaimed: dr.totalDaysClaimed + 1,
+    },
+  }
+
+  return {
+    updatedState,
+    reward,
+    items,
+    goldAwarded,
+    reputationAwarded,
+  }
+}

--- a/src/app/tap-tap-adventure/lib/defaultGameState.ts
+++ b/src/app/tap-tap-adventure/lib/defaultGameState.ts
@@ -18,4 +18,5 @@ export const defaultGameState: GameState = {
   genericMessage: null,
   achievements: [],
   legacyHeirlooms: [],
+  dailyReward: null,
 }

--- a/src/app/tap-tap-adventure/models/types.ts
+++ b/src/app/tap-tap-adventure/models/types.ts
@@ -74,6 +74,12 @@ export type {
   ActiveSpellEffectSchema,
 } from './combat'
 
+type DailyRewardState = {
+  lastClaimedDate: string | null // ISO date string (YYYY-MM-DD)
+  streak: number // consecutive days claimed
+  totalDaysClaimed: number
+}
+
 type GameState = {
   player: {
     id: string
@@ -90,6 +96,7 @@ type GameState = {
   genericMessage: string | null
   achievements: PlayerAchievement[]
   legacyHeirlooms: Item[]
+  dailyReward: DailyRewardState | null
 }
-export type { GameState }
+export type { GameState, DailyRewardState }
 export type { PlayerAchievement, Achievement, AchievementCategory } from './achievement'


### PR DESCRIPTION
## Summary
- Add a 7-day repeating daily reward cycle (gold, healing potions, equipment, spell scrolls, rare items) to drive player retention
- Players see a popup when opening the game if they haven't claimed today's reward, with streak tracking and visual day indicator
- Streak resets if a day is missed; cycle repeats after day 7

## Changes
- **New files**: `config/dailyRewards.ts` (reward definitions), `lib/dailyRewardTracker.ts` (claim logic), `components/DailyRewardPopup.tsx` (UI)
- **Modified**: `models/types.ts` (DailyRewardState type), `lib/defaultGameState.ts`, `hooks/useGameStore.ts` (store action + migration v11), `components/GameUI.tsx` (popup integration)
- **Tests**: `__tests__/dailyRewards.test.ts` — 15 tests covering claim eligibility, streak behavior, reward cycling, gold/reputation/item awards

## Test plan
- [x] `npx vitest run` — all 458 tests pass (including 15 new daily reward tests)
- [x] `npx next build` — builds successfully
- [ ] Manual: open game, verify popup appears, claim reward, verify no repeat same day
- [ ] Manual: return next day, verify streak increments and day 2 reward given

🤖 Generated with [Claude Code](https://claude.com/claude-code)