### PR TITLE
fix: landmark multi-encounter chain + duplicate starting weapon

### DIFF
--- a/src/app/tap-tap-adventure/components/GameUI.tsx
+++ b/src/app/tap-tap-adventure/components/GameUI.tsx
@@ -923,11 +923,10 @@ export default function GameUI({ onOpenStatus }: GameUIProps) {
                       eventResult={eventResult}
                       onDismissResult={() => {
                         setEventResult(null)
-                        // Only clear the decision point if it hasn't already been cleared by the server response
-                        const currentDP = useGameStore.getState().gameState.decisionPoint
-                        if (currentDP && currentDP.id === gameState.decisionPoint?.id) {
-                          setDecisionPoint(null)
-                        }
+                        // Don't clear the decision point here — if the server returned
+                        // a continue-exploring/leave-landmark prompt, it should render
+                        // now that eventResult is cleared. The decision point will be
+                        // cleared naturally when the player picks an option.
                       }}
                       showNPCPanel={showNPCPanel}
                       npcPanelContent={showNPCPanel && socialEncounter && character ? (

--- a/src/app/tap-tap-adventure/hooks/useCharacterCreation.ts
+++ b/src/app/tap-tap-adventure/hooks/useCharacterCreation.ts
@@ -245,7 +245,7 @@ export function useCharacterCreation() {
         effects: classData.startingWeapon.effects,
         rarity: 'common',
       }
-      startingInventory.push(weaponItem)
+      // Equip the weapon — don't add to inventory (equipped items are separate)
       startingEquipment = { weapon: weaponItem, armor: null, accessory: null }
     }
 


### PR DESCRIPTION
## Fixes

### 1. Landmark exploration now chains multiple encounters
Only one encounter per landmark because onDismissResult cleared the continue/leave prompt before it was shown. Fix: onDismissResult now only clears eventResult — the decision point renders naturally.

### 2. Starting weapon no longer duplicated in inventory
Removed startingInventory.push — equipped items are stored separately.

## Test plan
- [ ] Explore landmark → resolve → "Keep exploring / Leave" prompt appears
- [ ] Keep exploring → more encounters → exhausted → auto-leave
- [ ] New character → weapon in equipment only, not inventory

Closes #474