### PR TITLE
feat: add bounty system with hunters and town entry gating

### DIFF
--- a/src/app/api/v1/tap-tap-adventure/move-forward/services/moveForwardService.ts
+++ b/src/app/api/v1/tap-tap-adventure/move-forward/services/moveForwardService.ts
@@ -216,13 +216,36 @@ export async function moveForwardService(
           id: `decision-${arrivalEventId}`,
           eventId: arrivalEventId,
           prompt: activeLandmark.type === 'town'
-            ? `${activeLandmark.icon} You arrive at ${activeLandmark.name}. ${activeLandmark.description} The town is bustling with activity. What would you like to do?`
+            ? ((character.bounty ?? 0) > 0
+              ? `${activeLandmark.icon} You arrive at ${activeLandmark.name}. ${activeLandmark.description} Guards at the gate eye you suspiciously — there's a bounty of ${character.bounty} gold on your head!`
+              : `${activeLandmark.icon} You arrive at ${activeLandmark.name}. ${activeLandmark.description} The town is bustling with activity. What would you like to do?`)
             : (activeLandmark.explored
               ? `${activeLandmark.icon} You arrive at ${activeLandmark.name}. You've already explored this place thoroughly. What do you do?`
               : `${activeLandmark.icon} You arrive at ${activeLandmark.name}. ${activeLandmark.description} What do you do?`),
           options: activeLandmark.type === 'town'
             ? [
-                {
+                ...((character.bounty ?? 0) > 0 ? [
+                  {
+                    id: 'pay-bounty',
+                    text: `💰 Pay bounty (${character.bounty} gold) to enter`,
+                    successProbability: 1.0,
+                    successDescription: `You pay your ${character.bounty} gold bounty and the guards let you through.`,
+                    successEffects: {},
+                    failureDescription: '',
+                    failureEffects: {},
+                    resultDescription: `You pay your bounty and enter ${activeLandmark.name}.`,
+                  },
+                  {
+                    id: 'sneak-into-town',
+                    text: `🤫 Try to sneak in`,
+                    successProbability: 0.4,
+                    successDescription: `You slip past the guards unnoticed.`,
+                    successEffects: {},
+                    failureDescription: `The guards spot you! Your bounty increases.`,
+                    failureEffects: {},
+                    resultDescription: `You try to sneak past the guards.`,
+                  },
+                ] : [{
                   id: 'enter-town',
                   text: `🏘️ Enter ${activeLandmark.name}`,
                   successProbability: 1.0,
@@ -231,7 +254,7 @@ export async function moveForwardService(
                   failureDescription: '',
                   failureEffects: {},
                   resultDescription: `You enter ${activeLandmark.name}.`,
-                },
+                }]),
                 ...bypassOptions,
               ]
             : [
@@ -560,6 +583,72 @@ export async function moveForwardService(
         scenario,
       },
       landmarkProgress,
+    }
+  }
+
+  // Bounty hunter encounter: chance scales with bounty amount
+  const bountyAmount = character.bounty ?? 0
+  if (bountyAmount > 0 && newDistance > 20) {
+    const bountyHunterChance = Math.min(0.25, bountyAmount / 400) // up to 25% at 100+ bounty
+    if (Math.random() < bountyHunterChance) {
+      const hunterEventId = `bounty-hunter-${Date.now()}`
+      return {
+        character: {
+          ...updatedCharacter,
+          landmarkState: {
+            ...landmarkState,
+            positionInRegion: newPositionInRegion,
+            position: updatedPosition,
+          },
+        },
+        event: {
+          id: hunterEventId,
+          type: 'bounty_hunter',
+          characterId: character.id,
+          locationId: character.locationId,
+          timestamp: new Date().toISOString(),
+        },
+        decisionPoint: {
+          id: `decision-${hunterEventId}`,
+          eventId: hunterEventId,
+          prompt: `⚔️ A bounty hunter steps out from the shadows, blocking your path. "There's a bounty of ${bountyAmount} gold on your head. You can pay up, or we can settle this the hard way."`,
+          options: [
+            {
+              id: 'pay-bounty-hunter',
+              text: `💰 Pay the bounty (${bountyAmount} gold)`,
+              successProbability: 1.0,
+              successDescription: `You hand over ${bountyAmount} gold. The bounty hunter pockets it and disappears.`,
+              successEffects: {},
+              failureDescription: '',
+              failureEffects: {},
+              resultDescription: `You pay the bounty hunter.`,
+            },
+            {
+              id: 'fight-bounty-hunter',
+              text: '⚔️ Fight the bounty hunter',
+              successProbability: 1.0,
+              successDescription: 'You draw your weapon!',
+              successEffects: {},
+              failureDescription: '',
+              failureEffects: {},
+              resultDescription: 'You fight the bounty hunter!',
+              triggersCombat: true,
+            },
+            {
+              id: 'flee-bounty-hunter',
+              text: '🏃 Try to flee',
+              successProbability: 0.5,
+              successDescription: 'You dash away before the hunter can react!',
+              successEffects: {},
+              failureDescription: 'The hunter is too fast — they corner you. The bounty increases!',
+              failureEffects: { bountyChange: Math.ceil(bountyAmount * 0.25) },
+              resultDescription: 'You try to run.',
+            },
+          ],
+          resolved: false,
+        },
+        landmarkProgress,
+      }
     }
   }
 

--- a/src/app/api/v1/tap-tap-adventure/resolve-decision/route.ts
+++ b/src/app/api/v1/tap-tap-adventure/resolve-decision/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 
 import { getRegion } from '@/app/tap-tap-adventure/config/regions'
-import { buildStoryContext } from '@/app/tap-tap-adventure/lib/contextBuilder'
+import { buildStoryContext, clampGold } from '@/app/tap-tap-adventure/lib/contextBuilder'
 import {
   applyEffects,
   calculateEffectiveProbability,
@@ -156,6 +156,213 @@ export async function POST(req: NextRequest) {
           decisionPoint: fallbackDecisionPoint,
         })
       }
