### PR TITLE
fix: voice stats clobbered, flag failures silent, uid missing on docs

### DIFF
--- a/scripts/backfill-flag-rating-uid.ts
+++ b/scripts/backfill-flag-rating-uid.ts
@@ -1,0 +1,111 @@
+#!/usr/bin/env tsx
+/**
+ * Backfill the `uid` and `questionId` fields onto existing
+ * aiQuestions/{qid}/flags/{uid} and aiQuestions/{qid}/ratings/{uid}
+ * documents. The doc id is already the uid, but having it as a field
+ * enables collection-group queries like "all flags by user X."
+ *
+ * Idempotent: docs that already have both fields are skipped.
+ *
+ * Usage:
+ *   npx tsx --env-file=.env.local scripts/backfill-flag-rating-uid.ts [--dry-run]
+ */
+
+import { cert, getApps, initializeApp } from 'firebase-admin/app'
+import { type WriteBatch, getFirestore } from 'firebase-admin/firestore'
+
+const BATCH_SIZE = 400
+
+function ensureApp() {
+  if (getApps().length > 0) return
+  const projectId = process.env.FIREBASE_PROJECT_ID
+  const clientEmail = process.env.FIREBASE_CLIENT_EMAIL
+  const privateKey = process.env.FIREBASE_PRIVATE_KEY?.replace(/\\n/g, '\n')
+  if (!projectId || !clientEmail || !privateKey) {
+    console.error('ERROR: Missing Firebase env vars.')
+    process.exit(1)
+  }
+  initializeApp({ credential: cert({ projectId, clientEmail, privateKey }) })
+}
+
+async function backfillCollectionGroup(
+  db: FirebaseFirestore.Firestore,
+  groupName: 'flags' | 'ratings',
+  dryRun: boolean
+): Promise<{ scanned: number; updated: number; skipped: number }> {
+  const snap = await db.collectionGroup(groupName).get()
+  let updated = 0
+  let skipped = 0
+
+  let batch: WriteBatch = db.batch()
+  let batchCount = 0
+
+  for (const doc of snap.docs) {
+    const data = doc.data()
+    const uid = doc.id
+    const parent = doc.ref.parent.parent
+    if (!parent) {
+      skipped++
+      continue
+    }
+    const questionId = parent.id
+
+    const needsUid = !data.uid
+    const needsQid = !data.questionId
+    if (!needsUid && !needsQid) {
+      skipped++
+      continue
+    }
+
+    const updates: Record<string, string> = {}
+    if (needsUid) updates.uid = uid
+    if (needsQid) updates.questionId = questionId
+
+    if (dryRun) {
+      console.log(`would update ${doc.ref.path}`, updates)
+      updated++
+      continue
+    }
+
+    batch.update(doc.ref, updates)
+    batchCount++
+    updated++
+
+    if (batchCount >= BATCH_SIZE) {
+      await batch.commit()
+      batch = db.batch()
+      batchCount = 0
+    }
+  }
+
+  if (!dryRun && batchCount > 0) {
+    await batch.commit()
+  }
+
+  return { scanned: snap.size, updated, skipped }
+}
+
+async function main() {
+  const dryRun = process.argv.includes('--dry-run')
+  ensureApp()
+  const db = getFirestore()
+
+  console.log(`Dry run: ${dryRun ? 'YES (no writes)' : 'NO (will write to Firestore)'}`)
+  console.log('─'.repeat(60))
+
+  console.log('Scanning collection-group: flags')
+  const flagsResult = await backfillCollectionGroup(db, 'flags', dryRun)
+  console.log(`  scanned=${flagsResult.scanned} updated=${flagsResult.updated} skipped=${flagsResult.skipped}`)
+
+  console.log('Scanning collection-group: ratings')
+  const ratingsResult = await backfillCollectionGroup(db, 'ratings', dryRun)
+  console.log(`  scanned=${ratingsResult.scanned} updated=${ratingsResult.updated} skipped=${ratingsResult.skipped}`)
+
+  console.log('─'.repeat(60))
+  console.log('Done.')
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})

--- a/src/app/api/v1/trivia/questions/[id]/flag/route.ts
+++ b/src/app/api/v1/trivia/questions/[id]/flag/route.ts
@@ -1,5 +1,5 @@
-import { type NextRequest, NextResponse } from 'next/server';
 import { FieldValue } from 'firebase-admin/firestore';
