### PR TITLE
feat: LLM-powered conversations with party members

### DIFF
--- a/src/app/api/v1/tap-tap-adventure/party/dialogue/route.ts
+++ b/src/app/api/v1/tap-tap-adventure/party/dialogue/route.ts
@@ -1,0 +1,143 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { OpenAI } from 'openai'
+import { z } from 'zod'
+
+import { getRelationshipTier } from '@/app/tap-tap-adventure/config/npcs'
+
+const PERSONALITY_WEIGHTS: Record<string, Record<string, number>> = {
+  brave:      { flatter: 0, charm: -1, threaten: 1, inquire: 1, offend: -1 },
+  cautious:   { flatter: 1, charm: 1, threaten: -2, inquire: 1, offend: -2 },
+  aggressive: { flatter: -1, charm: -1, threaten: 1, inquire: 0, offend: 0 },
+  loyal:      { flatter: 1, charm: 1, threaten: -1, inquire: 1, offend: -2 },
+  cunning:    { flatter: -1, charm: 1, threaten: 0, inquire: 2, offend: -1 },
+  reckless:   { flatter: 0, charm: 0, threaten: 0, inquire: -1, offend: 1 },
+}
+
+const DialogueRequestSchema = z.object({
+  memberName: z.string(),
+  memberClassName: z.string(),
+  memberPersonality: z.string().optional(),
+  characterName: z.string(),
+  characterClass: z.string(),
+  characterLevel: z.number(),
+  characterCharisma: z.number().optional(),
+  message: z.string().optional(),
+  conversationHistory: z.array(z.object({
+    role: z.enum(['user', 'assistant']),
+    content: z.string(),
+  })).optional(),
+  disposition: z.number().optional(),
+  exchangeCount: z.number().optional(),
+})
+
+function getOpenAI() {
+  return new OpenAI({ apiKey: process.env.OPENAI_API_KEY })
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    const body = await req.json()
+    const parseResult = DialogueRequestSchema.safeParse(body)
+    if (!parseResult.success) {
+      return NextResponse.json({ error: 'Invalid request', details: parseResult.error }, { status: 400 })
+    }
+
+    const {
+      memberName,
+      memberClassName,
+      memberPersonality = 'loyal',
+      characterName,
+      characterClass,
+      characterLevel,
+      characterCharisma,
+      message,
+      conversationHistory,
+      disposition = 0,
+      exchangeCount = 1,
+    } = parseResult.data
+
+    const charisma = characterCharisma ?? 5
+    const tier = getRelationshipTier(disposition)
+    const weights = PERSONALITY_WEIGHTS[memberPersonality] ?? PERSONALITY_WEIGHTS.loyal
+    const weightsDescription = Object.entries(weights)
+      .map(([intent, weight]) => `${intent}: ${weight > 0 ? '+' : ''}${weight}`)
+      .join(', ')
+
+    const systemPrompt = `You are ${memberName}, a ${memberClassName} traveling with the player as a party member.
+Your personality: ${memberPersonality}.
+
+RELATIONSHIP: Your current disposition toward the player is ${disposition} (${tier.label}). You travel together and share camp.
+${disposition >= 50 ? 'You trust this person deeply and speak openly.' : disposition >= 20 ? 'You are getting comfortable with this person.' : disposition >= 0 ? 'You are still getting to know this person.' : 'You are wary of this person.'}
+
+PLAYER: ${characterName}, Level ${characterLevel} ${characterClass}. Charisma: ${charisma}.
+
+CONVERSATION: This is exchange ${exchangeCount}.
+
+Evaluate the player's message for intent. Choose one of: flatter, charm, threaten, inquire, offend, lie, bore, neutral.
+Your personality preferences (how much you like each intent): ${weightsDescription}
+
+Respond in character as a traveling companion, not a stranger. Keep responses under 4 sentences.
+
+RESPOND WITH ONLY THIS JSON (no markdown, no code fences):
+{
+  "dialogue": "Your in-character response here",
+  "intent": "detected intent",
+  "dispositionDelta": <integer from -10 to 8>,
+  "conversationComplete": <true if exchange >= 3 and conversation feels naturally concluded, otherwise false>
+}`
+
+    const userMessage = message
+      ? `${characterName} says: "${message}"`
+      : `${characterName} turns to you during travel.`
+
+    const historyMessages = conversationHistory ?? []
+
+    try {
+      const response = await getOpenAI().chat.completions.create({
+        model: 'gpt-4o',
+        messages: [
+          { role: 'system', content: systemPrompt },
+          ...historyMessages,
+          { role: 'user', content: userMessage },
+        ],
+        temperature: 0.7,
+        max_tokens: 300,
+        response_format: { type: 'json_object' },
+      })
+
+      const raw = response.choices[0]?.message?.content?.trim() ?? ''
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      let parsed: any = {}
+      try {
+        parsed = JSON.parse(raw)
+      } catch {
+        const dialogueMatch = raw.match(/"dialogue"\s*:\s*"([^"]+)"/)
+        parsed = { dialogue: dialogueMatch?.[1] ?? `*${memberName} nods quietly*`, dispositionDelta: 0 }
+      }
+
+      const dialogue = parsed.dialogue ?? `*${memberName} nods quietly*`
+      const rawDelta = typeof parsed.dispositionDelta === 'number' ? parsed.dispositionDelta : 0
+      const chaModifier = 1 + (charisma - 7) * 0.1
+      const adjustedDelta = Math.round(rawDelta * chaModifier)
+      const dispositionDelta = Math.max(-15, Math.min(12, adjustedDelta))
+
+      return NextResponse.json({
+        dialogue,
+        intent: parsed.intent ?? 'neutral',
+        dispositionDelta,
+        conversationComplete: parsed.conversationComplete ?? false,
+      })
+    } catch (err) {
+      console.error('Party dialogue LLM call failed', err)
+      return NextResponse.json({
+        dialogue: `*${memberName} nods quietly*`,
+        intent: 'neutral',
+        dispositionDelta: 0,
+        conversationComplete: false,
+      })
+    }
+  } catch (err) {
+    console.error('Error in party dialogue route', err)
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/src/app/tap-tap-adventure/components/MercenaryPanel.tsx
+++ b/src/app/tap-tap-adventure/components/MercenaryPanel.tsx
@@ -9,6 +9,7 @@ import { Mercenary } from '@/app/tap-tap-adventure/models/mercenary'
 import { getTavernRecruits } from '@/app/tap-tap-adventure/lib/partyRecruitment'
 import { calculateDay } from '@/app/tap-tap-adventure/lib/leveling'
 import { MAX_PARTY_SIZE } from '@/app/tap-tap-adventure/models/partyMember'
+import { PartyDialoguePanel } from '@/app/tap-tap-adventure/components/PartyDialoguePanel'
 
 interface MercenaryPanelProps {
   character: FantasyCharacter
@@ -60,9 +61,10 @@ function HpBar({ current, max }: { current: number; max: number }) {
 }
 
 export function MercenaryPanel({ character }: MercenaryPanelProps) {
-  const { recruitMercenary, dismissMercenary, setActiveMercenary, recruitTavernMember, removePartyMember } = useGameStore()
+  const { recruitMercenary, dismissMercenary, setActiveMercenary, recruitTavernMember, removePartyMember, updatePartyMemberRelationship } = useGameStore()
   const [isExpanded, setIsExpanded] = useState(false)
   const [dismissConfirm, setDismissConfirm] = useState<string | null>(null)
+  const [talkingTo, setTalkingTo] = useState<string | null>(null)
 
   // Stable tavern selection per character level — prevents re-randomization on each render
   const tavernMercs = useMemo(
@@ -265,8 +267,16 @@ export function MercenaryPanel({ character }: MercenaryPanelProps) {
                         onClick={() => setDismissConfirm(null)}>No</button>
                     </>
                   ) : (
-                    <button className="text-[10px] px-1.5 py-0.5 bg-red-900/30 text-red-400 rounded hover:bg-red-800/40 transition-colors"
-                      onClick={() => setDismissConfirm(`party-${member.id}`)}>Dismiss</button>
+                    <>
+                      <button
+                        className="text-[10px] px-1.5 py-0.5 bg-indigo-900/30 text-indigo-300 rounded hover:bg-indigo-800/40 transition-colors"
+                        onClick={() => setTalkingTo(member.id)}
+                      >
+                        Talk
+                      </button>
+                      <button className="text-[10px] px-1.5 py-0.5 bg-red-900/30 text-red-400 rounded hover:bg-red-800/40 transition-colors"
+                        onClick={() => setDismissConfirm(`party-${member.id}`)}>Dismiss</button>
+                    </>
                   )}
                 </div>
               </div>
@@ -274,6 +284,24 @@ export function MercenaryPanel({ character }: MercenaryPanelProps) {
           </div>
         </div>
       )}
+
+      {/* Party Dialogue Panel */}
+      {talkingTo && (() => {
+        const member = partyMembers.find(m => m.id === talkingTo)
+        if (!member) return null
+        return (
+          <PartyDialoguePanel
+            member={member}
+            characterName={character.name}
+            characterClass={character.classData?.name ?? character.class ?? 'Adventurer'}
+            characterLevel={character.level}
+            characterCharisma={character.charisma ?? 5}
+            disposition={member.relationship ?? 0}
+            onDispositionChange={(delta) => updatePartyMemberRelationship(member.id, delta)}
+            onClose={() => setTalkingTo(null)}
+          />
+        )
+      })()}
 
       {/* Tavern Recruits (Party Members) */}
       <div>

--- a/src/app/tap-tap-adventure/components/PartyDialoguePanel.tsx
+++ b/src/app/tap-tap-adventure/components/PartyDialoguePanel.tsx
@@ -1,0 +1,166 @@
+'use client'
+import { useState, useEffect, useRef } from 'react'
+import { getRelationshipTier } from '@/app/tap-tap-adventure/config/npcs'
+import { usePartyDialogue } from '@/app/tap-tap-adventure/hooks/usePartyDialogue'
+import type { PartyMember } from '@/app/tap-tap-adventure/models/partyMember'
+
+interface PartyDialoguePanelProps {
+  member: PartyMember
+  characterName: string
+  characterClass: string
+  characterLevel: number
+  characterCharisma: number
+  disposition: number
+  onDispositionChange: (delta: number) => void
+  onClose: () => void
+}
+
+export function PartyDialoguePanel({
+  member,
+  characterName,
+  characterClass,
+  characterLevel,
+  characterCharisma,
+  disposition,
+  onDispositionChange,
+  onClose,
+}: PartyDialoguePanelProps) {
+  const { conversationLog, isLoading, conversationComplete, fetchDialogue, reset } = usePartyDialogue()
+  const [inputText, setInputText] = useState('')
+  const logRef = useRef<HTMLDivElement>(null)
+  const [currentDisposition, setCurrentDisposition] = useState(disposition)
+
+  // Fetch greeting on mount
+  useEffect(() => {
+    fetchDialogue({
+      memberName: member.customName ?? member.name,
+      memberClassName: member.className,
+      memberPersonality: member.personality,
+      characterName,
+      characterClass,
+      characterLevel,
+      characterCharisma,
+      disposition: currentDisposition,
+    })
+    return () => reset()
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  // Auto-scroll log
+  useEffect(() => {
+    if (logRef.current) logRef.current.scrollTop = logRef.current.scrollHeight
+  }, [conversationLog])
+
+  const handleSend = async () => {
+    if (!inputText.trim() || isLoading || conversationComplete) return
+    const msg = inputText.trim()
+    setInputText('')
+    const result = await fetchDialogue({
+      memberName: member.customName ?? member.name,
+      memberClassName: member.className,
+      memberPersonality: member.personality,
+      characterName,
+      characterClass,
+      characterLevel,
+      characterCharisma,
+      message: msg,
+      disposition: currentDisposition,
+    })
+    if (result?.dispositionDelta) {
+      setCurrentDisposition(prev => Math.max(-100, Math.min(100, prev + result.dispositionDelta!)))
+      onDispositionChange(result.dispositionDelta)
+    }
+  }
+
+  const tier = getRelationshipTier(currentDisposition)
+  const tierColors: Record<string, string> = {
+    hostile: 'text-red-400 bg-red-900/30',
+    unfriendly: 'text-orange-400 bg-orange-900/30',
+    neutral: 'text-slate-300 bg-slate-700/30',
+    friendly: 'text-green-400 bg-green-900/30',
+    trusted: 'text-blue-400 bg-blue-900/30',
+    bonded: 'text-amber-400 bg-amber-900/30',
+  }
+
+  return (
+    <div className="bg-[#1e1f30] border border-[#3a3c56] rounded-lg p-3 space-y-3 max-h-[400px] flex flex-col">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <span className="text-xl">{member.icon}</span>
+          <div>
+            <div className="text-sm font-semibold text-slate-200">{member.customName ?? member.name}</div>
+            <div className="text-[10px] text-slate-400">{member.className}</div>
+          </div>
+          <span className={`text-[10px] px-1.5 py-0.5 rounded capitalize ${tierColors[tier.tier] ?? ''}`}>
+            {tier.label}
+          </span>
+        </div>
+        <button className="text-slate-400 hover:text-white text-sm" onClick={onClose}>&#x2715;</button>
+      </div>
+
+      {/* Disposition bar */}
+      <div className="h-1.5 bg-slate-700 rounded-full overflow-hidden">
+        <div
+          className="h-full bg-gradient-to-r from-red-500 via-yellow-500 to-green-500 rounded-full transition-all"
+          style={{ width: `${Math.max(0, Math.min(100, (currentDisposition + 100) / 2))}%` }}
+        />
+      </div>
+
+      {/* Conversation log */}
+      <div ref={logRef} className="flex-1 overflow-y-auto space-y-2 min-h-[120px] max-h-[200px]">
+        {conversationLog.map((entry, i) => (
+          <div key={i} className={`text-xs ${entry.role === 'player' ? 'text-right' : ''}`}>
+            {entry.role === 'player' ? (
+              <div className="inline-block bg-indigo-900/40 border border-indigo-700/30 rounded px-2 py-1 text-indigo-200">
+                {entry.content}
+              </div>
+            ) : (
+              <div className="text-slate-300">
+                <span className="text-slate-500">{member.customName ?? member.name}:</span> {entry.content}
+                {entry.dispositionDelta !== undefined && entry.dispositionDelta !== 0 && (
+                  <span className={`ml-1 text-[10px] ${entry.dispositionDelta > 0 ? 'text-green-400' : 'text-red-400'}`}>
+                    ({entry.dispositionDelta > 0 ? '+' : ''}{entry.dispositionDelta})
+                  </span>
+                )}
+              </div>
+            )}
+          </div>
+        ))}
+        {isLoading && <div className="text-[10px] text-slate-500 italic">Thinking...</div>}
+      </div>
+
+      {/* Input */}
+      <div className="flex gap-2">
+        <input
+          type="text"
+          className="flex-1 bg-[#252638] border border-[#3a3c56] rounded px-2 py-1 text-xs text-slate-200 placeholder:text-slate-500 focus:outline-none focus:border-indigo-500"
+          placeholder={conversationComplete ? 'Conversation ended' : 'Say something...'}
+          value={inputText}
+          onChange={e => setInputText(e.target.value)}
+          onKeyDown={e => e.key === 'Enter' && handleSend()}
+          disabled={isLoading || conversationComplete}
+        />
+        <button
+          className={`text-xs px-3 py-1 rounded transition-colors ${
+            isLoading || conversationComplete || !inputText.trim()
+              ? 'bg-slate-700/40 text-slate-500 cursor-not-allowed'
+              : 'bg-indigo-700/50 text-indigo-300 hover:bg-indigo-600/60'
+          }`}
+          onClick={handleSend}
+          disabled={isLoading || conversationComplete || !inputText.trim()}
+        >
+          Send
+        </button>
+      </div>
+
+      {/* End conversation */}
+      <button
+        className="text-[10px] text-slate-400 hover:text-slate-200 transition-colors"
+        onClick={onClose}
+      >
+        {conversationComplete ? 'Close' : 'End conversation'}
+      </button>
+    </div>
+  )
+}

--- a/src/app/tap-tap-adventure/hooks/useGameStore.ts
+++ b/src/app/tap-tap-adventure/hooks/useGameStore.ts
@@ -156,6 +156,7 @@ export interface GameStore {
   dismissLootCelebration: () => void
   clearNewItemId: (itemId: string) => void
   clearSocialEncounter: () => void
+  updatePartyMemberRelationship: (memberId: string, dispositionDelta: number) => void
 }
 
 export const useGameStore = create<GameStore>()(
@@ -1749,6 +1750,22 @@ export const useGameStore = create<GameStore>()(
       clearSocialEncounter: () => set(state => ({
         gameState: { ...state.gameState, socialEncounter: null }
       })),
+      updatePartyMemberRelationship: (memberId: string, dispositionDelta: number) => {
+        set(
+          produce((state: GameStore) => {
+            const selectedCharacter = get().getSelectedCharacter()
+            if (!selectedCharacter) return
+            const charIndex = state.gameState.characters.findIndex(c => c.id === selectedCharacter.id)
+            if (charIndex === -1) return
+            const party = state.gameState.characters[charIndex].party
+            if (!party) return
+            const memberIndex = party.findIndex(m => m.id === memberId)
+            if (memberIndex === -1) return
+            const current = party[memberIndex].relationship ?? 0
+            party[memberIndex].relationship = Math.max(-100, Math.min(100, current + dispositionDelta))
+          })
+        )
+      },
     }),
     {
       name: 'fantasy-tycoon-storage', // localStorage key (kept for backward compat)

--- a/src/app/tap-tap-adventure/hooks/usePartyDialogue.ts
+++ b/src/app/tap-tap-adventure/hooks/usePartyDialogue.ts
@@ -1,0 +1,109 @@
+'use client'
+import { useState, useCallback } from 'react'
+
+import type { IntentType } from '@/app/tap-tap-adventure/config/npcs'
+
+interface ConversationMessage {
+  role: 'user' | 'assistant'
+  content: string
+}
+
+export interface PartyConversationEntry {
+  role: 'player' | 'member'
+  content: string
+  intent?: IntentType
+  dispositionDelta?: number
+}
+
+interface PartyDialogueState {
+  dialogue: string
+  intent?: string
+  dispositionDelta?: number
+  conversationComplete?: boolean
+}
+
+const MAX_LOG_ENTRIES = 20
+
+export function usePartyDialogue() {
+  const [currentDialogue, setCurrentDialogue] = useState<PartyDialogueState | null>(null)
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [conversationHistory, setConversationHistory] = useState<ConversationMessage[]>([])
+  const [conversationLog, setConversationLog] = useState<PartyConversationEntry[]>([])
+  const [exchangeCount, setExchangeCount] = useState(1)
+  const [conversationComplete, setConversationComplete] = useState(false)
+
+  const fetchDialogue = useCallback(async (params: {
+    memberName: string
+    memberClassName: string
+    memberPersonality?: string
+    characterName: string
+    characterClass: string
+    characterLevel: number
+    characterCharisma?: number
+    message?: string
+    disposition?: number
+  }): Promise<PartyDialogueState | null> => {
+    setIsLoading(true)
+    setError(null)
+
+    const recentHistory = conversationHistory.slice(-6)
+
+    try {
+      const res = await fetch('/api/v1/tap-tap-adventure/party/dialogue', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          ...params,
+          conversationHistory: recentHistory,
+          exchangeCount,
+        }),
+      })
+
+      if (!res.ok) throw new Error('Failed to fetch party dialogue')
+
+      const data = await res.json() as PartyDialogueState
+
+      setCurrentDialogue(data)
+
+      const newHistory = [...conversationHistory]
+      if (params.message) newHistory.push({ role: 'user', content: params.message })
+      newHistory.push({ role: 'assistant', content: data.dialogue ?? '' })
+      setConversationHistory(newHistory)
+
+      setConversationLog(prev => {
+        const updated = [...prev]
+        if (params.message) {
+          updated.push({ role: 'player', content: params.message, intent: data.intent as IntentType | undefined })
+        }
+        updated.push({ role: 'member', content: data.dialogue ?? '', dispositionDelta: data.dispositionDelta })
+        return updated.slice(-MAX_LOG_ENTRIES)
+      })
+
+      setExchangeCount(prev => prev + 1)
+      if (data.conversationComplete) setConversationComplete(true)
+
+      return data
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Unknown error'
+      setError(msg)
+      const fallback: PartyDialogueState = { dialogue: `*nods quietly*` }
+      setCurrentDialogue(fallback)
+      setConversationLog(prev => [...prev, { role: 'member' as const, content: fallback.dialogue }].slice(-MAX_LOG_ENTRIES))
+      return fallback
+    } finally {
+      setIsLoading(false)
+    }
+  }, [conversationHistory, exchangeCount])
+
+  const reset = useCallback(() => {
+    setCurrentDialogue(null)
+    setError(null)
+    setConversationHistory([])
+    setConversationLog([])
+    setExchangeCount(1)
+    setConversationComplete(false)
+  }, [])
+
+  return { currentDialogue, isLoading, error, conversationLog, exchangeCount, conversationComplete, fetchDialogue, reset }
+}


### PR DESCRIPTION
## Summary
Players can now chat with party members during travel using LLM-powered dialogue. Conversations affect the member's relationship (disposition) and personality-aware responses.

- **"Talk" button** in the Companions section of the Party panel
- **Chat UI** with scrollable conversation log, disposition bar, tier badge, and delta indicators
- **Party dialogue API** (`/api/v1/tap-tap-adventure/party/dialogue`) using GPT-4o with personality-weighted intent evaluation
- **6 personality types** with distinct dialogue weights: brave, cautious, aggressive, loyal, cunning, reckless
- **Charisma modifier** affects disposition changes (same formula as NPC dialogue)
- **Disposition persisted** to PartyMember.relationship via new store action

Combat bonuses from relationship are a separate follow-up (steps 6-7 of the issue).

Partially addresses #386

## Changes
- `api/v1/tap-tap-adventure/party/dialogue/route.ts` (new) — party-specific dialogue endpoint
- `hooks/usePartyDialogue.ts` (new) — conversation state management hook
- `components/PartyDialoguePanel.tsx` (new) — chat panel with disposition tracking
- `hooks/useGameStore.ts` — added `updatePartyMemberRelationship` action
- `components/MercenaryPanel.tsx` — added "Talk" button and dialogue panel integration

## Test plan
- [ ] Click "Talk" on a party member — dialogue panel opens with greeting
- [ ] Type messages — LLM responds in character with personality
- [ ] Disposition bar updates after each exchange
- [ ] Conversation completes after 3+ exchanges
- [ ] Closing and reopening starts fresh conversation
- [ ] Different personalities respond differently to same topics
- [ ] TypeScript builds cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)