### PR TITLE
Implement To the Moon uncommon joker (#770)

### DIFF
--- a/src/app/daily-card-game/domain/game/__tests__/to-the-moon.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/to-the-moon.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest'
+
+import { defaultGameState } from '@/app/daily-card-game/domain/game/default-game-state'
+import { reduceGame } from '@/app/daily-card-game/domain/game/reduce-game'
+import type { GameState } from '@/app/daily-card-game/domain/game/types'
+import { jokers } from '@/app/daily-card-game/domain/joker/jokers'
+import { initializeJoker } from '@/app/daily-card-game/domain/joker/utils'
+import { calculateInterest } from '@/app/daily-card-game/domain/game/utils'
+
+describe('To the Moon joker', () => {
+  function createGameWithToTheMoon(): GameState {
+    const game: GameState = structuredClone(defaultGameState)
+    game.jokers = [initializeJoker(jokers.toTheMoonJoker, game)]
+    return game
+  }
+
+  it('increases maxInterest on GAME_START', () => {
+    const game = createGameWithToTheMoon()
+    expect(game.maxInterest).toBe(5)
+
+    const started = reduceGame(game, { type: 'GAME_START' })
+    expect(started.maxInterest).toBe(105)
+  })
+
+  it('allows interest beyond normal cap with $30', () => {
+    const game = createGameWithToTheMoon()
+    const started = reduceGame(game, { type: 'GAME_START' })
+    const withMoney = { ...started, money: 30 }
+
+    const interest = calculateInterest(withMoney)
+    expect(interest).toBe(6) // floor(30/5) = 6, normally capped at 5
+  })
+
+  it('allows high interest with $50', () => {
+    const game = createGameWithToTheMoon()
+    const started = reduceGame(game, { type: 'GAME_START' })
+    const withMoney = { ...started, money: 50 }
+
+    const interest = calculateInterest(withMoney)
+    expect(interest).toBe(10) // floor(50/5) = 10
+  })
+
+  it('reverts maxInterest when sold', () => {
+    const game = createGameWithToTheMoon()
+    const started = reduceGame(game, { type: 'GAME_START' })
+    expect(started.maxInterest).toBe(105)
+
+    const jokerInstance = started.jokers.find(j => j.jokerId === 'toTheMoonJoker')!
+    const selected = {
+      ...started,
+      gamePlayState: { ...started.gamePlayState, selectedJokerId: jokerInstance.id },
+    }
+
+    const afterSale = reduceGame(selected, { type: 'JOKER_SOLD' })
+    expect(afterSale.maxInterest).toBe(5)
+    expect(afterSale.jokers.some(j => j.jokerId === 'toTheMoonJoker')).toBe(false)
+  })
+})

--- a/src/app/daily-card-game/domain/joker/jokers.ts
+++ b/src/app/daily-card-game/domain/joker/jokers.ts
@@ -538,6 +538,66 @@ export const turtleBeanJoker: JokerDefinition = {
   rarity: 'uncommon',
 }
 
+export const toTheMoonJoker: JokerDefinition = {
+  id: 'toTheMoonJoker',
+  name: 'To the Moon',
+  description: 'Earn an extra $1 of interest for every $5 you have at end of round',
+  price: 5,
+  effects: [
+    {
+      event: { type: 'GAME_START' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        if (ctx.game.jokers.some(j => j.jokerId === 'toTheMoonJoker')) {
+          ctx.game.maxInterest += 100
+        }
+      },
+    },
+    {
+      event: { type: 'JOKER_ADDED' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        ctx.game.maxInterest += 100
+      },
+    },
+    {
+      event: { type: 'SHOP_BUY_CARD' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        const selectedCard = ctx.game.shopState.cardsForSale.find(
+          card => card.card.id === ctx.game.shopState.selectedCardId
+        )
+        if (!selectedCard) return
+        if (
+          isJokerState(selectedCard.card) &&
+          selectedCard.card.jokerId === 'toTheMoonJoker'
+        ) {
+          ctx.game.maxInterest += 100
+        }
+      },
+    },
+    {
+      event: { type: 'JOKER_SOLD' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        if (!ctx.game.jokers.some(j => j.jokerId === 'toTheMoonJoker')) {
+          ctx.game.maxInterest -= 100
+        }
+      },
+    },
+    {
+      event: { type: 'JOKER_REMOVED' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        if (!ctx.game.jokers.some(j => j.jokerId === 'toTheMoonJoker')) {
+          ctx.game.maxInterest -= 100
+        }
+      },
+    },
+  ],
+  rarity: 'uncommon',
+}
+
 export const jokers: Record<JokerDefinition['id'], JokerDefinition> = {
   jokerJoker,
   greedyJoker,
@@ -555,6 +615,7 @@ export const jokers: Record<JokerDefinition['id'], JokerDefinition> = {
   jokerStencil,
   fourFingersJoker,
   turtleBeanJoker,
+  toTheMoonJoker,
 }
 
 /***


### PR DESCRIPTION
## Summary
- Adds **To the Moon** uncommon joker: earns extra $1 of interest per $5 held at end of round
- Implemented by raising `maxInterest` by 100 when active, so existing interest formula (`floor(money/5)`) naturally produces uncapped results
- Follows the Four Fingers pattern for GAME_START/JOKER_ADDED/SHOP_BUY_CARD/JOKER_SOLD/JOKER_REMOVED lifecycle

Closes #770

**Note:** This PR is based on #987 (Turtle Bean) which provides the ROUND_END infrastructure.

## Test plan
- [x] maxInterest increases by 100 on GAME_START
- [x] Interest of $6 earned with $30 (beyond normal $5 cap)
- [x] Interest of $10 earned with $50
- [x] maxInterest reverts to 5 when joker is sold
- [x] All 1000 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)