### PR TITLE
fix: hide reputation impact on event options until after selection

### DIFF
--- a/src/app/tap-tap-adventure/components/GameUI.tsx
+++ b/src/app/tap-tap-adventure/components/GameUI.tsx
@@ -404,17 +404,6 @@ export default function GameUI({ onOpenStatus }: GameUIProps) {
                             >
                               <span className="hidden sm:inline text-slate-400 mr-2 text-xs font-mono">[{index + 1}]</span>
                               {option.text}
-                              {(() => {
-                                const sRep = option.successEffects?.reputation ?? option.effects?.reputation
-                                const fRep = option.failureEffects?.reputation
-                                if (sRep === undefined && fRep === undefined) return null
-                                if (sRep !== undefined && fRep !== undefined && sRep !== fRep) {
-                                  return <span className={`ml-2 text-xs ${sRep > 0 ? 'text-green-400' : 'text-red-400'}`}>({sRep > 0 ? '+' : ''}{sRep}/{fRep > 0 ? '+' : ''}{fRep} Rep)</span>
-                                }
-                                const rep = sRep ?? fRep ?? 0
-                                const color = rep > 0 ? 'text-green-400' : rep < 0 ? 'text-red-400' : 'text-slate-400'
-                                return <span className={`ml-2 text-xs ${color}`}>({rep > 0 ? '+' : ''}{rep} Rep)</span>
-                              })()}
                             </Button>
                           )
                         })}


### PR DESCRIPTION
## Summary
Closes #179

- Removed reputation numbers (`+X Rep`, `-X Rep`, `+X/-X Rep`) from decision option buttons in GameUI.tsx
- Players now make moral choices based on narrative context, not by gaming the numbers
- Reputation changes are still properly revealed in the story feed outcome after selection (via `ResourceDeltaDisplay`)

## Test plan
- [ ] Trigger a story event with decision options → options should show only narrative text, no rep numbers
- [ ] Select an option → outcome in StoryFeed should show reputation change (green for gain, red for loss)
- [ ] Verify ResourceDeltaDisplay still works correctly for gold, HP, and reputation deltas

🤖 Generated with [Claude Code](https://claude.com/claude-code)