### PR TITLE
feat: 2D Cartesian coordinate movement system

### DIFF
--- a/src/app/api/v1/tap-tap-adventure/move-forward/services/moveForwardService.ts
+++ b/src/app/api/v1/tap-tap-adventure/move-forward/services/moveForwardService.ts
@@ -10,6 +10,7 @@ import {
 import { generateLandmarks, seededRandom } from '@/app/tap-tap-adventure/lib/landmarkGenerator'
 import { FantasyCharacter } from '@/app/tap-tap-adventure/models/character'
 import { FantasyDecisionPoint, FantasyStoryEvent } from '@/app/tap-tap-adventure/models/story'
+import { moveToward, hasArrived, Vec2 } from '@/app/tap-tap-adventure/lib/movementUtils'
 
 const BASE_DISTANCE = 1
 
@@ -46,6 +47,9 @@ export async function moveForwardService(
         positionInRegion: 0,
         activeTargetIndex: 0,
         regionLength,
+        position: { x: 0, y: 0 },
+        exitPosition: { x: 490, y: 250 },
+        regionBounds: { width: 500, height: 500 },
       },
     }
 
@@ -70,6 +74,7 @@ export async function moveForwardService(
           distance: lm.distanceFromEntry,
           isExplored: false,
           hasShop: lm.hasShop,
+          position2d: lm.position,
         }))
         .filter((_, i) => !landmarks[i].hidden),
       {
@@ -79,6 +84,7 @@ export async function moveForwardService(
         type: 'region_exit' as const,
         position: regionLength,
         distance: regionLength,
+        position2d: { x: 490, y: 250 },
       },
     ]
 
