### PR TITLE
fix: reshuffle trivia answers — correct answer was always D

### DIFF
--- a/src/app/trivia/data/questions/2026-04-16.json
+++ b/src/app/trivia/data/questions/2026-04-16.json
@@ -7,10 +7,10 @@
       "id": "opentdb-2026-04-16-0",
       "question": "Which of the following Pacific Islander countries is ruled by a constitutional monarchy?",
       "options": [
-        "Palau",
-        "Kiribati",
+        "Tonga",
         "Fiji",
-        "Tonga"
+        "Palau",
+        "Kiribati"
       ],
       "difficulty": "easy",
       "category": "Politics",
@@ -22,9 +22,9 @@
       "question": "Whose 2016 presidential campaign slogan was \"Make America Great Again\"?",
       "options": [
         "Marco Rubio",
-        "Bernie Sanders",
+        "Donald Trump",
         "Ted Cruz",
-        "Donald Trump"
+        "Bernie Sanders"
       ],
       "difficulty": "easy",
       "category": "Politics",
@@ -36,9 +36,9 @@
       "question": "Who was South Africa's first Black President?",
       "options": [
         "Mangosuthu Buthelezi",
-        "Steve Biko ",
+        "Nelson Mandela",
         "Bishop Tutu",
-        "Nelson Mandela"
+        "Steve Biko "
       ],
       "difficulty": "easy",
       "category": "Politics",
@@ -50,9 +50,9 @@
       "question": "The 2014 movie \"The Raid 2: Berandal\" was mainly filmed in which Asian country?",
       "options": [
         "Thailand",
-        "Malaysia",
         "Brunei",
-        "Indonesia"
+        "Indonesia",
+        "Malaysia"
       ],
       "difficulty": "medium",
       "category": "Politics",
@@ -63,10 +63,10 @@
       "id": "opentdb-2026-04-16-4",
       "question": "What was the personal nickname of the 40th Governor of the US State Louisiana, Huey Long?",
       "options": [
-        "The Hoot Owl",
-        "The Oracle",
         "The Champ",
-        "The Kingfish"
+        "The Hoot Owl",
+        "The Kingfish",
+        "The Oracle"
       ],
       "difficulty": "medium",
       "category": "Politics",
@@ -77,10 +77,10 @@
       "id": "opentdb-2026-04-16-5",
       "question": "In June 2017, Saudi Arabia and Egypt broke off ties with which country over its supposed support for terrorism?",
       "options": [
-        "Bahrain",
-        "United States of America",
+        "Qatar",
         "Russia",
-        "Qatar"
+        "Bahrain",
+        "United States of America"
       ],
       "difficulty": "hard",
       "category": "Politics",

--- a/src/app/trivia/data/questions/2026-04-17.json
+++ b/src/app/trivia/data/questions/2026-04-17.json
@@ -8,9 +8,9 @@
       "question": "What is the world's oldest known piece of fiction?",
       "options": [
         "Code of Hammurabi",
-        "Rosetta Stone",
+        "Epic of Gilgamesh",
         "Papyrus of Ani",
-        "Epic of Gilgamesh"
+        "Rosetta Stone"
       ],
       "difficulty": "easy",
       "category": "Art",
@@ -22,9 +22,9 @@
       "question": "Who painted the biblical fresco The Creation of Adam?",
       "options": [
         "Leonardo da Vinci",
-        "Rembrandt",
+        "Michelangelo",
         "Caravaggio",
-        "Michelangelo"
+        "Rembrandt"
       ],
       "difficulty": "easy",
       "category": "Art",
@@ -36,9 +36,9 @@
       "question": "What is a fundamental element of the Gothic style of architecture?",
       "options": [
         "coffered ceilings",
-        "internal frescoes",
         "façades surmounted by a pediment ",
-        "pointed arch"
+        "pointed arch",
+        "internal frescoes"
       ],
       "difficulty": "easy",
       "category": "Art",
@@ -49,10 +49,10 @@
       "id": "opentdb-2026-04-17-3",
       "question": "Which artist painted \"The Treachery of Images,\" a painting of a pipe with the description \"this is not a pipe\"?",
       "options": [
-        "Matisse",
-        "Munch ",
         "Modigliani",
-        "Magritte"
+        "Matisse",
+        "Magritte",
+        "Munch "
       ],
       "difficulty": "medium",
       "category": "Art",
@@ -63,10 +63,10 @@
       "id": "opentdb-2026-04-17-4",
       "question": "Which artist's style was to use small different colored dots to create a picture?",
       "options": [
-        "Paul Cézanne",
-        "Vincent Van Gogh",
+        "Georges Seurat",
         "Henri Rousseau",
-        "Georges Seurat"
+        "Paul Cézanne",
+        "Vincent Van Gogh"
       ],
       "difficulty": "medium",
       "category": "Art",
@@ -77,10 +77,10 @@
       "id": "opentdb-2026-04-17-5",
       "question": "Which art movement was Pablo Picasso known for co-founding?",
       "options": [
-        "Futurism",
+        "Cubism",
         "Expressionism",
-        "Impressionism",
-        "Cubism"
+        "Futurism",
+        "Impressionism"
       ],
       "difficulty": "hard",
       "category": "Art",

--- a/src/app/trivia/data/questions/2026-04-18.json
+++ b/src/app/trivia/data/questions/2026-04-18.json
@@ -8,9 +8,9 @@
       "question": "What does film maker Dan Bell typically focus his films on?",
       "options": [
         "Action Films",
-        "Documentaries ",
+        "Abandoned Buildings and Dead Malls",
         "Historic Landmarks",
-        "Abandoned Buildings and Dead Malls"
+        "Documentaries "
       ],
       "difficulty": "easy",
       "category": "Celebrities",
@@ -22,9 +22,9 @@
       "question": "By which name is Ramon Estevez better known as?",
       "options": [
         "Ramon Sheen",
-        "Emilio Estevez",
         "Charlie Sheen",
-        "Martin Sheen"
+        "Martin Sheen",
+        "Emilio Estevez"
       ],
       "difficulty": "easy",
       "category": "Celebrities",
@@ -35,10 +35,10 @@
       "id": "opentdb-2026-04-18-2",
       "question": "Aubrey Graham is better known as",
       "options": [
-        "Travis Scott",
-        "Lil Wayne",
         "2 Chainz",
-        "Drake"
+        "Travis Scott",
+        "Drake",
+        "Lil Wayne"
       ],
       "difficulty": "easy",
       "category": "Celebrities",
@@ -49,10 +49,10 @@
       "id": "opentdb-2026-04-18-3",
       "question": "What is generally considered to be William Shakespeare's birth date?",
       "options": [
-        "July 4th, 1409",
-        "December 1st, 1750",
+        "April 23rd, 1564",
         "September 29th, 1699",
-        "April 23rd, 1564"
+        "July 4th, 1409",
+        "December 1st, 1750"
       ],
       "difficulty": "medium",
       "category": "Celebrities",
@@ -63,10 +63,10 @@
       "id": "opentdb-2026-04-18-4",
       "question": "What year did radio icon Howard Stern start a job at radio station WNBC?",
       "options": [
-        "1984",
+        "1982",
         "1995",
-        "1985",
-        "1982"
+        "1984",
+        "1985"
       ],
       "difficulty": "medium",
       "category": "Celebrities",
@@ -79,8 +79,8 @@
       "options": [
         "1970",
         "1960",
-        "1972",
-        "1962 "
+        "1962 ",
+        "1972"
       ],
       "difficulty": "hard",
       "category": "Celebrities",

--- a/src/app/trivia/data/questions/2026-04-19.json
+++ b/src/app/trivia/data/questions/2026-04-19.json
@@ -8,9 +8,9 @@
       "question": "How many teeth does an adult rabbit have?",
       "options": [
         "30",
-        "26",
         "24",
-        "28"
+        "28",
+        "26"
       ],
       "difficulty": "easy",
       "category": "Animals",
@@ -21,10 +21,10 @@
       "id": "opentdb-2026-04-19-1",
       "question": "What is the fastest  land animal?",
       "options": [
-        "Thomson's Gazelle",
-        "Pronghorn Antelope",
         "Lion",
-        "Cheetah"
+        "Thomson's Gazelle",
+        "Cheetah",
+        "Pronghorn Antelope"
       ],
       "difficulty": "easy",
       "category": "Animals",
@@ -35,10 +35,10 @@
       "id": "opentdb-2026-04-19-2",
       "question": "Which class of animals are newts members of?",
       "options": [
-        "Reptiles",
-        "Mammals",
+        "Amphibian",
         "Fish",
-        "Amphibian"
+        "Reptiles",
+        "Mammals"
       ],
       "difficulty": "easy",
       "category": "Animals",
@@ -49,10 +49,10 @@
       "id": "opentdb-2026-04-19-3",
       "question": "\"Decapods\" are an order of ten-footed crustaceans.  Which of these are NOT decapods?",
       "options": [
-        "Shrimp",
+        "Krill",
         "Crabs",
-        "Lobsters",
-        "Krill"
+        "Shrimp",
+        "Lobsters"
       ],
       "difficulty": "medium",
       "category": "Animals",
@@ -65,8 +65,8 @@
       "options": [
         "10%",
         "45%",
-        "80%",
-        "25%"
+        "25%",
+        "80%"
       ],
       "difficulty": "medium",
       "category": "Animals",
@@ -79,8 +79,8 @@
       "options": [
         "Cormorant",
         "Secretary bird",
-        "Cassowary",
-        "Hoatzin"
+        "Hoatzin",
+        "Cassowary"
       ],
       "difficulty": "hard",
       "category": "Animals",

