### PR TITLE
feat: surface lifetime ratings (likes, dislikes, reports) on stats page (#644)

### DIFF
--- a/src/app/api/v1/trivia/questions/[id]/flag/route.ts
+++ b/src/app/api/v1/trivia/questions/[id]/flag/route.ts
@@ -3,6 +3,7 @@ import { FieldValue } from 'firebase-admin/firestore';
 
 import { verifyRequestAuth } from '@/lib/api/auth';
 import { getFirestoreDb } from '@/lib/firebase/server';
+import { incrementVoiceStat } from '@/lib/trivia/triviaStats';
 
 const FLAG_THRESHOLD = 3;
 const BONUS_LIVES_MAX = 3;
@@ -99,6 +100,11 @@ export async function POST(
 
       return { wasFirstFlag, bonusLifeGranted };
     });
+
+    // Increment lifetime reports counter (fire-and-forget)
+    incrementVoiceStat(uid, 'reportsFiled').catch((err) =>
+      console.error('[flag] Failed to increment voice stat:', err)
+    );
 
     return NextResponse.json({ ok: true, wasFirstFlag: result.wasFirstFlag, bonusLifeGranted: result.bonusLifeGranted }, { status: 200 });
   } catch (err) {

--- a/src/app/api/v1/trivia/questions/[id]/rate/route.ts
+++ b/src/app/api/v1/trivia/questions/[id]/rate/route.ts
@@ -3,6 +3,7 @@ import { FieldValue } from 'firebase-admin/firestore';
 
 import { verifyRequestAuth } from '@/lib/api/auth';
 import { getFirestoreDb } from '@/lib/firebase/server';
+import { incrementVoiceStat } from '@/lib/trivia/triviaStats';
 
 const VALID_VOTES = ['up', 'down'] as const;
 type Vote = (typeof VALID_VOTES)[number];
@@ -37,6 +38,9 @@ export async function POST(
   const ratingRef = db.doc(`aiQuestions/${questionId}/ratings/${uid}`);
 
   try {
+    const existingSnap = await ratingRef.get();
+    const hadPriorVote = existingSnap.exists;
+
     if (vote === null) {
       await ratingRef.delete();
     } else {
@@ -44,6 +48,14 @@ export async function POST(
         vote,
         ratedAt: FieldValue.serverTimestamp(),
       });
+
+      // Only increment lifetime counter for new votes (not updates)
+      if (!hadPriorVote) {
+        const field = vote === 'up' ? 'likesGiven' : 'dislikesGiven';
+        incrementVoiceStat(uid, field).catch((err) =>
+          console.error('[rate] Failed to increment voice stat:', err)
+        );
+      }
     }
 
     return NextResponse.json({ ok: true }, { status: 200 });

--- a/src/app/trivia/components/InfiniteStats.tsx
+++ b/src/app/trivia/components/InfiniteStats.tsx
@@ -33,6 +33,9 @@ interface AggregateStats {
     medium: DifficultyStats
     hard: DifficultyStats
   }
+  likesGiven?: number
+  dislikesGiven?: number
+  reportsFiled?: number
 }
 
 function getAccuracyColor(accuracy: number): string {
@@ -469,6 +472,34 @@ export function InfiniteStats({ onBack }: { onBack: () => void }) {
           })}
         </ChunkyCardContent>
       </ChunkyCard>
