### PR TITLE
feat: per-category medal write path + tier-up toast (2/N)

### DIFF
--- a/src/app/trivia/components/InfiniteGame.tsx
+++ b/src/app/trivia/components/InfiniteGame.tsx
@@ -1,15 +1,17 @@
 'use client'
 import { useCallback, useEffect, useRef, useState } from 'react'
-import { useAuth } from '@/hooks/useAuth'
+
 import { useInfiniteRun } from '@/app/trivia/hooks/useInfiniteRun'
 import type { InfiniteMode } from '@/app/trivia/hooks/useInfiniteRun'
+import { ChunkyButton } from '@/components/ui/chunky-button'
+import { ChunkyCard, ChunkyCardContent } from '@/components/ui/chunky-card'
+import { useAuth } from '@/hooks/useAuth'
+import { CATEGORY_META } from '@/lib/trivia/categories'
+
+import { InfiniteExhaustedScreen } from './InfiniteExhaustedScreen'
 import { InfiniteHUD } from './InfiniteHUD'
 import { InfiniteQuestionCard } from './InfiniteQuestionCard'
 import { InfiniteRunSummary } from './InfiniteRunSummary'
-import { InfiniteExhaustedScreen } from './InfiniteExhaustedScreen'
-import { ChunkyButton } from '@/components/ui/chunky-button'
-import { ChunkyCard, ChunkyCardContent } from '@/components/ui/chunky-card'
-import { CATEGORY_META } from '@/lib/trivia/categories'
 
 const TIME_LIMIT = 60 // 60 seconds for AI free-text
 const RULES_SEEN_KEY = 'cometcave-infinite-rules-seen-v1'
