### PR TITLE
feat: companion gift crafting (#471)

### DIFF
--- a/src/app/tap-tap-adventure/components/MercenaryPanel.tsx
+++ b/src/app/tap-tap-adventure/components/MercenaryPanel.tsx
@@ -65,6 +65,7 @@ export function MercenaryPanel({ character }: MercenaryPanelProps) {
   const [isExpanded, setIsExpanded] = useState(false)
   const [dismissConfirm, setDismissConfirm] = useState<string | null>(null)
   const [talkingTo, setTalkingTo] = useState<string | null>(null)
+  const [giftingTo, setGiftingTo] = useState<string | null>(null)
 
   // Stable tavern selection per character level — prevents re-randomization on each render
   const tavernMercs = useMemo(
@@ -249,36 +250,88 @@ export function MercenaryPanel({ character }: MercenaryPanelProps) {
           <h4 className="text-xs font-semibold text-slate-400 uppercase mb-2">Companions ({partyMembers.length}/{MAX_PARTY_SIZE})</h4>
           <div className="space-y-1.5">
             {partyMembers.map(member => (
-              <div key={member.id} className="bg-[#252638] border border-[#3a3c56] rounded p-2 flex items-center justify-between">
-                <div className="flex items-center gap-1.5">
-                  <span className="text-lg">{member.icon}</span>
-                  <div>
-                    <div className="text-xs font-semibold text-slate-200">{member.customName ?? member.name}</div>
-                    <div className="text-[10px] text-slate-400">{member.className}</div>
-                    <div className="text-[10px] text-slate-500">Lv {member.level} · {member.dailyCost}g/day</div>
+              <div key={member.id}>
+                <div className="bg-[#252638] border border-[#3a3c56] rounded p-2 flex items-center justify-between">
+                  <div className="flex items-center gap-1.5">
+                    <span className="text-lg">{member.icon}</span>
+                    <div>
+                      <div className="text-xs font-semibold text-slate-200">{member.customName ?? member.name}</div>
+                      <div className="text-[10px] text-slate-400">{member.className}</div>
+                      <div className="text-[10px] text-slate-500">Lv {member.level} · {member.dailyCost}g/day</div>
+                    </div>
+                  </div>
+                  <div className="flex items-center gap-1.5">
+                    {dismissConfirm === `party-${member.id}` ? (
+                      <>
+                        <button className="text-[10px] px-1.5 py-0.5 bg-red-900/50 text-red-400 rounded hover:bg-red-800/50"
+                          onClick={() => { removePartyMember(member.id); setDismissConfirm(null) }}>Yes</button>
+                        <button className="text-[10px] px-1.5 py-0.5 bg-slate-700/50 text-slate-300 rounded hover:bg-slate-600/50"
+                          onClick={() => setDismissConfirm(null)}>No</button>
+                      </>
+                    ) : (
+                      <>
+                        <button
+                          className="text-[10px] px-1.5 py-0.5 bg-indigo-900/30 text-indigo-300 rounded hover:bg-indigo-800/40 transition-colors"
+                          onClick={() => setTalkingTo(member.id)}
+                        >
+                          Talk
+                        </button>
+                        <button
+                          className="text-[10px] px-1.5 py-0.5 bg-amber-900/30 text-amber-300 rounded hover:bg-amber-800/40 transition-colors"
+                          onClick={() => setGiftingTo(giftingTo === member.id ? null : member.id)}
+                        >
+                          Gift
+                        </button>
+                        <button className="text-[10px] px-1.5 py-0.5 bg-red-900/30 text-red-400 rounded hover:bg-red-800/40 transition-colors"
+                          onClick={() => setDismissConfirm(`party-${member.id}`)}>Dismiss</button>
+                      </>
+                    )}
                   </div>
                 </div>
-                <div className="flex items-center gap-1.5">
-                  {dismissConfirm === `party-${member.id}` ? (
-                    <>
-                      <button className="text-[10px] px-1.5 py-0.5 bg-red-900/50 text-red-400 rounded hover:bg-red-800/50"
-                        onClick={() => { removePartyMember(member.id); setDismissConfirm(null) }}>Yes</button>
-                      <button className="text-[10px] px-1.5 py-0.5 bg-slate-700/50 text-slate-300 rounded hover:bg-slate-600/50"
-                        onClick={() => setDismissConfirm(null)}>No</button>
-                    </>
-                  ) : (
-                    <>
-                      <button
-                        className="text-[10px] px-1.5 py-0.5 bg-indigo-900/30 text-indigo-300 rounded hover:bg-indigo-800/40 transition-colors"
-                        onClick={() => setTalkingTo(member.id)}
-                      >
-                        Talk
-                      </button>
-                      <button className="text-[10px] px-1.5 py-0.5 bg-red-900/30 text-red-400 rounded hover:bg-red-800/40 transition-colors"
-                        onClick={() => setDismissConfirm(`party-${member.id}`)}>Dismiss</button>
-                    </>
-                  )}
-                </div>
+                {giftingTo === member.id && (() => {
+                  const giftItems = character.inventory.filter(
+                    i => i.effects?.companionGift && i.quantity > 0 && i.status !== 'deleted'
+                  )
+                  if (giftItems.length === 0) {
+                    return (
+                      <div className="bg-[#161723] border border-amber-700/20 rounded p-2 mt-1 text-[10px] text-slate-400">
+                        No gift items in inventory. Craft a Friendship Token, Lucky Pendant, or Bond of Loyalty at a crafting station.
+                      </div>
+                    )
+                  }
+                  return (
+                    <div className="bg-[#161723] border border-amber-700/20 rounded p-2 mt-1 space-y-1">
+                      <p className="text-[10px] text-amber-300 font-semibold">Give a gift to {member.customName ?? member.name}:</p>
+                      {giftItems.map(item => (
+                        <button
+                          key={item.id}
+                          className="w-full flex justify-between items-center text-[10px] px-2 py-1 bg-amber-900/20 rounded hover:bg-amber-800/30 transition-colors"
+                          onClick={() => {
+                            const delta = item.effects?.companionGift ?? 0
+                            if (delta > 0) {
+                              updatePartyMemberRelationship(member.id, delta)
+                              const { gameState: gs, setGameState } = useGameStore.getState()
+                              const updatedChars = gs.characters.map(c => {
+                                if (c.id !== gs.selectedCharacterId) return c
+                                const updatedInv = c.inventory.map(i => {
+                                  if (i.id !== item.id) return i
+                                  const newQty = i.quantity - 1
+                                  return newQty <= 0 ? { ...i, quantity: 0, status: 'deleted' as const } : { ...i, quantity: newQty }
+                                }).filter(i => i.quantity > 0)
+                                return { ...c, inventory: updatedInv }
+                              })
+                              setGameState({ ...gs, characters: updatedChars })
+                              setGiftingTo(null)
+                            }
+                          }}
+                        >
+                          <span className="text-amber-200">{item.name} <span className="text-slate-500">×{item.quantity}</span></span>
+                          <span className="text-green-400">+{item.effects?.companionGift} rel</span>
+                        </button>
+                      ))}
+                    </div>
+                  )
+                })()}
               </div>
             ))}
           </div>

--- a/src/app/tap-tap-adventure/config/craftingRecipes.ts
+++ b/src/app/tap-tap-adventure/config/craftingRecipes.ts
@@ -346,4 +346,53 @@ export const CRAFTING_RECIPES: CraftingRecipe[] = [
       effects: { heal: 40, manaRestore: 20, shield: 10 },
     },
   },
+  // --- Companion Gifts ---
+  {
+    id: 'friendship_token',
+    name: 'Friendship Token',
+    description: 'A simple handmade charm that shows you care about your companions.',
+    ingredients: [
+      { type: 'consumable', quantity: 1 },
+      { type: 'misc', quantity: 1 },
+    ],
+    goldCost: 15,
+    result: {
+      name: 'Friendship Token',
+      description: 'A handcrafted charm. Gift it to a companion to strengthen your bond. (+5 relationship)',
+      type: 'consumable',
+      effects: { companionGift: 5 },
+    },
+  },
+  {
+    id: 'lucky_pendant',
+    name: 'Lucky Pendant',
+    description: 'Combine valuable materials into a pendant that any companion would treasure.',
+    ingredients: [
+      { type: 'misc', quantity: 2 },
+      { type: 'consumable', quantity: 1 },
+    ],
+    goldCost: 40,
+    result: {
+      name: 'Lucky Pendant',
+      description: 'A gleaming pendant imbued with good fortune. Gift it to greatly improve a companion\'s loyalty. (+15 relationship)',
+      type: 'consumable',
+      effects: { companionGift: 15 },
+    },
+  },
+  {
+    id: 'bond_of_loyalty',
+    name: 'Bond of Loyalty',
+    description: 'Forge a powerful token of loyalty from rare equipment and materials.',
+    ingredients: [
+      { type: 'equipment', quantity: 1 },
+      { type: 'misc', quantity: 2 },
+    ],
+    goldCost: 80,
+    result: {
+      name: 'Bond of Loyalty',
+      description: 'A masterwork token of devotion. Gift it to forge an unbreakable bond with a companion. (+25 relationship)',
+      type: 'consumable',
+      effects: { companionGift: 25 },
+    },
+  },
 ]

--- a/src/app/tap-tap-adventure/lib/itemEffects.ts
+++ b/src/app/tap-tap-adventure/lib/itemEffects.ts
@@ -91,6 +91,14 @@ export function useItem(character: FantasyCharacter, item: Item): UseItemResult 
     }
   }
 
