### PR TITLE
fix: progress segments show right/wrong; input contrast on dark theme

### DIFF
--- a/src/app/trivia/components/TriviaGame.tsx
+++ b/src/app/trivia/components/TriviaGame.tsx
@@ -220,6 +220,9 @@ export function TriviaGame({ onFinish, onFlee }: { onFinish: (result: TriviaGame
 
   const question = questions[currentIndex]
   const config = getQuestionConfig(question)
+  const segmentResults: Array<'correct' | 'incorrect'> = answers.map((a) =>
+    a.correct ? 'correct' : 'incorrect'
+  )
 
   // Difficulty badge colors
   const diffBadgeColor = {
@@ -239,6 +242,7 @@ export function TriviaGame({ onFinish, onFlee }: { onFinish: (result: TriviaGame
         timeLimit={config.timeLimit}
         onFlee={onFlee ?? (() => window.location.reload())}
         isPlaying={phase === 'playing'}
+        segmentResults={segmentResults}
       />
 
       {/* Question card */}
@@ -292,7 +296,7 @@ export function TriviaGame({ onFinish, onFlee }: { onFinish: (result: TriviaGame
                 value={textAnswer}
                 onChange={(e) => setTextAnswer(e.target.value)}
                 placeholder="Type your answer..."
-                className="bg-surface-dim/50 border-outline-variant text-on-surface"
+                className="bg-surface-container-low border-outline-variant text-on-surface text-base"
                 disabled={phase !== 'playing' || isChecking}
                 onKeyDown={(e) => {
                   if (e.key === 'Enter' && textAnswer.trim()) {

--- a/src/app/trivia/components/TriviaHUD.tsx
+++ b/src/app/trivia/components/TriviaHUD.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react'
 
 import { ChunkyButton } from '@/components/ui/chunky-button'
 import { Pill, ScoreChip } from '@/components/ui/pill'
-import { ProgressSegments } from '@/components/ui/progress-segments'
+import { type ProgressSegmentResult, ProgressSegments } from '@/components/ui/progress-segments'
 
 export interface TriviaHUDProps {
   currentQuestion: number
@@ -14,6 +14,7 @@ export interface TriviaHUDProps {
   timeLimit: number
   onFlee: () => void
   isPlaying: boolean
+  segmentResults?: Array<ProgressSegmentResult | undefined>
 }
 
 export function TriviaHUD({
@@ -24,6 +25,7 @@ export function TriviaHUD({
   timeLimit,
   onFlee,
   isPlaying,
+  segmentResults,
 }: TriviaHUDProps) {
   const [showFleeConfirm, setShowFleeConfirm] = useState(false)
 
@@ -78,6 +80,7 @@ export function TriviaHUD({
         total={totalQuestions}
         current={currentQuestion + 1}
         label="Chamber Depth"
+        segmentResults={segmentResults}
       />
 
       {/* Flee confirmation dialog */}

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -8,7 +8,7 @@ const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<'input'>>(
       <input
         type={type}
         className={cn(
-          'flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-base ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm bg-surface-container',
+          'flex h-10 w-full rounded-md border border-input bg-surface-container text-on-surface px-3 py-2 text-base file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-on-surface-variant/70 caret-on-surface focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ds-primary focus-visible:ring-offset-2 focus-visible:ring-offset-surface-container-low disabled:cursor-not-allowed disabled:opacity-50',
           className
         )}
         ref={ref}

--- a/src/components/ui/progress-segments.tsx
+++ b/src/components/ui/progress-segments.tsx
@@ -2,15 +2,18 @@ import * as React from 'react'
 
 import { cn } from '@/lib/utils'
 
+export type ProgressSegmentResult = 'correct' | 'incorrect'
+
 export interface ProgressSegmentsProps extends React.HTMLAttributes<HTMLDivElement> {
   total: number
   current: number
   label?: string
   accent?: 'primary' | 'secondary'
+  segmentResults?: Array<ProgressSegmentResult | undefined>
 }
 
 const ProgressSegments = React.forwardRef<HTMLDivElement, ProgressSegmentsProps>(
-  ({ total, current, label, accent = 'primary', className, ...props }, ref) => {
+  ({ total, current, label, accent = 'primary', segmentResults, className, ...props }, ref) => {
     const clampedCurrent = Math.max(0, Math.min(current, total))
 
     return (
@@ -37,15 +40,32 @@ const ProgressSegments = React.forwardRef<HTMLDivElement, ProgressSegmentsProps>
         )}
         {Array.from({ length: total }, (_, i) => {
           const index = i + 1
-          const isFilled = index < clampedCurrent
-          const isActive = index === clampedCurrent
-          const isEmpty = index > clampedCurrent
+          const result = segmentResults?.[i]
+          const isCorrect = result === 'correct'
+          const isIncorrect = result === 'incorrect'
+          const hasResult = isCorrect || isIncorrect
+          const isActive = !hasResult && index === clampedCurrent
+          const isFilled = !hasResult && index < clampedCurrent
+          const isEmpty = !hasResult && !isActive && !isFilled
+
+          const segmentLabel = isCorrect
+            ? `Question ${index}: correct`
+            : isIncorrect
+              ? `Question ${index}: incorrect`
+              : isActive
+                ? `Question ${index}: current`
+                : undefined
 
           return (
             <div
               key={i}
+              aria-label={segmentLabel}
               className={cn(
                 'h-3 flex-1 rounded-full transition-all duration-300 relative overflow-hidden',
+                isCorrect &&
+                  'bg-gradient-to-r from-green-500/80 to-green-400 shadow-[0_0_12px_rgba(74,222,128,0.45)]',
+                isIncorrect &&
+                  'bg-gradient-to-r from-red-500/80 to-red-400 shadow-[0_0_12px_rgba(239,68,68,0.45)]',
                 isFilled && [
                   accent === 'primary'
                     ? 'bg-gradient-to-r from-primary-container to-secondary-container shadow-glow-primary'
@@ -61,7 +81,7 @@ const ProgressSegments = React.forwardRef<HTMLDivElement, ProgressSegmentsProps>
                 isEmpty && 'bg-surface-container shadow-rim-inset-deep'
               )}
             >
-              {isFilled && (
+              {(isFilled || isCorrect) && (
                 <div
                   className="absolute inset-0 -skew-x-12 bg-gradient-to-r from-transparent via-white/20 to-transparent motion-reduce:hidden"
                   aria-hidden


### PR DESCRIPTION
Closes #614, #615.

## #614 — Progress segments reflect right/wrong per question
\`ProgressSegments\` now takes an optional \`segmentResults\` prop (indexed by question position). Answered segments render with green (correct) or red (incorrect) gradients + matching glow, with per-segment aria-labels.

Wired through \`TriviaHUD\` from \`TriviaGame\` so the segment turns green/red the moment the answer is recorded — not after advancing to the next question. Active / filled / empty states are unchanged for segments that haven't been answered yet.

## #615 — Input bg / contrast on the AI free-text question
The shared \`Input\` default carried both \`bg-background\` (which is white in \`:root\` since the design system stays dark regardless of shadcn light/dark CSS) and \`bg-surface-container\`. \`tailwind-merge\` wasn't reliably resolving the duplicate, so the white was bleeding through on the AI free-text question.

\`src/components/ui/input.tsx\` now uses a single dark token by default (\`bg-surface-container\`), explicit \`text-on-surface\` + \`caret-on-surface\`, a high-contrast placeholder, no \`md:text-sm\` shrinkage, and a themed focus ring. Trivia free-text override switches to \`bg-surface-container-low\` for the inset feel without transparency math.

## Test plan
- [ ] Play through a trivia run; each completed segment turns green/red the moment the answer is checked
- [ ] Color-blind sanity: aria-labels read out as "Question N: correct/incorrect/current"
- [ ] AI free-text question: input bg is dark, typed text is high-contrast cream, cursor visible
- [ ] Auth + Nickname dialog inputs still look right (use the same Input component)
- [ ] Lint, typecheck, Vercel preview pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)