### PR TITLE
feat: expand quest variety from 4 to 9 types (#434)

### DIFF
--- a/src/app/tap-tap-adventure/__tests__/questGenerator.test.ts
+++ b/src/app/tap-tap-adventure/__tests__/questGenerator.test.ts
@@ -39,7 +39,7 @@ describe('Quest Generator', () => {
       expect(quest.title).toBeTruthy()
       expect(quest.description).toBeTruthy()
       expect(quest.status).toBe('active')
-      expect(['reach_distance', 'collect_gold', 'win_combat', 'gain_reputation']).toContain(quest.type)
+      expect(['reach_distance', 'collect_gold', 'win_combat', 'gain_reputation', 'explore_landmarks', 'survive_combats', 'reach_level', 'hoard_items', 'visit_region']).toContain(quest.type)
       expect(quest.target).toBeGreaterThan(0)
       expect(quest.deadlineDay).toBeGreaterThan(quest.startDay)
       expect(quest.rewards.gold).toBeGreaterThan(0)
@@ -102,6 +102,74 @@ describe('Quest Generator', () => {
       const repQuest = { ...quest, type: 'gain_reputation' as const, target: 15 }
       const repChar = { ...baseChar, reputation: 20 }
       const result = checkQuestProgress(repQuest, repChar)
+      expect(result.status).toBe('completed')
+    })
+
+    it('marks explore_landmarks quest as completed when landmarks explored', () => {
+      const quest = generateTimedQuest(baseChar)
+      const exploreQuest = { ...quest, type: 'explore_landmarks' as const, target: 2, startValue: 0 }
+      const explorerChar = {
+        ...baseChar,
+        landmarkState: {
+          regionId: 'test',
+          landmarks: [
+            { templateId: 't1', name: 'Ruins', type: 'ruins', description: 'Old ruins', icon: '🏛️', hasShop: false, encounterPrompt: '', distanceFromEntry: 10, hidden: false, explored: true },
+            { templateId: 't2', name: 'Tower', type: 'tower', description: 'A tower', icon: '🗼', hasShop: false, encounterPrompt: '', distanceFromEntry: 20, hidden: false, explored: true },
+          ],
+          entryDistance: 0,
+          nextLandmarkIndex: 2,
+          exploring: false,
+          explorationDepth: 0,
+          positionInRegion: 50,
+          activeTargetIndex: 0,
+          regionLength: 200,
+        },
+      }
+      const result = checkQuestProgress(exploreQuest, explorerChar as any)
+      expect(result.status).toBe('completed')
+    })
+
+    it('tracks survive_combats progress incrementally', () => {
+      const quest = generateTimedQuest(baseChar)
+      const combatQuest = { ...quest, type: 'survive_combats' as const, target: 3, startValue: 0 }
+      // First win
+      const result1 = checkQuestProgress(combatQuest, baseChar, true)
+      expect(result1.status).toBe('active')
+      expect(result1.startValue).toBe(1)
+      // Second win
+      const result2 = checkQuestProgress(result1, baseChar, true)
+      expect(result2.status).toBe('active')
+      expect(result2.startValue).toBe(2)
+      // Third win — complete
+      const result3 = checkQuestProgress(result2, baseChar, true)
+      expect(result3.status).toBe('completed')
+    })
+
+    it('marks reach_level quest as completed', () => {
+      const quest = generateTimedQuest(baseChar)
+      const levelQuest = { ...quest, type: 'reach_level' as const, target: 5, startValue: 2 }
+      const leveledChar = { ...baseChar, level: 5 }
+      const result = checkQuestProgress(levelQuest, leveledChar)
+      expect(result.status).toBe('completed')
+    })
+
+    it('marks hoard_items quest as completed', () => {
+      const quest = generateTimedQuest(baseChar)
+      const hoardQuest = { ...quest, type: 'hoard_items' as const, target: 3, startValue: 0 }
+      const itemChar = { ...baseChar, inventory: [
+        { id: '1', name: 'Sword', description: 'A sword', quantity: 1 },
+        { id: '2', name: 'Shield', description: 'A shield', quantity: 1 },
+        { id: '3', name: 'Potion', description: 'A potion', quantity: 1 },
+      ]}
+      const result = checkQuestProgress(hoardQuest, itemChar as any)
+      expect(result.status).toBe('completed')
+    })
+
+    it('marks visit_region quest as completed', () => {
+      const quest = generateTimedQuest(baseChar)
+      const regionQuest = { ...quest, type: 'visit_region' as const, target: 2, startValue: 1 }
+      const traveledChar = { ...baseChar, visitedRegions: ['green_meadows', 'dark_forest'] }
+      const result = checkQuestProgress(regionQuest, traveledChar)
       expect(result.status).toBe('completed')
     })
   })

--- a/src/app/tap-tap-adventure/components/QuestPanel.tsx
+++ b/src/app/tap-tap-adventure/components/QuestPanel.tsx
@@ -134,6 +134,47 @@ export function QuestPanel() {
       targetDescription = `Reach ${quest.target} reputation`
       break
     }
+    case 'explore_landmarks': {
+      const explored = (character.landmarkState?.landmarks ?? []).filter(lm => lm.explored).length
+      const needed = quest.target - quest.startValue
+      const done = Math.max(0, explored - quest.startValue)
+      progress = Math.min(1, done / Math.max(1, needed))
+      progressText = `${explored} / ${quest.target} explored`
+      targetDescription = `Explore ${quest.target} landmarks`
+      break
+    }
+    case 'survive_combats': {
+      const wins = quest.startValue
+      progress = Math.min(1, wins / quest.target)
+      progressText = `${wins} / ${quest.target} won`
+      targetDescription = `Win ${quest.target} battles`
+      break
+    }
+    case 'reach_level': {
+      const needed = quest.target - quest.startValue
+      const done = Math.max(0, character.level - quest.startValue)
+      progress = Math.min(1, done / Math.max(1, needed))
+      progressText = `Level ${character.level} / ${quest.target}`
+      targetDescription = `Reach level ${quest.target}`
+      break
+    }
+    case 'hoard_items': {
+      const needed = quest.target - quest.startValue
+      const done = Math.max(0, character.inventory.length - quest.startValue)
+      progress = Math.min(1, done / Math.max(1, needed))
+      progressText = `${character.inventory.length} / ${quest.target} items`
+      targetDescription = `Collect ${quest.target} items`
+      break
+    }
+    case 'visit_region': {
+      const visited = character.visitedRegions?.length ?? 1
+      const needed = quest.target - quest.startValue
+      const done = Math.max(0, visited - quest.startValue)
+      progress = Math.min(1, done / Math.max(1, needed))
+      progressText = `${visited} / ${quest.target} regions`
+      targetDescription = `Visit ${quest.target} regions`
+      break
+    }
   }
 
   // Celebration modal for completed quests

