### PR TITLE
feat: Infinite Trivia 6 — Practice mode

### DIFF
--- a/src/app/trivia/components/InfiniteGame.tsx
+++ b/src/app/trivia/components/InfiniteGame.tsx
@@ -1,6 +1,7 @@
 'use client'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { useInfiniteRun } from '@/app/trivia/hooks/useInfiniteRun'
+import type { InfiniteMode } from '@/app/trivia/hooks/useInfiniteRun'
 import { InfiniteHUD } from './InfiniteHUD'
 import { InfiniteQuestionCard } from './InfiniteQuestionCard'
 import { InfiniteRunSummary } from './InfiniteRunSummary'
@@ -10,9 +11,10 @@ const TIME_LIMIT = 60 // 60 seconds for AI free-text
 
 interface Props {
   onBack: () => void
+  mode?: InfiniteMode
 }
 
-export function InfiniteGame({ onBack }: Props) {
+export function InfiniteGame({ onBack, mode = 'scored' }: Props) {
   const { state, startRun, submitAnswer, nextQuestion, endRun } = useInfiniteRun()
   const [timeRemaining, setTimeRemaining] = useState(TIME_LIMIT)
   const timerRef = useRef<ReturnType<typeof setInterval> | null>(null)
@@ -20,7 +22,7 @@ export function InfiniteGame({ onBack }: Props) {
 
   // Start run on mount
   useEffect(() => {
-    startRun()
+    startRun(mode)
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
@@ -54,8 +56,8 @@ export function InfiniteGame({ onBack }: Props) {
   }, [endRun])
 
   const handlePlayAgain = useCallback(() => {
-    startRun()
-  }, [startRun])
+    startRun(mode)
+  }, [startRun, mode])
 
   // Loading state
   if (state.phase === 'loading' || state.phase === 'idle') {
@@ -92,7 +94,7 @@ export function InfiniteGame({ onBack }: Props) {
 
   // End of run
   if (state.phase === 'ended') {
-    return <InfiniteRunSummary state={state} onPlayAgain={handlePlayAgain} onBack={onBack} />
+    return <InfiniteRunSummary state={state} onPlayAgain={handlePlayAgain} onBack={onBack} mode={state.mode} />
   }
 
   // Playing or answered
@@ -108,6 +110,7 @@ export function InfiniteGame({ onBack }: Props) {
         timeLimit={TIME_LIMIT}
         onFlee={handleFlee}
         isPlaying={state.phase === 'playing'}
+        mode={state.mode}
       />
 
       <InfiniteQuestionCard

--- a/src/app/trivia/components/InfiniteHUD.tsx
+++ b/src/app/trivia/components/InfiniteHUD.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react'
 import { ChunkyButton } from '@/components/ui/chunky-button'
 import { Pill, ScoreChip } from '@/components/ui/pill'
 import { computeStreakMultiplier } from '@/app/trivia/lib/infiniteScoring'
+import type { InfiniteMode } from '@/app/trivia/hooks/useInfiniteRun'
 
 interface InfiniteHUDProps {
   livesRemaining: number
@@ -12,6 +13,7 @@ interface InfiniteHUDProps {
   timeLimit: number
   onFlee: () => void
   isPlaying: boolean
+  mode?: InfiniteMode
 }
 
 export function InfiniteHUD({
@@ -22,6 +24,7 @@ export function InfiniteHUD({
   timeLimit,
   onFlee,
   isPlaying,
+  mode = 'scored',
 }: InfiniteHUDProps) {
   const [showFleeConfirm, setShowFleeConfirm] = useState(false)
   const mult = computeStreakMultiplier(currentStreak)
@@ -54,17 +57,21 @@ export function InfiniteHUD({
           <span className="hidden sm:inline">Flee</span>
         </ChunkyButton>
 
-        {/* Lives */}
-        <div className="flex items-center gap-1" aria-label={`${livesRemaining} lives remaining`}>
-          {[0, 1, 2].map(i => (
-            <span
-              key={i}
-              className={`text-lg transition-opacity ${i < livesRemaining ? 'opacity-100' : 'opacity-20'}`}
-            >
-              {i < livesRemaining ? '❤️' : '🖤'}
-            </span>
-          ))}
-        </div>
+        {/* Lives or Practice indicator */}
+        {mode === 'practice' ? (
+          <Pill tone="info" size="sm">Practice</Pill>
+        ) : (
+          <div className="flex items-center gap-1" aria-label={`${livesRemaining} lives remaining`}>
+            {[0, 1, 2].map(i => (
+              <span
+                key={i}
+                className={`text-lg transition-opacity ${i < livesRemaining ? 'opacity-100' : 'opacity-20'}`}
+              >
+                {i < livesRemaining ? '❤️' : '🖤'}
+              </span>
+            ))}
+          </div>
+        )}
 
         {/* Streak + multiplier */}
         <div className="flex items-center gap-1.5">

--- a/src/app/trivia/components/InfiniteRunSummary.tsx
+++ b/src/app/trivia/components/InfiniteRunSummary.tsx
@@ -7,12 +7,13 @@ import { useAuth } from '@/hooks/useAuth'
 import { SignInCard } from './SignInCTA'
 import { QuestionRating } from './QuestionRating'
 import { FlagQuestion } from './FlagQuestion'
-import type { InfiniteRunState } from '@/app/trivia/hooks/useInfiniteRun'
+import type { InfiniteRunState, InfiniteMode } from '@/app/trivia/hooks/useInfiniteRun'
 
 interface Props {
   state: InfiniteRunState
   onPlayAgain: () => void
   onBack: () => void
+  mode?: InfiniteMode
 }
 
 function formatTime(ms: number): string {
@@ -28,7 +29,7 @@ function getRunRating(longestStreak: number): string {
   return 'Keep Exploring!'
 }
 
-export function InfiniteRunSummary({ state, onPlayAgain, onBack }: Props) {
+export function InfiniteRunSummary({ state, onPlayAgain, onBack, mode = 'scored' }: Props) {
   const { user } = useAuth()
   const [copied, setCopied] = useState(false)
 
@@ -57,7 +58,14 @@ export function InfiniteRunSummary({ state, onPlayAgain, onBack }: Props) {
         <h2 className="font-headline text-headline-lg text-ds-tertiary drop-shadow-[0_4px_0_var(--surface-container-lowest)] mb-1">
           {getRunRating(state.longestStreak)}
         </h2>
-        <p className="text-on-surface/50 text-sm">Run Complete</p>
+        {mode === 'practice' ? (
+          <div className="flex flex-col items-center gap-1">
+            <Pill tone="info" size="sm">Practice Run</Pill>
+            <p className="text-on-surface/50 text-xs mt-1">Practice runs don&apos;t count toward stats.</p>
+          </div>
+        ) : (
+          <p className="text-on-surface/50 text-sm">Run Complete</p>
+        )}
       </div>
 
       {/* Hero: Longest Streak */}

--- a/src/app/trivia/components/TriviaLanding.tsx
+++ b/src/app/trivia/components/TriviaLanding.tsx
@@ -22,6 +22,7 @@ export function TriviaLanding({
   onViewLeaderboard,
   onStartInfinite,
   onViewInfiniteStats,
+  onStartPractice,
   todayResult,
 }: {
   onStartGame?: () => void
@@ -29,6 +30,7 @@ export function TriviaLanding({
   onViewLeaderboard?: () => void
   onStartInfinite?: () => void
   onViewInfiniteStats?: () => void
+  onStartPractice?: () => void
   todayResult: TriviaGameResult | null
 }) {
   const { user, loading: authLoading, configured: authConfigured, signOut } = useAuth()
@@ -166,6 +168,14 @@ export function TriviaLanding({
             onClick={onStartInfinite}
           >
             Enter the Infinite Cavern
+          </ChunkyButton>
+          <ChunkyButton
+            variant="ghost"
+            size="sm"
+            className="w-full"
+            onClick={onStartPractice}
+          >
+            Practice Mode
           </ChunkyButton>
         </ChunkyCardContent>
       </ChunkyCard>

--- a/src/app/trivia/hooks/useInfiniteRun.ts
+++ b/src/app/trivia/hooks/useInfiniteRun.ts
@@ -4,6 +4,7 @@ import { useAuth } from '@/hooks/useAuth'
 import { LIVES_START, type AnswerResult } from '@/app/trivia/lib/infiniteScoring'
 
 export type InfinitePhase = 'idle' | 'loading' | 'playing' | 'answering' | 'answered' | 'exhausted' | 'ended' | 'error'
+export type InfiniteMode = 'scored' | 'practice'
 
 export interface InfiniteQuestion {
   id: string
@@ -15,6 +16,7 @@ export interface InfiniteQuestion {
 
 export interface InfiniteRunState {
   phase: InfinitePhase
+  mode: InfiniteMode
   runId: string | null
   question: InfiniteQuestion | null
   livesRemaining: number
@@ -31,6 +33,7 @@ export interface InfiniteRunState {
 export function useInfiniteRun() {
   const [state, setState] = useState<InfiniteRunState>({
     phase: 'idle',
+    mode: 'scored',
     runId: null,
     question: null,
     livesRemaining: LIVES_START,
@@ -55,14 +58,14 @@ export function useInfiniteRun() {
     }
   }, [user])
 
-  const startRun = useCallback(async () => {
-    setState(s => ({ ...s, phase: 'loading', error: null }))
+  const startRun = useCallback(async (mode: InfiniteMode = 'scored') => {
+    setState(s => ({ ...s, phase: 'loading', mode, error: null }))
     try {
       const headers = await getAuthHeaders()
       const res = await fetch('/api/v1/trivia/infinite/runs', {
         method: 'POST',
         headers,
-        body: JSON.stringify({ mode: 'scored' }),
+        body: JSON.stringify({ mode }),
       })
       if (!res.ok) throw new Error('Failed to start run')
       const data = await res.json()
@@ -80,6 +83,7 @@ export function useInfiniteRun() {
       setState(s => ({
         ...s,
         phase: 'playing',
+        mode,
         runId: data.runId,
         question,
         livesRemaining: data.livesRemaining,

--- a/src/app/trivia/infinite/page.tsx
+++ b/src/app/trivia/infinite/page.tsx
@@ -1,8 +1,21 @@
 'use client'
-import { useRouter } from 'next/navigation'
+import { useRouter, useSearchParams } from 'next/navigation'
+import { Suspense } from 'react'
 import { InfiniteGame } from '@/app/trivia/components/InfiniteGame'
+import type { InfiniteMode } from '@/app/trivia/hooks/useInfiniteRun'
+
+function InfiniteTriviaPageInner() {
+  const router = useRouter()
+  const searchParams = useSearchParams()
+  const modeParam = searchParams.get('mode')
+  const mode: InfiniteMode = modeParam === 'practice' ? 'practice' : 'scored'
+  return <InfiniteGame onBack={() => router.push('/trivia')} mode={mode} />
+}
 
 export default function InfiniteTriviaPage() {
-  const router = useRouter()
-  return <InfiniteGame onBack={() => router.push('/trivia')} />
+  return (
+    <Suspense fallback={null}>
+      <InfiniteTriviaPageInner />
+    </Suspense>
+  )
 }

--- a/src/app/trivia/page.tsx
+++ b/src/app/trivia/page.tsx
@@ -24,7 +24,7 @@ import { TriviaStats } from './components/TriviaStats'
 import type { TriviaGameResult } from './models/trivia'
 import type { User } from 'firebase/auth'
 
-type View = 'landing' | 'playing' | 'results' | 'stats' | 'leaderboard' | 'infinite' | 'infinite-stats'
+type View = 'landing' | 'playing' | 'results' | 'stats' | 'leaderboard' | 'infinite' | 'infinite-stats' | 'practice'
 
 async function submitGameToServer(user: User, result: TriviaGameResult): Promise<void> {
   const token = await user.getIdToken()
@@ -113,6 +113,7 @@ export default function TriviaPage() {
   const handleViewLeaderboard = () => setView('leaderboard')
   const handleStartInfinite = () => setView('infinite')
   const handleViewInfiniteStats = () => setView('infinite-stats')
+  const handleStartPractice = () => setView('practice')
 
   const handleFinish = useCallback(
     (result: TriviaGameResult) => {
@@ -135,6 +136,10 @@ export default function TriviaPage() {
 
   if (view === 'infinite') {
     return <InfiniteGame onBack={handleBackToLanding} />
+  }
+
+  if (view === 'practice') {
+    return <InfiniteGame onBack={handleBackToLanding} mode="practice" />
   }
 
   if (view === 'infinite-stats') {
@@ -171,6 +176,7 @@ export default function TriviaPage() {
       onViewLeaderboard={handleViewLeaderboard}
       onStartInfinite={handleStartInfinite}
       onViewInfiniteStats={handleViewInfiniteStats}
+      onStartPractice={handleStartPractice}
       todayResult={todayResult}
     />
   )

--- a/src/lib/trivia/triviaStats.ts
+++ b/src/lib/trivia/triviaStats.ts
@@ -61,6 +61,9 @@ export async function applyRunToAggregate(uid: string, runId: string): Promise<v
     if (!runSnap.exists) throw new Error('Run not found')
     const run = runSnap.data() as RunDoc & { statsApplied?: boolean }
 
+    // Practice runs don't count toward stats
+    if (run.mode === 'practice') return
+
     // Idempotency: skip if already applied
     if (run.statsApplied === true) return
 


### PR DESCRIPTION
## Summary

Implements issue #574 — practice mode for Infinite Trivia (same question pool, no lives, no aggregate writes).

- **`useInfiniteRun`** — added `InfiniteMode` type, `mode` field in state, `startRun` accepts mode param
- **`InfiniteGame`** — accepts `mode` prop, passes to child components
- **`InfiniteHUD`** — practice mode replaces hearts with "Practice" pill indicator
- **`InfiniteRunSummary`** — shows "Practice Run" label + "Practice runs don't count toward stats" note
- **`TriviaLanding`** — "Practice Mode" ghost button on Endless Run card
- **`page.tsx`** — added `'practice'` view type with routing
- **`/trivia/infinite`** — reads `?mode=practice` query param via `useSearchParams`
- **`triviaStats.ts`** — `applyRunToAggregate` early-returns for practice mode

Closes #574

## Test plan

- [ ] `npx tsc --noEmit` passes (verified locally)
- [ ] Practice run never ends from wrong answers (lives not decremented)
- [ ] HUD shows "Practice" pill instead of hearts
- [ ] End-of-run summary shows "Practice Run" label
- [ ] Aggregate stats unchanged after practice run
- [ ] `seenQuestions` still written during practice
- [ ] Rating + flag buttons work in practice mode
- [ ] `/trivia/infinite?mode=practice` works directly

🤖 Generated with [Claude Code](https://claude.com/claude-code)