--- a/src/app/trivia/data/questions/2026-04-20.json
+++ b/src/app/trivia/data/questions/2026-04-20.json
@@ -7,10 +7,10 @@
       "id": "opentdb-2026-04-20-0",
       "question": "Which car tire manufacturer is famous for its \"Eagle\" brand of tires, and is the official tire supplier of NASCAR?",
       "options": [
-        "Pirelli",
         "Bridgestone",
+        "Goodyear",
         "Michelin",
-        "Goodyear"
+        "Pirelli"
       ],
       "difficulty": "easy",
       "category": "Vehicles",
@@ -21,10 +21,10 @@
       "id": "opentdb-2026-04-20-1",
       "question": "Which of the following vehicles from Ford is named after a WW2 Fighter Plane?",
       "options": [
-        "Explorer",
+        "Mustang",
         "Galaxy",
         "Ranger",
-        "Mustang"
+        "Explorer"
       ],
       "difficulty": "easy",
       "category": "Vehicles",
@@ -35,10 +35,10 @@
       "id": "opentdb-2026-04-20-2",
       "question": "Jaguar Cars was previously owned by which car manfacturer?",
       "options": [
-        "General Motors",
-        "Fiat",
+        "Ford",
         "Chrysler",
-        "Ford"
+        "Fiat",
+        "General Motors"
       ],
       "difficulty": "easy",
       "category": "Vehicles",
@@ -49,10 +49,10 @@
       "id": "opentdb-2026-04-20-3",
       "question": "Which of the following passenger jets is the longest?",
       "options": [
-        "Airbus A350-1000",
-        "Boeing 787-10",
+        "Boeing 747-8",
         "Airbus A330-200",
-        "Boeing 747-8"
+        "Boeing 787-10",
+        "Airbus A350-1000"
       ],
       "difficulty": "medium",
       "category": "Vehicles",
@@ -63,10 +63,10 @@
       "id": "opentdb-2026-04-20-4",
       "question": "Which car brand does NOT belong to General Motors?",
       "options": [
-        "Buick",
         "Cadillac",
         "Chevrolet",
-        "Ford"
+        "Ford",
+        "Buick"
       ],
       "difficulty": "medium",
       "category": "Vehicles",
@@ -77,10 +77,10 @@
       "id": "opentdb-2026-04-20-5",
       "question": "The difference between the lengths of a Boeing 777-300ER and an Airbus A350-1000 is closest to:",
       "options": [
-        "1m",
-        "10m ",
+        "0.1m",
         "100m",
-        "0.1m"
+        "1m",
+        "10m "
       ],
       "difficulty": "hard",
       "category": "Vehicles",

--- a/src/app/trivia/data/questions/2026-04-21.json
+++ b/src/app/trivia/data/questions/2026-04-21.json
@@ -7,10 +7,10 @@
       "id": "opentdb-2026-04-21-0",
       "question": "In \"Homestuck\" what is Dave Strider's guardian?",
       "options": [
-        "Becquerel",
+        "Bro",
         "Doc Scratch",
         "Halley",
-        "Bro"
+        "Becquerel"
       ],
       "difficulty": "easy",
       "category": "Entertainment: Comics",
@@ -21,10 +21,10 @@
       "id": "opentdb-2026-04-21-1",
       "question": "What is the alter-ego of the DC comics character \"Superman\"?",
       "options": [
-        "Arthur Curry",
-        "John Jones",
+        "Clark Kent",
         "Bruce Wayne",
-        "Clark Kent"
+        "John Jones",
+        "Arthur Curry"
       ],
       "difficulty": "easy",
       "category": "Entertainment: Comics",
@@ -35,10 +35,10 @@
       "id": "opentdb-2026-04-21-2",
       "question": "In the Marvel comic \"The Superior Spider-Man\", Peter Parker's body is taken over by which character?",
       "options": [
-        "Mary Jane",
-        "Eddie Brock ",
+        "Otto Octavius ",
         "Norman Osborn",
-        "Otto Octavius "
+        "Eddie Brock ",
+        "Mary Jane"
       ],
       "difficulty": "easy",
       "category": "Entertainment: Comics",
@@ -49,10 +49,10 @@
       "id": "opentdb-2026-04-21-3",
       "question": "Which \"Green Arrow\" sidekick commonly wears a baseball cap?",
       "options": [
-        "Black Canary",
         "Dick Grayson",
         "Emiko Queen",
-        "Roy Harper"
+        "Roy Harper",
+        "Black Canary"
       ],
       "difficulty": "medium",
       "category": "Entertainment: Comics",
@@ -63,10 +63,10 @@
       "id": "opentdb-2026-04-21-4",
       "question": "Who is the second person to take up the mantle of Night Owl in the Watchmen graphic novel?",
       "options": [
-        "Nelson Gardner",
-        "Hollis Mason",
+        "Daniel Dreiberg",
         "Adrian Veidt",
-        "Daniel Dreiberg"
+        "Nelson Gardner",
+        "Hollis Mason"
       ],
       "difficulty": "medium",
       "category": "Entertainment: Comics",
@@ -78,9 +78,9 @@
       "question": "Which pulp hero made appearances in Hellboy and BPRD comics before getting his own spin-off?",
       "options": [
         "Roger the Homunculus",
-        "The Spider",
+        "Lobster Johnson",
         "The Wendigo",
-        "Lobster Johnson"
+        "The Spider"
       ],
       "difficulty": "hard",
       "category": "Entertainment: Comics",

--- a/src/app/trivia/data/questions/2026-04-22.json
+++ b/src/app/trivia/data/questions/2026-04-22.json
@@ -7,10 +7,10 @@
       "id": "opentdb-2026-04-22-0",
       "question": "When did the CD begin to appear on the consumer market?",
       "options": [
-        "1972",
-        "1962",
+        "1982",
         "1992",
-        "1982"
+        "1962",
+        "1972"
       ],
       "difficulty": "easy",
       "category": "Science: Gadgets",
@@ -21,10 +21,10 @@
       "id": "opentdb-2026-04-22-1",
       "question": "Which gaming console is developed by Sony?",
       "options": [
-        "Xbox",
-        "Atari",
+        "PlayStation",
         "Nintendo Switch",
-        "PlayStation"
+        "Atari",
+        "Xbox"
       ],
       "difficulty": "easy",
       "category": "Science: Gadgets",
@@ -35,10 +35,10 @@
       "id": "opentdb-2026-04-22-2",
       "question": "When was the Tamagotchi digital pet released?",
       "options": [
-        "1989",
         "1990",
         "1992",
-        "1996"
+        "1996",
+        "1989"
       ],
       "difficulty": "easy",
       "category": "Science: Gadgets",
@@ -49,10 +49,10 @@
       "id": "opentdb-2026-04-22-3",
       "question": "How does a centrifuge separate&nbsp;heavy and light particles?",
       "options": [
-        "Sifting",
-        "Ionizing",
+        "Spinning",
         "Vibrating",
-        "Spinning"
+        "Sifting",
+        "Ionizing"
       ],
       "difficulty": "medium",
       "category": "Science: Gadgets",
@@ -64,9 +64,9 @@
       "question": "Which company designed the \"Betamax\" video cassette format?",
       "options": [
         "Panasonic",
-        "Fujitsu",
+        "Sony",
         "LG",
-        "Sony"
+        "Fujitsu"
       ],
       "difficulty": "medium",
       "category": "Science: Gadgets",
@@ -78,9 +78,9 @@
       "question": "Which of the following is the standard THX subwoofer crossover frequency?",
       "options": [
         "70 Hz",
-        "100 Hz",
+        "80 Hz",
         "90 Hz",
-        "80 Hz"
+        "100 Hz"
       ],
       "difficulty": "hard",
       "category": "Science: Gadgets",

--- a/src/app/trivia/data/questions/2026-04-23.json
+++ b/src/app/trivia/data/questions/2026-04-23.json
@@ -7,10 +7,10 @@
       "id": "opentdb-2026-04-23-0",
       "question": "Who is the colossal titan in \"Attack On Titan\"?",
       "options": [
-        "Reiner",
-        "Sasha",
+        "Bertolt Hoover",
         "Eren",
-        "Bertolt Hoover"
+        "Sasha",
+        "Reiner"
       ],
       "difficulty": "easy",
       "category": "Entertainment: Japanese Anime & Manga",
@@ -21,10 +21,10 @@
       "id": "opentdb-2026-04-23-1",
       "question": "Which anime heavily features music from the genre \"Eurobeat\"?",
       "options": [
-        "Wangan Midnight",
         "Kino no Tabi",
         "Cowboy Bebop",
-        "Initial D"
+        "Initial D",
+        "Wangan Midnight"
       ],
       "difficulty": "easy",
       "category": "Entertainment: Japanese Anime & Manga",
@@ -35,10 +35,10 @@
       "id": "opentdb-2026-04-23-2",
       "question": "Who is the main character with yellow hair in the anime Naruto?",
       "options": [
-        "Ten Ten",
-        "Sasuke",
+        "Naruto",
         "Kakashi",
-        "Naruto"
+        "Ten Ten",
+        "Sasuke"
       ],
       "difficulty": "easy",
       "category": "Entertainment: Japanese Anime & Manga",
@@ -50,9 +50,9 @@
       "question": "Which studio made Cowboy Bebop?",
       "options": [
         "Bones",
-        "Pierriot",
+        "Sunrise",
         "Madhouse",
-        "Sunrise"
+        "Pierriot"
       ],
       "difficulty": "medium",
       "category": "Entertainment: Japanese Anime & Manga",
