### PR TITLE
fix: starting weapon duplicated in inventory

### DIFF
--- a/src/app/tap-tap-adventure/hooks/useCharacterCreation.ts
+++ b/src/app/tap-tap-adventure/hooks/useCharacterCreation.ts
@@ -245,7 +245,7 @@ export function useCharacterCreation() {
         effects: classData.startingWeapon.effects,
         rarity: 'common',
       }
-      startingInventory.push(weaponItem)
+      // Equip the weapon — don't add to inventory (equipped items are separate)
       startingEquipment = { weapon: weaponItem, armor: null, accessory: null }
     }
 


### PR DESCRIPTION
## Bug
New characters had their starting weapon appearing twice — in the equipment slot AND in the inventory list.

## Cause
\`useCharacterCreation.ts\` line 248 pushed the weapon into \`startingInventory\` AND line 249 equipped it. Equipped items are stored separately from inventory, so the weapon existed in both places.

## Fix
Removed the \`startingInventory.push(weaponItem)\` line. The weapon is only placed in the equipment slot.

## Test plan
- [ ] Create new character — weapon appears in equipment slot only, not in inventory

🤖 Generated with [Claude Code](https://claude.com/claude-code)