### PR TITLE
feat: display enchantment level on items across all panels

### DIFF
--- a/src/app/tap-tap-adventure/components/EquipmentPanel.tsx
+++ b/src/app/tap-tap-adventure/components/EquipmentPanel.tsx
@@ -115,6 +115,11 @@ export function EquipmentPanel({ equipment }: EquipmentPanelProps) {
                           return (
                             <div className="flex items-center gap-1.5 flex-wrap">
                               <div className={`font-bold text-sm truncate ${item.rarity && item.rarity !== 'common' ? rarityStyle.text : 'text-white'}`}>{item.name}</div>
+                              {item.enchantmentLevel && item.enchantmentLevel > 0 && (
+                                <span className="text-[10px] px-1 py-0.5 bg-cyan-900/50 text-cyan-300 border border-cyan-700/40 rounded font-semibold ml-1">
+                                  +{item.enchantmentLevel}
+                                </span>
+                              )}
                               {item.rarity && item.rarity !== 'common' && (
                                 <span className={`text-[10px] px-1.5 py-0.5 ${rarityStyle.bg} ${rarityStyle.text} rounded`}>
                                   {rarityStyle.label}

--- a/src/app/tap-tap-adventure/components/InventoryPanel.tsx
+++ b/src/app/tap-tap-adventure/components/InventoryPanel.tsx
@@ -205,6 +205,11 @@ export function InventoryPanel({ inventory }: InventoryPanelProps) {
                       <span className="text-amber-400 text-sm" title="Heirloom">&#9733;</span>
                     )}
                     <div className={`font-bold ${item.rarity && item.rarity !== 'common' ? rarityStyle.text : 'text-white'}`}>{item.name}</div>
+                    {item.enchantmentLevel && item.enchantmentLevel > 0 && (
+                      <span className="text-[10px] px-1.5 py-0.5 bg-cyan-900/50 text-cyan-300 border border-cyan-700/40 rounded font-semibold">
+                        +{item.enchantmentLevel}
+                      </span>
+                    )}
                     {item.type === 'consumable' && (
                       <span className="text-[10px] px-1.5 py-0.5 bg-green-900/50 text-green-400 rounded">
                         Consumable
@@ -338,6 +343,9 @@ export function InventoryPanel({ inventory }: InventoryPanelProps) {
                 <div className="flex items-center gap-2 flex-wrap">
                   {detailItem.isHeirloom && <span className="text-amber-400">&#9733;</span>}
                   <h4 className={`font-bold text-lg ${detailItem.rarity && detailItem.rarity !== 'common' ? detailRarityStyle.text : 'text-white'}`}>{detailItem.name}</h4>
+                  {detailItem.enchantmentLevel && detailItem.enchantmentLevel > 0 && (
+                    <span className="text-sm text-cyan-300 font-semibold">+{detailItem.enchantmentLevel}</span>
+                  )}
                   {detailItem.type && (
                     <span className={`text-[10px] px-1.5 py-0.5 rounded ${
                       detailItem.type === 'consumable' ? 'bg-green-900/50 text-green-400' :

--- a/src/app/tap-tap-adventure/components/ShopUI.tsx
+++ b/src/app/tap-tap-adventure/components/ShopUI.tsx
@@ -355,6 +355,11 @@ export function ShopUI() {
                 <div className="flex justify-between items-start">
                   <div className="font-semibold text-white">
                     {item.name}
+                    {item.enchantmentLevel && item.enchantmentLevel > 0 && (
+                      <span className="text-[10px] px-1 py-0.5 bg-cyan-900/50 text-cyan-300 border border-cyan-700/40 rounded font-semibold ml-1">
+                        +{item.enchantmentLevel}
+                      </span>
+                    )}
                     {item.rarity && item.rarity !== 'common' && (
                       <span className={`ml-2 text-[10px] uppercase font-bold ${
                         item.rarity === 'legendary' ? 'text-yellow-400' :


### PR DESCRIPTION
## Summary
- Items with enchantment levels now show a cyan `+N` badge next to their name
- Displayed consistently across inventory cards, inventory detail modal, equipment panel, and shop
- Only shown when `enchantmentLevel > 0` (most items won't have it)
- Makes the enchanting system's results visible to players

## Changes
- `InventoryPanel.tsx`: Enchantment badge on item cards and detail modal
- `EquipmentPanel.tsx`: Enchantment badge on equipped items
- `ShopUI.tsx`: Enchantment badge on shop items

## Test plan
- [ ] Enchanted items show `+1`, `+2`, etc. badges in cyan
- [ ] Non-enchanted items show no badge (clean display)
- [ ] Badge appears in inventory, equipment panel, and shop
- [ ] Detail modal shows enchantment level next to item name

🤖 Generated with [Claude Code](https://claude.com/claude-code)