### PR TITLE
Add multiple spell acquisition paths

### DIFF
--- a/src/app/tap-tap-adventure/components/InventoryPanel.tsx
+++ b/src/app/tap-tap-adventure/components/InventoryPanel.tsx
@@ -4,6 +4,7 @@ import { useCallback, useState } from 'react'
 import { Button } from '@/app/tap-tap-adventure/components/ui/button'
 import { List } from '@/app/tap-tap-adventure/components/ui/list'
 import { useGameStore } from '@/app/tap-tap-adventure/hooks/useGameStore'
+import { soundEngine } from '@/app/tap-tap-adventure/lib/soundEngine'
 import { getEquipmentSlot } from '@/app/tap-tap-adventure/models/equipment'
 import { Item } from '@/app/tap-tap-adventure/models/types'
 
@@ -33,6 +34,9 @@ export function InventoryPanel({ inventory }: InventoryPanelProps) {
   const handleLearnSpell = useCallback((item: Item) => {
     const result = useGameStore.getState().learnSpell(item.id)
     if (result) {
+      if (result.learned) {
+        soundEngine.playSpellLearn()
+      }
       setFeedbackMessage(result.message)
       setTimeout(() => setFeedbackMessage(null), 3000)
     }

--- a/src/app/tap-tap-adventure/lib/combatEngine.ts
+++ b/src/app/tap-tap-adventure/lib/combatEngine.ts
@@ -22,6 +22,7 @@ import { getDifficultyModifiers } from '@/app/tap-tap-adventure/config/difficult
 
 import { applyCombatItemEffect, isUsableInCombat } from './combatItemEffects'
 import { calculateMaxMana } from './leveling'
+import { generateSpellForLevel } from './spellGenerator'
 import {
   applyShieldAbsorption,
   castSpell,
@@ -990,6 +991,23 @@ export function getCombatRewards(
       if (Math.random() < dropChance) {
         loot.push(item)
       }
+    }
+  }
+
+  // Regular (non-boss) enemies have a chance to drop a spell scroll
+  if (!combatState.isBoss) {
+    const spellDropChance = 0.05 + character.level * 0.01
+    if (Math.random() < spellDropChance) {
+      const spell = generateSpellForLevel(character.level)
+      const suffix = `${Date.now()}-${Math.floor(Math.random() * 10000)}`
+      loot.push({
+        id: `spell-drop-${suffix}`,
+        name: `Scroll of ${spell.name}`,
+        description: `A spell scroll found on the battlefield containing the spell ${spell.name}.`,
+        quantity: 1,
+        type: 'spell_scroll',
+        spell,
+      })
     }
   }
 

--- a/src/app/tap-tap-adventure/lib/itemEffects.ts
+++ b/src/app/tap-tap-adventure/lib/itemEffects.ts
@@ -8,6 +8,14 @@ export interface UseItemResult {
 }
 
 export function useItem(character: FantasyCharacter, item: Item): UseItemResult {
+  if (item.type === 'spell_scroll') {
+    return {
+      character,
+      consumed: false,
+      message: `${item.name} contains a spell. Use "Learn Spell" to add it to your spellbook.`,
+    }
+  }
+
   if (item.type !== 'consumable' || !item.effects) {
     return {
       character,

--- a/src/app/tap-tap-adventure/lib/llmEventGenerator.ts
+++ b/src/app/tap-tap-adventure/lib/llmEventGenerator.ts
@@ -8,6 +8,7 @@ import { SpellSchema } from '@/app/tap-tap-adventure/models/spell'
 
 import { getReputationTier } from './contextBuilder'
 import { inferItemTypeAndEffects } from './itemPostProcessor'
+import { generateSpellForLevel } from './spellGenerator'
 
 const processFallbackRewardItems = (
   items?: { id: string; name?: string; description?: string; quantity: number; type?: string; effects?: Record<string, number> }[]
@@ -414,6 +415,20 @@ function getRegionFallbackEvents(regionId: string): LLMGeneratedEvent[] {
     ],
     scorched_wastes: [
       {
+        id: `rfb-fire-convergence-${s}`,
+        description: 'Flames erupt from cracks in the scorched earth, spiraling upward into a vortex of pure fire magic. The heat is intense but the energy feels... learnable.',
+        options: [
+          { id: `channel-fire-${s}`, text: 'Channel the fire energy', successProbability: 0.5,
+            successDescription: 'The fire energy condenses into a spell scroll in your hands! The vortex dissipates.',
+            successEffects: { rewardItems: [createSpellScrollRewardItem(5, `fire-convergence-${s}`)] },
+            failureDescription: 'The fire is too intense to control. It scorches the ground and fades.',
+            failureEffects: {} },
+          { id: `retreat-fire-${s}`, text: 'Keep your distance', successProbability: 1.0,
+            successDescription: 'You watch the spectacular display from safety as it eventually burns out.',
+            successEffects: {}, failureDescription: '', failureEffects: {} },
+        ],
+      },
+      {
         id: `rfb-sandshift-${s}`,
         description: 'The sand shifts beneath your feet, revealing ancient ruins half-buried in the dunes.',
         options: [
@@ -456,6 +471,22 @@ function getRegionFallbackEvents(regionId: string): LLMGeneratedEvent[] {
       },
     ],
     frozen_peaks: [
+      {
+        id: `rfb-ice-convergence-${s}`,
+        description: 'Frost crystals spiral in mid-air, drawn together by an unseen force. The convergence of ice magic forms glowing runes that hang in the freezing air.',
+        options: [
+          { id: `grasp-ice-${s}`, text: 'Grasp the ice runes', successProbability: 0.5,
+            successDescription: 'The runes solidify into a frost-covered spell scroll! The convergence shatters into snowflakes.',
+            successEffects: { rewardItems: [createSpellScrollRewardItem(5, `ice-convergence-${s}`)] },
+            failureDescription: 'The runes shatter before you can reach them, leaving only frost on your fingertips.',
+            failureEffects: {} },
+          { id: `wait-ice-${s}`, text: 'Observe the phenomenon', successProbability: 0.8,
+            successDescription: 'You watch in awe as the magic plays out, learning something about the nature of ice magic.',
+            successEffects: { reputation: 2 },
+            failureDescription: 'The convergence fades quickly, leaving nothing behind.',
+            failureEffects: {} },
+        ],
+      },
       {
         id: `rfb-blizzard-${s}`,
         description: 'A blizzard closes in rapidly. Visibility drops to near zero.',
@@ -504,6 +535,22 @@ function getRegionFallbackEvents(regionId: string): LLMGeneratedEvent[] {
       },
     ],
     crystal_caves: [
+      {
+        id: `rfb-crystal-library-${s}`,
+        description: 'Deep within the caves, crystalline shelves hold preserved spell tomes, their pages protected by arcane resonance.',
+        options: [
+          { id: `read-crystal-tome-${s}`, text: 'Study a glowing tome', successProbability: 0.6,
+            successDescription: 'The crystal-preserved text reveals a powerful spell! You carefully transcribe it.',
+            successEffects: { rewardItems: [createSpellScrollRewardItem(5, `crystal-tome-${s}`)] },
+            failureDescription: 'The arcane resonance makes the text swim before your eyes. You cannot focus.',
+            failureEffects: {} },
+          { id: `harvest-crystals-${s}`, text: 'Harvest the crystal shelves', successProbability: 0.7,
+            successDescription: 'You break off valuable crystal fragments.',
+            successEffects: { gold: 10 },
+            failureDescription: 'The crystals shatter into worthless dust.',
+            failureEffects: {} },
+        ],
+      },
       {
         id: `rfb-crystalhum-${s}`,
         description: 'Crystals hum with magical energy, their light pulsing in rhythmic patterns.',
@@ -599,6 +646,22 @@ function getRegionFallbackEvents(regionId: string): LLMGeneratedEvent[] {
     ],
     sky_citadel: [
       {
+        id: `rfb-arcane-archive-${s}`,
+        description: 'You discover an intact arcane archive, its floating bookshelves still maintained by ancient enchantments. Spell formulae shimmer on ethereal pages.',
+        options: [
+          { id: `study-archive-${s}`, text: 'Study the spell formulae', successProbability: 0.6,
+            successDescription: 'You master one of the archived spells and record it on a scroll!',
+            successEffects: { rewardItems: [createSpellScrollRewardItem(5, `archive-spell-${s}`)] },
+            failureDescription: 'The formulae are too advanced for your current understanding.',
+            failureEffects: {} },
+          { id: `loot-archive-${s}`, text: 'Take the enchanted books to sell', successProbability: 0.7,
+            successDescription: 'The enchanted tomes fetch a fine price.',
+            successEffects: { gold: 15 },
+            failureDescription: 'The books lose their enchantment once removed from the shelves.',
+            failureEffects: {} },
+        ],
+      },
+      {
         id: `rfb-lightning-${s}`,
         description: 'Lightning crackles between floating platforms. The path ahead is electrified.',
         options: [
@@ -646,6 +709,18 @@ function getRegionFallbackEvents(regionId: string): LLMGeneratedEvent[] {
   }
 
   return regionEvents[regionId] ?? []
+}
+
+function createSpellScrollRewardItem(level: number, suffix: string): Item {
+  const spell = generateSpellForLevel(level)
+  return inferItemTypeAndEffects({
+    id: `spell-scroll-${suffix}`,
+    name: `Scroll of ${spell.name}`,
+    description: `A magical scroll containing the spell ${spell.name}.`,
+    quantity: 1,
+    type: 'spell_scroll',
+    spell,
+  })
 }
 
 function getDefaultEvents(regionId?: string): LLMGeneratedEvent[] {
@@ -838,6 +913,59 @@ function getDefaultEvents(regionId?: string): LLMGeneratedEvent[] {
           successDescription: 'The stone hums faintly. You feel a brief surge of energy.',
           successEffects: { reputation: 2 },
           failureDescription: 'Nothing happens. It\'s just a stone.',
+          failureEffects: {} },
+      ],
+    },
+    // Spell discovery events
+    {
+      id: `fb-dying-mage-${s}`,
+      description: 'A wounded mage lies by the roadside, clutching a glowing tome. "Please... help me bandage this wound, and I will teach you a spell in return."',
+      options: [
+        { id: `help-mage-${s}`, text: 'Help the mage', successProbability: 0.8,
+          successDescription: 'You tend to the mage\'s wounds. Grateful, they inscribe a spell onto a scroll and hand it to you.',
+          successEffects: { reputation: 3, rewardItems: [createSpellScrollRewardItem(5, `mage-spell-${s}`)] },
+          failureDescription: 'Despite your efforts, the mage\'s wounds are beyond your skill. They thank you for trying.',
+          failureEffects: { reputation: 2 } },
+        { id: `rob-mage-${s}`, text: 'Take the tome and leave', successProbability: 0.5,
+          successDescription: 'You snatch the tome. Inside you find a spell inscribed on loose parchment.',
+          successEffects: { reputation: -6, rewardItems: [createSpellScrollRewardItem(5, `stolen-spell-${s}`)] },
+          failureDescription: 'The mage clings to the tome with surprising strength. You give up and walk away.',
+          failureEffects: { reputation: -3 } },
+        { id: `ignore-mage-${s}`, text: 'Walk past', successProbability: 1.0,
+          successDescription: 'You continue on your way without stopping.',
+          successEffects: { reputation: -1 },
+          failureDescription: '', failureEffects: {} },
+      ],
+    },
+    {
+      id: `fb-ancient-library-${s}`,
+      description: 'Hidden behind a waterfall, you discover the entrance to an ancient library. Dusty tomes line the shelves, and magical light still flickers from enchanted sconces.',
+      options: [
+        { id: `search-tomes-${s}`, text: 'Search the tomes for spells', successProbability: 0.6,
+          successDescription: 'After careful study, you find a tome containing a spell you can learn! You transcribe it onto a scroll.',
+          successEffects: { rewardItems: [createSpellScrollRewardItem(5, `library-spell-${s}`)] },
+          failureDescription: 'The tomes are written in a language you cannot decipher. Perhaps with more experience...',
+          failureEffects: {} },
+        { id: `take-books-${s}`, text: 'Gather books to sell', successProbability: 0.7,
+          successDescription: 'You collect several valuable volumes that a scholar would pay well for.',
+          successEffects: { gold: 12 },
+          failureDescription: 'The books crumble to dust when you try to move them.',
+          failureEffects: {} },
+      ],
+    },
+    {
+      id: `fb-elemental-convergence-${s}`,
+      description: 'The air crackles with raw magical energy. Elemental forces swirl together at a nexus point, forming brief shapes and symbols in the air.',
+      options: [
+        { id: `absorb-magic-${s}`, text: 'Reach into the convergence', successProbability: 0.5,
+          successDescription: 'The magical energy coalesces into a spell scroll in your hand! The convergence fades.',
+          successEffects: { rewardItems: [createSpellScrollRewardItem(5, `convergence-spell-${s}`)] },
+          failureDescription: 'The energy is too wild to contain. It disperses harmlessly.',
+          failureEffects: {} },
+        { id: `observe-magic-${s}`, text: 'Observe from a safe distance', successProbability: 0.9,
+          successDescription: 'Watching the convergence teaches you something about the nature of magic.',
+          successEffects: { reputation: 2 },
+          failureDescription: 'The convergence fades before you can learn anything useful.',
           failureEffects: {} },
       ],
     },

--- a/src/app/tap-tap-adventure/lib/shopGenerator.ts
+++ b/src/app/tap-tap-adventure/lib/shopGenerator.ts
@@ -148,17 +148,32 @@ export function getFallbackShopItems(level: number): Item[] {
     },
   ]
 
-  // Add a spell scroll to the shop
-  const spell = generateSpellForLevel(level)
+  // Add 1-2 spell scrolls to the shop
+  const spellPrice = 20 + level * 10
+  const spell1 = generateSpellForLevel(level)
   items.push({
     id: `shop-spell-${suffix}`,
-    name: `Scroll of ${spell.name}`,
-    description: `A magical scroll containing the spell ${spell.name}.`,
+    name: `Scroll of ${spell1.name}`,
+    description: `A magical scroll containing the spell ${spell1.name}.`,
     quantity: 1,
     type: 'spell_scroll',
-    price: Math.round(basePrice * 2),
-    spell,
+    price: spellPrice,
+    spell: spell1,
   })
+
+  // 50% chance for a second spell scroll
+  if (Math.random() < 0.5) {
+    const spell2 = generateSpellForLevel(level)
+    items.push({
+      id: `shop-spell2-${suffix}`,
+      name: `Scroll of ${spell2.name}`,
+      description: `A magical scroll containing the spell ${spell2.name}.`,
+      quantity: 1,
+      type: 'spell_scroll',
+      price: spellPrice,
+      spell: spell2,
+    })
+  }
 
   return items.map(inferItemTypeAndEffects)
 }

--- a/src/app/tap-tap-adventure/lib/soundEngine.ts
+++ b/src/app/tap-tap-adventure/lib/soundEngine.ts
@@ -348,6 +348,33 @@ class SoundEngine {
       // fail silently
     }
   }
+
+  /** Mystical ascending shimmer — two detuned sines sweeping 300->600Hz over 300ms, gain 0.15 */
+  playSpellLearn() {
+    try {
+      if (!this.enabled) return
+      const ctx = this.getContext()
+      if (!ctx) return
+      const now = ctx.currentTime
+      const freqs = [300, 305] // Detuned pair for shimmer effect
+      freqs.forEach((startFreq) => {
+        const osc = ctx.createOscillator()
+        const gain = ctx.createGain()
+        osc.type = 'sine'
+        osc.frequency.setValueAtTime(startFreq, now)
+        osc.frequency.linearRampToValueAtTime(startFreq * 2, now + 0.3)
+        gain.gain.setValueAtTime(0.15, now)
+        gain.gain.linearRampToValueAtTime(0.08, now + 0.3)
+        gain.gain.linearRampToValueAtTime(0, now + 0.5) // Reverb-like tail
+        osc.connect(gain)
+        gain.connect(ctx.destination)
+        osc.start(now)
+        osc.stop(now + 0.5)
+      })
+    } catch {
+      // fail silently
+    }
+  }
 }
 
 export const soundEngine = new SoundEngine()


### PR DESCRIPTION
## Summary
- **Combat spell drops**: Regular (non-boss) enemies now have a chance to drop spell scrolls (5% + level*1%, so 6% at level 1, 15% at level 10) using `generateSpellForLevel`
- **Spell discovery events**: Added 3 new fallback events (Dying Mage choice event, Ancient Library exploration, Elemental Convergence) plus 4 region-specific spell events for crystal_caves, sky_citadel, scorched_wastes, and frozen_peaks
- **Spell merchant**: Shop fallback now stocks 1-2 spell scrolls priced at 20 + level*10 gold each
- **Spell learn UX**: Added `playSpellLearn()` sound effect (ascending detuned shimmer) triggered on successful spell learning; spell scrolls in `useItem` now show guidance message
- **No new type errors** introduced (all 57 TS errors are pre-existing in test fixtures)

## Test plan
- [ ] Verify regular combat enemies occasionally drop spell scrolls
- [ ] Verify fallback events include spell discovery events (Ancient Library, Dying Mage, Elemental Convergence)
- [ ] Verify region-specific spell events appear in crystal_caves, sky_citadel, scorched_wastes, frozen_peaks
- [ ] Verify shop fallback includes 1-2 spell scrolls at correct price
- [ ] Verify spell learn sound plays when learning a spell from a scroll
- [ ] Verify using a spell scroll via "Use" shows guidance to use "Learn Spell" instead
- [ ] Run `npx tsc --noEmit` and confirm no new errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)