### PR TITLE
fix: use document ID for nickname hydration on leaderboards

### DIFF
--- a/src/lib/trivia/infiniteRuns.ts
+++ b/src/lib/trivia/infiniteRuns.ts
@@ -228,9 +228,10 @@ async function hydrateNicknames(uids: string[]): Promise<Map<string, string>> {
   const map = new Map<string, string>()
   for (const snap of snaps) {
     if (!snap.exists) continue
-    const data = snap.data() as { uid?: string; nickname?: string }
-    if (data?.uid) {
-      map.set(data.uid, data.nickname ?? '')
+    const data = snap.data() as { nickname?: string }
+    const nickname = data?.nickname ?? ''
+    if (nickname) {
+      map.set(snap.ref.id, nickname)
     }
   }
   return map

--- a/src/lib/trivia/queries.ts
+++ b/src/lib/trivia/queries.ts
@@ -44,9 +44,10 @@ async function hydrateNicknames(uids: string[]): Promise<Map<string, string>> {
   const map = new Map<string, string>()
   for (const snap of snaps) {
     if (!snap.exists) continue
-    const data = snap.data() as { uid?: string; nickname?: string }
-    if (data?.uid) {
-      map.set(data.uid, data.nickname ?? '')
+    const data = snap.data() as { nickname?: string }
+    const nickname = data?.nickname ?? ''
+    if (nickname) {
+      map.set(snap.ref.id, nickname)
     }
   }
   return map


### PR DESCRIPTION
## Summary
Fixes #679

- `hydrateNicknames` was keying the nickname map on `data.uid`, but user documents store the UID as the Firestore document ID, not as a field in the document
- When `data.uid` is `undefined`, the nickname is never mapped, so every leaderboard entry falls back to `'Player'`
- Fixed in both `queries.ts` (daily/weekly leaderboards) and `infiniteRuns.ts` (infinite leaderboards) which had duplicate copies of the same bug

## Test plan
- [ ] Check all-time leaderboard — usernames should appear instead of "Player"
- [ ] Check infinite leaderboard — same fix applied there
- [ ] Verify users without nicknames still show "Player" as fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)