### PR TITLE
Add Location/Region Navigation system

### DIFF
--- a/src/app/api/v1/tap-tap-adventure/combat/start/route.ts
+++ b/src/app/api/v1/tap-tap-adventure/combat/start/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 
 import { getDifficultyModifiers } from '@/app/tap-tap-adventure/config/difficultyModes'
+import { getRegion } from '@/app/tap-tap-adventure/config/regions'
 import { buildStoryContext } from '@/app/tap-tap-adventure/lib/contextBuilder'
 import { initializePlayerCombatState } from '@/app/tap-tap-adventure/lib/combatEngine'
 import { generateCombatEncounter, generateBossEncounter } from '@/app/tap-tap-adventure/lib/combatGenerator'
@@ -18,13 +19,15 @@ export async function POST(req: NextRequest) {
       ? await generateBossEncounter(character, fullContext)
       : await generateCombatEncounter(character, fullContext)
 
-    // Apply difficulty modifiers to enemy stats
+    // Apply difficulty modifiers and region difficulty multiplier to enemy stats
     const diffMods = getDifficultyModifiers(character.difficultyMode)
+    const region = getRegion(character.currentRegion ?? 'green_meadows')
+    const regionMult = region.difficultyMultiplier
     const enemy = {
       ...rawEnemy,
-      hp: Math.round(rawEnemy.hp * diffMods.enemyHpMultiplier),
-      maxHp: Math.round(rawEnemy.maxHp * diffMods.enemyHpMultiplier),
-      attack: Math.round(rawEnemy.attack * diffMods.enemyAttackMultiplier),
+      hp: Math.round(rawEnemy.hp * diffMods.enemyHpMultiplier * regionMult),
+      maxHp: Math.round(rawEnemy.maxHp * diffMods.enemyHpMultiplier * regionMult),
+      attack: Math.round(rawEnemy.attack * diffMods.enemyAttackMultiplier * regionMult),
     }
 
     const playerState = initializePlayerCombatState(character)

--- a/src/app/api/v1/tap-tap-adventure/move-forward/services/moveForwardService.ts
+++ b/src/app/api/v1/tap-tap-adventure/move-forward/services/moveForwardService.ts
@@ -1,4 +1,5 @@
 import { MoveForwardResponse } from '@/app/api/v1/tap-tap-adventure/move-forward/schemas'
+import { getRegion, getConnectedRegions, canEnterRegion, CROSSROADS_INTERVAL } from '@/app/tap-tap-adventure/config/regions'
 import { buildStoryContext } from '@/app/tap-tap-adventure/lib/contextBuilder'
 import { generateLLMEvents } from '@/app/tap-tap-adventure/lib/llmEventGenerator'
 import {
@@ -78,6 +79,68 @@ export async function moveForwardService(
       },
       decisionPoint: null,
       shopEvent: true,
+    }
+  }
+
+  // Trigger crossroads event every CROSSROADS_INTERVAL steps
+  if (crossedMilestone(character.distance, newDistance, CROSSROADS_INTERVAL)) {
+    const currentRegion = getRegion(character.currentRegion ?? 'green_meadows')
+    const connected = getConnectedRegions(currentRegion.id)
+    const crossroadsEventId = `crossroads-event-${Date.now()}`
+
+    const difficultyLabel: Record<string, string> = {
+      easy: 'Easy',
+      medium: 'Medium',
+      hard: 'Hard',
+      very_hard: 'Very Hard',
+    }
+
+    const travelOptions = connected.map(region => {
+      const meetsLevel = canEnterRegion(region, character.level)
+      const levelWarning = meetsLevel ? '' : ` [Requires Lv.${region.minLevel}]`
+      return {
+        id: `travel-${region.id}`,
+        text: `${region.icon} ${region.name} (${difficultyLabel[region.difficulty] ?? region.difficulty})${levelWarning}`,
+        successProbability: meetsLevel ? 1.0 : 0.0,
+        successDescription: `You set out toward ${region.name}. ${region.description}`,
+        successEffects: {},
+        failureDescription: meetsLevel
+          ? `You set out toward ${region.name}.`
+          : `You are not experienced enough to enter ${region.name}. You need to be at least level ${region.minLevel}.`,
+        failureEffects: {},
+        resultDescription: meetsLevel
+          ? `You travel to ${region.name}.`
+          : `You cannot enter ${region.name} yet.`,
+      }
+    })
+
+    const stayOption = {
+      id: 'stay',
+      text: `${currentRegion.icon} Continue in ${currentRegion.name}`,
+      successProbability: 1.0,
+      successDescription: `You decide to continue exploring ${currentRegion.name}.`,
+      successEffects: {},
+      failureDescription: '',
+      failureEffects: {},
+      resultDescription: `You continue in ${currentRegion.name}.`,
+    }
+
+    return {
+      character: updatedCharacter,
+      event: {
+        id: crossroadsEventId,
+        type: 'crossroads',
+        characterId: character.id,
+        locationId: character.locationId,
+        timestamp: new Date().toISOString(),
+      },
+      decisionPoint: {
+        id: `decision-${crossroadsEventId}`,
+        eventId: crossroadsEventId,
+        prompt: `You reach a crossroads. Multiple paths stretch before you. You are currently in ${currentRegion.icon} ${currentRegion.name}. Where will you go?`,
+        options: [...travelOptions, stayOption],
+        resolved: false,
+      },
     }
   }
 

