### PR TITLE
feat: per-category medal config for infinite trivia (1/N)

### DIFF
--- a/src/lib/trivia/__tests__/medals.test.ts
+++ b/src/lib/trivia/__tests__/medals.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from 'vitest'
+
+import { CATEGORY_META } from '@/lib/trivia/categories'
+import {
+  CATEGORY_MEDAL_LADDERS,
+  MEDAL_THRESHOLDS,
+  getMedalLabel,
+  getMedalTier,
+  getNextThreshold,
+} from '@/lib/trivia/medals'
+
+describe('medals config', () => {
+  it('every category in CATEGORY_META has a medal ladder', () => {
+    for (const id of Object.keys(CATEGORY_META).map(Number)) {
+      expect(CATEGORY_MEDAL_LADDERS[id], `missing ladder for category ${id}`).toBeDefined()
+      expect(CATEGORY_MEDAL_LADDERS[id]).toHaveLength(5)
+    }
+  })
+
+  it('no medal ladder targets a category that does not exist', () => {
+    for (const id of Object.keys(CATEGORY_MEDAL_LADDERS).map(Number)) {
+      expect(CATEGORY_META[id], `unknown category ${id} in medal ladders`).toBeDefined()
+    }
+  })
+
+  it('thresholds are strictly increasing', () => {
+    const ts = [
+      MEDAL_THRESHOLDS.bronze,
+      MEDAL_THRESHOLDS.silver,
+      MEDAL_THRESHOLDS.gold,
+      MEDAL_THRESHOLDS.platinum,
+      MEDAL_THRESHOLDS.diamond,
+    ]
+    for (let i = 1; i < ts.length; i++) {
+      expect(ts[i]).toBeGreaterThan(ts[i - 1])
+    }
+  })
+})
+
+describe('getMedalTier', () => {
+  it('returns "none" below the bronze threshold', () => {
+    expect(getMedalTier(0)).toBe('none')
+    expect(getMedalTier(15)).toBe('none')
+  })
+
+  it('returns each tier at its exact threshold', () => {
+    expect(getMedalTier(16)).toBe('bronze')
+    expect(getMedalTier(64)).toBe('silver')
+    expect(getMedalTier(256)).toBe('gold')
+    expect(getMedalTier(1024)).toBe('platinum')
+    expect(getMedalTier(4096)).toBe('diamond')
+  })
+
+  it('returns the highest tier earned for in-between counts', () => {
+    expect(getMedalTier(63)).toBe('bronze')
+    expect(getMedalTier(255)).toBe('silver')
+    expect(getMedalTier(1023)).toBe('gold')
+    expect(getMedalTier(4095)).toBe('platinum')
+    expect(getMedalTier(99_999)).toBe('diamond')
+  })
+})
+
+describe('getMedalLabel', () => {
+  it('returns null for tier "none"', () => {
+    expect(getMedalLabel(9, 'none')).toBeNull()
+  })
+
+  it('returns null for an unknown category', () => {
+    expect(getMedalLabel(999, 'bronze')).toBeNull()
+  })
+
+  it('returns the category-specific label for each tier', () => {
+    // Anime ladder — sanity-check the full custom progression
+    expect(getMedalLabel(31, 'bronze')).toBe('Bug Trainer')
+    expect(getMedalLabel(31, 'silver')).toBe('Krillin')
+    expect(getMedalLabel(31, 'gold')).toBe('Soul Reaper')
+    expect(getMedalLabel(31, 'platinum')).toBe('Hokage')
+    expect(getMedalLabel(31, 'diamond')).toBe('Truth')
+  })
+
+  it('returns the right Diamond honorific for a different category', () => {
+    expect(getMedalLabel(24, 'diamond')).toBe('President')
+    expect(getMedalLabel(20, 'diamond')).toBe('Dreamweaver')
+  })
+})
+
+describe('getNextThreshold', () => {
+  it('returns the bronze threshold when no tier is earned yet', () => {
+    expect(getNextThreshold('none')).toBe(16)
+  })
+
+  it('returns the next tier threshold for each intermediate tier', () => {
+    expect(getNextThreshold('bronze')).toBe(64)
+    expect(getNextThreshold('silver')).toBe(256)
+    expect(getNextThreshold('gold')).toBe(1024)
+    expect(getNextThreshold('platinum')).toBe(4096)
+  })
+
+  it('returns null at the top tier', () => {
+    expect(getNextThreshold('diamond')).toBeNull()
+  })
+})

