### PR TITLE
Fix encounter results mismatch between EventDialog and story log

### DIFF
--- a/src/app/tap-tap-adventure/hooks/useResolveDecisionMutation.ts
+++ b/src/app/tap-tap-adventure/hooks/useResolveDecisionMutation.ts
@@ -290,9 +290,7 @@ export function useResolveDecisionMutation() {
         updateSelectedCharacter(data.updatedCharacter)
       }
 
-      const rewardItems = data.rewardItems ?? []
-
-      for (const reward of rewardItems) {
+      const rewardItems = (data.rewardItems ?? []).map(reward => {
         const item = inferItemTypeAndEffects({
           id: reward.id,
           name: reward.name,
@@ -300,7 +298,8 @@ export function useResolveDecisionMutation() {
           quantity: 1,
         })
         addItem(item)
-      }
+        return item
+      })
 
       const newStoryEvent = {
         decisionPoint,
@@ -315,7 +314,7 @@ export function useResolveDecisionMutation() {
           ? `You chose to fight: ${data.selectedOptionText}`
           : (data.outcomeDescription ?? ''),
         resourceDelta: data.resourceDelta,
-        rewardItems: rewardItems.map(item => ({ id: item.id, name: item.name, description: item.description })),
+        rewardItems: rewardItems,
       }
 
       // Append mount damage/death messages to outcome description

--- a/src/app/tap-tap-adventure/hooks/useResolveDecisionMutation.ts
+++ b/src/app/tap-tap-adventure/hooks/useResolveDecisionMutation.ts
@@ -315,6 +315,7 @@ export function useResolveDecisionMutation() {
           ? `You chose to fight: ${data.selectedOptionText}`
           : (data.outcomeDescription ?? ''),
         resourceDelta: data.resourceDelta,
+        rewardItems: rewardItems.map(item => ({ id: item.id, name: item.name, description: item.description })),
       }
 
       // Append mount damage/death messages to outcome description
@@ -406,7 +407,7 @@ export function useResolveDecisionMutation() {
       }
 
       onResult?.({
-        outcomeDescription: newStoryEvent.outcomeDescription,
+        outcomeDescription: data.outcomeDescription ?? '',
         resourceDelta: data.resourceDelta,
         rewardItems: rewardItems,
         mountDamage: data.mountDamage,


### PR DESCRIPTION
## Summary
Fixes #478 — encounter results shown in the EventDialog modal now match what appears in the story log.

- **Add rewardItems to story event**: The `newStoryEvent` object was missing the `rewardItems` field, so items earned from encounters appeared in the EventDialog but were completely absent from the StoryFeed. Now both paths show the same items.
- **Pass clean outcomeDescription to EventDialog**: The `onResult` callback was passing `newStoryEvent.outcomeDescription` which had mount damage/death text appended to it. Since EventDialog already renders mount info as separate badge elements (`mountDamage`, `mountDied` fields), the mount text was effectively duplicated. Now `onResult` receives the original server description, and mount info only appears via the dedicated badge UI.

## Test plan
- [ ] Trigger an encounter that rewards items → verify items appear in both the EventDialog modal and the story feed
- [ ] Trigger an encounter with mount damage → verify mount damage shows as a badge in EventDialog (not duplicated in description text) and as appended text in the story feed
- [ ] Trigger an encounter with mount death → same as above but for death message
- [ ] Verify resource deltas (gold, reputation) match between both views

🤖 Generated with [Claude Code](https://claude.com/claude-code)