### PR TITLE
feat: show daily category in stats history

### DIFF
--- a/src/app/trivia/components/TriviaStats.tsx
+++ b/src/app/trivia/components/TriviaStats.tsx
@@ -186,13 +186,21 @@ export function TriviaStats({ onBack }: { onBack: () => void }) {
                   key={game.date}
                   className="flex items-center justify-between py-2 px-3 rounded bg-surface-dim/40"
                 >
-                  <div className="flex flex-col">
-                    <span className="text-on-surface text-sm font-medium">
-                      {formatDisplayDate(game.date)}
-                    </span>
-                    <span className="text-on-surface/40 text-xs">
-                      {game.correct}/{game.total} correct
-                    </span>
+                  <div className="flex items-center gap-2">
+                    {game.category && (
+                      <span className="text-lg" title={game.category.name}>
+                        {game.category.icon}
+                      </span>
+                    )}
+                    <div className="flex flex-col">
+                      <span className="text-on-surface text-sm font-medium">
+                        {formatDisplayDate(game.date)}
+                      </span>
+                      <span className="text-on-surface/40 text-xs">
+                        {game.correct}/{game.total} correct
+                        {game.category && ` · ${game.category.name}`}
+                      </span>
+                    </div>
                   </div>
                   <div className="flex items-center gap-3">
                     {/* Visual bar */}

--- a/src/app/trivia/hooks/useTriviaUser.ts
+++ b/src/app/trivia/hooks/useTriviaUser.ts
@@ -64,13 +64,17 @@ function normalizeStats(data: DocumentData | undefined): TriviaStats {
 }
 
 function normalizeGame(data: DocumentData): TriviaGameResult {
-  return {
+  const result: TriviaGameResult = {
     date: typeof data.date === 'string' ? data.date : '',
     score: typeof data.score === 'number' ? data.score : 0,
     correct: typeof data.correct === 'number' ? data.correct : 0,
     total: typeof data.total === 'number' ? data.total : 0,
     answers: Array.isArray(data.answers) ? data.answers : [],
   }
+  if (data.category && typeof data.category === 'object' && typeof data.category.name === 'string') {
+    result.category = data.category
+  }
+  return result
 }
 
 export interface UseTriviaUserResult {

--- a/src/app/trivia/models/trivia.ts
+++ b/src/app/trivia/models/trivia.ts
@@ -11,6 +11,7 @@ export interface TriviaGameResult {
   correct: number
   total: number
   answers: TriviaAnswer[]
+  category?: { id: number; name: string; icon: string }
 }
 
 export interface TriviaStats {


### PR DESCRIPTION
## Summary
- Daily trivia game docs already store the category (id, name, icon) in Firestore, but it wasn't surfaced in the stats page
- Added optional `category` field to `TriviaGameResult` model
- Updated `normalizeGame` to extract category from Firestore docs
- Each "Recent Games" row in TriviaStats now shows the category emoji + name

## Test plan
- [ ] Type check passes
- [ ] Stats page "Recent Games" shows category icon next to each date
- [ ] Category name appears in the secondary line (e.g., "5/7 correct · Science")
- [ ] Games without category data (pre-existing) still render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)