### PR TITLE
feat: expand tactical combat consumables — shield, mana, cleanse, damage boost

### DIFF
--- a/src/app/tap-tap-adventure/lib/combatGenerator.ts
+++ b/src/app/tap-tap-adventure/lib/combatGenerator.ts
@@ -51,7 +51,11 @@ const enemySchemaForOpenAI = {
                   strength: { type: 'number' },
                   intelligence: { type: 'number' },
                   luck: { type: 'number' },
-                  heal: { type: 'number', description: 'Directly restores this amount of HP. Use for healing items instead of strength.' },
+                  heal: { type: 'number', description: 'Directly restores this amount of HP.' },
+                  shield: { type: 'number', description: 'Grants damage-absorbing shield points.' },
+                  manaRestore: { type: 'number', description: 'Restores mana points.' },
+                  cleanse: { type: 'boolean', description: 'Removes all negative status effects (poison, burn, etc.).' },
+                  damageBoost: { type: 'number', description: 'Temporary damage multiplier (e.g., 1.5 = +50% for 2 turns).' },
                 },
               },
             },
@@ -120,7 +124,7 @@ Stat guidelines for a level ${character.level} character:
 - Enemy attack: ${6 + character.level * 3} (±20%)
 - Enemy defense: ${2 + character.level} (±20%)
 - Gold reward: ${5 + character.level * 5}
-- Include 1-2 loot items (potions, scrolls, gems, etc.). For healing items, use the 'heal' effect (e.g., heal: 15 restores 15 HP). The 'strength' effect permanently increases the strength stat.
+- Include 1-2 loot items. Vary the types: healing potions (heal: 15), shield potions (shield: 15), mana potions (manaRestore: 15), antidotes (cleanse: true), rage elixirs (damageBoost: 1.5), or stat-boosting items (strength/intelligence/luck). Don't always drop healing potions — tactical variety matters.
 - Optionally include a special ability with cooldown of 2-4 turns
 - Some enemies can inflict status effects (poison, burn, slow, curse, fear). Include a statusAbility field with type, value (damage per turn or effect strength), duration (2-4 turns), and chance (0-1 probability of inflicting)
 - Assign an element to the enemy (fire, ice, lightning, shadow, nature, arcane, or none). Choose an element that fits the enemy's theme. For example: wolves = nature, fire elementals = fire, undead = shadow, golems = none.
