### PR TITLE
feat: show starting weapon on class selection screen (#411)

### DIFF
--- a/src/app/tap-tap-adventure/components/CharacterCreation.tsx
+++ b/src/app/tap-tap-adventure/components/CharacterCreation.tsx
@@ -91,6 +91,19 @@ function GeneratedClassCard({
         <span className="text-xs text-slate-500">{generatedClass.spellSlots} spell slots</span>
         <span className="text-xs text-slate-500">{generatedClass.manaMultiplier}x mana</span>
       </div>
+      {generatedClass.startingWeapon && (
+        <div className="mt-2 pt-2 border-t border-[#3a3c56]">
+          <div className="text-xs text-amber-300 font-medium">
+            {'⚔️ '}{generatedClass.startingWeapon.name}
+            <span className="ml-1 text-slate-500 font-normal">({generatedClass.startingWeapon.effects.range} range)</span>
+          </div>
+          <div className="text-xs text-slate-500 mt-0.5">
+            {generatedClass.startingWeapon.effects.strength ? `+${generatedClass.startingWeapon.effects.strength} STR` : ''}
+            {generatedClass.startingWeapon.effects.strength && generatedClass.startingWeapon.effects.intelligence ? ' · ' : ''}
+            {generatedClass.startingWeapon.effects.intelligence ? `+${generatedClass.startingWeapon.effects.intelligence} INT` : ''}
+          </div>
+        </div>
+      )}
       <div className="mt-2 pt-2 border-t border-[#3a3c56]">
         <div className="text-xs text-indigo-300 font-medium">{generatedClass.startingAbility.name}</div>
         <div className="text-xs text-slate-500 mt-0.5">{generatedClass.startingAbility.description}</div>


### PR DESCRIPTION
## Summary
- Displays starting weapon info on the generated class card during character creation
- Shows weapon name with sword emoji, range badge (close/mid/far), and stat bonuses (+STR/+INT)
- Only renders when `startingWeapon` is present (backwards compatible with old class data)

## Test plan
- [ ] Open character creation, select a race, view generated classes — verify weapon section appears
- [ ] Verify martial classes show "close range" and "+3 STR"
- [ ] Verify arcane classes show "far range" and "+3 INT"
- [ ] Verify divine/primal classes show both STR and INT bonuses
- [ ] Verify fallback classes also display weapon info

🤖 Generated with [Claude Code](https://claude.com/claude-code)