### PR TITLE
fix: anonymous-first UI audit + link anonymous users on sign-up

### DIFF
--- a/src/app/auth/page.tsx
+++ b/src/app/auth/page.tsx
@@ -7,7 +7,7 @@ import { type FormEvent, Suspense, useEffect, useState } from 'react'
 import { ChunkyButton } from '@/components/ui/chunky-button'
 import { ChunkyCard, ChunkyCardContent, ChunkyCardHeader, ChunkyCardTitle } from '@/components/ui/chunky-card'
 import { Input } from '@/components/ui/input'
-import { AuthProvider, useAuth } from '@/hooks/useAuth'
+import { AnonymousProgressOrphanedError, AuthProvider, useAuth } from '@/hooks/useAuth'
 
 function AuthPageInner() {
   const router = useRouter()
@@ -21,21 +21,28 @@ function AuthPageInner() {
   const [password, setPassword] = useState('')
   const [submitting, setSubmitting] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const [orphanNotice, setOrphanNotice] = useState<string | null>(null)
 
   useEffect(() => {
-    if (!loading && user) {
+    if (orphanNotice) return // user must acknowledge before redirect
+    if (!loading && user && !user.isAnonymous) {
       router.replace(redirectTo)
     }
-  }, [loading, user, redirectTo, router])
+  }, [loading, user, redirectTo, router, orphanNotice])
 
   const handleGoogle = async () => {
     setError(null)
+    setOrphanNotice(null)
     setSubmitting(true)
     try {
       await signInWithGoogle()
       router.replace(redirectTo)
     } catch (err) {
-      setError(formatAuthError(err))
+      if (err instanceof AnonymousProgressOrphanedError) {
+        setOrphanNotice(err.message)
+      } else {
+        setError(formatAuthError(err))
+      }
     } finally {
       setSubmitting(false)
     }
@@ -44,6 +51,7 @@ function AuthPageInner() {
   const handleEmail = async (e: FormEvent) => {
     e.preventDefault()
     setError(null)
+    setOrphanNotice(null)
     setSubmitting(true)
     try {
       if (mode === 'signin') {
@@ -53,7 +61,11 @@ function AuthPageInner() {
       }
       router.replace(redirectTo)
     } catch (err) {
-      setError(formatAuthError(err))
+      if (err instanceof AnonymousProgressOrphanedError) {
+        setOrphanNotice(err.message)
+      } else {
+        setError(formatAuthError(err))
+      }
     } finally {
       setSubmitting(false)
     }
@@ -149,10 +161,27 @@ function AuthPageInner() {
             </div>
           )}
 
+          {orphanNotice && (
+            <div
+              className="flex flex-col gap-3 rounded-lg border border-tertiary-fixed-dim/40 bg-tertiary-fixed-dim/15 p-3 text-on-surface/80 text-sm"
+              role="status"
+            >
+              <p>{orphanNotice}</p>
+              <ChunkyButton
+                variant="primary"
+                size="sm"
+                onClick={() => router.replace(redirectTo)}
+              >
+                Continue
+              </ChunkyButton>
+            </div>
+          )}
+
           <button
             type="button"
             onClick={() => {
               setError(null)
+              setOrphanNotice(null)
               setMode(mode === 'signin' ? 'signup' : 'signin')
             }}
             className="text-on-surface/50 text-sm text-center hover:text-on-surface/80 transition-colors"

--- a/src/hooks/useAuth.tsx
+++ b/src/hooks/useAuth.tsx
@@ -1,18 +1,39 @@
 'use client'
 
 import {
+  EmailAuthProvider,
   GoogleAuthProvider,
   type User,
   createUserWithEmailAndPassword,
   signOut as firebaseSignOut,
+  linkWithCredential,
+  linkWithPopup,
   onAuthStateChanged,
   signInAnonymously,
+  signInWithCredential,
   signInWithEmailAndPassword,
   signInWithPopup,
 } from 'firebase/auth'
 import { type ReactNode, createContext, useContext, useEffect, useState } from 'react'
 
 import { getFirebaseAuth, isFirebaseAuthConfigured } from '@/lib/firebase/client'
+
+/**
+ * Thrown by signInWithGoogle / signInWithEmail / signUpWithEmail when the
+ * caller was anonymous and the credential they provided already belongs to
+ * another Firebase user. The auth flow falls back to signing into the
+ * existing account, which means the *anonymous* user's uid (and any data
+ * keyed by it — daily history, infinite stats, etc.) is now orphaned.
+ *
+ * Surfaces in the UI should catch this and warn the player that
+ * pre-sign-in progress was tied to a different account on this device.
+ */
+export class AnonymousProgressOrphanedError extends Error {
+  constructor(message = 'Signed into an existing account; anonymous progress on this device was not migrated.') {
+    super(message)
+    this.name = 'AnonymousProgressOrphanedError'
+  }
+}
 
 interface AuthContextValue {
   user: User | null
@@ -22,6 +43,14 @@ interface AuthContextValue {
   signInWithEmail: (email: string, password: string) => Promise<void>
   signUpWithEmail: (email: string, password: string) => Promise<void>
   signOut: () => Promise<void>
+}
+
+function getErrorCode(err: unknown): string | undefined {
+  if (typeof err === 'object' && err !== null && 'code' in err) {
+    const code = (err as { code: unknown }).code
+    return typeof code === 'string' ? code : undefined
+  }
+  return undefined
 }
 
 const AuthContext = createContext<AuthContextValue | null>(null)
@@ -61,16 +90,78 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const signInWithGoogle = async () => {
     const auth = getFirebaseAuth()
     const provider = new GoogleAuthProvider()
+    const current = auth.currentUser
+
+    // If the caller is currently anonymous, link the Google credential to the
+    // existing anonymous user so their uid (and all uid-keyed Firestore data)
+    // carries over. Falls back to a normal sign-in if the credential is
+    // already tied to another account.
+    if (current?.isAnonymous) {
+      try {
+        await linkWithPopup(current, provider)
+        return
+      } catch (err) {
+        const code = getErrorCode(err)
+        if (code === 'auth/credential-already-in-use') {
+          const credential = GoogleAuthProvider.credentialFromError(
+            err as Parameters<typeof GoogleAuthProvider.credentialFromError>[0]
+          )
+          if (credential) {
+            await signInWithCredential(auth, credential)
+            throw new AnonymousProgressOrphanedError()
+          }
+        }
+        throw err
+      }
+    }
+
     await signInWithPopup(auth, provider)
   }
 
   const signInWithEmail = async (email: string, password: string) => {
     const auth = getFirebaseAuth()
+    const current = auth.currentUser
+
+    if (current?.isAnonymous) {
+      const credential = EmailAuthProvider.credential(email, password)
+      try {
+        await linkWithCredential(current, credential)
+        return
+      } catch (err) {
+        const code = getErrorCode(err)
+        if (code === 'auth/credential-already-in-use' || code === 'auth/email-already-in-use') {
+          // Email already belongs to a Firebase user — sign into that one.
+          await signInWithCredential(auth, credential)
+          throw new AnonymousProgressOrphanedError()
+        }
+        throw err
+      }
+    }
+
     await signInWithEmailAndPassword(auth, email, password)
   }
 
   const signUpWithEmail = async (email: string, password: string) => {
     const auth = getFirebaseAuth()
+    const current = auth.currentUser
+
+    if (current?.isAnonymous) {
+      const credential = EmailAuthProvider.credential(email, password)
+      try {
+        await linkWithCredential(current, credential)
+        return
+      } catch (err) {
+        const code = getErrorCode(err)
+        if (code === 'auth/credential-already-in-use' || code === 'auth/email-already-in-use') {
+          // Email already taken by another Firebase user — fall back to
+          // signing into that account. Anonymous progress is orphaned.
+          await signInWithCredential(auth, credential)
+          throw new AnonymousProgressOrphanedError()
+        }
+        throw err
+      }
+    }
+
     await createUserWithEmailAndPassword(auth, email, password)
   }
 


### PR DESCRIPTION
Closes #624. Also fixes a production-blocking regression introduced in #627: with auto-anonymous-sign-in, several UI gates treated the anonymous identity as a logged-in named account, leaving visitors stuck (no way to actually log in, no way to truly log out).

## Two related changes

### 1. UI audit — treat anonymous users as "not signed in" (production hotfix)

Anonymous Firebase users have a uid (so games can persist per-device state) but should be treated as "not signed in" wherever the UI cares about *named-account* identity. Patched the surfaces that were gating on bare \`user\`:

- **\`TriviaLanding.tsx\`** — the account-menu/sign-in toggle and the "Sign in to save your progress" promo banner. Anonymous users now see the Sign in link, not a dead-end Account menu.
- **\`TriviaResults.tsx\`** — share text and the "your score wasn't saved" CTA.
- **\`TriviaStats.tsx\`** — the empty-state CTA on the stats page.
- **\`/auth\` page** — auto-redirect was bouncing anonymous users away from /auth before they could sign in. Tightened to \`user && !user.isAnonymous\`.

Pattern applied per component: \`const isNamedUser = !!user && !user.isAnonymous\`. Existing run-summary / exhausted-screen sign-in CTAs already used \`!user || user.isAnonymous\` (added in #627) — kept consistent.

### 2. Account linking on sign-up (the original #624 scope)

When an auto-signed-in anonymous user signs in via Google or email, attach the credential to the existing anonymous user (\`linkWithPopup\` / \`linkWithCredential\`) instead of replacing them. The uid — and every Firestore document keyed by it (daily streak, daily history, infinite seenQuestions, run history, constellation, generation rate-limit counter) — carries over to the named account automatically because nothing about the key changed.

If the credential already belongs to another Firebase user (\`auth/credential-already-in-use\`, \`auth/email-already-in-use\`), fall back to \`signInWithCredential\` to switch into the existing account, and surface a typed \`AnonymousProgressOrphanedError\`. The auth page catches it, suppresses auto-redirect, and shows a Continue-gated notice so the player knows progress on this device wasn't migrated.

## Why now

#627 (the Infinite Trivia 8 PR) introduced auto-anonymous-sign-in so logged-out players could play. Two follow-on consequences hit production:

- ❌ **UI bug:** components reading bare \`user\` thought the anonymous identity was a named account → no way to actually sign in or sign out.
- ❌ **Data orphaning:** signing in afterwards replaced the anonymous uid with a new uid, orphaning streak/history/stats. Plus today's daily score double-wrote the leaderboard (once under the anonymous uid, once under the real uid via the existing localStorage reconciliation).

Linking + the audit together fix both.

## Files changed

- \`src/hooks/useAuth.tsx\` — link/credential branches in the three sign-in flows; new \`AnonymousProgressOrphanedError\`.
- \`src/app/auth/page.tsx\` — \`orphanNotice\` state + Continue-gated notice; tightened auto-redirect.
- \`src/app/trivia/components/TriviaLanding.tsx\` — \`isNamedUser\` for account-menu / sign-in promo gates.
- \`src/app/trivia/components/TriviaResults.tsx\` — \`isNamedUser\` for share player-name + sign-in card.
- \`src/app/trivia/components/TriviaStats.tsx\` — \`isNamedUser\` for empty-state CTA.

## Test plan

- [ ] **Anonymous load** of /trivia: Sign-in link visible in top-right, "Sign in to save your progress" promo banner visible, no faux Account menu.
- [ ] **Anonymous → /auth**: page renders normally (no auto-redirect), sign-in form usable.
- [ ] **Anonymous → first-time Google sign-in**: linking succeeds, uid preserved, daily streak / infinite stats / constellation all carry over.
- [ ] **Anonymous → first-time email sign-up**: same.
- [ ] **Anonymous → existing Google / email**: orphan notice appears with Continue button; clicking Continue lands in /trivia under the existing account.
- [ ] **Sign-out from named account**: returns to anonymous, Sign-in link reappears, no UserMenu.
- [ ] **Already-signed-in named user**: visiting /auth → auto-redirect to /trivia (existing behavior preserved).
- [ ] **Daily play history**: anonymous play → sign in via Google → daily history page shows the anonymous-era runs.

## Out of scope (follow-ups worth filing)

- **Server-side merge for the orphan-on-conflict case.** When an anonymous user signs into an existing account, their anonymous data is unreachable. A proper merge would query the anonymous uid's documents, merge into the named account, delete the anonymous user. Conflict resolution (which streak wins?) is non-trivial — separate epic.
- **Pruning orphaned anonymous uids in Firestore.** Storage cost grows over time.
- **Telemetry on link-success vs orphan-fallback rates.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)