### PR TITLE
feat: Infinite Trivia 4 — Stats aggregate + profile constellation

### DIFF
--- a/src/app/api/v1/trivia/stats/me/route.ts
+++ b/src/app/api/v1/trivia/stats/me/route.ts
@@ -1,0 +1,17 @@
+import { type NextRequest, NextResponse } from 'next/server'
+
+import { verifyRequestAuth } from '@/lib/api/auth'
+import { getAggregateStats } from '@/lib/trivia/triviaStats'
+
+export async function GET(request: NextRequest) {
+  const auth = await verifyRequestAuth(request)
+  if ('error' in auth) return auth.error
+
+  try {
+    const stats = await getAggregateStats(auth.claims.uid)
+    return NextResponse.json(stats)
+  } catch (err) {
+    console.error('Failed to fetch stats:', err)
+    return NextResponse.json({ error: 'Failed to fetch stats.' }, { status: 500 })
+  }
+}

--- a/src/app/trivia/components/InfiniteStats.tsx
+++ b/src/app/trivia/components/InfiniteStats.tsx
@@ -1,0 +1,336 @@
+'use client'
+import { useCallback, useEffect, useState } from 'react'
+
+import { ChunkyButton } from '@/components/ui/chunky-button'
+import { ChunkyCard, ChunkyCardContent } from '@/components/ui/chunky-card'
+import { useAuth } from '@/hooks/useAuth'
+
+import { SignInCard } from './SignInCTA'
+
+interface CategoryStats {
+  answered: number
+  correct: number
+  totalTimeMs: number
+}
+
+interface DifficultyStats {
+  answered: number
+  correct: number
+}
+
+interface AggregateStats {
+  totalAnswered: number
+  totalCorrect: number
+  runsPlayed: number
+  bestRun: { score: number; longestStreak: number } | null
+  bestStreak: number
+  trailblazerCount: number
+  totalTimeMs: number
+  byCategory: Record<string, CategoryStats>
+  byDifficulty: {
+    easy: DifficultyStats
+    medium: DifficultyStats
+    hard: DifficultyStats
+  }
+}
+
+function getAccuracyColor(accuracy: number): string {
+  if (accuracy >= 80) return 'text-ds-primary'
+  if (accuracy >= 60) return 'text-yellow-400'
+  return 'text-ds-error'
+}
+
+function AccuracyRing({ accuracy, size = 48 }: { accuracy: number; size?: number }) {
+  const radius = (size - 6) / 2
+  const circumference = 2 * Math.PI * radius
+  const offset = circumference - (accuracy / 100) * circumference
+  const color =
+    accuracy >= 80 ? 'stroke-ds-primary' : accuracy >= 60 ? 'stroke-yellow-400' : 'stroke-ds-error'
+
+  return (
+    <svg width={size} height={size} className="transform -rotate-90">
+      <circle
+        cx={size / 2}
+        cy={size / 2}
+        r={radius}
+        fill="none"
+        strokeWidth={3}
+        className="stroke-surface-container-highest"
+      />
+      <circle
+        cx={size / 2}
+        cy={size / 2}
+        r={radius}
+        fill="none"
+        strokeWidth={3}
+        strokeDasharray={circumference}
+        strokeDashoffset={offset}
+        strokeLinecap="round"
+        className={color}
+      />
+    </svg>
+  )
+}
+
+export function InfiniteStats({ onBack }: { onBack: () => void }) {
+  const { user } = useAuth()
+  const [stats, setStats] = useState<AggregateStats | null>(null)
+  const [loading, setLoading] = useState(true)
+
+  const fetchStats = useCallback(async () => {
+    if (!user) {
+      setLoading(false)
+      return
+    }
+    try {
+      const token = await user.getIdToken()
+      const res = await fetch('/api/v1/trivia/stats/me', {
+        headers: { Authorization: `Bearer ${token}` },
+      })
+      if (res.ok) {
+        setStats(await res.json())
+      }
+    } catch {
+      // silent
+    } finally {
+      setLoading(false)
+    }
+  }, [user])
+
+  useEffect(() => {
+    fetchStats()
+  }, [fetchStats])
+
+  if (loading) {
+    return (
+      <div className="flex flex-col items-center gap-4 py-8 max-w-lg mx-auto">
+        <div className="text-on-surface/60 text-lg">Loading stats...</div>
+      </div>
+    )
+  }
+
+  if (!user) {
+    return (
+      <div className="flex flex-col items-center gap-6 max-w-lg mx-auto py-8">
+        <h2 className="text-3xl font-bold text-ds-tertiary">Infinite Stats</h2>
+        <SignInCard
+          title="Your constellation awaits"
+          description="Sign in to track your infinite trivia journey — accuracy, streaks, and category mastery."
+        />
+        <ChunkyButton variant="secondary" onClick={onBack} className="w-full">
+          Back
+        </ChunkyButton>
+      </div>
+    )
+  }
+
+  if (!stats || stats.runsPlayed === 0) {
+    return (
+      <div className="flex flex-col items-center gap-6 max-w-lg mx-auto py-8">
+        <h2 className="text-3xl font-bold text-ds-tertiary">Infinite Stats</h2>
+        <ChunkyCard
+          variant="surface-variant"
+          className="w-full bg-surface-container/80 border-outline-variant"
+        >
+          <ChunkyCardContent className="pt-6 text-center">
+            <p className="text-on-surface/70 text-lg mb-2">The stars haven&apos;t aligned yet</p>
+            <p className="text-on-surface/50 text-sm">
+              Complete your first infinite run to begin mapping your constellation.
+            </p>
+          </ChunkyCardContent>
+        </ChunkyCard>
+        <ChunkyButton
+          variant="primary"
+          onClick={() => (window.location.href = '/trivia/infinite')}
+          className="w-full"
+        >
+          Enter the Infinite Cavern
+        </ChunkyButton>
+        <ChunkyButton variant="secondary" onClick={onBack} className="w-full">
+          Back
+        </ChunkyButton>
+      </div>
+    )
+  }
+
+  const accuracy =
+    stats.totalAnswered > 0
+      ? Math.round((stats.totalCorrect / stats.totalAnswered) * 100)
+      : 0
+  const avgTimeMs =
+    stats.totalAnswered > 0 ? Math.round(stats.totalTimeMs / stats.totalAnswered) : 0
+  const categories = Object.entries(stats.byCategory).sort((a, b) => b[1].answered - a[1].answered)
+
+  return (
+    <div className="flex flex-col gap-5 max-w-lg mx-auto py-6">
+      <div className="text-center">
+        <h2 className="text-3xl font-bold text-ds-tertiary mb-1">Infinite Stats</h2>
+        <p className="text-on-surface/50 text-sm">Your endless trivia journey</p>
+      </div>
+
+      {/* Hero stats */}
+      <div className="grid grid-cols-2 gap-3">
+        <ChunkyCard
+          variant="surface-variant"
+          className="bg-surface-container/80 border-outline-variant"
+        >
+          <ChunkyCardContent className="pt-5 pb-5 text-center">
+            <div className={`text-3xl font-bold ${getAccuracyColor(accuracy)}`}>{accuracy}%</div>
+            <div className="text-on-surface/50 text-xs mt-1">Accuracy</div>
+          </ChunkyCardContent>
+        </ChunkyCard>
+        <ChunkyCard
+          variant="surface-variant"
+          className="bg-surface-container/80 border-outline-variant"
+        >
+          <ChunkyCardContent className="pt-5 pb-5 text-center">
+            <div className="text-3xl font-bold text-on-surface">{stats.totalAnswered}</div>
+            <div className="text-on-surface/50 text-xs mt-1">Questions</div>
+          </ChunkyCardContent>
+        </ChunkyCard>
+        <ChunkyCard
+          variant="surface-variant"
+          className="bg-surface-container/80 border-outline-variant"
+        >
+          <ChunkyCardContent className="pt-5 pb-5 text-center">
+            <div className="text-3xl font-bold text-ds-tertiary">{stats.runsPlayed}</div>
+            <div className="text-on-surface/50 text-xs mt-1">Runs Played</div>
+          </ChunkyCardContent>
+        </ChunkyCard>
+        <ChunkyCard
+          variant="surface-variant"
+          className="bg-surface-container/80 border-outline-variant"
+        >
+          <ChunkyCardContent className="pt-5 pb-5 text-center">
+            <div className="text-3xl font-bold text-on-surface">
+              {Math.round(avgTimeMs / 1000)}s
+            </div>
+            <div className="text-on-surface/50 text-xs mt-1">Avg Answer</div>
+          </ChunkyCardContent>
+        </ChunkyCard>
+      </div>
+
+      {/* Best run */}
+      {stats.bestRun && (
+        <ChunkyCard
+          variant="surface-variant"
+          className="bg-surface-container/80 border-outline-variant"
+        >
+          <ChunkyCardContent className="pt-5 pb-5">
+            <h3 className="text-on-surface/70 text-sm font-semibold mb-3 uppercase tracking-wide">
+              Best Run
+            </h3>
+            <div className="grid grid-cols-2 gap-3">
+              <div className="text-center">
+                <div className="text-2xl font-bold text-ds-tertiary">
+                  🔥 {stats.bestRun.longestStreak}
+                </div>
+                <div className="text-on-surface/50 text-xs mt-1">Longest Streak</div>
+              </div>
+              <div className="text-center">
+                <div className="text-2xl font-bold text-on-surface">
+                  {stats.bestRun.score.toLocaleString()}
+                </div>
+                <div className="text-on-surface/50 text-xs mt-1">Score</div>
+              </div>
+            </div>
+          </ChunkyCardContent>
+        </ChunkyCard>
+      )}
+
+      {/* Streaks + trailblazer */}
+      <ChunkyCard
+        variant="surface-variant"
+        className="bg-surface-container/80 border-outline-variant"
+      >
+        <ChunkyCardContent className="pt-5 pb-5">
+          <div className="grid grid-cols-2 gap-3">
+            <div className="text-center">
+              <div className="text-2xl font-bold text-ds-tertiary">{stats.bestStreak}</div>
+              <div className="text-on-surface/50 text-xs mt-1">Best Streak</div>
+            </div>
+            <div className="text-center">
+              <div className="text-2xl font-bold text-ds-tertiary">
+                &#x2B50; {stats.trailblazerCount}
+              </div>
+              <div className="text-on-surface/50 text-xs mt-1">Trailblazers</div>
+            </div>
+          </div>
+        </ChunkyCardContent>
+      </ChunkyCard>
+
+      {/* Category constellation (grid of accuracy rings) */}
+      {categories.length > 0 && (
+        <ChunkyCard
+          variant="surface-variant"
+          className="bg-surface-container/80 border-outline-variant"
+        >
+          <ChunkyCardContent className="pt-5 pb-5">
+            <h3 className="text-on-surface/70 text-sm font-semibold mb-3 uppercase tracking-wide">
+              Category Constellation
+            </h3>
+            <div className="grid grid-cols-2 sm:grid-cols-3 gap-4">
+              {categories.map(([cat, data]) => {
+                const catAccuracy =
+                  data.answered > 0 ? Math.round((data.correct / data.answered) * 100) : 0
+                return (
+                  <div key={cat} className="flex flex-col items-center gap-1">
+                    <div className="relative">
+                      <AccuracyRing accuracy={catAccuracy} />
+                      <div className="absolute inset-0 flex items-center justify-center">
+                        <span className="text-xs font-bold text-on-surface">{catAccuracy}%</span>
+                      </div>
+                    </div>
+                    <span className="text-on-surface/60 text-xs text-center leading-tight">
+                      {cat}
+                    </span>
+                    <span className="text-on-surface/30 text-[10px]">{data.answered} Q</span>
+                  </div>
+                )
+              })}
+            </div>
+          </ChunkyCardContent>
+        </ChunkyCard>
+      )}
+
+      {/* Per-difficulty breakdown */}
+      <ChunkyCard
+        variant="surface-variant"
+        className="bg-surface-container/80 border-outline-variant"
+      >
+        <ChunkyCardContent className="pt-5 pb-5">
+          <h3 className="text-on-surface/70 text-sm font-semibold mb-3 uppercase tracking-wide">
+            By Difficulty
+          </h3>
+          {(['easy', 'medium', 'hard'] as const).map((diff) => {
+            const d = stats.byDifficulty[diff]
+            const pct = d.answered > 0 ? Math.round((d.correct / d.answered) * 100) : 0
+            const diffColors = {
+              easy: 'bg-green-500',
+              medium: 'bg-yellow-500',
+              hard: 'bg-red-500',
+            }
+            return (
+              <div key={diff} className="flex items-center gap-3 mb-2">
+                <span className="text-on-surface/60 text-sm w-16 capitalize">{diff}</span>
+                <div className="flex-1 h-3 bg-surface-container-highest rounded-full overflow-hidden">
+                  <div
+                    className={`h-full ${diffColors[diff]} transition-all`}
+                    style={{ width: `${pct}%` }}
+                  />
+                </div>
+                <span className="text-on-surface/60 text-xs w-12 text-right">
+                  {pct}% ({d.answered})
+                </span>
+              </div>
+            )
+          })}
+        </ChunkyCardContent>
+      </ChunkyCard>
+
+      <ChunkyButton variant="secondary" onClick={onBack} className="w-full">
+        Back
+      </ChunkyButton>
+    </div>
+  )
+}

