### PR TITLE
feat: mount combat abilities — free movement and flee bonus (#162)

### DIFF
--- a/src/app/tap-tap-adventure/__tests__/mounts.test.ts
+++ b/src/app/tap-tap-adventure/__tests__/mounts.test.ts
@@ -4,9 +4,11 @@ import {
   MOUNT_DEFINITIONS,
   getMountById,
   getMountsByRarity,
+  getMountFreeMoves,
+  getMountFleeBonus,
   getRandomMount,
 } from '@/app/tap-tap-adventure/config/mounts'
-import { initializePlayerCombatState, getCombatRewards } from '@/app/tap-tap-adventure/lib/combatEngine'
+import { initializePlayerCombatState, getCombatRewards, calculateFleeChance } from '@/app/tap-tap-adventure/lib/combatEngine'
 import { applyLevelFromDistance } from '@/app/tap-tap-adventure/lib/leveling'
 import { getMountDisplayName } from '@/app/tap-tap-adventure/lib/mountUtils'
 import { MountSchema } from '@/app/tap-tap-adventure/models/mount'
@@ -228,6 +230,111 @@ describe('Mount Daily Cost', () => {
     for (const m of MOUNT_DEFINITIONS) {
       expect(m.dailyCost).toBeGreaterThan(0)
     }
+  })
+})
+
+describe('getMountFreeMoves', () => {
+  it('common mount has 0 free moves', () => {
+    expect(getMountFreeMoves('common')).toBe(0)
+  })
+
+  it('uncommon mount has 1 free move', () => {
+    expect(getMountFreeMoves('uncommon')).toBe(1)
+  })
+
+  it('rare mount has 2 free moves', () => {
+    expect(getMountFreeMoves('rare')).toBe(2)
+  })
+
+  it('legendary mount has 4 free moves', () => {
+    expect(getMountFreeMoves('legendary')).toBe(4)
+  })
+})
+
+describe('getMountFleeBonus', () => {
+  it('common mount gives +10% flee bonus', () => {
+    expect(getMountFleeBonus('common')).toBe(10)
+  })
+
+  it('uncommon mount gives +20% flee bonus', () => {
+    expect(getMountFleeBonus('uncommon')).toBe(20)
+  })
+
+  it('rare mount gives +30% flee bonus', () => {
+    expect(getMountFleeBonus('rare')).toBe(30)
+  })
+
+  it('legendary mount gives +50% flee bonus', () => {
+    expect(getMountFleeBonus('legendary')).toBe(50)
+  })
+})
+
+describe('Mount free moves in combat state', () => {
+  it('common mount sets mountMovesRemaining to 0', () => {
+    const char = makeCharacter({ activeMount: getMountById('horse')! })
+    const state = initializePlayerCombatState(char)
+    expect(state.mountMovesRemaining).toBe(0)
+  })
+
+  it('uncommon mount sets mountMovesRemaining to 1', () => {
+    const char = makeCharacter({ activeMount: getMountById('war-horse')! })
+    const state = initializePlayerCombatState(char)
+    expect(state.mountMovesRemaining).toBe(1)
+  })
+
+  it('rare mount sets mountMovesRemaining to 2', () => {
+    const char = makeCharacter({ activeMount: getMountById('griffin')! })
+    const state = initializePlayerCombatState(char)
+    expect(state.mountMovesRemaining).toBe(2)
+  })
+
+  it('legendary mount sets mountMovesRemaining to 4', () => {
+    const char = makeCharacter({ activeMount: getMountById('dragon')! })
+    const state = initializePlayerCombatState(char)
+    expect(state.mountMovesRemaining).toBe(4)
+  })
+
+  it('no mount sets mountMovesRemaining to 0', () => {
+    const char = makeCharacter({ activeMount: null })
+    const state = initializePlayerCombatState(char)
+    expect(state.mountMovesRemaining).toBe(0)
+  })
+})
+
+describe('calculateFleeChance with mount bonus', () => {
+  const baseEnemy = {
+    id: 'e1',
+    name: 'Goblin',
+    description: 'A goblin',
+    hp: 20,
+    maxHp: 20,
+    attack: 5,
+    defense: 2,
+    level: 1,
+    goldReward: 5,
+  }
+
+  it('character without mount has base flee chance', () => {
+    const char = makeCharacter({ luck: 0, activeMount: null })
+    const chance = calculateFleeChance(char, baseEnemy)
+    // Base: 0.3 + 0*0.02 - 1*0.05 = 0.25, clamped to 0.25
+    expect(chance).toBeCloseTo(0.25, 2)
+  })
+
+  it('uncommon mount adds +20% flee bonus', () => {
+    const charNoMount = makeCharacter({ luck: 0, activeMount: null })
+    const charWithMount = makeCharacter({ luck: 0, activeMount: getMountById('war-horse')! })
+    const baseChance = calculateFleeChance(charNoMount, baseEnemy)
+    const mountChance = calculateFleeChance(charWithMount, baseEnemy)
+    expect(mountChance).toBeCloseTo(baseChance + 0.20, 2)
+  })
+
+  it('legendary mount adds +50% flee bonus', () => {
+    const charNoMount = makeCharacter({ luck: 0, activeMount: null })
+    const charWithMount = makeCharacter({ luck: 0, activeMount: getMountById('dragon')! })
+    const baseChance = calculateFleeChance(charNoMount, baseEnemy)
+    const mountChance = calculateFleeChance(charWithMount, baseEnemy)
+    expect(mountChance).toBeCloseTo(Math.min(0.9, baseChance + 0.50), 2)
   })
 })
 

