### PR TITLE
feat: Infinite Trivia 2 — Run lifecycle (lives, streak, trailblazer)

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -15,6 +15,24 @@
         { "fieldPath": "weekKey", "order": "ASCENDING" },
         { "fieldPath": "totalScore", "order": "DESCENDING" }
       ]
+    },
+    {
+      "collectionGroup": "aiQuestions",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "status", "order": "ASCENDING" },
+        { "fieldPath": "type", "order": "ASCENDING" },
+        { "fieldPath": "difficulty", "order": "ASCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "aiQuestions",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "status", "order": "ASCENDING" },
+        { "fieldPath": "type", "order": "ASCENDING" },
+        { "fieldPath": "timesShown", "order": "ASCENDING" }
+      ]
     }
   ],
   "fieldOverrides": [

--- a/firestore.rules
+++ b/firestore.rules
@@ -18,6 +18,11 @@ service cloud.firestore {
       // Client must not query these directly.
       match /triviaDaily/{docId}  { allow read, write: if false; }
       match /triviaWeekly/{docId} { allow read, write: if false; }
+
+      // Infinite Trivia — server-only subcollections
+      match /seenQuestions/{qid}     { allow read, write: if false; }
+      match /triviaInfinite/{runId}  { allow read, write: if false; }
+      match /triviaStats/{docId}     { allow read, write: if false; }
     }
 
     // Nicknames uniqueness index — server only
@@ -31,5 +36,9 @@ service cloud.firestore {
     // server-side reads via /api/v1/tap-tap-adventure/leaderboard route.
     // Client does not read directly.
     match /adventure-scores/{docId} { allow read, write: if false; }
+
+    // AI questions — server-only
+    match /aiQuestions/{docId} { allow read, write: if false; }
+    match /aiQuestions/{docId}/answeredBy/{entryId} { allow read, write: if false; }
   }
 }

--- a/scripts/backfill-aiquestion-fields.ts
+++ b/scripts/backfill-aiquestion-fields.ts
@@ -1,0 +1,103 @@
+#!/usr/bin/env tsx
+/**
+ * Backfill new infinite-mode fields onto existing aiQuestions documents.
+ *
+ * For each doc in the `aiQuestions` collection that is missing any of the new
+ * fields (status, timesShown, timesCorrect, flaggedCount, avgTimeMs), this
+ * script sets sensible defaults using batched writes.
+ *
+ * Idempotent — safe to re-run. Docs that already have all fields are skipped.
+ *
+ * Usage:
+ *   npx tsx scripts/backfill-aiquestion-fields.ts
+ *
+ * Required env vars (same as the app):
+ *   FIREBASE_PROJECT_ID
+ *   FIREBASE_CLIENT_EMAIL
+ *   FIREBASE_PRIVATE_KEY
+ */
+
+import { cert, getApps, initializeApp } from 'firebase-admin/app'
+import { getFirestore, WriteBatch } from 'firebase-admin/firestore'
+
+const BATCH_SIZE = 400 // Firestore max is 500; stay well under
+
+function ensureApp() {
+  if (getApps().length > 0) return
+  const projectId = process.env.FIREBASE_PROJECT_ID
+  const clientEmail = process.env.FIREBASE_CLIENT_EMAIL
+  const privateKey = process.env.FIREBASE_PRIVATE_KEY?.replace(/\\n/g, '\n')
+  if (!projectId || !clientEmail || !privateKey) {
+    console.error(
+      'ERROR: Missing Firebase env vars. Set FIREBASE_PROJECT_ID, FIREBASE_CLIENT_EMAIL, FIREBASE_PRIVATE_KEY.'
+    )
+    process.exit(1)
+  }
+  initializeApp({ credential: cert({ projectId, clientEmail, privateKey }) })
+}
+
+async function main() {
+  ensureApp()
+  const db = getFirestore()
+
+  console.log('Fetching all aiQuestions documents...')
+  const snap = await db.collection('aiQuestions').get()
+  console.log(`Found ${snap.size} document(s).`)
+
+  const DEFAULTS = {
+    status: 'active',
+    timesShown: 0,
+    timesCorrect: 0,
+    flaggedCount: 0,
+    avgTimeMs: null,
+  } as const
+
+  let batch: WriteBatch = db.batch()
+  let batchCount = 0
+  let updatedTotal = 0
+  let skippedTotal = 0
+
+  for (const doc of snap.docs) {
+    const data = doc.data()
+    const missing: Partial<typeof DEFAULTS> = {}
+
+    for (const [field, defaultValue] of Object.entries(DEFAULTS) as Array<
+      [keyof typeof DEFAULTS, (typeof DEFAULTS)[keyof typeof DEFAULTS]]
+    >) {
+      if (!(field in data)) {
+        ;(missing as Record<string, unknown>)[field] = defaultValue
+      }
+    }
+
+    if (Object.keys(missing).length === 0) {
+      skippedTotal++
+      continue
+    }
+
+    batch.update(doc.ref, missing)
+    batchCount++
+    updatedTotal++
+
+    if (batchCount >= BATCH_SIZE) {
+      process.stdout.write(`Committing batch of ${batchCount}...`)
+      await batch.commit()
+      console.log(' done.')
+      batch = db.batch()
+      batchCount = 0
+    }
+  }
+
+  if (batchCount > 0) {
+    process.stdout.write(`Committing final batch of ${batchCount}...`)
+    await batch.commit()
+    console.log(' done.')
+  }
+
+  console.log('─'.repeat(60))
+  console.log(`Updated: ${updatedTotal}  |  Skipped (already complete): ${skippedTotal}`)
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})

