### PR TITLE
feat: Infinite Trivia 5 — Ratings + flags + removal cascade

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -40,5 +40,7 @@ service cloud.firestore {
     // AI questions — server-only
     match /aiQuestions/{docId} { allow read, write: if false; }
     match /aiQuestions/{docId}/answeredBy/{entryId} { allow read, write: if false; }
+    match /aiQuestions/{docId}/flags/{uid}    { allow read, write: if false; }
+    match /aiQuestions/{docId}/ratings/{uid}  { allow read, write: if false; }
   }
 }

--- a/scripts/list-flagged-questions.ts
+++ b/scripts/list-flagged-questions.ts
@@ -1,0 +1,73 @@
+#!/usr/bin/env tsx
+/**
+ * Lists all aiQuestions with status === 'flagged'.
+ *
+ * Usage:
+ *   npx tsx scripts/list-flagged-questions.ts
+ *
+ * Required env vars:
+ *   FIREBASE_PROJECT_ID
+ *   FIREBASE_CLIENT_EMAIL
+ *   FIREBASE_PRIVATE_KEY
+ */
+
+import { cert, getApps, initializeApp } from 'firebase-admin/app'
+import { getFirestore } from 'firebase-admin/firestore'
+
+function ensureApp() {
+  if (getApps().length > 0) return
+  const projectId = process.env.FIREBASE_PROJECT_ID
+  const clientEmail = process.env.FIREBASE_CLIENT_EMAIL
+  const privateKey = process.env.FIREBASE_PRIVATE_KEY?.replace(/\\n/g, '\n')
+  if (!projectId || !clientEmail || !privateKey) {
+    console.error(
+      'ERROR: Missing Firebase env vars. Set FIREBASE_PROJECT_ID, FIREBASE_CLIENT_EMAIL, FIREBASE_PRIVATE_KEY.'
+    )
+    process.exit(1)
+  }
+  initializeApp({ credential: cert({ projectId, clientEmail, privateKey }) })
+}
+
+async function main() {
+  ensureApp()
+  const db = getFirestore()
+
+  console.log('Querying flagged aiQuestions...')
+  const snap = await db.collection('aiQuestions').where('status', '==', 'flagged').get()
+  console.log(`Found ${snap.size} flagged question(s).\n`)
+
+  if (snap.size === 0) {
+    console.log('No flagged questions.')
+    return
+  }
+
+  for (const doc of snap.docs) {
+    const data = doc.data()
+    console.log('─'.repeat(60))
+    console.log(`ID:           ${doc.id}`)
+    console.log(`Question:     ${data.question}`)
+    console.log(`Category:     ${data.category}`)
+    console.log(`Difficulty:   ${data.difficulty}`)
+    console.log(`FlaggedCount: ${data.flaggedCount ?? 0}`)
+
+    // Fetch flag subcollection
+    const flagsSnap = await db.collection(`aiQuestions/${doc.id}/flags`).get()
+    if (flagsSnap.size > 0) {
+      console.log('Flags:')
+      for (const flagDoc of flagsSnap.docs) {
+        const f = flagDoc.data()
+        const at = f.flaggedAt?.toDate?.()?.toISOString() ?? 'unknown'
+        const noteStr = f.note ? ` | note: "${f.note}"` : ''
+        console.log(`  - uid=${flagDoc.id} reason=${f.reason}${noteStr} at=${at}`)
+      }
+    } else {
+      console.log('Flags:        (none in subcollection)')
+    }
+  }
+  console.log('─'.repeat(60))
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})

--- a/scripts/remove-ai-question.ts
+++ b/scripts/remove-ai-question.ts
@@ -1,0 +1,139 @@
+#!/usr/bin/env tsx
+/**
+ * Removes an AI question and cascades through affected players' runs and stats.
+ *
+ * Usage:
+ *   npx tsx scripts/remove-ai-question.ts <questionId>
+ *
+ * Required env vars:
+ *   FIREBASE_PROJECT_ID
+ *   FIREBASE_CLIENT_EMAIL
+ *   FIREBASE_PRIVATE_KEY
+ */
+
+import { cert, getApps, initializeApp } from 'firebase-admin/app'
+import { FieldValue, getFirestore } from 'firebase-admin/firestore'
+
+function ensureApp() {
+  if (getApps().length > 0) return
+  const projectId = process.env.FIREBASE_PROJECT_ID
+  const clientEmail = process.env.FIREBASE_CLIENT_EMAIL
+  const privateKey = process.env.FIREBASE_PRIVATE_KEY?.replace(/\\n/g, '\n')
+  if (!projectId || !clientEmail || !privateKey) {
+    console.error(
+      'ERROR: Missing Firebase env vars. Set FIREBASE_PROJECT_ID, FIREBASE_CLIENT_EMAIL, FIREBASE_PRIVATE_KEY.'
+    )
+    process.exit(1)
+  }
+  initializeApp({ credential: cert({ projectId, clientEmail, privateKey }) })
+}
+
+async function removeQuestion(questionId: string): Promise<{ affectedPlayers: number }> {
+  const db = getFirestore()
+  const qRef = db.doc(`aiQuestions/${questionId}`)
+
+  const qSnap = await qRef.get()
+  if (!qSnap.exists) throw new Error('Question not found')
+  if (qSnap.data()!.status === 'removed') {
+    console.log('Question is already removed. Nothing to do (idempotent).')
+    return { affectedPlayers: 0 }
+  }
+
+  // Set status to removed
+  await qRef.update({ status: 'removed' })
+  console.log(`Set aiQuestions/${questionId} status = 'removed'`)
+
+  // Walk answeredBy reverse index
+  const answeredBySnap = await db.collection(`aiQuestions/${questionId}/answeredBy`).get()
+  console.log(`Found ${answeredBySnap.size} answeredBy entries to process.`)
+
+  let affectedPlayers = 0
+
+  for (const abDoc of answeredBySnap.docs) {
+    const { uid, runId, correct } = abDoc.data()
+    affectedPlayers++
+
+    try {
+      const runRef = db.doc(`users/${uid}/triviaInfinite/${runId}`)
+      const runSnap = await runRef.get()
+      if (!runSnap.exists) {
+        console.log(`  [${uid}/${runId}] Run not found, skipping.`)
+        continue
+      }
+      const run = runSnap.data()!
+
+      const answers = run.answers as Array<{ questionId: string; correct: boolean; points: number; timeMs: number; trailblazer: boolean }>
+      const answerIdx = answers.findIndex(a => a.questionId === questionId)
+      if (answerIdx === -1) {
+        console.log(`  [${uid}/${runId}] Answer not found in run, skipping.`)
+        continue
+      }
+
+      const removedAnswer = answers[answerIdx]
+      const newAnswers = [...answers.slice(0, answerIdx), ...answers.slice(answerIdx + 1)]
+      const newScore = newAnswers.reduce((sum, a) => sum + a.points, 0)
+
+      await runRef.update({ answers: newAnswers, score: newScore })
+      console.log(`  [${uid}/${runId}] Removed answer, new score: ${newScore}`)
+
+      // Decrement aggregate stats
+      const aggRef = db.doc(`users/${uid}/triviaStats/aggregate`)
+      const aggSnap = await aggRef.get()
+      if (aggSnap.exists) {
+        const qData = qSnap.data()!
+        const updates: Record<string, unknown> = {
+          totalAnswered: FieldValue.increment(-1),
+          totalTimeMs: FieldValue.increment(-removedAnswer.timeMs),
+        }
+        if (removedAnswer.correct) {
+          updates.totalCorrect = FieldValue.increment(-1)
+        }
+        if (removedAnswer.trailblazer) {
+          updates.trailblazerCount = FieldValue.increment(-1)
+        }
+        if (qData.category && qData.difficulty) {
+          updates[`byCategory.${qData.category}.answered`] = FieldValue.increment(-1)
+          if (removedAnswer.correct) {
+            updates[`byCategory.${qData.category}.correct`] = FieldValue.increment(-1)
+          }
+          updates[`byCategory.${qData.category}.totalTimeMs`] = FieldValue.increment(-removedAnswer.timeMs)
+          updates[`byDifficulty.${qData.difficulty}.answered`] = FieldValue.increment(-1)
+          if (removedAnswer.correct) {
+            updates[`byDifficulty.${qData.difficulty}.correct`] = FieldValue.increment(-1)
+          }
+        }
+        updates.lastUpdatedAt = FieldValue.serverTimestamp()
+        await aggRef.update(updates)
+        console.log(`  [${uid}] Updated aggregate stats.`)
+      }
+
+      // Remove seenQuestions entry
+      await db.doc(`users/${uid}/seenQuestions/${questionId}`).delete()
+      console.log(`  [${uid}] Removed seenQuestions entry.`)
+    } catch (err) {
+      console.error(`  ERROR processing uid=${uid}, runId=${runId}:`, err)
+    }
+  }
+
+  return { affectedPlayers }
+}
+
+async function main() {
+  const questionId = process.argv[2]
+  if (!questionId) {
+    console.error('Usage: npx tsx scripts/remove-ai-question.ts <questionId>')
+    process.exit(1)
+  }
+
+  ensureApp()
+
+  console.log(`Removing question: ${questionId}`)
+  const { affectedPlayers } = await removeQuestion(questionId)
+  console.log('─'.repeat(60))
+  console.log(`Done. Affected players: ${affectedPlayers}`)
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})

