### PR TITLE
fix: explore-landmark generic events, explored flag, infinite loop (#419)

### DIFF
--- a/src/app/api/v1/tap-tap-adventure/move-forward/services/moveForwardService.ts
+++ b/src/app/api/v1/tap-tap-adventure/move-forward/services/moveForwardService.ts
@@ -198,6 +198,27 @@ export async function moveForwardService(
     // Re-read landmark after potential reveal
     activeLandmark = landmarkState.landmarks[activeTargetIndex]
 
+    // Auto-advance past explored non-town landmarks
+    if (activeLandmark && activeLandmark.explored && activeLandmark.type !== 'town' && hasArrivedAtLandmark) {
+      const newIndex = Math.min(activeTargetIndex + 1, landmarkState.landmarks.length)
+      return {
+        character: {
+          ...updatedCharacter,
+          landmarkState: {
+            ...landmarkState,
+            positionInRegion: newPositionInRegion,
+            position: updatedPosition,
+            activeTargetIndex: newIndex,
+            nextLandmarkIndex: newIndex,
+          },
+        },
+        event: null,
+        decisionPoint: null,
+        genericMessage: `You pass by ${activeLandmark.name} — you've already explored this place.`,
+        landmarkProgress: null,
+      }
+    }
+
     if (activeLandmark && !activeLandmark.hidden && hasArrivedAtLandmark) {
       const arrivalEventId = `landmark-arrival-${Date.now()}`
 

--- a/src/app/api/v1/tap-tap-adventure/resolve-decision/route.ts
+++ b/src/app/api/v1/tap-tap-adventure/resolve-decision/route.ts
@@ -949,11 +949,15 @@ export async function POST(req: NextRequest) {
       const updatedLandmarkState = landmarkState
         ? {
             ...landmarkState,
-            // Don't auto-advance indexes — player stays at this landmark until they leave
             nextLandmarkIndex: targetIndex,
             exploring: true,
             explorationDepth: 1,
             exploringLandmarkName: exploredLandmark?.name ?? 'the landmark',
+            // Mark landmark explored immediately and snap position
+            landmarks: landmarkState.landmarks.map((lm, i) =>
+              i === targetIndex ? { ...lm, explored: true } : lm
+            ),
+            ...(exploredLandmark?.position ? { position: exploredLandmark.position } : {}),
           }
         : undefined
 
@@ -967,7 +971,7 @@ export async function POST(req: NextRequest) {
       const baseContext = buildStoryContext(character, storyEvents)
       const explorationDepth = updatedLandmarkState?.explorationDepth ?? 1
       const landmarkPrefix = exploredLandmark
-        ? `Landmark: ${exploredLandmark.name} (${exploredLandmark.type}). ${exploredLandmark.encounterPrompt}\nExploration depth: ${explorationDepth}. Scale rewards with depth — deeper encounters should have greater risks and greater rewards.\n\n`
+        ? `IMPORTANT: This encounter takes place INSIDE the landmark "${exploredLandmark.name}" (${exploredLandmark.type}). ${exploredLandmark.encounterPrompt}\nDo NOT generate a generic road or travel event. The encounter MUST be directly related to this specific location.\nExploration depth: ${explorationDepth}. Scale rewards with depth — deeper encounters should have greater risks and greater rewards.\n\n`
         : ''
       const combined = landmarkPrefix + baseContext
       const enrichedContext = combined.length > MAX_CONTEXT ? combined.slice(0, MAX_CONTEXT) : combined


### PR DESCRIPTION
## Summary
Three interrelated bugs in the landmark exploration system:

1. **Generic events**: LLM was ignoring the landmark context and generating road encounters. Fixed by making the prompt forceful: "This encounter takes place INSIDE [landmark]. Do NOT generate a generic road event."
2. **Not marked explored**: `explore-landmark` didn't set `explored: true` on the landmark. Now sets it immediately when the player chooses to explore, and snaps the player position to the landmark.
3. **Infinite re-trigger**: After exploring, the player could re-trigger arrival endlessly. Now `moveForwardService` auto-advances past explored non-town landmarks with a brief "you've already explored this" message.

Closes #419

## Test plan
- [ ] Explore a landmark — verify the encounter is thematically tied to the landmark (not generic road event)
- [ ] After exploring, verify landmark is marked explored (no "Explore" option on re-arrival)
- [ ] Walk past an explored landmark — verify auto-advance with "you've already explored this" message
- [ ] Arrive at an explored town — verify town arrival UI still shows (shop access preserved)
- [ ] Verify no infinite loop when walking through a region with explored landmarks

🤖 Generated with [Claude Code](https://claude.com/claude-code)