### PR TITLE
feat: spell effectiveness hints showing elemental advantage in combat

### DIFF
--- a/src/app/tap-tap-adventure/components/CombatUI.tsx
+++ b/src/app/tap-tap-adventure/components/CombatUI.tsx
@@ -722,22 +722,39 @@ export function CombatUI({ combatState }: CombatUIProps) {
               const notEnoughMana = currentMana < (spell.manaCost ?? 0)
               const disabled = isPending || onCooldown || notEnoughMana
 
+              // Determine spell's primary element and effectiveness vs enemy
+              const spellElement = spell.effects?.find(e => e.element && e.element !== 'none')?.element as SpellElement | undefined
+              const enemyElement = enemy.element as SpellElement | undefined
+              const elemMult = spellElement && enemyElement ? getElementalMultiplier(spellElement, enemyElement) : 1
+              const effectiveness = elemMult >= 2 ? { label: 'Super effective!', color: 'text-green-400', border: 'border-green-600/50' }
+                : elemMult <= 0.5 ? { label: 'Resisted', color: 'text-red-400', border: 'border-red-600/50' }
+                : null
+
               return (
                 <Button
                   key={spell.id}
                   className={`w-full text-left whitespace-normal h-auto text-xs py-2 px-3 rounded-md border ${
                     disabled
                       ? 'bg-slate-800 border-slate-600 text-slate-500 cursor-not-allowed'
-                      : 'bg-[#2a2b3f] border-[#3a3c56] hover:bg-[#3a3c56] text-white'
+                      : effectiveness
+                        ? `bg-[#2a2b3f] ${effectiveness.border} hover:bg-[#3a3c56] text-white`
+                        : 'bg-[#2a2b3f] border-[#3a3c56] hover:bg-[#3a3c56] text-white'
                   }`}
                   onClick={() => handleCastSpell(spell.id)}
                   disabled={disabled}
                 >
                   <div className="flex justify-between items-center">
                     <span className="font-semibold">{spell.name}</span>
-                    <span className={`text-[10px] ${notEnoughMana ? 'text-red-400' : 'text-blue-400'}`}>
-                      {spell.manaCost ?? 0} MP
-                    </span>
+                    <div className="flex items-center gap-2">
+                      {effectiveness && !disabled && (
+                        <span className={`text-[9px] font-bold ${effectiveness.color}`}>
+                          {effectiveness.label}
+                        </span>
+                      )}
+                      <span className={`text-[10px] ${notEnoughMana ? 'text-red-400' : 'text-blue-400'}`}>
+                        {spell.manaCost ?? 0} MP
+                      </span>
+                    </div>
                   </div>
                   <div className="text-[10px] text-slate-400 mt-0.5">
                     {spell.description}


### PR DESCRIPTION
## Summary

Adds elemental effectiveness indicators to spell buttons in the combat spell menu:

- **"Super effective!"** (green label + green border) when spell element deals 2x damage to enemy
- **"Resisted"** (red label + red border) when spell element deals 0.5x damage
- No indicator for neutral matchups
- Only shown when spell is usable (hidden when on cooldown or insufficient mana)
- Detects spell element from the first elemental effect in the spell's effects array

This connects the elemental matchup system directly to spell selection, helping players choose optimal spells. Works with the existing elemental matchup indicator on the enemy panel (PR #257) to create a complete tactical information flow.

## Test plan
- [ ] Open spell menu against a fire enemy → ice spells show "Super effective!"
- [ ] Open spell menu against a fire enemy → nature spells show "Resisted"
- [ ] Neutral element spells → no indicator
- [ ] Disabled spells (cooldown/no mana) → no effectiveness indicator shown
- [ ] Enemy with "none" element → no indicators on any spells
- [ ] Check mobile (320px) — labels fit alongside mana cost

🤖 Generated with [Claude Code](https://claude.com/claude-code)