### PR TITLE
Add tooltip to region map nodes showing enemies and element

### DIFF
--- a/src/app/tap-tap-adventure/components/RegionMap.tsx
+++ b/src/app/tap-tap-adventure/components/RegionMap.tsx
@@ -186,6 +186,8 @@ function RegionNode({
       style={isClickable ? { cursor: 'pointer' } : undefined}
       onClick={isClickable ? () => onRegionClick!(region.id) : undefined}
     >
+      <title>{`${region.name} (${DIFFICULTY_LABELS[region.difficulty]})${region.enemyTypes.length > 0 ? `\nEnemies: ${region.enemyTypes.join(', ')}` : ''}${region.element !== 'none' ? `\nElement: ${region.element}` : ''}${region.minLevel > 0 ? `\nMin Level: ${region.minLevel}` : ''}`}</title>
+
       {/* Pulse ring for current region */}
       {isCurrent && (
         <circle


### PR DESCRIPTION
## Summary
Fixes #502 — Hovering a visited region on the world map now shows a native tooltip with region details.

**Shows:**
- Region name and difficulty
- Enemy types (e.g., "wolves, bandits, wild boars")
- Dominant element (e.g., "nature", "shadow")
- Minimum level requirement

Uses SVG `<title>` element for native browser tooltip — no JS overhead. 2 lines added.

## Test plan
- [ ] Hover a visited region on the world map → tooltip appears with details
- [ ] Tooltip shows enemy types for combat regions
- [ ] Tooltip shows element for elemental regions
- [ ] Locked/fog-of-war regions don't show tooltips (they render a different branch)
- [ ] Tooltip shows "Min Level: X" for level-gated regions

🤖 Generated with [Claude Code](https://claude.com/claude-code)