### PR TITLE
Add death/retirement run summary screen

### DIFF
--- a/src/app/tap-tap-adventure/__tests__/achievements.test.ts
+++ b/src/app/tap-tap-adventure/__tests__/achievements.test.ts
@@ -49,6 +49,7 @@ const baseGameState: GameState = {
   legacyHeirlooms: [],
   dailyReward: null,
   metaProgression: null,
+  runSummary: null,
 }
 
 describe('Achievement Definitions', () => {

--- a/src/app/tap-tap-adventure/__tests__/dailyRewards.test.ts
+++ b/src/app/tap-tap-adventure/__tests__/dailyRewards.test.ts
@@ -53,6 +53,7 @@ function makeState(dailyReward: GameState['dailyReward'] = null): GameState {
     achievements: [],
     legacyHeirlooms: [],
     metaProgression: null,
+    runSummary: null,
     dailyReward,
   }
 }

--- a/src/app/tap-tap-adventure/components/CharacterList.tsx
+++ b/src/app/tap-tap-adventure/components/CharacterList.tsx
@@ -19,7 +19,12 @@ const selectRetireCharacter = (s: GameStore) => s.retireCharacter
 const selectLegacyHeirlooms = (s: GameStore) => s.gameState?.legacyHeirlooms ?? EMPTY_ARRAY
 const selectMetaProgression = (s: GameStore) => s.gameState?.metaProgression
 
-export default function CharacterList() {
+interface CharacterListProps {
+  defaultShowCreation?: boolean
+  onCreationShown?: () => void
+}
+
+export default function CharacterList({ defaultShowCreation, onCreationShown }: CharacterListProps) {
   const characters = useGameStore(selectCharacters)
   const selectedCharacterId = useGameStore(selectSelectedCharacterId)
   const selectCharacter = useGameStore(selectSelectCharacter)
@@ -27,8 +32,15 @@ export default function CharacterList() {
   const retireCharacter = useGameStore(selectRetireCharacter)
   const legacyHeirlooms = useGameStore(selectLegacyHeirlooms)
   const metaProgression = useGameStore(selectMetaProgression)
-  const [showCreation, setShowCreation] = useState(false)
+  const [showCreation, setShowCreation] = useState(defaultShowCreation ?? false)
   const [showMetaProgression, setShowMetaProgression] = useState(false)
+
+  // If defaultShowCreation was set from the parent, clear the flag
+  React.useEffect(() => {
+    if (defaultShowCreation && onCreationShown) {
+      onCreationShown()
+    }
+  }, [defaultShowCreation, onCreationShown])
 
   const handleSelect = (character: FantasyCharacter) => {
     selectCharacter(character.id)

--- a/src/app/tap-tap-adventure/components/RunSummary.tsx
+++ b/src/app/tap-tap-adventure/components/RunSummary.tsx
@@ -1,0 +1,217 @@
+'use client'
+
+import { calculateDay } from '@/app/tap-tap-adventure/lib/leveling'
+import { calculateSoulEssence } from '@/app/tap-tap-adventure/lib/soulEssenceCalculator'
+import type { RunSummaryData } from '@/app/tap-tap-adventure/models/types'
+
+interface RunSummaryProps {
+  data: RunSummaryData
+  onViewUpgrades: () => void
+  onNewCharacter: () => void
+  onBackToCharacters: () => void
+}
+
+function EssenceBreakdown({ character }: { character: RunSummaryData['character'] }) {
+  const baseEssence = Math.floor(character.distance / 10)
+  const levelBonus = character.level * 5
+  const subtotal = baseEssence + levelBonus
+
+  const deathPenaltyMultiplier = Math.max(0.5, 1 - character.deathCount * 0.1)
+  const afterDeathPenalty = Math.floor(subtotal * deathPenaltyMultiplier)
+
+  const diffMultipliers: Record<string, number> = {
+    casual: 0.5,
+    normal: 1,
+    hard: 1.5,
+    ironman: 2.5,
+  }
+  const diffMultiplier = diffMultipliers[character.difficultyMode ?? 'normal'] ?? 1
+  const diffLabel =
+    character.difficultyMode
+      ? character.difficultyMode.charAt(0).toUpperCase() + character.difficultyMode.slice(1)
+      : 'Normal'
+
+  return (
+    <div className="space-y-1 text-sm text-slate-400">
+      <div className="flex justify-between">
+        <span>Base (distance / 10)</span>
+        <span className="text-amber-300">+{baseEssence}</span>
+      </div>
+      <div className="flex justify-between">
+        <span>Level bonus (level x 5)</span>
+        <span className="text-amber-300">+{levelBonus}</span>
+      </div>
+      {character.deathCount > 0 && (
+        <div className="flex justify-between">
+          <span>Death penalty ({character.deathCount} deaths)</span>
+          <span className="text-red-400">x{deathPenaltyMultiplier.toFixed(1)}</span>
+        </div>
+      )}
+      {diffMultiplier !== 1 && (
+        <div className="flex justify-between">
+          <span>{diffLabel} difficulty</span>
+          <span className={diffMultiplier > 1 ? 'text-green-400' : 'text-red-400'}>
+            x{diffMultiplier}
+          </span>
+        </div>
+      )}
+      <div className="flex justify-between border-t border-slate-700 pt-1 font-semibold text-amber-400">
+        <span>Total</span>
+        <span>{calculateSoulEssence(character)}</span>
+      </div>
+    </div>
+  )
+}
+
+export default function RunSummary({
+  data,
+  onViewUpgrades,
+  onNewCharacter,
+  onBackToCharacters,
+}: RunSummaryProps) {
+  const { character, reason, essenceEarned, heirloom } = data
+
+  const isRetirement = reason === 'retirement'
+  const headerText = isRetirement ? 'Run Complete' : 'Fallen in Battle'
+  const headerColor = isRetirement
+    ? 'text-purple-300'
+    : 'text-red-400'
+  const headerBorder = isRetirement
+    ? 'border-purple-500/30'
+    : 'border-red-500/30'
+
+  const daysSurvived = calculateDay(character.distance)
+
+  // Count combat victories from story events if available (not tracked here, show N/A)
+  // We don't have storyEvents in the summary data, so we skip enemies defeated
+
+  return (
+    <div className="w-full mx-auto p-4 sm:p-6 bg-[#1a1b2e] border border-[#3a3c56] rounded-lg mt-6 max-w-2xl">
+      {/* Header */}
+      <div className={`text-center pb-4 mb-6 border-b ${headerBorder}`}>
+        <h2 className={`text-3xl sm:text-4xl font-bold ${headerColor}`}>
+          {headerText}
+        </h2>
+        <p className="text-slate-400 mt-2 text-lg">
+          {character.name} &mdash; Level {character.level} {character.race} {character.class}
+        </p>
+        {reason === 'permadeath' && (
+          <p className="text-red-500 text-sm mt-1 italic">This character is gone forever.</p>
+        )}
+      </div>
+
+      {/* Run Stats Grid */}
+      <div className="mb-6">
+        <h3 className="text-sm font-semibold text-slate-500 uppercase tracking-wider mb-3">
+          Run Statistics
+        </h3>
+        <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
+          <StatCard label="Distance" value={character.distance.toLocaleString()} sublabel="steps" />
+          <StatCard label="Level" value={String(character.level)} />
+          <StatCard label="Days Survived" value={String(daysSurvived)} />
+          <StatCard label="Gold" value={character.gold.toLocaleString()} />
+          <StatCard
+            label="Deaths"
+            value={String(character.deathCount)}
+            highlight={character.deathCount === 0 ? 'green' : undefined}
+          />
+          <StatCard
+            label="Difficulty"
+            value={
+              character.difficultyMode
+                ? character.difficultyMode.charAt(0).toUpperCase() +
+                  character.difficultyMode.slice(1)
+                : 'Normal'
+            }
+          />
+        </div>
+      </div>
+
+      {/* Soul Essence Section */}
+      <div className="mb-6 p-4 bg-amber-950/30 border border-amber-600/30 rounded-lg">
+        <h3 className="text-sm font-semibold text-amber-500 uppercase tracking-wider mb-3">
+          Soul Essence Earned
+        </h3>
+        <div className="text-center mb-4">
+          <span className="text-5xl sm:text-6xl font-bold text-amber-400 drop-shadow-[0_0_12px_rgba(251,191,36,0.4)]">
+            {essenceEarned}
+          </span>
+          <p className="text-amber-500/70 text-sm mt-1">Soul Essence</p>
+        </div>
+        <EssenceBreakdown character={character} />
+      </div>
+
+      {/* Heirloom Section */}
+      {heirloom && (
+        <div className="mb-6 p-4 bg-purple-950/30 border border-purple-600/30 rounded-lg">
+          <h3 className="text-sm font-semibold text-purple-400 uppercase tracking-wider mb-2">
+            Heirloom Generated
+          </h3>
+          <div className="flex items-start gap-3">
+            <div className="w-10 h-10 rounded bg-purple-800/40 border border-purple-500/30 flex items-center justify-center text-lg shrink-0">
+              {heirloom.type === 'equipment' ? '\u2694' : heirloom.type === 'spell_scroll' ? '\u{1F4DC}' : '\u2728'}
+            </div>
+            <div>
+              <p className="font-semibold text-purple-200">{heirloom.name}</p>
+              <p className="text-sm text-slate-400 mt-0.5">{heirloom.description}</p>
+              <p className="text-xs text-purple-400/70 mt-1 italic">
+                This item will be available for your next character.
+              </p>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Call to Action Buttons */}
+      <div className="space-y-3">
+        <button
+          type="button"
+          onClick={onViewUpgrades}
+          className="w-full py-3 px-4 rounded-lg bg-amber-600/20 border border-amber-500/40 text-amber-300 font-semibold text-lg hover:bg-amber-600/30 transition-colors cursor-pointer"
+        >
+          View Eternal Upgrades
+        </button>
+        <button
+          type="button"
+          onClick={onNewCharacter}
+          className="w-full py-3 px-4 rounded-lg bg-indigo-600/20 border border-indigo-500/40 text-indigo-300 font-semibold text-lg hover:bg-indigo-600/30 transition-colors cursor-pointer"
+        >
+          Create New Character
+        </button>
+        <button
+          type="button"
+          onClick={onBackToCharacters}
+          className="w-full py-3 px-4 rounded-lg bg-slate-700/30 border border-slate-600/40 text-slate-300 font-semibold text-lg hover:bg-slate-700/50 transition-colors cursor-pointer"
+        >
+          Back to Characters
+        </button>
+      </div>
+    </div>
+  )
+}
+
+function StatCard({
+  label,
+  value,
+  sublabel,
+  highlight,
+}: {
+  label: string
+  value: string
+  sublabel?: string
+  highlight?: 'green'
+}) {
+  return (
+    <div className="bg-[#161723] border border-[#3a3c56] rounded-lg p-3 text-center">
+      <p className="text-xs text-slate-500 uppercase tracking-wider">{label}</p>
+      <p
+        className={`text-xl font-bold mt-1 ${
+          highlight === 'green' ? 'text-green-400' : 'text-slate-200'
+        }`}
+      >
+        {value}
+      </p>
+      {sublabel && <p className="text-xs text-slate-500">{sublabel}</p>}
+    </div>
+  )
+}

--- a/src/app/tap-tap-adventure/hooks/useCombatActionMutation.ts
+++ b/src/app/tap-tap-adventure/hooks/useCombatActionMutation.ts
@@ -26,7 +26,7 @@ interface CombatActionResponse {
 
 export function useCombatActionMutation() {
   const queryClient = useQueryClient()
-  const { getSelectedCharacter, addHeirloom, deleteCharacter, awardSoulEssence } = useGameStore()
+  const { getSelectedCharacter, addHeirloom, deleteCharacter, awardSoulEssence, setRunSummary } = useGameStore()
   const {
     addItem,
     addStoryEvent,
@@ -144,7 +144,15 @@ export function useCombatActionMutation() {
             addHeirloom(heirloom)
 
             // Award soul essence for the run
-            awardSoulEssence(character)
+            const essenceEarned = awardSoulEssence(character)
+
+            // Show run summary screen
+            setRunSummary({
+              character: { ...character },
+              reason: 'permadeath',
+              essenceEarned,
+              heirloom,
+            })
 
             deleteCharacter(character.id)
           } else {
@@ -179,7 +187,15 @@ export function useCombatActionMutation() {
             addHeirloom(heirloom)
 
             // Award soul essence for the run
-            awardSoulEssence(character)
+            const essenceEarned = awardSoulEssence(character)
+
+            // Show run summary screen
+            setRunSummary({
+              character: { ...character },
+              reason: 'death',
+              essenceEarned,
+              heirloom,
+            })
           }
         } else if (data.combatState.status === 'fled') {
           addStoryEvent({

--- a/src/app/tap-tap-adventure/hooks/useGameStore.ts
+++ b/src/app/tap-tap-adventure/hooks/useGameStore.ts
@@ -26,6 +26,7 @@ import {
   GameState,
   Item,
   MetaProgressionState,
+  RunSummaryData,
   ShopState,
 } from '@/app/tap-tap-adventure/models/types'
 import { claimDailyReward as processDailyRewardClaim } from '@/app/tap-tap-adventure/lib/dailyRewardTracker'
@@ -91,6 +92,8 @@ export interface GameStore {
   awardSoulEssence: (character: FantasyCharacter) => number
   purchaseUpgrade: (upgradeId: string) => boolean
   getMetaBonuses: () => MetaBonuses
+  setRunSummary: (summary: RunSummaryData) => void
+  clearRunSummary: () => void
 }
 
 export const useGameStore = create<GameStore>()(
@@ -582,6 +585,9 @@ export const useGameStore = create<GameStore>()(
             if (!character || character.status !== 'active') return
             if ((character.distance ?? 0) < 100) return
 
+            // Snapshot character before mutation for the summary screen
+            const characterSnapshot = { ...character }
+
             // Award soul essence before retiring
             const essence = calculateSoulEssence(character)
             const meta = state.gameState.metaProgression ?? {
@@ -605,6 +611,14 @@ export const useGameStore = create<GameStore>()(
               state.gameState.legacyHeirlooms = []
             }
             state.gameState.legacyHeirlooms.push(heirloom)
+
+            // Set run summary for the end-of-run screen
+            state.gameState.runSummary = {
+              character: characterSnapshot,
+              reason: 'retirement',
+              essenceEarned: essence,
+              heirloom,
+            }
 
             // Deselect if this was the active character
             if (state.gameState.selectedCharacterId === characterId) {
@@ -662,10 +676,24 @@ export const useGameStore = create<GameStore>()(
         if (!meta) return getMetaBonuses({})
         return getMetaBonuses(meta.upgradeLevels)
       },
+      setRunSummary: (summary: RunSummaryData) => {
+        set(
+          produce((state: GameStore) => {
+            state.gameState.runSummary = summary
+          })
+        )
+      },
+      clearRunSummary: () => {
+        set(
+          produce((state: GameStore) => {
+            state.gameState.runSummary = null
+          })
+        )
+      },
     }),
     {
       name: 'fantasy-tycoon-storage', // localStorage key (kept for backward compat)
-      version: 12,
+      version: 13,
       migrate: (persistedState: unknown) => {
         const state = persistedState as GameStore
         if (state?.gameState && !('combatState' in state.gameState)) {
@@ -738,6 +766,10 @@ export const useGameStore = create<GameStore>()(
         // v12: Add metaProgression
         if (state?.gameState && !('metaProgression' in state.gameState)) {
           (state.gameState as GameState).metaProgression = null
+        }
+        // v13: Add runSummary
+        if (state?.gameState && !('runSummary' in state.gameState)) {
+          (state.gameState as GameState).runSummary = null
         }
         return state
       },

--- a/src/app/tap-tap-adventure/lib/defaultGameState.ts
+++ b/src/app/tap-tap-adventure/lib/defaultGameState.ts
@@ -20,4 +20,5 @@ export const defaultGameState: GameState = {
   legacyHeirlooms: [],
   dailyReward: null,
   metaProgression: null,
+  runSummary: null,
 }

--- a/src/app/tap-tap-adventure/models/types.ts
+++ b/src/app/tap-tap-adventure/models/types.ts
@@ -81,6 +81,13 @@ type DailyRewardState = {
   totalDaysClaimed: number
 }
 
+type RunSummaryData = {
+  character: FantasyCharacter
+  reason: 'death' | 'permadeath' | 'retirement'
+  essenceEarned: number
+  heirloom: Item | null
+}
+
 type GameState = {
   player: {
     id: string
@@ -99,8 +106,9 @@ type GameState = {
   legacyHeirlooms: Item[]
   dailyReward: DailyRewardState | null
   metaProgression: MetaProgressionState | null
+  runSummary: RunSummaryData | null
 }
-export type { GameState, DailyRewardState }
+export type { GameState, DailyRewardState, RunSummaryData }
 export type { PlayerAchievement, Achievement, AchievementCategory } from './achievement'
 export type {
   EternalUpgrade,

--- a/src/app/tap-tap-adventure/page.tsx
+++ b/src/app/tap-tap-adventure/page.tsx
@@ -1,14 +1,19 @@
 'use client'
+import { useState } from 'react'
 import CharacterList from './components/CharacterList'
 import GameUI from './components/GameUI'
 import { HudBar } from './components/HudBar'
+import MetaProgression from './components/MetaProgression'
+import RunSummary from './components/RunSummary'
 import { PageTemplate } from './components/ui/PageTemplate'
 import { useGameStore } from './hooks/useGameStore'
 
 type initialView = 'game' | 'characters'
 
 export default function TapTapAdventurePage() {
-  const { gameState } = useGameStore()
+  const { gameState, clearRunSummary } = useGameStore()
+  const [showMetaFromSummary, setShowMetaFromSummary] = useState(false)
+  const [showCreationFromSummary, setShowCreationFromSummary] = useState(false)
 
   let initialView: initialView = 'characters'
 
@@ -16,13 +21,41 @@ export default function TapTapAdventurePage() {
     initialView = 'game'
   }
 
+  // Run summary takes priority over everything
+  const runSummary = gameState?.runSummary ?? null
+
   return (
     <PageTemplate pageId={initialView}>
       <div className="flex-1">
         <HudBar />
       </div>
-      {initialView === 'game' && <GameUI />}
-      {initialView === 'characters' && <CharacterList />}
+      {runSummary ? (
+        <>
+          <RunSummary
+            data={runSummary}
+            onViewUpgrades={() => {
+              setShowMetaFromSummary(true)
+            }}
+            onNewCharacter={() => {
+              clearRunSummary()
+              setShowCreationFromSummary(true)
+            }}
+            onBackToCharacters={() => {
+              clearRunSummary()
+            }}
+          />
+          {showMetaFromSummary && (
+            <MetaProgression onClose={() => setShowMetaFromSummary(false)} />
+          )}
+        </>
+      ) : (
+        <>
+          {initialView === 'game' && <GameUI />}
+          {initialView === 'characters' && (
+            <CharacterList defaultShowCreation={showCreationFromSummary} onCreationShown={() => setShowCreationFromSummary(false)} />
+          )}
+        </>
+      )}
     </PageTemplate>
   )
 }


### PR DESCRIPTION
## Summary
- New `RunSummary` component that displays after character death or retirement with run stats (distance, level, days, gold, deaths, difficulty), soul essence earned with full breakdown, and heirloom info
- Added `runSummary` field to `GameState` (v13 migration), with `setRunSummary`/`clearRunSummary` store actions
- Integrated into combat defeat flow (`useCombatActionMutation`) and retirement flow (`retireCharacter`) to trigger the summary screen
- Summary screen renders as a priority overlay in `page.tsx` with buttons to view eternal upgrades, create a new character, or return to character list

## Test plan
- [ ] Retire a character with 100+ distance and verify the run summary screen appears with correct stats and essence breakdown
- [ ] Get defeated in combat (normal mode) and verify summary screen shows with "Fallen in Battle" header
- [ ] Get defeated in ironman/permadeath mode and verify summary screen shows with permadeath message
- [ ] Click "View Eternal Upgrades" on summary screen and verify MetaProgression panel opens
- [ ] Click "Create New Character" and verify navigation to character list with creation form open
- [ ] Click "Back to Characters" and verify clean return to character list
- [ ] Verify no new TypeScript errors introduced (`npx tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)