### PR TITLE
feat: public daily trivia share page with OG metadata

### DIFF
--- a/src/app/api/v1/trivia/daily/[date]/[uid]/route.ts
+++ b/src/app/api/v1/trivia/daily/[date]/[uid]/route.ts
@@ -1,0 +1,47 @@
+import { type NextRequest, NextResponse } from 'next/server'
+
+import { getFirestoreDb } from '@/lib/firebase/server'
+
+interface PageParams {
+  params: Promise<{ date: string; uid: string }>
+}
+
+export async function GET(_request: NextRequest, { params }: PageParams) {
+  const { date, uid } = await params
+
+  // Validate date format YYYY-MM-DD
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) {
+    return NextResponse.json({ error: 'Invalid date format' }, { status: 400 })
+  }
+
+  try {
+    const db = getFirestoreDb()
+    const snap = await db.doc(`users/${uid}/triviaGames/${date}`).get()
+    if (!snap.exists) {
+      return NextResponse.json({ error: 'Result not found' }, { status: 404 })
+    }
+
+    const data = snap.data()!
+    // Get nickname
+    const userSnap = await db.doc(`users/${uid}`).get()
+    const nickname = userSnap.exists ? (userSnap.data()?.nickname ?? '') : ''
+
+    // Build emoji grid from answers (correct/incorrect only, no question content)
+    const grid = Array.isArray(data.answers)
+      ? data.answers.map((a: { correct: boolean }) => (a.correct ? '🟩' : '🟥')).join('')
+      : ''
+
+    return NextResponse.json({
+      date: data.date,
+      score: data.score,
+      correct: data.correct,
+      total: data.total,
+      grid,
+      category: data.category ?? null,
+      nickname,
+    })
+  } catch (error) {
+    console.error('Error fetching daily result:', error)
+    return NextResponse.json({ error: 'Failed to fetch result' }, { status: 500 })
+  }
+}

