### PR TITLE
feat: Infinite Trivia 8 — On-demand generation + anonymous play

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -15,6 +15,24 @@
         { "fieldPath": "weekKey", "order": "ASCENDING" },
         { "fieldPath": "totalScore", "order": "DESCENDING" }
       ]
+    },
+    {
+      "collectionGroup": "aiQuestions",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "status", "order": "ASCENDING" },
+        { "fieldPath": "type", "order": "ASCENDING" },
+        { "fieldPath": "difficulty", "order": "ASCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "aiQuestions",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "status", "order": "ASCENDING" },
+        { "fieldPath": "type", "order": "ASCENDING" },
+        { "fieldPath": "timesShown", "order": "ASCENDING" }
+      ]
     }
   ],
   "fieldOverrides": [

--- a/firestore.rules
+++ b/firestore.rules
@@ -40,5 +40,7 @@ service cloud.firestore {
     // AI questions — server-only
     match /aiQuestions/{docId} { allow read, write: if false; }
     match /aiQuestions/{docId}/answeredBy/{entryId} { allow read, write: if false; }
+    match /aiQuestions/{docId}/flags/{uid}    { allow read, write: if false; }
+    match /aiQuestions/{docId}/ratings/{uid}  { allow read, write: if false; }
   }
 }

--- a/firestore.rules
+++ b/firestore.rules
@@ -18,6 +18,11 @@ service cloud.firestore {
       // Client must not query these directly.
       match /triviaDaily/{docId}  { allow read, write: if false; }
       match /triviaWeekly/{docId} { allow read, write: if false; }
+
+      // Infinite Trivia — server-only subcollections
+      match /seenQuestions/{qid}     { allow read, write: if false; }
+      match /triviaInfinite/{runId}  { allow read, write: if false; }
+      match /triviaStats/{docId}     { allow read, write: if false; }
     }
 
     // Nicknames uniqueness index — server only
@@ -31,5 +36,9 @@ service cloud.firestore {
     // server-side reads via /api/v1/tap-tap-adventure/leaderboard route.
     // Client does not read directly.
     match /adventure-scores/{docId} { allow read, write: if false; }
+
+    // AI questions — server-only
+    match /aiQuestions/{docId} { allow read, write: if false; }
+    match /aiQuestions/{docId}/answeredBy/{entryId} { allow read, write: if false; }
   }
 }

--- a/scripts/backfill-aiquestion-fields.ts
+++ b/scripts/backfill-aiquestion-fields.ts
@@ -1,0 +1,103 @@
+#!/usr/bin/env tsx
+/**
+ * Backfill new infinite-mode fields onto existing aiQuestions documents.
+ *
+ * For each doc in the `aiQuestions` collection that is missing any of the new
+ * fields (status, timesShown, timesCorrect, flaggedCount, avgTimeMs), this
+ * script sets sensible defaults using batched writes.
+ *
+ * Idempotent — safe to re-run. Docs that already have all fields are skipped.
+ *
+ * Usage:
+ *   npx tsx scripts/backfill-aiquestion-fields.ts
+ *
+ * Required env vars (same as the app):
+ *   FIREBASE_PROJECT_ID
+ *   FIREBASE_CLIENT_EMAIL
+ *   FIREBASE_PRIVATE_KEY
+ */
+
+import { cert, getApps, initializeApp } from 'firebase-admin/app'
+import { getFirestore, WriteBatch } from 'firebase-admin/firestore'
+
+const BATCH_SIZE = 400 // Firestore max is 500; stay well under
+
+function ensureApp() {
+  if (getApps().length > 0) return
+  const projectId = process.env.FIREBASE_PROJECT_ID
+  const clientEmail = process.env.FIREBASE_CLIENT_EMAIL
+  const privateKey = process.env.FIREBASE_PRIVATE_KEY?.replace(/\\n/g, '\n')
+  if (!projectId || !clientEmail || !privateKey) {
+    console.error(
+      'ERROR: Missing Firebase env vars. Set FIREBASE_PROJECT_ID, FIREBASE_CLIENT_EMAIL, FIREBASE_PRIVATE_KEY.'
+    )
+    process.exit(1)
+  }
+  initializeApp({ credential: cert({ projectId, clientEmail, privateKey }) })
+}
+
+async function main() {
+  ensureApp()
+  const db = getFirestore()
+
+  console.log('Fetching all aiQuestions documents...')
+  const snap = await db.collection('aiQuestions').get()
+  console.log(`Found ${snap.size} document(s).`)
+
+  const DEFAULTS = {
+    status: 'active',
+    timesShown: 0,
+    timesCorrect: 0,
+    flaggedCount: 0,
+    avgTimeMs: null,
+  } as const
+
+  let batch: WriteBatch = db.batch()
+  let batchCount = 0
+  let updatedTotal = 0
+  let skippedTotal = 0
+
+  for (const doc of snap.docs) {
+    const data = doc.data()
+    const missing: Partial<typeof DEFAULTS> = {}
+
+    for (const [field, defaultValue] of Object.entries(DEFAULTS) as Array<
+      [keyof typeof DEFAULTS, (typeof DEFAULTS)[keyof typeof DEFAULTS]]
+    >) {
+      if (!(field in data)) {
+        ;(missing as Record<string, unknown>)[field] = defaultValue
+      }
+    }
+
+    if (Object.keys(missing).length === 0) {
+      skippedTotal++
+      continue
+    }
+
+    batch.update(doc.ref, missing)
+    batchCount++
+    updatedTotal++
+
+    if (batchCount >= BATCH_SIZE) {
+      process.stdout.write(`Committing batch of ${batchCount}...`)
+      await batch.commit()
+      console.log(' done.')
+      batch = db.batch()
+      batchCount = 0
+    }
+  }
+
+  if (batchCount > 0) {
+    process.stdout.write(`Committing final batch of ${batchCount}...`)
+    await batch.commit()
+    console.log(' done.')
+  }
+
+  console.log('─'.repeat(60))
+  console.log(`Updated: ${updatedTotal}  |  Skipped (already complete): ${skippedTotal}`)
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})

--- a/scripts/list-flagged-questions.ts
+++ b/scripts/list-flagged-questions.ts
@@ -1,0 +1,73 @@
+#!/usr/bin/env tsx
+/**
+ * Lists all aiQuestions with status === 'flagged'.
+ *
+ * Usage:
+ *   npx tsx scripts/list-flagged-questions.ts
+ *
+ * Required env vars:
+ *   FIREBASE_PROJECT_ID
+ *   FIREBASE_CLIENT_EMAIL
+ *   FIREBASE_PRIVATE_KEY
+ */
+
+import { cert, getApps, initializeApp } from 'firebase-admin/app'
+import { getFirestore } from 'firebase-admin/firestore'
+
+function ensureApp() {
+  if (getApps().length > 0) return
+  const projectId = process.env.FIREBASE_PROJECT_ID
+  const clientEmail = process.env.FIREBASE_CLIENT_EMAIL
+  const privateKey = process.env.FIREBASE_PRIVATE_KEY?.replace(/\\n/g, '\n')
+  if (!projectId || !clientEmail || !privateKey) {
+    console.error(
+      'ERROR: Missing Firebase env vars. Set FIREBASE_PROJECT_ID, FIREBASE_CLIENT_EMAIL, FIREBASE_PRIVATE_KEY.'
+    )
+    process.exit(1)
+  }
+  initializeApp({ credential: cert({ projectId, clientEmail, privateKey }) })
+}
+
+async function main() {
+  ensureApp()
+  const db = getFirestore()
+
+  console.log('Querying flagged aiQuestions...')
+  const snap = await db.collection('aiQuestions').where('status', '==', 'flagged').get()
+  console.log(`Found ${snap.size} flagged question(s).\n`)
+
+  if (snap.size === 0) {
+    console.log('No flagged questions.')
+    return
+  }
+
+  for (const doc of snap.docs) {
+    const data = doc.data()
+    console.log('─'.repeat(60))
+    console.log(`ID:           ${doc.id}`)
+    console.log(`Question:     ${data.question}`)
+    console.log(`Category:     ${data.category}`)
+    console.log(`Difficulty:   ${data.difficulty}`)
+    console.log(`FlaggedCount: ${data.flaggedCount ?? 0}`)
+
+    // Fetch flag subcollection
+    const flagsSnap = await db.collection(`aiQuestions/${doc.id}/flags`).get()
+    if (flagsSnap.size > 0) {
+      console.log('Flags:')
+      for (const flagDoc of flagsSnap.docs) {
+        const f = flagDoc.data()
+        const at = f.flaggedAt?.toDate?.()?.toISOString() ?? 'unknown'
+        const noteStr = f.note ? ` | note: "${f.note}"` : ''
+        console.log(`  - uid=${flagDoc.id} reason=${f.reason}${noteStr} at=${at}`)
+      }
+    } else {
+      console.log('Flags:        (none in subcollection)')
+    }
+  }
+  console.log('─'.repeat(60))
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})

--- a/scripts/remove-ai-question.ts
+++ b/scripts/remove-ai-question.ts
@@ -1,0 +1,139 @@
+#!/usr/bin/env tsx
+/**
+ * Removes an AI question and cascades through affected players' runs and stats.
+ *
+ * Usage:
+ *   npx tsx scripts/remove-ai-question.ts <questionId>
+ *
+ * Required env vars:
+ *   FIREBASE_PROJECT_ID
+ *   FIREBASE_CLIENT_EMAIL
+ *   FIREBASE_PRIVATE_KEY
+ */
+
+import { cert, getApps, initializeApp } from 'firebase-admin/app'
+import { FieldValue, getFirestore } from 'firebase-admin/firestore'
+
+function ensureApp() {
+  if (getApps().length > 0) return
+  const projectId = process.env.FIREBASE_PROJECT_ID
+  const clientEmail = process.env.FIREBASE_CLIENT_EMAIL
+  const privateKey = process.env.FIREBASE_PRIVATE_KEY?.replace(/\\n/g, '\n')
+  if (!projectId || !clientEmail || !privateKey) {
+    console.error(
+      'ERROR: Missing Firebase env vars. Set FIREBASE_PROJECT_ID, FIREBASE_CLIENT_EMAIL, FIREBASE_PRIVATE_KEY.'
+    )
+    process.exit(1)
+  }
+  initializeApp({ credential: cert({ projectId, clientEmail, privateKey }) })
+}
+
+async function removeQuestion(questionId: string): Promise<{ affectedPlayers: number }> {
+  const db = getFirestore()
+  const qRef = db.doc(`aiQuestions/${questionId}`)
+
+  const qSnap = await qRef.get()
+  if (!qSnap.exists) throw new Error('Question not found')
+  if (qSnap.data()!.status === 'removed') {
+    console.log('Question is already removed. Nothing to do (idempotent).')
+    return { affectedPlayers: 0 }
+  }
+
+  // Set status to removed
+  await qRef.update({ status: 'removed' })
+  console.log(`Set aiQuestions/${questionId} status = 'removed'`)
+
+  // Walk answeredBy reverse index
+  const answeredBySnap = await db.collection(`aiQuestions/${questionId}/answeredBy`).get()
+  console.log(`Found ${answeredBySnap.size} answeredBy entries to process.`)
+
+  let affectedPlayers = 0
+
+  for (const abDoc of answeredBySnap.docs) {
+    const { uid, runId, correct } = abDoc.data()
+    affectedPlayers++
+
+    try {
+      const runRef = db.doc(`users/${uid}/triviaInfinite/${runId}`)
+      const runSnap = await runRef.get()
+      if (!runSnap.exists) {
+        console.log(`  [${uid}/${runId}] Run not found, skipping.`)
+        continue
+      }
+      const run = runSnap.data()!
+
+      const answers = run.answers as Array<{ questionId: string; correct: boolean; points: number; timeMs: number; trailblazer: boolean }>
+      const answerIdx = answers.findIndex(a => a.questionId === questionId)
+      if (answerIdx === -1) {
+        console.log(`  [${uid}/${runId}] Answer not found in run, skipping.`)
+        continue
+      }
+
+      const removedAnswer = answers[answerIdx]
+      const newAnswers = [...answers.slice(0, answerIdx), ...answers.slice(answerIdx + 1)]
+      const newScore = newAnswers.reduce((sum, a) => sum + a.points, 0)
+
+      await runRef.update({ answers: newAnswers, score: newScore })
+      console.log(`  [${uid}/${runId}] Removed answer, new score: ${newScore}`)
+
+      // Decrement aggregate stats
+      const aggRef = db.doc(`users/${uid}/triviaStats/aggregate`)
+      const aggSnap = await aggRef.get()
+      if (aggSnap.exists) {
+        const qData = qSnap.data()!
+        const updates: Record<string, unknown> = {
+          totalAnswered: FieldValue.increment(-1),
+          totalTimeMs: FieldValue.increment(-removedAnswer.timeMs),
+        }
+        if (removedAnswer.correct) {
+          updates.totalCorrect = FieldValue.increment(-1)
+        }
+        if (removedAnswer.trailblazer) {
+          updates.trailblazerCount = FieldValue.increment(-1)
+        }
+        if (qData.category && qData.difficulty) {
+          updates[`byCategory.${qData.category}.answered`] = FieldValue.increment(-1)
+          if (removedAnswer.correct) {
+            updates[`byCategory.${qData.category}.correct`] = FieldValue.increment(-1)
+          }
+          updates[`byCategory.${qData.category}.totalTimeMs`] = FieldValue.increment(-removedAnswer.timeMs)
+          updates[`byDifficulty.${qData.difficulty}.answered`] = FieldValue.increment(-1)
+          if (removedAnswer.correct) {
+            updates[`byDifficulty.${qData.difficulty}.correct`] = FieldValue.increment(-1)
+          }
+        }
+        updates.lastUpdatedAt = FieldValue.serverTimestamp()
+        await aggRef.update(updates)
+        console.log(`  [${uid}] Updated aggregate stats.`)
+      }
+
+      // Remove seenQuestions entry
+      await db.doc(`users/${uid}/seenQuestions/${questionId}`).delete()
+      console.log(`  [${uid}] Removed seenQuestions entry.`)
+    } catch (err) {
+      console.error(`  ERROR processing uid=${uid}, runId=${runId}:`, err)
+    }
+  }
+
+  return { affectedPlayers }
+}
+
+async function main() {
+  const questionId = process.argv[2]
+  if (!questionId) {
+    console.error('Usage: npx tsx scripts/remove-ai-question.ts <questionId>')
+    process.exit(1)
+  }
+
+  ensureApp()
+
+  console.log(`Removing question: ${questionId}`)
+  const { affectedPlayers } = await removeQuestion(questionId)
+  console.log('─'.repeat(60))
+  console.log(`Done. Affected players: ${affectedPlayers}`)
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})

--- a/scripts/seed-seen-questions.ts
+++ b/scripts/seed-seen-questions.ts
@@ -1,0 +1,84 @@
+#!/usr/bin/env tsx
+/**
+ * Mark every existing aiQuestions/* doc as "seen" for a single user.
+ *
+ * Used to test the on-demand generation fallback in Infinite Trivia without
+ * deleting any prod data. After running this for your uid, the sampler will
+ * find zero unseen questions for you and fall through to runtime generation
+ * on every /next request — every question you see during the test will be
+ * freshly minted by gpt-4o.
+ *
+ * Touches only `users/{uid}/seenQuestions/*`. Other users are unaffected.
+ * Daily Trivia (static JSON + `triviaDaily/*`) is untouched.
+ *
+ * Usage:
+ *   npx tsx --env-file=.env.local scripts/seed-seen-questions.ts <UID>
+ *
+ *   # If you don't have a .env.local:
+ *   FIREBASE_PROJECT_ID=... \
+ *   FIREBASE_CLIENT_EMAIL=... \
+ *   FIREBASE_PRIVATE_KEY=... \
+ *   npx tsx scripts/seed-seen-questions.ts <UID>
+ */
+
+import { cert, getApps, initializeApp } from 'firebase-admin/app'
+import { Timestamp, getFirestore } from 'firebase-admin/firestore'
+
+const BATCH_SIZE = 400
+
+function ensureApp(): void {
+  if (getApps().length) return
+  const projectId = process.env.FIREBASE_PROJECT_ID
+  const clientEmail = process.env.FIREBASE_CLIENT_EMAIL
+  const privateKey = process.env.FIREBASE_PRIVATE_KEY?.replace(/\\n/g, '\n')
+  if (!projectId || !clientEmail || !privateKey) {
+    throw new Error(
+      'Missing FIREBASE_PROJECT_ID / FIREBASE_CLIENT_EMAIL / FIREBASE_PRIVATE_KEY'
+    )
+  }
+  initializeApp({ credential: cert({ projectId, clientEmail, privateKey }) })
+}
+
+async function main() {
+  const uid = process.argv[2]
+  if (!uid) {
+    console.error('Usage: npx tsx --env-file=.env.local scripts/seed-seen-questions.ts <UID>')
+    process.exit(1)
+  }
+
+  ensureApp()
+  const db = getFirestore()
+
+  console.log(`Reading aiQuestions...`)
+  const snap = await db.collection('aiQuestions').get()
+  const ids = snap.docs.map((d) => d.id)
+  console.log(`  Found ${ids.length} questions`)
+
+  if (ids.length === 0) {
+    console.log('Nothing to seed. Either the pool is empty or rules block read.')
+    return
+  }
+
+  const now = Timestamp.now()
+  const seenCol = db.collection(`users/${uid}/seenQuestions`)
+
+  let written = 0
+  for (let i = 0; i < ids.length; i += BATCH_SIZE) {
+    const chunk = ids.slice(i, i + BATCH_SIZE)
+    const batch = db.batch()
+    for (const qid of chunk) {
+      batch.set(seenCol.doc(qid), { at: now, correct: true })
+    }
+    await batch.commit()
+    written += chunk.length
+    process.stdout.write(`  seeded ${written}/${ids.length}\r`)
+  }
+  process.stdout.write('\n')
+  console.log(`Done. ${written} seenQuestions docs written under users/${uid}/seenQuestions.`)
+  console.log('Now play /trivia/infinite — every question will be freshly generated.')
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})

--- a/src/app/api/v1/trivia/infinite/next/route.ts
+++ b/src/app/api/v1/trivia/infinite/next/route.ts
@@ -3,6 +3,7 @@ import { type NextRequest, NextResponse } from 'next/server'
 import { verifyRequestAuth } from '@/lib/api/auth'
 import { sampleNextQuestion } from '@/lib/trivia/sampler'
 import type { AIQuestion } from '@/lib/trivia/aiQuestions'
+import { trackExhaustion } from '@/lib/trivia/triviaStats'
 
 // GET /api/v1/trivia/infinite/next?streak=N
 export async function GET(request: NextRequest) {
@@ -23,6 +24,7 @@ export async function GET(request: NextRequest) {
 
     if (question === null) {
       // Library exhausted — no unseen questions remain
+      await trackExhaustion(auth.claims.uid)
       return new NextResponse(null, { status: 204 })
     }
 

--- a/src/app/api/v1/trivia/infinite/next/route.ts
+++ b/src/app/api/v1/trivia/infinite/next/route.ts
@@ -1,0 +1,38 @@
+import { type NextRequest, NextResponse } from 'next/server'
+
+import { verifyRequestAuth } from '@/lib/api/auth'
+import { sampleNextQuestion } from '@/lib/trivia/sampler'
+import type { AIQuestion } from '@/lib/trivia/aiQuestions'
+
+// GET /api/v1/trivia/infinite/next?streak=N
+export async function GET(request: NextRequest) {
+  const auth = await verifyRequestAuth(request)
+  if ('error' in auth) return auth.error
+
+  const { searchParams } = new URL(request.url)
+  const streakParam = searchParams.get('streak')
+  const streak = streakParam !== null ? parseInt(streakParam, 10) : 0
+  const parsedStreak = isNaN(streak) || streak < 0 ? 0 : streak
+
+  try {
+    const question = await sampleNextQuestion({
+      uid: auth.claims.uid,
+      streak: parsedStreak,
+      type: 'free-text',
+    })
+
+    if (question === null) {
+      // Library exhausted — no unseen questions remain
+      return new NextResponse(null, { status: 204 })
+    }
+
+    // Strip correctAnswer before sending to client
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { correctAnswer, ...safeQuestion }: AIQuestion = question
+
+    return NextResponse.json(safeQuestion)
+  } catch (err) {
+    console.error('Failed to sample next infinite trivia question:', err)
+    return NextResponse.json({ error: 'Failed to fetch question.' }, { status: 500 })
+  }
+}

--- a/src/app/api/v1/trivia/infinite/next/route.ts
+++ b/src/app/api/v1/trivia/infinite/next/route.ts
@@ -1,8 +1,11 @@
 import { type NextRequest, NextResponse } from 'next/server'
 
 import { verifyRequestAuth } from '@/lib/api/auth'
-import { sampleNextQuestion } from '@/lib/trivia/sampler'
 import type { AIQuestion } from '@/lib/trivia/aiQuestions'
+import { saveAIQuestion } from '@/lib/trivia/aiQuestions'
+import { generateInfiniteQuestion } from '@/lib/trivia/generateQuestion'
+import { checkAndIncrementGenerationLimit } from '@/lib/trivia/generationLimit'
+import { sampleNextQuestion } from '@/lib/trivia/sampler'
 import { trackExhaustion } from '@/lib/trivia/triviaStats'
 
 // GET /api/v1/trivia/infinite/next?streak=N
@@ -16,16 +19,40 @@ export async function GET(request: NextRequest) {
   const parsedStreak = isNaN(streak) || streak < 0 ? 0 : streak
 
   try {
-    const question = await sampleNextQuestion({
+    let question = await sampleNextQuestion({
       uid: auth.claims.uid,
       streak: parsedStreak,
       type: 'free-text',
     })
 
     if (question === null) {
-      // Library exhausted — no unseen questions remain
-      await trackExhaustion(auth.claims.uid)
-      return new NextResponse(null, { status: 204 })
+      // Pool exhausted for this player — generate a fresh question on demand,
+      // gated by a per-uid rate limit so a single client can't burn the
+      // OpenAI budget by hammering /next.
+      const { limited } = await checkAndIncrementGenerationLimit(auth.claims.uid)
+      if (limited) {
+        return NextResponse.json(
+          { error: 'Generation rate limit exceeded. Please try again later.' },
+          { status: 429 }
+        )
+      }
+
+      try {
+        const generated = await generateInfiniteQuestion({ streak: parsedStreak })
+        await saveAIQuestion(generated)
+        question = {
+          ...generated,
+          status: 'active',
+          timesShown: 0,
+          timesCorrect: 0,
+          flaggedCount: 0,
+          avgTimeMs: null,
+        }
+      } catch (genErr) {
+        console.error('On-demand question generation failed:', genErr)
+        await trackExhaustion(auth.claims.uid)
+        return new NextResponse(null, { status: 204 })
+      }
     }
 
     // Strip correctAnswer before sending to client

--- a/src/app/api/v1/trivia/infinite/runs/[runId]/answer/route.ts
+++ b/src/app/api/v1/trivia/infinite/runs/[runId]/answer/route.ts
@@ -42,7 +42,11 @@ export async function POST(
       elapsedMs: typeof elapsedMs === 'number' ? elapsedMs : 0,
     });
 
-    return NextResponse.json(result);
+    return NextResponse.json({
+      ...result,
+      correctAnswer: qData.correctAnswer,
+      explanation: qData.explanation ?? null,
+    });
   } catch (err: unknown) {
     const message = err instanceof Error ? err.message : String(err);
     if (message === 'Run already ended') {

--- a/src/app/api/v1/trivia/infinite/runs/[runId]/answer/route.ts
+++ b/src/app/api/v1/trivia/infinite/runs/[runId]/answer/route.ts
@@ -1,0 +1,57 @@
+import { type NextRequest, NextResponse } from 'next/server';
+
+import { verifyRequestAuth } from '@/lib/api/auth';
+import { getFirestoreDb } from '@/lib/firebase/server';
+import { judgeAnswer } from '@/lib/trivia/answerJudge';
+import { submitAnswer } from '@/lib/trivia/infiniteRuns';
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ runId: string }> }
+) {
+  const auth = await verifyRequestAuth(request);
+  if ('error' in auth) return auth.error;
+
+  const { runId } = await params;
+
+  try {
+    const body = await request.json();
+    const { questionId, answer, elapsedMs } = body;
+
+    if (!questionId || !answer || elapsedMs === undefined) {
+      return NextResponse.json({ error: 'questionId, answer, and elapsedMs are required.' }, { status: 400 });
+    }
+
+    // Load question
+    const db = getFirestoreDb();
+    const qSnap = await db.doc(`aiQuestions/${questionId}`).get();
+    if (!qSnap.exists || qSnap.data()?.status !== 'active') {
+      return NextResponse.json({ error: 'Question not found or inactive.' }, { status: 404 });
+    }
+    const qData = qSnap.data()!;
+
+    // Grade the answer
+    const correct = await judgeAnswer(qData.question, qData.correctAnswer, answer);
+
+    // Submit to run
+    const result = await submitAnswer({
+      uid: auth.claims.uid,
+      runId,
+      questionId,
+      correct,
+      elapsedMs: typeof elapsedMs === 'number' ? elapsedMs : 0,
+    });
+
+    return NextResponse.json(result);
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    if (message === 'Run already ended') {
+      return NextResponse.json({ error: 'Run already ended.' }, { status: 409 });
+    }
+    if (message === 'Run not found') {
+      return NextResponse.json({ error: 'Run not found.' }, { status: 404 });
+    }
+    console.error('Failed to submit answer:', err);
+    return NextResponse.json({ error: 'Failed to submit answer.' }, { status: 500 });
+  }
+}

--- a/src/app/api/v1/trivia/infinite/runs/[runId]/end/route.ts
+++ b/src/app/api/v1/trivia/infinite/runs/[runId]/end/route.ts
@@ -1,0 +1,26 @@
+import { type NextRequest, NextResponse } from 'next/server';
+
+import { verifyRequestAuth } from '@/lib/api/auth';
+import { endRun } from '@/lib/trivia/infiniteRuns';
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ runId: string }> }
+) {
+  const auth = await verifyRequestAuth(request);
+  if ('error' in auth) return auth.error;
+
+  const { runId } = await params;
+
+  try {
+    await endRun(auth.claims.uid, runId);
+    return NextResponse.json({ ended: true });
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    if (message === 'Run not found') {
+      return NextResponse.json({ error: 'Run not found.' }, { status: 404 });
+    }
+    console.error('Failed to end run:', err);
+    return NextResponse.json({ error: 'Failed to end run.' }, { status: 500 });
+  }
+}

