### PR TITLE
Add visual region map for navigation

### DIFF
--- a/src/app/tap-tap-adventure/components/GameUI.tsx
+++ b/src/app/tap-tap-adventure/components/GameUI.tsx
@@ -29,6 +29,7 @@ import { StatAllocationScreen } from './StatAllocationScreen'
 import { ShopUI } from './ShopUI'
 import { SkillPanel } from './SkillPanel'
 import { StoryFeed } from './StoryFeed'
+import { RegionMap } from './RegionMap'
 
 const DIFFICULTY_STYLES: Record<RegionDifficulty, { label: string; color: string }> = {
   easy: { label: 'Easy', color: 'bg-green-900/50 text-green-300 border-green-600/40' },
@@ -66,7 +67,7 @@ function getTravelButtonMessage({ isLoading, distance }: { isLoading: boolean; d
   if (distance === 0) return 'Start Your Adventure'
   return 'Continue Travelling'
 }
-type MobilePanel = 'equipment' | 'inventory' | 'skills' | 'quest' | null
+type MobilePanel = 'equipment' | 'inventory' | 'skills' | 'quest' | 'map' | null
 
 export default function GameUI() {
   const {
@@ -438,6 +439,12 @@ export default function GameUI() {
             <div className="border-t border-[#3a3c56] pt-4">
               <InventoryPanel inventory={getSelectedCharacter()?.inventory ?? []} />
             </div>
+            <div className="border-t border-[#3a3c56] pt-4">
+              <RegionMap
+                currentRegionId={character?.currentRegion ?? 'green_meadows'}
+                characterLevel={character?.level ?? 1}
+              />
+            </div>
           </div>
         </div>
         {/* Two-column grid END */}
@@ -454,7 +461,7 @@ export default function GameUI() {
           >
             <div className="flex justify-between items-center mb-2">
               <h3 className="text-sm font-semibold text-slate-300 uppercase">
-                {mobilePanel === 'equipment' ? 'Equipment' : mobilePanel === 'inventory' ? 'Inventory' : mobilePanel === 'skills' ? 'Skills' : 'Quest'}
+                {mobilePanel === 'equipment' ? 'Equipment' : mobilePanel === 'inventory' ? 'Inventory' : mobilePanel === 'skills' ? 'Skills' : mobilePanel === 'map' ? 'Map' : 'Quest'}
               </h3>
               <button
                 className="text-slate-400 hover:text-white text-sm px-2 py-1"
@@ -478,6 +485,12 @@ export default function GameUI() {
             {mobilePanel === 'skills' && (
               <SkillPanel unlockedSkillIds={character?.unlockedSkills ?? []} />
             )}
+            {mobilePanel === 'map' && (
+              <RegionMap
+                currentRegionId={character?.currentRegion ?? 'green_meadows'}
+                characterLevel={character?.level ?? 1}
+              />
+            )}
           </div>
         </div>
       )}
@@ -489,6 +502,7 @@ export default function GameUI() {
           { id: 'inventory' as MobilePanel, label: 'Items', icon: '\uD83C\uDF92' },
           { id: 'skills' as MobilePanel, label: 'Skills', icon: '\u2728' },
           { id: 'quest' as MobilePanel, label: 'Quest', icon: '\uD83D\uDCDC' },
+          { id: 'map' as MobilePanel, label: 'Map', icon: '\uD83D\uDDFA' },
         ]).map(tab => (
           <button
             key={tab.id}

--- a/src/app/tap-tap-adventure/components/RegionMap.tsx
+++ b/src/app/tap-tap-adventure/components/RegionMap.tsx
@@ -1,0 +1,125 @@
+'use client'
+
+import { REGIONS, canEnterRegion, Region } from '@/app/tap-tap-adventure/config/regions'
+
+interface RegionMapProps {
+  currentRegionId: string
+  characterLevel: number
+}
+
+const DIFFICULTY_COLORS: Record<string, string> = {
+  easy: 'border-green-500/60 bg-green-900/30',
+  medium: 'border-yellow-500/60 bg-yellow-900/30',
+  hard: 'border-orange-500/60 bg-orange-900/30',
+  very_hard: 'border-red-500/60 bg-red-900/30',
+}
+
+const DIFFICULTY_LABELS: Record<string, string> = {
+  easy: 'Easy',
+  medium: 'Medium',
+  hard: 'Hard',
+  very_hard: 'Very Hard',
+}
+
+// Fixed positions for the map layout (percentage-based)
+const POSITIONS: Record<string, { x: number; y: number }> = {
+  sky_citadel:     { x: 50, y: 5 },
+  scorched_wastes: { x: 18, y: 28 },
+  frozen_peaks:    { x: 50, y: 28 },
+  shadow_realm:    { x: 82, y: 28 },
+  dark_forest:     { x: 25, y: 55 },
+  crystal_caves:   { x: 75, y: 55 },
+  green_meadows:   { x: 50, y: 75 },
+  starting_village:{ x: 50, y: 95 },
+}
+
+function ConnectionLine({ from, to }: { from: { x: number; y: number }; to: { x: number; y: number } }) {
+  return (
+    <line
+      x1={`${from.x}%`}
+      y1={`${from.y}%`}
+      x2={`${to.x}%`}
+      y2={`${to.y}%`}
+      stroke="rgba(148, 163, 184, 0.3)"
+      strokeWidth="1.5"
+      strokeDasharray="4 4"
+    />
+  )
+}
+
+export function RegionMap({ currentRegionId, characterLevel }: RegionMapProps) {
+  const regions = Object.values(REGIONS)
+
+  // Build unique connection pairs to avoid drawing duplicates
+  const connections: { from: string; to: string }[] = []
+  const seen = new Set<string>()
+  for (const region of regions) {
+    for (const connId of region.connectedRegions) {
+      const key = [region.id, connId].sort().join('-')
+      if (!seen.has(key)) {
+        seen.add(key)
+        connections.push({ from: region.id, to: connId })
+      }
+    }
+  }
+
+  return (
+    <div className="w-full">
+      <h3 className="text-lg font-semibold text-white mb-3">Region Map</h3>
+      <div className="relative w-full" style={{ paddingBottom: '110%' }}>
+        {/* Connection lines */}
+        <svg className="absolute inset-0 w-full h-full" style={{ zIndex: 0 }}>
+          {connections.map(({ from, to }) => (
+            <ConnectionLine
+              key={`${from}-${to}`}
+              from={POSITIONS[from]}
+              to={POSITIONS[to]}
+            />
+          ))}
+        </svg>
+
+        {/* Region nodes */}
+        {regions.map((region: Region) => {
+          const pos = POSITIONS[region.id]
+          const isCurrent = region.id === currentRegionId
+          const accessible = canEnterRegion(region, characterLevel)
+
+          return (
+            <div
+              key={region.id}
+              className={`absolute transform -translate-x-1/2 -translate-y-1/2 w-24 sm:w-28 text-center rounded-lg border-2 px-1 py-1.5 transition-all ${
+                DIFFICULTY_COLORS[region.difficulty]
+              } ${
+                isCurrent
+                  ? 'ring-2 ring-white shadow-lg shadow-white/20 scale-110'
+                  : accessible
+                  ? 'opacity-80 hover:opacity-100'
+                  : 'opacity-40 grayscale'
+              }`}
+              style={{
+                left: `${pos.x}%`,
+                top: `${pos.y}%`,
+                zIndex: isCurrent ? 10 : 1,
+              }}
+              title={region.description}
+            >
+              <div className="text-lg leading-none">{region.icon}</div>
+              <div className="text-[10px] sm:text-xs font-bold text-white truncate">{region.name}</div>
+              <div className="text-[9px] text-slate-400">
+                {DIFFICULTY_LABELS[region.difficulty]}
+              </div>
+              {!accessible && (
+                <div className="text-[9px] text-red-400 font-semibold">
+                  Lv.{region.minLevel}+
+                </div>
+              )}
+              {isCurrent && (
+                <div className="text-[9px] text-emerald-400 font-bold">You are here</div>
+              )}
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- New `RegionMap` component showing all 8 game regions as positioned nodes
- Dashed connection lines between connected regions
- Difficulty color-coding: green (easy), yellow (medium), orange (hard), red (very hard)
- Current region highlighted with white ring and "You are here" label
- Inaccessible regions shown dimmed/greyed with level requirement badge
- Available on desktop sidebar and mobile tab bar (Map tab)

## Layout
```
         Sky Citadel
       /     |      \
  Scorched  Frozen   Shadow
  Wastes    Peaks    Realm
      |       |       |
  Dark       Crystal  |
  Forest     Caves   /
       \      /    /
      Green Meadows
           |
    Starting Village
```

## Test plan
- [ ] Verify map renders on desktop sidebar below inventory
- [ ] Open Map tab on mobile — verify layout and positioning
- [ ] Current region should be highlighted with ring
- [ ] Locked regions (level too low) should appear dimmed with level requirement
- [ ] Connection lines visible between connected regions
- [ ] Hover on region shows description tooltip

Closes #120

🤖 Generated with [Claude Code](https://claude.com/claude-code)