### PR TITLE
feat: implement Red Deck with +1 discard per round

### DIFF
--- a/src/app/daily-card-game/domain/decks/__tests__/red-deck.test.ts
+++ b/src/app/daily-card-game/domain/decks/__tests__/red-deck.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  applyDeckModifiers,
+  createGameStateWithDeck,
+  defaultGameState,
+} from '@/app/daily-card-game/domain/game/default-game-state'
+import { redDeck } from '@/app/daily-card-game/domain/decks/red-deck'
+
+describe('Red Deck', () => {
+  it('has 52 cards', () => {
+    expect(redDeck.cards).toHaveLength(52)
+  })
+
+  it('has +1 maxDiscards modifier', () => {
+    expect(redDeck.modifiers.maxDiscards).toBe(1)
+  })
+
+  it('has the correct id, name and description', () => {
+    expect(redDeck.id).toBe('redDeck')
+    expect(redDeck.name).toBe('Red Deck')
+    expect(redDeck.description).toBe('+1 discard every round')
+  })
+
+  it('when applied to a game state, maxDiscards becomes 4', () => {
+    const base = structuredClone(defaultGameState)
+    const modified = applyDeckModifiers(base, redDeck)
+    expect(modified.maxDiscards).toBe(4)
+  })
+
+  it('when applied to a game state, remainingDiscards starts at 4', () => {
+    const base = structuredClone(defaultGameState)
+    const modified = applyDeckModifiers(base, redDeck)
+    expect(modified.gamePlayState.remainingDiscards).toBe(4)
+  })
+
+  it('createGameStateWithDeck initializes a game with maxDiscards 4 for Red Deck', () => {
+    const state = createGameStateWithDeck('redDeck')
+    expect(state.maxDiscards).toBe(4)
+    expect(state.gamePlayState.remainingDiscards).toBe(4)
+    expect(state.selectedDeck).toBe('redDeck')
+  })
+
+  it('createGameStateWithDeck with Red Deck has 52 owned cards', () => {
+    const state = createGameStateWithDeck('redDeck')
+    expect(state.ownedCardIds).toHaveLength(52)
+  })
+})

--- a/src/app/daily-card-game/domain/decks/decks.ts
+++ b/src/app/daily-card-game/domain/decks/decks.ts
@@ -1,12 +1,20 @@
 import { GameState } from '@/app/daily-card-game/domain/game/types'
 import { PlayingCardState } from '@/app/daily-card-game/domain/playing-card/types'
+import { initializePlayingCard } from '@/app/daily-card-game/domain/playing-card/utils'
 
-import { initialPokerDeckState, pokerDeckDefinition } from './poker-deck'
+import { pokerDeck } from './poker-deck'
+import { redDeck } from './red-deck'
+import { DeckDefinition } from './types'
 
