### PR TITLE
feat(#337): add floating resource notifications for event outcomes

### DIFF
--- a/src/app/tap-tap-adventure/components/FloatingResources.tsx
+++ b/src/app/tap-tap-adventure/components/FloatingResources.tsx
@@ -1,0 +1,56 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+
+export interface ResourceEvent {
+  id: string
+  type: 'gold' | 'reputation' | 'item'
+  value: number    // positive = gain, negative = loss
+  label?: string   // item name for type 'item'
+}
+
+interface FloatingResourcesProps {
+  events: ResourceEvent[]
+}
+
+export function FloatingResources({ events }: FloatingResourcesProps) {
+  return (
+    <>
+      {events.map((event, i) => (
+        <FloatingResource key={event.id} event={event} index={i} />
+      ))}
+    </>
+  )
+}
+
+function FloatingResource({ event, index }: { event: ResourceEvent; index: number }) {
+  const [visible, setVisible] = useState(true)
+
+  useEffect(() => {
+    const timer = setTimeout(() => setVisible(false), 1500)
+    return () => clearTimeout(timer)
+  }, [])
+
+  if (!visible) return null
+
+  const isPositive = event.value > 0
+  const color = isPositive ? 'text-green-400' : 'text-red-400'
+  const icon = event.type === 'gold' ? '💰' : event.type === 'reputation' ? '⭐' : '🎁'
+  const label = event.type === 'item' ? event.label : event.type === 'gold' ? 'Gold' : 'Rep'
+  const sign = isPositive ? '+' : ''
+  // Stagger vertically so multiple rewards don't overlap
+  const topOffset = index * 24
+
+  return (
+    <span
+      className={`absolute animate-float-up pointer-events-none ${color} text-sm font-bold drop-shadow-lg whitespace-nowrap`}
+      style={{
+        left: '50%',
+        top: `${topOffset}px`,
+        transform: 'translateX(-50%)',
+      }}
+    >
+      {icon} {sign}{event.value} {label}
+    </span>
+  )
+}

--- a/src/app/tap-tap-adventure/components/GameUI.tsx
+++ b/src/app/tap-tap-adventure/components/GameUI.tsx
@@ -20,6 +20,7 @@ import { SKILLS } from '@/app/tap-tap-adventure/config/skills'
 import { getSkillBonus } from '@/app/tap-tap-adventure/lib/skillTracker'
 import { soundEngine } from '@/app/tap-tap-adventure/lib/soundEngine'
 
+import { FloatingResources, ResourceEvent } from './FloatingResources'
 import { DailyRewardPopup } from './DailyRewardPopup'
 import { AchievementPanel } from './AchievementPanel'
 import { AchievementToastContainer } from './AchievementToast'
@@ -139,6 +140,7 @@ export default function GameUI({ onOpenStatus }: GameUIProps) {
 
   const [newlyCompletedIds, setNewlyCompletedIds] = useState<string[]>([])
   const [showDailyReward, setShowDailyReward] = useState(false)
+  const [floatingResources, setFloatingResources] = useState<ResourceEvent[]>([])
   const [mobileCategory, setMobileCategory] = useState<MobileCategory>(null)
   const [travelTarget, setTravelTarget] = useState<string | null>(null)
   const [gearSubTab, setGearSubTab] = useState<GearSubTab>('equipment')
@@ -226,6 +228,20 @@ export default function GameUI({ onOpenStatus }: GameUIProps) {
       optionId: optionId,
       onSuccess: () => {
         setDecisionPoint(null)
+      },
+      onResourceDelta: (delta) => {
+        if (!delta) return
+        const events: ResourceEvent[] = []
+        if (delta.gold && delta.gold !== 0) {
+          events.push({ id: `gold-${Date.now()}`, type: 'gold', value: delta.gold })
+        }
+        if (delta.reputation && delta.reputation !== 0) {
+          events.push({ id: `rep-${Date.now()}`, type: 'reputation', value: delta.reputation })
+        }
+        if (events.length > 0) {
+          setFloatingResources(events)
+          setTimeout(() => setFloatingResources([]), 2000)
+        }
       },
     })
   }
@@ -678,28 +694,31 @@ export default function GameUI({ onOpenStatus }: GameUIProps) {
                     </div>
                   )
                 })()}
