### PR TITLE
feat: multiple enemies in combat scaling with party size

### DIFF
--- a/src/app/api/v1/tap-tap-adventure/combat/start/route.ts
+++ b/src/app/api/v1/tap-tap-adventure/combat/start/route.ts
@@ -5,7 +5,8 @@ import { getRegion } from '@/app/tap-tap-adventure/config/regions'
 import { buildStoryContext } from '@/app/tap-tap-adventure/lib/contextBuilder'
 import { initializePlayerCombatState } from '@/app/tap-tap-adventure/lib/combatEngine'
 import { generateCombatEncounter, generateBossEncounter, generateMiniBossEncounter, generateFinalBossEncounter } from '@/app/tap-tap-adventure/lib/combatGenerator'
-import { CombatState } from '@/app/tap-tap-adventure/models/combat'
+import { CombatState, CombatEnemy } from '@/app/tap-tap-adventure/models/combat'
+import { getEnemyCount, generateEnemyVariant, scaleBossForParty } from '@/app/tap-tap-adventure/lib/enemyVariants'
 
 export async function POST(req: NextRequest) {
   try {
@@ -73,15 +74,35 @@ export async function POST(req: NextRequest) {
         isKnockedOut: false,
       }))
 
+    const partySize = partyMemberStates.length
+    const isBossEncounter = isFinalBoss || effectiveIsBoss || isMiniBoss
+
+    // Scale boss stats for party size (instead of adding enemies)
+    const finalEnemy: CombatEnemy = isBossEncounter ? scaleBossForParty(enemy, partySize) : enemy
+
+    // Generate a stable combat ID first so we can use it for seeding
+    const combatId = `combat-${Date.now()}-${Math.floor(Math.random() * 10000)}`
+
+    // Generate additional enemies for non-boss fights with party members
+    let additionalEnemies: CombatEnemy[] | undefined
+    if (!isBossEncounter && partySize > 0) {
+      const count = getEnemyCount(partySize, false) - 1 // -1 because primary enemy counts
+      if (count > 0) {
+        additionalEnemies = Array.from({ length: count }, (_, i) =>
+          generateEnemyVariant(finalEnemy, i, combatId)
+        )
+      }
+    }
+
     // Clear exploration shield — it's been consumed by combat init
     const updatedCharacter = character.explorationShield
       ? { ...character, explorationShield: 0 }
       : character
 
     const combatState: CombatState = {
-      id: `combat-${Date.now()}-${Math.floor(Math.random() * 10000)}`,
+      id: combatId,
       eventId: `event-combat-${Date.now()}`,
-      enemy,
+      enemy: finalEnemy,
       playerState,
       turnNumber: 0,
       combatLog: [],
@@ -94,6 +115,7 @@ export async function POST(req: NextRequest) {
       combatDistance: region.startingCombatDistance ?? 'mid',
       ...(pendingRegionId ? { pendingRegionId } : {}),
       partyMemberStates: partyMemberStates.length > 0 ? partyMemberStates : undefined,
+      additionalEnemies,
     }
 
     return NextResponse.json({ combatState, updatedCharacter: character.explorationShield ? updatedCharacter : undefined })

--- a/src/app/tap-tap-adventure/__tests__/multiEnemy.test.ts
+++ b/src/app/tap-tap-adventure/__tests__/multiEnemy.test.ts
@@ -1,0 +1,112 @@
+import { getEnemyCount, generateEnemyVariant, scaleBossForParty } from '../lib/enemyVariants'
+import { CombatEnemy } from '../models/combat'
+
+const baseEnemy: CombatEnemy = {
+  id: 'goblin-1',
+  name: 'Goblin',
+  description: 'A sneaky goblin.',
+  hp: 100,
+  maxHp: 100,
+  attack: 20,
+  defense: 10,
+  level: 5,
+  goldReward: 50,
+}
+
+describe('getEnemyCount', () => {
+  it('returns 1 for solo player (no party)', () => {
+    expect(getEnemyCount(0, false)).toBe(1)
+  })
+
+  it('returns 1 for boss regardless of party size', () => {
+    expect(getEnemyCount(0, true)).toBe(1)
+    expect(getEnemyCount(2, true)).toBe(1)
+    expect(getEnemyCount(5, true)).toBe(1)
+  })
+
+  it('returns 1 or 2 for party size 1', () => {
+    // Run many times to cover both branches
+    const results = new Set<number>()
+    for (let i = 0; i < 100; i++) {
+      results.add(getEnemyCount(1, false))
+    }
+    // Should only contain 1 and/or 2
+    for (const r of results) {
+      expect([1, 2]).toContain(r)
+    }
+  })
+
+  it('returns 2 or 3 for party size 2+', () => {
+    const results = new Set<number>()
+    for (let i = 0; i < 100; i++) {
+      results.add(getEnemyCount(2, false))
+    }
+    for (const r of results) {
+      expect([2, 3]).toContain(r)
+    }
+  })
+})
+
+describe('generateEnemyVariant', () => {
+  it('creates enemy with 50-80% of base stats', () => {
+    const variant = generateEnemyVariant(baseEnemy, 0, 'test-seed')
+    expect(variant.hp).toBeGreaterThanOrEqual(Math.round(baseEnemy.maxHp * 0.5))
+    expect(variant.hp).toBeLessThanOrEqual(Math.round(baseEnemy.maxHp * 0.8) + 1) // +1 for rounding
+    expect(variant.attack).toBeGreaterThanOrEqual(Math.round(baseEnemy.attack * 0.5))
+    expect(variant.attack).toBeLessThanOrEqual(Math.round(baseEnemy.attack * 0.8) + 1)
+    expect(variant.defense).toBeGreaterThanOrEqual(Math.round(baseEnemy.defense * 0.5))
+    expect(variant.defense).toBeLessThanOrEqual(Math.round(baseEnemy.defense * 0.8) + 1)
+  })
+
+  it('gives a different name from base enemy', () => {
+    const variant = generateEnemyVariant(baseEnemy, 0, 'test-seed')
+    expect(variant.name).not.toBe(baseEnemy.name)
+    expect(variant.name).toContain(baseEnemy.name)
+  })
+
+  it('generates a unique id from base enemy', () => {
+    const variant = generateEnemyVariant(baseEnemy, 0, 'test-seed')
+    expect(variant.id).not.toBe(baseEnemy.id)
+    expect(variant.id).toContain(baseEnemy.id)
+  })
+
+  it('reduces gold reward by 50%', () => {
+    const variant = generateEnemyVariant(baseEnemy, 0, 'test-seed')
+    expect(variant.goldReward).toBe(Math.round(baseEnemy.goldReward * 0.5))
+  })
+
+  it('is deterministic for same seed', () => {
+    const v1 = generateEnemyVariant(baseEnemy, 0, 'my-seed')
+    const v2 = generateEnemyVariant(baseEnemy, 0, 'my-seed')
+    expect(v1.hp).toBe(v2.hp)
+    expect(v1.attack).toBe(v2.attack)
+    expect(v1.name).toBe(v2.name)
+  })
+})
+
+describe('scaleBossForParty', () => {
+  it('is identity for partySize=0', () => {
+    const scaled = scaleBossForParty(baseEnemy, 0)
+    expect(scaled).toEqual(baseEnemy)
+  })
+
+  it('scales HP by 25% per party member', () => {
+    const scaled = scaleBossForParty(baseEnemy, 2)
+    expect(scaled.hp).toBe(Math.round(baseEnemy.hp * 1.5))
+    expect(scaled.maxHp).toBe(Math.round(baseEnemy.maxHp * 1.5))
+  })
+
+  it('scales attack by 10% per party member', () => {
+    const scaled = scaleBossForParty(baseEnemy, 3)
+    expect(scaled.attack).toBe(Math.round(baseEnemy.attack * 1.3))
+  })
+
+  it('preserves other fields', () => {
+    const scaled = scaleBossForParty(baseEnemy, 1)
+    expect(scaled.id).toBe(baseEnemy.id)
+    expect(scaled.name).toBe(baseEnemy.name)
+    expect(scaled.defense).toBe(baseEnemy.defense)
+    expect(scaled.level).toBe(baseEnemy.level)
+    expect(scaled.goldReward).toBe(baseEnemy.goldReward)
+  })
+})

--- a/src/app/tap-tap-adventure/components/CombatUI.tsx
+++ b/src/app/tap-tap-adventure/components/CombatUI.tsx
@@ -446,6 +446,29 @@ export function CombatUI({ combatState }: CombatUIProps) {
         <FloatingDamage events={damageEvents.filter(e => e.target === 'enemy')} />
       </div>
 
+      {/* Additional enemies */}
+      {combatState.additionalEnemies?.map((addEnemy, idx) => (
+        addEnemy.hp > 0 ? (
+          <div key={addEnemy.id} className="bg-red-900/10 border border-red-900/30 rounded-lg p-2 space-y-1">
+            <div className="flex justify-between items-center">
+              <span className="text-sm font-semibold text-red-300">{addEnemy.name}</span>
+              <span className="text-[10px] text-slate-400">Lv {addEnemy.level}</span>
+            </div>
+            <HpBar current={addEnemy.hp} max={addEnemy.maxHp} label="" color="text-red-400" />
+            <button
+              className="text-[10px] px-2 py-0.5 bg-red-900/30 text-red-400 rounded hover:bg-red-800/40 transition-colors"
+              onClick={() => handleAction('switch_target', idx.toString())}
+            >
+              Target
+            </button>
+          </div>
+        ) : (
+          <div key={addEnemy.id} className="bg-slate-900/30 border border-slate-800 rounded-lg p-2">
+            <span className="text-xs text-slate-600 line-through">{addEnemy.name} — Defeated</span>
+          </div>
+        )
+      ))}
+
       {/* Enemy telegraph warning */}
       {combatState.enemyTelegraph && (
         <div className={`border rounded-lg p-2 text-center text-sm animate-pulse ${

--- a/src/app/tap-tap-adventure/lib/combatEngine.ts
+++ b/src/app/tap-tap-adventure/lib/combatEngine.ts
@@ -851,6 +851,7 @@ export function processPlayerAction(
   const bossAlreadyPhased = isBoss && !combatState.isFinalBoss ? enemy.name.includes('(Enraged)') : false
   let combatDistance: CombatDistance = combatState.combatDistance ?? 'mid'
   let partyMemberStates = combatState.partyMemberStates ? combatState.partyMemberStates.map(m => ({ ...m })) : undefined
+  let additionalEnemies = combatState.additionalEnemies ? combatState.additionalEnemies.map(e => ({ ...e })) : undefined
   // Only propagate combatDistance in returns if the original state had it set
   // This ensures backward compatibility with combat states created before range was added
   let rangeSystemActive = combatState.combatDistance !== undefined
@@ -868,6 +869,33 @@ export function processPlayerAction(
   }
   if (!playerState.turnActions) {
     playerState.turnActions = []
+  }
+
+  // Switch target is free (0 AP) — just swap primary and additional enemy
+  if (action.action === 'switch_target' && action.itemId !== undefined && additionalEnemies?.length) {
+    const targetIdx = parseInt(action.itemId, 10)
+    if (targetIdx >= 0 && targetIdx < additionalEnemies.length && additionalEnemies[targetIdx].hp > 0) {
+      const old = enemy
+      enemy = additionalEnemies[targetIdx]
+      additionalEnemies[targetIdx] = old
+      newLogs.push({
+        turn: turnNumber,
+        actor: 'player' as const,
+        action: 'switch_target',
+        description: `You switch your focus to ${enemy.name}!`,
+      })
+      return {
+        combatState: {
+          ...combatState,
+          enemy,
+          playerState,
+          combatLog: [...combatLog, ...newLogs],
+          turnPhase: 'player',
+          partyMemberStates,
+          additionalEnemies,
+        },
+      }
+    }
   }
 
   // Check AP cost for the requested action
@@ -889,6 +917,7 @@ export function processPlayerAction(
         ...(rangeSystemActive ? { combatDistance } : {}),
         turnPhase: 'player',
         partyMemberStates,
+        additionalEnemies,
       },
     }
   }
@@ -948,6 +977,7 @@ export function processPlayerAction(
             ...(rangeSystemActive ? { combatDistance } : {}),
             turnPhase: 'player',
             partyMemberStates,
+            additionalEnemies,
           },
           consumedItemId,
         }
@@ -1145,6 +1175,7 @@ export function processPlayerAction(
               enemyTelegraph: null,
               ...(rangeSystemActive ? { combatDistance } : {}),
               turnPhase: 'enemy_done',
+              additionalEnemies,
             },
           }
         }
@@ -1365,13 +1396,44 @@ export function processPlayerAction(
 
   // Check victory
   if (enemy.hp <= 0) {
-    status = 'victory'
+    const defeatedName = enemy.name
     newLogs.push({
       turn: turnNumber,
       actor: 'player',
       action: 'victory',
-      description: `You defeated ${enemy.name}!`,
+      description: `You defeated ${defeatedName}!`,
     })
+    // If additional enemies remain alive, auto-switch to next target
+    if (additionalEnemies?.some(e => e.hp > 0)) {
+      const nextIdx = additionalEnemies.findIndex(e => e.hp > 0)
+      const nextEnemy = additionalEnemies[nextIdx]
+      const remainingAdditional = additionalEnemies.filter((_, i) => i !== nextIdx)
+      newLogs.push({
+        turn: turnNumber,
+        actor: 'player' as const,
+        action: 'switch_target',
+        description: `${defeatedName} is defeated! You focus on ${nextEnemy.name}!`,
+      })
+      const nextTelegraph = generateEnemyTelegraph(nextEnemy, turnNumber, !!isBoss)
+      return {
+        combatState: {
+          ...combatState,
+          enemy: nextEnemy,
+          playerState: tickBuffs(playerState),
+          turnNumber,
+          combatLog: [...combatLog, ...newLogs],
+          status: 'active',
+          enemyTelegraph: nextTelegraph,
+          isBoss,
+          ...(rangeSystemActive ? { combatDistance } : {}),
+          turnPhase: 'enemy_done',
+          partyMemberStates,
+          additionalEnemies: remainingAdditional.length > 0 ? remainingAdditional : undefined,
+        },
+        consumedItemId,
+      }
+    }
+    status = 'victory'
     return {
       combatState: {
         ...combatState,
@@ -1383,6 +1445,7 @@ export function processPlayerAction(
         enemyTelegraph: null,
         ...(rangeSystemActive ? { combatDistance } : {}),
         turnPhase: 'enemy_done',
+        additionalEnemies: undefined,
       },
       consumedItemId,
     }
@@ -1403,6 +1466,7 @@ export function processPlayerAction(
         ...(rangeSystemActive ? { combatDistance } : {}),
         turnPhase: 'player',
         partyMemberStates,
+        additionalEnemies,
       },
       consumedItemId,
     }
@@ -1794,7 +1858,84 @@ export function processPlayerAction(
     partyMemberStates = partyResult.partyStates
     newLogs.push(...partyResult.logs)
     if (partyResult.killedEnemy) {
-      status = 'victory'
+      // If additional enemies remain, auto-switch target instead of declaring victory
+      if (additionalEnemies?.some(e => e.hp > 0)) {
+        const defeatedName = enemy.name
+        const nextIdx = additionalEnemies.findIndex(e => e.hp > 0)
+        enemy = additionalEnemies[nextIdx]
+        additionalEnemies = additionalEnemies.filter((_, i) => i !== nextIdx)
+        newLogs.push({
+          turn: turnNumber, actor: 'party_member' as const, action: 'switch_target',
+          description: `${defeatedName} is defeated! ${enemy.name} remains!`,
+        })
+      } else {
+        status = 'victory'
+      }
+    }
+  }
+
+  // Party members also strike additional enemies (round-robin assignment)
+  if (status === 'active' && additionalEnemies?.length && partyMemberStates?.length) {
+    const aliveParty = partyMemberStates.filter(m => !m.isKnockedOut)
+    for (let i = 0; i < additionalEnemies.length; i++) {
+      if (additionalEnemies[i].hp <= 0) continue
+      const assignedMember = aliveParty[i % aliveParty.length]
+      if (!assignedMember) continue
+      const baseDmg = assignedMember.attack
+      const raw = baseDmg - additionalEnemies[i].defense * 0.3 + (Math.random() - 0.5) * baseDmg * 0.3
+      const damage = Math.max(1, Math.round(raw))
+      additionalEnemies[i] = { ...additionalEnemies[i], hp: Math.max(0, additionalEnemies[i].hp - damage) }
+      newLogs.push({
+        turn: turnNumber, actor: 'party_member' as const, action: 'attack', damage,
+        description: `${assignedMember.icon} ${assignedMember.name} attacks ${additionalEnemies[i].name} for ${damage} damage!`,
+      })
+      if (additionalEnemies[i].hp <= 0) {
+        newLogs.push({
+          turn: turnNumber, actor: 'party_member' as const, action: 'victory',
+          description: `${assignedMember.name} defeats ${additionalEnemies[i].name}!`,
+        })
+      }
+    }
+  }
+
+  // Additional enemies auto-attack player/party at end of turn
+  if (status === 'active' && additionalEnemies?.length) {
+    for (let i = 0; i < additionalEnemies.length; i++) {
+      const addEnemy = additionalEnemies[i]
+      if (addEnemy.hp <= 0) continue
+
+      // 40% chance to target a party member, 60% player
+      const aliveMembers = partyMemberStates?.filter(m => !m.isKnockedOut) ?? []
+      const shouldTargetMember = aliveMembers.length > 0 && Math.random() < 0.4
+
+      if (shouldTargetMember) {
+        const tIdx = Math.floor(Math.random() * aliveMembers.length)
+        const target = aliveMembers[tIdx]
+        const dmg = Math.max(1, addEnemy.attack - target.defense)
+        const mIdx = partyMemberStates!.findIndex(m => m.memberId === target.memberId)
+        const newHp = Math.max(0, partyMemberStates![mIdx].hp - dmg)
+        partyMemberStates![mIdx] = { ...partyMemberStates![mIdx], hp: newHp, isKnockedOut: newHp <= 0 }
+        newLogs.push({
+          turn: turnNumber, actor: 'enemy' as const, action: 'attack', damage: dmg,
+          description: `${addEnemy.name} attacks ${target.name} for ${dmg} damage!${newHp <= 0 ? ` ${target.name} is knocked out!` : ''}`,
+        })
+      } else {
+        // Attack player
+        const dmg = addEnemy.attack - playerState.defense * 0.5
+        const finalDmg = playerState.isDefending ? Math.max(1, Math.floor(dmg * 0.5)) : Math.max(1, Math.round(dmg))
+        playerState = { ...playerState, hp: Math.max(0, playerState.hp - finalDmg) }
+        newLogs.push({
+          turn: turnNumber, actor: 'enemy' as const, action: 'attack', damage: finalDmg,
+          description: `${addEnemy.name} attacks you for ${finalDmg} damage!`,
+        })
+        if (playerState.hp <= 0) {
+          status = 'defeat'
+          newLogs.push({
+            turn: turnNumber, actor: 'enemy' as const, action: 'defeat',
+            description: `You have been defeated by ${addEnemy.name}...`,
+          })
+        }
+      }
     }
   }
 
@@ -1864,6 +2005,19 @@ export function processPlayerAction(
     }
   }
 
+  // If primary enemy was defeated (e.g. by status effects) but additional enemies remain, auto-switch
+  if (status === 'victory' && additionalEnemies?.some(e => e.hp > 0)) {
+    const defeatedName = enemy.name
+    const nextIdx = additionalEnemies.findIndex(e => e.hp > 0)
+    enemy = additionalEnemies[nextIdx]
+    additionalEnemies = additionalEnemies.filter((_, i) => i !== nextIdx)
+    status = 'active'
+    newLogs.push({
+      turn: turnNumber, actor: 'player' as const, action: 'switch_target',
+      description: `${defeatedName} is defeated! ${enemy.name} remains!`,
+    })
+  }
+
   // Generate telegraph for enemy's NEXT action
   const nextTelegraph = status === 'active'
     ? generateEnemyTelegraph(enemy, turnNumber, !!isBoss)
@@ -1882,6 +2036,7 @@ export function processPlayerAction(
       ...(rangeSystemActive ? { combatDistance } : {}),
       turnPhase: 'enemy_done',
       partyMemberStates,
+      additionalEnemies: additionalEnemies && additionalEnemies.length > 0 ? additionalEnemies : undefined,
     },
     consumedItemId,
     mountDied,
@@ -1906,7 +2061,16 @@ export function getCombatRewards(
   const lootBonus = getSkillBonus(skills, 'loot_chance')
   const diffMods = getDifficultyModifiers(character.difficultyMode)
   const regionMult = regionMultiplier ?? 1
-  const gold = Math.round(enemy.goldReward * (1 + goldBonus.percentage / 100) * diffMods.goldMultiplier * regionMult)
+  let gold = Math.round(enemy.goldReward * (1 + goldBonus.percentage / 100) * diffMods.goldMultiplier * regionMult)
+
+  // Add gold from defeated additional enemies
+  if (combatState.additionalEnemies?.length) {
+    for (const addEnemy of combatState.additionalEnemies) {
+      if (addEnemy.hp <= 0) {
+        gold += Math.round(addEnemy.goldReward * (1 + goldBonus.percentage / 100) * diffMods.goldMultiplier * regionMult)
+      }
+    }
+  }
 
   const loot: Item[] = []
   if (enemy.lootTable) {

--- a/src/app/tap-tap-adventure/lib/enemyVariants.ts
+++ b/src/app/tap-tap-adventure/lib/enemyVariants.ts
@@ -1,0 +1,55 @@
+import { CombatEnemy } from '@/app/tap-tap-adventure/models/combat'
+import { seededRandom } from '@/app/tap-tap-adventure/lib/landmarkGenerator'
+
+const VARIANT_PREFIXES = ['Lesser', 'Young', 'Feral', 'Wild', 'Frenzied']
+
+/**
+ * Determine how many enemies to spawn based on party size.
+ * Boss fights always have 1 enemy.
+ */
+export function getEnemyCount(partySize: number, isBoss: boolean): number {
+  if (isBoss) return 1
+  if (partySize === 0) return 1
+  if (partySize === 1) return Math.random() < 0.5 ? 1 : 2
+  return Math.random() < 0.4 ? 2 : 3
+}
+
+/**
+ * Generate a weaker variant of the base enemy.
+ * Stats are 50-80% of the original, less gold reward.
+ */
+export function generateEnemyVariant(baseEnemy: CombatEnemy, index: number, seed: string): CombatEnemy {
+  const rng = seededRandom(`${seed}-variant-${index}`)
+  const variance = 0.5 + rng() * 0.3 // 50-80% of base stats
+  const prefixIdx = Math.floor(rng() * VARIANT_PREFIXES.length)
+  const prefix = VARIANT_PREFIXES[prefixIdx]
+
+  return {
+    id: `${baseEnemy.id}-v${index}`,
+    name: `${prefix} ${baseEnemy.name}`,
+    description: baseEnemy.description,
+    hp: Math.max(5, Math.round(baseEnemy.maxHp * variance)),
+    maxHp: Math.max(5, Math.round(baseEnemy.maxHp * variance)),
+    attack: Math.max(2, Math.round(baseEnemy.attack * variance)),
+    defense: Math.max(1, Math.round(baseEnemy.defense * variance)),
+    level: Math.max(1, baseEnemy.level - 1),
+    goldReward: Math.round(baseEnemy.goldReward * 0.5),
+    range: baseEnemy.range,
+    element: baseEnemy.element,
+  }
+}
+
+/**
+ * Scale boss stats based on party size instead of adding more enemies.
+ */
+export function scaleBossForParty(boss: CombatEnemy, partySize: number): CombatEnemy {
+  if (partySize === 0) return boss
+  const hpScale = 1 + partySize * 0.25    // +25% HP per party member
+  const atkScale = 1 + partySize * 0.1    // +10% attack per party member
+  return {
+    ...boss,
+    hp: Math.round(boss.hp * hpScale),
+    maxHp: Math.round(boss.maxHp * hpScale),
+    attack: Math.round(boss.attack * atkScale),
+  }
+}

--- a/src/app/tap-tap-adventure/models/combat.ts
+++ b/src/app/tap-tap-adventure/models/combat.ts
@@ -110,7 +110,7 @@ export const CombatPlayerStateSchema = z.object({
 })
 export type CombatPlayerState = z.infer<typeof CombatPlayerStateSchema>
 
-export const CombatActionSchema = z.enum(['attack', 'defend', 'heavy_attack', 'use_item', 'flee', 'class_ability', 'cast_spell', 'end_turn', 'move_closer', 'move_away'])
+export const CombatActionSchema = z.enum(['attack', 'defend', 'heavy_attack', 'use_item', 'flee', 'class_ability', 'cast_spell', 'end_turn', 'move_closer', 'move_away', 'switch_target'])
 export type CombatAction = z.infer<typeof CombatActionSchema>
 
 export const CombatActionRequestSchema = z.object({
@@ -175,5 +175,6 @@ export const CombatStateSchema = z.object({
   turnPhase: TurnPhaseSchema.optional(),
   pendingRegionId: z.string().optional(),
   partyMemberStates: z.array(PartyMemberCombatStateSchema).optional(),
+  additionalEnemies: z.array(CombatEnemySchema).optional(),
 })
 export type CombatState = z.infer<typeof CombatStateSchema>


### PR DESCRIPTION
## Summary
Party-based encounters now spawn multiple enemies scaling with party size:
- **Solo**: 1 enemy (unchanged)
- **+1 party member**: 1-2 enemies
- **+2-3 party members**: 2-3 enemies
- **Boss fights**: 1 boss with scaled stats (+25% HP, +10% ATK per party member)

Additional enemies are weaker variants (50-80% stats) of the primary enemy with prefixed names (e.g., "Lesser Goblin", "Feral Wolf").

### Combat mechanics
- Additional enemies auto-attack player or party members each turn
- Party members split attacks across all enemies (round-robin)
- When primary enemy is defeated, next alive enemy auto-promotes to primary target
- Player can switch targets freely (0 AP) via target buttons
- Victory requires ALL enemies defeated
- Gold rewards aggregated from all enemies

Partially addresses #385

## Changes
- `models/combat.ts` — added `additionalEnemies` field and `switch_target` action
- `lib/enemyVariants.ts` (new) — enemy count scaling, variant generation, boss stat scaling
- `lib/combatEngine.ts` — additional enemy attacks, party target splitting, auto-switch, target switching
- `combat/start/route.ts` — generate additional enemies based on party size
- `CombatUI.tsx` — additional enemy HP bars with target buttons
- 13 unit tests

## Test plan
- [ ] Solo combat — exactly 1 enemy, no additional enemies
- [ ] Combat with 1+ party members — 1-3 enemies appear
- [ ] Click "Target" button — primary target switches
- [ ] Kill primary enemy with additional enemies alive — auto-switches
- [ ] All enemies dead — victory triggers, rewards include all enemies
- [ ] Boss fight with party — 1 boss with scaled stats, no additional enemies
- [ ] All 864 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)