+import { type NextRequest, NextResponse } from 'next/server';
 
 import { verifyRequestAuth } from '@/lib/api/auth';
 import { getFirestoreDb } from '@/lib/firebase/server';
@@ -66,7 +66,12 @@ export async function POST(
 
       tx.update(qRef, qUpdates);
 
+      // Store uid as a field too — the doc id is already the uid, but
+      // having it as a field lets us do collection-group queries like
+      // "all flags by user X" and lets admin tooling display it.
       const flagDoc: Record<string, unknown> = {
+        uid,
+        questionId,
         reason,
         flaggedAt: FieldValue.serverTimestamp(),
       };

--- a/src/app/api/v1/trivia/questions/[id]/rate/route.ts
+++ b/src/app/api/v1/trivia/questions/[id]/rate/route.ts
@@ -1,5 +1,5 @@
-import { type NextRequest, NextResponse } from 'next/server';
 import { FieldValue } from 'firebase-admin/firestore';
+import { type NextRequest, NextResponse } from 'next/server';
 
 import { verifyRequestAuth } from '@/lib/api/auth';
 import { getFirestoreDb } from '@/lib/firebase/server';
@@ -44,7 +44,11 @@ export async function POST(
     if (vote === null) {
       await ratingRef.delete();
     } else {
+      // Store uid + questionId as fields so admin tooling and
+      // collection-group queries can find ratings by user.
       await ratingRef.set({
+        uid,
+        questionId,
         vote,
         ratedAt: FieldValue.serverTimestamp(),
       });

--- a/src/app/trivia/components/FlagQuestion.tsx
+++ b/src/app/trivia/components/FlagQuestion.tsx
@@ -1,7 +1,8 @@
 'use client'
 import { useState } from 'react'
-import { useAuth } from '@/hooks/useAuth'
+
 import { ChunkyButton } from '@/components/ui/chunky-button'
+import { useAuth } from '@/hooks/useAuth'
 
 const FLAG_REASONS = [
   { value: 'obvious', label: 'Answer is included in the question / too obvious' },
@@ -30,6 +31,7 @@ export function FlagQuestion({ questionId, runId, onFlagged }: Props) {
   const [note, setNote] = useState('')
   const [submitted, setSubmitted] = useState(false)
   const [submitting, setSubmitting] = useState(false)
+  const [submitError, setSubmitError] = useState<string | null>(null)
 
   if (!user) return null
 
@@ -40,6 +42,7 @@ export function FlagQuestion({ questionId, runId, onFlagged }: Props) {
   const handleSubmit = async () => {
     if (!canSubmit) return
     setSubmitting(true)
+    setSubmitError(null)
     try {
       const token = await user.getIdToken()
       const res = await fetch(`/api/v1/trivia/questions/${questionId}/flag`, {
@@ -47,6 +50,19 @@ export function FlagQuestion({ questionId, runId, onFlagged }: Props) {
         headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
         body: JSON.stringify({ reason, note: trimmedNote || undefined, runId: runId ?? undefined }),
       })
+      if (!res.ok) {
+        // Surface the failure instead of silently showing "Reported".
+        // The user keeps the modal open and can retry.
+        let detail = `${res.status}`
+        try {
+          const errBody = (await res.json()) as { error?: string }
+          if (errBody?.error) detail = errBody.error
+        } catch {
+          // fall through with the status code
+        }
+        setSubmitError(`Couldn't send report (${detail}). Try again.`)
+        return
+      }
       setSubmitted(true)
       setShowModal(false)
       if (onFlagged) {
@@ -59,8 +75,8 @@ export function FlagQuestion({ questionId, runId, onFlagged }: Props) {
         }
         onFlagged(result)
       }
-    } catch {
-      // silent
+    } catch (err) {
+      setSubmitError(`Couldn't send report (${err instanceof Error ? err.message : 'network error'}). Try again.`)
     } finally {
       setSubmitting(false)
     }
@@ -92,6 +108,9 @@ export function FlagQuestion({ questionId, runId, onFlagged }: Props) {
               maxLength={500}
               className="bg-surface-container-highest border border-outline-variant rounded-lg p-2 text-on-surface text-sm resize-none h-20 placeholder:text-on-surface/40"
             />
+            {submitError && (
+              <p className="text-ds-error text-xs">{submitError}</p>
+            )}
             <div className="flex gap-3 justify-end">
               <ChunkyButton variant="secondary" size="sm" onClick={() => setShowModal(false)}>Cancel</ChunkyButton>
               <ChunkyButton variant="exit" size="sm" disabled={!canSubmit} onClick={handleSubmit}>

--- a/src/lib/trivia/triviaStats.ts
+++ b/src/lib/trivia/triviaStats.ts
@@ -56,11 +56,31 @@ export async function getAggregateStats(uid: string): Promise<AggregateStats> {
   const db = getFirestoreDb()
   const snap = await db.doc(`users/${uid}/triviaStats/aggregate`).get()
   if (!snap.exists) return { ...EMPTY_STATS }
-  return snap.data() as AggregateStats
+  // applyRunToAggregate now writes via merge-style field updates (instead
+  // of full-doc rewrites), so a stored doc may be missing some fields.
+  // Hydrate from EMPTY_STATS so the consumer always sees the full shape.
+  const stored = snap.data() as Partial<AggregateStats>
+  return {
+    ...EMPTY_STATS,
+    ...stored,
+    byCategory: stored.byCategory ?? {},
+    byDifficulty: {
+      easy: { ...EMPTY_STATS.byDifficulty.easy, ...stored.byDifficulty?.easy },
+      medium: { ...EMPTY_STATS.byDifficulty.medium, ...stored.byDifficulty?.medium },
+      hard: { ...EMPTY_STATS.byDifficulty.hard, ...stored.byDifficulty?.hard },
+    },
+  }
 }
 
 // Called at run finalization. Reads the run doc, walks its answers[],
 // and atomically updates the aggregate doc. Idempotent via statsApplied flag.
+//
+// Uses merge-style field updates (FieldValue.increment for counters,
+// dotted field paths for nested deltas) instead of a full-doc rewrite,
+// so concurrent writers like incrementVoiceStat / trackExhaustion never
+// have their writes clobbered. The only fields this function touches
+// are the run-derived ones; voice stats and exhaustion count belong
+// exclusively to their respective writers.
 export async function applyRunToAggregate(uid: string, runId: string): Promise<void> {
   const db = getFirestoreDb()
   const runRef = db.doc(`users/${uid}/triviaInfinite/${runId}`)
@@ -77,10 +97,12 @@ export async function applyRunToAggregate(uid: string, runId: string): Promise<v
     // Idempotency: skip if already applied
     if (run.statsApplied === true) return
 
+    // We only need the existing aggregate to compare against bestStreak /
+    // bestRun. Counters use FieldValue.increment so we don't read them.
     const aggSnap = await tx.get(aggRef)
-    const agg: AggregateStats = aggSnap.exists
-      ? (aggSnap.data() as AggregateStats)
-      : { ...EMPTY_STATS }
+    const existing: Partial<AggregateStats> = aggSnap.exists
+      ? (aggSnap.data() as Partial<AggregateStats>)
+      : {}
 
     // Batch-read all question docs referenced by answers
     const questionIds = run.answers.map((a) => a.questionId)
@@ -100,7 +122,7 @@ export async function applyRunToAggregate(uid: string, runId: string): Promise<v
     let totalTimeMs = 0
     let trailblazerCount = 0
     const byCategory: Record<string, { answered: number; correct: number; totalTimeMs: number }> = {}
-    const byDifficulty: Record<string, { answered: number; correct: number }> = {
+    const byDifficulty: Record<'easy' | 'medium' | 'hard', { answered: number; correct: number }> = {
       easy: { answered: 0, correct: 0 },
       medium: { answered: 0, correct: 0 },
       hard: { answered: 0, correct: 0 },
@@ -119,7 +141,6 @@ export async function applyRunToAggregate(uid: string, runId: string): Promise<v
 
       const qInfo = questionMap.get(answer.questionId)
       if (qInfo) {
-        // Category
         if (!byCategory[qInfo.category]) {
           byCategory[qInfo.category] = { answered: 0, correct: 0, totalTimeMs: 0 }
         }
@@ -127,61 +148,28 @@ export async function applyRunToAggregate(uid: string, runId: string): Promise<v
         if (answer.correct) byCategory[qInfo.category].correct += 1
         byCategory[qInfo.category].totalTimeMs += answer.timeMs
 
-        // Difficulty
         byDifficulty[qInfo.difficulty].answered += 1
         if (answer.correct) byDifficulty[qInfo.difficulty].correct += 1
       }
     }
 
-    // Merge byCategory: start from existing, add deltas
-    const mergedByCategory: Record<string, { answered: number; correct: number; totalTimeMs: number }> = {}
-    for (const [cat, val] of Object.entries(agg.byCategory)) {
-      mergedByCategory[cat] = { ...val }
-    }
-    for (const [cat, deltas] of Object.entries(byCategory)) {
-      if (!mergedByCategory[cat]) {
-        mergedByCategory[cat] = { answered: 0, correct: 0, totalTimeMs: 0 }
-      }
-      mergedByCategory[cat].answered += deltas.answered
-      mergedByCategory[cat].correct += deltas.correct
-      mergedByCategory[cat].totalTimeMs += deltas.totalTimeMs
+    // Build a sparse update — only fields this function owns.
+    const updates: Record<string, unknown> = {
+      totalAnswered: FieldValue.increment(totalAnswered),
+      totalCorrect: FieldValue.increment(totalCorrect),
+      totalScore: FieldValue.increment(run.score),
+      runsPlayed: FieldValue.increment(1),
+      trailblazerCount: FieldValue.increment(trailblazerCount),
+      totalTimeMs: FieldValue.increment(totalTimeMs),
+      lastUpdatedAt: FieldValue.serverTimestamp(),
     }
 
-    // Build merged aggregate
-    const newAgg: AggregateStats = {
-      totalAnswered: agg.totalAnswered + totalAnswered,
-      totalCorrect: agg.totalCorrect + totalCorrect,
-      totalScore: (agg.totalScore ?? 0) + run.score,
-      runsPlayed: agg.runsPlayed + 1,
-      bestRun: agg.bestRun,
-      bestStreak: Math.max(agg.bestStreak, run.longestStreak),
-      trailblazerCount: agg.trailblazerCount + trailblazerCount,
-      totalTimeMs: agg.totalTimeMs + totalTimeMs,
-      byCategory: mergedByCategory,
-      byDifficulty: {
-        easy: {
-          answered: agg.byDifficulty.easy.answered + byDifficulty.easy.answered,
-          correct: agg.byDifficulty.easy.correct + byDifficulty.easy.correct,
-        },
-        medium: {
-          answered: agg.byDifficulty.medium.answered + byDifficulty.medium.answered,
-          correct: agg.byDifficulty.medium.correct + byDifficulty.medium.correct,
-        },
-        hard: {
-          answered: agg.byDifficulty.hard.answered + byDifficulty.hard.answered,
-          correct: agg.byDifficulty.hard.correct + byDifficulty.hard.correct,
-        },
-      },
-      exhaustionCount: agg.exhaustionCount ?? 0,
-      likesGiven: agg.likesGiven ?? 0,
-      dislikesGiven: agg.dislikesGiven ?? 0,
-      reportsFiled: agg.reportsFiled ?? 0,
-      lastUpdatedAt: null, // overwritten by server timestamp below
+    // Max-style fields: read existing and only write if this run wins.
+    if ((existing.bestStreak ?? 0) < run.longestStreak) {
+      updates.bestStreak = run.longestStreak
     }
-
-    // Update bestRun if this run's score exceeds the current best
-    if (!newAgg.bestRun || run.score > newAgg.bestRun.score) {
-      newAgg.bestRun = {
+    if (!existing.bestRun || run.score > existing.bestRun.score) {
+      updates.bestRun = {
         score: run.score,
         longestStreak: run.longestStreak,
         runId: run.runId,
@@ -189,8 +177,21 @@ export async function applyRunToAggregate(uid: string, runId: string): Promise<v
       }
     }
 
-    // Write aggregate with server timestamp
-    tx.set(aggRef, { ...newAgg, lastUpdatedAt: FieldValue.serverTimestamp() })
+    // byDifficulty deltas via dotted field paths.
+    for (const diff of ['easy', 'medium', 'hard'] as const) {
+      const d = byDifficulty[diff]
+      if (d.answered > 0) updates[`byDifficulty.${diff}.answered`] = FieldValue.increment(d.answered)
+      if (d.correct > 0) updates[`byDifficulty.${diff}.correct`] = FieldValue.increment(d.correct)
+    }
+
+    // byCategory deltas.
+    for (const [cat, d] of Object.entries(byCategory)) {
+      if (d.answered > 0) updates[`byCategory.${cat}.answered`] = FieldValue.increment(d.answered)
+      if (d.correct > 0) updates[`byCategory.${cat}.correct`] = FieldValue.increment(d.correct)
+      if (d.totalTimeMs > 0) updates[`byCategory.${cat}.totalTimeMs`] = FieldValue.increment(d.totalTimeMs)
+    }
+
+    tx.set(aggRef, updates, { merge: true })
 
     // Mark the run as having its stats applied (idempotency guard)
     tx.update(runRef, { statsApplied: true })


### PR DESCRIPTION
## Summary
Three real bugs surfaced while reviewing the flag/rating pipeline.

### 1. Voice stats clobbered on run finalization (likely root cause of "stats say zero")
`applyRunToAggregate` was doing a full-doc `tx.set(aggRef, newAgg)` at run end. Even though it preserved `likesGiven/dislikesGiven/reportsFiled` by reading them first, the full-doc-rewrite raced with the non-transactional `incrementVoiceStat` writes from the flag and rate routes. Firestore retries on conflict, but the rewrite had no business touching those fields in the first place.

**Fix:** refactored to merge-style updates — `FieldValue.increment` for counters, dotted field paths (`byCategory.<cat>.answered`, etc.) for nested deltas. The function now only touches run-derived fields. `incrementVoiceStat` (and `trackExhaustion`) own their fields exclusively.

`getAggregateStats` was relying on the doc to always be a full `AggregateStats` shape. Now hydrates missing fields from `EMPTY_STATS` so partial-doc reads stay type-correct.

### 2. Flag failures silently shown as "Reported"
`FlagQuestion.handleSubmit` set `submitted=true` regardless of `res.ok`. Auth/network/server failures all showed "Reported" to the user; they thought it landed and never retried. **Likely the actual reason your count of "many flagged" doesn't match the 4 flag-count docs in Firestore.**

**Fix:** check `res.ok` first. On failure, surface the error inline in the modal so the user can retry. The modal stays open until the request actually succeeds.

### 3. Flag and rating docs missing `uid` field
The user IS associated with each flag/rating — via the **doc id** (`aiQuestions/{qid}/flags/{uid}`). But neither doc stored `uid` as a *field*, so admin tooling and collection-group queries couldn't read it cleanly.

**Fix:** new flag/rating writes include `uid` and `questionId` as fields. Existing docs get migrated by `scripts/backfill-flag-rating-uid.ts` (idempotent, `--dry-run` mode).

## After merge
1. **Backfill existing docs:**
   ```
   npx tsx --env-file=.env.local scripts/backfill-flag-rating-uid.ts --dry-run
   # review counts, then:
   npx tsx --env-file=.env.local scripts/backfill-flag-rating-uid.ts
   ```
2. **Watch the next run finalize** — `users/{uid}/triviaStats/aggregate.reportsFiled` should now correctly persist whatever has been incremented since the last apply (and in fresh runs, won't get clobbered).
3. **The flag-count discrepancy will fix itself going forward** — failed flags now show errors so users retry. Existing flag counts on questions are unaffected; we don't re-attempt past flags.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run` — all tests pass
- [x] `npx eslint` clean on touched files
- [ ] Manual: flag a question, verify network tab shows 200 and "Reported" appears
- [ ] Manual: simulate a network failure (devtools offline) and confirm the modal shows "Couldn't send report" instead of silently saying "Reported"
- [ ] Manual: confirm the flag doc in Firestore has `{uid, questionId, reason, flaggedAt, ...}` with uid/questionId as fields
- [ ] Manual: complete a run, then check that `users/{uid}/triviaStats/aggregate.reportsFiled` reflects all flags filed since the run started
- [ ] Run the backfill script and verify existing flag/rating docs gain uid/questionId fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)