### PR TITLE
refactor: derive flag count from subcollection, drop flaggedCount field

### DIFF
--- a/scripts/audit-flag-counts.ts
+++ b/scripts/audit-flag-counts.ts
@@ -1,0 +1,90 @@
+#!/usr/bin/env tsx
+/**
+ * Read-only audit of question flagging.
+ *
+ * Reports:
+ *   - Total aiQuestions docs
+ *   - Total flag docs (collection group sum)
+ *   - Unique questions with at least one flag doc
+ *   - Questions with status === 'flagged' that have NO flag docs
+ *     (a possible bug — would mean status got set without a flag landing)
+ *
+ * The flags subcollection is the source of truth for flag count;
+ * flaggedCount as a denormalized field has been removed.
+ *
+ * Usage:
+ *   npx tsx --env-file=.env.local scripts/audit-flag-counts.ts
+ */
+
+import { cert, getApps, initializeApp } from 'firebase-admin/app'
+import { getFirestore } from 'firebase-admin/firestore'
+
+function ensureApp() {
+  if (getApps().length > 0) return
+  const projectId = process.env.FIREBASE_PROJECT_ID
+  const clientEmail = process.env.FIREBASE_CLIENT_EMAIL
+  const privateKey = process.env.FIREBASE_PRIVATE_KEY?.replace(/\\n/g, '\n')
+  if (!projectId || !clientEmail || !privateKey) {
+    console.error('ERROR: Missing Firebase env vars.')
+    process.exit(1)
+  }
+  initializeApp({ credential: cert({ projectId, clientEmail, privateKey }) })
+}
+
+async function main() {
+  ensureApp()
+  const db = getFirestore()
+
+  console.log('Reading aiQuestions...')
+  const qSnap = await db.collection('aiQuestions').get()
+  const totalQuestions = qSnap.size
+  const flaggedStatusIds = new Set<string>(
+    qSnap.docs.filter((d) => d.data().status === 'flagged').map((d) => d.id)
+  )
+
+  console.log('Reading flags collection group...')
+  const flagsSnap = await db.collectionGroup('flags').get()
+
+  const flagCountByQuestion = new Map<string, number>()
+  for (const doc of flagsSnap.docs) {
+    const parent = doc.ref.parent.parent
+    if (!parent) continue
+    if (parent.parent.id !== 'aiQuestions') continue
+    const qid = parent.id
+    flagCountByQuestion.set(qid, (flagCountByQuestion.get(qid) ?? 0) + 1)
+  }
+
+  const totalFlagDocs = flagsSnap.docs.length
+  const questionsWithFlags = [...flagCountByQuestion.keys()]
+
+  // Status === 'flagged' but no flag docs: would mean the status got set
+  // without a corresponding flag write — a real bug.
+  const flaggedWithoutDocs = [...flaggedStatusIds].filter((id) => !flagCountByQuestion.has(id))
+
+  console.log('─'.repeat(60))
+  console.log(`aiQuestions docs:               ${totalQuestions}`)
+  console.log(`status === 'flagged':           ${flaggedStatusIds.size}`)
+  console.log(`Total flag docs:                ${totalFlagDocs}`)
+  console.log(`Unique questions with flags:    ${questionsWithFlags.length}`)
+  console.log('─'.repeat(60))
+  console.log(`Status='flagged' but no flag docs: ${flaggedWithoutDocs.length}`)
+  if (flaggedWithoutDocs.length > 0) {
+    console.log('  (first 20):')
+    for (const id of flaggedWithoutDocs.slice(0, 20)) {
+      console.log(`    ${id}`)
+    }
+  }
+
+  if (questionsWithFlags.length > 0) {
+    console.log('\nFlag distribution (top 10 by flag count):')
+    const sorted = [...flagCountByQuestion.entries()].sort((a, b) => b[1] - a[1])
+    for (const [qid, count] of sorted.slice(0, 10)) {
+      console.log(`  ${qid}  flags=${count}`)
+    }
+  }
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})