+  if (effects.companionGift) {
+    return {
+      character,
+      consumed: false,
+      message: `${item.name} is a companion gift. Use it from the Party panel to give it to a party member.`,
+    }
+  }
+
   // Update inventory: decrement quantity or remove
   const updatedInventory = character.inventory
     .map(i => {

--- a/src/app/tap-tap-adventure/models/item.ts
+++ b/src/app/tap-tap-adventure/models/item.ts
@@ -23,6 +23,8 @@ export const ItemEffectsSchema = z.object({
   damageBoost: z.number().optional(),
   /** Reveals a hidden landmark in the current region when used */
   revealLandmark: z.boolean().optional(),
+  /** Boosts a party member's relationship when gifted */
+  companionGift: z.number().optional(),
 })
 export type ItemEffects = z.infer<typeof ItemEffectsSchema>
 


### PR DESCRIPTION
## Summary
- Adds `companionGift` effect field to `ItemEffectsSchema` in `models/item.ts`
- Adds 3 gift crafting recipes (Friendship Token +5, Lucky Pendant +15, Bond of Loyalty +25 relationship) to `config/craftingRecipes.ts`
- Adds a "Gift" button in `MercenaryPanel.tsx` for each party companion, revealing a gift selection panel that consumes the item and boosts the companion's relationship score
- Adds early-return guard in `lib/itemEffects.ts` to prevent gift items from being accidentally consumed via the inventory "Use" button — redirects player to use the Party panel instead

## Test plan
- [ ] Build passes with no TypeScript errors (`npm run build`)
- [ ] Craft a Friendship Token, Lucky Pendant, and Bond of Loyalty at a crafting station
- [ ] Open the Party panel with at least one companion recruited
- [ ] Click "Gift" next to a companion — confirm the gift selection panel appears
- [ ] Select a gift item — confirm companion relationship increases by the correct amount and the item is removed from inventory
- [ ] Clicking "Gift" again while panel is open toggles it closed
- [ ] Attempting to "Use" a gift item from the Inventory panel shows the redirect message rather than consuming it

🤖 Generated with [Claude Code](https://claude.com/claude-code)