### PR TITLE
fix: anonymous-first sign-in unblocked (UI audit + listener race)

### DIFF
--- a/src/app/trivia/components/TriviaLanding.tsx
+++ b/src/app/trivia/components/TriviaLanding.tsx
@@ -48,13 +48,17 @@ export function TriviaLanding({
   const alreadyPlayed = !!todayResult
   const showFirestoreLoadingHint = !!user && firestoreLoading
   const category = getDailyCategory(todayStr)
-  const showSignInPromos = authConfigured && !authLoading && !user
+  // Anonymous Firebase users are signed in technically (so games can persist
+  // per-device state) but should be treated as "not signed in" for the UI's
+  // purposes — sign-in CTAs, account menu, profile display.
+  const isNamedUser = !!user && !user.isAnonymous
+  const showSignInPromos = authConfigured && !authLoading && !isNamedUser
   const nicknameSeed = nickname || user?.displayName || ''
 
   return (
     <div className="flex flex-col items-center gap-6 max-w-lg mx-auto py-8">
       <div className="w-full flex justify-end min-h-[1.75rem] text-sm">
-        {!authConfigured ? null : authLoading ? null : user ? (
+        {!authConfigured ? null : authLoading ? null : isNamedUser && user ? (
           <UserMenu
             displayName={displayName || user.email || 'Account'}
             photoURL={user.photoURL}

--- a/src/app/trivia/components/TriviaResults.tsx
+++ b/src/app/trivia/components/TriviaResults.tsx
@@ -103,13 +103,16 @@ export function TriviaResults({ result, onBack, onViewStats, onViewLeaderboard, 
   const currentStreak = stats.currentStreak
   const countdown = useCountdown()
 
+  // Treat anonymous Firebase users as "not signed in" for share-text and CTAs.
+  const isNamedUser = !!user && !user.isAnonymous
+
   const scorePercent = Math.round((result.score / MAX_SCORE) * 100)
   const correctPercent = result.total > 0 ? Math.round((result.correct / result.total) * 100) : 0
 
   const handleShare = async () => {
-    const playerName = user ? displayName || user.email || null : null
+    const playerName = isNamedUser && user ? displayName || user.email || null : null
     const text = getShareText(result, {
-      streak: user ? currentStreak : undefined,
+      streak: isNamedUser ? currentStreak : undefined,
       playerName,
     })
     try {
@@ -257,7 +260,7 @@ export function TriviaResults({ result, onBack, onViewStats, onViewLeaderboard, 
         </ChunkyCard>
       )}
 
-      {!user && (
+      {!isNamedUser && (
         <SignInCard
           title="🔒 Your score wasn't saved"
           description="Sign in to track your streak, save your stats, and compete on the leaderboard."

--- a/src/app/trivia/components/TriviaStats.tsx
+++ b/src/app/trivia/components/TriviaStats.tsx
@@ -20,6 +20,8 @@ function getAccuracyColor(accuracy: number): string {
 export function TriviaStats({ onBack }: { onBack: () => void }) {
   const { user } = useAuth()
   const { stats, history } = useTriviaUser()
+  // Treat anonymous Firebase users as "not signed in" for the empty-state CTA.
+  const isNamedUser = !!user && !user.isAnonymous
 
   const accuracy =
     stats.totalQuestions > 0
@@ -43,7 +45,7 @@ export function TriviaStats({ onBack }: { onBack: () => void }) {
           My Stats
           <ResetNoticeButton />
         </h2>
-        {user ? (
+        {isNamedUser ? (
           <ChunkyCard variant="surface-variant" className="w-full bg-surface-container/80 border-outline-variant">
             <ChunkyCardContent className="pt-6 text-center">
               <p className="text-on-surface/70 text-lg mb-2">No games played yet</p>


### PR DESCRIPTION
**Production hotfix.** Two related bugs left players unable to actually sign in or sign out after #627's auto-anonymous-sign-in shipped:

## 1. UI thought anonymous = signed-in

Several surfaces gated on bare \`user\`, treating the auto-minted anonymous identity as a logged-in named account:

- **\`TriviaLanding\`** rendered a faux "Account" UserMenu instead of the Sign-in link. Sign-out re-minted a fresh anonymous user, but the UserMenu stayed up — players had no path to log in or fully log out.
- The "Sign in to save your progress" promo banner never appeared (\`!user\` was always false).
- **\`TriviaResults\`** treated anonymous play as named — share text included a bogus player name and the "your score wasn't saved" CTA never showed.
- **\`TriviaStats\`** showed an empty "No games played yet" card to anonymous users instead of the sign-in CTA.

**Fix:** Per-component \`isNamedUser = !!user && !user.isAnonymous\` predicate. Anonymous users now see sign-in prompts, no account menu, and no "saved progress" framing — but their underlying per-device persistence (seenQuestions, infinite stats, etc.) is unchanged.

## 2. Auth listener race re-minted anonymous mid-sign-in

Even after the UI audit, players reported that signing in dropped them back on the login page. Root cause:

During a user-initiated sign-in flow (especially the \`signInWithCredential\` fallback when an existing account already owns the credential, but potentially also link-via-popup), Firebase can briefly fire \`onAuthStateChanged\` with \`null\` between operations. The listener was interpreting that as "signed out" and immediately minting a *new* anonymous user. That second mint races with the named sign-in completing, and the user ends up reverted to a fresh anonymous identity — visually indistinguishable from "I never signed in."

**Fix:** \`signInInProgressRef\` set by \`signInWithGoogle\` / \`signInWithEmail\` / \`signUpWithEmail\`. While the flag is set, the listener's null-handler skips auto-anonymous-mint. Cleared in a \`finally\` so success and failure both release it. Doesn't affect the legitimate \`signOut\` → re-mint flow because \`signOut\` doesn't set the flag.

## Files changed

- \`src/app/trivia/components/TriviaLanding.tsx\`
- \`src/app/trivia/components/TriviaResults.tsx\`
- \`src/app/trivia/components/TriviaStats.tsx\`
- \`src/hooks/useAuth.tsx\` — added \`signInInProgressRef\`, gated the listener's null-handler on it, wrapped the three sign-in methods with try/finally to set/clear the flag.

## Test plan

- [ ] **Anonymous load** of \`/trivia\`: Sign-in link visible in top-right, "Sign in to save your progress" promo banner visible, no faux Account menu.
- [ ] **Anonymous → click Sign in → Google sign-in (first time)**: post-popup, redirect lands on \`/trivia\` with the named UserMenu visible. *No* bounce back to the login page.
- [ ] **Anonymous → click Sign in → email sign-up (new email)**: same — lands on \`/trivia\` as named user.
- [ ] **Anonymous → existing Google account**: orphan notice appears with Continue button; clicking Continue lands on \`/trivia\` as the existing named account.
- [ ] **Sign-out from named account**: returns to anonymous, Sign-in link reappears, no UserMenu.
- [ ] **Already-signed-in named user visiting /auth**: auto-redirect to \`/trivia\` (existing behavior preserved).
- [ ] **Anonymous user visiting /auth directly**: stays on the page, sign-in form usable.
- [ ] **Anonymous on results screen**: "🔒 Your score wasn't saved" SignInCard appears; share text uses no player name.
- [ ] **Anonymous on stats screen**: "📊 Your stats will appear here" SignInCard appears.

## Related

Partially closes #625 (the broader audit-\`if (!user)\`-gates tracker).

🤖 Generated with [Claude Code](https://claude.com/claude-code)