--- a/scripts/list-flagged-questions.ts
+++ b/scripts/list-flagged-questions.ts
@@ -48,10 +48,10 @@ async function main() {
     console.log(`Question:     ${data.question}`)
     console.log(`Category:     ${data.category}`)
     console.log(`Difficulty:   ${data.difficulty}`)
-    console.log(`FlaggedCount: ${data.flaggedCount ?? 0}`)
 
-    // Fetch flag subcollection
+    // Fetch flag subcollection (the source of truth for flag count)
     const flagsSnap = await db.collection(`aiQuestions/${doc.id}/flags`).get()
+    console.log(`Flag count:   ${flagsSnap.size}`)
     if (flagsSnap.size > 0) {
       console.log('Flags:')
       for (const flagDoc of flagsSnap.docs) {

--- a/src/app/api/v1/trivia/infinite/next/route.ts
+++ b/src/app/api/v1/trivia/infinite/next/route.ts
@@ -72,7 +72,6 @@ export async function GET(request: NextRequest) {
           status: 'active',
           timesShown: 0,
           timesCorrect: 0,
-          flaggedCount: 0,
           avgTimeMs: null,
         }
       } catch (genErr) {

--- a/src/app/api/v1/trivia/questions/[id]/flag/route.ts
+++ b/src/app/api/v1/trivia/questions/[id]/flag/route.ts
@@ -5,10 +5,15 @@ import { verifyRequestAuth } from '@/lib/api/auth';
 import { getFirestoreDb } from '@/lib/firebase/server';
 import { incrementVoiceStat } from '@/lib/trivia/triviaStats';
 
-const FLAG_THRESHOLD = 1;
 const BONUS_LIVES_PER_RUN = 1;
 const VALID_REASONS = ['obvious', 'unanswerable', 'nonsense', 'inaccurate', 'difficulty_mismatch', 'other'] as const;
 type FlagReason = (typeof VALID_REASONS)[number];
+
+// One flag from any user is enough to remove a question from rotation.
+// We no longer maintain a denormalized flaggedCount on the question doc;
+// the flags subcollection is the source of truth. If the threshold is
+// ever raised above 1, this route can read the subcollection (or use a
+// Firestore aggregation count) inside the transaction.
 
 export async function POST(
   request: NextRequest,
@@ -51,24 +56,16 @@ export async function POST(
       const qSnap = await tx.get(qRef);
       if (!qSnap.exists) throw new Error('Question not found');
 
+      // Only flip status from active → flagged. Already-flagged or removed
+      // questions stay where they are (still record this user's flag doc).
       const qData = qSnap.data()!;
-      const currentFlaggedCount = qData.flaggedCount ?? 0;
-      const newFlaggedCount = currentFlaggedCount + 1;
-      const wasFirstFlag = currentFlaggedCount === 0;
-
-      const qUpdates: FirebaseFirestore.UpdateData<FirebaseFirestore.DocumentData> = {
-        flaggedCount: FieldValue.increment(1),
-      };
-
-      if (newFlaggedCount >= FLAG_THRESHOLD && qData.status === 'active') {
-        qUpdates.status = 'flagged';
+      if (qData.status === 'active') {
+        tx.update(qRef, { status: 'flagged' });
       }
 
-      tx.update(qRef, qUpdates);
-
-      // Store uid as a field too — the doc id is already the uid, but
-      // having it as a field lets us do collection-group queries like
-      // "all flags by user X" and lets admin tooling display it.
+      // Store uid + questionId as fields too — the doc id is already the
+      // uid, but having them as fields lets us do collection-group queries
+      // ("all flags by user X") and lets admin tooling display them.
       const flagDoc: Record<string, unknown> = {
         uid,
         questionId,
@@ -80,7 +77,7 @@ export async function POST(
       }
       tx.set(flagRef, flagDoc);
 
-      // Handle run updates if a runId is provided
+      // Award one bonus life per run (capped) when a flag is filed during play.
       let bonusLifeGranted = false;
       if (validRunId) {
         const runRef = db.doc(`users/${uid}/triviaInfinite/${validRunId}`);
@@ -103,15 +100,16 @@ export async function POST(
         }
       }
 
-      return { wasFirstFlag, bonusLifeGranted };
+      return { bonusLifeGranted };
     });
 
-    // Increment lifetime reports counter
+    // Increment lifetime reports counter (independent of the flag tx;
+    // owned by incrementVoiceStat exclusively after the run-aggregate fix).
     await incrementVoiceStat(uid, 'reportsFiled').catch((err) =>
       console.error('[flag] Failed to increment voice stat:', err)
     );
 
-    return NextResponse.json({ ok: true, wasFirstFlag: result.wasFirstFlag, bonusLifeGranted: result.bonusLifeGranted }, { status: 200 });
+    return NextResponse.json({ ok: true, bonusLifeGranted: result.bonusLifeGranted }, { status: 200 });
   } catch (err) {
     if (err instanceof Error && err.message === 'Question not found') {
       return NextResponse.json({ error: 'Question not found.' }, { status: 404 });

--- a/src/app/trivia/components/FlagQuestion.tsx
+++ b/src/app/trivia/components/FlagQuestion.tsx
@@ -14,7 +14,6 @@ const FLAG_REASONS = [
 ] as const
 
 interface FlagResult {
-  wasFirstFlag: boolean
   bonusLifeGranted: boolean
 }
 
@@ -66,10 +65,10 @@ export function FlagQuestion({ questionId, runId, onFlagged }: Props) {
       setSubmitted(true)
       setShowModal(false)
       if (onFlagged) {
-        let result: FlagResult = { wasFirstFlag: false, bonusLifeGranted: false }
+        let result: FlagResult = { bonusLifeGranted: false }
         try {
           const data = await res.json()
-          result = { wasFirstFlag: data.wasFirstFlag ?? false, bonusLifeGranted: data.bonusLifeGranted ?? false }
+          result = { bonusLifeGranted: data.bonusLifeGranted ?? false }
         } catch {
           // use defaults
         }

--- a/src/app/trivia/components/InfiniteQuestionCard.tsx
+++ b/src/app/trivia/components/InfiniteQuestionCard.tsx
@@ -1,15 +1,16 @@
 'use client'
 import { useState } from 'react'
-import { ChunkyCard, ChunkyCardContent, ChunkyCardHeader } from '@/components/ui/chunky-card'
-import { ChunkyButton } from '@/components/ui/chunky-button'
-import { Input } from '@/components/ui/input'
+
 import type { InfiniteQuestion } from '@/app/trivia/hooks/useInfiniteRun'
 import type { AnswerResult } from '@/app/trivia/lib/infiniteScoring'
+import { ChunkyButton } from '@/components/ui/chunky-button'
+import { ChunkyCard, ChunkyCardContent, ChunkyCardHeader } from '@/components/ui/chunky-card'
+import { Input } from '@/components/ui/input'
+
 import { FlagQuestion } from './FlagQuestion'
 import { QuestionRating } from './QuestionRating'
 
 interface FlagResult {
-  wasFirstFlag: boolean
   bonusLifeGranted: boolean
 }
 

--- a/src/app/trivia/components/InfiniteRunSummary.tsx
+++ b/src/app/trivia/components/InfiniteRunSummary.tsx
@@ -1,16 +1,17 @@
 'use client'
 import { useState } from 'react'
+
+import type { InfiniteMode, InfiniteRunState } from '@/app/trivia/hooks/useInfiniteRun'
 import { ChunkyButton } from '@/components/ui/chunky-button'
 import { ChunkyCard, ChunkyCardContent } from '@/components/ui/chunky-card'
 import { Pill } from '@/components/ui/pill'
 import { useAuth } from '@/hooks/useAuth'
-import { SignInCard } from './SignInCTA'
-import { QuestionRating } from './QuestionRating'
+
 import { FlagQuestion } from './FlagQuestion'
-import type { InfiniteRunState, InfiniteMode } from '@/app/trivia/hooks/useInfiniteRun'
+import { QuestionRating } from './QuestionRating'
+import { SignInCard } from './SignInCTA'
 
 interface FlagResult {
-  wasFirstFlag: boolean
   bonusLifeGranted: boolean
 }
 

--- a/src/app/trivia/hooks/useInfiniteRun.ts
+++ b/src/app/trivia/hooks/useInfiniteRun.ts
@@ -379,7 +379,7 @@ export function useInfiniteRun() {
     setState(s => ({ ...s, phase: 'ended' }))
   }, [state.runId, state.lastAnswer, getAuthHeaders, cancelPrefetch])
 
-  const handleQuestionFlagged = useCallback((questionId: string, result: { wasFirstFlag: boolean; bonusLifeGranted: boolean }) => {
+  const handleQuestionFlagged = useCallback((questionId: string, result: { bonusLifeGranted: boolean }) => {
     setState(s => {
       const newFlaggedQuestionIds = s.flaggedQuestionIds.includes(questionId)
         ? s.flaggedQuestionIds

--- a/src/lib/trivia/aiQuestions.ts
+++ b/src/lib/trivia/aiQuestions.ts
@@ -12,7 +12,6 @@ export interface AIQuestion {
   status: 'active' | 'flagged' | 'removed'
   timesShown: number
   timesCorrect: number
-  flaggedCount: number
   avgTimeMs: number | null
 }
 
@@ -22,7 +21,7 @@ export interface SeenQuestion {
 }
 
 export async function saveAIQuestion(
-  question: Omit<AIQuestion, 'status' | 'timesShown' | 'timesCorrect' | 'flaggedCount' | 'avgTimeMs'>
+  question: Omit<AIQuestion, 'status' | 'timesShown' | 'timesCorrect' | 'avgTimeMs'>
 ): Promise<string> {
   const db = getFirestoreDb()
   const doc: AIQuestion = {
@@ -30,7 +29,6 @@ export async function saveAIQuestion(
     status: 'active',
     timesShown: 0,
     timesCorrect: 0,
-    flaggedCount: 0,
     avgTimeMs: null,
   }
   const ref = db.collection('aiQuestions').doc(question.id)

--- a/src/lib/trivia/generateQuestion.ts
+++ b/src/lib/trivia/generateQuestion.ts
@@ -16,7 +16,7 @@ import {
 
 export type GeneratedQuestion = Omit<
   AIQuestion,
-  'status' | 'timesShown' | 'timesCorrect' | 'flaggedCount' | 'avgTimeMs'
+  'status' | 'timesShown' | 'timesCorrect' | 'avgTimeMs'
 >
 
 export interface GenerateInfiniteQuestionOptions {


### PR DESCRIPTION
## Summary
Removes the denormalized `flaggedCount` field on `aiQuestions/{id}` docs. The `flags/` subcollection is the source of truth.

With `FLAG_THRESHOLD = 1` (set in PR #711), the live path doesn't actually need a count — any single flag flips the question's `status` to `'flagged'` and that hides it from the sampler. So:

**Flag route now:**
1. Writes the flag doc (idempotent — doc id is the uid).
2. Flips `status` from `active` → `flagged` if needed; no-op if already flagged.
3. Done. No counter reads or writes.

**What got cleaned up alongside this:**
- `flaggedCount` removed from `AIQuestion` interface, `saveAIQuestion`, the synthesized question shape in `/next`.
- `wasFirstFlag` was plumbed through types but never consumed by the UI — dropped.
- `list-flagged-questions.ts` now reports counts from the subcollection.
- `audit-flag-counts.ts` simplified — the flaggedCount-vs-subcollection comparison is moot now.

## Why
Maintaining a denormalized counter is brittle: any failed write puts it out of sync with the source of truth. Today it's accurate (audit confirmed) but only because the only write path is the flag transaction. Removing the counter eliminates a class of future bugs.

If we ever raise `FLAG_THRESHOLD` above 1, the route can read the subcollection (or use Firestore aggregation `.count()`) inside the transaction for the threshold check. With only 6 flag docs across 254 questions, the cost is negligible.

## What's NOT touched
Existing `flaggedCount` values on old question docs are left in place — they're harmless because nothing reads them. They'll fall away naturally as docs get rewritten or deleted.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run` — all tests pass
- [x] `npx eslint` clean on touched files (pre-existing warnings on unrelated scripts remain)
- [ ] Manual: flag a question, confirm `aiQuestions/{id}.status` flips to `'flagged'` and a `flags/{uid}` doc lands
- [ ] Manual: run `npx tsx --env-file=.env.local scripts/audit-flag-counts.ts` and verify the report makes sense (no inconsistencies expected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)