### PR TITLE
feat: weekly crown system for all-time trivia leaderboard

### DIFF
--- a/src/app/trivia/components/TriviaLeaderboard.tsx
+++ b/src/app/trivia/components/TriviaLeaderboard.tsx
@@ -25,6 +25,7 @@ interface LeaderboardEntry {
   gamesPlayed?: number
   totalCorrect?: number
   totalQuestions?: number
+  crowns?: number
 }
 
 interface LeaderboardResponse {
@@ -138,16 +139,19 @@ export function TriviaLeaderboard({ onBack }: { onBack: () => void }) {
     }
 
     if (period === 'alltime') {
-      return data.entries.map((entry, i) => (
-        <LeaderboardRow
-          key={entry.uid || `${entry.displayName}-${i}`}
-          rank={i + 1}
-          name={entry.displayName || 'Unknown'}
-          primary={(entry.totalScore ?? 0).toLocaleString()}
-          secondary={`${entry.gamesPlayed ?? 0} ${(entry.gamesPlayed ?? 0) === 1 ? 'game' : 'games'}`}
-          isCurrentUser={!!currentUid && entry.uid === currentUid}
-        />
-      ))
+      return data.entries.map((entry, i) => {
+        const crownCount = entry.crowns ?? entry.score ?? 0
+        return (
+          <LeaderboardRow
+            key={entry.uid || `${entry.displayName}-${i}`}
+            rank={i + 1}
+            name={entry.displayName || 'Unknown'}
+            primary={`\uD83D\uDC51 ${crownCount}`}
+            secondary={crownCount === 1 ? 'crown' : 'crowns'}
+            isCurrentUser={!!currentUid && entry.uid === currentUid}
+          />
+        )
+      })
     }
 
     return null

--- a/src/lib/trivia/crowns.ts
+++ b/src/lib/trivia/crowns.ts
@@ -1,0 +1,65 @@
+import { getFirestoreDb } from '@/lib/firebase/server'
+import { getWeekKey, getTodayPST } from '@/lib/dates'
+
+interface CrownDoc {
+  weekKey: string
+  winnerUid: string
+  winnerScore: number
+}
+
+/**
+ * Ensures all past completed weeks have crown winners computed.
+ * Returns all crown docs (one per week).
+ *
+ * Lazy: only queries triviaWeekly for un-awarded weeks.
+ * Once a crown is written, it's never recomputed.
+ */
+export async function ensureCrownsAwarded(): Promise<CrownDoc[]> {
+  const db = getFirestoreDb()
+
+  // 1. Get all existing crown docs
+  const crownsSnap = await db.collection('weeklyCrowns').get()
+  const existing = new Map<string, CrownDoc>()
+  for (const doc of crownsSnap.docs) {
+    existing.set(doc.id, doc.data() as CrownDoc)
+  }
+
+  // 2. Current weekKey (exclude — week is not yet complete)
+  const currentWeek = getWeekKey(getTodayPST())
+
+  // 3. Get all triviaWeekly docs to find un-awarded weeks
+  const weeklySnap = await db.collectionGroup('triviaWeekly').get()
+
+  // 4. Group by weekKey, track the top scorer for each un-awarded past week
+  const weekWinners = new Map<string, { uid: string; totalScore: number }>()
+  for (const doc of weeklySnap.docs) {
+    const data = doc.data()
+    const weekKey = data.weekKey as string
+    if (weekKey === currentWeek) continue
+    if (existing.has(weekKey)) continue
+
+    const uid = data.uid as string
+    const totalScore = data.totalScore as number
+    const current = weekWinners.get(weekKey)
+    if (!current || totalScore > current.totalScore) {
+      weekWinners.set(weekKey, { uid, totalScore })
+    }
+  }
+
+  // 5. Write new crown docs (batch write for efficiency)
+  if (weekWinners.size > 0) {
+    const batch = db.batch()
+    for (const [weekKey, winner] of weekWinners) {
+      const crownDoc: CrownDoc = {
+        weekKey,
+        winnerUid: winner.uid,
+        winnerScore: winner.totalScore,
+      }
+      batch.set(db.collection('weeklyCrowns').doc(weekKey), crownDoc)
+      existing.set(weekKey, crownDoc)
+    }
+    await batch.commit()
+  }
+
+  return Array.from(existing.values())
+}

--- a/src/lib/trivia/queries.ts
+++ b/src/lib/trivia/queries.ts
@@ -1,4 +1,5 @@
 import { getFirestoreDb } from '@/lib/firebase/server'
+import { ensureCrownsAwarded } from '@/lib/trivia/crowns'
 
 export interface TriviaLeaderboardEntry {
   uid: string
@@ -10,6 +11,7 @@ export interface TriviaLeaderboardEntry {
   gamesPlayed?: number
   totalCorrect?: number
   totalQuestions?: number
+  crowns?: number
 }
 
 interface DailyDoc {
@@ -101,25 +103,29 @@ export async function getWeeklyTop(
 }
 
 export async function getAllTimeTop(limit = 20): Promise<TriviaLeaderboardEntry[]> {
-  const db = getFirestoreDb()
-  const snap = await db
-    .collectionGroup('triviaProfile')
-    .orderBy('totalScore', 'desc')
-    .limit(limit)
-    .get()
+  const crowns = await ensureCrownsAwarded()
 
-  const entries = snap.docs.map((d) => {
-    const profile = d.data() as ProfileDoc
-    const uid = d.ref.parent.parent?.id ?? ''
-    return { uid, totalScore: profile.totalScore, gamesPlayed: profile.gamesPlayed }
-  })
-  const nicknames = await hydrateNicknames(entries.map((e) => e.uid))
+  // Count crowns per user
+  const crownCounts = new Map<string, number>()
+  for (const crown of crowns) {
+    crownCounts.set(crown.winnerUid, (crownCounts.get(crown.winnerUid) ?? 0) + 1)
+  }
 
-  return entries.map((e) => ({
-    uid: e.uid,
-    displayName: nicknames.get(e.uid) || 'Player',
-    score: e.totalScore,
-    totalScore: e.totalScore,
-    gamesPlayed: e.gamesPlayed,
+  // Sort by crown count desc, take top N
+  const sorted = Array.from(crownCounts.entries())
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, limit)
+
+  if (sorted.length === 0) {
+    return []
+  }
+
+  const nicknames = await hydrateNicknames(sorted.map(([uid]) => uid))
+
+  return sorted.map(([uid, count]) => ({
+    uid,
+    displayName: nicknames.get(uid) || 'Player',
+    score: count,
+    crowns: count,
   }))
 }


### PR DESCRIPTION
## Summary
Fixes #680

Replaces the all-time leaderboard (previously ranked by total score) with a crown-based system:
- Each completed week, the top daily trivia scorer earns a **crown** (👑)
- All-time leaderboard now ranks by most crowns, not total score
- Crown winners are lazily computed and cached in a `weeklyCrowns` Firestore collection — once awarded, never recomputed

## Changes
- **New `lib/trivia/crowns.ts`** — `ensureCrownsAwarded()` scans `triviaWeekly` collection group for un-awarded past weeks, picks the top scorer per week, and batch-writes crown docs
- **Updated `queries.ts`** — `getAllTimeTop` now uses crown counts instead of `triviaProfile.totalScore`
- **Updated `TriviaLeaderboard.tsx`** — all-time tab displays crown count with 👑 emoji

## Test plan
- [ ] Load all-time leaderboard — verify crown counts appear with 👑
- [ ] Verify current (incomplete) week is excluded from crowns
- [ ] Verify crown docs are created in `weeklyCrowns` collection after first load
- [ ] Subsequent loads should be faster (cached crown docs, no recomputation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)