### PR TITLE
feat: auto-show reset notice on first visit

### DIFF
--- a/src/app/trivia/components/ResetNoticeButton.tsx
+++ b/src/app/trivia/components/ResetNoticeButton.tsx
@@ -4,8 +4,40 @@ import { useEffect, useState } from 'react'
 
 import { Button } from '@/components/ui/button'
 
+const SEEN_KEY = 'trivia:resetNoticeSeen'
+
+function hasSeenNotice(): boolean {
+  if (typeof window === 'undefined') return true
+  try {
+    return window.localStorage.getItem(SEEN_KEY) === '1'
+  } catch {
+    return true
+  }
+}
+
+function markSeen(): void {
+  if (typeof window === 'undefined') return
+  try {
+    window.localStorage.setItem(SEEN_KEY, '1')
+  } catch {
+    // ignore
+  }
+}
+
 export function ResetNoticeButton() {
   const [open, setOpen] = useState(false)
+
+  useEffect(() => {
+    if (!hasSeenNotice()) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      setOpen(true)
+    }
+  }, [])
+
+  const handleClose = () => {
+    markSeen()
+    setOpen(false)
+  }
 
   return (
     <>
@@ -18,7 +50,7 @@ export function ResetNoticeButton() {
       >
         i
       </button>
-      {open && <ResetDialog onClose={() => setOpen(false)} />}
+      {open && <ResetDialog onClose={handleClose} />}
     </>
   )
 }

--- a/src/app/trivia/components/TriviaLanding.tsx
+++ b/src/app/trivia/components/TriviaLanding.tsx
@@ -13,6 +13,7 @@ import { formatDisplayDate, getTodayPST } from '@/lib/dates'
 import { getDailyCategory } from '@/lib/trivia/categories'
 
 import { NicknameDialog } from './NicknameDialog'
+import { ResetNoticeButton } from './ResetNoticeButton'
 import { SignInBanner } from './SignInCTA'
 
 export function TriviaLanding({
@@ -65,7 +66,10 @@ export function TriviaLanding({
       </div>
 
       <div className="text-center">
-        <h1 className="text-4xl font-bold text-space-gold mb-2">Daily Trivia</h1>
+        <h1 className="text-4xl font-bold text-space-gold mb-2 inline-flex items-center gap-2">
+          Daily Trivia
+          <ResetNoticeButton />
+        </h1>
         <p className="text-cream-white/70 text-lg">{formatDisplayDate(todayStr)}</p>
       </div>
 


### PR DESCRIPTION
The click-only popover (#525) was easy to miss. Now the dialog opens automatically the first time a user lands on \`/trivia\`, \`/trivia/leaderboard\`, or \`/trivia/stats\` — whichever they hit first. Dismissal persisted in \`localStorage\` (\`trivia:resetNoticeSeen\`) so it doesn't keep nagging. Info icon still works for manual re-open.

Also adds the icon to the trivia landing title — previously only on Leaderboard / My Stats — so most users see the auto-open at \`/trivia\` instead of only on the secondary pages.

## Test plan
- [ ] Clear localStorage, visit \`/trivia\` — dialog opens automatically
- [ ] Click "Got it" — dialog closes, \`trivia:resetNoticeSeen=1\` set
- [ ] Refresh — no auto-open
- [ ] Click info icon — dialog opens manually (works after dismissal)
- [ ] Same flow starting from \`/trivia/leaderboard\` and \`/trivia/stats\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)