### PR TITLE
fix: resolve 3 critical landmark arrival bugs

### DIFF
--- a/src/app/api/v1/tap-tap-adventure/move-forward/services/moveForwardService.ts
+++ b/src/app/api/v1/tap-tap-adventure/move-forward/services/moveForwardService.ts
@@ -121,12 +121,13 @@ export async function moveForwardService(
     // Landmark target arrival
     const activeLandmark = landmarkState.landmarks[activeTargetIndex]
 
-    // Check arrival: prefer 2D check, fall back to 1D
+    // Check arrival: use 2D when data exists, fall back to 1D only when no 2D data
     const charPos = updatedPosition
     const targetPos = activeLandmark?.position
-    const arrived2d = charPos && targetPos ? hasArrived(charPos, targetPos) : false
-    const arrived1d = newPositionInRegion >= (activeLandmark?.distanceFromEntry ?? Infinity)
-    const hasArrivedAtLandmark = arrived2d || arrived1d
+    const has2dData = charPos && targetPos
+    const hasArrivedAtLandmark = has2dData
+      ? hasArrived(charPos, targetPos)
+      : newPositionInRegion >= (activeLandmark?.distanceFromEntry ?? Infinity)
 
     if (activeLandmark && !activeLandmark.hidden && hasArrivedAtLandmark) {
       const arrivalEventId = `landmark-arrival-${Date.now()}`
@@ -137,6 +138,7 @@ export async function moveForwardService(
           ...landmarkState,
           positionInRegion: newPositionInRegion,
           position: updatedPosition,
+          nextLandmarkIndex: activeTargetIndex, // keep in sync with activeTargetIndex
         },
       }
 
@@ -214,12 +216,13 @@ export async function moveForwardService(
     // Exit target arrival — triggers region travel decision
     const regionLength = landmarkState.regionLength ?? 200
 
-    // Check arrival: prefer 2D check, fall back to 1D
+    // Check arrival: use 2D when data exists, fall back to 1D only when no 2D data
     const exitCharPos = updatedPosition
     const exitTargetPos = landmarkState.exitPosition
-    const arrivedAtExit2d = exitCharPos && exitTargetPos ? hasArrived(exitCharPos, exitTargetPos) : false
-    const arrivedAtExit1d = newPositionInRegion >= regionLength
-    const hasArrivedAtExit = arrivedAtExit2d || arrivedAtExit1d
+    const has2dExitData = exitCharPos && exitTargetPos
+    const hasArrivedAtExit = has2dExitData
+      ? hasArrived(exitCharPos, exitTargetPos)
+      : newPositionInRegion >= regionLength
 
     if (hasArrivedAtExit) {
       const connected = getConnectedRegions(region.id)

--- a/src/app/tap-tap-adventure/components/GameUI.tsx
+++ b/src/app/tap-tap-adventure/components/GameUI.tsx
@@ -247,7 +247,7 @@ export default function GameUI({ onOpenStatus }: GameUIProps) {
     const targetPos2d = isExitTarget ? ls?.exitPosition : ls?.landmarks[activeTargetIndex]?.position
     const hitsTarget = charPos && targetPos2d
       ? hasArrived(moveToward(charPos, targetPos2d), targetPos2d)
-      : (ls != null && nextPosInRegion >= activeTargetPosition)
+      : (!charPos && ls != null && nextPosInRegion >= activeTargetPosition) // 1D ONLY when no 2D data
 
     // Always call server for milestone events (shop, target arrival)
     const hitsMilestone =

--- a/src/app/tap-tap-adventure/components/TargetList.tsx
+++ b/src/app/tap-tap-adventure/components/TargetList.tsx
@@ -9,6 +9,7 @@ interface LandmarkInfo {
   hasShop: boolean
   distanceFromEntry: number
   hidden?: boolean
+  explored?: boolean
   position?: { x: number; y: number }
 }
 
@@ -54,7 +55,7 @@ export function TargetList({
         icon: lm.icon,
         type: 'landmark' as const,
         position: lm.distanceFromEntry,
-        isExplored: false,
+        isExplored: lm.explored ?? false,
         hasShop: lm.hasShop,
         hidden: lm.hidden ?? false,
         position2d: lm.position,
@@ -74,7 +75,7 @@ export function TargetList({
     <div className="space-y-1">
       <p className="text-[10px] text-slate-500 uppercase tracking-wide mb-1">Targets</p>
       {targets.map(target => {
-        const isPassed = positionInRegion >= target.position
+        const isExplored = target.isExplored ?? false
         const isActive = target.index === activeTargetIndex
         const stepsRemaining = characterPosition && target.position2d
           ? Math.ceil(euclidean(characterPosition, target.position2d))
@@ -88,8 +89,8 @@ export function TargetList({
             className={`w-full text-left flex items-center justify-between px-2.5 py-1.5 rounded text-xs transition-colors border ${
               isActive
                 ? 'bg-indigo-900/50 border-indigo-500/60 text-indigo-200'
-                : isPassed
-                ? 'bg-[#1a1b2e]/40 border-[#2a2b3f]/50 text-slate-500 cursor-default'
+                : isExplored
+                ? 'bg-[#1a1b2e]/40 border-[#2a2b3f]/50 text-slate-500 opacity-60 hover:border-indigo-600/30 hover:text-slate-400'
                 : 'bg-[#1e1f30] border-[#3a3c56] text-slate-300 hover:border-indigo-600/50 hover:text-slate-100'
             } disabled:cursor-not-allowed`}
           >
@@ -103,14 +104,14 @@ export function TargetList({
               )}
             </span>
             <span className="flex items-center gap-1 flex-shrink-0 ml-2">
-              {isPassed ? (
-                <span className="text-[10px] text-slate-500">passed</span>
+              {isExplored ? (
+                <span className="text-[10px] text-slate-500">explored</span>
               ) : (
                 <span className={`text-[10px] ${isActive ? 'text-indigo-300' : 'text-slate-400'}`}>
                   {stepsRemaining === 0 ? 'here' : `${stepsRemaining} km`}
                 </span>
               )}
-              {isActive && !isPassed && (
+              {isActive && !isExplored && (
                 <span className="text-[9px] px-1 py-0.5 rounded bg-indigo-700/60 text-indigo-200 border border-indigo-500/40">
                   active
                 </span>

--- a/src/app/tap-tap-adventure/hooks/useGameStore.ts
+++ b/src/app/tap-tap-adventure/hooks/useGameStore.ts
@@ -290,28 +290,6 @@ export const useGameStore = create<GameStore>()(
               }
             }
 
-            // Auto-skip hidden landmarks the player has walked past
-            if (updatedCharacter.landmarkState) {
-              const ls = updatedCharacter.landmarkState
-              let idx = ls.activeTargetIndex ?? 0
-              while (
-                idx < ls.landmarks.length &&
-                ls.landmarks[idx]?.hidden &&
-                (ls.positionInRegion ?? 0) >= ls.landmarks[idx].distanceFromEntry
-              ) {
-                idx++
-              }
-              if (idx !== (ls.activeTargetIndex ?? 0)) {
-                updatedCharacter = {
-                  ...updatedCharacter,
-                  landmarkState: {
-                    ...ls,
-                    activeTargetIndex: idx,
-                  },
-                }
-              }
-            }
-
             // Mount daily upkeep: deduct gold when a new day boundary is crossed
             const oldDay = calculateDay(oldDistance)
             const newDay = calculateDay(newDistance)
@@ -1417,7 +1395,7 @@ export const useGameStore = create<GameStore>()(
     }),
     {
       name: 'fantasy-tycoon-storage', // localStorage key (kept for backward compat)
-      version: 27,
+      version: 28,
       migrate: (persistedState: unknown) => {
         const state = persistedState as GameStore
         if (state?.gameState && !('combatState' in state.gameState)) {
@@ -1538,6 +1516,13 @@ export const useGameStore = create<GameStore>()(
             // v27: Add 2D position to landmarkState
             if ((char as FantasyCharacter).landmarkState && !(char as FantasyCharacter).landmarkState!.position) {
               ;(char as FantasyCharacter).landmarkState!.position = { x: 0, y: 0 }
+            }
+            // v28: Add explored field to landmarks
+            if ((char as FantasyCharacter).landmarkState?.landmarks) {
+              (char as FantasyCharacter).landmarkState!.landmarks = (char as FantasyCharacter).landmarkState!.landmarks.map(lm => ({
+                ...lm,
+                explored: (lm as Record<string, unknown>).explored !== undefined ? Boolean((lm as Record<string, unknown>).explored) : false,
+              }))
             }
           }
         }

--- a/src/app/tap-tap-adventure/hooks/useResolveDecisionMutation.ts
+++ b/src/app/tap-tap-adventure/hooks/useResolveDecisionMutation.ts
@@ -53,9 +53,15 @@ export function useResolveDecisionMutation() {
         const landmarkState = character.landmarkState
         if (landmarkState) {
           const landmarkName = landmarkState.exploringLandmarkName ?? 'the landmark'
+          // Mark the current landmark as explored
+          const exploredIndex = landmarkState.activeTargetIndex ?? 0
+          const updatedLandmarks = landmarkState.landmarks.map((lm, i) =>
+            i === exploredIndex ? { ...lm, explored: true } : lm
+          )
           updateSelectedCharacter({
             landmarkState: {
               ...landmarkState,
+              landmarks: updatedLandmarks,
               exploring: false,
               explorationDepth: 0,
               exploringLandmarkName: undefined,
@@ -82,9 +88,9 @@ export function useResolveDecisionMutation() {
       if (optionId === 'bypass-landmark' || optionId.startsWith('bypass-toward-')) {
         const landmarkState = character.landmarkState
         if (landmarkState) {
-          const bypassedLandmark = landmarkState.landmarks[landmarkState.nextLandmarkIndex]
+          // Use activeTargetIndex (not nextLandmarkIndex) to identify the bypassed landmark
+          const bypassedLandmark = landmarkState.landmarks[landmarkState.activeTargetIndex ?? 0]
           const landmarkName = bypassedLandmark?.name ?? 'the landmark'
-          const newNextLandmarkIndex = landmarkState.nextLandmarkIndex + 1
 
           // Determine target based on which direction was chosen
           let newActiveTargetIndex: number
@@ -98,7 +104,7 @@ export function useResolveDecisionMutation() {
           } else {
             // Original bypass-landmark behavior: go to next target
             newActiveTargetIndex = Math.min(
-              newNextLandmarkIndex,
+              (landmarkState.activeTargetIndex ?? 0) + 1,
               landmarkState.landmarks.length
             )
           }
@@ -106,7 +112,7 @@ export function useResolveDecisionMutation() {
           updateSelectedCharacter({
             landmarkState: {
               ...landmarkState,
-              nextLandmarkIndex: newNextLandmarkIndex,
+              nextLandmarkIndex: newActiveTargetIndex, // keep in sync with activeTargetIndex
               activeTargetIndex: newActiveTargetIndex,
               exploring: false,
             },

--- a/src/app/tap-tap-adventure/lib/landmarkGenerator.ts
+++ b/src/app/tap-tap-adventure/lib/landmarkGenerator.ts
@@ -11,6 +11,7 @@ export interface GeneratedLandmark {
   encounterPrompt: string
   distanceFromEntry: number
   hidden: boolean
+  explored: boolean
   position: { x: number; y: number }
 }
 
@@ -81,6 +82,7 @@ export function generateLandmarks(
       encounterPrompt: template.encounterPrompt,
       distanceFromEntry: currentDist,
       hidden: false,
+      explored: false,
       position,
     })
     currentDist += 25 + Math.floor(rng() * 26) // 25-50
@@ -105,6 +107,7 @@ export function generateLandmarks(
       encounterPrompt: secretTemplate.encounterPrompt,
       distanceFromEntry: secretDist,
       hidden: true,
+      explored: false,
       position: secretPosition,
     })
     // Re-sort by distance

--- a/src/app/tap-tap-adventure/models/character.ts
+++ b/src/app/tap-tap-adventure/models/character.ts
@@ -80,6 +80,7 @@ export const FantasyCharacterSchema = z.object({
       encounterPrompt: z.string(),
       distanceFromEntry: z.number(),
       hidden: z.boolean().default(false),
+      explored: z.boolean().default(false),
       position: z.object({ x: z.number(), y: z.number() }).optional(),
     })),
     entryDistance: z.number(),


### PR DESCRIPTION
Fixes #299

## Summary

- **Bug 1 (wrong distance trigger):** Landmark/exit arrival checks now use the 2D `hasArrived` exclusively when 2D position data exists. The `|| arrived1d` fallback only fires when there is genuinely no 2D data. Fixed in `moveForwardService.ts` (both landmark and exit checks) and `GameUI.tsx` (`hitsTarget`).

- **Bug 2 (mixed-up landmark names):** The bypass handler in `useResolveDecisionMutation.ts` was reading from `nextLandmarkIndex` to identify the bypassed landmark, but arrival uses `activeTargetIndex`. Fixed to use `activeTargetIndex` and keep `nextLandmarkIndex` in sync. Server also syncs `nextLandmarkIndex = activeTargetIndex` on landmark arrival.

- **Bug 3 (passed → explored):** Added `explored: boolean` field to `GeneratedLandmark`, the character schema landmark array, and `landmarkGenerator.ts`. `TargetList.tsx` replaced the 1D `isPassed` check with `isExplored`. When a player leaves a landmark (`leave-landmark`), the landmark is marked `explored: true`. Explored landmarks render with an "explored" badge and reduced opacity but remain clickable (revisitable). Removed the auto-skip-hidden-landmarks logic in `useGameStore.ts` that was incorrectly using `positionInRegion >= distanceFromEntry` in 2D mode.

- **Store migration:** Version bumped 27 → 28 with migration to add `explored: false` to all existing landmark entries.

## Test plan

- [x] `npx vitest run src/app/tap-tap-adventure/__tests__/` — all 717 tests pass
- [x] `npx tsc --noEmit` — no new type errors in production source files
- [ ] Manual: walk toward a landmark, confirm arrival only triggers when 2D position reaches it (not on every step past the 1D threshold)
- [ ] Manual: bypass a landmark and confirm the story event names the correct landmark
- [ ] Manual: explore a landmark, leave it, confirm it shows "explored" (not "passed") in the target list and can still be retargeted

🤖 Generated with [Claude Code](https://claude.com/claude-code)