### PR TITLE
feat: PartyMember schema and store actions (#380)

### DIFF
--- a/src/app/tap-tap-adventure/hooks/useCharacterCreation.ts
+++ b/src/app/tap-tap-adventure/hooks/useCharacterCreation.ts
@@ -217,6 +217,7 @@ export function useCharacterCreation() {
       visitedRegions: ['green_meadows'],
       factionReputations: {},
       bounty: 0,
+      party: [],
     }
     const maxMana = calculateMaxMana(tempChar)
 

--- a/src/app/tap-tap-adventure/hooks/useGameStore.ts
+++ b/src/app/tap-tap-adventure/hooks/useGameStore.ts
@@ -26,6 +26,7 @@ import { PlayerAchievement } from '@/app/tap-tap-adventure/models/achievement'
 import { Mount } from '@/app/tap-tap-adventure/models/mount'
 import { assignMountPersonality, getMountMaxHp } from '@/app/tap-tap-adventure/config/mounts'
 import { Mercenary } from '@/app/tap-tap-adventure/models/mercenary'
+import { PartyMember, MAX_PARTY_SIZE } from '@/app/tap-tap-adventure/models/partyMember'
 import { getMercenaryMaxHp } from '@/app/tap-tap-adventure/config/mercenaries'
 import { TimedQuest } from '@/app/tap-tap-adventure/models/quest'
 import {
@@ -85,6 +86,7 @@ const defaultCharacter: FantasyCharacter = {
   activeMount: null,
   activeMercenary: null,
   mercenaryRoster: [],
+  party: [],
   difficultyMode: 'normal',
   currentRegion: 'green_meadows',
   currentWeather: 'clear',
@@ -124,6 +126,10 @@ export interface GameStore {
   recruitMercenary: (mercenary: Mercenary) => boolean
   dismissMercenary: (mercenaryId: string) => void
   setActiveMercenary: (mercenaryId: string) => void
+  addPartyMember: (member: PartyMember) => boolean
+  removePartyMember: (memberId: string) => void
+  renamePartyMember: (memberId: string, newName: string) => void
+  healPartyMember: (memberId: string, amount: number) => void
   addHeirloom: (item: Item) => void
   claimHeirloom: (itemId: string) => Item | null
   retireCharacter: (characterId: string) => void
@@ -943,6 +949,67 @@ export const useGameStore = create<GameStore>()(
           })
         )
       },
+      addPartyMember: (member: PartyMember) => {
+        const character = get().getSelectedCharacter()
+        if (!character) return false
+        const party = character.party ?? []
+        if (party.length >= MAX_PARTY_SIZE) return false
+
+        set(
+          produce((state: GameStore) => {
+            const charIndex = state.gameState.characters.findIndex(
+              c => c.id === state.gameState.selectedCharacterId
+            )
+            if (charIndex < 0) return
+            const char = state.gameState.characters[charIndex]
+            if (!char.party) char.party = []
+            char.party.push(member)
+          })
+        )
+        return true
+      },
+
+      removePartyMember: (memberId: string) => {
+        set(
+          produce((state: GameStore) => {
+            const charIndex = state.gameState.characters.findIndex(
+              c => c.id === state.gameState.selectedCharacterId
+            )
+            if (charIndex < 0) return
+            const char = state.gameState.characters[charIndex]
+            char.party = (char.party ?? []).filter(m => m.id !== memberId)
+          })
+        )
+      },
+
+      renamePartyMember: (memberId: string, newName: string) => {
+        set(
+          produce((state: GameStore) => {
+            const charIndex = state.gameState.characters.findIndex(
+              c => c.id === state.gameState.selectedCharacterId
+            )
+            if (charIndex < 0) return
+            const member = (state.gameState.characters[charIndex].party ?? []).find(m => m.id === memberId)
+            if (member) member.customName = newName
+          })
+        )
+      },
+
+      healPartyMember: (memberId: string, amount: number) => {
+        set(
+          produce((state: GameStore) => {
+            const charIndex = state.gameState.characters.findIndex(
+              c => c.id === state.gameState.selectedCharacterId
+            )
+            if (charIndex < 0) return
+            const member = (state.gameState.characters[charIndex].party ?? []).find(m => m.id === memberId)
+            if (member) {
+              member.hp = Math.min(member.maxHp, member.hp + amount)
+            }
+          })
+        )
+      },
+
       addHeirloom: (item: Item) => {
         set(
           produce((state: GameStore) => {
@@ -1648,7 +1715,7 @@ export const useGameStore = create<GameStore>()(
     }),
     {
       name: 'fantasy-tycoon-storage', // localStorage key (kept for backward compat)
-      version: 35,
+      version: 36,
       migrate: (persistedState: unknown) => {
         const state = persistedState as GameStore
         if (state?.gameState && !('combatState' in state.gameState)) {
@@ -1814,6 +1881,10 @@ export const useGameStore = create<GameStore>()(
             // v35: Add bounty field
             if ((char as FantasyCharacter).bounty === undefined) {
               ;(char as FantasyCharacter).bounty = 0
+            }
+            // v36: Add party array
+            if (!(char as FantasyCharacter).party) {
+              ;(char as FantasyCharacter).party = []
             }
           }
         }

--- a/src/app/tap-tap-adventure/models/character.ts
+++ b/src/app/tap-tap-adventure/models/character.ts
@@ -6,6 +6,7 @@ import { GeneratedClassSchema } from './generatedClass'
 import { ItemSchema } from './item'
 import { MountSchema } from './mount'
 import { MercenarySchema } from './mercenary'
+import { PartyMemberSchema } from './partyMember'
 import { MainQuestSchema } from './quest'
 import { SpellSchema, ActiveExplorationSpellSchema } from './spell'
 import { BestiaryEntrySchema } from './bestiary'
@@ -58,6 +59,7 @@ export const FantasyCharacterSchema = z.object({
   activeMount: MountSchema.nullable().optional(),
   activeMercenary: MercenarySchema.nullable().optional(),
   mercenaryRoster: z.array(MercenarySchema).optional(),
+  party: z.array(PartyMemberSchema).default([]),
   unlockedSkills: z.array(z.string()).optional(),
   classSkillTree: ClassSkillTreeSchema.optional(),
   unlockedTreeSkillIds: z.array(z.string()).optional(),

--- a/src/app/tap-tap-adventure/models/partyMember.ts
+++ b/src/app/tap-tap-adventure/models/partyMember.ts
@@ -1,0 +1,47 @@
+import { z } from 'zod'
+import { ItemSchema } from './item'
+
+export const PartyMemberSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  customName: z.string().optional(),
+  description: z.string(),
+  icon: z.string(),
+
+  // Class info
+  className: z.string(),
+
+  // Combat stats
+  level: z.number().default(1),
+  hp: z.number(),
+  maxHp: z.number(),
+  stats: z.object({
+    strength: z.number(),
+    intelligence: z.number(),
+    luck: z.number(),
+    charisma: z.number(),
+  }),
+
+  // Equipment (same slot structure as player)
+  equipment: z.object({
+    weapon: ItemSchema.nullable().default(null),
+    armor: ItemSchema.nullable().default(null),
+    accessory: ItemSchema.nullable().default(null),
+  }).default({ weapon: null, armor: null, accessory: null }),
+
+  // Economy
+  dailyCost: z.number().default(0),
+  recruitCost: z.number().default(0),
+  rarity: z.enum(['common', 'uncommon', 'rare', 'legendary']),
+
+  // Social
+  personality: z.string().optional(),
+  relationship: z.number().default(0),
+
+  // Role
+  role: z.enum(['combatant', 'non-combatant']).default('combatant'),
+})
+
+export type PartyMember = z.infer<typeof PartyMemberSchema>
+
+export const MAX_PARTY_SIZE = 3

--- a/src/app/tap-tap-adventure/models/types.ts
+++ b/src/app/tap-tap-adventure/models/types.ts
@@ -137,3 +137,5 @@ export type {
   MetaProgressionStateSchema,
 } from './metaProgression'
 export type { BestiaryEntry, BestiaryEntrySchema } from './bestiary'
+export type { PartyMember } from './partyMember'
+export { PartyMemberSchema, MAX_PARTY_SIZE } from './partyMember'


### PR DESCRIPTION
## Summary
Foundational data model and store actions for the party system epic (#378). This PR adds the schema and state management — no UI changes yet.

- **New `PartyMemberSchema`**: id, name, className, level, hp/maxHp, stats (STR/INT/LCK/CHA), equipment slots (weapon/armor/accessory), economy (dailyCost/recruitCost), rarity, personality, relationship, role (combatant/non-combatant)
- **`party[]` field** added to FantasyCharacter (default empty, max 3 members)
- **Store actions**: `addPartyMember`, `removePartyMember`, `renamePartyMember`, `healPartyMember`
- **Store migration v36**: backfills `party = []` on existing characters
- Existing mercenary system untouched (runs parallel for backward compatibility)

Closes #380

## Test plan
- [ ] Existing characters load without errors (v36 migration adds empty party array)
- [ ] New characters created with empty party array
- [ ] TypeScript compilation passes (no new errors)
- [ ] PartyMember type exported correctly from models/types.ts

🤖 Generated with [Claude Code](https://claude.com/claude-code)