### PR TITLE
Add item comparison indicators in shop and inventory

### DIFF
--- a/src/app/tap-tap-adventure/components/InventoryPanel.tsx
+++ b/src/app/tap-tap-adventure/components/InventoryPanel.tsx
@@ -5,7 +5,7 @@ import { Button } from '@/app/tap-tap-adventure/components/ui/button'
 import { List } from '@/app/tap-tap-adventure/components/ui/list'
 import { useGameStore } from '@/app/tap-tap-adventure/hooks/useGameStore'
 import { soundEngine } from '@/app/tap-tap-adventure/lib/soundEngine'
-import { getEquipmentSlot } from '@/app/tap-tap-adventure/models/equipment'
+import { getEquipmentSlot, EquipmentSlots } from '@/app/tap-tap-adventure/models/equipment'
 import { Item } from '@/app/tap-tap-adventure/models/types'
 
 interface InventoryPanelProps {
@@ -15,6 +15,8 @@ interface InventoryPanelProps {
 export function InventoryPanel({ inventory }: InventoryPanelProps) {
   const [activeTab, setActiveTab] = useState<'active' | 'deleted'>('active')
   const [feedbackMessage, setFeedbackMessage] = useState<string | null>(null)
+  const character = useGameStore(s => s.gameState.characters.find(c => c.id === s.gameState.selectedCharacterId))
+  const equipment = (character?.equipment ?? { weapon: null, armor: null, accessory: null }) as EquipmentSlots
 
   const handleUse = useCallback((item: Item) => {
     const result = useGameStore.getState().useItem(item.id)
@@ -118,6 +120,27 @@ export function InventoryPanel({ inventory }: InventoryPanelProps) {
                         .join(', ')}
                     </div>
                   )}
+                  {item.type === 'equipment' && (() => {
+                    const slot = getEquipmentSlot(item)
+                    const equipped = equipment[slot]
+                    if (!equipped) return <div className="text-xs text-green-400 mt-0.5">No item in {slot} slot</div>
+                    const stats = ['strength', 'intelligence', 'luck'] as const
+                    const deltas = stats.map(key => {
+                      const diff = (item.effects?.[key] ?? 0) - (equipped.effects?.[key] ?? 0)
+                      return diff !== 0 ? { label: key.slice(0, 3).toUpperCase(), diff } : null
+                    }).filter(Boolean) as { label: string; diff: number }[]
+                    if (deltas.length === 0) return <div className="text-xs text-gray-500 mt-0.5">Same stats as equipped {equipped.name}</div>
+                    return (
+                      <div className="text-xs mt-0.5 space-x-2">
+                        <span className="text-gray-500">vs {equipped.name}:</span>
+                        {deltas.map(d => (
+                          <span key={d.label} className={d.diff > 0 ? 'text-green-400' : 'text-red-400'}>
+                            {d.diff > 0 ? '+' : ''}{d.diff} {d.label}
+                          </span>
+                        ))}
+                      </div>
+                    )
+                  })()}
                   {item.quantity > 1 && (
                     <div className="text-xs text-gray-500 mt-0.5">Qty: {item.quantity}</div>
                   )}

--- a/src/app/tap-tap-adventure/components/ShopUI.tsx
+++ b/src/app/tap-tap-adventure/components/ShopUI.tsx
@@ -8,6 +8,8 @@ import { inferItemTypeAndEffects } from '@/app/tap-tap-adventure/lib/itemPostPro
 import { soundEngine } from '@/app/tap-tap-adventure/lib/soundEngine'
 import { calculateSellPrice } from '@/app/tap-tap-adventure/lib/sellPrice'
 import { Item } from '@/app/tap-tap-adventure/models/types'
+import { getEquipmentSlot, EquipmentSlots } from '@/app/tap-tap-adventure/models/equipment'
+import { ItemEffects } from '@/app/tap-tap-adventure/models/item'
 
 type ShopTab = 'buy' | 'sell'
 
@@ -20,6 +22,41 @@ function formatEffects(effects?: Item['effects']): string {
   if (effects.gold) parts.push(`+${effects.gold} Gold`)
   if (effects.reputation) parts.push(`+${effects.reputation} Rep`)
   return parts.length > 0 ? parts.join(', ') : 'No effects'
+}
+
+const STAT_KEYS: { key: keyof ItemEffects; label: string }[] = [
+  { key: 'strength', label: 'STR' },
+  { key: 'intelligence', label: 'INT' },
+  { key: 'luck', label: 'LCK' },
+]
+
+function ItemComparison({ item, equipment }: { item: Item; equipment: EquipmentSlots }) {
+  if (item.type !== 'equipment') return null
+  const slot = getEquipmentSlot(item)
+  const equipped = equipment[slot]
+  if (!equipped) {
+    return <div className="text-xs text-green-400">No item in {slot} slot — direct upgrade</div>
+  }
+  const deltas = STAT_KEYS.map(({ key, label }) => {
+    const newVal = item.effects?.[key] ?? 0
+    const oldVal = equipped.effects?.[key] ?? 0
+    const diff = newVal - oldVal
+    if (diff === 0) return null
+    return { label, diff }
+  }).filter(Boolean) as { label: string; diff: number }[]
+
+  if (deltas.length === 0) return <div className="text-xs text-gray-500">Same stats as equipped {equipped.name}</div>
+
+  return (
+    <div className="text-xs space-x-2">
+      <span className="text-gray-500">vs {equipped.name}:</span>
+      {deltas.map(d => (
+        <span key={d.label} className={d.diff > 0 ? 'text-green-400' : 'text-red-400'}>
+          {d.diff > 0 ? '+' : ''}{d.diff} {d.label}
+        </span>
+      ))}
+    </div>
+  )
 }
 
 export function ShopUI() {
@@ -272,6 +309,9 @@ export function ShopUI() {
                 </div>
                 <div className="text-xs text-gray-400">{item.description}</div>
                 <div className="text-xs text-indigo-300">{formatEffects(item.effects)}</div>
+                {character.equipment && (
+                  <ItemComparison item={item} equipment={character.equipment as EquipmentSlots} />
+                )}
                 <Button
                   className="w-full mt-2 bg-gradient-to-r from-yellow-600 to-amber-600 hover:from-yellow-500 hover:to-amber-500 border border-yellow-400/30 text-white font-bold text-base py-3 rounded disabled:opacity-40 disabled:cursor-not-allowed"
                   disabled={!canAfford || busy}


### PR DESCRIPTION
## Summary
- **Shop buy tab**: Equipment items now show a stat comparison against the currently equipped item in the same slot
- **Inventory panel**: Equipment items show the same comparison when browsing inventory
- Stat deltas are color-coded: green for upgrades, red for downgrades
- Empty slots display "direct upgrade" message
- Compares STR, INT, LCK stats

## Test plan
- [ ] Visit a shop with equipment items — verify comparison text appears below item effects
- [ ] Compare an item when the slot is empty — should say "No item in [slot] slot — direct upgrade"
- [ ] Compare an item with same stats as equipped — should say "Same stats as equipped [name]"
- [ ] Verify green/red coloring for positive/negative deltas
- [ ] Check inventory panel shows same comparison for equipment items with "Equip" button

Closes #119

🤖 Generated with [Claude Code](https://claude.com/claude-code)