--- a/src/app/api/v1/trivia/infinite/runs/route.ts
+++ b/src/app/api/v1/trivia/infinite/runs/route.ts
@@ -1,0 +1,19 @@
+import { type NextRequest, NextResponse } from 'next/server';
+
+import { verifyRequestAuth } from '@/lib/api/auth';
+import { startRun } from '@/lib/trivia/infiniteRuns';
+
+export async function POST(request: NextRequest) {
+  const auth = await verifyRequestAuth(request);
+  if ('error' in auth) return auth.error;
+
+  try {
+    const body = await request.json();
+    const mode = body.mode === 'practice' ? 'practice' : 'scored';
+    const result = await startRun(auth.claims.uid, mode);
+    return NextResponse.json(result, { status: 201 });
+  } catch (err) {
+    console.error('Failed to start infinite run:', err);
+    return NextResponse.json({ error: 'Failed to start run.' }, { status: 500 });
+  }
+}

--- a/src/app/api/v1/trivia/questions/[id]/flag/route.ts
+++ b/src/app/api/v1/trivia/questions/[id]/flag/route.ts
@@ -1,0 +1,81 @@
+import { type NextRequest, NextResponse } from 'next/server';
+import { FieldValue } from 'firebase-admin/firestore';
+
+import { verifyRequestAuth } from '@/lib/api/auth';
+import { getFirestoreDb } from '@/lib/firebase/server';
+
+const FLAG_THRESHOLD = 3;
+const VALID_REASONS = ['wrong_answer', 'ambiguous', 'inappropriate', 'other'] as const;
+type FlagReason = (typeof VALID_REASONS)[number];
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const auth = await verifyRequestAuth(request);
+  if ('error' in auth) return auth.error;
+
+  const { id: questionId } = await params;
+  const uid = auth.claims.uid;
+
+  let body: { reason?: unknown; note?: unknown };
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON.' }, { status: 400 });
+  }
+
+  const { reason, note } = body;
+
+  if (!VALID_REASONS.includes(reason as FlagReason)) {
+    return NextResponse.json(
+      { error: 'Invalid reason. Must be one of: wrong_answer, ambiguous, inappropriate, other.' },
+      { status: 400 }
+    );
+  }
+
+  if (note !== undefined && (typeof note !== 'string' || note.length > 500)) {
+    return NextResponse.json({ error: 'Note must be a string of max 500 characters.' }, { status: 400 });
+  }
+
+  const db = getFirestoreDb();
+  const qRef = db.doc(`aiQuestions/${questionId}`);
+  const flagRef = db.doc(`aiQuestions/${questionId}/flags/${uid}`);
+
+  try {
+    await db.runTransaction(async (tx) => {
+      const qSnap = await tx.get(qRef);
+      if (!qSnap.exists) throw new Error('Question not found');
+
+      const qData = qSnap.data()!;
+      const newFlaggedCount = (qData.flaggedCount ?? 0) + 1;
+
+      const qUpdates: FirebaseFirestore.UpdateData<FirebaseFirestore.DocumentData> = {
+        flaggedCount: FieldValue.increment(1),
+      };
+
+      if (newFlaggedCount >= FLAG_THRESHOLD && qData.status === 'active') {
+        qUpdates.status = 'flagged';
+      }
+
+      tx.update(qRef, qUpdates);
+
+      const flagDoc: Record<string, unknown> = {
+        reason,
+        flaggedAt: FieldValue.serverTimestamp(),
+      };
+      if (note !== undefined) {
+        flagDoc.note = note;
+      }
+      tx.set(flagRef, flagDoc);
+    });
+
+    return NextResponse.json({ ok: true }, { status: 200 });
+  } catch (err) {
+    if (err instanceof Error && err.message === 'Question not found') {
+      return NextResponse.json({ error: 'Question not found.' }, { status: 404 });
+    }
+    console.error('Failed to flag question:', err);
+    return NextResponse.json({ error: 'Failed to flag question.' }, { status: 500 });
+  }
+}

--- a/src/app/api/v1/trivia/questions/[id]/flag/route.ts
+++ b/src/app/api/v1/trivia/questions/[id]/flag/route.ts
@@ -5,7 +5,7 @@ import { verifyRequestAuth } from '@/lib/api/auth';
 import { getFirestoreDb } from '@/lib/firebase/server';
 
 const FLAG_THRESHOLD = 3;
-const VALID_REASONS = ['wrong_answer', 'ambiguous', 'inappropriate', 'other'] as const;
+const VALID_REASONS = ['obvious', 'unanswerable', 'nonsense', 'inaccurate', 'difficulty_mismatch', 'other'] as const;
 type FlagReason = (typeof VALID_REASONS)[number];
 
 export async function POST(
@@ -29,7 +29,7 @@ export async function POST(
 
   if (!VALID_REASONS.includes(reason as FlagReason)) {
     return NextResponse.json(
-      { error: 'Invalid reason. Must be one of: wrong_answer, ambiguous, inappropriate, other.' },
+      { error: `Invalid reason. Must be one of: ${VALID_REASONS.join(', ')}.` },
       { status: 400 }
     );
   }

--- a/src/app/api/v1/trivia/questions/[id]/rate/route.ts
+++ b/src/app/api/v1/trivia/questions/[id]/rate/route.ts
@@ -1,0 +1,54 @@
+import { type NextRequest, NextResponse } from 'next/server';
+import { FieldValue } from 'firebase-admin/firestore';
+
+import { verifyRequestAuth } from '@/lib/api/auth';
+import { getFirestoreDb } from '@/lib/firebase/server';
+
+const VALID_VOTES = ['up', 'down'] as const;
+type Vote = (typeof VALID_VOTES)[number];
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const auth = await verifyRequestAuth(request);
+  if ('error' in auth) return auth.error;
+
+  const { id: questionId } = await params;
+  const uid = auth.claims.uid;
+
+  let body: { vote?: unknown };
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON.' }, { status: 400 });
+  }
+
+  const { vote } = body;
+
+  if (vote !== null && !VALID_VOTES.includes(vote as Vote)) {
+    return NextResponse.json(
+      { error: 'Invalid vote. Must be "up", "down", or null.' },
+      { status: 400 }
+    );
+  }
+
+  const db = getFirestoreDb();
+  const ratingRef = db.doc(`aiQuestions/${questionId}/ratings/${uid}`);
+
+  try {
+    if (vote === null) {
+      await ratingRef.delete();
+    } else {
+      await ratingRef.set({
+        vote,
+        ratedAt: FieldValue.serverTimestamp(),
+      });
+    }
+
+    return NextResponse.json({ ok: true }, { status: 200 });
+  } catch (err) {
+    console.error('Failed to rate question:', err);
+    return NextResponse.json({ error: 'Failed to rate question.' }, { status: 500 });
+  }
+}

--- a/src/app/api/v1/trivia/stats/me/route.ts
+++ b/src/app/api/v1/trivia/stats/me/route.ts
@@ -1,0 +1,17 @@
+import { type NextRequest, NextResponse } from 'next/server'
+
+import { verifyRequestAuth } from '@/lib/api/auth'
+import { getAggregateStats } from '@/lib/trivia/triviaStats'
+
+export async function GET(request: NextRequest) {
+  const auth = await verifyRequestAuth(request)
+  if ('error' in auth) return auth.error
+
+  try {
+    const stats = await getAggregateStats(auth.claims.uid)
+    return NextResponse.json(stats)
+  } catch (err) {
+    console.error('Failed to fetch stats:', err)
+    return NextResponse.json({ error: 'Failed to fetch stats.' }, { status: 500 })
+  }
+}

--- a/src/app/trivia/components/FlagQuestion.tsx
+++ b/src/app/trivia/components/FlagQuestion.tsx
@@ -4,9 +4,11 @@ import { useAuth } from '@/hooks/useAuth'
 import { ChunkyButton } from '@/components/ui/chunky-button'
 
 const FLAG_REASONS = [
-  { value: 'wrong_answer', label: 'Wrong answer marked correct' },
-  { value: 'ambiguous', label: "Question doesn't have one right answer" },
-  { value: 'inappropriate', label: 'Inappropriate / off-brand' },
+  { value: 'obvious', label: 'Answer is included in the question / too obvious' },
+  { value: 'unanswerable', label: "Question doesn't have one right answer or is impossible to answer" },
+  { value: 'nonsense', label: "Question doesn't make sense" },
+  { value: 'inaccurate', label: 'Inaccurate or incorrect' },
+  { value: 'difficulty_mismatch', label: "Difficulty doesn't match the challenge" },
   { value: 'other', label: 'Other' },
 ] as const
 
