### PR TITLE
fix: await voice stat increments and use atomic set-merge

### DIFF
--- a/src/app/api/v1/trivia/questions/[id]/flag/route.ts
+++ b/src/app/api/v1/trivia/questions/[id]/flag/route.ts
@@ -101,8 +101,8 @@ export async function POST(
       return { wasFirstFlag, bonusLifeGranted };
     });
 
-    // Increment lifetime reports counter (fire-and-forget)
-    incrementVoiceStat(uid, 'reportsFiled').catch((err) =>
+    // Increment lifetime reports counter
+    await incrementVoiceStat(uid, 'reportsFiled').catch((err) =>
       console.error('[flag] Failed to increment voice stat:', err)
     );
 

--- a/src/app/api/v1/trivia/questions/[id]/rate/route.ts
+++ b/src/app/api/v1/trivia/questions/[id]/rate/route.ts
@@ -52,7 +52,7 @@ export async function POST(
       // Only increment lifetime counter for new votes (not updates)
       if (!hadPriorVote) {
         const field = vote === 'up' ? 'likesGiven' : 'dislikesGiven';
-        incrementVoiceStat(uid, field).catch((err) =>
+        await incrementVoiceStat(uid, field).catch((err) =>
           console.error('[rate] Failed to increment voice stat:', err)
         );
       }

--- a/src/lib/trivia/triviaStats.ts
+++ b/src/lib/trivia/triviaStats.ts
@@ -203,21 +203,17 @@ export async function incrementVoiceStat(
 ): Promise<void> {
   const db = getFirestoreDb()
   const aggRef = db.doc(`users/${uid}/triviaStats/aggregate`)
-  const snap = await aggRef.get()
-  if (snap.exists) {
-    await aggRef.update({ [field]: FieldValue.increment(1), lastUpdatedAt: FieldValue.serverTimestamp() })
-  } else {
-    await aggRef.set({ ...EMPTY_STATS, [field]: 1, lastUpdatedAt: FieldValue.serverTimestamp() })
-  }
+  await aggRef.set(
+    { [field]: FieldValue.increment(1), lastUpdatedAt: FieldValue.serverTimestamp() },
+    { merge: true }
+  )
 }
 
 export async function trackExhaustion(uid: string): Promise<void> {
   const db = getFirestoreDb()
   const aggRef = db.doc(`users/${uid}/triviaStats/aggregate`)
-  const snap = await aggRef.get()
-  if (snap.exists) {
-    await aggRef.update({ exhaustionCount: FieldValue.increment(1), lastUpdatedAt: FieldValue.serverTimestamp() })
-  } else {
-    await aggRef.set({ ...EMPTY_STATS, exhaustionCount: 1, lastUpdatedAt: FieldValue.serverTimestamp() })
-  }
+  await aggRef.set(
+    { exhaustionCount: FieldValue.increment(1), lastUpdatedAt: FieldValue.serverTimestamp() },
+    { merge: true }
+  )
 }


### PR DESCRIPTION
## Summary
Fixes #682

Two issues caused `reportsFiled` (and `likesGiven`/`dislikesGiven`) to silently fail:

1. **Fire-and-forget in serverless** — `incrementVoiceStat` was called without `await` in the flag and rate endpoints. Vercel can terminate the function after the response is sent, so the Firestore write may never complete.

2. **TOCTOU race in `incrementVoiceStat`** — the function read the doc to check existence, then called `update` or `set`. Between the read and write, another operation could interfere. Replaced with a single `set({ merge: true })` call which atomically creates or updates the document.

Also applied the same atomic fix to `trackExhaustion`.

## Changes
- `triviaStats.ts` — `incrementVoiceStat` and `trackExhaustion` now use `set` with `merge: true` (no read needed)
- `flag/route.ts` — `await` the `incrementVoiceStat` call
- `rate/route.ts` — `await` the `incrementVoiceStat` call

## Test plan
- [ ] Flag a question during an infinite run → check stats page shows reportsFiled incremented
- [ ] Rate a question up/down → check stats page shows likes/dislikes incremented
- [ ] Verify stats survive across multiple runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)