### PR TITLE
feat: trivia auth phase 4 — login CTAs and polished auth UX

### DIFF
--- a/src/app/trivia/components/SignInCTA.tsx
+++ b/src/app/trivia/components/SignInCTA.tsx
@@ -1,0 +1,50 @@
+'use client'
+
+import Link from 'next/link'
+
+import { Button } from '@/components/ui/button'
+import { Card, CardContent } from '@/components/ui/card'
+
+const REDIRECT = '/auth?redirect=/trivia'
+
+export function SignInBanner({
+  message,
+  cta = 'Log in',
+}: {
+  message: string
+  cta?: string
+}) {
+  return (
+    <div className="w-full flex items-center justify-between gap-3 px-4 py-2.5 rounded-lg bg-space-purple/15 border border-space-purple/30 text-sm">
+      <span className="text-cream-white/80">{message}</span>
+      <Link
+        href={REDIRECT}
+        className="text-space-gold hover:text-space-gold/80 underline-offset-4 hover:underline whitespace-nowrap font-semibold"
+      >
+        {cta} →
+      </Link>
+    </div>
+  )
+}
+
+export function SignInCard({
+  title,
+  description,
+}: {
+  title: string
+  description: string
+}) {
+  return (
+    <Card className="w-full bg-space-purple/15 border-space-purple/40">
+      <CardContent className="pt-5 pb-5 flex flex-col items-center gap-3 text-center">
+        <h3 className="text-lg font-bold text-cream-white">{title}</h3>
+        <p className="text-cream-white/70 text-sm">{description}</p>
+        <Link href={REDIRECT} className="w-full">
+          <Button variant="space" size="lg" className="w-full">
+            Sign in
+          </Button>
+        </Link>
+      </CardContent>
+    </Card>
+  )
+}

--- a/src/app/trivia/components/TriviaLanding.tsx
+++ b/src/app/trivia/components/TriviaLanding.tsx
@@ -2,12 +2,15 @@
 
 import Image from 'next/image'
 import Link from 'next/link'
+import { useEffect, useRef, useState } from 'react'
 
 import { useAuth } from '@/app/trivia/hooks/useAuth'
 import { useTriviaUser } from '@/app/trivia/hooks/useTriviaUser'
 import { formatDisplayDate, getDailyCategory, getTodayPST } from '@/app/trivia/lib/triviaUtils'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+
