### PR TITLE
feat: adventure leaderboard with Firestore persistence

### DIFF
--- a/src/app/api/v1/tap-tap-adventure/leaderboard/route.ts
+++ b/src/app/api/v1/tap-tap-adventure/leaderboard/route.ts
@@ -1,0 +1,57 @@
+import { type NextRequest, NextResponse } from 'next/server'
+import {
+  getLeaderboardByCategory,
+  type LeaderboardCategory,
+  type LeaderboardPeriod,
+} from '@/app/tap-tap-adventure/lib/adventureLeaderboardStore'
+
+const VALID_PERIODS: LeaderboardPeriod[] = ['daily', 'weekly', 'alltime']
+const VALID_CATEGORIES: LeaderboardCategory[] = ['distance', 'level', 'gold', 'regionsConquered']
+
+export async function GET(request: NextRequest) {
+  try {
+    const periodParam = request.nextUrl.searchParams.get('period') ?? 'daily'
+    const categoryParam = request.nextUrl.searchParams.get('category') ?? 'distance'
+
+    if (!VALID_PERIODS.includes(periodParam as LeaderboardPeriod)) {
+      return NextResponse.json(
+        { error: 'Invalid period. Use daily, weekly, or alltime.' },
+        { status: 400 }
+      )
+    }
+
+    if (!VALID_CATEGORIES.includes(categoryParam as LeaderboardCategory)) {
+      return NextResponse.json(
+        { error: 'Invalid category. Use distance, level, gold, or regionsConquered.' },
+        { status: 400 }
+      )
+    }
+
+    const period = periodParam as LeaderboardPeriod
+    const category = categoryParam as LeaderboardCategory
+
+    const entries = await getLeaderboardByCategory(category, period, 20)
+
+    return NextResponse.json({ period, category, entries })
+  } catch (error: unknown) {
+    console.error('Error fetching adventure leaderboard:', error)
+
+    // Firestore index errors — return empty results with a helpful message
+    const errMsg = error instanceof Error ? error.message : String(error)
+    if (errMsg.includes('index') || errMsg.includes('FAILED_PRECONDITION') || errMsg.includes('requires an index')) {
+      console.error('Firestore index missing. Create composite index: collection=adventure-scores, fields: date ASC + category DESC')
+      const urlMatch = errMsg.match(/(https:\/\/console\.firebase\.google\.com\S+)/)
+      if (urlMatch) {
+        console.error('Create index here:', urlMatch[1])
+      }
+      return NextResponse.json({
+        period: 'daily',
+        category: 'distance',
+        entries: [],
+        notice: 'Leaderboard is initializing. Please try again in a few minutes.',
+      })
+    }
+
+    return NextResponse.json({ error: 'Failed to fetch leaderboard.' }, { status: 500 })
+  }
+}

