### PR TITLE
feat: spell combo discovery system with reference panel

### DIFF
--- a/src/app/tap-tap-adventure/__tests__/spellCombos.test.ts
+++ b/src/app/tap-tap-adventure/__tests__/spellCombos.test.ts
@@ -1,0 +1,396 @@
+import { describe, expect, it } from 'vitest'
+
+import { SPELL_COMBOS, checkSpellCombo, getSpellElement } from '@/app/tap-tap-adventure/lib/spellCombos'
+import { castSpell } from '@/app/tap-tap-adventure/lib/spellEngine'
+import { FantasyCharacter } from '@/app/tap-tap-adventure/models/character'
+import { CombatPlayerState, CombatState } from '@/app/tap-tap-adventure/models/combat'
+import { Spell } from '@/app/tap-tap-adventure/models/spell'
+
+// ---- Helpers ----
+
+const baseMage: FantasyCharacter = {
+  id: '1',
+  playerId: 'p1',
+  name: 'TestMage',
+  race: 'Elf',
+  class: 'Mage',
+  level: 3,
+  abilities: [],
+  locationId: 'loc1',
+  gold: 50,
+  reputation: 10,
+  distance: 5,
+  status: 'active',
+  strength: 5,
+  intelligence: 10,
+  luck: 5,
+  charisma: 6,
+  inventory: [],
+  deathCount: 0,
+  pendingStatPoints: 0,
+  difficultyMode: 'normal',
+  currentRegion: 'green_meadows',
+  currentWeather: 'clear',
+  factionReputations: {},
+  mana: 100,
+  maxMana: 100,
+  spellbook: [],
+  discoveredCombos: [],
+}
+
+function makePlayerState(overrides: Partial<CombatPlayerState> = {}): CombatPlayerState {
+  return {
+    hp: 50,
+    maxHp: 50,
+    attack: 10,
+    defense: 5,
+    isDefending: false,
+    activeBuffs: [],
+    comboCount: 0,
+    abilityCooldown: 0,
+    enemyStunned: false,
+    mana: 100,
+    maxMana: 100,
+    spellCooldowns: {},
+    activeSpellEffects: [],
+    spellTagsUsed: [],
+    shield: 0,
+    ...overrides,
+  }
+}
+
+function makeEnemy(overrides = {}) {
+  return {
+    id: 'enemy-1',
+    name: 'Goblin',
+    description: 'A nasty goblin',
+    hp: 200,
+    maxHp: 200,
+    attack: 8,
+    defense: 3,
+    level: 2,
+    goldReward: 10,
+    ...overrides,
+  }
+}
+
+function makeCombatState(overrides: Partial<CombatState> = {}): CombatState {
+  return {
+    id: 'combat-1',
+    eventId: 'event-1',
+    enemy: makeEnemy(),
+    playerState: makePlayerState(),
+    turnNumber: 1,
+    combatLog: [],
+    status: 'active',
+    scenario: 'A test combat',
+    enemyTelegraph: null,
+    ...overrides,
+  }
+}
+
+function makeFireSpell(): Spell {
+  return {
+    id: 'fire-bolt',
+    name: 'Fire Bolt',
+    description: 'A bolt of fire',
+    school: 'arcane',
+    manaCost: 5,
+    cooldown: 0,
+    target: 'enemy',
+    effects: [{ type: 'damage', value: 20, element: 'fire' }],
+    tags: ['fire'],
+  }
+}
+
+function makeLightningSpell(): Spell {
+  return {
+    id: 'lightning-bolt',
+    name: 'Lightning Bolt',
+    description: 'A bolt of lightning',
+    school: 'arcane',
+    manaCost: 5,
+    cooldown: 0,
+    target: 'enemy',
+    effects: [{ type: 'damage', value: 20, element: 'lightning' }],
+    tags: ['lightning'],
+  }
+}
+
+function makeIceSpell(): Spell {
+  return {
+    id: 'ice-lance',
+    name: 'Ice Lance',
+    description: 'A lance of ice',
+    school: 'arcane',
+    manaCost: 5,
+    cooldown: 0,
+    target: 'enemy',
+    effects: [{ type: 'damage', value: 20, element: 'ice' }],
+    tags: ['ice'],
+  }
+}
+
+function makeArcaneSpell(id: string): Spell {
+  return {
+    id,
+    name: `Arcane Bolt ${id}`,
+    description: 'A bolt of arcane energy',
+    school: 'arcane',
+    manaCost: 5,
+    cooldown: 0,
+    target: 'enemy',
+    effects: [{ type: 'damage', value: 20, element: 'arcane' }],
+    tags: ['arcane'],
+  }
+}
+
+// ---- Tests ----
+
+describe('SPELL_COMBOS definitions', () => {
+  it('defines exactly 8 combos', () => {
+    expect(SPELL_COMBOS).toHaveLength(8)
+  })
+
+  it('each combo has required fields', () => {
+    for (const combo of SPELL_COMBOS) {
+      expect(combo.sequence).toBeDefined()
+      expect(combo.sequence.length).toBeGreaterThanOrEqual(2)
+      expect(combo.result.comboName).toBeTruthy()
+      expect(typeof combo.result.damageMultiplier).toBe('number')
+      expect(typeof combo.result.ignoreDefense).toBe('boolean')
+      expect(typeof combo.result.bonusHealPct).toBe('number')
+      expect(typeof combo.result.chainHit).toBe('boolean')
+      expect(typeof combo.result.removeEnemyDefenseBuff).toBe('boolean')
+      expect(typeof combo.result.slowEnemy).toBe('boolean')
+    }
+  })
+
+  it('has unique combo names', () => {
+    const names = SPELL_COMBOS.map(c => c.result.comboName)
+    const unique = new Set(names)
+    expect(unique.size).toBe(names.length)
+  })
+
+  it('3-element combos are listed before 2-element combos', () => {
+    const threeElement = SPELL_COMBOS.filter(c => c.sequence.length === 3)
+    const twoElement = SPELL_COMBOS.filter(c => c.sequence.length === 2)
+    const lastThreeIdx = SPELL_COMBOS.indexOf(threeElement[threeElement.length - 1])
+    const firstTwoIdx = SPELL_COMBOS.indexOf(twoElement[0])
+    expect(lastThreeIdx).toBeLessThan(firstTwoIdx)
+  })
+})
+
+describe('checkSpellCombo', () => {
+  it('returns null for empty history', () => {
+    expect(checkSpellCombo([])).toBeNull()
+  })
+
+  it('returns null when last element is none', () => {
+    expect(checkSpellCombo(['fire', 'none'])).toBeNull()
+  })
+
+  it('detects Plasma Burst (fire + lightning)', () => {
+    const result = checkSpellCombo(['fire', 'lightning'])
+    expect(result).not.toBeNull()
+    expect(result!.comboName).toBe('Plasma Burst')
+    expect(result!.damageMultiplier).toBe(1.5)
+  })
+
+  it('detects Frostfire (ice + fire)', () => {
+    const result = checkSpellCombo(['ice', 'fire'])
+    expect(result).not.toBeNull()
+    expect(result!.comboName).toBe('Frostfire')
+    expect(result!.removeEnemyDefenseBuff).toBe(true)
+  })
+
+  it('detects Arcane Cascade (arcane + arcane + arcane)', () => {
+    const result = checkSpellCombo(['arcane', 'arcane', 'arcane'])
+    expect(result).not.toBeNull()
+    expect(result!.comboName).toBe('Arcane Cascade')
+    expect(result!.damageMultiplier).toBe(3.0)
+  })
+
+  it('prefers 3-element combo over 2-element when tail matches both', () => {
+    // fire + ice + lightning should trigger Elemental Fury, not a 2-element combo
+    const result = checkSpellCombo(['fire', 'ice', 'lightning'])
+    expect(result).not.toBeNull()
+    expect(result!.comboName).toBe('Elemental Fury')
+  })
+
+  it('returns null for non-matching sequence', () => {
+    expect(checkSpellCombo(['fire', 'fire'])).toBeNull()
+    expect(checkSpellCombo(['arcane', 'shadow'])).toBeNull()
+  })
+})
+
+describe('getSpellElement', () => {
+  it('returns the element from a damage effect', () => {
+    const spell: Spell = {
+      id: 'test',
+      name: 'Fire Bolt',
+      description: '',
+      school: 'arcane',
+      manaCost: 5,
+      cooldown: 0,
+      target: 'enemy',
+      effects: [{ type: 'damage', value: 10, element: 'fire' }],
+      tags: [],
+    }
+    expect(getSpellElement(spell)).toBe('fire')
+  })
+
+  it('returns none when spell has no element and no school mapping', () => {
+    const spell: Spell = {
+      id: 'test',
+      name: 'Physical Strike',
+      description: '',
+      school: 'war',
+      manaCost: 0,
+      cooldown: 0,
+      target: 'enemy',
+      effects: [{ type: 'damage', value: 10, element: 'none' }],
+      tags: [],
+    }
+    expect(getSpellElement(spell)).toBe('none')
+  })
+
+  it('maps school to element as fallback for arcane school', () => {
+    const spell: Spell = {
+      id: 'test',
+      name: 'Arcane Blast',
+      description: '',
+      school: 'arcane',
+      manaCost: 5,
+      cooldown: 0,
+      target: 'enemy',
+      effects: [],
+      tags: [],
+    }
+    expect(getSpellElement(spell)).toBe('arcane')
+  })
+})
+
+describe('Combo triggers in castSpell', () => {
+  it('triggers Plasma Burst after fire then lightning', () => {
+    const fireSpell = makeFireSpell()
+    const lightningSpell = makeLightningSpell()
+    const enemy = makeEnemy()
+    const combatState = makeCombatState()
+
+    // Cast fire first
+    const after1 = castSpell(fireSpell, makePlayerState(), enemy, baseMage, combatState)
+    expect(after1.comboName).toBeNull()
+
+    // Cast lightning — should trigger Plasma Burst
+    const playerStateAfterFire = after1.playerState
+    const after2 = castSpell(lightningSpell, playerStateAfterFire, after1.enemy, baseMage, combatState)
+    expect(after2.comboName).toBe('Plasma Burst')
+  })
+
+  it('combo log entry has action=spell_combo', () => {
+    const fireSpell = makeFireSpell()
+    const lightningSpell = makeLightningSpell()
+    const after1 = castSpell(fireSpell, makePlayerState(), makeEnemy(), baseMage, makeCombatState())
+    const after2 = castSpell(lightningSpell, after1.playerState, after1.enemy, baseMage, makeCombatState())
+
+    const comboLog = after2.logs.find(l => l.action === 'spell_combo')
+    expect(comboLog).toBeDefined()
+    expect(comboLog?.description).toContain('Plasma Burst')
+  })
+
+  it('combo log description starts with COMBO: for ID extraction', () => {
+    const fireSpell = makeFireSpell()
+    const lightningSpell = makeLightningSpell()
+    const after1 = castSpell(fireSpell, makePlayerState(), makeEnemy(), baseMage, makeCombatState())
+    const after2 = castSpell(lightningSpell, after1.playerState, after1.enemy, baseMage, makeCombatState())
+
+    const comboLog = after2.logs.find(l => l.action === 'spell_combo')
+    expect(comboLog?.description).toMatch(/^COMBO: Plasma Burst!/)
+  })
+
+  it('triggers Arcane Cascade after three arcane spells', () => {
+    const a1 = makeArcaneSpell('arcane-1')
+    const a2 = makeArcaneSpell('arcane-2')
+    const a3 = makeArcaneSpell('arcane-3')
+    const enemy = makeEnemy()
+
+    const r1 = castSpell(a1, makePlayerState(), enemy, baseMage, makeCombatState())
+    // Reset cooldowns between casts (different spell IDs so no cooldown issue)
+    const r2 = castSpell(a2, r1.playerState, r1.enemy, baseMage, makeCombatState())
+    const r3 = castSpell(a3, r2.playerState, r2.enemy, baseMage, makeCombatState())
+
+    expect(r3.comboName).toBe('Arcane Cascade')
+  })
+
+  it('Nature\'s Wrath heals player (bonusHealPct > 0)', () => {
+    const natureSpell1: Spell = {
+      id: 'nature-1',
+      name: 'Nature Bolt 1',
+      description: '',
+      school: 'nature',
+      manaCost: 5,
+      cooldown: 0,
+      target: 'enemy',
+      effects: [{ type: 'damage', value: 15, element: 'nature' }],
+      tags: ['nature'],
+    }
+    const natureSpell2: Spell = {
+      id: 'nature-2',
+      name: 'Nature Bolt 2',
+      description: '',
+      school: 'nature',
+      manaCost: 5,
+      cooldown: 0,
+      target: 'enemy',
+      effects: [{ type: 'damage', value: 15, element: 'nature' }],
+      tags: ['nature'],
+    }
+
+    const playerState = makePlayerState({ hp: 10 }) // low HP so heal is detectable
+    const r1 = castSpell(natureSpell1, playerState, makeEnemy(), baseMage, makeCombatState())
+    const r2 = castSpell(natureSpell2, r1.playerState, r1.enemy, baseMage, makeCombatState())
+
+    expect(r2.comboName).toBe("Nature's Wrath")
+    // Player should have healed (15% of 50 maxHp = 7-8 HP)
+    expect(r2.playerState.hp).toBeGreaterThan(r1.playerState.hp)
+  })
+})
+
+describe('discoveredCombos field on character', () => {
+  it('character schema accepts discoveredCombos as optional array', () => {
+    // Simple type check — the field is optional
+    const charWithCombos = { ...baseMage, discoveredCombos: ['plasma_burst', 'frostfire'] }
+    const charWithEmptyCombos = { ...baseMage, discoveredCombos: [] }
+    expect(charWithCombos.discoveredCombos).toHaveLength(2)
+    expect(charWithEmptyCombos.discoveredCombos).toHaveLength(0)
+    // A character without the field (undefined) should also be valid
+    const { discoveredCombos: _removed, ...charNoCombos } = baseMage
+    expect((_removed as unknown[]) ?? undefined).toBeDefined() // baseMage has it as []
+    expect(charNoCombos.discoveredCombos).toBeUndefined()
+  })
+
+  it('combo ID format matches the pattern used in useCombatActionMutation', () => {
+    // Simulate the ID derivation logic: name → lowercase → underscores
+    function comboNameToId(name: string): string {
+      return name.toLowerCase().replace(/[^a-z0-9]+/g, '_')
+    }
+    expect(comboNameToId('Plasma Burst')).toBe('plasma_burst')
+    expect(comboNameToId('Frostfire')).toBe('frostfire')
+    expect(comboNameToId("Nature's Wrath")).toBe('nature_s_wrath')
+    expect(comboNameToId('Arcane Cascade')).toBe('arcane_cascade')
+    expect(comboNameToId('Shadow Storm')).toBe('shadow_storm')
+    expect(comboNameToId('Void Freeze')).toBe('void_freeze')
+    expect(comboNameToId('Wild Lightning')).toBe('wild_lightning')
+    expect(comboNameToId('Elemental Fury')).toBe('elemental_fury')
+  })
+
+  it('all 8 combo names produce unique IDs', () => {
+    function comboNameToId(name: string): string {
+      return name.toLowerCase().replace(/[^a-z0-9]+/g, '_')
+    }
+    const ids = SPELL_COMBOS.map(c => comboNameToId(c.result.comboName))
+    const unique = new Set(ids)
+    expect(unique.size).toBe(8)
+  })
+})