+
+      {/* Your Voice */}
+      {((stats.likesGiven ?? 0) > 0 || (stats.dislikesGiven ?? 0) > 0 || (stats.reportsFiled ?? 0) > 0) && (
+        <ChunkyCard
+          variant="surface-variant"
+          className="bg-surface-container/80 border-outline-variant"
+        >
+          <ChunkyCardContent className="pt-5 pb-5">
+            <h3 className="text-on-surface/70 text-sm font-semibold mb-3 uppercase tracking-wide">
+              Your Voice
+            </h3>
+            <div className="grid grid-cols-3 gap-3">
+              <div className="text-center">
+                <div className="text-2xl font-bold text-ds-primary">{stats.likesGiven ?? 0}</div>
+                <div className="text-on-surface/50 text-xs mt-1">Likes</div>
+              </div>
+              <div className="text-center">
+                <div className="text-2xl font-bold text-on-surface">{stats.dislikesGiven ?? 0}</div>
+                <div className="text-on-surface/50 text-xs mt-1">Dislikes</div>
+              </div>
+              <div className="text-center">
+                <div className="text-2xl font-bold text-on-surface">{stats.reportsFiled ?? 0}</div>
+                <div className="text-on-surface/50 text-xs mt-1">Reports</div>
+              </div>
+            </div>
+          </ChunkyCardContent>
+        </ChunkyCard>
+      )}
 
       <ChunkyButton variant="secondary" onClick={onBack} className="w-full">
         Back

--- a/src/lib/trivia/triviaStats.ts
+++ b/src/lib/trivia/triviaStats.ts
@@ -24,6 +24,9 @@ export interface AggregateStats {
     hard: { answered: number; correct: number }
   }
   exhaustionCount: number
+  likesGiven: number
+  dislikesGiven: number
+  reportsFiled: number
   lastUpdatedAt: FirebaseFirestore.Timestamp | null
 }
 
@@ -43,6 +46,9 @@ const EMPTY_STATS: AggregateStats = {
     hard: { answered: 0, correct: 0 },
   },
   exhaustionCount: 0,
+  likesGiven: 0,
+  dislikesGiven: 0,
+  reportsFiled: 0,
   lastUpdatedAt: null,
 }
 
@@ -167,6 +173,9 @@ export async function applyRunToAggregate(uid: string, runId: string): Promise<v
         },
       },
       exhaustionCount: agg.exhaustionCount ?? 0,
+      likesGiven: agg.likesGiven ?? 0,
+      dislikesGiven: agg.dislikesGiven ?? 0,
+      reportsFiled: agg.reportsFiled ?? 0,
       lastUpdatedAt: null, // overwritten by server timestamp below
     }
 
@@ -186,6 +195,20 @@ export async function applyRunToAggregate(uid: string, runId: string): Promise<v
     // Mark the run as having its stats applied (idempotency guard)
     tx.update(runRef, { statsApplied: true })
   })
+}
+
+export async function incrementVoiceStat(
+  uid: string,
+  field: 'likesGiven' | 'dislikesGiven' | 'reportsFiled'
+): Promise<void> {
+  const db = getFirestoreDb()
+  const aggRef = db.doc(`users/${uid}/triviaStats/aggregate`)
+  const snap = await aggRef.get()
+  if (snap.exists) {
+    await aggRef.update({ [field]: FieldValue.increment(1), lastUpdatedAt: FieldValue.serverTimestamp() })
+  } else {
+    await aggRef.set({ ...EMPTY_STATS, [field]: 1, lastUpdatedAt: FieldValue.serverTimestamp() })
+  }
 }
 
 export async function trackExhaustion(uid: string): Promise<void> {


### PR DESCRIPTION
## Summary
- Add **`likesGiven`**, **`dislikesGiven`**, **`reportsFiled`** fields to `AggregateStats` (backward-compatible via `?? 0`)
- Add **`incrementVoiceStat`** helper in `triviaStats.ts` for atomic counter increments
- **Rate handler**: increment `likesGiven`/`dislikesGiven` on new votes (skips updates to existing votes)
- **Flag handler**: increment `reportsFiled` on each flag submission
- **InfiniteStats.tsx**: new "Your Voice" card showing lifetime likes, dislikes, and reports (only shown when at least one counter > 0)

Closes #644

## Test plan
- [x] TypeScript compiles cleanly
- [x] All 27 trivia tests pass
- [ ] Verify "Your Voice" card appears on stats page after rating a question
- [ ] Verify counters don't double-count when re-visiting a rated question
- [ ] Verify card is hidden for users with no ratings/reports
- [ ] Verify existing aggregate docs read cleanly (missing fields default to 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)