### PR TITLE
feat: by-category leaderboard shows all categories on one page

### DIFF
--- a/src/app/api/v1/trivia/infinite/leaderboard/route.ts
+++ b/src/app/api/v1/trivia/infinite/leaderboard/route.ts
@@ -1,7 +1,10 @@
 import { type NextRequest, NextResponse } from 'next/server'
 
 import { CATEGORY_META } from '@/lib/trivia/categories'
-import { getInfiniteTopByCategory } from '@/lib/trivia/categoryMedals'
+import {
+  getInfiniteLeaderboardAllCategories,
+  getInfiniteTopByCategory,
+} from '@/lib/trivia/categoryMedals'
 import { getInfiniteTopByScore, getInfiniteTopByStreak } from '@/lib/trivia/infiniteRuns'
 
 export async function GET(request: NextRequest) {
@@ -20,6 +23,7 @@ export async function GET(request: NextRequest) {
     }
 
     if (sort === 'category') {
+      // Single-category mode (kept for backward compat / direct linking).
       const categoryId = categoryIdParam !== null ? parseInt(categoryIdParam, 10) : NaN
       if (isNaN(categoryId) || !(categoryId in CATEGORY_META)) {
         return NextResponse.json(
@@ -31,8 +35,13 @@ export async function GET(request: NextRequest) {
       return NextResponse.json({ sort: 'category', categoryId, entries })
     }
 
+    if (sort === 'allCategories') {
+      const sections = await getInfiniteLeaderboardAllCategories(5)
+      return NextResponse.json({ sort: 'allCategories', sections })
+    }
+
     return NextResponse.json(
-      { error: 'Invalid sort. Use score, streak, or category.' },
+      { error: 'Invalid sort. Use score, streak, category, or allCategories.' },
       { status: 400 }
     )
   } catch (error: unknown) {
@@ -45,11 +54,11 @@ export async function GET(request: NextRequest) {
     ) {
       const urlMatch = errMsg.match(/(https:\/\/console\.firebase\.google\.com\S+)/)
       if (urlMatch) console.error('Create index here:', urlMatch[1])
-      return NextResponse.json({
-        sort,
-        entries: [],
-        notice: 'Leaderboard is initializing. Please try again in a few minutes.',
-      })
+      const initializingNotice = 'Leaderboard is initializing. Please try again in a few minutes.'
+      if (sort === 'allCategories') {
+        return NextResponse.json({ sort, sections: [], notice: initializingNotice })
+      }
+      return NextResponse.json({ sort, entries: [], notice: initializingNotice })
     }
     return NextResponse.json({ error: 'Failed to fetch leaderboard.' }, { status: 500 })
   }

--- a/src/app/trivia/components/InfiniteLeaderboard.tsx
+++ b/src/app/trivia/components/InfiniteLeaderboard.tsx
@@ -7,12 +7,11 @@ import { ChunkyButton } from '@/components/ui/chunky-button'
 import { ChunkyCard, ChunkyCardContent } from '@/components/ui/chunky-card'
 import { Pill } from '@/components/ui/pill'
 import { useAuth } from '@/hooks/useAuth'
-import { CATEGORY_META } from '@/lib/trivia/categories'
 import type { MedalTier } from '@/lib/trivia/medals'
 
 import { SignInBanner } from './SignInCTA'
 
-type Sort = 'score' | 'streak' | 'category'
+type Sort = 'score' | 'streak' | 'allCategories'
 
 interface OverallEntry {
   uid: string
@@ -30,20 +29,26 @@ interface CategoryEntry {
   label: string | null
 }
 
+interface CategorySection {
+  categoryId: number
+  categoryName: string
+  icon: string
+  entries: CategoryEntry[]
+}
+
 interface OverallResponse {
   sort: 'score' | 'streak'
   entries: OverallEntry[]
   notice?: string
 }
 
-interface CategoryResponse {
-  sort: 'category'
-  categoryId: number
-  entries: CategoryEntry[]
+interface AllCategoriesResponse {
+  sort: 'allCategories'
+  sections: CategorySection[]
   notice?: string
 }
 
-type LeaderboardResponse = OverallResponse | CategoryResponse
+type LeaderboardResponse = OverallResponse | AllCategoriesResponse
 
 const TIER_EMOJI: Record<MedalTier, string> = {
   none: '',
@@ -54,13 +59,10 @@ const TIER_EMOJI: Record<MedalTier, string> = {
   diamond: '💎',
 }
 
-const FIRST_CATEGORY_ID = Number(Object.keys(CATEGORY_META)[0])
-
 export function InfiniteLeaderboard({ onBack }: { onBack: () => void }) {
   const { user } = useAuth()
   const { displayName: triviaDisplayName } = useTriviaUser()
   const [sort, setSort] = useState<Sort>('score')
-  const [categoryId, setCategoryId] = useState<number>(FIRST_CATEGORY_ID)
   const [loading, setLoading] = useState(true)
   const [data, setData] = useState<LeaderboardResponse | null>(null)
   const [error, setError] = useState<string | null>(null)
@@ -73,10 +75,7 @@ export function InfiniteLeaderboard({ onBack }: { onBack: () => void }) {
       setLoading(true)
       setError(null)
       try {
-        const url = sort === 'category'
-          ? `/api/v1/trivia/infinite/leaderboard?sort=category&categoryId=${categoryId}`
-          : `/api/v1/trivia/infinite/leaderboard?sort=${sort}`
-        const res = await fetch(url)
+        const res = await fetch(`/api/v1/trivia/infinite/leaderboard?sort=${sort}`)
         if (!res.ok) throw new Error('Failed to load leaderboard')
         const json = (await res.json()) as LeaderboardResponse
         setData(json)
@@ -87,10 +86,47 @@ export function InfiniteLeaderboard({ onBack }: { onBack: () => void }) {
       }
     }
     load()
-  }, [sort, categoryId])
+  }, [sort])
 
-  const renderEntries = () => {
+  const renderContent = () => {
     if (!data) return null
+
+    if (data.sort === 'allCategories') {
+      if (data.sections.length === 0) {
+        return (
+          <div className="text-center text-on-surface/50 py-8 px-4">
+            {data.notice ?? 'No medals earned yet. Be the first!'}
+          </div>
+        )
+      }
+      return (
+        <div className="flex flex-col gap-4">
+          {data.sections.map((section) => (
+            <div key={section.categoryId} className="flex flex-col gap-1.5">
+              <div className="flex items-center gap-2 px-1">
+                <span aria-hidden="true">{section.icon}</span>
+                <span className="text-on-surface text-sm font-semibold">{section.categoryName}</span>
+              </div>
+              {section.entries.map((entry, i) => {
+                const tierEmoji = entry.tier !== 'none' ? TIER_EMOJI[entry.tier] : ''
+                const primary = `${entry.correctCount.toLocaleString()} correct`
+                const secondary = entry.label ? `${tierEmoji} ${entry.label}`.trim() : 'No medal yet'
+                return (
+                  <LeaderboardRow
+                    key={`${entry.uid}-${i}`}
+                    rank={i + 1}
+                    name={entry.displayName || 'Unknown'}
+                    primary={primary}
+                    secondary={secondary}
+                    isCurrentUser={!!currentUid && entry.uid === currentUid}
+                  />
+                )
+              })}
+            </div>
+          ))}
+        </div>
+      )
+    }
 
     if (data.entries.length === 0) {
       return (
@@ -100,43 +136,29 @@ export function InfiniteLeaderboard({ onBack }: { onBack: () => void }) {
       )
     }
 
-    if (data.sort === 'category') {
-      return data.entries.map((entry, i) => {
-        const tierEmoji = entry.tier !== 'none' ? TIER_EMOJI[entry.tier] : ''
-        const primary = `${entry.correctCount.toLocaleString()} correct`
-        const secondary = entry.label ? `${tierEmoji} ${entry.label}`.trim() : 'No medal yet'
-        return (
-          <LeaderboardRow
-            key={`${entry.uid}-${i}`}
-            rank={i + 1}
-            name={entry.displayName || 'Unknown'}
-            primary={primary}
-            secondary={secondary}
-            isCurrentUser={!!currentUid && entry.uid === currentUid}
-          />
-        )
-      })
-    }
+    return (
+      <div className="flex flex-col gap-1.5">
+        {data.entries.map((entry, i) => {
+          const primary = data.sort === 'score'
+            ? `${entry.score.toLocaleString()} pts`
+            : `${entry.longestStreak} streak`
+          const secondary = data.sort === 'score'
+            ? `${entry.longestStreak} streak · ${entry.questionsAnswered} Qs`
+            : `${entry.score.toLocaleString()} pts · ${entry.questionsAnswered} Qs`
 
-    return data.entries.map((entry, i) => {
-      const primary = data.sort === 'score'
-        ? `${entry.score.toLocaleString()} pts`
-        : `${entry.longestStreak} streak`
-      const secondary = data.sort === 'score'
-        ? `${entry.longestStreak} streak · ${entry.questionsAnswered} Qs`
-        : `${entry.score.toLocaleString()} pts · ${entry.questionsAnswered} Qs`
-
-      return (
-        <LeaderboardRow
-          key={`${entry.uid}-${i}`}
-          rank={i + 1}
-          name={entry.displayName || 'Unknown'}
-          primary={primary}
-          secondary={secondary}
-          isCurrentUser={!!currentUid && entry.uid === currentUid}
-        />
-      )
-    })
+          return (
+            <LeaderboardRow
+              key={`${entry.uid}-${i}`}
+              rank={i + 1}
+              name={entry.displayName || 'Unknown'}
+              primary={primary}
+              secondary={secondary}
+              isCurrentUser={!!currentUid && entry.uid === currentUid}
+            />
+          )
+        })}
+      </div>
+    )
   }
 
   return (
@@ -158,7 +180,7 @@ export function InfiniteLeaderboard({ onBack }: { onBack: () => void }) {
 
       {/* Sort tabs */}
       <div className="grid grid-cols-3 gap-2">
-        {(['score', 'streak', 'category'] as Sort[]).map((s) => (
+        {(['score', 'streak', 'allCategories'] as Sort[]).map((s) => (
           <ChunkyButton
             key={s}
             variant={sort === s ? 'primary' : 'secondary'}
@@ -169,22 +191,6 @@ export function InfiniteLeaderboard({ onBack }: { onBack: () => void }) {
         ))}
       </div>
 
-      {/* Category picker — only visible when "By Category" is selected */}
-      {sort === 'category' && (
-        <select
-          aria-label="Pick a category"
-          className="bg-surface-container-high text-on-surface border border-outline-variant rounded-ds-md py-2 px-3 text-sm"
-          value={categoryId}
-          onChange={(e) => setCategoryId(Number(e.target.value))}
-        >
-          {Object.entries(CATEGORY_META).map(([id, meta]) => (
-            <option key={id} value={id}>
-              {meta.icon} {meta.name}
-            </option>
-          ))}
-        </select>
-      )}
-
       {/* Content */}
       <ChunkyCard variant="surface-container-high" className="bg-surface-container/80 border-outline-variant">
         <ChunkyCardContent className="pt-4 pb-4">
@@ -193,7 +199,7 @@ export function InfiniteLeaderboard({ onBack }: { onBack: () => void }) {
           ) : error ? (
             <div className="text-center text-ds-error py-8">{error}</div>
           ) : (
-            <div className="flex flex-col gap-1.5">{renderEntries()}</div>
+            renderContent()
           )}
         </ChunkyCardContent>
       </ChunkyCard>

--- a/src/lib/trivia/categoryMedals.ts
+++ b/src/lib/trivia/categoryMedals.ts
@@ -57,6 +57,13 @@ export async function getCategoryMedalsForUser(uid: string): Promise<CategoryMed
   return result
 }
 
+export interface CategoryLeaderboardSection {
+  categoryId: number
+  categoryName: string
+  icon: string
+  entries: CategoryLeaderboardEntry[]
+}
+
 // Top players for one category, sorted by lifetime correctCount in that
 // category. Hydrates nicknames from the parent users/{uid} doc so the
 // leaderboard shows display names instead of raw uids.
@@ -99,4 +106,27 @@ export async function getInfiniteTopByCategory(
       label: getMedalLabel(categoryId, tier),
     }
   })
+}
+
+// Returns one section per category that has at least one player, each
+// with the top N players in that category. Categories with no players
+// are omitted. Runs the per-category query in parallel; reuses the
+// existing (categoryId asc, correctCount desc) collection-group index.
+export async function getInfiniteLeaderboardAllCategories(
+  limit = 5
+): Promise<CategoryLeaderboardSection[]> {
+  const categoryIds = Object.keys(CATEGORY_META).map(Number)
+  const sections = await Promise.all(
+    categoryIds.map(async (categoryId) => {
+      const entries = await getInfiniteTopByCategory(categoryId, limit)
+      const meta = CATEGORY_META[categoryId]
+      return {
+        categoryId,
+        categoryName: meta.name,
+        icon: meta.icon,
+        entries,
+      }
+    })
+  )
+  return sections.filter((s) => s.entries.length > 0)
 }


### PR DESCRIPTION
## Summary
Replaces the category-picker dropdown on the "By Category" leaderboard tab with a single sectioned page that lists every populated category and its top medalists.

- **No category selector** — pick is gone, the whole page is one read.
- **Hides empty categories** — only categories with at least one player render. Stays clean while the dataset is small; works the same way at scale.
- **Top 5 per category** — enough to see depth without making 20+ sections feel huge.

## Implementation
- New lib helper `getInfiniteLeaderboardAllCategories` runs the existing per-category query in parallel via `Promise.all` and filters out empty categories. **No new Firestore index needed** — reuses the `(categoryId asc, correctCount desc)` collection-group index from PR #865.
- Leaderboard route accepts `sort=allCategories` returning a `sections` array. The legacy `sort=category&categoryId=N` path is preserved in case anything ever wants to deep-link to a single category.
- `InfiniteLeaderboard.tsx` "By Category" tab now uses the new endpoint; dropdown deleted.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run` — 988/988 pass
- [x] `npx eslint` clean on touched files
- [ ] Manual: open infinite leaderboard, click "By Category", verify the populated categories render as sections; categories no one has played are absent

🤖 Generated with [Claude Code](https://claude.com/claude-code)