--- a/src/app/tap-tap-adventure/components/CombatUI.tsx
+++ b/src/app/tap-tap-adventure/components/CombatUI.tsx
@@ -21,6 +21,7 @@ import { Spell } from '@/app/tap-tap-adventure/models/spell'
 import { Item } from '@/app/tap-tap-adventure/models/types'
 import { getDeathFlavorText, getStoryContext, getPermadeathEpitaph } from '@/app/tap-tap-adventure/lib/deathFlavorText'
 import { FloatingDamage, DamageEvent } from './FloatingDamage'
+import { SpellComboPanel } from './SpellComboPanel'
 
 function HpBar({ current, max, label, color }: { current: number; max: number; label: string; color: string }) {
   const pct = Math.max(0, Math.min(100, (current / max) * 100))
@@ -804,6 +805,9 @@ export function CombatUI({ combatState }: CombatUIProps) {
           </div>
         )}
       </div>
+
+      {/* Spell Combos reference (collapsed by default) */}
+      <SpellComboPanel discoveredCombos={character?.discoveredCombos ?? []} />
 
       {/* Turn counter with combat pressure indicator */}
       <div className="text-center text-xs">

--- a/src/app/tap-tap-adventure/components/GameUI.tsx
+++ b/src/app/tap-tap-adventure/components/GameUI.tsx
@@ -47,6 +47,7 @@ import { CraftingPanel } from './CraftingPanel'
 import { EnchantingPanel } from './EnchantingPanel'
 import { ExplorationSpellsPanel } from './ExplorationSpellsPanel'
 import { BestiaryPanel } from './BestiaryPanel'
