### PR TITLE
feat(#317): add purchasable map items that reveal hidden landmarks

### DIFF
--- a/src/app/tap-tap-adventure/lib/itemEffects.ts
+++ b/src/app/tap-tap-adventure/lib/itemEffects.ts
@@ -69,6 +69,26 @@ export function useItem(character: FantasyCharacter, item: Item): UseItemResult 
     updatedCharacter.charisma += effects.charisma
     effectMessages.push(`${effects.charisma > 0 ? '+' : ''}${effects.charisma} Charisma`)
   }
+  if (effects.revealLandmark) {
+    const ls = updatedCharacter.landmarkState
+    if (ls) {
+      const hiddenIdx = ls.landmarks.findIndex(lm => lm.hidden)
+      if (hiddenIdx !== -1) {
+        const updatedLandmarks = ls.landmarks.map((lm, i) =>
+          i === hiddenIdx ? { ...lm, hidden: false } : lm
+        )
+        updatedCharacter = {
+          ...updatedCharacter,
+          landmarkState: { ...ls, landmarks: updatedLandmarks },
+        }
+        effectMessages.push(`Revealed a hidden landmark: ${ls.landmarks[hiddenIdx].name}`)
+      } else {
+        effectMessages.push('No hidden landmarks to reveal')
+      }
+    } else {
+      effectMessages.push('No landmarks in this area')
+    }
+  }
 
   // Update inventory: decrement quantity or remove
   const updatedInventory = character.inventory

--- a/src/app/tap-tap-adventure/lib/itemPostProcessor.ts
+++ b/src/app/tap-tap-adventure/lib/itemPostProcessor.ts
@@ -53,6 +53,16 @@ function inferRarity(item: Item): Item['rarity'] {
 }
 
 function inferItemTypeAndEffectsInternal(item: Item): Item {
+  const nameLower = item.name.toLowerCase()
+
+  // Detect map/chart/atlas items: ensure revealLandmark effect is set
+  if (matchesAny(nameLower, ['map', 'chart', 'atlas']) && item.type === 'consumable') {
+    return {
+      ...item,
+      effects: { ...item.effects, revealLandmark: true },
+    }
+  }
+
   // Already fully specified
   if (item.type === 'consumable' && item.effects && Object.keys(item.effects).length > 0) {
     return item
@@ -63,7 +73,7 @@ function inferItemTypeAndEffectsInternal(item: Item): Item {
     return item
   }
 
-  const name = item.name.toLowerCase()
+  const name = nameLower
 
   // Detect spell scrolls by name pattern (when no type set and has spell data)
   if (!item.type || item.type === 'misc') {

--- a/src/app/tap-tap-adventure/lib/shopGenerator.ts
+++ b/src/app/tap-tap-adventure/lib/shopGenerator.ts
@@ -47,6 +47,7 @@ const shopSchemaForOpenAI = {
               intelligence: { type: 'number' },
               luck: { type: 'number' },
               heal: { type: 'number', description: 'Directly restores this amount of HP. Use for healing items instead of strength.' },
+              revealLandmark: { type: 'boolean', description: 'Set to true for map items that reveal hidden landmarks. Use for items like treasure maps, ancient charts, or cartographer notes.' },
             },
           },
         },
@@ -85,6 +86,7 @@ Include a mix of:
 - Stat-boosting items (strength, intelligence, luck)
 - Interesting thematic items that fit the fantasy setting
 - Occasionally a spell scroll (type: "spell_scroll") with a spell object containing id, name, description, school, manaCost, cooldown, target, effects, and tags
+- Occasionally a map or chart (type: "consumable" with effects: { revealLandmark: true }) that reveals hidden landmarks. Price these at 2-3x the base price. Use names like "Treasure Map", "Ancient Chart", "Explorer's Map", etc.
 
 Each item needs a unique id (e.g. "shop-item-1"), a creative name, a short description, quantity of 1, a gold price, and effects.
 
@@ -202,6 +204,21 @@ export function getFallbackShopItems(level: number, reputation: number = 0, char
       price: Math.round(spellPrice * reputationMultiplier),
       spell: spell2,
       rarity: 'rare',
+    })
+  }
+
+  // 40% chance to stock a region map
+  if (Math.random() < 0.4) {
+    const mapPrice = basePrice * 2
+    items.push({
+      id: `shop-map-${suffix}`,
+      name: 'Mysterious Map Fragment',
+      description: 'A weathered parchment that reveals the location of a hidden place in this region.',
+      quantity: 1,
+      type: 'consumable',
+      price: Math.round(mapPrice * reputationMultiplier),
+      effects: { revealLandmark: true },
+      rarity: 'uncommon',
     })
   }
 

--- a/src/app/tap-tap-adventure/models/item.ts
+++ b/src/app/tap-tap-adventure/models/item.ts
@@ -21,6 +21,8 @@ export const ItemEffectsSchema = z.object({
   cleanse: z.boolean().optional(),
   /** Temporary damage multiplier boost (e.g., 1.5 = +50% damage for 2 turns) */
   damageBoost: z.number().optional(),
+  /** Reveals a hidden landmark in the current region when used */
+  revealLandmark: z.boolean().optional(),
 })
 export type ItemEffects = z.infer<typeof ItemEffectsSchema>
 


### PR DESCRIPTION
## Summary
- Shops now sell map items (40% chance in fallback shops, LLM-generated shops prompted to include them)
- Maps are consumable items with `revealLandmark: true` effect
- Using a map reveals the first hidden landmark in the current region, showing its name
- Item post-processor detects "map", "chart", "atlas" in item names and ensures the effect is set
- Completes the landmark discovery system: proximity (#318), events/NPCs (#316), and now purchasable maps

Closes #317

## Changes
- `item.ts`: Added `revealLandmark` to ItemEffectsSchema
- `itemEffects.ts`: Handle `revealLandmark` in `useItem()` — finds and reveals first hidden landmark
- `shopGenerator.ts`: Added `revealLandmark` to OpenAI schema, shop prompt, and fallback items
- `itemPostProcessor.ts`: Auto-detect map/chart/atlas items and ensure correct effect

## Test plan
- [ ] Visit a shop — map items appear occasionally
- [ ] Buy and use a map — hidden landmark is revealed with name shown
- [ ] Use a map when no hidden landmarks exist — shows appropriate message
- [ ] LLM-generated shops can include map items
- [ ] Map items work with the existing inventory system (quantity, discard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)