### PR TITLE
Redesign 15: Replace global header with pill TopNavBar

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,12 +1,11 @@
 import { Plus_Jakarta_Sans, Be_Vietnam_Pro, Lexend } from 'next/font/google'
-import Link from 'next/link'
 
 import { Footer } from '@/components/footer'
 import { StarField } from '@/components/star-field'
+import { TopNavBar } from '@/components/top-nav-bar'
 
 import './globals.css'
 import { Providers } from './providers'
-import { ROUTE_CONSTANTS } from './route-constants'
 
 import type { Metadata } from 'next'
 import type React from 'react'
@@ -52,70 +51,9 @@ export default function RootLayout({
           />
         </head>
         <body className={`${plusJakartaSans.variable} ${beVietnamPro.variable} ${lexend.variable} ${beVietnamPro.className}`}>
-          <div id="site-wrapper" className="min-h-screen flex flex-col bg-space-black text-cream-white relative overflow-hidden">
+          <div id="site-wrapper" className="min-h-screen flex flex-col bg-surface-dim text-on-surface relative overflow-hidden">
             <StarField />
-            <header className="p-4 z-10 relative">
-              <div className="container mx-auto flex justify-between items-center flex-col md:flex-row">
-                <div>
-                  <Link
-                    href="/"
-                    className="text-2xl font-bold text-cream-white hover:text-cream-white/90 transition-colors"
-                  >
-                    COMETCAVE<span className="text-slate-400">.COM</span>
-                  </Link>
-                </div>
-                <nav className="flex gap-6 w-full justify-end md:justify-end gap-y-0 mt-1 md:mt-0 flex-wrap">
-                  <Link
-                    href={ROUTE_CONSTANTS.HOME}
-                    className="text-cream-white hover:text-cream-white/80 transition-colors"
-                  >
-                    HOME
-                  </Link>
-                  <Link
-                    href={ROUTE_CONSTANTS.ORACLE}
-                    className="text-space-purple hover:text-space-purple/80 transition-colors font-semibold"
-                  >
-                    I-CHING ORACLE
-                  </Link>
-                  <Link
-                    href={ROUTE_CONSTANTS.RING_TOSS}
-                    className="text-cream-white hover:text-cream-white/80 transition-colors"
-                  >
-                    RING TOSS
-                  </Link>
-                  <Link
-                    href={ROUTE_CONSTANTS.TAP_TAP_ADVENTURE}
-                    className="text-cream-white hover:text-cream-white/80 transition-colors"
-                  >
-                    TAP TAP ADVENTURE
-                  </Link>
-                  <Link
-                    href={ROUTE_CONSTANTS.CHAT_ROOM}
-                    className="text-cream-white hover:text-cream-white/80 transition-colors"
-                  >
-                    CHAT ROOM
-                  </Link>
-                  <Link
-                    href={ROUTE_CONSTANTS.TRIVIA}
-                    className="text-space-gold hover:text-space-gold/80 transition-colors font-semibold"
-                  >
-                    DAILY TRIVIA
-                  </Link>
-                  <Link
-                    href={ROUTE_CONSTANTS.SECRET_WORD}
-                    className="text-cream-white hover:text-cream-white/80 transition-colors"
-                  >
-                    SECRET WORD
-                  </Link>
-                  <Link
-                    href={ROUTE_CONSTANTS.VOTERS}
-                    className="text-cream-white hover:text-cream-white/80 transition-colors"
-                  >
-                    VOTERS
-                  </Link>
-                </nav>
-              </div>
-            </header>
+            <TopNavBar />
             <main className="flex-1 container mx-auto p-4 z-10 relative">{children}</main>
             <Footer />
           </div>

--- a/src/components/top-nav-bar.tsx
+++ b/src/components/top-nav-bar.tsx
@@ -7,7 +7,7 @@ import { NavPill } from '@/components/ui/nav-pill'
 
 import { ROUTE_CONSTANTS } from '@/app/route-constants'
 
-const navItems = [
+const navItems: readonly { href: string; label: string; exact?: boolean }[] = [
   { href: ROUTE_CONSTANTS.HOME, label: 'HOME', exact: true },
   { href: ROUTE_CONSTANTS.TRIVIA, label: 'TRIVIA' },
   { href: ROUTE_CONSTANTS.ORACLE, label: 'ORACLE' },
@@ -15,7 +15,7 @@ const navItems = [
   { href: ROUTE_CONSTANTS.CHAT_ROOM, label: 'CHAT' },
   { href: ROUTE_CONSTANTS.SECRET_WORD, label: 'SECRET WORD' },
   { href: ROUTE_CONSTANTS.VOTERS, label: 'VOTERS' },
-] as const
+]
 
 export function TopNavBar() {
   return (

--- a/src/components/top-nav-bar.tsx
+++ b/src/components/top-nav-bar.tsx
@@ -1,0 +1,52 @@
+'use client'
+
+import * as React from 'react'
+
+import { BrandMark } from '@/components/brand-mark'
+import { NavPill } from '@/components/ui/nav-pill'
+
+import { ROUTE_CONSTANTS } from '@/app/route-constants'
+
+const navItems = [
+  { href: ROUTE_CONSTANTS.HOME, label: 'HOME', exact: true },
+  { href: ROUTE_CONSTANTS.TRIVIA, label: 'TRIVIA' },
+  { href: ROUTE_CONSTANTS.ORACLE, label: 'ORACLE' },
+  { href: ROUTE_CONSTANTS.TAP_TAP_ADVENTURE, label: 'TAP TAP' },
+  { href: ROUTE_CONSTANTS.CHAT_ROOM, label: 'CHAT' },
+  { href: ROUTE_CONSTANTS.SECRET_WORD, label: 'SECRET WORD' },
+  { href: ROUTE_CONSTANTS.VOTERS, label: 'VOTERS' },
+] as const
+
+export function TopNavBar() {
+  return (
+    <header className="sticky top-0 z-30 mt-4 mx-4">
+      <div className="mx-auto max-w-7xl">
+        <nav
+          className={[
+            'flex items-center gap-2 px-4 py-2',
+            'bg-surface-container-lowest/90 backdrop-blur-md',
+            'rounded-full',
+            'border-4 border-surface-container-lowest',
+            'shadow-button',
+          ].join(' ')}
+          aria-label="Main navigation"
+        >
+          <BrandMark href="/" size="sm" className="shrink-0 mr-2" />
+
+          <div className="flex items-center gap-1 overflow-x-auto scrollbar-none flex-1">
+            {navItems.map(({ href, label, exact }) => (
+              <NavPill
+                key={href}
+                href={href}
+                layout="inline"
+                exact={exact}
+              >
+                {label}
+              </NavPill>
+            ))}
+          </div>
+        </nav>
+      </div>
+    </header>
+  )
+}


### PR DESCRIPTION
## Summary

Closes #544 — Part of epic #529 — **Phase 3: Cave Shell (1/4)**

Replaces the legacy inline `<header>` in `layout.tsx` with a new sticky pill-shaped TopNavBar component.

### Before → After
- **Before:** Flat text links (`text-cream-white`, `text-space-purple`, `text-space-gold`) in a flex row
- **After:** Sticky pill nav with `bg-surface-container-lowest/90` backdrop blur, rounded-full shape, border treatment, and `shadow-button` drop shadow

### Changes
- **New:** `src/components/top-nav-bar.tsx` — composes `BrandMark` + `NavPill` primitives
- **Modified:** `src/app/layout.tsx` — swaps inline header for `<TopNavBar />`, migrates `#site-wrapper` from legacy tokens (`bg-space-black text-cream-white`) to semantic tokens (`bg-surface-dim text-on-surface`)
- **Removed:** `Link` import and `ROUTE_CONSTANTS` import from layout.tsx (moved into TopNavBar)

### Features
- Sticky positioning (`sticky top-0 z-30 mt-4 mx-4`)
- Active state via `NavPill`'s `usePathname()` detection
- `aria-label="Main navigation"` on `<nav>`
- Horizontal scroll on mobile for overflow links
- Ring Toss intentionally omitted from nav (being sunset per #567)

## Test plan

- [ ] Verify Vercel preview deploys without errors
- [ ] Verify nav renders on all routes
- [ ] Verify active state highlights correctly
- [ ] Verify mobile horizontal scroll works

🤖 Generated with [Claude Code](https://claude.com/claude-code)