### PR TITLE
feat: add new player onboarding tooltips

### DIFF
--- a/src/app/tap-tap-adventure/components/GameUI.tsx
+++ b/src/app/tap-tap-adventure/components/GameUI.tsx
@@ -31,6 +31,8 @@ import { StoryFeed } from './StoryFeed'
 import { RegionMap } from './RegionMap'
 import { SettingsPanel } from './SettingsPanel'
 import { KeyboardHelp } from './KeyboardHelp'
+import { OnboardingHint } from './OnboardingHint'
+import { useOnboarding, HintKey } from '@/app/tap-tap-adventure/hooks/useOnboarding'
 
 const DIFFICULTY_STYLES: Record<RegionDifficulty, { label: string; color: string }> = {
   easy: { label: 'Easy', color: 'bg-green-900/50 text-green-300 border-green-600/40' },
@@ -46,6 +48,25 @@ const ELEMENT_STYLES: Record<string, { color: string }> = {
   fire: { color: 'bg-orange-900/40 text-orange-300' },
   ice: { color: 'bg-cyan-900/40 text-cyan-300' },
   none: { color: 'bg-slate-800/40 text-slate-400' },
+}
+
+const ONBOARDING_HINTS: Record<HintKey, { title: string; body: string }> = {
+  'first-tap': {
+    title: 'Welcome, Adventurer!',
+    body: 'Tap or hold the travel button to explore the world. Events will appear as you journey forward!',
+  },
+  'first-combat': {
+    title: 'Combat Begins!',
+    body: 'You have Action Points (AP) each turn. Attacks, spells, and abilities each cost AP. Plan your moves carefully — when your AP runs out, your turn ends!',
+  },
+  'first-item': {
+    title: 'Item Found!',
+    body: 'Check your inventory to equip or use items. Weapons and armor make you stronger — open your equipment panel to gear up!',
+  },
+  'first-crossroads': {
+    title: 'Choose Your Path',
+    body: 'A decision lies ahead! Choose wisely — harder paths offer better rewards, but greater danger.',
+  },
 }
 
 function getTimeOfDay(distance: number): string {
@@ -105,6 +126,18 @@ export default function GameUI({ onOpenStatus }: GameUIProps) {
     useResolveDecisionMutation()
 
   const character = getSelectedCharacter()
+
+  const { hasSeenHint, markHintSeen } = useOnboarding(character?.id)
+
+  // Determine which onboarding hint to show (priority order)
+  const activeHint: HintKey | null = (() => {
+    if (!character) return null
+    if (gameState.combatState?.status === 'active' && !hasSeenHint('first-combat')) return 'first-combat'
+    if (gameState.decisionPoint && !hasSeenHint('first-crossroads')) return 'first-crossroads'
+    if (character.inventory.length > 0 && !hasSeenHint('first-item')) return 'first-item'
+    if (character.distance === 0 && !hasSeenHint('first-tap')) return 'first-tap'
+    return null
+  })()
 
   const handleResolveDecision = (optionId: string) => {
     resolveDecisionMutation({
@@ -278,6 +311,13 @@ export default function GameUI({ onOpenStatus }: GameUIProps) {
           reward={getDailyReward(gameState.dailyReward?.streak ?? 0)}
           onClaim={() => claimDailyReward()}
           onDismiss={() => setShowDailyReward(false)}
+        />
+      )}
+      {activeHint && (
+        <OnboardingHint
+          title={ONBOARDING_HINTS[activeHint].title}
+          body={ONBOARDING_HINTS[activeHint].body}
+          onDismiss={() => markHintSeen(activeHint)}
         />
       )}
       {character && (character.pendingStatPoints ?? 0) > 0 && (

--- a/src/app/tap-tap-adventure/components/OnboardingHint.tsx
+++ b/src/app/tap-tap-adventure/components/OnboardingHint.tsx
@@ -1,0 +1,60 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { Button } from '@/app/tap-tap-adventure/components/ui/button'
+
+interface OnboardingHintProps {
+  title: string
+  body: string
+  onDismiss: () => void
+}
+
+export function OnboardingHint({ title, body, onDismiss }: OnboardingHintProps) {
+  const [isVisible, setIsVisible] = useState(false)
+
+  useEffect(() => {
+    requestAnimationFrame(() => setIsVisible(true))
+  }, [])
+
+  useEffect(() => {
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape' || e.key === 'Enter') {
+        setIsVisible(false)
+        setTimeout(onDismiss, 300)
+      }
+    }
+    window.addEventListener('keydown', handleKey)
+    return () => window.removeEventListener('keydown', handleKey)
+  }, [onDismiss])
+
+  const handleDismiss = () => {
+    setIsVisible(false)
+    setTimeout(onDismiss, 300)
+  }
+
+  return (
+    <div
+      className={`fixed inset-0 z-[60] flex items-center justify-center transition-opacity duration-300 ${
+        isVisible ? 'opacity-100' : 'opacity-0'
+      }`}
+    >
+      <div className="absolute inset-0 bg-black/60" onClick={handleDismiss} />
+      <div
+        className={`relative transition-all duration-500 ${
+          isVisible ? 'scale-100 translate-y-0' : 'scale-75 translate-y-8'
+        }`}
+      >
+        <div className="bg-gradient-to-b from-[#1e1f30] to-[#161723] border-2 border-amber-500/50 rounded-2xl px-8 py-6 text-center shadow-2xl shadow-amber-500/20 max-w-sm mx-4">
+          <p className="text-amber-400 font-bold text-lg mb-3">{title}</p>
+          <p className="text-slate-300 text-sm leading-relaxed mb-5">{body}</p>
+          <Button
+            className="bg-amber-600 hover:bg-amber-500 text-white px-6 py-2 rounded-md"
+            onClick={handleDismiss}
+          >
+            Got it!
+          </Button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/app/tap-tap-adventure/hooks/useOnboarding.ts
+++ b/src/app/tap-tap-adventure/hooks/useOnboarding.ts
@@ -1,0 +1,34 @@
+'use client'
+
+import { useCallback, useState } from 'react'
+
+const HINT_KEYS = ['first-tap', 'first-combat', 'first-item', 'first-crossroads'] as const
+export type HintKey = (typeof HINT_KEYS)[number]
+
+function storageKey(characterId: string, hint: HintKey): string {
+  return `tta-onboarding-${characterId}-${hint}`
+}
+
+export function useOnboarding(characterId: string | null | undefined) {
+  // Counter to force re-render when a hint is dismissed
+  const [, setTick] = useState(0)
+
+  const hasSeenHint = useCallback(
+    (hint: HintKey): boolean => {
+      if (!characterId || typeof window === 'undefined') return false
+      return localStorage.getItem(storageKey(characterId, hint)) === '1'
+    },
+    [characterId]
+  )
+
+  const markHintSeen = useCallback(
+    (hint: HintKey) => {
+      if (!characterId || typeof window === 'undefined') return
+      localStorage.setItem(storageKey(characterId, hint), '1')
+      setTick(t => t + 1)
+    },
+    [characterId]
+  )
+
+  return { hasSeenHint, markHintSeen }
+}


### PR DESCRIPTION
## Summary
Closes #130

- **4 contextual onboarding hints** shown once per character at key gameplay moments:
  - **First tap** — explains travel mechanic when distance is 0
  - **First combat** — explains AP system when combat starts
  - **First item** — prompts to check inventory/equipment
  - **First crossroads** — explains decision-making and difficulty/reward tradeoffs
- **localStorage persistence** per character ID — hints never re-appear after dismissal
- **Reusable `OnboardingHint` component** with fade-in animation, backdrop, and Escape/Enter dismiss
- **Priority system** — only one hint shown at a time (combat > crossroads > item > tap)

## Files changed
- `src/app/tap-tap-adventure/hooks/useOnboarding.ts` (new) — hook for localStorage hint state
- `src/app/tap-tap-adventure/components/OnboardingHint.tsx` (new) — modal overlay component
- `src/app/tap-tap-adventure/components/GameUI.tsx` — integration: imports, hint content, trigger logic, render

## Test plan
- [ ] New character: "Welcome, Adventurer!" hint appears before first tap; dismiss and reload — does not reappear
- [ ] First combat: "Combat Begins!" hint appears explaining AP; dismiss and enter combat again — no hint
- [ ] First item in inventory: "Item Found!" hint appears
- [ ] First decision point: "Choose Your Path" hint appears
- [ ] Second character: all 4 hints appear fresh (separate localStorage keys)
- [ ] Escape/Enter keys dismiss the active hint
- [ ] Hint sits above mobile bottom tab bar (z-[60])
- [ ] Victory/defeat/flee screens are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)