### PR TITLE
feat: party members participate in combat (v1)

### DIFF
--- a/src/app/api/v1/tap-tap-adventure/combat/action/route.ts
+++ b/src/app/api/v1/tap-tap-adventure/combat/action/route.ts
@@ -54,6 +54,22 @@ export async function POST(req: NextRequest) {
       }
     }
 
+    // Persist party member HP from combat state back to character
+    if (updatedCombat.partyMemberStates?.length && updatedCharacter.party?.length) {
+      updatedCharacter = {
+        ...updatedCharacter,
+        party: updatedCharacter.party.map((member: any) => {
+          const combatMember = updatedCombat.partyMemberStates?.find((m: any) => m.memberId === member.id)
+          if (!combatMember) return member
+          // After victory, KO'd members get 1 HP back
+          const postCombatHp = combatMember.isKnockedOut && updatedCombat.status === 'victory'
+            ? 1
+            : combatMember.hp
+          return { ...member, hp: Math.max(0, postCombatHp) }
+        }),
+      }
+    }
+
     return NextResponse.json({
       combatState: updatedCombat,
       rewards,

--- a/src/app/api/v1/tap-tap-adventure/combat/start/route.ts
+++ b/src/app/api/v1/tap-tap-adventure/combat/start/route.ts
@@ -59,6 +59,20 @@ export async function POST(req: NextRequest) {
 
     const playerState = initializePlayerCombatState(character)
 
+    // Initialize party member combat states
+    const partyMemberStates = ((character.party ?? []) as any[])
+      .filter((m: any) => m.role === 'combatant' && m.hp > 0)
+      .map((m: any) => ({
+        memberId: m.id,
+        name: m.customName ?? m.name,
+        icon: m.icon ?? '⚔️',
+        hp: m.hp,
+        maxHp: m.maxHp,
+        attack: m.stats?.strength ?? 5,
+        defense: Math.floor((m.stats?.strength ?? 5) / 2),
+        isKnockedOut: false,
+      }))
+
     // Clear exploration shield — it's been consumed by combat init
     const updatedCharacter = character.explorationShield
       ? { ...character, explorationShield: 0 }
@@ -79,6 +93,7 @@ export async function POST(req: NextRequest) {
       isSecretBoss: isSecretBoss || undefined,
       combatDistance: region.startingCombatDistance ?? 'mid',
       ...(pendingRegionId ? { pendingRegionId } : {}),
+      partyMemberStates: partyMemberStates.length > 0 ? partyMemberStates : undefined,
     }
 
     return NextResponse.json({ combatState, updatedCharacter: character.explorationShield ? updatedCharacter : undefined })

--- a/src/app/tap-tap-adventure/__tests__/partyCombat.test.ts
+++ b/src/app/tap-tap-adventure/__tests__/partyCombat.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from 'vitest'
+
+import { applyPartyMemberAttacks } from '@/app/tap-tap-adventure/lib/combatEngine'
+import { CombatEnemy, PartyMemberCombatState } from '@/app/tap-tap-adventure/models/combat'
+
+const baseEnemy: CombatEnemy = {
+  id: 'enemy-1',
+  name: 'Goblin',
+  description: 'A nasty goblin',
+  hp: 30,
+  maxHp: 30,
+  attack: 8,
+  defense: 3,
+  level: 2,
+  goldReward: 15,
+}
+
+function makePartyMember(overrides: Partial<PartyMemberCombatState> = {}): PartyMemberCombatState {
+  return {
+    memberId: 'member-1',
+    name: 'Rowan',
+    icon: '⚔️',
+    hp: 20,
+    maxHp: 20,
+    attack: 8,
+    defense: 3,
+    isKnockedOut: false,
+    ...overrides,
+  }
+}
+
+describe('applyPartyMemberAttacks', () => {
+  it('deals damage to enemy', () => {
+    const member = makePartyMember()
+    const result = applyPartyMemberAttacks([member], baseEnemy, 1)
+    expect(result.enemy.hp).toBeLessThan(baseEnemy.hp)
+    expect(result.logs.length).toBeGreaterThan(0)
+    expect(result.logs[0].actor).toBe('party_member')
+    expect(result.logs[0].action).toBe('attack')
+  })
+
+  it('KO\'d members do not attack', () => {
+    const member = makePartyMember({ isKnockedOut: true })
+    const result = applyPartyMemberAttacks([member], baseEnemy, 1)
+    expect(result.enemy.hp).toBe(baseEnemy.hp)
+    expect(result.logs.length).toBe(0)
+    expect(result.killedEnemy).toBe(false)
+  })
+
+  it('low HP members defend instead of attacking', () => {
+    // HP at 20% of max — below the 30% threshold
+    const member = makePartyMember({ hp: 4, maxHp: 20 })
+    const result = applyPartyMemberAttacks([member], baseEnemy, 1)
+    expect(result.enemy.hp).toBe(baseEnemy.hp)
+    expect(result.logs.length).toBe(1)
+    expect(result.logs[0].action).toBe('defend')
+    expect(result.killedEnemy).toBe(false)
+  })
+
+  it('enemy can be killed by party member', () => {
+    const weakEnemy: CombatEnemy = { ...baseEnemy, hp: 1, defense: 0 }
+    const strongMember = makePartyMember({ attack: 50 })
+    const result = applyPartyMemberAttacks([strongMember], weakEnemy, 1)
+    expect(result.killedEnemy).toBe(true)
+    expect(result.enemy.hp).toBe(0)
+    const victoryLog = result.logs.find(l => l.action === 'victory')
+    expect(victoryLog).toBeDefined()
+    expect(victoryLog?.actor).toBe('party_member')
+  })
+
+  it('multiple members attack in sequence and stop when enemy is dead', () => {
+    const weakEnemy: CombatEnemy = { ...baseEnemy, hp: 1, defense: 0 }
+    const members = [
+      makePartyMember({ memberId: 'member-1', name: 'Rowan', attack: 50 }),
+      makePartyMember({ memberId: 'member-2', name: 'Kael', attack: 50 }),
+    ]
+    const result = applyPartyMemberAttacks(members, weakEnemy, 1)
+    expect(result.killedEnemy).toBe(true)
+    // Only one attack log since second member skips after enemy is dead
+    const attackLogs = result.logs.filter(l => l.action === 'attack')
+    expect(attackLogs.length).toBe(1)
+  })
+
+  it('returns updated partyStates unchanged when no attack occurs', () => {
+    const member = makePartyMember({ isKnockedOut: true })
+    const result = applyPartyMemberAttacks([member], baseEnemy, 1)
+    expect(result.partyStates[0].memberId).toBe(member.memberId)
+    expect(result.partyStates[0].isKnockedOut).toBe(true)
+  })
+
+  it('PartyMemberCombatState initialization from party data maps correctly', () => {
+    // Simulate what the start route does
+    const partyMember = {
+      id: 'pm-1',
+      name: 'Lyra',
+      customName: 'Lyra the Bold',
+      icon: '🧙',
+      hp: 15,
+      maxHp: 20,
+      role: 'combatant',
+      stats: { strength: 10, intelligence: 5, luck: 3, charisma: 4 },
+    }
+    const state: PartyMemberCombatState = {
+      memberId: partyMember.id,
+      name: partyMember.customName ?? partyMember.name,
+      icon: partyMember.icon ?? '⚔️',
+      hp: partyMember.hp,
+      maxHp: partyMember.maxHp,
+      attack: partyMember.stats?.strength ?? 5,
+      defense: Math.floor((partyMember.stats?.strength ?? 5) / 2),
+      isKnockedOut: false,
+    }
+    expect(state.memberId).toBe('pm-1')
+    expect(state.name).toBe('Lyra the Bold')
+    expect(state.icon).toBe('🧙')
+    expect(state.attack).toBe(10)
+    expect(state.defense).toBe(5)
+    expect(state.isKnockedOut).toBe(false)
+  })
+})

--- a/src/app/tap-tap-adventure/components/CombatUI.tsx
+++ b/src/app/tap-tap-adventure/components/CombatUI.tsx
@@ -499,6 +499,16 @@ export function CombatUI({ combatState }: CombatUIProps) {
             color="text-amber-400"
           />
         )}
+        {/* Party member HP bars */}
+        {combatState.partyMemberStates?.map(member => (
+          <HpBar
+            key={member.memberId}
+            current={member.hp}
+            max={member.maxHp}
+            label={`${member.icon} ${member.name}${member.isKnockedOut ? ' (KO)' : ''}`}
+            color={member.isKnockedOut ? 'text-slate-500' : 'text-emerald-400'}
+          />
+        ))}
         {maxMana > 0 && (
           <ManaBar current={currentMana} max={maxMana} />
         )}

--- a/src/app/tap-tap-adventure/lib/combatEngine.ts
+++ b/src/app/tap-tap-adventure/lib/combatEngine.ts
@@ -14,6 +14,7 @@ import {
   CombatPlayerState,
   CombatState,
   EnemyTelegraph,
+  PartyMemberCombatState,
   StatusEffect,
   TurnPhase,
 } from '@/app/tap-tap-adventure/models/combat'
@@ -589,6 +590,62 @@ function applyMercenaryAutoAttack(
 }
 
 /**
+ * Party member auto-attacks: each non-KO party member attacks the enemy.
+ * Simple v1: attack only, defend if HP < 30%.
+ */
+export function applyPartyMemberAttacks(
+  partyStates: PartyMemberCombatState[],
+  enemy: CombatEnemy,
+  turnNumber: number
+): { enemy: CombatEnemy; partyStates: PartyMemberCombatState[]; logs: CombatLogEntry[]; killedEnemy: boolean } {
+  const logs: CombatLogEntry[] = []
+  let updatedEnemy = { ...enemy }
+  const updatedParty = partyStates.map(m => ({ ...m }))
+  let killedEnemy = false
+
+  for (const member of updatedParty) {
+    if (member.isKnockedOut || killedEnemy) continue
+
+    // If HP < 30%, defend instead of attacking
+    if (member.hp / member.maxHp < 0.3) {
+      logs.push({
+        turn: turnNumber,
+        actor: 'party_member' as const,
+        action: 'defend',
+        description: `${member.icon} ${member.name} takes a defensive stance.`,
+      })
+      continue
+    }
+
+    // Attack: strength-based damage with variance
+    const baseDmg = member.attack
+    const raw = baseDmg - updatedEnemy.defense * 0.3 + (Math.random() - 0.5) * baseDmg * 0.3
+    const damage = Math.max(1, Math.round(raw))
+    updatedEnemy = { ...updatedEnemy, hp: Math.max(0, updatedEnemy.hp - damage) }
+
+    logs.push({
+      turn: turnNumber,
+      actor: 'party_member' as const,
+      action: 'attack',
+      damage,
+      description: `${member.icon} ${member.name} attacks ${enemy.name} for ${damage} damage!`,
+    })
+
+    if (updatedEnemy.hp <= 0) {
+      killedEnemy = true
+      logs.push({
+        turn: turnNumber,
+        actor: 'party_member' as const,
+        action: 'victory',
+        description: `${member.name} delivers the killing blow on ${enemy.name}!`,
+      })
+    }
+  }
+
+  return { enemy: updatedEnemy, partyStates: updatedParty, logs, killedEnemy }
+}
+
+/**
  * Boss phase change: when a boss drops below 50% HP, boost their stats.
  * For the final boss, supports 3 phases triggered at 66% and 33% HP.
  */
@@ -793,6 +850,7 @@ export function processPlayerAction(
   let mountDied = false
   const bossAlreadyPhased = isBoss && !combatState.isFinalBoss ? enemy.name.includes('(Enraged)') : false
   let combatDistance: CombatDistance = combatState.combatDistance ?? 'mid'
+  let partyMemberStates = combatState.partyMemberStates ? combatState.partyMemberStates.map(m => ({ ...m })) : undefined
   // Only propagate combatDistance in returns if the original state had it set
   // This ensures backward compatibility with combat states created before range was added
   let rangeSystemActive = combatState.combatDistance !== undefined
@@ -830,6 +888,7 @@ export function processPlayerAction(
         combatLog: [...combatLog, ...newLogs],
         ...(rangeSystemActive ? { combatDistance } : {}),
         turnPhase: 'player',
+        partyMemberStates,
       },
     }
   }
@@ -888,6 +947,7 @@ export function processPlayerAction(
             isBoss,
             ...(rangeSystemActive ? { combatDistance } : {}),
             turnPhase: 'player',
+            partyMemberStates,
           },
           consumedItemId,
         }
