### PR TITLE
feat: live per-category progress in infinite HUD with tick-up animation

### DIFF
--- a/src/app/trivia/components/InfiniteGame.tsx
+++ b/src/app/trivia/components/InfiniteGame.tsx
@@ -7,7 +7,8 @@ import type { InfiniteMode } from '@/app/trivia/hooks/useInfiniteRun'
 import { ChunkyButton } from '@/components/ui/chunky-button'
 import { ChunkyCard, ChunkyCardContent } from '@/components/ui/chunky-card'
 import { useAuth } from '@/hooks/useAuth'
-import { CATEGORY_META } from '@/lib/trivia/categories'
+import { CATEGORY_META, getCategoryIdByName } from '@/lib/trivia/categories'
+import { getMedalTier, getNextThreshold } from '@/lib/trivia/medals'
 
 import { InfiniteExhaustedScreen } from './InfiniteExhaustedScreen'
 import { InfiniteHUD } from './InfiniteHUD'
@@ -295,6 +296,34 @@ export function InfiniteGame({ onBack, onViewStats, onViewLeaderboard, mode = 's
   // Playing or answered
   if (!state.question) return null
 
+  // Live per-category progress for the question currently on screen.
+  // Lifetime baseline comes from the category-stats fetch on mount; in-run
+  // delta is tracked by useInfiniteRun. Combined they give the count we
+  // display, plus the next-tier threshold for the "47 / 64" suffix.
+  const currentQuestionCategoryId = state.question
+    ? getCategoryIdByName(state.question.category)
+    : null
+  const currentQuestionCategoryMeta =
+    currentQuestionCategoryId !== null ? CATEGORY_META[currentQuestionCategoryId] : null
+  const baselineCount =
+    currentQuestionCategoryId !== null
+      ? medalsByCategoryId.get(currentQuestionCategoryId)?.correctCount ?? 0
+      : 0
+  const runDelta =
+    currentQuestionCategoryId !== null
+      ? state.correctsByCategoryThisRun[currentQuestionCategoryId] ?? 0
+      : 0
+  const liveCorrectCount = baselineCount + runDelta
+  const categoryProgress =
+    currentQuestionCategoryId !== null && currentQuestionCategoryMeta && state.mode === 'scored'
+      ? {
+          name: currentQuestionCategoryMeta.name,
+          icon: currentQuestionCategoryMeta.icon,
+          correctCount: liveCorrectCount,
+          nextThreshold: getNextThreshold(getMedalTier(liveCorrectCount)),
+        }
+      : null
+
   return (
     <div className="flex flex-col gap-3 sm:gap-4 max-w-lg mx-auto py-2 sm:py-4">
       <InfiniteHUD
@@ -307,6 +336,7 @@ export function InfiniteGame({ onBack, onViewStats, onViewLeaderboard, mode = 's
         isPlaying={state.phase === 'playing'}
         mode={state.mode}
         categoryName={state.categoryId != null ? CATEGORY_META[state.categoryId]?.name : undefined}
+        categoryProgress={categoryProgress}
         skipsRemaining={state.skipsRemaining}
       />
 

--- a/src/app/trivia/components/InfiniteHUD.tsx
+++ b/src/app/trivia/components/InfiniteHUD.tsx
@@ -1,9 +1,17 @@
 'use client'
-import { useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
+
+import type { InfiniteMode } from '@/app/trivia/hooks/useInfiniteRun'
+import { LIVES_MAX, computeStreakMultiplier } from '@/app/trivia/lib/infiniteScoring'
 import { ChunkyButton } from '@/components/ui/chunky-button'
 import { Pill, ScoreChip } from '@/components/ui/pill'
-import { computeStreakMultiplier, LIVES_MAX } from '@/app/trivia/lib/infiniteScoring'
-import type { InfiniteMode } from '@/app/trivia/hooks/useInfiniteRun'
+
+export interface CategoryProgress {
+  name: string
+  icon?: string
+  correctCount: number
+  nextThreshold: number | null
+}
 
 interface InfiniteHUDProps {
   livesRemaining: number
@@ -15,7 +23,49 @@ interface InfiniteHUDProps {
   isPlaying: boolean
   mode?: InfiniteMode
   categoryName?: string
+  categoryProgress?: CategoryProgress | null
   skipsRemaining?: number
+}
+
+// Renders a number that briefly pulses + floats a "+1" badge when it
+// increases. Used by the HUD's per-category progress line so each correct
+// answer feels like it landed.
+function TickUpCount({ value }: { value: number }) {
+  const prev = useRef(value)
+  const [pulse, setPulse] = useState(false)
+
+  useEffect(() => {
+    if (value > prev.current) {
+      // Transient animation flag triggered by a prop change; the cascade
+      // is bounded (one extra render to clear pulse after the timeout).
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      setPulse(true)
+      const id = window.setTimeout(() => setPulse(false), 700)
+      prev.current = value
+      return () => window.clearTimeout(id)
+    }
+    prev.current = value
+  }, [value])
+
+  return (
+    <span className="relative inline-block">
+      <span
+        className={`inline-block transition-transform duration-300 ${
+          pulse ? 'scale-125 text-ds-tertiary' : 'scale-100'
+        }`}
+      >
+        {value}
+      </span>
+      {pulse && (
+        <span
+          aria-hidden="true"
+          className="absolute -top-3 left-1/2 -translate-x-1/2 text-ds-tertiary text-[10px] font-bold animate-bounce"
+        >
+          +1
+        </span>
+      )}
+    </span>
+  )
 }
 
 export function InfiniteHUD({
@@ -28,6 +78,7 @@ export function InfiniteHUD({
   isPlaying,
   mode = 'scored',
   categoryName,
+  categoryProgress,
   skipsRemaining,
 }: InfiniteHUDProps) {
   const [showFleeConfirm, setShowFleeConfirm] = useState(false)
@@ -107,11 +158,23 @@ export function InfiniteHUD({
         />
       </div>
 
-      {/* Timer pill + category label */}
-      <div className="flex justify-center items-center gap-2">
+      {/* Timer pill + category progress */}
+      <div className="flex justify-center items-center gap-2 flex-wrap">
         <Pill tone="neutral" size="sm">{Math.ceil(timeRemaining)}s</Pill>
-        {categoryName && (
-          <Pill tone="neutral" size="sm">{categoryName}</Pill>
+        {categoryProgress ? (
+          <Pill tone="neutral" size="sm">
+            <span className="flex items-center gap-1">
+              {categoryProgress.icon && <span aria-hidden="true">{categoryProgress.icon}</span>}
+              <span>{categoryProgress.name}</span>
+              <span className="opacity-60">·</span>
+              <TickUpCount value={categoryProgress.correctCount} />
+              {categoryProgress.nextThreshold != null && (
+                <span className="opacity-60">/ {categoryProgress.nextThreshold}</span>
+              )}
+            </span>
+          </Pill>
+        ) : (
+          categoryName && <Pill tone="neutral" size="sm">{categoryName}</Pill>
         )}
       </div>
 

--- a/src/app/trivia/hooks/useInfiniteRun.ts
+++ b/src/app/trivia/hooks/useInfiniteRun.ts
@@ -3,6 +3,7 @@ import { useCallback, useRef, useState } from 'react'
 
 import { type AnswerResult, LIVES_START, SKIPS_PER_RUN } from '@/app/trivia/lib/infiniteScoring'
 import { useAuth } from '@/hooks/useAuth'
+import { getCategoryIdByName } from '@/lib/trivia/categories'
 import type { MedalEarned } from '@/lib/trivia/medals'
 
 export type InfinitePhase = 'idle' | 'loading' | 'playing' | 'answering' | 'answered' | 'exhausted' | 'ended' | 'error'
@@ -33,6 +34,10 @@ export interface InfiniteRunState {
   skipsUsed: number
   flaggedQuestionIds: string[]
   lastAnswer: (AnswerResult & { trailblazer: boolean; correctAnswer: string; explanation: string | null; timesShown?: number; timesCorrect?: number; medalEarned?: MedalEarned | null }) | null
+  // Per-category correct-answer deltas accumulated within the current run.
+  // Combined with each category's lifetime baseline (from the category-stats
+  // API), this gives the player's live count for any question.
+  correctsByCategoryThisRun: Record<number, number>
   answers: Array<{
     questionId: string
     correct: boolean
@@ -67,6 +72,7 @@ export function useInfiniteRun() {
     skipsUsed: 0,
     flaggedQuestionIds: [],
     lastAnswer: null,
+    correctsByCategoryThisRun: {},
     answers: [],
     error: null,
   })
@@ -160,6 +166,7 @@ export function useInfiniteRun() {
         skipsUsed: 0,
         flaggedQuestionIds: [],
         lastAnswer: null,
+        correctsByCategoryThisRun: {},
         answers: [],
       }))
     } catch (err) {
@@ -201,10 +208,16 @@ export function useInfiniteRun() {
         startPrefetch(result.currentStreak, state.categoryId)
       }
 
+      // If this was a correct answer in scored mode, increment the live
+      // per-category counter (HUD shows it as the player's current count).
+      const answeredCategoryId = getCategoryIdByName(currentQuestion.category)
+
       // Always show the answer feedback (correct answer + explanation + rating)
       // before transitioning to the summary, even when this answer ended the
       // run. The player clicks through to view the summary.
-      setState(s => ({
+      setState(s => {
+        const shouldBump = result.correct && s.mode === 'scored' && answeredCategoryId !== null
+        return {
         ...s,
         phase: 'answered',
         lastAnswer: result,
@@ -214,6 +227,9 @@ export function useInfiniteRun() {
         score: result.score,
         questionsAnswered: s.questionsAnswered + 1,
         trailblazes: result.trailblazer ? s.trailblazes + 1 : s.trailblazes,
+        correctsByCategoryThisRun: shouldBump && answeredCategoryId !== null
+          ? { ...s.correctsByCategoryThisRun, [answeredCategoryId]: (s.correctsByCategoryThisRun[answeredCategoryId] ?? 0) + 1 }
+          : s.correctsByCategoryThisRun,
         answers: [...s.answers, {
           questionId: currentQuestionId,
           correct: result.correct,
@@ -227,7 +243,8 @@ export function useInfiniteRun() {
           correctAnswer: result.correctAnswer,
           explanation: result.explanation,
         }],
-      }))
+        }
+      })
     } catch (err) {
       console.error('[infinite] submitAnswer failed:', err)
       setState(s => ({ ...s, phase: 'error', error: 'Failed to submit answer.' }))


### PR DESCRIPTION
## Summary
Implements the A + C combination from the progress-feedback proposal: a live per-category counter in the HUD plus a tick-up animation on each correct answer.

The current question's category now renders as a pill in the HUD: `🎌 Anime & Manga · 47 / 64`, where the count ticks up with a scale-pulse and a floating "+1" badge when a correct answer lands. The threshold on the right is the next-tier medal target — once at Diamond (4096), the suffix disappears.

## Implementation
**No server changes.** Numbers are derived entirely client-side:
- **Lifetime baseline** — already fetched via `useCategoryMedals` (the existing category-stats API).
- **In-run delta** — added to `useInfiniteRun` state as `correctsByCategoryThisRun: Record<number, number>`. Resets on `startRun`; bumps on each correct scored answer using the question's category (looked up via the existing `getCategoryIdByName`).
- **Display count** — `baseline + delta`. Tier and next-threshold are computed from `getMedalTier` + `getNextThreshold`.

**HUD changes:**
- New optional `categoryProgress` prop on `InfiniteHUD`.
- New small `TickUpCount` subcomponent: watches the prop value, plays a scale-up + "+1" floater whenever the value increases.
- Falls back to the existing static `categoryName` pill if `categoryProgress` isn't passed (Practice mode, anonymous users).

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run` — all tests pass
- [x] `npx eslint` clean on touched files
- [ ] Manual: start a scored run in any category, answer questions correctly, verify count ticks up with pulse + "+1"
- [ ] Manual: start in "All" mode, verify the HUD pill shows whichever category the *current* question belongs to (not the run's "All" selection)
- [ ] Manual: start a Practice run, verify no progress pill (since practice doesn't count toward medals)
- [ ] Manual: at Diamond tier (4096+), verify the threshold suffix disappears

🤖 Generated with [Claude Code](https://claude.com/claude-code)