### PR TITLE
feat: per-category infinite leaderboard (5/N)

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -51,6 +51,14 @@
         { "fieldPath": "endedAt", "order": "ASCENDING" },
         { "fieldPath": "longestStreak", "order": "DESCENDING" }
       ]
+    },
+    {
+      "collectionGroup": "triviaCategoryStats",
+      "queryScope": "COLLECTION_GROUP",
+      "fields": [
+        { "fieldPath": "categoryId", "order": "ASCENDING" },
+        { "fieldPath": "correctCount", "order": "DESCENDING" }
+      ]
     }
   ],
   "fieldOverrides": [

--- a/src/app/api/v1/trivia/infinite/leaderboard/route.ts
+++ b/src/app/api/v1/trivia/infinite/leaderboard/route.ts
@@ -1,9 +1,12 @@
 import { type NextRequest, NextResponse } from 'next/server'
 
+import { CATEGORY_META } from '@/lib/trivia/categories'
+import { getInfiniteTopByCategory } from '@/lib/trivia/categoryMedals'
 import { getInfiniteTopByScore, getInfiniteTopByStreak } from '@/lib/trivia/infiniteRuns'
 
 export async function GET(request: NextRequest) {
   const sort = request.nextUrl.searchParams.get('sort') || 'score'
+  const categoryIdParam = request.nextUrl.searchParams.get('categoryId')
 
   try {
     if (sort === 'score') {
@@ -16,8 +19,20 @@ export async function GET(request: NextRequest) {
       return NextResponse.json({ sort: 'streak', entries })
     }
 
+    if (sort === 'category') {
+      const categoryId = categoryIdParam !== null ? parseInt(categoryIdParam, 10) : NaN
+      if (isNaN(categoryId) || !(categoryId in CATEGORY_META)) {
+        return NextResponse.json(
+          { error: 'sort=category requires a valid categoryId.' },
+          { status: 400 }
+        )
+      }
+      const entries = await getInfiniteTopByCategory(categoryId, 20)
+      return NextResponse.json({ sort: 'category', categoryId, entries })
+    }
+
     return NextResponse.json(
-      { error: 'Invalid sort. Use score or streak.' },
+      { error: 'Invalid sort. Use score, streak, or category.' },
       { status: 400 }
     )
   } catch (error: unknown) {

--- a/src/app/trivia/components/InfiniteLeaderboard.tsx
+++ b/src/app/trivia/components/InfiniteLeaderboard.tsx
@@ -7,12 +7,14 @@ import { ChunkyButton } from '@/components/ui/chunky-button'
 import { ChunkyCard, ChunkyCardContent } from '@/components/ui/chunky-card'
 import { Pill } from '@/components/ui/pill'
 import { useAuth } from '@/hooks/useAuth'
+import { CATEGORY_META } from '@/lib/trivia/categories'
+import type { MedalTier } from '@/lib/trivia/medals'
 
 import { SignInBanner } from './SignInCTA'
 
-type Sort = 'score' | 'streak'
+type Sort = 'score' | 'streak' | 'category'
 
-interface InfiniteLeaderboardEntry {
+interface OverallEntry {
   uid: string
   displayName: string
   score: number
@@ -20,18 +22,47 @@ interface InfiniteLeaderboardEntry {
   questionsAnswered: number
 }
 
-interface InfiniteLeaderboardResponse {
-  sort: Sort
-  entries: InfiniteLeaderboardEntry[]
+interface CategoryEntry {
+  uid: string
+  displayName: string
+  correctCount: number
+  tier: MedalTier
+  label: string | null
+}
+
+interface OverallResponse {
+  sort: 'score' | 'streak'
+  entries: OverallEntry[]
   notice?: string
 }
+
+interface CategoryResponse {
+  sort: 'category'
+  categoryId: number
+  entries: CategoryEntry[]
+  notice?: string
+}
+
+type LeaderboardResponse = OverallResponse | CategoryResponse
+
+const TIER_EMOJI: Record<MedalTier, string> = {
+  none: '',
+  bronze: '🥉',
+  silver: '🥈',
+  gold: '🥇',
+  platinum: '🏅',
+  diamond: '💎',
+}
+
+const FIRST_CATEGORY_ID = Number(Object.keys(CATEGORY_META)[0])
 
 export function InfiniteLeaderboard({ onBack }: { onBack: () => void }) {
   const { user } = useAuth()
   const { displayName: triviaDisplayName } = useTriviaUser()
   const [sort, setSort] = useState<Sort>('score')
+  const [categoryId, setCategoryId] = useState<number>(FIRST_CATEGORY_ID)
   const [loading, setLoading] = useState(true)
-  const [data, setData] = useState<InfiniteLeaderboardResponse | null>(null)
+  const [data, setData] = useState<LeaderboardResponse | null>(null)
   const [error, setError] = useState<string | null>(null)
 
   const currentUid = user?.uid ?? null
@@ -42,9 +73,12 @@ export function InfiniteLeaderboard({ onBack }: { onBack: () => void }) {
       setLoading(true)
       setError(null)
       try {
-        const res = await fetch(`/api/v1/trivia/infinite/leaderboard?sort=${sort}`)
+        const url = sort === 'category'
+          ? `/api/v1/trivia/infinite/leaderboard?sort=category&categoryId=${categoryId}`
+          : `/api/v1/trivia/infinite/leaderboard?sort=${sort}`
+        const res = await fetch(url)
         if (!res.ok) throw new Error('Failed to load leaderboard')
-        const json = await res.json()
+        const json = (await res.json()) as LeaderboardResponse
         setData(json)
       } catch {
         setError('Failed to load leaderboard.')
@@ -53,10 +87,10 @@ export function InfiniteLeaderboard({ onBack }: { onBack: () => void }) {
       }
     }
     load()
-  }, [sort])
+  }, [sort, categoryId])
 
   const renderEntries = () => {
-    if (!data || !data.entries) return null
+    if (!data) return null
 
     if (data.entries.length === 0) {
       return (
@@ -66,11 +100,29 @@ export function InfiniteLeaderboard({ onBack }: { onBack: () => void }) {
       )
     }
 
+    if (data.sort === 'category') {
+      return data.entries.map((entry, i) => {
+        const tierEmoji = entry.tier !== 'none' ? TIER_EMOJI[entry.tier] : ''
+        const primary = `${entry.correctCount.toLocaleString()} correct`
+        const secondary = entry.label ? `${tierEmoji} ${entry.label}`.trim() : 'No medal yet'
+        return (
+          <LeaderboardRow
+            key={`${entry.uid}-${i}`}
+            rank={i + 1}
+            name={entry.displayName || 'Unknown'}
+            primary={primary}
+            secondary={secondary}
+            isCurrentUser={!!currentUid && entry.uid === currentUid}
+          />
+        )
+      })
+    }
+
     return data.entries.map((entry, i) => {
-      const primary = sort === 'score'
+      const primary = data.sort === 'score'
         ? `${entry.score.toLocaleString()} pts`
         : `${entry.longestStreak} streak`
-      const secondary = sort === 'score'
+      const secondary = data.sort === 'score'
         ? `${entry.longestStreak} streak · ${entry.questionsAnswered} Qs`
         : `${entry.score.toLocaleString()} pts · ${entry.questionsAnswered} Qs`
 
@@ -105,17 +157,33 @@ export function InfiniteLeaderboard({ onBack }: { onBack: () => void }) {
       )}
 
       {/* Sort tabs */}
-      <div className="grid grid-cols-2 gap-2">
-        {(['score', 'streak'] as Sort[]).map((s) => (
+      <div className="grid grid-cols-3 gap-2">
+        {(['score', 'streak', 'category'] as Sort[]).map((s) => (
           <ChunkyButton
             key={s}
             variant={sort === s ? 'primary' : 'secondary'}
             onClick={() => setSort(s)}
           >
-            {s === 'score' ? 'Top Score' : 'Top Streak'}
+            {s === 'score' ? 'Top Score' : s === 'streak' ? 'Top Streak' : 'By Category'}
           </ChunkyButton>
         ))}
       </div>
+
+      {/* Category picker — only visible when "By Category" is selected */}
+      {sort === 'category' && (
+        <select
+          aria-label="Pick a category"
+          className="bg-surface-container-high text-on-surface border border-outline-variant rounded-ds-md py-2 px-3 text-sm"
+          value={categoryId}
+          onChange={(e) => setCategoryId(Number(e.target.value))}
+        >
+          {Object.entries(CATEGORY_META).map(([id, meta]) => (
+            <option key={id} value={id}>
+              {meta.icon} {meta.name}
+            </option>
+          ))}
+        </select>
+      )}
 
       {/* Content */}
       <ChunkyCard variant="surface-container-high" className="bg-surface-container/80 border-outline-variant">

--- a/src/lib/trivia/categoryMedals.ts
+++ b/src/lib/trivia/categoryMedals.ts
@@ -16,6 +16,14 @@ export interface CategoryMedalSummary {
   nextThreshold: number | null
 }
 
+export interface CategoryLeaderboardEntry {
+  uid: string
+  displayName: string
+  correctCount: number
+  tier: MedalTier
+  label: string | null
+}
+
 // Returns one summary entry per known category, including categories the
 // user has never answered in (correctCount: 0, tier: 'none'). The selector
 // uses this to paint either a colored badge or an empty silhouette on
@@ -47,4 +55,48 @@ export async function getCategoryMedalsForUser(uid: string): Promise<CategoryMed
     })
   }
   return result
+}
+
+// Top players for one category, sorted by lifetime correctCount in that
+// category. Hydrates nicknames from the parent users/{uid} doc so the
+// leaderboard shows display names instead of raw uids.
+export async function getInfiniteTopByCategory(
+  categoryId: number,
+  limit = 20
+): Promise<CategoryLeaderboardEntry[]> {
+  const db = getFirestoreDb()
+  const snap = await db
+    .collectionGroup('triviaCategoryStats')
+    .where('categoryId', '==', categoryId)
+    .orderBy('correctCount', 'desc')
+    .limit(limit)
+    .get()
+
+  const rows = snap.docs.map((d) => {
+    const data = d.data()
+    const uid = d.ref.parent.parent?.id ?? ''
+    return { uid, correctCount: (data.correctCount as number) ?? 0 }
+  })
+
+  if (rows.length === 0) return []
+
+  const userRefs = rows.map((r) => db.doc(`users/${r.uid}`))
+  const userSnaps = await db.getAll(...userRefs)
+  const nicknameByUid = new Map<string, string>()
+  for (const s of userSnaps) {
+    if (!s.exists) continue
+    const data = s.data() as { nickname?: string }
+    if (data?.nickname) nicknameByUid.set(s.ref.id, data.nickname)
+  }
+
+  return rows.map((r) => {
+    const tier = getMedalTier(r.correctCount)
+    return {
+      uid: r.uid,
+      displayName: nicknameByUid.get(r.uid) || 'Player',
+      correctCount: r.correctCount,
+      tier,
+      label: getMedalLabel(categoryId, tier),
+    }
+  })
 }


### PR DESCRIPTION
## Summary
Adds the "By Category" leaderboard you asked for. Picking a category from the dropdown lists the top 20 players by **lifetime correct answers in that category**, with each player's current medal label as the secondary line.

- **Lib.** `getInfiniteTopByCategory(categoryId, limit)` queries `triviaCategoryStats` (collection-group) by `categoryId asc, correctCount desc`, then hydrates display names from `users/{uid}`.
- **Route.** `/api/v1/trivia/infinite/leaderboard` now accepts `?sort=category&categoryId=N`. Existing `score` / `streak` sorts unchanged.
- **UI.** `InfiniteLeaderboard.tsx` gains a third "By Category" tab + a category dropdown. Each row shows `1234 correct` as the primary metric and `🥇 Soul Reaper` (tier emoji + label) as the secondary line.
- **Firestore index.** `firestore.indexes.json` gets a new composite index — `triviaCategoryStats: categoryId asc, correctCount desc`. Until the index finishes building in production, the existing `Leaderboard is initializing…` fallback covers the gap automatically; no client changes needed.

## Deploy step (after merge)
The index needs to be deployed to production for the new sort to actually return data. Same pattern as the earlier triviaInfinite indexes — run:
```
firebase deploy --only firestore:indexes --project cometcave-2d1c4
```
I'll offer this once the PR merges (it's a production action so you should be the one to confirm).

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — 988/988 pass
- [x] `npx eslint` — clean on touched files
- [ ] Manual after deploy: open infinite leaderboard, pick "By Category" + a populated category, verify rows render with tier emoji + label
- [ ] Manual after deploy: confirm "Top Score" and "Top Streak" still work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)