### PR TITLE
feat: event companion rewards and NPC recruitment tracking (#383)

### DIFF
--- a/src/app/tap-tap-adventure/__tests__/eventResolution.test.ts
+++ b/src/app/tap-tap-adventure/__tests__/eventResolution.test.ts
@@ -59,4 +59,52 @@ describe('Decision Resolution', () => {
     // 0.2 + (2*0.05) + (1*0.1) + (5*0.001 reputation modifier) = 0.405
     expect(calculateEffectiveProbability(option, baseChar)).toBeCloseTo(0.405)
   })
+
+  it('grants a companion when party has room', () => {
+    const effects = {
+      grantCompanion: {
+        name: 'Test Companion',
+        description: 'A test ally',
+        icon: '🧑',
+        dailyCost: 0,
+        rarity: 'common' as const,
+      },
+    }
+    const updated = applyEffects(baseChar, effects)
+    expect(updated.party).toBeDefined()
+    expect(updated.party!.length).toBe(1)
+    expect(updated.party![0].name).toBe('Test Companion')
+  })
+
+  it('does not grant companion when party is full', () => {
+    const fullPartyChar = {
+      ...baseChar,
+      party: Array.from({ length: 3 }, (_, i) => ({
+        id: `member-${i}`,
+        name: `Member ${i}`,
+        description: 'test',
+        icon: '⚔️',
+        className: 'Warrior',
+        level: 1,
+        hp: 50,
+        maxHp: 50,
+        stats: { strength: 5, intelligence: 5, luck: 5, charisma: 5 },
+        equipment: { weapon: null, armor: null, accessory: null },
+        dailyCost: 0,
+        recruitCost: 0,
+        rarity: 'common' as const,
+        relationship: 0,
+        role: 'combatant' as const,
+      })),
+    }
+    const effects = {
+      grantCompanion: {
+        name: 'Extra Companion',
+        dailyCost: 0,
+        rarity: 'common' as const,
+      },
+    }
+    const updated = applyEffects(fullPartyChar as any, effects)
+    expect((updated.party ?? []).length).toBe(3) // Still 3, not 4
+  })
 })

--- a/src/app/tap-tap-adventure/hooks/useGameStore.ts
+++ b/src/app/tap-tap-adventure/hooks/useGameStore.ts
@@ -1250,6 +1250,17 @@ export const useGameStore = create<GameStore>()(
             const char = state.gameState.characters[charIndex]
             if (!char.party) char.party = []
             char.party.push(member)
+
+            // Mark NPC as recruited to prevent duplicate recruitment
+            if (member.id.startsWith('npc-')) {
+              const npcId = member.id.replace('npc-', '')
+              if (!char.npcEncounters) char.npcEncounters = {}
+              if (char.npcEncounters[npcId]) {
+                char.npcEncounters[npcId].recruited = true
+              } else {
+                char.npcEncounters[npcId] = { timesSpoken: 0, disposition: 0, recruited: true }
+              }
+            }
           })
         )
         return true
@@ -1284,6 +1295,14 @@ export const useGameStore = create<GameStore>()(
             if (charIndex < 0) return
             const char = state.gameState.characters[charIndex]
             char.party = (char.party ?? []).filter(m => m.id !== memberId)
+
+            // Clear recruited flag so NPC can be re-recruited later
+            if (memberId.startsWith('npc-')) {
+              const npcId = memberId.replace('npc-', '')
+              if (char.npcEncounters?.[npcId]) {
+                char.npcEncounters[npcId].recruited = false
+              }
+            }
           })
         )
       },

--- a/src/app/tap-tap-adventure/lib/eventResolution.ts
+++ b/src/app/tap-tap-adventure/lib/eventResolution.ts
@@ -3,6 +3,8 @@ import { FantasyDecisionOption } from '@/app/tap-tap-adventure/models/story'
 import { getCampBonuses } from '@/app/tap-tap-adventure/config/baseBuildings'
 import { getFactionForRegion, FACTIONS } from '@/app/tap-tap-adventure/config/factions'
 import { clampGold } from '@/app/tap-tap-adventure/lib/contextBuilder'
