### PR TITLE
fix: start new characters at center of region instead of top-left

### DIFF
--- a/src/app/api/v1/tap-tap-adventure/move-forward/services/moveForwardService.ts
+++ b/src/app/api/v1/tap-tap-adventure/move-forward/services/moveForwardService.ts
@@ -68,7 +68,7 @@ export async function moveForwardService(
         positionInRegion: 0,
         activeTargetIndex: 0,
         regionLength,
-        position: { x: 0, y: 0 },
+        position: { x: Math.round(regionSize / 2), y: Math.round(regionSize / 2) },
         exitPosition: exitPositions[0]?.position ?? { x: Math.round(regionSize * 0.98), y: Math.round(regionSize / 2) },
         exitPositions,
         regionBounds: { width: regionSize, height: regionSize },


### PR DESCRIPTION
## Summary
- Changes the starting position for new regions from `(0, 0)` (top-left corner) to `(regionSize/2, regionSize/2)` (center of region)
- This makes spatial sense — players begin exploring from the middle of a region rather than from an arbitrary corner

Closes #363
Parent epic: #362

## Test plan
- [ ] Start a new game — character should appear at the center of the first region
- [ ] Travel to a new region — character should start at the center of the new region
- [ ] Verify landmark distances and exit positions still work correctly relative to center start

🤖 Generated with [Claude Code](https://claude.com/claude-code)