### PR TITLE
feat(#306): scale distances by region difficulty

### DIFF
--- a/src/app/api/v1/tap-tap-adventure/move-forward/services/moveForwardService.ts
+++ b/src/app/api/v1/tap-tap-adventure/move-forward/services/moveForwardService.ts
@@ -31,11 +31,11 @@ export async function moveForwardService(
   const existingLandmarkState = character.landmarkState
   if (!existingLandmarkState || existingLandmarkState.regionId !== currentRegion) {
     const visitCount = (character.visitedRegions ?? []).filter(id => id === currentRegion).length
-    const landmarks = generateLandmarks(currentRegion, character.id, visitCount)
+    const landmarks = generateLandmarks(currentRegion, character.id, visitCount, region.difficultyMultiplier)
 
-    // Seeded region length between 150-250 steps
+    // Seeded region length between 150-250 steps, scaled by difficulty
     const regionLengthSeed = `${currentRegion}-${character.id}-${visitCount}-length`
-    const regionLength = 150 + Math.floor(seededRandom(regionLengthSeed)() * 101)
+    const regionLength = Math.floor((150 + Math.floor(seededRandom(regionLengthSeed)() * 101)) * region.difficultyMultiplier)
 
     // Generate exit positions spread around region edges, one per connected region
     const connected = getConnectedRegions(region.id)

--- a/src/app/tap-tap-adventure/__tests__/landmarks.test.ts
+++ b/src/app/tap-tap-adventure/__tests__/landmarks.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import { generateLandmarks, seededRandom } from '../lib/landmarkGenerator'
 import { getTemplatesForRegion, LANDMARK_TEMPLATES } from '../config/landmarks'
+import { getRegion } from '../config/regions'
 
 const ALL_REGION_IDS = [
   'starting_village',
@@ -21,9 +22,9 @@ const ALL_REGION_IDS = [
 ]
 
 // Helper to compute regionLength the same way the service does
-function generateRegionLength(regionId: string, charId: string, visitCount: number): number {
+function generateRegionLength(regionId: string, charId: string, visitCount: number, difficultyMultiplier: number = 1): number {
   const seed = `${regionId}-${charId}-${visitCount}-length`
-  return 150 + Math.floor(seededRandom(seed)() * 101)
+  return Math.floor((150 + Math.floor(seededRandom(seed)() * 101)) * difficultyMultiplier)
 }
 
 describe('generateLandmarks', () => {
@@ -77,20 +78,24 @@ describe('generateLandmarks', () => {
     expect(aIds).not.toBe(bIds)
   })
 
-  it('first landmark distance is in range 20-40', () => {
+  it('first landmark distance scales with region difficulty', () => {
     for (const regionId of ALL_REGION_IDS) {
-      const landmarks = generateLandmarks(regionId, 'char-1')
-      expect(landmarks[0].distanceFromEntry).toBeGreaterThanOrEqual(20)
-      expect(landmarks[0].distanceFromEntry).toBeLessThanOrEqual(40)
+      const region = getRegion(regionId)
+      const mult = region.difficultyMultiplier
+      const landmarks = generateLandmarks(regionId, 'char-1', 0, mult)
+      expect(landmarks[0].distanceFromEntry).toBeGreaterThanOrEqual(Math.floor(20 * mult))
+      expect(landmarks[0].distanceFromEntry).toBeLessThanOrEqual(Math.floor(40 * mult))
     }
   })
 
-  it('all landmark distances are in range [20, 140]', () => {
+  it('all landmark distances scale with region difficulty', () => {
     for (const regionId of ALL_REGION_IDS) {
-      const landmarks = generateLandmarks(regionId, 'char-1')
+      const region = getRegion(regionId)
+      const mult = region.difficultyMultiplier
+      const landmarks = generateLandmarks(regionId, 'char-1', 0, mult)
       for (const lm of landmarks) {
-        expect(lm.distanceFromEntry).toBeGreaterThanOrEqual(20)
-        expect(lm.distanceFromEntry).toBeLessThanOrEqual(140)
+        expect(lm.distanceFromEntry).toBeGreaterThanOrEqual(Math.floor(20 * mult) - 1)
+        expect(lm.distanceFromEntry).toBeLessThanOrEqual(Math.ceil(140 * mult))
       }
     }
   })
@@ -138,11 +143,12 @@ describe('seededRandom', () => {
 })
 
 describe('regionLength determinism', () => {
-  it('returns a value in [150, 250] for all known regions', () => {
+  it('returns a scaled value based on region difficulty', () => {
     for (const regionId of ALL_REGION_IDS) {
-      const len = generateRegionLength(regionId, 'char-test', 0)
-      expect(len).toBeGreaterThanOrEqual(150)
-      expect(len).toBeLessThanOrEqual(250)
+      const region = getRegion(regionId)
+      const len = generateRegionLength(regionId, 'char-test', 0, region.difficultyMultiplier)
+      expect(len).toBeGreaterThanOrEqual(Math.floor(150 * region.difficultyMultiplier))
+      expect(len).toBeLessThanOrEqual(Math.ceil(250 * region.difficultyMultiplier))
     }
   })
 

--- a/src/app/tap-tap-adventure/lib/landmarkGenerator.ts
+++ b/src/app/tap-tap-adventure/lib/landmarkGenerator.ts
@@ -57,7 +57,8 @@ function seededShuffle<T>(arr: T[], rng: () => number): T[] {
 export function generateLandmarks(
   regionId: string,
   characterId: string,
-  visitCount: number = 0
+  visitCount: number = 0,
+  difficultyMultiplier: number = 1
 ): GeneratedLandmark[] {
   const templates = getTemplatesForRegion(regionId)
   const seed = `${regionId}-${characterId}-${visitCount}`
@@ -66,8 +67,8 @@ export function generateLandmarks(
   // Pick 3 landmarks from templates (shuffled deterministically)
   const selected = seededShuffle([...templates], rng).slice(0, 3) as LandmarkTemplate[]
 
-  // Assign distances: first at 20-40 steps, subsequent 25-50 steps apart
-  let currentDist = 20 + Math.floor(rng() * 21) // 20-40
+  // Assign distances: first at 20-40 steps, subsequent 25-50 steps apart (scaled by difficulty)
+  let currentDist = Math.floor((20 + Math.floor(rng() * 21)) * difficultyMultiplier) // 20-40, scaled
   const landmarks: GeneratedLandmark[] = []
 
   for (const template of selected) {
@@ -85,7 +86,7 @@ export function generateLandmarks(
       explored: false,
       position,
     })
-    currentDist += 25 + Math.floor(rng() * 26) // 25-50
+    currentDist += Math.floor((25 + Math.floor(rng() * 26)) * difficultyMultiplier) // 25-50, scaled
   }
 
   // Add 1 secret landmark per region (hidden until revealed)


### PR DESCRIPTION
## Summary
- Landmark distances and region lengths now scale with each region's `difficultyMultiplier`
- Green Meadows (0.8x) landmarks appear at 16-32 steps instead of 20-40 — much closer together for new players
- Celestial Throne (2.8x) landmarks appear at 56-112 steps — rewarding endgame traversal
- Region length also scales: easy regions are shorter to cross, hard regions are longer

Closes #306

## Changes
- `landmarkGenerator.ts`: Added `difficultyMultiplier` parameter, applied to first landmark distance and inter-landmark spacing
- `moveForwardService.ts`: Passes `region.difficultyMultiplier` to landmark generator and scales region length
- `landmarks.test.ts`: Updated distance range assertions to account for per-region scaling

## Test plan
- [x] All 21 landmark tests pass
- [ ] Playtest Green Meadows — landmarks should feel closer (16-32 steps to first landmark)
- [ ] Playtest a harder region — landmarks should be proportionally farther apart

🤖 Generated with [Claude Code](https://claude.com/claude-code)