### PR TITLE
Convert Hearthwood from region to town landmark in Green Meadows

### DIFF
--- a/src/app/tap-tap-adventure/__tests__/landmarks.test.ts
+++ b/src/app/tap-tap-adventure/__tests__/landmarks.test.ts
@@ -4,7 +4,6 @@ import { getTemplatesForRegion, LANDMARK_TEMPLATES } from '../config/landmarks'
 import { getRegion } from '../config/regions'
 
 const ALL_REGION_IDS = [
-  'hearthwood',
   'green_meadows',
   'dark_forest',
   'sunken_ruins',
@@ -272,26 +271,16 @@ describe('LandmarkTemplate feature flags', () => {
     expect(willowbrook?.hasTransport).toBe(true)
   })
 
-  it("Garron's Forge (sv_blacksmith) has no extra features", () => {
-    const templates = getTemplatesForRegion('hearthwood')
-    const forge = templates.find(t => t.id === 'sv_blacksmith')
-    expect(forge).toBeDefined()
-    expect(forge?.hasInn).toBe(false)
-    expect(forge?.hasStable).toBe(false)
-    expect(forge?.hasMailbox).toBe(false)
-    expect(forge?.hasNoticeBoard).toBe(false)
-    expect(forge?.hasTransport).toBe(false)
-  })
-
-  it('The Rusty Flagon (sv_tavern) has inn, mailbox, notice board but no stable or transport', () => {
-    const templates = getTemplatesForRegion('hearthwood')
-    const tavern = templates.find(t => t.id === 'sv_tavern')
-    expect(tavern).toBeDefined()
-    expect(tavern?.hasInn).toBe(true)
-    expect(tavern?.hasStable).toBe(false)
-    expect(tavern?.hasMailbox).toBe(true)
-    expect(tavern?.hasNoticeBoard).toBe(true)
-    expect(tavern?.hasTransport).toBe(false)
+  it('Hearthwood town (gm_hearthwood) has inn, mailbox, notice board, crafting but no stable or transport', () => {
+    const templates = getTemplatesForRegion('green_meadows')
+    const hearthwood = templates.find(t => t.id === 'gm_hearthwood')
+    expect(hearthwood).toBeDefined()
+    expect(hearthwood?.hasInn).toBe(true)
+    expect(hearthwood?.hasStable).toBe(false)
+    expect(hearthwood?.hasMailbox).toBe(true)
+    expect(hearthwood?.hasNoticeBoard).toBe(true)
+    expect(hearthwood?.hasTransport).toBe(false)
+    expect(hearthwood?.hasCrafting).toBe(true)
   })
 
   it("Puck's Bazaar (fg_market) only has transport", () => {
@@ -306,26 +295,24 @@ describe('LandmarkTemplate feature flags', () => {
   })
 
   it('Non-town landmarks do not have feature flags', () => {
-    const templates = getTemplatesForRegion('hearthwood')
-    const noticeBoard = templates.find(t => t.id === 'sv_notice_board')
-    expect(noticeBoard).toBeDefined()
-    expect(noticeBoard?.hasInn).toBeUndefined()
-    expect(noticeBoard?.hasStable).toBeUndefined()
-    expect(noticeBoard?.hasMailbox).toBeUndefined()
-    expect(noticeBoard?.hasNoticeBoard).toBeUndefined()
-    expect(noticeBoard?.hasTransport).toBeUndefined()
+    const templates = getTemplatesForRegion('green_meadows')
+    const ford = templates.find(t => t.id === 'gm_ford')
+    expect(ford).toBeDefined()
+    expect(ford?.hasInn).toBeUndefined()
+    expect(ford?.hasStable).toBeUndefined()
+    expect(ford?.hasMailbox).toBeUndefined()
+    expect(ford?.hasNoticeBoard).toBeUndefined()
+    expect(ford?.hasTransport).toBeUndefined()
   })
 
   it('feature flags are preserved through generateLandmarks for town landmarks', () => {
     const landmarks = generateLandmarks('green_meadows', 'test-char', 0, 1, 100)
     const townLandmark = landmarks.find(lm => lm.type === 'town')
     expect(townLandmark).toBeDefined()
-    // green_meadows only has gm_hamlet as town, which has all features
+    // green_meadows has gm_hearthwood and gm_hamlet as towns, both have an inn
     expect(townLandmark?.hasInn).toBe(true)
-    expect(townLandmark?.hasStable).toBe(true)
     expect(townLandmark?.hasMailbox).toBe(true)
     expect(townLandmark?.hasNoticeBoard).toBe(true)
-    expect(townLandmark?.hasTransport).toBe(true)
   })
 
   it('non-town generated landmarks have undefined feature flags', () => {

--- a/src/app/tap-tap-adventure/__tests__/regions.test.ts
+++ b/src/app/tap-tap-adventure/__tests__/regions.test.ts
@@ -11,7 +11,6 @@ import {
 describe('Region definitions', () => {
   it('should define all expected regions', () => {
     const expectedIds = [
-      'hearthwood',
       'green_meadows',
       'dark_forest',
       'crystal_caves',
@@ -55,7 +54,6 @@ describe('Region definitions', () => {
   })
 
   it('should have correct difficulty multipliers', () => {
-    expect(REGIONS.hearthwood.difficultyMultiplier).toBe(0.5)
     expect(REGIONS.green_meadows.difficultyMultiplier).toBe(0.8)
     expect(REGIONS.dark_forest.difficultyMultiplier).toBe(1.0)
     expect(REGIONS.crystal_caves.difficultyMultiplier).toBe(1.1)
@@ -88,7 +86,6 @@ describe('Region definitions', () => {
 
 describe('Min level requirements', () => {
   it('starting areas should have low level requirements', () => {
-    expect(REGIONS.hearthwood.minLevel).toBe(0)
     expect(REGIONS.green_meadows.minLevel).toBe(0)
     expect(REGIONS.dark_forest.minLevel).toBe(1)
   })
@@ -132,14 +129,12 @@ describe('getConnectedRegions', () => {
   it('should return connected Region objects', () => {
     const connected = getConnectedRegions('green_meadows')
     const ids = connected.map(r => r.id)
-    expect(ids).toContain('hearthwood')
     expect(ids).toContain('dark_forest')
     expect(ids).toContain('sunken_ruins')
   })
 
   it('should return correct number of connections', () => {
-    expect(getConnectedRegions('hearthwood')).toHaveLength(1)
-    expect(getConnectedRegions('green_meadows')).toHaveLength(3)
+    expect(getConnectedRegions('green_meadows')).toHaveLength(2)
     expect(getConnectedRegions('sky_citadel')).toHaveLength(2) // dragons_spine + abyssal_depths
   })
 })
@@ -232,12 +227,13 @@ describe('Tree structure fields', () => {
     }
   })
 
-  it('hearthwood should be the root (no parent)', () => {
-    expect(REGIONS.hearthwood.parentRegion).toBeUndefined()
+  it('green_meadows should be the root (no parent)', () => {
+    expect(REGIONS.green_meadows.parentRegion).toBeUndefined()
   })
 
-  it('hearthwood should have children', () => {
-    expect(REGIONS.hearthwood.childRegions).toContain('green_meadows')
+  it('green_meadows should have children', () => {
+    expect(REGIONS.green_meadows.childRegions).toContain('dark_forest')
+    expect(REGIONS.green_meadows.childRegions).toContain('sunken_ruins')
   })
 })
 

--- a/src/app/tap-tap-adventure/__tests__/weather.test.ts
+++ b/src/app/tap-tap-adventure/__tests__/weather.test.ts
@@ -57,12 +57,6 @@ describe('Weather Config', () => {
 })
 
 describe('rollWeather', () => {
-  it('hearthwood always returns clear', () => {
-    for (let i = 0; i < 100; i++) {
-      expect(rollWeather('hearthwood')).toBe('clear')
-    }
-  })
-
   it('frozen_peaks only returns weather from its pool', () => {
     const validIds = new Set(Object.keys(REGION_WEATHER_POOLS.frozen_peaks))
     for (let i = 0; i < 100; i++) {

--- a/src/app/tap-tap-adventure/components/RegionMap.tsx
+++ b/src/app/tap-tap-adventure/components/RegionMap.tsx
@@ -13,8 +13,7 @@ interface RegionMapProps {
 
 // Absolute SVG coordinates in 400x1100 viewBox (bottom = high y, top = low y)
 const TREE_LAYOUT: Record<string, { x: number; y: number }> = {
-  hearthwood:        { x: 200, y: 1040 },
-  green_meadows:     { x: 200, y:  940 },
+  green_meadows:     { x: 200, y: 1040 },
   dark_forest:       { x:  95, y:  845 },
   sunken_ruins:      { x: 305, y:  845 },
   feywild_grove:     { x:  95, y:  755 },
@@ -31,7 +30,6 @@ const TREE_LAYOUT: Record<string, { x: number; y: number }> = {
 }
 
 const TERRAIN_GRADIENTS: Record<string, [string, string]> = {
-  hearthwood:        ['#4a5e3a', '#2d3b22'],
   green_meadows:     ['#3a7d44', '#1e4d2b'],
   dark_forest:       ['#1a2e1a', '#0d1a0d'],
   sunken_ruins:      ['#1a3a4a', '#0d2233'],
@@ -366,7 +364,7 @@ export function RegionMap({
 }: RegionMapProps) {
   const containerRef = useRef<HTMLDivElement>(null)
   const regions = Object.values(REGIONS)
-  const visited = new Set([...visitedRegions, currentRegionId, 'hearthwood'])
+  const visited = new Set([...visitedRegions, currentRegionId])
 
   // Auto-scroll to current region on mount / change
   useEffect(() => {

--- a/src/app/tap-tap-adventure/components/TavernPanel.tsx
+++ b/src/app/tap-tap-adventure/components/TavernPanel.tsx
@@ -11,7 +11,6 @@ interface TavernPanelProps {
 }
 
 const TAVERN_FLAVORS: Record<string, string> = {
-  hearthwood: 'The hearth crackles warmly as the barkeep polishes a well-worn mug. The smell of roasted meat and fresh bread fills the cozy room.',
   green_meadows: 'Farmers and merchants share tables over simple fare. A bard in the corner plays a gentle melody on a worn lute.',
   dark_forest: 'Lantern light flickers across rough-hewn walls. The patrons speak in hushed tones, glancing toward the dark windows.',
   sunken_ruins: 'Water drips from the ceiling into carefully placed buckets. The air tastes of salt and the drinks are suspiciously warm.',

--- a/src/app/tap-tap-adventure/components/WorldMap.tsx
+++ b/src/app/tap-tap-adventure/components/WorldMap.tsx
@@ -15,7 +15,7 @@ export function WorldMap({ character }: WorldMapProps) {
   const regionIds = Object.keys(REGIONS)
 
   // Find root
-  const root = 'hearthwood'
+  const root = 'green_meadows'
 
   // BFS to build ordered list with depth
   type TreeNode = { id: string; depth: number; parentId?: string }

--- a/src/app/tap-tap-adventure/config/landmarks.ts
+++ b/src/app/tap-tap-adventure/config/landmarks.ts
@@ -18,66 +18,22 @@ export interface LandmarkTemplate {
 }
 
 export const LANDMARK_TEMPLATES: Record<string, LandmarkTemplate[]> = {
-  hearthwood: [
+  green_meadows: [
     {
-      id: 'sv_notice_board',
-      name: 'Notice Board',
-      type: 'waypoint',
-      description: 'A weathered board covered in job postings and missing-person notices.',
-      icon: '📋',
-      hasShop: false,
-      encounterPrompt: 'A crowded notice board in the village square. Adventurers and locals gather to read postings about work, missing persons, and local news.',
-    },
-    {
-      id: 'sv_tavern',
-      name: 'The Rusty Flagon',
+      id: 'gm_hearthwood',
+      name: 'Hearthwood',
       type: 'town',
-      description: 'A lively tavern where weary travelers gather to trade tales and resupply.',
-      icon: '🍺',
+      description: 'A warm and welcoming hamlet nestled in a sunlit valley. Adventurers rest, resupply, and share tales by the hearth.',
+      icon: '🏘️',
       hasShop: true,
-      encounterPrompt: 'A warm, bustling tavern filled with the smell of roasted meat and spilled ale. The barkeep is friendly and the locals are chatty.',
+      encounterPrompt: 'A cozy hamlet with a central hearth, welcoming taverns, artisan shops, and friendly townsfolk. The smell of roasted meat and fresh bread fills the air.',
       hasInn: true,
       hasStable: false,
       hasMailbox: true,
       hasNoticeBoard: true,
       hasTransport: false,
-    },
-    {
-      id: 'sv_temple',
-      name: 'Village Temple',
-      type: 'shrine',
-      description: 'A modest stone temple offering blessings to departing adventurers.',
-      icon: '⛪',
-      hasShop: false,
-      encounterPrompt: 'A small but well-kept stone temple. A robed priest offers blessings and the scent of incense fills the air.',
-    },
-    {
-      id: 'sv_blacksmith',
-      name: "Garron's Forge",
-      type: 'town',
-      description: 'A busy smithy where the clanging of hammers rings from dawn to dusk.',
-      icon: '⚒️',
-      hasShop: true,
-      encounterPrompt: "A hot smithy where sparks fly and the smell of molten iron fills the air. The blacksmith Garron is gruff but fair, selling quality wares.",
-      hasInn: false,
-      hasStable: false,
-      hasMailbox: false,
-      hasNoticeBoard: false,
-      hasTransport: false,
       hasCrafting: true,
     },
-    {
-      id: 'sv_well',
-      name: 'The Old Well',
-      type: 'ruins',
-      description: 'An ancient well said to grant visions to those who drink from it.',
-      icon: '🪣',
-      hasShop: false,
-      encounterPrompt: 'An ancient moss-covered well at the edge of the village. Locals whisper that it sometimes shows visions of the future in its depths.',
-    },
-  ],
-
-  green_meadows: [
     {
       id: 'gm_mill',
       name: 'The Old Mill',
@@ -744,11 +700,9 @@ export function getTemplatesForRegion(regionId: string): LandmarkTemplate[] {
 }
 
 export const SECRET_LANDMARK_TEMPLATES: Record<string, LandmarkTemplate[]> = {
-  hearthwood: [
-    { id: 'sv_hidden_cellar', name: 'Hidden Cellar', type: 'dungeon', description: 'A concealed entrance beneath the cobblestones leads to a forgotten cellar.', icon: '🕳️', hasShop: false, encounterPrompt: 'A damp cellar filled with old crates and cobwebs. Something glints in the darkness.', isSecret: true },
-  ],
   green_meadows: [
     { id: 'gm_fairy_ring', name: 'Fairy Ring', type: 'shrine', description: 'A circle of glowing mushrooms hidden in a meadow hollow.', icon: '🍄', hasShop: false, encounterPrompt: 'A ring of luminescent mushrooms pulses with fey energy. Tiny lights dance above the circle.', isSecret: true },
+    { id: 'sv_hidden_cellar', name: 'Hidden Cellar', type: 'dungeon', description: 'A concealed entrance beneath the cobblestones leads to a forgotten cellar.', icon: '🕳️', hasShop: false, encounterPrompt: 'A damp cellar filled with old crates and cobwebs. Something glints in the darkness.', isSecret: true },
   ],
   dark_forest: [
     { id: 'df_shadow_grotto', name: 'Shadow Grotto', type: 'dungeon', description: 'A cave entrance concealed by twisted roots and perpetual shadow.', icon: '🕸️', hasShop: false, encounterPrompt: 'A grotto shrouded in unnatural darkness. Strange whispers echo from within.', isSecret: true },

--- a/src/app/tap-tap-adventure/config/npcs.ts
+++ b/src/app/tap-tap-adventure/config/npcs.ts
@@ -46,7 +46,7 @@ export const NPCS: GameNPC[] = [
     name: 'Elder Maren',
     role: 'Village Elder',
     description: 'The wise elder of Hearthwood, keeper of ancient lore and guide to new adventurers.',
-    regionId: 'hearthwood',
+    regionId: 'green_meadows',
     personality: 'Wise, welcoming, and patient. Speaks with warmth and authority. Offers practical advice and tips to adventurers. Uses gentle humor. Values courage and kindness.',
     icon: '\u{1F9D9}',
     combatRole: 'non-combatant',

--- a/src/app/tap-tap-adventure/config/regions.ts
+++ b/src/app/tap-tap-adventure/config/regions.ts
@@ -24,21 +24,6 @@ export interface Region {
 }
 
 export const REGIONS: Record<string, Region> = {
-  hearthwood: {
-    id: 'hearthwood',
-    name: 'Hearthwood',
-    description: 'A warm and welcoming hamlet nestled in a sunlit valley. Adventurers rest, resupply, and share tales by the hearth.',
-    difficulty: 'easy',
-    difficultyMultiplier: 0.5,
-    theme: 'cozy hamlet with a central hearth, welcoming taverns, artisan shops, and friendly townsfolk',
-    enemyTypes: [],
-    element: 'none',
-    connectedRegions: ['green_meadows'],
-    minLevel: 0,
-    icon: '\u{1F3D8}\u{FE0F}',
-    childRegions: ['green_meadows'],
-    bounds: { width: 500, height: 500 },
-  },
   green_meadows: {
     id: 'green_meadows',
     name: 'Green Meadows',
@@ -48,11 +33,10 @@ export const REGIONS: Record<string, Region> = {
     theme: 'rolling green hills, wildflower meadows, gentle streams, and scattered farmsteads',
     enemyTypes: ['wolves', 'bandits', 'wild boars'],
     element: 'nature',
-    connectedRegions: ['hearthwood', 'dark_forest', 'sunken_ruins'],
+    connectedRegions: ['dark_forest', 'sunken_ruins'],
     minLevel: 0,
     icon: '\u{1F33F}',
     startingCombatDistance: 'far',
-    parentRegion: 'hearthwood',
     childRegions: ['dark_forest', 'sunken_ruins'],
     bounds: { width: 500, height: 500 },
   },

--- a/src/app/tap-tap-adventure/config/weather.ts
+++ b/src/app/tap-tap-adventure/config/weather.ts
@@ -99,7 +99,6 @@ export const WEATHER_TYPES: Record<WeatherId, WeatherType> = {
 
 /** Weighted weather pools per region. Keys must match region IDs in config/regions.ts */
 export const REGION_WEATHER_POOLS: Record<string, RegionWeatherPool> = {
-  hearthwood: { clear: 10 },
   green_meadows: { clear: 5, rain: 3, storm: 1, fog: 1 },
   dark_forest: { clear: 2, fog: 5, rain: 3, storm: 1 },
   crystal_caves: { clear: 5, fog: 3, blizzard: 2 },

--- a/src/app/tap-tap-adventure/lib/mainQuestManager.ts
+++ b/src/app/tap-tap-adventure/lib/mainQuestManager.ts
@@ -1,6 +1,6 @@
 import { MainQuest } from '@/app/tap-tap-adventure/models/quest'
 
-// All conquerable regions (excludes hearthwood which is a non-combat hub)
+// All conquerable regions
 export const CONQUERABLE_REGIONS = [
   'green_meadows', 'dark_forest', 'crystal_caves', 'scorched_wastes',
   'frozen_peaks', 'shadow_realm', 'sky_citadel', 'sunken_ruins',


### PR DESCRIPTION
## Summary
Fixes #481 — Hearthwood was a standalone region with its own coordinate space and landmark set. It should be a town landmark within Green Meadows, not a separate region.

**Changes across 11 files:**
- **regions.ts**: Removed `hearthwood` region entry. Updated `green_meadows` to be the tree root (no parent, no hearthwood in connections)
- **landmarks.ts**: Replaced the 5 individual hearthwood sub-landmarks with a single `gm_hearthwood` town landmark in the green_meadows array. Moved the secret landmark (`sv_hidden_cellar`) into green_meadows secrets
- **WorldMap.tsx**: Changed BFS root from `hearthwood` to `green_meadows`
- **RegionMap.tsx**: Removed hearthwood from layout/gradients, moved green_meadows to bottom position. Removed hearthwood from hardcoded visited set
- **weather.ts**: Removed hearthwood weather entry
- **npcs.ts**: Moved Elder Maren to `green_meadows`
- **TavernPanel.tsx**: Removed hearthwood tavern flavor text
- **mainQuestManager.ts**: Updated comment
- **Tests**: Updated region, landmark, and weather tests to reflect the new structure

The backward-compat filter in `useGameStore.ts` (`r !== 'hearthwood'`) is kept for existing save data that may still reference hearthwood in `visitedRegions`.

## Test plan
- [ ] New game starts in Green Meadows (no Hearthwood region visible)
- [ ] World map shows Green Meadows as root node, no Hearthwood node
- [ ] Hearthwood appears as a town landmark when exploring Green Meadows
- [ ] Hearthwood town landmark has shop, inn, mailbox, notice board, crafting
- [ ] Elder Maren NPC appears in Green Meadows
- [ ] Existing saves with hearthwood in visitedRegions still work (conquest count unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)