### PR TITLE
feat: Infinite Trivia 7 — Polish (exhaustion, difficulty docs, pagination)

### DIFF
--- a/src/app/api/v1/trivia/infinite/next/route.ts
+++ b/src/app/api/v1/trivia/infinite/next/route.ts
@@ -3,6 +3,7 @@ import { type NextRequest, NextResponse } from 'next/server'
 import { verifyRequestAuth } from '@/lib/api/auth'
 import { sampleNextQuestion } from '@/lib/trivia/sampler'
 import type { AIQuestion } from '@/lib/trivia/aiQuestions'
+import { trackExhaustion } from '@/lib/trivia/triviaStats'
 
 // GET /api/v1/trivia/infinite/next?streak=N
 export async function GET(request: NextRequest) {
@@ -23,6 +24,7 @@ export async function GET(request: NextRequest) {
 
     if (question === null) {
       // Library exhausted — no unseen questions remain
+      await trackExhaustion(auth.claims.uid)
       return new NextResponse(null, { status: 204 })
     }
 

--- a/src/app/trivia/components/InfiniteExhaustedScreen.tsx
+++ b/src/app/trivia/components/InfiniteExhaustedScreen.tsx
@@ -1,0 +1,62 @@
+'use client'
+import { ChunkyButton } from '@/components/ui/chunky-button'
+import { ChunkyCard, ChunkyCardContent } from '@/components/ui/chunky-card'
+import { useAuth } from '@/hooks/useAuth'
+import { SignInCard } from './SignInCTA'
+
+interface Props {
+  onBack: () => void
+  score?: number
+  questionsAnswered?: number
+}
+
+export function InfiniteExhaustedScreen({ onBack, score, questionsAnswered }: Props) {
+  const { user } = useAuth()
+
+  return (
+    <div className="flex flex-col items-center gap-6 max-w-lg mx-auto py-8">
+      <div className="text-center">
+        <div className="text-6xl mb-4">✨</div>
+        <h2 className="font-headline text-headline-lg text-ds-tertiary drop-shadow-[0_4px_0_var(--surface-container-lowest)] mb-2">
+          The Cave Rests
+        </h2>
+        <p className="text-on-surface/60 text-lg leading-relaxed max-w-sm mx-auto">
+          You have explored every question the cavern holds. The stars are still writing new ones — return soon, traveler.
+        </p>
+      </div>
+
+      {(score !== undefined || questionsAnswered !== undefined) && (
+        <ChunkyCard variant="surface-variant" className="w-full bg-surface-container/80 border-outline-variant">
+          <ChunkyCardContent className="pt-6 text-center">
+            <p className="text-on-surface/50 text-sm mb-2">This run</p>
+            <div className="grid grid-cols-2 gap-3">
+              {score !== undefined && (
+                <div className="text-center">
+                  <div className="text-2xl font-bold text-ds-tertiary">{score.toLocaleString()}</div>
+                  <div className="text-on-surface/50 text-xs">Score</div>
+                </div>
+              )}
+              {questionsAnswered !== undefined && (
+                <div className="text-center">
+                  <div className="text-2xl font-bold text-on-surface">{questionsAnswered}</div>
+                  <div className="text-on-surface/50 text-xs">Questions</div>
+                </div>
+              )}
+            </div>
+          </ChunkyCardContent>
+        </ChunkyCard>
+      )}
+
+      {!user && (
+        <SignInCard
+          title="🔔 Want to know when new questions arrive?"
+          description="Sign in and we'll let you know when the cave has more to discover."
+        />
+      )}
+
+      <ChunkyButton variant="secondary" size="lg" className="w-full" onClick={onBack}>
+        Back to Trivia
+      </ChunkyButton>
+    </div>
+  )
+}

--- a/src/app/trivia/components/InfiniteGame.tsx
+++ b/src/app/trivia/components/InfiniteGame.tsx
@@ -5,6 +5,7 @@ import type { InfiniteMode } from '@/app/trivia/hooks/useInfiniteRun'
 import { InfiniteHUD } from './InfiniteHUD'
 import { InfiniteQuestionCard } from './InfiniteQuestionCard'
 import { InfiniteRunSummary } from './InfiniteRunSummary'
+import { InfiniteExhaustedScreen } from './InfiniteExhaustedScreen'
 import { ChunkyButton } from '@/components/ui/chunky-button'
 
 const TIME_LIMIT = 60 // 60 seconds for AI free-text
@@ -82,13 +83,11 @@ export function InfiniteGame({ onBack, mode = 'scored' }: Props) {
   // Exhausted state
   if (state.phase === 'exhausted') {
     return (
-      <div className="flex flex-col items-center gap-4 py-8 max-w-lg mx-auto">
-        <h2 className="font-headline text-headline-lg text-ds-tertiary">The Cave Rests</h2>
-        <p className="text-on-surface/60 text-center">
-          You have explored every question in the cavern. New discoveries await — return soon.
-        </p>
-        <ChunkyButton variant="secondary" onClick={onBack}>Back to Trivia</ChunkyButton>
-      </div>
+      <InfiniteExhaustedScreen
+        onBack={onBack}
+        score={state.score}
+        questionsAnswered={state.questionsAnswered}
+      />
     )
   }
 

--- a/src/app/trivia/components/InfiniteRunSummary.tsx
+++ b/src/app/trivia/components/InfiniteRunSummary.tsx
@@ -29,9 +29,12 @@ function getRunRating(longestStreak: number): string {
   return 'Keep Exploring!'
 }
 
+const ANSWERS_PAGE_SIZE = 20
+
 export function InfiniteRunSummary({ state, onPlayAgain, onBack, mode = 'scored' }: Props) {
   const { user } = useAuth()
   const [copied, setCopied] = useState(false)
+  const [showAllAnswers, setShowAllAnswers] = useState(false)
 
   const handleShare = async () => {
     const lines = [
@@ -108,8 +111,8 @@ export function InfiniteRunSummary({ state, onPlayAgain, onBack, mode = 'scored'
             <h3 className="text-on-surface/70 text-sm font-semibold mb-3 uppercase tracking-wide">
               Answer History
             </h3>
-            <div className="flex flex-col gap-2 max-h-64 overflow-y-auto">
-              {state.answers.map((a, i) => (
+            <div className="flex flex-col gap-2">
+              {(showAllAnswers ? state.answers : state.answers.slice(0, ANSWERS_PAGE_SIZE)).map((a, i) => (
                 <div key={i} className="flex items-center justify-between py-2 px-3 rounded bg-surface-dim/40">
                   <div className="flex items-center gap-3">
                     <span className="text-on-surface/50 text-sm font-mono w-4">{i + 1}</span>
@@ -129,6 +132,14 @@ export function InfiniteRunSummary({ state, onPlayAgain, onBack, mode = 'scored'
                 </div>
               ))}
             </div>
+            {state.answers.length > ANSWERS_PAGE_SIZE && !showAllAnswers && (
+              <button
+                className="mt-3 w-full text-on-surface/50 text-sm hover:text-on-surface/80 transition-colors py-1"
+                onClick={() => setShowAllAnswers(true)}
+              >
+                Show all {state.answers.length} answers
+              </button>
+            )}
           </ChunkyCardContent>
         </ChunkyCard>
       )}

--- a/src/lib/trivia/sampler.ts
+++ b/src/lib/trivia/sampler.ts
@@ -7,8 +7,28 @@ export interface SamplerOptions {
   type?: 'free-text' // v1 only free-text
 }
 
-// Difficulty weights by streak band
-// [easy%, medium%, hard%]
+/**
+ * Difficulty-bias curve for the sampler.
+ *
+ * Designed to feel progressively harder without sudden cliff-edges.
+ * The bands are:
+ *
+ *   Streak 0-4   → 60% easy, 30% medium, 10% hard   (onboarding)
+ *   Streak 5-9   → 30% easy, 40% medium, 30% hard   (warming up)
+ *   Streak 10-19 → 10% easy, 30% medium, 60% hard   (challenge zone)
+ *   Streak 20+   → 5% easy, 25% medium, 70% hard    (expert territory)
+ *
+ * Tuning notes (v1 — 2026-04-28):
+ * - No telemetry data yet; these are design estimates.
+ * - The 20+ band caps hard at 70% rather than 100% to prevent
+ *   frustration spirals where a single hard miss ends a long run.
+ * - Freshness bias (1/(1+timesShown)) ensures under-seen questions
+ *   surface first, preventing "greatest hits" stagnation.
+ * - Revisit after ~1 week of real run data using:
+ *     SELECT difficulty, AVG(correct::int), COUNT(*)
+ *     FROM answers JOIN questions ON ...
+ *     GROUP BY difficulty, streak_band
+ */
 function getDifficultyWeights(streak: number): [number, number, number] {
   if (streak >= 20) return [0.05, 0.25, 0.70]
   if (streak >= 10) return [0.10, 0.30, 0.60]

--- a/src/lib/trivia/triviaStats.ts
+++ b/src/lib/trivia/triviaStats.ts
@@ -22,6 +22,7 @@ export interface AggregateStats {
     medium: { answered: number; correct: number }
     hard: { answered: number; correct: number }
   }
+  exhaustionCount: number
   lastUpdatedAt: FirebaseFirestore.Timestamp | null
 }
 
@@ -39,6 +40,7 @@ const EMPTY_STATS: AggregateStats = {
     medium: { answered: 0, correct: 0 },
     hard: { answered: 0, correct: 0 },
   },
+  exhaustionCount: 0,
   lastUpdatedAt: null,
 }
 
@@ -156,6 +158,7 @@ export async function applyRunToAggregate(uid: string, runId: string): Promise<v
           correct: agg.byDifficulty.hard.correct + byDifficulty.hard.correct,
         },
       },
+      exhaustionCount: agg.exhaustionCount ?? 0,
       lastUpdatedAt: null, // overwritten by server timestamp below
     }
 
@@ -175,4 +178,15 @@ export async function applyRunToAggregate(uid: string, runId: string): Promise<v
     // Mark the run as having its stats applied (idempotency guard)
     tx.update(runRef, { statsApplied: true })
   })
+}
+
+export async function trackExhaustion(uid: string): Promise<void> {
+  const db = getFirestoreDb()
+  const aggRef = db.doc(`users/${uid}/triviaStats/aggregate`)
+  const snap = await aggRef.get()
+  if (snap.exists) {
+    await aggRef.update({ exhaustionCount: FieldValue.increment(1), lastUpdatedAt: FieldValue.serverTimestamp() })
+  } else {
+    await aggRef.set({ ...EMPTY_STATS, exhaustionCount: 1, lastUpdatedAt: FieldValue.serverTimestamp() })
+  }
 }


### PR DESCRIPTION
## Summary

Implements issue #575 — final polish for the Infinite Trivia epic.

- **InfiniteExhaustedScreen** — hand-crafted full-page state with cosmic-narrator copy ("The Cave Rests"), optional run stats display, sign-in CTA for anonymous users
- **Difficulty curve documentation** — comprehensive JSDoc on `getDifficultyWeights` documenting all 4 streak bands, tuning rationale, freshness bias, and SQL template for future telemetry
- **Exhaustion tracking** — `exhaustionCount` added to `AggregateStats`, `trackExhaustion(uid)` called on 204 responses to measure library depletion across users
- **Answer history pagination** — long runs (>20 answers) show first 20 with "Show all" button, replacing scroll overflow for better mobile UX
- Wired exhaustion screen into InfiniteGame replacing inline placeholder

**Deferred to follow-on:** OG share-image generation (ImageResponse), public share landing page (`/trivia/runs/{runId}`), and run resume (GET endpoint for reconnecting after network drop). These are valuable but can ship independently.

Closes #575

## Test plan

- [ ] `npx tsc --noEmit` passes (verified locally)
- [ ] Exhaustion screen shows when all questions are seen (204 from sampler)
- [ ] Exhaustion screen uses cosmic-narrator copy, not a generic error
- [ ] Anonymous exhaustion screen shows sign-in CTA
- [ ] Answer history shows "Show all N answers" button when >20 answers
- [ ] Difficulty curve comment block is accurate and helpful
- [ ] `exhaustionCount` increments in aggregate stats on 204

🤖 Generated with [Claude Code](https://claude.com/claude-code)