### PR TITLE
feat: daily challenges with rotating objectives and streak bonuses

### DIFF
--- a/src/app/tap-tap-adventure/__tests__/achievements.test.ts
+++ b/src/app/tap-tap-adventure/__tests__/achievements.test.ts
@@ -48,6 +48,7 @@ const baseGameState: GameState = {
   achievements: [],
   legacyHeirlooms: [],
   dailyReward: null,
+  dailyChallenges: null,
   metaProgression: null,
   runSummary: null,
 }

--- a/src/app/tap-tap-adventure/__tests__/dailyChallenges.test.ts
+++ b/src/app/tap-tap-adventure/__tests__/dailyChallenges.test.ts
@@ -1,0 +1,298 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  generateChallengesForDate,
+  shouldRefreshChallenges,
+  refreshChallenges,
+  applyProgress,
+  computeBonusReward,
+  canClaimBonusReward,
+} from '@/app/tap-tap-adventure/lib/dailyChallengeTracker'
+import { DailyChallengesState } from '@/app/tap-tap-adventure/models/dailyChallenge'
+
+const TODAY = '2026-04-17'
+const YESTERDAY = '2026-04-16'
+
+// Helper to build a minimal DailyChallengesState
+function buildState(overrides: Partial<DailyChallengesState> = {}): DailyChallengesState {
+  const challenges = generateChallengesForDate(TODAY, 1)
+  return {
+    date: TODAY,
+    challenges,
+    allCompletedClaimed: false,
+    streak: 0,
+    ...overrides,
+  }
+}
+
+describe('generateChallengesForDate', () => {
+  it('returns exactly 3 challenges', () => {
+    const challenges = generateChallengesForDate(TODAY, 1)
+    expect(challenges).toHaveLength(3)
+  })
+
+  it('all challenges have distinct types', () => {
+    const challenges = generateChallengesForDate(TODAY, 1)
+    const types = challenges.map(c => c.type)
+    expect(new Set(types).size).toBe(3)
+  })
+
+  it('produces the same result for the same date and level (seeded determinism)', () => {
+    const a = generateChallengesForDate(TODAY, 1)
+    const b = generateChallengesForDate(TODAY, 1)
+    expect(a.map(c => c.type)).toEqual(b.map(c => c.type))
+    expect(a.map(c => c.target)).toEqual(b.map(c => c.target))
+  })
+
+  it('produces different challenges for different dates', () => {
+    const a = generateChallengesForDate('2026-04-17', 1)
+    const b = generateChallengesForDate('2026-04-18', 1)
+    // Very unlikely to be exactly the same, but check at least the type order
+    expect(a.map(c => c.type)).not.toEqual(b.map(c => c.type))
+  })
+
+  it('scales targets and rewards at bucket 0 (level 1)', () => {
+    const challenges = generateChallengesForDate(TODAY, 1)
+    const travelChallenge = challenges.find(c => c.type === 'travel_distance')
+    if (travelChallenge) {
+      expect(travelChallenge.target).toBe(50) // base: 50 + 0*30 = 50
+      expect(travelChallenge.reward.gold).toBe(15) // base: 15 + 0*5 = 15
+    }
+    const winChallenge = challenges.find(c => c.type === 'win_combats')
+    if (winChallenge) {
+      expect(winChallenge.target).toBe(2) // base: 2 + 0*1 = 2
+      expect(winChallenge.reward.gold).toBe(20) // base: 20 + 0*5 = 20
+    }
+  })
+
+  it('scales targets and rewards at bucket 4 (level 21+)', () => {
+    const challenges = generateChallengesForDate(TODAY, 21)
+    const travelChallenge = challenges.find(c => c.type === 'travel_distance')
+    if (travelChallenge) {
+      expect(travelChallenge.target).toBe(170) // 50 + 4*30 = 170
+      expect(travelChallenge.reward.gold).toBe(35) // 15 + 4*5 = 35
+    }
+    const winChallenge = challenges.find(c => c.type === 'win_combats')
+    if (winChallenge) {
+      expect(winChallenge.target).toBe(6) // 2 + 4*1 = 6
+      expect(winChallenge.reward.gold).toBe(40) // 20 + 4*5 = 40
+    }
+  })
+
+  it('craft_item always has target of 1 and 30 gold + 5 rep reward', () => {
+    // Try a date that happens to include craft_item
+    for (let day = 1; day <= 30; day++) {
+      const date = `2026-04-${String(day).padStart(2, '0')}`
+      const challenges = generateChallengesForDate(date, 10)
+      const craft = challenges.find(c => c.type === 'craft_item')
+      if (craft) {
+        expect(craft.target).toBe(1)
+        expect(craft.reward.gold).toBe(30)
+        expect(craft.reward.reputation).toBe(5)
+        break
+      }
+    }
+  })
+})
+
+describe('shouldRefreshChallenges', () => {
+  it('returns true when state is null', () => {
+    expect(shouldRefreshChallenges(null, TODAY)).toBe(true)
+  })
+
+  it('returns true when state is undefined', () => {
+    expect(shouldRefreshChallenges(undefined, TODAY)).toBe(true)
+  })
+
+  it('returns true when state date is different from today', () => {
+    const state = buildState({ date: YESTERDAY })
+    expect(shouldRefreshChallenges(state, TODAY)).toBe(true)
+  })
+
+  it('returns false when state date matches today', () => {
+    const state = buildState({ date: TODAY })
+    expect(shouldRefreshChallenges(state, TODAY)).toBe(false)
+  })
+})
+
+describe('refreshChallenges', () => {
+  it('generates 3 new challenges with todays date', () => {
+    const result = refreshChallenges(null, TODAY, 1)
+    expect(result.date).toBe(TODAY)
+    expect(result.challenges).toHaveLength(3)
+  })
+
+  it('starts streak at 0 when previous state is null', () => {
+    const result = refreshChallenges(null, TODAY, 1)
+    expect(result.streak).toBe(0)
+  })
+
+  it('increments streak when all previous challenges were completed', () => {
+    const prevChallenges = generateChallengesForDate(YESTERDAY, 1).map(c => ({
+      ...c,
+      progress: c.target,
+      completed: true,
+    }))
+    const prevState: DailyChallengesState = {
+      date: YESTERDAY,
+      challenges: prevChallenges,
+      allCompletedClaimed: true,
+      streak: 2,
+    }
+    const result = refreshChallenges(prevState, TODAY, 1)
+    expect(result.streak).toBe(3)
+  })
+
+  it('resets streak to 0 when previous day was not all completed', () => {
+    const prevChallenges = generateChallengesForDate(YESTERDAY, 1)
+    // Leave challenges uncompleted
+    const prevState: DailyChallengesState = {
+      date: YESTERDAY,
+      challenges: prevChallenges,
+      allCompletedClaimed: false,
+      streak: 5,
+    }
+    const result = refreshChallenges(prevState, TODAY, 1)
+    expect(result.streak).toBe(0)
+  })
+
+  it('resets allCompletedClaimed to false', () => {
+    const result = refreshChallenges(null, TODAY, 1)
+    expect(result.allCompletedClaimed).toBe(false)
+  })
+})
+
+describe('applyProgress', () => {
+  it('increments progress for a matching type', () => {
+    const state = buildState()
+    const targetType = state.challenges[0].type
+    // Apply amount=1 which is always <= any challenge target
+    const updated = applyProgress(state, targetType, 1)
+    const challenge = updated.challenges.find(c => c.type === targetType)!
+    expect(challenge.progress).toBe(1)
+  })
+
+  it('clamps progress at target', () => {
+    const state = buildState()
+    const firstChallenge = state.challenges[0]
+    const updated = applyProgress(state, firstChallenge.type, firstChallenge.target + 100)
+    const challenge = updated.challenges.find(c => c.type === firstChallenge.type)!
+    expect(challenge.progress).toBe(firstChallenge.target)
+    expect(challenge.completed).toBe(true)
+  })
+
+  it('marks challenge as completed when progress >= target', () => {
+    const state = buildState()
+    const firstChallenge = state.challenges[0]
+    const updated = applyProgress(state, firstChallenge.type, firstChallenge.target)
+    const challenge = updated.challenges.find(c => c.type === firstChallenge.type)!
+    expect(challenge.completed).toBe(true)
+  })
+
+  it('skips already-completed challenges', () => {
+    const state = buildState()
+    const firstChallenge = state.challenges[0]
+    // Complete it first
+    const intermediate = applyProgress(state, firstChallenge.type, firstChallenge.target)
+    // Apply more progress — should not change
+    const updated = applyProgress(intermediate, firstChallenge.type, 999)
+    const challenge = updated.challenges.find(c => c.type === firstChallenge.type)!
+    expect(challenge.progress).toBe(firstChallenge.target) // still capped, not more
+  })
+
+  it('does not mutate the original state', () => {
+    const state = buildState()
+    const firstType = state.challenges[0].type
+    const originalProgress = state.challenges[0].progress
+    applyProgress(state, firstType, 10)
+    expect(state.challenges[0].progress).toBe(originalProgress) // unchanged
+  })
+
+  it('does not affect challenges of a different type', () => {
+    const state = buildState()
+    // Get a type that is NOT the first challenge
+    const otherType = (['travel_distance', 'earn_gold', 'win_combats', 'gain_reputation', 'craft_item'] as const)
+      .find(t => t !== state.challenges[0].type && state.challenges.some(c => c.type === t))
+    if (otherType) {
+      const updated = applyProgress(state, state.challenges[0].type, 99)
+      const otherChallenge = updated.challenges.find(c => c.type === otherType)!
+      expect(otherChallenge.progress).toBe(0) // untouched
+    }
+  })
+})
+
+describe('computeBonusReward', () => {
+  it('returns base values at streak 0', () => {
+    const reward = computeBonusReward(0)
+    expect(reward.gold).toBe(50)
+    expect(reward.reputation).toBe(10)
+  })
+
+  it('scales correctly at streak 1', () => {
+    const reward = computeBonusReward(1)
+    expect(reward.gold).toBe(65)
+    expect(reward.reputation).toBe(15)
+  })
+
+  it('caps at streak 10', () => {
+    const reward10 = computeBonusReward(10)
+    const reward20 = computeBonusReward(20)
+    expect(reward10.gold).toBe(reward20.gold)
+    expect(reward10.reputation).toBe(reward20.reputation)
+  })
+
+  it('returns max values at streak 10', () => {
+    const reward = computeBonusReward(10)
+    expect(reward.gold).toBe(50 + 10 * 15) // 200
+    expect(reward.reputation).toBe(10 + 10 * 5) // 60
+  })
+})
+
+describe('canClaimBonusReward', () => {
+  it('returns true when all 3 completed and not yet claimed', () => {
+    const challenges = generateChallengesForDate(TODAY, 1).map(c => ({
+      ...c,
+      progress: c.target,
+      completed: true,
+    }))
+    const state: DailyChallengesState = {
+      date: TODAY,
+      challenges,
+      allCompletedClaimed: false,
+      streak: 0,
+    }
+    expect(canClaimBonusReward(state)).toBe(true)
+  })
+
+  it('returns false when already claimed', () => {
+    const challenges = generateChallengesForDate(TODAY, 1).map(c => ({
+      ...c,
+      progress: c.target,
+      completed: true,
+    }))
+    const state: DailyChallengesState = {
+      date: TODAY,
+      challenges,
+      allCompletedClaimed: true,
+      streak: 0,
+    }
+    expect(canClaimBonusReward(state)).toBe(false)
+  })
+
+  it('returns false when not all challenges are completed', () => {
+    const challenges = generateChallengesForDate(TODAY, 1)
+    // Only complete 2 of 3
+    const partial = challenges.map((c, i) => ({
+      ...c,
+      progress: i < 2 ? c.target : 0,
+      completed: i < 2,
+    }))
+    const state: DailyChallengesState = {
+      date: TODAY,
+      challenges: partial,
+      allCompletedClaimed: false,
+      streak: 0,
+    }
+    expect(canClaimBonusReward(state)).toBe(false)
+  })
+})

