### PR TITLE
Replace remaining 'steps' with 'km' in user-facing strings

### DIFF
--- a/src/app/tap-tap-adventure/components/ShopUI.tsx
+++ b/src/app/tap-tap-adventure/components/ShopUI.tsx
@@ -304,7 +304,7 @@ export function ShopUI() {
             if (mount.bonuses.intelligence) bonusParts.push(`+${mount.bonuses.intelligence} INT`)
             if (mount.bonuses.luck) bonusParts.push(`+${mount.bonuses.luck} LCK`)
             if (mount.bonuses.autoWalkSpeed) bonusParts.push(`${mount.bonuses.autoWalkSpeed}x speed`)
-            if (mount.bonuses.healRate) bonusParts.push(`+${mount.bonuses.healRate} heal/step`)
+            if (mount.bonuses.healRate) bonusParts.push(`+${mount.bonuses.healRate} heal/km`)
             return (
               <div className="border border-purple-500/40 bg-[#2a2040] rounded-lg p-3 space-y-1">
                 <div className="flex justify-between items-start">
@@ -390,7 +390,7 @@ export function ShopUI() {
             if (mount.bonuses.intelligence) bonusParts.push(`+${mount.bonuses.intelligence} INT`)
             if (mount.bonuses.luck) bonusParts.push(`+${mount.bonuses.luck} LCK`)
             if (mount.bonuses.autoWalkSpeed) bonusParts.push(`${mount.bonuses.autoWalkSpeed}x speed`)
-            if (mount.bonuses.healRate) bonusParts.push(`+${mount.bonuses.healRate} heal/step`)
+            if (mount.bonuses.healRate) bonusParts.push(`+${mount.bonuses.healRate} heal/km`)
             return (
               <div className="border border-purple-500/40 bg-[#2a2040] rounded-lg p-3 space-y-1">
                 <div className="flex justify-between items-start">

--- a/src/app/tap-tap-adventure/hooks/useGameStore.ts
+++ b/src/app/tap-tap-adventure/hooks/useGameStore.ts
@@ -1349,7 +1349,7 @@ export const useGameStore = create<GameStore>()(
               position: newLsPosition,
             }
             updates.distance = (character.distance ?? 0) + effect.value
-            message = `${spell.name}: Advanced ${effect.value} steps! (${manaCost} MP spent)`
+            message = `${spell.name}: Advanced ${effect.value} km! (${manaCost} MP spent)`
             break
           }
           case 'shield': {

--- a/src/app/tap-tap-adventure/lib/heirloomGenerator.ts
+++ b/src/app/tap-tap-adventure/lib/heirloomGenerator.ts
@@ -106,7 +106,7 @@ function generateEquipmentHeirloom(character: FantasyCharacter): Item {
     effects,
     isHeirloom: true,
     rarity,
-    loreText: `Carried by ${character.name} through ${character.distance ?? 0} steps of adventure.`,
+    loreText: `Carried by ${character.name} through ${character.distance ?? 0} km of adventure.`,
     ...(onHitEffect ? { onHitEffect } : {}),
     ...(drawback ? { drawback } : {}),
   }

--- a/src/app/tap-tap-adventure/lib/questGenerator.ts
+++ b/src/app/tap-tap-adventure/lib/questGenerator.ts
@@ -18,8 +18,8 @@ interface QuestTemplate {
 const QUEST_TEMPLATES: QuestTemplate[] = [
   {
     type: 'reach_distance',
-    getTitle: (target) => `Journey to Step ${target}`,
-    getDescription: (target, days) => `Travel to step ${target} within ${days} days. Keep moving!`,
+    getTitle: (target) => `Journey to km ${target}`,
+    getDescription: (target, days) => `Travel to km ${target} within ${days} days. Keep moving!`,
     getTarget: (char) => char.distance + 75 + Math.floor(Math.random() * 50),
     getDaysAllowed: (char) => 3 + Math.floor(char.level / 2),
     getStartValue: (char) => char.distance,


### PR DESCRIPTION
## Summary
- Fixes #310 — replaces remaining "steps" distance references with "km" in user-facing strings
- **questGenerator.ts**: "Journey to Step N" → "Journey to km N", "Travel to step N" → "Travel to km N"
- **heirloomGenerator.ts**: "N steps of adventure" → "N km of adventure"
- **ShopUI.tsx**: "heal/step" → "heal/km" (2 occurrences in mount tooltips)
- **useGameStore.ts**: "Advanced N steps!" → "Advanced N km!" (spell teleport message)

Narrative uses of "step" as a verb (e.g. "steps into your path") and code identifiers were intentionally left unchanged.

## Test plan
- [ ] Check quest descriptions show "km" not "steps"
- [ ] Check heirloom lore text shows "km"
- [ ] Check mount shop tooltips show "heal/km"
- [ ] Check teleport spell message shows "km"
- [ ] All 736 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)