### PR TITLE
feat: focused dialog workflow for events/encounters (#405)

### DIFF
--- a/src/app/tap-tap-adventure/components/EventDialog.tsx
+++ b/src/app/tap-tap-adventure/components/EventDialog.tsx
@@ -1,0 +1,222 @@
+'use client'
+
+import React from 'react'
+import { LoaderCircle } from 'lucide-react'
+import { Button } from './ui/button'
+import { REGIONS } from '@/app/tap-tap-adventure/config/regions'
+import type { RegionDifficulty } from '@/app/tap-tap-adventure/config/regions'
+import type { FantasyDecisionPoint } from '@/app/tap-tap-adventure/models/types'
+
+const DIFFICULTY_STYLES: Record<RegionDifficulty, { label: string; color: string }> = {
+  easy: { label: 'Easy', color: 'bg-green-900/50 text-green-300 border-green-600/40' },
+  medium: { label: 'Medium', color: 'bg-yellow-900/50 text-yellow-300 border-yellow-600/40' },
+  hard: { label: 'Hard', color: 'bg-red-900/50 text-red-300 border-red-600/40' },
+  very_hard: { label: 'Very Hard', color: 'bg-purple-900/50 text-purple-300 border-purple-600/40' },
+  extreme: { label: 'Extreme', color: 'bg-purple-950/70 text-purple-200 border-purple-400/50' },
+}
+
+const ELEMENT_STYLES: Record<string, { color: string }> = {
+  nature: { color: 'bg-green-900/40 text-green-300' },
+  shadow: { color: 'bg-slate-800/60 text-slate-300' },
+  arcane: { color: 'bg-violet-900/40 text-violet-300' },
+  fire: { color: 'bg-orange-900/40 text-orange-300' },
+  ice: { color: 'bg-cyan-900/40 text-cyan-300' },
+  none: { color: 'bg-slate-800/40 text-slate-400' },
+}
+
+export interface EventResult {
+  outcomeDescription: string
+  resourceDelta?: { gold?: number; reputation?: number }
+  rewardItems?: { name: string; description?: string }[]
+  mountDamage?: number
+  mountDied?: boolean
+}
+
+interface EventDialogProps {
+  decisionPoint: FantasyDecisionPoint | null
+  isLandmarkArrival: boolean
+  arrivalLandmark: { name: string; icon: string; description: string; hasShop: boolean } | null
+  isLegendary: boolean
+  isResolving: boolean
+  decisionGracePeriod: boolean
+  onSelectOption: (optionId: string) => void
+  // Results step
+  eventResult: EventResult | null
+  onDismissResult: () => void
+  // NPC dialogue
+  showNPCPanel: boolean
+  npcPanelContent: React.ReactNode | null
+}
+
+export function EventDialog({
+  decisionPoint,
+  isLandmarkArrival,
+  arrivalLandmark,
+  isLegendary,
+  isResolving,
+  decisionGracePeriod,
+  onSelectOption,
+  eventResult,
+  onDismissResult,
+  showNPCPanel,
+  npcPanelContent,
+}: EventDialogProps) {
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-start justify-center pt-16 px-4"
+      style={{ backdropFilter: 'blur(4px)', background: 'rgba(0,0,0,0.6)' }}
+    >
+      <div
+        className="bg-[#1e1f30] border border-[#3a3c56] rounded-lg max-w-md w-full p-5 shadow-xl max-h-[80vh] overflow-y-auto"
+        onClick={e => e.stopPropagation()}
+      >
+        {/* Results step */}
+        {eventResult && !isResolving ? (
+          <>
+            <div className="text-center mb-4 pb-2 border-b border-[#3a3c56]">
+              <h4 className="font-semibold uppercase text-emerald-400">Outcome</h4>
+            </div>
+            <p className="mb-4 break-words">{eventResult.outcomeDescription}</p>
+
+            {/* Resource deltas */}
+            {eventResult.resourceDelta && (
+              <div className="flex flex-wrap gap-2 justify-center mb-4">
+                {eventResult.resourceDelta.gold != null && eventResult.resourceDelta.gold !== 0 && (
+                  <span className={`text-sm px-2 py-1 rounded ${eventResult.resourceDelta.gold > 0 ? 'bg-yellow-900/40 text-yellow-300' : 'bg-red-900/40 text-red-300'}`}>
+                    {eventResult.resourceDelta.gold > 0 ? '+' : ''}{eventResult.resourceDelta.gold} Gold
+                  </span>
+                )}
+                {eventResult.resourceDelta.reputation != null && eventResult.resourceDelta.reputation !== 0 && (
+                  <span className={`text-sm px-2 py-1 rounded ${eventResult.resourceDelta.reputation > 0 ? 'bg-blue-900/40 text-blue-300' : 'bg-red-900/40 text-red-300'}`}>
+                    {eventResult.resourceDelta.reputation > 0 ? '+' : ''}{eventResult.resourceDelta.reputation} Rep
+                  </span>
+                )}
+              </div>
+            )}
+
+            {/* Reward items */}
+            {eventResult.rewardItems && eventResult.rewardItems.length > 0 && (
+              <div className="space-y-1 mb-4">
+                {eventResult.rewardItems.map((item, i) => (
+                  <div key={i} className="text-sm px-2 py-1 rounded bg-purple-900/30 text-purple-300 border border-purple-600/30">
+                    🎁 {item.name}
+                  </div>
+                ))}
+              </div>
+            )}
+
+            {/* Mount damage/death */}
+            {eventResult.mountDied && (
+              <div className="text-sm text-red-400 mb-4">💀 Your mount has fallen!</div>
+            )}
+            {eventResult.mountDamage != null && eventResult.mountDamage > 0 && !eventResult.mountDied && (
+              <div className="text-sm text-orange-400 mb-4">🐴 Your mount took {eventResult.mountDamage} damage!</div>
+            )}
+
+            <Button
+              className="w-full bg-indigo-600 hover:bg-indigo-700 text-white"
+              onClick={onDismissResult}
+            >
+              Continue
+            </Button>
+          </>
+        ) : (
+          /* Decision step */
+          <>
+            {/* Header */}
+            {arrivalLandmark ? (
+              <div className="text-center mb-4 pb-2 border-b border-indigo-600/40">
+                <div className="text-3xl mb-1">{arrivalLandmark.icon}</div>
+                <h4 className="font-semibold uppercase text-indigo-300">{arrivalLandmark.name}</h4>
+                <p className="text-xs text-slate-400 italic mt-1">{arrivalLandmark.description}</p>
+                {arrivalLandmark.hasShop && (
+                  <span className="inline-block mt-1 text-[10px] px-1.5 py-0.5 rounded bg-yellow-900/40 border border-yellow-600/40 text-yellow-300">
+                    🛒 Shop Available
+                  </span>
+                )}
+              </div>
+            ) : (
+              <h4 className={`font-semibold w-full text-center uppercase border-b pb-2 mb-4 ${
+                isLegendary
+                  ? 'text-amber-400 border-amber-500/50'
+                  : 'border-[#3a3c56]'
+              }`}>
+                {isLegendary ? '✨ Legendary Encounter ✨' : 'Event'}
+              </h4>
+            )}
+
+            {/* NPC dialogue panel replaces options when active */}
+            {showNPCPanel ? (
+              <div className="mt-2">
+                {npcPanelContent}
+              </div>
+            ) : decisionPoint && !decisionPoint.resolved ? (
+              <div>
+                <div className="font-semibold mb-6 break-words">{decisionPoint.prompt}</div>
+                {isResolving ? (
+                  <div className="flex flex-col items-center gap-3 py-6 text-slate-400">
+                    <LoaderCircle className="animate-spin h-6 w-6" />
+                    <span className="text-sm">Resolving your choice...</span>
+                  </div>
+                ) : (
+                  <div className="space-y-2 mt-2">
+                    {decisionPoint.options.map((option: { id: string; text: string; successEffects?: { reputation?: number }; failureEffects?: { reputation?: number }; effects?: { reputation?: number } }, index: number) => {
+                      if (!option) return null
+
+                      // Enrich crossroads travel options with region data
+                      const isTravelOption = option.id.startsWith('travel-')
+                      const travelRegionId = isTravelOption ? option.id.replace('travel-', '') : null
+                      const travelRegion = travelRegionId ? REGIONS[travelRegionId] : null
+                      const diffStyle = travelRegion ? DIFFICULTY_STYLES[travelRegion.difficulty] : null
+                      const elemStyle = travelRegion && travelRegion.element !== 'none' ? ELEMENT_STYLES[travelRegion.element] : null
+                      const borderColor = diffStyle
+                        ? travelRegion!.difficulty === 'easy' ? 'border-green-600/50'
+                          : travelRegion!.difficulty === 'medium' ? 'border-yellow-600/50'
+                          : travelRegion!.difficulty === 'hard' ? 'border-orange-600/50'
+                          : travelRegion!.difficulty === 'very_hard' ? 'border-red-600/50'
+                          : 'border-purple-600/50'
+                        : 'border-[#3a3c56]'
+
+                      return (
+                        <Button
+                          key={option.id}
+                          className={`block w-full text-left whitespace-normal h-auto border bg-[#2a2b3f] hover:bg-[#3a3c56] text-white px-3 py-3 text-base mt-2 rounded disabled:opacity-60 ${borderColor}`}
+                          disabled={isResolving || decisionGracePeriod}
+                          onClick={() => onSelectOption(option.id)}
+                        >
+                          <span className="hidden sm:inline text-slate-400 mr-2 text-xs font-mono">[{index + 1}]</span>
+                          {option.text}
+                          {travelRegion && (
+                            <span className="flex items-center gap-1.5 mt-1.5">
+                              {diffStyle && (
+                                <span className={`text-[10px] px-1.5 py-0.5 rounded border ${diffStyle.color}`}>
+                                  {diffStyle.label}
+                                </span>
+                              )}
+                              {elemStyle && (
+                                <span className={`text-[10px] px-1.5 py-0.5 rounded ${elemStyle.color}`}>
+                                  {travelRegion.element}
+                                </span>
+                              )}
+                              {travelRegion.minLevel > 0 && (
+                                <span className="text-[10px] text-slate-500">
+                                  Lv.{travelRegion.minLevel}+
+                                </span>
+                              )}
+                            </span>
+                          )}
+                        </Button>
+                      )
+                    })}
+                  </div>
+                )}
+              </div>
+            ) : null}
+
+            {/* Show landmark arrival options even when isLandmarkArrival with no decisionPoint resolved check handled above */}
+          </>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/app/tap-tap-adventure/components/GameUI.tsx
+++ b/src/app/tap-tap-adventure/components/GameUI.tsx
@@ -57,6 +57,7 @@ import { StatsPanel } from '@/app/tap-tap-adventure/components/StatsPanel'
 import { RunHistoryPanel } from '@/app/tap-tap-adventure/components/RunHistoryPanel'
 import { NPCDialoguePanel } from './NPCDialoguePanel'
 import { ContactsList } from './ContactsList'
+import { EventDialog, EventResult } from './EventDialog'
 
 const DIFFICULTY_STYLES: Record<RegionDifficulty, { label: string; color: string }> = {
   easy: { label: 'Easy', color: 'bg-green-900/50 text-green-300 border-green-600/40' },
@@ -155,6 +156,7 @@ export default function GameUI({ onOpenStatus }: GameUIProps) {
   const [showKeyboardHelp, setShowKeyboardHelp] = useState(false)
   const [decisionGracePeriod, setDecisionGracePeriod] = useState(false)
   const [showNPCPanel, setShowNPCPanel] = useState(false)
+  const [eventResult, setEventResult] = useState<EventResult | null>(null)
 
   useEffect(() => {
     if (gameState?.decisionPoint && !gameState.decisionPoint.resolved) {
@@ -249,6 +251,23 @@ export default function GameUI({ onOpenStatus }: GameUIProps) {
         const currentDP = useGameStore.getState().gameState.decisionPoint
         if (currentDP && currentDP.id === gameState.decisionPoint?.id) {
           setDecisionPoint(null)
+        }
+      },
+      onResult: (result) => {
+        // Don't show results for options that navigate away (bypass, travel, explore-landmark, etc)
+        const skipResults = optionId.startsWith('bypass-') || optionId.startsWith('travel-') ||
+          optionId === 'explore-landmark' || optionId === 'leave-landmark' ||
+          optionId === 'continue-exploring' || optionId === 'visit-shop' ||
+          optionId === 'back-to-town' || optionId === 'pay-bounty' ||
+          optionId === 'fight-secret-boss'
+        if (!skipResults && result.outcomeDescription) {
+          setEventResult({
+            outcomeDescription: result.outcomeDescription,
+            resourceDelta: result.resourceDelta,
+            rewardItems: result.rewardItems?.map(item => ({ name: item.name, description: item.description })),
+            mountDamage: result.mountDamage,
+            mountDied: result.mountDied,
+          })
         }
       },
       onResourceDelta: (delta) => {
@@ -538,137 +557,9 @@ export default function GameUI({ onOpenStatus }: GameUIProps) {
               />
             ) : gameState.shopState?.isOpen ? (
               <ShopUI />
-            ) : gameState.decisionPoint ? (
-              <>
-                {(() => {
-                  const isLandmarkArrival = gameState.decisionPoint?.options?.some(
-                    (o: { id: string }) => o.id === 'explore-landmark' || o.id === 'bypass-landmark'
-                  )
-                  // Find landmark data from character state (the one we just arrived at)
-                  // nextLandmarkIndex has NOT been incremented yet at this point (server didn't increment it)
-                  const arrivalLandmark = isLandmarkArrival && character?.landmarkState
-                    ? character.landmarkState.landmarks[character.landmarkState.nextLandmarkIndex]
-                    : null
-
-                  if (arrivalLandmark) {
-                    return (
-                      <div className="text-center mb-4 pb-2 border-b border-indigo-600/40">
-                        <div className="text-3xl mb-1">{arrivalLandmark.icon}</div>
-                        <h4 className="font-semibold uppercase text-indigo-300">{arrivalLandmark.name}</h4>
-                        <p className="text-xs text-slate-400 italic mt-1">{arrivalLandmark.description}</p>
-                        {arrivalLandmark.hasShop && (
-                          <span className="inline-block mt-1 text-[10px] px-1.5 py-0.5 rounded bg-yellow-900/40 border border-yellow-600/40 text-yellow-300">
-                            🛒 Shop Available
-                          </span>
-                        )}
-                      </div>
-                    )
-                  }
-
-                  return (
-                    <h4 className={`font-semibold w-full text-center uppercase border-b pb-2 mb-4 ${
-                      gameState.decisionPoint?.isLegendary
-                        ? 'text-amber-400 border-amber-500/50'
-                        : 'border-[#3a3c56]'
-                    }`}>
-                      {gameState.decisionPoint?.isLegendary ? '✨ Legendary Encounter ✨' : 'Event'}
-                    </h4>
-                  )
-                })()}
-                {showNPCPanel && socialEncounter && character && (
-                  <div className="mt-2">
-                    <NPCDialoguePanel
-                      npc={socialEncounter.npc}
-                      characterName={character.name}
-                      characterClass={character.class}
-                      characterLevel={character.level}
-                      reputation={character.reputation}
-                      region={character.currentRegion ?? 'green_meadows'}
-                      characterCharisma={character.charisma ?? 5}
-                      activeCharismaBonus={character.activeExplorationSpells?.filter(s => s.effectType === 'cha_boost').reduce((sum, s) => sum + (s.value ?? 0), 0) ?? 0}
-                      disposition={character.npcEncounters?.[socialEncounter.npc.id]?.disposition ?? 0}
-                      hiddenLandmarkName={character.landmarkState?.landmarks.find(lm => lm.hidden)?.name}
-                      hiddenLandmarkType={character.landmarkState?.landmarks.find(lm => lm.hidden)?.type}
-                      onEncounterUpdate={(dispositionDelta, reward, revealLandmark) => {
-                        recordNPCEncounter(socialEncounter.npc.id, dispositionDelta, reward, revealLandmark)
-                      }}
-                      onClose={() => {
-                        setShowNPCPanel(false)
-                        clearSocialEncounter()
-                        setDecisionPoint(null)
-                      }}
-                    />
-                  </div>
-                )}
-                {!showNPCPanel && !gameState.decisionPoint.resolved && (
-                  <div>
-                    <div className="font-semibold mb-6 break-words">{gameState.decisionPoint.prompt}</div>
-                    {resolveDecisionPending ? (
-                      <div className="flex flex-col items-center gap-3 py-6 text-slate-400">
-                        <LoaderCircle className="animate-spin h-6 w-6" />
-                        <span className="text-sm">Resolving your choice...</span>
-                      </div>
-                    ) : (
-                      <div className="space-y-2 mt-2">
-                        {gameState.decisionPoint.options.map((option: { id: string; text: string; successEffects?: { reputation?: number }; failureEffects?: { reputation?: number }; effects?: { reputation?: number } }, index: number) => {
-                          if (!option) return null
-                          if (!gameState.decisionPoint) return null
-
-                          // Enrich crossroads travel options with region data
-                          const isTravelOption = option.id.startsWith('travel-')
-                          const travelRegionId = isTravelOption ? option.id.replace('travel-', '') : null
-                          const travelRegion = travelRegionId ? REGIONS[travelRegionId] : null
-                          const diffStyle = travelRegion ? DIFFICULTY_STYLES[travelRegion.difficulty] : null
-                          const elemStyle = travelRegion && travelRegion.element !== 'none' ? ELEMENT_STYLES[travelRegion.element] : null
-                          const borderColor = diffStyle
-                            ? travelRegion!.difficulty === 'easy' ? 'border-green-600/50'
-                              : travelRegion!.difficulty === 'medium' ? 'border-yellow-600/50'
-                              : travelRegion!.difficulty === 'hard' ? 'border-orange-600/50'
-                              : travelRegion!.difficulty === 'very_hard' ? 'border-red-600/50'
-                              : 'border-purple-600/50'
-                            : 'border-[#3a3c56]'
-
-                          return (
-                            <Button
-                              key={option.id}
-                              className={`block w-full text-left whitespace-normal h-auto border bg-[#2a2b3f] hover:bg-[#3a3c56] text-white px-3 py-3 text-base mt-2 rounded disabled:opacity-60 ${borderColor}`}
-                              disabled={resolveDecisionPending || decisionGracePeriod}
-                              onClick={() => {
-                                handleResolveDecision(option.id)
-                              }}
-                            >
-                              <span className="hidden sm:inline text-slate-400 mr-2 text-xs font-mono">[{index + 1}]</span>
-                              {option.text}
-                              {travelRegion && (
-                                <span className="flex items-center gap-1.5 mt-1.5">
-                                  {diffStyle && (
-                                    <span className={`text-[10px] px-1.5 py-0.5 rounded border ${diffStyle.color}`}>
-                                      {diffStyle.label}
-                                    </span>
-                                  )}
-                                  {elemStyle && (
-                                    <span className={`text-[10px] px-1.5 py-0.5 rounded ${elemStyle.color}`}>
-                                      {travelRegion.element}
-                                    </span>
-                                  )}
-                                  {travelRegion.minLevel > 0 && (
-                                    <span className="text-[10px] text-slate-500">
-                                      Lv.{travelRegion.minLevel}+
-                                    </span>
-                                  )}
-                                </span>
-                              )}
-                            </Button>
-                          )
-                        })}
-                      </div>
-                    )}
-                  </div>
-                )}
-              </>
             ) : (
               <>
-                {/* Region info */}
+                {/* Region info — always visible behind the event dialog */}
                 {(() => {
                   const dist = character?.distance ?? 0
                   const region = getRegion(character?.currentRegion ?? 'green_meadows')
@@ -742,6 +633,66 @@ export default function GameUI({ onOpenStatus }: GameUIProps) {
                 <div className="select-text">
                   <StoryFeed events={storyEvents} filterCharacterId={selectedCharacterId} />
                 </div>
+
+                {/* Event dialog overlay — shown when there's an active decision point or pending result */}
+                {(gameState.decisionPoint || eventResult) && (() => {
+                  const isLandmarkArrival = gameState.decisionPoint?.options?.some(
+                    (o: { id: string }) => o.id === 'explore-landmark' || o.id === 'bypass-landmark'
+                  ) ?? false
+                  const arrivalLandmark = isLandmarkArrival && character?.landmarkState
+                    ? character.landmarkState.landmarks[character.landmarkState.nextLandmarkIndex]
+                    : null
+
+                  return (
+                    <EventDialog
+                      decisionPoint={gameState.decisionPoint ?? null}
+                      isLandmarkArrival={isLandmarkArrival}
+                      arrivalLandmark={arrivalLandmark ? {
+                        name: arrivalLandmark.name,
+                        icon: arrivalLandmark.icon,
+                        description: arrivalLandmark.description ?? '',
+                        hasShop: arrivalLandmark.hasShop ?? false,
+                      } : null}
+                      isLegendary={gameState.decisionPoint?.isLegendary ?? false}
+                      isResolving={resolveDecisionPending}
+                      decisionGracePeriod={decisionGracePeriod}
+                      onSelectOption={handleResolveDecision}
+                      eventResult={eventResult}
+                      onDismissResult={() => {
+                        setEventResult(null)
+                        // Only clear the decision point if it hasn't already been cleared by the server response
+                        const currentDP = useGameStore.getState().gameState.decisionPoint
+                        if (currentDP && currentDP.id === gameState.decisionPoint?.id) {
+                          setDecisionPoint(null)
+                        }
+                      }}
+                      showNPCPanel={showNPCPanel}
+                      npcPanelContent={showNPCPanel && socialEncounter && character ? (
+                        <NPCDialoguePanel
+                          npc={socialEncounter.npc}
+                          characterName={character.name}
+                          characterClass={character.class}
+                          characterLevel={character.level}
+                          reputation={character.reputation}
+                          region={character.currentRegion ?? 'green_meadows'}
+                          characterCharisma={character.charisma ?? 5}
+                          activeCharismaBonus={character.activeExplorationSpells?.filter(s => s.effectType === 'cha_boost').reduce((sum, s) => sum + (s.value ?? 0), 0) ?? 0}
+                          disposition={character.npcEncounters?.[socialEncounter.npc.id]?.disposition ?? 0}
+                          hiddenLandmarkName={character.landmarkState?.landmarks.find(lm => lm.hidden)?.name}
+                          hiddenLandmarkType={character.landmarkState?.landmarks.find(lm => lm.hidden)?.type}
+                          onEncounterUpdate={(dispositionDelta, reward, revealLandmark) => {
+                            recordNPCEncounter(socialEncounter.npc.id, dispositionDelta, reward, revealLandmark)
+                          }}
+                          onClose={() => {
+                            setShowNPCPanel(false)
+                            clearSocialEncounter()
+                            setDecisionPoint(null)
+                          }}
+                        />
+                      ) : null}
+                    />
+                  )
+                })()}
               </>
             )}
           </div>

--- a/src/app/tap-tap-adventure/hooks/useResolveDecisionMutation.ts
+++ b/src/app/tap-tap-adventure/hooks/useResolveDecisionMutation.ts
@@ -41,11 +41,19 @@ export function useResolveDecisionMutation() {
       optionId,
       onSuccess,
       onResourceDelta,
+      onResult,
     }: {
       decisionPoint: FantasyDecisionPoint
       optionId: string
       onSuccess?: () => void
       onResourceDelta?: (delta: ResolveDecisionResponse['resourceDelta']) => void
+      onResult?: (result: {
+        outcomeDescription?: string
+        resourceDelta?: { gold?: number; reputation?: number }
+        rewardItems?: Item[]
+        mountDamage?: number
+        mountDied?: boolean
+      }) => void
     }) => {
       const character = getSelectedCharacter()
       if (!character) throw new Error('No character found')
@@ -344,6 +352,14 @@ export function useResolveDecisionMutation() {
           }
         }
       }
+
+      onResult?.({
+        outcomeDescription: newStoryEvent.outcomeDescription,
+        resourceDelta: data.resourceDelta,
+        rewardItems: rewardItems,
+        mountDamage: data.mountDamage,
+        mountDied: data.mountDied,
+      })
 
       commit()
       onSuccess?.()


### PR DESCRIPTION
## Summary
- Events/encounters now display in a **focused overlay dialog** instead of inline in the main game panel
- Two-step workflow: **decision prompt** (options) -> **results** (outcome, resource badges, reward items) -> dismiss
- Travel screen (region info, targets, travel button, story feed) stays **visible behind** the dialog with backdrop blur
- Navigation options (bypass, travel, explore-landmark, visit-shop, etc.) **skip the results step** to avoid interrupting flow
- Resource deltas shown as colored badges (gold in yellow, reputation in blue, losses in red)
- Reward items, mount damage/death displayed in results step

## Changes
- **New**: `EventDialog.tsx` — overlay dialog component with decision and results steps
- **Modified**: `GameUI.tsx` — restructured to always render travel screen; EventDialog overlays when active
- **Modified**: `useResolveDecisionMutation.ts` — added `onResult` callback for capturing resolution data

Closes #405

## Test plan
- [ ] Walk until an event triggers — verify it appears as an overlay dialog, not inline
- [ ] Choose an option — verify loading spinner shows, then results step with outcome and resource badges
- [ ] Click "Continue" on results — verify dialog dismisses and travel screen is back
- [ ] Arrive at a landmark — verify landmark header (icon, name, shop badge) shows in dialog
- [ ] Choose "Bypass" — verify no results step, dialog closes immediately
- [ ] Trigger a legendary encounter — verify golden "Legendary Encounter" header
- [ ] Social NPC encounter — verify NPC dialogue panel renders inside the dialog
- [ ] Verify travel screen (region, targets, story feed) is visible behind the blurred dialog

🤖 Generated with [Claude Code](https://claude.com/claude-code)