### PR TITLE
feat: user stats view for daily trivia

### DIFF
--- a/src/app/trivia/components/TriviaLanding.tsx
+++ b/src/app/trivia/components/TriviaLanding.tsx
@@ -5,7 +5,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { useTriviaStore } from '../hooks/useTriviaStore'
 import { formatDisplayDate, getTodayPST } from '../lib/triviaUtils'
 
-export function TriviaLanding({ onStartGame }: { onStartGame?: () => void }) {
+export function TriviaLanding({ onStartGame, onViewStats }: { onStartGame?: () => void; onViewStats?: () => void }) {
   const { userData, canPlayToday } = useTriviaStore()
   const todayStr = getTodayPST()
   const alreadyPlayed = !canPlayToday()
@@ -88,8 +88,13 @@ export function TriviaLanding({ onStartGame }: { onStartGame?: () => void }) {
       </div>
 
       {/* Links */}
-      <div className="flex gap-4 text-sm">
-        <span className="text-cream-white/40 cursor-not-allowed">Stats (coming soon)</span>
+      <div className="flex gap-3 text-sm">
+        <button
+          onClick={onViewStats}
+          className="text-space-gold hover:text-space-gold/80 transition-colors underline-offset-4 hover:underline"
+        >
+          My Stats
+        </button>
         <span className="text-cream-white/20">·</span>
         <span className="text-cream-white/40 cursor-not-allowed">Leaderboard (coming soon)</span>
       </div>

--- a/src/app/trivia/components/TriviaResults.tsx
+++ b/src/app/trivia/components/TriviaResults.tsx
@@ -79,11 +79,12 @@ const SCORING_CONFIG: Record<string, { maxPoints: number }> = {
 interface TriviaResultsProps {
   result: TriviaGameResult
   onBack: () => void
+  onViewStats?: () => void
   // Optional: pass questions data for difficulty display
   questionDifficulties?: Array<{ difficulty: string; source: string }>
 }
 
-export function TriviaResults({ result, onBack }: TriviaResultsProps) {
+export function TriviaResults({ result, onBack, onViewStats }: TriviaResultsProps) {
   const [copied, setCopied] = useState(false)
   const { userData } = useTriviaStore()
   const countdown = useCountdown()
@@ -225,8 +226,13 @@ export function TriviaResults({ result, onBack }: TriviaResultsProps) {
       {/* Navigation */}
       <div className="flex gap-3 w-full">
         <Button variant="outline" onClick={onBack} className="flex-1">
-          Back to Trivia
+          Back
         </Button>
+        {onViewStats && (
+          <Button variant="outline" onClick={onViewStats} className="flex-1">
+            View Stats
+          </Button>
+        )}
       </div>
     </div>
   )

--- a/src/app/trivia/components/TriviaStats.tsx
+++ b/src/app/trivia/components/TriviaStats.tsx
@@ -1,0 +1,205 @@
+'use client'
+
+import { Button } from '@/components/ui/button'
+import { Card, CardContent } from '@/components/ui/card'
+import { useTriviaStore } from '../hooks/useTriviaStore'
+import { formatDisplayDate } from '../lib/triviaUtils'
+
+const MAX_SCORE_PER_GAME = 3000
+
+function getAccuracyColor(accuracy: number): string {
+  if (accuracy >= 80) return 'text-green-400'
+  if (accuracy >= 60) return 'text-yellow-400'
+  return 'text-red-400'
+}
+
+export function TriviaStats({ onBack }: { onBack: () => void }) {
+  const { userData } = useTriviaStore()
+  const { stats, history } = userData
+
+  const accuracy =
+    stats.totalQuestions > 0
+      ? Math.round((stats.totalCorrect / stats.totalQuestions) * 100)
+      : 0
+
+  const avgScore = stats.gamesPlayed > 0
+    ? Math.round(stats.totalScore / stats.gamesPlayed)
+    : 0
+
+  // Last 14 days, most recent first
+  const recentHistory = [...history].reverse().slice(0, 14)
+
+  // Highest single-game score
+  const bestScore = history.reduce((max, h) => Math.max(max, h.score), 0)
+
+  if (stats.gamesPlayed === 0) {
+    return (
+      <div className="flex flex-col items-center gap-6 max-w-lg mx-auto py-8">
+        <h2 className="text-3xl font-bold text-space-gold">My Stats</h2>
+        <Card className="w-full bg-space-dark/80 border-space-grey">
+          <CardContent className="pt-6 text-center">
+            <p className="text-cream-white/70 text-lg mb-2">No games played yet</p>
+            <p className="text-cream-white/50 text-sm">
+              Play your first daily trivia to start building your stats!
+            </p>
+          </CardContent>
+        </Card>
+        <Button variant="outline" onClick={onBack} className="w-full">
+          Back to Trivia
+        </Button>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex flex-col gap-5 max-w-lg mx-auto py-6">
+      {/* Header */}
+      <div className="text-center">
+        <h2 className="text-3xl font-bold text-space-gold mb-1">My Stats</h2>
+        <p className="text-cream-white/50 text-sm">Your trivia journey so far</p>
+      </div>
+
+      {/* Top-level stats grid */}
+      <div className="grid grid-cols-2 gap-3">
+        <Card className="bg-space-dark/80 border-space-grey">
+          <CardContent className="pt-5 pb-5 text-center">
+            <div className="text-3xl font-bold text-space-gold">
+              {stats.gamesPlayed}
+            </div>
+            <div className="text-cream-white/50 text-xs mt-1">Games Played</div>
+          </CardContent>
+        </Card>
+
+        <Card className="bg-space-dark/80 border-space-grey">
+          <CardContent className="pt-5 pb-5 text-center">
+            <div className={`text-3xl font-bold ${getAccuracyColor(accuracy)}`}>
+              {accuracy}%
+            </div>
+            <div className="text-cream-white/50 text-xs mt-1">Accuracy</div>
+          </CardContent>
+        </Card>
+
+        <Card className="bg-space-dark/80 border-space-grey">
+          <CardContent className="pt-5 pb-5 text-center">
+            <div className="text-3xl font-bold text-cream-white">
+              {stats.totalScore.toLocaleString()}
+            </div>
+            <div className="text-cream-white/50 text-xs mt-1">Total Score</div>
+          </CardContent>
+        </Card>
+
+        <Card className="bg-space-dark/80 border-space-grey">
+          <CardContent className="pt-5 pb-5 text-center">
+            <div className="text-3xl font-bold text-cream-white">
+              {avgScore.toLocaleString()}
+            </div>
+            <div className="text-cream-white/50 text-xs mt-1">Avg / Game</div>
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* Streaks */}
+      <Card className="bg-space-dark/80 border-space-grey">
+        <CardContent className="pt-5 pb-5">
+          <div className="grid grid-cols-2 gap-3">
+            <div className="text-center">
+              <div className="flex items-center justify-center gap-1">
+                <span className="text-2xl">🔥</span>
+                <span className="text-3xl font-bold text-space-gold">
+                  {stats.currentStreak}
+                </span>
+              </div>
+              <div className="text-cream-white/50 text-xs mt-1">Current Streak</div>
+            </div>
+            <div className="text-center">
+              <div className="text-3xl font-bold text-space-purple-light">
+                {stats.bestStreak}
+              </div>
+              <div className="text-cream-white/50 text-xs mt-1">Best Streak</div>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Additional totals */}
+      <Card className="bg-space-dark/80 border-space-grey">
+        <CardContent className="pt-5 pb-5">
+          <h3 className="text-cream-white/70 text-sm font-semibold mb-3 uppercase tracking-wide">
+            Totals
+          </h3>
+          <div className="space-y-2">
+            <div className="flex justify-between items-center">
+              <span className="text-cream-white/60 text-sm">Best single game</span>
+              <span className="text-space-gold font-bold">
+                {bestScore.toLocaleString()}
+              </span>
+            </div>
+            <div className="flex justify-between items-center">
+              <span className="text-cream-white/60 text-sm">Questions answered</span>
+              <span className="text-cream-white font-bold">
+                {stats.totalQuestions.toLocaleString()}
+              </span>
+            </div>
+            <div className="flex justify-between items-center">
+              <span className="text-cream-white/60 text-sm">Correct answers</span>
+              <span className="text-green-400 font-bold">
+                {stats.totalCorrect.toLocaleString()}
+              </span>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Recent history */}
+      <Card className="bg-space-dark/80 border-space-grey">
+        <CardContent className="pt-5 pb-5">
+          <h3 className="text-cream-white/70 text-sm font-semibold mb-3 uppercase tracking-wide">
+            Recent Games
+          </h3>
+          <div className="flex flex-col gap-2">
+            {recentHistory.map((game) => {
+              const gameAccuracy =
+                game.total > 0 ? Math.round((game.correct / game.total) * 100) : 0
+              const scorePercent = Math.round((game.score / MAX_SCORE_PER_GAME) * 100)
+
+              return (
+                <div
+                  key={game.date}
+                  className="flex items-center justify-between py-2 px-3 rounded bg-space-black/40"
+                >
+                  <div className="flex flex-col">
+                    <span className="text-cream-white text-sm font-medium">
+                      {formatDisplayDate(game.date)}
+                    </span>
+                    <span className="text-cream-white/40 text-xs">
+                      {game.correct}/{game.total} correct
+                    </span>
+                  </div>
+                  <div className="flex items-center gap-3">
+                    {/* Visual bar */}
+                    <div className="w-16 h-2 bg-space-grey rounded-full overflow-hidden">
+                      <div
+                        className="h-full bg-space-gold transition-all"
+                        style={{ width: `${scorePercent}%` }}
+                      />
+                    </div>
+                    <span
+                      className={`font-bold text-sm min-w-[4rem] text-right ${getAccuracyColor(gameAccuracy)}`}
+                    >
+                      {game.score.toLocaleString()}
+                    </span>
+                  </div>
+                </div>
+              )
+            })}
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Navigation */}
+      <Button variant="outline" onClick={onBack} className="w-full">
+        Back to Trivia
+      </Button>
+    </div>
+  )
+}

--- a/src/app/trivia/page.tsx
+++ b/src/app/trivia/page.tsx
@@ -4,16 +4,16 @@ import { useState, useEffect } from 'react'
 import { TriviaLanding } from './components/TriviaLanding'
 import { TriviaGame } from './components/TriviaGame'
 import { TriviaResults } from './components/TriviaResults'
+import { TriviaStats } from './components/TriviaStats'
 import { useTriviaStore } from './hooks/useTriviaStore'
 import { getTodayPST } from './lib/triviaUtils'
 import type { TriviaGameResult } from './models/trivia'
 
-type View = 'landing' | 'playing' | 'results'
+type View = 'landing' | 'playing' | 'results' | 'stats'
 
 export default function TriviaPage() {
-  const { recordGame, canPlayToday, userData } = useTriviaStore()
+  const { recordGame, userData } = useTriviaStore()
 
-  // Determine initial view: if already played today, show results
   const getTodayResult = (): TriviaGameResult | null => {
     const today = getTodayPST()
     return userData.history.find((h) => h.date === today) ?? null
@@ -23,7 +23,6 @@ export default function TriviaPage() {
   const [view, setView] = useState<View>(todayResult ? 'results' : 'landing')
   const [lastResult, setLastResult] = useState<TriviaGameResult | null>(todayResult)
 
-  // Also sync on hydration (Zustand persist loads async)
   useEffect(() => {
     const result = getTodayResult()
     if (result && view === 'landing') {
@@ -32,9 +31,8 @@ export default function TriviaPage() {
     }
   }, [userData.history])
 
-  const handleStartGame = () => {
-    setView('playing')
-  }
+  const handleStartGame = () => setView('playing')
+  const handleViewStats = () => setView('stats')
 
   const handleFinish = (result: TriviaGameResult) => {
     recordGame(result)
@@ -42,17 +40,25 @@ export default function TriviaPage() {
     setView('results')
   }
 
-  const handleBackToLanding = () => {
-    setView('landing')
-  }
+  const handleBackToLanding = () => setView('landing')
 
   if (view === 'playing') {
     return <TriviaGame onFinish={handleFinish} />
   }
 
   if (view === 'results' && lastResult) {
-    return <TriviaResults result={lastResult} onBack={handleBackToLanding} />
+    return (
+      <TriviaResults
+        result={lastResult}
+        onBack={handleBackToLanding}
+        onViewStats={handleViewStats}
+      />
+    )
   }
 
-  return <TriviaLanding onStartGame={handleStartGame} />
+  if (view === 'stats') {
+    return <TriviaStats onBack={handleBackToLanding} />
+  }
+
+  return <TriviaLanding onStartGame={handleStartGame} onViewStats={handleViewStats} />
 }


### PR DESCRIPTION
## Summary
Closes #194

New **My Stats** view accessible from both the trivia landing page and the results screen. Pulls everything from localStorage (`cometcave-trivia-user`) — no server calls needed.

### Included stats
- Games played, accuracy %, total score, avg score per game
- Current streak (with 🔥) and best streak
- Totals: best single-game score, total questions answered, total correct
- Recent 14-game history with visual score bars and color-coded accuracy
- Empty state for new users

### UI
- Color-coded accuracy: green (>80%), yellow (>60%), red (<60%)
- Mobile-first, scrollable card layout using existing space theme
- "My Stats" button replaces the "Stats (coming soon)" placeholder on landing
- "View Stats" button added to results screen (next to Back)

Per-category breakdown was scoped out — we don't track category at the answer level. Could be added later if we extend `TriviaAnswer` to include category.

## Test plan
- [ ] New user with 0 games — empty state renders with "No games played yet"
- [ ] After playing a game — stats reflect game (games=1, accuracy matches, etc.)
- [ ] "My Stats" button on landing navigates to stats view
- [ ] "View Stats" button on results navigates to stats view
- [ ] "Back to Trivia" returns to landing
- [ ] Recent history shows most recent game first, up to 14 entries
- [ ] Accuracy colors change correctly at 80%/60% thresholds

🤖 Generated with [Claude Code](https://claude.com/claude-code)