### PR TITLE
feat: multi-select categories + start button above the fold

### DIFF
--- a/src/app/api/v1/trivia/infinite/next/route.ts
+++ b/src/app/api/v1/trivia/infinite/next/route.ts
@@ -3,13 +3,14 @@ import { type NextRequest, NextResponse } from 'next/server'
 import { verifyRequestAuth } from '@/lib/api/auth'
 import type { AIQuestion } from '@/lib/trivia/aiQuestions'
 import { saveAIQuestion } from '@/lib/trivia/aiQuestions'
+import { CATEGORY_META } from '@/lib/trivia/categories'
 import { generateInfiniteQuestion } from '@/lib/trivia/generateQuestion'
-import { checkAndIncrementGenerationLimit, MAX_GENERATIONS_PER_WINDOW, WINDOW_MS } from '@/lib/trivia/generationLimit'
+import { MAX_GENERATIONS_PER_WINDOW, WINDOW_MS, checkAndIncrementGenerationLimit } from '@/lib/trivia/generationLimit'
 import { sampleNextQuestion } from '@/lib/trivia/sampler'
 import { trackExhaustion } from '@/lib/trivia/triviaStats'
-import { CATEGORY_META } from '@/lib/trivia/categories'
 
-// GET /api/v1/trivia/infinite/next?streak=N&categoryId=N
+// GET /api/v1/trivia/infinite/next?streak=N[&categoryIds=12,13,15]
+// Backward-compat: also accepts the legacy single ?categoryId=N param.
 export async function GET(request: NextRequest) {
   const auth = await verifyRequestAuth(request)
   if ('error' in auth) return auth.error
@@ -19,22 +20,25 @@ export async function GET(request: NextRequest) {
   const streak = streakParam !== null ? parseInt(streakParam, 10) : 0
   const parsedStreak = isNaN(streak) || streak < 0 ? 0 : streak
 
-  // Parse optional categoryId
-  let categoryId: number | undefined
-  const categoryIdParam = searchParams.get('categoryId')
-  if (categoryIdParam !== null) {
-    const parsed = parseInt(categoryIdParam, 10)
-    if (!isNaN(parsed) && parsed in CATEGORY_META) {
-      categoryId = parsed
-    }
-  }
+  // Parse optional categoryIds (comma-separated). Legacy single
+  // ?categoryId= is honored too.
+  const categoryIdsParam = searchParams.get('categoryIds')
+  const legacyCategoryIdParam = searchParams.get('categoryId')
+  const rawIds = categoryIdsParam !== null
+    ? categoryIdsParam.split(',')
+    : legacyCategoryIdParam !== null
+      ? [legacyCategoryIdParam]
+      : []
+  const categoryIds = rawIds
+    .map((s) => parseInt(s, 10))
+    .filter((n) => !isNaN(n) && n in CATEGORY_META)
 
   try {
     let question = await sampleNextQuestion({
       uid: auth.claims.uid,
       streak: parsedStreak,
       type: 'free-text',
-      categoryId,
+      categoryIds,
     })
 
     if (question === null) {
@@ -56,7 +60,12 @@ export async function GET(request: NextRequest) {
       }
 
       try {
-        const generated = await generateInfiniteQuestion({ streak: parsedStreak, categoryId })
+        // For multi-category runs, pick a random selected category to
+        // generate within. (Single-category runs reuse the same id.)
+        const generationCategoryId = categoryIds.length > 0
+          ? categoryIds[Math.floor(Math.random() * categoryIds.length)]
+          : undefined
+        const generated = await generateInfiniteQuestion({ streak: parsedStreak, categoryId: generationCategoryId })
         await saveAIQuestion(generated)
         question = {
           ...generated,

--- a/src/app/api/v1/trivia/infinite/runs/route.ts
+++ b/src/app/api/v1/trivia/infinite/runs/route.ts
@@ -2,8 +2,8 @@ import { type NextRequest, NextResponse } from 'next/server';
 
 import { verifyRequestAuth } from '@/lib/api/auth';
 import { getFirestoreDb } from '@/lib/firebase/server';
-import { startRun } from '@/lib/trivia/infiniteRuns';
 import { CATEGORY_META } from '@/lib/trivia/categories';
+import { startRun } from '@/lib/trivia/infiniteRuns';
 
 export async function GET(request: NextRequest) {
   const auth = await verifyRequestAuth(request)
@@ -50,16 +50,21 @@ export async function POST(request: NextRequest) {
     const body = await request.json();
     const mode = body.mode === 'practice' ? 'practice' : 'scored';
 
-    // Parse and validate optional categoryId
-    let categoryId: number | undefined
-    if (body.categoryId !== undefined && body.categoryId !== null) {
+    // Parse and validate categoryIds (preferred) — falls back to the legacy
+    // single categoryId field for backward compatibility.
+    let categoryIds: number[] = []
+    if (Array.isArray(body.categoryIds)) {
+      categoryIds = body.categoryIds
+        .map((v: unknown) => Number(v))
+        .filter((n: number) => !isNaN(n) && n in CATEGORY_META)
+    } else if (body.categoryId !== undefined && body.categoryId !== null) {
       const parsed = Number(body.categoryId)
       if (!isNaN(parsed) && parsed in CATEGORY_META) {
-        categoryId = parsed
+        categoryIds = [parsed]
       }
     }
 
-    const result = await startRun(auth.claims.uid, mode, categoryId);
+    const result = await startRun(auth.claims.uid, mode, categoryIds);
     return NextResponse.json(result, { status: 201 });
   } catch (err) {
     console.error('Failed to start infinite run:', err);

--- a/src/app/trivia/components/InfiniteGame.tsx
+++ b/src/app/trivia/components/InfiniteGame.tsx
@@ -33,7 +33,9 @@ export function InfiniteGame({ onBack, onViewStats, onViewLeaderboard, mode = 's
   const timerStartRef = useRef<number>(0)
   const hasStartedRef = useRef(false)
   const [showPreGame, setShowPreGame] = useState(true)
-  const [selectedCategoryId, setSelectedCategoryId] = useState<number | undefined>(undefined)
+  // Empty set = "All Categories" (no filter). Players toggle individual
+  // tiles to build up a multi-category selection.
+  const [selectedCategoryIds, setSelectedCategoryIds] = useState<Set<number>>(new Set())
   const [showRulesOverlay, setShowRulesOverlay] = useState(false)
   const [bonusLifeToast, setBonusLifeToast] = useState<string | null>(null)
   const [medalToast, setMedalToast] = useState<string | null>(null)
@@ -58,8 +60,17 @@ export function InfiniteGame({ onBack, onViewStats, onViewLeaderboard, mode = 's
     }
     hasStartedRef.current = true
     setShowPreGame(false)
-    startRun(chosenMode, selectedCategoryId)
-  }, [mode, startRun, selectedCategoryId])
+    startRun(chosenMode, Array.from(selectedCategoryIds))
+  }, [mode, startRun, selectedCategoryIds])
+
+  const toggleCategoryId = useCallback((id: number) => {
+    setSelectedCategoryIds((prev) => {
+      const next = new Set(prev)
+      if (next.has(id)) next.delete(id)
+      else next.add(id)
+      return next
+    })
+  }, [])
 
   // Timer logic
   useEffect(() => {
@@ -128,6 +139,11 @@ export function InfiniteGame({ onBack, onViewStats, onViewLeaderboard, mode = 's
 
   // Pre-game screen — inline, not a modal
   if (showPreGame) {
+    const selectionCount = selectedCategoryIds.size
+    const isAllMode = selectionCount === 0
+    const startLabel = isAllMode
+      ? 'Start'
+      : `Start (${selectionCount} categor${selectionCount === 1 ? 'y' : 'ies'})`
     return (
       <div className="flex flex-col gap-4 max-w-lg mx-auto py-6">
         <div className="text-center">
@@ -141,28 +157,47 @@ export function InfiniteGame({ onBack, onViewStats, onViewLeaderboard, mode = 's
           </button>
         </div>
 
-        {/* Category selector — always visible, inline */}
+        {/* All-categories quick-pick + Start buttons sit above the grid so
+            the most common action is always visible without scrolling. */}
+        <div className="flex flex-col gap-2">
+          <button
+            type="button"
+            onClick={() => setSelectedCategoryIds(new Set())}
+            className={`flex items-center justify-center gap-2 py-2 rounded-ds-md text-sm font-medium transition-colors ${
+              isAllMode
+                ? 'bg-ds-primary text-on-primary'
+                : 'bg-surface-container text-on-surface/80 hover:bg-surface-container-highest'
+            }`}
+          >
+            <span aria-hidden="true">🌐</span>
+            All Categories
+          </button>
+          <ChunkyButton variant="primary" size="lg" className="w-full" onClick={() => handleStart(mode === 'practice' ? 'practice' : 'scored')}>
+            {startLabel}
+          </ChunkyButton>
+          <ChunkyButton variant="secondary" size="sm" className="w-full" onClick={() => handleStart('practice')}>
+            Practice Mode
+          </ChunkyButton>
+        </div>
+
+        {/* Browse + multi-select categories. Tapping a tile toggles
+            membership; "All Categories" above clears the set. */}
         <ChunkyCard variant="surface-variant">
           <ChunkyCardContent className="pt-4 pb-4 flex flex-col gap-3">
-            <p className="text-on-surface/70 text-sm font-medium">Category</p>
-            <button
-              type="button"
-              onClick={() => setSelectedCategoryId(undefined)}
-              className={`flex items-center justify-center gap-2 py-2 rounded-ds-md text-sm font-medium transition-colors ${
-                selectedCategoryId === undefined
-                  ? 'bg-ds-primary text-on-primary'
-                  : 'bg-surface-container text-on-surface/80 hover:bg-surface-container-highest'
-              }`}
-            >
-              <span aria-hidden="true">🌐</span>
-              All Categories
-            </button>
+            <p className="text-on-surface/70 text-sm font-medium">
+              Pick categories
+              {selectionCount > 0 && (
+                <span className="ml-2 text-on-surface/50 text-xs">
+                  · {selectionCount} selected
+                </span>
+              )}
+            </p>
             <div className="grid grid-cols-2 sm:grid-cols-3 gap-2">
               {categoryEntries.map(({ id, name, icon }) => {
                 const medal = medalsByCategoryId.get(id)
                 const earnedTier = medal && medal.tier !== 'none' ? medal.tier : null
                 const tierEmoji = earnedTier ? TIER_EMOJI[earnedTier] : null
-                const isSelected = selectedCategoryId === id
+                const isSelected = selectedCategoryIds.has(id)
                 const titleText = medal && medal.label
                   ? `${medal.label} — ${medal.correctCount} correct${medal.nextThreshold ? ` (next tier at ${medal.nextThreshold})` : ''}`
                   : medal
@@ -172,8 +207,9 @@ export function InfiniteGame({ onBack, onViewStats, onViewLeaderboard, mode = 's
                   <button
                     key={id}
                     type="button"
-                    onClick={() => setSelectedCategoryId(id)}
+                    onClick={() => toggleCategoryId(id)}
                     title={titleText}
+                    aria-pressed={isSelected}
                     className={`flex flex-col items-center justify-between gap-2 p-3 rounded-ds-md text-xs font-medium transition-colors min-h-[120px] ${
                       isSelected
                         ? 'bg-ds-primary text-on-primary ring-2 ring-ds-primary'
@@ -209,16 +245,6 @@ export function InfiniteGame({ onBack, onViewStats, onViewLeaderboard, mode = 's
             </div>
           </ChunkyCardContent>
         </ChunkyCard>
-
-        {/* Start buttons */}
-        <div className="flex flex-col gap-2">
-          <ChunkyButton variant="primary" size="lg" className="w-full" onClick={() => handleStart(mode === 'practice' ? 'practice' : 'scored')}>
-            Start
-          </ChunkyButton>
-          <ChunkyButton variant="secondary" size="sm" className="w-full" onClick={() => handleStart('practice')}>
-            Practice Mode
-          </ChunkyButton>
-        </div>
 
         <ChunkyButton variant="ghost" size="sm" onClick={onBack}>
           ← Back to Trivia
@@ -335,7 +361,13 @@ export function InfiniteGame({ onBack, onViewStats, onViewLeaderboard, mode = 's
         onFlee={handleFlee}
         isPlaying={state.phase === 'playing'}
         mode={state.mode}
-        categoryName={state.categoryId != null ? CATEGORY_META[state.categoryId]?.name : undefined}
+        categoryName={
+          state.categoryIds.length === 1
+            ? CATEGORY_META[state.categoryIds[0]]?.name
+            : state.categoryIds.length > 1
+              ? `${state.categoryIds.length} categories`
+              : undefined
+        }
         categoryProgress={categoryProgress}
         skipsRemaining={state.skipsRemaining}
       />

--- a/src/app/trivia/hooks/useInfiniteRun.ts
+++ b/src/app/trivia/hooks/useInfiniteRun.ts
@@ -20,7 +20,8 @@ export interface InfiniteQuestion {
 export interface InfiniteRunState {
   phase: InfinitePhase
   mode: InfiniteMode
-  categoryId: number | null
+  // Empty array = all categories.
+  categoryIds: number[]
   runId: string | null
   question: InfiniteQuestion | null
   livesRemaining: number
@@ -58,7 +59,7 @@ export function useInfiniteRun() {
   const [state, setState] = useState<InfiniteRunState>({
     phase: 'idle',
     mode: 'scored',
-    categoryId: null,
+    categoryIds: [],
     runId: null,
     question: null,
     livesRemaining: LIVES_START,
@@ -98,7 +99,7 @@ export function useInfiniteRun() {
     prefetchRef.current = null
   }, [])
 
-  const startPrefetch = useCallback((streak: number, categoryId?: number | null) => {
+  const startPrefetch = useCallback((streak: number, categoryIds: number[]) => {
     cancelPrefetch()
     const controller = new AbortController()
     prefetchAbortRef.current = controller
@@ -106,7 +107,7 @@ export function useInfiniteRun() {
       try {
         const headers = await getAuthHeaders()
         const params = new URLSearchParams({ streak: String(streak) })
-        if (categoryId != null) params.set('categoryId', String(categoryId))
+        if (categoryIds.length > 0) params.set('categoryIds', categoryIds.join(','))
         const qRes = await fetch(`/api/v1/trivia/infinite/next?${params.toString()}`, {
           headers,
           signal: controller.signal,
@@ -119,22 +120,22 @@ export function useInfiniteRun() {
     })()
   }, [cancelPrefetch, getAuthHeaders])
 
-  const startRun = useCallback(async (mode: InfiniteMode = 'scored', categoryId?: number) => {
+  const startRun = useCallback(async (mode: InfiniteMode = 'scored', categoryIds: number[] = []) => {
     cancelPrefetch()
-    setState(s => ({ ...s, phase: 'loading', mode, categoryId: categoryId ?? null, error: null }))
+    setState(s => ({ ...s, phase: 'loading', mode, categoryIds, error: null }))
     try {
       const headers = await getAuthHeaders()
       const res = await fetch('/api/v1/trivia/infinite/runs', {
         method: 'POST',
         headers,
-        body: JSON.stringify({ mode, categoryId: categoryId ?? null }),
+        body: JSON.stringify({ mode, categoryIds }),
       })
       if (!res.ok) throw new Error('Failed to start run')
       const data = await res.json()
 
       // Immediately fetch first question
       const firstParams = new URLSearchParams({ streak: '0' })
-      if (categoryId != null) firstParams.set('categoryId', String(categoryId))
+      if (categoryIds.length > 0) firstParams.set('categoryIds', categoryIds.join(','))
       const qRes = await fetch(`/api/v1/trivia/infinite/next?${firstParams.toString()}`, { headers })
       if (qRes.status === 204) {
         setState(s => ({ ...s, phase: 'exhausted', runId: data.runId }))
@@ -152,7 +153,7 @@ export function useInfiniteRun() {
         ...s,
         phase: 'playing',
         mode,
-        categoryId: categoryId ?? null,
+        categoryIds,
         runId: data.runId,
         question,
         livesRemaining: data.livesRemaining,
@@ -205,7 +206,7 @@ export function useInfiniteRun() {
       // Kick off the next question fetch in the background while the player
       // reads their feedback — only when the run is continuing.
       if (!result.runOver) {
-        startPrefetch(result.currentStreak, state.categoryId)
+        startPrefetch(result.currentStreak, state.categoryIds)
       }
 
       // If this was a correct answer in scored mode, increment the live
@@ -249,7 +250,7 @@ export function useInfiniteRun() {
       console.error('[infinite] submitAnswer failed:', err)
       setState(s => ({ ...s, phase: 'error', error: 'Failed to submit answer.' }))
     }
-  }, [state.phase, state.runId, state.question, state.categoryId, getAuthHeaders, startPrefetch, cancelPrefetch])
+  }, [state.phase, state.runId, state.question, state.categoryIds, getAuthHeaders, startPrefetch, cancelPrefetch])
 
   const nextQuestion = useCallback(async () => {
     if (state.phase !== 'answered' || !state.runId) return
@@ -272,7 +273,7 @@ export function useInfiniteRun() {
     try {
       const headers = await getAuthHeaders()
       const nextParams = new URLSearchParams({ streak: String(state.currentStreak) })
-      if (state.categoryId != null) nextParams.set('categoryId', String(state.categoryId))
+      if (state.categoryIds.length > 0) nextParams.set('categoryIds', state.categoryIds.join(','))
       const qRes = await fetch(`/api/v1/trivia/infinite/next?${nextParams.toString()}`, { headers })
       if (qRes.status === 204) {
         setState(s => ({ ...s, phase: 'exhausted' }))
@@ -291,7 +292,7 @@ export function useInfiniteRun() {
       console.error('[infinite] nextQuestion failed:', err)
       setState(s => ({ ...s, phase: 'error', error: 'Failed to fetch next question.' }))
     }
-  }, [state.phase, state.runId, state.currentStreak, state.categoryId, getAuthHeaders])
+  }, [state.phase, state.runId, state.currentStreak, state.categoryIds, getAuthHeaders])
 
   const skipQuestion = useCallback(async () => {
     if (state.phase !== 'playing' || state.skipsRemaining <= 0 || !state.question || !state.runId) return

--- a/src/lib/trivia/infiniteRuns.ts
+++ b/src/lib/trivia/infiniteRuns.ts
@@ -11,6 +11,12 @@ export interface RunDoc {
   runId: string
   uid: string
   mode: 'scored' | 'practice'
+  // Empty array = all categories. Single-element = legacy single-category
+  // behavior. The old categoryFilter field is still written for back-compat
+  // with any reader that hasn't been updated.
+  categoryFilters: number[]
+  // Deprecated, kept for backward compatibility. Equals categoryFilters[0]
+  // when there's exactly one filter, null otherwise.
   categoryFilter: number | null
   score: number
   livesRemaining: number
@@ -34,7 +40,11 @@ export interface RunAnswer {
   answeredAt: FirebaseFirestore.Timestamp
 }
 
-export async function startRun(uid: string, mode: 'scored' | 'practice' = 'scored', categoryId?: number): Promise<{ runId: string; livesRemaining: number; currentStreak: number }> {
+export async function startRun(
+  uid: string,
+  mode: 'scored' | 'practice' = 'scored',
+  categoryIds: number[] = []
+): Promise<{ runId: string; livesRemaining: number; currentStreak: number }> {
   const db = getFirestoreDb()
   const runRef = db.collection(`users/${uid}/triviaInfinite`).doc()
   const now = FieldValue.serverTimestamp()
@@ -42,7 +52,8 @@ export async function startRun(uid: string, mode: 'scored' | 'practice' = 'score
     runId: runRef.id,
     uid,
     mode,
-    categoryFilter: categoryId ?? null,
+    categoryFilters: categoryIds,
+    categoryFilter: categoryIds.length === 1 ? categoryIds[0] : null,
     score: 0,
     livesRemaining: LIVES_START,
     currentStreak: 0,

--- a/src/lib/trivia/sampler.ts
+++ b/src/lib/trivia/sampler.ts
@@ -6,7 +6,9 @@ export interface SamplerOptions {
   uid: string
   streak: number
   type?: 'free-text' // v1 only free-text
-  categoryId?: number
+  // List of category ids to draw from. Empty/undefined = all categories.
+  // Single-element arrays behave the same as the old single-category mode.
+  categoryIds?: number[]
 }
 
 /**
@@ -56,7 +58,7 @@ function freshnessWeight(timesShown: number): number {
 }
 
 export async function sampleNextQuestion(options: SamplerOptions): Promise<AIQuestion | null> {
-  const { uid, streak, type = 'free-text', categoryId } = options
+  const { uid, streak, type = 'free-text', categoryIds } = options
   const db = getFirestoreDb()
 
   // 1. Query active questions of the requested type
@@ -65,11 +67,17 @@ export async function sampleNextQuestion(options: SamplerOptions): Promise<AIQue
     .where('status', '==', 'active')
     .where('type', '==', type)
 
-  // If a category filter is provided, restrict to that category by name
-  if (categoryId !== undefined) {
-    const categoryMeta = CATEGORY_META[categoryId]
-    if (categoryMeta) {
-      query = query.where('category', '==', categoryMeta.name)
+  // Resolve the optional category filter to category-name strings (the
+  // shape stored on aiQuestions docs). Firestore `in` clause caps at 30
+  // values, which is comfortably more than our 24 categories.
+  if (categoryIds && categoryIds.length > 0) {
+    const names = categoryIds
+      .map((id) => CATEGORY_META[id]?.name)
+      .filter((name): name is string => !!name)
+    if (names.length === 1) {
+      query = query.where('category', '==', names[0])
+    } else if (names.length > 1) {
+      query = query.where('category', 'in', names)
     }
   }
 


### PR DESCRIPTION
## Summary
Two related infinite-trivia pre-game changes.

### Multi-select categories
Players can now pick any combination of categories for a run instead of "one OR all." Tapping a tile toggles it. The Start button label reflects the count: "Start" (all), "Start (1 category)", "Start (3 categories)", …

### Start above the fold
Pre-game order is now: header → All Categories quick-pick → **Start | Practice** → grid. The most common action is visible on first load on every device — the grid is for deliberate selection, not a wall between the header and the start button.

## Implementation

**Server:**
- `sampler` accepts `categoryIds: number[]`; uses Firestore `where('category', 'in', names)` for multi-pick (cap is 30 — we have 24 categories, fits comfortably). Single-element falls back to `==` for the cheaper index path.
- `/infinite/next` accepts `?categoryIds=12,13,15` (legacy `?categoryId=N` still honored).
- `/infinite/runs` accepts `categoryIds: number[]` in the POST body.
- Run docs gain `categoryFilters: number[]`; the legacy `categoryFilter: number | null` scalar is still written for back-compat with any existing reader.
- On-demand AI generation picks a random category from the selected set when the pool is exhausted.

**Client:**
- `useInfiniteRun` state changed `categoryId: number | null` → `categoryIds: number[]`. `startRun(mode, categoryIds[])` signature.
- `InfiniteGame` keeps a `Set<number>` for selection. `toggleCategoryId` flips membership; "All Categories" button clears the set.
- HUD shows `"3 categories"` as the fallback label when running with multiple selected categories. The live per-category progress pill (from PR #951) still tracks whichever category the *current question* is in.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run` — all tests pass
- [x] `npx eslint` — only pre-existing warnings on `user`/`authLoading`
- [ ] Manual: tap multiple tiles, start run, verify questions come from the selected mix
- [ ] Manual: start with no selection ("All"), verify all-category run still works
- [ ] Manual: confirm Start button is visible without scrolling on mobile
- [ ] Manual: legacy single-category URL params still work (`/api/v1/trivia/infinite/next?categoryId=11`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)