### PR TITLE
Redesign 14: BrandMark + AmbientOrbs primitives

### DIFF
--- a/src/components/ambient-orbs.tsx
+++ b/src/components/ambient-orbs.tsx
@@ -1,0 +1,59 @@
+import * as React from 'react'
+
+import { cn } from '@/lib/utils'
+
+type OrbColor = 'primary' | 'secondary' | 'tertiary'
+
+const orbColorMap: Record<OrbColor, string> = {
+  primary: 'bg-ds-primary',
+  secondary: 'bg-ds-secondary',
+  tertiary: 'bg-ds-tertiary',
+}
+
+const intensityMap = {
+  low: 'opacity-10',
+  medium: 'opacity-20',
+  high: 'opacity-30',
+} as const
+
+// Deterministic positions so layouts stay stable across renders
+const orbPositions = [
+  { top: '10%', left: '75%', size: 'h-96 w-96' },
+  { top: '60%', left: '10%', size: 'h-80 w-80' },
+  { top: '30%', left: '50%', size: 'h-64 w-64' },
+] as const
+
+export interface AmbientOrbsProps extends React.HTMLAttributes<HTMLDivElement> {
+  palette?: OrbColor[]
+  intensity?: 'low' | 'medium' | 'high'
+}
+
+const AmbientOrbs = React.forwardRef<HTMLDivElement, AmbientOrbsProps>(
+  ({ palette = ['primary', 'secondary'], intensity = 'medium', className, ...props }, ref) => (
+    <div
+      ref={ref}
+      aria-hidden="true"
+      className={cn('pointer-events-none fixed inset-0 z-0 overflow-hidden', className)}
+      {...props}
+    >
+      {palette.map((color, i) => {
+        const pos = orbPositions[i % orbPositions.length]
+        return (
+          <div
+            key={`${color}-${i}`}
+            className={cn(
+              'absolute rounded-full blur-3xl',
+              orbColorMap[color],
+              intensityMap[intensity],
+              pos.size
+            )}
+            style={{ top: pos.top, left: pos.left }}
+          />
+        )
+      })}
+    </div>
+  )
+)
+AmbientOrbs.displayName = 'AmbientOrbs'
+
+export { AmbientOrbs }

--- a/src/components/brand-mark.tsx
+++ b/src/components/brand-mark.tsx
@@ -1,0 +1,50 @@
+import Link from 'next/link'
+import * as React from 'react'
+
+import { cn } from '@/lib/utils'
+
+const sizeStyles = {
+  sm: 'text-lg',
+  md: 'text-2xl',
+  lg: 'text-4xl',
+} as const
+
+export interface BrandMarkProps extends React.HTMLAttributes<HTMLElement> {
+  size?: 'sm' | 'md' | 'lg'
+  href?: string
+}
+
+const BrandMark = React.forwardRef<HTMLElement, BrandMarkProps>(
+  ({ size = 'md', href, className, ...props }, ref) => {
+    const classes = cn(
+      'inline-block font-headline font-bold tracking-tight',
+      'text-primary-container',
+      'drop-shadow-[0_2px_0_var(--surface-container-lowest)]',
+      'select-none',
+      sizeStyles[size],
+      className
+    )
+
+    if (href) {
+      return (
+        <Link
+          ref={ref as React.Ref<HTMLAnchorElement>}
+          href={href}
+          className={cn(classes, 'hover:opacity-90 transition-opacity')}
+          {...(props as React.AnchorHTMLAttributes<HTMLAnchorElement>)}
+        >
+          COMET<span className="text-on-surface-variant">CAVE</span>
+        </Link>
+      )
+    }
+
+    return (
+      <span ref={ref as React.Ref<HTMLSpanElement>} className={classes} {...props}>
+        COMET<span className="text-on-surface-variant">CAVE</span>
+      </span>
+    )
+  }
+)
+BrandMark.displayName = 'BrandMark'
+
+export { BrandMark }


### PR DESCRIPTION
## Summary

Closes #543 — Part of epic #529 — **Phase 2: Shared Primitives (7/7) — COMPLETES PHASE 2**

### BrandMark (`src/components/brand-mark.tsx`)
- "COMET" in `primary-container` + "CAVE" in `on-surface-variant`
- Drop shadow using `surface-container-lowest`
- 3 sizes: `sm`, `md`, `lg`
- Optional `href` renders as `next/link`

### AmbientOrbs (`src/components/ambient-orbs.tsx`)
- Fixed-position blurred radial orbs behind page content
- Configurable `palette` (primary/secondary/tertiary) and `intensity` (low/medium/high)
- Deterministic positions for stable layouts
- `pointer-events-none`, `z-0`, `aria-hidden="true"`
- Static blurs — no animation needed, naturally respects reduced-motion

## Test plan

- [ ] Verify Vercel preview deploys without errors
- [ ] No hex literals or legacy tokens
- [ ] Orbs don't cause horizontal overflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)