### PR TITLE
fix: show empty-medal-slot indicator on unearned category tiles

### DIFF
--- a/src/app/trivia/components/InfiniteGame.tsx
+++ b/src/app/trivia/components/InfiniteGame.tsx
@@ -161,6 +161,10 @@ export function InfiniteGame({ onBack, onViewStats, onViewLeaderboard, mode = 's
                 const medal = medalsByCategoryId.get(id)
                 const earnedTier = medal && medal.tier !== 'none' ? medal.tier : null
                 const tierEmoji = earnedTier ? TIER_EMOJI[earnedTier] : null
+                // For categories with no medal yet, show a ghosted bronze
+                // medal as an empty-slot indicator so every tile reads as
+                // "there is a medal here to earn."
+                const showEmptySlot = !earnedTier && !!medal
                 const titleText = medal && medal.label
                   ? `${medal.label} — ${medal.correctCount} correct${medal.nextThreshold ? ` (next tier at ${medal.nextThreshold})` : ''}`
                   : medal
@@ -182,6 +186,14 @@ export function InfiniteGame({ onBack, onViewStats, onViewLeaderboard, mode = 's
                     {name}
                     {tierEmoji && (
                       <span aria-label={`${medal?.label ?? earnedTier} medal`}>{tierEmoji}</span>
+                    )}
+                    {showEmptySlot && (
+                      <span
+                        aria-label="No medal yet"
+                        className="opacity-30 grayscale"
+                      >
+                        🥉
+                      </span>
                     )}
                   </button>
                 )


### PR DESCRIPTION
## Summary
Fixes the missing half of the original "show medals or **visible lack of medal**" brief. PR #853 shipped the earned-medal badge but rendered nothing on tiles without a tier yet, so unearned categories looked unchanged.

Now: every tile that the API returns a medal record for shows either the colored earned-tier emoji **or** a ghosted bronze 🥉 (opacity 30%, grayscale) as an empty-slot indicator. Anonymous users still see no badges at all (consistent with the rest of the medal UX).

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx eslint` — only pre-existing warnings
- [ ] Manual: sign in, open infinite pre-game; every category tile shows either a colored medal or a ghosted bronze
- [ ] Manual: sign out, no badges anywhere

🤖 Generated with [Claude Code](https://claude.com/claude-code)