### PR TITLE
feat: Infinite Trivia 3 — Game UI (entry, question card, HUD, end-of-run)

### DIFF
--- a/src/app/trivia/components/InfiniteGame.tsx
+++ b/src/app/trivia/components/InfiniteGame.tsx
@@ -1,0 +1,128 @@
+'use client'
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { useInfiniteRun } from '@/app/trivia/hooks/useInfiniteRun'
+import { InfiniteHUD } from './InfiniteHUD'
+import { InfiniteQuestionCard } from './InfiniteQuestionCard'
+import { InfiniteRunSummary } from './InfiniteRunSummary'
+import { ChunkyButton } from '@/components/ui/chunky-button'
+
+const TIME_LIMIT = 60 // 60 seconds for AI free-text
+
+interface Props {
+  onBack: () => void
+}
+
+export function InfiniteGame({ onBack }: Props) {
+  const { state, startRun, submitAnswer, nextQuestion, endRun } = useInfiniteRun()
+  const [timeRemaining, setTimeRemaining] = useState(TIME_LIMIT)
+  const timerRef = useRef<ReturnType<typeof setInterval> | null>(null)
+  const timerStartRef = useRef<number>(0)
+
+  // Start run on mount
+  useEffect(() => {
+    startRun()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  // Timer logic
+  useEffect(() => {
+    if (state.phase !== 'playing') {
+      if (timerRef.current) clearInterval(timerRef.current)
+      return
+    }
+    timerStartRef.current = Date.now()
+    setTimeRemaining(TIME_LIMIT)
+    timerRef.current = setInterval(() => {
+      const elapsed = (Date.now() - timerStartRef.current) / 1000
+      const remaining = Math.max(0, TIME_LIMIT - elapsed)
+      setTimeRemaining(remaining)
+      if (remaining <= 0) {
+        if (timerRef.current) clearInterval(timerRef.current)
+        // Auto-submit empty on timeout
+        submitAnswer('')
+      }
+    }, 100)
+    return () => {
+      if (timerRef.current) clearInterval(timerRef.current)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [state.phase, state.question?.id])
+
+  const handleFlee = useCallback(() => {
+    if (timerRef.current) clearInterval(timerRef.current)
+    endRun()
+  }, [endRun])
+
+  const handlePlayAgain = useCallback(() => {
+    startRun()
+  }, [startRun])
+
+  // Loading state
+  if (state.phase === 'loading' || state.phase === 'idle') {
+    return (
+      <div className="flex flex-col items-center gap-4 py-8 max-w-lg mx-auto">
+        <div className="text-on-surface/60 text-lg">Entering the infinite cavern...</div>
+      </div>
+    )
+  }
+
+  // Error state
+  if (state.phase === 'error') {
+    return (
+      <div className="flex flex-col items-center gap-4 py-8 max-w-lg mx-auto">
+        <p className="text-ds-error">{state.error}</p>
+        <ChunkyButton variant="secondary" onClick={() => startRun()}>Try Again</ChunkyButton>
+        <ChunkyButton variant="ghost" size="sm" onClick={onBack}>Back to Trivia</ChunkyButton>
+      </div>
+    )
+  }
+
+  // Exhausted state
+  if (state.phase === 'exhausted') {
+    return (
+      <div className="flex flex-col items-center gap-4 py-8 max-w-lg mx-auto">
+        <h2 className="font-headline text-headline-lg text-ds-tertiary">The Cave Rests</h2>
+        <p className="text-on-surface/60 text-center">
+          You have explored every question in the cavern. New discoveries await — return soon.
+        </p>
+        <ChunkyButton variant="secondary" onClick={onBack}>Back to Trivia</ChunkyButton>
+      </div>
+    )
+  }
+
+  // End of run
+  if (state.phase === 'ended') {
+    return <InfiniteRunSummary state={state} onPlayAgain={handlePlayAgain} onBack={onBack} />
+  }
+
+  // Playing or answered
+  if (!state.question) return null
+
+  return (
+    <div className="flex flex-col gap-3 sm:gap-4 max-w-lg mx-auto py-2 sm:py-4">
+      <InfiniteHUD
+        livesRemaining={state.livesRemaining}
+        currentStreak={state.currentStreak}
+        score={state.score}
+        timeRemaining={timeRemaining}
+        timeLimit={TIME_LIMIT}
+        onFlee={handleFlee}
+        isPlaying={state.phase === 'playing'}
+      />
+
+      <InfiniteQuestionCard
+        question={state.question}
+        onSubmit={submitAnswer}
+        isSubmitting={state.phase === 'answering'}
+        answerResult={state.lastAnswer}
+        questionsAnswered={state.questionsAnswered}
+      />
+
+      {state.phase === 'answered' && (
+        <ChunkyButton variant="primary" size="lg" className="w-full" onClick={nextQuestion}>
+          Next Question
+        </ChunkyButton>
+      )}
+    </div>
+  )
+}

--- a/src/app/trivia/components/InfiniteHUD.tsx
+++ b/src/app/trivia/components/InfiniteHUD.tsx
@@ -1,0 +1,128 @@
+'use client'
+import { useState } from 'react'
+import { ChunkyButton } from '@/components/ui/chunky-button'
+import { Pill, ScoreChip } from '@/components/ui/pill'
+import { computeStreakMultiplier } from '@/app/trivia/lib/infiniteScoring'
+
+interface InfiniteHUDProps {
+  livesRemaining: number
+  currentStreak: number
+  score: number
+  timeRemaining: number
+  timeLimit: number
+  onFlee: () => void
+  isPlaying: boolean
+}
+
+export function InfiniteHUD({
+  livesRemaining,
+  currentStreak,
+  score,
+  timeRemaining,
+  timeLimit,
+  onFlee,
+  isPlaying,
+}: InfiniteHUDProps) {
+  const [showFleeConfirm, setShowFleeConfirm] = useState(false)
+  const mult = computeStreakMultiplier(currentStreak)
+
+  const timerPercent = (timeRemaining / timeLimit) * 100
+  const timerColor =
+    timerPercent > 60
+      ? 'bg-green-500'
+      : timerPercent > 30
+        ? 'bg-yellow-500'
+        : 'bg-red-500'
+
+  const handleFlee = () => {
+    if (isPlaying) setShowFleeConfirm(true)
+    else onFlee()
+  }
+
+  return (
+    <div className="flex flex-col gap-3">
+      {/* Top bar */}
+      <div className="flex items-center justify-between gap-3">
+        <ChunkyButton
+          variant="exit"
+          size="sm"
+          onClick={handleFlee}
+          iconStart={
+            <span className="material-symbols-outlined text-[18px]">close</span>
+          }
+        >
+          <span className="hidden sm:inline">Flee</span>
+        </ChunkyButton>
+
+        {/* Lives */}
+        <div className="flex items-center gap-1" aria-label={`${livesRemaining} lives remaining`}>
+          {[0, 1, 2].map(i => (
+            <span
+              key={i}
+              className={`text-lg transition-opacity ${i < livesRemaining ? 'opacity-100' : 'opacity-20'}`}
+            >
+              {i < livesRemaining ? '❤️' : '🖤'}
+            </span>
+          ))}
+        </div>
+
+        {/* Streak + multiplier */}
+        <div className="flex items-center gap-1.5">
+          {currentStreak > 0 && (
+            <Pill tone="hot" size="sm">
+              🔥 {currentStreak}
+            </Pill>
+          )}
+          {mult > 1 && (
+            <Pill tone="info" size="sm">
+              ×{mult}
+            </Pill>
+          )}
+        </div>
+
+        <ScoreChip score={score} />
+      </div>
+
+      {/* Timer bar */}
+      <div className="w-full bg-surface-container-highest rounded-full h-2 overflow-hidden">
+        <div
+          className={`h-full ${timerColor} transition-all duration-100 ease-linear`}
+          style={{ width: `${timerPercent}%` }}
+        />
+      </div>
+
+      {/* Timer pill */}
+      <div className="flex justify-center">
+        <Pill tone="neutral" size="sm">{Math.ceil(timeRemaining)}s</Pill>
+      </div>
+
+      {/* Flee confirmation */}
+      {showFleeConfirm && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-surface-dim/80 backdrop-blur-sm">
+          <div className="bg-surface-container-high rounded-ds-lg p-8 max-w-sm mx-4 shadow-hero text-center flex flex-col gap-4">
+            <p className="text-on-surface text-body-lg">End your run? Your score will be saved.</p>
+            <div className="flex gap-3 justify-center">
+              <ChunkyButton
+                variant="secondary"
+                size="sm"
+                onClick={() => setShowFleeConfirm(false)}
+              >
+                Stay
+              </ChunkyButton>
+              <ChunkyButton
+                variant="exit"
+                size="sm"
+                onClick={() => {
+                  setShowFleeConfirm(false)
+                  onFlee()
+                }}
+              >
+                End Run
+              </ChunkyButton>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/app/trivia/components/InfiniteQuestionCard.tsx
+++ b/src/app/trivia/components/InfiniteQuestionCard.tsx
@@ -1,0 +1,115 @@
+'use client'
+import { useState } from 'react'
+import { ChunkyCard, ChunkyCardContent, ChunkyCardHeader } from '@/components/ui/chunky-card'
+import { ChunkyButton } from '@/components/ui/chunky-button'
+import { Input } from '@/components/ui/input'
+import type { InfiniteQuestion } from '@/app/trivia/hooks/useInfiniteRun'
+import type { AnswerResult } from '@/app/trivia/lib/infiniteScoring'
+
+interface Props {
+  question: InfiniteQuestion
+  onSubmit: (answer: string) => void
+  isSubmitting: boolean
+  answerResult: (AnswerResult & { trailblazer: boolean }) | null
+  questionsAnswered: number
+}
+
+function getSocialSignal(timesShown: number): string {
+  if (timesShown === 0) return 'You are the first traveler to find this question.'
+  if (timesShown === 1) return '1 other traveler has answered this.'
+  return `${timesShown} other travelers have answered this.`
+}
+
+export function InfiniteQuestionCard({
+  question,
+  onSubmit,
+  isSubmitting,
+  answerResult,
+  questionsAnswered,
+}: Props) {
+  const [textAnswer, setTextAnswer] = useState('')
+  const isAnswered = answerResult !== null
+
+  const diffBadgeColor = {
+    easy: 'bg-green-600/30 text-green-400 border-green-600/50',
+    medium: 'bg-yellow-600/30 text-yellow-400 border-yellow-600/50',
+    hard: 'bg-red-600/30 text-red-400 border-red-600/50',
+  }[question.difficulty]
+
+  const handleSubmit = () => {
+    if (textAnswer.trim() && !isSubmitting && !isAnswered) {
+      onSubmit(textAnswer.trim())
+    }
+  }
+
+  return (
+    <ChunkyCard variant="surface-variant" shadow="hero">
+      <ChunkyCardHeader className="pb-2 pt-3 sm:pt-6 px-4 sm:px-6">
+        <div className="flex justify-between items-center">
+          <span className="text-on-surface/50 text-xs sm:text-sm">
+            Question {questionsAnswered + 1}
+          </span>
+          <span className={`text-[10px] sm:text-xs px-2 py-0.5 rounded-full border ${diffBadgeColor}`}>
+            {question.difficulty.toUpperCase()}
+          </span>
+        </div>
+        {/* Social signal */}
+        <p className="text-on-surface/30 text-xs italic mt-1">
+          {getSocialSignal(question.timesShown)}
+        </p>
+      </ChunkyCardHeader>
+      <ChunkyCardContent className="px-4 sm:px-6 pb-4 sm:pb-6">
+        <p className="text-on-surface/60 text-xs uppercase tracking-wide mb-1">{question.category}</p>
+        <p aria-live="polite" className="text-on-surface text-base sm:text-lg mb-3 sm:mb-4 leading-snug">
+          {question.question}
+        </p>
+
+        {/* Free-text input */}
+        <div className="flex flex-col gap-2">
+          <Input
+            value={textAnswer}
+            onChange={(e) => setTextAnswer(e.target.value)}
+            placeholder="Type your answer..."
+            className="bg-surface-dim/50 border-outline-variant text-on-surface"
+            disabled={isAnswered || isSubmitting}
+            onKeyDown={(e) => { if (e.key === 'Enter') handleSubmit() }}
+            autoFocus
+          />
+          {!isAnswered && (
+            <ChunkyButton
+              variant="primary"
+              disabled={isSubmitting || !textAnswer.trim()}
+              onClick={handleSubmit}
+            >
+              {isSubmitting ? 'Checking...' : 'Submit Answer'}
+            </ChunkyButton>
+          )}
+        </div>
+
+        {/* Answer feedback */}
+        {isAnswered && answerResult && (
+          <div
+            className={`mt-4 p-3 rounded-lg ${
+              answerResult.correct
+                ? 'bg-primary-container/20 border border-primary-container/40'
+                : 'bg-ds-error/20 border border-ds-error/40'
+            }`}
+          >
+            <div className="font-bold mb-1">
+              {answerResult.correct ? (
+                <span className="text-ds-primary">
+                  Correct! +{answerResult.points} pts
+                  {answerResult.trailblazer && (
+                    <span className="ml-2 text-ds-tertiary">⭐ Trailblazer!</span>
+                  )}
+                </span>
+              ) : (
+                <span className="text-ds-error">Incorrect — 0 pts</span>
+              )}
+            </div>
+          </div>
+        )}
+      </ChunkyCardContent>
+    </ChunkyCard>
+  )
+}

--- a/src/app/trivia/components/InfiniteRunSummary.tsx
+++ b/src/app/trivia/components/InfiniteRunSummary.tsx
@@ -1,0 +1,146 @@
+'use client'
+import { useState } from 'react'
+import { ChunkyButton } from '@/components/ui/chunky-button'
+import { ChunkyCard, ChunkyCardContent } from '@/components/ui/chunky-card'
+import { Pill } from '@/components/ui/pill'
+import { useAuth } from '@/hooks/useAuth'
+import { SignInCard } from './SignInCTA'
+import type { InfiniteRunState } from '@/app/trivia/hooks/useInfiniteRun'
+
+interface Props {
+  state: InfiniteRunState
+  onPlayAgain: () => void
+  onBack: () => void
+}
+
+function formatTime(ms: number): string {
+  const seconds = Math.round(ms / 1000)
+  return `${seconds}s`
+}
+
+function getRunRating(longestStreak: number): string {
+  if (longestStreak >= 20) return 'Legendary!'
+  if (longestStreak >= 10) return 'Amazing!'
+  if (longestStreak >= 5) return 'Great Run!'
+  if (longestStreak >= 2) return 'Good Try!'
+  return 'Keep Exploring!'
+}
+
+export function InfiniteRunSummary({ state, onPlayAgain, onBack }: Props) {
+  const { user } = useAuth()
+  const [copied, setCopied] = useState(false)
+
+  const handleShare = async () => {
+    const lines = [
+      '🧠 CometCave Infinite Trivia',
+      `🔥 Longest Streak: ${state.longestStreak}`,
+      `💎 Score: ${state.score.toLocaleString()}`,
+      `📊 ${state.questionsAnswered} questions answered`,
+      state.trailblazes > 0 ? `⭐ ${state.trailblazes} trailblazer${state.trailblazes === 1 ? '' : 's'}` : null,
+      'https://cometcave.com/trivia',
+    ].filter(Boolean).join('\n')
+
+    try {
+      await navigator.clipboard.writeText(lines)
+      setCopied(true)
+      setTimeout(() => setCopied(false), 2000)
+    } catch {
+      // Silent fail
+    }
+  }
+
+  return (
+    <div className="flex flex-col items-center gap-5 max-w-lg mx-auto py-6">
+      <div className="text-center">
+        <h2 className="font-headline text-headline-lg text-ds-tertiary drop-shadow-[0_4px_0_var(--surface-container-lowest)] mb-1">
+          {getRunRating(state.longestStreak)}
+        </h2>
+        <p className="text-on-surface/50 text-sm">Run Complete</p>
+      </div>
+
+      {/* Hero: Longest Streak */}
+      <ChunkyCard variant="surface-variant" className="w-full bg-surface-container/80 border-outline-variant">
+        <ChunkyCardContent className="pt-6">
+          <div className="text-center mb-4">
+            <div className="text-6xl font-bold text-ds-tertiary">
+              🔥 {state.longestStreak}
+            </div>
+            <div className="text-on-surface/40 text-sm mt-1">Longest Streak</div>
+          </div>
+
+          <div className="grid grid-cols-3 gap-3 mb-4">
+            <div className="text-center">
+              <div className="text-xl font-bold text-on-surface">{state.score.toLocaleString()}</div>
+              <div className="text-on-surface/50 text-xs">Total Score</div>
+            </div>
+            <div className="text-center">
+              <div className="text-xl font-bold text-on-surface">{state.questionsAnswered}</div>
+              <div className="text-on-surface/50 text-xs">Questions</div>
+            </div>
+            <div className="text-center">
+              <div className="text-xl font-bold text-ds-tertiary">{state.trailblazes}</div>
+              <div className="text-on-surface/50 text-xs">Trailblazers</div>
+            </div>
+          </div>
+        </ChunkyCardContent>
+      </ChunkyCard>
+
+      {state.longestStreak >= 5 && (
+        <Pill tone="hot" icon="local_fire_department">
+          {state.longestStreak} streak!
+        </Pill>
+      )}
+
+      {/* Per-question breakdown */}
+      {state.answers.length > 0 && (
+        <ChunkyCard variant="surface-variant" className="w-full bg-surface-container/80 border-outline-variant">
+          <ChunkyCardContent className="pt-4">
+            <h3 className="text-on-surface/70 text-sm font-semibold mb-3 uppercase tracking-wide">
+              Answer History
+            </h3>
+            <div className="flex flex-col gap-2 max-h-64 overflow-y-auto">
+              {state.answers.map((a, i) => (
+                <div key={i} className="flex items-center justify-between py-2 px-3 rounded bg-surface-dim/40">
+                  <div className="flex items-center gap-3">
+                    <span className="text-on-surface/50 text-sm font-mono w-4">{i + 1}</span>
+                    <span className={`text-lg ${a.correct ? 'text-ds-primary' : 'text-ds-error'}`}>
+                      {a.correct ? '✓' : '✗'}
+                    </span>
+                    {a.trailblazer && <span className="text-xs">⭐</span>}
+                  </div>
+                  <div className="flex items-center gap-3">
+                    <span className="text-on-surface/40 text-xs">{formatTime(a.timeMs)}</span>
+                    <span className={`font-bold text-sm min-w-[4rem] text-right ${a.correct ? 'text-ds-tertiary' : 'text-on-surface/30'}`}>
+                      +{a.points}
+                    </span>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </ChunkyCardContent>
+        </ChunkyCard>
+      )}
+
+      {/* Actions */}
+      <div className="flex flex-col gap-3 w-full">
+        <ChunkyButton variant="primary" size="hero" className="w-full" onClick={onPlayAgain}>
+          Play Again
+        </ChunkyButton>
+        <ChunkyButton variant="secondary" className="w-full" onClick={handleShare}>
+          {copied ? 'Copied!' : 'Share Run'}
+        </ChunkyButton>
+      </div>
+
+      {!user && (
+        <SignInCard
+          title="🔒 Your run wasn't saved"
+          description="Sign in to save your runs, build your constellation, and compete on the leaderboard."
+        />
+      )}
+
+      <ChunkyButton variant="ghost" size="sm" onClick={onBack}>
+        Back to Trivia
+      </ChunkyButton>
+    </div>
+  )
+}

--- a/src/app/trivia/components/TriviaLanding.tsx
+++ b/src/app/trivia/components/TriviaLanding.tsx
@@ -20,11 +20,13 @@ export function TriviaLanding({
   onStartGame,
   onViewStats,
   onViewLeaderboard,
+  onStartInfinite,
   todayResult,
 }: {
   onStartGame?: () => void
   onViewStats?: () => void
   onViewLeaderboard?: () => void
+  onStartInfinite?: () => void
   todayResult: TriviaGameResult | null
 }) {
   const { user, loading: authLoading, configured: authConfigured, signOut } = useAuth()
@@ -145,6 +147,24 @@ export function TriviaLanding({
               {todayResult.correct}/{todayResult.total} correct
             </div>
           )}
+        </ChunkyCardContent>
+      </ChunkyCard>
+
+      {/* Endless Run entry */}
+      <ChunkyCard variant="surface-container-high" className="w-full">
+        <ChunkyCardContent className="flex flex-col items-center gap-3 pt-6">
+          <div className="text-center">
+            <h3 className="text-on-surface font-bold text-lg">Endless Run</h3>
+            <p className="text-on-surface/50 text-sm">The cave doesn&apos;t sleep. How far can you go?</p>
+          </div>
+          <ChunkyButton
+            variant="secondary"
+            size="lg"
+            className="w-full"
+            onClick={onStartInfinite}
+          >
+            Enter the Infinite Cavern
+          </ChunkyButton>
         </ChunkyCardContent>
       </ChunkyCard>
 

--- a/src/app/trivia/hooks/useInfiniteRun.ts
+++ b/src/app/trivia/hooks/useInfiniteRun.ts
@@ -1,0 +1,179 @@
+'use client'
+import { useCallback, useRef, useState } from 'react'
+import { useAuth } from '@/hooks/useAuth'
+import { LIVES_START, type AnswerResult } from '@/app/trivia/lib/infiniteScoring'
+
+export type InfinitePhase = 'idle' | 'loading' | 'playing' | 'answering' | 'answered' | 'exhausted' | 'ended' | 'error'
+
+export interface InfiniteQuestion {
+  id: string
+  question: string
+  category: string
+  difficulty: 'easy' | 'medium' | 'hard'
+  timesShown: number
+}
+
+export interface InfiniteRunState {
+  phase: InfinitePhase
+  runId: string | null
+  question: InfiniteQuestion | null
+  livesRemaining: number
+  currentStreak: number
+  longestStreak: number
+  score: number
+  questionsAnswered: number
+  trailblazes: number
+  lastAnswer: (AnswerResult & { trailblazer: boolean }) | null
+  answers: Array<{ correct: boolean; points: number; timeMs: number; trailblazer: boolean }>
+  error: string | null
+}
+
+export function useInfiniteRun() {
+  const [state, setState] = useState<InfiniteRunState>({
+    phase: 'idle',
+    runId: null,
+    question: null,
+    livesRemaining: LIVES_START,
+    currentStreak: 0,
+    longestStreak: 0,
+    score: 0,
+    questionsAnswered: 0,
+    trailblazes: 0,
+    lastAnswer: null,
+    answers: [],
+    error: null,
+  })
+  const { user } = useAuth()
+  const startTimeRef = useRef<number>(0)
+
+  const getAuthHeaders = useCallback(async () => {
+    if (!user) throw new Error('Not authenticated')
+    const token = await user.getIdToken()
+    return {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${token}`,
+    }
+  }, [user])
+
+  const startRun = useCallback(async () => {
+    setState(s => ({ ...s, phase: 'loading', error: null }))
+    try {
+      const headers = await getAuthHeaders()
+      const res = await fetch('/api/v1/trivia/infinite/runs', {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({ mode: 'scored' }),
+      })
+      if (!res.ok) throw new Error('Failed to start run')
+      const data = await res.json()
+
+      // Immediately fetch first question
+      const qRes = await fetch(`/api/v1/trivia/infinite/next?streak=0`, { headers })
+      if (qRes.status === 204) {
+        setState(s => ({ ...s, phase: 'exhausted', runId: data.runId }))
+        return
+      }
+      if (!qRes.ok) throw new Error('Failed to fetch question')
+      const question = await qRes.json()
+
+      startTimeRef.current = Date.now()
+      setState(s => ({
+        ...s,
+        phase: 'playing',
+        runId: data.runId,
+        question,
+        livesRemaining: data.livesRemaining,
+        currentStreak: 0,
+        longestStreak: 0,
+        score: 0,
+        questionsAnswered: 0,
+        trailblazes: 0,
+        lastAnswer: null,
+        answers: [],
+      }))
+    } catch {
+      setState(s => ({ ...s, phase: 'error', error: 'Failed to start run.' }))
+    }
+  }, [getAuthHeaders])
+
+  const submitAnswer = useCallback(async (answer: string) => {
+    if (state.phase !== 'playing' || !state.runId || !state.question) return
+
+    setState(s => ({ ...s, phase: 'answering' }))
+    const elapsedMs = Date.now() - startTimeRef.current
+
+    try {
+      const headers = await getAuthHeaders()
+      const res = await fetch(`/api/v1/trivia/infinite/runs/${state.runId}/answer`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({
+          questionId: state.question.id,
+          answer,
+          elapsedMs,
+        }),
+      })
+      if (res.status === 409) {
+        setState(s => ({ ...s, phase: 'ended' }))
+        return
+      }
+      if (!res.ok) throw new Error('Failed to submit answer')
+      const result = await res.json()
+
+      setState(s => ({
+        ...s,
+        phase: result.runOver ? 'ended' : 'answered',
+        lastAnswer: result,
+        livesRemaining: result.livesRemaining,
+        currentStreak: result.currentStreak,
+        longestStreak: result.longestStreak,
+        score: result.score,
+        questionsAnswered: s.questionsAnswered + 1,
+        trailblazes: result.trailblazer ? s.trailblazes + 1 : s.trailblazes,
+        answers: [...s.answers, { correct: result.correct, points: result.points, timeMs: elapsedMs, trailblazer: result.trailblazer }],
+      }))
+    } catch {
+      setState(s => ({ ...s, phase: 'error', error: 'Failed to submit answer.' }))
+    }
+  }, [state.phase, state.runId, state.question, getAuthHeaders])
+
+  const nextQuestion = useCallback(async () => {
+    if (state.phase !== 'answered' || !state.runId) return
+
+    setState(s => ({ ...s, phase: 'loading' }))
+    try {
+      const headers = await getAuthHeaders()
+      const qRes = await fetch(`/api/v1/trivia/infinite/next?streak=${state.currentStreak}`, { headers })
+      if (qRes.status === 204) {
+        setState(s => ({ ...s, phase: 'exhausted' }))
+        return
+      }
+      if (!qRes.ok) throw new Error('Failed to fetch question')
+      const question = await qRes.json()
+
+      startTimeRef.current = Date.now()
+      setState(s => ({ ...s, phase: 'playing', question, lastAnswer: null }))
+    } catch {
+      setState(s => ({ ...s, phase: 'error', error: 'Failed to fetch next question.' }))
+    }
+  }, [state.phase, state.runId, state.currentStreak, getAuthHeaders])
+
+  const endRun = useCallback(async () => {
+    if (!state.runId) {
+      setState(s => ({ ...s, phase: 'ended' }))
+      return
+    }
+    try {
+      const headers = await getAuthHeaders()
+      await fetch(`/api/v1/trivia/infinite/runs/${state.runId}/end`, {
+        method: 'POST',
+        headers,
+      })
+    } catch {
+      // Best effort
+    }
+    setState(s => ({ ...s, phase: 'ended' }))
+  }, [state.runId, getAuthHeaders])
+
+  return { state, startRun, submitAnswer, nextQuestion, endRun }
+}

--- a/src/app/trivia/infinite/page.tsx
+++ b/src/app/trivia/infinite/page.tsx
@@ -1,0 +1,8 @@
+'use client'
+import { useRouter } from 'next/navigation'
+import { InfiniteGame } from '@/app/trivia/components/InfiniteGame'
+
+export default function InfiniteTriviaPage() {
+  const router = useRouter()
+  return <InfiniteGame onBack={() => router.push('/trivia')} />
+}

--- a/src/app/trivia/page.tsx
+++ b/src/app/trivia/page.tsx
@@ -13,6 +13,7 @@ import { useAuth } from '@/hooks/useAuth'
 import { getTodayPST } from '@/lib/dates'
 import { getDailyCategory } from '@/lib/trivia/categories'
 
+import { InfiniteGame } from './components/InfiniteGame'
 import { TriviaGame } from './components/TriviaGame'
 import { TriviaLanding } from './components/TriviaLanding'
 import { TriviaLeaderboard } from './components/TriviaLeaderboard'
@@ -22,7 +23,7 @@ import { TriviaStats } from './components/TriviaStats'
 import type { TriviaGameResult } from './models/trivia'
 import type { User } from 'firebase/auth'
 
-type View = 'landing' | 'playing' | 'results' | 'stats' | 'leaderboard'
+type View = 'landing' | 'playing' | 'results' | 'stats' | 'leaderboard' | 'infinite'
 
 async function submitGameToServer(user: User, result: TriviaGameResult): Promise<void> {
   const token = await user.getIdToken()
@@ -109,6 +110,7 @@ export default function TriviaPage() {
   const handleStartGame = () => setView('playing')
   const handleViewStats = () => setView('stats')
   const handleViewLeaderboard = () => setView('leaderboard')
+  const handleStartInfinite = () => setView('infinite')
 
   const handleFinish = useCallback(
     (result: TriviaGameResult) => {
@@ -128,6 +130,10 @@ export default function TriviaPage() {
   )
 
   const handleBackToLanding = () => setView('landing')
+
+  if (view === 'infinite') {
+    return <InfiniteGame onBack={handleBackToLanding} />
+  }
 
   if (view === 'playing') {
     return <TriviaGame onFinish={handleFinish} />
@@ -157,6 +163,7 @@ export default function TriviaPage() {
       onStartGame={handleStartGame}
       onViewStats={handleViewStats}
       onViewLeaderboard={handleViewLeaderboard}
+      onStartInfinite={handleStartInfinite}
       todayResult={todayResult}
     />
   )


### PR DESCRIPTION
## Summary

Implements issue #570 — the player-facing game loop for Infinite Trivia mode.

- **`useInfiniteRun` hook** — state machine managing the full run lifecycle (idle → loading → playing → answering → answered → ended/exhausted) with Bearer-auth API calls
- **InfiniteHUD** — lives (3 hearts), streak fire pill, multiplier badge (×1.5/×2/×3), score chip, animated timer bar, flee confirmation dialog
- **InfiniteQuestionCard** — free-text input with Enter support, difficulty badge, social signal copy ("N travelers have answered this"), answer feedback with trailblazer indicator
- **InfiniteRunSummary** — run rating headline, longest streak hero stat, score/questions/trailblazes grid, scrollable answer history, share-to-clipboard, play again CTA, sign-in prompt
- **InfiniteGame** — orchestration shell with 60s countdown timer, auto-submit on timeout, phase-based routing
- **`/trivia/infinite`** page route
- **TriviaLanding** — "Endless Run" entry card with cosmic-narrator copy

Depends on #613 and #616 (already merged to integration branch)
Closes #570

## Test plan

- [ ] `npx tsc --noEmit` passes (verified locally)
- [ ] Landing page shows "Endless Run" card below daily trivia
- [ ] Clicking "Enter the Infinite Cavern" starts a run (with auth)
- [ ] HUD shows lives, streak, multiplier, score, timer
- [ ] Question card shows social signal, difficulty badge, free-text input
- [ ] Answer feedback shows correct/incorrect with points and trailblazer badge
- [ ] Timer auto-submits at 0s
- [ ] Flee button shows confirmation dialog, ends run on confirm
- [ ] End-of-run screen shows streak hero, answer history, share button
- [ ] "Play Again" starts a new run
- [ ] Mobile + desktop viewports verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)