### PR TITLE
fix: trivia UI polish — rename heading, add stats link (#643, #645, #646)

### DIFF
--- a/src/app/trivia/components/InfiniteGame.tsx
+++ b/src/app/trivia/components/InfiniteGame.tsx
@@ -15,10 +15,11 @@ const RULES_DISMISSED_KEY = 'cometcave-infinite-rules-dismissed-v1'
 
 interface Props {
   onBack: () => void
+  onViewStats?: () => void
   mode?: InfiniteMode
 }
 
-export function InfiniteGame({ onBack, mode = 'scored' }: Props) {
+export function InfiniteGame({ onBack, onViewStats, mode = 'scored' }: Props) {
   const { user, loading: authLoading } = useAuth()
   const { state, startRun, submitAnswer, nextQuestion, endRun, handleQuestionFlagged } = useInfiniteRun()
   const [timeRemaining, setTimeRemaining] = useState(TIME_LIMIT)
@@ -133,7 +134,7 @@ export function InfiniteGame({ onBack, mode = 'scored' }: Props) {
 
   // End of run
   if (state.phase === 'ended') {
-    return <InfiniteRunSummary state={state} onPlayAgain={handlePlayAgain} onBack={onBack} mode={state.mode} runId={state.runId} onFlagged={handleQuestionFlagged} />
+    return <InfiniteRunSummary state={state} onPlayAgain={handlePlayAgain} onBack={onBack} onViewStats={onViewStats} mode={state.mode} runId={state.runId} onFlagged={handleQuestionFlagged} />
   }
 
   // Playing or answered

--- a/src/app/trivia/components/InfiniteRunSummary.tsx
+++ b/src/app/trivia/components/InfiniteRunSummary.tsx
@@ -18,6 +18,7 @@ interface Props {
   state: InfiniteRunState
   onPlayAgain: () => void
   onBack: () => void
+  onViewStats?: () => void
   mode?: InfiniteMode
   runId?: string | null
   onFlagged?: (questionId: string, result: FlagResult) => void
@@ -33,14 +34,14 @@ function getRunRating(longestStreak: number): string {
   if (longestStreak >= 10) return 'Amazing!'
   if (longestStreak >= 5) return 'Great Run!'
   if (longestStreak >= 2) return 'Good Try!'
-  return 'Keep Exploring!'
+  return 'Try Again!'
 }
 
 const ANSWERS_PAGE_SIZE = 20
 
 type AnswerEntry = InfiniteRunState['answers'][number]
 
-export function InfiniteRunSummary({ state, onPlayAgain, onBack, mode = 'scored', runId, onFlagged }: Props) {
+export function InfiniteRunSummary({ state, onPlayAgain, onBack, onViewStats, mode = 'scored', runId, onFlagged }: Props) {
   const { user } = useAuth()
   const [copied, setCopied] = useState(false)
   const [showAllAnswers, setShowAllAnswers] = useState(false)
@@ -178,6 +179,12 @@ export function InfiniteRunSummary({ state, onPlayAgain, onBack, mode = 'scored'
           {copied ? 'Copied!' : 'Share Run'}
         </ChunkyButton>
       </div>
+
+      {onViewStats && user && !user.isAnonymous && (
+        <ChunkyButton variant="ghost" size="sm" className="w-full" onClick={onViewStats}>
+          View Lifetime Stats
+        </ChunkyButton>
+      )}
 
       {(!user || user.isAnonymous) && (
         <SignInCard

--- a/src/app/trivia/components/InfiniteStats.tsx
+++ b/src/app/trivia/components/InfiniteStats.tsx
@@ -304,7 +304,7 @@ export function InfiniteStats({ onBack }: { onBack: () => void }) {
         </ChunkyCard>
       )}
 
-      {/* Streaks + trailblazer */}
+      {/* Streaks + first answers */}
       <ChunkyCard
         variant="surface-variant"
         className="bg-surface-container/80 border-outline-variant"

--- a/src/app/trivia/page.tsx
+++ b/src/app/trivia/page.tsx
@@ -135,11 +135,11 @@ export default function TriviaPage() {
   const handleBackToLanding = () => setView('landing')
 
   if (view === 'infinite') {
-    return <InfiniteGame onBack={handleBackToLanding} />
+    return <InfiniteGame onBack={handleBackToLanding} onViewStats={handleViewInfiniteStats} />
   }
 
   if (view === 'practice') {
-    return <InfiniteGame onBack={handleBackToLanding} mode="practice" />
+    return <InfiniteGame onBack={handleBackToLanding} onViewStats={handleViewInfiniteStats} mode="practice" />
   }
 
   if (view === 'infinite-stats') {


### PR DESCRIPTION
## Summary
- **#646**: Rename "Keep Exploring!" to "Try Again!" on low-streak run summaries
- **#645**: Add "View Lifetime Stats" ghost button on run summary for signed-in users, wired through InfiniteGame → trivia page
- **#643**: Clean up internal comment from "trailblazer" to "first answers" (label was already correct)

Closes #643, closes #645, closes #646

## Test plan
- [x] TypeScript compiles cleanly
- [x] All 27 trivia tests pass
- [ ] Verify "Try Again!" shows for runs with streak < 2
- [ ] Verify "View Lifetime Stats" button appears for signed-in users on run summary
- [ ] Verify anonymous users don't see the stats button (see sign-in CTA instead)

🤖 Generated with [Claude Code](https://claude.com/claude-code)