### PR TITLE
fix: flag transaction violated Firestore read-before-write rule

### DIFF
--- a/src/app/api/v1/trivia/questions/[id]/flag/route.ts
+++ b/src/app/api/v1/trivia/questions/[id]/flag/route.ts
@@ -51,14 +51,26 @@ export async function POST(
   const qRef = db.doc(`aiQuestions/${questionId}`);
   const flagRef = db.doc(`aiQuestions/${questionId}/flags/${uid}`);
 
+  const runRef = validRunId ? db.doc(`users/${uid}/triviaInfinite/${validRunId}`) : null;
+
   try {
     const result = await db.runTransaction(async (tx) => {
+      // Firestore transactions require all reads before any writes.
+      // Read the question doc and (optionally) the run doc up front,
+      // then do every write below.
       const qSnap = await tx.get(qRef);
       if (!qSnap.exists) throw new Error('Question not found');
+      const runSnap = runRef ? await tx.get(runRef) : null;
+
+      const qData = qSnap.data()!;
+      const runData = runSnap?.exists ? runSnap.data()! : null;
+      const bonusLivesEarned = runData?.bonusLivesEarned ?? 0;
+      const shouldGrantBonusLife = runData !== null && bonusLivesEarned < BONUS_LIVES_PER_RUN;
+
+      // ── all writes below ──────────────────────────────────────────
 
       // Only flip status from active → flagged. Already-flagged or removed
       // questions stay where they are (still record this user's flag doc).
-      const qData = qSnap.data()!;
       if (qData.status === 'active') {
         tx.update(qRef, { status: 'flagged' });
       }
@@ -78,29 +90,18 @@ export async function POST(
       tx.set(flagRef, flagDoc);
 
       // Award one bonus life per run (capped) when a flag is filed during play.
-      let bonusLifeGranted = false;
-      if (validRunId) {
-        const runRef = db.doc(`users/${uid}/triviaInfinite/${validRunId}`);
-        const runSnap = await tx.get(runRef);
-        if (runSnap.exists) {
-          const runData = runSnap.data()!;
-          const bonusLivesEarned = runData.bonusLivesEarned ?? 0;
-
-          const runUpdates: FirebaseFirestore.UpdateData<FirebaseFirestore.DocumentData> = {
-            flaggedQuestionIds: FieldValue.arrayUnion(questionId),
-          };
-
-          if (bonusLivesEarned < BONUS_LIVES_PER_RUN) {
-            runUpdates.livesRemaining = FieldValue.increment(1);
-            runUpdates.bonusLivesEarned = FieldValue.increment(1);
-            bonusLifeGranted = true;
-          }
-
-          tx.update(runRef, runUpdates);
+      if (runRef && runData) {
+        const runUpdates: FirebaseFirestore.UpdateData<FirebaseFirestore.DocumentData> = {
+          flaggedQuestionIds: FieldValue.arrayUnion(questionId),
+        };
+        if (shouldGrantBonusLife) {
+          runUpdates.livesRemaining = FieldValue.increment(1);
+          runUpdates.bonusLivesEarned = FieldValue.increment(1);
         }
+        tx.update(runRef, runUpdates);
       }
 
-      return { bonusLifeGranted };
+      return { bonusLifeGranted: shouldGrantBonusLife };
     });
 
     // Increment lifetime reports counter (independent of the flag tx;


### PR DESCRIPTION
## Summary
The flag route's transaction read the question, wrote to it and to the flag doc, then read the run doc — which Firestore rejects with:

> Firestore transactions require all reads to be executed before all writes.

This bug predates the recent flag refactor; it's been latent for a while. PR #984's silent-failure fix made `FlagQuestion` actually surface failures, which is how this finally got reported instead of looking like a successful flag.

## Fix
Read the question doc and (when present) the run doc up front, then do every write. No behavior change beyond actually working.

```diff
 const qSnap = await tx.get(qRef);
 if (!qSnap.exists) throw new Error('Question not found');
+const runSnap = runRef ? await tx.get(runRef) : null;

-tx.update(qRef, { status: 'flagged' });
-tx.set(flagRef, flagDoc);
-if (validRunId) {
-  const runSnap = await tx.get(runRef);  // ❌ read after writes
-  ...
-}
+// all writes below
+tx.update(qRef, { status: 'flagged' });
+tx.set(flagRef, flagDoc);
+if (runRef && runSnap?.exists) {
+  tx.update(runRef, runUpdates);
+}
```

## Verified clean elsewhere
Audited the other Firestore transactions in the codebase:
- `submitAnswer` (`src/lib/trivia/infiniteRuns.ts`) — all reads at top, then writes ✓
- `applyRunToAggregate` (`src/lib/trivia/triviaStats.ts`) — same ✓
- `flag/route.ts` — was the only offender, now fixed.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run` — all tests pass
- [x] `npx eslint` clean
- [ ] **Manual:** flag a question during a live run — confirm the flag lands and the bonus-life toast fires (no error toast, no 500)
- [ ] Manual: flag a question from the run summary screen (no active run) — same expectation

🤖 Generated with [Claude Code](https://claude.com/claude-code)