-export const decks = {
-  pokerDeck: pokerDeckDefinition,
+export const decks: Record<string, DeckDefinition> = {
+  pokerDeck: pokerDeck,
+  redDeck: redDeck,
 }
 
-export const initialDeckStates = (game: GameState): Record<string, PlayingCardState[]> => ({
-  pokerDeck: initialPokerDeckState(game),
-})
+export const initialDeckStates = (game: GameState): Record<string, PlayingCardState[]> => {
+  const result: Record<string, PlayingCardState[]> = {}
+  for (const [key, deck] of Object.entries(decks)) {
+    result[key] = deck.cards.map(card => initializePlayingCard(card, game))
+  }
+  return result
+}

--- a/src/app/daily-card-game/domain/decks/poker-deck.ts
+++ b/src/app/daily-card-game/domain/decks/poker-deck.ts
@@ -6,6 +6,8 @@ import {
 } from '@/app/daily-card-game/domain/playing-card/types'
 import { initializePlayingCard } from '@/app/daily-card-game/domain/playing-card/utils'
 
+import { DeckDefinition } from './types'
+
 export const pokerDeckDefinition: PlayingCardDefinition[] = [
   getDefaultCard('2', 'hearts'),
   getDefaultCard('2', 'diamonds'),
@@ -63,3 +65,11 @@ export const pokerDeckDefinition: PlayingCardDefinition[] = [
 
 export const initialPokerDeckState = (game: GameState): PlayingCardState[] =>
   pokerDeckDefinition.map(card => initializePlayingCard(card, game))
+
+export const pokerDeck: DeckDefinition = {
+  id: 'pokerDeck',
+  name: 'Poker Deck',
+  description: 'Standard 52-card deck',
+  cards: pokerDeckDefinition,
+  modifiers: {},
+}

--- a/src/app/daily-card-game/domain/decks/red-deck.ts
+++ b/src/app/daily-card-game/domain/decks/red-deck.ts
@@ -1,0 +1,12 @@
+import { pokerDeckDefinition } from './poker-deck'
+import { DeckDefinition } from './types'
+
+export const redDeck: DeckDefinition = {
+  id: 'redDeck',
+  name: 'Red Deck',
+  description: '+1 discard every round',
+  cards: pokerDeckDefinition,
+  modifiers: {
+    maxDiscards: 1,
+  },
+}

--- a/src/app/daily-card-game/domain/decks/types.ts
+++ b/src/app/daily-card-game/domain/decks/types.ts
@@ -1,0 +1,17 @@
+import { PlayingCardDefinition } from '@/app/daily-card-game/domain/playing-card/types'
+
+export interface DeckDefinition {
+  id: string
+  name: string
+  description: string
+  cards: PlayingCardDefinition[]
+  modifiers: DeckModifiers
+}
+
+export interface DeckModifiers {
+  maxDiscards?: number
+  maxHands?: number
+  money?: number
+  maxJokers?: number
+  maxConsumables?: number
+}

--- a/src/app/daily-card-game/domain/game/default-game-state.ts
+++ b/src/app/daily-card-game/domain/game/default-game-state.ts
@@ -1,4 +1,5 @@
-import { initialDeckStates } from '@/app/daily-card-game/domain/decks/decks'
+import { decks, initialDeckStates } from '@/app/daily-card-game/domain/decks/decks'
+import { DeckDefinition } from '@/app/daily-card-game/domain/decks/types'
 import {
   fiveOfAKindHand,
   flushFiveHand,
@@ -46,6 +47,7 @@ const gameState: GameState = {
   },
   gameSeed: gameSeed,
   handsPlayed: 0,
+  selectedDeck: 'pokerDeck',
   jokers: [],
   maxConsumables: 2,
   maxJokers: 5,
@@ -129,6 +131,24 @@ const gameState: GameState = {
   vouchers: [],
 }
 
+export function applyDeckModifiers(state: GameState, deck: DeckDefinition): GameState {
+  const { modifiers } = deck
+  return {
+    ...state,
+    maxDiscards: state.maxDiscards + (modifiers.maxDiscards ?? 0),
+    maxHands: state.maxHands + (modifiers.maxHands ?? 0),
+    money: state.money + (modifiers.money ?? 0),
+    maxJokers: state.maxJokers + (modifiers.maxJokers ?? 0),
+    maxConsumables: state.maxConsumables + (modifiers.maxConsumables ?? 0),
+    gamePlayState: {
+      ...state.gamePlayState,
+      remainingDiscards:
+        state.gamePlayState.remainingDiscards + (modifiers.maxDiscards ?? 0),
+      remainingHands: state.gamePlayState.remainingHands + (modifiers.maxHands ?? 0),
+    },
+  }
+}
+
 // Initialize the card registry and owned cards from the initial deck
 const initialDeck = initialDeckStates(gameState).pokerDeck
 const cards: Record<string, (typeof initialDeck)[number]> = {}
@@ -143,4 +163,33 @@ export const defaultGameState: GameState = {
   ...gameState,
   cards,
   ownedCardIds,
+}
+
+export function createGameStateWithDeck(deckId: string): GameState {
+  const deck = decks[deckId]
+  if (!deck) {
+    throw new Error(`Unknown deck: ${deckId}`)
+  }
+
+  const baseState: GameState = {
+    ...gameState,
+    selectedDeck: deckId,
+  }
+
+  const stateWithModifiers = applyDeckModifiers(baseState, deck)
+
+  const deckCards = initialDeckStates(stateWithModifiers)[deckId]
+  const deckCardMap: Record<string, (typeof deckCards)[number]> = {}
+  const deckOwnedCardIds: string[] = []
+
+  for (const card of deckCards) {
+    deckCardMap[card.id] = card
+    deckOwnedCardIds.push(card.id)
+  }
+
+  return {
+    ...stateWithModifiers,
+    cards: deckCardMap,
+    ownedCardIds: deckOwnedCardIds,
+  }
 }

--- a/src/app/daily-card-game/domain/game/types.ts
+++ b/src/app/daily-card-game/domain/game/types.ts
@@ -23,6 +23,7 @@ export interface GameState {
   gamePlayState: GamePlayState // values which reset between hands, blinds, or rounds
   gameSeed: string
   handsPlayed: number
+  selectedDeck: string
   jokers: JokerState[]
   maxConsumables: number
   maxDiscards: number


### PR DESCRIPTION
## Summary
- Implements Red Deck (#963) from the Decks epic (#701)
- Red Deck uses standard 52 cards but grants +1 discard every round (4 total instead of 3)
- Introduces `DeckDefinition` type system and `DeckModifiers` for deck-specific game state changes
- Adds `applyDeckModifiers()` and `createGameStateWithDeck()` helpers for deck initialization
- Adds `selectedDeck` field to `GameState` to track which deck is in use

## Changes
- **New:** `domain/decks/types.ts` — `DeckDefinition` and `DeckModifiers` interfaces
- **New:** `domain/decks/red-deck.ts` — Red Deck definition
- **New:** `domain/decks/__tests__/red-deck.test.ts` — 7 tests
- **Modified:** `domain/decks/poker-deck.ts` — Added `DeckDefinition` export
- **Modified:** `domain/decks/decks.ts` — Generic deck registry
- **Modified:** `domain/game/types.ts` — Added `selectedDeck` to `GameState`
- **Modified:** `domain/game/default-game-state.ts` — Deck modifier application infrastructure

## Test plan
- [x] Red Deck has 52 cards
- [x] Red Deck has correct id, name, description
- [x] Red Deck modifier is +1 maxDiscards
- [x] `applyDeckModifiers` sets maxDiscards to 4
- [x] `applyDeckModifiers` sets remainingDiscards to 4
- [x] `createGameStateWithDeck('redDeck')` creates correct state
- [x] All 992 existing tests pass

Closes #963

🤖 Generated with [Claude Code](https://claude.com/claude-code)