### PR TITLE
feat: secret boss encounters at hidden landmarks

### DIFF
--- a/src/app/api/v1/tap-tap-adventure/combat/start/route.ts
+++ b/src/app/api/v1/tap-tap-adventure/combat/start/route.ts
@@ -9,19 +9,27 @@ import { CombatState } from '@/app/tap-tap-adventure/models/combat'
 
 export async function POST(req: NextRequest) {
   try {
-    const { character, storyEvents = [], eventContext, isBoss = false, isMiniBoss = false, pendingRegionId } = await req.json()
+    const { character, storyEvents = [], eventContext, isBoss = false, isMiniBoss = false, isSecretBoss = false, pendingRegionId } = await req.json()
     const storyContext = buildStoryContext(character, storyEvents)
+
+    // Build context string — for secret bosses, emphasize the guardian nature
+    const secretBossPrefix = isSecretBoss
+      ? `A powerful ancient guardian protects this secret place. Generate a formidable boss-level guardian enemy that feels mythic and dangerous.\n\n`
+      : ''
     const fullContext = eventContext
-      ? `The player chose to fight in this situation: "${eventContext}"\n\nGenerate an enemy that matches this encounter. The enemy should be the creature or opponent described in the event above.\n\n${storyContext}`
-      : storyContext
+      ? `${secretBossPrefix}The player chose to fight in this situation: "${eventContext}"\n\nGenerate an enemy that matches this encounter. The enemy should be the creature or opponent described in the event above.\n\n${storyContext}`
+      : `${secretBossPrefix}${storyContext}`
 
     const isFinalBoss = pendingRegionId === 'celestial_throne'
+
+    // Secret boss always uses boss-level generation
+    const effectiveIsBoss = isBoss || isSecretBoss
 
     const { enemy: rawEnemy, scenario } = isFinalBoss
       ? await generateFinalBossEncounter(character, fullContext)
       : isMiniBoss
         ? await generateMiniBossEncounter(character, fullContext)
-        : isBoss
+        : effectiveIsBoss
           ? await generateBossEncounter(character, fullContext)
           : await generateCombatEncounter(character, fullContext)
 
@@ -29,6 +37,8 @@ export async function POST(req: NextRequest) {
     const diffMods = getDifficultyModifiers(character.difficultyMode)
     const region = getRegion(character.currentRegion ?? 'green_meadows')
     const regionMult = region.difficultyMultiplier
+    // Secret bosses get an additional 2x scaling on top of regular modifiers
+    const secretBossMultiplier = isSecretBoss ? 2.0 : 1.0
     // Determine enemy range type based on element and name
     const enemyNameLower = rawEnemy.name.toLowerCase()
     const rangedByElement = rawEnemy.element === 'arcane' || rawEnemy.element === 'shadow'
@@ -39,11 +49,11 @@ export async function POST(req: NextRequest) {
 
     const enemy = {
       ...rawEnemy,
-      hp: Math.round(rawEnemy.hp * diffMods.enemyHpMultiplier * regionMult),
-      maxHp: Math.round(rawEnemy.maxHp * diffMods.enemyHpMultiplier * regionMult),
-      attack: Math.round(rawEnemy.attack * diffMods.enemyAttackMultiplier * regionMult),
-      defense: Math.round(rawEnemy.defense * regionMult),
-      goldReward: Math.round(rawEnemy.goldReward * regionMult),
+      hp: Math.round(rawEnemy.hp * diffMods.enemyHpMultiplier * regionMult * secretBossMultiplier),
+      maxHp: Math.round(rawEnemy.maxHp * diffMods.enemyHpMultiplier * regionMult * secretBossMultiplier),
+      attack: Math.round(rawEnemy.attack * diffMods.enemyAttackMultiplier * regionMult * secretBossMultiplier),
+      defense: Math.round(rawEnemy.defense * regionMult * secretBossMultiplier),
+      goldReward: Math.round(rawEnemy.goldReward * regionMult * secretBossMultiplier),
       range: enemyRange,
     }
 
@@ -63,9 +73,10 @@ export async function POST(req: NextRequest) {
       combatLog: [],
       status: 'active',
       scenario,
-      isBoss: isFinalBoss ? true : isBoss,
+      isBoss: isFinalBoss ? true : effectiveIsBoss,
       isMiniBoss,
       isFinalBoss: isFinalBoss || undefined,
+      isSecretBoss: isSecretBoss || undefined,
       combatDistance: region.startingCombatDistance ?? 'mid',
       ...(pendingRegionId ? { pendingRegionId } : {}),
     }

--- a/src/app/api/v1/tap-tap-adventure/resolve-decision/route.ts
+++ b/src/app/api/v1/tap-tap-adventure/resolve-decision/route.ts
@@ -358,6 +358,11 @@ export async function POST(req: NextRequest) {
       const depth = currentLandmarkState.explorationDepth ?? 1
       const maxDepth = 2 + Math.floor(Math.abs(hashString(currentLandmarkState.exploringLandmarkName)) % 4)
 
+      // Find the currently-explored landmark to check isSecret
+      const exploredLandmarkIndex = currentLandmarkState.activeTargetIndex ?? 0
+      const exploredLandmark = currentLandmarkState.landmarks[exploredLandmarkIndex]
+      const isSecretLandmark = exploredLandmark?.isSecret === true
+
       if (depth < maxDepth) {
         const continueDecision: FantasyDecisionPoint = {
           id: `decision-continue-${Date.now()}`,
@@ -388,8 +393,40 @@ export async function POST(req: NextRequest) {
           resolved: false,
         }
         response.decisionPoint = continueDecision
+      } else if (isSecretLandmark) {
+        // Max depth reached on a secret landmark — boss encounter instead of ending
+        const guardianDecision: FantasyDecisionPoint = {
+          id: `decision-guardian-${Date.now()}`,
+          eventId: `guardian-${Date.now()}`,
+          prompt: `As you reach the innermost sanctum of ${currentLandmarkState.exploringLandmarkName}, a powerful guardian emerges from the shadows. This ancient protector has watched over this secret place since time immemorial. The air crackles with dangerous energy — this will be no ordinary fight.`,
+          options: [
+            {
+              id: 'fight-secret-boss',
+              text: 'Face the Guardian',
+              successProbability: 1.0,
+              successDescription: 'You steel yourself and charge at the guardian!',
+              successEffects: {},
+              failureDescription: '',
+              failureEffects: {},
+              resultDescription: 'You engage the guardian in battle!',
+              triggersCombat: true,
+            },
+            {
+              id: 'leave-landmark',
+              text: 'Retreat — this is too dangerous',
+              successProbability: 1.0,
+              successDescription: 'You back away carefully and slip out of the sanctum.',
+              successEffects: {},
+              failureDescription: '',
+              failureEffects: {},
+              resultDescription: `You retreat from ${currentLandmarkState.exploringLandmarkName}.`,
+            },
+          ],
+          resolved: false,
+        }
+        response.decisionPoint = guardianDecision
       } else {
-        // Max depth reached — end exploration
+        // Max depth reached on a normal landmark — end exploration
         response.outcomeDescription = `${response.outcomeDescription ?? ''} You've explored everything ${currentLandmarkState.exploringLandmarkName} has to offer.`
         updatedCharacter = {
           ...updatedCharacter,

--- a/src/app/tap-tap-adventure/__tests__/combatEngine.test.ts
+++ b/src/app/tap-tap-adventure/__tests__/combatEngine.test.ts
@@ -406,4 +406,66 @@ describe('Combat Engine', () => {
       vi.restoreAllMocks()
     })
   })
+
+  describe('getCombatRewards — secret boss loot', () => {
+    const baseLootItem = { id: 'loot-1', name: 'Ancient Relic', description: 'A relic', quantity: 1 }
+
+    it('secret boss guarantees 100% item drop', () => {
+      const combat = makeActiveCombat({
+        isSecretBoss: true,
+        enemy: { ...makeActiveCombat().enemy, lootTable: [baseLootItem] },
+      })
+      // Even with Math.random = 0.99 (normally would miss at 30% chance), secret boss always drops
+      vi.spyOn(Math, 'random').mockReturnValue(0.99)
+      const rewards = getCombatRewards(combat, baseChar)
+      expect(rewards.loot.length).toBe(1)
+      vi.restoreAllMocks()
+    })
+
+    it('secret boss applies elite rarity weights (no common/uncommon)', () => {
+      const combat = makeActiveCombat({
+        isSecretBoss: true,
+        enemy: {
+          ...makeActiveCombat().enemy,
+          lootTable: Array.from({ length: 10 }, (_, i) => ({
+            id: `loot-${i}`,
+            name: `Relic ${i}`,
+            description: 'A relic',
+            quantity: 1,
+          })),
+        },
+      })
+      // Use fixed Math.random sequence: first 10 calls for drop (all drop since secret boss),
+      // next calls for rarity rolls
+      let callCount = 0
+      vi.spyOn(Math, 'random').mockImplementation(() => {
+        callCount++
+        // First 10 calls: item drop checks (all pass for secret boss)
+        // After that: rarity rolls — alternate between 0.1 (rare), 0.5 (epic), 0.8 (legendary)
+        const rarityValue = [0.1, 0.5, 0.8][callCount % 3]
+        return rarityValue
+      })
+      const rewards = getCombatRewards(combat, baseChar)
+      // All loot should be rare, epic, or legendary — no common or uncommon
+      for (const item of rewards.loot) {
+        expect(['rare', 'epic', 'legendary']).toContain(item.rarity)
+      }
+      vi.restoreAllMocks()
+    })
+
+    it('regular boss uses standard boss rarity weights (no common)', () => {
+      const combat = makeActiveCombat({
+        isBoss: true,
+        enemy: {
+          ...makeActiveCombat().enemy,
+          lootTable: [{ id: 'loot-boss', name: 'Boss Loot', description: 'Boss', quantity: 1 }],
+        },
+      })
+      // Roll = 0.05 → rare (cumulative: uncommon=0.2, rare=0.6, epic=0.9, legendary=1.0)
+      vi.spyOn(Math, 'random').mockReturnValue(0.05)
+      const rewards = getCombatRewards(combat, baseChar)
+      expect(rewards.loot[0]?.rarity).toBe('uncommon')
+      vi.restoreAllMocks()
+    })
+  })
 })

--- a/src/app/tap-tap-adventure/__tests__/landmarks.test.ts
+++ b/src/app/tap-tap-adventure/__tests__/landmarks.test.ts
@@ -187,6 +187,41 @@ describe('regionLength determinism', () => {
   })
 })
 
+describe('secret landmarks', () => {
+  it('secret landmark has isSecret: true', () => {
+    // All known regions have a secret landmark — the last one added is always the secret one
+    for (const regionId of ALL_REGION_IDS) {
+      const landmarks = generateLandmarks(regionId, 'char-secret-test')
+      const secretLandmarks = landmarks.filter(lm => lm.isSecret === true)
+      expect(secretLandmarks.length).toBe(1)
+    }
+  })
+
+  it('secret landmark has hidden: true initially', () => {
+    for (const regionId of ALL_REGION_IDS) {
+      const landmarks = generateLandmarks(regionId, 'char-hidden-test')
+      const secretLandmark = landmarks.find(lm => lm.isSecret === true)
+      expect(secretLandmark).toBeDefined()
+      expect(secretLandmark!.hidden).toBe(true)
+    }
+  })
+
+  it('normal landmarks do not have isSecret: true', () => {
+    for (const regionId of ALL_REGION_IDS) {
+      const landmarks = generateLandmarks(regionId, 'char-normal-test')
+      const normalLandmarks = landmarks.filter(lm => !lm.isSecret)
+      // There should be 3 normal landmarks and 1 secret
+      expect(normalLandmarks.length).toBe(3)
+    }
+  })
+
+  it('unknown region produces no secret landmarks (no secret templates)', () => {
+    const landmarks = generateLandmarks('unknown_region', 'char-1')
+    const secretLandmarks = landmarks.filter(lm => lm.isSecret === true)
+    expect(secretLandmarks.length).toBe(0)
+  })
+})
+
 describe('getTemplatesForRegion', () => {
   it('returns at least 3 templates for every known region', () => {
     for (const regionId of ALL_REGION_IDS) {

--- a/src/app/tap-tap-adventure/hooks/useGameStore.ts
+++ b/src/app/tap-tap-adventure/hooks/useGameStore.ts
@@ -1585,7 +1585,7 @@ export const useGameStore = create<GameStore>()(
     }),
     {
       name: 'fantasy-tycoon-storage', // localStorage key (kept for backward compat)
-      version: 30,
+      version: 31,
       migrate: (persistedState: unknown) => {
         const state = persistedState as GameStore
         if (state?.gameState && !('combatState' in state.gameState)) {
@@ -1730,6 +1730,13 @@ export const useGameStore = create<GameStore>()(
             // v30: Add activeExplorationSpells
             if (!(char as FantasyCharacter).activeExplorationSpells) {
               ;(char as FantasyCharacter).activeExplorationSpells = []
+            }
+            // v31: Backfill isSecret on existing landmarks (undefined → false for normal, keep true for secret)
+            if ((char as FantasyCharacter).landmarkState?.landmarks) {
+              (char as FantasyCharacter).landmarkState!.landmarks = (char as FantasyCharacter).landmarkState!.landmarks.map(lm => ({
+                ...lm,
+                isSecret: (lm as Record<string, unknown>).isSecret !== undefined ? Boolean((lm as Record<string, unknown>).isSecret) : false,
+              }))
             }
           }
         }

--- a/src/app/tap-tap-adventure/hooks/useResolveDecisionMutation.ts
+++ b/src/app/tap-tap-adventure/hooks/useResolveDecisionMutation.ts
@@ -317,8 +317,10 @@ export function useResolveDecisionMutation() {
         const { gameState } = useGameStore.getState()
         const chosenOption = decisionPoint.options.find(o => o.id === optionId)
         const isBoss = (chosenOption as Record<string, unknown>)?.isBoss === true
+        // Secret boss: triggered when player chooses to fight the secret landmark guardian
+        const isSecretBoss = optionId === 'fight-secret-boss'
         // Mini-boss: 5% chance on non-boss combat when distance > 100
-        const isMiniBoss = !isBoss && (data.updatedCharacter.distance ?? 0) > 100 && Math.random() < 0.05
+        const isMiniBoss = !isBoss && !isSecretBoss && (data.updatedCharacter.distance ?? 0) > 100 && Math.random() < 0.05
         const combatRes = await fetch('/api/v1/tap-tap-adventure/combat/start', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
@@ -326,8 +328,9 @@ export function useResolveDecisionMutation() {
             character: data.updatedCharacter,
             storyEvents: gameState.storyEvents,
             eventContext: decisionPoint.prompt,
-            isBoss,
+            isBoss: isBoss || isSecretBoss,
             isMiniBoss,
+            isSecretBoss,
           }),
         })
         if (combatRes.ok) {

--- a/src/app/tap-tap-adventure/lib/combatEngine.ts
+++ b/src/app/tap-tap-adventure/lib/combatEngine.ts
@@ -1813,7 +1813,8 @@ export function getCombatRewards(
   const loot: Item[] = []
   if (enemy.lootTable) {
     for (const item of enemy.lootTable) {
-      const baseDropChance = combatState.isBoss ? 1.0 : 0.3 + character.luck * 0.03
+      // Secret bosses guarantee 100% item drop; regular bosses also guarantee; others use luck-based chance
+      const baseDropChance = (combatState.isBoss || combatState.isSecretBoss) ? 1.0 : 0.3 + character.luck * 0.03
       const dropChance = Math.min(1, (baseDropChance + lootBonus.percentage / 100) * diffMods.lootChanceMultiplier)
       if (Math.random() < dropChance) {
         loot.push(item)
@@ -1822,11 +1823,14 @@ export function getCombatRewards(
   }
 
   // Assign rarity to loot items that don't have one
-  const rarityWeights = combatState.isBoss
-    ? { common: 0, uncommon: 0.2, rare: 0.4, epic: 0.3, legendary: 0.1 }
-    : combatState.isMiniBoss
-      ? { common: 0.1, uncommon: 0.3, rare: 0.4, epic: 0.15, legendary: 0.05 }
-      : { common: 0.5, uncommon: 0.3, rare: 0.15, epic: 0.04, legendary: 0.01 }
+  // Secret bosses: elite rarity weights (20% rare, 50% epic, 30% legendary)
+  const rarityWeights = combatState.isSecretBoss
+    ? { common: 0, uncommon: 0, rare: 0.2, epic: 0.5, legendary: 0.3 }
+    : combatState.isBoss
+      ? { common: 0, uncommon: 0.2, rare: 0.4, epic: 0.3, legendary: 0.1 }
+      : combatState.isMiniBoss
+        ? { common: 0.1, uncommon: 0.3, rare: 0.4, epic: 0.15, legendary: 0.05 }
+        : { common: 0.5, uncommon: 0.3, rare: 0.15, epic: 0.04, legendary: 0.01 }
 
   function rollRarity(weights: Record<string, number>): string {
     const roll = Math.random()

--- a/src/app/tap-tap-adventure/lib/landmarkGenerator.ts
+++ b/src/app/tap-tap-adventure/lib/landmarkGenerator.ts
@@ -11,6 +11,7 @@ export interface GeneratedLandmark {
   encounterPrompt: string
   distanceFromEntry: number
   hidden: boolean
+  isSecret?: boolean
   explored: boolean
   position: { x: number; y: number }
 }
@@ -108,6 +109,7 @@ export function generateLandmarks(
       encounterPrompt: secretTemplate.encounterPrompt,
       distanceFromEntry: secretDist,
       hidden: true,
+      isSecret: true,
       explored: false,
       position: secretPosition,
     })

--- a/src/app/tap-tap-adventure/models/character.ts
+++ b/src/app/tap-tap-adventure/models/character.ts
@@ -81,6 +81,7 @@ export const FantasyCharacterSchema = z.object({
       encounterPrompt: z.string(),
       distanceFromEntry: z.number(),
       hidden: z.boolean().default(false),
+      isSecret: z.boolean().optional(),
       explored: z.boolean().default(false),
       position: z.object({ x: z.number(), y: z.number() }).optional(),
     })),

--- a/src/app/tap-tap-adventure/models/combat.ts
+++ b/src/app/tap-tap-adventure/models/combat.ts
@@ -158,6 +158,7 @@ export const CombatStateSchema = z.object({
   isBoss: z.boolean().optional(),
   isMiniBoss: z.boolean().optional(),
   isFinalBoss: z.boolean().optional(),
+  isSecretBoss: z.boolean().optional(),
   combatDistance: CombatDistanceSchema.optional(),
   turnPhase: TurnPhaseSchema.optional(),
   pendingRegionId: z.string().optional(),


### PR DESCRIPTION
## Summary

Completes #278 Phase 2 — the capstone feature of Epic #271.

When players fully explore a secret landmark, they encounter a powerful guardian boss:

- **Boss Trigger**: At max exploration depth on `isSecret` landmarks, a "Guardian Awaits" decision appears with fight/retreat options
- **2x Stat Scaling**: Secret bosses are harder than region guardians (2.0x multiplier vs 1.5x for regular bosses)
- **Elite Loot**: 100% guaranteed drop with elite rarity weights — 20% rare, 50% epic, 30% legendary (no common/uncommon)
- **Fight or Flee**: Players can retreat from the guardian without penalty
- **Store Migration v31**: Backfills `isSecret: false` on existing landmarks

This completes all 7 items from Epic #271:
1. ~~Charisma stat~~ ✅
2. ~~Landmark system~~ ✅
3. ~~Directional movement~~ ✅
4. ~~NPC dialogue overhaul~~ ✅
5. ~~Complex spells~~ ✅ (PR #352)
6. ~~Magic item rarity~~ ✅ (PR #351)
7. **Secret areas & bosses** ✅ (this PR)

## Test plan

- [x] 768 tests pass (7 new tests)
- [x] Secret landmarks generated with `isSecret: true` from SECRET_LANDMARK_TEMPLATES
- [x] Secret boss guarantees 100% item drop
- [x] Secret boss loot uses elite rarity weights (no common/uncommon)
- [x] Normal boss loot uses standard weights (unaffected)
- [ ] Manual: explore secret landmark to max depth → see boss decision
- [ ] Manual: fight guardian → verify 2x stat scaling
- [ ] Manual: defeat guardian → verify epic/legendary drop
- [ ] Manual: retreat from guardian → return to travel normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)