### PR TITLE
feat: share-image OG route + public run landing page (#575)

### DIFF
--- a/src/app/api/v1/trivia/infinite/runs/[runId]/share-image/route.tsx
+++ b/src/app/api/v1/trivia/infinite/runs/[runId]/share-image/route.tsx
@@ -1,0 +1,68 @@
+import { ImageResponse } from 'next/og'
+import { type NextRequest } from 'next/server'
+import { getRunByIdPublic } from '@/lib/trivia/infiniteRuns'
+
+export const runtime = 'nodejs'
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ runId: string }> }
+) {
+  const { runId } = await params
+  const result = await getRunByIdPublic(runId)
+  if (!result) {
+    return new Response('Run not found', { status: 404 })
+  }
+  const { run } = result
+
+  const questionsAnswered = run.answers.length
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          justifyContent: 'center',
+          width: '100%',
+          height: '100%',
+          backgroundColor: '#1a1025',
+          color: '#e0d8f0',
+          fontFamily: 'sans-serif',
+          padding: '60px',
+        }}
+      >
+        <div style={{ display: 'flex', fontSize: '32px', color: '#a78bfa', marginBottom: '20px' }}>
+          CometCave Infinite Trivia
+        </div>
+        <div style={{ display: 'flex', fontSize: '80px', marginBottom: '10px' }}>
+          🔥 {run.longestStreak} Streak
+        </div>
+        <div style={{ display: 'flex', gap: '60px', fontSize: '28px', color: '#c4b5fd', marginTop: '20px' }}>
+          <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
+            <div style={{ display: 'flex', fontSize: '48px', color: '#e0d8f0', fontWeight: 'bold' }}>{run.score.toLocaleString()}</div>
+            <div style={{ display: 'flex' }}>Score</div>
+          </div>
+          <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
+            <div style={{ display: 'flex', fontSize: '48px', color: '#e0d8f0', fontWeight: 'bold' }}>{questionsAnswered}</div>
+            <div style={{ display: 'flex' }}>Questions</div>
+          </div>
+          {run.trailblazes > 0 && (
+            <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
+              <div style={{ display: 'flex', fontSize: '48px', color: '#e0d8f0', fontWeight: 'bold' }}>{run.trailblazes}</div>
+              <div style={{ display: 'flex' }}>First Answers</div>
+            </div>
+          )}
+        </div>
+        <div style={{ display: 'flex', fontSize: '20px', color: '#7c3aed', marginTop: '40px' }}>
+          cometcave.com/trivia
+        </div>
+      </div>
+    ),
+    {
+      width: 1200,
+      height: 630,
+    }
+  )
+}

