### PR TITLE
feat: trivia localStorage today-state (#518) + nickname display (#520)

### DIFF
--- a/src/app/api/v1/trivia/submit-score/route.ts
+++ b/src/app/api/v1/trivia/submit-score/route.ts
@@ -1,14 +1,28 @@
 import { type NextRequest, NextResponse } from 'next/server'
 
-import { getFirebaseAuthAdmin } from '@/app/trivia/lib/firebase'
+import { getFirebaseAuthAdmin, getFirestoreDb } from '@/app/trivia/lib/firebase'
 import { submitScore } from '@/app/trivia/lib/leaderboardStore'
 import { getTodayPST } from '@/app/trivia/lib/triviaUtils'
 
 const MAX_SCORE = 3150
 const MAX_NAME_LENGTH = 20
 
-function deriveDisplayName(token: { name?: string; email?: string }): string | null {
-  const candidate = (token.name ?? token.email ?? '').trim()
+async function resolveDisplayName(decoded: {
+  uid: string
+  name?: string
+  email?: string
+}): Promise<string | null> {
+  try {
+    const snap = await getFirestoreDb()
+      .collection('trivia-users')
+      .doc(decoded.uid)
+      .get()
+    const nickname = (snap.data()?.nickname as string | undefined)?.trim()
+    if (nickname) return nickname.slice(0, MAX_NAME_LENGTH)
+  } catch (err) {
+    console.warn('Failed to read nickname for score submission:', err)
+  }
+  const candidate = (decoded.name ?? decoded.email ?? '').trim()
   if (!candidate) return null
   return candidate.slice(0, MAX_NAME_LENGTH)
 }
@@ -29,7 +43,7 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: 'Invalid auth token.' }, { status: 401 })
     }
 
-    const displayName = deriveDisplayName(decoded)
+    const displayName = await resolveDisplayName(decoded)
     if (!displayName) {
       return NextResponse.json(
         { error: 'Account is missing a display name. Update your profile and try again.' },

--- a/src/app/trivia/components/NicknameDialog.tsx
+++ b/src/app/trivia/components/NicknameDialog.tsx
@@ -1,0 +1,106 @@
+'use client'
+
+import { useEffect, useRef, useState } from 'react'
+
+import { NICKNAME_MAX_LENGTH, sanitizeNickname } from '@/app/trivia/hooks/useTriviaUser'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+
+interface NicknameDialogProps {
+  initialValue: string
+  onClose: () => void
+  onSave: (nickname: string) => Promise<void>
+}
+
+export function NicknameDialog({ initialValue, onClose, onSave }: NicknameDialogProps) {
+  const [value, setValue] = useState(initialValue)
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const inputRef = useRef<HTMLInputElement | null>(null)
+
+  useEffect(() => {
+    inputRef.current?.focus()
+  }, [])
+
+  useEffect(() => {
+    function onKeyDown(e: KeyboardEvent) {
+      if (e.key === 'Escape') onClose()
+    }
+    window.addEventListener('keydown', onKeyDown)
+    return () => window.removeEventListener('keydown', onKeyDown)
+  }, [onClose])
+
+  const trimmedLength = value.trim().length
+  const canSave = trimmedLength > 0 && !saving
+
+  const handleSave = async () => {
+    const clean = sanitizeNickname(value)
+    if (!clean) {
+      setError('Nickname cannot be empty.')
+      return
+    }
+    setSaving(true)
+    setError(null)
+    try {
+      await onSave(clean)
+      onClose()
+    } catch (err) {
+      console.error('Failed to save nickname:', err)
+      setError('Could not save nickname. Try again.')
+      setSaving(false)
+    }
+  }
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="nickname-dialog-title"
+      className="fixed inset-0 bg-black/80 flex items-center justify-center z-50 px-4"
+      onClick={onClose}
+    >
+      <div
+        className="w-full max-w-sm rounded-lg border border-space-grey bg-space-dark p-6 shadow-xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h2
+          id="nickname-dialog-title"
+          className="text-lg font-bold text-space-gold mb-1"
+        >
+          Choose your nickname
+        </h2>
+        <p className="text-cream-white/60 text-sm mb-4">
+          Shown on the leaderboard and wherever your name appears.
+        </p>
+        <Input
+          ref={inputRef}
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' && canSave) {
+              e.preventDefault()
+              handleSave()
+            }
+          }}
+          maxLength={NICKNAME_MAX_LENGTH}
+          placeholder="e.g. Stargazer"
+          className="text-cream-white"
+        />
+        <div className="flex items-center justify-between mt-2">
+          <span className="text-xs text-cream-white/40">
+            {trimmedLength}/{NICKNAME_MAX_LENGTH}
+          </span>
+          {error && <span className="text-xs text-red-400">{error}</span>}
+        </div>
+        <div className="grid grid-cols-2 gap-2 mt-4">
+          <Button variant="outline" onClick={onClose} disabled={saving}>
+            Cancel
+          </Button>
+          <Button variant="space" onClick={handleSave} disabled={!canSave}>
+            {saving ? 'Saving…' : 'Save'}
+          </Button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/app/trivia/components/TriviaLanding.tsx
+++ b/src/app/trivia/components/TriviaLanding.tsx
@@ -7,6 +7,7 @@ import { useEffect, useRef, useState } from 'react'
 import { useAuth } from '@/app/trivia/hooks/useAuth'
 import { useTriviaUser } from '@/app/trivia/hooks/useTriviaUser'
 import { formatDisplayDate, getDailyCategory, getTodayPST } from '@/app/trivia/lib/triviaUtils'
