### PR TITLE
feat: fix item classification, add trade goods, and improve actions

### DIFF
--- a/src/app/tap-tap-adventure/__tests__/itemPostProcessor.test.ts
+++ b/src/app/tap-tap-adventure/__tests__/itemPostProcessor.test.ts
@@ -94,10 +94,10 @@ describe('itemPostProcessor', () => {
   })
 
   describe('charms', () => {
-    it('infers amulet as consumable with luck', () => {
+    it('infers amulet as equipment with luck', () => {
       const item = makeItem({ name: 'Ancient Amulet' })
       const result = inferItemTypeAndEffects(item)
-      expect(result.type).toBe('consumable')
+      expect(result.type).toBe('equipment')
       expect(result.effects?.luck).toBe(2)
     })
 

--- a/src/app/tap-tap-adventure/components/InventoryPanel.tsx
+++ b/src/app/tap-tap-adventure/components/InventoryPanel.tsx
@@ -25,8 +25,8 @@ const TYPE_FILTERS = [
   { value: 'consumable', label: 'Consumable' },
   { value: 'equipment', label: 'Equipment' },
   { value: 'spell_scroll', label: 'Spell' },
+  { value: 'trade_good', label: 'Trade' },
   { value: 'quest', label: 'Quest' },
-  { value: 'misc', label: 'Misc' },
 ]
 
 export function InventoryPanel({ inventory }: InventoryPanelProps) {
@@ -326,7 +326,16 @@ export function InventoryPanel({ inventory }: InventoryPanelProps) {
                       Equip
                     </Button>
                   )}
-                  {activeTab === 'active' ? (
+                  {activeTab === 'active' && item.type === 'trade_good' && (
+                    <Button
+                      className="flex-1 bg-amber-700 hover:bg-amber-800 text-white text-sm py-3 px-3 rounded-md transition-colors"
+                      onClick={() => handleUse(item)}
+                      title={`Sell for gold`}
+                    >
+                      Sell
+                    </Button>
+                  )}
+                  {activeTab === 'active' && item.type !== 'quest' ? (
                     <Button
                       className="flex-1 bg-red-700 hover:bg-red-800 text-white text-sm py-3 px-3 rounded-md transition-colors"
                       onClick={() => handleDiscard(item)}
@@ -334,7 +343,7 @@ export function InventoryPanel({ inventory }: InventoryPanelProps) {
                     >
                       Discard
                     </Button>
-                  ) : (
+                  ) : activeTab === 'deleted' ? (
                     <Button
                       className="flex-1 bg-blue-700 hover:bg-blue-800 text-white text-sm py-3 px-3 rounded-md transition-colors"
                       onClick={() => handleRestore(item)}
@@ -342,7 +351,7 @@ export function InventoryPanel({ inventory }: InventoryPanelProps) {
                     >
                       Restore
                     </Button>
-                  )}
+                  ) : null}
                 </div>
               </div>
               )

--- a/src/app/tap-tap-adventure/hooks/useGameStore.ts
+++ b/src/app/tap-tap-adventure/hooks/useGameStore.ts
@@ -1642,7 +1642,7 @@ export const useGameStore = create<GameStore>()(
     }),
     {
       name: 'fantasy-tycoon-storage', // localStorage key (kept for backward compat)
-      version: 33,
+      version: 34,
       migrate: (persistedState: unknown) => {
         const state = persistedState as GameStore
         if (state?.gameState && !('combatState' in state.gameState)) {
@@ -1798,6 +1798,12 @@ export const useGameStore = create<GameStore>()(
             // v32: Add discoveredCombos
             if (!(char as FantasyCharacter).discoveredCombos) {
               ;(char as FantasyCharacter).discoveredCombos = []
+            }
+            // v34: Reclassify misc items as trade_good
+            if ((char as FantasyCharacter).inventory) {
+              for (const item of (char as FantasyCharacter).inventory) {
+                if (item.type === 'misc') item.type = 'trade_good'
+              }
             }
           }
         }

--- a/src/app/tap-tap-adventure/lib/itemPostProcessor.ts
+++ b/src/app/tap-tap-adventure/lib/itemPostProcessor.ts
@@ -55,10 +55,11 @@ function inferRarity(item: Item): Item['rarity'] {
 function inferItemTypeAndEffectsInternal(item: Item): Item {
   const nameLower = item.name.toLowerCase()
 
-  // Detect map/chart/atlas items: ensure revealLandmark effect is set
-  if (matchesAny(nameLower, ['map', 'chart', 'atlas']) && item.type === 'consumable') {
+  // Detect map/chart/atlas items: force consumable with revealLandmark
+  if (matchesAny(nameLower, ['map', 'chart', 'atlas'])) {
     return {
       ...item,
+      type: 'consumable',
       effects: { ...item.effects, revealLandmark: true },
     }
   }
@@ -138,11 +139,11 @@ function inferItemTypeAndEffectsInternal(item: Item): Item {
     }
   }
 
-  // Charms / Amulets (consumable by default, but equipment if explicitly typed)
+  // Charms / Amulets — wearable accessories
   if (matchesAny(name, ['charm', 'amulet', 'talisman', 'trinket', 'lucky'])) {
     return {
       ...item,
-      type: item.type === 'equipment' ? 'equipment' : 'consumable',
+      type: 'equipment',
       effects: item.effects ?? { luck: 2 },
     }
   }
@@ -196,6 +197,15 @@ function inferItemTypeAndEffectsInternal(item: Item): Item {
     }
   }
 
+  // Trade goods: valuable items meant to be sold
+  if (matchesAny(name, ['pelt', 'hide', 'fur', 'silk', 'spice', 'ore', 'ingot', 'pearl', 'ivory', 'amber', 'relic', 'artifact', 'trophy', 'idol', 'figurine', 'tapestry', 'cloth', 'wine', 'perfume', 'incense'])) {
+    return {
+      ...item,
+      type: 'trade_good',
+      effects: item.effects ?? { gold: 20 },
+    }
+  }
+
   // Has effects but missing type
   if (item.effects && Object.keys(item.effects).length > 0) {
     return { ...item, type: 'consumable' }
@@ -207,6 +217,11 @@ function inferItemTypeAndEffectsInternal(item: Item): Item {
       ...item,
       effects: { heal: 5, luck: 1 },
     }
+  }
+
+  // Reclassify misc items as trade goods (they have no specific use)
+  if (item.type === 'misc') {
+    return { ...item, type: 'trade_good', effects: item.effects ?? { gold: 5 } }
   }
 
   return item

--- a/src/app/tap-tap-adventure/lib/sellPrice.ts
+++ b/src/app/tap-tap-adventure/lib/sellPrice.ts
@@ -9,6 +9,8 @@ import { Item } from '@/app/tap-tap-adventure/models/item'
  *   - Other / no type: 3
  */
 export function calculateSellPrice(item: Item): number {
+  if (item.type === 'quest') return 0
+
   if (item.price != null && item.price > 0) {
     return Math.floor(item.price * 0.5)
   }
@@ -18,6 +20,8 @@ export function calculateSellPrice(item: Item): number {
   switch (item.type) {
     case 'equipment':
       return 10 + effectSum * 5
+    case 'trade_good':
+      return 15 + effectSum * 3
     case 'consumable':
       return 5 + effectSum * 3
     default:

--- a/src/app/tap-tap-adventure/lib/shopGenerator.ts
+++ b/src/app/tap-tap-adventure/lib/shopGenerator.ts
@@ -35,7 +35,7 @@ const shopSchemaForOpenAI = {
           name: { type: 'string' },
           description: { type: 'string' },
           quantity: { type: 'number' },
-          type: { type: 'string', enum: ['consumable', 'equipment', 'quest', 'misc'] },
+          type: { type: 'string', enum: ['consumable', 'equipment', 'quest', 'trade_good', 'spell_scroll'] },
           price: { type: 'number' },
           rarity: { type: 'string', enum: ['common', 'uncommon', 'rare', 'epic', 'legendary'] },
           effects: {

--- a/src/app/tap-tap-adventure/models/item.ts
+++ b/src/app/tap-tap-adventure/models/item.ts
@@ -32,7 +32,7 @@ export const ItemSchema = z.object({
   description: z.string(),
   quantity: z.number(),
   status: z.enum(['active', 'deleted']).optional(),
-  type: z.enum(['consumable', 'equipment', 'quest', 'misc', 'spell_scroll']).optional(),
+  type: z.enum(['consumable', 'equipment', 'quest', 'misc', 'spell_scroll', 'trade_good']).optional(),
   effects: ItemEffectsSchema.optional(),
   price: z.number().optional(),
   spell: SpellSchema.optional(),


### PR DESCRIPTION
## Summary
- Adds `trade_good` item type for valuable sellable items (pelts, ores, silks, relics)
- Fixes maps to always be `consumable` with `revealLandmark` effect regardless of LLM-assigned type
- Fixes charms/amulets to classify as `equipment` instead of `consumable`
- Reclassifies `misc` items as `trade_good` (eliminates the useless misc category)
- Adds amber "Sell" button for trade goods in inventory
- Protects quest items from being discarded
- Updates sell prices: trade goods worth more (15 + effects × 3), quest items unsellable
- Updates LLM generation schema to include `trade_good` and `spell_scroll` types
- Adds store migration (v33→v34) to reclassify existing `misc` items

Closes #366
Parent epic: #362

## Test plan
- [ ] Generate items in shop — weapons should be equipment, maps should be consumable
- [ ] Trade good items (pelts, gems, ores) should show amber "Sell" button
- [ ] Quest items should not have a "Discard" button
- [ ] Maps should be usable and reveal landmarks
- [ ] Charms/amulets should be equippable, not consumable
- [ ] Existing characters with `misc` items should have them reclassified after migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)