--- a/src/app/tap-tap-adventure/lib/questGenerator.ts
+++ b/src/app/tap-tap-adventure/lib/questGenerator.ts
@@ -4,7 +4,7 @@ import { TimedQuest } from '@/app/tap-tap-adventure/models/quest'
 import { calculateDay } from './leveling'
 import { inferItemTypeAndEffects } from './itemPostProcessor'
 
-type QuestType = 'reach_distance' | 'collect_gold' | 'win_combat' | 'gain_reputation'
+type QuestType = 'reach_distance' | 'collect_gold' | 'win_combat' | 'gain_reputation' | 'explore_landmarks' | 'survive_combats' | 'reach_level' | 'hoard_items' | 'visit_region'
 
 interface QuestTemplate {
   type: QuestType
@@ -47,6 +47,46 @@ const QUEST_TEMPLATES: QuestTemplate[] = [
     getTarget: (char) => char.reputation + 5 + Math.floor(Math.random() * 5),
     getDaysAllowed: () => 4 + Math.floor(Math.random() * 2),
     getStartValue: (char) => char.reputation,
+  },
+  {
+    type: 'explore_landmarks',
+    getTitle: (target) => `Explore ${target} Landmarks`,
+    getDescription: (target, days) => `Explore ${target} landmark${target > 1 ? 's' : ''} within ${days} days. Seek out points of interest!`,
+    getTarget: () => 2 + Math.floor(Math.random() * 2),
+    getDaysAllowed: () => 5 + Math.floor(Math.random() * 2),
+    getStartValue: (char) => (char.landmarkState?.landmarks ?? []).filter(lm => lm.explored).length,
+  },
+  {
+    type: 'survive_combats',
+    getTitle: (target) => `Win ${target} Battles`,
+    getDescription: (target, days) => `Win ${target} combat encounter${target > 1 ? 's' : ''} within ${days} days. Seek out worthy foes!`,
+    getTarget: () => 2 + Math.floor(Math.random() * 2),
+    getDaysAllowed: () => 4 + Math.floor(Math.random() * 2),
+    getStartValue: () => 0,
+  },
+  {
+    type: 'reach_level',
+    getTitle: (target) => `Reach Level ${target}`,
+    getDescription: (target, days) => `Advance to level ${target} within ${days} days. Defeat enemies and gain experience!`,
+    getTarget: (char) => char.level + 1,
+    getDaysAllowed: () => 5 + Math.floor(Math.random() * 3),
+    getStartValue: (char) => char.level,
+  },
+  {
+    type: 'hoard_items',
+    getTitle: (target) => `Collect ${target} Items`,
+    getDescription: (target, days) => `Gather ${target} item${target > 1 ? 's' : ''} in your inventory within ${days} days. Loot, buy, and craft!`,
+    getTarget: (char) => char.inventory.length + 3 + Math.floor(Math.random() * 3),
+    getDaysAllowed: () => 4 + Math.floor(Math.random() * 2),
+    getStartValue: (char) => char.inventory.length,
+  },
+  {
+    type: 'visit_region',
+    getTitle: () => 'Venture to New Lands',
+    getDescription: (_target, days) => `Enter a new region within ${days} days. Push forward past the edge of the known world!`,
+    getTarget: (char) => (char.visitedRegions?.length ?? 1) + 1,
+    getDaysAllowed: () => 6 + Math.floor(Math.random() * 3),
+    getStartValue: (char) => char.visitedRegions?.length ?? 1,
   },
 ]
 
