### PR TITLE
feat: Notice Board for town hubs

### DIFF
--- a/src/app/api/v1/tap-tap-adventure/resolve-decision/route.ts
+++ b/src/app/api/v1/tap-tap-adventure/resolve-decision/route.ts
@@ -244,6 +244,11 @@ export async function POST(req: NextRequest) {
             failureDescription: '', failureEffects: {}, resultDescription: 'You check your mailbox.',
           },
           {
+            id: 'visit-notice-board', text: '📋 Notice Board', successProbability: 1.0,
+            successDescription: 'You check the town notice board.', successEffects: {},
+            failureDescription: '', failureEffects: {}, resultDescription: 'You check the notice board.',
+          },
+          {
             id: 'leave-town', text: '🚪 Leave Town', successProbability: 1.0,
             successDescription: 'You leave.', successEffects: {},
             failureDescription: '', failureEffects: {}, resultDescription: `You leave.`,
@@ -325,6 +330,11 @@ export async function POST(req: NextRequest) {
               id: 'check-mailbox', text: '📬 Check Mailbox', successProbability: 1.0,
               successDescription: 'You check your mailbox for messages.', successEffects: {},
               failureDescription: '', failureEffects: {}, resultDescription: 'You check your mailbox.',
+            },
+            {
+              id: 'visit-notice-board', text: '📋 Notice Board', successProbability: 1.0,
+              successDescription: 'You check the town notice board.', successEffects: {},
+              failureDescription: '', failureEffects: {}, resultDescription: 'You check the notice board.',
             },
             {
               id: 'leave-town', text: '🚪 Leave Town', successProbability: 1.0,
@@ -478,6 +488,16 @@ export async function POST(req: NextRequest) {
             failureEffects: {},
             resultDescription: 'You check your mailbox.',
           },
+          {
+            id: 'visit-notice-board',
+            text: '📋 Notice Board',
+            successProbability: 1.0,
+            successDescription: 'You check the town notice board.',
+            successEffects: {},
+            failureDescription: '',
+            failureEffects: {},
+            resultDescription: 'You check the notice board.',
+          },
           ...buildNPCOptions(character.currentRegion ?? 'green_meadows'),
           {
             id: 'leave-town',
@@ -567,6 +587,16 @@ export async function POST(req: NextRequest) {
             failureDescription: '',
             failureEffects: {},
             resultDescription: 'You check your mailbox.',
+          },
+          {
+            id: 'visit-notice-board',
+            text: '📋 Notice Board',
+            successProbability: 1.0,
+            successDescription: 'You check the town notice board.',
+            successEffects: {},
+            failureDescription: '',
+            failureEffects: {},
+            resultDescription: 'You check the notice board.',
           },
           ...buildNPCOptions(character.currentRegion ?? 'green_meadows'),
           {
@@ -672,6 +702,16 @@ export async function POST(req: NextRequest) {
             failureDescription: '',
             failureEffects: {},
             resultDescription: 'You check your mailbox.',
+          },
+          {
+            id: 'visit-notice-board',
+            text: '📋 Notice Board',
+            successProbability: 1.0,
+            successDescription: 'You check the town notice board.',
+            successEffects: {},
+            failureDescription: '',
+            failureEffects: {},
+            resultDescription: 'You check the notice board.',
           },
           ...buildNPCOptions(character.currentRegion ?? 'green_meadows'),
           {
@@ -795,6 +835,16 @@ export async function POST(req: NextRequest) {
               failureDescription: '',
               failureEffects: {},
               resultDescription: 'You check your mailbox.',
+            },
+            {
+              id: 'visit-notice-board',
+              text: '📋 Notice Board',
+              successProbability: 1.0,
+              successDescription: 'You check the town notice board.',
+              successEffects: {},
+              failureDescription: '',
+              failureEffects: {},
+              resultDescription: 'You check the notice board.',
             },
             ...buildNPCOptions(character.currentRegion ?? 'green_meadows'),
             {
@@ -932,6 +982,16 @@ export async function POST(req: NextRequest) {
               failureEffects: {},
               resultDescription: 'You check your mailbox.',
             },
+            {
+              id: 'visit-notice-board',
+              text: '📋 Notice Board',
+              successProbability: 1.0,
+              successDescription: 'You check the town notice board.',
+              successEffects: {},
+              failureDescription: '',
+              failureEffects: {},
+              resultDescription: 'You check the notice board.',
+            },
             ...buildNPCOptions(character.currentRegion ?? 'green_meadows'),
             {
               id: 'leave-town',
@@ -1047,6 +1107,16 @@ export async function POST(req: NextRequest) {
             failureEffects: {},
             resultDescription: 'You check your mailbox.',
           },
+          {
+            id: 'visit-notice-board',
+            text: '📋 Notice Board',
+            successProbability: 1.0,
+            successDescription: 'You check the town notice board.',
+            successEffects: {},
+            failureDescription: '',
+            failureEffects: {},
+            resultDescription: 'You check the notice board.',
+          },
           ...buildNPCOptions(character.currentRegion ?? 'green_meadows'),
           {
             id: 'leave-town',
@@ -1134,6 +1204,16 @@ export async function POST(req: NextRequest) {
             failureDescription: '',
             failureEffects: {},
             resultDescription: 'You check your mailbox.',
+          },
+          {
+            id: 'visit-notice-board',
+            text: '📋 Notice Board',
+            successProbability: 1.0,
+            successDescription: 'You check the town notice board.',
+            successEffects: {},
+            failureDescription: '',
+            failureEffects: {},
+            resultDescription: 'You check the notice board.',
           },
           ...buildNPCOptions(character.currentRegion ?? 'green_meadows'),
           {
@@ -1225,6 +1305,16 @@ export async function POST(req: NextRequest) {
             failureEffects: {},
             resultDescription: 'You check your mailbox.',
           },
+          {
+            id: 'visit-notice-board',
+            text: '📋 Notice Board',
+            successProbability: 1.0,
+            successDescription: 'You check the town notice board.',
+            successEffects: {},
+            failureDescription: '',
+            failureEffects: {},
+            resultDescription: 'You check the notice board.',
+          },
           ...buildNPCOptions(character.currentRegion ?? 'green_meadows'),
           {
             id: 'leave-town',
@@ -1250,6 +1340,106 @@ export async function POST(req: NextRequest) {
         resourceDelta: {},
         decisionPoint: townHub,
         mailboxOpen: true,
+      })
+    }
+
+    // Handle visit-notice-board: client-side panel, server just returns town hub
+    if (optionId === 'visit-notice-board') {
+      const landmarkState = character.landmarkState
+      const townName = landmarkState?.exploringLandmarkName ?? 'the town'
+      const regionMult = getRegion(character.currentRegion ?? 'green_meadows').difficultyMultiplier
+      const innCost = Math.round(10 * regionMult)
+
+      const townHub: FantasyDecisionPoint = {
+        id: `decision-town-hub-${Date.now()}`,
+        eventId: `town-hub-${Date.now()}`,
+        prompt: `You check the notice board. What else would you like to do in ${townName}?`,
+        options: [
+          {
+            id: 'visit-shop',
+            text: '🏪 Visit the Shop',
+            successProbability: 1.0,
+            successDescription: 'You browse the wares.',
+            successEffects: {},
+            failureDescription: '',
+            failureEffects: {},
+            resultDescription: 'You visit the shop.',
+          },
+          {
+            id: 'rest-at-inn',
+            text: `🛏️ Rest at the Inn (${innCost} gold)`,
+            successProbability: 1.0,
+            successDescription: 'You rest.',
+            successEffects: {},
+            failureDescription: '',
+            failureEffects: {},
+            resultDescription: 'You rest.',
+          },
+          {
+            id: 'hire-transport',
+            text: '🐴 Hire Transport',
+            successProbability: 1.0,
+            successDescription: 'You check transport.',
+            successEffects: {},
+            failureDescription: '',
+            failureEffects: {},
+            resultDescription: 'You check transport.',
+          },
+          {
+            id: 'visit-stable',
+            text: '🐴 Visit the Stable',
+            successProbability: 1.0,
+            successDescription: 'You visit the stable.',
+            successEffects: {},
+            failureDescription: '',
+            failureEffects: {},
+            resultDescription: 'You visit the stable.',
+          },
+          {
+            id: 'check-mailbox',
+            text: '📬 Check Mailbox',
+            successProbability: 1.0,
+            successDescription: 'You check your mailbox.',
+            successEffects: {},
+            failureDescription: '',
+            failureEffects: {},
+            resultDescription: 'You check your mailbox.',
+          },
+          {
+            id: 'visit-notice-board',
+            text: '📋 Notice Board again',
+            successProbability: 1.0,
+            successDescription: 'You check the notice board again.',
+            successEffects: {},
+            failureDescription: '',
+            failureEffects: {},
+            resultDescription: 'You check the notice board.',
+          },
+          ...buildNPCOptions(character.currentRegion ?? 'green_meadows'),
+          {
+            id: 'leave-town',
+            text: '🚪 Leave Town',
+            successProbability: 1.0,
+            successDescription: 'You leave.',
+            successEffects: {},
+            failureDescription: '',
+            failureEffects: {},
+            resultDescription: `You leave ${townName}.`,
+          },
+        ],
+        resolved: false,
+      }
+
+      return NextResponse.json({
+        updatedCharacter: character,
+        resultDescription: 'You check the notice board.',
+        appliedEffects: {},
+        selectedOptionId: optionId,
+        selectedOptionText: option.text,
+        outcomeDescription: 'You check the town notice board.',
+        resourceDelta: {},
+        decisionPoint: townHub,
+        noticeBoardOpen: true,
       })
     }
 

--- a/src/app/tap-tap-adventure/components/GameUI.tsx
+++ b/src/app/tap-tap-adventure/components/GameUI.tsx
@@ -62,6 +62,7 @@ import { ContactsList } from './ContactsList'
 import { EventDialog, EventResult } from './EventDialog'
 import { StablePanel } from './StablePanel'
 import { MailboxPanel } from './MailboxPanel'
+import { NoticeBoard } from './NoticeBoard'
 import { TownHub } from './TownHub'
 
 const DIFFICULTY_STYLES: Record<RegionDifficulty, { label: string; color: string }> = {
@@ -164,6 +165,7 @@ export default function GameUI({ onOpenStatus }: GameUIProps) {
   const [showNPCPanel, setShowNPCPanel] = useState(false)
   const [showStablePanel, setShowStablePanel] = useState(false)
   const [showMailbox, setShowMailbox] = useState(false)
+  const [showNoticeBoard, setShowNoticeBoard] = useState(false)
   const [eventResult, setEventResult] = useState<EventResult | null>(null)
   const [townNPC, setTownNPC] = useState<GameNPC | null>(null)
 
@@ -176,9 +178,10 @@ export default function GameUI({ onOpenStatus }: GameUIProps) {
     setDecisionGracePeriod(false)
   }, [gameState?.decisionPoint?.id])
 
-  // Clear town NPC panel when decision point changes (e.g. player leaves town)
+  // Clear town NPC panel and notice board when decision point changes (e.g. player leaves town)
   useEffect(() => {
     setTownNPC(null)
+    setShowNoticeBoard(false)
   }, [gameState?.decisionPoint?.id])
 
   // Check for daily reward on mount
@@ -266,6 +269,11 @@ export default function GameUI({ onOpenStatus }: GameUIProps) {
       setShowMailbox(true)
       return
     }
+    // Notice Board: open the notice board panel client-side
+    if (optionId === 'visit-notice-board') {
+      setShowNoticeBoard(true)
+      return
+    }
     // Town NPC: open dialogue panel for the selected NPC (client-side only)
     if (optionId.startsWith('talk-to-npc-')) {
       const npcId = optionId.replace('talk-to-npc-', '')
@@ -294,7 +302,7 @@ export default function GameUI({ onOpenStatus }: GameUIProps) {
           optionId === 'continue-exploring' || optionId === 'visit-shop' ||
           optionId === 'back-to-town' || optionId === 'pay-bounty' ||
           optionId === 'fight-secret-boss' || optionId === 'visit-stable' ||
-          optionId === 'check-mailbox' || optionId === 'rest-at-inn' ||
+          optionId === 'check-mailbox' || optionId === 'visit-notice-board' || optionId === 'rest-at-inn' ||
           optionId === 'hire-transport' || optionId === 'leave-town' ||
           optionId === 'enter-town'
         if (!skipResults && result.outcomeDescription) {
@@ -656,6 +664,17 @@ export default function GameUI({ onOpenStatus }: GameUIProps) {
                     Object.entries(character?.npcEncounters ?? {}).map(([id, enc]) => [id, enc.disposition ?? 0])
                   )}
                 />
+                {showNoticeBoard && character && (
+                  <NoticeBoard
+                    character={character}
+                    activeQuest={gameState.activeQuest ?? null}
+                    onAcceptQuest={(quest) => {
+                      useGameStore.getState().setActiveQuest(quest)
+                      setShowNoticeBoard(false)
+                    }}
+                    onClose={() => setShowNoticeBoard(false)}
+                  />
+                )}
                 {townNPC && character && (
                   <NPCDialoguePanel
                     npc={townNPC}

--- a/src/app/tap-tap-adventure/components/NoticeBoard.tsx
+++ b/src/app/tap-tap-adventure/components/NoticeBoard.tsx
@@ -1,0 +1,215 @@
+'use client'
+import { useState, useEffect } from 'react'
+import { FantasyCharacter } from '@/app/tap-tap-adventure/models/types'
+import { TimedQuest } from '@/app/tap-tap-adventure/models/quest'
+import { getRegion, REGIONS } from '@/app/tap-tap-adventure/config/regions'
+import { calculateDay } from '@/app/tap-tap-adventure/lib/leveling'
+import { generateTimedQuest } from '@/app/tap-tap-adventure/lib/questGenerator'
+
+interface NoticeBoardProps {
+  character: FantasyCharacter
+  activeQuest: TimedQuest | null
+  onAcceptQuest: (quest: TimedQuest) => void
+  onClose: () => void
+}
+
+function getQuestProgress(quest: TimedQuest, character: FantasyCharacter): { current: number; total: number } {
+  const range = quest.target - quest.startValue
+  switch (quest.type) {
+    case 'reach_distance':
+      return { current: Math.max(0, character.distance - quest.startValue), total: range }
+    case 'collect_gold':
+      return { current: Math.max(0, character.gold - quest.startValue), total: range }
+    case 'gain_reputation':
+      return { current: Math.max(0, character.reputation - quest.startValue), total: range }
+    case 'win_combat':
+      return { current: quest.status === 'completed' ? 1 : 0, total: 1 }
+    default:
+      return { current: 0, total: 1 }
+  }
+}
+
+function generateRumors(character: FantasyCharacter): string[] {
+  const region = getRegion(character.currentRegion ?? 'green_meadows')
+  const rumors: string[] = []
+
+  // Rumor about connected regions
+  const connectedIds = region.connectedRegions.filter(id => id !== (character.currentRegion ?? 'green_meadows'))
+  if (connectedIds.length > 0) {
+    const connectedRegion = REGIONS[connectedIds[0]]
+    if (connectedRegion) {
+      rumors.push(`Travelers speak of ${connectedRegion.icon} ${connectedRegion.name} — said to be ${connectedRegion.description.split('.')[0].toLowerCase()}.`)
+    }
+    if (connectedIds.length > 1) {
+      const second = REGIONS[connectedIds[1]]
+      if (second) {
+        rumors.push(`Merchants warn that ${second.name} grows more dangerous by the day. Only seasoned adventurers dare venture there.`)
+      }
+    }
+  }
+
+  // Rumor about unexplored landmarks
+  const unexplored = (character.landmarkState?.landmarks ?? []).filter(lm => !lm.explored && !lm.hidden)
+  if (unexplored.length > 0) {
+    const lm = unexplored[0]
+    rumors.push(`Locals whisper of ${lm.icon} ${lm.name} nearby — few have ventured inside and returned to tell the tale.`)
+  }
+
+  // Rumor about hidden landmarks
+  const hidden = (character.landmarkState?.landmarks ?? []).filter(lm => lm.hidden)
+  if (hidden.length > 0) {
+    rumors.push(`An old wanderer mutters something about a secret place hidden in this region, but refuses to say more.`)
+  }
+
+  // Fallback regional flavor
+  if (rumors.length < 2) {
+    rumors.push(`The ${region.theme.split(',')[0]} here is said to hold ancient secrets for those patient enough to seek them.`)
+  }
+
+  return rumors.slice(0, 3)
+}
+
+export function NoticeBoard({ character, activeQuest, onAcceptQuest, onClose }: NoticeBoardProps) {
+  const [generatedQuest, setGeneratedQuest] = useState<TimedQuest | null>(null)
+
+  useEffect(() => {
+    if (!activeQuest) {
+      setGeneratedQuest(generateTimedQuest(character))
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  const currentDay = calculateDay(character.distance ?? 0)
+  const rumors = generateRumors(character)
+  const landmarks = character.landmarkState?.landmarks ?? []
+
+  const daysColor = (quest: TimedQuest) => {
+    const remaining = quest.deadlineDay - currentDay
+    if (remaining <= 0) return 'text-red-400'
+    if (remaining <= 2) return 'text-yellow-400'
+    return 'text-green-400'
+  }
+
+  return (
+    <div className="bg-[#1e1f30] border border-[#3a3c56] rounded-lg p-3 space-y-4">
+      {/* Header */}
+      <div className="flex justify-between items-center">
+        <span className="text-sm font-bold text-amber-400">📋 Notice Board</span>
+        <button className="text-slate-400 hover:text-white text-sm" onClick={onClose}>✕</button>
+      </div>
+
+      {/* Section 1: Quests & Bounties */}
+      <div>
+        <h4 className="text-xs font-semibold text-slate-400 uppercase border-b border-[#3a3c56] pb-1 mb-2">
+          Quests &amp; Bounties
+        </h4>
+        {activeQuest ? (
+          <div className="bg-[#252638] border border-[#3a3c56] rounded p-2 space-y-1.5">
+            <div className="text-xs font-semibold text-slate-200">{activeQuest.title}</div>
+            <div className="text-[10px] text-slate-400 leading-relaxed">{activeQuest.description}</div>
+            {(() => {
+              const { current, total } = getQuestProgress(activeQuest, character)
+              const pct = total > 0 ? Math.min(100, Math.round((current / total) * 100)) : 0
+              return (
+                <div className="space-y-0.5">
+                  <div className="flex items-center gap-1.5">
+                    <div className="flex-1 h-1.5 bg-slate-700 rounded-full overflow-hidden">
+                      <div className="h-full bg-indigo-500 rounded-full transition-all" style={{ width: `${pct}%` }} />
+                    </div>
+                    <span className="text-[10px] text-slate-400 w-16 text-right">{current} / {total}</span>
+                  </div>
+                </div>
+              )
+            })()}
+            <div className={`text-[10px] font-semibold ${daysColor(activeQuest)}`}>
+              {activeQuest.deadlineDay - currentDay <= 0
+                ? 'Quest expired!'
+                : `${activeQuest.deadlineDay - currentDay} day(s) remaining`}
+            </div>
+          </div>
+        ) : generatedQuest ? (
+          <div className="bg-[#252638] border border-indigo-700/40 rounded p-2 space-y-1.5">
+            <div className="text-[10px] text-indigo-400 font-semibold uppercase">New Quest Available</div>
+            <div className="text-xs font-semibold text-slate-200">{generatedQuest.title}</div>
+            <div className="text-[10px] text-slate-400 leading-relaxed">{generatedQuest.description}</div>
+            <div className="text-[10px] text-amber-300">
+              Reward: {generatedQuest.rewards.gold}g
+              {generatedQuest.rewards.reputation ? ` · ${generatedQuest.rewards.reputation} rep` : ''}
+              {generatedQuest.rewards.items?.length ? ` · ${generatedQuest.rewards.items[0].name}` : ''}
+            </div>
+            <button
+              className="text-[10px] px-2 py-1 bg-indigo-900/50 text-indigo-300 rounded hover:bg-indigo-800/60 transition-colors"
+              onClick={() => onAcceptQuest(generatedQuest)}
+            >
+              Accept Quest
+            </button>
+          </div>
+        ) : (
+          <div className="text-xs text-slate-500 italic">No quests available right now.</div>
+        )}
+      </div>
+
+      {/* Section 2: Area Landmarks */}
+      <div>
+        <h4 className="text-xs font-semibold text-slate-400 uppercase border-b border-[#3a3c56] pb-1 mb-2">
+          Area Landmarks
+        </h4>
+        {landmarks.length === 0 ? (
+          <div className="text-xs text-slate-500 italic">No landmarks discovered in this area.</div>
+        ) : (
+          <div className="space-y-1">
+            {landmarks.map((lm, i) => {
+              if (lm.hidden) {
+                return (
+                  <div key={i} className="flex items-center gap-2 text-[10px] text-slate-600 italic">
+                    <span>❓</span>
+                    <span>??? — Rumored location</span>
+                  </div>
+                )
+              }
+              if (lm.explored) {
+                return (
+                  <div key={i} className="flex items-center gap-2 text-[10px] text-slate-500">
+                    <span>{lm.icon}</span>
+                    <span className="flex-1 truncate">{lm.name}</span>
+                    <span className="text-green-600 text-[9px]">✓ Explored</span>
+                  </div>
+                )
+              }
+              return (
+                <div key={i} className="flex items-center gap-2 text-[10px] text-slate-300">
+                  <span>{lm.icon}</span>
+                  <span className="flex-1 truncate">{lm.name}</span>
+                  <span className="text-[9px] px-1 py-0.5 bg-amber-900/40 text-amber-400 rounded">Unexplored</span>
+                </div>
+              )
+            })}
+          </div>
+        )}
+      </div>
+
+      {/* Section 3: Regional Rumors */}
+      <div>
+        <h4 className="text-xs font-semibold text-slate-400 uppercase border-b border-[#3a3c56] pb-1 mb-2">
+          Regional Rumors
+        </h4>
+        <div className="space-y-2">
+          {rumors.map((rumor, i) => (
+            <div key={i} className="flex gap-1.5 text-[10px] text-slate-400 italic leading-relaxed">
+              <span className="shrink-0">💬</span>
+              <span>{rumor}</span>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* Back button */}
+      <button
+        className="w-full text-xs text-slate-400 hover:text-slate-200 py-1 transition-colors"
+        onClick={onClose}
+      >
+        Back to Town
+      </button>
+    </div>
+  )
+}

--- a/src/app/tap-tap-adventure/components/TownHub.tsx
+++ b/src/app/tap-tap-adventure/components/TownHub.tsx
@@ -72,6 +72,11 @@ const FEATURE_CONFIGS: Record<string, FeatureConfig> = {
     className:
       'bg-purple-900/40 hover:bg-purple-800/60 border-purple-600/40 text-purple-200 hover:text-purple-100',
   },
+  'visit-notice-board': {
+    icon: '📋',
+    label: 'Notice Board',
+    className: 'bg-indigo-900/40 hover:bg-indigo-800/60 border-indigo-600/40 text-indigo-200 hover:text-indigo-100',
+  },
 }
 
 export function TownHub({


### PR DESCRIPTION
## Summary

- Adds a new `NoticeBoard` component that opens when the player clicks "📋 Notice Board" in any town hub
- Shows three sections: active/available quests with progress, area landmarks (explored/unexplored/hidden), and regional flavor rumors
- Adds `visit-notice-board` option to all town hub option arrays in the resolve-decision API route (~10 locations)
- Adds `visit-notice-board` to `FEATURE_CONFIGS` in `TownHub.tsx` for styled button rendering
- Wires up quest acceptance via `useGameStore.getState().setActiveQuest(quest)` in `GameUI.tsx`
- No backend API calls needed — fully client-side panel following the StablePanel/MailboxPanel pattern

## Test plan

- [ ] Enter a town hub — confirm "📋 Notice Board" button appears in the feature list
- [ ] Click Notice Board — confirm panel opens with three sections
- [ ] With no active quest: verify a generated quest preview appears with "Accept Quest" button
- [ ] Accept quest — verify it becomes the active quest in the quest panel; notice board closes
- [ ] With active quest: verify progress bar and days remaining display correctly
- [ ] Days remaining color codes: green (>2), yellow (1-2), red (<=0)
- [ ] Area Landmarks section shows explored (muted + checkmark), unexplored (amber badge), hidden (??? rumored)
- [ ] Regional Rumors section shows 2-3 flavor text items with 💬 icon
- [ ] Leaving town clears the notice board panel
- [ ] Build passes with no TypeScript errors (`npm run build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)