### PR TITLE
Add synthesized sound effects to Tap Tap Adventure

### DIFF
--- a/src/app/tap-tap-adventure/components/CombatUI.tsx
+++ b/src/app/tap-tap-adventure/components/CombatUI.tsx
@@ -10,6 +10,7 @@ import { useCombatActionMutation } from '@/app/tap-tap-adventure/hooks/useCombat
 import { useGameStore } from '@/app/tap-tap-adventure/hooks/useGameStore'
 import { isUsableInCombat } from '@/app/tap-tap-adventure/lib/combatItemEffects'
 import { ELEMENT_COLORS } from '@/app/tap-tap-adventure/config/elements'
+import { soundEngine } from '@/app/tap-tap-adventure/lib/soundEngine'
 import { CombatAction, CombatState, StatusEffect } from '@/app/tap-tap-adventure/models/combat'
 import { Spell } from '@/app/tap-tap-adventure/models/spell'
 import { Item } from '@/app/tap-tap-adventure/models/types'
@@ -122,15 +123,21 @@ export function CombatUI({ combatState }: CombatUIProps) {
 
   const handleUseItem = useCallback(
     (itemId: string) => {
+      // Check if the item has healing effects
+      const item = combatItems.find((i: Item) => i.id === itemId)
+      if (item?.effects?.heal && item.effects.heal > 0) {
+        soundEngine.playHeal()
+      }
       setShowItemMenu(false)
       setShowSpellMenu(false)
       combatAction({ action: 'use_item', itemId })
     },
-    [combatAction]
+    [combatAction, combatItems]
   )
 
   const handleCastSpell = useCallback(
     (spellId: string) => {
+      soundEngine.playSpellCast()
       setShowSpellMenu(false)
       setShowItemMenu(false)
       combatAction({ action: 'cast_spell', spellId })

--- a/src/app/tap-tap-adventure/components/GameUI.tsx
+++ b/src/app/tap-tap-adventure/components/GameUI.tsx
@@ -16,6 +16,7 @@ import { flipCoin } from '@/app/utils'
 
 import { SKILLS } from '@/app/tap-tap-adventure/config/skills'
 import { getSkillBonus } from '@/app/tap-tap-adventure/lib/skillTracker'
+import { soundEngine } from '@/app/tap-tap-adventure/lib/soundEngine'
 
 import { DailyRewardPopup } from './DailyRewardPopup'
 import { AchievementPanel } from './AchievementPanel'
@@ -114,6 +115,7 @@ export default function GameUI() {
   }
 
   const handleMoveForward = () => {
+    soundEngine.playTap()
     const character = getSelectedCharacter()
     const distance = character?.distance ?? 0
     const nextDistance = distance + 1

--- a/src/app/tap-tap-adventure/components/HudBar.tsx
+++ b/src/app/tap-tap-adventure/components/HudBar.tsx
@@ -1,10 +1,11 @@
 'use client'
-import { useCallback, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 
 import { getDifficultyMode } from '@/app/tap-tap-adventure/config/difficultyModes'
 import { getRegion } from '@/app/tap-tap-adventure/config/regions'
 import { Mount } from '@/app/tap-tap-adventure/models/mount'
 import { useGameStore } from '@/app/tap-tap-adventure/hooks/useGameStore'
+import { soundEngine } from '@/app/tap-tap-adventure/lib/soundEngine'
 import { getReputationTier } from '@/app/tap-tap-adventure/lib/contextBuilder'
 import { levelProgress, stepsToNextLevel, stepsRequiredForLevel, calculateDay } from '@/app/tap-tap-adventure/lib/leveling'
 import { FantasyCharacter } from '@/app/tap-tap-adventure/models/character'
@@ -117,6 +118,34 @@ export function HudBar() {
     }),
     [character]
   ) as Record<IconType, number | string>
+
+  const [soundEnabled, setSoundEnabled] = useState(true)
+
+  useEffect(() => {
+    try {
+      const stored = localStorage.getItem('tap-tap-sound-enabled')
+      if (stored !== null) {
+        const val = stored === 'true'
+        setSoundEnabled(val)
+        soundEngine.setEnabled(val)
+      }
+    } catch {
+      // localStorage unavailable, keep default
+    }
+  }, [])
+
+  const toggleSound = useCallback(() => {
+    setSoundEnabled(prev => {
+      const next = !prev
+      soundEngine.setEnabled(next)
+      try {
+        localStorage.setItem('tap-tap-sound-enabled', String(next))
+      } catch {
+        // fail silently
+      }
+      return next
+    })
+  }, [])
 
   const [activeTooltip, setActiveTooltip] = useState<IconType | null>(null)
 
@@ -245,6 +274,14 @@ export function HudBar() {
           </div>
         )}
         {STATS_RIGHT.map(renderStat)}
+        <button
+          className="text-sm px-1.5 py-0.5 rounded border border-[#3a3c56] bg-[#2a2b3f] hover:bg-[#3a3c56] transition-colors"
+          onClick={toggleSound}
+          title={soundEnabled ? 'Mute sounds' : 'Enable sounds'}
+          aria-label={soundEnabled ? 'Mute sounds' : 'Enable sounds'}
+        >
+          <span>{soundEnabled ? '\u{1F50A}' : '\u{1F507}'}</span>
+        </button>
       </div>
     </div>
   )

--- a/src/app/tap-tap-adventure/components/LevelUpCelebration.tsx
+++ b/src/app/tap-tap-adventure/components/LevelUpCelebration.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useEffect, useState } from 'react'
+import { soundEngine } from '@/app/tap-tap-adventure/lib/soundEngine'
 
 interface LevelUpCelebrationProps {
   level: number
@@ -11,6 +12,8 @@ export function LevelUpCelebration({ level, onDismiss }: LevelUpCelebrationProps
   const [isVisible, setIsVisible] = useState(false)
 
   useEffect(() => {
+    // Play level up sound
+    soundEngine.playLevelUp()
     // Trigger entrance animation
     requestAnimationFrame(() => setIsVisible(true))
 

--- a/src/app/tap-tap-adventure/hooks/useCombatActionMutation.ts
+++ b/src/app/tap-tap-adventure/hooks/useCombatActionMutation.ts
@@ -10,6 +10,8 @@ import { CombatAction, CombatState } from '@/app/tap-tap-adventure/models/combat
 import { Mount } from '@/app/tap-tap-adventure/models/mount'
 import { FantasyCharacter, Item } from '@/app/tap-tap-adventure/models/types'
 
+import { soundEngine } from '@/app/tap-tap-adventure/lib/soundEngine'
+
 import { useGameStateBuilder, useGameStore } from './useGameStore'
 
 interface CombatActionResponse {
@@ -96,13 +98,23 @@ export function useCombatActionMutation() {
       })
 
       if (data.combatState.status === 'active') {
-        // Combat continues
+        // Combat continues — play sounds based on what happened
+        if (action === 'attack' || action === 'heavy_attack' || action === 'class_ability') {
+          soundEngine.playHit()
+        }
+        // If player took damage this turn (enemy attacked), play enemy hit sound
+        const prevHp = combatState.playerState.hp
+        const newHp = data.combatState.playerState.hp
+        if (newHp < prevHp) {
+          soundEngine.playEnemyHit()
+        }
         setCombatState(data.combatState)
       } else {
         // Combat ended
         const enemy = combatState.enemy
 
         if (data.combatState.status === 'victory' && data.rewards) {
+          soundEngine.playVictory()
           // Add loot items
           for (const lootItem of data.rewards.loot) {
             addItem(inferItemTypeAndEffects(lootItem))
@@ -125,6 +137,7 @@ export function useCombatActionMutation() {
             },
           })
         } else if (data.combatState.status === 'defeat') {
+          soundEngine.playDefeat()
           const diffMods = getDifficultyModifiers(character.difficultyMode)
 
           if (diffMods.permadeath) {

--- a/src/app/tap-tap-adventure/hooks/useMoveForwardMutation.ts
+++ b/src/app/tap-tap-adventure/hooks/useMoveForwardMutation.ts
@@ -10,6 +10,8 @@ import {
   Item,
 } from '@/app/tap-tap-adventure/models/types'
 
+import { soundEngine } from '@/app/tap-tap-adventure/lib/soundEngine'
+
 import { useGameStateBuilder, useGameStore } from './useGameStore'
 
 export interface MoveForwardResponse {
@@ -71,6 +73,7 @@ export function useMoveForwardMutation() {
       }
 
       if (data.shopEvent) {
+        soundEngine.playGold()
         // Step milestone triggered a shop - fetch shop items from server
         const shopRes = await fetch('/api/v1/tap-tap-adventure/shop/generate', {
           method: 'POST',
@@ -84,6 +87,7 @@ export function useMoveForwardMutation() {
           setShopState({ items: shopData.shopItems, isOpen: true })
         }
       } else if (data.decisionPoint) {
+        soundEngine.playEvent()
         setGenericMessage(null)
         setDecisionPoint(data.decisionPoint)
       }

--- a/src/app/tap-tap-adventure/hooks/useResolveDecisionMutation.ts
+++ b/src/app/tap-tap-adventure/hooks/useResolveDecisionMutation.ts
@@ -5,6 +5,8 @@ import { getRandomMount } from '@/app/tap-tap-adventure/config/mounts'
 import { inferItemTypeAndEffects } from '@/app/tap-tap-adventure/lib/itemPostProcessor'
 import { FantasyCharacter, FantasyDecisionPoint, Item } from '@/app/tap-tap-adventure/models/types'
 
+import { soundEngine } from '@/app/tap-tap-adventure/lib/soundEngine'
+
 import { useGameStateBuilder, useGameStore } from './useGameStore'
 
 export interface ResolveDecisionResponse {
@@ -43,6 +45,7 @@ export function useResolveDecisionMutation() {
 
       // Handle crossroads region travel decisions client-side
       if (optionId.startsWith('travel-')) {
+        soundEngine.playCrossroads()
         const regionId = optionId.replace('travel-', '')
         updateSelectedCharacter({ currentRegion: regionId })
         const chosenOption = decisionPoint.options.find(o => o.id === optionId)
@@ -136,6 +139,7 @@ export function useResolveDecisionMutation() {
       // If the chosen option triggers combat, start a combat encounter
       // Pass the event description so the enemy matches the narrative
       if (data.triggersCombat) {
+        soundEngine.playBoss()
         const { gameState } = useGameStore.getState()
         const chosenOption = decisionPoint.options.find(o => o.id === optionId)
         const isBoss = (chosenOption as Record<string, unknown>)?.isBoss === true

--- a/src/app/tap-tap-adventure/lib/soundEngine.ts
+++ b/src/app/tap-tap-adventure/lib/soundEngine.ts
@@ -1,0 +1,353 @@
+'use client'
+
+class SoundEngine {
+  private ctx: AudioContext | null = null
+  private enabled: boolean = true
+
+  private getContext(): AudioContext | null {
+    if (!this.ctx) {
+      try {
+        this.ctx = new AudioContext()
+      } catch {
+        return null
+      }
+    }
+    if (this.ctx.state === 'suspended') this.ctx.resume()
+    return this.ctx
+  }
+
+  setEnabled(enabled: boolean) {
+    this.enabled = enabled
+  }
+
+  isEnabled() {
+    return this.enabled
+  }
+
+  /** Soft click for walking. 50ms sine 800->600Hz, gain 0.08 */
+  playTap() {
+    try {
+      if (!this.enabled) return
+      const ctx = this.getContext()
+      if (!ctx) return
+      const now = ctx.currentTime
+      const osc = ctx.createOscillator()
+      const gain = ctx.createGain()
+      osc.type = 'sine'
+      osc.frequency.setValueAtTime(800, now)
+      osc.frequency.linearRampToValueAtTime(600, now + 0.05)
+      gain.gain.setValueAtTime(0.08, now)
+      gain.gain.linearRampToValueAtTime(0, now + 0.05)
+      osc.connect(gain)
+      gain.connect(ctx.destination)
+      osc.start(now)
+      osc.stop(now + 0.05)
+    } catch {
+      // fail silently
+    }
+  }
+
+  /** Chime for events. Two notes C5 (523Hz) then E5 (659Hz), 80ms each, gain 0.15 */
+  playEvent() {
+    try {
+      if (!this.enabled) return
+      const ctx = this.getContext()
+      if (!ctx) return
+      const now = ctx.currentTime
+      const notes = [523, 659]
+      notes.forEach((freq, i) => {
+        const osc = ctx.createOscillator()
+        const gain = ctx.createGain()
+        osc.type = 'sine'
+        osc.frequency.setValueAtTime(freq, now)
+        const start = now + i * 0.08
+        gain.gain.setValueAtTime(0, start)
+        gain.gain.linearRampToValueAtTime(0.15, start + 0.01)
+        gain.gain.linearRampToValueAtTime(0, start + 0.08)
+        osc.connect(gain)
+        gain.connect(ctx.destination)
+        osc.start(start)
+        osc.stop(start + 0.08)
+      })
+    } catch {
+      // fail silently
+    }
+  }
+
+  /** Player attacks. White noise burst 60ms, bandpass 200Hz, gain 0.2 */
+  playHit() {
+    try {
+      if (!this.enabled) return
+      const ctx = this.getContext()
+      if (!ctx) return
+      const now = ctx.currentTime
+      const bufferSize = ctx.sampleRate * 0.06
+      const buffer = ctx.createBuffer(1, bufferSize, ctx.sampleRate)
+      const data = buffer.getChannelData(0)
+      for (let i = 0; i < bufferSize; i++) {
+        data[i] = Math.random() * 2 - 1
+      }
+      const source = ctx.createBufferSource()
+      source.buffer = buffer
+      const filter = ctx.createBiquadFilter()
+      filter.type = 'bandpass'
+      filter.frequency.setValueAtTime(200, now)
+      const gain = ctx.createGain()
+      gain.gain.setValueAtTime(0.2, now)
+      gain.gain.linearRampToValueAtTime(0, now + 0.06)
+      source.connect(filter)
+      filter.connect(gain)
+      gain.connect(ctx.destination)
+      source.start(now)
+      source.stop(now + 0.06)
+    } catch {
+      // fail silently
+    }
+  }
+
+  /** Enemy hits player. White noise 80ms, bandpass 120Hz, gain 0.15 */
+  playEnemyHit() {
+    try {
+      if (!this.enabled) return
+      const ctx = this.getContext()
+      if (!ctx) return
+      const now = ctx.currentTime
+      const bufferSize = ctx.sampleRate * 0.08
+      const buffer = ctx.createBuffer(1, bufferSize, ctx.sampleRate)
+      const data = buffer.getChannelData(0)
+      for (let i = 0; i < bufferSize; i++) {
+        data[i] = Math.random() * 2 - 1
+      }
+      const source = ctx.createBufferSource()
+      source.buffer = buffer
+      const filter = ctx.createBiquadFilter()
+      filter.type = 'bandpass'
+      filter.frequency.setValueAtTime(120, now)
+      const gain = ctx.createGain()
+      gain.gain.setValueAtTime(0.15, now)
+      gain.gain.linearRampToValueAtTime(0, now + 0.08)
+      source.connect(filter)
+      filter.connect(gain)
+      gain.connect(ctx.destination)
+      source.start(now)
+      source.stop(now + 0.08)
+    } catch {
+      // fail silently
+    }
+  }
+
+  /** Three ascending notes C5/E5/G5, 120ms each staggered, gain 0.2 */
+  playVictory() {
+    try {
+      if (!this.enabled) return
+      const ctx = this.getContext()
+      if (!ctx) return
+      const now = ctx.currentTime
+      const notes = [523, 659, 784]
+      notes.forEach((freq, i) => {
+        const osc = ctx.createOscillator()
+        const gain = ctx.createGain()
+        osc.type = 'sine'
+        osc.frequency.setValueAtTime(freq, now)
+        const start = now + i * 0.12
+        gain.gain.setValueAtTime(0, start)
+        gain.gain.linearRampToValueAtTime(0.2, start + 0.01)
+        gain.gain.linearRampToValueAtTime(0, start + 0.12)
+        osc.connect(gain)
+        gain.connect(ctx.destination)
+        osc.start(start)
+        osc.stop(start + 0.12)
+      })
+    } catch {
+      // fail silently
+    }
+  }
+
+  /** Three descending notes G4/Eb4/C4, 150ms each, gain 0.15 */
+  playDefeat() {
+    try {
+      if (!this.enabled) return
+      const ctx = this.getContext()
+      if (!ctx) return
+      const now = ctx.currentTime
+      const notes = [392, 311, 262]
+      notes.forEach((freq, i) => {
+        const osc = ctx.createOscillator()
+        const gain = ctx.createGain()
+        osc.type = 'sine'
+        osc.frequency.setValueAtTime(freq, now)
+        const start = now + i * 0.15
+        gain.gain.setValueAtTime(0, start)
+        gain.gain.linearRampToValueAtTime(0.15, start + 0.01)
+        gain.gain.linearRampToValueAtTime(0, start + 0.15)
+        osc.connect(gain)
+        gain.connect(ctx.destination)
+        osc.start(start)
+        osc.stop(start + 0.15)
+      })
+    } catch {
+      // fail silently
+    }
+  }
+
+  /** Four ascending notes C5/E5/G5/C6, 100ms each, gain 0.2 */
+  playLevelUp() {
+    try {
+      if (!this.enabled) return
+      const ctx = this.getContext()
+      if (!ctx) return
+      const now = ctx.currentTime
+      const notes = [523, 659, 784, 1047]
+      notes.forEach((freq, i) => {
+        const osc = ctx.createOscillator()
+        const gain = ctx.createGain()
+        osc.type = 'sine'
+        osc.frequency.setValueAtTime(freq, now)
+        const start = now + i * 0.1
+        gain.gain.setValueAtTime(0, start)
+        gain.gain.linearRampToValueAtTime(0.2, start + 0.01)
+        gain.gain.linearRampToValueAtTime(0, start + 0.1)
+        osc.connect(gain)
+        gain.connect(ctx.destination)
+        osc.start(start)
+        osc.stop(start + 0.1)
+      })
+    } catch {
+      // fail silently
+    }
+  }
+
+  /** Quick ping, sine 1200Hz, 40ms, gain 0.1 */
+  playGold() {
+    try {
+      if (!this.enabled) return
+      const ctx = this.getContext()
+      if (!ctx) return
+      const now = ctx.currentTime
+      const osc = ctx.createOscillator()
+      const gain = ctx.createGain()
+      osc.type = 'sine'
+      osc.frequency.setValueAtTime(1200, now)
+      gain.gain.setValueAtTime(0.1, now)
+      gain.gain.linearRampToValueAtTime(0, now + 0.04)
+      osc.connect(gain)
+      gain.connect(ctx.destination)
+      osc.start(now)
+      osc.stop(now + 0.04)
+    } catch {
+      // fail silently
+    }
+  }
+
+  /** Warm sweep sine 440->880Hz, 200ms, gain 0.12 */
+  playHeal() {
+    try {
+      if (!this.enabled) return
+      const ctx = this.getContext()
+      if (!ctx) return
+      const now = ctx.currentTime
+      const osc = ctx.createOscillator()
+      const gain = ctx.createGain()
+      osc.type = 'sine'
+      osc.frequency.setValueAtTime(440, now)
+      osc.frequency.linearRampToValueAtTime(880, now + 0.2)
+      gain.gain.setValueAtTime(0.12, now)
+      gain.gain.linearRampToValueAtTime(0, now + 0.2)
+      osc.connect(gain)
+      gain.connect(ctx.destination)
+      osc.start(now)
+      osc.stop(now + 0.2)
+    } catch {
+      // fail silently
+    }
+  }
+
+  /** Low rumble 80Hz 300ms + high sting 1000->800Hz 100ms, gain 0.2 */
+  playBoss() {
+    try {
+      if (!this.enabled) return
+      const ctx = this.getContext()
+      if (!ctx) return
+      const now = ctx.currentTime
+      // Low rumble
+      const oscLow = ctx.createOscillator()
+      const gainLow = ctx.createGain()
+      oscLow.type = 'sine'
+      oscLow.frequency.setValueAtTime(80, now)
+      gainLow.gain.setValueAtTime(0.2, now)
+      gainLow.gain.linearRampToValueAtTime(0, now + 0.3)
+      oscLow.connect(gainLow)
+      gainLow.connect(ctx.destination)
+      oscLow.start(now)
+      oscLow.stop(now + 0.3)
+      // High sting
+      const oscHigh = ctx.createOscillator()
+      const gainHigh = ctx.createGain()
+      oscHigh.type = 'sine'
+      oscHigh.frequency.setValueAtTime(1000, now)
+      oscHigh.frequency.linearRampToValueAtTime(800, now + 0.1)
+      gainHigh.gain.setValueAtTime(0.2, now)
+      gainHigh.gain.linearRampToValueAtTime(0, now + 0.1)
+      oscHigh.connect(gainHigh)
+      gainHigh.connect(ctx.destination)
+      oscHigh.start(now)
+      oscHigh.stop(now + 0.1)
+    } catch {
+      // fail silently
+    }
+  }
+
+  /** Detuned beating sines 440+445Hz, 200ms, gain 0.12 */
+  playSpellCast() {
+    try {
+      if (!this.enabled) return
+      const ctx = this.getContext()
+      if (!ctx) return
+      const now = ctx.currentTime
+      const freqs = [440, 445]
+      freqs.forEach((freq) => {
+        const osc = ctx.createOscillator()
+        const gain = ctx.createGain()
+        osc.type = 'sine'
+        osc.frequency.setValueAtTime(freq, now)
+        gain.gain.setValueAtTime(0.12, now)
+        gain.gain.linearRampToValueAtTime(0, now + 0.2)
+        osc.connect(gain)
+        gain.connect(ctx.destination)
+        osc.start(now)
+        osc.stop(now + 0.2)
+      })
+    } catch {
+      // fail silently
+    }
+  }
+
+  /** Descending G5/E5/C5, 100ms each overlapped, gain 0.1 */
+  playCrossroads() {
+    try {
+      if (!this.enabled) return
+      const ctx = this.getContext()
+      if (!ctx) return
+      const now = ctx.currentTime
+      const notes = [784, 659, 523]
+      notes.forEach((freq, i) => {
+        const osc = ctx.createOscillator()
+        const gain = ctx.createGain()
+        osc.type = 'sine'
+        osc.frequency.setValueAtTime(freq, now)
+        const start = now + i * 0.07
+        gain.gain.setValueAtTime(0, start)
+        gain.gain.linearRampToValueAtTime(0.1, start + 0.01)
+        gain.gain.linearRampToValueAtTime(0, start + 0.1)
+        osc.connect(gain)
+        gain.connect(ctx.destination)
+        osc.start(start)
+        osc.stop(start + 0.1)
+      })
+    } catch {
+      // fail silently
+    }
+  }
+}
+
+export const soundEngine = new SoundEngine()


### PR DESCRIPTION
## Summary
- Adds a `SoundEngine` singleton (`lib/soundEngine.ts`) that generates 12 distinct sounds using the Web Audio API -- no audio files or npm dependencies
- Integrates sound triggers at key gameplay moments: walking (tap), events (chime), combat (hit/enemy hit/victory/defeat), spells, healing items, level up, gold/shop, boss encounters, and crossroads travel
- Adds a mute/unmute toggle button in the HUD bar with localStorage persistence (`tap-tap-sound-enabled`)

## Details
All sounds are synthesized (sine waves, white noise with bandpass filters), under 300ms (victory/defeat under 500ms), with gain levels between 0.05-0.2. Every sound method is wrapped in try/catch to fail silently. AudioContext is lazy-initialized on first user gesture.

### Files changed
- **New:** `lib/soundEngine.ts` -- singleton with 12 sound methods
- **Modified:** `components/GameUI.tsx` -- playTap on move forward
- **Modified:** `hooks/useMoveForwardMutation.ts` -- playEvent on decision, playGold on shop
- **Modified:** `hooks/useCombatActionMutation.ts` -- playHit, playEnemyHit, playVictory, playDefeat
- **Modified:** `hooks/useResolveDecisionMutation.ts` -- playCrossroads on travel, playBoss on combat trigger
- **Modified:** `components/CombatUI.tsx` -- playSpellCast on spell, playHeal on healing item
- **Modified:** `components/LevelUpCelebration.tsx` -- playLevelUp on mount
- **Modified:** `components/HudBar.tsx` -- sound toggle button with localStorage

## Test plan
- [ ] Walk around and verify soft tap click on each step
- [ ] Trigger an event and hear the chime
- [ ] Enter combat and verify hit/enemy hit sounds play
- [ ] Win a combat and hear victory fanfare
- [ ] Lose a combat and hear defeat sound
- [ ] Cast a spell and hear the detuned beating effect
- [ ] Use a healing item and hear the warm sweep
- [ ] Level up and hear the ascending four-note sequence
- [ ] Visit a shop and hear the gold ping
- [ ] Travel at crossroads and hear descending notes
- [ ] Toggle mute in HUD, refresh page, confirm setting persists
- [ ] Verify no TypeScript errors introduced (pre-existing test errors only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)