+    }
+
+    // Handle pay-bounty: pay bounty to enter town
+    if (optionId === 'pay-bounty') {
+      const landmarkState = character.landmarkState
+      const targetIndex = landmarkState?.activeTargetIndex ?? 0
+      const townLandmark = landmarkState?.landmarks[targetIndex]
+      const bountyAmount = character.bounty ?? 0
+
+      if ((character.gold ?? 0) < bountyAmount) {
+        return NextResponse.json({
+          updatedCharacter: character,
+          resultDescription: `You don't have enough gold to pay your bounty of ${bountyAmount} gold.`,
+          appliedEffects: {},
+          selectedOptionId: optionId,
+          selectedOptionText: option.text,
+          outcomeDescription: `You need ${bountyAmount} gold but only have ${character.gold ?? 0}.`,
+          resourceDelta: {},
+        })
+      }
+
+      // Pay bounty and enter town (same as enter-town flow)
+      const updatedLandmarkState = landmarkState
+        ? {
+            ...landmarkState,
+            exploring: true,
+            explorationDepth: 0,
+            exploringLandmarkName: townLandmark?.name ?? 'the town',
+          }
+        : undefined
+
+      const updatedCharacter: FantasyCharacter = {
+        ...character,
+        gold: clampGold((character.gold ?? 0) - bountyAmount),
+        bounty: 0,
+        landmarkState: updatedLandmarkState,
+      }
+
+      const regionMult = getRegion(character.currentRegion ?? 'green_meadows').difficultyMultiplier
+      const innCost = Math.round(10 * regionMult)
+
+      // Return the standard town hub (same as enter-town)
+      const townHub: FantasyDecisionPoint = {
+        id: `decision-town-hub-${Date.now()}`,
+        eventId: `town-hub-${Date.now()}`,
+        prompt: `You pay your ${bountyAmount} gold bounty to the guards. Your name is cleared! Welcome to ${townLandmark?.name ?? 'the town'}. What would you like to do?`,
+        options: [
+          {
+            id: 'visit-shop', text: '🏪 Visit the Shop', successProbability: 1.0,
+            successDescription: 'You browse the wares.', successEffects: {},
+            failureDescription: '', failureEffects: {}, resultDescription: 'You visit the shop.',
+          },
+          {
+            id: 'rest-at-inn', text: `🛏️ Rest at the Inn (${innCost} gold)`, successProbability: 1.0,
+            successDescription: `You pay ${innCost} gold for rest.`, successEffects: {},
+            failureDescription: '', failureEffects: {}, resultDescription: 'You rest.',
+          },
+          {
+            id: 'hire-transport', text: '🐴 Hire Transport', successProbability: 1.0,
+            successDescription: 'You check transport.', successEffects: {},
+            failureDescription: '', failureEffects: {}, resultDescription: 'You check transport.',
+          },
+          {
+            id: 'leave-town', text: '🚪 Leave Town', successProbability: 1.0,
+            successDescription: 'You leave.', successEffects: {},
+            failureDescription: '', failureEffects: {}, resultDescription: `You leave.`,
+          },
+        ],
+        resolved: false,
+      }
+
+      return NextResponse.json({
+        updatedCharacter,
+        resultDescription: `You pay your ${bountyAmount} gold bounty. Your name is cleared!`,
+        appliedEffects: { gold: -bountyAmount },
+        selectedOptionId: optionId,
+        selectedOptionText: option.text,
+        outcomeDescription: `Bounty paid! (-${bountyAmount} gold)`,
+        resourceDelta: { gold: -bountyAmount },
+        decisionPoint: townHub,
+        shopEvent: true,
+      })
+    }
+
+    // Handle sneak-into-town: risky attempt to enter town with bounty
+    if (optionId === 'sneak-into-town') {
+      const landmarkState = character.landmarkState
+      const targetIndex = landmarkState?.activeTargetIndex ?? 0
+      const townLandmark = landmarkState?.landmarks[targetIndex]
+      const bountyAmount = character.bounty ?? 0
+
+      // Success based on luck (higher luck = better chance)
+      const luckBonus = Math.min(0.3, (character.luck ?? 0) * 0.02)
+      const sneakChance = 0.35 + luckBonus
+      const success = Math.random() < sneakChance
+
+      if (success) {
+        // Sneak in successfully — enter town but bounty remains
+        const updatedLandmarkState = landmarkState
+          ? {
+              ...landmarkState,
+              exploring: true,
+              explorationDepth: 0,
+              exploringLandmarkName: townLandmark?.name ?? 'the town',
+            }
+          : undefined
+
+        const updatedCharacter: FantasyCharacter = {
+          ...character,
+          landmarkState: updatedLandmarkState,
+        }
+
+        const regionMult = getRegion(character.currentRegion ?? 'green_meadows').difficultyMultiplier
+        const innCost = Math.round(10 * regionMult)
+
+        const townHub: FantasyDecisionPoint = {
+          id: `decision-town-hub-${Date.now()}`,
+          eventId: `town-hub-${Date.now()}`,
+          prompt: `You slip past the guards! You're inside ${townLandmark?.name ?? 'the town'}, but keep a low profile — your bounty is still active. What would you like to do?`,
+          options: [
+            {
+              id: 'visit-shop', text: '🏪 Visit the Shop', successProbability: 1.0,
+              successDescription: 'You browse the wares.', successEffects: {},
+              failureDescription: '', failureEffects: {}, resultDescription: 'You visit the shop.',
+            },
+            {
+              id: 'rest-at-inn', text: `🛏️ Rest at the Inn (${innCost} gold)`, successProbability: 1.0,
+              successDescription: 'You rest.', successEffects: {},
+              failureDescription: '', failureEffects: {}, resultDescription: 'You rest.',
+            },
+            {
+              id: 'hire-transport', text: '🐴 Hire Transport', successProbability: 1.0,
+              successDescription: 'You check transport.', successEffects: {},
+              failureDescription: '', failureEffects: {}, resultDescription: 'You check transport.',
+            },
+            {
+              id: 'leave-town', text: '🚪 Leave Town', successProbability: 1.0,
+              successDescription: 'You leave.', successEffects: {},
+              failureDescription: '', failureEffects: {}, resultDescription: 'You leave.',
+            },
+          ],
+          resolved: false,
+        }
+
+        return NextResponse.json({
+          updatedCharacter,
+          resultDescription: `You successfully sneak into ${townLandmark?.name ?? 'the town'}!`,
+          appliedEffects: {},
+          selectedOptionId: optionId,
+          selectedOptionText: option.text,
+          outcomeDescription: `You slip past the guards unnoticed.`,
+          resourceDelta: {},
+          decisionPoint: townHub,
+          shopEvent: true,
+        })
+      } else {
+        // Failed sneak — bounty increases by 25%
+        const bountyIncrease = Math.max(5, Math.ceil(bountyAmount * 0.25))
+        const updatedCharacter: FantasyCharacter = {
+          ...character,
+          bounty: bountyAmount + bountyIncrease,
+        }
+
+        return NextResponse.json({
+          updatedCharacter,
+          resultDescription: `The guards spot you! "Halt! Your bounty just went up!" (+${bountyIncrease} bounty)`,
+          appliedEffects: {},
+          selectedOptionId: optionId,
+          selectedOptionText: option.text,
+          outcomeDescription: `You're caught trying to sneak in! Bounty increased to ${bountyAmount + bountyIncrease} gold.`,
+          resourceDelta: {},
+        })
+      }
+    }
+
+    // Handle pay-bounty-hunter: pay bounty to the hunter
+    if (optionId === 'pay-bounty-hunter') {
+      const bountyAmount = character.bounty ?? 0
+
+      if ((character.gold ?? 0) < bountyAmount) {
+        return NextResponse.json({
+          updatedCharacter: character,
+          resultDescription: `You don't have enough gold. The bounty hunter draws their weapon!`,
+          appliedEffects: {},
+          selectedOptionId: optionId,
+          selectedOptionText: option.text,
+          outcomeDescription: `You can't afford to pay. The hunter attacks!`,
+          resourceDelta: {},
+          triggersCombat: true,
+        })
+      }
+
+      const updatedCharacter: FantasyCharacter = {
+        ...character,
+        gold: clampGold((character.gold ?? 0) - bountyAmount),
+        bounty: 0,
+      }
+
+      return NextResponse.json({
+        updatedCharacter,
+        resultDescription: `You hand over ${bountyAmount} gold. The bounty hunter nods and disappears into the shadows. Your name is cleared.`,
+        appliedEffects: { gold: -bountyAmount },
+        selectedOptionId: optionId,
+        selectedOptionText: option.text,
+        outcomeDescription: `Bounty paid! (-${bountyAmount} gold). Your record is clean.`,
+        resourceDelta: { gold: -bountyAmount },
+      })
     }
 
     // Handle enter-town: set up town hub and present town menu

