### PR TITLE
fix: flag bonus life works + toast + 5 lives / 3-streak

### DIFF
--- a/src/app/api/v1/trivia/questions/[id]/flag/route.ts
+++ b/src/app/api/v1/trivia/questions/[id]/flag/route.ts
@@ -6,7 +6,7 @@ import { getFirestoreDb } from '@/lib/firebase/server';
 import { incrementVoiceStat } from '@/lib/trivia/triviaStats';
 
 const FLAG_THRESHOLD = 3;
-const BONUS_LIVES_MAX = 3;
+const BONUS_LIVES_PER_RUN = 1;
 const VALID_REASONS = ['obvious', 'unanswerable', 'nonsense', 'inaccurate', 'difficulty_mismatch', 'other'] as const;
 type FlagReason = (typeof VALID_REASONS)[number];
 
@@ -88,7 +88,7 @@ export async function POST(
             flaggedQuestionIds: FieldValue.arrayUnion(questionId),
           };
 
-          if (wasFirstFlag && bonusLivesEarned < BONUS_LIVES_MAX) {
+          if (bonusLivesEarned < BONUS_LIVES_PER_RUN) {
             runUpdates.livesRemaining = FieldValue.increment(1);
             runUpdates.bonusLivesEarned = FieldValue.increment(1);
             bonusLifeGranted = true;

--- a/src/app/trivia/components/InfiniteGame.tsx
+++ b/src/app/trivia/components/InfiniteGame.tsx
@@ -31,6 +31,7 @@ export function InfiniteGame({ onBack, onViewStats, onViewLeaderboard, mode = 's
   const [showPreGame, setShowPreGame] = useState(true)
   const [selectedCategoryId, setSelectedCategoryId] = useState<number | undefined>(undefined)
   const [showRulesOverlay, setShowRulesOverlay] = useState(false)
+  const [flagLifeToast, setFlagLifeToast] = useState(false)
 
   const categoryEntries = Object.entries(CATEGORY_META).map(([id, meta]) => ({
     id: Number(id),
@@ -157,7 +158,7 @@ export function InfiniteGame({ onBack, onViewStats, onViewLeaderboard, mode = 's
               <ul className="text-on-surface/80 text-sm flex flex-col gap-2 mb-4">
                 <li className="flex gap-2">
                   <span>❤️</span>
-                  <span><strong>3 lives.</strong> A wrong answer costs one. Zero lives ends the run.</span>
+                  <span><strong>5 lives.</strong> A wrong answer costs one. Zero lives ends the run.</span>
                 </li>
                 <li className="flex gap-2">
                   <span>🔥</span>
@@ -165,7 +166,7 @@ export function InfiniteGame({ onBack, onViewStats, onViewLeaderboard, mode = 's
                 </li>
                 <li className="flex gap-2">
                   <span>🩹</span>
-                  <span><strong>Bonus life.</strong> Every 10-streak refunds a life (cap of 3).</span>
+                  <span><strong>Bonus life.</strong> Every 3-streak refunds a life (cap of 5).</span>
                 </li>
                 <li className="flex gap-2">
                   <span>⏭️</span>
@@ -244,10 +245,23 @@ export function InfiniteGame({ onBack, onViewStats, onViewLeaderboard, mode = 's
         answerResult={state.lastAnswer}
         questionsAnswered={state.questionsAnswered}
         runId={state.runId}
-        onFlagged={handleQuestionFlagged}
+        onFlagged={(questionId, result) => {
+          handleQuestionFlagged(questionId, result)
+          if (result.bonusLifeGranted) {
+            setFlagLifeToast(true)
+            setTimeout(() => setFlagLifeToast(false), 3000)
+          }
+        }}
         skipsRemaining={state.skipsRemaining}
         onSkip={skipQuestion}
       />
+
+      {/* Bonus life toast */}
+      {flagLifeToast && (
+        <div className="fixed top-4 left-1/2 -translate-x-1/2 z-50 bg-ds-primary text-on-primary px-4 py-2 rounded-ds-md shadow-hero text-sm font-medium animate-bounce">
+          ❤️ +1 Bonus Life for reporting!
+        </div>
+      )}
 
       {state.phase === 'answered' && (
         state.lastAnswer?.runOver ? (

--- a/src/app/trivia/components/InfiniteRulesModal.tsx
+++ b/src/app/trivia/components/InfiniteRulesModal.tsx
@@ -59,7 +59,7 @@ export function InfiniteRulesModal({ defaultMode, onContinue, onCancel }: Props)
           <ul className="text-on-surface/80 text-sm flex flex-col gap-2">
             <li className="flex gap-2">
               <span aria-hidden="true">❤️</span>
-              <span><strong className="text-on-surface">3 lives.</strong> A wrong answer costs one. Zero lives ends the run.</span>
+              <span><strong className="text-on-surface">5 lives.</strong> A wrong answer costs one. Zero lives ends the run.</span>
             </li>
             <li className="flex gap-2">
               <span aria-hidden="true">🔥</span>
@@ -67,7 +67,7 @@ export function InfiniteRulesModal({ defaultMode, onContinue, onCancel }: Props)
             </li>
             <li className="flex gap-2">
               <span aria-hidden="true">🩹</span>
-              <span><strong className="text-on-surface">Bonus life.</strong> Every 10-streak refunds a life (cap of 3).</span>
+              <span><strong className="text-on-surface">Bonus life.</strong> Every 3-streak refunds a life (cap of 5).</span>
             </li>
             <li className="flex gap-2">
               <span aria-hidden="true">⏭️</span>

--- a/src/app/trivia/lib/infiniteScoring.ts
+++ b/src/app/trivia/lib/infiniteScoring.ts
@@ -1,6 +1,6 @@
-export const LIVES_START = 3
-export const LIVES_MAX = 3
-export const LIFE_REFUND_EVERY = 10
+export const LIVES_START = 5
+export const LIVES_MAX = 5
+export const LIFE_REFUND_EVERY = 3
 export const SKIPS_PER_RUN = 2
 
 export const STREAK_TIERS = [

--- a/src/lib/trivia/__tests__/infiniteScoring.test.ts
+++ b/src/lib/trivia/__tests__/infiniteScoring.test.ts
@@ -44,23 +44,23 @@ describe('computeStreakMultiplier', () => {
 })
 
 describe('shouldRefundLife', () => {
-  it('returns true at streak 10 when lives < LIVES_MAX', () => {
-    expect(shouldRefundLife(10, 2)).toBe(true)
+  it('returns true at streak 3 when lives < LIVES_MAX', () => {
+    expect(shouldRefundLife(3, 2)).toBe(true)
   })
 
-  it('returns true at streak 20 when lives < LIVES_MAX', () => {
-    expect(shouldRefundLife(20, 1)).toBe(true)
+  it('returns true at streak 6 when lives < LIVES_MAX', () => {
+    expect(shouldRefundLife(6, 1)).toBe(true)
   })
 
-  it('returns true at streak 30 when lives < LIVES_MAX', () => {
-    expect(shouldRefundLife(30, 2)).toBe(true)
+  it('returns true at streak 9 when lives < LIVES_MAX', () => {
+    expect(shouldRefundLife(9, 2)).toBe(true)
   })
 
-  it('returns false at streak 10 when lives === LIVES_MAX', () => {
-    expect(shouldRefundLife(10, LIVES_MAX)).toBe(false)
+  it('returns false at streak 3 when lives === LIVES_MAX', () => {
+    expect(shouldRefundLife(3, LIVES_MAX)).toBe(false)
   })
 
-  it('returns false at streak 5 (non-multiple of 10)', () => {
+  it('returns false at streak 5 (non-multiple of 3)', () => {
     expect(shouldRefundLife(5, 2)).toBe(false)
   })
 
@@ -68,8 +68,8 @@ describe('shouldRefundLife', () => {
     expect(shouldRefundLife(0, 2)).toBe(false)
   })
 
-  it('returns false at streak 11 (non-multiple of 10)', () => {
-    expect(shouldRefundLife(11, 1)).toBe(false)
+  it('returns false at streak 4 (non-multiple of 3)', () => {
+    expect(shouldRefundLife(4, 1)).toBe(false)
   })
 })
 
@@ -141,26 +141,26 @@ describe('applyAnswer', () => {
     expect(result.points).toBe(0)
   })
 
-  it('refunds a life at streak 10 when lives are below max', () => {
+  it('refunds a life at streak 3 when lives are below max', () => {
     const result = applyAnswer({
       ...baseParams,
       correct: true,
       elapsedMs: 0,
-      prevStreak: 9,
-      prevLongestStreak: 9,
-      prevLives: 2,
+      prevStreak: 2,
+      prevLongestStreak: 2,
+      prevLives: 3,
     })
-    expect(result.currentStreak).toBe(10)
-    expect(result.livesRemaining).toBe(3) // restored to LIVES_MAX
+    expect(result.currentStreak).toBe(3)
+    expect(result.livesRemaining).toBe(4)
   })
 
-  it('does not refund life at streak 10 when already at max lives', () => {
+  it('does not refund life at streak 3 when already at max lives', () => {
     const result = applyAnswer({
       ...baseParams,
       correct: true,
       elapsedMs: 0,
-      prevStreak: 9,
-      prevLongestStreak: 9,
+      prevStreak: 2,
+      prevLongestStreak: 2,
       prevLives: LIVES_MAX,
     })
     expect(result.livesRemaining).toBe(LIVES_MAX)


### PR DESCRIPTION
## Fixes
1. **Flag bonus life**: removed wasFirstFlag check — any report earns +1 life (max 1 per run)
2. **Toast**: bouncing "❤️ +1 Bonus Life for reporting!" for 3 seconds
3. **5 lives / 3-streak**: LIVES_START=5, LIVES_MAX=5, LIFE_REFUND_EVERY=3
4. Rules text + tests updated

All 27 scoring tests pass.