### PR TITLE
Generate new landmarks when map items are used

### DIFF
--- a/src/app/tap-tap-adventure/lib/itemEffects.ts
+++ b/src/app/tap-tap-adventure/lib/itemEffects.ts
@@ -1,6 +1,7 @@
 import { FantasyCharacter } from '@/app/tap-tap-adventure/models/character'
 import { Item } from '@/app/tap-tap-adventure/models/item'
 import { clampGold } from '@/app/tap-tap-adventure/lib/contextBuilder'
+import { generateMapLandmark, GeneratedLandmark } from '@/app/tap-tap-adventure/lib/landmarkGenerator'
 
 export interface UseItemResult {
   character: FantasyCharacter
@@ -75,6 +76,7 @@ export function useItem(character: FantasyCharacter, item: Item): UseItemResult 
     if (ls) {
       const hiddenIdx = ls.landmarks.findIndex(lm => lm.hidden)
       if (hiddenIdx !== -1) {
+        // Reveal existing hidden landmark
         const updatedLandmarks = ls.landmarks.map((lm, i) =>
           i === hiddenIdx ? { ...lm, hidden: false } : lm
         )
@@ -84,7 +86,21 @@ export function useItem(character: FantasyCharacter, item: Item): UseItemResult 
         }
         effectMessages.push(`Revealed a hidden landmark: ${ls.landmarks[hiddenIdx].name}`)
       } else {
-        effectMessages.push('No hidden landmarks to reveal')
+        // No hidden landmarks — generate a new one
+        const bounds = ls.regionBounds ?? { width: 500, height: 500 }
+        const newLandmark = generateMapLandmark(ls.regionId, ls.landmarks as GeneratedLandmark[], bounds)
+        if (newLandmark) {
+          const updatedLandmarks = [...ls.landmarks, newLandmark].sort(
+            (a, b) => a.distanceFromEntry - b.distanceFromEntry
+          )
+          updatedCharacter = {
+            ...updatedCharacter,
+            landmarkState: { ...ls, landmarks: updatedLandmarks },
+          }
+          effectMessages.push(`Your map reveals a new location: ${newLandmark.name}`)
+        } else {
+          effectMessages.push('Your map shows nothing new in this area')
+        }
       }
     } else {
       effectMessages.push('No landmarks in this area')

--- a/src/app/tap-tap-adventure/lib/landmarkGenerator.ts
+++ b/src/app/tap-tap-adventure/lib/landmarkGenerator.ts
@@ -156,3 +156,61 @@ export function generateLandmarks(
 
   return landmarks
 }
+
+/**
+ * Generate a single new landmark for the current region when a map item is used.
+ * Avoids duplicating templates already present in the landmark list.
+ */
+export function generateMapLandmark(
+  regionId: string,
+  existingLandmarks: GeneratedLandmark[],
+  regionBounds: { width: number; height: number },
+): GeneratedLandmark | null {
+  const templates = getTemplatesForRegion(regionId)
+  const secretTemplates = getSecretTemplatesForRegion(regionId)
+  const allTemplates = [...templates, ...secretTemplates]
+
+  // Filter out templates already used
+  const existingIds = new Set(existingLandmarks.map(lm => lm.templateId))
+  const available = allTemplates.filter(t => !existingIds.has(t.id))
+
+  if (available.length === 0) return null
+
+  // Use timestamp-based seed for non-deterministic generation (each map use is unique)
+  const rng = seededRandom(`map-${regionId}-${Date.now()}`)
+  const template = available[Math.floor(rng() * available.length)]
+
+  const margin = regionBounds.width * 0.1
+  const rangeX = regionBounds.width - 2 * margin
+  const rangeY = regionBounds.height - 2 * margin
+
+  // Place landmark at a distance between existing ones
+  const maxDist = existingLandmarks.length > 0
+    ? Math.max(...existingLandmarks.map(lm => lm.distanceFromEntry))
+    : 50
+  const distanceFromEntry = Math.floor(maxDist * 0.3 + rng() * maxDist * 0.6)
+
+  return {
+    templateId: template.id,
+    name: template.name,
+    type: template.type,
+    description: template.description,
+    icon: template.icon,
+    hasShop: template.hasShop,
+    encounterPrompt: template.encounterPrompt,
+    distanceFromEntry,
+    hidden: false,
+    isSecret: template.isSecret ?? false,
+    explored: false,
+    position: {
+      x: Math.round(margin + rng() * rangeX),
+      y: Math.round(margin + rng() * rangeY),
+    },
+    hasInn: template.hasInn,
+    hasStable: template.hasStable,
+    hasMailbox: template.hasMailbox,
+    hasNoticeBoard: template.hasNoticeBoard,
+    hasTransport: template.hasTransport,
+    hasCrafting: template.hasCrafting,
+  }
+}


### PR DESCRIPTION
## Summary
Fixes #480 — Map items now generate new landmarks when no hidden ones remain to reveal, instead of showing "No hidden landmarks to reveal".

**Changes:**
- **landmarkGenerator.ts**: Added `generateMapLandmark()` function that picks an unused template from the region's pool (including secrets), generates a random position within region bounds, and returns a new visible landmark
- **itemEffects.ts**: Updated `revealLandmark` handler to fall back to `generateMapLandmark()` when no hidden landmarks exist. New landmarks are inserted sorted by distance and immediately visible

**Behavior:**
1. If hidden landmarks exist → reveal them (unchanged)
2. If no hidden landmarks → generate a new one from unused templates
3. If all templates exhausted → "Your map shows nothing new in this area"

## Test plan
- [ ] Use a map when a hidden secret landmark exists → reveals it (existing behavior preserved)
- [ ] Use a map after the secret landmark is already revealed → generates a new landmark with a different template
- [ ] New landmark appears in the landmark list sorted by distance
- [ ] New landmark is visible (not hidden) and unexplored
- [ ] Use maps repeatedly until all templates are exhausted → shows "nothing new" message
- [ ] Verify new landmark has correct position within region bounds

🤖 Generated with [Claude Code](https://claude.com/claude-code)