### PR TITLE
feat: visual feedback for status effects and elemental matchups

### DIFF
--- a/src/app/tap-tap-adventure/components/CombatUI.tsx
+++ b/src/app/tap-tap-adventure/components/CombatUI.tsx
@@ -58,6 +58,17 @@ function ManaBar({ current, max }: { current: number; max: number }) {
 function StatusEffectBadges({ effects, label }: { effects: StatusEffect[]; label: string }) {
   if (effects.length === 0) return null
 
+  const iconMap: Record<string, string> = {
+    poison: '☠️',
+    burn: '🔥',
+    slow: '🐌',
+    curse: '💀',
+    thorns: '🌿',
+    berserk: '😡',
+    fear: '😨',
+    reflect: '🪞',
+  }
+
   const colorMap: Record<string, string> = {
     poison: 'bg-green-900/50 text-green-400',
     burn: 'bg-orange-900/50 text-orange-400',
@@ -77,7 +88,7 @@ function StatusEffectBadges({ effects, label }: { effects: StatusEffect[]; label
           className={`text-[10px] px-1.5 py-0.5 rounded ${colorMap[effect.type] ?? 'bg-slate-700/50 text-slate-300'}`}
           title={`${effect.name}: ${effect.value > 0 ? effect.value + ' per turn, ' : ''}${effect.turnsRemaining} turns remaining`}
         >
-          {effect.name} ({effect.turnsRemaining}t)
+          {iconMap[effect.type] ?? '⬡'} {effect.name} ({effect.turnsRemaining}t)
         </span>
       ))}
     </div>
@@ -102,6 +113,7 @@ export function CombatUI({ combatState }: CombatUIProps) {
   const [comboKey, setComboKey] = useState(0)
   const prevLogLenRef = useRef(0)
   const prevComboRef = useRef(0)
+  const [effectivenessFlash, setEffectivenessFlash] = useState<'super' | 'resisted' | null>(null)
 
   const character = getSelectedCharacter()
   const { enemy, playerState, combatLog, scenario, status } = combatState
@@ -113,12 +125,29 @@ export function CombatUI({ combatState }: CombatUIProps) {
       const newEntries = combatLog.slice(prevLen)
       const newDamageEvents: DamageEvent[] = newEntries
         .filter(entry => entry.damage && entry.damage > 0)
-        .map((entry, i) => ({
-          id: `${combatLog.length}-${i}-${Date.now()}`,
-          amount: entry.damage!,
-          isCritical: entry.isCritical ?? false,
-          target: entry.actor === 'enemy' ? 'player' : 'enemy',
-        }))
+        .map((entry, i) => {
+          const isDot = entry.action === 'status_effect'
+          const dotType = isDot
+            ? entry.description.toLowerCase().includes('poison') ? 'poison' as const
+              : entry.description.toLowerCase().includes('burn') ? 'burn' as const
+              : undefined
+            : undefined
+
+          // Detect elemental effectiveness from description
+          let effectiveness: 'super' | 'resisted' | null = null
+          if (entry.description.includes('Super effective')) effectiveness = 'super'
+          else if (entry.description.includes('Resisted')) effectiveness = 'resisted'
+
+          return {
+            id: `${combatLog.length}-${i}-${Date.now()}`,
+            amount: entry.damage!,
+            isCritical: entry.isCritical ?? false,
+            target: (entry.actor === 'enemy' ? 'player' : 'enemy') as 'player' | 'enemy',
+            isDot,
+            dotType,
+            effectiveness,
+          }
+        })
 
       if (newDamageEvents.length > 0) {
         setDamageEvents(prev => [...prev, ...newDamageEvents])
@@ -132,6 +161,16 @@ export function CombatUI({ combatState }: CombatUIProps) {
       if (newEntries.some(e => e.isCritical)) {
         setShowCritFlash(true)
         setTimeout(() => setShowCritFlash(false), 500)
+      }
+
+      // Elemental effectiveness flash
+      const effectivenessEntry = newEntries.find(e =>
+        e.description.includes('Super effective') || e.description.includes('Resisted')
+      )
+      if (effectivenessEntry) {
+        const type = effectivenessEntry.description.includes('Super effective') ? 'super' : 'resisted'
+        setEffectivenessFlash(type)
+        setTimeout(() => setEffectivenessFlash(null), 1200)
       }
     }
     prevLogLenRef.current = combatLog.length
@@ -244,6 +283,18 @@ export function CombatUI({ combatState }: CombatUIProps) {
       {/* Critical hit flash overlay */}
       {showCritFlash && (
         <div className="fixed inset-0 z-[55] pointer-events-none bg-yellow-400/20 animate-crit-flash" />
+      )}
+      {/* Elemental effectiveness flash */}
+      {effectivenessFlash && (
+        <div className="absolute inset-x-0 top-1 z-10 flex justify-center pointer-events-none">
+          <span className={`text-sm font-bold px-3 py-1 rounded-full animate-float-up ${
+            effectivenessFlash === 'super'
+              ? 'text-yellow-300 bg-yellow-900/60 border border-yellow-500/40'
+              : 'text-blue-300 bg-blue-900/60 border border-blue-500/40'
+          }`}>
+            {effectivenessFlash === 'super' ? '⚡ Super Effective!' : '🛡️ Resisted!'}
+          </span>
+        </div>
       )}
       {/* Header */}
       <div className="text-center">
@@ -389,7 +440,14 @@ export function CombatUI({ combatState }: CombatUIProps) {
               >
                 <span className="text-slate-500">T{entry.turn}:</span>{' '}
                 {entry.isCritical && <span className="text-yellow-400 mr-1">&#9733;</span>}
-                {entry.description}
+                {entry.action === 'status_effect' && <span className="mr-1">{entry.description.toLowerCase().includes('poison') ? '☠️' : '🔥'}</span>}
+                {entry.description.includes('Super effective') ? (
+                  <>{entry.description.replace('Super effective!', '')}<span className="text-yellow-400 font-bold"> Super effective!</span></>
+                ) : entry.description.includes('Resisted') ? (
+                  <>{entry.description.replace('Resisted!', '')}<span className="text-blue-400 font-bold"> Resisted!</span></>
+                ) : (
+                  entry.description
+                )}
               </div>
             ))}
           </div>

--- a/src/app/tap-tap-adventure/components/FloatingDamage.tsx
+++ b/src/app/tap-tap-adventure/components/FloatingDamage.tsx
@@ -7,6 +7,9 @@ export interface DamageEvent {
   amount: number
   isCritical: boolean
   target: 'player' | 'enemy'
+  isDot: boolean        // true for poison/burn tick damage
+  dotType?: 'poison' | 'burn'  // which status effect
+  effectiveness?: 'super' | 'resisted' | null  // elemental matchup
 }
 
 interface FloatingDamageProps {
@@ -34,12 +37,22 @@ function FloatingNumber({ event }: { event: DamageEvent }) {
   if (!visible) return null
 
   const isPlayer = event.target === 'player'
+  // Color by damage type
   const color = event.isCritical
     ? 'text-yellow-300'
-    : isPlayer
-      ? 'text-red-400'
-      : 'text-green-400'
-  const size = event.isCritical ? 'text-lg font-black' : 'text-sm font-bold'
+    : event.isDot && event.dotType === 'poison'
+      ? 'text-green-400'
+      : event.isDot && event.dotType === 'burn'
+        ? 'text-orange-400'
+        : isPlayer
+          ? 'text-red-400'
+          : 'text-green-400'
+
+  const size = event.isCritical
+    ? 'text-lg font-black'
+    : event.isDot
+      ? 'text-xs font-semibold italic'
+      : 'text-sm font-bold'
   // Stagger horizontal position slightly based on id hash
   const offset = ((event.id.charCodeAt(0) ?? 0) % 5) * 10 - 20
 
@@ -48,11 +61,11 @@ function FloatingNumber({ event }: { event: DamageEvent }) {
       className={`absolute animate-float-up pointer-events-none ${color} ${size} drop-shadow-lg`}
       style={{
         left: `calc(50% + ${offset}px)`,
-        top: isPlayer ? '0' : '0',
+        top: '0',
       }}
     >
       {event.isCritical && '★ '}
-      {isPlayer ? `-${event.amount}` : `-${event.amount}`}
+      {event.isDot ? `${event.amount} ${event.dotType}` : `-${event.amount}`}
       {event.isCritical && ' ★'}
     </span>
   )


### PR DESCRIPTION
## Summary
Closes #134

Enhances combat visual feedback so players understand what's happening mechanically:

- **Status effect icons** — each badge now has a Unicode icon: poison ☠️, burn 🔥, slow 🐌, curse 💀, thorns 🌿, berserk 😡, fear 😨, reflect 🪞
- **Elemental matchup indicator** — "⚡ Super Effective!" (yellow) or "🛡️ Resisted!" (blue) flash banner appears above combat when elemental multipliers trigger
- **Damage type coloring** — floating damage numbers are now colored by type: green for poison ticks, orange for burn ticks, yellow for criticals. DoT damage uses smaller italic text to visually distinguish from attack damage.
- **Combat log enhancements** — effectiveness text highlighted in bold yellow/blue, status tick entries get matching poison/burn icons

### Technical approach
All changes are client-side only — no model or server changes. Elemental effectiveness and damage types are detected from the existing combat log data (description text matching and action field).

## Files changed
- `src/app/tap-tap-adventure/components/FloatingDamage.tsx` — extended DamageEvent with isDot/dotType/effectiveness, updated color+size logic
- `src/app/tap-tap-adventure/components/CombatUI.tsx` — effectiveness flash state+overlay, status effect icons, enriched damage event creation, combat log formatting

## Test plan
- [ ] Enter combat against elemental enemy → attack → verify "Super Effective!" or "Resisted!" flash when matchup triggers
- [ ] Get poisoned → verify green floating "N poison" tick damage (smaller, italic)
- [ ] Get burned → verify orange floating "N burn" tick damage
- [ ] Check status effect badges show icons (☠️🔥🐌💀🌿😡😨🪞)
- [ ] Combat log: effectiveness text highlighted in yellow/blue bold
- [ ] Combat log: status tick entries prefixed with poison/burn icons
- [ ] Non-elemental combat is unaffected (no false positive flashes)
- [ ] Mobile layout unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)