### PR TITLE
feat: show area map inline below travel button (#404)

### DIFF
--- a/src/app/tap-tap-adventure/components/AreaMap.tsx
+++ b/src/app/tap-tap-adventure/components/AreaMap.tsx
@@ -28,6 +28,7 @@ interface AreaMapProps {
   regionName: string
   regionIcon: string
   onSelectTarget: (index: number) => void
+  compact?: boolean
 }
 
 type DiscoveryTier = 'hidden' | 'distant' | 'unknown' | 'revealed'
@@ -59,6 +60,7 @@ export function AreaMap({
   regionName,
   regionIcon,
   onSelectTarget,
+  compact = false,
 }: AreaMapProps) {
   const worldW = regionBounds.width || 500
   const worldH = regionBounds.height || 500
@@ -96,11 +98,13 @@ export function AreaMap({
   const r100 = 100 * avgScale
 
   return (
-    <div className="space-y-2">
-      <div className="flex items-center justify-between">
-        <p className="text-xs text-slate-400 font-medium">{regionIcon} {regionName} — Area Map</p>
-      </div>
-      <div className="relative w-full" style={{ paddingBottom: '100%' }}>
+    <div className={compact ? 'space-y-1' : 'space-y-2'}>
+      {!compact && (
+        <div className="flex items-center justify-between">
+          <p className="text-xs text-slate-400 font-medium">{regionIcon} {regionName} — Area Map</p>
+        </div>
+      )}
+      <div className="relative w-full" style={{ paddingBottom: compact ? '60%' : '100%' }}>
         <svg
           className="absolute inset-0 w-full h-full rounded-lg border border-[#2a2b3f]"
           viewBox="0 0 500 500"

--- a/src/app/tap-tap-adventure/components/GameUI.tsx
+++ b/src/app/tap-tap-adventure/components/GameUI.tsx
@@ -630,6 +630,35 @@ export default function GameUI({ onOpenStatus }: GameUIProps) {
                 {gameState.genericMessage && (
                   <div className="text-sm">{gameState.genericMessage}</div>
                 )}
+                {/* Inline area map — always visible while traveling */}
+                {character?.landmarkState && (
+                  <div className="mt-2">
+                    <AreaMap
+                      playerPosition={character.landmarkState.position ?? { x: 0, y: 0 }}
+                      landmarks={character.landmarkState.landmarks.map((lm, i) => ({
+                        index: i,
+                        name: lm.name,
+                        icon: lm.icon,
+                        position: lm.position ?? { x: 0, y: 0 },
+                        explored: lm.explored ?? false,
+                        hidden: lm.hidden ?? false,
+                        hasShop: lm.hasShop ?? false,
+                      }))}
+                      exits={(character.landmarkState.exitPositions ?? []).map((exit, i) => ({
+                        index: character.landmarkState!.landmarks.length + i,
+                        name: exit.name,
+                        icon: exit.icon,
+                        position: exit.position,
+                      }))}
+                      activeTargetIndex={character.landmarkState.activeTargetIndex ?? 0}
+                      regionBounds={character.landmarkState.regionBounds ?? { width: 500, height: 500 }}
+                      regionName={getRegion(character.currentRegion ?? 'green_meadows').name}
+                      regionIcon={getRegion(character.currentRegion ?? 'green_meadows').icon}
+                      onSelectTarget={(i) => setActiveTarget(i)}
+                      compact
+                    />
+                  </div>
+                )}
                 <div className="select-text">
                   <StoryFeed events={storyEvents} filterCharacterId={selectedCharacterId} />
                 </div>


### PR DESCRIPTION
## Summary
- Area map now renders **inline** on the travel screen, directly below the "Continue Travelling" button
- Uses a new **compact mode** (60% aspect ratio, no title header) for the inline view
- Full square map remains available in the right-column Map tab
- Tapping landmarks/exits on the inline map sets the active target
- Makes the spatial world visible at all times without opening a menu

## Changes
- `AreaMap.tsx` — added `compact` prop: shorter aspect ratio (60% vs 100%), hides title header
- `GameUI.tsx` — renders AreaMap inline between travel button and story feed when landmarkState exists

Closes #404

## Test plan
- [ ] Travel screen shows compact area map below the travel button
- [ ] Player dot, landmarks, exits visible on the inline map
- [ ] Tap a landmark on the inline map — verify it sets as active target
- [ ] Full map in Map tab still renders as square with title header
- [ ] Map not shown when landmarkState is missing (e.g., during region transition)

🤖 Generated with [Claude Code](https://claude.com/claude-code)