### PR TITLE
Main quest: Conquer the World

### DIFF
--- a/src/app/tap-tap-adventure/components/GameUI.tsx
+++ b/src/app/tap-tap-adventure/components/GameUI.tsx
@@ -25,6 +25,7 @@ import { CombatUI, CombatResult } from './CombatUI'
 import { EquipmentPanel } from './EquipmentPanel'
 import { InventoryPanel } from './InventoryPanel'
 import { QuestPanel } from './QuestPanel'
+import { MainQuestPanel } from './MainQuestPanel'
 import { StatAllocationScreen } from './StatAllocationScreen'
 import { ShopUI } from './ShopUI'
 import { StoryFeed } from './StoryFeed'
@@ -497,6 +498,7 @@ export default function GameUI({ onOpenStatus }: GameUIProps) {
           </div>
           {/* Right column: Quest, Equipment, Achievements & Inventory Panel — hidden on mobile */}
           <div className="hidden md:block p-4 bg-[#161723] border border-[#3a3c56] rounded-lg space-y-4 h-fit md:sticky md:top-8">
+            {character && <MainQuestPanel character={character} />}
             <QuestPanel />
             <AchievementPanel achievements={gameState.achievements ?? []} />
             <EquipmentPanel
@@ -539,6 +541,7 @@ export default function GameUI({ onOpenStatus }: GameUIProps) {
                 Close
               </button>
             </div>
+            {mobilePanel === 'quest' && character && <MainQuestPanel character={character} />}
             {mobilePanel === 'quest' && <QuestPanel />}
             {mobilePanel === 'equipment' && (
               <>

--- a/src/app/tap-tap-adventure/components/MainQuestPanel.tsx
+++ b/src/app/tap-tap-adventure/components/MainQuestPanel.tsx
@@ -1,0 +1,68 @@
+'use client'
+
+import { getConqueredCount, CONQUERABLE_REGIONS, TOTAL_CONQUERABLE } from '@/app/tap-tap-adventure/lib/mainQuestManager'
+import { getRegion } from '@/app/tap-tap-adventure/config/regions'
+import { FantasyCharacter } from '@/app/tap-tap-adventure/models/character'
+
+export function MainQuestPanel({ character }: { character: FantasyCharacter }) {
+  const mainQuest = character.mainQuest
+  if (!mainQuest) return null
+
+  const visited = character.visitedRegions ?? ['green_meadows']
+  const conquered = getConqueredCount(visited)
+  const progress = conquered / TOTAL_CONQUERABLE
+  const isComplete = mainQuest.status === 'completed'
+
+  return (
+    <div className={`border rounded-lg p-3 space-y-2 ${isComplete ? 'bg-amber-950/30 border-amber-700/50' : 'bg-[#1e1f30] border-indigo-700/30'}`}>
+      <div className="flex justify-between items-center">
+        <span className={`text-sm font-bold ${isComplete ? 'text-amber-400' : 'text-indigo-400'}`}>
+          {isComplete ? '👑 Quest Complete!' : '⚔️ Main Quest'}
+        </span>
+        <span className="text-[10px] px-1.5 py-0.5 rounded bg-indigo-900/50 text-indigo-300">
+          {conquered}/{TOTAL_CONQUERABLE}
+        </span>
+      </div>
+      <p className="text-xs text-white font-semibold">{mainQuest.title}</p>
+      <p className="text-[10px] text-slate-400">{mainQuest.description}</p>
+
+      {/* Progress bar */}
+      <div className="space-y-1">
+        <div className="flex justify-between text-[10px] text-slate-400">
+          <span>Regions Conquered</span>
+          <span>{Math.round(progress * 100)}%</span>
+        </div>
+        <div className="h-2 bg-slate-700 rounded-full overflow-hidden">
+          <div
+            className={`h-full rounded-full transition-all duration-300 ${isComplete ? 'bg-amber-500' : 'bg-indigo-500'}`}
+            style={{ width: `${progress * 100}%` }}
+          />
+        </div>
+      </div>
+
+      {/* Region list */}
+      <div className="grid grid-cols-2 gap-1">
+        {CONQUERABLE_REGIONS.map(regionId => {
+          const region = getRegion(regionId)
+          const isVisited = visited.includes(regionId)
+          return (
+            <div key={regionId} className={`text-[10px] px-1.5 py-0.5 rounded ${isVisited ? 'text-emerald-400 bg-emerald-950/30' : 'text-slate-500 bg-slate-800/50'}`}>
+              {region.icon} {region.name} {isVisited ? '✓' : ''}
+            </div>
+          )
+        })}
+      </div>
+
+      {/* Milestones */}
+      <div className="space-y-1">
+        <p className="text-[10px] text-slate-400 uppercase tracking-wider font-semibold">Milestones</p>
+        {mainQuest.milestones.map(m => (
+          <div key={m.regionsRequired} className={`flex justify-between text-[10px] ${m.claimed ? 'text-emerald-400' : conquered >= m.regionsRequired - 1 ? 'text-yellow-400' : 'text-slate-500'}`}>
+            <span>{m.claimed ? '✓' : '○'} {m.title} ({m.regionsRequired} regions)</span>
+            <span>+{m.goldReward} gold</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src/app/tap-tap-adventure/hooks/useCombatActionMutation.ts
+++ b/src/app/tap-tap-adventure/hooks/useCombatActionMutation.ts
@@ -7,6 +7,7 @@ import { DeathPenalty } from '@/app/tap-tap-adventure/lib/deathPenalty'
 import { generateHeirloom } from '@/app/tap-tap-adventure/lib/heirloomGenerator'
 import { inferItemTypeAndEffects } from '@/app/tap-tap-adventure/lib/itemPostProcessor'
 import { checkQuestProgress } from '@/app/tap-tap-adventure/lib/questGenerator'
+import { claimNewMilestones, getConqueredCount } from '@/app/tap-tap-adventure/lib/mainQuestManager'
 import { CombatAction, CombatState } from '@/app/tap-tap-adventure/models/combat'
 import { Mount } from '@/app/tap-tap-adventure/models/mount'
 import { FantasyCharacter, Item } from '@/app/tap-tap-adventure/models/types'
@@ -166,6 +167,25 @@ export function useCombatActionMutation(options?: { onMountDrop?: (mount: Mount)
           // Reputation gain for combat victory
           const repGain = pendingRegionId ? 3 : 1
           updateSelectedCharacter({ reputation: (character.reputation ?? 0) + repGain })
+
+          // Check main quest milestones
+          if (character.mainQuest && character.mainQuest.status === 'active') {
+            const updatedVisited = pendingRegionId
+              ? [...(character.visitedRegions ?? ['green_meadows']), pendingRegionId]
+              : (character.visitedRegions ?? ['green_meadows'])
+            const conquered = getConqueredCount(updatedVisited)
+            const milestoneGold = claimNewMilestones(character.mainQuest, conquered)
+            if (milestoneGold > 0) {
+              updateSelectedCharacter({ mainQuest: character.mainQuest })
+              // Use fresh gold from store since updateSelectedCharacter has been called multiple times
+              const freshChar = useGameStore.getState().gameState.characters.find(c => c.id === character.id)
+              if (freshChar) {
+                updateSelectedCharacter({ gold: freshChar.gold + milestoneGold })
+              }
+            } else {
+              updateSelectedCharacter({ mainQuest: character.mainQuest })
+            }
+          }
 
           addStoryEvent({
             id: `combat-victory-${Date.now()}`,

--- a/src/app/tap-tap-adventure/hooks/useGameStore.ts
+++ b/src/app/tap-tap-adventure/hooks/useGameStore.ts
@@ -13,6 +13,7 @@ import { defaultGameState } from '@/app/tap-tap-adventure/lib/defaultGameState'
 import { useItem as applyItemUse } from '@/app/tap-tap-adventure/lib/itemEffects'
 import { applyLevelFromDistance, calculateDay, calculateMaxHp, calculateMaxMana } from '@/app/tap-tap-adventure/lib/leveling'
 import { checkQuestProgress } from '@/app/tap-tap-adventure/lib/questGenerator'
+import { createMainQuest } from '@/app/tap-tap-adventure/lib/mainQuestManager'
 import { getUpgradeById } from '@/app/tap-tap-adventure/config/eternalUpgrades'
 import { getSpellConfigForCharacter } from '@/app/tap-tap-adventure/config/characterOptions'
 import { FantasyCharacter } from '@/app/tap-tap-adventure/models/character'
@@ -62,6 +63,7 @@ const defaultCharacter: FantasyCharacter = {
   difficultyMode: 'normal',
   currentRegion: 'green_meadows',
   visitedRegions: ['green_meadows'],
+  mainQuest: createMainQuest(),
 }
 
 export interface GameStore {
@@ -699,7 +701,7 @@ export const useGameStore = create<GameStore>()(
     }),
     {
       name: 'fantasy-tycoon-storage', // localStorage key (kept for backward compat)
-      version: 15,
+      version: 16,
       migrate: (persistedState: unknown) => {
         const state = persistedState as GameStore
         if (state?.gameState && !('combatState' in state.gameState)) {
@@ -756,6 +758,17 @@ export const useGameStore = create<GameStore>()(
               ;(char as FantasyCharacter).visitedRegions = [(char as FantasyCharacter).currentRegion ?? 'green_meadows']
             }
             // v15: customName is optional on activeMount; no action needed for backward compat
+            // v16: Add mainQuest
+            if (!(char as FantasyCharacter).mainQuest) {
+              ;(char as FantasyCharacter).mainQuest = createMainQuest()
+              // Mark milestones as claimed for already-visited regions (no retroactive gold)
+              const visited = (char as FantasyCharacter).visitedRegions ?? ['green_meadows']
+              const count = visited.filter((r: string) => r !== 'starting_village').length
+              for (const m of (char as FantasyCharacter).mainQuest!.milestones) {
+                if (count >= m.regionsRequired) m.claimed = true
+              }
+              if (count >= 12) (char as FantasyCharacter).mainQuest!.status = 'completed'
+            }
           }
         }
         // v6: Add activeQuest

--- a/src/app/tap-tap-adventure/lib/mainQuestManager.ts
+++ b/src/app/tap-tap-adventure/lib/mainQuestManager.ts
@@ -1,0 +1,45 @@
+import { MainQuest } from '@/app/tap-tap-adventure/models/quest'
+
+// All conquerable regions (excludes starting_village which is a non-combat hub)
+export const CONQUERABLE_REGIONS = [
+  'green_meadows', 'dark_forest', 'crystal_caves', 'scorched_wastes',
+  'frozen_peaks', 'shadow_realm', 'sky_citadel', 'sunken_ruins',
+  'volcanic_forge', 'feywild_grove', 'bone_wastes', 'dragons_spine',
+]
+
+export const TOTAL_CONQUERABLE = CONQUERABLE_REGIONS.length // 12
+
+const MILESTONES = [
+  { regionsRequired: 3, title: 'First Frontiers', goldReward: 150 },
+  { regionsRequired: 6, title: 'Halfway There', goldReward: 300 },
+  { regionsRequired: 9, title: 'Almost Supreme', goldReward: 500 },
+  { regionsRequired: TOTAL_CONQUERABLE, title: 'World Conqueror', goldReward: 1000 },
+]
+
+export function createMainQuest(): MainQuest {
+  return {
+    title: 'Conquer the World',
+    description: 'Defeat every region boss guardian and unite the lands under your banner.',
+    status: 'active',
+    milestones: MILESTONES.map(m => ({ ...m, claimed: false })),
+  }
+}
+
+export function getConqueredCount(visitedRegions: string[]): number {
+  return visitedRegions.filter(r => CONQUERABLE_REGIONS.includes(r)).length
+}
+
+/** Check for newly reached milestones and return total gold to award. Mutates milestone claimed flags. */
+export function claimNewMilestones(mainQuest: MainQuest, conqueredCount: number): number {
+  let goldAwarded = 0
+  for (const milestone of mainQuest.milestones) {
+    if (!milestone.claimed && conqueredCount >= milestone.regionsRequired) {
+      milestone.claimed = true
+      goldAwarded += milestone.goldReward
+    }
+  }
+  if (conqueredCount >= TOTAL_CONQUERABLE) {
+    mainQuest.status = 'completed'
+  }
+  return goldAwarded
+}

--- a/src/app/tap-tap-adventure/models/character.ts
+++ b/src/app/tap-tap-adventure/models/character.ts
@@ -3,6 +3,7 @@ import { z } from 'zod'
 import { GeneratedClassSchema } from './generatedClass'
 import { ItemSchema } from './item'
 import { MountSchema } from './mount'
+import { MainQuestSchema } from './quest'
 import { SpellSchema } from './spell'
 
 /** All schemas in this file are the single source of truth for both runtime validation and static typing. */
@@ -51,6 +52,7 @@ export const FantasyCharacterSchema = z.object({
   difficultyMode: z.string().optional().default('normal'),
   currentRegion: z.string().optional().default('green_meadows'),
   visitedRegions: z.array(z.string()).optional(),
+  mainQuest: MainQuestSchema.optional(),
 })
 export type FantasyCharacter = z.infer<typeof FantasyCharacterSchema>
 

--- a/src/app/tap-tap-adventure/models/quest.ts
+++ b/src/app/tap-tap-adventure/models/quest.ts
@@ -24,3 +24,19 @@ export const TimedQuestSchema = z.object({
   }),
 })
 export type TimedQuest = z.infer<typeof TimedQuestSchema>
+
+export const MainQuestMilestoneSchema = z.object({
+  regionsRequired: z.number(),
+  title: z.string(),
+  goldReward: z.number(),
+  claimed: z.boolean(),
+})
+export type MainQuestMilestone = z.infer<typeof MainQuestMilestoneSchema>
+
+export const MainQuestSchema = z.object({
+  title: z.string(),
+  description: z.string(),
+  status: z.enum(['active', 'completed']),
+  milestones: z.array(MainQuestMilestoneSchema),
+})
+export type MainQuest = z.infer<typeof MainQuestSchema>

--- a/src/app/tap-tap-adventure/models/types.ts
+++ b/src/app/tap-tap-adventure/models/types.ts
@@ -60,7 +60,7 @@ export type {
   SpellConditionSchema,
 } from './spell'
 export type { Mount, MountSchema, MountBonuses, MountBonusesSchema, MountRarity, MountRaritySchema } from './mount'
-export type { TimedQuest, TimedQuestSchema } from './quest'
+export type { TimedQuest, TimedQuestSchema, MainQuest, MainQuestSchema, MainQuestMilestone, MainQuestMilestoneSchema } from './quest'
 export type {
   CombatState,
   CombatEnemy,


### PR DESCRIPTION
## Summary
- **New main quest**: Every character starts with "Conquer the World" — defeat all 12 region boss guardians
- **MainQuestPanel**: Always-visible panel showing region conquest grid (with check marks), progress bar, and milestone rewards
- **Milestone rewards**: Gold bonuses at 3 regions (150g), 6 regions (300g), 9 regions (500g), and all 12 (1000g)
- **Boss victory integration**: Defeating a boss guardian auto-updates quest progress and claims eligible milestones
- **Store migration v16**: Existing characters get the quest with milestones pre-marked (no retroactive gold)

## Test plan
- [ ] New character → main quest panel visible with 1/12 progress (green_meadows pre-visited)
- [ ] Defeat a boss guardian → quest progress increments, region gets check mark
- [ ] Reach 3 regions → "First Frontiers" milestone claimed, +150 gold
- [ ] Existing character loads → migration assigns quest, already-visited milestones marked as claimed
- [ ] Quest panel renders on both desktop sidebar and mobile quest drawer
- [ ] Main quest coexists with timed quests (both visible)
- [ ] Complete all 12 regions → quest status changes to "completed", crown icon

Closes #168

🤖 Generated with [Claude Code](https://claude.com/claude-code)