### PR TITLE
fix: infinite leaderboard index + hide anonymous players

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -53,6 +53,24 @@
       ]
     },
     {
+      "collectionGroup": "triviaInfinite",
+      "queryScope": "COLLECTION_GROUP",
+      "fields": [
+        { "fieldPath": "mode", "order": "ASCENDING" },
+        { "fieldPath": "score", "order": "DESCENDING" },
+        { "fieldPath": "endedAt", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "triviaInfinite",
+      "queryScope": "COLLECTION_GROUP",
+      "fields": [
+        { "fieldPath": "mode", "order": "ASCENDING" },
+        { "fieldPath": "longestStreak", "order": "DESCENDING" },
+        { "fieldPath": "endedAt", "order": "DESCENDING" }
+      ]
+    },
+    {
       "collectionGroup": "triviaCategoryStats",
       "queryScope": "COLLECTION_GROUP",
       "fields": [

--- a/src/app/api/v1/trivia/infinite/leaderboard/route.ts
+++ b/src/app/api/v1/trivia/infinite/leaderboard/route.ts
@@ -48,7 +48,6 @@ export async function GET(request: NextRequest) {
     console.error('Error fetching infinite leaderboard:', error)
     const errMsg = error instanceof Error ? error.message : String(error)
     if (
-      errMsg.includes('index') ||
       errMsg.includes('FAILED_PRECONDITION') ||
       errMsg.includes('requires an index')
     ) {

--- a/src/app/api/v1/trivia/leaderboard/route.ts
+++ b/src/app/api/v1/trivia/leaderboard/route.ts
@@ -32,7 +32,6 @@ export async function GET(request: NextRequest) {
     console.error('Error fetching leaderboard:', error)
     const errMsg = error instanceof Error ? error.message : String(error)
     if (
-      errMsg.includes('index') ||
       errMsg.includes('FAILED_PRECONDITION') ||
       errMsg.includes('requires an index')
     ) {

--- a/src/lib/trivia/categoryMedals.ts
+++ b/src/lib/trivia/categoryMedals.ts
@@ -72,11 +72,13 @@ export async function getInfiniteTopByCategory(
   limit = 20
 ): Promise<CategoryLeaderboardEntry[]> {
   const db = getFirestoreDb()
+  // Overfetch so the post-hydration "drop unnamed players" filter still
+  // returns up to `limit` entries.
   const snap = await db
     .collectionGroup('triviaCategoryStats')
     .where('categoryId', '==', categoryId)
     .orderBy('correctCount', 'desc')
-    .limit(limit)
+    .limit(limit * 2)
     .get()
 
   const rows = snap.docs.map((d) => {
@@ -96,16 +98,19 @@ export async function getInfiniteTopByCategory(
     if (data?.nickname) nicknameByUid.set(s.ref.id, data.nickname)
   }
 
-  return rows.map((r) => {
-    const tier = getMedalTier(r.correctCount)
-    return {
-      uid: r.uid,
-      displayName: nicknameByUid.get(r.uid) || 'Player',
-      correctCount: r.correctCount,
-      tier,
-      label: getMedalLabel(categoryId, tier),
-    }
-  })
+  return rows
+    .filter((r) => !!nicknameByUid.get(r.uid))
+    .slice(0, limit)
+    .map((r) => {
+      const tier = getMedalTier(r.correctCount)
+      return {
+        uid: r.uid,
+        displayName: nicknameByUid.get(r.uid) as string,
+        correctCount: r.correctCount,
+        tier,
+        label: getMedalLabel(categoryId, tier),
+      }
+    })
 }
 
 // Returns one section per category that has at least one player, each

--- a/src/lib/trivia/infiniteRuns.ts
+++ b/src/lib/trivia/infiniteRuns.ts
@@ -290,12 +290,14 @@ async function hydrateNicknames(uids: string[]): Promise<Map<string, string>> {
 
 export async function getInfiniteTopByScore(limit = 20): Promise<InfiniteLeaderboardEntry[]> {
   const db = getFirestoreDb()
+  // Overfetch so that the post-hydration filter that drops players without
+  // a nickname still returns up to `limit` entries.
   const snap = await db
     .collectionGroup('triviaInfinite')
     .where('mode', '==', 'scored')
     .where('endedAt', '!=', null)
     .orderBy('score', 'desc')
-    .limit(limit)
+    .limit(limit * 2)
     .get()
 
   const entries = snap.docs.map((d) => {
@@ -304,10 +306,13 @@ export async function getInfiniteTopByScore(limit = 20): Promise<InfiniteLeaderb
     return { uid, score: run.score, longestStreak: run.longestStreak, questionsAnswered: run.answers?.length ?? 0, date: run.endedAt }
   })
   const nicknames = await hydrateNicknames(entries.map((e) => e.uid))
-  return entries.map((e) => ({
-    ...e,
-    displayName: nicknames.get(e.uid) || 'Player',
-  }))
+  return entries
+    .filter((e) => !!nicknames.get(e.uid))
+    .slice(0, limit)
+    .map((e) => ({
+      ...e,
+      displayName: nicknames.get(e.uid) as string,
+    }))
 }
 
 export async function getInfiniteTopByStreak(limit = 20): Promise<InfiniteLeaderboardEntry[]> {
@@ -317,7 +322,7 @@ export async function getInfiniteTopByStreak(limit = 20): Promise<InfiniteLeader
     .where('mode', '==', 'scored')
     .where('endedAt', '!=', null)
     .orderBy('longestStreak', 'desc')
-    .limit(limit)
+    .limit(limit * 2)
     .get()
 
   const entries = snap.docs.map((d) => {
@@ -326,8 +331,11 @@ export async function getInfiniteTopByStreak(limit = 20): Promise<InfiniteLeader
     return { uid, score: run.score, longestStreak: run.longestStreak, questionsAnswered: run.answers?.length ?? 0, date: run.endedAt }
   })
   const nicknames = await hydrateNicknames(entries.map((e) => e.uid))
-  return entries.map((e) => ({
-    ...e,
-    displayName: nicknames.get(e.uid) || 'Player',
-  }))
+  return entries
+    .filter((e) => !!nicknames.get(e.uid))
+    .slice(0, limit)
+    .map((e) => ({
+      ...e,
+      displayName: nicknames.get(e.uid) as string,
+    }))
 }

--- a/src/lib/trivia/queries.ts
+++ b/src/lib/trivia/queries.ts
@@ -55,25 +55,46 @@ async function hydrateNicknames(uids: string[]): Promise<Map<string, string>> {
   return map
 }
 
+// Returns the resolved display name for a leaderboard row, preferring the
+// player's current nickname and falling back to the snapshot taken when
+// the row was written. Returns null for fully-anonymous players (no
+// nickname in either place) so callers can drop them.
+function resolveDisplayName(
+  uid: string,
+  nicknames: Map<string, string>,
+  snapshot: string | undefined | null
+): string | null {
+  return nicknames.get(uid) || snapshot || null
+}
+
 export async function getDailyTop(date: string, limit = 20): Promise<TriviaLeaderboardEntry[]> {
   const db = getFirestoreDb()
+  // Overfetch so the post-hydration drop-anonymous filter still returns
+  // up to `limit` named entries.
   const snap = await db
     .collectionGroup('triviaDaily')
     .where('date', '==', date)
     .orderBy('score', 'desc')
-    .limit(limit)
+    .limit(limit * 2)
     .get()
 
   const docs = snap.docs.map((d) => d.data() as DailyDoc)
   const nicknames = await hydrateNicknames(docs.map((d) => d.uid))
 
-  return docs.map((d) => ({
-    uid: d.uid,
-    displayName: nicknames.get(d.uid) || d.nicknameSnapshot,
-    score: d.score,
-    correct: d.correct,
-    total: d.total,
-  }))
+  const result: TriviaLeaderboardEntry[] = []
+  for (const d of docs) {
+    const displayName = resolveDisplayName(d.uid, nicknames, d.nicknameSnapshot)
+    if (!displayName) continue
+    result.push({
+      uid: d.uid,
+      displayName,
+      score: d.score,
+      correct: d.correct,
+      total: d.total,
+    })
+    if (result.length >= limit) break
+  }
+  return result
 }
 
 export async function getWeeklyTop(
@@ -85,21 +106,28 @@ export async function getWeeklyTop(
     .collectionGroup('triviaWeekly')
     .where('weekKey', '==', weekKey)
     .orderBy('totalScore', 'desc')
-    .limit(limit)
+    .limit(limit * 2)
     .get()
 
   const docs = snap.docs.map((d) => d.data() as WeeklyDoc)
   const nicknames = await hydrateNicknames(docs.map((d) => d.uid))
 
-  return docs.map((d) => ({
-    uid: d.uid,
-    displayName: nicknames.get(d.uid) || d.nicknameSnapshot,
-    score: d.totalScore,
-    totalScore: d.totalScore,
-    gamesPlayed: d.gamesPlayed,
-    totalCorrect: d.totalCorrect,
-    totalQuestions: d.totalQuestions,
-  }))
+  const result: TriviaLeaderboardEntry[] = []
+  for (const d of docs) {
+    const displayName = resolveDisplayName(d.uid, nicknames, d.nicknameSnapshot)
+    if (!displayName) continue
+    result.push({
+      uid: d.uid,
+      displayName,
+      score: d.totalScore,
+      totalScore: d.totalScore,
+      gamesPlayed: d.gamesPlayed,
+      totalCorrect: d.totalCorrect,
+      totalQuestions: d.totalQuestions,
+    })
+    if (result.length >= limit) break
+  }
+  return result
 }
 
 export async function getAllTimeTop(limit = 20): Promise<TriviaLeaderboardEntry[]> {
@@ -111,10 +139,11 @@ export async function getAllTimeTop(limit = 20): Promise<TriviaLeaderboardEntry[
     crownCounts.set(crown.winnerUid, (crownCounts.get(crown.winnerUid) ?? 0) + 1)
   }
 
-  // Sort by crown count desc, take top N
+  // Sort by crown count desc, overfetch so the drop-anonymous filter
+  // still returns up to `limit` named entries.
   const sorted = Array.from(crownCounts.entries())
     .sort((a, b) => b[1] - a[1])
-    .slice(0, limit)
+    .slice(0, limit * 2)
 
   if (sorted.length === 0) {
     return []
@@ -122,10 +151,13 @@ export async function getAllTimeTop(limit = 20): Promise<TriviaLeaderboardEntry[
 
   const nicknames = await hydrateNicknames(sorted.map(([uid]) => uid))
 
-  return sorted.map(([uid, count]) => ({
-    uid,
-    displayName: nicknames.get(uid) || 'Player',
-    score: count,
-    crowns: count,
-  }))
+  return sorted
+    .filter(([uid]) => !!nicknames.get(uid))
+    .slice(0, limit)
+    .map(([uid, count]) => ({
+      uid,
+      displayName: nicknames.get(uid) as string,
+      score: count,
+      crowns: count,
+    }))
 }


### PR DESCRIPTION
## Summary
Three connected leaderboard fixes — the real cause of the persistent "initializing" message, plus two preventive fixes.

### 1. Real cause of "Leaderboard is initializing" on Top Score / Top Streak
Firestore changed how it selects indexes for queries that combine `!=` with `orderBy` on a different field. The actual error from production:

> The query contains range and inequality filters on multiple fields, please refer to... https://cloud.google.com/firestore/docs/query-data/multiple-range-fields

The hint URL's encoded protobuf decodes to `mode ASC, score DESC, endedAt DESC` — different from our existing `mode ASC, endedAt ASC, score DESC`. Same for the streak query. **Adds two new composite indexes**; keeps the old ones in case anything else needs them.

> ⚠️ This requires `firebase deploy --only firestore:indexes --project cometcave-2d1c4` to take effect.

### 2. Tighter error matcher
The route's catch block routed any error containing the literal substring **"index"** to the "initializing" notice — which is exactly how (1) was masked for days. Now matches only the explicit Firestore signals (`FAILED_PRECONDITION` and `requires an index`). Same fix in the daily leaderboard route.

### 3. Hide anonymous players from leaderboards
Players without a nickname were showing up as the literal string **"Player"** on every leaderboard surface. Now every leaderboard query overfetches by 2x and drops entries whose uid doesn't have a current nickname (daily/weekly also accept their stored `nicknameSnapshot` as a fallback identity). Returns up to `limit` named entries.

Files touched:
- `firestore.indexes.json` — two new triviaInfinite composite indexes
- `src/app/api/v1/trivia/infinite/leaderboard/route.ts` — error matcher
- `src/app/api/v1/trivia/leaderboard/route.ts` — error matcher
- `src/lib/trivia/infiniteRuns.ts` — overfetch + filter (Top Score, Top Streak)
- `src/lib/trivia/categoryMedals.ts` — overfetch + filter (per-category top)
- `src/lib/trivia/queries.ts` — overfetch + filter (Daily, Weekly, All-time)

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run` — 988/988 pass
- [x] `npx eslint` clean on touched files
- [x] Repro confirmed locally: ran the same query via Firebase Admin and got the exact error above
- [ ] **After deploy:** `curl -sL "https://cometcave.com/api/v1/trivia/infinite/leaderboard?sort=score"` should return non-empty entries (no `notice`)
- [ ] **After deploy:** Daily / Infinite leaderboards no longer show entries labeled "Player"

🤖 Generated with [Claude Code](https://claude.com/claude-code)