### PR TITLE
feat: trivia auth phase 1 — Firebase Auth infrastructure

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "cmdk": "1.0.4",
     "date-fns": "4.1.0",
     "embla-carousel-react": "8.5.1",
+    "firebase": "^12.12.1",
     "firebase-admin": "^13.8.0",
     "framer-motion": "latest",
     "immer": "^10.1.1",

--- a/src/app/auth/page.tsx
+++ b/src/app/auth/page.tsx
@@ -2,7 +2,7 @@
 
 import { FirebaseError } from 'firebase/app'
 import { useRouter, useSearchParams } from 'next/navigation'
-import { type FormEvent, useEffect, useState } from 'react'
+import { Suspense, type FormEvent, useEffect, useState } from 'react'
 
 import { AuthProvider, useAuth } from '@/app/trivia/hooks/useAuth'
 import { Button } from '@/components/ui/button'
@@ -183,7 +183,9 @@ function formatAuthError(err: unknown): string {
 export default function AuthPage() {
   return (
     <AuthProvider>
-      <AuthPageInner />
+      <Suspense fallback={null}>
+        <AuthPageInner />
+      </Suspense>
     </AuthProvider>
   )
 }

--- a/src/app/auth/page.tsx
+++ b/src/app/auth/page.tsx
@@ -1,0 +1,189 @@
+'use client'
+
+import { FirebaseError } from 'firebase/app'
+import { useRouter, useSearchParams } from 'next/navigation'
+import { type FormEvent, useEffect, useState } from 'react'
+
+import { AuthProvider, useAuth } from '@/app/trivia/hooks/useAuth'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
+
+function AuthPageInner() {
+  const router = useRouter()
+  const searchParams = useSearchParams()
+  const redirectTo = searchParams.get('redirect') ?? '/trivia'
+  const { user, loading, configured, signInWithGoogle, signInWithEmail, signUpWithEmail } =
+    useAuth()
+
+  const [mode, setMode] = useState<'signin' | 'signup'>('signin')
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!loading && user) {
+      router.replace(redirectTo)
+    }
+  }, [loading, user, redirectTo, router])
+
+  const handleGoogle = async () => {
+    setError(null)
+    setSubmitting(true)
+    try {
+      await signInWithGoogle()
+      router.replace(redirectTo)
+    } catch (err) {
+      setError(formatAuthError(err))
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  const handleEmail = async (e: FormEvent) => {
+    e.preventDefault()
+    setError(null)
+    setSubmitting(true)
+    try {
+      if (mode === 'signin') {
+        await signInWithEmail(email, password)
+      } else {
+        await signUpWithEmail(email, password)
+      }
+      router.replace(redirectTo)
+    } catch (err) {
+      setError(formatAuthError(err))
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  if (!configured) {
+    return (
+      <div className="flex flex-col items-center gap-6 max-w-md mx-auto py-8">
+        <Card className="w-full bg-space-dark/80 border-space-grey">
+          <CardContent className="pt-6 text-center text-cream-white/80">
+            Sign-in isn&apos;t configured yet. Please try again later.
+          </CardContent>
+        </Card>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex flex-col items-center gap-6 max-w-md mx-auto py-8">
+      <div className="text-center">
+        <h1 className="text-3xl font-bold text-space-gold mb-2">
+          {mode === 'signin' ? 'Sign in' : 'Create an account'}
+        </h1>
+        <p className="text-cream-white/70 text-sm">
+          Save your trivia stats and compete on the leaderboard
+        </p>
+      </div>
+
+      <Card className="w-full bg-space-dark/80 border-space-grey">
+        <CardHeader>
+          <CardTitle className="text-cream-white text-center">Welcome</CardTitle>
+        </CardHeader>
+        <CardContent className="flex flex-col gap-4">
+          <Button
+            variant="space"
+            size="lg"
+            className="w-full"
+            onClick={handleGoogle}
+            disabled={submitting}
+          >
+            Sign in with Google
+          </Button>
+
+          <div className="flex items-center gap-3 text-cream-white/40 text-xs">
+            <div className="flex-1 h-px bg-space-grey" />
+            OR
+            <div className="flex-1 h-px bg-space-grey" />
+          </div>
+
+          <form className="flex flex-col gap-3" onSubmit={handleEmail}>
+            <Input
+              type="email"
+              required
+              placeholder="Email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              className="bg-space-black/50 border-space-grey text-cream-white placeholder:text-cream-white/30"
+              autoComplete="email"
+            />
+            <Input
+              type="password"
+              required
+              placeholder="Password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              className="bg-space-black/50 border-space-grey text-cream-white placeholder:text-cream-white/30"
+              autoComplete={mode === 'signin' ? 'current-password' : 'new-password'}
+              minLength={6}
+            />
+            <Button
+              type="submit"
+              variant="outline"
+              className="w-full"
+              disabled={submitting || email.length === 0 || password.length === 0}
+            >
+              {mode === 'signin' ? 'Sign in with email' : 'Create account'}
+            </Button>
+          </form>
+
+          {error && (
+            <div className="text-red-400 text-sm text-center" role="alert">
+              {error}
+            </div>
+          )}
+
+          <button
+            type="button"
+            onClick={() => {
+              setError(null)
+              setMode(mode === 'signin' ? 'signup' : 'signin')
+            }}
+            className="text-cream-white/50 text-sm text-center hover:text-cream-white/80 transition-colors"
+          >
+            {mode === 'signin'
+              ? "Don't have an account? Sign up"
+              : 'Already have an account? Sign in'}
+          </button>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}
+
+function formatAuthError(err: unknown): string {
+  if (err instanceof FirebaseError) {
+    switch (err.code) {
+      case 'auth/invalid-credential':
+      case 'auth/wrong-password':
+      case 'auth/user-not-found':
+        return 'Invalid email or password.'
+      case 'auth/email-already-in-use':
+        return 'That email is already registered. Try signing in.'
+      case 'auth/weak-password':
+        return 'Password must be at least 6 characters.'
+      case 'auth/invalid-email':
+        return 'That email address is not valid.'
+      case 'auth/popup-closed-by-user':
+      case 'auth/cancelled-popup-request':
+        return 'Sign-in cancelled.'
+      default:
+        return err.message
+    }
+  }
+  return 'Something went wrong. Please try again.'
+}
+
+export default function AuthPage() {
+  return (
+    <AuthProvider>
+      <AuthPageInner />
+    </AuthProvider>
+  )
+}

--- a/src/app/trivia/components/TriviaLanding.tsx
+++ b/src/app/trivia/components/TriviaLanding.tsx
@@ -1,10 +1,16 @@
 'use client'
 
+import Image from 'next/image'
+import Link from 'next/link'
 import { useState } from 'react'
+
+import { useAuth } from '@/app/trivia/hooks/useAuth'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+
 import { useTriviaStore } from '../hooks/useTriviaStore'
 import { formatDisplayDate, getDailyCategory, getTodayPST } from '../lib/triviaUtils'
+
 import { NamePrompt } from './NamePrompt'
 
 export function TriviaLanding({
@@ -17,6 +23,7 @@ export function TriviaLanding({
   onViewLeaderboard?: () => void
 }) {
   const { userData, canPlayToday, setDisplayName, skipName } = useTriviaStore()
+  const { user, loading: authLoading, configured: authConfigured } = useAuth()
   const [showChangeName, setShowChangeName] = useState(false)
   const needsNamePrompt = !userData.displayName && !userData.nameSkipped
   const todayStr = getTodayPST()
@@ -25,6 +32,33 @@ export function TriviaLanding({
 
   return (
     <div className="flex flex-col items-center gap-6 max-w-lg mx-auto py-8">
+      <div className="w-full flex justify-end min-h-[1.25rem] text-sm">
+        {!authConfigured ? null : authLoading ? null : user ? (
+          <div className="flex items-center gap-2 text-cream-white/70">
+            {user.photoURL && (
+              <Image
+                src={user.photoURL}
+                alt=""
+                width={24}
+                height={24}
+                className="rounded-full"
+                unoptimized
+              />
+            )}
+            <span className="text-cream-white/80 truncate max-w-[10rem]">
+              {user.displayName ?? user.email}
+            </span>
+          </div>
+        ) : (
+          <Link
+            href="/auth?redirect=/trivia"
+            className="text-space-gold/80 hover:text-space-gold underline-offset-4 hover:underline transition-colors"
+          >
+            Sign in
+          </Link>
+        )}
+      </div>
+
       <div className="text-center">
         <h1 className="text-4xl font-bold text-space-gold mb-2">Daily Trivia</h1>
         <p className="text-cream-white/70 text-lg">{formatDisplayDate(todayStr)}</p>

--- a/src/app/trivia/hooks/useAuth.tsx
+++ b/src/app/trivia/hooks/useAuth.tsx
@@ -1,0 +1,90 @@
+'use client'
+
+import {
+  GoogleAuthProvider,
+  type User,
+  createUserWithEmailAndPassword,
+  signOut as firebaseSignOut,
+  onAuthStateChanged,
+  signInWithEmailAndPassword,
+  signInWithPopup,
+} from 'firebase/auth'
+import { type ReactNode, createContext, useContext, useEffect, useState } from 'react'
+
+import { getFirebaseAuth, isFirebaseAuthConfigured } from '@/app/trivia/lib/firebaseClient'
+
+interface AuthContextValue {
+  user: User | null
+  loading: boolean
+  configured: boolean
+  signInWithGoogle: () => Promise<void>
+  signInWithEmail: (email: string, password: string) => Promise<void>
+  signUpWithEmail: (email: string, password: string) => Promise<void>
+  signOut: () => Promise<void>
+}
+
+const AuthContext = createContext<AuthContextValue | null>(null)
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+  const [user, setUser] = useState<User | null>(null)
+  const [loading, setLoading] = useState(true)
+  const configured = isFirebaseAuthConfigured()
+
+  useEffect(() => {
+    if (!configured) {
+      setLoading(false)
+      return
+    }
+    const auth = getFirebaseAuth()
+    const unsub = onAuthStateChanged(auth, (u) => {
+      setUser(u)
+      setLoading(false)
+    })
+    return () => unsub()
+  }, [configured])
+
+  const signInWithGoogle = async () => {
+    const auth = getFirebaseAuth()
+    const provider = new GoogleAuthProvider()
+    await signInWithPopup(auth, provider)
+  }
+
+  const signInWithEmail = async (email: string, password: string) => {
+    const auth = getFirebaseAuth()
+    await signInWithEmailAndPassword(auth, email, password)
+  }
+
+  const signUpWithEmail = async (email: string, password: string) => {
+    const auth = getFirebaseAuth()
+    await createUserWithEmailAndPassword(auth, email, password)
+  }
+
+  const signOut = async () => {
+    const auth = getFirebaseAuth()
+    await firebaseSignOut(auth)
+  }
+
+  return (
+    <AuthContext.Provider
+      value={{
+        user,
+        loading,
+        configured,
+        signInWithGoogle,
+        signInWithEmail,
+        signUpWithEmail,
+        signOut,
+      }}
+    >
+      {children}
+    </AuthContext.Provider>
+  )
+}
+
+export function useAuth(): AuthContextValue {
+  const ctx = useContext(AuthContext)
+  if (!ctx) {
+    throw new Error('useAuth must be used within an AuthProvider')
+  }
+  return ctx
+}

--- a/src/app/trivia/layout.tsx
+++ b/src/app/trivia/layout.tsx
@@ -1,0 +1,7 @@
+import { AuthProvider } from '@/app/trivia/hooks/useAuth'
+
+import type { ReactNode } from 'react'
+
+export default function TriviaLayout({ children }: { children: ReactNode }) {
+  return <AuthProvider>{children}</AuthProvider>
+}

--- a/src/app/trivia/lib/firebaseClient.ts
+++ b/src/app/trivia/lib/firebaseClient.ts
@@ -1,0 +1,32 @@
+import { type FirebaseApp, getApps, initializeApp } from 'firebase/app'
+import { type Auth, getAuth } from 'firebase/auth'
+
+const firebaseConfig = {
+  apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY,
+  authDomain: process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN,
+  projectId: process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID,
+}
+
+let _app: FirebaseApp | null = null
+let _auth: Auth | null = null
+
+export function isFirebaseAuthConfigured(): boolean {
+  return Boolean(firebaseConfig.apiKey && firebaseConfig.authDomain && firebaseConfig.projectId)
+}
+
+function getApp(): FirebaseApp {
+  if (_app) return _app
+  _app = getApps()[0] ?? initializeApp(firebaseConfig)
+  return _app
+}
+
+export function getFirebaseAuth(): Auth {
+  if (_auth) return _auth
+  if (!isFirebaseAuthConfigured()) {
+    throw new Error(
+      'Firebase client config missing. Set NEXT_PUBLIC_FIREBASE_API_KEY, NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN, and NEXT_PUBLIC_FIREBASE_PROJECT_ID.'
+    )
+  }
+  _auth = getAuth(getApp())
+  return _auth
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -927,10 +927,86 @@
   resolved "https://registry.yarnpkg.com/@fastify/busboy/-/busboy-3.2.0.tgz#13ed8212f3b9ba697611529d15347f8528058cea"
   integrity sha512-m9FVDXU3GT2ITSe0UaMA5rU3QkfC/UXtCU8y0gSN/GugTqtVldOBWIB5V6V3sbmenVZUIpU6f+mPEO2+m5iTaA==
 
+"@firebase/ai@2.11.1":
+  version "2.11.1"
+  resolved "https://registry.yarnpkg.com/@firebase/ai/-/ai-2.11.1.tgz#a78c8d8a8acc5261fb2e0fa0216209b43a57c6dc"
+  integrity sha512-WGTF81W3WBKJY+c7xqTzO15OGAkCAs8cpADqflAI0skhTZjIkhF0qyf55rq4Ctt6jKygkv99rPfMrjAHTgXaVQ==
+  dependencies:
+    "@firebase/app-check-interop-types" "0.3.3"
+    "@firebase/component" "0.7.2"
+    "@firebase/logger" "0.5.0"
+    "@firebase/util" "1.15.0"
+    tslib "^2.1.0"
+
+"@firebase/analytics-compat@0.2.27":
+  version "0.2.27"
+  resolved "https://registry.yarnpkg.com/@firebase/analytics-compat/-/analytics-compat-0.2.27.tgz#58ef74a91930267923577f07ca371182d9f7ce2e"
+  integrity sha512-ZObpYpAxL6JfgH7GnvlDD0sbzGZ0o4nijV8skatV9ZX49hJtCYbFqaEcPYptT94rgX1KUoKEderC7/fa7hybtw==
+  dependencies:
+    "@firebase/analytics" "0.10.21"
+    "@firebase/analytics-types" "0.8.3"
+    "@firebase/component" "0.7.2"
+    "@firebase/util" "1.15.0"
+    tslib "^2.1.0"
+
+"@firebase/analytics-types@0.8.3":
+  version "0.8.3"
+  resolved "https://registry.yarnpkg.com/@firebase/analytics-types/-/analytics-types-0.8.3.tgz#d08cd39a6209693ca2039ba7a81570dfa6c1518f"
+  integrity sha512-VrIp/d8iq2g501qO46uGz3hjbDb8xzYMrbu8Tp0ovzIzrvJZ2fvmj649gTjge/b7cCCcjT0H37g1gVtlNhnkbg==
+
+"@firebase/analytics@0.10.21":
+  version "0.10.21"
+  resolved "https://registry.yarnpkg.com/@firebase/analytics/-/analytics-0.10.21.tgz#109d95d287acefe3d8276835291dbbcf4688c18c"
+  integrity sha512-j2y2q65BlgLGB5Pwjhv/Jopw2X/TBTzvAtI5z/DSp56U4wBj7LfhBfzbdCtFPges+Wz0g55GdoawXibOH5jGng==
+  dependencies:
+    "@firebase/component" "0.7.2"
+    "@firebase/installations" "0.6.21"
+    "@firebase/logger" "0.5.0"
+    "@firebase/util" "1.15.0"
+    tslib "^2.1.0"
+
+"@firebase/app-check-compat@0.4.2":
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/@firebase/app-check-compat/-/app-check-compat-0.4.2.tgz#c0b3808ebe9a366d3b2cba295eb7a1587de66314"
+  integrity sha512-M91NhxqbSkI0ChkJWy69blC+rPr6HEgaeRllddSaU1pQ/7IiegeCQM9pPDIgvWnwnBSzKhUHpe6ro/jhJ+cvzw==
+  dependencies:
+    "@firebase/app-check" "0.11.2"
+    "@firebase/app-check-types" "0.5.3"
+    "@firebase/component" "0.7.2"
+    "@firebase/logger" "0.5.0"
+    "@firebase/util" "1.15.0"
+    tslib "^2.1.0"
+
 "@firebase/app-check-interop-types@0.3.3":
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/@firebase/app-check-interop-types/-/app-check-interop-types-0.3.3.tgz#ed9c4a4f48d1395ef378f007476db3940aa5351a"
   integrity sha512-gAlxfPLT2j8bTI/qfe3ahl2I2YcBQ8cFIBdhAQA4I2f3TndcO+22YizyGYuttLHPQEpWkhmpFW60VCFEPg4g5A==
+
+"@firebase/app-check-types@0.5.3":
+  version "0.5.3"
+  resolved "https://registry.yarnpkg.com/@firebase/app-check-types/-/app-check-types-0.5.3.tgz#38ba954acf4bffe451581a32fffa20337f11d8e5"
+  integrity sha512-hyl5rKSj0QmwPdsAxrI5x1otDlByQ7bvNvVt8G/XPO2CSwE++rmSVf3VEhaeOR4J8ZFaF0Z0NDSmLejPweZ3ng==
+
+"@firebase/app-check@0.11.2":
+  version "0.11.2"
+  resolved "https://registry.yarnpkg.com/@firebase/app-check/-/app-check-0.11.2.tgz#c7f771c5222d77a810978081e7b493d3f5e8968f"
+  integrity sha512-jcXQVMHAQ5AEKzVD5C7s5fmAYeFOuN6lAJeNTgZK2B9aLnofWaJt8u1A8Idm8gpsBBYSaY3cVyeH5SWMOVPBLQ==
+  dependencies:
+    "@firebase/component" "0.7.2"
+    "@firebase/logger" "0.5.0"
+    "@firebase/util" "1.15.0"
+    tslib "^2.1.0"
+
+"@firebase/app-compat@0.5.11":
+  version "0.5.11"
+  resolved "https://registry.yarnpkg.com/@firebase/app-compat/-/app-compat-0.5.11.tgz#4cb54f447cb03446465a05d00a71509b5f2ec620"
+  integrity sha512-KaACDjXkK5VLpI01vEs592R7/8s5DjFdIXfKoR385ly1SmK3Tu+jMHCIB4MsiY5jsez6v7VlEX/3rJ90dVkHyA==
+  dependencies:
+    "@firebase/app" "0.14.11"
+    "@firebase/component" "0.7.2"
+    "@firebase/logger" "0.5.0"
+    "@firebase/util" "1.15.0"
+    tslib "^2.1.0"
 
 "@firebase/app-types@0.9.4":
   version "0.9.4"
@@ -939,10 +1015,47 @@
   dependencies:
     "@firebase/logger" "0.5.0"
 
+"@firebase/app@0.14.11":
+  version "0.14.11"
+  resolved "https://registry.yarnpkg.com/@firebase/app/-/app-0.14.11.tgz#150f5f98299c24569fab8fbbffb7295075f526d7"
+  integrity sha512-yxADFW35LYkP8oSGobGsYIrI42I+GPCvKTNHx4meT9Yq3C950IVz1eANoBk822I9tbKv1wyv9P4Bv1G5TpucFw==
+  dependencies:
+    "@firebase/component" "0.7.2"
+    "@firebase/logger" "0.5.0"
+    "@firebase/util" "1.15.0"
+    idb "7.1.1"
+    tslib "^2.1.0"
+
+"@firebase/auth-compat@0.6.5":
+  version "0.6.5"
+  resolved "https://registry.yarnpkg.com/@firebase/auth-compat/-/auth-compat-0.6.5.tgz#d12d27a4c2230d3ee32ef5c200ebd3b9108528ca"
+  integrity sha512-IfVsafZ3QiXbsydXTP/XMI0wVYbJLI1rkb8Qqf03/h5FnL+upbbPOb+6Yj3RpcX+Y1iP5Uh18lxTHlXfbiyAow==
+  dependencies:
+    "@firebase/auth" "1.13.0"
+    "@firebase/auth-types" "0.13.0"
+    "@firebase/component" "0.7.2"
+    "@firebase/util" "1.15.0"
+    tslib "^2.1.0"
+
 "@firebase/auth-interop-types@0.2.4":
   version "0.2.4"
   resolved "https://registry.yarnpkg.com/@firebase/auth-interop-types/-/auth-interop-types-0.2.4.tgz#176a08686b0685596ff03d7879b7e4115af53de0"
   integrity sha512-JPgcXKCuO+CWqGDnigBtvo09HeBs5u/Ktc2GaFj2m01hLarbxthLNm7Fk8iOP1aqAtXV+fnnGj7U28xmk7IwVA==
+
+"@firebase/auth-types@0.13.0":
+  version "0.13.0"
+  resolved "https://registry.yarnpkg.com/@firebase/auth-types/-/auth-types-0.13.0.tgz#ae6e0015e3bd4bfe18edd0942b48a0a118a098d9"
+  integrity sha512-S/PuIjni0AQRLF+l9ck0YpsMOdE8GO2KU6ubmBB7P+7TJUCQDa3R1dlgYm9UzGbbePMZsp0xzB93f2b/CgxMOg==
+
+"@firebase/auth@1.13.0":
+  version "1.13.0"
+  resolved "https://registry.yarnpkg.com/@firebase/auth/-/auth-1.13.0.tgz#da83853b465c1ab4b638e542d78df6b3c4855a15"
+  integrity sha512-mKkSLNym3UbnnZ06dAmtqzp5EpPGCANGCZDJbkoR135aoUdKG6Aizwcnp29RzsQpwH0nmy5nay17Sfbsh9oY8A==
+  dependencies:
+    "@firebase/component" "0.7.2"
+    "@firebase/logger" "0.5.0"
+    "@firebase/util" "1.15.0"
+    tslib "^2.1.0"
 
 "@firebase/component@0.7.2":
   version "0.7.2"
@@ -952,7 +1065,18 @@
     "@firebase/util" "1.15.0"
     tslib "^2.1.0"
 
-"@firebase/database-compat@^2.0.0":
+"@firebase/data-connect@0.6.0":
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/@firebase/data-connect/-/data-connect-0.6.0.tgz#c4581d13685eccac724895b8c7292df4a24cd334"
+  integrity sha512-OiugPRcdlhqXF97oR9CjVObILmsWU0dFUS0gXNYEe4bDfpW8pZmQ5GqhIPPtLWbT/0W2lMJJD7VILFMk+xuHPg==
+  dependencies:
+    "@firebase/auth-interop-types" "0.2.4"
+    "@firebase/component" "0.7.2"
+    "@firebase/logger" "0.5.0"
+    "@firebase/util" "1.15.0"
+    tslib "^2.1.0"
+
+"@firebase/database-compat@2.1.3", "@firebase/database-compat@^2.0.0":
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/@firebase/database-compat/-/database-compat-2.1.3.tgz#19a512209afbba9710d7febc52cd875e1b239e3c"
   integrity sha512-GMyfWjD8mehjg/QpNkY/tl9G/MoeugPeg91n9D0atggxbWuKF/2KhVPHZDH+XmoP0EKYqMWYTtKxBsaBaNKLYQ==
@@ -985,11 +1109,203 @@
     faye-websocket "0.11.4"
     tslib "^2.1.0"
 
+"@firebase/firestore-compat@0.4.8":
+  version "0.4.8"
+  resolved "https://registry.yarnpkg.com/@firebase/firestore-compat/-/firestore-compat-0.4.8.tgz#00651c9d01f940d9906b34ae2cc4229527f4b7f8"
+  integrity sha512-WK9NJRpnosGD2nuyjdr7K+Ht7AxRYJlTF62myI4rRA7ibJOosbecvjacR5oirJ7s1BgNS6qzcBw7n4fD3a5w1w==
+  dependencies:
+    "@firebase/component" "0.7.2"
+    "@firebase/firestore" "4.14.0"
+    "@firebase/firestore-types" "3.0.3"
+    "@firebase/util" "1.15.0"
+    tslib "^2.1.0"
+
+"@firebase/firestore-types@3.0.3":
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/@firebase/firestore-types/-/firestore-types-3.0.3.tgz#7d0c3dd8850c0193d8f5ee0cc8f11961407742c1"
+  integrity sha512-hD2jGdiWRxB/eZWF89xcK9gF8wvENDJkzpVFb4aGkzfEaKxVRD1kjz1t1Wj8VZEp2LCB53Yx1zD8mrhQu87R6Q==
+
+"@firebase/firestore@4.14.0":
+  version "4.14.0"
+  resolved "https://registry.yarnpkg.com/@firebase/firestore/-/firestore-4.14.0.tgz#a17801fe2e8a0095fc655d38cd791c4a48058cb4"
+  integrity sha512-bZc6YOjRkMBVA16527tgzi6iN9n//xRB3Mmx/R+Gr6UAP/+xrIKOejQIcn1hh+tCzNT8jO0jI+kWox5J4tB/qQ==
+  dependencies:
+    "@firebase/component" "0.7.2"
+    "@firebase/logger" "0.5.0"
+    "@firebase/util" "1.15.0"
+    "@firebase/webchannel-wrapper" "1.0.5"
+    "@grpc/grpc-js" "~1.9.0"
+    "@grpc/proto-loader" "^0.7.8"
+    tslib "^2.1.0"
+
+"@firebase/functions-compat@0.4.3":
+  version "0.4.3"
+  resolved "https://registry.yarnpkg.com/@firebase/functions-compat/-/functions-compat-0.4.3.tgz#bb7e5b8330143db594466c1140267799cf41680d"
+  integrity sha512-BxkEwWgx1of0tKaao/r2VR6WBLk/RAiyztatiONPrPE8gkitFkOnOCxf8i9cUyA5hX5RGt5H30uNn25Q6QNEmQ==
+  dependencies:
+    "@firebase/component" "0.7.2"
+    "@firebase/functions" "0.13.3"
+    "@firebase/functions-types" "0.6.3"
+    "@firebase/util" "1.15.0"
+    tslib "^2.1.0"
+
+"@firebase/functions-types@0.6.3":
+  version "0.6.3"
+  resolved "https://registry.yarnpkg.com/@firebase/functions-types/-/functions-types-0.6.3.tgz#f5faf770248b13f45d256f614230da6a11bfb654"
+  integrity sha512-EZoDKQLUHFKNx6VLipQwrSMh01A1SaL3Wg6Hpi//x6/fJ6Ee4hrAeswK99I5Ht8roiniKHw4iO0B1Oxj5I4plg==
+
+"@firebase/functions@0.13.3":
+  version "0.13.3"
+  resolved "https://registry.yarnpkg.com/@firebase/functions/-/functions-0.13.3.tgz#e923cb6f6763531cbe909253155920abb4105f04"
+  integrity sha512-csO7ckK3SSs+NUZW1nms9EK7ckHe/1QOjiP8uAkCYa7ND18s44vjE9g3KxEeIUpyEPqZaX1EhJuFyZjHigAcYw==
+  dependencies:
+    "@firebase/app-check-interop-types" "0.3.3"
+    "@firebase/auth-interop-types" "0.2.4"
+    "@firebase/component" "0.7.2"
+    "@firebase/messaging-interop-types" "0.2.3"
+    "@firebase/util" "1.15.0"
+    tslib "^2.1.0"
+
+"@firebase/installations-compat@0.2.21":
+  version "0.2.21"
+  resolved "https://registry.yarnpkg.com/@firebase/installations-compat/-/installations-compat-0.2.21.tgz#c00e1e1b3957aff0957cff80a776109895328c54"
+  integrity sha512-zahIUkaVKbR8zmTeBHkdfaVl6JGWlhVoSjF7CVH33nFqD3SlPEpEEegn2GNT5iAfsVdtlCyJJ9GW4YKjq+RJKQ==
+  dependencies:
+    "@firebase/component" "0.7.2"
+    "@firebase/installations" "0.6.21"
+    "@firebase/installations-types" "0.5.3"
+    "@firebase/util" "1.15.0"
+    tslib "^2.1.0"
+
+"@firebase/installations-types@0.5.3":
+  version "0.5.3"
+  resolved "https://registry.yarnpkg.com/@firebase/installations-types/-/installations-types-0.5.3.tgz#cac8a14dd49f09174da9df8ae453f9b359c3ef2f"
+  integrity sha512-2FJI7gkLqIE0iYsNQ1P751lO3hER+Umykel+TkLwHj6plzWVxqvfclPUZhcKFVQObqloEBTmpi2Ozn7EkCABAA==
+
+"@firebase/installations@0.6.21":
+  version "0.6.21"
+  resolved "https://registry.yarnpkg.com/@firebase/installations/-/installations-0.6.21.tgz#38c9a5487c7ccc7dd4328736556afad8eebf453e"
+  integrity sha512-xGFGTeICJZ5vhrmmDukeczIcFULFXybojML2+QSDFoKj5A7zbGN7KzFGSKNhDkIxpjzsYG9IleJyUebuAcmqWA==
+  dependencies:
+    "@firebase/component" "0.7.2"
+    "@firebase/util" "1.15.0"
+    idb "7.1.1"
+    tslib "^2.1.0"
+
 "@firebase/logger@0.5.0":
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/@firebase/logger/-/logger-0.5.0.tgz#a9e55b1c669a0983dc67127fa4a5964ce8ed5e1b"
   integrity sha512-cGskaAvkrnh42b3BA3doDWeBmuHFO/Mx5A83rbRDYakPjO9bJtRL3dX7javzc2Rr/JHZf4HlterTW2lUkfeN4g==
   dependencies:
+    tslib "^2.1.0"
+
+"@firebase/messaging-compat@0.2.25":
+  version "0.2.25"
+  resolved "https://registry.yarnpkg.com/@firebase/messaging-compat/-/messaging-compat-0.2.25.tgz#1fd6f317d303dfab57ec51409eb41c89080f2dd6"
+  integrity sha512-eoOQqGLtRlseTdiemTN44LlHZpltK5gnhq8XVUuLgtIOG+odtDzrz2UoTpcJWSzaJQVxNLb/x9f39tHdDM4N4w==
+  dependencies:
+    "@firebase/component" "0.7.2"
+    "@firebase/messaging" "0.12.25"
+    "@firebase/util" "1.15.0"
+    tslib "^2.1.0"
+
+"@firebase/messaging-interop-types@0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@firebase/messaging-interop-types/-/messaging-interop-types-0.2.3.tgz#e647c9cd1beecfe6a6e82018a6eec37555e4da3e"
+  integrity sha512-xfzFaJpzcmtDjycpDeCUj0Ge10ATFi/VHVIvEEjDNc3hodVBQADZ7BWQU7CuFpjSHE+eLuBI13z5F/9xOoGX8Q==
+
+"@firebase/messaging@0.12.25":
+  version "0.12.25"
+  resolved "https://registry.yarnpkg.com/@firebase/messaging/-/messaging-0.12.25.tgz#465135006a5d728efaeea1d35790f0e6e20a3e54"
+  integrity sha512-7RhDwoDHlOK1/ou0/LeubxmjcngsTjDdrY/ssg2vwAVpUuVAhQzQvuCAOYxcX5wNC1zCgQ54AP1vdngBwbCmOQ==
+  dependencies:
+    "@firebase/component" "0.7.2"
+    "@firebase/installations" "0.6.21"
+    "@firebase/messaging-interop-types" "0.2.3"
+    "@firebase/util" "1.15.0"
+    idb "7.1.1"
+    tslib "^2.1.0"
+
+"@firebase/performance-compat@0.2.24":
+  version "0.2.24"
+  resolved "https://registry.yarnpkg.com/@firebase/performance-compat/-/performance-compat-0.2.24.tgz#1c970640119a8839f7447f624de365f150f21399"
+  integrity sha512-YRlejH8wLt7ThWao+HXoKUHUrZKGYq+otxkPS+8nuE5PeN1cBXX7NAJl9ueuUkBwMIrnKdnDqL/voHXxDAAt3g==
+  dependencies:
+    "@firebase/component" "0.7.2"
+    "@firebase/logger" "0.5.0"
+    "@firebase/performance" "0.7.11"
+    "@firebase/performance-types" "0.2.3"
+    "@firebase/util" "1.15.0"
+    tslib "^2.1.0"
+
+"@firebase/performance-types@0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@firebase/performance-types/-/performance-types-0.2.3.tgz#5ce64e90fa20ab5561f8b62a305010cf9fab86fb"
+  integrity sha512-IgkyTz6QZVPAq8GSkLYJvwSLr3LS9+V6vNPQr0x4YozZJiLF5jYixj0amDtATf1X0EtYHqoPO48a9ija8GocxQ==
+
+"@firebase/performance@0.7.11":
+  version "0.7.11"
+  resolved "https://registry.yarnpkg.com/@firebase/performance/-/performance-0.7.11.tgz#238a805f78c5411f1d41c4cdba7854ca4115a1b7"
+  integrity sha512-V3uAhrz7IYJuji+OgT3qYTGKxpek/TViXti9OSsUJ4AexZ3jQjYH5Yrn7JvBxk8MGiSLsC872hh+BxQiPZsm7g==
+  dependencies:
+    "@firebase/component" "0.7.2"
+    "@firebase/installations" "0.6.21"
+    "@firebase/logger" "0.5.0"
+    "@firebase/util" "1.15.0"
+    tslib "^2.1.0"
+    web-vitals "^4.2.4"
+
+"@firebase/remote-config-compat@0.2.23":
+  version "0.2.23"
+  resolved "https://registry.yarnpkg.com/@firebase/remote-config-compat/-/remote-config-compat-0.2.23.tgz#3614d83c1f22c68152793bbbf6965715e1716d07"
+  integrity sha512-4+KqRRHEUUmKT6tFmnpWATOsaFfmSuBs1jXH8JzVtMLEYqq/WS9IDM92OdefFDSrAA2xGd0WN004z8mKeIIscw==
+  dependencies:
+    "@firebase/component" "0.7.2"
+    "@firebase/logger" "0.5.0"
+    "@firebase/remote-config" "0.8.2"
+    "@firebase/remote-config-types" "0.5.0"
+    "@firebase/util" "1.15.0"
+    tslib "^2.1.0"
+
+"@firebase/remote-config-types@0.5.0":
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/@firebase/remote-config-types/-/remote-config-types-0.5.0.tgz#f0f503b32edda3384f5252f9900cd9613adbb99c"
+  integrity sha512-vI3bqLoF14L/GchtgayMiFpZJF+Ao3uR8WCde0XpYNkSokDpAKca2DxvcfeZv7lZUqkUwQPL2wD83d3vQ4vvrg==
+
+"@firebase/remote-config@0.8.2":
+  version "0.8.2"
+  resolved "https://registry.yarnpkg.com/@firebase/remote-config/-/remote-config-0.8.2.tgz#389d2b01d4d877c6cb13bf85692dfda45d61fe6d"
+  integrity sha512-5EXqOThV4upjK9D38d/qOSVwOqRhemlaOFk9vCkMNNALeIlwr+4pLjtLNo4qoY8etQmU/1q4aIATE9N8PFqg0g==
+  dependencies:
+    "@firebase/component" "0.7.2"
+    "@firebase/installations" "0.6.21"
+    "@firebase/logger" "0.5.0"
+    "@firebase/util" "1.15.0"
+    tslib "^2.1.0"
+
+"@firebase/storage-compat@0.4.2":
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/@firebase/storage-compat/-/storage-compat-0.4.2.tgz#866e3bfc4533510bc1d6207d10e9ef5748359cf4"
+  integrity sha512-R+aB38wxCH5zjIO/xu9KznI7fgiPuZAG98uVm1NcidHyyupGgIDLKigGmRGBZMnxibe/m2oxNKoZpfEbUX2aQQ==
+  dependencies:
+    "@firebase/component" "0.7.2"
+    "@firebase/storage" "0.14.2"
+    "@firebase/storage-types" "0.8.3"
+    "@firebase/util" "1.15.0"
+    tslib "^2.1.0"
+
+"@firebase/storage-types@0.8.3":
+  version "0.8.3"
+  resolved "https://registry.yarnpkg.com/@firebase/storage-types/-/storage-types-0.8.3.tgz#2531ef593a3452fc12c59117195d6485c6632d3d"
+  integrity sha512-+Muk7g9uwngTpd8xn9OdF/D48uiQ7I1Fae7ULsWPuKoCH3HU7bfFPhxtJYzyhjdniowhuDpQcfPmuNRAqZEfvg==
+
+"@firebase/storage@0.14.2":
+  version "0.14.2"
+  resolved "https://registry.yarnpkg.com/@firebase/storage/-/storage-0.14.2.tgz#476bad2594ad26487b232620f0a23991d65ab69a"
+  integrity sha512-o/culaTeJ8GRpKXRJov21rux/n9dRaSOWLebyatFP2sqEdCxQPjVA1H9Z2fzYwQxMIU0JVmC7SPPmU11v7L6vQ==
+  dependencies:
+    "@firebase/component" "0.7.2"
+    "@firebase/util" "1.15.0"
     tslib "^2.1.0"
 
 "@firebase/util@1.15.0":
@@ -998,6 +1314,11 @@
   integrity sha512-AmWf3cHAOMbrCPG4xdPKQaj5iHnyYfyLKZxwz+Xf55bqKbpAmcYifB4jQinT2W9XhDRHISOoPyBOariJpCG6FA==
   dependencies:
     tslib "^2.1.0"
+
+"@firebase/webchannel-wrapper@1.0.5":
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/@firebase/webchannel-wrapper/-/webchannel-wrapper-1.0.5.tgz#39cf5a600450cb42f1f0b507cc385459bf103b27"
+  integrity sha512-+uGNN7rkfn41HLO0vekTFhTxk61eKa8mTpRGLO0QSqlQdKvIoGAvLp3ppdVIWbTGYJWM6Kp0iN+PjMIOcnVqTw==
 
 "@floating-ui/core@^1.6.0":
   version "1.6.9"
@@ -1084,7 +1405,15 @@
     "@grpc/proto-loader" "^0.8.0"
     "@js-sdsl/ordered-map" "^4.4.2"
 
-"@grpc/proto-loader@^0.7.13":
+"@grpc/grpc-js@~1.9.0":
+  version "1.9.15"
+  resolved "https://registry.yarnpkg.com/@grpc/grpc-js/-/grpc-js-1.9.15.tgz#433d7ac19b1754af690ea650ab72190bd700739b"
+  integrity sha512-nqE7Hc0AzI+euzUwDAy0aY5hCp10r734gMGRdU+qOPX0XSceI2ULrcXB5U2xSc5VkWwalCj4M7GzCAygZl2KoQ==
+  dependencies:
+    "@grpc/proto-loader" "^0.7.8"
+    "@types/node" ">=12.12.47"
+
+"@grpc/proto-loader@^0.7.13", "@grpc/proto-loader@^0.7.8":
   version "0.7.15"
   resolved "https://registry.yarnpkg.com/@grpc/proto-loader/-/proto-loader-0.7.15.tgz#4cdfbf35a35461fc843abe8b9e2c0770b5095e60"
   integrity sha512-tMXdRCfYVixjuFK+Hk0Q1s38gV9zDiDJfWL3h1rv4Qc39oILCu1TRTDt7+fGUI8K4G1Fj125Hx/ru3azECWTyQ==
@@ -2786,7 +3115,7 @@
   dependencies:
     undici-types "~6.21.0"
 
-"@types/node@>=13.7.0":
+"@types/node@>=12.12.47", "@types/node@>=13.7.0":
   version "25.6.0"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-25.6.0.tgz#4e09bad9b469871f2d0f68140198cbd714f4edca"
   integrity sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==
@@ -4882,6 +5211,40 @@ firebase-admin@^13.8.0:
     "@google-cloud/firestore" "^7.11.0"
     "@google-cloud/storage" "^7.19.0"
 
+firebase@^12.12.1:
+  version "12.12.1"
+  resolved "https://registry.yarnpkg.com/firebase/-/firebase-12.12.1.tgz#4c5145ce819509b1e547d27aef584ab719809d29"
+  integrity sha512-ee7xA+bTJLfjB9BP/8FQr3EkxmpAAGc1lNc5QkWgTDpUw24HYXFPm7FEWRdLtGnygxIdYpFmepSc5VjkI6NHhw==
+  dependencies:
+    "@firebase/ai" "2.11.1"
+    "@firebase/analytics" "0.10.21"
+    "@firebase/analytics-compat" "0.2.27"
+    "@firebase/app" "0.14.11"
+    "@firebase/app-check" "0.11.2"
+    "@firebase/app-check-compat" "0.4.2"
+    "@firebase/app-compat" "0.5.11"
+    "@firebase/app-types" "0.9.4"
+    "@firebase/auth" "1.13.0"
+    "@firebase/auth-compat" "0.6.5"
+    "@firebase/data-connect" "0.6.0"
+    "@firebase/database" "1.1.2"
+    "@firebase/database-compat" "2.1.3"
+    "@firebase/firestore" "4.14.0"
+    "@firebase/firestore-compat" "0.4.8"
+    "@firebase/functions" "0.13.3"
+    "@firebase/functions-compat" "0.4.3"
+    "@firebase/installations" "0.6.21"
+    "@firebase/installations-compat" "0.2.21"
+    "@firebase/messaging" "0.12.25"
+    "@firebase/messaging-compat" "0.2.25"
+    "@firebase/performance" "0.7.11"
+    "@firebase/performance-compat" "0.2.24"
+    "@firebase/remote-config" "0.8.2"
+    "@firebase/remote-config-compat" "0.2.23"
+    "@firebase/storage" "0.14.2"
+    "@firebase/storage-compat" "0.4.2"
+    "@firebase/util" "1.15.0"
+
 flat-cache@^4.0.0:
   version "4.0.1"
   resolved "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz"
@@ -5369,6 +5732,11 @@ iconv-lite@0.6.3:
   integrity sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==
   dependencies:
     safer-buffer ">= 2.1.2 < 3.0.0"
+
+idb@7.1.1:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/idb/-/idb-7.1.1.tgz#d910ded866d32c7ced9befc5bfdf36f572ced72b"
+  integrity sha512-gchesWBzyvGHRO9W8tzUWFDycow5gwjvFKfyV9FF32Y7F50yZMp7mP+T2mJIWFx49zicqyC4uefHM17o6xKIVQ==
 
 ignore@^5.2.0:
   version "5.3.2"
@@ -8542,6 +8910,11 @@ web-streams-polyfill@^3.0.3:
   version "3.3.3"
   resolved "https://registry.yarnpkg.com/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz#2073b91a2fdb1fbfbd401e7de0ac9f8214cecb4b"
   integrity sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==
+
+web-vitals@^4.2.4:
+  version "4.2.4"
+  resolved "https://registry.yarnpkg.com/web-vitals/-/web-vitals-4.2.4.tgz#1d20bc8590a37769bd0902b289550936069184b7"
+  integrity sha512-r4DIlprAGwJ7YM11VZp4R884m0Vmgr6EAKe3P+kO0PPj3Unqyvv59rczf6UiGcb9Z8QxZVcqKNwv/g0WNdWwsw==
 
 webidl-conversions@^3.0.0:
   version "3.0.1"


### PR DESCRIPTION
Closes #243

## Summary
- Add Firebase client SDK + `firebaseClient.ts` (with `isFirebaseAuthConfigured()` graceful check)
- `useAuth` context: `signInWithGoogle`, `signInWithEmail`, `signUpWithEmail`, `signOut`, wraps `onAuthStateChanged`
- New `/auth` page: Google primary CTA, email/password form, signup toggle, redirect back to `/trivia`
- Trivia route layout wraps the page tree with `<AuthProvider>`
- Trivia landing shows subtle Sign In link top-right (avatar + display name when logged in)

## Production safety
Purely additive. If `NEXT_PUBLIC_FIREBASE_*` env vars aren't set:
- The Sign In link is hidden
- The `/auth` page shows a friendly "Sign-in isn't configured yet" message
- No throws; trivia gameplay/persistence/leaderboard are completely untouched

## Required setup (out of band, not in this PR)
- Firebase Console → Authentication → enable Google + Email/Password providers
- Authorized domains: `cometcave.com`, `www.cometcave.com`, `localhost`
- Set `NEXT_PUBLIC_FIREBASE_API_KEY`, `NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN`, `NEXT_PUBLIC_FIREBASE_PROJECT_ID` in Vercel + `.env.local`

## Test plan
- [x] `yarn typecheck` — no new errors
- [x] `yarn lint` — net −17 errors vs main; 0 lint errors in new files
- [x] `/trivia` renders unchanged when Firebase unconfigured
- [x] `/auth` shows graceful fallback when Firebase unconfigured
- [x] Local sign-in flow tested end-to-end with env vars set (Google sign-in, redirect back to /trivia, avatar shows in header)
- [ ] Verify on Vercel preview after env vars are set
- [ ] Confirm no regression in existing trivia gameplay/persistence/leaderboard

## What does NOT change
- Trivia gameplay (questions, timer, scoring)
- localStorage persistence (still works as before — Phase 3 removes it)
- Leaderboard (still display-name based — Phase 2 migrates to auth-based)
- Stats view, share text

## Blocks
- #244 (Phase 2 — Firestore persistence)
- #245 (Phase 3 — remove localStorage)
- #246 (Phase 4 — login CTAs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)