### PR TITLE
feat(#313): make target selector collapsible on mobile

### DIFF
--- a/src/app/tap-tap-adventure/components/TargetList.tsx
+++ b/src/app/tap-tap-adventure/components/TargetList.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { useState } from 'react'
 import { euclidean } from '@/app/tap-tap-adventure/lib/movementUtils'
 
 // Minimal landmark shape compatible with both GeneratedLandmark and the character schema
@@ -55,6 +56,8 @@ export function TargetList({
   characterPosition,
   exitTargets,
 }: TargetListProps) {
+  const [isExpanded, setIsExpanded] = useState(false)
+
   // Build target list: landmarks + per-exit targets (hidden landmarks are excluded from display)
   const exitList = exitTargets && exitTargets.length > 0
     ? exitTargets
@@ -84,55 +87,118 @@ export function TargetList({
     })),
   ]
 
+  const activeTarget = targets.find(t => t.index === activeTargetIndex) ?? targets[0]
+
   return (
     <div className="space-y-1">
       <p className="text-[10px] text-slate-500 uppercase tracking-wide mb-1">Targets</p>
-      {targets.map(target => {
-        const isExplored = target.isExplored ?? false
-        const isActive = target.index === activeTargetIndex
-        const stepsRemaining = characterPosition && target.position2d
-          ? Math.ceil(euclidean(characterPosition, target.position2d))
-          : Math.max(0, target.position - positionInRegion)
 
-        return (
+      {/* Mobile collapsed view - only show on small screens when not expanded */}
+      {!isExpanded && (
+        <div className="md:hidden">
+          {activeTarget && (() => {
+            const isExplored = activeTarget.isExplored ?? false
+            const stepsRemaining = characterPosition && activeTarget.position2d
+              ? Math.ceil(euclidean(characterPosition, activeTarget.position2d))
+              : Math.max(0, activeTarget.position - positionInRegion)
+
+            return (
+              <div className="flex items-center gap-1">
+                <div className="flex-1 flex items-center justify-between px-2.5 py-1.5 rounded text-xs bg-indigo-900/50 border border-indigo-500/60 text-indigo-200">
+                  <span className="flex items-center gap-1.5 min-w-0">
+                    <span className="text-sm flex-shrink-0">{activeTarget.icon}</span>
+                    <span className="truncate font-medium">{activeTarget.name}</span>
+                    {activeTarget.hasShop && (
+                      <span className="text-[9px] px-1 py-0.5 rounded bg-yellow-900/40 border border-yellow-600/40 text-yellow-300 flex-shrink-0">
+                        Shop
+                      </span>
+                    )}
+                  </span>
+                  <span className="flex items-center gap-1 flex-shrink-0 ml-2">
+                    {isExplored ? (
+                      <span className="text-[10px] text-slate-500">explored</span>
+                    ) : (
+                      <span className="text-[10px] text-indigo-300">
+                        {stepsRemaining === 0 ? 'here' : `${stepsRemaining} km`}
+                      </span>
+                    )}
+                  </span>
+                </div>
+                <button
+                  onClick={() => setIsExpanded(true)}
+                  className="px-2 py-1.5 rounded text-[10px] text-slate-400 hover:text-slate-200 border border-[#3a3c56] hover:border-indigo-600/50 bg-[#1e1f30] transition-colors flex-shrink-0"
+                >
+                  Change &#9660;
+                </button>
+              </div>
+            )
+          })()}
+        </div>
+      )}
+
+      {/* Full list - always visible on md+, toggleable on mobile */}
+      <div className={`${isExpanded ? '' : 'hidden'} md:block`}>
+        {/* On mobile when expanded, show collapse button */}
+        {isExpanded && (
           <button
-            key={target.index}
-            onClick={() => !disabled && onSelectTarget(target.index)}
-            disabled={disabled}
-            className={`w-full text-left flex items-center justify-between px-2.5 py-1.5 rounded text-xs transition-colors border ${
-              isActive
-                ? 'bg-indigo-900/50 border-indigo-500/60 text-indigo-200'
-                : isExplored
-                ? 'bg-[#1a1b2e]/40 border-[#2a2b3f]/50 text-slate-500 opacity-60 hover:border-indigo-600/30 hover:text-slate-400'
-                : 'bg-[#1e1f30] border-[#3a3c56] text-slate-300 hover:border-indigo-600/50 hover:text-slate-100'
-            } disabled:cursor-not-allowed`}
+            onClick={() => setIsExpanded(false)}
+            className="md:hidden w-full text-center text-[10px] text-slate-400 hover:text-slate-200 py-1 mb-1"
           >
-            <span className="flex items-center gap-1.5 min-w-0">
-              <span className="text-sm flex-shrink-0">{target.icon}</span>
-              <span className="truncate font-medium">{target.name}</span>
-              {target.hasShop && (
-                <span className="text-[9px] px-1 py-0.5 rounded bg-yellow-900/40 border border-yellow-600/40 text-yellow-300 flex-shrink-0">
-                  Shop
-                </span>
-              )}
-            </span>
-            <span className="flex items-center gap-1 flex-shrink-0 ml-2">
-              {isExplored ? (
-                <span className="text-[10px] text-slate-500">explored</span>
-              ) : (
-                <span className={`text-[10px] ${isActive ? 'text-indigo-300' : 'text-slate-400'}`}>
-                  {stepsRemaining === 0 ? 'here' : `${stepsRemaining} km`}
-                </span>
-              )}
-              {isActive && !isExplored && (
-                <span className="text-[9px] px-1 py-0.5 rounded bg-indigo-700/60 text-indigo-200 border border-indigo-500/40">
-                  active
-                </span>
-              )}
-            </span>
+            &#9650; Collapse
           </button>
-        )
-      })}
+        )}
+        {targets.map(target => {
+          const isExplored = target.isExplored ?? false
+          const isActive = target.index === activeTargetIndex
+          const stepsRemaining = characterPosition && target.position2d
+            ? Math.ceil(euclidean(characterPosition, target.position2d))
+            : Math.max(0, target.position - positionInRegion)
+
+          return (
+            <button
+              key={target.index}
+              onClick={() => {
+                if (!disabled) {
+                  onSelectTarget(target.index)
+                  setIsExpanded(false)
+                }
+              }}
+              disabled={disabled}
+              className={`w-full text-left flex items-center justify-between px-2.5 py-1.5 rounded text-xs transition-colors border ${
+                isActive
+                  ? 'bg-indigo-900/50 border-indigo-500/60 text-indigo-200'
+                  : isExplored
+                  ? 'bg-[#1a1b2e]/40 border-[#2a2b3f]/50 text-slate-500 opacity-60 hover:border-indigo-600/30 hover:text-slate-400'
+                  : 'bg-[#1e1f30] border-[#3a3c56] text-slate-300 hover:border-indigo-600/50 hover:text-slate-100'
+              } disabled:cursor-not-allowed`}
+            >
+              <span className="flex items-center gap-1.5 min-w-0">
+                <span className="text-sm flex-shrink-0">{target.icon}</span>
+                <span className="truncate font-medium">{target.name}</span>
+                {target.hasShop && (
+                  <span className="text-[9px] px-1 py-0.5 rounded bg-yellow-900/40 border border-yellow-600/40 text-yellow-300 flex-shrink-0">
+                    Shop
+                  </span>
+                )}
+              </span>
+              <span className="flex items-center gap-1 flex-shrink-0 ml-2">
+                {isExplored ? (
+                  <span className="text-[10px] text-slate-500">explored</span>
+                ) : (
+                  <span className={`text-[10px] ${isActive ? 'text-indigo-300' : 'text-slate-400'}`}>
+                    {stepsRemaining === 0 ? 'here' : `${stepsRemaining} km`}
+                  </span>
+                )}
+                {isActive && !isExplored && (
+                  <span className="text-[9px] px-1 py-0.5 rounded bg-indigo-700/60 text-indigo-200 border border-indigo-500/40">
+                    active
+                  </span>
+                )}
+              </span>
+            </button>
+          )
+        })}
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- Target selector now defaults to collapsed on mobile, showing only the active target with a "Change ▼" button
- Selecting a new target auto-collapses the list
- Desktop experience unchanged — full list always visible
- Saves ~150-200px of vertical space on mobile during normal gameplay

Closes #313

## Changes
- `TargetList.tsx`: Added local `isExpanded` state, mobile collapsed view with active target summary, responsive show/hide using `md:block`/`md:hidden`

## Test plan
- [ ] Mobile: target list shows only active target by default
- [ ] Mobile: tapping "Change ▼" expands the full list
- [ ] Mobile: selecting a target collapses the list
- [ ] Mobile: "▲ Collapse" button works
- [ ] Desktop: full list always visible, no collapse UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)