--- a/src/app/api/v1/trivia/infinite/next/route.ts
+++ b/src/app/api/v1/trivia/infinite/next/route.ts
@@ -1,0 +1,38 @@
+import { type NextRequest, NextResponse } from 'next/server'
+
+import { verifyRequestAuth } from '@/lib/api/auth'
+import { sampleNextQuestion } from '@/lib/trivia/sampler'
+import type { AIQuestion } from '@/lib/trivia/aiQuestions'
+
+// GET /api/v1/trivia/infinite/next?streak=N
+export async function GET(request: NextRequest) {
+  const auth = await verifyRequestAuth(request)
+  if ('error' in auth) return auth.error
+
+  const { searchParams } = new URL(request.url)
+  const streakParam = searchParams.get('streak')
+  const streak = streakParam !== null ? parseInt(streakParam, 10) : 0
+  const parsedStreak = isNaN(streak) || streak < 0 ? 0 : streak
+
+  try {
+    const question = await sampleNextQuestion({
+      uid: auth.claims.uid,
+      streak: parsedStreak,
+      type: 'free-text',
+    })
+
+    if (question === null) {
+      // Library exhausted — no unseen questions remain
+      return new NextResponse(null, { status: 204 })
+    }
+
+    // Strip correctAnswer before sending to client
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { correctAnswer, ...safeQuestion }: AIQuestion = question
+
+    return NextResponse.json(safeQuestion)
+  } catch (err) {
+    console.error('Failed to sample next infinite trivia question:', err)
+    return NextResponse.json({ error: 'Failed to fetch question.' }, { status: 500 })
+  }
+}

--- a/src/app/api/v1/trivia/infinite/runs/[runId]/answer/route.ts
+++ b/src/app/api/v1/trivia/infinite/runs/[runId]/answer/route.ts
@@ -1,0 +1,57 @@
+import { type NextRequest, NextResponse } from 'next/server';
+
+import { verifyRequestAuth } from '@/lib/api/auth';
+import { getFirestoreDb } from '@/lib/firebase/server';
+import { judgeAnswer } from '@/lib/trivia/answerJudge';
+import { submitAnswer } from '@/lib/trivia/infiniteRuns';
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ runId: string }> }
+) {
+  const auth = await verifyRequestAuth(request);
+  if ('error' in auth) return auth.error;
+
+  const { runId } = await params;
+
+  try {
+    const body = await request.json();
+    const { questionId, answer, elapsedMs } = body;
+
+    if (!questionId || !answer || elapsedMs === undefined) {
+      return NextResponse.json({ error: 'questionId, answer, and elapsedMs are required.' }, { status: 400 });
+    }
+
+    // Load question
+    const db = getFirestoreDb();
+    const qSnap = await db.doc(`aiQuestions/${questionId}`).get();
+    if (!qSnap.exists || qSnap.data()?.status !== 'active') {
+      return NextResponse.json({ error: 'Question not found or inactive.' }, { status: 404 });
+    }
+    const qData = qSnap.data()!;
+
+    // Grade the answer
+    const correct = await judgeAnswer(qData.question, qData.correctAnswer, answer);
+
+    // Submit to run
+    const result = await submitAnswer({
+      uid: auth.claims.uid,
+      runId,
+      questionId,
+      correct,
+      elapsedMs: typeof elapsedMs === 'number' ? elapsedMs : 0,
+    });
+
+    return NextResponse.json(result);
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    if (message === 'Run already ended') {
+      return NextResponse.json({ error: 'Run already ended.' }, { status: 409 });
+    }
+    if (message === 'Run not found') {
+      return NextResponse.json({ error: 'Run not found.' }, { status: 404 });
+    }
+    console.error('Failed to submit answer:', err);
+    return NextResponse.json({ error: 'Failed to submit answer.' }, { status: 500 });
+  }
+}

