### PR TITLE
Redesign 22: Trivia results / end-of-session refresh

### DIFF
--- a/src/app/trivia/components/TriviaResults.tsx
+++ b/src/app/trivia/components/TriviaResults.tsx
@@ -4,8 +4,9 @@ import { useEffect, useState } from 'react'
 
 import { useTriviaUser } from '@/app/trivia/hooks/useTriviaUser'
 import type { TriviaGameResult } from '@/app/trivia/models/trivia'
-import { Button } from '@/components/ui/button'
-import { Card, CardContent } from '@/components/ui/card'
+import { ChunkyButton } from '@/components/ui/chunky-button'
+import { ChunkyCard, ChunkyCardContent } from '@/components/ui/chunky-card'
+import { Pill } from '@/components/ui/pill'
 import { useAuth } from '@/hooks/useAuth'
 import { formatDisplayDate } from '@/lib/dates'
 import { getDailyCategory } from '@/lib/trivia/categories'
@@ -131,20 +132,20 @@ export function TriviaResults({ result, onBack, onViewStats, onViewLeaderboard }
     <div className="flex flex-col items-center gap-5 max-w-lg mx-auto py-6">
       {/* Header */}
       <div className="text-center">
-        <h2 className="text-3xl font-bold text-space-gold mb-1">
+        <h2 aria-live="polite" className="font-headline text-headline-lg text-ds-tertiary drop-shadow-[0_4px_0_var(--surface-container-lowest)] mb-1">
           {getScoreRating(correctPercent)}
         </h2>
-        <p className="text-cream-white/50 text-sm">{formatDisplayDate(result.date)}</p>
+        <p className="text-on-surface/50 text-sm">{formatDisplayDate(result.date)}</p>
       </div>
 
       {/* Score card */}
-      <Card className="w-full bg-space-dark/80 border-space-grey">
-        <CardContent className="pt-6">
+      <ChunkyCard variant="surface-variant" className="w-full bg-surface-container/80 border-outline-variant">
+        <ChunkyCardContent className="pt-6">
           <div className="text-center mb-4">
-            <div className="text-5xl font-bold text-space-gold">
+            <div className="text-5xl font-bold text-ds-tertiary">
               {result.score.toLocaleString()}
             </div>
-            <div className="text-cream-white/40 text-sm">
+            <div className="text-on-surface/40 text-sm">
               / {MAX_SCORE.toLocaleString()} ({scorePercent}%)
             </div>
           </div>
@@ -152,18 +153,18 @@ export function TriviaResults({ result, onBack, onViewStats, onViewLeaderboard }
           {/* Summary stats */}
           <div className="grid grid-cols-3 gap-3 mb-4">
             <div className="text-center">
-              <div className="text-xl font-bold text-cream-white">
+              <div className="text-xl font-bold text-on-surface">
                 {result.correct}/{result.total}
               </div>
-              <div className="text-cream-white/50 text-xs">Correct</div>
+              <div className="text-on-surface/50 text-xs">Correct</div>
             </div>
             <div className="text-center">
-              <div className="text-xl font-bold text-cream-white">{correctPercent}%</div>
-              <div className="text-cream-white/50 text-xs">Accuracy</div>
+              <div className="text-xl font-bold text-on-surface">{correctPercent}%</div>
+              <div className="text-on-surface/50 text-xs">Accuracy</div>
             </div>
             <div className="text-center">
-              <div className="text-xl font-bold text-space-gold">{currentStreak}</div>
-              <div className="text-cream-white/50 text-xs">Streak</div>
+              <div className="text-xl font-bold text-ds-tertiary">{currentStreak}</div>
+              <div className="text-on-surface/50 text-xs">Streak</div>
             </div>
           </div>
 
@@ -174,44 +175,50 @@ export function TriviaResults({ result, onBack, onViewStats, onViewLeaderboard }
                 key={i}
                 className={`w-9 h-9 rounded flex items-center justify-center text-lg ${
                   a.correct
-                    ? 'bg-green-600/40 border border-green-500/50'
-                    : 'bg-red-600/40 border border-red-500/50'
+                    ? 'bg-primary-container/40 border border-primary-container/50'
+                    : 'bg-ds-error/40 border border-ds-error/50'
                 }`}
               >
                 {a.correct ? '🟩' : '🟥'}
               </div>
             ))}
           </div>
-        </CardContent>
-      </Card>
+        </ChunkyCardContent>
+      </ChunkyCard>
+
+      {currentStreak > 0 && (
+        <Pill tone={currentStreak >= stats.bestStreak ? 'hot' : 'info'} icon="local_fire_department">
+          {currentStreak} day streak
+        </Pill>
+      )}
 
       {/* Per-question breakdown */}