@@ -64,9 +64,9 @@
       "question": "What year did the popular Vocaloid: Hatsune Miku come out?",
       "options": [
         "2008",
-        "2010",
+        "2007",
         "2000",
-        "2007"
+        "2010"
       ],
       "difficulty": "medium",
       "category": "Entertainment: Japanese Anime & Manga",
@@ -78,9 +78,9 @@
       "question": "Who is One Punch Man voiced by in the Japanese version.",
       "options": [
         "Zach Aguilar",
-        "Kaito Ishikawa",
         "Max Mittelman ",
-        "Makoto Furukawa"
+        "Makoto Furukawa",
+        "Kaito Ishikawa"
       ],
       "difficulty": "hard",
       "category": "Entertainment: Japanese Anime & Manga",

--- a/src/app/trivia/data/questions/2026-04-24.json
+++ b/src/app/trivia/data/questions/2026-04-24.json
@@ -7,10 +7,10 @@
       "id": "opentdb-2026-04-24-0",
       "question": "Which of these cartoons had a character named Heinz Doofenshmirtz?",
       "options": [
-        "Ben 10",
         "Batman: The Animated Series",
         "Ren & Stimpy",
-        "Phineas & Ferb"
+        "Phineas & Ferb",
+        "Ben 10"
       ],
       "difficulty": "easy",
       "category": "Entertainment: Cartoon & Animations",
@@ -21,10 +21,10 @@
       "id": "opentdb-2026-04-24-1",
       "question": "In the 1993 Disney animated series \"Bonkers\", what is the name of Bonker's second partner?",
       "options": [
-        "Dick Tracy",
-        "Eddie Valiant",
+        "Miranda Wright",
         "Dr. Ludwig von Drake",
-        "Miranda Wright"
+        "Dick Tracy",
+        "Eddie Valiant"
       ],
       "difficulty": "easy",
       "category": "Entertainment: Cartoon & Animations",
@@ -36,9 +36,9 @@
       "question": "Butters Stotch, Pip Pirrup, and Wendy Testaburger are all characters in which long running animated TV series?",
       "options": [
         "The Simpsons",
-        "Bob's Burgers",
+        "South Park",
         "Family Guy",
-        "South Park"
+        "Bob's Burgers"
       ],
       "difficulty": "easy",
       "category": "Entertainment: Cartoon & Animations",
@@ -50,9 +50,9 @@
       "question": "What was the number on Gerald's shirt in \"Hey Arnold!\"?",
       "options": [
         "88",
-        "83",
+        "33",
         "38",
-        "33"
+        "83"
       ],
       "difficulty": "medium",
       "category": "Entertainment: Cartoon & Animations",
@@ -64,9 +64,9 @@
       "question": "Who voiced Finn in Adventure Time?",
       "options": [
         "Nolan North",
-        "John DiMaggio",
         "Tom Kenny",
-        "Jeremy Shada"
+        "Jeremy Shada",
+        "John DiMaggio"
       ],
       "difficulty": "medium",
       "category": "Entertainment: Cartoon & Animations",
@@ -77,10 +77,10 @@
       "id": "opentdb-2026-04-24-5",
       "question": "Who played Stan's dog in the South Park episode \"Big Gay Al's Big Gay Boat Ride\"?",
       "options": [
-        "Jay Leno",
-        "Matt Stone",
         "Robert Smith",
-        "George Clooney"
+        "Jay Leno",
+        "George Clooney",
+        "Matt Stone"
       ],
       "difficulty": "hard",
       "category": "Entertainment: Cartoon & Animations",

--- a/src/app/trivia/data/questions/2026-04-25.json
+++ b/src/app/trivia/data/questions/2026-04-25.json
@@ -7,10 +7,10 @@
       "id": "opentdb-2026-04-25-0",
       "question": "In which fast food chain can you order a Jamocha Shake?",
       "options": [
-        "McDonald's",
-        "Burger King",
+        "Arby's",
         "Wendy's",
-        "Arby's"
+        "McDonald's",
+        "Burger King"
       ],
       "difficulty": "easy",
       "category": "General Knowledge",
@@ -22,9 +22,9 @@
       "question": "What do the letters of the fast food chain KFC stand for?",
       "options": [
         "Kentucky Fresh Cheese",
-        "Kiwi Food Cut",
+        "Kentucky Fried Chicken",
         "Kibbled Freaky Cow",
-        "Kentucky Fried Chicken"
+        "Kiwi Food Cut"
       ],
       "difficulty": "easy",
       "category": "General Knowledge",
@@ -36,9 +36,9 @@
       "question": "How tall is the Burj Khalifa?",
       "options": [
         "2,546 ft",
-        "3,024 ft",
+        "2,722 ft",
         "2,717 ft",
-        "2,722 ft"
+        "3,024 ft"
       ],
       "difficulty": "easy",
       "category": "General Knowledge",
@@ -50,9 +50,9 @@
       "question": "Which of these Nicktoons were NOT originally a short on Oh Yeah! Cartoons before becoming their own series?",
       "options": [
         "My Life as a Teenage Robot",
-        "The Fairly OddParents",
         "ChalkZone",
-        "Danny Phantom"
+        "Danny Phantom",
+        "The Fairly OddParents"
       ],
       "difficulty": "medium",
       "category": "General Knowledge",
@@ -63,10 +63,10 @@
       "id": "opentdb-2026-04-25-4",
       "question": "What character was once considered to be the 27th letter of the alphabet?",
       "options": [
-        "Tilde",
-        "Pilcrow",
         "Interrobang",
-        "Ampersand"
+        "Tilde",
+        "Ampersand",
+        "Pilcrow"
       ],
       "difficulty": "medium",
       "category": "General Knowledge",
@@ -77,10 +77,10 @@
       "id": "opentdb-2026-04-25-5",
       "question": "What is the romanized Korean word for \"heart\"?",
       "options": [
-        "Aejeong",
-        "Segseu",
+        "Simjang",
         "Jeongsin",
-        "Simjang"
+        "Aejeong",
+        "Segseu"
       ],
       "difficulty": "hard",
       "category": "General Knowledge",

--- a/src/app/trivia/data/questions/2026-04-26.json
+++ b/src/app/trivia/data/questions/2026-04-26.json
@@ -8,9 +8,9 @@
       "question": "Who wrote the young adult novel \"The Fault in Our Stars\"?",
       "options": [
         "Stephenie Meyer",
-        "Stephen Chbosky",
+        "John Green",
         "Suzanne Collins",
-        "John Green"
+        "Stephen Chbosky"
       ],
       "difficulty": "easy",
       "category": "Entertainment: Books",
@@ -22,9 +22,9 @@
       "question": "In what Harry Potter book was a Horcrux first encountered?",
       "options": [
         "The Goblet of Fire",
-        "The Deathly Hallows",
+        "The Chamber of Secrets",
         "The Half-Blood Prince",
-        "The Chamber of Secrets"
+        "The Deathly Hallows"
       ],
       "difficulty": "easy",
       "category": "Entertainment: Books",
@@ -36,9 +36,9 @@
       "question": "Which famous book is sub-titled 'The Modern Prometheus'?",
       "options": [
         "The Strange Case of Dr. Jekyll and Mr. Hyde ",
-        "The Legend of Sleepy Hollow",
         "Dracula",
-        "Frankenstein"
+        "Frankenstein",
+        "The Legend of Sleepy Hollow"
       ],
       "difficulty": "easy",
       "category": "Entertainment: Books",
@@ -49,10 +49,10 @@
       "id": "opentdb-2026-04-26-3",
       "question": "Which novel by John Grisham was conceived on a road trip to Florida while thinking about stolen books with his wife?",
       "options": [
-        "Gray Mountain",
-        "The Litigators",
         "Rogue Lawyer",
-        "Camino Island"
+        "Gray Mountain",
+        "Camino Island",
+        "The Litigators"
       ],
       "difficulty": "medium",
       "category": "Entertainment: Books",
@@ -63,10 +63,10 @@
       "id": "opentdb-2026-04-26-4",
       "question": "Who is the author of the series \"Malazan Book of the Fallen\"?",
       "options": [
-        "Ian Cameron Esslemont",
-        "J. R. R. Tolkien",
+        "Steven Erikson",
         "George R. R. Martin",
-        "Steven Erikson"
+        "Ian Cameron Esslemont",
+        "J. R. R. Tolkien"
       ],
       "difficulty": "medium",
       "category": "Entertainment: Books",
@@ -77,10 +77,10 @@
       "id": "opentdb-2026-04-26-5",
       "question": "In which classic novel is there a character named Homer Simpson?",
       "options": [
-        "Catch-22",
+        "The Day of the Locust",
         "A Separate Peace",
-        "Of Mice and Men",
-        "The Day of the Locust"
+        "Catch-22",
+        "Of Mice and Men"
       ],
       "difficulty": "hard",
       "category": "Entertainment: Books",

--- a/src/app/trivia/data/questions/2026-04-27.json
+++ b/src/app/trivia/data/questions/2026-04-27.json
@@ -8,9 +8,9 @@
       "question": "Who directed the Kill Bill movies?",
       "options": [
         "Arnold Schwarzenegger",
-        "David Lean",
+        "Quentin Tarantino",
         "Stanley Kubrick",
-        "Quentin Tarantino"
+        "David Lean"
       ],
       "difficulty": "easy",
       "category": "Entertainment: Film",
