### PR TITLE
Fix step counting and add directional exits at landmarks

### DIFF
--- a/src/app/api/v1/tap-tap-adventure/move-forward/services/moveForwardService.ts
+++ b/src/app/api/v1/tap-tap-adventure/move-forward/services/moveForwardService.ts
@@ -113,6 +113,38 @@ export async function moveForwardService(
         },
       }
 
+      // Build directional bypass options: show what lies ahead
+      const bypassOptions = []
+
+      // Add next landmarks (after the current one)
+      for (let i = activeTargetIndex + 1; i < landmarkState.landmarks.length; i++) {
+        const nextLm = landmarkState.landmarks[i]
+        const dist = nextLm.distanceFromEntry - newPositionInRegion
+        bypassOptions.push({
+          id: `bypass-toward-${i}`,
+          text: `${nextLm.icon} Head toward ${nextLm.name} (${dist} steps)`,
+          successProbability: 1.0,
+          successDescription: `You leave ${activeLandmark.name} behind and head toward ${nextLm.name}.`,
+          successEffects: {},
+          failureDescription: '',
+          failureEffects: {},
+          resultDescription: `You pass by ${activeLandmark.name} and head toward ${nextLm.name}.`,
+        })
+      }
+
+      // Add region exit option
+      const exitDist = (landmarkState.regionLength ?? 200) - newPositionInRegion
+      bypassOptions.push({
+        id: `bypass-toward-exit`,
+        text: `🚪 Head toward ${region.name} border (${exitDist} steps)`,
+        successProbability: 1.0,
+        successDescription: `You leave ${activeLandmark.name} behind and continue toward the edge of ${region.name}.`,
+        successEffects: {},
+        failureDescription: '',
+        failureEffects: {},
+        resultDescription: `You pass by ${activeLandmark.name} and head toward the border.`,
+      })
+
       return {
         character: characterWithUpdatedState,
         event: {
@@ -137,16 +169,7 @@ export async function moveForwardService(
               failureEffects: {},
               resultDescription: `You explore ${activeLandmark.name}.`,
             },
-            {
-              id: 'bypass-landmark',
-              text: 'Pass by without stopping',
-              successProbability: 1.0,
-              successDescription: `You leave ${activeLandmark.name} behind and continue on your journey.`,
-              successEffects: {},
-              failureDescription: '',
-              failureEffects: {},
-              resultDescription: `You pass by ${activeLandmark.name}.`,
-            },
+            ...bypassOptions,
           ],
           resolved: false,
         },

--- a/src/app/tap-tap-adventure/hooks/useGameStore.ts
+++ b/src/app/tap-tap-adventure/hooks/useGameStore.ts
@@ -254,6 +254,17 @@ export const useGameStore = create<GameStore>()(
               distance: newDistance,
             }, 1, metaBonuses)
 
+            // Increment positionInRegion so TargetList shows correct distance
+            if (updatedCharacter.landmarkState) {
+              updatedCharacter = {
+                ...updatedCharacter,
+                landmarkState: {
+                  ...updatedCharacter.landmarkState,
+                  positionInRegion: (updatedCharacter.landmarkState.positionInRegion ?? 0) + 1,
+                },
+              }
+            }
+
             // Mount daily upkeep: deduct gold when a new day boundary is crossed
             const oldDay = calculateDay(oldDistance)
             const newDay = calculateDay(newDistance)

--- a/src/app/tap-tap-adventure/hooks/useResolveDecisionMutation.ts
+++ b/src/app/tap-tap-adventure/hooks/useResolveDecisionMutation.ts
@@ -49,16 +49,30 @@ export function useResolveDecisionMutation() {
       if (!character) throw new Error('No character found')
 
       // Handle landmark bypass client-side — just increment the index and continue
-      if (optionId === 'bypass-landmark') {
+      if (optionId === 'bypass-landmark' || optionId.startsWith('bypass-toward-')) {
         const landmarkState = character.landmarkState
         if (landmarkState) {
           const bypassedLandmark = landmarkState.landmarks[landmarkState.nextLandmarkIndex]
           const landmarkName = bypassedLandmark?.name ?? 'the landmark'
           const newNextLandmarkIndex = landmarkState.nextLandmarkIndex + 1
-          const newActiveTargetIndex = Math.min(
-            newNextLandmarkIndex,
-            landmarkState.landmarks.length
-          )
+
+          // Determine target based on which direction was chosen
+          let newActiveTargetIndex: number
+          if (optionId.startsWith('bypass-toward-')) {
+            const targetPart = optionId.replace('bypass-toward-', '')
+            if (targetPart === 'exit') {
+              newActiveTargetIndex = landmarkState.landmarks.length
+            } else {
+              newActiveTargetIndex = parseInt(targetPart, 10)
+            }
+          } else {
+            // Original bypass-landmark behavior: go to next target
+            newActiveTargetIndex = Math.min(
+              newNextLandmarkIndex,
+              landmarkState.landmarks.length
+            )
+          }
+
           updateSelectedCharacter({
             landmarkState: {
               ...landmarkState,
@@ -76,7 +90,7 @@ export function useResolveDecisionMutation() {
             timestamp: new Date().toISOString(),
             selectedOptionId: optionId,
             selectedOptionText: chosenOption?.text ?? 'Pass by without stopping',
-            outcomeDescription: `You pass by ${landmarkName} without stopping and continue your journey.`,
+            outcomeDescription: `You pass by ${landmarkName} and continue your journey.`,
           })
           commit()
           onSuccess?.()


### PR DESCRIPTION
## Summary
Fixes two critical spatial world bugs:

- **#286 — Steps now decrease distance to target**: `incrementDistance()` was only updating `character.distance` but not `landmarkState.positionInRegion`. Since 97% of non-milestone taps use the client-side `incrementDistance()` optimization, the TargetList was never seeing movement progress. Now `positionInRegion` is incremented alongside distance.

- **#287 — Exits are now directional choices**: Landmark arrival decisions now show directional bypass options instead of a single "Pass by without stopping." Each remaining landmark and the region exit are listed with icon, name, and step count (e.g. "🏰 Head toward Ruined Tower (35 steps)"). The chosen direction sets `activeTargetIndex` so the player walks toward their selected destination.

## Changes
- `src/app/tap-tap-adventure/hooks/useGameStore.ts` — `incrementDistance()` also increments `positionInRegion`
- `src/app/api/v1/tap-tap-adventure/move-forward/services/moveForwardService.ts` — Build directional bypass options at landmark arrival
- `src/app/tap-tap-adventure/hooks/useResolveDecisionMutation.ts` — Handle `bypass-toward-{index}` and `bypass-toward-exit` option IDs

## Test plan
- [ ] Tap travel repeatedly — the step count in TargetList should decrease on EVERY tap, not just on server calls
- [ ] Arrive at a landmark — should see "Explore [name]" plus directional options like "Head toward [next landmark] (X steps)" and "Head toward border (X steps)"
- [ ] Choose a directional bypass — should skip the landmark and set the chosen target as active
- [ ] All 736 existing tests pass

Closes #286
Closes #287

🤖 Generated with [Claude Code](https://claude.com/claude-code)