### PR TITLE
fix: move single-field CG index to fieldOverrides

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -15,14 +15,16 @@
         { "fieldPath": "weekKey", "order": "ASCENDING" },
         { "fieldPath": "totalScore", "order": "DESCENDING" }
       ]
-    },
-    {
-      "collectionGroup": "triviaProfile",
-      "queryScope": "COLLECTION_GROUP",
-      "fields": [
-        { "fieldPath": "totalScore", "order": "DESCENDING" }
-      ]
     }
   ],
-  "fieldOverrides": []
+  "fieldOverrides": [
+    {
+      "collectionGroup": "triviaProfile",
+      "fieldPath": "totalScore",
+      "indexes": [
+        { "order": "ASCENDING", "queryScope": "COLLECTION_GROUP" },
+        { "order": "DESCENDING", "queryScope": "COLLECTION_GROUP" }
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
The all-time leaderboard query is a single-field CG query. Single-field CG indexes go under \`fieldOverrides\`, not \`indexes\` (which is for composite, multi-field). The previous shape was silently dropped by \`firebase deploy --only firestore:indexes\`, which is why the all-time index never appeared in the console.

Daily / weekly entries are unchanged — they're proper composite CG indexes.

## To verify
After merge:
\`\`\`
git pull
firebase deploy --only firestore:indexes
\`\`\`
You should see the CLI report 2 composite indexes + 1 field override being created. Then check Firebase Console → Firestore → Indexes → Composite tab + Single-field tab.