### PR TITLE
feat: AI question rating system with Cloud Storage

### DIFF
--- a/src/app/api/v1/trivia/rate-question/route.ts
+++ b/src/app/api/v1/trivia/rate-question/route.ts
@@ -1,0 +1,55 @@
+import { type NextRequest, NextResponse } from 'next/server'
+import { randomBytes } from 'crypto'
+
+import { getStorageBucket } from '@/lib/firebase/server'
+
+const VALID_RATINGS = ['up', 'down'] as const
+
+export async function POST(request: NextRequest) {
+  let body: Record<string, unknown>
+  try {
+    body = await request.json()
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON.' }, { status: 400 })
+  }
+
+  const { questionId, rating, date, question, correctAnswer, userAnswer, wasCorrect, difficulty, category } = body
+
+  if (!questionId || typeof questionId !== 'string') {
+    return NextResponse.json({ error: 'questionId is required.' }, { status: 400 })
+  }
+  if (!VALID_RATINGS.includes(rating as typeof VALID_RATINGS[number])) {
+    return NextResponse.json({ error: 'rating must be "up" or "down".' }, { status: 400 })
+  }
+  if (!date || typeof date !== 'string') {
+    return NextResponse.json({ error: 'date is required.' }, { status: 400 })
+  }
+
+  const ratingData = {
+    date,
+    questionId,
+    question: question ?? '',
+    correctAnswer: correctAnswer ?? '',
+    userAnswer: userAnswer ?? '',
+    wasCorrect: !!wasCorrect,
+    rating,
+    difficulty: difficulty ?? 'unknown',
+    category: category ?? 'unknown',
+    timestamp: new Date().toISOString(),
+  }
+
+  try {
+    const bucket = getStorageBucket()
+    const suffix = randomBytes(2).toString('hex')
+    const filename = `trivia-ratings/${date}/rating-${Date.now()}-${suffix}.json`
+    await bucket.file(filename).save(JSON.stringify(ratingData, null, 2), {
+      contentType: 'application/json',
+    })
+    return NextResponse.json({ stored: true })
+  } catch (err) {
+    console.error('Failed to store rating:', err)
+    // Don't fail the user experience — return success anyway
+    // The rating data is best-effort for training purposes
+    return NextResponse.json({ stored: false })
+  }
+}

--- a/src/app/trivia/components/TriviaGame.tsx
+++ b/src/app/trivia/components/TriviaGame.tsx
@@ -48,6 +48,9 @@ export function TriviaGame({ onFinish, onFlee }: { onFinish: (result: TriviaGame
   const [answerResult, setAnswerResult] = useState<CheckAnswerResponse | null>(null)
   const [isChecking, setIsChecking] = useState(false)
 
+  // Rating state
+  const [questionRating, setQuestionRating] = useState<string | null>(null)
+
   // Game results
   const [answers, setAnswers] = useState<TriviaAnswer[]>([])
   const [totalScore, setTotalScore] = useState(0)
@@ -166,7 +169,36 @@ export function TriviaGame({ onFinish, onFlee }: { onFinish: (result: TriviaGame
     }
   }, [phase, isChecking, currentIndex, questions])
 
+  const handleRateQuestion = (rating: 'up' | 'down') => {
+    const q = questions[currentIndex]
+    if (!q || q.source !== 'ai') return
+
+    const storageKey = `trivia-rated-${q.id}`
+    if (localStorage.getItem(storageKey)) return
+
+    localStorage.setItem(storageKey, rating)
+    setQuestionRating(rating)
+
+    // Fire-and-forget — don't await
+    fetch('/api/v1/trivia/rate-question', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        questionId: q.id,
+        rating,
+        date: getTodayPST(),
+        question: q.question,
+        correctAnswer: answerResult?.correctAnswer ?? '',
+        userAnswer: selectedAnswer,
+        wasCorrect: answerResult?.correct ?? false,
+        difficulty: q.difficulty,
+        category: q.category,
+      }),
+    }).catch(() => {}) // swallow errors — best effort
+  }
+
   const nextQuestion = useCallback(() => {
+    setQuestionRating(null)
     if (currentIndex + 1 >= questions.length) {
       // Game over
       const today = getTodayPST()
@@ -345,6 +377,33 @@ export function TriviaGame({ onFinish, onFlee }: { onFinish: (result: TriviaGame
           )}
         </ChunkyCardContent>
       </ChunkyCard>
+
+      {/* AI question rating */}
+      {phase === 'answered' && questions[currentIndex]?.source === 'ai' && (
+        <div className="flex items-center justify-center gap-3 text-sm">
+          {questionRating || localStorage.getItem(`trivia-rated-${questions[currentIndex]?.id}`) ? (
+            <span className="text-on-surface/50">Thanks for the feedback!</span>
+          ) : (
+            <>
+              <span className="text-on-surface/50">Good question?</span>
+              <button
+                onClick={() => handleRateQuestion('up')}
+                className="px-3 py-1 rounded-full bg-surface-container hover:bg-surface-container-high transition-colors"
+                aria-label="Good question"
+              >
+                👍
+              </button>
+              <button
+                onClick={() => handleRateQuestion('down')}
+                className="px-3 py-1 rounded-full bg-surface-container hover:bg-surface-container-high transition-colors"
+                aria-label="Bad question"
+              >
+                👎
+              </button>
+            </>
+          )}
+        </div>
+      )}
 
       {/* Next button */}
       {phase === 'answered' && (

--- a/src/lib/firebase/server.ts
+++ b/src/lib/firebase/server.ts
@@ -1,6 +1,7 @@
 import { cert, getApps, initializeApp } from 'firebase-admin/app'
 import { type Auth, getAuth } from 'firebase-admin/auth'
 import { getFirestore } from 'firebase-admin/firestore'
+import { getStorage } from 'firebase-admin/storage'
 
 let _db: FirebaseFirestore.Firestore | null = null
 let _auth: Auth | null = null
@@ -37,4 +38,9 @@ export function getFirebaseAuthAdmin(): Auth {
     _auth = getAuth()
   }
   return _auth
+}
+
+export function getStorageBucket() {
+  ensureApp()
+  return getStorage().bucket()
 }


### PR DESCRIPTION
## Summary
Fixes #241

Adds thumbs up/down rating for AI-generated daily trivia questions. Ratings are stored as self-contained JSON files in Firebase Cloud Storage for future use as training data.

## Changes
- **New `api/v1/trivia/rate-question/route.ts`** — POST endpoint that stores rating JSON to Cloud Storage at `trivia-ratings/{date}/rating-{timestamp}-{hex}.json`
- **Updated `TriviaGame.tsx`** — rating buttons (👍/👎) appear after answering AI questions, with localStorage dedup
- **Updated `firebase/server.ts`** — added `getStorageBucket()` helper

## How it works
- After answering an AI question, "Good question? 👍 👎" appears below the answer feedback
- One-tap, fire-and-forget — no loading state, graceful failure
- localStorage prevents duplicate ratings per question
- Each rating file is self-contained: question text, correct answer, user answer, difficulty, category, and rating

## Setup required
Firebase Cloud Storage must be enabled on the project (default bucket). No additional env vars needed — `firebase-admin` SDK uses the existing service account.

## Test plan
- [ ] Answer an AI question in daily trivia → verify rating buttons appear
- [ ] Tap 👍 or 👎 → verify "Thanks for the feedback!" replaces buttons
- [ ] Refresh and answer same question → verify buttons don't reappear (localStorage)
- [ ] Check Cloud Storage for rating files in `trivia-ratings/` path
- [ ] Answer an OpenTDB question → verify no rating buttons shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)