--- a/src/app/api/v1/trivia/questions/[id]/flag/route.ts
+++ b/src/app/api/v1/trivia/questions/[id]/flag/route.ts
@@ -1,0 +1,81 @@
+import { type NextRequest, NextResponse } from 'next/server';
+import { FieldValue } from 'firebase-admin/firestore';
+
+import { verifyRequestAuth } from '@/lib/api/auth';
+import { getFirestoreDb } from '@/lib/firebase/server';
+
+const FLAG_THRESHOLD = 3;
+const VALID_REASONS = ['wrong_answer', 'ambiguous', 'inappropriate', 'other'] as const;
+type FlagReason = (typeof VALID_REASONS)[number];
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const auth = await verifyRequestAuth(request);
+  if ('error' in auth) return auth.error;
+
+  const { id: questionId } = await params;
+  const uid = auth.claims.uid;
+
+  let body: { reason?: unknown; note?: unknown };
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON.' }, { status: 400 });
+  }
+
+  const { reason, note } = body;
+
+  if (!VALID_REASONS.includes(reason as FlagReason)) {
+    return NextResponse.json(
+      { error: 'Invalid reason. Must be one of: wrong_answer, ambiguous, inappropriate, other.' },
+      { status: 400 }
+    );
+  }
+
+  if (note !== undefined && (typeof note !== 'string' || note.length > 500)) {
+    return NextResponse.json({ error: 'Note must be a string of max 500 characters.' }, { status: 400 });
+  }
+
+  const db = getFirestoreDb();
+  const qRef = db.doc(`aiQuestions/${questionId}`);
+  const flagRef = db.doc(`aiQuestions/${questionId}/flags/${uid}`);
+
+  try {
+    await db.runTransaction(async (tx) => {
+      const qSnap = await tx.get(qRef);
+      if (!qSnap.exists) throw new Error('Question not found');
+
+      const qData = qSnap.data()!;
+      const newFlaggedCount = (qData.flaggedCount ?? 0) + 1;
+
+      const qUpdates: FirebaseFirestore.UpdateData<FirebaseFirestore.DocumentData> = {
+        flaggedCount: FieldValue.increment(1),
+      };
+
+      if (newFlaggedCount >= FLAG_THRESHOLD && qData.status === 'active') {
+        qUpdates.status = 'flagged';
+      }
+
+      tx.update(qRef, qUpdates);
+
+      const flagDoc: Record<string, unknown> = {
+        reason,
+        flaggedAt: FieldValue.serverTimestamp(),
+      };
+      if (note !== undefined) {
+        flagDoc.note = note;
+      }
+      tx.set(flagRef, flagDoc);
+    });
+
+    return NextResponse.json({ ok: true }, { status: 200 });
+  } catch (err) {
+    if (err instanceof Error && err.message === 'Question not found') {
+      return NextResponse.json({ error: 'Question not found.' }, { status: 404 });
+    }
+    console.error('Failed to flag question:', err);
+    return NextResponse.json({ error: 'Failed to flag question.' }, { status: 500 });
+  }
+}

--- a/src/app/api/v1/trivia/questions/[id]/rate/route.ts
+++ b/src/app/api/v1/trivia/questions/[id]/rate/route.ts
@@ -1,0 +1,54 @@
+import { type NextRequest, NextResponse } from 'next/server';
+import { FieldValue } from 'firebase-admin/firestore';
+
+import { verifyRequestAuth } from '@/lib/api/auth';
+import { getFirestoreDb } from '@/lib/firebase/server';
+
+const VALID_VOTES = ['up', 'down'] as const;
+type Vote = (typeof VALID_VOTES)[number];
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const auth = await verifyRequestAuth(request);
+  if ('error' in auth) return auth.error;
+
+  const { id: questionId } = await params;
+  const uid = auth.claims.uid;
+
+  let body: { vote?: unknown };
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON.' }, { status: 400 });
+  }
+
+  const { vote } = body;
+
+  if (vote !== null && !VALID_VOTES.includes(vote as Vote)) {
+    return NextResponse.json(
+      { error: 'Invalid vote. Must be "up", "down", or null.' },
+      { status: 400 }
+    );
+  }
+
+  const db = getFirestoreDb();
+  const ratingRef = db.doc(`aiQuestions/${questionId}/ratings/${uid}`);
+
+  try {
+    if (vote === null) {
+      await ratingRef.delete();
+    } else {
+      await ratingRef.set({
+        vote,
+        ratedAt: FieldValue.serverTimestamp(),
+      });
+    }
+
+    return NextResponse.json({ ok: true }, { status: 200 });
+  } catch (err) {
+    console.error('Failed to rate question:', err);
+    return NextResponse.json({ error: 'Failed to rate question.' }, { status: 500 });
+  }
+}

