### PR TITLE
feat: replace single exit with per-region directional exits

### DIFF
--- a/src/app/api/v1/tap-tap-adventure/move-forward/services/moveForwardService.ts
+++ b/src/app/api/v1/tap-tap-adventure/move-forward/services/moveForwardService.ts
@@ -35,6 +35,20 @@ export async function moveForwardService(
     const regionLengthSeed = `${currentRegion}-${character.id}-${visitCount}-length`
     const regionLength = 150 + Math.floor(seededRandom(regionLengthSeed)() * 101)
 
+    // Generate exit positions spread around region edges, one per connected region
+    const connected = getConnectedRegions(region.id)
+    const exitPositions = connected.map((connRegion, i) => {
+      const angle = (i / connected.length) * Math.PI * 2
+      const edgeX = 250 + Math.cos(angle) * 240
+      const edgeY = 250 + Math.sin(angle) * 240
+      return {
+        regionId: connRegion.id,
+        name: `Path to ${connRegion.name}`,
+        icon: connRegion.icon,
+        position: { x: Math.round(edgeX), y: Math.round(edgeY) },
+      }
+    })
+
     const initializedCharacter: FantasyCharacter = {
       ...updatedCharacter,
       landmarkState: {
@@ -48,7 +62,8 @@ export async function moveForwardService(
         activeTargetIndex: 0,
         regionLength,
         position: { x: 0, y: 0 },
-        exitPosition: { x: 490, y: 250 },
+        exitPosition: exitPositions[0]?.position ?? { x: 490, y: 250 },
+        exitPositions,
         regionBounds: { width: 500, height: 500 },
       },
     }
@@ -77,15 +92,16 @@ export async function moveForwardService(
           position2d: lm.position,
         }))
         .filter((_, i) => !landmarks[i].hidden),
