### PR TITLE
feat: personal run history + end-of-run leaderboard link (#663)

### DIFF
--- a/src/app/api/v1/trivia/infinite/runs/route.ts
+++ b/src/app/api/v1/trivia/infinite/runs/route.ts
@@ -1,8 +1,46 @@
 import { type NextRequest, NextResponse } from 'next/server';
 
 import { verifyRequestAuth } from '@/lib/api/auth';
+import { getFirestoreDb } from '@/lib/firebase/server';
 import { startRun } from '@/lib/trivia/infiniteRuns';
 import { CATEGORY_META } from '@/lib/trivia/categories';
+
+export async function GET(request: NextRequest) {
+  const auth = await verifyRequestAuth(request)
+  if ('error' in auth) return auth.error
+
+  const uid = auth.claims.uid
+  const limitParam = request.nextUrl.searchParams.get('limit')
+  const limit = Math.min(Math.max(parseInt(limitParam || '20', 10) || 20, 1), 50)
+
+  try {
+    const db = getFirestoreDb()
+    const snap = await db
+      .collection(`users/${uid}/triviaInfinite`)
+      .where('endedAt', '!=', null)
+      .orderBy('endedAt', 'desc')
+      .limit(limit)
+      .get()
+
+    const runs = snap.docs.map((d) => {
+      const data = d.data()
+      return {
+        runId: data.runId,
+        mode: data.mode,
+        score: data.score,
+        longestStreak: data.longestStreak,
+        questionsAnswered: data.answers?.length ?? 0,
+        skipsUsed: data.skipsUsed ?? 0,
+        endedAt: data.endedAt?.toMillis() ?? null,
+      }
+    })
+
+    return NextResponse.json({ runs })
+  } catch (error) {
+    console.error('Error fetching run history:', error)
+    return NextResponse.json({ error: 'Failed to fetch runs.' }, { status: 500 })
+  }
+}
 
 export async function POST(request: NextRequest) {
   const auth = await verifyRequestAuth(request);

--- a/src/app/trivia/components/InfiniteGame.tsx
+++ b/src/app/trivia/components/InfiniteGame.tsx
@@ -17,10 +17,11 @@ const RULES_DISMISSED_KEY = 'cometcave-infinite-rules-dismissed-v1'
 interface Props {
   onBack: () => void
   onViewStats?: () => void
+  onViewLeaderboard?: () => void
   mode?: InfiniteMode
 }
 
-export function InfiniteGame({ onBack, onViewStats, mode = 'scored' }: Props) {
+export function InfiniteGame({ onBack, onViewStats, onViewLeaderboard, mode = 'scored' }: Props) {
   const { user, loading: authLoading } = useAuth()
   const { state, startRun, submitAnswer, nextQuestion, skipQuestion, endRun, handleQuestionFlagged } = useInfiniteRun()
   const [timeRemaining, setTimeRemaining] = useState(TIME_LIMIT)
@@ -135,7 +136,7 @@ export function InfiniteGame({ onBack, onViewStats, mode = 'scored' }: Props) {
 
   // End of run
   if (state.phase === 'ended') {
-    return <InfiniteRunSummary state={state} onPlayAgain={handlePlayAgain} onBack={onBack} onViewStats={onViewStats} mode={state.mode} runId={state.runId} onFlagged={handleQuestionFlagged} />
+    return <InfiniteRunSummary state={state} onPlayAgain={handlePlayAgain} onBack={onBack} onViewStats={onViewStats} onViewLeaderboard={onViewLeaderboard} mode={state.mode} runId={state.runId} onFlagged={handleQuestionFlagged} />
   }
 
   // Playing or answered

--- a/src/app/trivia/components/InfiniteRunSummary.tsx
+++ b/src/app/trivia/components/InfiniteRunSummary.tsx
@@ -19,6 +19,7 @@ interface Props {
   onPlayAgain: () => void
   onBack: () => void
   onViewStats?: () => void
+  onViewLeaderboard?: () => void
   mode?: InfiniteMode
   runId?: string | null
   onFlagged?: (questionId: string, result: FlagResult) => void
@@ -41,7 +42,7 @@ const ANSWERS_PAGE_SIZE = 20
 
 type AnswerEntry = InfiniteRunState['answers'][number]
 
-export function InfiniteRunSummary({ state, onPlayAgain, onBack, onViewStats, mode = 'scored', runId, onFlagged }: Props) {
+export function InfiniteRunSummary({ state, onPlayAgain, onBack, onViewStats, onViewLeaderboard, mode = 'scored', runId, onFlagged }: Props) {
   const { user } = useAuth()
   const [copied, setCopied] = useState(false)
   const [showAllAnswers, setShowAllAnswers] = useState(false)
@@ -191,6 +192,12 @@ export function InfiniteRunSummary({ state, onPlayAgain, onBack, onViewStats, mo
       {onViewStats && user && !user.isAnonymous && (
         <ChunkyButton variant="ghost" size="sm" className="w-full" onClick={onViewStats}>
           View Lifetime Stats
+        </ChunkyButton>
+      )}
+
+      {onViewLeaderboard && (
+        <ChunkyButton variant="ghost" size="sm" className="w-full" onClick={onViewLeaderboard}>
+          View Leaderboard
         </ChunkyButton>
       )}
 

--- a/src/app/trivia/components/InfiniteStats.tsx
+++ b/src/app/trivia/components/InfiniteStats.tsx
@@ -7,6 +7,16 @@ import { useAuth } from '@/hooks/useAuth'
 
 import { SignInCard } from './SignInCTA'
 
+interface RunHistoryEntry {
+  runId: string
+  mode: 'scored' | 'practice'
+  score: number
+  longestStreak: number
+  questionsAnswered: number
+  skipsUsed: number
+  endedAt: number | null
+}
+
 interface CategoryStats {
   answered: number
   correct: number
@@ -80,6 +90,8 @@ export function InfiniteStats({ onBack }: { onBack: () => void }) {
   const { user } = useAuth()
   const [stats, setStats] = useState<AggregateStats | null>(null)
   const [loading, setLoading] = useState(true)
+  const [runs, setRuns] = useState<RunHistoryEntry[]>([])
+  const [runsLoading, setRunsLoading] = useState(true)
 
   const fetchStats = useCallback(async () => {
     if (!user) {
@@ -104,6 +116,30 @@ export function InfiniteStats({ onBack }: { onBack: () => void }) {
   useEffect(() => {
     fetchStats()
   }, [fetchStats])
+
+  useEffect(() => {
+    async function loadRuns() {
+      if (!user) {
+        setRunsLoading(false)
+        return
+      }
+      try {
+        const token = await user.getIdToken()
+        const res = await fetch('/api/v1/trivia/infinite/runs?limit=20', {
+          headers: { Authorization: `Bearer ${token}` },
+        })
+        if (res.ok) {
+          const data = await res.json()
+          setRuns(data.runs ?? [])
+        }
+      } catch {
+        // silent
+      } finally {
+        setRunsLoading(false)
+      }
+    }
+    loadRuns()
+  }, [user])
 
   if (loading) {
     return (
@@ -497,6 +533,53 @@ export function InfiniteStats({ onBack }: { onBack: () => void }) {
                 <div className="text-on-surface/50 text-xs mt-1">Reports</div>
               </div>
             </div>
+          </ChunkyCardContent>
+        </ChunkyCard>
+      )}
+
+      {/* Recent Runs */}
+      {runs.length > 0 && (
+        <ChunkyCard
+          variant="surface-variant"
+          className="bg-surface-container/80 border-outline-variant"
+        >
+          <ChunkyCardContent className="pt-5 pb-5">
+            <h3 className="text-on-surface/70 text-sm font-semibold mb-3 uppercase tracking-wide">
+              Recent Runs
+            </h3>
+            <div className="flex flex-col gap-2">
+              {runs.map((run) => {
+                const dateStr = run.endedAt
+                  ? new Date(run.endedAt).toLocaleDateString('en-US', {
+                      month: 'short',
+                      day: 'numeric',
+                    })
+                  : ''
+                return (
+                  <div
+                    key={run.runId}
+                    className="flex items-center justify-between py-2 px-3 rounded bg-surface-dim/40"
+                  >
+                    <div className="flex items-center gap-3 min-w-0">
+                      <div className="text-on-surface/40 text-xs w-12">{dateStr}</div>
+                      <div className="text-on-surface font-medium text-sm">
+                        {run.score.toLocaleString()} pts
+                      </div>
+                      {run.mode === 'practice' && (
+                        <span className="text-on-surface/30 text-xs">(practice)</span>
+                      )}
+                    </div>
+                    <div className="flex items-center gap-3 text-xs text-on-surface/50">
+                      <span>{run.longestStreak} streak</span>
+                      <span>{run.questionsAnswered} Qs</span>
+                    </div>
+                  </div>
+                )
+              })}
+            </div>
+            {runsLoading && (
+              <div className="text-center text-on-surface/50 py-4 text-sm">Loading...</div>
+            )}
           </ChunkyCardContent>
         </ChunkyCard>
       )}

--- a/src/app/trivia/page.tsx
+++ b/src/app/trivia/page.tsx
@@ -135,11 +135,11 @@ export default function TriviaPage() {
   const handleBackToLanding = () => setView('landing')
 
   if (view === 'infinite') {
-    return <InfiniteGame onBack={handleBackToLanding} onViewStats={handleViewInfiniteStats} />
+    return <InfiniteGame onBack={handleBackToLanding} onViewStats={handleViewInfiniteStats} onViewLeaderboard={handleViewLeaderboard} />
   }
 
   if (view === 'practice') {
-    return <InfiniteGame onBack={handleBackToLanding} onViewStats={handleViewInfiniteStats} mode="practice" />
+    return <InfiniteGame onBack={handleBackToLanding} onViewStats={handleViewInfiniteStats} onViewLeaderboard={handleViewLeaderboard} mode="practice" />
   }
 
   if (view === 'infinite-stats') {


### PR DESCRIPTION
## Summary
- Adds a `GET /api/v1/trivia/infinite/runs` endpoint returning the user's last 20 completed runs
- **InfiniteStats** now shows a "Recent Runs" section with score, streak, questions answered, and date for each past run
- **InfiniteRunSummary** gains a "View Leaderboard" button so players can check rankings right after finishing a run
- Wired through InfiniteGame to the trivia page's leaderboard view

## Test plan
- [ ] Type check passes (`npx tsc --noEmit`)
- [ ] After completing an infinite run, "View Leaderboard" button appears
- [ ] Infinite Stats page shows "Recent Runs" section with past runs listed
- [ ] Run history shows correct score, streak, and question count per run
- [ ] Practice runs appear with "(practice)" label
- [ ] API returns 401 for unauthenticated requests

Closes #663

🤖 Generated with [Claude Code](https://claude.com/claude-code)