### PR TITLE
Add more ways to acquire mounts

### DIFF
--- a/src/app/api/v1/tap-tap-adventure/shop/generate/route.ts
+++ b/src/app/api/v1/tap-tap-adventure/shop/generate/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 
-import { generateShopItems } from '@/app/tap-tap-adventure/lib/shopGenerator'
+import { generateShopItems, generateShopMount } from '@/app/tap-tap-adventure/lib/shopGenerator'
 
 export async function POST(req: NextRequest) {
   try {
@@ -10,7 +10,8 @@ export async function POST(req: NextRequest) {
     }
 
     const shopItems = await generateShopItems(character)
-    return NextResponse.json({ shopItems })
+    const shopMount = generateShopMount(character)
+    return NextResponse.json({ shopItems, shopMount })
   } catch (err) {
     console.error('Error generating shop', err)
     return NextResponse.json(

--- a/src/app/tap-tap-adventure/components/ShopUI.tsx
+++ b/src/app/tap-tap-adventure/components/ShopUI.tsx
@@ -5,6 +5,7 @@ import { useState } from 'react'
 import { Button } from '@/app/tap-tap-adventure/components/ui/button'
 import { useGameStore } from '@/app/tap-tap-adventure/hooks/useGameStore'
 import { inferItemTypeAndEffects } from '@/app/tap-tap-adventure/lib/itemPostProcessor'
+import { soundEngine } from '@/app/tap-tap-adventure/lib/soundEngine'
 import { calculateSellPrice } from '@/app/tap-tap-adventure/lib/sellPrice'
 import { Item } from '@/app/tap-tap-adventure/models/types'
 
@@ -131,6 +132,34 @@ export function ShopUI() {
     }
   }
 
+  const handleBuyMount = () => {
+    const mountData = shopState.shopMount
+    if (!mountData || character.gold < mountData.price) return
+    setBusy(true)
+    setFeedback(null)
+
+    const oldMount = character.activeMount
+    const updatedCharacters = gameState.characters.map(c => {
+      if (c.id !== character.id) return c
+      return {
+        ...c,
+        gold: c.gold - mountData.price,
+        activeMount: mountData.mount,
+      }
+    })
+
+    setGameState({
+      ...gameState,
+      characters: updatedCharacters,
+      shopState: { ...shopState, shopMount: null },
+    })
+
+    soundEngine.playMountAcquired()
+    const replacedText = oldMount ? ` (Replaced ${oldMount.name})` : ''
+    setFeedback(`Purchased ${mountData.mount.name}!${replacedText}`)
+    setBusy(false)
+  }
+
   const handleLeaveShop = () => {
     setShopState(null)
   }
@@ -180,6 +209,54 @@ export function ShopUI() {
       {/* Buy tab */}
       {activeTab === 'buy' && (
         <div className="space-y-3">
+          {/* Mount for sale */}
+          {shopState.shopMount && (() => {
+            const { mount, price } = shopState.shopMount
+            const canAffordMount = character.gold >= price
+            const rarityColors: Record<string, string> = {
+              common: 'text-gray-300',
+              uncommon: 'text-green-400',
+              rare: 'text-blue-400',
+              legendary: 'text-yellow-400',
+            }
+            const bonusParts: string[] = []
+            if (mount.bonuses.strength) bonusParts.push(`+${mount.bonuses.strength} STR`)
+            if (mount.bonuses.intelligence) bonusParts.push(`+${mount.bonuses.intelligence} INT`)
+            if (mount.bonuses.luck) bonusParts.push(`+${mount.bonuses.luck} LCK`)
+            if (mount.bonuses.autoWalkSpeed) bonusParts.push(`${mount.bonuses.autoWalkSpeed}x speed`)
+            if (mount.bonuses.healRate) bonusParts.push(`+${mount.bonuses.healRate} heal/step`)
+            return (
+              <div className="border border-purple-500/40 bg-[#2a2040] rounded-lg p-3 space-y-1">
+                <div className="flex justify-between items-start">
+                  <div className="font-semibold text-white">
+                    {mount.icon} {mount.name}
+                    <span className={`ml-2 text-xs uppercase ${rarityColors[mount.rarity]}`}>
+                      {mount.rarity}
+                    </span>
+                  </div>
+                  <div className="text-yellow-400 font-bold text-sm whitespace-nowrap ml-2">
+                    {price} gold
+                  </div>
+                </div>
+                <div className="text-xs text-gray-400">{mount.description}</div>
+                <div className="text-xs text-purple-300">{bonusParts.join(', ')}</div>
+                <div className="text-xs text-gray-500">Daily upkeep: {mount.dailyCost} gold</div>
+                {character.activeMount && (
+                  <div className="text-xs text-amber-400">
+                    Replaces current mount: {character.activeMount.icon} {character.activeMount.name}
+                  </div>
+                )}
+                <Button
+                  className="w-full mt-2 bg-gradient-to-r from-purple-600 to-indigo-600 hover:from-purple-500 hover:to-indigo-500 border border-purple-400/30 text-white font-bold text-base py-3 rounded disabled:opacity-40 disabled:cursor-not-allowed"
+                  disabled={!canAffordMount || busy}
+                  onClick={handleBuyMount}
+                >
+                  {canAffordMount ? 'Buy Mount' : 'Not enough gold'}
+                </Button>
+              </div>
+            )
+          })()}
+
           {shopState.items.map(item => {
             const canAfford = character.gold >= (item.price ?? 0)
             return (

--- a/src/app/tap-tap-adventure/config/mounts.ts
+++ b/src/app/tap-tap-adventure/config/mounts.ts
@@ -20,6 +20,28 @@ export function getMountsByRarity(rarity: Mount['rarity']): Mount[] {
   return MOUNT_DEFINITIONS.filter(m => m.rarity === rarity)
 }
 
+export function getMountPrice(rarity: Mount['rarity']): number {
+  switch (rarity) {
+    case 'common': return 30
+    case 'uncommon': return 60
+    case 'rare': return 120
+    case 'legendary': return 300
+  }
+}
+
+/** Returns a mount appropriate for the character's level (never legendary in shops). */
+export function getShopMount(characterLevel: number): Mount {
+  let pool: Mount[]
+  if (characterLevel >= 7) {
+    pool = [...getMountsByRarity('uncommon'), ...getMountsByRarity('rare')]
+  } else if (characterLevel >= 4) {
+    pool = [...getMountsByRarity('common'), ...getMountsByRarity('uncommon')]
+  } else {
+    pool = getMountsByRarity('common')
+  }
+  return pool[Math.floor(Math.random() * pool.length)]
+}
+
 export function getRandomMount(luckBonus: number = 0): Mount {
   const roll = Math.random() + luckBonus * 0.02
   let pool: Mount[]

--- a/src/app/tap-tap-adventure/hooks/useCombatActionMutation.ts
+++ b/src/app/tap-tap-adventure/hooks/useCombatActionMutation.ts
@@ -126,9 +126,14 @@ export function useCombatActionMutation() {
             addItem(inferItemTypeAndEffects(lootItem))
           }
 
-          // If boss dropped a mount, equip it (via builder so commit() includes it)
+          // If combat dropped a mount, equip it
+          let mountText = ''
           if (data.rewards.mountDrop) {
+            const oldMount = character.activeMount
             updateSelectedCharacter({ activeMount: data.rewards.mountDrop })
+            soundEngine.playMountAcquired()
+            const replacedText = oldMount ? ` (Replaced ${oldMount.name})` : ''
+            mountText = ` You tamed a ${data.rewards.mountDrop.name}! ${data.rewards.mountDrop.icon}${replacedText}`
           }
 
           addStoryEvent({
@@ -137,7 +142,7 @@ export function useCombatActionMutation() {
             characterId: character.id,
             locationId: character.locationId,
             timestamp: new Date().toISOString(),
-            outcomeDescription: `You defeated ${enemy.name}! +${data.rewards.gold} Gold.${data.rewards.mountDrop ? ` You tamed a ${data.rewards.mountDrop.name}! ${data.rewards.mountDrop.icon}` : ''}`,
+            outcomeDescription: `You defeated ${enemy.name}! +${data.rewards.gold} Gold.${mountText}`,
             resourceDelta: {
               gold: data.rewards.gold,
             },

--- a/src/app/tap-tap-adventure/hooks/useMoveForwardMutation.ts
+++ b/src/app/tap-tap-adventure/hooks/useMoveForwardMutation.ts
@@ -84,7 +84,7 @@ export function useMoveForwardMutation() {
           const shopData = await shopRes.json()
           setGenericMessage(null)
           setDecisionPoint(null)
-          setShopState({ items: shopData.shopItems, isOpen: true })
+          setShopState({ items: shopData.shopItems, isOpen: true, shopMount: shopData.shopMount ?? null })
         }
       } else if (data.decisionPoint) {
         soundEngine.playEvent()

--- a/src/app/tap-tap-adventure/hooks/useResolveDecisionMutation.ts
+++ b/src/app/tap-tap-adventure/hooks/useResolveDecisionMutation.ts
@@ -129,11 +129,16 @@ export function useResolveDecisionMutation() {
       addStoryEvent(newStoryEvent)
 
       // Check if this event grants a mount (mount discovery events)
-      const isMountEvent = optionId.includes('tame-horse') || optionId.includes('claim-mount')
+      const isMountEvent = optionId.includes('tame-') || optionId.includes('claim-mount')
       if (isMountEvent && data.outcomeDescription && !data.outcomeDescription.includes('bolts') && !data.outcomeDescription.includes("won't let you")) {
         const currentChar = getSelectedCharacter()
+        const oldMount = currentChar?.activeMount
         const mount = getRandomMount(currentChar?.luck ?? 0)
         updateSelectedCharacter({ activeMount: mount })
+        soundEngine.playMountAcquired()
+        // Update the story event to note the mount gained (and any replacement)
+        const replacedText = oldMount ? ` (Replaced ${oldMount.name})` : ''
+        newStoryEvent.outcomeDescription = `${data.outcomeDescription} You gained a ${mount.name}! ${mount.icon}${replacedText}`
       }
 
       // If the chosen option triggers combat, start a combat encounter

--- a/src/app/tap-tap-adventure/lib/combatEngine.ts
+++ b/src/app/tap-tap-adventure/lib/combatEngine.ts
@@ -1047,11 +1047,16 @@ export function getCombatRewards(
     }
   }
 
-  // Bosses have a chance to drop a mount
+  // Bosses have a 25% chance to drop a mount; non-boss enemies have a 3% chance
   let mountDrop: Mount | undefined
   if (combatState.isBoss) {
     const mountDropChance = 0.25 + character.luck * 0.02
     if (Math.random() < mountDropChance) {
+      mountDrop = getRandomMount(character.luck)
+    }
+  } else {
+    const nonBossMountChance = 0.03 + character.luck * 0.005
+    if (Math.random() < nonBossMountChance) {
       mountDrop = getRandomMount(character.luck)
     }
   }

--- a/src/app/tap-tap-adventure/lib/llmEventGenerator.ts
+++ b/src/app/tap-tap-adventure/lib/llmEventGenerator.ts
@@ -405,6 +405,20 @@ function getRegionFallbackEvents(regionId: string): LLMGeneratedEvent[] {
         ],
       },
       {
+        id: `rfb-shadow-wolves-${s}`,
+        description: 'A pack of shadow wolves slinks through the dark undergrowth, their eyes glowing with an eerie violet light. The alpha pauses and locks eyes with you.',
+        options: [
+          { id: `tame-shadow-wolf-${s}`, text: 'Offer your hand to the alpha (taming attempt)', successProbability: 0.5,
+            successDescription: 'The shadow wolf sniffs your hand, then nuzzles against it. The alpha accepts you as its pack leader! You have gained a new mount.',
+            successEffects: { reputation: 3 },
+            failureDescription: 'The wolf snarls and bolts into the shadows. It won\'t let you near.',
+            failureEffects: {} },
+          { id: `leave-wolves-${s}`, text: 'Back away slowly', successProbability: 1.0,
+            successDescription: 'The pack watches you retreat before melting back into the darkness.',
+            successEffects: {}, failureDescription: '', failureEffects: {} },
+        ],
+      },
+      {
         id: `rfb-treant-${s}`,
         description: 'A corrupted treant blocks the path, its bark oozing dark sap. It groans menacingly.',
         options: [
@@ -432,6 +446,20 @@ function getRegionFallbackEvents(regionId: string): LLMGeneratedEvent[] {
           { id: `retreat-fire-${s}`, text: 'Keep your distance', successProbability: 1.0,
             successDescription: 'You watch the spectacular display from safety as it eventually burns out.',
             successEffects: {}, failureDescription: '', failureEffects: {} },
+        ],
+      },
+      {
+        id: `rfb-phoenix-feather-${s}`,
+        description: 'Among the scorched sands, you spot a single feather blazing with living flame. It hovers above the ground, radiating intense heat and pulsing with rebirth energy.',
+        options: [
+          { id: `claim-mount-phoenix-${s}`, text: 'Grasp the phoenix feather (taming attempt)', successProbability: 0.3,
+            successDescription: 'The feather flares brilliantly and transforms into a majestic phoenix that bows before you. It has chosen you as its rider! You have gained a new mount.',
+            successEffects: { reputation: 5 },
+            failureDescription: 'The feather burns white-hot and disintegrates. The phoenix bolts skyward in a column of fire. It won\'t let you claim it.',
+            failureEffects: {} },
+          { id: `leave-feather-${s}`, text: 'Admire the feather from a safe distance', successProbability: 1.0,
+            successDescription: 'The feather eventually burns out, leaving a small pile of warm ash.',
+            successEffects: { reputation: 1 }, failureDescription: '', failureEffects: {} },
         ],
       },
       {
@@ -491,6 +519,20 @@ function getRegionFallbackEvents(regionId: string): LLMGeneratedEvent[] {
             successEffects: { reputation: 2 },
             failureDescription: 'The convergence fades quickly, leaving nothing behind.',
             failureEffects: {} },
+        ],
+      },
+      {
+        id: `rfb-ice-griffin-${s}`,
+        description: 'High on a frozen ledge, you spot an abandoned griffin nest. Inside, a lone griffin chick chirps weakly, its frost-blue feathers ruffled against the cold.',
+        options: [
+          { id: `tame-griffin-chick-${s}`, text: 'Wrap the chick in your cloak and raise it (taming attempt)', successProbability: 0.4,
+            successDescription: 'The griffin chick bonds with you instantly, nuzzling into your warmth. As you care for it, it grows rapidly into a majestic ice griffin mount! You have gained a new mount.',
+            successEffects: { reputation: 4 },
+            failureDescription: 'The chick screeches in alarm and bolts away. It won\'t let you near.',
+            failureEffects: {} },
+          { id: `leave-nest-${s}`, text: 'Leave the nest undisturbed', successProbability: 1.0,
+            successDescription: 'You leave the chick, hoping its parent will return.',
+            successEffects: { reputation: 1 }, failureDescription: '', failureEffects: {} },
         ],
       },
       {
@@ -555,6 +597,20 @@ function getRegionFallbackEvents(regionId: string): LLMGeneratedEvent[] {
             successEffects: { gold: 10 },
             failureDescription: 'The crystals shatter into worthless dust.',
             failureEffects: {} },
+        ],
+      },
+      {
+        id: `rfb-glowing-owl-${s}`,
+        description: 'A luminous owl perches on a crystal stalactite above you, its feathers shimmering with arcane light. It tilts its head and hoots softly, studying you with intelligent eyes.',
+        options: [
+          { id: `tame-glowing-owl-${s}`, text: 'Extend your arm and whistle gently (taming attempt)', successProbability: 0.6,
+            successDescription: 'The owl flutters down and lands on your arm, its warm glow enveloping you. It has chosen you as its companion! You have gained a new mount.',
+            successEffects: { reputation: 3 },
+            failureDescription: 'The owl hoots dismissively and bolts deeper into the caves. It won\'t let you near.',
+            failureEffects: {} },
+          { id: `watch-owl-${s}`, text: 'Watch the owl in wonder', successProbability: 1.0,
+            successDescription: 'The owl takes flight, trailing sparkles through the dark cavern. A beautiful sight.',
+            successEffects: { reputation: 1 }, failureDescription: '', failureEffects: {} },
         ],
       },
       {

--- a/src/app/tap-tap-adventure/lib/shopGenerator.ts
+++ b/src/app/tap-tap-adventure/lib/shopGenerator.ts
@@ -3,10 +3,17 @@ import { z } from 'zod'
 
 import { FantasyCharacter } from '@/app/tap-tap-adventure/models/character'
 import { Item, ItemSchema } from '@/app/tap-tap-adventure/models/item'
+import { Mount } from '@/app/tap-tap-adventure/models/mount'
+import { getMountPrice, getShopMount } from '@/app/tap-tap-adventure/config/mounts'
 
 import { getReputationPriceMultiplier } from './contextBuilder'
 import { inferItemTypeAndEffects } from './itemPostProcessor'
 import { generateSpellForLevel } from './spellGenerator'
+
+export interface ShopMount {
+  mount: Mount
+  price: number
+}
 
 function getOpenAIClient() {
   return new OpenAI({ apiKey: process.env.OPENAI_API_KEY })
@@ -47,6 +54,13 @@ const shopSchemaForOpenAI = {
     },
   },
   required: ['items'],
+}
+
+export function generateShopMount(character: FantasyCharacter): ShopMount | null {
+  if (Math.random() > 0.3) return null // 30% chance
+  const mount = getShopMount(character.level)
+  const price = getMountPrice(mount.rarity)
+  return { mount, price }
 }
 
 export async function generateShopItems(character: FantasyCharacter): Promise<Item[]> {

--- a/src/app/tap-tap-adventure/lib/soundEngine.ts
+++ b/src/app/tap-tap-adventure/lib/soundEngine.ts
@@ -374,6 +374,41 @@ class SoundEngine {
     }
   }
 
+  /** Mount acquired fanfare — low note (200Hz) + high sweep (400->800Hz), 300ms, gain 0.2 */
+  playMountAcquired() {
+    try {
+      if (!this.enabled) return
+      const ctx = this.getContext()
+      if (!ctx) return
+      const now = ctx.currentTime
+      // Low note
+      const oscLow = ctx.createOscillator()
+      const gainLow = ctx.createGain()
+      oscLow.type = 'sine'
+      oscLow.frequency.setValueAtTime(200, now)
+      gainLow.gain.setValueAtTime(0.2, now)
+      gainLow.gain.linearRampToValueAtTime(0, now + 0.3)
+      oscLow.connect(gainLow)
+      gainLow.connect(ctx.destination)
+      oscLow.start(now)
+      oscLow.stop(now + 0.3)
+      // High sweep
+      const oscHigh = ctx.createOscillator()
+      const gainHigh = ctx.createGain()
+      oscHigh.type = 'sine'
+      oscHigh.frequency.setValueAtTime(400, now)
+      oscHigh.frequency.linearRampToValueAtTime(800, now + 0.3)
+      gainHigh.gain.setValueAtTime(0.2, now)
+      gainHigh.gain.linearRampToValueAtTime(0, now + 0.3)
+      oscHigh.connect(gainHigh)
+      gainHigh.connect(ctx.destination)
+      oscHigh.start(now)
+      oscHigh.stop(now + 0.3)
+    } catch {
+      // fail silently
+    }
+  }
+
   /** Mystical ascending shimmer — two detuned sines sweeping 300->600Hz over 300ms, gain 0.15 */
   playSpellLearn() {
     try {

--- a/src/app/tap-tap-adventure/models/types.ts
+++ b/src/app/tap-tap-adventure/models/types.ts
@@ -6,12 +6,19 @@ import { CombatState } from './combat'
 import { Item } from './item'
 import { FantasyLocation } from './location'
 import { MetaProgressionState } from './metaProgression'
+import { Mount } from './mount'
 import { TimedQuest } from './quest'
 import { FantasyDecisionPoint, FantasyStoryEvent } from './story'
+
+export type ShopMountData = {
+  mount: Mount
+  price: number
+}
 
 export type ShopState = {
   items: Item[]
   isOpen: boolean
+  shopMount?: ShopMountData | null
 }
 
 export type {


### PR DESCRIPTION
## Summary
- **Shop mounts**: 30% chance a mount appears in any shop, priced by rarity (common=30g, uncommon=60g, rare=120g). Level-gated rarity tiers; never legendary in shops. Purple-themed mount card in Shop UI with replacement warning.
- **Region mount taming events**: 4 new fallback events — Shadow Wolf Pack (Dark Forest, 50%), Ice Griffin Nest (Frozen Peaks, 40%), Glowing Owl (Crystal Caves, 60%), Phoenix Feather (Scorched Wastes, 30%). Each uses the existing `tame-`/`claim-mount` detection pattern.
- **Non-boss combat mount drops**: 3% base chance (+luck scaling) for regular enemies to drop a mount, in addition to the existing 25% boss drop rate.
- **Mount replacement UX**: All mount acquisition paths now show "You gained [Mount]! (Replaced [Old Mount])" when replacing an existing mount.
- **Mount acquired sound effect**: `playMountAcquired()` — low 200Hz note + 400-800Hz sweep, 300ms — played on all acquisition paths (shop buy, event taming, combat drop).

## Files changed (11)
- `config/mounts.ts` — `getMountPrice()`, `getShopMount(level)` 
- `lib/shopGenerator.ts` — `ShopMount` type, `generateShopMount()`
- `api/shop/generate/route.ts` — returns `shopMount` alongside `shopItems`
- `models/types.ts` — `ShopMountData` type, optional `shopMount` on `ShopState`
- `hooks/useMoveForwardMutation.ts` — passes `shopMount` to shop state
- `components/ShopUI.tsx` — mount card UI with buy handler
- `lib/llmEventGenerator.ts` — 4 region-specific mount taming events
- `hooks/useResolveDecisionMutation.ts` — broader taming detection (`tame-`), sound + replacement text
- `lib/combatEngine.ts` — 3% non-boss mount drop chance
- `hooks/useCombatActionMutation.ts` — replacement text in victory description, mount sound
- `lib/soundEngine.ts` — `playMountAcquired()` method

## Test plan
- [ ] Visit a shop and verify mount card appears ~30% of the time with correct pricing
- [ ] Buy a mount from shop; verify gold deduction, mount equipped, sound plays
- [ ] Buy a mount when already having one; verify replacement message
- [ ] Encounter region-specific taming events in Dark Forest, Frozen Peaks, Crystal Caves, Scorched Wastes
- [ ] Successfully tame a mount from event; verify sound + story text
- [ ] Fail a taming attempt; verify no mount granted
- [ ] Defeat non-boss enemies repeatedly; verify occasional mount drop (~3%)
- [ ] Defeat a boss; verify mount drop still works at ~25%
- [ ] Verify `npx tsc --noEmit` shows no new type errors (pre-existing test fixture errors only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)