### PR TITLE
feat: merge daily and infinite trivia stats into tabbed page

### DIFF
--- a/src/app/trivia/components/UnifiedStats.tsx
+++ b/src/app/trivia/components/UnifiedStats.tsx
@@ -1,0 +1,41 @@
+'use client'
+
+import { useState } from 'react'
+
+import { ChunkyButton } from '@/components/ui/chunky-button'
+
+import { InfiniteStats } from './InfiniteStats'
+import { TriviaStats } from './TriviaStats'
+
+type StatsTab = 'daily' | 'infinite'
+
+export function UnifiedStats({ onBack, defaultTab = 'daily' }: { onBack: () => void; defaultTab?: StatsTab }) {
+  const [tab, setTab] = useState<StatsTab>(defaultTab)
+
+  return (
+    <div className="flex flex-col gap-4 max-w-lg mx-auto pt-6">
+      {/* Tabs */}
+      <div className="grid grid-cols-2 gap-2 px-4">
+        <ChunkyButton
+          variant={tab === 'daily' ? 'primary' : 'secondary'}
+          onClick={() => setTab('daily')}
+        >
+          Daily
+        </ChunkyButton>
+        <ChunkyButton
+          variant={tab === 'infinite' ? 'primary' : 'secondary'}
+          onClick={() => setTab('infinite')}
+        >
+          Infinite
+        </ChunkyButton>
+      </div>
+
+      {/* Tab content */}
+      {tab === 'daily' ? (
+        <TriviaStats onBack={onBack} />
+      ) : (
+        <InfiniteStats onBack={onBack} />
+      )}
+    </div>
+  )
+}

--- a/src/app/trivia/page.tsx
+++ b/src/app/trivia/page.tsx
@@ -15,17 +15,18 @@ import { getDailyCategory } from '@/lib/trivia/categories'
 
 import { InfiniteGame } from './components/InfiniteGame'
 import { InfiniteLeaderboard } from './components/InfiniteLeaderboard'
-import { InfiniteStats } from './components/InfiniteStats'
+import { UnifiedStats } from './components/UnifiedStats'
 import { TriviaGame } from './components/TriviaGame'
 import { TriviaLanding } from './components/TriviaLanding'
 import { TriviaLeaderboard } from './components/TriviaLeaderboard'
 import { TriviaResults } from './components/TriviaResults'
-import { TriviaStats } from './components/TriviaStats'
 
 import type { TriviaGameResult } from './models/trivia'
 import type { User } from 'firebase/auth'
 
 type View = 'landing' | 'playing' | 'results' | 'stats' | 'leaderboard' | 'infinite' | 'infinite-stats' | 'practice' | 'infinite-leaderboard'
+
+type StatsDefaultTab = 'daily' | 'infinite'
 
 async function submitGameToServer(user: User, result: TriviaGameResult): Promise<void> {
   const token = await user.getIdToken()
@@ -58,6 +59,7 @@ export default function TriviaPage() {
   const firestoreToday = user ? history.find((h) => h.date === today) ?? null : null
 
   const [view, setView] = useState<View>('landing')
+  const [statsDefaultTab, setStatsDefaultTab] = useState<StatsDefaultTab>('daily')
   const [lastResult, setLastResult] = useState<TriviaGameResult | null>(null)
   const [localToday, setLocalToday] = useState<TriviaGameResult | null>(null)
   const [autoResultsShown, setAutoResultsShown] = useState(false)
@@ -110,10 +112,10 @@ export default function TriviaPage() {
   }, [user, triviaLoading, firestoreToday, today])
 
   const handleStartGame = () => setView('playing')
-  const handleViewStats = () => setView('stats')
+  const handleViewStats = () => { setStatsDefaultTab('daily'); setView('stats') }
   const handleViewLeaderboard = () => setView('leaderboard')
   const handleStartInfinite = () => setView('infinite')
-  const handleViewInfiniteStats = () => setView('infinite-stats')
+  const handleViewInfiniteStats = () => { setStatsDefaultTab('infinite'); setView('stats') }
   const handleStartPractice = () => setView('practice')
   const handleViewInfiniteLeaderboard = () => setView('infinite-leaderboard')
 
@@ -145,7 +147,7 @@ export default function TriviaPage() {
   }
 
   if (view === 'infinite-stats') {
-    return <InfiniteStats onBack={handleBackToLanding} />
+    return <UnifiedStats onBack={handleBackToLanding} defaultTab="infinite" />
   }
 
   if (view === 'playing') {
@@ -165,7 +167,7 @@ export default function TriviaPage() {
   }
 
   if (view === 'stats') {
-    return <TriviaStats onBack={handleBackToLanding} />
+    return <UnifiedStats onBack={handleBackToLanding} defaultTab={statsDefaultTab} />
   }
 
   if (view === 'leaderboard') {


### PR DESCRIPTION
## Summary
Fixes #673

- New `UnifiedStats` component with Daily/Infinite tab switcher using ChunkyButton (same pattern as leaderboard tabs)
- Both stats views accessible from a single page — tab defaults to whichever mode the player navigated from
- No changes to the individual `TriviaStats` or `InfiniteStats` components — they render as before, just wrapped by the tab container

## Changes
- **New `components/UnifiedStats.tsx`** — tab wrapper with Daily/Infinite toggle
- **Updated `page.tsx`** — both `stats` and `infinite-stats` views now render `UnifiedStats` with the appropriate default tab

## Test plan
- [ ] Click "Stats" from daily trivia → opens with Daily tab active
- [ ] Click "Stats" from infinite trivia → opens with Infinite tab active
- [ ] Switch between tabs — content loads correctly
- [ ] Back button works from both tabs

🤖 Generated with [Claude Code](https://claude.com/claude-code)