### PR TITLE
Redesign 01: Add brand fonts + Material Symbols icon font

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -7,13 +7,36 @@ html {
 }
 
 body {
-  font-family: 'Space Grotesk', Arial, sans-serif;
+  font-family: var(--font-body), 'Be Vietnam Pro', Arial, sans-serif;
 }
 
 @layer utilities {
   .text-balance {
     text-wrap: balance;
   }
+}
+
+.material-symbols-outlined {
+  font-family: 'Material Symbols Outlined';
+  font-weight: normal;
+  font-style: normal;
+  font-size: 24px;
+  line-height: 1;
+  letter-spacing: normal;
+  text-transform: none;
+  display: inline-block;
+  white-space: nowrap;
+  word-wrap: normal;
+  direction: ltr;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  text-rendering: optimizeLegibility;
+  font-feature-settings: 'liga';
+  font-variation-settings:
+    'FILL' 0,
+    'wght' 600,
+    'GRAD' 0,
+    'opsz' 24;
 }
 
 /* When game is active on mobile, hide site chrome and fix scrolling */

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,4 @@
-import { Space_Grotesk } from 'next/font/google'
+import { Plus_Jakarta_Sans, Be_Vietnam_Pro, Lexend } from 'next/font/google'
 import Link from 'next/link'
 
 import { Footer } from '@/components/footer'
@@ -11,7 +11,26 @@ import { ROUTE_CONSTANTS } from './route-constants'
 import type { Metadata } from 'next'
 import type React from 'react'
 
-const spaceGrotesk = Space_Grotesk({ subsets: ['latin'] })
+const plusJakartaSans = Plus_Jakarta_Sans({
+  subsets: ['latin'],
+  weight: ['500', '800'],
+  variable: '--font-headline',
+  display: 'swap',
+})
+
+const beVietnamPro = Be_Vietnam_Pro({
+  subsets: ['latin'],
+  weight: ['400', '500', '700'],
+  variable: '--font-body',
+  display: 'swap',
+})
+
+const lexend = Lexend({
+  subsets: ['latin'],
+  weight: ['700'],
+  variable: '--font-label',
+  display: 'swap',
+})
 
 export const metadata: Metadata = {
   title: 'CometCave - AI Galaxy Arcade',
@@ -26,7 +45,13 @@ export default function RootLayout({
   return (
     <Providers>
       <html lang="en">
-        <body className={spaceGrotesk.className}>
+        <head>
+          <link
+            href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200&display=swap"
+            rel="stylesheet"
+          />
+        </head>
+        <body className={`${plusJakartaSans.variable} ${beVietnamPro.variable} ${lexend.variable} ${beVietnamPro.className}`}>
           <div id="site-wrapper" className="min-h-screen flex flex-col bg-space-black text-cream-white relative overflow-hidden">
             <StarField />
             <header className="p-4 z-10 relative">


### PR DESCRIPTION
## Summary

- Replaces `Space_Grotesk` with **Plus Jakarta Sans** (500/800), **Be Vietnam Pro** (400/500/700), and **Lexend** (700) via `next/font/google`
- Loads **Material Symbols Outlined** variable icon font via Google Fonts CDN `<link>` with `font-display: swap`
- Exposes CSS custom properties `--font-headline`, `--font-body`, `--font-label` for downstream token issues
- Adds `.material-symbols-outlined` base class in `globals.css` (24px default, weight 600)
- Body defaults to Be Vietnam Pro

Closes #530
Parent epic: #529

## Test plan

- [ ] Dev server renders Be Vietnam Pro as the default body font
- [ ] `--font-headline`, `--font-body`, `--font-label` CSS vars are set on `<body>`
- [ ] Material Symbols icon class renders glyphs (e.g. `<span class="material-symbols-outlined">home</span>`)
- [ ] No FOUC beyond ~200ms on page load
- [ ] No hex literals or `space-*` tokens introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)