### PR TITLE
Add keyboard shortcuts for core gameplay actions

### DIFF
--- a/src/app/tap-tap-adventure/components/CombatUI.tsx
+++ b/src/app/tap-tap-adventure/components/CombatUI.tsx
@@ -123,6 +123,43 @@ export function CombatUI({ combatState }: CombatUIProps) {
     [combatAction]
   )
 
+  // Keyboard shortcuts for combat actions
+  useEffect(() => {
+    if (status !== 'active') return
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (isPending) return
+      if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) return
+
+      const ap = playerState.ap ?? 3
+      switch (e.key.toLowerCase()) {
+        case 'a': // Attack
+          if (ap >= (AP_COSTS.attack ?? 1)) { e.preventDefault(); handleAction('attack') }
+          break
+        case 'h': // Heavy Attack
+          if (ap >= (AP_COSTS.heavy_attack ?? 2)) { e.preventDefault(); handleAction('heavy_attack') }
+          break
+        case 'd': // Defend
+          if (ap >= (AP_COSTS.defend ?? 1)) { e.preventDefault(); handleAction('defend') }
+          break
+        case 'f': // Flee
+          if (ap >= (AP_COSTS.flee ?? 3)) { e.preventDefault(); handleAction('flee') }
+          break
+        case 'q': // Class Ability
+          if (classAbility && abilityCooldown === 0 && ap >= (AP_COSTS.class_ability ?? 2)) {
+            e.preventDefault(); handleAction('class_ability')
+          }
+          break
+        case 'e': // End Turn
+          e.preventDefault(); handleAction('end_turn')
+          break
+      }
+    }
+
+    window.addEventListener('keydown', handleKeyDown)
+    return () => window.removeEventListener('keydown', handleKeyDown)
+  })
+
   const handleUseItem = useCallback(
     (itemId: string) => {
       // Check if the item has healing effects

--- a/src/app/tap-tap-adventure/components/GameUI.tsx
+++ b/src/app/tap-tap-adventure/components/GameUI.tsx
@@ -196,6 +196,42 @@ export default function GameUI() {
     }
   }, [clearAutoWalk])
 
+  // Keyboard shortcuts
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      // Ignore when typing in inputs
+      if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) return
+
+      // Escape — close mobile panel
+      if (e.key === 'Escape') {
+        setMobilePanel(null)
+        return
+      }
+
+      // During decision point — 1-4 to pick options
+      if (gameState.decisionPoint && !gameState.decisionPoint.resolved && !resolveDecisionPending) {
+        const num = parseInt(e.key, 10)
+        if (num >= 1 && num <= gameState.decisionPoint.options.length) {
+          e.preventDefault()
+          handleResolveDecision(gameState.decisionPoint.options[num - 1].id)
+        }
+        return
+      }
+
+      // During combat or shop — let those components handle their own shortcuts
+      if (gameState.combatState?.status === 'active' || gameState.shopState?.isOpen) return
+
+      // Travel mode — Space or Enter to move forward
+      if ((e.key === ' ' || e.key === 'Enter') && !moveForwardPending) {
+        e.preventDefault()
+        handleMoveForward()
+      }
+    }
+
+    window.addEventListener('keydown', handleKeyDown)
+    return () => window.removeEventListener('keydown', handleKeyDown)
+  })
+
   const handlePointerDown = (e: React.PointerEvent) => {
     e.preventDefault()
     const mountSpeed = character?.activeMount?.bonuses?.autoWalkSpeed ?? 1
@@ -295,7 +331,7 @@ export default function GameUI() {
                       </div>
                     ) : (
                       <div className="space-y-2 mt-2">
-                        {gameState.decisionPoint.options.map((option: { id: string; text: string }) => {
+                        {gameState.decisionPoint.options.map((option: { id: string; text: string }, index: number) => {
                           if (!option) return null
                           if (!gameState.decisionPoint) return null
                           return (
@@ -307,6 +343,7 @@ export default function GameUI() {
                                 handleResolveDecision(option.id)
                               }}
                             >
+                              <span className="hidden sm:inline text-slate-400 mr-2 text-xs font-mono">[{index + 1}]</span>
                               {option.text}
                             </Button>
                           )


### PR DESCRIPTION
## Summary
- **Space / Enter** to move forward during travel
- **1-4** to select decision options during events (with `[N]` hint labels on desktop)
- **A** Attack, **H** Heavy Attack, **D** Defend, **F** Flee, **Q** Class Ability, **E** End Turn during combat
- **Escape** to close mobile panels

Shortcuts are context-aware — they only fire for the currently active game state (travel, decision, combat) and respect pending/disabled states. Input fields are excluded so typing in text inputs works normally.

## Test plan
- [ ] Press Space during travel — character moves forward
- [ ] During a decision event, press 1-4 to pick options
- [ ] In combat, press A/H/D/F/Q/E for respective actions
- [ ] Verify shortcuts don't fire when actions are disabled (insufficient AP, pending)
- [ ] Verify Escape closes mobile panel overlays

Closes #116

🤖 Generated with [Claude Code](https://claude.com/claude-code)