### PR TITLE
feat: add rewards and consequences to landmark encounters

### DIFF
--- a/src/app/api/v1/tap-tap-adventure/resolve-decision/route.ts
+++ b/src/app/api/v1/tap-tap-adventure/resolve-decision/route.ts
@@ -183,8 +183,9 @@ export async function POST(req: NextRequest) {
       // Build enriched context with landmark's encounterPrompt prepended
       const MAX_CONTEXT = 1500
       const baseContext = buildStoryContext(character, storyEvents)
+      const explorationDepth = updatedLandmarkState?.explorationDepth ?? 1
       const landmarkPrefix = exploredLandmark
-        ? `Landmark: ${exploredLandmark.name} (${exploredLandmark.type}). ${exploredLandmark.encounterPrompt}\n\n`
+        ? `Landmark: ${exploredLandmark.name} (${exploredLandmark.type}). ${exploredLandmark.encounterPrompt}\nExploration depth: ${explorationDepth}. Scale rewards with depth — deeper encounters should have greater risks and greater rewards.\n\n`
         : ''
       const combined = landmarkPrefix + baseContext
       const enrichedContext = combined.length > MAX_CONTEXT ? combined.slice(0, MAX_CONTEXT) : combined
@@ -229,17 +230,27 @@ export async function POST(req: NextRequest) {
         const fallbackDecisionPoint: FantasyDecisionPoint = {
           id: `decision-${fallbackId}`,
           eventId: fallbackId,
-          prompt: `You explore ${exploredLandmark?.name ?? 'the landmark'}, but the area seems quiet for now. What would you like to do?`,
+          prompt: `You explore ${exploredLandmark?.name ?? 'the landmark'} and discover a dimly lit chamber. Ancient symbols line the walls, and you notice what could be hidden compartments. What would you like to do?`,
           options: [
             {
+              id: 'search-treasure',
+              text: 'Search for hidden treasure',
+              successProbability: 0.7,
+              successDescription: 'You find a hidden cache of coins and supplies!',
+              successEffects: { gold: 15, reputation: 1 },
+              failureDescription: 'You trigger a trap while searching! A dart grazes your arm.',
+              failureEffects: { gold: -5, statusChange: 'Wounded' },
+              resultDescription: 'You search the area thoroughly.',
+            },
+            {
               id: 'continue-exploring',
-              text: 'Continue Exploring',
-              successProbability: 1.0,
-              successDescription: 'You press on, searching for something of interest.',
-              successEffects: {},
-              failureDescription: '',
+              text: 'Continue Exploring cautiously',
+              successProbability: 0.9,
+              successDescription: 'You find a few coins and something interesting.',
+              successEffects: { gold: 5 },
+              failureDescription: 'The area proves difficult to navigate.',
               failureEffects: {},
-              resultDescription: 'You press on, searching for something of interest.',
+              resultDescription: 'You explore cautiously.',
             },
             {
               id: 'leave-landmark',
@@ -427,7 +438,16 @@ export async function POST(req: NextRequest) {
         response.decisionPoint = guardianDecision
       } else {
         // Max depth reached on a normal landmark — end exploration, mark as explored
-        response.outcomeDescription = `${response.outcomeDescription ?? ''} You've explored everything ${currentLandmarkState.exploringLandmarkName} has to offer.`
+        // Award completion bonus scaled by region difficulty
+        const completionGold = Math.round(20 * regionMult)
+        const completionRep = 2
+
+        updatedCharacter = {
+          ...updatedCharacter,
+          gold: (updatedCharacter.gold ?? 0) + completionGold,
+          reputation: (updatedCharacter.reputation ?? 0) + completionRep,
+        }
+
         const updatedLandmarks = currentLandmarkState.landmarks.map(lm =>
           lm.name === currentLandmarkState.exploringLandmarkName
             ? { ...lm, explored: true }
@@ -443,7 +463,10 @@ export async function POST(req: NextRequest) {
             exploringLandmarkName: undefined,
           },
         }
+
+        response.outcomeDescription = `${response.outcomeDescription ?? ''} You've explored everything ${currentLandmarkState.exploringLandmarkName} has to offer. Exploration complete! +${completionGold} gold, +${completionRep} reputation.`
         response.updatedCharacter = updatedCharacter
+        response.appliedEffects = { ...response.appliedEffects, gold: completionGold, reputation: completionRep }
       }
     }
 

--- a/src/app/tap-tap-adventure/lib/llmEventGenerator.ts
+++ b/src/app/tap-tap-adventure/lib/llmEventGenerator.ts
@@ -363,6 +363,9 @@ When rewarding items, sometimes include consumable items (type: "consumable") wi
 Sometimes include equipment items (type: "equipment") like weapons, armor, or accessories with stat-boosting effects. Examples: a steel sword with +2 strength, iron armor with +2 intelligence, or a lucky charm with +1 luck.
 Sometimes reward spell scrolls — items with type "spell_scroll" containing a spell with a creative name, 2-3 effects, optional conditions, and tags. The spell field should have: id, name, description, school (arcane/nature/shadow/war), manaCost, cooldown, target (enemy/self), effects array, optional conditions array, and tags array.
 
+IMPORTANT — Encounter effects:
+Every encounter option MUST include meaningful successEffects and failureEffects with mechanical rewards or consequences. Do NOT create purely narrative encounters with empty effects. At minimum, include gold, reputation, or statusChange in each outcome path. Scale rewards by risk — dangerous options should offer higher gold (15-40) or item rewards but also include negative consequences on failure (gold loss, negative reputation, statusChange like "Wounded" or "Cursed"). Safe options should give smaller but guaranteed rewards (5-10 gold, +1 reputation). Example successEffects: { "gold": 15, "reputation": 1 }. Example failureEffects: { "gold": -5, "statusChange": "Bruised" }.
+
 IMPORTANT — Combat events:
 Exactly 1 of the 3 events MUST be a combat encounter (bandits, monsters, aggressive creatures, rivals, etc.). That event MUST include at least one option with "triggersCombat": true — this represents the character choosing to fight. The other options on that event can be peaceful alternatives (negotiate, flee, pay a toll, sneak past). The remaining 2 events should be non-combat (exploration, social, discovery, etc.) with NO options that have triggersCombat. This ensures approximately 25% of events over time involve combat potential.
 


### PR DESCRIPTION
## Summary
- Updates LLM prompt to require mechanical effects (gold, reputation, status) in every landmark encounter option
- Adds exploration depth context so the LLM can scale rewards with depth
- Awards a completion bonus (gold + reputation, scaled by region difficulty) when fully exploring a landmark
- Replaces empty fallback landmark encounters with engaging options that include treasure hunting and risk/reward tradeoffs

Closes #367
Parent epic: #362

## Test plan
- [ ] Explore a landmark — encounter options should include gold/reputation/status effects
- [ ] Complete a full landmark exploration — should receive completion bonus message
- [ ] Fallback encounters (when LLM fails) should have treasure search and cautious explore options with effects
- [ ] Rewards should scale with region difficulty (harder regions = more gold)
- [ ] No regressions in road events or combat encounters

🤖 Generated with [Claude Code](https://claude.com/claude-code)