### PR TITLE
feat: NPC dialogue overhaul — interactive conversations with relationship tiers

### DIFF
--- a/src/app/api/v1/tap-tap-adventure/npc/dialogue/route.ts
+++ b/src/app/api/v1/tap-tap-adventure/npc/dialogue/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { OpenAI } from 'openai'
 import { z } from 'zod'
 
-import { getNPCById } from '@/app/tap-tap-adventure/config/npcs'
+import { getNPCById, getRelationshipTier } from '@/app/tap-tap-adventure/config/npcs'
 import { getRegion } from '@/app/tap-tap-adventure/config/regions'
 
 const DialogueRequestSchema = z.object({
@@ -18,6 +18,8 @@ const DialogueRequestSchema = z.object({
     role: z.enum(['user', 'assistant']),
     content: z.string(),
   })).optional(),
+  disposition: z.number().optional(),
+  exchangeCount: z.number().optional(),
 })
 
 function getOpenAI() {
@@ -35,7 +37,21 @@ export async function POST(req: NextRequest) {
       )
     }
 
-    const { npcId, characterName, characterClass, characterLevel, reputation, region, characterCharisma, message, conversationHistory } = parseResult.data
+    const {
+      npcId,
+      characterName,
+      characterClass,
+      characterLevel,
+      reputation,
+      region,
+      characterCharisma,
+      message,
+      conversationHistory,
+      disposition = 0,
+      exchangeCount = 1,
+    } = parseResult.data
+
+    const charisma = characterCharisma ?? 5
 
     const npc = getNPCById(npcId)
     if (!npc) {
@@ -45,13 +61,38 @@ export async function POST(req: NextRequest) {
     const regionData = getRegion(region)
     const regionName = regionData?.name ?? region
 
-    const systemPrompt = `You are ${npc.name}, ${npc.role} in ${regionName}. Personality: ${npc.personality}. Respond in character. Keep responses under 3 sentences. Occasionally offer a small reward (a gold tip, a reputation boost, or a useful hint about the area). End with a natural conversation hook or question. If you choose to offer a reward, include a JSON block at the very end of your response in this exact format: [REWARD:{"gold":N}] or [REWARD:{"reputation":N}] or [REWARD:{"gold":N,"reputation":N}] where N is a small number (gold: 5-25, reputation: 1-5). Only offer rewards occasionally, not every message.`
+    const tier = getRelationshipTier(disposition)
+    const weightsDescription = npc.personalityWeights
+      ? Object.entries(npc.personalityWeights)
+          .map(([intent, weight]) => `${intent}: ${weight && weight > 0 ? '+' : ''}${weight}`)
+          .join(', ')
+      : 'balanced'
 
-    const characterContext = `The adventurer ${characterName} (Level ${characterLevel} ${characterClass}, Reputation: ${reputation}, Charisma: ${characterCharisma ?? 5}) approaches.`
+    const systemPrompt = `You are ${npc.name}, ${npc.role} in ${regionName}. Personality: ${npc.personality}
+
+RELATIONSHIP: The player's current disposition toward you is ${disposition} (${tier.label}). Adjust your warmth and willingness accordingly.
+
+PLAYER: ${characterName}, Level ${characterLevel} ${characterClass}. Reputation: ${reputation}. Charisma: ${charisma}.
+
+CONVERSATION: This is exchange ${exchangeCount}.
+
+Evaluate the player's message for intent. Choose one of: flatter, charm, threaten, inquire, offend, lie, bore, neutral.
+Your personality preferences (how much you like each intent): ${weightsDescription}
+
+Respond in character. Keep responses under 4 sentences.
+
+RESPOND WITH ONLY THIS JSON (no markdown, no code fences):
+{
+  "dialogue": "Your in-character response here",
+  "intent": "detected intent",
+  "dispositionDelta": <integer from -10 to 8>,
+  "conversationComplete": <true if exchange >= 3 and conversation feels naturally concluded, otherwise false>,
+  "reward": { "gold": <integer 0-25>, "reputation": <integer 0-5> } or null
+}`
 
     const userMessage = message
-      ? `${characterContext}\n\nPlayer says: "${message}"`
-      : `${characterContext}\n\nThe adventurer approaches you for the first time.`
+      ? `${characterName} says: "${message}"`
+      : `${characterName} (Level ${characterLevel} ${characterClass}) approaches you.`
 
     const historyMessages: { role: 'user' | 'assistant'; content: string }[] = conversationHistory ?? []
 
@@ -63,32 +104,50 @@ export async function POST(req: NextRequest) {
           ...historyMessages,
           { role: 'user', content: userMessage },
         ],
-        temperature: 0.85,
-        max_tokens: 200,
+        temperature: 0.7,
+        max_tokens: 300,
+        response_format: { type: 'json_object' },
       })
 
-      const raw = response.choices[0]?.message?.content?.trim() ?? npc.greeting
+      const raw = response.choices[0]?.message?.content?.trim() ?? ''
 
-      // Parse optional reward block
-      const rewardMatch = raw.match(/\[REWARD:(\{[^}]+\})\]/)
-      let reward: { gold?: number; reputation?: number } | undefined
-      let dialogue = raw
+      let parsed: {
+        dialogue?: string
+        intent?: string
+        dispositionDelta?: number
+        conversationComplete?: boolean
+        reward?: { gold?: number; reputation?: number } | null
+      } = {}
 
-      if (rewardMatch) {
-        try {
-          reward = JSON.parse(rewardMatch[1]) as { gold?: number; reputation?: number }
-          // Remove the reward block from dialogue text
-          dialogue = raw.replace(/\s*\[REWARD:[^\]]+\]/, '').trim()
-        } catch {
-          // Ignore malformed reward block
-          dialogue = raw.replace(/\s*\[REWARD:[^\]]+\]/, '').trim()
-        }
+      try {
+        parsed = JSON.parse(raw) as typeof parsed
+      } catch {
+        // Fallback: try to extract dialogue from partial JSON
+        const dialogueMatch = raw.match(/"dialogue"\s*:\s*"([^"]+)"/)
+        parsed = { dialogue: dialogueMatch ? dialogueMatch[1] : npc.greeting, dispositionDelta: 0 }
       }
 
