### PR TITLE
feat: prompt for display name before trivia, auto-submit to leaderboard

### DIFF
--- a/src/app/trivia/components/NamePrompt.tsx
+++ b/src/app/trivia/components/NamePrompt.tsx
@@ -1,0 +1,81 @@
+'use client'
+
+import { useEffect, useRef, useState } from 'react'
+
+import { Button } from '@/components/ui/button'
+import { Card, CardContent } from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
+
+interface NamePromptProps {
+  onSave: (name: string) => void
+  onSkip?: () => void
+  title?: string
+  description?: string
+  showSkip?: boolean
+  initialName?: string
+}
+
+export function NamePrompt({
+  onSave,
+  onSkip,
+  title = 'Enter a display name',
+  description = 'Your name will appear on the leaderboard',
+  showSkip = true,
+  initialName = '',
+}: NamePromptProps) {
+  const [name, setName] = useState(initialName)
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  useEffect(() => {
+    inputRef.current?.focus()
+  }, [])
+
+  const handleSave = () => {
+    const trimmed = name.trim()
+    if (trimmed.length > 0) {
+      onSave(trimmed)
+    }
+  }
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      handleSave()
+    }
+  }
+
+  return (
+    <Card className="w-full bg-space-dark/80 border-space-grey">
+      <CardContent className="pt-6 flex flex-col gap-4">
+        <div className="text-center">
+          <h3 className="text-lg font-bold text-cream-white">{title}</h3>
+          <p className="text-cream-white/60 text-sm mt-1">{description}</p>
+        </div>
+        <Input
+          ref={inputRef}
+          value={name}
+          onChange={(e) => setName(e.target.value.slice(0, 20))}
+          placeholder="Your display name"
+          className="bg-space-black/50 border-space-grey text-cream-white placeholder:text-cream-white/30"
+          onKeyDown={handleKeyDown}
+          maxLength={20}
+        />
+        <Button
+          variant="space"
+          onClick={handleSave}
+          disabled={name.trim().length === 0}
+          className="w-full"
+        >
+          Save
+        </Button>
+        {showSkip && onSkip && (
+          <button
+            onClick={onSkip}
+            className="text-cream-white/40 text-sm text-center hover:text-cream-white/60 transition-colors"
+          >
+            Skip for now
+          </button>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/src/app/trivia/components/TriviaLanding.tsx
+++ b/src/app/trivia/components/TriviaLanding.tsx
@@ -1,9 +1,11 @@
 'use client'
 
+import { useState } from 'react'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { useTriviaStore } from '../hooks/useTriviaStore'
 import { formatDisplayDate, getDailyCategory, getTodayPST } from '../lib/triviaUtils'
+import { NamePrompt } from './NamePrompt'
 
 export function TriviaLanding({
   onStartGame,
@@ -14,7 +16,9 @@ export function TriviaLanding({
   onViewStats?: () => void
   onViewLeaderboard?: () => void
 }) {
-  const { userData, canPlayToday } = useTriviaStore()
+  const { userData, canPlayToday, setDisplayName, skipName } = useTriviaStore()
+  const [showChangeName, setShowChangeName] = useState(false)
+  const needsNamePrompt = !userData.displayName && !userData.nameSkipped
   const todayStr = getTodayPST()
   const alreadyPlayed = !canPlayToday()
   const category = getDailyCategory(todayStr)
@@ -34,6 +38,30 @@ export function TriviaLanding({
           <span>{category.name}</span>
         </div>
       </div>
+
+      {needsNamePrompt ? (
+        <NamePrompt onSave={setDisplayName} onSkip={skipName} />
+      ) : userData.displayName && !showChangeName ? (
+        <div className="w-full text-center text-cream-white/60 text-sm">
+          Playing as{' '}
+          <span className="text-space-gold font-semibold">{userData.displayName}</span>
+          {' · '}
+          <button
+            onClick={() => setShowChangeName(true)}
+            className="text-space-gold/70 hover:text-space-gold hover:underline underline-offset-4 transition-colors"
+          >
+            change
+          </button>
+        </div>
+      ) : showChangeName ? (
+        <NamePrompt
+          showSkip={false}
+          initialName={userData.displayName ?? ''}
+          title="Change display name"
+          onSave={(name) => { setDisplayName(name); setShowChangeName(false) }}
+          onSkip={() => setShowChangeName(false)}
+        />
+      ) : null}
 
       <Card className="w-full bg-space-dark/80 border-space-grey">
         <CardHeader>

--- a/src/app/trivia/components/TriviaLeaderboard.tsx
+++ b/src/app/trivia/components/TriviaLeaderboard.tsx
@@ -81,14 +81,14 @@ export function TriviaLeaderboard({ onBack }: { onBack: () => void }) {
 
     if (period === 'daily') {
       return data.entries.map((entry: DailyEntry, i: number) => {
-        const isCurrentUser = entry.displayName.toLowerCase().trim() === currentName
+        const isCurrentUser = entry.displayName?.toLowerCase().trim() === currentName
         return (
           <LeaderboardRow
             key={`${entry.displayName}-${i}`}
             rank={i + 1}
-            name={entry.displayName}
-            primary={entry.score.toLocaleString()}
-            secondary={`${entry.correct}/${entry.total} correct`}
+            name={entry.displayName ?? 'Unknown'}
+            primary={(entry.score ?? 0).toLocaleString()}
+            secondary={`${entry.correct ?? 0}/${entry.total ?? 0} correct`}
             isCurrentUser={isCurrentUser}
           />
         )
@@ -97,17 +97,18 @@ export function TriviaLeaderboard({ onBack }: { onBack: () => void }) {
 
     if (period === 'weekly') {
       return data.entries.map((entry: WeeklyEntry, i: number) => {
-        const isCurrentUser = entry.displayName.toLowerCase().trim() === currentName
-        const accuracy = entry.totalQuestions > 0
-          ? Math.round((entry.totalCorrect / entry.totalQuestions) * 100)
+        const isCurrentUser = entry.displayName?.toLowerCase().trim() === currentName
+        const totalQ = entry.totalQuestions ?? 0
+        const accuracy = totalQ > 0
+          ? Math.round(((entry.totalCorrect ?? 0) / totalQ) * 100)
           : 0
         return (
           <LeaderboardRow
             key={`${entry.displayName}-${i}`}
             rank={i + 1}
-            name={entry.displayName}
-            primary={entry.totalScore.toLocaleString()}
-            secondary={`${entry.gamesPlayed} games · ${accuracy}%`}
+            name={entry.displayName ?? 'Unknown'}
+            primary={(entry.totalScore ?? 0).toLocaleString()}
+            secondary={`${entry.gamesPlayed ?? 0} games · ${accuracy}%`}
             isCurrentUser={isCurrentUser}
           />
         )
@@ -116,14 +117,15 @@ export function TriviaLeaderboard({ onBack }: { onBack: () => void }) {
 
     if (period === 'alltime') {
       return data.entries.map((entry: AllTimeEntry, i: number) => {
-        const isCurrentUser = entry.displayName.toLowerCase().trim() === currentName
+        const isCurrentUser = entry.displayName?.toLowerCase().trim() === currentName
+        const wins = entry.weeklyWins ?? 0
         return (
           <LeaderboardRow
             key={`${entry.displayName}-${i}`}
             rank={i + 1}
-            name={entry.displayName}
-            primary={`${entry.weeklyWins} ${entry.weeklyWins === 1 ? 'win' : 'wins'}`}
-            secondary={`${entry.totalScore.toLocaleString()} pts`}
+            name={entry.displayName ?? 'Unknown'}
+            primary={`${wins} ${wins === 1 ? 'win' : 'wins'}`}
+            secondary={`${(entry.totalScore ?? 0).toLocaleString()} pts`}
             isCurrentUser={isCurrentUser}
           />
         )

--- a/src/app/trivia/components/TriviaLeaderboard.tsx
+++ b/src/app/trivia/components/TriviaLeaderboard.tsx
@@ -37,7 +37,7 @@ export function TriviaLeaderboard({ onBack }: { onBack: () => void }) {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const [data, setData] = useState<any>(null)
   const [error, setError] = useState<string | null>(null)
-  const [showNameDialog, setShowNameDialog] = useState(!userData.displayName)
+  const [showNameDialog, setShowNameDialog] = useState(!userData.displayName && !userData.nameSkipped)
   const [nameInput, setNameInput] = useState(userData.displayName ?? '')
 
   const currentName = userData.displayName?.toLowerCase().trim() ?? ''

--- a/src/app/trivia/components/TriviaResults.tsx
+++ b/src/app/trivia/components/TriviaResults.tsx
@@ -1,10 +1,11 @@
 'use client'
 
-import { useState, useEffect } from 'react'
+import { useEffect, useState } from 'react'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent } from '@/components/ui/card'
 import { useTriviaStore } from '../hooks/useTriviaStore'
 import { formatDisplayDate, getDailyCategory, getTodayPST } from '../lib/triviaUtils'
+import { NamePrompt } from './NamePrompt'
 import type { TriviaGameResult } from '../models/trivia'
 
 const MAX_SCORE = 3150
@@ -88,8 +89,28 @@ interface TriviaResultsProps {
 
 export function TriviaResults({ result, onBack, onViewStats, onViewLeaderboard }: TriviaResultsProps) {
   const [copied, setCopied] = useState(false)
-  const { userData } = useTriviaStore()
+  const [namePromptDismissed, setNamePromptDismissed] = useState(false)
+  const { userData, setDisplayName } = useTriviaStore()
+  const [scoreSubmitted, setScoreSubmitted] = useState(!!userData.displayName)
   const countdown = useCountdown()
+
+  useEffect(() => {
+    if (userData.displayName && !scoreSubmitted) {
+      fetch('/api/v1/trivia/submit-score', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          displayName: userData.displayName,
+          date: result.date,
+          score: result.score,
+          correct: result.correct,
+          total: result.total,
+        }),
+      })
+        .then(() => setScoreSubmitted(true))
+        .catch((err) => console.error('Failed to submit score:', err))
+    }
+  }, [userData.displayName, scoreSubmitted, result])
   const scorePercent = Math.round((result.score / MAX_SCORE) * 100)
   const correctPercent = result.total > 0 ? Math.round((result.correct / result.total) * 100) : 0
 
@@ -219,6 +240,24 @@ export function TriviaResults({ result, onBack, onViewStats, onViewLeaderboard }
       >
         {copied ? 'Copied!' : 'Share Score'}
       </Button>
+
+      {!userData.displayName && !namePromptDismissed && (
+        <NamePrompt
+          title="Join the leaderboard?"
+          description="Set a display name to save your score"
+          onSave={(name) => {
+            setDisplayName(name)
+            setNamePromptDismissed(true)
+          }}
+          onSkip={() => setNamePromptDismissed(true)}
+        />
+      )}
+
+      {scoreSubmitted && userData.displayName && (
+        <div className="text-center text-green-400/70 text-sm">
+          Score submitted to leaderboard
+        </div>
+      )}
 
       {/* Countdown to next reset */}
       <div className="text-center text-cream-white/40 text-sm">

--- a/src/app/trivia/hooks/useTriviaStore.ts
+++ b/src/app/trivia/hooks/useTriviaStore.ts
@@ -7,6 +7,7 @@ import { getTodayPST, hasPlayedToday } from '../lib/triviaUtils'
 
 const defaultUserData: TriviaUserData = {
   displayName: null,
+  nameSkipped: false,
   stats: {
     gamesPlayed: 0,
     totalScore: 0,
@@ -24,6 +25,7 @@ interface TriviaStore {
   userData: TriviaUserData
   canPlayToday: () => boolean
   setDisplayName: (name: string) => void
+  skipName: () => void
   recordGame: (result: TriviaGameResult) => void
   resetStats: () => void
 }
@@ -39,7 +41,13 @@ export const useTriviaStore = create<TriviaStore>()(
 
       setDisplayName: (name: string) => {
         set((state) => ({
-          userData: { ...state.userData, displayName: name },
+          userData: { ...state.userData, displayName: name, nameSkipped: false },
+        }))
+      },
+
+      skipName: () => {
+        set((state) => ({
+          userData: { ...state.userData, nameSkipped: true },
         }))
       },
 
@@ -73,7 +81,7 @@ export const useTriviaStore = create<TriviaStore>()(
                 currentStreak: newStreak,
                 bestStreak,
               },
-              history: [...state.userData.history, result],
+              history: state.userData.displayName ? [...state.userData.history, result] : state.userData.history,
             },
           }
         })
@@ -85,7 +93,14 @@ export const useTriviaStore = create<TriviaStore>()(
     }),
     {
       name: 'cometcave-trivia-user',
-      version: 1,
+      version: 2,
+      migrate: (persistedState: unknown, version: number) => {
+        if (version < 2) {
+          const state = persistedState as { userData: TriviaUserData }
+          return { ...state, userData: { ...state.userData, nameSkipped: false } }
+        }
+        return persistedState
+      },
     }
   )
 )

--- a/src/app/trivia/models/trivia.ts
+++ b/src/app/trivia/models/trivia.ts
@@ -25,6 +25,7 @@ export interface TriviaStats {
 
 export interface TriviaUserData {
   displayName: string | null
+  nameSkipped: boolean
   stats: TriviaStats
   history: TriviaGameResult[]
   lastPlayedDate: string | null


### PR DESCRIPTION
## Summary
Closes #237

- Adds a **NamePrompt** inline card component that prompts first-time users for a display name before starting trivia
- Users can **skip** the prompt (respected via `nameSkipped` flag in localStorage)
- Returning users see **"Playing as: {name}"** with a change link on the landing page
- After completing trivia, users who skipped get a **post-game name prompt** on the results page
- Setting a name retroactively **auto-submits the score** to the leaderboard
- Unnamed users' games are **not saved to history** (stats still update, but history stays clean)
- Leaderboard dialog no longer auto-opens for users who skipped the name prompt
- Store migrated from v1 → v2 with `nameSkipped: false` default for existing users

## Files changed
- `models/trivia.ts` — Added `nameSkipped` to `TriviaUserData`
- `hooks/useTriviaStore.ts` — Added `skipName` action, conditional history, v2 migration
- `components/NamePrompt.tsx` — New reusable inline card component
- `components/TriviaLanding.tsx` — Name prompt / "Playing as" display
- `components/TriviaResults.tsx` — Post-game name prompt + retroactive score submission
- `components/TriviaLeaderboard.tsx` — Fixed auto-dialog for skippers

## Test plan
- [ ] New user: sees name prompt on landing, enters name, starts game, score auto-submits
- [ ] New user skips: prompt disappears, plays game, results show post-game name prompt
- [ ] Skipper enters name on results: score retroactively submitted, confirmation shown
- [ ] Returning user with name: sees "Playing as: {name}" with change link
- [ ] Change name flow: click change, enter new name, displays correctly
- [ ] Existing v1 localStorage users: page loads without crash, nameSkipped defaults to false
- [ ] Leaderboard: dialog does not auto-open when nameSkipped is true

🤖 Generated with [Claude Code](https://claude.com/claude-code)