### PR TITLE
Show enemy name on death run summary screen

### DIFF
--- a/src/app/tap-tap-adventure/components/RunSummary.tsx
+++ b/src/app/tap-tap-adventure/components/RunSummary.tsx
@@ -98,7 +98,7 @@ export default function RunSummary({
   onNewCharacter,
   onBackToCharacters,
 }: RunSummaryProps) {
-  const { character, reason, essenceEarned, heirloom } = data
+  const { character, reason, essenceEarned, heirloom, killedBy } = data
 
   const [playerName, setPlayerName] = useState<string>('')
   const [nameInput, setNameInput] = useState<string>('')
@@ -193,6 +193,9 @@ export default function RunSummary({
         </p>
         {reason === 'victory' && (
           <p className="text-yellow-400 mt-2 font-semibold">You have united all lands under your banner.</p>
+        )}
+        {killedBy && (reason === 'death' || reason === 'permadeath') && (
+          <p className="text-slate-300 mt-2">Slain by <span className="font-semibold text-red-300">{killedBy}</span></p>
         )}
         {reason === 'permadeath' && (
           <p className="text-red-500 text-sm mt-1 italic">This character is gone forever.</p>

--- a/src/app/tap-tap-adventure/hooks/useCombatActionMutation.ts
+++ b/src/app/tap-tap-adventure/hooks/useCombatActionMutation.ts
@@ -336,6 +336,7 @@ export function useCombatActionMutation(options?: { onMountDrop?: (mount: Mount)
               reason: 'permadeath',
               essenceEarned,
               heirloom,
+              killedBy: enemy.name,
             })
 
             recordRun({
@@ -395,6 +396,7 @@ export function useCombatActionMutation(options?: { onMountDrop?: (mount: Mount)
               reason: 'death',
               essenceEarned,
               heirloom,
+              killedBy: enemy.name,
             })
 
             recordRun({

--- a/src/app/tap-tap-adventure/models/types.ts
+++ b/src/app/tap-tap-adventure/models/types.ts
@@ -96,6 +96,7 @@ type RunSummaryData = {
   reason: 'death' | 'permadeath' | 'retirement' | 'victory'
   essenceEarned: number
   heirloom: Item | null
+  killedBy?: string
 }
 
 type GameState = {


### PR DESCRIPTION
## Summary
Fixes #500 — When a character dies in combat, the run summary screen now shows "Slain by [enemy name]" so players know what killed them.

**Changes across 3 files:**
- **types.ts**: Added optional `killedBy` field to `RunSummaryData`
- **useCombatActionMutation.ts**: Passes `enemy.name` as `killedBy` on both death and permadeath
- **RunSummary.tsx**: Displays "Slain by **enemy**" in red below the character info on death screens

7 lines added across 3 files.

## Test plan
- [ ] Die in combat → run summary shows "Slain by [enemy name]"
- [ ] Permadeath → shows "Slain by [enemy]" AND "This character is gone forever"
- [ ] Retire character → no "Slain by" shown (only for deaths)
- [ ] Victory → no "Slain by" shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)