### PR TITLE
feat: blacksmith crafting at forge towns

### DIFF
--- a/src/app/api/v1/tap-tap-adventure/resolve-decision/townHubBuilder.ts
+++ b/src/app/api/v1/tap-tap-adventure/resolve-decision/townHubBuilder.ts
@@ -9,6 +9,7 @@ interface TownFeatures {
   hasMailbox?: boolean
   hasNoticeBoard?: boolean
   hasTransport?: boolean
+  hasCrafting?: boolean
 }
 
 export function buildTownHubDecisionPoint(params: {
@@ -106,6 +107,21 @@ export function buildTownHubDecisionPoint(params: {
       failureDescription: '',
       failureEffects: {},
       resultDescription: 'You check the notice board.',
+    })
+  }
+
+  const hasCrafting = features?.hasCrafting === true
+
+  if (hasCrafting) {
+    options.push({
+      id: 'visit-blacksmith',
+      text: '⚒️ Visit the Blacksmith',
+      successProbability: 1.0,
+      successDescription: 'You head to the forge to craft and repair.',
+      successEffects: {},
+      failureDescription: '',
+      failureEffects: {},
+      resultDescription: 'You visit the blacksmith.',
     })
   }
 

--- a/src/app/tap-tap-adventure/components/GameUI.tsx
+++ b/src/app/tap-tap-adventure/components/GameUI.tsx
@@ -168,6 +168,7 @@ export default function GameUI({ onOpenStatus }: GameUIProps) {
   const [showMailbox, setShowMailbox] = useState(false)
   const [showNoticeBoard, setShowNoticeBoard] = useState(false)
   const [showTavern, setShowTavern] = useState(false)
+  const [showBlacksmith, setShowBlacksmith] = useState(false)
   const restFromTavern = useRef(false)
   const [eventResult, setEventResult] = useState<EventResult | null>(null)
   const [townNPC, setTownNPC] = useState<GameNPC | null>(null)
@@ -186,6 +187,7 @@ export default function GameUI({ onOpenStatus }: GameUIProps) {
     setTownNPC(null)
     setShowNoticeBoard(false)
     setShowTavern(false)
+    setShowBlacksmith(false)
   }, [gameState?.decisionPoint?.id])
 
   // Check for daily reward on mount
@@ -278,6 +280,11 @@ export default function GameUI({ onOpenStatus }: GameUIProps) {
       setShowNoticeBoard(true)
       return
     }
+    // Blacksmith: open the crafting panel client-side
+    if (optionId === 'visit-blacksmith') {
+      setShowBlacksmith(true)
+      return
+    }
     // Tavern: open the tavern panel client-side (bypass if triggered from within the panel)
     if (optionId === 'rest-at-inn' && !restFromTavern.current) {
       setShowTavern(true)
@@ -312,7 +319,7 @@ export default function GameUI({ onOpenStatus }: GameUIProps) {
           optionId === 'continue-exploring' || optionId === 'visit-shop' ||
           optionId === 'back-to-town' || optionId === 'pay-bounty' ||
           optionId === 'fight-secret-boss' || optionId === 'visit-stable' ||
-          optionId === 'check-mailbox' || optionId === 'visit-notice-board' || optionId === 'rest-at-inn' ||
+          optionId === 'check-mailbox' || optionId === 'visit-notice-board' || optionId === 'rest-at-inn' || optionId === 'visit-blacksmith' ||
           optionId === 'hire-transport' || optionId === 'leave-town' ||
           optionId === 'enter-town'
         if (!skipResults && result.outcomeDescription) {
@@ -735,6 +742,12 @@ export default function GameUI({ onOpenStatus }: GameUIProps) {
                     }}
                     isRecruited={(character.party ?? []).some(m => m.id === `npc-${townNPC.id}`)}
                   />
+                )}
+                {showBlacksmith && (
+                  <div className="space-y-2">
+                    <button className="text-[10px] text-slate-400 hover:text-slate-200" onClick={() => setShowBlacksmith(false)}>← Back to Town</button>
+                    <CraftingPanel />
+                  </div>
                 )}
               </>
             ) : (

--- a/src/app/tap-tap-adventure/components/TownHub.tsx
+++ b/src/app/tap-tap-adventure/components/TownHub.tsx
@@ -62,6 +62,11 @@ const FEATURE_CONFIGS: Record<string, FeatureConfig> = {
     label: 'Notice Board',
     className: 'bg-indigo-900/40 hover:bg-indigo-800/60 border-indigo-600/40 text-indigo-200 hover:text-indigo-100',
   },
+  'visit-blacksmith': {
+    icon: '⚒️',
+    label: 'Visit Blacksmith',
+    className: 'bg-orange-900/40 hover:bg-orange-800/60 border-orange-600/40 text-orange-200 hover:text-orange-100',
+  },
 }
 
 export function TownHub({

--- a/src/app/tap-tap-adventure/config/landmarks.ts
+++ b/src/app/tap-tap-adventure/config/landmarks.ts
@@ -14,6 +14,7 @@ export interface LandmarkTemplate {
   hasMailbox?: boolean
   hasNoticeBoard?: boolean
   hasTransport?: boolean
+  hasCrafting?: boolean
 }
 
 export const LANDMARK_TEMPLATES: Record<string, LandmarkTemplate[]> = {
@@ -63,6 +64,7 @@ export const LANDMARK_TEMPLATES: Record<string, LandmarkTemplate[]> = {
       hasMailbox: false,
       hasNoticeBoard: false,
       hasTransport: false,
+      hasCrafting: true,
     },
     {
       id: 'sv_well',
@@ -441,6 +443,7 @@ export const LANDMARK_TEMPLATES: Record<string, LandmarkTemplate[]> = {
       hasMailbox: false,
       hasNoticeBoard: false,
       hasTransport: false,
+      hasCrafting: true,
     },
     {
       id: 'vf_shrine',

--- a/src/app/tap-tap-adventure/lib/landmarkGenerator.ts
+++ b/src/app/tap-tap-adventure/lib/landmarkGenerator.ts
@@ -19,6 +19,7 @@ export interface GeneratedLandmark {
   hasMailbox?: boolean
   hasNoticeBoard?: boolean
   hasTransport?: boolean
+  hasCrafting?: boolean
 }
 
 // Simple string hash for seeded random
@@ -113,6 +114,7 @@ export function generateLandmarks(
       hasMailbox: template.hasMailbox,
       hasNoticeBoard: template.hasNoticeBoard,
       hasTransport: template.hasTransport,
+      hasCrafting: template.hasCrafting,
     })
     currentDist += Math.floor((25 + Math.floor(rng() * 26)) * difficultyMultiplier) // 25-50, scaled
   }
@@ -146,6 +148,7 @@ export function generateLandmarks(
       hasMailbox: secretTemplate.hasMailbox,
       hasNoticeBoard: secretTemplate.hasNoticeBoard,
       hasTransport: secretTemplate.hasTransport,
+      hasCrafting: secretTemplate.hasCrafting,
     })
     landmarks.sort((a, b) => a.distanceFromEntry - b.distanceFromEntry)
   }

--- a/src/app/tap-tap-adventure/models/character.ts
+++ b/src/app/tap-tap-adventure/models/character.ts
@@ -122,6 +122,7 @@ export const FantasyCharacterSchema = z.object({
       hasMailbox: z.boolean().optional(),
       hasNoticeBoard: z.boolean().optional(),
       hasTransport: z.boolean().optional(),
+      hasCrafting: z.boolean().optional(),
     })),
     entryDistance: z.number(),
     nextLandmarkIndex: z.number(),


