### PR TITLE
Mount personality traits with gameplay effects

### DIFF
--- a/src/app/tap-tap-adventure/components/MountNamingModal.tsx
+++ b/src/app/tap-tap-adventure/components/MountNamingModal.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react'
 import { Button } from '@/app/tap-tap-adventure/components/ui/button'
 import { Mount } from '@/app/tap-tap-adventure/models/mount'
+import { MOUNT_PERSONALITY_INFO } from '@/app/tap-tap-adventure/config/mounts'
 
 interface MountNamingModalProps {
   mount: Mount
@@ -55,6 +56,15 @@ export function MountNamingModal({ mount, isOpen, onConfirm }: MountNamingModalP
             </div>
           </div>
           <p className="text-xs text-slate-400">{mount.description}</p>
+          {mount.personality && MOUNT_PERSONALITY_INFO[mount.personality] && (
+            <div className="mt-2 flex items-center gap-2 bg-amber-950/30 rounded px-2 py-1">
+              <span>{MOUNT_PERSONALITY_INFO[mount.personality].icon}</span>
+              <div className="text-left">
+                <span className="text-xs font-semibold text-amber-300">{MOUNT_PERSONALITY_INFO[mount.personality].label}</span>
+                <span className="text-[10px] text-slate-400 ml-1">— {MOUNT_PERSONALITY_INFO[mount.personality].description}</span>
+              </div>
+            </div>
+          )}
         </div>
 
         {/* Name input */}

--- a/src/app/tap-tap-adventure/components/PlayerStatusView.tsx
+++ b/src/app/tap-tap-adventure/components/PlayerStatusView.tsx
@@ -11,6 +11,7 @@ import { EquipmentSlotType } from '@/app/tap-tap-adventure/models/equipment'
 import { FantasyCharacter } from '@/app/tap-tap-adventure/models/character'
 import { getMountDisplayName } from '@/app/tap-tap-adventure/lib/mountUtils'
 import { MountNamingModal } from '@/app/tap-tap-adventure/components/MountNamingModal'
+import { MOUNT_PERSONALITY_INFO } from '@/app/tap-tap-adventure/config/mounts'
 
 interface PlayerStatusViewProps {
   onClose: () => void
@@ -393,6 +394,11 @@ export function PlayerStatusView({ onClose }: PlayerStatusViewProps) {
                   {mount.bonuses.healRate ? (
                     <span className="bg-green-900/30 text-green-300 px-2 py-0.5 rounded">+{mount.bonuses.healRate} Heal</span>
                   ) : null}
+                  {mount.personality && MOUNT_PERSONALITY_INFO[mount.personality] && (
+                    <span className="bg-amber-900/30 text-amber-300 px-2 py-0.5 rounded">
+                      {MOUNT_PERSONALITY_INFO[mount.personality].icon} {MOUNT_PERSONALITY_INFO[mount.personality].label}
+                    </span>
+                  )}
                 </div>
                 <div className="text-xs text-slate-400 mt-2">{mount.dailyCost} gp/day upkeep</div>
                 <button

--- a/src/app/tap-tap-adventure/config/mounts.ts
+++ b/src/app/tap-tap-adventure/config/mounts.ts
@@ -1,4 +1,4 @@
-import { Mount } from '@/app/tap-tap-adventure/models/mount'
+import { Mount, MountPersonality } from '@/app/tap-tap-adventure/models/mount'
 
 export const MOUNT_DEFINITIONS: Mount[] = [
   { id: 'horse', name: 'Horse', description: 'A reliable steed.', rarity: 'common', bonuses: { strength: 1, autoWalkSpeed: 1.5 }, icon: '🐴', dailyCost: 1 },
@@ -53,6 +53,28 @@ export function getMountFleeBonus(rarity: Mount['rarity']): number {
   }
 }
 
+export const MOUNT_PERSONALITY_INFO: Record<MountPersonality, { label: string; description: string; icon: string }> = {
+  loyal: { label: 'Loyal', description: 'Never abandons you. +5% flee chance.', icon: '🤝' },
+  skittish: { label: 'Skittish', description: 'Nervous in combat. -5% flee chance.', icon: '😰' },
+  aggressive: { label: 'Aggressive', description: '+2 bonus damage at close range.', icon: '😤' },
+  cautious: { label: 'Cautious', description: 'Prefers safety. +15% flee chance.', icon: '🛡️' },
+  prideful: { label: 'Prideful', description: 'Prideful nature. +10% damage at high reputation.', icon: '👑' },
+  wild: { label: 'Wild', description: 'Untamed spirit. Occasionally disobeys.', icon: '🌪️' },
+  gentle: { label: 'Gentle', description: '+1 heal rate while traveling.', icon: '🌿' },
+  fierce: { label: 'Fierce', description: 'Reflects 10% damage back to attackers.', icon: '🔥' },
+  stubborn: { label: 'Stubborn', description: 'Immune to fear effects.', icon: '🪨' },
+  greedy: { label: 'Greedy', description: '+10% gold from combat.', icon: '💰' },
+}
+
+const PERSONALITY_POOL: MountPersonality[] = [
+  'loyal', 'skittish', 'aggressive', 'cautious', 'prideful',
+  'wild', 'gentle', 'fierce', 'stubborn', 'greedy',
+]
+
+export function assignMountPersonality(): MountPersonality {
+  return PERSONALITY_POOL[Math.floor(Math.random() * PERSONALITY_POOL.length)]
+}
+
 /** Returns a mount appropriate for the character's level (never legendary in shops). */
 export function getShopMount(characterLevel: number): Mount {
   let pool: Mount[]
@@ -63,7 +85,8 @@ export function getShopMount(characterLevel: number): Mount {
   } else {
     pool = getMountsByRarity('common')
   }
-  return pool[Math.floor(Math.random() * pool.length)]
+  const mount = pool[Math.floor(Math.random() * pool.length)]
+  return { ...mount, personality: assignMountPersonality() }
 }
 
 export function getRandomMount(luckBonus: number = 0): Mount {
@@ -73,5 +96,6 @@ export function getRandomMount(luckBonus: number = 0): Mount {
   else if (roll > 0.8) { pool = getMountsByRarity('rare') }
   else if (roll > 0.5) { pool = getMountsByRarity('uncommon') }
   else { pool = getMountsByRarity('common') }
-  return pool[Math.floor(Math.random() * pool.length)]
+  const mount = pool[Math.floor(Math.random() * pool.length)]
+  return { ...mount, personality: assignMountPersonality() }
 }

--- a/src/app/tap-tap-adventure/hooks/useGameStore.ts
+++ b/src/app/tap-tap-adventure/hooks/useGameStore.ts
@@ -21,6 +21,7 @@ import { CombatState } from '@/app/tap-tap-adventure/models/combat'
 import { getEquipmentSlot, EquipmentSlotType } from '@/app/tap-tap-adventure/models/equipment'
 import { PlayerAchievement } from '@/app/tap-tap-adventure/models/achievement'
 import { Mount } from '@/app/tap-tap-adventure/models/mount'
+import { assignMountPersonality } from '@/app/tap-tap-adventure/config/mounts'
 import { TimedQuest } from '@/app/tap-tap-adventure/models/quest'
 import {
   FantasyDecisionPoint,
@@ -701,7 +702,7 @@ export const useGameStore = create<GameStore>()(
     }),
     {
       name: 'fantasy-tycoon-storage', // localStorage key (kept for backward compat)
-      version: 16,
+      version: 17,
       migrate: (persistedState: unknown) => {
         const state = persistedState as GameStore
         if (state?.gameState && !('combatState' in state.gameState)) {
@@ -768,6 +769,10 @@ export const useGameStore = create<GameStore>()(
                 if (count >= m.regionsRequired) m.claimed = true
               }
               if (count >= 12) (char as FantasyCharacter).mainQuest!.status = 'completed'
+            }
+            // v17: Add mount personality
+            if ((char as FantasyCharacter).activeMount && !(char as FantasyCharacter).activeMount!.personality) {
+              ;(char as FantasyCharacter).activeMount!.personality = assignMountPersonality()
             }
           }
         }

--- a/src/app/tap-tap-adventure/lib/combatEngine.ts
+++ b/src/app/tap-tap-adventure/lib/combatEngine.ts
@@ -247,7 +247,14 @@ export function calculateFleeChance(
   const mountFleeBonus = character.activeMount
     ? getMountFleeBonus(character.activeMount.rarity) / 100
     : 0
-  const chance = 0.3 + effectiveLuck * 0.02 - enemy.level * 0.05 + fleeBonus.percentage / 100 + mountFleeBonus
+  const personalityFleeBonus = (() => {
+    const p = character.activeMount?.personality
+    if (p === 'loyal') return 0.05
+    if (p === 'skittish') return -0.05
+    if (p === 'cautious') return 0.15
+    return 0
+  })()
+  const chance = 0.3 + effectiveLuck * 0.02 - enemy.level * 0.05 + fleeBonus.percentage / 100 + mountFleeBonus + personalityFleeBonus
   return Math.max(0.1, Math.min(0.9, chance))
 }
 
@@ -585,7 +592,8 @@ export function processPlayerAction(
               combatDistance
             )
           : 1.0
-        const damage = Math.max(1, Math.round(rawAtkDmg * wRangeMult))
+        const aggressiveBonus = (character.activeMount?.personality === 'aggressive' && combatDistance === 'close') ? 2 : 0
+        const damage = Math.max(1, Math.round(rawAtkDmg * wRangeMult) + aggressiveBonus)
         enemy.hp = Math.max(0, enemy.hp - damage)
         playerState.comboCount = (playerState.comboCount ?? 0) + 1
         const comboText =
@@ -618,7 +626,8 @@ export function processPlayerAction(
               combatDistance
             )
           : 1.0
-        const damage = Math.max(1, Math.round(baseDmg * 1.8 * heavyWRangeMult))
+        const heavyAggressiveBonus = (character.activeMount?.personality === 'aggressive' && combatDistance === 'close') ? 2 : 0
+        const damage = Math.max(1, Math.round(baseDmg * 1.8 * heavyWRangeMult) + heavyAggressiveBonus)
         enemy.hp = Math.max(0, enemy.hp - damage)
         playerState.comboCount = (playerState.comboCount ?? 0) + 1
         const comboText = playerState.comboCount > 1 ? ` (${playerState.comboCount}x combo!)` : ''
@@ -1058,6 +1067,15 @@ export function processPlayerAction(
           description: `Thorns deal ${thornsDmg} damage back to ${enemy.name}!`,
         })
       }
+      // Fierce mount personality: reflect 10% damage
+      if (character.activeMount?.personality === 'fierce' && actualDamageDealt > 0) {
+        const fierceReflect = Math.max(1, Math.round(actualDamageDealt * 0.1))
+        enemy.hp = Math.max(0, enemy.hp - fierceReflect)
+        newLogs.push({
+          turn: turnNumber, actor: 'player', action: 'reflect', damage: fierceReflect,
+          description: `Your mount retaliates, dealing ${fierceReflect} damage to ${enemy.name}!`,
+        })
+      }
     }
     if (!result.moveCloser) {
       newLogs.push(...result.logs)
@@ -1139,6 +1157,15 @@ export function processPlayerAction(
           action: 'thorns',
           damage: thornsDmg,
           description: `Thorns deal ${thornsDmg} damage back to ${enemy.name}!`,
+        })
+      }
+      // Fierce mount personality: reflect 10% damage
+      if (character.activeMount?.personality === 'fierce' && actualDmg > 0) {
+        const fierceReflect = Math.max(1, Math.round(actualDmg * 0.1))
+        enemy.hp = Math.max(0, enemy.hp - fierceReflect)
+        newLogs.push({
+          turn: turnNumber, actor: 'player', action: 'reflect', damage: fierceReflect,
+          description: `Your mount retaliates, dealing ${fierceReflect} damage to ${enemy.name}!`,
         })
       }
 

--- a/src/app/tap-tap-adventure/lib/leveling.ts
+++ b/src/app/tap-tap-adventure/lib/leveling.ts
@@ -163,7 +163,7 @@ export function applyLevelFromDistance(
   // Uses floor(newDist/rate) - floor(oldDist/rate) so single-step increments work
   const oldDistance = updated.distance - stepsGained
   const currentHp = updated.hp ?? maxHp
-  const mountHealBonus = updated.activeMount?.bonuses?.healRate ?? 0
+  const mountHealBonus = (updated.activeMount?.bonuses?.healRate ?? 0) + (updated.activeMount?.personality === 'gentle' ? 1 : 0)
   const skills = resolveSkills(updated)
   const healSkillBonus = getSkillBonus(skills, 'heal_rate')
   const diffMods = getDifficultyModifiers(updated.difficultyMode)

--- a/src/app/tap-tap-adventure/models/mount.ts
+++ b/src/app/tap-tap-adventure/models/mount.ts
@@ -13,6 +13,12 @@ export type MountBonuses = z.infer<typeof MountBonusesSchema>
 export const MountRaritySchema = z.enum(['common', 'uncommon', 'rare', 'legendary'])
 export type MountRarity = z.infer<typeof MountRaritySchema>
 
+export const MountPersonalitySchema = z.enum([
+  'loyal', 'skittish', 'aggressive', 'cautious', 'prideful',
+  'wild', 'gentle', 'fierce', 'stubborn', 'greedy',
+])
+export type MountPersonality = z.infer<typeof MountPersonalitySchema>
+
 export const MountSchema = z.object({
   id: z.string(),
   name: z.string(),
@@ -22,6 +28,7 @@ export const MountSchema = z.object({
   icon: z.string(),
   dailyCost: z.number(),
   customName: z.string().optional(),
+  personality: MountPersonalitySchema.optional(),
 })
 
 export type Mount = z.infer<typeof MountSchema>

--- a/src/app/tap-tap-adventure/models/types.ts
+++ b/src/app/tap-tap-adventure/models/types.ts
@@ -59,7 +59,7 @@ export type {
   SpellCondition,
   SpellConditionSchema,
 } from './spell'
-export type { Mount, MountSchema, MountBonuses, MountBonusesSchema, MountRarity, MountRaritySchema } from './mount'
+export type { Mount, MountSchema, MountBonuses, MountBonusesSchema, MountRarity, MountRaritySchema, MountPersonality, MountPersonalitySchema } from './mount'
 export type { TimedQuest, TimedQuestSchema, MainQuest, MainQuestSchema, MainQuestMilestone, MainQuestMilestoneSchema } from './quest'
 export type {
   CombatState,


### PR DESCRIPTION
## Summary
- **10 personality traits**: Loyal, Skittish, Aggressive, Cautious, Prideful, Wild, Gentle, Fierce, Stubborn, Greedy — each with unique icon, label, and description
- **Random assignment**: Every mount gets a random personality on acquisition (combat drops, shop purchases, event taming)
- **Combat effects implemented**: 
  - Loyal: +5% flee chance
  - Skittish: -5% flee chance  
  - Cautious: +15% flee chance
  - Aggressive: +2 bonus damage at close range
  - Fierce: 10% damage reflection when hit
  - Gentle: +1 heal rate while traveling
- **UI display**: Personality shown in MountNamingModal (on acquisition) and PlayerStatusView (in character sheet)
- **Store migration v17**: Existing mounts get a random personality assigned

Note: Complex behavioral traits (Prideful reputation-gated abandonment, Wild/Stubborn disobedience, Greedy shop interactions) are deferred to a follow-up PR.

## Test plan
- [ ] Acquire mount from combat → naming modal shows personality trait
- [ ] Buy mount from shop → personality assigned
- [ ] Check character sheet → personality badge visible in mount section
- [ ] Flee with Loyal mount → higher flee chance than base
- [ ] Flee with Cautious mount → significantly higher flee chance
- [ ] Attack at close range with Aggressive mount → +2 damage bonus
- [ ] Get hit with Fierce mount → 10% damage reflected in combat log
- [ ] Travel with Gentle mount → faster HP regen
- [ ] Existing save loads → mount gets personality via v17 migration

Closes #165

🤖 Generated with [Claude Code](https://claude.com/claude-code)