### PR TITLE
Redesign 23: Trivia Stats + Leaderboard refresh

### DIFF
--- a/src/app/trivia/components/TriviaLeaderboard.tsx
+++ b/src/app/trivia/components/TriviaLeaderboard.tsx
@@ -3,8 +3,9 @@
 import { useEffect, useState } from 'react'
 
 import { useTriviaUser } from '@/app/trivia/hooks/useTriviaUser'
-import { Button } from '@/components/ui/button'
-import { Card, CardContent } from '@/components/ui/card'
+import { ChunkyButton } from '@/components/ui/chunky-button'
+import { ChunkyCard, ChunkyCardContent } from '@/components/ui/chunky-card'
+import { Pill } from '@/components/ui/pill'
 import { useAuth } from '@/hooks/useAuth'
 import { getTodayPST } from '@/lib/dates'
 import { getDailyCategory } from '@/lib/trivia/categories'
@@ -99,7 +100,7 @@ export function TriviaLeaderboard({ onBack }: { onBack: () => void }) {
 
     if (data.entries.length === 0) {
       return (
-        <div className="text-center text-cream-white/50 py-8 px-4">
+        <div className="text-center text-on-surface/50 py-8 px-4">
           {data.notice ?? 'No scores yet. Be the first!'}
         </div>
       )
@@ -155,13 +156,13 @@ export function TriviaLeaderboard({ onBack }: { onBack: () => void }) {
   return (
     <div className="flex flex-col gap-4 max-w-lg mx-auto py-6">
       <div className="text-center">
-        <h2 className="text-3xl font-bold text-space-gold mb-1 inline-flex items-center gap-2">
+        <h2 className="text-3xl font-bold text-ds-tertiary mb-1 inline-flex items-center gap-2">
           Leaderboard
           <ResetNoticeButton />
         </h2>
         {authName ? (
-          <p className="text-cream-white/50 text-sm">
-            Playing as <span className="text-space-gold">{authName}</span>
+          <p className="text-on-surface/50 text-sm">
+            Playing as <span className="text-ds-tertiary">{authName}</span>
           </p>
         ) : null}
       </div>
@@ -173,44 +174,44 @@ export function TriviaLeaderboard({ onBack }: { onBack: () => void }) {
       {/* Tabs */}
       <div className="grid grid-cols-3 gap-2">
         {(['daily', 'weekly', 'alltime'] as Period[]).map((p) => (
-          <Button
+          <ChunkyButton
             key={p}
-            variant={period === p ? 'space' : 'outline'}
+            variant={period === p ? 'space' : 'secondary'}
             onClick={() => setPeriod(p)}
             className="capitalize"
           >
             {p === 'alltime' ? 'All-Time' : p}
-          </Button>
+          </ChunkyButton>
         ))}
       </div>
 
       {/* Content */}
-      <Card className="bg-space-dark/80 border-space-grey">
-        <CardContent className="pt-4 pb-4">
+      <ChunkyCard variant="surface-container-high" className="bg-surface-container/80 border-outline-variant">
+        <ChunkyCardContent className="pt-4 pb-4">
           {loading ? (
-            <div className="text-center text-cream-white/50 py-8">Loading...</div>
+            <div className="text-center text-on-surface/50 py-8">Loading...</div>
           ) : error ? (
-            <div className="text-center text-red-400 py-8">{error}</div>
+            <div className="text-center text-ds-error py-8">{error}</div>
           ) : (
             <div className="flex flex-col gap-1.5">{renderEntries()}</div>
           )}
-        </CardContent>
-      </Card>
+        </ChunkyCardContent>
+      </ChunkyCard>
 
       {/* Share leaderboard button — daily tab only */}
       {period === 'daily' && (data?.entries?.length ?? 0) > 0 && (
-        <Button
-          variant="outline"
+        <ChunkyButton
+          variant="secondary"
           onClick={handleShareLeaderboard}
           className="w-full"
         >
           {copied ? '✅ Copied!' : '📋 Share Leaderboard'}
-        </Button>
+        </ChunkyButton>
       )}
 
-      <Button variant="outline" onClick={onBack} className="w-full">
+      <ChunkyButton variant="secondary" onClick={onBack} className="w-full">
         Back to Trivia
-      </Button>
+      </ChunkyButton>
     </div>
   )
 }
@@ -234,27 +235,27 @@ function LeaderboardRow({
     <div
       className={`flex items-center justify-between py-2.5 px-3 rounded ${
         isCurrentUser
-          ? 'bg-space-gold/20 border border-space-gold/40'
-          : 'bg-space-black/40'
+          ? 'bg-ds-tertiary/20 border border-ds-tertiary/40'
+          : 'bg-surface-dim/40'
       }`}
     >
       <div className="flex items-center gap-3 min-w-0 flex-1">
         <div className="flex items-center justify-center w-8">
           {rankEmoji ? (
-            <span className="text-xl">{rankEmoji}</span>
+            <Pill tone="success">{rankEmoji}</Pill>
           ) : (
-            <span className="text-cream-white/50 text-sm font-mono">#{rank}</span>
+            <Pill tone="neutral">#{rank}</Pill>
           )}
         </div>
         <div className="min-w-0 flex-1">
-          <div className={`font-medium truncate ${isCurrentUser ? 'text-space-gold' : 'text-cream-white'}`}>
+          <div className={`font-medium truncate ${isCurrentUser ? 'text-ds-tertiary' : 'text-on-surface'}`}>
             {name}
-            {isCurrentUser && <span className="text-xs ml-2 text-space-gold/70">(you)</span>}
+            {isCurrentUser && <span className="text-xs ml-2 text-ds-tertiary/70">(you)</span>}
           </div>
-          <div className="text-cream-white/40 text-xs">{secondary}</div>
+          <div className="text-on-surface/40 text-xs">{secondary}</div>
         </div>
       </div>
-      <div className={`font-bold text-right ${isCurrentUser ? 'text-space-gold' : 'text-cream-white'}`}>
+      <div className={`font-bold text-right ${isCurrentUser ? 'text-ds-tertiary' : 'text-on-surface'}`}>
         {primary}
       </div>
     </div>

--- a/src/app/trivia/components/TriviaLeaderboard.tsx
+++ b/src/app/trivia/components/TriviaLeaderboard.tsx
@@ -176,7 +176,7 @@ export function TriviaLeaderboard({ onBack }: { onBack: () => void }) {
         {(['daily', 'weekly', 'alltime'] as Period[]).map((p) => (
           <ChunkyButton
             key={p}
-            variant={period === p ? 'space' : 'secondary'}
+            variant={period === p ? 'primary' : 'secondary'}
             onClick={() => setPeriod(p)}
             className="capitalize"
           >

--- a/src/app/trivia/components/TriviaStats.tsx
+++ b/src/app/trivia/components/TriviaStats.tsx
@@ -1,8 +1,8 @@
 'use client'
 
 import { useTriviaUser } from '@/app/trivia/hooks/useTriviaUser'
-import { Button } from '@/components/ui/button'
-import { Card, CardContent } from '@/components/ui/card'
+import { ChunkyButton } from '@/components/ui/chunky-button'
+import { ChunkyCard, ChunkyCardContent } from '@/components/ui/chunky-card'
 import { useAuth } from '@/hooks/useAuth'
 import { formatDisplayDate } from '@/lib/dates'
 
@@ -12,9 +12,9 @@ import { SignInCard } from './SignInCTA'
 const MAX_SCORE_PER_GAME = 3150
 
 function getAccuracyColor(accuracy: number): string {
-  if (accuracy >= 80) return 'text-green-400'
+  if (accuracy >= 80) return 'text-ds-primary'
   if (accuracy >= 60) return 'text-yellow-400'
-  return 'text-red-400'
+  return 'text-ds-error'
 }
 
 export function TriviaStats({ onBack }: { onBack: () => void }) {
@@ -39,28 +39,28 @@ export function TriviaStats({ onBack }: { onBack: () => void }) {
   if (stats.gamesPlayed === 0) {
     return (
       <div className="flex flex-col items-center gap-6 max-w-lg mx-auto py-8">
-        <h2 className="text-3xl font-bold text-space-gold inline-flex items-center gap-2">
+        <h2 className="text-3xl font-bold text-ds-tertiary inline-flex items-center gap-2">
           My Stats
           <ResetNoticeButton />
         </h2>
         {user ? (
-          <Card className="w-full bg-space-dark/80 border-space-grey">
-            <CardContent className="pt-6 text-center">
-              <p className="text-cream-white/70 text-lg mb-2">No games played yet</p>
-              <p className="text-cream-white/50 text-sm">
+          <ChunkyCard variant="surface-variant" className="w-full bg-surface-container/80 border-outline-variant">
+            <ChunkyCardContent className="pt-6 text-center">
+              <p className="text-on-surface/70 text-lg mb-2">No games played yet</p>
+              <p className="text-on-surface/50 text-sm">
                 Play your first daily trivia to start building your stats!
               </p>
-            </CardContent>
-          </Card>
+            </ChunkyCardContent>
+          </ChunkyCard>
         ) : (
           <SignInCard
             title="📊 Your stats will appear here"
             description="Sign in to start tracking your scores, streaks, and history."
           />
         )}
-        <Button variant="outline" onClick={onBack} className="w-full">
+        <ChunkyButton variant="secondary" onClick={onBack} className="w-full">
           Back to Trivia
-        </Button>
+        </ChunkyButton>
       </div>
     )
   }
@@ -69,108 +69,108 @@ export function TriviaStats({ onBack }: { onBack: () => void }) {
     <div className="flex flex-col gap-5 max-w-lg mx-auto py-6">
       {/* Header */}
       <div className="text-center">
-        <h2 className="text-3xl font-bold text-space-gold mb-1 inline-flex items-center gap-2">
+        <h2 className="text-3xl font-bold text-ds-tertiary mb-1 inline-flex items-center gap-2">
           My Stats
           <ResetNoticeButton />
         </h2>
-        <p className="text-cream-white/50 text-sm">Your trivia journey so far</p>
+        <p className="text-on-surface/50 text-sm">Your trivia journey so far</p>
       </div>
 
       {/* Top-level stats grid */}
       <div className="grid grid-cols-2 gap-3">
-        <Card className="bg-space-dark/80 border-space-grey">
-          <CardContent className="pt-5 pb-5 text-center">
-            <div className="text-3xl font-bold text-space-gold">
+        <ChunkyCard variant="surface-variant" className="bg-surface-container/80 border-outline-variant">
+          <ChunkyCardContent className="pt-5 pb-5 text-center">
+            <div className="text-3xl font-bold text-ds-tertiary">
               {stats.gamesPlayed}
             </div>
-            <div className="text-cream-white/50 text-xs mt-1">Games Played</div>
-          </CardContent>
-        </Card>
+            <div className="text-on-surface/50 text-xs mt-1">Games Played</div>
+          </ChunkyCardContent>
+        </ChunkyCard>
 
-        <Card className="bg-space-dark/80 border-space-grey">
-          <CardContent className="pt-5 pb-5 text-center">
+        <ChunkyCard variant="surface-variant" className="bg-surface-container/80 border-outline-variant">
+          <ChunkyCardContent className="pt-5 pb-5 text-center">
             <div className={`text-3xl font-bold ${getAccuracyColor(accuracy)}`}>
               {accuracy}%
             </div>
-            <div className="text-cream-white/50 text-xs mt-1">Accuracy</div>
-          </CardContent>
-        </Card>
+            <div className="text-on-surface/50 text-xs mt-1">Accuracy</div>
+          </ChunkyCardContent>
+        </ChunkyCard>
 
-        <Card className="bg-space-dark/80 border-space-grey">
-          <CardContent className="pt-5 pb-5 text-center">
-            <div className="text-3xl font-bold text-cream-white">
+        <ChunkyCard variant="surface-variant" className="bg-surface-container/80 border-outline-variant">
+          <ChunkyCardContent className="pt-5 pb-5 text-center">
+            <div className="text-3xl font-bold text-on-surface">
               {stats.totalScore.toLocaleString()}
             </div>
-            <div className="text-cream-white/50 text-xs mt-1">Total Score</div>
-          </CardContent>
-        </Card>
+            <div className="text-on-surface/50 text-xs mt-1">Total Score</div>
+          </ChunkyCardContent>
+        </ChunkyCard>
 
-        <Card className="bg-space-dark/80 border-space-grey">
-          <CardContent className="pt-5 pb-5 text-center">
-            <div className="text-3xl font-bold text-cream-white">
+        <ChunkyCard variant="surface-variant" className="bg-surface-container/80 border-outline-variant">
+          <ChunkyCardContent className="pt-5 pb-5 text-center">
+            <div className="text-3xl font-bold text-on-surface">
               {avgScore.toLocaleString()}
             </div>
-            <div className="text-cream-white/50 text-xs mt-1">Avg / Game</div>
-          </CardContent>
-        </Card>
+            <div className="text-on-surface/50 text-xs mt-1">Avg / Game</div>
+          </ChunkyCardContent>
+        </ChunkyCard>
       </div>
 
       {/* Streaks */}
-      <Card className="bg-space-dark/80 border-space-grey">
-        <CardContent className="pt-5 pb-5">
+      <ChunkyCard variant="surface-variant" className="bg-surface-container/80 border-outline-variant">
+        <ChunkyCardContent className="pt-5 pb-5">
           <div className="grid grid-cols-2 gap-3">
             <div className="text-center">
               <div className="flex items-center justify-center gap-1">
                 <span className="text-2xl">🔥</span>
-                <span className="text-3xl font-bold text-space-gold">
+                <span className="text-3xl font-bold text-ds-tertiary">
                   {stats.currentStreak}
                 </span>
               </div>
-              <div className="text-cream-white/50 text-xs mt-1">Current Streak</div>
+              <div className="text-on-surface/50 text-xs mt-1">Current Streak</div>
             </div>
             <div className="text-center">
-              <div className="text-3xl font-bold text-space-purple-light">
+              <div className="text-3xl font-bold text-on-surface-variant">
                 {stats.bestStreak}
               </div>
-              <div className="text-cream-white/50 text-xs mt-1">Best Streak</div>
+              <div className="text-on-surface/50 text-xs mt-1">Best Streak</div>
             </div>
           </div>
-        </CardContent>
-      </Card>
+        </ChunkyCardContent>
+      </ChunkyCard>
 
       {/* Additional totals */}
-      <Card className="bg-space-dark/80 border-space-grey">
-        <CardContent className="pt-5 pb-5">
-          <h3 className="text-cream-white/70 text-sm font-semibold mb-3 uppercase tracking-wide">
+      <ChunkyCard variant="surface-variant" className="bg-surface-container/80 border-outline-variant">
+        <ChunkyCardContent className="pt-5 pb-5">
+          <h3 className="text-on-surface/70 text-sm font-semibold mb-3 uppercase tracking-wide">
             Totals
           </h3>
           <div className="space-y-2">
             <div className="flex justify-between items-center">
-              <span className="text-cream-white/60 text-sm">Best single game</span>
-              <span className="text-space-gold font-bold">
+              <span className="text-on-surface/60 text-sm">Best single game</span>
+              <span className="text-ds-tertiary font-bold">
                 {bestScore.toLocaleString()}
               </span>
             </div>
             <div className="flex justify-between items-center">
-              <span className="text-cream-white/60 text-sm">Questions answered</span>
-              <span className="text-cream-white font-bold">
+              <span className="text-on-surface/60 text-sm">Questions answered</span>
+              <span className="text-on-surface font-bold">
                 {stats.totalQuestions.toLocaleString()}
               </span>
             </div>
             <div className="flex justify-between items-center">
-              <span className="text-cream-white/60 text-sm">Correct answers</span>
-              <span className="text-green-400 font-bold">
+              <span className="text-on-surface/60 text-sm">Correct answers</span>
+              <span className="text-ds-primary font-bold">
                 {stats.totalCorrect.toLocaleString()}
               </span>
             </div>
           </div>
-        </CardContent>
-      </Card>
+        </ChunkyCardContent>
+      </ChunkyCard>
 
       {/* Recent history */}
-      <Card className="bg-space-dark/80 border-space-grey">
-        <CardContent className="pt-5 pb-5">
-          <h3 className="text-cream-white/70 text-sm font-semibold mb-3 uppercase tracking-wide">
+      <ChunkyCard variant="surface-variant" className="bg-surface-container/80 border-outline-variant">
+        <ChunkyCardContent className="pt-5 pb-5">
+          <h3 className="text-on-surface/70 text-sm font-semibold mb-3 uppercase tracking-wide">
             Recent Games
           </h3>
           <div className="flex flex-col gap-2">
@@ -182,21 +182,21 @@ export function TriviaStats({ onBack }: { onBack: () => void }) {
               return (
                 <div
                   key={game.date}
-                  className="flex items-center justify-between py-2 px-3 rounded bg-space-black/40"
+                  className="flex items-center justify-between py-2 px-3 rounded bg-surface-dim/40"
                 >
                   <div className="flex flex-col">
-                    <span className="text-cream-white text-sm font-medium">
+                    <span className="text-on-surface text-sm font-medium">
                       {formatDisplayDate(game.date)}
                     </span>
-                    <span className="text-cream-white/40 text-xs">
+                    <span className="text-on-surface/40 text-xs">
                       {game.correct}/{game.total} correct
                     </span>
                   </div>
                   <div className="flex items-center gap-3">
                     {/* Visual bar */}
-                    <div className="w-16 h-2 bg-space-grey rounded-full overflow-hidden">
+                    <div className="w-16 h-2 bg-outline-variant rounded-full overflow-hidden">
                       <div
-                        className="h-full bg-space-gold transition-all"
+                        className="h-full bg-ds-tertiary transition-all"
                         style={{ width: `${scorePercent}%` }}
                       />
                     </div>
@@ -210,13 +210,13 @@ export function TriviaStats({ onBack }: { onBack: () => void }) {
               )
             })}
           </div>
-        </CardContent>
-      </Card>
+        </ChunkyCardContent>
+      </ChunkyCard>
 
       {/* Navigation */}
-      <Button variant="outline" onClick={onBack} className="w-full">
+      <ChunkyButton variant="secondary" onClick={onBack} className="w-full">
         Back to Trivia
-      </Button>
+      </ChunkyButton>
     </div>
   )
 }


### PR DESCRIPTION
## Summary

Closes #552 — Part of epic #529 — **Phase 4: Trivia (5/6)**

Refreshes both `TriviaStats.tsx` and `TriviaLeaderboard.tsx` with design-system tokens.

### TriviaStats changes
- All `Card`/`CardContent` → `ChunkyCard variant="surface-variant"`/`ChunkyCardContent`
- `Button` → `ChunkyButton variant="secondary"`
- Token migration: space-gold → ds-tertiary, cream-white → on-surface, space-dark → surface-container, etc.
- Visual bars: `bg-space-grey` track → `bg-outline-variant`, `bg-space-gold` fill → `bg-ds-tertiary`

### TriviaLeaderboard changes
- Main card → `ChunkyCard variant="surface-container-high"`
- `Button` → `ChunkyButton` (tabs + navigation)
- **Rank badges:** Top 3 → `Pill tone="success"`, rank 4+ → `Pill tone="neutral"`
- Current-user row highlight: `bg-ds-tertiary/20 border-ds-tertiary/40`
- All legacy tokens migrated

### Preserved
- All data hooks, Firestore queries, loading/empty states, mystical personality text
- Run history, accuracy charts, streak displays
- Tab switching, pagination, share functionality

## Test plan

- [ ] Verify Vercel preview deploys without errors
- [ ] Verify stats panel shows correct data
- [ ] Verify leaderboard loads and highlights current user

🤖 Generated with [Claude Code](https://claude.com/claude-code)