--- a/src/app/tap-tap-adventure/components/CombatUI.tsx
+++ b/src/app/tap-tap-adventure/components/CombatUI.tsx
@@ -246,10 +246,10 @@ export function CombatUI({ combatState }: CombatUIProps) {
           if (ap >= (AP_COSTS.flee ?? 3)) { e.preventDefault(); handleAction('flee') }
           break
         case 'q': // Move Closer
-          if (ap >= (AP_COSTS.move_closer ?? 1) && combatState.combatDistance !== 'close') { e.preventDefault(); handleAction('move_closer') }
+          if ((ap >= (AP_COSTS.move_closer ?? 1) || (playerState.mountMovesRemaining ?? 0) > 0) && combatState.combatDistance !== 'close') { e.preventDefault(); handleAction('move_closer') }
           break
         case 'e': // Move Away
-          if (ap >= (AP_COSTS.move_away ?? 1) && combatState.combatDistance !== 'far') { e.preventDefault(); handleAction('move_away') }
+          if ((ap >= (AP_COSTS.move_away ?? 1) || (playerState.mountMovesRemaining ?? 0) > 0) && combatState.combatDistance !== 'far') { e.preventDefault(); handleAction('move_away') }
           break
         case 'z': // End Turn
           e.preventDefault(); handleAction('end_turn')
@@ -518,6 +518,9 @@ export function CombatUI({ combatState }: CombatUIProps) {
             ))}
           </span>
           <span className="text-xs text-amber-400">({playerState.ap ?? 3}/{playerState.maxAp ?? 3})</span>
+          {(playerState.mountMovesRemaining ?? 0) > 0 && (
+            <span className="text-xs text-cyan-400 ml-2">| Mount: {playerState.mountMovesRemaining} free move{(playerState.mountMovesRemaining ?? 0) !== 1 ? 's' : ''}</span>
+          )}
         </div>
       </div>
 
