### PR TITLE
feat: add skip mechanic to Infinite Trivia runs (#657)

### DIFF
--- a/scripts/trivia/generation-limit-stats.ts
+++ b/scripts/trivia/generation-limit-stats.ts
@@ -1,0 +1,125 @@
+#!/usr/bin/env tsx
+/**
+ * Generation rate-limit telemetry report for issue #626.
+ *
+ * Queries Firestore for the past N days (default 7) and reports:
+ * - Total unique UIDs with generation limit docs
+ * - Histogram of generations-per-uid (quantiles: p50, p90, p95, p99, max)
+ * - UIDs that hit the limit ceiling (count >= MAX_GENERATIONS_PER_WINDOW)
+ * - Total generations across all users
+ *
+ * Usage:
+ *   npx tsx scripts/trivia/generation-limit-stats.ts [--days 7]
+ *
+ * Required env vars (same as the app):
+ *   FIREBASE_PROJECT_ID
+ *   FIREBASE_CLIENT_EMAIL
+ *   FIREBASE_PRIVATE_KEY
+ */
+
+import { cert, getApps, initializeApp } from 'firebase-admin/app'
+import { getFirestore } from 'firebase-admin/firestore'
+
+const MAX_GENERATIONS_PER_WINDOW = 30
+
+function ensureApp() {
+  if (getApps().length > 0) return
+  const projectId = process.env.FIREBASE_PROJECT_ID
+  const clientEmail = process.env.FIREBASE_CLIENT_EMAIL
+  const privateKey = process.env.FIREBASE_PRIVATE_KEY?.replace(/\\n/g, '\n')
+  if (!projectId || !clientEmail || !privateKey) {
+    console.error('Missing FIREBASE_PROJECT_ID, FIREBASE_CLIENT_EMAIL, or FIREBASE_PRIVATE_KEY')
+    process.exit(1)
+  }
+  initializeApp({ credential: cert({ projectId, clientEmail, privateKey }) })
+}
+
+function percentile(sorted: number[], p: number): number {
+  const idx = Math.ceil((p / 100) * sorted.length) - 1
+  return sorted[Math.max(0, idx)]
+}
+
+async function main() {
+  const daysArg = process.argv.includes('--days')
+    ? parseInt(process.argv[process.argv.indexOf('--days') + 1], 10)
+    : 7
+  const days = isNaN(daysArg) || daysArg < 1 ? 7 : daysArg
+
+  ensureApp()
+  const db = getFirestore()
+
+  console.log(`\n📊 Generation Rate-Limit Stats (past ${days} days)\n`)
+  console.log('='.repeat(50))
+
+  // Query all generationLimit docs via collection group
+  const limitSnaps = await db.collectionGroup('triviaInfiniteMeta').get()
+
+  const cutoff = Date.now() - days * 24 * 60 * 60 * 1000
+  const counts: number[] = []
+  const throttledUids: string[] = []
+  let totalGenerations = 0
+  let activeUids = 0
+
+  for (const doc of limitSnaps.docs) {
+    if (doc.id !== 'generationLimit') continue
+
+    const data = doc.data()
+    const windowStart: number = data?.windowStart?.toMillis?.() ?? 0
+    const count: number = data?.count ?? 0
+
+    // Only consider docs within the time window
+    if (windowStart < cutoff) continue
+
+    activeUids++
+    counts.push(count)
+    totalGenerations += count
+
+    if (count >= MAX_GENERATIONS_PER_WINDOW) {
+      const uid = doc.ref.parent.parent?.id ?? 'unknown'
+      throttledUids.push(uid)
+    }
+  }
+
+  if (counts.length === 0) {
+    console.log('\nNo generation limit data found in the specified window.')
+    console.log('This is expected if Infinite Trivia has not had traffic yet.')
+    return
+  }
+
+  counts.sort((a, b) => a - b)
+
+  console.log(`\n🔢 Summary`)
+  console.log(`  Active UIDs with generation data: ${activeUids}`)
+  console.log(`  Total generations: ${totalGenerations}`)
+  console.log(`  Avg generations/uid: ${(totalGenerations / activeUids).toFixed(1)}`)
+
+  console.log(`\n📈 Generations per UID (quantiles)`)
+  console.log(`  p50: ${percentile(counts, 50)}`)
+  console.log(`  p90: ${percentile(counts, 90)}`)
+  console.log(`  p95: ${percentile(counts, 95)}`)
+  console.log(`  p99: ${percentile(counts, 99)}`)
+  console.log(`  max: ${counts[counts.length - 1]}`)
+
+  console.log(`\n🚫 Throttled UIDs (hit ${MAX_GENERATIONS_PER_WINDOW}/window ceiling)`)
+  if (throttledUids.length === 0) {
+    console.log('  None — no users have hit the rate limit.')
+  } else {
+    console.log(`  ${throttledUids.length} unique UIDs hit the limit:`)
+    // Anonymize UIDs by showing first 8 chars
+    for (const uid of throttledUids) {
+      console.log(`    ${uid.slice(0, 8)}...`)
+    }
+    console.log(`  Throttle rate: ${((throttledUids.length / activeUids) * 100).toFixed(1)}% of active UIDs`)
+  }
+
+  console.log(`\n💡 Recommendation thresholds`)
+  console.log(`  If throttle rate > 5%: consider raising to 60/hr`)
+  console.log(`  If throttle rate < 1%: current limit is fine`)
+  console.log(`  If total daily spend > $X: consider adding global cap`)
+  console.log('')
+}
+
+main().catch((err) => {
+  console.error('Script failed:', err)
+  process.exit(1)
+})

--- a/src/app/api/v1/trivia/infinite/next/route.ts
+++ b/src/app/api/v1/trivia/infinite/next/route.ts
@@ -7,8 +7,9 @@ import { generateInfiniteQuestion } from '@/lib/trivia/generateQuestion'
 import { checkAndIncrementGenerationLimit } from '@/lib/trivia/generationLimit'
 import { sampleNextQuestion } from '@/lib/trivia/sampler'
 import { trackExhaustion } from '@/lib/trivia/triviaStats'
+import { CATEGORY_META } from '@/lib/trivia/categories'
 
-// GET /api/v1/trivia/infinite/next?streak=N
+// GET /api/v1/trivia/infinite/next?streak=N&categoryId=N
 export async function GET(request: NextRequest) {
   const auth = await verifyRequestAuth(request)
   if ('error' in auth) return auth.error
@@ -18,11 +19,22 @@ export async function GET(request: NextRequest) {
   const streak = streakParam !== null ? parseInt(streakParam, 10) : 0
   const parsedStreak = isNaN(streak) || streak < 0 ? 0 : streak
 
+  // Parse optional categoryId
+  let categoryId: number | undefined
+  const categoryIdParam = searchParams.get('categoryId')
+  if (categoryIdParam !== null) {
+    const parsed = parseInt(categoryIdParam, 10)
+    if (!isNaN(parsed) && parsed in CATEGORY_META) {
+      categoryId = parsed
+    }
+  }
+
   try {
     let question = await sampleNextQuestion({
       uid: auth.claims.uid,
       streak: parsedStreak,
       type: 'free-text',
+      categoryId,
     })
 
     if (question === null) {
@@ -44,7 +56,7 @@ export async function GET(request: NextRequest) {
       }
 
       try {
-        const generated = await generateInfiniteQuestion({ streak: parsedStreak })
+        const generated = await generateInfiniteQuestion({ streak: parsedStreak, categoryId })
         await saveAIQuestion(generated)
         question = {
           ...generated,

--- a/src/app/api/v1/trivia/infinite/next/route.ts
+++ b/src/app/api/v1/trivia/infinite/next/route.ts
@@ -29,8 +29,14 @@ export async function GET(request: NextRequest) {
       // Pool exhausted for this player — generate a fresh question on demand,
       // gated by a per-uid rate limit so a single client can't burn the
       // OpenAI budget by hammering /next.
-      const { limited } = await checkAndIncrementGenerationLimit(auth.claims.uid)
+      const { limited, remaining } = await checkAndIncrementGenerationLimit(auth.claims.uid)
       if (limited) {
+        console.warn('[trivia/infinite/next] 429 rate limit hit', {
+          uid: auth.claims.uid,
+          remaining,
+          limitWindowMs: 60 * 60 * 1000,
+          maxPerWindow: 30,
+        })
         return NextResponse.json(
           { error: 'Generation rate limit exceeded. Please try again later.' },
           { status: 429 }

--- a/src/app/api/v1/trivia/infinite/runs/[runId]/share-image/route.tsx
+++ b/src/app/api/v1/trivia/infinite/runs/[runId]/share-image/route.tsx
@@ -1,0 +1,68 @@
+import { ImageResponse } from 'next/og'
+import { type NextRequest } from 'next/server'
+import { getRunByIdPublic } from '@/lib/trivia/infiniteRuns'
+
+export const runtime = 'nodejs'
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ runId: string }> }
+) {
+  const { runId } = await params
+  const result = await getRunByIdPublic(runId)
+  if (!result) {
+    return new Response('Run not found', { status: 404 })
+  }
+  const { run } = result
+
+  const questionsAnswered = run.answers.length
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          justifyContent: 'center',
+          width: '100%',
+          height: '100%',
+          backgroundColor: '#1a1025',
+          color: '#e0d8f0',
+          fontFamily: 'sans-serif',
+          padding: '60px',
+        }}
+      >
+        <div style={{ display: 'flex', fontSize: '32px', color: '#a78bfa', marginBottom: '20px' }}>
+          CometCave Infinite Trivia
+        </div>
+        <div style={{ display: 'flex', fontSize: '80px', marginBottom: '10px' }}>
+          🔥 {run.longestStreak} Streak
+        </div>
+        <div style={{ display: 'flex', gap: '60px', fontSize: '28px', color: '#c4b5fd', marginTop: '20px' }}>
+          <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
+            <div style={{ display: 'flex', fontSize: '48px', color: '#e0d8f0', fontWeight: 'bold' }}>{run.score.toLocaleString()}</div>
+            <div style={{ display: 'flex' }}>Score</div>
+          </div>
+          <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
+            <div style={{ display: 'flex', fontSize: '48px', color: '#e0d8f0', fontWeight: 'bold' }}>{questionsAnswered}</div>
+            <div style={{ display: 'flex' }}>Questions</div>
+          </div>
+          {run.trailblazes > 0 && (
+            <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
+              <div style={{ display: 'flex', fontSize: '48px', color: '#e0d8f0', fontWeight: 'bold' }}>{run.trailblazes}</div>
+              <div style={{ display: 'flex' }}>First Answers</div>
+            </div>
+          )}
+        </div>
+        <div style={{ display: 'flex', fontSize: '20px', color: '#7c3aed', marginTop: '40px' }}>
+          cometcave.com/trivia
+        </div>
+      </div>
+    ),
+    {
+      width: 1200,
+      height: 630,
+    }
+  )
+}

--- a/src/app/api/v1/trivia/infinite/runs/[runId]/skip/route.ts
+++ b/src/app/api/v1/trivia/infinite/runs/[runId]/skip/route.ts
@@ -1,0 +1,24 @@
+import { type NextRequest, NextResponse } from 'next/server';
+
+import { verifyRequestAuth } from '@/lib/api/auth';
+import { recordSkip } from '@/lib/trivia/infiniteRuns';
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ runId: string }> }
+) {
+  const auth = await verifyRequestAuth(request);
+  if ('error' in auth) return auth.error;
+
+  const { runId } = await params;
+
+  try {
+    const body = await request.json();
+    const { questionId } = body;
+    await recordSkip(auth.claims.uid, runId, questionId ?? '');
+    return NextResponse.json({ ok: true });
+  } catch (err: unknown) {
+    console.error('Failed to record skip:', err);
+    return NextResponse.json({ error: 'Failed to record skip.' }, { status: 500 });
+  }
+}

--- a/src/app/api/v1/trivia/infinite/runs/route.ts
+++ b/src/app/api/v1/trivia/infinite/runs/route.ts
@@ -2,6 +2,7 @@ import { type NextRequest, NextResponse } from 'next/server';
 
 import { verifyRequestAuth } from '@/lib/api/auth';
 import { startRun } from '@/lib/trivia/infiniteRuns';
