### PR TITLE
Redesign 24: Trivia auth surfaces (SignInCTA, NicknameDialog, ResetNotice)

### DIFF
--- a/src/app/trivia/components/NicknameDialog.tsx
+++ b/src/app/trivia/components/NicknameDialog.tsx
@@ -7,7 +7,7 @@ import {
   NicknameInUseError,
   sanitizeNickname,
 } from '@/app/trivia/hooks/useTriviaUser'
-import { Button } from '@/components/ui/button'
+import { ChunkyButton } from '@/components/ui/chunky-button'
 import { Input } from '@/components/ui/input'
 
 interface NicknameDialogProps {
@@ -64,20 +64,20 @@ export function NicknameDialog({ initialValue, onClose, onSave }: NicknameDialog
       role="dialog"
       aria-modal="true"
       aria-labelledby="nickname-dialog-title"
-      className="fixed inset-0 bg-black/80 flex items-center justify-center z-50 px-4"
+      className="fixed inset-0 bg-surface-dim/80 backdrop-blur-sm flex items-center justify-center z-50 px-4"
       onClick={onClose}
     >
       <div
-        className="w-full max-w-sm rounded-lg border border-space-grey bg-space-dark p-6 shadow-xl"
+        className="w-full max-w-sm rounded-ds-lg border border-outline-variant bg-surface-container p-6 shadow-hero"
         onClick={(e) => e.stopPropagation()}
       >
         <h2
           id="nickname-dialog-title"
-          className="text-lg font-bold text-space-gold mb-1"
+          className="text-lg font-bold text-ds-tertiary mb-1"
         >
           Choose your nickname
         </h2>
-        <p className="text-cream-white/60 text-sm mb-4">
+        <p className="text-on-surface/60 text-sm mb-4">
           Shown on the leaderboard and wherever your name appears.
         </p>
         <Input
@@ -92,21 +92,21 @@ export function NicknameDialog({ initialValue, onClose, onSave }: NicknameDialog
           }}
           maxLength={NICKNAME_MAX_LENGTH}
           placeholder="e.g. Stargazer"
-          className="text-cream-white"
+          className="text-on-surface"
         />
         <div className="flex items-center justify-between mt-2">
-          <span className="text-xs text-cream-white/40">
+          <span className="text-xs text-on-surface/40">
             {trimmedLength}/{NICKNAME_MAX_LENGTH}
           </span>
-          {error && <span className="text-xs text-red-400">{error}</span>}
+          {error && <span className="text-xs text-ds-error">{error}</span>}
         </div>
         <div className="grid grid-cols-2 gap-2 mt-4">
-          <Button variant="outline" onClick={onClose} disabled={saving}>
+          <ChunkyButton variant="secondary" onClick={onClose} disabled={saving}>
             Cancel
-          </Button>
-          <Button variant="space" onClick={handleSave} disabled={!canSave}>
+          </ChunkyButton>
+          <ChunkyButton variant="primary" onClick={handleSave} disabled={!canSave}>
             {saving ? 'Saving…' : 'Save'}
-          </Button>
+          </ChunkyButton>
         </div>
       </div>
     </div>

--- a/src/app/trivia/components/ResetNoticeButton.tsx
+++ b/src/app/trivia/components/ResetNoticeButton.tsx
@@ -2,7 +2,8 @@
 
 import { useEffect, useState } from 'react'
 
-import { Button } from '@/components/ui/button'
+import { ChunkyButton } from '@/components/ui/chunky-button'
+import { Pill } from '@/components/ui/pill'
 
 const SEEN_KEY = 'trivia:resetNoticeSeen'
 
@@ -46,9 +47,11 @@ export function ResetNoticeButton() {
         onClick={() => setOpen(true)}
         aria-label="Why is this reset?"
         title="Why is this reset?"
-        className="inline-flex items-center justify-center w-5 h-5 rounded-full text-cream-white/40 hover:text-cream-white/80 hover:bg-space-purple/20 transition-colors text-xs font-semibold"
+        className="inline-flex items-center"
       >
-        i
+        <Pill tone="neutral" size="xs" icon="info">
+          info
+        </Pill>
       </button>
       {open && <ResetDialog onClose={handleClose} />}
     </>
@@ -69,17 +72,17 @@ function ResetDialog({ onClose }: { onClose: () => void }) {
       role="dialog"
       aria-modal="true"
       aria-labelledby="reset-dialog-title"
-      className="fixed inset-0 bg-black/80 flex items-center justify-center z-50 px-4"
+      className="fixed inset-0 bg-surface-dim/80 backdrop-blur-sm flex items-center justify-center z-50 px-4"
       onClick={onClose}
     >
       <div
-        className="w-full max-w-sm rounded-lg border border-space-grey bg-space-dark p-6 shadow-xl"
+        className="w-full max-w-sm rounded-ds-lg border border-outline-variant bg-surface-container p-6 shadow-hero"
         onClick={(e) => e.stopPropagation()}
       >
-        <h2 id="reset-dialog-title" className="text-lg font-bold text-space-gold mb-3">
+        <h2 id="reset-dialog-title" className="text-lg font-bold text-ds-tertiary mb-3">
           About this reset
         </h2>
-        <div className="text-cream-white/80 text-sm space-y-2 mb-4">
+        <div className="text-on-surface/80 text-sm space-y-2 mb-4">
           <p>
             We just rebuilt the trivia database to fix nickname collisions and make
             leaderboards scale properly.
@@ -89,9 +92,9 @@ function ResetDialog({ onClose }: { onClose: () => void }) {
             yours. Future games will count toward fresh totals.
           </p>
         </div>
-        <Button variant="space" onClick={onClose} className="w-full">
+        <ChunkyButton variant="primary" onClick={onClose} className="w-full">
           Got it
-        </Button>
+        </ChunkyButton>
       </div>
     </div>
   )

--- a/src/app/trivia/components/SignInCTA.tsx
+++ b/src/app/trivia/components/SignInCTA.tsx
@@ -2,8 +2,8 @@
 
 import Link from 'next/link'
 
-import { Button } from '@/components/ui/button'
-import { Card, CardContent } from '@/components/ui/card'
+import { ChunkyButton } from '@/components/ui/chunky-button'
+import { ChunkyCard, ChunkyCardContent } from '@/components/ui/chunky-card'
 
 const REDIRECT = '/auth?redirect=/trivia'
 
@@ -15,11 +15,11 @@ export function SignInBanner({
   cta?: string
 }) {
   return (
-    <div className="w-full flex items-center justify-between gap-3 px-4 py-2.5 rounded-lg bg-space-purple/15 border border-space-purple/30 text-sm">
-      <span className="text-cream-white/80">{message}</span>
+    <div className="w-full flex items-center justify-between gap-3 px-4 py-2.5 rounded-ds-sm bg-surface-variant/15 border border-surface-variant/30 text-sm">
+      <span className="text-on-surface/80">{message}</span>
       <Link
         href={REDIRECT}
-        className="text-space-gold hover:text-space-gold/80 underline-offset-4 hover:underline whitespace-nowrap font-semibold"
+        className="text-ds-tertiary hover:text-ds-tertiary/80 underline-offset-4 hover:underline whitespace-nowrap font-semibold"
       >
         {cta} →
       </Link>
@@ -35,16 +35,16 @@ export function SignInCard({
   description: string
 }) {
   return (
-    <Card className="w-full bg-space-purple/15 border-space-purple/40">
-      <CardContent className="pt-5 pb-5 flex flex-col items-center gap-3 text-center">
-        <h3 className="text-lg font-bold text-cream-white">{title}</h3>
-        <p className="text-cream-white/70 text-sm">{description}</p>
+    <ChunkyCard variant="surface-container-high" className="w-full">
+      <ChunkyCardContent className="pt-5 pb-5 flex flex-col items-center gap-3 text-center">
+        <h3 className="text-lg font-bold text-on-surface">{title}</h3>
+        <p className="text-on-surface/70 text-sm">{description}</p>
         <Link href={REDIRECT} className="w-full">
-          <Button variant="space" size="lg" className="w-full">
+          <ChunkyButton variant="primary" size="lg" className="w-full">
             Sign in
-          </Button>
+          </ChunkyButton>
         </Link>
-      </CardContent>
-    </Card>
+      </ChunkyCardContent>
+    </ChunkyCard>
   )
 }


### PR DESCRIPTION
## Summary

Closes #553 — Part of epic #529 — **Phase 4: Trivia (6/6) — COMPLETES PHASE 4**

Migrates all three trivia auth-adjacent components to design-system tokens.

### SignInCTA.tsx
- `SignInBanner`: `bg-surface-variant/15 border-surface-variant/30`, `text-ds-tertiary` links
- `SignInCard`: `Card` → `ChunkyCard variant="surface-container-high"`, `Button` → `ChunkyButton`

### NicknameDialog.tsx
- Dialog overlay: `bg-surface-dim/80 backdrop-blur-sm`
- Dialog body: `bg-surface-container rounded-ds-lg border-outline-variant shadow-hero`
- Title: `text-ds-tertiary`, buttons: `ChunkyButton primary/secondary`
- Error text: `text-ds-error`

### ResetNoticeButton.tsx
- Trigger button: Now uses `Pill tone="neutral" size="xs" icon="info"` primitive
- Dialog: Same overlay/body treatment as NicknameDialog
- "Got it" button: `ChunkyButton variant="primary"`

All business logic, localStorage, event handlers, and keyboard shortcuts preserved.

## Test plan

- [ ] Verify Vercel preview deploys without errors
- [ ] Verify sign-in banner/card render for anonymous users
- [ ] Verify nickname dialog opens, saves, and closes
- [ ] Verify reset notice popover works

🤖 Generated with [Claude Code](https://claude.com/claude-code)