@@ -22,9 +22,9 @@
       "question": "In the 1995 film \"Balto\", who are Steele's accomplices?",
       "options": [
         "Dusty, Kirby, and Ralph",
-        "Jenna, Sylvie, and Dixie",
         "Nuk, Yak, and Sumac",
-        "Kaltag, Nikki, and Star"
+        "Kaltag, Nikki, and Star",
+        "Jenna, Sylvie, and Dixie"
       ],
       "difficulty": "easy",
       "category": "Entertainment: Film",
@@ -35,10 +35,10 @@
       "id": "opentdb-2026-04-27-2",
       "question": "Who directed the 2015 movie \"The Revenant\"?",
       "options": [
-        "David Fincher",
-        "Wes Anderson",
         "Christopher Nolan",
-        "Alejandro G. Iñárritu"
+        "David Fincher",
+        "Alejandro G. Iñárritu",
+        "Wes Anderson"
       ],
       "difficulty": "easy",
       "category": "Entertainment: Film",
@@ -49,10 +49,10 @@
       "id": "opentdb-2026-04-27-3",
       "question": "In \"The Hobbit,\" who was head of the White Council? ",
       "options": [
-        "Gandalf",
-        "Elrond",
+        "Saruman",
         "Lady Galadriel ",
-        "Saruman"
+        "Gandalf",
+        "Elrond"
       ],
       "difficulty": "medium",
       "category": "Entertainment: Film",
@@ -63,10 +63,10 @@
       "id": "opentdb-2026-04-27-4",
       "question": "What is the name of the Artificial Intelligence system in the 1983 film, \"WarGames\"?",
       "options": [
-        "Master Control Program",
+        "War Operation Plan Response",
         "West Campus Analog Computer",
-        "Self Evolving Thought Helix",
-        "War Operation Plan Response"
+        "Master Control Program",
+        "Self Evolving Thought Helix"
       ],
       "difficulty": "medium",
       "category": "Entertainment: Film",
@@ -79,8 +79,8 @@
       "options": [
         "Sergio Leone, Ennio Morricone, and Tonino Delli Colli",
         "Aldo Giuffrè, Mario Brega, and Luigi Pistilli",
-        "Yul Brynner, Steve McQueen, and Charles Bronson",
-        "Clint Eastwood, Eli Wallach, and Lee Van Cleef"
+        "Clint Eastwood, Eli Wallach, and Lee Van Cleef",
+        "Yul Brynner, Steve McQueen, and Charles Bronson"
       ],
       "difficulty": "hard",
       "category": "Entertainment: Film",

--- a/src/app/trivia/data/questions/2026-04-28.json
+++ b/src/app/trivia/data/questions/2026-04-28.json
@@ -8,9 +8,9 @@
       "question": "Which of these is the name of a song by Tears for Fears?",
       "options": [
         "Scream",
-        "Yell",
         "Shriek",
-        "Shout"
+        "Shout",
+        "Yell"
       ],
       "difficulty": "easy",
       "category": "Entertainment: Music",
@@ -21,10 +21,10 @@
       "id": "opentdb-2026-04-28-1",
       "question": "The band Muse released their first album, Showbiz, in what year?",
       "options": [
-        "2000",
-        "2001",
         "1998",
-        "1999"
+        "2000",
+        "1999",
+        "2001"
       ],
       "difficulty": "easy",
       "category": "Entertainment: Music",
@@ -35,10 +35,10 @@
       "id": "opentdb-2026-04-28-2",
       "question": "What was Daft Punk's first studio album?",
       "options": [
-        "Random Access Memories",
-        "Human After All",
+        "Homework",
         "Discovery",
-        "Homework"
+        "Random Access Memories",
+        "Human After All"
       ],
       "difficulty": "easy",
       "category": "Entertainment: Music",
@@ -49,10 +49,10 @@
       "id": "opentdb-2026-04-28-3",
       "question": "Which one of these artists appears in the album Deltron 3030?",
       "options": [
-        "Lamarr Kendrick",
+        "Dan the Automater",
         "CeeLo Green",
-        "Danger Mouse",
-        "Dan the Automater"
+        "Lamarr Kendrick",
+        "Danger Mouse"
       ],
       "difficulty": "medium",
       "category": "Entertainment: Music",
@@ -65,8 +65,8 @@
       "options": [
         "2014",
         "2009",
-        "2011",
-        "2013"
+        "2013",
+        "2011"
       ],
       "difficulty": "medium",
       "category": "Entertainment: Music",
@@ -79,8 +79,8 @@
       "options": [
         "Bottomless Pit",
         "The Money Store",
-        "The Powers That B",
-        "No Love Deep Web"
+        "No Love Deep Web",
+        "The Powers That B"
       ],
       "difficulty": "hard",
       "category": "Entertainment: Music",

--- a/src/app/trivia/data/questions/2026-04-29.json
+++ b/src/app/trivia/data/questions/2026-04-29.json
@@ -7,10 +7,10 @@
       "id": "opentdb-2026-04-29-0",
       "question": "How many plays is Shakespeare generally considered to have written?",
       "options": [
-        "54",
-        "25",
         "18",
-        "37"
+        "54",
+        "37",
+        "25"
       ],
       "difficulty": "easy",
       "category": "Entertainment: Musicals & Theatres",
@@ -21,10 +21,10 @@
       "id": "opentdb-2026-04-29-1",
       "question": "Which Shakespeare play inspired the musical 'West Side Story'?",
       "options": [
-        "Hamlet",
-        "Macbeth",
+        "Romeo & Juliet",
         "Othello",
-        "Romeo & Juliet"
+        "Hamlet",
+        "Macbeth"
       ],
       "difficulty": "easy",
       "category": "Entertainment: Musicals & Theatres",
@@ -35,10 +35,10 @@
       "id": "opentdb-2026-04-29-2",
       "question": "Who wrote the award winning musical \"In The Heights\"?",
       "options": [
-        "Francis Scott Key",
+        "Lin-Manuel Miranda",
         "John Phillips Sousa",
-        "Steven Sondheim",
-        "Lin-Manuel Miranda"
+        "Francis Scott Key",
+        "Steven Sondheim"
       ],
       "difficulty": "easy",
       "category": "Entertainment: Musicals & Theatres",
@@ -51,8 +51,8 @@
       "options": [
         "Renee Elise-Goldberry",
         "Leslie Odom Jr.",
-        "Lin-Manuel Miranda",
-        "Alex Lacamoire"
+        "Alex Lacamoire",
+        "Lin-Manuel Miranda"
       ],
       "difficulty": "medium",
       "category": "Entertainment: Musicals & Theatres",
@@ -65,8 +65,8 @@
       "options": [
         "The Color Purple",
         "Newsies",
-        "American Idiot",
-        "Rent"
+        "Rent",
+        "American Idiot"
       ],
       "difficulty": "medium",
       "category": "Entertainment: Musicals & Theatres",
@@ -77,10 +77,10 @@
       "id": "opentdb-2026-04-29-5",
       "question": "Who serves as the speaker of the prologue in Shakespeare's Romeo and Juliet?",
       "options": [
+        "Chorus",
         "Montague",
         "Capulet",
-        "Refrain",
-        "Chorus"
+        "Refrain"
       ],
       "difficulty": "hard",
       "category": "Entertainment: Musicals & Theatres",

--- a/src/app/trivia/data/questions/2026-04-30.json
+++ b/src/app/trivia/data/questions/2026-04-30.json
@@ -7,10 +7,10 @@
       "id": "opentdb-2026-04-30-0",
       "question": "Who won the 10th season of Big Brother in the United States?",
       "options": [
-        "Adam Jasinski",
+        "Dan Gheesling",
         "Dick Donato",
         "Hayden Moss",
-        "Dan Gheesling"
+        "Adam Jasinski"
       ],
       "difficulty": "easy",
       "category": "Entertainment: Television",
@@ -21,10 +21,10 @@
       "id": "opentdb-2026-04-30-1",
       "question": "Who won Big Brother 2014 UK?",
       "options": [
-        "Christopher Hall",
-        "Pauline Bennett",
+        "Helen Wood",
         "Pavandeep \"Pav\" Paul",
-        "Helen Wood"
+        "Pauline Bennett",
+        "Christopher Hall"
       ],
       "difficulty": "easy",
       "category": "Entertainment: Television",
@@ -35,10 +35,10 @@
       "id": "opentdb-2026-04-30-2",
       "question": "In the show \"Dragonball Z\", what is the name of Cell's most powerful attack?",
       "options": [
-        "Super Kamehameha",
-        "Cell Kamehameha",
+        "Solar Kamehameha",
         "Android Kamehameha",
-        "Solar Kamehameha"
+        "Cell Kamehameha",
+        "Super Kamehameha"
       ],
       "difficulty": "easy",
       "category": "Entertainment: Television",
@@ -49,10 +49,10 @@
       "id": "opentdb-2026-04-30-3",
       "question": "Which WWF wrestler had the nickname \"The Ayatollah of Rock 'N' Rolla\"?",
       "options": [
-        "Marty Jannetty",
         "Shawn Michaels",
         "Scott Hall",
-        "Chris Jericho"
+        "Chris Jericho",
+        "Marty Jannetty"
       ],
       "difficulty": "medium",
       "category": "Entertainment: Television",
@@ -63,10 +63,10 @@
       "id": "opentdb-2026-04-30-4",
       "question": "What year did the television company BBC officially launch the channel BBC One?",
       "options": [
-        "1932",
-        "1955",
+        "1936",
         "1948",
-        "1936"
+        "1932",
+        "1955"
       ],
       "difficulty": "medium",
       "category": "Entertainment: Television",
