### PR TITLE
Add weather-themed combat achievements

### DIFF
--- a/src/app/tap-tap-adventure/components/GameUI.tsx
+++ b/src/app/tap-tap-adventure/components/GameUI.tsx
@@ -607,6 +607,7 @@ export default function GameUI({ onOpenStatus }: GameUIProps) {
                         partyTotal: (combatState.partyMemberStates ?? []).length,
                         enemyLevel: combatState.enemy.level,
                         playerLevel: character.level,
+                        currentWeather: character.currentWeather,
                       }
                     )
                     updateAchievements(achievements)

--- a/src/app/tap-tap-adventure/config/achievements.ts
+++ b/src/app/tap-tap-adventure/config/achievements.ts
@@ -290,6 +290,35 @@ export const ACHIEVEMENTS: Achievement[] = [
     reward: { gold: 500, reputation: 100 },
   },
 
+  // Weather combat achievements
+  {
+    id: 'special_storm_warrior',
+    name: 'Storm Warrior',
+    description: 'Win 5 combats during adverse weather',
+    category: 'special',
+    requirement: 5,
+    icon: '🌧️',
+    reward: { gold: 30, reputation: 5 },
+  },
+  {
+    id: 'special_tempest_champion',
+    name: 'Tempest Champion',
+    description: 'Win 25 combats during adverse weather',
+    category: 'special',
+    requirement: 25,
+    icon: '⛈️',
+    reward: { gold: 100, reputation: 15 },
+  },
+  {
+    id: 'special_storm_boss',
+    name: 'Eye of the Storm',
+    description: 'Defeat a boss during adverse weather',
+    category: 'special',
+    requirement: 1,
+    icon: '🌪️',
+    reward: { gold: 75, reputation: 10 },
+  },
+
   // Spell Combo achievements
   {
     id: 'combo_first_combo',

--- a/src/app/tap-tap-adventure/lib/achievementTracker.ts
+++ b/src/app/tap-tap-adventure/lib/achievementTracker.ts
@@ -4,7 +4,7 @@ import { FantasyCharacter } from '@/app/tap-tap-adventure/models/character'
 import { GameState } from '@/app/tap-tap-adventure/models/types'
 
 export type AchievementEvent =
-  | { type: 'combat_win'; hpAfterCombat: number; maxHp: number; isBoss: boolean; turnCount?: number; partyAlive?: number; partyTotal?: number; enemyLevel?: number; playerLevel?: number }
+  | { type: 'combat_win'; hpAfterCombat: number; maxHp: number; isBoss: boolean; turnCount?: number; partyAlive?: number; partyTotal?: number; enemyLevel?: number; playerLevel?: number; currentWeather?: string }
   | { type: 'shop_purchase' }
   | { type: 'death' }
 
@@ -221,6 +221,26 @@ function getProgress(
     if (event?.type === 'death') {
       return 1
     }
+    return existing?.progress ?? 0
+  }
+
+  // Weather combat achievements — cumulative wins during adverse weather
+  if (achievementId === 'special_storm_warrior') {
+    const existing = currentAchievements.find(a => a.achievementId === achievementId)
+    const current = existing?.progress ?? 0
+    if (event?.type === 'combat_win' && event.currentWeather && event.currentWeather !== 'clear') return current + 1
+    return current
+  }
+  if (achievementId === 'special_tempest_champion') {
+    const existing = currentAchievements.find(a => a.achievementId === achievementId)
+    const current = existing?.progress ?? 0
+    if (event?.type === 'combat_win' && event.currentWeather && event.currentWeather !== 'clear') return current + 1
+    return current
+  }
+  if (achievementId === 'special_storm_boss') {
+    const existing = currentAchievements.find(a => a.achievementId === achievementId)
+    if (existing?.completed) return existing.progress
+    if (event?.type === 'combat_win' && event.isBoss && event.currentWeather && event.currentWeather !== 'clear') return 1
     return existing?.progress ?? 0
   }
 


### PR DESCRIPTION
## Summary
Fixes #506 — Three new achievements reward players for fighting during adverse weather conditions, leveraging the existing weather mechanics system.

**New achievements:**
- **Storm Warrior** 🌧️ — Win 5 combats during adverse weather (+30 gold, +5 rep)
- **Tempest Champion** ⛈️ — Win 25 combats during adverse weather (+100 gold, +15 rep)
- **Eye of the Storm** 🌪️ — Defeat a boss during adverse weather (+75 gold, +10 rep)

**Changes across 3 files:**
- `config/achievements.ts` — 3 new achievement definitions
- `lib/achievementTracker.ts` — Added `currentWeather` to combat_win event type + 3 evaluation handlers
- `components/GameUI.tsx` — Passes `character.currentWeather` through the combat_win event

## Test plan
- [ ] Win a combat during non-clear weather → Storm Warrior progress increments
- [ ] Win 5 combats during weather → Storm Warrior unlocks with rewards
- [ ] Win 25 during weather → Tempest Champion unlocks
- [ ] Beat a boss during weather → Eye of the Storm unlocks
- [ ] Combat during clear weather → no weather achievement progress
- [ ] Achievements appear in achievement panel with correct icons

🤖 Generated with [Claude Code](https://claude.com/claude-code)