-                <Button
-                  className={`w-full border text-white font-bold text-xl sm:text-2xl py-8 sm:py-10 rounded-xl transition-all duration-300 select-none ${
-                    isAutoWalking
-                      ? 'bg-gradient-to-r from-emerald-700 to-teal-700 border-emerald-400/30 shadow-lg shadow-emerald-500/20 animate-pulse'
-                      : moveForwardPending
-                      ? 'bg-gradient-to-r from-indigo-800 to-purple-800 border-indigo-500/20 shadow-none animate-pulse cursor-wait'
-                      : 'bg-gradient-to-r from-indigo-600 to-purple-600 hover:from-indigo-500 hover:to-purple-500 border-indigo-400/30 shadow-lg shadow-indigo-500/20 hover:shadow-indigo-500/40 active:translate-y-0.5 active:shadow-none'
-                  }`}
-                  onClick={handleMoveForward}
-                  onPointerDown={handlePointerDown}
-                  onPointerUp={handlePointerUpOrLeave}
-                  onPointerLeave={handlePointerUpOrLeave}
-                  onPointerCancel={handlePointerUpOrLeave}
-                  disabled={moveForwardPending || resolveDecisionPending}
-                >
-                  {isAutoWalking
-                    ? 'Walking...'
-                    : getTravelButtonMessage({
-                        isLoading: moveForwardPending,
-                        distance: getSelectedCharacter()?.distance ?? 0,
-                      })}
-                </Button>
+                <div className="relative">
+                  <FloatingResources events={floatingResources} />
+                  <Button
+                    className={`w-full border text-white font-bold text-xl sm:text-2xl py-8 sm:py-10 rounded-xl transition-all duration-300 select-none ${
+                      isAutoWalking
+                        ? 'bg-gradient-to-r from-emerald-700 to-teal-700 border-emerald-400/30 shadow-lg shadow-emerald-500/20 animate-pulse'
+                        : moveForwardPending
+                        ? 'bg-gradient-to-r from-indigo-800 to-purple-800 border-indigo-500/20 shadow-none animate-pulse cursor-wait'
+                        : 'bg-gradient-to-r from-indigo-600 to-purple-600 hover:from-indigo-500 hover:to-purple-500 border-indigo-400/30 shadow-lg shadow-indigo-500/20 hover:shadow-indigo-500/40 active:translate-y-0.5 active:shadow-none'
+                    }`}
+                    onClick={handleMoveForward}
+                    onPointerDown={handlePointerDown}
+                    onPointerUp={handlePointerUpOrLeave}
+                    onPointerLeave={handlePointerUpOrLeave}
+                    onPointerCancel={handlePointerUpOrLeave}
+                    disabled={moveForwardPending || resolveDecisionPending}
+                  >
+                    {isAutoWalking
+                      ? 'Walking...'
+                      : getTravelButtonMessage({
+                          isLoading: moveForwardPending,
+                          distance: getSelectedCharacter()?.distance ?? 0,
+                        })}
+                  </Button>
+                </div>
                 {gameState.genericMessage && (
                   <div className="text-sm">{gameState.genericMessage}</div>
                 )}

--- a/src/app/tap-tap-adventure/hooks/useResolveDecisionMutation.ts
+++ b/src/app/tap-tap-adventure/hooks/useResolveDecisionMutation.ts
@@ -40,10 +40,12 @@ export function useResolveDecisionMutation() {
       decisionPoint,
       optionId,
       onSuccess,
+      onResourceDelta,
     }: {
       decisionPoint: FantasyDecisionPoint
       optionId: string
       onSuccess?: () => void
+      onResourceDelta?: (delta: ResolveDecisionResponse['resourceDelta']) => void
     }) => {
       const character = getSelectedCharacter()
       if (!character) throw new Error('No character found')
@@ -301,6 +303,11 @@ export function useResolveDecisionMutation() {
         // Update the story event to note the mount gained (and any replacement)
         const replacedText = oldMount ? ` (Replaced ${oldMount.name})` : ''
         newStoryEvent.outcomeDescription = `${data.outcomeDescription} You gained a ${mount.name}! ${mount.icon}${replacedText}`
+      }
+
+      // Notify caller of resource changes so floating notifications can be shown
+      if (data.resourceDelta) {
+        onResourceDelta?.(data.resourceDelta)
       }
 
       // If the chosen option triggers combat, start a combat encounter


### PR DESCRIPTION
## Summary
- Add `FloatingResources` component that shows animated gold/reputation deltas floating upward when decisions resolve
- Reuses the existing `animate-float-up` CSS animation (already defined in `tailwind.config.js` for `FloatingDamage`)
- Extend `useResolveDecisionMutation` with an `onResourceDelta` callback so callers can react to resource changes
- Integrate into `GameUI.tsx` — notifications appear near the travel button area where player attention is

## Behavior
- Positive changes (gold/rep gained) display in green with a `+` prefix
- Negative changes display in red
- Multiple notifications stagger vertically (24px offset each) so they don't overlap
- Auto-dismisses after 1.5s (fade), state clears after 2s
- Does not affect the existing `StoryFeed` `ResourceDeltaDisplay` — purely additive

## Test plan
- [ ] Resolve a decision that grants gold — floating `💰 +X Gold` appears near the travel button
- [ ] Resolve a decision that costs gold — floating `💰 -X Gold` appears in red
- [ ] Resolve a decision that changes reputation — floating `⭐ ±X Rep` appears
- [ ] Both gold and reputation change simultaneously — two notifications stagger vertically
- [ ] Notification disappears after ~1.5 seconds
- [ ] TypeScript check passes with no errors in modified files

🤖 Generated with [Claude Code](https://claude.com/claude-code)