### PR TITLE
feat: fast-travel waypoints between visited towns

### DIFF
--- a/src/app/api/v1/tap-tap-adventure/resolve-decision/route.ts
+++ b/src/app/api/v1/tap-tap-adventure/resolve-decision/route.ts
@@ -225,11 +225,33 @@ export async function POST(req: NextRequest) {
           }
         : undefined
 
-      const updatedCharacter: FantasyCharacter = {
+      let updatedCharacter: FantasyCharacter = {
         ...character,
         gold: clampGold((character.gold ?? 0) - bountyAmount),
         bounty: 0,
         landmarkState: updatedLandmarkState,
+      }
+
+      // Record this town as visited for fast-travel waypoints
+      if (townLandmark) {
+        const bountyRegionId = character.currentRegion ?? 'green_meadows'
+        const alreadyVisited = (updatedCharacter.visitedTowns ?? []).some(
+          t => t.landmarkId === townLandmark.templateId && t.regionId === bountyRegionId
+        )
+        if (!alreadyVisited) {
+          updatedCharacter = {
+            ...updatedCharacter,
+            visitedTowns: [
+              ...(updatedCharacter.visitedTowns ?? []),
+              {
+                name: townLandmark.name,
+                icon: townLandmark.icon,
+                regionId: bountyRegionId,
+                landmarkId: townLandmark.templateId,
+              },
+            ],
+          }
+        }
       }
 
       const regionId = character.currentRegion ?? 'green_meadows'
@@ -280,9 +302,31 @@ export async function POST(req: NextRequest) {
             }
           : undefined
 
-        const updatedCharacter: FantasyCharacter = {
+        let updatedCharacter: FantasyCharacter = {
           ...character,
           landmarkState: updatedLandmarkState,
+        }
+
+        // Record this town as visited for fast-travel waypoints
+        if (townLandmark) {
+          const sneakVisitRegionId = character.currentRegion ?? 'green_meadows'
+          const alreadyVisited = (updatedCharacter.visitedTowns ?? []).some(
+            t => t.landmarkId === townLandmark.templateId && t.regionId === sneakVisitRegionId
+          )
+          if (!alreadyVisited) {
+            updatedCharacter = {
+              ...updatedCharacter,
+              visitedTowns: [
+                ...(updatedCharacter.visitedTowns ?? []),
+                {
+                  name: townLandmark.name,
+                  icon: townLandmark.icon,
+                  regionId: sneakVisitRegionId,
+                  landmarkId: townLandmark.templateId,
+                },
+              ],
+            }
+          }
         }
 
         const sneakRegionId = character.currentRegion ?? 'green_meadows'
@@ -377,9 +421,31 @@ export async function POST(req: NextRequest) {
           }
         : undefined
 
-      const updatedCharacter: FantasyCharacter = {
+      let updatedCharacter: FantasyCharacter = {
         ...character,
         landmarkState: updatedLandmarkState,
+      }
+
+      // Record this town as visited for fast-travel waypoints
+      if (townLandmark) {
+        const enterRegionIdForVisit = character.currentRegion ?? 'green_meadows'
+        const alreadyVisited = (updatedCharacter.visitedTowns ?? []).some(
+          t => t.landmarkId === townLandmark.templateId && t.regionId === enterRegionIdForVisit
+        )
+        if (!alreadyVisited) {
+          updatedCharacter = {
+            ...updatedCharacter,
+            visitedTowns: [
+              ...(updatedCharacter.visitedTowns ?? []),
+              {
+                name: townLandmark.name,
+                icon: townLandmark.icon,
+                regionId: enterRegionIdForVisit,
+                landmarkId: townLandmark.templateId,
+              },
+            ],
+          }
+        }
       }
 
       // Check for random town event (~15% chance)

--- a/src/app/api/v1/tap-tap-adventure/resolve-decision/townHubBuilder.ts
+++ b/src/app/api/v1/tap-tap-adventure/resolve-decision/townHubBuilder.ts
@@ -91,6 +91,16 @@ export function buildTownHubDecisionPoint(params: {
       failureEffects: {},
       resultDescription: 'You check available transport.',
     })
+    options.push({
+      id: 'visit-waypoints',
+      text: '🗺️ Waypoints',
+      successProbability: 1.0,
+      successDescription: 'You check the waypoint board for fast travel destinations.',
+      successEffects: {},
+      failureDescription: '',
+      failureEffects: {},
+      resultDescription: 'You check the waypoint board.',
+    })
   }
 
   if (hasStable) {

--- a/src/app/tap-tap-adventure/components/GameUI.tsx
+++ b/src/app/tap-tap-adventure/components/GameUI.tsx
@@ -65,6 +65,7 @@ import { MailboxPanel } from './MailboxPanel'
 import { NoticeBoard } from './NoticeBoard'
 import { TavernPanel } from './TavernPanel'
 import { TownHub } from './TownHub'
+import { WaypointPanel } from './WaypointPanel'
 
 const DIFFICULTY_STYLES: Record<RegionDifficulty, { label: string; color: string }> = {
   easy: { label: 'Easy', color: 'bg-green-900/50 text-green-300 border-green-600/40' },
@@ -169,6 +170,7 @@ export default function GameUI({ onOpenStatus }: GameUIProps) {
   const [showNoticeBoard, setShowNoticeBoard] = useState(false)
   const [showTavern, setShowTavern] = useState(false)
   const [showBlacksmith, setShowBlacksmith] = useState(false)
+  const [showWaypoints, setShowWaypoints] = useState(false)
   const restFromTavern = useRef(false)
   const [eventResult, setEventResult] = useState<EventResult | null>(null)
   const [townNPC, setTownNPC] = useState<GameNPC | null>(null)
@@ -188,6 +190,7 @@ export default function GameUI({ onOpenStatus }: GameUIProps) {
     setShowNoticeBoard(false)
     setShowTavern(false)
     setShowBlacksmith(false)
+    setShowWaypoints(false)
   }, [gameState?.decisionPoint?.id])
 
   // Check for daily reward on mount
@@ -285,6 +288,11 @@ export default function GameUI({ onOpenStatus }: GameUIProps) {
       setShowBlacksmith(true)
       return
     }
+    // Waypoints: open the waypoint panel client-side
+    if (optionId === 'visit-waypoints') {
+      setShowWaypoints(true)
+      return
+    }
     // Tavern: open the tavern panel client-side (bypass if triggered from within the panel)
     if (optionId === 'rest-at-inn' && !restFromTavern.current) {
       setShowTavern(true)
@@ -321,7 +329,7 @@ export default function GameUI({ onOpenStatus }: GameUIProps) {
           optionId === 'fight-secret-boss' || optionId === 'visit-stable' ||
           optionId === 'check-mailbox' || optionId === 'visit-notice-board' || optionId === 'rest-at-inn' || optionId === 'visit-blacksmith' ||
           optionId === 'hire-transport' || optionId === 'leave-town' ||
-          optionId === 'enter-town'
+          optionId === 'enter-town' || optionId === 'visit-waypoints'
         if (!skipResults && result.outcomeDescription) {
           setEventResult({
             outcomeDescription: result.outcomeDescription,
@@ -748,6 +756,24 @@ export default function GameUI({ onOpenStatus }: GameUIProps) {
                     <button className="text-[10px] text-slate-400 hover:text-slate-200" onClick={() => setShowBlacksmith(false)}>← Back to Town</button>
                     <CraftingPanel />
                   </div>
+                )}
+                {showWaypoints && character && (
+                  <WaypointPanel
+                    character={character}
+                    currentTownName={character.landmarkState?.exploringLandmarkName ?? 'the town'}
+                    onTravel={(regionId, _landmarkId, cost) => {
+                      setShowWaypoints(false)
+                      const newGold = Math.max(0, (character.gold ?? 0) - cost)
+                      updateSelectedCharacter({
+                        gold: newGold,
+                        currentRegion: regionId,
+                        currentWeather: rollWeather(regionId),
+                        landmarkState: undefined,
+                      })
+                      setDecisionPoint(null)
+                    }}
+                    onClose={() => setShowWaypoints(false)}
+                  />
                 )}
               </>
             ) : (

--- a/src/app/tap-tap-adventure/components/TownHub.tsx
+++ b/src/app/tap-tap-adventure/components/TownHub.tsx
@@ -67,6 +67,11 @@ const FEATURE_CONFIGS: Record<string, FeatureConfig> = {
     label: 'Visit Blacksmith',
     className: 'bg-orange-900/40 hover:bg-orange-800/60 border-orange-600/40 text-orange-200 hover:text-orange-100',
   },
+  'visit-waypoints': {
+    icon: '🗺️',
+    label: 'Waypoints',
+    className: 'bg-cyan-900/40 hover:bg-cyan-800/60 border-cyan-600/40 text-cyan-200 hover:text-cyan-100',
+  },
 }
 
 export function TownHub({

--- a/src/app/tap-tap-adventure/components/WaypointPanel.tsx
+++ b/src/app/tap-tap-adventure/components/WaypointPanel.tsx
@@ -1,0 +1,78 @@
+'use client'
+import { FantasyCharacter } from '@/app/tap-tap-adventure/models/types'
+import { getRegion, REGIONS } from '@/app/tap-tap-adventure/config/regions'
+
+interface WaypointPanelProps {
+  character: FantasyCharacter
+  currentTownName: string
+  onTravel: (regionId: string, landmarkId: string, cost: number) => void
+  onClose: () => void
+}
+
+export function WaypointPanel({ character, currentTownName, onTravel, onClose }: WaypointPanelProps) {
+  const currentRegion = character.currentRegion ?? 'green_meadows'
+  const visitedTowns = (character.visitedTowns ?? []).filter(
+    t => !(t.regionId === currentRegion && t.name === currentTownName)
+  )
+
+  return (
+    <div className="bg-[#1e1f30] border border-[#3a3c56] rounded-lg p-3 space-y-3">
+      <div className="flex justify-between items-center">
+        <span className="text-sm font-bold text-amber-400">🗺️ Waypoints</span>
+        <button className="text-slate-400 hover:text-white text-sm" onClick={onClose}>✕</button>
+      </div>
+
+      <div className="text-[10px] text-slate-400 italic">
+        Travel instantly to a town you&apos;ve visited before. Cost varies by distance.
+      </div>
+
+      <div className="space-y-1.5 max-h-[250px] overflow-y-auto">
+        {visitedTowns.length === 0 ? (
+          <div className="text-xs text-slate-500 italic py-3 text-center">
+            No other waypoints discovered yet. Visit more towns to unlock fast travel!
+          </div>
+        ) : (
+          visitedTowns.map((town, i) => {
+            const region = REGIONS[town.regionId]
+            const isSameRegion = town.regionId === currentRegion
+            const baseCost = isSameRegion ? 15 : 30
+            const regionMult = getRegion(town.regionId).difficultyMultiplier
+            const cost = Math.round(baseCost * regionMult)
+            const canAfford = (character.gold ?? 0) >= cost
+
+            return (
+              <button
+                key={`${town.landmarkId}-${town.regionId}-${i}`}
+                className={`w-full text-left bg-[#252638] border rounded p-2 flex items-center gap-2 transition-colors ${
+                  canAfford
+                    ? 'border-[#3a3c56] hover:border-indigo-500'
+                    : 'border-[#3a3c56] opacity-50 cursor-not-allowed'
+                }`}
+                disabled={!canAfford}
+                onClick={() => canAfford && onTravel(town.regionId, town.landmarkId, cost)}
+              >
+                <span className="text-lg">{town.icon}</span>
+                <div className="flex-1 min-w-0">
+                  <div className="text-xs font-semibold text-slate-200">{town.name}</div>
+                  <div className="text-[10px] text-slate-500">
+                    {region?.icon} {region?.name ?? town.regionId}
+                    {isSameRegion && ' (same region)'}
+                  </div>
+                </div>
+                <div className="text-right shrink-0">
+                  <div className={`text-[10px] font-semibold ${canAfford ? 'text-amber-400' : 'text-red-400'}`}>
+                    {cost}g
+                  </div>
+                </div>
+              </button>
+            )
+          })
+        )}
+      </div>
+
+      <button className="w-full text-xs text-slate-400 hover:text-slate-200 py-1 transition-colors" onClick={onClose}>
+        ← Back to Town
+      </button>
+    </div>
+  )
+}

--- a/src/app/tap-tap-adventure/hooks/useCharacterCreation.ts
+++ b/src/app/tap-tap-adventure/hooks/useCharacterCreation.ts
@@ -215,6 +215,7 @@ export function useCharacterCreation() {
       currentRegion: 'green_meadows',
       currentWeather: 'clear',
       visitedRegions: ['green_meadows'],
+      visitedTowns: [],
       factionReputations: {},
       bounty: 0,
       party: [],

--- a/src/app/tap-tap-adventure/hooks/useGameStore.ts
+++ b/src/app/tap-tap-adventure/hooks/useGameStore.ts
@@ -146,6 +146,7 @@ const defaultCharacter: FantasyCharacter = {
   currentRegion: 'green_meadows',
   currentWeather: 'clear',
   visitedRegions: ['green_meadows'],
+  visitedTowns: [],
   mainQuest: createMainQuest(),
   factionReputations: {},
   bestiary: [],

--- a/src/app/tap-tap-adventure/models/character.ts
+++ b/src/app/tap-tap-adventure/models/character.ts
@@ -96,6 +96,12 @@ export const FantasyCharacterSchema = z.object({
   currentRegion: z.string().optional().default('green_meadows'),
   currentWeather: z.string().optional().default('clear'),
   visitedRegions: z.array(z.string()).optional(),
+  visitedTowns: z.array(z.object({
+    name: z.string(),
+    icon: z.string(),
+    regionId: z.string(),
+    landmarkId: z.string(),
+  })).optional().default([]),
   mainQuest: MainQuestSchema.optional(),
   campState: CampStateSchema.optional(),
   factionReputations: z.record(z.string(), z.number()).optional().default({}),


### PR DESCRIPTION
## Summary
Players can now fast-travel between previously visited towns via a waypoint network:

- **Automatic tracking**: Entering a town (via enter-town, pay-bounty, or sneak-into-town) records it in `visitedTowns`
- **Waypoint panel**: Transport-enabled towns show a "Waypoints" option that opens a panel listing all visited towns
- **Cross-region travel**: Teleport between regions instantly, with gold cost scaled by distance
- **Cost model**: Same-region 15g base, cross-region 30g base, multiplied by destination region difficulty

## Changes
| File | What |
|------|------|
| `models/character.ts` | Add `visitedTowns` schema (name, icon, regionId, landmarkId) |
| `route.ts` | Record town visits in 3 entry handlers |
| `townHubBuilder.ts` | Add "Waypoints" option (gated by hasTransport) |
| `TownHub.tsx` | Add feature config with cyan styling |
| `WaypointPanel.tsx` | **NEW** — scrollable waypoint list with cost/affordability |
| `GameUI.tsx` | Intercept, state, render WaypointPanel with travel logic |
| `useGameStore.ts` / `useCharacterCreation.ts` | Add `visitedTowns: []` defaults |

## Test plan
- [x] All 931 tests pass
- [x] `next build` succeeds
- [ ] Manual: enter a town, verify it appears in waypoints at another transport-enabled town
- [ ] Manual: travel to a different region, check waypoints show cross-region towns
- [ ] Manual: verify gold deduction and region change after waypoint travel

Closes #460

🤖 Generated with [Claude Code](https://claude.com/claude-code)