### PR TITLE
feat: endgame — two ultra-hard regions, 3-phase final boss, victory screen

### DIFF
--- a/src/app/api/v1/tap-tap-adventure/combat/start/route.ts
+++ b/src/app/api/v1/tap-tap-adventure/combat/start/route.ts
@@ -4,7 +4,7 @@ import { getDifficultyModifiers } from '@/app/tap-tap-adventure/config/difficult
 import { getRegion } from '@/app/tap-tap-adventure/config/regions'
 import { buildStoryContext } from '@/app/tap-tap-adventure/lib/contextBuilder'
 import { initializePlayerCombatState } from '@/app/tap-tap-adventure/lib/combatEngine'
-import { generateCombatEncounter, generateBossEncounter, generateMiniBossEncounter } from '@/app/tap-tap-adventure/lib/combatGenerator'
+import { generateCombatEncounter, generateBossEncounter, generateMiniBossEncounter, generateFinalBossEncounter } from '@/app/tap-tap-adventure/lib/combatGenerator'
 import { CombatState } from '@/app/tap-tap-adventure/models/combat'
 
 export async function POST(req: NextRequest) {
@@ -15,11 +15,15 @@ export async function POST(req: NextRequest) {
       ? `The player chose to fight in this situation: "${eventContext}"\n\nGenerate an enemy that matches this encounter. The enemy should be the creature or opponent described in the event above.\n\n${storyContext}`
       : storyContext
 
-    const { enemy: rawEnemy, scenario } = isMiniBoss
-      ? await generateMiniBossEncounter(character, fullContext)
-      : isBoss
-        ? await generateBossEncounter(character, fullContext)
-        : await generateCombatEncounter(character, fullContext)
+    const isFinalBoss = pendingRegionId === 'celestial_throne'
+
+    const { enemy: rawEnemy, scenario } = isFinalBoss
+      ? await generateFinalBossEncounter(character, fullContext)
+      : isMiniBoss
+        ? await generateMiniBossEncounter(character, fullContext)
+        : isBoss
+          ? await generateBossEncounter(character, fullContext)
+          : await generateCombatEncounter(character, fullContext)
 
     // Apply difficulty modifiers and region difficulty multiplier to enemy stats
     const diffMods = getDifficultyModifiers(character.difficultyMode)
@@ -54,8 +58,9 @@ export async function POST(req: NextRequest) {
       combatLog: [],
       status: 'active',
       scenario,
-      isBoss,
+      isBoss: isFinalBoss ? true : isBoss,
       isMiniBoss,
+      isFinalBoss: isFinalBoss || undefined,
       combatDistance: region.startingCombatDistance ?? 'mid',
       ...(pendingRegionId ? { pendingRegionId } : {}),
     }

--- a/src/app/tap-tap-adventure/__tests__/regions.test.ts
+++ b/src/app/tap-tap-adventure/__tests__/regions.test.ts
@@ -77,7 +77,7 @@ describe('Region definitions', () => {
   })
 
   it('should have valid difficulty levels', () => {
-    const validDifficulties = ['easy', 'medium', 'hard', 'very_hard']
+    const validDifficulties = ['easy', 'medium', 'hard', 'very_hard', 'extreme']
     for (const region of Object.values(REGIONS)) {
       expect(validDifficulties).toContain(region.difficulty)
     }
@@ -138,7 +138,7 @@ describe('getConnectedRegions', () => {
   it('should return correct number of connections', () => {
     expect(getConnectedRegions('starting_village')).toHaveLength(1)
     expect(getConnectedRegions('green_meadows')).toHaveLength(3)
-    expect(getConnectedRegions('sky_citadel')).toHaveLength(1)
+    expect(getConnectedRegions('sky_citadel')).toHaveLength(2) // dragons_spine + abyssal_depths
   })
 })
 

--- a/src/app/tap-tap-adventure/components/GameUI.tsx
+++ b/src/app/tap-tap-adventure/components/GameUI.tsx
@@ -40,6 +40,7 @@ const DIFFICULTY_STYLES: Record<RegionDifficulty, { label: string; color: string
   medium: { label: 'Medium', color: 'bg-yellow-900/50 text-yellow-300 border-yellow-600/40' },
   hard: { label: 'Hard', color: 'bg-red-900/50 text-red-300 border-red-600/40' },
   very_hard: { label: 'Very Hard', color: 'bg-purple-900/50 text-purple-300 border-purple-600/40' },
+  extreme: { label: 'Extreme', color: 'bg-purple-950/70 text-purple-200 border-purple-400/50' },
 }
 
 const ELEMENT_STYLES: Record<string, { color: string }> = {

--- a/src/app/tap-tap-adventure/components/RegionMap.tsx
+++ b/src/app/tap-tap-adventure/components/RegionMap.tsx
@@ -12,6 +12,7 @@ const DIFFICULTY_COLORS: Record<string, string> = {
   medium: 'border-yellow-500/60 bg-yellow-900/30',
   hard: 'border-orange-500/60 bg-orange-900/30',
   very_hard: 'border-red-500/60 bg-red-900/30',
+  extreme: 'border-purple-500/60 bg-purple-900/30',
 }
 
 const DIFFICULTY_LABELS: Record<string, string> = {
@@ -19,24 +20,27 @@ const DIFFICULTY_LABELS: Record<string, string> = {
   medium: 'Medium',
   hard: 'Hard',
   very_hard: 'Very Hard',
+  extreme: 'Extreme',
 }
 
 // Fixed positions for the map layout (percentage-based)
 // Linear top-to-bottom layout matching the progression path
 const POSITIONS: Record<string, { x: number; y: number }> = {
-  sky_citadel:      { x: 50, y: 3 },
-  dragons_spine:    { x: 50, y: 12 },
-  volcanic_forge:   { x: 28, y: 23 },
-  shadow_realm:     { x: 72, y: 23 },
-  scorched_wastes:  { x: 28, y: 35 },
-  frozen_peaks:     { x: 72, y: 35 },
-  bone_wastes:      { x: 50, y: 47 },
-  feywild_grove:    { x: 28, y: 59 },
-  crystal_caves:    { x: 72, y: 59 },
-  dark_forest:      { x: 28, y: 71 },
-  sunken_ruins:     { x: 72, y: 71 },
-  green_meadows:    { x: 50, y: 83 },
-  starting_village: { x: 50, y: 95 },
+  celestial_throne: { x: 50, y: 3 },
+  abyssal_depths:   { x: 50, y: 12 },
+  sky_citadel:      { x: 50, y: 16 },
+  dragons_spine:    { x: 50, y: 25 },
+  volcanic_forge:   { x: 28, y: 36 },
+  shadow_realm:     { x: 72, y: 36 },
+  scorched_wastes:  { x: 28, y: 48 },
+  frozen_peaks:     { x: 72, y: 48 },
+  bone_wastes:      { x: 50, y: 60 },
+  feywild_grove:    { x: 28, y: 72 },
+  crystal_caves:    { x: 72, y: 72 },
+  dark_forest:      { x: 28, y: 83 },
+  sunken_ruins:     { x: 72, y: 83 },
+  green_meadows:    { x: 50, y: 92 },
+  starting_village: { x: 50, y: 99 },
 }
 
 function ConnectionLine({ from, to }: { from: { x: number; y: number }; to: { x: number; y: number } }) {
@@ -72,7 +76,7 @@ export function RegionMap({ currentRegionId, characterLevel }: RegionMapProps) {
   return (
     <div className="w-full">
       <h3 className="text-lg font-semibold text-white mb-3">Region Map</h3>
-      <div className="relative w-full" style={{ paddingBottom: '110%' }}>
+      <div className="relative w-full" style={{ paddingBottom: '125%' }}>
         {/* Connection lines */}
         <svg className="absolute inset-0 w-full h-full" style={{ zIndex: 0 }}>
           {connections.map(({ from, to }) => {

--- a/src/app/tap-tap-adventure/components/RunSummary.tsx
+++ b/src/app/tap-tap-adventure/components/RunSummary.tsx
@@ -2,6 +2,7 @@
 
 import { calculateDay } from '@/app/tap-tap-adventure/lib/leveling'
 import { calculateSoulEssence } from '@/app/tap-tap-adventure/lib/soulEssenceCalculator'
+import { CONQUERABLE_REGIONS } from '@/app/tap-tap-adventure/lib/mainQuestManager'
 import type { RunSummaryData } from '@/app/tap-tap-adventure/models/types'
 
 interface RunSummaryProps {
@@ -11,13 +12,12 @@ interface RunSummaryProps {
   onBackToCharacters: () => void
 }
 
-function EssenceBreakdown({ character }: { character: RunSummaryData['character'] }) {
+function EssenceBreakdown({ character, isVictory, essenceEarned }: { character: RunSummaryData['character']; isVictory?: boolean; essenceEarned?: number }) {
   const baseEssence = Math.floor(character.distance / 10)
   const levelBonus = character.level * 5
   const subtotal = baseEssence + levelBonus
 
   const deathPenaltyMultiplier = Math.max(0.5, 1 - character.deathCount * 0.1)
-  const afterDeathPenalty = Math.floor(subtotal * deathPenaltyMultiplier)
 
   const diffMultipliers: Record<string, number> = {
     casual: 0.5,
@@ -30,6 +30,8 @@ function EssenceBreakdown({ character }: { character: RunSummaryData['character'
     character.difficultyMode
       ? character.difficultyMode.charAt(0).toUpperCase() + character.difficultyMode.slice(1)
       : 'Normal'
+
+  const displayTotal = isVictory && essenceEarned !== undefined ? essenceEarned : calculateSoulEssence(character)
 
   return (
     <div className="space-y-1 text-sm text-slate-400">
@@ -55,9 +57,15 @@ function EssenceBreakdown({ character }: { character: RunSummaryData['character'
           </span>
         </div>
       )}
+      {isVictory && (
+        <div className="flex justify-between">
+          <span>Victory bonus</span>
+          <span className="text-yellow-400">x5</span>
+        </div>
+      )}
       <div className="flex justify-between border-t border-slate-700 pt-1 font-semibold text-amber-400">
         <span>Total</span>
-        <span>{calculateSoulEssence(character)}</span>
+        <span>{displayTotal}</span>
       </div>
     </div>
   )
@@ -72,13 +80,20 @@ export default function RunSummary({
   const { character, reason, essenceEarned, heirloom } = data
 
   const isRetirement = reason === 'retirement'
-  const headerText = isRetirement ? 'Run Complete' : 'Fallen in Battle'
-  const headerColor = isRetirement
-    ? 'text-purple-300'
-    : 'text-red-400'
-  const headerBorder = isRetirement
-    ? 'border-purple-500/30'
-    : 'border-red-500/30'
+  const isVictory = reason === 'victory'
+  const headerText = isVictory ? 'World Conquered!' : isRetirement ? 'Run Complete' : 'Fallen in Battle'
+  const headerColor = isVictory
+    ? 'text-yellow-300'
+    : isRetirement
+      ? 'text-purple-300'
+      : 'text-red-400'
+  const headerBorder = isVictory
+    ? 'border-yellow-500/30'
+    : isRetirement
+      ? 'border-purple-500/30'
+      : 'border-red-500/30'
+
+  const regionsConquered = character.visitedRegions?.filter(r => CONQUERABLE_REGIONS.includes(r)).length ?? 0
 
   const daysSurvived = calculateDay(character.distance)
 
@@ -95,6 +110,9 @@ export default function RunSummary({
         <p className="text-slate-400 mt-2 text-lg">
           {character.name} &mdash; Level {character.level} {character.race} {character.class}
         </p>
+        {reason === 'victory' && (
+          <p className="text-yellow-400 mt-2 font-semibold">You have united all lands under your banner.</p>
+        )}
         {reason === 'permadeath' && (
           <p className="text-red-500 text-sm mt-1 italic">This character is gone forever.</p>
         )}
@@ -124,6 +142,11 @@ export default function RunSummary({
                 : 'Normal'
             }
           />
+          <StatCard
+            label="Regions Conquered"
+            value={String(regionsConquered)}
+            highlight={regionsConquered >= 14 ? 'green' : undefined}
+          />
         </div>
       </div>
 
@@ -138,7 +161,7 @@ export default function RunSummary({
           </span>
           <p className="text-amber-500/70 text-sm mt-1">Soul Essence</p>
         </div>
-        <EssenceBreakdown character={character} />
+        <EssenceBreakdown character={character} isVictory={isVictory} essenceEarned={essenceEarned} />
       </div>
 
       {/* Heirloom Section */}
@@ -164,6 +187,15 @@ export default function RunSummary({
 
       {/* Call to Action Buttons */}
       <div className="space-y-3">
+        {isVictory && (
+          <button
+            type="button"
+            onClick={onBackToCharacters}
+            className="w-full py-3 px-4 rounded-lg bg-yellow-600/20 border border-yellow-500/40 text-yellow-300 font-semibold text-lg hover:bg-yellow-600/30 transition-colors cursor-pointer"
+          >
+            Continue Playing (Post-Game)
+          </button>
+        )}
         <button
           type="button"
           onClick={onViewUpgrades}
@@ -178,13 +210,15 @@ export default function RunSummary({
         >
           Create New Character
         </button>
-        <button
-          type="button"
-          onClick={onBackToCharacters}
-          className="w-full py-3 px-4 rounded-lg bg-slate-700/30 border border-slate-600/40 text-slate-300 font-semibold text-lg hover:bg-slate-700/50 transition-colors cursor-pointer"
-        >
-          Back to Characters
-        </button>
+        {!isVictory && (
+          <button
+            type="button"
+            onClick={onBackToCharacters}
+            className="w-full py-3 px-4 rounded-lg bg-slate-700/30 border border-slate-600/40 text-slate-300 font-semibold text-lg hover:bg-slate-700/50 transition-colors cursor-pointer"
+          >
+            Back to Characters
+          </button>
+        )}
       </div>
     </div>
   )

--- a/src/app/tap-tap-adventure/config/achievements.ts
+++ b/src/app/tap-tap-adventure/config/achievements.ts
@@ -208,4 +208,13 @@ export const ACHIEVEMENTS: Achievement[] = [
     icon: '☠️',
     reward: { gold: 15, reputation: 3 },
   },
+  {
+    id: 'special_world_conqueror',
+    name: 'World Conqueror',
+    description: 'Conquer all 14 regions and complete the main quest',
+    category: 'special',
+    requirement: 14,
+    icon: '🌍',
+    reward: { gold: 500, reputation: 100 },
+  },
 ]

--- a/src/app/tap-tap-adventure/config/regions.ts
+++ b/src/app/tap-tap-adventure/config/regions.ts
@@ -1,6 +1,6 @@
 import { SpellElement } from '@/app/tap-tap-adventure/models/spell'
 
-export type RegionDifficulty = 'easy' | 'medium' | 'hard' | 'very_hard'
+export type RegionDifficulty = 'easy' | 'medium' | 'hard' | 'very_hard' | 'extreme'
 
 export interface Region {
   id: string
@@ -124,10 +124,38 @@ export const REGIONS: Record<string, Region> = {
     theme: 'floating fortress in the sky, ancient arcane machinery, cloud platforms, and celestial architecture',
     enemyTypes: ['sky knights', 'ancient dragons', 'arcane sentinels'],
     element: 'arcane',
-    connectedRegions: ['dragons_spine'],
+    connectedRegions: ['dragons_spine', 'abyssal_depths'],
     minLevel: 8,
     icon: '\u{26C5}',
     startingCombatDistance: 'mid',
+  },
+  abyssal_depths: {
+    id: 'abyssal_depths',
+    name: 'Abyssal Depths',
+    description: 'A crushing ocean abyss where bioluminescent nightmares dwell in ancient sunken fortresses. Few who descend ever return.',
+    difficulty: 'very_hard',
+    difficultyMultiplier: 2.5,
+    theme: 'crushing ocean abyss, bioluminescent nightmares, ancient sunken fortresses, and tentacled void creatures',
+    enemyTypes: ['abyssal horrors', 'drowned titans', 'void krakens'],
+    element: 'shadow',
+    connectedRegions: ['sky_citadel', 'celestial_throne'],
+    minLevel: 10,
+    icon: '\u{1F30A}',
+    startingCombatDistance: 'mid',
+  },
+  celestial_throne: {
+    id: 'celestial_throne',
+    name: 'Celestial Throne',
+    description: 'The realm of the gods itself — blinding white spires and floating celestial islands where divine beings of immense power hold dominion.',
+    difficulty: 'extreme',
+    difficultyMultiplier: 3.0,
+    theme: 'realm of the gods, blinding white spires, floating celestial islands, and divine beings of immense power',
+    enemyTypes: ['divine sentinels', 'celestial wyrms', 'corrupted archangels'],
+    element: 'arcane',
+    connectedRegions: ['abyssal_depths'],
+    minLevel: 12,
+    icon: '\u2728',
+    startingCombatDistance: 'far',
   },
   sunken_ruins: {
     id: 'sunken_ruins',

--- a/src/app/tap-tap-adventure/hooks/useCombatActionMutation.ts
+++ b/src/app/tap-tap-adventure/hooks/useCombatActionMutation.ts
@@ -197,6 +197,21 @@ export function useCombatActionMutation(options?: { onMountDrop?: (mount: Mount)
             } else {
               updateSelectedCharacter({ mainQuest: character.mainQuest })
             }
+
+            // Check if the main quest just completed (final boss victory)
+            // claimNewMilestones mutates the mainQuest object in place, so status may now be 'completed'
+            const questStatus = (character.mainQuest as { status: string }).status
+            if (questStatus === 'completed') {
+              const freshChar = useGameStore.getState().gameState.characters.find(c => c.id === character.id)
+              const victoryEssence = awardSoulEssence(freshChar ?? character, 5)
+              setRunSummary({
+                character: freshChar ? { ...freshChar } : { ...character },
+                reason: 'victory',
+                essenceEarned: victoryEssence,
+                heirloom: null,
+              })
+              // Do NOT delete the character — post-game character persists
+            }
           }
 
           addStoryEvent({

--- a/src/app/tap-tap-adventure/hooks/useGameStore.ts
+++ b/src/app/tap-tap-adventure/hooks/useGameStore.ts
@@ -96,7 +96,7 @@ export interface GameStore {
   claimHeirloom: (itemId: string) => Item | null
   retireCharacter: (characterId: string) => void
   claimDailyReward: () => import('@/app/tap-tap-adventure/lib/dailyRewardTracker').ClaimResult | null
-  awardSoulEssence: (character: FantasyCharacter) => number
+  awardSoulEssence: (character: FantasyCharacter, bonusMultiplier?: number) => number
   purchaseUpgrade: (upgradeId: string) => boolean
   getMetaBonuses: () => MetaBonuses
   setRunSummary: (summary: RunSummaryData) => void
@@ -679,8 +679,8 @@ export const useGameStore = create<GameStore>()(
           })
         )
       },
-      awardSoulEssence: (character: FantasyCharacter) => {
-        const essence = calculateSoulEssence(character)
+      awardSoulEssence: (character: FantasyCharacter, bonusMultiplier?: number) => {
+        const essence = calculateSoulEssence(character) * (bonusMultiplier ?? 1)
         set(
           produce((state: GameStore) => {
             const meta: MetaProgressionState = state.gameState.metaProgression ?? {

--- a/src/app/tap-tap-adventure/lib/combatEngine.ts
+++ b/src/app/tap-tap-adventure/lib/combatEngine.ts
@@ -436,13 +436,67 @@ function executeEnemyTelegraph(
 
 /**
  * Boss phase change: when a boss drops below 50% HP, boost their stats.
+ * For the final boss, supports 3 phases triggered at 66% and 33% HP.
  */
 function checkBossPhaseChange(
   enemy: CombatEnemy,
   isBoss: boolean,
-  alreadyPhased: boolean
+  alreadyPhased: boolean,
+  isFinalBoss?: boolean
 ): { enemy: CombatEnemy; phaseChanged: boolean; log?: CombatLogEntry } {
-  if (!isBoss || alreadyPhased) return { enemy, phaseChanged: false }
+  if (!isBoss) return { enemy, phaseChanged: false }
+
+  if (isFinalBoss) {
+    const isPhase2 = enemy.name.includes('(Phase 2)')
+    const isPhase3 = enemy.name.includes('(Phase 3)')
+
+    if (!isPhase2 && !isPhase3) {
+      // Phase 1 → 2 at 66% HP
+      if (enemy.hp > enemy.maxHp * 0.66) return { enemy, phaseChanged: false }
+      const originalName = enemy.name
+      const phase2Enemy = {
+        ...enemy,
+        attack: Math.round(enemy.attack * 1.3),
+        defense: Math.round(enemy.defense * 1.2),
+        name: `${originalName} (Phase 2)`,
+      }
+      return {
+        enemy: phase2Enemy,
+        phaseChanged: true,
+        log: {
+          turn: 0,
+          actor: 'enemy',
+          action: 'phase_change',
+          description: `${originalName} enters Phase 2! Power intensifies!`,
+        },
+      }
+    } else if (isPhase2 && !isPhase3) {
+      // Phase 2 → 3 at 33% HP
+      if (enemy.hp > enemy.maxHp * 0.33) return { enemy, phaseChanged: false }
+      const baseName = enemy.name.replace(' (Phase 2)', '')
+      const phase3Enemy = {
+        ...enemy,
+        attack: Math.round(enemy.attack * 1.4),
+        defense: Math.round(enemy.defense * 1.3),
+        name: `${baseName} (Phase 3)`,
+      }
+      return {
+        enemy: phase3Enemy,
+        phaseChanged: true,
+        log: {
+          turn: 0,
+          actor: 'enemy',
+          action: 'phase_change',
+          description: `${baseName} ascends to Phase 3! Celestial fury unleashed!`,
+        },
+      }
+    }
+    // Already Phase 3 — no further change
+    return { enemy, phaseChanged: false }
+  }
+
+  // Regular boss: single enrage at 50% HP
+  if (alreadyPhased) return { enemy, phaseChanged: false }
   if (enemy.hp > enemy.maxHp * 0.5) return { enemy, phaseChanged: false }
 
   const enragedEnemy = {
@@ -473,7 +527,7 @@ export function processPlayerAction(
   const newLogs: CombatLogEntry[] = []
   let consumedItemId: string | undefined
   let mountDied = false
-  const bossAlreadyPhased = isBoss ? enemy.name.includes('(Enraged)') : false
+  const bossAlreadyPhased = isBoss && !combatState.isFinalBoss ? enemy.name.includes('(Enraged)') : false
   let combatDistance: CombatDistance = combatState.combatDistance ?? 'mid'
   // Only propagate combatDistance in returns if the original state had it set
   // This ensures backward compatibility with combat states created before range was added
@@ -931,7 +985,7 @@ export function processPlayerAction(
 
   // Check boss phase change
   if (enemy.hp > 0) {
-    const phase = checkBossPhaseChange(enemy, !!isBoss, bossAlreadyPhased)
+    const phase = checkBossPhaseChange(enemy, !!isBoss, bossAlreadyPhased, combatState.isFinalBoss)
     if (phase.phaseChanged) {
       enemy = phase.enemy
       if (phase.log) {

--- a/src/app/tap-tap-adventure/lib/combatGenerator.ts
+++ b/src/app/tap-tap-adventure/lib/combatGenerator.ts
@@ -356,6 +356,126 @@ function getDefaultMiniBossEncounter(
   }
 }
 
+export async function generateFinalBossEncounter(
+  character: FantasyCharacter,
+  context: string
+): Promise<{ enemy: CombatEnemy; scenario: string }> {
+  const level = character.level
+  try {
+    const response = await getOpenAI().chat.completions.create({
+      model: 'gpt-4o',
+      messages: [
+        {
+          role: 'user',
+          content: `Generate the SUPREME FINAL BOSS combat encounter for this fantasy character. This is the ultimate confrontation — the guardian of the Celestial Throne, the last obstacle to complete world conquest. The boss should be awe-inspiring, devastating, and legendary. It guards the realm of the gods and has never been defeated.
+
+This is the FINAL BOSS of the entire game. It must feel truly supreme and nearly unstoppable:
+- Final Boss HP: ${Math.round((35 + level * 15) * 4)} (4x normal — overwhelming)
+- Final Boss attack: ${Math.round((6 + level * 3) * 3.5)} (3.5x normal)
+- Final Boss defense: ${Math.round((2 + level) * 3)} (3x normal)
+- Gold reward: ${Math.round((5 + level * 5) * 10)} (10x normal — legendary haul)
+- Include 3-4 legendary loot items including a spell scroll
+- MUST include a devastating special ability with cooldown of 2 turns — maximum lethality
+- Give the boss a name that conveys absolute power and divine authority
+- The element MUST be arcane
+
+Character:
+${JSON.stringify(character, null, 2)}
+
+Context:
+${context}`,
+        },
+      ],
+      tools: [
+        {
+          type: 'function',
+          function: {
+            name: 'generate_combat',
+            description: 'Generate the final boss combat encounter.',
+            parameters: enemySchemaForOpenAI,
+          },
+        },
+      ],
+      tool_choice: { type: 'function', function: { name: 'generate_combat' } },
+      temperature: 0.8,
+      max_tokens: 1000,
+    })
+
+    const toolCall = response.choices[0]?.message?.tool_calls?.[0]
+    if (toolCall && toolCall.function?.name === 'generate_combat') {
+      const parsed = JSON.parse(toolCall.function.arguments)
+      const validated = combatResponseSchema.parse(parsed)
+      if (validated.enemy.lootTable) {
+        validated.enemy.lootTable = validated.enemy.lootTable.map(inferItemTypeAndEffects)
+      }
+      return validated
+    }
+    throw new Error('No tool call in response')
+  } catch (err) {
+    console.error('Final boss generation failed, using fallback', err)
+    return getDefaultFinalBossEncounter(character)
+  }
+}
+
+function getDefaultFinalBossEncounter(
+  character: FantasyCharacter
+): { enemy: CombatEnemy; scenario: string } {
+  const level = character.level
+  const suffix = `${Date.now()}-${Math.floor(Math.random() * 10000)}`
+
+  const spell = generateSpellForLevel(Math.max(level, 8))
+
+  return {
+    scenario: `You stand before the Celestial Throne itself. The air shimmers with divine power as The Eternal Sovereign materializes from blinding light — a being of immeasurable power that has guarded the realm of the gods since the dawn of creation. This is the ultimate test. Win this battle and you will have conquered the entire world.`,
+    enemy: {
+      id: `final-boss-${suffix}`,
+      name: 'The Eternal Sovereign',
+      description: 'A supreme divine being of incomprehensible power, wreathed in celestial fire and ancient authority. Its presence alone bends reality.',
+      hp: Math.round((35 + level * 15) * 4),
+      maxHp: Math.round((35 + level * 15) * 4),
+      attack: Math.round((6 + level * 3) * 3.5),
+      defense: Math.round((2 + level) * 3),
+      level: level + 5,
+      goldReward: Math.round((5 + level * 5) * 10),
+      lootTable: [
+        inferItemTypeAndEffects({
+          id: `final-boss-loot-1-${suffix}`,
+          name: 'Elixir of Eternal Life',
+          description: 'A legendary elixir radiating pure divine energy.',
+          quantity: 1,
+        }),
+        inferItemTypeAndEffects({
+          id: `final-boss-loot-2-${suffix}`,
+          name: 'Crown of the Sovereign',
+          description: 'The crown of a defeated god, still pulsing with immense power.',
+          quantity: 1,
+        }),
+        inferItemTypeAndEffects({
+          id: `final-boss-loot-3-${suffix}`,
+          name: 'Celestial Shard',
+          description: 'A fragment of divine power broken from the Celestial Throne.',
+          quantity: 1,
+        }),
+        {
+          id: `final-boss-loot-spell-${suffix}`,
+          name: `Scroll of ${spell.name}`,
+          description: `A supreme spell scroll containing divine knowledge.`,
+          quantity: 1,
+          type: 'spell_scroll' as const,
+          spell,
+        },
+      ],
+      specialAbility: {
+        name: 'Celestial Judgment',
+        description: 'Calls down a pillar of divine light that obliterates everything in its path.',
+        damage: Math.round((5 + level * 2) * 4),
+        cooldown: 2,
+      },
+      element: 'arcane',
+    },
+  }
+}
+
 function getDefaultBossEncounter(
   character: FantasyCharacter
 ): { enemy: CombatEnemy; scenario: string } {

--- a/src/app/tap-tap-adventure/lib/llmEventGenerator.ts
+++ b/src/app/tap-tap-adventure/lib/llmEventGenerator.ts
@@ -1199,6 +1199,92 @@ function getRegionFallbackEvents(regionId: string): LLMGeneratedEvent[] {
         ],
       },
     ],
+    abyssal_depths: [
+      {
+        id: `rfb-tentacle-${s}`,
+        description: 'A colossal tentacle erupts from the abyss below your feet, slamming against the obsidian floor where you stand.',
+        options: [
+          { id: `dodge-tentacle-${s}`, text: 'Dive and dodge the tentacle', successProbability: 0.7,
+            successDescription: 'You roll clear as the tentacle crashes down. In the impact zone you spot scattered abyssal coins and a strange glowing shard.',
+            successEffects: { gold: 20, reputation: 2, rewardItems: processFallbackRewardItems([{ id: `void-shard-${s}`, name: 'Void Shard', description: 'A fragment of solidified void energy', quantity: 1, type: 'consumable', effects: { intelligence: 1 } }]) },
+            failureDescription: 'The tentacle grazes you as you dodge, knocking you back. You scramble away unharmed but shaken.',
+            failureEffects: { reputation: -1 } },
+          { id: `fight-tentacle-${s}`, text: 'Draw your weapon and fight the creature', triggersCombat: true,
+            successProbability: 0.5, successDescription: 'The void creature drags itself fully from the depths, ready to fight!',
+            successEffects: {}, failureDescription: 'The void creature drags itself fully from the depths, ready to fight!', failureEffects: {} },
+        ],
+      },
+      {
+        id: `rfb-jellyfish-${s}`,
+        description: 'Bioluminescent jellyfish drift around you, their soft glow revealing an ancient chest resting on the seafloor below a translucent membrane.',
+        options: [
+          { id: `dive-chest-${s}`, text: 'Dive through the membrane to reach the chest', successProbability: 0.6,
+            successDescription: 'You breach the membrane and pry open the chest. Inside: ancient coins and an intact scroll of abyssal knowledge.',
+            successEffects: { gold: 35, rewardItems: [createSpellScrollRewardItem(8, `abyssal-scroll-${s}`)] },
+            failureDescription: 'The membrane resists your entry and the pressure forces you back. The chest remains out of reach.',
+            failureEffects: {} },
+          { id: `ignore-chest-${s}`, text: 'Admire the view and move on', successProbability: 1.0,
+            successDescription: 'The jellyfish pulse gently as you pass, their bioluminescence lighting your way through the dark.',
+            successEffects: {}, failureDescription: '', failureEffects: {} },
+        ],
+      },
+      {
+        id: `rfb-titan-skull-${s}`,
+        description: 'The skull of a drowned titan towers above you, its hollow eye sockets filled with pulsing shadow energy. Smaller void creatures nest within its jaw.',
+        options: [
+          { id: `search-skull-${s}`, text: 'Search the skull for treasure', successProbability: 0.5,
+            successDescription: 'Wedged between massive teeth you find a cache of gold coins preserved for eons.',
+            successEffects: { gold: 30, reputation: 2 },
+            failureDescription: 'The shadow energy flares as you approach, driving you back empty-handed.',
+            failureEffects: {} },
+          { id: `channel-shadow-${s}`, text: 'Channel the shadow energy emanating from the eye sockets', triggersCombat: true,
+            successProbability: 0.5, successDescription: 'The shadow energy coalesces into a hostile void entity that lashes out!',
+            successEffects: {}, failureDescription: 'The shadow energy coalesces into a hostile void entity that lashes out!', failureEffects: {} },
+        ],
+      },
+    ],
+    celestial_throne: [
+      {
+        id: `rfb-divine-sentinel-${s}`,
+        description: 'A divine sentinel in gleaming white armor bars your path, its celestial eyes boring into your soul. "Prove your worth, mortal, or turn back."',
+        options: [
+          { id: `challenge-sentinel-${s}`, text: 'Challenge the sentinel to single combat', triggersCombat: true,
+            successProbability: 0.5, successDescription: 'The sentinel raises its blade and lunges forward!',
+            successEffects: {}, failureDescription: 'The sentinel raises its blade and lunges forward!', failureEffects: {} },
+          { id: `diplomatic-pass-${s}`, text: 'Invoke your deeds and conquests to earn passage', successProbability: 0.3,
+            successDescription: 'The sentinel considers your words, then steps aside. "Your legend precedes you. Pass, champion."',
+            successEffects: { reputation: 8 },
+            failureDescription: 'The sentinel shakes its head. "Words alone are not enough. Prove yourself with action."',
+            failureEffects: { reputation: -2 } },
+        ],
+      },
+      {
+        id: `rfb-celestial-light-${s}`,
+        description: 'A blinding pillar of celestial light descends before you, humming with divine energy. You feel it could grant great power — or destroy you.',
+        options: [
+          { id: `step-into-light-${s}`, text: 'Step into the celestial light', successProbability: 0.7,
+            successDescription: 'The divine energy surges through you, filling you with clarity. A blessed scroll materializes in your hands.',
+            successEffects: { reputation: 6, rewardItems: [createSpellScrollRewardItem(10, `celestial-scroll-${s}`)] },
+            failureDescription: 'The light is too intense. You are blinded temporarily and stagger back, dazed but unharmed.',
+            failureEffects: { reputation: -1 } },
+          { id: `avoid-light-${s}`, text: 'Step around the pillar carefully', successProbability: 1.0,
+            successDescription: 'You give the pillar wide berth. It eventually fades, leaving only a warm impression on the air.',
+            successEffects: {}, failureDescription: '', failureEffects: {} },
+        ],
+      },
+      {
+        id: `rfb-archangel-trial-${s}`,
+        description: 'A corrupted archangel descends from the spires above, its once-white wings now streaked with void. It offers you a trial of strength.',
+        options: [
+          { id: `accept-trial-${s}`, text: 'Accept the archangel\'s trial', triggersCombat: true,
+            successProbability: 0.5, successDescription: 'The archangel spreads its massive wings and attacks!',
+            successEffects: {}, failureDescription: 'The archangel spreads its massive wings and attacks!', failureEffects: {} },
+          { id: `decline-trial-${s}`, text: 'Decline and move on', successProbability: 1.0,
+            successDescription: 'The archangel watches you pass with cold, appraising eyes, then returns to the spires above.',
+            successEffects: {}, failureDescription: '', failureEffects: {} },
+        ],
+      },
+    ],
   }
 
   return regionEvents[regionId] ?? []

--- a/src/app/tap-tap-adventure/lib/mainQuestManager.ts
+++ b/src/app/tap-tap-adventure/lib/mainQuestManager.ts
@@ -5,15 +5,17 @@ export const CONQUERABLE_REGIONS = [
   'green_meadows', 'dark_forest', 'crystal_caves', 'scorched_wastes',
   'frozen_peaks', 'shadow_realm', 'sky_citadel', 'sunken_ruins',
   'volcanic_forge', 'feywild_grove', 'bone_wastes', 'dragons_spine',
+  'abyssal_depths', 'celestial_throne',
 ]
 
-export const TOTAL_CONQUERABLE = CONQUERABLE_REGIONS.length // 12
+export const TOTAL_CONQUERABLE = CONQUERABLE_REGIONS.length // 14
 
 const MILESTONES = [
   { regionsRequired: 3, title: 'First Frontiers', goldReward: 150 },
   { regionsRequired: 6, title: 'Halfway There', goldReward: 300 },
   { regionsRequired: 9, title: 'Almost Supreme', goldReward: 500 },
-  { regionsRequired: TOTAL_CONQUERABLE, title: 'World Conqueror', goldReward: 1000 },
+  { regionsRequired: 12, title: 'World Conqueror', goldReward: 1000 },
+  { regionsRequired: TOTAL_CONQUERABLE, title: 'World Domination', goldReward: 2000 },
 ]
 
 export function createMainQuest(): MainQuest {

--- a/src/app/tap-tap-adventure/models/combat.ts
+++ b/src/app/tap-tap-adventure/models/combat.ts
@@ -149,6 +149,7 @@ export const CombatStateSchema = z.object({
   enemyTelegraph: EnemyTelegraphSchema.optional().nullable(),
   isBoss: z.boolean().optional(),
   isMiniBoss: z.boolean().optional(),
+  isFinalBoss: z.boolean().optional(),
   combatDistance: CombatDistanceSchema.optional(),
   turnPhase: TurnPhaseSchema.optional(),
   pendingRegionId: z.string().optional(),

--- a/src/app/tap-tap-adventure/models/types.ts
+++ b/src/app/tap-tap-adventure/models/types.ts
@@ -90,7 +90,7 @@ type DailyRewardState = {
 
 type RunSummaryData = {
   character: FantasyCharacter
-  reason: 'death' | 'permadeath' | 'retirement'
+  reason: 'death' | 'permadeath' | 'retirement' | 'victory'
   essenceEarned: number
   heirloom: Item | null
 }


### PR DESCRIPTION
## Summary
Closes #169

Adds the game's endgame content — two ultra-hard regions culminating in a 3-phase final boss and a victory screen.

### New regions
- **Abyssal Depths** (2.5x difficulty, shadow, L10) — connected from Sky Citadel
- **Celestial Throne** (3.0x, extreme difficulty, arcane, L12) — the final region

### Final boss
- "The Eternal Sovereign" — triggered when entering Celestial Throne
- 4x HP, 3.5x attack, 3x defense, 10x gold reward
- 3-phase fight: transitions at 66% and 33% HP with escalating stats
- Regular bosses unchanged (single enrage at 50%)

### Victory system
- Defeating the final boss completes the main quest
- Victory screen: "World Conquered!" with full run stats and 5x soul essence bonus
- Character survives post-game — can continue exploring
- "World Conqueror" achievement added

### Other changes
- `extreme` difficulty tier added to `RegionDifficulty`
- Main quest updated to 14 regions with new "World Domination" milestone
- 6 fallback events for the new regions
- Region map positions adjusted for new top-level regions
- `isFinalBoss` flag on CombatState schema

**15 files changed** across config, models, lib, hooks, components, and API routes.

## Test plan
- [ ] Region map shows Abyssal Depths and Celestial Throne at the top
- [ ] Abyssal Depths shows "Lv.10+" lock for under-leveled characters
- [ ] Celestial Throne shows "Extreme" difficulty label in purple
- [ ] Enter Celestial Throne → final boss spawns with elevated stats
- [ ] Final boss has 3 phase transitions (at 66% and 33% HP)
- [ ] Regular region bosses still only enrage once at 50% HP
- [ ] Defeating final boss → victory screen with "World Conquered!"
- [ ] Victory screen shows 5x soul essence bonus
- [ ] Character still playable after victory (post-game)
- [ ] Main quest shows "World Domination" milestone at 14 regions
- [ ] Existing 12-region characters don't prematurely trigger victory

🤖 Generated with [Claude Code](https://claude.com/claude-code)