### PR TITLE
Expand reputation to hero-to-criminal spectrum

### DIFF
--- a/src/app/tap-tap-adventure/__tests__/contextBuilder.test.ts
+++ b/src/app/tap-tap-adventure/__tests__/contextBuilder.test.ts
@@ -110,6 +110,20 @@ describe('buildStoryContext', () => {
     expect(context).toContain('Bounty hunters')
   })
 
+  it('includes reputation tier for very negative reputation', () => {
+    const criminalChar = { ...baseChar, reputation: -60 }
+    const context = buildStoryContext(criminalChar, [])
+    expect(context).toContain('Wanted Criminal')
+    expect(context).toContain('flee or attack on sight')
+  })
+
+  it('includes reputation tier for very high reputation', () => {
+    const legendChar = { ...baseChar, reputation: 160 }
+    const context = buildStoryContext(legendChar, [])
+    expect(context).toContain('Living Legend')
+    expect(context).toContain('mythic figure')
+  })
+
   it('caps context string length', () => {
     const longEvents = Array.from({ length: 50 }, (_, i) =>
       makeEvent({

--- a/src/app/tap-tap-adventure/__tests__/reputationTier.test.ts
+++ b/src/app/tap-tap-adventure/__tests__/reputationTier.test.ts
@@ -5,9 +5,14 @@ import { calculateEffectiveProbability } from '@/app/tap-tap-adventure/lib/event
 import { FantasyCharacter } from '@/app/tap-tap-adventure/models/character'
 
 describe('getReputationTier', () => {
-  it('returns Infamous for reputation below -20', () => {
+  it('returns Wanted Criminal for reputation below -50', () => {
+    expect(getReputationTier(-51)).toBe('Wanted Criminal')
+    expect(getReputationTier(-100)).toBe('Wanted Criminal')
+  })
+
+  it('returns Infamous for reputation -50 to -21', () => {
+    expect(getReputationTier(-50)).toBe('Infamous')
     expect(getReputationTier(-21)).toBe('Infamous')
-    expect(getReputationTier(-100)).toBe('Infamous')
   })
 
   it('returns Disreputable for reputation -20 to -1', () => {
@@ -30,12 +35,19 @@ describe('getReputationTier', () => {
     expect(getReputationTier(99)).toBe('Renowned')
   })
 
-  it('returns Legendary for reputation 100+', () => {
+  it('returns Legendary for reputation 100 to 149', () => {
     expect(getReputationTier(100)).toBe('Legendary')
-    expect(getReputationTier(500)).toBe('Legendary')
+    expect(getReputationTier(149)).toBe('Legendary')
+  })
+
+  it('returns Living Legend for reputation 150+', () => {
+    expect(getReputationTier(150)).toBe('Living Legend')
+    expect(getReputationTier(500)).toBe('Living Legend')
   })
 
   it('handles boundary values correctly', () => {
+    expect(getReputationTier(-51)).toBe('Wanted Criminal')
+    expect(getReputationTier(-50)).toBe('Infamous')
     expect(getReputationTier(-21)).toBe('Infamous')
     expect(getReputationTier(-20)).toBe('Disreputable')
     expect(getReputationTier(-1)).toBe('Disreputable')
@@ -46,6 +58,8 @@ describe('getReputationTier', () => {
     expect(getReputationTier(50)).toBe('Renowned')
     expect(getReputationTier(99)).toBe('Renowned')
     expect(getReputationTier(100)).toBe('Legendary')
+    expect(getReputationTier(149)).toBe('Legendary')
+    expect(getReputationTier(150)).toBe('Living Legend')
   })
 })
 

--- a/src/app/tap-tap-adventure/components/HudBar.tsx
+++ b/src/app/tap-tap-adventure/components/HudBar.tsx
@@ -6,7 +6,7 @@ import { getRegion } from '@/app/tap-tap-adventure/config/regions'
 import { Mount } from '@/app/tap-tap-adventure/models/mount'
 import { useGameStore } from '@/app/tap-tap-adventure/hooks/useGameStore'
 import { soundEngine } from '@/app/tap-tap-adventure/lib/soundEngine'
-import { getReputationTier } from '@/app/tap-tap-adventure/lib/contextBuilder'
+import { getReputationTier, ReputationTier } from '@/app/tap-tap-adventure/lib/contextBuilder'
 import { levelProgress, stepsToNextLevel, stepsRequiredForLevel, calculateDay } from '@/app/tap-tap-adventure/lib/leveling'
 import { FantasyCharacter } from '@/app/tap-tap-adventure/models/character'
 
@@ -165,6 +165,19 @@ export function HudBar() {
     setTimeout(() => setActiveTooltip(null), 2000)
   }, [])
 
+  const reputationTier = getReputationTier(character?.reputation ?? 0)
+  const reputationTierColorMap: Record<ReputationTier, string> = {
+    'Wanted Criminal': 'text-red-400',
+    Infamous: 'text-red-400',
+    Disreputable: 'text-orange-400',
+    Unknown: 'text-slate-400',
+    Respected: 'text-blue-400',
+    Renowned: 'text-purple-400',
+    Legendary: 'text-amber-400',
+    'Living Legend': 'text-yellow-300',
+  }
+  const reputationTierColor = reputationTierColorMap[reputationTier]
+
   const renderStat = (key: IconType) => (
     <div key={key} className="relative">
       <button
@@ -176,6 +189,9 @@ export function HudBar() {
         <div className="flex items-center gap-1">
           <span className="inline-block align-middle shrink-0">{ICONS[key]}</span>
           <span>{stats[key]}</span>
+        {key === 'waterDropIcon' && (
+          <span className={`text-[8px] sm:text-[9px] ${reputationTierColor} ml-0.5`}>{reputationTier}</span>
+        )}
         {key === 'heartIcon' && (
           <span className="w-8 sm:w-12 h-1.5 bg-slate-700 rounded-full overflow-hidden ml-1">
             <span

--- a/src/app/tap-tap-adventure/hooks/useCombatActionMutation.ts
+++ b/src/app/tap-tap-adventure/hooks/useCombatActionMutation.ts
@@ -217,14 +217,15 @@ export function useCombatActionMutation() {
             })
           }
         } else if (data.combatState.status === 'fled') {
+          updateSelectedCharacter({ reputation: character.reputation - 2 })
           addStoryEvent({
             id: `combat-fled-${Date.now()}`,
             type: 'combat_fled',
             characterId: character.id,
             locationId: character.locationId,
             timestamp: new Date().toISOString(),
-            outcomeDescription: `You fled from ${enemy.name}, losing some gold in your haste.`,
-            resourceDelta: { gold: data.rewards?.gold },
+            outcomeDescription: `You fled from ${enemy.name}, losing some gold and a bit of your reputation in your haste.`,
+            resourceDelta: { gold: data.rewards?.gold, reputation: -2 },
           })
         }
 

--- a/src/app/tap-tap-adventure/hooks/useGameStore.ts
+++ b/src/app/tap-tap-adventure/hooks/useGameStore.ts
@@ -4,6 +4,7 @@ import { create } from 'zustand'
 import { persist } from 'zustand/middleware'
 
 import { checkAchievements } from '@/app/tap-tap-adventure/lib/achievementTracker'
+import { clampReputation } from '@/app/tap-tap-adventure/lib/contextBuilder'
 import { generateHeirloom } from '@/app/tap-tap-adventure/lib/heirloomGenerator'
 import { getMetaBonuses, MetaBonuses } from '@/app/tap-tap-adventure/lib/metaProgressionBonuses'
 import { calculateSoulEssence } from '@/app/tap-tap-adventure/lib/soulEssenceCalculator'
@@ -830,6 +831,11 @@ export function useGameStateBuilder() {
 
     const charIndex = gameStateClone.characters.findIndex(c => c.id === selectedCharacterId)
     if (charIndex === -1) return
+
+    // Clamp reputation if it's being updated
+    if (characterUpdate.reputation !== undefined) {
+      characterUpdate = { ...characterUpdate, reputation: clampReputation(characterUpdate.reputation) }
+    }
 
     // Create a new character object and recalculate level from distance
     const merged = {

--- a/src/app/tap-tap-adventure/lib/combatGenerator.ts
+++ b/src/app/tap-tap-adventure/lib/combatGenerator.ts
@@ -184,6 +184,9 @@ export async function generateBossEncounter(
 
 Region context: This boss guards the ${getRegion(character.currentRegion ?? 'green_meadows').name}. Theme: ${getRegion(character.currentRegion ?? 'green_meadows').theme}. The dominant element is ${getRegion(character.currentRegion ?? 'green_meadows').element}. Generate a boss that fits this setting. Common enemy types in this region: ${getRegion(character.currentRegion ?? 'green_meadows').enemyTypes.join(', ') || 'none'}.
 
+Reputation context: This character's reputation is ${character.reputation} (${getReputationTier(character.reputation)}).
+${character.reputation >= 50 ? 'High reputation: the boss might acknowledge the character\'s fame, offer a challenge of honor, or be a rival drawn by their renown.' : ''}${character.reputation <= -20 ? 'Low reputation: the boss might be a bounty hunter leader, a vengeful warlord who has heard of the character\'s crimes, or a dark entity drawn to their infamy.' : ''}
+
 This is a level ${character.level} character facing a boss fight. The boss should be significantly stronger than normal enemies:
 - Boss HP: ${Math.round((35 + character.level * 15) * 1.5)} (1.5x normal)
 - Boss attack: ${Math.round((6 + character.level * 3) * 1.3)} (1.3x normal)

--- a/src/app/tap-tap-adventure/lib/contextBuilder.ts
+++ b/src/app/tap-tap-adventure/lib/contextBuilder.ts
@@ -4,24 +4,47 @@ import { FantasyStoryEvent } from '@/app/tap-tap-adventure/models/story'
 
 const MAX_CONTEXT_LENGTH = 1500
 
-export type ReputationTier = 'Infamous' | 'Disreputable' | 'Unknown' | 'Respected' | 'Renowned' | 'Legendary'
+export type ReputationTier = 'Wanted Criminal' | 'Infamous' | 'Disreputable' | 'Unknown' | 'Respected' | 'Renowned' | 'Legendary' | 'Living Legend'
 
 const REPUTATION_TIER_IMPLICATIONS: Record<ReputationTier, string> = {
+  'Wanted Criminal': 'NPCs flee or attack on sight. Bounty hunters relentlessly pursue the character. Prices are extortionate. Guards may arrest the character. Almost no one will offer aid.',
   Infamous: 'NPCs are hostile or fearful. Bounty hunters pursue the character. Prices are much higher. Few will offer aid.',
   Disreputable: 'NPCs are suspicious and distrustful. Prices are higher. Fewer friendly encounters.',
   Unknown: 'NPCs are neutral. Standard pricing and interactions.',
   Respected: 'NPCs are friendly and helpful. Better deals available. Some share useful information.',
   Renowned: 'NPCs eagerly offer help, share secrets, and propose important quests. Excellent prices.',
   Legendary: 'NPCs revere the character. The best deals, exclusive quests, and powerful allies seek them out.',
+  'Living Legend': 'The character is a mythic figure. Kings seek their counsel, entire armies rally behind them, and merchants offer their finest wares at steep discounts just for the honor.',
 }
 
 export function getReputationTier(reputation: number): ReputationTier {
+  if (reputation < -50) return 'Wanted Criminal'
   if (reputation < -20) return 'Infamous'
   if (reputation < 0) return 'Disreputable'
   if (reputation < 20) return 'Unknown'
   if (reputation < 50) return 'Respected'
   if (reputation < 100) return 'Renowned'
-  return 'Legendary'
+  if (reputation < 150) return 'Legendary'
+  return 'Living Legend'
+}
+
+export function getReputationPriceMultiplier(reputation: number): number {
+  const tier = getReputationTier(reputation)
+  const multipliers: Record<ReputationTier, number> = {
+    'Wanted Criminal': 1.30,
+    Infamous: 1.30,
+    Disreputable: 1.15,
+    Unknown: 1.00,
+    Respected: 0.95,
+    Renowned: 0.90,
+    Legendary: 0.85,
+    'Living Legend': 0.80,
+  }
+  return multipliers[tier]
+}
+
+export function clampReputation(value: number): number {
+  return Math.max(-100, Math.min(200, value))
 }
 
 export function buildStoryContext(

--- a/src/app/tap-tap-adventure/lib/llmEventGenerator.ts
+++ b/src/app/tap-tap-adventure/lib/llmEventGenerator.ts
@@ -256,16 +256,22 @@ function getCompletionsConfig(character: FantasyCharacter, context: string) {
   const reputationTier = getReputationTier(character.reputation)
 
   let reputationGuidance = ''
-  if (character.reputation >= 50) {
-    reputationGuidance = `This character has a ${reputationTier} reputation (${character.reputation}). NPCs should be friendly and welcoming. Offer better deals, share secrets, and present important quests. Some NPCs may recognize the character by name and ask for help with critical tasks.`
+  if (character.reputation >= 150) {
+    reputationGuidance = `This character is a ${reputationTier} (${character.reputation}). They are a mythic figure — kings seek their counsel, armies rally behind them, and merchants offer their finest wares at steep discounts. NPCs should be awestruck, reverent, or even intimidated by the character's sheer fame. Present world-shaping quests and legendary encounters.`
+  } else if (character.reputation >= 100) {
+    reputationGuidance = `This character has a ${reputationTier} reputation (${character.reputation}). NPCs revere the character. The best deals, exclusive quests, and powerful allies seek them out. Some NPCs may recognize the character by name and ask for help with critical tasks.`
+  } else if (character.reputation >= 50) {
+    reputationGuidance = `This character has a ${reputationTier} reputation (${character.reputation}). NPCs should be friendly and welcoming. Offer better deals, share secrets, and present important quests.`
   } else if (character.reputation >= 20) {
     reputationGuidance = `This character has a ${reputationTier} reputation (${character.reputation}). NPCs should be generally positive and willing to help. Fair deals and occasional bonus opportunities.`
   } else if (character.reputation >= 0) {
     reputationGuidance = `This character has an ${reputationTier} reputation (${character.reputation}). NPCs are neutral — standard interactions and pricing.`
   } else if (character.reputation >= -20) {
     reputationGuidance = `This character has a ${reputationTier} reputation (${character.reputation}). NPCs should be suspicious and wary. Prices are higher, information is harder to obtain, and some may refuse to deal with the character.`
-  } else {
+  } else if (character.reputation >= -50) {
     reputationGuidance = `This character has an ${reputationTier} reputation (${character.reputation}). NPCs are hostile or fearful. Bounty hunters or rival adventurers may appear. Prices are much higher. Very few friendly encounters — most NPCs want nothing to do with this character.`
+  } else {
+    reputationGuidance = `This character is a ${reputationTier} (${character.reputation}). They are actively hunted. NPCs flee or attack on sight. Guards may attempt arrest. Bounty hunters relentlessly pursue them. Prices are extortionate if anyone will even deal with them. The world has turned against this character — present desperate, dangerous situations with few allies.`
   }
 
   const region = getRegion(character.currentRegion ?? 'green_meadows')
@@ -1153,6 +1159,91 @@ function getDefaultEvents(regionId?: string): LLMGeneratedEvent[] {
           successDescription: 'You keep your head down and move on.',
           successEffects: {},
           failureDescription: '', failureEffects: {} },
+      ],
+    },
+    // Moral choice events — reputation spectrum
+    {
+      id: `fb-lost-cargo-${s}`,
+      description: 'You find a merchant\'s lost cargo scattered along the road. Crates of fine goods lie unguarded, their owner nowhere in sight.',
+      options: [
+        { id: `return-cargo-${s}`, text: 'Track down the merchant and return the cargo', successProbability: 0.8,
+          successDescription: 'You find the grateful merchant a mile down the road. "Bless you, traveler! My livelihood was in those crates." Word of your honesty spreads.',
+          successEffects: { reputation: 5 },
+          failureDescription: 'You search but cannot find the owner. You leave the goods untouched.',
+          failureEffects: { reputation: 2 } },
+        { id: `keep-cargo-${s}`, text: 'Help yourself to the goods', successProbability: 0.9,
+          successDescription: 'You pocket valuable items from the crates. Finders keepers.',
+          successEffects: { gold: 15, reputation: -5 },
+          failureDescription: 'Most of the goods are spoiled or broken. You salvage a little.',
+          failureEffects: { gold: 5, reputation: -3 } },
+      ],
+    },
+    {
+      id: `fb-beggars-plea-${s}`,
+      description: 'A ragged beggar sits by the roadside, hollow-eyed and trembling. "Please, traveler... just a few coins for bread."',
+      options: [
+        { id: `give-beggar-${s}`, text: 'Give them some gold', successProbability: 1.0,
+          successDescription: 'The beggar\'s eyes fill with tears. "You have a kind heart." Nearby villagers notice your generosity.',
+          successEffects: { gold: -5, reputation: 3 },
+          failureDescription: '', failureEffects: {} },
+        { id: `ignore-beggar-${s}`, text: 'Walk past without a word', successProbability: 1.0,
+          successDescription: 'You continue on your way. The beggar says nothing.',
+          successEffects: {},
+          failureDescription: '', failureEffects: {} },
+        { id: `rob-beggar-${s}`, text: 'Rob what little they have', successProbability: 0.7,
+          successDescription: 'You snatch a few coins from the beggar\'s cup. They cower in fear. Witnesses look on in disgust.',
+          successEffects: { gold: 2, reputation: -3 },
+          failureDescription: 'The beggar has nothing worth taking. You feel the weight of many disapproving stares.',
+          failureEffects: { reputation: -2 } },
+      ],
+    },
+    {
+      id: `fb-wanted-poster-${s}`,
+      description: 'A wanted poster flutters on a signpost. As you read it, a nervous figure steps from the bushes. "That\'s me on the poster. I swear I\'m innocent. Will you help me, or turn me in?"',
+      options: [
+        { id: `turn-in-fugitive-${s}`, text: 'Turn the fugitive in to the authorities', successProbability: 0.8,
+          successDescription: 'The guards thank you and hand over the bounty. Justice is served — or so they say.',
+          successEffects: { reputation: 5, gold: 10 },
+          failureDescription: 'The fugitive escapes before the guards arrive. They note your attempt, at least.',
+          failureEffects: { reputation: 2 } },
+        { id: `help-fugitive-${s}`, text: 'Help the fugitive escape', successProbability: 0.7,
+          successDescription: '"Thank you, friend. Take this — it\'s all I have." The fugitive presses gold into your hands before disappearing.',
+          successEffects: { reputation: -5, gold: 20 },
+          failureDescription: 'A patrol spots you helping and gives you a stern warning. The fugitive slips away in the confusion.',
+          failureEffects: { reputation: -3 } },
+      ],
+    },
+    {
+      id: `fb-corrupt-guard-${s}`,
+      description: 'A town guard pulls you aside. "Look, I know you saw what happened back there. Keep quiet about it, and this gold is yours. Report me, and... well, don\'t."',
+      options: [
+        { id: `report-guard-${s}`, text: 'Report the corrupt guard', successProbability: 0.7,
+          successDescription: 'The captain listens carefully and arrests the corrupt guard. "The town owes you a debt." Your integrity earns respect.',
+          successEffects: { reputation: 5 },
+          failureDescription: 'Your report is noted but the guard has connections. Nothing happens immediately, but people remember your courage.',
+          failureEffects: { reputation: 2 } },
+        { id: `accept-bribe-${s}`, text: 'Accept the bribe and stay silent', successProbability: 0.9,
+          successDescription: 'The guard nods and hands you a pouch of gold. "Smart choice." You feel the weight of compromise.',
+          successEffects: { gold: 10, reputation: -3 },
+          failureDescription: 'The guard shortchanges you. "Be glad I gave you anything."',
+          failureEffects: { gold: 5, reputation: -2 } },
+      ],
+    },
+    {
+      id: `fb-village-attack-${s}`,
+      description: 'Smoke rises from a village ahead. Raiders are pillaging homes while villagers flee in panic. You could help — or profit from the chaos.',
+      options: [
+        { id: `defend-village-${s}`, text: 'Rush to defend the village', triggersCombat: true,
+          successProbability: 0.5,
+          successDescription: 'You charge into the fray to protect the innocent! The raiders turn to face you.',
+          successEffects: { reputation: 8 },
+          failureDescription: 'You charge into the fray to protect the innocent! The raiders turn to face you.',
+          failureEffects: { reputation: 8 } },
+        { id: `loot-chaos-${s}`, text: 'Loot abandoned homes in the chaos', successProbability: 0.8,
+          successDescription: 'While everyone is distracted, you fill your pockets. Survivors will remember your cowardice.',
+          successEffects: { gold: 25, reputation: -10 },
+          failureDescription: 'A fleeing villager catches you looting and screams "Thief!" You grab what you can and run.',
+          failureEffects: { gold: 10, reputation: -8 } },
       ],
     },
   ]

--- a/src/app/tap-tap-adventure/lib/shopGenerator.ts
+++ b/src/app/tap-tap-adventure/lib/shopGenerator.ts
@@ -4,6 +4,7 @@ import { z } from 'zod'
 import { FantasyCharacter } from '@/app/tap-tap-adventure/models/character'
 import { Item, ItemSchema } from '@/app/tap-tap-adventure/models/item'
 
+import { getReputationPriceMultiplier } from './contextBuilder'
 import { inferItemTypeAndEffects } from './itemPostProcessor'
 import { generateSpellForLevel } from './spellGenerator'
 
@@ -95,18 +96,23 @@ ${JSON.stringify({ name: character.name, race: character.race, class: character.
     if (toolCall && toolCall.function?.name === 'generate_shop') {
       const parsed = JSON.parse(toolCall.function.arguments)
       const validated = shopResponseSchema.parse(parsed)
-      return validated.items.map(inferItemTypeAndEffects)
+      const reputationMultiplier = getReputationPriceMultiplier(character.reputation)
+      return validated.items.map(item => inferItemTypeAndEffects({
+        ...item,
+        price: item.price !== undefined ? Math.round(item.price * reputationMultiplier) : undefined,
+      }))
     }
 
     throw new Error('No tool call in response')
   } catch (err) {
     console.error('Shop generation failed, using fallback', err)
-    return getFallbackShopItems(character.level)
+    return getFallbackShopItems(character.level, character.reputation)
   }
 }
 
-export function getFallbackShopItems(level: number): Item[] {
+export function getFallbackShopItems(level: number, reputation: number = 0): Item[] {
   const basePrice = 10 + level * 5
+  const reputationMultiplier = getReputationPriceMultiplier(reputation)
   const suffix = `${Date.now()}-${Math.floor(Math.random() * 10000)}`
 
   const items: Item[] = [
@@ -116,7 +122,7 @@ export function getFallbackShopItems(level: number): Item[] {
       description: 'A warm, glowing vial that restores vitality.',
       quantity: 1,
       type: 'consumable',
-      price: Math.round(basePrice * 0.8),
+      price: Math.round(basePrice * 0.8 * reputationMultiplier),
       effects: { heal: 10 + level * 5 },
     },
     {
@@ -125,7 +131,7 @@ export function getFallbackShopItems(level: number): Item[] {
       description: 'A thick, crimson brew that bolsters raw power.',
       quantity: 1,
       type: 'consumable',
-      price: Math.round(basePrice * 1.5),
+      price: Math.round(basePrice * 1.5 * reputationMultiplier),
       effects: { strength: 2 + Math.floor(level / 2) },
     },
     {
@@ -134,7 +140,7 @@ export function getFallbackShopItems(level: number): Item[] {
       description: 'Ancient parchment inscribed with arcane knowledge.',
       quantity: 1,
       type: 'consumable',
-      price: Math.round(basePrice * 1.5),
+      price: Math.round(basePrice * 1.5 * reputationMultiplier),
       effects: { intelligence: 2 + Math.floor(level / 2) },
     },
     {
@@ -143,7 +149,7 @@ export function getFallbackShopItems(level: number): Item[] {
       description: 'A small trinket that seems to shimmer with fortune.',
       quantity: 1,
       type: 'consumable',
-      price: basePrice,
+      price: Math.round(basePrice * reputationMultiplier),
       effects: { luck: 2 + Math.floor(level / 3) },
     },
   ]
@@ -156,7 +162,7 @@ export function getFallbackShopItems(level: number): Item[] {
     description: `A magical scroll containing the spell ${spell.name}.`,
     quantity: 1,
     type: 'spell_scroll',
-    price: Math.round(basePrice * 2),
+    price: Math.round(basePrice * 2 * reputationMultiplier),
     spell,
   })
 


### PR DESCRIPTION
## Summary
- **8 reputation tiers** (up from 6): Wanted Criminal, Infamous, Disreputable, Unknown, Respected, Renowned, Legendary, Living Legend
- **Shop price multiplier** based on reputation tier (0.80x to 1.30x), stacks with Merchant's Favor eternal upgrade
- **Reputation clamp** [-100, 200] applied centrally in `updateSelectedCharacter`
- **Fleeing penalty**: -2 reputation when fleeing combat
- **5 moral choice fallback events**: Merchant's Lost Cargo, Beggar's Plea, Wanted Poster, Corrupt Guard, Village Under Attack
- **Boss encounters** now include reputation context in the LLM prompt
- **LLM guidance** updated for all 8 tiers with dramatic flavor for extremes
- **HUD display** shows tier name with tier-colored text (red for criminals, gold for legends)

## Test plan
- [x] TypeScript compiles with no new errors (`npx tsc --noEmit`)
- [x] Reputation tier tests pass with updated boundaries
- [x] Context builder tests pass including new tier assertions
- [ ] Manual: verify HUD shows tier name with correct color at various rep values
- [ ] Manual: verify shop prices change with reputation
- [ ] Manual: verify fleeing from combat deducts 2 reputation

🤖 Generated with [Claude Code](https://claude.com/claude-code)