### PR TITLE
feat: surface leaderboard init state + reset-notice popover

### DIFF
--- a/src/app/trivia/components/ResetNoticeButton.tsx
+++ b/src/app/trivia/components/ResetNoticeButton.tsx
@@ -1,0 +1,66 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+
+import { Button } from '@/components/ui/button'
+
+export function ResetNoticeButton() {
+  const [open, setOpen] = useState(false)
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        aria-label="Why is this reset?"
+        title="Why is this reset?"
+        className="inline-flex items-center justify-center w-5 h-5 rounded-full text-cream-white/40 hover:text-cream-white/80 hover:bg-space-purple/20 transition-colors text-xs font-semibold"
+      >
+        i
+      </button>
+      {open && <ResetDialog onClose={() => setOpen(false)} />}
+    </>
+  )
+}
+
+function ResetDialog({ onClose }: { onClose: () => void }) {
+  useEffect(() => {
+    function onKeyDown(e: KeyboardEvent) {
+      if (e.key === 'Escape') onClose()
+    }
+    window.addEventListener('keydown', onKeyDown)
+    return () => window.removeEventListener('keydown', onKeyDown)
+  }, [onClose])
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="reset-dialog-title"
+      className="fixed inset-0 bg-black/80 flex items-center justify-center z-50 px-4"
+      onClick={onClose}
+    >
+      <div
+        className="w-full max-w-sm rounded-lg border border-space-grey bg-space-dark p-6 shadow-xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h2 id="reset-dialog-title" className="text-lg font-bold text-space-gold mb-3">
+          About this reset
+        </h2>
+        <div className="text-cream-white/80 text-sm space-y-2 mb-4">
+          <p>
+            We just rebuilt the trivia database to fix nickname collisions and make
+            leaderboards scale properly.
+          </p>
+          <p>
+            Stats, streaks, and leaderboard entries are reset for everyone — including
+            yours. Future games will count toward fresh totals.
+          </p>
+        </div>
+        <Button variant="space" onClick={onClose} className="w-full">
+          Got it
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/src/app/trivia/components/TriviaLeaderboard.tsx
+++ b/src/app/trivia/components/TriviaLeaderboard.tsx
@@ -9,6 +9,7 @@ import { useAuth } from '@/hooks/useAuth'
 import { getTodayPST } from '@/lib/dates'
 import { getDailyCategory } from '@/lib/trivia/categories'
 
+import { ResetNoticeButton } from './ResetNoticeButton'
 import { SignInBanner } from './SignInCTA'
 
 type Period = 'daily' | 'weekly' | 'alltime'
@@ -98,8 +99,8 @@ export function TriviaLeaderboard({ onBack }: { onBack: () => void }) {
 
     if (data.entries.length === 0) {
       return (
-        <div className="text-center text-cream-white/50 py-8">
-          No scores yet. Be the first!
+        <div className="text-center text-cream-white/50 py-8 px-4">
+          {data.notice ?? 'No scores yet. Be the first!'}
         </div>
       )
     }
@@ -154,7 +155,10 @@ export function TriviaLeaderboard({ onBack }: { onBack: () => void }) {
   return (
     <div className="flex flex-col gap-4 max-w-lg mx-auto py-6">
       <div className="text-center">
-        <h2 className="text-3xl font-bold text-space-gold mb-1">Leaderboard</h2>
+        <h2 className="text-3xl font-bold text-space-gold mb-1 inline-flex items-center gap-2">
+          Leaderboard
+          <ResetNoticeButton />
+        </h2>
         {authName ? (
           <p className="text-cream-white/50 text-sm">
             Playing as <span className="text-space-gold">{authName}</span>

--- a/src/app/trivia/components/TriviaStats.tsx
+++ b/src/app/trivia/components/TriviaStats.tsx
@@ -6,6 +6,7 @@ import { Card, CardContent } from '@/components/ui/card'
 import { useAuth } from '@/hooks/useAuth'
 import { formatDisplayDate } from '@/lib/dates'
 
+import { ResetNoticeButton } from './ResetNoticeButton'
 import { SignInCard } from './SignInCTA'
 
 const MAX_SCORE_PER_GAME = 3150
@@ -38,7 +39,10 @@ export function TriviaStats({ onBack }: { onBack: () => void }) {
   if (stats.gamesPlayed === 0) {
     return (
       <div className="flex flex-col items-center gap-6 max-w-lg mx-auto py-8">
-        <h2 className="text-3xl font-bold text-space-gold">My Stats</h2>
+        <h2 className="text-3xl font-bold text-space-gold inline-flex items-center gap-2">
+          My Stats
+          <ResetNoticeButton />
+        </h2>
         {user ? (
           <Card className="w-full bg-space-dark/80 border-space-grey">
             <CardContent className="pt-6 text-center">
@@ -65,7 +69,10 @@ export function TriviaStats({ onBack }: { onBack: () => void }) {
     <div className="flex flex-col gap-5 max-w-lg mx-auto py-6">
       {/* Header */}
       <div className="text-center">
-        <h2 className="text-3xl font-bold text-space-gold mb-1">My Stats</h2>
+        <h2 className="text-3xl font-bold text-space-gold mb-1 inline-flex items-center gap-2">
+          My Stats
+          <ResetNoticeButton />
+        </h2>
         <p className="text-cream-white/50 text-sm">Your trivia journey so far</p>
       </div>
 


### PR DESCRIPTION
## Why
After #523 / #524 the leaderboards return empty + a \`notice\` field while Firestore builds the new collection-group indexes. The client was hiding the notice and showing "No scores yet, be the first!" which is misleading. Also adds the popover explaining why stats / leaderboards are reset.

## Changes
- **Surface the API notice.** When \`entries\` is empty AND \`notice\` is present, the empty state renders the notice instead of "No scores yet."
- **New \`ResetNoticeButton\`** — info icon next to \`Leaderboard\` and \`My Stats\` titles. Click → small dialog explaining the database rewrite and reset.

## Independent next step (not in this PR)
The leaderboards still need three Firestore CG indexes built before they return real data. Until then they will keep showing the "Leaderboard is initializing" notice. Two options to deploy:

\`\`\`
npx firebase login
npx firebase deploy --only firestore:indexes
\`\`\`

OR find the auto-create URLs in the Vercel runtime logs (they are logged by the leaderboard route on FAILED_PRECONDITION) and click through them in the Firebase console.

## Test plan
- [ ] Open /trivia/leaderboard — see "Leaderboard is initializing..." (or real data, after indexes build)
- [ ] Click info icon next to "Leaderboard" → popover opens, explains the reset
- [ ] Escape / click outside / "Got it" all close the popover
- [ ] Same on /trivia/stats both with and without played games
- [ ] Lint, typecheck, Vercel preview pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)