--- a/src/app/api/v1/trivia/infinite/runs/[runId]/end/route.ts
+++ b/src/app/api/v1/trivia/infinite/runs/[runId]/end/route.ts
@@ -1,0 +1,26 @@
+import { type NextRequest, NextResponse } from 'next/server';
+
+import { verifyRequestAuth } from '@/lib/api/auth';
+import { endRun } from '@/lib/trivia/infiniteRuns';
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ runId: string }> }
+) {
+  const auth = await verifyRequestAuth(request);
+  if ('error' in auth) return auth.error;
+
+  const { runId } = await params;
+
+  try {
+    await endRun(auth.claims.uid, runId);
+    return NextResponse.json({ ended: true });
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    if (message === 'Run not found') {
+      return NextResponse.json({ error: 'Run not found.' }, { status: 404 });
+    }
+    console.error('Failed to end run:', err);
+    return NextResponse.json({ error: 'Failed to end run.' }, { status: 500 });
+  }
+}

--- a/src/app/api/v1/trivia/infinite/runs/route.ts
+++ b/src/app/api/v1/trivia/infinite/runs/route.ts
@@ -1,0 +1,19 @@
+import { type NextRequest, NextResponse } from 'next/server';
+
+import { verifyRequestAuth } from '@/lib/api/auth';
+import { startRun } from '@/lib/trivia/infiniteRuns';
+
+export async function POST(request: NextRequest) {
+  const auth = await verifyRequestAuth(request);
+  if ('error' in auth) return auth.error;
+
+  try {
+    const body = await request.json();
+    const mode = body.mode === 'practice' ? 'practice' : 'scored';
+    const result = await startRun(auth.claims.uid, mode);
+    return NextResponse.json(result, { status: 201 });
+  } catch (err) {
+    console.error('Failed to start infinite run:', err);
+    return NextResponse.json({ error: 'Failed to start run.' }, { status: 500 });
+  }
+}

--- a/src/app/trivia/lib/infiniteScoring.ts
+++ b/src/app/trivia/lib/infiniteScoring.ts
@@ -1,0 +1,84 @@
+export const LIVES_START = 3
+export const LIVES_MAX = 3
+export const LIFE_REFUND_EVERY = 10
+export const TRAILBLAZER_BONUS = 50
+
+export const STREAK_TIERS = [
+  { at: 0, mult: 1 },
+  { at: 5, mult: 1.5 },
+  { at: 10, mult: 2 },
+  { at: 20, mult: 3 },
+] as const
+
+// Max points per question (before multiplier)
+export const BASE_MAX_POINTS = 100
+
+export function computeStreakMultiplier(streak: number): number {
+  // Walk tiers in reverse, return first match
+  for (let i = STREAK_TIERS.length - 1; i >= 0; i--) {
+    if (streak >= STREAK_TIERS[i].at) return STREAK_TIERS[i].mult
+  }
+  return 1
+}
+
+export function computeSpeedBonus(elapsedMs: number, timeLimitMs: number = 30000): number {
+  // max * (timeRemaining / timeLimit), clamped to [0, BASE_MAX_POINTS]
+  const remaining = Math.max(0, timeLimitMs - elapsedMs)
+  return Math.round(BASE_MAX_POINTS * (remaining / timeLimitMs))
+}
+
+export function shouldRefundLife(newStreak: number, livesRemaining: number): boolean {
+  return newStreak > 0 && newStreak % LIFE_REFUND_EVERY === 0 && livesRemaining < LIVES_MAX
+}
+
+export interface AnswerResult {
+  correct: boolean
+  points: number
+  trailblazer: boolean
+  livesRemaining: number
+  currentStreak: number
+  longestStreak: number
+  score: number
+  runOver: boolean
+}
+
+export function applyAnswer(params: {
+  correct: boolean
+  trailblazer: boolean
+  elapsedMs: number
+  mode: 'scored' | 'practice'
+  prevLives: number
+  prevStreak: number
+  prevLongestStreak: number
+  prevScore: number
+}): AnswerResult {
+  const { correct, trailblazer, elapsedMs, mode, prevLives, prevStreak, prevLongestStreak, prevScore } = params
+
+  let lives = prevLives
+  let streak = prevStreak
+  let longestStreak = prevLongestStreak
+  let points = 0
+
+  if (correct) {
+    streak += 1
+    longestStreak = Math.max(longestStreak, streak)
+    const speedBonus = computeSpeedBonus(elapsedMs)
+    const mult = computeStreakMultiplier(streak)
+    points = Math.round(speedBonus * mult)
+    if (trailblazer) points += TRAILBLAZER_BONUS
+    // Life refund
+    if (shouldRefundLife(streak, lives)) {
+      lives = Math.min(lives + 1, LIVES_MAX)
+    }
+  } else {
+    streak = 0
+    if (mode === 'scored') {
+      lives -= 1
+    }
+  }
+
+  const score = prevScore + points
+  const runOver = mode === 'scored' && lives <= 0
+
+  return { correct, points, trailblazer, livesRemaining: lives, currentStreak: streak, longestStreak, score, runOver }
+}

