### PR TITLE
feat: region danger indicator + fix stat descriptions in HUD and level-up screen

### DIFF
--- a/src/app/tap-tap-adventure/components/HudBar.tsx
+++ b/src/app/tap-tap-adventure/components/HudBar.tsx
@@ -82,9 +82,9 @@ const STAT_LABELS: Record<IconType, string> = {
   leafIcon: 'Steps',
   fireIcon: 'Level',
   dayIcon: 'Day',
-  purpleCircleIcon: 'Strength',
-  blueCircleIcon: 'Intelligence',
-  yellowMoonIcon: 'Luck',
+  purpleCircleIcon: 'STR — Attack power, max HP',
+  blueCircleIcon: 'INT — Defense, mana pool',
+  yellowMoonIcon: 'LCK — Crit chance, loot, flee',
 } as const
 
 const STATS_LEFT: IconType[] = ['heartIcon', 'sunIcon', 'waterDropIcon', 'leafIcon', 'fireIcon', 'dayIcon']
@@ -310,6 +310,23 @@ export function HudBar({ onOpenStatus }: HudBarProps = {}) {
         >
           {currentRegion.icon} {currentRegion.name}
         </span>
+        {/* Region danger indicator */}
+        {(() => {
+          const levelDiff = (currentRegion.minLevel ?? 0) - level
+          const mult = currentRegion.difficultyMultiplier ?? 1
+          const danger = levelDiff >= 4 ? { label: 'Deadly', color: 'border-red-500 text-red-400', icon: '☠️' }
+            : levelDiff >= 2 ? { label: 'Hard', color: 'border-orange-500 text-orange-400', icon: '⚠️' }
+            : mult >= 1.5 ? { label: 'Tough', color: 'border-yellow-500 text-yellow-400', icon: '💪' }
+            : null
+          return danger ? (
+            <span
+              className={`text-[10px] px-1.5 py-0.5 border rounded ${danger.color} bg-[#2a2b3f]`}
+              title={`Region difficulty: ${currentRegion.difficulty} (${mult}x). Recommended level: ${currentRegion.minLevel}+`}
+            >
+              {danger.icon} {danger.label}
+            </span>
+          ) : null
+        })()}
         {(() => {
           const weatherType = WEATHER_TYPES[(character?.currentWeather ?? 'clear') as WeatherId] ?? WEATHER_TYPES.clear
           return weatherType.id !== 'clear' ? (

--- a/src/app/tap-tap-adventure/components/StatAllocationScreen.tsx
+++ b/src/app/tap-tap-adventure/components/StatAllocationScreen.tsx
@@ -10,9 +10,9 @@ interface StatAllocationScreenProps {
 }
 
 const STAT_DESCRIPTIONS: Record<string, string> = {
-  strength: 'Attack power, HP',
-  intelligence: 'Defense',
-  luck: 'Flee chance, loot drops',
+  strength: 'Attack power, max HP',
+  intelligence: 'Defense, mana pool',
+  luck: 'Crit chance, loot drops, flee chance',
 }
 
 const STAT_LABELS: Record<string, string> = {


### PR DESCRIPTION
## Summary

- **Region danger indicator**: new badge in the HUD showing threat level relative to the player's level
  - ☠️ Deadly: 4+ levels under recommended
  - ⚠️ Hard: 2+ levels under recommended
  - 💪 Tough: high difficulty multiplier (1.5x+) even at appropriate level
  - Tooltip shows exact difficulty rating and recommended level
  - Only shows when there's actual danger (no badge for safe regions)
- **Fixed stat descriptions** in both the level-up allocation screen and HUD tooltips:
  - STR: "Attack power, max HP" (was correct)
  - INT: "Defense, mana pool" (was just "Defense" — missing mana)
  - LCK: "Crit chance, loot drops, flee chance" (was missing crit chance)

## Test plan
- [ ] Travel to a region well above your level → ☠️ Deadly badge appears
- [ ] Travel to a region 2-3 levels above → ⚠️ Hard badge appears
- [ ] Travel to a high-multiplier region at correct level → 💪 Tough badge
- [ ] Stay in starting/easy regions → no danger badge
- [ ] Hover over danger badge → tooltip shows difficulty details
- [ ] Hover over STR/INT/LCK in HUD → updated descriptions appear
- [ ] Level up → stat allocation screen shows corrected descriptions
- [ ] Check on mobile (320px) — badge wraps correctly in HUD

🤖 Generated with [Claude Code](https://claude.com/claude-code)