### PR TITLE
Cap story events at 200 to prevent unbounded memory growth

### DIFF
--- a/src/app/tap-tap-adventure/hooks/useGameStore.ts
+++ b/src/app/tap-tap-adventure/hooks/useGameStore.ts
@@ -801,8 +801,13 @@ export function useGameStateBuilder() {
     selectedCharacter.inventory.push(item)
   }
 
+  const MAX_STORY_EVENTS = 200
+
   const addStoryEvent = (event: FantasyStoryEvent) => {
     gameStateClone.storyEvents.push(event)
+    if (gameStateClone.storyEvents.length > MAX_STORY_EVENTS) {
+      gameStateClone.storyEvents = gameStateClone.storyEvents.slice(-MAX_STORY_EVENTS)
+    }
   }
 
   const setCombatState = (combatState: CombatState | null) => {


### PR DESCRIPTION
## Summary
- Caps the `storyEvents` array at 200 entries in the Zustand store
- When a new event is added and the array exceeds 200, the oldest events are trimmed
- Prevents unbounded localStorage growth during long play sessions

The LLM context builder already only reads the last 10 events, so older entries serve no gameplay purpose beyond history viewing. 200 entries preserves plenty of scrollback while bounding memory usage.

## Test plan
- [ ] Verify existing tests pass (pre-existing failures are unrelated)
- [ ] Play through several events and confirm story feed displays correctly
- [ ] Confirm old events are trimmed after 200+ entries accumulate

Closes #117

🤖 Generated with [Claude Code](https://claude.com/claude-code)