### PR TITLE
feat: boss-gated region travel

### DIFF
--- a/src/app/api/v1/tap-tap-adventure/combat/start/route.ts
+++ b/src/app/api/v1/tap-tap-adventure/combat/start/route.ts
@@ -9,7 +9,7 @@ import { CombatState } from '@/app/tap-tap-adventure/models/combat'
 
 export async function POST(req: NextRequest) {
   try {
-    const { character, storyEvents = [], eventContext, isBoss = false } = await req.json()
+    const { character, storyEvents = [], eventContext, isBoss = false, pendingRegionId } = await req.json()
     const storyContext = buildStoryContext(character, storyEvents)
     const fullContext = eventContext
       ? `The player chose to fight in this situation: "${eventContext}"\n\nGenerate an enemy that matches this encounter. The enemy should be the creature or opponent described in the event above.\n\n${storyContext}`
@@ -44,6 +44,7 @@ export async function POST(req: NextRequest) {
       status: 'active',
       scenario,
       isBoss,
+      ...(pendingRegionId ? { pendingRegionId } : {}),
     }
 
     return NextResponse.json({ combatState })

--- a/src/app/api/v1/tap-tap-adventure/move-forward/services/moveForwardService.ts
+++ b/src/app/api/v1/tap-tap-adventure/move-forward/services/moveForwardService.ts
@@ -4,7 +4,6 @@ import { buildStoryContext } from '@/app/tap-tap-adventure/lib/contextBuilder'
 import { generateLLMEvents } from '@/app/tap-tap-adventure/lib/llmEventGenerator'
 import {
   crossedMilestone,
-  BOSS_MILESTONE_INTERVAL,
   SHOP_MILESTONE_INTERVAL,
   calculateDay,
 } from '@/app/tap-tap-adventure/lib/leveling'
@@ -21,51 +20,6 @@ export async function moveForwardService(
   const updatedCharacter = { ...character, distance: newDistance }
   const day = calculateDay(newDistance)
 
-  // Trigger boss event every BOSS_MILESTONE_INTERVAL steps (500)
-  if (crossedMilestone(character.distance, newDistance, BOSS_MILESTONE_INTERVAL)) {
-    const bossEventId = `boss-event-${Date.now()}`
-    return {
-      character: updatedCharacter,
-      event: {
-        id: bossEventId,
-        type: 'boss_available',
-        characterId: character.id,
-        locationId: character.locationId,
-        timestamp: new Date().toISOString(),
-      },
-      decisionPoint: {
-        id: `decision-${bossEventId}`,
-        eventId: bossEventId,
-        prompt: `You sense a powerful presence ahead. A formidable guardian blocks the path forward. You have traveled ${newDistance} steps on day ${day} — do you feel ready to face this challenge?`,
-        options: [
-          {
-            id: `boss-fight-${bossEventId}`,
-            text: 'Challenge the boss!',
-            triggersCombat: true,
-            isBoss: true,
-            successProbability: 0.5,
-            successDescription: 'You prepare for an epic battle!',
-            successEffects: {},
-            failureDescription: 'You prepare for an epic battle!',
-            failureEffects: {},
-            resultDescription: 'You prepare for an epic battle!',
-          },
-          {
-            id: `boss-skip-${bossEventId}`,
-            text: 'Not yet — keep traveling and grow stronger',
-            successProbability: 1.0,
-            successDescription: 'You wisely decide to prepare more before facing this challenge. The boss will still be here when you return.',
-            successEffects: { reputation: 0 },
-            failureDescription: 'You continue your journey.',
-            failureEffects: {},
-            resultDescription: 'You wisely decide to prepare more before facing this challenge.',
-          },
-        ],
-        resolved: false,
-      },
-    }
-  }
-
   // Trigger crossroads event every CROSSROADS_INTERVAL steps (75)
   if (crossedMilestone(character.distance, newDistance, CROSSROADS_INTERVAL)) {
     const currentRegion = getRegion(character.currentRegion ?? 'green_meadows')
@@ -79,12 +33,17 @@ export async function moveForwardService(
       very_hard: 'Very Hard',
     }
 
+    const visitedRegions = character.visitedRegions ?? ['green_meadows']
+
     const travelOptions = connected.map(region => {
       const meetsLevel = canEnterRegion(region, character.level)
       const levelWarning = meetsLevel ? '' : ` [Requires Lv.${region.minLevel}]`
+      const isVisited = visitedRegions.includes(region.id)
+      const bossTag = !isVisited && meetsLevel ? ' — ⚔️ BOSS GUARDIAN' : ''
       return {
         id: `travel-${region.id}`,
-        text: `${region.icon} ${region.name} (${difficultyLabel[region.difficulty] ?? region.difficulty})${levelWarning}`,
+        text: `${!isVisited && meetsLevel ? '⚔️ ' : ''}${region.icon} ${region.name} (${difficultyLabel[region.difficulty] ?? region.difficulty})${levelWarning}${bossTag}`,
+        requiresBoss: !isVisited && meetsLevel,
         successProbability: meetsLevel ? 1.0 : 0.0,
         successDescription: `You set out toward ${region.name}. ${region.description}`,
         successEffects: {},

--- a/src/app/tap-tap-adventure/__tests__/leveling.test.ts
+++ b/src/app/tap-tap-adventure/__tests__/leveling.test.ts
@@ -8,7 +8,6 @@ import {
   levelProgress,
   stepsRequiredForLevel,
   stepsToNextLevel,
-  BOSS_MILESTONE_INTERVAL,
   SHOP_MILESTONE_INTERVAL,
   STEPS_PER_DAY,
 } from '@/app/tap-tap-adventure/lib/leveling'
@@ -120,8 +119,8 @@ describe('Distance-Based Leveling (rebalanced)', () => {
       expect(crossedMilestone(50, 51, SHOP_MILESTONE_INTERVAL)).toBe(false)
     })
 
-    it('detects boss milestone at 500', () => {
-      expect(crossedMilestone(499, 500, BOSS_MILESTONE_INTERVAL)).toBe(true)
+    it('detects milestone at 500', () => {
+      expect(crossedMilestone(499, 500, 500)).toBe(true)
     })
   })
 
@@ -129,7 +128,6 @@ describe('Distance-Based Leveling (rebalanced)', () => {
     it('has expected milestone values', () => {
       expect(STEPS_PER_DAY).toBe(50)
       expect(SHOP_MILESTONE_INTERVAL).toBe(75)
-      expect(BOSS_MILESTONE_INTERVAL).toBe(500)
     })
   })
 

--- a/src/app/tap-tap-adventure/components/GameUI.tsx
+++ b/src/app/tap-tap-adventure/components/GameUI.tsx
@@ -9,7 +9,7 @@ import { useResolveDecisionMutation } from '@/app/tap-tap-adventure/hooks/useRes
 import { getGenericTravelMessage } from '@/app/tap-tap-adventure/lib/getGenericTravelMessage'
 import { checkAchievements } from '@/app/tap-tap-adventure/lib/achievementTracker'
 import { canClaimDailyReward, getDailyReward } from '@/app/tap-tap-adventure/lib/dailyRewardTracker'
-import { crossedMilestone, BOSS_MILESTONE_INTERVAL, SHOP_MILESTONE_INTERVAL, STEPS_PER_DAY, calculateDay } from '@/app/tap-tap-adventure/lib/leveling'
+import { crossedMilestone, SHOP_MILESTONE_INTERVAL, STEPS_PER_DAY, calculateDay } from '@/app/tap-tap-adventure/lib/leveling'
 import { CROSSROADS_INTERVAL, getRegion } from '@/app/tap-tap-adventure/config/regions'
 import type { RegionDifficulty } from '@/app/tap-tap-adventure/config/regions'
 import { flipCoin } from '@/app/utils'
@@ -164,11 +164,10 @@ export default function GameUI({ onOpenStatus }: GameUIProps) {
     const distance = character?.distance ?? 0
     const nextDistance = distance + 1
 
-    // Always call server for milestone events (crossroads, shop, boss)
+    // Always call server for milestone events (crossroads, shop)
     const hitsMilestone =
       crossedMilestone(distance, nextDistance, CROSSROADS_INTERVAL) ||
-      crossedMilestone(distance, nextDistance, SHOP_MILESTONE_INTERVAL) ||
-      crossedMilestone(distance, nextDistance, BOSS_MILESTONE_INTERVAL)
+      crossedMilestone(distance, nextDistance, SHOP_MILESTONE_INTERVAL)
 
     if (hitsMilestone) {
       moveForwardMutation()
@@ -423,8 +422,7 @@ export default function GameUI({ onOpenStatus }: GameUIProps) {
                   const milestones = [
                     { label: 'Crossroads', icon: '🔀', steps: CROSSROADS_INTERVAL - (dist % CROSSROADS_INTERVAL) },
                     { label: 'Shop', icon: '🛒', steps: SHOP_MILESTONE_INTERVAL - (dist % SHOP_MILESTONE_INTERVAL) },
-                    { label: 'Boss', icon: '💀', steps: BOSS_MILESTONE_INTERVAL - (dist % BOSS_MILESTONE_INTERVAL) },
-                  ].sort((a, b) => a.steps - b.steps).slice(0, 3)
+                  ].sort((a, b) => a.steps - b.steps)
 
                   return (
                     <div className="space-y-2 mb-1">

--- a/src/app/tap-tap-adventure/hooks/useCharacterCreation.ts
+++ b/src/app/tap-tap-adventure/hooks/useCharacterCreation.ts
@@ -167,6 +167,7 @@ export function useCharacterCreation() {
       classData,
       difficultyMode: selectedDifficulty.id,
       currentRegion: 'green_meadows',
+      visitedRegions: ['green_meadows'],
     }
     const maxMana = calculateMaxMana(tempChar)
 

--- a/src/app/tap-tap-adventure/hooks/useCombatActionMutation.ts
+++ b/src/app/tap-tap-adventure/hooks/useCombatActionMutation.ts
@@ -2,6 +2,7 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 
 import { getDifficultyModifiers } from '@/app/tap-tap-adventure/config/difficultyModes'
+import { getRegion } from '@/app/tap-tap-adventure/config/regions'
 import { DeathPenalty } from '@/app/tap-tap-adventure/lib/deathPenalty'
 import { generateHeirloom } from '@/app/tap-tap-adventure/lib/heirloomGenerator'
 import { inferItemTypeAndEffects } from '@/app/tap-tap-adventure/lib/itemPostProcessor'
@@ -136,13 +137,29 @@ export function useCombatActionMutation() {
             mountText = ` You tamed a ${data.rewards.mountDrop.name}! ${data.rewards.mountDrop.icon}${replacedText}`
           }
 
+          // Handle boss-gated region travel on victory
+          let regionTravelText = ''
+          const pendingRegionId = combatState.pendingRegionId
+          if (pendingRegionId) {
+            const destRegion = getRegion(pendingRegionId)
+            const visitedRegions = character.visitedRegions ?? ['green_meadows']
+            const updatedVisited = visitedRegions.includes(pendingRegionId)
+              ? visitedRegions
+              : [...visitedRegions, pendingRegionId]
+            updateSelectedCharacter({
+              currentRegion: pendingRegionId,
+              visitedRegions: updatedVisited,
+            })
+            regionTravelText = ` You conquered the guardian and entered ${destRegion.icon} ${destRegion.name}!`
+          }
+
           addStoryEvent({
             id: `combat-victory-${Date.now()}`,
-            type: 'combat_victory',
+            type: pendingRegionId ? 'boss_guardian_victory' : 'combat_victory',
             characterId: character.id,
             locationId: character.locationId,
             timestamp: new Date().toISOString(),
-            outcomeDescription: `You defeated ${enemy.name}! +${data.rewards.gold} Gold.${mountText}`,
+            outcomeDescription: `You defeated ${enemy.name}! +${data.rewards.gold} Gold.${mountText}${regionTravelText}`,
             resourceDelta: {
               gold: data.rewards.gold,
             },
@@ -150,6 +167,10 @@ export function useCombatActionMutation() {
         } else if (data.combatState.status === 'defeat') {
           soundEngine.playDefeat()
           const diffMods = getDifficultyModifiers(character.difficultyMode)
+          const defeatPendingRegion = combatState.pendingRegionId
+          const guardianDefeatText = defeatPendingRegion
+            ? ` The guardian of ${getRegion(defeatPendingRegion).name} remains undefeated.`
+            : ''
 
           if (diffMods.permadeath) {
             // Permadeath: delete character permanently
@@ -159,7 +180,7 @@ export function useCombatActionMutation() {
               characterId: character.id,
               locationId: character.locationId,
               timestamp: new Date().toISOString(),
-              outcomeDescription: `${character.name} was slain by ${enemy.name}. Permadeath: this character is gone forever.`,
+              outcomeDescription: `${character.name} was slain by ${enemy.name}. Permadeath: this character is gone forever.${guardianDefeatText}`,
               resourceDelta: {},
             })
 
@@ -199,7 +220,7 @@ export function useCombatActionMutation() {
               characterId: character.id,
               locationId: character.locationId,
               timestamp: new Date().toISOString(),
-              outcomeDescription: `You were defeated by ${enemy.name}.${lossDescription} (Death #${penalty?.newDeathCount ?? '?'})`,
+              outcomeDescription: `You were defeated by ${enemy.name}.${lossDescription}${guardianDefeatText} (Death #${penalty?.newDeathCount ?? '?'})`,
               resourceDelta: {
                 gold: data.rewards?.gold,
                 reputation: penalty ? -penalty.reputationLost : undefined,
@@ -223,13 +244,17 @@ export function useCombatActionMutation() {
           }
         } else if (data.combatState.status === 'fled') {
           updateSelectedCharacter({ reputation: character.reputation - 2 })
+          const fledPendingRegion = combatState.pendingRegionId
+          const fledRegionText = fledPendingRegion
+            ? ` The guardian of ${getRegion(fledPendingRegion).name} still blocks the path.`
+            : ''
           addStoryEvent({
             id: `combat-fled-${Date.now()}`,
-            type: 'combat_fled',
+            type: fledPendingRegion ? 'boss_guardian_fled' : 'combat_fled',
             characterId: character.id,
             locationId: character.locationId,
             timestamp: new Date().toISOString(),
-            outcomeDescription: `You fled from ${enemy.name}, losing some gold and a bit of your reputation in your haste.`,
+            outcomeDescription: `You fled from ${enemy.name}, losing some gold and a bit of your reputation in your haste.${fledRegionText}`,
             resourceDelta: { gold: data.rewards?.gold, reputation: -2 },
           })
         }

--- a/src/app/tap-tap-adventure/hooks/useGameStore.ts
+++ b/src/app/tap-tap-adventure/hooks/useGameStore.ts
@@ -61,6 +61,7 @@ const defaultCharacter: FantasyCharacter = {
   activeMount: null,
   difficultyMode: 'normal',
   currentRegion: 'green_meadows',
+  visitedRegions: ['green_meadows'],
 }
 
 export interface GameStore {
@@ -694,7 +695,7 @@ export const useGameStore = create<GameStore>()(
     }),
     {
       name: 'fantasy-tycoon-storage', // localStorage key (kept for backward compat)
-      version: 13,
+      version: 14,
       migrate: (persistedState: unknown) => {
         const state = persistedState as GameStore
         if (state?.gameState && !('combatState' in state.gameState)) {
@@ -745,6 +746,10 @@ export const useGameStore = create<GameStore>()(
             // v12: Add currentRegion
             if ((char as FantasyCharacter).currentRegion === undefined) {
               ;(char as FantasyCharacter).currentRegion = 'green_meadows'
+            }
+            // v14: Add visitedRegions
+            if (!(char as FantasyCharacter).visitedRegions) {
+              ;(char as FantasyCharacter).visitedRegions = [(char as FantasyCharacter).currentRegion ?? 'green_meadows']
             }
           }
         }

--- a/src/app/tap-tap-adventure/hooks/useResolveDecisionMutation.ts
+++ b/src/app/tap-tap-adventure/hooks/useResolveDecisionMutation.ts
@@ -2,6 +2,7 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 
 import { getRandomMount } from '@/app/tap-tap-adventure/config/mounts'
+import { getRegion } from '@/app/tap-tap-adventure/config/regions'
 import { inferItemTypeAndEffects } from '@/app/tap-tap-adventure/lib/itemPostProcessor'
 import { FantasyCharacter, FantasyDecisionPoint, Item } from '@/app/tap-tap-adventure/models/types'
 
@@ -45,8 +46,47 @@ export function useResolveDecisionMutation() {
 
       // Handle crossroads region travel decisions client-side
       if (optionId.startsWith('travel-')) {
-        soundEngine.playCrossroads()
         const regionId = optionId.replace('travel-', '')
+        const visitedRegions = character.visitedRegions ?? ['green_meadows']
+        const isUnvisited = !visitedRegions.includes(regionId)
+
+        // Boss-gated travel: unvisited regions require defeating a boss guardian
+        if (isUnvisited) {
+          soundEngine.playBoss()
+          const destRegion = getRegion(regionId)
+          const { gameState: gs } = useGameStore.getState()
+          const bossContext = `A powerful guardian of ${destRegion.name} blocks the path. This ${destRegion.element !== 'none' ? destRegion.element + '-aligned ' : ''}boss protects the entrance to ${destRegion.name} (${destRegion.theme}). Enemy types in this region: ${destRegion.enemyTypes.join(', ')}. The boss should be a powerful version of these creatures.`
+          const combatRes = await fetch('/api/v1/tap-tap-adventure/combat/start', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              character,
+              storyEvents: gs.storyEvents,
+              eventContext: bossContext,
+              isBoss: true,
+              pendingRegionId: regionId,
+            }),
+          })
+          if (combatRes.ok) {
+            const combatData = await combatRes.json()
+            setCombatState(combatData.combatState)
+          }
+          addStoryEvent({
+            id: `result-${Date.now()}`,
+            type: 'boss_guardian',
+            characterId: character.id,
+            locationId: character.locationId,
+            timestamp: new Date().toISOString(),
+            selectedOptionId: optionId,
+            selectedOptionText: `Challenge the guardian of ${destRegion.name}`,
+            outcomeDescription: `A fearsome guardian blocks the path to ${destRegion.name}! You must defeat it to enter.`,
+          })
+          commit()
+          onSuccess?.()
+          return
+        }
+
+        soundEngine.playCrossroads()
         updateSelectedCharacter({ currentRegion: regionId })
         const chosenOption = decisionPoint.options.find(o => o.id === optionId)
         addStoryEvent({

--- a/src/app/tap-tap-adventure/models/character.ts
+++ b/src/app/tap-tap-adventure/models/character.ts
@@ -50,6 +50,7 @@ export const FantasyCharacterSchema = z.object({
   unlockedSkills: z.array(z.string()).optional(),
   difficultyMode: z.string().optional().default('normal'),
   currentRegion: z.string().optional().default('green_meadows'),
+  visitedRegions: z.array(z.string()).optional(),
 })
 export type FantasyCharacter = z.infer<typeof FantasyCharacterSchema>
 

--- a/src/app/tap-tap-adventure/models/combat.ts
+++ b/src/app/tap-tap-adventure/models/combat.ts
@@ -142,5 +142,6 @@ export const CombatStateSchema = z.object({
   enemyTelegraph: EnemyTelegraphSchema.optional().nullable(),
   isBoss: z.boolean().optional(),
   turnPhase: TurnPhaseSchema.optional(),
+  pendingRegionId: z.string().optional(),
 })
 export type CombatState = z.infer<typeof CombatStateSchema>


### PR DESCRIPTION
## Summary
- Replaces the fixed 500-step boss milestone with boss guardians that block entry to unvisited regions at crossroads
- When selecting an unvisited region, players fight a themed boss; victory grants entry, defeat/flee keeps them in place
- Previously visited regions remain free to travel to
- Adds `visitedRegions` to character model and `pendingRegionId` to combat state, with store migration (v13 -> v14)

## Changes
- **models/character.ts**: Add `visitedRegions: z.array(z.string()).optional()`
- **models/combat.ts**: Add `pendingRegionId: z.string().optional()` to CombatState
- **hooks/useGameStore.ts**: Bump version to 14, add migration, update default character
- **hooks/useCharacterCreation.ts**: Set `visitedRegions: ['green_meadows']` on new characters
- **move-forward/services/moveForwardService.ts**: Remove boss milestone trigger, mark unvisited regions with boss guardian warning
- **components/GameUI.tsx**: Remove boss milestone from client-side checks and milestone indicators
- **hooks/useResolveDecisionMutation.ts**: Trigger boss combat for unvisited regions instead of direct travel
- **hooks/useCombatActionMutation.ts**: Handle victory (enter region, update visitedRegions) and defeat/flee (stay in place)
- **combat/start/route.ts**: Accept and pass through `pendingRegionId`
- **__tests__/leveling.test.ts**: Remove BOSS_MILESTONE_INTERVAL references

## Design
Compatible with or without PR #153 (more regions) since it works with the existing region system generically — any region in `connectedRegions` that isn't in `visitedRegions` gets a boss guardian.

## Test plan
- [ ] Verify `npx tsc --noEmit` shows no new type errors (57 pre-existing, unchanged)
- [ ] Verify `npx vitest run src/app/tap-tap-adventure/__tests__/regions.test.ts` passes (17/17)
- [ ] Verify crossroads show boss guardian markers on unvisited regions
- [ ] Verify selecting an unvisited region triggers boss combat
- [ ] Verify boss victory moves player to new region and marks it visited
- [ ] Verify boss defeat/flee keeps player in current region
- [ ] Verify previously visited regions are free to travel to
- [ ] Verify new characters start with `visitedRegions: ['green_meadows']`
- [ ] Verify store migration adds `visitedRegions` to existing characters

Closes #147

🤖 Generated with [Claude Code](https://claude.com/claude-code)