--- a/src/app/api/v1/tap-tap-adventure/leaderboard/submit-score/route.ts
+++ b/src/app/api/v1/tap-tap-adventure/leaderboard/submit-score/route.ts
@@ -1,0 +1,115 @@
+import { type NextRequest, NextResponse } from 'next/server'
+import { getTodayPST } from '@/app/trivia/lib/triviaUtils'
+import { submitAdventureScore } from '@/app/tap-tap-adventure/lib/adventureLeaderboardStore'
+
+const MAX_NAME_LENGTH = 20
+const MAX_CHAR_NAME_LENGTH = 50
+const MAX_REGIONS = 20
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json()
+    const {
+      playerName,
+      characterId,
+      characterName,
+      characterClass,
+      distance,
+      level,
+      gold,
+      regionsConquered,
+      date,
+    } = body
+
+    // Validate playerName
+    if (!playerName || typeof playerName !== 'string') {
+      return NextResponse.json({ error: 'playerName is required.' }, { status: 400 })
+    }
+    const trimmedName = playerName.trim()
+    if (trimmedName.length === 0 || trimmedName.length > MAX_NAME_LENGTH) {
+      return NextResponse.json(
+        { error: `playerName must be 1-${MAX_NAME_LENGTH} characters.` },
+        { status: 400 }
+      )
+    }
+
+    // Validate characterId
+    if (!characterId || typeof characterId !== 'string') {
+      return NextResponse.json({ error: 'characterId is required.' }, { status: 400 })
+    }
+
+    // Validate characterName
+    if (!characterName || typeof characterName !== 'string') {
+      return NextResponse.json({ error: 'characterName is required.' }, { status: 400 })
+    }
+    const trimmedCharName = characterName.trim()
+    if (trimmedCharName.length === 0 || trimmedCharName.length > MAX_CHAR_NAME_LENGTH) {
+      return NextResponse.json(
+        { error: `characterName must be 1-${MAX_CHAR_NAME_LENGTH} characters.` },
+        { status: 400 }
+      )
+    }
+
+    // Validate characterClass
+    if (!characterClass || typeof characterClass !== 'string') {
+      return NextResponse.json({ error: 'characterClass is required.' }, { status: 400 })
+    }
+
+    // Validate distance
+    if (typeof distance !== 'number' || distance < 0) {
+      return NextResponse.json({ error: 'distance must be a number >= 0.' }, { status: 400 })
+    }
+
+    // Validate level
+    if (typeof level !== 'number' || level < 1) {
+      return NextResponse.json({ error: 'level must be a number >= 1.' }, { status: 400 })
+    }
+
+    // Validate gold
+    if (typeof gold !== 'number' || gold < 0) {
+      return NextResponse.json({ error: 'gold must be a number >= 0.' }, { status: 400 })
+    }
+
+    // Validate regionsConquered
+    if (typeof regionsConquered !== 'number' || regionsConquered < 0 || regionsConquered > MAX_REGIONS) {
+      return NextResponse.json(
+        { error: `regionsConquered must be a number between 0 and ${MAX_REGIONS}.` },
+        { status: 400 }
+      )
+    }
+
+    // Validate date
+    if (date !== getTodayPST()) {
+      return NextResponse.json(
+        { error: 'Can only submit scores for today.' },
+        { status: 400 }
+      )
+    }
+
+    const result = await submitAdventureScore({
+      playerName: trimmedName,
+      characterId,
+      characterName: trimmedCharName,
+      characterClass,
+      distance,
+      level,
+      gold,
+      regionsConquered,
+      date,
+      submittedAt: Date.now(),
+    })
+
+    return NextResponse.json({ stored: result.stored })
+  } catch (error: unknown) {
+    console.error('Error submitting adventure score:', error)
+    // Don't block the user if Firestore is temporarily unavailable
+    const errMsg = error instanceof Error ? error.message : String(error)
+    if (errMsg.includes('FAILED_PRECONDITION') || errMsg.includes('index')) {
+      return NextResponse.json({
+        stored: false,
+        notice: 'Leaderboard is initializing.',
+      })
+    }
+    return NextResponse.json({ error: 'Failed to submit score.' }, { status: 500 })
+  }
+}

