### PR TITLE
Redesign 32: Daily Card Game refresh to new tokens

### DIFF
--- a/src/app/daily-card-game/components/blind-selection/blind-card.tsx
+++ b/src/app/daily-card-game/components/blind-selection/blind-card.tsx
@@ -47,7 +47,7 @@ export function BlindCard({
           {tag && (
             <div className="flex flex-col gap-2">
               <ChunkyButton
-                variant="outline"
+                variant="secondary"
                 className="w-full mt-2 h-auto whitespace-break-spaces"
                 disabled={disabled}
                 onClick={() => {

--- a/src/app/daily-card-game/components/blind-selection/blind-card.tsx
+++ b/src/app/daily-card-game/components/blind-selection/blind-card.tsx
@@ -2,7 +2,7 @@ import { DollarSigns } from '@/app/daily-card-game/components/global/dollar-sign
 import { eventEmitter } from '@/app/daily-card-game/domain/events/event-emitter'
 import { implementedTags as tags } from '@/app/daily-card-game/domain/tag/tags'
 import type { TagType } from '@/app/daily-card-game/domain/tag/types'
-import { Button } from '@/components/ui/button'
+import { ChunkyButton } from '@/components/ui/chunky-button'
 import { Card } from '@/components/ui/card'
 
 export function BlindCard({
@@ -23,10 +23,10 @@ export function BlindCard({
   tag?: TagType
 }) {
   return (
-    <Card className="bg-space-grey border-space-purple p-4 text-cream-white h-63 w-1/3 flex flex-col justify-between text-center">
+    <Card className="bg-surface-container-highest border-surface-variant p-4 text-on-surface h-63 w-1/3 flex flex-col justify-between text-center">
       <div className="flex flex-col gap-2 h-full">
         <h3 className="text-xl font-bold">{name}</h3>
-        {description && <p className="text-sm text-cream-white/50">{description}</p>}
+        {description && <p className="text-sm text-on-surface/50">{description}</p>}
         <p>
           Reward: <DollarSigns count={reward} />
         </p>
@@ -35,7 +35,7 @@ export function BlindCard({
       <div className="flex flex-col gap-2 justify-start h-full mt-7">
         {minimumScore !== undefined && <p>Score at Least: {minimumScore.toString()}</p>}
         <div>
-          <Button
+          <ChunkyButton
             className="w-full"
             disabled={disabled}
             onClick={() => {
@@ -43,10 +43,10 @@ export function BlindCard({
             }}
           >
             Select
-          </Button>
+          </ChunkyButton>
           {tag && (
             <div className="flex flex-col gap-2">
-              <Button
+              <ChunkyButton
                 variant="outline"
                 className="w-full mt-2 h-auto whitespace-break-spaces"
                 disabled={disabled}
@@ -55,8 +55,8 @@ export function BlindCard({
                 }}
               >
                 Skip and get the {tags[tag]?.name} tag
-              </Button>{' '}
-              <div className="text-sm text-cream-white/50">
+              </ChunkyButton>{' '}
+              <div className="text-sm text-on-surface/50">
                 {tags[tag]?.name} Tag: {tags[tag]?.benefit}
               </div>
             </div>

--- a/src/app/daily-card-game/components/game-views/game-over.tsx
+++ b/src/app/daily-card-game/components/game-views/game-over.tsx
@@ -3,7 +3,7 @@
 import { useCallback, useMemo, useState } from 'react'
 
 import { useGameState } from '@/app/daily-card-game/useGameState'
-import { Button } from '@/components/ui/button'
+import { ChunkyButton } from '@/components/ui/chunky-button'
 import { Card } from '@/components/ui/card'
 
 import { ViewTemplate } from './view-template'
@@ -66,7 +66,7 @@ export function GameOverView() {
 
   return (
     <ViewTemplate>
-      <Card className="bg-space-grey border-space-purple p-4 text-cream-white h-63 w-1/3 flex flex-col justify-between text-center mx-auto">
+      <Card className="bg-surface-container-highest border-surface-variant p-4 text-on-surface h-63 w-1/3 flex flex-col justify-between text-center mx-auto">
         <div className="flex flex-col items-center justify-center">
           <h2>{didWin ? 'You Win!' : 'Game Over: You Lose'}</h2>
           <div>Total Score: {game.totalScore.toString()}</div>
@@ -95,10 +95,10 @@ export function GameOverView() {
             </div>
           </div>
           <div className="mt-4">
-            <Button onClick={onShare}>{hasCopied ? 'Copied!' : 'Share Score'}</Button>
+            <ChunkyButton onClick={onShare}>{hasCopied ? 'Copied!' : 'Share Score'}</ChunkyButton>
           </div>
           <div className="mt-4">
-            <p className="text-lg font-bold text-space-gold">Try again tomorrow for a new game!</p>
+            <p className="text-lg font-bold text-ds-tertiary">Try again tomorrow for a new game!</p>
           </div>
         </div>
       </Card>

--- a/src/app/daily-card-game/components/gameplay/playing-card.tsx
+++ b/src/app/daily-card-game/components/gameplay/playing-card.tsx
@@ -20,10 +20,10 @@ const cardColors = {
 const enchantmentStyles: Record<PlayingCardFlags['enchantment'], string> = {
   bonus: 'bg-blue-500',
   mult: 'bg-red-500',
-  gold: 'bg-space-gold',
-  glass: 'bg-gradient-to-br from-cream-white to-transparent',
+  gold: 'bg-ds-tertiary',
+  glass: 'bg-gradient-to-br from-on-surface to-transparent',
   lucky: 'bg-green-500',
-  steel: 'bg-space-grey',
+  steel: 'bg-surface-container-highest',
   stone: 'bg-grey-500',
   wild: 'bg-white',
   none: 'bg-white',
@@ -32,7 +32,7 @@ const enchantmentStyles: Record<PlayingCardFlags['enchantment'], string> = {
 const sealStyles: Record<PlayingCardFlags['seal'], string> = {
   blue: 'bg-blue-500',
   purple: 'bg-purple-500',
-  gold: 'bg-space-gold',
+  gold: 'bg-ds-tertiary',
   red: 'bg-red-500',
   none: 'bg-white',
 }
@@ -74,7 +74,7 @@ const FaceUpCard = ({ playingCard }: { playingCard: PlayingCardState }) => {
         {playingCard.flags.edition !== 'normal' && (
           <div
             data-name="edition-row"
-            className="flex justify-center bg-cream-white -mx-1 rounded-b-xl"
+            className="flex justify-center bg-on-surface -mx-1 rounded-b-xl"
           >
             <div className="text-xs">{playingCard.flags.edition}</div>
           </div>
@@ -86,7 +86,7 @@ const FaceUpCard = ({ playingCard }: { playingCard: PlayingCardState }) => {
 
 const FaceDownCard = () => {
   return (
-    <div className="flex flex-col px-1 h-full bg-space-grey">
+    <div className="flex flex-col px-1 h-full bg-surface-container-highest">
       <div data-name="top-row" className="flex justify-between">
         <div>?</div>
       </div>

--- a/src/app/daily-card-game/components/global/deck.tsx
+++ b/src/app/daily-card-game/components/global/deck.tsx
@@ -7,7 +7,7 @@ import { getDrawPile, getOwnedCards } from '@/app/daily-card-game/domain/game/ca
 import { playingCards } from '@/app/daily-card-game/domain/playing-card/playing-cards'
 import { PlayingCardState } from '@/app/daily-card-game/domain/playing-card/types'
 import { useGameState } from '@/app/daily-card-game/useGameState'
-import { Button } from '@/components/ui/button'
+import { ChunkyButton } from '@/components/ui/chunky-button'
 import { cn } from '@/lib/utils'
 
 const CardRow = ({ cards }: { cards: PlayingCardState[] }) => {
@@ -36,18 +36,18 @@ export const Deck = () => {
     <div>
       <div className="mb-2">
         {' '}
-        <Button
-          className={cn(deckType === 'remaining' ? 'bg-space-blue' : 'bg-space-grey')}
+        <ChunkyButton
+          className={cn(deckType === 'remaining' ? 'bg-space-blue' : 'bg-surface-container-highest')}
           onClick={() => setDeckType('remaining')}
         >
           Remaining Deck
-        </Button>
-        <Button
-          className={cn(deckType === 'full' ? 'bg-space-blue' : 'bg-space-grey')}
+        </ChunkyButton>
+        <ChunkyButton
+          className={cn(deckType === 'full' ? 'bg-space-blue' : 'bg-surface-container-highest')}
           onClick={() => setDeckType('full')}
         >
           Full Deck
-        </Button>
+        </ChunkyButton>
       </div>
 
       <CardRow cards={spades} />

--- a/src/app/daily-card-game/components/global/dollar-signs.tsx
+++ b/src/app/daily-card-game/components/global/dollar-signs.tsx
@@ -1,6 +1,6 @@
 export const DollarSigns = ({ count }: { count: number }) => {
   return Array.from({ length: count }, (_, index) => (
-    <span className="text-space-gold" key={index}>
+    <span className="text-ds-tertiary" key={index}>
       $
     </span>
   ))

--- a/src/app/daily-card-game/components/ui/game-card.tsx
+++ b/src/app/daily-card-game/components/ui/game-card.tsx
@@ -15,7 +15,7 @@ export const GameCard = ({
   return (
     <Card
       className={cn(
-        isSelected ? 'ring-2 ring-space-purple transform -translate-y-2' : '',
+        isSelected ? 'ring-2 ring-surface-variant transform -translate-y-2' : '',
         'h-36 w-24 transform transition-all duration-300 cursor-pointer',
         className
       )}


### PR DESCRIPTION
## Summary

Closes #562 — Part of epic #529 — **Phase 6: Per-game refresh (6/9)**

Token migration across 6 Daily Card Game component files. Button → ChunkyButton where used. All game logic preserved.

## Test plan
- [ ] Verify Vercel preview deploys without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)