### PR TITLE
feat: drawback penalties and rarity-weighted loot (Magic Items Phase 3)

### DIFF
--- a/src/app/tap-tap-adventure/hooks/useGameStore.ts
+++ b/src/app/tap-tap-adventure/hooks/useGameStore.ts
@@ -562,7 +562,18 @@ export const useGameStore = create<GameStore>()(
               updatedInventory = [...updatedInventory, currentlyEquipped]
             }
 
-            state.gameState.characters[characterIndex] = {
+            // Apply drawback from new item, reverse drawback from old item
+            let statAdjustments: Record<string, number> = {}
+            if (item.drawback) {
+              const stat = item.drawback.stat
+              statAdjustments[stat] = (statAdjustments[stat] ?? 0) + item.drawback.value
+            }
+            if (currentlyEquipped?.drawback) {
+              const stat = currentlyEquipped.drawback.stat
+              statAdjustments[stat] = (statAdjustments[stat] ?? 0) - currentlyEquipped.drawback.value // reverse: subtract the negative = add
+            }
+
+            const charWithEquipment = {
               ...selectedCharacter,
               inventory: updatedInventory,
               equipment: {
@@ -570,6 +581,15 @@ export const useGameStore = create<GameStore>()(
                 [targetSlot]: item,
               },
             }
+
+            // Apply stat adjustments
+            for (const [stat, adjustment] of Object.entries(statAdjustments)) {
+              if (stat in charWithEquipment && typeof (charWithEquipment as Record<string, unknown>)[stat] === 'number') {
+                (charWithEquipment as unknown as Record<string, number>)[stat] = Math.max(0, ((charWithEquipment as unknown as Record<string, number>)[stat] ?? 0) + adjustment)
+              }
+            }
+
+            state.gameState.characters[characterIndex] = charWithEquipment
           })
         )
       },
@@ -588,7 +608,7 @@ export const useGameStore = create<GameStore>()(
             const equippedItem = equipment[slot]
             if (!equippedItem) return
 
-            state.gameState.characters[characterIndex] = {
+            const updatedChar = {
               ...selectedCharacter,
               inventory: [...selectedCharacter.inventory, equippedItem],
               equipment: {
@@ -596,6 +616,16 @@ export const useGameStore = create<GameStore>()(
                 [slot]: null,
               },
             }
+
+            // Reverse drawback from unequipped item
+            if (equippedItem.drawback) {
+              const stat = equippedItem.drawback.stat
+              if (stat in updatedChar && typeof (updatedChar as Record<string, unknown>)[stat] === 'number') {
+                (updatedChar as unknown as Record<string, number>)[stat] = Math.max(0, ((updatedChar as unknown as Record<string, number>)[stat] ?? 0) - equippedItem.drawback.value) // subtract negative = add back
+              }
+            }
+
+            state.gameState.characters[characterIndex] = updatedChar
           })
         )
       },

--- a/src/app/tap-tap-adventure/lib/combatEngine.ts
+++ b/src/app/tap-tap-adventure/lib/combatEngine.ts
@@ -1727,6 +1727,29 @@ export function getCombatRewards(
     }
   }
 
+  // Assign rarity to loot items that don't have one
+  const rarityWeights = combatState.isBoss
+    ? { common: 0, uncommon: 0.2, rare: 0.4, epic: 0.3, legendary: 0.1 }
+    : combatState.isMiniBoss
+      ? { common: 0.1, uncommon: 0.3, rare: 0.4, epic: 0.15, legendary: 0.05 }
+      : { common: 0.5, uncommon: 0.3, rare: 0.15, epic: 0.04, legendary: 0.01 }
+
+  function rollRarity(weights: Record<string, number>): string {
+    const roll = Math.random()
+    let cumulative = 0
+    for (const [rarity, weight] of Object.entries(weights)) {
+      cumulative += weight
+      if (roll < cumulative) return rarity
+    }
+    return 'common'
+  }
+
+  for (let i = 0; i < loot.length; i++) {
+    if (!loot[i].rarity) {
+      loot[i] = { ...loot[i], rarity: rollRarity(rarityWeights) as Item['rarity'] }
+    }
+  }
+
   // Regular (non-boss) enemies have a chance to drop a spell scroll
   if (!combatState.isBoss) {
     const spellDropChance = 0.05 + character.level * 0.01
@@ -1740,6 +1763,7 @@ export function getCombatRewards(
         quantity: 1,
         type: 'spell_scroll',
         spell,
+        rarity: 'rare', // Spell scrolls are always rare quality
       })
     }
   }

--- a/src/app/tap-tap-adventure/lib/combatGenerator.ts
+++ b/src/app/tap-tap-adventure/lib/combatGenerator.ts
@@ -43,6 +43,7 @@ const enemySchemaForOpenAI = {
               description: { type: 'string' },
               quantity: { type: 'number' },
               type: { type: 'string', enum: ['consumable', 'equipment', 'quest', 'misc'] },
+              rarity: { type: 'string', enum: ['common', 'uncommon', 'rare', 'epic', 'legendary'] },
               effects: {
                 type: 'object',
                 properties: {


### PR DESCRIPTION
## Summary
Completes the core magic items feature (#277) — items now have meaningful tradeoffs and combat loot has rarity-appropriate drops.

- **Drawback penalties**: Equipping an item with a `drawback` applies its stat penalty (e.g., -2 luck). Unequipping reverses it. Swapping items handles both old/new drawbacks correctly. Stats clamped to 0 minimum.
- **Rarity-weighted loot**: Combat rewards now assign rarity based on enemy type:
  - Bosses: 0% common, 20% uncommon, 40% rare, 30% epic, 10% legendary
  - Mini-bosses: 10% common, 30% uncommon, 40% rare, 15% epic, 5% legendary
  - Regular enemies: 50% common, 30% uncommon, 15% rare, 4% epic, 1% legendary
- **Spell scrolls**: Always drop as rare quality
- **LLM loot generation**: Added rarity to the OpenAI schema so AI-generated loot includes rarity

## Changes
- `src/app/tap-tap-adventure/hooks/useGameStore.ts` — equipItem/unequipItem handle drawback stat adjustments
- `src/app/tap-tap-adventure/lib/combatEngine.ts` — getCombatRewards assigns rarity via weighted roll
- `src/app/tap-tap-adventure/lib/combatGenerator.ts` — Added rarity to LLM loot schema

## Test plan
- [ ] All 736 existing tests pass
- [ ] Equip an item with a drawback → character stat should decrease
- [ ] Unequip the same item → character stat should restore
- [ ] Swap two items where both have drawbacks → stats adjust correctly
- [ ] Win combat against a boss → loot should have higher rarity (uncommon+)
- [ ] Win combat against regular enemy → loot is mostly common/uncommon
- [ ] Spell scroll drops show as rare in inventory

## Magic Items Feature Status (#277)
- [x] Phase 1: Schema + rarity UI + generation (PR #285, merged)
- [x] Phase 2: On-hit combat effects (PR #289, merged)
- [x] Phase 3: Drawback penalties + loot rarity (this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)