+import { createPartyMember } from '@/app/tap-tap-adventure/lib/partyRecruitment'
+import { MAX_PARTY_SIZE } from '@/app/tap-tap-adventure/models/partyMember'
 
 export function applyEffects(
   character: FantasyCharacter,
@@ -17,6 +19,16 @@ export function applyEffects(
     hpChange?: number
     mpChange?: number
     bountyChange?: number
+    grantCompanion?: {
+      name: string
+      description?: string
+      icon?: string
+      level?: number
+      dailyCost?: number
+      rarity?: 'common' | 'uncommon' | 'rare' | 'legendary'
+      isTemporary?: boolean
+      turnsRemaining?: number
+    }
   }
 ): FantasyCharacter {
   if (!effects) return character
@@ -110,6 +122,28 @@ export function applyEffects(
       updatedCharacter = {
         ...updatedCharacter,
         landmarkState: { ...lmState, landmarks: updatedLandmarks },
+      }
+    }
+  }
+
+  // Grant companion
+  if (effects.grantCompanion) {
+    const party = updatedCharacter.party ?? []
+    if (party.length < MAX_PARTY_SIZE) {
+      const comp = effects.grantCompanion
+      const member = createPartyMember({
+        id: `event-companion-${Date.now()}-${Math.floor(Math.random() * 10000)}`,
+        name: comp.name,
+        description: comp.description,
+        icon: comp.icon ?? '⚔️',
+        level: comp.level ?? updatedCharacter.level,
+        dailyCost: comp.dailyCost ?? 0,
+        rarity: comp.rarity ?? 'common',
+        role: 'combatant',
+      })
+      updatedCharacter = {
+        ...updatedCharacter,
+        party: [...party, member],
       }
     }
   }

--- a/src/app/tap-tap-adventure/lib/llmEventGenerator.ts
+++ b/src/app/tap-tap-adventure/lib/llmEventGenerator.ts
@@ -43,6 +43,16 @@ export interface LLMEventOption {
     revealLandmark?: boolean
     hpChange?: number
     mpChange?: number
+    grantCompanion?: {
+      name: string
+      description?: string
+      icon?: string
+      level?: number
+      dailyCost?: number
+      rarity?: 'common' | 'uncommon' | 'rare' | 'legendary'
+      isTemporary?: boolean
+      turnsRemaining?: number
+    }
   }
   failureDescription: string
   failureEffects: {
@@ -55,6 +65,16 @@ export interface LLMEventOption {
     revealLandmark?: boolean
     hpChange?: number
     mpChange?: number
+    grantCompanion?: {
+      name: string
+      description?: string
+      icon?: string
+      level?: number
+      dailyCost?: number
+      rarity?: 'common' | 'uncommon' | 'rare' | 'legendary'
+      isTemporary?: boolean
+      turnsRemaining?: number
+    }
   }
   triggersCombat?: boolean
 }
