### PR TITLE
fix: town arrival opens shop instead of showing Enter Town menu

### DIFF
--- a/src/app/api/v1/tap-tap-adventure/move-forward/services/moveForwardService.ts
+++ b/src/app/api/v1/tap-tap-adventure/move-forward/services/moveForwardService.ts
@@ -336,7 +336,8 @@ export async function moveForwardService(
               ],
           resolved: false,
         },
-        shopEvent: activeLandmark.hasShop ? true : undefined,
+        // Don't auto-open shop on town arrival — player enters town first, then visits shop from the hub menu
+        shopEvent: activeLandmark.type !== 'town' && activeLandmark.hasShop ? true : undefined,
         landmarkArrival: {
           name: activeLandmark.name,
           type: activeLandmark.type,


### PR DESCRIPTION
## Bug
Arriving at a town immediately opened the shop, skipping the Enter Town decision point entirely.

## Cause
The arrival response set \`shopEvent: true\` for any landmark with \`hasShop: true\` — including towns. The client saw \`shopEvent\`, cleared the decision point (\`setDecisionPoint(null)\`), and opened ShopUI. The player never saw "Enter Town".

## Fix
Don't set \`shopEvent\` on arrival for \`type: 'town'\` landmarks. The shop is accessed from the town hub via "Visit the Shop".

## Test plan
- [ ] Walk to town → see "Enter Town" / bypass options
- [ ] Enter town → see hub menu (Shop, Inn, Stable, etc.)
- [ ] Click "Visit the Shop" → shop opens
- [ ] Non-town landmarks with shops still auto-open shop on arrival