### PR TITLE
Constrain starting weapons to simple mundane weapons

### DIFF
--- a/src/app/tap-tap-adventure/config/fallbackClasses.ts
+++ b/src/app/tap-tap-adventure/config/fallbackClasses.ts
@@ -24,7 +24,7 @@ export const FALLBACK_CLASSES: GeneratedClass[] = [
       ],
       tags: ['war', 'defense', 'iron'],
     },
-    startingWeapon: { name: 'Iron Greatsword', description: 'A massive iron blade, heavy but devastating.', effects: { strength: 3, range: 'close' } },
+    startingWeapon: { name: 'Iron Sword', description: 'A sturdy iron blade, well-balanced and reliable.', effects: { strength: 2, range: 'close' } },
   },
   {
     id: 'flame-knight',
@@ -48,7 +48,7 @@ export const FALLBACK_CLASSES: GeneratedClass[] = [
       ],
       tags: ['war', 'fire', 'melee'],
     },
-    startingWeapon: { name: 'Blazing Longsword', description: 'A sword wreathed in flickering flames.', effects: { strength: 3, range: 'close' } },
+    startingWeapon: { name: 'Wooden Club', description: 'A heavy wooden club, simple but effective.', effects: { strength: 2, range: 'close' } },
   },
   {
     id: 'storm-berserker',
@@ -72,7 +72,7 @@ export const FALLBACK_CLASSES: GeneratedClass[] = [
       ],
       tags: ['war', 'storm', 'melee'],
     },
-    startingWeapon: { name: 'Thunder Maul', description: 'A war hammer crackling with static charge.', effects: { strength: 3, range: 'close' } },
+    startingWeapon: { name: 'Simple Axe', description: 'A basic hand axe with a sharp edge.', effects: { strength: 2, range: 'close' } },
   },
 
   // Arcane
@@ -98,7 +98,7 @@ export const FALLBACK_CLASSES: GeneratedClass[] = [
       ],
       tags: ['arcane', 'ice', 'ranged'],
     },
-    startingWeapon: { name: 'Frost Scepter', description: 'A crystalline rod that radiates bitter cold.', effects: { intelligence: 3, range: 'far' } },
+    startingWeapon: { name: 'Apprentice Wand', description: 'A plain wooden wand, standard issue for novice mages.', effects: { intelligence: 2, range: 'far' } },
   },
   {
     id: 'void-channeler',
@@ -122,7 +122,7 @@ export const FALLBACK_CLASSES: GeneratedClass[] = [
       ],
       tags: ['arcane', 'void', 'ranged'],
     },
-    startingWeapon: { name: 'Void Staff', description: 'A staff carved from petrified shadow.', effects: { intelligence: 3, range: 'far' } },
+    startingWeapon: { name: 'Oak Staff', description: 'A tall oak staff, worn smooth from use.', effects: { intelligence: 2, range: 'far' } },
   },
   {
     id: 'tempest-sage',
@@ -146,7 +146,7 @@ export const FALLBACK_CLASSES: GeneratedClass[] = [
       ],
       tags: ['arcane', 'storm', 'ranged'],
     },
-    startingWeapon: { name: 'Storm Wand', description: 'A wand that hums with bottled lightning.', effects: { intelligence: 3, range: 'far' } },
+    startingWeapon: { name: 'Simple Scepter', description: 'A basic scepter topped with a dull crystal.', effects: { intelligence: 2, range: 'far' } },
   },
 
   // Shadow
@@ -172,7 +172,7 @@ export const FALLBACK_CLASSES: GeneratedClass[] = [
       ],
       tags: ['shadow', 'melee', 'stealth'],
     },
-    startingWeapon: { name: 'Umbral Daggers', description: 'Twin blades forged from solidified darkness.', effects: { strength: 3, range: 'close' } },
+    startingWeapon: { name: 'Worn Dagger', description: 'A short dagger with a leather-wrapped grip.', effects: { strength: 1, range: 'close' } },
   },
   {
     id: 'blood-stalker',
@@ -196,7 +196,7 @@ export const FALLBACK_CLASSES: GeneratedClass[] = [
       ],
       tags: ['shadow', 'blood', 'melee'],
     },
-    startingWeapon: { name: 'Crimson Fang', description: 'A curved blade with a thirst for blood.', effects: { strength: 3, range: 'close' } },
+    startingWeapon: { name: 'Rusty Shortsword', description: 'A battered shortsword, still sharp enough.', effects: { strength: 1, range: 'close' } },
   },
   {
     id: 'beast-lurker',
@@ -220,7 +220,7 @@ export const FALLBACK_CLASSES: GeneratedClass[] = [
       ],
       tags: ['shadow', 'beast', 'melee'],
     },