-      {
-        index: landmarks.length,
-        name: `Leave ${region.name}`,
-        icon: '🚪',
+      ...exitPositions.map((exit, i) => ({
+        index: landmarks.length + i,
+        name: exit.name,
+        icon: exit.icon,
         type: 'region_exit' as const,
         position: regionLength,
         distance: regionLength,
-        position2d: { x: 490, y: 250 },
-      },
+        position2d: exit.position,
+        exitRegionId: exit.regionId,
+      })),
     ]
 
     return {
@@ -107,9 +123,14 @@ export async function moveForwardService(
   // Compute updated 2D position for this step
   const isExitTargetForPos = activeTargetIndex >= landmarkState.landmarks.length
   let updatedPosition = landmarkState.position
-  const activePosTarget: Vec2 | undefined = isExitTargetForPos
-    ? landmarkState.exitPosition
-    : landmarkState.landmarks[activeTargetIndex]?.position
+  let activePosTarget: Vec2 | undefined
+  if (isExitTargetForPos) {
+    const exitIdx = activeTargetIndex - landmarkState.landmarks.length
+    const exits = landmarkState.exitPositions ?? []
+    activePosTarget = exits[exitIdx]?.position ?? landmarkState.exitPosition
+  } else {
+    activePosTarget = landmarkState.landmarks[activeTargetIndex]?.position
+  }
   if (updatedPosition && activePosTarget) {
     updatedPosition = moveToward(updatedPosition, activePosTarget)
   }
@@ -213,20 +234,123 @@ export async function moveForwardService(
       }
     }
   } else {
-    // Exit target arrival — triggers region travel decision
+    // Exit target arrival — triggers travel decision for the specific exit chosen
     const regionLength = landmarkState.regionLength ?? 200
+    const exitIdx = activeTargetIndex - landmarkState.landmarks.length
+    const exits = landmarkState.exitPositions ?? []
+    const targetExit = exits[exitIdx]
 
-    // Check arrival: use 2D when data exists, fall back to 1D only when no 2D data
+    // Check arrival at the specific exit — 2D only when data exists, 1D fallback otherwise
+    const exitTargetPos = targetExit?.position ?? landmarkState.exitPosition
     const exitCharPos = updatedPosition
-    const exitTargetPos = landmarkState.exitPosition
     const has2dExitData = exitCharPos && exitTargetPos
     const hasArrivedAtExit = has2dExitData
       ? hasArrived(exitCharPos, exitTargetPos)
       : newPositionInRegion >= regionLength
 
     if (hasArrivedAtExit) {
-      const connected = getConnectedRegions(region.id)
       const exitEventId = `region-exit-${Date.now()}`
+      const visitedRegions = character.visitedRegions ?? ['green_meadows']
+
+      const characterWithUpdatedState: FantasyCharacter = {
+        ...updatedCharacter,
+        landmarkState: {
+          ...landmarkState,
+          positionInRegion: newPositionInRegion,
+          position: updatedPosition,
+        },
+      }
+
+      // If we have a specific target exit, show a focused decision for that region
+      if (targetExit) {
+        const targetRegion = getRegion(targetExit.regionId)
+        const meetsLevel = canEnterRegion(targetRegion, character.level)
+        const isVisited = visitedRegions.includes(targetExit.regionId)
+
+        let travelOptions
+        if (!meetsLevel) {
+          travelOptions = [
+            {
+              id: 'turn-back',
+              text: `${region.icon} Turn back — not high enough level (need Lv.${targetRegion.minLevel})`,
+              successProbability: 1.0,
+              successDescription: `You are not ready to enter ${targetRegion.name} yet. You return to explore ${region.name}.`,
+              successEffects: {},
+              failureDescription: '',
+              failureEffects: {},
+              resultDescription: `You turn back from the path to ${targetRegion.name}.`,
+            },
+          ]
+        } else if (!isVisited) {
+          travelOptions = [
+            {
+              id: `travel-${targetExit.regionId}`,
+              text: `⚔️ Face the Guardian of ${targetRegion.icon} ${targetRegion.name}`,
+              requiresBoss: true,
+              successProbability: 1.0,
+              successDescription: `You approach ${targetRegion.name} and prepare to face its guardian.`,
+              successEffects: {},
+              failureDescription: '',
+              failureEffects: {},
+              resultDescription: `You enter ${targetRegion.name}.`,
+            },
+            {
+              id: 'turn-back',
+              text: `${region.icon} Turn back`,
+              successProbability: 1.0,
+              successDescription: `You decide to continue exploring ${region.name}.`,
+              successEffects: {},
+              failureDescription: '',
+              failureEffects: {},
+              resultDescription: `You continue in ${region.name}.`,
+            },
+          ]
+        } else {
+          travelOptions = [
+            {
+              id: `travel-${targetExit.regionId}`,
+              text: `Enter ${targetRegion.icon} ${targetRegion.name}`,
+              successProbability: 1.0,
+              successDescription: `You set out toward ${targetRegion.name}. ${targetRegion.description}`,
+              successEffects: {},
+              failureDescription: '',
+              failureEffects: {},
+              resultDescription: `You travel to ${targetRegion.name}.`,
+            },
+            {
+              id: 'turn-back',
+              text: `${region.icon} Stay in ${region.name}`,
+              successProbability: 1.0,
+              successDescription: `You decide to continue exploring ${region.name}.`,
+              successEffects: {},
+              failureDescription: '',
+              failureEffects: {},
+              resultDescription: `You continue in ${region.name}.`,
+            },
+          ]
+        }
+
+        return {
+          character: characterWithUpdatedState,
+          event: {
+            id: exitEventId,
+            type: 'crossroads',
+            characterId: character.id,
+            locationId: character.locationId,
+            timestamp: new Date().toISOString(),
+          },
+          decisionPoint: {
+            id: `decision-${exitEventId}`,
+            eventId: exitEventId,
+            prompt: `You have reached the ${targetExit.icon} path toward ${targetRegion.name}. ${isVisited ? `This region is familiar to you.` : `A guardian blocks the way to this uncharted territory.`}`,
+            options: travelOptions,
+            resolved: false,
+          },
+        }
+      }
+
+      // Fallback: no specific exit found — show all connected regions (backward compat)
+      const connected = getConnectedRegions(region.id)
 
       const difficultyLabel: Record<string, string> = {
         easy: 'Easy',
@@ -234,8 +358,6 @@ export async function moveForwardService(
         hard: 'Hard',
         very_hard: 'Very Hard',
       }
-
-      const visitedRegions = character.visitedRegions ?? ['green_meadows']
 
       const travelOptions = connected.map(connectedRegion => {
         const meetsLevel = canEnterRegion(connectedRegion, character.level)
@@ -268,15 +390,6 @@ export async function moveForwardService(
         failureDescription: '',
         failureEffects: {},
         resultDescription: `You continue in ${region.name}.`,
-      }
-
-      const characterWithUpdatedState: FantasyCharacter = {
-        ...updatedCharacter,
-        landmarkState: {
-          ...landmarkState,
-          positionInRegion: newPositionInRegion,
-          position: updatedPosition,
-        },
       }
 
       return {

--- a/src/app/tap-tap-adventure/components/GameUI.tsx
+++ b/src/app/tap-tap-adventure/components/GameUI.tsx
@@ -244,7 +244,15 @@ export default function GameUI({ onOpenStatus }: GameUIProps) {
         : ls.landmarks[activeTargetIndex]?.distanceFromEntry ?? Infinity
       : Infinity
     const charPos = ls?.position
-    const targetPos2d = isExitTarget ? ls?.exitPosition : ls?.landmarks[activeTargetIndex]?.position
+    let targetPos2d
+    if (isExitTarget && ls?.exitPositions) {
+      const exitIdx = activeTargetIndex - ls.landmarks.length
+      targetPos2d = ls.exitPositions[exitIdx]?.position ?? ls.exitPosition
+    } else if (isExitTarget) {
+      targetPos2d = ls?.exitPosition
+    } else {
+      targetPos2d = ls?.landmarks[activeTargetIndex]?.position
+    }
     const hitsTarget = charPos && targetPos2d
       ? hasArrived(moveToward(charPos, targetPos2d), targetPos2d)
       : (!charPos && ls != null && nextPosInRegion >= activeTargetPosition) // 1D ONLY when no 2D data
@@ -599,6 +607,7 @@ export default function GameUI({ onOpenStatus }: GameUIProps) {
                           onSelectTarget={(i) => setActiveTarget(i)}
                           disabled={moveForwardPending || resolveDecisionPending}
                           characterPosition={ls.position}
+                          exitTargets={ls.exitPositions}
                         />
                       )}
                     </div>

--- a/src/app/tap-tap-adventure/components/TargetList.tsx
+++ b/src/app/tap-tap-adventure/components/TargetList.tsx
@@ -25,6 +25,13 @@ interface Target {
   position2d?: { x: number; y: number }
 }
 
+interface ExitTargetInfo {
+  regionId: string
+  name: string
+  icon: string
+  position: { x: number; y: number }
+}
+
 interface TargetListProps {
   landmarks: LandmarkInfo[]
   positionInRegion: number
@@ -34,6 +41,7 @@ interface TargetListProps {
   onSelectTarget: (index: number) => void
   disabled: boolean
   characterPosition?: { x: number; y: number }
+  exitTargets?: ExitTargetInfo[]
 }
 
 export function TargetList({
@@ -45,8 +53,13 @@ export function TargetList({
   onSelectTarget,
   disabled,
   characterPosition,
+  exitTargets,
 }: TargetListProps) {
-  // Build target list: landmarks + region exit (hidden landmarks are excluded from display)
+  // Build target list: landmarks + per-exit targets (hidden landmarks are excluded from display)
+  const exitList = exitTargets && exitTargets.length > 0
+    ? exitTargets
+    : [{ regionId: '', name: regionName ? `Leave ${regionName}` : 'Leave Region', icon: '🚪', position: { x: 490, y: 250 } }]
+
   const targets: Target[] = [
     ...landmarks
       .map((lm, i) => ({
@@ -61,14 +74,14 @@ export function TargetList({
         position2d: lm.position,
       }))
       .filter(t => !t.hidden),
-    {
-      index: landmarks.length,
-      name: regionName ? `Leave ${regionName}` : 'Leave Region',
-      icon: '🚪',
+    ...exitList.map((exit, i) => ({
+      index: landmarks.length + i,
+      name: exit.name,
+      icon: exit.icon,
       type: 'region_exit' as const,
       position: regionLength,
-      position2d: { x: 490, y: 250 },
-    },
+      position2d: exit.position,
+    })),
   ]
 
   return (

--- a/src/app/tap-tap-adventure/hooks/useGameStore.ts
+++ b/src/app/tap-tap-adventure/hooks/useGameStore.ts
@@ -270,8 +270,13 @@ export const useGameStore = create<GameStore>()(
                 const isExit = activeIdx >= ls.landmarks.length
                 let targetPos: Vec2 | null = null
 
-                if (isExit && ls.exitPosition) {
-                  targetPos = ls.exitPosition
+                if (isExit) {
+                  if (ls.exitPositions && ls.exitPositions.length > 0) {
+                    const exitIdx = activeIdx - ls.landmarks.length
+                    targetPos = ls.exitPositions[exitIdx]?.position ?? ls.exitPosition ?? null
+                  } else if (ls.exitPosition) {
+                    targetPos = ls.exitPosition
+                  }
                 } else if (!isExit && ls.landmarks[activeIdx]?.position) {
                   targetPos = ls.landmarks[activeIdx].position!
                 }
@@ -1320,8 +1325,13 @@ export const useGameStore = create<GameStore>()(
               const activeIdx = ls.activeTargetIndex ?? 0
               const isExit = activeIdx >= ls.landmarks.length
               let targetPos: Vec2 | null = null
-              if (isExit && ls.exitPosition) {
-                targetPos = ls.exitPosition
+              if (isExit) {
+                if (ls.exitPositions && ls.exitPositions.length > 0) {
+                  const exitIdx = activeIdx - ls.landmarks.length
+                  targetPos = ls.exitPositions[exitIdx]?.position ?? ls.exitPosition ?? null
+                } else if (ls.exitPosition) {
+                  targetPos = ls.exitPosition
+                }
               } else if (!isExit && ls.landmarks[activeIdx]?.position) {
                 targetPos = ls.landmarks[activeIdx].position!
               }

--- a/src/app/tap-tap-adventure/models/character.ts
+++ b/src/app/tap-tap-adventure/models/character.ts
@@ -93,6 +93,12 @@ export const FantasyCharacterSchema = z.object({
     regionLength: z.number().default(200),
     position: z.object({ x: z.number(), y: z.number() }).optional(),
     exitPosition: z.object({ x: z.number(), y: z.number() }).optional(),
+    exitPositions: z.array(z.object({
+      regionId: z.string(),
+      name: z.string(),
+      icon: z.string(),
+      position: z.object({ x: z.number(), y: z.number() }),
+    })).optional(),
     regionBounds: z.object({ width: z.number(), height: z.number() }).optional(),
   }).optional(),
 })


### PR DESCRIPTION
## Summary
Replaces the single "Leave Green Meadows" exit with separate exits per connected region:
- "Path to Dark Forest" at one edge of the region
- "Path to Sunken Ruins" at another edge
- "Path to Starting Village" at a third edge

Each exit is a real location with 2D coordinates spread evenly around the region perimeter. Walking toward an exit takes you directly to that region — no more "pick which region" popup after arriving.

## Changes
- **character.ts**: added `exitPositions` array to landmark state schema
- **moveForwardService.ts**: generates per-region exit positions on region init; arrival at a specific exit shows focused decision (enter, face boss, or turn back)
- **TargetList.tsx**: renders each exit as a separate target
- **GameUI.tsx**: resolves exit position from `exitPositions[exitIdx]`
- **useGameStore.ts**: movement toward exits uses the specific exit's coordinates

Includes the 2D-only arrival fix from PR #300 applied to exit checks.

## Test plan
- [ ] Enter Green Meadows — see 3 separate exits at different distances
- [ ] Walk toward one exit — distance decreases, others change naturally
- [ ] Arrive at exit — focused decision for that specific region

🤖 Generated with [Claude Code](https://claude.com/claude-code)