### PR TITLE
feat: trivia auth phase 2 — Firestore persistence for logged-in users

### DIFF
--- a/src/app/api/v1/trivia/submit-score/route.ts
+++ b/src/app/api/v1/trivia/submit-score/route.ts
@@ -1,26 +1,44 @@
 import { type NextRequest, NextResponse } from 'next/server'
-import { getTodayPST } from '@/app/trivia/lib/triviaUtils'
+
+import { getFirebaseAuthAdmin } from '@/app/trivia/lib/firebase'
 import { submitScore } from '@/app/trivia/lib/leaderboardStore'
+import { getTodayPST } from '@/app/trivia/lib/triviaUtils'
 
 const MAX_SCORE = 3150
 const MAX_NAME_LENGTH = 20
 
+function deriveDisplayName(token: { name?: string; email?: string }): string | null {
+  const candidate = (token.name ?? token.email ?? '').trim()
+  if (!candidate) return null
+  return candidate.slice(0, MAX_NAME_LENGTH)
+}
+
 export async function POST(request: NextRequest) {
   try {
-    const body = await request.json()
-    const { displayName, date, score, correct, total } = body
-
-    // Validation
-    if (!displayName || typeof displayName !== 'string') {
-      return NextResponse.json({ error: 'displayName is required.' }, { status: 400 })
+    const authHeader = request.headers.get('authorization') ?? request.headers.get('Authorization')
+    const match = authHeader?.match(/^Bearer\s+(.+)$/i)
+    if (!match) {
+      return NextResponse.json({ error: 'Authentication required.' }, { status: 401 })
     }
-    const trimmedName = displayName.trim()
-    if (trimmedName.length === 0 || trimmedName.length > MAX_NAME_LENGTH) {
+    const idToken = match[1]
+
+    let decoded: { uid: string; name?: string; email?: string }
+    try {
+      decoded = await getFirebaseAuthAdmin().verifyIdToken(idToken)
+    } catch {
+      return NextResponse.json({ error: 'Invalid auth token.' }, { status: 401 })
+    }
+
+    const displayName = deriveDisplayName(decoded)
+    if (!displayName) {
       return NextResponse.json(
-        { error: `displayName must be 1-${MAX_NAME_LENGTH} characters.` },
+        { error: 'Account is missing a display name. Update your profile and try again.' },
         { status: 400 }
       )
     }
+
+    const body = await request.json()
+    const { date, score, correct, total } = body
 
     if (typeof score !== 'number' || score < 0 || score > MAX_SCORE) {
       return NextResponse.json(
@@ -34,14 +52,11 @@ export async function POST(request: NextRequest) {
     }
 
     if (date !== getTodayPST()) {
-      return NextResponse.json(
-        { error: 'Can only submit scores for today.' },
-        { status: 400 }
-      )
+      return NextResponse.json({ error: 'Can only submit scores for today.' }, { status: 400 })
     }
 
     const result = await submitScore({
-      displayName: trimmedName,
+      displayName,
       date,
       score,
       correct,
@@ -52,13 +67,17 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({
       stored: result.stored,
       previousScore: result.previous?.score ?? null,
+      displayName,
     })
   } catch (error: unknown) {
     console.error('Error submitting score:', error)
-    // Don't block the user if Firestore is temporarily unavailable
     const errMsg = error instanceof Error ? error.message : String(error)
     if (errMsg.includes('FAILED_PRECONDITION') || errMsg.includes('index')) {
-      return NextResponse.json({ stored: false, previousScore: null, notice: 'Leaderboard is initializing.' })
+      return NextResponse.json({
+        stored: false,
+        previousScore: null,
+        notice: 'Leaderboard is initializing.',
+      })
     }
     return NextResponse.json({ error: 'Failed to submit score.' }, { status: 500 })
   }

--- a/src/app/trivia/components/TriviaLanding.tsx
+++ b/src/app/trivia/components/TriviaLanding.tsx
@@ -5,11 +5,11 @@ import Link from 'next/link'
 import { useState } from 'react'
 
 import { useAuth } from '@/app/trivia/hooks/useAuth'
+import { useTriviaStore } from '@/app/trivia/hooks/useTriviaStore'
+import { useTriviaUser } from '@/app/trivia/hooks/useTriviaUser'
+import { formatDisplayDate, getDailyCategory, getTodayPST } from '@/app/trivia/lib/triviaUtils'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
-
-import { useTriviaStore } from '../hooks/useTriviaStore'
-import { formatDisplayDate, getDailyCategory, getTodayPST } from '../lib/triviaUtils'
 
 import { NamePrompt } from './NamePrompt'
 
@@ -22,12 +22,25 @@ export function TriviaLanding({
   onViewStats?: () => void
   onViewLeaderboard?: () => void
 }) {
-  const { userData, canPlayToday, setDisplayName, skipName } = useTriviaStore()
+  const { userData: localUser, canPlayToday: canPlayLocal, setDisplayName, skipName } =
+    useTriviaStore()
+  const {
+    userData: firestoreUser,
+    canPlayToday: canPlayFirestore,
+    loading: firestoreLoading,
+  } = useTriviaUser()
   const { user, loading: authLoading, configured: authConfigured } = useAuth()
   const [showChangeName, setShowChangeName] = useState(false)
-  const needsNamePrompt = !userData.displayName && !userData.nameSkipped
+
+  const stats = user ? firestoreUser.stats : localUser.stats
   const todayStr = getTodayPST()
-  const alreadyPlayed = !canPlayToday()
+  const todayHistoryEntry = user
+    ? firestoreUser.history.find((h) => h.date === todayStr) ?? null
+    : localUser.history.find((h) => h.date === todayStr) ?? null
+  const alreadyPlayed = user ? !canPlayFirestore() : !canPlayLocal()
+  const showNamePrompt = !user && !localUser.displayName && !localUser.nameSkipped
+  const showPlayingAs = !user && !!localUser.displayName
+  const showFirestoreLoadingHint = !!user && firestoreLoading
   const category = getDailyCategory(todayStr)
 
   return (
@@ -73,12 +86,12 @@ export function TriviaLanding({
         </div>
       </div>
 
-      {needsNamePrompt ? (
+      {showNamePrompt ? (
         <NamePrompt onSave={setDisplayName} onSkip={skipName} />
-      ) : userData.displayName && !showChangeName ? (
+      ) : showPlayingAs && !showChangeName ? (
         <div className="w-full text-center text-cream-white/60 text-sm">
           Playing as{' '}
-          <span className="text-space-gold font-semibold">{userData.displayName}</span>
+          <span className="text-space-gold font-semibold">{localUser.displayName}</span>
           {' · '}
           <button
             onClick={() => setShowChangeName(true)}
@@ -90,7 +103,7 @@ export function TriviaLanding({
       ) : showChangeName ? (
         <NamePrompt
           showSkip={false}
-          initialName={userData.displayName ?? ''}
+          initialName={localUser.displayName ?? ''}
           title="Change display name"
           onSave={(name) => { setDisplayName(name); setShowChangeName(false) }}
           onSkip={() => setShowChangeName(false)}
@@ -100,7 +113,11 @@ export function TriviaLanding({
       <Card className="w-full bg-space-dark/80 border-space-grey">
         <CardHeader>
           <CardTitle className="text-cream-white text-center">
-            {alreadyPlayed ? "You've already played today!" : 'Ready to test your knowledge?'}
+            {showFirestoreLoadingHint
+              ? 'Loading your progress…'
+              : alreadyPlayed
+                ? "You've already played today!"
+                : 'Ready to test your knowledge?'}
           </CardTitle>
         </CardHeader>
         <CardContent className="flex flex-col items-center gap-4">
@@ -108,21 +125,20 @@ export function TriviaLanding({
             variant="space"
             size="lg"
             className="w-full text-lg py-6"
-            disabled={alreadyPlayed}
+            disabled={alreadyPlayed || showFirestoreLoadingHint}
             onClick={onStartGame}
           >
             {alreadyPlayed ? 'Come Back Tomorrow' : "Start Today's Trivia"}
           </Button>
 
-          {alreadyPlayed && userData.history.length > 0 && (
+          {alreadyPlayed && todayHistoryEntry && (
             <div className="text-center text-cream-white/60 text-sm">
               Today&apos;s score:{' '}
               <span className="text-space-gold font-semibold">
-                {userData.history[userData.history.length - 1].score} pts
+                {todayHistoryEntry.score} pts
               </span>
               {' · '}
-              {userData.history[userData.history.length - 1].correct}/
-              {userData.history[userData.history.length - 1].total} correct
+              {todayHistoryEntry.correct}/{todayHistoryEntry.total} correct
             </div>
           )}
         </CardContent>
@@ -132,33 +148,27 @@ export function TriviaLanding({
       <div className="grid grid-cols-2 gap-4 w-full">
         <Card className="bg-space-dark/80 border-space-grey">
           <CardContent className="pt-6 text-center">
-            <div className="text-3xl font-bold text-space-gold">
-              {userData.stats.currentStreak}
-            </div>
+            <div className="text-3xl font-bold text-space-gold">{stats.currentStreak}</div>
             <div className="text-cream-white/60 text-sm">Current Streak</div>
           </CardContent>
         </Card>
         <Card className="bg-space-dark/80 border-space-grey">
           <CardContent className="pt-6 text-center">
-            <div className="text-3xl font-bold text-space-purple-light">
-              {userData.stats.bestStreak}
-            </div>
+            <div className="text-3xl font-bold text-space-purple-light">{stats.bestStreak}</div>
             <div className="text-cream-white/60 text-sm">Best Streak</div>
           </CardContent>
         </Card>
         <Card className="bg-space-dark/80 border-space-grey">
           <CardContent className="pt-6 text-center">
-            <div className="text-3xl font-bold text-cream-white">
-              {userData.stats.gamesPlayed}
-            </div>
+            <div className="text-3xl font-bold text-cream-white">{stats.gamesPlayed}</div>
             <div className="text-cream-white/60 text-sm">Games Played</div>
           </CardContent>
         </Card>
         <Card className="bg-space-dark/80 border-space-grey">
           <CardContent className="pt-6 text-center">
             <div className="text-3xl font-bold text-cream-white">
-              {userData.stats.totalQuestions > 0
-                ? Math.round((userData.stats.totalCorrect / userData.stats.totalQuestions) * 100)
+              {stats.totalQuestions > 0
+                ? Math.round((stats.totalCorrect / stats.totalQuestions) * 100)
                 : 0}
               %
             </div>

--- a/src/app/trivia/components/TriviaResults.tsx
+++ b/src/app/trivia/components/TriviaResults.tsx
@@ -1,12 +1,14 @@
 'use client'
 
 import { useEffect, useState } from 'react'
+
+import { useAuth } from '@/app/trivia/hooks/useAuth'
+import { useTriviaStore } from '@/app/trivia/hooks/useTriviaStore'
+import { useTriviaUser } from '@/app/trivia/hooks/useTriviaUser'
+import { formatDisplayDate, getDailyCategory } from '@/app/trivia/lib/triviaUtils'
+import type { TriviaGameResult } from '@/app/trivia/models/trivia'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent } from '@/components/ui/card'
-import { useTriviaStore } from '../hooks/useTriviaStore'
-import { formatDisplayDate, getDailyCategory, getTodayPST } from '../lib/triviaUtils'
-import { NamePrompt } from './NamePrompt'
-import type { TriviaGameResult } from '../models/trivia'
 
 const MAX_SCORE = 3150
 
@@ -89,28 +91,41 @@ interface TriviaResultsProps {
 
 export function TriviaResults({ result, onBack, onViewStats, onViewLeaderboard }: TriviaResultsProps) {
   const [copied, setCopied] = useState(false)
-  const [namePromptDismissed, setNamePromptDismissed] = useState(false)
-  const { userData, setDisplayName } = useTriviaStore()
-  const [scoreSubmitted, setScoreSubmitted] = useState(!!userData.displayName)
+  const { user } = useAuth()
+  const { userData: firestoreUser } = useTriviaUser()
+  const { userData: localUser } = useTriviaStore()
+  const currentStreak = user ? firestoreUser.stats.currentStreak : localUser.stats.currentStreak
+  const [scoreSubmitted, setScoreSubmitted] = useState(false)
   const countdown = useCountdown()
 
   useEffect(() => {
-    if (userData.displayName && !scoreSubmitted) {
-      fetch('/api/v1/trivia/submit-score', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          displayName: userData.displayName,
-          date: result.date,
-          score: result.score,
-          correct: result.correct,
-          total: result.total,
-        }),
-      })
-        .then(() => setScoreSubmitted(true))
-        .catch((err) => console.error('Failed to submit score:', err))
+    if (!user || scoreSubmitted) return
+    let cancelled = false
+    ;(async () => {
+      try {
+        const token = await user.getIdToken()
+        const res = await fetch('/api/v1/trivia/submit-score', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${token}`,
+          },
+          body: JSON.stringify({
+            date: result.date,
+            score: result.score,
+            correct: result.correct,
+            total: result.total,
+          }),
+        })
+        if (!cancelled && res.ok) setScoreSubmitted(true)
+      } catch (err) {
+        console.error('Failed to submit score:', err)
+      }
+    })()
+    return () => {
+      cancelled = true
     }
-  }, [userData.displayName, scoreSubmitted, result])
+  }, [user, scoreSubmitted, result])
   const scorePercent = Math.round((result.score / MAX_SCORE) * 100)
   const correctPercent = result.total > 0 ? Math.round((result.correct / result.total) * 100) : 0
 
@@ -168,9 +183,7 @@ export function TriviaResults({ result, onBack, onViewStats, onViewLeaderboard }
               <div className="text-cream-white/50 text-xs">Accuracy</div>
             </div>
             <div className="text-center">
-              <div className="text-xl font-bold text-space-gold">
-                {userData.stats.currentStreak}
-              </div>
+              <div className="text-xl font-bold text-space-gold">{currentStreak}</div>
               <div className="text-cream-white/50 text-xs">Streak</div>
             </div>
           </div>
@@ -241,19 +254,7 @@ export function TriviaResults({ result, onBack, onViewStats, onViewLeaderboard }
         {copied ? 'Copied!' : 'Share Score'}
       </Button>
 
-      {!userData.displayName && !namePromptDismissed && (
-        <NamePrompt
-          title="Join the leaderboard?"
-          description="Set a display name to save your score"
-          onSave={(name) => {
-            setDisplayName(name)
-            setNamePromptDismissed(true)
-          }}
-          onSkip={() => setNamePromptDismissed(true)}
-        />
-      )}
-
-      {scoreSubmitted && userData.displayName && (
+      {scoreSubmitted && (
         <div className="text-center text-green-400/70 text-sm">
           Score submitted to leaderboard
         </div>

--- a/src/app/trivia/components/TriviaStats.tsx
+++ b/src/app/trivia/components/TriviaStats.tsx
@@ -1,9 +1,11 @@
 'use client'
 
+import { useAuth } from '@/app/trivia/hooks/useAuth'
+import { useTriviaStore } from '@/app/trivia/hooks/useTriviaStore'
+import { useTriviaUser } from '@/app/trivia/hooks/useTriviaUser'
+import { formatDisplayDate } from '@/app/trivia/lib/triviaUtils'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent } from '@/components/ui/card'
-import { useTriviaStore } from '../hooks/useTriviaStore'
-import { formatDisplayDate } from '../lib/triviaUtils'
 
 const MAX_SCORE_PER_GAME = 3150
 
@@ -14,8 +16,11 @@ function getAccuracyColor(accuracy: number): string {
 }
 
 export function TriviaStats({ onBack }: { onBack: () => void }) {
-  const { userData } = useTriviaStore()
-  const { stats, history } = userData
+  const { user } = useAuth()
+  const { userData: localUser } = useTriviaStore()
+  const { userData: firestoreUser } = useTriviaUser()
+  const stats = user ? firestoreUser.stats : localUser.stats
+  const history = user ? firestoreUser.history : localUser.history
 
   const accuracy =
     stats.totalQuestions > 0

--- a/src/app/trivia/hooks/useAuth.tsx
+++ b/src/app/trivia/hooks/useAuth.tsx
@@ -26,15 +26,12 @@ interface AuthContextValue {
 const AuthContext = createContext<AuthContextValue | null>(null)
 
 export function AuthProvider({ children }: { children: ReactNode }) {
-  const [user, setUser] = useState<User | null>(null)
-  const [loading, setLoading] = useState(true)
   const configured = isFirebaseAuthConfigured()
+  const [user, setUser] = useState<User | null>(null)
+  const [loading, setLoading] = useState(configured)
 
   useEffect(() => {
-    if (!configured) {
-      setLoading(false)
-      return
-    }
+    if (!configured) return
     const auth = getFirebaseAuth()
     const unsub = onAuthStateChanged(auth, (u) => {
       setUser(u)

--- a/src/app/trivia/hooks/useTriviaUser.ts
+++ b/src/app/trivia/hooks/useTriviaUser.ts
@@ -1,0 +1,157 @@
+'use client'
+
+import { type DocumentData, doc, getDoc, setDoc } from 'firebase/firestore'
+import { useCallback, useEffect, useState } from 'react'
+
+import { useAuth } from '@/app/trivia/hooks/useAuth'
+import { getFirebaseFirestore } from '@/app/trivia/lib/firebaseClient'
+import { getTodayPST, hasPlayedToday } from '@/app/trivia/lib/triviaUtils'
+import type { TriviaGameResult } from '@/app/trivia/models/trivia'
+
+interface FirestoreStats {
+  gamesPlayed: number
+  totalScore: number
+  totalCorrect: number
+  totalQuestions: number
+  currentStreak: number
+  bestStreak: number
+}
+
+export interface TriviaUserDocument {
+  displayName: string
+  stats: FirestoreStats
+  history: TriviaGameResult[]
+  lastPlayedDate: string | null
+}
+
+const EMPTY_STATS: FirestoreStats = {
+  gamesPlayed: 0,
+  totalScore: 0,
+  totalCorrect: 0,
+  totalQuestions: 0,
+  currentStreak: 0,
+  bestStreak: 0,
+}
+
+const EMPTY_USER: TriviaUserDocument = {
+  displayName: '',
+  stats: EMPTY_STATS,
+  history: [],
+  lastPlayedDate: null,
+}
+
+function getYesterdayPST(): string {
+  const d = new Date()
+  d.setDate(d.getDate() - 1)
+  const pst = new Date(d.toLocaleString('en-US', { timeZone: 'America/Los_Angeles' }))
+  const yyyy = pst.getFullYear()
+  const mm = String(pst.getMonth() + 1).padStart(2, '0')
+  const dd = String(pst.getDate()).padStart(2, '0')
+  return `${yyyy}-${mm}-${dd}`
+}
+
+function computeNextState(
+  existing: TriviaUserDocument,
+  result: TriviaGameResult,
+  displayName: string
+): TriviaUserDocument {
+  const today = getTodayPST()
+  const yesterday = getYesterdayPST()
+  const wasYesterday = existing.lastPlayedDate === yesterday
+  const newStreak = wasYesterday ? existing.stats.currentStreak + 1 : 1
+  const bestStreak = Math.max(newStreak, existing.stats.bestStreak)
+
+  return {
+    displayName,
+    lastPlayedDate: today,
+    stats: {
+      gamesPlayed: existing.stats.gamesPlayed + 1,
+      totalScore: existing.stats.totalScore + result.score,
+      totalCorrect: existing.stats.totalCorrect + result.correct,
+      totalQuestions: existing.stats.totalQuestions + result.total,
+      currentStreak: newStreak,
+      bestStreak,
+    },
+    history: [...existing.history, result],
+  }
+}
+
+function normalizeDoc(data: DocumentData | undefined): TriviaUserDocument {
+  if (!data) return EMPTY_USER
+  return {
+    displayName: typeof data.displayName === 'string' ? data.displayName : '',
+    stats: { ...EMPTY_STATS, ...(data.stats ?? {}) },
+    history: Array.isArray(data.history) ? (data.history as TriviaGameResult[]) : [],
+    lastPlayedDate:
+      typeof data.lastPlayedDate === 'string' || data.lastPlayedDate === null
+        ? data.lastPlayedDate
+        : null,
+  }
+}
+
+export interface UseTriviaUserResult {
+  userData: TriviaUserDocument
+  loading: boolean
+  isLoggedIn: boolean
+  canPlayToday: () => boolean
+  saveGameResult: (result: TriviaGameResult) => Promise<void>
+  refresh: () => Promise<void>
+}
+
+export function useTriviaUser(): UseTriviaUserResult {
+  const { user, loading: authLoading } = useAuth()
+  const [userData, setUserData] = useState<TriviaUserDocument>(EMPTY_USER)
+  const [loading, setLoading] = useState(true)
+
+  const refresh = useCallback(async () => {
+    if (!user) {
+      setUserData(EMPTY_USER)
+      setLoading(false)
+      return
+    }
+    try {
+      const ref = doc(getFirebaseFirestore(), 'trivia-users', user.uid)
+      const snap = await getDoc(ref)
+      setUserData(normalizeDoc(snap.data()))
+    } catch (err) {
+      console.error('Failed to load trivia user data:', err)
+      setUserData(EMPTY_USER)
+    } finally {
+      setLoading(false)
+    }
+  }, [user])
+
+  useEffect(() => {
+    if (authLoading) return
+    setLoading(true)
+    refresh()
+  }, [authLoading, refresh])
+
+  const saveGameResult = useCallback(
+    async (result: TriviaGameResult) => {
+      if (!user) return
+      const ref = doc(getFirebaseFirestore(), 'trivia-users', user.uid)
+      const snap = await getDoc(ref)
+      const existing = normalizeDoc(snap.data())
+      const displayName = user.displayName ?? user.email ?? existing.displayName
+      const next = computeNextState(existing, result, displayName)
+      await setDoc(ref, next)
+      setUserData(next)
+    },
+    [user]
+  )
+
+  const canPlayToday = useCallback((): boolean => {
+    if (!user) return true
+    return !hasPlayedToday(userData.lastPlayedDate)
+  }, [user, userData.lastPlayedDate])
+
+  return {
+    userData,
+    loading,
+    isLoggedIn: !!user,
+    canPlayToday,
+    saveGameResult,
+    refresh,
+  }
+}

--- a/src/app/trivia/lib/firebase.ts
+++ b/src/app/trivia/lib/firebase.ts
@@ -1,28 +1,40 @@
-import { initializeApp, getApps, cert } from 'firebase-admin/app'
+import { cert, getApps, initializeApp } from 'firebase-admin/app'
+import { type Auth, getAuth } from 'firebase-admin/auth'
 import { getFirestore } from 'firebase-admin/firestore'
 
 let _db: FirebaseFirestore.Firestore | null = null
+let _auth: Auth | null = null
 
-export function getFirestoreDb(): FirebaseFirestore.Firestore {
-  if (!getApps().length) {
-    const projectId = process.env.FIREBASE_PROJECT_ID
-    const clientEmail = process.env.FIREBASE_CLIENT_EMAIL
-    const privateKey = process.env.FIREBASE_PRIVATE_KEY?.replace(/\\n/g, '\n')
+function ensureApp(): void {
+  if (getApps().length) return
 
-    if (!projectId || !clientEmail || !privateKey) {
-      throw new Error(
-        'Firebase config missing. Set FIREBASE_PROJECT_ID, FIREBASE_CLIENT_EMAIL, and FIREBASE_PRIVATE_KEY environment variables.'
-      )
-    }
+  const projectId = process.env.FIREBASE_PROJECT_ID
+  const clientEmail = process.env.FIREBASE_CLIENT_EMAIL
+  const privateKey = process.env.FIREBASE_PRIVATE_KEY?.replace(/\\n/g, '\n')
 
-    initializeApp({
-      credential: cert({ projectId, clientEmail, privateKey }),
-    })
+  if (!projectId || !clientEmail || !privateKey) {
+    throw new Error(
+      'Firebase config missing. Set FIREBASE_PROJECT_ID, FIREBASE_CLIENT_EMAIL, and FIREBASE_PRIVATE_KEY environment variables.'
+    )
   }
 
+  initializeApp({
+    credential: cert({ projectId, clientEmail, privateKey }),
+  })
+}
+
+export function getFirestoreDb(): FirebaseFirestore.Firestore {
+  ensureApp()
   if (!_db) {
     _db = getFirestore()
   }
-
   return _db
+}
+
+export function getFirebaseAuthAdmin(): Auth {
+  ensureApp()
+  if (!_auth) {
+    _auth = getAuth()
+  }
+  return _auth
 }

--- a/src/app/trivia/lib/firebaseClient.ts
+++ b/src/app/trivia/lib/firebaseClient.ts
@@ -1,5 +1,6 @@
 import { type FirebaseApp, getApps, initializeApp } from 'firebase/app'
 import { type Auth, getAuth } from 'firebase/auth'
+import { type Firestore, getFirestore } from 'firebase/firestore'
 
 const firebaseConfig = {
   apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY,
@@ -9,6 +10,7 @@ const firebaseConfig = {
 
 let _app: FirebaseApp | null = null
 let _auth: Auth | null = null
+let _firestore: Firestore | null = null
 
 export function isFirebaseAuthConfigured(): boolean {
   return Boolean(firebaseConfig.apiKey && firebaseConfig.authDomain && firebaseConfig.projectId)
@@ -29,4 +31,15 @@ export function getFirebaseAuth(): Auth {
   }
   _auth = getAuth(getApp())
   return _auth
+}
+
+export function getFirebaseFirestore(): Firestore {
+  if (_firestore) return _firestore
+  if (!isFirebaseAuthConfigured()) {
+    throw new Error(
+      'Firebase client config missing. Set NEXT_PUBLIC_FIREBASE_API_KEY, NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN, and NEXT_PUBLIC_FIREBASE_PROJECT_ID.'
+    )
+  }
+  _firestore = getFirestore(getApp())
+  return _firestore
 }

--- a/src/app/trivia/page.tsx
+++ b/src/app/trivia/page.tsx
@@ -1,36 +1,46 @@
 'use client'
 
-import { useState, useEffect } from 'react'
-import { TriviaLanding } from './components/TriviaLanding'
+import { useEffect, useState } from 'react'
+
+import { useAuth } from '@/app/trivia/hooks/useAuth'
+import { useTriviaStore } from '@/app/trivia/hooks/useTriviaStore'
+import { useTriviaUser } from '@/app/trivia/hooks/useTriviaUser'
+import { getTodayPST } from '@/app/trivia/lib/triviaUtils'
+
 import { TriviaGame } from './components/TriviaGame'
+import { TriviaLanding } from './components/TriviaLanding'
+import { TriviaLeaderboard } from './components/TriviaLeaderboard'
 import { TriviaResults } from './components/TriviaResults'
 import { TriviaStats } from './components/TriviaStats'
-import { TriviaLeaderboard } from './components/TriviaLeaderboard'
-import { useTriviaStore } from './hooks/useTriviaStore'
-import { getTodayPST } from './lib/triviaUtils'
+
 import type { TriviaGameResult } from './models/trivia'
 
 type View = 'landing' | 'playing' | 'results' | 'stats' | 'leaderboard'
 
 export default function TriviaPage() {
-  const { recordGame, userData } = useTriviaStore()
+  const { user } = useAuth()
+  const { recordGame, userData: localUser } = useTriviaStore()
+  const {
+    userData: firestoreUser,
+    saveGameResult: saveToFirestore,
+    loading: firestoreLoading,
+  } = useTriviaUser()
 
-  const getTodayResult = (): TriviaGameResult | null => {
-    const today = getTodayPST()
-    return userData.history.find((h) => h.date === today) ?? null
-  }
+  const today = getTodayPST()
+  const todayLocal = localUser.history.find((h) => h.date === today) ?? null
+  const todayFirestore = firestoreUser.history.find((h) => h.date === today) ?? null
+  const todayResult = user ? todayFirestore : todayLocal
 
-  const todayResult = getTodayResult()
-  const [view, setView] = useState<View>(todayResult ? 'results' : 'landing')
-  const [lastResult, setLastResult] = useState<TriviaGameResult | null>(todayResult)
+  const [view, setView] = useState<View>('landing')
+  const [lastResult, setLastResult] = useState<TriviaGameResult | null>(null)
 
   useEffect(() => {
-    const result = getTodayResult()
-    if (result && view === 'landing') {
-      setLastResult(result)
+    if (user && firestoreLoading) return
+    if (todayResult && view === 'landing') {
+      setLastResult(todayResult)
       setView('results')
     }
-  }, [userData.history])
+  }, [user, firestoreLoading, todayResult, view])
 
   const handleStartGame = () => setView('playing')
   const handleViewStats = () => setView('stats')
@@ -38,23 +48,13 @@ export default function TriviaPage() {
 
   const handleFinish = (result: TriviaGameResult) => {
     recordGame(result)
+    if (user) {
+      saveToFirestore(result).catch((err) =>
+        console.error('Failed to save trivia result to Firestore:', err)
+      )
+    }
     setLastResult(result)
     setView('results')
-
-    // Submit score to leaderboard if user has a display name (fire and forget)
-    if (userData.displayName) {
-      fetch('/api/v1/trivia/submit-score', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          displayName: userData.displayName,
-          date: result.date,
-          score: result.score,
-          correct: result.correct,
-          total: result.total,
-        }),
-      }).catch((err) => console.error('Failed to submit score:', err))
-    }
   }
 
   const handleBackToLanding = () => setView('landing')


### PR DESCRIPTION
Closes #244

> ⚠️ Stacked on top of #513 (Phase 1). Merge order: #513 → this PR → Phase 3.
> Reviewing only the Phase 2 diff: compare against \`feat/243-trivia-auth-phase-1\` (the PR base above).

## Summary
- New \`useTriviaUser\` hook: loads/saves \`trivia-users/{uid}\` via Firebase client SDK; empty defaults when not logged in
- \`submit-score\` route now requires \`Authorization: Bearer {idToken}\`; \`displayName\` derived from the verified token (not body); 401 if missing/invalid
- \`TriviaResults\` fetches the ID token via \`user.getIdToken()\` and submits with the auth header; NamePrompt fallback removed for results
- \`page.tsx\` calls \`saveGameResult\` on finish for logged-in users; \`canPlayToday\` checks Firestore for logged-in users, localStorage for anon
- \`TriviaLanding\` + \`TriviaStats\` read from Firestore when logged in, localStorage when anon (anon path stays until Phase 3)
- Admin: \`getFirebaseAuthAdmin()\` helper for verifying ID tokens server-side
- Client: \`getFirebaseFirestore()\` exposed from \`firebaseClient.ts\`

## Required out-of-band setup
**Firestore security rules** — deploy this rule (Firebase Console → Firestore Database → Rules) so each user can only read/write their own \`trivia-users/{uid}\` doc:

\`\`\`
rules_version = '2';
service cloud.firestore {
  match /databases/{database}/documents {
    match /trivia-users/{uid} {
      allow read, write: if request.auth != null && request.auth.uid == uid;
    }
    // Existing trivia-scores rules stay as-is (server-only writes via admin SDK).
    match /trivia-scores/{doc} {
      allow read: if true;
      allow write: if false;
    }
  }
}
\`\`\`

(Adjust to match your existing rules — the key addition is the \`trivia-users/{uid}\` block.)

## Test plan
- [x] \`yarn typecheck\` — clean
- [x] \`yarn lint\` — net −20 errors vs Phase 1; 0 lint errors in Phase 2 files
- [x] \`/trivia\` and \`/auth\` render
- [x] \`POST /api/v1/trivia/submit-score\` returns 401 without Authorization header
- [ ] Logged-in: play a game → \`trivia-users/{uid}\` doc created with stats + history; appears on leaderboard with Google account name
- [ ] Logged-in: replay attempt blocked by \`canPlayToday\` (Firestore lastPlayedDate)
- [ ] Logged-in: stats persist across browsers/devices
- [ ] Anonymous: localStorage gameplay unchanged from Phase 1
- [ ] Old anon leaderboard entries (if any) still display; new entries are auth-only

## What does NOT change yet
- localStorage code path is still present for anon users — Phase 3 (#245) removes it
- NamePrompt component still exists for anon "Playing as" display — Phase 3 deletes it
- Login CTAs are subtle — Phase 4 (#246) makes them prominent

## Blocks
- #245 (Phase 3 — remove localStorage)
- #246 (Phase 4 — login CTAs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)