### PR TITLE
fix: lift main above footer so trivia modal isn't clipped

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -54,7 +54,7 @@ export default function RootLayout({
           <div id="site-wrapper" className="min-h-screen flex flex-col bg-surface-dim text-on-surface relative overflow-hidden">
             <AmbientOrbs palette={['primary', 'secondary', 'tertiary']} intensity="medium" />
             <TopNavBar />
-            <main className="flex-1 container mx-auto p-4 z-10 relative">{children}</main>
+            <main className="flex-1 container mx-auto p-4 z-20 relative">{children}</main>
             <Footer />
           </div>
         </body>


### PR DESCRIPTION
## Summary
- `<main>` and `<footer>` both had `z-10 relative`, creating sibling stacking contexts at the same level. Document order put the footer on top.
- The Infinite Trivia rules modal (`fixed inset-0 z-50`) was trapped inside main's `z-10` context, so its `z-50` couldn't escape — the bottom of the modal was clipped behind the footer.
- Bumps `<main>` to `z-20` so its stacking context sits above the footer.

## Test plan
- [ ] Open `/trivia/infinite` on a viewport where the footer is visible — confirm the rules modal renders fully above the footer.
- [ ] Spot-check other pages to confirm the nav/footer/orbs still stack correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)