### PR TITLE
Redesign 03: Define semantic spacing, radius, and typography tokens

### DIFF
--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -111,6 +111,38 @@ CSS custom properties set via `next/font/google` in `app/layout.tsx`:
 
 Icon font: **Material Symbols Outlined** (loaded via CDN `<link>`).
 
+## Spacing
+
+| Token | Value | Intent |
+|---|---|---|
+| `--space-unit` | `8px` | Base unit — smallest spacing increment |
+| `--space-stack-gap` | `16px` | Vertical gap between stacked elements |
+| `--space-gutter` | `24px` | Horizontal gap between columns/cards |
+| `--space-margin` | `32px` | Outer margin for sections |
+| `--space-component-padding-x` | `24px` | Horizontal padding inside components |
+| `--space-component-padding-y` | `16px` | Vertical padding inside components |
+
+## Radius
+
+| Token | Value | Intent |
+|---|---|---|
+| `--radius-sm` | `1rem` | Default card/container radius |
+| `--radius-lg` | `2rem` | Large cards, hero sections |
+| `--radius-xl` | `3rem` | Nav pill, side-nav |
+| `--radius-full` | `9999px` | Circular badges, pills |
+
+## Typography
+
+Font family tokens are set in `app/layout.tsx` (see Fonts above). The typography tokens below combine family, size, weight, and line-height for each semantic text style.
+
+| Style | Size | Line-height | Weight | Tracking | Family |
+|---|---|---|---|---|---|
+| `headline-lg` | 40px (2.5rem) | 1.2 | 800 | -0.02em | `--font-headline` |
+| `headline-md` | 32px (2rem) | 1.2 | 800 | — | `--font-headline` |
+| `body-lg` | 18px (1.125rem) | 1.6 | 500 | — | `--font-body` |
+| `body-md` | 16px (1rem) | 1.6 | 400 | — | `--font-body` |
+| `label-caps` | 14px (0.875rem) | 1.0 | 700 | 0.05em | `--font-label` |
+
 ## Legacy tokens (to be removed)
 
 The following primitive tokens in `tailwind.config.js` are legacy and will be replaced by semantic tokens during the redesign:

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -110,6 +110,49 @@ body {
   /* --- On-surface ------------------------------------------------- */
   --on-surface: #e4e1d6;             /* high-emphasis text */
   --on-surface-variant: #c4c5d0;     /* medium-emphasis text */
+
+  /* --- Spacing ---------------------------------------------------- */
+  --space-unit: 8px;
+  --space-stack-gap: 16px;
+  --space-gutter: 24px;
+  --space-margin: 32px;
+  --space-component-padding-x: 24px;
+  --space-component-padding-y: 16px;
+
+  /* --- Radius ----------------------------------------------------- */
+  --radius-sm: 1rem;
+  --radius-lg: 2rem;
+  --radius-xl: 3rem;
+  --radius-full: 9999px;
+
+  /* --- Typography ------------------------------------------------- */
+  --text-headline-lg-size: 2.5rem;        /* 40px */
+  --text-headline-lg-line-height: 1.2;
+  --text-headline-lg-weight: 800;
+  --text-headline-lg-tracking: -0.02em;
+  --text-headline-lg-family: var(--font-headline);
+
+  --text-headline-md-size: 2rem;           /* 32px */
+  --text-headline-md-line-height: 1.2;
+  --text-headline-md-weight: 800;
+  --text-headline-md-family: var(--font-headline);
+
+  --text-body-lg-size: 1.125rem;           /* 18px */
+  --text-body-lg-line-height: 1.6;
+  --text-body-lg-weight: 500;
+  --text-body-lg-family: var(--font-body);
+
+  --text-body-md-size: 1rem;               /* 16px */
+  --text-body-md-line-height: 1.6;
+  --text-body-md-weight: 400;
+  --text-body-md-family: var(--font-body);
+
+  --text-label-caps-size: 0.875rem;        /* 14px */
+  --text-label-caps-line-height: 1.0;
+  --text-label-caps-weight: 700;
+  --text-label-caps-tracking: 0.05em;
+  --text-label-caps-family: var(--font-label);
+  --text-label-caps-transform: uppercase;
 }
 
 /* When game is active on mobile, hide site chrome and fix scrolling */


### PR DESCRIPTION
## Summary

Closes #532 — Part of epic #529

- Adds 6 **spacing** tokens (`--space-unit`, `--space-stack-gap`, `--space-gutter`, `--space-margin`, `--space-component-padding-x/y`) to `:root` in `globals.css`
- Adds 4 **radius** tokens (`--radius-sm` 1rem, `--radius-lg` 2rem, `--radius-xl` 3rem, `--radius-full` 9999px)
- Adds 21 **typography** tokens covering 5 semantic text styles (`headline-lg`, `headline-md`, `body-lg`, `body-md`, `label-caps`) with size, line-height, weight, tracking, family, and transform properties
- Updates `docs/design-system.md` with Spacing, Radius, and Typography sections

No component code was changed — this is token definitions only. Tailwind wiring happens in #534.

## Test plan

- [ ] Verify `globals.css` `:root` block contains all new custom properties
- [ ] Verify `docs/design-system.md` has Spacing, Radius, and Typography tables
- [ ] Verify no hex literals or legacy tokens introduced
- [ ] Verify Vercel preview deploys without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)