--- a/src/app/tap-tap-adventure/components/HudBar.tsx
+++ b/src/app/tap-tap-adventure/components/HudBar.tsx
@@ -411,6 +411,12 @@ export function HudBar({ onOpenStatus }: HudBarProps = {}) {
             </div>
           )
         })()}
+        {(character?.bounty ?? 0) > 0 && (
+          <div className="text-xs text-red-400 flex items-center gap-1">
+            <span>💀</span>
+            <span>Bounty: {character!.bounty}g</span>
+          </div>
+        )}
         <div className="hidden sm:flex items-center gap-1 sm:gap-4">
           {STATS_RIGHT.map(renderStat)}
         </div>

--- a/src/app/tap-tap-adventure/hooks/useCharacterCreation.ts
+++ b/src/app/tap-tap-adventure/hooks/useCharacterCreation.ts
@@ -216,6 +216,7 @@ export function useCharacterCreation() {
       currentWeather: 'clear',
       visitedRegions: ['green_meadows'],
       factionReputations: {},
+      bounty: 0,
     }
     const maxMana = calculateMaxMana(tempChar)
 

--- a/src/app/tap-tap-adventure/hooks/useGameStore.ts
+++ b/src/app/tap-tap-adventure/hooks/useGameStore.ts
@@ -65,6 +65,7 @@ const defaultCharacter: FantasyCharacter = {
   locationId: '',
   gold: 0,
   reputation: 0,
+  bounty: 0,
   distance: 0,
   status: 'active',
   strength: 0,
@@ -1647,7 +1648,7 @@ export const useGameStore = create<GameStore>()(
     }),
     {
       name: 'fantasy-tycoon-storage', // localStorage key (kept for backward compat)
-      version: 34,
+      version: 35,
       migrate: (persistedState: unknown) => {
         const state = persistedState as GameStore
         if (state?.gameState && !('combatState' in state.gameState)) {
@@ -1809,6 +1810,10 @@ export const useGameStore = create<GameStore>()(
               for (const item of (char as FantasyCharacter).inventory) {
                 if (item.type === 'misc') item.type = 'trade_good'
               }
+            }
+            // v35: Add bounty field
+            if ((char as FantasyCharacter).bounty === undefined) {
+              ;(char as FantasyCharacter).bounty = 0
             }
           }
         }

--- a/src/app/tap-tap-adventure/lib/eventResolution.ts
+++ b/src/app/tap-tap-adventure/lib/eventResolution.ts
@@ -16,6 +16,7 @@ export function applyEffects(
     revealLandmark?: boolean
     hpChange?: number
     mpChange?: number
+    bountyChange?: number
   }
 ): FantasyCharacter {
   if (!effects) return character
@@ -54,6 +55,17 @@ export function applyEffects(
     const maxMp = updatedCharacter.maxMana ?? 50
     const newMp = Math.max(0, Math.min(maxMp, currentMp + effects.mpChange))
     updatedCharacter = { ...updatedCharacter, mana: newMp }
+  }
+
+  // Bounty change
+  if (effects.bountyChange) {
+    const currentBounty = updatedCharacter.bounty ?? 0
+    updatedCharacter = { ...updatedCharacter, bounty: Math.max(0, currentBounty + effects.bountyChange) }
+  }
+
+  // Auto-bounty from very low reputation
+  if ((updatedCharacter.reputation ?? 0) < -30 && (updatedCharacter.bounty ?? 0) === 0) {
+    updatedCharacter = { ...updatedCharacter, bounty: Math.abs(updatedCharacter.reputation ?? 0) }
   }
 
   // Faction reputation gain

--- a/src/app/tap-tap-adventure/models/character.ts
+++ b/src/app/tap-tap-adventure/models/character.ts
@@ -32,6 +32,7 @@ export const FantasyCharacterSchema = z.object({
   locationId: z.string(),
   gold: z.number().min(0),
   reputation: z.number(),
+  bounty: z.number().min(0).optional().default(0),
   distance: z.number(),
   status: z.enum(['active', 'retired', 'dead']),
   strength: z.number(),

--- a/src/app/tap-tap-adventure/models/story.ts
+++ b/src/app/tap-tap-adventure/models/story.ts
@@ -23,6 +23,7 @@ const EffectsSchema = z.object({
   revealLandmark: z.boolean().optional(),
   hpChange: z.number().optional(),
   mpChange: z.number().optional(),
+  bountyChange: z.number().optional(),
 })
 
 export const FantasyDecisionOptionSchema = z.object({


### PR DESCRIPTION
## Summary
- Characters gain bounty from low reputation (auto-assigned when rep drops below -30) or from criminal event effects (`bountyChange` in EffectsSchema)
- **Bounty hunters** appear on the road with frequency scaling based on bounty amount (up to 25% chance at 100+ bounty). Options: pay bounty, fight, or flee (risky — bounty increases on failure)
- **Towns gate entry** when bounty is active:
  - 💰 Pay bounty (deducts gold, clears bounty, enters town)
  - 🤫 Sneak in (luck-based, 35% + luck bonus — failure increases bounty by 25%)
  - Continue traveling (bypass town)
- **Bounty UI indicator** (💀) shown in HudBar when bounty > 0
- Store migration v34→v35 adds `bounty: 0` to existing characters

Closes #373
Parent epic: #362

## Test plan
- [ ] Low reputation (below -30) auto-assigns bounty
- [ ] Event with `bountyChange` effect modifies bounty correctly
- [ ] Bounty hunter encounters appear on the road when bounty > 0
- [ ] Pay bounty hunter clears bounty; fight triggers combat; flee has chance of bounty increase
- [ ] Town arrival with bounty shows pay/sneak options instead of "Enter town"
- [ ] Paying bounty at town clears bounty and lets player enter
- [ ] Sneak success enters town (bounty remains); sneak failure increases bounty
- [ ] Bounty indicator visible in HUD when bounty > 0
- [ ] Gold never goes negative when paying bounty (uses clampGold)

🤖 Generated with [Claude Code](https://claude.com/claude-code)