### PR TITLE
Redesign 29: Whowouldwininator refresh to new tokens

### DIFF
--- a/src/app/whowouldwininator/components/step01-define-characters.tsx
+++ b/src/app/whowouldwininator/components/step01-define-characters.tsx
@@ -1,6 +1,6 @@
 import { Loader2, RefreshCcw, Sparkles } from 'lucide-react'
 
-import { Button } from '@/components/ui/button'
+import { ChunkyButton } from '@/components/ui/chunky-button'
 import { Input } from '@/components/ui/input'
 import { Textarea } from '@/components/ui/textarea'
 
@@ -38,29 +38,29 @@ export function Step01DefineCharacters({
       {/* Mobile and Desktop Layout */}
       <div className="flex flex-col lg:flex-row gap-6 lg:gap-4 w-full">
         {/* Character 1 */}
-        <div className="flex flex-col gap-4 flex-grow bg-space-dark rounded-lg p-4 lg:p-6 lg:w-[35%]">
+        <div className="flex flex-col gap-4 flex-grow bg-surface-container rounded-lg p-4 lg:p-6 lg:w-[35%]">
           <div className="flex flex-col sm:flex-row gap-2 sm:justify-between sm:items-center">
-            <h2 className="text-xl sm:text-2xl font-bold text-cream-white">
+            <h2 className="text-xl sm:text-2xl font-bold text-on-surface">
               {candidate1Name ? candidate1Name : `Character 1`}
             </h2>
-            <Button
-              variant="outline"
+            <ChunkyButton
+              variant="secondary"
               size="sm"
               onClick={() => generateRandomCharacter(1)}
               disabled={isGeneratingCandidate1}
               className="self-start sm:self-auto"
             >
               {isGeneratingCandidate1 ? (
-                <Loader2 className="w-4 h-4 text-space-purple animate-spin" />
+                <Loader2 className="w-4 h-4 text-on-surface-variant animate-spin" />
               ) : (
-                <RefreshCcw className="w-4 h-4 text-space-purple" />
+                <RefreshCcw className="w-4 h-4 text-on-surface-variant" />
               )}
               <span className="ml-2">Random</span>
-            </Button>
+            </ChunkyButton>
           </div>
 
           <div className="space-y-2">
-            <label htmlFor="candidate1" className="text-sm font-medium text-cream-white">
+            <label htmlFor="candidate1" className="text-sm font-medium text-on-surface">
               Name:
             </label>
             <Input
@@ -69,7 +69,7 @@ export function Step01DefineCharacters({
               value={candidate1Name ?? ''}
               onChange={e => updateCandidate1(e.target.value, null)}
               disabled={isGeneratingCandidate1}
-              className="bg-space-dark border-space-purple/30"
+              className="bg-surface-container border-surface-variant/30"
             />
           </div>
 
@@ -77,12 +77,12 @@ export function Step01DefineCharacters({
             <div className="flex items-center justify-between">
               <label
                 htmlFor="candidate1-description"
-                className="text-sm font-medium text-cream-white"
+                className="text-sm font-medium text-on-surface"
               >
                 Description:
               </label>
-              <Button
-                variant="outline"
+              <ChunkyButton
+                variant="secondary"
                 size="sm"
                 onClick={() => generateCharacterDescription(1)}
                 disabled={
@@ -94,19 +94,19 @@ export function Step01DefineCharacters({
                 className="self-start sm:self-auto"
               >
                 {isGeneratingCandidate1Description ? (
-                  <Loader2 className="w-4 h-4 text-space-purple animate-spin" />
+                  <Loader2 className="w-4 h-4 text-on-surface-variant animate-spin" />
                 ) : (
-                  <Sparkles className="w-4 h-4 text-space-purple" />
+                  <Sparkles className="w-4 h-4 text-on-surface-variant" />
                 )}
                 <span className="ml-2">Generate</span>
-              </Button>
+              </ChunkyButton>
             </div>
             <Textarea
               id="candidate1-description"
               value={candidate1Description ?? ''}
               onChange={e => updateCandidate1(null, e.target.value)}
               placeholder="(Optional) Describe your character's appearance, abilities, and personality..."
-              className="min-h-[100px] sm:min-h-[120px] resize-none bg-space-dark border-space-purple/30"
+              className="min-h-[100px] sm:min-h-[120px] resize-none bg-surface-container border-surface-variant/30"
               disabled={isGeneratingCandidate1 || isGeneratingCandidate1Description}
             />
           </div>
@@ -114,35 +114,35 @@ export function Step01DefineCharacters({
 
         {/* VS Divider */}
         <div className="flex items-center justify-center lg:flex-col lg:justify-center lg:px-2">
-          <div className="text-xl sm:text-2xl font-bold text-cream-white bg-space-purple/20 px-4 py-2 rounded-full">
+          <div className="text-xl sm:text-2xl font-bold text-on-surface bg-surface-variant/20 px-4 py-2 rounded-full">
             VS
           </div>
         </div>
 
         {/* Character 2 */}
-        <div className="flex flex-col gap-4 flex-grow bg-space-dark rounded-lg p-4 lg:p-6 lg:w-[35%]">
+        <div className="flex flex-col gap-4 flex-grow bg-surface-container rounded-lg p-4 lg:p-6 lg:w-[35%]">
           <div className="flex flex-col sm:flex-row gap-2 sm:justify-between sm:items-center">
-            <h2 className="text-xl sm:text-2xl font-bold text-cream-white">
+            <h2 className="text-xl sm:text-2xl font-bold text-on-surface">
               {candidate2Name ? candidate2Name : `Character 2`}
             </h2>
-            <Button
-              variant="outline"
+            <ChunkyButton
+              variant="secondary"
               size="sm"
               onClick={() => generateRandomCharacter(2)}
               disabled={isGeneratingCandidate2}
               className="self-start sm:self-auto"
             >
               {isGeneratingCandidate2 ? (
-                <Loader2 className="w-4 h-4 text-space-purple animate-spin" />
+                <Loader2 className="w-4 h-4 text-on-surface-variant animate-spin" />
               ) : (
-                <RefreshCcw className="w-4 h-4 text-space-purple" />
+                <RefreshCcw className="w-4 h-4 text-on-surface-variant" />
               )}
               <span className="ml-2">Random</span>
-            </Button>
+            </ChunkyButton>
           </div>
 
           <div className="space-y-2">
-            <label htmlFor="candidate2" className="text-sm font-medium text-cream-white">
+            <label htmlFor="candidate2" className="text-sm font-medium text-on-surface">
               Name:
             </label>
             <Input
@@ -151,7 +151,7 @@ export function Step01DefineCharacters({
               value={candidate2Name ?? ''}
               onChange={e => updateCandidate2(e.target.value, null)}
               disabled={isGeneratingCandidate2}
-              className="bg-space-dark border-space-purple/30"
+              className="bg-surface-container border-surface-variant/30"
             />
           </div>
 
@@ -159,12 +159,12 @@ export function Step01DefineCharacters({
             <div className="flex items-center justify-between">
               <label
                 htmlFor="candidate2-description"
-                className="text-sm font-medium text-cream-white"
+                className="text-sm font-medium text-on-surface"
               >
                 Description:
               </label>
-              <Button
-                variant="outline"
+              <ChunkyButton
+                variant="secondary"
                 size="sm"
                 onClick={() => generateCharacterDescription(2)}
                 disabled={
@@ -176,19 +176,19 @@ export function Step01DefineCharacters({
                 className="self-start sm:self-auto"
               >
                 {isGeneratingCandidate2Description ? (
-                  <Loader2 className="w-4 h-4 text-space-purple animate-spin" />
+                  <Loader2 className="w-4 h-4 text-on-surface-variant animate-spin" />
                 ) : (
-                  <Sparkles className="w-4 h-4 text-space-purple" />
+                  <Sparkles className="w-4 h-4 text-on-surface-variant" />
                 )}
                 <span className="ml-2">Generate</span>
-              </Button>
+              </ChunkyButton>
             </div>
             <Textarea
               id="candidate2-description"
               value={candidate2Description ?? ''}
               onChange={e => updateCandidate2(null, e.target.value)}
               placeholder="(Optional) Describe your character's appearance, abilities, and personality..."
-              className="min-h-[100px] sm:min-h-[120px] resize-none bg-space-dark border-space-purple/30"
+              className="min-h-[100px] sm:min-h-[120px] resize-none bg-surface-container border-surface-variant/30"
               disabled={isGeneratingCandidate2 || isGeneratingCandidate2Description}
             />
           </div>
@@ -196,15 +196,16 @@ export function Step01DefineCharacters({
       </div>
 
       {/* Next Button */}
-      <Button
+      <ChunkyButton
+        variant="primary"
         onClick={onNext}
         disabled={
           !candidate1Name || !candidate2Name || isGeneratingCandidate1 || isGeneratingCandidate2
         }
-        className="w-full bg-space-purple text-cream-white hover:bg-space-purple/90 py-3"
+        className="w-full py-3"
       >
         Next: Review Characters
-      </Button>
+      </ChunkyButton>
     </div>
   )
 }

--- a/src/app/whowouldwininator/components/step02-review-characters.tsx
+++ b/src/app/whowouldwininator/components/step02-review-characters.tsx
@@ -4,7 +4,7 @@ import { Edit2, Loader2, Save } from 'lucide-react'
 import Image from 'next/image'
 import { useEffect, useRef, useState } from 'react'
 
-import { Button } from '@/components/ui/button'
+import { ChunkyButton } from '@/components/ui/chunky-button'
 import { Progress } from '@/components/ui/progress'
 import { Slider } from '@/components/ui/slider'
 import { Textarea } from '@/components/ui/textarea'
@@ -75,7 +75,7 @@ const CardContent = ({
 const StatBar = ({ label, value, max = 100 }: { label: string; value: number; max?: number }) => (
   <div className="flex items-center gap-2">
     <span className="text-sm font-medium w-20">{label}:</span>
-    <Progress value={(value / max) * 100} className="flex-1 text-space-purple" />
+    <Progress value={(value / max) * 100} className="flex-1 text-on-surface-variant" />
     <span className="text-sm w-8">{value}</span>
   </div>
 )
@@ -123,9 +123,9 @@ const CharacterCard = ({
   const isEditing = (field: keyof CharacterDetails) => editingFields[candidateKey].has(field)
 
   return (
-    <Card className="bg-space-dark border-space-purple/30">
+    <Card className="bg-surface-container border-surface-variant/30">
       <CardHeader>
-        <CardTitle className="text-2xl text-cream-white">{name}</CardTitle>
+        <CardTitle className="text-2xl text-on-surface">{name}</CardTitle>
         <p className="text-sm text-gray-300">{description}</p>
       </CardHeader>
       <CardContent className="space-y-6">
@@ -133,21 +133,21 @@ const CharacterCard = ({
         {imageGenerationAllowed && (
           <div>
             <div className="flex items-center justify-between mb-2">
-              <h3 className="text-lg font-semibold text-cream-white">Portrait</h3>
+              <h3 className="text-lg font-semibold text-on-surface">Portrait</h3>
               {!details.portrait && !loading.portrait && (
-                <Button
-                  variant="outline"
+                <ChunkyButton
+                  variant="secondary"
                   size="sm"
                   onClick={() => handleGeneratePortrait(candidateNumber)}
-                  className="border-space-purple/30 text-cream-white hover:bg-space-purple/20"
+                  className="border-surface-variant/30 text-on-surface hover:bg-surface-variant/20"
                 >
                   Generate Portrait
-                </Button>
+                </ChunkyButton>
               )}
             </div>
             {loading.portrait ? (
-              <div className="flex items-center justify-center h-48 bg-space-grey/20 rounded-lg">
-                <Loader2 className="w-8 h-8 animate-spin text-space-purple" />
+              <div className="flex items-center justify-center h-48 bg-surface-container-highest/20 rounded-lg">
+                <Loader2 className="w-8 h-8 animate-spin text-on-surface-variant" />
               </div>
             ) : details.portrait ? (
               <Image
@@ -158,14 +158,14 @@ const CharacterCard = ({
                 height={1024}
               />
             ) : (
-              <div className="flex flex-col items-center justify-center h-48 bg-space-grey/20 rounded-lg gap-3">
-                <Button
-                  variant="outline"
+              <div className="flex flex-col items-center justify-center h-48 bg-surface-container-highest/20 rounded-lg gap-3">
+                <ChunkyButton
+                  variant="secondary"
                   onClick={() => handleGeneratePortrait(candidateNumber)}
-                  className="border-space-purple/30 text-cream-white hover:bg-space-purple/20"
+                  className="border-surface-variant/30 text-on-surface hover:bg-surface-variant/20"
                 >
                   Generate Portrait
-                </Button>
+                </ChunkyButton>
               </div>
             )}
           </div>
@@ -174,8 +174,8 @@ const CharacterCard = ({
         {/* Backstory */}
         <div>
           <div className="flex items-center justify-between mb-2">
-            <h3 className="text-lg font-semibold text-cream-white">Backstory</h3>
-            <Button
+            <h3 className="text-lg font-semibold text-on-surface">Backstory</h3>
+            <ChunkyButton
               variant="ghost"
               size="sm"
               onClick={() => toggleEdit(candidateNumber, 'backstory')}
@@ -185,18 +185,18 @@ const CharacterCard = ({
               ) : (
                 <Edit2 className="w-4 h-4" />
               )}
-            </Button>
+            </ChunkyButton>
           </div>
           {loading.backstory ? (
             <div className="flex items-center gap-2">
-              <Loader2 className="w-4 h-4 animate-spin text-space-purple" />
+              <Loader2 className="w-4 h-4 animate-spin text-on-surface-variant" />
               <span className="text-sm text-gray-400">Generating backstory...</span>
             </div>
           ) : isEditing('backstory') ? (
             <Textarea
               value={details.backstory || ''}
               onChange={e => updateCharacterDetail(candidateNumber, 'backstory', e.target.value)}
-              className="bg-space-dark border-space-purple/30"
+              className="bg-surface-container border-surface-variant/30"
               rows={4}
             />
           ) : (
@@ -209,14 +209,14 @@ const CharacterCard = ({
                   : 'No backstory available'}
               </p>
               {details.backstory && details.backstory.length > 150 && (
-                <Button
+                <ChunkyButton
                   variant="ghost"
                   size="sm"
                   onClick={() => toggleBackstoryExpansion(candidateNumber)}
-                  className="mt-2 text-space-purple hover:text-space-purple/80 p-0 h-auto"
+                  className="mt-2 text-on-surface-variant hover:text-on-surface-variant/80 p-0 h-auto"
                 >
                   {expandedBackstories[candidateKey] ? 'Show less' : 'Show more'}
-                </Button>
+                </ChunkyButton>
               )}
             </div>
           )}
@@ -225,14 +225,14 @@ const CharacterCard = ({
         {/* Powers */}
         <div>
           <div className="flex items-center justify-between mb-2">
-            <h3 className="text-lg font-semibold text-cream-white">Powers</h3>
-            <Button variant="ghost" size="sm" onClick={() => toggleEdit(candidateNumber, 'powers')}>
+            <h3 className="text-lg font-semibold text-on-surface">Powers</h3>
+            <ChunkyButton variant="ghost" size="sm" onClick={() => toggleEdit(candidateNumber, 'powers')}>
               {isEditing('powers') ? <Save className="w-4 h-4" /> : <Edit2 className="w-4 h-4" />}
-            </Button>
+            </ChunkyButton>
           </div>
           {loading.powers ? (
             <div className="flex items-center gap-2">
-              <Loader2 className="w-4 h-4 animate-spin text-space-purple" />
+              <Loader2 className="w-4 h-4 animate-spin text-on-surface-variant" />
               <span className="text-sm text-gray-400">Generating powers...</span>
             </div>
           ) : isEditing('powers') ? (
@@ -245,7 +245,7 @@ const CharacterCard = ({
                   e.target.value.split('\n').filter(p => p.trim())
                 )
               }
-              className="bg-space-dark border-space-purple/30"
+              className="bg-surface-container border-surface-variant/30"
               rows={3}
               placeholder="Enter powers, one per line"
             />
@@ -254,7 +254,7 @@ const CharacterCard = ({
               {details.powers?.map((power, index) => (
                 <span
                   key={index}
-                  className="px-2 py-1 bg-space-purple/20 text-purple-200 rounded-md text-sm"
+                  className="px-2 py-1 bg-surface-variant/20 text-on-surface-variant rounded-md text-sm"
                 >
                   {power}
                 </span>
@@ -266,14 +266,14 @@ const CharacterCard = ({
         {/* Stats */}
         <div>
           <div className="flex items-center justify-between mb-2">
-            <h3 className="text-lg font-semibold text-cream-white">Combat Stats</h3>
-            <Button variant="ghost" size="sm" onClick={() => toggleEdit(candidateNumber, 'stats')}>
+            <h3 className="text-lg font-semibold text-on-surface">Combat Stats</h3>
+            <ChunkyButton variant="ghost" size="sm" onClick={() => toggleEdit(candidateNumber, 'stats')}>
               {isEditing('stats') ? <Save className="w-4 h-4" /> : <Edit2 className="w-4 h-4" />}
-            </Button>
+            </ChunkyButton>
           </div>
           {loading.stats ? (
             <div className="flex items-center gap-2">
-              <Loader2 className="w-4 h-4 animate-spin text-space-purple" />
+              <Loader2 className="w-4 h-4 animate-spin text-on-surface-variant" />
               <span className="text-sm text-gray-400">Generating stats...</span>
             </div>
           ) : isEditing('stats') ? (
@@ -282,7 +282,7 @@ const CharacterCard = ({
                 Object.entries(details.stats).map(([statName, statValue]) => (
                   <div key={statName} className="space-y-2">
                     <div className="flex justify-between items-center">
-                      <label className="text-sm font-medium text-cream-white capitalize">
+                      <label className="text-sm font-medium text-on-surface capitalize">
                         {statName}
                       </label>
                       <span className="text-sm text-gray-300">{statValue}</span>
@@ -324,14 +324,14 @@ const CharacterCard = ({
         {/* Feats */}
         <div>
           <div className="flex items-center justify-between mb-2">
-            <h3 className="text-lg font-semibold text-cream-white">Notable Feats</h3>
-            <Button variant="ghost" size="sm" onClick={() => toggleEdit(candidateNumber, 'feats')}>
+            <h3 className="text-lg font-semibold text-on-surface">Notable Feats</h3>
+            <ChunkyButton variant="ghost" size="sm" onClick={() => toggleEdit(candidateNumber, 'feats')}>
               {isEditing('feats') ? <Save className="w-4 h-4" /> : <Edit2 className="w-4 h-4" />}
-            </Button>
+            </ChunkyButton>
           </div>
           {loading.feats ? (
             <div className="flex items-center gap-2">
-              <Loader2 className="w-4 h-4 animate-spin text-space-purple" />
+              <Loader2 className="w-4 h-4 animate-spin text-on-surface-variant" />
               <span className="text-sm text-gray-400">Generating feats...</span>
             </div>
           ) : isEditing('feats') ? (
@@ -344,7 +344,7 @@ const CharacterCard = ({
                   e.target.value.split('\n').filter(f => f.trim())
                 )
               }
-              className="bg-space-dark border-space-purple/30"
+              className="bg-surface-container border-surface-variant/30"
               rows={4}
               placeholder="Enter feats, one per line"
             />
@@ -567,19 +567,19 @@ export function Step02ReviewCharacters({
       </div>
 
       <div className="flex justify-between">
-        <Button
-          variant="outline"
+        <ChunkyButton
+          variant="secondary"
           onClick={onPrevious}
-          className="border-space-purple/30 text-cream-white hover:bg-space-purple/20"
+          className="border-surface-variant/30 text-on-surface hover:bg-surface-variant/20"
         >
           Previous
-        </Button>
-        <Button
+        </ChunkyButton>
+        <ChunkyButton
+          variant="primary"
           onClick={onNext}
-          className="bg-space-purple text-cream-white hover:bg-space-purple/90"
         >
           Next: Define Scenario
-        </Button>
+        </ChunkyButton>
       </div>
     </div>
   )

--- a/src/app/whowouldwininator/components/step03-define-scenario.tsx
+++ b/src/app/whowouldwininator/components/step03-define-scenario.tsx
@@ -11,7 +11,7 @@ import {
   Swords,
 } from 'lucide-react'
 
-import { Button } from '@/components/ui/button'
+import { ChunkyButton } from '@/components/ui/chunky-button'
 import { Textarea } from '@/components/ui/textarea'
 
 interface BattleScenario {
@@ -89,8 +89,8 @@ export function Step03DefineScenario({
         <h2 className="text-2xl font-bold text-gray-400 mb-2 mt-6">Define the Battle Scenario</h2>
         <p className="text-gray-300 mb-4">
           Customize the battle conditions for{' '}
-          <span className="text-space-purple font-semibold">{candidate1Name}</span> vs{' '}
-          <span className="text-space-purple font-semibold">{candidate2Name}</span>
+          <span className="text-on-surface-variant font-semibold">{candidate1Name}</span> vs{' '}
+          <span className="text-on-surface-variant font-semibold">{candidate2Name}</span>
         </p>
         <p className="text-sm text-gray-400">
           Leave fields empty to use default settings: Standard TKO battle in an open field with peak
@@ -100,12 +100,12 @@ export function Step03DefineScenario({
 
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
         {/* Setting */}
-        <SimpleCard className="bg-space-dark border-space-purple/30">
+        <SimpleCard className="bg-surface-container border-surface-variant/30">
           <SimpleCardHeader>
             <div className="flex items-center gap-2">
-              <MapPin className="w-5 h-5 text-space-purple" />
+              <MapPin className="w-5 h-5 text-on-surface-variant" />
               <SimpleCardTitle>
-                <span className="text-cream-white">Battle Setting</span>
+                <span className="text-on-surface">Battle Setting</span>
               </SimpleCardTitle>
             </div>
           </SimpleCardHeader>
@@ -114,19 +114,19 @@ export function Step03DefineScenario({
               value={battleScenario.setting}
               onChange={e => updateBattleScenario('setting', e.target.value)}
               placeholder="Describe the location and environment where the battle takes place..."
-              className="bg-space-dark border-space-purple/30 text-cream-white min-h-[100px]"
+              className="bg-surface-container border-surface-variant/30 text-on-surface min-h-[100px]"
             />
             <p className="text-xs text-gray-400 mt-2">Default: Open field with no obstacles</p>
           </SimpleCardContent>
         </SimpleCard>
 
         {/* Rules */}
-        <SimpleCard className="bg-space-dark border-space-purple/30">
+        <SimpleCard className="bg-surface-container border-surface-variant/30">
           <SimpleCardHeader>
             <div className="flex items-center gap-2">
-              <Swords className="w-5 h-5 text-space-purple" />
+              <Swords className="w-5 h-5 text-on-surface-variant" />
               <SimpleCardTitle>
-                <span className="text-cream-white">Battle Rules</span>
+                <span className="text-on-surface">Battle Rules</span>
               </SimpleCardTitle>
             </div>
           </SimpleCardHeader>
@@ -135,7 +135,7 @@ export function Step03DefineScenario({
               value={battleScenario.rules}
               onChange={e => updateBattleScenario('rules', e.target.value)}
               placeholder="Define the victory conditions and combat rules..."
-              className="bg-space-dark border-space-purple/30 text-cream-white min-h-[100px]"
+              className="bg-surface-container border-surface-variant/30 text-on-surface min-h-[100px]"
             />
             <p className="text-xs text-gray-400 mt-2">
               Default: Fight until one character is knocked out or unable to continue
@@ -144,12 +144,12 @@ export function Step03DefineScenario({
         </SimpleCard>
 
         {/* Obstacles */}
-        <SimpleCard className="bg-space-dark border-space-purple/30">
+        <SimpleCard className="bg-surface-container border-surface-variant/30">
           <SimpleCardHeader>
             <div className="flex items-center gap-2">
-              <Shield className="w-5 h-5 text-space-purple" />
+              <Shield className="w-5 h-5 text-on-surface-variant" />
               <SimpleCardTitle>
-                <span className="text-cream-white">Obstacles & Hazards</span>
+                <span className="text-on-surface">Obstacles & Hazards</span>
               </SimpleCardTitle>
             </div>
           </SimpleCardHeader>
@@ -158,19 +158,19 @@ export function Step03DefineScenario({
               value={battleScenario.obstacles}
               onChange={e => updateBattleScenario('obstacles', e.target.value)}
               placeholder="Describe any environmental hazards, traps, or obstacles..."
-              className="bg-space-dark border-space-purple/30 text-cream-white min-h-[100px]"
+              className="bg-surface-container border-surface-variant/30 text-on-surface min-h-[100px]"
             />
             <p className="text-xs text-gray-400 mt-2">Default: No obstacles or hazards</p>
           </SimpleCardContent>
         </SimpleCard>
 
         {/* Limitations */}
-        <SimpleCard className="bg-space-dark border-space-purple/30">
+        <SimpleCard className="bg-surface-container border-surface-variant/30">
           <SimpleCardHeader>
             <div className="flex items-center gap-2">
-              <AlertTriangle className="w-5 h-5 text-space-purple" />
+              <AlertTriangle className="w-5 h-5 text-on-surface-variant" />
               <SimpleCardTitle>
-                <span className="text-cream-white">Limitations & Restrictions</span>
+                <span className="text-on-surface">Limitations & Restrictions</span>
               </SimpleCardTitle>
             </div>
           </SimpleCardHeader>
@@ -179,7 +179,7 @@ export function Step03DefineScenario({
               value={battleScenario.limitations}
               onChange={e => updateBattleScenario('limitations', e.target.value)}
               placeholder="Any power restrictions, equipment limitations, or special conditions..."
-              className="bg-space-dark border-space-purple/30 text-cream-white min-h-[100px]"
+              className="bg-surface-container border-surface-variant/30 text-on-surface min-h-[100px]"
             />
             <p className="text-xs text-gray-400 mt-2">
               Default: No limitations, characters at peak abilities
@@ -189,12 +189,12 @@ export function Step03DefineScenario({
       </div>
 
       {/* Additional Context */}
-      <SimpleCard className="bg-space-dark border-space-purple/30">
+      <SimpleCard className="bg-surface-container border-surface-variant/30">
         <SimpleCardHeader>
           <div className="flex items-center gap-2">
-            <FileText className="w-5 h-5 text-space-purple" />
+            <FileText className="w-5 h-5 text-on-surface-variant" />
             <SimpleCardTitle>
-              <span className="text-cream-white">Additional Context</span>
+              <span className="text-on-surface">Additional Context</span>
             </SimpleCardTitle>
           </div>
         </SimpleCardHeader>
@@ -203,7 +203,7 @@ export function Step03DefineScenario({
             value={battleScenario.additionalContext}
             onChange={e => updateBattleScenario('additionalContext', e.target.value)}
             placeholder="Any other important details, motivations, or special circumstances..."
-            className="bg-space-dark border-space-purple/30 text-cream-white min-h-[120px]"
+            className="bg-surface-container border-surface-variant/30 text-on-surface min-h-[120px]"
           />
           <p className="text-xs text-gray-400 mt-2">
             Default: Both characters are at peak abilities from their respective canon
@@ -213,15 +213,15 @@ export function Step03DefineScenario({
 
       {/* Preview */}
       {hasCustomScenario && (
-        <SimpleCard className="bg-space-grey/20 border-space-purple/20">
+        <SimpleCard className="bg-surface-container-highest/20 border-surface-variant/20">
           <SimpleCardHeader>
             <SimpleCardTitle>
-              <span className="text-cream-white">Scenario Preview</span>
+              <span className="text-on-surface">Scenario Preview</span>
             </SimpleCardTitle>
           </SimpleCardHeader>
           <SimpleCardContent>
             <div className="text-sm text-gray-300 whitespace-pre-line">
-              <strong className="text-space-purple">
+              <strong className="text-on-surface-variant">
                 {candidate1Name} vs {candidate2Name}
               </strong>
               {battleScenario.setting && (
@@ -266,29 +266,29 @@ export function Step03DefineScenario({
 
       {/* Action Buttons */}
       <div className="flex justify-between items-center">
-        <Button
-          variant="outline"
+        <ChunkyButton
+          variant="secondary"
           onClick={onPrevious}
-          className="border-space-purple/30 text-cream-white hover:bg-space-purple/20"
+          className="border-surface-variant/30 text-on-surface hover:bg-surface-variant/20"
         >
           Previous
-        </Button>
+        </ChunkyButton>
 
         <div className="flex gap-2 justify-end flex-wrap">
-          <Button
+          <ChunkyButton
             variant="ghost"
             onClick={resetToDefaults}
-            className="text-gray-400 hover:text-cream-white hover:bg-space-purple/20"
+            className="text-gray-400 hover:text-on-surface hover:bg-surface-variant/20"
           >
             <RotateCcw className="w-4 h-4 mr-2" />
             Reset to Defaults
-          </Button>
+          </ChunkyButton>
 
-          <Button
+          <ChunkyButton
             variant="ghost"
             onClick={generateRandomScenario}
             disabled={isGeneratingScenario}
-            className="text-gray-400 hover:text-cream-white hover:bg-space-purple/20"
+            className="text-gray-400 hover:text-on-surface hover:bg-surface-variant/20"
           >
             {isGeneratingScenario ? (
               <Loader2 className="w-4 h-4 mr-2 animate-spin" />
@@ -296,14 +296,14 @@ export function Step03DefineScenario({
               <RefreshCcw className="w-4 h-4 mr-2" />
             )}
             {isGeneratingScenario ? 'Generating...' : 'Random Scenario'}
-          </Button>
+          </ChunkyButton>
 
-          <Button
+          <ChunkyButton
+            variant="primary"
             onClick={onNext}
-            className="bg-space-purple text-cream-white hover:bg-space-purple/90"
           >
             Generate Battle Results
-          </Button>
+          </ChunkyButton>
         </div>
       </div>
     </div>

--- a/src/app/whowouldwininator/components/step04-view-results.tsx
+++ b/src/app/whowouldwininator/components/step04-view-results.tsx
@@ -4,7 +4,7 @@ import { Loader2, Target, Trophy, Zap } from 'lucide-react'
 import Image from 'next/image'
 import { useEffect, useRef, useState } from 'react'
 
-import { Button } from '@/components/ui/button'
+import { ChunkyButton } from '@/components/ui/chunky-button'
 import { Progress } from '@/components/ui/progress'
 import { getImageGenerationDisableReasonClient, isImageGenerationAllowedClient } from '@/lib/utils'
 
@@ -201,9 +201,9 @@ export function Step04ViewResults({
 
       {/* Loading State */}
       {isGeneratingResults && (
-        <div className="bg-space-dark rounded-lg p-8 text-center">
-          <Loader2 className="w-12 h-12 text-space-purple animate-spin mx-auto mb-4" />
-          <h3 className="text-xl font-semibold text-cream-white mb-2">Analyzing Battle...</h3>
+        <div className="bg-surface-container rounded-lg p-8 text-center">
+          <Loader2 className="w-12 h-12 text-on-surface-variant animate-spin mx-auto mb-4" />
+          <h3 className="text-xl font-semibold text-on-surface mb-2">Analyzing Battle...</h3>
           <p className="text-gray-300">
             Evaluating character abilities, stats, and scenario conditions...
           </p>
@@ -214,19 +214,19 @@ export function Step04ViewResults({
       {contestResults && !isGeneratingResults && (
         <div className="space-y-6">
           {/* Winner Announcement */}
-          <div className="bg-space-dark rounded-lg p-6 border-2 border-space-purple">
+          <div className="bg-surface-container rounded-lg p-6 border-2 border-surface-variant">
             <div className="text-center">
               <Trophy className="w-16 h-16 text-yellow-500 mx-auto mb-4" />
 
               {contestResults.winner === 'tie' ? (
                 <div>
-                  <h3 className="text-2xl font-bold text-cream-white mb-2">It&apos;s a Tie!</h3>
+                  <h3 className="text-2xl font-bold text-on-surface mb-2">It&apos;s a Tie!</h3>
                   <p className="text-gray-300">Both characters are evenly matched</p>
                 </div>
               ) : (
                 <div>
-                  <h3 className="text-2xl font-bold text-cream-white mb-2">Winner</h3>
-                  <p className="text-3xl font-bold text-space-purple mb-2">{winnerDisplay?.name}</p>
+                  <h3 className="text-2xl font-bold text-on-surface mb-2">Winner</h3>
+                  <p className="text-3xl font-bold text-on-surface-variant mb-2">{winnerDisplay?.name}</p>
                   <p className="text-gray-300">{winnerDisplay?.description}</p>
                 </div>
               )}
@@ -234,16 +234,16 @@ export function Step04ViewResults({
           </div>
 
           {/* Confidence Score */}
-          <div className="bg-space-dark rounded-lg p-6">
+          <div className="bg-surface-container rounded-lg p-6">
             <div className="flex items-center gap-3 mb-4">
-              <Target className="w-6 h-6 text-space-purple" />
-              <h3 className="text-xl font-semibold text-cream-white">Confidence Score</h3>
+              <Target className="w-6 h-6 text-on-surface-variant" />
+              <h3 className="text-xl font-semibold text-on-surface">Confidence Score</h3>
             </div>
 
             <div className="space-y-3">
               <div className="flex justify-between items-center">
                 <span className="text-gray-300">Certainty Level</span>
-                <span className="text-2xl font-bold text-space-purple">
+                <span className="text-2xl font-bold text-on-surface-variant">
                   {contestResults.confidence}/10
                 </span>
               </div>
@@ -264,10 +264,10 @@ export function Step04ViewResults({
           </div>
 
           {/* Reasoning */}
-          <div className="bg-space-dark rounded-lg p-6">
+          <div className="bg-surface-container rounded-lg p-6">
             <div className="flex items-center gap-3 mb-4">
-              <Zap className="w-6 h-6 text-space-purple" />
-              <h3 className="text-xl font-semibold text-cream-white">Analysis</h3>
+              <Zap className="w-6 h-6 text-on-surface-variant" />
+              <h3 className="text-xl font-semibold text-on-surface">Analysis</h3>
             </div>
 
             <div className="prose prose-invert max-w-none">
@@ -279,8 +279,8 @@ export function Step04ViewResults({
 
           {/* Character Comparison */}
           <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-            <div className="bg-space-dark rounded-lg p-6">
-              <h4 className="text-lg font-semibold text-cream-white mb-4">
+            <div className="bg-surface-container rounded-lg p-6">
+              <h4 className="text-lg font-semibold text-on-surface mb-4">
                 {candidate1Name}
                 {contestResults.winner === 'candidate1' && (
                   <Trophy className="w-5 h-5 text-yellow-500 inline ml-2" />
@@ -295,7 +295,7 @@ export function Step04ViewResults({
                       <span className="text-gray-300 capitalize">{stat}</span>
                       <div className="flex items-center gap-2">
                         <Progress value={value} className="w-20 h-2" />
-                        <span className="text-sm text-cream-white w-6">{value}</span>
+                        <span className="text-sm text-on-surface w-6">{value}</span>
                       </div>
                     </div>
                   ))}
@@ -303,8 +303,8 @@ export function Step04ViewResults({
               )}
             </div>
 
-            <div className="bg-space-dark rounded-lg p-6">
-              <h4 className="text-lg font-semibold text-cream-white mb-4">
+            <div className="bg-surface-container rounded-lg p-6">
+              <h4 className="text-lg font-semibold text-on-surface mb-4">
                 {candidate2Name}
                 {contestResults.winner === 'candidate2' && (
                   <Trophy className="w-5 h-5 text-yellow-500 inline ml-2" />
@@ -319,7 +319,7 @@ export function Step04ViewResults({
                       <span className="text-gray-300 capitalize">{stat}</span>
                       <div className="flex items-center gap-2">
                         <Progress value={value} className="w-20 h-2" />
-                        <span className="text-sm text-cream-white w-6">{value}</span>
+                        <span className="text-sm text-on-surface w-6">{value}</span>
                       </div>
                     </div>
                   ))}
@@ -334,8 +334,8 @@ export function Step04ViewResults({
             battleScenario.obstacles ||
             battleScenario.limitations ||
             battleScenario.additionalContext) && (
-            <div className="bg-space-dark rounded-lg p-6">
-              <h4 className="text-lg font-semibold text-cream-white mb-4">Battle Scenario</h4>
+            <div className="bg-surface-container rounded-lg p-6">
+              <h4 className="text-lg font-semibold text-on-surface mb-4">Battle Scenario</h4>
               <div className="space-y-2 text-sm">
                 {battleScenario.setting && (
                   <div>
@@ -399,22 +399,22 @@ export function Step04ViewResults({
           )}
 
           {/* Contest Story Sections */}
-          <div className="bg-space-dark rounded-lg p-6">
+          <div className="bg-surface-container rounded-lg p-6">
             <div className="flex items-center justify-between mb-4">
               <div className="flex items-center gap-3">
-                <Zap className="w-6 h-6 text-space-purple" />
-                <h3 className="text-xl font-semibold text-cream-white">Battle Story</h3>
+                <Zap className="w-6 h-6 text-on-surface-variant" />
+                <h3 className="text-xl font-semibold text-on-surface">Battle Story</h3>
               </div>
               {!contestStory && !isGeneratingStory && (
-                <Button
-                  variant="outline"
+                <ChunkyButton
+                  variant="secondary"
                   onClick={
                     imageGenerationAllowed ? handleGenerateStoryAndImages : generateContestStory
                   }
-                  className="border-space-purple/30 text-cream-white hover:bg-space-purple/20"
+                  className="border-surface-variant/30 text-on-surface hover:bg-surface-variant/20"
                 >
                   {imageGenerationAllowed ? 'Generate Story & Images' : 'Generate Story'}
-                </Button>
+                </ChunkyButton>
               )}
             </div>
 
@@ -428,9 +428,9 @@ export function Step04ViewResults({
             {contestStory && !isGeneratingStory && (
               <div className="space-y-6">
                 {/* Intro Section */}
-                <div className="border-l-4 border-space-purple pl-4">
+                <div className="border-l-4 border-surface-variant pl-4">
                   <div className="mb-3">
-                    <h4 className="text-lg font-semibold text-cream-white">Introduction</h4>
+                    <h4 className="text-lg font-semibold text-on-surface">Introduction</h4>
                   </div>
                   <div className="prose prose-invert max-w-none mb-4">
                     <p className="text-gray-300 leading-relaxed whitespace-pre-wrap">
@@ -469,7 +469,7 @@ export function Step04ViewResults({
                 {/* Climax Section */}
                 <div className="border-l-4 border-red-500 pl-4">
                   <div className="mb-3">
-                    <h4 className="text-lg font-semibold text-cream-white">Climax</h4>
+                    <h4 className="text-lg font-semibold text-on-surface">Climax</h4>
                   </div>
                   <div className="prose prose-invert max-w-none mb-4">
                     <p className="text-gray-300 leading-relaxed whitespace-pre-wrap">
@@ -508,7 +508,7 @@ export function Step04ViewResults({
                 {/* Ending Section */}
                 <div className="border-l-4 border-yellow-500 pl-4">
                   <div className="mb-3">
-                    <h4 className="text-lg font-semibold text-cream-white">Ending</h4>
+                    <h4 className="text-lg font-semibold text-on-surface">Ending</h4>
                   </div>
                   <div className="prose prose-invert max-w-none mb-4">
                     <p className="text-gray-300 leading-relaxed whitespace-pre-wrap">
@@ -553,15 +553,15 @@ export function Step04ViewResults({
                     ? 'Ready to generate the complete battle story with images for each section'
                     : 'Ready to generate the complete battle story'}
                 </div>
-                <Button
-                  variant="outline"
+                <ChunkyButton
+                  variant="secondary"
                   onClick={
                     imageGenerationAllowed ? handleGenerateStoryAndImages : generateContestStory
                   }
-                  className="border-space-purple/30 text-cream-white hover:bg-space-purple/20"
+                  className="border-surface-variant/30 text-on-surface hover:bg-surface-variant/20"
                 >
                   {imageGenerationAllowed ? 'Generate Story & Images' : 'Generate Story'}
-                </Button>
+                </ChunkyButton>
               </div>
             )}
           </div>
@@ -570,22 +570,22 @@ export function Step04ViewResults({
 
       {/* Navigation */}
       <div className="flex justify-between items-center">
-        <Button
-          variant="outline"
+        <ChunkyButton
+          variant="secondary"
           onClick={onPrevious}
-          className="border-space-purple/30 text-cream-white hover:bg-space-purple/20"
+          className="border-surface-variant/30 text-on-surface hover:bg-surface-variant/20"
         >
           Previous
-        </Button>
+        </ChunkyButton>
 
         <div className="flex gap-3">
-          <Button
+          <ChunkyButton
             onClick={() => window.location.reload()}
-            variant="outline"
-            className="border-space-purple/30 text-cream-white hover:bg-space-purple/20"
+            variant="secondary"
+            className="border-surface-variant/30 text-on-surface hover:bg-surface-variant/20"
           >
             Start Over
-          </Button>
+          </ChunkyButton>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary

Closes #559 — Part of epic #529 — **Phase 6: Per-game refresh (3/9)**

Token migration in 4 Whowouldwininator step components.

- All `space-dark`/`space-purple`/`cream-white`/`space-grey` classes replaced with semantic tokens
- `Button` → `ChunkyButton` in all 4 files (outline→secondary, default→primary, ghost→ghost)
- All business logic preserved

## Test plan

- [ ] Verify Vercel preview deploys without errors
- [ ] Verify Whowouldwininator game workflow still functions

🤖 Generated with [Claude Code](https://claude.com/claude-code)