### PR TITLE
Fix mount UX: mobile release, sell at shops, release from status

### DIFF
--- a/src/app/tap-tap-adventure/components/HudBar.tsx
+++ b/src/app/tap-tap-adventure/components/HudBar.tsx
@@ -285,11 +285,12 @@ export function HudBar({ onOpenStatus }: HudBarProps = {}) {
               <span className="hidden sm:inline text-[10px]">{activeMount.name}</span>
             </button>
             <button
-              className="hidden sm:inline text-[10px] text-red-400 hover:text-red-300 border border-red-400/30 rounded px-1 py-0.5 bg-[#2a2b3f] hover:bg-[#3a3c56]"
+              className="text-[9px] sm:text-[10px] text-red-400 hover:text-red-300 border border-red-400/30 rounded px-1 py-0.5 bg-[#2a2b3f] hover:bg-[#3a3c56]"
               title="Release mount"
               onClick={() => setMount(null)}
             >
-              Release
+              <span className="sm:hidden">&#10005;</span>
+              <span className="hidden sm:inline">Release</span>
             </button>
           </div>
         )}

--- a/src/app/tap-tap-adventure/components/PlayerStatusView.tsx
+++ b/src/app/tap-tap-adventure/components/PlayerStatusView.tsx
@@ -111,7 +111,7 @@ function getMetaBonusDescriptions(bonuses: ReturnType<typeof useGameStore.getSta
 }
 
 export function PlayerStatusView({ onClose }: PlayerStatusViewProps) {
-  const { getSelectedCharacter, getMetaBonuses: getMetaBonusesFn } = useGameStore()
+  const { getSelectedCharacter, getMetaBonuses: getMetaBonusesFn, setMount } = useGameStore()
 
   const character = getSelectedCharacter()
   if (!character) return null
@@ -387,6 +387,12 @@ export function PlayerStatusView({ onClose }: PlayerStatusViewProps) {
                   ) : null}
                 </div>
                 <div className="text-xs text-slate-400 mt-2">{mount.dailyCost} gp/day upkeep</div>
+                <button
+                  className="mt-2 text-xs text-red-400 hover:text-red-300 border border-red-400/30 rounded px-2 py-1 bg-[#2a2b3f] hover:bg-[#3a3c56] transition-colors"
+                  onClick={() => setMount(null)}
+                >
+                  Release Mount
+                </button>
               </div>
             )}
           </SectionCard>

--- a/src/app/tap-tap-adventure/components/ShopUI.tsx
+++ b/src/app/tap-tap-adventure/components/ShopUI.tsx
@@ -7,6 +7,7 @@ import { useGameStore } from '@/app/tap-tap-adventure/hooks/useGameStore'
 import { inferItemTypeAndEffects } from '@/app/tap-tap-adventure/lib/itemPostProcessor'
 import { soundEngine } from '@/app/tap-tap-adventure/lib/soundEngine'
 import { calculateSellPrice } from '@/app/tap-tap-adventure/lib/sellPrice'
+import { getMountSellPrice } from '@/app/tap-tap-adventure/config/mounts'
 import { Item } from '@/app/tap-tap-adventure/models/types'
 import { getEquipmentSlot, EquipmentSlots } from '@/app/tap-tap-adventure/models/equipment'
 import { ItemEffects } from '@/app/tap-tap-adventure/models/item'