--- a/src/app/trivia/components/TriviaResults.tsx
+++ b/src/app/trivia/components/TriviaResults.tsx
@@ -111,10 +111,17 @@ export function TriviaResults({ result, onBack, onViewStats, onViewLeaderboard, 
 
   const handleShare = async () => {
     const playerName = isNamedUser && user ? displayName || user.email || null : null
-    const text = getShareText(result, {
+    let text = getShareText(result, {
       streak: isNamedUser ? currentStreak : undefined,
       playerName,
     })
+    // Replace generic trivia link with personalized share page if signed in
+    if (user && !user.isAnonymous) {
+      text = text.replace(
+        'https://cometcave.com/trivia',
+        `https://cometcave.com/trivia/daily/${result.date}/${user.uid}`
+      )
+    }
     try {
       await navigator.clipboard.writeText(text)
       setCopied(true)

--- a/src/app/trivia/daily/[date]/[uid]/DailySharePage.tsx
+++ b/src/app/trivia/daily/[date]/[uid]/DailySharePage.tsx
@@ -1,0 +1,86 @@
+'use client'
+import { ChunkyButton } from '@/components/ui/chunky-button'
+import { ChunkyCard, ChunkyCardContent } from '@/components/ui/chunky-card'
+
+interface DailyResult {
+  date: string
+  score: number
+  correct: number
+  total: number
+  grid: string
+  category: { id: number; name: string; icon: string } | null
+  nickname: string
+}
+
+export function DailySharePage({ result }: { result: DailyResult }) {
+  const displayDate = new Date(result.date + 'T12:00:00').toLocaleDateString('en-US', {
+    weekday: 'long',
+    month: 'long',
+    day: 'numeric',
+  })
+  const accuracy = result.total > 0 ? Math.round((result.correct / result.total) * 100) : 0
+
+  return (
+    <div className="flex flex-col items-center gap-6 max-w-lg mx-auto py-10 px-4">
+      <div className="text-center">
+        <h1 className="font-headline text-headline-lg text-ds-tertiary drop-shadow-[0_4px_0_var(--surface-container-lowest)] mb-2">
+          CometCave Daily Trivia
+        </h1>
+        <p className="text-on-surface/50 text-sm">{displayDate}</p>
+        {result.nickname && (
+          <p className="text-on-surface/60 text-sm mt-1">
+            Played by <span className="text-ds-tertiary font-medium">{result.nickname}</span>
+          </p>
+        )}
+      </div>
+
+      {result.category && (
+        <div className="flex items-center gap-2 text-lg">
+          <span className="text-2xl">{result.category.icon}</span>
+          <span className="text-on-surface/70 font-medium">{result.category.name}</span>
+        </div>
+      )}
+
+      <ChunkyCard variant="surface-variant" className="w-full bg-surface-container/80 border-outline-variant">
+        <ChunkyCardContent className="pt-6">
+          {result.grid && (
+            <div className="text-center mb-4">
+              <div className="text-3xl tracking-wider">{result.grid}</div>
+            </div>
+          )}
+
+          <div className="text-center mb-4">
+            <div className="text-5xl font-bold text-ds-tertiary">
+              {result.correct}/{result.total}
+            </div>
+            <div className="text-on-surface/40 text-sm mt-1">Correct Answers</div>
+          </div>
+
+          <div className="grid grid-cols-2 gap-3">
+            <div className="text-center">
+              <div className="text-xl font-bold text-on-surface">{result.score.toLocaleString()}</div>
+              <div className="text-on-surface/50 text-xs">Score</div>
+            </div>
+            <div className="text-center">
+              <div className="text-xl font-bold text-on-surface">{accuracy}%</div>
+              <div className="text-on-surface/50 text-xs">Accuracy</div>
+            </div>
+          </div>
+        </ChunkyCardContent>
+      </ChunkyCard>
+
+      <ChunkyButton
+        variant="primary"
+        size="hero"
+        className="w-full"
+        onClick={() => window.location.href = '/trivia'}
+      >
+        Play Today&apos;s Trivia
+      </ChunkyButton>
+
+      <p className="text-on-surface/30 text-xs text-center">
+        CometCave — daily trivia adventure
+      </p>
+    </div>
+  )
+}

--- a/src/app/trivia/daily/[date]/[uid]/page.tsx
+++ b/src/app/trivia/daily/[date]/[uid]/page.tsx
@@ -1,0 +1,53 @@
+import { Metadata } from 'next'
+import { notFound } from 'next/navigation'
+import { getFirestoreDb } from '@/lib/firebase/server'
+import { getDailyCategory } from '@/lib/trivia/categories'
+import { DailySharePage } from './DailySharePage'
+
+interface PageProps {
+  params: Promise<{ date: string; uid: string }>
+}
+
+async function getDailyResult(date: string, uid: string) {
+  const db = getFirestoreDb()
+  const snap = await db.doc(`users/${uid}/triviaGames/${date}`).get()
+  if (!snap.exists) return null
+  const data = snap.data()!
+  const userSnap = await db.doc(`users/${uid}`).get()
+  const nickname = userSnap.exists ? (userSnap.data()?.nickname ?? '') : ''
+  const grid = Array.isArray(data.answers)
+    ? data.answers.map((a: { correct: boolean }) => (a.correct ? '🟩' : '🟥')).join('')
+    : ''
+  return {
+    date: data.date as string,
+    score: data.score as number,
+    correct: data.correct as number,
+    total: data.total as number,
+    grid,
+    category: data.category as { id: number; name: string; icon: string } | null,
+    nickname,
+  }
+}
+
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+  const { date, uid } = await params
+  const result = await getDailyResult(date, uid)
+  if (!result) return { title: 'Result Not Found — CometCave' }
+  const category = result.category ?? getDailyCategory(date)
+  const displayDate = new Date(date + 'T12:00:00').toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
+  const title = `${category.icon} ${result.correct}/${result.total} — CometCave Daily Trivia`
+  const description = `Score: ${result.score.toLocaleString()} · ${displayDate} · ${category.name}`
+  return {
+    title,
+    description,
+    openGraph: { title, description },
+    twitter: { card: 'summary', title, description },
+  }
+}
+
+export default async function Page({ params }: PageProps) {
+  const { date, uid } = await params
+  const result = await getDailyResult(date, uid)
+  if (!result) notFound()
+  return <DailySharePage result={result} />
+}


### PR DESCRIPTION
## Summary
- Adds a public share page for daily trivia results at `/trivia/daily/[date]/[uid]`
- Players can now share a link (not just clipboard text) to their daily performance
- Page shows: date, category, emoji grid, correct/total, score, accuracy
- OG + Twitter metadata for social card previews
- Share text in TriviaResults now includes personalized URL for signed-in users
- API returns stats only (no question text/answers) for privacy

## New files
- `src/app/api/v1/trivia/daily/[date]/[uid]/route.ts` — public stats API
- `src/app/trivia/daily/[date]/[uid]/page.tsx` — server-rendered share page
- `src/app/trivia/daily/[date]/[uid]/DailySharePage.tsx` — client component

## Test plan
- [ ] Type check passes
- [ ] Visit `/trivia/daily/2026-04-29/{uid}` shows result page
- [ ] 404 returned for non-existent results
- [ ] OG metadata renders correctly (check with og:image debugger)
- [ ] Share text includes personalized URL for signed-in users
- [ ] Anonymous users still get generic trivia link in share text
- [ ] No question text or answers are exposed in the API response

🤖 Generated with [Claude Code](https://claude.com/claude-code)