### PR TITLE
feat: show community accuracy after infinite trivia answers (#671)

### DIFF
--- a/src/app/api/v1/trivia/infinite/runs/[runId]/answer/route.ts
+++ b/src/app/api/v1/trivia/infinite/runs/[runId]/answer/route.ts
@@ -42,10 +42,18 @@ export async function POST(
       elapsedMs: typeof elapsedMs === 'number' ? elapsedMs : 0,
     });
 
+    // Read updated question stats for community accuracy
+    const updatedQSnap = await db.doc(`aiQuestions/${questionId}`).get();
+    const updatedQ = updatedQSnap.data();
+    const timesShown = updatedQ?.timesShown ?? 1;
+    const timesCorrect = updatedQ?.timesCorrect ?? 0;
+
     return NextResponse.json({
       ...result,
       correctAnswer: qData.correctAnswer,
       explanation: qData.explanation ?? null,
+      timesShown,
+      timesCorrect,
     });
   } catch (err: unknown) {
     const message = err instanceof Error ? err.message : String(err);

--- a/src/app/api/v1/trivia/infinite/runs/[runId]/skip/route.ts
+++ b/src/app/api/v1/trivia/infinite/runs/[runId]/skip/route.ts
@@ -18,9 +18,11 @@ export async function POST(
     const { questionId } = body;
     await recordSkip(auth.claims.uid, runId, questionId ?? '');
 
-    // Return the correct answer so the client can show it
+    // Return the correct answer and community stats so the client can show them
     let correctAnswer: string | null = null;
     let explanation: string | null = null;
+    let timesShown = 0;
+    let timesCorrect = 0;
     if (questionId) {
       const db = getFirestoreDb();
       const qSnap = await db.doc(`aiQuestions/${questionId}`).get();
@@ -28,10 +30,12 @@ export async function POST(
         const qData = qSnap.data()!;
         correctAnswer = qData.correctAnswer ?? null;
         explanation = qData.explanation ?? null;
+        timesShown = qData.timesShown ?? 0;
+        timesCorrect = qData.timesCorrect ?? 0;
       }
     }
 
-    return NextResponse.json({ ok: true, correctAnswer, explanation });
+    return NextResponse.json({ ok: true, correctAnswer, explanation, timesShown, timesCorrect });
   } catch (err: unknown) {
     console.error('Failed to record skip:', err);
     return NextResponse.json({ error: 'Failed to record skip.' }, { status: 500 });

--- a/src/app/trivia/components/InfiniteQuestionCard.tsx
+++ b/src/app/trivia/components/InfiniteQuestionCard.tsx
@@ -166,7 +166,7 @@ export function InfiniteQuestionCard({
               )
             })() : answerResult.timesShown != null && answerResult.timesShown > 0 ? (
               <div className="text-on-surface/40 text-sm mt-2">
-                You&apos;re one of the first to answer this!
+                {answerResult.timesCorrect ?? 0} of {answerResult.timesShown} other {answerResult.timesShown === 1 ? 'person' : 'people'} answered this correctly
               </div>
             ) : null}
           </div>

--- a/src/app/trivia/components/InfiniteQuestionCard.tsx
+++ b/src/app/trivia/components/InfiniteQuestionCard.tsx
@@ -17,7 +17,7 @@ interface Props {
   question: InfiniteQuestion
   onSubmit: (answer: string) => void
   isSubmitting: boolean
-  answerResult: (AnswerResult & { trailblazer: boolean; correctAnswer: string; explanation: string | null }) | null
+  answerResult: (AnswerResult & { trailblazer: boolean; correctAnswer: string; explanation: string | null; timesShown?: number; timesCorrect?: number }) | null
   questionsAnswered: number
   runId?: string | null
   onFlagged?: (questionId: string, result: FlagResult) => void
@@ -155,6 +155,20 @@ export function InfiniteQuestionCard({
                 {answerResult.explanation}
               </div>
             )}
+            {/* Community accuracy */}
+            {answerResult.timesShown != null && answerResult.timesShown >= 5 ? (() => {
+              const pct = Math.round(((answerResult.timesCorrect ?? 0) / answerResult.timesShown) * 100)
+              const color = pct > 70 ? 'text-ds-primary' : pct > 40 ? 'text-yellow-400' : 'text-ds-error'
+              return (
+                <div className={`text-sm mt-2 ${color}`}>
+                  {pct}% of players got this right
+                </div>
+              )
+            })() : answerResult.timesShown != null && answerResult.timesShown > 0 ? (
+              <div className="text-on-surface/40 text-sm mt-2">
+                You&apos;re one of the first to answer this!
+              </div>
+            ) : null}
           </div>
         )}
       </ChunkyCardContent>

--- a/src/app/trivia/hooks/useInfiniteRun.ts
+++ b/src/app/trivia/hooks/useInfiniteRun.ts
@@ -30,7 +30,7 @@ export interface InfiniteRunState {
   skipsRemaining: number
   skipsUsed: number
   flaggedQuestionIds: string[]
-  lastAnswer: (AnswerResult & { trailblazer: boolean; correctAnswer: string; explanation: string | null }) | null
+  lastAnswer: (AnswerResult & { trailblazer: boolean; correctAnswer: string; explanation: string | null; timesShown?: number; timesCorrect?: number }) | null
   answers: Array<{
     questionId: string
     correct: boolean
@@ -295,7 +295,7 @@ export function useInfiniteRun() {
         headers,
         body: JSON.stringify({ questionId }),
       })
-      const skipData: { correctAnswer: string | null; explanation: string | null } = skipRes.ok
+      const skipData: { correctAnswer: string | null; explanation: string | null; timesShown?: number; timesCorrect?: number } = skipRes.ok
         ? await skipRes.json()
         : { correctAnswer: null, explanation: null }
 
@@ -315,6 +315,8 @@ export function useInfiniteRun() {
           runOver: false,
           correctAnswer,
           explanation,
+          timesShown: skipData.timesShown,
+          timesCorrect: skipData.timesCorrect,
         }
         return {
           ...s,


### PR DESCRIPTION
## Summary
After answering or skipping an infinite trivia question, shows what percentage of other players got it right.

- **>= 5 answers**: "72% of players got this right" (green >70%, yellow 40-70%, red <40%)
- **< 5 answers**: "You're one of the first to answer this!"

## Changes
- Answer + Skip APIs now return \`timesShown\` and \`timesCorrect\`
- \`lastAnswer\` state extended with these fields
- \`InfiniteQuestionCard\` renders the accuracy below the explanation

## Test plan
- [ ] Answer a question → see accuracy percentage below explanation
- [ ] Skip a question → also see accuracy
- [ ] New questions (< 5 answers) → "one of the first" message
- [ ] Color coding: green/yellow/red based on percentage

Closes #671