### PR TITLE
fix: remove time-based scoring from Infinite Trivia

### DIFF
--- a/src/app/trivia/lib/infiniteScoring.ts
+++ b/src/app/trivia/lib/infiniteScoring.ts
@@ -21,12 +21,6 @@ export function computeStreakMultiplier(streak: number): number {
   return 1
 }
 
-export function computeSpeedBonus(elapsedMs: number, timeLimitMs: number = 30000): number {
-  // max * (timeRemaining / timeLimit), clamped to [0, BASE_MAX_POINTS]
-  const remaining = Math.max(0, timeLimitMs - elapsedMs)
-  return Math.round(BASE_MAX_POINTS * (remaining / timeLimitMs))
-}
-
 export function shouldRefundLife(newStreak: number, livesRemaining: number): boolean {
   return newStreak > 0 && newStreak % LIFE_REFUND_EVERY === 0 && livesRemaining < LIVES_MAX
 }
@@ -52,7 +46,7 @@ export function applyAnswer(params: {
   prevLongestStreak: number
   prevScore: number
 }): AnswerResult {
-  const { correct, trailblazer, elapsedMs, mode, prevLives, prevStreak, prevLongestStreak, prevScore } = params
+  const { correct, trailblazer, mode, prevLives, prevStreak, prevLongestStreak, prevScore } = params
 
   let lives = prevLives
   let streak = prevStreak
@@ -62,9 +56,8 @@ export function applyAnswer(params: {
   if (correct) {
     streak += 1
     longestStreak = Math.max(longestStreak, streak)
-    const speedBonus = computeSpeedBonus(elapsedMs)
     const mult = computeStreakMultiplier(streak)
-    points = Math.round(speedBonus * mult)
+    points = Math.round(BASE_MAX_POINTS * mult)
     if (trailblazer) points += TRAILBLAZER_BONUS
     // Life refund
     if (shouldRefundLife(streak, lives)) {

--- a/src/lib/trivia/__tests__/infiniteScoring.test.ts
+++ b/src/lib/trivia/__tests__/infiniteScoring.test.ts
@@ -6,7 +6,6 @@ import {
   LIVES_START,
   TRAILBLAZER_BONUS,
   applyAnswer,
-  computeSpeedBonus,
   computeStreakMultiplier,
   shouldRefundLife,
 } from '@/app/trivia/lib/infiniteScoring'
@@ -42,29 +41,6 @@ describe('computeStreakMultiplier', () => {
 
   it('returns 3 at streak 50 (well above last tier)', () => {
     expect(computeStreakMultiplier(50)).toBe(3)
-  })
-})
-
-describe('computeSpeedBonus', () => {
-  it('returns BASE_MAX_POINTS at 0ms elapsed', () => {
-    expect(computeSpeedBonus(0)).toBe(BASE_MAX_POINTS)
-  })
-
-  it('returns 0 at exactly timeLimitMs elapsed', () => {
-    expect(computeSpeedBonus(30000)).toBe(0)
-  })
-
-  it('returns 0 for elapsed > timeLimitMs', () => {
-    expect(computeSpeedBonus(35000)).toBe(0)
-  })
-
-  it('returns ~50 at halfway through time', () => {
-    expect(computeSpeedBonus(15000)).toBe(50)
-  })
-
-  it('respects custom timeLimitMs', () => {
-    // 5000ms elapsed out of 10000ms limit → 50% remaining → 50 points
-    expect(computeSpeedBonus(5000, 10000)).toBe(50)
   })
 })
 
@@ -150,7 +126,7 @@ describe('applyAnswer', () => {
     // 5th correct answer should trigger 1.5x multiplier
     const result = applyAnswer({ ...state, correct: true, elapsedMs: 0 })
     expect(result.currentStreak).toBe(5)
-    // At streak 5 with 0ms elapsed: BASE_MAX_POINTS * 1.5 = 150
+    // At streak 5: BASE_MAX_POINTS * 1.5 = 150
     expect(result.points).toBe(Math.round(BASE_MAX_POINTS * 1.5))
   })
 
@@ -195,6 +171,13 @@ describe('applyAnswer', () => {
     const first = applyAnswer({ ...baseParams, correct: true, elapsedMs: 0, prevScore: 0 })
     const second = applyAnswer({ ...baseParams, correct: true, elapsedMs: 0, prevScore: first.score, prevStreak: 1, prevLongestStreak: 1 })
     expect(second.score).toBeGreaterThan(first.score)
+  })
+
+  it('scores the same regardless of elapsed time', () => {
+    const fast = applyAnswer({ ...baseParams, correct: true, elapsedMs: 0 })
+    const slow = applyAnswer({ ...baseParams, correct: true, elapsedMs: 25000 })
+    expect(fast.points).toBe(slow.points)
+    expect(fast.points).toBe(BASE_MAX_POINTS)
   })
 
   it('longestStreak does not decrease on wrong answer', () => {


### PR DESCRIPTION
## Summary
- Removes `computeSpeedBonus()` from scoring math — correct answers now score flat `BASE_MAX_POINTS × streakMultiplier` regardless of answer speed
- Timer remains visible and still ends the question on expiry (pacing only)
- `elapsedMs` is still recorded on answer records for analytics
- Deleted `computeSpeedBonus` tests; added new test verifying scoring is time-independent

## Changes
| File | Change |
|------|--------|
| `src/app/trivia/lib/infiniteScoring.ts` | Removed `computeSpeedBonus()`, updated `applyAnswer` to use flat `BASE_MAX_POINTS * mult` |
| `src/lib/trivia/__tests__/infiniteScoring.test.ts` | Removed speed bonus tests, added time-independence test |

## Test plan
- [x] All 27 scoring tests pass (`vitest run`)
- [x] Typecheck clean (no new errors)
- [x] Verified no remaining references to `computeSpeedBonus` in codebase
- [ ] Manual: confirm correct answer at 0s and 25s elapsed produce same score

Closes #632

🤖 Generated with [Claude Code](https://claude.com/claude-code)