### PR TITLE
feat: NPC party members use seed-based class generation

### DIFF
--- a/src/app/tap-tap-adventure/__tests__/npcClassGeneration.test.ts
+++ b/src/app/tap-tap-adventure/__tests__/npcClassGeneration.test.ts
@@ -1,0 +1,82 @@
+import { getClassForNPC, deriveNPCCombatStats } from '@/app/tap-tap-adventure/lib/classGenerator'
+import { FALLBACK_CLASSES } from '@/app/tap-tap-adventure/config/fallbackClasses'
+
+describe('getClassForNPC', () => {
+  it('is deterministic — same name always returns the same class', () => {
+    const result1 = getClassForNPC('Aldric the Bold')
+    const result2 = getClassForNPC('Aldric the Bold')
+    expect(result1.id).toBe(result2.id)
+    expect(result1.name).toBe(result2.name)
+  })
+
+  it('returns different classes for different names', () => {
+    const names = ['Morgana', 'Theron', 'Sylvara', 'Borin']
+    const classes = names.map(n => getClassForNPC(n).id)
+    // At least 2 distinct class IDs among the 4 names
+    const unique = new Set(classes)
+    expect(unique.size).toBeGreaterThanOrEqual(2)
+  })
+
+  it('returned class is a valid GeneratedClass with required fields', () => {
+    const cls = getClassForNPC('TestNPC')
+    expect(typeof cls.id).toBe('string')
+    expect(cls.id.length).toBeGreaterThan(0)
+    expect(typeof cls.name).toBe('string')
+    expect(cls.name.length).toBeGreaterThan(0)
+    expect(typeof cls.description).toBe('string')
+    expect(cls.statDistribution).toBeDefined()
+    expect(typeof cls.statDistribution.strength).toBe('number')
+    expect(typeof cls.statDistribution.intelligence).toBe('number')
+    expect(typeof cls.statDistribution.luck).toBe('number')
+    expect(typeof cls.statDistribution.charisma).toBe('number')
+    expect(cls.startingAbility).toBeDefined()
+    expect(typeof cls.favoredSchool).toBe('string')
+  })
+
+  it('always returns one of the FALLBACK_CLASSES entries', () => {
+    const fallbackIds = new Set(FALLBACK_CLASSES.map(c => c.id))
+    const testNames = ['Alice', 'Bob', 'Carol', 'Dave', 'Eve', 'Frank']
+    for (const name of testNames) {
+      const cls = getClassForNPC(name)
+      expect(fallbackIds.has(cls.id)).toBe(true)
+    }
+  })
+})
+
+describe('deriveNPCCombatStats', () => {
+  it('produces positive HP values', () => {
+    const cls = getClassForNPC('TestNPC')
+    const stats = deriveNPCCombatStats(cls, 1)
+    expect(stats.hp).toBeGreaterThan(0)
+    expect(stats.maxHp).toBeGreaterThan(0)
+  })
+
+  it('hp equals maxHp on fresh creation', () => {
+    const cls = getClassForNPC('TestNPC')
+    const stats = deriveNPCCombatStats(cls, 1)
+    expect(stats.hp).toBe(stats.maxHp)
+  })
+
+  it('stats match the class statDistribution', () => {
+    const cls = getClassForNPC('TestNPC')
+    const combatStats = deriveNPCCombatStats(cls, 1)
+    expect(combatStats.stats.strength).toBe(cls.statDistribution.strength)
+    expect(combatStats.stats.intelligence).toBe(cls.statDistribution.intelligence)
+    expect(combatStats.stats.luck).toBe(cls.statDistribution.luck)
+    expect(combatStats.stats.charisma).toBe(cls.statDistribution.charisma)
+  })
+
+  it('scales HP with level', () => {
+    const cls = getClassForNPC('ScalingTest')
+    const statsLevel1 = deriveNPCCombatStats(cls, 1)
+    const statsLevel10 = deriveNPCCombatStats(cls, 10)
+    expect(statsLevel10.maxHp).toBeGreaterThan(statsLevel1.maxHp)
+  })
+
+  it('level 10 HP is 45 more than level 1 HP (5 per level)', () => {
+    const cls = getClassForNPC('ScalingTest')
+    const statsLevel1 = deriveNPCCombatStats(cls, 1)
+    const statsLevel10 = deriveNPCCombatStats(cls, 10)
+    expect(statsLevel10.maxHp - statsLevel1.maxHp).toBe(45) // (10 - 1) * 5
+  })
+})

