### PR TITLE
Show spell effect summary in combat spell menu

### DIFF
--- a/src/app/tap-tap-adventure/components/CombatUI.tsx
+++ b/src/app/tap-tap-adventure/components/CombatUI.tsx
@@ -828,6 +828,25 @@ export function CombatUI({ combatState }: CombatUIProps) {
                       </span>
                     </div>
                   </div>
+                  {spell.effects && spell.effects.length > 0 && (() => {
+                    const dmg = spell.effects.filter(e => ['damage', 'true_damage', 'lifesteal'].includes(e.type)).reduce((s, e) => s + e.value, 0)
+                    const heal = spell.effects.filter(e => e.type === 'heal').reduce((s, e) => s + e.value, 0)
+                    const dot = spell.effects.find(e => ['damage_over_time', 'apply_poison', 'apply_burn', 'bleed'].includes(e.type))
+                    const shield = spell.effects.filter(e => e.type === 'shield').reduce((s, e) => s + e.value, 0)
+                    const parts: string[] = []
+                    if (dmg > 0) parts.push(`${dmg} dmg`)
+                    if (heal > 0) parts.push(`${heal} heal`)
+                    if (shield > 0) parts.push(`${shield} shield`)
+                    if (dot) parts.push(`${dot.value}/${dot.duration ?? 1}t ${dot.type.replace('apply_', '').replace('damage_over_time', 'DoT')}`)
+                    if (parts.length === 0) return null
+                    return (
+                      <div className="flex items-center gap-2 mt-0.5 text-[10px]">
+                        <span className="text-slate-500 capitalize">{spell.school}</span>
+                        <span className="text-amber-300">{parts.join(' + ')}</span>
+                        {!onCooldown && spell.cooldown > 0 && <span className="text-slate-600">{spell.cooldown}t cd</span>}
+                      </div>
+                    )
+                  })()}
                   <div className="text-[10px] text-slate-400 mt-0.5">
                     {spell.description}
                   </div>


### PR DESCRIPTION
## Summary
Fixes #498 — Combat spell menu now shows a compact effect summary line between the spell name and description.

**Shows:**
- Spell school name (e.g., "arcane", "war")
- Damage total (sum of damage + true_damage + lifesteal effects)
- Heal amount
- Shield value
- DoT/status effects with value and duration (e.g., "5/3t poison")
- Cooldown turns (when not currently on cooldown)

This lets players make informed decisions about which spell to cast without relying on description text alone. 19 lines added to a single file.

## Test plan
- [ ] Open combat → spell menu shows effect summary below spell name
- [ ] Damage spells show "X dmg" in amber
- [ ] Heal spells show "X heal"
- [ ] Shield spells show "X shield"
- [ ] DoT spells show "X/Yt type" (e.g. "5/3t poison")
- [ ] Multi-effect spells show combined (e.g. "12 dmg + 5 heal")
- [ ] School name shown in slate color
- [ ] Cooldown shown as "Xt cd" when spell is not on cooldown
- [ ] Spells with no damage/heal/shield effects don't show the summary line

🤖 Generated with [Claude Code](https://claude.com/claude-code)