### PR TITLE
chore: increase trivia generation limit from 30 to 100 per hour

### DIFF
--- a/src/lib/trivia/generationLimit.ts
+++ b/src/lib/trivia/generationLimit.ts
@@ -3,7 +3,7 @@ import { Timestamp } from 'firebase-admin/firestore'
 import { getFirestoreDb } from '@/lib/firebase/server'
 
 const WINDOW_MS = 60 * 60 * 1000 // 1 hour
-const MAX_GENERATIONS_PER_WINDOW = 30
+const MAX_GENERATIONS_PER_WINDOW = 100
 
 /**
  * Atomically check whether the given uid has exceeded the on-demand generation


### PR DESCRIPTION
One-line change: MAX_GENERATIONS_PER_WINDOW from 30 to 100.