### PR TITLE
Fix: landmark arrival fails for hidden landmarks (#400)

### DIFF
--- a/src/app/api/v1/tap-tap-adventure/move-forward/services/moveForwardService.ts
+++ b/src/app/api/v1/tap-tap-adventure/move-forward/services/moveForwardService.ts
@@ -15,6 +15,28 @@ import { moveToward, hasArrived, Vec2 } from '@/app/tap-tap-adventure/lib/moveme
 
 const BASE_DISTANCE = 1
 
+function getBypassDiscoveryTier(distance: number, isExplored: boolean, isHidden: boolean = false): 'hidden' | 'distant' | 'unknown' | 'revealed' {
+  if (isExplored) return 'revealed'
+  if (isHidden) {
+    if (distance > 100) return 'hidden'
+    if (distance > 20) return 'unknown'
+    return 'revealed'
+  }
+  if (distance > 100) return 'hidden'
+  if (distance > 50) return 'distant'
+  if (distance > 20) return 'unknown'
+  return 'revealed'
+}
+
+function getBypassDisplayName(tier: string, realName: string, realIcon: string): { name: string; icon: string } {
+  switch (tier) {
+    case 'hidden': return { name: 'Distant landmark', icon: '🔍' }
+    case 'distant': return { name: 'Distant landmark', icon: '🔍' }
+    case 'unknown': return { name: 'Unknown landmark', icon: '❓' }
+    default: return { name: realName, icon: realIcon }
+  }
+}
+
 export async function moveForwardService(
   character: FantasyCharacter,
   storyEvents: FantasyStoryEvent[] = []
@@ -158,6 +180,21 @@ export async function moveForwardService(
       ? hasArrived(charPos, targetPos)
       : newPositionInRegion >= (activeLandmark?.distanceFromEntry ?? Infinity)
 
+    // Auto-reveal hidden landmarks within 20km
+    if (activeLandmark && activeLandmark.hidden) {
+      const charPos2d = updatedPosition
+      const targetPos2d = activeLandmark.position
+      const distToHidden = (charPos2d && targetPos2d)
+        ? Math.sqrt(Math.pow(charPos2d.x - targetPos2d.x, 2) + Math.pow(charPos2d.y - targetPos2d.y, 2))
+        : activeLandmark.distanceFromEntry - newPositionInRegion
+      if (distToHidden <= 20) {
+        const revealedLandmarks = landmarkState.landmarks.map((lm, i) =>
+          i === activeTargetIndex ? { ...lm, hidden: false } : lm
+        )
+        ;(landmarkState as typeof landmarkState).landmarks = revealedLandmarks
+      }
+    }
+
     if (activeLandmark && !activeLandmark.hidden && hasArrivedAtLandmark) {
       const arrivalEventId = `landmark-arrival-${Date.now()}`
 
@@ -178,15 +215,18 @@ export async function moveForwardService(
       for (let i = activeTargetIndex + 1; i < landmarkState.landmarks.length; i++) {
         const nextLm = landmarkState.landmarks[i]
         const dist = nextLm.distanceFromEntry - newPositionInRegion
+        const tier = getBypassDiscoveryTier(dist, nextLm.explored ?? false, nextLm.hidden ?? false)
+        if (tier === 'hidden') continue
+        const display = getBypassDisplayName(tier, nextLm.name, nextLm.icon)
         bypassOptions.push({
           id: `bypass-toward-${i}`,
-          text: `${nextLm.icon} Head toward ${nextLm.name} (${dist} km)`,
+          text: `${display.icon} Head toward ${display.name} (${dist} km)`,
           successProbability: 1.0,
-          successDescription: `You leave ${activeLandmark.name} behind and head toward ${nextLm.name}.`,
+          successDescription: `You leave ${activeLandmark.name} behind and head toward ${display.name}.`,
           successEffects: {},
           failureDescription: '',
           failureEffects: {},
-          resultDescription: `You pass by ${activeLandmark.name} and head toward ${nextLm.name}.`,
+          resultDescription: `You pass by ${activeLandmark.name} and head toward ${display.name}.`,
         })
       }
 

--- a/src/app/api/v1/tap-tap-adventure/move-forward/services/moveForwardService.ts
+++ b/src/app/api/v1/tap-tap-adventure/move-forward/services/moveForwardService.ts
@@ -170,7 +170,7 @@ export async function moveForwardService(
 
   if (!isExitTarget) {
     // Landmark target arrival
-    const activeLandmark = landmarkState.landmarks[activeTargetIndex]
+    let activeLandmark = landmarkState.landmarks[activeTargetIndex]
 
     // Check arrival: use 2D when data exists, fall back to 1D only when no 2D data
     const charPos = updatedPosition
@@ -194,6 +194,9 @@ export async function moveForwardService(
         ;(landmarkState as typeof landmarkState).landmarks = revealedLandmarks
       }
     }
+
+    // Re-read landmark after potential reveal
+    activeLandmark = landmarkState.landmarks[activeTargetIndex]
 
     if (activeLandmark && !activeLandmark.hidden && hasArrivedAtLandmark) {
       const arrivalEventId = `landmark-arrival-${Date.now()}`

--- a/src/app/api/v1/tap-tap-adventure/resolve-decision/route.ts
+++ b/src/app/api/v1/tap-tap-adventure/resolve-decision/route.ts
@@ -1160,7 +1160,7 @@ export async function POST(req: NextRequest) {
         const continueDecision: FantasyDecisionPoint = {
           id: `decision-continue-${Date.now()}`,
           eventId: `continue-explore-${Date.now()}`,
-          prompt: `You pause and look around ${currentLandmarkState.exploringLandmarkName}. There seems to be more to discover... (Encounter ${depth} of ~${maxDepth})`,
+          prompt: `You pause and look around ${currentLandmarkState.exploringLandmarkName}. There seems to be more to discover...`,
           options: [
             {
               id: 'continue-exploring',

--- a/src/app/api/v1/tap-tap-adventure/resolve-decision/route.ts
+++ b/src/app/api/v1/tap-tap-adventure/resolve-decision/route.ts
@@ -1239,6 +1239,7 @@ export async function POST(req: NextRequest) {
             ? { ...lm, explored: true }
             : lm
         )
+        const newLandmarkIndex = Math.min(exploredLandmarkIndex + 1, currentLandmarkState.landmarks.length)
         updatedCharacter = {
           ...updatedCharacter,
           landmarkState: {
@@ -1247,6 +1248,8 @@ export async function POST(req: NextRequest) {
             exploring: false,
             explorationDepth: 0,
             exploringLandmarkName: undefined,
+            activeTargetIndex: newLandmarkIndex,
+            nextLandmarkIndex: newLandmarkIndex,
           },
         }
 

--- a/src/app/tap-tap-adventure/hooks/useResolveDecisionMutation.ts
+++ b/src/app/tap-tap-adventure/hooks/useResolveDecisionMutation.ts
@@ -60,6 +60,7 @@ export function useResolveDecisionMutation() {
           const updatedLandmarks = landmarkState.landmarks.map((lm, i) =>
             i === exploredIndex ? { ...lm, explored: true } : lm
           )
+          const newIndex = Math.min((landmarkState.activeTargetIndex ?? 0) + 1, landmarkState.landmarks.length)
           updateSelectedCharacter({
             landmarkState: {
               ...landmarkState,
@@ -67,6 +68,8 @@ export function useResolveDecisionMutation() {
               exploring: false,
               explorationDepth: 0,
               exploringLandmarkName: undefined,
+              activeTargetIndex: newIndex,
+              nextLandmarkIndex: newIndex,
             },
           })
           const chosenOption = decisionPoint.options.find(o => o.id === optionId)


### PR DESCRIPTION
## Summary
- **Stale reference fix**: `activeLandmark` was captured as `const` before the auto-reveal block in `moveForwardService.ts`. When a hidden landmark was revealed within 20km, the arrival check at line 198 still used the old object with `hidden: true`, causing the landmark arrival to fail and a random encounter to trigger instead. Now re-reads from the updated landmarks array after the reveal block.
- **Auto-advance after exploration**: After exploration completion (max depth) or leaving a landmark, `activeTargetIndex` was not advanced — causing the player to re-arrive at the just-explored landmark on their next step. Both server-side (`resolve-decision/route.ts`) and client-side (`useResolveDecisionMutation.ts`) now advance the index.

Closes #400

## Test plan
- [ ] Enter a region and walk toward a landmark — verify landmark arrival triggers correctly (explore/bypass options shown)
- [ ] Walk toward a hidden (secret) landmark — verify it reveals and triggers arrival without an intermediate random encounter
- [ ] Complete exploration of a non-town landmark — verify activeTargetIndex advances to next landmark automatically
- [ ] Leave a landmark mid-exploration — verify activeTargetIndex advances and player doesn't re-arrive at same landmark

🤖 Generated with [Claude Code](https://claude.com/claude-code)