### PR TITLE
feat: interactive region map with click-to-travel and confirmation dialog

### DIFF
--- a/src/app/tap-tap-adventure/components/GameUI.tsx
+++ b/src/app/tap-tap-adventure/components/GameUI.tsx
@@ -3,15 +3,16 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { LoaderCircle } from 'lucide-react'
 import { Button } from '@/app/tap-tap-adventure/components/ui/button'
-import { useGameStore } from '@/app/tap-tap-adventure/hooks/useGameStore'
+import { useGameStore, useGameStateBuilder } from '@/app/tap-tap-adventure/hooks/useGameStore'
 import { useMoveForwardMutation } from '@/app/tap-tap-adventure/hooks/useMoveForwardMutation'
 import { useResolveDecisionMutation } from '@/app/tap-tap-adventure/hooks/useResolveDecisionMutation'
 import { getGenericTravelMessage } from '@/app/tap-tap-adventure/lib/getGenericTravelMessage'
 import { checkAchievements } from '@/app/tap-tap-adventure/lib/achievementTracker'
 import { canClaimDailyReward, getDailyReward } from '@/app/tap-tap-adventure/lib/dailyRewardTracker'
 import { crossedMilestone, SHOP_MILESTONE_INTERVAL, STEPS_PER_DAY, calculateDay } from '@/app/tap-tap-adventure/lib/leveling'
-import { CROSSROADS_INTERVAL, getRegion } from '@/app/tap-tap-adventure/config/regions'
+import { CROSSROADS_INTERVAL, getRegion, REGIONS, canEnterRegion } from '@/app/tap-tap-adventure/config/regions'
 import type { RegionDifficulty } from '@/app/tap-tap-adventure/config/regions'
+import { rollWeather } from '@/app/tap-tap-adventure/config/weather'
 import { flipCoin } from '@/app/utils'
 
 import { SKILLS } from '@/app/tap-tap-adventure/config/skills'
@@ -30,6 +31,7 @@ import { StatAllocationScreen } from './StatAllocationScreen'
 import { ShopUI } from './ShopUI'
 import { StoryFeed } from './StoryFeed'
 import { RegionMap } from './RegionMap'
+import { TravelConfirmDialog } from './TravelConfirmDialog'
 import { CONQUERABLE_REGIONS } from '@/app/tap-tap-adventure/lib/mainQuestManager'
 import { SettingsPanel } from './SettingsPanel'
 import { KeyboardHelp } from './KeyboardHelp'
