### PR TITLE
Redesign 21: Trivia HUD (Flee, ScoreChip, Chamber Depth progress)

### DIFF
--- a/src/app/trivia/components/TriviaGame.tsx
+++ b/src/app/trivia/components/TriviaGame.tsx
@@ -10,6 +10,8 @@ import { ChunkyCard, ChunkyCardContent, ChunkyCardHeader } from '@/components/ui
 import { Input } from '@/components/ui/input'
 import { getTodayPST } from '@/lib/dates'
 
+import { TriviaHUD } from './TriviaHUD'
+
 // Scoring config per difficulty
 const SCORING = {
   easy: { maxPoints: 300, timeLimit: 30 },
@@ -28,7 +30,7 @@ function getQuestionConfig(q: TriviaQuestion) {
 
 type GamePhase = 'loading' | 'playing' | 'answered' | 'finished'
 
-export function TriviaGame({ onFinish }: { onFinish: (result: TriviaGameResult) => void }) {
+export function TriviaGame({ onFinish, onFlee }: { onFinish: (result: TriviaGameResult) => void; onFlee?: () => void }) {
   const [questions, setQuestions] = useState<TriviaQuestion[]>([])
   const [currentIndex, setCurrentIndex] = useState(0)
   const [phase, setPhase] = useState<GamePhase>('loading')
@@ -218,8 +220,6 @@ export function TriviaGame({ onFinish }: { onFinish: (result: TriviaGameResult) 
 
   const question = questions[currentIndex]
   const config = getQuestionConfig(question)
-  const timerPercent = (timeRemaining / config.timeLimit) * 100
-  const timerColor = timerPercent > 60 ? 'bg-green-500' : timerPercent > 30 ? 'bg-yellow-500' : 'bg-red-500'
 
   // Difficulty badge colors
   const diffBadgeColor = {
@@ -230,37 +230,16 @@ export function TriviaGame({ onFinish }: { onFinish: (result: TriviaGameResult) 
 
   return (
     <div className="flex flex-col gap-3 sm:gap-4 max-w-lg mx-auto py-2 sm:py-4">
-      {/* Top bar: progress + score */}
-      <div className="flex justify-between items-center">
-        <div className="flex gap-1.5">
-          {questions.map((_, i) => (
-            <div
-              key={i}
-              className={`w-3 h-3 rounded-full ${
-                i < currentIndex
-                  ? answers[i]?.correct
-                    ? 'bg-green-500'
-                    : 'bg-red-500'
-                  : i === currentIndex
-                  ? 'bg-ds-tertiary'
-                  : 'bg-surface-container-highest'
-              }`}
-            />
-          ))}
-        </div>
-        <div className="text-ds-tertiary font-bold text-lg">{totalScore} pts</div>
-      </div>
-
-      {/* Timer bar */}
-      <div className="w-full bg-surface-container-highest rounded-full h-2 overflow-hidden">
-        <div
-          className={`h-full ${timerColor} transition-all duration-100 ease-linear`}
-          style={{ width: `${timerPercent}%` }}
-        />
-      </div>
-      <div className="text-center text-sm text-on-surface/60">
-        {Math.ceil(timeRemaining)}s
-      </div>
+      {/* HUD: Flee + score + timer + progress */}
+      <TriviaHUD
+        currentQuestion={currentIndex}
+        totalQuestions={questions.length}
+        score={totalScore}
+        timeRemaining={timeRemaining}
+        timeLimit={config.timeLimit}
+        onFlee={onFlee ?? (() => window.location.reload())}
+        isPlaying={phase === 'playing'}
+      />
 
       {/* Question card */}
       <ChunkyCard variant="surface-variant" shadow="hero">

--- a/src/app/trivia/components/TriviaHUD.tsx
+++ b/src/app/trivia/components/TriviaHUD.tsx
@@ -1,0 +1,114 @@
+'use client'
+
+import { useState } from 'react'
+
+import { ChunkyButton } from '@/components/ui/chunky-button'
+import { Pill, ScoreChip } from '@/components/ui/pill'
+import { ProgressSegments } from '@/components/ui/progress-segments'
+
+export interface TriviaHUDProps {
+  currentQuestion: number
+  totalQuestions: number
+  score: number
+  timeRemaining: number
+  timeLimit: number
+  onFlee: () => void
+  isPlaying: boolean
+}
+
+export function TriviaHUD({
+  currentQuestion,
+  totalQuestions,
+  score,
+  timeRemaining,
+  timeLimit,
+  onFlee,
+  isPlaying,
+}: TriviaHUDProps) {
+  const [showFleeConfirm, setShowFleeConfirm] = useState(false)
+
+  const timerPercent = (timeRemaining / timeLimit) * 100
+  const timerColor =
+    timerPercent > 60
+      ? 'bg-green-500'
+      : timerPercent > 30
+        ? 'bg-yellow-500'
+        : 'bg-red-500'
+
+  const handleFlee = () => {
+    if (isPlaying) {
+      setShowFleeConfirm(true)
+    } else {
+      onFlee()
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-3">
+      {/* Top bar: Flee + timer pill + score */}
+      <div className="flex items-center justify-between gap-3">
+        <ChunkyButton
+          variant="exit"
+          size="sm"
+          onClick={handleFlee}
+          iconStart={
+            <span className="material-symbols-outlined text-[18px]">close</span>
+          }
+        >
+          <span className="hidden sm:inline">Flee</span>
+        </ChunkyButton>
+
+        <Pill tone="neutral" size="sm">
+          {Math.ceil(timeRemaining)}s
+        </Pill>
+
+        <ScoreChip score={score} />
+      </div>
+
+      {/* Timer bar */}
+      <div className="w-full bg-surface-container-highest rounded-full h-2 overflow-hidden">
+        <div
+          className={`h-full ${timerColor} transition-all duration-100 ease-linear`}
+          style={{ width: `${timerPercent}%` }}
+        />
+      </div>
+
+      {/* Chamber Depth progress */}
+      <ProgressSegments
+        total={totalQuestions}
+        current={currentQuestion + 1}
+        label="Chamber Depth"
+      />
+
+      {/* Flee confirmation dialog */}
+      {showFleeConfirm && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-surface-dim/80 backdrop-blur-sm">
+          <div className="bg-surface-container-high rounded-ds-lg p-8 max-w-sm mx-4 shadow-hero text-center flex flex-col gap-4">
+            <p className="text-on-surface text-body-lg">
+              Leave the cavern? Your unfinished round will fade.
+            </p>
+            <div className="flex gap-3 justify-center">
+              <ChunkyButton
+                variant="secondary"
+                size="sm"
+                onClick={() => setShowFleeConfirm(false)}
+              >
+                Stay
+              </ChunkyButton>
+              <ChunkyButton
+                variant="exit"
+                size="sm"
+                onClick={() => {
+                  setShowFleeConfirm(false)
+                  onFlee()
+                }}
+              >
+                Flee
+              </ChunkyButton>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

Closes #550 — Part of epic #529 — **Phase 4: Trivia (3/6)**

New `TriviaHUD.tsx` component — the transactional header inside the active trivia game.

### Features
- **Flee button:** `ChunkyButton exit` with `close` icon, label hidden on mobile (`hidden sm:inline`)
- **Flee confirmation:** Modal dialog when mid-question: "Leave the cavern? Your unfinished round will fade." with Stay/Flee options
- **ScoreChip:** Shows current score using the `ScoreChip` primitive
- **Timer pill:** Countdown in seconds using `Pill neutral`
- **Timer bar:** Visual progress bar with green/yellow/red states
- **Chamber Depth:** `ProgressSegments` showing question progress (e.g., "Chamber Depth 3/5")

### Integration
- `TriviaHUD` wired into `TriviaGame`, replacing inline progress dots + timer + score display
- New `onFlee` optional prop on `TriviaGame` (defaults to page reload)
- Removed unused `timerPercent`/`timerColor` variables from TriviaGame (now internal to HUD)

## Test plan

- [ ] Verify Vercel preview deploys without errors
- [ ] Verify HUD renders during active game
- [ ] Verify Flee button shows confirmation when mid-question
- [ ] Verify progress bar advances with questions

🤖 Generated with [Claude Code](https://claude.com/claude-code)