### PR TITLE
Fix class generation to use effects-first approach

### DIFF
--- a/src/app/tap-tap-adventure/__tests__/classGenerator.test.ts
+++ b/src/app/tap-tap-adventure/__tests__/classGenerator.test.ts
@@ -1,9 +1,15 @@
 import { describe, expect, it } from 'vitest'
 
 import { FALLBACK_CLASSES } from '@/app/tap-tap-adventure/config/fallbackClasses'
+import { SpellEffectTypeSchema, SpellElementSchema } from '@/app/tap-tap-adventure/models/spell'
 import {
   COMBAT_STYLES,
+  generateManaAndSlots,
+  generateStartingAbility,
+  generateStatDistribution,
+  getElementForModifier,
   getSchoolForModifier,
+  getStyleCategory,
   MODIFIERS,
   pickRandomSeeds,
 } from '@/app/tap-tap-adventure/lib/classGenerator'
@@ -90,6 +96,168 @@ describe('getSchoolForModifier', () => {
   })
 })
 
+describe('getStyleCategory', () => {
+  it('maps martial styles to martial', () => {
+    expect(getStyleCategory('martial')).toBe('martial')
+    expect(getStyleCategory('berserker')).toBe('martial')
+    expect(getStyleCategory('guardian')).toBe('martial')
+  })
+
+  it('maps arcane styles to arcane', () => {
+    expect(getStyleCategory('arcane')).toBe('arcane')
+    expect(getStyleCategory('elementalist')).toBe('arcane')
+  })
+
+  it('maps shadow styles to shadow', () => {
+    expect(getStyleCategory('shadow')).toBe('shadow')
+    expect(getStyleCategory('assassin')).toBe('shadow')
+  })
+
+  it('defaults to martial for unknown styles', () => {
+    expect(getStyleCategory('unknown')).toBe('martial')
+  })
+})
+
+describe('getElementForModifier', () => {
+  it('maps fire to fire element', () => {
+    expect(getElementForModifier('fire')).toBe('fire')
+  })
+
+  it('maps ice to ice element', () => {
+    expect(getElementForModifier('ice')).toBe('ice')
+  })
+
+  it('maps storm to lightning element', () => {
+    expect(getElementForModifier('storm')).toBe('lightning')
+  })
+
+  it('maps void to shadow element', () => {
+    expect(getElementForModifier('void')).toBe('shadow')
+  })
+
+  it('returns none for unknown modifiers', () => {
+    expect(getElementForModifier('unknown')).toBe('none')
+  })
+
+  it('returns a valid SpellElement for all known modifiers', () => {
+    const validElements = SpellElementSchema.options
+    for (const modifier of MODIFIERS) {
+      const element = getElementForModifier(modifier)
+      expect(validElements).toContain(element)
+    }
+  })
+})
+
+describe('generateStatDistribution', () => {
+  it('always totals 18', () => {
+    for (const style of COMBAT_STYLES) {
+      const stats = generateStatDistribution(style)
+      expect(stats.strength + stats.intelligence + stats.luck).toBe(18)
+    }
+  })
+
+  it('keeps all stats between 3 and 10', () => {
+    // Run multiple times for randomness coverage
+    for (let i = 0; i < 50; i++) {
+      for (const style of ['martial', 'arcane', 'divine', 'shadow']) {
+        const stats = generateStatDistribution(style)
+        expect(stats.strength).toBeGreaterThanOrEqual(3)
+        expect(stats.strength).toBeLessThanOrEqual(10)
+        expect(stats.intelligence).toBeGreaterThanOrEqual(3)
+        expect(stats.intelligence).toBeLessThanOrEqual(10)
+        expect(stats.luck).toBeGreaterThanOrEqual(3)
+        expect(stats.luck).toBeLessThanOrEqual(10)
+      }
+    }
+  })
+
+  it('martial styles favor strength', () => {
+    // Average over many runs
+    let totalStr = 0
+    const runs = 100
+    for (let i = 0; i < runs; i++) {
+      totalStr += generateStatDistribution('martial').strength
+    }
+    expect(totalStr / runs).toBeGreaterThan(6)
+  })
+
+  it('arcane styles favor intelligence', () => {
+    let totalInt = 0
+    const runs = 100
+    for (let i = 0; i < runs; i++) {
+      totalInt += generateStatDistribution('arcane').intelligence
+    }
+    expect(totalInt / runs).toBeGreaterThan(7)
+  })
+})
+
+describe('generateManaAndSlots', () => {
+  it('returns manaMultiplier between 0.5 and 1.5', () => {
+    for (let i = 0; i < 50; i++) {
+      for (const style of ['martial', 'arcane', 'divine', 'psionic']) {
+        const { manaMultiplier } = generateManaAndSlots(style)
+        expect(manaMultiplier).toBeGreaterThanOrEqual(0.5)
+        expect(manaMultiplier).toBeLessThanOrEqual(1.5)
+      }
+    }
+  })
+
+  it('returns spellSlots between 2 and 6', () => {
+    for (let i = 0; i < 50; i++) {
+      for (const style of ['martial', 'arcane', 'divine', 'psionic']) {
+        const { spellSlots } = generateManaAndSlots(style)
+        expect(spellSlots).toBeGreaterThanOrEqual(2)
+        expect(spellSlots).toBeLessThanOrEqual(6)
+      }
+    }
+  })
+})
+
+describe('generateStartingAbility', () => {
+  it('returns valid SpellEffect types', () => {
+    const validTypes = SpellEffectTypeSchema.options
+    for (const style of COMBAT_STYLES) {
+      const ability = generateStartingAbility(style, 'fire', 'war')
+      for (const effect of ability.effects) {
+        expect(validTypes).toContain(effect.type)
+      }
+    }
+  })
+
+  it('returns 2+ effects', () => {
+    for (const style of COMBAT_STYLES) {
+      const ability = generateStartingAbility(style, 'ice', 'arcane')
+      expect(ability.effects.length).toBeGreaterThanOrEqual(2)
+    }
+  })
+
+  it('uses the correct element from modifier', () => {
+    const ability = generateStartingAbility('arcane', 'fire', 'war')
+    const damageEffects = ability.effects.filter(e => e.element)
+    if (damageEffects.length > 0) {
+      expect(damageEffects[0].element).toBe('fire')
+    }
+  })
+
+  it('has valid target', () => {
+    for (const style of COMBAT_STYLES) {
+      const ability = generateStartingAbility(style, 'fire', 'war')
+      expect(['enemy', 'self']).toContain(ability.target)
+    }
+  })
+
+  it('has manaCost and cooldown', () => {
+    const ability = generateStartingAbility('martial', 'iron', 'war')
+    expect(ability.manaCost).toBeGreaterThan(0)
+    expect(ability.cooldown).toBeGreaterThan(0)
+  })
+
+  it('has tags', () => {
+    const ability = generateStartingAbility('martial', 'iron', 'war')
+    expect(ability.tags.length).toBeGreaterThan(0)
+  })
+})
+
 describe('fallback classes', () => {
   it('has at least 15 fallback classes', () => {
     expect(FALLBACK_CLASSES.length).toBeGreaterThanOrEqual(15)
@@ -151,5 +319,25 @@ describe('fallback classes', () => {
     const ids = FALLBACK_CLASSES.map(c => c.id)
     const uniqueIds = new Set(ids)
     expect(uniqueIds.size).toBe(ids.length)
+  })
+
+  it('all fallback class abilities use valid SpellEffect types', () => {
+    const validTypes = SpellEffectTypeSchema.options
+    for (const cls of FALLBACK_CLASSES) {
+      for (const effect of cls.startingAbility.effects) {
+        expect(validTypes).toContain(effect.type)
+      }
+    }
+  })
+
+  it('all fallback class abilities use valid SpellElement values', () => {
+    const validElements = SpellElementSchema.options
+    for (const cls of FALLBACK_CLASSES) {
+      for (const effect of cls.startingAbility.effects) {
+        if (effect.element) {
+          expect(validElements).toContain(effect.element)
+        }
+      }
+    }
   })
 })

--- a/src/app/tap-tap-adventure/lib/classGenerator.ts
+++ b/src/app/tap-tap-adventure/lib/classGenerator.ts
@@ -1,8 +1,8 @@
 import { OpenAI } from 'openai'
 
 import { FALLBACK_CLASSES } from '@/app/tap-tap-adventure/config/fallbackClasses'
-import { GeneratedClass } from '@/app/tap-tap-adventure/models/generatedClass'
-import { SpellSchool } from '@/app/tap-tap-adventure/models/spell'
+import { GeneratedClass, GeneratedClassStartingAbility } from '@/app/tap-tap-adventure/models/generatedClass'
+import { SpellEffect, SpellElement, SpellSchool } from '@/app/tap-tap-adventure/models/spell'
 
 export const COMBAT_STYLES = [
   // Physical
@@ -89,33 +89,305 @@ export function getSchoolForModifier(modifier: string): SpellSchool {
   return mapping[modifier] ?? 'arcane'
 }
 
-const CLASS_GENERATION_PROMPT = `Generate 5 unique fantasy character classes based on the seed: [STYLE] + [MODIFIER].
+/**
+ * Style categories used to determine ability effect combinations.
+ */
+const STYLE_CATEGORIES: Record<string, string[]> = {
+  martial: ['martial', 'berserker', 'duelist', 'guardian', 'monk'],
+  arcane: ['arcane', 'elementalist', 'enchanter', 'summoner', 'ritualist'],
+  divine: ['divine', 'shaman', 'oracle', 'mystic', 'zealot'],
+  primal: ['primal', 'feral', 'druid', 'beastmaster', 'nomad'],
+  shadow: ['shadow', 'assassin', 'trickster', 'phantom', 'spy'],
+  psionic: ['psionic', 'telepath', 'dreamwalker', 'illusionist', 'savant'],
+}
 
-Each class must have:
-- A creative, thematic name (2-3 words)
-- A 1-2 sentence description
-- Stat distribution (strength, intelligence, luck) totaling 18, each between 3 and 10
-- A favored spell school (arcane/nature/shadow/war)
-- Mana multiplier (0.5-1.5, higher for caster types)
-- Spell slots (2-6, more for caster types)
-- A starting ability with effects using these types: damage, heal, buff, debuff, shield, damage_over_time, stun, combo_boost
+/**
+ * Get the style category for a given combat style.
+ */
+export function getStyleCategory(style: string): string {
+  for (const [category, styles] of Object.entries(STYLE_CATEGORIES)) {
+    if (styles.includes(style)) return category
+  }
+  return 'martial'
+}
 
-The [STYLE] determines the combat feel:
-- martial/berserker/duelist/guardian/monk: physical fighters, melee, high strength
-- arcane/elementalist/enchanter/summoner/ritualist: spellcasters, ranged, high intelligence
-- divine/shaman/oracle/mystic/zealot: spiritual, support/healing, balanced stats
-- primal/feral/druid/beastmaster/nomad: wild, nature-connected, strength + luck
-- shadow/assassin/trickster/phantom/spy: stealth, precision, high luck
-- psionic/telepath/dreamwalker/illusionist/savant: mental powers, intelligence + luck
+/**
+ * Map a modifier to a SpellElement for use in damage effects.
+ */
+export function getElementForModifier(modifier: string): SpellElement {
+  const mapping: Record<string, SpellElement> = {
+    fire: 'fire', ice: 'ice', storm: 'lightning', lightning: 'lightning',
+    earth: 'nature', water: 'ice', wind: 'arcane',
+    shadow: 'shadow', void: 'shadow', light: 'arcane', radiance: 'arcane',
+    twilight: 'shadow', eclipse: 'shadow',
+    blood: 'shadow', bone: 'shadow', death: 'shadow', life: 'nature',
+    spirit: 'nature', soul: 'arcane',
+    nature: 'nature', beast: 'nature', flora: 'nature', fungal: 'nature',
+    venom: 'nature', coral: 'nature',
+    iron: 'none', crystal: 'arcane', obsidian: 'none', gold: 'none',
+    jade: 'nature', amber: 'nature',
+    time: 'arcane', fate: 'arcane', chaos: 'shadow', order: 'arcane',
+    dream: 'arcane', memory: 'arcane', rage: 'fire', song: 'nature',
+  }
+  return mapping[modifier] ?? 'none'
+}
 
-The [MODIFIER] adds elemental/thematic flavor and determines the starting ability's element. Be creative — combine the style and modifier into something unique and evocative.`
+/**
+ * Effect templates for each style category. Each template is a list of
+ * effect-building functions that produce valid SpellEffect arrays.
+ */
+type EffectTemplate = {
+  effects: (element: SpellElement) => SpellEffect[]
+  target: 'enemy' | 'self'
+  manaCost: number
+  cooldown: number
+}
 
-const classGenerationFunctions: OpenAI.Chat.Completions.ChatCompletionTool[] = [
+const EFFECT_TEMPLATES: Record<string, EffectTemplate[]> = {
+  martial: [
+    {
+      effects: (el) => [
+        { type: 'damage', value: 10, element: el },
+        { type: 'buff', value: 3, stat: 'attack', duration: 2 },
+      ],
+      target: 'enemy', manaCost: 6, cooldown: 2,
+    },
+    {
+      effects: (el) => [
+        { type: 'damage', value: 12, element: el },
+        { type: 'stun', value: 1 },
+      ],
+      target: 'enemy', manaCost: 7, cooldown: 3,
+    },
+    {
+      effects: () => [
+        { type: 'shield', value: 12 },
+        { type: 'buff', value: 3, stat: 'defense', duration: 2 },
+      ],
+      target: 'self', manaCost: 5, cooldown: 3,
+    },
+  ],
+  arcane: [
+    {
+      effects: (el) => [
+        { type: 'damage', value: 11, element: el },
+        { type: 'damage_over_time', value: 3, element: el, duration: 3 },
+      ],
+      target: 'enemy', manaCost: 6, cooldown: 2,
+    },
+    {
+      effects: (el) => [
+        { type: 'damage', value: 10, element: el },
+        { type: 'shield', value: 8 },
+      ],
+      target: 'enemy', manaCost: 7, cooldown: 2,
+    },
+    {
+      effects: (el) => [
+        { type: 'damage', value: 10, element: el },
+        { type: 'debuff', value: 2, stat: 'attack', duration: 2 },
+      ],
+      target: 'enemy', manaCost: 5, cooldown: 1,
+    },
+  ],
+  divine: [
+    {
+      effects: () => [
+        { type: 'heal', value: 8 },
+        { type: 'buff', value: 3, stat: 'defense', duration: 2 },
+      ],
+      target: 'self', manaCost: 6, cooldown: 3,
+    },
+    {
+      effects: () => [
+        { type: 'shield', value: 10 },
+        { type: 'heal', value: 5 },
+      ],
+      target: 'self', manaCost: 6, cooldown: 3,
+    },
+    {
+      effects: (el) => [
+        { type: 'debuff', value: 3, stat: 'attack', duration: 2 },
+        { type: 'damage', value: 6, element: el },
+      ],
+      target: 'enemy', manaCost: 7, cooldown: 3,
+    },
+  ],
+  primal: [
+    {
+      effects: (el) => [
+        { type: 'damage', value: 9, element: el },
+        { type: 'apply_poison', value: 3, duration: 3 },
+      ],
+      target: 'enemy', manaCost: 5, cooldown: 2,
+    },
+    {
+      effects: (el) => [
+        { type: 'damage', value: 9, element: el },
+        { type: 'combo_boost', value: 1 },
+      ],
+      target: 'enemy', manaCost: 5, cooldown: 2,
+    },
+    {
+      effects: (el) => [
+        { type: 'damage', value: 5, element: el },
+        { type: 'damage_over_time', value: 4, element: el, duration: 3 },
+      ],
+      target: 'enemy', manaCost: 6, cooldown: 3,
+    },
+  ],
+  shadow: [
+    {
+      effects: (el) => [
+        { type: 'damage', value: 10, element: el },
+        { type: 'debuff', value: 2, stat: 'defense', duration: 2 },
+      ],
+      target: 'enemy', manaCost: 6, cooldown: 2,
+    },
+    {
+      effects: (el) => [
+        { type: 'damage', value: 9, element: el },
+        { type: 'apply_slow', value: 1, duration: 2 },
+      ],
+      target: 'enemy', manaCost: 5, cooldown: 2,
+    },
+    {
+      effects: (el) => [
+        { type: 'damage', value: 9, element: el },
+        { type: 'combo_boost', value: 2 },
+      ],
+      target: 'enemy', manaCost: 5, cooldown: 2,
+    },
+  ],
+  psionic: [
+    {
+      effects: (el) => [
+        { type: 'debuff', value: 3, stat: 'attack', duration: 2 },
+        { type: 'shield', value: 8 },
+      ],
+      target: 'enemy', manaCost: 7, cooldown: 3,
+    },
+    {
+      effects: (el) => [
+        { type: 'stun', value: 1 },
+        { type: 'damage', value: 10, element: el },
+      ],
+      target: 'enemy', manaCost: 7, cooldown: 3,
+    },
+    {
+      effects: () => [
+        { type: 'buff', value: 5, stat: 'attack', duration: 3 },
+        { type: 'damage', value: 3 },
+      ],
+      target: 'self', manaCost: 4, cooldown: 2,
+    },
+  ],
+}
+
+/**
+ * Generate a starting ability's mechanical data from style, modifier, and school.
+ * Picks a random effect template for the style category.
+ */
+export function generateStartingAbility(
+  style: string,
+  modifier: string,
+  school: SpellSchool
+): Omit<GeneratedClassStartingAbility, 'name' | 'description'> {
+  const category = getStyleCategory(style)
+  const element = getElementForModifier(modifier)
+  const templates = EFFECT_TEMPLATES[category] ?? EFFECT_TEMPLATES.martial
+  const template = templates[Math.floor(Math.random() * templates.length)]
+  const effects = template.effects(element)
+
+  return {
+    manaCost: template.manaCost,
+    cooldown: template.cooldown,
+    target: template.target,
+    effects,
+    tags: [school, modifier, template.target === 'self' ? 'defense' : 'offense'],
+  }
+}
+
+/**
+ * Generate stat distribution based on style category.
+ * Total always sums to 18, each stat between 3 and 10.
+ */
+export function generateStatDistribution(style: string): {
+  strength: number
+  intelligence: number
+  luck: number
+} {
+  const category = getStyleCategory(style)
+  // Base distributions per category with small random variance
+  const bases: Record<string, [number, number, number]> = {
+    martial:  [8, 4, 6],
+    arcane:   [3, 9, 6],
+    divine:   [5, 7, 6],
+    primal:   [7, 4, 7],
+    shadow:   [5, 4, 9],
+    psionic:  [3, 8, 7],
+  }
+  const [str, int, lck] = bases[category] ?? bases.martial
+
+  // Add small random variance (-1 to +1) while keeping total at 18 and within bounds
+  const variance = Math.floor(Math.random() * 3) - 1 // -1, 0, or 1
+  let strength = Math.max(3, Math.min(10, str + variance))
+  let intelligence = Math.max(3, Math.min(10, int - variance))
+  let luck = 18 - strength - intelligence
+  luck = Math.max(3, Math.min(10, luck))
+  // Re-adjust if luck clamping changed the total
+  const remaining = 18 - strength - luck
+  intelligence = Math.max(3, Math.min(10, remaining))
+
+  return { strength, intelligence, luck }
+}
+
+/**
+ * Generate mana multiplier and spell slots from style category.
+ */
+export function generateManaAndSlots(style: string): {
+  manaMultiplier: number
+  spellSlots: number
+} {
+  const category = getStyleCategory(style)
+  const config: Record<string, { mana: number; slots: number }> = {
+    martial:  { mana: 0.6, slots: 2 },
+    arcane:   { mana: 1.3, slots: 5 },
+    divine:   { mana: 1.1, slots: 4 },
+    primal:   { mana: 0.8, slots: 3 },
+    shadow:   { mana: 0.8, slots: 3 },
+    psionic:  { mana: 1.2, slots: 5 },
+  }
+  const { mana, slots } = config[category] ?? config.martial
+  // Small random variance
+  const manaVariance = (Math.random() * 0.2 - 0.1) // -0.1 to +0.1
+  const slotVariance = Math.random() > 0.5 ? 1 : 0
+  return {
+    manaMultiplier: Math.round(Math.max(0.5, Math.min(1.5, mana + manaVariance)) * 10) / 10,
+    spellSlots: Math.max(2, Math.min(6, slots + slotVariance)),
+  }
+}
+
+/**
+ * Format effects into a human-readable string for the LLM prompt.
+ */
+function describeEffects(effects: SpellEffect[]): string {
+  return effects.map(e => {
+    const parts = [e.type]
+    if (e.value) parts.push(`value: ${e.value}`)
+    if (e.element) parts.push(`element: ${e.element}`)
+    if (e.stat) parts.push(`stat: ${e.stat}`)
+    if (e.duration) parts.push(`duration: ${e.duration} turns`)
+    return parts.join(', ')
+  }).join('; ')
+}
+
+const classNamingFunctions: OpenAI.Chat.Completions.ChatCompletionTool[] = [
   {
     type: 'function',
     function: {
       name: 'return_classes',
-      description: 'Return 5 generated character classes',
+      description: 'Return creative names and descriptions for 5 pre-built character classes',
       parameters: {
         type: 'object',
         properties: {
@@ -124,53 +396,12 @@ const classGenerationFunctions: OpenAI.Chat.Completions.ChatCompletionTool[] = [
             items: {
               type: 'object',
               properties: {
-                id: { type: 'string', description: 'kebab-case identifier, e.g. "frost-weaver"' },
-                name: { type: 'string', description: 'Display name, 2-3 words' },
-                description: { type: 'string', description: '1-2 sentence flavor text' },
-                statDistribution: {
-                  type: 'object',
-                  properties: {
-                    strength: { type: 'number', minimum: 3, maximum: 10 },
-                    intelligence: { type: 'number', minimum: 3, maximum: 10 },
-                    luck: { type: 'number', minimum: 3, maximum: 10 },
-                  },
-                  required: ['strength', 'intelligence', 'luck'],
-                },
-                favoredSchool: { type: 'string', enum: ['arcane', 'nature', 'shadow', 'war'] },
-                manaMultiplier: { type: 'number', minimum: 0.5, maximum: 1.5 },
-                spellSlots: { type: 'number', minimum: 2, maximum: 6 },
-                startingAbility: {
-                  type: 'object',
-                  properties: {
-                    name: { type: 'string' },
-                    description: { type: 'string' },
-                    manaCost: { type: 'number' },
-                    cooldown: { type: 'number' },
-                    target: { type: 'string', enum: ['enemy', 'self'] },
-                    effects: {
-                      type: 'array',
-                      items: {
-                        type: 'object',
-                        properties: {
-                          type: {
-                            type: 'string',
-                            enum: ['damage', 'heal', 'buff', 'debuff', 'shield', 'damage_over_time', 'stun', 'combo_boost'],
-                          },
-                          value: { type: 'number' },
-                          element: { type: 'string', enum: ['fire', 'ice', 'lightning', 'shadow', 'nature', 'arcane', 'none'] },
-                          stat: { type: 'string' },
-                          duration: { type: 'number' },
-                          percentage: { type: 'number' },
-                        },
-                        required: ['type', 'value'],
-                      },
-                    },
-                    tags: { type: 'array', items: { type: 'string' } },
-                  },
-                  required: ['name', 'description', 'manaCost', 'cooldown', 'target', 'effects', 'tags'],
-                },
+                name: { type: 'string', description: 'Creative display name, 2-3 words' },
+                description: { type: 'string', description: '1-2 sentence flavor text that matches the actual mechanics' },
+                abilityName: { type: 'string', description: 'Creative name for the starting ability' },
+                abilityDescription: { type: 'string', description: 'Short description of the ability that accurately reflects its effects' },
               },
-              required: ['id', 'name', 'description', 'statDistribution', 'favoredSchool', 'manaMultiplier', 'spellSlots', 'startingAbility'],
+              required: ['name', 'description', 'abilityName', 'abilityDescription'],
             },
             minItems: 5,
             maxItems: 5,
@@ -184,21 +415,45 @@ const classGenerationFunctions: OpenAI.Chat.Completions.ChatCompletionTool[] = [
 
 /**
  * Call OpenAI to generate 5 classes from a seed combo, then pick 1 randomly.
+ * Mechanical effects are built programmatically first; the LLM only provides
+ * creative names and descriptions that match the pre-built effects.
  */
 export async function generateClassFromSeed(
   style: string,
   modifier: string
 ): Promise<GeneratedClass> {
   const openai = new OpenAI()
+  const school = getSchoolForModifier(modifier)
 
-  const prompt = CLASS_GENERATION_PROMPT
-    .replace('[STYLE]', style)
-    .replace('[MODIFIER]', modifier)
+  // Step 1: Build 5 classes mechanically
+  const mechanicalClasses = Array.from({ length: 5 }, () => {
+    const stats = generateStatDistribution(style)
+    const { manaMultiplier, spellSlots } = generateManaAndSlots(style)
+    const ability = generateStartingAbility(style, modifier, school)
+    return { stats, manaMultiplier, spellSlots, ability }
+  })
+
+  // Step 2: Ask LLM only for creative names/descriptions
+  const classDescriptions = mechanicalClasses.map((cls, i) => {
+    return `Class ${i + 1}:
+- Combat style: ${style}, Modifier: ${modifier}
+- Stats: STR ${cls.stats.strength}, INT ${cls.stats.intelligence}, LCK ${cls.stats.luck}
+- Spell school: ${school}
+- Starting ability target: ${cls.ability.target}
+- Starting ability effects: ${describeEffects(cls.ability.effects)}`
+  }).join('\n\n')
+
+  const prompt = `Given these 5 fantasy character classes with pre-built mechanics, generate a creative name for each class and a 1-2 sentence description.
+Also name each starting ability and describe what it does.
+
+DO NOT invent new mechanics. Each description must accurately reflect the effects listed.
+
+${classDescriptions}`
 
   const response = await openai.chat.completions.create({
     model: 'gpt-4o-mini',
     messages: [{ role: 'user', content: prompt }],
-    tools: classGenerationFunctions,
+    tools: classNamingFunctions,
     tool_choice: { type: 'function', function: { name: 'return_classes' } },
     temperature: 1.0,
   })
@@ -209,22 +464,34 @@ export async function generateClassFromSeed(
   }
 
   const parsed = JSON.parse(toolCall.function.arguments)
-  const classes: GeneratedClass[] = parsed.classes.map((cls: Record<string, unknown>) => ({
-    ...cls,
-    combatStyle: style,
-    modifier: modifier,
-  }))
+  const namedClasses = parsed.classes as {
+    name: string
+    description: string
+    abilityName: string
+    abilityDescription: string
+  }[]
 
-  // Validate and fix stat totals
-  for (const cls of classes) {
-    const total = cls.statDistribution.strength + cls.statDistribution.intelligence + cls.statDistribution.luck
-    if (total !== 18) {
-      // Adjust intelligence to make total 18
-      cls.statDistribution.intelligence = Math.max(3, Math.min(10, 18 - cls.statDistribution.strength - cls.statDistribution.luck))
-      const remaining = 18 - cls.statDistribution.strength - cls.statDistribution.intelligence
-      cls.statDistribution.luck = Math.max(3, Math.min(10, remaining))
+  // Step 3: Combine mechanical data with LLM-generated names
+  const classes: GeneratedClass[] = namedClasses.map((named, i) => {
+    const mech = mechanicalClasses[i]
+    const id = named.name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '')
+    return {
+      id,
+      name: named.name,
+      description: named.description,
+      combatStyle: style,
+      modifier: modifier,
+      statDistribution: mech.stats,
+      favoredSchool: school,
+      manaMultiplier: mech.manaMultiplier,
+      spellSlots: mech.spellSlots,
+      startingAbility: {
+        name: named.abilityName,
+        description: named.abilityDescription,
+        ...mech.ability,
+      },
     }
-  }
+  })
 
   // Pick 1 random class from the 5
   const randomIndex = Math.floor(Math.random() * classes.length)

--- a/src/app/tap-tap-adventure/lib/classGenerator.ts
+++ b/src/app/tap-tap-adventure/lib/classGenerator.ts
@@ -373,7 +373,7 @@ export function generateManaAndSlots(style: string): {
  */
 function describeEffects(effects: SpellEffect[]): string {
   return effects.map(e => {
-    const parts = [e.type]
+    const parts: string[] = [e.type]
     if (e.value) parts.push(`value: ${e.value}`)
     if (e.element) parts.push(`element: ${e.element}`)
     if (e.stat) parts.push(`stat: ${e.stat}`)


### PR DESCRIPTION
## Summary
- Build ability effects, stats, mana multiplier, and spell slots **programmatically** from valid `SpellEffect` types before calling the LLM
- The LLM now only returns creative names and descriptions -- it can no longer invent mechanics that don't exist in the game (e.g. "heals all allies", "reduces enemy accuracy")
- Added `generateStartingAbility()`, `generateStatDistribution()`, `generateManaAndSlots()`, `getStyleCategory()`, and `getElementForModifier()` helper functions
- Simplified the OpenAI function-calling schema to only request `name`, `description`, `abilityName`, `abilityDescription`
- Added 24 new tests covering all new helpers, plus validation that all fallback class effects use valid types

## Test plan
- [x] All 482 tests pass (`npx vitest run`)
- [x] New tests verify stats always total 18 and stay within 3-10 bounds
- [x] New tests verify all generated effects use valid `SpellEffectType` values
- [x] New tests verify element mapping covers all known modifiers
- [x] Fallback classes validated for correct effect types and elements

🤖 Generated with [Claude Code](https://claude.com/claude-code)