### PR TITLE
feat: NPC dialogue system with LLM-generated conversations

### DIFF
--- a/src/app/api/v1/tap-tap-adventure/npc/dialogue/route.ts
+++ b/src/app/api/v1/tap-tap-adventure/npc/dialogue/route.ts
@@ -1,0 +1,96 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { OpenAI } from 'openai'
+import { z } from 'zod'
+
+import { getNPCById } from '@/app/tap-tap-adventure/config/npcs'
+import { getRegion } from '@/app/tap-tap-adventure/config/regions'
+
+const DialogueRequestSchema = z.object({
+  npcId: z.string(),
+  characterName: z.string(),
+  characterClass: z.string(),
+  characterLevel: z.number(),
+  reputation: z.number(),
+  region: z.string(),
+  message: z.string().optional(),
+  conversationHistory: z.array(z.object({
+    role: z.enum(['user', 'assistant']),
+    content: z.string(),
+  })).optional(),
+})
+
+function getOpenAI() {
+  return new OpenAI({ apiKey: process.env.OPENAI_API_KEY })
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    const body = await req.json()
+    const parseResult = DialogueRequestSchema.safeParse(body)
+    if (!parseResult.success) {
+      return NextResponse.json(
+        { error: 'Invalid request', details: parseResult.error },
+        { status: 400 }
+      )
+    }
+
+    const { npcId, characterName, characterClass, characterLevel, reputation, region, message, conversationHistory } = parseResult.data
+
+    const npc = getNPCById(npcId)
+    if (!npc) {
+      return NextResponse.json({ error: 'NPC not found' }, { status: 404 })
+    }
+
+    const regionData = getRegion(region)
+    const regionName = regionData?.name ?? region
+
+    const systemPrompt = `You are ${npc.name}, ${npc.role} in ${regionName}. Personality: ${npc.personality}. Respond in character. Keep responses under 3 sentences. Occasionally offer a small reward (a gold tip, a reputation boost, or a useful hint about the area). End with a natural conversation hook or question. If you choose to offer a reward, include a JSON block at the very end of your response in this exact format: [REWARD:{"gold":N}] or [REWARD:{"reputation":N}] or [REWARD:{"gold":N,"reputation":N}] where N is a small number (gold: 5-25, reputation: 1-5). Only offer rewards occasionally, not every message.`
+
+    const characterContext = `The adventurer ${characterName} (Level ${characterLevel} ${characterClass}, Reputation: ${reputation}) approaches.`
+
+    const userMessage = message
+      ? `${characterContext}\n\nPlayer says: "${message}"`
+      : `${characterContext}\n\nThe adventurer approaches you for the first time.`
+
+    const historyMessages: { role: 'user' | 'assistant'; content: string }[] = conversationHistory ?? []
+
+    try {
+      const response = await getOpenAI().chat.completions.create({
+        model: 'gpt-4o',
+        messages: [
+          { role: 'system', content: systemPrompt },
+          ...historyMessages,
+          { role: 'user', content: userMessage },
+        ],
+        temperature: 0.85,
+        max_tokens: 200,
+      })
+
+      const raw = response.choices[0]?.message?.content?.trim() ?? npc.greeting
+
+      // Parse optional reward block
+      const rewardMatch = raw.match(/\[REWARD:(\{[^}]+\})\]/)
+      let reward: { gold?: number; reputation?: number } | undefined
+      let dialogue = raw
+
+      if (rewardMatch) {
+        try {
+          reward = JSON.parse(rewardMatch[1]) as { gold?: number; reputation?: number }
+          // Remove the reward block from dialogue text
+          dialogue = raw.replace(/\s*\[REWARD:[^\]]+\]/, '').trim()
+        } catch {
+          // Ignore malformed reward block
+          dialogue = raw.replace(/\s*\[REWARD:[^\]]+\]/, '').trim()
+        }
+      }
+
+      return NextResponse.json({ dialogue, reward })
+    } catch (err) {
+      console.error('NPC dialogue LLM call failed', err)
+      return NextResponse.json({ dialogue: npc.greeting })
+    }
+  } catch (err) {
+    console.error('Error in NPC dialogue route', err)
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/src/app/tap-tap-adventure/components/GameUI.tsx
+++ b/src/app/tap-tap-adventure/components/GameUI.tsx
@@ -43,6 +43,8 @@ import { CraftingPanel } from './CraftingPanel'
 import { EnchantingPanel } from './EnchantingPanel'
 import { BestiaryPanel } from './BestiaryPanel'
 import { DailyChallengesPanel } from './DailyChallengesPanel'
+import { NPCDialoguePanel } from './NPCDialoguePanel'
+import { getNPCsForRegion } from '@/app/tap-tap-adventure/config/npcs'
 import { useOnboarding, HintKey } from '@/app/tap-tap-adventure/hooks/useOnboarding'
 
 const DIFFICULTY_STYLES: Record<RegionDifficulty, { label: string; color: string }> = {
@@ -101,7 +103,7 @@ function getTravelButtonMessage({ isLoading, distance }: { isLoading: boolean; d
   if (distance === 0) return 'Start Your Adventure'
   return 'Continue Travelling'
 }
-type MobilePanel = 'equipment' | 'inventory' | 'quest' | 'map' | 'settings' | 'base' | 'party' | 'factions' | 'leaderboard' | 'crafting' | 'enchant' | 'bestiary' | null
+type MobilePanel = 'equipment' | 'inventory' | 'quest' | 'map' | 'settings' | 'base' | 'party' | 'factions' | 'leaderboard' | 'crafting' | 'enchant' | 'bestiary' | 'npc' | null
 
 interface GameUIProps {
   onOpenStatus?: () => void
@@ -119,12 +121,14 @@ export default function GameUI({ onOpenStatus }: GameUIProps) {
     updateAchievements,
     applyAchievementRewards,
     claimDailyReward,
+    recordNPCEncounter,
   } = useGameStore()
 
   const [newlyCompletedIds, setNewlyCompletedIds] = useState<string[]>([])
   const [showDailyReward, setShowDailyReward] = useState(false)
   const [mobilePanel, setMobilePanel] = useState<MobilePanel>(null)
   const [showKeyboardHelp, setShowKeyboardHelp] = useState(false)
+  const [showNPCPanel, setShowNPCPanel] = useState(false)
 
   // Check for daily reward on mount
   useEffect(() => {
@@ -468,6 +472,44 @@ export default function GameUI({ onOpenStatus }: GameUIProps) {
                     </div>
                   )
                 })()}
+                {/* NPC button and panel */}
+                {(() => {
+                  const regionNPCs = getNPCsForRegion(character?.currentRegion ?? 'green_meadows')
+                  if (regionNPCs.length === 0) return null
+                  const npc = regionNPCs[0]
+                  const encounters = character?.npcEncounters ?? {}
+                  const timesSpoken = encounters[npc.id]?.timesSpoken ?? 0
+                  return (
+                    <div>
+                      {showNPCPanel ? (
+                        <NPCDialoguePanel
+                          npc={npc}
+                          characterName={character?.name ?? 'Adventurer'}
+                          characterClass={character?.class ?? 'Unknown'}
+                          characterLevel={character?.level ?? 1}
+                          reputation={character?.reputation ?? 0}
+                          region={character?.currentRegion ?? 'green_meadows'}
+                          timesSpoken={timesSpoken}
+                          onReward={(reward) => {
+                            recordNPCEncounter(npc.id, reward)
+                          }}
+                          onClose={() => {
+                            setShowNPCPanel(false)
+                          }}
+                        />
+                      ) : (
+                        <button
+                          className="w-full text-left text-xs bg-[#1e1f30] border border-[#3a3c56] hover:border-indigo-700/50 rounded-lg px-3 py-2 text-slate-300 transition-colors"
+                          onClick={() => setShowNPCPanel(true)}
+                        >
+                          <span className="mr-1.5">{npc.icon}</span>
+                          <span className="font-semibold">{npc.name}</span>
+                          <span className="text-slate-500 ml-1">is nearby &mdash; Talk?</span>
+                        </button>
+                      )}
+                    </div>
+                  )
+                })()}
                 <Button
                   className={`w-full border text-white font-bold text-xl sm:text-2xl py-8 sm:py-10 rounded-xl transition-all duration-300 select-none ${
                     isAutoWalking
@@ -562,7 +604,7 @@ export default function GameUI({ onOpenStatus }: GameUIProps) {
           >
             <div className="flex justify-between items-center mb-2">
               <h3 className="text-sm font-semibold text-slate-300 uppercase">
-                {mobilePanel === 'equipment' ? 'Equipment' : mobilePanel === 'inventory' ? 'Inventory' : mobilePanel === 'map' ? 'Map' : mobilePanel === 'settings' ? 'Settings' : mobilePanel === 'base' ? 'Camp' : mobilePanel === 'party' ? 'Party' : mobilePanel === 'factions' ? 'Factions' : mobilePanel === 'leaderboard' ? 'Leaderboard' : mobilePanel === 'crafting' ? 'Crafting' : mobilePanel === 'enchant' ? 'Enchanting' : mobilePanel === 'bestiary' ? 'Bestiary' : 'Quest'}
+                {mobilePanel === 'equipment' ? 'Equipment' : mobilePanel === 'inventory' ? 'Inventory' : mobilePanel === 'map' ? 'Map' : mobilePanel === 'settings' ? 'Settings' : mobilePanel === 'base' ? 'Camp' : mobilePanel === 'party' ? 'Party' : mobilePanel === 'factions' ? 'Factions' : mobilePanel === 'leaderboard' ? 'Leaderboard' : mobilePanel === 'crafting' ? 'Crafting' : mobilePanel === 'enchant' ? 'Enchanting' : mobilePanel === 'bestiary' ? 'Bestiary' : mobilePanel === 'npc' ? 'NPC' : 'Quest'}
               </h3>
               <button
                 className="text-slate-400 hover:text-white text-sm px-2 py-1"
@@ -603,6 +645,30 @@ export default function GameUI({ onOpenStatus }: GameUIProps) {
             {mobilePanel === 'crafting' && <CraftingPanel />}
             {mobilePanel === 'enchant' && <EnchantingPanel />}
             {mobilePanel === 'bestiary' && character && <BestiaryPanel bestiary={character.bestiary ?? []} />}
+            {mobilePanel === 'npc' && character && (() => {
+              const regionNPCs = getNPCsForRegion(character.currentRegion ?? 'green_meadows')
+              if (regionNPCs.length === 0) return <p className="text-sm text-slate-400">No NPCs in this region.</p>
+              const npc = regionNPCs[0]
+              const encounters = character.npcEncounters ?? {}
+              const timesSpoken = encounters[npc.id]?.timesSpoken ?? 0
+              return (
+                <NPCDialoguePanel
+                  npc={npc}
+                  characterName={character.name}
+                  characterClass={character.class}
+                  characterLevel={character.level}
+                  reputation={character.reputation}
+                  region={character.currentRegion ?? 'green_meadows'}
+                  timesSpoken={timesSpoken}
+                  onReward={(reward) => {
+                    recordNPCEncounter(npc.id, reward)
+                  }}
+                  onClose={() => {
+                    setMobilePanel(null)
+                  }}
+                />
+              )
+            })()}
           </div>
         </div>
       )}
@@ -621,6 +687,7 @@ export default function GameUI({ onOpenStatus }: GameUIProps) {
           { id: 'factions' as MobilePanel, label: 'Factions', icon: '\uD83C\uDFF0' },
           { id: 'leaderboard' as MobilePanel, label: 'Ranks', icon: '\uD83C\uDFC6' },
           { id: 'bestiary' as MobilePanel, label: 'Bestiary', icon: '\uD83D\uDC09' },
+          { id: 'npc' as MobilePanel, label: 'NPCs', icon: '\uD83D\uDDE3\uFE0F' },
           { id: 'settings' as MobilePanel, label: 'Settings', icon: '\u2699' },
         ]).map(tab => (
           <button

--- a/src/app/tap-tap-adventure/components/NPCDialoguePanel.tsx
+++ b/src/app/tap-tap-adventure/components/NPCDialoguePanel.tsx
@@ -1,0 +1,156 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { LoaderCircle } from 'lucide-react'
+import { Button } from '@/app/tap-tap-adventure/components/ui/button'
+import { GameNPC } from '@/app/tap-tap-adventure/config/npcs'
+import { useNPCDialogue } from '@/app/tap-tap-adventure/hooks/useNPCDialogue'
+
+interface NPCDialoguePanelProps {
+  npc: GameNPC
+  characterName: string
+  characterClass: string
+  characterLevel: number
+  reputation: number
+  region: string
+  timesSpoken: number
+  onReward?: (reward: { gold?: number; reputation?: number }) => void
+  onClose: () => void
+}
+
+function getDispositionLabel(timesSpoken: number): { label: string; color: string } {
+  if (timesSpoken === 0) return { label: 'Stranger', color: 'text-slate-400' }
+  if (timesSpoken < 3) return { label: 'Acquaintance', color: 'text-blue-400' }
+  if (timesSpoken < 7) return { label: 'Friendly', color: 'text-green-400' }
+  return { label: 'Trusted Friend', color: 'text-amber-400' }
+}
+
+export function NPCDialoguePanel({
+  npc,
+  characterName,
+  characterClass,
+  characterLevel,
+  reputation,
+  region,
+  timesSpoken,
+  onReward,
+  onClose,
+}: NPCDialoguePanelProps) {
+  const { currentDialogue, isLoading, fetchDialogue } = useNPCDialogue()
+  const [rewardMessage, setRewardMessage] = useState<string | null>(null)
+  const [hasOpened, setHasOpened] = useState(false)
+
+  const disposition = getDispositionLabel(timesSpoken)
+
+  const startDialogue = async () => {
+    const result = await fetchDialogue({
+      npc,
+      characterName,
+      characterClass,
+      characterLevel,
+      reputation,
+      region,
+    })
+    // Always record the encounter (increments timesSpoken, applies optional reward)
+    if (onReward) {
+      onReward(result?.reward ?? {})
+    }
+    if (result?.reward) {
+      const parts: string[] = []
+      if (result.reward.gold) parts.push(`+${result.reward.gold} gold`)
+      if (result.reward.reputation) parts.push(`+${result.reward.reputation} reputation`)
+      if (parts.length > 0) setRewardMessage(parts.join(', '))
+    }
+  }
+
+  // Auto-fetch dialogue on first open
+  useEffect(() => {
+    if (!hasOpened) {
+      setHasOpened(true)
+      startDialogue()
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  const handleTalkAgain = async () => {
+    setRewardMessage(null)
+    const result = await fetchDialogue({
+      npc,
+      characterName,
+      characterClass,
+      characterLevel,
+      reputation,
+      region,
+    })
+    // Record the encounter each time the player talks
+    if (onReward) {
+      onReward(result?.reward ?? {})
+    }
+    if (result?.reward) {
+      const parts: string[] = []
+      if (result.reward.gold) parts.push(`+${result.reward.gold} gold`)
+      if (result.reward.reputation) parts.push(`+${result.reward.reputation} reputation`)
+      if (parts.length > 0) setRewardMessage(parts.join(', '))
+    }
+  }
+
+  return (
+    <div className="bg-[#1e1f30] border border-[#3a3c56] rounded-lg p-4 space-y-3">
+      {/* NPC Header */}
+      <div className="flex items-start justify-between gap-2">
+        <div className="flex items-center gap-2">
+          <span className="text-2xl" aria-hidden="true">{npc.icon}</span>
+          <div>
+            <div className="font-bold text-white text-sm">{npc.name}</div>
+            <div className="text-xs text-slate-400">{npc.role}</div>
+          </div>
+        </div>
+        <div className="flex items-center gap-2">
+          <span className={`text-[10px] font-semibold uppercase tracking-wide ${disposition.color}`}>
+            {disposition.label}
+          </span>
+          <button
+            className="text-slate-400 hover:text-white text-xs px-2 py-1 border border-[#3a3c56] rounded hover:border-slate-500 transition-colors"
+            onClick={onClose}
+          >
+            Close
+          </button>
+        </div>
+      </div>
+
+      {/* Dialogue area */}
+      <div className="min-h-[80px] bg-[#161723] border border-[#2a2b3f] rounded p-3">
+        {isLoading ? (
+          <div className="flex items-center gap-2 text-slate-400 text-sm">
+            <LoaderCircle className="animate-spin h-4 w-4" />
+            <span>{npc.name} is speaking...</span>
+          </div>
+        ) : currentDialogue ? (
+          <p className="text-sm text-slate-200 leading-relaxed italic">
+            &ldquo;{currentDialogue.dialogue}&rdquo;
+          </p>
+        ) : (
+          <p className="text-sm text-slate-500 italic">Approach {npc.name} to speak...</p>
+        )}
+      </div>
+
+      {/* Reward notification */}
+      {rewardMessage && (
+        <div className="text-xs text-amber-300 bg-amber-900/20 border border-amber-700/30 rounded px-2 py-1.5">
+          {npc.name} granted you: {rewardMessage}
+        </div>
+      )}
+
+      {/* Actions */}
+      <div className="flex gap-2">
+        <Button
+          className="flex-1 text-sm border border-[#3a3c56] bg-[#2a2b3f] hover:bg-[#3a3c56] text-white py-2 rounded disabled:opacity-60"
+          onClick={handleTalkAgain}
+          disabled={isLoading}
+        >
+          Talk Again
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/src/app/tap-tap-adventure/config/npcs.ts
+++ b/src/app/tap-tap-adventure/config/npcs.ts
@@ -1,0 +1,101 @@
+export interface GameNPC {
+  id: string
+  name: string
+  role: string
+  description: string
+  regionId: string
+  personality: string
+  icon: string
+  greeting: string
+}
+
+export const NPCS: GameNPC[] = [
+  {
+    id: 'elder_maren',
+    name: 'Elder Maren',
+    role: 'Village Elder',
+    description: 'The wise elder of the starting village, keeper of ancient lore and guide to new adventurers.',
+    regionId: 'starting_village',
+    personality: 'Wise, welcoming, and patient. Speaks with warmth and authority. Offers practical advice and tips to adventurers. Uses gentle humor. Values courage and kindness.',
+    icon: '\u{1F9D9}',
+    greeting: 'Ah, a new face! Welcome, traveler. This village has seen many adventurers pass through — may your journey be long and your tales worth telling.',
+  },
+  {
+    id: 'bramble',
+    name: 'Bramble',
+    role: 'Traveling Merchant',
+    description: 'A jovial merchant who roams the Green Meadows, always eager to share gossip and strike deals.',
+    regionId: 'green_meadows',
+    personality: 'Jovial, chatty, and loves gossip. Always looking for a deal. Speaks enthusiastically and uses merchant slang. Has a laugh for every situation. Drops hints about rare goods or local rumors.',
+    icon: '\u{1F9F3}',
+    greeting: "Ha! You look like someone who appreciates a good bargain. Bramble's the name — finest goods this side of the Dark Forest, and tales to boot!",
+  },
+  {
+    id: 'whisper',
+    name: 'Whisper',
+    role: 'Forest Spirit',
+    description: 'An ancient spirit of the Dark Forest, speaking in riddles and half-truths.',
+    regionId: 'dark_forest',
+    personality: 'Mysterious, cryptic, and speaks in riddles and metaphors. Ancient and otherworldly. Reveals hidden truths obliquely. Neither fully good nor evil. Knows secrets of the forest.',
+    icon: '\u{1F9DA}',
+    greeting: 'The trees... they remember your footsteps. Every path chosen is a path not taken. What brings the warmth of flesh to where shadows breathe?',
+  },
+  {
+    id: 'grimjaw',
+    name: 'Grimjaw',
+    role: 'Grizzled Veteran',
+    description: 'A battle-scarred warrior who survived the Bone Wastes and now broods among the remains.',
+    regionId: 'bone_wastes',
+    personality: 'Gruff, direct, and battle-hardened. Respects strength and survival above all. Short sentences. Dismissive of weakness. Warms up slightly to those who prove themselves. Knows tactical battle wisdom.',
+    icon: '\u{1F9B4}',
+    greeting: "You want to talk? Fine. Make it quick. Every minute standing still is a minute something out there gains on you.",
+  },
+  {
+    id: 'crystalline',
+    name: 'Crystalline',
+    role: 'Crystal Golem',
+    description: 'An ancient construct of living crystal, guardian of the Crystal Caves and keeper of deep lore.',
+    regionId: 'crystal_caves',
+    personality: 'Ancient, formal, and precise. Speaks in measured, deliberate tones. Deeply knowledgeable about history and arcane lore. Emotionless but not unkind. Values accuracy and truth above all.',
+    icon: '\u{1F48E}',
+    greeting: 'Designation: traveler. Purpose: unknown. This unit has observed 4,712 adventurers traverse these caverns. State your query and I will consult my archives.',
+  },
+  {
+    id: 'pyraxis',
+    name: 'Pyraxis',
+    role: 'Fire Mage',
+    description: 'A passionate scholar of flame magic who studies the Scorched Wastes with fervent dedication.',
+    regionId: 'scorched_wastes',
+    personality: 'Passionate, hot-tempered, and scholarly. Enthusiastic about fire magic and ancient lore. Gets excited easily and speaks in bursts. Brilliant but impatient with ignorance. Generous with knowledge when impressed.',
+    icon: '\u{1F525}',
+    greeting: "You dare venture here? EXCELLENT! The Wastes are magnificent — most flee screaming. Tell me, do you feel it? The ambient heat reading is up twelve degrees today!",
+  },
+  {
+    id: 'umbra',
+    name: 'Umbra',
+    role: 'Shadow Broker',
+    description: 'A mysterious dealer in secrets who operates from the Shadow Realm, trading information for information.',
+    regionId: 'shadow_realm',
+    personality: 'Sly, transactional, and deals in secrets. Everything is a negotiation. Smooth and calculating. Amused by mortals but not contemptuous. Will share valuable secrets for the right price or information.',
+    icon: '\u{1F578}\u{FE0F}',
+    greeting: "Oh my... a living soul in my realm. How refreshing. I deal in secrets, traveler — and you have the look of someone who wants one. Shall we... negotiate?",
+  },
+  {
+    id: 'seraphiel',
+    name: 'Seraphiel',
+    role: 'Angelic Guardian',
+    description: 'A divine guardian of the Celestial Throne who tests the worthiness of all who approach.',
+    regionId: 'celestial_throne',
+    personality: 'Noble, dignified, and tests worthiness. Speaks with divine authority. Fair but demanding. Rewards genuine virtue and punishes arrogance. Genuinely cares for mortal souls despite stern demeanor.',
+    icon: '\u{1F47C}',
+    greeting: 'Halt, mortal. Few souls reach the Celestial Throne. Fewer still are worthy of what lies within. Speak — what virtue do you carry that justifies your presence here?',
+  },
+]
+
+export function getNPCsForRegion(regionId: string): GameNPC[] {
+  return NPCS.filter(npc => npc.regionId === regionId)
+}
+
+export function getNPCById(id: string): GameNPC | undefined {
+  return NPCS.find(npc => npc.id === id)
+}

--- a/src/app/tap-tap-adventure/hooks/useGameStore.ts
+++ b/src/app/tap-tap-adventure/hooks/useGameStore.ts
@@ -87,6 +87,7 @@ const defaultCharacter: FantasyCharacter = {
   mainQuest: createMainQuest(),
   factionReputations: {},
   bestiary: [],
+  npcEncounters: {},
 }
 
 export interface GameStore {
@@ -134,6 +135,7 @@ export interface GameStore {
   enchantItem: (slot: 'weapon' | 'armor' | 'accessory') => { message: string; success: boolean } | null
   updateDailyChallengeProgress: (type: DailyChallengeType, amount: number) => void
   claimDailyChallengeBonus: () => { gold: number; reputation: number } | null
+  recordNPCEncounter: (npcId: string, reward?: { gold?: number; reputation?: number }) => void
 }
 
 export const useGameStore = create<GameStore>()(
@@ -1148,6 +1150,33 @@ export const useGameStore = create<GameStore>()(
           })
         )
         return bonus
+      },
+      recordNPCEncounter: (npcId: string, reward?: { gold?: number; reputation?: number }) => {
+        set(
+          produce((state: GameStore) => {
+            const selectedCharacter = get().getSelectedCharacter()
+            if (!selectedCharacter) return
+            const charIndex = state.gameState.characters.findIndex(c => c.id === selectedCharacter.id)
+            if (charIndex === -1) return
+
+            const encounters = state.gameState.characters[charIndex].npcEncounters ?? {}
+            const existing = encounters[npcId] ?? { timesSpoken: 0, disposition: 0 }
+            encounters[npcId] = {
+              timesSpoken: existing.timesSpoken + 1,
+              disposition: Math.min(100, existing.disposition + 5),
+            }
+            state.gameState.characters[charIndex].npcEncounters = encounters
+
+            if (reward?.gold) {
+              state.gameState.characters[charIndex].gold += reward.gold
+            }
+            if (reward?.reputation) {
+              state.gameState.characters[charIndex].reputation = clampReputation(
+                state.gameState.characters[charIndex].reputation + reward.reputation
+              )
+            }
+          })
+        )
       },
     }),
     {

--- a/src/app/tap-tap-adventure/hooks/useNPCDialogue.ts
+++ b/src/app/tap-tap-adventure/hooks/useNPCDialogue.ts
@@ -1,0 +1,107 @@
+'use client'
+import { useState, useCallback } from 'react'
+
+import { GameNPC } from '@/app/tap-tap-adventure/config/npcs'
+
+interface ConversationMessage {
+  role: 'user' | 'assistant'
+  content: string
+}
+
+interface DialogueState {
+  dialogue: string
+  reward?: { gold?: number; reputation?: number }
+}
+
+interface UseNPCDialogueReturn {
+  currentDialogue: DialogueState | null
+  isLoading: boolean
+  error: string | null
+  conversationHistory: ConversationMessage[]
+  fetchDialogue: (params: {
+    npc: GameNPC
+    characterName: string
+    characterClass: string
+    characterLevel: number
+    reputation: number
+    region: string
+    message?: string
+  }) => Promise<DialogueState | null>
+  reset: () => void
+}
+
+export function useNPCDialogue(): UseNPCDialogueReturn {
+  const [currentDialogue, setCurrentDialogue] = useState<DialogueState | null>(null)
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [conversationHistory, setConversationHistory] = useState<ConversationMessage[]>([])
+
+  const fetchDialogue = useCallback(async (params: {
+    npc: GameNPC
+    characterName: string
+    characterClass: string
+    characterLevel: number
+    reputation: number
+    region: string
+    message?: string
+  }): Promise<DialogueState | null> => {
+    const { npc, characterName, characterClass, characterLevel, reputation, region, message } = params
+    setIsLoading(true)
+    setError(null)
+
+    // Keep only last 3 exchanges (6 messages) for context
+    const recentHistory = conversationHistory.slice(-6)
+
+    try {
+      const res = await fetch('/api/v1/tap-tap-adventure/npc/dialogue', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          npcId: npc.id,
+          characterName,
+          characterClass,
+          characterLevel,
+          reputation,
+          region,
+          message,
+          conversationHistory: recentHistory,
+        }),
+      })
+
+      if (!res.ok) {
+        throw new Error('Failed to fetch NPC dialogue')
+      }
+
+      const data = await res.json() as { dialogue: string; reward?: { gold?: number; reputation?: number } }
+      const result: DialogueState = { dialogue: data.dialogue, reward: data.reward }
+
+      setCurrentDialogue(result)
+
+      // Append to conversation history
+      const newHistory: ConversationMessage[] = [...conversationHistory]
+      if (message) {
+        newHistory.push({ role: 'user', content: message })
+      }
+      newHistory.push({ role: 'assistant', content: data.dialogue })
+      setConversationHistory(newHistory)
+
+      return result
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Unknown error'
+      setError(msg)
+      const fallback: DialogueState = { dialogue: npc.greeting }
+      setCurrentDialogue(fallback)
+      return fallback
+    } finally {
+      setIsLoading(false)
+    }
+  }, [conversationHistory])
+
+  const reset = useCallback(() => {
+    setCurrentDialogue(null)
+    setError(null)
+    setConversationHistory([])
+  }, [])
+
+  return { currentDialogue, isLoading, error, conversationHistory, fetchDialogue, reset }
+}

--- a/src/app/tap-tap-adventure/models/character.ts
+++ b/src/app/tap-tap-adventure/models/character.ts
@@ -65,6 +65,7 @@ export const FantasyCharacterSchema = z.object({
   campState: CampStateSchema.optional(),
   factionReputations: z.record(z.string(), z.number()).optional().default({}),
   bestiary: z.array(BestiaryEntrySchema).optional(),
+  npcEncounters: z.record(z.string(), z.object({ timesSpoken: z.number(), disposition: z.number() })).optional(),
 })
 export type FantasyCharacter = z.infer<typeof FantasyCharacterSchema>
 


### PR DESCRIPTION
## Summary

Closes #228

Adds persistent NPCs across 8 key regions with LLM-generated dialogue. Players can talk to NPCs for context-aware conversations, rewards, and lore.

**8 NPCs:**
| NPC | Region | Role |
|-----|--------|------|
| 🧙 Elder Maren | Starting Village | Village Elder — wise, gives tips |
| 🎪 Bramble | Green Meadows | Traveling Merchant — jovial gossip |
| 🌿 Whisper | Dark Forest | Forest Spirit — mysterious riddles |
| 💀 Grimjaw | Bone Wastes | Grizzled Veteran — respects strength |
| 💎 Crystalline | Crystal Caves | Crystal Golem — ancient lore |
| 🔥 Pyraxis | Scorched Wastes | Fire Mage — passionate scholar |
| 🗡️ Umbra | Shadow Realm | Shadow Broker — deals in secrets |
| 👼 Seraphiel | Celestial Throne | Angelic Guardian — tests worthiness |

**Features:**
- LLM-generated dialogue via gpt-4o with NPC personality and character context
- Conversation history (last 3 exchanges) for continuity
- Disposition tracking: Stranger → Acquaintance → Friendly → Trusted Friend
- Occasional gold/reputation rewards from conversations
- "Talk to NPC" button appears when in an NPC's region
- Fallback to static greeting when LLM is unavailable
- NPCDialoguePanel with Talk Again and reward notifications

## Test plan

- [ ] Visit Starting Village → "Talk to Elder Maren" button appears
- [ ] Click Talk → LLM dialogue loads with NPC personality
- [ ] Click Talk Again → new dialogue, conversation continues contextually
- [ ] Move to Green Meadows → "Talk to Bramble" button appears
- [ ] Move to a region without NPC → no Talk button
- [ ] NPC occasionally gives gold/reputation reward
- [ ] Disposition changes after multiple conversations
- [ ] Mobile NPCs tab opens dialogue panel
- [ ] LLM unavailable → fallback greeting displays
- [ ] TypeScript compiles with no new errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)