--- a/src/app/api/v1/trivia/stats/me/route.ts
+++ b/src/app/api/v1/trivia/stats/me/route.ts
@@ -1,0 +1,17 @@
+import { type NextRequest, NextResponse } from 'next/server'
+
+import { verifyRequestAuth } from '@/lib/api/auth'
+import { getAggregateStats } from '@/lib/trivia/triviaStats'
+
+export async function GET(request: NextRequest) {
+  const auth = await verifyRequestAuth(request)
+  if ('error' in auth) return auth.error
+
+  try {
+    const stats = await getAggregateStats(auth.claims.uid)
+    return NextResponse.json(stats)
+  } catch (err) {
+    console.error('Failed to fetch stats:', err)
+    return NextResponse.json({ error: 'Failed to fetch stats.' }, { status: 500 })
+  }
+}

--- a/src/app/trivia/components/FlagQuestion.tsx
+++ b/src/app/trivia/components/FlagQuestion.tsx
@@ -1,0 +1,79 @@
+'use client'
+import { useState } from 'react'
+import { useAuth } from '@/hooks/useAuth'
+import { ChunkyButton } from '@/components/ui/chunky-button'
+
+const FLAG_REASONS = [
+  { value: 'wrong_answer', label: 'Wrong answer marked correct' },
+  { value: 'ambiguous', label: "Question doesn't have one right answer" },
+  { value: 'inappropriate', label: 'Inappropriate / off-brand' },
+  { value: 'other', label: 'Other' },
+] as const
+
+interface Props {
+  questionId: string
+}
+
+export function FlagQuestion({ questionId }: Props) {
+  const { user } = useAuth()
+  const [showModal, setShowModal] = useState(false)
+  const [reason, setReason] = useState<string>('')
+  const [note, setNote] = useState('')
+  const [submitted, setSubmitted] = useState(false)
+  const [submitting, setSubmitting] = useState(false)
+
+  if (!user) return null
+
+  const handleSubmit = async () => {
+    if (!reason || submitting) return
+    setSubmitting(true)
+    try {
+      const token = await user.getIdToken()
+      await fetch(`/api/v1/trivia/questions/${questionId}/flag`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+        body: JSON.stringify({ reason, note: note.trim() || undefined }),
+      })
+      setSubmitted(true)
+      setShowModal(false)
+    } catch {
+      // silent
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  if (submitted) return <span className="text-on-surface/30 text-xs">Reported</span>
+
+  return (
+    <>
+      <button onClick={() => setShowModal(true)} className="text-on-surface/20 hover:text-ds-error/60 text-xs transition-colors" aria-label="Report question" title="Report this question">
+        🚩
+      </button>
+      {showModal && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-surface-dim/80 backdrop-blur-sm">
+          <div className="bg-surface-container-high rounded-ds-lg p-6 max-w-sm mx-4 shadow-hero flex flex-col gap-4">
+            <h3 className="text-on-surface font-bold text-lg">Report Question</h3>
+            <div className="flex flex-col gap-2">
+              {FLAG_REASONS.map(r => (
+                <label key={r.value} className="flex items-center gap-2 text-on-surface/80 text-sm cursor-pointer">
+                  <input type="radio" name="flag-reason" value={r.value} checked={reason === r.value} onChange={() => setReason(r.value)} className="accent-ds-tertiary" />
+                  {r.label}
+                </label>
+              ))}
+            </div>
+            {reason === 'other' && (
+              <textarea value={note} onChange={e => setNote(e.target.value.slice(0, 500))} placeholder="Tell us more..." maxLength={500} className="bg-surface-dim/50 border border-outline-variant rounded-lg p-2 text-on-surface text-sm resize-none h-20" />
+            )}
+            <div className="flex gap-3 justify-end">
+              <ChunkyButton variant="secondary" size="sm" onClick={() => setShowModal(false)}>Cancel</ChunkyButton>
+              <ChunkyButton variant="exit" size="sm" disabled={!reason || submitting} onClick={handleSubmit}>
+                {submitting ? 'Sending...' : 'Report'}
+              </ChunkyButton>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  )
+}

--- a/src/app/trivia/components/InfiniteRunSummary.tsx
+++ b/src/app/trivia/components/InfiniteRunSummary.tsx
@@ -5,6 +5,8 @@ import { ChunkyCard, ChunkyCardContent } from '@/components/ui/chunky-card'
 import { Pill } from '@/components/ui/pill'
 import { useAuth } from '@/hooks/useAuth'
 import { SignInCard } from './SignInCTA'
+import { QuestionRating } from './QuestionRating'
+import { FlagQuestion } from './FlagQuestion'
 import type { InfiniteRunState } from '@/app/trivia/hooks/useInfiniteRun'
 
 interface Props {
@@ -113,6 +115,8 @@ export function InfiniteRunSummary({ state, onPlayAgain, onBack }: Props) {
                     <span className={`font-bold text-sm min-w-[4rem] text-right ${a.correct ? 'text-ds-tertiary' : 'text-on-surface/30'}`}>
                       +{a.points}
                     </span>
+                    <QuestionRating questionId={a.questionId} />
+                    <FlagQuestion questionId={a.questionId} />
                   </div>
                 </div>
               ))}

--- a/src/app/trivia/components/InfiniteStats.tsx
+++ b/src/app/trivia/components/InfiniteStats.tsx
@@ -1,0 +1,336 @@
+'use client'
+import { useCallback, useEffect, useState } from 'react'
+
+import { ChunkyButton } from '@/components/ui/chunky-button'
+import { ChunkyCard, ChunkyCardContent } from '@/components/ui/chunky-card'
+import { useAuth } from '@/hooks/useAuth'
+
+import { SignInCard } from './SignInCTA'
+
+interface CategoryStats {
+  answered: number
+  correct: number
+  totalTimeMs: number
+}
+
+interface DifficultyStats {
+  answered: number
+  correct: number
+}
+
+interface AggregateStats {
+  totalAnswered: number
+  totalCorrect: number
+  runsPlayed: number
+  bestRun: { score: number; longestStreak: number } | null
+  bestStreak: number
+  trailblazerCount: number
+  totalTimeMs: number
+  byCategory: Record<string, CategoryStats>
+  byDifficulty: {
+    easy: DifficultyStats
+    medium: DifficultyStats
+    hard: DifficultyStats
+  }
+}
+
+function getAccuracyColor(accuracy: number): string {
+  if (accuracy >= 80) return 'text-ds-primary'
+  if (accuracy >= 60) return 'text-yellow-400'
+  return 'text-ds-error'
+}
+
+function AccuracyRing({ accuracy, size = 48 }: { accuracy: number; size?: number }) {
+  const radius = (size - 6) / 2
+  const circumference = 2 * Math.PI * radius
+  const offset = circumference - (accuracy / 100) * circumference
+  const color =
+    accuracy >= 80 ? 'stroke-ds-primary' : accuracy >= 60 ? 'stroke-yellow-400' : 'stroke-ds-error'
+
+  return (
+    <svg width={size} height={size} className="transform -rotate-90">
+      <circle
+        cx={size / 2}
+        cy={size / 2}
+        r={radius}
+        fill="none"
+        strokeWidth={3}
+        className="stroke-surface-container-highest"
+      />
+      <circle
+        cx={size / 2}
+        cy={size / 2}
+        r={radius}
+        fill="none"
+        strokeWidth={3}
+        strokeDasharray={circumference}
+        strokeDashoffset={offset}
+        strokeLinecap="round"
+        className={color}
+      />
+    </svg>
+  )
+}
+
+export function InfiniteStats({ onBack }: { onBack: () => void }) {
+  const { user } = useAuth()
+  const [stats, setStats] = useState<AggregateStats | null>(null)
+  const [loading, setLoading] = useState(true)
+
+  const fetchStats = useCallback(async () => {
+    if (!user) {
+      setLoading(false)
+      return
+    }
+    try {
+      const token = await user.getIdToken()
+      const res = await fetch('/api/v1/trivia/stats/me', {
+        headers: { Authorization: `Bearer ${token}` },
+      })
+      if (res.ok) {
+        setStats(await res.json())
+      }
+    } catch {
+      // silent
+    } finally {
+      setLoading(false)
+    }
+  }, [user])
+
+  useEffect(() => {
+    fetchStats()
+  }, [fetchStats])
+
+  if (loading) {
+    return (
+      <div className="flex flex-col items-center gap-4 py-8 max-w-lg mx-auto">
+        <div className="text-on-surface/60 text-lg">Loading stats...</div>
+      </div>
+    )
+  }
+
+  if (!user) {
+    return (
+      <div className="flex flex-col items-center gap-6 max-w-lg mx-auto py-8">
+        <h2 className="text-3xl font-bold text-ds-tertiary">Infinite Stats</h2>
+        <SignInCard
+          title="Your constellation awaits"
+          description="Sign in to track your infinite trivia journey — accuracy, streaks, and category mastery."
+        />
+        <ChunkyButton variant="secondary" onClick={onBack} className="w-full">
+          Back
+        </ChunkyButton>
+      </div>
+    )
+  }
+
+  if (!stats || stats.runsPlayed === 0) {
+    return (
+      <div className="flex flex-col items-center gap-6 max-w-lg mx-auto py-8">
+        <h2 className="text-3xl font-bold text-ds-tertiary">Infinite Stats</h2>
+        <ChunkyCard
+          variant="surface-variant"
+          className="w-full bg-surface-container/80 border-outline-variant"
+        >
+          <ChunkyCardContent className="pt-6 text-center">
+            <p className="text-on-surface/70 text-lg mb-2">The stars haven&apos;t aligned yet</p>
+            <p className="text-on-surface/50 text-sm">
+              Complete your first infinite run to begin mapping your constellation.
+            </p>
+          </ChunkyCardContent>
+        </ChunkyCard>
+        <ChunkyButton
+          variant="primary"
+          onClick={() => (window.location.href = '/trivia/infinite')}
+          className="w-full"
+        >
+          Enter the Infinite Cavern
+        </ChunkyButton>
+        <ChunkyButton variant="secondary" onClick={onBack} className="w-full">
+          Back
+        </ChunkyButton>
+      </div>
+    )
+  }
+
+  const accuracy =
+    stats.totalAnswered > 0
+      ? Math.round((stats.totalCorrect / stats.totalAnswered) * 100)
+      : 0
+  const avgTimeMs =
+    stats.totalAnswered > 0 ? Math.round(stats.totalTimeMs / stats.totalAnswered) : 0
+  const categories = Object.entries(stats.byCategory).sort((a, b) => b[1].answered - a[1].answered)
+
+  return (
+    <div className="flex flex-col gap-5 max-w-lg mx-auto py-6">
+      <div className="text-center">
+        <h2 className="text-3xl font-bold text-ds-tertiary mb-1">Infinite Stats</h2>
+        <p className="text-on-surface/50 text-sm">Your endless trivia journey</p>
+      </div>
+
+      {/* Hero stats */}
+      <div className="grid grid-cols-2 gap-3">
+        <ChunkyCard
+          variant="surface-variant"
+          className="bg-surface-container/80 border-outline-variant"
+        >
+          <ChunkyCardContent className="pt-5 pb-5 text-center">
+            <div className={`text-3xl font-bold ${getAccuracyColor(accuracy)}`}>{accuracy}%</div>
+            <div className="text-on-surface/50 text-xs mt-1">Accuracy</div>
+          </ChunkyCardContent>
+        </ChunkyCard>
+        <ChunkyCard
+          variant="surface-variant"
+          className="bg-surface-container/80 border-outline-variant"
+        >
+          <ChunkyCardContent className="pt-5 pb-5 text-center">
+            <div className="text-3xl font-bold text-on-surface">{stats.totalAnswered}</div>
+            <div className="text-on-surface/50 text-xs mt-1">Questions</div>
+          </ChunkyCardContent>
+        </ChunkyCard>
+        <ChunkyCard
+          variant="surface-variant"
+          className="bg-surface-container/80 border-outline-variant"
+        >
+          <ChunkyCardContent className="pt-5 pb-5 text-center">
+            <div className="text-3xl font-bold text-ds-tertiary">{stats.runsPlayed}</div>
+            <div className="text-on-surface/50 text-xs mt-1">Runs Played</div>
+          </ChunkyCardContent>
+        </ChunkyCard>
+        <ChunkyCard
+          variant="surface-variant"
+          className="bg-surface-container/80 border-outline-variant"
+        >
+          <ChunkyCardContent className="pt-5 pb-5 text-center">
+            <div className="text-3xl font-bold text-on-surface">
+              {Math.round(avgTimeMs / 1000)}s
+            </div>
+            <div className="text-on-surface/50 text-xs mt-1">Avg Answer</div>
+          </ChunkyCardContent>
+        </ChunkyCard>
+      </div>
+
+      {/* Best run */}
+      {stats.bestRun && (
+        <ChunkyCard
+          variant="surface-variant"
+          className="bg-surface-container/80 border-outline-variant"
+        >
+          <ChunkyCardContent className="pt-5 pb-5">
+            <h3 className="text-on-surface/70 text-sm font-semibold mb-3 uppercase tracking-wide">
+              Best Run
+            </h3>
+            <div className="grid grid-cols-2 gap-3">
+              <div className="text-center">
+                <div className="text-2xl font-bold text-ds-tertiary">
+                  🔥 {stats.bestRun.longestStreak}
+                </div>
+                <div className="text-on-surface/50 text-xs mt-1">Longest Streak</div>
+              </div>
+              <div className="text-center">
+                <div className="text-2xl font-bold text-on-surface">
+                  {stats.bestRun.score.toLocaleString()}
+                </div>
+                <div className="text-on-surface/50 text-xs mt-1">Score</div>
+              </div>
+            </div>
+          </ChunkyCardContent>
+        </ChunkyCard>
+      )}
+
+      {/* Streaks + trailblazer */}
+      <ChunkyCard
+        variant="surface-variant"
+        className="bg-surface-container/80 border-outline-variant"
+      >
+        <ChunkyCardContent className="pt-5 pb-5">
+          <div className="grid grid-cols-2 gap-3">
+            <div className="text-center">
+              <div className="text-2xl font-bold text-ds-tertiary">{stats.bestStreak}</div>
+              <div className="text-on-surface/50 text-xs mt-1">Best Streak</div>
+            </div>
+            <div className="text-center">
+              <div className="text-2xl font-bold text-ds-tertiary">
+                &#x2B50; {stats.trailblazerCount}
+              </div>
+              <div className="text-on-surface/50 text-xs mt-1">Trailblazers</div>
+            </div>
+          </div>
+        </ChunkyCardContent>
+      </ChunkyCard>
+
+      {/* Category constellation (grid of accuracy rings) */}
+      {categories.length > 0 && (
+        <ChunkyCard
+          variant="surface-variant"
+          className="bg-surface-container/80 border-outline-variant"
+        >
+          <ChunkyCardContent className="pt-5 pb-5">
+            <h3 className="text-on-surface/70 text-sm font-semibold mb-3 uppercase tracking-wide">
+              Category Constellation
+            </h3>
+            <div className="grid grid-cols-2 sm:grid-cols-3 gap-4">
+              {categories.map(([cat, data]) => {
+                const catAccuracy =
+                  data.answered > 0 ? Math.round((data.correct / data.answered) * 100) : 0
+                return (
+                  <div key={cat} className="flex flex-col items-center gap-1">
+                    <div className="relative">
+                      <AccuracyRing accuracy={catAccuracy} />
+                      <div className="absolute inset-0 flex items-center justify-center">
+                        <span className="text-xs font-bold text-on-surface">{catAccuracy}%</span>
+                      </div>
+                    </div>
+                    <span className="text-on-surface/60 text-xs text-center leading-tight">
+                      {cat}
+                    </span>
+                    <span className="text-on-surface/30 text-[10px]">{data.answered} Q</span>
+                  </div>
+                )
+              })}
+            </div>
+          </ChunkyCardContent>
+        </ChunkyCard>
+      )}
+
+      {/* Per-difficulty breakdown */}
+      <ChunkyCard
+        variant="surface-variant"
+        className="bg-surface-container/80 border-outline-variant"
+      >
+        <ChunkyCardContent className="pt-5 pb-5">
+          <h3 className="text-on-surface/70 text-sm font-semibold mb-3 uppercase tracking-wide">
+            By Difficulty
+          </h3>
+          {(['easy', 'medium', 'hard'] as const).map((diff) => {
+            const d = stats.byDifficulty[diff]
+            const pct = d.answered > 0 ? Math.round((d.correct / d.answered) * 100) : 0
+            const diffColors = {
+              easy: 'bg-green-500',
+              medium: 'bg-yellow-500',
+              hard: 'bg-red-500',
+            }
+            return (
+              <div key={diff} className="flex items-center gap-3 mb-2">
+                <span className="text-on-surface/60 text-sm w-16 capitalize">{diff}</span>
+                <div className="flex-1 h-3 bg-surface-container-highest rounded-full overflow-hidden">
+                  <div
+                    className={`h-full ${diffColors[diff]} transition-all`}
+                    style={{ width: `${pct}%` }}
+                  />
+                </div>
+                <span className="text-on-surface/60 text-xs w-12 text-right">
+                  {pct}% ({d.answered})
+                </span>
+              </div>
+            )
+          })}
+        </ChunkyCardContent>
+      </ChunkyCard>
+
+      <ChunkyButton variant="secondary" onClick={onBack} className="w-full">
+        Back
+      </ChunkyButton>
+    </div>
+  )
+}

--- a/src/app/trivia/components/QuestionRating.tsx
+++ b/src/app/trivia/components/QuestionRating.tsx
@@ -1,0 +1,41 @@
+'use client'
+import { useState } from 'react'
+import { useAuth } from '@/hooks/useAuth'
+
+interface Props {
+  questionId: string
+}
+
+export function QuestionRating({ questionId }: Props) {
+  const { user } = useAuth()
+  const [vote, setVote] = useState<'up' | 'down' | null>(null)
+
+  if (!user) return null  // logged-in only
+
+  const handleVote = async (newVote: 'up' | 'down') => {
+    const prev = vote
+    setVote(newVote === vote ? null : newVote)  // toggle
+    try {
+      const token = await user.getIdToken()
+      const res = await fetch(`/api/v1/trivia/questions/${questionId}/rate`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+        body: JSON.stringify({ vote: newVote === vote ? null : newVote }),
+      })
+      if (!res.ok) setVote(prev) // rollback
+    } catch {
+      setVote(prev) // rollback
+    }
+  }
+
+  return (
+    <div className="flex items-center gap-1">
+      <button onClick={() => handleVote('up')} className={`text-sm p-0.5 rounded transition-colors ${vote === 'up' ? 'text-ds-primary' : 'text-on-surface/30 hover:text-on-surface/60'}`} aria-label="Rate up">
+        👍
+      </button>
+      <button onClick={() => handleVote('down')} className={`text-sm p-0.5 rounded transition-colors ${vote === 'down' ? 'text-ds-error' : 'text-on-surface/30 hover:text-on-surface/60'}`} aria-label="Rate down">
+        👎
+      </button>
+    </div>
+  )
+}

