### PR TITLE
feat: Infinite Trivia 1 — Schema + sampler foundation

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -15,6 +15,24 @@
         { "fieldPath": "weekKey", "order": "ASCENDING" },
         { "fieldPath": "totalScore", "order": "DESCENDING" }
       ]
+    },
+    {
+      "collectionGroup": "aiQuestions",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "status", "order": "ASCENDING" },
+        { "fieldPath": "type", "order": "ASCENDING" },
+        { "fieldPath": "difficulty", "order": "ASCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "aiQuestions",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "status", "order": "ASCENDING" },
+        { "fieldPath": "type", "order": "ASCENDING" },
+        { "fieldPath": "timesShown", "order": "ASCENDING" }
+      ]
     }
   ],
   "fieldOverrides": [

--- a/firestore.rules
+++ b/firestore.rules
@@ -18,6 +18,11 @@ service cloud.firestore {
       // Client must not query these directly.
       match /triviaDaily/{docId}  { allow read, write: if false; }
       match /triviaWeekly/{docId} { allow read, write: if false; }
+
+      // Infinite Trivia — server-only subcollections
+      match /seenQuestions/{qid}     { allow read, write: if false; }
+      match /triviaInfinite/{runId}  { allow read, write: if false; }
+      match /triviaStats/{docId}     { allow read, write: if false; }
     }
 
     // Nicknames uniqueness index — server only
@@ -31,5 +36,9 @@ service cloud.firestore {
     // server-side reads via /api/v1/tap-tap-adventure/leaderboard route.
     // Client does not read directly.
     match /adventure-scores/{docId} { allow read, write: if false; }
+
+    // AI questions — server-only
+    match /aiQuestions/{docId} { allow read, write: if false; }
+    match /aiQuestions/{docId}/answeredBy/{entryId} { allow read, write: if false; }
   }
 }

--- a/scripts/backfill-aiquestion-fields.ts
+++ b/scripts/backfill-aiquestion-fields.ts
@@ -1,0 +1,103 @@
+#!/usr/bin/env tsx
+/**
+ * Backfill new infinite-mode fields onto existing aiQuestions documents.
+ *
+ * For each doc in the `aiQuestions` collection that is missing any of the new
+ * fields (status, timesShown, timesCorrect, flaggedCount, avgTimeMs), this
+ * script sets sensible defaults using batched writes.
+ *
+ * Idempotent — safe to re-run. Docs that already have all fields are skipped.
+ *
+ * Usage:
+ *   npx tsx scripts/backfill-aiquestion-fields.ts
+ *
+ * Required env vars (same as the app):
+ *   FIREBASE_PROJECT_ID
+ *   FIREBASE_CLIENT_EMAIL
+ *   FIREBASE_PRIVATE_KEY
+ */
+
+import { cert, getApps, initializeApp } from 'firebase-admin/app'
+import { getFirestore, WriteBatch } from 'firebase-admin/firestore'
+
+const BATCH_SIZE = 400 // Firestore max is 500; stay well under
+
+function ensureApp() {
+  if (getApps().length > 0) return
+  const projectId = process.env.FIREBASE_PROJECT_ID
+  const clientEmail = process.env.FIREBASE_CLIENT_EMAIL
+  const privateKey = process.env.FIREBASE_PRIVATE_KEY?.replace(/\\n/g, '\n')
+  if (!projectId || !clientEmail || !privateKey) {
+    console.error(
+      'ERROR: Missing Firebase env vars. Set FIREBASE_PROJECT_ID, FIREBASE_CLIENT_EMAIL, FIREBASE_PRIVATE_KEY.'
+    )
+    process.exit(1)
+  }
+  initializeApp({ credential: cert({ projectId, clientEmail, privateKey }) })
+}
+
+async function main() {
+  ensureApp()
+  const db = getFirestore()
+
+  console.log('Fetching all aiQuestions documents...')
+  const snap = await db.collection('aiQuestions').get()
+  console.log(`Found ${snap.size} document(s).`)
+
+  const DEFAULTS = {
+    status: 'active',
+    timesShown: 0,
+    timesCorrect: 0,
+    flaggedCount: 0,
+    avgTimeMs: null,
+  } as const
+
+  let batch: WriteBatch = db.batch()
+  let batchCount = 0
+  let updatedTotal = 0
+  let skippedTotal = 0
+
+  for (const doc of snap.docs) {
+    const data = doc.data()
+    const missing: Partial<typeof DEFAULTS> = {}
+
+    for (const [field, defaultValue] of Object.entries(DEFAULTS) as Array<
+      [keyof typeof DEFAULTS, (typeof DEFAULTS)[keyof typeof DEFAULTS]]
+    >) {
+      if (!(field in data)) {
+        ;(missing as Record<string, unknown>)[field] = defaultValue
+      }
+    }
+
+    if (Object.keys(missing).length === 0) {
+      skippedTotal++
+      continue
+    }
+
+    batch.update(doc.ref, missing)
+    batchCount++
+    updatedTotal++
+
+    if (batchCount >= BATCH_SIZE) {
+      process.stdout.write(`Committing batch of ${batchCount}...`)
+      await batch.commit()
+      console.log(' done.')
+      batch = db.batch()
+      batchCount = 0
+    }
+  }
+
+  if (batchCount > 0) {
+    process.stdout.write(`Committing final batch of ${batchCount}...`)
+    await batch.commit()
+    console.log(' done.')
+  }
+
+  console.log('─'.repeat(60))
+  console.log(`Updated: ${updatedTotal}  |  Skipped (already complete): ${skippedTotal}`)
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})

