### PR TITLE
feat: add town hub system with shop, inn, and revisitable towns

### DIFF
--- a/src/app/api/v1/tap-tap-adventure/move-forward/services/moveForwardService.ts
+++ b/src/app/api/v1/tap-tap-adventure/move-forward/services/moveForwardService.ts
@@ -214,22 +214,38 @@ export async function moveForwardService(
         decisionPoint: {
           id: `decision-${arrivalEventId}`,
           eventId: arrivalEventId,
-          prompt: activeLandmark.explored
-            ? `${activeLandmark.icon} You arrive at ${activeLandmark.name}. You've already explored this place thoroughly. What do you do?`
-            : `${activeLandmark.icon} You arrive at ${activeLandmark.name}. ${activeLandmark.description} What do you do?`,
-          options: [
-            ...(activeLandmark.explored ? [] : [{
-              id: 'explore-landmark',
-              text: `Explore ${activeLandmark.name}`,
-              successProbability: 1.0,
-              successDescription: `You venture into ${activeLandmark.name} to see what awaits.`,
-              successEffects: {},
-              failureDescription: '',
-              failureEffects: {},
-              resultDescription: `You explore ${activeLandmark.name}.`,
-            }]),
-            ...bypassOptions,
-          ],
+          prompt: activeLandmark.type === 'town'
+            ? `${activeLandmark.icon} You arrive at ${activeLandmark.name}. ${activeLandmark.description} The town is bustling with activity. What would you like to do?`
+            : (activeLandmark.explored
+              ? `${activeLandmark.icon} You arrive at ${activeLandmark.name}. You've already explored this place thoroughly. What do you do?`
+              : `${activeLandmark.icon} You arrive at ${activeLandmark.name}. ${activeLandmark.description} What do you do?`),
+          options: activeLandmark.type === 'town'
+            ? [
+                {
+                  id: 'enter-town',
+                  text: `🏘️ Enter ${activeLandmark.name}`,
+                  successProbability: 1.0,
+                  successDescription: `You walk through the gates of ${activeLandmark.name}.`,
+                  successEffects: {},
+                  failureDescription: '',
+                  failureEffects: {},
+                  resultDescription: `You enter ${activeLandmark.name}.`,
+                },
+                ...bypassOptions,
+              ]
+            : [
+                ...(activeLandmark.explored ? [] : [{
+                  id: 'explore-landmark',
+                  text: `Explore ${activeLandmark.name}`,
+                  successProbability: 1.0,
+                  successDescription: `You venture into ${activeLandmark.name} to see what awaits.`,
+                  successEffects: {},
+                  failureDescription: '',
+                  failureEffects: {},
+                  resultDescription: `You explore ${activeLandmark.name}.`,
+                }]),
+                ...bypassOptions,
+              ],
           resolved: false,
         },
         shopEvent: activeLandmark.hasShop ? true : undefined,

--- a/src/app/api/v1/tap-tap-adventure/resolve-decision/route.ts
+++ b/src/app/api/v1/tap-tap-adventure/resolve-decision/route.ts
@@ -158,6 +158,241 @@ export async function POST(req: NextRequest) {
       }
     }
 