--- a/src/app/trivia/components/TriviaLanding.tsx
+++ b/src/app/trivia/components/TriviaLanding.tsx
@@ -21,12 +21,14 @@ export function TriviaLanding({
   onViewStats,
   onViewLeaderboard,
   onStartInfinite,
+  onViewInfiniteStats,
   todayResult,
 }: {
   onStartGame?: () => void
   onViewStats?: () => void
   onViewLeaderboard?: () => void
   onStartInfinite?: () => void
+  onViewInfiniteStats?: () => void
   todayResult: TriviaGameResult | null
 }) {
   const { user, loading: authLoading, configured: authConfigured, signOut } = useAuth()
@@ -202,7 +204,7 @@ export function TriviaLanding({
       </div>
 
       {/* Links */}
-      <div className="flex gap-3 text-sm">
+      <div className="flex gap-3 text-sm flex-wrap justify-center">
         <button
           onClick={onViewStats}
           className="text-ds-tertiary hover:text-ds-tertiary/80 transition-colors underline-offset-4 hover:underline"
@@ -215,6 +217,13 @@ export function TriviaLanding({
           className="text-ds-tertiary hover:text-ds-tertiary/80 transition-colors underline-offset-4 hover:underline"
         >
           Leaderboard
+        </button>
+        <span className="text-on-surface/20">·</span>
+        <button
+          onClick={onViewInfiniteStats}
+          className="text-ds-tertiary hover:text-ds-tertiary/80 transition-colors underline-offset-4 hover:underline"
+        >
+          Infinite Stats
         </button>
       </div>
 

--- a/src/app/trivia/hooks/useInfiniteRun.ts
+++ b/src/app/trivia/hooks/useInfiniteRun.ts
@@ -24,7 +24,7 @@ export interface InfiniteRunState {
   questionsAnswered: number
   trailblazes: number
   lastAnswer: (AnswerResult & { trailblazer: boolean }) | null
-  answers: Array<{ correct: boolean; points: number; timeMs: number; trailblazer: boolean }>
+  answers: Array<{ questionId: string; correct: boolean; points: number; timeMs: number; trailblazer: boolean }>
   error: string | null
 }
 
@@ -99,6 +99,7 @@ export function useInfiniteRun() {
   const submitAnswer = useCallback(async (answer: string) => {
     if (state.phase !== 'playing' || !state.runId || !state.question) return
 
+    const currentQuestionId = state.question.id
     setState(s => ({ ...s, phase: 'answering' }))
     const elapsedMs = Date.now() - startTimeRef.current
 
@@ -108,7 +109,7 @@ export function useInfiniteRun() {
         method: 'POST',
         headers,
         body: JSON.stringify({
-          questionId: state.question.id,
+          questionId: currentQuestionId,
           answer,
           elapsedMs,
         }),
@@ -130,7 +131,7 @@ export function useInfiniteRun() {
         score: result.score,
         questionsAnswered: s.questionsAnswered + 1,
         trailblazes: result.trailblazer ? s.trailblazes + 1 : s.trailblazes,
-        answers: [...s.answers, { correct: result.correct, points: result.points, timeMs: elapsedMs, trailblazer: result.trailblazer }],
+        answers: [...s.answers, { questionId: currentQuestionId, correct: result.correct, points: result.points, timeMs: elapsedMs, trailblazer: result.trailblazer }],
       }))
     } catch {
       setState(s => ({ ...s, phase: 'error', error: 'Failed to submit answer.' }))

--- a/src/app/trivia/page.tsx
+++ b/src/app/trivia/page.tsx
@@ -14,6 +14,7 @@ import { getTodayPST } from '@/lib/dates'
 import { getDailyCategory } from '@/lib/trivia/categories'
 
 import { InfiniteGame } from './components/InfiniteGame'
+import { InfiniteStats } from './components/InfiniteStats'
 import { TriviaGame } from './components/TriviaGame'
 import { TriviaLanding } from './components/TriviaLanding'
 import { TriviaLeaderboard } from './components/TriviaLeaderboard'
@@ -23,7 +24,7 @@ import { TriviaStats } from './components/TriviaStats'
 import type { TriviaGameResult } from './models/trivia'
 import type { User } from 'firebase/auth'
 
-type View = 'landing' | 'playing' | 'results' | 'stats' | 'leaderboard' | 'infinite'
+type View = 'landing' | 'playing' | 'results' | 'stats' | 'leaderboard' | 'infinite' | 'infinite-stats'
 
 async function submitGameToServer(user: User, result: TriviaGameResult): Promise<void> {
   const token = await user.getIdToken()
@@ -111,6 +112,7 @@ export default function TriviaPage() {
   const handleViewStats = () => setView('stats')
   const handleViewLeaderboard = () => setView('leaderboard')
   const handleStartInfinite = () => setView('infinite')
+  const handleViewInfiniteStats = () => setView('infinite-stats')
 
   const handleFinish = useCallback(
     (result: TriviaGameResult) => {
@@ -133,6 +135,10 @@ export default function TriviaPage() {
 
   if (view === 'infinite') {
     return <InfiniteGame onBack={handleBackToLanding} />
+  }
+
+  if (view === 'infinite-stats') {
+    return <InfiniteStats onBack={handleBackToLanding} />
   }
 
   if (view === 'playing') {
@@ -164,6 +170,7 @@ export default function TriviaPage() {
       onViewStats={handleViewStats}
       onViewLeaderboard={handleViewLeaderboard}
       onStartInfinite={handleStartInfinite}
+      onViewInfiniteStats={handleViewInfiniteStats}
       todayResult={todayResult}
     />
   )

--- a/src/lib/trivia/infiniteRuns.ts
+++ b/src/lib/trivia/infiniteRuns.ts
@@ -3,6 +3,7 @@ import { FieldValue } from 'firebase-admin/firestore'
 import { LIVES_START, applyAnswer } from '@/app/trivia/lib/infiniteScoring'
 import type { AnswerResult } from '@/app/trivia/lib/infiniteScoring'
 import { getFirestoreDb } from '@/lib/firebase/server'
+import { applyRunToAggregate } from '@/lib/trivia/triviaStats'
 
 export interface RunDoc {
   runId: string
@@ -62,7 +63,7 @@ export async function submitAnswer(params: {
   const seenRef = db.doc(`users/${uid}/seenQuestions/${questionId}`)
   const answeredByRef = db.doc(`aiQuestions/${questionId}/answeredBy/${uid}_${runId}`)
 
-  return db.runTransaction(async (tx) => {
+  const result = await db.runTransaction(async (tx) => {
     const runSnap = await tx.get(runRef)
     if (!runSnap.exists) throw new Error('Run not found')
     const run = runSnap.data() as RunDoc
@@ -77,7 +78,7 @@ export async function submitAnswer(params: {
     const isTrailblazer = correct && (qData.timesShown ?? 0) === 0
 
     // Compute result using pure function
-    const result = applyAnswer({
+    const txResult = applyAnswer({
       correct,
       trailblazer: isTrailblazer,
       elapsedMs,
@@ -115,7 +116,7 @@ export async function submitAnswer(params: {
     const answerEntry = {
       questionId,
       correct,
-      points: result.points,
+      points: txResult.points,
       timeMs: elapsedMs,
       trailblazer: isTrailblazer,
       answeredAt: now,
@@ -123,22 +124,31 @@ export async function submitAnswer(params: {
 
     // Update run doc
     const runUpdates: FirebaseFirestore.UpdateData<FirebaseFirestore.DocumentData> = {
-      score: result.score,
-      livesRemaining: result.livesRemaining,
-      currentStreak: result.currentStreak,
-      longestStreak: result.longestStreak,
+      score: txResult.score,
+      livesRemaining: txResult.livesRemaining,
+      currentStreak: txResult.currentStreak,
+      longestStreak: txResult.longestStreak,
       answers: FieldValue.arrayUnion(answerEntry),
     }
     if (isTrailblazer) {
       runUpdates.trailblazes = FieldValue.increment(1)
     }
-    if (result.runOver) {
+    if (txResult.runOver) {
       runUpdates.endedAt = now
     }
     tx.update(runRef, runUpdates)
 
-    return result
+    return { ...txResult, trailblazer: isTrailblazer }
   })
+
+  // Auto-finalize: apply aggregate stats outside the transaction (no nesting)
+  if (result.runOver) {
+    applyRunToAggregate(uid, runId).catch((err) =>
+      console.error('[submitAnswer] Failed to apply run to aggregate:', err)
+    )
+  }
+
+  return result
 }
 
 export async function endRun(uid: string, runId: string): Promise<void> {
@@ -147,6 +157,17 @@ export async function endRun(uid: string, runId: string): Promise<void> {
   const snap = await runRef.get()
   if (!snap.exists) throw new Error('Run not found')
   const data = snap.data()!
-  if (data.endedAt !== null) return // idempotent
+  if (data.endedAt !== null) {
+    // Run was already ended (e.g. auto-finalized when lives hit 0).
+    // Still attempt to apply stats in case they weren't applied yet
+    // (applyRunToAggregate is idempotent via statsApplied flag).
+    applyRunToAggregate(uid, runId).catch((err) =>
+      console.error('[endRun] Failed to apply run to aggregate:', err)
+    )
+    return
+  }
   await runRef.update({ endedAt: FieldValue.serverTimestamp() })
+  applyRunToAggregate(uid, runId).catch((err) =>
+    console.error('[endRun] Failed to apply run to aggregate:', err)
+  )
 }

--- a/src/lib/trivia/questionRemoval.ts
+++ b/src/lib/trivia/questionRemoval.ts
@@ -1,0 +1,85 @@
+import { FieldValue } from 'firebase-admin/firestore'
+import { getFirestoreDb } from '@/lib/firebase/server'
+
+export async function removeQuestion(questionId: string): Promise<{ affectedPlayers: number }> {
+  const db = getFirestoreDb()
+  const qRef = db.doc(`aiQuestions/${questionId}`)
+
+  const qSnap = await qRef.get()
+  if (!qSnap.exists) throw new Error('Question not found')
+  if (qSnap.data()!.status === 'removed') return { affectedPlayers: 0 } // idempotent
+
+  // Set status to removed
+  await qRef.update({ status: 'removed' })
+
+  // Walk answeredBy reverse index
+  const answeredBySnap = await db.collection(`aiQuestions/${questionId}/answeredBy`).get()
+  let affectedPlayers = 0
+
+  for (const abDoc of answeredBySnap.docs) {
+    const { uid, runId, correct } = abDoc.data()
+    affectedPlayers++
+
+    try {
+      // Load the run
+      const runRef = db.doc(`users/${uid}/triviaInfinite/${runId}`)
+      const runSnap = await runRef.get()
+      if (!runSnap.exists) continue
+      const run = runSnap.data()!
+
+      // Find and remove the answer entry
+      const answers = run.answers as Array<{ questionId: string; correct: boolean; points: number; timeMs: number; trailblazer: boolean }>
+      const answerIdx = answers.findIndex(a => a.questionId === questionId)
+      if (answerIdx === -1) continue
+
+      const removedAnswer = answers[answerIdx]
+      const newAnswers = [...answers.slice(0, answerIdx), ...answers.slice(answerIdx + 1)]
+
+      // Recompute score (simple sum of remaining points)
+      const newScore = newAnswers.reduce((sum, a) => sum + a.points, 0)
+
+      await runRef.update({
+        answers: newAnswers,
+        score: newScore,
+      })
+
+      // Decrement aggregate stats
+      const aggRef = db.doc(`users/${uid}/triviaStats/aggregate`)
+      const aggSnap = await aggRef.get()
+      if (aggSnap.exists) {
+        const qData = qSnap.data()!
+        const updates: Record<string, unknown> = {
+          totalAnswered: FieldValue.increment(-1),
+          totalTimeMs: FieldValue.increment(-removedAnswer.timeMs),
+        }
+        if (removedAnswer.correct) {
+          updates.totalCorrect = FieldValue.increment(-1)
+        }
+        if (removedAnswer.trailblazer) {
+          updates.trailblazerCount = FieldValue.increment(-1)
+        }
+        // Note: byCategory and byDifficulty decrements use the question's category/difficulty
+        if (qData.category && qData.difficulty) {
+          updates[`byCategory.${qData.category}.answered`] = FieldValue.increment(-1)
+          if (removedAnswer.correct) {
+            updates[`byCategory.${qData.category}.correct`] = FieldValue.increment(-1)
+          }
+          updates[`byCategory.${qData.category}.totalTimeMs`] = FieldValue.increment(-removedAnswer.timeMs)
+          updates[`byDifficulty.${qData.difficulty}.answered`] = FieldValue.increment(-1)
+          if (removedAnswer.correct) {
+            updates[`byDifficulty.${qData.difficulty}.correct`] = FieldValue.increment(-1)
+          }
+        }
+        updates.lastUpdatedAt = FieldValue.serverTimestamp()
+        await aggRef.update(updates)
+      }
+
+      // Remove seenQuestions entry
+      await db.doc(`users/${uid}/seenQuestions/${questionId}`).delete()
+    } catch (err) {
+      console.error(`Failed to process removal for uid=${uid}, runId=${runId}:`, err)
+    }
+  }
+
+  return { affectedPlayers }
+}

--- a/src/lib/trivia/triviaStats.ts
+++ b/src/lib/trivia/triviaStats.ts
@@ -1,0 +1,175 @@
+import { FieldValue } from 'firebase-admin/firestore'
+
+import { getFirestoreDb } from '@/lib/firebase/server'
+import type { RunDoc } from '@/lib/trivia/infiniteRuns'
+
+export interface AggregateStats {
+  totalAnswered: number
+  totalCorrect: number
+  runsPlayed: number
+  bestRun: {
+    score: number
+    longestStreak: number
+    runId: string
+    endedAt: FirebaseFirestore.Timestamp | null
+  } | null
+  bestStreak: number
+  trailblazerCount: number
+  totalTimeMs: number
+  byCategory: Record<string, { answered: number; correct: number; totalTimeMs: number }>
+  byDifficulty: {
+    easy: { answered: number; correct: number }
+    medium: { answered: number; correct: number }
+    hard: { answered: number; correct: number }
+  }
+  lastUpdatedAt: FirebaseFirestore.Timestamp | null
+}
+
+const EMPTY_STATS: AggregateStats = {
+  totalAnswered: 0,
+  totalCorrect: 0,
+  runsPlayed: 0,
+  bestRun: null,
+  bestStreak: 0,
+  trailblazerCount: 0,
+  totalTimeMs: 0,
+  byCategory: {},
+  byDifficulty: {
+    easy: { answered: 0, correct: 0 },
+    medium: { answered: 0, correct: 0 },
+    hard: { answered: 0, correct: 0 },
+  },
+  lastUpdatedAt: null,
+}
+
+export async function getAggregateStats(uid: string): Promise<AggregateStats> {
+  const db = getFirestoreDb()
+  const snap = await db.doc(`users/${uid}/triviaStats/aggregate`).get()
+  if (!snap.exists) return { ...EMPTY_STATS }
+  return snap.data() as AggregateStats
+}
+
+// Called at run finalization. Reads the run doc, walks its answers[],
+// and atomically updates the aggregate doc. Idempotent via statsApplied flag.
+export async function applyRunToAggregate(uid: string, runId: string): Promise<void> {
+  const db = getFirestoreDb()
+  const runRef = db.doc(`users/${uid}/triviaInfinite/${runId}`)
+  const aggRef = db.doc(`users/${uid}/triviaStats/aggregate`)
+
+  await db.runTransaction(async (tx) => {
+    const runSnap = await tx.get(runRef)
+    if (!runSnap.exists) throw new Error('Run not found')
+    const run = runSnap.data() as RunDoc & { statsApplied?: boolean }
+
+    // Idempotency: skip if already applied
+    if (run.statsApplied === true) return
+
+    const aggSnap = await tx.get(aggRef)
+    const agg: AggregateStats = aggSnap.exists
+      ? (aggSnap.data() as AggregateStats)
+      : { ...EMPTY_STATS }
+
+    // Batch-read all question docs referenced by answers
+    const questionIds = run.answers.map((a) => a.questionId)
+    const questionRefs = questionIds.map((id) => db.doc(`aiQuestions/${id}`))
+    const questionSnaps = questionRefs.length > 0 ? await tx.getAll(...questionRefs) : []
+    const questionMap = new Map<string, { category: string; difficulty: 'easy' | 'medium' | 'hard' }>()
+    for (const qs of questionSnaps) {
+      if (qs.exists) {
+        const qd = qs.data()!
+        questionMap.set(qs.id, { category: qd.category, difficulty: qd.difficulty })
+      }
+    }
+
+    // Accumulate deltas from this run's answers
+    let totalAnswered = 0
+    let totalCorrect = 0
+    let totalTimeMs = 0
+    let trailblazerCount = 0
+    const byCategory: Record<string, { answered: number; correct: number; totalTimeMs: number }> = {}
+    const byDifficulty: Record<string, { answered: number; correct: number }> = {
+      easy: { answered: 0, correct: 0 },
+      medium: { answered: 0, correct: 0 },
+      hard: { answered: 0, correct: 0 },
+    }
+
+    for (const answer of run.answers) {
+      totalAnswered += 1
+      if (answer.correct) totalCorrect += 1
+      totalTimeMs += answer.timeMs
+      if (answer.trailblazer) trailblazerCount += 1
+
+      const qInfo = questionMap.get(answer.questionId)
+      if (qInfo) {
+        // Category
+        if (!byCategory[qInfo.category]) {
+          byCategory[qInfo.category] = { answered: 0, correct: 0, totalTimeMs: 0 }
+        }
+        byCategory[qInfo.category].answered += 1
+        if (answer.correct) byCategory[qInfo.category].correct += 1
+        byCategory[qInfo.category].totalTimeMs += answer.timeMs
+
+        // Difficulty
+        byDifficulty[qInfo.difficulty].answered += 1
+        if (answer.correct) byDifficulty[qInfo.difficulty].correct += 1
+      }
+    }
+
+    // Merge byCategory: start from existing, add deltas
+    const mergedByCategory: Record<string, { answered: number; correct: number; totalTimeMs: number }> = {}
+    for (const [cat, val] of Object.entries(agg.byCategory)) {
+      mergedByCategory[cat] = { ...val }
+    }
+    for (const [cat, deltas] of Object.entries(byCategory)) {
+      if (!mergedByCategory[cat]) {
+        mergedByCategory[cat] = { answered: 0, correct: 0, totalTimeMs: 0 }
+      }
+      mergedByCategory[cat].answered += deltas.answered
+      mergedByCategory[cat].correct += deltas.correct
+      mergedByCategory[cat].totalTimeMs += deltas.totalTimeMs
+    }
+
+    // Build merged aggregate
+    const newAgg: AggregateStats = {
+      totalAnswered: agg.totalAnswered + totalAnswered,
+      totalCorrect: agg.totalCorrect + totalCorrect,
+      runsPlayed: agg.runsPlayed + 1,
+      bestRun: agg.bestRun,
+      bestStreak: Math.max(agg.bestStreak, run.longestStreak),
+      trailblazerCount: agg.trailblazerCount + trailblazerCount,
+      totalTimeMs: agg.totalTimeMs + totalTimeMs,
+      byCategory: mergedByCategory,
+      byDifficulty: {
+        easy: {
+          answered: agg.byDifficulty.easy.answered + byDifficulty.easy.answered,
+          correct: agg.byDifficulty.easy.correct + byDifficulty.easy.correct,
+        },
+        medium: {
+          answered: agg.byDifficulty.medium.answered + byDifficulty.medium.answered,
+          correct: agg.byDifficulty.medium.correct + byDifficulty.medium.correct,
+        },
+        hard: {
+          answered: agg.byDifficulty.hard.answered + byDifficulty.hard.answered,
+          correct: agg.byDifficulty.hard.correct + byDifficulty.hard.correct,
+        },
+      },
+      lastUpdatedAt: null, // overwritten by server timestamp below
+    }
+
+    // Update bestRun if this run's score exceeds the current best
+    if (!newAgg.bestRun || run.score > newAgg.bestRun.score) {
+      newAgg.bestRun = {
+        score: run.score,
+        longestStreak: run.longestStreak,
+        runId: run.runId,
+        endedAt: run.endedAt,
+      }
+    }
+
+    // Write aggregate with server timestamp
+    tx.set(aggRef, { ...newAgg, lastUpdatedAt: FieldValue.serverTimestamp() })
+
+    // Mark the run as having its stats applied (idempotency guard)
+    tx.update(runRef, { statsApplied: true })
+  })
+}


### PR DESCRIPTION
## Summary

Implements issue #573 — question quality signals and removal cascade for Infinite Trivia.

- **QuestionRating** — thumbs up/down per question in end-of-run summary, optimistic UI with rollback, writes `ratings/{uid}` subcollection
- **FlagQuestion** — flag icon + modal with 4 reason types (wrong answer, ambiguous, inappropriate, other with note), writes `flags/{uid}` subcollection
- **Flag API** (`POST /questions/{id}/flag`) — transactional `flaggedCount` increment, auto-flips to `'flagged'` status at threshold (3 flags)
- **Rate API** (`POST /questions/{id}/rate`) — up/down/null vote, overwrite-on-flip
- **Question removal cascade** (`questionRemoval.ts`) — sets `status='removed'`, walks `answeredBy` reverse index, removes answer from each affected run, recomputes score, decrements aggregate stats by category/difficulty, deletes `seenQuestions` entry. Idempotent.
- **Admin scripts** — `list-flagged-questions.ts` (prints flagged questions + reasons), `remove-ai-question.ts <id>` (runs cascade)
- **Client tracking** — added `questionId` to client-side answers array for rating/flag UI
- **Firestore rules** — deny client access to `flags` and `ratings` subcollections

Depends on #620 (Stats aggregate)
Closes #573

## Test plan

- [ ] `npx tsc --noEmit` passes (verified locally)
- [ ] Rating up/down toggles correctly, persists on refresh
- [ ] Flag modal submits correctly, shows "Reported" after
- [ ] 3 flags → question status flips to 'flagged', excluded from sampler
- [ ] `remove-ai-question.ts <id>` cascades: run score decremented, aggregate stats decremented, seenQuestions cleaned
- [ ] Re-running removal on same question is a no-op
- [ ] Firestore rules deny client direct access to flags/ratings subcollections

🤖 Generated with [Claude Code](https://claude.com/claude-code)