### PR TITLE
feat: recurring daily costs for party members

### DIFF
--- a/src/app/tap-tap-adventure/__tests__/partyUpkeep.test.ts
+++ b/src/app/tap-tap-adventure/__tests__/partyUpkeep.test.ts
@@ -1,0 +1,114 @@
+import { processPartyUpkeep } from '@/app/tap-tap-adventure/lib/partyUpkeep'
+import { PartyMember } from '@/app/tap-tap-adventure/models/partyMember'
+
+function makePartyMember(overrides: Partial<PartyMember>): PartyMember {
+  return {
+    id: 'member-1',
+    name: 'Test Member',
+    description: 'A test party member',
+    icon: '⚔️',
+    className: 'Warrior',
+    level: 1,
+    hp: 50,
+    maxHp: 50,
+    stats: { strength: 5, intelligence: 3, luck: 2, charisma: 3 },
+    equipment: { weapon: null, armor: null, accessory: null },
+    dailyCost: 10,
+    recruitCost: 100,
+    rarity: 'common',
+    relationship: 0,
+    role: 'combatant',
+    ...overrides,
+  }
+}
+
+describe('processPartyUpkeep', () => {
+  it('deducts daily cost for each party member at day boundary', () => {
+    const party = [
+      makePartyMember({ id: 'a', name: 'Alice', dailyCost: 10 }),
+      makePartyMember({ id: 'b', name: 'Bob', dailyCost: 5 }),
+    ]
+    const { remainingParty, newGold, dismissed } = processPartyUpkeep(party, 50, 0)
+
+    expect(newGold).toBe(35) // 50 - 10 - 5
+    expect(remainingParty).toHaveLength(2)
+    expect(dismissed).toHaveLength(0)
+  })
+
+  it('quest-reward companion with dailyCost=0 incurs no cost', () => {
+    const party = [
+      makePartyMember({ id: 'quest', name: 'Quest Companion', dailyCost: 0 }),
+    ]
+    const { remainingParty, newGold, dismissed } = processPartyUpkeep(party, 100, 0)
+
+    expect(newGold).toBe(100)
+    expect(remainingParty).toHaveLength(1)
+    expect(dismissed).toHaveLength(0)
+  })
+
+  it('dismisses most expensive member first when gold is insufficient', () => {
+    const party = [
+      makePartyMember({ id: 'cheap', name: 'Cheap', dailyCost: 5 }),
+      makePartyMember({ id: 'expensive', name: 'Expensive', dailyCost: 20 }),
+    ]
+    // Only 10 gold — can't afford the 20-cost member; should dismiss Expensive and keep Cheap
+    const { remainingParty, newGold, dismissed } = processPartyUpkeep(party, 10, 0)
+
+    expect(dismissed).toContain('Expensive')
+    expect(remainingParty.map(m => m.name)).toContain('Cheap')
+    expect(newGold).toBe(5) // 10 - 5
+  })
+
+  it('gold never goes negative after upkeep', () => {
+    const party = [
+      makePartyMember({ id: 'a', name: 'Alice', dailyCost: 50 }),
+      makePartyMember({ id: 'b', name: 'Bob', dailyCost: 30 }),
+    ]
+    // Only 5 gold — can't afford either
+    const { newGold, dismissed } = processPartyUpkeep(party, 5, 0)
+
+    expect(newGold).toBeGreaterThanOrEqual(0)
+    expect(dismissed).toHaveLength(2)
+  })
+
+  it('barracks discount reduces party upkeep correctly', () => {
+    const party = [
+      makePartyMember({ id: 'a', name: 'Alice', dailyCost: 20 }),
+    ]
+    // 15% discount (1 level barracks): cost = floor(20 * (1 - 0.15)) = floor(17) = 17
+    const { newGold, remainingParty } = processPartyUpkeep(party, 100, 15)
+
+    expect(newGold).toBe(83) // 100 - 17
+    expect(remainingParty).toHaveLength(1)
+  })
+
+  it('applies 45% discount with 3 levels of barracks', () => {
+    const party = [
+      makePartyMember({ id: 'a', name: 'Alice', dailyCost: 20 }),
+    ]
+    // 45% discount: cost = floor(20 * (1 - 0.45)) = floor(11) = 11
+    const { newGold, remainingParty } = processPartyUpkeep(party, 100, 45)
+
+    expect(newGold).toBe(89) // 100 - 11
+    expect(remainingParty).toHaveLength(1)
+  })
+
+  it('handles empty party without error', () => {
+    const { remainingParty, newGold, dismissed } = processPartyUpkeep([], 100, 0)
+
+    expect(remainingParty).toHaveLength(0)
+    expect(newGold).toBe(100)
+    expect(dismissed).toHaveLength(0)
+  })
+
+  it('retains zero-cost companions even when gold is zero', () => {
+    const party = [
+      makePartyMember({ id: 'quest', name: 'Quest NPC', dailyCost: 0 }),
+      makePartyMember({ id: 'paid', name: 'Hired', dailyCost: 10 }),
+    ]
+    const { remainingParty, dismissed } = processPartyUpkeep(party, 0, 0)
+
+    expect(dismissed).toContain('Hired')
+    expect(remainingParty.map(m => m.name)).toContain('Quest NPC')
+  })
+})