--- a/src/app/tap-tap-adventure/__tests__/dailyRewards.test.ts
+++ b/src/app/tap-tap-adventure/__tests__/dailyRewards.test.ts
@@ -55,6 +55,7 @@ function makeState(dailyReward: GameState['dailyReward'] = null): GameState {
     metaProgression: null,
     runSummary: null,
     dailyReward,
+    dailyChallenges: null,
   }
 }
 

--- a/src/app/tap-tap-adventure/components/DailyChallengesPanel.tsx
+++ b/src/app/tap-tap-adventure/components/DailyChallengesPanel.tsx
@@ -1,0 +1,123 @@
+'use client'
+
+import { useState } from 'react'
+import { Button } from '@/app/tap-tap-adventure/components/ui/button'
+import { useGameStore } from '@/app/tap-tap-adventure/hooks/useGameStore'
+import { canClaimBonusReward, computeBonusReward, getTodayDateString } from '@/app/tap-tap-adventure/lib/dailyChallengeTracker'
+import { DailyChallenge } from '@/app/tap-tap-adventure/models/dailyChallenge'
+
+function formatDate(dateStr: string): string {
+  const [year, month, day] = dateStr.split('-').map(Number)
+  const d = new Date(year, month - 1, day)
+  return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
+}
+
+function ChallengeRow({ challenge }: { challenge: DailyChallenge }) {
+  const pct = Math.min(100, Math.round((challenge.progress / challenge.target) * 100))
+
+  return (
+    <div className="space-y-1">
+      <div className="flex items-center justify-between gap-2">
+        <span className="text-xs text-slate-300 flex-1">{challenge.description}</span>
+        <div className="flex items-center gap-1 shrink-0">
+          {challenge.reward.gold && (
+            <span className="text-[10px] text-yellow-400">+{challenge.reward.gold}g</span>
+          )}
+          {challenge.reward.reputation && (
+            <span className="text-[10px] text-blue-400">+{challenge.reward.reputation} rep</span>
+          )}
+          {challenge.completed && (
+            <span className="text-emerald-400 text-xs font-bold ml-1">&#10003;</span>
+          )}
+        </div>
+      </div>
+      <div className="flex items-center gap-2">
+        <div className="flex-1 h-1.5 bg-slate-700 rounded-full overflow-hidden">
+          <div
+            className={`h-full rounded-full transition-all duration-300 ${challenge.completed ? 'bg-emerald-500' : 'bg-indigo-500'}`}
+            style={{ width: `${pct}%` }}
+          />
+        </div>
+        <span className="text-[10px] text-slate-400 shrink-0 w-12 text-right">
+          {challenge.progress}/{challenge.target}
+        </span>
+      </div>
+    </div>
+  )
+}
+
+export function DailyChallengesPanel() {
+  const { gameState, claimDailyChallengeBonus } = useGameStore()
+  const [expanded, setExpanded] = useState(true)
+
+  const challenges = gameState.dailyChallenges
+
+  // Don't render if no challenges have been generated yet (first step triggers generation)
+  if (!challenges) return null
+
+  const today = getTodayDateString()
+  // If the panel date doesn't match today, challenges are stale — still show them
+  const displayDate = challenges.date === today ? today : challenges.date
+
+  const allDone = challenges.challenges.every(c => c.completed)
+  const canClaim = canClaimBonusReward(challenges)
+  const bonus = computeBonusReward(challenges.streak)
+
+  return (
+    <div className="bg-[#1e1f30] border border-[#3a3c56] rounded-lg p-3 space-y-2">
+      {/* Header */}
+      <button
+        className="w-full flex items-center justify-between text-left"
+        onClick={() => setExpanded(prev => !prev)}
+      >
+        <div className="flex items-center gap-2">
+          <span className="text-xs font-bold text-amber-400">Daily Challenges</span>
+          <span className="text-[10px] px-1.5 py-0.5 bg-slate-700 text-slate-300 rounded">
+            {formatDate(displayDate)}
+          </span>
+          {challenges.streak > 0 && (
+            <span className="text-[10px] px-1.5 py-0.5 bg-orange-900/50 text-orange-300 rounded">
+              &#128293; {challenges.streak}
+            </span>
+          )}
+        </div>
+        <span className="text-slate-500 text-xs">{expanded ? '▲' : '▼'}</span>
+      </button>
+
+      {expanded && (
+        <>
+          {/* Challenge rows */}
+          <div className="space-y-3 pt-1">
+            {challenges.challenges.map(challenge => (
+              <ChallengeRow key={challenge.id} challenge={challenge} />
+            ))}
+          </div>
+
+          {/* Bonus section */}
+          {canClaim && (
+            <div className="mt-2 bg-emerald-950/40 border border-emerald-700/40 rounded p-2 space-y-1">
+              <p className="text-xs font-semibold text-emerald-400">All Complete! Bonus Reward:</p>
+              <div className="flex gap-3 text-[10px]">
+                <span className="text-yellow-400">+{bonus.gold} Gold</span>
+                <span className="text-blue-400">+{bonus.reputation} Reputation</span>
+              </div>
+              <Button
+                className="w-full bg-emerald-700 hover:bg-emerald-600 text-white text-xs py-1 rounded mt-1"
+                onClick={() => claimDailyChallengeBonus()}
+              >
+                Claim Bonus
+              </Button>
+            </div>
+          )}
+
+          {/* Already claimed */}
+          {allDone && challenges.allCompletedClaimed && (
+            <p className="text-[10px] text-emerald-400 text-center py-1">
+              Challenges complete for today!
+            </p>
+          )}
+        </>
+      )}
+    </div>
+  )
+}