--- a/src/app/tap-tap-adventure/__tests__/regions.test.ts
+++ b/src/app/tap-tap-adventure/__tests__/regions.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  REGIONS,
+  getRegion,
+  getConnectedRegions,
+  canEnterRegion,
+  CROSSROADS_INTERVAL,
+} from '@/app/tap-tap-adventure/config/regions'
+
+describe('Region definitions', () => {
+  it('should define all expected regions', () => {
+    const expectedIds = [
+      'starting_village',
+      'green_meadows',
+      'dark_forest',
+      'crystal_caves',
+      'scorched_wastes',
+      'frozen_peaks',
+      'shadow_realm',
+      'sky_citadel',
+    ]
+    for (const id of expectedIds) {
+      expect(REGIONS[id]).toBeDefined()
+      expect(REGIONS[id].id).toBe(id)
+    }
+  })
+
+  it('should have valid connected regions (all connected regions exist)', () => {
+    for (const region of Object.values(REGIONS)) {
+      for (const connectedId of region.connectedRegions) {
+        expect(
+          REGIONS[connectedId],
+          `Region "${region.id}" references non-existent connected region "${connectedId}"`
+        ).toBeDefined()
+      }
+    }
+  })
+
+  it('should have bidirectional connections', () => {
+    for (const region of Object.values(REGIONS)) {
+      for (const connectedId of region.connectedRegions) {
+        const connected = REGIONS[connectedId]
+        expect(
+          connected.connectedRegions,
+          `Region "${connectedId}" should connect back to "${region.id}"`
+        ).toContain(region.id)
+      }
+    }
+  })
+
+  it('should have correct difficulty multipliers', () => {
+    expect(REGIONS.starting_village.difficultyMultiplier).toBe(0.5)
+    expect(REGIONS.green_meadows.difficultyMultiplier).toBe(0.8)
+    expect(REGIONS.dark_forest.difficultyMultiplier).toBe(1.0)
+    expect(REGIONS.crystal_caves.difficultyMultiplier).toBe(1.0)
+    expect(REGIONS.scorched_wastes.difficultyMultiplier).toBe(1.5)
+    expect(REGIONS.frozen_peaks.difficultyMultiplier).toBe(1.5)
+    expect(REGIONS.shadow_realm.difficultyMultiplier).toBe(2.0)
+    expect(REGIONS.sky_citadel.difficultyMultiplier).toBe(2.0)
+  })
+
+  it('should have valid difficulty multipliers (positive numbers)', () => {
+    for (const region of Object.values(REGIONS)) {
+      expect(region.difficultyMultiplier).toBeGreaterThan(0)
+    }
+  })
+
+  it('should have valid difficulty levels', () => {
+    const validDifficulties = ['easy', 'medium', 'hard', 'very_hard']
+    for (const region of Object.values(REGIONS)) {
+      expect(validDifficulties).toContain(region.difficulty)
+    }
+  })
+})
+
+describe('Min level requirements', () => {
+  it('starting areas should have no level requirement', () => {
+    expect(REGIONS.starting_village.minLevel).toBe(0)
+    expect(REGIONS.green_meadows.minLevel).toBe(0)
+    expect(REGIONS.dark_forest.minLevel).toBe(0)
+    expect(REGIONS.crystal_caves.minLevel).toBe(0)
+  })
+
+  it('hard regions should require level 3', () => {
+    expect(REGIONS.scorched_wastes.minLevel).toBe(3)
+    expect(REGIONS.frozen_peaks.minLevel).toBe(3)
+  })
+
+  it('very hard regions should require higher levels', () => {
+    expect(REGIONS.shadow_realm.minLevel).toBe(5)
+    expect(REGIONS.sky_citadel.minLevel).toBe(7)
+  })
+
+  it('canEnterRegion should respect min level', () => {
+    expect(canEnterRegion(REGIONS.green_meadows, 1)).toBe(true)
+    expect(canEnterRegion(REGIONS.scorched_wastes, 2)).toBe(false)
+    expect(canEnterRegion(REGIONS.scorched_wastes, 3)).toBe(true)
+    expect(canEnterRegion(REGIONS.scorched_wastes, 5)).toBe(true)
+    expect(canEnterRegion(REGIONS.sky_citadel, 6)).toBe(false)
+    expect(canEnterRegion(REGIONS.sky_citadel, 7)).toBe(true)
+  })
+})
+
+describe('getRegion', () => {
+  it('should return the correct region by ID', () => {
+    const region = getRegion('dark_forest')
+    expect(region.name).toBe('Dark Forest')
+    expect(region.element).toBe('shadow')
+  })
+
+  it('should fall back to green_meadows for unknown region ID', () => {
+    const region = getRegion('nonexistent_place')
+    expect(region.id).toBe('green_meadows')
+  })
+})
+
+describe('getConnectedRegions', () => {
+  it('should return connected Region objects', () => {
+    const connected = getConnectedRegions('green_meadows')
+    const ids = connected.map(r => r.id)
+    expect(ids).toContain('starting_village')
+    expect(ids).toContain('dark_forest')
+    expect(ids).toContain('crystal_caves')
+  })
+
+  it('should return correct number of connections', () => {
+    expect(getConnectedRegions('starting_village')).toHaveLength(1)
+    expect(getConnectedRegions('green_meadows')).toHaveLength(3)
+    expect(getConnectedRegions('sky_citadel')).toHaveLength(3)
+  })
+})
+
+describe('Crossroads generation', () => {
+  it('should have a crossroads interval of 75 steps', () => {
+    expect(CROSSROADS_INTERVAL).toBe(75)
+  })
+
+  it('should generate crossroads options for connected regions', () => {
+    const region = getRegion('green_meadows')
+    const connected = getConnectedRegions(region.id)
+    expect(connected.length).toBeGreaterThan(0)
+
+    // All connected regions should have required fields for crossroads display
+    for (const r of connected) {
+      expect(r.name).toBeTruthy()
+      expect(r.icon).toBeTruthy()
+      expect(r.difficulty).toBeTruthy()
+      expect(typeof r.minLevel).toBe('number')
+    }
+  })
+
+  it('each region should have at least one connected region', () => {
+    for (const region of Object.values(REGIONS)) {
+      expect(
+        region.connectedRegions.length,
+        `Region "${region.id}" has no connections`
+      ).toBeGreaterThanOrEqual(1)
+    }
+  })
+})

