### PR TITLE
fix: guarantee at least one town landmark per region

### DIFF
--- a/src/app/tap-tap-adventure/__tests__/landmarks.test.ts
+++ b/src/app/tap-tap-adventure/__tests__/landmarks.test.ts
@@ -100,6 +100,14 @@ describe('generateLandmarks', () => {
     }
   })
 
+  it('should always include at least one town landmark when region has town templates', () => {
+    for (let i = 0; i < 50; i++) {
+      const landmarks = generateLandmarks('green_meadows', `test-char-${i}`, 0)
+      const hasTown = landmarks.some(l => l.type === 'town')
+      expect(hasTown).toBe(true)
+    }
+  })
+
   it('each landmark has required fields', () => {
     const landmarks = generateLandmarks('green_meadows', 'char-1')
     for (const lm of landmarks) {

--- a/src/app/tap-tap-adventure/lib/landmarkGenerator.ts
+++ b/src/app/tap-tap-adventure/lib/landmarkGenerator.ts
@@ -66,8 +66,17 @@ export function generateLandmarks(
   const seed = `${regionId}-${characterId}-${visitCount}`
   const rng = seededRandom(seed)
 
-  // Pick 3 landmarks from templates (shuffled deterministically)
-  const selected = seededShuffle([...templates], rng).slice(0, 3) as LandmarkTemplate[]
+  // Pick 3 landmarks, always including at least 1 town if available
+  const towns = templates.filter(t => t.type === 'town')
+  const nonTowns = templates.filter(t => t.type !== 'town')
+  let selected: LandmarkTemplate[]
+  if (towns.length > 0) {
+    const shuffledTowns = seededShuffle([...towns], rng)
+    const shuffledNonTowns = seededShuffle([...nonTowns], rng)
+    selected = [shuffledTowns[0], ...shuffledNonTowns.slice(0, 2)] as LandmarkTemplate[]
+  } else {
+    selected = seededShuffle([...templates], rng).slice(0, 3) as LandmarkTemplate[]
+  }
 
   // Scale positions within the region size (margin = 10% of size)
   const margin = regionSize * 0.1


### PR DESCRIPTION
## Summary
- Fixes #442 — towns were not guaranteed to appear in regions because only 3 of 4+ landmarks were picked randomly
- Landmark selection now always includes at least one town template (if any exist for the region) before filling remaining slots with non-town landmarks
- Added test verifying town presence across 50 seeds for green_meadows region

## Test plan
- [x] All 26 landmark tests pass (including 1 new test)
- [ ] Manual: verify Green Meadows always spawns Willowbrook across multiple character seeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)