--- a/src/app/trivia/components/TriviaLanding.tsx
+++ b/src/app/trivia/components/TriviaLanding.tsx
@@ -21,12 +21,14 @@ export function TriviaLanding({
   onViewStats,
   onViewLeaderboard,
   onStartInfinite,
+  onViewInfiniteStats,
   todayResult,
 }: {
   onStartGame?: () => void
   onViewStats?: () => void
   onViewLeaderboard?: () => void
   onStartInfinite?: () => void
+  onViewInfiniteStats?: () => void
   todayResult: TriviaGameResult | null
 }) {
   const { user, loading: authLoading, configured: authConfigured, signOut } = useAuth()
@@ -202,7 +204,7 @@ export function TriviaLanding({
       </div>
 
       {/* Links */}
-      <div className="flex gap-3 text-sm">
+      <div className="flex gap-3 text-sm flex-wrap justify-center">
         <button
           onClick={onViewStats}
           className="text-ds-tertiary hover:text-ds-tertiary/80 transition-colors underline-offset-4 hover:underline"
@@ -215,6 +217,13 @@ export function TriviaLanding({
           className="text-ds-tertiary hover:text-ds-tertiary/80 transition-colors underline-offset-4 hover:underline"
         >
           Leaderboard
+        </button>
+        <span className="text-on-surface/20">·</span>
+        <button
+          onClick={onViewInfiniteStats}
+          className="text-ds-tertiary hover:text-ds-tertiary/80 transition-colors underline-offset-4 hover:underline"
+        >
+          Infinite Stats
         </button>
       </div>
 

--- a/src/app/trivia/page.tsx
+++ b/src/app/trivia/page.tsx
@@ -14,6 +14,7 @@ import { getTodayPST } from '@/lib/dates'
 import { getDailyCategory } from '@/lib/trivia/categories'
 
 import { InfiniteGame } from './components/InfiniteGame'
+import { InfiniteStats } from './components/InfiniteStats'
 import { TriviaGame } from './components/TriviaGame'
 import { TriviaLanding } from './components/TriviaLanding'
 import { TriviaLeaderboard } from './components/TriviaLeaderboard'
@@ -23,7 +24,7 @@ import { TriviaStats } from './components/TriviaStats'
 import type { TriviaGameResult } from './models/trivia'
 import type { User } from 'firebase/auth'
 
-type View = 'landing' | 'playing' | 'results' | 'stats' | 'leaderboard' | 'infinite'
+type View = 'landing' | 'playing' | 'results' | 'stats' | 'leaderboard' | 'infinite' | 'infinite-stats'
 
 async function submitGameToServer(user: User, result: TriviaGameResult): Promise<void> {
   const token = await user.getIdToken()
@@ -111,6 +112,7 @@ export default function TriviaPage() {
   const handleViewStats = () => setView('stats')
   const handleViewLeaderboard = () => setView('leaderboard')
   const handleStartInfinite = () => setView('infinite')
+  const handleViewInfiniteStats = () => setView('infinite-stats')
 
   const handleFinish = useCallback(
     (result: TriviaGameResult) => {
@@ -133,6 +135,10 @@ export default function TriviaPage() {
 
   if (view === 'infinite') {
     return <InfiniteGame onBack={handleBackToLanding} />
+  }
+
+  if (view === 'infinite-stats') {
+    return <InfiniteStats onBack={handleBackToLanding} />
   }
 
   if (view === 'playing') {
@@ -164,6 +170,7 @@ export default function TriviaPage() {
       onViewStats={handleViewStats}
       onViewLeaderboard={handleViewLeaderboard}
       onStartInfinite={handleStartInfinite}
+      onViewInfiniteStats={handleViewInfiniteStats}
       todayResult={todayResult}
     />
   )

--- a/src/lib/trivia/infiniteRuns.ts
+++ b/src/lib/trivia/infiniteRuns.ts
@@ -3,6 +3,7 @@ import { FieldValue } from 'firebase-admin/firestore'
 import { LIVES_START, applyAnswer } from '@/app/trivia/lib/infiniteScoring'
 import type { AnswerResult } from '@/app/trivia/lib/infiniteScoring'
 import { getFirestoreDb } from '@/lib/firebase/server'
+import { applyRunToAggregate } from '@/lib/trivia/triviaStats'
 
 export interface RunDoc {
   runId: string
@@ -62,7 +63,7 @@ export async function submitAnswer(params: {
   const seenRef = db.doc(`users/${uid}/seenQuestions/${questionId}`)
   const answeredByRef = db.doc(`aiQuestions/${questionId}/answeredBy/${uid}_${runId}`)
 
-  return db.runTransaction(async (tx) => {
+  const result = await db.runTransaction(async (tx) => {
     const runSnap = await tx.get(runRef)
     if (!runSnap.exists) throw new Error('Run not found')
     const run = runSnap.data() as RunDoc
@@ -77,7 +78,7 @@ export async function submitAnswer(params: {
     const isTrailblazer = correct && (qData.timesShown ?? 0) === 0
 
     // Compute result using pure function
-    const result = applyAnswer({
+    const txResult = applyAnswer({
       correct,
       trailblazer: isTrailblazer,
       elapsedMs,
@@ -115,7 +116,7 @@ export async function submitAnswer(params: {
     const answerEntry = {
       questionId,
       correct,
-      points: result.points,
+      points: txResult.points,
       timeMs: elapsedMs,
       trailblazer: isTrailblazer,
       answeredAt: now,
@@ -123,22 +124,31 @@ export async function submitAnswer(params: {
 
     // Update run doc
     const runUpdates: FirebaseFirestore.UpdateData<FirebaseFirestore.DocumentData> = {
-      score: result.score,
-      livesRemaining: result.livesRemaining,
-      currentStreak: result.currentStreak,
-      longestStreak: result.longestStreak,
+      score: txResult.score,
+      livesRemaining: txResult.livesRemaining,
+      currentStreak: txResult.currentStreak,
+      longestStreak: txResult.longestStreak,
       answers: FieldValue.arrayUnion(answerEntry),
     }
     if (isTrailblazer) {
       runUpdates.trailblazes = FieldValue.increment(1)
     }
-    if (result.runOver) {
+    if (txResult.runOver) {
       runUpdates.endedAt = now
     }
     tx.update(runRef, runUpdates)
 
-    return result
+    return { ...txResult, trailblazer: isTrailblazer }
   })
+
+  // Auto-finalize: apply aggregate stats outside the transaction (no nesting)
+  if (result.runOver) {
+    applyRunToAggregate(uid, runId).catch((err) =>
+      console.error('[submitAnswer] Failed to apply run to aggregate:', err)
+    )
+  }
+
+  return result
 }
 
 export async function endRun(uid: string, runId: string): Promise<void> {
@@ -147,6 +157,17 @@ export async function endRun(uid: string, runId: string): Promise<void> {
   const snap = await runRef.get()
   if (!snap.exists) throw new Error('Run not found')
   const data = snap.data()!
-  if (data.endedAt !== null) return // idempotent
+  if (data.endedAt !== null) {
+    // Run was already ended (e.g. auto-finalized when lives hit 0).
+    // Still attempt to apply stats in case they weren't applied yet
+    // (applyRunToAggregate is idempotent via statsApplied flag).
+    applyRunToAggregate(uid, runId).catch((err) =>
+      console.error('[endRun] Failed to apply run to aggregate:', err)
+    )
+    return
+  }
   await runRef.update({ endedAt: FieldValue.serverTimestamp() })
+  applyRunToAggregate(uid, runId).catch((err) =>
+    console.error('[endRun] Failed to apply run to aggregate:', err)
+  )
 }

--- a/src/lib/trivia/triviaStats.ts
+++ b/src/lib/trivia/triviaStats.ts
@@ -1,0 +1,175 @@
+import { FieldValue } from 'firebase-admin/firestore'
+
+import { getFirestoreDb } from '@/lib/firebase/server'
+import type { RunDoc } from '@/lib/trivia/infiniteRuns'
+
+export interface AggregateStats {
+  totalAnswered: number
+  totalCorrect: number
+  runsPlayed: number
+  bestRun: {
+    score: number
+    longestStreak: number
+    runId: string
+    endedAt: FirebaseFirestore.Timestamp | null
+  } | null
+  bestStreak: number
+  trailblazerCount: number
+  totalTimeMs: number
+  byCategory: Record<string, { answered: number; correct: number; totalTimeMs: number }>
+  byDifficulty: {
+    easy: { answered: number; correct: number }
+    medium: { answered: number; correct: number }
+    hard: { answered: number; correct: number }
+  }
+  lastUpdatedAt: FirebaseFirestore.Timestamp | null
+}
+
+const EMPTY_STATS: AggregateStats = {
+  totalAnswered: 0,
+  totalCorrect: 0,
+  runsPlayed: 0,
+  bestRun: null,
+  bestStreak: 0,
+  trailblazerCount: 0,
+  totalTimeMs: 0,
+  byCategory: {},
+  byDifficulty: {
+    easy: { answered: 0, correct: 0 },
+    medium: { answered: 0, correct: 0 },
+    hard: { answered: 0, correct: 0 },
+  },
+  lastUpdatedAt: null,
+}
+
+export async function getAggregateStats(uid: string): Promise<AggregateStats> {
+  const db = getFirestoreDb()
+  const snap = await db.doc(`users/${uid}/triviaStats/aggregate`).get()
+  if (!snap.exists) return { ...EMPTY_STATS }
+  return snap.data() as AggregateStats
+}
+
+// Called at run finalization. Reads the run doc, walks its answers[],
+// and atomically updates the aggregate doc. Idempotent via statsApplied flag.
+export async function applyRunToAggregate(uid: string, runId: string): Promise<void> {
+  const db = getFirestoreDb()
+  const runRef = db.doc(`users/${uid}/triviaInfinite/${runId}`)
+  const aggRef = db.doc(`users/${uid}/triviaStats/aggregate`)
+
+  await db.runTransaction(async (tx) => {
+    const runSnap = await tx.get(runRef)
+    if (!runSnap.exists) throw new Error('Run not found')
+    const run = runSnap.data() as RunDoc & { statsApplied?: boolean }
+
+    // Idempotency: skip if already applied
+    if (run.statsApplied === true) return
+
+    const aggSnap = await tx.get(aggRef)
+    const agg: AggregateStats = aggSnap.exists
+      ? (aggSnap.data() as AggregateStats)
+      : { ...EMPTY_STATS }
+
+    // Batch-read all question docs referenced by answers
+    const questionIds = run.answers.map((a) => a.questionId)
+    const questionRefs = questionIds.map((id) => db.doc(`aiQuestions/${id}`))
+    const questionSnaps = questionRefs.length > 0 ? await tx.getAll(...questionRefs) : []
+    const questionMap = new Map<string, { category: string; difficulty: 'easy' | 'medium' | 'hard' }>()
+    for (const qs of questionSnaps) {
+      if (qs.exists) {
+        const qd = qs.data()!
+        questionMap.set(qs.id, { category: qd.category, difficulty: qd.difficulty })
+      }
+    }
+
+    // Accumulate deltas from this run's answers
+    let totalAnswered = 0
+    let totalCorrect = 0
+    let totalTimeMs = 0
+    let trailblazerCount = 0
+    const byCategory: Record<string, { answered: number; correct: number; totalTimeMs: number }> = {}
+    const byDifficulty: Record<string, { answered: number; correct: number }> = {
+      easy: { answered: 0, correct: 0 },
+      medium: { answered: 0, correct: 0 },
+      hard: { answered: 0, correct: 0 },
+    }
+
+    for (const answer of run.answers) {
+      totalAnswered += 1
+      if (answer.correct) totalCorrect += 1
+      totalTimeMs += answer.timeMs
+      if (answer.trailblazer) trailblazerCount += 1
+
+      const qInfo = questionMap.get(answer.questionId)
+      if (qInfo) {
+        // Category
+        if (!byCategory[qInfo.category]) {
+          byCategory[qInfo.category] = { answered: 0, correct: 0, totalTimeMs: 0 }
+        }
+        byCategory[qInfo.category].answered += 1
+        if (answer.correct) byCategory[qInfo.category].correct += 1
+        byCategory[qInfo.category].totalTimeMs += answer.timeMs
+
+        // Difficulty
+        byDifficulty[qInfo.difficulty].answered += 1
+        if (answer.correct) byDifficulty[qInfo.difficulty].correct += 1
+      }
+    }
+
+    // Merge byCategory: start from existing, add deltas
+    const mergedByCategory: Record<string, { answered: number; correct: number; totalTimeMs: number }> = {}
+    for (const [cat, val] of Object.entries(agg.byCategory)) {
+      mergedByCategory[cat] = { ...val }
+    }
+    for (const [cat, deltas] of Object.entries(byCategory)) {
+      if (!mergedByCategory[cat]) {
+        mergedByCategory[cat] = { answered: 0, correct: 0, totalTimeMs: 0 }
+      }
+      mergedByCategory[cat].answered += deltas.answered
+      mergedByCategory[cat].correct += deltas.correct
+      mergedByCategory[cat].totalTimeMs += deltas.totalTimeMs
+    }
+
+    // Build merged aggregate
+    const newAgg: AggregateStats = {
+      totalAnswered: agg.totalAnswered + totalAnswered,
+      totalCorrect: agg.totalCorrect + totalCorrect,
+      runsPlayed: agg.runsPlayed + 1,
+      bestRun: agg.bestRun,
+      bestStreak: Math.max(agg.bestStreak, run.longestStreak),
+      trailblazerCount: agg.trailblazerCount + trailblazerCount,
+      totalTimeMs: agg.totalTimeMs + totalTimeMs,
+      byCategory: mergedByCategory,
+      byDifficulty: {
+        easy: {
+          answered: agg.byDifficulty.easy.answered + byDifficulty.easy.answered,
+          correct: agg.byDifficulty.easy.correct + byDifficulty.easy.correct,
+        },
+        medium: {
+          answered: agg.byDifficulty.medium.answered + byDifficulty.medium.answered,
+          correct: agg.byDifficulty.medium.correct + byDifficulty.medium.correct,
+        },
+        hard: {
+          answered: agg.byDifficulty.hard.answered + byDifficulty.hard.answered,
+          correct: agg.byDifficulty.hard.correct + byDifficulty.hard.correct,
+        },
+      },
+      lastUpdatedAt: null, // overwritten by server timestamp below
+    }
+
+    // Update bestRun if this run's score exceeds the current best
+    if (!newAgg.bestRun || run.score > newAgg.bestRun.score) {
+      newAgg.bestRun = {
+        score: run.score,
+        longestStreak: run.longestStreak,
+        runId: run.runId,
+        endedAt: run.endedAt,
+      }
+    }
+
+    // Write aggregate with server timestamp
+    tx.set(aggRef, { ...newAgg, lastUpdatedAt: FieldValue.serverTimestamp() })
+
+    // Mark the run as having its stats applied (idempotency guard)
+    tx.update(runRef, { statsApplied: true })
+  })
+}


### PR DESCRIPTION
## Summary

Implements issue #572 — lifetime stats with category constellation for Infinite Trivia.

- **`triviaStats.ts`** — `AggregateStats` interface + `applyRunToAggregate` transactional write (idempotent via `statsApplied` flag, batch-reads question docs for category/difficulty, merges deltas correctly into existing aggregate)
- **`GET /api/v1/trivia/stats/me`** — returns aggregate stats for signed-in user
- **`InfiniteStats` component** — hero stats grid (accuracy, questions, runs, avg answer time), best run card, category constellation with SVG accuracy rings in a responsive grid, per-difficulty progress bars, hand-crafted empty states
- **`infiniteRuns.ts`** — wired `applyRunToAggregate` on both auto-finalize (lives=0) and explicit `endRun`, fire-and-forget outside transaction to avoid nesting
- **Navigation** — "Infinite Stats" link on landing page, `infinite-stats` view in page router

Closes #572

## Test plan

- [ ] `npx tsc --noEmit` passes (verified locally)
- [ ] Completing a run updates aggregate stats (totalAnswered, byCategory, byDifficulty)
- [ ] Second run increments (adds to existing, doesn't overwrite)
- [ ] `bestRun` only updates when new score exceeds current
- [ ] `statsApplied` flag prevents double-counting on retry
- [ ] Profile renders category constellation with accuracy rings
- [ ] Empty state shows cosmic-narrator copy + CTA for users with no runs
- [ ] Anon user gets 401 on `/stats/me`
- [ ] Mobile + desktop layouts verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)