### PR TITLE
fix: prevent gold from going negative

### DIFF
--- a/src/app/tap-tap-adventure/hooks/useGameStore.ts
+++ b/src/app/tap-tap-adventure/hooks/useGameStore.ts
@@ -5,7 +5,7 @@ import { persist } from 'zustand/middleware'
 
 import { checkAchievements } from '@/app/tap-tap-adventure/lib/achievementTracker'
 import { ACHIEVEMENTS } from '@/app/tap-tap-adventure/config/achievements'
-import { clampReputation } from '@/app/tap-tap-adventure/lib/contextBuilder'
+import { clampReputation, clampGold } from '@/app/tap-tap-adventure/lib/contextBuilder'
 import { generateHeirloom } from '@/app/tap-tap-adventure/lib/heirloomGenerator'
 import { getMetaBonuses, MetaBonuses } from '@/app/tap-tap-adventure/lib/metaProgressionBonuses'
 import { calculateSoulEssence } from '@/app/tap-tap-adventure/lib/soulEssenceCalculator'
@@ -894,7 +894,7 @@ export const useGameStore = create<GameStore>()(
             const updatedRoster = [...(char.mercenaryRoster ?? []), fullMercenary]
             state.gameState.characters[charIndex] = {
               ...char,
-              gold: char.gold - mercenary.recruitCost,
+              gold: clampGold(char.gold - mercenary.recruitCost),
               mercenaryRoster: updatedRoster,
               activeMercenary: char.activeMercenary ?? fullMercenary,
             }
@@ -1096,7 +1096,7 @@ export const useGameStore = create<GameStore>()(
             if (!char.campState) {
               char.campState = { buildingLevels: {} }
             }
-            char.gold -= cost
+            char.gold = clampGold(char.gold - cost)
             char.campState.buildingLevels[buildingId] = currentLevel + 1
           })
         )
@@ -1152,7 +1152,7 @@ export const useGameStore = create<GameStore>()(
             )
             if (charIndex === -1) return
             const char = state.gameState.characters[charIndex]
-            char.gold -= gear.price
+            char.gold = clampGold(char.gold - gear.price)
             char.inventory = [...char.inventory, newItem]
           })
         )