@@ -111,6 +151,31 @@ export function checkQuestProgress(
       break
     case 'gain_reputation':
       completed = character.reputation >= quest.target
+      break
+    case 'explore_landmarks': {
+      const exploredCount = (character.landmarkState?.landmarks ?? []).filter(lm => lm.explored).length
+      completed = exploredCount >= quest.target
+      break
+    }
+    case 'survive_combats':
+      if (combatWon) {
+        const newProgress = (quest.startValue ?? 0) + 1
+        if (newProgress >= quest.target) {
+          completed = true
+        } else {
+          // Update startValue to track cumulative wins
+          return { ...quest, startValue: newProgress }
+        }
+      }
+      break
+    case 'reach_level':
+      completed = character.level >= quest.target
+      break
+    case 'hoard_items':
+      completed = character.inventory.length >= quest.target
+      break
+    case 'visit_region':
+      completed = (character.visitedRegions?.length ?? 1) >= quest.target
       break
   }
 

--- a/src/app/tap-tap-adventure/models/quest.ts
+++ b/src/app/tap-tap-adventure/models/quest.ts
@@ -7,7 +7,7 @@ export const TimedQuestSchema = z.object({
   title: z.string(),
   description: z.string(),
   status: z.enum(['active', 'completed', 'failed']),
-  type: z.enum(['reach_distance', 'collect_gold', 'win_combat', 'gain_reputation']),
+  type: z.enum(['reach_distance', 'collect_gold', 'win_combat', 'gain_reputation', 'explore_landmarks', 'survive_combats', 'reach_level', 'hoard_items', 'visit_region']),
   // Target value to reach
   target: z.number(),
   // Starting value when quest was accepted


### PR DESCRIPTION
## Summary

- Adds 5 new quest types to the Tap Tap Adventure game: `explore_landmarks`, `survive_combats`, `reach_level`, `hoard_items`, and `visit_region`
- Updates `TimedQuestSchema` enum and `QuestType` union type to include all 9 types
- Adds quest templates with `getTarget`, `getDaysAllowed`, and `getStartValue` using existing `FantasyCharacter` fields (`landmarkState`, `level`, `inventory`, `visitedRegions`)
- Adds `survive_combats` incremental counter logic (tracks wins via `startValue` mutation on each `combatWon` call)
- Adds progress display cases in `QuestPanel.tsx` for all 5 new types
- Adds 5 new test cases covering completion logic for each new type (14 total, all passing)

## Test plan

- [x] `npx vitest run src/app/tap-tap-adventure/__tests__/questGenerator.test.ts` — 14/14 tests pass
- [x] `npm run build` — compiled successfully, no TypeScript errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)