--- a/src/app/trivia/components/InfiniteRunSummary.tsx
+++ b/src/app/trivia/components/InfiniteRunSummary.tsx
@@ -53,7 +53,7 @@ export function InfiniteRunSummary({ state, onPlayAgain, onBack, mode = 'scored'
       `💎 Score: ${state.score.toLocaleString()}`,
       `📊 ${state.questionsAnswered} questions answered`,
       state.trailblazes > 0 ? `${state.trailblazes} first answer${state.trailblazes === 1 ? '' : 's'}` : null,
-      'https://cometcave.com/trivia',
+      runId ? `https://cometcave.com/trivia/runs/${runId}` : 'https://cometcave.com/trivia',
     ].filter(Boolean).join('\n')
 
     try {

--- a/src/app/trivia/runs/[runId]/RunSharePage.tsx
+++ b/src/app/trivia/runs/[runId]/RunSharePage.tsx
@@ -1,0 +1,70 @@
+'use client'
+import { ChunkyButton } from '@/components/ui/chunky-button'
+import { ChunkyCard, ChunkyCardContent } from '@/components/ui/chunky-card'
+import { Pill } from '@/components/ui/pill'
+
+interface RunData {
+  longestStreak: number
+  score: number
+  questionsAnswered: number
+  trailblazes: number
+  mode: 'scored' | 'practice'
+}
+
+export function RunSharePage({ run }: { run: RunData }) {
+  return (
+    <div className="flex flex-col items-center gap-6 max-w-lg mx-auto py-10 px-4">
+      <div className="text-center">
+        <h1 className="font-headline text-headline-lg text-ds-tertiary drop-shadow-[0_4px_0_var(--surface-container-lowest)] mb-2">
+          CometCave Trivia
+        </h1>
+        <p className="text-on-surface/50 text-sm">A traveler completed this run</p>
+      </div>
+
+      <ChunkyCard variant="surface-variant" className="w-full bg-surface-container/80 border-outline-variant">
+        <ChunkyCardContent className="pt-6">
+          <div className="text-center mb-4">
+            <div className="text-6xl font-bold text-ds-tertiary">
+              🔥 {run.longestStreak}
+            </div>
+            <div className="text-on-surface/40 text-sm mt-1">Longest Streak</div>
+          </div>
+
+          <div className="grid grid-cols-3 gap-3">
+            <div className="text-center">
+              <div className="text-xl font-bold text-on-surface">{run.score.toLocaleString()}</div>
+              <div className="text-on-surface/50 text-xs">Score</div>
+            </div>
+            <div className="text-center">
+              <div className="text-xl font-bold text-on-surface">{run.questionsAnswered}</div>
+              <div className="text-on-surface/50 text-xs">Questions</div>
+            </div>
+            <div className="text-center">
+              <div className="text-xl font-bold text-ds-tertiary">{run.trailblazes}</div>
+              <div className="text-on-surface/50 text-xs">First Answers</div>
+            </div>
+          </div>
+
+          {run.mode === 'practice' && (
+            <div className="flex justify-center mt-3">
+              <Pill tone="info" size="sm">Practice Run</Pill>
+            </div>
+          )}
+        </ChunkyCardContent>
+      </ChunkyCard>
+
+      <ChunkyButton
+        variant="primary"
+        size="hero"
+        className="w-full"
+        onClick={() => window.location.href = '/trivia'}
+      >
+        Play Now
+      </ChunkyButton>
+
+      <p className="text-on-surface/30 text-xs text-center">
+        CometCave — an endless trivia adventure
+      </p>
+    </div>
+  )
+}

--- a/src/app/trivia/runs/[runId]/page.tsx
+++ b/src/app/trivia/runs/[runId]/page.tsx
@@ -1,0 +1,46 @@
+import { Metadata } from 'next'
+import { notFound } from 'next/navigation'
+import { getRunByIdPublic } from '@/lib/trivia/infiniteRuns'
+import { RunSharePage } from './RunSharePage'
+
+interface PageProps {
+  params: Promise<{ runId: string }>
+}
+
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+  const { runId } = await params
+  const result = await getRunByIdPublic(runId)
+  if (!result) return { title: 'Run Not Found — CometCave' }
+  const { run } = result
+  const title = `🔥 ${run.longestStreak} Streak — CometCave Infinite Trivia`
+  const description = `Score: ${run.score.toLocaleString()} · ${run.answers.length} questions answered`
+  return {
+    title,
+    description,
+    openGraph: {
+      title,
+      description,
+      images: [`/api/v1/trivia/infinite/runs/${runId}/share-image`],
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title,
+      description,
+      images: [`/api/v1/trivia/infinite/runs/${runId}/share-image`],
+    },
+  }
+}
+
+export default async function Page({ params }: PageProps) {
+  const { runId } = await params
+  const result = await getRunByIdPublic(runId)
+  if (!result) notFound()
+  const { run } = result
+  return <RunSharePage run={{
+    longestStreak: run.longestStreak,
+    score: run.score,
+    questionsAnswered: run.answers.length,
+    trailblazes: run.trailblazes,
+    mode: run.mode,
+  }} />
+}

--- a/src/lib/trivia/infiniteRuns.ts
+++ b/src/lib/trivia/infiniteRuns.ts
@@ -156,6 +156,20 @@ export async function submitAnswer(params: {
   return result
 }
 
+export async function getRunByIdPublic(runId: string): Promise<{ run: RunDoc; uid: string } | null> {
+  const db = getFirestoreDb()
+  const snaps = await db.collectionGroup('triviaInfinite')
+    .where('runId', '==', runId)
+    .limit(1)
+    .get()
+  if (snaps.empty) return null
+  const doc = snaps.docs[0]
+  const run = doc.data() as RunDoc
+  // Extract uid from the document path: users/{uid}/triviaInfinite/{runId}
+  const uid = doc.ref.parent.parent?.id ?? ''
+  return { run, uid }
+}
+
 export async function endRun(uid: string, runId: string): Promise<void> {
   const db = getFirestoreDb()
   const runRef = db.doc(`users/${uid}/triviaInfinite/${runId}`)


### PR DESCRIPTION
## Summary
- Add **share-image OG route** (`/api/v1/trivia/infinite/runs/[runId]/share-image`) using Next.js `ImageResponse` — generates a dark-themed 1200x630 card with streak, score, and questions count
- Add **public run landing page** (`/trivia/runs/[runId]`) with OG/Twitter meta tags for rich social previews and a "Play Now" CTA
- Add **`getRunByIdPublic`** helper using Firestore collection group query to look up runs without auth
- Update **share button** in `InfiniteRunSummary` to copy the public run URL when available

Partial fix for #575 (share asset sub-task)

## Test plan
- [x] TypeScript compiles cleanly (no new errors)
- [ ] Verify share-image route returns a valid PNG at `/api/v1/trivia/infinite/runs/{runId}/share-image`
- [ ] Verify public run page renders run summary and has working "Play Now" CTA
- [ ] Verify OG meta tags render correctly (use Twitter Card Validator or similar)
- [ ] Verify share button copies the correct URL with run ID
- [ ] Verify 404 is returned for nonexistent run IDs

🤖 Generated with [Claude Code](https://claude.com/claude-code)