### PR TITLE
Mount speed increases travel distance per click

### DIFF
--- a/src/app/api/v1/tap-tap-adventure/move-forward/services/moveForwardService.ts
+++ b/src/app/api/v1/tap-tap-adventure/move-forward/services/moveForwardService.ts
@@ -18,7 +18,9 @@ export async function moveForwardService(
   character: FantasyCharacter,
   storyEvents: FantasyStoryEvent[] = []
 ): Promise<MoveForwardResponse> {
-  const newDistance = character.distance + BASE_DISTANCE
+  const mountSpeed = character.activeMount?.bonuses?.autoWalkSpeed ?? 1
+  const moveDistance = BASE_DISTANCE * mountSpeed
+  const newDistance = character.distance + moveDistance
   const updatedCharacter = { ...character, distance: newDistance }
   const day = calculateDay(newDistance)
 
@@ -116,8 +118,8 @@ export async function moveForwardService(
 
   const landmarkState = existingLandmarkState
 
-  // Increment positionInRegion by 1 for this step
-  const newPositionInRegion = (landmarkState.positionInRegion ?? 0) + 1
+  // Increment positionInRegion by moveDistance for this step
+  const newPositionInRegion = (landmarkState.positionInRegion ?? 0) + moveDistance
   const activeTargetIndex = landmarkState.activeTargetIndex ?? 0
 
   // Compute updated 2D position for this step
@@ -132,7 +134,7 @@ export async function moveForwardService(
     activePosTarget = landmarkState.landmarks[activeTargetIndex]?.position
   }
   if (updatedPosition && activePosTarget) {
-    updatedPosition = moveToward(updatedPosition, activePosTarget)
+    updatedPosition = moveToward(updatedPosition, activePosTarget, moveDistance)
   }
 
   // Priority 2: Target arrival check

--- a/src/app/tap-tap-adventure/components/GameUI.tsx
+++ b/src/app/tap-tap-adventure/components/GameUI.tsx
@@ -240,12 +240,13 @@ export default function GameUI({ onOpenStatus }: GameUIProps) {
     if (moveForwardPending) return
     soundEngine.playTap()
     const character = getSelectedCharacter()
+    const mountSpeed = character?.activeMount?.bonuses?.autoWalkSpeed ?? 1
     const distance = character?.distance ?? 0
-    const nextDistance = distance + 1
+    const nextDistance = distance + mountSpeed
 
     // Check if the next step would hit a target arrival (landmark or region exit)
     const ls = character?.landmarkState
-    const nextPosInRegion = (ls?.positionInRegion ?? 0) + 1
+    const nextPosInRegion = (ls?.positionInRegion ?? 0) + mountSpeed
     const activeTargetIndex = ls?.activeTargetIndex ?? 0
     const isExitTarget = ls ? activeTargetIndex >= ls.landmarks.length : false
     const activeTargetPosition = ls
@@ -264,7 +265,7 @@ export default function GameUI({ onOpenStatus }: GameUIProps) {
       targetPos2d = ls?.landmarks[activeTargetIndex]?.position
     }
     const hitsTarget = charPos && targetPos2d
-      ? hasArrived(moveToward(charPos, targetPos2d), targetPos2d)
+      ? hasArrived(moveToward(charPos, targetPos2d, mountSpeed), targetPos2d)
       : (!charPos && ls != null && nextPosInRegion >= activeTargetPosition) // 1D ONLY when no 2D data
 
     // Always call server for milestone events (shop, target arrival)
@@ -281,7 +282,7 @@ export default function GameUI({ onOpenStatus }: GameUIProps) {
     if (shouldDoNothing) {
       const genericMessage = getGenericTravelMessage()
       setGenericMessage(genericMessage)
-      incrementDistance()
+      incrementDistance(mountSpeed)
     } else {
       moveForwardMutation()
     }

--- a/src/app/tap-tap-adventure/hooks/useGameStore.ts
+++ b/src/app/tap-tap-adventure/hooks/useGameStore.ts
@@ -101,7 +101,7 @@ export interface GameStore {
   clearGameState: () => void
   deleteCharacter: (id: string) => void
   getSelectedCharacter: () => FantasyCharacter | null
-  incrementDistance: () => void
+  incrementDistance: (distanceMultiplier?: number) => void
   selectCharacter: (id: string) => void
   setCombatState: (combatState: CombatState | null) => void
   setShopState: (shopState: ShopState | null) => void
@@ -223,7 +223,7 @@ export const useGameStore = create<GameStore>()(
         if (!state) return null
         return state.characters?.find(c => c.id === state.selectedCharacterId) ?? null
       },
-      incrementDistance: () => {
+      incrementDistance: (distanceMultiplier: number = 1) => {
         set(
           produce((state: GameStore) => {
             const selectedCharacter = get().getSelectedCharacter()
@@ -243,12 +243,12 @@ export const useGameStore = create<GameStore>()(
               state.gameState.dailyChallenges = applyDailyChallengeProgress(
                 state.gameState.dailyChallenges,
                 'travel_distance',
-                1
+                distanceMultiplier
               )
             }
 
             const oldDistance = selectedCharacter.distance || 0
-            const newDistance = oldDistance + 1
+            const newDistance = oldDistance + distanceMultiplier
             const metaBonuses = get().getMetaBonuses()
             const campBonuses = get().getCampBonuses()
             let updatedCharacter = applyLevelFromDistance({
@@ -261,7 +261,7 @@ export const useGameStore = create<GameStore>()(
               const ls = updatedCharacter.landmarkState
               let newLandmarkState = {
                 ...ls,
-                positionInRegion: (ls.positionInRegion ?? 0) + 1,
+                positionInRegion: (ls.positionInRegion ?? 0) + distanceMultiplier,
               }
 
               // Update 2D position toward active target
@@ -284,7 +284,7 @@ export const useGameStore = create<GameStore>()(
                 if (targetPos) {
                   newLandmarkState = {
                     ...newLandmarkState,
-                    position: moveToward(ls.position, targetPos),
+                    position: moveToward(ls.position, targetPos, distanceMultiplier),
                   }
                 }
               }


### PR DESCRIPTION
## Summary
- Fixes #307 — mounts now increase travel distance per click, not just auto-walk speed
- A Horse (1.5x) moves 1.5 units per click, a Dragon (2x) moves 2 units per click
- Applied consistently across server-side movement, client-side `incrementDistance`, and 2D position updates
- Uses the existing `autoWalkSpeed` mount bonus as the multiplier

### Changes
- **moveForwardService.ts** — `BASE_DISTANCE * mountSpeed` for distance, position, and 2D movement stepSize
- **useGameStore.ts** — `incrementDistance` accepts optional `distanceMultiplier` parameter
- **GameUI.tsx** — calculates `mountSpeed` and passes it through for arrival detection and distance increment

## Test plan
- [ ] Without mount: each click moves 1 unit (unchanged behavior)
- [ ] With Horse (1.5x): each click moves 1.5 units
- [ ] With Dragon (2x): each click moves 2 units
- [ ] Landmark arrival detection still works correctly with fractional distances
- [ ] Region exit detection works correctly
- [ ] Auto-walk still functions at the correct speed
- [ ] All 736 tests pass, build compiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)