### PR TITLE
fix: replace remaining 'steps' with 'km' in bypass options, spells, death text (#403)

### DIFF
--- a/src/app/api/v1/tap-tap-adventure/move-forward/services/moveForwardService.ts
+++ b/src/app/api/v1/tap-tap-adventure/move-forward/services/moveForwardService.ts
@@ -180,7 +180,7 @@ export async function moveForwardService(
         const dist = nextLm.distanceFromEntry - newPositionInRegion
         bypassOptions.push({
           id: `bypass-toward-${i}`,
-          text: `${nextLm.icon} Head toward ${nextLm.name} (${dist} steps)`,
+          text: `${nextLm.icon} Head toward ${nextLm.name} (${dist} km)`,
           successProbability: 1.0,
           successDescription: `You leave ${activeLandmark.name} behind and head toward ${nextLm.name}.`,
           successEffects: {},
@@ -194,7 +194,7 @@ export async function moveForwardService(
       const exitDist = (landmarkState.regionLength ?? 200) - newPositionInRegion
       bypassOptions.push({
         id: `bypass-toward-exit`,
-        text: `🚪 Head toward ${region.name} border (${exitDist} steps)`,
+        text: `🚪 Head toward ${region.name} border (${exitDist} km)`,
         successProbability: 1.0,
         successDescription: `You leave ${activeLandmark.name} behind and continue toward the edge of ${region.name}.`,
         successEffects: {},

--- a/src/app/tap-tap-adventure/lib/deathFlavorText.ts
+++ b/src/app/tap-tap-adventure/lib/deathFlavorText.ts
@@ -194,7 +194,7 @@ export function getStoryContext(
 
   // 4. Long distance
   if (character.distance > 1000) {
-    return `After ${character.distance} steps into the unknown, the journey ends here.`
+    return `After ${character.distance} km into the unknown, the journey ends here.`
   }
 
   return null

--- a/src/app/tap-tap-adventure/lib/spellGenerator.ts
+++ b/src/app/tap-tap-adventure/lib/spellGenerator.ts
@@ -184,25 +184,25 @@ export function generateSpellForLevel(level: number, school?: SpellSchool): Spel
       {
         type: 'cha_boost',
         value: 2 + Math.floor(level / 5),
-        description: `Boosts your charisma by ${2 + Math.floor(level / 5)} for NPC interactions (10 steps).`,
+        description: `Boosts your charisma by ${2 + Math.floor(level / 5)} for NPC interactions (10 km).`,
         duration: 10,
       },
       {
         type: 'faster_travel',
         value: 2,
-        description: `Doubles your travel speed for 20 steps.`,
+        description: `Doubles your travel speed for 20 km.`,
         duration: 20,
       },
       {
         type: 'auto_stealth',
         value: 1,
-        description: `Renders you unseen, avoiding random encounters for 8 steps.`,
+        description: `Renders you unseen, avoiding random encounters for 8 km.`,
         duration: 8,
       },
       {
         type: 'loot_bonus',
         value: 1.25,
-        description: `Increases loot quality for 25 steps.`,
+        description: `Increases loot quality for 25 km.`,
         duration: 25,
       },
       {


### PR DESCRIPTION
## Summary
The steps→km rename missed several locations:

- **moveForwardService.ts**: landmark bypass options — "Head toward X (42 steps)" → "42 km"
- **spellGenerator.ts**: 4 exploration spell descriptions — "for 20 steps" → "for 20 km"
- **deathFlavorText.ts**: death message — "steps into the unknown" → "km into the unknown"

Closes #403

## Test plan
- [ ] Arrive at landmark → bypass options show "km" not "steps"
- [ ] Check spell descriptions in spellbook → "km" not "steps"

🤖 Generated with [Claude Code](https://claude.com/claude-code)