@@ -132,6 +134,7 @@ export default function GameUI({ onOpenStatus }: GameUIProps) {
   const [newlyCompletedIds, setNewlyCompletedIds] = useState<string[]>([])
   const [showDailyReward, setShowDailyReward] = useState(false)
   const [mobileCategory, setMobileCategory] = useState<MobileCategory>(null)
+  const [travelTarget, setTravelTarget] = useState<string | null>(null)
   const [gearSubTab, setGearSubTab] = useState<GearSubTab>('equipment')
   const [questSubTab, setQuestSubTab] = useState<QuestSubTab>('quests')
   const [socialSubTab, setSocialSubTab] = useState<SocialSubTab>('party')
@@ -151,6 +154,8 @@ export default function GameUI({ onOpenStatus }: GameUIProps) {
   const { mutate: resolveDecisionMutation, isPending: resolveDecisionPending } =
     useResolveDecisionMutation()
 
+  const { addStoryEvent, commit, updateSelectedCharacter } = useGameStateBuilder()
+
   const character = getSelectedCharacter()
 
   const { hasSeenHint, markHintSeen } = useOnboarding(character?.id)
@@ -164,6 +169,39 @@ export default function GameUI({ onOpenStatus }: GameUIProps) {
     if (character.distance === 0 && !hasSeenHint('first-tap')) return 'first-tap'
     return null
   })()
+
+  const handleRegionClick = useCallback((regionId: string) => {
+    const region = REGIONS[regionId]
+    if (!region || !character) return
+    const currentRegion = getRegion(character.currentRegion ?? 'green_meadows')
+    const isConnected = currentRegion.connectedRegions.includes(regionId)
+    const isVisited = (character.visitedRegions ?? []).includes(regionId)
+    if (isConnected && isVisited && canEnterRegion(region, character.level)) {
+      setTravelTarget(regionId)
+    }
+  }, [character])
+
+  const handleTravelConfirm = useCallback(() => {
+    if (!travelTarget || !character) return
+    const destRegion = getRegion(travelTarget)
+    updateSelectedCharacter({
+      currentRegion: travelTarget,
+      currentWeather: rollWeather(travelTarget),
+    })
+    addStoryEvent({
+      id: `map-travel-${Date.now()}`,
+      type: 'region_travel',
+      characterId: character.id,
+      locationId: character.locationId,
+      timestamp: new Date().toISOString(),
+      selectedOptionId: travelTarget,
+      selectedOptionText: `Traveled to ${destRegion.name}`,
+      outcomeDescription: `You set out for ${destRegion.icon} ${destRegion.name} \u2014 ${destRegion.description}`,
+    })
+    commit()
+    setTravelTarget(null)
+    soundEngine.playCrossroads()
+  }, [travelTarget, character, updateSelectedCharacter, addStoryEvent, commit])
 
   const handleResolveDecision = (optionId: string) => {
     resolveDecisionMutation({
@@ -569,6 +607,7 @@ export default function GameUI({ onOpenStatus }: GameUIProps) {
                 characterLevel={character?.level ?? 1}
                 visitedRegions={character?.visitedRegions ?? []}
                 conqueredRegions={character?.visitedRegions?.filter(r => CONQUERABLE_REGIONS.includes(r)) ?? []}
+                onRegionClick={handleRegionClick}
               />
             </div>
             <div className="border-t border-[#3a3c56] pt-4">
@@ -685,6 +724,7 @@ export default function GameUI({ onOpenStatus }: GameUIProps) {
                 characterLevel={character?.level ?? 1}
                 visitedRegions={character?.visitedRegions ?? []}
                 conqueredRegions={character?.visitedRegions?.filter(r => CONQUERABLE_REGIONS.includes(r)) ?? []}
+                onRegionClick={handleRegionClick}
               />
             )}
             {mobileCategory === 'quest' && questSubTab === 'bestiary' && character && (
@@ -760,6 +800,15 @@ export default function GameUI({ onOpenStatus }: GameUIProps) {
       </div>
       {/* Bottom padding spacer for mobile tab bar */}
       <div className="md:hidden h-14" />
+
+      {/* Travel confirm dialog */}
+      {travelTarget && (
+        <TravelConfirmDialog
+          region={getRegion(travelTarget)}
+          onConfirm={handleTravelConfirm}
+          onCancel={() => setTravelTarget(null)}
+        />
+      )}
     </div>
     </>
   )

--- a/src/app/tap-tap-adventure/components/RegionMap.tsx
+++ b/src/app/tap-tap-adventure/components/RegionMap.tsx
@@ -8,6 +8,7 @@ interface RegionMapProps {
   characterLevel: number
   visitedRegions?: string[]
   conqueredRegions?: string[]
+  onRegionClick?: (regionId: string) => void
 }
 
 // Absolute SVG coordinates in 400x1100 viewBox (bottom = high y, top = low y)
@@ -138,6 +139,7 @@ function RegionNode({
   isConquered,
   accessible,
   characterLevel,
+  onRegionClick,
 }: {
   region: Region
   x: number
@@ -147,10 +149,12 @@ function RegionNode({
   isConquered: boolean
   accessible: boolean
   characterLevel: number
+  onRegionClick?: (regionId: string) => void
 }) {
   const diffColor = DIFFICULTY_COLOR[region.difficulty] ?? DIFFICULTY_COLOR.easy
   const displayName = region.name.length > 12 ? region.name.slice(0, 11) + '\u2026' : region.name
   const isLocked = !isVisited && !isCurrent
+  const isClickable = isVisited && accessible && !isCurrent && !!onRegionClick
 
   if (isLocked) {
     // Fog-of-war: blurred dark box
@@ -179,7 +183,11 @@ function RegionNode({
 
   // Visited / current node
   return (
-    <g transform={`translate(${x},${y})`}>
+    <g
+      transform={`translate(${x},${y})`}
+      style={isClickable ? { cursor: 'pointer' } : undefined}
+      onClick={isClickable ? () => onRegionClick!(region.id) : undefined}
+    >
       {/* Pulse ring for current region */}
       {isCurrent && (
         <circle
@@ -275,6 +283,30 @@ function RegionNode({
           ⭐
         </text>
       )}
+
+      {/* Travel indicator for clickable nodes */}
+      {isClickable && (
+        <>
+          <rect
+            x={-32} y={-26} width={64} height={52} rx={10}
+            fill="rgba(99,179,237,0.08)"
+            stroke="rgba(99,179,237,0.35)"
+            strokeWidth={1}
+            className="hover:fill-[rgba(99,179,237,0.18)]"
+            style={{ pointerEvents: 'all' }}
+          />
+          <text
+            y={42}
+            textAnchor="middle"
+            fontSize={7}
+            fill="#60a5fa"
+            fontWeight="bold"
+            style={{ pointerEvents: 'none' }}
+          >
+            ▶ Travel
+          </text>
+        </>
+      )}
     </g>
   )
 }
@@ -330,6 +362,7 @@ export function RegionMap({
   characterLevel,
   visitedRegions = [],
   conqueredRegions = [],
+  onRegionClick,
 }: RegionMapProps) {
   const containerRef = useRef<HTMLDivElement>(null)
   const regions = Object.values(REGIONS)
@@ -485,6 +518,7 @@ export function RegionMap({
                 isConquered={isConquered}
                 accessible={accessible}
                 characterLevel={characterLevel}
+                onRegionClick={onRegionClick}
               />
             )
           })}

--- a/src/app/tap-tap-adventure/components/TravelConfirmDialog.tsx
+++ b/src/app/tap-tap-adventure/components/TravelConfirmDialog.tsx
@@ -1,0 +1,94 @@
+'use client'
+
+import { Region } from '@/app/tap-tap-adventure/config/regions'
+
+interface TravelConfirmDialogProps {
+  region: Region
+  onConfirm: () => void
+  onCancel: () => void
+}
+
+const DIFFICULTY_BADGE: Record<string, { label: string; classes: string }> = {
+  easy:      { label: 'Easy',      classes: 'bg-green-900/60 text-green-300 border border-green-600/40' },
+  medium:    { label: 'Medium',    classes: 'bg-yellow-900/60 text-yellow-300 border border-yellow-600/40' },
+  hard:      { label: 'Hard',      classes: 'bg-orange-900/60 text-orange-300 border border-orange-600/40' },
+  very_hard: { label: 'Very Hard', classes: 'bg-red-900/60 text-red-300 border border-red-600/40' },
+  extreme:   { label: 'Extreme',   classes: 'bg-purple-950/70 text-purple-200 border border-purple-400/50' },
+}
+
+const ELEMENT_BADGE: Record<string, { label: string; classes: string }> = {
+  nature: { label: 'Nature', classes: 'bg-green-900/40 text-green-300' },
+  shadow: { label: 'Shadow', classes: 'bg-slate-800/60 text-slate-300' },
+  arcane: { label: 'Arcane', classes: 'bg-violet-900/40 text-violet-300' },
+  fire:   { label: 'Fire',   classes: 'bg-orange-900/40 text-orange-300' },
+  ice:    { label: 'Ice',    classes: 'bg-cyan-900/40 text-cyan-300' },
+  none:   { label: 'Neutral', classes: 'bg-slate-800/40 text-slate-400' },
+}
+
+export function TravelConfirmDialog({ region, onConfirm, onCancel }: TravelConfirmDialogProps) {
+  const difficulty = DIFFICULTY_BADGE[region.difficulty] ?? DIFFICULTY_BADGE.easy
+  const element = ELEMENT_BADGE[region.element] ?? ELEMENT_BADGE.none
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center p-4"
+      style={{ backdropFilter: 'blur(4px)', background: 'rgba(0,0,0,0.6)' }}
+      onClick={onCancel}
+    >
+      <div
+        className="bg-[#1e1f30] border border-[#3a3c56] rounded-lg max-w-sm w-full p-5 space-y-4 shadow-xl"
+        onClick={e => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div className="flex items-center gap-3">
+          <span className="text-4xl leading-none">{region.icon}</span>
+          <div>
+            <h2 className="text-lg font-bold text-white">{region.name}</h2>
+            <div className="flex items-center gap-2 mt-1 flex-wrap">
+              <span className={`text-xs px-2 py-0.5 rounded-full font-medium ${difficulty.classes}`}>
+                {difficulty.label}
+              </span>
+              {region.element !== 'none' && (
+                <span className={`text-xs px-2 py-0.5 rounded-full ${element.classes}`}>
+                  {element.label}
+                </span>
+              )}
+              {region.minLevel > 0 && (
+                <span className="text-xs px-2 py-0.5 rounded-full bg-slate-800/60 text-slate-300 border border-slate-600/40">
+                  Lv.{region.minLevel}+
+                </span>
+              )}
+            </div>
+          </div>
+        </div>
+
+        {/* Description */}
+        <p className="text-sm text-slate-300 leading-relaxed">{region.description}</p>
+
+        {/* Enemy types */}
+        {region.enemyTypes.length > 0 && (
+          <div>
+            <p className="text-xs text-slate-500 uppercase tracking-wide mb-1">Enemies</p>
+            <p className="text-xs text-slate-400">{region.enemyTypes.join(', ')}</p>
+          </div>
+        )}
+
+        {/* Actions */}
+        <div className="flex gap-3 pt-1">
+          <button
+            onClick={onConfirm}
+            className="flex-1 py-2.5 rounded-lg bg-blue-600 hover:bg-blue-500 text-white text-sm font-semibold transition-colors"
+          >
+            Travel
+          </button>
+          <button
+            onClick={onCancel}
+            className="flex-1 py-2.5 rounded-lg bg-slate-700 hover:bg-slate-600 text-slate-200 text-sm font-medium transition-colors"
+          >
+            Cancel
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

- **Clickable map nodes**: visited, connected, accessible regions now show "▶ Travel" with pointer cursor
- **Travel confirmation dialog**: clicking a region opens a modal showing icon, name, difficulty badge (color-coded), element badge, level requirement, description, and enemy types — with Travel and Cancel buttons
- **Direct region travel**: confirmed travel updates character's currentRegion, rolls new weather, adds a story event to the feed, and plays the crossroads sound effect
- **Safety guards**: only connected + visited + level-accessible regions are clickable; unvisited regions still require the crossroads boss fight
- **Both layouts**: works in desktop sidebar and mobile Quest > Map tab

Closes #252

## Test plan
- [ ] Open map, verify visited connected regions show "▶ Travel" label
- [ ] Click a travel-enabled node → dialog opens with correct region info
- [ ] Click Travel → character moves to new region, story feed updates
- [ ] Click Cancel or backdrop → dialog closes, no travel
- [ ] Verify current region node is NOT clickable (no "Travel" label)
- [ ] Verify unvisited/locked regions are NOT clickable
- [ ] Verify level-gated regions show "Lv.X+" and are NOT clickable if underleveled
- [ ] Test on mobile (320px) → dialog fits, map nodes responsive
- [ ] After traveling, map updates to show new current position

🤖 Generated with [Claude Code](https://claude.com/claude-code)