### PR TITLE
fix: sync rate limit constants with actual 100/hr cap (#626)

### DIFF
--- a/scripts/trivia/generation-limit-stats.ts
+++ b/scripts/trivia/generation-limit-stats.ts
@@ -20,7 +20,8 @@
 import { cert, getApps, initializeApp } from 'firebase-admin/app'
 import { getFirestore } from 'firebase-admin/firestore'
 
-const MAX_GENERATIONS_PER_WINDOW = 30
+// NOTE: keep this in sync with src/lib/trivia/generationLimit.ts
+const MAX_GENERATIONS_PER_WINDOW = 100
 
 function ensureApp() {
   if (getApps().length > 0) return

--- a/src/app/api/v1/trivia/infinite/next/route.ts
+++ b/src/app/api/v1/trivia/infinite/next/route.ts
@@ -4,7 +4,7 @@ import { verifyRequestAuth } from '@/lib/api/auth'
 import type { AIQuestion } from '@/lib/trivia/aiQuestions'
 import { saveAIQuestion } from '@/lib/trivia/aiQuestions'
 import { generateInfiniteQuestion } from '@/lib/trivia/generateQuestion'
-import { checkAndIncrementGenerationLimit } from '@/lib/trivia/generationLimit'
+import { checkAndIncrementGenerationLimit, MAX_GENERATIONS_PER_WINDOW, WINDOW_MS } from '@/lib/trivia/generationLimit'
 import { sampleNextQuestion } from '@/lib/trivia/sampler'
 import { trackExhaustion } from '@/lib/trivia/triviaStats'
 import { CATEGORY_META } from '@/lib/trivia/categories'
@@ -46,8 +46,8 @@ export async function GET(request: NextRequest) {
         console.warn('[trivia/infinite/next] 429 rate limit hit', {
           uid: auth.claims.uid,
           remaining,
-          limitWindowMs: 60 * 60 * 1000,
-          maxPerWindow: 30,
+          limitWindowMs: WINDOW_MS,
+          maxPerWindow: MAX_GENERATIONS_PER_WINDOW,
         })
         return NextResponse.json(
           { error: 'Generation rate limit exceeded. Please try again later.' },

--- a/src/lib/trivia/generationLimit.ts
+++ b/src/lib/trivia/generationLimit.ts
@@ -2,8 +2,8 @@ import { Timestamp } from 'firebase-admin/firestore'
 
 import { getFirestoreDb } from '@/lib/firebase/server'
 
-const WINDOW_MS = 60 * 60 * 1000 // 1 hour
-const MAX_GENERATIONS_PER_WINDOW = 100
+export const WINDOW_MS = 60 * 60 * 1000 // 1 hour
+export const MAX_GENERATIONS_PER_WINDOW = 100
 
 /**
  * Atomically check whether the given uid has exceeded the on-demand generation


### PR DESCRIPTION
## Summary
- The 429 log in `/api/v1/trivia/infinite/next` and the telemetry script `scripts/trivia/generation-limit-stats.ts` both hardcoded `maxPerWindow: 30`, but the actual enforced limit in `generationLimit.ts` is `100`
- Exported `WINDOW_MS` and `MAX_GENERATIONS_PER_WINDOW` from `generationLimit.ts` so the route uses the real constants
- Updated the telemetry script to match (`100`) with a sync comment

## Test plan
- [ ] Verify type check passes (`npx tsc --noEmit`)
- [ ] Verify 429 log now shows `maxPerWindow: 100` when rate limit is hit
- [ ] Verify telemetry script reports correct ceiling threshold

Relates to #626

🤖 Generated with [Claude Code](https://claude.com/claude-code)