--- a/src/app/tap-tap-adventure/components/AdventureLeaderboard.tsx
+++ b/src/app/tap-tap-adventure/components/AdventureLeaderboard.tsx
@@ -1,0 +1,323 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import type { AdventureScoreEntry, LeaderboardCategory, LeaderboardPeriod } from '@/app/tap-tap-adventure/lib/adventureLeaderboardStore'
+
+interface AdventureLeaderboardProps {
+  onBack: () => void
+}
+
+function getStoredPlayerName(): string {
+  try {
+    if (typeof window === 'undefined') return ''
+    return localStorage.getItem('adventure-player-name') ?? ''
+  } catch {
+    return ''
+  }
+}
+
+function setStoredPlayerName(name: string): void {
+  try {
+    if (typeof window === 'undefined') return
+    localStorage.setItem('adventure-player-name', name)
+  } catch {
+    // ignore
+  }
+}
+
+const PERIOD_LABELS: Record<LeaderboardPeriod, string> = {
+  daily: 'Today',
+  weekly: 'This Week',
+  alltime: 'All-Time',
+}
+
+const CATEGORY_LABELS: Record<LeaderboardCategory, string> = {
+  distance: 'Distance',
+  level: 'Level',
+  gold: 'Gold',
+  regionsConquered: 'Regions',
+}
+
+export default function AdventureLeaderboard({ onBack }: AdventureLeaderboardProps) {
+  const [period, setPeriod] = useState<LeaderboardPeriod>('daily')
+  const [category, setCategory] = useState<LeaderboardCategory>('distance')
+  const [loading, setLoading] = useState(true)
+  const [data, setData] = useState<{ period: string; category: string; entries: AdventureScoreEntry[] } | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [playerName, setPlayerName] = useState<string>('')
+  const [showNameDialog, setShowNameDialog] = useState(false)
+  const [nameInput, setNameInput] = useState('')
+
+  // Load player name from localStorage on mount
+  useEffect(() => {
+    const stored = getStoredPlayerName()
+    setPlayerName(stored)
+    if (!stored) {
+      setShowNameDialog(true)
+    }
+  }, [])
+
+  // Fetch leaderboard when period or category changes
+  useEffect(() => {
+    async function load() {
+      setLoading(true)
+      setError(null)
+      try {
+        const res = await fetch(
+          `/api/v1/tap-tap-adventure/leaderboard?period=${period}&category=${category}`
+        )
+        if (!res.ok) throw new Error('Failed to load leaderboard')
+        const json = await res.json()
+        setData(json)
+      } catch {
+        setError('Failed to load leaderboard.')
+      } finally {
+        setLoading(false)
+      }
+    }
+    load()
+  }, [period, category])
+
+  const handleSaveName = () => {
+    const trimmed = nameInput.trim()
+    if (trimmed.length > 0 && trimmed.length <= 20) {
+      setStoredPlayerName(trimmed)
+      setPlayerName(trimmed)
+      setShowNameDialog(false)
+    }
+  }
+
+  const currentNameLower = playerName.toLowerCase().trim()
+
+  const renderPrimary = (entry: AdventureScoreEntry): string => {
+    switch (category) {
+      case 'distance':
+        return `${entry.distance.toLocaleString()} steps`
+      case 'level':
+        return `Lv ${entry.level}`
+      case 'gold':
+        return `${entry.gold.toLocaleString()} gp`
+      case 'regionsConquered':
+        return `${entry.regionsConquered} regions`
+    }
+  }
+
+  const renderSecondary = (entry: AdventureScoreEntry): string => {
+    switch (category) {
+      case 'distance':
+        return `Lv ${entry.level} ${entry.characterClass}`
+      case 'level':
+        return `${entry.distance.toLocaleString()} steps`
+      case 'gold':
+        return `Lv ${entry.level} ${entry.characterClass}`
+      case 'regionsConquered':
+        return entry.characterName
+    }
+  }
+
+  const renderEntries = () => {
+    if (!data || !data.entries) return null
+
+    if (data.entries.length === 0) {
+      return (
+        <div className="text-center text-slate-400 py-8">
+          No scores yet. Be the first!
+        </div>
+      )
+    }
+
+    return data.entries.map((entry, i) => {
+      const isCurrentUser =
+        entry.playerName.toLowerCase().trim() === currentNameLower && currentNameLower !== ''
+      return (
+        <LeaderboardRow
+          key={`${entry.playerName}-${entry.characterId}-${i}`}
+          rank={i + 1}
+          name={entry.playerName}
+          primary={renderPrimary(entry)}
+          secondary={renderSecondary(entry)}
+          isCurrentUser={isCurrentUser}
+        />
+      )
+    })
+  }
+
+  return (
+    <div className="w-full mx-auto p-4 sm:p-6 bg-[#1a1b2e] min-h-full">
+      {/* Header */}
+      <div className="flex items-center justify-between mb-6">
+        <button
+          type="button"
+          onClick={onBack}
+          className="text-slate-400 hover:text-slate-200 text-sm px-3 py-1.5 rounded border border-[#3a3c56] hover:border-slate-500 transition-colors"
+        >
+          &larr; Back
+        </button>
+        <h2 className="text-2xl font-bold text-amber-400">Leaderboard</h2>
+        <div className="w-16" />
+      </div>
+
+      {/* Player name display */}
+      <div className="text-center mb-4">
+        {playerName ? (
+          <p className="text-slate-400 text-sm">
+            Playing as{' '}
+            <button
+              type="button"
+              onClick={() => { setNameInput(playerName); setShowNameDialog(true) }}
+              className="text-amber-400 hover:underline"
+            >
+              {playerName}
+            </button>
+          </p>
+        ) : (
+          <p className="text-slate-400 text-sm">
+            <button
+              type="button"
+              onClick={() => { setNameInput(''); setShowNameDialog(true) }}
+              className="text-amber-400 hover:underline"
+            >
+              Set your player name
+            </button>{' '}
+            to appear on the leaderboard
+          </p>
+        )}
+      </div>
+
+      {/* Period tabs */}
+      <div className="grid grid-cols-3 gap-2 mb-3">
+        {(['daily', 'weekly', 'alltime'] as LeaderboardPeriod[]).map(p => (
+          <button
+            key={p}
+            type="button"
+            onClick={() => setPeriod(p)}
+            className={`py-2 px-3 rounded text-sm font-medium transition-colors ${
+              period === p
+                ? 'bg-indigo-600/30 border border-indigo-500/50 text-indigo-300'
+                : 'bg-[#161723] border border-[#3a3c56] text-slate-400 hover:text-slate-200 hover:border-slate-500'
+            }`}
+          >
+            {PERIOD_LABELS[p]}
+          </button>
+        ))}
+      </div>
+
+      {/* Category tabs */}
+      <div className="grid grid-cols-4 gap-2 mb-4">
+        {(['distance', 'level', 'gold', 'regionsConquered'] as LeaderboardCategory[]).map(c => (
+          <button
+            key={c}
+            type="button"
+            onClick={() => setCategory(c)}
+            className={`py-1.5 px-2 rounded text-xs font-medium transition-colors ${
+              category === c
+                ? 'bg-amber-600/20 border border-amber-500/40 text-amber-300'
+                : 'bg-[#161723] border border-[#3a3c56] text-slate-400 hover:text-slate-200 hover:border-slate-500'
+            }`}
+          >
+            {CATEGORY_LABELS[c]}
+          </button>
+        ))}
+      </div>
+
+      {/* Entries */}
+      <div className="bg-[#161723] border border-[#3a3c56] rounded-lg p-3">
+        {loading ? (
+          <div className="text-center text-slate-400 py-8">Loading...</div>
+        ) : error ? (
+          <div className="text-center text-red-400 py-8">{error}</div>
+        ) : (
+          <div className="flex flex-col gap-1.5">{renderEntries()}</div>
+        )}
+      </div>
+
+      {/* Name dialog */}
+      {showNameDialog && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 p-4">
+          <div className="w-full max-w-md bg-[#1a1b2e] border border-[#3a3c56] rounded-lg p-6 flex flex-col gap-4">
+            <h3 className="text-xl font-bold text-amber-400 text-center">
+              {playerName ? 'Change Player Name' : 'Set Player Name'}
+            </h3>
+            <p className="text-slate-400 text-sm text-center">
+              This name will appear on the leaderboard (1-20 characters).
+            </p>
+            <input
+              type="text"
+              value={nameInput}
+              onChange={e => setNameInput(e.target.value.slice(0, 20))}
+              placeholder="Your player name"
+              className="w-full px-3 py-2 rounded bg-[#161723] border border-[#3a3c56] text-slate-200 placeholder-slate-500 focus:outline-none focus:border-indigo-500"
+              onKeyDown={e => { if (e.key === 'Enter') handleSaveName() }}
+              autoFocus
+            />
+            <div className="flex gap-2">
+              {playerName && (
+                <button
+                  type="button"
+                  onClick={() => setShowNameDialog(false)}
+                  className="flex-1 py-2 px-4 rounded bg-slate-700/30 border border-slate-600/40 text-slate-300 hover:bg-slate-700/50 transition-colors"
+                >
+                  Cancel
+                </button>
+              )}
+              <button
+                type="button"
+                onClick={handleSaveName}
+                disabled={nameInput.trim().length === 0}
+                className="flex-1 py-2 px-4 rounded bg-indigo-600/20 border border-indigo-500/40 text-indigo-300 font-semibold hover:bg-indigo-600/30 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                Save
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+function LeaderboardRow({
+  rank,
+  name,
+  primary,
+  secondary,
+  isCurrentUser,
+}: {
+  rank: number
+  name: string
+  primary: string
+  secondary: string
+  isCurrentUser: boolean
+}) {
+  const rankEmoji = rank === 1 ? '\uD83E\uDD47' : rank === 2 ? '\uD83E\uDD48' : rank === 3 ? '\uD83E\uDD49' : null
+
+  return (
+    <div
+      className={`flex items-center justify-between py-2.5 px-3 rounded ${
+        isCurrentUser
+          ? 'bg-amber-600/15 border border-amber-500/30'
+          : 'bg-[#1a1b2e]'
+      }`}
+    >
+      <div className="flex items-center gap-3 min-w-0 flex-1">
+        <div className="flex items-center justify-center w-8 shrink-0">
+          {rankEmoji ? (
+            <span className="text-xl">{rankEmoji}</span>
+          ) : (
+            <span className="text-slate-500 text-sm font-mono">#{rank}</span>
+          )}
+        </div>
+        <div className="min-w-0 flex-1">
+          <div className={`font-medium truncate ${isCurrentUser ? 'text-amber-400' : 'text-slate-200'}`}>
+            {name}
+            {isCurrentUser && <span className="text-xs ml-2 text-amber-400/60">(you)</span>}
+          </div>
+          <div className="text-slate-500 text-xs">{secondary}</div>
+        </div>
+      </div>
+      <div className={`font-bold text-right shrink-0 ml-2 ${isCurrentUser ? 'text-amber-400' : 'text-slate-200'}`}>
+        {primary}
+      </div>
+    </div>
+  )
+}

--- a/src/app/tap-tap-adventure/components/GameUI.tsx
+++ b/src/app/tap-tap-adventure/components/GameUI.tsx
@@ -37,6 +37,7 @@ import { SkillPanel } from './SkillPanel'
 import { BasePanel } from './BasePanel'
 import { MercenaryPanel } from './MercenaryPanel'
 import { FactionPanel } from './FactionPanel'
+import AdventureLeaderboard from './AdventureLeaderboard'
 import { useOnboarding, HintKey } from '@/app/tap-tap-adventure/hooks/useOnboarding'
 
 const DIFFICULTY_STYLES: Record<RegionDifficulty, { label: string; color: string }> = {
@@ -95,7 +96,7 @@ function getTravelButtonMessage({ isLoading, distance }: { isLoading: boolean; d
   if (distance === 0) return 'Start Your Adventure'
   return 'Continue Travelling'
 }
-type MobilePanel = 'equipment' | 'inventory' | 'quest' | 'map' | 'settings' | 'base' | 'party' | 'factions' | null
+type MobilePanel = 'equipment' | 'inventory' | 'quest' | 'map' | 'settings' | 'base' | 'party' | 'factions' | 'leaderboard' | null
 
 interface GameUIProps {
   onOpenStatus?: () => void
@@ -543,7 +544,7 @@ export default function GameUI({ onOpenStatus }: GameUIProps) {
           >
             <div className="flex justify-between items-center mb-2">
               <h3 className="text-sm font-semibold text-slate-300 uppercase">
-                {mobilePanel === 'equipment' ? 'Equipment' : mobilePanel === 'inventory' ? 'Inventory' : mobilePanel === 'map' ? 'Map' : mobilePanel === 'settings' ? 'Settings' : mobilePanel === 'base' ? 'Camp' : mobilePanel === 'party' ? 'Party' : mobilePanel === 'factions' ? 'Factions' : 'Quest'}
+                {mobilePanel === 'equipment' ? 'Equipment' : mobilePanel === 'inventory' ? 'Inventory' : mobilePanel === 'map' ? 'Map' : mobilePanel === 'settings' ? 'Settings' : mobilePanel === 'base' ? 'Camp' : mobilePanel === 'party' ? 'Party' : mobilePanel === 'factions' ? 'Factions' : mobilePanel === 'leaderboard' ? 'Leaderboard' : 'Quest'}
               </h3>
               <button
                 className="text-slate-400 hover:text-white text-sm px-2 py-1"
@@ -575,6 +576,9 @@ export default function GameUI({ onOpenStatus }: GameUIProps) {
             {mobilePanel === 'base' && <BasePanel />}
             {mobilePanel === 'party' && character && <MercenaryPanel character={character} />}
             {mobilePanel === 'factions' && character && <FactionPanel character={character} />}
+            {mobilePanel === 'leaderboard' && (
+              <AdventureLeaderboard onBack={() => setMobilePanel(null)} />
+            )}
           </div>
         </div>
       )}
@@ -589,6 +593,7 @@ export default function GameUI({ onOpenStatus }: GameUIProps) {
           { id: 'base' as MobilePanel, label: 'Camp', icon: '\uD83C\uDFD5' },
           { id: 'party' as MobilePanel, label: 'Party', icon: '\u2694\uFE0F' },
           { id: 'factions' as MobilePanel, label: 'Factions', icon: '\uD83C\uDFF0' },
+          { id: 'leaderboard' as MobilePanel, label: 'Ranks', icon: '\uD83C\uDFC6' },
           { id: 'settings' as MobilePanel, label: 'Settings', icon: '\u2699' },
         ]).map(tab => (
           <button

--- a/src/app/tap-tap-adventure/components/RunSummary.tsx
+++ b/src/app/tap-tap-adventure/components/RunSummary.tsx
@@ -1,9 +1,30 @@
 'use client'
 
+import { useState, useEffect } from 'react'
 import { calculateDay } from '@/app/tap-tap-adventure/lib/leveling'
 import { calculateSoulEssence } from '@/app/tap-tap-adventure/lib/soulEssenceCalculator'
 import { CONQUERABLE_REGIONS } from '@/app/tap-tap-adventure/lib/mainQuestManager'
 import type { RunSummaryData } from '@/app/tap-tap-adventure/models/types'
+import { getTodayPST } from '@/app/trivia/lib/triviaUtils'
+import AdventureLeaderboard from './AdventureLeaderboard'
+
+function getStoredPlayerName(): string {
+  try {
+    if (typeof window === 'undefined') return ''
+    return localStorage.getItem('adventure-player-name') ?? ''
+  } catch {
+    return ''
+  }
+}
+
+function setStoredPlayerName(name: string): void {
+  try {
+    if (typeof window === 'undefined') return
+    localStorage.setItem('adventure-player-name', name)
+  } catch {
+    // ignore
+  }
+}
 
 interface RunSummaryProps {
   data: RunSummaryData
@@ -79,6 +100,57 @@ export default function RunSummary({
 }: RunSummaryProps) {
   const { character, reason, essenceEarned, heirloom } = data
 
+  const [playerName, setPlayerName] = useState<string>('')
+  const [nameInput, setNameInput] = useState<string>('')
+  const [showNameInput, setShowNameInput] = useState(false)
+  const [submitStatus, setSubmitStatus] = useState<'idle' | 'submitting' | 'success' | 'error'>('idle')
+  const [showLeaderboard, setShowLeaderboard] = useState(false)
+
+  // Load player name from localStorage on mount
+  useEffect(() => {
+    const stored = getStoredPlayerName()
+    setPlayerName(stored)
+    setNameInput(stored)
+    if (!stored) {
+      setShowNameInput(true)
+    }
+  }, [])
+
+  const handleSaveName = () => {
+    const trimmed = nameInput.trim()
+    if (trimmed.length > 0 && trimmed.length <= 20) {
+      setStoredPlayerName(trimmed)
+      setPlayerName(trimmed)
+      setShowNameInput(false)
+    }
+  }
+
+  const handleSubmitScore = async () => {
+    if (!playerName || submitStatus === 'submitting') return
+    setSubmitStatus('submitting')
+    try {
+      const res = await fetch('/api/v1/tap-tap-adventure/leaderboard/submit-score', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          playerName,
+          characterId: character.id,
+          characterName: character.name,
+          characterClass: character.class,
+          distance: character.distance,
+          level: character.level,
+          gold: character.gold,
+          regionsConquered: character.visitedRegions?.filter(r => CONQUERABLE_REGIONS.includes(r)).length ?? 0,
+          date: getTodayPST(),
+        }),
+      })
+      if (!res.ok) throw new Error('Failed to submit')
+      setSubmitStatus('success')
+    } catch {
+      setSubmitStatus('error')
+    }
+  }
+
   const isRetirement = reason === 'retirement'
   const isVictory = reason === 'victory'
   const headerText = isVictory ? 'World Conquered!' : isRetirement ? 'Run Complete' : 'Fallen in Battle'
@@ -99,6 +171,15 @@ export default function RunSummary({
 
   // Count combat victories from story events if available (not tracked here, show N/A)
   // We don't have storyEvents in the summary data, so we skip enemies defeated
+
+  // Leaderboard overlay
+  if (showLeaderboard) {
+    return (
+      <div className="fixed inset-0 z-50 overflow-y-auto bg-[#1a1b2e] p-4">
+        <AdventureLeaderboard onBack={() => setShowLeaderboard(false)} />
+      </div>
+    )
+  }
 
   return (
     <div className="w-full mx-auto p-4 sm:p-6 bg-[#1a1b2e] border border-[#3a3c56] rounded-lg mt-6 max-w-2xl">
@@ -147,6 +228,82 @@ export default function RunSummary({
             value={String(regionsConquered)}
             highlight={regionsConquered >= 14 ? 'green' : undefined}
           />
+        </div>
+      </div>
+
+      {/* Leaderboard Section */}
+      <div className="mb-6 p-4 bg-indigo-950/30 border border-indigo-600/30 rounded-lg">
+        <h3 className="text-sm font-semibold text-indigo-400 uppercase tracking-wider mb-3">
+          Submit to Leaderboard
+        </h3>
+
+        {/* Player name input */}
+        {showNameInput ? (
+          <div className="flex gap-2 mb-3">
+            <input
+              type="text"
+              value={nameInput}
+              onChange={e => setNameInput(e.target.value.slice(0, 20))}
+              placeholder="Enter your player name"
+              className="flex-1 px-3 py-2 rounded bg-[#161723] border border-[#3a3c56] text-slate-200 placeholder-slate-500 focus:outline-none focus:border-indigo-500 text-sm"
+              onKeyDown={e => { if (e.key === 'Enter') handleSaveName() }}
+            />
+            <button
+              type="button"
+              onClick={handleSaveName}
+              disabled={nameInput.trim().length === 0}
+              className="px-3 py-2 rounded bg-indigo-600/20 border border-indigo-500/40 text-indigo-300 text-sm font-medium hover:bg-indigo-600/30 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              Save
+            </button>
+          </div>
+        ) : (
+          <p className="text-slate-400 text-sm mb-3">
+            Submitting as{' '}
+            <button
+              type="button"
+              onClick={() => { setNameInput(playerName); setShowNameInput(true) }}
+              className="text-indigo-400 hover:underline"
+            >
+              {playerName}
+            </button>
+          </p>
+        )}
+
+        {/* Submit button / status */}
+        <div className="flex gap-2 flex-wrap">
+          {submitStatus === 'idle' && (
+            <button
+              type="button"
+              onClick={handleSubmitScore}
+              disabled={!playerName || showNameInput}
+              className="py-2 px-4 rounded bg-indigo-600/20 border border-indigo-500/40 text-indigo-300 text-sm font-semibold hover:bg-indigo-600/30 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              Submit Score
+            </button>
+          )}
+          {submitStatus === 'submitting' && (
+            <span className="py-2 px-4 text-slate-400 text-sm">Submitting...</span>
+          )}
+          {submitStatus === 'success' && (
+            <span className="py-2 px-1 text-green-400 text-sm">Score submitted!</span>
+          )}
+          {submitStatus === 'error' && (
+            <button
+              type="button"
+              onClick={handleSubmitScore}
+              className="py-2 px-4 rounded bg-red-600/20 border border-red-500/40 text-red-300 text-sm font-semibold hover:bg-red-600/30 transition-colors"
+            >
+              Failed — Retry?
+            </button>
+          )}
+          <button
+            type="button"
+            onClick={() => setShowLeaderboard(true)}
+            className="py-2 px-4 rounded bg-[#161723] border border-[#3a3c56] text-slate-300 text-sm hover:border-slate-500 hover:text-slate-100 transition-colors"
+          >
+            View Leaderboard
+          </button>
         </div>
       </div>
 

--- a/src/app/tap-tap-adventure/lib/adventureLeaderboardStore.ts
+++ b/src/app/tap-tap-adventure/lib/adventureLeaderboardStore.ts
@@ -1,0 +1,118 @@
+import { getFirestoreDb } from '@/app/trivia/lib/firebase'
+
+const COLLECTION = 'adventure-scores'
+
+export interface AdventureScoreEntry {
+  playerName: string
+  characterName: string
+  characterClass: string
+  characterId: string
+  distance: number
+  level: number
+  gold: number
+  regionsConquered: number
+  date: string // YYYY-MM-DD PST
+  submittedAt: number // Date.now() ms
+}
+
+export type LeaderboardCategory = 'distance' | 'level' | 'gold' | 'regionsConquered'
+export type LeaderboardPeriod = 'daily' | 'weekly' | 'alltime'
+
+function docId(playerName: string, characterId: string): string {
+  return `${playerName.toLowerCase().trim()}|${characterId}`
+}
+
+export async function submitAdventureScore(
+  entry: AdventureScoreEntry
+): Promise<{ stored: boolean }> {
+  const db = getFirestoreDb()
+  const id = docId(entry.playerName, entry.characterId)
+  const ref = db.collection(COLLECTION).doc(id)
+
+  await ref.set({
+    playerName: entry.playerName,
+    playerNameLower: entry.playerName.toLowerCase().trim(),
+    characterName: entry.characterName,
+    characterClass: entry.characterClass,
+    characterId: entry.characterId,
+    distance: entry.distance,
+    level: entry.level,
+    gold: entry.gold,
+    regionsConquered: entry.regionsConquered,
+    date: entry.date,
+    submittedAt: entry.submittedAt,
+  })
+
+  return { stored: true }
+}
+
+export async function getLeaderboardByCategory(
+  category: LeaderboardCategory,
+  period: LeaderboardPeriod,
+  limit = 20
+): Promise<AdventureScoreEntry[]> {
+  const db = getFirestoreDb()
+  const collection = db.collection(COLLECTION)
+
+  if (period === 'daily') {
+    const today = getTodayPSTLocal()
+    const snap = await collection
+      .where('date', '==', today)
+      .orderBy(category, 'desc')
+      .limit(limit)
+      .get()
+    return snap.docs.map(doc => doc.data() as AdventureScoreEntry)
+  }
+
+  if (period === 'weekly') {
+    const { start, end } = getCurrentWeekRange()
+    const snap = await collection
+      .where('date', '>=', start)
+      .where('date', '<=', end)
+      .get()
+
+    const entries = snap.docs.map(doc => doc.data() as AdventureScoreEntry)
+    return entries
+      .sort((a, b) => b[category] - a[category])
+      .slice(0, limit)
+  }
+
+  // alltime — fetch all, sort in memory
+  const snap = await collection.get()
+  const entries = snap.docs.map(doc => doc.data() as AdventureScoreEntry)
+  return entries
+    .sort((a, b) => b[category] - a[category])
+    .slice(0, limit)
+}
+
+function getTodayPSTLocal(): string {
+  const now = new Date()
+  const pst = now.toLocaleString('en-US', { timeZone: 'America/Los_Angeles' })
+  const d = new Date(pst)
+  const yyyy = d.getFullYear()
+  const mm = String(d.getMonth() + 1).padStart(2, '0')
+  const dd = String(d.getDate()).padStart(2, '0')
+  return `${yyyy}-${mm}-${dd}`
+}
+
+export function getCurrentWeekRange(): { start: string; end: string } {
+  const now = new Date()
+  const pstStr = now.toLocaleString('en-US', { timeZone: 'America/Los_Angeles' })
+  const today = new Date(pstStr)
+
+  const dayOfWeek = today.getDay() || 7
+  const monday = new Date(today)
+  monday.setDate(today.getDate() - (dayOfWeek - 1))
+
+  const sunday = new Date(monday)
+  sunday.setDate(monday.getDate() + 6)
+
+  const fmt = (d: Date) => {
+    const yyyy = d.getFullYear()
+    const mm = String(d.getMonth() + 1).padStart(2, '0')
+    const dd = String(d.getDate()).padStart(2, '0')
+    return `${yyyy}-${mm}-${dd}`
+  }
+
+  return { start: fmt(monday), end: fmt(sunday) }
+}


### PR DESCRIPTION
## Summary

Closes #143

Adds a Firestore-backed leaderboard system for Tap Tap Adventure, mirroring the existing trivia leaderboard infrastructure.

**Leaderboard categories:**
- Distance Traveled
- Highest Level
- Most Gold
- Regions Conquered

**Time periods:** Daily, Weekly, All-Time

**How it works:**
- On death/victory/retirement, players can submit their character's stats to the leaderboard from the Run Summary screen
- Player name persists in localStorage for repeat submissions
- One entry per player per character (upserts on resubmit)
- Leaderboard accessible from Run Summary and mobile nav (Ranks tab)

**Technical:**
- Reuses existing Firebase/Firestore instance from trivia system
- `adventure-scores` Firestore collection with composite index support
- Submit + Fetch API routes with graceful Firestore error handling
- AdventureLeaderboard client component with period/category tabs and player highlighting

**Deployment note:** 4 Firestore composite indexes need manual creation for daily queries on each category. Routes handle missing indexes gracefully until created.

## Test plan

- [ ] Submit score from Run Summary → POST succeeds, shows success state
- [ ] View leaderboard from Run Summary → overlay with entries
- [ ] Switch period tabs → data refreshes
- [ ] Switch category tabs → data refreshes
- [ ] Current player highlighted in amber
- [ ] Player name persists across sessions (localStorage)
- [ ] Invalid submit (empty name) → error message
- [ ] Firestore without indexes → graceful empty results with notice
- [ ] Mobile Ranks tab → opens leaderboard panel
- [ ] TypeScript compiles with no new errors
- [ ] Existing trivia leaderboard unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)