+import { SignInBanner } from './SignInCTA'
 
 export function TriviaLanding({
   onStartGame,
@@ -18,7 +21,7 @@ export function TriviaLanding({
   onViewStats?: () => void
   onViewLeaderboard?: () => void
 }) {
-  const { user, loading: authLoading, configured: authConfigured } = useAuth()
+  const { user, loading: authLoading, configured: authConfigured, signOut } = useAuth()
   const {
     userData: firestoreUser,
     canPlayToday: canPlayFirestore,
@@ -33,26 +36,17 @@ export function TriviaLanding({
   const alreadyPlayed = user ? !canPlayFirestore() : false
   const showFirestoreLoadingHint = !!user && firestoreLoading
   const category = getDailyCategory(todayStr)
+  const showSignInPromos = authConfigured && !authLoading && !user
 
   return (
     <div className="flex flex-col items-center gap-6 max-w-lg mx-auto py-8">
-      <div className="w-full flex justify-end min-h-[1.25rem] text-sm">
+      <div className="w-full flex justify-end min-h-[1.75rem] text-sm">
         {!authConfigured ? null : authLoading ? null : user ? (
-          <div className="flex items-center gap-2 text-cream-white/70">
-            {user.photoURL && (
-              <Image
-                src={user.photoURL}
-                alt=""
-                width={24}
-                height={24}
-                className="rounded-full"
-                unoptimized
-              />
-            )}
-            <span className="text-cream-white/80 truncate max-w-[10rem]">
-              {user.displayName ?? user.email}
-            </span>
-          </div>
+          <UserMenu
+            displayName={user.displayName ?? user.email ?? 'Account'}
+            photoURL={user.photoURL}
+            onSignOut={signOut}
+          />
         ) : (
           <Link
             href="/auth?redirect=/trivia"
@@ -76,6 +70,23 @@ export function TriviaLanding({
           <span>{category.name}</span>
         </div>
       </div>
+
+      {/* Streak hero (logged-in users with an active streak) */}
+      {user && stats.currentStreak > 0 && (
+        <div className="w-full flex items-center justify-center gap-2 text-cream-white/80">
+          <span className="text-2xl">🔥</span>
+          <span className="text-lg">
+            <span className="text-space-gold font-bold text-2xl">{stats.currentStreak}</span>
+            <span className="ml-2">
+              day{stats.currentStreak === 1 ? '' : 's'} in a row
+            </span>
+          </span>
+        </div>
+      )}
+
+      {showSignInPromos && (
+        <SignInBanner message="Sign in to save your progress" />
+      )}
 
       <Card className="w-full bg-space-dark/80 border-space-grey">
         <CardHeader>
@@ -160,6 +171,80 @@ export function TriviaLanding({
           Leaderboard
         </button>
       </div>
+    </div>
+  )
+}
+
+function UserMenu({
+  displayName,
+  photoURL,
+  onSignOut,
+}: {
+  displayName: string
+  photoURL: string | null
+  onSignOut: () => Promise<void>
+}) {
+  const [open, setOpen] = useState(false)
+  const containerRef = useRef<HTMLDivElement | null>(null)
+
+  useEffect(() => {
+    if (!open) return
+    function onPointerDown(e: PointerEvent) {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setOpen(false)
+      }
+    }
+    function onKeyDown(e: KeyboardEvent) {
+      if (e.key === 'Escape') setOpen(false)
+    }
+    window.addEventListener('pointerdown', onPointerDown)
+    window.addEventListener('keydown', onKeyDown)
+    return () => {
+      window.removeEventListener('pointerdown', onPointerDown)
+      window.removeEventListener('keydown', onKeyDown)
+    }
+  }, [open])
+
+  return (
+    <div ref={containerRef} className="relative">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        className="flex items-center gap-2 text-cream-white/70 hover:text-cream-white transition-colors px-2 py-1 rounded-md hover:bg-space-dark/40"
+        aria-haspopup="menu"
+        aria-expanded={open}
+      >
+        {photoURL && (
+          <Image
+            src={photoURL}
+            alt=""
+            width={24}
+            height={24}
+            className="rounded-full"
+            unoptimized
+          />
+        )}
+        <span className="text-cream-white/80 truncate max-w-[10rem]">{displayName}</span>
+        <span className="text-cream-white/40 text-xs">▾</span>
+      </button>
+      {open && (
+        <div
+          role="menu"
+          className="absolute right-0 mt-1 min-w-[10rem] rounded-md border border-space-grey bg-space-dark shadow-lg z-20 overflow-hidden"
+        >
+          <button
+            type="button"
+            role="menuitem"
+            onClick={() => {
+              setOpen(false)
+              onSignOut().catch((err) => console.error('Sign out failed:', err))
+            }}
+            className="w-full text-left px-3 py-2 text-sm text-cream-white/80 hover:bg-space-purple/20 hover:text-cream-white transition-colors"
+          >
+            Sign out
+          </button>
+        </div>
+      )}
     </div>
   )
 }

--- a/src/app/trivia/components/TriviaLeaderboard.tsx
+++ b/src/app/trivia/components/TriviaLeaderboard.tsx
@@ -7,6 +7,8 @@ import { getDailyCategory, getTodayPST } from '@/app/trivia/lib/triviaUtils'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent } from '@/components/ui/card'
 
+import { SignInBanner } from './SignInCTA'
+
 type Period = 'daily' | 'weekly' | 'alltime'
 
 interface DailyEntry {
@@ -170,6 +172,10 @@ export function TriviaLeaderboard({ onBack }: { onBack: () => void }) {
           </p>
         ) : null}
       </div>
+
+      {!authName && (
+        <SignInBanner message="Log in to see your rank and compete" cta="Sign in" />
+      )}
 
       {/* Tabs */}
       <div className="grid grid-cols-3 gap-2">

--- a/src/app/trivia/components/TriviaResults.tsx
+++ b/src/app/trivia/components/TriviaResults.tsx
@@ -9,6 +9,8 @@ import type { TriviaGameResult } from '@/app/trivia/models/trivia'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent } from '@/components/ui/card'
 
+import { SignInCard } from './SignInCTA'
+
 const MAX_SCORE = 3150
 
 function getScoreRating(percentage: number) {
@@ -24,7 +26,10 @@ function formatTime(ms: number): string {
   return `${seconds}s`
 }
 
-function getShareText(result: TriviaGameResult, streak?: number): string {
+function getShareText(
+  result: TriviaGameResult,
+  options: { streak?: number; playerName?: string | null } = {}
+): string {
   const date = new Date(result.date + 'T12:00:00')
   const dateStr = date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
   const category = getDailyCategory(result.date)
@@ -34,9 +39,20 @@ function getShareText(result: TriviaGameResult, streak?: number): string {
     .join('')
 
   const pct = Math.round((result.score / MAX_SCORE) * 100)
-  const streakLine = streak && streak >= 2 ? `\n🔥 ${streak}-day streak` : ''
-
-  return `🧠 CometCave Daily Trivia — ${dateStr}\nTheme: ${category.icon} ${category.name}\n${squares}\nScore: ${result.score.toLocaleString()} / ${MAX_SCORE.toLocaleString()} (${pct}%)${streakLine}\nhttps://cometcave.com/trivia`
+  const lines = [
+    `🧠 CometCave Daily Trivia — ${dateStr}`,
+    `Theme: ${category.icon} ${category.name}`,
+    squares,
+    `Score: ${result.score.toLocaleString()} / ${MAX_SCORE.toLocaleString()} (${pct}%)`,
+  ]
+  if (options.streak && options.streak >= 2) {
+    lines.push(`🔥 ${options.streak}-day streak`)
+  }
+  if (options.playerName) {
+    lines.push(`— played by ${options.playerName}`)
+  }
+  lines.push('https://cometcave.com/trivia')
+  return lines.join('\n')
 }
 
 function useCountdown() {
@@ -115,7 +131,11 @@ export function TriviaResults({ result, onBack, onViewStats, onViewLeaderboard }
   const correctPercent = result.total > 0 ? Math.round((result.correct / result.total) * 100) : 0
 
   const handleShare = async () => {
-    const text = getShareText(result, currentStreak)
+    const playerName = user ? user.displayName ?? user.email ?? null : null
+    const text = getShareText(result, {
+      streak: user ? currentStreak : undefined,
+      playerName,
+    })
     try {
       await navigator.clipboard.writeText(text)
       setCopied(true)
@@ -243,6 +263,13 @@ export function TriviaResults({ result, onBack, onViewStats, onViewLeaderboard }
         <div className="text-center text-green-400/70 text-sm">
           Score submitted to leaderboard
         </div>
+      )}
+
+      {!user && (
+        <SignInCard
+          title="🔒 Your score wasn't saved"
+          description="Sign in to track your streak, save your stats, and compete on the leaderboard."
+        />
       )}
 
       {/* Countdown to next reset */}

--- a/src/app/trivia/components/TriviaStats.tsx
+++ b/src/app/trivia/components/TriviaStats.tsx
@@ -1,9 +1,12 @@
 'use client'
 
+import { useAuth } from '@/app/trivia/hooks/useAuth'
 import { useTriviaUser } from '@/app/trivia/hooks/useTriviaUser'
 import { formatDisplayDate } from '@/app/trivia/lib/triviaUtils'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent } from '@/components/ui/card'
+
+import { SignInCard } from './SignInCTA'
 
 const MAX_SCORE_PER_GAME = 3150
 
@@ -14,6 +17,7 @@ function getAccuracyColor(accuracy: number): string {
 }
 
 export function TriviaStats({ onBack }: { onBack: () => void }) {
+  const { user } = useAuth()
   const { userData: firestoreUser } = useTriviaUser()
   const stats = firestoreUser.stats
   const history = firestoreUser.history
@@ -37,14 +41,21 @@ export function TriviaStats({ onBack }: { onBack: () => void }) {
     return (
       <div className="flex flex-col items-center gap-6 max-w-lg mx-auto py-8">
         <h2 className="text-3xl font-bold text-space-gold">My Stats</h2>
-        <Card className="w-full bg-space-dark/80 border-space-grey">
-          <CardContent className="pt-6 text-center">
-            <p className="text-cream-white/70 text-lg mb-2">No games played yet</p>
-            <p className="text-cream-white/50 text-sm">
-              Play your first daily trivia to start building your stats!
-            </p>
-          </CardContent>
-        </Card>
+        {user ? (
+          <Card className="w-full bg-space-dark/80 border-space-grey">
+            <CardContent className="pt-6 text-center">
+              <p className="text-cream-white/70 text-lg mb-2">No games played yet</p>
+              <p className="text-cream-white/50 text-sm">
+                Play your first daily trivia to start building your stats!
+              </p>
+            </CardContent>
+          </Card>
+        ) : (
+          <SignInCard
+            title="📊 Your stats will appear here"
+            description="Sign in to start tracking your scores, streaks, and history."
+          />
+        )}
         <Button variant="outline" onClick={onBack} className="w-full">
           Back to Trivia
         </Button>


### PR DESCRIPTION
Closes #246

> ⚠️ Stacked on #515 (Phase 3). Merge order: #513 → #514 → #515 → this PR.
> Reviewing only the Phase 4 diff: compare against \`feat/245-trivia-auth-phase-3\` (the PR base above).

## Summary

### CTAs for anonymous users
| Location | Treatment |
| --- | --- |
| Landing | Subtle inline banner above Start: "Sign in to save your progress → Log in" |
| Post-game | Prominent card: "🔒 Your score wasn't saved — Sign in to track your streak…" with a Sign in button |
| Leaderboard | Top banner: "Log in to see your rank and compete" |
| Stats (empty) | Replaces "No games played yet" with: "📊 Your stats will appear here…" + Sign in button |

A single \`SignInCTA\` component exposes \`SignInBanner\` (inline) and \`SignInCard\` (boxed) so the four locations share styling.

### Logged-in polish
- **Streak hero** on the landing page: when a logged-in user has \`currentStreak ≥ 1\`, a "🔥 N days in a row" line shows above the Start card.
- **User menu**: the avatar+name in the top-right is now a click-to-open dropdown with a Sign out option (closes on escape / outside click; no library — vanilla React).
- **Share text** picks up two new lines when applicable:
  \`\`\`
  🧠 CometCave Daily Trivia — Apr 27
  Theme: 🏛️ Politics
  🟩🟩🟥🟩🟩🟩🟩🟥
  Score: 2,300 / 3,150 (73%)
  🔥 5-day streak           ← when logged in and streak ≥ 2
  — played by NickOlu       ← when logged in
  https://cometcave.com/trivia
  \`\`\`

## Tone
Per the issue spec: encouraging, not annoying. No modals, no popups, no blocking. Google sign-in remains the lowest-friction path via \`/auth\`.

## Test plan
- [x] \`yarn build\` — production build clean; \`/trivia\` and \`/auth\` prerender as static
- [x] \`yarn typecheck\` — clean
- [x] \`yarn lint\` — no new errors in Phase 4 files
- [x] \`/trivia\` and \`/auth\` render in dev with no runtime errors
- [ ] Anonymous: see banner on landing, banner on leaderboard, card after game, card on stats
- [ ] Anonymous: copy share text — verify no streak line, no playerName line
- [ ] Logged-in: streak hero appears on landing when streak > 0
- [ ] Logged-in: click avatar → Sign out works, returns to anon state
- [ ] Logged-in with streak ≥ 2: copy share text — verify both extra lines present
- [ ] Mobile: banner + card layouts don't overflow

## Notes
- The user menu uses a small inline pattern (clickable avatar + outside-click handler + escape key) rather than pulling in a Radix DropdownMenu component. One menu item, one binding to wire — no need for a full menu primitive. Easy to swap later if more items are added.
- "Best streak: X days" is already prominent in the existing 2-col stats card; didn't add a duplicate callout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)