### PR TITLE
fix: reject gaming answers like 'correct' in trivia judge

### DIFF
--- a/src/lib/trivia/answerJudge.ts
+++ b/src/lib/trivia/answerJudge.ts
@@ -2,7 +2,17 @@ import { createOpenAI } from '@ai-sdk/openai'
 import { generateObject } from 'ai'
 import { z } from 'zod'
 
+// Reject answers that are obviously gaming the system rather than answering
+const GAMING_PATTERNS = /^(correct|right|yes|true|the answer|answer|idk|i don'?t know|<correct>|<answer>|pass|skip|none|n\/a)$/i
+
 export async function judgeAnswer(question: string, correctAnswer: string, userAnswer: string): Promise<boolean> {
+  const trimmed = userAnswer.trim()
+
+  // Pre-check: reject obviously non-answers and gaming attempts
+  if (!trimmed || trimmed.length < 2 || GAMING_PATTERNS.test(trimmed)) {
+    return false
+  }
+
   const apiKey = process.env.NEXT_PUBLIC_OPENAI_API_KEY ?? process.env.OPENAI_API_KEY
   if (!apiKey) throw new Error('OpenAI API key not configured')
 
@@ -14,14 +24,18 @@ export async function judgeAnswer(question: string, correctAnswer: string, userA
   const result = await generateObject({
     model: openaiClient('gpt-4o-mini'),
     schema: JudgeSchema,
-    prompt: `You are a trivia answer judge. Determine if the user's answer is correct.
+    prompt: `You are a strict trivia answer judge. Determine if the user's answer is correct.
 
 Question: "${question}"
 Correct answer: "${correctAnswer}"
-User's answer: "${userAnswer}"
+User's answer: "${trimmed}"
 
-Accept reasonable variations, minor spelling errors, and equivalent answers.
-Be generous — if the core concept is correct, mark it correct.`,
+Rules:
+- Accept reasonable variations, minor spelling errors, and equivalent answers.
+- The user must provide a SPECIFIC answer that matches the correct answer.
+- Do NOT accept generic words like "correct", "right", "yes", "true", or meta-answers like "<correct>".
+- Do NOT accept answers that merely describe the category or topic without giving a specific answer.
+- If the answer is vague or could apply to many questions, mark it INCORRECT.`,
     temperature: 0.1,
     maxTokens: 100,
   })


### PR DESCRIPTION
## Bug
Typing \"correct\", \"\<correct\>\", \"yes\", \"right\" etc. as an answer to a free-text trivia question sometimes got marked correct by the LLM judge.

## Fix
1. **Pre-check regex**: rejects obvious non-answers before hitting the AI — \"correct\", \"right\", \"yes\", \"true\", \"\<correct\>\", \"idk\", \"pass\", \"skip\", \"none\", answers under 2 chars
2. **Stricter prompt**: explicitly tells the judge not to accept generic/meta-answers

## Test plan
- [ ] Type \"correct\" → marked wrong
- [ ] Type \"\<correct\>\" → marked wrong  
- [ ] Type the actual answer → still marked correct
- [ ] Minor spelling errors → still accepted