+import { CATEGORY_META } from '@/lib/trivia/categories';
 
 export async function POST(request: NextRequest) {
   const auth = await verifyRequestAuth(request);
@@ -10,7 +11,17 @@ export async function POST(request: NextRequest) {
   try {
     const body = await request.json();
     const mode = body.mode === 'practice' ? 'practice' : 'scored';
-    const result = await startRun(auth.claims.uid, mode);
+
+    // Parse and validate optional categoryId
+    let categoryId: number | undefined
+    if (body.categoryId !== undefined && body.categoryId !== null) {
+      const parsed = Number(body.categoryId)
+      if (!isNaN(parsed) && parsed in CATEGORY_META) {
+        categoryId = parsed
+      }
+    }
+
+    const result = await startRun(auth.claims.uid, mode, categoryId);
     return NextResponse.json(result, { status: 201 });
   } catch (err) {
     console.error('Failed to start infinite run:', err);

--- a/src/app/api/v1/trivia/questions/[id]/flag/route.ts
+++ b/src/app/api/v1/trivia/questions/[id]/flag/route.ts
@@ -3,6 +3,7 @@ import { FieldValue } from 'firebase-admin/firestore';
 
 import { verifyRequestAuth } from '@/lib/api/auth';
 import { getFirestoreDb } from '@/lib/firebase/server';
+import { incrementVoiceStat } from '@/lib/trivia/triviaStats';
 
 const FLAG_THRESHOLD = 3;
 const BONUS_LIVES_MAX = 3;
@@ -99,6 +100,11 @@ export async function POST(
 
       return { wasFirstFlag, bonusLifeGranted };
     });
+
+    // Increment lifetime reports counter (fire-and-forget)
+    incrementVoiceStat(uid, 'reportsFiled').catch((err) =>
+      console.error('[flag] Failed to increment voice stat:', err)
+    );
 
     return NextResponse.json({ ok: true, wasFirstFlag: result.wasFirstFlag, bonusLifeGranted: result.bonusLifeGranted }, { status: 200 });
   } catch (err) {

--- a/src/app/api/v1/trivia/questions/[id]/flag/route.ts
+++ b/src/app/api/v1/trivia/questions/[id]/flag/route.ts
@@ -5,6 +5,7 @@ import { verifyRequestAuth } from '@/lib/api/auth';
 import { getFirestoreDb } from '@/lib/firebase/server';
 
 const FLAG_THRESHOLD = 3;
+const BONUS_LIVES_MAX = 3;
 const VALID_REASONS = ['obvious', 'unanswerable', 'nonsense', 'inaccurate', 'difficulty_mismatch', 'other'] as const;
 type FlagReason = (typeof VALID_REASONS)[number];
 
@@ -18,14 +19,14 @@ export async function POST(
   const { id: questionId } = await params;
   const uid = auth.claims.uid;
 
-  let body: { reason?: unknown; note?: unknown };
+  let body: { reason?: unknown; note?: unknown; runId?: unknown };
   try {
     body = await request.json();
   } catch {
     return NextResponse.json({ error: 'Invalid JSON.' }, { status: 400 });
   }
 
-  const { reason, note } = body;
+  const { reason, note, runId } = body;
 
   if (!VALID_REASONS.includes(reason as FlagReason)) {
     return NextResponse.json(
@@ -38,17 +39,21 @@ export async function POST(
     return NextResponse.json({ error: 'Note must be a string of max 500 characters.' }, { status: 400 });
   }
 
+  const validRunId = typeof runId === 'string' && runId.length > 0 ? runId : null;
+
   const db = getFirestoreDb();
   const qRef = db.doc(`aiQuestions/${questionId}`);
   const flagRef = db.doc(`aiQuestions/${questionId}/flags/${uid}`);
 
   try {
-    await db.runTransaction(async (tx) => {
+    const result = await db.runTransaction(async (tx) => {
       const qSnap = await tx.get(qRef);
       if (!qSnap.exists) throw new Error('Question not found');
 
       const qData = qSnap.data()!;
-      const newFlaggedCount = (qData.flaggedCount ?? 0) + 1;
+      const currentFlaggedCount = qData.flaggedCount ?? 0;
+      const newFlaggedCount = currentFlaggedCount + 1;
+      const wasFirstFlag = currentFlaggedCount === 0;
 
       const qUpdates: FirebaseFirestore.UpdateData<FirebaseFirestore.DocumentData> = {
         flaggedCount: FieldValue.increment(1),
@@ -68,9 +73,34 @@ export async function POST(
         flagDoc.note = note;
       }
       tx.set(flagRef, flagDoc);
+
+      // Handle run updates if a runId is provided
+      let bonusLifeGranted = false;
+      if (validRunId) {
+        const runRef = db.doc(`users/${uid}/triviaInfinite/${validRunId}`);
+        const runSnap = await tx.get(runRef);
+        if (runSnap.exists) {
+          const runData = runSnap.data()!;
+          const bonusLivesEarned = runData.bonusLivesEarned ?? 0;
+
+          const runUpdates: FirebaseFirestore.UpdateData<FirebaseFirestore.DocumentData> = {
+            flaggedQuestionIds: FieldValue.arrayUnion(questionId),
+          };
+
+          if (wasFirstFlag && bonusLivesEarned < BONUS_LIVES_MAX) {
+            runUpdates.livesRemaining = FieldValue.increment(1);
+            runUpdates.bonusLivesEarned = FieldValue.increment(1);
+            bonusLifeGranted = true;
+          }
+
+          tx.update(runRef, runUpdates);
+        }
+      }
+
+      return { wasFirstFlag, bonusLifeGranted };
     });
 
-    return NextResponse.json({ ok: true }, { status: 200 });
+    return NextResponse.json({ ok: true, wasFirstFlag: result.wasFirstFlag, bonusLifeGranted: result.bonusLifeGranted }, { status: 200 });
   } catch (err) {
     if (err instanceof Error && err.message === 'Question not found') {
       return NextResponse.json({ error: 'Question not found.' }, { status: 404 });

--- a/src/app/api/v1/trivia/questions/[id]/rate/route.ts
+++ b/src/app/api/v1/trivia/questions/[id]/rate/route.ts
@@ -3,6 +3,7 @@ import { FieldValue } from 'firebase-admin/firestore';
 
 import { verifyRequestAuth } from '@/lib/api/auth';
 import { getFirestoreDb } from '@/lib/firebase/server';
+import { incrementVoiceStat } from '@/lib/trivia/triviaStats';
 
 const VALID_VOTES = ['up', 'down'] as const;
 type Vote = (typeof VALID_VOTES)[number];
@@ -37,6 +38,9 @@ export async function POST(
   const ratingRef = db.doc(`aiQuestions/${questionId}/ratings/${uid}`);
 
   try {
+    const existingSnap = await ratingRef.get();
+    const hadPriorVote = existingSnap.exists;
+
     if (vote === null) {
       await ratingRef.delete();
     } else {
@@ -44,6 +48,14 @@ export async function POST(
         vote,
         ratedAt: FieldValue.serverTimestamp(),
       });
+
+      // Only increment lifetime counter for new votes (not updates)
+      if (!hadPriorVote) {
+        const field = vote === 'up' ? 'likesGiven' : 'dislikesGiven';
+        incrementVoiceStat(uid, field).catch((err) =>
+          console.error('[rate] Failed to increment voice stat:', err)
+        );
+      }
     }
 
     return NextResponse.json({ ok: true }, { status: 200 });

--- a/src/app/auth/page.tsx
+++ b/src/app/auth/page.tsx
@@ -105,63 +105,10 @@ function AuthPageInner() {
       {/* Terminal canvas */}
       <ChunkyCard variant="surface-container" shadow="hero" className="w-full border-[6px] border-surface-container-high bg-ds-surface/80 backdrop-blur-2xl">
         <ChunkyCardHeader>
-          <ChunkyCardTitle className="text-center text-on-surface">Welcome</ChunkyCardTitle>
+          <ChunkyCardTitle className="text-center text-on-surface">{orphanNotice ? 'Almost there' : 'Welcome'}</ChunkyCardTitle>
         </ChunkyCardHeader>
         <ChunkyCardContent className="flex flex-col gap-4">
-          <ChunkyButton
-            variant="primary"
-            size="lg"
-            className="w-full"
-            onClick={handleGoogle}
-            disabled={submitting}
-            iconStart={<span className="material-symbols-outlined text-[20px]">login</span>}
-          >
-            Sign in with Google
-          </ChunkyButton>
-
-          <div className="flex items-center gap-3 text-on-surface/40 text-xs">
-            <div className="flex-1 h-px bg-outline-variant" />
-            OR
-            <div className="flex-1 h-px bg-outline-variant" />
-          </div>
-
-          <form className="flex flex-col gap-3" onSubmit={handleEmail}>
-            <Input
-              type="email"
-              required
-              placeholder="Email"
-              value={email}
-              onChange={(e) => setEmail(e.target.value)}
-              className="bg-surface-dim/50 border-outline-variant text-on-surface placeholder:text-on-surface/30"
-              autoComplete="email"
-            />
-            <Input
-              type="password"
-              required
-              placeholder="Password"
-              value={password}
-              onChange={(e) => setPassword(e.target.value)}
-              className="bg-surface-dim/50 border-outline-variant text-on-surface placeholder:text-on-surface/30"
-              autoComplete={mode === 'signin' ? 'current-password' : 'new-password'}
-              minLength={6}
-            />
-            <ChunkyButton
-              type="submit"
-              variant="secondary"
-              className="w-full"
-              disabled={submitting || email.length === 0 || password.length === 0}
-            >
-              {mode === 'signin' ? 'Sign in with email' : 'Create account'}
-            </ChunkyButton>
-          </form>
-
-          {error && (
-            <div className="text-ds-error text-sm text-center" role="alert">
-              {error}
-            </div>
-          )}
-
-          {orphanNotice && (
+          {orphanNotice ? (
             <div
               className="flex flex-col gap-3 rounded-lg border border-tertiary-fixed-dim/40 bg-tertiary-fixed-dim/15 p-3 text-on-surface/80 text-sm"
               role="status"
@@ -175,21 +122,75 @@ function AuthPageInner() {
                 Continue
               </ChunkyButton>
             </div>
-          )}
+          ) : (
+            <>
+              <ChunkyButton
+                variant="primary"
+                size="lg"
+                className="w-full"
+                onClick={handleGoogle}
+                disabled={submitting}
+                iconStart={<span className="material-symbols-outlined text-[20px]">login</span>}
+              >
+                Sign in with Google
+              </ChunkyButton>
 
-          <button
-            type="button"
-            onClick={() => {
-              setError(null)
-              setOrphanNotice(null)
-              setMode(mode === 'signin' ? 'signup' : 'signin')
-            }}
-            className="text-on-surface/50 text-sm text-center hover:text-on-surface/80 transition-colors"
-          >
-            {mode === 'signin'
-              ? "Don't have an account? Sign up"
-              : 'Already have an account? Sign in'}
-          </button>
+              <div className="flex items-center gap-3 text-on-surface/40 text-xs">
+                <div className="flex-1 h-px bg-outline-variant" />
+                OR
+                <div className="flex-1 h-px bg-outline-variant" />
+              </div>
+
+              <form className="flex flex-col gap-3" onSubmit={handleEmail}>
+                <Input
+                  type="email"
+                  required
+                  placeholder="Email"
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
+                  className="bg-surface-dim/50 border-outline-variant text-on-surface placeholder:text-on-surface/30"
+                  autoComplete="email"
+                />
+                <Input
+                  type="password"
+                  required
+                  placeholder="Password"
+                  value={password}
+                  onChange={(e) => setPassword(e.target.value)}
+                  className="bg-surface-dim/50 border-outline-variant text-on-surface placeholder:text-on-surface/30"
+                  autoComplete={mode === 'signin' ? 'current-password' : 'new-password'}
+                  minLength={6}
+                />
+                <ChunkyButton
+                  type="submit"
+                  variant="secondary"
+                  className="w-full"
+                  disabled={submitting || email.length === 0 || password.length === 0}
+                >
+                  {mode === 'signin' ? 'Sign in with email' : 'Create account'}
+                </ChunkyButton>
+              </form>
+
+              {error && (
+                <div className="text-ds-error text-sm text-center" role="alert">
+                  {error}
+                </div>
+              )}
+
+              <button
+                type="button"
+                onClick={() => {
+                  setError(null)
+                  setMode(mode === 'signin' ? 'signup' : 'signin')
+                }}
+                className="text-on-surface/50 text-sm text-center hover:text-on-surface/80 transition-colors"
+              >
+                {mode === 'signin'
+                  ? "Don't have an account? Sign up"
+                  : 'Already have an account? Sign in'}
+              </button>
+            </>
+          )}
         </ChunkyCardContent>
       </ChunkyCard>
     </div>

--- a/src/app/trivia/components/FlagQuestion.tsx
+++ b/src/app/trivia/components/FlagQuestion.tsx
@@ -12,11 +12,18 @@ const FLAG_REASONS = [
   { value: 'other', label: 'Other' },
 ] as const
 
-interface Props {
-  questionId: string
+interface FlagResult {
+  wasFirstFlag: boolean
+  bonusLifeGranted: boolean
 }
 
-export function FlagQuestion({ questionId }: Props) {
+interface Props {
+  questionId: string
+  runId?: string | null
+  onFlagged?: (result: FlagResult) => void
+}
+
+export function FlagQuestion({ questionId, runId, onFlagged }: Props) {
   const { user } = useAuth()
   const [showModal, setShowModal] = useState(false)
   const [reason, setReason] = useState<string>('')
@@ -35,13 +42,23 @@ export function FlagQuestion({ questionId }: Props) {
     setSubmitting(true)
     try {
       const token = await user.getIdToken()
-      await fetch(`/api/v1/trivia/questions/${questionId}/flag`, {
+      const res = await fetch(`/api/v1/trivia/questions/${questionId}/flag`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
-        body: JSON.stringify({ reason, note: trimmedNote || undefined }),
+        body: JSON.stringify({ reason, note: trimmedNote || undefined, runId: runId ?? undefined }),
       })
       setSubmitted(true)
       setShowModal(false)
+      if (onFlagged) {
+        let result: FlagResult = { wasFirstFlag: false, bonusLifeGranted: false }
+        try {
+          const data = await res.json()
+          result = { wasFirstFlag: data.wasFirstFlag ?? false, bonusLifeGranted: data.bonusLifeGranted ?? false }
+        } catch {
+          // use defaults
+        }
+        onFlagged(result)
+      }
     } catch {
       // silent
     } finally {

--- a/src/app/trivia/components/InfiniteGame.tsx
+++ b/src/app/trivia/components/InfiniteGame.tsx
@@ -15,10 +15,11 @@ const RULES_DISMISSED_KEY = 'cometcave-infinite-rules-dismissed-v1'
 
 interface Props {
   onBack: () => void
+  onViewStats?: () => void
   mode?: InfiniteMode
 }
 
-export function InfiniteGame({ onBack, mode = 'scored' }: Props) {
+export function InfiniteGame({ onBack, onViewStats, mode = 'scored' }: Props) {
   const { user, loading: authLoading } = useAuth()
   const { state, startRun, submitAnswer, nextQuestion, endRun, handleQuestionFlagged } = useInfiniteRun()
   const [timeRemaining, setTimeRemaining] = useState(TIME_LIMIT)
@@ -133,7 +134,7 @@ export function InfiniteGame({ onBack, mode = 'scored' }: Props) {
 
   // End of run
   if (state.phase === 'ended') {
-    return <InfiniteRunSummary state={state} onPlayAgain={handlePlayAgain} onBack={onBack} mode={state.mode} runId={state.runId} onFlagged={handleQuestionFlagged} />
+    return <InfiniteRunSummary state={state} onPlayAgain={handlePlayAgain} onBack={onBack} onViewStats={onViewStats} mode={state.mode} runId={state.runId} onFlagged={handleQuestionFlagged} />
   }
 
   // Playing or answered

--- a/src/app/trivia/components/InfiniteGame.tsx
+++ b/src/app/trivia/components/InfiniteGame.tsx
@@ -20,7 +20,7 @@ interface Props {
 
 export function InfiniteGame({ onBack, mode = 'scored' }: Props) {
   const { user, loading: authLoading } = useAuth()
-  const { state, startRun, submitAnswer, nextQuestion, endRun } = useInfiniteRun()
+  const { state, startRun, submitAnswer, nextQuestion, endRun, handleQuestionFlagged } = useInfiniteRun()
   const [timeRemaining, setTimeRemaining] = useState(TIME_LIMIT)
   const timerRef = useRef<ReturnType<typeof setInterval> | null>(null)
   const timerStartRef = useRef<number>(0)
@@ -133,7 +133,7 @@ export function InfiniteGame({ onBack, mode = 'scored' }: Props) {
 
   // End of run
   if (state.phase === 'ended') {
-    return <InfiniteRunSummary state={state} onPlayAgain={handlePlayAgain} onBack={onBack} mode={state.mode} />
+    return <InfiniteRunSummary state={state} onPlayAgain={handlePlayAgain} onBack={onBack} mode={state.mode} runId={state.runId} onFlagged={handleQuestionFlagged} />
   }
 
   // Playing or answered
@@ -159,6 +159,8 @@ export function InfiniteGame({ onBack, mode = 'scored' }: Props) {
         isSubmitting={state.phase === 'answering'}
         answerResult={state.lastAnswer}
         questionsAnswered={state.questionsAnswered}
+        runId={state.runId}
+        onFlagged={handleQuestionFlagged}
       />
 
       {state.phase === 'answered' && (

--- a/src/app/trivia/components/InfiniteGame.tsx
+++ b/src/app/trivia/components/InfiniteGame.tsx
@@ -22,7 +22,7 @@ interface Props {
 
 export function InfiniteGame({ onBack, onViewStats, mode = 'scored' }: Props) {
   const { user, loading: authLoading } = useAuth()
-  const { state, startRun, submitAnswer, nextQuestion, endRun, handleQuestionFlagged } = useInfiniteRun()
+  const { state, startRun, submitAnswer, nextQuestion, skipQuestion, endRun, handleQuestionFlagged } = useInfiniteRun()
   const [timeRemaining, setTimeRemaining] = useState(TIME_LIMIT)
   const timerRef = useRef<ReturnType<typeof setInterval> | null>(null)
   const timerStartRef = useRef<number>(0)
@@ -153,6 +153,7 @@ export function InfiniteGame({ onBack, onViewStats, mode = 'scored' }: Props) {
         isPlaying={state.phase === 'playing'}
         mode={state.mode}
         categoryName={state.categoryId != null ? CATEGORY_META[state.categoryId]?.name : undefined}
+        skipsRemaining={state.skipsRemaining}
       />
 
       <InfiniteQuestionCard
@@ -164,6 +165,8 @@ export function InfiniteGame({ onBack, onViewStats, mode = 'scored' }: Props) {
         questionsAnswered={state.questionsAnswered}
         runId={state.runId}
         onFlagged={handleQuestionFlagged}
+        skipsRemaining={state.skipsRemaining}
+        onSkip={skipQuestion}
       />
 
       {state.phase === 'answered' && (

--- a/src/app/trivia/components/InfiniteGame.tsx
+++ b/src/app/trivia/components/InfiniteGame.tsx
@@ -9,6 +9,7 @@ import { InfiniteRunSummary } from './InfiniteRunSummary'
 import { InfiniteExhaustedScreen } from './InfiniteExhaustedScreen'
 import { InfiniteRulesModal } from './InfiniteRulesModal'
 import { ChunkyButton } from '@/components/ui/chunky-button'
+import { CATEGORY_META } from '@/lib/trivia/categories'
 
 const TIME_LIMIT = 60 // 60 seconds for AI free-text
 const RULES_DISMISSED_KEY = 'cometcave-infinite-rules-dismissed-v1'
@@ -45,7 +46,7 @@ export function InfiniteGame({ onBack, onViewStats, mode = 'scored' }: Props) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [authLoading, user, showRules])
 
-  const handleRulesContinue = useCallback((chosenMode: InfiniteMode, dismissForever: boolean) => {
+  const handleRulesContinue = useCallback((chosenMode: InfiniteMode, dismissForever: boolean, categoryId?: number) => {
     if (dismissForever && typeof window !== 'undefined') {
       window.localStorage.setItem(RULES_DISMISSED_KEY, '1')
     }
@@ -56,7 +57,7 @@ export function InfiniteGame({ onBack, onViewStats, mode = 'scored' }: Props) {
     }
     hasStartedRef.current = true
     setShowRules(false)
-    startRun(chosenMode)
+    startRun(chosenMode, categoryId)
   }, [mode, startRun])
 
   // Timer logic
@@ -151,6 +152,7 @@ export function InfiniteGame({ onBack, onViewStats, mode = 'scored' }: Props) {
         onFlee={handleFlee}
         isPlaying={state.phase === 'playing'}
         mode={state.mode}
+        categoryName={state.categoryId != null ? CATEGORY_META[state.categoryId]?.name : undefined}
       />
 
       <InfiniteQuestionCard

--- a/src/app/trivia/components/InfiniteHUD.tsx
+++ b/src/app/trivia/components/InfiniteHUD.tsx
@@ -14,6 +14,7 @@ interface InfiniteHUDProps {
   onFlee: () => void
   isPlaying: boolean
   mode?: InfiniteMode
+  categoryName?: string
 }
 
 export function InfiniteHUD({
@@ -25,6 +26,7 @@ export function InfiniteHUD({
   onFlee,
   isPlaying,
   mode = 'scored',
+  categoryName,
 }: InfiniteHUDProps) {
   const [showFleeConfirm, setShowFleeConfirm] = useState(false)
   const mult = computeStreakMultiplier(currentStreak)
@@ -98,9 +100,12 @@ export function InfiniteHUD({
         />
       </div>
 
-      {/* Timer pill */}
-      <div className="flex justify-center">
+      {/* Timer pill + category label */}
+      <div className="flex justify-center items-center gap-2">
         <Pill tone="neutral" size="sm">{Math.ceil(timeRemaining)}s</Pill>
+        {categoryName && (
+          <Pill tone="neutral" size="sm">{categoryName}</Pill>
+        )}
       </div>
 
       {/* Flee confirmation */}

--- a/src/app/trivia/components/InfiniteHUD.tsx
+++ b/src/app/trivia/components/InfiniteHUD.tsx
@@ -15,6 +15,7 @@ interface InfiniteHUDProps {
   isPlaying: boolean
   mode?: InfiniteMode
   categoryName?: string
+  skipsRemaining?: number
 }
 
 export function InfiniteHUD({
@@ -27,6 +28,7 @@ export function InfiniteHUD({
   isPlaying,
   mode = 'scored',
   categoryName,
+  skipsRemaining,
 }: InfiniteHUDProps) {
   const [showFleeConfirm, setShowFleeConfirm] = useState(false)
   const mult = computeStreakMultiplier(currentStreak)
@@ -73,6 +75,11 @@ export function InfiniteHUD({
               </span>
             ))}
           </div>
+        )}
+
+        {/* Skips remaining */}
+        {skipsRemaining != null && skipsRemaining > 0 && (
+          <Pill tone="neutral" size="sm">⏭️ {skipsRemaining}</Pill>
         )}
 
         {/* Streak + multiplier */}

--- a/src/app/trivia/components/InfiniteQuestionCard.tsx
+++ b/src/app/trivia/components/InfiniteQuestionCard.tsx
@@ -8,12 +8,19 @@ import type { AnswerResult } from '@/app/trivia/lib/infiniteScoring'
 import { FlagQuestion } from './FlagQuestion'
 import { QuestionRating } from './QuestionRating'
 
+interface FlagResult {
+  wasFirstFlag: boolean
+  bonusLifeGranted: boolean
+}
+
 interface Props {
   question: InfiniteQuestion
   onSubmit: (answer: string) => void
   isSubmitting: boolean
   answerResult: (AnswerResult & { trailblazer: boolean; correctAnswer: string; explanation: string | null }) | null
   questionsAnswered: number
+  runId?: string | null
+  onFlagged?: (questionId: string, result: FlagResult) => void
 }
 
 function getSocialSignal(timesShown: number): string {
@@ -28,6 +35,8 @@ export function InfiniteQuestionCard({
   isSubmitting,
   answerResult,
   questionsAnswered,
+  runId,
+  onFlagged,
 }: Props) {
   const [textAnswer, setTextAnswer] = useState('')
   const isAnswered = answerResult !== null
@@ -113,7 +122,11 @@ export function InfiniteQuestionCard({
               )}
               <div className="flex items-center gap-2 shrink-0">
                 <QuestionRating questionId={question.id} />
-                <FlagQuestion questionId={question.id} />
+                <FlagQuestion
+                  questionId={question.id}
+                  runId={runId}
+                  onFlagged={onFlagged ? (result) => onFlagged(question.id, result) : undefined}
+                />
               </div>
             </div>
             {!answerResult.correct && (

--- a/src/app/trivia/components/InfiniteQuestionCard.tsx
+++ b/src/app/trivia/components/InfiniteQuestionCard.tsx
@@ -21,6 +21,8 @@ interface Props {
   questionsAnswered: number
   runId?: string | null
   onFlagged?: (questionId: string, result: FlagResult) => void
+  skipsRemaining?: number
+  onSkip?: () => void
 }
 
 function getSocialSignal(timesShown: number): string {
@@ -37,6 +39,8 @@ export function InfiniteQuestionCard({
   questionsAnswered,
   runId,
   onFlagged,
+  skipsRemaining,
+  onSkip,
 }: Props) {
   const [textAnswer, setTextAnswer] = useState('')
   const isAnswered = answerResult !== null
@@ -90,13 +94,25 @@ export function InfiniteQuestionCard({
             spellCheck={false}
           />
           {!isAnswered && (
-            <ChunkyButton
-              variant="primary"
-              disabled={isSubmitting || !textAnswer.trim()}
-              onClick={handleSubmit}
-            >
-              {isSubmitting ? 'Checking...' : 'Submit Answer'}
-            </ChunkyButton>
+            <div className="flex gap-2">
+              <ChunkyButton
+                variant="primary"
+                className="flex-1"
+                disabled={isSubmitting || !textAnswer.trim()}
+                onClick={handleSubmit}
+              >
+                {isSubmitting ? 'Checking...' : 'Submit Answer'}
+              </ChunkyButton>
+              {onSkip && skipsRemaining != null && skipsRemaining > 0 && !isSubmitting && (
+                <ChunkyButton
+                  variant="ghost"
+                  size="sm"
+                  onClick={onSkip}
+                >
+                  Skip
+                </ChunkyButton>
+              )}
+            </div>
           )}
         </div>
 

--- a/src/app/trivia/components/InfiniteQuestionCard.tsx
+++ b/src/app/trivia/components/InfiniteQuestionCard.tsx
@@ -105,7 +105,7 @@ export function InfiniteQuestionCard({
                 <span className="text-ds-primary">
                   Correct! +{answerResult.points} pts
                   {answerResult.trailblazer && (
-                    <span className="ml-2 text-ds-tertiary">⭐ Trailblazer!</span>
+                    <span className="ml-2 text-on-surface/70">First to answer this question</span>
                   )}
                 </span>
               ) : (

--- a/src/app/trivia/components/InfiniteRulesModal.tsx
+++ b/src/app/trivia/components/InfiniteRulesModal.tsx
@@ -35,10 +35,6 @@ export function InfiniteRulesModal({ defaultMode, onContinue, onCancel }: Props)
             <span aria-hidden="true">🩹</span>
             <span><strong className="text-on-surface">Bonus life.</strong> Every 10-streak refunds a life (cap of 3).</span>
           </li>
-          <li className="flex gap-2">
-            <span aria-hidden="true">⭐</span>
-            <span><strong className="text-on-surface">Trailblazer.</strong> First to answer a fresh question? +50 bonus.</span>
-          </li>
         </ul>
 
         <p className="text-on-surface/50 text-xs">

--- a/src/app/trivia/components/InfiniteRulesModal.tsx
+++ b/src/app/trivia/components/InfiniteRulesModal.tsx
@@ -42,6 +42,10 @@ export function InfiniteRulesModal({ defaultMode, onContinue, onCancel }: Props)
             <span aria-hidden="true">🩹</span>
             <span><strong className="text-on-surface">Bonus life.</strong> Every 10-streak refunds a life (cap of 3).</span>
           </li>
+          <li className="flex gap-2">
+            <span aria-hidden="true">⏭️</span>
+            <span><strong className="text-on-surface">Two skips.</strong> Stuck on a question? Skip it — no life lost, no streak broken. Two per run.</span>
+          </li>
         </ul>
 
         <p className="text-on-surface/50 text-xs">

--- a/src/app/trivia/components/InfiniteRulesModal.tsx
+++ b/src/app/trivia/components/InfiniteRulesModal.tsx
@@ -2,19 +2,26 @@
 import { useState } from 'react'
 import { ChunkyButton } from '@/components/ui/chunky-button'
 import type { InfiniteMode } from '@/app/trivia/hooks/useInfiniteRun'
+import { CATEGORY_META } from '@/lib/trivia/categories'
 
 interface Props {
   defaultMode: InfiniteMode
-  onContinue: (mode: InfiniteMode, dismissForever: boolean) => void
+  onContinue: (mode: InfiniteMode, dismissForever: boolean, categoryId?: number) => void
   onCancel: () => void
 }
 
 export function InfiniteRulesModal({ defaultMode, onContinue, onCancel }: Props) {
   const [dismissForever, setDismissForever] = useState(false)
+  const [selectedCategoryId, setSelectedCategoryId] = useState<number | undefined>(undefined)
+
+  const categoryEntries = Object.entries(CATEGORY_META).map(([id, meta]) => ({
+    id: Number(id),
+    ...meta,
+  }))
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-surface-dim/80 backdrop-blur-sm p-4">
-      <div className="bg-surface-container-high rounded-ds-lg p-6 max-w-md w-full shadow-hero flex flex-col gap-4">
+      <div className="bg-surface-container-high rounded-ds-lg p-6 max-w-md w-full shadow-hero flex flex-col gap-4 max-h-[90vh] overflow-y-auto">
         <div>
           <h2 className="text-on-surface text-xl font-bold mb-1">Infinite Trivia</h2>
           <p className="text-on-surface/60 text-sm">
@@ -41,6 +48,41 @@ export function InfiniteRulesModal({ defaultMode, onContinue, onCancel }: Props)
           Practice mode plays the same questions with no lives and no scoring — a low-pressure way to explore.
         </p>
 
+        {/* Category selector */}
+        <div className="flex flex-col gap-2">
+          <p className="text-on-surface/70 text-sm font-medium">Category</p>
+          <div className="flex flex-wrap gap-1.5">
+            {/* "All" chip */}
+            <button
+              type="button"
+              onClick={() => setSelectedCategoryId(undefined)}
+              className={`flex items-center gap-1 px-2 py-1 rounded-full text-xs font-medium transition-colors ${
+                selectedCategoryId === undefined
+                  ? 'bg-ds-primary text-on-primary'
+                  : 'bg-surface-container text-on-surface/70 hover:bg-surface-container-highest'
+              }`}
+            >
+              <span aria-hidden="true">🌐</span>
+              All
+            </button>
+            {categoryEntries.map(({ id, name, icon }) => (
+              <button
+                key={id}
+                type="button"
+                onClick={() => setSelectedCategoryId(id)}
+                className={`flex items-center gap-1 px-2 py-1 rounded-full text-xs font-medium transition-colors ${
+                  selectedCategoryId === id
+                    ? 'bg-ds-primary text-on-primary'
+                    : 'bg-surface-container text-on-surface/70 hover:bg-surface-container-highest'
+                }`}
+              >
+                <span aria-hidden="true">{icon}</span>
+                {name}
+              </button>
+            ))}
+          </div>
+        </div>
+
         <label className="flex items-center gap-2 text-on-surface/70 text-sm cursor-pointer select-none">
           <input
             type="checkbox"
@@ -58,14 +100,14 @@ export function InfiniteRulesModal({ defaultMode, onContinue, onCancel }: Props)
           <ChunkyButton
             variant="secondary"
             size="sm"
-            onClick={() => onContinue('practice', dismissForever)}
+            onClick={() => onContinue('practice', dismissForever, selectedCategoryId)}
           >
             Practice Mode
           </ChunkyButton>
           <ChunkyButton
             variant="primary"
             size="sm"
-            onClick={() => onContinue(defaultMode === 'practice' ? 'practice' : 'scored', dismissForever)}
+            onClick={() => onContinue(defaultMode === 'practice' ? 'practice' : 'scored', dismissForever, selectedCategoryId)}
           >
             Continue
           </ChunkyButton>

--- a/src/app/trivia/components/InfiniteRunSummary.tsx
+++ b/src/app/trivia/components/InfiniteRunSummary.tsx
@@ -53,7 +53,7 @@ export function InfiniteRunSummary({ state, onPlayAgain, onBack, mode = 'scored'
       `💎 Score: ${state.score.toLocaleString()}`,
       `📊 ${state.questionsAnswered} questions answered`,
       state.trailblazes > 0 ? `${state.trailblazes} first answer${state.trailblazes === 1 ? '' : 's'}` : null,
-      'https://cometcave.com/trivia',
+      runId ? `https://cometcave.com/trivia/runs/${runId}` : 'https://cometcave.com/trivia',
     ].filter(Boolean).join('\n')
 
     try {

--- a/src/app/trivia/components/InfiniteRunSummary.tsx
+++ b/src/app/trivia/components/InfiniteRunSummary.tsx
@@ -29,11 +29,11 @@ function formatTime(ms: number): string {
   return `${seconds}s`
 }
 
-function getRunRating(longestStreak: number): string {
-  if (longestStreak >= 20) return 'Legendary!'
-  if (longestStreak >= 10) return 'Amazing!'
-  if (longestStreak >= 5) return 'Great Run!'
-  if (longestStreak >= 2) return 'Good Try!'
+function getRunRating(questionsCorrect: number): string {
+  if (questionsCorrect >= 20) return 'Legendary!'
+  if (questionsCorrect >= 10) return 'Amazing!'
+  if (questionsCorrect >= 5) return 'Great Run!'
+  if (questionsCorrect >= 2) return 'Good Try!'
   return 'Try Again!'
 }
 
@@ -47,13 +47,14 @@ export function InfiniteRunSummary({ state, onPlayAgain, onBack, onViewStats, mo
   const [showAllAnswers, setShowAllAnswers] = useState(false)
   const [detailFor, setDetailFor] = useState<AnswerEntry | null>(null)
 
+  const questionsCorrect = state.answers.filter(a => a.correct).length
+
   const handleShare = async () => {
     const lines = [
       '🧠 CometCave Infinite Trivia',
-      `🔥 Longest Streak: ${state.longestStreak}`,
+      `✓ Correct: ${questionsCorrect} / ${state.questionsAnswered}`,
       `💎 Score: ${state.score.toLocaleString()}`,
-      `📊 ${state.questionsAnswered} questions answered`,
-      state.trailblazes > 0 ? `${state.trailblazes} first answer${state.trailblazes === 1 ? '' : 's'}` : null,
+      `🔥 Longest Streak: ${state.longestStreak}`,
       runId ? `https://cometcave.com/trivia/runs/${runId}` : 'https://cometcave.com/trivia',
     ].filter(Boolean).join('\n')
 
@@ -70,7 +71,7 @@ export function InfiniteRunSummary({ state, onPlayAgain, onBack, onViewStats, mo
     <div className="flex flex-col items-center gap-5 max-w-lg mx-auto py-6">
       <div className="text-center">
         <h2 className="font-headline text-headline-lg text-ds-tertiary drop-shadow-[0_4px_0_var(--surface-container-lowest)] mb-1">
-          {getRunRating(state.longestStreak)}
+          {getRunRating(questionsCorrect)}
         </h2>
         {mode === 'practice' ? (
           <div className="flex flex-col items-center gap-1">
@@ -82,28 +83,28 @@ export function InfiniteRunSummary({ state, onPlayAgain, onBack, onViewStats, mo
         )}
       </div>
 
-      {/* Hero: Longest Streak */}
+      {/* Hero: Questions Correct */}
       <ChunkyCard variant="surface-variant" className="w-full bg-surface-container/80 border-outline-variant">
         <ChunkyCardContent className="pt-6">
           <div className="text-center mb-4">
             <div className="text-6xl font-bold text-ds-tertiary">
-              🔥 {state.longestStreak}
+              {questionsCorrect}
             </div>
-            <div className="text-on-surface/40 text-sm mt-1">Longest Streak</div>
+            <div className="text-on-surface/40 text-sm mt-1">Questions Correct</div>
           </div>
 
           <div className="grid grid-cols-3 gap-3 mb-4">
             <div className="text-center">
               <div className="text-xl font-bold text-on-surface">{state.score.toLocaleString()}</div>
-              <div className="text-on-surface/50 text-xs">Total Score</div>
+              <div className="text-on-surface/50 text-xs">Score</div>
+            </div>
+            <div className="text-center">
+              <div className="text-xl font-bold text-on-surface">{state.longestStreak}</div>
+              <div className="text-on-surface/50 text-xs">Longest Streak</div>
             </div>
             <div className="text-center">
               <div className="text-xl font-bold text-on-surface">{state.questionsAnswered}</div>
-              <div className="text-on-surface/50 text-xs">Questions</div>
-            </div>
-            <div className="text-center">
-              <div className="text-xl font-bold text-ds-tertiary">{state.trailblazes}</div>
-              <div className="text-on-surface/50 text-xs">First answers</div>
+              <div className="text-on-surface/50 text-xs">Attempted</div>
             </div>
           </div>
         </ChunkyCardContent>

--- a/src/app/trivia/components/InfiniteRunSummary.tsx
+++ b/src/app/trivia/components/InfiniteRunSummary.tsx
@@ -45,7 +45,7 @@ export function InfiniteRunSummary({ state, onPlayAgain, onBack, mode = 'scored'
       `🔥 Longest Streak: ${state.longestStreak}`,
       `💎 Score: ${state.score.toLocaleString()}`,
       `📊 ${state.questionsAnswered} questions answered`,
-      state.trailblazes > 0 ? `⭐ ${state.trailblazes} trailblazer${state.trailblazes === 1 ? '' : 's'}` : null,
+      state.trailblazes > 0 ? `${state.trailblazes} first answer${state.trailblazes === 1 ? '' : 's'}` : null,
       'https://cometcave.com/trivia',
     ].filter(Boolean).join('\n')
 
@@ -95,7 +95,7 @@ export function InfiniteRunSummary({ state, onPlayAgain, onBack, mode = 'scored'
             </div>
             <div className="text-center">
               <div className="text-xl font-bold text-ds-tertiary">{state.trailblazes}</div>
-              <div className="text-on-surface/50 text-xs">Trailblazers</div>
+              <div className="text-on-surface/50 text-xs">First answers</div>
             </div>
           </div>
         </ChunkyCardContent>
@@ -122,7 +122,7 @@ export function InfiniteRunSummary({ state, onPlayAgain, onBack, mode = 'scored'
                     <span className={`text-lg ${a.correct ? 'text-ds-primary' : 'text-ds-error'}`}>
                       {a.correct ? '✓' : '✗'}
                     </span>
-                    {a.trailblazer && <span className="text-xs">⭐</span>}
+                    {a.trailblazer && <span className="text-xs text-on-surface/50">1st</span>}
                     {a.questionText && (
                       <button
                         type="button"
@@ -198,7 +198,7 @@ export function InfiniteRunSummary({ state, onPlayAgain, onBack, mode = 'scored'
                   {detailFor.correct ? 'Correct' : 'Wrong'}
                 </Pill>
                 <Pill tone="neutral" size="sm">{detailFor.difficulty.toUpperCase()}</Pill>
-                {detailFor.trailblazer && <Pill tone="warning" size="sm">⭐ Trailblazer</Pill>}
+                {detailFor.trailblazer && <Pill tone="neutral" size="sm">First to answer</Pill>}
               </div>
               <button
                 onClick={() => setDetailFor(null)}

--- a/src/app/trivia/components/InfiniteRunSummary.tsx
+++ b/src/app/trivia/components/InfiniteRunSummary.tsx
@@ -9,11 +9,18 @@ import { QuestionRating } from './QuestionRating'
 import { FlagQuestion } from './FlagQuestion'
 import type { InfiniteRunState, InfiniteMode } from '@/app/trivia/hooks/useInfiniteRun'
 
+interface FlagResult {
+  wasFirstFlag: boolean
+  bonusLifeGranted: boolean
+}
+
 interface Props {
   state: InfiniteRunState
   onPlayAgain: () => void
   onBack: () => void
   mode?: InfiniteMode
+  runId?: string | null
+  onFlagged?: (questionId: string, result: FlagResult) => void
 }
 
 function formatTime(ms: number): string {
@@ -33,7 +40,7 @@ const ANSWERS_PAGE_SIZE = 20
 
 type AnswerEntry = InfiniteRunState['answers'][number]
 
-export function InfiniteRunSummary({ state, onPlayAgain, onBack, mode = 'scored' }: Props) {
+export function InfiniteRunSummary({ state, onPlayAgain, onBack, mode = 'scored', runId, onFlagged }: Props) {
   const { user } = useAuth()
   const [copied, setCopied] = useState(false)
   const [showAllAnswers, setShowAllAnswers] = useState(false)
@@ -141,7 +148,11 @@ export function InfiniteRunSummary({ state, onPlayAgain, onBack, mode = 'scored'
                       +{a.points}
                     </span>
                     <QuestionRating questionId={a.questionId} />
-                    <FlagQuestion questionId={a.questionId} />
+                    <FlagQuestion
+                      questionId={a.questionId}
+                      runId={runId}
+                      onFlagged={onFlagged ? (result) => onFlagged(a.questionId, result) : undefined}
+                    />
                   </div>
                 </div>
               ))}

--- a/src/app/trivia/components/InfiniteRunSummary.tsx
+++ b/src/app/trivia/components/InfiniteRunSummary.tsx
@@ -18,6 +18,7 @@ interface Props {
   state: InfiniteRunState
   onPlayAgain: () => void
   onBack: () => void
+  onViewStats?: () => void
   mode?: InfiniteMode
   runId?: string | null
   onFlagged?: (questionId: string, result: FlagResult) => void
@@ -33,14 +34,14 @@ function getRunRating(longestStreak: number): string {
   if (longestStreak >= 10) return 'Amazing!'
   if (longestStreak >= 5) return 'Great Run!'
   if (longestStreak >= 2) return 'Good Try!'
-  return 'Keep Exploring!'
+  return 'Try Again!'
 }
 
 const ANSWERS_PAGE_SIZE = 20
 
 type AnswerEntry = InfiniteRunState['answers'][number]
 
-export function InfiniteRunSummary({ state, onPlayAgain, onBack, mode = 'scored', runId, onFlagged }: Props) {
+export function InfiniteRunSummary({ state, onPlayAgain, onBack, onViewStats, mode = 'scored', runId, onFlagged }: Props) {
   const { user } = useAuth()
   const [copied, setCopied] = useState(false)
   const [showAllAnswers, setShowAllAnswers] = useState(false)
@@ -178,6 +179,12 @@ export function InfiniteRunSummary({ state, onPlayAgain, onBack, mode = 'scored'
           {copied ? 'Copied!' : 'Share Run'}
         </ChunkyButton>
       </div>
+
+      {onViewStats && user && !user.isAnonymous && (
+        <ChunkyButton variant="ghost" size="sm" className="w-full" onClick={onViewStats}>
+          View Lifetime Stats
+        </ChunkyButton>
+      )}
 
       {(!user || user.isAnonymous) && (
         <SignInCard

--- a/src/app/trivia/components/InfiniteRunSummary.tsx
+++ b/src/app/trivia/components/InfiniteRunSummary.tsx
@@ -107,6 +107,13 @@ export function InfiniteRunSummary({ state, onPlayAgain, onBack, onViewStats, mo
               <div className="text-on-surface/50 text-xs">Attempted</div>
             </div>
           </div>
+
+          {state.skipsUsed > 0 && (
+            <div className="text-center mb-4">
+              <div className="text-2xl font-bold text-on-surface">{state.skipsUsed}</div>
+              <div className="text-on-surface/50 text-xs mt-1">Skips Used</div>
+            </div>
+          )}
         </ChunkyCardContent>
       </ChunkyCard>
 

--- a/src/app/trivia/components/InfiniteStats.tsx
+++ b/src/app/trivia/components/InfiniteStats.tsx
@@ -304,7 +304,7 @@ export function InfiniteStats({ onBack }: { onBack: () => void }) {
         </ChunkyCard>
       )}
 
-      {/* Streaks + trailblazer */}
+      {/* Streaks + first answers */}
       <ChunkyCard
         variant="surface-variant"
         className="bg-surface-container/80 border-outline-variant"

--- a/src/app/trivia/components/InfiniteStats.tsx
+++ b/src/app/trivia/components/InfiniteStats.tsx
@@ -21,6 +21,7 @@ interface DifficultyStats {
 interface AggregateStats {
   totalAnswered: number
   totalCorrect: number
+  totalScore: number
   runsPlayed: number
   bestRun: { score: number; longestStreak: number } | null
   bestStreak: number
@@ -161,6 +162,35 @@ export function InfiniteStats({ onBack }: { onBack: () => void }) {
     stats.totalAnswered > 0 ? Math.round(stats.totalTimeMs / stats.totalAnswered) : 0
   const categories = Object.entries(stats.byCategory).sort((a, b) => b[1].answered - a[1].answered)
 
+  const avgScorePerRun = stats.runsPlayed > 0
+    ? Math.round((stats.totalScore ?? 0) / stats.runsPlayed)
+    : 0
+
+  const MIN_CATEGORY_VOLUME = 5
+  const qualifiedCategories = categories.filter(([, data]) => data.answered >= MIN_CATEGORY_VOLUME)
+  const bestCategory = qualifiedCategories.length > 0
+    ? qualifiedCategories.reduce((best, curr) =>
+        (curr[1].correct / curr[1].answered) > (best[1].correct / best[1].answered) ? curr : best
+      )
+    : null
+  const worstCategory = qualifiedCategories.length > 0
+    ? qualifiedCategories.reduce((worst, curr) =>
+        (curr[1].correct / curr[1].answered) < (worst[1].correct / worst[1].answered) ? curr : worst
+      )
+    : null
+  const categoriesExplored = categories.length
+  const categoriesWithTime = categories.filter(([, data]) => data.answered >= MIN_CATEGORY_VOLUME && data.totalTimeMs > 0)
+  const fastestCategory = categoriesWithTime.length > 0
+    ? categoriesWithTime.reduce((fast, curr) =>
+        (curr[1].totalTimeMs / curr[1].answered) < (fast[1].totalTimeMs / fast[1].answered) ? curr : fast
+      )
+    : null
+  const slowestCategory = categoriesWithTime.length > 0
+    ? categoriesWithTime.reduce((slow, curr) =>
+        (curr[1].totalTimeMs / curr[1].answered) > (slow[1].totalTimeMs / slow[1].answered) ? curr : slow
+      )
+    : null
+
   return (
     <div className="flex flex-col gap-5 max-w-lg mx-auto py-6">
       <div className="text-center">
@@ -209,6 +239,42 @@ export function InfiniteStats({ onBack }: { onBack: () => void }) {
           </ChunkyCardContent>
         </ChunkyCard>
       </div>
+
+      {/* Journey */}
+      <ChunkyCard
+        variant="surface-variant"
+        className="bg-surface-container/80 border-outline-variant"
+      >
+        <ChunkyCardContent className="pt-5 pb-5">
+          <h3 className="text-on-surface/70 text-sm font-semibold mb-3 uppercase tracking-wide">
+            Journey
+          </h3>
+          <div className="grid grid-cols-2 gap-3">
+            <div className="text-center">
+              <div className="text-2xl font-bold text-ds-tertiary">
+                {stats.runsPlayed > 0 ? Math.round(stats.totalAnswered / stats.runsPlayed) : 0}
+              </div>
+              <div className="text-on-surface/50 text-xs mt-1">Avg Q/Run</div>
+            </div>
+            <div className="text-center">
+              <div className="text-2xl font-bold text-ds-tertiary">
+                {stats.runsPlayed > 0 ? Math.round(stats.totalCorrect / stats.runsPlayed) : 0}
+              </div>
+              <div className="text-on-surface/50 text-xs mt-1">Avg Correct/Run</div>
+            </div>
+            <div className="text-center">
+              <div className="text-2xl font-bold text-ds-tertiary">
+                {Math.round(stats.totalTimeMs / 1000 / 60)}m
+              </div>
+              <div className="text-on-surface/50 text-xs mt-1">Time Played</div>
+            </div>
+            <div className="text-center">
+              <div className="text-2xl font-bold text-ds-tertiary">{avgScorePerRun.toLocaleString()}</div>
+              <div className="text-on-surface/50 text-xs mt-1">Avg Score/Run</div>
+            </div>
+          </div>
+        </ChunkyCardContent>
+      </ChunkyCard>
 
       {/* Best run */}
       {stats.bestRun && (
@@ -284,10 +350,86 @@ export function InfiniteStats({ onBack }: { onBack: () => void }) {
                     <span className="text-on-surface/60 text-xs text-center leading-tight">
                       {cat}
                     </span>
+                    <span className="text-on-surface/30 text-[10px]">
+                      {(data.totalTimeMs / data.answered / 1000).toFixed(1)}s avg
+                    </span>
                     <span className="text-on-surface/30 text-[10px]">{data.answered} Q</span>
                   </div>
                 )
               })}
+            </div>
+          </ChunkyCardContent>
+        </ChunkyCard>
+      )}
+
+      {/* Category Insights */}
+      {(bestCategory || categoriesExplored > 0) && (
+        <ChunkyCard
+          variant="surface-variant"
+          className="bg-surface-container/80 border-outline-variant"
+        >
+          <ChunkyCardContent className="pt-5 pb-5">
+            <h3 className="text-on-surface/70 text-sm font-semibold mb-3 uppercase tracking-wide">
+              Category Insights
+            </h3>
+            <div className="flex flex-col gap-3">
+              {bestCategory && (
+                <div className="flex items-center justify-between">
+                  <div className="text-on-surface/60 text-sm">Strongest</div>
+                  <div className="text-right">
+                    <span className="text-ds-primary font-semibold text-sm">{bestCategory[0]}</span>
+                    <span className="text-on-surface/40 text-xs ml-2">
+                      {Math.round((bestCategory[1].correct / bestCategory[1].answered) * 100)}%
+                    </span>
+                  </div>
+                </div>
+              )}
+              {worstCategory && bestCategory && worstCategory[0] !== bestCategory[0] && (
+                <div className="flex items-center justify-between">
+                  <div className="text-on-surface/60 text-sm">Weakest</div>
+                  <div className="text-right">
+                    <span className="text-ds-error font-semibold text-sm">{worstCategory[0]}</span>
+                    <span className="text-on-surface/40 text-xs ml-2">
+                      {Math.round((worstCategory[1].correct / worstCategory[1].answered) * 100)}%
+                    </span>
+                  </div>
+                </div>
+              )}
+              <div className="flex items-center justify-between">
+                <div className="text-on-surface/60 text-sm">Categories Explored</div>
+                <div className="text-on-surface font-semibold text-sm">{categoriesExplored}</div>
+              </div>
+              {categories.length > 0 && (
+                <div className="flex items-center justify-between">
+                  <div className="text-on-surface/60 text-sm">Favorite</div>
+                  <div className="text-right">
+                    <span className="text-ds-tertiary font-semibold text-sm">{categories[0][0]}</span>
+                    <span className="text-on-surface/40 text-xs ml-2">{categories[0][1].answered} Q</span>
+                  </div>
+                </div>
+              )}
+              {fastestCategory && (
+                <div className="flex items-center justify-between">
+                  <div className="text-on-surface/60 text-sm">Fastest</div>
+                  <div className="text-right">
+                    <span className="text-on-surface font-semibold text-sm">{fastestCategory[0]}</span>
+                    <span className="text-on-surface/40 text-xs ml-2">
+                      {(fastestCategory[1].totalTimeMs / fastestCategory[1].answered / 1000).toFixed(1)}s avg
+                    </span>
+                  </div>
+                </div>
+              )}
+              {slowestCategory && fastestCategory && slowestCategory[0] !== fastestCategory[0] && (
+                <div className="flex items-center justify-between">
+                  <div className="text-on-surface/60 text-sm">Slowest</div>
+                  <div className="text-right">
+                    <span className="text-on-surface font-semibold text-sm">{slowestCategory[0]}</span>
+                    <span className="text-on-surface/40 text-xs ml-2">
+                      {(slowestCategory[1].totalTimeMs / slowestCategory[1].answered / 1000).toFixed(1)}s avg
+                    </span>
+                  </div>
+                </div>
+              )}
             </div>
           </ChunkyCardContent>
         </ChunkyCard>

--- a/src/app/trivia/components/InfiniteStats.tsx
+++ b/src/app/trivia/components/InfiniteStats.tsx
@@ -33,6 +33,9 @@ interface AggregateStats {
     medium: DifficultyStats
     hard: DifficultyStats
   }
+  likesGiven?: number
+  dislikesGiven?: number
+  reportsFiled?: number
 }
 
 function getAccuracyColor(accuracy: number): string {
@@ -469,6 +472,34 @@ export function InfiniteStats({ onBack }: { onBack: () => void }) {
           })}
         </ChunkyCardContent>
       </ChunkyCard>
+
+      {/* Your Voice */}
+      {((stats.likesGiven ?? 0) > 0 || (stats.dislikesGiven ?? 0) > 0 || (stats.reportsFiled ?? 0) > 0) && (
+        <ChunkyCard
+          variant="surface-variant"
+          className="bg-surface-container/80 border-outline-variant"
+        >
+          <ChunkyCardContent className="pt-5 pb-5">
+            <h3 className="text-on-surface/70 text-sm font-semibold mb-3 uppercase tracking-wide">
+              Your Voice
+            </h3>
+            <div className="grid grid-cols-3 gap-3">
+              <div className="text-center">
+                <div className="text-2xl font-bold text-ds-primary">{stats.likesGiven ?? 0}</div>
+                <div className="text-on-surface/50 text-xs mt-1">Likes</div>
+              </div>
+              <div className="text-center">
+                <div className="text-2xl font-bold text-on-surface">{stats.dislikesGiven ?? 0}</div>
+                <div className="text-on-surface/50 text-xs mt-1">Dislikes</div>
+              </div>
+              <div className="text-center">
+                <div className="text-2xl font-bold text-on-surface">{stats.reportsFiled ?? 0}</div>
+                <div className="text-on-surface/50 text-xs mt-1">Reports</div>
+              </div>
+            </div>
+          </ChunkyCardContent>
+        </ChunkyCard>
+      )}
 
       <ChunkyButton variant="secondary" onClick={onBack} className="w-full">
         Back

--- a/src/app/trivia/components/InfiniteStats.tsx
+++ b/src/app/trivia/components/InfiniteStats.tsx
@@ -250,10 +250,10 @@ export function InfiniteStats({ onBack }: { onBack: () => void }) {
               <div className="text-on-surface/50 text-xs mt-1">Best Streak</div>
             </div>
             <div className="text-center">
-              <div className="text-2xl font-bold text-ds-tertiary">
-                &#x2B50; {stats.trailblazerCount}
+              <div className="text-2xl font-bold text-on-surface">
+                {stats.trailblazerCount}
               </div>
-              <div className="text-on-surface/50 text-xs mt-1">Trailblazers</div>
+              <div className="text-on-surface/50 text-xs mt-1">First answers</div>
             </div>
           </div>
         </ChunkyCardContent>

--- a/src/app/trivia/hooks/useInfiniteRun.ts
+++ b/src/app/trivia/hooks/useInfiniteRun.ts
@@ -1,7 +1,7 @@
 'use client'
 import { useCallback, useRef, useState } from 'react'
 import { useAuth } from '@/hooks/useAuth'
-import { LIVES_START, type AnswerResult } from '@/app/trivia/lib/infiniteScoring'
+import { LIVES_START, SKIPS_PER_RUN, type AnswerResult } from '@/app/trivia/lib/infiniteScoring'
 
 export type InfinitePhase = 'idle' | 'loading' | 'playing' | 'answering' | 'answered' | 'exhausted' | 'ended' | 'error'
 export type InfiniteMode = 'scored' | 'practice'
@@ -27,6 +27,8 @@ export interface InfiniteRunState {
   questionsAnswered: number
   trailblazes: number
   bonusLivesEarned: number
+  skipsRemaining: number
+  skipsUsed: number
   flaggedQuestionIds: string[]
   lastAnswer: (AnswerResult & { trailblazer: boolean; correctAnswer: string; explanation: string | null }) | null
   answers: Array<{
@@ -59,6 +61,8 @@ export function useInfiniteRun() {
     questionsAnswered: 0,
     trailblazes: 0,
     bonusLivesEarned: 0,
+    skipsRemaining: SKIPS_PER_RUN,
+    skipsUsed: 0,
     flaggedQuestionIds: [],
     lastAnswer: null,
     answers: [],
@@ -150,6 +154,8 @@ export function useInfiniteRun() {
         questionsAnswered: 0,
         trailblazes: 0,
         bonusLivesEarned: 0,
+        skipsRemaining: SKIPS_PER_RUN,
+        skipsUsed: 0,
         flaggedQuestionIds: [],
         lastAnswer: null,
         answers: [],
@@ -268,6 +274,54 @@ export function useInfiniteRun() {
     }
   }, [state.phase, state.runId, state.currentStreak, state.categoryId, getAuthHeaders])
 
+  const skipQuestion = useCallback(async () => {
+    if (state.phase !== 'playing' || state.skipsRemaining <= 0 || !state.question || !state.runId) return
+
+    const questionId = state.question.id
+    cancelPrefetch()
+
+    setState(s => ({
+      ...s,
+      phase: 'loading',
+      skipsRemaining: s.skipsRemaining - 1,
+      skipsUsed: s.skipsUsed + 1,
+    }))
+
+    // Fire-and-forget: record skip on the server
+    getAuthHeaders().then(headers =>
+      fetch(`/api/v1/trivia/infinite/runs/${state.runId}/skip`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({ questionId }),
+      })
+    ).catch(() => {
+      // Best effort
+    })
+
+    try {
+      const headers = await getAuthHeaders()
+      const nextParams = new URLSearchParams({ streak: String(state.currentStreak) })
+      if (state.categoryId != null) nextParams.set('categoryId', String(state.categoryId))
+      const qRes = await fetch(`/api/v1/trivia/infinite/next?${nextParams.toString()}`, { headers })
+      if (qRes.status === 204) {
+        setState(s => ({ ...s, phase: 'exhausted' }))
+        return
+      }
+      if (qRes.status === 429) {
+        setState(s => ({ ...s, phase: 'error', error: 'Too many fresh questions generated for now. Try again in a bit.' }))
+        return
+      }
+      if (!qRes.ok) throw new Error('Failed to fetch question')
+      const question = await qRes.json()
+
+      startTimeRef.current = Date.now()
+      setState(s => ({ ...s, phase: 'playing', question, lastAnswer: null }))
+    } catch (err) {
+      console.error('[infinite] skipQuestion failed:', err)
+      setState(s => ({ ...s, phase: 'error', error: 'Failed to fetch next question.' }))
+    }
+  }, [state.phase, state.skipsRemaining, state.question, state.runId, state.currentStreak, state.categoryId, getAuthHeaders, cancelPrefetch])
+
   const endRun = useCallback(async () => {
     cancelPrefetch()
     // If the server already auto-finalized this run (lives reached 0), skip
@@ -310,5 +364,5 @@ export function useInfiniteRun() {
     })
   }, [])
 
-  return { state, startRun, submitAnswer, nextQuestion, endRun, handleQuestionFlagged }
+  return { state, startRun, submitAnswer, nextQuestion, skipQuestion, endRun, handleQuestionFlagged }
 }

--- a/src/app/trivia/hooks/useInfiniteRun.ts
+++ b/src/app/trivia/hooks/useInfiniteRun.ts
@@ -25,6 +25,8 @@ export interface InfiniteRunState {
   score: number
   questionsAnswered: number
   trailblazes: number
+  bonusLivesEarned: number
+  flaggedQuestionIds: string[]
   lastAnswer: (AnswerResult & { trailblazer: boolean; correctAnswer: string; explanation: string | null }) | null
   answers: Array<{
     questionId: string
@@ -54,6 +56,8 @@ export function useInfiniteRun() {
     score: 0,
     questionsAnswered: 0,
     trailblazes: 0,
+    bonusLivesEarned: 0,
+    flaggedQuestionIds: [],
     lastAnswer: null,
     answers: [],
     error: null,
@@ -138,6 +142,8 @@ export function useInfiniteRun() {
         score: 0,
         questionsAnswered: 0,
         trailblazes: 0,
+        bonusLivesEarned: 0,
+        flaggedQuestionIds: [],
         lastAnswer: null,
         answers: [],
       }))
@@ -274,5 +280,26 @@ export function useInfiniteRun() {
     setState(s => ({ ...s, phase: 'ended' }))
   }, [state.runId, state.lastAnswer, getAuthHeaders, cancelPrefetch])
 
-  return { state, startRun, submitAnswer, nextQuestion, endRun }
+  const handleQuestionFlagged = useCallback((questionId: string, result: { wasFirstFlag: boolean; bonusLifeGranted: boolean }) => {
+    setState(s => {
+      const newFlaggedQuestionIds = s.flaggedQuestionIds.includes(questionId)
+        ? s.flaggedQuestionIds
+        : [...s.flaggedQuestionIds, questionId]
+
+      // Remove flagged answer from answers array (stats scrub)
+      const newAnswers = s.answers.filter(a => a.questionId !== questionId)
+      const answersRemoved = s.answers.length - newAnswers.length
+
+      return {
+        ...s,
+        livesRemaining: result.bonusLifeGranted ? s.livesRemaining + 1 : s.livesRemaining,
+        bonusLivesEarned: result.bonusLifeGranted ? s.bonusLivesEarned + 1 : s.bonusLivesEarned,
+        flaggedQuestionIds: newFlaggedQuestionIds,
+        answers: newAnswers,
+        questionsAnswered: Math.max(0, s.questionsAnswered - answersRemoved),
+      }
+    })
+  }, [])
+
+  return { state, startRun, submitAnswer, nextQuestion, endRun, handleQuestionFlagged }
 }

--- a/src/app/trivia/hooks/useInfiniteRun.ts
+++ b/src/app/trivia/hooks/useInfiniteRun.ts
@@ -17,6 +17,7 @@ export interface InfiniteQuestion {
 export interface InfiniteRunState {
   phase: InfinitePhase
   mode: InfiniteMode
+  categoryId: number | null
   runId: string | null
   question: InfiniteQuestion | null
   livesRemaining: number
@@ -48,6 +49,7 @@ export function useInfiniteRun() {
   const [state, setState] = useState<InfiniteRunState>({
     phase: 'idle',
     mode: 'scored',
+    categoryId: null,
     runId: null,
     question: null,
     livesRemaining: LIVES_START,
@@ -84,14 +86,16 @@ export function useInfiniteRun() {
     prefetchRef.current = null
   }, [])
 
-  const startPrefetch = useCallback((streak: number) => {
+  const startPrefetch = useCallback((streak: number, categoryId?: number | null) => {
     cancelPrefetch()
     const controller = new AbortController()
     prefetchAbortRef.current = controller
     prefetchRef.current = (async (): Promise<InfiniteQuestion | null> => {
       try {
         const headers = await getAuthHeaders()
-        const qRes = await fetch(`/api/v1/trivia/infinite/next?streak=${streak}`, {
+        const params = new URLSearchParams({ streak: String(streak) })
+        if (categoryId != null) params.set('categoryId', String(categoryId))
+        const qRes = await fetch(`/api/v1/trivia/infinite/next?${params.toString()}`, {
           headers,
           signal: controller.signal,
         })
@@ -103,21 +107,23 @@ export function useInfiniteRun() {
     })()
   }, [cancelPrefetch, getAuthHeaders])
 
-  const startRun = useCallback(async (mode: InfiniteMode = 'scored') => {
+  const startRun = useCallback(async (mode: InfiniteMode = 'scored', categoryId?: number) => {
     cancelPrefetch()
-    setState(s => ({ ...s, phase: 'loading', mode, error: null }))
+    setState(s => ({ ...s, phase: 'loading', mode, categoryId: categoryId ?? null, error: null }))
     try {
       const headers = await getAuthHeaders()
       const res = await fetch('/api/v1/trivia/infinite/runs', {
         method: 'POST',
         headers,
-        body: JSON.stringify({ mode }),
+        body: JSON.stringify({ mode, categoryId: categoryId ?? null }),
       })
       if (!res.ok) throw new Error('Failed to start run')
       const data = await res.json()
 
       // Immediately fetch first question
-      const qRes = await fetch(`/api/v1/trivia/infinite/next?streak=0`, { headers })
+      const firstParams = new URLSearchParams({ streak: '0' })
+      if (categoryId != null) firstParams.set('categoryId', String(categoryId))
+      const qRes = await fetch(`/api/v1/trivia/infinite/next?${firstParams.toString()}`, { headers })
       if (qRes.status === 204) {
         setState(s => ({ ...s, phase: 'exhausted', runId: data.runId }))
         return
@@ -134,6 +140,7 @@ export function useInfiniteRun() {
         ...s,
         phase: 'playing',
         mode,
+        categoryId: categoryId ?? null,
         runId: data.runId,
         question,
         livesRemaining: data.livesRemaining,
@@ -183,7 +190,7 @@ export function useInfiniteRun() {
       // Kick off the next question fetch in the background while the player
       // reads their feedback — only when the run is continuing.
       if (!result.runOver) {
-        startPrefetch(result.currentStreak)
+        startPrefetch(result.currentStreak, state.categoryId)
       }
 
       // Always show the answer feedback (correct answer + explanation + rating)
@@ -217,7 +224,7 @@ export function useInfiniteRun() {
       console.error('[infinite] submitAnswer failed:', err)
       setState(s => ({ ...s, phase: 'error', error: 'Failed to submit answer.' }))
     }
-  }, [state.phase, state.runId, state.question, getAuthHeaders, startPrefetch, cancelPrefetch])
+  }, [state.phase, state.runId, state.question, state.categoryId, getAuthHeaders, startPrefetch, cancelPrefetch])
 
   const nextQuestion = useCallback(async () => {
     if (state.phase !== 'answered' || !state.runId) return
@@ -239,7 +246,9 @@ export function useInfiniteRun() {
     setState(s => ({ ...s, phase: 'loading' }))
     try {
       const headers = await getAuthHeaders()
-      const qRes = await fetch(`/api/v1/trivia/infinite/next?streak=${state.currentStreak}`, { headers })
+      const nextParams = new URLSearchParams({ streak: String(state.currentStreak) })
+      if (state.categoryId != null) nextParams.set('categoryId', String(state.categoryId))
+      const qRes = await fetch(`/api/v1/trivia/infinite/next?${nextParams.toString()}`, { headers })
       if (qRes.status === 204) {
         setState(s => ({ ...s, phase: 'exhausted' }))
         return
@@ -257,7 +266,7 @@ export function useInfiniteRun() {
       console.error('[infinite] nextQuestion failed:', err)
       setState(s => ({ ...s, phase: 'error', error: 'Failed to fetch next question.' }))
     }
-  }, [state.phase, state.runId, state.currentStreak, getAuthHeaders])
+  }, [state.phase, state.runId, state.currentStreak, state.categoryId, getAuthHeaders])
 
   const endRun = useCallback(async () => {
     cancelPrefetch()

--- a/src/app/trivia/lib/infiniteScoring.ts
+++ b/src/app/trivia/lib/infiniteScoring.ts
@@ -21,12 +21,6 @@ export function computeStreakMultiplier(streak: number): number {
   return 1
 }
 
-export function computeSpeedBonus(elapsedMs: number, timeLimitMs: number = 30000): number {
-  // max * (timeRemaining / timeLimit), clamped to [0, BASE_MAX_POINTS]
-  const remaining = Math.max(0, timeLimitMs - elapsedMs)
-  return Math.round(BASE_MAX_POINTS * (remaining / timeLimitMs))
-}
-
 export function shouldRefundLife(newStreak: number, livesRemaining: number): boolean {
   return newStreak > 0 && newStreak % LIFE_REFUND_EVERY === 0 && livesRemaining < LIVES_MAX
 }
@@ -52,7 +46,7 @@ export function applyAnswer(params: {
   prevLongestStreak: number
   prevScore: number
 }): AnswerResult {
-  const { correct, trailblazer, elapsedMs, mode, prevLives, prevStreak, prevLongestStreak, prevScore } = params
+  const { correct, trailblazer, mode, prevLives, prevStreak, prevLongestStreak, prevScore } = params
 
   let lives = prevLives
   let streak = prevStreak
@@ -62,9 +56,8 @@ export function applyAnswer(params: {
   if (correct) {
     streak += 1
     longestStreak = Math.max(longestStreak, streak)
-    const speedBonus = computeSpeedBonus(elapsedMs)
     const mult = computeStreakMultiplier(streak)
-    points = Math.round(speedBonus * mult)
+    points = Math.round(BASE_MAX_POINTS * mult)
     if (trailblazer) points += TRAILBLAZER_BONUS
     // Life refund
     if (shouldRefundLife(streak, lives)) {

--- a/src/app/trivia/lib/infiniteScoring.ts
+++ b/src/app/trivia/lib/infiniteScoring.ts
@@ -1,7 +1,6 @@
 export const LIVES_START = 3
 export const LIVES_MAX = 3
 export const LIFE_REFUND_EVERY = 10
-export const TRAILBLAZER_BONUS = 50
 
 export const STREAK_TIERS = [
   { at: 0, mult: 1 },
@@ -58,7 +57,6 @@ export function applyAnswer(params: {
     longestStreak = Math.max(longestStreak, streak)
     const mult = computeStreakMultiplier(streak)
     points = Math.round(BASE_MAX_POINTS * mult)
-    if (trailblazer) points += TRAILBLAZER_BONUS
     // Life refund
     if (shouldRefundLife(streak, lives)) {
       lives = Math.min(lives + 1, LIVES_MAX)

--- a/src/app/trivia/lib/infiniteScoring.ts
+++ b/src/app/trivia/lib/infiniteScoring.ts
@@ -1,6 +1,7 @@
 export const LIVES_START = 3
 export const LIVES_MAX = 3
 export const LIFE_REFUND_EVERY = 10
+export const SKIPS_PER_RUN = 2
 
 export const STREAK_TIERS = [
   { at: 0, mult: 1 },

--- a/src/app/trivia/page.tsx
+++ b/src/app/trivia/page.tsx
@@ -135,11 +135,11 @@ export default function TriviaPage() {
   const handleBackToLanding = () => setView('landing')
 
   if (view === 'infinite') {
-    return <InfiniteGame onBack={handleBackToLanding} />
+    return <InfiniteGame onBack={handleBackToLanding} onViewStats={handleViewInfiniteStats} />
   }
 
   if (view === 'practice') {
-    return <InfiniteGame onBack={handleBackToLanding} mode="practice" />
+    return <InfiniteGame onBack={handleBackToLanding} onViewStats={handleViewInfiniteStats} mode="practice" />
   }
 
   if (view === 'infinite-stats') {

--- a/src/app/trivia/runs/[runId]/RunSharePage.tsx
+++ b/src/app/trivia/runs/[runId]/RunSharePage.tsx
@@ -1,0 +1,70 @@
+'use client'
+import { ChunkyButton } from '@/components/ui/chunky-button'
+import { ChunkyCard, ChunkyCardContent } from '@/components/ui/chunky-card'
+import { Pill } from '@/components/ui/pill'
+
+interface RunData {
+  longestStreak: number
+  score: number
+  questionsAnswered: number
+  trailblazes: number
+  mode: 'scored' | 'practice'
+}
+
+export function RunSharePage({ run }: { run: RunData }) {
+  return (
+    <div className="flex flex-col items-center gap-6 max-w-lg mx-auto py-10 px-4">
+      <div className="text-center">
+        <h1 className="font-headline text-headline-lg text-ds-tertiary drop-shadow-[0_4px_0_var(--surface-container-lowest)] mb-2">
+          CometCave Trivia
+        </h1>
+        <p className="text-on-surface/50 text-sm">A traveler completed this run</p>
+      </div>
+
+      <ChunkyCard variant="surface-variant" className="w-full bg-surface-container/80 border-outline-variant">
+        <ChunkyCardContent className="pt-6">
+          <div className="text-center mb-4">
+            <div className="text-6xl font-bold text-ds-tertiary">
+              🔥 {run.longestStreak}
+            </div>
+            <div className="text-on-surface/40 text-sm mt-1">Longest Streak</div>
+          </div>
+
+          <div className="grid grid-cols-3 gap-3">
+            <div className="text-center">
+              <div className="text-xl font-bold text-on-surface">{run.score.toLocaleString()}</div>
+              <div className="text-on-surface/50 text-xs">Score</div>
+            </div>
+            <div className="text-center">
+              <div className="text-xl font-bold text-on-surface">{run.questionsAnswered}</div>
+              <div className="text-on-surface/50 text-xs">Questions</div>
+            </div>
+            <div className="text-center">
+              <div className="text-xl font-bold text-ds-tertiary">{run.trailblazes}</div>
+              <div className="text-on-surface/50 text-xs">First Answers</div>
+            </div>
+          </div>
+
+          {run.mode === 'practice' && (
+            <div className="flex justify-center mt-3">
+              <Pill tone="info" size="sm">Practice Run</Pill>
+            </div>
+          )}
+        </ChunkyCardContent>
+      </ChunkyCard>
+
+      <ChunkyButton
+        variant="primary"
+        size="hero"
+        className="w-full"
+        onClick={() => window.location.href = '/trivia'}
+      >
+        Play Now
+      </ChunkyButton>
+
+      <p className="text-on-surface/30 text-xs text-center">
+        CometCave — an endless trivia adventure
+      </p>
+    </div>
+  )
+}

--- a/src/app/trivia/runs/[runId]/page.tsx
+++ b/src/app/trivia/runs/[runId]/page.tsx
@@ -1,0 +1,46 @@
+import { Metadata } from 'next'
+import { notFound } from 'next/navigation'
+import { getRunByIdPublic } from '@/lib/trivia/infiniteRuns'
+import { RunSharePage } from './RunSharePage'
+
+interface PageProps {
+  params: Promise<{ runId: string }>
+}
+
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+  const { runId } = await params
+  const result = await getRunByIdPublic(runId)
+  if (!result) return { title: 'Run Not Found — CometCave' }
+  const { run } = result
+  const title = `🔥 ${run.longestStreak} Streak — CometCave Infinite Trivia`
+  const description = `Score: ${run.score.toLocaleString()} · ${run.answers.length} questions answered`
+  return {
+    title,
+    description,
+    openGraph: {
+      title,
+      description,
+      images: [`/api/v1/trivia/infinite/runs/${runId}/share-image`],
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title,
+      description,
+      images: [`/api/v1/trivia/infinite/runs/${runId}/share-image`],
+    },
+  }
+}
+
+export default async function Page({ params }: PageProps) {
+  const { runId } = await params
+  const result = await getRunByIdPublic(runId)
+  if (!result) notFound()
+  const { run } = result
+  return <RunSharePage run={{
+    longestStreak: run.longestStreak,
+    score: run.score,
+    questionsAnswered: run.answers.length,
+    trailblazes: run.trailblazes,
+    mode: run.mode,
+  }} />
+}

--- a/src/lib/trivia/__tests__/infiniteScoring.test.ts
+++ b/src/lib/trivia/__tests__/infiniteScoring.test.ts
@@ -6,7 +6,6 @@ import {
   LIVES_START,
   TRAILBLAZER_BONUS,
   applyAnswer,
-  computeSpeedBonus,
   computeStreakMultiplier,
   shouldRefundLife,
 } from '@/app/trivia/lib/infiniteScoring'
@@ -42,29 +41,6 @@ describe('computeStreakMultiplier', () => {
 
   it('returns 3 at streak 50 (well above last tier)', () => {
     expect(computeStreakMultiplier(50)).toBe(3)
-  })
-})
-
-describe('computeSpeedBonus', () => {
-  it('returns BASE_MAX_POINTS at 0ms elapsed', () => {
-    expect(computeSpeedBonus(0)).toBe(BASE_MAX_POINTS)
-  })
-
-  it('returns 0 at exactly timeLimitMs elapsed', () => {
-    expect(computeSpeedBonus(30000)).toBe(0)
-  })
-
-  it('returns 0 for elapsed > timeLimitMs', () => {
-    expect(computeSpeedBonus(35000)).toBe(0)
-  })
-
-  it('returns ~50 at halfway through time', () => {
-    expect(computeSpeedBonus(15000)).toBe(50)
-  })
-
-  it('respects custom timeLimitMs', () => {
-    // 5000ms elapsed out of 10000ms limit → 50% remaining → 50 points
-    expect(computeSpeedBonus(5000, 10000)).toBe(50)
   })
 })
 
@@ -150,7 +126,7 @@ describe('applyAnswer', () => {
     // 5th correct answer should trigger 1.5x multiplier
     const result = applyAnswer({ ...state, correct: true, elapsedMs: 0 })
     expect(result.currentStreak).toBe(5)
-    // At streak 5 with 0ms elapsed: BASE_MAX_POINTS * 1.5 = 150
+    // At streak 5: BASE_MAX_POINTS * 1.5 = 150
     expect(result.points).toBe(Math.round(BASE_MAX_POINTS * 1.5))
   })
 
@@ -195,6 +171,13 @@ describe('applyAnswer', () => {
     const first = applyAnswer({ ...baseParams, correct: true, elapsedMs: 0, prevScore: 0 })
     const second = applyAnswer({ ...baseParams, correct: true, elapsedMs: 0, prevScore: first.score, prevStreak: 1, prevLongestStreak: 1 })
     expect(second.score).toBeGreaterThan(first.score)
+  })
+
+  it('scores the same regardless of elapsed time', () => {
+    const fast = applyAnswer({ ...baseParams, correct: true, elapsedMs: 0 })
+    const slow = applyAnswer({ ...baseParams, correct: true, elapsedMs: 25000 })
+    expect(fast.points).toBe(slow.points)
+    expect(fast.points).toBe(BASE_MAX_POINTS)
   })
 
   it('longestStreak does not decrease on wrong answer', () => {

--- a/src/lib/trivia/__tests__/infiniteScoring.test.ts
+++ b/src/lib/trivia/__tests__/infiniteScoring.test.ts
@@ -4,7 +4,6 @@ import {
   BASE_MAX_POINTS,
   LIVES_MAX,
   LIVES_START,
-  TRAILBLAZER_BONUS,
   applyAnswer,
   computeStreakMultiplier,
   shouldRefundLife,
@@ -130,10 +129,10 @@ describe('applyAnswer', () => {
     expect(result.points).toBe(Math.round(BASE_MAX_POINTS * 1.5))
   })
 
-  it('adds TRAILBLAZER_BONUS when trailblazer is true', () => {
+  it('trailblazer flag does not affect points', () => {
     const regular = applyAnswer({ ...baseParams, correct: true, trailblazer: false, elapsedMs: 0 })
     const trailblazer = applyAnswer({ ...baseParams, correct: true, trailblazer: true, elapsedMs: 0 })
-    expect(trailblazer.points - regular.points).toBe(TRAILBLAZER_BONUS)
+    expect(trailblazer.points).toBe(regular.points)
     expect(trailblazer.trailblazer).toBe(true)
   })
 

--- a/src/lib/trivia/categories.ts
+++ b/src/lib/trivia/categories.ts
@@ -1,6 +1,6 @@
 import { getTodayPST } from '@/lib/dates'
 
-const CATEGORY_META: Record<number, { name: string; icon: string }> = {
+export const CATEGORY_META: Record<number, { name: string; icon: string }> = {
   9: { name: 'General Knowledge', icon: '🧠' },
   10: { name: 'Books', icon: '📚' },
   11: { name: 'Film', icon: '🎬' },

--- a/src/lib/trivia/generationLimit.ts
+++ b/src/lib/trivia/generationLimit.ts
@@ -3,7 +3,7 @@ import { Timestamp } from 'firebase-admin/firestore'
 import { getFirestoreDb } from '@/lib/firebase/server'
 
 const WINDOW_MS = 60 * 60 * 1000 // 1 hour
-const MAX_GENERATIONS_PER_WINDOW = 30
+const MAX_GENERATIONS_PER_WINDOW = 100
 
 /**
  * Atomically check whether the given uid has exceeded the on-demand generation

--- a/src/lib/trivia/infiniteRuns.ts
+++ b/src/lib/trivia/infiniteRuns.ts
@@ -9,6 +9,7 @@ export interface RunDoc {
   runId: string
   uid: string
   mode: 'scored' | 'practice'
+  categoryFilter: number | null
   score: number
   livesRemaining: number
   currentStreak: number
@@ -30,7 +31,7 @@ export interface RunAnswer {
   answeredAt: FirebaseFirestore.Timestamp
 }
 
-export async function startRun(uid: string, mode: 'scored' | 'practice' = 'scored'): Promise<{ runId: string; livesRemaining: number; currentStreak: number }> {
+export async function startRun(uid: string, mode: 'scored' | 'practice' = 'scored', categoryId?: number): Promise<{ runId: string; livesRemaining: number; currentStreak: number }> {
   const db = getFirestoreDb()
   const runRef = db.collection(`users/${uid}/triviaInfinite`).doc()
   const now = FieldValue.serverTimestamp()
@@ -38,6 +39,7 @@ export async function startRun(uid: string, mode: 'scored' | 'practice' = 'score
     runId: runRef.id,
     uid,
     mode,
+    categoryFilter: categoryId ?? null,
     score: 0,
     livesRemaining: LIVES_START,
     currentStreak: 0,

--- a/src/lib/trivia/infiniteRuns.ts
+++ b/src/lib/trivia/infiniteRuns.ts
@@ -156,6 +156,20 @@ export async function submitAnswer(params: {
   return result
 }
 
+export async function getRunByIdPublic(runId: string): Promise<{ run: RunDoc; uid: string } | null> {
+  const db = getFirestoreDb()
+  const snaps = await db.collectionGroup('triviaInfinite')
+    .where('runId', '==', runId)
+    .limit(1)
+    .get()
+  if (snaps.empty) return null
+  const doc = snaps.docs[0]
+  const run = doc.data() as RunDoc
+  // Extract uid from the document path: users/{uid}/triviaInfinite/{runId}
+  const uid = doc.ref.parent.parent?.id ?? ''
+  return { run, uid }
+}
+
 export async function endRun(uid: string, runId: string): Promise<void> {
   const db = getFirestoreDb()
   const runRef = db.doc(`users/${uid}/triviaInfinite/${runId}`)

--- a/src/lib/trivia/infiniteRuns.ts
+++ b/src/lib/trivia/infiniteRuns.ts
@@ -17,6 +17,7 @@ export interface RunDoc {
   trailblazes: number
   answers: RunAnswer[]
   bonusLivesEarned: number
+  skipsUsed: number
   flaggedQuestionIds: string[]
   startedAt: FirebaseFirestore.Timestamp
   endedAt: FirebaseFirestore.Timestamp | null
@@ -47,6 +48,7 @@ export async function startRun(uid: string, mode: 'scored' | 'practice' = 'score
     trailblazes: 0,
     answers: [],
     bonusLivesEarned: 0,
+    skipsUsed: 0,
     flaggedQuestionIds: [],
     startedAt: now,
     endedAt: null,
@@ -170,6 +172,14 @@ export async function getRunByIdPublic(runId: string): Promise<{ run: RunDoc; ui
   // Extract uid from the document path: users/{uid}/triviaInfinite/{runId}
   const uid = doc.ref.parent.parent?.id ?? ''
   return { run, uid }
+}
+
+export async function recordSkip(uid: string, runId: string, questionId: string): Promise<void> {
+  const db = getFirestoreDb()
+  const runRef = db.doc(`users/${uid}/triviaInfinite/${runId}`)
+  await runRef.update({
+    skipsUsed: FieldValue.increment(1),
+  })
 }
 
 export async function endRun(uid: string, runId: string): Promise<void> {

--- a/src/lib/trivia/infiniteRuns.ts
+++ b/src/lib/trivia/infiniteRuns.ts
@@ -15,6 +15,8 @@ export interface RunDoc {
   longestStreak: number
   trailblazes: number
   answers: RunAnswer[]
+  bonusLivesEarned: number
+  flaggedQuestionIds: string[]
   startedAt: FirebaseFirestore.Timestamp
   endedAt: FirebaseFirestore.Timestamp | null
 }
@@ -42,6 +44,8 @@ export async function startRun(uid: string, mode: 'scored' | 'practice' = 'score
     longestStreak: 0,
     trailblazes: 0,
     answers: [],
+    bonusLivesEarned: 0,
+    flaggedQuestionIds: [],
     startedAt: now,
     endedAt: null,
   })

--- a/src/lib/trivia/sampler.ts
+++ b/src/lib/trivia/sampler.ts
@@ -1,10 +1,12 @@
 import { getFirestoreDb } from '@/lib/firebase/server'
 import type { AIQuestion } from '@/lib/trivia/aiQuestions'
+import { CATEGORY_META } from '@/lib/trivia/categories'
 
 export interface SamplerOptions {
   uid: string
   streak: number
   type?: 'free-text' // v1 only free-text
+  categoryId?: number
 }
 
 /**
@@ -54,15 +56,24 @@ function freshnessWeight(timesShown: number): number {
 }
 
 export async function sampleNextQuestion(options: SamplerOptions): Promise<AIQuestion | null> {
-  const { uid, streak, type = 'free-text' } = options
+  const { uid, streak, type = 'free-text', categoryId } = options
   const db = getFirestoreDb()
 
   // 1. Query active questions of the requested type
-  const questionsSnap = await db
+  let query = db
     .collection('aiQuestions')
     .where('status', '==', 'active')
     .where('type', '==', type)
-    .get()
+
+  // If a category filter is provided, restrict to that category by name
+  if (categoryId !== undefined) {
+    const categoryMeta = CATEGORY_META[categoryId]
+    if (categoryMeta) {
+      query = query.where('category', '==', categoryMeta.name)
+    }
+  }
+
+  const questionsSnap = await query.get()
 
   if (questionsSnap.empty) return null
 

--- a/src/lib/trivia/triviaStats.ts
+++ b/src/lib/trivia/triviaStats.ts
@@ -98,7 +98,12 @@ export async function applyRunToAggregate(uid: string, runId: string): Promise<v
       hard: { answered: 0, correct: 0 },
     }
 
+    const flaggedSet = new Set<string>(run.flaggedQuestionIds ?? [])
+
     for (const answer of run.answers) {
+      // Skip flagged questions — they don't count toward stats
+      if (flaggedSet.has(answer.questionId)) continue
+
       totalAnswered += 1
       if (answer.correct) totalCorrect += 1
       totalTimeMs += answer.timeMs

--- a/src/lib/trivia/triviaStats.ts
+++ b/src/lib/trivia/triviaStats.ts
@@ -6,6 +6,7 @@ import type { RunDoc } from '@/lib/trivia/infiniteRuns'
 export interface AggregateStats {
   totalAnswered: number
   totalCorrect: number
+  totalScore: number
   runsPlayed: number
   bestRun: {
     score: number
@@ -29,6 +30,7 @@ export interface AggregateStats {
 const EMPTY_STATS: AggregateStats = {
   totalAnswered: 0,
   totalCorrect: 0,
+  totalScore: 0,
   runsPlayed: 0,
   bestRun: null,
   bestStreak: 0,
@@ -143,6 +145,7 @@ export async function applyRunToAggregate(uid: string, runId: string): Promise<v
     const newAgg: AggregateStats = {
       totalAnswered: agg.totalAnswered + totalAnswered,
       totalCorrect: agg.totalCorrect + totalCorrect,
+      totalScore: (agg.totalScore ?? 0) + run.score,
       runsPlayed: agg.runsPlayed + 1,
       bestRun: agg.bestRun,
       bestStreak: Math.max(agg.bestStreak, run.longestStreak),

--- a/src/lib/trivia/triviaStats.ts
+++ b/src/lib/trivia/triviaStats.ts
@@ -24,6 +24,9 @@ export interface AggregateStats {
     hard: { answered: number; correct: number }
   }
   exhaustionCount: number
+  likesGiven: number
+  dislikesGiven: number
+  reportsFiled: number
   lastUpdatedAt: FirebaseFirestore.Timestamp | null
 }
 
@@ -43,6 +46,9 @@ const EMPTY_STATS: AggregateStats = {
     hard: { answered: 0, correct: 0 },
   },
   exhaustionCount: 0,
+  likesGiven: 0,
+  dislikesGiven: 0,
+  reportsFiled: 0,
   lastUpdatedAt: null,
 }
 
@@ -167,6 +173,9 @@ export async function applyRunToAggregate(uid: string, runId: string): Promise<v
         },
       },
       exhaustionCount: agg.exhaustionCount ?? 0,
+      likesGiven: agg.likesGiven ?? 0,
+      dislikesGiven: agg.dislikesGiven ?? 0,
+      reportsFiled: agg.reportsFiled ?? 0,
       lastUpdatedAt: null, // overwritten by server timestamp below
     }
 
@@ -186,6 +195,20 @@ export async function applyRunToAggregate(uid: string, runId: string): Promise<v
     // Mark the run as having its stats applied (idempotency guard)
     tx.update(runRef, { statsApplied: true })
   })
+}
+
+export async function incrementVoiceStat(
+  uid: string,
+  field: 'likesGiven' | 'dislikesGiven' | 'reportsFiled'
+): Promise<void> {
+  const db = getFirestoreDb()
+  const aggRef = db.doc(`users/${uid}/triviaStats/aggregate`)
+  const snap = await aggRef.get()
+  if (snap.exists) {
+    await aggRef.update({ [field]: FieldValue.increment(1), lastUpdatedAt: FieldValue.serverTimestamp() })
+  } else {
+    await aggRef.set({ ...EMPTY_STATS, [field]: 1, lastUpdatedAt: FieldValue.serverTimestamp() })
+  }
 }
 
 export async function trackExhaustion(uid: string): Promise<void> {


### PR DESCRIPTION
## Summary
- Adds 2 skips per Infinite Trivia run — skip advances to the next question without costing a life, breaking streak, or awarding points
- Skip button appears on question card (ghost variant, subdued), hidden when skips are exhausted
- HUD shows remaining skips with ⏭️ indicator
- Rules modal explains the mechanic
- Run summary shows "Skips Used" stat when player used any
- Server tracks `skipsUsed` on RunDoc via fire-and-forget `/skip` endpoint for analytics

Closes #657

## Files changed (9)
- `infiniteScoring.ts` — `SKIPS_PER_RUN = 2` constant
- `useInfiniteRun.ts` — `skipsRemaining`/`skipsUsed` state + `skipQuestion()` callback
- `InfiniteGame.tsx` — wires skip to card and HUD
- `InfiniteQuestionCard.tsx` — Skip button alongside Submit
- `InfiniteHUD.tsx` — skip counter pill
- `InfiniteRulesModal.tsx` — new rule bullet
- `InfiniteRunSummary.tsx` — conditional skips-used stat
- `infiniteRuns.ts` — `skipsUsed` on RunDoc + `recordSkip()`
- `runs/[runId]/skip/route.ts` — new POST endpoint

## Test plan
- [x] Existing `infiniteScoring.test.ts` passes (27/27)
- [ ] Verify skip button appears during `playing` phase with skips > 0
- [ ] Verify skip button disappears after 2 skips are used
- [ ] Verify skip does not cost a life or break streak
- [ ] Verify skipped question is not in the answers array
- [ ] Verify HUD skip counter decrements correctly
- [ ] Verify run summary shows "Skips Used" when applicable
- [ ] Verify rules modal shows the skip rule

🤖 Generated with [Claude Code](https://claude.com/claude-code)