--- a/src/lib/trivia/medals.ts
+++ b/src/lib/trivia/medals.ts
@@ -1,0 +1,82 @@
+// Category medal system for infinite trivia.
+//
+// Each category has a custom 5-tier ladder of honorific titles, earned by
+// answering questions correctly *in that category, scored mode only*. The
+// thresholds are shared across all categories; only the labels vary.
+//
+// Storage and write-path wiring live in subsequent PRs — this file is
+// config + pure helpers only.
+
+export type MedalTier = 'none' | 'bronze' | 'silver' | 'gold' | 'platinum' | 'diamond'
+
+const TIER_ORDER: Array<Exclude<MedalTier, 'none'>> = [
+  'bronze',
+  'silver',
+  'gold',
+  'platinum',
+  'diamond',
+]
+
+export const MEDAL_THRESHOLDS: Record<Exclude<MedalTier, 'none'>, number> = {
+  bronze: 16,
+  silver: 64,
+  gold: 256,
+  platinum: 1024,
+  diamond: 4096,
+}
+
+// Per-category ladder. Index 0 = bronze, 4 = diamond. Keys match
+// CATEGORY_META in src/lib/trivia/categories.ts.
+export const CATEGORY_MEDAL_LADDERS: Record<number, [string, string, string, string, string]> = {
+  9:  ['Curious',     'Student',       'Scholar',         'Sage',            'Polymath'],
+  10: ['Reader',      'Bookworm',      'Scribe',          'Librarian',       'Bibliomancer'],
+  11: ['Cinephile',   'Critic',        'Editor',          'Director',        'Auteur'],
+  12: ['Listener',    'Performer',     'Composer',        'Conductor',       'Maestro'],
+  13: ['Understudy',  'Ensemble',      'Lead',            'Director',        'Encore'],
+  14: ['Viewer',      'Binger',        'Critic',          'Producer',        'Showrunner'],
+  15: ['Player',      'Completionist', 'Speedrunner',     'Pro',             'Final Boss'],
+  16: ['Pawn',        'Tactician',     'Strategist',      'Master',          'Grandmaster'],
+  17: ['Hiker',       'Field Scout',   'Botanist',        'Specimen Keeper', 'Naturalist'],
+  18: ['Hello World', 'Hacker',        'Coder',           'Sysadmin',        'The Compiler'],
+  19: ['Counter',     'Solver',        'Theorist',        'Proofwriter',     'Axiom'],
+  20: ['Mortal',      'Acolyte',       'Oracle',          'Demigod',         'Dreamweaver'],
+  21: ['Rookie',      'Starter',       'All-Star',        'MVP',             'Hall of Fame'],
+  22: ['Tourist',     'Wanderer',      'Explorer',        'Surveyor',        'Cartographer'],
+  23: ['Witness',     'Student',       'Historian',       'Archivist',       'Chronicler'],
+  24: ['Voter',       'Pundit',        'Strategist',      'Diplomat',        'President'],
+  25: ['Doodler',     'Sketcher',      'Painter',         'Critic',          'Curator'],
+  26: ['Fan',         'Stan',          'Paparazzi',       'Insider',         'Headline'],
+  27: ['Petkeeper',   'Tracker',       'Zookeeper',       'Vet',             'Beastfriend'],
+  28: ['Driver',      'Gearhead',      'Tuner',           'Engineer',        'The Mechanic'],
+  29: ['Reader',      'Collector',     'Inker',           'Writer',          'Origin Story'],
+  30: ['Unboxer',     'Hobbyist',      'Modder',          'Inventor',        'The Architect'],
+  31: ['Bug Trainer', 'Krillin',       'Soul Reaper',     'Hokage',          'Truth'],
+  32: ['Toon',        'Inker',         'Storyboarder',    'Director',        'The Animator'],
+}
+
+export function getMedalTier(correctCount: number): MedalTier {
+  for (let i = TIER_ORDER.length - 1; i >= 0; i--) {
+    const tier = TIER_ORDER[i]
+    if (correctCount >= MEDAL_THRESHOLDS[tier]) return tier
+  }
+  return 'none'
+}
+
+export function getMedalLabel(categoryId: number, tier: MedalTier): string | null {
+  if (tier === 'none') return null
+  const ladder = CATEGORY_MEDAL_LADDERS[categoryId]
+  if (!ladder) return null
+  const idx = TIER_ORDER.indexOf(tier)
+  if (idx === -1) return null
+  return ladder[idx]
+}
+
+// Threshold required to reach the next tier from the given one.
+// Returns null when already at the top (diamond).
+export function getNextThreshold(tier: MedalTier): number | null {
+  if (tier === 'diamond') return null
+  if (tier === 'none') return MEDAL_THRESHOLDS.bronze
+  const idx = TIER_ORDER.indexOf(tier)
+  if (idx === -1 || idx === TIER_ORDER.length - 1) return null
+  return MEDAL_THRESHOLDS[TIER_ORDER[idx + 1]]
+}


### PR DESCRIPTION
## Summary
First slice of the category-medals feature. Pure config + pure helpers, no behavior change.

- New `src/lib/trivia/medals.ts` with:
  - 5-tier system (`bronze` / `silver` / `gold` / `platinum` / `diamond`) keyed off correct-answer counts.
  - Thresholds: **16 / 64 / 256 / 1024 / 4096**.
  - 24 custom ladders — one per category — so each category's tier names are themed (e.g. Anime & Manga: Bug Trainer → Krillin → Soul Reaper → Hokage → **Truth**).
  - Helpers: `getMedalTier`, `getMedalLabel`, `getNextThreshold`.
- Vitest coverage in `src/lib/trivia/__tests__/medals.test.ts` — 13 tests including a structural check that every `CATEGORY_META` entry has a ladder and vice versa.

Nothing imports this module yet, so production behavior is unchanged.

## Follow-up PRs
1. Aggregate doc + write path in `submitAnswer` + tier-up toast
2. One-shot backfill script (idempotent, dry-run mode)
3. `GET /api/v1/trivia/infinite/category-stats` + medal badges on the category selector
4. Per-category infinite leaderboard
5. Firestore index deploy for the new collection-group query

## Test plan
- [x] `npx vitest run src/lib/trivia/__tests__/medals.test.ts` — 13/13 pass
- [x] `npx eslint` — clean
- [x] Type-checks clean (pre-existing tap-tap-adventure errors unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)