### PR TITLE
fix: firestore rules for new shared-identity paths

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -1,0 +1,6 @@
+{
+  "firestore": {
+    "rules": "firestore.rules",
+    "indexes": "firestore.indexes.json"
+  }
+}

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,0 +1,35 @@
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+
+    // Canonical user profile (read by owner; writes via admin SDK only)
+    match /users/{uid} {
+      allow read: if request.auth != null && request.auth.uid == uid;
+
+      // Per-user trivia data — readable by the owning user
+      match /triviaProfile/{docId} {
+        allow read: if request.auth != null && request.auth.uid == uid;
+      }
+      match /triviaGames/{docId} {
+        allow read: if request.auth != null && request.auth.uid == uid;
+      }
+
+      // Server-only — admin SDK reads via collection-group queries.
+      // Client must not query these directly.
+      match /triviaDaily/{docId}  { allow read, write: if false; }
+      match /triviaWeekly/{docId} { allow read, write: if false; }
+    }
+
+    // Nicknames uniqueness index — server only
+    match /nicknames/{name} { allow read, write: if false; }
+
+    // Legacy trivia collections (pre-#523) — no longer used
+    match /trivia-users/{uid}    { allow read, write: if false; }
+    match /trivia-scores/{docId} { allow read, write: if false; }
+
+    // Tap-tap-adventure leaderboard — server-side writes via admin SDK,
+    // server-side reads via /api/v1/tap-tap-adventure/leaderboard route.
+    // Client does not read directly.
+    match /adventure-scores/{docId} { allow read, write: if false; }
+  }
+}


### PR DESCRIPTION
## What
Adds version-controlled \`firestore.rules\` and \`firebase.json\` for the new shared-identity schema. Fixes the \`Missing or insufficient permissions\` console errors that appear after #523 — the client \`onSnapshot\` calls in \`useTriviaUser\` were hitting paths (\`users/{uid}\`, \`triviaProfile\`, \`triviaGames\`) that fell through to default-deny.

## Rules summary
- **Owner-readable:** \`users/{uid}\`, \`users/{uid}/triviaProfile/*\`, \`users/{uid}/triviaGames/*\`.
- **Server-only (deny client):** \`users/{uid}/triviaDaily/*\`, \`users/{uid}/triviaWeekly/*\`, \`nicknames/*\`. The leaderboard route reads these via the admin SDK (which bypasses rules).
- **Legacy, denied:** \`trivia-users\`, \`trivia-scores\`, \`adventure-scores\` (reads/writes for these all live in admin-SDK server routes).

## Deploy
Rules don't auto-deploy with Vercel. Apply via:
\`\`\`
firebase deploy --only firestore:rules
\`\`\`
or paste the contents of \`firestore.rules\` into Firebase Console → Firestore → Rules → Publish.

## Test plan
- [ ] After deploy, signed-in user opens /trivia → no console errors
- [ ] User stats and history load
- [ ] Leaderboards (daily/weekly/all-time) load (server-side, no client rule changes needed)
- [ ] Nickname edit works
- [ ] Anonymous user → no errors (no Firestore subscriptions for anon)

🤖 Generated with [Claude Code](https://claude.com/claude-code)