### PR TITLE
feat: enchanting system — upgrade equipment with stat bonuses

### DIFF
--- a/src/app/tap-tap-adventure/components/EnchantingPanel.tsx
+++ b/src/app/tap-tap-adventure/components/EnchantingPanel.tsx
@@ -1,0 +1,157 @@
+'use client'
+import { useState } from 'react'
+
+import { useGameStore } from '@/app/tap-tap-adventure/hooks/useGameStore'
+import { getEnchantCost, getEnchantBonusStat, MAX_ENCHANT_LEVEL } from '@/app/tap-tap-adventure/config/enchanting'
+import type { Item } from '@/app/tap-tap-adventure/models/item'
+
+type EquipSlot = 'weapon' | 'armor' | 'accessory'
+
+const SLOT_LABELS: Record<EquipSlot, string> = {
+  weapon: 'Weapon',
+  armor: 'Armor',
+  accessory: 'Accessory',
+}
+
+function EnchantSlotCard({
+  slot,
+  item,
+  gold,
+  onEnchant,
+}: {
+  slot: EquipSlot
+  item: Item | null
+  gold: number
+  onEnchant: (slot: EquipSlot) => void
+}) {
+  if (!item) {
+    return (
+      <div className="bg-[#1e1f30] border border-[#3a3c56] p-3 rounded-lg flex items-center justify-between gap-2 opacity-50">
+        <div>
+          <div className="text-xs text-gray-500 uppercase font-semibold">{SLOT_LABELS[slot]}</div>
+          <div className="text-sm text-gray-600 italic mt-0.5">Empty</div>
+        </div>
+      </div>
+    )
+  }
+
+  const currentLevel = item.enchantmentLevel ?? 0
+  const cost = getEnchantCost(currentLevel)
+  const bonusStat = getEnchantBonusStat(item)
+  const isMaxed = currentLevel >= MAX_ENCHANT_LEVEL
+  const canAfford = cost !== null && gold >= cost
+  const canEnchant = !isMaxed && canAfford && bonusStat !== null
+
+  const displayName = currentLevel > 0
+    ? `${item.name} +${currentLevel}`
+    : item.name
+
+  return (
+    <div className="bg-[#1e1f30] border border-[#3a3c56] p-3 rounded-lg space-y-2">
+      <div className="flex items-start justify-between gap-2">
+        <div>
+          <div className="text-xs text-gray-500 uppercase font-semibold">{SLOT_LABELS[slot]}</div>
+          <div className="text-sm text-white font-medium mt-0.5">
+            {currentLevel > 0 && <span className="mr-1 text-yellow-400">✨</span>}
+            {displayName}
+          </div>
+          {bonusStat && (
+            <div className="text-xs text-indigo-300 mt-0.5">
+              Boosts: {bonusStat} (currently {item.effects?.[bonusStat] ?? 0})
+            </div>
+          )}
+          {!bonusStat && (
+            <div className="text-xs text-gray-500 mt-0.5 italic">No boostable stat</div>
+          )}
+        </div>
+        <div className="text-right shrink-0">
+          <div className="text-xs text-gray-500">Level</div>
+          <div className="text-sm font-bold text-amber-400">{currentLevel}/{MAX_ENCHANT_LEVEL}</div>
+        </div>
+      </div>
+
+      <button
+        disabled={!canEnchant}
+        onClick={() => onEnchant(slot)}
+        className={`w-full py-1.5 px-3 rounded-md text-sm font-medium transition-colors ${
+          isMaxed
+            ? 'bg-[#2a2b3f] text-amber-600 cursor-not-allowed border border-amber-800/40'
+            : canEnchant
+            ? 'bg-indigo-600 hover:bg-indigo-700 text-white cursor-pointer'
+            : 'bg-[#2a2b3f] text-gray-600 cursor-not-allowed border border-[#3a3c56]'
+        }`}
+      >
+        {isMaxed
+          ? 'Max Level'
+          : bonusStat === null
+          ? 'No Stat to Boost'
+          : cost !== null
+          ? `Enchant — ${cost}g`
+          : 'Enchant'}
+      </button>
+    </div>
+  )
+}
+
+export function EnchantingPanel() {
+  const [feedbackMessage, setFeedbackMessage] = useState<string | null>(null)
+  const [feedbackSuccess, setFeedbackSuccess] = useState(false)
+
+  const character = useGameStore(s =>
+    s.gameState.characters.find(c => c.id === s.gameState.selectedCharacterId)
+  )
+  const enchantItemAction = useGameStore(s => s.enchantItem)
+
+  if (!character) {
+    return (
+      <div>
+        <h3 className="text-lg font-semibold text-white mb-1">Enchanting</h3>
+        <p className="text-gray-400 text-sm">No character selected.</p>
+      </div>
+    )
+  }
+
+  const { equipment, gold } = character
+
+  const handleEnchant = (slot: EquipSlot) => {
+    const result = enchantItemAction(slot)
+    if (result) {
+      setFeedbackSuccess(result.success)
+      setFeedbackMessage(result.message)
+      setTimeout(() => setFeedbackMessage(null), 3000)
+    }
+  }
+
+  return (
+    <div className="w-full">
+      <div className="mb-3">
+        <h3 className="text-lg font-semibold text-white">✨ Enchanting</h3>
+        <p className="text-xs text-gray-500">Spend gold to boost equipped item stats</p>
+      </div>
+
+      {feedbackMessage && (
+        <div
+          className={`mb-3 p-2 rounded-md text-sm animate-pulse border ${
+            feedbackSuccess
+              ? 'bg-green-900/50 border-green-700 text-green-300'
+              : 'bg-red-900/50 border-red-700 text-red-300'
+          }`}
+        >
+          {feedbackMessage}
+        </div>
+      )}
+
+      <div className="space-y-2">
+        {(['weapon', 'armor', 'accessory'] as EquipSlot[]).map(slot => (
+          <EnchantSlotCard
+            key={slot}
+            slot={slot}
+            item={(equipment ?? {})[slot] ?? null}
+            gold={gold}
+            onEnchant={handleEnchant}
+          />
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src/app/tap-tap-adventure/components/GameUI.tsx
+++ b/src/app/tap-tap-adventure/components/GameUI.tsx
@@ -40,6 +40,7 @@ import { MercenaryPanel } from './MercenaryPanel'
 import { FactionPanel } from './FactionPanel'
 import AdventureLeaderboard from './AdventureLeaderboard'
 import { CraftingPanel } from './CraftingPanel'
+import { EnchantingPanel } from './EnchantingPanel'
 import { BestiaryPanel } from './BestiaryPanel'
 import { DailyChallengesPanel } from './DailyChallengesPanel'
 import { useOnboarding, HintKey } from '@/app/tap-tap-adventure/hooks/useOnboarding'
@@ -100,7 +101,7 @@ function getTravelButtonMessage({ isLoading, distance }: { isLoading: boolean; d
   if (distance === 0) return 'Start Your Adventure'
   return 'Continue Travelling'
 }
-type MobilePanel = 'equipment' | 'inventory' | 'quest' | 'map' | 'settings' | 'base' | 'party' | 'factions' | 'leaderboard' | 'crafting' | 'bestiary' | null
+type MobilePanel = 'equipment' | 'inventory' | 'quest' | 'map' | 'settings' | 'base' | 'party' | 'factions' | 'leaderboard' | 'crafting' | 'enchant' | 'bestiary' | null
 
 interface GameUIProps {
   onOpenStatus?: () => void
@@ -540,6 +541,9 @@ export default function GameUI({ onOpenStatus }: GameUIProps) {
               <CraftingPanel />
             </div>
             <div className="border-t border-[#3a3c56] pt-4">
+              <EnchantingPanel />
+            </div>
+            <div className="border-t border-[#3a3c56] pt-4">
               <SettingsPanel />
             </div>
           </div>
@@ -558,7 +562,7 @@ export default function GameUI({ onOpenStatus }: GameUIProps) {
           >
             <div className="flex justify-between items-center mb-2">
               <h3 className="text-sm font-semibold text-slate-300 uppercase">
-                {mobilePanel === 'equipment' ? 'Equipment' : mobilePanel === 'inventory' ? 'Inventory' : mobilePanel === 'map' ? 'Map' : mobilePanel === 'settings' ? 'Settings' : mobilePanel === 'base' ? 'Camp' : mobilePanel === 'party' ? 'Party' : mobilePanel === 'factions' ? 'Factions' : mobilePanel === 'leaderboard' ? 'Leaderboard' : mobilePanel === 'crafting' ? 'Crafting' : mobilePanel === 'bestiary' ? 'Bestiary' : 'Quest'}
+                {mobilePanel === 'equipment' ? 'Equipment' : mobilePanel === 'inventory' ? 'Inventory' : mobilePanel === 'map' ? 'Map' : mobilePanel === 'settings' ? 'Settings' : mobilePanel === 'base' ? 'Camp' : mobilePanel === 'party' ? 'Party' : mobilePanel === 'factions' ? 'Factions' : mobilePanel === 'leaderboard' ? 'Leaderboard' : mobilePanel === 'crafting' ? 'Crafting' : mobilePanel === 'enchant' ? 'Enchanting' : mobilePanel === 'bestiary' ? 'Bestiary' : 'Quest'}
               </h3>
               <button
                 className="text-slate-400 hover:text-white text-sm px-2 py-1"
@@ -597,6 +601,7 @@ export default function GameUI({ onOpenStatus }: GameUIProps) {
               <AdventureLeaderboard onBack={() => setMobilePanel(null)} />
             )}
             {mobilePanel === 'crafting' && <CraftingPanel />}
+            {mobilePanel === 'enchant' && <EnchantingPanel />}
             {mobilePanel === 'bestiary' && character && <BestiaryPanel bestiary={character.bestiary ?? []} />}
           </div>
         </div>
@@ -608,6 +613,7 @@ export default function GameUI({ onOpenStatus }: GameUIProps) {
           { id: 'equipment' as MobilePanel, label: 'Equip', icon: '\u2694' },
           { id: 'inventory' as MobilePanel, label: 'Items', icon: '\uD83C\uDF92' },
           { id: 'crafting' as MobilePanel, label: 'Craft', icon: '\u2692' },
+          { id: 'enchant' as MobilePanel, label: 'Enchant', icon: '\u2728' },
           { id: 'quest' as MobilePanel, label: 'Quest', icon: '\uD83D\uDCDC' },
           { id: 'map' as MobilePanel, label: 'Map', icon: '\uD83D\uDDFA' },
           { id: 'base' as MobilePanel, label: 'Camp', icon: '\uD83C\uDFD5' },

--- a/src/app/tap-tap-adventure/config/enchanting.ts
+++ b/src/app/tap-tap-adventure/config/enchanting.ts
@@ -1,0 +1,30 @@
+import type { Item } from '@/app/tap-tap-adventure/models/item'
+
+export const ENCHANT_COSTS = [50, 100, 175, 275, 400] // cost for levels 1-5
+export const MAX_ENCHANT_LEVEL = 5
+
+export function getEnchantCost(currentLevel: number): number | null {
+  if (currentLevel >= MAX_ENCHANT_LEVEL) return null
+  return ENCHANT_COSTS[currentLevel] ?? null
+}
+
+/**
+ * Returns the stat key with the highest value in item.effects, or null if no
+ * numeric stat effects exist. Only considers strength, intelligence, and luck.
+ */
+export function getEnchantBonusStat(item: Item): 'strength' | 'intelligence' | 'luck' | null {
+  const effects = item.effects
+  if (!effects) return null
+
+  const all: Array<{ stat: 'strength' | 'intelligence' | 'luck'; value: number }> = [
+    { stat: 'strength', value: effects.strength ?? 0 },
+    { stat: 'intelligence', value: effects.intelligence ?? 0 },
+    { stat: 'luck', value: effects.luck ?? 0 },
+  ]
+  const candidates = all.filter(c => c.value > 0)
+
+  if (candidates.length === 0) return null
+
+  candidates.sort((a, b) => b.value - a.value)
+  return candidates[0].stat
+}

--- a/src/app/tap-tap-adventure/hooks/useGameStore.ts
+++ b/src/app/tap-tap-adventure/hooks/useGameStore.ts
@@ -49,6 +49,7 @@ import { FACTIONS, FactionId } from '@/app/tap-tap-adventure/config/factions'
 import { rollWeather, WEATHER_CHANGE_INTERVAL } from '@/app/tap-tap-adventure/config/weather'
 import { CRAFTING_RECIPES } from '@/app/tap-tap-adventure/config/craftingRecipes'
 import { canCraft, applyCraft } from '@/app/tap-tap-adventure/lib/craftingEngine'
+import { getEnchantCost, getEnchantBonusStat, MAX_ENCHANT_LEVEL } from '@/app/tap-tap-adventure/config/enchanting'
 
 const defaultCharacter: FantasyCharacter = {
   id: '',
@@ -130,6 +131,7 @@ export interface GameStore {
   clearRunSummary: () => void
   purchaseFactionGear: (factionId: FactionId, gearId: string) => boolean
   craftItem: (recipeId: string) => { message: string; success: boolean } | null
+  enchantItem: (slot: 'weapon' | 'armor' | 'accessory') => { message: string; success: boolean } | null
   updateDailyChallengeProgress: (type: DailyChallengeType, amount: number) => void
   claimDailyChallengeBonus: () => { gold: number; reputation: number } | null
 }
@@ -1051,6 +1053,69 @@ export const useGameStore = create<GameStore>()(
         )
 
         return { message: `Crafted ${recipe.result.name}!`, success: true }
+      },
+      enchantItem: (slot: 'weapon' | 'armor' | 'accessory') => {
+        const selectedCharacter = get().getSelectedCharacter()
+        if (!selectedCharacter) return null
+
+        const equipment = selectedCharacter.equipment ?? { weapon: null, armor: null, accessory: null }
+        const item = equipment[slot]
+        if (!item) return { message: 'No item equipped in that slot.', success: false }
+
+        const currentLevel = item.enchantmentLevel ?? 0
+        if (currentLevel >= MAX_ENCHANT_LEVEL) {
+          return { message: `${item.name} is already at max enchantment level!`, success: false }
+        }
+
+        const cost = getEnchantCost(currentLevel)
+        if (cost === null) return { message: 'Cannot enchant further.', success: false }
+        if (selectedCharacter.gold < cost) {
+          return { message: `Not enough gold! Need ${cost}g.`, success: false }
+        }
+
+        const bonusStat = getEnchantBonusStat(item)
+        if (!bonusStat) {
+          return { message: `${item.name} has no stat to boost.`, success: false }
+        }
+
+        const newLevel = currentLevel + 1
+        const enchantedItem: Item = {
+          ...item,
+          enchantmentLevel: newLevel,
+          effects: {
+            ...item.effects,
+            [bonusStat]: (item.effects?.[bonusStat] ?? 0) + 1,
+          },
+        }
+
+        set(
+          produce((state: GameStore) => {
+            const charIndex = state.gameState.characters.findIndex(
+              char => char.id === selectedCharacter.id
+            )
+            if (charIndex === -1) return
+            const char = state.gameState.characters[charIndex]
+            // Deduct gold
+            char.gold -= cost
+            // Update equipped item
+            const currentEquipment = char.equipment ?? { weapon: null, armor: null, accessory: null }
+            char.equipment = {
+              weapon: currentEquipment.weapon ?? null,
+              armor: currentEquipment.armor ?? null,
+              accessory: currentEquipment.accessory ?? null,
+              [slot]: enchantedItem,
+            }
+            // Update the same item in inventory (if present by id)
+            char.inventory = char.inventory.map(invItem =>
+              invItem.id === item.id ? enchantedItem : invItem
+            )
+          })
+        )
+
+        return {
+          message: `${enchantedItem.name} +${newLevel} enchanted! (+1 ${bonusStat})`,
+          success: true,
+        }
       },
       updateDailyChallengeProgress: (type: DailyChallengeType, amount: number) => {
         set(

--- a/src/app/tap-tap-adventure/models/item.ts
+++ b/src/app/tap-tap-adventure/models/item.ts
@@ -26,6 +26,7 @@ export const ItemSchema = z.object({
   price: z.number().optional(),
   spell: SpellSchema.optional(),
   isHeirloom: z.boolean().optional(),
+  enchantmentLevel: z.number().optional(),
 })
 
 export type Item = z.infer<typeof ItemSchema>


### PR DESCRIPTION
## Summary

Closes #227

Adds an enchanting system where players spend gold to upgrade equipped items, boosting their primary stat.

**Mechanics:**
- Enchant any equipped weapon, armor, or accessory
- Each level adds +1 to the item's highest stat (strength, intelligence, or luck)
- Max 5 enchantment levels per item
- Escalating gold cost: 50 → 100 → 175 → 275 → 400g

**Visual:**
- Enchanted items show `✨ Item Name +3` styling
- EnchantingPanel shows all 3 equipment slots with current level, stat being boosted, cost, and Enchant button

**Implementation:**
- `enchanting.ts` config with cost table and stat detection
- `EnchantingPanel.tsx` with slot cards and enchant buttons
- `enchantItem(slot)` store action updates both equipment and inventory
- No combat engine changes needed — equipment effects auto-apply at combat start

## Test plan

- [ ] Equip a weapon → EnchantingPanel shows it with "Enchant (50g)" button
- [ ] Click Enchant → gold deducted, item shows "+1", stat increased
- [ ] Enchant again → cost is 100g, item shows "+2"
- [ ] Reach level 5 → button shows "Max Level"
- [ ] Insufficient gold → button disabled
- [ ] No item in slot → shows "Empty" placeholder
- [ ] Item with no boostable stat → "No stat to boost" message
- [ ] Enchanted item effects apply in next combat
- [ ] Mobile Enchant tab opens panel
- [ ] TypeScript compiles with no new errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)