### PR TITLE
Add settings panel with sound toggle

### DIFF
--- a/src/app/tap-tap-adventure/components/GameUI.tsx
+++ b/src/app/tap-tap-adventure/components/GameUI.tsx
@@ -30,6 +30,7 @@ import { ShopUI } from './ShopUI'
 import { SkillPanel } from './SkillPanel'
 import { StoryFeed } from './StoryFeed'
 import { RegionMap } from './RegionMap'
+import { SettingsPanel } from './SettingsPanel'
 
 const DIFFICULTY_STYLES: Record<RegionDifficulty, { label: string; color: string }> = {
   easy: { label: 'Easy', color: 'bg-green-900/50 text-green-300 border-green-600/40' },
@@ -67,7 +68,7 @@ function getTravelButtonMessage({ isLoading, distance }: { isLoading: boolean; d
   if (distance === 0) return 'Start Your Adventure'
   return 'Continue Travelling'
 }
-type MobilePanel = 'equipment' | 'inventory' | 'skills' | 'quest' | 'map' | null
+type MobilePanel = 'equipment' | 'inventory' | 'skills' | 'quest' | 'map' | 'settings' | null
 
 export default function GameUI() {
   const {
@@ -445,6 +446,9 @@ export default function GameUI() {
                 characterLevel={character?.level ?? 1}
               />
             </div>
+            <div className="border-t border-[#3a3c56] pt-4">
+              <SettingsPanel />
+            </div>
           </div>
         </div>
         {/* Two-column grid END */}
@@ -461,7 +465,7 @@ export default function GameUI() {
           >
             <div className="flex justify-between items-center mb-2">
               <h3 className="text-sm font-semibold text-slate-300 uppercase">
-                {mobilePanel === 'equipment' ? 'Equipment' : mobilePanel === 'inventory' ? 'Inventory' : mobilePanel === 'skills' ? 'Skills' : mobilePanel === 'map' ? 'Map' : 'Quest'}
+                {mobilePanel === 'equipment' ? 'Equipment' : mobilePanel === 'inventory' ? 'Inventory' : mobilePanel === 'skills' ? 'Skills' : mobilePanel === 'map' ? 'Map' : mobilePanel === 'settings' ? 'Settings' : 'Quest'}
               </h3>
               <button
                 className="text-slate-400 hover:text-white text-sm px-2 py-1"
@@ -491,6 +495,7 @@ export default function GameUI() {
                 characterLevel={character?.level ?? 1}
               />
             )}
+            {mobilePanel === 'settings' && <SettingsPanel />}
           </div>
         </div>
       )}
@@ -503,6 +508,7 @@ export default function GameUI() {
           { id: 'skills' as MobilePanel, label: 'Skills', icon: '\u2728' },
           { id: 'quest' as MobilePanel, label: 'Quest', icon: '\uD83D\uDCDC' },
           { id: 'map' as MobilePanel, label: 'Map', icon: '\uD83D\uDDFA' },
+          { id: 'settings' as MobilePanel, label: 'Settings', icon: '\u2699' },
         ]).map(tab => (
           <button
             key={tab.id}

--- a/src/app/tap-tap-adventure/components/SettingsPanel.tsx
+++ b/src/app/tap-tap-adventure/components/SettingsPanel.tsx
@@ -1,0 +1,45 @@
+'use client'
+
+import { useState } from 'react'
+import { soundEngine } from '@/app/tap-tap-adventure/lib/soundEngine'
+
+export function SettingsPanel() {
+  const [soundEnabled, setSoundEnabled] = useState(soundEngine.isEnabled())
+
+  const toggleSound = () => {
+    const newValue = !soundEnabled
+    soundEngine.setEnabled(newValue)
+    setSoundEnabled(newValue)
+    try {
+      localStorage.setItem('tta-sound-enabled', JSON.stringify(newValue))
+    } catch {
+      // localStorage may not be available
+    }
+  }
+
+  return (
+    <div className="w-full flex flex-col">
+      <h3 className="text-lg font-semibold text-white mb-3">Settings</h3>
+      <div className="space-y-3">
+        <div className="flex items-center justify-between bg-[#1e1f30] border border-[#3a3c56] p-3 rounded-lg">
+          <div>
+            <div className="text-sm font-medium text-white">Sound Effects</div>
+            <div className="text-xs text-slate-400">Toggle game audio</div>
+          </div>
+          <button
+            onClick={toggleSound}
+            className={`relative w-11 h-6 rounded-full transition-colors ${
+              soundEnabled ? 'bg-indigo-600' : 'bg-slate-600'
+            }`}
+          >
+            <span
+              className={`absolute top-0.5 left-0.5 w-5 h-5 rounded-full bg-white transition-transform ${
+                soundEnabled ? 'translate-x-5' : 'translate-x-0'
+              }`}
+            />
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/app/tap-tap-adventure/lib/soundEngine.ts
+++ b/src/app/tap-tap-adventure/lib/soundEngine.ts
@@ -4,6 +4,17 @@ class SoundEngine {
   private ctx: AudioContext | null = null
   private enabled: boolean = true
 
+  constructor() {
+    try {
+      if (typeof window !== 'undefined') {
+        const stored = localStorage.getItem('tta-sound-enabled')
+        if (stored !== null) this.enabled = JSON.parse(stored)
+      }
+    } catch {
+      // localStorage may not be available during SSR
+    }
+  }
+
   private getContext(): AudioContext | null {
     if (!this.ctx) {
       try {


### PR DESCRIPTION
## Summary
- New `SettingsPanel` component with a sound on/off toggle switch
- Sound preference persisted to `localStorage` (`tta-sound-enabled` key)
- Sound engine restores preference on page load via constructor
- Accessible from desktop sidebar and mobile tab bar (Settings tab with gear icon)

## Test plan
- [ ] Toggle sound off — verify tap and combat sounds stop playing
- [ ] Toggle sound on — verify sounds resume
- [ ] Refresh page — verify sound preference is remembered
- [ ] Check desktop sidebar — settings panel visible below region map
- [ ] Check mobile — Settings tab accessible in bottom bar

Closes #127

🤖 Generated with [Claude Code](https://claude.com/claude-code)