-      return NextResponse.json({ dialogue, reward })
+      const dialogue = parsed.dialogue ?? npc.greeting
+      const rawDelta = typeof parsed.dispositionDelta === 'number' ? parsed.dispositionDelta : 0
+
+      // Apply CHA modifier: CHA 7 = baseline 1.0; each point adds/subtracts 0.1
+      const chaModifier = 1 + (charisma - 7) * 0.1
+      const adjustedDelta = Math.round(rawDelta * chaModifier)
+      // Clamp to [-15, +12]
+      const dispositionDelta = Math.max(-15, Math.min(12, adjustedDelta))
+
+      const reward = parsed.reward && (parsed.reward.gold || parsed.reward.reputation) ? parsed.reward : undefined
+
+      return NextResponse.json({
+        dialogue,
+        intent: parsed.intent ?? 'neutral',
+        dispositionDelta,
+        conversationComplete: parsed.conversationComplete ?? false,
+        reward,
+      })
     } catch (err) {
       console.error('NPC dialogue LLM call failed', err)
-      return NextResponse.json({ dialogue: npc.greeting })
+      return NextResponse.json({ dialogue: npc.greeting, intent: 'neutral', dispositionDelta: 0, conversationComplete: false })
     }
   } catch (err) {
     console.error('Error in NPC dialogue route', err)

--- a/src/app/tap-tap-adventure/__tests__/npcDialogue.test.ts
+++ b/src/app/tap-tap-adventure/__tests__/npcDialogue.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  NPCS,
+  RELATIONSHIP_TIERS,
+  getRelationshipTier,
+  IntentType,
+} from '@/app/tap-tap-adventure/config/npcs'
+
+const ALL_INTENT_TYPES: IntentType[] = ['flatter', 'charm', 'threaten', 'inquire', 'offend', 'lie', 'bore', 'neutral']
+
+describe('getRelationshipTier', () => {
+  it('returns hostile for disposition -100', () => {
+    expect(getRelationshipTier(-100).tier).toBe('hostile')
+  })
+
+  it('returns hostile for disposition -31', () => {
+    expect(getRelationshipTier(-31).tier).toBe('hostile')
+  })
+
+  it('returns unfriendly for disposition -30', () => {
+    expect(getRelationshipTier(-30).tier).toBe('unfriendly')
+  })
+
+  it('returns neutral for disposition -10', () => {
+    expect(getRelationshipTier(-10).tier).toBe('neutral')
+  })
+
+  it('returns neutral for disposition 0', () => {
+    expect(getRelationshipTier(0).tier).toBe('neutral')
+  })
+
+  it('returns friendly for disposition 20', () => {
+    expect(getRelationshipTier(20).tier).toBe('friendly')
+  })
+
+  it('returns trusted for disposition 50', () => {
+    expect(getRelationshipTier(50).tier).toBe('trusted')
+  })
+
+  it('returns bonded for disposition 80', () => {
+    expect(getRelationshipTier(80).tier).toBe('bonded')
+  })
+
+  it('returns bonded for disposition 100', () => {
+    expect(getRelationshipTier(100).tier).toBe('bonded')
+  })
+
+  it('clamps values above 100 to bonded', () => {
+    expect(getRelationshipTier(150).tier).toBe('bonded')
+  })
+
+  it('clamps values below -100 to hostile', () => {
+    expect(getRelationshipTier(-200).tier).toBe('hostile')
+  })
+})
+
+describe('RELATIONSHIP_TIERS', () => {
+  it('defines all 6 expected tiers', () => {
+    const tierNames = RELATIONSHIP_TIERS.map(t => t.tier)
+    expect(tierNames).toContain('hostile')
+    expect(tierNames).toContain('unfriendly')
+    expect(tierNames).toContain('neutral')
+    expect(tierNames).toContain('friendly')
+    expect(tierNames).toContain('trusted')
+    expect(tierNames).toContain('bonded')
+    expect(RELATIONSHIP_TIERS).toHaveLength(6)
+  })
+
+  it('each tier has min, max, label, and color', () => {
+    for (const tier of RELATIONSHIP_TIERS) {
+      expect(typeof tier.min).toBe('number')
+      expect(typeof tier.max).toBe('number')
+      expect(typeof tier.label).toBe('string')
+      expect(typeof tier.color).toBe('string')
+      expect(tier.label.length).toBeGreaterThan(0)
+    }
+  })
+
+  it('tiers cover the full range from -100 to 100 with no gaps', () => {
+    const sorted = [...RELATIONSHIP_TIERS].sort((a, b) => a.min - b.min)
+    expect(sorted[0].min).toBe(-100)
+    // Last tier max should be 100
+    expect(sorted[sorted.length - 1].max).toBe(100)
+    // Each tier's max should equal the next tier's min
+    for (let i = 0; i < sorted.length - 1; i++) {
+      expect(sorted[i].max).toBe(sorted[i + 1].min)
+    }
+  })
+})
+
+describe('NPC definitions', () => {
+  const expectedNPCIds = [
+    'elder_maren',
+    'bramble',
+    'whisper',
+    'grimjaw',
+    'crystalline',
+    'pyraxis',
+    'umbra',
+    'seraphiel',
+  ]
+
+  it('defines all 8 NPCs', () => {
+    const ids = NPCS.map(n => n.id)
+    for (const id of expectedNPCIds) {
+      expect(ids).toContain(id)
+    }
+    expect(NPCS).toHaveLength(8)
+  })
+
+  it('all 8 NPCs have personalityWeights defined', () => {
+    for (const npc of NPCS) {
+      expect(npc.personalityWeights).toBeDefined()
+      expect(typeof npc.personalityWeights).toBe('object')
+    }
+  })
+
+  it('all 8 NPCs have at least 1 topic defined', () => {
+    for (const npc of NPCS) {
+      expect(npc.topics).toBeDefined()
+      expect(Array.isArray(npc.topics)).toBe(true)
+      expect((npc.topics ?? []).length).toBeGreaterThan(0)
+    }
+  })
+
+  it('all NPC personalityWeights use valid IntentType keys', () => {
+    for (const npc of NPCS) {
+      if (!npc.personalityWeights) continue
+      for (const key of Object.keys(npc.personalityWeights)) {
+        expect(ALL_INTENT_TYPES).toContain(key as IntentType)
+      }
+    }
+  })
+
+  it('each NPC has all 8 intent types covered in personalityWeights', () => {
+    for (const npc of NPCS) {
+      expect(npc.personalityWeights).toBeDefined()
+      const keys = Object.keys(npc.personalityWeights ?? {}) as IntentType[]
+      for (const intent of ALL_INTENT_TYPES) {
+        expect(keys).toContain(intent)
+      }
+    }
+  })
+})
+
+describe('IntentType values', () => {
+  it('covers all expected intent types', () => {
+    // Verify our ALL_INTENT_TYPES array covers all 8 intended values
+    expect(ALL_INTENT_TYPES).toHaveLength(8)
+    expect(ALL_INTENT_TYPES).toContain('flatter')
+    expect(ALL_INTENT_TYPES).toContain('charm')
+    expect(ALL_INTENT_TYPES).toContain('threaten')
+    expect(ALL_INTENT_TYPES).toContain('inquire')
+    expect(ALL_INTENT_TYPES).toContain('offend')
+    expect(ALL_INTENT_TYPES).toContain('lie')
+    expect(ALL_INTENT_TYPES).toContain('bore')
+    expect(ALL_INTENT_TYPES).toContain('neutral')
+  })
+})

