### PR TITLE
Implement Rocket uncommon joker (#771)

### DIFF
--- a/src/app/daily-card-game/domain/game/__tests__/rocket.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/rocket.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest'
+
+import { defaultGameState } from '@/app/daily-card-game/domain/game/default-game-state'
+import { reduceGame } from '@/app/daily-card-game/domain/game/reduce-game'
+import type { GameState } from '@/app/daily-card-game/domain/game/types'
+import { jokers } from '@/app/daily-card-game/domain/joker/jokers'
+import { initializeJoker } from '@/app/daily-card-game/domain/joker/utils'
+
+describe('Rocket joker', () => {
+  function createGameWithRocket(): GameState {
+    const game: GameState = structuredClone(defaultGameState)
+    game.jokers = [initializeJoker(jokers.rocketJoker, game)]
+    return game
+  }
+
+  it('initializes payout to 1 on GAME_START', () => {
+    const game = createGameWithRocket()
+    const started = reduceGame(game, { type: 'GAME_START' })
+    const rk = started.jokers.find(j => j.jokerId === 'rocketJoker')
+    expect(rk?.metadata?.payout).toBe(1)
+  })
+
+  it('pays out $1 on ROUND_END', () => {
+    const game = createGameWithRocket()
+    const started = reduceGame(game, { type: 'GAME_START' })
+    const initialMoney = started.money
+
+    const afterRound = reduceGame(started, { type: 'ROUND_END' })
+    expect(afterRound.money).toBe(initialMoney + 1)
+  })
+
+  it('increases payout by $2 when boss blind is completed', () => {
+    const game = createGameWithRocket()
+    const started = reduceGame(game, { type: 'GAME_START' })
+
+    // Simulate boss blind completed
+    const withBossCompleted: GameState = {
+      ...started,
+      rounds: started.rounds.map((round, i) =>
+        i === started.roundIndex
+          ? { ...round, bossBlind: { ...round.bossBlind, status: 'completed' as const } }
+          : round
+      ),
+    }
+
+    const afterRound = reduceGame(withBossCompleted, { type: 'ROUND_END' })
+    const rk = afterRound.jokers.find(j => j.jokerId === 'rocketJoker')
+    expect(rk?.metadata?.payout).toBe(3) // 1 + 2
+  })
+
+  it('does not increase payout on non-boss blind rounds', () => {
+    const game = createGameWithRocket()
+    const started = reduceGame(game, { type: 'GAME_START' })
+
+    // Boss blind is notStarted (default)
+    const afterRound = reduceGame(started, { type: 'ROUND_END' })
+    const rk = afterRound.jokers.find(j => j.jokerId === 'rocketJoker')
+    expect(rk?.metadata?.payout).toBe(1) // unchanged
+  })
+})

--- a/src/app/daily-card-game/domain/joker/jokers.ts
+++ b/src/app/daily-card-game/domain/joker/jokers.ts
@@ -598,6 +598,58 @@ export const toTheMoonJoker: JokerDefinition = {
   rarity: 'uncommon',
 }
 
+export const rocketJoker: JokerDefinition = {
+  id: 'rocketJoker',
+  name: 'Rocket',
+  description: 'Earn $1 at end of round. Payout increases by $2 when Boss Blind is defeated',
+  price: 6,
+  effects: [
+    {
+      event: { type: 'GAME_START' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        const rk = ctx.game.jokers.find(j => j.jokerId === 'rocketJoker')
+        if (rk) {
+          rk.metadata = { ...rk.metadata, payout: rk.metadata?.payout ?? 1, lastBossRound: -1 }
+        }
+      },
+    },
+    {
+      event: { type: 'JOKER_ADDED' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        const rk = ctx.game.jokers.find(j => j.jokerId === 'rocketJoker')
+        if (rk) {
+          rk.metadata = { ...rk.metadata, payout: 1, lastBossRound: -1 }
+        }
+      },
+    },
+    {
+      event: { type: 'ROUND_END' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        const rk = ctx.game.jokers.find(j => j.jokerId === 'rocketJoker')
+        if (!rk || !rk.metadata) return
+
+        // Pay out current amount
+        ctx.game.money += rk.metadata.payout
+
+        // Check if boss blind was defeated this round
+        const round = ctx.game.rounds[ctx.game.roundIndex]
+        if (
+          round &&
+          round.bossBlind.status === 'completed' &&
+          rk.metadata.lastBossRound !== ctx.game.roundIndex
+        ) {
+          rk.metadata.payout += 2
+          rk.metadata.lastBossRound = ctx.game.roundIndex
+        }
+      },
+    },
+  ],
+  rarity: 'uncommon',
+}
+
 export const jokers: Record<JokerDefinition['id'], JokerDefinition> = {
   jokerJoker,
   greedyJoker,
@@ -616,6 +668,7 @@ export const jokers: Record<JokerDefinition['id'], JokerDefinition> = {
   fourFingersJoker,
   turtleBeanJoker,
   toTheMoonJoker,
+  rocketJoker,
 }
 
 /***


### PR DESCRIPTION
## Summary
- Adds **Rocket** uncommon joker: earns $1 at end of round, payout increases by $2 when Boss Blind is defeated
- Uses `metadata.payout` to track current payout amount (starts at 1)
- Uses `metadata.lastBossRound` to prevent double-counting boss blind bonuses

Closes #771

## Test plan
- [x] Initializes payout to $1 on GAME_START
- [x] Pays out correct amount on ROUND_END
- [x] Increases payout by $2 when boss blind is completed
- [x] Does not increase payout on non-boss blind rounds
- [x] All 1004 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)