### PR TITLE
fix: add Violet Vessel boss blind

### DIFF
--- a/src/app/daily-card-game/domain/round/boss-blinds.ts
+++ b/src/app/daily-card-game/domain/round/boss-blinds.ts
@@ -54,7 +54,19 @@ const theOx: BossBlindDefinition = {
   ],
 }
 
-export const bossBlinds: BossBlindDefinition[] = [theHook, theOx]
+const violetVessel: BossBlindDefinition = {
+  type: 'bossBlind',
+  status: 'notStarted',
+  anteMultiplier: 6,
+  name: 'Violet Vessel',
+  description: 'Very large blind',
+  image: 'violet-vessel.png',
+  minimumAnte: 8,
+  baseReward: 8,
+  effects: [],
+}
+
+export const bossBlinds: BossBlindDefinition[] = [theHook, theOx, violetVessel]
 
 /**
  


### PR DESCRIPTION
## Summary
- add the Violet Vessel showdown boss blind definition
- register it in the boss blind pool so it can appear from ante 8 onward

Fixes #960

## Testing
- `git diff --check`
- attempted `yarn typecheck` *(blocked: `yarn` is not installed in this runner)*
- attempted `yarn test src/lib/trivia/__tests__/medals.test.ts` *(blocked: `yarn` is not installed in this runner)*
