### PR TITLE
Redesign 10: NavPill primitive (top-nav + side-nav)

### DIFF
--- a/src/components/ui/nav-pill.tsx
+++ b/src/components/ui/nav-pill.tsx
@@ -1,0 +1,84 @@
+'use client'
+
+import { type VariantProps, cva } from 'class-variance-authority'
+import Link from 'next/link'
+import { usePathname } from 'next/navigation'
+import * as React from 'react'
+
+import { cn } from '@/lib/utils'
+
+const navPillVariants = cva(
+  [
+    'inline-flex items-center gap-2 whitespace-nowrap',
+    'font-label text-label-caps uppercase tracking-widest',
+    'transition-all duration-150 ease-out',
+    'focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-container',
+    'disabled:pointer-events-none disabled:opacity-50',
+  ].join(' '),
+  {
+    variants: {
+      layout: {
+        inline: 'px-3 py-2 text-xs border-b-4 border-transparent hover:scale-105',
+        block: [
+          'w-full px-component-px py-3 rounded-ds-sm text-sm',
+          'hover:bg-surface-container-high/60',
+        ].join(' '),
+      },
+    },
+    defaultVariants: {
+      layout: 'inline',
+    },
+  }
+)
+
+export interface NavPillProps
+  extends Omit<React.AnchorHTMLAttributes<HTMLAnchorElement>, 'href'>,
+    VariantProps<typeof navPillVariants> {
+  href: string
+  icon?: string
+  exact?: boolean
+}
+
+const NavPill = React.forwardRef<HTMLAnchorElement, NavPillProps>(
+  ({ className, layout, href, icon, exact = false, children, ...props }, ref) => {
+    const pathname = usePathname()
+    const isActive = exact ? pathname === href : pathname.startsWith(href)
+
+    const activeStyles =
+      layout === 'block'
+        ? 'bg-primary-container text-on-primary-container shadow-glow-primary'
+        : 'border-b-primary-container text-on-surface'
+
+    const inactiveStyles = 'text-on-surface-variant'
+
+    return (
+      <Link
+        ref={ref}
+        href={href}
+        aria-current={isActive ? 'page' : undefined}
+        className={cn(
+          navPillVariants({ layout, className }),
+          isActive ? activeStyles : inactiveStyles
+        )}
+        {...props}
+      >
+        {icon && (
+          <span
+            className={cn(
+              'material-symbols-outlined text-[20px] leading-none',
+              isActive && 'font-variation-settings-fill'
+            )}
+            style={isActive ? { fontVariationSettings: "'FILL' 1" } : undefined}
+            aria-hidden
+          >
+            {icon}
+          </span>
+        )}
+        {children}
+      </Link>
+    )
+  }
+)
+NavPill.displayName = 'NavPill'
+
+export { NavPill, navPillVariants }


### PR DESCRIPTION
## Summary

Closes #539 — Part of epic #529 — **Phase 2: Shared Primitives (3/7)**

New `src/components/ui/nav-pill.tsx` — the link/pill component for top navigation and side navigation.

### Layouts
| Layout | Active state | Use case |
|---|---|---|
| `inline` (default) | `border-b-primary-container` underline | Top pill nav |
| `block` | `bg-primary-container text-on-primary-container` + `shadow-glow-primary` | Side nav rows |

### Features
- **Auto-active detection:** Uses `usePathname()` to compare against `href`; `exact` prop for exact match
- **ARIA:** Sets `aria-current="page"` on active item
- **Material Symbols icon:** Optional `icon` prop (string name), renders filled (`FILL 1`) when active
- **Accessible focus:** `outline-primary-container` focus ring
- **Composes `next/link`:** Works with App Router navigation
- Token-only — no hex or legacy tokens

### Usage
```tsx
<NavPill href="/trivia" icon="quiz" layout="block">Daily Trivia</NavPill>
<NavPill href="/" exact layout="inline">HOME</NavPill>
```

## Test plan

- [ ] Verify Vercel preview deploys without errors
- [ ] No hex literals or legacy tokens

🤖 Generated with [Claude Code](https://claude.com/claude-code)