### PR TITLE
Redesign 18: Wire AmbientOrbs into root layout (replace StarField)

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,7 +1,7 @@
 import { Plus_Jakarta_Sans, Be_Vietnam_Pro, Lexend } from 'next/font/google'
 
+import { AmbientOrbs } from '@/components/ambient-orbs'
 import { Footer } from '@/components/footer'
-import { StarField } from '@/components/star-field'
 import { TopNavBar } from '@/components/top-nav-bar'
 
 import './globals.css'
@@ -52,7 +52,7 @@ export default function RootLayout({
         </head>
         <body className={`${plusJakartaSans.variable} ${beVietnamPro.variable} ${lexend.variable} ${beVietnamPro.className}`}>
           <div id="site-wrapper" className="min-h-screen flex flex-col bg-surface-dim text-on-surface relative overflow-hidden">
-            <StarField />
+            <AmbientOrbs palette={['primary', 'secondary', 'tertiary']} intensity="medium" />
             <TopNavBar />
             <main className="flex-1 container mx-auto p-4 z-10 relative">{children}</main>
             <Footer />


### PR DESCRIPTION
## Summary

Closes #547 — Part of epic #529 — **Phase 3: Cave Shell (3/4)**

Replaces the `<StarField />` particle background with `<AmbientOrbs />` — the blurred radial orb system from issue #543.

### Changes
- **Removed:** `StarField` import from `layout.tsx`
- **Added:** `AmbientOrbs` with `palette={['primary', 'secondary', 'tertiary']}` and `intensity="medium"`
- Orbs render at `z-0`, `fixed`, `pointer-events-none`, `aria-hidden`
- No layout shift — orbs are positioned absolutely within a fixed container

### Note
The `StarField` component file (`src/components/star-field.tsx`) is kept for now — it may still be useful for specific pages. The import is just removed from the root layout.

## Test plan

- [ ] Verify Vercel preview deploys without errors
- [ ] Verify ambient orbs render behind content
- [ ] Verify orbs don't intercept clicks

🤖 Generated with [Claude Code](https://claude.com/claude-code)