### PR TITLE
Add scoring animations: floating numbers, combo pulse, animated counters

### DIFF
--- a/src/app/daily-card-game/components/animations/animated-score-display.tsx
+++ b/src/app/daily-card-game/components/animations/animated-score-display.tsx
@@ -1,0 +1,53 @@
+'use client'
+
+import { AnimatePresence, motion } from 'framer-motion'
+
+interface AnimatedScoreDisplayProps {
+  chips: number
+  mult: number
+}
+
+const slideVariants = {
+  initial: { y: -12, opacity: 0 },
+  animate: { y: 0, opacity: 1 },
+  exit: { y: 12, opacity: 0 },
+}
+
+export function AnimatedScoreDisplay({ chips, mult }: AnimatedScoreDisplayProps) {
+  return (
+    <div>
+      <strong>Chips x Mult:</strong>{' '}
+      <span className="inline-flex items-center gap-1">
+        <span className="text-blue-300 inline-block overflow-hidden align-middle">
+          <AnimatePresence mode="popLayout" initial={false}>
+            <motion.span
+              key={chips}
+              variants={slideVariants}
+              initial="initial"
+              animate="animate"
+              exit="exit"
+              transition={{ duration: 0.2 }}
+              className="inline-block"
+            >
+              {chips}
+            </motion.span>
+          </AnimatePresence>
+        </span>
+        <span> x </span>
+        <AnimatePresence mode="popLayout" initial={false}>
+          <motion.span
+            key={mult}
+            variants={slideVariants}
+            initial="initial"
+            animate="animate"
+            exit="exit"
+            transition={{ duration: 0.2 }}
+            className="inline-block text-orange-400 animate-combo-pulse"
+          >
+            {mult}
+          </motion.span>
+        </AnimatePresence>
+      </span>
+    </div>
+  )
+}

--- a/src/app/daily-card-game/components/animations/scoring-feed.tsx
+++ b/src/app/daily-card-game/components/animations/scoring-feed.tsx
@@ -1,0 +1,77 @@
+'use client'
+
+import { useEffect, useRef, useState } from 'react'
+
+import { isCustomScoringEvent } from '@/app/daily-card-game/domain/game/types'
+import type { ScoringEvent } from '@/app/daily-card-game/domain/game/types'
+import { useDailyCardGameStore } from '@/app/daily-card-game/store'
+
+interface ActiveEvent {
+  id: string
+  event: ScoringEvent
+}
+
+export function ScoringFeed() {
+  const [activeEvents, setActiveEvents] = useState<ActiveEvent[]>([])
+  const scoringEvents = useDailyCardGameStore(state => state.game.gamePlayState.scoringEvents)
+  const seenIdsRef = useRef<Set<string>>(new Set())
+
+  useEffect(() => {
+    const newEvents: ActiveEvent[] = []
+    for (const event of scoringEvents) {
+      if (isCustomScoringEvent(event)) continue
+      if (seenIdsRef.current.has(event.id)) continue
+      seenIdsRef.current.add(event.id)
+      newEvents.push({ id: event.id, event })
+    }
+    if (newEvents.length > 0) {
+      setActiveEvents(prev => [...prev, ...newEvents])
+    }
+  }, [scoringEvents])
+
+  // Clean up seenIds when scoringEvents is cleared
+  useEffect(() => {
+    if (scoringEvents.length === 0) {
+      seenIdsRef.current.clear()
+    }
+  }, [scoringEvents.length])
+
+  const removeEvent = (id: string) => {
+    setActiveEvents(prev => prev.filter(e => e.id !== id))
+  }
+
+  if (activeEvents.length === 0) return null
+
+  return (
+    <div className="pointer-events-none flex flex-col gap-1 pl-2">
+      {activeEvents.map(({ id, event }) => {
+        const isMultiplicative = event.type === 'mult' && event.operator === 'x'
+        const isChips = event.type === 'chips'
+
+        let colorClass: string
+        let label: string
+
+        if (isChips) {
+          colorClass = 'text-blue-300'
+          label = `+${event.value}`
+        } else if (isMultiplicative) {
+          colorClass = 'text-yellow-300 font-bold'
+          label = `×${event.value}`
+        } else {
+          colorClass = 'text-orange-400'
+          label = `+${event.value}`
+        }
+
+        return (
+          <div
+            key={id}
+            className={`animate-float-up text-sm font-semibold ${colorClass}`}
+            onAnimationEnd={() => removeEvent(id)}
+          >
+            {label}
+          </div>
+        )
+      })}
+    </div>
+  )
+}

--- a/src/app/daily-card-game/components/game-views/gameplay.tsx
+++ b/src/app/daily-card-game/components/game-views/gameplay.tsx
@@ -18,6 +18,9 @@ import { useDailyCardGameStore } from '@/app/daily-card-game/store'
 import { useGameState } from '@/app/daily-card-game/useGameState'
 import { Button } from '@/components/ui/button'
 
+import { AnimatedScoreDisplay } from '@/app/daily-card-game/components/animations/animated-score-display'
+import { ScoringFeed } from '@/app/daily-card-game/components/animations/scoring-feed'
+
 import { ViewTemplate } from './view-template'
 
 const SelectedHandScore = ({ hand }: { hand: PokerHandState }) => {
@@ -106,10 +109,9 @@ export function GamePlayView() {
     <ViewTemplate
       sidebarContentBottom={
         <>
+          <ScoringFeed />
           <div className="pl-2">
-            <div>
-              <strong>Chips x Mult:</strong> {score.chips} x {score.mult}
-            </div>
+            <AnimatedScoreDisplay chips={score.chips} mult={score.mult} />
             <div>
               <strong>Your Score:</strong> {currentBlind?.score.toString()}
             </div>


### PR DESCRIPTION
## Summary
- Adds `AnimatedScoreDisplay` component using Framer Motion to smoothly animate chips/mult values as they change during scoring, with combo-pulse effect on mult increases
- Adds `ScoringFeed` component that shows floating +chips/+mult/×mult labels during hand scoring using the existing `float-up` Tailwind keyframe
- Replaces static "Chips x Mult" text in gameplay sidebar with animated versions

## Implementation details
- Uses existing Tailwind keyframes (`float-up`, `combo-pulse`) — no new CSS added
- `ScoringFeed` tracks seen event IDs to detect new scoring events and auto-removes them after animation completes
- Color-coded: chips (blue), additive mult (orange), multiplicative mult (yellow bold)
- Existing scoring events log in sidebar is preserved unchanged

Closes #133

## Test plan
- [ ] Play a hand and verify floating score numbers appear in the sidebar during scoring
- [ ] Verify chips values animate blue, mult orange, multiplicative mult (polychrome) yellow
- [ ] Verify the Chips x Mult display smoothly transitions when values change
- [ ] Verify combo-pulse fires on mult value changes
- [ ] Play multiple hands back-to-back — animations should not bleed between hands
- [ ] Verify scoring events log in sidebar still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)