@@ -1342,6 +1402,7 @@ export function processPlayerAction(
         isBoss,
         ...(rangeSystemActive ? { combatDistance } : {}),
         turnPhase: 'player',
+        partyMemberStates,
       },
       consumedItemId,
     }
@@ -1701,6 +1762,42 @@ export function processPlayerAction(
     }
   }
 
+  // Enemy occasionally strikes a party member (separate from main attack)
+  if (status === 'active' && partyMemberStates?.length) {
+    const aliveMembers = partyMemberStates.filter(m => !m.isKnockedOut)
+    if (aliveMembers.length > 0 && Math.random() < 0.25) {
+      const targetIdx = Math.floor(Math.random() * aliveMembers.length)
+      const target = aliveMembers[targetIdx]
+      const strikeDmg = Math.max(1, Math.floor(enemy.attack * 0.4) - target.defense)
+      const memberIdx = partyMemberStates.findIndex(m => m.memberId === target.memberId)
+      const newHp = Math.max(0, partyMemberStates[memberIdx].hp - strikeDmg)
+      const isKnockedOut = newHp <= 0
+      partyMemberStates[memberIdx] = {
+        ...partyMemberStates[memberIdx],
+        hp: newHp,
+        isKnockedOut,
+      }
+      newLogs.push({
+        turn: turnNumber,
+        actor: 'enemy' as const,
+        action: 'attack',
+        damage: strikeDmg,
+        description: `${enemy.name} lashes out at ${target.name} for ${strikeDmg} damage!${isKnockedOut ? ` ${target.name} is knocked out!` : ''}`,
+      })
+    }
+  }
+
+  // Party member auto-attacks fire at end of each full turn
+  if (status === 'active' && partyMemberStates?.length) {
+    const partyResult = applyPartyMemberAttacks(partyMemberStates, enemy, turnNumber)
+    enemy = partyResult.enemy
+    partyMemberStates = partyResult.partyStates
+    newLogs.push(...partyResult.logs)
+    if (partyResult.killedEnemy) {
+      status = 'victory'
+    }
+  }
+
   // Tick buffs at end of full turn
   playerState = tickBuffs(playerState)
 
