### PR TITLE
feat: NPC relationship rewards — shop discounts (#356)

### DIFF
--- a/src/app/tap-tap-adventure/components/ShopUI.tsx
+++ b/src/app/tap-tap-adventure/components/ShopUI.tsx
@@ -13,6 +13,7 @@ import { Item } from '@/app/tap-tap-adventure/models/types'
 import { Mount } from '@/app/tap-tap-adventure/models/mount'
 import { getEquipmentSlot, EquipmentSlots } from '@/app/tap-tap-adventure/models/equipment'
 import { ItemEffects } from '@/app/tap-tap-adventure/models/item'
+import { getNPCDispositionPriceMultiplier } from '@/app/tap-tap-adventure/lib/contextBuilder'
 
 type ShopTab = 'buy' | 'sell'
 
@@ -83,6 +84,9 @@ export function ShopUI() {
 
   const character = gameState.characters.find(c => c.id === gameState.selectedCharacterId)
   if (!character) return null
+
+  const npcDiscount = getNPCDispositionPriceMultiplier(character.npcEncounters)
+  const npcDiscountPercent = Math.round((1 - npcDiscount) * 100)
 
   const handlePurchase = async (item: Item) => {
     if (!item.price || character.gold < item.price) return
@@ -264,6 +268,11 @@ export function ShopUI() {
       </p>
       <div className="text-sm text-center text-yellow-400 font-semibold">
         Your Gold: {character.gold}
+        {npcDiscountPercent > 0 && (
+          <span className="text-xs text-green-400 ml-2">
+            ({npcDiscountPercent}% NPC discount applied)
+          </span>
+        )}
       </div>
 
       {/* Tab toggle */}

--- a/src/app/tap-tap-adventure/lib/contextBuilder.ts
+++ b/src/app/tap-tap-adventure/lib/contextBuilder.ts
@@ -58,6 +58,18 @@ export function getCharismaPriceMultiplier(charisma: number): number {
   return 1.0 - discount
 }
 
+export function getNPCDispositionPriceMultiplier(npcEncounters?: Record<string, { disposition: number }>): number {
+  if (!npcEncounters) return 1.0
+  const dispositions = Object.values(npcEncounters).map(e => e.disposition)
+  if (dispositions.length === 0) return 1.0
+  const maxDisposition = Math.max(...dispositions)
+  // Discount tiers based on best NPC relationship
+  if (maxDisposition >= 80) return 0.85  // Bonded: 15% discount
+  if (maxDisposition >= 50) return 0.90  // Trusted: 10% discount
+  if (maxDisposition >= 20) return 0.95  // Friendly: 5% discount
+  return 1.0 // Neutral or worse: no discount
+}
+
 export function buildStoryContext(
   character: FantasyCharacter,
   storyEvents: FantasyStoryEvent[],

--- a/src/app/tap-tap-adventure/lib/shopGenerator.ts
+++ b/src/app/tap-tap-adventure/lib/shopGenerator.ts
@@ -6,7 +6,7 @@ import { Item, ItemSchema } from '@/app/tap-tap-adventure/models/item'
 import { Mount } from '@/app/tap-tap-adventure/models/mount'
 import { getMountPrice, getShopMount } from '@/app/tap-tap-adventure/config/mounts'
 
-import { getCharismaPriceMultiplier, getReputationPriceMultiplier } from './contextBuilder'
+import { getCharismaPriceMultiplier, getNPCDispositionPriceMultiplier, getReputationPriceMultiplier } from './contextBuilder'
 import { inferItemTypeAndEffects } from './itemPostProcessor'
 import { generateSpellForLevel } from './spellGenerator'
 
@@ -149,7 +149,7 @@ ${JSON.stringify({ name: character.name, race: character.race, class: character.
     if (toolCall && toolCall.function?.name === 'generate_shop') {
       const parsed = JSON.parse(toolCall.function.arguments)
       const validated = shopResponseSchema.parse(parsed)
-      const priceMultiplier = Math.max(0.60, getReputationPriceMultiplier(character.reputation) * getCharismaPriceMultiplier(character.charisma))
+      const priceMultiplier = Math.max(0.60, getReputationPriceMultiplier(character.reputation) * getCharismaPriceMultiplier(character.charisma) * getNPCDispositionPriceMultiplier(character.npcEncounters))
       return validated.items.map(item => inferItemTypeAndEffects({
         ...item,
         price: item.price !== undefined ? Math.round(item.price * priceMultiplier) : undefined,


### PR DESCRIPTION
## Summary
- NPC relationships now provide **shop discounts** based on the player's best NPC disposition:
  - **Friendly** (20+): 5% discount
  - **Trusted** (50+): 10% discount
  - **Bonded** (80+): 15% discount
- Discounts stack with existing reputation and charisma multipliers (floor at 60% of base price)
- ShopUI shows a green **"(X% NPC discount applied)"** badge next to the gold display

## Changes
- `contextBuilder.ts` — new `getNPCDispositionPriceMultiplier()` function
- `shopGenerator.ts` — added NPC discount to the price multiplier calculation
- `ShopUI.tsx` — shows discount badge when NPC relationships provide a discount

Closes #356

## Test plan
- [ ] With no NPC encounters — verify no discount badge, prices unchanged
- [ ] Speak with NPCs until one reaches Friendly (20+) — verify 5% discount badge in shop
- [ ] Reach Trusted (50+) — verify 10% discount shown and prices reduced
- [ ] Reach Bonded (80+) — verify 15% discount
- [ ] Verify prices never drop below 60% of base (floor still enforced)

🤖 Generated with [Claude Code](https://claude.com/claude-code)