-    startingWeapon: { name: 'Predator Claws', description: 'Iron claws strapped to the knuckles.', effects: { strength: 3, range: 'close' } },
+    startingWeapon: { name: 'Chipped Knife', description: 'A utility knife pressed into service as a weapon.', effects: { strength: 1, range: 'close' } },
   },
 
   // Divine
@@ -246,7 +246,7 @@ export const FALLBACK_CLASSES: GeneratedClass[] = [
       ],
       tags: ['divine', 'light', 'defense'],
     },
-    startingWeapon: { name: 'Radiant Mace', description: 'A golden mace that glows with inner light.', effects: { strength: 2, intelligence: 1, range: 'close' } },
+    startingWeapon: { name: 'Wooden Mace', description: 'A sturdy mace with an iron-banded head.', effects: { strength: 1, intelligence: 1, range: 'close' } },
   },
   {
     id: 'nature-priest',
@@ -270,7 +270,7 @@ export const FALLBACK_CLASSES: GeneratedClass[] = [
       ],
       tags: ['nature', 'heal', 'divine'],
     },
-    startingWeapon: { name: 'Living Staff', description: 'A staff of living wood that sprouts tiny leaves.', effects: { strength: 2, intelligence: 1, range: 'close' } },
+    startingWeapon: { name: 'Iron Flail', description: 'A simple flail with a weighted chain.', effects: { strength: 1, intelligence: 1, range: 'close' } },
   },
   {
     id: 'time-keeper',
@@ -294,7 +294,7 @@ export const FALLBACK_CLASSES: GeneratedClass[] = [
       ],
       tags: ['divine', 'time', 'ranged'],
     },
-    startingWeapon: { name: 'Chrono Scepter', description: 'A scepter containing a tiny hourglass.', effects: { strength: 2, intelligence: 1, range: 'close' } },
+    startingWeapon: { name: 'Plain Hammer', description: 'A well-worn hammer, practical and dependable.', effects: { strength: 1, intelligence: 1, range: 'close' } },
   },
 
   // Primal
@@ -320,7 +320,7 @@ export const FALLBACK_CLASSES: GeneratedClass[] = [
       ],
       tags: ['primal', 'beast', 'melee'],
     },
-    startingWeapon: { name: 'Fang Spear', description: "A spear tipped with a great beast's fang.", effects: { strength: 2, intelligence: 1, range: 'mid' } },
+    startingWeapon: { name: 'Wooden Spear', description: 'A sharpened spear with a fire-hardened tip.', effects: { strength: 1, intelligence: 1, range: 'mid' } },
   },
   {
     id: 'flame-shaman',
@@ -344,7 +344,7 @@ export const FALLBACK_CLASSES: GeneratedClass[] = [
       ],
       tags: ['primal', 'fire', 'totem'],
     },
-    startingWeapon: { name: 'Ember Staff', description: 'A gnarled staff with a perpetually glowing tip.', effects: { strength: 2, intelligence: 1, range: 'mid' } },
+    startingWeapon: { name: 'Hunting Bow', description: 'A simple shortbow made from flexible wood.', effects: { strength: 1, intelligence: 1, range: 'mid' } },
   },
   {
     id: 'ice-warden',
@@ -368,7 +368,7 @@ export const FALLBACK_CLASSES: GeneratedClass[] = [
       ],
       tags: ['primal', 'ice', 'defense'],
     },
-    startingWeapon: { name: 'Frost Halberd', description: 'A polearm edged with permanent ice.', effects: { strength: 2, intelligence: 1, range: 'mid' } },
+    startingWeapon: { name: 'Quarterstaff', description: 'A solid wooden staff, good for keeping distance.', effects: { strength: 1, intelligence: 1, range: 'mid' } },
   },
 
   // Psionic
@@ -394,7 +394,7 @@ export const FALLBACK_CLASSES: GeneratedClass[] = [
       ],
       tags: ['psionic', 'void', 'ranged'],
     },
-    startingWeapon: { name: 'Void Crystal', description: 'A hovering crystal that amplifies psychic power.', effects: { intelligence: 3, range: 'far' } },
+    startingWeapon: { name: 'Crystal Focus', description: 'A rough crystal that hums faintly when held.', effects: { intelligence: 1, range: 'far' } },
   },
   {
     id: 'blood-seer',
@@ -418,6 +418,6 @@ export const FALLBACK_CLASSES: GeneratedClass[] = [
       ],
       tags: ['psionic', 'blood', 'self-harm'],
     },
-    startingWeapon: { name: 'Sanguine Focus', description: 'A lens of hardened blood that channels psionic energy.', effects: { intelligence: 3, range: 'far' } },
+    startingWeapon: { name: 'Simple Rod', description: 'A plain metal rod used to channel mental energy.', effects: { intelligence: 1, range: 'far' } },
   },
 ]

