### PR TITLE
feat: Infinite Trivia enhancements — leaderboard, run history, skip fix, rate limit

### DIFF
--- a/scripts/trivia/generation-limit-stats.ts
+++ b/scripts/trivia/generation-limit-stats.ts
@@ -20,7 +20,8 @@
 import { cert, getApps, initializeApp } from 'firebase-admin/app'
 import { getFirestore } from 'firebase-admin/firestore'
 
-const MAX_GENERATIONS_PER_WINDOW = 30
+// NOTE: keep this in sync with src/lib/trivia/generationLimit.ts
+const MAX_GENERATIONS_PER_WINDOW = 100
 
 function ensureApp() {
   if (getApps().length > 0) return

--- a/src/app/api/v1/trivia/infinite/leaderboard/route.ts
+++ b/src/app/api/v1/trivia/infinite/leaderboard/route.ts
@@ -1,0 +1,41 @@
+import { type NextRequest, NextResponse } from 'next/server'
+
+import { getInfiniteTopByScore, getInfiniteTopByStreak } from '@/lib/trivia/infiniteRuns'
+
+export async function GET(request: NextRequest) {
+  const sort = request.nextUrl.searchParams.get('sort') || 'score'
+
+  try {
+    if (sort === 'score') {
+      const entries = await getInfiniteTopByScore(20)
+      return NextResponse.json({ sort: 'score', entries })
+    }
+
+    if (sort === 'streak') {
+      const entries = await getInfiniteTopByStreak(20)
+      return NextResponse.json({ sort: 'streak', entries })
+    }
+
+    return NextResponse.json(
+      { error: 'Invalid sort. Use score or streak.' },
+      { status: 400 }
+    )
+  } catch (error: unknown) {
+    console.error('Error fetching infinite leaderboard:', error)
+    const errMsg = error instanceof Error ? error.message : String(error)
+    if (
+      errMsg.includes('index') ||
+      errMsg.includes('FAILED_PRECONDITION') ||
+      errMsg.includes('requires an index')
+    ) {
+      const urlMatch = errMsg.match(/(https:\/\/console\.firebase\.google\.com\S+)/)
+      if (urlMatch) console.error('Create index here:', urlMatch[1])
+      return NextResponse.json({
+        sort,
+        entries: [],
+        notice: 'Leaderboard is initializing. Please try again in a few minutes.',
+      })
+    }
+    return NextResponse.json({ error: 'Failed to fetch leaderboard.' }, { status: 500 })
+  }
+}

--- a/src/app/api/v1/trivia/infinite/next/route.ts
+++ b/src/app/api/v1/trivia/infinite/next/route.ts
@@ -4,7 +4,7 @@ import { verifyRequestAuth } from '@/lib/api/auth'
 import type { AIQuestion } from '@/lib/trivia/aiQuestions'
 import { saveAIQuestion } from '@/lib/trivia/aiQuestions'
 import { generateInfiniteQuestion } from '@/lib/trivia/generateQuestion'
-import { checkAndIncrementGenerationLimit } from '@/lib/trivia/generationLimit'
+import { checkAndIncrementGenerationLimit, MAX_GENERATIONS_PER_WINDOW, WINDOW_MS } from '@/lib/trivia/generationLimit'
 import { sampleNextQuestion } from '@/lib/trivia/sampler'
 import { trackExhaustion } from '@/lib/trivia/triviaStats'
 import { CATEGORY_META } from '@/lib/trivia/categories'
@@ -46,8 +46,8 @@ export async function GET(request: NextRequest) {
         console.warn('[trivia/infinite/next] 429 rate limit hit', {
           uid: auth.claims.uid,
           remaining,
-          limitWindowMs: 60 * 60 * 1000,
-          maxPerWindow: 30,
+          limitWindowMs: WINDOW_MS,
+          maxPerWindow: MAX_GENERATIONS_PER_WINDOW,
         })
         return NextResponse.json(
           { error: 'Generation rate limit exceeded. Please try again later.' },

--- a/src/app/api/v1/trivia/infinite/runs/route.ts
+++ b/src/app/api/v1/trivia/infinite/runs/route.ts
@@ -1,8 +1,46 @@
 import { type NextRequest, NextResponse } from 'next/server';
 
 import { verifyRequestAuth } from '@/lib/api/auth';
+import { getFirestoreDb } from '@/lib/firebase/server';
 import { startRun } from '@/lib/trivia/infiniteRuns';
 import { CATEGORY_META } from '@/lib/trivia/categories';
+
+export async function GET(request: NextRequest) {
+  const auth = await verifyRequestAuth(request)
+  if ('error' in auth) return auth.error
+
+  const uid = auth.claims.uid
+  const limitParam = request.nextUrl.searchParams.get('limit')
+  const limit = Math.min(Math.max(parseInt(limitParam || '20', 10) || 20, 1), 50)
+
+  try {
+    const db = getFirestoreDb()
+    const snap = await db
+      .collection(`users/${uid}/triviaInfinite`)
+      .where('endedAt', '!=', null)
+      .orderBy('endedAt', 'desc')
+      .limit(limit)
+      .get()
+
+    const runs = snap.docs.map((d) => {
+      const data = d.data()
+      return {
+        runId: data.runId,
+        mode: data.mode,
+        score: data.score,
+        longestStreak: data.longestStreak,
+        questionsAnswered: data.answers?.length ?? 0,
+        skipsUsed: data.skipsUsed ?? 0,
+        endedAt: data.endedAt?.toMillis() ?? null,
+      }
+    })
+
+    return NextResponse.json({ runs })
+  } catch (error) {
+    console.error('Error fetching run history:', error)
+    return NextResponse.json({ error: 'Failed to fetch runs.' }, { status: 500 })
+  }
+}
 
 export async function POST(request: NextRequest) {
   const auth = await verifyRequestAuth(request);

--- a/src/app/trivia/components/InfiniteGame.tsx
+++ b/src/app/trivia/components/InfiniteGame.tsx
@@ -17,10 +17,11 @@ const RULES_DISMISSED_KEY = 'cometcave-infinite-rules-dismissed-v1'
 interface Props {
   onBack: () => void
   onViewStats?: () => void
+  onViewLeaderboard?: () => void
   mode?: InfiniteMode
 }
 
-export function InfiniteGame({ onBack, onViewStats, mode = 'scored' }: Props) {
+export function InfiniteGame({ onBack, onViewStats, onViewLeaderboard, mode = 'scored' }: Props) {
   const { user, loading: authLoading } = useAuth()
   const { state, startRun, submitAnswer, nextQuestion, skipQuestion, endRun, handleQuestionFlagged } = useInfiniteRun()
   const [timeRemaining, setTimeRemaining] = useState(TIME_LIMIT)
@@ -135,7 +136,7 @@ export function InfiniteGame({ onBack, onViewStats, mode = 'scored' }: Props) {
 
   // End of run
   if (state.phase === 'ended') {
-    return <InfiniteRunSummary state={state} onPlayAgain={handlePlayAgain} onBack={onBack} onViewStats={onViewStats} mode={state.mode} runId={state.runId} onFlagged={handleQuestionFlagged} />
+    return <InfiniteRunSummary state={state} onPlayAgain={handlePlayAgain} onBack={onBack} onViewStats={onViewStats} onViewLeaderboard={onViewLeaderboard} mode={state.mode} runId={state.runId} onFlagged={handleQuestionFlagged} />
   }
 
   // Playing or answered

--- a/src/app/trivia/components/InfiniteLeaderboard.tsx
+++ b/src/app/trivia/components/InfiniteLeaderboard.tsx
@@ -1,0 +1,184 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+
+import { useTriviaUser } from '@/app/trivia/hooks/useTriviaUser'
+import { ChunkyButton } from '@/components/ui/chunky-button'
+import { ChunkyCard, ChunkyCardContent } from '@/components/ui/chunky-card'
+import { Pill } from '@/components/ui/pill'
+import { useAuth } from '@/hooks/useAuth'
+
+import { SignInBanner } from './SignInCTA'
+
+type Sort = 'score' | 'streak'
+
+interface InfiniteLeaderboardEntry {
+  uid: string
+  displayName: string
+  score: number
+  longestStreak: number
+  questionsAnswered: number
+}
+
+interface InfiniteLeaderboardResponse {
+  sort: Sort
+  entries: InfiniteLeaderboardEntry[]
+  notice?: string
+}
+
+export function InfiniteLeaderboard({ onBack }: { onBack: () => void }) {
+  const { user } = useAuth()
+  const { displayName: triviaDisplayName } = useTriviaUser()
+  const [sort, setSort] = useState<Sort>('score')
+  const [loading, setLoading] = useState(true)
+  const [data, setData] = useState<InfiniteLeaderboardResponse | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  const currentUid = user?.uid ?? null
+  const authName = user ? triviaDisplayName || user.email || null : null
+
+  useEffect(() => {
+    async function load() {
+      setLoading(true)
+      setError(null)
+      try {
+        const res = await fetch(`/api/v1/trivia/infinite/leaderboard?sort=${sort}`)
+        if (!res.ok) throw new Error('Failed to load leaderboard')
+        const json = await res.json()
+        setData(json)
+      } catch {
+        setError('Failed to load leaderboard.')
+      } finally {
+        setLoading(false)
+      }
+    }
+    load()
+  }, [sort])
+
+  const renderEntries = () => {
+    if (!data || !data.entries) return null
+
+    if (data.entries.length === 0) {
+      return (
+        <div className="text-center text-on-surface/50 py-8 px-4">
+          {data.notice ?? 'No runs yet. Be the first!'}
+        </div>
+      )
+    }
+
+    return data.entries.map((entry, i) => {
+      const primary = sort === 'score'
+        ? `${entry.score.toLocaleString()} pts`
+        : `${entry.longestStreak} streak`
+      const secondary = sort === 'score'
+        ? `${entry.longestStreak} streak · ${entry.questionsAnswered} Qs`
+        : `${entry.score.toLocaleString()} pts · ${entry.questionsAnswered} Qs`
+
+      return (
+        <LeaderboardRow
+          key={`${entry.uid}-${i}`}
+          rank={i + 1}
+          name={entry.displayName || 'Unknown'}
+          primary={primary}
+          secondary={secondary}
+          isCurrentUser={!!currentUid && entry.uid === currentUid}
+        />
+      )
+    })
+  }
+
+  return (
+    <div className="flex flex-col gap-4 max-w-lg mx-auto py-6">
+      <div className="text-center">
+        <h2 className="text-3xl font-bold text-ds-tertiary mb-1">
+          Infinite Leaderboard
+        </h2>
+        {authName ? (
+          <p className="text-on-surface/50 text-sm">
+            Playing as <span className="text-ds-tertiary">{authName}</span>
+          </p>
+        ) : null}
+      </div>
+
+      {!authName && (
+        <SignInBanner message="Log in to see your rank and compete" cta="Sign in" />
+      )}
+
+      {/* Sort tabs */}
+      <div className="grid grid-cols-2 gap-2">
+        {(['score', 'streak'] as Sort[]).map((s) => (
+          <ChunkyButton
+            key={s}
+            variant={sort === s ? 'primary' : 'secondary'}
+            onClick={() => setSort(s)}
+          >
+            {s === 'score' ? 'Top Score' : 'Top Streak'}
+          </ChunkyButton>
+        ))}
+      </div>
+
+      {/* Content */}
+      <ChunkyCard variant="surface-container-high" className="bg-surface-container/80 border-outline-variant">
+        <ChunkyCardContent className="pt-4 pb-4">
+          {loading ? (
+            <div className="text-center text-on-surface/50 py-8">Loading...</div>
+          ) : error ? (
+            <div className="text-center text-ds-error py-8">{error}</div>
+          ) : (
+            <div className="flex flex-col gap-1.5">{renderEntries()}</div>
+          )}
+        </ChunkyCardContent>
+      </ChunkyCard>
+
+      <ChunkyButton variant="secondary" onClick={onBack} className="w-full">
+        Back to Trivia
+      </ChunkyButton>
+    </div>
+  )
+}
+
+function LeaderboardRow({
+  rank,
+  name,
+  primary,
+  secondary,
+  isCurrentUser,
+}: {
+  rank: number
+  name: string
+  primary: string
+  secondary: string
+  isCurrentUser: boolean
+}) {
+  const rankEmoji = rank === 1 ? '🥇' : rank === 2 ? '🥈' : rank === 3 ? '🥉' : null
+
+  return (
+    <div
+      className={`flex items-center justify-between py-2.5 px-3 rounded ${
+        isCurrentUser
+          ? 'bg-ds-tertiary/20 border border-ds-tertiary/40'
+          : 'bg-surface-dim/40'
+      }`}
+    >
+      <div className="flex items-center gap-3 min-w-0 flex-1">
+        <div className="flex items-center justify-center w-8">
+          {rankEmoji ? (
+            <Pill tone="success">{rankEmoji}</Pill>
+          ) : (
+            <Pill tone="neutral">#{rank}</Pill>
+          )}
+        </div>
+        <div className="min-w-0 flex-1">
+          <div className={`font-medium truncate ${isCurrentUser ? 'text-ds-tertiary' : 'text-on-surface'}`}>
+            {name}
+            {isCurrentUser && <span className="text-xs ml-2 text-ds-tertiary/70">(you)</span>}
+          </div>
+          <div className="text-on-surface/40 text-xs">{secondary}</div>
+        </div>
+      </div>
+      <div className={`font-bold text-right ${isCurrentUser ? 'text-ds-tertiary' : 'text-on-surface'}`}>
+        {primary}
+      </div>
+    </div>
+  )
+}

--- a/src/app/trivia/components/InfiniteRunSummary.tsx
+++ b/src/app/trivia/components/InfiniteRunSummary.tsx
@@ -19,6 +19,7 @@ interface Props {
   onPlayAgain: () => void
   onBack: () => void
   onViewStats?: () => void
+  onViewLeaderboard?: () => void
   mode?: InfiniteMode
   runId?: string | null
   onFlagged?: (questionId: string, result: FlagResult) => void
@@ -41,7 +42,7 @@ const ANSWERS_PAGE_SIZE = 20
 
 type AnswerEntry = InfiniteRunState['answers'][number]
 
-export function InfiniteRunSummary({ state, onPlayAgain, onBack, onViewStats, mode = 'scored', runId, onFlagged }: Props) {
+export function InfiniteRunSummary({ state, onPlayAgain, onBack, onViewStats, onViewLeaderboard, mode = 'scored', runId, onFlagged }: Props) {
   const { user } = useAuth()
   const [copied, setCopied] = useState(false)
   const [showAllAnswers, setShowAllAnswers] = useState(false)
@@ -191,6 +192,12 @@ export function InfiniteRunSummary({ state, onPlayAgain, onBack, onViewStats, mo
       {onViewStats && user && !user.isAnonymous && (
         <ChunkyButton variant="ghost" size="sm" className="w-full" onClick={onViewStats}>
           View Lifetime Stats
+        </ChunkyButton>
+      )}
+
+      {onViewLeaderboard && (
+        <ChunkyButton variant="ghost" size="sm" className="w-full" onClick={onViewLeaderboard}>
+          View Leaderboard
         </ChunkyButton>
       )}
 

--- a/src/app/trivia/components/InfiniteStats.tsx
+++ b/src/app/trivia/components/InfiniteStats.tsx
@@ -7,6 +7,16 @@ import { useAuth } from '@/hooks/useAuth'
 
 import { SignInCard } from './SignInCTA'
 
+interface RunHistoryEntry {
+  runId: string
+  mode: 'scored' | 'practice'
+  score: number
+  longestStreak: number
+  questionsAnswered: number
+  skipsUsed: number
+  endedAt: number | null
+}
+
 interface CategoryStats {
   answered: number
   correct: number
@@ -80,6 +90,8 @@ export function InfiniteStats({ onBack }: { onBack: () => void }) {
   const { user } = useAuth()
   const [stats, setStats] = useState<AggregateStats | null>(null)
   const [loading, setLoading] = useState(true)
+  const [runs, setRuns] = useState<RunHistoryEntry[]>([])
+  const [runsLoading, setRunsLoading] = useState(true)
 
   const fetchStats = useCallback(async () => {
     if (!user) {
@@ -104,6 +116,30 @@ export function InfiniteStats({ onBack }: { onBack: () => void }) {
   useEffect(() => {
     fetchStats()
   }, [fetchStats])
+
+  useEffect(() => {
+    async function loadRuns() {
+      if (!user) {
+        setRunsLoading(false)
+        return
+      }
+      try {
+        const token = await user.getIdToken()
+        const res = await fetch('/api/v1/trivia/infinite/runs?limit=20', {
+          headers: { Authorization: `Bearer ${token}` },
+        })
+        if (res.ok) {
+          const data = await res.json()
+          setRuns(data.runs ?? [])
+        }
+      } catch {
+        // silent
+      } finally {
+        setRunsLoading(false)
+      }
+    }
+    loadRuns()
+  }, [user])
 
   if (loading) {
     return (
@@ -497,6 +533,53 @@ export function InfiniteStats({ onBack }: { onBack: () => void }) {
                 <div className="text-on-surface/50 text-xs mt-1">Reports</div>
               </div>
             </div>
+          </ChunkyCardContent>
+        </ChunkyCard>
+      )}
+
+      {/* Recent Runs */}
+      {runs.length > 0 && (
+        <ChunkyCard
+          variant="surface-variant"
+          className="bg-surface-container/80 border-outline-variant"
+        >
+          <ChunkyCardContent className="pt-5 pb-5">
+            <h3 className="text-on-surface/70 text-sm font-semibold mb-3 uppercase tracking-wide">
+              Recent Runs
+            </h3>
+            <div className="flex flex-col gap-2">
+              {runs.map((run) => {
+                const dateStr = run.endedAt
+                  ? new Date(run.endedAt).toLocaleDateString('en-US', {
+                      month: 'short',
+                      day: 'numeric',
+                    })
+                  : ''
+                return (
+                  <div
+                    key={run.runId}
+                    className="flex items-center justify-between py-2 px-3 rounded bg-surface-dim/40"
+                  >
+                    <div className="flex items-center gap-3 min-w-0">
+                      <div className="text-on-surface/40 text-xs w-12">{dateStr}</div>
+                      <div className="text-on-surface font-medium text-sm">
+                        {run.score.toLocaleString()} pts
+                      </div>
+                      {run.mode === 'practice' && (
+                        <span className="text-on-surface/30 text-xs">(practice)</span>
+                      )}
+                    </div>
+                    <div className="flex items-center gap-3 text-xs text-on-surface/50">
+                      <span>{run.longestStreak} streak</span>
+                      <span>{run.questionsAnswered} Qs</span>
+                    </div>
+                  </div>
+                )
+              })}
+            </div>
+            {runsLoading && (
+              <div className="text-center text-on-surface/50 py-4 text-sm">Loading...</div>
+            )}
           </ChunkyCardContent>
         </ChunkyCard>
       )}

--- a/src/app/trivia/components/TriviaLanding.tsx
+++ b/src/app/trivia/components/TriviaLanding.tsx
@@ -23,6 +23,7 @@ export function TriviaLanding({
   onStartInfinite,
   onViewInfiniteStats,
   onStartPractice,
+  onViewInfiniteLeaderboard,
   todayResult,
 }: {
   onStartGame?: () => void
@@ -31,6 +32,7 @@ export function TriviaLanding({
   onStartInfinite?: () => void
   onViewInfiniteStats?: () => void
   onStartPractice?: () => void
+  onViewInfiniteLeaderboard?: () => void
   todayResult: TriviaGameResult | null
 }) {
   const { user, loading: authLoading, configured: authConfigured, signOut } = useAuth()
@@ -238,6 +240,13 @@ export function TriviaLanding({
           className="text-ds-tertiary hover:text-ds-tertiary/80 transition-colors underline-offset-4 hover:underline"
         >
           Infinite Stats
+        </button>
+        <span className="text-on-surface/20">·</span>
+        <button
+          onClick={onViewInfiniteLeaderboard}
+          className="text-ds-tertiary hover:text-ds-tertiary/80 transition-colors underline-offset-4 hover:underline"
+        >
+          Infinite Ranks
         </button>
       </div>
 

--- a/src/app/trivia/components/TriviaStats.tsx
+++ b/src/app/trivia/components/TriviaStats.tsx
@@ -186,13 +186,21 @@ export function TriviaStats({ onBack }: { onBack: () => void }) {
                   key={game.date}
                   className="flex items-center justify-between py-2 px-3 rounded bg-surface-dim/40"
                 >
-                  <div className="flex flex-col">
-                    <span className="text-on-surface text-sm font-medium">
-                      {formatDisplayDate(game.date)}
-                    </span>
-                    <span className="text-on-surface/40 text-xs">
-                      {game.correct}/{game.total} correct
-                    </span>
+                  <div className="flex items-center gap-2">
+                    {game.category && (
+                      <span className="text-lg" title={game.category.name}>
+                        {game.category.icon}
+                      </span>
+                    )}
+                    <div className="flex flex-col">
+                      <span className="text-on-surface text-sm font-medium">
+                        {formatDisplayDate(game.date)}
+                      </span>
+                      <span className="text-on-surface/40 text-xs">
+                        {game.correct}/{game.total} correct
+                        {game.category && ` · ${game.category.name}`}
+                      </span>
+                    </div>
                   </div>
                   <div className="flex items-center gap-3">
                     {/* Visual bar */}

--- a/src/app/trivia/hooks/useTriviaUser.ts
+++ b/src/app/trivia/hooks/useTriviaUser.ts
@@ -64,13 +64,17 @@ function normalizeStats(data: DocumentData | undefined): TriviaStats {
 }
 
 function normalizeGame(data: DocumentData): TriviaGameResult {
-  return {
+  const result: TriviaGameResult = {
     date: typeof data.date === 'string' ? data.date : '',
     score: typeof data.score === 'number' ? data.score : 0,
     correct: typeof data.correct === 'number' ? data.correct : 0,
     total: typeof data.total === 'number' ? data.total : 0,
     answers: Array.isArray(data.answers) ? data.answers : [],
   }
+  if (data.category && typeof data.category === 'object' && typeof data.category.name === 'string') {
+    result.category = data.category
+  }
+  return result
 }
 
 export interface UseTriviaUserResult {

--- a/src/app/trivia/models/trivia.ts
+++ b/src/app/trivia/models/trivia.ts
@@ -11,6 +11,7 @@ export interface TriviaGameResult {
   correct: number
   total: number
   answers: TriviaAnswer[]
+  category?: { id: number; name: string; icon: string }
 }
 
 export interface TriviaStats {

--- a/src/app/trivia/page.tsx
+++ b/src/app/trivia/page.tsx
@@ -14,6 +14,7 @@ import { getTodayPST } from '@/lib/dates'
 import { getDailyCategory } from '@/lib/trivia/categories'
 
 import { InfiniteGame } from './components/InfiniteGame'
+import { InfiniteLeaderboard } from './components/InfiniteLeaderboard'
 import { InfiniteStats } from './components/InfiniteStats'
 import { TriviaGame } from './components/TriviaGame'
 import { TriviaLanding } from './components/TriviaLanding'
@@ -24,7 +25,7 @@ import { TriviaStats } from './components/TriviaStats'
 import type { TriviaGameResult } from './models/trivia'
 import type { User } from 'firebase/auth'
 
-type View = 'landing' | 'playing' | 'results' | 'stats' | 'leaderboard' | 'infinite' | 'infinite-stats' | 'practice'
+type View = 'landing' | 'playing' | 'results' | 'stats' | 'leaderboard' | 'infinite' | 'infinite-stats' | 'practice' | 'infinite-leaderboard'
 
 async function submitGameToServer(user: User, result: TriviaGameResult): Promise<void> {
   const token = await user.getIdToken()
@@ -114,6 +115,7 @@ export default function TriviaPage() {
   const handleStartInfinite = () => setView('infinite')
   const handleViewInfiniteStats = () => setView('infinite-stats')
   const handleStartPractice = () => setView('practice')
+  const handleViewInfiniteLeaderboard = () => setView('infinite-leaderboard')
 
   const handleFinish = useCallback(
     (result: TriviaGameResult) => {
@@ -170,6 +172,10 @@ export default function TriviaPage() {
     return <TriviaLeaderboard onBack={handleBackToLanding} />
   }
 
+  if (view === 'infinite-leaderboard') {
+    return <InfiniteLeaderboard onBack={handleBackToLanding} />
+  }
+
   return (
     <TriviaLanding
       onStartGame={handleStartGame}
@@ -178,6 +184,7 @@ export default function TriviaPage() {
       onStartInfinite={handleStartInfinite}
       onViewInfiniteStats={handleViewInfiniteStats}
       onStartPractice={handleStartPractice}
+      onViewInfiniteLeaderboard={handleViewInfiniteLeaderboard}
       todayResult={todayResult}
     />
   )

--- a/src/app/trivia/page.tsx
+++ b/src/app/trivia/page.tsx
@@ -135,11 +135,11 @@ export default function TriviaPage() {
   const handleBackToLanding = () => setView('landing')
 
   if (view === 'infinite') {
-    return <InfiniteGame onBack={handleBackToLanding} onViewStats={handleViewInfiniteStats} />
+    return <InfiniteGame onBack={handleBackToLanding} onViewStats={handleViewInfiniteStats} onViewLeaderboard={handleViewLeaderboard} />
   }
 
   if (view === 'practice') {
-    return <InfiniteGame onBack={handleBackToLanding} onViewStats={handleViewInfiniteStats} mode="practice" />
+    return <InfiniteGame onBack={handleBackToLanding} onViewStats={handleViewInfiniteStats} onViewLeaderboard={handleViewLeaderboard} mode="practice" />
   }
 
   if (view === 'infinite-stats') {

--- a/src/app/trivia/page.tsx
+++ b/src/app/trivia/page.tsx
@@ -137,11 +137,11 @@ export default function TriviaPage() {
   const handleBackToLanding = () => setView('landing')
 
   if (view === 'infinite') {
-    return <InfiniteGame onBack={handleBackToLanding} onViewStats={handleViewInfiniteStats} onViewLeaderboard={handleViewLeaderboard} />
+    return <InfiniteGame onBack={handleBackToLanding} onViewStats={handleViewInfiniteStats} onViewLeaderboard={handleViewInfiniteLeaderboard} />
   }
 
   if (view === 'practice') {
-    return <InfiniteGame onBack={handleBackToLanding} onViewStats={handleViewInfiniteStats} onViewLeaderboard={handleViewLeaderboard} mode="practice" />
+    return <InfiniteGame onBack={handleBackToLanding} onViewStats={handleViewInfiniteStats} onViewLeaderboard={handleViewInfiniteLeaderboard} mode="practice" />
   }
 
   if (view === 'infinite-stats') {

--- a/src/lib/trivia/generationLimit.ts
+++ b/src/lib/trivia/generationLimit.ts
@@ -2,8 +2,8 @@ import { Timestamp } from 'firebase-admin/firestore'
 
 import { getFirestoreDb } from '@/lib/firebase/server'
 
-const WINDOW_MS = 60 * 60 * 1000 // 1 hour
-const MAX_GENERATIONS_PER_WINDOW = 100
+export const WINDOW_MS = 60 * 60 * 1000 // 1 hour
+export const MAX_GENERATIONS_PER_WINDOW = 100
 
 /**
  * Atomically check whether the given uid has exceeded the on-demand generation

--- a/src/lib/trivia/infiniteRuns.ts
+++ b/src/lib/trivia/infiniteRuns.ts
@@ -202,3 +202,72 @@ export async function endRun(uid: string, runId: string): Promise<void> {
     console.error('[endRun] Failed to apply run to aggregate:', err)
   )
 }
+
+export interface InfiniteLeaderboardEntry {
+  uid: string
+  displayName: string
+  score: number
+  longestStreak: number
+  questionsAnswered: number
+  date: FirebaseFirestore.Timestamp | null
+}
+
+async function hydrateNicknames(uids: string[]): Promise<Map<string, string>> {
+  if (uids.length === 0) return new Map()
+  const db = getFirestoreDb()
+  const refs = uids.map((uid) => db.doc(`users/${uid}`))
+  const snaps = await db.getAll(...refs)
+  const map = new Map<string, string>()
+  for (const snap of snaps) {
+    if (!snap.exists) continue
+    const data = snap.data() as { uid?: string; nickname?: string }
+    if (data?.uid) {
+      map.set(data.uid, data.nickname ?? '')
+    }
+  }
+  return map
+}
+
+export async function getInfiniteTopByScore(limit = 20): Promise<InfiniteLeaderboardEntry[]> {
+  const db = getFirestoreDb()
+  const snap = await db
+    .collectionGroup('triviaInfinite')
+    .where('mode', '==', 'scored')
+    .where('endedAt', '!=', null)
+    .orderBy('score', 'desc')
+    .limit(limit)
+    .get()
+
+  const entries = snap.docs.map((d) => {
+    const run = d.data() as RunDoc
+    const uid = d.ref.parent.parent?.id ?? ''
+    return { uid, score: run.score, longestStreak: run.longestStreak, questionsAnswered: run.answers?.length ?? 0, date: run.endedAt }
+  })
+  const nicknames = await hydrateNicknames(entries.map((e) => e.uid))
+  return entries.map((e) => ({
+    ...e,
+    displayName: nicknames.get(e.uid) || 'Player',
+  }))
+}
+
+export async function getInfiniteTopByStreak(limit = 20): Promise<InfiniteLeaderboardEntry[]> {
+  const db = getFirestoreDb()
+  const snap = await db
+    .collectionGroup('triviaInfinite')
+    .where('mode', '==', 'scored')
+    .where('endedAt', '!=', null)
+    .orderBy('longestStreak', 'desc')
+    .limit(limit)
+    .get()
+
+  const entries = snap.docs.map((d) => {
+    const run = d.data() as RunDoc
+    const uid = d.ref.parent.parent?.id ?? ''
+    return { uid, score: run.score, longestStreak: run.longestStreak, questionsAnswered: run.answers?.length ?? 0, date: run.endedAt }
+  })
+  const nicknames = await hydrateNicknames(entries.map((e) => e.uid))
+  return entries.map((e) => ({
+    ...e,
+    displayName: nicknames.get(e.uid) || 'Player',
+  }))
+}


### PR DESCRIPTION
## Summary

Integration branch collecting several Infinite Trivia enhancements built this session:

- **Skip mechanic** (#657/658) — Players get 2 skips per infinite run at no cost
- **Rate limit constant fix** (#626/660) — 429 log and telemetry script now reference the actual 100/hr limit instead of the stale 30/hr value; constants exported for single-source-of-truth
- **Global leaderboard** (#661/662) — New `GET /api/v1/trivia/infinite/leaderboard?sort=score|streak` endpoint + `InfiniteLeaderboard` UI with Top Score / Top Streak tabs, accessible from landing page via "Infinite Ranks"
- **Personal run history** (#663/664) — New `GET /api/v1/trivia/infinite/runs` endpoint + "Recent Runs" section in InfiniteStats showing past runs with score, streak, questions, and date
- **End-of-run leaderboard link** — "View Leaderboard" button in run summary navigates to the infinite leaderboard
- **Post-merge wiring fix** — Ensured infinite game's leaderboard button correctly targets the infinite leaderboard (not daily)

## New files
- `src/app/api/v1/trivia/infinite/leaderboard/route.ts`
- `src/app/trivia/components/InfiniteLeaderboard.tsx`

## Modified files
- `src/lib/trivia/infiniteRuns.ts` — leaderboard query functions + nickname hydration
- `src/lib/trivia/generationLimit.ts` — exported constants
- `src/app/api/v1/trivia/infinite/next/route.ts` — use exported constants in 429 log
- `src/app/api/v1/trivia/infinite/runs/route.ts` — added GET handler for run history
- `src/app/trivia/page.tsx` — infinite-leaderboard view + wiring
- `src/app/trivia/components/TriviaLanding.tsx` — "Infinite Ranks" link
- `src/app/trivia/components/InfiniteGame.tsx` — leaderboard callback prop
- `src/app/trivia/components/InfiniteRunSummary.tsx` — "View Leaderboard" button
- `src/app/trivia/components/InfiniteStats.tsx` — "Recent Runs" section
- `scripts/trivia/generation-limit-stats.ts` — updated constant to 100

## Test plan
- [ ] Infinite trivia skip mechanic works (2 skips per run)
- [ ] Landing page shows "Infinite Ranks" link → opens infinite leaderboard
- [ ] Leaderboard shows top runs by score (default) and by streak (tab switch)
- [ ] After completing a run, "View Leaderboard" button navigates to infinite leaderboard
- [ ] Infinite Stats page shows "Recent Runs" with past run history
- [ ] Rate limit 429 log shows `maxPerWindow: 100` (not 30)
- [ ] Type check passes (`npx tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)