### PR TITLE
Guard tap handler against duplicate in-flight mutations

### DIFF
--- a/src/app/tap-tap-adventure/components/GameUI.tsx
+++ b/src/app/tap-tap-adventure/components/GameUI.tsx
@@ -118,6 +118,7 @@ export default function GameUI() {
   }
 
   const handleMoveForward = () => {
+    if (moveForwardPending) return
     soundEngine.playTap()
     const character = getSelectedCharacter()
     const distance = character?.distance ?? 0


### PR DESCRIPTION
## Summary
- Adds early return in `handleMoveForward()` when `moveForwardPending` is true
- Prevents rapid taps from queuing multiple concurrent API calls before the button's `disabled` attribute takes effect
- Protects both manual taps and auto-walk interval calls since both route through the same function

This is a minimal, targeted fix — the button already has `disabled={moveForwardPending}` but pointer events can still fire before React re-renders the disabled state.

## Test plan
- [ ] Rapid-tap the advance button — only one API call should fire at a time
- [ ] Auto-walk should continue to work normally, advancing one step per interval
- [ ] Milestone events (crossroads, shop, boss) should still trigger correctly

Closes #118

🤖 Generated with [Claude Code](https://claude.com/claude-code)