### PR TITLE
feat: include skill bonuses in character stat breakdown

### DIFF
--- a/src/app/tap-tap-adventure/components/PlayerStatusView.tsx
+++ b/src/app/tap-tap-adventure/components/PlayerStatusView.tsx
@@ -10,6 +10,7 @@ import { SKILLS } from '@/app/tap-tap-adventure/config/skills'
 import { EquipmentSlotType } from '@/app/tap-tap-adventure/models/equipment'
 import { FantasyCharacter } from '@/app/tap-tap-adventure/models/character'
 import { getMountDisplayName } from '@/app/tap-tap-adventure/lib/mountUtils'
+import { getSkillBonus } from '@/app/tap-tap-adventure/lib/skillTracker'
 import { MountNamingModal } from '@/app/tap-tap-adventure/components/MountNamingModal'
 import { MOUNT_PERSONALITY_INFO } from '@/app/tap-tap-adventure/config/mounts'
 
@@ -175,16 +176,32 @@ export function PlayerStatusView({ onClose }: PlayerStatusViewProps) {
   const equipBonuses = getEquipmentBonuses(character)
   const mountStatBonuses = getMountBonuses()
 
-  const baseStr = character.strength - equipBonuses.strength - mountStatBonuses.strength - metaBonuses.bonusStrength
-  const baseInt = character.intelligence - equipBonuses.intelligence - mountStatBonuses.intelligence - metaBonuses.bonusIntelligence
-  const baseLck = character.luck - equipBonuses.luck - mountStatBonuses.luck - metaBonuses.bonusLuck
-  const baseCha = character.charisma - equipBonuses.charisma - mountStatBonuses.charisma
+  const getSkillStatBonuses = () => {
+    const strBonus = getSkillBonus(unlockedSkills, 'strength')
+    const intBonus = getSkillBonus(unlockedSkills, 'intelligence')
+    const lckBonus = getSkillBonus(unlockedSkills, 'luck')
+    const chaBonus = getSkillBonus(unlockedSkills, 'charisma')
+    const allBonus = getSkillBonus(unlockedSkills, 'all_stats')
+    return {
+      strength: strBonus.flat + allBonus.flat,
+      intelligence: intBonus.flat + allBonus.flat,
+      luck: lckBonus.flat + allBonus.flat,
+      charisma: chaBonus.flat + allBonus.flat,
+    }
+  }
+  const skillBonuses = getSkillStatBonuses()
 
-  const formatBonus = (base: number, equip: number, mountB: number, meta: number) => {
+  const baseStr = character.strength - equipBonuses.strength - mountStatBonuses.strength - metaBonuses.bonusStrength - skillBonuses.strength
+  const baseInt = character.intelligence - equipBonuses.intelligence - mountStatBonuses.intelligence - metaBonuses.bonusIntelligence - skillBonuses.intelligence
+  const baseLck = character.luck - equipBonuses.luck - mountStatBonuses.luck - metaBonuses.bonusLuck - skillBonuses.luck
+  const baseCha = character.charisma - equipBonuses.charisma - mountStatBonuses.charisma - skillBonuses.charisma
+
+  const formatBonus = (base: number, equip: number, mountB: number, meta: number, skill: number) => {
     const parts: string[] = [`${base} base`]
     if (equip > 0) parts.push(`+${equip} equip`)
     if (mountB > 0) parts.push(`+${mountB} mount`)
     if (meta > 0) parts.push(`+${meta} eternal`)
+    if (skill > 0) parts.push(`+${skill} skills`)
     return parts.join(', ')
   }
 
@@ -252,28 +269,28 @@ export function PlayerStatusView({ onClose }: PlayerStatusViewProps) {
                   <div className="text-xs text-slate-500 mb-1">Strength</div>
                   <div className="text-xl font-bold text-purple-300">{character.strength}</div>
                   <div className="text-[10px] text-slate-500 mt-0.5">
-                    {formatBonus(baseStr, equipBonuses.strength, mountStatBonuses.strength, metaBonuses.bonusStrength)}
+                    {formatBonus(baseStr, equipBonuses.strength, mountStatBonuses.strength, metaBonuses.bonusStrength, skillBonuses.strength)}
                   </div>
                 </div>
                 <div className="bg-[#161723] rounded-lg p-3 border border-slate-700/30">
                   <div className="text-xs text-slate-500 mb-1">Intelligence</div>
                   <div className="text-xl font-bold text-blue-300">{character.intelligence}</div>
                   <div className="text-[10px] text-slate-500 mt-0.5">
-                    {formatBonus(baseInt, equipBonuses.intelligence, mountStatBonuses.intelligence, metaBonuses.bonusIntelligence)}
+                    {formatBonus(baseInt, equipBonuses.intelligence, mountStatBonuses.intelligence, metaBonuses.bonusIntelligence, skillBonuses.intelligence)}
                   </div>
                 </div>
                 <div className="bg-[#161723] rounded-lg p-3 border border-slate-700/30">
                   <div className="text-xs text-slate-500 mb-1">Luck</div>
                   <div className="text-xl font-bold text-yellow-300">{character.luck}</div>
                   <div className="text-[10px] text-slate-500 mt-0.5">
-                    {formatBonus(baseLck, equipBonuses.luck, mountStatBonuses.luck, metaBonuses.bonusLuck)}
+                    {formatBonus(baseLck, equipBonuses.luck, mountStatBonuses.luck, metaBonuses.bonusLuck, skillBonuses.luck)}
                   </div>
                 </div>
                 <div className="bg-[#161723] rounded-lg p-3 border border-slate-700/30">
                   <div className="text-xs text-slate-500 mb-1">Charisma</div>
                   <div className="text-xl font-bold text-pink-400">{character.charisma}</div>
                   <div className="text-[10px] text-slate-500 mt-0.5">
-                    {formatBonus(baseCha, equipBonuses.charisma, mountStatBonuses.charisma, 0)}
+                    {formatBonus(baseCha, equipBonuses.charisma, mountStatBonuses.charisma, 0, skillBonuses.charisma)}
                   </div>
                 </div>
                 <div className="bg-[#161723] rounded-lg p-3 border border-slate-700/30">


### PR DESCRIPTION
## Summary
- Character stat breakdown now shows skill bonuses alongside equipment, mount, and eternal bonuses
- Example: "10 base, +3 equip, +2 mount, +1 skills" instead of just "10 base, +3 equip, +2 mount"
- Supports both individual stat skills (e.g., "Lucky Traveler" +1 luck) and all-stats skills (e.g., "Veteran" +1 to all stats)
- Base stat calculation corrected to subtract skill bonuses for accurate display

## Changes
- `PlayerStatusView.tsx`: Added `getSkillBonus` import, computed skill bonuses per stat, updated `formatBonus` and all call sites

## Test plan
- [ ] Character with no skills — breakdown shows normally (no "skills" entry)
- [ ] Character with "Lucky Traveler" skill — luck breakdown shows "+1 skills"
- [ ] Character with "Veteran" skill — all four stats show "+1 skills"
- [ ] Base stat values are correct (total - equip - mount - eternal - skills)

🤖 Generated with [Claude Code](https://claude.com/claude-code)