### PR TITLE
feat: spell progression — level up spells through use

### DIFF
--- a/src/app/api/v1/tap-tap-adventure/combat/action/route.ts
+++ b/src/app/api/v1/tap-tap-adventure/combat/action/route.ts
@@ -3,6 +3,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { getRegion } from '@/app/tap-tap-adventure/config/regions'
 import { processPlayerAction, getCombatRewards } from '@/app/tap-tap-adventure/lib/combatEngine'
 import { applyDeathPenalty } from '@/app/tap-tap-adventure/lib/deathPenalty'
+import { getSpellLevel } from '@/app/tap-tap-adventure/lib/spellProgression'
 import { CombatActionRequestSchema } from '@/app/tap-tap-adventure/models/combat'
 
 export async function POST(req: NextRequest) {
@@ -36,6 +37,27 @@ export async function POST(req: NextRequest) {
         gold: Math.max(0, character.gold - goldLoss),
       }
       rewards = { gold: -goldLoss, loot: [] }
+    }
+
+    // Grant spell XP if a spell was cast this turn
+    if (actionParsed.action === 'cast_spell' && actionParsed.spellId) {
+      const castLog = updatedCombat.combatLog.find(
+        (l: any) => l.turn === updatedCombat.turnNumber && l.actor === 'player' && l.action === 'cast_spell' && !l.description?.includes('fizzle')
+      )
+      if (castLog && updatedCharacter.spellbook) {
+        const spellIdx = updatedCharacter.spellbook.findIndex((s: any) => s.id === actionParsed.spellId)
+        if (spellIdx >= 0) {
+          const spell = updatedCharacter.spellbook[spellIdx]
+          const newXp = (spell.spellXp ?? 0) + 1
+          const newLevel = getSpellLevel(newXp)
+          updatedCharacter = {
+            ...updatedCharacter,
+            spellbook: updatedCharacter.spellbook.map((s: any, i: number) =>
+              i === spellIdx ? { ...s, spellXp: newXp, spellLevel: newLevel } : s
+            ),
+          }
+        }
+      }
     }
 
     // If mount died in combat, remove it from character

--- a/src/app/tap-tap-adventure/__tests__/achievements.test.ts
+++ b/src/app/tap-tap-adventure/__tests__/achievements.test.ts
@@ -191,6 +191,8 @@ describe('Collection Achievements', () => {
       effects: [],
       cooldown: 1,
       tags: [],
+      spellXp: 0,
+      spellLevel: 1,
     }))
     const char = { ...baseChar, spellbook: spells }
     const { newlyCompleted } = checkAchievements(char, baseGameState, [])

--- a/src/app/tap-tap-adventure/__tests__/achievements.test.ts
+++ b/src/app/tap-tap-adventure/__tests__/achievements.test.ts
@@ -191,8 +191,6 @@ describe('Collection Achievements', () => {
       effects: [],
       cooldown: 1,
       tags: [],
-      spellXp: 0,
-      spellLevel: 1,
     }))
     const char = { ...baseChar, spellbook: spells }
     const { newlyCompleted } = checkAchievements(char, baseGameState, [])

--- a/src/app/tap-tap-adventure/__tests__/spellProgression.test.ts
+++ b/src/app/tap-tap-adventure/__tests__/spellProgression.test.ts
@@ -1,0 +1,47 @@
+import { getSpellLevel, getXpForNextLevel, getSpellLevelMultiplier, MAX_SPELL_LEVEL } from '../lib/spellProgression'
+
+describe('Spell progression', () => {
+  it('level 1 at 0 XP', () => {
+    expect(getSpellLevel(0)).toBe(1)
+  })
+
+  it('level 2 at 3 XP', () => {
+    expect(getSpellLevel(3)).toBe(2)
+  })
+
+  it('level 3 at 8 XP', () => {
+    expect(getSpellLevel(8)).toBe(3)
+  })
+
+  it('level 4 at 15 XP', () => {
+    expect(getSpellLevel(15)).toBe(4)
+  })
+
+  it('level 5 at 25 XP', () => {
+    expect(getSpellLevel(25)).toBe(5)
+  })
+
+  it('stays at level 5 above 25 XP', () => {
+    expect(getSpellLevel(100)).toBe(5)
+  })
+
+  it('XP for next level at level 1 is 3', () => {
+    expect(getXpForNextLevel(1)).toBe(3)
+  })
+
+  it('XP for next level at max level is 0', () => {
+    expect(getXpForNextLevel(5)).toBe(0)
+  })
+
+  it('multiplier is 1.0 at level 1', () => {
+    expect(getSpellLevelMultiplier(1)).toBeCloseTo(1.0)
+  })
+
+  it('multiplier is 1.4 at level 5', () => {
+    expect(getSpellLevelMultiplier(5)).toBeCloseTo(1.4)
+  })
+
+  it('max spell level is 5', () => {
+    expect(MAX_SPELL_LEVEL).toBe(5)
+  })
+})