+import type { TriviaGameResult } from '@/app/trivia/models/trivia'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 
@@ -16,24 +17,19 @@ export function TriviaLanding({
   onStartGame,
   onViewStats,
   onViewLeaderboard,
+  todayResult,
 }: {
   onStartGame?: () => void
   onViewStats?: () => void
   onViewLeaderboard?: () => void
+  todayResult: TriviaGameResult | null
 }) {
   const { user, loading: authLoading, configured: authConfigured, signOut } = useAuth()
-  const {
-    userData: firestoreUser,
-    canPlayToday: canPlayFirestore,
-    loading: firestoreLoading,
-  } = useTriviaUser()
+  const { userData: firestoreUser, loading: firestoreLoading } = useTriviaUser()
 
   const stats = firestoreUser.stats
   const todayStr = getTodayPST()
-  const todayHistoryEntry = user
-    ? firestoreUser.history.find((h) => h.date === todayStr) ?? null
-    : null
-  const alreadyPlayed = user ? !canPlayFirestore() : false
+  const alreadyPlayed = !!todayResult
   const showFirestoreLoadingHint = !!user && firestoreLoading
   const category = getDailyCategory(todayStr)
   const showSignInPromos = authConfigured && !authLoading && !user
@@ -109,14 +105,14 @@ export function TriviaLanding({
             {alreadyPlayed ? 'Come Back Tomorrow' : "Start Today's Trivia"}
           </Button>
 
-          {alreadyPlayed && todayHistoryEntry && (
+          {alreadyPlayed && todayResult && (
             <div className="text-center text-cream-white/60 text-sm">
               Today&apos;s score:{' '}
               <span className="text-space-gold font-semibold">
-                {todayHistoryEntry.score} pts
+                {todayResult.score} pts
               </span>
               {' · '}
-              {todayHistoryEntry.correct}/{todayHistoryEntry.total} correct
+              {todayResult.correct}/{todayResult.total} correct
             </div>
           )}
         </CardContent>

--- a/src/app/trivia/components/TriviaLanding.tsx
+++ b/src/app/trivia/components/TriviaLanding.tsx
@@ -11,6 +11,7 @@ import type { TriviaGameResult } from '@/app/trivia/models/trivia'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 
+import { NicknameDialog } from './NicknameDialog'
 import { SignInBanner } from './SignInCTA'
 
 export function TriviaLanding({
@@ -25,7 +26,14 @@ export function TriviaLanding({
   todayResult: TriviaGameResult | null
 }) {
   const { user, loading: authLoading, configured: authConfigured, signOut } = useAuth()
-  const { userData: firestoreUser, loading: firestoreLoading } = useTriviaUser()
+  const {
+    userData: firestoreUser,
+    loading: firestoreLoading,
+    displayName,
+    needsNickname,
+    setNickname,
+  } = useTriviaUser()
+  const [nicknameDialogOpen, setNicknameDialogOpen] = useState(false)
 
   const stats = firestoreUser.stats
   const todayStr = getTodayPST()
@@ -33,15 +41,17 @@ export function TriviaLanding({
   const showFirestoreLoadingHint = !!user && firestoreLoading
   const category = getDailyCategory(todayStr)
   const showSignInPromos = authConfigured && !authLoading && !user
+  const nicknameSeed = firestoreUser.nickname || user?.displayName || ''
 
   return (
     <div className="flex flex-col items-center gap-6 max-w-lg mx-auto py-8">
       <div className="w-full flex justify-end min-h-[1.75rem] text-sm">
         {!authConfigured ? null : authLoading ? null : user ? (
           <UserMenu
-            displayName={user.displayName ?? user.email ?? 'Account'}
+            displayName={displayName || user.email || 'Account'}
             photoURL={user.photoURL}
             onSignOut={signOut}
+            onEditNickname={() => setNicknameDialogOpen(true)}
           />
         ) : (
           <Link
@@ -82,6 +92,21 @@ export function TriviaLanding({
 
       {showSignInPromos && (
         <SignInBanner message="Sign in to save your progress" />
+      )}
+
+      {needsNickname && (
+        <button
+          type="button"
+          onClick={() => setNicknameDialogOpen(true)}
+          className="w-full flex items-center justify-between gap-3 px-4 py-2.5 rounded-lg bg-space-purple/15 border border-space-purple/30 text-sm text-left hover:bg-space-purple/20 transition-colors"
+        >
+          <span className="text-cream-white/80">
+            Pick a nickname for the leaderboard
+          </span>
+          <span className="text-space-gold whitespace-nowrap font-semibold">
+            Set nickname →
+          </span>
+        </button>
       )}
 
       <Card className="w-full bg-space-dark/80 border-space-grey">
@@ -167,6 +192,14 @@ export function TriviaLanding({
           Leaderboard
         </button>
       </div>
+
+      {nicknameDialogOpen && (
+        <NicknameDialog
+          initialValue={nicknameSeed}
+          onClose={() => setNicknameDialogOpen(false)}
+          onSave={setNickname}
+        />
+      )}
     </div>
   )
 }
@@ -175,10 +208,12 @@ function UserMenu({
   displayName,
   photoURL,
   onSignOut,
+  onEditNickname,
 }: {
   displayName: string
   photoURL: string | null
   onSignOut: () => Promise<void>
+  onEditNickname: () => void
 }) {
   const [open, setOpen] = useState(false)
   const containerRef = useRef<HTMLDivElement | null>(null)
@@ -228,6 +263,17 @@ function UserMenu({
           role="menu"
           className="absolute right-0 mt-1 min-w-[10rem] rounded-md border border-space-grey bg-space-dark shadow-lg z-20 overflow-hidden"
         >
+          <button
+            type="button"
+            role="menuitem"
+            onClick={() => {
+              setOpen(false)
+              onEditNickname()
+            }}
+            className="w-full text-left px-3 py-2 text-sm text-cream-white/80 hover:bg-space-purple/20 hover:text-cream-white transition-colors"
+          >
+            Edit nickname
+          </button>
           <button
             type="button"
             role="menuitem"

--- a/src/app/trivia/components/TriviaLeaderboard.tsx
+++ b/src/app/trivia/components/TriviaLeaderboard.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from 'react'
 
 import { useAuth } from '@/app/trivia/hooks/useAuth'
+import { useTriviaUser } from '@/app/trivia/hooks/useTriviaUser'
 import { getDailyCategory, getTodayPST } from '@/app/trivia/lib/triviaUtils'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent } from '@/components/ui/card'
@@ -35,6 +36,7 @@ interface AllTimeEntry {
 
 export function TriviaLeaderboard({ onBack }: { onBack: () => void }) {
   const { user } = useAuth()
+  const { displayName: triviaDisplayName } = useTriviaUser()
   const [period, setPeriod] = useState<Period>('daily')
   const [loading, setLoading] = useState(true)
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -42,7 +44,7 @@ export function TriviaLeaderboard({ onBack }: { onBack: () => void }) {
   const [error, setError] = useState<string | null>(null)
   const [copied, setCopied] = useState(false)
 
-  const authName = user?.displayName ?? user?.email ?? null
+  const authName = user ? triviaDisplayName || user.email || null : null
   const currentName = authName?.toLowerCase().trim() ?? ''
 
   useEffect(() => {

--- a/src/app/trivia/components/TriviaResults.tsx
+++ b/src/app/trivia/components/TriviaResults.tsx
@@ -94,7 +94,7 @@ interface TriviaResultsProps {
 export function TriviaResults({ result, onBack, onViewStats, onViewLeaderboard }: TriviaResultsProps) {
   const [copied, setCopied] = useState(false)
   const { user } = useAuth()
-  const { userData: firestoreUser } = useTriviaUser()
+  const { userData: firestoreUser, displayName } = useTriviaUser()
   const currentStreak = firestoreUser.stats.currentStreak
   const [scoreSubmitted, setScoreSubmitted] = useState(false)
   const countdown = useCountdown()
@@ -131,7 +131,7 @@ export function TriviaResults({ result, onBack, onViewStats, onViewLeaderboard }
   const correctPercent = result.total > 0 ? Math.round((result.correct / result.total) * 100) : 0
 
   const handleShare = async () => {
-    const playerName = user ? user.displayName ?? user.email ?? null : null
+    const playerName = user ? displayName || user.email || null : null
     const text = getShareText(result, {
       streak: user ? currentStreak : undefined,
       playerName,

--- a/src/app/trivia/hooks/useTriviaUser.ts
+++ b/src/app/trivia/hooks/useTriviaUser.ts
@@ -19,6 +19,7 @@ interface FirestoreStats {
 
 export interface TriviaUserDocument {
   displayName: string
+  nickname: string
   stats: FirestoreStats
   history: TriviaGameResult[]
   lastPlayedDate: string | null
@@ -35,9 +36,16 @@ const EMPTY_STATS: FirestoreStats = {
 
 const EMPTY_USER: TriviaUserDocument = {
   displayName: '',
+  nickname: '',
   stats: EMPTY_STATS,
   history: [],
   lastPlayedDate: null,
+}
+
+export const NICKNAME_MAX_LENGTH = 20
+
+export function sanitizeNickname(raw: string): string {
+  return raw.trim().slice(0, NICKNAME_MAX_LENGTH)
 }
 
 function getYesterdayPST(): string {
@@ -63,6 +71,7 @@ function computeNextState(
 
   return {
     displayName,
+    nickname: existing.nickname,
     lastPlayedDate: today,
     stats: {
       gamesPlayed: existing.stats.gamesPlayed + 1,
@@ -80,6 +89,7 @@ function normalizeDoc(data: DocumentData | undefined): TriviaUserDocument {
   if (!data) return EMPTY_USER
   return {
     displayName: typeof data.displayName === 'string' ? data.displayName : '',
+    nickname: typeof data.nickname === 'string' ? data.nickname : '',
     stats: { ...EMPTY_STATS, ...(data.stats ?? {}) },
     history: Array.isArray(data.history) ? (data.history as TriviaGameResult[]) : [],
     lastPlayedDate:
@@ -93,8 +103,11 @@ export interface UseTriviaUserResult {
   userData: TriviaUserDocument
   loading: boolean
   isLoggedIn: boolean
+  displayName: string
+  needsNickname: boolean
   canPlayToday: () => boolean
   saveGameResult: (result: TriviaGameResult) => Promise<void>
+  setNickname: (raw: string) => Promise<void>
   refresh: () => Promise<void>
 }
 
@@ -133,10 +146,27 @@ export function useTriviaUser(): UseTriviaUserResult {
       const ref = doc(getFirebaseFirestore(), 'trivia-users', user.uid)
       const snap = await getDoc(ref)
       const existing = normalizeDoc(snap.data())
-      const displayName = user.displayName ?? user.email ?? existing.displayName
-      const next = computeNextState(existing, result, displayName)
+      const resolvedName =
+        existing.nickname ||
+        user.displayName ||
+        user.email ||
+        existing.displayName ||
+        ''
+      const next = computeNextState(existing, result, resolvedName)
       await setDoc(ref, next)
       setUserData(next)
+    },
+    [user]
+  )
+
+  const setNickname = useCallback(
+    async (raw: string) => {
+      if (!user) return
+      const clean = sanitizeNickname(raw)
+      if (!clean) return
+      const ref = doc(getFirebaseFirestore(), 'trivia-users', user.uid)
+      await setDoc(ref, { nickname: clean, displayName: clean }, { merge: true })
+      setUserData((prev) => ({ ...prev, nickname: clean, displayName: clean }))
     },
     [user]
   )
@@ -146,12 +176,19 @@ export function useTriviaUser(): UseTriviaUserResult {
     return !hasPlayedToday(userData.lastPlayedDate)
   }, [user, userData.lastPlayedDate])
 
+  const fallbackName = user?.displayName ?? user?.email ?? ''
+  const displayName = userData.nickname || fallbackName
+  const needsNickname = !!user && !loading && !userData.nickname
+
   return {
     userData,
     loading,
     isLoggedIn: !!user,
+    displayName,
+    needsNickname,
     canPlayToday,
     saveGameResult,
+    setNickname,
     refresh,
   }
 }

--- a/src/app/trivia/lib/todayLocalStorage.ts
+++ b/src/app/trivia/lib/todayLocalStorage.ts
@@ -1,0 +1,59 @@
+import type { TriviaGameResult } from '@/app/trivia/models/trivia'
+
+const KEY_PREFIX = 'trivia:today:'
+
+function isBrowser(): boolean {
+  return typeof window !== 'undefined'
+}
+
+function keyFor(date: string): string {
+  return `${KEY_PREFIX}${date}`
+}
+
+export function loadTodayResult(today: string): TriviaGameResult | null {
+  if (!isBrowser()) return null
+  try {
+    const raw = window.localStorage.getItem(keyFor(today))
+    if (!raw) return null
+    const parsed = JSON.parse(raw) as TriviaGameResult
+    if (parsed?.date !== today) return null
+    return parsed
+  } catch {
+    return null
+  }
+}
+
+export function saveTodayResult(result: TriviaGameResult): void {
+  if (!isBrowser()) return
+  try {
+    window.localStorage.setItem(keyFor(result.date), JSON.stringify(result))
+  } catch {
+    // ignore quota/serialization errors — local state will fall through to Firestore on next login
+  }
+}
+
+export function clearTodayResult(today: string): void {
+  if (!isBrowser()) return
+  try {
+    window.localStorage.removeItem(keyFor(today))
+  } catch {
+    // ignore
+  }
+}
+
+export function cleanupOldDays(today: string): void {
+  if (!isBrowser()) return
+  try {
+    const todayKey = keyFor(today)
+    const toRemove: string[] = []
+    for (let i = 0; i < window.localStorage.length; i++) {
+      const k = window.localStorage.key(i)
+      if (k && k.startsWith(KEY_PREFIX) && k !== todayKey) {
+        toRemove.push(k)
+      }
+    }
+    for (const k of toRemove) window.localStorage.removeItem(k)
+  } catch {
+    // ignore
+  }
+}

--- a/src/app/trivia/page.tsx
+++ b/src/app/trivia/page.tsx
@@ -1,9 +1,15 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 
 import { useAuth } from '@/app/trivia/hooks/useAuth'
 import { useTriviaUser } from '@/app/trivia/hooks/useTriviaUser'
+import {
+  cleanupOldDays,
+  clearTodayResult,
+  loadTodayResult,
+  saveTodayResult,
+} from '@/app/trivia/lib/todayLocalStorage'
 import { getTodayPST } from '@/app/trivia/lib/triviaUtils'
 
 import { TriviaGame } from './components/TriviaGame'
@@ -25,13 +31,22 @@ export default function TriviaPage() {
   } = useTriviaUser()
 
   const today = getTodayPST()
-  const todayResult = user
+  const firestoreToday = user
     ? firestoreUser.history.find((h) => h.date === today) ?? null
     : null
 
   const [view, setView] = useState<View>('landing')
   const [lastResult, setLastResult] = useState<TriviaGameResult | null>(null)
+  const [localToday, setLocalToday] = useState<TriviaGameResult | null>(null)
   const [autoResultsShown, setAutoResultsShown] = useState(false)
+  const prevUserUid = useRef<string | null>(null)
+
+  useEffect(() => {
+    cleanupOldDays(today)
+    setLocalToday(loadTodayResult(today))
+  }, [today])
+
+  const todayResult = firestoreToday ?? localToday
 
   useEffect(() => {
     if (autoResultsShown) return
@@ -43,15 +58,46 @@ export default function TriviaPage() {
     setAutoResultsShown(true)
   }, [autoResultsShown, user, firestoreLoading, todayResult, view])
 
+  useEffect(() => {
+    const uid = user?.uid ?? null
+    const prevUid = prevUserUid.current
+    prevUserUid.current = uid
+
+    if (!uid) return
+    if (firestoreLoading) return
+
+    const local = loadTodayResult(today)
+    if (!local) return
+
+    if (firestoreToday) {
+      clearTodayResult(today)
+      setLocalToday(null)
+      return
+    }
+
+    if (prevUid === uid) return
+
+    saveToFirestore(local)
+      .then(() => {
+        clearTodayResult(today)
+        setLocalToday(null)
+      })
+      .catch((err) => console.error('Failed to reconcile local trivia result:', err))
+  }, [user, firestoreLoading, firestoreToday, today, saveToFirestore])
+
   const handleStartGame = () => setView('playing')
   const handleViewStats = () => setView('stats')
   const handleViewLeaderboard = () => setView('leaderboard')
 
   const handleFinish = (result: TriviaGameResult) => {
+    saveTodayResult(result)
+    setLocalToday(result)
     if (user) {
-      saveToFirestore(result).catch((err) =>
-        console.error('Failed to save trivia result to Firestore:', err)
-      )
+      saveToFirestore(result)
+        .then(() => clearTodayResult(today))
+        .catch((err) =>
+          console.error('Failed to save trivia result to Firestore:', err)
+        )
     }
     setLastResult(result)
     setView('results')
@@ -87,6 +133,7 @@ export default function TriviaPage() {
       onStartGame={handleStartGame}
       onViewStats={handleViewStats}
       onViewLeaderboard={handleViewLeaderboard}
+      todayResult={todayResult}
     />
   )
 }


### PR DESCRIPTION
## Summary
Two related trivia changes bundled in one PR — both touch the `useTriviaUser` hook and player-name surfaces.

### #518 — Persist today's trivia in localStorage alongside Firebase
- New `src/app/trivia/lib/todayLocalStorage.ts` (`load/save/clear/cleanupOldDays`). Key: `trivia:today:YYYY-MM-DD`. SSR-safe.
- Anonymous players now keep today's run across refresh, and the run is reconciled to Firestore on account creation / login (only written if Firestore has no entry for today; otherwise discarded).
- Logged-in users also write a localStorage copy as a safety net while the Firestore write is in flight; cleared on success.
- Old day-keys pruned on mount.

### #520 — User-chosen account nickname as display name
- New `nickname` field on `trivia-users/{uid}` Firestore doc.
- `useTriviaUser` exposes derived `displayName = nickname || authDisplayName || email` and `setNickname()`.
- New `NicknameDialog` modal, opened from `UserMenu` → **Edit nickname**.
- Inline prompt on the landing for users who haven't picked one yet (covers email signups whose only auth name is their address).
- `submit-score` API route reads the Firestore nickname and prefers it over the ID token's name claim — leaderboard entries respect the user's choice.
- All player-name surfaces (UserMenu label, results share text, leaderboard "Playing as" + current-user match) switched to the hook's derived `displayName`.

## Files changed
**New:** `todayLocalStorage.ts`, `NicknameDialog.tsx`
**Modified:** `page.tsx`, `useTriviaUser.ts`, `TriviaLanding.tsx`, `TriviaResults.tsx`, `TriviaLeaderboard.tsx`, `submit-score/route.ts`

## Test plan
- [ ] Anonymous: complete today's trivia, refresh — lands on results, can't replay
- [ ] Anonymous: complete, then sign up — Firestore record gets today's score, localStorage cleared
- [ ] Logged-in user with existing today entry signs in elsewhere — local copy is discarded (server wins)
- [ ] localStorage cleanup removes yesterday's keys on next-day visit
- [ ] Email signup: sees "Pick a nickname" banner; setting one updates UserMenu, share text, leaderboard
- [ ] Google signup: nickname seeded with Google displayName; can edit via UserMenu
- [ ] Submit score: leaderboard entry uses the nickname (not the email)
- [ ] Existing users without a nickname: prompt appears, fallback name still shown until set

## Notes
- Includes the same `autoResultsShown` flag fix as #519 / PR #521 — if #521 lands first this branch may need a rebase to drop the duplicate hunk in `page.tsx`.
- `useTriviaUser`'s reconcile-on-login effect tracks the previous uid via `useRef` so it doesn't re-fire on refresh while already logged in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)