### PR TITLE
feat: read API + medal badges on category selector (4/N)

### DIFF
--- a/src/app/api/v1/trivia/infinite/category-stats/route.ts
+++ b/src/app/api/v1/trivia/infinite/category-stats/route.ts
@@ -1,0 +1,17 @@
+import { type NextRequest, NextResponse } from 'next/server'
+
+import { verifyRequestAuth } from '@/lib/api/auth'
+import { getCategoryMedalsForUser } from '@/lib/trivia/categoryMedals'
+
+export async function GET(request: NextRequest) {
+  const auth = await verifyRequestAuth(request)
+  if ('error' in auth) return auth.error
+
+  try {
+    const medals = await getCategoryMedalsForUser(auth.claims.uid)
+    return NextResponse.json({ medals })
+  } catch (err) {
+    console.error('Failed to fetch category medals:', err)
+    return NextResponse.json({ error: 'Failed to fetch category medals.' }, { status: 500 })
+  }
+}

--- a/src/app/trivia/components/InfiniteGame.tsx
+++ b/src/app/trivia/components/InfiniteGame.tsx
@@ -1,6 +1,7 @@
 'use client'
 import { useCallback, useEffect, useRef, useState } from 'react'
 
+import { TIER_EMOJI, useCategoryMedals } from '@/app/trivia/hooks/useCategoryMedals'
 import { useInfiniteRun } from '@/app/trivia/hooks/useInfiniteRun'
 import type { InfiniteMode } from '@/app/trivia/hooks/useInfiniteRun'
 import { ChunkyButton } from '@/components/ui/chunky-button'
@@ -42,6 +43,8 @@ export function InfiniteGame({ onBack, onViewStats, onViewLeaderboard, mode = 's
     id: Number(id),
     ...meta,
   }))