--- a/src/app/tap-tap-adventure/hooks/useCharacterCreation.ts
+++ b/src/app/tap-tap-adventure/hooks/useCharacterCreation.ts
@@ -242,6 +242,7 @@ export function useCharacterCreation() {
         quantity: 1,
         type: 'equipment',
         effects: classData.startingWeapon.effects,
+        rarity: 'common',
       }
       startingInventory.push(weaponItem)
       startingEquipment = { weapon: weaponItem, armor: null, accessory: null }

--- a/src/app/tap-tap-adventure/lib/classGenerator.ts
+++ b/src/app/tap-tap-adventure/lib/classGenerator.ts
@@ -285,44 +285,44 @@ const EFFECT_TEMPLATES: Record<string, EffectTemplate[]> = {
   ],
 }
 
-const WEAPON_TEMPLATES: Record<string, { name: string; effects: { strength?: number; intelligence?: number; range: 'close' | 'mid' | 'far' } }[]> = {
+const WEAPON_TEMPLATES: Record<string, { name: string; description: string; effects: { strength?: number; intelligence?: number; range: 'close' | 'mid' | 'far' } }[]> = {
   martial: [
-    { name: 'Iron Longsword', effects: { strength: 3, range: 'close' } },
-    { name: 'Battle Axe', effects: { strength: 3, range: 'close' } },
-    { name: 'War Hammer', effects: { strength: 3, range: 'close' } },
+    { name: 'Iron Sword', description: 'A sturdy iron blade, well-balanced and reliable.', effects: { strength: 2, range: 'close' } },
+    { name: 'Wooden Club', description: 'A heavy wooden club, simple but effective.', effects: { strength: 2, range: 'close' } },
+    { name: 'Simple Axe', description: 'A basic hand axe with a sharp edge.', effects: { strength: 2, range: 'close' } },
   ],
   arcane: [
-    { name: 'Crystal Wand', effects: { intelligence: 3, range: 'far' } },
-    { name: 'Arcane Scepter', effects: { intelligence: 3, range: 'far' } },
-    { name: 'Mystic Orb', effects: { intelligence: 3, range: 'far' } },
+    { name: 'Apprentice Wand', description: 'A plain wooden wand, standard issue for novice mages.', effects: { intelligence: 2, range: 'far' } },
+    { name: 'Oak Staff', description: 'A tall oak staff, worn smooth from use.', effects: { intelligence: 2, range: 'far' } },
+    { name: 'Simple Scepter', description: 'A basic scepter topped with a dull crystal.', effects: { intelligence: 2, range: 'far' } },
   ],
   divine: [
-    { name: 'Holy Mace', effects: { strength: 2, intelligence: 1, range: 'close' } },
-    { name: 'Blessed Flail', effects: { strength: 2, intelligence: 1, range: 'close' } },
-    { name: 'Sacred Hammer', effects: { strength: 2, intelligence: 1, range: 'close' } },
+    { name: 'Wooden Mace', description: 'A sturdy mace with an iron-banded head.', effects: { strength: 1, intelligence: 1, range: 'close' } },
+    { name: 'Iron Flail', description: 'A simple flail with a weighted chain.', effects: { strength: 1, intelligence: 1, range: 'close' } },
+    { name: 'Plain Hammer', description: 'A well-worn hammer, practical and dependable.', effects: { strength: 1, intelligence: 1, range: 'close' } },
   ],
   primal: [
-    { name: 'Hunting Spear', effects: { strength: 2, intelligence: 1, range: 'mid' } },
-    { name: 'Oak Quarterstaff', effects: { strength: 2, intelligence: 1, range: 'mid' } },
-    { name: 'Bone Club', effects: { strength: 2, intelligence: 1, range: 'mid' } },
+    { name: 'Wooden Spear', description: 'A sharpened spear with a fire-hardened tip.', effects: { strength: 1, intelligence: 1, range: 'mid' } },
+    { name: 'Hunting Bow', description: 'A simple shortbow made from flexible wood.', effects: { strength: 1, intelligence: 1, range: 'mid' } },
+    { name: 'Quarterstaff', description: 'A solid wooden staff, good for keeping distance.', effects: { strength: 1, intelligence: 1, range: 'mid' } },
   ],
   shadow: [
-    { name: 'Shadow Daggers', effects: { strength: 3, range: 'close' } },
-    { name: 'Venomed Blade', effects: { strength: 3, range: 'close' } },
-    { name: 'Stiletto', effects: { strength: 3, range: 'close' } },
+    { name: 'Worn Dagger', description: 'A short dagger with a leather-wrapped grip.', effects: { strength: 1, range: 'close' } },
+    { name: 'Rusty Shortsword', description: 'A battered shortsword, still sharp enough.', effects: { strength: 1, range: 'close' } },
+    { name: 'Chipped Knife', description: 'A utility knife pressed into service as a weapon.', effects: { strength: 1, range: 'close' } },
   ],
   psionic: [
-    { name: 'Mind Crystal', effects: { intelligence: 3, range: 'far' } },
-    { name: 'Psi Focus', effects: { intelligence: 3, range: 'far' } },
-    { name: 'Thought Shard', effects: { intelligence: 3, range: 'far' } },
+    { name: 'Crystal Focus', description: 'A rough crystal that hums faintly when held.', effects: { intelligence: 1, range: 'far' } },
+    { name: 'Simple Rod', description: 'A plain metal rod used to channel mental energy.', effects: { intelligence: 1, range: 'far' } },
+    { name: 'Glass Orb', description: 'A cloudy glass sphere, slightly warm to the touch.', effects: { intelligence: 1, range: 'far' } },
   ],
 }
 
-export function generateStartingWeapon(style: string, modifier: string): Omit<StartingWeapon, 'name' | 'description'> {
+export function generateStartingWeapon(style: string, modifier: string): StartingWeapon {
   const category = getStyleCategory(style)
   const templates = WEAPON_TEMPLATES[category] ?? WEAPON_TEMPLATES.martial
   const template = templates[Math.floor(Math.random() * templates.length)]
-  return { effects: template.effects }
+  return { name: template.name, description: template.description, effects: template.effects }
 }
 
 /**
@@ -446,10 +446,8 @@ const classNamingFunctions: OpenAI.Chat.Completions.ChatCompletionTool[] = [
                 description: { type: 'string', description: '1-2 sentence flavor text that matches the actual mechanics' },
                 abilityName: { type: 'string', description: 'Creative name for the starting ability' },
                 abilityDescription: { type: 'string', description: 'Short description of the ability that accurately reflects its effects' },
-                weaponName: { type: 'string', description: 'Creative name for the starting weapon that matches the class theme' },
-                weaponDescription: { type: 'string', description: 'One sentence describing the starting weapon' },
               },
-              required: ['name', 'description', 'abilityName', 'abilityDescription', 'weaponName', 'weaponDescription'],
+              required: ['name', 'description', 'abilityName', 'abilityDescription'],
             },
             minItems: 5,
             maxItems: 5,
@@ -495,7 +493,6 @@ export async function generateClassFromSeed(
 
   const prompt = `Given these 5 fantasy character classes with pre-built mechanics, generate a creative name for each class and a 1-2 sentence description.
 Also name each starting ability and describe what it does.
-Also name the starting weapon and describe it in one sentence. The weapon should match the class theme.
 
 DO NOT invent new mechanics. Each description must accurately reflect the effects listed.
 
@@ -520,8 +517,6 @@ ${classDescriptions}`
     description: string
     abilityName: string
     abilityDescription: string
-    weaponName: string
-    weaponDescription: string
   }[]
 
   // Step 3: Combine mechanical data with LLM-generated names
@@ -543,11 +538,7 @@ ${classDescriptions}`
         description: named.abilityDescription,
         ...mech.ability,
       },
-      startingWeapon: {
-        name: named.weaponName,
-        description: named.weaponDescription,
-        ...mech.weapon,
-      },
+      startingWeapon: mech.weapon,
     }
   })
 


### PR DESCRIPTION
## Summary
Closes #441

- **Weapon templates** updated with mundane names and descriptions (e.g. "Iron Sword", "Worn Dagger", "Apprentice Wand") — no elemental or thematic modifiers
- **Stat bonuses capped** at +1 to +2 STR or INT per category (martial +2 STR, shadow +1 STR, arcane +2 INT, psionic +1 INT, divine/primal +1 STR +1 INT)
- **Weapon naming removed from LLM** — names and descriptions now come from hardcoded templates, preventing creative/fancy names
- **All 17 fallback classes** updated with mundane weapon equivalents
- **Rarity set to `common`** when equipping the starting weapon during character creation

## Files changed
- `lib/classGenerator.ts` — mundane weapon templates, `generateStartingWeapon` returns full `StartingWeapon`, LLM no longer names weapons
- `config/fallbackClasses.ts` — all 17 fallback weapons replaced with mundane versions
- `hooks/useCharacterCreation.ts` — added `rarity: 'common'` to weapon item

## Test plan
- [ ] Create a new character for each combat style category and verify mundane weapon name/stats
- [ ] Verify weapon shows `common` rarity in inventory
- [ ] Verify stat bonuses are +1 to +2 only (no +3)
- [ ] Verify no elemental/thematic weapon names appear
- [ ] Build passes with no type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)