### PR TITLE
fix: story log now shows same rewards as encounter modal (#478)

### DIFF
--- a/src/app/tap-tap-adventure/hooks/useResolveDecisionMutation.ts
+++ b/src/app/tap-tap-adventure/hooks/useResolveDecisionMutation.ts
@@ -315,6 +315,7 @@ export function useResolveDecisionMutation() {
           ? `You chose to fight: ${data.selectedOptionText}`
           : (data.outcomeDescription ?? ''),
         resourceDelta: data.resourceDelta,
+        rewardItems: rewardItems.length > 0 ? rewardItems : undefined,
       }
 
       // Append mount damage/death messages to outcome description


### PR DESCRIPTION
## Summary
Fixes #478

The story event created in `useResolveDecisionMutation` was missing the `rewardItems` field. This caused the StoryFeed to show different (incomplete) results compared to the EventDialog modal after resolving an encounter.

## Root cause
Two separate data paths diverged:
- **EventDialog** received `rewardItems` via the `onResult` callback
- **StoryFeed** looked for `storyEvent.rewardItems` but it was never set in the story event object

## Fix
One-line addition: include `rewardItems` in the `newStoryEvent` object so both the modal and the story log display identical reward information.

## Test plan
- [ ] Resolve an encounter that gives items → verify the story log shows the same items as the modal
- [ ] Resolve an encounter without items → verify no empty item section appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)