### PR TITLE
feat: base building system with gold-funded upgrades

### DIFF
--- a/src/app/tap-tap-adventure/components/BasePanel.tsx
+++ b/src/app/tap-tap-adventure/components/BasePanel.tsx
@@ -1,0 +1,121 @@
+'use client'
+
+import { useState } from 'react'
+import { BASE_BUILDINGS } from '@/app/tap-tap-adventure/config/baseBuildings'
+import { useGameStore } from '@/app/tap-tap-adventure/hooks/useGameStore'
+
+export function BasePanel() {
+  const { getSelectedCharacter, upgradeBuilding } = useGameStore()
+  const [isExpanded, setIsExpanded] = useState(false)
+
+  const character = getSelectedCharacter()
+  const buildingLevels = character?.campState?.buildingLevels ?? {}
+  const gold = character?.gold ?? 0
+
+  if (!isExpanded) {
+    const totalLevels = Object.values(buildingLevels).reduce((sum, v) => sum + v, 0)
+    const maxLevels = BASE_BUILDINGS.length * 3
+    return (
+      <button
+        className="w-full bg-[#1e1f30] border border-[#3a3c56] rounded-lg p-3 text-left hover:border-amber-700/50 transition-colors"
+        onClick={() => setIsExpanded(true)}
+      >
+        <div className="flex justify-between items-center">
+          <span className="text-sm font-bold text-amber-400">&#x1F3D5; Camp Buildings</span>
+          <span className="text-xs text-slate-400">{totalLevels}/{maxLevels} levels</span>
+        </div>
+        <div className="h-1.5 bg-slate-700 rounded-full overflow-hidden mt-2">
+          <div
+            className="h-full bg-amber-500 rounded-full transition-all duration-300"
+            style={{ width: `${maxLevels > 0 ? (totalLevels / maxLevels) * 100 : 0}%` }}
+          />
+        </div>
+      </button>
+    )
+  }
+
+  return (
+    <div className="bg-[#1e1f30] border border-[#3a3c56] rounded-lg p-3 space-y-3">
+      <div className="flex justify-between items-center">
+        <button
+          className="text-sm font-bold text-amber-400 hover:text-amber-300 transition-colors"
+          onClick={() => setIsExpanded(false)}
+        >
+          &#x1F3D5; Camp Buildings
+        </button>
+        <span className="text-xs text-amber-300 font-semibold">
+          &#x1F4B0; {gold.toLocaleString()}g
+        </span>
+      </div>
+
+      <div className="grid grid-cols-1 gap-2">
+        {BASE_BUILDINGS.map(building => {
+          const level = buildingLevels[building.id] ?? 0
+          const isMaxed = level >= building.maxLevel
+          const cost = isMaxed ? null : building.costPerLevel[level]
+          const canAfford = cost !== null && cost !== undefined && gold >= cost
+
+          return (
+            <div
+              key={building.id}
+              className={`rounded-lg p-2.5 border text-xs ${
+                isMaxed
+                  ? 'bg-amber-950/20 border-amber-600/30'
+                  : 'bg-[#161723] border-[#2a2b3f]'
+              }`}
+            >
+              <div className="flex items-start gap-2">
+                <span className="text-xl leading-none mt-0.5">{building.icon}</span>
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center justify-between gap-2">
+                    <span className={`font-semibold ${isMaxed ? 'text-amber-400' : 'text-slate-200'}`}>
+                      {building.name}
+                    </span>
+                    {/* Level pips */}
+                    <div className="flex gap-0.5 shrink-0">
+                      {Array.from({ length: building.maxLevel }).map((_, i) => (
+                        <span
+                          key={i}
+                          className={`text-[10px] ${i < level ? 'text-amber-400' : 'text-slate-600'}`}
+                        >
+                          {i < level ? '\u25CF' : '\u25CB'}
+                        </span>
+                      ))}
+                    </div>
+                  </div>
+                  <p className="text-[10px] text-slate-400 mt-0.5">{building.description}</p>
+                  <p className="text-[10px] text-amber-300/80 mt-0.5">{building.effectDescription}</p>
+                </div>
+              </div>
+
+              <div className="flex items-center justify-between mt-2 gap-2">
+                {isMaxed ? (
+                  <span className="text-[10px] uppercase tracking-wider text-amber-500 font-semibold">
+                    Maxed
+                  </span>
+                ) : (
+                  <>
+                    <span className="text-[10px] text-slate-400">
+                      Cost: <span className={canAfford ? 'text-amber-300' : 'text-red-400'}>{cost}g</span>
+                    </span>
+                    <button
+                      className={`text-[10px] px-2 py-1 rounded font-semibold transition-colors ${
+                        canAfford
+                          ? 'bg-amber-600 hover:bg-amber-500 text-white'
+                          : 'bg-slate-700 text-slate-500 cursor-not-allowed'
+                      }`}
+                      disabled={!canAfford}
+                      onClick={() => upgradeBuilding(building.id)}
+                    >
+                      Upgrade
+                    </button>
+                  </>
+                )}
+              </div>
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/src/app/tap-tap-adventure/components/GameUI.tsx
+++ b/src/app/tap-tap-adventure/components/GameUI.tsx
@@ -34,6 +34,7 @@ import { SettingsPanel } from './SettingsPanel'
 import { KeyboardHelp } from './KeyboardHelp'
 import { OnboardingHint } from './OnboardingHint'
 import { SkillPanel } from './SkillPanel'
+import { BasePanel } from './BasePanel'
 import { useOnboarding, HintKey } from '@/app/tap-tap-adventure/hooks/useOnboarding'
 
 const DIFFICULTY_STYLES: Record<RegionDifficulty, { label: string; color: string }> = {
@@ -92,7 +93,7 @@ function getTravelButtonMessage({ isLoading, distance }: { isLoading: boolean; d
   if (distance === 0) return 'Start Your Adventure'
   return 'Continue Travelling'
 }
-type MobilePanel = 'equipment' | 'inventory' | 'quest' | 'map' | 'settings' | null
+type MobilePanel = 'equipment' | 'inventory' | 'quest' | 'map' | 'settings' | 'base' | null
 
 interface GameUIProps {
   onOpenStatus?: () => void
@@ -513,6 +514,9 @@ export default function GameUI({ onOpenStatus }: GameUIProps) {
               />
             </div>
             <div className="border-t border-[#3a3c56] pt-4">
+              <BasePanel />
+            </div>
+            <div className="border-t border-[#3a3c56] pt-4">
               <SettingsPanel />
             </div>
           </div>
@@ -531,7 +535,7 @@ export default function GameUI({ onOpenStatus }: GameUIProps) {
           >
             <div className="flex justify-between items-center mb-2">
               <h3 className="text-sm font-semibold text-slate-300 uppercase">
-                {mobilePanel === 'equipment' ? 'Equipment' : mobilePanel === 'inventory' ? 'Inventory' : mobilePanel === 'map' ? 'Map' : mobilePanel === 'settings' ? 'Settings' : 'Quest'}
+                {mobilePanel === 'equipment' ? 'Equipment' : mobilePanel === 'inventory' ? 'Inventory' : mobilePanel === 'map' ? 'Map' : mobilePanel === 'settings' ? 'Settings' : mobilePanel === 'base' ? 'Camp' : 'Quest'}
               </h3>
               <button
                 className="text-slate-400 hover:text-white text-sm px-2 py-1"
@@ -560,6 +564,7 @@ export default function GameUI({ onOpenStatus }: GameUIProps) {
               />
             )}
             {mobilePanel === 'settings' && <SettingsPanel />}
+            {mobilePanel === 'base' && <BasePanel />}
           </div>
         </div>
       )}
@@ -571,6 +576,7 @@ export default function GameUI({ onOpenStatus }: GameUIProps) {
           { id: 'inventory' as MobilePanel, label: 'Items', icon: '\uD83C\uDF92' },
           { id: 'quest' as MobilePanel, label: 'Quest', icon: '\uD83D\uDCDC' },
           { id: 'map' as MobilePanel, label: 'Map', icon: '\uD83D\uDDFA' },
+          { id: 'base' as MobilePanel, label: 'Camp', icon: '\uD83C\uDFD5' },
           { id: 'settings' as MobilePanel, label: 'Settings', icon: '\u2699' },
         ]).map(tab => (
           <button

--- a/src/app/tap-tap-adventure/config/baseBuildings.ts
+++ b/src/app/tap-tap-adventure/config/baseBuildings.ts
@@ -1,0 +1,118 @@
+export interface BaseBuilding {
+  id: string
+  name: string
+  description: string
+  icon: string
+  maxLevel: number
+  costPerLevel: number[]
+  effectDescription: string
+}
+
+export interface CampBonuses {
+  goldEventBonusPct: number
+  bonusStrength: number
+  bonusIntelligence: number
+  reputationGainBonusPct: number
+  mountUpkeepDiscountPct: number
+  combatSuccessBonus: number
+}
+
+export const BASE_BUILDINGS: BaseBuilding[] = [
+  {
+    id: 'tavern',
+    name: 'Tavern',
+    description: 'A lively inn where tales of fortune are shared.',
+    icon: '\uD83C\uDF7A',
+    maxLevel: 3,
+    costPerLevel: [50, 150, 400],
+    effectDescription: '+5% gold from events per level',
+  },
+  {
+    id: 'armory',
+    name: 'Armory',
+    description: 'Weapons and training to strengthen your fighters.',
+    icon: '\u2694\uFE0F',
+    maxLevel: 3,
+    costPerLevel: [75, 200, 500],
+    effectDescription: '+1 Strength per level',
+  },
+  {
+    id: 'library',
+    name: 'Library',
+    description: 'Ancient tomes that sharpen the mind.',
+    icon: '\uD83D\uDCDA',
+    maxLevel: 3,
+    costPerLevel: [75, 200, 500],
+    effectDescription: '+1 Intelligence per level',
+  },
+  {
+    id: 'shrine',
+    name: 'Shrine',
+    description: 'A sacred place that improves your standing with locals.',
+    icon: '\uD83D\uDD6F\uFE0F',
+    maxLevel: 3,
+    costPerLevel: [60, 175, 450],
+    effectDescription: '+5% reputation gain per level',
+  },
+  {
+    id: 'stable',
+    name: 'Stable',
+    description: 'Quality care for your mounts reduces their daily cost.',
+    icon: '\uD83D\uDC34',
+    maxLevel: 3,
+    costPerLevel: [80, 225, 550],
+    effectDescription: '-20% mount upkeep per level',
+  },
+  {
+    id: 'watchtower',
+    name: 'Watchtower',
+    description: 'A vantage point that improves tactical awareness in combat.',
+    icon: '\uD83D\uDDFC',
+    maxLevel: 3,
+    costPerLevel: [100, 250, 600],
+    effectDescription: '+5% combat success per level',
+  },
+]
+
+export function getBuildingById(id: string): BaseBuilding | undefined {
+  return BASE_BUILDINGS.find(b => b.id === id)
+}
+
+export function getCampBonuses(buildingLevels: Record<string, number>): CampBonuses {
+  const bonuses: CampBonuses = {
+    goldEventBonusPct: 0,
+    bonusStrength: 0,
+    bonusIntelligence: 0,
+    reputationGainBonusPct: 0,
+    mountUpkeepDiscountPct: 0,
+    combatSuccessBonus: 0,
+  }
+
+  for (const building of BASE_BUILDINGS) {
+    const level = buildingLevels[building.id] ?? 0
+    if (level <= 0) continue
+
+    switch (building.id) {
+      case 'tavern':
+        bonuses.goldEventBonusPct += 5 * level
+        break
+      case 'armory':
+        bonuses.bonusStrength += 1 * level
+        break
+      case 'library':
+        bonuses.bonusIntelligence += 1 * level
+        break
+      case 'shrine':
+        bonuses.reputationGainBonusPct += 5 * level
+        break
+      case 'stable':
+        bonuses.mountUpkeepDiscountPct += 20 * level
+        break
+      case 'watchtower':
+        bonuses.combatSuccessBonus += 0.05 * level
+        break
+    }
+  }
+
+  return bonuses
+}

--- a/src/app/tap-tap-adventure/hooks/useGameStore.ts
+++ b/src/app/tap-tap-adventure/hooks/useGameStore.ts
@@ -15,6 +15,7 @@ import { applyLevelFromDistance, calculateDay, calculateMaxHp, calculateMaxMana 
 import { checkQuestProgress } from '@/app/tap-tap-adventure/lib/questGenerator'
 import { createMainQuest } from '@/app/tap-tap-adventure/lib/mainQuestManager'
 import { getUpgradeById } from '@/app/tap-tap-adventure/config/eternalUpgrades'
+import { getCampBonuses as computeCampBonuses, getBuildingById, CampBonuses } from '@/app/tap-tap-adventure/config/baseBuildings'
 import { getSpellConfigForCharacter } from '@/app/tap-tap-adventure/config/characterOptions'
 import { FantasyCharacter } from '@/app/tap-tap-adventure/models/character'
 import { CombatState } from '@/app/tap-tap-adventure/models/combat'
@@ -99,6 +100,8 @@ export interface GameStore {
   awardSoulEssence: (character: FantasyCharacter, bonusMultiplier?: number) => number
   purchaseUpgrade: (upgradeId: string) => boolean
   getMetaBonuses: () => MetaBonuses
+  upgradeBuilding: (buildingId: string) => boolean
+  getCampBonuses: () => CampBonuses
   setRunSummary: (summary: RunSummaryData) => void
   clearRunSummary: () => void
 }
@@ -189,6 +192,7 @@ export const useGameStore = create<GameStore>()(
             const oldDistance = selectedCharacter.distance || 0
             const newDistance = oldDistance + 1
             const metaBonuses = get().getMetaBonuses()
+            const campBonuses = get().getCampBonuses()
             let updatedCharacter = applyLevelFromDistance({
               ...selectedCharacter,
               distance: newDistance,
@@ -198,7 +202,8 @@ export const useGameStore = create<GameStore>()(
             const oldDay = calculateDay(oldDistance)
             const newDay = calculateDay(newDistance)
             if (newDay > oldDay && updatedCharacter.activeMount) {
-              const cost = updatedCharacter.activeMount.dailyCost ?? 0
+              const rawCost = updatedCharacter.activeMount.dailyCost ?? 0
+              const cost = Math.max(0, Math.floor(rawCost * (1 - campBonuses.mountUpkeepDiscountPct / 100)))
               const newGold = updatedCharacter.gold - cost
               if (newGold < 0) {
                 // Can't afford upkeep — auto-release mount
@@ -741,6 +746,39 @@ export const useGameStore = create<GameStore>()(
         if (!meta) return getMetaBonuses({})
         return getMetaBonuses(meta.upgradeLevels)
       },
+      upgradeBuilding: (buildingId: string) => {
+        const selectedCharacter = get().getSelectedCharacter()
+        if (!selectedCharacter) return false
+
+        const building = getBuildingById(buildingId)
+        if (!building) return false
+
+        const currentLevel = selectedCharacter.campState?.buildingLevels[buildingId] ?? 0
+        if (currentLevel >= building.maxLevel) return false
+
+        const cost = building.costPerLevel[currentLevel]
+        if (cost === undefined || selectedCharacter.gold < cost) return false
+
+        set(
+          produce((state: GameStore) => {
+            const charIndex = state.gameState.characters.findIndex(
+              char => char.id === selectedCharacter.id
+            )
+            if (charIndex === -1) return
+            const char = state.gameState.characters[charIndex]
+            if (!char.campState) {
+              char.campState = { buildingLevels: {} }
+            }
+            char.gold -= cost
+            char.campState.buildingLevels[buildingId] = currentLevel + 1
+          })
+        )
+        return true
+      },
+      getCampBonuses: () => {
+        const char = get().getSelectedCharacter()
+        return computeCampBonuses(char?.campState?.buildingLevels ?? {})
+      },
       setRunSummary: (summary: RunSummaryData) => {
         set(
           produce((state: GameStore) => {
@@ -758,7 +796,7 @@ export const useGameStore = create<GameStore>()(
     }),
     {
       name: 'fantasy-tycoon-storage', // localStorage key (kept for backward compat)
-      version: 18,
+      version: 19,
       migrate: (persistedState: unknown) => {
         const state = persistedState as GameStore
         if (state?.gameState && !('combatState' in state.gameState)) {
@@ -840,6 +878,10 @@ export const useGameStore = create<GameStore>()(
             // v19: Add unlockedTreeSkillIds
             if ((char as FantasyCharacter).unlockedTreeSkillIds === undefined) {
               ;(char as FantasyCharacter).unlockedTreeSkillIds = []
+            }
+            // v19: Add campState
+            if ((char as FantasyCharacter).campState === undefined) {
+              ;(char as FantasyCharacter).campState = { buildingLevels: {} }
             }
           }
         }

--- a/src/app/tap-tap-adventure/lib/combatEngine.ts
+++ b/src/app/tap-tap-adventure/lib/combatEngine.ts
@@ -20,6 +20,7 @@ import { Mount } from '@/app/tap-tap-adventure/models/mount'
 import { getRandomMount, getMountFreeMoves, getMountFleeBonus, getMountMaxHp } from '@/app/tap-tap-adventure/config/mounts'
 
 import { getDifficultyModifiers } from '@/app/tap-tap-adventure/config/difficultyModes'
+import { getCampBonuses } from '@/app/tap-tap-adventure/config/baseBuildings'
 
 import { applyCombatItemEffect, isUsableInCombat } from './combatItemEffects'
 import { calculateMaxMana } from './leveling'
@@ -80,6 +81,9 @@ export function initializePlayerCombatState(character: FantasyCharacter): Combat
   const mountIntBonus = character.activeMount?.bonuses?.intelligence ?? 0
   const mountLuckBonus = character.activeMount?.bonuses?.luck ?? 0
 
+  // Calculate camp bonuses
+  const campBonuses = getCampBonuses(character.campState?.buildingLevels ?? {})
+
   // Resolve passive skill bonuses
   const skills = resolveSkills(character)
   const attackBonus = getSkillBonus(skills, 'attack')
@@ -91,8 +95,8 @@ export function initializePlayerCombatState(character: FantasyCharacter): Combat
   const maxMana = character.maxMana ?? calculateMaxMana(character)
   const currentMana = character.mana ?? maxMana
 
-  const baseAttack = 2 + character.strength + mountStrBonus + Math.floor(character.level / 2) + weaponBonus * 2
-  const baseDefense = 1 + Math.floor((character.intelligence + mountIntBonus) / 2) + Math.floor(character.level / 2) + armorBonus
+  const baseAttack = 2 + character.strength + mountStrBonus + campBonuses.bonusStrength + Math.floor(character.level / 2) + weaponBonus * 2
+  const baseDefense = 1 + Math.floor((character.intelligence + mountIntBonus) / 2) + Math.floor(campBonuses.bonusIntelligence / 2) + Math.floor(character.level / 2) + armorBonus
 
   // Calculate total luck for crit chance
   const totalLuck = character.luck + mountLuckBonus + accessoryLuckBonus

--- a/src/app/tap-tap-adventure/lib/eventResolution.ts
+++ b/src/app/tap-tap-adventure/lib/eventResolution.ts
@@ -1,5 +1,6 @@
 import { FantasyCharacter } from '@/app/tap-tap-adventure/models/character'
 import { FantasyDecisionOption } from '@/app/tap-tap-adventure/models/story'
+import { getCampBonuses } from '@/app/tap-tap-adventure/config/baseBuildings'
 
 export function applyEffects(
   character: FantasyCharacter,
@@ -13,10 +14,21 @@ export function applyEffects(
   }
 ): FantasyCharacter {
   if (!effects) return character
+
+  const campBonuses = getCampBonuses(character.campState?.buildingLevels ?? {})
+  const goldGain = effects.gold ?? 0
+  const adjustedGold = goldGain > 0
+    ? Math.round(goldGain * (1 + campBonuses.goldEventBonusPct / 100))
+    : goldGain
+  const repGain = effects.reputation ?? 0
+  const adjustedRep = repGain > 0
+    ? Math.round(repGain * (1 + campBonuses.reputationGainBonusPct / 100))
+    : repGain
+
   let updatedCharacter: FantasyCharacter = {
     ...character,
-    gold: character.gold + (effects.gold ?? 0),
-    reputation: character.reputation + (effects.reputation ?? 0),
+    gold: character.gold + adjustedGold,
+    reputation: character.reputation + adjustedRep,
     distance: character.distance + (effects.distance ?? 0),
     status: effects.statusChange
       ? (effects.statusChange as FantasyCharacter['status'])
@@ -50,8 +62,10 @@ export function calculateEffectiveProbability(
   }
   const base = typedOption.successProbability ?? 1
 
+  const campBonuses = getCampBonuses(character.campState?.buildingLevels ?? {})
+
   if (!typedOption.relevantAttributes || typedOption.relevantAttributes.length === 0) {
-    return Math.max(0, Math.min(1, base))
+    return Math.max(0, Math.min(1, base + campBonuses.combatSuccessBonus))
   }
 
   let modifier = 0
@@ -65,5 +79,5 @@ export function calculateEffectiveProbability(
   const reputationModifier = Math.max(-0.1, Math.min(0.1, character.reputation * 0.001))
   modifier += reputationModifier
 
-  return Math.max(0, Math.min(1, Number(base) + modifier))
+  return Math.max(0, Math.min(1, Number(base) + modifier + campBonuses.combatSuccessBonus))
 }

--- a/src/app/tap-tap-adventure/models/camp.ts
+++ b/src/app/tap-tap-adventure/models/camp.ts
@@ -1,0 +1,7 @@
+import { z } from 'zod'
+
+export const CampStateSchema = z.object({
+  buildingLevels: z.record(z.string(), z.number()),
+})
+
+export type CampState = z.infer<typeof CampStateSchema>

--- a/src/app/tap-tap-adventure/models/character.ts
+++ b/src/app/tap-tap-adventure/models/character.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod'
 
 import { ClassSkillTreeSchema } from './classSkillTree'
+import { CampStateSchema } from './camp'
 import { GeneratedClassSchema } from './generatedClass'
 import { ItemSchema } from './item'
 import { MountSchema } from './mount'
@@ -56,6 +57,7 @@ export const FantasyCharacterSchema = z.object({
   currentRegion: z.string().optional().default('green_meadows'),
   visitedRegions: z.array(z.string()).optional(),
   mainQuest: MainQuestSchema.optional(),
+  campState: CampStateSchema.optional(),
 })
 export type FantasyCharacter = z.infer<typeof FantasyCharacterSchema>
 

--- a/src/app/tap-tap-adventure/models/types.ts
+++ b/src/app/tap-tap-adventure/models/types.ts
@@ -61,6 +61,7 @@ export type {
 } from './spell'
 export type { Mount, MountSchema, MountBonuses, MountBonusesSchema, MountRarity, MountRaritySchema, MountPersonality, MountPersonalitySchema } from './mount'
 export type { TimedQuest, TimedQuestSchema, MainQuest, MainQuestSchema, MainQuestMilestone, MainQuestMilestoneSchema } from './quest'
+export type { CampState, CampStateSchema } from './camp'
 export type {
   CombatState,
   CombatEnemy,


### PR DESCRIPTION
## Summary

Closes #142

Adds a camp/base building system where players spend gold to upgrade 6 buildings, each with 3 levels providing passive bonuses:

| Building | Effect per Level | Costs (L1/L2/L3) |
|----------|-----------------|-------------------|
| 🍺 Tavern | +5% gold from events | 50 / 150 / 400 |
| ⚔️ Armory | +1 Strength | 75 / 200 / 500 |
| 📚 Library | +1 Intelligence | 75 / 200 / 500 |
| 🕯️ Shrine | +5% reputation gain | 60 / 175 / 450 |
| 🐴 Stable | -20% mount upkeep | 80 / 225 / 550 |
| 🗼 Watchtower | +5% combat success | 100 / 250 / 600 |

- **Data model**: `CampStateSchema` with `buildingLevels` record
- **Config**: Building definitions with escalating costs and bonus aggregator
- **UI**: BasePanel with building cards, level pips, upgrade buttons (mobile tab + desktop column)
- **Integration**: Bonuses apply to combat engine (STR/INT), event resolution (gold/rep %), mount upkeep (discount), and success probability
- **Store**: `upgradeBuilding` action + v19 migration for existing characters

## Test plan

- [ ] Purchase Tavern L1 (50g) → gold deducted, level pip filled, bonus active
- [ ] Gold event with Tavern L1 → 5% more gold than base
- [ ] Armory L1 → +1 attack in combat
- [ ] Library L1 → INT bonus in combat defense
- [ ] Shrine L1 → +5% reputation from positive events
- [ ] Stable L1 → mount upkeep reduced by 20%
- [ ] Watchtower L1 → success probability increased by 0.05
- [ ] Max level reached → Upgrade button shows "Max Level"
- [ ] Insufficient gold → Upgrade button disabled
- [ ] Existing characters (no campState) → migration initializes empty buildingLevels
- [ ] TypeScript compiles with no new errors
- [ ] BasePanel visible in mobile Camp tab and desktop right column

🤖 Generated with [Claude Code](https://claude.com/claude-code)