### PR TITLE
feat: exploration spells — cast spells outside combat

### DIFF
--- a/src/app/tap-tap-adventure/components/ExplorationSpellsPanel.tsx
+++ b/src/app/tap-tap-adventure/components/ExplorationSpellsPanel.tsx
@@ -1,0 +1,79 @@
+'use client'
+import { useState, useCallback } from 'react'
+
+import { Button } from '@/app/tap-tap-adventure/components/ui/button'
+import { useGameStore } from '@/app/tap-tap-adventure/hooks/useGameStore'
+import { Spell } from '@/app/tap-tap-adventure/models/spell'
+
+export function ExplorationSpellsPanel() {
+  const character = useGameStore(s => s.gameState.characters.find(c => c.id === s.gameState.selectedCharacterId))
+  const { castExplorationSpell } = useGameStore()
+  const [feedbackMessage, setFeedbackMessage] = useState<string | null>(null)
+  const [feedbackSuccess, setFeedbackSuccess] = useState(true)
+
+  const spellbook = character?.spellbook ?? []
+  const explorationSpells = spellbook.filter(s => s.explorationEffect)
+  const currentMana = character?.mana ?? 0
+
+  const handleCast = useCallback((spellId: string) => {
+    const result = castExplorationSpell(spellId)
+    if (result) {
+      setFeedbackMessage(result.message)
+      setFeedbackSuccess(result.success)
+      setTimeout(() => setFeedbackMessage(null), 3000)
+    }
+  }, [castExplorationSpell])
+
+  if (explorationSpells.length === 0) {
+    return (
+      <div className="text-sm text-slate-500 italic p-2">
+        No exploration spells available. Some spells can be cast outside combat — look for spells with exploration effects.
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center justify-between mb-1">
+        <h4 className="text-sm font-semibold text-white">Exploration Spells</h4>
+        <span className="text-xs text-blue-300">{currentMana} MP available</span>
+      </div>
+      {feedbackMessage && (
+        <div className={`p-2 rounded-md text-sm animate-pulse ${feedbackSuccess ? 'bg-green-900/50 border border-green-700 text-green-300' : 'bg-red-900/50 border border-red-700 text-red-300'}`}>
+          {feedbackMessage}
+        </div>
+      )}
+      {explorationSpells.map((spell: Spell) => {
+        const manaCost = spell.explorationManaCost ?? spell.manaCost
+        const canCast = currentMana >= manaCost
+        const effect = spell.explorationEffect!
+        return (
+          <div
+            key={spell.id}
+            className="bg-[#1e1f30] border border-[#3a3c56] p-3 rounded-lg"
+          >
+            <div className="flex items-center justify-between mb-1">
+              <span className="font-bold text-sm text-white">{spell.name}</span>
+              <span className={`text-xs ${canCast ? 'text-blue-300' : 'text-red-400'}`}>
+                {manaCost} MP
+              </span>
+            </div>
+            <p className="text-xs text-violet-400 capitalize mb-1">{spell.school}</p>
+            <p className="text-xs text-slate-400 mb-2">{effect.description}</p>
+            <Button
+              className={`w-full text-sm py-2 rounded-md transition-colors ${
+                canCast
+                  ? 'bg-violet-700 hover:bg-violet-800 text-white'
+                  : 'bg-[#2a2b3f] text-slate-500 cursor-not-allowed'
+              }`}
+              onClick={() => canCast && handleCast(spell.id)}
+              disabled={!canCast}
+            >
+              {canCast ? `Cast ${effect.type === 'heal' ? '❤️' : effect.type === 'mana_restore' ? '💎' : '⚡'} ${effect.type.replace('_', ' ')}` : 'Not enough mana'}
+            </Button>
+          </div>
+        )
+      })}
+    </div>
+  )
+}

--- a/src/app/tap-tap-adventure/components/GameUI.tsx
+++ b/src/app/tap-tap-adventure/components/GameUI.tsx
@@ -43,6 +43,7 @@ import { FactionPanel } from './FactionPanel'
 import AdventureLeaderboard from './AdventureLeaderboard'
 import { CraftingPanel } from './CraftingPanel'
 import { EnchantingPanel } from './EnchantingPanel'
+import { ExplorationSpellsPanel } from './ExplorationSpellsPanel'
 import { BestiaryPanel } from './BestiaryPanel'
 import { DailyChallengesPanel } from './DailyChallengesPanel'
 import { NPCDialoguePanel } from './NPCDialoguePanel'
@@ -109,7 +110,7 @@ function getTravelButtonMessage({ isLoading, distance }: { isLoading: boolean; d
   return 'Continue Travelling'
 }
 type MobileCategory = 'gear' | 'quest' | 'social' | 'more' | null
-type GearSubTab = 'equipment' | 'inventory' | 'crafting' | 'enchant'
+type GearSubTab = 'equipment' | 'inventory' | 'crafting' | 'enchant' | 'spells'
 type QuestSubTab = 'quests' | 'map' | 'bestiary'
 type SocialSubTab = 'party' | 'factions' | 'npc' | 'leaderboard'
 type MoreSubTab = 'status' | 'history' | 'base' | 'settings'
@@ -713,6 +714,9 @@ export default function GameUI({ onOpenStatus }: GameUIProps) {
               <EnchantingPanel />
             </div>
             <div className="border-t border-[#3a3c56] pt-4">
+              <ExplorationSpellsPanel />
+            </div>
+            <div className="border-t border-[#3a3c56] pt-4">
               <SettingsPanel />
             </div>
             <div className="border-t border-[#3a3c56] pt-4">
@@ -742,6 +746,7 @@ export default function GameUI({ onOpenStatus }: GameUIProps) {
                 { id: 'inventory' as GearSubTab, label: 'Items' },
                 { id: 'crafting' as GearSubTab, label: 'Craft' },
                 { id: 'enchant' as GearSubTab, label: 'Enchant' },
+                { id: 'spells' as GearSubTab, label: 'Spells' },
               ]).map(t => (
                 <button key={t.id} onClick={() => setGearSubTab(t.id)}
                   className={`flex-1 text-xs py-1.5 px-2 rounded-md transition-colors ${gearSubTab === t.id ? 'bg-indigo-600 text-white' : 'text-slate-400 hover:text-white'}`}
@@ -792,6 +797,7 @@ export default function GameUI({ onOpenStatus }: GameUIProps) {
             )}
             {mobileCategory === 'gear' && gearSubTab === 'crafting' && <CraftingPanel />}
             {mobileCategory === 'gear' && gearSubTab === 'enchant' && <EnchantingPanel />}
+            {mobileCategory === 'gear' && gearSubTab === 'spells' && <ExplorationSpellsPanel />}
 
             {/* Quest panels */}
             {mobileCategory === 'quest' && questSubTab === 'quests' && (

--- a/src/app/tap-tap-adventure/hooks/useGameStore.ts
+++ b/src/app/tap-tap-adventure/hooks/useGameStore.ts
@@ -140,6 +140,7 @@ export interface GameStore {
   claimDailyChallengeBonus: () => { gold: number; reputation: number } | null
   recordNPCEncounter: (npcId: string, dispositionDelta: number, reward?: { gold?: number; reputation?: number }) => void
   setActiveTarget: (index: number) => void
+  castExplorationSpell: (spellId: string) => { message: string; success: boolean } | null
 }
 
 export const useGameStore = create<GameStore>()(
@@ -1239,6 +1240,79 @@ export const useGameStore = create<GameStore>()(
             state.gameState.characters[charIndex].landmarkState = { ...ls, activeTargetIndex: index }
           })
         )
+      },
+      castExplorationSpell: (spellId: string) => {
+        const character = get().getSelectedCharacter()
+        if (!character) return null
+
+        const spell = (character.spellbook ?? []).find(s => s.id === spellId)
+        if (!spell?.explorationEffect) return { message: 'This spell has no exploration effect.', success: false }
+
+        const manaCost = spell.explorationManaCost ?? spell.manaCost
+        const currentMana = character.mana ?? 0
+        if (currentMana < manaCost) {
+          return { message: `Not enough mana! Need ${manaCost} MP, have ${currentMana} MP.`, success: false }
+        }
+
+        const effect = spell.explorationEffect
+        let message = ''
+        const updates: Partial<typeof character> = {
+          mana: currentMana - manaCost,
+        }
+
+        switch (effect.type) {
+          case 'heal': {
+            const maxHp = character.maxHp ?? 100
+            const currentHp = character.hp ?? maxHp
+            const healAmount = Math.min(effect.value, maxHp - currentHp)
+            if (healAmount <= 0) {
+              return { message: 'Already at full health!', success: false }
+            }
+            updates.hp = currentHp + healAmount
+            message = `${spell.name}: Restored ${healAmount} HP! (${manaCost} MP spent)`
+            break
+          }
+          case 'mana_restore': {
+            // Mana restore costs mana but restores more — net positive
+            const maxMana = character.maxMana ?? 20
+            const netRestore = effect.value - manaCost
+            if (netRestore <= 0) {
+              return { message: 'This spell would not restore net mana.', success: false }
+            }
+            const newMana = Math.min(maxMana, currentMana + effect.value - manaCost)
+            updates.mana = newMana
+            message = `${spell.name}: Restored ${netRestore} mana! (net gain)`
+            break
+          }
+          case 'speed_boost': {
+            // Advance positionInRegion
+            if (!character.landmarkState) {
+              return { message: 'No active travel to speed up.', success: false }
+            }
+            const ls = character.landmarkState
+            const newPosition = (ls.positionInRegion ?? 0) + effect.value
+            updates.landmarkState = {
+              ...ls,
+              positionInRegion: newPosition,
+            }
+            updates.distance = (character.distance ?? 0) + effect.value
+            message = `${spell.name}: Advanced ${effect.value} steps! (${manaCost} MP spent)`
+            break
+          }
+        }
+
+        set(
+          produce((state: GameStore) => {
+            const charIndex = state.gameState.characters.findIndex(c => c.id === character.id)
+            if (charIndex === -1) return
+            state.gameState.characters[charIndex] = {
+              ...state.gameState.characters[charIndex],
+              ...updates,
+            }
+          })
+        )
+
+        return { message, success: true }
       },
     }),
     {

--- a/src/app/tap-tap-adventure/lib/spellGenerator.ts
+++ b/src/app/tap-tap-adventure/lib/spellGenerator.ts
@@ -1,4 +1,4 @@
-import { Spell, SpellEffect, SpellSchool, SpellElement, SpellCondition } from '@/app/tap-tap-adventure/models/spell'
+import { Spell, SpellEffect, SpellSchool, SpellElement, SpellCondition, ExplorationEffect } from '@/app/tap-tap-adventure/models/spell'
 
 const SPELL_NAMES: Record<string, string[]> = {
   arcane: ['Arcane Missile', 'Mana Surge', 'Ethereal Lance', 'Astral Barrage', 'Void Bolt'],
@@ -147,6 +147,32 @@ export function generateSpellForLevel(level: number, school?: SpellSchool): Spel
 
   const suffix = `${Date.now()}-${Math.floor(Math.random() * 10000)}`
 
+  // 30% chance for an exploration effect
+  let explorationEffect: ExplorationEffect | undefined
+  let explorationManaCost: number | undefined
+  if (Math.random() < 0.3) {
+    const explorationTypes = [
+      {
+        type: 'heal' as const,
+        value: 10 + level * 5,
+        description: `Restores ${10 + level * 5} HP outside of combat.`,
+      },
+      {
+        type: 'mana_restore' as const,
+        value: 5 + level * 2,
+        description: `Restores ${5 + level * 2} mana outside of combat.`,
+      },
+      {
+        type: 'speed_boost' as const,
+        value: 3 + Math.floor(level / 2),
+        description: `Advances ${3 + Math.floor(level / 2)} steps toward your target.`,
+      },
+    ]
+    const chosen = pickRandom(explorationTypes)
+    explorationEffect = chosen
+    explorationManaCost = Math.max(2, Math.floor(manaCost * 0.6)) // cheaper than combat cost
+  }
+
   return {
     id: `spell-${spellSchool}-${suffix}`,
     name: `${name}${level > 3 ? ' II' : ''}${level > 7 ? 'I' : ''}`,
@@ -158,5 +184,7 @@ export function generateSpellForLevel(level: number, school?: SpellSchool): Spel
     effects,
     conditions: conditions.length > 0 ? conditions : undefined,
     tags: [spellSchool, ...tags],
+    explorationEffect,
+    explorationManaCost,
   }
 }

--- a/src/app/tap-tap-adventure/models/spell.ts
+++ b/src/app/tap-tap-adventure/models/spell.ts
@@ -73,6 +73,20 @@ export const SpellConditionSchema = z.object({
 })
 export type SpellCondition = z.infer<typeof SpellConditionSchema>
 
+export const ExplorationEffectTypeSchema = z.enum([
+  'heal',
+  'mana_restore',
+  'speed_boost',
+])
+export type ExplorationEffectType = z.infer<typeof ExplorationEffectTypeSchema>
+
+export const ExplorationEffectSchema = z.object({
+  type: ExplorationEffectTypeSchema,
+  value: z.number(),
+  description: z.string(),
+})
+export type ExplorationEffect = z.infer<typeof ExplorationEffectSchema>
+
 export const SpellSchema = z.object({
   id: z.string(),
   name: z.string(),
@@ -84,5 +98,7 @@ export const SpellSchema = z.object({
   effects: z.array(SpellEffectSchema),
   conditions: z.array(SpellConditionSchema).optional(),
   tags: z.array(z.string()),
+  explorationEffect: ExplorationEffectSchema.optional(),
+  explorationManaCost: z.number().optional(),
 })
 export type Spell = z.infer<typeof SpellSchema>


### PR DESCRIPTION
## Summary
Phase 1 of #276 — spells can now be cast during travel, not just in combat. Players spend mana to heal, restore mana, or speed-boost through the world.

- **Schema**: `explorationEffect` (heal/mana_restore/speed_boost) and `explorationManaCost` added to Spell type
- **Generation**: ~30% of generated spells include an exploration effect with reduced mana cost (60% of combat cost)
- **Casting**: `castExplorationSpell()` handles mana deduction and effect application:
  - `heal`: Restores HP (blocked at full health)
  - `mana_restore`: Net-positive mana gain (blocked if net gain is 0)
  - `speed_boost`: Advances position in region + global distance
- **UI**: New `ExplorationSpellsPanel` component shows castable spells with mana cost, effect description, and cast button. Added to desktop sidebar and mobile gear "Spells" sub-tab.

## Changes
- `src/app/tap-tap-adventure/models/spell.ts` — ExplorationEffect schema + Spell fields
- `src/app/tap-tap-adventure/lib/spellGenerator.ts` — 30% chance to add exploration effect
- `src/app/tap-tap-adventure/hooks/useGameStore.ts` — castExplorationSpell implementation
- `src/app/tap-tap-adventure/components/ExplorationSpellsPanel.tsx` — New casting UI
- `src/app/tap-tap-adventure/components/GameUI.tsx` — Integrated panel in desktop + mobile

## Test plan
- [ ] All 736 existing tests pass
- [ ] Learn a spell with exploration effect → "Spells" tab appears in gear section
- [ ] Cast heal spell → HP increases, mana decreases
- [ ] Cast mana restore → mana increases (net positive)
- [ ] Cast speed boost → steps advance toward target, position updates in TargetList
- [ ] Cast with insufficient mana → error message shown
- [ ] Cast heal at full HP → "Already at full health" message
- [ ] Spells without exploration effects don't appear in the panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)