### PR DESCRIPTION
## Summary
- **"Visit Blacksmith" option** at forge-type town landmarks (Garron's Forge, Ironblood Forge)
- Opens the existing CraftingPanel directly from the town hub
- Uses `hasCrafting` feature flag (defaults to false — only explicitly enabled forge towns show it)
- Follows the same pattern as stable/mailbox/notice board (client-side intercept)

## Changes
| File | What |
|------|------|
| `config/landmarks.ts` | Add `hasCrafting` flag, set true on sv_blacksmith + vf_forge |
| `lib/landmarkGenerator.ts` | Copy `hasCrafting` to GeneratedLandmark |
| `models/character.ts` | Add `hasCrafting` to landmark Zod schema |
| `townHubBuilder.ts` | Add crafting option (defaults false, unlike other features) |
| `TownHub.tsx` | Add feature config with orange styling |
| `GameUI.tsx` | Intercept + render CraftingPanel with back button |

## Test plan
- [x] `next build` succeeds
- [ ] Manual: visit Garron's Forge, see "Visit Blacksmith" option
- [ ] Manual: visit Willowbrook (no forge), confirm no blacksmith option
- [ ] Manual: click blacksmith, craft an item, return to town hub

Closes #452

🤖 Generated with [Claude Code](https://claude.com/claude-code)