### PR TITLE
Redesign 27: Oracle refresh to new tokens

### DIFF
--- a/src/app/oracle/components/workflow/step01-enter-question.tsx
+++ b/src/app/oracle/components/workflow/step01-enter-question.tsx
@@ -1,7 +1,7 @@
 import { TextField } from '@mui/material'
 
 import { DivinationQuestion } from '@/app/oracle/types'
-import { Button } from '@/components/ui/button'
+import { ChunkyButton } from '@/components/ui/chunky-button'
 import { Typography } from '@/components/ui/typography'
 
 export const Step01EnterQuestion = ({
@@ -34,7 +34,7 @@ export const Step01EnterQuestion = ({
               setDivinationQuestion({ ...divinationQuestion, question: e.target.value })
             }
             placeholder="What guidance do you seek?"
-            className="w-full bg-slate-800 border-slate-700 text-cream-white"
+            className="w-full bg-slate-800 border-slate-700 text-on-surface"
           />
         </div>
         <div>
@@ -53,13 +53,13 @@ export const Step01EnterQuestion = ({
               setDivinationQuestion({ ...divinationQuestion, context: e.target.value })
             }
             placeholder="Share any relevant context about your situation..."
-            className="w-full bg-slate-800 border-slate-700 text-cream-white"
+            className="w-full bg-slate-800 border-slate-700 text-on-surface"
           />
         </div>
       </div>
-      <Button type="button" disabled={!divinationQuestion.question.trim()} onClick={onNext}>
+      <ChunkyButton type="button" variant="primary" disabled={!divinationQuestion.question.trim()} onClick={onNext}>
         Next
-      </Button>
+      </ChunkyButton>
     </div>
   )
 }

--- a/src/app/oracle/components/workflow/step02-select-generation-method.tsx
+++ b/src/app/oracle/components/workflow/step02-select-generation-method.tsx
@@ -3,12 +3,12 @@
 import { AnimatePresence } from 'framer-motion'
 
 import { TransitionWrapper } from '@/app/oracle/components/ui/transition-wrapper'
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { ChunkyCard, ChunkyCardContent } from '@/components/ui/chunky-card'
 import { Typography } from '@/components/ui/typography'
 
 const SparkleIcon = () => (
   <svg
-    className="w-24 h-24 text-space-purple opacity-20"
+    className="w-24 h-24 text-on-surface-variant opacity-20"
     fill="currentColor"
     viewBox="0 0 24 24"
     xmlns="http://www.w3.org/2000/svg"
@@ -20,18 +20,18 @@ const SparkleIcon = () => (
 
 const HexagramIcon = () => (
   <div className="flex flex-col gap-2 w-24 h-24 items-center justify-center opacity-20">
-    <div className="w-16 h-2 bg-space-purple rounded" />
+    <div className="w-16 h-2 bg-surface-variant rounded" />
     <div className="flex gap-2">
-      <div className="w-7 h-2 bg-space-purple rounded" />
-      <div className="w-7 h-2 bg-space-purple rounded" />
+      <div className="w-7 h-2 bg-surface-variant rounded" />
+      <div className="w-7 h-2 bg-surface-variant rounded" />
     </div>
-    <div className="w-16 h-2 bg-space-purple rounded" />
+    <div className="w-16 h-2 bg-surface-variant rounded" />
     <div className="flex gap-2">
-      <div className="w-7 h-2 bg-space-purple rounded" />
-      <div className="w-7 h-2 bg-space-purple rounded" />
+      <div className="w-7 h-2 bg-surface-variant rounded" />
+      <div className="w-7 h-2 bg-surface-variant rounded" />
     </div>
-    <div className="w-16 h-2 bg-space-purple rounded" />
-    <div className="w-16 h-2 bg-space-purple rounded" />
+    <div className="w-16 h-2 bg-surface-variant rounded" />
+    <div className="w-16 h-2 bg-surface-variant rounded" />
   </div>
 )
 
@@ -61,69 +61,69 @@ export const Step02SelectGenerationMethod = ({
                 </Typography>
               </div>
               <div className="grid md:grid-cols-2 gap-6">
-                <Card
-                  className="cursor-pointer hover:border-space-purple hover:shadow-lg transition-all duration-200 group relative overflow-hidden"
+                <ChunkyCard
+                  className="cursor-pointer hover:border-surface-variant hover:shadow-lg transition-all duration-200 group relative overflow-hidden"
                   onClick={() => handleSelectGenerationMethod('generate')}
                 >
                   <div className="absolute top-4 right-4">
                     <SparkleIcon />
                   </div>
-                  <CardHeader className="space-y-3 pb-4">
-                    <CardTitle className="text-2xl">Generate with Divination</CardTitle>
-                    <CardDescription className="text-base">
+                  <div className="space-y-3 pb-4">
+                    <div className="text-2xl font-semibold">Generate with Divination</div>
+                    <div className="text-base text-muted-foreground">
                       Let your intuition guide you as you draw on the canvas. The oracle will
                       interpret your movements to generate a hexagram.
-                    </CardDescription>
-                  </CardHeader>
-                  <CardContent className="space-y-2">
+                    </div>
+                  </div>
+                  <ChunkyCardContent className="space-y-2">
                     <div className="text-sm text-muted-foreground space-y-1">
                       <div className="flex items-start gap-2">
-                        <span className="text-space-purple mt-0.5">✦</span>
+                        <span className="text-on-surface-variant mt-0.5">✦</span>
                         <span>Intuitive and spontaneous</span>
                       </div>
                       <div className="flex items-start gap-2">
-                        <span className="text-space-purple mt-0.5">✦</span>
+                        <span className="text-on-surface-variant mt-0.5">✦</span>
                         <span>No prior I-Ching knowledge needed</span>
                       </div>
                       <div className="flex items-start gap-2">
-                        <span className="text-space-purple mt-0.5">✦</span>
+                        <span className="text-on-surface-variant mt-0.5">✦</span>
                         <span>Quick and meditative</span>
                       </div>
                     </div>
-                  </CardContent>
-                </Card>
+                  </ChunkyCardContent>
+                </ChunkyCard>
 
-                <Card
-                  className="cursor-pointer hover:border-space-purple hover:shadow-lg transition-all duration-200 group relative overflow-hidden"
+                <ChunkyCard
+                  className="cursor-pointer hover:border-surface-variant hover:shadow-lg transition-all duration-200 group relative overflow-hidden"
                   onClick={() => handleSelectGenerationMethod('build')}
                 >
                   <div className="absolute top-4 right-4">
                     <HexagramIcon />
                   </div>
-                  <CardHeader className="space-y-3 pb-4">
-                    <CardTitle className="text-2xl">Enter Hexagram Manually</CardTitle>
-                    <CardDescription className="text-base">
+                  <div className="space-y-3 pb-4">
+                    <div className="text-2xl font-semibold">Enter Hexagram Manually</div>
+                    <div className="text-base text-muted-foreground">
                       Already have a hexagram from coins, yarrow stalks, or another method? Enter
                       it here to receive your interpretation.
-                    </CardDescription>
-                  </CardHeader>
-                  <CardContent className="space-y-2">
+                    </div>
+                  </div>
+                  <ChunkyCardContent className="space-y-2">
                     <div className="text-sm text-muted-foreground space-y-1">
                       <div className="flex items-start gap-2">
-                        <span className="text-space-purple mt-0.5">✦</span>
+                        <span className="text-on-surface-variant mt-0.5">✦</span>
                         <span>Use traditional methods</span>
                       </div>
                       <div className="flex items-start gap-2">
-                        <span className="text-space-purple mt-0.5">✦</span>
+                        <span className="text-on-surface-variant mt-0.5">✦</span>
                         <span>For experienced practitioners</span>
                       </div>
                       <div className="flex items-start gap-2">
-                        <span className="text-space-purple mt-0.5">✦</span>
+                        <span className="text-on-surface-variant mt-0.5">✦</span>
                         <span>Full control over the hexagram</span>
                       </div>
                     </div>
-                  </CardContent>
-                </Card>
+                  </ChunkyCardContent>
+                </ChunkyCard>
               </div>
             </div>
           </TransitionWrapper>

--- a/src/app/oracle/components/workflow/step04-review-changing-lines.tsx
+++ b/src/app/oracle/components/workflow/step04-review-changing-lines.tsx
@@ -138,7 +138,7 @@ const ChangingLines = ({ divinationResult }: { divinationResult: DivinationResul
 
           return (
             <div key={lineIndex} className="space-y-2">
-              <Typography variant="h5" className="text-space-purple">
+              <Typography variant="h5" className="text-on-surface-variant">
                 Line {lineNumber} ({direction})
               </Typography>
               <Typography variant="body1" className="whitespace-pre-line text-left">
@@ -213,31 +213,31 @@ const DivinationResult = ({ divinationResult }: { divinationResult: DivinationRe
             <TabsList className="grid w-full grid-cols-5 mb-16 bg-transparent">
               <TabsTrigger
                 value="overview"
-                className="data-[state=active]:bg-space-purple data-[state=active]:text-cream-white"
+                className="data-[state=active]:bg-surface-variant data-[state=active]:text-on-surface"
               >
                 Overview
               </TabsTrigger>
               <TabsTrigger
                 value="present"
-                className="data-[state=active]:bg-space-purple data-[state=active]:text-cream-white"
+                className="data-[state=active]:bg-surface-variant data-[state=active]:text-on-surface"
               >
                 Present
               </TabsTrigger>
               <TabsTrigger
                 value="changing-lines"
-                className="data-[state=active]:bg-space-purple data-[state=active]:text-cream-white"
+                className="data-[state=active]:bg-surface-variant data-[state=active]:text-on-surface"
               >
                 Changing Lines
               </TabsTrigger>
               <TabsTrigger
                 value="future"
-                className="data-[state=active]:bg-space-purple data-[state=active]:text-cream-white"
+                className="data-[state=active]:bg-surface-variant data-[state=active]:text-on-surface"
               >
                 Future
               </TabsTrigger>
               <TabsTrigger
                 value="interpretation"
-                className="data-[state=active]:bg-space-purple data-[state=active]:text-cream-white"
+                className="data-[state=active]:bg-surface-variant data-[state=active]:text-on-surface"
               >
                 Interpretation
               </TabsTrigger>


### PR DESCRIPTION
## Summary

Closes #556 — Part of epic #529 — **Phase 6: Per-game refresh (1/9)**

Token migration in 3 Oracle workflow components.

### Files changed
- `step01-enter-question.tsx` — `Button` → `ChunkyButton`, `text-cream-white` → `text-on-surface`
- `step02-select-generation-method.tsx` — `Card` → `ChunkyCard`, `text-space-purple` → `text-on-surface-variant`, `bg-space-purple` → `bg-surface-variant`
- `step04-review-changing-lines.tsx` — Tab trigger data states migrated from `space-purple`/`cream-white` to `surface-variant`/`on-surface`

All business logic preserved.

## Test plan

- [ ] Verify Vercel preview deploys without errors
- [ ] Verify Oracle workflow still functions

🤖 Generated with [Claude Code](https://claude.com/claude-code)