### PR TITLE
fix: allow logout after completing today's trivia (#519)

### DIFF
--- a/src/app/trivia/page.tsx
+++ b/src/app/trivia/page.tsx
@@ -31,14 +31,17 @@ export default function TriviaPage() {
 
   const [view, setView] = useState<View>('landing')
   const [lastResult, setLastResult] = useState<TriviaGameResult | null>(null)
+  const [autoResultsShown, setAutoResultsShown] = useState(false)
 
   useEffect(() => {
+    if (autoResultsShown) return
     if (user && firestoreLoading) return
     if (todayResult && view === 'landing') {
       setLastResult(todayResult)
       setView('results')
     }
-  }, [user, firestoreLoading, todayResult, view])
+    setAutoResultsShown(true)
+  }, [autoResultsShown, user, firestoreLoading, todayResult, view])
 
   const handleStartGame = () => setView('playing')
   const handleViewStats = () => setView('stats')


### PR DESCRIPTION
## Summary
Fixes #519 — users couldn't log out after completing today's trivia.

## Root cause
The auto-redirect from landing → results in `useEffect` re-fired on every render, so when the user clicked **Back** from `TriviaResults` it bounced them straight back to the results screen — and `TriviaLanding` is the only surface that exposes the Sign-out menu.

## Fix
Gate the redirect behind a one-shot `autoResultsShown` flag so it only runs on the initial load. After back-navigation, re-renders no longer trigger the redirect. +4/-1 lines in `src/app/trivia/page.tsx`.

## Test plan
- [ ] Sign in, complete today's trivia → results screen shown
- [ ] Click **Back** → returns to landing, Sign-out menu reachable
- [ ] Sign out from landing succeeds
- [ ] Refresh as a completed-today user still lands on results (initial-load behavior preserved)
- [ ] Already-played landing CTA "Come Back Tomorrow" still disabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)