### PR TITLE
feat: make auth/login global across the site

### DIFF
--- a/src/app/auth/page.tsx
+++ b/src/app/auth/page.tsx
@@ -7,12 +7,12 @@ import { type FormEvent, Suspense, useEffect, useState } from 'react'
 import { ChunkyButton } from '@/components/ui/chunky-button'
 import { ChunkyCard, ChunkyCardContent, ChunkyCardHeader, ChunkyCardTitle } from '@/components/ui/chunky-card'
 import { Input } from '@/components/ui/input'
-import { AnonymousProgressOrphanedError, AuthProvider, useAuth } from '@/hooks/useAuth'
+import { AnonymousProgressOrphanedError, useAuth } from '@/hooks/useAuth'
 
 function AuthPageInner() {
   const router = useRouter()
   const searchParams = useSearchParams()
-  const redirectTo = searchParams.get('redirect') ?? '/trivia'
+  const redirectTo = searchParams.get('redirect') ?? '/'
   const { user, loading, configured, signInWithGoogle, signInWithEmail, signUpWithEmail } =
     useAuth()
 
@@ -222,10 +222,8 @@ function formatAuthError(err: unknown): string {
 
 export default function AuthPage() {
   return (
-    <AuthProvider>
-      <Suspense fallback={null}>
-        <AuthPageInner />
-      </Suspense>
-    </AuthProvider>
+    <Suspense fallback={null}>
+      <AuthPageInner />
+    </Suspense>
   )
 }

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -3,13 +3,16 @@ import { ThemeProvider } from '@mui/material/styles'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { useState } from 'react'
 
+import { AuthProvider } from '@/hooks/useAuth'
 import { theme } from '@/theme'
 
 export function Providers({ children }: { children: React.ReactNode }) {
   const [queryClient] = useState(() => new QueryClient())
   return (
     <QueryClientProvider client={queryClient}>
-      <ThemeProvider theme={theme}>{children}</ThemeProvider>
+      <ThemeProvider theme={theme}>
+        <AuthProvider>{children}</AuthProvider>
+      </ThemeProvider>
     </QueryClientProvider>
   )
 }

--- a/src/app/trivia/layout.tsx
+++ b/src/app/trivia/layout.tsx
@@ -1,10 +1,5 @@
-import { AuthProvider } from '@/hooks/useAuth'
-
 import type { ReactNode } from 'react'
 
 export default function TriviaLayout({ children }: { children: ReactNode }) {
-  // No height styling here — the root <main> in src/app/layout.tsx is
-  // already flex-1 inside a min-h-screen flex column with header + footer,
-  // so trivia content fills exactly the leftover viewport space.
-  return <AuthProvider>{children}</AuthProvider>
+  return <>{children}</>
 }

--- a/src/components/top-nav-bar.tsx
+++ b/src/components/top-nav-bar.tsx
@@ -6,6 +6,7 @@ import { BrandMark } from '@/components/brand-mark'
 import { NavPill } from '@/components/ui/nav-pill'
 
 import { ROUTE_CONSTANTS } from '@/app/route-constants'
+import { useAuth } from '@/hooks/useAuth'
 
 const navItems: readonly { href: string; label: string; exact?: boolean }[] = [
   { href: ROUTE_CONSTANTS.HOME, label: 'HOME', exact: true },
@@ -18,6 +19,7 @@ const navItems: readonly { href: string; label: string; exact?: boolean }[] = [
 ]
 
 export function TopNavBar() {
+  const { user, loading } = useAuth()
   return (
     <header className="sticky top-0 z-30 mt-4 mx-4">
       <div className="mx-auto max-w-7xl">
@@ -44,6 +46,20 @@ export function TopNavBar() {
                 {label}
               </NavPill>
             ))}
+          </div>
+
+          <div className="flex items-center gap-1 ml-auto shrink-0">
+            {!loading && (
+              user && !user.isAnonymous ? (
+                <NavPill href="/auth" layout="inline">
+                  {user.displayName || user.email?.split('@')[0] || 'Account'}
+                </NavPill>
+              ) : (
+                <NavPill href="/auth" layout="inline">
+                  Sign in
+                </NavPill>
+              )
+            )}
           </div>
         </nav>
       </div>


### PR DESCRIPTION
## Summary
Fixes #674

Makes the auth/login experience site-wide instead of trivia-scoped:

- **AuthProvider moved to root** — `useAuth()` now works on every page, not just trivia
- **User indicator in top nav** — shows display name when signed in, "Sign in" link when not
- **Auth page redirect updated** — defaults to `/` instead of `/trivia` after login
- **Cleaned up redundant wrappers** — removed AuthProvider from trivia layout and auth page (now inherited from root)

## Changes
- `providers.tsx` — wrap children in `<AuthProvider>`
- `trivia/layout.tsx` — simplified to passthrough (auth now inherited)
- `auth/page.tsx` — removed AuthProvider wrapper, changed default redirect to `/`
- `top-nav-bar.tsx` — added user state indicator with `useAuth()`

## Test plan
- [ ] Visit any page — verify no auth errors
- [ ] Check top nav shows "Sign in" when logged out
- [ ] Sign in → verify top nav shows username/email
- [ ] Trivia auth features still work (stats, leaderboard, flagging)
- [ ] Auth page redirects to referrer page (or `/` by default)

🤖 Generated with [Claude Code](https://claude.com/claude-code)