### PR TITLE
chore: add .firebaserc with default project pointer

### DIFF
--- a/.firebaserc
+++ b/.firebaserc
@@ -1,0 +1,5 @@
+{
+  "projects": {
+    "default": "cometcave-2d1c4"
+  }
+}


### PR DESCRIPTION
Lets `firebase deploy --only firestore:indexes|rules` work without needing to run `firebase use` first. Project ID is not sensitive — already in NEXT_PUBLIC_FIREBASE_PROJECT_ID.