--- a/src/app/tap-tap-adventure/components/GameUI.tsx
+++ b/src/app/tap-tap-adventure/components/GameUI.tsx
@@ -603,7 +603,7 @@ export default function GameUI({ onOpenStatus }: GameUIProps) {
                   if (regionNPCs.length === 0) return null
                   const npc = regionNPCs[0]
                   const encounters = character?.npcEncounters ?? {}
-                  const timesSpoken = encounters[npc.id]?.timesSpoken ?? 0
+                  const disposition = encounters[npc.id]?.disposition ?? 0
                   return (
                     <div>
                       {showNPCPanel ? (
@@ -614,9 +614,10 @@ export default function GameUI({ onOpenStatus }: GameUIProps) {
                           characterLevel={character?.level ?? 1}
                           reputation={character?.reputation ?? 0}
                           region={character?.currentRegion ?? 'green_meadows'}
-                          timesSpoken={timesSpoken}
-                          onReward={(reward) => {
-                            recordNPCEncounter(npc.id, reward)
+                          characterCharisma={character?.charisma ?? 5}
+                          disposition={disposition}
+                          onEncounterUpdate={(dispositionDelta, reward) => {
+                            recordNPCEncounter(npc.id, dispositionDelta, reward)
                           }}
                           onClose={() => {
                             setShowNPCPanel(false)
@@ -828,7 +829,7 @@ export default function GameUI({ onOpenStatus }: GameUIProps) {
               if (regionNPCs.length === 0) return <p className="text-sm text-slate-400">No NPCs in this region.</p>
               const npc = regionNPCs[0]
               const encounters = character.npcEncounters ?? {}
-              const timesSpoken = encounters[npc.id]?.timesSpoken ?? 0
+              const disposition = encounters[npc.id]?.disposition ?? 0
               return (
                 <NPCDialoguePanel
                   npc={npc}
@@ -837,9 +838,10 @@ export default function GameUI({ onOpenStatus }: GameUIProps) {
                   characterLevel={character.level}
                   reputation={character.reputation}
                   region={character.currentRegion ?? 'green_meadows'}
-                  timesSpoken={timesSpoken}
-                  onReward={(reward) => {
-                    recordNPCEncounter(npc.id, reward)
+                  characterCharisma={character.charisma ?? 5}
+                  disposition={disposition}
+                  onEncounterUpdate={(dispositionDelta, reward) => {
+                    recordNPCEncounter(npc.id, dispositionDelta, reward)
                   }}
                   onClose={() => {
                     setMobileCategory(null)

--- a/src/app/tap-tap-adventure/components/NPCDialoguePanel.tsx
+++ b/src/app/tap-tap-adventure/components/NPCDialoguePanel.tsx
@@ -1,9 +1,9 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { LoaderCircle } from 'lucide-react'
 import { Button } from '@/app/tap-tap-adventure/components/ui/button'
-import { GameNPC } from '@/app/tap-tap-adventure/config/npcs'
+import { GameNPC, getRelationshipTier } from '@/app/tap-tap-adventure/config/npcs'
 import { useNPCDialogue } from '@/app/tap-tap-adventure/hooks/useNPCDialogue'
 
 interface NPCDialoguePanelProps {
@@ -13,16 +13,10 @@ interface NPCDialoguePanelProps {
   characterLevel: number
   reputation: number
   region: string
-  timesSpoken: number
-  onReward?: (reward: { gold?: number; reputation?: number }) => void
+  characterCharisma: number
+  disposition: number
+  onEncounterUpdate: (dispositionDelta: number, reward?: { gold?: number; reputation?: number }) => void
   onClose: () => void
-}
-
-function getDispositionLabel(timesSpoken: number): { label: string; color: string } {
-  if (timesSpoken === 0) return { label: 'Stranger', color: 'text-slate-400' }
-  if (timesSpoken < 3) return { label: 'Acquaintance', color: 'text-blue-400' }
-  if (timesSpoken < 7) return { label: 'Friendly', color: 'text-green-400' }
-  return { label: 'Trusted Friend', color: 'text-amber-400' }
 }
 
 export function NPCDialoguePanel({
@@ -32,17 +26,76 @@ export function NPCDialoguePanel({
   characterLevel,
   reputation,
   region,
-  timesSpoken,
-  onReward,
+  characterCharisma,
+  disposition,
+  onEncounterUpdate,
   onClose,
 }: NPCDialoguePanelProps) {
-  const { currentDialogue, isLoading, fetchDialogue } = useNPCDialogue()
+  const {
+    isLoading,
+    conversationLog,
+    exchangeCount,
+    conversationComplete,
+    fetchDialogue,
+    reset,
+  } = useNPCDialogue()
+
+  const [playerInput, setPlayerInput] = useState('')
   const [rewardMessage, setRewardMessage] = useState<string | null>(null)
   const [hasOpened, setHasOpened] = useState(false)
+  const logEndRef = useRef<HTMLDivElement>(null)
 
-  const disposition = getDispositionLabel(timesSpoken)
+  const tier = getRelationshipTier(disposition)
 
-  const startDialogue = async () => {
+  const tierBadgeColors: Record<string, string> = {
+    hostile: 'text-red-500',
+    unfriendly: 'text-orange-400',
+    neutral: 'text-slate-400',
+    friendly: 'text-green-400',
+    trusted: 'text-blue-400',
+    bonded: 'text-amber-400',
+  }
+
+  const badgeColor = tierBadgeColors[tier.tier] ?? 'text-slate-400'
+
+  // Auto-scroll to bottom of conversation log
+  useEffect(() => {
+    logEndRef.current?.scrollIntoView({ behavior: 'smooth' })
+  }, [conversationLog])
+
+  // Fetch NPC greeting on first open
+  useEffect(() => {
+    if (!hasOpened) {
+      setHasOpened(true)
+      void fetchDialogue({
+        npc,
+        characterName,
+        characterClass,
+        characterLevel,
+        reputation,
+        region,
+        disposition,
+      }).then(result => {
+        onEncounterUpdate(result?.dispositionDelta ?? 0, result?.reward)
+        if (result?.reward) {
+          const parts: string[] = []
+          if (result.reward.gold) parts.push(`+${result.reward.gold} gold`)
+          if (result.reward.reputation) parts.push(`+${result.reward.reputation} reputation`)
+          if (parts.length > 0) setRewardMessage(parts.join(', '))
+        }
+      })
+    }
+    // Reset on unmount
+    return () => { reset() }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  const handleSend = async () => {
+    const trimmed = playerInput.trim()
+    if (!trimmed || isLoading || conversationComplete) return
+    setPlayerInput('')
+    setRewardMessage(null)
+
     const result = await fetchDialogue({
       npc,
       characterName,
@@ -50,11 +103,12 @@ export function NPCDialoguePanel({
       characterLevel,
       reputation,
       region,
+      message: trimmed,
+      disposition,
     })
-    // Always record the encounter (increments timesSpoken, applies optional reward)
-    if (onReward) {
-      onReward(result?.reward ?? {})
-    }
+
+    onEncounterUpdate(result?.dispositionDelta ?? 0, result?.reward)
+
     if (result?.reward) {
       const parts: string[] = []
       if (result.reward.gold) parts.push(`+${result.reward.gold} gold`)
@@ -63,34 +117,10 @@ export function NPCDialoguePanel({
     }
   }
 
-  // Auto-fetch dialogue on first open
-  useEffect(() => {
-    if (!hasOpened) {
-      setHasOpened(true)
-      startDialogue()
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
-
-  const handleTalkAgain = async () => {
-    setRewardMessage(null)
-    const result = await fetchDialogue({
-      npc,
-      characterName,
-      characterClass,
-      characterLevel,
-      reputation,
-      region,
-    })
-    // Record the encounter each time the player talks
-    if (onReward) {
-      onReward(result?.reward ?? {})
-    }
-    if (result?.reward) {
-      const parts: string[] = []
-      if (result.reward.gold) parts.push(`+${result.reward.gold} gold`)
-      if (result.reward.reputation) parts.push(`+${result.reward.reputation} reputation`)
-      if (parts.length > 0) setRewardMessage(parts.join(', '))
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault()
+      void handleSend()
     }
   }
 
@@ -106,9 +136,12 @@ export function NPCDialoguePanel({
           </div>
         </div>
         <div className="flex items-center gap-2">
-          <span className={`text-[10px] font-semibold uppercase tracking-wide ${disposition.color}`}>
-            {disposition.label}
-          </span>
+          <div className="flex flex-col items-end">
+            <span className={`text-[10px] font-semibold uppercase tracking-wide ${badgeColor}`}>
+              {tier.label}
+            </span>
+            <span className="text-[9px] text-slate-500">({disposition > 0 ? '+' : ''}{disposition})</span>
+          </div>
           <button
             className="text-slate-400 hover:text-white text-xs px-2 py-1 border border-[#3a3c56] rounded hover:border-slate-500 transition-colors"
             onClick={onClose}
@@ -118,20 +151,47 @@ export function NPCDialoguePanel({
         </div>
       </div>
 
-      {/* Dialogue area */}
-      <div className="min-h-[80px] bg-[#161723] border border-[#2a2b3f] rounded p-3">
-        {isLoading ? (
+      {/* Exchange counter */}
+      {exchangeCount > 1 && (
+        <div className="text-[10px] text-slate-500 text-right">
+          Exchange {exchangeCount - 1}
+        </div>
+      )}
+
+      {/* Conversation log */}
+      <div className="max-h-60 overflow-y-auto bg-[#161723] border border-[#2a2b3f] rounded p-3 space-y-2">
+        {conversationLog.length === 0 && !isLoading && (
+          <p className="text-sm text-slate-500 italic">Approach {npc.name} to speak...</p>
+        )}
+        {conversationLog.map((entry, idx) => (
+          <div key={idx} className={`flex flex-col ${entry.role === 'player' ? 'items-end' : 'items-start'}`}>
+            {entry.role === 'npc' ? (
+              <p className="text-sm text-slate-200 leading-relaxed italic max-w-[90%]">
+                <span className="not-italic mr-1">{npc.icon}</span>
+                &ldquo;{entry.content}&rdquo;
+              </p>
+            ) : (
+              <p className="text-sm text-slate-300 leading-relaxed max-w-[90%] bg-[#252640] rounded px-2 py-1">
+                {entry.content}
+              </p>
+            )}
+            {entry.role === 'player' && entry.intent && entry.intent !== 'neutral' && (
+              <span className="text-[9px] text-slate-500 mt-0.5 capitalize">{entry.intent}</span>
+            )}
+            {entry.role === 'npc' && entry.dispositionDelta !== undefined && entry.dispositionDelta !== 0 && (
+              <span className={`text-[9px] mt-0.5 ${entry.dispositionDelta > 0 ? 'text-green-500' : 'text-red-400'}`}>
+                {entry.dispositionDelta > 0 ? '+' : ''}{entry.dispositionDelta} rep
+              </span>
+            )}
+          </div>
+        ))}
+        {isLoading && (
           <div className="flex items-center gap-2 text-slate-400 text-sm">
             <LoaderCircle className="animate-spin h-4 w-4" />
             <span>{npc.name} is speaking...</span>
           </div>
-        ) : currentDialogue ? (
-          <p className="text-sm text-slate-200 leading-relaxed italic">
-            &ldquo;{currentDialogue.dialogue}&rdquo;
-          </p>
-        ) : (
-          <p className="text-sm text-slate-500 italic">Approach {npc.name} to speak...</p>
         )}
+        <div ref={logEndRef} />
       </div>
 
       {/* Reward notification */}
@@ -141,14 +201,35 @@ export function NPCDialoguePanel({
         </div>
       )}
 
-      {/* Actions */}
+      {/* Text input */}
+      {!conversationComplete && (
+        <div className="flex gap-2">
+          <input
+            type="text"
+            className="flex-1 bg-[#161723] border border-[#2a2b3f] rounded px-3 py-2 text-sm text-slate-200 placeholder-slate-500 focus:outline-none focus:border-indigo-600 disabled:opacity-50"
+            placeholder="Type your response..."
+            value={playerInput}
+            onChange={e => setPlayerInput(e.target.value)}
+            onKeyDown={handleKeyDown}
+            disabled={isLoading || conversationComplete}
+          />
+          <Button
+            className="text-sm border border-indigo-700 bg-indigo-800 hover:bg-indigo-700 text-white px-3 py-2 rounded disabled:opacity-60"
+            onClick={() => void handleSend()}
+            disabled={isLoading || !playerInput.trim() || conversationComplete}
+          >
+            Send
+          </Button>
+        </div>
+      )}
+
+      {/* Action row */}
       <div className="flex gap-2">
         <Button
-          className="flex-1 text-sm border border-[#3a3c56] bg-[#2a2b3f] hover:bg-[#3a3c56] text-white py-2 rounded disabled:opacity-60"
-          onClick={handleTalkAgain}
-          disabled={isLoading}
+          className="flex-1 text-sm border border-[#3a3c56] bg-[#2a2b3f] hover:bg-[#3a3c56] text-white py-2 rounded"
+          onClick={onClose}
         >
-          Talk Again
+          {conversationComplete ? 'Farewell' : 'Walk Away'}
         </Button>
       </div>
     </div>

--- a/src/app/tap-tap-adventure/config/npcs.ts
+++ b/src/app/tap-tap-adventure/config/npcs.ts
@@ -1,3 +1,31 @@
+export type IntentType = 'flatter' | 'charm' | 'threaten' | 'inquire' | 'offend' | 'lie' | 'bore' | 'neutral'
+
+export interface RelationshipTier {
+  tier: string
+  label: string
+  min: number
+  max: number
+  color: string
+}
+
+export const RELATIONSHIP_TIERS: RelationshipTier[] = [
+  { tier: 'hostile',    label: 'Hostile',    min: -100, max: -30, color: 'text-red-500' },
+  { tier: 'unfriendly', label: 'Unfriendly', min: -30,  max: -10, color: 'text-orange-400' },
+  { tier: 'neutral',    label: 'Neutral',    min: -10,  max: 20,  color: 'text-slate-400' },
+  { tier: 'friendly',   label: 'Friendly',   min: 20,   max: 50,  color: 'text-green-400' },
+  { tier: 'trusted',    label: 'Trusted',    min: 50,   max: 80,  color: 'text-blue-400' },
+  { tier: 'bonded',     label: 'Bonded',     min: 80,   max: 100, color: 'text-amber-400' },
+]
+
+export function getRelationshipTier(disposition: number): RelationshipTier {
+  const clamped = Math.max(-100, Math.min(100, disposition))
+  for (const tier of RELATIONSHIP_TIERS) {
+    if (clamped >= tier.min && clamped < tier.max) return tier
+  }
+  // disposition === 100 falls through — return bonded
+  return RELATIONSHIP_TIERS[RELATIONSHIP_TIERS.length - 1]
+}
+
 export interface GameNPC {
   id: string
   name: string
@@ -7,6 +35,8 @@ export interface GameNPC {
   personality: string
   icon: string
   greeting: string
+  personalityWeights?: Partial<Record<IntentType, number>>
+  topics?: string[]
 }
 
 export const NPCS: GameNPC[] = [
@@ -19,6 +49,8 @@ export const NPCS: GameNPC[] = [
     personality: 'Wise, welcoming, and patient. Speaks with warmth and authority. Offers practical advice and tips to adventurers. Uses gentle humor. Values courage and kindness.',
     icon: '\u{1F9D9}',
     greeting: 'Ah, a new face! Welcome, traveler. This village has seen many adventurers pass through — may your journey be long and your tales worth telling.',
+    personalityWeights: { charm: 2, inquire: 1, flatter: 1, threaten: -2, offend: -2, bore: -1, lie: -1, neutral: 0 },
+    topics: ['village history', 'adventurer guidance', 'ancient lore', 'local legends'],
   },
   {
     id: 'bramble',
@@ -29,6 +61,8 @@ export const NPCS: GameNPC[] = [
     personality: 'Jovial, chatty, and loves gossip. Always looking for a deal. Speaks enthusiastically and uses merchant slang. Has a laugh for every situation. Drops hints about rare goods or local rumors.',
     icon: '\u{1F9F3}',
     greeting: "Ha! You look like someone who appreciates a good bargain. Bramble's the name — finest goods this side of the Dark Forest, and tales to boot!",
+    personalityWeights: { flatter: 2, charm: 1, inquire: 1, threaten: -1, offend: -2, bore: -1, lie: 0, neutral: 0 },
+    topics: ['rare goods', 'trade rumors', 'local gossip', 'bargains', 'travel routes'],
   },
   {
     id: 'whisper',
@@ -39,6 +73,8 @@ export const NPCS: GameNPC[] = [
     personality: 'Mysterious, cryptic, and speaks in riddles and metaphors. Ancient and otherworldly. Reveals hidden truths obliquely. Neither fully good nor evil. Knows secrets of the forest.',
     icon: '\u{1F9DA}',
     greeting: 'The trees... they remember your footsteps. Every path chosen is a path not taken. What brings the warmth of flesh to where shadows breathe?',
+    personalityWeights: { inquire: 2, charm: 1, neutral: 1, offend: -2, threaten: -1, bore: -1, flatter: 0, lie: -1 },
+    topics: ['forest secrets', 'ancient riddles', 'hidden paths', 'shadow lore', 'nature omens'],
   },
   {
     id: 'grimjaw',
@@ -49,6 +85,8 @@ export const NPCS: GameNPC[] = [
     personality: 'Gruff, direct, and battle-hardened. Respects strength and survival above all. Short sentences. Dismissive of weakness. Warms up slightly to those who prove themselves. Knows tactical battle wisdom.',
     icon: '\u{1F9B4}',
     greeting: "You want to talk? Fine. Make it quick. Every minute standing still is a minute something out there gains on you.",
+    personalityWeights: { threaten: 1, inquire: 1, neutral: 1, flatter: -1, bore: -2, offend: -1, charm: 0, lie: -1 },
+    topics: ['battle tactics', 'survival skills', 'Bone Wastes dangers', 'old wars', 'enemy weaknesses'],
   },
   {
     id: 'crystalline',
@@ -59,6 +97,8 @@ export const NPCS: GameNPC[] = [
     personality: 'Ancient, formal, and precise. Speaks in measured, deliberate tones. Deeply knowledgeable about history and arcane lore. Emotionless but not unkind. Values accuracy and truth above all.',
     icon: '\u{1F48E}',
     greeting: 'Designation: traveler. Purpose: unknown. This unit has observed 4,712 adventurers traverse these caverns. State your query and I will consult my archives.',
+    personalityWeights: { inquire: 2, neutral: 1, charm: 0, flatter: -1, threaten: -2, offend: -2, bore: -1, lie: -2 },
+    topics: ['crystal cave history', 'arcane lore', 'ancient records', 'golem origins', 'magical theory'],
   },
   {
     id: 'pyraxis',
@@ -69,6 +109,8 @@ export const NPCS: GameNPC[] = [
     personality: 'Passionate, hot-tempered, and scholarly. Enthusiastic about fire magic and ancient lore. Gets excited easily and speaks in bursts. Brilliant but impatient with ignorance. Generous with knowledge when impressed.',
     icon: '\u{1F525}',
     greeting: "You dare venture here? EXCELLENT! The Wastes are magnificent — most flee screaming. Tell me, do you feel it? The ambient heat reading is up twelve degrees today!",
+    personalityWeights: { inquire: 2, charm: 1, flatter: 1, bore: -2, offend: -1, threaten: -1, neutral: 0, lie: -1 },
+    topics: ['fire magic', 'Scorched Wastes phenomena', 'elemental theory', 'ancient ruins', 'magical experiments'],
   },
   {
     id: 'umbra',
@@ -79,6 +121,8 @@ export const NPCS: GameNPC[] = [
     personality: 'Sly, transactional, and deals in secrets. Everything is a negotiation. Smooth and calculating. Amused by mortals but not contemptuous. Will share valuable secrets for the right price or information.',
     icon: '\u{1F578}\u{FE0F}',
     greeting: "Oh my... a living soul in my realm. How refreshing. I deal in secrets, traveler — and you have the look of someone who wants one. Shall we... negotiate?",
+    personalityWeights: { lie: 1, charm: 1, inquire: 1, bore: -1, flatter: 0, threaten: -1, offend: -2, neutral: 0 },
+    topics: ['secret information', 'shadow realm trade', 'hidden knowledge', 'bargaining chips', 'dangerous rumors'],
   },
   {
     id: 'seraphiel',
@@ -89,6 +133,8 @@ export const NPCS: GameNPC[] = [
     personality: 'Noble, dignified, and tests worthiness. Speaks with divine authority. Fair but demanding. Rewards genuine virtue and punishes arrogance. Genuinely cares for mortal souls despite stern demeanor.',
     icon: '\u{1F47C}',
     greeting: 'Halt, mortal. Few souls reach the Celestial Throne. Fewer still are worthy of what lies within. Speak — what virtue do you carry that justifies your presence here?',
+    personalityWeights: { charm: 2, inquire: 1, neutral: 1, lie: -2, offend: -2, threaten: -1, flatter: -1, bore: -1 },
+    topics: ['divine worthiness', 'celestial lore', 'virtuous deeds', 'mortal trials', 'heavenly knowledge'],
   },
 ]
 

--- a/src/app/tap-tap-adventure/hooks/useGameStore.ts
+++ b/src/app/tap-tap-adventure/hooks/useGameStore.ts
@@ -47,6 +47,7 @@ import {
 } from '@/app/tap-tap-adventure/lib/dailyChallengeTracker'
 import { DailyChallengeType } from '@/app/tap-tap-adventure/models/dailyChallenge'
 import { FACTIONS, FactionId } from '@/app/tap-tap-adventure/config/factions'
+import { getRelationshipTier } from '@/app/tap-tap-adventure/config/npcs'
 import { rollWeather, WEATHER_CHANGE_INTERVAL } from '@/app/tap-tap-adventure/config/weather'
 import { CRAFTING_RECIPES } from '@/app/tap-tap-adventure/config/craftingRecipes'
 import { canCraft, applyCraft } from '@/app/tap-tap-adventure/lib/craftingEngine'
@@ -137,7 +138,7 @@ export interface GameStore {
   enchantItem: (slot: 'weapon' | 'armor' | 'accessory') => { message: string; success: boolean } | null
   updateDailyChallengeProgress: (type: DailyChallengeType, amount: number) => void
   claimDailyChallengeBonus: () => { gold: number; reputation: number } | null
-  recordNPCEncounter: (npcId: string, reward?: { gold?: number; reputation?: number }) => void
+  recordNPCEncounter: (npcId: string, dispositionDelta: number, reward?: { gold?: number; reputation?: number }) => void
   setActiveTarget: (index: number) => void
 }
 
@@ -1155,7 +1156,7 @@ export const useGameStore = create<GameStore>()(
         )
         return bonus
       },
-      recordNPCEncounter: (npcId: string, reward?: { gold?: number; reputation?: number }) => {
+      recordNPCEncounter: (npcId: string, dispositionDelta: number, reward?: { gold?: number; reputation?: number }) => {
         set(
           produce((state: GameStore) => {
             const selectedCharacter = get().getSelectedCharacter()
@@ -1165,9 +1166,12 @@ export const useGameStore = create<GameStore>()(
 
             const encounters = state.gameState.characters[charIndex].npcEncounters ?? {}
             const existing = encounters[npcId] ?? { timesSpoken: 0, disposition: 0 }
+            const newDisposition = Math.max(-100, Math.min(100, existing.disposition + dispositionDelta))
+            const tier = getRelationshipTier(newDisposition)
             encounters[npcId] = {
               timesSpoken: existing.timesSpoken + 1,
-              disposition: Math.min(100, existing.disposition + 5),
+              disposition: newDisposition,
+              lastTier: tier.tier,
             }
             state.gameState.characters[charIndex].npcEncounters = encounters
 
@@ -1198,7 +1202,7 @@ export const useGameStore = create<GameStore>()(
     }),
     {
       name: 'fantasy-tycoon-storage', // localStorage key (kept for backward compat)
-      version: 25,
+      version: 26,
       migrate: (persistedState: unknown) => {
         const state = persistedState as GameStore
         if (state?.gameState && !('combatState' in state.gameState)) {
@@ -1307,6 +1311,14 @@ export const useGameStore = create<GameStore>()(
               ;(char as FantasyCharacter).landmarkState!.positionInRegion = 0
               ;(char as FantasyCharacter).landmarkState!.activeTargetIndex = 0
               ;(char as FantasyCharacter).landmarkState!.regionLength = 200
+            }
+            // v26: Add lastTier to npcEncounters
+            if ((char as FantasyCharacter).npcEncounters) {
+              for (const enc of Object.values((char as FantasyCharacter).npcEncounters!)) {
+                if (enc.lastTier === undefined) {
+                  enc.lastTier = getRelationshipTier(enc.disposition).tier
+                }
+              }
             }
           }
         }

--- a/src/app/tap-tap-adventure/hooks/useNPCDialogue.ts
+++ b/src/app/tap-tap-adventure/hooks/useNPCDialogue.ts
@@ -1,15 +1,25 @@
 'use client'
 import { useState, useCallback } from 'react'
 
-import { GameNPC } from '@/app/tap-tap-adventure/config/npcs'
+import { GameNPC, IntentType } from '@/app/tap-tap-adventure/config/npcs'
 
 interface ConversationMessage {
   role: 'user' | 'assistant'
   content: string
 }
 
+export interface ConversationEntry {
+  role: 'player' | 'npc'
+  content: string
+  intent?: IntentType
+  dispositionDelta?: number
+}
+
 interface DialogueState {
   dialogue: string
+  intent?: string
+  dispositionDelta?: number
+  conversationComplete?: boolean
   reward?: { gold?: number; reputation?: number }
 }
 
@@ -18,6 +28,9 @@ interface UseNPCDialogueReturn {
   isLoading: boolean
   error: string | null
   conversationHistory: ConversationMessage[]
+  conversationLog: ConversationEntry[]
+  exchangeCount: number
+  conversationComplete: boolean
   fetchDialogue: (params: {
     npc: GameNPC
     characterName: string
@@ -26,15 +39,21 @@ interface UseNPCDialogueReturn {
     reputation: number
     region: string
     message?: string
+    disposition?: number
   }) => Promise<DialogueState | null>
   reset: () => void
 }
+
+const MAX_LOG_ENTRIES = 20
 
 export function useNPCDialogue(): UseNPCDialogueReturn {
   const [currentDialogue, setCurrentDialogue] = useState<DialogueState | null>(null)
   const [isLoading, setIsLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [conversationHistory, setConversationHistory] = useState<ConversationMessage[]>([])
+  const [conversationLog, setConversationLog] = useState<ConversationEntry[]>([])
+  const [exchangeCount, setExchangeCount] = useState(1)
+  const [conversationComplete, setConversationComplete] = useState(false)
 
   const fetchDialogue = useCallback(async (params: {
     npc: GameNPC
@@ -44,8 +63,9 @@ export function useNPCDialogue(): UseNPCDialogueReturn {
     reputation: number
     region: string
     message?: string
+    disposition?: number
   }): Promise<DialogueState | null> => {
-    const { npc, characterName, characterClass, characterLevel, reputation, region, message } = params
+    const { npc, characterName, characterClass, characterLevel, reputation, region, message, disposition = 0 } = params
     setIsLoading(true)
     setError(null)
 
@@ -65,6 +85,8 @@ export function useNPCDialogue(): UseNPCDialogueReturn {
           region,
           message,
           conversationHistory: recentHistory,
+          disposition,
+          exchangeCount,
         }),
       })
 
@@ -72,12 +94,25 @@ export function useNPCDialogue(): UseNPCDialogueReturn {
         throw new Error('Failed to fetch NPC dialogue')
       }
 
-      const data = await res.json() as { dialogue: string; reward?: { gold?: number; reputation?: number } }
-      const result: DialogueState = { dialogue: data.dialogue, reward: data.reward }
+      const data = await res.json() as {
+        dialogue: string
+        intent?: string
+        dispositionDelta?: number
+        conversationComplete?: boolean
+        reward?: { gold?: number; reputation?: number }
+      }
+
+      const result: DialogueState = {
+        dialogue: data.dialogue,
+        intent: data.intent,
+        dispositionDelta: data.dispositionDelta,
+        conversationComplete: data.conversationComplete,
+        reward: data.reward,
+      }
 
       setCurrentDialogue(result)
 
-      // Append to conversation history
+      // Append to conversation history (for LLM context)
       const newHistory: ConversationMessage[] = [...conversationHistory]
       if (message) {
         newHistory.push({ role: 'user', content: message })
@@ -85,23 +120,64 @@ export function useNPCDialogue(): UseNPCDialogueReturn {
       newHistory.push({ role: 'assistant', content: data.dialogue })
       setConversationHistory(newHistory)
 
+      // Append to conversation log (for UI display), capped at MAX_LOG_ENTRIES
+      setConversationLog(prev => {
+        const updated = [...prev]
+        if (message) {
+          updated.push({
+            role: 'player',
+            content: message,
+            intent: data.intent as IntentType | undefined,
+          })
+        }
+        updated.push({
+          role: 'npc',
+          content: data.dialogue,
+          dispositionDelta: data.dispositionDelta,
+        })
+        return updated.slice(-MAX_LOG_ENTRIES)
+      })
+
+      setExchangeCount(prev => prev + 1)
+
+      if (data.conversationComplete) {
+        setConversationComplete(true)
+      }
+
       return result
     } catch (err) {
       const msg = err instanceof Error ? err.message : 'Unknown error'
       setError(msg)
       const fallback: DialogueState = { dialogue: npc.greeting }
       setCurrentDialogue(fallback)
+      setConversationLog(prev => {
+        const updated = [...prev, { role: 'npc' as const, content: npc.greeting }]
+        return updated.slice(-MAX_LOG_ENTRIES)
+      })
       return fallback
     } finally {
       setIsLoading(false)
     }
-  }, [conversationHistory])
+  }, [conversationHistory, exchangeCount])
 
   const reset = useCallback(() => {
     setCurrentDialogue(null)
     setError(null)
     setConversationHistory([])
+    setConversationLog([])
+    setExchangeCount(1)
+    setConversationComplete(false)
   }, [])
 
-  return { currentDialogue, isLoading, error, conversationHistory, fetchDialogue, reset }
+  return {
+    currentDialogue,
+    isLoading,
+    error,
+    conversationHistory,
+    conversationLog,
+    exchangeCount,
+    conversationComplete,
+    fetchDialogue,
+    reset,
+  }
 }

--- a/src/app/tap-tap-adventure/models/character.ts
+++ b/src/app/tap-tap-adventure/models/character.ts
@@ -66,7 +66,7 @@ export const FantasyCharacterSchema = z.object({
   campState: CampStateSchema.optional(),
   factionReputations: z.record(z.string(), z.number()).optional().default({}),
   bestiary: z.array(BestiaryEntrySchema).optional(),
-  npcEncounters: z.record(z.string(), z.object({ timesSpoken: z.number(), disposition: z.number() })).optional(),
+  npcEncounters: z.record(z.string(), z.object({ timesSpoken: z.number(), disposition: z.number(), lastTier: z.string().optional() })).optional(),
   landmarkState: z.object({
     regionId: z.string(),
     landmarks: z.array(z.object({


### PR DESCRIPTION
## Summary

Implements #275 (Phase 1) — transforms NPC conversations from one-way monologues into interactive, relationship-driven dialogues.

- **Free-text input**: Players type responses to NPCs instead of just clicking "Talk Again"
- **Intent evaluation**: LLM detects 8 intent types (flatter, charm, threaten, inquire, offend, lie, bore, neutral)
- **Personality weights**: Each NPC responds differently — Grimjaw respects threats, Whisper loves curiosity
- **6 relationship tiers**: Hostile → Unfriendly → Neutral → Friendly → Trusted → Bonded (gate outcomes)
- **CHA modifier**: Charisma scales disposition changes (±10% per point from baseline 7)
- **Structured JSON API**: Replaced regex `[REWARD:]` parsing with `response_format: { type: "json_object" }`
- **Conversation flow**: 3-5 exchanges with natural NPC-driven endings
- **UI overhaul**: Scrollable conversation log, relationship badge, exchange counter, walk-away option

8 files changed (1 new, 7 modified), 540 additions.

## Test plan

- [x] 717 tests pass (39 test files, 20 new NPC dialogue tests)
- [x] Relationship tier boundaries validated (hostile through bonded)
- [x] All 8 NPCs have personality weights and topics
- [x] RELATIONSHIP_TIERS structure complete
- [ ] Manual: type free-text to NPC and see response
- [ ] Manual: verify intent evaluation affects disposition
- [ ] Manual: relationship badge updates after conversation
- [ ] Manual: conversation ends naturally after 3-5 exchanges
- [ ] Manual: walk away mid-conversation

## Deferred to Phase 2

- NPC-landmark integration (keep floating Talk button)
- New NPCs (keep existing 8)
- Quest system, secret reveals, mercenary offers
- Hidden NPCs at deep encounter depths

Closes #275

🤖 Generated with [Claude Code](https://claude.com/claude-code)