### PR TITLE
fix: scale region distances by difficulty (#360)

### DIFF
--- a/src/app/api/v1/tap-tap-adventure/move-forward/services/moveForwardService.ts
+++ b/src/app/api/v1/tap-tap-adventure/move-forward/services/moveForwardService.ts
@@ -31,18 +31,23 @@ export async function moveForwardService(
   const existingLandmarkState = character.landmarkState
   if (!existingLandmarkState || existingLandmarkState.regionId !== currentRegion) {
     const visitCount = (character.visitedRegions ?? []).filter(id => id === currentRegion).length
-    const landmarks = generateLandmarks(currentRegion, character.id, visitCount, region.difficultyMultiplier)
 
-    // Seeded region length between 150-250 steps, scaled by difficulty
+    // Scale region size by difficulty: easy (0.8) → 80, medium (1.0) → 100, hard (1.5) → 150, extreme (3.0) → 300
+    const regionSize = Math.round(100 * region.difficultyMultiplier)
+    const landmarks = generateLandmarks(currentRegion, character.id, visitCount, region.difficultyMultiplier, regionSize)
+
+    // Seeded region length scaled by difficulty
     const regionLengthSeed = `${currentRegion}-${character.id}-${visitCount}-length`
-    const regionLength = Math.floor((150 + Math.floor(seededRandom(regionLengthSeed)() * 101)) * region.difficultyMultiplier)
+    const regionLength = Math.floor((50 + Math.floor(seededRandom(regionLengthSeed)() * 31)) * region.difficultyMultiplier)
 
     // Generate exit positions spread around region edges, one per connected region
     const connected = getConnectedRegions(region.id)
+    const center = regionSize / 2
+    const edgeRadius = regionSize * 0.48
     const exitPositions = connected.map((connRegion, i) => {
       const angle = (i / connected.length) * Math.PI * 2
-      const edgeX = 250 + Math.cos(angle) * 240
-      const edgeY = 250 + Math.sin(angle) * 240
+      const edgeX = center + Math.cos(angle) * edgeRadius
+      const edgeY = center + Math.sin(angle) * edgeRadius
       return {
         regionId: connRegion.id,
         name: `Path to ${connRegion.name}`,
@@ -64,9 +69,9 @@ export async function moveForwardService(
         activeTargetIndex: 0,
         regionLength,
         position: { x: 0, y: 0 },
-        exitPosition: exitPositions[0]?.position ?? { x: 490, y: 250 },
+        exitPosition: exitPositions[0]?.position ?? { x: Math.round(regionSize * 0.98), y: Math.round(regionSize / 2) },
         exitPositions,
-        regionBounds: { width: 500, height: 500 },
+        regionBounds: { width: regionSize, height: regionSize },
       },
     }
 

--- a/src/app/tap-tap-adventure/lib/landmarkGenerator.ts
+++ b/src/app/tap-tap-adventure/lib/landmarkGenerator.ts
@@ -59,7 +59,8 @@ export function generateLandmarks(
   regionId: string,
   characterId: string,
   visitCount: number = 0,
-  difficultyMultiplier: number = 1
+  difficultyMultiplier: number = 1,
+  regionSize: number = 100
 ): GeneratedLandmark[] {
   const templates = getTemplatesForRegion(regionId)
   const seed = `${regionId}-${characterId}-${visitCount}`
@@ -68,12 +69,19 @@ export function generateLandmarks(
   // Pick 3 landmarks from templates (shuffled deterministically)
   const selected = seededShuffle([...templates], rng).slice(0, 3) as LandmarkTemplate[]
 
+  // Scale positions within the region size (margin = 10% of size)
+  const margin = regionSize * 0.1
+  const range = regionSize - 2 * margin
+
   // Assign distances: first at 20-40 steps, subsequent 25-50 steps apart (scaled by difficulty)
   let currentDist = Math.floor((20 + Math.floor(rng() * 21)) * difficultyMultiplier) // 20-40, scaled
   const landmarks: GeneratedLandmark[] = []
 
   for (const template of selected) {
-    const position = { x: 50 + rng() * 400, y: 50 + rng() * 400 }
+    const position = {
+      x: Math.round(margin + rng() * range),
+      y: Math.round(margin + rng() * range),
+    }
     landmarks.push({
       templateId: template.id,
       name: template.name,
@@ -94,11 +102,13 @@ export function generateLandmarks(
   const secretTemplates = getSecretTemplatesForRegion(regionId)
   if (secretTemplates.length > 0) {
     const secretTemplate = secretTemplates[Math.floor(rng() * secretTemplates.length)]
-    // Place secret landmark between existing landmarks (roughly middle of region)
     const secretDist = landmarks.length > 1
       ? Math.floor((landmarks[0].distanceFromEntry + landmarks[landmarks.length - 1].distanceFromEntry) / 2) + Math.floor(rng() * 15)
       : 30 + Math.floor(rng() * 20)
-    const secretPosition = { x: 50 + rng() * 400, y: 50 + rng() * 400 }
+    const secretPosition = {
+      x: Math.round(margin + rng() * range),
+      y: Math.round(margin + rng() * range),
+    }
     landmarks.push({
       templateId: secretTemplate.id,
       name: secretTemplate.name,
@@ -113,7 +123,6 @@ export function generateLandmarks(
       explored: false,
       position: secretPosition,
     })
-    // Re-sort by distance
     landmarks.sort((a, b) => a.distanceFromEntry - b.distanceFromEntry)
   }
 


### PR DESCRIPTION
## Problem
Green Meadows landmarks were 300-600 km away because the 2D coordinate space was a fixed 500x500 for all regions. The \`difficultyMultiplier\` only scaled the old 1D values.

## Fix
Region size now scales: \`regionSize = 100 * difficultyMultiplier\`

| Region | Multiplier | Size | Landmark range | Exit range |
|--------|-----------|------|----------------|------------|
| Green Meadows | 0.8x | 80x80 | 8-72 km | ~38 km |
| Dark Forest | 1.0x | 100x100 | 10-90 km | ~48 km |
| Scorched Wastes | 1.5x | 150x150 | 15-135 km | ~72 km |
| Shadow Realm | 2.0x | 200x200 | 20-180 km | ~96 km |
| Celestial Throne | 3.0x | 300x300 | 30-270 km | ~144 km |

## Test plan
- [ ] New character in Green Meadows — landmarks should be 8-72 km away (not 300+)
- [ ] Exits should be ~38 km (not 340+)
- [ ] Higher difficulty regions should have proportionally larger distances

Closes #360

🤖 Generated with [Claude Code](https://claude.com/claude-code)