@@ -78,9 +78,9 @@
       "question": "In \"Star Trek\", what sauce is commonly used by Klingons on bregit lung?",
       "options": [
         "Gazorpazorp pudding",
-        "Sweet chili sauce",
+        "Grapok sauce",
         "Grapork sauce",
-        "Grapok sauce"
+        "Sweet chili sauce"
       ],
       "difficulty": "hard",
       "category": "Entertainment: Television",

--- a/src/app/trivia/data/questions/2026-05-01.json
+++ b/src/app/trivia/data/questions/2026-05-01.json
@@ -7,10 +7,10 @@
       "id": "opentdb-2026-05-01-0",
       "question": "In the game Half-Life, which enemy is showcased as the final boss?",
       "options": [
-        "Dr. Wallace Breen",
         "The Gonarch",
+        "The Nihilanth",
         "G-Man",
-        "The Nihilanth"
+        "Dr. Wallace Breen"
       ],
       "difficulty": "easy",
       "category": "Entertainment: Video Games",
@@ -21,10 +21,10 @@
       "id": "opentdb-2026-05-01-1",
       "question": "In the Assassin's Creed series,what was the name of Desmond Miles given by Abstergo?",
       "options": [
-        "Subject 16",
+        "Subject 17",
         "Subject 18",
         "Alta&iuml;r Ibn-La'Ahad",
-        "Subject 17"
+        "Subject 16"
       ],
       "difficulty": "easy",
       "category": "Entertainment: Video Games",
@@ -35,10 +35,10 @@
       "id": "opentdb-2026-05-01-2",
       "question": "In the Street Fighter franchise, what's Ken's surname?",
       "options": [
-        "Mitchell",
-        "Morrison",
+        "Masters",
         "Michaels",
-        "Masters"
+        "Morrison",
+        "Mitchell"
       ],
       "difficulty": "easy",
       "category": "Entertainment: Video Games",
@@ -49,10 +49,10 @@
       "id": "opentdb-2026-05-01-3",
       "question": "When was the Sega Genesis released in Japan?",
       "options": [
-        "November 30, 1990",
-        "September 1, 1986",
+        "October 29, 1988",
         "August 14, 1989",
-        "October 29, 1988"
+        "September 1, 1986",
+        "November 30, 1990"
       ],
       "difficulty": "medium",
       "category": "Entertainment: Video Games",
@@ -63,10 +63,10 @@
       "id": "opentdb-2026-05-01-4",
       "question": "In the game series \"The Legend of Zelda\", what was the first 3D game?",
       "options": [
-        "Majora's Mask",
         "A Link to the Past",
         "The Wind Waker",
-        "Ocarina of Time"
+        "Ocarina of Time",
+        "Majora's Mask"
       ],
       "difficulty": "medium",
       "category": "Entertainment: Video Games",
@@ -77,10 +77,10 @@
       "id": "opentdb-2026-05-01-5",
       "question": "In the game \"VA-11 Hall-A\" during Virgilio's ending, Virgilio opens his own:",
       "options": [
-        "Bar",
-        "Law Firm",
+        "Curry Stand",
         "Museum",
-        "Curry Stand"
+        "Bar",
+        "Law Firm"
       ],
       "difficulty": "hard",
       "category": "Entertainment: Video Games",

--- a/src/app/trivia/data/questions/2026-05-02.json
+++ b/src/app/trivia/data/questions/2026-05-02.json
@@ -7,10 +7,10 @@
       "id": "opentdb-2026-05-02-0",
       "question": "What is the maximum level you can have in a single class in Dungeons and Dragons (5e)?",
       "options": [
-        "30",
+        "20",
         "15",
         "25",
-        "20"
+        "30"
       ],
       "difficulty": "easy",
       "category": "Entertainment: Board Games",
@@ -21,10 +21,10 @@
       "id": "opentdb-2026-05-02-1",
       "question": "In a standard game of Monopoly, what colour are the two cheapest properties?",
       "options": [
-        "Green",
-        "Yellow",
+        "Brown",
         "Blue",
-        "Brown"
+        "Yellow",
+        "Green"
       ],
       "difficulty": "easy",
       "category": "Entertainment: Board Games",
@@ -35,10 +35,10 @@
       "id": "opentdb-2026-05-02-2",
       "question": "When was the board game Twister, released to the public?",
       "options": [
-        "January 1969",
-        "February 1966",
+        "April 1966",
         "September 1965",
-        "April 1966"
+        "February 1966",
+        "January 1969"
       ],
       "difficulty": "easy",
       "category": "Entertainment: Board Games",
@@ -49,10 +49,10 @@
       "id": "opentdb-2026-05-02-3",
       "question": "What letter is used to refer to blue mana in the card game Magic The Gathering?",
       "options": [
-        "L",
         "E",
         "B",
-        "U"
+        "U",
+        "L"
       ],
       "difficulty": "medium",
       "category": "Entertainment: Board Games",
@@ -63,10 +63,10 @@
       "id": "opentdb-2026-05-02-4",
       "question": "In \"Magic: The Gathering\", what instant card has the highest converted mana cost?",
       "options": [
-        " Chant of Vitu-Ghazi",
-        "Assert Authority",
+        "Blinkmoth Infusion",
         "Vitalizing Wind",
-        "Blinkmoth Infusion"
+        " Chant of Vitu-Ghazi",
+        "Assert Authority"
       ],
       "difficulty": "medium",
       "category": "Entertainment: Board Games",
@@ -78,9 +78,9 @@
       "question": "Some of the \"Fallen Empires\" cards from \"Magic: The Gathering\" were misprinted on the backs of which other card game?",
       "options": [
         "Pokemon",
-        "Yu-Gi-Oh",
+        "Wyvern",
         "Dominion",
-        "Wyvern"
+        "Yu-Gi-Oh"
       ],
       "difficulty": "hard",
       "category": "Entertainment: Board Games",

--- a/src/app/trivia/data/questions/2026-05-03.json
+++ b/src/app/trivia/data/questions/2026-05-03.json
@@ -7,10 +7,10 @@
       "id": "opentdb-2026-05-03-0",
       "question": "Which type of rock is created by intense heat AND pressure?",
       "options": [
-        "Sedimentary",
-        "Diamond",
+        "Metamorphic",
         "Igneous",
-        "Metamorphic"
+        "Diamond",
+        "Sedimentary"
       ],
       "difficulty": "easy",
       "category": "Science & Nature",
@@ -21,10 +21,10 @@
       "id": "opentdb-2026-05-03-1",
       "question": "Which is the longest bone in the human body? ",
       "options": [
-        "Fibula",
-        "Ulna",
+        "Femur",
         "Scapula",
-        "Femur"
+        "Ulna",
+        "Fibula"
       ],
       "difficulty": "easy",
       "category": "Science & Nature",
@@ -35,10 +35,10 @@
       "id": "opentdb-2026-05-03-2",
       "question": "How many laws of thermodynamics are there?",
       "options": [
-        "Three",
         "Two",
         "Five",
-        "Four"
+        "Four",
+        "Three"
       ],
       "difficulty": "easy",
       "category": "Science & Nature",
@@ -49,10 +49,10 @@
       "id": "opentdb-2026-05-03-3",
       "question": "What stage of development do the majority of eukaryotic cells remain in for most of their life?",
       "options": [
-        "Stasis",
-        "Telophase",
+        "Interphase",
         "Prophase",
-        "Interphase"
+        "Stasis",
+        "Telophase"
       ],
       "difficulty": "medium",
       "category": "Science & Nature",
@@ -64,9 +64,9 @@
       "question": "In aeronautics, flaps and slats are used to control what on an aircraft?",
       "options": [
         "Thrust",
-        "Drag",
+        "Lift",
         "Weight ",
-        "Lift"
+        "Drag"
       ],
       "difficulty": "medium",
       "category": "Science & Nature",
@@ -78,9 +78,9 @@
       "question": "Which is not a type of neuron?",
       "options": [
         "Motor Neuron",
-        "Interneuron",
+        "Perceptual Neuron",
         "Sensory Neuron",
-        "Perceptual Neuron"
+        "Interneuron"
       ],
       "difficulty": "hard",
       "category": "Science & Nature",

--- a/src/app/trivia/data/questions/2026-05-04.json
+++ b/src/app/trivia/data/questions/2026-05-04.json
@@ -7,10 +7,10 @@
       "id": "opentdb-2026-05-04-0",
       "question": "In web design, what does CSS stand for?",
       "options": [
-        "Corrective Style Sheet",
-        "Computer Style Sheet",
+        "Cascading Style Sheet",
         "Counter Strike: Source",
-        "Cascading Style Sheet"
+        "Computer Style Sheet",
+        "Corrective Style Sheet"
       ],
       "difficulty": "easy",
       "category": "Science: Computers",
@@ -21,10 +21,10 @@
       "id": "opentdb-2026-05-04-1",
       "question": "In computing, what does LAN stand for?",
       "options": [
-        "Long Antenna Node",
         "Light Access Node",
         "Land Address Navigation",
-        "Local Area Network"
+        "Local Area Network",
+        "Long Antenna Node"
       ],
       "difficulty": "easy",
       "category": "Science: Computers",
@@ -35,10 +35,10 @@
       "id": "opentdb-2026-05-04-2",
       "question": "In computing, what does MIDI stand for?",
       "options": [
-        "Musical Interface of Digital Instruments",
-        "Musical Instrument Data Interface",
+        "Musical Instrument Digital Interface",
         "Modular Interface of Digital Instruments",
-        "Musical Instrument Digital Interface"
+        "Musical Interface of Digital Instruments",
+        "Musical Instrument Data Interface"
       ],
       "difficulty": "easy",
       "category": "Science: Computers",