@@ -2640,6 +2660,52 @@ function getDefaultEvents(regionId?: string): LLMGeneratedEvent[] {
         { id: `trade-${s}`, text: 'Browse their wares while they work', successProbability: 1.0,
           successDescription: 'Nothing catches your eye, but you exchange pleasantries.',
           successEffects: { reputation: 1 },
+          failureDescription: '', failureEffects: {} },
+      ],
+    },
+    // Companion-granting events — uncommon/rare positive events
+    {
+      id: `fb-traveling-healer-companion-${s}`,
+      description: 'A wandering healer steps out from a side path, her herb satchel bulging. She looks you over with practiced eyes. "You seem like someone worth following for a while. I could use a traveling companion, and you could use someone to patch you up."',
+      options: [
+        { id: `accept-healer-companion-${s}`, text: 'Accept her offer to join your party', successProbability: 0.85,
+          successDescription: 'She clasps your hand warmly. "Then let\'s travel together a while." A skilled healer joins your party.',
+          successEffects: { reputation: 2, grantCompanion: { name: 'Traveling Healer', description: 'A wandering healer who offers to accompany you for a while.', icon: '🧑‍⚕️', dailyCost: 0, rarity: 'common' } },
+          failureDescription: 'She nods respectfully. "Another time, then. Safe travels."',
+          failureEffects: {} },
+        { id: `decline-healer-companion-${s}`, text: 'Decline politely', successProbability: 1.0,
+          successDescription: 'She smiles. "No worries. May the road treat you kindly." She heads off down the path.',
+          successEffects: { reputation: 1 },
+          failureDescription: '', failureEffects: {} },
+      ],
+    },
+    {
+      id: `fb-mercenary-companion-${s}`,
+      description: 'A battle-worn soldier sits on a roadside rock, contract papers at his feet. He looks up as you pass. "Between jobs. My last employer\'s outfit collapsed. I\'m good in a fight — willing to tag along for a modest wage if you\'re heading somewhere interesting."',
+      options: [
+        { id: `hire-mercenary-${s}`, text: 'Take on the idle mercenary (1 gold/day)', successProbability: 0.8,
+          successDescription: 'He scoops up his gear with practiced efficiency. "Pleasure doing business." An experienced fighter joins your party.',
+          successEffects: { reputation: 1, grantCompanion: { name: 'Mercenary Without a Contract', description: 'An idle soldier looking for work. Reliable in a fight.', icon: '⚔️', dailyCost: 1, rarity: 'uncommon' } },
+          failureDescription: 'He looks you over again and shakes his head. "Actually, I think I\'ll wait for a better offer."',
+          failureEffects: {} },
+        { id: `pass-mercenary-${s}`, text: 'Keep walking', successProbability: 1.0,
+          successDescription: 'You continue on your way. The mercenary tips a salute and goes back to waiting.',
+          successEffects: {},
+          failureDescription: '', failureEffects: {} },
+      ],
+    },
+    {
+      id: `fb-rescued-prisoner-companion-${s}`,
+      description: 'You discover a bedraggled figure chained to a post at the side of a long-abandoned road — left behind, it seems, by raiders who took everything else. They look up at you with hollow but determined eyes. "Free me. Whatever you need after that, I will do."',
+      options: [
+        { id: `free-prisoner-${s}`, text: 'Break their chains and free them', successProbability: 0.9,
+          successDescription: 'The chains snap. They straighten up and grip your arm fiercely. "My life is yours until this debt is repaid." A grateful companion pledges loyalty to your cause.',
+          successEffects: { reputation: 5, grantCompanion: { name: 'Rescued Prisoner', description: 'Someone you freed who now pledges their loyalty to your cause.', icon: '🧑', dailyCost: 0, rarity: 'rare' } },
+          failureDescription: 'The chains resist your tools — you cannot free them today, but you leave what supplies you can spare.',
+          failureEffects: { reputation: 2 } },
+        { id: `leave-prisoner-${s}`, text: 'Pass by — you cannot get involved', successProbability: 1.0,
+          successDescription: 'You walk on with a heavy heart. Their eyes follow you until you round the bend.',
+          successEffects: { reputation: -2 },
           failureDescription: '', failureEffects: {} },
       ],
     },


### PR DESCRIPTION
## Summary

Partial implementation of issue #383, covering three areas:

- **`grantCompanion` event effect**: Added a new `grantCompanion` effect to `applyEffects` in `eventResolution.ts`. When an event option includes `grantCompanion`, a new party member is created via `createPartyMember` and added to the character's party (if there is room, i.e. below `MAX_PARTY_SIZE`).
- **NPC recruited flag tracking**: Fixed `addPartyMember` in `useGameStore.ts` to set `npcEncounters[npcId].recruited = true` when a member whose ID starts with `npc-` is added, preventing duplicate recruitment. Fixed `removePartyMember` to clear the `recruited` flag when an NPC is dismissed so they can be re-recruited later.
- **3 companion-granting fallback events**: Added to the `pool` array in `llmEventGenerator.ts` — a Traveling Healer (common, 0 daily cost), a Mercenary Without a Contract (uncommon, 1 daily cost), and a Rescued Prisoner (rare, 0 daily cost).

## Test plan

- [x] `npx vitest run src/app/tap-tap-adventure/__tests__/eventResolution.test.ts` — 5 tests pass (includes 2 new tests for `grantCompanion`)
- [x] `npm run build` — compiles cleanly, no TypeScript errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)