### PR TITLE
Implement Turtle Bean uncommon joker (#769)

### DIFF
--- a/src/app/daily-card-game/domain/game/__tests__/turtle-bean.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/turtle-bean.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest'
+
+import { defaultGameState } from '@/app/daily-card-game/domain/game/default-game-state'
+import { reduceGame } from '@/app/daily-card-game/domain/game/reduce-game'
+import type { GameState } from '@/app/daily-card-game/domain/game/types'
+import { jokers } from '@/app/daily-card-game/domain/joker/jokers'
+import { initializeJoker } from '@/app/daily-card-game/domain/joker/utils'
+
+describe('Turtle Bean joker', () => {
+  function createGameWithTurtleBean(): GameState {
+    const game: GameState = structuredClone(defaultGameState)
+    const tb = initializeJoker(jokers.turtleBeanJoker, game)
+    tb.metadata = { handSizeBonus: 5 }
+    game.jokers = [tb]
+    return game
+  }
+
+  it('adds +5 hand size modifier on GAME_START', () => {
+    const game = createGameWithTurtleBean()
+    expect(game.handSizeModifier).toBe(0)
+
+    const started = reduceGame(game, { type: 'GAME_START' })
+    expect(started.handSizeModifier).toBe(5)
+  })
+
+  it('reduces hand size modifier by 1 on ROUND_END', () => {
+    const game = createGameWithTurtleBean()
+    const started = reduceGame(game, { type: 'GAME_START' })
+    expect(started.handSizeModifier).toBe(5)
+
+    const afterRound1 = reduceGame(started, { type: 'ROUND_END' })
+    expect(afterRound1.handSizeModifier).toBe(4)
+    const tb1 = afterRound1.jokers.find(j => j.jokerId === 'turtleBeanJoker')
+    expect(tb1).toBeTruthy()
+    expect(tb1!.metadata?.handSizeBonus).toBe(4)
+  })
+
+  it('self-destructs after 5 rounds', () => {
+    let game = createGameWithTurtleBean()
+    game = reduceGame(game, { type: 'GAME_START' })
+
+    for (let i = 0; i < 5; i++) {
+      game = reduceGame(game, { type: 'ROUND_END' })
+    }
+
+    expect(game.handSizeModifier).toBe(0)
+    expect(game.jokers.some(j => j.jokerId === 'turtleBeanJoker')).toBe(false)
+  })
+
+  it('reverts hand size modifier when sold', () => {
+    const game = createGameWithTurtleBean()
+    const started = reduceGame(game, { type: 'GAME_START' })
+    expect(started.handSizeModifier).toBe(5)
+
+    // Sell after 2 rounds (bonus should be 3)
+    let afterRounds = started
+    afterRounds = reduceGame(afterRounds, { type: 'ROUND_END' })
+    afterRounds = reduceGame(afterRounds, { type: 'ROUND_END' })
+    expect(afterRounds.handSizeModifier).toBe(3)
+
+    const tbInstance = afterRounds.jokers.find(j => j.jokerId === 'turtleBeanJoker')!
+    const selected = {
+      ...afterRounds,
+      gamePlayState: { ...afterRounds.gamePlayState, selectedJokerId: tbInstance.id },
+    }
+
+    const afterSale = reduceGame(selected, { type: 'JOKER_SOLD' })
+    expect(afterSale.handSizeModifier).toBe(0)
+    expect(afterSale.jokers.some(j => j.jokerId === 'turtleBeanJoker')).toBe(false)
+  })
+})

--- a/src/app/daily-card-game/domain/game/default-game-state.ts
+++ b/src/app/daily-card-game/domain/game/default-game-state.ts
@@ -52,6 +52,7 @@ const gameState: GameState = {
   maxConsumables: 2,
   maxJokers: 5,
   maxHands: 4,
+  handSizeModifier: 0,
   maxDiscards: 3,
   maxInterest: 5,
   money: 0,

--- a/src/app/daily-card-game/domain/game/handlers.ts
+++ b/src/app/daily-card-game/domain/game/handlers.ts
@@ -155,7 +155,7 @@ export function handleHandScoringEnd(draft: Draft<GameState>, event: GameEvent) 
   }
 
   // Continue gameplay: refill + reset score
-  const cardsNeeded = HAND_SIZE - draft.gamePlayState.handIds.length
+  const cardsNeeded = HAND_SIZE + draft.handSizeModifier - draft.gamePlayState.handIds.length
   dealCardsFromDrawPile(draft as unknown as GameState, cardsNeeded)
   draft.gamePhase = 'gameplay'
   resetScoreForNextHand(draft.gamePlayState)

--- a/src/app/daily-card-game/domain/game/handlers/gameplay.ts
+++ b/src/app/daily-card-game/domain/game/handlers/gameplay.ts
@@ -77,7 +77,7 @@ export function handleDiscardSelectedCards(draft: GameState) {
   gamePlayState.remainingDiscards -= 1
 
   // refill immediately (this was previously orchestrated in useGameEvents)
-  const cardsNeeded = HAND_SIZE - gamePlayState.handIds.length
+  const cardsNeeded = HAND_SIZE + draft.handSizeModifier - gamePlayState.handIds.length
   dealCardsFromDrawPile(draft as unknown as GameState, cardsNeeded)
 
   // Purple seal: add a tarot card for each discarded card with purple seal

--- a/src/app/daily-card-game/domain/game/handlers/shop.ts
+++ b/src/app/daily-card-game/domain/game/handlers/shop.ts
@@ -337,7 +337,7 @@ export function handleShopOpenPack(draft: GameState, event: ShopOpenPackEvent) {
       seed: seed,
       iteration: draft.roundIndex + blindIndices[nextBlind?.type ?? 'smallBlind'],
     })
-    dealCardsFromDrawPile(draft, HAND_SIZE)
+    dealCardsFromDrawPile(draft, HAND_SIZE + draft.handSizeModifier)
   }
   if (packDefinition.cardType === 'spectralCard') {
     draft.gamePlayState.drawPileIds = shuffleCardIds({
@@ -351,7 +351,7 @@ export function handleShopOpenPack(draft: GameState, event: ShopOpenPackEvent) {
       ]),
       iteration: draft.roundIndex + blindIndices[nextBlind?.type ?? 'smallBlind'],
     })
