### PR TITLE
feat: combat turn pressure indicator with escalating urgency warnings

### DIFF
--- a/src/app/tap-tap-adventure/components/CombatUI.tsx
+++ b/src/app/tap-tap-adventure/components/CombatUI.tsx
@@ -763,8 +763,28 @@ export function CombatUI({ combatState }: CombatUIProps) {
         )}
       </div>
 
-      <div className="text-center text-xs text-slate-500">
-        Turn {combatState.turnNumber}
+      {/* Turn counter with combat pressure indicator */}
+      <div className="text-center text-xs">
+        {(() => {
+          const turn = combatState.turnNumber ?? 1
+          if (turn >= 10) {
+            return (
+              <div className="flex items-center justify-center gap-2">
+                <span className="text-red-400 font-semibold animate-pulse">Turn {turn}</span>
+                <span className="text-red-500/70">— Prolonged fight! Enemy growing desperate</span>
+              </div>
+            )
+          }
+          if (turn >= 6) {
+            return (
+              <div className="flex items-center justify-center gap-2">
+                <span className="text-yellow-400 font-medium">Turn {turn}</span>
+                <span className="text-yellow-500/60">— Fight dragging on...</span>
+              </div>
+            )
+          }
+          return <span className="text-slate-500">Turn {turn}</span>
+        })()}
       </div>
 
       {pendingMountDrop && (


### PR DESCRIPTION
## Summary

Replace the plain "Turn X" counter with a dynamic pressure indicator that creates combat urgency:

- **Turns 1-5**: Normal slate text — no pressure, early combat
- **Turns 6-9**: Yellow warning — "Turn X — Fight dragging on..." signals inefficiency
- **Turns 10+**: Red pulsing text — "Turn X — Prolonged fight! Enemy growing desperate" creates urgency

This encourages players to make efficient tactical decisions rather than turtling, improving the challenge feel without changing combat mechanics. Works with the existing boss enrage system (which triggers at 50% HP) to create multi-layered pressure.

## Test plan
- [ ] Start combat → turns 1-5 show normal "Turn X" in slate
- [ ] Reach turn 6 → yellow warning appears
- [ ] Reach turn 10 → red pulsing warning appears
- [ ] Verify boss fights also show the pressure indicator
- [ ] Check mobile (320px) — text wraps correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)