### PR TITLE
feat: show mount HP in HUD with color-coded health indicator

### DIFF
--- a/src/app/tap-tap-adventure/components/HudBar.tsx
+++ b/src/app/tap-tap-adventure/components/HudBar.tsx
@@ -296,7 +296,8 @@ export function HudBar({ onOpenStatus }: HudBarProps = {}) {
     if (mount.bonuses.autoWalkSpeed) bonusParts.push(`${mount.bonuses.autoWalkSpeed}x speed`)
     if (mount.bonuses.healRate) bonusParts.push(`+${mount.bonuses.healRate} heal`)
     const bonusStr = bonusParts.length > 0 ? bonusParts.join(', ') : 'no bonuses'
-    return `${getMountDisplayName(mount)} — ${bonusStr} (${mount.dailyCost} gp/day)`
+    const hpStr = mount.hp !== undefined && mount.maxHp !== undefined ? ` | HP: ${mount.hp}/${mount.maxHp}` : ''
+    return `${getMountDisplayName(mount)} — ${bonusStr} (${mount.dailyCost} gp/day)${hpStr}`
   }
 
   const mountRarityColor: Record<string, string> = {
@@ -362,6 +363,15 @@ export function HudBar({ onOpenStatus }: HudBarProps = {}) {
             >
               <span>{activeMount.icon}</span>
               <span className="hidden sm:inline text-[10px]">{getMountDisplayName(activeMount)}</span>
+              {activeMount.hp !== undefined && activeMount.maxHp !== undefined && (
+                <span className={`text-[9px] ml-0.5 ${
+                  activeMount.hp / activeMount.maxHp > 0.5 ? 'text-green-400' :
+                  activeMount.hp / activeMount.maxHp > 0.25 ? 'text-yellow-400' :
+                  'text-red-400'
+                }`}>
+                  {activeMount.hp}/{activeMount.maxHp}
+                </span>
+              )}
             </button>
             <button
               className="text-[9px] sm:text-[10px] text-red-400 hover:text-red-300 border border-red-400/30 rounded px-1 py-0.5 bg-[#2a2b3f] hover:bg-[#3a3c56]"


### PR DESCRIPTION
## Summary
- Mount HP now visible in the HUD bar between fights (previously only shown during combat)
- Color-coded: green (>50%), yellow (25-50%), red (<25%)
- HP also added to mount tooltip on hover
- Players can now make informed decisions about entering combat based on mount health

## Changes
- `HudBar.tsx`: Added HP display inside mount button, color-coded by health percentage. Added HP to tooltip.

## Test plan
- [ ] Mount at full HP — shows green HP numbers
- [ ] Mount at low HP — shows yellow/red HP numbers
- [ ] Hover mount — tooltip shows HP alongside stats
- [ ] No mount — no HP display (unchanged)
- [ ] Mount without HP fields — no HP display (graceful fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)