@@ -50,9 +50,9 @@
       "question": "In CSS, which of these values CANNOT be used with the \"position\" property?",
       "options": [
         "absolute",
-        "relative",
+        "center",
         "static",
-        "center"
+        "relative"
       ],
       "difficulty": "medium",
       "category": "Science: Computers",
@@ -64,9 +64,9 @@
       "question": "How many cores does the Intel i7-6950X have?",
       "options": [
         "8",
-        "4",
+        "10",
         "12",
-        "10"
+        "4"
       ],
       "difficulty": "medium",
       "category": "Science: Computers",
@@ -78,9 +78,9 @@
       "question": "Which kind of algorithm is Ron Rivest not famous for creating?",
       "options": [
         "Hashing algorithm",
-        "Stream cipher",
         "Asymmetric encryption",
-        "Secret sharing scheme"
+        "Secret sharing scheme",
+        "Stream cipher"
       ],
       "difficulty": "hard",
       "category": "Science: Computers",

--- a/src/app/trivia/data/questions/2026-05-05.json
+++ b/src/app/trivia/data/questions/2026-05-05.json
@@ -7,10 +7,10 @@
       "id": "opentdb-2026-05-05-0",
       "question": "What comes after a Million, a Billion, and a Trillion?",
       "options": [
-        "Quintillion",
         "Septillion",
         "Sextillion",
-        "Quadrillion"
+        "Quadrillion",
+        "Quintillion"
       ],
       "difficulty": "easy",
       "category": "Science: Mathematics",
@@ -21,10 +21,10 @@
       "id": "opentdb-2026-05-05-1",
       "question": "The metric prefix \"atto-\" makes a measurement how much smaller than the base unit?",
       "options": [
-        "One Quadrillionth",
-        "One Septillionth",
+        "One Quintillionth",
         "One Billionth",
-        "One Quintillionth"
+        "One Quadrillionth",
+        "One Septillionth"
       ],
       "difficulty": "easy",
       "category": "Science: Mathematics",
@@ -36,9 +36,9 @@
       "question": "How many sides does a Möbius strip have?",
       "options": [
         "3",
-        "4",
+        "1",
         "2",
-        "1"
+        "4"
       ],
       "difficulty": "easy",
       "category": "Science: Mathematics",
@@ -50,9 +50,9 @@
       "question": "What is the derivative of sin(x)",
       "options": [
         "csc(x)",
-        "-sin(x)",
+        "cos(x)",
         "-cos(x)",
-        "cos(x)"
+        "-sin(x)"
       ],
       "difficulty": "medium",
       "category": "Science: Mathematics",
@@ -64,9 +64,9 @@
       "question": "What type of function is x&sup2;+2x+1?",
       "options": [
         "Linear",
-        "Exponential",
         "Rational",
-        "Quadratic"
+        "Quadratic",
+        "Exponential"
       ],
       "difficulty": "medium",
       "category": "Science: Mathematics",
@@ -77,10 +77,10 @@
       "id": "opentdb-2026-05-05-5",
       "question": "The French mathematician Évariste Galois is primarily known for his work in which?",
       "options": [
-        "Galois' Continued Fractions",
-        "Galois' Method for PDE's ",
         "Abelian Integration",
-        "Galois Theory"
+        "Galois' Continued Fractions",
+        "Galois Theory",
+        "Galois' Method for PDE's "
       ],
       "difficulty": "hard",
       "category": "Science: Mathematics",

--- a/src/app/trivia/data/questions/2026-05-06.json
+++ b/src/app/trivia/data/questions/2026-05-06.json
@@ -7,10 +7,10 @@
       "id": "opentdb-2026-05-06-0",
       "question": "Who was the only god from Greece who did not get a name change in Rome?",
       "options": [
-        "Zeus",
-        "Athena",
+        "Apollo",
         "Demeter",
-        "Apollo"
+        "Zeus",
+        "Athena"
       ],
       "difficulty": "easy",
       "category": "Mythology",
@@ -22,9 +22,9 @@
       "question": "Who was the King of Gods in Ancient Greek mythology?",
       "options": [
         "Apollo",
-        "Hermes",
+        "Zeus",
         "Poseidon",
-        "Zeus"
+        "Hermes"
       ],
       "difficulty": "easy",
       "category": "Mythology",
@@ -36,9 +36,9 @@
       "question": "What mythology did the god \"Apollo\" come from?",
       "options": [
         "Greek and Chinese",
-        "Greek, Roman and Norse",
+        "Greek and Roman",
         "Roman and Spanish",
-        "Greek and Roman"
+        "Greek, Roman and Norse"
       ],
       "difficulty": "easy",
       "category": "Mythology",
@@ -50,9 +50,9 @@
       "question": "The Maori hold that which island nation was founded by Kupe, who discovered it under a long white cloud?",
       "options": [
         "Fiji",
-        "Hawaii",
         "Vanuatu",
-        "New Zealand"
+        "New Zealand",
+        "Hawaii"
       ],
       "difficulty": "medium",
       "category": "Mythology",
@@ -63,10 +63,10 @@
       "id": "opentdb-2026-05-06-4",
       "question": "Who is the God Loki's son? ",
       "options": [
-        "Hel",
-        "Sigyn",
         "Odin",
-        "Fenrir "
+        "Hel",
+        "Fenrir ",
+        "Sigyn"
       ],
       "difficulty": "medium",
       "category": "Mythology",
@@ -77,10 +77,10 @@
       "id": "opentdb-2026-05-06-5",
       "question": "What immense structure is referred to in Norse Mythology as the Yggdrasil.",
       "options": [
-        "Mountain",
-        "Castle",
+        "Tree",
         "Temple",
-        "Tree"
+        "Mountain",
+        "Castle"
       ],
       "difficulty": "hard",
       "category": "Mythology",

--- a/src/app/trivia/data/questions/2026-05-07.json
+++ b/src/app/trivia/data/questions/2026-05-07.json
@@ -8,9 +8,9 @@
       "question": "Which city did the former NHL team \"The Nordiques\" originiate from?",
       "options": [
         "Houston",
-        "New York",
+        "Quebec City",
         "Montreal",
-        "Quebec City"
+        "New York"
       ],
       "difficulty": "easy",
       "category": "Sports",
@@ -22,9 +22,9 @@
       "question": "This Canadian television sportscaster is known for his \"Hockey Night in Canada\" role, a commentary show during hockey games.",
       "options": [
         "Don McKellar",
-        "Don Taylor ",
+        "Don Cherry",
         "Donald Sutherland",
-        "Don Cherry"
+        "Don Taylor "
       ],
       "difficulty": "easy",
       "category": "Sports",
@@ -36,9 +36,9 @@
       "question": "Which of these teams has Jaromir Jagr not played for?",
       "options": [
         "Calgary Flames",
-        "New Jersey Devils",
         "Dallas Stars",
-        "New York Islanders"
+        "New York Islanders",
+        "New Jersey Devils"
       ],
       "difficulty": "easy",
       "category": "Sports",
@@ -49,10 +49,10 @@
       "id": "opentdb-2026-05-07-3",
       "question": "What is the highest belt you can get in Taekwondo?",
       "options": [
-        "White",
-        "Green",
         "Red",
-        "Black"
+        "White",
+        "Black",
+        "Green"
       ],
       "difficulty": "medium",
       "category": "Sports",
@@ -63,10 +63,10 @@
       "id": "opentdb-2026-05-07-4",
       "question": "Which football manager won more trophies than any other during his tenure at English football club Manchester United?",
       "options": [
-        "Louis van Gaal",
-        "José Mourinho",
+        "Sir Alex Ferguson",
         "David Moyes",
-        "Sir Alex Ferguson"
+        "Louis van Gaal",
+        "José Mourinho"
       ],
       "difficulty": "medium",
       "category": "Sports",
@@ -77,10 +77,10 @@
       "id": "opentdb-2026-05-07-5",
       "question": "The Mazda 787B won the 24 Hours of Le Mans in what year?",
       "options": [
-        "1990",
+        "1991",
         "2000",
-        "1987",
-        "1991"
+        "1990",
+        "1987"
       ],
       "difficulty": "hard",
       "category": "Sports",

--- a/src/app/trivia/data/questions/2026-05-08.json
+++ b/src/app/trivia/data/questions/2026-05-08.json
@@ -8,9 +8,9 @@
       "question": "Which country was NOT part of the Soviet Union?",
       "options": [
         "Turkmenistan",
-        "Tajikistan",
+        "Romania",
         "Belarus",
-        "Romania"
+        "Tajikistan"
       ],
       "difficulty": "easy",
       "category": "Geography",
@@ -22,9 +22,9 @@
       "question": "Which area of Eastern Europe is famous for its association with vampires?",
       "options": [
         "Silesia",
-        "Slovakia",
         "Macedonia",
-        "Transylvania"
+        "Transylvania",
+        "Slovakia"
       ],
       "difficulty": "easy",
       "category": "Geography",
@@ -35,10 +35,10 @@
       "id": "opentdb-2026-05-08-2",
       "question": "What is the largest country, by area, that has only one time zone?",
       "options": [
-        "Canada",
-        "India",
         "Russia",
-        "China"
+        "Canada",
+        "China",
+        "India"
       ],
       "difficulty": "easy",
       "category": "Geography",
