### PR TITLE
fix: include https:// in trivia share URL for linkification

### DIFF
--- a/src/app/trivia/components/TriviaResults.tsx
+++ b/src/app/trivia/components/TriviaResults.tsx
@@ -33,7 +33,7 @@ function getShareText(result: TriviaGameResult): string {
 
   const pct = Math.round((result.score / MAX_SCORE) * 100)
 
-  return `🧠 CometCave Daily Trivia — ${dateStr}\nTheme: ${category.icon} ${category.name}\n${squares}\nScore: ${result.score.toLocaleString()} / ${MAX_SCORE.toLocaleString()} (${pct}%)\ncometcave.com/trivia`
+  return `🧠 CometCave Daily Trivia — ${dateStr}\nTheme: ${category.icon} ${category.name}\n${squares}\nScore: ${result.score.toLocaleString()} / ${MAX_SCORE.toLocaleString()} (${pct}%)\nhttps://cometcave.com/trivia`
 }
 
 function useCountdown() {


### PR DESCRIPTION
## Summary
The share text ended with \`cometcave.com/trivia\` (no protocol), which doesn't auto-linkify in most apps (Slack, iMessage, Twitter, Discord). Adding \`https://\` makes it a clickable link everywhere.

Before:
\`\`\`
Score: 2,300 / 3,150 (73%)
cometcave.com/trivia
\`\`\`

After:
\`\`\`
Score: 2,300 / 3,150 (73%)
https://cometcave.com/trivia
\`\`\`

## Test plan
- [ ] Share score on Slack/iMessage — link renders as clickable

🤖 Generated with [Claude Code](https://claude.com/claude-code)