@@ -627,12 +631,17 @@ function getDefaultCombatEncounter(
       level,
       goldReward: 5 + level * 5,
       lootTable: [
-        inferItemTypeAndEffects({
-          id: `loot-potion-${suffix}`,
-          name: 'Healing Potion',
-          description: 'A small vial of restorative liquid.',
-          quantity: 1,
-        }),
+        inferItemTypeAndEffects((() => {
+          const potionTypes = [
+            { name: 'Healing Potion', description: 'A small vial of restorative liquid.' },
+            { name: 'Shield Potion', description: 'A shimmering brew that grants a protective barrier.' },
+            { name: 'Mana Elixir', description: 'A glowing blue elixir that restores magical energy.' },
+            ...(level >= 3 ? [{ name: 'Rage Elixir', description: 'A fiery red brew that temporarily boosts damage.' }] : []),
+            ...(level >= 2 ? [{ name: 'Antidote', description: 'A herbal remedy that purges toxins and curses.' }] : []),
+          ]
+          const pick = potionTypes[Math.floor(Math.random() * potionTypes.length)]
+          return { id: `loot-potion-${suffix}`, name: pick.name, description: pick.description, quantity: 1 }
+        })()),
         ...(level >= 2 ? [inferItemTypeAndEffects({
           id: `loot-equipment-${suffix}`,
           name: level <= 3 ? 'Rusty Dagger' : level <= 5 ? 'Iron Sword' : 'Steel Blade',

--- a/src/app/tap-tap-adventure/lib/combatItemEffects.ts
+++ b/src/app/tap-tap-adventure/lib/combatItemEffects.ts
@@ -3,8 +3,8 @@ import { Item } from '@/app/tap-tap-adventure/models/item'
 
 export function isUsableInCombat(item: Item): boolean {
   if (item.type !== 'consumable' || !item.effects) return false
-  const { strength, intelligence, luck, heal } = item.effects
-  return !!(strength || intelligence || luck || heal)
+  const { strength, intelligence, luck, heal, shield, manaRestore, cleanse, damageBoost } = item.effects
+  return !!(strength || intelligence || luck || heal || shield || manaRestore || cleanse || damageBoost)
 }
 
 export function applyCombatItemEffect(
@@ -15,7 +15,11 @@ export function applyCombatItemEffect(
     return { playerState, description: `${item.name} has no effect in combat.` }
   }
 
-  const updated = { ...playerState, activeBuffs: [...(playerState.activeBuffs ?? [])] }
+  const updated = {
+    ...playerState,
+    activeBuffs: [...(playerState.activeBuffs ?? [])],
+    statusEffects: [...(playerState.statusEffects ?? [])],
+  }
   const parts: string[] = []
 
   // Heal effect → restore HP directly
@@ -26,6 +30,47 @@ export function applyCombatItemEffect(
     if (actualHeal > 0) {
       parts.push(`restored ${actualHeal} HP`)
     }
+  }
+
+  // Shield effect → add damage-absorbing shield
+  if (item.effects.shield) {
+    updated.shield = (updated.shield ?? 0) + item.effects.shield
+    parts.push(`gained ${item.effects.shield} shield`)
+  }
+
+  // Mana restore → restore MP directly
+  if (item.effects.manaRestore) {
+    const oldMana = updated.mana ?? 0
+    const maxMana = updated.maxMana ?? 0
+    updated.mana = Math.min(maxMana, oldMana + item.effects.manaRestore)
+    const actualRestore = (updated.mana ?? 0) - oldMana
+    if (actualRestore > 0) {
+      parts.push(`restored ${actualRestore} MP`)
+    }
+  }
+
+  // Cleanse → remove all negative status effects
+  if (item.effects.cleanse) {
+    const debuffTypes = new Set(['poison', 'burn', 'slow', 'curse', 'fear'])
+    const before = updated.statusEffects.length
+    updated.statusEffects = updated.statusEffects.filter(e => !debuffTypes.has(e.type))
+    const removed = before - updated.statusEffects.length
+    if (removed > 0) {
+      parts.push(`cleansed ${removed} debuff${removed !== 1 ? 's' : ''}`)
+    } else {
+      parts.push('no debuffs to cleanse')
+    }
+  }
+
+  // Damage boost → temporary attack buff
+  if (item.effects.damageBoost) {
+    const boostValue = Math.round((item.effects.damageBoost - 1) * 100)
+    updated.activeBuffs.push({
+      stat: 'attack',
+      value: Math.max(3, Math.round(updated.attack * (item.effects.damageBoost - 1))),
+      turnsRemaining: 2,
+    })
+    parts.push(`+${boostValue}% damage for 2 turns`)
   }
 
   // Strength effect → attack buff

--- a/src/app/tap-tap-adventure/lib/itemPostProcessor.ts
+++ b/src/app/tap-tap-adventure/lib/itemPostProcessor.ts
@@ -13,6 +13,10 @@ const POTION_SUBRULES: KeywordRule[] = [
   { keywords: ['luck', 'fortune', 'lucky', 'chance'], effects: { luck: 2 } },
   { keywords: ['strength', 'power', 'might', 'vigor', 'brawn'], effects: { strength: 3 } },
   { keywords: ['gold', 'wealth', 'rich', 'greed'], effects: { gold: 20 } },
+  { keywords: ['shield', 'barrier', 'protection', 'ward', 'aegis'], effects: { shield: 15 } },
+  { keywords: ['mana', 'arcane', 'ether', 'spirit', 'mystic'], effects: { manaRestore: 15 } },
+  { keywords: ['antidote', 'cure', 'cleanse', 'purify', 'remedy'], effects: { cleanse: true } },
+  { keywords: ['rage', 'fury', 'berserk', 'wrath', 'destruction'], effects: { damageBoost: 1.5 } },
 ]
 
 const SCROLL_SUBRULES: KeywordRule[] = [
@@ -94,6 +98,24 @@ function inferItemTypeAndEffectsInternal(item: Item): Item {
   }
   if (matchesAny(name, ['coin', 'gold piece', 'gold pouch'])) {
     return { ...item, type: 'consumable', effects: item.effects ?? { gold: 15 } }
+  }
+
+  // Bombs / Throwables
+  if (matchesAny(name, ['bomb', 'grenade', 'explosive', 'firebomb', 'flashbang'])) {
+    return {
+      ...item,
+      type: 'consumable',
+      effects: item.effects ?? { damageBoost: 1.5 },
+    }
+  }
+
+  // Antidotes / Remedies
+  if (matchesAny(name, ['antidote', 'remedy', 'panacea', 'salve'])) {
+    return {
+      ...item,
+      type: 'consumable',
+      effects: item.effects ?? { cleanse: true, heal: 5 },
+    }
   }
 
   // Charms / Amulets (consumable by default, but equipment if explicitly typed)

--- a/src/app/tap-tap-adventure/models/item.ts
+++ b/src/app/tap-tap-adventure/models/item.ts
@@ -12,6 +12,14 @@ export const ItemEffectsSchema = z.object({
   luck: z.number().optional(),
   heal: z.number().optional(),
   range: z.enum(['close', 'mid', 'far']).optional(),
+  /** Grants a damage-absorbing shield (points) */
+  shield: z.number().optional(),
+  /** Restores mana points */
+  manaRestore: z.number().optional(),
+  /** Removes all negative status effects */
+  cleanse: z.boolean().optional(),
+  /** Temporary damage multiplier boost (e.g., 1.5 = +50% damage for 2 turns) */
+  damageBoost: z.number().optional(),
 })
 export type ItemEffects = z.infer<typeof ItemEffectsSchema>
 


### PR DESCRIPTION
## Summary

Expands the combat consumable system from 4 basic effects to 8, adding meaningful tactical decisions:

- **Shield potions**: grant damage-absorbing shield points (15 HP absorb)
- **Mana elixirs**: restore mana for spell casting (15 MP)
- **Antidotes/cleanse**: remove all negative status effects (poison, burn, slow, curse, fear)
- **Rage elixirs/damage boost**: +50% damage for 2 turns

### Changes across 4 files:
- `models/item.ts`: Extended `ItemEffectsSchema` with `shield`, `manaRestore`, `cleanse`, `damageBoost`
- `lib/combatItemEffects.ts`: New effect handlers for all 4 types + updated `isUsableInCombat` check
- `lib/itemPostProcessor.ts`: 4 new keyword rules for potion inference + bomb/antidote item categories
- `lib/combatGenerator.ts`: Updated LLM schema with new fields + prompt requesting varied loot + randomized fallback potion drops (5 types instead of always Healing Potion)

## Test plan
- [ ] Fight enemies → loot drops include varied potion types (shield, mana, antidote, rage)
- [ ] Use Shield Potion in combat → shield value increases
- [ ] Use Mana Elixir → mana restores up to max
- [ ] Get poisoned, use Antidote → poison removed
- [ ] Use Rage Elixir → damage increased for 2 turns
- [ ] Verify all new items show as "usable in combat" in the item menu
- [ ] LLM-generated enemies drop varied loot types

🤖 Generated with [Claude Code](https://claude.com/claude-code)