@@ -49,10 +49,10 @@
       "id": "opentdb-2026-05-08-3",
       "question": "How many timezones does Russia have?",
       "options": [
-        "6",
-        "24",
+        "11",
         "16",
-        "11"
+        "6",
+        "24"
       ],
       "difficulty": "medium",
       "category": "Geography",
@@ -63,10 +63,10 @@
       "id": "opentdb-2026-05-08-4",
       "question": "What was the African nation of Zimbabwe formerly known as?",
       "options": [
-        "Zambia",
+        "Rhodesia",
         "Mozambique",
-        " Bulawayo",
-        "Rhodesia"
+        "Zambia",
+        " Bulawayo"
       ],
       "difficulty": "medium",
       "category": "Geography",
@@ -79,8 +79,8 @@
       "options": [
         "Port Moresby",
         "Port-au-Prince",
-        "Port Vila",
-        "Port Louis"
+        "Port Louis",
+        "Port Vila"
       ],
       "difficulty": "hard",
       "category": "Geography",

--- a/src/app/trivia/data/questions/2026-05-09.json
+++ b/src/app/trivia/data/questions/2026-05-09.json
@@ -8,9 +8,9 @@
       "question": "What was William Frederick Cody better known as?",
       "options": [
         "Wild Bill Hickok",
-        "Pawnee Bill",
         "Billy the Kid",
-        "Buffalo Bill"
+        "Buffalo Bill",
+        "Pawnee Bill"
       ],
       "difficulty": "easy",
       "category": "History",
@@ -21,10 +21,10 @@
       "id": "opentdb-2026-05-09-1",
       "question": "Who was the Confederate general in the American Civil War?",
       "options": [
-        "George A. Custer",
-        "Ulysses S. Grant",
         "George B. McClellan",
-        "Robert E. Lee"
+        "George A. Custer",
+        "Robert E. Lee",
+        "Ulysses S. Grant"
       ],
       "difficulty": "easy",
       "category": "History",
@@ -35,10 +35,10 @@
       "id": "opentdb-2026-05-09-2",
       "question": "Which country was Josef Stalin born in?",
       "options": [
-        "Russia",
-        "Poland",
+        "Georgia",
         "Germany",
-        "Georgia"
+        "Russia",
+        "Poland"
       ],
       "difficulty": "easy",
       "category": "History",
@@ -49,10 +49,10 @@
       "id": "opentdb-2026-05-09-3",
       "question": "When was the People's Republic of China founded?",
       "options": [
-        "April 3, 1947",
+        "October 1, 1949",
         "May 7, 1945",
-        "December 6, 1950",
-        "October 1, 1949"
+        "April 3, 1947",
+        "December 6, 1950"
       ],
       "difficulty": "medium",
       "category": "History",
@@ -65,8 +65,8 @@
       "options": [
         "1999",
         "2005",
-        "1981",
-        "1982"
+        "1982",
+        "1981"
       ],
       "difficulty": "medium",
       "category": "History",
@@ -79,8 +79,8 @@
       "options": [
         "Vietnam",
         "Thailand",
-        "Cambodia",
-        "Laos"
+        "Laos",
+        "Cambodia"
       ],
       "difficulty": "hard",
       "category": "History",

--- a/src/app/trivia/data/questions/2026-05-10.json
+++ b/src/app/trivia/data/questions/2026-05-10.json
@@ -7,10 +7,10 @@
       "id": "opentdb-2026-05-10-0",
       "question": "Who was South Africa's first Black President?",
       "options": [
-        "Mangosuthu Buthelezi",
         "Bishop Tutu",
+        "Nelson Mandela",
         "Steve Biko ",
-        "Nelson Mandela"
+        "Mangosuthu Buthelezi"
       ],
       "difficulty": "easy",
       "category": "Politics",
@@ -21,10 +21,10 @@
       "id": "opentdb-2026-05-10-1",
       "question": "Whose 2016 presidential campaign slogan was \"Make America Great Again\"?",
       "options": [
-        "Marco Rubio",
+        "Donald Trump",
         "Bernie Sanders",
         "Ted Cruz",
-        "Donald Trump"
+        "Marco Rubio"
       ],
       "difficulty": "easy",
       "category": "Politics",
@@ -35,10 +35,10 @@
       "id": "opentdb-2026-05-10-2",
       "question": "The largest consumer market in 2015 was...",
       "options": [
-        "Germany",
-        "Japan",
+        "The United States of America",
         "United Kingdom",
-        "The United States of America"
+        "Japan",
+        "Germany"
       ],
       "difficulty": "easy",
       "category": "Politics",
@@ -49,10 +49,10 @@
       "id": "opentdb-2026-05-10-3",
       "question": "Due to the Nagoya Resolution, China agreed to allow Taiwan to compete separately in international sporting events under what name?",
       "options": [
-        "Chinese Taiwan",
-        "Republic of Taiwan",
+        "Chinese Taipei",
         "Republic of Taipei ",
-        "Chinese Taipei"
+        "Republic of Taiwan",
+        "Chinese Taiwan"
       ],
       "difficulty": "medium",
       "category": "Politics",
@@ -63,10 +63,10 @@
       "id": "opentdb-2026-05-10-4",
       "question": "Who succeeded Joseph Stalin as General Secretary of the Communist Party of the Soviet Union?",
       "options": [
-        "Mikhail Gorbachev",
         "Boris Yeltsin",
         "Leonid Brezhnev",
-        "Nikita Khrushchev"
+        "Nikita Khrushchev",
+        "Mikhail Gorbachev"
       ],
       "difficulty": "medium",
       "category": "Politics",
@@ -77,10 +77,10 @@
       "id": "opentdb-2026-05-10-5",
       "question": "Which nation joined NATO as its 29th member in 2017?",
       "options": [
-        "Estonia",
-        "Iceland",
+        "Montenegro",
         "Andorra",
-        "Montenegro"
+        "Estonia",
+        "Iceland"
       ],
       "difficulty": "hard",
       "category": "Politics",

--- a/src/app/trivia/data/questions/2026-05-11.json
+++ b/src/app/trivia/data/questions/2026-05-11.json
@@ -7,10 +7,10 @@
       "id": "opentdb-2026-05-11-0",
       "question": "Who painted the biblical fresco The Creation of Adam?",
       "options": [
-        "Caravaggio",
+        "Michelangelo",
         "Rembrandt",
         "Leonardo da Vinci",
-        "Michelangelo"
+        "Caravaggio"
       ],
       "difficulty": "easy",
       "category": "Art",
@@ -21,10 +21,10 @@
       "id": "opentdb-2026-05-11-1",
       "question": "What is the world's oldest known piece of fiction?",
       "options": [
-        "Papyrus of Ani",
-        "Code of Hammurabi",
+        "Epic of Gilgamesh",
         "Rosetta Stone",
-        "Epic of Gilgamesh"
+        "Code of Hammurabi",
+        "Papyrus of Ani"
       ],
       "difficulty": "easy",
       "category": "Art",
@@ -35,10 +35,10 @@
       "id": "opentdb-2026-05-11-2",
       "question": "Who painted the Mona Lisa?",
       "options": [
-        "Pablo Picasso",
-        "Michelangelo",
+        "Leonardo da Vinci ",
         " Vincent van Gogh",
-        "Leonardo da Vinci "
+        "Michelangelo",
+        "Pablo Picasso"
       ],
       "difficulty": "easy",
       "category": "Art",
@@ -49,10 +49,10 @@
       "id": "opentdb-2026-05-11-3",
       "question": "In \"Last Supper\" by Leonardo Da Vinci, what two colors were the robes worn by Jesus?",
       "options": [
-        "Red and Yellow",
         "Red and Black",
         "Red and White",
-        "Red and Blue"
+        "Red and Blue",
+        "Red and Yellow"
       ],
       "difficulty": "medium",
       "category": "Art",
@@ -63,10 +63,10 @@
       "id": "opentdb-2026-05-11-4",
       "question": "What nationality was the surrealist painter Salvador Dali?",
       "options": [
-        "French",
-        "Portuguese",
+        "Spanish",
         "Italian",
-        "Spanish"
+        "French",
+        "Portuguese"
       ],
       "difficulty": "medium",
       "category": "Art",
@@ -78,9 +78,9 @@
       "question": "What nationality was the famous artist Van Gogh?",
       "options": [
         "French",
-        "Polish",
+        "Dutch",
         "Russian",
-        "Dutch"
+        "Polish"
       ],
       "difficulty": "hard",
       "category": "Art",

--- a/src/app/trivia/data/questions/2026-05-12.json
+++ b/src/app/trivia/data/questions/2026-05-12.json
@@ -7,10 +7,10 @@
       "id": "opentdb-2026-05-12-0",
       "question": "What was the cause of Marilyn Monroes suicide?",
       "options": [
-        "House Fire",
-        "Gunshot",
+        "Drug Overdose",
         "Knife Attack",
-        "Drug Overdose"
+        "Gunshot",
+        "House Fire"
       ],
       "difficulty": "easy",
       "category": "Celebrities",
@@ -21,10 +21,10 @@
       "id": "opentdb-2026-05-12-1",
       "question": "What does film maker Dan Bell typically focus his films on?",
       "options": [
-        "Action Films",
-        "Documentaries ",
+        "Abandoned Buildings and Dead Malls",
         "Historic Landmarks",
-        "Abandoned Buildings and Dead Malls"
+        "Documentaries ",
+        "Action Films"
       ],
       "difficulty": "easy",
       "category": "Celebrities",
