### PR TITLE
fix: remove sidebar from trivia page

### DIFF
--- a/src/app/trivia/layout.tsx
+++ b/src/app/trivia/layout.tsx
@@ -1,4 +1,3 @@
-import { GameShell } from '@/components/game-shell'
 import { AuthProvider } from '@/hooks/useAuth'
 
 import type { ReactNode } from 'react'
@@ -6,7 +5,7 @@ import type { ReactNode } from 'react'
 export default function TriviaLayout({ children }: { children: ReactNode }) {
   return (
     <AuthProvider>
-      <GameShell>{children}</GameShell>
+      <div className="min-h-screen">{children}</div>
     </AuthProvider>
   )
 }


### PR DESCRIPTION
## Fix
The redesign epic wrapped the trivia layout in GameShell (which includes SideNavBar). Trivia should be a standalone fullscreen page without the sidebar.

Removed GameShell wrapper, replaced with a simple min-h-screen div.

## Target branch
release/redesign-epic-529 (the redesign epic branch)