-      <Card className="w-full bg-space-dark/80 border-space-grey">
-        <CardContent className="pt-4">
-          <h3 className="text-cream-white/70 text-sm font-semibold mb-3 uppercase tracking-wide">
+      <ChunkyCard variant="surface-variant" className="w-full bg-surface-container/80 border-outline-variant">
+        <ChunkyCardContent className="pt-4">
+          <h3 className="text-on-surface/70 text-sm font-semibold mb-3 uppercase tracking-wide">
             Question Breakdown
           </h3>
           <div className="flex flex-col gap-2">
             {result.answers.map((a, i) => (
               <div
                 key={i}
-                className="flex items-center justify-between py-2 px-3 rounded bg-space-black/40"
+                className="flex items-center justify-between py-2 px-3 rounded bg-surface-dim/40"
               >
                 <div className="flex items-center gap-3">
-                  <span className="text-cream-white/50 text-sm font-mono w-4">
+                  <span className="text-on-surface/50 text-sm font-mono w-4">
                     {i + 1}
                   </span>
-                  <span className={`text-lg ${a.correct ? 'text-green-400' : 'text-red-400'}`}>
+                  <span className={`text-lg ${a.correct ? 'text-ds-primary' : 'text-ds-error'}`}>
                     {a.correct ? '✓' : '✗'}
                   </span>
                 </div>
                 <div className="flex items-center gap-3">
-                  <span className="text-cream-white/40 text-xs">
+                  <span className="text-on-surface/40 text-xs">
                     {formatTime(a.timeMs)}
                   </span>
                   <span
                     className={`font-bold text-sm min-w-[4rem] text-right ${
-                      a.correct ? 'text-space-gold' : 'text-cream-white/30'
+                      a.correct ? 'text-ds-tertiary' : 'text-on-surface/30'
                     }`}
                   >
                     +{a.points}
@@ -220,18 +227,18 @@ export function TriviaResults({ result, onBack, onViewStats, onViewLeaderboard }
               </div>
             ))}
           </div>
-        </CardContent>
-      </Card>
+        </ChunkyCardContent>
+      </ChunkyCard>
 
       {/* Share button */}
-      <Button
-        variant="space"
-        size="lg"
-        className="w-full py-4 text-lg"
+      <ChunkyButton
+        variant="primary"
+        size="hero"
+        className="w-full"
         onClick={handleShare}
       >
         {copied ? 'Copied!' : 'Share Score'}
-      </Button>
+      </ChunkyButton>
 
       {!user && (
         <SignInCard
@@ -241,24 +248,24 @@ export function TriviaResults({ result, onBack, onViewStats, onViewLeaderboard }
       )}
 
       {/* Countdown to next reset */}
-      <div className="text-center text-cream-white/40 text-sm">
-        Next trivia in <span className="text-cream-white/60 font-mono">{countdown}</span>
+      <div className="text-center text-on-surface/40 text-sm">
+        Next trivia in <span className="text-on-surface/60 font-mono">{countdown}</span>
       </div>
 
       {/* Navigation */}
       <div className="grid grid-cols-3 gap-2 w-full">
-        <Button variant="outline" onClick={onBack}>
+        <ChunkyButton variant="secondary" size="sm" onClick={onBack}>
           Back
-        </Button>
+        </ChunkyButton>
         {onViewStats && (
-          <Button variant="outline" onClick={onViewStats}>
+          <ChunkyButton variant="secondary" size="sm" onClick={onViewStats}>
             Stats
-          </Button>
+          </ChunkyButton>
         )}
         {onViewLeaderboard && (
-          <Button variant="outline" onClick={onViewLeaderboard}>
+          <ChunkyButton variant="secondary" size="sm" onClick={onViewLeaderboard}>
             Board
-          </Button>
+          </ChunkyButton>
         )}
       </div>
     </div>


### PR DESCRIPTION
## Summary

Closes #551 — Part of epic #529 — **Phase 4: Trivia (4/6)**

Refreshes `TriviaResults.tsx` with design-system tokens and primitives.

### Changes
- **Score heading:** `font-headline text-headline-lg text-ds-tertiary` with chunky drop-shadow
- **Score/breakdown cards:** `Card` → `ChunkyCard variant="surface-variant"` 
- **Share button:** `Button variant="space"` → `ChunkyButton variant="primary" size="hero"`
- **Nav buttons:** `Button variant="outline"` → `ChunkyButton variant="secondary" size="sm"`
- **Streak Pill:** Added after score card — `Pill tone="hot"` when at best, `tone="info"` otherwise
- **Result squares:** `bg-green-600` → `bg-primary-container`, `bg-red-600` → `bg-ds-error`
- **Accessibility:** `aria-live="polite"` on result heading
- All legacy tokens migrated (space-gold, cream-white, space-dark, space-black, etc.)
- All business logic preserved (share text, countdown, scoring, callbacks)

## Test plan

- [ ] Verify Vercel preview deploys without errors
- [ ] Verify results screen shows after completing trivia
- [ ] Verify share button copies text to clipboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)