### PR TITLE
feat: AI question quality gate + cheaper generation + sharper voice

### DIFF
--- a/src/lib/trivia/generateQuestion.ts
+++ b/src/lib/trivia/generateQuestion.ts
@@ -59,20 +59,61 @@ const QuestionSchema = z.object({
     .describe('2-3 sentences explaining the answer and why it is interesting.'),
 })
 
-/**
- * Generate a single trivia question on the fly for Infinite Trivia.
- * Picks a random category + seed/modifier combo so back-to-back calls don't collide.
- * Returns the AIQuestion shape sans auto-initialized counters; pair with saveAIQuestion().
- */
-export async function generateInfiniteQuestion(
-  options: GenerateInfiniteQuestionOptions = {}
-): Promise<GeneratedQuestion> {
-  const apiKey = process.env.NEXT_PUBLIC_OPENAI_API_KEY ?? process.env.OPENAI_API_KEY
-  if (!apiKey) throw new Error('OpenAI API key not configured')
+const ReviewSchema = z.object({
+  accept: z
+    .boolean()
+    .describe('Whether the question meets the quality bar described in the prompt.'),
+  inferred_category: z
+    .string()
+    .describe('The single category from the provided list this question best belongs to.'),
+  rejection_reason: z
+    .string()
+    .nullable()
+    .describe('Brief explanation if rejected, otherwise null.'),
+})
 
-  const difficulty =
-    options.difficulty ?? streakBiasedDifficulty(options.streak ?? 0)
-  const categoryId = options.categoryId ?? pickCategoryId()
+const KNOWN_CATEGORIES = [
+  'General Knowledge',
+  'Books',
+  'Film',
+  'Music',
+  'Musicals & Theatre',
+  'Television',
+  'Video Games',
+  'Board Games',
+  'Science & Nature',
+  'Computers',
+  'Mathematics',
+  'Mythology',
+  'Sports',
+  'Geography',
+  'History',
+  'Politics',
+  'Art',
+  'Celebrities',
+  'Animals',
+  'Vehicles',
+  'Comics',
+  'Gadgets',
+  'Anime & Manga',
+  'Cartoons & Animation',
+] as const
+
+interface DraftQuestion {
+  question: string
+  correct_answer: string
+  explanation: string
+  difficulty: 'easy' | 'medium' | 'hard'
+  categoryName: string
+  seedSummary: string
+}
+
+async function generateDraft(
+  apiKey: string,
+  opts: GenerateInfiniteQuestionOptions
+): Promise<DraftQuestion> {
+  const difficulty = opts.difficulty ?? streakBiasedDifficulty(opts.streak ?? 0)
+  const categoryId = opts.categoryId ?? pickCategoryId()
   const categoryName = getOpenTDBCategoryName(categoryId)
   const seeds = CATEGORIZED_SEEDS[categoryId] ?? CATEGORIZED_SEEDS[9]
   const seedWord = pickRandom(seeds)
@@ -82,38 +123,137 @@ export async function generateInfiniteQuestion(
   const openaiClient = createOpenAI({ apiKey })
 
   const result = await generateObject({
-    model: openaiClient('gpt-4o'),
+    model: openaiClient('gpt-4o-mini'),
     schema: QuestionSchema,
     system:
-      'You are a trivia question creator. Create a specific trivia question with a clear factual answer.',
-    prompt: `Generate a ${difficulty} trivia question about the topic: "${seedStr}"
+      'You are a trivia question creator for a cosmic-cave-themed game. Each question should feel hand-crafted and a little surprising — the kind of fact that makes someone say "huh, I didn\'t know that." Avoid the obvious; reach for the well-loved deep cut.',
+    prompt: `Generate a ${difficulty} trivia question.
+
+Topical seed: "${seedStr}"
 Category: ${categoryName}
 
 Difficulty: ${difficulty.toUpperCase()}. ${DIFFICULTY_GUIDANCE[difficulty]}
 
 The question should:
-- Be specific enough that someone knowledgeable could guess the exact answer
-- Not mention the answer in the question text
-- Have a clear, specific correct answer (a name, date, number, place, or concept — typically 1-3 words)
-- Be answerable without multiple choice options`,
+- Have ONE specific, unambiguous correct answer (a name, date, number, place, or concept — typically 1-3 words).
+- Be specific enough that a knowledgeable person could land the exact answer with confidence.
+- Be the kind of fact that's slightly surprising or rewarding to know — favor unusual angles over common-knowledge framings.
+- NOT mention the answer (or a synonym/translation of it) in the question text.
+- NOT be a multiple-choice question — answer is free-text.
+- Belong unambiguously to the category "${categoryName}". If the seed pulls you toward a different category, ignore it and stay in this one.
+
+Return the question, the exact correct answer, and a 2-3 sentence explanation that makes the fact interesting.`,
     temperature: 0.7,
     maxTokens: 400,
   })
 
-  const { question, correct_answer, explanation } = result.object
-  if (!question || !correct_answer) {
+  if (!result.object.question || !result.object.correct_answer) {
     throw new Error('OpenAI response missing required fields')
   }
 
-  const id = `ai-infinite-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`
+  return {
+    question: result.object.question,
+    correct_answer: result.object.correct_answer,
+    explanation: result.object.explanation,
+    difficulty,
+    categoryName,
+    seedSummary: seedStr,
+  }
+}
+
+interface ReviewResult {
+  accept: boolean
+  reason: string | null
+  inferred_category: string
+}
+
+async function reviewQuestion(apiKey: string, draft: DraftQuestion): Promise<ReviewResult> {
+  const openaiClient = createOpenAI({ apiKey })
+
+  const result = await generateObject({
+    model: openaiClient('gpt-4o-mini'),
+    schema: ReviewSchema,
+    system:
+      'You are a strict quality reviewer for trivia questions. You reject anything that would frustrate a player.',
+    prompt: `Review this trivia question for the category "${draft.categoryName}".
+
+Question: ${draft.question}
+Correct answer: ${draft.correct_answer}
+Explanation: ${draft.explanation}
+
+Reject the question if ANY of these are true:
+- The answer is unambiguously stated (or trivially translated) inside the question text.
+- The question has multiple equally-valid answers — it must have ONE specific answer.
+- The question is too vague to answer without options.
+- The question is nonsensical, broken, or contradicts itself.
+- The "correct answer" doesn't actually answer the question.
+- The factual claim in the question or explanation is wrong.
+- The question doesn't belong to the category "${draft.categoryName}" — pick the best-fitting category from this list:
+  ${KNOWN_CATEGORIES.join(', ')}
+
+Set accept=true ONLY if every check passes AND inferred_category equals "${draft.categoryName}".
+If you reject, give a one-sentence rejection_reason. Otherwise rejection_reason is null.`,
+    temperature: 0,
+    maxTokens: 150,
+  })
 
   return {
-    id,
-    question,
-    correctAnswer: correct_answer,
-    explanation,
-    category: categoryName,
-    difficulty,
-    type: 'free-text',
+    accept: result.object.accept && result.object.inferred_category === draft.categoryName,
+    reason: result.object.rejection_reason,
+    inferred_category: result.object.inferred_category,
   }
+}
+
+const MAX_GENERATION_ATTEMPTS = 2
+
+/**
+ * Generate a single trivia question on the fly for Infinite Trivia.
+ *
+ * Two-stage pipeline:
+ *   1. Draft generation (gpt-4o-mini, temp 0.7) using a random seed-word
+ *      and modifier from the chosen category's bucket.
+ *   2. Quality review (gpt-4o-mini, temp 0) that rejects questions
+ *      that leak the answer, are vague, contradict themselves, are
+ *      factually wrong, or fall outside the requested category.
+ *
+ * On rejection we retry once with a fresh seed/modifier before failing.
+ * The /next route maps the throw to a 204 (pool exhausted), same as
+ * any other generation failure.
+ */
+export async function generateInfiniteQuestion(
+  options: GenerateInfiniteQuestionOptions = {}
+): Promise<GeneratedQuestion> {
+  const apiKey = process.env.NEXT_PUBLIC_OPENAI_API_KEY ?? process.env.OPENAI_API_KEY
+  if (!apiKey) throw new Error('OpenAI API key not configured')
+
+  let lastReason = 'unknown'
+  for (let attempt = 1; attempt <= MAX_GENERATION_ATTEMPTS; attempt++) {
+    const draft = await generateDraft(apiKey, options)
+    const review = await reviewQuestion(apiKey, draft)
+
+    if (review.accept) {
+      const id = `ai-infinite-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`
+      return {
+        id,
+        question: draft.question,
+        correctAnswer: draft.correct_answer,
+        explanation: draft.explanation,
+        category: draft.categoryName,
+        difficulty: draft.difficulty,
+        type: 'free-text',
+      }
+    }
+
+    lastReason = review.reason ?? `inferred=${review.inferred_category}`
+    console.warn('[generateInfiniteQuestion] draft rejected', {
+      attempt,
+      category: draft.categoryName,
+      seed: draft.seedSummary,
+      reason: lastReason,
+    })
+  }
+
+  throw new Error(
+    `Generation failed quality gate after ${MAX_GENERATION_ATTEMPTS} attempts: ${lastReason}`
+  )
 }


### PR DESCRIPTION
## Summary
Implements 4 of the 6 review observations from the generation-pipeline walkthrough.

### Two-stage draft/review pipeline
**Stage 1 — Draft** (`gpt-4o-mini`, temp 0.7): same seed-word + modifier strategy as before, but with a sharper prompt that pushes for surprising / deep-cut facts in the cosmic-cave brand voice instead of just "specific and clear."

**Stage 2 — Review** (`gpt-4o-mini`, temp 0): a strict reviewer that rejects questions if any of these are true:
- Answer is leaked inside the question text
- Question has multiple equally-valid answers
- Question is vague, broken, or contradicts itself
- The "correct answer" doesn't actually answer the question
- A factual claim in the question or explanation is wrong
- The question doesn't actually belong to the requested category (reviewer returns `inferred_category` and we reject on mismatch)

On rejection, we retry once with a fresh seed/modifier. If both attempts fail, we throw and the `/next` route maps it to a 204 (same as any other generation failure).

### Cost
Old: 1× **gpt-4o** call per generation (full model). New best case: 2× gpt-4o-mini calls (~6× cheaper per call). Worst case: 4× gpt-4o-mini (one rejection + retry + retry-review). Even the worst case is meaningfully cheaper than the old single full-4o call.

### What this addresses
- **#1 quality gate** ✅
- **#2 category trust** ✅ (reviewer must confirm `inferred_category` matches)
- **#3 cost** ✅ (gpt-4o → gpt-4o-mini for generation)
- **#6 prompt voice** ✅ (cosmic-cave hand-crafted framing in the system prompt)

### Deferred (need seed/modifier tracking on saved questions first)
- **#4 seed bucket imbalance** — needs telemetry to know which combos produce flagged questions
- **#5 modifier audit** — same; can't tell if `@#$&(*!)` etc. are net-positive without per-modifier flag rates
- **Seed tracking itself** — confirmed not currently stored on `aiQuestions/*`. Adding `seed: string, modifier: string` to the saved doc is a 3-line follow-up; will open a separate PR for it.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run` — all tests pass
- [x] `npx eslint` clean on touched files
- [ ] Manual: trigger pool-exhausted state on a fresh account, verify generated questions still flow through
- [ ] Manual: monitor server logs for `[generateInfiniteQuestion] draft rejected` warnings — at low volume initially, climbing if the reviewer catches genuine misses
- [ ] After ~24 hours of real traffic: review the kinds of rejections logged to tune reviewer strictness

🤖 Generated with [Claude Code](https://claude.com/claude-code)