### PR TITLE
feat: bestiary — track defeated monsters with stats

### DIFF
--- a/src/app/tap-tap-adventure/components/BestiaryPanel.tsx
+++ b/src/app/tap-tap-adventure/components/BestiaryPanel.tsx
@@ -1,0 +1,128 @@
+'use client'
+
+import { useState } from 'react'
+import { BestiaryEntry } from '@/app/tap-tap-adventure/models/bestiary'
+
+const ELEMENT_STYLES: Record<string, string> = {
+  nature: 'bg-green-900/40 text-green-300',
+  shadow: 'bg-slate-800/60 text-slate-300',
+  arcane: 'bg-violet-900/40 text-violet-300',
+  fire: 'bg-orange-900/40 text-orange-300',
+  ice: 'bg-cyan-900/40 text-cyan-300',
+  none: 'bg-slate-800/40 text-slate-400',
+}
+
+function getElementStyle(element?: string): string {
+  if (!element) return ELEMENT_STYLES['none']
+  return ELEMENT_STYLES[element] ?? ELEMENT_STYLES['none']
+}
+
+export function BestiaryPanel({ bestiary }: { bestiary: BestiaryEntry[] }) {
+  const [isExpanded, setIsExpanded] = useState(false)
+
+  const count = bestiary.length
+
+  if (!isExpanded) {
+    return (
+      <button
+        className="w-full bg-[#1e1f30] border border-[#3a3c56] rounded-lg p-3 text-left hover:border-indigo-700/50 transition-colors"
+        onClick={() => setIsExpanded(true)}
+      >
+        <div className="flex justify-between items-center">
+          <span className="text-sm font-bold text-indigo-400">Bestiary</span>
+          <span className="text-xs text-slate-400">{count} discovered</span>
+        </div>
+      </button>
+    )
+  }
+
+  // Group entries by region
+  const byRegion = new Map<string, BestiaryEntry[]>()
+  for (const entry of bestiary) {
+    const existing = byRegion.get(entry.region)
+    if (existing) {
+      existing.push(entry)
+    } else {
+      byRegion.set(entry.region, [entry])
+    }
+  }
+
+  const regionKeys = Array.from(byRegion.keys())
+
+  return (
+    <div className="bg-[#1e1f30] border border-[#3a3c56] rounded-lg p-3 space-y-3">
+      <div className="flex justify-between items-center">
+        <button
+          className="text-sm font-bold text-indigo-400 hover:text-indigo-300 transition-colors"
+          onClick={() => setIsExpanded(false)}
+        >
+          Bestiary
+        </button>
+        <span className="text-xs text-slate-400">{count} discovered</span>
+      </div>
+
+      {count === 0 && (
+        <p className="text-xs text-slate-500 italic">No monsters encountered yet. Defeat enemies to fill your bestiary.</p>
+      )}
+
+      {regionKeys.map(region => {
+        const entries = byRegion.get(region)!
+        const regionLabel = region
+          .replace(/_/g, ' ')
+          .replace(/\b\w/g, c => c.toUpperCase())
+
+        return (
+          <div key={region} className="space-y-1.5">
+            <h4 className="text-[10px] uppercase tracking-wider text-slate-500 font-semibold">
+              {regionLabel}
+            </h4>
+            {entries.map(entry => (
+              <div
+                key={entry.name}
+                className="rounded p-2 text-xs bg-[#161723] border border-[#2a2b3f]"
+              >
+                <div className="flex items-center gap-1.5 flex-wrap">
+                  <span className="font-semibold text-white">{entry.name}</span>
+                  {entry.isBoss && (
+                    <span className="text-[9px] font-bold uppercase tracking-wide bg-amber-900/50 text-amber-300 border border-amber-600/40 rounded px-1 py-0.5">
+                      Boss
+                    </span>
+                  )}
+                  {entry.element && (
+                    <span className={`text-[9px] font-semibold uppercase tracking-wide rounded px-1 py-0.5 ${getElementStyle(entry.element)}`}>
+                      {entry.element}
+                    </span>
+                  )}
+                  <span className="text-slate-500 ml-auto">Lv {entry.level}</span>
+                </div>
+                <div className="flex gap-3 mt-1 text-[10px] text-slate-400">
+                  <span>HP <span className="text-slate-200">{entry.maxHp}</span></span>
+                  <span>ATK <span className="text-slate-200">{entry.attack}</span></span>
+                  <span>DEF <span className="text-slate-200">{entry.defense}</span></span>
+                </div>
+                {(entry.specialAbility || entry.statusAbility) && (
+                  <div className="flex flex-wrap gap-1.5 mt-1">
+                    {entry.specialAbility && (
+                      <span className="text-[9px] bg-purple-900/30 text-purple-300 border border-purple-700/30 rounded px-1 py-0.5">
+                        {entry.specialAbility.name}
+                      </span>
+                    )}
+                    {entry.statusAbility && (
+                      <span className="text-[9px] bg-rose-900/30 text-rose-300 border border-rose-700/30 rounded px-1 py-0.5">
+                        {entry.statusAbility.type}
+                      </span>
+                    )}
+                  </div>
+                )}
+                <div className="flex justify-between mt-1 text-[9px] text-slate-500">
+                  <span>Defeated <span className="text-slate-300">{entry.timesDefeated}x</span></span>
+                  <span>First seen {new Date(entry.firstEncountered).toLocaleDateString()}</span>
+                </div>
+              </div>
+            ))}
+          </div>
+        )
+      })}
+    </div>
+  )
+}