+    // Handle enter-town: set up town hub and present town menu
+    if (optionId === 'enter-town') {
+      const landmarkState = character.landmarkState
+      const targetIndex = landmarkState?.activeTargetIndex ?? 0
+      const townLandmark = landmarkState?.landmarks[targetIndex]
+
+      const updatedLandmarkState = landmarkState
+        ? {
+            ...landmarkState,
+            exploring: true,
+            explorationDepth: 0,
+            exploringLandmarkName: townLandmark?.name ?? 'the town',
+          }
+        : undefined
+
+      const updatedCharacter: FantasyCharacter = {
+        ...character,
+        landmarkState: updatedLandmarkState,
+      }
+
+      const regionMult = getRegion(character.currentRegion ?? 'green_meadows').difficultyMultiplier
+      const innCost = Math.round(10 * regionMult)
+
+      const townHub: FantasyDecisionPoint = {
+        id: `decision-town-hub-${Date.now()}`,
+        eventId: `town-hub-${Date.now()}`,
+        prompt: `Welcome to ${townLandmark?.name ?? 'the town'}! The town square is alive with merchants, travelers, and townsfolk going about their day. What would you like to do?`,
+        options: [
+          {
+            id: 'visit-shop',
+            text: '🏪 Visit the Shop',
+            successProbability: 1.0,
+            successDescription: 'You browse the merchant\'s wares.',
+            successEffects: {},
+            failureDescription: '',
+            failureEffects: {},
+            resultDescription: 'You visit the shop.',
+          },
+          {
+            id: 'rest-at-inn',
+            text: `🛏️ Rest at the Inn (${innCost} gold)`,
+            successProbability: 1.0,
+            successDescription: `You pay ${innCost} gold for a warm meal and a soft bed. You feel completely refreshed!`,
+            successEffects: {},
+            failureDescription: '',
+            failureEffects: {},
+            resultDescription: `You rest at the inn for ${innCost} gold.`,
+          },
+          {
+            id: 'leave-town',
+            text: '🚪 Leave Town',
+            successProbability: 1.0,
+            successDescription: `You wave goodbye and head back out on the road.`,
+            successEffects: {},
+            failureDescription: '',
+            failureEffects: {},
+            resultDescription: `You leave ${townLandmark?.name ?? 'the town'}.`,
+          },
+        ],
+        resolved: false,
+      }
+
+      return NextResponse.json({
+        updatedCharacter,
+        resultDescription: `You enter ${townLandmark?.name ?? 'the town'}.`,
+        appliedEffects: {},
+        selectedOptionId: optionId,
+        selectedOptionText: option.text,
+        outcomeDescription: `You walk through the gates of ${townLandmark?.name ?? 'the town'}.`,
+        resourceDelta: {},
+        decisionPoint: townHub,
+        shopEvent: true,
+      })
+    }
+
+    // Handle visit-shop: show town hub again with shop triggered
+    if (optionId === 'visit-shop') {
+      const landmarkState = character.landmarkState
+      const townName = landmarkState?.exploringLandmarkName ?? 'the town'
+      const regionMult = getRegion(character.currentRegion ?? 'green_meadows').difficultyMultiplier
+      const innCost = Math.round(10 * regionMult)
+
+      const townHub: FantasyDecisionPoint = {
+        id: `decision-town-hub-${Date.now()}`,
+        eventId: `town-hub-${Date.now()}`,
+        prompt: `You've browsed the shop. What else would you like to do in ${townName}?`,
+        options: [
+          {
+            id: 'visit-shop',
+            text: '🏪 Visit the Shop again',
+            successProbability: 1.0,
+            successDescription: 'You browse the merchant\'s wares.',
+            successEffects: {},
+            failureDescription: '',
+            failureEffects: {},
+            resultDescription: 'You visit the shop.',
+          },
+          {
+            id: 'rest-at-inn',
+            text: `🛏️ Rest at the Inn (${innCost} gold)`,
+            successProbability: 1.0,
+            successDescription: `You pay ${innCost} gold for a warm meal and a soft bed.`,
+            successEffects: {},
+            failureDescription: '',
+            failureEffects: {},
+            resultDescription: `You rest at the inn.`,
+          },
+          {
+            id: 'leave-town',
+            text: '🚪 Leave Town',
+            successProbability: 1.0,
+            successDescription: `You wave goodbye and head back out on the road.`,
+            successEffects: {},
+            failureDescription: '',
+            failureEffects: {},
+            resultDescription: `You leave ${townName}.`,
+          },
+        ],
+        resolved: false,
+      }
+
+      return NextResponse.json({
+        updatedCharacter: character,
+        resultDescription: 'You browse the shop\'s offerings.',
+        appliedEffects: {},
+        selectedOptionId: optionId,
+        selectedOptionText: option.text,
+        outcomeDescription: 'You browse the shop.',
+        resourceDelta: {},
+        decisionPoint: townHub,
+        shopEvent: true,
+      })
+    }
+
+    // Handle rest-at-inn: pay gold, restore HP and MP to full
+    if (optionId === 'rest-at-inn') {
+      const landmarkState = character.landmarkState
+      const townName = landmarkState?.exploringLandmarkName ?? 'the town'
+      const regionMult = getRegion(character.currentRegion ?? 'green_meadows').difficultyMultiplier
+      const innCost = Math.round(10 * regionMult)
+
+      let updatedCharacter = { ...character }
+      let outcomeDesc: string
+
+      if ((updatedCharacter.gold ?? 0) >= innCost) {
+        updatedCharacter = {
+          ...updatedCharacter,
+          gold: (updatedCharacter.gold ?? 0) - innCost,
+          hp: updatedCharacter.maxHp ?? 100,
+          mana: updatedCharacter.maxMana ?? 50,
+        }
+        outcomeDesc = `You pay ${innCost} gold and enjoy a warm meal and a comfortable bed. You wake feeling completely refreshed! HP and MP fully restored.`
+      } else {
+        outcomeDesc = `You don't have enough gold to stay at the inn. You need ${innCost} gold.`
+      }
+
+      const townHub: FantasyDecisionPoint = {
+        id: `decision-town-hub-${Date.now()}`,
+        eventId: `town-hub-${Date.now()}`,
+        prompt: `${outcomeDesc} What else would you like to do in ${townName}?`,
+        options: [
+          {
+            id: 'visit-shop',
+            text: '🏪 Visit the Shop',
+            successProbability: 1.0,
+            successDescription: 'You browse the merchant\'s wares.',
+            successEffects: {},
+            failureDescription: '',
+            failureEffects: {},
+            resultDescription: 'You visit the shop.',
+          },
+          {
+            id: 'rest-at-inn',
+            text: `🛏️ Rest at the Inn (${innCost} gold)`,
+            successProbability: 1.0,
+            successDescription: `You pay ${innCost} gold for rest.`,
+            successEffects: {},
+            failureDescription: '',
+            failureEffects: {},
+            resultDescription: 'You rest at the inn.',
+          },
+          {
+            id: 'leave-town',
+            text: '🚪 Leave Town',
+            successProbability: 1.0,
+            successDescription: `You head back out on the road.`,
+            successEffects: {},
+            failureDescription: '',
+            failureEffects: {},
+            resultDescription: `You leave ${townName}.`,
+          },
+        ],
+        resolved: false,
+      }
+
+      return NextResponse.json({
+        updatedCharacter,
+        resultDescription: outcomeDesc,
+        appliedEffects: (updatedCharacter.gold ?? 0) !== (character.gold ?? 0) ? { gold: -innCost } : {},
+        selectedOptionId: optionId,
+        selectedOptionText: option.text,
+        outcomeDescription: outcomeDesc,
+        resourceDelta: (updatedCharacter.gold ?? 0) !== (character.gold ?? 0) ? { gold: -innCost } : {},
+        decisionPoint: townHub,
+      })
+    }
+
+    // Handle leave-town: exit town without marking as explored
+    if (optionId === 'leave-town') {
+      const landmarkState = character.landmarkState
+      const townName = landmarkState?.exploringLandmarkName ?? 'the town'
+
+      const updatedCharacter: FantasyCharacter = {
+        ...character,
+        landmarkState: landmarkState
+          ? {
+              ...landmarkState,
+              exploring: false,
+              explorationDepth: 0,
+              exploringLandmarkName: undefined,
+            }
+          : undefined,
+      }
+
+      return NextResponse.json({
+        updatedCharacter,
+        resultDescription: `You leave ${townName} and continue your journey.`,
+        appliedEffects: {},
+        selectedOptionId: optionId,
+        selectedOptionText: option.text,
+        outcomeDescription: `You leave ${townName} and head back out on the road.`,
+        resourceDelta: {},
+      })
+    }
+
     // Handle explore-landmark: use activeTargetIndex to find the landmark the player walked to
     if (optionId === 'explore-landmark') {
       const landmarkState = character.landmarkState
@@ -438,6 +673,10 @@ export async function POST(req: NextRequest) {
         response.decisionPoint = guardianDecision
       } else {
         // Max depth reached on a normal landmark — end exploration, mark as explored
+        // (Towns use their own hub flow and should never reach this code path)
+        const exploredLandmarkForCompletion = currentLandmarkState.landmarks[exploredLandmarkIndex]
+        const isTown = exploredLandmarkForCompletion?.type === 'town'
+
         // Award completion bonus scaled by region difficulty
         const completionGold = Math.round(20 * regionMult)
         const completionRep = 2
@@ -449,7 +688,7 @@ export async function POST(req: NextRequest) {
         }
 
         const updatedLandmarks = currentLandmarkState.landmarks.map(lm =>
-          lm.name === currentLandmarkState.exploringLandmarkName
+          lm.name === currentLandmarkState.exploringLandmarkName && !isTown
             ? { ...lm, explored: true }
             : lm
         )


### PR DESCRIPTION
## Summary
- Towns now use a **hub interaction model** instead of sequential encounters
- When arriving at a town landmark, players can **enter the town** to access:
  - 🏪 **Visit Shop** — browse merchant wares (uses existing shop system)
  - 🛏️ **Rest at Inn** — pay gold (scaled by region difficulty: 8/10/15/30) to fully restore HP and MP
  - 🚪 **Leave Town** — exit without marking as explored
- After each town action, players return to the hub menu (can repeat actions)
- Towns are **never marked as explored** — always revisitable
- Safety check added to prevent maxDepth logic from marking towns as explored

Closes #369
Parent epic: #362

## Test plan
- [ ] Arrive at a town landmark — see "Enter town" option instead of "Explore"
- [ ] Enter town — see hub menu with Shop, Inn, Leave options
- [ ] Visit Shop — shop UI appears, then return to town hub
- [ ] Rest at Inn with enough gold — HP/MP restored to full, gold deducted
- [ ] Rest at Inn without enough gold — rejection message, no gold deducted
- [ ] Leave town — return to travel, town NOT marked as explored
- [ ] Revisit same town — can enter again (not blocked)
- [ ] Non-town landmarks still use normal explore/encounter flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)