### PR TITLE
feat: Run History panel showing past character runs with stats and death cause

### DIFF
--- a/src/app/tap-tap-adventure/components/GameUI.tsx
+++ b/src/app/tap-tap-adventure/components/GameUI.tsx
@@ -49,6 +49,7 @@ import { NPCDialoguePanel } from './NPCDialoguePanel'
 import { getNPCsForRegion } from '@/app/tap-tap-adventure/config/npcs'
 import { useOnboarding, HintKey } from '@/app/tap-tap-adventure/hooks/useOnboarding'
 import { StatsPanel } from '@/app/tap-tap-adventure/components/StatsPanel'
+import { RunHistoryPanel } from '@/app/tap-tap-adventure/components/RunHistoryPanel'
 
 const DIFFICULTY_STYLES: Record<RegionDifficulty, { label: string; color: string }> = {
   easy: { label: 'Easy', color: 'bg-green-900/50 text-green-300 border-green-600/40' },
@@ -110,7 +111,7 @@ type MobileCategory = 'gear' | 'quest' | 'social' | 'more' | null
 type GearSubTab = 'equipment' | 'inventory' | 'crafting' | 'enchant'
 type QuestSubTab = 'quests' | 'map' | 'bestiary'
 type SocialSubTab = 'party' | 'factions' | 'npc' | 'leaderboard'
-type MoreSubTab = 'status' | 'base' | 'settings'
+type MoreSubTab = 'status' | 'history' | 'base' | 'settings'
 
 interface GameUIProps {
   onOpenStatus?: () => void
@@ -639,6 +640,9 @@ export default function GameUI({ onOpenStatus }: GameUIProps) {
             <div className="border-t border-[#3a3c56] pt-4">
               <StatsPanel />
             </div>
+            <div className="border-t border-[#3a3c56] pt-4">
+              <RunHistoryPanel />
+            </div>
           </div>
         </div>
         {/* Two-column grid END */}
@@ -686,6 +690,7 @@ export default function GameUI({ onOpenStatus }: GameUIProps) {
               ))}
               {mobileCategory === 'more' && ([
                 { id: 'status' as MoreSubTab, label: 'Status' },
+                { id: 'history' as MoreSubTab, label: 'History' },
                 { id: 'base' as MoreSubTab, label: 'Camp' },
                 { id: 'settings' as MoreSubTab, label: 'Settings' },
               ]).map(t => (
@@ -769,6 +774,9 @@ export default function GameUI({ onOpenStatus }: GameUIProps) {
             {/* More panels */}
             {mobileCategory === 'more' && moreSubTab === 'status' && (
               <StatsPanel />
+            )}
+            {mobileCategory === 'more' && moreSubTab === 'history' && (
+              <RunHistoryPanel />
             )}
             {mobileCategory === 'more' && moreSubTab === 'base' && <BasePanel />}
             {mobileCategory === 'more' && moreSubTab === 'settings' && <SettingsPanel />}

--- a/src/app/tap-tap-adventure/components/RunHistoryPanel.tsx
+++ b/src/app/tap-tap-adventure/components/RunHistoryPanel.tsx
@@ -1,0 +1,117 @@
+'use client'
+
+import { useState } from 'react'
+import { useGameStore } from '@/app/tap-tap-adventure/hooks/useGameStore'
+import { getRegion } from '@/app/tap-tap-adventure/config/regions'
+import type { FantasyCharacter } from '@/app/tap-tap-adventure/models/character'
+
+const REASON_CONFIG: Record<string, { label: string; color: string; icon: string }> = {
+  dead: { label: 'Slain', color: 'text-red-400', icon: '💀' },
+  retired: { label: 'Retired', color: 'text-amber-400', icon: '🏆' },
+}
+
+function RunCard({ character }: { character: FantasyCharacter }) {
+  const [expanded, setExpanded] = useState(false)
+  const reason = REASON_CONFIG[character.status] ?? REASON_CONFIG.dead
+  const region = getRegion(character.currentRegion ?? 'green_meadows')
+  const regionsVisited = (character.visitedRegions ?? []).length
+
+  return (
+    <button
+      type="button"
+      onClick={() => setExpanded(!expanded)}
+      className="w-full text-left bg-[#161723] border border-[#3a3c56] rounded-lg p-2.5 hover:border-slate-500 transition-colors"
+    >
+      {/* Header row */}
+      <div className="flex items-center justify-between gap-2">
+        <div className="flex items-center gap-2 min-w-0">
+          <span className="text-sm">{reason.icon}</span>
+          <span className="font-semibold text-sm text-slate-200 truncate">{character.name}</span>
+          <span className="text-xs text-slate-500">Lv.{character.level}</span>
+        </div>
+        <span className={`text-[10px] font-medium px-1.5 py-0.5 rounded ${reason.color} bg-slate-800/60`}>
+          {reason.label}
+        </span>
+      </div>
+
+      {/* Quick stats row */}
+      <div className="flex items-center gap-3 mt-1.5 text-[10px] text-slate-400">
+        <span>{character.class}</span>
+        <span>·</span>
+        <span>{(character.distance ?? 0).toLocaleString()} steps</span>
+        <span>·</span>
+        <span>{(character.gold ?? 0).toLocaleString()} gold</span>
+        <span>·</span>
+        <span>{regionsVisited} region{regionsVisited !== 1 ? 's' : ''}</span>
+      </div>
+
+      {/* Expanded details */}
+      {expanded && (
+        <div className="mt-2 pt-2 border-t border-[#3a3c56] space-y-1.5 text-xs">
+          <div className="flex justify-between">
+            <span className="text-slate-500">Last Region</span>
+            <span className="text-slate-300">{region.icon} {region.name}</span>
+          </div>
+          <div className="flex justify-between">
+            <span className="text-slate-500">Stats</span>
+            <span className="text-slate-300">
+              STR {character.strength} · INT {character.intelligence} · LCK {character.luck}
+            </span>
+          </div>
+          <div className="flex justify-between">
+            <span className="text-slate-500">Deaths</span>
+            <span className="text-slate-300">{character.deathCount ?? 0}</span>
+          </div>
+          <div className="flex justify-between">
+            <span className="text-slate-500">Difficulty</span>
+            <span className="text-slate-300 capitalize">{character.difficultyMode ?? 'normal'}</span>
+          </div>
+          {character.equipment?.weapon && (
+            <div className="flex justify-between">
+              <span className="text-slate-500">Weapon</span>
+              <span className="text-slate-300 truncate ml-2">{character.equipment.weapon.name}</span>
+            </div>
+          )}
+        </div>
+      )}
+    </button>
+  )
+}
+
+export function RunHistoryPanel() {
+  const { gameState } = useGameStore()
+  const [isExpanded, setIsExpanded] = useState(true)
+
+  const pastRuns = (gameState.characters ?? [])
+    .filter(c => c.status === 'dead' || c.status === 'retired')
+    .sort((a, b) => (b.level ?? 0) - (a.level ?? 0))
+
+  return (
+    <div className="bg-[#1e1f30] border border-[#3a3c56] rounded-lg overflow-hidden">
+      <button
+        onClick={() => setIsExpanded(!isExpanded)}
+        className="w-full flex items-center justify-between px-3 py-2.5 text-left hover:bg-[#252640] transition-colors"
+      >
+        <span className="text-sm font-semibold text-slate-200">
+          📜 Run History
+        </span>
+        <div className="flex items-center gap-2">
+          <span className="text-xs text-slate-500">{pastRuns.length} run{pastRuns.length !== 1 ? 's' : ''}</span>
+          <span className="text-slate-400 text-xs">{isExpanded ? '▲' : '▼'}</span>
+        </div>
+      </button>
+
+      {isExpanded && (
+        <div className="p-3 space-y-2">
+          {pastRuns.length === 0 ? (
+            <p className="text-xs text-slate-500 text-center py-4">
+              No completed runs yet. Your fallen and retired characters will appear here.
+            </p>
+          ) : (
+            pastRuns.map(char => <RunCard key={char.id} character={char} />)
+          )}
+        </div>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

- **New `RunHistoryPanel` component** showing all dead and retired characters as expandable run cards
- **Run card** displays: character name, level, class, cause (💀 Slain / 🏆 Retired), distance, gold, regions discovered
- **Expandable details**: last region with icon, stat spread (STR/INT/LCK), death count, difficulty mode, equipped weapon
- **Sorted** by highest level first, with run count in header
- **Empty state** message for players with no completed runs yet
- **Desktop sidebar**: appears after Stats panel in the right column
- **Mobile**: new "History" sub-tab under "More" category

Closes #232

## Test plan
- [ ] Create and kill/retire characters → they appear in Run History
- [ ] Verify run cards show correct name, level, class, and cause
- [ ] Click a run card → expanded details show last region, stats, weapon
- [ ] Verify sorting (highest level first)
- [ ] Desktop: panel visible in right sidebar after Stats
- [ ] Mobile: More > History tab shows the panel
- [ ] Empty state: new game shows "No completed runs yet" message
- [ ] Check 320px viewport — cards fit without overflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)