### PR TITLE
feat: add combat animations — floating damage, crit flash, combo pulse

### DIFF
--- a/src/app/tap-tap-adventure/components/CombatUI.tsx
+++ b/src/app/tap-tap-adventure/components/CombatUI.tsx
@@ -15,6 +15,7 @@ import { CombatAction, CombatState, StatusEffect } from '@/app/tap-tap-adventure
 import { Spell } from '@/app/tap-tap-adventure/models/spell'
 import { Item } from '@/app/tap-tap-adventure/models/types'
 import { getDeathFlavorText, getStoryContext, getPermadeathEpitaph } from '@/app/tap-tap-adventure/lib/deathFlavorText'
+import { FloatingDamage, DamageEvent } from './FloatingDamage'
 
 function HpBar({ current, max, label, color }: { current: number; max: number; label: string; color: string }) {
   const pct = Math.max(0, Math.min(100, (current / max) * 100))
@@ -96,9 +97,54 @@ export function CombatUI({ combatState }: CombatUIProps) {
   const [showFullLog, setShowFullLog] = useState(false)
   const [showEnemyDesc, setShowEnemyDesc] = useState(false)
   const logRef = useRef<HTMLDivElement>(null)
+  const [damageEvents, setDamageEvents] = useState<DamageEvent[]>([])
+  const [showCritFlash, setShowCritFlash] = useState(false)
+  const [comboKey, setComboKey] = useState(0)
+  const prevLogLenRef = useRef(0)
+  const prevComboRef = useRef(0)
 
   const character = getSelectedCharacter()
   const { enemy, playerState, combatLog, scenario, status } = combatState
+
+  // Detect new combat log entries and create floating damage events
+  useEffect(() => {
+    const prevLen = prevLogLenRef.current
+    if (combatLog.length > prevLen) {
+      const newEntries = combatLog.slice(prevLen)
+      const newDamageEvents: DamageEvent[] = newEntries
+        .filter(entry => entry.damage && entry.damage > 0)
+        .map((entry, i) => ({
+          id: `${combatLog.length}-${i}-${Date.now()}`,
+          amount: entry.damage!,
+          isCritical: entry.isCritical ?? false,
+          target: entry.actor === 'enemy' ? 'player' : 'enemy',
+        }))
+
+      if (newDamageEvents.length > 0) {
+        setDamageEvents(prev => [...prev, ...newDamageEvents])
+        // Auto-cleanup after animation
+        setTimeout(() => {
+          setDamageEvents(prev => prev.filter(e => !newDamageEvents.some(ne => ne.id === e.id)))
+        }, 1100)
+      }
+
+      // Critical hit flash
+      if (newEntries.some(e => e.isCritical)) {
+        setShowCritFlash(true)
+        setTimeout(() => setShowCritFlash(false), 500)
+      }
+    }
+    prevLogLenRef.current = combatLog.length
+  }, [combatLog])
+
+  // Combo pulse detection
+  useEffect(() => {
+    const currentCombo = playerState.comboCount ?? 0
+    if (currentCombo > prevComboRef.current && currentCombo > 0) {
+      setComboKey(k => k + 1)
+    }
+    prevComboRef.current = currentCombo
+  }, [playerState.comboCount])
 
   const combatItems = (character?.inventory ?? []).filter(
     (i: Item) => i.status !== 'deleted' && isUsableInCombat(i)
@@ -195,6 +241,10 @@ export function CombatUI({ combatState }: CombatUIProps) {
 
   return (
     <div className="space-y-4">
+      {/* Critical hit flash overlay */}
+      {showCritFlash && (
+        <div className="fixed inset-0 z-[55] pointer-events-none bg-yellow-400/20 animate-crit-flash" />
+      )}
       {/* Header */}
       <div className="text-center">
         <h4 className="font-semibold uppercase border-b border-red-900/50 pb-2 mb-2">
@@ -208,7 +258,7 @@ export function CombatUI({ combatState }: CombatUIProps) {
       </div>
 
       {/* Enemy info — condensed for mobile */}
-      <div className="bg-[#1e1f30] border border-red-900/30 rounded-lg p-2 sm:p-3 space-y-1">
+      <div className="relative bg-[#1e1f30] border border-red-900/30 rounded-lg p-2 sm:p-3 space-y-1">
         <div className="flex items-center gap-2 flex-wrap">
           <span className="font-bold text-red-400 text-sm">{enemy.name}</span>
           <span className="text-xs text-slate-400">Lv.{enemy.level}</span>
@@ -234,6 +284,7 @@ export function CombatUI({ combatState }: CombatUIProps) {
         )}
         <HpBar current={enemy.hp} max={enemy.maxHp} label="Enemy" color="text-red-400" />
         <StatusEffectBadges effects={enemy.statusEffects ?? []} label="Enemy" />
+        <FloatingDamage events={damageEvents.filter(e => e.target === 'enemy')} />
       </div>
 
       {/* Enemy telegraph warning */}
@@ -250,12 +301,12 @@ export function CombatUI({ combatState }: CombatUIProps) {
       )}
 
       {/* Player info — compact for mobile */}
-      <div className="bg-[#1e1f30] border border-blue-900/30 rounded-lg p-2 sm:p-3 space-y-1">
+      <div className="relative bg-[#1e1f30] border border-blue-900/30 rounded-lg p-2 sm:p-3 space-y-1">
         <div className="flex justify-between items-center">
           <span className="font-bold text-blue-400 text-sm">{character?.name ?? 'You'}</span>
           <div className="flex gap-1 flex-wrap">
             {(playerState.comboCount ?? 0) > 0 && (
-              <span className="text-[10px] px-1.5 py-0.5 bg-orange-900/50 text-orange-400 rounded font-bold">
+              <span key={comboKey} className="text-[10px] px-1.5 py-0.5 bg-orange-900/50 text-orange-400 rounded font-bold animate-combo-pulse">
                 {playerState.comboCount}x Combo
               </span>
             )}
@@ -317,6 +368,7 @@ export function CombatUI({ combatState }: CombatUIProps) {
             })}
           </div>
         )}