@@ -35,10 +35,10 @@
       "id": "opentdb-2026-05-12-2",
       "question": "By what name is Carlos Estevez better known? ",
       "options": [
-        "Ricky Martin",
         "Bruno Mars",
         "Joaquin Phoenix",
-        "Charlie Sheen"
+        "Charlie Sheen",
+        "Ricky Martin"
       ],
       "difficulty": "easy",
       "category": "Celebrities",
@@ -49,10 +49,10 @@
       "id": "opentdb-2026-05-12-3",
       "question": "Who is \"James Rolfe\" better known as?",
       "options": [
-        "TotalBiscuit",
-        "PewDiePie",
+        "The Angry Video Game Nerd",
         "PeanutButterGamer",
-        "The Angry Video Game Nerd"
+        "TotalBiscuit",
+        "PewDiePie"
       ],
       "difficulty": "medium",
       "category": "Celebrities",
@@ -64,9 +64,9 @@
       "question": "How much weight did Chris Pratt lose for his role as Star-Lord in \"Guardians of the Galaxy\"?",
       "options": [
         "50 lbs",
-        "70 lbs",
+        "60 lbs",
         "30 lbs",
-        "60 lbs"
+        "70 lbs"
       ],
       "difficulty": "medium",
       "category": "Celebrities",
@@ -78,9 +78,9 @@
       "question": "Billy Herrington is from which US state?",
       "options": [
         "Arizona",
-        "California",
+        "New York",
         "Georgia",
-        "New York"
+        "California"
       ],
       "difficulty": "hard",
       "category": "Celebrities",

--- a/src/app/trivia/data/questions/2026-05-13.json
+++ b/src/app/trivia/data/questions/2026-05-13.json
@@ -7,10 +7,10 @@
       "id": "opentdb-2026-05-13-0",
       "question": "By definition, where does an abyssopelagic animal live?",
       "options": [
-        "In the desert",
-        "Inside a tree",
+        "At the bottom of the ocean",
         "On top of a mountain",
-        "At the bottom of the ocean"
+        "Inside a tree",
+        "In the desert"
       ],
       "difficulty": "easy",
       "category": "Animals",
@@ -21,10 +21,10 @@
       "id": "opentdb-2026-05-13-1",
       "question": "Which class of animals are newts members of?",
       "options": [
-        "Fish",
         "Reptiles",
         "Mammals",
-        "Amphibian"
+        "Amphibian",
+        "Fish"
       ],
       "difficulty": "easy",
       "category": "Animals",
@@ -35,10 +35,10 @@
       "id": "opentdb-2026-05-13-2",
       "question": "How many teeth does an adult rabbit have?",
       "options": [
-        "30",
-        "26",
+        "28",
         "24",
-        "28"
+        "30",
+        "26"
       ],
       "difficulty": "easy",
       "category": "Animals",
@@ -50,9 +50,9 @@
       "question": "What is the collective noun for rats?",
       "options": [
         "Race",
-        "Drift",
+        "Mischief",
         "Pack",
-        "Mischief"
+        "Drift"
       ],
       "difficulty": "medium",
       "category": "Animals",
@@ -64,9 +64,9 @@
       "question": "Which dog breed is named after a region in Croatia",
       "options": [
         "Chihuahua ",
-        "Pomeranian",
+        "Dalmatian",
         "Pekingnese",
-        "Dalmatian"
+        "Pomeranian"
       ],
       "difficulty": "medium",
       "category": "Animals",
@@ -78,9 +78,9 @@
       "question": "What scientific family does the Aardwolf belong to?",
       "options": [
         "Canidae",
-        "Eupleridae",
         "Felidae",
-        "Hyaenidae"
+        "Hyaenidae",
+        "Eupleridae"
       ],
       "difficulty": "hard",
       "category": "Animals",

--- a/src/app/trivia/data/questions/2026-05-14.json
+++ b/src/app/trivia/data/questions/2026-05-14.json
@@ -7,10 +7,10 @@
       "id": "opentdb-2026-05-14-0",
       "question": "Which car tire manufacturer is famous for its \"P Zero\" line?",
       "options": [
-        "Goodyear",
         "Bridgestone",
         "Michelin",
-        "Pirelli"
+        "Pirelli",
+        "Goodyear"
       ],
       "difficulty": "easy",
       "category": "Vehicles",
@@ -21,10 +21,10 @@
       "id": "opentdb-2026-05-14-1",
       "question": "What country was the Trabant 601 manufactured in?",
       "options": [
-        "Soviet Union",
-        "Hungary",
+        "East Germany",
         "France",
-        "East Germany"
+        "Soviet Union",
+        "Hungary"
       ],
       "difficulty": "easy",
       "category": "Vehicles",
@@ -36,9 +36,9 @@
       "question": "What animal is pictured on the logo of the automobile manufacturer Porsche?",
       "options": [
         "Bull",
-        "Lion",
+        "Horse",
         "Cheetah",
-        "Horse"
+        "Lion"
       ],
       "difficulty": "easy",
       "category": "Vehicles",
@@ -50,9 +50,9 @@
       "question": "What do the 4 Rings in Audi's Logo represent?",
       "options": [
         "States in which Audi makes the most sales",
-        "Main cities vital to Audi",
+        "Previously independent automobile manufacturers",
         "Countries in which Audi makes the most sales",
-        "Previously independent automobile manufacturers"
+        "Main cities vital to Audi"
       ],
       "difficulty": "medium",
       "category": "Vehicles",
@@ -64,9 +64,9 @@
       "question": "What was the aircraft registration for the last Concorde built?",
       "options": [
         "F-BTSC",
-        "F-BVFF",
         "G-BOAC",
-        "G-BOAF"
+        "G-BOAF",
+        "F-BVFF"
       ],
       "difficulty": "medium",
       "category": "Vehicles",
@@ -77,10 +77,10 @@
       "id": "opentdb-2026-05-14-5",
       "question": "Which of these is NOT a car model produced by Malaysian car manufacturer Proton?",
       "options": [
-        "Perdana",
-        "Inspira",
         "Saga",
-        "Kelisa"
+        "Perdana",
+        "Kelisa",
+        "Inspira"
       ],
       "difficulty": "hard",
       "category": "Vehicles",

--- a/src/app/trivia/data/questions/2026-05-15.json
+++ b/src/app/trivia/data/questions/2026-05-15.json
@@ -7,10 +7,10 @@
       "id": "opentdb-2026-05-15-0",
       "question": "The main six year old protagonist in Calvin and Hobbes is named after what theologian?",
       "options": [
-        "Calvin Klein",
-        "Phillip Calvin McGraw",
+        "John Calvin",
         "Calvin Coolidge",
-        "John Calvin"
+        "Calvin Klein",
+        "Phillip Calvin McGraw"
       ],
       "difficulty": "easy",
       "category": "Entertainment: Comics",
@@ -22,9 +22,9 @@
       "question": "Who is the creator of the comic series \"The Walking Dead\"?",
       "options": [
         "Stan Lee",
-        "Robert Crumb",
+        "Robert Kirkman",
         "Malcolm Wheeler-Nicholson",
-        "Robert Kirkman"
+        "Robert Crumb"
       ],
       "difficulty": "easy",
       "category": "Entertainment: Comics",
@@ -36,9 +36,9 @@
       "question": "In Black Hammer, what city did the heroes save from the Anti-God?",
       "options": [
         "Mega-City One",
-        "Rockwood",
+        "Spiral City",
         "Star City",
-        "Spiral City"
+        "Rockwood"
       ],
       "difficulty": "easy",
       "category": "Entertainment: Comics",
@@ -50,9 +50,9 @@
       "question": "What is Homestuck character Gamzee's last name?",
       "options": [
         "Makera",
-        "Makare",
         "Makrea",
-        "Makara"
+        "Makara",
+        "Makare"
       ],
       "difficulty": "medium",
       "category": "Entertainment: Comics",
@@ -63,10 +63,10 @@
       "id": "opentdb-2026-05-15-4",
       "question": "What was the name of the first Robin in the Batman comics?",
       "options": [
-        "Bruce Wayne",
-        "Jason Todd",
         "Tim Drake",
-        "Dick Grayson"
+        "Bruce Wayne",
+        "Dick Grayson",
+        "Jason Todd"
       ],
       "difficulty": "medium",
       "category": "Entertainment: Comics",
@@ -77,10 +77,10 @@
       "id": "opentdb-2026-05-15-5",
       "question": "Which of the following rings from the DC Comics' \"Lantern Corps\" are classified as Parasitic?",
       "options": [
-        "White (Life)",
-        "Yellow (Fear)",
+        "Indigo (Compassion)",
         "Green (Willpower)",
-        "Indigo (Compassion)"
+        "White (Life)",
+        "Yellow (Fear)"
       ],
       "difficulty": "hard",
       "category": "Entertainment: Comics",


### PR DESCRIPTION
## Bug
Every multiple-choice trivia question across all 30 pre-generated days had the correct answer at position D. Players could score 100% by always picking D.

## Root cause
The seeded shuffle in the generator script didn't properly randomize during the initial generation run. The options array was always [correct, wrong1, wrong2, wrong3] with the correct answer ending up at the last position.

## Fix
Re-shuffled all 30 question files with a deterministic Fisher-Yates shuffle seeded from each question's ID. Verified answers are now distributed across A, B, C, and D.

Before: all D
After: mixed (A: 25%, B: 30%, C: 30%, D: 15% — natural distribution)

## Test plan
- [ ] Play trivia — correct answers appear at different positions per question

🤖 Generated with [Claude Code](https://claude.com/claude-code)