### PR TITLE
feat: hidden landmarks revealed by exploration spells (Secret Areas Phase 1)

### DIFF
--- a/src/app/api/v1/tap-tap-adventure/move-forward/services/moveForwardService.ts
+++ b/src/app/api/v1/tap-tap-adventure/move-forward/services/moveForwardService.ts
@@ -58,18 +58,20 @@ export async function moveForwardService(
         }
       : null
 
-    // Build availableTargets for TargetList rendering
+    // Build availableTargets for TargetList rendering (hidden landmarks excluded)
     const availableTargets = [
-      ...landmarks.map((lm, i) => ({
-        index: i,
-        name: lm.name,
-        icon: lm.icon,
-        type: 'landmark' as const,
-        position: lm.distanceFromEntry,
-        distance: lm.distanceFromEntry,
-        isExplored: false,
-        hasShop: lm.hasShop,
-      })),
+      ...landmarks
+        .map((lm, i) => ({
+          index: i,
+          name: lm.name,
+          icon: lm.icon,
+          type: 'landmark' as const,
+          position: lm.distanceFromEntry,
+          distance: lm.distanceFromEntry,
+          isExplored: false,
+          hasShop: lm.hasShop,
+        }))
+        .filter((_, i) => !landmarks[i].hidden),
       {
         index: landmarks.length,
         name: `Leave ${region.name}`,
@@ -103,7 +105,7 @@ export async function moveForwardService(
     // Landmark target arrival
     const activeLandmark = landmarkState.landmarks[activeTargetIndex]
 
-    if (activeLandmark && newPositionInRegion >= activeLandmark.distanceFromEntry) {
+    if (activeLandmark && !activeLandmark.hidden && newPositionInRegion >= activeLandmark.distanceFromEntry) {
       const arrivalEventId = `landmark-arrival-${Date.now()}`
 
       const characterWithUpdatedState: FantasyCharacter = {
@@ -263,9 +265,14 @@ export async function moveForwardService(
   }
 
   // Priority 3: Compute landmark progress for non-arrival steps
+  // Find the next visible (non-hidden) target for progress display
+  let progressTargetIndex = activeTargetIndex
+  while (progressTargetIndex < landmarkState.landmarks.length && landmarkState.landmarks[progressTargetIndex]?.hidden) {
+    progressTargetIndex++
+  }
   let landmarkProgress: MoveForwardResponse['landmarkProgress'] = null
-  if (activeTargetIndex < landmarkState.landmarks.length) {
-    const nextLandmark = landmarkState.landmarks[activeTargetIndex]
+  if (progressTargetIndex < landmarkState.landmarks.length) {
+    const nextLandmark = landmarkState.landmarks[progressTargetIndex]
     const stepsRemaining = nextLandmark.distanceFromEntry - newPositionInRegion
     landmarkProgress = {
       nextLandmarkName: nextLandmark.name,

--- a/src/app/tap-tap-adventure/__tests__/landmarks.test.ts
+++ b/src/app/tap-tap-adventure/__tests__/landmarks.test.ts
@@ -27,10 +27,10 @@ function generateRegionLength(regionId: string, charId: string, visitCount: numb
 }
 
 describe('generateLandmarks', () => {
-  it('returns exactly 3 landmarks for every known region', () => {
+  it('returns exactly 4 landmarks for every known region (3 regular + 1 secret)', () => {
     for (const regionId of ALL_REGION_IDS) {
       const landmarks = generateLandmarks(regionId, 'char-1')
-      expect(landmarks).toHaveLength(3)
+      expect(landmarks).toHaveLength(4)
     }
   })
 
@@ -43,7 +43,7 @@ describe('generateLandmarks', () => {
     for (const regionId of ALL_REGION_IDS) {
       const landmarks = generateLandmarks(regionId, 'char-1')
       for (let i = 1; i < landmarks.length; i++) {
-        expect(landmarks[i].distanceFromEntry).toBeGreaterThan(landmarks[i - 1].distanceFromEntry)
+        expect(landmarks[i].distanceFromEntry).toBeGreaterThanOrEqual(landmarks[i - 1].distanceFromEntry)
       }
     }
   })

--- a/src/app/tap-tap-adventure/components/TargetList.tsx
+++ b/src/app/tap-tap-adventure/components/TargetList.tsx
@@ -6,6 +6,7 @@ interface LandmarkInfo {
   icon: string
   hasShop: boolean
   distanceFromEntry: number
+  hidden?: boolean
 }
 
 interface Target {
@@ -16,6 +17,7 @@ interface Target {
   position: number
   isExplored?: boolean
   hasShop?: boolean
+  hidden?: boolean
 }
 
 interface TargetListProps {
@@ -37,17 +39,20 @@ export function TargetList({
   onSelectTarget,
   disabled,
 }: TargetListProps) {
-  // Build target list: landmarks + region exit
+  // Build target list: landmarks + region exit (hidden landmarks are excluded from display)
   const targets: Target[] = [
-    ...landmarks.map((lm, i) => ({
-      index: i,
-      name: lm.name,
-      icon: lm.icon,
-      type: 'landmark' as const,
-      position: lm.distanceFromEntry,
-      isExplored: false,
-      hasShop: lm.hasShop,
-    })),
+    ...landmarks
+      .map((lm, i) => ({
+        index: i,
+        name: lm.name,
+        icon: lm.icon,
+        type: 'landmark' as const,
+        position: lm.distanceFromEntry,
+        isExplored: false,
+        hasShop: lm.hasShop,
+        hidden: lm.hidden ?? false,
+      }))
+      .filter(t => !t.hidden),
     {
       index: landmarks.length,
       name: regionName ? `Leave ${regionName}` : 'Leave Region',

--- a/src/app/tap-tap-adventure/config/landmarks.ts
+++ b/src/app/tap-tap-adventure/config/landmarks.ts
@@ -8,6 +8,7 @@ export interface LandmarkTemplate {
   icon: string
   hasShop: boolean
   encounterPrompt: string
+  isSecret?: boolean
 }
 
 export const LANDMARK_TEMPLATES: Record<string, LandmarkTemplate[]> = {
@@ -647,4 +648,56 @@ const GENERIC_LANDMARKS: LandmarkTemplate[] = [
 
 export function getTemplatesForRegion(regionId: string): LandmarkTemplate[] {
   return LANDMARK_TEMPLATES[regionId] ?? GENERIC_LANDMARKS
+}
+
+export const SECRET_LANDMARK_TEMPLATES: Record<string, LandmarkTemplate[]> = {
+  starting_village: [
+    { id: 'sv_hidden_cellar', name: 'Hidden Cellar', type: 'dungeon', description: 'A concealed entrance beneath the cobblestones leads to a forgotten cellar.', icon: '🕳️', hasShop: false, encounterPrompt: 'A damp cellar filled with old crates and cobwebs. Something glints in the darkness.', isSecret: true },
+  ],
+  green_meadows: [
+    { id: 'gm_fairy_ring', name: 'Fairy Ring', type: 'shrine', description: 'A circle of glowing mushrooms hidden in a meadow hollow.', icon: '🍄', hasShop: false, encounterPrompt: 'A ring of luminescent mushrooms pulses with fey energy. Tiny lights dance above the circle.', isSecret: true },
+  ],
+  dark_forest: [
+    { id: 'df_shadow_grotto', name: 'Shadow Grotto', type: 'dungeon', description: 'A cave entrance concealed by twisted roots and perpetual shadow.', icon: '🕸️', hasShop: false, encounterPrompt: 'A grotto shrouded in unnatural darkness. Strange whispers echo from within.', isSecret: true },
+  ],
+  crystal_caves: [
+    { id: 'cc_resonance_chamber', name: 'Resonance Chamber', type: 'shrine', description: 'A hidden chamber where crystals sing in perfect harmony.', icon: '🔮', hasShop: false, encounterPrompt: 'A vast chamber where crystals of every color resonate with harmonic energy. The air hums.', isSecret: true },
+  ],
+  sunken_ruins: [
+    { id: 'sr_drowned_vault', name: 'Drowned Vault', type: 'dungeon', description: 'A sealed vault deep beneath the flooded ruins.', icon: '🗝️', hasShop: false, encounterPrompt: 'An ancient vault sealed by water pressure. Inside, preserved treasures await.', isSecret: true },
+  ],
+  scorched_wastes: [
+    { id: 'sw_ember_sanctum', name: 'Ember Sanctum', type: 'shrine', description: 'A hidden temple where eternal flames guard ancient secrets.', icon: '🕯️', hasShop: false, encounterPrompt: 'A sanctum of eternal flames. Fire spirits dance between the pillars.', isSecret: true },
+  ],
+  frozen_peaks: [
+    { id: 'fp_ice_throne', name: 'Ice Throne', type: 'ruins', description: 'A frozen throne room sealed beneath the glacial ice.', icon: '🧊', hasShop: false, encounterPrompt: 'A throne of pure ice sits in a frozen chamber. An ancient power lingers here.', isSecret: true },
+  ],
+  feywild_grove: [
+    { id: 'fg_dream_pool', name: 'Dream Pool', type: 'shrine', description: 'A pool of liquid starlight hidden among the fey trees.', icon: '✨', hasShop: false, encounterPrompt: 'A pool of shimmering liquid starlight. Looking into it shows visions of other worlds.', isSecret: true },
+  ],
+  bone_wastes: [
+    { id: 'bw_ossuary', name: 'The Ossuary', type: 'dungeon', description: 'A hidden chamber of carefully arranged bones and dark rituals.', icon: '💀', hasShop: false, encounterPrompt: 'A chamber where bones are arranged in intricate patterns. Necromantic energy pulses.', isSecret: true },
+  ],
+  volcanic_forge: [
+    { id: 'vf_heart_of_fire', name: 'Heart of Fire', type: 'shrine', description: 'The molten core of the volcano, where the original forge still burns.', icon: '❤️‍🔥', hasShop: false, encounterPrompt: 'The primordial forge at the heart of the volcano. Ancient weapons and armor glow white-hot.', isSecret: true },
+  ],
+  shadow_realm: [
+    { id: 'shr_void_nexus', name: 'Void Nexus', type: 'ruins', description: 'A tear in reality where shadow and void converge.', icon: '🌀', hasShop: false, encounterPrompt: 'A nexus of swirling void energy. Reality bends and shifts around you.', isSecret: true },
+  ],
+  dragons_spine: [
+    { id: 'ds_elder_hoard', name: "Elder Dragon's Hoard", type: 'dungeon', description: 'A legendary treasure vault guarded by the eldest dragon.', icon: '🐲', hasShop: false, encounterPrompt: "Mountains of gold and artifacts fill this vast cavern. The elder dragon's presence is overwhelming.", isSecret: true },
+  ],
+  sky_citadel: [
+    { id: 'sc_astral_library', name: 'Astral Library', type: 'shrine', description: 'A library containing knowledge from across the planes.', icon: '📚', hasShop: false, encounterPrompt: 'Books float in the air, pages turning on their own. The collected knowledge of the cosmos awaits.', isSecret: true },
+  ],
+  abyssal_depths: [
+    { id: 'ad_leviathan_lair', name: "Leviathan's Lair", type: 'dungeon', description: 'The resting place of an ancient sea god.', icon: '🐙', hasShop: false, encounterPrompt: 'A massive underwater cavern where something impossibly large sleeps. Ancient power radiates from the depths.', isSecret: true },
+  ],
+  celestial_throne: [
+    { id: 'ct_genesis_chamber', name: 'Genesis Chamber', type: 'shrine', description: 'The chamber where gods shaped the world.', icon: '⚡', hasShop: false, encounterPrompt: 'A chamber of pure light where creation itself began. Divine energy is overwhelming.', isSecret: true },
+  ],
+}
+
+export function getSecretTemplatesForRegion(regionId: string): LandmarkTemplate[] {
+  return SECRET_LANDMARK_TEMPLATES[regionId] ?? []
 }

--- a/src/app/tap-tap-adventure/hooks/useGameStore.ts
+++ b/src/app/tap-tap-adventure/hooks/useGameStore.ts
@@ -266,6 +266,28 @@ export const useGameStore = create<GameStore>()(
               }
             }
 
+            // Auto-skip hidden landmarks the player has walked past
+            if (updatedCharacter.landmarkState) {
+              const ls = updatedCharacter.landmarkState
+              let idx = ls.activeTargetIndex ?? 0
+              while (
+                idx < ls.landmarks.length &&
+                ls.landmarks[idx]?.hidden &&
+                (ls.positionInRegion ?? 0) >= ls.landmarks[idx].distanceFromEntry
+              ) {
+                idx++
+              }
+              if (idx !== (ls.activeTargetIndex ?? 0)) {
+                updatedCharacter = {
+                  ...updatedCharacter,
+                  landmarkState: {
+                    ...ls,
+                    activeTargetIndex: idx,
+                  },
+                }
+              }
+            }
+
             // Mount daily upkeep: deduct gold when a new day boundary is crossed
             const oldDay = calculateDay(oldDistance)
             const newDay = calculateDay(newDistance)
@@ -1306,11 +1328,26 @@ export const useGameStore = create<GameStore>()(
             break
           }
           case 'reveal': {
-            // Reveal info about the next landmark
             const ls = character.landmarkState
             if (!ls) {
               return { message: 'No active travel — nothing to reveal.', success: false }
             }
+            // Find the nearest hidden landmark
+            const hiddenLandmarkIdx = ls.landmarks.findIndex(lm => lm.hidden)
+            if (hiddenLandmarkIdx !== -1) {
+              // Reveal the hidden landmark
+              const revealedLandmark = ls.landmarks[hiddenLandmarkIdx]
+              const updatedLandmarks = ls.landmarks.map((lm, i) =>
+                i === hiddenLandmarkIdx ? { ...lm, hidden: false } : lm
+              )
+              updates.landmarkState = {
+                ...ls,
+                landmarks: updatedLandmarks,
+              }
+              message = `${spell.name}: You sense a hidden location! ${revealedLandmark.icon} ${revealedLandmark.name} has been revealed on your map! (${manaCost} MP spent)`
+              break
+            }
+            // No hidden landmarks — fall back to showing next visible landmark info
             const activeIdx = ls.activeTargetIndex ?? 0
             if (activeIdx >= ls.landmarks.length) {
               return { message: 'No more landmarks ahead to reveal.', success: false }

--- a/src/app/tap-tap-adventure/lib/landmarkGenerator.ts
+++ b/src/app/tap-tap-adventure/lib/landmarkGenerator.ts
@@ -1,4 +1,4 @@
-import { getTemplatesForRegion, LandmarkTemplate, LandmarkType } from '../config/landmarks'
+import { getTemplatesForRegion, getSecretTemplatesForRegion, LandmarkTemplate, LandmarkType } from '../config/landmarks'
 
 export interface GeneratedLandmark {
   templateId: string
@@ -9,6 +9,7 @@ export interface GeneratedLandmark {
   hasShop: boolean
   encounterPrompt: string
   distanceFromEntry: number
+  hidden: boolean
 }
 
 // Simple string hash for seeded random
@@ -76,8 +77,32 @@ export function generateLandmarks(
       hasShop: template.hasShop,
       encounterPrompt: template.encounterPrompt,
       distanceFromEntry: currentDist,
+      hidden: false,
     })
     currentDist += 25 + Math.floor(rng() * 26) // 25-50
+  }
+
+  // Add 1 secret landmark per region (hidden until revealed)
+  const secretTemplates = getSecretTemplatesForRegion(regionId)
+  if (secretTemplates.length > 0) {
+    const secretTemplate = secretTemplates[Math.floor(rng() * secretTemplates.length)]
+    // Place secret landmark between existing landmarks (roughly middle of region)
+    const secretDist = landmarks.length > 1
+      ? Math.floor((landmarks[0].distanceFromEntry + landmarks[landmarks.length - 1].distanceFromEntry) / 2) + Math.floor(rng() * 15)
+      : 30 + Math.floor(rng() * 20)
+    landmarks.push({
+      templateId: secretTemplate.id,
+      name: secretTemplate.name,
+      type: secretTemplate.type,
+      description: secretTemplate.description,
+      icon: secretTemplate.icon,
+      hasShop: secretTemplate.hasShop,
+      encounterPrompt: secretTemplate.encounterPrompt,
+      distanceFromEntry: secretDist,
+      hidden: true,
+    })
+    // Re-sort by distance
+    landmarks.sort((a, b) => a.distanceFromEntry - b.distanceFromEntry)
   }
 
   return landmarks

--- a/src/app/tap-tap-adventure/models/character.ts
+++ b/src/app/tap-tap-adventure/models/character.ts
@@ -79,6 +79,7 @@ export const FantasyCharacterSchema = z.object({
       hasShop: z.boolean(),
       encounterPrompt: z.string(),
       distanceFromEntry: z.number(),
+      hidden: z.boolean().default(false),
     })),
     entryDistance: z.number(),
     nextLandmarkIndex: z.number(),


### PR DESCRIPTION
## Summary
Phase 1 of #278 — each region now generates 1 hidden/secret landmark alongside the 3 regular ones. Secret landmarks are invisible until revealed by the player's reveal exploration spell.

- **Secret templates**: 15 unique secret landmarks (one per region) with thematic names like Fairy Ring, Shadow Grotto, Resonance Chamber, Elder Dragon's Hoard, Genesis Chamber
- **Hidden flag**: Landmarks have a `hidden` boolean. Hidden landmarks are filtered from the TargetList and cannot be arrived at during travel
- **Auto-skip**: Movement logic automatically advances `activeTargetIndex` past hidden landmarks so the player walks past them without noticing
- **Reveal spell integration**: The reveal exploration spell now prioritizes unhiding secret landmarks. When cast, the nearest hidden landmark becomes visible on the map with a discovery message. Falls back to showing landmark info if no secrets remain
- **Seamless integration**: Once revealed, secret landmarks work exactly like regular landmarks — they can be explored, bypassed, etc.

## Changes
- `src/app/tap-tap-adventure/config/landmarks.ts` — SECRET_LANDMARK_TEMPLATES + getSecretTemplatesForRegion
- `src/app/tap-tap-adventure/lib/landmarkGenerator.ts` — Generate 1 hidden landmark per region
- `src/app/tap-tap-adventure/models/character.ts` — `hidden` field on landmark schema
- `src/app/tap-tap-adventure/components/TargetList.tsx` — Filter hidden landmarks from display
- `src/app/api/v1/tap-tap-adventure/move-forward/services/moveForwardService.ts` — Skip hidden landmarks, filter from availableTargets
- `src/app/tap-tap-adventure/hooks/useGameStore.ts` — Auto-skip hidden in incrementDistance, reveal spell unhides landmarks

## Test plan
- [ ] All 736 tests pass (updated landmark count test from 3 to 4)
- [ ] Enter a new region → TargetList shows 3 landmarks + exit (secret not visible)
- [ ] Walk past a hidden landmark's position → no arrival event triggered
- [ ] Cast reveal spell → "Hidden location revealed!" message, secret landmark appears in TargetList
- [ ] Navigate to revealed secret landmark → normal arrival + explore/bypass options
- [ ] Explore revealed landmark → multi-step encounter chain works
- [ ] Cast reveal with no hidden landmarks → falls back to landmark info display

🤖 Generated with [Claude Code](https://claude.com/claude-code)