@@ -602,25 +605,25 @@ export function CombatUI({ combatState }: CombatUIProps) {
           </Button>
           <Button
             className={`text-base py-3 rounded-md transition-colors border ${
-              combatState.combatDistance === 'close' || (playerState.ap ?? 3) < (AP_COSTS.move_closer ?? 1)
+              combatState.combatDistance === 'close' || ((playerState.ap ?? 3) < (AP_COSTS.move_closer ?? 1) && (playerState.mountMovesRemaining ?? 0) === 0)
                 ? 'bg-slate-800 border-slate-600 text-slate-500 cursor-not-allowed'
                 : 'bg-cyan-900/50 border-cyan-800 hover:bg-cyan-800 text-white'
             }`}
             onClick={() => handleAction('move_closer')}
-            disabled={isPending || combatState.combatDistance === 'close' || (playerState.ap ?? 3) < (AP_COSTS.move_closer ?? 1)}
+            disabled={isPending || combatState.combatDistance === 'close' || ((playerState.ap ?? 3) < (AP_COSTS.move_closer ?? 1) && (playerState.mountMovesRemaining ?? 0) === 0)}
           >
-            Close In ({AP_COSTS.move_closer} AP)
+            Close In ({(playerState.mountMovesRemaining ?? 0) > 0 ? 'Free' : `${AP_COSTS.move_closer} AP`})
           </Button>
           <Button
             className={`text-base py-3 rounded-md transition-colors border ${
-              combatState.combatDistance === 'far' || (playerState.ap ?? 3) < (AP_COSTS.move_away ?? 1)
+              combatState.combatDistance === 'far' || ((playerState.ap ?? 3) < (AP_COSTS.move_away ?? 1) && (playerState.mountMovesRemaining ?? 0) === 0)
                 ? 'bg-slate-800 border-slate-600 text-slate-500 cursor-not-allowed'
                 : 'bg-teal-900/50 border-teal-800 hover:bg-teal-800 text-white'
             }`}
             onClick={() => handleAction('move_away')}
-            disabled={isPending || combatState.combatDistance === 'far' || (playerState.ap ?? 3) < (AP_COSTS.move_away ?? 1)}
+            disabled={isPending || combatState.combatDistance === 'far' || ((playerState.ap ?? 3) < (AP_COSTS.move_away ?? 1) && (playerState.mountMovesRemaining ?? 0) === 0)}
           >
-            Back Away ({AP_COSTS.move_away} AP)
+            Back Away ({(playerState.mountMovesRemaining ?? 0) > 0 ? 'Free' : `${AP_COSTS.move_away} AP`})
           </Button>
           <Button
             className={`text-base py-3 rounded-md transition-colors border ${

--- a/src/app/tap-tap-adventure/config/mounts.ts
+++ b/src/app/tap-tap-adventure/config/mounts.ts
@@ -33,6 +33,26 @@ export function getMountSellPrice(rarity: Mount['rarity']): number {
   return Math.floor(getMountPrice(rarity) / 2)
 }
 
+/** Returns the number of free movement actions per turn based on mount rarity. */
+export function getMountFreeMoves(rarity: Mount['rarity']): number {
+  switch (rarity) {
+    case 'common': return 0
+    case 'uncommon': return 1
+    case 'rare': return 2
+    case 'legendary': return 4
+  }
+}
+
+/** Returns the flee chance bonus (as a percentage, e.g. 10 = +10%) based on mount rarity. */
+export function getMountFleeBonus(rarity: Mount['rarity']): number {
+  switch (rarity) {
+    case 'common': return 10
+    case 'uncommon': return 20
+    case 'rare': return 30
+    case 'legendary': return 50
+  }
+}
+
 /** Returns a mount appropriate for the character's level (never legendary in shops). */
 export function getShopMount(characterLevel: number): Mount {
   let pool: Mount[]

--- a/src/app/tap-tap-adventure/lib/combatEngine.ts
+++ b/src/app/tap-tap-adventure/lib/combatEngine.ts
@@ -17,7 +17,7 @@ import {
 } from '@/app/tap-tap-adventure/models/combat'
 import { Item } from '@/app/tap-tap-adventure/models/item'
 import { Mount } from '@/app/tap-tap-adventure/models/mount'
-import { getRandomMount } from '@/app/tap-tap-adventure/config/mounts'
+import { getRandomMount, getMountFreeMoves, getMountFleeBonus } from '@/app/tap-tap-adventure/config/mounts'
 
 import { getDifficultyModifiers } from '@/app/tap-tap-adventure/config/difficultyModes'
 
@@ -80,6 +80,10 @@ export function initializePlayerCombatState(character: FantasyCharacter): Combat
   // Calculate total luck for crit chance
   const totalLuck = character.luck + mountLuckBonus + accessoryLuckBonus
 
+  const mountFreeMoves = character.activeMount
+    ? getMountFreeMoves(character.activeMount.rarity)
+    : 0
+
   return {
     hp: currentHp,
     maxHp,
@@ -104,6 +108,7 @@ export function initializePlayerCombatState(character: FantasyCharacter): Combat
     maxAp: MAX_AP,
     turnActions: [],
     luck: totalLuck,
+    mountMovesRemaining: mountFreeMoves,
   }
 }
 
@@ -239,7 +244,10 @@ export function calculateFleeChance(
   const fleeBonus = getSkillBonus(skills, 'flee_chance')
   const allStatsBonus = getSkillBonus(skills, 'all_stats')
   const effectiveLuck = character.luck + allStatsBonus.flat
-  const chance = 0.3 + effectiveLuck * 0.02 - enemy.level * 0.05 + fleeBonus.percentage / 100
+  const mountFleeBonus = character.activeMount
+    ? getMountFleeBonus(character.activeMount.rarity) / 100
+    : 0
+  const chance = 0.3 + effectiveLuck * 0.02 - enemy.level * 0.05 + fleeBonus.percentage / 100 + mountFleeBonus
   return Math.max(0.1, Math.min(0.9, chance))
 }
 
@@ -869,8 +877,18 @@ export function processPlayerAction(
           playerState.ap += apCost
           playerState.turnActions = playerState.turnActions?.slice(0, -1) ?? []
         } else {
+          const usedMountMove = (playerState.mountMovesRemaining ?? 0) > 0
+          if (usedMountMove) {
+            // Refund the AP cost — this move is free via mount
+            playerState.ap += apCost
+            playerState.turnActions = playerState.turnActions?.slice(0, -1) ?? []
+            playerState.mountMovesRemaining = (playerState.mountMovesRemaining ?? 1) - 1
+          }
           combatDistance = combatDistance === 'far' ? 'mid' : 'close'
-          newLogs.push({ turn: turnNumber, actor: 'player', action: 'move_closer', description: `You close the distance to ${combatDistance} range!` })
+          const moveDesc = usedMountMove
+            ? `Your mount carries you to ${combatDistance} range!`
+            : `You close the distance to ${combatDistance} range!`
+          newLogs.push({ turn: turnNumber, actor: 'player', action: 'move_closer', description: moveDesc })
         }
         break
       }
@@ -881,8 +899,18 @@ export function processPlayerAction(
           playerState.ap += apCost
           playerState.turnActions = playerState.turnActions?.slice(0, -1) ?? []
         } else {
+          const usedMountMove = (playerState.mountMovesRemaining ?? 0) > 0
+          if (usedMountMove) {
+            // Refund the AP cost — this move is free via mount
+            playerState.ap += apCost
+            playerState.turnActions = playerState.turnActions?.slice(0, -1) ?? []
+            playerState.mountMovesRemaining = (playerState.mountMovesRemaining ?? 1) - 1
+          }
           combatDistance = combatDistance === 'close' ? 'mid' : 'far'
-          newLogs.push({ turn: turnNumber, actor: 'player', action: 'move_away', description: `You move back to ${combatDistance} range!` })
+          const moveDesc = usedMountMove
+            ? `Your mount swiftly carries you back to ${combatDistance} range!`
+            : `You move back to ${combatDistance} range!`
+          newLogs.push({ turn: turnNumber, actor: 'player', action: 'move_away', description: moveDesc })
         }
         break
       }
@@ -1194,6 +1222,10 @@ export function processPlayerAction(
   playerState.ap = playerState.maxAp ?? MAX_AP
   playerState.turnActions = []
   playerState.isDefending = false
+  // Reset mount free moves for next turn
+  if (character.activeMount) {
+    playerState.mountMovesRemaining = getMountFreeMoves(character.activeMount.rarity)
+  }
 
   // Enemy may try to change distance based on their range type
   if (status === 'active' && combatDistance !== 'close' && enemy.range !== 'ranged') {

--- a/src/app/tap-tap-adventure/models/combat.ts
+++ b/src/app/tap-tap-adventure/models/combat.ts
@@ -96,6 +96,7 @@ export const CombatPlayerStateSchema = z.object({
   maxAp: z.number().default(3),
   turnActions: z.array(z.string()).optional(),
   luck: z.number().default(0),
+  mountMovesRemaining: z.number().optional(),
 })
 export type CombatPlayerState = z.infer<typeof CombatPlayerStateSchema>
 


### PR DESCRIPTION
## Summary
- Mounts now provide free combat movement based on rarity tier (common: 0, uncommon: 1, rare: 2, legendary: 4 moves/turn)
- Free mount moves don't cost AP — shown as "Free" in the UI with a mount move counter
- Flee chance bonus added per mount rarity (common: +10%, uncommon: +20%, rare: +30%, legendary: +50%)
- Distinct combat log messages for mounted movement ("Your mount carries you to...")
- Mount moves reset each turn
- 16 new tests covering free moves, flee bonus, and combat state initialization

Closes #162

## Test plan
- [ ] Enter combat with an uncommon+ mount → see "Free" on movement buttons, mount move indicator
- [ ] Use free move → mount moves counter decreases, AP unchanged
- [ ] Exhaust free moves → buttons revert to showing AP cost
- [ ] Next turn → free moves reset
- [ ] Attempt flee with a mount → higher success rate than without
- [ ] Run `npx vitest run` → all mount tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)