--- a/src/lib/trivia/__tests__/infiniteScoring.test.ts
+++ b/src/lib/trivia/__tests__/infiniteScoring.test.ts
@@ -1,0 +1,210 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  BASE_MAX_POINTS,
+  LIVES_MAX,
+  LIVES_START,
+  TRAILBLAZER_BONUS,
+  applyAnswer,
+  computeSpeedBonus,
+  computeStreakMultiplier,
+  shouldRefundLife,
+} from '@/app/trivia/lib/infiniteScoring'
+
+describe('computeStreakMultiplier', () => {
+  it('returns 1 at streak 0', () => {
+    expect(computeStreakMultiplier(0)).toBe(1)
+  })
+
+  it('returns 1 at streak 4 (below tier at 5)', () => {
+    expect(computeStreakMultiplier(4)).toBe(1)
+  })
+
+  it('returns 1.5 at streak 5', () => {
+    expect(computeStreakMultiplier(5)).toBe(1.5)
+  })
+
+  it('returns 1.5 at streak 9 (below tier at 10)', () => {
+    expect(computeStreakMultiplier(9)).toBe(1.5)
+  })
+
+  it('returns 2 at streak 10', () => {
+    expect(computeStreakMultiplier(10)).toBe(2)
+  })
+
+  it('returns 2 at streak 19 (below tier at 20)', () => {
+    expect(computeStreakMultiplier(19)).toBe(2)
+  })
+
+  it('returns 3 at streak 20', () => {
+    expect(computeStreakMultiplier(20)).toBe(3)
+  })
+
+  it('returns 3 at streak 50 (well above last tier)', () => {
+    expect(computeStreakMultiplier(50)).toBe(3)
+  })
+})
+
+describe('computeSpeedBonus', () => {
+  it('returns BASE_MAX_POINTS at 0ms elapsed', () => {
+    expect(computeSpeedBonus(0)).toBe(BASE_MAX_POINTS)
+  })
+
+  it('returns 0 at exactly timeLimitMs elapsed', () => {
+    expect(computeSpeedBonus(30000)).toBe(0)
+  })
+
+  it('returns 0 for elapsed > timeLimitMs', () => {
+    expect(computeSpeedBonus(35000)).toBe(0)
+  })
+
+  it('returns ~50 at halfway through time', () => {
+    expect(computeSpeedBonus(15000)).toBe(50)
+  })
+
+  it('respects custom timeLimitMs', () => {
+    // 5000ms elapsed out of 10000ms limit → 50% remaining → 50 points
+    expect(computeSpeedBonus(5000, 10000)).toBe(50)
+  })
+})
+
+describe('shouldRefundLife', () => {
+  it('returns true at streak 10 when lives < LIVES_MAX', () => {
+    expect(shouldRefundLife(10, 2)).toBe(true)
+  })
+
+  it('returns true at streak 20 when lives < LIVES_MAX', () => {
+    expect(shouldRefundLife(20, 1)).toBe(true)
+  })
+
+  it('returns true at streak 30 when lives < LIVES_MAX', () => {
+    expect(shouldRefundLife(30, 2)).toBe(true)
+  })
+
+  it('returns false at streak 10 when lives === LIVES_MAX', () => {
+    expect(shouldRefundLife(10, LIVES_MAX)).toBe(false)
+  })
+
+  it('returns false at streak 5 (non-multiple of 10)', () => {
+    expect(shouldRefundLife(5, 2)).toBe(false)
+  })
+
+  it('returns false at streak 0', () => {
+    expect(shouldRefundLife(0, 2)).toBe(false)
+  })
+
+  it('returns false at streak 11 (non-multiple of 10)', () => {
+    expect(shouldRefundLife(11, 1)).toBe(false)
+  })
+})
+
+describe('applyAnswer', () => {
+  const baseParams = {
+    trailblazer: false,
+    elapsedMs: 0,
+    mode: 'scored' as const,
+    prevLives: LIVES_START,
+    prevStreak: 0,
+    prevLongestStreak: 0,
+    prevScore: 0,
+  }
+
+  it('increments streak and awards points on correct answer', () => {
+    const result = applyAnswer({ ...baseParams, correct: true })
+    expect(result.correct).toBe(true)
+    expect(result.currentStreak).toBe(1)
+    expect(result.longestStreak).toBe(1)
+    expect(result.points).toBeGreaterThan(0)
+    expect(result.livesRemaining).toBe(LIVES_START)
+    expect(result.runOver).toBe(false)
+  })
+
+  it('resets streak and decrements lives on wrong answer in scored mode', () => {
+    const result = applyAnswer({ ...baseParams, correct: false, prevStreak: 3 })
+    expect(result.correct).toBe(false)
+    expect(result.currentStreak).toBe(0)
+    expect(result.points).toBe(0)
+    expect(result.livesRemaining).toBe(LIVES_START - 1)
+    expect(result.runOver).toBe(false)
+  })
+
+  it('sets runOver when lives reach 0 in scored mode', () => {
+    const result = applyAnswer({ ...baseParams, correct: false, prevLives: 1 })
+    expect(result.livesRemaining).toBe(0)
+    expect(result.runOver).toBe(true)
+  })
+
+  it('does NOT decrement lives on wrong answer in practice mode', () => {
+    const result = applyAnswer({ ...baseParams, correct: false, mode: 'practice' })
+    expect(result.livesRemaining).toBe(LIVES_START)
+    expect(result.runOver).toBe(false)
+  })
+
+  it('applies streak multiplier after 5 correct answers', () => {
+    // Build up to streak 4
+    let state = { ...baseParams, prevScore: 0, prevStreak: 0, prevLongestStreak: 0, prevLives: LIVES_START }
+    for (let i = 0; i < 4; i++) {
+      const r = applyAnswer({ ...state, correct: true, elapsedMs: 0 })
+      state = { ...state, prevStreak: r.currentStreak, prevLongestStreak: r.longestStreak, prevScore: r.score }
+    }
+    // 5th correct answer should trigger 1.5x multiplier
+    const result = applyAnswer({ ...state, correct: true, elapsedMs: 0 })
+    expect(result.currentStreak).toBe(5)
+    // At streak 5 with 0ms elapsed: BASE_MAX_POINTS * 1.5 = 150
+    expect(result.points).toBe(Math.round(BASE_MAX_POINTS * 1.5))
+  })
+
+  it('adds TRAILBLAZER_BONUS when trailblazer is true', () => {
+    const regular = applyAnswer({ ...baseParams, correct: true, trailblazer: false, elapsedMs: 0 })
+    const trailblazer = applyAnswer({ ...baseParams, correct: true, trailblazer: true, elapsedMs: 0 })
+    expect(trailblazer.points - regular.points).toBe(TRAILBLAZER_BONUS)
+    expect(trailblazer.trailblazer).toBe(true)
+  })
+
+  it('does not award trailblazer bonus on wrong answer', () => {
+    const result = applyAnswer({ ...baseParams, correct: false, trailblazer: true, elapsedMs: 0 })
+    expect(result.points).toBe(0)
+  })
+
+  it('refunds a life at streak 10 when lives are below max', () => {
+    const result = applyAnswer({
+      ...baseParams,
+      correct: true,
+      elapsedMs: 0,
+      prevStreak: 9,
+      prevLongestStreak: 9,
+      prevLives: 2,
+    })
+    expect(result.currentStreak).toBe(10)
+    expect(result.livesRemaining).toBe(3) // restored to LIVES_MAX
+  })
+
+  it('does not refund life at streak 10 when already at max lives', () => {
+    const result = applyAnswer({
+      ...baseParams,
+      correct: true,
+      elapsedMs: 0,
+      prevStreak: 9,
+      prevLongestStreak: 9,
+      prevLives: LIVES_MAX,
+    })
+    expect(result.livesRemaining).toBe(LIVES_MAX)
+  })
+
+  it('accumulates score across answers', () => {
+    const first = applyAnswer({ ...baseParams, correct: true, elapsedMs: 0, prevScore: 0 })
+    const second = applyAnswer({ ...baseParams, correct: true, elapsedMs: 0, prevScore: first.score, prevStreak: 1, prevLongestStreak: 1 })
+    expect(second.score).toBeGreaterThan(first.score)
+  })
+
+  it('longestStreak does not decrease on wrong answer', () => {
+    const result = applyAnswer({
+      ...baseParams,
+      correct: false,
+      prevStreak: 5,
+      prevLongestStreak: 5,
+    })
+    expect(result.longestStreak).toBe(5)
+    expect(result.currentStreak).toBe(0)
+  })
+})

