### PR TITLE
fix: add missing Firestore indexes for infinite trivia leaderboard

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -33,6 +33,24 @@
         { "fieldPath": "type", "order": "ASCENDING" },
         { "fieldPath": "timesShown", "order": "ASCENDING" }
       ]
+    },
+    {
+      "collectionGroup": "triviaInfinite",
+      "queryScope": "COLLECTION_GROUP",
+      "fields": [
+        { "fieldPath": "mode", "order": "ASCENDING" },
+        { "fieldPath": "endedAt", "order": "ASCENDING" },
+        { "fieldPath": "score", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "triviaInfinite",
+      "queryScope": "COLLECTION_GROUP",
+      "fields": [
+        { "fieldPath": "mode", "order": "ASCENDING" },
+        { "fieldPath": "endedAt", "order": "ASCENDING" },
+        { "fieldPath": "longestStreak", "order": "DESCENDING" }
+      ]
     }
   ],
   "fieldOverrides": [


### PR DESCRIPTION
## Summary
Fixes #683

- Adds two missing composite indexes for the `triviaInfinite` collection group in `firestore.indexes.json`
- The infinite leaderboard queries require `mode` + `endedAt` + `score`/`longestStreak` composite indexes
- Without these, Firestore throws `FAILED_PRECONDITION` and the API permanently returns "Leaderboard is initializing"

## Post-merge action
After merging, deploy indexes with:
```
firebase deploy --only firestore:indexes
```
Index creation takes a few minutes. Once built, the leaderboard will start returning real data.

## Test plan
- [ ] Deploy firestore indexes after merge
- [ ] Verify infinite leaderboard loads entries instead of showing "initializing" notice
- [ ] Check both sort modes (score and streak) return data

🤖 Generated with [Claude Code](https://claude.com/claude-code)