### PR TITLE
fix: always show category chooser before infinite trivia (#675)

### DIFF
--- a/src/app/api/v1/trivia/infinite/runs/[runId]/answer/route.ts
+++ b/src/app/api/v1/trivia/infinite/runs/[runId]/answer/route.ts
@@ -18,9 +18,12 @@ export async function POST(
     const body = await request.json();
     const { questionId, answer, elapsedMs } = body;
 
-    if (!questionId || !answer || elapsedMs === undefined) {
-      return NextResponse.json({ error: 'questionId, answer, and elapsedMs are required.' }, { status: 400 });
+    if (!questionId || elapsedMs === undefined) {
+      return NextResponse.json({ error: 'questionId and elapsedMs are required.' }, { status: 400 });
     }
+
+    // Empty answer (timeout) is treated as incorrect — skip the judge
+    const isTimeout = !answer || answer.trim() === ''
 
     // Load question
     const db = getFirestoreDb();
@@ -30,8 +33,8 @@ export async function POST(
     }
     const qData = qSnap.data()!;
 
-    // Grade the answer
-    const correct = await judgeAnswer(qData.question, qData.correctAnswer, answer);
+    // Grade the answer — timeout (empty) is automatically incorrect
+    const correct = isTimeout ? false : await judgeAnswer(qData.question, qData.correctAnswer, answer);
 
     // Submit to run
     const result = await submitAnswer({

--- a/src/app/trivia/components/InfiniteGame.tsx
+++ b/src/app/trivia/components/InfiniteGame.tsx
@@ -12,7 +12,6 @@ import { ChunkyButton } from '@/components/ui/chunky-button'
 import { CATEGORY_META } from '@/lib/trivia/categories'
 
 const TIME_LIMIT = 60 // 60 seconds for AI free-text
-const RULES_DISMISSED_KEY = 'cometcave-infinite-rules-dismissed-v1'
 
 interface Props {
   onBack: () => void
@@ -28,36 +27,17 @@ export function InfiniteGame({ onBack, onViewStats, onViewLeaderboard, mode = 's
   const timerRef = useRef<ReturnType<typeof setInterval> | null>(null)
   const timerStartRef = useRef<number>(0)
   const hasStartedRef = useRef(false)
-  const [showRules, setShowRules] = useState<boolean | null>(null)
+  // Always show the pre-game screen until the player clicks Start
+  const [showPreGame, setShowPreGame] = useState(true)
 
-  // Determine whether to show the rules modal once on mount.
-  useEffect(() => {
-    if (typeof window === 'undefined') return
-    const dismissed = window.localStorage.getItem(RULES_DISMISSED_KEY) === '1'
-    setShowRules(!dismissed)
-  }, [])
-
-  // Start run once auth has settled, user is present, and rules have been
-  // either dismissed previously or acknowledged this session.
-  useEffect(() => {
-    if (authLoading || !user || hasStartedRef.current) return
-    if (showRules !== false) return
-    hasStartedRef.current = true
-    startRun(mode)
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [authLoading, user, showRules])
-
-  const handleRulesContinue = useCallback((chosenMode: InfiniteMode, dismissForever: boolean, categoryId?: number) => {
-    if (dismissForever && typeof window !== 'undefined') {
-      window.localStorage.setItem(RULES_DISMISSED_KEY, '1')
-    }
+  const handlePreGameContinue = useCallback((chosenMode: InfiniteMode, categoryId?: number) => {
     if (chosenMode !== mode && typeof window !== 'undefined') {
       const url = new URL(window.location.href)
       url.searchParams.set('mode', chosenMode)
       window.history.replaceState({}, '', url.toString())
     }
     hasStartedRef.current = true
-    setShowRules(false)
+    setShowPreGame(false)
     startRun(chosenMode, categoryId)
   }, [mode, startRun])
 
@@ -91,14 +71,14 @@ export function InfiniteGame({ onBack, onViewStats, onViewLeaderboard, mode = 's
   }, [endRun])
 
   const handlePlayAgain = useCallback(() => {
-    startRun(mode)
-  }, [startRun, mode])
+    setShowPreGame(true)
+  }, [])
 
-  // Rules gate (before first run). Shown over the loading screen.
-  if (showRules) {
+  // Pre-game screen — always shown until the player clicks Start
+  if (showPreGame) {
     return (
       <div className="flex flex-col items-center gap-4 py-8 max-w-lg mx-auto">
-        <InfiniteRulesModal defaultMode={mode} onContinue={handleRulesContinue} onCancel={onBack} />
+        <InfiniteRulesModal defaultMode={mode} onContinue={handlePreGameContinue} onCancel={onBack} />
       </div>
     )
   }

--- a/src/app/trivia/components/InfiniteQuestionCard.tsx
+++ b/src/app/trivia/components/InfiniteQuestionCard.tsx
@@ -155,20 +155,32 @@ export function InfiniteQuestionCard({
                 {answerResult.explanation}
               </div>
             )}
-            {/* Community accuracy */}
-            {answerResult.timesShown != null && answerResult.timesShown >= 5 ? (() => {
-              const pct = Math.round(((answerResult.timesCorrect ?? 0) / answerResult.timesShown) * 100)
-              const color = pct > 70 ? 'text-ds-primary' : pct > 40 ? 'text-yellow-400' : 'text-ds-error'
+            {/* Community accuracy — exclude the current player from the count */}
+            {(() => {
+              const rawShown = answerResult.timesShown ?? 0
+              const rawCorrect = answerResult.timesCorrect ?? 0
+              // Subtract current player from the totals
+              const othersShown = Math.max(0, rawShown - 1)
+              const othersCorrect = Math.max(0, rawCorrect - (answerResult.correct ? 1 : 0))
+
+              if (othersShown === 0) return null // No other players — don't show anything
+
+              if (othersShown >= 5) {
+                const pct = Math.round((othersCorrect / othersShown) * 100)
+                const color = pct > 70 ? 'text-ds-primary' : pct > 40 ? 'text-yellow-400' : 'text-ds-error'
+                return (
+                  <div className={`text-sm mt-2 ${color}`}>
+                    {pct}% of other players got this right
+                  </div>
+                )
+              }
+
               return (
-                <div className={`text-sm mt-2 ${color}`}>
-                  {pct}% of players got this right
+                <div className="text-on-surface/40 text-sm mt-2">
+                  {othersCorrect} of {othersShown} other {othersShown === 1 ? 'person' : 'people'} answered this correctly
                 </div>
               )
-            })() : answerResult.timesShown != null && answerResult.timesShown > 0 ? (
-              <div className="text-on-surface/40 text-sm mt-2">
-                {answerResult.timesCorrect ?? 0} of {answerResult.timesShown} other {answerResult.timesShown === 1 ? 'person' : 'people'} answered this correctly
-              </div>
-            ) : null}
+            })()}
           </div>
         )}
       </ChunkyCardContent>

--- a/src/app/trivia/components/InfiniteRulesModal.tsx
+++ b/src/app/trivia/components/InfiniteRulesModal.tsx
@@ -4,15 +4,31 @@ import { ChunkyButton } from '@/components/ui/chunky-button'
 import type { InfiniteMode } from '@/app/trivia/hooks/useInfiniteRun'
 import { CATEGORY_META } from '@/lib/trivia/categories'
 
+const RULES_SEEN_KEY = 'cometcave-infinite-rules-seen-v1'
+
 interface Props {
   defaultMode: InfiniteMode
-  onContinue: (mode: InfiniteMode, dismissForever: boolean, categoryId?: number) => void
+  onContinue: (mode: InfiniteMode, categoryId?: number) => void
   onCancel: () => void
 }
 
 export function InfiniteRulesModal({ defaultMode, onContinue, onCancel }: Props) {
-  const [dismissForever, setDismissForever] = useState(false)
   const [selectedCategoryId, setSelectedCategoryId] = useState<number | undefined>(undefined)
+
+  // Only hide the rules explanation if the user has seen it before
+  const rulesSeen = typeof window !== 'undefined'
+    ? window.localStorage.getItem(RULES_SEEN_KEY) === '1'
+    : false
+
+  const [showRulesText, setShowRulesText] = useState(!rulesSeen)
+
+  const handleContinue = (mode: InfiniteMode) => {
+    // Mark rules as seen so the explanation is collapsed next time
+    if (typeof window !== 'undefined') {
+      window.localStorage.setItem(RULES_SEEN_KEY, '1')
+    }
+    onContinue(mode, selectedCategoryId)
+  }
 
   const categoryEntries = Object.entries(CATEGORY_META).map(([id, meta]) => ({
     id: Number(id),
@@ -24,39 +40,46 @@ export function InfiniteRulesModal({ defaultMode, onContinue, onCancel }: Props)
       <div className="bg-surface-container-high rounded-ds-lg p-6 max-w-md w-full shadow-hero flex flex-col gap-4 max-h-[90vh] overflow-y-auto">
         <div>
           <h2 className="text-on-surface text-xl font-bold mb-1">Infinite Trivia</h2>
-          <p className="text-on-surface/60 text-sm">
-            An endless run powered by fresh AI-generated questions. Here&apos;s how it works:
-          </p>
+          {!showRulesText ? (
+            <button
+              type="button"
+              onClick={() => setShowRulesText(true)}
+              className="text-ds-primary text-xs hover:underline"
+            >
+              How to play →
+            </button>
+          ) : (
+            <p className="text-on-surface/60 text-sm">
+              An endless run powered by fresh AI-generated questions.
+            </p>
+          )}
         </div>
 
-        <ul className="text-on-surface/80 text-sm flex flex-col gap-2">
-          <li className="flex gap-2">
-            <span aria-hidden="true">❤️</span>
-            <span><strong className="text-on-surface">3 lives.</strong> A wrong answer costs one. Zero lives ends the run.</span>
-          </li>
-          <li className="flex gap-2">
-            <span aria-hidden="true">🔥</span>
-            <span><strong className="text-on-surface">Streak multiplier.</strong> ×1.5 at 5 correct → ×2 at 10 → ×3 at 20.</span>
-          </li>
-          <li className="flex gap-2">
-            <span aria-hidden="true">🩹</span>
-            <span><strong className="text-on-surface">Bonus life.</strong> Every 10-streak refunds a life (cap of 3).</span>
-          </li>
-          <li className="flex gap-2">
-            <span aria-hidden="true">⏭️</span>
-            <span><strong className="text-on-surface">Two skips.</strong> Stuck on a question? Skip it — no life lost, no streak broken. Two per run.</span>
-          </li>
-        </ul>
+        {showRulesText && (
+          <ul className="text-on-surface/80 text-sm flex flex-col gap-2">
+            <li className="flex gap-2">
+              <span aria-hidden="true">❤️</span>
+              <span><strong className="text-on-surface">3 lives.</strong> A wrong answer costs one. Zero lives ends the run.</span>
+            </li>
+            <li className="flex gap-2">
+              <span aria-hidden="true">🔥</span>
+              <span><strong className="text-on-surface">Streak multiplier.</strong> ×1.5 at 5 correct → ×2 at 10 → ×3 at 20.</span>
+            </li>
+            <li className="flex gap-2">
+              <span aria-hidden="true">🩹</span>
+              <span><strong className="text-on-surface">Bonus life.</strong> Every 10-streak refunds a life (cap of 3).</span>
+            </li>
+            <li className="flex gap-2">
+              <span aria-hidden="true">⏭️</span>
+              <span><strong className="text-on-surface">Two skips.</strong> Stuck on a question? Skip it — no life lost. Two per run.</span>
+            </li>
+          </ul>
+        )}
 
-        <p className="text-on-surface/50 text-xs">
-          Practice mode plays the same questions with no lives and no scoring — a low-pressure way to explore.
-        </p>
-
-        {/* Category selector */}
+        {/* Category selector — always visible */}
         <div className="flex flex-col gap-2">
           <p className="text-on-surface/70 text-sm font-medium">Category</p>
           <div className="flex flex-wrap gap-1.5">
-            {/* "All" chip */}
             <button
               type="button"
               onClick={() => setSelectedCategoryId(undefined)}
@@ -87,16 +110,6 @@ export function InfiniteRulesModal({ defaultMode, onContinue, onCancel }: Props)
           </div>
         </div>
 
-        <label className="flex items-center gap-2 text-on-surface/70 text-sm cursor-pointer select-none">
-          <input
-            type="checkbox"
-            checked={dismissForever}
-            onChange={(e) => setDismissForever(e.target.checked)}
-            className="accent-ds-primary"
-          />
-          Don&apos;t show this again
-        </label>
-
         <div className="flex flex-col sm:flex-row gap-2 sm:justify-end">
           <ChunkyButton variant="ghost" size="sm" onClick={onCancel}>
             Back
@@ -104,16 +117,16 @@ export function InfiniteRulesModal({ defaultMode, onContinue, onCancel }: Props)
           <ChunkyButton
             variant="secondary"
             size="sm"
-            onClick={() => onContinue('practice', dismissForever, selectedCategoryId)}
+            onClick={() => handleContinue('practice')}
           >
             Practice Mode
           </ChunkyButton>
           <ChunkyButton
             variant="primary"
             size="sm"
-            onClick={() => onContinue(defaultMode === 'practice' ? 'practice' : 'scored', dismissForever, selectedCategoryId)}
+            onClick={() => handleContinue(defaultMode === 'practice' ? 'practice' : 'scored')}
           >
-            Continue
+            Start
           </ChunkyButton>
         </div>
       </div>


### PR DESCRIPTION
## Bug
Category picker was inside the rules modal. Dismissing rules ("Don't show again") also skipped the category picker — runs auto-started with no category.

## Fix
- Pre-game screen ALWAYS shows with category + mode selection
- Rules text auto-collapses for returning users (not hidden entirely)
- "How to play →" link expands the rules
- Removed "Don't show again" checkbox
- "Play Again" returns to pre-game screen to allow category change

## Test plan
- [ ] First visit → see rules + category picker + Start
- [ ] Second visit → rules collapsed, category picker visible, "How to play →" link
- [ ] Select a category → start run → questions match category
- [ ] Play Again → returns to pre-game screen

Closes #675