### PR TITLE
fix: prevent re-exploration of fully explored landmarks

### DIFF
--- a/src/app/api/v1/tap-tap-adventure/move-forward/services/moveForwardService.ts
+++ b/src/app/api/v1/tap-tap-adventure/move-forward/services/moveForwardService.ts
@@ -214,9 +214,11 @@ export async function moveForwardService(
         decisionPoint: {
           id: `decision-${arrivalEventId}`,
           eventId: arrivalEventId,
-          prompt: `${activeLandmark.icon} You arrive at ${activeLandmark.name}. ${activeLandmark.description} What do you do?`,
+          prompt: activeLandmark.explored
+            ? `${activeLandmark.icon} You arrive at ${activeLandmark.name}. You've already explored this place thoroughly. What do you do?`
+            : `${activeLandmark.icon} You arrive at ${activeLandmark.name}. ${activeLandmark.description} What do you do?`,
           options: [
-            {
+            ...(activeLandmark.explored ? [] : [{
               id: 'explore-landmark',
               text: `Explore ${activeLandmark.name}`,
               successProbability: 1.0,
@@ -225,7 +227,7 @@ export async function moveForwardService(
               failureDescription: '',
               failureEffects: {},
               resultDescription: `You explore ${activeLandmark.name}.`,
-            },
+            }]),
             ...bypassOptions,
           ],
           resolved: false,

--- a/src/app/api/v1/tap-tap-adventure/resolve-decision/route.ts
+++ b/src/app/api/v1/tap-tap-adventure/resolve-decision/route.ts
@@ -426,12 +426,18 @@ export async function POST(req: NextRequest) {
         }
         response.decisionPoint = guardianDecision
       } else {
-        // Max depth reached on a normal landmark — end exploration
+        // Max depth reached on a normal landmark — end exploration, mark as explored
         response.outcomeDescription = `${response.outcomeDescription ?? ''} You've explored everything ${currentLandmarkState.exploringLandmarkName} has to offer.`
+        const updatedLandmarks = currentLandmarkState.landmarks.map(lm =>
+          lm.name === currentLandmarkState.exploringLandmarkName
+            ? { ...lm, explored: true }
+            : lm
+        )
         updatedCharacter = {
           ...updatedCharacter,
           landmarkState: {
             ...currentLandmarkState,
+            landmarks: updatedLandmarks,
             exploring: false,
             explorationDepth: 0,
             exploringLandmarkName: undefined,


### PR DESCRIPTION
## Summary
- Marks landmarks as `explored: true` server-side when exploration depth reaches maxDepth
- Removes the "Explore" option from decision points for already-explored landmarks
- Shows "You've already explored this place thoroughly" prompt at explored landmarks, with only bypass options available

Closes #365
Parent epic: #362

## Test plan
- [ ] Explore a landmark fully (complete all encounters) — it should be marked explored
- [ ] Return to that landmark — "Explore" button should not appear, only bypass options
- [ ] Partially explored landmarks (left early) should still be explorable
- [ ] No regressions in landmark arrival, exploration flow, or bypass navigation

🤖 Generated with [Claude Code](https://claude.com/claude-code)