### PR TITLE
feat: tavern companion recruitment and shared helper

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -4,6 +4,9 @@ module.exports = {
   testEnvironment: 'jsdom',
   testMatch: ['**/__tests__/**/*.test.ts', '**/__tests__/**/*.test.tsx'],
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/src/$1',
+  },
   globals: {
     'ts-jest': {
       tsconfig: 'tsconfig.json',

--- a/src/app/tap-tap-adventure/__tests__/partyRecruitment.test.ts
+++ b/src/app/tap-tap-adventure/__tests__/partyRecruitment.test.ts
@@ -1,0 +1,179 @@
+import { createPartyMember, getTavernRecruits } from '@/app/tap-tap-adventure/lib/partyRecruitment'
+
+describe('createPartyMember', () => {
+  it('returns a valid PartyMember with generatedClass populated', () => {
+    const member = createPartyMember({
+      id: 'test-1',
+      name: 'Rowan',
+      level: 3,
+      dailyCost: 2,
+    })
+    expect(member.id).toBe('test-1')
+    expect(member.name).toBe('Rowan')
+    expect(member.level).toBe(3)
+    expect(member.dailyCost).toBe(2)
+    expect(member.generatedClass).toBeDefined()
+    expect(member.hp).toBeGreaterThan(0)
+    expect(member.maxHp).toBeGreaterThan(0)
+    expect(member.stats).toBeDefined()
+    expect(typeof member.stats.strength).toBe('number')
+    expect(typeof member.stats.intelligence).toBe('number')
+    expect(typeof member.stats.luck).toBe('number')
+    expect(typeof member.stats.charisma).toBe('number')
+  })
+
+  it('className matches generatedClass.name (shared class generation)', () => {
+    const member = createPartyMember({
+      id: 'test-2',
+      name: 'Kael',
+      level: 5,
+      dailyCost: 3,
+    })
+    expect(member.className).toBe(member.generatedClass?.name)
+  })
+
+  it('uses provided icon when given', () => {
+    const member = createPartyMember({
+      id: 'test-3',
+      name: 'Lyra',
+      icon: '🧙',
+      level: 1,
+      dailyCost: 1,
+    })
+    expect(member.icon).toBe('🧙')
+  })
+
+  it('falls back to default icon when not provided', () => {
+    const member = createPartyMember({
+      id: 'test-4',
+      name: 'Thorne',
+      level: 1,
+      dailyCost: 1,
+    })
+    expect(member.icon).toBe('⚔️')
+  })
+
+  it('defaults rarity to common', () => {
+    const member = createPartyMember({
+      id: 'test-5',
+      name: 'Mira',
+      level: 1,
+      dailyCost: 1,
+    })
+    expect(member.rarity).toBe('common')
+  })
+
+  it('uses provided rarity', () => {
+    const member = createPartyMember({
+      id: 'test-6',
+      name: 'Dax',
+      level: 1,
+      dailyCost: 2,
+      rarity: 'rare',
+    })
+    expect(member.rarity).toBe('rare')
+  })
+
+  it('defaults role to combatant', () => {
+    const member = createPartyMember({
+      id: 'test-7',
+      name: 'Selene',
+      level: 1,
+      dailyCost: 1,
+    })
+    expect(member.role).toBe('combatant')
+  })
+
+  it('has equipment slots initialized to null', () => {
+    const member = createPartyMember({
+      id: 'test-8',
+      name: 'Flint',
+      level: 1,
+      dailyCost: 1,
+    })
+    expect(member.equipment.weapon).toBeNull()
+    expect(member.equipment.armor).toBeNull()
+    expect(member.equipment.accessory).toBeNull()
+  })
+
+  it('recruitCost defaults to 0', () => {
+    const member = createPartyMember({
+      id: 'test-9',
+      name: 'Ivy',
+      level: 1,
+      dailyCost: 1,
+    })
+    expect(member.recruitCost).toBe(0)
+  })
+})
+
+describe('getTavernRecruits', () => {
+  it('returns exactly 2 recruits', () => {
+    const recruits = getTavernRecruits(5, 'green_meadows', 1)
+    expect(recruits).toHaveLength(2)
+  })
+
+  it('is deterministic — same args always produce the same recruits', () => {
+    const recruits1 = getTavernRecruits(5, 'green_meadows', 1)
+    const recruits2 = getTavernRecruits(5, 'green_meadows', 1)
+    expect(recruits1[0].id).toBe(recruits2[0].id)
+    expect(recruits1[0].name).toBe(recruits2[0].name)
+    expect(recruits1[1].id).toBe(recruits2[1].id)
+    expect(recruits1[1].name).toBe(recruits2[1].name)
+  })
+
+  it('varies by region', () => {
+    const recruitsA = getTavernRecruits(5, 'green_meadows', 1)
+    const recruitsB = getTavernRecruits(5, 'dark_forest', 1)
+    // At least one recruit should differ between regions
+    const sameFirst = recruitsA[0].name === recruitsB[0].name && recruitsA[0].rarity === recruitsB[0].rarity
+    const sameSecond = recruitsA[1].name === recruitsB[1].name && recruitsA[1].rarity === recruitsB[1].rarity
+    expect(sameFirst && sameSecond).toBe(false)
+  })
+
+  it('varies by day', () => {
+    const recruitsDay1 = getTavernRecruits(5, 'green_meadows', 1)
+    const recruitsDay2 = getTavernRecruits(5, 'green_meadows', 2)
+    // At least one recruit should differ between days
+    const sameFirst = recruitsDay1[0].name === recruitsDay2[0].name && recruitsDay1[0].rarity === recruitsDay2[0].rarity
+    const sameSecond = recruitsDay1[1].name === recruitsDay2[1].name && recruitsDay1[1].rarity === recruitsDay2[1].rarity
+    expect(sameFirst && sameSecond).toBe(false)
+  })
+
+  it('recruits have recruitCost > 0', () => {
+    const recruits = getTavernRecruits(5, 'green_meadows', 1)
+    for (const recruit of recruits) {
+      expect(recruit.recruitCost).toBeGreaterThan(0)
+    }
+  })
+
+  it('recruits have dailyCost > 0', () => {
+    const recruits = getTavernRecruits(5, 'green_meadows', 1)
+    for (const recruit of recruits) {
+      expect(recruit.dailyCost).toBeGreaterThan(0)
+    }
+  })
+
+  it('all recruits have role combatant', () => {
+    const recruits = getTavernRecruits(5, 'green_meadows', 1)
+    for (const recruit of recruits) {
+      expect(recruit.role).toBe('combatant')
+    }
+  })
+
+  it('recruits have valid rarity values', () => {
+    const validRarities = ['common', 'uncommon', 'rare', 'legendary']
+    const recruits = getTavernRecruits(10, 'green_meadows', 1)
+    for (const recruit of recruits) {
+      expect(validRarities).toContain(recruit.rarity)
+    }
+  })
+
+  it('recruits have generatedClass populated', () => {
+    const recruits = getTavernRecruits(5, 'green_meadows', 1)
+    for (const recruit of recruits) {
+      expect(recruit.generatedClass).toBeDefined()
+      expect(recruit.className).toBe(recruit.generatedClass?.name)
+    }
+  })
+})

--- a/src/app/tap-tap-adventure/components/GameUI.tsx
+++ b/src/app/tap-tap-adventure/components/GameUI.tsx
@@ -56,8 +56,7 @@ import { useOnboarding, HintKey } from '@/app/tap-tap-adventure/hooks/useOnboard
 import { StatsPanel } from '@/app/tap-tap-adventure/components/StatsPanel'
 import { RunHistoryPanel } from '@/app/tap-tap-adventure/components/RunHistoryPanel'
 import { NPCDialoguePanel } from './NPCDialoguePanel'
-import type { PartyMember } from '@/app/tap-tap-adventure/models/partyMember'
-import { getClassForNPC, deriveNPCCombatStats } from '@/app/tap-tap-adventure/lib/classGenerator'
+import { createPartyMember } from '@/app/tap-tap-adventure/lib/partyRecruitment'
 import { ContactsList } from './ContactsList'
 import { EventDialog, EventResult } from './EventDialog'
 
@@ -721,27 +720,18 @@ export default function GameUI({ onOpenStatus }: GameUIProps) {
                             setDecisionPoint(null)
                           }}
                           onRecruit={() => {
-                            const npcClass = getClassForNPC(socialEncounter.npc.name)
-                            const combatStats = deriveNPCCombatStats(npcClass, character.level)
-                            const member: PartyMember = {
+                            const member = createPartyMember({
                               id: `npc-${socialEncounter.npc.id}`,
                               name: socialEncounter.npc.name,
                               description: socialEncounter.npc.description,
                               icon: socialEncounter.npc.icon,
-                              className: npcClass.name,
-                              generatedClass: npcClass,
                               level: character.level,
-                              hp: combatStats.hp,
-                              maxHp: combatStats.maxHp,
-                              stats: combatStats.stats,
-                              equipment: { weapon: null, armor: null, accessory: null },
                               dailyCost: Math.max(1, Math.floor(character.level / 2)),
-                              recruitCost: 0,
                               rarity: 'uncommon',
                               personality: socialEncounter.npc.personality,
                               relationship: character.npcEncounters?.[socialEncounter.npc.id]?.disposition ?? 0,
                               role: 'combatant',
-                            }
+                            })
                             const added = addPartyMember(member)
                             if (added) {
                               setShowNPCPanel(false)

--- a/src/app/tap-tap-adventure/components/MercenaryPanel.tsx
+++ b/src/app/tap-tap-adventure/components/MercenaryPanel.tsx
@@ -6,6 +6,9 @@ import { getTavernMercenaries, getMercenaryMaxHp } from '@/app/tap-tap-adventure
 import { useGameStore } from '@/app/tap-tap-adventure/hooks/useGameStore'
 import { FantasyCharacter } from '@/app/tap-tap-adventure/models/character'
 import { Mercenary } from '@/app/tap-tap-adventure/models/mercenary'
+import { getTavernRecruits } from '@/app/tap-tap-adventure/lib/partyRecruitment'
+import { calculateDay } from '@/app/tap-tap-adventure/lib/leveling'
+import { MAX_PARTY_SIZE } from '@/app/tap-tap-adventure/models/partyMember'
 
 interface MercenaryPanelProps {
   character: FantasyCharacter
@@ -57,7 +60,7 @@ function HpBar({ current, max }: { current: number; max: number }) {
 }
 
 export function MercenaryPanel({ character }: MercenaryPanelProps) {
-  const { recruitMercenary, dismissMercenary, setActiveMercenary } = useGameStore()
+  const { recruitMercenary, dismissMercenary, setActiveMercenary, recruitTavernMember, removePartyMember } = useGameStore()
   const [isExpanded, setIsExpanded] = useState(false)
   const [dismissConfirm, setDismissConfirm] = useState<string | null>(null)
 
@@ -67,6 +70,13 @@ export function MercenaryPanel({ character }: MercenaryPanelProps) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [character.level]
   )
+
+  const day = calculateDay(character.distance ?? 0)
+  const tavernRecruits = useMemo(
+    () => getTavernRecruits(character.level, character.currentRegion ?? 'green_meadows', day),
+    [character.level, character.currentRegion, day]
+  )
+  const partyMembers = character.party ?? []
 
   const roster = character.mercenaryRoster ?? []
   const active = character.activeMercenary
@@ -230,6 +240,84 @@ export function MercenaryPanel({ character }: MercenaryPanelProps) {
           </div>
         </div>
       )}
+
+      {/* Party Members */}
+      {partyMembers.length > 0 && (
+        <div>
+          <h4 className="text-xs font-semibold text-slate-400 uppercase mb-2">Companions ({partyMembers.length}/{MAX_PARTY_SIZE})</h4>
+          <div className="space-y-1.5">
+            {partyMembers.map(member => (
+              <div key={member.id} className="bg-[#252638] border border-[#3a3c56] rounded p-2 flex items-center justify-between">
+                <div className="flex items-center gap-1.5">
+                  <span className="text-lg">{member.icon}</span>
+                  <div>
+                    <div className="text-xs font-semibold text-slate-200">{member.customName ?? member.name}</div>
+                    <div className="text-[10px] text-slate-400">{member.className}</div>
+                    <div className="text-[10px] text-slate-500">Lv {member.level} · {member.dailyCost}g/day</div>
+                  </div>
+                </div>
+                <div className="flex items-center gap-1.5">
+                  {dismissConfirm === `party-${member.id}` ? (
+                    <>
+                      <button className="text-[10px] px-1.5 py-0.5 bg-red-900/50 text-red-400 rounded hover:bg-red-800/50"
+                        onClick={() => { removePartyMember(member.id); setDismissConfirm(null) }}>Yes</button>
+                      <button className="text-[10px] px-1.5 py-0.5 bg-slate-700/50 text-slate-300 rounded hover:bg-slate-600/50"
+                        onClick={() => setDismissConfirm(null)}>No</button>
+                    </>
+                  ) : (
+                    <button className="text-[10px] px-1.5 py-0.5 bg-red-900/30 text-red-400 rounded hover:bg-red-800/40 transition-colors"
+                      onClick={() => setDismissConfirm(`party-${member.id}`)}>Dismiss</button>
+                  )}
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Tavern Recruits (Party Members) */}
+      <div>
+        <h4 className="text-xs font-semibold text-slate-400 uppercase mb-2">Hire Companions</h4>
+        {(partyMembers.length >= MAX_PARTY_SIZE) && (
+          <div className="text-[10px] text-amber-500 mb-2">Party full ({MAX_PARTY_SIZE}/{MAX_PARTY_SIZE}). Dismiss a companion to hire more.</div>
+        )}
+        <div className="space-y-1.5">
+          {tavernRecruits.map(recruit => {
+            const alreadyHave = partyMembers.some(m => m.name === recruit.name)
+            const canAfford = character.gold >= (recruit.recruitCost ?? 0)
+            const partyFull = partyMembers.length >= MAX_PARTY_SIZE
+            const disabled = !canAfford || partyFull || alreadyHave
+
+            return (
+              <div key={recruit.id} className="bg-[#252638] border border-[#3a3c56] rounded p-2 flex items-center justify-between">
+                <div className="flex items-center gap-1.5">
+                  <span className="text-lg">{recruit.icon}</span>
+                  <div>
+                    <div className="text-xs font-semibold text-slate-200">{recruit.name}</div>
+                    <div className="text-[10px] text-slate-400">{recruit.className}</div>
+                    <div className="text-[10px] text-slate-500">Lv {recruit.level} · {recruit.dailyCost}g/day</div>
+                  </div>
+                </div>
+                <div className="text-right">
+                  {alreadyHave ? (
+                    <span className="text-[10px] text-green-400">In party</span>
+                  ) : (
+                    <button
+                      className={`text-[10px] px-2 py-1 rounded transition-colors ${
+                        disabled ? 'bg-slate-700/40 text-slate-500 cursor-not-allowed' : 'bg-amber-700/50 text-amber-300 hover:bg-amber-600/60'
+                      }`}
+                      disabled={disabled}
+                      onClick={() => recruitTavernMember(recruit)}
+                    >
+                      {recruit.recruitCost}g Hire
+                    </button>
+                  )}
+                </div>
+              </div>
+            )
+          })}
+        </div>
+      </div>
 
       {/* Tavern */}
       <div>

--- a/src/app/tap-tap-adventure/hooks/useGameStore.ts
+++ b/src/app/tap-tap-adventure/hooks/useGameStore.ts
@@ -130,6 +130,7 @@ export interface GameStore {
   setActiveMercenary: (mercenaryId: string) => void
   addPartyMember: (member: PartyMember) => boolean
   removePartyMember: (memberId: string) => void
+  recruitTavernMember: (member: PartyMember) => boolean
   renamePartyMember: (memberId: string, newName: string) => void
   healPartyMember: (memberId: string, amount: number) => void
   addHeirloom: (item: Item) => void
@@ -982,6 +983,26 @@ export const useGameStore = create<GameStore>()(
             char.party.push(member)
           })
         )
+        return true
+      },
+
+      recruitTavernMember: (member: PartyMember) => {
+        const state = get()
+        const characters = state.gameState.characters
+        const idx = characters.findIndex(c => c.id === state.gameState.selectedCharacterId)
+        if (idx < 0) return false
+        const char = characters[idx]
+
+        if ((char.party?.length ?? 0) >= MAX_PARTY_SIZE) return false
+        if (char.gold < (member.recruitCost ?? 0)) return false
+        if (char.party?.some(m => m.id === member.id)) return false
+
+        set(produce((draft: GameStore) => {
+          const dChar = draft.gameState.characters[idx]
+          dChar.gold -= member.recruitCost ?? 0
+          if (!dChar.party) dChar.party = []
+          dChar.party.push(member)
+        }))
         return true
       },
 

--- a/src/app/tap-tap-adventure/lib/partyRecruitment.ts
+++ b/src/app/tap-tap-adventure/lib/partyRecruitment.ts
@@ -1,0 +1,100 @@
+import { getClassForNPC, deriveNPCCombatStats } from '@/app/tap-tap-adventure/lib/classGenerator'
+import type { PartyMember } from '@/app/tap-tap-adventure/models/partyMember'
+import { seededRandom } from '@/app/tap-tap-adventure/lib/landmarkGenerator'
+
+// NPC names pool for tavern recruits — unique adventurers looking for work
+const TAVERN_RECRUIT_NAMES = [
+  'Rowan', 'Kael', 'Lyra', 'Thorne', 'Mira',
+  'Dax', 'Selene', 'Flint', 'Ivy', 'Bram',
+  'Zara', 'Orrin', 'Piper', 'Jareth', 'Nessa',
+  'Cade', 'Ember', 'Sable', 'Wren', 'Gareth',
+]
+
+const TAVERN_RECRUIT_ICONS = [
+  '🧝', '🧙', '🗡️', '🛡️', '🏹',
+  '⚔️', '🔮', '🪓', '🐺', '🌿',
+]
+
+export function createPartyMember(params: {
+  id: string
+  name: string
+  description?: string
+  icon?: string
+  level: number
+  dailyCost: number
+  recruitCost?: number
+  rarity?: PartyMember['rarity']
+  personality?: string
+  relationship?: number
+  role?: PartyMember['role']
+}): PartyMember {
+  const npcClass = getClassForNPC(params.name)
+  const combatStats = deriveNPCCombatStats(npcClass, params.level)
+  return {
+    id: params.id,
+    name: params.name,
+    description: params.description ?? `A ${npcClass.name} looking for adventure.`,
+    icon: params.icon ?? '⚔️',
+    className: npcClass.name,
+    generatedClass: npcClass,
+    level: params.level,
+    hp: combatStats.hp,
+    maxHp: combatStats.maxHp,
+    stats: combatStats.stats,
+    equipment: { weapon: null, armor: null, accessory: null },
+    dailyCost: params.dailyCost,
+    recruitCost: params.recruitCost ?? 0,
+    rarity: params.rarity ?? 'common',
+    personality: params.personality,
+    relationship: params.relationship ?? 0,
+    role: params.role ?? 'combatant',
+  }
+}
+
+/**
+ * Generate tavern recruits — adventurers available for hire.
+ * Deterministic per region + day so they don't re-randomize on re-render.
+ */
+export function getTavernRecruits(characterLevel: number, regionId: string, day: number): PartyMember[] {
+  const seed = `tavern-${regionId}-${day}`
+  const rng = seededRandom(seed)
+
+  // Pick 2 unique names from pool
+  const shuffledNames = [...TAVERN_RECRUIT_NAMES].sort(() => rng() - 0.5)
+  const count = 2
+
+  const recruits: PartyMember[] = []
+  for (let i = 0; i < count; i++) {
+    const name = shuffledNames[i]
+    const iconIdx = Math.floor(rng() * TAVERN_RECRUIT_ICONS.length)
+
+    // Rarity based on level
+    let rarity: PartyMember['rarity'] = 'common'
+    const roll = rng()
+    if (characterLevel >= 8 && roll > 0.7) rarity = 'rare'
+    else if (characterLevel >= 4 && roll > 0.6) rarity = 'uncommon'
+    else if (roll > 0.8) rarity = 'uncommon'
+
+    // Recruit cost scales with rarity and level
+    const baseCost = { common: 30, uncommon: 75, rare: 150, legendary: 300 }[rarity]
+    const recruitCost = baseCost + characterLevel * 5
+
+    // Daily cost scales with rarity
+    const dailyCostBase = { common: 1, uncommon: 2, rare: 4, legendary: 8 }[rarity]
+    const dailyCost = Math.max(1, dailyCostBase + Math.floor(characterLevel / 3))
+
+    recruits.push(createPartyMember({
+      id: `tavern-${name.toLowerCase()}-${regionId}-${day}`,
+      name,
+      icon: TAVERN_RECRUIT_ICONS[iconIdx],
+      level: Math.max(1, characterLevel - 1 + Math.floor(rng() * 3)),  // level +-1 from player
+      dailyCost,
+      recruitCost,
+      rarity,
+      personality: undefined,
+      role: 'combatant',
+    }))
+  }
+
+  return recruits
+}


### PR DESCRIPTION
## Summary
- New **tavern companion hiring** system: 2 recruitable adventurers per region/day with generated classes, level-scaling stats, and gold costs
- Shared `createPartyMember()` helper used by both tavern and NPC dialogue recruitment
- `getTavernRecruits()` generates deterministic recruits seeded by region + day (no re-randomization on re-render)
- New `recruitTavernMember` store action with gold deduction and party capacity checks
- MercenaryPanel now shows **Companions** (current party) and **Hire Companions** (tavern recruits) sections alongside existing mercenary system
- Refactored NPC dialogue recruitment to use the shared helper (removes duplication)

Partially addresses #383 (tavern + NPC recruitment paths; event/quest/landmark paths are future work)

## Changes
- `lib/partyRecruitment.ts` (new) — `createPartyMember()` helper, `getTavernRecruits()` with 20-name pool
- `hooks/useGameStore.ts` — added `recruitTavernMember` action
- `components/MercenaryPanel.tsx` — companions list + hire companions UI
- `components/GameUI.tsx` — refactored NPC recruitment to use shared helper
- `jest.config.js` — fixed `@/` path alias for tests
- 18 new unit tests

## Test plan
- [ ] Open Party panel in town — verify "Hire Companions" section with 2 recruits
- [ ] Hire a companion — verify gold deducted, companion appears in party
- [ ] Travel to new region — verify different recruits available
- [ ] Dismiss a companion from the panel
- [ ] Recruit NPC via dialogue — verify still works with shared helper
- [ ] All tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)