### PR TITLE
Redesign 16: SideNavBar (desktop, game routes)

### DIFF
--- a/src/app/trivia/layout.tsx
+++ b/src/app/trivia/layout.tsx
@@ -1,7 +1,12 @@
+import { GameShell } from '@/components/game-shell'
 import { AuthProvider } from '@/hooks/useAuth'
 
 import type { ReactNode } from 'react'
 
 export default function TriviaLayout({ children }: { children: ReactNode }) {
-  return <AuthProvider>{children}</AuthProvider>
+  return (
+    <AuthProvider>
+      <GameShell>{children}</GameShell>
+    </AuthProvider>
+  )
 }

--- a/src/components/game-shell.tsx
+++ b/src/components/game-shell.tsx
@@ -1,0 +1,12 @@
+import * as React from 'react'
+
+import { SideNavBar } from '@/components/side-nav-bar'
+
+export function GameShell({ children }: { children: React.ReactNode }) {
+  return (
+    <>
+      <SideNavBar />
+      <div className="md:ml-[280px]">{children}</div>
+    </>
+  )
+}

--- a/src/components/side-nav-bar.tsx
+++ b/src/components/side-nav-bar.tsx
@@ -1,0 +1,60 @@
+'use client'
+
+import * as React from 'react'
+
+import { BrandMark } from '@/components/brand-mark'
+import { NavPill } from '@/components/ui/nav-pill'
+
+import { ROUTE_CONSTANTS } from '@/app/route-constants'
+
+const gameNavItems: readonly { href: string; label: string; icon: string }[] = [
+  { href: ROUTE_CONSTANTS.HOME, label: 'Home', icon: 'home' },
+  { href: ROUTE_CONSTANTS.TRIVIA, label: 'Daily Trivia', icon: 'quiz' },
+  { href: ROUTE_CONSTANTS.ORACLE, label: 'Oracle', icon: 'auto_awesome' },
+  { href: ROUTE_CONSTANTS.TAP_TAP_ADVENTURE, label: 'Tap Tap', icon: 'swords' },
+  { href: ROUTE_CONSTANTS.CHAT_ROOM, label: 'Chat Room', icon: 'chat' },
+  { href: ROUTE_CONSTANTS.SECRET_WORD, label: 'Secret Word', icon: 'lock' },
+  { href: ROUTE_CONSTANTS.VOTERS, label: 'Voters', icon: 'how_to_vote' },
+]
+
+export function SideNavBar() {
+  return (
+    <aside
+      className={[
+        'hidden md:flex flex-col',
+        'fixed top-0 left-0 z-20',
+        'h-screen w-[280px]',
+        'bg-surface-container-low/95 backdrop-blur-md',
+        'rounded-r-[3rem]',
+        'border-r-4 border-r-surface-container-lowest',
+        'border-t-0 border-b-0',
+        'py-8 px-4',
+        'shadow-hero',
+      ].join(' ')}
+      aria-label="Game navigation"
+    >
+      <div className="px-4 mb-8">
+        <BrandMark href="/" size="sm" />
+      </div>
+
+      <nav className="flex flex-col gap-1 flex-1 overflow-y-auto">
+        {gameNavItems.map(({ href, label, icon }) => (
+          <NavPill
+            key={href}
+            href={href}
+            layout="block"
+            icon={icon}
+          >
+            {label}
+          </NavPill>
+        ))}
+      </nav>
+
+      <div className="px-4 pt-4 border-t border-t-outline-variant/30">
+        <p className="text-xs text-on-surface-variant/60 font-label uppercase tracking-widest">
+          CometCave Arcade
+        </p>
+      </div>
+    </aside>
+  )
+}


### PR DESCRIPTION
## Summary

Closes #545 — Part of epic #529 — **Phase 3: Cave Shell (4/4) — COMPLETES PHASE 3**

### New files
- **`src/components/side-nav-bar.tsx`** — Rounded-r-3xl side panel with NavPill block items
- **`src/components/game-shell.tsx`** — Wrapper that renders SideNavBar + shifts content right

### SideNavBar features
- `hidden md:flex` — desktop only, mobile uses top nav
- `bg-surface-container-low/95 backdrop-blur-md`
- `rounded-r-[3rem]` with border treatment and `shadow-hero`
- 7 nav items with Material Symbols icons (home, quiz, auto_awesome, swords, chat, lock, how_to_vote)
- Active state via NavPill's `usePathname()` detection
- BrandMark at top, "CometCave Arcade" footer

### Integration approach
- **Trivia route** wired as proof of concept — `GameShell` wraps inside `AuthProvider`
- **Other game routes** will adopt `GameShell` in their Phase 6 per-game refresh issues
- **Decision:** Per-route opt-in via `GameShell` wrapper rather than a `(game)` route group, since game routes have diverse layout needs (auth providers, game-active class, etc.)

### Identity tile (deferred)
The `useAuth` hook is only available under `AuthProvider` which not all game routes use. Identity tile will be added when auth surfaces are refreshed (#553).

## Test plan

- [ ] Verify Vercel preview deploys without errors
- [ ] Verify side nav renders on trivia route at desktop width
- [ ] Verify side nav hidden on mobile
- [ ] Verify content shifts right by 280px on desktop

🤖 Generated with [Claude Code](https://claude.com/claude-code)