### PR TITLE
feat: quest companion rewards (#383)

### DIFF
--- a/src/app/tap-tap-adventure/components/QuestCelebration.tsx
+++ b/src/app/tap-tap-adventure/components/QuestCelebration.tsx
@@ -55,6 +55,9 @@ export function QuestCelebration({ quest, onClaim }: QuestCelebrationProps) {
             {quest.rewards.items?.map(item => (
               <p key={item.id} className="text-sm text-purple-400">+ {item.name}</p>
             ))}
+            {quest.rewards.companion && (
+              <p className="text-sm text-green-400">+ {quest.rewards.companion.icon ?? '⚔️'} {quest.rewards.companion.name} joins your party!</p>
+            )}
           </div>
 
           <Button

--- a/src/app/tap-tap-adventure/components/QuestPanel.tsx
+++ b/src/app/tap-tap-adventure/components/QuestPanel.tsx
@@ -5,8 +5,10 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import { Button } from '@/app/tap-tap-adventure/components/ui/button'
 import { useGameStore } from '@/app/tap-tap-adventure/hooks/useGameStore'
 import { calculateDay, STEPS_PER_DAY } from '@/app/tap-tap-adventure/lib/leveling'
+import { createPartyMember } from '@/app/tap-tap-adventure/lib/partyRecruitment'
 import { soundEngine } from '@/app/tap-tap-adventure/lib/soundEngine'
 import { TimedQuest } from '@/app/tap-tap-adventure/models/quest'
+import { MAX_PARTY_SIZE } from '@/app/tap-tap-adventure/models/partyMember'
 import { QuestCelebration } from './QuestCelebration'
 
 function getUrgencyStyle(daysLeft: number): { badge: string; bar: string; border: string } {
@@ -28,7 +30,7 @@ function getUrgencyStyle(daysLeft: number): { badge: string; bar: string; border
 }
 
 function RewardPreview({ quest }: { quest: TimedQuest }) {
-  const hasRewards = quest.rewards.gold || quest.rewards.reputation || (quest.rewards.items && quest.rewards.items.length > 0)
+  const hasRewards = quest.rewards.gold || quest.rewards.reputation || (quest.rewards.items && quest.rewards.items.length > 0) || quest.rewards.companion
   if (!hasRewards) return null
 
   return (
@@ -44,6 +46,9 @@ function RewardPreview({ quest }: { quest: TimedQuest }) {
         {quest.rewards.items?.map(item => (
           <span key={item.id} className="text-[10px] text-purple-400">+ {item.name}</span>
         ))}
+        {quest.rewards.companion && (
+          <span className="text-[10px] text-green-400">+ {quest.rewards.companion.name} (companion)</span>
+        )}
       </div>
     </div>
   )
@@ -84,7 +89,21 @@ export function QuestPanel() {
     const updatedChars = gs.characters.map(c => {
       if (c.id !== character.id) return c
       const updatedInventory = [...c.inventory, ...(rewards.items ?? [])]
-      return { ...c, gold: updatedGold, reputation: updatedRep, inventory: updatedInventory }
+      let updatedParty = [...(c.party ?? [])]
+      if (rewards.companion && updatedParty.length < MAX_PARTY_SIZE) {
+        const member = createPartyMember({
+          id: `quest-companion-${Date.now()}-${Math.floor(Math.random() * 10000)}`,
+          name: rewards.companion.name,
+          description: rewards.companion.description,
+          icon: rewards.companion.icon ?? '⚔️',
+          level: character.level,
+          dailyCost: 0,  // Quest companions are loyal — no upkeep
+          rarity: rewards.companion.rarity ?? 'common',
+          role: 'combatant',
+        })
+        updatedParty = [...updatedParty, member]
+      }
+      return { ...c, gold: updatedGold, reputation: updatedRep, inventory: updatedInventory, party: updatedParty }
     })
     setGameState({ ...gs, characters: updatedChars, activeQuest: null })
     setShowCelebration(false)
@@ -196,6 +215,7 @@ export function QuestPanel() {
           {quest.rewards.items?.map(item => (
             <div key={item.id}>+ {item.name}</div>
           ))}
+          {quest.rewards.companion && <div>+ {quest.rewards.companion.name} (companion)</div>}
         </div>
         <Button
           className="w-full bg-emerald-700 hover:bg-emerald-600 text-white text-xs py-1.5 rounded"

--- a/src/app/tap-tap-adventure/lib/questGenerator.ts
+++ b/src/app/tap-tap-adventure/lib/questGenerator.ts
@@ -4,6 +4,14 @@ import { TimedQuest } from '@/app/tap-tap-adventure/models/quest'
 import { calculateDay } from './leveling'
 import { inferItemTypeAndEffects } from './itemPostProcessor'
 
+const QUEST_COMPANION_NAMES = [
+  { name: 'Rescued Scout', description: 'A grateful scout who pledges loyalty after being saved.', icon: '🏹' },
+  { name: 'Freed Prisoner', description: 'A former captive, eager to repay their debt.', icon: '⛓️' },
+  { name: 'Grateful Pilgrim', description: 'A traveling pilgrim who offers their sword in thanks.', icon: '🙏' },
+  { name: 'Lost Squire', description: 'A young squire separated from their knight, seeking protection.', icon: '🛡️' },
+  { name: 'Wandering Monk', description: 'A monk whose monastery was destroyed, looking for purpose.', icon: '🧘' },
+]
+
 type QuestType = 'reach_distance' | 'collect_gold' | 'win_combat' | 'gain_reputation' | 'explore_landmarks' | 'survive_combats' | 'reach_level' | 'hoard_items' | 'visit_region'
 
 interface QuestTemplate {
@@ -100,6 +108,16 @@ export function generateTimedQuest(character: FantasyCharacter): TimedQuest {
   const goldReward = 15 + character.level * 10 + Math.floor(Math.random() * 10)
   const repReward = 3 + Math.floor(Math.random() * 5)
 
+  // ~10% chance of companion reward for level 3+ characters on harder quests
+  let companionReward: { name: string; description?: string; icon?: string; rarity?: 'common' | 'uncommon' | 'rare' | 'legendary' } | undefined
+  if (character.level >= 3 && Math.random() < 0.1) {
+    const companion = QUEST_COMPANION_NAMES[Math.floor(Math.random() * QUEST_COMPANION_NAMES.length)]
+    companionReward = {
+      ...companion,
+      rarity: character.level >= 8 ? 'uncommon' : 'common',
+    }
+  }
+
   return {
     id: `quest-${Date.now()}-${Math.floor(Math.random() * 10000)}`,
     title: template.getTitle(target),
@@ -121,6 +139,7 @@ export function generateTimedQuest(character: FantasyCharacter): TimedQuest {
           quantity: 1,
         }),
       ],
+      companion: companionReward,
     },
   }
 }

--- a/src/app/tap-tap-adventure/models/quest.ts
+++ b/src/app/tap-tap-adventure/models/quest.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod'
 
 import { ItemSchema } from './item'
+import { PartyMemberSchema } from './partyMember'
 
 export const TimedQuestSchema = z.object({
   id: z.string(),
@@ -21,6 +22,12 @@ export const TimedQuestSchema = z.object({
     gold: z.number().optional(),
     reputation: z.number().optional(),
     items: z.array(ItemSchema).optional(),
+    companion: z.object({
+      name: z.string(),
+      description: z.string().optional(),
+      icon: z.string().optional(),
+      rarity: z.enum(['common', 'uncommon', 'rare', 'legendary']).optional(),
+    }).optional(),
   }),
 })
 export type TimedQuest = z.infer<typeof TimedQuestSchema>


### PR DESCRIPTION
## Summary

- Adds optional `companion` field to `TimedQuestSchema` rewards (name, description, icon, rarity stored inline — not a full `PartyMember`)
- ~10% of quests generated for level 3+ characters now include a companion reward, chosen from 5 named archetypes (Rescued Scout, Freed Prisoner, etc.); level 8+ companions get `uncommon` rarity
- Quest companions have `dailyCost: 0` (loyal followers, no upkeep) and are added to the party via `createPartyMember` when rewards are claimed, respecting `MAX_PARTY_SIZE`
- Companion reward shown in: quest reward preview panel, completed-quest fallback display, and `QuestCelebration` modal

## Test plan

- [ ] Build passes with no TypeScript errors (`npm run build`)
- [ ] Active quest reward preview shows companion name when present
- [ ] Completing a quest with companion reward shows companion in celebration modal
- [ ] Claiming rewards adds companion to party (verify party size cap is respected)
- [ ] Quest completion without companion reward is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)