--- a/src/app/tap-tap-adventure/components/GameUI.tsx
+++ b/src/app/tap-tap-adventure/components/GameUI.tsx
@@ -40,6 +40,7 @@ import { FactionPanel } from './FactionPanel'
 import AdventureLeaderboard from './AdventureLeaderboard'
 import { CraftingPanel } from './CraftingPanel'
 import { BestiaryPanel } from './BestiaryPanel'
+import { DailyChallengesPanel } from './DailyChallengesPanel'
 import { useOnboarding, HintKey } from '@/app/tap-tap-adventure/hooks/useOnboarding'
 
 const DIFFICULTY_STYLES: Record<RegionDifficulty, { label: string; color: string }> = {
@@ -500,6 +501,7 @@ export default function GameUI({ onOpenStatus }: GameUIProps) {
           <div className="hidden md:block p-4 bg-[#161723] border border-[#3a3c56] rounded-lg space-y-4 h-fit md:sticky md:top-8">
             {character && <MainQuestPanel character={character} />}
             <QuestPanel />
+            <DailyChallengesPanel />
             <AchievementPanel achievements={gameState.achievements ?? []} />
             <BestiaryPanel bestiary={character?.bestiary ?? []} />
             <EquipmentPanel
@@ -564,6 +566,7 @@ export default function GameUI({ onOpenStatus }: GameUIProps) {
             </div>
             {mobilePanel === 'quest' && character && <MainQuestPanel character={character} />}
             {mobilePanel === 'quest' && <QuestPanel />}
+            {mobilePanel === 'quest' && <DailyChallengesPanel />}
             {mobilePanel === 'equipment' && (
               <>
                 <EquipmentPanel

--- a/src/app/tap-tap-adventure/hooks/useCombatActionMutation.ts
+++ b/src/app/tap-tap-adventure/hooks/useCombatActionMutation.ts
@@ -147,6 +147,8 @@ export function useCombatActionMutation(options?: { onMountDrop?: (mount: Mount)
 
         if (data.combatState.status === 'victory' && data.rewards) {
           soundEngine.playVictory()
+          // Track daily challenge: win_combats
+          useGameStore.getState().updateDailyChallengeProgress('win_combats', 1)
           // Add loot items and collect for story event
           const processedLoot: Item[] = []
           for (const lootItem of data.rewards.loot) {

--- a/src/app/tap-tap-adventure/hooks/useGameStore.ts
+++ b/src/app/tap-tap-adventure/hooks/useGameStore.ts
@@ -36,7 +36,15 @@ import {
   RunSummaryData,
   ShopState,
 } from '@/app/tap-tap-adventure/models/types'
-import { claimDailyReward as processDailyRewardClaim } from '@/app/tap-tap-adventure/lib/dailyRewardTracker'
+import { claimDailyReward as processDailyRewardClaim, getTodayDateString } from '@/app/tap-tap-adventure/lib/dailyRewardTracker'
+import {
+  shouldRefreshChallenges,
+  refreshChallenges,
+  applyProgress as applyDailyChallengeProgress,
+  computeBonusReward,
+  canClaimBonusReward,
+} from '@/app/tap-tap-adventure/lib/dailyChallengeTracker'
+import { DailyChallengeType } from '@/app/tap-tap-adventure/models/dailyChallenge'
 import { FACTIONS, FactionId } from '@/app/tap-tap-adventure/config/factions'
 import { rollWeather, WEATHER_CHANGE_INTERVAL } from '@/app/tap-tap-adventure/config/weather'
 import { CRAFTING_RECIPES } from '@/app/tap-tap-adventure/config/craftingRecipes'
@@ -122,6 +130,8 @@ export interface GameStore {
   clearRunSummary: () => void
   purchaseFactionGear: (factionId: FactionId, gearId: string) => boolean
   craftItem: (recipeId: string) => { message: string; success: boolean } | null
+  updateDailyChallengeProgress: (type: DailyChallengeType, amount: number) => void
+  claimDailyChallengeBonus: () => { gold: number; reputation: number } | null
 }
 
 export const useGameStore = create<GameStore>()(
@@ -207,6 +217,25 @@ export const useGameStore = create<GameStore>()(
           produce((state: GameStore) => {
             const selectedCharacter = get().getSelectedCharacter()
             if (!selectedCharacter) return
+
+            // Refresh daily challenges if date has changed
+            const today = getTodayDateString()
+            if (shouldRefreshChallenges(state.gameState.dailyChallenges, today)) {
+              state.gameState.dailyChallenges = refreshChallenges(
+                state.gameState.dailyChallenges,
+                today,
+                selectedCharacter.level ?? 1
+              )
+            }
+            // Track travel_distance progress
+            if (state.gameState.dailyChallenges) {
+              state.gameState.dailyChallenges = applyDailyChallengeProgress(
+                state.gameState.dailyChallenges,
+                'travel_distance',
+                1
+              )
+            }
+
             const oldDistance = selectedCharacter.distance || 0
             const newDistance = oldDistance + 1
             const metaBonuses = get().getMetaBonuses()
@@ -1010,15 +1039,55 @@ export const useGameStore = create<GameStore>()(
             )
             if (charIndex === -1) return
             state.gameState.characters[charIndex] = updatedCharacter
+            // Track craft_item daily challenge progress
+            if (state.gameState.dailyChallenges) {
+              state.gameState.dailyChallenges = applyDailyChallengeProgress(
+                state.gameState.dailyChallenges,
+                'craft_item',
+                1
+              )
+            }
           })
         )
 
         return { message: `Crafted ${recipe.result.name}!`, success: true }
       },
+      updateDailyChallengeProgress: (type: DailyChallengeType, amount: number) => {
+        set(
+          produce((state: GameStore) => {
+            if (!state.gameState.dailyChallenges) return
+            state.gameState.dailyChallenges = applyDailyChallengeProgress(
+              state.gameState.dailyChallenges,
+              type,
+              amount
+            )
+          })
+        )
+      },
+      claimDailyChallengeBonus: () => {
+        const challenges = get().gameState.dailyChallenges
+        const selectedCharacter = get().getSelectedCharacter()
+        if (!challenges || !selectedCharacter) return null
+        if (!canClaimBonusReward(challenges)) return null
+
+        const bonus = computeBonusReward(challenges.streak)
+        set(
+          produce((state: GameStore) => {
+            const charIndex = state.gameState.characters.findIndex(c => c.id === selectedCharacter.id)
+            if (charIndex === -1) return
+            state.gameState.characters[charIndex].gold += bonus.gold
+            state.gameState.characters[charIndex].reputation = clampReputation(
+              state.gameState.characters[charIndex].reputation + bonus.reputation
+            )
+            state.gameState.dailyChallenges!.allCompletedClaimed = true
+          })
+        )
+        return bonus
+      },
     }),
     {
       name: 'fantasy-tycoon-storage', // localStorage key (kept for backward compat)
-      version: 22,
+      version: 23,
       migrate: (persistedState: unknown) => {
         const state = persistedState as GameStore
         if (state?.gameState && !('combatState' in state.gameState)) {
@@ -1143,6 +1212,10 @@ export const useGameStore = create<GameStore>()(
         // v13: Add runSummary
         if (state?.gameState && !('runSummary' in state.gameState)) {
           (state.gameState as GameState).runSummary = null
+        }
+        // v23: Add dailyChallenges
+        if (state?.gameState && !('dailyChallenges' in state.gameState)) {
+          (state.gameState as GameState).dailyChallenges = null
         }
         return state
       },

--- a/src/app/tap-tap-adventure/hooks/useMoveForwardMutation.ts
+++ b/src/app/tap-tap-adventure/hooks/useMoveForwardMutation.ts
@@ -39,6 +39,8 @@ export function useMoveForwardMutation() {
     mutationFn: async () => {
       const currentCharacter = getSelectedCharacter()
       if (!currentCharacter) throw new Error('No character found')
+      const prevGold = currentCharacter.gold
+      const prevReputation = currentCharacter.reputation
 
       const { gameState } = useGameStore.getState()
       const res = await fetch('/api/v1/tap-tap-adventure/move-forward', {
@@ -110,6 +112,16 @@ export function useMoveForwardMutation() {
       }
 
       commit()
+
+      // Track daily challenge progress for gold and reputation gains
+      const goldDelta = (data.character.gold ?? 0) - prevGold
+      const repDelta = (data.character.reputation ?? 0) - prevReputation
+      if (goldDelta > 0) {
+        useGameStore.getState().updateDailyChallengeProgress('earn_gold', goldDelta)
+      }
+      if (repDelta > 0) {
+        useGameStore.getState().updateDailyChallengeProgress('gain_reputation', repDelta)
+      }
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['tap-tap-adventure', 'game-state'] })

--- a/src/app/tap-tap-adventure/lib/dailyChallengeTracker.ts
+++ b/src/app/tap-tap-adventure/lib/dailyChallengeTracker.ts
@@ -1,0 +1,179 @@
+import { DailyChallenge, DailyChallengeType, DailyChallengesState } from '@/app/tap-tap-adventure/models/dailyChallenge'
+export { getTodayDateString } from '@/app/tap-tap-adventure/lib/dailyRewardTracker'
+
+// ---------------------------------------------------------------------------
+// Seeded PRNG (Linear Congruential Generator)
+// ---------------------------------------------------------------------------
+
+function seededRandom(seed: number): () => number {
+  let s = seed >>> 0
+  return function () {
+    s = (Math.imul(1664525, s) + 1013904223) >>> 0
+    return s / 4294967296
+  }
+}
+
+function dateToSeed(date: string): number {
+  let seed = 0
+  for (let i = 0; i < date.length; i++) {
+    seed += date.charCodeAt(i)
+  }
+  return seed
+}
+
+// ---------------------------------------------------------------------------
+// Challenge template definitions
+// ---------------------------------------------------------------------------
+
+interface ChallengeTemplate {
+  type: DailyChallengeType
+  descriptionFn: (target: number) => string
+  targetFn: (bucket: number) => number
+  goldRewardFn: (bucket: number) => number
+  repReward?: number
+}
+
+const CHALLENGE_TEMPLATES: ChallengeTemplate[] = [
+  {
+    type: 'travel_distance',
+    descriptionFn: (target) => `Travel ${target} steps`,
+    targetFn: (bucket) => 50 + bucket * 30,
+    goldRewardFn: (bucket) => 15 + bucket * 5,
+  },
+  {
+    type: 'earn_gold',
+    descriptionFn: (target) => `Earn ${target} gold`,
+    targetFn: (bucket) => 20 + bucket * 20,
+    goldRewardFn: (bucket) => 10 + bucket * 3,
+    repReward: 3,
+  },
+  {
+    type: 'win_combats',
+    descriptionFn: (target) => `Win ${target} combat${target !== 1 ? 's' : ''}`,
+    targetFn: (bucket) => 2 + bucket * 1,
+    goldRewardFn: (bucket) => 20 + bucket * 5,
+  },
+  {
+    type: 'gain_reputation',
+    descriptionFn: (target) => `Gain ${target} reputation`,
+    targetFn: (bucket) => 3 + bucket * 3,
+    goldRewardFn: (bucket) => 15 + bucket * 5,
+  },
+  {
+    type: 'craft_item',
+    descriptionFn: () => 'Craft an item',
+    targetFn: () => 1,
+    goldRewardFn: () => 30,
+    repReward: 5,
+  },
+]
+
+// ---------------------------------------------------------------------------
+// Public functions
+// ---------------------------------------------------------------------------
+
+/**
+ * Generate 3 deterministic daily challenges for a given date and character level.
+ */
+export function generateChallengesForDate(date: string, characterLevel: number): DailyChallenge[] {
+  const bucket = Math.min(4, Math.floor((characterLevel - 1) / 5))
+  const rand = seededRandom(dateToSeed(date))
+
+  // Fisher-Yates shuffle using seeded PRNG
+  const indices = [0, 1, 2, 3, 4]
+  for (let i = indices.length - 1; i > 0; i--) {
+    const j = Math.floor(rand() * (i + 1))
+    ;[indices[i], indices[j]] = [indices[j], indices[i]]
+  }
+
+  const selected = indices.slice(0, 3)
+
+  return selected.map((templateIndex, i) => {
+    const template = CHALLENGE_TEMPLATES[templateIndex]
+    const target = template.targetFn(bucket)
+    const gold = template.goldRewardFn(bucket)
+    return {
+      id: `${date}-${i}`,
+      type: template.type,
+      description: template.descriptionFn(target),
+      target,
+      progress: 0,
+      completed: false,
+      reward: {
+        gold,
+        ...(template.repReward !== undefined ? { reputation: template.repReward } : {}),
+      },
+    }
+  })
+}
+
+/**
+ * Return true if the challenges state is missing or stale (different date).
+ */
+export function shouldRefreshChallenges(
+  state: DailyChallengesState | null | undefined,
+  today: string
+): boolean {
+  return !state || state.date !== today
+}
+
+/**
+ * Build a fresh DailyChallengesState for today. Handles streak carry-over.
+ */
+export function refreshChallenges(
+  currentState: DailyChallengesState | null | undefined,
+  today: string,
+  characterLevel: number
+): DailyChallengesState {
+  let newStreak = 0
+  if (currentState && currentState.challenges.every(c => c.completed)) {
+    newStreak = currentState.streak + 1
+  }
+
+  const challenges = generateChallengesForDate(today, characterLevel)
+  return {
+    date: today,
+    challenges,
+    allCompletedClaimed: false,
+    streak: newStreak,
+  }
+}
+
+/**
+ * Apply progress to a specific challenge type. Returns a new state (pure function).
+ */
+export function applyProgress(
+  state: DailyChallengesState,
+  type: DailyChallengeType,
+  amount: number
+): DailyChallengesState {
+  const updatedChallenges = state.challenges.map(challenge => {
+    if (challenge.type !== type || challenge.completed) return challenge
+    const newProgress = Math.min(challenge.target, challenge.progress + amount)
+    return {
+      ...challenge,
+      progress: newProgress,
+      completed: newProgress >= challenge.target,
+    }
+  })
+  return { ...state, challenges: updatedChallenges }
+}
+
+/**
+ * Compute the bonus reward for completing all 3 daily challenges.
+ * Base: 50g + 10 rep. +15g / +5 rep per streak level (capped at 10).
+ */
+export function computeBonusReward(streak: number): { gold: number; reputation: number } {
+  const cappedStreak = Math.min(10, streak)
+  return {
+    gold: 50 + cappedStreak * 15,
+    reputation: 10 + cappedStreak * 5,
+  }
+}
+
+/**
+ * Return true if the bonus reward can currently be claimed.
+ */
+export function canClaimBonusReward(state: DailyChallengesState): boolean {
+  return state.challenges.every(c => c.completed) && !state.allCompletedClaimed
+}

--- a/src/app/tap-tap-adventure/lib/defaultGameState.ts
+++ b/src/app/tap-tap-adventure/lib/defaultGameState.ts
@@ -19,6 +19,7 @@ export const defaultGameState: GameState = {
   achievements: [],
   legacyHeirlooms: [],
   dailyReward: null,
+  dailyChallenges: null,
   metaProgression: null,
   runSummary: null,
 }

--- a/src/app/tap-tap-adventure/models/dailyChallenge.ts
+++ b/src/app/tap-tap-adventure/models/dailyChallenge.ts
@@ -1,0 +1,32 @@
+import { z } from 'zod'
+
+export const DailyChallengeTypeSchema = z.enum([
+  'travel_distance',
+  'earn_gold',
+  'win_combats',
+  'gain_reputation',
+  'craft_item',
+])
+export type DailyChallengeType = z.infer<typeof DailyChallengeTypeSchema>
+
+export const DailyChallengeSchema = z.object({
+  id: z.string(), // e.g. "2026-04-17-0"
+  type: DailyChallengeTypeSchema,
+  description: z.string(),
+  target: z.number(),
+  progress: z.number(),
+  completed: z.boolean(),
+  reward: z.object({
+    gold: z.number().optional(),
+    reputation: z.number().optional(),
+  }),
+})
+export type DailyChallenge = z.infer<typeof DailyChallengeSchema>
+
+export const DailyChallengesStateSchema = z.object({
+  date: z.string(), // YYYY-MM-DD
+  challenges: z.array(DailyChallengeSchema), // always 3
+  allCompletedClaimed: z.boolean(),
+  streak: z.number(),
+})
+export type DailyChallengesState = z.infer<typeof DailyChallengesStateSchema>

--- a/src/app/tap-tap-adventure/models/types.ts
+++ b/src/app/tap-tap-adventure/models/types.ts
@@ -3,6 +3,7 @@
 import { PlayerAchievement } from './achievement'
 import { FantasyCharacter } from './character'
 import { CombatState } from './combat'
+import { DailyChallengesState } from './dailyChallenge'
 import { Item } from './item'
 import { FantasyLocation } from './location'
 import { MetaProgressionState } from './metaProgression'
@@ -113,10 +114,12 @@ type GameState = {
   achievements: PlayerAchievement[]
   legacyHeirlooms: Item[]
   dailyReward: DailyRewardState | null
+  dailyChallenges: DailyChallengesState | null
   metaProgression: MetaProgressionState | null
   runSummary: RunSummaryData | null
 }
 export type { GameState, DailyRewardState, RunSummaryData }
+export type { DailyChallenge, DailyChallengeType, DailyChallengesState } from './dailyChallenge'
 export type { PlayerAchievement, Achievement, AchievementCategory } from './achievement'
 export type {
   EternalUpgrade,


### PR DESCRIPTION
## Summary

Closes #221

Adds a daily challenge system with 3 rotating objectives that refresh each real-world day. Completing all 3 earns a bonus reward that scales with streak.

**5 challenge types (scaled by character level):**
| Type | Example Target | Reward |
|------|---------------|--------|
| Travel Distance | 50-200 steps | 15-40g |
| Earn Gold | 20-100g | 10-25g + 3 rep |
| Win Combats | 1-5 fights | 20-50g |
| Gain Reputation | 3-15 rep | 15-35g |
| Craft Item | 1 craft | 30g + 5 rep |

**Features:**
- Seeded PRNG ensures same 3 challenges all day for same level bucket
- Progress tracked from travel, combat victories, crafting, and move-forward events
- Streak tracking for consecutive days completing all 3
- Bonus reward: 50g + 10 rep base, +15g/+5rep per streak (capped at streak 10)
- DailyChallengesPanel in quest drawer (desktop + mobile)
- 29 new unit tests covering all tracker functions

## Test plan

- [ ] First step generates 3 daily challenges
- [ ] Travel increases travel_distance progress
- [ ] Win combat increases win_combats progress
- [ ] Earn gold from events increases earn_gold progress
- [ ] Craft item increases craft_item progress
- [ ] Completing all 3 → bonus claim available
- [ ] Claim bonus → gold/rep applied to character
- [ ] Challenges refresh at day boundary with new objectives
- [ ] Streak increments when previous day was all-complete
- [ ] Streak resets when previous day was incomplete
- [ ] DailyChallengesPanel visible in desktop sidebar and mobile quest drawer
- [ ] 29/29 new tests pass
- [ ] TypeScript compiles with no new errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)