### PR TITLE
fix: explore-landmark uses activeTargetIndex instead of nextLandmarkIndex (#302)

### DIFF
--- a/src/app/api/v1/tap-tap-adventure/resolve-decision/route.ts
+++ b/src/app/api/v1/tap-tap-adventure/resolve-decision/route.ts
@@ -128,19 +128,17 @@ export async function POST(req: NextRequest) {
       }
     }
 
-    // Handle explore-landmark: increment nextLandmarkIndex, call LLM with landmark context
+    // Handle explore-landmark: use activeTargetIndex to find the landmark the player walked to
     if (optionId === 'explore-landmark') {
       const landmarkState = character.landmarkState
-      const exploredLandmark = landmarkState?.landmarks[landmarkState.nextLandmarkIndex]
+      const targetIndex = landmarkState?.activeTargetIndex ?? 0
+      const exploredLandmark = landmarkState?.landmarks[targetIndex]
 
       const updatedLandmarkState = landmarkState
         ? {
             ...landmarkState,
-            nextLandmarkIndex: landmarkState.nextLandmarkIndex + 1,
-            activeTargetIndex: Math.min(
-              landmarkState.nextLandmarkIndex + 1,
-              landmarkState.landmarks.length
-            ),
+            // Don't auto-advance indexes — player stays at this landmark until they leave
+            nextLandmarkIndex: targetIndex,
             exploring: true,
             explorationDepth: 1,
             exploringLandmarkName: exploredLandmark?.name ?? 'the landmark',


### PR DESCRIPTION
## Summary
The explore-landmark handler used \`nextLandmarkIndex\` to find which landmark the player was exploring, but the player walked to it via \`activeTargetIndex\`. When out of sync, \`exploredLandmark\` was undefined → LLM had no context → exploration produced nothing visible.

## Changes
- Line 134: \`landmarks[nextLandmarkIndex]\` → \`landmarks[activeTargetIndex]\`
- Lines 139-143: removed auto-advance of both indexes. Player stays at current landmark until they leave.
- \`nextLandmarkIndex\` synced to \`activeTargetIndex\` (kept for backward compat)

## Test plan
- [ ] Walk to a landmark → click Explore → encounter content appears
- [ ] Encounter matches the landmark you walked to (not a different one)
- [ ] Continue exploring works for multiple encounters
- [ ] Leaving the landmark returns to the target list

Closes #302

🤖 Generated with [Claude Code](https://claude.com/claude-code)