### PR TITLE
feat: add action icons and color coding to combat log

### DIFF
--- a/src/app/tap-tap-adventure/components/CombatUI.tsx
+++ b/src/app/tap-tap-adventure/components/CombatUI.tsx
@@ -524,12 +524,21 @@ export function CombatUI({ combatState }: CombatUIProps) {
                 className={`text-xs ${
                   entry.isCritical
                     ? 'text-yellow-300 font-bold'
+                    : entry.action === 'heal' || entry.action === 'use_item'
+                    ? 'text-emerald-300'
+                    : entry.action === 'defend'
+                    ? 'text-sky-300'
                     : entry.actor === 'player' ? 'text-blue-300' : 'text-red-300'
                 }`}
               >
                 <span className="text-slate-500">T{entry.turn}:</span>{' '}
                 {entry.isCritical && <span className="text-yellow-400 mr-1">&#9733;</span>}
                 {entry.action === 'status_effect' && <span className="mr-1">{entry.description.toLowerCase().includes('poison') ? '☠️' : '🔥'}</span>}
+                {entry.action === 'heal' && <span className="mr-1">❤️</span>}
+                {entry.action === 'defend' && <span className="mr-1">🛡️</span>}
+                {entry.action === 'use_item' && <span className="mr-1">🧪</span>}
+                {entry.action === 'flee' && <span className="mr-1">💨</span>}
+                {entry.action === 'mercenary_attack' && <span className="mr-1">⚔️</span>}
                 {entry.action === 'spell_combo' ? (
                   <><span className="text-purple-400 font-bold">COMBO! </span>{entry.description.replace(/^COMBO: [^!]+! /, '')}</>
                 ) : entry.description.includes('Super effective') ? (


### PR DESCRIPTION
## Summary
- Combat log entries now have distinct icons and colors by action type
- ❤️ Heal (emerald green) — instantly scannable during boss fights
- 🛡️ Defend (sky blue) — defensive actions stand out
- 🧪 Item use (emerald green) — consumable usage visible
- 💨 Flee attempts
- ⚔️ Mercenary attacks
- Previously only crits and status effects had icons; everything else was plain text

## Changes
- `CombatUI.tsx`: Added 5 action type icons and color-coded heal/defend/item entries

## Test plan
- [ ] Heal in combat — log shows ❤️ in emerald green
- [ ] Defend — log shows 🛡️ in sky blue
- [ ] Use item — log shows 🧪 in emerald green
- [ ] Flee — log shows 💨
- [ ] Mercenary attack — log shows ⚔️
- [ ] Regular attacks still show blue (player) / red (enemy)
- [ ] Crits still show ★ in yellow

🤖 Generated with [Claude Code](https://claude.com/claude-code)