+import { SpellComboPanel } from './SpellComboPanel'
 import { DailyChallengesPanel } from './DailyChallengesPanel'
 import { NPCDialoguePanel } from './NPCDialoguePanel'
 import { TargetList } from './TargetList'
@@ -741,6 +742,7 @@ export default function GameUI({ onOpenStatus }: GameUIProps) {
             <DailyChallengesPanel />
             <AchievementPanel achievements={gameState.achievements ?? []} />
             <BestiaryPanel bestiary={character?.bestiary ?? []} />
+            <SpellComboPanel discoveredCombos={character?.discoveredCombos ?? []} />
             <EquipmentPanel
               equipment={getSelectedCharacter()?.equipment ?? { weapon: null, armor: null, accessory: null }}
             />
@@ -945,7 +947,10 @@ export default function GameUI({ onOpenStatus }: GameUIProps) {
               </div>
             )}
             {mobileCategory === 'quest' && questSubTab === 'bestiary' && character && (
-              <BestiaryPanel bestiary={character.bestiary ?? []} />
+              <>
+                <BestiaryPanel bestiary={character.bestiary ?? []} />
+                <SpellComboPanel discoveredCombos={character.discoveredCombos ?? []} />
+              </>
             )}
 
             {/* Social panels */}

--- a/src/app/tap-tap-adventure/components/SpellComboPanel.tsx
+++ b/src/app/tap-tap-adventure/components/SpellComboPanel.tsx
@@ -1,0 +1,131 @@
+'use client'
+
+import { useState } from 'react'
+import { SPELL_COMBOS } from '@/app/tap-tap-adventure/lib/spellCombos'
+
+const ELEMENT_ICONS: Record<string, string> = {
+  fire: '🔥',
+  ice: '❄️',
+  lightning: '⚡',
+  shadow: '🌑',
+  nature: '🌿',
+  arcane: '✨',
+}
+
+/** Derive the stored combo ID from the combo name (mirrors useCombatActionMutation logic) */
+function comboNameToId(name: string): string {
+  return name.toLowerCase().replace(/[^a-z0-9]+/g, '_')
+}
+
+function getEffectDescription(result: (typeof SPELL_COMBOS)[0]['result']): string {
+  const parts: string[] = []
+  if (result.damageMultiplier > 1.0) {
+    parts.push(`${result.damageMultiplier}x damage`)
+  }
+  if (result.ignoreDefense) {
+    parts.push('ignores defense')
+  }
+  if (result.bonusHealPct > 0) {
+    parts.push(`heals ${Math.round(result.bonusHealPct * 100)}% max HP`)
+  }
+  if (result.chainHit) {
+    parts.push('chain hit at 50% damage')
+  }
+  if (result.removeEnemyDefenseBuff) {
+    parts.push('halves enemy defense')
+  }
+  if (result.slowEnemy) {
+    parts.push('slows enemy')
+  }
+  return parts.join(', ')
+}
+
+interface SpellComboPanelProps {
+  discoveredCombos: string[]
+}
+
+export function SpellComboPanel({ discoveredCombos }: SpellComboPanelProps) {
+  const [isExpanded, setIsExpanded] = useState(false)
+
+  const discoveredCount = SPELL_COMBOS.filter(c =>
+    discoveredCombos.includes(comboNameToId(c.result.comboName))
+  ).length
+
+  if (!isExpanded) {
+    return (
+      <button
+        className="w-full bg-[#1e1f30] border border-[#3a3c56] rounded-lg p-3 text-left hover:border-indigo-700/50 transition-colors"
+        onClick={() => setIsExpanded(true)}
+      >
+        <div className="flex justify-between items-center">
+          <span className="text-sm font-bold text-indigo-400">Spell Combos</span>
+          <span className="text-xs text-slate-400">{discoveredCount} / {SPELL_COMBOS.length} discovered</span>
+        </div>
+      </button>
+    )
+  }
+
+  return (
+    <div className="bg-[#1e1f30] border border-[#3a3c56] rounded-lg p-3 space-y-3">
+      <div className="flex justify-between items-center">
+        <span className="text-sm font-bold text-indigo-400">Spell Combos</span>
+        <button
+          className="text-xs text-slate-500 hover:text-slate-300 transition-colors"
+          onClick={() => setIsExpanded(false)}
+        >
+          Collapse
+        </button>
+      </div>
+
+      <p className="text-xs text-slate-400">
+        Discovered: {discoveredCount} / {SPELL_COMBOS.length}
+      </p>
+
+      <div className="space-y-2">
+        {SPELL_COMBOS.map((combo) => {
+          const comboId = comboNameToId(combo.result.comboName)
+          const isDiscovered = discoveredCombos.includes(comboId)
+          const elementCount = combo.sequence.length
+
+          if (isDiscovered) {
+            return (
+              <div
+                key={comboId}
+                className="bg-[#161723] border border-indigo-900/40 rounded-md p-2 space-y-1"
+              >
+                <div className="flex items-center gap-1.5">
+                  <span className="text-green-400 text-sm">&#10003;</span>
+                  <span className="text-sm font-semibold text-indigo-300">{combo.result.comboName}</span>
+                </div>
+                <div className="flex items-center gap-1 flex-wrap">
+                  {combo.sequence.map((el, i) => (
+                    <span key={i} className="flex items-center gap-0.5 text-xs text-slate-300">
+                      {i > 0 && <span className="text-slate-600 mx-0.5">+</span>}
+                      <span>{ELEMENT_ICONS[el] ?? el}</span>
+                      <span className="capitalize">{el}</span>
+                    </span>
+                  ))}
+                </div>
+                <p className="text-xs text-slate-400">{getEffectDescription(combo.result)}</p>
+              </div>
+            )
+          }
+
+          return (
+            <div
+              key={comboId}
+              className="bg-[#161723] border border-slate-700/40 rounded-md p-2 space-y-1 opacity-60"
+            >
+              <div className="flex items-center gap-1.5">
+                <span className="text-slate-500 text-sm">?</span>
+                <span className="text-sm font-semibold text-slate-500">???</span>
+                <span className="text-xs text-slate-600 ml-auto">{elementCount}-element combo</span>
+              </div>
+              <p className="text-xs text-slate-600">Discover by casting the right sequence!</p>
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/src/app/tap-tap-adventure/config/achievements.ts
+++ b/src/app/tap-tap-adventure/config/achievements.ts
@@ -217,4 +217,24 @@ export const ACHIEVEMENTS: Achievement[] = [
     icon: '🌍',
     reward: { gold: 500, reputation: 100 },
   },
+
+  // Spell Combo achievements
+  {
+    id: 'combo_first_combo',
+    name: 'First Combo',
+    description: 'Trigger any spell combo for the first time',
+    category: 'special',
+    requirement: 1,
+    icon: '✨',
+    reward: { gold: 20, reputation: 5 },
+  },
+  {
+    id: 'combo_master',
+    name: 'Combo Master',
+    description: 'Discover all 8 spell combos',
+    category: 'special',
+    requirement: 8,
+    icon: '🔮',
+    reward: { gold: 200, reputation: 25 },
+  },
 ]

--- a/src/app/tap-tap-adventure/hooks/useCombatActionMutation.ts
+++ b/src/app/tap-tap-adventure/hooks/useCombatActionMutation.ts
@@ -123,6 +123,20 @@ export function useCombatActionMutation(options?: { onMountDrop?: (mount: Mount)
         })
       }
 
+      // Detect spell combos in new log entries and record discoveries
+      {
+        const prevLogLen = combatState.combatLog.length
+        const newEntries = data.combatState.combatLog.slice(prevLogLen)
+        const comboEntry = newEntries.find(e => e.action === 'spell_combo')
+        if (comboEntry) {
+          const match = comboEntry.description.match(/^COMBO: ([^!]+)!/)
+          if (match) {
+            const comboId = match[1].trim().toLowerCase().replace(/[^a-z0-9]+/g, '_')
+            useGameStore.getState().discoverCombo(comboId)
+          }
+        }
+      }
+
       if (data.combatState.status === 'active') {
         // Combat continues — play sounds based on what happened
         // Check for critical hits in new log entries

--- a/src/app/tap-tap-adventure/hooks/useGameStore.ts
+++ b/src/app/tap-tap-adventure/hooks/useGameStore.ts
@@ -142,6 +142,7 @@ export interface GameStore {
   recordNPCEncounter: (npcId: string, dispositionDelta: number, reward?: { gold?: number; reputation?: number }, revealLandmark?: boolean) => void
   setActiveTarget: (index: number) => void
   castExplorationSpell: (spellId: string) => { message: string; success: boolean } | null
+  discoverCombo: (comboId: string) => void
 }
 
 export const useGameStore = create<GameStore>()(
@@ -1582,10 +1583,50 @@ export const useGameStore = create<GameStore>()(
 
         return { message, success: true }
       },
+      discoverCombo: (comboId: string) => {
+        set(
+          produce((state: GameStore) => {
+            const selectedCharacter = get().getSelectedCharacter()
+            if (!selectedCharacter) return
+            const charIndex = state.gameState.characters.findIndex(c => c.id === selectedCharacter.id)
+            if (charIndex === -1) return
+            const discovered = state.gameState.characters[charIndex].discoveredCombos ?? []
+            if (discovered.includes(comboId)) return
+            state.gameState.characters[charIndex].discoveredCombos = [...discovered, comboId]
+
+            // Check achievements after updating combo discovery
+            const updatedChar = state.gameState.characters[charIndex]
+            const { achievements, newlyCompleted } = checkAchievements(
+              updatedChar,
+              state.gameState,
+              state.gameState.achievements ?? []
+            )
+            state.gameState.achievements = achievements
+            if (newlyCompleted.length > 0) {
+              let goldGain = 0
+              let repGain = 0
+              for (const id of newlyCompleted) {
+                const config = ACHIEVEMENTS.find(a => a.id === id)
+                if (config?.reward) {
+                  goldGain += config.reward.gold ?? 0
+                  repGain += config.reward.reputation ?? 0
+                }
+                const pa = state.gameState.achievements.find(a => a.achievementId === id)
+                if (pa) pa.rewardClaimed = true
+              }
+              state.gameState.characters[charIndex] = {
+                ...state.gameState.characters[charIndex],
+                gold: state.gameState.characters[charIndex].gold + goldGain,
+                reputation: clampReputation(state.gameState.characters[charIndex].reputation + repGain),
+              }
+            }
+          })
+        )
+      },
     }),
     {
       name: 'fantasy-tycoon-storage', // localStorage key (kept for backward compat)
-      version: 31,
+      version: 32,
       migrate: (persistedState: unknown) => {
         const state = persistedState as GameStore
         if (state?.gameState && !('combatState' in state.gameState)) {
@@ -1737,6 +1778,10 @@ export const useGameStore = create<GameStore>()(
                 ...lm,
                 isSecret: (lm as Record<string, unknown>).isSecret !== undefined ? Boolean((lm as Record<string, unknown>).isSecret) : false,
               }))
+            }
+            // v32: Add discoveredCombos
+            if (!(char as FantasyCharacter).discoveredCombos) {
+              ;(char as FantasyCharacter).discoveredCombos = []
             }
           }
         }

--- a/src/app/tap-tap-adventure/lib/achievementTracker.ts
+++ b/src/app/tap-tap-adventure/lib/achievementTracker.ts
@@ -160,5 +160,14 @@ function getProgress(
     return existing?.progress ?? 0
   }
 
+  // Spell combo achievements — snapshot of discoveredCombos
+  if (achievementId === 'combo_first_combo') {
+    return (character.discoveredCombos?.length ?? 0) >= 1 ? 1 : 0
+  }
+
+  if (achievementId === 'combo_master') {
+    return character.discoveredCombos?.length ?? 0
+  }
+
   return 0
 }

--- a/src/app/tap-tap-adventure/models/character.ts
+++ b/src/app/tap-tap-adventure/models/character.ts
@@ -68,6 +68,7 @@ export const FantasyCharacterSchema = z.object({
   campState: CampStateSchema.optional(),
   factionReputations: z.record(z.string(), z.number()).optional().default({}),
   bestiary: z.array(BestiaryEntrySchema).optional(),
+  discoveredCombos: z.array(z.string()).optional(),
   npcEncounters: z.record(z.string(), z.object({ timesSpoken: z.number(), disposition: z.number(), lastTier: z.string().optional() })).optional(),
   landmarkState: z.object({
     regionId: z.string(),


### PR DESCRIPTION
## Summary

Closes #354

Makes the 8 spell combos discoverable and trackable:

- **SpellComboPanel**: New collapsible panel showing all 8 combos — discovered ones display name, element sequence with icons, and effect description; undiscovered show "???" with element count hints
- **Persistent Discovery**: `discoveredCombos` array on character tracks which combos the player has triggered; discoveries happen automatically when a `spell_combo` combat log entry is detected
- **Achievements**: "First Combo" (trigger any combo, +20g +5 rep) and "Combo Master" (discover all 8, +200g +25 rep)
- **UI Integration**: Panel accessible in combat view and in the main game view alongside Bestiary/Achievements
- **Store Migration v32**: Backfills `discoveredCombos: []` on existing characters

## Test plan

- [x] 790 tests pass (22 new spell combo tests)
- [x] All 8 combos defined with required fields, unique names
- [x] Combo detection works for 2-element and 3-element combos
- [x] discoveredCombos field initialized correctly
- [ ] Manual: trigger a combo in combat → verify it appears as discovered in panel
- [ ] Manual: verify undiscovered combos show as "???"
- [ ] Manual: verify achievements trigger on first combo and all combos

🤖 Generated with [Claude Code](https://claude.com/claude-code)