### PR TITLE
feat: elemental matchup indicator showing enemy weakness/resistance in combat

### DIFF
--- a/src/app/tap-tap-adventure/components/CombatUI.tsx
+++ b/src/app/tap-tap-adventure/components/CombatUI.tsx
@@ -10,7 +10,8 @@ import { useCombatActionMutation } from '@/app/tap-tap-adventure/hooks/useCombat
 import { useGameStore } from '@/app/tap-tap-adventure/hooks/useGameStore'
 import { MountNamingModal } from '@/app/tap-tap-adventure/components/MountNamingModal'
 import { isUsableInCombat } from '@/app/tap-tap-adventure/lib/combatItemEffects'
-import { ELEMENT_COLORS } from '@/app/tap-tap-adventure/config/elements'
+import { ELEMENT_COLORS, getElementalMultiplier } from '@/app/tap-tap-adventure/config/elements'
+import { SpellElement } from '@/app/tap-tap-adventure/models/spell'
 import { soundEngine } from '@/app/tap-tap-adventure/lib/soundEngine'
 import { CombatAction, CombatState } from '@/app/tap-tap-adventure/models/combat'
 import { getWeatherType } from '@/app/tap-tap-adventure/config/weather'
@@ -56,6 +57,51 @@ function ManaBar({ current, max }: { current: number; max: number }) {
           style={{ width: `${pct}%` }}
         />
       </div>
+    </div>
+  )
+}
+
+const ELEMENT_ICONS: Record<string, string> = {
+  fire: '🔥', ice: '❄️', lightning: '⚡', shadow: '🌑', nature: '🌿', arcane: '✨',
+}
+
+function ElementalMatchup({ enemyElement }: { enemyElement: SpellElement | undefined }) {
+  if (!enemyElement || enemyElement === 'none') return null
+
+  const allElements: SpellElement[] = ['fire', 'ice', 'lightning', 'shadow', 'nature', 'arcane']
+  const strong: SpellElement[] = []
+  const weak: SpellElement[] = []
+
+  for (const atk of allElements) {
+    const mult = getElementalMultiplier(atk, enemyElement)
+    if (mult >= 2.0) strong.push(atk)
+    else if (mult <= 0.5) weak.push(atk)
+  }
+
+  if (strong.length === 0 && weak.length === 0) return null
+
+  return (
+    <div className="flex items-center gap-3 text-[10px] text-slate-400 mt-1">
+      {strong.length > 0 && (
+        <span className="flex items-center gap-1">
+          <span className="text-green-500">Weak to</span>
+          {strong.map(e => (
+            <span key={e} className="text-green-400" title={`${e} deals 2x damage`}>
+              {ELEMENT_ICONS[e] ?? e}
+            </span>
+          ))}
+        </span>
+      )}
+      {weak.length > 0 && (
+        <span className="flex items-center gap-1">
+          <span className="text-red-500">Resists</span>
+          {weak.map(e => (
+            <span key={e} className="text-red-400" title={`${e} deals 0.5x damage`}>
+              {ELEMENT_ICONS[e] ?? e}
+            </span>
+          ))}
+        </span>
+      )}
     </div>
   )
 }
@@ -363,6 +409,7 @@ export function CombatUI({ combatState }: CombatUIProps) {
         {showEnemyDesc && (
           <p className="text-xs text-slate-400">{enemy.description}</p>
         )}
+        <ElementalMatchup enemyElement={enemy.element as SpellElement | undefined} />
         <HpBar current={enemy.hp} max={enemy.maxHp} label="Enemy" color="text-red-400" />
         <StatusEffectsHUD
           statusEffects={enemy.statusEffects ?? []}


### PR DESCRIPTION
## Summary

- **Elemental matchup indicator** in enemy info panel during combat
- Shows **"Weak to"** (green) with element icons for elements that deal 2x damage to the enemy
- Shows **"Resists"** (red) with element icons for elements that deal 0.5x damage
- Element icons: 🔥 fire, ❄️ ice, ⚡ lightning, 🌑 shadow, 🌿 nature, ✨ arcane
- Only appears for enemies with a non-neutral element
- Hover tooltips explain the exact multiplier
- Helps players make informed spell choices during combat

Example: A fire-element enemy shows "Weak to ❄️" and "Resists 🔥"

Closes #256

## Test plan
- [ ] Fight a fire enemy → shows "Weak to ❄️" and "Resists 🌿" (wait, fire resists ice... let me check) Actually: fire is *beaten by* ice (ice attacks deal 2x to fire), and fire *resists* nothing in the defense chart. The indicator shows what *attacks* are strong against the enemy.
- [ ] Fight a shadow enemy → shows "Weak to 🌿" (nature deals 2x to shadow)
- [ ] Fight a "none" element enemy → no matchup indicator shown
- [ ] Verify on mobile (320px) — compact inline display fits

🤖 Generated with [Claude Code](https://claude.com/claude-code)