### PR TITLE
Redesign 04: Define semantic shadow tokens (chunky drop, glow, rim)

### DIFF
--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -143,6 +143,49 @@ Font family tokens are set in `app/layout.tsx` (see Fonts above). The typography
 | `body-md` | 16px (1rem) | 1.6 | 400 | — | `--font-body` |
 | `label-caps` | 14px (0.875rem) | 1.0 | 700 | 0.05em | `--font-label` |
 
+## Shadows
+
+Shadow tokens define the "chunky" visual signature. Every solid drop-shadow pairs with a press offset for interactive elements.
+
+### Chunky drop-shadows
+
+| Token | Value | Paired press offset | Intent |
+|---|---|---|---|
+| `--shadow-card` | `0 8px 0 0 surface-container-lowest` | `--press-offset-card` (8px) | Game cards, content cards |
+| `--shadow-hero` | `0 12px 0 0 surface-container-lowest` | `--press-offset-hero` (12px) | Hero sections, question cards |
+| `--shadow-button` | `0 6px 0 0 surface-container-lowest` | `--press-offset-button` (6px) | Primary/secondary buttons |
+| `--shadow-button-sm` | `0 4px 0 0 surface-container-lowest` | `--press-offset-button-sm` (4px) | Pill nav, score chips, small buttons |
+| `--shadow-pressed` | `none` | — | Active/pressed state (remove shadow) |
+
+### Neon glows
+
+| Token | Value | Intent |
+|---|---|---|
+| `--shadow-glow-primary` | `0 0 20px primary/40%` | Primary accent hover/focus glow |
+| `--shadow-glow-secondary` | `0 0 15px secondary/20%` | Secondary accent glow |
+| `--shadow-glow-tertiary` | `0 0 15px tertiary/25%` | Tertiary/gold glow |
+| `--shadow-glow-error` | `0 0 15px error/30%` | Error state glow |
+
+### Inset rim lights
+
+| Token | Value | Intent |
+|---|---|---|
+| `--shadow-rim-top` | `inset 0 2px 4px white/5%` | Subtle top highlight on cards |
+| `--shadow-rim-inset-deep` | `inset 0 4px 10px black/50%` | Sunken input / recessed areas |
+
+### Chunky-press recipes
+
+Apply one class for the full drop-shadow + press-down effect:
+
+| Class | Shadow token | Press offset | Use for |
+|---|---|---|---|
+| `.chunky-card` | `--shadow-card` | 8px | Clickable cards |
+| `.chunky-hero` | `--shadow-hero` | 12px | Hero elements |
+| `.chunky-button` | `--shadow-button` | 6px | Buttons |
+| `.chunky-button-sm` | `--shadow-button-sm` | 4px | Small interactive elements |
+
+Each recipe applies `transition: transform 0.1s ease, box-shadow 0.1s ease` and on `:active` sets `box-shadow: none` + `translateY(offset)`.
+
 ## Legacy tokens (to be removed)
 
 The following primitive tokens in `tailwind.config.js` are legacy and will be replaced by semantic tokens during the redesign:

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -153,6 +153,73 @@ body {
   --text-label-caps-tracking: 0.05em;
   --text-label-caps-family: var(--font-label);
   --text-label-caps-transform: uppercase;
+
+  /* --- Shadows (chunky drop, glow, rim) ----------------------------- */
+  /* Chunky solid drop-shadows — the "squishy" signature */
+  --shadow-card: 0 8px 0 0 var(--surface-container-lowest);
+  --shadow-hero: 0 12px 0 0 var(--surface-container-lowest);
+  --shadow-button: 0 6px 0 0 var(--surface-container-lowest);
+  --shadow-button-sm: 0 4px 0 0 var(--surface-container-lowest);
+  --shadow-pressed: none;                /* active state — remove shadow */
+
+  /* Neon glow halos */
+  --shadow-glow-primary: 0 0 20px rgba(0, 255, 194, 0.4);
+  --shadow-glow-secondary: 0 0 15px rgba(20, 209, 255, 0.2);
+  --shadow-glow-tertiary: 0 0 15px rgba(255, 186, 32, 0.25);
+  --shadow-glow-error: 0 0 15px rgba(255, 84, 73, 0.3);
+
+  /* Inset rim lights */
+  --shadow-rim-top: inset 0 2px 4px rgba(255, 255, 255, 0.05);
+  --shadow-rim-inset-deep: inset 0 4px 10px rgba(0, 0, 0, 0.5);
+
+  /* Paired press offsets (translateY values matching drop-shadow heights) */
+  --press-offset-card: 8px;
+  --press-offset-hero: 12px;
+  --press-offset-button: 6px;
+  --press-offset-button-sm: 4px;
+}
+
+/* ───────────────────────────────────────────────────────────────────
+   Chunky-press recipes — apply one class for the full drop+press effect.
+   Each pairs a solid drop-shadow with a matching translateY on :active.
+   ─────────────────────────────────────────────────────────────────── */
+
+@layer components {
+  .chunky-card {
+    box-shadow: var(--shadow-card);
+    transition: transform 0.1s ease, box-shadow 0.1s ease;
+  }
+  .chunky-card:active {
+    box-shadow: var(--shadow-pressed);
+    transform: translateY(var(--press-offset-card));
+  }
+
+  .chunky-hero {
+    box-shadow: var(--shadow-hero);
+    transition: transform 0.1s ease, box-shadow 0.1s ease;
+  }
+  .chunky-hero:active {
+    box-shadow: var(--shadow-pressed);
+    transform: translateY(var(--press-offset-hero));
+  }
+
+  .chunky-button {
+    box-shadow: var(--shadow-button);
+    transition: transform 0.1s ease, box-shadow 0.1s ease;
+  }
+  .chunky-button:active {
+    box-shadow: var(--shadow-pressed);
+    transform: translateY(var(--press-offset-button));
+  }
+
+  .chunky-button-sm {
+    box-shadow: var(--shadow-button-sm);
+    transition: transform 0.1s ease, box-shadow 0.1s ease;
+  }
+  .chunky-button-sm:active {
+    box-shadow: var(--shadow-pressed);
+    transform: translateY(var(--press-offset-button-sm));
+  }
 }
 
 /* When game is active on mobile, hide site chrome and fix scrolling */


### PR DESCRIPTION
## Summary

Closes #533 — Part of epic #529

- Adds **15 shadow CSS custom properties** to `:root` in `globals.css`:
  - 5 chunky drop-shadows (`--shadow-card`, `--shadow-hero`, `--shadow-button`, `--shadow-button-sm`, `--shadow-pressed`)
  - 4 neon glow halos (`--shadow-glow-primary/secondary/tertiary/error`)
  - 2 inset rim lights (`--shadow-rim-top`, `--shadow-rim-inset-deep`)
  - 4 paired press offsets (`--press-offset-card/hero/button/button-sm`)
- Adds `@layer components` **chunky-press recipes** (`.chunky-card`, `.chunky-hero`, `.chunky-button`, `.chunky-button-sm`) that pair drop-shadow with `:active` translateY press-down
- Updates `docs/design-system.md` with Shadows section

No component code changed — token definitions and recipes only.

## Test plan

- [ ] Verify `globals.css` `:root` contains all shadow and press-offset custom properties
- [ ] Verify `.chunky-*` recipes exist in `@layer components`
- [ ] Verify `docs/design-system.md` has Shadows section with all four tables
- [ ] Verify Vercel preview deploys without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)