### PR TITLE
Improve post-battle reward feedback

### DIFF
--- a/src/app/tap-tap-adventure/components/CombatUI.tsx
+++ b/src/app/tap-tap-adventure/components/CombatUI.tsx
@@ -751,6 +751,10 @@ export function CombatResult({ combatState, onContinue }: CombatResultProps) {
     status === 'defeat'
       ? [...lastStoryEvents].reverse().find(e => e.type === 'combat_defeat')
       : null
+  const lastVictoryEvent =
+    status === 'victory'
+      ? [...lastStoryEvents].reverse().find(e => e.type === 'combat_victory' || e.type === 'boss_guardian_victory')
+      : null
 
   const [showPenalties, setShowPenalties] = useState(status !== 'defeat')
 
@@ -806,6 +810,34 @@ export function CombatResult({ combatState, onContinue }: CombatResultProps) {
     <div className={`${c.bgColor} border ${c.borderColor} rounded-lg p-6 text-center space-y-4`}>
       <h4 className={`text-xl font-bold ${c.color}`}>{c.title}</h4>
       <p className="text-slate-300">{c.message}</p>
+      {status === 'victory' && lastVictoryEvent && (
+        <div className="space-y-3">
+          {lastVictoryEvent.resourceDelta?.gold ? (
+            <p className="text-yellow-400 font-semibold">+{lastVictoryEvent.resourceDelta.gold} Gold</p>
+          ) : null}
+          {(() => {
+            const allItems = [
+              ...(lastVictoryEvent.resourceDelta?.rewardItems || []),
+              ...(lastVictoryEvent.rewardItems || []),
+            ]
+            return allItems.length > 0 ? (
+              <div className="text-sm text-yellow-200 space-y-1 bg-yellow-950/30 rounded p-3">
+                <p className="font-semibold text-yellow-300">Rewards gained:</p>
+                {allItems.map((item, idx) => (
+                  <p key={item.id + idx}>
+                    <span className="text-yellow-200">{item.name}</span>
+                    {item.quantity > 1 && <span className="text-yellow-400"> x{item.quantity}</span>}
+                    {item.type === 'spell_scroll' && <span className="text-purple-400 ml-1">(Scroll)</span>}
+                  </p>
+                ))}
+              </div>
+            ) : null
+          })()}
+          {lastVictoryEvent.outcomeDescription && (
+            <p className="text-slate-400 text-sm italic">{lastVictoryEvent.outcomeDescription}</p>
+          )}
+        </div>
+      )}
       {status === 'defeat' && (
         <>
           {/* Flavor text - visible immediately */}

--- a/src/app/tap-tap-adventure/components/StoryFeed.tsx
+++ b/src/app/tap-tap-adventure/components/StoryFeed.tsx
@@ -132,7 +132,7 @@ function DecisionPointDisplay({
 }
 
 interface RewardItemDisplayProps {
-  item: { id: string; name: string; quantity: number }
+  item: { id: string; name: string; quantity: number; type?: string }
   isHighlighted: boolean
 }
 
@@ -143,6 +143,9 @@ function RewardItemDisplay({ item, isHighlighted }: RewardItemDisplayProps) {
         You received {item.quantity > 1 ? `${item.quantity} ` : ''}
         <span className={`font-semibold ${isHighlighted ? 'text-yellow-300' : 'text-yellow-400'}`}>
           {item.name}
+          {item.type === 'spell_scroll' && (
+            <span className="text-purple-400 ml-1">(Scroll)</span>
+          )}
         </span>
       </span>
     </div>
@@ -193,7 +196,7 @@ export function StoryFeed({
   return (
     <div
       ref={feedRef}
-      className="border border-slate-700 rounded-lg max-h-48 sm:max-h-64 md:max-h-[calc(100vh-479px)] overflow-y-auto flex p-2 space-y-2 flex-col bg-slate-900"
+      className="border border-slate-700 rounded-lg max-h-64 sm:max-h-80 md:max-h-[calc(100vh-479px)] overflow-y-auto flex p-2 space-y-2 flex-col bg-slate-900"
     >
       {filteredEvents.reverse().map(storyEvent => {
         const isHighlighted = highlightedEventId === storyEvent.id

--- a/src/app/tap-tap-adventure/hooks/useCombatActionMutation.ts
+++ b/src/app/tap-tap-adventure/hooks/useCombatActionMutation.ts
@@ -122,9 +122,12 @@ export function useCombatActionMutation(options?: { onMountDrop?: (mount: Mount)
 
         if (data.combatState.status === 'victory' && data.rewards) {
           soundEngine.playVictory()
-          // Add loot items
+          // Add loot items and collect for story event
+          const processedLoot: Item[] = []
           for (const lootItem of data.rewards.loot) {
-            addItem(inferItemTypeAndEffects(lootItem))
+            const processed = inferItemTypeAndEffects(lootItem)
+            addItem(processed)
+            processedLoot.push(processed)
           }
 
           // If combat dropped a mount, trigger naming modal or equip directly
@@ -166,10 +169,11 @@ export function useCombatActionMutation(options?: { onMountDrop?: (mount: Mount)
             characterId: character.id,
             locationId: character.locationId,
             timestamp: new Date().toISOString(),
-            outcomeDescription: `You defeated ${enemy.name}! +${data.rewards.gold} Gold.${mountText}${regionTravelText}`,
+            outcomeDescription: `You defeated ${enemy.name}!${mountText}${regionTravelText}`,
             resourceDelta: {
               gold: data.rewards.gold,
             },
+            rewardItems: processedLoot.length > 0 ? processedLoot : undefined,
           })
         } else if (data.combatState.status === 'defeat') {
           soundEngine.playDefeat()


### PR DESCRIPTION
## Summary
- **Data fix**: Combat victory events now populate `rewardItems` with processed loot items, so they appear in the story feed and combat result screen
- **CombatResult rewards card**: Victory screen now shows gold earned, individual loot items with quantities, spell scroll badges, and narrative text — mirroring the defeat penalty display
- **StoryFeed improvements**: Increased mobile height (max-h-48 → max-h-64, sm: max-h-64 → max-h-80), added "(Scroll)" badge for spell scroll items in reward displays

## Test plan
- [ ] Win combat with loot drops: CombatResult shows "Rewards gained:" box with item names
- [ ] Win combat with no loot: gold shows but no rewards box
- [ ] Spell scroll drop: purple "(Scroll)" badge in both CombatResult and StoryFeed
- [ ] Boss guardian victory: rewards display works, region travel text still appears
- [ ] Defeat: penalty display unchanged (regression check)
- [ ] Mobile viewport: StoryFeed is taller, shows more events

Closes #170

🤖 Generated with [Claude Code](https://claude.com/claude-code)