### PR TITLE
fix: single flag removes infinite trivia question for all users

### DIFF
--- a/src/app/api/v1/trivia/questions/[id]/flag/route.ts
+++ b/src/app/api/v1/trivia/questions/[id]/flag/route.ts
@@ -5,7 +5,7 @@ import { verifyRequestAuth } from '@/lib/api/auth';
 import { getFirestoreDb } from '@/lib/firebase/server';
 import { incrementVoiceStat } from '@/lib/trivia/triviaStats';
 
-const FLAG_THRESHOLD = 3;
+const FLAG_THRESHOLD = 1;
 const BONUS_LIVES_PER_RUN = 1;
 const VALID_REASONS = ['obvious', 'unanswerable', 'nonsense', 'inaccurate', 'difficulty_mismatch', 'other'] as const;
 type FlagReason = (typeof VALID_REASONS)[number];


### PR DESCRIPTION
## Summary
- Lower `FLAG_THRESHOLD` from 3 → 1 in the question flag route, so a single flag from any user immediately sets `status: 'flagged'` on the question.
- The infinite sampler already filters by `status == 'active'`, so flagged questions are excluded for everyone on the next sample. Daily mode is unaffected (it uses OpenTDB / pre-generated JSON, not the `aiQuestions` collection).

## Test plan
- [ ] Flag a question in infinite mode as user A, then verify it never appears for user B (start a new run on a different account / different device).
- [ ] Confirm the bonus-life behavior on first flag still works for user A (`bonusLifeGranted: true`).
- [ ] Confirm daily mode question pool is unchanged.

> Note: with threshold = 1, a single bad-faith flag can yank any infinite question. If that becomes a problem we can add a soft-quarantine `pending_review` status for triage before permanent removal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)