### PR TITLE
feat: bonus life when flagging first-time question; scrub flagged Qs

### DIFF
--- a/src/app/api/v1/trivia/questions/[id]/flag/route.ts
+++ b/src/app/api/v1/trivia/questions/[id]/flag/route.ts
@@ -5,6 +5,7 @@ import { verifyRequestAuth } from '@/lib/api/auth';
 import { getFirestoreDb } from '@/lib/firebase/server';
 
 const FLAG_THRESHOLD = 3;
+const BONUS_LIVES_MAX = 3;
 const VALID_REASONS = ['obvious', 'unanswerable', 'nonsense', 'inaccurate', 'difficulty_mismatch', 'other'] as const;
 type FlagReason = (typeof VALID_REASONS)[number];
 
@@ -18,14 +19,14 @@ export async function POST(
   const { id: questionId } = await params;
   const uid = auth.claims.uid;
 
-  let body: { reason?: unknown; note?: unknown };
+  let body: { reason?: unknown; note?: unknown; runId?: unknown };
   try {
     body = await request.json();
   } catch {
     return NextResponse.json({ error: 'Invalid JSON.' }, { status: 400 });
   }
 
-  const { reason, note } = body;
+  const { reason, note, runId } = body;
 
   if (!VALID_REASONS.includes(reason as FlagReason)) {
     return NextResponse.json(
@@ -38,17 +39,21 @@ export async function POST(
     return NextResponse.json({ error: 'Note must be a string of max 500 characters.' }, { status: 400 });
   }
 
+  const validRunId = typeof runId === 'string' && runId.length > 0 ? runId : null;
+
   const db = getFirestoreDb();
   const qRef = db.doc(`aiQuestions/${questionId}`);
   const flagRef = db.doc(`aiQuestions/${questionId}/flags/${uid}`);
 
   try {
-    await db.runTransaction(async (tx) => {
+    const result = await db.runTransaction(async (tx) => {
       const qSnap = await tx.get(qRef);
       if (!qSnap.exists) throw new Error('Question not found');
 
       const qData = qSnap.data()!;
-      const newFlaggedCount = (qData.flaggedCount ?? 0) + 1;
+      const currentFlaggedCount = qData.flaggedCount ?? 0;
+      const newFlaggedCount = currentFlaggedCount + 1;
+      const wasFirstFlag = currentFlaggedCount === 0;
 
       const qUpdates: FirebaseFirestore.UpdateData<FirebaseFirestore.DocumentData> = {
         flaggedCount: FieldValue.increment(1),
@@ -68,9 +73,34 @@ export async function POST(
         flagDoc.note = note;
       }
       tx.set(flagRef, flagDoc);
+
+      // Handle run updates if a runId is provided
+      let bonusLifeGranted = false;
+      if (validRunId) {
+        const runRef = db.doc(`users/${uid}/triviaInfinite/${validRunId}`);
+        const runSnap = await tx.get(runRef);
+        if (runSnap.exists) {
+          const runData = runSnap.data()!;
+          const bonusLivesEarned = runData.bonusLivesEarned ?? 0;
+
+          const runUpdates: FirebaseFirestore.UpdateData<FirebaseFirestore.DocumentData> = {
+            flaggedQuestionIds: FieldValue.arrayUnion(questionId),
+          };
+
+          if (wasFirstFlag && bonusLivesEarned < BONUS_LIVES_MAX) {
+            runUpdates.livesRemaining = FieldValue.increment(1);
+            runUpdates.bonusLivesEarned = FieldValue.increment(1);
+            bonusLifeGranted = true;
+          }
+
+          tx.update(runRef, runUpdates);
+        }
+      }
+
+      return { wasFirstFlag, bonusLifeGranted };
     });
 
-    return NextResponse.json({ ok: true }, { status: 200 });
+    return NextResponse.json({ ok: true, wasFirstFlag: result.wasFirstFlag, bonusLifeGranted: result.bonusLifeGranted }, { status: 200 });
   } catch (err) {
     if (err instanceof Error && err.message === 'Question not found') {
       return NextResponse.json({ error: 'Question not found.' }, { status: 404 });

--- a/src/app/trivia/components/FlagQuestion.tsx
+++ b/src/app/trivia/components/FlagQuestion.tsx
@@ -12,11 +12,18 @@ const FLAG_REASONS = [
   { value: 'other', label: 'Other' },
 ] as const
 
-interface Props {
-  questionId: string
+interface FlagResult {
+  wasFirstFlag: boolean
+  bonusLifeGranted: boolean
 }
 
-export function FlagQuestion({ questionId }: Props) {
+interface Props {
+  questionId: string
+  runId?: string | null
+  onFlagged?: (result: FlagResult) => void
+}
+
+export function FlagQuestion({ questionId, runId, onFlagged }: Props) {
   const { user } = useAuth()
   const [showModal, setShowModal] = useState(false)
   const [reason, setReason] = useState<string>('')
@@ -35,13 +42,23 @@ export function FlagQuestion({ questionId }: Props) {
     setSubmitting(true)
     try {
       const token = await user.getIdToken()
-      await fetch(`/api/v1/trivia/questions/${questionId}/flag`, {
+      const res = await fetch(`/api/v1/trivia/questions/${questionId}/flag`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
-        body: JSON.stringify({ reason, note: trimmedNote || undefined }),
+        body: JSON.stringify({ reason, note: trimmedNote || undefined, runId: runId ?? undefined }),
       })
       setSubmitted(true)
       setShowModal(false)
+      if (onFlagged) {
+        let result: FlagResult = { wasFirstFlag: false, bonusLifeGranted: false }
+        try {
+          const data = await res.json()
+          result = { wasFirstFlag: data.wasFirstFlag ?? false, bonusLifeGranted: data.bonusLifeGranted ?? false }
+        } catch {
+          // use defaults
+        }
+        onFlagged(result)
+      }
     } catch {
       // silent
     } finally {

--- a/src/app/trivia/components/InfiniteGame.tsx
+++ b/src/app/trivia/components/InfiniteGame.tsx
@@ -20,7 +20,7 @@ interface Props {
 
 export function InfiniteGame({ onBack, mode = 'scored' }: Props) {
   const { user, loading: authLoading } = useAuth()
-  const { state, startRun, submitAnswer, nextQuestion, endRun } = useInfiniteRun()
+  const { state, startRun, submitAnswer, nextQuestion, endRun, handleQuestionFlagged } = useInfiniteRun()
   const [timeRemaining, setTimeRemaining] = useState(TIME_LIMIT)
   const timerRef = useRef<ReturnType<typeof setInterval> | null>(null)
   const timerStartRef = useRef<number>(0)
@@ -133,7 +133,7 @@ export function InfiniteGame({ onBack, mode = 'scored' }: Props) {
 
   // End of run
   if (state.phase === 'ended') {
-    return <InfiniteRunSummary state={state} onPlayAgain={handlePlayAgain} onBack={onBack} mode={state.mode} />
+    return <InfiniteRunSummary state={state} onPlayAgain={handlePlayAgain} onBack={onBack} mode={state.mode} runId={state.runId} onFlagged={handleQuestionFlagged} />
   }
 
   // Playing or answered
@@ -159,6 +159,8 @@ export function InfiniteGame({ onBack, mode = 'scored' }: Props) {
         isSubmitting={state.phase === 'answering'}
         answerResult={state.lastAnswer}
         questionsAnswered={state.questionsAnswered}
+        runId={state.runId}
+        onFlagged={handleQuestionFlagged}
       />
 
       {state.phase === 'answered' && (

--- a/src/app/trivia/components/InfiniteQuestionCard.tsx
+++ b/src/app/trivia/components/InfiniteQuestionCard.tsx
@@ -8,12 +8,19 @@ import type { AnswerResult } from '@/app/trivia/lib/infiniteScoring'
 import { FlagQuestion } from './FlagQuestion'
 import { QuestionRating } from './QuestionRating'
 
+interface FlagResult {
+  wasFirstFlag: boolean
+  bonusLifeGranted: boolean
+}
+
 interface Props {
   question: InfiniteQuestion
   onSubmit: (answer: string) => void
   isSubmitting: boolean
   answerResult: (AnswerResult & { trailblazer: boolean; correctAnswer: string; explanation: string | null }) | null
   questionsAnswered: number
+  runId?: string | null
+  onFlagged?: (questionId: string, result: FlagResult) => void
 }
 
 function getSocialSignal(timesShown: number): string {
@@ -28,6 +35,8 @@ export function InfiniteQuestionCard({
   isSubmitting,
   answerResult,
   questionsAnswered,
+  runId,
+  onFlagged,
 }: Props) {
   const [textAnswer, setTextAnswer] = useState('')
   const isAnswered = answerResult !== null
@@ -113,7 +122,11 @@ export function InfiniteQuestionCard({
               )}
               <div className="flex items-center gap-2 shrink-0">
                 <QuestionRating questionId={question.id} />
-                <FlagQuestion questionId={question.id} />
+                <FlagQuestion
+                  questionId={question.id}
+                  runId={runId}
+                  onFlagged={onFlagged ? (result) => onFlagged(question.id, result) : undefined}
+                />
               </div>
             </div>
             {!answerResult.correct && (

--- a/src/app/trivia/components/InfiniteRunSummary.tsx
+++ b/src/app/trivia/components/InfiniteRunSummary.tsx
@@ -9,11 +9,18 @@ import { QuestionRating } from './QuestionRating'
 import { FlagQuestion } from './FlagQuestion'
 import type { InfiniteRunState, InfiniteMode } from '@/app/trivia/hooks/useInfiniteRun'
 
+interface FlagResult {
+  wasFirstFlag: boolean
+  bonusLifeGranted: boolean
+}
+
 interface Props {
   state: InfiniteRunState
   onPlayAgain: () => void
   onBack: () => void
   mode?: InfiniteMode
+  runId?: string | null
+  onFlagged?: (questionId: string, result: FlagResult) => void
 }
 
 function formatTime(ms: number): string {
@@ -33,7 +40,7 @@ const ANSWERS_PAGE_SIZE = 20
 
 type AnswerEntry = InfiniteRunState['answers'][number]
 
-export function InfiniteRunSummary({ state, onPlayAgain, onBack, mode = 'scored' }: Props) {
+export function InfiniteRunSummary({ state, onPlayAgain, onBack, mode = 'scored', runId, onFlagged }: Props) {
   const { user } = useAuth()
   const [copied, setCopied] = useState(false)
   const [showAllAnswers, setShowAllAnswers] = useState(false)
@@ -141,7 +148,11 @@ export function InfiniteRunSummary({ state, onPlayAgain, onBack, mode = 'scored'
                       +{a.points}
                     </span>
                     <QuestionRating questionId={a.questionId} />
-                    <FlagQuestion questionId={a.questionId} />
+                    <FlagQuestion
+                      questionId={a.questionId}
+                      runId={runId}
+                      onFlagged={onFlagged ? (result) => onFlagged(a.questionId, result) : undefined}
+                    />
                   </div>
                 </div>
               ))}

--- a/src/app/trivia/hooks/useInfiniteRun.ts
+++ b/src/app/trivia/hooks/useInfiniteRun.ts
@@ -25,6 +25,8 @@ export interface InfiniteRunState {
   score: number
   questionsAnswered: number
   trailblazes: number
+  bonusLivesEarned: number
+  flaggedQuestionIds: string[]
   lastAnswer: (AnswerResult & { trailblazer: boolean; correctAnswer: string; explanation: string | null }) | null
   answers: Array<{
     questionId: string
@@ -54,6 +56,8 @@ export function useInfiniteRun() {
     score: 0,
     questionsAnswered: 0,
     trailblazes: 0,
+    bonusLivesEarned: 0,
+    flaggedQuestionIds: [],
     lastAnswer: null,
     answers: [],
     error: null,
@@ -138,6 +142,8 @@ export function useInfiniteRun() {
         score: 0,
         questionsAnswered: 0,
         trailblazes: 0,
+        bonusLivesEarned: 0,
+        flaggedQuestionIds: [],
         lastAnswer: null,
         answers: [],
       }))
@@ -274,5 +280,26 @@ export function useInfiniteRun() {
     setState(s => ({ ...s, phase: 'ended' }))
   }, [state.runId, state.lastAnswer, getAuthHeaders, cancelPrefetch])
 
-  return { state, startRun, submitAnswer, nextQuestion, endRun }
+  const handleQuestionFlagged = useCallback((questionId: string, result: { wasFirstFlag: boolean; bonusLifeGranted: boolean }) => {
+    setState(s => {
+      const newFlaggedQuestionIds = s.flaggedQuestionIds.includes(questionId)
+        ? s.flaggedQuestionIds
+        : [...s.flaggedQuestionIds, questionId]
+
+      // Remove flagged answer from answers array (stats scrub)
+      const newAnswers = s.answers.filter(a => a.questionId !== questionId)
+      const answersRemoved = s.answers.length - newAnswers.length
+
+      return {
+        ...s,
+        livesRemaining: result.bonusLifeGranted ? s.livesRemaining + 1 : s.livesRemaining,
+        bonusLivesEarned: result.bonusLifeGranted ? s.bonusLivesEarned + 1 : s.bonusLivesEarned,
+        flaggedQuestionIds: newFlaggedQuestionIds,
+        answers: newAnswers,
+        questionsAnswered: Math.max(0, s.questionsAnswered - answersRemoved),
+      }
+    })
+  }, [])
+
+  return { state, startRun, submitAnswer, nextQuestion, endRun, handleQuestionFlagged }
 }

--- a/src/lib/trivia/infiniteRuns.ts
+++ b/src/lib/trivia/infiniteRuns.ts
@@ -15,6 +15,8 @@ export interface RunDoc {
   longestStreak: number
   trailblazes: number
   answers: RunAnswer[]
+  bonusLivesEarned: number
+  flaggedQuestionIds: string[]
   startedAt: FirebaseFirestore.Timestamp
   endedAt: FirebaseFirestore.Timestamp | null
 }
@@ -42,6 +44,8 @@ export async function startRun(uid: string, mode: 'scored' | 'practice' = 'score
     longestStreak: 0,
     trailblazes: 0,
     answers: [],
+    bonusLivesEarned: 0,
+    flaggedQuestionIds: [],
     startedAt: now,
     endedAt: null,
   })

--- a/src/lib/trivia/triviaStats.ts
+++ b/src/lib/trivia/triviaStats.ts
@@ -98,7 +98,12 @@ export async function applyRunToAggregate(uid: string, runId: string): Promise<v
       hard: { answered: 0, correct: 0 },
     }
 
+    const flaggedSet = new Set<string>(run.flaggedQuestionIds ?? [])
+
     for (const answer of run.answers) {
+      // Skip flagged questions — they don't count toward stats
+      if (flaggedSet.has(answer.questionId)) continue
+
       totalAnswered += 1
       if (answer.correct) totalCorrect += 1
       totalTimeMs += answer.timeMs


### PR DESCRIPTION
## Summary
- When a player flags a question that has never been flagged before (`flaggedCount === 0`), grants +1 bonus life in the current run
- Max 3 bonus lives per run; bonus lives can push above the normal `LIVES_MAX` of 3
- Flagged questions are scrubbed from the player's stats (removed from answers array, not counted in aggregation)
- Flag API updated to return `wasFirstFlag` and `bonusLifeGranted` signals
- All changes happen atomically in the existing Firestore transaction

## Changes
| File | Change |
|------|--------|
| `flag/route.ts` | Accept `runId`, compute `wasFirstFlag`, grant bonus life in transaction |
| `FlagQuestion.tsx` | New `runId` and `onFlagged` props, passes through to API |
| `useInfiniteRun.ts` | New `bonusLivesEarned`, `flaggedQuestionIds` state; `handleQuestionFlagged` function |
| `InfiniteGame.tsx` | Wire `handleQuestionFlagged` to question card and run summary |
| `InfiniteQuestionCard.tsx` | Pass `runId` and `onFlagged` to FlagQuestion |
| `InfiniteRunSummary.tsx` | Pass `runId` and `onFlagged` to FlagQuestion in answer history |
| `infiniteRuns.ts` | New `bonusLivesEarned`, `flaggedQuestionIds` fields in RunDoc |
| `triviaStats.ts` | Skip flagged questions in `applyRunToAggregate` |

## Out of scope
- Results-screen "answer one more question" modal (follow-up)
- HUD visibility of bonus-life count (explicitly chosen against per issue spec)

## Test plan
- [x] All 27 existing scoring tests pass
- [x] No new TypeScript errors
- [ ] Manual: flag a never-before-flagged question → verify +1 life appears
- [ ] Manual: flag 4 first-time questions in one run → verify only 3 bonus lives granted
- [ ] Manual: verify flagged question removed from run summary and aggregate stats

Closes #633

🤖 Generated with [Claude Code](https://claude.com/claude-code)