### PR TITLE
feat: combat animations — damage tiers, stat indicators, level-up particles

### DIFF
--- a/src/app/tap-tap-adventure/components/FloatingDamage.tsx
+++ b/src/app/tap-tap-adventure/components/FloatingDamage.tsx
@@ -49,12 +49,14 @@ function FloatingNumber({ event }: { event: DamageEvent }) {
           : 'text-green-400'
 
   const size = event.isCritical
-    ? 'text-lg font-black'
-    : event.isDot
-      ? 'text-xs font-semibold italic'
-      : 'text-sm font-bold'
+    ? 'text-2xl font-black'
+    : !event.isDot && event.amount >= 50
+      ? 'text-xl font-black text-yellow-200'
+      : event.isDot
+        ? 'text-xs font-semibold italic'
+        : 'text-sm font-bold'
   // Stagger horizontal position slightly based on id hash
-  const offset = ((event.id.charCodeAt(0) ?? 0) % 5) * 10 - 20
+  const offset = ((event.id.charCodeAt(0) ?? 0) % 5) * 12 - 30
 
   return (
     <span
@@ -65,8 +67,10 @@ function FloatingNumber({ event }: { event: DamageEvent }) {
       }}
     >
       {event.isCritical && '★ '}
-      {event.isDot ? `${event.amount} ${event.dotType}` : `-${event.amount}`}
+      {event.isDot ? `${event.amount}` : `-${event.amount}`}
       {event.isCritical && ' ★'}
+      {event.effectiveness === 'super' && <span className="text-yellow-300 text-[10px] ml-0.5">⚡</span>}
+      {event.effectiveness === 'resisted' && <span className="text-blue-400 text-[10px] ml-0.5">~</span>}
     </span>
   )
 }

--- a/src/app/tap-tap-adventure/components/HudBar.tsx
+++ b/src/app/tap-tap-adventure/components/HudBar.tsx
@@ -1,5 +1,5 @@
 'use client'
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import { getDifficultyMode } from '@/app/tap-tap-adventure/config/difficultyModes'
 import { getRegion } from '@/app/tap-tap-adventure/config/regions'
@@ -124,6 +124,37 @@ export function HudBar({ onOpenStatus }: HudBarProps = {}) {
     [character]
   ) as Record<IconType, number | string>
 
+  interface StatDelta { id: string; key: IconType; delta: number }
+  const [statDeltas, setStatDeltas] = useState<StatDelta[]>([])
+  const prevStatsRef = useRef<Partial<Record<IconType, number>>>({})
+
+  useEffect(() => {
+    const trackedKeys: IconType[] = ['heartIcon', 'sunIcon', 'waterDropIcon']
+    const newDeltas: StatDelta[] = []
+    for (const key of trackedKeys) {
+      const rawVal = stats[key]
+      const current = typeof rawVal === 'string' ? parseInt(rawVal, 10) : (rawVal as number)
+      const prev = prevStatsRef.current[key]
+      if (prev !== undefined && !isNaN(current) && current !== prev) {
+        newDeltas.push({ id: `${key}-${Date.now()}`, key, delta: current - prev })
+      }
+      if (!isNaN(current)) {
+        prevStatsRef.current[key] = current
+      }
+    }
+    if (newDeltas.length > 0) {
+      setStatDeltas(prev => {
+        const combined = [...prev, ...newDeltas].slice(-5)
+        return combined
+      })
+      newDeltas.forEach(d => {
+        setTimeout(() => {
+          setStatDeltas(prev => prev.filter(x => x.id !== d.id))
+        }, 1200)
+      })
+    }
+  }, [stats])
+
   const [soundEnabled, setSoundEnabled] = useState(true)
 
   useEffect(() => {
@@ -223,6 +254,14 @@ export function HudBar({ onOpenStatus }: HudBarProps = {}) {
           {getTooltipText(key)}
         </div>
       )}
+      {statDeltas.filter(d => d.key === key).map(d => (
+        <span
+          key={d.id}
+          className={`absolute top-0 left-full ml-1 text-[10px] font-bold pointer-events-none animate-float-up ${d.delta > 0 ? 'text-green-400' : 'text-red-400'}`}
+        >
+          {d.delta > 0 ? `+${d.delta}` : `${d.delta}`}
+        </span>
+      ))}
     </div>
   )
 