--- a/src/lib/trivia/aiQuestions.ts
+++ b/src/lib/trivia/aiQuestions.ts
@@ -1,0 +1,39 @@
+import { getFirestoreDb } from '@/lib/firebase/server'
+
+export interface AIQuestion {
+  id: string
+  question: string
+  correctAnswer: string
+  explanation?: string
+  category: string
+  difficulty: 'easy' | 'medium' | 'hard'
+  type: 'free-text'
+  // New fields for infinite mode
+  status: 'active' | 'flagged' | 'removed'
+  timesShown: number
+  timesCorrect: number
+  flaggedCount: number
+  avgTimeMs: number | null
+}
+
+export interface SeenQuestion {
+  at: FirebaseFirestore.Timestamp
+  correct: boolean
+}
+
+export async function saveAIQuestion(
+  question: Omit<AIQuestion, 'status' | 'timesShown' | 'timesCorrect' | 'flaggedCount' | 'avgTimeMs'>
+): Promise<string> {
+  const db = getFirestoreDb()
+  const doc: AIQuestion = {
+    ...question,
+    status: 'active',
+    timesShown: 0,
+    timesCorrect: 0,
+    flaggedCount: 0,
+    avgTimeMs: null,
+  }
+  const ref = db.collection('aiQuestions').doc(question.id)
+  await ref.set(doc)
+  return ref.id
+}