--- a/src/app/api/v1/trivia/infinite/next/route.ts
+++ b/src/app/api/v1/trivia/infinite/next/route.ts
@@ -1,0 +1,38 @@
+import { type NextRequest, NextResponse } from 'next/server'
+
+import { verifyRequestAuth } from '@/lib/api/auth'
+import { sampleNextQuestion } from '@/lib/trivia/sampler'
+import type { AIQuestion } from '@/lib/trivia/aiQuestions'
+
+// GET /api/v1/trivia/infinite/next?streak=N
+export async function GET(request: NextRequest) {
+  const auth = await verifyRequestAuth(request)
+  if ('error' in auth) return auth.error
+
+  const { searchParams } = new URL(request.url)
+  const streakParam = searchParams.get('streak')
+  const streak = streakParam !== null ? parseInt(streakParam, 10) : 0
+  const parsedStreak = isNaN(streak) || streak < 0 ? 0 : streak
+
+  try {
+    const question = await sampleNextQuestion({
+      uid: auth.claims.uid,
+      streak: parsedStreak,
+      type: 'free-text',
+    })
+
+    if (question === null) {
+      // Library exhausted — no unseen questions remain
+      return new NextResponse(null, { status: 204 })
+    }
+
+    // Strip correctAnswer before sending to client
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { correctAnswer, ...safeQuestion }: AIQuestion = question
+
+    return NextResponse.json(safeQuestion)
+  } catch (err) {
+    console.error('Failed to sample next infinite trivia question:', err)
+    return NextResponse.json({ error: 'Failed to fetch question.' }, { status: 500 })
+  }
+}

--- a/src/lib/trivia/aiQuestions.ts
+++ b/src/lib/trivia/aiQuestions.ts
@@ -1,0 +1,39 @@
+import { getFirestoreDb } from '@/lib/firebase/server'
+
+export interface AIQuestion {
+  id: string
+  question: string
+  correctAnswer: string
+  explanation?: string
+  category: string
+  difficulty: 'easy' | 'medium' | 'hard'
+  type: 'free-text'
+  // New fields for infinite mode
+  status: 'active' | 'flagged' | 'removed'
+  timesShown: number
+  timesCorrect: number
+  flaggedCount: number
+  avgTimeMs: number | null
+}
+
+export interface SeenQuestion {
+  at: FirebaseFirestore.Timestamp
+  correct: boolean
+}
+
+export async function saveAIQuestion(
+  question: Omit<AIQuestion, 'status' | 'timesShown' | 'timesCorrect' | 'flaggedCount' | 'avgTimeMs'>
+): Promise<string> {
+  const db = getFirestoreDb()
+  const doc: AIQuestion = {
+    ...question,
+    status: 'active',
+    timesShown: 0,
+    timesCorrect: 0,
+    flaggedCount: 0,
+    avgTimeMs: null,
+  }
+  const ref = db.collection('aiQuestions').doc(question.id)
+  await ref.set(doc)
+  return ref.id
+}

