### PR TITLE
feat: weapon on-hit effects in combat (Magic Items Phase 2)

### DIFF
--- a/src/app/tap-tap-adventure/lib/combatEngine.ts
+++ b/src/app/tap-tap-adventure/lib/combatEngine.ts
@@ -14,6 +14,7 @@ import {
   CombatPlayerState,
   CombatState,
   EnemyTelegraph,
+  StatusEffect,
   TurnPhase,
 } from '@/app/tap-tap-adventure/models/combat'
 import { Item } from '@/app/tap-tap-adventure/models/item'
@@ -37,10 +38,12 @@ import {
 import {
   applyStatusEffect,
   checkFearSkip,
+  checkStunSkip,
   createStatusEffectFromAbility,
   getBerserkAttackMultiplier,
   getBerserkDefenseMultiplier,
   getBurnDefenseMultiplier,
+  getFreezeMultiplier,
   getSlowMultiplier,
   getThornsDamage,
   hasStatusEffect,
@@ -295,6 +298,7 @@ export function calculateEnemyDamage(
       .filter(b => b.stat === 'defense')
       .reduce((sum, b) => sum + b.value, 0)
   const slowMultiplier = getSlowMultiplier(enemy.statusEffects)
+  const freezeMultiplier = getFreezeMultiplier(enemy.statusEffects)
 
   const defenseElement = character
     ? getClassElement(character.class, character.classData)
@@ -308,7 +312,7 @@ export function calculateEnemyDamage(
     : enemy.element === 'lightning' ? enemyWeatherMods.lightningMultiplier
     : 1.0
 
-  const attackPower = (isHeavyAttack ? enemy.attack * 1.5 : enemy.attack) * slowMultiplier * elementalMultiplier * enemyWeatherElementalBoost
+  const attackPower = (isHeavyAttack ? enemy.attack * 1.5 : enemy.attack) * slowMultiplier * freezeMultiplier * elementalMultiplier * enemyWeatherElementalBoost
   const raw = randomVariance(attackPower) - buffedDefense
 
   // Enemy critical strike check
@@ -637,6 +641,116 @@ function checkBossPhaseChange(
   }
 }
 
+/**
+ * Apply weapon on-hit effects after a successful attack.
+ * Returns updated enemy, playerState, and combat log entries.
+ */
+function applyWeaponOnHitEffect(
+  weapon: Item,
+  enemy: CombatEnemy,
+  playerState: CombatPlayerState,
+  damageDealt: number,
+  turnNumber: number
+): { enemy: CombatEnemy; playerState: CombatPlayerState; logs: CombatLogEntry[] } {
+  const logs: CombatLogEntry[] = []
+  const onHit = weapon.onHitEffect
+  if (!onHit || damageDealt <= 0) return { enemy, playerState, logs }
+
+  if (Math.random() >= onHit.chance) return { enemy, playerState, logs }
+
+  const effectDamage = onHit.damage ?? 0
+  const effectDuration = onHit.duration ?? 2
+
+  switch (onHit.type) {
+    case 'poison':
+    case 'burn':
+    case 'bleed': {
+      const typeNames = { poison: 'Poisoned', burn: 'Burning', bleed: 'Bleeding' }
+      const effect: StatusEffect = {
+        id: `weapon-${onHit.type}-${Date.now()}`,
+        name: typeNames[onHit.type],
+        type: onHit.type,
+        value: effectDamage,
+        turnsRemaining: effectDuration,
+        source: 'player',
+      }
+      enemy = {
+        ...enemy,
+        statusEffects: applyStatusEffect(enemy.statusEffects ?? [], effect),
+      }
+      logs.push({
+        turn: turnNumber,
+        actor: 'player',
+        action: 'status_effect',
+        description: `Your weapon inflicts ${typeNames[onHit.type].toLowerCase()} on ${enemy.name}! (${effectDamage} damage/turn for ${effectDuration} turns)`,
+      })
+      break
+    }
+    case 'freeze': {
+      const effect: StatusEffect = {
+        id: `weapon-freeze-${Date.now()}`,
+        name: 'Frozen',
+        type: 'freeze',
+        value: effectDamage,
+        turnsRemaining: effectDuration,
+        source: 'player',
+      }
+      enemy = {
+        ...enemy,
+        statusEffects: applyStatusEffect(enemy.statusEffects ?? [], effect),
+      }
+      logs.push({
+        turn: turnNumber,
+        actor: 'player',
+        action: 'status_effect',
+        description: `Your weapon freezes ${enemy.name}! Attack power reduced by 50% for ${effectDuration} turns.`,
+      })
+      break
+    }
+    case 'stun': {
+      const effect: StatusEffect = {
+        id: `weapon-stun-${Date.now()}`,
+        name: 'Stunned',
+        type: 'stun',
+        value: 1,
+        turnsRemaining: 1, // Stun always lasts 1 turn
+        source: 'player',
+      }
+      enemy = {
+        ...enemy,
+        statusEffects: applyStatusEffect(enemy.statusEffects ?? [], effect),
+      }
+      logs.push({
+        turn: turnNumber,
+        actor: 'player',
+        action: 'status_effect',
+        description: `Your weapon stuns ${enemy.name}! They will skip their next action.`,
+      })
+      break
+    }
+    case 'lifesteal': {
+      const healAmount = Math.max(1, Math.floor(damageDealt * 0.2))
+      const oldHp = playerState.hp
+      playerState = {
+        ...playerState,
+        hp: Math.min(playerState.maxHp, playerState.hp + healAmount),
+      }
+      const actualHeal = playerState.hp - oldHp
+      if (actualHeal > 0) {
+        logs.push({
+          turn: turnNumber,
+          actor: 'player',
+          action: 'heal',
+          description: `Your weapon drains life from ${enemy.name}, restoring ${actualHeal} HP!`,
+        })
+      }
+      break
+    }
+  }
+
+  return { enemy, playerState, logs }
+}
+
 export function processPlayerAction(
   combatState: CombatState,
   action: CombatActionRequest,
@@ -772,6 +886,13 @@ export function processPlayerAction(
         const damage = Math.max(1, Math.round(rawAtkDmg * wRangeMult) + aggressiveBonus)
         enemy.hp = Math.max(0, enemy.hp - damage)
         playerState.comboCount = (playerState.comboCount ?? 0) + 1
+        // Apply weapon on-hit effects
+        if (character.equipment?.weapon?.onHitEffect) {
+          const onHitResult = applyWeaponOnHitEffect(character.equipment.weapon, enemy, playerState, damage, turnNumber)
+          enemy = onHitResult.enemy
+          playerState = onHitResult.playerState
+          newLogs.push(...onHitResult.logs)
+        }
         const comboText =
           playerState.comboCount > 1 ? ` (${playerState.comboCount}x combo!)` : ''
         const elemText = getEffectivenessText(elementalMultiplier)
@@ -806,6 +927,13 @@ export function processPlayerAction(
         const damage = Math.max(1, Math.round(baseDmg * 1.8 * heavyWRangeMult) + heavyAggressiveBonus)
         enemy.hp = Math.max(0, enemy.hp - damage)
         playerState.comboCount = (playerState.comboCount ?? 0) + 1
+        // Apply weapon on-hit effects
+        if (character.equipment?.weapon?.onHitEffect) {
+          const onHitResult = applyWeaponOnHitEffect(character.equipment.weapon, enemy, playerState, damage, turnNumber)
+          enemy = onHitResult.enemy
+          playerState = onHitResult.playerState
+          newLogs.push(...onHitResult.logs)
+        }
         const comboText = playerState.comboCount > 1 ? ` (${playerState.comboCount}x combo!)` : ''
         const elemText = getEffectivenessText(elementalMultiplier)
         newLogs.push({
@@ -1164,8 +1292,16 @@ export function processPlayerAction(
   // Execute enemy's telegraphed action (or normal attack if no telegraph)
   // Check fear: 50% chance to skip action
   const enemyFeared = checkFearSkip(enemy.statusEffects)
+  const enemyStatusStunned = checkStunSkip(enemy.statusEffects)
   if (playerState.enemyStunned) {
     playerState.enemyStunned = false
+    newLogs.push({
+      turn: turnNumber,
+      actor: 'enemy',
+      action: 'stunned',
+      description: `${enemy.name} is stunned and cannot act!`,
+    })
+  } else if (enemyStatusStunned) {
     newLogs.push({
       turn: turnNumber,
       actor: 'enemy',

--- a/src/app/tap-tap-adventure/lib/statusEffects.ts
+++ b/src/app/tap-tap-adventure/lib/statusEffects.ts
@@ -98,6 +98,11 @@ export function tickStatusEffects(
         logs.push({ turn: turnNumber, actor: 'player', action: 'status_effect', damage: effect.value, description: `${updatedEnemy.name} takes ${effect.value} burn damage! Their defense is reduced by 20%.` })
         break
       }
+      case 'bleed': {
+        updatedEnemy = { ...updatedEnemy, hp: Math.max(0, updatedEnemy.hp - effect.value) }
+        logs.push({ turn: turnNumber, actor: 'player', action: 'status_effect', damage: effect.value, description: `${updatedEnemy.name} takes ${effect.value} bleed damage!` })
+        break
+      }
     }
   }
 
@@ -168,6 +173,15 @@ export function processReflect(
   return { reflectedDamage, updatedEffects: removeExpiredEffects(updatedEffects) }
 }
 
+export function getFreezeMultiplier(statusEffects: StatusEffect[] | undefined): number {
+  return hasStatusEffect(statusEffects, 'freeze') ? 0.5 : 1
+}
+
+export function checkStunSkip(statusEffects: StatusEffect[] | undefined): boolean {
+  if (!hasStatusEffect(statusEffects, 'stun')) return false
+  return true // stun always prevents action (unlike fear which is 50%)
+}
+
 export function createStatusEffectFromAbility(
   type: StatusEffectType,
   value: number,
@@ -183,6 +197,9 @@ export function createStatusEffectFromAbility(
     berserk: 'Berserk',
     fear: 'Feared',
     reflect: 'Reflecting',
+    freeze: 'Frozen',
+    stun: 'Stunned',
+    bleed: 'Bleeding',
   }
 
   return {

--- a/src/app/tap-tap-adventure/models/combat.ts
+++ b/src/app/tap-tap-adventure/models/combat.ts
@@ -12,6 +12,9 @@ export const StatusEffectTypeSchema = z.enum([
   'berserk',
   'fear',
   'reflect',
+  'freeze',
+  'stun',
+  'bleed',
 ])
 export type StatusEffectType = z.infer<typeof StatusEffectTypeSchema>
 


### PR DESCRIPTION
## Summary
Phase 2 of #277 — integrates on-hit effects from equipped weapons into the combat engine. Weapons with `onHitEffect` now proc during attacks, making the rarity system functionally meaningful in combat.

- **6 on-hit types**: poison, burn, bleed (DoT), freeze (50% attack debuff), stun (skip enemy turn), lifesteal (heal 20% of damage)
- **New status effects**: `freeze`, `stun`, `bleed` added to the combat status effect schema
- **Combat integration**: `applyWeaponOnHitEffect()` hooks into both `attack` and `heavy_attack` actions after damage is dealt
- **Enemy turn effects**: stun check added alongside fear check; freeze multiplier applied to enemy damage calculation
- **DoT ticks**: bleed ticks each turn like poison/burn in `tickStatusEffects()`

## Changes
- `src/app/tap-tap-adventure/models/combat.ts` — Add freeze/stun/bleed to StatusEffectTypeSchema
- `src/app/tap-tap-adventure/lib/statusEffects.ts` — Bleed tick, freeze/stun helpers, effect names
- `src/app/tap-tap-adventure/lib/combatEngine.ts` — `applyWeaponOnHitEffect()` function + hooks in attack/heavy_attack + enemy stun/freeze handling

## Test plan
- [ ] All 736 existing tests pass
- [ ] Equip a weapon with on-hit effect (e.g. Epic heirloom with bleed) → attack enemy → on-hit should proc based on chance
- [ ] Poison/burn/bleed: enemy takes DoT damage each turn
- [ ] Freeze: enemy deals reduced damage while frozen
- [ ] Stun: enemy skips their next action
- [ ] Lifesteal: player heals when the effect procs
- [ ] Combat log shows descriptive messages for each proc

🤖 Generated with [Claude Code](https://claude.com/claude-code)