### PR TITLE
fix: add The Wall boss blind

### DIFF
--- a/src/app/daily-card-game/domain/round/boss-blinds.ts
+++ b/src/app/daily-card-game/domain/round/boss-blinds.ts
@@ -54,7 +54,19 @@ const theOx: BossBlindDefinition = {
   ],
 }
 
-export const bossBlinds: BossBlindDefinition[] = [theHook, theOx]
+const theWall: BossBlindDefinition = {
+  type: 'bossBlind',
+  status: 'notStarted',
+  anteMultiplier: 4,
+  name: 'The Wall',
+  description: 'Extra large blind',
+  image: 'the-wall.png',
+  minimumAnte: 2,
+  baseReward: 5,
+  effects: [],
+}
+
+export const bossBlinds: BossBlindDefinition[] = [theHook, theOx, theWall]
 
 /**
  


### PR DESCRIPTION
## Summary
- Adds The Wall boss blind definition with a 4x ante multiplier
- Registers it in the boss blind pool for ante 2+
- Leaves effects empty because this blind only changes the chip requirement

Fixes #937

## Testing
- `npm test` — 58 files / 981 tests passed
- `npx prettier --check src/app/daily-card-game/domain/round/boss-blinds.ts`
- `git diff --check`
- Source assertion verified The Wall has `anteMultiplier: 4`, `minimumAnte: 2`, `baseReward: 5`, empty `effects`, and is registered in `bossBlinds`

Note: I also tried the repo-wide `npm run typecheck` and `npm run lint`. Typecheck currently fails in existing tap-tap-adventure tests due to unrelated fixture/type drift, and lint fails during tooling startup with `ERR_PACKAGE_PATH_NOT_EXPORTED` for zod's `./v4/core` subpath. The targeted change and full Vitest suite pass.
