### PR TITLE
fix: remove trailblazer bonus score, keep first-answerer label

### DIFF
--- a/src/app/trivia/components/InfiniteQuestionCard.tsx
+++ b/src/app/trivia/components/InfiniteQuestionCard.tsx
@@ -105,7 +105,7 @@ export function InfiniteQuestionCard({
                 <span className="text-ds-primary">
                   Correct! +{answerResult.points} pts
                   {answerResult.trailblazer && (
-                    <span className="ml-2 text-ds-tertiary">⭐ Trailblazer!</span>
+                    <span className="ml-2 text-on-surface/70">First to answer this question</span>
                   )}
                 </span>
               ) : (

--- a/src/app/trivia/components/InfiniteRulesModal.tsx
+++ b/src/app/trivia/components/InfiniteRulesModal.tsx
@@ -35,10 +35,6 @@ export function InfiniteRulesModal({ defaultMode, onContinue, onCancel }: Props)
             <span aria-hidden="true">🩹</span>
             <span><strong className="text-on-surface">Bonus life.</strong> Every 10-streak refunds a life (cap of 3).</span>
           </li>
-          <li className="flex gap-2">
-            <span aria-hidden="true">⭐</span>
-            <span><strong className="text-on-surface">Trailblazer.</strong> First to answer a fresh question? +50 bonus.</span>
-          </li>
         </ul>
 
         <p className="text-on-surface/50 text-xs">

--- a/src/app/trivia/components/InfiniteRunSummary.tsx
+++ b/src/app/trivia/components/InfiniteRunSummary.tsx
@@ -45,7 +45,7 @@ export function InfiniteRunSummary({ state, onPlayAgain, onBack, mode = 'scored'
       `🔥 Longest Streak: ${state.longestStreak}`,
       `💎 Score: ${state.score.toLocaleString()}`,
       `📊 ${state.questionsAnswered} questions answered`,
-      state.trailblazes > 0 ? `⭐ ${state.trailblazes} trailblazer${state.trailblazes === 1 ? '' : 's'}` : null,
+      state.trailblazes > 0 ? `${state.trailblazes} first answer${state.trailblazes === 1 ? '' : 's'}` : null,
       'https://cometcave.com/trivia',
     ].filter(Boolean).join('\n')
 
@@ -95,7 +95,7 @@ export function InfiniteRunSummary({ state, onPlayAgain, onBack, mode = 'scored'
             </div>
             <div className="text-center">
               <div className="text-xl font-bold text-ds-tertiary">{state.trailblazes}</div>
-              <div className="text-on-surface/50 text-xs">Trailblazers</div>
+              <div className="text-on-surface/50 text-xs">First answers</div>
             </div>
           </div>
         </ChunkyCardContent>
@@ -122,7 +122,7 @@ export function InfiniteRunSummary({ state, onPlayAgain, onBack, mode = 'scored'
                     <span className={`text-lg ${a.correct ? 'text-ds-primary' : 'text-ds-error'}`}>
                       {a.correct ? '✓' : '✗'}
                     </span>
-                    {a.trailblazer && <span className="text-xs">⭐</span>}
+                    {a.trailblazer && <span className="text-xs text-on-surface/50">1st</span>}
                     {a.questionText && (
                       <button
                         type="button"
@@ -198,7 +198,7 @@ export function InfiniteRunSummary({ state, onPlayAgain, onBack, mode = 'scored'
                   {detailFor.correct ? 'Correct' : 'Wrong'}
                 </Pill>
                 <Pill tone="neutral" size="sm">{detailFor.difficulty.toUpperCase()}</Pill>
-                {detailFor.trailblazer && <Pill tone="warning" size="sm">⭐ Trailblazer</Pill>}
+                {detailFor.trailblazer && <Pill tone="neutral" size="sm">First to answer</Pill>}
               </div>
               <button
                 onClick={() => setDetailFor(null)}

--- a/src/app/trivia/components/InfiniteStats.tsx
+++ b/src/app/trivia/components/InfiniteStats.tsx
@@ -250,10 +250,10 @@ export function InfiniteStats({ onBack }: { onBack: () => void }) {
               <div className="text-on-surface/50 text-xs mt-1">Best Streak</div>
             </div>
             <div className="text-center">
-              <div className="text-2xl font-bold text-ds-tertiary">
-                &#x2B50; {stats.trailblazerCount}
+              <div className="text-2xl font-bold text-on-surface">
+                {stats.trailblazerCount}
               </div>
-              <div className="text-on-surface/50 text-xs mt-1">Trailblazers</div>
+              <div className="text-on-surface/50 text-xs mt-1">First answers</div>
             </div>
           </div>
         </ChunkyCardContent>

--- a/src/app/trivia/lib/infiniteScoring.ts
+++ b/src/app/trivia/lib/infiniteScoring.ts
@@ -1,7 +1,6 @@
 export const LIVES_START = 3
 export const LIVES_MAX = 3
 export const LIFE_REFUND_EVERY = 10
-export const TRAILBLAZER_BONUS = 50
 
 export const STREAK_TIERS = [
   { at: 0, mult: 1 },
@@ -58,7 +57,6 @@ export function applyAnswer(params: {
     longestStreak = Math.max(longestStreak, streak)
     const mult = computeStreakMultiplier(streak)
     points = Math.round(BASE_MAX_POINTS * mult)
-    if (trailblazer) points += TRAILBLAZER_BONUS
     // Life refund
     if (shouldRefundLife(streak, lives)) {
       lives = Math.min(lives + 1, LIVES_MAX)

--- a/src/lib/trivia/__tests__/infiniteScoring.test.ts
+++ b/src/lib/trivia/__tests__/infiniteScoring.test.ts
@@ -4,7 +4,6 @@ import {
   BASE_MAX_POINTS,
   LIVES_MAX,
   LIVES_START,
-  TRAILBLAZER_BONUS,
   applyAnswer,
   computeStreakMultiplier,
   shouldRefundLife,
@@ -130,10 +129,10 @@ describe('applyAnswer', () => {
     expect(result.points).toBe(Math.round(BASE_MAX_POINTS * 1.5))
   })
 
-  it('adds TRAILBLAZER_BONUS when trailblazer is true', () => {
+  it('trailblazer flag does not affect points', () => {
     const regular = applyAnswer({ ...baseParams, correct: true, trailblazer: false, elapsedMs: 0 })
     const trailblazer = applyAnswer({ ...baseParams, correct: true, trailblazer: true, elapsedMs: 0 })
-    expect(trailblazer.points - regular.points).toBe(TRAILBLAZER_BONUS)
+    expect(trailblazer.points).toBe(regular.points)
     expect(trailblazer.trailblazer).toBe(true)
   })
 


### PR DESCRIPTION
## Summary
- Removes the +50 trailblazer bonus from scoring — first-answerer no longer affects points
- Replaces "⭐ Trailblazer!" branding with plain "First to answer" text throughout the UI
- Removes the Trailblazer rule from the rules modal
- Keeps server-side first-answerer detection and tracking (data layer unchanged)

**Open decisions resolved:** Option A for both — keep first-answerer label as plain text, keep lifetime stat renamed to "First answers"

## Changes
| File | Change |
|------|--------|
| `infiniteScoring.ts` | Removed `TRAILBLAZER_BONUS` constant and bonus logic |
| `InfiniteQuestionCard.tsx` | "⭐ Trailblazer!" → "First to answer this question" |
| `InfiniteRunSummary.tsx` | Renamed labels, removed star emojis, neutral pill tone |
| `InfiniteStats.tsx` | "Trailblazers" → "First answers" |
| `InfiniteRulesModal.tsx` | Removed Trailblazer rule line |
| `infiniteScoring.test.ts` | Updated test to verify trailblazer flag doesn't affect points |

## Not changed (intentionally)
- Firestore field names (`trailblazer`, `trailblazes`, `trailblazerCount`) — renaming would break existing documents
- Server-side `isTrailblazer` detection in `infiniteRuns.ts`
- Client-side tracking in `useInfiniteRun.ts` and `triviaStats.ts`

## Test plan
- [x] All 27 scoring tests pass
- [x] Rebased cleanly on top of #636 (remove time-based scoring)
- [ ] Manual: verify first-answerer shows "First to answer" not "Trailblazer"

Closes #631

🤖 Generated with [Claude Code](https://claude.com/claude-code)