### PR TITLE
feat: town-aware shop inventory — themed items per landmark

### DIFF
--- a/src/app/api/v1/tap-tap-adventure/shop/generate/route.ts
+++ b/src/app/api/v1/tap-tap-adventure/shop/generate/route.ts
@@ -4,12 +4,12 @@ import { generateShopItems, generateShopMount } from '@/app/tap-tap-adventure/li
 
 export async function POST(req: NextRequest) {
   try {
-    const { character } = await req.json()
+    const { character, townName, townDescription } = await req.json()
     if (!character) {
       return NextResponse.json({ error: 'Character is required' }, { status: 400 })
     }
 
-    const shopItems = await generateShopItems(character)
+    const shopItems = await generateShopItems(character, townName, townDescription)
     const shopMount = generateShopMount(character)
     return NextResponse.json({ shopItems, shopMount })
   } catch (err) {

--- a/src/app/tap-tap-adventure/__tests__/shopGenerator.test.ts
+++ b/src/app/tap-tap-adventure/__tests__/shopGenerator.test.ts
@@ -4,10 +4,10 @@ import { getFallbackShopItems } from '@/app/tap-tap-adventure/lib/shopGenerator'
 
 describe('shopGenerator', () => {
   describe('getFallbackShopItems', () => {
-    it('returns 5 or 6 items (4 consumables + 1-2 spell scrolls)', () => {
+    it('returns 5 to 7 items (4 consumables + 1-2 spell scrolls + optional map)', () => {
       const items = getFallbackShopItems(1)
       expect(items.length).toBeGreaterThanOrEqual(5)
-      expect(items.length).toBeLessThanOrEqual(6)
+      expect(items.length).toBeLessThanOrEqual(7)
     })
 
     it('all items have required fields', () => {

--- a/src/app/tap-tap-adventure/hooks/useResolveDecisionMutation.ts
+++ b/src/app/tap-tap-adventure/hooks/useResolveDecisionMutation.ts
@@ -308,10 +308,16 @@ export function useResolveDecisionMutation() {
       if (data.shopEvent) {
         soundEngine.playGold()
         const currentCharacter = getSelectedCharacter()
+        const landmarkState = (currentCharacter ?? data.updatedCharacter)?.landmarkState
+        const townLandmark = landmarkState?.landmarks?.[landmarkState?.activeTargetIndex ?? 0]
         const shopRes = await fetch('/api/v1/tap-tap-adventure/shop/generate', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ character: currentCharacter ?? data.updatedCharacter }),
+          body: JSON.stringify({
+            character: currentCharacter ?? data.updatedCharacter,
+            townName: landmarkState?.exploringLandmarkName,
+            townDescription: townLandmark?.description,
+          }),
         })
         if (shopRes.ok) {
           const shopData = await shopRes.json()

--- a/src/app/tap-tap-adventure/lib/shopGenerator.ts
+++ b/src/app/tap-tap-adventure/lib/shopGenerator.ts
@@ -97,16 +97,30 @@ export function generateShopMount(character: FantasyCharacter): ShopMount | null
   return { mount, price }
 }
 
-export async function generateShopItems(character: FantasyCharacter): Promise<Item[]> {
+export async function generateShopItems(
+  character: FantasyCharacter,
+  townName?: string,
+  townDescription?: string
+): Promise<Item[]> {
   try {
     const basePrice = 10 + character.level * 5
+    const shopContext = townName
+      ? `Generate 3-5 shop items for the merchant's shop at "${townName}"${townDescription ? ` — ${townDescription}` : ''}. The items should be thematically appropriate for this specific shop AND suitable for a level ${character.level} ${character.class} ${character.race} character.
+
+Shop theme guidance:
+- If this is a forge/smithy/blacksmith, focus on weapons, armor, and metal goods
+- If this is a tavern/inn, focus on food, drinks, potions, and consumables
+- If this is a market/bazaar, offer a diverse mix of trade goods and exotic items
+- If this is an outpost/camp, focus on survival supplies and basic equipment
+- Match the shop's personality to its name and description`
+      : `Generate 3-5 shop items for a fantasy merchant's shop. The items should be appropriate for a level ${character.level} ${character.class} ${character.race} character.`
     const openai = getOpenAIClient()
     const response = await openai.chat.completions.create({
       model: 'gpt-4o',
       messages: [
         {
           role: 'user',
-          content: `Generate 3-5 shop items for a fantasy merchant's shop. The items should be appropriate for a level ${character.level} ${character.class} ${character.race} character.
+          content: `${shopContext}
 
 Price guidelines for level ${character.level}:
 - Cheap items: ${Math.round(basePrice * 0.5)}-${basePrice} gold


### PR DESCRIPTION
## Summary
Shop inventory is now themed based on the town landmark. Each town's shop generates items that match its personality:

| Town Type | Shop Focus |
|-----------|-----------|
| Forge/Smithy (Garron's Forge, Ironblood Forge) | Weapons, armor, metal goods |
| Tavern/Inn (The Rusty Flagon) | Food, drinks, potions, consumables |
| Market/Bazaar (Puck's Bazaar, Void Market) | Diverse trade goods, exotic items |
| Outpost/Camp (Bone Outpost, Miner's Camp) | Survival supplies, basic equipment |

The town name and description are passed to the LLM shop generator prompt, which uses them to theme the inventory. Milestone shops (triggered by distance) remain generic.

## Changes
| File | What |
|------|------|
| `shop/generate/route.ts` | Accept optional `townName`, `townDescription` params |
| `lib/shopGenerator.ts` | Use town context in LLM prompt with type-specific guidance |
| `hooks/useResolveDecisionMutation.ts` | Pass landmark name/description when generating town shops |
| `__tests__/shopGenerator.test.ts` | Fix pre-existing flaky test bound |

## Test plan
- [x] All 931 tests pass
- [x] `next build` succeeds
- [ ] Manual: visit Garron's Forge shop, see weapons/armor focus
- [ ] Manual: visit The Rusty Flagon shop, see consumables focus
- [ ] Manual: milestone shops still show generic inventory

🤖 Generated with [Claude Code](https://claude.com/claude-code)