--- a/src/lib/trivia/answerJudge.ts
+++ b/src/lib/trivia/answerJudge.ts
@@ -1,0 +1,30 @@
+import { createOpenAI } from '@ai-sdk/openai'
+import { generateObject } from 'ai'
+import { z } from 'zod'
+
+export async function judgeAnswer(question: string, correctAnswer: string, userAnswer: string): Promise<boolean> {
+  const apiKey = process.env.NEXT_PUBLIC_OPENAI_API_KEY ?? process.env.OPENAI_API_KEY
+  if (!apiKey) throw new Error('OpenAI API key not configured')
+
+  const openaiClient = createOpenAI({ apiKey })
+  const JudgeSchema = z.object({
+    correct: z.boolean().describe('Whether the answer is correct or close enough'),
+  })
+
+  const result = await generateObject({
+    model: openaiClient('gpt-4o-mini'),
+    schema: JudgeSchema,
+    prompt: `You are a trivia answer judge. Determine if the user's answer is correct.
+
+Question: "${question}"
+Correct answer: "${correctAnswer}"
+User's answer: "${userAnswer}"
+
+Accept reasonable variations, minor spelling errors, and equivalent answers.
+Be generous — if the core concept is correct, mark it correct.`,
+    temperature: 0.1,
+    maxTokens: 100,
+  })
+
+  return result.object.correct
+}