--- a/src/app/tap-tap-adventure/components/LevelUpCelebration.tsx
+++ b/src/app/tap-tap-adventure/components/LevelUpCelebration.tsx
@@ -1,7 +1,17 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import { soundEngine } from '@/app/tap-tap-adventure/lib/soundEngine'
+
+const PARTICLE_COLORS = ['#FACC15', '#FB923C', '#A78BFA', '#60A5FA']
+const PARTICLES = Array.from({ length: 12 }, (_, i) => {
+  const angle = (i / 12) * 2 * Math.PI
+  const radius = [40, 55, 70][i % 3]
+  const tx = Math.round(Math.cos(angle) * radius)
+  const ty = Math.round(Math.sin(angle) * radius)
+  const color = PARTICLE_COLORS[i % PARTICLE_COLORS.length]
+  return { id: i, tx, ty, color }
+})
 
 interface LevelUpCelebrationProps {
   level: number
@@ -45,7 +55,19 @@ export function LevelUpCelebration({ level, onDismiss }: LevelUpCelebrationProps
           setTimeout(onDismiss, 300)
         }}
       >
-        <div className="bg-gradient-to-b from-[#1e1f30] to-[#161723] border-2 border-yellow-500/50 rounded-2xl px-10 py-8 text-center shadow-2xl shadow-yellow-500/20">
+        <div className="relative bg-gradient-to-b from-[#1e1f30] to-[#161723] border-2 border-yellow-500/50 rounded-2xl px-10 py-8 text-center shadow-2xl shadow-yellow-500/20">
+          {isVisible && PARTICLES.map(p => (
+            <span
+              key={p.id}
+              className="absolute top-1/2 left-1/2 w-2 h-2 rounded-full pointer-events-none animate-particle-burst"
+              style={{
+                '--tx': `${p.tx}px`,
+                '--ty': `${p.ty}px`,
+                backgroundColor: p.color,
+                animationDelay: `${p.id * 40}ms`,
+              } as React.CSSProperties}
+            />
+          ))}
           {/* Stars */}
           <div className="text-4xl mb-2">
             <span className="inline-block animate-bounce" style={{ animationDelay: '0ms' }}>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -102,6 +102,11 @@ const config = {
           '50%': { transform: 'scale(1.15)', boxShadow: '0 0 12px 4px rgba(251, 146, 60, 0.4)' },
           '100%': { transform: 'scale(1)', boxShadow: '0 0 0 0 rgba(251, 146, 60, 0)' },
         },
+        'particle-burst': {
+          '0%':   { opacity: '1', transform: 'translate(0, 0) scale(1)' },
+          '80%':  { opacity: '0.6', transform: 'translate(var(--tx), var(--ty)) scale(0.5)' },
+          '100%': { opacity: '0', transform: 'translate(var(--tx), var(--ty)) scale(0)' },
+        },
       },
       animation: {
         'accordion-down': 'accordion-down 0.2s ease-out',
@@ -109,6 +114,7 @@ const config = {
         'float-up': 'float-up 1s ease-out forwards',
         'crit-flash': 'crit-flash 0.5s ease-out forwards',
         'combo-pulse': 'combo-pulse 0.6s ease-out',
+        'particle-burst': 'particle-burst 0.8s ease-out forwards',
       },
     },
   },


### PR DESCRIPTION
## Summary
Closes #133

- **Damage number enhancements** (FloatingDamage.tsx): crits are now visually larger (`text-2xl`), high-damage non-crit hits (≥50) get a distinct yellow tier (`text-xl`), effectiveness suffixes added (⚡ for super effective, ~ for resisted), DoT text simplified to number-only
- **Stat change indicators** (HudBar.tsx): floating +/- numbers appear next to HP, gold, and reputation icons when values change, color-coded green/red, auto-fade via `animate-float-up`
- **Level-up particle burst** (LevelUpCelebration.tsx): 12 colored particles radiate outward from the modal center on level-up, using a new `particle-burst` CSS keyframe with CSS custom properties for direction

## Test plan
- [ ] Enter combat, deal a critical hit → floating number should be noticeably larger with ★ markers
- [ ] Deal ≥50 non-crit damage → yellow text-xl floating number
- [ ] Use an elemental attack that's super effective → ⚡ suffix on damage number
- [ ] Use an elemental attack that's resisted → ~ suffix on damage number
- [ ] Take damage → red `-X` indicator floats near HP icon in HudBar
- [ ] Win combat → green `+X` indicators near gold and reputation icons
- [ ] No false indicators on initial page load
- [ ] Level up → colored particles burst outward from the level-up modal center
- [ ] Particles stay within modal boundary (overflow-hidden)
- [ ] Level-up modal still auto-dismisses after 4 seconds
- [ ] Combo pulse badge still works on combo increase
- [ ] Crit flash overlay still fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)