+        <FloatingDamage events={damageEvents.filter(e => e.target === 'player')} />
       </div>
 
       {/* Combat Log — collapsed by default on mobile, show last 2 entries */}

--- a/src/app/tap-tap-adventure/components/FloatingDamage.tsx
+++ b/src/app/tap-tap-adventure/components/FloatingDamage.tsx
@@ -1,0 +1,59 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+
+export interface DamageEvent {
+  id: string
+  amount: number
+  isCritical: boolean
+  target: 'player' | 'enemy'
+}
+
+interface FloatingDamageProps {
+  events: DamageEvent[]
+}
+
+export function FloatingDamage({ events }: FloatingDamageProps) {
+  return (
+    <>
+      {events.map(event => (
+        <FloatingNumber key={event.id} event={event} />
+      ))}
+    </>
+  )
+}
+
+function FloatingNumber({ event }: { event: DamageEvent }) {
+  const [visible, setVisible] = useState(true)
+
+  useEffect(() => {
+    const timer = setTimeout(() => setVisible(false), 1000)
+    return () => clearTimeout(timer)
+  }, [])
+
+  if (!visible) return null
+
+  const isPlayer = event.target === 'player'
+  const color = event.isCritical
+    ? 'text-yellow-300'
+    : isPlayer
+      ? 'text-red-400'
+      : 'text-green-400'
+  const size = event.isCritical ? 'text-lg font-black' : 'text-sm font-bold'
+  // Stagger horizontal position slightly based on id hash
+  const offset = ((event.id.charCodeAt(0) ?? 0) % 5) * 10 - 20
+
+  return (
+    <span
+      className={`absolute animate-float-up pointer-events-none ${color} ${size} drop-shadow-lg`}
+      style={{
+        left: `calc(50% + ${offset}px)`,
+        top: isPlayer ? '0' : '0',
+      }}
+    >
+      {event.isCritical && '★ '}
+      {isPlayer ? `-${event.amount}` : `-${event.amount}`}
+      {event.isCritical && ' ★'}
+    </span>
+  )
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -89,10 +89,26 @@ const config = {
             height: '0',
           },
         },
+        'float-up': {
+          '0%': { opacity: '1', transform: 'translateY(0) scale(1)' },
+          '100%': { opacity: '0', transform: 'translateY(-40px) scale(0.8)' },
+        },
+        'crit-flash': {
+          '0%': { opacity: '0.7' },
+          '100%': { opacity: '0' },
+        },
+        'combo-pulse': {
+          '0%': { transform: 'scale(1)', boxShadow: '0 0 0 0 rgba(251, 146, 60, 0.7)' },
+          '50%': { transform: 'scale(1.15)', boxShadow: '0 0 12px 4px rgba(251, 146, 60, 0.4)' },
+          '100%': { transform: 'scale(1)', boxShadow: '0 0 0 0 rgba(251, 146, 60, 0)' },
+        },
       },
       animation: {
         'accordion-down': 'accordion-down 0.2s ease-out',
         'accordion-up': 'accordion-up 0.2s ease-out',
+        'float-up': 'float-up 1s ease-out forwards',
+        'crit-flash': 'crit-flash 0.5s ease-out forwards',
+        'combo-pulse': 'combo-pulse 0.6s ease-out',
       },
     },
   },


### PR DESCRIPTION
## Summary
Partial implementation of #133

Adds three core combat animations that provide immediate visual feedback during fights:

- **Floating damage numbers** — numbers rise and fade from HP bars when damage is dealt. Color-coded: red for damage taken, green for damage dealt, yellow for critical hits. Positioned relative to the target's info panel.
- **Critical hit flash** — brief yellow screen flash (0.5s) when any critical strike lands, complementing the existing yellow text + sound effect.
- **Combo pulse** — orange glow pulse animation on the combo badge when combo count increases, using React key remount to replay the CSS animation.

### Technical approach
- Custom Tailwind keyframes (`float-up`, `crit-flash`, `combo-pulse`) in tailwind.config.js
- New `FloatingDamage` component with auto-cleanup after animation
- Combat log diff detection via `useEffect` + `useRef` to create damage events from new log entries
- No new dependencies

## Files changed
- `tailwind.config.js` — 3 new keyframes + animation utilities
- `src/app/tap-tap-adventure/components/FloatingDamage.tsx` (new) — floating number component
- `src/app/tap-tap-adventure/components/CombatUI.tsx` — damage event tracking, crit flash overlay, combo pulse, floating damage integration

## Test plan
- [ ] Enter combat → attack enemy → floating green damage number rises from enemy HP bar
- [ ] Enemy attacks player → floating red damage number rises from player HP bar
- [ ] Land a critical hit → yellow floating number with stars + brief yellow screen flash
- [ ] Build combo (consecutive attacks) → combo badge pulses orange each time it increases
- [ ] Victory/defeat/flee screens are unaffected
- [ ] Mobile layout unaffected (floating numbers use absolute positioning within relative containers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)