--- a/src/lib/trivia/infiniteRuns.ts
+++ b/src/lib/trivia/infiniteRuns.ts
@@ -1,0 +1,152 @@
+import { FieldValue } from 'firebase-admin/firestore'
+
+import { LIVES_START, applyAnswer } from '@/app/trivia/lib/infiniteScoring'
+import type { AnswerResult } from '@/app/trivia/lib/infiniteScoring'
+import { getFirestoreDb } from '@/lib/firebase/server'
+
+export interface RunDoc {
+  runId: string
+  uid: string
+  mode: 'scored' | 'practice'
+  score: number
+  livesRemaining: number
+  currentStreak: number
+  longestStreak: number
+  trailblazes: number
+  answers: RunAnswer[]
+  startedAt: FirebaseFirestore.Timestamp
+  endedAt: FirebaseFirestore.Timestamp | null
+}
+
+export interface RunAnswer {
+  questionId: string
+  correct: boolean
+  points: number
+  timeMs: number
+  trailblazer: boolean
+  answeredAt: FirebaseFirestore.Timestamp
+}
+
+export async function startRun(uid: string, mode: 'scored' | 'practice' = 'scored'): Promise<{ runId: string; livesRemaining: number; currentStreak: number }> {
+  const db = getFirestoreDb()
+  const runRef = db.collection(`users/${uid}/triviaInfinite`).doc()
+  const now = FieldValue.serverTimestamp()
+  await runRef.set({
+    runId: runRef.id,
+    uid,
+    mode,
+    score: 0,
+    livesRemaining: LIVES_START,
+    currentStreak: 0,
+    longestStreak: 0,
+    trailblazes: 0,
+    answers: [],
+    startedAt: now,
+    endedAt: null,
+  })
+  return { runId: runRef.id, livesRemaining: LIVES_START, currentStreak: 0 }
+}
+
+export async function submitAnswer(params: {
+  uid: string
+  runId: string
+  questionId: string
+  correct: boolean
+  elapsedMs: number
+}): Promise<AnswerResult & { trailblazer: boolean }> {
+  const db = getFirestoreDb()
+  const { uid, runId, questionId, correct, elapsedMs } = params
+
+  const runRef = db.doc(`users/${uid}/triviaInfinite/${runId}`)
+  const questionRef = db.doc(`aiQuestions/${questionId}`)
+  const seenRef = db.doc(`users/${uid}/seenQuestions/${questionId}`)
+  const answeredByRef = db.doc(`aiQuestions/${questionId}/answeredBy/${uid}_${runId}`)
+
+  return db.runTransaction(async (tx) => {
+    const runSnap = await tx.get(runRef)
+    if (!runSnap.exists) throw new Error('Run not found')
+    const run = runSnap.data() as RunDoc
+
+    if (run.endedAt !== null) throw new Error('Run already ended')
+
+    const qSnap = await tx.get(questionRef)
+    if (!qSnap.exists) throw new Error('Question not found')
+    const qData = qSnap.data()!
+
+    // Trailblazer: if timesShown was 0 before this answer
+    const isTrailblazer = correct && (qData.timesShown ?? 0) === 0
+
+    // Compute result using pure function
+    const result = applyAnswer({
+      correct,
+      trailblazer: isTrailblazer,
+      elapsedMs,
+      mode: run.mode,
+      prevLives: run.livesRemaining,
+      prevStreak: run.currentStreak,
+      prevLongestStreak: run.longestStreak,
+      prevScore: run.score,
+    })
+
+    const now = FieldValue.serverTimestamp()
+
+    // Update question counters
+    const qUpdates: FirebaseFirestore.UpdateData<FirebaseFirestore.DocumentData> = {
+      timesShown: FieldValue.increment(1),
+    }
+    if (correct) {
+      qUpdates.timesCorrect = FieldValue.increment(1)
+    }
+    // Running mean for avgTimeMs
+    const prevAvg = qData.avgTimeMs ?? 0
+    const prevCount = qData.timesShown ?? 0
+    const newAvg = prevCount === 0 ? elapsedMs : Math.round((prevAvg * prevCount + elapsedMs) / (prevCount + 1))
+    qUpdates.avgTimeMs = newAvg
+
+    tx.update(questionRef, qUpdates)
+
+    // Write seenQuestions
+    tx.set(seenRef, { at: now, correct })
+
+    // Write answeredBy reverse index
+    tx.set(answeredByRef, { uid, runId, correct, at: now })
+
+    // Build answer entry
+    const answerEntry = {
+      questionId,
+      correct,
+      points: result.points,
+      timeMs: elapsedMs,
+      trailblazer: isTrailblazer,
+      answeredAt: now,
+    }
+
+    // Update run doc
+    const runUpdates: FirebaseFirestore.UpdateData<FirebaseFirestore.DocumentData> = {
+      score: result.score,
+      livesRemaining: result.livesRemaining,
+      currentStreak: result.currentStreak,
+      longestStreak: result.longestStreak,
+      answers: FieldValue.arrayUnion(answerEntry),
+    }
+    if (isTrailblazer) {
+      runUpdates.trailblazes = FieldValue.increment(1)
+    }
+    if (result.runOver) {
+      runUpdates.endedAt = now
+    }
+    tx.update(runRef, runUpdates)
+
+    return result
+  })
+}
+
+export async function endRun(uid: string, runId: string): Promise<void> {
+  const db = getFirestoreDb()
+  const runRef = db.doc(`users/${uid}/triviaInfinite/${runId}`)
+  const snap = await runRef.get()
+  if (!snap.exists) throw new Error('Run not found')
+  const data = snap.data()!
+  if (data.endedAt !== null) return // idempotent
+  await runRef.update({ endedAt: FieldValue.serverTimestamp() })
+}