@@ -1784,6 +1881,7 @@ export function processPlayerAction(
       isBoss,
       ...(rangeSystemActive ? { combatDistance } : {}),
       turnPhase: 'enemy_done',
+      partyMemberStates,
     },
     consumedItemId,
     mountDied,

--- a/src/app/tap-tap-adventure/models/combat.ts
+++ b/src/app/tap-tap-adventure/models/combat.ts
@@ -122,13 +122,25 @@ export type CombatActionRequest = z.infer<typeof CombatActionRequestSchema>
 
 export const CombatLogEntrySchema = z.object({
   turn: z.number(),
-  actor: z.enum(['player', 'enemy']),
+  actor: z.enum(['player', 'enemy', 'party_member']),
   action: z.string(),
   damage: z.number().optional(),
   description: z.string(),
   isCritical: z.boolean().optional(),
 })
 export type CombatLogEntry = z.infer<typeof CombatLogEntrySchema>
+
+export const PartyMemberCombatStateSchema = z.object({
+  memberId: z.string(),
+  name: z.string(),
+  icon: z.string().default('⚔️'),
+  hp: z.number(),
+  maxHp: z.number(),
+  attack: z.number(),
+  defense: z.number(),
+  isKnockedOut: z.boolean().default(false),
+})
+export type PartyMemberCombatState = z.infer<typeof PartyMemberCombatStateSchema>
 
 export const CombatStatusSchema = z.enum(['active', 'victory', 'defeat', 'fled'])
 export type CombatStatus = z.infer<typeof CombatStatusSchema>