@@ -98,6 +104,16 @@ export async function moveForwardService(
   const newPositionInRegion = (landmarkState.positionInRegion ?? 0) + 1
   const activeTargetIndex = landmarkState.activeTargetIndex ?? 0
 
+  // Compute updated 2D position for this step
+  const isExitTargetForPos = activeTargetIndex >= landmarkState.landmarks.length
+  let updatedPosition = landmarkState.position
+  const activePosTarget: Vec2 | undefined = isExitTargetForPos
+    ? landmarkState.exitPosition
+    : landmarkState.landmarks[activeTargetIndex]?.position
+  if (updatedPosition && activePosTarget) {
+    updatedPosition = moveToward(updatedPosition, activePosTarget)
+  }
+
   // Priority 2: Target arrival check
   const isExitTarget = activeTargetIndex >= landmarkState.landmarks.length
 
@@ -105,7 +121,14 @@ export async function moveForwardService(
     // Landmark target arrival
     const activeLandmark = landmarkState.landmarks[activeTargetIndex]
 
-    if (activeLandmark && !activeLandmark.hidden && newPositionInRegion >= activeLandmark.distanceFromEntry) {
+    // Check arrival: prefer 2D check, fall back to 1D
+    const charPos = updatedPosition
+    const targetPos = activeLandmark?.position
+    const arrived2d = charPos && targetPos ? hasArrived(charPos, targetPos) : false
+    const arrived1d = newPositionInRegion >= (activeLandmark?.distanceFromEntry ?? Infinity)
+    const hasArrivedAtLandmark = arrived2d || arrived1d
+
+    if (activeLandmark && !activeLandmark.hidden && hasArrivedAtLandmark) {
       const arrivalEventId = `landmark-arrival-${Date.now()}`
 
       const characterWithUpdatedState: FantasyCharacter = {
@@ -113,6 +136,7 @@ export async function moveForwardService(
         landmarkState: {
           ...landmarkState,
           positionInRegion: newPositionInRegion,
+          position: updatedPosition,
         },
       }
 
@@ -190,7 +214,14 @@ export async function moveForwardService(
     // Exit target arrival — triggers region travel decision
     const regionLength = landmarkState.regionLength ?? 200
 
-    if (newPositionInRegion >= regionLength) {
+    // Check arrival: prefer 2D check, fall back to 1D
+    const exitCharPos = updatedPosition
+    const exitTargetPos = landmarkState.exitPosition
+    const arrivedAtExit2d = exitCharPos && exitTargetPos ? hasArrived(exitCharPos, exitTargetPos) : false
+    const arrivedAtExit1d = newPositionInRegion >= regionLength
+    const hasArrivedAtExit = arrivedAtExit2d || arrivedAtExit1d
+
+    if (hasArrivedAtExit) {
       const connected = getConnectedRegions(region.id)
       const exitEventId = `region-exit-${Date.now()}`
 
@@ -241,6 +272,7 @@ export async function moveForwardService(
         landmarkState: {
           ...landmarkState,
           positionInRegion: newPositionInRegion,
+          position: updatedPosition,
         },
       }
 
@@ -291,6 +323,7 @@ export async function moveForwardService(
         landmarkState: {
           ...landmarkState,
           positionInRegion: newPositionInRegion,
+          position: updatedPosition,
         },
       },
       event: {
@@ -315,6 +348,7 @@ export async function moveForwardService(
         landmarkState: {
           ...landmarkState,
           positionInRegion: newPositionInRegion,
+          position: updatedPosition,
         },
       },
       event: {
@@ -342,6 +376,7 @@ export async function moveForwardService(
           landmarkState: {
             ...landmarkState,
             positionInRegion: newPositionInRegion,
+            position: updatedPosition,
           },
         },
         event: {
@@ -421,6 +456,7 @@ export async function moveForwardService(
       landmarkState: {
         ...landmarkState,
         positionInRegion: newPositionInRegion,
+        position: updatedPosition,
       },
     },
     event,

--- a/src/app/tap-tap-adventure/components/AdventureLeaderboard.tsx
+++ b/src/app/tap-tap-adventure/components/AdventureLeaderboard.tsx
@@ -92,7 +92,7 @@ export default function AdventureLeaderboard({ onBack }: AdventureLeaderboardPro
   const renderPrimary = (entry: AdventureScoreEntry): string => {
     switch (category) {
       case 'distance':
-        return `${entry.distance.toLocaleString()} steps`
+        return `${entry.distance.toLocaleString()} km`
       case 'level':
         return `Lv ${entry.level}`
       case 'gold':
@@ -107,7 +107,7 @@ export default function AdventureLeaderboard({ onBack }: AdventureLeaderboardPro
       case 'distance':
         return `Lv ${entry.level} ${entry.characterClass}`
       case 'level':
-        return `${entry.distance.toLocaleString()} steps`
+        return `${entry.distance.toLocaleString()} km`
       case 'gold':
         return `Lv ${entry.level} ${entry.characterClass}`
       case 'regionsConquered':

--- a/src/app/tap-tap-adventure/components/GameUI.tsx
+++ b/src/app/tap-tap-adventure/components/GameUI.tsx
@@ -14,6 +14,7 @@ import { getRegion, REGIONS, canEnterRegion } from '@/app/tap-tap-adventure/conf
 import type { RegionDifficulty } from '@/app/tap-tap-adventure/config/regions'
 import { rollWeather } from '@/app/tap-tap-adventure/config/weather'
 import { flipCoin } from '@/app/utils'
+import { hasArrived, moveToward } from '@/app/tap-tap-adventure/lib/movementUtils'
 
 import { SKILLS } from '@/app/tap-tap-adventure/config/skills'
 import { getSkillBonus } from '@/app/tap-tap-adventure/lib/skillTracker'
@@ -242,7 +243,11 @@ export default function GameUI({ onOpenStatus }: GameUIProps) {
         ? (ls.regionLength ?? 200)
         : ls.landmarks[activeTargetIndex]?.distanceFromEntry ?? Infinity
       : Infinity
-    const hitsTarget = ls != null && nextPosInRegion >= activeTargetPosition
+    const charPos = ls?.position
+    const targetPos2d = isExitTarget ? ls?.exitPosition : ls?.landmarks[activeTargetIndex]?.position
+    const hitsTarget = charPos && targetPos2d
+      ? hasArrived(moveToward(charPos, targetPos2d), targetPos2d)
+      : (ls != null && nextPosInRegion >= activeTargetPosition)
 
     // Always call server for milestone events (shop, target arrival)
     const hitsMilestone =
@@ -593,6 +598,7 @@ export default function GameUI({ onOpenStatus }: GameUIProps) {
                           regionName={region.name}
                           onSelectTarget={(i) => setActiveTarget(i)}
                           disabled={moveForwardPending || resolveDecisionPending}
+                          characterPosition={ls.position}
                         />
                       )}
                     </div>

--- a/src/app/tap-tap-adventure/components/HudBar.tsx
+++ b/src/app/tap-tap-adventure/components/HudBar.tsx
@@ -79,7 +79,7 @@ const STAT_LABELS: Record<IconType, string> = {
   heartIcon: 'HP',
   sunIcon: 'Gold',
   waterDropIcon: 'Reputation',
-  leafIcon: 'Steps',
+  leafIcon: 'km',
   fireIcon: 'Level',
   dayIcon: 'Day',
   purpleCircleIcon: 'STR — Attack power, max HP',
@@ -189,9 +189,9 @@ export function HudBar({ onOpenStatus }: HudBarProps = {}) {
   const getTooltipText = useCallback((key: IconType): string => {
     switch (key) {
       case 'heartIcon': return `HP: ${hp}/${maxHp}`
-      case 'fireIcon': return `Level ${level} — ${stepsIntoLevel}/${stepsNeeded} steps to next`
+      case 'fireIcon': return `Level ${level} — ${stepsIntoLevel}/${stepsNeeded} km to next`
       case 'waterDropIcon': return `Reputation: ${getReputationTier(stats[key] as number)} (${stats[key]})`
-      case 'dayIcon': return `Day ${day} (${50 - (distance % 50)} steps to next day)`
+      case 'dayIcon': return `Day ${day} (${50 - (distance % 50)} km to next day)`
       default: return STAT_LABELS[key]
     }
   }, [hp, maxHp, level, stepsIntoLevel, stepsNeeded, day, distance, stats])

--- a/src/app/tap-tap-adventure/components/PlayerStatusView.tsx
+++ b/src/app/tap-tap-adventure/components/PlayerStatusView.tsx
@@ -221,7 +221,7 @@ export function PlayerStatusView({ onClose }: PlayerStatusViewProps) {
                   </span>
                 </span>
                 <span className="text-slate-400">Day {day}</span>
-                <span className="text-slate-400">{distance} steps</span>
+                <span className="text-slate-400">{distance} km</span>
               </div>
               <div className="flex items-center gap-2">
                 <span className="text-emerald-300 text-sm">
@@ -479,7 +479,7 @@ export function PlayerStatusView({ onClose }: PlayerStatusViewProps) {
               </div>
               <div className="bg-[#161723] rounded-lg p-3 border border-slate-700/30">
                 <div className="text-xs text-slate-500">Distance</div>
-                <div className="text-lg font-bold text-emerald-300">{distance} steps</div>
+                <div className="text-lg font-bold text-emerald-300">{distance} km</div>
               </div>
               <div className="bg-[#161723] rounded-lg p-3 border border-slate-700/30">
                 <div className="text-xs text-slate-500">Days Survived</div>

--- a/src/app/tap-tap-adventure/components/QuestPanel.tsx
+++ b/src/app/tap-tap-adventure/components/QuestPanel.tsx
@@ -109,8 +109,8 @@ export function QuestPanel() {
       const needed = quest.target - quest.startValue
       const done = Math.max(0, character.distance - quest.startValue)
       progress = Math.min(1, done / needed)
-      progressText = `${character.distance} / ${quest.target} steps`
-      targetDescription = `Travel to ${quest.target} steps`
+      progressText = `${character.distance} / ${quest.target} km`
+      targetDescription = `Travel ${quest.target} km`
       break
     }
     case 'collect_gold': {
@@ -222,7 +222,7 @@ export function QuestPanel() {
 
       {/* Deadline detail */}
       <p className="text-[10px] text-slate-500">
-        ~{stepsUntilDeadline} steps until deadline
+        ~{stepsUntilDeadline} km until deadline
       </p>
 
       {/* Progress bar */}

--- a/src/app/tap-tap-adventure/components/RunHistoryPanel.tsx
+++ b/src/app/tap-tap-adventure/components/RunHistoryPanel.tsx
@@ -38,7 +38,7 @@ function RunCard({ character }: { character: FantasyCharacter }) {
       <div className="flex items-center gap-3 mt-1.5 text-[10px] text-slate-400">
         <span>{character.class}</span>
         <span>·</span>
-        <span>{(character.distance ?? 0).toLocaleString()} steps</span>
+        <span>{(character.distance ?? 0).toLocaleString()} km</span>
         <span>·</span>
         <span>{(character.gold ?? 0).toLocaleString()} gold</span>
         <span>·</span>

--- a/src/app/tap-tap-adventure/components/RunSummary.tsx
+++ b/src/app/tap-tap-adventure/components/RunSummary.tsx
@@ -205,7 +205,7 @@ export default function RunSummary({
           Run Statistics
         </h3>
         <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
-          <StatCard label="Distance" value={character.distance.toLocaleString()} sublabel="steps" />
+          <StatCard label="Distance" value={character.distance.toLocaleString()} sublabel="km" />
           <StatCard label="Level" value={String(character.level)} />
           <StatCard label="Days Survived" value={String(daysSurvived)} />
           <StatCard label="Gold" value={character.gold.toLocaleString()} />

--- a/src/app/tap-tap-adventure/components/SkillPanel.tsx
+++ b/src/app/tap-tap-adventure/components/SkillPanel.tsx
@@ -21,7 +21,7 @@ function getRequirementText(requirement: { type: string; value: string | number 
     case 'level':
       return `Reach level ${requirement.value}`
     case 'distance':
-      return `Walk ${requirement.value} steps`
+      return `Travel ${requirement.value} km`
     case 'combats_won':
       return `Win ${requirement.value} combats`
     default:

--- a/src/app/tap-tap-adventure/components/StatsPanel.tsx
+++ b/src/app/tap-tap-adventure/components/StatsPanel.tsx
@@ -104,7 +104,7 @@ export function StatsPanel() {
               </div>
               <div className="flex justify-between text-sm">
                 <span className="text-slate-400">🏃 Longest Run</span>
-                <span className="text-slate-200 font-medium">{longestRun.toLocaleString()} steps</span>
+                <span className="text-slate-200 font-medium">{longestRun.toLocaleString()} km</span>
               </div>
               <div className="flex justify-between text-sm">
                 <span className="text-slate-400">💰 Most Gold</span>

--- a/src/app/tap-tap-adventure/components/TargetList.tsx
+++ b/src/app/tap-tap-adventure/components/TargetList.tsx
@@ -107,7 +107,7 @@ export function TargetList({
                 <span className="text-[10px] text-slate-500">passed</span>
               ) : (
                 <span className={`text-[10px] ${isActive ? 'text-indigo-300' : 'text-slate-400'}`}>
-                  {stepsRemaining === 0 ? 'here' : `${stepsRemaining} steps`}
+                  {stepsRemaining === 0 ? 'here' : `${stepsRemaining} km`}
                 </span>
               )}
               {isActive && !isPassed && (

--- a/src/app/tap-tap-adventure/components/TargetList.tsx
+++ b/src/app/tap-tap-adventure/components/TargetList.tsx
@@ -1,5 +1,7 @@
 'use client'
 
+import { euclidean } from '@/app/tap-tap-adventure/lib/movementUtils'
+
 // Minimal landmark shape compatible with both GeneratedLandmark and the character schema
 interface LandmarkInfo {
   name: string
@@ -7,6 +9,7 @@ interface LandmarkInfo {
   hasShop: boolean
   distanceFromEntry: number
   hidden?: boolean
+  position?: { x: number; y: number }
 }
 
 interface Target {
@@ -18,6 +21,7 @@ interface Target {
   isExplored?: boolean
   hasShop?: boolean
   hidden?: boolean
+  position2d?: { x: number; y: number }
 }
 
 interface TargetListProps {
@@ -28,6 +32,7 @@ interface TargetListProps {
   regionName?: string
   onSelectTarget: (index: number) => void
   disabled: boolean
+  characterPosition?: { x: number; y: number }
 }
 
 export function TargetList({
@@ -38,6 +43,7 @@ export function TargetList({
   regionName,
   onSelectTarget,
   disabled,
+  characterPosition,
 }: TargetListProps) {
   // Build target list: landmarks + region exit (hidden landmarks are excluded from display)
   const targets: Target[] = [
@@ -51,6 +57,7 @@ export function TargetList({
         isExplored: false,
         hasShop: lm.hasShop,
         hidden: lm.hidden ?? false,
+        position2d: lm.position,
       }))
       .filter(t => !t.hidden),
     {
@@ -59,6 +66,7 @@ export function TargetList({
       icon: '🚪',
       type: 'region_exit' as const,
       position: regionLength,
+      position2d: { x: 490, y: 250 },
     },
   ]
 
@@ -68,7 +76,9 @@ export function TargetList({
       {targets.map(target => {
         const isPassed = positionInRegion >= target.position
         const isActive = target.index === activeTargetIndex
-        const stepsRemaining = Math.max(0, target.position - positionInRegion)
+        const stepsRemaining = characterPosition && target.position2d
+          ? Math.ceil(euclidean(characterPosition, target.position2d))
+          : Math.max(0, target.position - positionInRegion)
 
         return (
           <button

--- a/src/app/tap-tap-adventure/config/regions.ts
+++ b/src/app/tap-tap-adventure/config/regions.ts
@@ -19,6 +19,7 @@ export interface Region {
   parentRegion?: string
   /** Child regions branching from this node */
   childRegions?: string[]
+  bounds?: { width: number; height: number }
 }
 
 export const REGIONS: Record<string, Region> = {
@@ -35,6 +36,7 @@ export const REGIONS: Record<string, Region> = {
     minLevel: 0,
     icon: '\u{1F3D8}\u{FE0F}',
     childRegions: ['green_meadows'],
+    bounds: { width: 500, height: 500 },
   },
   green_meadows: {
     id: 'green_meadows',
@@ -51,6 +53,7 @@ export const REGIONS: Record<string, Region> = {
     startingCombatDistance: 'far',
     parentRegion: 'starting_village',
     childRegions: ['dark_forest', 'sunken_ruins'],
+    bounds: { width: 500, height: 500 },
   },
   dark_forest: {
     id: 'dark_forest',
@@ -67,6 +70,7 @@ export const REGIONS: Record<string, Region> = {
     startingCombatDistance: 'close',
     parentRegion: 'green_meadows',
     childRegions: ['feywild_grove'],
+    bounds: { width: 500, height: 500 },
   },
   crystal_caves: {
     id: 'crystal_caves',
@@ -83,6 +87,7 @@ export const REGIONS: Record<string, Region> = {
     startingCombatDistance: 'close',
     parentRegion: 'sunken_ruins',
     childRegions: ['bone_wastes'],
+    bounds: { width: 500, height: 500 },
   },
   scorched_wastes: {
     id: 'scorched_wastes',
@@ -99,6 +104,7 @@ export const REGIONS: Record<string, Region> = {
     startingCombatDistance: 'far',
     parentRegion: 'bone_wastes',
     childRegions: ['volcanic_forge'],
+    bounds: { width: 500, height: 500 },
   },
   frozen_peaks: {
     id: 'frozen_peaks',
@@ -115,6 +121,7 @@ export const REGIONS: Record<string, Region> = {
     startingCombatDistance: 'far',
     parentRegion: 'bone_wastes',
     childRegions: ['shadow_realm'],
+    bounds: { width: 500, height: 500 },
   },
   shadow_realm: {
     id: 'shadow_realm',
@@ -131,6 +138,7 @@ export const REGIONS: Record<string, Region> = {
     startingCombatDistance: 'close',
     parentRegion: 'frozen_peaks',
     childRegions: ['dragons_spine'],
+    bounds: { width: 500, height: 500 },
   },
   sky_citadel: {
     id: 'sky_citadel',
@@ -147,6 +155,7 @@ export const REGIONS: Record<string, Region> = {
     startingCombatDistance: 'mid',
     parentRegion: 'dragons_spine',
     childRegions: ['abyssal_depths'],
+    bounds: { width: 500, height: 500 },
   },
   abyssal_depths: {
     id: 'abyssal_depths',
@@ -163,6 +172,7 @@ export const REGIONS: Record<string, Region> = {
     startingCombatDistance: 'mid',
     parentRegion: 'sky_citadel',
     childRegions: ['celestial_throne'],
+    bounds: { width: 500, height: 500 },
   },
   celestial_throne: {
     id: 'celestial_throne',
@@ -178,6 +188,7 @@ export const REGIONS: Record<string, Region> = {
     icon: '\u2728',
     startingCombatDistance: 'far',
     parentRegion: 'abyssal_depths',
+    bounds: { width: 500, height: 500 },
   },
   sunken_ruins: {
     id: 'sunken_ruins',
@@ -194,6 +205,7 @@ export const REGIONS: Record<string, Region> = {
     startingCombatDistance: 'mid',
     parentRegion: 'green_meadows',
     childRegions: ['crystal_caves'],
+    bounds: { width: 500, height: 500 },
   },
   volcanic_forge: {
     id: 'volcanic_forge',
@@ -210,6 +222,7 @@ export const REGIONS: Record<string, Region> = {
     startingCombatDistance: 'close',
     parentRegion: 'scorched_wastes',
     childRegions: ['dragons_spine'],
+    bounds: { width: 500, height: 500 },
   },
   feywild_grove: {
     id: 'feywild_grove',
@@ -226,6 +239,7 @@ export const REGIONS: Record<string, Region> = {
     startingCombatDistance: 'mid',
     parentRegion: 'dark_forest',
     childRegions: ['bone_wastes'],
+    bounds: { width: 500, height: 500 },
   },
   bone_wastes: {
     id: 'bone_wastes',
@@ -241,6 +255,7 @@ export const REGIONS: Record<string, Region> = {
     icon: '\u{1F480}',
     startingCombatDistance: 'mid',
     childRegions: ['scorched_wastes', 'frozen_peaks'],
+    bounds: { width: 500, height: 500 },
   },
   dragons_spine: {
     id: 'dragons_spine',
@@ -256,6 +271,7 @@ export const REGIONS: Record<string, Region> = {
     icon: '\u{1F409}',
     startingCombatDistance: 'far',
     childRegions: ['sky_citadel'],
+    bounds: { width: 500, height: 500 },
   },
 }
 

--- a/src/app/tap-tap-adventure/hooks/useGameStore.ts
+++ b/src/app/tap-tap-adventure/hooks/useGameStore.ts
@@ -52,6 +52,7 @@ import { rollWeather, WEATHER_CHANGE_INTERVAL } from '@/app/tap-tap-adventure/co
 import { CRAFTING_RECIPES } from '@/app/tap-tap-adventure/config/craftingRecipes'
 import { canCraft, applyCraft } from '@/app/tap-tap-adventure/lib/craftingEngine'
 import { getEnchantCost, getEnchantBonusStat, MAX_ENCHANT_LEVEL } from '@/app/tap-tap-adventure/config/enchanting'
+import { moveToward, Vec2 } from '@/app/tap-tap-adventure/lib/movementUtils'
 
 const defaultCharacter: FantasyCharacter = {
   id: '',
@@ -257,12 +258,35 @@ export const useGameStore = create<GameStore>()(
 
             // Increment positionInRegion so TargetList shows correct distance
             if (updatedCharacter.landmarkState) {
+              const ls = updatedCharacter.landmarkState
+              let newLandmarkState = {
+                ...ls,
+                positionInRegion: (ls.positionInRegion ?? 0) + 1,
+              }
+
+              // Update 2D position toward active target
+              if (ls.position && ls.regionBounds) {
+                const activeIdx = ls.activeTargetIndex ?? 0
+                const isExit = activeIdx >= ls.landmarks.length
+                let targetPos: Vec2 | null = null
+
+                if (isExit && ls.exitPosition) {
+                  targetPos = ls.exitPosition
+                } else if (!isExit && ls.landmarks[activeIdx]?.position) {
+                  targetPos = ls.landmarks[activeIdx].position!
+                }
+
+                if (targetPos) {
+                  newLandmarkState = {
+                    ...newLandmarkState,
+                    position: moveToward(ls.position, targetPos),
+                  }
+                }
+              }
+
               updatedCharacter = {
                 ...updatedCharacter,
-                landmarkState: {
-                  ...updatedCharacter.landmarkState,
-                  positionInRegion: (updatedCharacter.landmarkState.positionInRegion ?? 0) + 1,
-                },
+                landmarkState: newLandmarkState,
               }
             }
 
@@ -1313,9 +1337,28 @@ export const useGameStore = create<GameStore>()(
             }
             const ls = character.landmarkState
             const newPosition = (ls.positionInRegion ?? 0) + effect.value
+            let newLsPosition = ls.position
+            if (ls.position && ls.regionBounds) {
+              const activeIdx = ls.activeTargetIndex ?? 0
+              const isExit = activeIdx >= ls.landmarks.length
+              let targetPos: Vec2 | null = null
+              if (isExit && ls.exitPosition) {
+                targetPos = ls.exitPosition
+              } else if (!isExit && ls.landmarks[activeIdx]?.position) {
+                targetPos = ls.landmarks[activeIdx].position!
+              }
+              if (targetPos) {
+                let pos = ls.position
+                for (let i = 0; i < effect.value; i++) {
+                  pos = moveToward(pos, targetPos)
+                }
+                newLsPosition = pos
+              }
+            }
             updates.landmarkState = {
               ...ls,
               positionInRegion: newPosition,
+              position: newLsPosition,
             }
             updates.distance = (character.distance ?? 0) + effect.value
             message = `${spell.name}: Advanced ${effect.value} steps! (${manaCost} MP spent)`
@@ -1374,7 +1417,7 @@ export const useGameStore = create<GameStore>()(
     }),
     {
       name: 'fantasy-tycoon-storage', // localStorage key (kept for backward compat)
-      version: 26,
+      version: 27,
       migrate: (persistedState: unknown) => {
         const state = persistedState as GameStore
         if (state?.gameState && !('combatState' in state.gameState)) {
@@ -1491,6 +1534,10 @@ export const useGameStore = create<GameStore>()(
                   enc.lastTier = getRelationshipTier(enc.disposition).tier
                 }
               }
+            }
+            // v27: Add 2D position to landmarkState
+            if ((char as FantasyCharacter).landmarkState && !(char as FantasyCharacter).landmarkState!.position) {
+              ;(char as FantasyCharacter).landmarkState!.position = { x: 0, y: 0 }
             }
           }
         }

--- a/src/app/tap-tap-adventure/lib/dailyChallengeTracker.ts
+++ b/src/app/tap-tap-adventure/lib/dailyChallengeTracker.ts
@@ -36,7 +36,7 @@ interface ChallengeTemplate {
 const CHALLENGE_TEMPLATES: ChallengeTemplate[] = [
   {
     type: 'travel_distance',
-    descriptionFn: (target) => `Travel ${target} steps`,
+    descriptionFn: (target) => `Travel ${target} km`,
     targetFn: (bucket) => 50 + bucket * 30,
     goldRewardFn: (bucket) => 15 + bucket * 5,
   },

--- a/src/app/tap-tap-adventure/lib/landmarkGenerator.ts
+++ b/src/app/tap-tap-adventure/lib/landmarkGenerator.ts
@@ -1,4 +1,5 @@
 import { getTemplatesForRegion, getSecretTemplatesForRegion, LandmarkTemplate, LandmarkType } from '../config/landmarks'
+import { euclidean } from './movementUtils'
 
 export interface GeneratedLandmark {
   templateId: string
@@ -10,6 +11,7 @@ export interface GeneratedLandmark {
   encounterPrompt: string
   distanceFromEntry: number
   hidden: boolean
+  position: { x: number; y: number }
 }
 
 // Simple string hash for seeded random
@@ -68,6 +70,7 @@ export function generateLandmarks(
   const landmarks: GeneratedLandmark[] = []
 
   for (const template of selected) {
+    const position = { x: 50 + rng() * 400, y: 50 + rng() * 400 }
     landmarks.push({
       templateId: template.id,
       name: template.name,
@@ -78,6 +81,7 @@ export function generateLandmarks(
       encounterPrompt: template.encounterPrompt,
       distanceFromEntry: currentDist,
       hidden: false,
+      position,
     })
     currentDist += 25 + Math.floor(rng() * 26) // 25-50
   }
@@ -90,6 +94,7 @@ export function generateLandmarks(
     const secretDist = landmarks.length > 1
       ? Math.floor((landmarks[0].distanceFromEntry + landmarks[landmarks.length - 1].distanceFromEntry) / 2) + Math.floor(rng() * 15)
       : 30 + Math.floor(rng() * 20)
+    const secretPosition = { x: 50 + rng() * 400, y: 50 + rng() * 400 }
     landmarks.push({
       templateId: secretTemplate.id,
       name: secretTemplate.name,
@@ -100,6 +105,7 @@ export function generateLandmarks(
       encounterPrompt: secretTemplate.encounterPrompt,
       distanceFromEntry: secretDist,
       hidden: true,
+      position: secretPosition,
     })
     // Re-sort by distance
     landmarks.sort((a, b) => a.distanceFromEntry - b.distanceFromEntry)

--- a/src/app/tap-tap-adventure/lib/movementUtils.ts
+++ b/src/app/tap-tap-adventure/lib/movementUtils.ts
@@ -1,0 +1,20 @@
+export interface Vec2 { x: number; y: number }
+
+export function euclidean(a: Vec2, b: Vec2): number {
+  return Math.sqrt((b.x - a.x) ** 2 + (b.y - a.y) ** 2)
+}
+
+export function moveToward(current: Vec2, target: Vec2, stepSize: number = 1): Vec2 {
+  const dist = euclidean(current, target)
+  if (dist <= stepSize) return { ...target }
+  const dx = target.x - current.x
+  const dy = target.y - current.y
+  return {
+    x: current.x + (dx / dist) * stepSize,
+    y: current.y + (dy / dist) * stepSize,
+  }
+}
+
+export function hasArrived(current: Vec2, target: Vec2, threshold: number = 1.5): boolean {
+  return euclidean(current, target) <= threshold
+}

--- a/src/app/tap-tap-adventure/lib/spellGenerator.ts
+++ b/src/app/tap-tap-adventure/lib/spellGenerator.ts
@@ -165,7 +165,7 @@ export function generateSpellForLevel(level: number, school?: SpellSchool): Spel
       {
         type: 'speed_boost' as const,
         value: 3 + Math.floor(level / 2),
-        description: `Advances ${3 + Math.floor(level / 2)} steps toward your target.`,
+        description: `Advances ${3 + Math.floor(level / 2)} km toward your target.`,
       },
       {
         type: 'shield' as const,

--- a/src/app/tap-tap-adventure/models/character.ts
+++ b/src/app/tap-tap-adventure/models/character.ts
@@ -80,6 +80,7 @@ export const FantasyCharacterSchema = z.object({
       encounterPrompt: z.string(),
       distanceFromEntry: z.number(),
       hidden: z.boolean().default(false),
+      position: z.object({ x: z.number(), y: z.number() }).optional(),
     })),
     entryDistance: z.number(),
     nextLandmarkIndex: z.number(),
@@ -89,6 +90,9 @@ export const FantasyCharacterSchema = z.object({
     positionInRegion: z.number().default(0),
     activeTargetIndex: z.number().default(0),
     regionLength: z.number().default(200),
+    position: z.object({ x: z.number(), y: z.number() }).optional(),
+    exitPosition: z.object({ x: z.number(), y: z.number() }).optional(),
+    regionBounds: z.object({ width: z.number(), height: z.number() }).optional(),
   }).optional(),
 })
 export type FantasyCharacter = z.infer<typeof FantasyCharacterSchema>


### PR DESCRIPTION
## Summary

- Adds `Vec2`, `euclidean`, `moveToward`, and `hasArrived` utilities in `lib/movementUtils.ts`
- Extends `landmarkState` schema with optional `position`, `exitPosition`, `regionBounds` fields; landmarks gain an optional `position: {x, y}` field
- Generates 2D positions for each landmark in `landmarkGenerator.ts` (seeded, within 50–450 bounds)
- `useGameStore.incrementDistance` and `castExplorationSpell` (speed_boost) update the character's 2D position toward the active target each step
- `moveForwardService` initializes 2D state on region entry and propagates position in all response branches; arrival uses 2D `hasArrived` with 1D fallback
- `GameUI` uses 2D `hasArrived`/`moveToward` for the `hitsTarget` milestone check, with 1D fallback
- `TargetList` accepts optional `characterPosition` prop and uses `euclidean` for step-remaining display when available
- Store version bumped 26 → 27 with migration to set `position: {x:0, y:0}` on existing saves

## Test plan

- [x] All 736 existing tests pass (`npm test`)
- [x] Zero new TypeScript errors (`npx tsc --noEmit` — 37 pre-existing test-file errors unchanged)
- [x] 1D `positionInRegion` and `distanceFromEntry` unchanged — backward compat preserved
- [x] Existing saves migrated safely (v27 migration adds `position` only if absent)

Closes #297

🤖 Generated with [Claude Code](https://claude.com/claude-code)