@@ -32,7 +34,9 @@ export function InfiniteGame({ onBack, onViewStats, onViewLeaderboard, mode = 's
   const [selectedCategoryId, setSelectedCategoryId] = useState<number | undefined>(undefined)
   const [showRulesOverlay, setShowRulesOverlay] = useState(false)
   const [bonusLifeToast, setBonusLifeToast] = useState<string | null>(null)
+  const [medalToast, setMedalToast] = useState<string | null>(null)
   const prevLivesRef = useRef<number | null>(null)
+  const lastMedalAnswerIdRef = useRef<string | null>(null)
 
   const categoryEntries = Object.entries(CATEGORY_META).map(([id, meta]) => ({
     id: Number(id),
@@ -94,6 +98,25 @@ export function InfiniteGame({ onBack, onViewStats, onViewLeaderboard, mode = 's
       prevLivesRef.current = state.livesRemaining
     }
   }, [state.phase, state.livesRemaining, state.lastAnswer])
+
+  // Show medal toast when an answer crosses a tier line. Track the question
+  // id so the toast doesn't re-fire if the same answered state lingers.
+  useEffect(() => {
+    if (state.phase !== 'answered') return
+    const earned = state.lastAnswer?.medalEarned
+    if (!earned) return
+    const answerKey = state.answers[state.answers.length - 1]?.questionId ?? null
+    if (answerKey === lastMedalAnswerIdRef.current) return
+    lastMedalAnswerIdRef.current = answerKey
+    const tierEmoji =
+      earned.tier === 'bronze' ? '🥉'
+      : earned.tier === 'silver' ? '🥈'
+      : earned.tier === 'gold' ? '🥇'
+      : earned.tier === 'platinum' ? '🏅'
+      : '💎'
+    setMedalToast(`${tierEmoji} ${earned.label} — ${earned.categoryName}`)
+    setTimeout(() => setMedalToast(null), 4000)
+  }, [state.phase, state.lastAnswer, state.answers])
 
   const handlePlayAgain = useCallback(() => {
     setShowPreGame(true)
@@ -274,6 +297,17 @@ export function InfiniteGame({ onBack, onViewStats, onViewLeaderboard, mode = 's
       {bonusLifeToast && (
         <div className="fixed top-24 left-1/2 -translate-x-1/2 z-50 bg-ds-primary text-on-primary px-5 py-3 rounded-ds-md shadow-hero text-base font-semibold animate-bounce">
           {bonusLifeToast}
+        </div>
+      )}
+
+      {/* Medal toast — shows when an answer crosses a tier line */}
+      {medalToast && (
+        <div
+          className={`fixed left-1/2 -translate-x-1/2 z-50 bg-ds-tertiary text-on-tertiary px-5 py-3 rounded-ds-md shadow-hero text-base font-semibold animate-bounce ${
+            bonusLifeToast ? 'top-40' : 'top-24'
+          }`}
+        >
+          {medalToast}
         </div>
       )}
 

--- a/src/app/trivia/hooks/useInfiniteRun.ts
+++ b/src/app/trivia/hooks/useInfiniteRun.ts
@@ -1,7 +1,9 @@
 'use client'
 import { useCallback, useRef, useState } from 'react'
+
+import { type AnswerResult, LIVES_START, SKIPS_PER_RUN } from '@/app/trivia/lib/infiniteScoring'
 import { useAuth } from '@/hooks/useAuth'
-import { LIVES_START, SKIPS_PER_RUN, type AnswerResult } from '@/app/trivia/lib/infiniteScoring'
+import type { MedalEarned } from '@/lib/trivia/medals'
 
 export type InfinitePhase = 'idle' | 'loading' | 'playing' | 'answering' | 'answered' | 'exhausted' | 'ended' | 'error'
 export type InfiniteMode = 'scored' | 'practice'
@@ -30,7 +32,7 @@ export interface InfiniteRunState {
   skipsRemaining: number
   skipsUsed: number
   flaggedQuestionIds: string[]
-  lastAnswer: (AnswerResult & { trailblazer: boolean; correctAnswer: string; explanation: string | null; timesShown?: number; timesCorrect?: number }) | null
+  lastAnswer: (AnswerResult & { trailblazer: boolean; correctAnswer: string; explanation: string | null; timesShown?: number; timesCorrect?: number; medalEarned?: MedalEarned | null }) | null
   answers: Array<{
     questionId: string
     correct: boolean

--- a/src/lib/trivia/__tests__/medals.test.ts
+++ b/src/lib/trivia/__tests__/medals.test.ts
@@ -1,9 +1,10 @@
 import { describe, expect, it } from 'vitest'
 
-import { CATEGORY_META } from '@/lib/trivia/categories'
+import { CATEGORY_META, getCategoryIdByName } from '@/lib/trivia/categories'
 import {
   CATEGORY_MEDAL_LADDERS,
   MEDAL_THRESHOLDS,
+  detectMedalEarned,
   getMedalLabel,
   getMedalTier,
   getNextThreshold,
@@ -98,5 +99,38 @@ describe('getNextThreshold', () => {
 
   it('returns null at the top tier', () => {
     expect(getNextThreshold('diamond')).toBeNull()
+  })
+})
+
+describe('detectMedalEarned', () => {
+  it('returns null when no tier line is crossed', () => {
+    expect(detectMedalEarned(0, 1, 31)).toBeNull()
+    expect(detectMedalEarned(64, 65, 31)).toBeNull()
+    expect(detectMedalEarned(255, 255, 31)).toBeNull()
+  })
+
+  it('returns the new tier and label on a tier crossing', () => {
+    expect(detectMedalEarned(15, 16, 31)).toEqual({ tier: 'bronze', label: 'Bug Trainer' })
+    expect(detectMedalEarned(63, 64, 31)).toEqual({ tier: 'silver', label: 'Krillin' })
+    expect(detectMedalEarned(1023, 1024, 31)).toEqual({ tier: 'platinum', label: 'Hokage' })
+    expect(detectMedalEarned(4095, 4096, 31)).toEqual({ tier: 'diamond', label: 'Truth' })
+  })
+
+  it('returns null for an unknown category', () => {
+    expect(detectMedalEarned(15, 16, 999)).toBeNull()
+  })
+})
+
+describe('getCategoryIdByName', () => {
+  it('round-trips every CATEGORY_META entry', () => {
+    for (const id of Object.keys(CATEGORY_META).map(Number)) {
+      const name = CATEGORY_META[id].name
+      expect(getCategoryIdByName(name)).toBe(id)
+    }
+  })
+
+  it('returns null for unknown names', () => {
+    expect(getCategoryIdByName('Underwater Basket Weaving')).toBeNull()
+    expect(getCategoryIdByName('')).toBeNull()
   })
 })

--- a/src/lib/trivia/categories.ts
+++ b/src/lib/trivia/categories.ts
@@ -45,3 +45,14 @@ export function getDailyCategory(dateStr?: string): DailyCategory {
   const meta = CATEGORY_META[id] ?? CATEGORY_META[9]
   return { id, name: meta.name, icon: meta.icon }
 }
+
+const CATEGORY_NAME_TO_ID: ReadonlyMap<string, number> = new Map(
+  Object.entries(CATEGORY_META).map(([id, meta]) => [meta.name, Number(id)])
+)
+
+// Reverse lookup for the question.category string stored on aiQuestions docs.
+// Returns null when the name doesn't match a known category (e.g. legacy
+// questions tagged with a free-form topic).
+export function getCategoryIdByName(name: string): number | null {
+  return CATEGORY_NAME_TO_ID.get(name) ?? null
+}

--- a/src/lib/trivia/infiniteRuns.ts
+++ b/src/lib/trivia/infiniteRuns.ts
@@ -3,6 +3,8 @@ import { FieldValue, Timestamp } from 'firebase-admin/firestore'
 import { LIVES_START, applyAnswer } from '@/app/trivia/lib/infiniteScoring'
 import type { AnswerResult } from '@/app/trivia/lib/infiniteScoring'
 import { getFirestoreDb } from '@/lib/firebase/server'
+import { getCategoryIdByName } from '@/lib/trivia/categories'
+import { type MedalEarned, detectMedalEarned } from '@/lib/trivia/medals'
 import { applyRunToAggregate } from '@/lib/trivia/triviaStats'
 
 export interface RunDoc {
@@ -62,7 +64,7 @@ export async function submitAnswer(params: {
   questionId: string
   correct: boolean
   elapsedMs: number
-}): Promise<AnswerResult & { trailblazer: boolean }> {
+}): Promise<AnswerResult & { trailblazer: boolean; medalEarned: MedalEarned | null }> {
   const db = getFirestoreDb()
   const { uid, runId, questionId, correct, elapsedMs } = params
 
@@ -84,6 +86,17 @@ export async function submitAnswer(params: {
 
     // Trailblazer: if timesShown was 0 before this answer
     const isTrailblazer = correct && (qData.timesShown ?? 0) === 0
+
+    // Resolve categoryId for medal tracking. Only correct answers in scored
+    // mode count toward medals; questions tagged with an unknown category
+    // string are silently skipped.
+    const categoryId = typeof qData.category === 'string' ? getCategoryIdByName(qData.category) : null
+    const eligibleForMedal = correct && run.mode === 'scored' && categoryId !== null
+    const medalStatsRef = eligibleForMedal
+      ? db.doc(`users/${uid}/triviaCategoryStats/${categoryId}`)
+      : null
+    const medalStatsSnap = medalStatsRef ? await tx.get(medalStatsRef) : null
+    const prevCorrectCount = medalStatsSnap?.exists ? (medalStatsSnap.data()?.correctCount ?? 0) : 0
 
     // Compute result using pure function
     const txResult = applyAnswer({
@@ -120,6 +133,44 @@ export async function submitAnswer(params: {
     // Write answeredBy reverse index
     tx.set(answeredByRef, { uid, runId, correct, at: now })
 
+    // Update or create the per-category medal aggregate.
+    let medalEarned: MedalEarned | null = null
+    if (eligibleForMedal && medalStatsRef && categoryId !== null) {
+      const newCorrectCount = prevCorrectCount + 1
+      const earned = detectMedalEarned(prevCorrectCount, newCorrectCount, categoryId)
+
+      const baseUpdates: FirebaseFirestore.UpdateData<FirebaseFirestore.DocumentData> = {
+        categoryId,
+        correctCount: FieldValue.increment(1),
+        lastAnswerAt: now,
+      }
+      if (earned) {
+        baseUpdates.lastTierEarnedAt = now
+      }
+
+      if (medalStatsSnap?.exists) {
+        tx.update(medalStatsRef, baseUpdates)
+      } else {
+        tx.set(medalStatsRef, {
+          categoryId,
+          correctCount: 1,
+          lastAnswerAt: now,
+          lastTierEarnedAt: earned ? now : null,
+        })
+      }
+
+      if (earned) {
+        const categoryName = typeof qData.category === 'string' ? qData.category : ''
+        medalEarned = {
+          tier: earned.tier,
+          label: earned.label,
+          categoryId,
+          categoryName,
+          correctCount: newCorrectCount,
+        }
+      }
+    }
+
     // Build answer entry. Note: serverTimestamp() can't appear inside an
     // arrayUnion element, so we use a client-computed Timestamp here.
     const answerEntry = {
@@ -147,7 +198,7 @@ export async function submitAnswer(params: {
     }
     tx.update(runRef, runUpdates)
 
-    return { ...txResult, trailblazer: isTrailblazer }
+    return { ...txResult, trailblazer: isTrailblazer, medalEarned }
   })
 
   // Auto-finalize: apply aggregate stats outside the transaction (no nesting)

--- a/src/lib/trivia/medals.ts
+++ b/src/lib/trivia/medals.ts
@@ -80,3 +80,39 @@ export function getNextThreshold(tier: MedalTier): number | null {
   if (idx === -1 || idx === TIER_ORDER.length - 1) return null
   return MEDAL_THRESHOLDS[TIER_ORDER[idx + 1]]
 }
+
+// Pure tier-up detection. Returns the medal earned at this answer, or null
+// if no tier line was crossed. categoryId must be a known category;
+// otherwise null.
+export function detectMedalEarned(
+  prevCorrectCount: number,
+  newCorrectCount: number,
+  categoryId: number
+): { tier: MedalTier; label: string } | null {
+  const prevTier = getMedalTier(prevCorrectCount)
+  const newTier = getMedalTier(newCorrectCount)
+  if (newTier === prevTier) return null
+  if (newTier === 'none') return null
+  const label = getMedalLabel(categoryId, newTier)
+  if (!label) return null
+  return { tier: newTier, label }
+}
+
+// Stored shape at users/{uid}/triviaCategoryStats/{categoryId}.
+// medalTier and label are derived from correctCount on read — not stored —
+// so future threshold retuning takes effect retroactively without migrations.
+export interface CategoryMedalStats {
+  categoryId: number
+  correctCount: number
+  lastAnswerAt: FirebaseFirestore.Timestamp | null
+  lastTierEarnedAt: FirebaseFirestore.Timestamp | null
+}
+
+// Returned from submitAnswer when an answer crosses a tier line. Client-safe.
+export interface MedalEarned {
+  tier: MedalTier
+  label: string
+  categoryId: number
+  categoryName: string
+  correctCount: number
+}


### PR DESCRIPTION
## Summary
Second slice of the category-medals feature: actually start counting correct answers and awarding tier-ups.

- **Server.** `submitAnswer` now writes a per-category aggregate at `users/{uid}/triviaCategoryStats/{categoryId}` inside the existing run transaction. Only **correct answers in scored mode** count toward medals; questions tagged with an unknown category string are silently skipped.
- **Pure helper.** `detectMedalEarned(prevCount, newCount, categoryId)` returns `{ tier, label }` when an answer crosses a tier line, or `null` otherwise — fully unit-tested.
- **Stored shape (intentionally minimal):**
  ```
  { categoryId, correctCount, lastAnswerAt, lastTierEarnedAt }
  ```
  `medalTier` and `label` are **derived from `correctCount` on read**, not stored — so retuning thresholds in `medals.ts` later applies retroactively without migrations.
- **Client.** `submitAnswer` response now includes `medalEarned: MedalEarned | null`. `InfiniteGame.tsx` shows a tier-emoji toast (🥉 → 💎) when a tier line is crossed; stacks above the existing bonus-life toast if both fire.
- **Reverse lookup.** Added `getCategoryIdByName` to `categories.ts` to map the question.category *string* (e.g. "Anime & Manga") back to its numeric id.
- **Tests.** 18 passing in `medals.test.ts` (5 new for `detectMedalEarned` and `getCategoryIdByName`); full suite — 988 tests — green.

## Out of scope (future PRs)
- Backfill historical runs (PR 3)
- `GET /api/v1/trivia/infinite/category-stats` + medal badges on the category selector (PR 4)
- Per-category leaderboard (PR 5)
- Firestore index for the new collection-group sort (PR 6)

## Test plan
- [x] `npx vitest run` — 988/988 pass
- [x] `npx eslint` clean on touched files (only pre-existing `user`/`authLoading` warnings remain in `InfiniteGame.tsx`, unrelated)
- [x] `npx tsc --noEmit` — no new errors
- [ ] Manual: play a few correct scored answers in Anime category, verify a "🥉 Bug Trainer — Anime & Manga" toast at the 16th correct
- [ ] Manual: confirm Practice mode does NOT award medals (no aggregate doc written)

🤖 Generated with [Claude Code](https://claude.com/claude-code)