### PR TITLE
fix: show all 5 hearts + toast for streak/flag bonus lives

### DIFF
--- a/src/app/trivia/components/InfiniteGame.tsx
+++ b/src/app/trivia/components/InfiniteGame.tsx
@@ -31,7 +31,8 @@ export function InfiniteGame({ onBack, onViewStats, onViewLeaderboard, mode = 's
   const [showPreGame, setShowPreGame] = useState(true)
   const [selectedCategoryId, setSelectedCategoryId] = useState<number | undefined>(undefined)
   const [showRulesOverlay, setShowRulesOverlay] = useState(false)
-  const [flagLifeToast, setFlagLifeToast] = useState(false)
+  const [bonusLifeToast, setBonusLifeToast] = useState<string | null>(null)
+  const prevLivesRef = useRef<number | null>(null)
 
   const categoryEntries = Object.entries(CATEGORY_META).map(([id, meta]) => ({
     id: Number(id),
@@ -80,6 +81,19 @@ export function InfiniteGame({ onBack, onViewStats, onViewLeaderboard, mode = 's
     if (timerRef.current) clearInterval(timerRef.current)
     endRun()
   }, [endRun])
+
+  // Detect streak bonus life — compare lives before and after answering
+  useEffect(() => {
+    if (state.phase === 'answered' && state.lastAnswer?.correct && prevLivesRef.current !== null) {
+      if (state.livesRemaining > prevLivesRef.current) {
+        setBonusLifeToast(`🔥 ${state.lastAnswer.currentStreak}-streak! +1 Bonus Life`)
+        setTimeout(() => setBonusLifeToast(null), 3000)
+      }
+    }
+    if (state.phase === 'playing' || state.phase === 'answered') {
+      prevLivesRef.current = state.livesRemaining
+    }
+  }, [state.phase, state.livesRemaining, state.lastAnswer])
 
   const handlePlayAgain = useCallback(() => {
     setShowPreGame(true)
@@ -248,18 +262,18 @@ export function InfiniteGame({ onBack, onViewStats, onViewLeaderboard, mode = 's
         onFlagged={(questionId, result) => {
           handleQuestionFlagged(questionId, result)
           if (result.bonusLifeGranted) {
-            setFlagLifeToast(true)
-            setTimeout(() => setFlagLifeToast(false), 3000)
+            setBonusLifeToast('❤️ +1 Bonus Life for reporting!')
+            setTimeout(() => setBonusLifeToast(null), 3000)
           }
         }}
         skipsRemaining={state.skipsRemaining}
         onSkip={skipQuestion}
       />
 
-      {/* Bonus life toast */}
-      {flagLifeToast && (
+      {/* Bonus life toast — shows for streak refund or flag reward */}
+      {bonusLifeToast && (
         <div className="fixed top-4 left-1/2 -translate-x-1/2 z-50 bg-ds-primary text-on-primary px-4 py-2 rounded-ds-md shadow-hero text-sm font-medium animate-bounce">
-          ❤️ +1 Bonus Life for reporting!
+          {bonusLifeToast}
         </div>
       )}
 

--- a/src/app/trivia/components/InfiniteHUD.tsx
+++ b/src/app/trivia/components/InfiniteHUD.tsx
@@ -2,7 +2,7 @@
 import { useState } from 'react'
 import { ChunkyButton } from '@/components/ui/chunky-button'
 import { Pill, ScoreChip } from '@/components/ui/pill'
-import { computeStreakMultiplier } from '@/app/trivia/lib/infiniteScoring'
+import { computeStreakMultiplier, LIVES_MAX } from '@/app/trivia/lib/infiniteScoring'
 import type { InfiniteMode } from '@/app/trivia/hooks/useInfiniteRun'
 
 interface InfiniteHUDProps {
@@ -65,11 +65,11 @@ export function InfiniteHUD({
         {mode === 'practice' ? (
           <Pill tone="info" size="sm">Practice</Pill>
         ) : (
-          <div className="flex items-center gap-1" aria-label={`${livesRemaining} lives remaining`}>
-            {[0, 1, 2].map(i => (
+          <div className="flex items-center gap-0.5" aria-label={`${livesRemaining} lives remaining`}>
+            {Array.from({ length: LIVES_MAX }, (_, i) => (
               <span
                 key={i}
-                className={`text-lg transition-opacity ${i < livesRemaining ? 'opacity-100' : 'opacity-20'}`}
+                className={`text-sm transition-opacity ${i < livesRemaining ? 'opacity-100' : 'opacity-20'}`}
               >
                 {i < livesRemaining ? '❤️' : '🖤'}
               </span>


### PR DESCRIPTION
## Fixes

### 1. HUD shows 5 hearts (was hardcoded to 3)
Used LIVES_MAX constant instead of hardcoded array. Slightly smaller hearts to fit 5.

### 2. Streak bonus life toast
"🔥 3-streak! +1 Bonus Life" — detects by comparing previous vs current lives.

### 3. Unified toast
Flag reward and streak refund both use the same toast.

## Test plan
- [ ] See 5 hearts at start
- [ ] 3-streak → toast + heart refills
- [ ] Report → toast + heart refills