--- a/src/app/tap-tap-adventure/components/GameUI.tsx
+++ b/src/app/tap-tap-adventure/components/GameUI.tsx
@@ -39,6 +39,7 @@ import { MercenaryPanel } from './MercenaryPanel'
 import { FactionPanel } from './FactionPanel'
 import AdventureLeaderboard from './AdventureLeaderboard'
 import { CraftingPanel } from './CraftingPanel'
+import { BestiaryPanel } from './BestiaryPanel'
 import { useOnboarding, HintKey } from '@/app/tap-tap-adventure/hooks/useOnboarding'
 
 const DIFFICULTY_STYLES: Record<RegionDifficulty, { label: string; color: string }> = {
@@ -97,7 +98,7 @@ function getTravelButtonMessage({ isLoading, distance }: { isLoading: boolean; d
   if (distance === 0) return 'Start Your Adventure'
   return 'Continue Travelling'
 }
-type MobilePanel = 'equipment' | 'inventory' | 'quest' | 'map' | 'settings' | 'base' | 'party' | 'factions' | 'leaderboard' | 'crafting' | null
+type MobilePanel = 'equipment' | 'inventory' | 'quest' | 'map' | 'settings' | 'base' | 'party' | 'factions' | 'leaderboard' | 'crafting' | 'bestiary' | null
 
 interface GameUIProps {
   onOpenStatus?: () => void
@@ -500,6 +501,7 @@ export default function GameUI({ onOpenStatus }: GameUIProps) {
             {character && <MainQuestPanel character={character} />}
             <QuestPanel />
             <AchievementPanel achievements={gameState.achievements ?? []} />
+            <BestiaryPanel bestiary={character?.bestiary ?? []} />
             <EquipmentPanel
               equipment={getSelectedCharacter()?.equipment ?? { weapon: null, armor: null, accessory: null }}
             />
@@ -551,7 +553,7 @@ export default function GameUI({ onOpenStatus }: GameUIProps) {
           >
             <div className="flex justify-between items-center mb-2">
               <h3 className="text-sm font-semibold text-slate-300 uppercase">
-                {mobilePanel === 'equipment' ? 'Equipment' : mobilePanel === 'inventory' ? 'Inventory' : mobilePanel === 'map' ? 'Map' : mobilePanel === 'settings' ? 'Settings' : mobilePanel === 'base' ? 'Camp' : mobilePanel === 'party' ? 'Party' : mobilePanel === 'factions' ? 'Factions' : mobilePanel === 'leaderboard' ? 'Leaderboard' : mobilePanel === 'crafting' ? 'Crafting' : 'Quest'}
+                {mobilePanel === 'equipment' ? 'Equipment' : mobilePanel === 'inventory' ? 'Inventory' : mobilePanel === 'map' ? 'Map' : mobilePanel === 'settings' ? 'Settings' : mobilePanel === 'base' ? 'Camp' : mobilePanel === 'party' ? 'Party' : mobilePanel === 'factions' ? 'Factions' : mobilePanel === 'leaderboard' ? 'Leaderboard' : mobilePanel === 'crafting' ? 'Crafting' : mobilePanel === 'bestiary' ? 'Bestiary' : 'Quest'}
               </h3>
               <button
                 className="text-slate-400 hover:text-white text-sm px-2 py-1"
@@ -587,6 +589,7 @@ export default function GameUI({ onOpenStatus }: GameUIProps) {
               <AdventureLeaderboard onBack={() => setMobilePanel(null)} />
             )}
             {mobilePanel === 'crafting' && <CraftingPanel />}
+            {mobilePanel === 'bestiary' && character && <BestiaryPanel bestiary={character.bestiary ?? []} />}
           </div>
         </div>
       )}
@@ -603,6 +606,7 @@ export default function GameUI({ onOpenStatus }: GameUIProps) {
           { id: 'party' as MobilePanel, label: 'Party', icon: '\u2694\uFE0F' },
           { id: 'factions' as MobilePanel, label: 'Factions', icon: '\uD83C\uDFF0' },
           { id: 'leaderboard' as MobilePanel, label: 'Ranks', icon: '\uD83C\uDFC6' },
+          { id: 'bestiary' as MobilePanel, label: 'Bestiary', icon: '\uD83D\uDC09' },
           { id: 'settings' as MobilePanel, label: 'Settings', icon: '\u2699' },
         ]).map(tab => (
           <button

--- a/src/app/tap-tap-adventure/hooks/useCombatActionMutation.ts
+++ b/src/app/tap-tap-adventure/hooks/useCombatActionMutation.ts
@@ -12,6 +12,7 @@ import { claimNewMilestones, getConqueredCount } from '@/app/tap-tap-adventure/l
 import { CombatAction, CombatState } from '@/app/tap-tap-adventure/models/combat'
 import { Mount } from '@/app/tap-tap-adventure/models/mount'
 import { FantasyCharacter, Item } from '@/app/tap-tap-adventure/models/types'
+import { BestiaryEntry } from '@/app/tap-tap-adventure/models/bestiary'
 
 import { soundEngine } from '@/app/tap-tap-adventure/lib/soundEngine'
 
@@ -224,6 +225,38 @@ export function useCombatActionMutation(options?: { onMountDrop?: (mount: Mount)
               })
               // Do NOT delete the character — post-game character persists
             }
+          }
+
+          // Update bestiary on victory
+          {
+            const existingBestiary: BestiaryEntry[] = character.bestiary ?? []
+            const enemyNameLower = enemy.name.toLowerCase()
+            const existingIndex = existingBestiary.findIndex(
+              e => e.name.toLowerCase() === enemyNameLower
+            )
+            let updatedBestiary: BestiaryEntry[]
+            if (existingIndex !== -1) {
+              updatedBestiary = existingBestiary.map((e, i) =>
+                i === existingIndex ? { ...e, timesDefeated: e.timesDefeated + 1 } : e
+              )
+            } else {
+              const newEntry: BestiaryEntry = {
+                name: enemy.name,
+                element: enemy.element,
+                level: enemy.level,
+                attack: enemy.attack,
+                defense: enemy.defense,
+                maxHp: enemy.maxHp,
+                specialAbility: enemy.specialAbility,
+                statusAbility: enemy.statusAbility,
+                region: character.currentRegion ?? 'green_meadows',
+                timesDefeated: 1,
+                firstEncountered: new Date().toISOString(),
+                isBoss: combatState.isBoss,
+              }
+              updatedBestiary = [...existingBestiary, newEntry]
+            }
+            updateSelectedCharacter({ bestiary: updatedBestiary })
           }
 
           addStoryEvent({

--- a/src/app/tap-tap-adventure/hooks/useGameStore.ts
+++ b/src/app/tap-tap-adventure/hooks/useGameStore.ts
@@ -77,6 +77,7 @@ const defaultCharacter: FantasyCharacter = {
   visitedRegions: ['green_meadows'],
   mainQuest: createMainQuest(),
   factionReputations: {},
+  bestiary: [],
 }
 
 export interface GameStore {
@@ -1017,7 +1018,7 @@ export const useGameStore = create<GameStore>()(
     }),
     {
       name: 'fantasy-tycoon-storage', // localStorage key (kept for backward compat)
-      version: 21,
+      version: 22,
       migrate: (persistedState: unknown) => {
         const state = persistedState as GameStore
         if (state?.gameState && !('combatState' in state.gameState)) {
@@ -1112,6 +1113,10 @@ export const useGameStore = create<GameStore>()(
             // v21: Add currentWeather
             if ((char as FantasyCharacter).currentWeather === undefined) {
               ;(char as FantasyCharacter).currentWeather = 'clear'
+            }
+            // v22: Add bestiary
+            if (!(char as FantasyCharacter).bestiary) {
+              ;(char as FantasyCharacter).bestiary = []
             }
           }
         }

--- a/src/app/tap-tap-adventure/models/bestiary.ts
+++ b/src/app/tap-tap-adventure/models/bestiary.ts
@@ -1,0 +1,28 @@
+import { z } from 'zod'
+
+import { SpellElementSchema } from './spell'
+import { StatusAbilitySchema } from './combat'
+
+export const BestiaryEntrySchema = z.object({
+  name: z.string(),
+  element: SpellElementSchema.optional(),
+  level: z.number(),
+  attack: z.number(),
+  defense: z.number(),
+  maxHp: z.number(),
+  specialAbility: z
+    .object({
+      name: z.string(),
+      description: z.string(),
+      damage: z.number(),
+      cooldown: z.number(),
+    })
+    .optional(),
+  statusAbility: StatusAbilitySchema.optional(),
+  region: z.string(),
+  timesDefeated: z.number(),
+  firstEncountered: z.string(),
+  isBoss: z.boolean().optional(),
+})
+
+export type BestiaryEntry = z.infer<typeof BestiaryEntrySchema>

--- a/src/app/tap-tap-adventure/models/character.ts
+++ b/src/app/tap-tap-adventure/models/character.ts
@@ -8,6 +8,7 @@ import { MountSchema } from './mount'
 import { MercenarySchema } from './mercenary'
 import { MainQuestSchema } from './quest'
 import { SpellSchema } from './spell'
+import { BestiaryEntrySchema } from './bestiary'
 
 /** All schemas in this file are the single source of truth for both runtime validation and static typing. */
 
@@ -63,6 +64,7 @@ export const FantasyCharacterSchema = z.object({
   mainQuest: MainQuestSchema.optional(),
   campState: CampStateSchema.optional(),
   factionReputations: z.record(z.string(), z.number()).optional().default({}),
+  bestiary: z.array(BestiaryEntrySchema).optional(),
 })
 export type FantasyCharacter = z.infer<typeof FantasyCharacterSchema>
 

--- a/src/app/tap-tap-adventure/models/types.ts
+++ b/src/app/tap-tap-adventure/models/types.ts
@@ -126,3 +126,4 @@ export type {
   MetaProgressionState,
   MetaProgressionStateSchema,
 } from './metaProgression'
+export type { BestiaryEntry, BestiaryEntrySchema } from './bestiary'


### PR DESCRIPTION
## Summary

Closes #220

Adds a monster compendium that automatically records defeated enemies, creating a satisfying collection mechanic.

**How it works:**
- When a player defeats an enemy, the bestiary auto-captures: name, element, level, HP/ATK/DEF, special abilities, status abilities, region, and boss flag
- Repeat kills of the same monster increment a "times defeated" counter (case-insensitive de-duplication)
- BestiaryPanel shows entries grouped by region with colored element badges, stat displays, and boss indicators

**Implementation:**
- `BestiaryEntry` Zod schema with all combat-relevant enemy stats
- Auto-capture in combat victory branch of `useCombatActionMutation.ts`
- BestiaryPanel collapsible UI matching existing panel patterns
- Store migration v22 initializes empty bestiary on existing characters
- Bestiary tab (🐉) in mobile nav + desktop right column

## Test plan

- [ ] Defeat an enemy → bestiary shows new entry with correct stats and region
- [ ] Defeat same enemy again → timesDefeated increments, firstEncountered unchanged
- [ ] Defeat a boss → entry shows boss indicator
- [ ] Defeat enemies in different regions → entries grouped by region in panel
- [ ] Reload page → bestiary entries persist
- [ ] Mobile Bestiary tab opens panel
- [ ] Desktop right column shows BestiaryPanel
- [ ] New character starts with empty bestiary
- [ ] Existing character (pre-v22) → migration initializes bestiary: []
- [ ] TypeScript compiles with no new errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)