### PR TITLE
Add critical strike system to combat

### DIFF
--- a/src/app/tap-tap-adventure/components/CombatUI.tsx
+++ b/src/app/tap-tap-adventure/components/CombatUI.tsx
@@ -267,10 +267,14 @@ export function CombatUI({ combatState }: CombatUIProps) {
             <div
               key={i}
               className={`text-xs ${
-                entry.actor === 'player' ? 'text-blue-300' : 'text-red-300'
+                entry.isCritical
+                  ? 'text-yellow-300 font-bold'
+                  : entry.actor === 'player' ? 'text-blue-300' : 'text-red-300'
               }`}
             >
-              <span className="text-slate-500">T{entry.turn}:</span> {entry.description}
+              <span className="text-slate-500">T{entry.turn}:</span>{' '}
+              {entry.isCritical && <span className="text-yellow-400 mr-1">&#9733;</span>}
+              {entry.description}
             </div>
           ))}
         </div>

--- a/src/app/tap-tap-adventure/hooks/useCombatActionMutation.ts
+++ b/src/app/tap-tap-adventure/hooks/useCombatActionMutation.ts
@@ -99,7 +99,13 @@ export function useCombatActionMutation() {
 
       if (data.combatState.status === 'active') {
         // Combat continues — play sounds based on what happened
-        if (action === 'attack' || action === 'heavy_attack' || action === 'class_ability') {
+        // Check for critical hits in new log entries
+        const prevLogLen = combatState.combatLog.length
+        const newEntries = data.combatState.combatLog.slice(prevLogLen)
+        const hasCrit = newEntries.some(e => e.isCritical)
+        if (hasCrit) {
+          soundEngine.playCritical()
+        } else if (action === 'attack' || action === 'heavy_attack' || action === 'class_ability') {
           soundEngine.playHit()
         }
         // If player took damage this turn (enemy attacked), play enemy hit sound

--- a/src/app/tap-tap-adventure/lib/combatEngine.ts
+++ b/src/app/tap-tap-adventure/lib/combatEngine.ts
@@ -75,6 +75,9 @@ export function initializePlayerCombatState(character: FantasyCharacter): Combat
   const baseAttack = 2 + character.strength + mountStrBonus + Math.floor(character.level / 2) + weaponBonus * 2
   const baseDefense = 1 + Math.floor((character.intelligence + mountIntBonus) / 2) + Math.floor(character.level / 2) + armorBonus
 
+  // Calculate total luck for crit chance
+  const totalLuck = character.luck + mountLuckBonus + accessoryLuckBonus
+
   return {
     hp: currentHp,
     maxHp,
@@ -98,6 +101,7 @@ export function initializePlayerCombatState(character: FantasyCharacter): Combat
     ap: MAX_AP,
     maxAp: MAX_AP,
     turnActions: [],
+    luck: totalLuck,
   }
 }
 
@@ -114,11 +118,21 @@ function getComboMultiplier(comboCount: number): number {
   return Math.min(1.75, 1 + comboCount * 0.25)
 }
 
+/**
+ * Calculate the player's crit chance based on luck.
+ * Base 5% + 1% per luck point, capped at 40%.
+ */
+function getPlayerCritChance(luck: number, bonusCritChance: number = 0): number {
+  const baseCritChance = 0.05 + luck * 0.01 + bonusCritChance
+  return Math.min(0.4, baseCritChance)
+}
+
 export function calculatePlayerDamage(
   playerState: CombatPlayerState,
   enemy: CombatEnemy,
-  character?: FantasyCharacter
-): { damage: number; elementalMultiplier: number } {
+  character?: FantasyCharacter,
+  bonusCritChance: number = 0
+): { damage: number; elementalMultiplier: number; isCritical: boolean } {
   const buffedAttack =
     playerState.attack +
     (playerState.activeBuffs ?? [])
@@ -136,15 +150,26 @@ export function calculatePlayerDamage(
   const raw = randomVariance(buffedAttack) * comboMultiplier * berserkMultiplier * elementalMultiplier - enemyDefense
   // AP system: reduce per-action damage so 3 attacks ≈ 1.8x old single attack
   const apScaled = raw * 0.6
-  return { damage: Math.max(1, Math.round(apScaled)), elementalMultiplier }
+
+  // Critical strike check
+  const luck = playerState.luck ?? 0
+  const critChance = getPlayerCritChance(luck, bonusCritChance)
+  const isCritical = Math.random() < critChance
+  const critMultiplier = isCritical ? 2.0 : 1.0
+
+  return { damage: Math.max(1, Math.round(apScaled * critMultiplier)), elementalMultiplier, isCritical }
 }
+
+/** Flat 5% crit chance for enemies, dealing 1.5x damage. */
+const ENEMY_CRIT_CHANCE = 0.05
+const ENEMY_CRIT_MULTIPLIER = 1.5
 
 export function calculateEnemyDamage(
   enemy: CombatEnemy,
   playerState: CombatPlayerState,
   isHeavyAttack: boolean = false,
   character?: FantasyCharacter
-): { damage: number; elementalMultiplier: number } {
+): { damage: number; elementalMultiplier: number; isCritical: boolean } {
   const effectiveDefense = playerState.isDefending
     ? playerState.defense * 2
     : playerState.defense
@@ -164,7 +189,12 @@ export function calculateEnemyDamage(
 
   const attackPower = (isHeavyAttack ? enemy.attack * 1.5 : enemy.attack) * slowMultiplier * elementalMultiplier
   const raw = randomVariance(attackPower) - buffedDefense
-  return { damage: Math.max(1, Math.round(raw)), elementalMultiplier }
+
+  // Enemy critical strike check
+  const isCritical = Math.random() < ENEMY_CRIT_CHANCE
+  const critMultiplier = isCritical ? ENEMY_CRIT_MULTIPLIER : 1.0
+
+  return { damage: Math.max(1, Math.round(raw * critMultiplier)), elementalMultiplier, isCritical }
 }
 
 export function calculateFleeChance(
@@ -257,7 +287,7 @@ function executeEnemyTelegraph(
 
   switch (telegraph.action) {
     case 'heavy_attack': {
-      const { damage: dmg, elementalMultiplier } = calculateEnemyDamage(enemy, updatedPlayer, true, character)
+      const { damage: dmg, elementalMultiplier, isCritical } = calculateEnemyDamage(enemy, updatedPlayer, true, character)
       updatedPlayer.hp = Math.max(0, updatedPlayer.hp - dmg)
       const elemText = getEffectivenessText(elementalMultiplier)
       logs.push({
@@ -265,7 +295,8 @@ function executeEnemyTelegraph(
         actor: 'enemy',
         action: 'heavy_attack',
         damage: dmg,
-        description: `${enemy.name} unleashes a powerful blow for ${dmg} damage!${elemText ? ` ${elemText}` : ''}`,
+        description: `${isCritical ? 'CRITICAL! ' : ''}${enemy.name} unleashes a powerful blow for ${dmg} damage!${elemText ? ` ${elemText}` : ''}`,
+        isCritical,
       })
       break
     }
@@ -301,7 +332,7 @@ function executeEnemyTelegraph(
     }
     case 'normal_attack':
     default: {
-      const { damage: dmg, elementalMultiplier } = calculateEnemyDamage(enemy, updatedPlayer, false, character)
+      const { damage: dmg, elementalMultiplier, isCritical } = calculateEnemyDamage(enemy, updatedPlayer, false, character)
       updatedPlayer.hp = Math.max(0, updatedPlayer.hp - dmg)
       const elemText = getEffectivenessText(elementalMultiplier)
       logs.push({
@@ -309,7 +340,8 @@ function executeEnemyTelegraph(
         actor: 'enemy',
         action: 'attack',
         damage: dmg,
-        description: `${enemy.name} attacks you for ${dmg} damage!${elemText ? ` ${elemText}` : ''}`,
+        description: `${isCritical ? 'CRITICAL! ' : ''}${enemy.name} attacks you for ${dmg} damage!${elemText ? ` ${elemText}` : ''}`,
+        isCritical,
       })
       break
     }
@@ -419,17 +451,19 @@ export function processPlayerAction(
         const effectiveEnemy = enemyDefending
           ? { ...enemy, defense: enemy.defense * 2 }
           : enemy
-        const { damage, elementalMultiplier } = calculatePlayerDamage(playerState, effectiveEnemy, character)
+        const { damage, elementalMultiplier, isCritical } = calculatePlayerDamage(playerState, effectiveEnemy, character)
         enemy.hp = Math.max(0, enemy.hp - damage)
         playerState.comboCount = (playerState.comboCount ?? 0) + 1
         const comboText = playerState.comboCount > 1 ? ` (${playerState.comboCount}x combo!)` : ''
         const elemText = getEffectivenessText(elementalMultiplier)
+        const critText = isCritical ? ' CRITICAL HIT!' : ''
         newLogs.push({
           turn: turnNumber,
           actor: 'player',
           action: 'attack',
           damage,
-          description: `You strike ${enemy.name} for ${damage} damage!${comboText}${elemText ? ` ${elemText}` : ''}`,
+          description: `${critText ? 'CRITICAL HIT! ' : ''}You strike ${enemy.name} for ${damage} damage!${comboText}${elemText ? ` ${elemText}` : ''}`,
+          isCritical,
         })
         break
       }
@@ -437,7 +471,7 @@ export function processPlayerAction(
         const effectiveEnemy = enemyDefending
           ? { ...enemy, defense: enemy.defense * 2 }
           : enemy
-        const { damage: baseDmg, elementalMultiplier } = calculatePlayerDamage(playerState, effectiveEnemy, character)
+        const { damage: baseDmg, elementalMultiplier, isCritical } = calculatePlayerDamage(playerState, effectiveEnemy, character, 0.05)
         const damage = Math.max(1, Math.round(baseDmg * 1.8))
         enemy.hp = Math.max(0, enemy.hp - damage)
         playerState.comboCount = (playerState.comboCount ?? 0) + 1
@@ -448,7 +482,8 @@ export function processPlayerAction(
           actor: 'player',
           action: 'heavy_attack',
           damage,
-          description: `You deliver a powerful heavy attack on ${enemy.name} for ${damage} damage!${comboText}${elemText ? ` ${elemText}` : ''}`,
+          description: `${isCritical ? 'CRITICAL HIT! ' : ''}You deliver a powerful heavy attack on ${enemy.name} for ${damage} damage!${comboText}${elemText ? ` ${elemText}` : ''}`,
+          isCritical,
         })
         break
       }
@@ -833,7 +868,7 @@ export function processPlayerAction(
       }
     }
   } else {
-    const { damage: enemyDmg, elementalMultiplier: enemyElemMult } = calculateEnemyDamage(enemy, playerState, false, character)
+    const { damage: enemyDmg, elementalMultiplier: enemyElemMult, isCritical: enemyCrit } = calculateEnemyDamage(enemy, playerState, false, character)
     const dmgReduction = getActiveDamageReduction(playerState)
     const reducedDmg = Math.max(1, Math.round(enemyDmg * (1 - dmgReduction / 100)))
     const shieldResult = applyShieldAbsorption(playerState, reducedDmg)
@@ -857,7 +892,8 @@ export function processPlayerAction(
     playerState.hp = Math.max(0, playerState.hp - actualDmg)
     newLogs.push({
       turn: turnNumber, actor: 'enemy', action: 'attack', damage: actualDmg,
-      description: `${enemy.name} attacks you for ${actualDmg} damage!${dmgReduction > 0 ? ` (${dmgReduction}% reduced)` : ''}${(playerState.shield ?? 0) > 0 || reducedDmg !== actualDmg ? ' (shield absorbed some)' : ''}${enemyElemText ? ` ${enemyElemText}` : ''}`,
+      description: `${enemyCrit ? 'CRITICAL! ' : ''}${enemy.name} attacks you for ${actualDmg} damage!${dmgReduction > 0 ? ` (${dmgReduction}% reduced)` : ''}${(playerState.shield ?? 0) > 0 || reducedDmg !== actualDmg ? ' (shield absorbed some)' : ''}${enemyElemText ? ` ${enemyElemText}` : ''}`,
+      isCritical: enemyCrit,
     })
 
     // Apply thorns damage back to enemy
@@ -1006,4 +1042,4 @@ export function getCombatRewards(
 }
 
 // Re-export for tests
-export { getComboMultiplier, generateEnemyTelegraph, checkBossPhaseChange }
+export { getComboMultiplier, generateEnemyTelegraph, checkBossPhaseChange, getPlayerCritChance }

--- a/src/app/tap-tap-adventure/lib/soundEngine.ts
+++ b/src/app/tap-tap-adventure/lib/soundEngine.ts
@@ -322,6 +322,31 @@ class SoundEngine {
     }
   }
 
+  /** Critical hit: sharp high note (1000Hz) with metallic ring (detuned 1005Hz), 150ms, gain 0.25 */
+  playCritical() {
+    try {
+      if (!this.enabled) return
+      const ctx = this.getContext()
+      if (!ctx) return
+      const now = ctx.currentTime
+      const freqs = [1000, 1005]
+      freqs.forEach((freq) => {
+        const osc = ctx.createOscillator()
+        const gain = ctx.createGain()
+        osc.type = 'sine'
+        osc.frequency.setValueAtTime(freq, now)
+        gain.gain.setValueAtTime(0.25, now)
+        gain.gain.linearRampToValueAtTime(0, now + 0.15)
+        osc.connect(gain)
+        gain.connect(ctx.destination)
+        osc.start(now)
+        osc.stop(now + 0.15)
+      })
+    } catch {
+      // fail silently
+    }
+  }
+
   /** Descending G5/E5/C5, 100ms each overlapped, gain 0.1 */
   playCrossroads() {
     try {

--- a/src/app/tap-tap-adventure/models/combat.ts
+++ b/src/app/tap-tap-adventure/models/combat.ts
@@ -94,6 +94,7 @@ export const CombatPlayerStateSchema = z.object({
   ap: z.number().default(3),
   maxAp: z.number().default(3),
   turnActions: z.array(z.string()).optional(),
+  luck: z.number().default(0),
 })
 export type CombatPlayerState = z.infer<typeof CombatPlayerStateSchema>
 
@@ -113,6 +114,7 @@ export const CombatLogEntrySchema = z.object({
   action: z.string(),
   damage: z.number().optional(),
   description: z.string(),
+  isCritical: z.boolean().optional(),
 })
 export type CombatLogEntry = z.infer<typeof CombatLogEntrySchema>
 


### PR DESCRIPTION
## Summary
- Player critical hits deal 2x damage, with crit chance scaling from the `luck` stat: `5% base + 1% per luck point` (capped at 40%). Heavy attacks get an extra +5% crit bonus.
- Enemy critical hits have a flat 5% chance and deal 1.5x damage.
- Combat log entries with crits are highlighted in yellow with a star icon and bold text.
- New `playCritical()` sound effect: sharp metallic ring (detuned 1000/1005Hz, 150ms) plays on any critical hit.

## Changes
- **`models/combat.ts`**: Added `isCritical: z.boolean().optional()` to `CombatLogEntrySchema` and `luck: z.number().default(0)` to `CombatPlayerStateSchema`.
- **`lib/combatEngine.ts`**: Added `getPlayerCritChance()` helper; modified `calculatePlayerDamage` to roll for crits and return `isCritical`; modified `calculateEnemyDamage` with flat 5% enemy crit chance at 1.5x; updated all attack log entries to include crit text and `isCritical` flag; initialized `luck` in `initializePlayerCombatState` from character + mount + equipment bonuses.
- **`lib/soundEngine.ts`**: Added `playCritical()` method.
- **`components/CombatUI.tsx`**: Critical log entries render with `text-yellow-300 font-bold` styling and a star icon.
- **`hooks/useCombatActionMutation.ts`**: Plays crit sound when new log entries contain `isCritical`.

## Test plan
- [ ] Verify 0 new TypeScript errors (`npx tsc --noEmit` -- 57 pre-existing errors unchanged)
- [ ] `combatBalance.test.ts` has same 3 pre-existing failures, no regressions
- [ ] Manual: enter combat, attack repeatedly, observe occasional yellow "CRITICAL HIT!" log entries
- [ ] Manual: verify heavy attacks crit slightly more often than normal attacks
- [ ] Manual: verify enemy crits appear as yellow "CRITICAL!" entries at ~5% rate

🤖 Generated with [Claude Code](https://claude.com/claude-code)