### PR TITLE
feat: item rarity system with on-hit effects and drawbacks

### DIFF
--- a/src/app/tap-tap-adventure/components/EquipmentPanel.tsx
+++ b/src/app/tap-tap-adventure/components/EquipmentPanel.tsx
@@ -10,6 +10,14 @@ interface EquipmentPanelProps {
   equipment: EquipmentSlots
 }
 
+const RARITY_COLORS: Record<string, { border: string; text: string; bg: string; label: string }> = {
+  common: { border: 'border-gray-600/50', text: 'text-gray-400', bg: 'bg-gray-900/30', label: 'Common' },
+  uncommon: { border: 'border-green-600/50', text: 'text-green-400', bg: 'bg-green-900/30', label: 'Uncommon' },
+  rare: { border: 'border-blue-500/60', text: 'text-blue-400', bg: 'bg-blue-900/30', label: 'Rare' },
+  epic: { border: 'border-purple-500/60', text: 'text-purple-400', bg: 'bg-purple-900/30', label: 'Epic' },
+  legendary: { border: 'border-amber-500/60', text: 'text-amber-400', bg: 'bg-amber-900/30', label: 'Legendary' },
+}
+
 const SLOT_LABELS: Record<EquipmentSlotType, string> = {
   weapon: 'Weapon',
   armor: 'Armor',
@@ -102,7 +110,19 @@ export function EquipmentPanel({ equipment }: EquipmentPanelProps) {
                     <div className="text-xs text-gray-500 uppercase">{SLOT_LABELS[slot]}</div>
                     {item ? (
                       <>
-                        <div className="font-bold text-white text-sm truncate">{item.name}</div>
+                        {(() => {
+                          const rarityStyle = RARITY_COLORS[item.rarity ?? 'common']
+                          return (
+                            <div className="flex items-center gap-1.5 flex-wrap">
+                              <div className={`font-bold text-sm truncate ${item.rarity && item.rarity !== 'common' ? rarityStyle.text : 'text-white'}`}>{item.name}</div>
+                              {item.rarity && item.rarity !== 'common' && (
+                                <span className={`text-[10px] px-1.5 py-0.5 ${rarityStyle.bg} ${rarityStyle.text} rounded`}>
+                                  {rarityStyle.label}
+                                </span>
+                              )}
+                            </div>
+                          )
+                        })()}
                         {item.effects && (
                           <div className="text-xs text-emerald-400">
                             {Object.entries(item.effects)
@@ -114,6 +134,16 @@ export function EquipmentPanel({ equipment }: EquipmentPanelProps) {
                                   `+${v} ${k.charAt(0).toUpperCase() + k.slice(1)}`
                               )
                               .join(', ')}
+                          </div>
+                        )}
+                        {item.onHitEffect && (
+                          <div className="text-xs text-orange-400">
+                            On Hit: {item.onHitEffect.description} ({Math.round(item.onHitEffect.chance * 100)}% chance)
+                          </div>
+                        )}
+                        {item.drawback && (
+                          <div className="text-xs text-red-400">
+                            Drawback: {item.drawback.description} ({item.drawback.value} {item.drawback.stat})
                           </div>
                         )}
                         {slot === 'weapon' && item.effects?.range && (

--- a/src/app/tap-tap-adventure/components/InventoryPanel.tsx
+++ b/src/app/tap-tap-adventure/components/InventoryPanel.tsx
@@ -8,6 +8,14 @@ import { soundEngine } from '@/app/tap-tap-adventure/lib/soundEngine'
 import { getEquipmentSlot, EquipmentSlots } from '@/app/tap-tap-adventure/models/equipment'
 import { Item } from '@/app/tap-tap-adventure/models/types'
 
+const RARITY_COLORS: Record<string, { border: string; text: string; bg: string; label: string }> = {
+  common: { border: 'border-gray-600/50', text: 'text-gray-400', bg: 'bg-gray-900/30', label: 'Common' },
+  uncommon: { border: 'border-green-600/50', text: 'text-green-400', bg: 'bg-green-900/30', label: 'Uncommon' },
+  rare: { border: 'border-blue-500/60', text: 'text-blue-400', bg: 'bg-blue-900/30', label: 'Rare' },
+  epic: { border: 'border-purple-500/60', text: 'text-purple-400', bg: 'bg-purple-900/30', label: 'Epic' },
+  legendary: { border: 'border-amber-500/60', text: 'text-amber-400', bg: 'bg-amber-900/30', label: 'Legendary' },
+}
+
 interface InventoryPanelProps {
   inventory: Item[]
 }
@@ -25,7 +33,7 @@ export function InventoryPanel({ inventory }: InventoryPanelProps) {
   const [activeTab, setActiveTab] = useState<'active' | 'deleted'>('active')
   const [feedbackMessage, setFeedbackMessage] = useState<string | null>(null)
   const [typeFilter, setTypeFilter] = useState<string>('all')
-  const [sortBy, setSortBy] = useState<'default' | 'name' | 'type' | 'value'>('default')
+  const [sortBy, setSortBy] = useState<'default' | 'name' | 'type' | 'value' | 'rarity'>('default')
   const [detailItem, setDetailItem] = useState<Item | null>(null)
   const longPressTimerRef = useRef<NodeJS.Timeout | null>(null)
 
@@ -98,6 +106,10 @@ export function InventoryPanel({ inventory }: InventoryPanelProps) {
         const bVal = Object.values(b.effects ?? {}).reduce((sum: number, v) => sum + (typeof v === 'number' ? Math.abs(v) : 0), 0)
         return bVal - aVal
       }
+      case 'rarity': {
+        const rarityOrder: Record<string, number> = { legendary: 5, epic: 4, rare: 3, uncommon: 2, common: 1 }
+        return (rarityOrder[b.rarity ?? 'common'] ?? 0) - (rarityOrder[a.rarity ?? 'common'] ?? 0)
+      }
       default: return 0
     }
   })
@@ -117,6 +129,7 @@ export function InventoryPanel({ inventory }: InventoryPanelProps) {
           <option value="name">Sort: Name</option>
           <option value="type">Sort: Type</option>
           <option value="value">Sort: Value</option>
+          <option value="rarity">Sort: Rarity</option>
         </select>
         <Button
           onClick={() => setActiveTab(activeTab === 'active' ? 'deleted' : 'active')}
@@ -157,9 +170,14 @@ export function InventoryPanel({ inventory }: InventoryPanelProps) {
           <List
             items={sortedItems}
             className="space-y-0 w-full"
-            renderItem={(item: Item) => (
+            renderItem={(item: Item) => {
+              const rarityStyle = RARITY_COLORS[item.rarity ?? 'common']
+              const borderClass = item.isHeirloom
+                ? `${rarityStyle.border} ring-1 ring-amber-500/30`
+                : rarityStyle.border
+              return (
               <div
-                className={`relative bg-[#1e1f30] border ${item.isHeirloom ? 'border-amber-500/60 ring-1 ring-amber-500/30' : 'border-[#3a3c56]'} p-4 rounded-lg space-y-2 mb-3 w-full`}
+                className={`relative bg-[#1e1f30] border ${borderClass} p-4 rounded-lg space-y-2 mb-3 w-full`}
                 onPointerDown={() => handlePointerDown(item)}
                 onPointerUp={handlePointerUp}
                 onPointerLeave={handlePointerUp}
@@ -174,7 +192,7 @@ export function InventoryPanel({ inventory }: InventoryPanelProps) {
                     {item.isHeirloom && (
                       <span className="text-amber-400 text-sm" title="Heirloom">&#9733;</span>
                     )}
-                    <div className="font-bold text-white">{item.name}</div>
+                    <div className={`font-bold ${item.rarity && item.rarity !== 'common' ? rarityStyle.text : 'text-white'}`}>{item.name}</div>
                     {item.type === 'consumable' && (
                       <span className="text-[10px] px-1.5 py-0.5 bg-green-900/50 text-green-400 rounded">
                         Consumable
@@ -190,8 +208,16 @@ export function InventoryPanel({ inventory }: InventoryPanelProps) {
                         Spell Scroll
                       </span>
                     )}
+                    {item.rarity && item.rarity !== 'common' && (
+                      <span className={`text-[10px] px-1.5 py-0.5 ${rarityStyle.bg} ${rarityStyle.text} rounded`}>
+                        {rarityStyle.label}
+                      </span>
+                    )}
                   </div>
                   <div className="text-xs text-gray-400">{item.description}</div>
+                  {item.loreText && (
+                    <div className="text-xs text-amber-300/70 italic mt-0.5">{item.loreText}</div>
+                  )}
                   {item.effects && (
                     <div className="text-xs text-emerald-400 mt-1">
                       Effects: {Object.entries(item.effects)
@@ -221,6 +247,16 @@ export function InventoryPanel({ inventory }: InventoryPanelProps) {
                       </div>
                     )
                   })()}
+                  {item.onHitEffect && (
+                    <div className="text-xs text-orange-400 mt-0.5">
+                      On Hit: {item.onHitEffect.description} ({Math.round(item.onHitEffect.chance * 100)}% chance)
+                    </div>
+                  )}
+                  {item.drawback && (
+                    <div className="text-xs text-red-400 mt-0.5">
+                      Drawback: {item.drawback.description} ({item.drawback.value} {item.drawback.stat})
+                    </div>
+                  )}
                 </div>
                 <div className="flex space-x-2 mt-3">
                   {activeTab === 'active' && item.type === 'consumable' && (
@@ -269,7 +305,8 @@ export function InventoryPanel({ inventory }: InventoryPanelProps) {
                   )}
                 </div>
               </div>
-            )}
+              )
+            }}
           />
         )}
       </div>
@@ -282,22 +319,35 @@ export function InventoryPanel({ inventory }: InventoryPanelProps) {
             className="bg-[#1e1f30] border border-[#3a3c56] rounded-xl p-5 max-w-sm w-full mx-4 space-y-3"
             onClick={e => e.stopPropagation()}
           >
-            <div className="flex items-center gap-2">
-              {detailItem.isHeirloom && <span className="text-amber-400">&#9733;</span>}
-              <h4 className="text-white font-bold text-lg">{detailItem.name}</h4>
-              {detailItem.type && (
-                <span className={`text-[10px] px-1.5 py-0.5 rounded ${
-                  detailItem.type === 'consumable' ? 'bg-green-900/50 text-green-400' :
-                  detailItem.type === 'equipment' ? 'bg-indigo-900/50 text-indigo-400' :
-                  detailItem.type === 'spell_scroll' ? 'bg-purple-900/50 text-purple-400' :
-                  detailItem.type === 'quest' ? 'bg-yellow-900/50 text-yellow-400' :
-                  'bg-gray-900/50 text-gray-400'
-                }`}>
-                  {detailItem.type === 'spell_scroll' ? 'Spell Scroll' : detailItem.type.charAt(0).toUpperCase() + detailItem.type.slice(1)}
-                </span>
-              )}
-            </div>
+            {(() => {
+              const detailRarityStyle = RARITY_COLORS[detailItem.rarity ?? 'common']
+              return (
+                <div className="flex items-center gap-2 flex-wrap">
+                  {detailItem.isHeirloom && <span className="text-amber-400">&#9733;</span>}
+                  <h4 className={`font-bold text-lg ${detailItem.rarity && detailItem.rarity !== 'common' ? detailRarityStyle.text : 'text-white'}`}>{detailItem.name}</h4>
+                  {detailItem.type && (
+                    <span className={`text-[10px] px-1.5 py-0.5 rounded ${
+                      detailItem.type === 'consumable' ? 'bg-green-900/50 text-green-400' :
+                      detailItem.type === 'equipment' ? 'bg-indigo-900/50 text-indigo-400' :
+                      detailItem.type === 'spell_scroll' ? 'bg-purple-900/50 text-purple-400' :
+                      detailItem.type === 'quest' ? 'bg-yellow-900/50 text-yellow-400' :
+                      'bg-gray-900/50 text-gray-400'
+                    }`}>
+                      {detailItem.type === 'spell_scroll' ? 'Spell Scroll' : detailItem.type.charAt(0).toUpperCase() + detailItem.type.slice(1)}
+                    </span>
+                  )}
+                  {detailItem.rarity && detailItem.rarity !== 'common' && (
+                    <span className={`text-[10px] px-1.5 py-0.5 ${detailRarityStyle.bg} ${detailRarityStyle.text} rounded`}>
+                      {detailRarityStyle.label}
+                    </span>
+                  )}
+                </div>
+              )
+            })()}
             <p className="text-gray-300 text-sm">{detailItem.description}</p>
+            {detailItem.loreText && (
+              <div className="text-xs text-amber-300/70 italic">{detailItem.loreText}</div>
+            )}
             {detailItem.quantity > 1 && (
               <div className="text-xs text-gray-400">Quantity: {detailItem.quantity}</div>
             )}
@@ -344,6 +394,18 @@ export function InventoryPanel({ inventory }: InventoryPanelProps) {
               <div className="space-y-1">
                 <div className="text-xs text-gray-500 uppercase font-semibold">Spell: {detailItem.spell.name}</div>
                 <div className="text-sm text-gray-300">{detailItem.spell.description}</div>
+              </div>
+            )}
+            {detailItem.onHitEffect && (
+              <div className="space-y-1">
+                <div className="text-xs text-gray-500 uppercase font-semibold">On Hit Effect</div>
+                <div className="text-sm text-orange-400">{detailItem.onHitEffect.description} ({Math.round(detailItem.onHitEffect.chance * 100)}% chance)</div>
+              </div>
+            )}
+            {detailItem.drawback && (
+              <div className="space-y-1">
+                <div className="text-xs text-gray-500 uppercase font-semibold">Drawback</div>
+                <div className="text-sm text-red-400">{detailItem.drawback.description} ({detailItem.drawback.value} {detailItem.drawback.stat})</div>
               </div>
             )}
             <button

--- a/src/app/tap-tap-adventure/lib/heirloomGenerator.ts
+++ b/src/app/tap-tap-adventure/lib/heirloomGenerator.ts
@@ -59,6 +59,7 @@ function generateEquipmentHeirloom(character: FantasyCharacter): Item {
   const { tier, multiplier } = qualityTier(character)
   const stat = strongestStat(character)
   const baseBonus = Math.max(1, Math.floor(character.level * multiplier))
+  const rarity = tier.toLowerCase() as Item['rarity']
 
   const nameTemplates = [
     `${character.name}'s Lucky Charm`,
@@ -78,6 +79,24 @@ function generateEquipmentHeirloom(character: FantasyCharacter): Item {
     effects[secondaryStat] = Math.max(1, Math.floor(baseBonus * 0.5))
   }
 
+  // On-hit effect for Epic and Legendary
+  let onHitEffect: Item['onHitEffect']
+  if (multiplier >= 2.2) {
+    if (stat === 'strength') {
+      onHitEffect = { type: 'bleed', chance: 0.15, damage: 3, duration: 2, description: 'Causes bleeding on hit' }
+    } else if (stat === 'intelligence') {
+      onHitEffect = { type: 'burn', chance: 0.15, damage: 3, duration: 2, description: 'Burns the enemy on hit' }
+    } else {
+      onHitEffect = { type: 'lifesteal', chance: 0.2, damage: 0, duration: 0, description: 'Steals life on hit' }
+    }
+  }
+
+  // Drawback for Legendary
+  let drawback: Item['drawback']
+  if (multiplier >= 3) {
+    drawback = { stat: 'luck', value: -2, description: 'Cursed by memories of its fallen owner' }
+  }
+
   return {
     id: `heirloom-${character.id}-${Date.now()}`,
     name,
@@ -86,6 +105,10 @@ function generateEquipmentHeirloom(character: FantasyCharacter): Item {
     type: 'equipment',
     effects,
     isHeirloom: true,
+    rarity,
+    loreText: `Carried by ${character.name} through ${character.distance ?? 0} steps of adventure.`,
+    ...(onHitEffect ? { onHitEffect } : {}),
+    ...(drawback ? { drawback } : {}),
   }
 }
 
@@ -103,6 +126,7 @@ function generateConsumableHeirloom(character: FantasyCharacter): Item {
       heal: healAmount,
     },
     isHeirloom: true,
+    rarity: tier.toLowerCase() as Item['rarity'],
   }
 }
 
@@ -110,6 +134,7 @@ function generateSpellScrollHeirloom(character: FantasyCharacter): Item {
   const spells = character.spellbook ?? []
   // Pick the "best" spell (highest mana cost generally = strongest)
   const spell = [...spells].sort((a, b) => b.manaCost - a.manaCost)[0]
+  const { tier } = qualityTier(character)
 
   return {
     id: `heirloom-${character.id}-${Date.now()}`,
@@ -119,6 +144,7 @@ function generateSpellScrollHeirloom(character: FantasyCharacter): Item {
     type: 'spell_scroll',
     spell,
     isHeirloom: true,
+    rarity: tier.toLowerCase() as Item['rarity'],
   }
 }
 

--- a/src/app/tap-tap-adventure/lib/itemPostProcessor.ts
+++ b/src/app/tap-tap-adventure/lib/itemPostProcessor.ts
@@ -39,7 +39,17 @@ function findMatchingEffects(name: string, rules: KeywordRule[], fallback: ItemE
 
 export function inferItemTypeAndEffects(item: Item): Item {
   const inferred = inferItemTypeAndEffectsInternal(item)
-  return { ...inferred, description: generateItemDescription(inferred) }
+  const withDescription = { ...inferred, description: generateItemDescription(inferred) }
+  return withDescription.rarity ? withDescription : { ...withDescription, rarity: inferRarity(withDescription) }
+}
+
+function inferRarity(item: Item): Item['rarity'] {
+  const name = item.name.toLowerCase()
+  if (matchesAny(name, ['legendary', 'mythic', 'divine', 'godly'])) return 'legendary'
+  if (matchesAny(name, ['epic', 'ancient', 'primordial', 'eternal'])) return 'epic'
+  if (matchesAny(name, ['rare', 'enchanted', 'mystic', 'arcane'])) return 'rare'
+  if (matchesAny(name, ['fine', 'quality', 'superior', 'sturdy', 'sharp', 'greater'])) return 'uncommon'
+  return 'common'
 }
 
 function inferItemTypeAndEffectsInternal(item: Item): Item {

--- a/src/app/tap-tap-adventure/lib/shopGenerator.ts
+++ b/src/app/tap-tap-adventure/lib/shopGenerator.ts
@@ -37,6 +37,7 @@ const shopSchemaForOpenAI = {
           quantity: { type: 'number' },
           type: { type: 'string', enum: ['consumable', 'equipment', 'quest', 'misc'] },
           price: { type: 'number' },
+          rarity: { type: 'string', enum: ['common', 'uncommon', 'rare', 'epic', 'legendary'] },
           effects: {
             type: 'object',
             properties: {
@@ -86,6 +87,9 @@ Include a mix of:
 - Occasionally a spell scroll (type: "spell_scroll") with a spell object containing id, name, description, school, manaCost, cooldown, target, effects, and tags
 
 Each item needs a unique id (e.g. "shop-item-1"), a creative name, a short description, quantity of 1, a gold price, and effects.
+
+- Each item should have a rarity: common (basic supplies), uncommon (quality goods), rare (special finds), epic (very rare), legendary (once in a lifetime)
+- Most items should be common or uncommon. Include at most 1 rare item. Epic/legendary items should almost never appear in shops.
 
 Character:
 ${JSON.stringify({ name: character.name, race: character.race, class: character.class, level: character.level }, null, 2)}`,
@@ -138,6 +142,7 @@ export function getFallbackShopItems(level: number, reputation: number = 0, char
       type: 'consumable',
       price: Math.round(basePrice * 0.8 * reputationMultiplier),
       effects: { heal: 10 + level * 5 },
+      rarity: 'common',
     },
     {
       id: `shop-str-${suffix}`,
@@ -147,6 +152,7 @@ export function getFallbackShopItems(level: number, reputation: number = 0, char
       type: 'consumable',
       price: Math.round(basePrice * 1.5 * reputationMultiplier),
       effects: { strength: 2 + Math.floor(level / 2) },
+      rarity: 'uncommon',
     },
     {
       id: `shop-int-${suffix}`,
@@ -156,6 +162,7 @@ export function getFallbackShopItems(level: number, reputation: number = 0, char
       type: 'consumable',
       price: Math.round(basePrice * 1.5 * reputationMultiplier),
       effects: { intelligence: 2 + Math.floor(level / 2) },
+      rarity: 'uncommon',
     },
     {
       id: `shop-luck-${suffix}`,
@@ -165,6 +172,7 @@ export function getFallbackShopItems(level: number, reputation: number = 0, char
       type: 'consumable',
       price: Math.round(basePrice * reputationMultiplier),
       effects: { luck: 2 + Math.floor(level / 3) },
+      rarity: 'common',
     },
   ]
 
@@ -179,6 +187,7 @@ export function getFallbackShopItems(level: number, reputation: number = 0, char
     type: 'spell_scroll',
     price: Math.round(spellPrice * reputationMultiplier),
     spell: spell1,
+    rarity: 'rare',
   })
 
   // 50% chance for a second spell scroll
@@ -192,6 +201,7 @@ export function getFallbackShopItems(level: number, reputation: number = 0, char
       type: 'spell_scroll',
       price: Math.round(spellPrice * reputationMultiplier),
       spell: spell2,
+      rarity: 'rare',
     })
   }
 

--- a/src/app/tap-tap-adventure/models/item.ts
+++ b/src/app/tap-tap-adventure/models/item.ts
@@ -36,6 +36,20 @@ export const ItemSchema = z.object({
   spell: SpellSchema.optional(),
   isHeirloom: z.boolean().optional(),
   enchantmentLevel: z.number().optional(),
+  rarity: z.enum(['common', 'uncommon', 'rare', 'epic', 'legendary']).optional(),
+  loreText: z.string().optional(),
+  onHitEffect: z.object({
+    type: z.enum(['poison', 'burn', 'freeze', 'lifesteal', 'stun', 'bleed']),
+    chance: z.number(),
+    damage: z.number().optional(),
+    duration: z.number().optional(),
+    description: z.string(),
+  }).optional(),
+  drawback: z.object({
+    stat: z.string(),
+    value: z.number(),
+    description: z.string(),
+  }).optional(),
 })
 
 export type Item = z.infer<typeof ItemSchema>


### PR DESCRIPTION
## Summary
Implements Phase 1 of #277 — adds a 5-tier rarity system to items with visual identity, on-hit combat procs, drawbacks, and lore text.

- **Schema**: `rarity` (common/uncommon/rare/epic/legendary), `loreText`, `onHitEffect` (type/chance/damage/duration), and `drawback` (stat/value/description) fields added to ItemSchema
- **Generation**: Heirloom generator maps existing quality tiers to rarity with on-hit effects for Epic+ and drawbacks for Legendary. Shop generator includes rarity in LLM prompts and fallback items. Item post-processor infers rarity from name keywords
- **UI**: Items color-coded by rarity (gray/green/blue/purple/amber) in inventory and equipment panels with rarity badges, lore text, on-hit indicators, drawback warnings, and sort-by-rarity option

## What's NOT in this PR (follow-up work)
- Combat engine integration for on-hit effects (applying procs during attacks)
- Drawback stat penalties when equipping items
- Expanded NPC/landmark drops with rarity-weighted loot tables

## Test plan
- [ ] Existing 736 tests pass (verified locally)
- [ ] Create a character, play until a shop appears — items should show rarity badges with appropriate colors
- [ ] Die with a high-level character — heirloom should have rarity, lore text, and Epic+ should have on-hit effects
- [ ] Inventory panel shows rarity colors on item borders and names
- [ ] Sort by rarity option works in inventory
- [ ] Long-press item detail modal shows rarity badge, lore text, on-hit effect, and drawback sections
- [ ] Equipment panel shows rarity badges and on-hit/drawback info for equipped items

🤖 Generated with [Claude Code](https://claude.com/claude-code)