--- a/src/app/tap-tap-adventure/components/HudBar.tsx
+++ b/src/app/tap-tap-adventure/components/HudBar.tsx
@@ -2,6 +2,7 @@
 import { useCallback, useMemo, useState } from 'react'
 
 import { getDifficultyMode } from '@/app/tap-tap-adventure/config/difficultyModes'
+import { getRegion } from '@/app/tap-tap-adventure/config/regions'
 import { Mount } from '@/app/tap-tap-adventure/models/mount'
 import { useGameStore } from '@/app/tap-tap-adventure/hooks/useGameStore'
 import { getReputationTier } from '@/app/tap-tap-adventure/lib/contextBuilder'
@@ -175,6 +176,7 @@ export function HudBar() {
     </div>
   )
 
+  const currentRegion = getRegion(character?.currentRegion ?? 'green_meadows')
   const difficultyMode = getDifficultyMode(character?.difficultyMode ?? 'normal')
   const difficultyColorMap: Record<string, string> = {
     normal: 'border-indigo-400 text-indigo-300',
@@ -210,6 +212,12 @@ export function HudBar() {
         {STATS_LEFT.map(renderStat)}
       </div>
       <div className="flex items-center gap-2 sm:gap-4">
+        <span
+          className="text-[10px] px-1.5 py-0.5 border rounded border-emerald-400 text-emerald-300 bg-[#2a2b3f]"
+          title={`${currentRegion.name}: ${currentRegion.description}`}
+        >
+          {currentRegion.icon} {currentRegion.name}
+        </span>
         {difficultyMode.id !== 'normal' && (
           <span
             className={`text-[10px] px-1.5 py-0.5 border rounded ${difficultyColor} bg-[#2a2b3f]`}

--- a/src/app/tap-tap-adventure/config/gameDefaults.ts
+++ b/src/app/tap-tap-adventure/config/gameDefaults.ts
@@ -46,4 +46,5 @@ export const DEFAULT_CHARACTER = {
   maxMana: 20,
   spellbook: [],
   classData: undefined,
+  currentRegion: 'green_meadows',
 }

--- a/src/app/tap-tap-adventure/config/regions.ts
+++ b/src/app/tap-tap-adventure/config/regions.ts
@@ -1,0 +1,139 @@
+import { SpellElement } from '@/app/tap-tap-adventure/models/spell'
+
+export type RegionDifficulty = 'easy' | 'medium' | 'hard' | 'very_hard'
+
+export interface Region {
+  id: string
+  name: string
+  description: string
+  difficulty: RegionDifficulty
+  difficultyMultiplier: number
+  theme: string
+  enemyTypes: string[]
+  element: SpellElement
+  connectedRegions: string[]
+  minLevel: number
+  icon: string
+}
+
+export const REGIONS: Record<string, Region> = {
+  starting_village: {
+    id: 'starting_village',
+    name: 'Starting Village',
+    description: 'A safe hub where adventurers rest and resupply. No combat here.',
+    difficulty: 'easy',
+    difficultyMultiplier: 0.5,
+    theme: 'peaceful village with taverns, shops, and friendly NPCs',
+    enemyTypes: [],
+    element: 'none',
+    connectedRegions: ['green_meadows'],
+    minLevel: 0,
+    icon: '\u{1F3D8}\u{FE0F}',
+  },
+  green_meadows: {
+    id: 'green_meadows',
+    name: 'Green Meadows',
+    description: 'Rolling hills dotted with wildflowers and gentle streams. A good place for new adventurers.',
+    difficulty: 'easy',
+    difficultyMultiplier: 0.8,
+    theme: 'rolling green hills, wildflower meadows, gentle streams, and scattered farmsteads',
+    enemyTypes: ['wolves', 'bandits', 'wild boars'],
+    element: 'nature',
+    connectedRegions: ['starting_village', 'dark_forest', 'crystal_caves'],
+    minLevel: 0,
+    icon: '\u{1F33F}',
+  },
+  dark_forest: {
+    id: 'dark_forest',
+    name: 'Dark Forest',
+    description: 'Dense, ancient woods where sunlight barely reaches the floor. Strange creatures lurk in the shadows.',
+    difficulty: 'medium',
+    difficultyMultiplier: 1.0,
+    theme: 'dense dark woods, twisted trees, thick fog, and eerie silence',
+    enemyTypes: ['shadow beasts', 'giant spiders', 'corrupted treants'],
+    element: 'shadow',
+    connectedRegions: ['green_meadows', 'scorched_wastes', 'shadow_realm'],
+    minLevel: 0,
+    icon: '\u{1F332}',
+  },
+  crystal_caves: {
+    id: 'crystal_caves',
+    name: 'Crystal Caves',
+    description: 'A vast underground network of glittering caverns filled with magical crystals and ancient secrets.',
+    difficulty: 'medium',
+    difficultyMultiplier: 1.0,
+    theme: 'underground caverns, glowing crystals, echoing tunnels, and underground rivers',
+    enemyTypes: ['crystal golems', 'cave bats', 'gem serpents'],
+    element: 'arcane',
+    connectedRegions: ['green_meadows', 'frozen_peaks'],
+    minLevel: 0,
+    icon: '\u{1F48E}',
+  },
+  scorched_wastes: {
+    id: 'scorched_wastes',
+    name: 'Scorched Wastes',
+    description: 'A barren desert of cracked earth and ancient ruins, baked under a merciless sun.',
+    difficulty: 'hard',
+    difficultyMultiplier: 1.5,
+    theme: 'scorching desert, ancient ruins, sand dunes, and volcanic vents',
+    enemyTypes: ['fire elementals', 'sand wyrms', 'scorpion warriors'],
+    element: 'fire',
+    connectedRegions: ['dark_forest', 'sky_citadel'],
+    minLevel: 3,
+    icon: '\u{1F525}',
+  },
+  frozen_peaks: {
+    id: 'frozen_peaks',
+    name: 'Frozen Peaks',
+    description: 'Towering snow-capped mountains battered by howling blizzards. Only the hardiest survive.',
+    difficulty: 'hard',
+    difficultyMultiplier: 1.5,
+    theme: 'snow-capped mountains, howling blizzards, frozen lakes, and ice caverns',
+    enemyTypes: ['ice wraiths', 'frost giants', 'snow wolves'],
+    element: 'ice',
+    connectedRegions: ['crystal_caves', 'sky_citadel'],
+    minLevel: 3,
+    icon: '\u{2744}\u{FE0F}',
+  },
+  shadow_realm: {
+    id: 'shadow_realm',
+    name: 'Shadow Realm',
+    description: 'A dark dimension where reality warps and nightmares walk. Only the bravest dare enter.',
+    difficulty: 'very_hard',
+    difficultyMultiplier: 2.0,
+    theme: 'dark otherworldly dimension, floating islands of shadow, warped reality, and nightmare landscapes',
+    enemyTypes: ['demons', 'undead knights', 'shadow dragons'],
+    element: 'shadow',
+    connectedRegions: ['dark_forest', 'sky_citadel'],
+    minLevel: 5,
+    icon: '\u{1F311}',
+  },
+  sky_citadel: {
+    id: 'sky_citadel',
+    name: 'Sky Citadel',
+    description: 'A massive floating fortress high above the clouds. The ultimate challenge for legendary adventurers.',
+    difficulty: 'very_hard',
+    difficultyMultiplier: 2.0,
+    theme: 'floating fortress in the sky, ancient arcane machinery, cloud platforms, and celestial architecture',
+    enemyTypes: ['sky knights', 'ancient dragons', 'arcane sentinels'],
+    element: 'arcane',
+    connectedRegions: ['scorched_wastes', 'frozen_peaks', 'shadow_realm'],
+    minLevel: 7,
+    icon: '\u{26C5}',
+  },
+}
+
+export function getRegion(regionId: string): Region {
+  return REGIONS[regionId] ?? REGIONS.green_meadows
+}
+
+export function getConnectedRegions(regionId: string): Region[] {
+  const region = getRegion(regionId)
+  return region.connectedRegions.map(id => getRegion(id))
+}
+
+export function canEnterRegion(region: Region, characterLevel: number): boolean {
+  return characterLevel >= region.minLevel
+}
+
+export const CROSSROADS_INTERVAL = 75

--- a/src/app/tap-tap-adventure/hooks/useCharacterCreation.ts
+++ b/src/app/tap-tap-adventure/hooks/useCharacterCreation.ts
@@ -165,6 +165,7 @@ export function useCharacterCreation() {
       pendingStatPoints: 0,
       classData,
       difficultyMode: selectedDifficulty.id,
+      currentRegion: 'green_meadows',
     }
     const maxMana = calculateMaxMana(tempChar)
 

--- a/src/app/tap-tap-adventure/hooks/useGameStore.ts
+++ b/src/app/tap-tap-adventure/hooks/useGameStore.ts
@@ -54,6 +54,7 @@ const defaultCharacter: FantasyCharacter = {
   classData: undefined,
   activeMount: null,
   difficultyMode: 'normal',
+  currentRegion: 'green_meadows',
 }
 
 export interface GameStore {
@@ -590,7 +591,7 @@ export const useGameStore = create<GameStore>()(
     }),
     {
       name: 'fantasy-tycoon-storage', // localStorage key (kept for backward compat)
-      version: 11,
+      version: 12,
       migrate: (persistedState: unknown) => {
         const state = persistedState as GameStore
         if (state?.gameState && !('combatState' in state.gameState)) {
@@ -637,6 +638,10 @@ export const useGameStore = create<GameStore>()(
             // v11: Add unlockedSkills
             if ((char as FantasyCharacter).unlockedSkills === undefined) {
               ;(char as FantasyCharacter).unlockedSkills = []
+            }
+            // v12: Add currentRegion
+            if ((char as FantasyCharacter).currentRegion === undefined) {
+              ;(char as FantasyCharacter).currentRegion = 'green_meadows'
             }
           }
         }

--- a/src/app/tap-tap-adventure/hooks/useResolveDecisionMutation.ts
+++ b/src/app/tap-tap-adventure/hooks/useResolveDecisionMutation.ts
@@ -41,6 +41,42 @@ export function useResolveDecisionMutation() {
       const character = getSelectedCharacter()
       if (!character) throw new Error('No character found')
 
+      // Handle crossroads region travel decisions client-side
+      if (optionId.startsWith('travel-')) {
+        const regionId = optionId.replace('travel-', '')
+        updateSelectedCharacter({ currentRegion: regionId })
+        const chosenOption = decisionPoint.options.find(o => o.id === optionId)
+        addStoryEvent({
+          id: `result-${Date.now()}`,
+          type: 'region_travel',
+          characterId: character.id,
+          locationId: character.locationId,
+          timestamp: new Date().toISOString(),
+          selectedOptionId: optionId,
+          selectedOptionText: chosenOption?.text ?? '',
+          outcomeDescription: chosenOption?.successDescription ?? `You travel to a new region.`,
+        })
+        commit()
+        onSuccess?.()
+        return
+      }
+      if (optionId === 'stay') {
+        const chosenOption = decisionPoint.options.find(o => o.id === optionId)
+        addStoryEvent({
+          id: `result-${Date.now()}`,
+          type: 'region_stay',
+          characterId: character.id,
+          locationId: character.locationId,
+          timestamp: new Date().toISOString(),
+          selectedOptionId: optionId,
+          selectedOptionText: chosenOption?.text ?? '',
+          outcomeDescription: chosenOption?.successDescription ?? 'You continue on your way.',
+        })
+        commit()
+        onSuccess?.()
+        return
+      }
+
       const res = await fetch('/api/v1/tap-tap-adventure/resolve-decision', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },

--- a/src/app/tap-tap-adventure/lib/combatGenerator.ts
+++ b/src/app/tap-tap-adventure/lib/combatGenerator.ts
@@ -1,6 +1,7 @@
 import { OpenAI } from 'openai'
 import { z } from 'zod'
 
+import { getRegion } from '@/app/tap-tap-adventure/config/regions'
 import { FantasyCharacter } from '@/app/tap-tap-adventure/models/character'
 import { CombatEnemy, CombatEnemySchema } from '@/app/tap-tap-adventure/models/combat'
 
@@ -111,6 +112,8 @@ export async function generateCombatEncounter(
         {
           role: 'user',
           content: `Generate a combat encounter for this fantasy character. Create an enemy appropriate for the character's level with a vivid scenario description.
+
+Region context: Generate an enemy appropriate for the ${getRegion(character.currentRegion ?? 'green_meadows').name} region. Common enemy types: ${getRegion(character.currentRegion ?? 'green_meadows').enemyTypes.join(', ') || 'none'}. Dominant element: ${getRegion(character.currentRegion ?? 'green_meadows').element}. Setting: ${getRegion(character.currentRegion ?? 'green_meadows').theme}.
 
 Stat guidelines for a level ${character.level} character:
 - Enemy HP: ${35 + character.level * 15} (±20%)

--- a/src/app/tap-tap-adventure/lib/llmEventGenerator.ts
+++ b/src/app/tap-tap-adventure/lib/llmEventGenerator.ts
@@ -1,6 +1,7 @@
 import { OpenAI } from 'openai'
 import { z } from 'zod'
 
+import { getRegion } from '@/app/tap-tap-adventure/config/regions'
 import { FantasyCharacter } from '@/app/tap-tap-adventure/models/character'
 import { Item } from '@/app/tap-tap-adventure/models/item'
 import { SpellSchema } from '@/app/tap-tap-adventure/models/spell'
@@ -267,10 +268,16 @@ function getCompletionsConfig(character: FantasyCharacter, context: string) {
     reputationGuidance = `This character has an ${reputationTier} reputation (${character.reputation}). NPCs are hostile or fearful. Bounty hunters or rival adventurers may appear. Prices are much higher. Very few friendly encounters — most NPCs want nothing to do with this character.`
   }
 
+  const region = getRegion(character.currentRegion ?? 'green_meadows')
+  const regionContext = `The character is currently in ${region.name}: ${region.description}. Generate events that fit this setting. ${region.enemyTypes.length > 0 ? `Enemy types common here: ${region.enemyTypes.join(', ')}.` : 'This is a safe zone with no combat.'} The dominant element is ${region.element}.`
+
   const messages: OpenAI.Chat.Completions.ChatCompletionMessageParam[] = [
     {
       role: 'user',
       content: `Generate 3 fantasy adventure events for this character. Reference their past adventures and current state when creating events. Events should feel like a continuation of their story, not random encounters.
+
+IMPORTANT — Region context:
+${regionContext}
 
 IMPORTANT — Reputation guidance:
 ${reputationGuidance}

--- a/src/app/tap-tap-adventure/models/character.ts
+++ b/src/app/tap-tap-adventure/models/character.ts
@@ -49,6 +49,7 @@ export const FantasyCharacterSchema = z.object({
   activeMount: MountSchema.nullable().optional(),
   unlockedSkills: z.array(z.string()).optional(),
   difficultyMode: z.string().optional().default('normal'),
+  currentRegion: z.string().optional().default('green_meadows'),
 })
 export type FantasyCharacter = z.infer<typeof FantasyCharacterSchema>
 


### PR DESCRIPTION
## Summary
- Define 8 world regions with distinct themes, difficulty levels, elements, enemy types, and level requirements
- Add crossroads decision events every 75 steps so players can choose which region to travel to
- Inject region context into LLM prompts for thematic event/enemy generation
- Apply region difficulty multiplier to enemy HP and attack stats in combat
- Show current region name and icon in the HUD bar
- Handle region travel decisions client-side in useResolveDecisionMutation
- Add `currentRegion` field to character model with store migration v12
- Add 17 unit tests covering region definitions, connections, level requirements, and crossroads

## Test plan
- [x] All 17 new region tests pass (`npx vitest run`)
- [x] All pre-existing passing tests still pass (no regressions)
- [x] `npx next build` compiles with zero TypeScript errors
- [ ] Manual test: create a new character, walk 75 steps, verify crossroads event appears
- [ ] Manual test: travel to a new region and verify HUD updates
- [ ] Manual test: verify combat enemies reflect region theme and difficulty

🤖 Generated with [Claude Code](https://claude.com/claude-code)