### PR TITLE
feat: Tavern & Inn panel with atmosphere + atmospheric town prompts

### DIFF
--- a/src/app/api/v1/tap-tap-adventure/resolve-decision/route.ts
+++ b/src/app/api/v1/tap-tap-adventure/resolve-decision/route.ts
@@ -196,9 +196,12 @@ export async function POST(req: NextRequest) {
       }
 
       const regionId = character.currentRegion ?? 'green_meadows'
+      const bountyAtmosphere = townLandmark?.encounterPrompt
+        ? `You pay your ${bountyAmount} gold bounty to the guards. Your name is cleared! ${townLandmark.encounterPrompt} What would you like to do?`
+        : `You pay your ${bountyAmount} gold bounty to the guards. Your name is cleared! Welcome to ${townLandmark?.name ?? 'the town'}. What would you like to do?`
       const townHub = buildTownHubDecisionPoint({
         townName: townLandmark?.name ?? 'the town',
-        prompt: `You pay your ${bountyAmount} gold bounty to the guards. Your name is cleared! Welcome to ${townLandmark?.name ?? 'the town'}. What would you like to do?`,
+        prompt: bountyAtmosphere,
         regionId,
         features: townLandmark ? {
           hasShop: townLandmark.hasShop,
@@ -252,9 +255,12 @@ export async function POST(req: NextRequest) {
         }
 
         const sneakRegionId = character.currentRegion ?? 'green_meadows'
+        const sneakAtmosphere = townLandmark?.encounterPrompt
+          ? `You slip past the guards! Keep a low profile — your bounty is still active. ${townLandmark.encounterPrompt} What would you like to do?`
+          : `You slip past the guards! You're inside ${townLandmark?.name ?? 'the town'}, but keep a low profile — your bounty is still active. What would you like to do?`
         const townHub = buildTownHubDecisionPoint({
           townName: townLandmark?.name ?? 'the town',
-          prompt: `You slip past the guards! You're inside ${townLandmark?.name ?? 'the town'}, but keep a low profile — your bounty is still active. What would you like to do?`,
+          prompt: sneakAtmosphere,
           regionId: sneakRegionId,
           features: townLandmark ? {
             hasShop: townLandmark.hasShop,
@@ -352,9 +358,12 @@ export async function POST(req: NextRequest) {
       }
 
       const enterRegionId = character.currentRegion ?? 'green_meadows'
+      const enterAtmosphere = townLandmark?.encounterPrompt
+        ? `${townLandmark.encounterPrompt} What would you like to do?`
+        : `Welcome to ${townLandmark?.name ?? 'the town'}! What would you like to do?`
       const townHub = buildTownHubDecisionPoint({
         townName: townLandmark?.name ?? 'the town',
-        prompt: `Welcome to ${townLandmark?.name ?? 'the town'}! The town square is alive with merchants, travelers, and townsfolk going about their day. What would you like to do?`,
+        prompt: enterAtmosphere,
         regionId: enterRegionId,
         features: townLandmark ? {
           hasShop: townLandmark.hasShop,
@@ -650,9 +659,12 @@ export async function POST(req: NextRequest) {
       const targetIndex = landmarkState?.activeTargetIndex ?? 0
       const townLandmark = landmarkState?.landmarks[targetIndex]
 
+      const backAtmosphere = townLandmark?.encounterPrompt
+        ? `You return to the town square. ${townLandmark.encounterPrompt} What would you like to do?`
+        : `You return to the town square of ${townName}. What would you like to do?`
       const townHub = buildTownHubDecisionPoint({
         townName,
-        prompt: `You return to the town square of ${townName}. What would you like to do?`,
+        prompt: backAtmosphere,
         regionId: backRegionId,
         features: townLandmark ? {
           hasShop: townLandmark.hasShop,

--- a/src/app/tap-tap-adventure/components/GameUI.tsx
+++ b/src/app/tap-tap-adventure/components/GameUI.tsx
@@ -63,6 +63,7 @@ import { EventDialog, EventResult } from './EventDialog'
 import { StablePanel } from './StablePanel'
 import { MailboxPanel } from './MailboxPanel'
 import { NoticeBoard } from './NoticeBoard'
+import { TavernPanel } from './TavernPanel'
 import { TownHub } from './TownHub'
 
 const DIFFICULTY_STYLES: Record<RegionDifficulty, { label: string; color: string }> = {
@@ -166,6 +167,8 @@ export default function GameUI({ onOpenStatus }: GameUIProps) {
   const [showStablePanel, setShowStablePanel] = useState(false)
   const [showMailbox, setShowMailbox] = useState(false)
   const [showNoticeBoard, setShowNoticeBoard] = useState(false)
+  const [showTavern, setShowTavern] = useState(false)
+  const restFromTavern = useRef(false)
   const [eventResult, setEventResult] = useState<EventResult | null>(null)
   const [townNPC, setTownNPC] = useState<GameNPC | null>(null)
 
@@ -182,6 +185,7 @@ export default function GameUI({ onOpenStatus }: GameUIProps) {
   useEffect(() => {
     setTownNPC(null)
     setShowNoticeBoard(false)
+    setShowTavern(false)
   }, [gameState?.decisionPoint?.id])
 
   // Check for daily reward on mount
@@ -274,6 +278,12 @@ export default function GameUI({ onOpenStatus }: GameUIProps) {
       setShowNoticeBoard(true)
       return
     }
+    // Tavern: open the tavern panel client-side (bypass if triggered from within the panel)
+    if (optionId === 'rest-at-inn' && !restFromTavern.current) {
+      setShowTavern(true)
+      return
+    }
+    restFromTavern.current = false
     // Town NPC: open dialogue panel for the selected NPC (client-side only)
     if (optionId.startsWith('talk-to-npc-')) {
       const npcId = optionId.replace('talk-to-npc-', '')
@@ -673,6 +683,19 @@ export default function GameUI({ onOpenStatus }: GameUIProps) {
                       setShowNoticeBoard(false)
                     }}
                     onClose={() => setShowNoticeBoard(false)}
+                  />
+                )}
+                {showTavern && character && (
+                  <TavernPanel
+                    character={character}
+                    townName={character.landmarkState?.exploringLandmarkName ?? 'the town'}
+                    onRest={() => {
+                      setShowTavern(false)
+                      restFromTavern.current = true
+                      handleResolveDecision('rest-at-inn')
+                    }}
+                    isResting={resolveDecisionPending}
+                    onClose={() => setShowTavern(false)}
                   />
                 )}
                 {townNPC && character && (

--- a/src/app/tap-tap-adventure/components/TavernPanel.tsx
+++ b/src/app/tap-tap-adventure/components/TavernPanel.tsx
@@ -1,0 +1,171 @@
+'use client'
+import { FantasyCharacter } from '@/app/tap-tap-adventure/models/types'
+import { getRegion, REGIONS } from '@/app/tap-tap-adventure/config/regions'
+
+interface TavernPanelProps {
+  character: FantasyCharacter
+  townName: string
+  onRest: () => void
+  isResting: boolean
+  onClose: () => void
+}
+
+const TAVERN_FLAVORS: Record<string, string> = {
+  hearthwood: 'The hearth crackles warmly as the barkeep polishes a well-worn mug. The smell of roasted meat and fresh bread fills the cozy room.',
+  green_meadows: 'Farmers and merchants share tables over simple fare. A bard in the corner plays a gentle melody on a worn lute.',
+  dark_forest: 'Lantern light flickers across rough-hewn walls. The patrons speak in hushed tones, glancing toward the dark windows.',
+  sunken_ruins: 'Water drips from the ceiling into carefully placed buckets. The air tastes of salt and the drinks are suspiciously warm.',
+  feywild_grove: 'The tables float slightly above the ground. Your drink changes color each time you look away, but it always tastes pleasant.',
+  crystal_caves: 'Luminescent crystals serve as lanterns. The miners around you nurse their drinks with calloused hands, sharing stories of what they\'ve found below.',
+  bone_wastes: 'The bar is made from a massive rib bone. The drinks are strong and the atmosphere grim, but the warmth is welcome.',
+  scorched_wastes: 'A blessed breeze from enchanted fans keeps the heat at bay. Cool water is the most popular order here.',
+  frozen_peaks: 'A roaring fire dominates the room. Everyone huddles close, thawing frozen limbs and sharing tales of the mountain passes.',
+  volcanic_forge: 'The natural heat from the caldera keeps the room uncomfortably warm. The forge-master\'s apprentices drink deeply between shifts.',
+  dragons_spine: 'Dragon scale decorations line the walls. The patrons here are battle-hardened, and stories of narrow escapes fill the air.',
+  shadow_realm: 'The tavern flickers in and out of solidity. Your mug feels both real and dreamlike. The barkeep\'s face is hard to remember.',
+  sky_citadel: 'Wind howls past the windows of this floating establishment. The view is breathtaking if you dare to look down.',
+  abyssal_depths: 'Bioluminescent organisms provide dim light. The drinks are exotic and the pressure makes everything taste slightly different.',
+  celestial_throne: 'Divine light streams through impossible windows. The nectar served here is said to grant brief moments of clarity beyond mortal understanding.',
+}
+
+function getTavernFlavor(regionId: string): string {
+  return TAVERN_FLAVORS[regionId] ?? 'The tavern is warm and welcoming. The smell of ale and woodsmoke mingles with the sound of laughter and clinking mugs.'
+}
+
+function generateRumors(character: FantasyCharacter): string[] {
+  const region = getRegion(character.currentRegion ?? 'green_meadows')
+  const rumors: string[] = []
+
+  // Rumor about connected regions
+  const connectedIds = region.connectedRegions.filter(id => id !== (character.currentRegion ?? 'green_meadows'))
+  if (connectedIds.length > 0) {
+    const connectedRegion = REGIONS[connectedIds[0]]
+    if (connectedRegion) {
+      rumors.push(`Travelers speak of ${connectedRegion.icon} ${connectedRegion.name} — said to be ${connectedRegion.description.split('.')[0].toLowerCase()}.`)
+    }
+    if (connectedIds.length > 1) {
+      const second = REGIONS[connectedIds[1]]
+      if (second) {
+        rumors.push(`Merchants warn that ${second.name} grows more dangerous by the day. Only seasoned adventurers dare venture there.`)
+      }
+    }
+  }
+
+  // Rumor about unexplored landmarks
+  const unexplored = (character.landmarkState?.landmarks ?? []).filter(lm => !lm.explored && !lm.hidden)
+  if (unexplored.length > 0) {
+    const lm = unexplored[0]
+    rumors.push(`Locals whisper of ${lm.icon} ${lm.name} nearby — few have ventured inside and returned to tell the tale.`)
+  }
+
+  // Rumor about hidden landmarks
+  const hidden = (character.landmarkState?.landmarks ?? []).filter(lm => lm.hidden)
+  if (hidden.length > 0) {
+    rumors.push(`An old wanderer mutters something about a secret place hidden in this region, but refuses to say more.`)
+  }
+
+  // Fallback regional flavor
+  if (rumors.length < 2) {
+    rumors.push(`The ${region.theme.split(',')[0]} here is said to hold ancient secrets for those patient enough to seek them.`)
+  }
+
+  return rumors.slice(0, 3)
+}
+
+export function TavernPanel({ character, townName, onRest, isResting, onClose }: TavernPanelProps) {
+  const regionId = character.currentRegion ?? 'green_meadows'
+  const region = getRegion(regionId)
+  const innCost = Math.round(10 * region.difficultyMultiplier)
+  const canAfford = (character.gold ?? 0) >= innCost
+  const hp = character.hp ?? character.maxHp ?? 0
+  const maxHp = character.maxHp ?? 100
+  const mana = character.mana ?? character.maxMana ?? 0
+  const maxMana = character.maxMana ?? 50
+  const isFullHealth = hp >= maxHp && mana >= maxMana
+
+  const rumors = generateRumors(character)
+  const flavor = getTavernFlavor(regionId)
+
+  return (
+    <div className="bg-[#1e1f30] border border-[#3a3c56] rounded-lg p-3 space-y-4">
+      {/* Header */}
+      <div className="flex justify-between items-center">
+        <span className="text-sm font-bold text-amber-400">🍺 Tavern &amp; Inn</span>
+        <button className="text-slate-400 hover:text-white text-sm" onClick={onClose}>✕</button>
+      </div>
+
+      {/* Atmosphere */}
+      <div className="text-[11px] text-slate-300 leading-relaxed italic bg-[#181929] border border-[#2a2c42] rounded p-2">
+        {flavor}
+      </div>
+
+      {/* Rest section */}
+      <div>
+        <h4 className="text-xs font-semibold text-slate-400 uppercase border-b border-[#3a3c56] pb-1 mb-2">
+          Rest &amp; Recover
+        </h4>
+        <div className="bg-[#252638] border border-[#3a3c56] rounded p-2 space-y-2">
+          <div className="flex gap-4 text-[10px]">
+            <span>
+              <span className="text-slate-400">HP </span>
+              <span className="text-red-400 font-semibold">{hp}</span>
+              <span className="text-slate-600"> / {maxHp}</span>
+            </span>
+            <span>
+              <span className="text-slate-400">MP </span>
+              <span className="text-blue-400 font-semibold">{mana}</span>
+              <span className="text-slate-600"> / {maxMana}</span>
+            </span>
+            <span>
+              <span className="text-amber-300 font-semibold">🪙 {character.gold} gold</span>
+            </span>
+          </div>
+          <div className="text-[10px] text-slate-400">
+            A night&apos;s rest costs <span className="text-amber-300 font-semibold">{innCost} gold</span> and fully restores HP and MP.
+          </div>
+          {isFullHealth ? (
+            <div className="text-[10px] text-green-400 italic">You are already at full health and mana.</div>
+          ) : !canAfford ? (
+            <div className="text-[10px] text-red-400 italic">
+              Not enough gold. You need {innCost}g (have {character.gold ?? 0}g).
+            </div>
+          ) : null}
+          <button
+            className={`text-[10px] px-3 py-1.5 rounded transition-colors font-semibold ${
+              canAfford && !isResting
+                ? 'bg-teal-900/50 text-teal-300 hover:bg-teal-800/60'
+                : 'bg-slate-700/40 text-slate-500 cursor-not-allowed opacity-60'
+            }`}
+            disabled={!canAfford || isResting}
+            onClick={onRest}
+          >
+            {isResting ? 'Resting...' : `Rest (${innCost} gold)`}
+          </button>
+        </div>
+      </div>
+
+      {/* Rumors section */}
+      <div>
+        <h4 className="text-xs font-semibold text-slate-400 uppercase border-b border-[#3a3c56] pb-1 mb-2">
+          Tavern Rumors
+        </h4>
+        <div className="space-y-2">
+          {rumors.map((rumor, i) => (
+            <div key={i} className="flex gap-1.5 text-[10px] text-slate-400 italic leading-relaxed">
+              <span className="shrink-0">💬</span>
+              <span>{rumor}</span>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* Back button */}
+      <button
+        className="w-full text-xs text-slate-400 hover:text-slate-200 py-1 transition-colors"
+        onClick={onClose}
+      >
+        Back to Town
+      </button>
+    </div>
+  )
+}

--- a/src/app/tap-tap-adventure/components/TownHub.tsx
+++ b/src/app/tap-tap-adventure/components/TownHub.tsx
@@ -34,25 +34,10 @@ const FEATURE_CONFIGS: Record<string, FeatureConfig> = {
       'bg-amber-900/40 hover:bg-amber-800/60 border-amber-600/40 text-amber-200 hover:text-amber-100',
   },
   'rest-at-inn': {
-    icon: '🛏️',
-    label: 'Rest at Inn',
+    icon: '🍺',
+    label: 'Tavern & Inn',
     className:
       'bg-teal-900/40 hover:bg-teal-800/60 border-teal-600/40 text-teal-200 hover:text-teal-100',
-    disabledClassName:
-      'bg-slate-900/40 border-slate-700/40 text-slate-500 cursor-not-allowed opacity-60',
-    isDisabled: (option, character) => {
-      const match = option.text.match(/\((\d+) gold\)/)
-      if (!match) return false
-      const cost = parseInt(match[1], 10)
-      return character.gold < cost
-    },
-    disabledReason: (option, character) => {
-      const match = option.text.match(/\((\d+) gold\)/)
-      if (!match) return null
-      const cost = parseInt(match[1], 10)
-      if (character.gold < cost) return `Need ${cost} gold (have ${character.gold})`
-      return null
-    },
   },
   'hire-transport': {
     icon: '🐴',


### PR DESCRIPTION
## Summary
- **New TavernPanel component** — replaces the plain "Rest at Inn" button with a full sub-panel (like Shop/Stable/NoticeBoard) showing:
  - Region-specific atmosphere text (15 unique tavern descriptions, one per region)
  - HP/MP/gold status with clear rest cost display
  - Rest button with affordability check and full-health detection
  - Tavern rumors (regional hints about landmarks, connected regions, secrets)
- **Atmospheric town entry prompts** — enter-town, pay-bounty, sneak-into-town, and back-to-town now use each landmark's unique `encounterPrompt` instead of generic text. Every town now greets the player with its own flavor.

## Changes
| File | What |
|------|------|
| `components/TavernPanel.tsx` | **NEW** — 172-line tavern panel with atmosphere, rest, and rumors |
| `components/GameUI.tsx` | Wire up TavernPanel with ref-based bypass pattern for rest action |
| `components/TownHub.tsx` | Rename "Rest at Inn" to "Tavern & Inn", remove inline cost/disabled logic |
| `resolve-decision/route.ts` | Use landmark encounterPrompt in 4 town entry handlers |

## Test plan
- [x] `next build` succeeds
- [ ] Manual: enter a town, click "Tavern & Inn", see atmosphere text and rumors
- [ ] Manual: click Rest in tavern, verify HP/MP restored and gold deducted
- [ ] Manual: verify disabled state when can't afford or already at full health
- [ ] Manual: enter different towns (Rusty Flagon vs Willowbrook vs Bone Outpost) and see unique welcome text

Part of #410

🤖 Generated with [Claude Code](https://claude.com/claude-code)