@@ -60,7 +61,7 @@ function ItemComparison({ item, equipment }: { item: Item; equipment: EquipmentS
 }
 
 export function ShopUI() {
-  const { gameState, setShopState, setGameState } = useGameStore()
+  const { gameState, setShopState, setGameState, setMount } = useGameStore()
   const [feedback, setFeedback] = useState<string | null>(null)
   const [busy, setBusy] = useState(false)
   const [activeTab, setActiveTab] = useState<ShopTab>('buy')
@@ -201,6 +202,29 @@ export function ShopUI() {
     setShopState(null)
   }
 
+  const handleSellMount = () => {
+    if (!character.activeMount) return
+    const sellPrice = getMountSellPrice(character.activeMount.rarity)
+    const mountName = character.activeMount.name
+
+    const updatedCharacters = gameState.characters.map(c => {
+      if (c.id !== character.id) return c
+      return {
+        ...c,
+        gold: c.gold + sellPrice,
+        activeMount: null,
+      }
+    })
+
+    setGameState({
+      ...gameState,
+      characters: updatedCharacters,
+    })
+
+    soundEngine.playGold()
+    setFeedback(`Sold ${mountName} for ${sellPrice} gold!`)
+  }
+
   const sellableItems = character.inventory.filter(i => i.status !== 'deleted' && i.quantity > 0)
 
   return (
@@ -332,6 +356,49 @@ export function ShopUI() {
       {/* Sell tab */}
       {activeTab === 'sell' && (
         <div className="space-y-3">
+          {/* Sell Mount */}
+          {character.activeMount && (() => {
+            const mount = character.activeMount
+            const sellPrice = getMountSellPrice(mount.rarity)
+            const rarityColors: Record<string, string> = {
+              common: 'text-gray-300',
+              uncommon: 'text-green-400',
+              rare: 'text-blue-400',
+              legendary: 'text-yellow-400',
+            }
+            const bonusParts: string[] = []
+            if (mount.bonuses.strength) bonusParts.push(`+${mount.bonuses.strength} STR`)
+            if (mount.bonuses.intelligence) bonusParts.push(`+${mount.bonuses.intelligence} INT`)
+            if (mount.bonuses.luck) bonusParts.push(`+${mount.bonuses.luck} LCK`)
+            if (mount.bonuses.autoWalkSpeed) bonusParts.push(`${mount.bonuses.autoWalkSpeed}x speed`)
+            if (mount.bonuses.healRate) bonusParts.push(`+${mount.bonuses.healRate} heal/step`)
+            return (
+              <div className="border border-purple-500/40 bg-[#2a2040] rounded-lg p-3 space-y-1">
+                <div className="flex justify-between items-start">
+                  <div className="font-semibold text-white">
+                    {mount.icon} {mount.name}
+                    <span className={`ml-2 text-xs uppercase ${rarityColors[mount.rarity]}`}>
+                      {mount.rarity}
+                    </span>
+                  </div>
+                  <div className="text-emerald-400 font-bold text-sm whitespace-nowrap ml-2">
+                    {sellPrice} gold
+                  </div>
+                </div>
+                <div className="text-xs text-gray-400">{mount.description}</div>
+                <div className="text-xs text-purple-300">{bonusParts.join(', ')}</div>
+                <div className="text-xs text-gray-500">Daily upkeep: {mount.dailyCost} gold</div>
+                <Button
+                  className="w-full mt-2 bg-gradient-to-r from-emerald-600 to-green-600 hover:from-emerald-500 hover:to-green-500 border border-green-400/30 text-white font-bold text-base py-3 rounded disabled:opacity-40 disabled:cursor-not-allowed"
+                  disabled={busy}
+                  onClick={handleSellMount}
+                >
+                  Sell Mount
+                </Button>
+              </div>
+            )
+          })()}
+
           {sellableItems.map(item => {
             const sellPrice = calculateSellPrice(item)
             return (
@@ -363,7 +430,7 @@ export function ShopUI() {
             )
           })}
 
-          {sellableItems.length === 0 && (
+          {sellableItems.length === 0 && !character.activeMount && (
             <div className="text-sm text-gray-500 text-center">You have nothing to sell.</div>
           )}
         </div>

--- a/src/app/tap-tap-adventure/config/mounts.ts
+++ b/src/app/tap-tap-adventure/config/mounts.ts
@@ -29,6 +29,10 @@ export function getMountPrice(rarity: Mount['rarity']): number {
   }
 }
 
+export function getMountSellPrice(rarity: Mount['rarity']): number {
+  return Math.floor(getMountPrice(rarity) / 2)
+}
+
 /** Returns a mount appropriate for the character's level (never legendary in shops). */
 export function getShopMount(characterLevel: number): Mount {
   let pool: Mount[]


### PR DESCRIPTION
## Summary
- **HudBar**: Mount release button was hidden on mobile (`hidden sm:inline`). Now visible on all screen sizes -- shows a compact "X" icon on mobile and "Release" text on desktop.
- **ShopUI**: Added "Sell Mount" section to the sell tab. When the player has an active mount, it appears as a card showing name, icon, rarity, bonuses, and sell price (50% of buy price). Selling adds gold, clears the mount, plays gold sound, and shows feedback.
- **PlayerStatusView**: Added a "Release Mount" button in the Active Mount section so players can release their mount from the status screen.
- **config/mounts**: Added `getMountSellPrice(rarity)` helper (returns half of `getMountPrice`).

## Test plan
- [ ] On mobile viewport, verify the mount release button (X icon) is visible in the HUD bar
- [ ] On desktop viewport, verify the mount release button shows "Release" text
- [ ] Open a shop with an active mount, switch to Sell tab, verify mount card appears with correct sell price
- [ ] Sell the mount and verify gold increases, mount is removed, feedback message shows
- [ ] Open character status with an active mount, verify "Release Mount" button appears
- [ ] Click "Release Mount" in status view, verify mount is removed
- [ ] Verify sell prices: common=15g, uncommon=30g, rare=60g, legendary=150g

Generated with [Claude Code](https://claude.com/claude-code)