### PR TITLE
Redesign 37: Visually sunset Ring Toss

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -77,6 +77,7 @@ const eslintConfig = [
     files: ['src/**/*.{js,jsx,ts,tsx}'],
     ignores: [
       'src/app/globals.css',
+      'src/app/ring-toss/**',
       'src/**/*.test.*',
       'src/**/*.spec.*',
       'src/**/*.stories.*',


### PR DESCRIPTION
## Summary

Closes #567 — Part of epic #529 — **Phase 7: Cleanup (1/2)**

Ring Toss is already visually sunset:
- Removed from home grid (PR #599, issue #554)
- Not in TopNavBar (PR #589, issue #544) 
- Not in SideNavBar (PR #592, issue #545)

This PR adds the lint allowlist so Ring Toss internal files don't trigger design-system ESLint warnings. The `/ring-toss` route continues to work for direct URL access.

## Test plan
- [ ] Verify Vercel preview deploys without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)