### PR TITLE
feat(#316): reveal hidden landmarks from story events and NPC dialogue

### DIFF
--- a/src/app/api/v1/tap-tap-adventure/npc/dialogue/route.ts
+++ b/src/app/api/v1/tap-tap-adventure/npc/dialogue/route.ts
@@ -20,6 +20,8 @@ const DialogueRequestSchema = z.object({
   })).optional(),
   disposition: z.number().optional(),
   exchangeCount: z.number().optional(),
+  hiddenLandmarkName: z.string().optional(),
+  hiddenLandmarkType: z.string().optional(),
 })
 
 function getOpenAI() {
@@ -49,6 +51,8 @@ export async function POST(req: NextRequest) {
       conversationHistory,
       disposition = 0,
       exchangeCount = 1,
+      hiddenLandmarkName,
+      hiddenLandmarkType,
     } = parseResult.data
 
     const charisma = characterCharisma ?? 5
@@ -68,6 +72,10 @@ export async function POST(req: NextRequest) {
           .join(', ')
       : 'balanced'
 
+    const landmarkHint = hiddenLandmarkName
+      ? `\n\nHIDDEN LANDMARK: There is a hidden landmark nearby called "${hiddenLandmarkName}" (${hiddenLandmarkType ?? 'location'}). If the player has good rapport with you (disposition > 30) and it feels narratively natural, you may share a rumor or hint about this place. When you do, set "revealLandmark": true in your response. Only reveal it occasionally — not every conversation.`
+      : ''
+
     const systemPrompt = `You are ${npc.name}, ${npc.role} in ${regionName}. Personality: ${npc.personality}
 
 RELATIONSHIP: The player's current disposition toward you is ${disposition} (${tier.label}). Adjust your warmth and willingness accordingly.
@@ -79,7 +87,7 @@ CONVERSATION: This is exchange ${exchangeCount}.
 Evaluate the player's message for intent. Choose one of: flatter, charm, threaten, inquire, offend, lie, bore, neutral.
 Your personality preferences (how much you like each intent): ${weightsDescription}
 
-Respond in character. Keep responses under 4 sentences.
+Respond in character. Keep responses under 4 sentences.${landmarkHint}
 
 RESPOND WITH ONLY THIS JSON (no markdown, no code fences):
 {
@@ -87,7 +95,8 @@ RESPOND WITH ONLY THIS JSON (no markdown, no code fences):
   "intent": "detected intent",
   "dispositionDelta": <integer from -10 to 8>,
   "conversationComplete": <true if exchange >= 3 and conversation feels naturally concluded, otherwise false>,
-  "reward": { "gold": <integer 0-25>, "reputation": <integer 0-5> } or null
+  "reward": { "gold": <integer 0-25>, "reputation": <integer 0-5> } or null,
+  "revealLandmark": <true if you are revealing the hidden landmark to the player, otherwise omit>
 }`
 
     const userMessage = message
@@ -117,6 +126,7 @@ RESPOND WITH ONLY THIS JSON (no markdown, no code fences):
         dispositionDelta?: number
         conversationComplete?: boolean
         reward?: { gold?: number; reputation?: number } | null
+        revealLandmark?: boolean
       } = {}
 
       try {
@@ -144,6 +154,7 @@ RESPOND WITH ONLY THIS JSON (no markdown, no code fences):
         dispositionDelta,
         conversationComplete: parsed.conversationComplete ?? false,
         reward,
+        revealLandmark: parsed.revealLandmark === true ? true : undefined,
       })
     } catch (err) {
       console.error('NPC dialogue LLM call failed', err)

--- a/src/app/tap-tap-adventure/components/GameUI.tsx
+++ b/src/app/tap-tap-adventure/components/GameUI.tsx
@@ -656,8 +656,10 @@ export default function GameUI({ onOpenStatus }: GameUIProps) {
                           region={character?.currentRegion ?? 'green_meadows'}
                           characterCharisma={character?.charisma ?? 5}
                           disposition={disposition}
-                          onEncounterUpdate={(dispositionDelta, reward) => {
-                            recordNPCEncounter(npc.id, dispositionDelta, reward)
+                          hiddenLandmarkName={character?.landmarkState?.landmarks.find(lm => lm.hidden)?.name}
+                          hiddenLandmarkType={character?.landmarkState?.landmarks.find(lm => lm.hidden)?.type}
+                          onEncounterUpdate={(dispositionDelta, reward, revealLandmark) => {
+                            recordNPCEncounter(npc.id, dispositionDelta, reward, revealLandmark)
                           }}
                           onClose={() => {
                             setShowNPCPanel(false)
@@ -947,8 +949,10 @@ export default function GameUI({ onOpenStatus }: GameUIProps) {
                   region={character.currentRegion ?? 'green_meadows'}
                   characterCharisma={character.charisma ?? 5}
                   disposition={disposition}
-                  onEncounterUpdate={(dispositionDelta, reward) => {
-                    recordNPCEncounter(npc.id, dispositionDelta, reward)
+                  hiddenLandmarkName={character.landmarkState?.landmarks.find(lm => lm.hidden)?.name}
+                  hiddenLandmarkType={character.landmarkState?.landmarks.find(lm => lm.hidden)?.type}
+                  onEncounterUpdate={(dispositionDelta, reward, revealLandmark) => {
+                    recordNPCEncounter(npc.id, dispositionDelta, reward, revealLandmark)
                   }}
                   onClose={() => {
                     setMobileCategory(null)

--- a/src/app/tap-tap-adventure/components/NPCDialoguePanel.tsx
+++ b/src/app/tap-tap-adventure/components/NPCDialoguePanel.tsx
@@ -15,7 +15,9 @@ interface NPCDialoguePanelProps {
   region: string
   characterCharisma: number
   disposition: number
-  onEncounterUpdate: (dispositionDelta: number, reward?: { gold?: number; reputation?: number }) => void
+  hiddenLandmarkName?: string
+  hiddenLandmarkType?: string
+  onEncounterUpdate: (dispositionDelta: number, reward?: { gold?: number; reputation?: number }, revealLandmark?: boolean) => void
   onClose: () => void
 }
 
@@ -28,6 +30,8 @@ export function NPCDialoguePanel({
   region,
   characterCharisma,
   disposition,
+  hiddenLandmarkName,
+  hiddenLandmarkType,
   onEncounterUpdate,
   onClose,
 }: NPCDialoguePanelProps) {
@@ -75,8 +79,10 @@ export function NPCDialoguePanel({
         reputation,
         region,
         disposition,
+        hiddenLandmarkName,
+        hiddenLandmarkType,
       }).then(result => {
-        onEncounterUpdate(result?.dispositionDelta ?? 0, result?.reward)
+        onEncounterUpdate(result?.dispositionDelta ?? 0, result?.reward, result?.revealLandmark)
         if (result?.reward) {
           const parts: string[] = []
           if (result.reward.gold) parts.push(`+${result.reward.gold} gold`)
@@ -105,9 +111,11 @@ export function NPCDialoguePanel({
       region,
       message: trimmed,
       disposition,
+      hiddenLandmarkName,
+      hiddenLandmarkType,
     })
 
-    onEncounterUpdate(result?.dispositionDelta ?? 0, result?.reward)
+    onEncounterUpdate(result?.dispositionDelta ?? 0, result?.reward, result?.revealLandmark)
 
     if (result?.reward) {
       const parts: string[] = []

--- a/src/app/tap-tap-adventure/hooks/useGameStore.ts
+++ b/src/app/tap-tap-adventure/hooks/useGameStore.ts
@@ -139,7 +139,7 @@ export interface GameStore {
   enchantItem: (slot: 'weapon' | 'armor' | 'accessory') => { message: string; success: boolean } | null
   updateDailyChallengeProgress: (type: DailyChallengeType, amount: number) => void
   claimDailyChallengeBonus: () => { gold: number; reputation: number } | null
-  recordNPCEncounter: (npcId: string, dispositionDelta: number, reward?: { gold?: number; reputation?: number }) => void
+  recordNPCEncounter: (npcId: string, dispositionDelta: number, reward?: { gold?: number; reputation?: number }, revealLandmark?: boolean) => void
   setActiveTarget: (index: number) => void
   castExplorationSpell: (spellId: string) => { message: string; success: boolean } | null
 }
@@ -1227,7 +1227,7 @@ export const useGameStore = create<GameStore>()(
         )
         return bonus
       },
-      recordNPCEncounter: (npcId: string, dispositionDelta: number, reward?: { gold?: number; reputation?: number }) => {
+      recordNPCEncounter: (npcId: string, dispositionDelta: number, reward?: { gold?: number; reputation?: number }, revealLandmark?: boolean) => {
         set(
           produce((state: GameStore) => {
             const selectedCharacter = get().getSelectedCharacter()
@@ -1253,6 +1253,20 @@ export const useGameStore = create<GameStore>()(
               state.gameState.characters[charIndex].reputation = clampReputation(
                 state.gameState.characters[charIndex].reputation + reward.reputation
               )
+            }
+
+            // Reveal hidden landmark if NPC shared location info
+            if (revealLandmark) {
+              const ls = state.gameState.characters[charIndex].landmarkState
+              if (ls) {
+                const hiddenIdx = ls.landmarks.findIndex(lm => lm.hidden)
+                if (hiddenIdx !== -1) {
+                  const updatedLandmarks = ls.landmarks.map((lm, i) =>
+                    i === hiddenIdx ? { ...lm, hidden: false } : lm
+                  )
+                  state.gameState.characters[charIndex].landmarkState = { ...ls, landmarks: updatedLandmarks }
+                }
+              }
             }
           })
         )

--- a/src/app/tap-tap-adventure/hooks/useNPCDialogue.ts
+++ b/src/app/tap-tap-adventure/hooks/useNPCDialogue.ts
@@ -21,6 +21,7 @@ interface DialogueState {
   dispositionDelta?: number
   conversationComplete?: boolean
   reward?: { gold?: number; reputation?: number }
+  revealLandmark?: boolean
 }
 
 interface UseNPCDialogueReturn {
@@ -40,6 +41,8 @@ interface UseNPCDialogueReturn {
     region: string
     message?: string
     disposition?: number
+    hiddenLandmarkName?: string
+    hiddenLandmarkType?: string
   }) => Promise<DialogueState | null>
   reset: () => void
 }
@@ -64,8 +67,10 @@ export function useNPCDialogue(): UseNPCDialogueReturn {
     region: string
     message?: string
     disposition?: number
+    hiddenLandmarkName?: string
+    hiddenLandmarkType?: string
   }): Promise<DialogueState | null> => {
-    const { npc, characterName, characterClass, characterLevel, reputation, region, message, disposition = 0 } = params
+    const { npc, characterName, characterClass, characterLevel, reputation, region, message, disposition = 0, hiddenLandmarkName, hiddenLandmarkType } = params
     setIsLoading(true)
     setError(null)
 
@@ -87,6 +92,8 @@ export function useNPCDialogue(): UseNPCDialogueReturn {
           conversationHistory: recentHistory,
           disposition,
           exchangeCount,
+          hiddenLandmarkName,
+          hiddenLandmarkType,
         }),
       })
 
@@ -100,6 +107,7 @@ export function useNPCDialogue(): UseNPCDialogueReturn {
         dispositionDelta?: number
         conversationComplete?: boolean
         reward?: { gold?: number; reputation?: number }
+        revealLandmark?: boolean
       }
 
       const result: DialogueState = {
@@ -108,6 +116,7 @@ export function useNPCDialogue(): UseNPCDialogueReturn {
         dispositionDelta: data.dispositionDelta,
         conversationComplete: data.conversationComplete,
         reward: data.reward,
+        revealLandmark: data.revealLandmark,
       }
 
       setCurrentDialogue(result)

--- a/src/app/tap-tap-adventure/lib/eventResolution.ts
+++ b/src/app/tap-tap-adventure/lib/eventResolution.ts
@@ -12,6 +12,7 @@ export function applyEffects(
     statusChange?: string
     mountDamage?: number
     mountDeath?: boolean
+    revealLandmark?: boolean
   }
 ): FantasyCharacter {
   if (!effects) return character
@@ -64,6 +65,21 @@ export function applyEffects(
       updatedCharacter = newHp <= 0
         ? { ...updatedCharacter, activeMount: null }
         : { ...updatedCharacter, activeMount: { ...updatedCharacter.activeMount, hp: newHp } }
+    }
+  }
+
+  // Landmark revelation
+  if (effects.revealLandmark && updatedCharacter.landmarkState) {
+    const lmState = updatedCharacter.landmarkState
+    const hiddenIdx = lmState.landmarks.findIndex(lm => lm.hidden)
+    if (hiddenIdx !== -1) {
+      const updatedLandmarks = lmState.landmarks.map((lm, i) =>
+        i === hiddenIdx ? { ...lm, hidden: false } : lm
+      )
+      updatedCharacter = {
+        ...updatedCharacter,
+        landmarkState: { ...lmState, landmarks: updatedLandmarks },
+      }
     }
   }
 

--- a/src/app/tap-tap-adventure/lib/llmEventGenerator.ts
+++ b/src/app/tap-tap-adventure/lib/llmEventGenerator.ts
@@ -35,6 +35,7 @@ export interface LLMEventOption {
     rewardItems?: Item[]
     mountDamage?: number
     mountDeath?: boolean
+    revealLandmark?: boolean
   }
   failureDescription: string
   failureEffects: {
@@ -44,6 +45,7 @@ export interface LLMEventOption {
     rewardItems?: Item[]
     mountDamage?: number
     mountDeath?: boolean
+    revealLandmark?: boolean
   }
   triggersCombat?: boolean
 }
@@ -83,6 +85,7 @@ const eventOptionSchema = z.object({
     rewardItems: z.array(rewardItemSchema).optional(),
     mountDamage: z.number().optional(),
     mountDeath: z.boolean().optional(),
+    revealLandmark: z.boolean().optional(),
   }),
   failureDescription: z.string(),
   failureEffects: z.object({
@@ -92,6 +95,7 @@ const eventOptionSchema = z.object({
     rewardItems: z.array(rewardItemSchema).optional(),
     mountDamage: z.number().optional(),
     mountDeath: z.boolean().optional(),
+    revealLandmark: z.boolean().optional(),
   }),
   triggersCombat: z.boolean().optional(),
 })
@@ -181,6 +185,7 @@ const eventOptionSchemaForOpenAI = {
         },
         mountDamage: { type: 'number', description: 'HP damage dealt to the character\'s mount (if they have one). Use 3-10 for minor damage, 10-20 for serious damage.' },
         mountDeath: { type: 'boolean', description: 'Set to true only if the mount is killed outright by the event outcome.' },
+        revealLandmark: { type: 'boolean', description: 'Set to true if this event reveals a hidden landmark nearby. Only use when the narrative involves discovering a hidden location, receiving a treasure map, or learning about a secret place from an NPC.' },
       },
     },
     failureDescription: { type: 'string' },
@@ -196,6 +201,7 @@ const eventOptionSchemaForOpenAI = {
         },
         mountDamage: { type: 'number', description: 'HP damage dealt to the character\'s mount (if they have one). Use 3-10 for minor damage, 10-20 for serious damage.' },
         mountDeath: { type: 'boolean', description: 'Set to true only if the mount is killed outright by the event outcome.' },
+        revealLandmark: { type: 'boolean', description: 'Set to true if this event reveals a hidden landmark nearby. Only use when the narrative involves discovering a hidden location, receiving a treasure map, or learning about a secret place from an NPC.' },
       },
     },
     triggersCombat: { type: 'boolean', description: 'Set to true if this option leads to a fight' },
@@ -329,6 +335,16 @@ function getCompletionsConfig(character: FantasyCharacter, context: string) {
     ? `\n\nWeather context: ${eventWeatherType.icon} ${eventWeatherType.name}. ${eventWeatherType.description} Weave the weather atmosphere subtly into events.`
     : ''
 
+  // Build landmark context for potential revelation events
+  let landmarkHint = ''
+  const ls = character.landmarkState
+  if (ls) {
+    const hiddenLandmarks = ls.landmarks.filter(lm => lm.hidden)
+    if (hiddenLandmarks.length > 0) {
+      landmarkHint = `\n\nIMPORTANT — Hidden landmark opportunity:\nThere is a hidden landmark nearby: "${hiddenLandmarks[0].name}" (${hiddenLandmarks[0].type}). Occasionally (roughly 1 in 5 non-combat events), create an event where an NPC, old map, or mysterious sign reveals this hidden place. When this happens, set revealLandmark: true in the successEffects. Make the revelation feel natural — a traveler shares rumors, a map is found, or ancient markings are deciphered. Do NOT always reveal the landmark — only when narratively fitting.`
+    }
+  }
+
   const messages: OpenAI.Chat.Completions.ChatCompletionMessageParam[] = [
     {
       role: 'user',
@@ -357,7 +373,7 @@ Character:
 ${JSON.stringify(character, null, 2)}
 
 Recent History & Context:
-${context || 'No prior adventures yet — this is the beginning of their journey.'}${seasonalInjection}${weatherInjection}`,
+${context || 'No prior adventures yet — this is the beginning of their journey.'}${seasonalInjection}${weatherInjection}${landmarkHint}`,
     },
   ]
 

--- a/src/app/tap-tap-adventure/models/story.ts
+++ b/src/app/tap-tap-adventure/models/story.ts
@@ -20,6 +20,7 @@ const EffectsSchema = z.object({
   distance: z.number().optional(),
   statusChange: z.string().optional(),
   rewardItems: z.array(ItemSchema).optional(),
+  revealLandmark: z.boolean().optional(),
 })
 
 export const FantasyDecisionOptionSchema = z.object({


### PR DESCRIPTION
## Summary
- Story events can now reveal hidden landmarks via `revealLandmark: true` in effects
- NPC dialogue can reveal hidden landmarks when disposition is high enough
- LLM prompt includes hidden landmark context so it naturally weaves revelations into the narrative
- Extends the discovery system from #315 and #318 with an interactive revelation mechanic

Closes #316

## Changes
- `story.ts`: Added `revealLandmark` to EffectsSchema
- `llmEventGenerator.ts`: Added `revealLandmark` to all effect schemas (interface, Zod, OpenAI), added landmark context hint to LLM prompt
- `eventResolution.ts`: Extended `applyEffects()` to unhide first hidden landmark when `revealLandmark: true`
- `npc/dialogue/route.ts`: Added landmark context to NPC system prompt, `revealLandmark` to response
- `useNPCDialogue.ts`: Added `revealLandmark` to dialogue state and API params
- `useGameStore.ts`: Extended `recordNPCEncounter()` to handle landmark revelation
- `NPCDialoguePanel.tsx`: Forwards landmark data to dialogue hook and revelation flag to store
- `GameUI.tsx`: Passes landmark state to NPC panel

## Test plan
- [ ] Travel through a region with a hidden landmark — story events occasionally reveal it
- [ ] Talk to an NPC with high disposition — they may share landmark rumors
- [ ] Revealed landmarks appear in the target list and area map
- [ ] Events without `revealLandmark` work unchanged
- [ ] Existing spell-based revelation still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)