### PR TITLE
Fix infinite crossroads loop by writing server distance back to store

### DIFF
--- a/src/app/tap-tap-adventure/hooks/useMoveForwardMutation.ts
+++ b/src/app/tap-tap-adventure/hooks/useMoveForwardMutation.ts
@@ -30,6 +30,7 @@ export function useMoveForwardMutation() {
     setGenericMessage,
     setShopState,
     setActiveQuest,
+    updateSelectedCharacter,
   } = useGameStateBuilder()
 
   return useMutation({
@@ -52,6 +53,11 @@ export function useMoveForwardMutation() {
       }
 
       const data: MoveForwardResponse = await res.json()
+
+      // Update character with server response (includes incremented distance)
+      if (data.character) {
+        updateSelectedCharacter(data.character)
+      }
 
       const rewardItems: Item[] = data.event?.resourceDelta?.rewardItems ?? []
       for (const reward of rewardItems) {


### PR DESCRIPTION
## Summary
- `useMoveForwardMutation` never wrote the server's character response back to the client store
- The server increments distance (e.g. 74→75) but the client still thought it was 74
- On next tap, the client-side milestone check saw `crossedMilestone(74, 75, 75)` = true again → infinite crossroads loop
- Fix: call `updateSelectedCharacter(data.character)` after every server response

This was the missing second commit from PR #101 that didn't make it into the merge.

## Test plan
- [ ] Walk to step 75 — crossroads appears once, resolving it advances the game normally
- [ ] No more infinite crossroads loop

🤖 Generated with [Claude Code](https://claude.com/claude-code)