--- a/src/app/tap-tap-adventure/config/baseBuildings.ts
+++ b/src/app/tap-tap-adventure/config/baseBuildings.ts
@@ -15,6 +15,7 @@ export interface CampBonuses {
   reputationGainBonusPct: number
   mountUpkeepDiscountPct: number
   combatSuccessBonus: number
+  partyUpkeepDiscountPct: number
 }
 
 export const BASE_BUILDINGS: BaseBuilding[] = [
@@ -72,6 +73,15 @@ export const BASE_BUILDINGS: BaseBuilding[] = [
     costPerLevel: [100, 250, 600],
     effectDescription: '+5% combat success per level',
   },
+  {
+    id: 'barracks',
+    name: 'Barracks',
+    description: 'Quarters for your companions, reducing their daily upkeep.',
+    icon: '\uD83C\uDFE0',
+    maxLevel: 3,
+    costPerLevel: [100, 275, 650],
+    effectDescription: '-15% party member upkeep per level',
+  },
 ]
 
 export function getBuildingById(id: string): BaseBuilding | undefined {
@@ -86,6 +96,7 @@ export function getCampBonuses(buildingLevels: Record<string, number>): CampBonu
     reputationGainBonusPct: 0,
     mountUpkeepDiscountPct: 0,
     combatSuccessBonus: 0,
+    partyUpkeepDiscountPct: 0,
   }
 
   for (const building of BASE_BUILDINGS) {
@@ -110,6 +121,9 @@ export function getCampBonuses(buildingLevels: Record<string, number>): CampBonu
         break
       case 'watchtower':
         bonuses.combatSuccessBonus += 0.05 * level
+        break
+      case 'barracks':
+        bonuses.partyUpkeepDiscountPct += 15 * level
         break
     }
   }

--- a/src/app/tap-tap-adventure/hooks/useGameStore.ts
+++ b/src/app/tap-tap-adventure/hooks/useGameStore.ts
@@ -27,6 +27,7 @@ import { Mount } from '@/app/tap-tap-adventure/models/mount'
 import { assignMountPersonality, getMountMaxHp } from '@/app/tap-tap-adventure/config/mounts'
 import { Mercenary } from '@/app/tap-tap-adventure/models/mercenary'
 import { PartyMember, MAX_PARTY_SIZE } from '@/app/tap-tap-adventure/models/partyMember'
+import { processPartyUpkeep } from '@/app/tap-tap-adventure/lib/partyUpkeep'
 import { getClassForNPC, deriveNPCCombatStats } from '@/app/tap-tap-adventure/lib/classGenerator'
 import { getMercenaryMaxHp } from '@/app/tap-tap-adventure/config/mercenaries'
 import { TimedQuest } from '@/app/tap-tap-adventure/models/quest'
@@ -346,6 +347,20 @@ export const useGameStore = create<GameStore>()(
                 updatedCharacter = { ...updatedCharacter, activeMercenary: null }
               } else {
                 updatedCharacter = { ...updatedCharacter, gold: mercGold }
+              }
+            }
+
+            // Party member daily upkeep
+            if (newDay > oldDay && updatedCharacter.party?.length > 0) {
+              const { remainingParty, newGold } = processPartyUpkeep(
+                updatedCharacter.party,
+                updatedCharacter.gold,
+                campBonuses.partyUpkeepDiscountPct
+              )
+              updatedCharacter = {
+                ...updatedCharacter,
+                gold: newGold,
+                party: remainingParty,
               }
             }
 

--- a/src/app/tap-tap-adventure/lib/partyUpkeep.ts
+++ b/src/app/tap-tap-adventure/lib/partyUpkeep.ts
@@ -1,0 +1,28 @@
+import { PartyMember } from '@/app/tap-tap-adventure/models/partyMember'
+
+export function processPartyUpkeep(
+  party: PartyMember[],
+  gold: number,
+  discountPct: number
+): { remainingParty: PartyMember[]; newGold: number; dismissed: string[] } {
+  const sorted = [...party].sort((a, b) => (b.dailyCost ?? 0) - (a.dailyCost ?? 0))
+  let currentGold = gold
+  const remainingParty: PartyMember[] = []
+  const dismissed: string[] = []
+
+  for (const member of sorted) {
+    if ((member.dailyCost ?? 0) <= 0) {
+      remainingParty.push(member)
+      continue
+    }
+    const cost = Math.max(0, Math.floor((member.dailyCost ?? 0) * (1 - discountPct / 100)))
+    if (currentGold >= cost) {
+      currentGold -= cost
+      remainingParty.push(member)
+    } else {
+      dismissed.push(member.name)
+    }
+  }
+
+  return { remainingParty, newGold: currentGold, dismissed }
+}


### PR DESCRIPTION
## Summary
- Party members now have their daily upkeep deducted at day boundaries (every 50 steps)
- When gold is insufficient, the most expensive member is dismissed first; quest-reward companions (free) are never dismissed
- New **Barracks** camp building provides -15% party upkeep per level (max 3 levels, -45% at max)
- Extracted `processPartyUpkeep()` as a pure, testable function

Closes #382

## Changes
- `baseBuildings.ts` — added `partyUpkeepDiscountPct` to CampBonuses, added Barracks building
- `lib/partyUpkeep.ts` (new) — pure function: sorts party by cost, applies discount, deducts gold, dismisses unaffordable members
- `useGameStore.ts` — wired party upkeep into `incrementDistance` after mount/mercenary upkeep
- 8 unit tests covering deduction, free companions, dismiss ordering, gold floor, and barracks discount

## Test plan
- [ ] Travel 50+ steps with party members — verify gold deducted
- [ ] Have insufficient gold — verify most expensive member dismissed
- [ ] Quest companion (dailyCost=0) — verify no charge
- [ ] Build Barracks — verify upkeep reduced
- [ ] All 826 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)