### PR TITLE
feat: shield and reveal exploration spell effects (Complex Spells Phase 2)

### DIFF
--- a/src/app/api/v1/tap-tap-adventure/combat/start/route.ts
+++ b/src/app/api/v1/tap-tap-adventure/combat/start/route.ts
@@ -49,6 +49,11 @@ export async function POST(req: NextRequest) {
 
     const playerState = initializePlayerCombatState(character)
 
+    // Clear exploration shield — it's been consumed by combat init
+    const updatedCharacter = character.explorationShield
+      ? { ...character, explorationShield: 0 }
+      : character
+
     const combatState: CombatState = {
       id: `combat-${Date.now()}-${Math.floor(Math.random() * 10000)}`,
       eventId: `event-combat-${Date.now()}`,
@@ -65,7 +70,7 @@ export async function POST(req: NextRequest) {
       ...(pendingRegionId ? { pendingRegionId } : {}),
     }
 
-    return NextResponse.json({ combatState })
+    return NextResponse.json({ combatState, updatedCharacter: character.explorationShield ? updatedCharacter : undefined })
   } catch (err) {
     console.error('Error starting combat', err)
     return NextResponse.json(

--- a/src/app/tap-tap-adventure/components/ExplorationSpellsPanel.tsx
+++ b/src/app/tap-tap-adventure/components/ExplorationSpellsPanel.tsx
@@ -36,7 +36,12 @@ export function ExplorationSpellsPanel() {
     <div className="space-y-2">
       <div className="flex items-center justify-between mb-1">
         <h4 className="text-sm font-semibold text-white">Exploration Spells</h4>
-        <span className="text-xs text-blue-300">{currentMana} MP available</span>
+        <div className="flex items-center gap-2">
+          {(character?.explorationShield ?? 0) > 0 && (
+            <span className="text-xs text-cyan-300">🛡️ {character!.explorationShield} shield</span>
+          )}
+          <span className="text-xs text-blue-300">{currentMana} MP available</span>
+        </div>
       </div>
       {feedbackMessage && (
         <div className={`p-2 rounded-md text-sm animate-pulse ${feedbackSuccess ? 'bg-green-900/50 border border-green-700 text-green-300' : 'bg-red-900/50 border border-red-700 text-red-300'}`}>
@@ -69,7 +74,7 @@ export function ExplorationSpellsPanel() {
               onClick={() => canCast && handleCast(spell.id)}
               disabled={!canCast}
             >
-              {canCast ? `Cast ${effect.type === 'heal' ? '❤️' : effect.type === 'mana_restore' ? '💎' : '⚡'} ${effect.type.replace('_', ' ')}` : 'Not enough mana'}
+              {canCast ? `Cast ${effect.type === 'heal' ? '❤️' : effect.type === 'mana_restore' ? '💎' : effect.type === 'speed_boost' ? '⚡' : effect.type === 'shield' ? '🛡️' : '🔮'} ${effect.type.replace(/_/g, ' ')}` : 'Not enough mana'}
             </Button>
           </div>
         )

--- a/src/app/tap-tap-adventure/hooks/useGameStore.ts
+++ b/src/app/tap-tap-adventure/hooks/useGameStore.ts
@@ -1299,6 +1299,26 @@ export const useGameStore = create<GameStore>()(
             message = `${spell.name}: Advanced ${effect.value} steps! (${manaCost} MP spent)`
             break
           }
+          case 'shield': {
+            const currentShield = character.explorationShield ?? 0
+            updates.explorationShield = currentShield + effect.value
+            message = `${spell.name}: Gained ${effect.value} shield for your next combat! (${manaCost} MP spent)`
+            break
+          }
+          case 'reveal': {
+            // Reveal info about the next landmark
+            const ls = character.landmarkState
+            if (!ls) {
+              return { message: 'No active travel — nothing to reveal.', success: false }
+            }
+            const activeIdx = ls.activeTargetIndex ?? 0
+            if (activeIdx >= ls.landmarks.length) {
+              return { message: 'No more landmarks ahead to reveal.', success: false }
+            }
+            const landmark = ls.landmarks[activeIdx]
+            message = `${spell.name}: You sense what lies ahead... ${landmark.icon} ${landmark.name} — ${landmark.encounterPrompt} (${manaCost} MP spent)`
+            break
+          }
         }
 
         set(

--- a/src/app/tap-tap-adventure/hooks/useResolveDecisionMutation.ts
+++ b/src/app/tap-tap-adventure/hooks/useResolveDecisionMutation.ts
@@ -154,6 +154,9 @@ export function useResolveDecisionMutation() {
           if (combatRes.ok) {
             const combatData = await combatRes.json()
             setCombatState(combatData.combatState)
+            if (combatData.updatedCharacter) {
+              updateSelectedCharacter(combatData.updatedCharacter)
+            }
           }
           addStoryEvent({
             id: `result-${Date.now()}`,
@@ -317,6 +320,9 @@ export function useResolveDecisionMutation() {
         if (combatRes.ok) {
           const combatData = await combatRes.json()
           setCombatState(combatData.combatState)
+          if (combatData.updatedCharacter) {
+            updateSelectedCharacter(combatData.updatedCharacter)
+          }
         }
       }
 

--- a/src/app/tap-tap-adventure/lib/combatEngine.ts
+++ b/src/app/tap-tap-adventure/lib/combatEngine.ts
@@ -128,7 +128,7 @@ export function initializePlayerCombatState(character: FantasyCharacter): Combat
     spellCooldowns: {},
     activeSpellEffects: [],
     spellTagsUsed: [],
-    shield: 0,
+    shield: character.explorationShield ?? 0,
     statusEffects: [],
     ap: MAX_AP,
     maxAp: MAX_AP,

--- a/src/app/tap-tap-adventure/lib/spellGenerator.ts
+++ b/src/app/tap-tap-adventure/lib/spellGenerator.ts
@@ -167,6 +167,16 @@ export function generateSpellForLevel(level: number, school?: SpellSchool): Spel
         value: 3 + Math.floor(level / 2),
         description: `Advances ${3 + Math.floor(level / 2)} steps toward your target.`,
       },
+      {
+        type: 'shield' as const,
+        value: 8 + level * 3,
+        description: `Grants a ${8 + level * 3} point shield that activates in your next combat.`,
+      },
+      {
+        type: 'reveal' as const,
+        value: 1,
+        description: `Reveals details about the next landmark ahead.`,
+      },
     ]
     const chosen = pickRandom(explorationTypes)
     explorationEffect = chosen

--- a/src/app/tap-tap-adventure/models/character.ts
+++ b/src/app/tap-tap-adventure/models/character.ts
@@ -50,6 +50,7 @@ export const FantasyCharacterSchema = z.object({
   pendingStatPoints: z.number().default(0),
   mana: z.number().optional(),
   maxMana: z.number().optional(),
+  explorationShield: z.number().optional(),
   spellbook: z.array(SpellSchema).optional(),
   classData: GeneratedClassSchema.optional(),
   activeMount: MountSchema.nullable().optional(),

--- a/src/app/tap-tap-adventure/models/spell.ts
+++ b/src/app/tap-tap-adventure/models/spell.ts
@@ -77,6 +77,8 @@ export const ExplorationEffectTypeSchema = z.enum([
   'heal',
   'mana_restore',
   'speed_boost',
+  'shield',
+  'reveal',
 ])
 export type ExplorationEffectType = z.infer<typeof ExplorationEffectTypeSchema>
 


### PR DESCRIPTION
## Summary
Phase 2 of #276 — adds two new exploration spell effects that bridge the gap between travel and combat.

- **Shield**: Grants a damage-absorbing shield that persists on the character until their next combat. When combat starts, the shield is applied to the player's combat state and consumed. Shield stacks if cast multiple times before combat.
- **Reveal**: Shows hidden details about the next landmark ahead (encounter prompt, type, icon). Helps players make informed decisions about whether to explore or bypass.

## Changes
- `src/app/tap-tap-adventure/models/spell.ts` — shield + reveal added to ExplorationEffectTypeSchema
- `src/app/tap-tap-adventure/models/character.ts` — explorationShield field
- `src/app/tap-tap-adventure/lib/spellGenerator.ts` — shield + reveal exploration effect templates
- `src/app/tap-tap-adventure/hooks/useGameStore.ts` — shield + reveal casting logic
- `src/app/tap-tap-adventure/lib/combatEngine.ts` — initializePlayerCombatState reads explorationShield
- `src/app/api/v1/tap-tap-adventure/combat/start/route.ts` — clears explorationShield after consuming
- `src/app/tap-tap-adventure/hooks/useResolveDecisionMutation.ts` — applies updatedCharacter from combat start
- `src/app/tap-tap-adventure/components/ExplorationSpellsPanel.tsx` — shield indicator + emoji updates

## Test plan
- [ ] All 736 existing tests pass
- [ ] Cast shield spell → "Gained X shield" message, shield icon appears in panel
- [ ] Enter combat after casting shield → player starts with shield points
- [ ] After combat, explorationShield is cleared
- [ ] Cast shield multiple times → shield stacks
- [ ] Cast reveal spell → shows landmark name, icon, and encounter details
- [ ] Cast reveal with no landmarks ahead → error message
- [ ] New spells can generate with shield/reveal exploration effects

## Complex Spells Feature Status (#276)
- [x] Phase 1: Exploration spells (heal, mana_restore, speed_boost) + UI (PR #292)
- [x] Phase 2: Shield + reveal effects with combat integration (this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)