### PR TITLE
feat: town NPCs in TownHub with inline dialogue

### DIFF
--- a/src/app/api/v1/tap-tap-adventure/resolve-decision/route.ts
+++ b/src/app/api/v1/tap-tap-adventure/resolve-decision/route.ts
@@ -10,6 +10,21 @@ import { generateLLMEvents } from '@/app/tap-tap-adventure/lib/llmEventGenerator
 import { FantasyCharacter } from '@/app/tap-tap-adventure/models/character'
 import { Item } from '@/app/tap-tap-adventure/models/item'
 import { FantasyDecisionOption, FantasyDecisionPoint, FantasyStoryEvent } from '@/app/tap-tap-adventure/models/story'
+import { getNPCsForRegion } from '@/app/tap-tap-adventure/config/npcs'
+
+function buildNPCOptions(regionId: string): FantasyDecisionOption[] {
+  const regionNPCs = getNPCsForRegion(regionId)
+  return regionNPCs.map(npc => ({
+    id: `talk-to-npc-${npc.id}`,
+    text: `${npc.icon} Talk to ${npc.name} — ${npc.role}`,
+    successProbability: 1.0,
+    successDescription: `You approach ${npc.name}.`,
+    successEffects: {},
+    failureDescription: '',
+    failureEffects: {},
+    resultDescription: `You talk to ${npc.name}.`,
+  }))
+}
 
 function hashString(str: string): number {
   let hash = 0
@@ -463,6 +478,7 @@ export async function POST(req: NextRequest) {
             failureEffects: {},
             resultDescription: 'You check your mailbox.',
           },
+          ...buildNPCOptions(character.currentRegion ?? 'green_meadows'),
           {
             id: 'leave-town',
             text: '🚪 Leave Town',
@@ -552,6 +568,7 @@ export async function POST(req: NextRequest) {
             failureEffects: {},
             resultDescription: 'You check your mailbox.',
           },
+          ...buildNPCOptions(character.currentRegion ?? 'green_meadows'),
           {
             id: 'leave-town',
             text: '🚪 Leave Town',
@@ -656,6 +673,7 @@ export async function POST(req: NextRequest) {
             failureEffects: {},
             resultDescription: 'You check your mailbox.',
           },
+          ...buildNPCOptions(character.currentRegion ?? 'green_meadows'),
           {
             id: 'leave-town',
             text: '🚪 Leave Town',
@@ -778,6 +796,7 @@ export async function POST(req: NextRequest) {
               failureEffects: {},
               resultDescription: 'You check your mailbox.',
             },
+            ...buildNPCOptions(character.currentRegion ?? 'green_meadows'),
             {
               id: 'leave-town',
               text: '🚪 Leave Town',
@@ -913,6 +932,7 @@ export async function POST(req: NextRequest) {
               failureEffects: {},
               resultDescription: 'You check your mailbox.',
             },
+            ...buildNPCOptions(character.currentRegion ?? 'green_meadows'),
             {
               id: 'leave-town',
               text: '🚪 Leave Town',
@@ -1027,6 +1047,7 @@ export async function POST(req: NextRequest) {
             failureEffects: {},
             resultDescription: 'You check your mailbox.',
           },
+          ...buildNPCOptions(character.currentRegion ?? 'green_meadows'),
           {
             id: 'leave-town',
             text: '🚪 Leave Town',
@@ -1114,6 +1135,7 @@ export async function POST(req: NextRequest) {
             failureEffects: {},
             resultDescription: 'You check your mailbox.',
           },
+          ...buildNPCOptions(character.currentRegion ?? 'green_meadows'),
           {
             id: 'leave-town',
             text: '🚪 Leave Town',
@@ -1203,6 +1225,7 @@ export async function POST(req: NextRequest) {
             failureEffects: {},
             resultDescription: 'You check your mailbox.',
           },
+          ...buildNPCOptions(character.currentRegion ?? 'green_meadows'),
           {
             id: 'leave-town',
             text: '🚪 Leave Town',

--- a/src/app/tap-tap-adventure/components/GameUI.tsx
+++ b/src/app/tap-tap-adventure/components/GameUI.tsx
@@ -57,6 +57,7 @@ import { StatsPanel } from '@/app/tap-tap-adventure/components/StatsPanel'
 import { RunHistoryPanel } from '@/app/tap-tap-adventure/components/RunHistoryPanel'
 import { NPCDialoguePanel } from './NPCDialoguePanel'
 import { createPartyMember } from '@/app/tap-tap-adventure/lib/partyRecruitment'
+import { getNPCById, type GameNPC } from '@/app/tap-tap-adventure/config/npcs'
 import { ContactsList } from './ContactsList'
 import { EventDialog, EventResult } from './EventDialog'
 import { StablePanel } from './StablePanel'
@@ -164,6 +165,7 @@ export default function GameUI({ onOpenStatus }: GameUIProps) {
   const [showStablePanel, setShowStablePanel] = useState(false)
   const [showMailbox, setShowMailbox] = useState(false)
   const [eventResult, setEventResult] = useState<EventResult | null>(null)
+  const [townNPC, setTownNPC] = useState<GameNPC | null>(null)
 
   useEffect(() => {
     if (gameState?.decisionPoint && !gameState.decisionPoint.resolved) {
@@ -172,6 +174,11 @@ export default function GameUI({ onOpenStatus }: GameUIProps) {
       return () => clearTimeout(timer)
     }
     setDecisionGracePeriod(false)
+  }, [gameState?.decisionPoint?.id])
+
+  // Clear town NPC panel when decision point changes (e.g. player leaves town)
+  useEffect(() => {
+    setTownNPC(null)
   }, [gameState?.decisionPoint?.id])
 
   // Check for daily reward on mount
@@ -259,6 +266,15 @@ export default function GameUI({ onOpenStatus }: GameUIProps) {
       setShowMailbox(true)
       return
     }
+    // Town NPC: open dialogue panel for the selected NPC (client-side only)
+    if (optionId.startsWith('talk-to-npc-')) {
+      const npcId = optionId.replace('talk-to-npc-', '')
+      const npc = getNPCById(npcId)
+      if (npc) {
+        setTownNPC(npc)
+      }
+      return
+    }
     resolveDecisionMutation({
       decisionPoint: gameState.decisionPoint!,
       optionId: optionId,
@@ -273,6 +289,7 @@ export default function GameUI({ onOpenStatus }: GameUIProps) {
       onResult: (result) => {
         // Don't show results for options that navigate away (bypass, travel, explore-landmark, etc)
         const skipResults = optionId.startsWith('bypass-') || optionId.startsWith('travel-') ||
+          optionId.startsWith('talk-to-npc-') ||
           optionId === 'explore-landmark' || optionId === 'leave-landmark' ||
           optionId === 'continue-exploring' || optionId === 'visit-shop' ||
           optionId === 'back-to-town' || optionId === 'pay-bounty' ||
@@ -635,7 +652,48 @@ export default function GameUI({ onOpenStatus }: GameUIProps) {
                   isResolving={resolveDecisionPending}
                   character={character!}
                   onSelectOption={handleResolveDecision}
+                  npcDispositions={Object.fromEntries(
+                    Object.entries(character?.npcEncounters ?? {}).map(([id, enc]) => [id, enc.disposition ?? 0])
+                  )}
                 />
+                {townNPC && character && (
+                  <NPCDialoguePanel
+                    npc={townNPC}
+                    characterName={character.name}
+                    characterClass={character.class}
+                    characterLevel={character.level}
+                    reputation={character.reputation}
+                    region={character.currentRegion ?? 'green_meadows'}
+                    characterCharisma={character.charisma ?? 5}
+                    activeCharismaBonus={character.activeExplorationSpells?.filter(s => s.effectType === 'cha_boost').reduce((sum, s) => sum + (s.value ?? 0), 0) ?? 0}
+                    disposition={character.npcEncounters?.[townNPC.id]?.disposition ?? 0}
+                    hiddenLandmarkName={character.landmarkState?.landmarks.find(lm => lm.hidden)?.name}
+                    hiddenLandmarkType={character.landmarkState?.landmarks.find(lm => lm.hidden)?.type}
+                    onEncounterUpdate={(dispositionDelta, reward, revealLandmark) => {
+                      recordNPCEncounter(townNPC.id, dispositionDelta, reward, revealLandmark)
+                    }}
+                    onClose={() => setTownNPC(null)}
+                    onRecruit={() => {
+                      const member = createPartyMember({
+                        id: `npc-${townNPC.id}`,
+                        name: townNPC.name,
+                        description: townNPC.description,
+                        icon: townNPC.icon,
+                        level: character.level,
+                        dailyCost: Math.max(1, Math.floor(character.level / 2)),
+                        rarity: 'uncommon',
+                        personality: townNPC.personality,
+                        relationship: character.npcEncounters?.[townNPC.id]?.disposition ?? 0,
+                        role: 'combatant',
+                      })
+                      const added = addPartyMember(member)
+                      if (added) {
+                        setTownNPC(null)
+                      }
+                    }}
+                    isRecruited={(character.party ?? []).some(m => m.id === `npc-${townNPC.id}`)}
+                  />
+                )}
               </>
             ) : (
               <>

--- a/src/app/tap-tap-adventure/components/TownHub.tsx
+++ b/src/app/tap-tap-adventure/components/TownHub.tsx
@@ -4,6 +4,7 @@ import React from 'react'
 import { LoaderCircle } from 'lucide-react'
 import { Button } from './ui/button'
 import type { FantasyDecisionPoint, FantasyCharacter } from '@/app/tap-tap-adventure/models/types'
+import { getRelationshipTier } from '@/app/tap-tap-adventure/config/npcs'
 
 interface TownHubProps {
   townName: string
@@ -13,6 +14,7 @@ interface TownHubProps {
   character: FantasyCharacter
   onSelectOption: (optionId: string) => void
   statusMessage?: string | null
+  npcDispositions?: Record<string, number>
 }
 
 interface FeatureConfig {
@@ -79,8 +81,12 @@ export function TownHub({
   isResolving,
   character,
   onSelectOption,
+  npcDispositions,
 }: TownHubProps) {
-  const mainOptions = decisionPoint.options.filter(o => o.id !== 'leave-town')
+  const featureOptions = decisionPoint.options.filter(
+    o => o.id !== 'leave-town' && !o.id.startsWith('talk-to-npc-')
+  )
+  const npcOptions = decisionPoint.options.filter(o => o.id.startsWith('talk-to-npc-'))
   const leaveOption = decisionPoint.options.find(o => o.id === 'leave-town')
 
   return (
@@ -115,7 +121,7 @@ export function TownHub({
 
       {/* Feature buttons */}
       <div className="p-4 space-y-2">
-        {mainOptions.map(option => {
+        {featureOptions.map(option => {
           const config = FEATURE_CONFIGS[option.id]
           const icon = config?.icon ?? '✨'
           const disabled =
@@ -146,6 +152,44 @@ export function TownHub({
             </div>
           )
         })}
+
+        {/* Townspeople section */}
+        {npcOptions.length > 0 && (
+          <>
+            <div className="border-t border-[#2a2c42] my-3 flex items-center gap-2">
+              <span className="text-xs text-slate-500 whitespace-nowrap">Townspeople</span>
+              <div className="flex-1 border-t border-[#2a2c42]" />
+            </div>
+            {npcOptions.map(option => {
+              const npcId = option.id.replace('talk-to-npc-', '')
+              const disposition = npcDispositions?.[npcId] ?? 0
+              const tier = getRelationshipTier(disposition)
+              const npcClassName = isResolving
+                ? 'bg-slate-900/40 border-slate-700/40 text-slate-500 cursor-not-allowed opacity-60'
+                : 'bg-emerald-900/40 hover:bg-emerald-800/60 border-emerald-600/40 text-emerald-200 hover:text-emerald-100'
+
+              return (
+                <button
+                  key={option.id}
+                  className={`w-full flex items-center gap-3 px-4 py-3 rounded-lg border transition-colors text-left ${npcClassName}`}
+                  onClick={() => !isResolving && onSelectOption(option.id)}
+                  disabled={isResolving}
+                >
+                  <span className="text-xl leading-none flex-shrink-0">
+                    {/* Extract the emoji from the option text (first grapheme cluster) */}
+                    {[...option.text][0]}
+                  </span>
+                  <div className="flex-1 min-w-0">
+                    <div className="font-semibold text-sm leading-tight">{option.text.slice([...option.text][0].length).trim()}</div>
+                    {disposition !== 0 && (
+                      <div className={`text-xs mt-0.5 ${tier.color}`}>{tier.label}</div>
+                    )}
+                  </div>
+                </button>
+              )
+            })}
+          </>
+        )}
 
         {/* Divider before leave */}
         {leaveOption && (


### PR DESCRIPTION
## Summary

- Region-specific NPCs now appear in the TownHub under a "Townspeople" divider section
- Clicking an NPC opens `NPCDialoguePanel` inline below the TownHub (no navigation away)
- Relationship tier badges (Neutral, Friendly, Trusted, etc.) show for NPCs with prior encounters
- NPC options are added to all town hub rebuilds in the resolve-decision API (enter-town, visit-shop, rest-at-inn, hire-transport fallbacks, back-to-town, visit-stable, check-mailbox)
- Closing the NPC panel returns the player to the TownHub; leaving town clears the panel automatically

## Test plan

- [ ] Enter a town in Starting Village — verify Elder Maren appears under "Townspeople"
- [ ] Enter a town in Green Meadows — verify Bramble appears
- [ ] Click an NPC — verify NPCDialoguePanel opens below TownHub
- [ ] Talk to an NPC and accumulate disposition — verify relationship tier badge appears on subsequent visits
- [ ] Recruit an NPC via the dialogue panel — verify it works correctly
- [ ] Click Leave Town — verify the panel is hidden and the player exits
- [ ] Visit Shop / Rest at Inn / Back to Town — verify NPC buttons persist across hub rebuilds
- [ ] Verify `npm run build` passes with no TypeScript errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)