### PR TITLE
fix: remove flashing/pulse animation on new items

### DIFF
--- a/src/app/tap-tap-adventure/components/InventoryPanel.tsx
+++ b/src/app/tap-tap-adventure/components/InventoryPanel.tsx
@@ -172,7 +172,7 @@ export function InventoryPanel({ inventory }: InventoryPanelProps) {
         </div>
       )}
       {feedbackMessage && (
-        <div className="mb-2 p-2 bg-green-900/50 border border-green-700 rounded-md text-green-300 text-sm animate-pulse">
+        <div className="mb-2 p-2 bg-green-900/50 border border-green-700 rounded-md text-green-300 text-sm">
           {feedbackMessage}
         </div>
       )}
@@ -191,7 +191,7 @@ export function InventoryPanel({ inventory }: InventoryPanelProps) {
               const borderClass = item.isHeirloom
                 ? `${rarityStyle.border} ring-1 ring-amber-500/30`
                 : isNew
-                ? `${rarityStyle.border} ring-1 ring-indigo-400/60 animate-pulse`
+                ? `${rarityStyle.border} ring-1 ring-indigo-400/60`
                 : rarityStyle.border
               return (
               <div


### PR DESCRIPTION
## Summary
- Removes `animate-pulse` CSS class from new inventory item borders and feedback messages in `InventoryPanel.tsx`
- Static ring highlight on new items is preserved — only the distracting flashing is removed
- Rare loot celebration modal animations are left untouched (as requested)

Closes #421

## Test plan
- [ ] Open inventory with a new item — confirm no pulsing animation
- [ ] Confirm the indigo ring highlight still appears on new items
- [ ] Confirm rare loot celebration modal still animates

🤖 Generated with [Claude Code](https://claude.com/claude-code)