+
+  const { byCategoryId: medalsByCategoryId } = useCategoryMedals()
 
   const handleStart = useCallback((chosenMode: InfiniteMode) => {
     if (typeof window !== 'undefined') {
@@ -154,21 +157,35 @@ export function InfiniteGame({ onBack, onViewStats, onViewLeaderboard, mode = 's
                 <span aria-hidden="true">🌐</span>
                 All
               </button>
-              {categoryEntries.map(({ id, name, icon }) => (
-                <button
-                  key={id}
-                  type="button"
-                  onClick={() => setSelectedCategoryId(id)}
-                  className={`flex items-center gap-1 px-2.5 py-1.5 rounded-full text-xs font-medium transition-colors ${
-                    selectedCategoryId === id
-                      ? 'bg-ds-primary text-on-primary'
-                      : 'bg-surface-container text-on-surface/70 hover:bg-surface-container-highest'
-                  }`}
-                >
-                  <span aria-hidden="true">{icon}</span>
-                  {name}
-                </button>
-              ))}
+              {categoryEntries.map(({ id, name, icon }) => {
+                const medal = medalsByCategoryId.get(id)
+                const earnedTier = medal && medal.tier !== 'none' ? medal.tier : null
+                const tierEmoji = earnedTier ? TIER_EMOJI[earnedTier] : null
+                const titleText = medal && medal.label
+                  ? `${medal.label} — ${medal.correctCount} correct${medal.nextThreshold ? ` (next tier at ${medal.nextThreshold})` : ''}`
+                  : medal
+                    ? `${medal.correctCount} correct${medal.nextThreshold ? ` (first tier at ${medal.nextThreshold})` : ''}`
+                    : undefined
+                return (
+                  <button
+                    key={id}
+                    type="button"
+                    onClick={() => setSelectedCategoryId(id)}
+                    title={titleText}
+                    className={`flex items-center gap-1 px-2.5 py-1.5 rounded-full text-xs font-medium transition-colors ${
+                      selectedCategoryId === id
+                        ? 'bg-ds-primary text-on-primary'
+                        : 'bg-surface-container text-on-surface/70 hover:bg-surface-container-highest'
+                    }`}
+                  >
+                    <span aria-hidden="true">{icon}</span>
+                    {name}
+                    {tierEmoji && (
+                      <span aria-label={`${medal?.label ?? earnedTier} medal`}>{tierEmoji}</span>
+                    )}
+                  </button>
+                )
+              })}
             </div>
           </ChunkyCardContent>
         </ChunkyCard>

--- a/src/app/trivia/hooks/useCategoryMedals.ts
+++ b/src/app/trivia/hooks/useCategoryMedals.ts
@@ -1,0 +1,67 @@
+'use client'
+import { useEffect, useState } from 'react'
+
+import { useAuth } from '@/hooks/useAuth'
+import type { MedalTier } from '@/lib/trivia/medals'
+
+export interface CategoryMedalSummary {
+  categoryId: number
+  categoryName: string
+  correctCount: number
+  tier: MedalTier
+  label: string | null
+  nextThreshold: number | null
+}
+
+interface State {
+  loading: boolean
+  byCategoryId: Map<number, CategoryMedalSummary>
+}
+
+const EMPTY: State = { loading: false, byCategoryId: new Map() }
+
+export function useCategoryMedals(): State {
+  const { user } = useAuth()
+  const [state, setState] = useState<State>(EMPTY)
+
+  useEffect(() => {
+    if (!user) {
+      setState(EMPTY)
+      return
+    }
+
+    let cancelled = false
+    setState((s) => ({ ...s, loading: true }))
+    ;(async () => {
+      try {
+        const token = await user.getIdToken()
+        const res = await fetch('/api/v1/trivia/infinite/category-stats', {
+          headers: { Authorization: `Bearer ${token}` },
+        })
+        if (!res.ok) throw new Error('Failed to load category medals')
+        const data = (await res.json()) as { medals: CategoryMedalSummary[] }
+        if (cancelled) return
+        const byCategoryId = new Map<number, CategoryMedalSummary>()
+        for (const m of data.medals) byCategoryId.set(m.categoryId, m)
+        setState({ loading: false, byCategoryId })
+      } catch {
+        if (!cancelled) setState(EMPTY)
+      }
+    })()
+
+    return () => {
+      cancelled = true
+    }
+  }, [user])
+
+  return state
+}
+
+export const TIER_EMOJI: Record<MedalTier, string> = {
+  none: '',
+  bronze: '🥉',
+  silver: '🥈',
+  gold: '🥇',
+  platinum: '🏅',
+  diamond: '💎',
+}

--- a/src/lib/trivia/categoryMedals.ts
+++ b/src/lib/trivia/categoryMedals.ts
@@ -1,0 +1,50 @@
+import { getFirestoreDb } from '@/lib/firebase/server'
+import { CATEGORY_META } from '@/lib/trivia/categories'
+import {
+  type MedalTier,
+  getMedalLabel,
+  getMedalTier,
+  getNextThreshold,
+} from '@/lib/trivia/medals'
+
+export interface CategoryMedalSummary {
+  categoryId: number
+  categoryName: string
+  correctCount: number
+  tier: MedalTier
+  label: string | null
+  nextThreshold: number | null
+}
+
+// Returns one summary entry per known category, including categories the
+// user has never answered in (correctCount: 0, tier: 'none'). The selector
+// uses this to paint either a colored badge or an empty silhouette on
+// every tile in a single pass.
+export async function getCategoryMedalsForUser(uid: string): Promise<CategoryMedalSummary[]> {
+  const db = getFirestoreDb()
+  const snap = await db.collection(`users/${uid}/triviaCategoryStats`).get()
+
+  const counts = new Map<number, number>()
+  for (const doc of snap.docs) {
+    const data = doc.data()
+    const id = typeof data.categoryId === 'number' ? data.categoryId : Number(doc.id)
+    if (Number.isNaN(id)) continue
+    counts.set(id, data.correctCount ?? 0)
+  }
+
+  const result: CategoryMedalSummary[] = []
+  for (const [idStr, meta] of Object.entries(CATEGORY_META)) {
+    const categoryId = Number(idStr)
+    const correctCount = counts.get(categoryId) ?? 0
+    const tier = getMedalTier(correctCount)
+    result.push({
+      categoryId,
+      categoryName: meta.name,
+      correctCount,
+      tier,
+      label: getMedalLabel(categoryId, tier),
+      nextThreshold: getNextThreshold(tier),
+    })
+  }
+  return result
+}


### PR DESCRIPTION
## Summary
Surfaces the medals players have earned. Once this ships and the backfill (PR #3) runs, players will open the infinite pre-game screen and see their existing medals on each category tile.

- **`GET /api/v1/trivia/infinite/category-stats`** — auth-required. Returns one entry per known category, including zero-progress categories, so the client can paint every tile in a single pass.
- **`getCategoryMedalsForUser(uid)`** — server lib that hydrates from `users/{uid}/triviaCategoryStats/*` and derives `tier` / `label` / `nextThreshold` from `correctCount`. Tier is computed at read time so threshold retunes apply retroactively.
- **`useCategoryMedals`** — client hook. Fetches once when a user is present; returns an empty map for anon. Also exports a `TIER_EMOJI` map (🥉 🥈 🥇 🏅 💎) for shared rendering.
- **`InfiniteGame.tsx`** category tiles — show the tier emoji next to the name when earned, with a hover tooltip:
  > `Krillin — 78 correct (next tier at 256)`

Anonymous users see no badges, matching the "sign-up as reward" principle in `CLAUDE.md`.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run` — 988/988 pass
- [x] `npx eslint` clean on touched files (only pre-existing `user`/`authLoading` warnings remain in `InfiniteGame.tsx`, unrelated)
- [ ] Manual: sign in, open infinite pre-game; verify badges render for any seeded category, no badge for unplayed ones
- [ ] Manual: sign out, confirm no badges appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)