### PR TITLE
Fix milestone events never triggering (crossroads, shop, boss)

### DIFF
--- a/src/app/api/v1/tap-tap-adventure/move-forward/services/moveForwardService.ts
+++ b/src/app/api/v1/tap-tap-adventure/move-forward/services/moveForwardService.ts
@@ -66,23 +66,7 @@ export async function moveForwardService(
     }
   }
 
-  // Trigger shop event every SHOP_MILESTONE_INTERVAL steps (100)
-  if (crossedMilestone(character.distance, newDistance, SHOP_MILESTONE_INTERVAL)) {
-    return {
-      character: updatedCharacter,
-      event: {
-        id: `shop-event-${Date.now()}`,
-        type: 'shop',
-        characterId: character.id,
-        locationId: character.locationId,
-        timestamp: new Date().toISOString(),
-      },
-      decisionPoint: null,
-      shopEvent: true,
-    }
-  }
-
-  // Trigger crossroads event every CROSSROADS_INTERVAL steps
+  // Trigger crossroads event every CROSSROADS_INTERVAL steps (75)
   if (crossedMilestone(character.distance, newDistance, CROSSROADS_INTERVAL)) {
     const currentRegion = getRegion(character.currentRegion ?? 'green_meadows')
     const connected = getConnectedRegions(currentRegion.id)
@@ -141,6 +125,22 @@ export async function moveForwardService(
         options: [...travelOptions, stayOption],
         resolved: false,
       },
+    }
+  }
+
+  // Trigger shop event every SHOP_MILESTONE_INTERVAL steps (100)
+  if (crossedMilestone(character.distance, newDistance, SHOP_MILESTONE_INTERVAL)) {
+    return {
+      character: updatedCharacter,
+      event: {
+        id: `shop-event-${Date.now()}`,
+        type: 'shop',
+        characterId: character.id,
+        locationId: character.locationId,
+        timestamp: new Date().toISOString(),
+      },
+      decisionPoint: null,
+      shopEvent: true,
     }
   }
 

--- a/src/app/tap-tap-adventure/components/GameUI.tsx
+++ b/src/app/tap-tap-adventure/components/GameUI.tsx
@@ -9,6 +9,8 @@ import { useResolveDecisionMutation } from '@/app/tap-tap-adventure/hooks/useRes
 import { getGenericTravelMessage } from '@/app/tap-tap-adventure/lib/getGenericTravelMessage'
 import { checkAchievements } from '@/app/tap-tap-adventure/lib/achievementTracker'
 import { canClaimDailyReward, getDailyReward } from '@/app/tap-tap-adventure/lib/dailyRewardTracker'
+import { crossedMilestone, BOSS_MILESTONE_INTERVAL, SHOP_MILESTONE_INTERVAL } from '@/app/tap-tap-adventure/lib/leveling'
+import { CROSSROADS_INTERVAL } from '@/app/tap-tap-adventure/config/regions'
 import { flipCoin } from '@/app/utils'
 
 import { SKILLS } from '@/app/tap-tap-adventure/config/skills'
@@ -86,6 +88,21 @@ export default function GameUI() {
   }
 
   const handleMoveForward = () => {
+    const character = getSelectedCharacter()
+    const distance = character?.distance ?? 0
+    const nextDistance = distance + 1
+
+    // Always call server for milestone events (crossroads, shop, boss)
+    const hitsMilestone =
+      crossedMilestone(distance, nextDistance, CROSSROADS_INTERVAL) ||
+      crossedMilestone(distance, nextDistance, SHOP_MILESTONE_INTERVAL) ||
+      crossedMilestone(distance, nextDistance, BOSS_MILESTONE_INTERVAL)
+
+    if (hitsMilestone) {
+      moveForwardMutation()
+      return
+    }
+
     const shouldDoNothing = flipCoin(0.03, 0.97)
     if (shouldDoNothing) {
       const genericMessage = getGenericTravelMessage()

--- a/src/app/tap-tap-adventure/lib/leveling.ts
+++ b/src/app/tap-tap-adventure/lib/leveling.ts
@@ -17,7 +17,7 @@ const STEPS_PER_LEVEL_INCREMENT = 50
 
 // Milestone constants
 export const STEPS_PER_DAY = 50
-export const SHOP_MILESTONE_INTERVAL = 75
+export const SHOP_MILESTONE_INTERVAL = 100
 export const BOSS_MILESTONE_INTERVAL = 500
 
 /**


### PR DESCRIPTION
## Summary
- Milestone events (crossroads every 75 steps, shop every 100, boss every 500) were only checked server-side, but the server was only called 3% of the time via coin flip — making it nearly impossible to hit a milestone boundary on a server call
- Client-side `handleMoveForward` now checks if the next step crosses any milestone and always calls the server when it does, bypassing the random coin flip
- Separated shop interval (now 100) from crossroads interval (75) so they don't collide on the same step
- Reordered server-side checks: boss → crossroads → shop (crossroads gets priority)

## Test plan
- [ ] Walk 75+ steps — should see a crossroads/region travel event
- [ ] Walk 100+ steps — should see a shop event
- [ ] Walk 500+ steps — should see a boss event
- [ ] Verify existing region tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)