--- a/src/app/tap-tap-adventure/components/CombatUI.tsx
+++ b/src/app/tap-tap-adventure/components/CombatUI.tsx
@@ -12,6 +12,7 @@ import { MountNamingModal } from '@/app/tap-tap-adventure/components/MountNaming
 import { isUsableInCombat } from '@/app/tap-tap-adventure/lib/combatItemEffects'
 import { ELEMENT_COLORS, getElementalMultiplier } from '@/app/tap-tap-adventure/config/elements'
 import { SpellElement } from '@/app/tap-tap-adventure/models/spell'
+import { getXpForNextLevel } from '@/app/tap-tap-adventure/lib/spellProgression'
 import { soundEngine } from '@/app/tap-tap-adventure/lib/soundEngine'
 import { CombatAction, CombatState } from '@/app/tap-tap-adventure/models/combat'
 import { getWeatherType } from '@/app/tap-tap-adventure/config/weather'
@@ -815,7 +816,7 @@ export function CombatUI({ combatState }: CombatUIProps) {
                   disabled={disabled}
                 >
                   <div className="flex justify-between items-center">
-                    <span className="font-semibold">{spell.name}</span>
+                    <span className="font-semibold">{spell.name}<span className="text-[10px] text-amber-400 ml-1">Lv{spell.spellLevel ?? 1}</span></span>
                     <div className="flex items-center gap-2">
                       {effectiveness && !disabled && (
                         <span className={`text-[9px] font-bold ${effectiveness.color}`}>
@@ -830,6 +831,11 @@ export function CombatUI({ combatState }: CombatUIProps) {
                   <div className="text-[10px] text-slate-400 mt-0.5">
                     {spell.description}
                   </div>
+                  {(spell.spellLevel ?? 1) < 5 && (
+                    <div className="text-[10px] text-slate-600">
+                      XP: {spell.spellXp ?? 0}/{getXpForNextLevel(spell.spellLevel ?? 1)}
+                    </div>
+                  )}
                   {onCooldown && (
                     <span className="text-[10px] text-yellow-400">
                       Cooldown: {spellCooldowns[spell.id]} turns

--- a/src/app/tap-tap-adventure/lib/spellEngine.ts
+++ b/src/app/tap-tap-adventure/lib/spellEngine.ts
@@ -17,6 +17,7 @@ import {
   getCurseHealingMultiplier,
 } from './statusEffects'
 import { checkSpellCombo, getSpellElement } from './spellCombos'
+import { getSpellLevelMultiplier } from './spellProgression'
 
 export interface CastSpellResult {
   playerState: CombatPlayerState
@@ -161,8 +162,9 @@ export function castSpell(
   let totalDamageDealt = 0
 
   for (const effect of spell.effects ?? []) {
-    const damageMultiplier = synergyMultiplier * schoolMultiplier * (doubleDamage ? 2 : 1)
-    const healMultiplier = synergyMultiplier * (doubleHeal ? 2 : 1)
+    const levelMultiplier = getSpellLevelMultiplier(spell.spellLevel ?? 1)
+    const damageMultiplier = synergyMultiplier * schoolMultiplier * (doubleDamage ? 2 : 1) * levelMultiplier
+    const healMultiplier = synergyMultiplier * (doubleHeal ? 2 : 1) * levelMultiplier
     const durationBonus = extendDuration ? 2 : 0
 
     switch (effect.type) {

--- a/src/app/tap-tap-adventure/lib/spellProgression.ts
+++ b/src/app/tap-tap-adventure/lib/spellProgression.ts
@@ -1,0 +1,32 @@
+const XP_THRESHOLDS = [0, 3, 8, 15, 25] // Level 1-5
+
+/**
+ * Get the level for a given XP amount.
+ */
+export function getSpellLevel(xp: number): number {
+  for (let i = XP_THRESHOLDS.length - 1; i >= 0; i--) {
+    if (xp >= XP_THRESHOLDS[i]) return i + 1
+  }
+  return 1
+}
+
+/**
+ * Get the XP needed for the next level. Returns 0 if max level.
+ */
+export function getXpForNextLevel(level: number): number {
+  if (level >= XP_THRESHOLDS.length) return 0
+  return XP_THRESHOLDS[level]
+}
+
+/**
+ * Get the damage/effect multiplier for a spell level.
+ * Each level adds +10% (1.0, 1.1, 1.2, 1.3, 1.4).
+ */
+export function getSpellLevelMultiplier(level: number): number {
+  return 1 + (Math.min(level, 5) - 1) * 0.1
+}
+
+/**
+ * Max spell level.
+ */
+export const MAX_SPELL_LEVEL = 5

--- a/src/app/tap-tap-adventure/models/spell.ts
+++ b/src/app/tap-tap-adventure/models/spell.ts
@@ -123,7 +123,7 @@ export const SpellSchema = z.object({
   tags: z.array(z.string()),
   explorationEffect: ExplorationEffectSchema.optional(),
   explorationManaCost: z.number().optional(),
-  spellXp: z.number().default(0),
-  spellLevel: z.number().default(1),
+  spellXp: z.number().optional(),
+  spellLevel: z.number().optional(),
 })
 export type Spell = z.infer<typeof SpellSchema>

--- a/src/app/tap-tap-adventure/models/spell.ts
+++ b/src/app/tap-tap-adventure/models/spell.ts
@@ -123,5 +123,7 @@ export const SpellSchema = z.object({
   tags: z.array(z.string()),
   explorationEffect: ExplorationEffectSchema.optional(),
   explorationManaCost: z.number().optional(),
+  spellXp: z.number().default(0),
+  spellLevel: z.number().default(1),
 })
 export type Spell = z.infer<typeof SpellSchema>


### PR DESCRIPTION
## Summary
Spells now gain XP each time they're cast and level up to become more powerful:

| Level | XP Required | Effect Multiplier |
|-------|------------|-------------------|
| 1 | 0 | 1.0x |
| 2 | 3 | 1.1x |
| 3 | 8 | 1.2x |
| 4 | 15 | 1.3x |
| 5 (max) | 25 | 1.4x |

- Every successful cast grants 1 spell XP
- Level multiplier applies to ALL numeric effects (damage, healing, shields, DOT, HOT)
- Spell level and XP progress shown in combat spell selection UI
- Backward compatible: existing spells default to Level 1, 0 XP

Closes #435

## Changes
- `models/spell.ts` — added `spellXp`/`spellLevel` fields with defaults
- `lib/spellProgression.ts` (new) — XP thresholds, level calculation, multiplier formula
- `lib/spellEngine.ts` — applied level multiplier to damage and heal calculations
- `combat/action/route.ts` — grants spell XP after successful cast
- `components/CombatUI.tsx` — level badge and XP progress in spell selection
- 11 unit tests

## Test plan
- [ ] Cast a spell — XP increments by 1
- [ ] Cast same spell 3 times — levels up to 2, damage increases ~10%
- [ ] Spell level shown as amber "Lv2" badge in spell menu
- [ ] XP progress shown (e.g., "XP: 3/8")
- [ ] Max level spell (Lv5) shows no XP bar
- [ ] Existing spells work at Level 1 without migration
- [ ] All tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)