-    dealCardsFromDrawPile(draft as unknown as GameState, HAND_SIZE)
+    dealCardsFromDrawPile(draft as unknown as GameState, HAND_SIZE + draft.handSizeModifier)
   }
 }
 

--- a/src/app/daily-card-game/domain/game/reduce-game.ts
+++ b/src/app/daily-card-game/domain/game/reduce-game.ts
@@ -116,7 +116,7 @@ export function reduceGame(game: GameState, event: GameEvent): GameState {
 
       case 'HAND_DEALT': {
         if (draft.gamePlayState.handIds.length) return
-        dealCardsFromDrawPile(draft, HAND_SIZE)
+        dealCardsFromDrawPile(draft, HAND_SIZE + draft.handSizeModifier)
         return
       }
       case 'CARD_SELECTED': {
@@ -313,6 +313,8 @@ export function reduceGame(game: GameState, event: GameEvent): GameState {
        */
 
       case 'ROUND_END': {
+        const roundEndCtx = getEffectContext(draft as unknown as GameState, event)
+        dispatchEffects(event, roundEndCtx, collectEffects(roundEndCtx.game))
         return
       }
 

--- a/src/app/daily-card-game/domain/game/types.ts
+++ b/src/app/daily-card-game/domain/game/types.ts
@@ -28,6 +28,7 @@ export interface GameState {
   maxConsumables: number
   maxDiscards: number
   maxHands: number
+  handSizeModifier: number
   maxJokers: number
   maxInterest: number
   money: number

--- a/src/app/daily-card-game/domain/joker/jokers.ts
+++ b/src/app/daily-card-game/domain/joker/jokers.ts
@@ -467,6 +467,77 @@ export const fourFingersJoker: JokerDefinition = {
   rarity: 'uncommon',
 }
 
+export const turtleBeanJoker: JokerDefinition = {
+  id: 'turtleBeanJoker',
+  name: 'Turtle Bean',
+  description: '+5 hand size, reduces by 1 each round',
+  price: 6,
+  effects: [
+    {
+      event: { type: 'GAME_START' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        const tb = ctx.game.jokers.find(j => j.jokerId === 'turtleBeanJoker')
+        if (tb) {
+          if (!tb.metadata?.handSizeBonus) {
+            tb.metadata = { ...tb.metadata, handSizeBonus: 5 }
+          }
+          const bonus = tb.metadata?.handSizeBonus ?? 5
+          ctx.game.handSizeModifier += bonus
+        }
+      },
+    },
+    {
+      event: { type: 'JOKER_ADDED' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        const tb = ctx.game.jokers.find(j => j.jokerId === 'turtleBeanJoker')
+        if (tb) {
+          tb.metadata = { ...tb.metadata, handSizeBonus: 5 }
+          ctx.game.handSizeModifier += 5
+        }
+      },
+    },
+    {
+      event: { type: 'ROUND_END' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        const tb = ctx.game.jokers.find(j => j.jokerId === 'turtleBeanJoker')
+        if (!tb || !tb.metadata) return
+
+        ctx.game.handSizeModifier -= 1
+        tb.metadata.handSizeBonus -= 1
+
+        if (tb.metadata.handSizeBonus <= 0) {
+          ctx.game.jokers = ctx.game.jokers.filter(j => j.id !== tb.id)
+        }
+      },
+    },
+    {
+      event: { type: 'JOKER_SOLD' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        // Joker already removed from array. Recalculate from remaining instances.
+        const remainingBonus = ctx.game.jokers
+          .filter(j => j.jokerId === 'turtleBeanJoker')
+          .reduce((sum, j) => sum + (j.metadata?.handSizeBonus ?? 0), 0)
+        ctx.game.handSizeModifier = remainingBonus
+      },
+    },
+    {
+      event: { type: 'JOKER_REMOVED' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        const remainingBonus = ctx.game.jokers
+          .filter(j => j.jokerId === 'turtleBeanJoker')
+          .reduce((sum, j) => sum + (j.metadata?.handSizeBonus ?? 0), 0)
+        ctx.game.handSizeModifier = remainingBonus
+      },
+    },
+  ],
+  rarity: 'uncommon',
+}
+
 export const jokers: Record<JokerDefinition['id'], JokerDefinition> = {
   jokerJoker,
   greedyJoker,
@@ -483,6 +554,7 @@ export const jokers: Record<JokerDefinition['id'], JokerDefinition> = {
   halfJoker,
   jokerStencil,
   fourFingersJoker,
+  turtleBeanJoker,
 }
 
 /***

--- a/src/app/daily-card-game/domain/joker/types.ts
+++ b/src/app/daily-card-game/domain/joker/types.ts
@@ -15,6 +15,7 @@ export interface JokerState {
   flags: JokerFlags
   edition: 'holographic' | 'foil' | 'polychrome' | 'negative' | 'normal'
   isFaceUp: boolean
+  metadata?: Record<string, number>
 }
 
 export interface JokerFlags {


### PR DESCRIPTION
## Summary
- Adds **Turtle Bean** uncommon joker: +5 hand size, reduces by 1 each round, self-destructs when bonus reaches 0
- Adds `handSizeModifier` to `GameState` and updates all `HAND_SIZE` references to respect it (infrastructure for future hand-size jokers like Juggler, Troubadour)
- Adds optional `metadata` field to `JokerState` for per-joker state tracking (counters, etc.)
- Enables `ROUND_END` effect dispatching in `reduceGame` (was previously a no-op)

Closes #769

## Test plan
- [x] Turtle Bean adds +5 hand size modifier on GAME_START
- [x] Hand size modifier reduces by 1 each ROUND_END
- [x] Joker self-destructs after 5 rounds (bonus reaches 0)
- [x] Selling the joker correctly reverts remaining hand size bonus
- [x] All 996 existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)