### PR TITLE
Fix mount not persisting after boss kill

### DIFF
--- a/src/app/tap-tap-adventure/hooks/useCombatActionMutation.ts
+++ b/src/app/tap-tap-adventure/hooks/useCombatActionMutation.ts
@@ -26,7 +26,7 @@ interface CombatActionResponse {
 
 export function useCombatActionMutation() {
   const queryClient = useQueryClient()
-  const { getSelectedCharacter, setMount, addHeirloom, deleteCharacter, awardSoulEssence } = useGameStore()
+  const { getSelectedCharacter, addHeirloom, deleteCharacter, awardSoulEssence } = useGameStore()
   const {
     addItem,
     addStoryEvent,
@@ -108,9 +108,9 @@ export function useCombatActionMutation() {
             addItem(inferItemTypeAndEffects(lootItem))
           }
 
-          // If boss dropped a mount, equip it
+          // If boss dropped a mount, equip it (via builder so commit() includes it)
           if (data.rewards.mountDrop) {
-            setMount(data.rewards.mountDrop)
+            updateSelectedCharacter({ activeMount: data.rewards.mountDrop })
           }
 
           addStoryEvent({

--- a/src/app/tap-tap-adventure/hooks/useMoveForwardMutation.ts
+++ b/src/app/tap-tap-adventure/hooks/useMoveForwardMutation.ts
@@ -71,7 +71,7 @@ export function useMoveForwardMutation() {
       }
 
       if (data.shopEvent) {
-        // Level up triggered a shop - fetch shop items from server
+        // Step milestone triggered a shop - fetch shop items from server
         const shopRes = await fetch('/api/v1/tap-tap-adventure/shop/generate', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },


### PR DESCRIPTION
## Summary
- **B7 fix**: `setMount()` was called directly on the Zustand store after boss victories, but `commit()` then overwrote the state with a stale snapshot. Mounts were acquired and immediately erased. Fix: use `updateSelectedCharacter({ activeMount })` through the builder so `commit()` includes the mount.
- **B8 fix**: Updated stale comment "Level up triggered a shop" to "Step milestone triggered a shop"

## Test plan
- [ ] Kill a boss — mount should persist in HUD badge, auto-walk speed should change, combat stats should reflect mount bonuses
- [ ] Mount should survive page refresh (localStorage persistence)

🤖 Generated with [Claude Code](https://claude.com/claude-code)