@@ -162,5 +174,6 @@ export const CombatStateSchema = z.object({
   combatDistance: CombatDistanceSchema.optional(),
   turnPhase: TurnPhaseSchema.optional(),
   pendingRegionId: z.string().optional(),
+  partyMemberStates: z.array(PartyMemberCombatStateSchema).optional(),
 })
 export type CombatState = z.infer<typeof CombatStateSchema>


### PR DESCRIPTION
## Summary
Party members now fight alongside the player in combat with autonomous AI:
- **Auto-attack** each turn using strength-based damage with variance
- **Defend** automatically when HP drops below 30%
- **Enemy targeting**: 25% chance per turn the enemy lashes out at a random party member
- **KO system**: members knocked out at 0 HP, restored to 1 HP on victory
- **HP bars** shown in combat UI with KO state (greyed out)
- **HP sync**: party member HP persisted back to character after combat ends

This is v1 (minimal viable party combat). Future work: spells/abilities, player control, multiple enemies (#385).

Partially addresses #384

## Changes
- `models/combat.ts` — added `PartyMemberCombatState` schema, extended log actor type, added `partyMemberStates` to CombatState
- `lib/combatEngine.ts` — added `applyPartyMemberAttacks()`, enemy targeting, threaded party state through all return paths
- `combat/start/route.ts` — initialize party member combat states from character party
- `combat/action/route.ts` — sync party HP back after combat (KO'd → 1 HP on victory)
- `CombatUI.tsx` — party member HP bars with KO indicators
- 7 new unit tests

## Test plan
- [ ] Enter combat with party members — verify HP bars appear
- [ ] Watch combat log — party members should attack or defend each turn
- [ ] Party member takes damage — HP bar decreases
- [ ] Party member KO'd — label shows (KO), bar grayed out
- [ ] Win combat — KO'd members restored to 1 HP
- [ ] Solo combat (no party) — works identically to before
- [ ] All 851 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)