### PR TITLE
fix: trivia views overflow viewport due to redundant min-h-screen

### DIFF
--- a/src/app/trivia/layout.tsx
+++ b/src/app/trivia/layout.tsx
@@ -3,9 +3,8 @@ import { AuthProvider } from '@/hooks/useAuth'
 import type { ReactNode } from 'react'
 
 export default function TriviaLayout({ children }: { children: ReactNode }) {
-  return (
-    <AuthProvider>
-      <div className="min-h-screen">{children}</div>
-    </AuthProvider>
-  )
+  // No height styling here — the root <main> in src/app/layout.tsx is
+  // already flex-1 inside a min-h-screen flex column with header + footer,
+  // so trivia content fills exactly the leftover viewport space.
+  return <AuthProvider>{children}</AuthProvider>
 }


### PR DESCRIPTION
## Summary

Trivia routes were rendering taller than the viewport on first paint. Root cause: the trivia layout was wrapping its children in a \`min-h-screen\` div, **inside** the root layout's already-\`min-h-screen\` wrapper. The math:

\`\`\`
#site-wrapper (root):  min-h-screen, flex-col
  TopNavBar:           ~64px
  <main flex-1>:       expands to fill leftover viewport space
    trivia-layout div: min-h-screen  ← forces 100vh inside the flex
  Footer:              ~80px
\`\`\`

Total page height = 100vh (trivia layout) + ~144px (nav + footer) → overflows the window on every trivia view, introducing an unnecessary vertical scroll even when the content is short.

## Fix

Drop the inner \`min-h-screen\` from \`src/app/trivia/layout.tsx\`. Trivia content sizes to its own content inside the \`<main flex-1>\` space, which is already exactly the leftover viewport.

## Test plan

- [ ] \`/trivia\` (landing): no scroll on a screen that comfortably fits the content; content sits naturally between header and footer.
- [ ] \`/trivia/infinite\`: same.
- [ ] Pages with intentionally tall content (long answer history, full stats page): scroll appears only when content actually exceeds the viewport, not as a side effect of layout.
- [ ] Footer doesn't ride up unnaturally close to the content; the \`<main flex-1>\` still pushes the footer to the bottom of the viewport on short pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)