--- a/src/app/tap-tap-adventure/components/GameUI.tsx
+++ b/src/app/tap-tap-adventure/components/GameUI.tsx
@@ -57,6 +57,7 @@ import { StatsPanel } from '@/app/tap-tap-adventure/components/StatsPanel'
 import { RunHistoryPanel } from '@/app/tap-tap-adventure/components/RunHistoryPanel'
 import { NPCDialoguePanel } from './NPCDialoguePanel'
 import type { PartyMember } from '@/app/tap-tap-adventure/models/partyMember'
+import { getClassForNPC, deriveNPCCombatStats } from '@/app/tap-tap-adventure/lib/classGenerator'
 import { ContactsList } from './ContactsList'
 import { EventDialog, EventResult } from './EventDialog'
 
@@ -720,16 +721,19 @@ export default function GameUI({ onOpenStatus }: GameUIProps) {
                             setDecisionPoint(null)
                           }}
                           onRecruit={() => {
+                            const npcClass = getClassForNPC(socialEncounter.npc.name)
+                            const combatStats = deriveNPCCombatStats(npcClass, character.level)
                             const member: PartyMember = {
                               id: `npc-${socialEncounter.npc.id}`,
                               name: socialEncounter.npc.name,
                               description: socialEncounter.npc.description,
                               icon: socialEncounter.npc.icon,
-                              className: socialEncounter.npc.role,
+                              className: npcClass.name,
+                              generatedClass: npcClass,
                               level: character.level,
-                              hp: 30 + character.level * 5,
-                              maxHp: 30 + character.level * 5,
-                              stats: { strength: 5, intelligence: 5, luck: 5, charisma: 5 },
+                              hp: combatStats.hp,
+                              maxHp: combatStats.maxHp,
+                              stats: combatStats.stats,
                               equipment: { weapon: null, armor: null, accessory: null },
                               dailyCost: Math.max(1, Math.floor(character.level / 2)),
                               recruitCost: 0,

--- a/src/app/tap-tap-adventure/hooks/useGameStore.ts
+++ b/src/app/tap-tap-adventure/hooks/useGameStore.ts
@@ -27,6 +27,7 @@ import { Mount } from '@/app/tap-tap-adventure/models/mount'
 import { assignMountPersonality, getMountMaxHp } from '@/app/tap-tap-adventure/config/mounts'
 import { Mercenary } from '@/app/tap-tap-adventure/models/mercenary'
 import { PartyMember, MAX_PARTY_SIZE } from '@/app/tap-tap-adventure/models/partyMember'
+import { getClassForNPC, deriveNPCCombatStats } from '@/app/tap-tap-adventure/lib/classGenerator'
 import { getMercenaryMaxHp } from '@/app/tap-tap-adventure/config/mercenaries'
 import { TimedQuest } from '@/app/tap-tap-adventure/models/quest'
 import {
@@ -1715,7 +1716,7 @@ export const useGameStore = create<GameStore>()(
     }),
     {
       name: 'fantasy-tycoon-storage', // localStorage key (kept for backward compat)
-      version: 36,
+      version: 37,
       migrate: (persistedState: unknown) => {
         const state = persistedState as GameStore
         if (state?.gameState && !('combatState' in state.gameState)) {
@@ -1885,6 +1886,20 @@ export const useGameStore = create<GameStore>()(
             // v36: Add party array
             if (!(char as FantasyCharacter).party) {
               ;(char as FantasyCharacter).party = []
+            }
+            // v37: Backfill generatedClass on party members
+            if ((char as FantasyCharacter).party) {
+              for (const member of (char as FantasyCharacter).party!) {
+                if (!member.generatedClass) {
+                  const npcClass = getClassForNPC(member.name)
+                  const combatStats = deriveNPCCombatStats(npcClass, member.level ?? 1)
+                  member.generatedClass = npcClass
+                  member.className = npcClass.name
+                  member.stats = combatStats.stats
+                  member.hp = Math.min(member.hp, combatStats.maxHp)
+                  member.maxHp = combatStats.maxHp
+                }
+              }
             }
           }
         }

--- a/src/app/tap-tap-adventure/lib/classGenerator.ts
+++ b/src/app/tap-tap-adventure/lib/classGenerator.ts
@@ -3,6 +3,7 @@ import { OpenAI } from 'openai'
 import { FALLBACK_CLASSES } from '@/app/tap-tap-adventure/config/fallbackClasses'
 import { GeneratedClass, GeneratedClassStartingAbility, StartingWeapon } from '@/app/tap-tap-adventure/models/generatedClass'
 import { SpellEffect, SpellElement, SpellSchool } from '@/app/tap-tap-adventure/models/spell'
+import { seededRandom } from '@/app/tap-tap-adventure/lib/landmarkGenerator'
 
 export const COMBAT_STYLES = [
   // Physical
@@ -565,4 +566,36 @@ export function pickRandomFallback(excludeIds: Set<string> = new Set()): Generat
     return FALLBACK_CLASSES[Math.floor(Math.random() * FALLBACK_CLASSES.length)]
   }
   return available[Math.floor(Math.random() * available.length)]
+}
+
+/**
+ * Deterministically pick a fallback class for an NPC based on their name.
+ * No API call — instant, offline, deterministic.
+ */
+export function getClassForNPC(npcName: string): GeneratedClass {
+  const rng = seededRandom(npcName)
+  const index = Math.floor(rng() * FALLBACK_CLASSES.length)
+  return FALLBACK_CLASSES[index]
+}
+
+/**
+ * Derive combat stats from a GeneratedClass and level.
+ */
+export function deriveNPCCombatStats(genClass: GeneratedClass, level: number): {
+  hp: number
+  maxHp: number
+  stats: { strength: number; intelligence: number; luck: number; charisma: number }
+} {
+  const { statDistribution } = genClass
+  const hp = 20 + statDistribution.strength * 3 + level * 5
+  return {
+    hp,
+    maxHp: hp,
+    stats: {
+      strength: statDistribution.strength,
+      intelligence: statDistribution.intelligence,
+      luck: statDistribution.luck,
+      charisma: statDistribution.charisma,
+    },
+  }
 }

--- a/src/app/tap-tap-adventure/models/partyMember.ts
+++ b/src/app/tap-tap-adventure/models/partyMember.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod'
 import { ItemSchema } from './item'
+import { GeneratedClassSchema } from '../models/generatedClass'
 
 export const PartyMemberSchema = z.object({
   id: z.string(),
@@ -10,6 +11,7 @@ export const PartyMemberSchema = z.object({
 
   // Class info
   className: z.string(),
+  generatedClass: GeneratedClassSchema.optional(),
 
   // Combat stats
   level: z.number().default(1),


### PR DESCRIPTION
## Summary
- NPC recruits now get a deterministic generated class from the 17 fallback classes, seeded by NPC name — no more hardcoded flat stats
- Each NPC gets unique class name, description, stat distribution (STR/INT/LCK/CHA), favored spell school, starting ability, and weapon
- Stats and HP now scale with class distribution and level instead of being flat 5s
- Store migration backfills existing party members with their generated class

Closes #379

## Changes
- `classGenerator.ts` — added `getClassForNPC()` (deterministic seed-based selection) and `deriveNPCCombatStats()` (HP/stats from class + level)
- `partyMember.ts` — added optional `generatedClass` field to schema
- `GameUI.tsx` — recruitment now uses generated class data
- `useGameStore.ts` — version 36→37, migration backfills existing party members
- 9 new unit tests for determinism, variety, stat validity, and level scaling

## Test plan
- [ ] Recruit an NPC — verify they get a unique class name (not "combatant")
- [ ] Recruit the same NPC twice (different saves) — verify same class (determinism)
- [ ] Check party member stats are not all flat 5s
- [ ] Load an old save with party members — verify migration assigns classes
- [ ] All 818 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)