@@ -1233,7 +1233,7 @@ export const useGameStore = create<GameStore>()(
             if (charIndex === -1) return
             const char = state.gameState.characters[charIndex]
             // Deduct gold
-            char.gold -= cost
+            char.gold = clampGold(char.gold - cost)
             // Update equipped item
             const currentEquipment = char.equipment ?? { weapon: null, armor: null, accessory: null }
             char.equipment = {
@@ -1922,6 +1922,9 @@ export function useGameStateBuilder() {
     // Clamp reputation if it's being updated
     if (characterUpdate.reputation !== undefined) {
       characterUpdate = { ...characterUpdate, reputation: clampReputation(characterUpdate.reputation) }
+    }
+    if (characterUpdate.gold !== undefined) {
+      characterUpdate = { ...characterUpdate, gold: clampGold(characterUpdate.gold) }
     }
 
     // Create a new character object and recalculate level from distance

--- a/src/app/tap-tap-adventure/lib/contextBuilder.ts
+++ b/src/app/tap-tap-adventure/lib/contextBuilder.ts
@@ -49,6 +49,10 @@ export function clampReputation(value: number): number {
   return Math.max(-100, Math.min(200, value))
 }
 
+export function clampGold(value: number): number {
+  return Math.max(0, value)
+}
+
 export function getCharismaPriceMultiplier(charisma: number): number {
   const discount = Math.min(0.10, (charisma - 5) * 0.01)
   return 1.0 - discount

--- a/src/app/tap-tap-adventure/lib/craftingEngine.ts
+++ b/src/app/tap-tap-adventure/lib/craftingEngine.ts
@@ -1,6 +1,7 @@
 import { CraftingRecipe } from '@/app/tap-tap-adventure/config/craftingRecipes'
 import { FantasyCharacter } from '@/app/tap-tap-adventure/models/character'
 import { Item } from '@/app/tap-tap-adventure/models/item'
+import { clampGold } from '@/app/tap-tap-adventure/lib/contextBuilder'
 
 /**
  * Check whether a character can craft the given recipe.
@@ -73,7 +74,7 @@ export function applyCraft(
 
   return {
     ...character,
-    gold: character.gold - recipe.goldCost,
+    gold: clampGold(character.gold - recipe.goldCost),
     inventory: updatedInventory,
   }
 }

--- a/src/app/tap-tap-adventure/lib/eventResolution.ts
+++ b/src/app/tap-tap-adventure/lib/eventResolution.ts
@@ -2,6 +2,7 @@ import { FantasyCharacter } from '@/app/tap-tap-adventure/models/character'
 import { FantasyDecisionOption } from '@/app/tap-tap-adventure/models/story'
 import { getCampBonuses } from '@/app/tap-tap-adventure/config/baseBuildings'
 import { getFactionForRegion, FACTIONS } from '@/app/tap-tap-adventure/config/factions'
+import { clampGold } from '@/app/tap-tap-adventure/lib/contextBuilder'
 
 export function applyEffects(
   character: FantasyCharacter,
@@ -31,7 +32,7 @@ export function applyEffects(
 
   let updatedCharacter: FantasyCharacter = {
     ...character,
-    gold: character.gold + adjustedGold,
+    gold: clampGold(character.gold + adjustedGold),
     reputation: character.reputation + adjustedRep,
     distance: character.distance + (effects.distance ?? 0),
     status: effects.statusChange

--- a/src/app/tap-tap-adventure/lib/itemEffects.ts
+++ b/src/app/tap-tap-adventure/lib/itemEffects.ts
@@ -1,5 +1,6 @@
 import { FantasyCharacter } from '@/app/tap-tap-adventure/models/character'
 import { Item } from '@/app/tap-tap-adventure/models/item'
+import { clampGold } from '@/app/tap-tap-adventure/lib/contextBuilder'
 
 export interface UseItemResult {
   character: FantasyCharacter
@@ -37,7 +38,7 @@ export function useItem(character: FantasyCharacter, item: Item): UseItemResult 
   const effectMessages: string[] = []
 
   if (effects.gold) {
-    updatedCharacter.gold += effects.gold
+    updatedCharacter.gold = clampGold(updatedCharacter.gold + effects.gold)
     effectMessages.push(`${effects.gold > 0 ? '+' : ''}${effects.gold} Gold`)
   }
   if (effects.reputation) {

--- a/src/app/tap-tap-adventure/models/character.ts
+++ b/src/app/tap-tap-adventure/models/character.ts
@@ -30,7 +30,7 @@ export const FantasyCharacterSchema = z.object({
   level: z.number(),
   abilities: z.array(FantasyAbilitySchema),
   locationId: z.string(),
-  gold: z.number(),
+  gold: z.number().min(0),
   reputation: z.number(),
   distance: z.number(),
   status: z.enum(['active', 'retired', 'dead']),


### PR DESCRIPTION
## Summary
- Adds `clampGold()` helper (mirrors existing `clampReputation()`) to ensure gold is always >= 0
- Applied to all gold modification points across the codebase:
  - Event resolution (encounter rewards/penalties)
  - Item effects (using consumables with gold effects)
  - Crafting engine (gold cost deduction)
  - Camp building upgrades
  - Faction gear purchases
  - Item enchantments
  - Mercenary recruitment
  - `updateSelectedCharacter` safety net (catches any remaining cases)
- Added `z.number().min(0)` to character schema for schema-level validation

Closes #377
Parent epic: #362

## Test plan
- [ ] Trigger an encounter with negative gold effect when player has 0 gold — gold stays at 0
- [ ] Attempt crafting/enchanting/purchasing with insufficient gold — gold doesn't go negative
- [ ] Mount/mercenary upkeep still auto-dismisses correctly (already guarded)
- [ ] Death penalty still works correctly (already clamped)
- [ ] Normal gold gains still work as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)