--- a/src/lib/trivia/sampler.ts
+++ b/src/lib/trivia/sampler.ts
@@ -1,0 +1,94 @@
+import { getFirestoreDb } from '@/lib/firebase/server'
+import type { AIQuestion } from '@/lib/trivia/aiQuestions'
+
+export interface SamplerOptions {
+  uid: string
+  streak: number
+  type?: 'free-text' // v1 only free-text
+}
+
+// Difficulty weights by streak band
+// [easy%, medium%, hard%]
+function getDifficultyWeights(streak: number): [number, number, number] {
+  if (streak >= 20) return [0.05, 0.25, 0.70]
+  if (streak >= 10) return [0.10, 0.30, 0.60]
+  if (streak >= 5)  return [0.30, 0.40, 0.30]
+  return [0.60, 0.30, 0.10]
+}
+
+// Weighted random selection over an array of items with numeric weights
+function weightedRandom<T>(items: T[], weights: number[]): T {
+  const total = weights.reduce((a, b) => a + b, 0)
+  let rand = Math.random() * total
+  for (let i = 0; i < items.length; i++) {
+    rand -= weights[i]
+    if (rand <= 0) return items[i]
+  }
+  return items[items.length - 1]
+}
+
+// Compute per-question weight within a difficulty bucket.
+// Lower timesShown → higher weight (freshness bias).
+function freshnessWeight(timesShown: number): number {
+  return 1 / (1 + timesShown)
+}
+
+export async function sampleNextQuestion(options: SamplerOptions): Promise<AIQuestion | null> {
+  const { uid, streak, type = 'free-text' } = options
+  const db = getFirestoreDb()
+
+  // 1. Query active questions of the requested type
+  const questionsSnap = await db
+    .collection('aiQuestions')
+    .where('status', '==', 'active')
+    .where('type', '==', type)
+    .get()
+
+  if (questionsSnap.empty) return null
+
+  // 2. Get IDs already seen by this user
+  const seenSnap = await db.collection(`users/${uid}/seenQuestions`).get()
+  const seenIds = new Set(seenSnap.docs.map((d) => d.id))
+
+  // 3. Filter out seen questions
+  const unseen = questionsSnap.docs
+    .map((d) => ({ id: d.id, ...(d.data() as Omit<AIQuestion, 'id'>) }))
+    .filter((q) => !seenIds.has(q.id))
+
+  if (unseen.length === 0) return null
+
+  // 4. Bucket by difficulty
+  const byDifficulty: Record<'easy' | 'medium' | 'hard', AIQuestion[]> = {
+    easy: [],
+    medium: [],
+    hard: [],
+  }
+  for (const q of unseen) {
+    byDifficulty[q.difficulty].push(q)
+  }
+
+  // 5. Determine which difficulty to pick from, weighted by streak
+  const [easyW, mediumW, hardW] = getDifficultyWeights(streak)
+
+  // Only include difficulty levels that have available questions
+  const availableDifficulties: Array<{ key: 'easy' | 'medium' | 'hard'; weight: number }> = []
+  if (byDifficulty.easy.length > 0)   availableDifficulties.push({ key: 'easy',   weight: easyW })
+  if (byDifficulty.medium.length > 0) availableDifficulties.push({ key: 'medium', weight: mediumW })
+  if (byDifficulty.hard.length > 0)   availableDifficulties.push({ key: 'hard',   weight: hardW })
+
+  if (availableDifficulties.length === 0) return null
+
+  const chosenDifficulty = weightedRandom(
+    availableDifficulties.map((d) => d.key),
+    availableDifficulties.map((d) => d.weight)
+  )
+
+  // 6. Within the chosen bucket, apply freshness bias (lower timesShown → higher weight)
+  const bucket = byDifficulty[chosenDifficulty]
+  const bucketWeights = bucket.map((q) => freshnessWeight(q.timesShown))
+
+  // 7. Select one question
+  const selected = weightedRandom(bucket, bucketWeights)
+
+  return selected
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -16,6 +16,8 @@ export default defineConfig({
       'src/app/tap-tap-adventure/**/*.test.ts',
       'src/app/daily-card-game/**/*.test.ts',
       'src/app/daily-card-game/**/*.test.tsx',
+      'src/lib/trivia/**/*.test.ts',
+      'src/app/trivia/**/*.test.ts',
     ],
     coverage: {
       reporter: ['text', 'json', 'html'],


### PR DESCRIPTION
## Summary

Implements issue #569 — server-owned run lifecycle for Infinite Trivia mode.

- **Scoring constants + pure functions** (`infiniteScoring.ts`): streak multiplier tiers (x1/x1.5/x2/x3), speed bonus, life refund every 10-streak, trailblazer bonus (+50 pts)
- **Transactional run management** (`infiniteRuns.ts`): `startRun`, `submitAnswer` (atomic trailblazer detection, question counter updates, seenQuestions + answeredBy writes), `endRun` (idempotent)
- **Answer judging** (`answerJudge.ts`): extracted semantic GPT-4o-mini matching for reuse across modes
- **API routes**: `POST /runs` (201), `POST /runs/{runId}/answer` (grades + updates atomically), `POST /runs/{runId}/end` (409 if already ended)
- **31 unit tests** for scoring logic — all passing

Depends on #613 (Schema + sampler foundation)
Closes #569

## Test plan

- [x] 31 vitest unit tests for `infiniteScoring.ts` — streak tiers, speed bonus, life refund, practice mode, trailblazer
- [ ] Verify `POST /runs` creates run doc with correct initial state
- [ ] Verify answer submission updates question counters atomically
- [ ] Verify trailblazer detection: only first answerer of a fresh question gets bonus
- [ ] Verify 0 lives → `runOver: true`, subsequent answers return 409
- [ ] Verify practice mode: wrong answers don't decrement lives
- [ ] `npx tsc --noEmit` passes (verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)