### PR TITLE
feat: mercenary/party member system

### DIFF
--- a/src/app/api/v1/tap-tap-adventure/combat/action/route.ts
+++ b/src/app/api/v1/tap-tap-adventure/combat/action/route.ts
@@ -43,6 +43,17 @@ export async function POST(req: NextRequest) {
       updatedCharacter = { ...updatedCharacter, activeMount: null }
     }
 
+    // Persist mercenary HP from combat state back to character
+    if (updatedCombat.playerState.mercenaryHp !== undefined && updatedCharacter.activeMercenary) {
+      updatedCharacter = {
+        ...updatedCharacter,
+        activeMercenary: {
+          ...updatedCharacter.activeMercenary,
+          hp: updatedCombat.playerState.mercenaryHp,
+        },
+      }
+    }
+
     return NextResponse.json({
       combatState: updatedCombat,
       rewards,

--- a/src/app/tap-tap-adventure/components/CombatUI.tsx
+++ b/src/app/tap-tap-adventure/components/CombatUI.tsx
@@ -422,6 +422,14 @@ export function CombatUI({ combatState }: CombatUIProps) {
         {playerState.mountHp !== undefined && playerState.mountMaxHp !== undefined && playerState.mountHp > 0 && (
           <HpBar current={playerState.mountHp} max={playerState.mountMaxHp} label={`${character?.activeMount?.icon ?? '🐴'} Mount`} color="text-amber-400" />
         )}
+        {playerState.mercenaryHp !== undefined && playerState.mercenaryMaxHp !== undefined && playerState.mercenaryHp > 0 && (
+          <HpBar
+            current={playerState.mercenaryHp}
+            max={playerState.mercenaryMaxHp}
+            label={`${character?.activeMercenary?.icon ?? '⚔️'} ${character?.activeMercenary?.customName ?? character?.activeMercenary?.name ?? 'Mercenary'}`}
+            color="text-amber-400"
+          />
+        )}
         {maxMana > 0 && (
           <ManaBar current={currentMana} max={maxMana} />
         )}

--- a/src/app/tap-tap-adventure/components/GameUI.tsx
+++ b/src/app/tap-tap-adventure/components/GameUI.tsx
@@ -35,6 +35,7 @@ import { KeyboardHelp } from './KeyboardHelp'
 import { OnboardingHint } from './OnboardingHint'
 import { SkillPanel } from './SkillPanel'
 import { BasePanel } from './BasePanel'
+import { MercenaryPanel } from './MercenaryPanel'
 import { useOnboarding, HintKey } from '@/app/tap-tap-adventure/hooks/useOnboarding'
 
 const DIFFICULTY_STYLES: Record<RegionDifficulty, { label: string; color: string }> = {
@@ -93,7 +94,7 @@ function getTravelButtonMessage({ isLoading, distance }: { isLoading: boolean; d
   if (distance === 0) return 'Start Your Adventure'
   return 'Continue Travelling'
 }
-type MobilePanel = 'equipment' | 'inventory' | 'quest' | 'map' | 'settings' | 'base' | null
+type MobilePanel = 'equipment' | 'inventory' | 'quest' | 'map' | 'settings' | 'base' | 'party' | null
 
 interface GameUIProps {
   onOpenStatus?: () => void
@@ -517,6 +518,9 @@ export default function GameUI({ onOpenStatus }: GameUIProps) {
               <BasePanel />
             </div>
             <div className="border-t border-[#3a3c56] pt-4">
+              {character && <MercenaryPanel character={character} />}
+            </div>
+            <div className="border-t border-[#3a3c56] pt-4">
               <SettingsPanel />
             </div>
           </div>
@@ -535,7 +539,7 @@ export default function GameUI({ onOpenStatus }: GameUIProps) {
           >
             <div className="flex justify-between items-center mb-2">
               <h3 className="text-sm font-semibold text-slate-300 uppercase">
-                {mobilePanel === 'equipment' ? 'Equipment' : mobilePanel === 'inventory' ? 'Inventory' : mobilePanel === 'map' ? 'Map' : mobilePanel === 'settings' ? 'Settings' : mobilePanel === 'base' ? 'Camp' : 'Quest'}
+                {mobilePanel === 'equipment' ? 'Equipment' : mobilePanel === 'inventory' ? 'Inventory' : mobilePanel === 'map' ? 'Map' : mobilePanel === 'settings' ? 'Settings' : mobilePanel === 'base' ? 'Camp' : mobilePanel === 'party' ? 'Party' : 'Quest'}
               </h3>
               <button
                 className="text-slate-400 hover:text-white text-sm px-2 py-1"
@@ -565,6 +569,7 @@ export default function GameUI({ onOpenStatus }: GameUIProps) {
             )}
             {mobilePanel === 'settings' && <SettingsPanel />}
             {mobilePanel === 'base' && <BasePanel />}
+            {mobilePanel === 'party' && character && <MercenaryPanel character={character} />}
           </div>
         </div>
       )}
@@ -577,6 +582,7 @@ export default function GameUI({ onOpenStatus }: GameUIProps) {
           { id: 'quest' as MobilePanel, label: 'Quest', icon: '\uD83D\uDCDC' },
           { id: 'map' as MobilePanel, label: 'Map', icon: '\uD83D\uDDFA' },
           { id: 'base' as MobilePanel, label: 'Camp', icon: '\uD83C\uDFD5' },
+          { id: 'party' as MobilePanel, label: 'Party', icon: '\u2694\uFE0F' },
           { id: 'settings' as MobilePanel, label: 'Settings', icon: '\u2699' },
         ]).map(tab => (
           <button

--- a/src/app/tap-tap-adventure/components/MercenaryPanel.tsx
+++ b/src/app/tap-tap-adventure/components/MercenaryPanel.tsx
@@ -1,0 +1,290 @@
+'use client'
+
+import { useMemo, useState } from 'react'
+
+import { getTavernMercenaries, getMercenaryMaxHp } from '@/app/tap-tap-adventure/config/mercenaries'
+import { useGameStore } from '@/app/tap-tap-adventure/hooks/useGameStore'
+import { FantasyCharacter } from '@/app/tap-tap-adventure/models/character'
+import { Mercenary } from '@/app/tap-tap-adventure/models/mercenary'
+
+interface MercenaryPanelProps {
+  character: FantasyCharacter
+}
+
+function RarityBadge({ rarity }: { rarity: Mercenary['rarity'] }) {
+  const colors: Record<string, string> = {
+    common: 'text-slate-300 bg-slate-700/60',
+    uncommon: 'text-green-400 bg-green-900/40',
+    rare: 'text-blue-400 bg-blue-900/40',
+    legendary: 'text-amber-400 bg-amber-900/40',
+  }
+  return (
+    <span className={`text-[10px] px-1.5 py-0.5 rounded capitalize font-semibold ${colors[rarity] ?? ''}`}>
+      {rarity}
+    </span>
+  )
+}
+
+function ClassBadge({ cls }: { cls: Mercenary['class'] }) {
+  const icons: Record<string, string> = {
+    warrior: '⚔️',
+    ranger: '🏹',
+    mage: '🔮',
+    rogue: '🗡️',
+    cleric: '✨',
+  }
+  return (
+    <span className="text-[10px] text-slate-400 capitalize">
+      {icons[cls] ?? ''} {cls}
+    </span>
+  )
+}
+
+function HpBar({ current, max }: { current: number; max: number }) {
+  const pct = max > 0 ? Math.max(0, Math.min(100, (current / max) * 100)) : 0
+  return (
+    <div className="flex items-center gap-1.5 text-[10px]">
+      <span className="text-slate-400 w-5">HP</span>
+      <div className="flex-1 h-1.5 bg-slate-700 rounded-full overflow-hidden">
+        <div
+          className="h-full bg-red-500 rounded-full transition-all"
+          style={{ width: `${pct}%` }}
+        />
+      </div>
+      <span className="text-slate-400 text-right w-12">{current}/{max}</span>
+    </div>
+  )
+}
+
+export function MercenaryPanel({ character }: MercenaryPanelProps) {
+  const { recruitMercenary, dismissMercenary, setActiveMercenary } = useGameStore()
+  const [isExpanded, setIsExpanded] = useState(false)
+  const [dismissConfirm, setDismissConfirm] = useState<string | null>(null)
+
+  // Stable tavern selection per character level — prevents re-randomization on each render
+  const tavernMercs = useMemo(
+    () => getTavernMercenaries(character.level),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [character.level]
+  )
+
+  const roster = character.mercenaryRoster ?? []
+  const active = character.activeMercenary
+
+  if (!isExpanded) {
+    return (
+      <button
+        className="w-full bg-[#1e1f30] border border-[#3a3c56] rounded-lg p-3 text-left hover:border-amber-700/50 transition-colors"
+        onClick={() => setIsExpanded(true)}
+      >
+        <div className="flex justify-between items-center">
+          <span className="text-sm font-bold text-amber-400">&#x2694;&#xFE0F; Party</span>
+          <span className="text-xs text-slate-400">
+            {active ? `${active.icon} ${active.customName ?? active.name}` : 'No mercenary'}
+          </span>
+        </div>
+      </button>
+    )
+  }
+
+  return (
+    <div className="bg-[#1e1f30] border border-[#3a3c56] rounded-lg p-3 space-y-4">
+      {/* Header */}
+      <div className="flex justify-between items-center">
+        <button
+          className="text-sm font-bold text-amber-400 hover:text-amber-300 transition-colors"
+          onClick={() => setIsExpanded(false)}
+        >
+          &#x2694;&#xFE0F; Party
+        </button>
+        <span className="text-xs text-amber-300 font-semibold">
+          &#x1F4B0; {character.gold.toLocaleString()}g
+        </span>
+      </div>
+
+      {/* Active Mercenary */}
+      <div>
+        <h4 className="text-xs font-semibold text-slate-400 uppercase mb-2">Active</h4>
+        {active ? (
+          <div className="bg-[#252638] border border-[#3a3c56] rounded p-2 space-y-1.5">
+            <div className="flex items-center justify-between">
+              <div className="flex items-center gap-1.5">
+                <span className="text-xl">{active.icon}</span>
+                <div>
+                  <div className="text-sm font-semibold text-slate-200">
+                    {active.customName ?? active.name}
+                  </div>
+                  <div className="flex items-center gap-1 mt-0.5">
+                    <ClassBadge cls={active.class} />
+                    <RarityBadge rarity={active.rarity} />
+                  </div>
+                </div>
+              </div>
+              <div className="text-right text-[10px] text-slate-400">
+                <div>ATK {active.attack} · DEF {active.defense}</div>
+                <div>{active.dailyCost}g/day</div>
+              </div>
+            </div>
+            <HpBar
+              current={active.hp ?? getMercenaryMaxHp(active.rarity)}
+              max={active.maxHp ?? getMercenaryMaxHp(active.rarity)}
+            />
+            {dismissConfirm === active.id ? (
+              <div className="flex items-center gap-2 mt-1">
+                <span className="text-[10px] text-red-400">Dismiss {active.name}?</span>
+                <button
+                  className="text-[10px] px-2 py-0.5 bg-red-900/50 text-red-400 rounded hover:bg-red-800/50"
+                  onClick={() => {
+                    dismissMercenary(active.id)
+                    setDismissConfirm(null)
+                  }}
+                >
+                  Yes
+                </button>
+                <button
+                  className="text-[10px] px-2 py-0.5 bg-slate-700/50 text-slate-300 rounded hover:bg-slate-600/50"
+                  onClick={() => setDismissConfirm(null)}
+                >
+                  No
+                </button>
+              </div>
+            ) : (
+              <button
+                className="text-[10px] px-2 py-0.5 bg-red-900/30 text-red-400 rounded hover:bg-red-800/40 transition-colors"
+                onClick={() => setDismissConfirm(active.id)}
+              >
+                Dismiss
+              </button>
+            )}
+          </div>
+        ) : (
+          <div className="text-xs text-slate-500 italic">No active mercenary. Recruit from the tavern below.</div>
+        )}
+      </div>
+
+      {/* Roster */}
+      {roster.length > 0 && (
+        <div>
+          <h4 className="text-xs font-semibold text-slate-400 uppercase mb-2">Roster ({roster.length}/3)</h4>
+          <div className="space-y-1.5">
+            {roster.map(merc => (
+              <div
+                key={merc.id}
+                className={`bg-[#252638] border rounded p-2 flex items-center justify-between ${
+                  active?.id === merc.id ? 'border-amber-600/60' : 'border-[#3a3c56]'
+                }`}
+              >
+                <div className="flex items-center gap-1.5">
+                  <span className="text-lg">{merc.icon}</span>
+                  <div>
+                    <div className="text-xs font-semibold text-slate-200">{merc.customName ?? merc.name}</div>
+                    <div className="flex items-center gap-1 mt-0.5">
+                      <ClassBadge cls={merc.class} />
+                      <RarityBadge rarity={merc.rarity} />
+                    </div>
+                  </div>
+                </div>
+                <div className="flex items-center gap-1.5">
+                  {dismissConfirm === `roster-${merc.id}` ? (
+                    <>
+                      <button
+                        className="text-[10px] px-1.5 py-0.5 bg-red-900/50 text-red-400 rounded hover:bg-red-800/50"
+                        onClick={() => {
+                          dismissMercenary(merc.id)
+                          setDismissConfirm(null)
+                        }}
+                      >
+                        Yes
+                      </button>
+                      <button
+                        className="text-[10px] px-1.5 py-0.5 bg-slate-700/50 text-slate-300 rounded hover:bg-slate-600/50"
+                        onClick={() => setDismissConfirm(null)}
+                      >
+                        No
+                      </button>
+                    </>
+                  ) : (
+                    <>
+                      {active?.id !== merc.id && (
+                        <button
+                          className="text-[10px] px-2 py-0.5 bg-indigo-900/50 text-indigo-300 rounded hover:bg-indigo-800/50 transition-colors"
+                          onClick={() => setActiveMercenary(merc.id)}
+                        >
+                          Set Active
+                        </button>
+                      )}
+                      {active?.id === merc.id && (
+                        <span className="text-[10px] text-amber-400 font-semibold">Active</span>
+                      )}
+                      <button
+                        className="text-[10px] px-1.5 py-0.5 bg-red-900/30 text-red-400 rounded hover:bg-red-800/40 transition-colors"
+                        onClick={() => setDismissConfirm(`roster-${merc.id}`)}
+                      >
+                        ✕
+                      </button>
+                    </>
+                  )}
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Tavern */}
+      <div>
+        <h4 className="text-xs font-semibold text-slate-400 uppercase mb-2">Tavern</h4>
+        {roster.length >= 3 && (
+          <div className="text-[10px] text-amber-500 mb-2">Roster full (3/3). Dismiss a mercenary to recruit more.</div>
+        )}
+        <div className="space-y-1.5">
+          {tavernMercs.map(merc => {
+            const alreadyHave = roster.some(m => m.id === merc.id)
+            const canAfford = character.gold >= merc.recruitCost
+            const rosterFull = roster.length >= 3
+            const disabled = !canAfford || rosterFull || alreadyHave
+
+            return (
+              <div
+                key={merc.id}
+                className="bg-[#252638] border border-[#3a3c56] rounded p-2 flex items-center justify-between"
+              >
+                <div className="flex items-center gap-1.5">
+                  <span className="text-lg">{merc.icon}</span>
+                  <div>
+                    <div className="text-xs font-semibold text-slate-200">{merc.name}</div>
+                    <div className="flex items-center gap-1 mt-0.5">
+                      <ClassBadge cls={merc.class} />
+                      <RarityBadge rarity={merc.rarity} />
+                    </div>
+                    <div className="text-[10px] text-slate-500 mt-0.5">
+                      ATK {merc.attack} · DEF {merc.defense} · {merc.dailyCost}g/day
+                    </div>
+                  </div>
+                </div>
+                <div className="text-right">
+                  {alreadyHave ? (
+                    <span className="text-[10px] text-green-400">In roster</span>
+                  ) : (
+                    <button
+                      className={`text-[10px] px-2 py-1 rounded transition-colors ${
+                        disabled
+                          ? 'bg-slate-700/40 text-slate-500 cursor-not-allowed'
+                          : 'bg-amber-700/50 text-amber-300 hover:bg-amber-600/60'
+                      }`}
+                      disabled={disabled}
+                      onClick={() => recruitMercenary(merc)}
+                      title={!canAfford ? `Need ${merc.recruitCost}g` : rosterFull ? 'Roster full' : ''}
+                    >
+                      {merc.recruitCost}g Recruit
+                    </button>
+                  )}
+                </div>
+              </div>
+            )
+          })}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/app/tap-tap-adventure/config/mercenaries.ts
+++ b/src/app/tap-tap-adventure/config/mercenaries.ts
@@ -1,0 +1,224 @@
+import { Mercenary, MercenaryRarity } from '@/app/tap-tap-adventure/models/mercenary'
+
+export const MERCENARY_DEFINITIONS: Mercenary[] = [
+  // Common (recruit: 50g, daily: 2g, HP: 25)
+  {
+    id: 'town-guard',
+    name: 'Town Guard',
+    description: 'A stalwart defender, trained to hold the line.',
+    class: 'warrior',
+    rarity: 'common',
+    attack: 5,
+    defense: 2,
+    icon: '🛡️',
+    dailyCost: 2,
+    recruitCost: 50,
+  },
+  {
+    id: 'wandering-archer',
+    name: 'Wandering Archer',
+    description: 'A steady hand with a bow, reliable in skirmishes.',
+    class: 'ranger',
+    rarity: 'common',
+    attack: 6,
+    defense: 1,
+    icon: '🏹',
+    dailyCost: 2,
+    recruitCost: 50,
+  },
+  {
+    id: 'hedge-witch',
+    name: 'Hedge Witch',
+    description: 'A folk healer with a few destructive cantrips up her sleeve.',
+    class: 'cleric',
+    rarity: 'common',
+    attack: 4,
+    defense: 2,
+    icon: '🌿',
+    dailyCost: 2,
+    recruitCost: 50,
+  },
+
+  // Uncommon (recruit: 120g, daily: 4g, HP: 40)
+  {
+    id: 'sellsword',
+    name: 'Sellsword',
+    description: 'A seasoned mercenary with scars to prove it.',
+    class: 'warrior',
+    rarity: 'uncommon',
+    attack: 10,
+    defense: 4,
+    icon: '⚔️',
+    dailyCost: 4,
+    recruitCost: 120,
+  },
+  {
+    id: 'shadow-thief',
+    name: 'Shadow Thief',
+    description: 'Strikes from the blind spot and vanishes before retaliation.',
+    class: 'rogue',
+    rarity: 'uncommon',
+    attack: 13,
+    defense: 3,
+    icon: '🗡️',
+    dailyCost: 4,
+    recruitCost: 120,
+  },
+  {
+    id: 'battle-mage',
+    name: 'Battle Mage',
+    description: 'Combines raw spellcraft with martial discipline.',
+    class: 'mage',
+    rarity: 'uncommon',
+    attack: 11,
+    defense: 3,
+    icon: '🔮',
+    dailyCost: 4,
+    recruitCost: 120,
+  },
+
+  // Rare (recruit: 250g, daily: 7g, HP: 60)
+  {
+    id: 'veteran-knight',
+    name: 'Veteran Knight',
+    description: 'A knight who has survived a hundred campaigns.',
+    class: 'warrior',
+    rarity: 'rare',
+    attack: 15,
+    defense: 7,
+    icon: '🏰',
+    dailyCost: 7,
+    recruitCost: 250,
+  },
+  {
+    id: 'elven-scout',
+    name: 'Elven Scout',
+    description: 'Fleet of foot, never misses her mark.',
+    class: 'ranger',
+    rarity: 'rare',
+    attack: 18,
+    defense: 5,
+    icon: '🌲',
+    dailyCost: 7,
+    recruitCost: 250,
+  },
+  {
+    id: 'war-cleric',
+    name: 'War Cleric',
+    description: 'Channels divine wrath into each blow.',
+    class: 'cleric',
+    rarity: 'rare',
+    attack: 16,
+    defense: 6,
+    icon: '✨',
+    dailyCost: 7,
+    recruitCost: 250,
+  },
+
+  // Legendary (recruit: 500g, daily: 12g, HP: 90)
+  {
+    id: 'dread-knight',
+    name: 'Dread Knight',
+    description: 'A fallen paladin, channeling destruction without mercy.',
+    class: 'warrior',
+    rarity: 'legendary',
+    attack: 25,
+    defense: 11,
+    icon: '💀',
+    dailyCost: 12,
+    recruitCost: 500,
+  },
+  {
+    id: 'archmage-exile',
+    name: 'Archmage Exile',
+    description: 'Cast out from the tower, still commands terrible power.',
+    class: 'mage',
+    rarity: 'legendary',
+    attack: 28,
+    defense: 8,
+    icon: '🌌',
+    dailyCost: 12,
+    recruitCost: 500,
+  },
+  {
+    id: 'phantom-blade',
+    name: 'Phantom Blade',
+    description: 'An assassin whose name is spoken only in whispers.',
+    class: 'rogue',
+    rarity: 'legendary',
+    attack: 26,
+    defense: 9,
+    icon: '👤',
+    dailyCost: 12,
+    recruitCost: 500,
+  },
+]
+
+export function getMercenaryById(id: string): Mercenary | undefined {
+  return MERCENARY_DEFINITIONS.find(m => m.id === id)
+}
+
+export function getMercenariesByRarity(rarity: MercenaryRarity): Mercenary[] {
+  return MERCENARY_DEFINITIONS.filter(m => m.rarity === rarity)
+}
+
+export function getMercenaryMaxHp(rarity: MercenaryRarity): number {
+  switch (rarity) {
+    case 'common': return 25
+    case 'uncommon': return 40
+    case 'rare': return 60
+    case 'legendary': return 90
+  }
+}
+
+export function getMercenaryRecruitCost(rarity: MercenaryRarity): number {
+  switch (rarity) {
+    case 'common': return 50
+    case 'uncommon': return 120
+    case 'rare': return 250
+    case 'legendary': return 500
+  }
+}
+
+export function getMercenaryDailyCost(rarity: MercenaryRarity): number {
+  switch (rarity) {
+    case 'common': return 2
+    case 'uncommon': return 4
+    case 'rare': return 7
+    case 'legendary': return 12
+  }
+}
+
+/**
+ * Calculate mercenary damage against an enemy.
+ * Warrior gets +2 bonus. Mage gets +1 if enemy.defense > merc.attack (to punish heavily-armored targets).
+ * Uses inline variance to avoid importing private combatEngine functions.
+ */
+export function calculateMercenaryDamage(merc: Mercenary, enemyDefense: number): number {
+  let base = merc.attack
+  if (merc.class === 'warrior') base += 2
+  if (merc.class === 'mage' && enemyDefense > merc.attack) base += 1
+
+  const raw = base - enemyDefense * 0.4 + (Math.random() - 0.5) * base * 0.3
+  return Math.max(1, Math.round(raw))
+}
+
+/**
+ * Returns 3 recruitable mercenaries appropriate for the character's level.
+ * Below level 4: common only
+ * Level 4-7: common + uncommon
+ * Level 8+: uncommon + rare
+ */
+export function getTavernMercenaries(characterLevel: number): Mercenary[] {
+  let pool: Mercenary[]
+  if (characterLevel >= 8) {
+    pool = [...getMercenariesByRarity('uncommon'), ...getMercenariesByRarity('rare')]
+  } else if (characterLevel >= 4) {
+    pool = [...getMercenariesByRarity('common'), ...getMercenariesByRarity('uncommon')]
+  } else {
+    pool = getMercenariesByRarity('common')
+  }
+  // Shuffle and take 3
+  const shuffled = [...pool].sort(() => Math.random() - 0.5)
+  return shuffled.slice(0, 3)
+}

--- a/src/app/tap-tap-adventure/hooks/useCombatActionMutation.ts
+++ b/src/app/tap-tap-adventure/hooks/useCombatActionMutation.ts
@@ -111,6 +111,16 @@ export function useCombatActionMutation(options?: { onMountDrop?: (mount: Mount)
         }
       }
 
+      // Sync mercenary HP back to character
+      if (data.combatState.playerState.mercenaryHp !== undefined && character.activeMercenary) {
+        updateSelectedCharacter({
+          activeMercenary: {
+            ...character.activeMercenary,
+            hp: data.combatState.playerState.mercenaryHp,
+          },
+        })
+      }
+
       if (data.combatState.status === 'active') {
         // Combat continues — play sounds based on what happened
         // Check for critical hits in new log entries

--- a/src/app/tap-tap-adventure/hooks/useGameStore.ts
+++ b/src/app/tap-tap-adventure/hooks/useGameStore.ts
@@ -23,6 +23,8 @@ import { getEquipmentSlot, EquipmentSlotType } from '@/app/tap-tap-adventure/mod
 import { PlayerAchievement } from '@/app/tap-tap-adventure/models/achievement'
 import { Mount } from '@/app/tap-tap-adventure/models/mount'
 import { assignMountPersonality, getMountMaxHp } from '@/app/tap-tap-adventure/config/mounts'
+import { Mercenary } from '@/app/tap-tap-adventure/models/mercenary'
+import { getMercenaryMaxHp } from '@/app/tap-tap-adventure/config/mercenaries'
 import { TimedQuest } from '@/app/tap-tap-adventure/models/quest'
 import {
   FantasyDecisionPoint,
@@ -62,6 +64,8 @@ const defaultCharacter: FantasyCharacter = {
   spellbook: [],
   classData: undefined,
   activeMount: null,
+  activeMercenary: null,
+  mercenaryRoster: [],
   difficultyMode: 'normal',
   currentRegion: 'green_meadows',
   visitedRegions: ['green_meadows'],
@@ -93,6 +97,9 @@ export interface GameStore {
   setMount: (mount: Mount | null, customName?: string) => void
   damageMountHp: (damage: number) => void
   killMount: () => void
+  recruitMercenary: (mercenary: Mercenary) => boolean
+  dismissMercenary: (mercenaryId: string) => void
+  setActiveMercenary: (mercenaryId: string) => void
   addHeirloom: (item: Item) => void
   claimHeirloom: (itemId: string) => Item | null
   retireCharacter: (characterId: string) => void
@@ -210,6 +217,17 @@ export const useGameStore = create<GameStore>()(
                 updatedCharacter = { ...updatedCharacter, gold: updatedCharacter.gold, activeMount: null }
               } else {
                 updatedCharacter = { ...updatedCharacter, gold: newGold }
+              }
+            }
+
+            // Mercenary daily upkeep
+            if (newDay > oldDay && updatedCharacter.activeMercenary) {
+              const mercCost = updatedCharacter.activeMercenary.dailyCost ?? 0
+              const mercGold = updatedCharacter.gold - mercCost
+              if (mercGold < 0) {
+                updatedCharacter = { ...updatedCharacter, activeMercenary: null }
+              } else {
+                updatedCharacter = { ...updatedCharacter, gold: mercGold }
               }
             }
 
@@ -611,6 +629,75 @@ export const useGameStore = create<GameStore>()(
             state.gameState.characters[characterIndex] = {
               ...state.gameState.characters[characterIndex],
               activeMount: null,
+            }
+          })
+        )
+      },
+      recruitMercenary: (mercenary: Mercenary) => {
+        const selectedCharacter = get().getSelectedCharacter()
+        if (!selectedCharacter) return false
+        if (selectedCharacter.gold < mercenary.recruitCost) return false
+        const roster = selectedCharacter.mercenaryRoster ?? []
+        if (roster.length >= 3) return false
+        if (roster.some(m => m.id === mercenary.id)) return false
+
+        const maxHp = getMercenaryMaxHp(mercenary.rarity)
+        const fullMercenary: Mercenary = { ...mercenary, hp: maxHp, maxHp }
+
+        set(
+          produce((state: GameStore) => {
+            const charIndex = state.gameState.characters.findIndex(
+              char => char.id === selectedCharacter.id
+            )
+            if (charIndex === -1) return
+            const char = state.gameState.characters[charIndex]
+            const updatedRoster = [...(char.mercenaryRoster ?? []), fullMercenary]
+            state.gameState.characters[charIndex] = {
+              ...char,
+              gold: char.gold - mercenary.recruitCost,
+              mercenaryRoster: updatedRoster,
+              activeMercenary: char.activeMercenary ?? fullMercenary,
+            }
+          })
+        )
+        return true
+      },
+      dismissMercenary: (mercenaryId: string) => {
+        set(
+          produce((state: GameStore) => {
+            const selectedCharacter = get().getSelectedCharacter()
+            if (!selectedCharacter) return
+            const charIndex = state.gameState.characters.findIndex(
+              char => char.id === selectedCharacter.id
+            )
+            if (charIndex === -1) return
+            const char = state.gameState.characters[charIndex]
+            const updatedRoster = (char.mercenaryRoster ?? []).filter(m => m.id !== mercenaryId)
+            const updatedActive =
+              char.activeMercenary?.id === mercenaryId ? null : char.activeMercenary
+            state.gameState.characters[charIndex] = {
+              ...char,
+              mercenaryRoster: updatedRoster,
+              activeMercenary: updatedActive,
+            }
+          })
+        )
+      },
+      setActiveMercenary: (mercenaryId: string) => {
+        set(
+          produce((state: GameStore) => {
+            const selectedCharacter = get().getSelectedCharacter()
+            if (!selectedCharacter) return
+            const charIndex = state.gameState.characters.findIndex(
+              char => char.id === selectedCharacter.id
+            )
+            if (charIndex === -1) return
+            const char = state.gameState.characters[charIndex]
+            const merc = (char.mercenaryRoster ?? []).find(m => m.id === mercenaryId)
+            if (!merc) return
+            state.gameState.characters[charIndex] = {
+              ...char,
+              activeMercenary: merc,
             }
           })
         )

--- a/src/app/tap-tap-adventure/lib/combatEngine.ts
+++ b/src/app/tap-tap-adventure/lib/combatEngine.ts
@@ -18,6 +18,7 @@ import {
 import { Item } from '@/app/tap-tap-adventure/models/item'
 import { Mount } from '@/app/tap-tap-adventure/models/mount'
 import { getRandomMount, getMountFreeMoves, getMountFleeBonus, getMountMaxHp } from '@/app/tap-tap-adventure/config/mounts'
+import { calculateMercenaryDamage, getMercenaryMaxHp } from '@/app/tap-tap-adventure/config/mercenaries'
 
 import { getDifficultyModifiers } from '@/app/tap-tap-adventure/config/difficultyModes'
 import { getCampBonuses } from '@/app/tap-tap-adventure/config/baseBuildings'
@@ -132,6 +133,12 @@ export function initializePlayerCombatState(character: FantasyCharacter): Combat
     mountMovesRemaining: mountFreeMoves,
     mountHp: character.activeMount ? (character.activeMount.hp ?? getMountMaxHp(character.activeMount.rarity)) : undefined,
     mountMaxHp: character.activeMount ? getMountMaxHp(character.activeMount.rarity) : undefined,
+    mercenaryHp: character.activeMercenary
+      ? (character.activeMercenary.hp ?? getMercenaryMaxHp(character.activeMercenary.rarity))
+      : undefined,
+    mercenaryMaxHp: character.activeMercenary
+      ? getMercenaryMaxHp(character.activeMercenary.rarity)
+      : undefined,
   }
 }
 
@@ -456,6 +463,35 @@ function executeEnemyTelegraph(
 }
 
 /**
+ * Mercenary auto-attack: fires at the end of each full turn.
+ * Returns updated enemy, combat logs, and a flag for whether the merc killed the enemy.
+ */
+function applyMercenaryAutoAttack(
+  character: FantasyCharacter,
+  playerState: CombatPlayerState,
+  enemy: CombatEnemy,
+  turnNumber: number
+): { enemy: CombatEnemy; logs: CombatLogEntry[]; killedEnemy: boolean } {
+  if (!character.activeMercenary || (playerState.mercenaryHp ?? 1) <= 0) {
+    return { enemy, logs: [], killedEnemy: false }
+  }
+  const merc = character.activeMercenary
+  const damage = calculateMercenaryDamage(merc, enemy.defense)
+  const updatedEnemy = { ...enemy, hp: Math.max(0, enemy.hp - damage) }
+  const logs: CombatLogEntry[] = [
+    {
+      turn: turnNumber,
+      actor: 'player',
+      action: 'mercenary_attack',
+      damage,
+      description: `${merc.icon} ${merc.name} strikes ${enemy.name} for ${damage} damage!`,
+    },
+  ]
+  const killedEnemy = updatedEnemy.hp <= 0
+  return { enemy: updatedEnemy, logs, killedEnemy }
+}
+
+/**
  * Boss phase change: when a boss drops below 50% HP, boost their stats.
  * For the final boss, supports 3 phases triggered at 66% and 33% HP.
  */
@@ -543,7 +579,7 @@ export function processPlayerAction(
   combatState: CombatState,
   action: CombatActionRequest,
   character: FantasyCharacter
-): { combatState: CombatState; consumedItemId?: string; mountDied?: boolean } {
+): { combatState: CombatState; consumedItemId?: string; mountDied?: boolean; mercenaryDied?: boolean } {
   let { enemy, playerState, turnNumber, combatLog, status, enemyTelegraph, isBoss } = structuredClone(combatState)
   const newLogs: CombatLogEntry[] = []
   let consumedItemId: string | undefined
@@ -1346,6 +1382,22 @@ export function processPlayerAction(
     }
   }
 
+  // Mercenary auto-attack fires at end of each full turn
+  if (status === 'active' && character.activeMercenary) {
+    const mercResult = applyMercenaryAutoAttack(character, playerState, enemy, turnNumber)
+    enemy = mercResult.enemy
+    newLogs.push(...mercResult.logs)
+    if (mercResult.killedEnemy) {
+      status = 'victory'
+      newLogs.push({
+        turn: turnNumber,
+        actor: 'player',
+        action: 'victory',
+        description: `${character.activeMercenary.name} delivers the killing blow on ${enemy.name}!`,
+      })
+    }
+  }
+
   // Tick buffs at end of full turn
   playerState = tickBuffs(playerState)
 
@@ -1432,6 +1484,7 @@ export function processPlayerAction(
     },
     consumedItemId,
     mountDied,
+    mercenaryDied: false,
   }
 }
 

--- a/src/app/tap-tap-adventure/models/character.ts
+++ b/src/app/tap-tap-adventure/models/character.ts
@@ -5,6 +5,7 @@ import { CampStateSchema } from './camp'
 import { GeneratedClassSchema } from './generatedClass'
 import { ItemSchema } from './item'
 import { MountSchema } from './mount'
+import { MercenarySchema } from './mercenary'
 import { MainQuestSchema } from './quest'
 import { SpellSchema } from './spell'
 
@@ -50,6 +51,8 @@ export const FantasyCharacterSchema = z.object({
   spellbook: z.array(SpellSchema).optional(),
   classData: GeneratedClassSchema.optional(),
   activeMount: MountSchema.nullable().optional(),
+  activeMercenary: MercenarySchema.nullable().optional(),
+  mercenaryRoster: z.array(MercenarySchema).optional(),
   unlockedSkills: z.array(z.string()).optional(),
   classSkillTree: ClassSkillTreeSchema.optional(),
   unlockedTreeSkillIds: z.array(z.string()).optional(),

--- a/src/app/tap-tap-adventure/models/combat.ts
+++ b/src/app/tap-tap-adventure/models/combat.ts
@@ -99,6 +99,8 @@ export const CombatPlayerStateSchema = z.object({
   mountMovesRemaining: z.number().optional(),
   mountHp: z.number().optional(),
   mountMaxHp: z.number().optional(),
+  mercenaryHp: z.number().optional(),
+  mercenaryMaxHp: z.number().optional(),
 })
 export type CombatPlayerState = z.infer<typeof CombatPlayerStateSchema>
 

--- a/src/app/tap-tap-adventure/models/mercenary.ts
+++ b/src/app/tap-tap-adventure/models/mercenary.ts
@@ -1,0 +1,31 @@
+import { z } from 'zod'
+
+export const MercenaryClassSchema = z.enum(['warrior', 'ranger', 'mage', 'rogue', 'cleric'])
+export type MercenaryClass = z.infer<typeof MercenaryClassSchema>
+
+export const MercenaryRaritySchema = z.enum(['common', 'uncommon', 'rare', 'legendary'])
+export type MercenaryRarity = z.infer<typeof MercenaryRaritySchema>
+
+export const MercenaryPersonalitySchema = z.enum([
+  'brave', 'cautious', 'aggressive', 'loyal', 'cunning', 'reckless',
+])
+export type MercenaryPersonality = z.infer<typeof MercenaryPersonalitySchema>
+
+export const MercenarySchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  description: z.string(),
+  class: MercenaryClassSchema,
+  rarity: MercenaryRaritySchema,
+  attack: z.number(),
+  defense: z.number(),
+  icon: z.string(),
+  dailyCost: z.number(),
+  recruitCost: z.number(),
+  personality: MercenaryPersonalitySchema.optional(),
+  hp: z.number().optional(),
+  maxHp: z.number().optional(),
+  customName: z.string().optional(),
+})
+
+export type Mercenary = z.infer<typeof MercenarySchema>


### PR DESCRIPTION
## Summary

Closes #140

Adds a mercenary system where players recruit NPC companions that fight alongside them in combat.

- **12 static mercenaries** across 4 rarity tiers: Common (50g, 2g/day), Uncommon (120g, 4g/day), Rare (250g, 7g/day), Legendary (500g, 12g/day)
- **Combat integration**: Mercenary auto-attacks at end of each turn with damage based on their attack stat vs enemy defense. Can finish off enemies for victory.
- **Roster management**: Max 3 mercenaries, one active at a time. Recruit from Tavern, swap active, dismiss.
- **Gold upkeep**: Daily cost like mounts — mercenary auto-dismissed if player can't afford upkeep.
- **HP tracking**: Mercenary HP initialized in combat state, synced back to character after combat.
- **UI**: MercenaryPanel with Active/Roster/Tavern sections. Mercenary HP bar in CombatUI. Party tab in mobile nav + desktop column.

## Test plan

- [ ] Recruit a common mercenary (50g) → gold deducted, appears in roster and as active
- [ ] Enter combat → mercenary HP bar visible, combat log shows "mercenary_attack" entries
- [ ] Mercenary kills enemy → victory triggers correctly
- [ ] Fill roster to 3 → Recruit button disabled
- [ ] Swap active mercenary → correct mercenary shown
- [ ] Dismiss mercenary → removed from roster
- [ ] Advance days with low gold → mercenary auto-dismissed when upkeep unaffordable
- [ ] No active mercenary → no mercenary HP bar in combat, no auto-attack logs
- [ ] Existing characters (no mercenary fields) → graceful handling, no errors
- [ ] TypeScript compiles with no new errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)