### PR TITLE
Fix: Ironman permadeath characters not deleted after death

### DIFF
--- a/src/app/tap-tap-adventure/hooks/useCombatActionMutation.ts
+++ b/src/app/tap-tap-adventure/hooks/useCombatActionMutation.ts
@@ -262,7 +262,8 @@ export function useCombatActionMutation(options?: { onMountDrop?: (mount: Mount)
               heirloom,
             })
 
-            deleteCharacter(character.id)
+            // NOTE: deleteCharacter is called AFTER commit() below
+            // to prevent commit() from overwriting the deletion with a stale snapshot
           } else {
             const penalty = data.deathPenalty
             const penaltyParts: string[] = []
@@ -334,6 +335,15 @@ export function useCombatActionMutation(options?: { onMountDrop?: (mount: Mount)
       }
 
       commit()
+
+      // Permadeath deletion must happen AFTER commit() to avoid the stale snapshot overwriting it
+      if (data.combatState.status === 'defeat') {
+        const diffMods = getDifficultyModifiers(character.difficultyMode)
+        if (diffMods.permadeath) {
+          deleteCharacter(character.id)
+        }
+      }
+
       return data
     },
     onSuccess: () => {


### PR DESCRIPTION
## Summary
- `deleteCharacter()` was called before `commit()`, which then overwrote the game state with a stale snapshot from before the deletion — restoring the dead character
- Fix: `deleteCharacter()` now runs after `commit()` so the deletion persists
- Same root cause as the mount persistence bug (PR #104) — the builder's `commit()` replaces the entire game state with its pre-mutation clone

## Test plan
- [ ] Create an Ironman character, die in combat — character should be permanently deleted
- [ ] Run Summary screen should appear with Soul Essence earned
- [ ] Returning to character list should not show the dead character
- [ ] Non-ironman death should still work normally (character survives with penalties)

Closes #187

🤖 Generated with [Claude Code](https://claude.com/claude-code)