### PR TITLE
feat: include charisma in equipment comparison and upgrade detection

### DIFF
--- a/src/app/tap-tap-adventure/components/EquipmentPanel.tsx
+++ b/src/app/tap-tap-adventure/components/EquipmentPanel.tsx
@@ -30,9 +30,9 @@ const SLOT_ICONS: Record<EquipmentSlotType, string> = {
   accessory: 'LCK',
 }
 
-const COMPARE_STATS = ['strength', 'intelligence', 'luck'] as const
+const COMPARE_STATS = ['strength', 'intelligence', 'luck', 'charisma'] as const
 
-/** Sum the total stat value of an item across STR/INT/LCK */
+/** Sum the total stat value of an item across STR/INT/LCK/CHA */
 function itemStatTotal(item: Item | null): number {
   if (!item?.effects) return 0
   return COMPARE_STATS.reduce((sum, key) => sum + (item.effects?.[key] ?? 0), 0)


### PR DESCRIPTION
## Summary
- Equipment panel now considers Charisma stat in comparisons and upgrade detection
- Previously only STR/INT/LCK were compared — Charisma bonuses from equipment were ignored
- Consistent with ShopUI comparison (fixed in PR #343)
- Affects: total stat calculation for upgrade suggestions, stat delta display in upgrade cards

## Changes
- `EquipmentPanel.tsx`: Added `'charisma'` to `COMPARE_STATS` array (one-line fix)

## Test plan
- [ ] Equipment with CHA bonus shows in upgrade comparison
- [ ] Upgrade suggestions consider CHA value
- [ ] CHA delta displayed correctly (+N CHA / -N CHA)

🤖 Generated with [Claude Code](https://claude.com/claude-code)