--- a/src/lib/trivia/sampler.ts
+++ b/src/lib/trivia/sampler.ts
@@ -1,0 +1,94 @@
+import { getFirestoreDb } from '@/lib/firebase/server'
+import type { AIQuestion } from '@/lib/trivia/aiQuestions'
+
+export interface SamplerOptions {
+  uid: string
+  streak: number
+  type?: 'free-text' // v1 only free-text
+}
+
+// Difficulty weights by streak band
+// [easy%, medium%, hard%]
+function getDifficultyWeights(streak: number): [number, number, number] {
+  if (streak >= 20) return [0.05, 0.25, 0.70]
+  if (streak >= 10) return [0.10, 0.30, 0.60]
+  if (streak >= 5)  return [0.30, 0.40, 0.30]
+  return [0.60, 0.30, 0.10]
+}
+
+// Weighted random selection over an array of items with numeric weights
+function weightedRandom<T>(items: T[], weights: number[]): T {
+  const total = weights.reduce((a, b) => a + b, 0)
+  let rand = Math.random() * total
+  for (let i = 0; i < items.length; i++) {
+    rand -= weights[i]
+    if (rand <= 0) return items[i]
+  }
+  return items[items.length - 1]
+}
+
+// Compute per-question weight within a difficulty bucket.
+// Lower timesShown → higher weight (freshness bias).
+function freshnessWeight(timesShown: number): number {
+  return 1 / (1 + timesShown)
+}
+
+export async function sampleNextQuestion(options: SamplerOptions): Promise<AIQuestion | null> {
+  const { uid, streak, type = 'free-text' } = options
+  const db = getFirestoreDb()
+
+  // 1. Query active questions of the requested type
+  const questionsSnap = await db
+    .collection('aiQuestions')
+    .where('status', '==', 'active')
+    .where('type', '==', type)
+    .get()
+
+  if (questionsSnap.empty) return null
+
+  // 2. Get IDs already seen by this user
+  const seenSnap = await db.collection(`users/${uid}/seenQuestions`).get()
+  const seenIds = new Set(seenSnap.docs.map((d) => d.id))
+
+  // 3. Filter out seen questions
+  const unseen = questionsSnap.docs
+    .map((d) => ({ id: d.id, ...(d.data() as Omit<AIQuestion, 'id'>) }))
+    .filter((q) => !seenIds.has(q.id))
+
+  if (unseen.length === 0) return null
+
+  // 4. Bucket by difficulty
+  const byDifficulty: Record<'easy' | 'medium' | 'hard', AIQuestion[]> = {
+    easy: [],
+    medium: [],
+    hard: [],
+  }
+  for (const q of unseen) {
+    byDifficulty[q.difficulty].push(q)
+  }
+
+  // 5. Determine which difficulty to pick from, weighted by streak
+  const [easyW, mediumW, hardW] = getDifficultyWeights(streak)
+
+  // Only include difficulty levels that have available questions
+  const availableDifficulties: Array<{ key: 'easy' | 'medium' | 'hard'; weight: number }> = []
+  if (byDifficulty.easy.length > 0)   availableDifficulties.push({ key: 'easy',   weight: easyW })
+  if (byDifficulty.medium.length > 0) availableDifficulties.push({ key: 'medium', weight: mediumW })
+  if (byDifficulty.hard.length > 0)   availableDifficulties.push({ key: 'hard',   weight: hardW })
+
+  if (availableDifficulties.length === 0) return null
+
+  const chosenDifficulty = weightedRandom(
+    availableDifficulties.map((d) => d.key),
+    availableDifficulties.map((d) => d.weight)
+  )
+
+  // 6. Within the chosen bucket, apply freshness bias (lower timesShown → higher weight)
+  const bucket = byDifficulty[chosenDifficulty]
+  const bucketWeights = bucket.map((q) => freshnessWeight(q.timesShown))
+
+  // 7. Select one question
+  const selected = weightedRandom(bucket, bucketWeights)
+
+  return selected
+}


### PR DESCRIPTION
## Summary

Implements issue #568 — the data and read-path foundation for Infinite Trivia mode.

- **`AIQuestion` interface + `saveAIQuestion` helper** — extends the AI question schema with `status`, `timesShown`, `timesCorrect`, `flaggedCount`, `avgTimeMs` fields with sensible defaults
- **Weighted sampler** (`src/lib/trivia/sampler.ts`) — streak-based difficulty weighting across 4 bands, freshness bias toward less-shown questions, excludes previously-seen questions per user
- **API endpoint** `GET /api/v1/trivia/infinite/next?streak=N` — auth required, returns one unseen question (stripped of answer), 204 when library exhausted
- **Firestore rules** — deny client access to `seenQuestions`, `triviaInfinite`, `triviaStats`, `aiQuestions`, and `answeredBy` subcollections
- **Composite indexes** — `(status, type, difficulty)` and `(status, type, timesShown)` on `aiQuestions`
- **Backfill script** — `scripts/backfill-aiquestion-fields.ts` for existing docs (idempotent, batched)

Closes #568

## Test plan

- [ ] `npx tsc --noEmit` passes (verified locally)
- [ ] Verify sampler returns different difficulty distributions at streak=0 vs streak=20
- [ ] Verify sampler returns null when all questions are in seenQuestions
- [ ] Verify endpoint returns 401 without auth token
- [ ] Verify endpoint returns 204 when library is exhausted
- [ ] Verify backfill script is idempotent (safe to re-run)
- [ ] Verify firestore rules deny client direct read on new collections

🤖 Generated with [Claude Code](https://claude.com/claude-code)