### PR TITLE
Mount HP system: mounts can be targeted and killed in combat

### DIFF
--- a/src/app/api/v1/tap-tap-adventure/combat/action/route.ts
+++ b/src/app/api/v1/tap-tap-adventure/combat/action/route.ts
@@ -38,6 +38,11 @@ export async function POST(req: NextRequest) {
       rewards = { gold: -goldLoss, loot: [] }
     }
 
+    // If mount died in combat, remove it from character
+    if (result.mountDied) {
+      updatedCharacter = { ...updatedCharacter, activeMount: null }
+    }
+
     return NextResponse.json({
       combatState: updatedCombat,
       rewards,

--- a/src/app/tap-tap-adventure/components/CombatUI.tsx
+++ b/src/app/tap-tap-adventure/components/CombatUI.tsx
@@ -419,6 +419,9 @@ export function CombatUI({ combatState }: CombatUIProps) {
         </div>
         {/* HP + Mana on compact rows */}
         <HpBar current={playerState.hp} max={playerState.maxHp} label="You" color="text-blue-400" />
+        {playerState.mountHp !== undefined && playerState.mountMaxHp !== undefined && playerState.mountHp > 0 && (
+          <HpBar current={playerState.mountHp} max={playerState.mountMaxHp} label={`${character?.activeMount?.icon ?? '🐴'} Mount`} color="text-amber-400" />
+        )}
         {maxMana > 0 && (
           <ManaBar current={currentMana} max={maxMana} />
         )}

--- a/src/app/tap-tap-adventure/config/mounts.ts
+++ b/src/app/tap-tap-adventure/config/mounts.ts
@@ -53,6 +53,16 @@ export function getMountFleeBonus(rarity: Mount['rarity']): number {
   }
 }
 
+/** Returns the max HP for a mount based on rarity. */
+export function getMountMaxHp(rarity: Mount['rarity']): number {
+  switch (rarity) {
+    case 'common': return 20
+    case 'uncommon': return 35
+    case 'rare': return 50
+    case 'legendary': return 80
+  }
+}
+
 export const MOUNT_PERSONALITY_INFO: Record<MountPersonality, { label: string; description: string; icon: string }> = {
   loyal: { label: 'Loyal', description: 'Never abandons you. +5% flee chance.', icon: '🤝' },
   skittish: { label: 'Skittish', description: 'Nervous in combat. -5% flee chance.', icon: '😰' },
@@ -86,7 +96,7 @@ export function getShopMount(characterLevel: number): Mount {
     pool = getMountsByRarity('common')
   }
   const mount = pool[Math.floor(Math.random() * pool.length)]
-  return { ...mount, personality: assignMountPersonality() }
+  return { ...mount, personality: assignMountPersonality(), hp: getMountMaxHp(mount.rarity), maxHp: getMountMaxHp(mount.rarity) }
 }
 
 export function getRandomMount(luckBonus: number = 0): Mount {
@@ -97,5 +107,5 @@ export function getRandomMount(luckBonus: number = 0): Mount {
   else if (roll > 0.5) { pool = getMountsByRarity('uncommon') }
   else { pool = getMountsByRarity('common') }
   const mount = pool[Math.floor(Math.random() * pool.length)]
-  return { ...mount, personality: assignMountPersonality() }
+  return { ...mount, personality: assignMountPersonality(), hp: getMountMaxHp(mount.rarity), maxHp: getMountMaxHp(mount.rarity) }
 }

--- a/src/app/tap-tap-adventure/hooks/useCombatActionMutation.ts
+++ b/src/app/tap-tap-adventure/hooks/useCombatActionMutation.ts
@@ -99,6 +99,18 @@ export function useCombatActionMutation(options?: { onMountDrop?: (mount: Mount)
         maxMana: data.combatState.playerState.maxMana,
       })
 
+      // Sync mount HP back to character
+      if (data.combatState.playerState.mountHp !== undefined && character.activeMount) {
+        if (data.combatState.playerState.mountHp <= 0) {
+          // Mount died in combat
+          updateSelectedCharacter({ activeMount: null })
+        } else {
+          updateSelectedCharacter({
+            activeMount: { ...character.activeMount, hp: data.combatState.playerState.mountHp },
+          })
+        }
+      }
+
       if (data.combatState.status === 'active') {
         // Combat continues — play sounds based on what happened
         // Check for critical hits in new log entries

--- a/src/app/tap-tap-adventure/hooks/useGameStore.ts
+++ b/src/app/tap-tap-adventure/hooks/useGameStore.ts
@@ -21,7 +21,7 @@ import { CombatState } from '@/app/tap-tap-adventure/models/combat'
 import { getEquipmentSlot, EquipmentSlotType } from '@/app/tap-tap-adventure/models/equipment'
 import { PlayerAchievement } from '@/app/tap-tap-adventure/models/achievement'
 import { Mount } from '@/app/tap-tap-adventure/models/mount'
-import { assignMountPersonality } from '@/app/tap-tap-adventure/config/mounts'
+import { assignMountPersonality, getMountMaxHp } from '@/app/tap-tap-adventure/config/mounts'
 import { TimedQuest } from '@/app/tap-tap-adventure/models/quest'
 import {
   FantasyDecisionPoint,
@@ -702,7 +702,7 @@ export const useGameStore = create<GameStore>()(
     }),
     {
       name: 'fantasy-tycoon-storage', // localStorage key (kept for backward compat)
-      version: 17,
+      version: 18,
       migrate: (persistedState: unknown) => {
         const state = persistedState as GameStore
         if (state?.gameState && !('combatState' in state.gameState)) {
@@ -773,6 +773,13 @@ export const useGameStore = create<GameStore>()(
             // v17: Add mount personality
             if ((char as FantasyCharacter).activeMount && !(char as FantasyCharacter).activeMount!.personality) {
               ;(char as FantasyCharacter).activeMount!.personality = assignMountPersonality()
+            }
+            // v18: Add mount HP
+            if ((char as FantasyCharacter).activeMount && (char as FantasyCharacter).activeMount!.hp === undefined) {
+              const rarity = (char as FantasyCharacter).activeMount!.rarity
+              const hp = getMountMaxHp(rarity)
+              ;(char as FantasyCharacter).activeMount!.hp = hp
+              ;(char as FantasyCharacter).activeMount!.maxHp = hp
             }
           }
         }

--- a/src/app/tap-tap-adventure/lib/combatEngine.ts
+++ b/src/app/tap-tap-adventure/lib/combatEngine.ts
@@ -17,7 +17,7 @@ import {
 } from '@/app/tap-tap-adventure/models/combat'
 import { Item } from '@/app/tap-tap-adventure/models/item'
 import { Mount } from '@/app/tap-tap-adventure/models/mount'
-import { getRandomMount, getMountFreeMoves, getMountFleeBonus } from '@/app/tap-tap-adventure/config/mounts'
+import { getRandomMount, getMountFreeMoves, getMountFleeBonus, getMountMaxHp } from '@/app/tap-tap-adventure/config/mounts'
 
 import { getDifficultyModifiers } from '@/app/tap-tap-adventure/config/difficultyModes'
 
@@ -109,6 +109,8 @@ export function initializePlayerCombatState(character: FantasyCharacter): Combat
     turnActions: [],
     luck: totalLuck,
     mountMovesRemaining: mountFreeMoves,
+    mountHp: character.activeMount ? (character.activeMount.hp ?? getMountMaxHp(character.activeMount.rarity)) : undefined,
+    mountMaxHp: character.activeMount ? getMountMaxHp(character.activeMount.rarity) : undefined,
   }
 }
 
@@ -466,10 +468,11 @@ export function processPlayerAction(
   combatState: CombatState,
   action: CombatActionRequest,
   character: FantasyCharacter
-): { combatState: CombatState; consumedItemId?: string } {
+): { combatState: CombatState; consumedItemId?: string; mountDied?: boolean } {
   let { enemy, playerState, turnNumber, combatLog, status, enemyTelegraph, isBoss } = structuredClone(combatState)
   const newLogs: CombatLogEntry[] = []
   let consumedItemId: string | undefined
+  let mountDied = false
   const bossAlreadyPhased = isBoss ? enemy.name.includes('(Enraged)') : false
   let combatDistance: CombatDistance = combatState.combatDistance ?? 'mid'
   // Only propagate combatDistance in returns if the original state had it set
@@ -1045,7 +1048,24 @@ export function processPlayerAction(
         }
       }
 
-      playerState.hp = Math.max(0, playerState.hp - actualDamageDealt)
+      // Mount targeting: 20% chance enemy targets mount instead of player
+      if (playerState.mountHp !== undefined && playerState.mountHp > 0 && Math.random() < 0.2) {
+        playerState.mountHp = Math.max(0, playerState.mountHp - actualDamageDealt)
+        newLogs.push({
+          turn: turnNumber, actor: 'enemy', action: 'attack', damage: actualDamageDealt,
+          description: `${enemy.name} targets your mount for ${actualDamageDealt} damage!`,
+        })
+        if (playerState.mountHp <= 0) {
+          mountDied = true
+          playerState.mountHp = 0
+          newLogs.push({
+            turn: turnNumber, actor: 'enemy', action: 'status_effect',
+            description: `Your mount has fallen in combat! 💀`,
+          })
+        }
+      } else {
+        playerState.hp = Math.max(0, playerState.hp - actualDamageDealt)
+      }
 
       if (dmgReduction > 0 || actualDamageDealt < reducedDmg) {
         const shieldAbsorbed = reducedDmg - actualDamageDealt
@@ -1068,7 +1088,7 @@ export function processPlayerAction(
         })
       }
       // Fierce mount personality: reflect 10% damage
-      if (character.activeMount?.personality === 'fierce' && actualDamageDealt > 0) {
+      if (character.activeMount?.personality === 'fierce' && actualDamageDealt > 0 && !mountDied) {
         const fierceReflect = Math.max(1, Math.round(actualDamageDealt * 0.1))
         enemy.hp = Math.max(0, enemy.hp - fierceReflect)
         newLogs.push({
@@ -1137,15 +1157,32 @@ export function processPlayerAction(
       }
 
       const enemyElemText = getEffectivenessText(enemyElemMult)
-      playerState.hp = Math.max(0, playerState.hp - actualDmg)
-      newLogs.push({
-        turn: turnNumber,
-        actor: 'enemy',
-        action: 'attack',
-        damage: actualDmg,
-        description: `${enemyCrit ? 'CRITICAL! ' : ''}${enemy.name} attacks you for ${actualDmg} damage!${dmgReduction > 0 ? ` (${dmgReduction}% reduced)` : ''}${(playerState.shield ?? 0) > 0 || reducedDmg !== actualDmg ? ' (shield absorbed some)' : ''}${enemyElemText ? ` ${enemyElemText}` : ''}`,
-        isCritical: enemyCrit,
-      })
+      // Mount targeting: 20% chance enemy targets mount instead of player
+      if (playerState.mountHp !== undefined && playerState.mountHp > 0 && Math.random() < 0.2) {
+        playerState.mountHp = Math.max(0, playerState.mountHp - actualDmg)
+        newLogs.push({
+          turn: turnNumber, actor: 'enemy', action: 'attack', damage: actualDmg,
+          description: `${enemy.name} targets your mount for ${actualDmg} damage!`,
+        })
+        if (playerState.mountHp <= 0) {
+          mountDied = true
+          playerState.mountHp = 0
+          newLogs.push({
+            turn: turnNumber, actor: 'enemy', action: 'status_effect',
+            description: `Your mount has fallen in combat! 💀`,
+          })
+        }
+      } else {
+        playerState.hp = Math.max(0, playerState.hp - actualDmg)
+        newLogs.push({
+          turn: turnNumber,
+          actor: 'enemy',
+          action: 'attack',
+          damage: actualDmg,
+          description: `${enemyCrit ? 'CRITICAL! ' : ''}${enemy.name} attacks you for ${actualDmg} damage!${dmgReduction > 0 ? ` (${dmgReduction}% reduced)` : ''}${(playerState.shield ?? 0) > 0 || reducedDmg !== actualDmg ? ' (shield absorbed some)' : ''}${enemyElemText ? ` ${enemyElemText}` : ''}`,
+          isCritical: enemyCrit,
+        })
+      }
 
       // Apply thorns damage back to enemy
       const thornsDmg = getThornsDamage(playerState.statusEffects)
@@ -1160,7 +1197,7 @@ export function processPlayerAction(
         })
       }
       // Fierce mount personality: reflect 10% damage
-      if (character.activeMount?.personality === 'fierce' && actualDmg > 0) {
+      if (character.activeMount?.personality === 'fierce' && actualDmg > 0 && !mountDied) {
         const fierceReflect = Math.max(1, Math.round(actualDmg * 0.1))
         enemy.hp = Math.max(0, enemy.hp - fierceReflect)
         newLogs.push({
@@ -1319,6 +1356,7 @@ export function processPlayerAction(
       turnPhase: 'enemy_done',
     },
     consumedItemId,
+    mountDied,
   }
 }
 

--- a/src/app/tap-tap-adventure/lib/leveling.ts
+++ b/src/app/tap-tap-adventure/lib/leveling.ts
@@ -1,5 +1,6 @@
 import { CLASS_SPELL_CONFIG } from '@/app/tap-tap-adventure/config/characterOptions'
 import { getDifficultyModifiers } from '@/app/tap-tap-adventure/config/difficultyModes'
+import { getMountMaxHp } from '@/app/tap-tap-adventure/config/mounts'
 import { SKILLS } from '@/app/tap-tap-adventure/config/skills'
 import { FantasyCharacter } from '@/app/tap-tap-adventure/models/character'
 import { Skill } from '@/app/tap-tap-adventure/models/skill'
@@ -171,6 +172,14 @@ export function applyLevelFromDistance(
   const metaHealMultiplier = metaBonuses?.healRateMultiplier ?? 1
   const baseHeal = Math.max(0, healTicks) * (1 + healSkillBonus.flat) + (healTicks > 0 ? mountHealBonus : 0)
   const healed = Math.min(maxHp, currentHp + Math.round(baseHeal * diffMods.healRateMultiplier * metaHealMultiplier))
+
+  // Mount HP healing while traveling
+  if (updated.activeMount && healTicks > 0 && updated.activeMount.hp !== undefined && updated.activeMount.maxHp !== undefined) {
+    const mountMaxHp = updated.activeMount.maxHp
+    const mountHealAmount = 1
+    const newMountHp = Math.min(mountMaxHp, (updated.activeMount.hp ?? mountMaxHp) + mountHealAmount)
+    updated = { ...updated, activeMount: { ...updated.activeMount, hp: newMountHp } }
+  }
 
   const classConfig = CLASS_SPELL_CONFIG[updated.class.toLowerCase()]
   const regenMultiplier = classConfig?.regenMultiplier ?? 1

--- a/src/app/tap-tap-adventure/models/combat.ts
+++ b/src/app/tap-tap-adventure/models/combat.ts
@@ -97,6 +97,8 @@ export const CombatPlayerStateSchema = z.object({
   turnActions: z.array(z.string()).optional(),
   luck: z.number().default(0),
   mountMovesRemaining: z.number().optional(),
+  mountHp: z.number().optional(),
+  mountMaxHp: z.number().optional(),
 })
 export type CombatPlayerState = z.infer<typeof CombatPlayerStateSchema>
 

--- a/src/app/tap-tap-adventure/models/mount.ts
+++ b/src/app/tap-tap-adventure/models/mount.ts
@@ -29,6 +29,8 @@ export const MountSchema = z.object({
   dailyCost: z.number(),
   customName: z.string().optional(),
   personality: MountPersonalitySchema.optional(),
+  hp: z.number().optional(),
+  maxHp: z.number().optional(),
 })
 
 export type Mount = z.infer<typeof MountSchema>


### PR DESCRIPTION
## Summary
- **Mount HP by rarity**: Common=20, Uncommon=35, Rare=50, Legendary=80 HP
- **Enemy mount targeting**: 20% chance each turn the enemy attacks your mount instead of you
- **Mount death**: When mount HP reaches 0, mount dies permanently with combat log message and is removed from character
- **Mount HP bar**: Displayed in combat UI below player HP (amber-colored, with mount icon)
- **Travel healing**: Mounts heal 1 HP per travel tick alongside player healing
- **Mount HP initialization**: New mounts from combat drops, shop purchases, and events all get HP
- **Store migration v18**: Existing mounts backfilled with full HP

## Test plan
- [ ] Enter combat with mount → mount HP bar visible below player HP
- [ ] Take damage in combat → ~20% of hits target mount instead of player
- [ ] Mount HP reaches 0 → "Your mount has fallen in combat!" log, mount removed
- [ ] After mount death → mount bonuses no longer apply, HP bar disappears
- [ ] Travel with damaged mount → mount HP slowly regenerates (1 per tick)
- [ ] Buy mount from shop → starts at full HP
- [ ] Win mount from combat drop → starts at full HP
- [ ] Existing save loads → mount gets full HP via v18 migration
- [ ] Fierce mount hit → reflects damage only if mount is still alive

Closes #163

🤖 Generated with [Claude Code](https://claude.com/claude-code)