### PR TITLE
feat: add Infinite Trivia global leaderboard (#661)

### DIFF
--- a/src/app/api/v1/trivia/infinite/leaderboard/route.ts
+++ b/src/app/api/v1/trivia/infinite/leaderboard/route.ts
@@ -1,0 +1,41 @@
+import { type NextRequest, NextResponse } from 'next/server'
+
+import { getInfiniteTopByScore, getInfiniteTopByStreak } from '@/lib/trivia/infiniteRuns'
+
+export async function GET(request: NextRequest) {
+  const sort = request.nextUrl.searchParams.get('sort') || 'score'
+
+  try {
+    if (sort === 'score') {
+      const entries = await getInfiniteTopByScore(20)
+      return NextResponse.json({ sort: 'score', entries })
+    }
+
+    if (sort === 'streak') {
+      const entries = await getInfiniteTopByStreak(20)
+      return NextResponse.json({ sort: 'streak', entries })
+    }
+
+    return NextResponse.json(
+      { error: 'Invalid sort. Use score or streak.' },
+      { status: 400 }
+    )
+  } catch (error: unknown) {
+    console.error('Error fetching infinite leaderboard:', error)
+    const errMsg = error instanceof Error ? error.message : String(error)
+    if (
+      errMsg.includes('index') ||
+      errMsg.includes('FAILED_PRECONDITION') ||
+      errMsg.includes('requires an index')
+    ) {
+      const urlMatch = errMsg.match(/(https:\/\/console\.firebase\.google\.com\S+)/)
+      if (urlMatch) console.error('Create index here:', urlMatch[1])
+      return NextResponse.json({
+        sort,
+        entries: [],
+        notice: 'Leaderboard is initializing. Please try again in a few minutes.',
+      })
+    }
+    return NextResponse.json({ error: 'Failed to fetch leaderboard.' }, { status: 500 })
+  }
+}

--- a/src/app/trivia/components/InfiniteLeaderboard.tsx
+++ b/src/app/trivia/components/InfiniteLeaderboard.tsx
@@ -1,0 +1,184 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+
+import { useTriviaUser } from '@/app/trivia/hooks/useTriviaUser'
+import { ChunkyButton } from '@/components/ui/chunky-button'
+import { ChunkyCard, ChunkyCardContent } from '@/components/ui/chunky-card'
+import { Pill } from '@/components/ui/pill'
+import { useAuth } from '@/hooks/useAuth'
+
+import { SignInBanner } from './SignInCTA'
+
+type Sort = 'score' | 'streak'
+
+interface InfiniteLeaderboardEntry {
+  uid: string
+  displayName: string
+  score: number
+  longestStreak: number
+  questionsAnswered: number
+}
+
+interface InfiniteLeaderboardResponse {
+  sort: Sort
+  entries: InfiniteLeaderboardEntry[]
+  notice?: string
+}
+
+export function InfiniteLeaderboard({ onBack }: { onBack: () => void }) {
+  const { user } = useAuth()
+  const { displayName: triviaDisplayName } = useTriviaUser()
+  const [sort, setSort] = useState<Sort>('score')
+  const [loading, setLoading] = useState(true)
+  const [data, setData] = useState<InfiniteLeaderboardResponse | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  const currentUid = user?.uid ?? null
+  const authName = user ? triviaDisplayName || user.email || null : null
+
+  useEffect(() => {
+    async function load() {
+      setLoading(true)
+      setError(null)
+      try {
+        const res = await fetch(`/api/v1/trivia/infinite/leaderboard?sort=${sort}`)
+        if (!res.ok) throw new Error('Failed to load leaderboard')
+        const json = await res.json()
+        setData(json)
+      } catch {
+        setError('Failed to load leaderboard.')
+      } finally {
+        setLoading(false)
+      }
+    }
+    load()
+  }, [sort])
+
+  const renderEntries = () => {
+    if (!data || !data.entries) return null
+
+    if (data.entries.length === 0) {
+      return (
+        <div className="text-center text-on-surface/50 py-8 px-4">
+          {data.notice ?? 'No runs yet. Be the first!'}
+        </div>
+      )
+    }
+
+    return data.entries.map((entry, i) => {
+      const primary = sort === 'score'
+        ? `${entry.score.toLocaleString()} pts`
+        : `${entry.longestStreak} streak`
+      const secondary = sort === 'score'
+        ? `${entry.longestStreak} streak · ${entry.questionsAnswered} Qs`
+        : `${entry.score.toLocaleString()} pts · ${entry.questionsAnswered} Qs`
+
+      return (
+        <LeaderboardRow
+          key={`${entry.uid}-${i}`}
+          rank={i + 1}
+          name={entry.displayName || 'Unknown'}
+          primary={primary}
+          secondary={secondary}
+          isCurrentUser={!!currentUid && entry.uid === currentUid}
+        />
+      )
+    })
+  }
+
+  return (
+    <div className="flex flex-col gap-4 max-w-lg mx-auto py-6">
+      <div className="text-center">
+        <h2 className="text-3xl font-bold text-ds-tertiary mb-1">
+          Infinite Leaderboard
+        </h2>
+        {authName ? (
+          <p className="text-on-surface/50 text-sm">
+            Playing as <span className="text-ds-tertiary">{authName}</span>
+          </p>
+        ) : null}
+      </div>
+
+      {!authName && (
+        <SignInBanner message="Log in to see your rank and compete" cta="Sign in" />
+      )}
+
+      {/* Sort tabs */}
+      <div className="grid grid-cols-2 gap-2">
+        {(['score', 'streak'] as Sort[]).map((s) => (
+          <ChunkyButton
+            key={s}
+            variant={sort === s ? 'primary' : 'secondary'}
+            onClick={() => setSort(s)}
+          >
+            {s === 'score' ? 'Top Score' : 'Top Streak'}
+          </ChunkyButton>
+        ))}
+      </div>
+
+      {/* Content */}
+      <ChunkyCard variant="surface-container-high" className="bg-surface-container/80 border-outline-variant">
+        <ChunkyCardContent className="pt-4 pb-4">
+          {loading ? (
+            <div className="text-center text-on-surface/50 py-8">Loading...</div>
+          ) : error ? (
+            <div className="text-center text-ds-error py-8">{error}</div>
+          ) : (
+            <div className="flex flex-col gap-1.5">{renderEntries()}</div>
+          )}
+        </ChunkyCardContent>
+      </ChunkyCard>
+
+      <ChunkyButton variant="secondary" onClick={onBack} className="w-full">
+        Back to Trivia
+      </ChunkyButton>
+    </div>
+  )
+}
+
+function LeaderboardRow({
+  rank,
+  name,
+  primary,
+  secondary,
+  isCurrentUser,
+}: {
+  rank: number
+  name: string
+  primary: string
+  secondary: string
+  isCurrentUser: boolean
+}) {
+  const rankEmoji = rank === 1 ? '🥇' : rank === 2 ? '🥈' : rank === 3 ? '🥉' : null
+
+  return (
+    <div
+      className={`flex items-center justify-between py-2.5 px-3 rounded ${
+        isCurrentUser
+          ? 'bg-ds-tertiary/20 border border-ds-tertiary/40'
+          : 'bg-surface-dim/40'
+      }`}
+    >
+      <div className="flex items-center gap-3 min-w-0 flex-1">
+        <div className="flex items-center justify-center w-8">
+          {rankEmoji ? (
+            <Pill tone="success">{rankEmoji}</Pill>
+          ) : (
+            <Pill tone="neutral">#{rank}</Pill>
+          )}
+        </div>
+        <div className="min-w-0 flex-1">
+          <div className={`font-medium truncate ${isCurrentUser ? 'text-ds-tertiary' : 'text-on-surface'}`}>
+            {name}
+            {isCurrentUser && <span className="text-xs ml-2 text-ds-tertiary/70">(you)</span>}
+          </div>
+          <div className="text-on-surface/40 text-xs">{secondary}</div>
+        </div>
+      </div>
+      <div className={`font-bold text-right ${isCurrentUser ? 'text-ds-tertiary' : 'text-on-surface'}`}>
+        {primary}
+      </div>
+    </div>
+  )
+}

--- a/src/app/trivia/components/TriviaLanding.tsx
+++ b/src/app/trivia/components/TriviaLanding.tsx
@@ -23,6 +23,7 @@ export function TriviaLanding({
   onStartInfinite,
   onViewInfiniteStats,
   onStartPractice,
+  onViewInfiniteLeaderboard,
   todayResult,
 }: {
   onStartGame?: () => void
@@ -31,6 +32,7 @@ export function TriviaLanding({
   onStartInfinite?: () => void
   onViewInfiniteStats?: () => void
   onStartPractice?: () => void
+  onViewInfiniteLeaderboard?: () => void
   todayResult: TriviaGameResult | null
 }) {
   const { user, loading: authLoading, configured: authConfigured, signOut } = useAuth()
@@ -238,6 +240,13 @@ export function TriviaLanding({
           className="text-ds-tertiary hover:text-ds-tertiary/80 transition-colors underline-offset-4 hover:underline"
         >
           Infinite Stats
+        </button>
+        <span className="text-on-surface/20">·</span>
+        <button
+          onClick={onViewInfiniteLeaderboard}
+          className="text-ds-tertiary hover:text-ds-tertiary/80 transition-colors underline-offset-4 hover:underline"
+        >
+          Infinite Ranks
         </button>
       </div>
 

--- a/src/app/trivia/page.tsx
+++ b/src/app/trivia/page.tsx
@@ -14,6 +14,7 @@ import { getTodayPST } from '@/lib/dates'
 import { getDailyCategory } from '@/lib/trivia/categories'
 
 import { InfiniteGame } from './components/InfiniteGame'
+import { InfiniteLeaderboard } from './components/InfiniteLeaderboard'
 import { InfiniteStats } from './components/InfiniteStats'
 import { TriviaGame } from './components/TriviaGame'
 import { TriviaLanding } from './components/TriviaLanding'
@@ -24,7 +25,7 @@ import { TriviaStats } from './components/TriviaStats'
 import type { TriviaGameResult } from './models/trivia'
 import type { User } from 'firebase/auth'
 
-type View = 'landing' | 'playing' | 'results' | 'stats' | 'leaderboard' | 'infinite' | 'infinite-stats' | 'practice'
+type View = 'landing' | 'playing' | 'results' | 'stats' | 'leaderboard' | 'infinite' | 'infinite-stats' | 'practice' | 'infinite-leaderboard'
 
 async function submitGameToServer(user: User, result: TriviaGameResult): Promise<void> {
   const token = await user.getIdToken()
@@ -114,6 +115,7 @@ export default function TriviaPage() {
   const handleStartInfinite = () => setView('infinite')
   const handleViewInfiniteStats = () => setView('infinite-stats')
   const handleStartPractice = () => setView('practice')
+  const handleViewInfiniteLeaderboard = () => setView('infinite-leaderboard')
 
   const handleFinish = useCallback(
     (result: TriviaGameResult) => {
@@ -170,6 +172,10 @@ export default function TriviaPage() {
     return <TriviaLeaderboard onBack={handleBackToLanding} />
   }
 
+  if (view === 'infinite-leaderboard') {
+    return <InfiniteLeaderboard onBack={handleBackToLanding} />
+  }
+
   return (
     <TriviaLanding
       onStartGame={handleStartGame}
@@ -178,6 +184,7 @@ export default function TriviaPage() {
       onStartInfinite={handleStartInfinite}
       onViewInfiniteStats={handleViewInfiniteStats}
       onStartPractice={handleStartPractice}
+      onViewInfiniteLeaderboard={handleViewInfiniteLeaderboard}
       todayResult={todayResult}
     />
   )

--- a/src/lib/trivia/infiniteRuns.ts
+++ b/src/lib/trivia/infiniteRuns.ts
@@ -202,3 +202,72 @@ export async function endRun(uid: string, runId: string): Promise<void> {
     console.error('[endRun] Failed to apply run to aggregate:', err)
   )
 }
+
+export interface InfiniteLeaderboardEntry {
+  uid: string
+  displayName: string
+  score: number
+  longestStreak: number
+  questionsAnswered: number
+  date: FirebaseFirestore.Timestamp | null
+}
+
+async function hydrateNicknames(uids: string[]): Promise<Map<string, string>> {
+  if (uids.length === 0) return new Map()
+  const db = getFirestoreDb()
+  const refs = uids.map((uid) => db.doc(`users/${uid}`))
+  const snaps = await db.getAll(...refs)
+  const map = new Map<string, string>()
+  for (const snap of snaps) {
+    if (!snap.exists) continue
+    const data = snap.data() as { uid?: string; nickname?: string }
+    if (data?.uid) {
+      map.set(data.uid, data.nickname ?? '')
+    }
+  }
+  return map
+}
+
+export async function getInfiniteTopByScore(limit = 20): Promise<InfiniteLeaderboardEntry[]> {
+  const db = getFirestoreDb()
+  const snap = await db
+    .collectionGroup('triviaInfinite')
+    .where('mode', '==', 'scored')
+    .where('endedAt', '!=', null)
+    .orderBy('score', 'desc')
+    .limit(limit)
+    .get()
+
+  const entries = snap.docs.map((d) => {
+    const run = d.data() as RunDoc
+    const uid = d.ref.parent.parent?.id ?? ''
+    return { uid, score: run.score, longestStreak: run.longestStreak, questionsAnswered: run.answers?.length ?? 0, date: run.endedAt }
+  })
+  const nicknames = await hydrateNicknames(entries.map((e) => e.uid))
+  return entries.map((e) => ({
+    ...e,
+    displayName: nicknames.get(e.uid) || 'Player',
+  }))
+}
+
+export async function getInfiniteTopByStreak(limit = 20): Promise<InfiniteLeaderboardEntry[]> {
+  const db = getFirestoreDb()
+  const snap = await db
+    .collectionGroup('triviaInfinite')
+    .where('mode', '==', 'scored')
+    .where('endedAt', '!=', null)
+    .orderBy('longestStreak', 'desc')
+    .limit(limit)
+    .get()
+
+  const entries = snap.docs.map((d) => {
+    const run = d.data() as RunDoc
+    const uid = d.ref.parent.parent?.id ?? ''
+    return { uid, score: run.score, longestStreak: run.longestStreak, questionsAnswered: run.answers?.length ?? 0, date: run.endedAt }
+  })
+  const nicknames = await hydrateNicknames(entries.map((e) => e.uid))
+  return entries.map((e) => ({
+    ...e,
+    displayName: nicknames.get(e.uid) || 'Player',
+  }))
+}


### PR DESCRIPTION
## Summary
- Adds a global leaderboard for Infinite Trivia showing top runs by **score** or **longest streak**
- New API route `GET /api/v1/trivia/infinite/leaderboard?sort=score|streak` using collection-group queries on `triviaInfinite`
- New `InfiniteLeaderboard` component with tab switching, current-user highlighting, and medal ranks
- Accessible via "Infinite Ranks" link on the trivia landing page

## Test plan
- [ ] Type check passes (`npx tsc --noEmit`)
- [ ] Navigate to trivia landing → "Infinite Ranks" link visible
- [ ] Leaderboard loads and shows top runs by score (default tab)
- [ ] Switching to "Top Streak" tab shows runs ranked by longest streak
- [ ] Current user's row is highlighted
- [ ] Graceful empty state when no scored runs exist
- [ ] Firestore composite indexes created if needed (error message includes link)

Closes #661

🤖 Generated with [Claude Code](https://claude.com/claude-code)