@@ -24,15 +26,19 @@ export function FlagQuestion({ questionId }: Props) {
 
   if (!user) return null
 
+  const noteRequired = reason === 'other'
+  const trimmedNote = note.trim()
+  const canSubmit = !!reason && (!noteRequired || trimmedNote.length > 0) && !submitting
+
   const handleSubmit = async () => {
-    if (!reason || submitting) return
+    if (!canSubmit) return
     setSubmitting(true)
     try {
       const token = await user.getIdToken()
       await fetch(`/api/v1/trivia/questions/${questionId}/flag`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
-        body: JSON.stringify({ reason, note: note.trim() || undefined }),
+        body: JSON.stringify({ reason, note: trimmedNote || undefined }),
       })
       setSubmitted(true)
       setShowModal(false)
@@ -47,7 +53,7 @@ export function FlagQuestion({ questionId }: Props) {
 
   return (
     <>
-      <button onClick={() => setShowModal(true)} className="text-on-surface/20 hover:text-ds-error/60 text-xs transition-colors" aria-label="Report question" title="Report this question">
+      <button onClick={() => setShowModal(true)} className="text-on-surface/20 hover:text-ds-error/60 text-xs transition-colors" aria-label="Flag for Removal/Deletion" title="Flag for Removal/Deletion">
         🚩
       </button>
       {showModal && (
@@ -62,12 +68,16 @@ export function FlagQuestion({ questionId }: Props) {
                 </label>
               ))}
             </div>
-            {reason === 'other' && (
-              <textarea value={note} onChange={e => setNote(e.target.value.slice(0, 500))} placeholder="Tell us more..." maxLength={500} className="bg-surface-dim/50 border border-outline-variant rounded-lg p-2 text-on-surface text-sm resize-none h-20" />
-            )}
+            <textarea
+              value={note}
+              onChange={e => setNote(e.target.value.slice(0, 500))}
+              placeholder={noteRequired ? 'Tell us more (required)...' : 'Add context (optional)...'}
+              maxLength={500}
+              className="bg-surface-container-highest border border-outline-variant rounded-lg p-2 text-on-surface text-sm resize-none h-20 placeholder:text-on-surface/40"
+            />
             <div className="flex gap-3 justify-end">
               <ChunkyButton variant="secondary" size="sm" onClick={() => setShowModal(false)}>Cancel</ChunkyButton>
-              <ChunkyButton variant="exit" size="sm" disabled={!reason || submitting} onClick={handleSubmit}>
+              <ChunkyButton variant="exit" size="sm" disabled={!canSubmit} onClick={handleSubmit}>
                 {submitting ? 'Sending...' : 'Report'}
               </ChunkyButton>
             </div>

--- a/src/app/trivia/components/FlagQuestion.tsx
+++ b/src/app/trivia/components/FlagQuestion.tsx
@@ -1,0 +1,79 @@
+'use client'
+import { useState } from 'react'
+import { useAuth } from '@/hooks/useAuth'
+import { ChunkyButton } from '@/components/ui/chunky-button'
+
+const FLAG_REASONS = [
+  { value: 'wrong_answer', label: 'Wrong answer marked correct' },
+  { value: 'ambiguous', label: "Question doesn't have one right answer" },
+  { value: 'inappropriate', label: 'Inappropriate / off-brand' },
+  { value: 'other', label: 'Other' },
+] as const
+
+interface Props {
+  questionId: string
+}
+
+export function FlagQuestion({ questionId }: Props) {
+  const { user } = useAuth()
+  const [showModal, setShowModal] = useState(false)
+  const [reason, setReason] = useState<string>('')
+  const [note, setNote] = useState('')
+  const [submitted, setSubmitted] = useState(false)
+  const [submitting, setSubmitting] = useState(false)
+
+  if (!user) return null
+
+  const handleSubmit = async () => {
+    if (!reason || submitting) return
+    setSubmitting(true)
+    try {
+      const token = await user.getIdToken()
+      await fetch(`/api/v1/trivia/questions/${questionId}/flag`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+        body: JSON.stringify({ reason, note: note.trim() || undefined }),
+      })
+      setSubmitted(true)
+      setShowModal(false)
+    } catch {
+      // silent
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  if (submitted) return <span className="text-on-surface/30 text-xs">Reported</span>
+
+  return (
+    <>
+      <button onClick={() => setShowModal(true)} className="text-on-surface/20 hover:text-ds-error/60 text-xs transition-colors" aria-label="Report question" title="Report this question">
+        🚩
+      </button>
+      {showModal && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-surface-dim/80 backdrop-blur-sm">
+          <div className="bg-surface-container-high rounded-ds-lg p-6 max-w-sm mx-4 shadow-hero flex flex-col gap-4">
+            <h3 className="text-on-surface font-bold text-lg">Report Question</h3>
+            <div className="flex flex-col gap-2">
+              {FLAG_REASONS.map(r => (
+                <label key={r.value} className="flex items-center gap-2 text-on-surface/80 text-sm cursor-pointer">
+                  <input type="radio" name="flag-reason" value={r.value} checked={reason === r.value} onChange={() => setReason(r.value)} className="accent-ds-tertiary" />
+                  {r.label}
+                </label>
+              ))}
+            </div>
+            {reason === 'other' && (
+              <textarea value={note} onChange={e => setNote(e.target.value.slice(0, 500))} placeholder="Tell us more..." maxLength={500} className="bg-surface-dim/50 border border-outline-variant rounded-lg p-2 text-on-surface text-sm resize-none h-20" />
+            )}
+            <div className="flex gap-3 justify-end">
+              <ChunkyButton variant="secondary" size="sm" onClick={() => setShowModal(false)}>Cancel</ChunkyButton>
+              <ChunkyButton variant="exit" size="sm" disabled={!reason || submitting} onClick={handleSubmit}>
+                {submitting ? 'Sending...' : 'Report'}
+              </ChunkyButton>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  )
+}

--- a/src/app/trivia/components/InfiniteExhaustedScreen.tsx
+++ b/src/app/trivia/components/InfiniteExhaustedScreen.tsx
@@ -1,0 +1,62 @@
+'use client'
+import { ChunkyButton } from '@/components/ui/chunky-button'
+import { ChunkyCard, ChunkyCardContent } from '@/components/ui/chunky-card'
+import { useAuth } from '@/hooks/useAuth'
+import { SignInCard } from './SignInCTA'
+
+interface Props {
+  onBack: () => void
+  score?: number
+  questionsAnswered?: number
+}
+
+export function InfiniteExhaustedScreen({ onBack, score, questionsAnswered }: Props) {
+  const { user } = useAuth()
+
+  return (
+    <div className="flex flex-col items-center gap-6 max-w-lg mx-auto py-8">
+      <div className="text-center">
+        <div className="text-6xl mb-4">✨</div>
+        <h2 className="font-headline text-headline-lg text-ds-tertiary drop-shadow-[0_4px_0_var(--surface-container-lowest)] mb-2">
+          The Cave Rests
+        </h2>
+        <p className="text-on-surface/60 text-lg leading-relaxed max-w-sm mx-auto">
+          You have explored every question the cavern holds. The stars are still writing new ones — return soon, traveler.
+        </p>
+      </div>
+
+      {(score !== undefined || questionsAnswered !== undefined) && (
+        <ChunkyCard variant="surface-variant" className="w-full bg-surface-container/80 border-outline-variant">
+          <ChunkyCardContent className="pt-6 text-center">
+            <p className="text-on-surface/50 text-sm mb-2">This run</p>
+            <div className="grid grid-cols-2 gap-3">
+              {score !== undefined && (
+                <div className="text-center">
+                  <div className="text-2xl font-bold text-ds-tertiary">{score.toLocaleString()}</div>
+                  <div className="text-on-surface/50 text-xs">Score</div>
+                </div>
+              )}
+              {questionsAnswered !== undefined && (
+                <div className="text-center">
+                  <div className="text-2xl font-bold text-on-surface">{questionsAnswered}</div>
+                  <div className="text-on-surface/50 text-xs">Questions</div>
+                </div>
+              )}
+            </div>
+          </ChunkyCardContent>
+        </ChunkyCard>
+      )}
+
+      {!user && (
+        <SignInCard
+          title="🔔 Want to know when new questions arrive?"
+          description="Sign in and we'll let you know when the cave has more to discover."
+        />
+      )}
+
+      <ChunkyButton variant="secondary" size="lg" className="w-full" onClick={onBack}>
+        Back to Trivia
+      </ChunkyButton>
+    </div>
+  )
+}

--- a/src/app/trivia/components/InfiniteExhaustedScreen.tsx
+++ b/src/app/trivia/components/InfiniteExhaustedScreen.tsx
@@ -18,10 +18,10 @@ export function InfiniteExhaustedScreen({ onBack, score, questionsAnswered }: Pr
       <div className="text-center">
         <div className="text-6xl mb-4">✨</div>
         <h2 className="font-headline text-headline-lg text-ds-tertiary drop-shadow-[0_4px_0_var(--surface-container-lowest)] mb-2">
-          The Cave Rests
+          You&apos;re all caught up
         </h2>
         <p className="text-on-surface/60 text-lg leading-relaxed max-w-sm mx-auto">
-          You have explored every question the cavern holds. The stars are still writing new ones — return soon, traveler.
+          You&apos;ve answered every question we have right now. New ones are on the way — check back soon.
         </p>
       </div>
 
@@ -47,10 +47,10 @@ export function InfiniteExhaustedScreen({ onBack, score, questionsAnswered }: Pr
         </ChunkyCard>
       )}
 
-      {!user && (
+      {(!user || user.isAnonymous) && (
         <SignInCard
           title="🔔 Want to know when new questions arrive?"
-          description="Sign in and we'll let you know when the cave has more to discover."
+          description="Sign in and we'll let you know when more questions are ready."
         />
       )}
 

--- a/src/app/trivia/components/InfiniteGame.tsx
+++ b/src/app/trivia/components/InfiniteGame.tsx
@@ -5,6 +5,7 @@ import type { InfiniteMode } from '@/app/trivia/hooks/useInfiniteRun'
 import { InfiniteHUD } from './InfiniteHUD'
 import { InfiniteQuestionCard } from './InfiniteQuestionCard'
 import { InfiniteRunSummary } from './InfiniteRunSummary'
+import { InfiniteExhaustedScreen } from './InfiniteExhaustedScreen'
 import { ChunkyButton } from '@/components/ui/chunky-button'
 
 const TIME_LIMIT = 60 // 60 seconds for AI free-text
@@ -82,13 +83,11 @@ export function InfiniteGame({ onBack, mode = 'scored' }: Props) {
   // Exhausted state
   if (state.phase === 'exhausted') {
     return (
-      <div className="flex flex-col items-center gap-4 py-8 max-w-lg mx-auto">
-        <h2 className="font-headline text-headline-lg text-ds-tertiary">The Cave Rests</h2>
-        <p className="text-on-surface/60 text-center">
-          You have explored every question in the cavern. New discoveries await — return soon.
-        </p>
-        <ChunkyButton variant="secondary" onClick={onBack}>Back to Trivia</ChunkyButton>
-      </div>
+      <InfiniteExhaustedScreen
+        onBack={onBack}
+        score={state.score}
+        questionsAnswered={state.questionsAnswered}
+      />
     )
   }
 

--- a/src/app/trivia/components/InfiniteGame.tsx
+++ b/src/app/trivia/components/InfiniteGame.tsx
@@ -1,0 +1,128 @@
+'use client'
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { useInfiniteRun } from '@/app/trivia/hooks/useInfiniteRun'
+import { InfiniteHUD } from './InfiniteHUD'
+import { InfiniteQuestionCard } from './InfiniteQuestionCard'
+import { InfiniteRunSummary } from './InfiniteRunSummary'
+import { ChunkyButton } from '@/components/ui/chunky-button'
+
+const TIME_LIMIT = 60 // 60 seconds for AI free-text
+
+interface Props {
+  onBack: () => void
+}
+
+export function InfiniteGame({ onBack }: Props) {
+  const { state, startRun, submitAnswer, nextQuestion, endRun } = useInfiniteRun()
+  const [timeRemaining, setTimeRemaining] = useState(TIME_LIMIT)
+  const timerRef = useRef<ReturnType<typeof setInterval> | null>(null)
+  const timerStartRef = useRef<number>(0)
+
+  // Start run on mount
+  useEffect(() => {
+    startRun()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  // Timer logic
+  useEffect(() => {
+    if (state.phase !== 'playing') {
+      if (timerRef.current) clearInterval(timerRef.current)
+      return
+    }
+    timerStartRef.current = Date.now()
+    setTimeRemaining(TIME_LIMIT)
+    timerRef.current = setInterval(() => {
+      const elapsed = (Date.now() - timerStartRef.current) / 1000
+      const remaining = Math.max(0, TIME_LIMIT - elapsed)
+      setTimeRemaining(remaining)
+      if (remaining <= 0) {
+        if (timerRef.current) clearInterval(timerRef.current)
+        // Auto-submit empty on timeout
+        submitAnswer('')
+      }
+    }, 100)
+    return () => {
+      if (timerRef.current) clearInterval(timerRef.current)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [state.phase, state.question?.id])
+
+  const handleFlee = useCallback(() => {
+    if (timerRef.current) clearInterval(timerRef.current)
+    endRun()
+  }, [endRun])
+
+  const handlePlayAgain = useCallback(() => {
+    startRun()
+  }, [startRun])
+
+  // Loading state
+  if (state.phase === 'loading' || state.phase === 'idle') {
+    return (
+      <div className="flex flex-col items-center gap-4 py-8 max-w-lg mx-auto">
+        <div className="text-on-surface/60 text-lg">Entering the infinite cavern...</div>
+      </div>
+    )
+  }
+
+  // Error state
+  if (state.phase === 'error') {
+    return (
+      <div className="flex flex-col items-center gap-4 py-8 max-w-lg mx-auto">
+        <p className="text-ds-error">{state.error}</p>
+        <ChunkyButton variant="secondary" onClick={() => startRun()}>Try Again</ChunkyButton>
+        <ChunkyButton variant="ghost" size="sm" onClick={onBack}>Back to Trivia</ChunkyButton>
+      </div>
+    )
+  }
+
+  // Exhausted state
+  if (state.phase === 'exhausted') {
+    return (
+      <div className="flex flex-col items-center gap-4 py-8 max-w-lg mx-auto">
+        <h2 className="font-headline text-headline-lg text-ds-tertiary">The Cave Rests</h2>
+        <p className="text-on-surface/60 text-center">
+          You have explored every question in the cavern. New discoveries await — return soon.
+        </p>
+        <ChunkyButton variant="secondary" onClick={onBack}>Back to Trivia</ChunkyButton>
+      </div>
+    )
+  }
+
+  // End of run
+  if (state.phase === 'ended') {
+    return <InfiniteRunSummary state={state} onPlayAgain={handlePlayAgain} onBack={onBack} />
+  }
+
+  // Playing or answered
+  if (!state.question) return null
+
+  return (
+    <div className="flex flex-col gap-3 sm:gap-4 max-w-lg mx-auto py-2 sm:py-4">
+      <InfiniteHUD
+        livesRemaining={state.livesRemaining}
+        currentStreak={state.currentStreak}
+        score={state.score}
+        timeRemaining={timeRemaining}
+        timeLimit={TIME_LIMIT}
+        onFlee={handleFlee}
+        isPlaying={state.phase === 'playing'}
+      />
+
+      <InfiniteQuestionCard
+        question={state.question}
+        onSubmit={submitAnswer}
+        isSubmitting={state.phase === 'answering'}
+        answerResult={state.lastAnswer}
+        questionsAnswered={state.questionsAnswered}
+      />
+
+      {state.phase === 'answered' && (
+        <ChunkyButton variant="primary" size="lg" className="w-full" onClick={nextQuestion}>
+          Next Question
+        </ChunkyButton>
+      )}
+    </div>
+  )
+}

--- a/src/app/trivia/components/InfiniteGame.tsx
+++ b/src/app/trivia/components/InfiniteGame.tsx
@@ -1,14 +1,17 @@
 'use client'
 import { useCallback, useEffect, useRef, useState } from 'react'
+import { useAuth } from '@/hooks/useAuth'
 import { useInfiniteRun } from '@/app/trivia/hooks/useInfiniteRun'
 import type { InfiniteMode } from '@/app/trivia/hooks/useInfiniteRun'
 import { InfiniteHUD } from './InfiniteHUD'
 import { InfiniteQuestionCard } from './InfiniteQuestionCard'
 import { InfiniteRunSummary } from './InfiniteRunSummary'
 import { InfiniteExhaustedScreen } from './InfiniteExhaustedScreen'
+import { InfiniteRulesModal } from './InfiniteRulesModal'
 import { ChunkyButton } from '@/components/ui/chunky-button'
 
 const TIME_LIMIT = 60 // 60 seconds for AI free-text
+const RULES_DISMISSED_KEY = 'cometcave-infinite-rules-dismissed-v1'
 
 interface Props {
   onBack: () => void
@@ -16,16 +19,44 @@ interface Props {
 }
 
 export function InfiniteGame({ onBack, mode = 'scored' }: Props) {
+  const { user, loading: authLoading } = useAuth()
   const { state, startRun, submitAnswer, nextQuestion, endRun } = useInfiniteRun()
   const [timeRemaining, setTimeRemaining] = useState(TIME_LIMIT)
   const timerRef = useRef<ReturnType<typeof setInterval> | null>(null)
   const timerStartRef = useRef<number>(0)
+  const hasStartedRef = useRef(false)
+  const [showRules, setShowRules] = useState<boolean | null>(null)
 
-  // Start run on mount
+  // Determine whether to show the rules modal once on mount.
   useEffect(() => {
+    if (typeof window === 'undefined') return
+    const dismissed = window.localStorage.getItem(RULES_DISMISSED_KEY) === '1'
+    setShowRules(!dismissed)
+  }, [])
+
+  // Start run once auth has settled, user is present, and rules have been
+  // either dismissed previously or acknowledged this session.
+  useEffect(() => {
+    if (authLoading || !user || hasStartedRef.current) return
+    if (showRules !== false) return
+    hasStartedRef.current = true
     startRun(mode)
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
+  }, [authLoading, user, showRules])
+
+  const handleRulesContinue = useCallback((chosenMode: InfiniteMode, dismissForever: boolean) => {
+    if (dismissForever && typeof window !== 'undefined') {
+      window.localStorage.setItem(RULES_DISMISSED_KEY, '1')
+    }
+    if (chosenMode !== mode && typeof window !== 'undefined') {
+      const url = new URL(window.location.href)
+      url.searchParams.set('mode', chosenMode)
+      window.history.replaceState({}, '', url.toString())
+    }
+    hasStartedRef.current = true
+    setShowRules(false)
+    startRun(chosenMode)
+  }, [mode, startRun])
 
   // Timer logic
   useEffect(() => {
@@ -60,11 +91,20 @@ export function InfiniteGame({ onBack, mode = 'scored' }: Props) {
     startRun(mode)
   }, [startRun, mode])
 
+  // Rules gate (before first run). Shown over the loading screen.
+  if (showRules) {
+    return (
+      <div className="flex flex-col items-center gap-4 py-8 max-w-lg mx-auto">
+        <InfiniteRulesModal defaultMode={mode} onContinue={handleRulesContinue} onCancel={onBack} />
+      </div>
+    )
+  }
+
   // Loading state
   if (state.phase === 'loading' || state.phase === 'idle') {
     return (
       <div className="flex flex-col items-center gap-4 py-8 max-w-lg mx-auto">
-        <div className="text-on-surface/60 text-lg">Entering the infinite cavern...</div>
+        <div className="text-on-surface/60 text-lg">Loading Infinite Trivia...</div>
       </div>
     )
   }
@@ -113,6 +153,7 @@ export function InfiniteGame({ onBack, mode = 'scored' }: Props) {
       />
 
       <InfiniteQuestionCard
+        key={state.question.id}
         question={state.question}
         onSubmit={submitAnswer}
         isSubmitting={state.phase === 'answering'}
@@ -121,9 +162,15 @@ export function InfiniteGame({ onBack, mode = 'scored' }: Props) {
       />
 
       {state.phase === 'answered' && (
-        <ChunkyButton variant="primary" size="lg" className="w-full" onClick={nextQuestion}>
-          Next Question
-        </ChunkyButton>
+        state.lastAnswer?.runOver ? (
+          <ChunkyButton variant="primary" size="lg" className="w-full" onClick={endRun}>
+            View Run Summary
+          </ChunkyButton>
+        ) : (
+          <ChunkyButton variant="primary" size="lg" className="w-full" onClick={nextQuestion}>
+            Next Question
+          </ChunkyButton>
+        )
       )}
     </div>
   )

--- a/src/app/trivia/components/InfiniteGame.tsx
+++ b/src/app/trivia/components/InfiniteGame.tsx
@@ -1,6 +1,7 @@
 'use client'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { useInfiniteRun } from '@/app/trivia/hooks/useInfiniteRun'
+import type { InfiniteMode } from '@/app/trivia/hooks/useInfiniteRun'
 import { InfiniteHUD } from './InfiniteHUD'
 import { InfiniteQuestionCard } from './InfiniteQuestionCard'
 import { InfiniteRunSummary } from './InfiniteRunSummary'
@@ -10,9 +11,10 @@ const TIME_LIMIT = 60 // 60 seconds for AI free-text
 
 interface Props {
   onBack: () => void
+  mode?: InfiniteMode
 }
 
-export function InfiniteGame({ onBack }: Props) {
+export function InfiniteGame({ onBack, mode = 'scored' }: Props) {
   const { state, startRun, submitAnswer, nextQuestion, endRun } = useInfiniteRun()
   const [timeRemaining, setTimeRemaining] = useState(TIME_LIMIT)
   const timerRef = useRef<ReturnType<typeof setInterval> | null>(null)
@@ -20,7 +22,7 @@ export function InfiniteGame({ onBack }: Props) {
 
   // Start run on mount
   useEffect(() => {
-    startRun()
+    startRun(mode)
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
@@ -54,8 +56,8 @@ export function InfiniteGame({ onBack }: Props) {
   }, [endRun])
 
   const handlePlayAgain = useCallback(() => {
-    startRun()
-  }, [startRun])
+    startRun(mode)
+  }, [startRun, mode])
 
   // Loading state
   if (state.phase === 'loading' || state.phase === 'idle') {
@@ -92,7 +94,7 @@ export function InfiniteGame({ onBack }: Props) {
 
   // End of run
   if (state.phase === 'ended') {
-    return <InfiniteRunSummary state={state} onPlayAgain={handlePlayAgain} onBack={onBack} />
+    return <InfiniteRunSummary state={state} onPlayAgain={handlePlayAgain} onBack={onBack} mode={state.mode} />
   }
 
   // Playing or answered
@@ -108,6 +110,7 @@ export function InfiniteGame({ onBack }: Props) {
         timeLimit={TIME_LIMIT}
         onFlee={handleFlee}
         isPlaying={state.phase === 'playing'}
+        mode={state.mode}
       />
 
       <InfiniteQuestionCard

--- a/src/app/trivia/components/InfiniteHUD.tsx
+++ b/src/app/trivia/components/InfiniteHUD.tsx
@@ -1,0 +1,128 @@
+'use client'
+import { useState } from 'react'
+import { ChunkyButton } from '@/components/ui/chunky-button'
+import { Pill, ScoreChip } from '@/components/ui/pill'
+import { computeStreakMultiplier } from '@/app/trivia/lib/infiniteScoring'
+
+interface InfiniteHUDProps {
+  livesRemaining: number
+  currentStreak: number
+  score: number
+  timeRemaining: number
+  timeLimit: number
+  onFlee: () => void
+  isPlaying: boolean
+}
+
+export function InfiniteHUD({
+  livesRemaining,
+  currentStreak,
+  score,
+  timeRemaining,
+  timeLimit,
+  onFlee,
+  isPlaying,
+}: InfiniteHUDProps) {
+  const [showFleeConfirm, setShowFleeConfirm] = useState(false)
+  const mult = computeStreakMultiplier(currentStreak)
+
+  const timerPercent = (timeRemaining / timeLimit) * 100
+  const timerColor =
+    timerPercent > 60
+      ? 'bg-green-500'
+      : timerPercent > 30
+        ? 'bg-yellow-500'
+        : 'bg-red-500'
+
+  const handleFlee = () => {
+    if (isPlaying) setShowFleeConfirm(true)
+    else onFlee()
+  }
+
+  return (
+    <div className="flex flex-col gap-3">
+      {/* Top bar */}
+      <div className="flex items-center justify-between gap-3">
+        <ChunkyButton
+          variant="exit"
+          size="sm"
+          onClick={handleFlee}
+          iconStart={
+            <span className="material-symbols-outlined text-[18px]">close</span>
+          }
+        >
+          <span className="hidden sm:inline">Flee</span>
+        </ChunkyButton>
+
+        {/* Lives */}
+        <div className="flex items-center gap-1" aria-label={`${livesRemaining} lives remaining`}>
+          {[0, 1, 2].map(i => (
+            <span
+              key={i}
+              className={`text-lg transition-opacity ${i < livesRemaining ? 'opacity-100' : 'opacity-20'}`}
+            >
+              {i < livesRemaining ? '❤️' : '🖤'}
+            </span>
+          ))}
+        </div>
+
+        {/* Streak + multiplier */}
+        <div className="flex items-center gap-1.5">
+          {currentStreak > 0 && (
+            <Pill tone="hot" size="sm">
+              🔥 {currentStreak}
+            </Pill>
+          )}
+          {mult > 1 && (
+            <Pill tone="info" size="sm">
+              ×{mult}
+            </Pill>
+          )}
+        </div>
+
+        <ScoreChip score={score} />
+      </div>
+
+      {/* Timer bar */}
+      <div className="w-full bg-surface-container-highest rounded-full h-2 overflow-hidden">
+        <div
+          className={`h-full ${timerColor} transition-all duration-100 ease-linear`}
+          style={{ width: `${timerPercent}%` }}
+        />
+      </div>
+
+      {/* Timer pill */}
+      <div className="flex justify-center">
+        <Pill tone="neutral" size="sm">{Math.ceil(timeRemaining)}s</Pill>
+      </div>
+
+      {/* Flee confirmation */}
+      {showFleeConfirm && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-surface-dim/80 backdrop-blur-sm">
+          <div className="bg-surface-container-high rounded-ds-lg p-8 max-w-sm mx-4 shadow-hero text-center flex flex-col gap-4">
+            <p className="text-on-surface text-body-lg">End your run? Your score will be saved.</p>
+            <div className="flex gap-3 justify-center">
+              <ChunkyButton
+                variant="secondary"
+                size="sm"
+                onClick={() => setShowFleeConfirm(false)}
+              >
+                Stay
+              </ChunkyButton>
+              <ChunkyButton
+                variant="exit"
+                size="sm"
+                onClick={() => {
+                  setShowFleeConfirm(false)
+                  onFlee()
+                }}
+              >
+                End Run
+              </ChunkyButton>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/app/trivia/components/InfiniteHUD.tsx
+++ b/src/app/trivia/components/InfiniteHUD.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react'
 import { ChunkyButton } from '@/components/ui/chunky-button'
 import { Pill, ScoreChip } from '@/components/ui/pill'
 import { computeStreakMultiplier } from '@/app/trivia/lib/infiniteScoring'
+import type { InfiniteMode } from '@/app/trivia/hooks/useInfiniteRun'
 
 interface InfiniteHUDProps {
   livesRemaining: number
@@ -12,6 +13,7 @@ interface InfiniteHUDProps {
   timeLimit: number
   onFlee: () => void
   isPlaying: boolean
+  mode?: InfiniteMode
 }
 
 export function InfiniteHUD({
@@ -22,6 +24,7 @@ export function InfiniteHUD({
   timeLimit,
   onFlee,
   isPlaying,
+  mode = 'scored',
 }: InfiniteHUDProps) {
   const [showFleeConfirm, setShowFleeConfirm] = useState(false)
   const mult = computeStreakMultiplier(currentStreak)
@@ -54,17 +57,21 @@ export function InfiniteHUD({
           <span className="hidden sm:inline">Flee</span>
         </ChunkyButton>
 
-        {/* Lives */}
-        <div className="flex items-center gap-1" aria-label={`${livesRemaining} lives remaining`}>
-          {[0, 1, 2].map(i => (
-            <span
-              key={i}
-              className={`text-lg transition-opacity ${i < livesRemaining ? 'opacity-100' : 'opacity-20'}`}
-            >
-              {i < livesRemaining ? '❤️' : '🖤'}
-            </span>
-          ))}
-        </div>
+        {/* Lives or Practice indicator */}
+        {mode === 'practice' ? (
+          <Pill tone="info" size="sm">Practice</Pill>
+        ) : (
+          <div className="flex items-center gap-1" aria-label={`${livesRemaining} lives remaining`}>
+            {[0, 1, 2].map(i => (
+              <span
+                key={i}
+                className={`text-lg transition-opacity ${i < livesRemaining ? 'opacity-100' : 'opacity-20'}`}
+              >
+                {i < livesRemaining ? '❤️' : '🖤'}
+              </span>
+            ))}
+          </div>
+        )}
 
         {/* Streak + multiplier */}
         <div className="flex items-center gap-1.5">

--- a/src/app/trivia/components/InfiniteHUD.tsx
+++ b/src/app/trivia/components/InfiniteHUD.tsx
@@ -54,7 +54,7 @@ export function InfiniteHUD({
             <span className="material-symbols-outlined text-[18px]">close</span>
           }
         >
-          <span className="hidden sm:inline">Flee</span>
+          <span className="hidden sm:inline">Exit Game</span>
         </ChunkyButton>
 
         {/* Lives or Practice indicator */}

--- a/src/app/trivia/components/InfiniteQuestionCard.tsx
+++ b/src/app/trivia/components/InfiniteQuestionCard.tsx
@@ -1,0 +1,115 @@
+'use client'
+import { useState } from 'react'
+import { ChunkyCard, ChunkyCardContent, ChunkyCardHeader } from '@/components/ui/chunky-card'
+import { ChunkyButton } from '@/components/ui/chunky-button'
+import { Input } from '@/components/ui/input'
+import type { InfiniteQuestion } from '@/app/trivia/hooks/useInfiniteRun'
+import type { AnswerResult } from '@/app/trivia/lib/infiniteScoring'
+
+interface Props {
+  question: InfiniteQuestion
+  onSubmit: (answer: string) => void
+  isSubmitting: boolean
+  answerResult: (AnswerResult & { trailblazer: boolean }) | null
+  questionsAnswered: number
+}
+
+function getSocialSignal(timesShown: number): string {
+  if (timesShown === 0) return 'You are the first traveler to find this question.'
+  if (timesShown === 1) return '1 other traveler has answered this.'
+  return `${timesShown} other travelers have answered this.`
+}
+
+export function InfiniteQuestionCard({
+  question,
+  onSubmit,
+  isSubmitting,
+  answerResult,
+  questionsAnswered,
+}: Props) {
+  const [textAnswer, setTextAnswer] = useState('')
+  const isAnswered = answerResult !== null
+
+  const diffBadgeColor = {
+    easy: 'bg-green-600/30 text-green-400 border-green-600/50',
+    medium: 'bg-yellow-600/30 text-yellow-400 border-yellow-600/50',
+    hard: 'bg-red-600/30 text-red-400 border-red-600/50',
+  }[question.difficulty]
+
+  const handleSubmit = () => {
+    if (textAnswer.trim() && !isSubmitting && !isAnswered) {
+      onSubmit(textAnswer.trim())
+    }
+  }
+
+  return (
+    <ChunkyCard variant="surface-variant" shadow="hero">
+      <ChunkyCardHeader className="pb-2 pt-3 sm:pt-6 px-4 sm:px-6">
+        <div className="flex justify-between items-center">
+          <span className="text-on-surface/50 text-xs sm:text-sm">
+            Question {questionsAnswered + 1}
+          </span>
+          <span className={`text-[10px] sm:text-xs px-2 py-0.5 rounded-full border ${diffBadgeColor}`}>
+            {question.difficulty.toUpperCase()}
+          </span>
+        </div>
+        {/* Social signal */}
+        <p className="text-on-surface/30 text-xs italic mt-1">
+          {getSocialSignal(question.timesShown)}
+        </p>
+      </ChunkyCardHeader>
+      <ChunkyCardContent className="px-4 sm:px-6 pb-4 sm:pb-6">
+        <p className="text-on-surface/60 text-xs uppercase tracking-wide mb-1">{question.category}</p>
+        <p aria-live="polite" className="text-on-surface text-base sm:text-lg mb-3 sm:mb-4 leading-snug">
+          {question.question}
+        </p>
+
+        {/* Free-text input */}
+        <div className="flex flex-col gap-2">
+          <Input
+            value={textAnswer}
+            onChange={(e) => setTextAnswer(e.target.value)}
+            placeholder="Type your answer..."
+            className="bg-surface-dim/50 border-outline-variant text-on-surface"
+            disabled={isAnswered || isSubmitting}
+            onKeyDown={(e) => { if (e.key === 'Enter') handleSubmit() }}
+            autoFocus
+          />
+          {!isAnswered && (
+            <ChunkyButton
+              variant="primary"
+              disabled={isSubmitting || !textAnswer.trim()}
+              onClick={handleSubmit}
+            >
+              {isSubmitting ? 'Checking...' : 'Submit Answer'}
+            </ChunkyButton>
+          )}
+        </div>
+
+        {/* Answer feedback */}
+        {isAnswered && answerResult && (
+          <div
+            className={`mt-4 p-3 rounded-lg ${
+              answerResult.correct
+                ? 'bg-primary-container/20 border border-primary-container/40'
+                : 'bg-ds-error/20 border border-ds-error/40'
+            }`}
+          >
+            <div className="font-bold mb-1">
+              {answerResult.correct ? (
+                <span className="text-ds-primary">
+                  Correct! +{answerResult.points} pts
+                  {answerResult.trailblazer && (
+                    <span className="ml-2 text-ds-tertiary">⭐ Trailblazer!</span>
+                  )}
+                </span>
+              ) : (
+                <span className="text-ds-error">Incorrect — 0 pts</span>
+              )}
+            </div>
+          </div>
+        )}
+      </ChunkyCardContent>
+    </ChunkyCard>
+  )
+}

--- a/src/app/trivia/components/InfiniteQuestionCard.tsx
+++ b/src/app/trivia/components/InfiniteQuestionCard.tsx
@@ -5,19 +5,21 @@ import { ChunkyButton } from '@/components/ui/chunky-button'
 import { Input } from '@/components/ui/input'
 import type { InfiniteQuestion } from '@/app/trivia/hooks/useInfiniteRun'
 import type { AnswerResult } from '@/app/trivia/lib/infiniteScoring'
+import { FlagQuestion } from './FlagQuestion'
+import { QuestionRating } from './QuestionRating'
 
 interface Props {
   question: InfiniteQuestion
   onSubmit: (answer: string) => void
   isSubmitting: boolean
-  answerResult: (AnswerResult & { trailblazer: boolean }) | null
+  answerResult: (AnswerResult & { trailblazer: boolean; correctAnswer: string; explanation: string | null }) | null
   questionsAnswered: number
 }
 
 function getSocialSignal(timesShown: number): string {
-  if (timesShown === 0) return 'You are the first traveler to find this question.'
-  if (timesShown === 1) return '1 other traveler has answered this.'
-  return `${timesShown} other travelers have answered this.`
+  if (timesShown === 0) return 'You are the first to find this question.'
+  if (timesShown === 1) return '1 other person has answered this.'
+  return `${timesShown} other people have answered this.`
 }
 
 export function InfiniteQuestionCard({
@@ -70,10 +72,13 @@ export function InfiniteQuestionCard({
             value={textAnswer}
             onChange={(e) => setTextAnswer(e.target.value)}
             placeholder="Type your answer..."
-            className="bg-surface-dim/50 border-outline-variant text-on-surface"
+            className="!bg-surface-container-high border-outline-variant text-on-surface placeholder:text-on-surface/40"
             disabled={isAnswered || isSubmitting}
             onKeyDown={(e) => { if (e.key === 'Enter') handleSubmit() }}
             autoFocus
+            autoComplete="off"
+            autoCorrect="off"
+            spellCheck={false}
           />
           {!isAnswered && (
             <ChunkyButton
@@ -95,7 +100,7 @@ export function InfiniteQuestionCard({
                 : 'bg-ds-error/20 border border-ds-error/40'
             }`}
           >
-            <div className="font-bold mb-1">
+            <div className="font-bold mb-1 flex items-start justify-between gap-2">
               {answerResult.correct ? (
                 <span className="text-ds-primary">
                   Correct! +{answerResult.points} pts
@@ -106,7 +111,21 @@ export function InfiniteQuestionCard({
               ) : (
                 <span className="text-ds-error">Incorrect — 0 pts</span>
               )}
+              <div className="flex items-center gap-2 shrink-0">
+                <QuestionRating questionId={question.id} />
+                <FlagQuestion questionId={question.id} />
+              </div>
             </div>
+            {!answerResult.correct && (
+              <div className="text-on-surface/70 text-sm">
+                Answer: <span className="text-on-surface font-medium">{answerResult.correctAnswer}</span>
+              </div>
+            )}
+            {answerResult.explanation && (
+              <div className="text-on-surface/50 text-sm mt-1">
+                {answerResult.explanation}
+              </div>
+            )}
           </div>
         )}
       </ChunkyCardContent>

--- a/src/app/trivia/components/InfiniteRulesModal.tsx
+++ b/src/app/trivia/components/InfiniteRulesModal.tsx
@@ -1,0 +1,80 @@
+'use client'
+import { useState } from 'react'
+import { ChunkyButton } from '@/components/ui/chunky-button'
+import type { InfiniteMode } from '@/app/trivia/hooks/useInfiniteRun'
+
+interface Props {
+  defaultMode: InfiniteMode
+  onContinue: (mode: InfiniteMode, dismissForever: boolean) => void
+  onCancel: () => void
+}
+
+export function InfiniteRulesModal({ defaultMode, onContinue, onCancel }: Props) {
+  const [dismissForever, setDismissForever] = useState(false)
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-surface-dim/80 backdrop-blur-sm p-4">
+      <div className="bg-surface-container-high rounded-ds-lg p-6 max-w-md w-full shadow-hero flex flex-col gap-4">
+        <div>
+          <h2 className="text-on-surface text-xl font-bold mb-1">Infinite Trivia</h2>
+          <p className="text-on-surface/60 text-sm">
+            An endless run powered by fresh AI-generated questions. Here&apos;s how it works:
+          </p>
+        </div>
+
+        <ul className="text-on-surface/80 text-sm flex flex-col gap-2">
+          <li className="flex gap-2">
+            <span aria-hidden="true">❤️</span>
+            <span><strong className="text-on-surface">3 lives.</strong> A wrong answer costs one. Zero lives ends the run.</span>
+          </li>
+          <li className="flex gap-2">
+            <span aria-hidden="true">🔥</span>
+            <span><strong className="text-on-surface">Streak multiplier.</strong> ×1.5 at 5 correct → ×2 at 10 → ×3 at 20.</span>
+          </li>
+          <li className="flex gap-2">
+            <span aria-hidden="true">🩹</span>
+            <span><strong className="text-on-surface">Bonus life.</strong> Every 10-streak refunds a life (cap of 3).</span>
+          </li>
+          <li className="flex gap-2">
+            <span aria-hidden="true">⭐</span>
+            <span><strong className="text-on-surface">Trailblazer.</strong> First to answer a fresh question? +50 bonus.</span>
+          </li>
+        </ul>
+
+        <p className="text-on-surface/50 text-xs">
+          Practice mode plays the same questions with no lives and no scoring — a low-pressure way to explore.
+        </p>
+
+        <label className="flex items-center gap-2 text-on-surface/70 text-sm cursor-pointer select-none">
+          <input
+            type="checkbox"
+            checked={dismissForever}
+            onChange={(e) => setDismissForever(e.target.checked)}
+            className="accent-ds-primary"
+          />
+          Don&apos;t show this again
+        </label>
+
+        <div className="flex flex-col sm:flex-row gap-2 sm:justify-end">
+          <ChunkyButton variant="ghost" size="sm" onClick={onCancel}>
+            Back
+          </ChunkyButton>
+          <ChunkyButton
+            variant="secondary"
+            size="sm"
+            onClick={() => onContinue('practice', dismissForever)}
+          >
+            Practice Mode
+          </ChunkyButton>
+          <ChunkyButton
+            variant="primary"
+            size="sm"
+            onClick={() => onContinue(defaultMode === 'practice' ? 'practice' : 'scored', dismissForever)}
+          >
+            Continue
+          </ChunkyButton>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/app/trivia/components/InfiniteRunSummary.tsx
+++ b/src/app/trivia/components/InfiniteRunSummary.tsx
@@ -5,6 +5,8 @@ import { ChunkyCard, ChunkyCardContent } from '@/components/ui/chunky-card'
 import { Pill } from '@/components/ui/pill'
 import { useAuth } from '@/hooks/useAuth'
 import { SignInCard } from './SignInCTA'
+import { QuestionRating } from './QuestionRating'
+import { FlagQuestion } from './FlagQuestion'
 import type { InfiniteRunState } from '@/app/trivia/hooks/useInfiniteRun'
 
 interface Props {
@@ -113,6 +115,8 @@ export function InfiniteRunSummary({ state, onPlayAgain, onBack }: Props) {
                     <span className={`font-bold text-sm min-w-[4rem] text-right ${a.correct ? 'text-ds-tertiary' : 'text-on-surface/30'}`}>
                       +{a.points}
                     </span>
+                    <QuestionRating questionId={a.questionId} />
+                    <FlagQuestion questionId={a.questionId} />
                   </div>
                 </div>
               ))}

--- a/src/app/trivia/components/InfiniteRunSummary.tsx
+++ b/src/app/trivia/components/InfiniteRunSummary.tsx
@@ -7,12 +7,13 @@ import { useAuth } from '@/hooks/useAuth'
 import { SignInCard } from './SignInCTA'
 import { QuestionRating } from './QuestionRating'
 import { FlagQuestion } from './FlagQuestion'
-import type { InfiniteRunState } from '@/app/trivia/hooks/useInfiniteRun'
+import type { InfiniteRunState, InfiniteMode } from '@/app/trivia/hooks/useInfiniteRun'
 
 interface Props {
   state: InfiniteRunState
   onPlayAgain: () => void
   onBack: () => void
+  mode?: InfiniteMode
 }
 
 function formatTime(ms: number): string {
@@ -28,7 +29,7 @@ function getRunRating(longestStreak: number): string {
   return 'Keep Exploring!'
 }
 
-export function InfiniteRunSummary({ state, onPlayAgain, onBack }: Props) {
+export function InfiniteRunSummary({ state, onPlayAgain, onBack, mode = 'scored' }: Props) {
   const { user } = useAuth()
   const [copied, setCopied] = useState(false)
 
@@ -57,7 +58,14 @@ export function InfiniteRunSummary({ state, onPlayAgain, onBack }: Props) {
         <h2 className="font-headline text-headline-lg text-ds-tertiary drop-shadow-[0_4px_0_var(--surface-container-lowest)] mb-1">
           {getRunRating(state.longestStreak)}
         </h2>
-        <p className="text-on-surface/50 text-sm">Run Complete</p>
+        {mode === 'practice' ? (
+          <div className="flex flex-col items-center gap-1">
+            <Pill tone="info" size="sm">Practice Run</Pill>
+            <p className="text-on-surface/50 text-xs mt-1">Practice runs don&apos;t count toward stats.</p>
+          </div>
+        ) : (
+          <p className="text-on-surface/50 text-sm">Run Complete</p>
+        )}
       </div>
 
       {/* Hero: Longest Streak */}

--- a/src/app/trivia/components/InfiniteRunSummary.tsx
+++ b/src/app/trivia/components/InfiniteRunSummary.tsx
@@ -1,0 +1,146 @@
+'use client'
+import { useState } from 'react'
+import { ChunkyButton } from '@/components/ui/chunky-button'
+import { ChunkyCard, ChunkyCardContent } from '@/components/ui/chunky-card'
+import { Pill } from '@/components/ui/pill'
+import { useAuth } from '@/hooks/useAuth'
+import { SignInCard } from './SignInCTA'
+import type { InfiniteRunState } from '@/app/trivia/hooks/useInfiniteRun'
+
+interface Props {
+  state: InfiniteRunState
+  onPlayAgain: () => void
+  onBack: () => void
+}
+
+function formatTime(ms: number): string {
+  const seconds = Math.round(ms / 1000)
+  return `${seconds}s`
+}
+
+function getRunRating(longestStreak: number): string {
+  if (longestStreak >= 20) return 'Legendary!'
+  if (longestStreak >= 10) return 'Amazing!'
+  if (longestStreak >= 5) return 'Great Run!'
+  if (longestStreak >= 2) return 'Good Try!'
+  return 'Keep Exploring!'
+}
+
+export function InfiniteRunSummary({ state, onPlayAgain, onBack }: Props) {
+  const { user } = useAuth()
+  const [copied, setCopied] = useState(false)
+
+  const handleShare = async () => {
+    const lines = [
+      '🧠 CometCave Infinite Trivia',
+      `🔥 Longest Streak: ${state.longestStreak}`,
+      `💎 Score: ${state.score.toLocaleString()}`,
+      `📊 ${state.questionsAnswered} questions answered`,
+      state.trailblazes > 0 ? `⭐ ${state.trailblazes} trailblazer${state.trailblazes === 1 ? '' : 's'}` : null,
+      'https://cometcave.com/trivia',
+    ].filter(Boolean).join('\n')
+
+    try {
+      await navigator.clipboard.writeText(lines)
+      setCopied(true)
+      setTimeout(() => setCopied(false), 2000)
+    } catch {
+      // Silent fail
+    }
+  }
+
+  return (
+    <div className="flex flex-col items-center gap-5 max-w-lg mx-auto py-6">
+      <div className="text-center">
+        <h2 className="font-headline text-headline-lg text-ds-tertiary drop-shadow-[0_4px_0_var(--surface-container-lowest)] mb-1">
+          {getRunRating(state.longestStreak)}
+        </h2>
+        <p className="text-on-surface/50 text-sm">Run Complete</p>
+      </div>
+
+      {/* Hero: Longest Streak */}
+      <ChunkyCard variant="surface-variant" className="w-full bg-surface-container/80 border-outline-variant">
+        <ChunkyCardContent className="pt-6">
+          <div className="text-center mb-4">
+            <div className="text-6xl font-bold text-ds-tertiary">
+              🔥 {state.longestStreak}
+            </div>
+            <div className="text-on-surface/40 text-sm mt-1">Longest Streak</div>
+          </div>
+
+          <div className="grid grid-cols-3 gap-3 mb-4">
+            <div className="text-center">
+              <div className="text-xl font-bold text-on-surface">{state.score.toLocaleString()}</div>
+              <div className="text-on-surface/50 text-xs">Total Score</div>
+            </div>
+            <div className="text-center">
+              <div className="text-xl font-bold text-on-surface">{state.questionsAnswered}</div>
+              <div className="text-on-surface/50 text-xs">Questions</div>
+            </div>
+            <div className="text-center">
+              <div className="text-xl font-bold text-ds-tertiary">{state.trailblazes}</div>
+              <div className="text-on-surface/50 text-xs">Trailblazers</div>
+            </div>
+          </div>
+        </ChunkyCardContent>
+      </ChunkyCard>
+
+      {state.longestStreak >= 5 && (
+        <Pill tone="hot" icon="local_fire_department">
+          {state.longestStreak} streak!
+        </Pill>
+      )}
+
+      {/* Per-question breakdown */}
+      {state.answers.length > 0 && (
+        <ChunkyCard variant="surface-variant" className="w-full bg-surface-container/80 border-outline-variant">
+          <ChunkyCardContent className="pt-4">
+            <h3 className="text-on-surface/70 text-sm font-semibold mb-3 uppercase tracking-wide">
+              Answer History
+            </h3>
+            <div className="flex flex-col gap-2 max-h-64 overflow-y-auto">
+              {state.answers.map((a, i) => (
+                <div key={i} className="flex items-center justify-between py-2 px-3 rounded bg-surface-dim/40">
+                  <div className="flex items-center gap-3">
+                    <span className="text-on-surface/50 text-sm font-mono w-4">{i + 1}</span>
+                    <span className={`text-lg ${a.correct ? 'text-ds-primary' : 'text-ds-error'}`}>
+                      {a.correct ? '✓' : '✗'}
+                    </span>
+                    {a.trailblazer && <span className="text-xs">⭐</span>}
+                  </div>
+                  <div className="flex items-center gap-3">
+                    <span className="text-on-surface/40 text-xs">{formatTime(a.timeMs)}</span>
+                    <span className={`font-bold text-sm min-w-[4rem] text-right ${a.correct ? 'text-ds-tertiary' : 'text-on-surface/30'}`}>
+                      +{a.points}
+                    </span>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </ChunkyCardContent>
+        </ChunkyCard>
+      )}
+
+      {/* Actions */}
+      <div className="flex flex-col gap-3 w-full">
+        <ChunkyButton variant="primary" size="hero" className="w-full" onClick={onPlayAgain}>
+          Play Again
+        </ChunkyButton>
+        <ChunkyButton variant="secondary" className="w-full" onClick={handleShare}>
+          {copied ? 'Copied!' : 'Share Run'}
+        </ChunkyButton>
+      </div>
+
+      {!user && (
+        <SignInCard
+          title="🔒 Your run wasn't saved"
+          description="Sign in to save your runs, build your constellation, and compete on the leaderboard."
+        />
+      )}
+
+      <ChunkyButton variant="ghost" size="sm" onClick={onBack}>
+        Back to Trivia
+      </ChunkyButton>
+    </div>
+  )
+}

--- a/src/app/trivia/components/InfiniteRunSummary.tsx
+++ b/src/app/trivia/components/InfiniteRunSummary.tsx
@@ -31,10 +31,13 @@ function getRunRating(longestStreak: number): string {
 
 const ANSWERS_PAGE_SIZE = 20
 
+type AnswerEntry = InfiniteRunState['answers'][number]
+
 export function InfiniteRunSummary({ state, onPlayAgain, onBack, mode = 'scored' }: Props) {
   const { user } = useAuth()
   const [copied, setCopied] = useState(false)
   const [showAllAnswers, setShowAllAnswers] = useState(false)
+  const [detailFor, setDetailFor] = useState<AnswerEntry | null>(null)
 
   const handleShare = async () => {
     const lines = [
@@ -120,6 +123,17 @@ export function InfiniteRunSummary({ state, onPlayAgain, onBack, mode = 'scored'
                       {a.correct ? '✓' : '✗'}
                     </span>
                     {a.trailblazer && <span className="text-xs">⭐</span>}
+                    {a.questionText && (
+                      <button
+                        type="button"
+                        onClick={() => setDetailFor(a)}
+                        className="text-on-surface/30 hover:text-on-surface/60 text-xs transition-colors"
+                        aria-label="View question details"
+                        title="View question"
+                      >
+                        ℹ️
+                      </button>
+                    )}
                   </div>
                   <div className="flex items-center gap-3">
                     <span className="text-on-surface/40 text-xs">{formatTime(a.timeMs)}</span>
@@ -154,16 +168,69 @@ export function InfiniteRunSummary({ state, onPlayAgain, onBack, mode = 'scored'
         </ChunkyButton>
       </div>
 
-      {!user && (
+      {(!user || user.isAnonymous) && (
         <SignInCard
-          title="🔒 Your run wasn't saved"
-          description="Sign in to save your runs, build your constellation, and compete on the leaderboard."
+          title={user?.isAnonymous ? '✨ Lock in your progress' : "🔒 Your run wasn't saved"}
+          description={
+            user?.isAnonymous
+              ? 'Create an account to keep your runs across devices, build your constellation, and compete on the leaderboard.'
+              : 'Sign in to save your runs, build your constellation, and compete on the leaderboard.'
+          }
         />
       )}
 
       <ChunkyButton variant="ghost" size="sm" onClick={onBack}>
         Back to Trivia
       </ChunkyButton>
+
+      {detailFor && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-surface-dim/80 backdrop-blur-sm p-4"
+          onClick={() => setDetailFor(null)}
+        >
+          <div
+            className="bg-surface-container-high rounded-ds-lg p-5 max-w-md w-full shadow-hero flex flex-col gap-3"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div className="flex items-start justify-between gap-3">
+              <div className="flex flex-wrap items-center gap-2">
+                <Pill tone={detailFor.correct ? 'success' : 'hot'} size="sm">
+                  {detailFor.correct ? 'Correct' : 'Wrong'}
+                </Pill>
+                <Pill tone="neutral" size="sm">{detailFor.difficulty.toUpperCase()}</Pill>
+                {detailFor.trailblazer && <Pill tone="warning" size="sm">⭐ Trailblazer</Pill>}
+              </div>
+              <button
+                onClick={() => setDetailFor(null)}
+                className="text-on-surface/40 hover:text-on-surface text-xl leading-none px-1"
+                aria-label="Close"
+              >
+                ×
+              </button>
+            </div>
+            <p className="text-on-surface/60 text-xs uppercase tracking-wide">{detailFor.category}</p>
+            <p className="text-on-surface text-base leading-snug">{detailFor.questionText}</p>
+            <div className="text-sm flex flex-col gap-1">
+              <div className="text-on-surface/70">
+                Your answer:{' '}
+                <span className={`font-medium ${detailFor.correct ? 'text-ds-primary' : 'text-ds-error'}`}>
+                  {detailFor.userAnswer || '—'}
+                </span>
+              </div>
+              {!detailFor.correct && (
+                <div className="text-on-surface/70">
+                  Correct answer: <span className="text-on-surface font-medium">{detailFor.correctAnswer}</span>
+                </div>
+              )}
+            </div>
+            {detailFor.explanation && (
+              <div className="text-on-surface/60 text-sm border-t border-outline-variant pt-3">
+                {detailFor.explanation}
+              </div>
+            )}
+          </div>
+        </div>
+      )}
     </div>
   )
 }

--- a/src/app/trivia/components/InfiniteRunSummary.tsx
+++ b/src/app/trivia/components/InfiniteRunSummary.tsx
@@ -29,9 +29,12 @@ function getRunRating(longestStreak: number): string {
   return 'Keep Exploring!'
 }
 
+const ANSWERS_PAGE_SIZE = 20
+
 export function InfiniteRunSummary({ state, onPlayAgain, onBack, mode = 'scored' }: Props) {
   const { user } = useAuth()
   const [copied, setCopied] = useState(false)
+  const [showAllAnswers, setShowAllAnswers] = useState(false)
 
   const handleShare = async () => {
     const lines = [
@@ -108,8 +111,8 @@ export function InfiniteRunSummary({ state, onPlayAgain, onBack, mode = 'scored'
             <h3 className="text-on-surface/70 text-sm font-semibold mb-3 uppercase tracking-wide">
               Answer History
             </h3>
-            <div className="flex flex-col gap-2 max-h-64 overflow-y-auto">
-              {state.answers.map((a, i) => (
+            <div className="flex flex-col gap-2">
+              {(showAllAnswers ? state.answers : state.answers.slice(0, ANSWERS_PAGE_SIZE)).map((a, i) => (
                 <div key={i} className="flex items-center justify-between py-2 px-3 rounded bg-surface-dim/40">
                   <div className="flex items-center gap-3">
                     <span className="text-on-surface/50 text-sm font-mono w-4">{i + 1}</span>
@@ -129,6 +132,14 @@ export function InfiniteRunSummary({ state, onPlayAgain, onBack, mode = 'scored'
                 </div>
               ))}
             </div>
+            {state.answers.length > ANSWERS_PAGE_SIZE && !showAllAnswers && (
+              <button
+                className="mt-3 w-full text-on-surface/50 text-sm hover:text-on-surface/80 transition-colors py-1"
+                onClick={() => setShowAllAnswers(true)}
+              >
+                Show all {state.answers.length} answers
+              </button>
+            )}
           </ChunkyCardContent>
         </ChunkyCard>
       )}

--- a/src/app/trivia/components/InfiniteStats.tsx
+++ b/src/app/trivia/components/InfiniteStats.tsx
@@ -144,7 +144,7 @@ export function InfiniteStats({ onBack }: { onBack: () => void }) {
           onClick={() => (window.location.href = '/trivia/infinite')}
           className="w-full"
         >
-          Enter the Infinite Cavern
+          Start Infinite Trivia
         </ChunkyButton>
         <ChunkyButton variant="secondary" onClick={onBack} className="w-full">
           Back

--- a/src/app/trivia/components/InfiniteStats.tsx
+++ b/src/app/trivia/components/InfiniteStats.tsx
@@ -1,0 +1,336 @@
+'use client'
+import { useCallback, useEffect, useState } from 'react'
+
+import { ChunkyButton } from '@/components/ui/chunky-button'
+import { ChunkyCard, ChunkyCardContent } from '@/components/ui/chunky-card'
+import { useAuth } from '@/hooks/useAuth'
+
+import { SignInCard } from './SignInCTA'
+
+interface CategoryStats {
+  answered: number
+  correct: number
+  totalTimeMs: number
+}
+
+interface DifficultyStats {
+  answered: number
+  correct: number
+}
+
+interface AggregateStats {
+  totalAnswered: number
+  totalCorrect: number
+  runsPlayed: number
+  bestRun: { score: number; longestStreak: number } | null
+  bestStreak: number
+  trailblazerCount: number
+  totalTimeMs: number
+  byCategory: Record<string, CategoryStats>
+  byDifficulty: {
+    easy: DifficultyStats
+    medium: DifficultyStats
+    hard: DifficultyStats
+  }
+}
+
+function getAccuracyColor(accuracy: number): string {
+  if (accuracy >= 80) return 'text-ds-primary'
+  if (accuracy >= 60) return 'text-yellow-400'
+  return 'text-ds-error'
+}
+
+function AccuracyRing({ accuracy, size = 48 }: { accuracy: number; size?: number }) {
+  const radius = (size - 6) / 2
+  const circumference = 2 * Math.PI * radius
+  const offset = circumference - (accuracy / 100) * circumference
+  const color =
+    accuracy >= 80 ? 'stroke-ds-primary' : accuracy >= 60 ? 'stroke-yellow-400' : 'stroke-ds-error'
+
+  return (
+    <svg width={size} height={size} className="transform -rotate-90">
+      <circle
+        cx={size / 2}
+        cy={size / 2}
+        r={radius}
+        fill="none"
+        strokeWidth={3}
+        className="stroke-surface-container-highest"
+      />
+      <circle
+        cx={size / 2}
+        cy={size / 2}
+        r={radius}
+        fill="none"
+        strokeWidth={3}
+        strokeDasharray={circumference}
+        strokeDashoffset={offset}
+        strokeLinecap="round"
+        className={color}
+      />
+    </svg>
+  )
+}
+
+export function InfiniteStats({ onBack }: { onBack: () => void }) {
+  const { user } = useAuth()
+  const [stats, setStats] = useState<AggregateStats | null>(null)
+  const [loading, setLoading] = useState(true)
+
+  const fetchStats = useCallback(async () => {
+    if (!user) {
+      setLoading(false)
+      return
+    }
+    try {
+      const token = await user.getIdToken()
+      const res = await fetch('/api/v1/trivia/stats/me', {
+        headers: { Authorization: `Bearer ${token}` },
+      })
+      if (res.ok) {
+        setStats(await res.json())
+      }
+    } catch {
+      // silent
+    } finally {
+      setLoading(false)
+    }
+  }, [user])
+
+  useEffect(() => {
+    fetchStats()
+  }, [fetchStats])
+
+  if (loading) {
+    return (
+      <div className="flex flex-col items-center gap-4 py-8 max-w-lg mx-auto">
+        <div className="text-on-surface/60 text-lg">Loading stats...</div>
+      </div>
+    )
+  }
+
+  if (!user) {
+    return (
+      <div className="flex flex-col items-center gap-6 max-w-lg mx-auto py-8">
+        <h2 className="text-3xl font-bold text-ds-tertiary">Infinite Stats</h2>
+        <SignInCard
+          title="Your constellation awaits"
+          description="Sign in to track your infinite trivia journey — accuracy, streaks, and category mastery."
+        />
+        <ChunkyButton variant="secondary" onClick={onBack} className="w-full">
+          Back
+        </ChunkyButton>
+      </div>
+    )
+  }
+
+  if (!stats || stats.runsPlayed === 0) {
+    return (
+      <div className="flex flex-col items-center gap-6 max-w-lg mx-auto py-8">
+        <h2 className="text-3xl font-bold text-ds-tertiary">Infinite Stats</h2>
+        <ChunkyCard
+          variant="surface-variant"
+          className="w-full bg-surface-container/80 border-outline-variant"
+        >
+          <ChunkyCardContent className="pt-6 text-center">
+            <p className="text-on-surface/70 text-lg mb-2">The stars haven&apos;t aligned yet</p>
+            <p className="text-on-surface/50 text-sm">
+              Complete your first infinite run to begin mapping your constellation.
+            </p>
+          </ChunkyCardContent>
+        </ChunkyCard>
+        <ChunkyButton
+          variant="primary"
+          onClick={() => (window.location.href = '/trivia/infinite')}
+          className="w-full"
+        >
+          Enter the Infinite Cavern
+        </ChunkyButton>
+        <ChunkyButton variant="secondary" onClick={onBack} className="w-full">
+          Back
+        </ChunkyButton>
+      </div>
+    )
+  }
+
+  const accuracy =
+    stats.totalAnswered > 0
+      ? Math.round((stats.totalCorrect / stats.totalAnswered) * 100)
+      : 0
+  const avgTimeMs =
+    stats.totalAnswered > 0 ? Math.round(stats.totalTimeMs / stats.totalAnswered) : 0
+  const categories = Object.entries(stats.byCategory).sort((a, b) => b[1].answered - a[1].answered)
+
+  return (
+    <div className="flex flex-col gap-5 max-w-lg mx-auto py-6">
+      <div className="text-center">
+        <h2 className="text-3xl font-bold text-ds-tertiary mb-1">Infinite Stats</h2>
+        <p className="text-on-surface/50 text-sm">Your endless trivia journey</p>
+      </div>
+
+      {/* Hero stats */}
+      <div className="grid grid-cols-2 gap-3">
+        <ChunkyCard
+          variant="surface-variant"
+          className="bg-surface-container/80 border-outline-variant"
+        >
+          <ChunkyCardContent className="pt-5 pb-5 text-center">
+            <div className={`text-3xl font-bold ${getAccuracyColor(accuracy)}`}>{accuracy}%</div>
+            <div className="text-on-surface/50 text-xs mt-1">Accuracy</div>
+          </ChunkyCardContent>
+        </ChunkyCard>
+        <ChunkyCard
+          variant="surface-variant"
+          className="bg-surface-container/80 border-outline-variant"
+        >
+          <ChunkyCardContent className="pt-5 pb-5 text-center">
+            <div className="text-3xl font-bold text-on-surface">{stats.totalAnswered}</div>
+            <div className="text-on-surface/50 text-xs mt-1">Questions</div>
+          </ChunkyCardContent>
+        </ChunkyCard>
+        <ChunkyCard
+          variant="surface-variant"
+          className="bg-surface-container/80 border-outline-variant"
+        >
+          <ChunkyCardContent className="pt-5 pb-5 text-center">
+            <div className="text-3xl font-bold text-ds-tertiary">{stats.runsPlayed}</div>
+            <div className="text-on-surface/50 text-xs mt-1">Runs Played</div>
+          </ChunkyCardContent>
+        </ChunkyCard>
+        <ChunkyCard
+          variant="surface-variant"
+          className="bg-surface-container/80 border-outline-variant"
+        >
+          <ChunkyCardContent className="pt-5 pb-5 text-center">
+            <div className="text-3xl font-bold text-on-surface">
+              {Math.round(avgTimeMs / 1000)}s
+            </div>
+            <div className="text-on-surface/50 text-xs mt-1">Avg Answer</div>
+          </ChunkyCardContent>
+        </ChunkyCard>
+      </div>
+
+      {/* Best run */}
+      {stats.bestRun && (
+        <ChunkyCard
+          variant="surface-variant"
+          className="bg-surface-container/80 border-outline-variant"
+        >
+          <ChunkyCardContent className="pt-5 pb-5">
+            <h3 className="text-on-surface/70 text-sm font-semibold mb-3 uppercase tracking-wide">
+              Best Run
+            </h3>
+            <div className="grid grid-cols-2 gap-3">
+              <div className="text-center">
+                <div className="text-2xl font-bold text-ds-tertiary">
+                  🔥 {stats.bestRun.longestStreak}
+                </div>
+                <div className="text-on-surface/50 text-xs mt-1">Longest Streak</div>
+              </div>
+              <div className="text-center">
+                <div className="text-2xl font-bold text-on-surface">
+                  {stats.bestRun.score.toLocaleString()}
+                </div>
+                <div className="text-on-surface/50 text-xs mt-1">Score</div>
+              </div>
+            </div>
+          </ChunkyCardContent>
+        </ChunkyCard>
+      )}
+
+      {/* Streaks + trailblazer */}
+      <ChunkyCard
+        variant="surface-variant"
+        className="bg-surface-container/80 border-outline-variant"
+      >
+        <ChunkyCardContent className="pt-5 pb-5">
+          <div className="grid grid-cols-2 gap-3">
+            <div className="text-center">
+              <div className="text-2xl font-bold text-ds-tertiary">{stats.bestStreak}</div>
+              <div className="text-on-surface/50 text-xs mt-1">Best Streak</div>
+            </div>
+            <div className="text-center">
+              <div className="text-2xl font-bold text-ds-tertiary">
+                &#x2B50; {stats.trailblazerCount}
+              </div>
+              <div className="text-on-surface/50 text-xs mt-1">Trailblazers</div>
+            </div>
+          </div>
+        </ChunkyCardContent>
+      </ChunkyCard>
+
+      {/* Category constellation (grid of accuracy rings) */}
+      {categories.length > 0 && (
+        <ChunkyCard
+          variant="surface-variant"
+          className="bg-surface-container/80 border-outline-variant"
+        >
+          <ChunkyCardContent className="pt-5 pb-5">
+            <h3 className="text-on-surface/70 text-sm font-semibold mb-3 uppercase tracking-wide">
+              Category Constellation
+            </h3>
+            <div className="grid grid-cols-2 sm:grid-cols-3 gap-4">
+              {categories.map(([cat, data]) => {
+                const catAccuracy =
+                  data.answered > 0 ? Math.round((data.correct / data.answered) * 100) : 0
+                return (
+                  <div key={cat} className="flex flex-col items-center gap-1">
+                    <div className="relative">
+                      <AccuracyRing accuracy={catAccuracy} />
+                      <div className="absolute inset-0 flex items-center justify-center">
+                        <span className="text-xs font-bold text-on-surface">{catAccuracy}%</span>
+                      </div>
+                    </div>
+                    <span className="text-on-surface/60 text-xs text-center leading-tight">
+                      {cat}
+                    </span>
+                    <span className="text-on-surface/30 text-[10px]">{data.answered} Q</span>
+                  </div>
+                )
+              })}
+            </div>
+          </ChunkyCardContent>
+        </ChunkyCard>
+      )}
+
+      {/* Per-difficulty breakdown */}
+      <ChunkyCard
+        variant="surface-variant"
+        className="bg-surface-container/80 border-outline-variant"
+      >
+        <ChunkyCardContent className="pt-5 pb-5">
+          <h3 className="text-on-surface/70 text-sm font-semibold mb-3 uppercase tracking-wide">
+            By Difficulty
+          </h3>
+          {(['easy', 'medium', 'hard'] as const).map((diff) => {
+            const d = stats.byDifficulty[diff]
+            const pct = d.answered > 0 ? Math.round((d.correct / d.answered) * 100) : 0
+            const diffColors = {
+              easy: 'bg-green-500',
+              medium: 'bg-yellow-500',
+              hard: 'bg-red-500',
+            }
+            return (
+              <div key={diff} className="flex items-center gap-3 mb-2">
+                <span className="text-on-surface/60 text-sm w-16 capitalize">{diff}</span>
+                <div className="flex-1 h-3 bg-surface-container-highest rounded-full overflow-hidden">
+                  <div
+                    className={`h-full ${diffColors[diff]} transition-all`}
+                    style={{ width: `${pct}%` }}
+                  />
+                </div>
+                <span className="text-on-surface/60 text-xs w-12 text-right">
+                  {pct}% ({d.answered})
+                </span>
+              </div>
+            )
+          })}
+        </ChunkyCardContent>
+      </ChunkyCard>
+
+      <ChunkyButton variant="secondary" onClick={onBack} className="w-full">
+        Back
+      </ChunkyButton>
+    </div>
+  )
+}

--- a/src/app/trivia/components/QuestionRating.tsx
+++ b/src/app/trivia/components/QuestionRating.tsx
@@ -1,0 +1,41 @@
+'use client'
+import { useState } from 'react'
+import { useAuth } from '@/hooks/useAuth'
+
+interface Props {
+  questionId: string
+}
+
+export function QuestionRating({ questionId }: Props) {
+  const { user } = useAuth()
+  const [vote, setVote] = useState<'up' | 'down' | null>(null)
+
+  if (!user) return null  // logged-in only
+
+  const handleVote = async (newVote: 'up' | 'down') => {
+    const prev = vote
+    setVote(newVote === vote ? null : newVote)  // toggle
+    try {
+      const token = await user.getIdToken()
+      const res = await fetch(`/api/v1/trivia/questions/${questionId}/rate`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+        body: JSON.stringify({ vote: newVote === vote ? null : newVote }),
+      })
+      if (!res.ok) setVote(prev) // rollback
+    } catch {
+      setVote(prev) // rollback
+    }
+  }
+
+  return (
+    <div className="flex items-center gap-1">
+      <button onClick={() => handleVote('up')} className={`text-sm p-0.5 rounded transition-colors ${vote === 'up' ? 'text-ds-primary' : 'text-on-surface/30 hover:text-on-surface/60'}`} aria-label="Rate up">
+        👍
+      </button>
+      <button onClick={() => handleVote('down')} className={`text-sm p-0.5 rounded transition-colors ${vote === 'down' ? 'text-ds-error' : 'text-on-surface/30 hover:text-on-surface/60'}`} aria-label="Rate down">
+        👎
+      </button>
+    </div>
+  )
+}

--- a/src/app/trivia/components/QuestionRating.tsx
+++ b/src/app/trivia/components/QuestionRating.tsx
@@ -13,27 +13,34 @@ export function QuestionRating({ questionId }: Props) {
   if (!user) return null  // logged-in only
 
   const handleVote = async (newVote: 'up' | 'down') => {
-    const prev = vote
-    setVote(newVote === vote ? null : newVote)  // toggle
+    if (vote !== null) return // terminal — one vote per question per session
+    setVote(newVote)
     try {
       const token = await user.getIdToken()
       const res = await fetch(`/api/v1/trivia/questions/${questionId}/rate`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
-        body: JSON.stringify({ vote: newVote === vote ? null : newVote }),
+        body: JSON.stringify({ vote: newVote }),
       })
-      if (!res.ok) setVote(prev) // rollback
+      if (!res.ok) setVote(null) // rollback
     } catch {
-      setVote(prev) // rollback
+      setVote(null) // rollback
     }
+  }
+
+  if (vote === 'up') {
+    return <span className="text-on-surface/40 text-xs">👍 Liked</span>
+  }
+  if (vote === 'down') {
+    return <span className="text-on-surface/40 text-xs">👎 Disliked</span>
   }
 
   return (
     <div className="flex items-center gap-1">
-      <button onClick={() => handleVote('up')} className={`text-sm p-0.5 rounded transition-colors ${vote === 'up' ? 'text-ds-primary' : 'text-on-surface/30 hover:text-on-surface/60'}`} aria-label="Rate up">
+      <button onClick={() => handleVote('up')} className="text-sm p-0.5 rounded text-on-surface/30 hover:text-on-surface/60 transition-colors" aria-label="Good Question" title="Good Question">
         👍
       </button>
-      <button onClick={() => handleVote('down')} className={`text-sm p-0.5 rounded transition-colors ${vote === 'down' ? 'text-ds-error' : 'text-on-surface/30 hover:text-on-surface/60'}`} aria-label="Rate down">
+      <button onClick={() => handleVote('down')} className="text-sm p-0.5 rounded text-on-surface/30 hover:text-on-surface/60 transition-colors" aria-label="Bad Question" title="Bad Question">
         👎
       </button>
     </div>

--- a/src/app/trivia/components/TriviaHUD.tsx
+++ b/src/app/trivia/components/TriviaHUD.tsx
@@ -55,7 +55,7 @@ export function TriviaHUD({
             <span className="material-symbols-outlined text-[18px]">close</span>
           }
         >
-          <span className="hidden sm:inline">Flee</span>
+          <span className="hidden sm:inline">Exit Game</span>
         </ChunkyButton>
 
         <Pill tone="neutral" size="sm">
@@ -85,7 +85,7 @@ export function TriviaHUD({
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-surface-dim/80 backdrop-blur-sm">
           <div className="bg-surface-container-high rounded-ds-lg p-8 max-w-sm mx-4 shadow-hero text-center flex flex-col gap-4">
             <p className="text-on-surface text-body-lg">
-              Leave the cavern? Your unfinished round will fade.
+              End this round? Your unfinished progress will be lost.
             </p>
             <div className="flex gap-3 justify-center">
               <ChunkyButton
@@ -103,7 +103,7 @@ export function TriviaHUD({
                   onFlee()
                 }}
               >
-                Flee
+                Exit Game
               </ChunkyButton>
             </div>
           </div>

--- a/src/app/trivia/components/TriviaLanding.tsx
+++ b/src/app/trivia/components/TriviaLanding.tsx
@@ -21,12 +21,14 @@ export function TriviaLanding({
   onViewStats,
   onViewLeaderboard,
   onStartInfinite,
+  onViewInfiniteStats,
   todayResult,
 }: {
   onStartGame?: () => void
   onViewStats?: () => void
   onViewLeaderboard?: () => void
   onStartInfinite?: () => void
+  onViewInfiniteStats?: () => void
   todayResult: TriviaGameResult | null
 }) {
   const { user, loading: authLoading, configured: authConfigured, signOut } = useAuth()
@@ -202,7 +204,7 @@ export function TriviaLanding({
       </div>
 
       {/* Links */}
-      <div className="flex gap-3 text-sm">
+      <div className="flex gap-3 text-sm flex-wrap justify-center">
         <button
           onClick={onViewStats}
           className="text-ds-tertiary hover:text-ds-tertiary/80 transition-colors underline-offset-4 hover:underline"
@@ -215,6 +217,13 @@ export function TriviaLanding({
           className="text-ds-tertiary hover:text-ds-tertiary/80 transition-colors underline-offset-4 hover:underline"
         >
           Leaderboard
+        </button>
+        <span className="text-on-surface/20">·</span>
+        <button
+          onClick={onViewInfiniteStats}
+          className="text-ds-tertiary hover:text-ds-tertiary/80 transition-colors underline-offset-4 hover:underline"
+        >
+          Infinite Stats
         </button>
       </div>
 

--- a/src/app/trivia/components/TriviaLanding.tsx
+++ b/src/app/trivia/components/TriviaLanding.tsx
@@ -167,7 +167,7 @@ export function TriviaLanding({
             className="w-full"
             onClick={onStartInfinite}
           >
-            Enter the Infinite Cavern
+            Start Infinite Trivia
           </ChunkyButton>
           <ChunkyButton
             variant="ghost"

--- a/src/app/trivia/components/TriviaLanding.tsx
+++ b/src/app/trivia/components/TriviaLanding.tsx
@@ -20,11 +20,13 @@ export function TriviaLanding({
   onStartGame,
   onViewStats,
   onViewLeaderboard,
+  onStartInfinite,
   todayResult,
 }: {
   onStartGame?: () => void
   onViewStats?: () => void
   onViewLeaderboard?: () => void
+  onStartInfinite?: () => void
   todayResult: TriviaGameResult | null
 }) {
   const { user, loading: authLoading, configured: authConfigured, signOut } = useAuth()
@@ -145,6 +147,24 @@ export function TriviaLanding({
               {todayResult.correct}/{todayResult.total} correct
             </div>
           )}
+        </ChunkyCardContent>
+      </ChunkyCard>
+
+      {/* Endless Run entry */}
+      <ChunkyCard variant="surface-container-high" className="w-full">
+        <ChunkyCardContent className="flex flex-col items-center gap-3 pt-6">
+          <div className="text-center">
+            <h3 className="text-on-surface font-bold text-lg">Endless Run</h3>
+            <p className="text-on-surface/50 text-sm">The cave doesn&apos;t sleep. How far can you go?</p>
+          </div>
+          <ChunkyButton
+            variant="secondary"
+            size="lg"
+            className="w-full"
+            onClick={onStartInfinite}
+          >
+            Enter the Infinite Cavern
+          </ChunkyButton>
         </ChunkyCardContent>
       </ChunkyCard>
 

--- a/src/app/trivia/components/TriviaLanding.tsx
+++ b/src/app/trivia/components/TriviaLanding.tsx
@@ -22,6 +22,7 @@ export function TriviaLanding({
   onViewLeaderboard,
   onStartInfinite,
   onViewInfiniteStats,
+  onStartPractice,
   todayResult,
 }: {
   onStartGame?: () => void
@@ -29,6 +30,7 @@ export function TriviaLanding({
   onViewLeaderboard?: () => void
   onStartInfinite?: () => void
   onViewInfiniteStats?: () => void
+  onStartPractice?: () => void
   todayResult: TriviaGameResult | null
 }) {
   const { user, loading: authLoading, configured: authConfigured, signOut } = useAuth()
@@ -166,6 +168,14 @@ export function TriviaLanding({
             onClick={onStartInfinite}
           >
             Enter the Infinite Cavern
+          </ChunkyButton>
+          <ChunkyButton
+            variant="ghost"
+            size="sm"
+            className="w-full"
+            onClick={onStartPractice}
+          >
+            Practice Mode
           </ChunkyButton>
         </ChunkyCardContent>
       </ChunkyCard>

--- a/src/app/trivia/components/TriviaResults.tsx
+++ b/src/app/trivia/components/TriviaResults.tsx
@@ -91,11 +91,12 @@ interface TriviaResultsProps {
   onBack: () => void
   onViewStats?: () => void
   onViewLeaderboard?: () => void
+  onStartInfinite?: () => void
   // Optional: pass questions data for difficulty display
   questionDifficulties?: Array<{ difficulty: string; source: string }>
 }
 
-export function TriviaResults({ result, onBack, onViewStats, onViewLeaderboard }: TriviaResultsProps) {
+export function TriviaResults({ result, onBack, onViewStats, onViewLeaderboard, onStartInfinite }: TriviaResultsProps) {
   const [copied, setCopied] = useState(false)
   const { user } = useAuth()
   const { stats, displayName } = useTriviaUser()
@@ -239,6 +240,22 @@ export function TriviaResults({ result, onBack, onViewStats, onViewLeaderboard }
       >
         {copied ? 'Copied!' : 'Share Score'}
       </ChunkyButton>
+
+      {onStartInfinite && (
+        <ChunkyCard variant="surface-variant" className="w-full bg-surface-container/80 border-outline-variant">
+          <ChunkyCardContent className="pt-4 pb-4 flex flex-col gap-3 items-center text-center">
+            <div>
+              <h3 className="text-on-surface font-semibold text-base mb-0.5">Want more?</h3>
+              <p className="text-on-surface/60 text-sm">
+                Keep going with Infinite Trivia — endless AI-generated questions.
+              </p>
+            </div>
+            <ChunkyButton variant="secondary" className="w-full" onClick={onStartInfinite}>
+              Start Infinite Trivia
+            </ChunkyButton>
+          </ChunkyCardContent>
+        </ChunkyCard>
+      )}
 
       {!user && (
         <SignInCard

--- a/src/app/trivia/hooks/useInfiniteRun.ts
+++ b/src/app/trivia/hooks/useInfiniteRun.ts
@@ -25,8 +25,20 @@ export interface InfiniteRunState {
   score: number
   questionsAnswered: number
   trailblazes: number
-  lastAnswer: (AnswerResult & { trailblazer: boolean }) | null
-  answers: Array<{ questionId: string; correct: boolean; points: number; timeMs: number; trailblazer: boolean }>
+  lastAnswer: (AnswerResult & { trailblazer: boolean; correctAnswer: string; explanation: string | null }) | null
+  answers: Array<{
+    questionId: string
+    correct: boolean
+    points: number
+    timeMs: number
+    trailblazer: boolean
+    userAnswer: string
+    questionText: string
+    category: string
+    difficulty: 'easy' | 'medium' | 'hard'
+    correctAnswer: string
+    explanation: string | null
+  }>
   error: string | null
 }
 
@@ -48,6 +60,8 @@ export function useInfiniteRun() {
   })
   const { user } = useAuth()
   const startTimeRef = useRef<number>(0)
+  const prefetchRef = useRef<Promise<InfiniteQuestion | null> | null>(null)
+  const prefetchAbortRef = useRef<AbortController | null>(null)
 
   const getAuthHeaders = useCallback(async () => {
     if (!user) throw new Error('Not authenticated')
@@ -58,7 +72,35 @@ export function useInfiniteRun() {
     }
   }, [user])
 
+  const cancelPrefetch = useCallback(() => {
+    if (prefetchAbortRef.current) {
+      prefetchAbortRef.current.abort()
+      prefetchAbortRef.current = null
+    }
+    prefetchRef.current = null
+  }, [])
+
+  const startPrefetch = useCallback((streak: number) => {
+    cancelPrefetch()
+    const controller = new AbortController()
+    prefetchAbortRef.current = controller
+    prefetchRef.current = (async (): Promise<InfiniteQuestion | null> => {
+      try {
+        const headers = await getAuthHeaders()
+        const qRes = await fetch(`/api/v1/trivia/infinite/next?streak=${streak}`, {
+          headers,
+          signal: controller.signal,
+        })
+        if (qRes.status === 204 || !qRes.ok) return null
+        return (await qRes.json()) as InfiniteQuestion
+      } catch {
+        return null
+      }
+    })()
+  }, [cancelPrefetch, getAuthHeaders])
+
   const startRun = useCallback(async (mode: InfiniteMode = 'scored') => {
+    cancelPrefetch()
     setState(s => ({ ...s, phase: 'loading', mode, error: null }))
     try {
       const headers = await getAuthHeaders()
@@ -74,6 +116,10 @@ export function useInfiniteRun() {
       const qRes = await fetch(`/api/v1/trivia/infinite/next?streak=0`, { headers })
       if (qRes.status === 204) {
         setState(s => ({ ...s, phase: 'exhausted', runId: data.runId }))
+        return
+      }
+      if (qRes.status === 429) {
+        setState(s => ({ ...s, phase: 'error', error: 'Too many fresh questions generated for now. Try again in a bit.' }))
         return
       }
       if (!qRes.ok) throw new Error('Failed to fetch question')
@@ -95,15 +141,17 @@ export function useInfiniteRun() {
         lastAnswer: null,
         answers: [],
       }))
-    } catch {
+    } catch (err) {
+      console.error('[infinite] startRun failed:', err)
       setState(s => ({ ...s, phase: 'error', error: 'Failed to start run.' }))
     }
-  }, [getAuthHeaders])
+  }, [getAuthHeaders, cancelPrefetch])
 
   const submitAnswer = useCallback(async (answer: string) => {
     if (state.phase !== 'playing' || !state.runId || !state.question) return
 
-    const currentQuestionId = state.question.id
+    const currentQuestion = state.question
+    const currentQuestionId = currentQuestion.id
     setState(s => ({ ...s, phase: 'answering' }))
     const elapsedMs = Date.now() - startTimeRef.current
 
@@ -119,15 +167,25 @@ export function useInfiniteRun() {
         }),
       })
       if (res.status === 409) {
+        cancelPrefetch()
         setState(s => ({ ...s, phase: 'ended' }))
         return
       }
       if (!res.ok) throw new Error('Failed to submit answer')
       const result = await res.json()
 
+      // Kick off the next question fetch in the background while the player
+      // reads their feedback — only when the run is continuing.
+      if (!result.runOver) {
+        startPrefetch(result.currentStreak)
+      }
+
+      // Always show the answer feedback (correct answer + explanation + rating)
+      // before transitioning to the summary, even when this answer ended the
+      // run. The player clicks through to view the summary.
       setState(s => ({
         ...s,
-        phase: result.runOver ? 'ended' : 'answered',
+        phase: 'answered',
         lastAnswer: result,
         livesRemaining: result.livesRemaining,
         currentStreak: result.currentStreak,
@@ -135,15 +193,42 @@ export function useInfiniteRun() {
         score: result.score,
         questionsAnswered: s.questionsAnswered + 1,
         trailblazes: result.trailblazer ? s.trailblazes + 1 : s.trailblazes,
-        answers: [...s.answers, { questionId: currentQuestionId, correct: result.correct, points: result.points, timeMs: elapsedMs, trailblazer: result.trailblazer }],
+        answers: [...s.answers, {
+          questionId: currentQuestionId,
+          correct: result.correct,
+          points: result.points,
+          timeMs: elapsedMs,
+          trailblazer: result.trailblazer,
+          userAnswer: answer,
+          questionText: currentQuestion.question,
+          category: currentQuestion.category,
+          difficulty: currentQuestion.difficulty,
+          correctAnswer: result.correctAnswer,
+          explanation: result.explanation,
+        }],
       }))
-    } catch {
+    } catch (err) {
+      console.error('[infinite] submitAnswer failed:', err)
       setState(s => ({ ...s, phase: 'error', error: 'Failed to submit answer.' }))
     }
-  }, [state.phase, state.runId, state.question, getAuthHeaders])
+  }, [state.phase, state.runId, state.question, getAuthHeaders, startPrefetch, cancelPrefetch])
 
   const nextQuestion = useCallback(async () => {
     if (state.phase !== 'answered' || !state.runId) return
+
+    // If a prefetch is in-flight or already complete, await/consume it before
+    // falling back to a fresh request.
+    if (prefetchRef.current) {
+      const pending = prefetchRef.current
+      prefetchRef.current = null
+      prefetchAbortRef.current = null
+      const prefetched = await pending
+      if (prefetched) {
+        startTimeRef.current = Date.now()
+        setState(s => ({ ...s, phase: 'playing', question: prefetched, lastAnswer: null }))
+        return
+      }
+    }
 
     setState(s => ({ ...s, phase: 'loading' }))
     try {
@@ -153,18 +238,27 @@ export function useInfiniteRun() {
         setState(s => ({ ...s, phase: 'exhausted' }))
         return
       }
+      if (qRes.status === 429) {
+        setState(s => ({ ...s, phase: 'error', error: 'Too many fresh questions generated for now. Try again in a bit.' }))
+        return
+      }
       if (!qRes.ok) throw new Error('Failed to fetch question')
       const question = await qRes.json()
 
       startTimeRef.current = Date.now()
       setState(s => ({ ...s, phase: 'playing', question, lastAnswer: null }))
-    } catch {
+    } catch (err) {
+      console.error('[infinite] nextQuestion failed:', err)
       setState(s => ({ ...s, phase: 'error', error: 'Failed to fetch next question.' }))
     }
   }, [state.phase, state.runId, state.currentStreak, getAuthHeaders])
 
   const endRun = useCallback(async () => {
-    if (!state.runId) {
+    cancelPrefetch()
+    // If the server already auto-finalized this run (lives reached 0), skip
+    // the redundant /end call and just navigate to the summary.
+    const alreadyEnded = state.lastAnswer?.runOver === true
+    if (!state.runId || alreadyEnded) {
       setState(s => ({ ...s, phase: 'ended' }))
       return
     }
@@ -178,7 +272,7 @@ export function useInfiniteRun() {
       // Best effort
     }
     setState(s => ({ ...s, phase: 'ended' }))
-  }, [state.runId, getAuthHeaders])
+  }, [state.runId, state.lastAnswer, getAuthHeaders, cancelPrefetch])
 
   return { state, startRun, submitAnswer, nextQuestion, endRun }
 }

--- a/src/app/trivia/hooks/useInfiniteRun.ts
+++ b/src/app/trivia/hooks/useInfiniteRun.ts
@@ -24,7 +24,7 @@ export interface InfiniteRunState {
   questionsAnswered: number
   trailblazes: number
   lastAnswer: (AnswerResult & { trailblazer: boolean }) | null
-  answers: Array<{ correct: boolean; points: number; timeMs: number; trailblazer: boolean }>
+  answers: Array<{ questionId: string; correct: boolean; points: number; timeMs: number; trailblazer: boolean }>
   error: string | null
 }
 
@@ -99,6 +99,7 @@ export function useInfiniteRun() {
   const submitAnswer = useCallback(async (answer: string) => {
     if (state.phase !== 'playing' || !state.runId || !state.question) return
 
+    const currentQuestionId = state.question.id
     setState(s => ({ ...s, phase: 'answering' }))
     const elapsedMs = Date.now() - startTimeRef.current
 
@@ -108,7 +109,7 @@ export function useInfiniteRun() {
         method: 'POST',
         headers,
         body: JSON.stringify({
-          questionId: state.question.id,
+          questionId: currentQuestionId,
           answer,
           elapsedMs,
         }),
@@ -130,7 +131,7 @@ export function useInfiniteRun() {
         score: result.score,
         questionsAnswered: s.questionsAnswered + 1,
         trailblazes: result.trailblazer ? s.trailblazes + 1 : s.trailblazes,
-        answers: [...s.answers, { correct: result.correct, points: result.points, timeMs: elapsedMs, trailblazer: result.trailblazer }],
+        answers: [...s.answers, { questionId: currentQuestionId, correct: result.correct, points: result.points, timeMs: elapsedMs, trailblazer: result.trailblazer }],
       }))
     } catch {
       setState(s => ({ ...s, phase: 'error', error: 'Failed to submit answer.' }))

--- a/src/app/trivia/hooks/useInfiniteRun.ts
+++ b/src/app/trivia/hooks/useInfiniteRun.ts
@@ -1,0 +1,179 @@
+'use client'
+import { useCallback, useRef, useState } from 'react'
+import { useAuth } from '@/hooks/useAuth'
+import { LIVES_START, type AnswerResult } from '@/app/trivia/lib/infiniteScoring'
+
+export type InfinitePhase = 'idle' | 'loading' | 'playing' | 'answering' | 'answered' | 'exhausted' | 'ended' | 'error'
+
+export interface InfiniteQuestion {
+  id: string
+  question: string
+  category: string
+  difficulty: 'easy' | 'medium' | 'hard'
+  timesShown: number
+}
+
+export interface InfiniteRunState {
+  phase: InfinitePhase
+  runId: string | null
+  question: InfiniteQuestion | null
+  livesRemaining: number
+  currentStreak: number
+  longestStreak: number
+  score: number
+  questionsAnswered: number
+  trailblazes: number
+  lastAnswer: (AnswerResult & { trailblazer: boolean }) | null
+  answers: Array<{ correct: boolean; points: number; timeMs: number; trailblazer: boolean }>
+  error: string | null
+}
+
+export function useInfiniteRun() {
+  const [state, setState] = useState<InfiniteRunState>({
+    phase: 'idle',
+    runId: null,
+    question: null,
+    livesRemaining: LIVES_START,
+    currentStreak: 0,
+    longestStreak: 0,
+    score: 0,
+    questionsAnswered: 0,
+    trailblazes: 0,
+    lastAnswer: null,
+    answers: [],
+    error: null,
+  })
+  const { user } = useAuth()
+  const startTimeRef = useRef<number>(0)
+
+  const getAuthHeaders = useCallback(async () => {
+    if (!user) throw new Error('Not authenticated')
+    const token = await user.getIdToken()
+    return {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${token}`,
+    }
+  }, [user])
+
+  const startRun = useCallback(async () => {
+    setState(s => ({ ...s, phase: 'loading', error: null }))
+    try {
+      const headers = await getAuthHeaders()
+      const res = await fetch('/api/v1/trivia/infinite/runs', {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({ mode: 'scored' }),
+      })
+      if (!res.ok) throw new Error('Failed to start run')
+      const data = await res.json()
+
+      // Immediately fetch first question
+      const qRes = await fetch(`/api/v1/trivia/infinite/next?streak=0`, { headers })
+      if (qRes.status === 204) {
+        setState(s => ({ ...s, phase: 'exhausted', runId: data.runId }))
+        return
+      }
+      if (!qRes.ok) throw new Error('Failed to fetch question')
+      const question = await qRes.json()
+
+      startTimeRef.current = Date.now()
+      setState(s => ({
+        ...s,
+        phase: 'playing',
+        runId: data.runId,
+        question,
+        livesRemaining: data.livesRemaining,
+        currentStreak: 0,
+        longestStreak: 0,
+        score: 0,
+        questionsAnswered: 0,
+        trailblazes: 0,
+        lastAnswer: null,
+        answers: [],
+      }))
+    } catch {
+      setState(s => ({ ...s, phase: 'error', error: 'Failed to start run.' }))
+    }
+  }, [getAuthHeaders])
+
+  const submitAnswer = useCallback(async (answer: string) => {
+    if (state.phase !== 'playing' || !state.runId || !state.question) return
+
+    setState(s => ({ ...s, phase: 'answering' }))
+    const elapsedMs = Date.now() - startTimeRef.current
+
+    try {
+      const headers = await getAuthHeaders()
+      const res = await fetch(`/api/v1/trivia/infinite/runs/${state.runId}/answer`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({
+          questionId: state.question.id,
+          answer,
+          elapsedMs,
+        }),
+      })
+      if (res.status === 409) {
+        setState(s => ({ ...s, phase: 'ended' }))
+        return
+      }
+      if (!res.ok) throw new Error('Failed to submit answer')
+      const result = await res.json()
+
+      setState(s => ({
+        ...s,
+        phase: result.runOver ? 'ended' : 'answered',
+        lastAnswer: result,
+        livesRemaining: result.livesRemaining,
+        currentStreak: result.currentStreak,
+        longestStreak: result.longestStreak,
+        score: result.score,
+        questionsAnswered: s.questionsAnswered + 1,
+        trailblazes: result.trailblazer ? s.trailblazes + 1 : s.trailblazes,
+        answers: [...s.answers, { correct: result.correct, points: result.points, timeMs: elapsedMs, trailblazer: result.trailblazer }],
+      }))
+    } catch {
+      setState(s => ({ ...s, phase: 'error', error: 'Failed to submit answer.' }))
+    }
+  }, [state.phase, state.runId, state.question, getAuthHeaders])
+
+  const nextQuestion = useCallback(async () => {
+    if (state.phase !== 'answered' || !state.runId) return
+
+    setState(s => ({ ...s, phase: 'loading' }))
+    try {
+      const headers = await getAuthHeaders()
+      const qRes = await fetch(`/api/v1/trivia/infinite/next?streak=${state.currentStreak}`, { headers })
+      if (qRes.status === 204) {
+        setState(s => ({ ...s, phase: 'exhausted' }))
+        return
+      }
+      if (!qRes.ok) throw new Error('Failed to fetch question')
+      const question = await qRes.json()
+
+      startTimeRef.current = Date.now()
+      setState(s => ({ ...s, phase: 'playing', question, lastAnswer: null }))
+    } catch {
+      setState(s => ({ ...s, phase: 'error', error: 'Failed to fetch next question.' }))
+    }
+  }, [state.phase, state.runId, state.currentStreak, getAuthHeaders])
+
+  const endRun = useCallback(async () => {
+    if (!state.runId) {
+      setState(s => ({ ...s, phase: 'ended' }))
+      return
+    }
+    try {
+      const headers = await getAuthHeaders()
+      await fetch(`/api/v1/trivia/infinite/runs/${state.runId}/end`, {
+        method: 'POST',
+        headers,
+      })
+    } catch {
+      // Best effort
+    }
+    setState(s => ({ ...s, phase: 'ended' }))
+  }, [state.runId, getAuthHeaders])
+
+  return { state, startRun, submitAnswer, nextQuestion, endRun }
+}

--- a/src/app/trivia/hooks/useInfiniteRun.ts
+++ b/src/app/trivia/hooks/useInfiniteRun.ts
@@ -4,6 +4,7 @@ import { useAuth } from '@/hooks/useAuth'
 import { LIVES_START, type AnswerResult } from '@/app/trivia/lib/infiniteScoring'
 
 export type InfinitePhase = 'idle' | 'loading' | 'playing' | 'answering' | 'answered' | 'exhausted' | 'ended' | 'error'
+export type InfiniteMode = 'scored' | 'practice'
 
 export interface InfiniteQuestion {
   id: string
@@ -15,6 +16,7 @@ export interface InfiniteQuestion {
 
 export interface InfiniteRunState {
   phase: InfinitePhase
+  mode: InfiniteMode
   runId: string | null
   question: InfiniteQuestion | null
   livesRemaining: number
@@ -31,6 +33,7 @@ export interface InfiniteRunState {
 export function useInfiniteRun() {
   const [state, setState] = useState<InfiniteRunState>({
     phase: 'idle',
+    mode: 'scored',
     runId: null,
     question: null,
     livesRemaining: LIVES_START,
@@ -55,14 +58,14 @@ export function useInfiniteRun() {
     }
   }, [user])
 
-  const startRun = useCallback(async () => {
-    setState(s => ({ ...s, phase: 'loading', error: null }))
+  const startRun = useCallback(async (mode: InfiniteMode = 'scored') => {
+    setState(s => ({ ...s, phase: 'loading', mode, error: null }))
     try {
       const headers = await getAuthHeaders()
       const res = await fetch('/api/v1/trivia/infinite/runs', {
         method: 'POST',
         headers,
-        body: JSON.stringify({ mode: 'scored' }),
+        body: JSON.stringify({ mode }),
       })
       if (!res.ok) throw new Error('Failed to start run')
       const data = await res.json()
@@ -80,6 +83,7 @@ export function useInfiniteRun() {
       setState(s => ({
         ...s,
         phase: 'playing',
+        mode,
         runId: data.runId,
         question,
         livesRemaining: data.livesRemaining,

--- a/src/app/trivia/infinite/page.tsx
+++ b/src/app/trivia/infinite/page.tsx
@@ -1,8 +1,21 @@
 'use client'
-import { useRouter } from 'next/navigation'
+import { useRouter, useSearchParams } from 'next/navigation'
+import { Suspense } from 'react'
 import { InfiniteGame } from '@/app/trivia/components/InfiniteGame'
+import type { InfiniteMode } from '@/app/trivia/hooks/useInfiniteRun'
+
+function InfiniteTriviaPageInner() {
+  const router = useRouter()
+  const searchParams = useSearchParams()
+  const modeParam = searchParams.get('mode')
+  const mode: InfiniteMode = modeParam === 'practice' ? 'practice' : 'scored'
+  return <InfiniteGame onBack={() => router.push('/trivia')} mode={mode} />
+}
 
 export default function InfiniteTriviaPage() {
-  const router = useRouter()
-  return <InfiniteGame onBack={() => router.push('/trivia')} />
+  return (
+    <Suspense fallback={null}>
+      <InfiniteTriviaPageInner />
+    </Suspense>
+  )
 }

--- a/src/app/trivia/infinite/page.tsx
+++ b/src/app/trivia/infinite/page.tsx
@@ -1,0 +1,8 @@
+'use client'
+import { useRouter } from 'next/navigation'
+import { InfiniteGame } from '@/app/trivia/components/InfiniteGame'
+
+export default function InfiniteTriviaPage() {
+  const router = useRouter()
+  return <InfiniteGame onBack={() => router.push('/trivia')} />
+}

--- a/src/app/trivia/lib/infiniteScoring.ts
+++ b/src/app/trivia/lib/infiniteScoring.ts
@@ -1,0 +1,84 @@
+export const LIVES_START = 3
+export const LIVES_MAX = 3
+export const LIFE_REFUND_EVERY = 10
+export const TRAILBLAZER_BONUS = 50
+
+export const STREAK_TIERS = [
+  { at: 0, mult: 1 },
+  { at: 5, mult: 1.5 },
+  { at: 10, mult: 2 },
+  { at: 20, mult: 3 },
+] as const
+
+// Max points per question (before multiplier)
+export const BASE_MAX_POINTS = 100
+
+export function computeStreakMultiplier(streak: number): number {
+  // Walk tiers in reverse, return first match
+  for (let i = STREAK_TIERS.length - 1; i >= 0; i--) {
+    if (streak >= STREAK_TIERS[i].at) return STREAK_TIERS[i].mult
+  }
+  return 1
+}
+
+export function computeSpeedBonus(elapsedMs: number, timeLimitMs: number = 30000): number {
+  // max * (timeRemaining / timeLimit), clamped to [0, BASE_MAX_POINTS]
+  const remaining = Math.max(0, timeLimitMs - elapsedMs)
+  return Math.round(BASE_MAX_POINTS * (remaining / timeLimitMs))
+}
+
+export function shouldRefundLife(newStreak: number, livesRemaining: number): boolean {
+  return newStreak > 0 && newStreak % LIFE_REFUND_EVERY === 0 && livesRemaining < LIVES_MAX
+}
+
+export interface AnswerResult {
+  correct: boolean
+  points: number
+  trailblazer: boolean
+  livesRemaining: number
+  currentStreak: number
+  longestStreak: number
+  score: number
+  runOver: boolean
+}
+
+export function applyAnswer(params: {
+  correct: boolean
+  trailblazer: boolean
+  elapsedMs: number
+  mode: 'scored' | 'practice'
+  prevLives: number
+  prevStreak: number
+  prevLongestStreak: number
+  prevScore: number
+}): AnswerResult {
+  const { correct, trailblazer, elapsedMs, mode, prevLives, prevStreak, prevLongestStreak, prevScore } = params
+
+  let lives = prevLives
+  let streak = prevStreak
+  let longestStreak = prevLongestStreak
+  let points = 0
+
+  if (correct) {
+    streak += 1
+    longestStreak = Math.max(longestStreak, streak)
+    const speedBonus = computeSpeedBonus(elapsedMs)
+    const mult = computeStreakMultiplier(streak)
+    points = Math.round(speedBonus * mult)
+    if (trailblazer) points += TRAILBLAZER_BONUS
+    // Life refund
+    if (shouldRefundLife(streak, lives)) {
+      lives = Math.min(lives + 1, LIVES_MAX)
+    }
+  } else {
+    streak = 0
+    if (mode === 'scored') {
+      lives -= 1
+    }
+  }
+
+  const score = prevScore + points
+  const runOver = mode === 'scored' && lives <= 0
+
+  return { correct, points, trailblazer, livesRemaining: lives, currentStreak: streak, longestStreak, score, runOver }
+}

--- a/src/app/trivia/page.tsx
+++ b/src/app/trivia/page.tsx
@@ -14,6 +14,7 @@ import { getTodayPST } from '@/lib/dates'
 import { getDailyCategory } from '@/lib/trivia/categories'
 
 import { InfiniteGame } from './components/InfiniteGame'
+import { InfiniteStats } from './components/InfiniteStats'
 import { TriviaGame } from './components/TriviaGame'
 import { TriviaLanding } from './components/TriviaLanding'
 import { TriviaLeaderboard } from './components/TriviaLeaderboard'
@@ -23,7 +24,7 @@ import { TriviaStats } from './components/TriviaStats'
 import type { TriviaGameResult } from './models/trivia'
 import type { User } from 'firebase/auth'
 
-type View = 'landing' | 'playing' | 'results' | 'stats' | 'leaderboard' | 'infinite'
+type View = 'landing' | 'playing' | 'results' | 'stats' | 'leaderboard' | 'infinite' | 'infinite-stats'
 
 async function submitGameToServer(user: User, result: TriviaGameResult): Promise<void> {
   const token = await user.getIdToken()
@@ -111,6 +112,7 @@ export default function TriviaPage() {
   const handleViewStats = () => setView('stats')
   const handleViewLeaderboard = () => setView('leaderboard')
   const handleStartInfinite = () => setView('infinite')
+  const handleViewInfiniteStats = () => setView('infinite-stats')
 
   const handleFinish = useCallback(
     (result: TriviaGameResult) => {
@@ -133,6 +135,10 @@ export default function TriviaPage() {
 
   if (view === 'infinite') {
     return <InfiniteGame onBack={handleBackToLanding} />
+  }
+
+  if (view === 'infinite-stats') {
+    return <InfiniteStats onBack={handleBackToLanding} />
   }
 
   if (view === 'playing') {
@@ -164,6 +170,7 @@ export default function TriviaPage() {
       onViewStats={handleViewStats}
       onViewLeaderboard={handleViewLeaderboard}
       onStartInfinite={handleStartInfinite}
+      onViewInfiniteStats={handleViewInfiniteStats}
       todayResult={todayResult}
     />
   )

--- a/src/app/trivia/page.tsx
+++ b/src/app/trivia/page.tsx
@@ -13,6 +13,7 @@ import { useAuth } from '@/hooks/useAuth'
 import { getTodayPST } from '@/lib/dates'
 import { getDailyCategory } from '@/lib/trivia/categories'
 
+import { InfiniteGame } from './components/InfiniteGame'
 import { TriviaGame } from './components/TriviaGame'
 import { TriviaLanding } from './components/TriviaLanding'
 import { TriviaLeaderboard } from './components/TriviaLeaderboard'
@@ -22,7 +23,7 @@ import { TriviaStats } from './components/TriviaStats'
 import type { TriviaGameResult } from './models/trivia'
 import type { User } from 'firebase/auth'
 
-type View = 'landing' | 'playing' | 'results' | 'stats' | 'leaderboard'
+type View = 'landing' | 'playing' | 'results' | 'stats' | 'leaderboard' | 'infinite'
 
 async function submitGameToServer(user: User, result: TriviaGameResult): Promise<void> {
   const token = await user.getIdToken()
@@ -109,6 +110,7 @@ export default function TriviaPage() {
   const handleStartGame = () => setView('playing')
   const handleViewStats = () => setView('stats')
   const handleViewLeaderboard = () => setView('leaderboard')
+  const handleStartInfinite = () => setView('infinite')
 
   const handleFinish = useCallback(
     (result: TriviaGameResult) => {
@@ -128,6 +130,10 @@ export default function TriviaPage() {
   )
 
   const handleBackToLanding = () => setView('landing')
+
+  if (view === 'infinite') {
+    return <InfiniteGame onBack={handleBackToLanding} />
+  }
 
   if (view === 'playing') {
     return <TriviaGame onFinish={handleFinish} />
@@ -157,6 +163,7 @@ export default function TriviaPage() {
       onStartGame={handleStartGame}
       onViewStats={handleViewStats}
       onViewLeaderboard={handleViewLeaderboard}
+      onStartInfinite={handleStartInfinite}
       todayResult={todayResult}
     />
   )

--- a/src/app/trivia/page.tsx
+++ b/src/app/trivia/page.tsx
@@ -24,7 +24,7 @@ import { TriviaStats } from './components/TriviaStats'
 import type { TriviaGameResult } from './models/trivia'
 import type { User } from 'firebase/auth'
 
-type View = 'landing' | 'playing' | 'results' | 'stats' | 'leaderboard' | 'infinite' | 'infinite-stats'
+type View = 'landing' | 'playing' | 'results' | 'stats' | 'leaderboard' | 'infinite' | 'infinite-stats' | 'practice'
 
 async function submitGameToServer(user: User, result: TriviaGameResult): Promise<void> {
   const token = await user.getIdToken()
@@ -113,6 +113,7 @@ export default function TriviaPage() {
   const handleViewLeaderboard = () => setView('leaderboard')
   const handleStartInfinite = () => setView('infinite')
   const handleViewInfiniteStats = () => setView('infinite-stats')
+  const handleStartPractice = () => setView('practice')
 
   const handleFinish = useCallback(
     (result: TriviaGameResult) => {
@@ -135,6 +136,10 @@ export default function TriviaPage() {
 
   if (view === 'infinite') {
     return <InfiniteGame onBack={handleBackToLanding} />
+  }
+
+  if (view === 'practice') {
+    return <InfiniteGame onBack={handleBackToLanding} mode="practice" />
   }
 
   if (view === 'infinite-stats') {
@@ -171,6 +176,7 @@ export default function TriviaPage() {
       onViewLeaderboard={handleViewLeaderboard}
       onStartInfinite={handleStartInfinite}
       onViewInfiniteStats={handleViewInfiniteStats}
+      onStartPractice={handleStartPractice}
       todayResult={todayResult}
     />
   )

--- a/src/app/trivia/page.tsx
+++ b/src/app/trivia/page.tsx
@@ -157,6 +157,7 @@ export default function TriviaPage() {
         onBack={handleBackToLanding}
         onViewStats={handleViewStats}
         onViewLeaderboard={handleViewLeaderboard}
+        onStartInfinite={handleStartInfinite}
       />
     )
   }

--- a/src/hooks/useAuth.tsx
+++ b/src/hooks/useAuth.tsx
@@ -6,6 +6,7 @@ import {
   createUserWithEmailAndPassword,
   signOut as firebaseSignOut,
   onAuthStateChanged,
+  signInAnonymously,
   signInWithEmailAndPassword,
   signInWithPopup,
 } from 'firebase/auth'
@@ -33,9 +34,26 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   useEffect(() => {
     if (!configured) return
     const auth = getFirebaseAuth()
-    const unsub = onAuthStateChanged(auth, (u) => {
-      setUser(u)
-      setLoading(false)
+    let signingInAnonymously = false
+    const unsub = onAuthStateChanged(auth, async (u) => {
+      if (u) {
+        setUser(u)
+        setLoading(false)
+        return
+      }
+      // Anonymous-first (CLAUDE.md #1): mint an anonymous uid so games can
+      // persist per-device state. The listener re-fires with the new user.
+      if (signingInAnonymously) return
+      signingInAnonymously = true
+      try {
+        await signInAnonymously(auth)
+      } catch (err) {
+        console.error('Anonymous sign-in failed:', err)
+        setUser(null)
+        setLoading(false)
+      } finally {
+        signingInAnonymously = false
+      }
     })
     return () => unsub()
   }, [configured])

--- a/src/lib/trivia/__tests__/infiniteScoring.test.ts
+++ b/src/lib/trivia/__tests__/infiniteScoring.test.ts
@@ -1,0 +1,210 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  BASE_MAX_POINTS,
+  LIVES_MAX,
+  LIVES_START,
+  TRAILBLAZER_BONUS,
+  applyAnswer,
+  computeSpeedBonus,
+  computeStreakMultiplier,
+  shouldRefundLife,
+} from '@/app/trivia/lib/infiniteScoring'
+
+describe('computeStreakMultiplier', () => {
+  it('returns 1 at streak 0', () => {
+    expect(computeStreakMultiplier(0)).toBe(1)
+  })
+
+  it('returns 1 at streak 4 (below tier at 5)', () => {
+    expect(computeStreakMultiplier(4)).toBe(1)
+  })
+
+  it('returns 1.5 at streak 5', () => {
+    expect(computeStreakMultiplier(5)).toBe(1.5)
+  })
+
+  it('returns 1.5 at streak 9 (below tier at 10)', () => {
+    expect(computeStreakMultiplier(9)).toBe(1.5)
+  })
+
+  it('returns 2 at streak 10', () => {
+    expect(computeStreakMultiplier(10)).toBe(2)
+  })
+
+  it('returns 2 at streak 19 (below tier at 20)', () => {
+    expect(computeStreakMultiplier(19)).toBe(2)
+  })
+
+  it('returns 3 at streak 20', () => {
+    expect(computeStreakMultiplier(20)).toBe(3)
+  })
+
+  it('returns 3 at streak 50 (well above last tier)', () => {
+    expect(computeStreakMultiplier(50)).toBe(3)
+  })
+})
+
+describe('computeSpeedBonus', () => {
+  it('returns BASE_MAX_POINTS at 0ms elapsed', () => {
+    expect(computeSpeedBonus(0)).toBe(BASE_MAX_POINTS)
+  })
+
+  it('returns 0 at exactly timeLimitMs elapsed', () => {
+    expect(computeSpeedBonus(30000)).toBe(0)
+  })
+
+  it('returns 0 for elapsed > timeLimitMs', () => {
+    expect(computeSpeedBonus(35000)).toBe(0)
+  })
+
+  it('returns ~50 at halfway through time', () => {
+    expect(computeSpeedBonus(15000)).toBe(50)
+  })
+
+  it('respects custom timeLimitMs', () => {
+    // 5000ms elapsed out of 10000ms limit → 50% remaining → 50 points
+    expect(computeSpeedBonus(5000, 10000)).toBe(50)
+  })
+})
+
+describe('shouldRefundLife', () => {
+  it('returns true at streak 10 when lives < LIVES_MAX', () => {
+    expect(shouldRefundLife(10, 2)).toBe(true)
+  })
+
+  it('returns true at streak 20 when lives < LIVES_MAX', () => {
+    expect(shouldRefundLife(20, 1)).toBe(true)
+  })
+
+  it('returns true at streak 30 when lives < LIVES_MAX', () => {
+    expect(shouldRefundLife(30, 2)).toBe(true)
+  })
+
+  it('returns false at streak 10 when lives === LIVES_MAX', () => {
+    expect(shouldRefundLife(10, LIVES_MAX)).toBe(false)
+  })
+
+  it('returns false at streak 5 (non-multiple of 10)', () => {
+    expect(shouldRefundLife(5, 2)).toBe(false)
+  })
+
+  it('returns false at streak 0', () => {
+    expect(shouldRefundLife(0, 2)).toBe(false)
+  })
+
+  it('returns false at streak 11 (non-multiple of 10)', () => {
+    expect(shouldRefundLife(11, 1)).toBe(false)
+  })
+})
+
+describe('applyAnswer', () => {
+  const baseParams = {
+    trailblazer: false,
+    elapsedMs: 0,
+    mode: 'scored' as const,
+    prevLives: LIVES_START,
+    prevStreak: 0,
+    prevLongestStreak: 0,
+    prevScore: 0,
+  }
+
+  it('increments streak and awards points on correct answer', () => {
+    const result = applyAnswer({ ...baseParams, correct: true })
+    expect(result.correct).toBe(true)
+    expect(result.currentStreak).toBe(1)
+    expect(result.longestStreak).toBe(1)
+    expect(result.points).toBeGreaterThan(0)
+    expect(result.livesRemaining).toBe(LIVES_START)
+    expect(result.runOver).toBe(false)
+  })
+
+  it('resets streak and decrements lives on wrong answer in scored mode', () => {
+    const result = applyAnswer({ ...baseParams, correct: false, prevStreak: 3 })
+    expect(result.correct).toBe(false)
+    expect(result.currentStreak).toBe(0)
+    expect(result.points).toBe(0)
+    expect(result.livesRemaining).toBe(LIVES_START - 1)
+    expect(result.runOver).toBe(false)
+  })
+
+  it('sets runOver when lives reach 0 in scored mode', () => {
+    const result = applyAnswer({ ...baseParams, correct: false, prevLives: 1 })
+    expect(result.livesRemaining).toBe(0)
+    expect(result.runOver).toBe(true)
+  })
+
+  it('does NOT decrement lives on wrong answer in practice mode', () => {
+    const result = applyAnswer({ ...baseParams, correct: false, mode: 'practice' })
+    expect(result.livesRemaining).toBe(LIVES_START)
+    expect(result.runOver).toBe(false)
+  })
+
+  it('applies streak multiplier after 5 correct answers', () => {
+    // Build up to streak 4
+    let state = { ...baseParams, prevScore: 0, prevStreak: 0, prevLongestStreak: 0, prevLives: LIVES_START }
+    for (let i = 0; i < 4; i++) {
+      const r = applyAnswer({ ...state, correct: true, elapsedMs: 0 })
+      state = { ...state, prevStreak: r.currentStreak, prevLongestStreak: r.longestStreak, prevScore: r.score }
+    }
+    // 5th correct answer should trigger 1.5x multiplier
+    const result = applyAnswer({ ...state, correct: true, elapsedMs: 0 })
+    expect(result.currentStreak).toBe(5)
+    // At streak 5 with 0ms elapsed: BASE_MAX_POINTS * 1.5 = 150
+    expect(result.points).toBe(Math.round(BASE_MAX_POINTS * 1.5))
+  })
+
+  it('adds TRAILBLAZER_BONUS when trailblazer is true', () => {
+    const regular = applyAnswer({ ...baseParams, correct: true, trailblazer: false, elapsedMs: 0 })
+    const trailblazer = applyAnswer({ ...baseParams, correct: true, trailblazer: true, elapsedMs: 0 })
+    expect(trailblazer.points - regular.points).toBe(TRAILBLAZER_BONUS)
+    expect(trailblazer.trailblazer).toBe(true)
+  })
+
+  it('does not award trailblazer bonus on wrong answer', () => {
+    const result = applyAnswer({ ...baseParams, correct: false, trailblazer: true, elapsedMs: 0 })
+    expect(result.points).toBe(0)
+  })
+
+  it('refunds a life at streak 10 when lives are below max', () => {
+    const result = applyAnswer({
+      ...baseParams,
+      correct: true,
+      elapsedMs: 0,
+      prevStreak: 9,
+      prevLongestStreak: 9,
+      prevLives: 2,
+    })
+    expect(result.currentStreak).toBe(10)
+    expect(result.livesRemaining).toBe(3) // restored to LIVES_MAX
+  })
+
+  it('does not refund life at streak 10 when already at max lives', () => {
+    const result = applyAnswer({
+      ...baseParams,
+      correct: true,
+      elapsedMs: 0,
+      prevStreak: 9,
+      prevLongestStreak: 9,
+      prevLives: LIVES_MAX,
+    })
+    expect(result.livesRemaining).toBe(LIVES_MAX)
+  })
+
+  it('accumulates score across answers', () => {
+    const first = applyAnswer({ ...baseParams, correct: true, elapsedMs: 0, prevScore: 0 })
+    const second = applyAnswer({ ...baseParams, correct: true, elapsedMs: 0, prevScore: first.score, prevStreak: 1, prevLongestStreak: 1 })
+    expect(second.score).toBeGreaterThan(first.score)
+  })
+
+  it('longestStreak does not decrease on wrong answer', () => {
+    const result = applyAnswer({
+      ...baseParams,
+      correct: false,
+      prevStreak: 5,
+      prevLongestStreak: 5,
+    })
+    expect(result.longestStreak).toBe(5)
+    expect(result.currentStreak).toBe(0)
+  })
+})

--- a/src/lib/trivia/aiQuestions.ts
+++ b/src/lib/trivia/aiQuestions.ts
@@ -1,0 +1,39 @@
+import { getFirestoreDb } from '@/lib/firebase/server'
+
+export interface AIQuestion {
+  id: string
+  question: string
+  correctAnswer: string
+  explanation?: string
+  category: string
+  difficulty: 'easy' | 'medium' | 'hard'
+  type: 'free-text'
+  // New fields for infinite mode
+  status: 'active' | 'flagged' | 'removed'
+  timesShown: number
+  timesCorrect: number
+  flaggedCount: number
+  avgTimeMs: number | null
+}
+
+export interface SeenQuestion {
+  at: FirebaseFirestore.Timestamp
+  correct: boolean
+}
+
+export async function saveAIQuestion(
+  question: Omit<AIQuestion, 'status' | 'timesShown' | 'timesCorrect' | 'flaggedCount' | 'avgTimeMs'>
+): Promise<string> {
+  const db = getFirestoreDb()
+  const doc: AIQuestion = {
+    ...question,
+    status: 'active',
+    timesShown: 0,
+    timesCorrect: 0,
+    flaggedCount: 0,
+    avgTimeMs: null,
+  }
+  const ref = db.collection('aiQuestions').doc(question.id)
+  await ref.set(doc)
+  return ref.id
+}

--- a/src/lib/trivia/answerJudge.ts
+++ b/src/lib/trivia/answerJudge.ts
@@ -1,0 +1,30 @@
+import { createOpenAI } from '@ai-sdk/openai'
+import { generateObject } from 'ai'
+import { z } from 'zod'
+
+export async function judgeAnswer(question: string, correctAnswer: string, userAnswer: string): Promise<boolean> {
+  const apiKey = process.env.NEXT_PUBLIC_OPENAI_API_KEY ?? process.env.OPENAI_API_KEY
+  if (!apiKey) throw new Error('OpenAI API key not configured')
+
+  const openaiClient = createOpenAI({ apiKey })
+  const JudgeSchema = z.object({
+    correct: z.boolean().describe('Whether the answer is correct or close enough'),
+  })
+
+  const result = await generateObject({
+    model: openaiClient('gpt-4o-mini'),
+    schema: JudgeSchema,
+    prompt: `You are a trivia answer judge. Determine if the user's answer is correct.
+
+Question: "${question}"
+Correct answer: "${correctAnswer}"
+User's answer: "${userAnswer}"
+
+Accept reasonable variations, minor spelling errors, and equivalent answers.
+Be generous — if the core concept is correct, mark it correct.`,
+    temperature: 0.1,
+    maxTokens: 100,
+  })
+
+  return result.object.correct
+}

--- a/src/lib/trivia/generateQuestion.ts
+++ b/src/lib/trivia/generateQuestion.ts
@@ -1,0 +1,119 @@
+import { createOpenAI } from '@ai-sdk/openai'
+import { generateObject } from 'ai'
+import { z } from 'zod'
+
+import {
+  CATEGORIZED_SEEDS,
+  MODIFIERS,
+  getOpenTDBCategoryName,
+} from '@/app/trivia/data/seeds'
+import type { AIQuestion } from '@/lib/trivia/aiQuestions'
+
+export type GeneratedQuestion = Omit<
+  AIQuestion,
+  'status' | 'timesShown' | 'timesCorrect' | 'flaggedCount' | 'avgTimeMs'
+>
+
+export interface GenerateInfiniteQuestionOptions {
+  difficulty?: 'easy' | 'medium' | 'hard'
+  categoryId?: number
+  streak?: number
+}
+
+const DIFFICULTY_GUIDANCE: Record<'easy' | 'medium' | 'hard', string> = {
+  easy: 'Should be approachable — a well-known fact that many people could answer correctly.',
+  medium:
+    'Should require some specific knowledge — harder than common knowledge but not obscure trivia.',
+  hard: 'Should require real, specific knowledge of the topic — challenging but fair.',
+}
+
+function streakBiasedDifficulty(streak: number): 'easy' | 'medium' | 'hard' {
+  let weights: [number, number, number]
+  if (streak >= 20) weights = [0.05, 0.25, 0.7]
+  else if (streak >= 10) weights = [0.1, 0.3, 0.6]
+  else if (streak >= 5) weights = [0.3, 0.4, 0.3]
+  else weights = [0.6, 0.3, 0.1]
+
+  const r = Math.random()
+  if (r < weights[0]) return 'easy'
+  if (r < weights[0] + weights[1]) return 'medium'
+  return 'hard'
+}
+
+function pickRandom<T>(arr: T[]): T {
+  return arr[Math.floor(Math.random() * arr.length)]
+}
+
+function pickCategoryId(): number {
+  const ids = Object.keys(CATEGORIZED_SEEDS).map(Number)
+  return pickRandom(ids)
+}
+
+const QuestionSchema = z.object({
+  question: z.string().describe('The trivia question text, ending with a question mark.'),
+  correct_answer: z
+    .string()
+    .describe('The specific correct answer — typically 1-3 words (a name, date, number, place, or concept).'),
+  explanation: z
+    .string()
+    .describe('2-3 sentences explaining the answer and why it is interesting.'),
+})
+
+/**
+ * Generate a single trivia question on the fly for Infinite Trivia.
+ * Picks a random category + seed/modifier combo so back-to-back calls don't collide.
+ * Returns the AIQuestion shape sans auto-initialized counters; pair with saveAIQuestion().
+ */
+export async function generateInfiniteQuestion(
+  options: GenerateInfiniteQuestionOptions = {}
+): Promise<GeneratedQuestion> {
+  const apiKey = process.env.NEXT_PUBLIC_OPENAI_API_KEY ?? process.env.OPENAI_API_KEY
+  if (!apiKey) throw new Error('OpenAI API key not configured')
+
+  const difficulty =
+    options.difficulty ?? streakBiasedDifficulty(options.streak ?? 0)
+  const categoryId = options.categoryId ?? pickCategoryId()
+  const categoryName = getOpenTDBCategoryName(categoryId)
+  const seeds = CATEGORIZED_SEEDS[categoryId] ?? CATEGORIZED_SEEDS[9]
+  const seedWord = pickRandom(seeds)
+  const modifier = pickRandom(MODIFIERS)
+  const seedStr = `${seedWord} :: ${modifier}`
+
+  const openaiClient = createOpenAI({ apiKey })
+
+  const result = await generateObject({
+    model: openaiClient('gpt-4o'),
+    schema: QuestionSchema,
+    system:
+      'You are a trivia question creator. Create a specific trivia question with a clear factual answer.',
+    prompt: `Generate a ${difficulty} trivia question about the topic: "${seedStr}"
+Category: ${categoryName}
+
+Difficulty: ${difficulty.toUpperCase()}. ${DIFFICULTY_GUIDANCE[difficulty]}
+
+The question should:
+- Be specific enough that someone knowledgeable could guess the exact answer
+- Not mention the answer in the question text
+- Have a clear, specific correct answer (a name, date, number, place, or concept — typically 1-3 words)
+- Be answerable without multiple choice options`,
+    temperature: 0.7,
+    maxTokens: 400,
+  })
+
+  const { question, correct_answer, explanation } = result.object
+  if (!question || !correct_answer) {
+    throw new Error('OpenAI response missing required fields')
+  }
+
+  const id = `ai-infinite-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`
+
+  return {
+    id,
+    question,
+    correctAnswer: correct_answer,
+    explanation,
+    category: categoryName,
+    difficulty,
+    type: 'free-text',
+  }
+}

--- a/src/lib/trivia/generationLimit.ts
+++ b/src/lib/trivia/generationLimit.ts
@@ -1,0 +1,51 @@
+import { Timestamp } from 'firebase-admin/firestore'
+
+import { getFirestoreDb } from '@/lib/firebase/server'
+
+const WINDOW_MS = 60 * 60 * 1000 // 1 hour
+const MAX_GENERATIONS_PER_WINDOW = 30
+
+/**
+ * Atomically check whether the given uid has exceeded the on-demand generation
+ * rate limit for the current window. Increments the counter on success.
+ *
+ * Returns `true` if the request should be rate-limited (i.e. caller must reject).
+ *
+ * Stored at `users/{uid}/triviaInfiniteMeta/generationLimit` to keep limit
+ * state out of the user-visible run/stats subtrees.
+ */
+export async function checkAndIncrementGenerationLimit(uid: string): Promise<{
+  limited: boolean
+  remaining: number
+}> {
+  const db = getFirestoreDb()
+  const ref = db.doc(`users/${uid}/triviaInfiniteMeta/generationLimit`)
+  const now = Date.now()
+
+  return db.runTransaction(async (tx) => {
+    const snap = await tx.get(ref)
+    const data = snap.data()
+    const prevWindowStart: number = data?.windowStart?.toMillis?.() ?? 0
+    let count: number = data?.count ?? 0
+    let windowStart = prevWindowStart
+
+    if (now - prevWindowStart > WINDOW_MS) {
+      windowStart = now
+      count = 0
+    }
+
+    if (count >= MAX_GENERATIONS_PER_WINDOW) {
+      return { limited: true, remaining: 0 }
+    }
+
+    const nextCount = count + 1
+    tx.set(ref, {
+      count: nextCount,
+      windowStart: Timestamp.fromMillis(windowStart),
+    })
+    return {
+      limited: false,
+      remaining: MAX_GENERATIONS_PER_WINDOW - nextCount,
+    }
+  })
+}

--- a/src/lib/trivia/infiniteRuns.ts
+++ b/src/lib/trivia/infiniteRuns.ts
@@ -3,6 +3,7 @@ import { FieldValue } from 'firebase-admin/firestore'
 import { LIVES_START, applyAnswer } from '@/app/trivia/lib/infiniteScoring'
 import type { AnswerResult } from '@/app/trivia/lib/infiniteScoring'
 import { getFirestoreDb } from '@/lib/firebase/server'
+import { applyRunToAggregate } from '@/lib/trivia/triviaStats'
 
 export interface RunDoc {
   runId: string
@@ -62,7 +63,7 @@ export async function submitAnswer(params: {
   const seenRef = db.doc(`users/${uid}/seenQuestions/${questionId}`)
   const answeredByRef = db.doc(`aiQuestions/${questionId}/answeredBy/${uid}_${runId}`)
 
-  return db.runTransaction(async (tx) => {
+  const result = await db.runTransaction(async (tx) => {
     const runSnap = await tx.get(runRef)
     if (!runSnap.exists) throw new Error('Run not found')
     const run = runSnap.data() as RunDoc
@@ -77,7 +78,7 @@ export async function submitAnswer(params: {
     const isTrailblazer = correct && (qData.timesShown ?? 0) === 0
 
     // Compute result using pure function
-    const result = applyAnswer({
+    const txResult = applyAnswer({
       correct,
       trailblazer: isTrailblazer,
       elapsedMs,
@@ -115,7 +116,7 @@ export async function submitAnswer(params: {
     const answerEntry = {
       questionId,
       correct,
-      points: result.points,
+      points: txResult.points,
       timeMs: elapsedMs,
       trailblazer: isTrailblazer,
       answeredAt: now,
@@ -123,22 +124,31 @@ export async function submitAnswer(params: {
 
     // Update run doc
     const runUpdates: FirebaseFirestore.UpdateData<FirebaseFirestore.DocumentData> = {
-      score: result.score,
-      livesRemaining: result.livesRemaining,
-      currentStreak: result.currentStreak,
-      longestStreak: result.longestStreak,
+      score: txResult.score,
+      livesRemaining: txResult.livesRemaining,
+      currentStreak: txResult.currentStreak,
+      longestStreak: txResult.longestStreak,
       answers: FieldValue.arrayUnion(answerEntry),
     }
     if (isTrailblazer) {
       runUpdates.trailblazes = FieldValue.increment(1)
     }
-    if (result.runOver) {
+    if (txResult.runOver) {
       runUpdates.endedAt = now
     }
     tx.update(runRef, runUpdates)
 
-    return result
+    return { ...txResult, trailblazer: isTrailblazer }
   })
+
+  // Auto-finalize: apply aggregate stats outside the transaction (no nesting)
+  if (result.runOver) {
+    applyRunToAggregate(uid, runId).catch((err) =>
+      console.error('[submitAnswer] Failed to apply run to aggregate:', err)
+    )
+  }
+
+  return result
 }
 
 export async function endRun(uid: string, runId: string): Promise<void> {
@@ -147,6 +157,17 @@ export async function endRun(uid: string, runId: string): Promise<void> {
   const snap = await runRef.get()
   if (!snap.exists) throw new Error('Run not found')
   const data = snap.data()!
-  if (data.endedAt !== null) return // idempotent
+  if (data.endedAt !== null) {
+    // Run was already ended (e.g. auto-finalized when lives hit 0).
+    // Still attempt to apply stats in case they weren't applied yet
+    // (applyRunToAggregate is idempotent via statsApplied flag).
+    applyRunToAggregate(uid, runId).catch((err) =>
+      console.error('[endRun] Failed to apply run to aggregate:', err)
+    )
+    return
+  }
   await runRef.update({ endedAt: FieldValue.serverTimestamp() })
+  applyRunToAggregate(uid, runId).catch((err) =>
+    console.error('[endRun] Failed to apply run to aggregate:', err)
+  )
 }

--- a/src/lib/trivia/infiniteRuns.ts
+++ b/src/lib/trivia/infiniteRuns.ts
@@ -1,0 +1,152 @@
+import { FieldValue } from 'firebase-admin/firestore'
+
+import { LIVES_START, applyAnswer } from '@/app/trivia/lib/infiniteScoring'
+import type { AnswerResult } from '@/app/trivia/lib/infiniteScoring'
+import { getFirestoreDb } from '@/lib/firebase/server'
+
+export interface RunDoc {
+  runId: string
+  uid: string
+  mode: 'scored' | 'practice'
+  score: number
+  livesRemaining: number
+  currentStreak: number
+  longestStreak: number
+  trailblazes: number
+  answers: RunAnswer[]
+  startedAt: FirebaseFirestore.Timestamp
+  endedAt: FirebaseFirestore.Timestamp | null
+}
+
+export interface RunAnswer {
+  questionId: string
+  correct: boolean
+  points: number
+  timeMs: number
+  trailblazer: boolean
+  answeredAt: FirebaseFirestore.Timestamp
+}
+
+export async function startRun(uid: string, mode: 'scored' | 'practice' = 'scored'): Promise<{ runId: string; livesRemaining: number; currentStreak: number }> {
+  const db = getFirestoreDb()
+  const runRef = db.collection(`users/${uid}/triviaInfinite`).doc()
+  const now = FieldValue.serverTimestamp()
+  await runRef.set({
+    runId: runRef.id,
+    uid,
+    mode,
+    score: 0,
+    livesRemaining: LIVES_START,
+    currentStreak: 0,
+    longestStreak: 0,
+    trailblazes: 0,
+    answers: [],
+    startedAt: now,
+    endedAt: null,
+  })
+  return { runId: runRef.id, livesRemaining: LIVES_START, currentStreak: 0 }
+}
+
+export async function submitAnswer(params: {
+  uid: string
+  runId: string
+  questionId: string
+  correct: boolean
+  elapsedMs: number
+}): Promise<AnswerResult & { trailblazer: boolean }> {
+  const db = getFirestoreDb()
+  const { uid, runId, questionId, correct, elapsedMs } = params
+
+  const runRef = db.doc(`users/${uid}/triviaInfinite/${runId}`)
+  const questionRef = db.doc(`aiQuestions/${questionId}`)
+  const seenRef = db.doc(`users/${uid}/seenQuestions/${questionId}`)
+  const answeredByRef = db.doc(`aiQuestions/${questionId}/answeredBy/${uid}_${runId}`)
+
+  return db.runTransaction(async (tx) => {
+    const runSnap = await tx.get(runRef)
+    if (!runSnap.exists) throw new Error('Run not found')
+    const run = runSnap.data() as RunDoc
+
+    if (run.endedAt !== null) throw new Error('Run already ended')
+
+    const qSnap = await tx.get(questionRef)
+    if (!qSnap.exists) throw new Error('Question not found')
+    const qData = qSnap.data()!
+
+    // Trailblazer: if timesShown was 0 before this answer
+    const isTrailblazer = correct && (qData.timesShown ?? 0) === 0
+
+    // Compute result using pure function
+    const result = applyAnswer({
+      correct,
+      trailblazer: isTrailblazer,
+      elapsedMs,
+      mode: run.mode,
+      prevLives: run.livesRemaining,
+      prevStreak: run.currentStreak,
+      prevLongestStreak: run.longestStreak,
+      prevScore: run.score,
+    })
+
+    const now = FieldValue.serverTimestamp()
+
+    // Update question counters
+    const qUpdates: FirebaseFirestore.UpdateData<FirebaseFirestore.DocumentData> = {
+      timesShown: FieldValue.increment(1),
+    }
+    if (correct) {
+      qUpdates.timesCorrect = FieldValue.increment(1)
+    }
+    // Running mean for avgTimeMs
+    const prevAvg = qData.avgTimeMs ?? 0
+    const prevCount = qData.timesShown ?? 0
+    const newAvg = prevCount === 0 ? elapsedMs : Math.round((prevAvg * prevCount + elapsedMs) / (prevCount + 1))
+    qUpdates.avgTimeMs = newAvg
+
+    tx.update(questionRef, qUpdates)
+
+    // Write seenQuestions
+    tx.set(seenRef, { at: now, correct })
+
+    // Write answeredBy reverse index
+    tx.set(answeredByRef, { uid, runId, correct, at: now })
+
+    // Build answer entry
+    const answerEntry = {
+      questionId,
+      correct,
+      points: result.points,
+      timeMs: elapsedMs,
+      trailblazer: isTrailblazer,
+      answeredAt: now,
+    }
+
+    // Update run doc
+    const runUpdates: FirebaseFirestore.UpdateData<FirebaseFirestore.DocumentData> = {
+      score: result.score,
+      livesRemaining: result.livesRemaining,
+      currentStreak: result.currentStreak,
+      longestStreak: result.longestStreak,
+      answers: FieldValue.arrayUnion(answerEntry),
+    }
+    if (isTrailblazer) {
+      runUpdates.trailblazes = FieldValue.increment(1)
+    }
+    if (result.runOver) {
+      runUpdates.endedAt = now
+    }
+    tx.update(runRef, runUpdates)
+
+    return result
+  })
+}
+
+export async function endRun(uid: string, runId: string): Promise<void> {
+  const db = getFirestoreDb()
+  const runRef = db.doc(`users/${uid}/triviaInfinite/${runId}`)
+  const snap = await runRef.get()
+  if (!snap.exists) throw new Error('Run not found')
+  const data = snap.data()!
+  if (data.endedAt !== null) return // idempotent
+  await runRef.update({ endedAt: FieldValue.serverTimestamp() })
+}

--- a/src/lib/trivia/infiniteRuns.ts
+++ b/src/lib/trivia/infiniteRuns.ts
@@ -1,4 +1,4 @@
-import { FieldValue } from 'firebase-admin/firestore'
+import { FieldValue, Timestamp } from 'firebase-admin/firestore'
 
 import { LIVES_START, applyAnswer } from '@/app/trivia/lib/infiniteScoring'
 import type { AnswerResult } from '@/app/trivia/lib/infiniteScoring'
@@ -112,14 +112,15 @@ export async function submitAnswer(params: {
     // Write answeredBy reverse index
     tx.set(answeredByRef, { uid, runId, correct, at: now })
 
-    // Build answer entry
+    // Build answer entry. Note: serverTimestamp() can't appear inside an
+    // arrayUnion element, so we use a client-computed Timestamp here.
     const answerEntry = {
       questionId,
       correct,
       points: txResult.points,
       timeMs: elapsedMs,
       trailblazer: isTrailblazer,
-      answeredAt: now,
+      answeredAt: Timestamp.now(),
     }
 
     // Update run doc

--- a/src/lib/trivia/questionRemoval.ts
+++ b/src/lib/trivia/questionRemoval.ts
@@ -1,0 +1,85 @@
+import { FieldValue } from 'firebase-admin/firestore'
+import { getFirestoreDb } from '@/lib/firebase/server'
+
+export async function removeQuestion(questionId: string): Promise<{ affectedPlayers: number }> {
+  const db = getFirestoreDb()
+  const qRef = db.doc(`aiQuestions/${questionId}`)
+
+  const qSnap = await qRef.get()
+  if (!qSnap.exists) throw new Error('Question not found')
+  if (qSnap.data()!.status === 'removed') return { affectedPlayers: 0 } // idempotent
+
+  // Set status to removed
+  await qRef.update({ status: 'removed' })
+
+  // Walk answeredBy reverse index
+  const answeredBySnap = await db.collection(`aiQuestions/${questionId}/answeredBy`).get()
+  let affectedPlayers = 0
+
+  for (const abDoc of answeredBySnap.docs) {
+    const { uid, runId, correct } = abDoc.data()
+    affectedPlayers++
+
+    try {
+      // Load the run
+      const runRef = db.doc(`users/${uid}/triviaInfinite/${runId}`)
+      const runSnap = await runRef.get()
+      if (!runSnap.exists) continue
+      const run = runSnap.data()!
+
+      // Find and remove the answer entry
+      const answers = run.answers as Array<{ questionId: string; correct: boolean; points: number; timeMs: number; trailblazer: boolean }>
+      const answerIdx = answers.findIndex(a => a.questionId === questionId)
+      if (answerIdx === -1) continue
+
+      const removedAnswer = answers[answerIdx]
+      const newAnswers = [...answers.slice(0, answerIdx), ...answers.slice(answerIdx + 1)]
+
+      // Recompute score (simple sum of remaining points)
+      const newScore = newAnswers.reduce((sum, a) => sum + a.points, 0)
+
+      await runRef.update({
+        answers: newAnswers,
+        score: newScore,
+      })
+
+      // Decrement aggregate stats
+      const aggRef = db.doc(`users/${uid}/triviaStats/aggregate`)
+      const aggSnap = await aggRef.get()
+      if (aggSnap.exists) {
+        const qData = qSnap.data()!
+        const updates: Record<string, unknown> = {
+          totalAnswered: FieldValue.increment(-1),
+          totalTimeMs: FieldValue.increment(-removedAnswer.timeMs),
+        }
+        if (removedAnswer.correct) {
+          updates.totalCorrect = FieldValue.increment(-1)
+        }
+        if (removedAnswer.trailblazer) {
+          updates.trailblazerCount = FieldValue.increment(-1)
+        }
+        // Note: byCategory and byDifficulty decrements use the question's category/difficulty
+        if (qData.category && qData.difficulty) {
+          updates[`byCategory.${qData.category}.answered`] = FieldValue.increment(-1)
+          if (removedAnswer.correct) {
+            updates[`byCategory.${qData.category}.correct`] = FieldValue.increment(-1)
+          }
+          updates[`byCategory.${qData.category}.totalTimeMs`] = FieldValue.increment(-removedAnswer.timeMs)
+          updates[`byDifficulty.${qData.difficulty}.answered`] = FieldValue.increment(-1)
+          if (removedAnswer.correct) {
+            updates[`byDifficulty.${qData.difficulty}.correct`] = FieldValue.increment(-1)
+          }
+        }
+        updates.lastUpdatedAt = FieldValue.serverTimestamp()
+        await aggRef.update(updates)
+      }
+
+      // Remove seenQuestions entry
+      await db.doc(`users/${uid}/seenQuestions/${questionId}`).delete()
+    } catch (err) {
+      console.error(`Failed to process removal for uid=${uid}, runId=${runId}:`, err)
+    }
+  }
+
+  return { affectedPlayers }
+}

--- a/src/lib/trivia/sampler.ts
+++ b/src/lib/trivia/sampler.ts
@@ -7,8 +7,28 @@ export interface SamplerOptions {
   type?: 'free-text' // v1 only free-text
 }
 
-// Difficulty weights by streak band
-// [easy%, medium%, hard%]
+/**
+ * Difficulty-bias curve for the sampler.
+ *
+ * Designed to feel progressively harder without sudden cliff-edges.
+ * The bands are:
+ *
+ *   Streak 0-4   → 60% easy, 30% medium, 10% hard   (onboarding)
+ *   Streak 5-9   → 30% easy, 40% medium, 30% hard   (warming up)
+ *   Streak 10-19 → 10% easy, 30% medium, 60% hard   (challenge zone)
+ *   Streak 20+   → 5% easy, 25% medium, 70% hard    (expert territory)
+ *
+ * Tuning notes (v1 — 2026-04-28):
+ * - No telemetry data yet; these are design estimates.
+ * - The 20+ band caps hard at 70% rather than 100% to prevent
+ *   frustration spirals where a single hard miss ends a long run.
+ * - Freshness bias (1/(1+timesShown)) ensures under-seen questions
+ *   surface first, preventing "greatest hits" stagnation.
+ * - Revisit after ~1 week of real run data using:
+ *     SELECT difficulty, AVG(correct::int), COUNT(*)
+ *     FROM answers JOIN questions ON ...
+ *     GROUP BY difficulty, streak_band
+ */
 function getDifficultyWeights(streak: number): [number, number, number] {
   if (streak >= 20) return [0.05, 0.25, 0.70]
   if (streak >= 10) return [0.10, 0.30, 0.60]

--- a/src/lib/trivia/sampler.ts
+++ b/src/lib/trivia/sampler.ts
@@ -1,0 +1,94 @@
+import { getFirestoreDb } from '@/lib/firebase/server'
+import type { AIQuestion } from '@/lib/trivia/aiQuestions'
+
+export interface SamplerOptions {
+  uid: string
+  streak: number
+  type?: 'free-text' // v1 only free-text
+}
+
+// Difficulty weights by streak band
+// [easy%, medium%, hard%]
+function getDifficultyWeights(streak: number): [number, number, number] {
+  if (streak >= 20) return [0.05, 0.25, 0.70]
+  if (streak >= 10) return [0.10, 0.30, 0.60]
+  if (streak >= 5)  return [0.30, 0.40, 0.30]
+  return [0.60, 0.30, 0.10]
+}
+
+// Weighted random selection over an array of items with numeric weights
+function weightedRandom<T>(items: T[], weights: number[]): T {
+  const total = weights.reduce((a, b) => a + b, 0)
+  let rand = Math.random() * total
+  for (let i = 0; i < items.length; i++) {
+    rand -= weights[i]
+    if (rand <= 0) return items[i]
+  }
+  return items[items.length - 1]
+}
+
+// Compute per-question weight within a difficulty bucket.
+// Lower timesShown → higher weight (freshness bias).
+function freshnessWeight(timesShown: number): number {
+  return 1 / (1 + timesShown)
+}
+
+export async function sampleNextQuestion(options: SamplerOptions): Promise<AIQuestion | null> {
+  const { uid, streak, type = 'free-text' } = options
+  const db = getFirestoreDb()
+
+  // 1. Query active questions of the requested type
+  const questionsSnap = await db
+    .collection('aiQuestions')
+    .where('status', '==', 'active')
+    .where('type', '==', type)
+    .get()
+
+  if (questionsSnap.empty) return null
+
+  // 2. Get IDs already seen by this user
+  const seenSnap = await db.collection(`users/${uid}/seenQuestions`).get()
+  const seenIds = new Set(seenSnap.docs.map((d) => d.id))
+
+  // 3. Filter out seen questions
+  const unseen = questionsSnap.docs
+    .map((d) => ({ id: d.id, ...(d.data() as Omit<AIQuestion, 'id'>) }))
+    .filter((q) => !seenIds.has(q.id))
+
+  if (unseen.length === 0) return null
+
+  // 4. Bucket by difficulty
+  const byDifficulty: Record<'easy' | 'medium' | 'hard', AIQuestion[]> = {
+    easy: [],
+    medium: [],
+    hard: [],
+  }
+  for (const q of unseen) {
+    byDifficulty[q.difficulty].push(q)
+  }
+
+  // 5. Determine which difficulty to pick from, weighted by streak
+  const [easyW, mediumW, hardW] = getDifficultyWeights(streak)
+
+  // Only include difficulty levels that have available questions
+  const availableDifficulties: Array<{ key: 'easy' | 'medium' | 'hard'; weight: number }> = []
+  if (byDifficulty.easy.length > 0)   availableDifficulties.push({ key: 'easy',   weight: easyW })
+  if (byDifficulty.medium.length > 0) availableDifficulties.push({ key: 'medium', weight: mediumW })
+  if (byDifficulty.hard.length > 0)   availableDifficulties.push({ key: 'hard',   weight: hardW })
+
+  if (availableDifficulties.length === 0) return null
+
+  const chosenDifficulty = weightedRandom(
+    availableDifficulties.map((d) => d.key),
+    availableDifficulties.map((d) => d.weight)
+  )
+
+  // 6. Within the chosen bucket, apply freshness bias (lower timesShown → higher weight)
+  const bucket = byDifficulty[chosenDifficulty]
+  const bucketWeights = bucket.map((q) => freshnessWeight(q.timesShown))
+
+  // 7. Select one question
+  const selected = weightedRandom(bucket, bucketWeights)
+
+  return selected
+}

--- a/src/lib/trivia/triviaStats.ts
+++ b/src/lib/trivia/triviaStats.ts
@@ -1,0 +1,175 @@
+import { FieldValue } from 'firebase-admin/firestore'
+
+import { getFirestoreDb } from '@/lib/firebase/server'
+import type { RunDoc } from '@/lib/trivia/infiniteRuns'
+
+export interface AggregateStats {
+  totalAnswered: number
+  totalCorrect: number
+  runsPlayed: number
+  bestRun: {
+    score: number
+    longestStreak: number
+    runId: string
+    endedAt: FirebaseFirestore.Timestamp | null
+  } | null
+  bestStreak: number
+  trailblazerCount: number
+  totalTimeMs: number
+  byCategory: Record<string, { answered: number; correct: number; totalTimeMs: number }>
+  byDifficulty: {
+    easy: { answered: number; correct: number }
+    medium: { answered: number; correct: number }
+    hard: { answered: number; correct: number }
+  }
+  lastUpdatedAt: FirebaseFirestore.Timestamp | null
+}
+
+const EMPTY_STATS: AggregateStats = {
+  totalAnswered: 0,
+  totalCorrect: 0,
+  runsPlayed: 0,
+  bestRun: null,
+  bestStreak: 0,
+  trailblazerCount: 0,
+  totalTimeMs: 0,
+  byCategory: {},
+  byDifficulty: {
+    easy: { answered: 0, correct: 0 },
+    medium: { answered: 0, correct: 0 },
+    hard: { answered: 0, correct: 0 },
+  },
+  lastUpdatedAt: null,
+}
+
+export async function getAggregateStats(uid: string): Promise<AggregateStats> {
+  const db = getFirestoreDb()
+  const snap = await db.doc(`users/${uid}/triviaStats/aggregate`).get()
+  if (!snap.exists) return { ...EMPTY_STATS }
+  return snap.data() as AggregateStats
+}
+
+// Called at run finalization. Reads the run doc, walks its answers[],
+// and atomically updates the aggregate doc. Idempotent via statsApplied flag.
+export async function applyRunToAggregate(uid: string, runId: string): Promise<void> {
+  const db = getFirestoreDb()
+  const runRef = db.doc(`users/${uid}/triviaInfinite/${runId}`)
+  const aggRef = db.doc(`users/${uid}/triviaStats/aggregate`)
+
+  await db.runTransaction(async (tx) => {
+    const runSnap = await tx.get(runRef)
+    if (!runSnap.exists) throw new Error('Run not found')
+    const run = runSnap.data() as RunDoc & { statsApplied?: boolean }
+
+    // Idempotency: skip if already applied
+    if (run.statsApplied === true) return
+
+    const aggSnap = await tx.get(aggRef)
+    const agg: AggregateStats = aggSnap.exists
+      ? (aggSnap.data() as AggregateStats)
+      : { ...EMPTY_STATS }
+
+    // Batch-read all question docs referenced by answers
+    const questionIds = run.answers.map((a) => a.questionId)
+    const questionRefs = questionIds.map((id) => db.doc(`aiQuestions/${id}`))
+    const questionSnaps = questionRefs.length > 0 ? await tx.getAll(...questionRefs) : []
+    const questionMap = new Map<string, { category: string; difficulty: 'easy' | 'medium' | 'hard' }>()
+    for (const qs of questionSnaps) {
+      if (qs.exists) {
+        const qd = qs.data()!
+        questionMap.set(qs.id, { category: qd.category, difficulty: qd.difficulty })
+      }
+    }
+
+    // Accumulate deltas from this run's answers
+    let totalAnswered = 0
+    let totalCorrect = 0
+    let totalTimeMs = 0
+    let trailblazerCount = 0
+    const byCategory: Record<string, { answered: number; correct: number; totalTimeMs: number }> = {}
+    const byDifficulty: Record<string, { answered: number; correct: number }> = {
+      easy: { answered: 0, correct: 0 },
+      medium: { answered: 0, correct: 0 },
+      hard: { answered: 0, correct: 0 },
+    }
+
+    for (const answer of run.answers) {
+      totalAnswered += 1
+      if (answer.correct) totalCorrect += 1
+      totalTimeMs += answer.timeMs
+      if (answer.trailblazer) trailblazerCount += 1
+
+      const qInfo = questionMap.get(answer.questionId)
+      if (qInfo) {
+        // Category
+        if (!byCategory[qInfo.category]) {
+          byCategory[qInfo.category] = { answered: 0, correct: 0, totalTimeMs: 0 }
+        }
+        byCategory[qInfo.category].answered += 1
+        if (answer.correct) byCategory[qInfo.category].correct += 1
+        byCategory[qInfo.category].totalTimeMs += answer.timeMs
+
+        // Difficulty
+        byDifficulty[qInfo.difficulty].answered += 1
+        if (answer.correct) byDifficulty[qInfo.difficulty].correct += 1
+      }
+    }
+
+    // Merge byCategory: start from existing, add deltas
+    const mergedByCategory: Record<string, { answered: number; correct: number; totalTimeMs: number }> = {}
+    for (const [cat, val] of Object.entries(agg.byCategory)) {
+      mergedByCategory[cat] = { ...val }
+    }
+    for (const [cat, deltas] of Object.entries(byCategory)) {
+      if (!mergedByCategory[cat]) {
+        mergedByCategory[cat] = { answered: 0, correct: 0, totalTimeMs: 0 }
+      }
+      mergedByCategory[cat].answered += deltas.answered
+      mergedByCategory[cat].correct += deltas.correct
+      mergedByCategory[cat].totalTimeMs += deltas.totalTimeMs
+    }
+
+    // Build merged aggregate
+    const newAgg: AggregateStats = {
+      totalAnswered: agg.totalAnswered + totalAnswered,
+      totalCorrect: agg.totalCorrect + totalCorrect,
+      runsPlayed: agg.runsPlayed + 1,
+      bestRun: agg.bestRun,
+      bestStreak: Math.max(agg.bestStreak, run.longestStreak),
+      trailblazerCount: agg.trailblazerCount + trailblazerCount,
+      totalTimeMs: agg.totalTimeMs + totalTimeMs,
+      byCategory: mergedByCategory,
+      byDifficulty: {
+        easy: {
+          answered: agg.byDifficulty.easy.answered + byDifficulty.easy.answered,
+          correct: agg.byDifficulty.easy.correct + byDifficulty.easy.correct,
+        },
+        medium: {
+          answered: agg.byDifficulty.medium.answered + byDifficulty.medium.answered,
+          correct: agg.byDifficulty.medium.correct + byDifficulty.medium.correct,
+        },
+        hard: {
+          answered: agg.byDifficulty.hard.answered + byDifficulty.hard.answered,
+          correct: agg.byDifficulty.hard.correct + byDifficulty.hard.correct,
+        },
+      },
+      lastUpdatedAt: null, // overwritten by server timestamp below
+    }
+
+    // Update bestRun if this run's score exceeds the current best
+    if (!newAgg.bestRun || run.score > newAgg.bestRun.score) {
+      newAgg.bestRun = {
+        score: run.score,
+        longestStreak: run.longestStreak,
+        runId: run.runId,
+        endedAt: run.endedAt,
+      }
+    }
+
+    // Write aggregate with server timestamp
+    tx.set(aggRef, { ...newAgg, lastUpdatedAt: FieldValue.serverTimestamp() })
+
+    // Mark the run as having its stats applied (idempotency guard)
+    tx.update(runRef, { statsApplied: true })
+  })
+}

--- a/src/lib/trivia/triviaStats.ts
+++ b/src/lib/trivia/triviaStats.ts
@@ -61,6 +61,9 @@ export async function applyRunToAggregate(uid: string, runId: string): Promise<v
     if (!runSnap.exists) throw new Error('Run not found')
     const run = runSnap.data() as RunDoc & { statsApplied?: boolean }
 
+    // Practice runs don't count toward stats
+    if (run.mode === 'practice') return
+
     // Idempotency: skip if already applied
     if (run.statsApplied === true) return
 

--- a/src/lib/trivia/triviaStats.ts
+++ b/src/lib/trivia/triviaStats.ts
@@ -22,6 +22,7 @@ export interface AggregateStats {
     medium: { answered: number; correct: number }
     hard: { answered: number; correct: number }
   }
+  exhaustionCount: number
   lastUpdatedAt: FirebaseFirestore.Timestamp | null
 }
 
@@ -39,6 +40,7 @@ const EMPTY_STATS: AggregateStats = {
     medium: { answered: 0, correct: 0 },
     hard: { answered: 0, correct: 0 },
   },
+  exhaustionCount: 0,
   lastUpdatedAt: null,
 }
 
@@ -156,6 +158,7 @@ export async function applyRunToAggregate(uid: string, runId: string): Promise<v
           correct: agg.byDifficulty.hard.correct + byDifficulty.hard.correct,
         },
       },
+      exhaustionCount: agg.exhaustionCount ?? 0,
       lastUpdatedAt: null, // overwritten by server timestamp below
     }
 
@@ -175,4 +178,15 @@ export async function applyRunToAggregate(uid: string, runId: string): Promise<v
     // Mark the run as having its stats applied (idempotency guard)
     tx.update(runRef, { statsApplied: true })
   })
+}
+
+export async function trackExhaustion(uid: string): Promise<void> {
+  const db = getFirestoreDb()
+  const aggRef = db.doc(`users/${uid}/triviaStats/aggregate`)
+  const snap = await aggRef.get()
+  if (snap.exists) {
+    await aggRef.update({ exhaustionCount: FieldValue.increment(1), lastUpdatedAt: FieldValue.serverTimestamp() })
+  } else {
+    await aggRef.set({ ...EMPTY_STATS, exhaustionCount: 1, lastUpdatedAt: FieldValue.serverTimestamp() })
+  }
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -16,6 +16,8 @@ export default defineConfig({
       'src/app/tap-tap-adventure/**/*.test.ts',
       'src/app/daily-card-game/**/*.test.ts',
       'src/app/daily-card-game/**/*.test.tsx',
+      'src/lib/trivia/**/*.test.ts',
+      'src/app/trivia/**/*.test.ts',
     ],
     coverage: {
       reporter: ['text', 'json', 'html'],


### PR DESCRIPTION
## Summary

Closes the gap between the Infinite Trivia epic spec and the shipped app: questions now generate on demand when a player exhausts their pool, anyone can play (logged in or not), and the per-question loop got a polish pass.

## What ships

**On-demand question generation**
- New `src/lib/trivia/generateQuestion.ts` extracts the OpenAI generation logic into a shared, server-only module.
- `/api/v1/trivia/infinite/next` falls through to generation when the sampler returns null, persists via `saveAIQuestion()`, returns the question. The graceful 204 fallback survives if OpenAI is unavailable.
- Streak-biased difficulty so generated questions slot into the existing curve.

**Preload pipeline**
- `useInfiniteRun` kicks off a background `/next` fetch as soon as the player submits an answer (and the run is continuing). `nextQuestion` consumes the prefetch instantly. AbortController cancels stale prefetches.

**Per-uid generation rate limit**
- New `src/lib/trivia/generationLimit.ts`: 30 generations/hour/uid, stored at `users/{uid}/triviaInfiniteMeta/generationLimit`. Keyed by uid, so per-player.
- `/next` returns 429 when exceeded; client surfaces a friendly error with a Try Again button.

**Anonymous-first auth**
- `useAuth` auto-signs-in anonymously when no user is present, honoring CLAUDE.md #1. Logged-out players get full per-device persistence (seenQuestions, run history, stats).
- Sign-in CTAs (run summary, exhausted screen) now fire for `!user || user.isAnonymous`, so anonymous players are invited to upgrade at the moment of earned value.

**Pre-game rules modal**
- New `InfiniteRulesModal` shows once before the first run with the four rules (lives, streak multiplier, bonus life, trailblazer). \"Don't show again\" persists to localStorage. Buttons: Back / Practice Mode / Continue.

**End-of-daily CTA**
- `TriviaResults` renders a \"Want more? Keep going with Infinite Trivia\" card after the share button when an `onStartInfinite` handler is wired (it now is, from `page.tsx`).

**Per-question loop polish**
- Answer feedback panel now includes the correct answer (when wrong), explanation, ratings (👍/👎), and the report flag — same as daily mode.
- Rating UI mirrors the flag's terminal pattern: after voting, replaces the buttons with `👍 Liked` / `👎 Disliked` text.
- Report modal: full reason set + always-available free-text note (required for `Other`, optional for the others).
- Tooltips/aria-labels on the rating + flag buttons.
- Input: solid dark `bg-surface-container-high` with `!` important to defeat browser autofill; `key={question.id}` resets state between questions; `autoComplete=off`.
- Question text + user answer + correct answer + explanation captured per run; an ℹ️ button on each row in the run-summary history opens a modal with full context.

**Terminal-wrong-answer flow**
- When a wrong answer takes the player to 0 lives, the hook now stays on `phase: 'answered'` so they see the correct answer + explanation before clicking through to the summary. \"Next Question\" becomes \"View Run Summary\". `endRun` short-circuits the redundant `/end` call when the server already auto-finalized.

**Copy**
- \"Infinite cavern\" / \"traveler\" framing dropped throughout the trivia tree.
- \"Flee\" → \"Exit Game\" in both daily and infinite HUDs.
- \"Enter the Infinite Cavern\" → \"Start Infinite Trivia\" on landing + stats CTAs.

**Bug fix**
- `submitAnswer` was crashing with `FieldValue.serverTimestamp() cannot be used inside of an array` because `answeredAt` was a sentinel inside the `answers[]` arrayUnion. Switched that one field to `Timestamp.now()`; the genuinely top-level uses of `serverTimestamp()` are unchanged.

## Pre-deploy checklist

- [ ] **Enable Anonymous sign-in in Firebase Console**: Authentication → Sign-in method → Anonymous → Enable. Without this, the auto-anonymous flow will fail with `auth/admin-restricted-operation` and any logged-out visitor will be stuck on the loading screen.
- [ ] Confirm `OPENAI_API_KEY` is set in production (used by both the answer judge and the new generator).
- [ ] Firestore indexes already cover the sampler's queries — no new indexes required.

## Follow-ups (filed)

- #624 — Anonymous-to-permanent account linking on sign-up (`linkWithCredential` so anonymous progress migrates when they sign up).
- #625 — Audit `if (!user)` gates after anonymous-first.
- #626 — Tune Infinite Trivia generation rate limit after telemetry.

## Test plan

- [ ] **Logged-in scored run**: 3 lives, streak multiplier kicks in at 5/10/20, life refund at 10-streak.
- [ ] **Logged-in practice run**: same questions, no lives, no leaderboard write.
- [ ] **Logged-out / anonymous run**: page loads, anonymous uid minted, run starts, end-of-run CTA shows \"Lock in your progress\".
- [ ] **On-demand generation**: with the seenQuestions seeder applied (`scripts/seed-seen-questions.ts`), every question is freshly generated; \"You are the first to find this question\" copy fires; +50 trailblazer bonus on each correct answer.
- [ ] **Preload**: DevTools network tab — `/next` fires while the answer-feedback screen is up; \"Next Question\" click is instant (no second request).
- [ ] **Rate limit**: hammer `/next` past 30 in an hour → 429 + friendly error UI.
- [ ] **Rules modal**: appears on first visit; check Don't show again, refresh, confirm it's skipped.
- [ ] **Terminal wrong answer**: lose your last life → still see the correct answer + explanation + rating + flag → click View Run Summary.
- [ ] **End-of-daily CTA**: finish a daily run → \"Want more?\" card appears with Start Infinite Trivia button.
- [ ] **Reporting**: every reason submits cleanly with optional note; Other requires a note; a flag without a note still works for non-Other reasons.
- [ ] **Daily mode untouched**: daily questions still load from JSON files; no Firestore writes to `aiQuestions/*` from the daily flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)