### PR TITLE
fix: generation 204s — looser reviewer, more retries, better logs

### DIFF
--- a/src/app/api/v1/trivia/infinite/next/route.ts
+++ b/src/app/api/v1/trivia/infinite/next/route.ts
@@ -75,7 +75,14 @@ export async function GET(request: NextRequest) {
           avgTimeMs: null,
         }
       } catch (genErr) {
-        console.error('On-demand question generation failed:', genErr)
+        console.error('[trivia/infinite/next] generation failed', {
+          uid: auth.claims.uid,
+          streak: parsedStreak,
+          requestedCategoryIds: categoryIds,
+          rateRemaining: remaining,
+          error: genErr instanceof Error ? genErr.message : String(genErr),
+          stack: genErr instanceof Error ? genErr.stack : undefined,
+        })
         await trackExhaustion(auth.claims.uid)
         return new NextResponse(null, { status: 204 })
       }

--- a/src/lib/trivia/generateQuestion.ts
+++ b/src/lib/trivia/generateQuestion.ts
@@ -31,7 +31,7 @@ export interface GenerateInfiniteQuestionOptions {
 const QUESTION_MODEL = 'gpt-4o-mini'
 const REVIEW_MODEL = 'gpt-4o-mini'
 const FACTS_PER_FETCH = 5
-const MAX_GENERATION_ATTEMPTS = 2
+const MAX_GENERATION_ATTEMPTS = 3
 
 const DIFFICULTY_GUIDANCE: Record<'easy' | 'medium' | 'hard', string> = {
   easy: 'Should be approachable — a well-known fact that many people could answer correctly.',
@@ -218,8 +218,13 @@ If you reject, give a one-sentence rejection_reason. Otherwise rejection_reason 
     maxTokens: 150,
   })
 
+  // Trust the LLM's overall accept signal. We previously also required
+  // inferred_category === draft.categoryName exactly, but that produced
+  // false rejections for near-matches ("Pop Music" vs "Music") and the
+  // construction prompt already enforces category fidelity upstream.
+  // Keep inferred_category in the return for telemetry.
   return {
-    accept: result.object.accept && result.object.inferred_category === draft.categoryName,
+    accept: result.object.accept,
     reason: result.object.rejection_reason,
     inferred_category: result.object.inferred_category,
   }
@@ -297,6 +302,15 @@ export async function generateInfiniteQuestion(
 
     if (review.accept) {
       const id = `ai-infinite-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`
+      console.info('[generateInfiniteQuestion] generated', {
+        id,
+        category: categoryName,
+        difficulty,
+        attempt,
+        factSource: factSource.id,
+        factSourceCitation: fact.source,
+        inferredCategory: review.inferred_category,
+      })
       return {
         id,
         question: draft.question,


### PR DESCRIPTION
## Summary
Player hits `/api/v1/trivia/infinite/next?streak=0` and gets `204 No Content`. That happens when:
1. The sampler returned null (their seenQuestions covers all 250 active questions), AND
2. The on-demand generation pipeline threw.

This PR doesn't fix root cause #1 (active player just played a lot), but it makes generation more resilient so we don't fall through to 204 unnecessarily.

### What changed

**1. Reviewer was too strict on category equality**
PR #983's reviewer required `review.inferred_category === draft.categoryName` exactly. The LLM frequently returns near-matches like `"Pop Music"` instead of `"Music"`, causing false rejections. The construction prompt already pushes the question to stay in category, so the reviewer's redundant check was producing ~no signal beyond noise. Now we trust the reviewer's overall `accept` boolean and keep `inferred_category` for telemetry only.

**2. Bumped retries 2 → 3**
Fact extraction occasionally returns zero usable facts when the seed×modifier combo is chaotic (`@#$&(*!)`, `weird`, etc.). One more attempt costs little — worst case is six gpt-4o-mini calls per request, still cheaper than the original single gpt-4o call.

**3. Structured logging on failure and success**
- 204 path now logs `{ uid, streak, requestedCategoryIds, rateRemaining, error message, stack }` so you can see *why* generation failed by checking server logs instead of guessing.
- Successful generations log one info line with attempt count + fact source — tuning data for later.

## What this doesn't fix
If a player has genuinely seen all 250 active questions, the only path is generation. If generation hits the per-uid rate limit (100/hour) or genuinely fails, they'll still see 204. The new logs make it diagnosable.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run` — all tests pass
- [x] `npx eslint` clean
- [ ] **Real fix:** after deploy, watch server logs for `[generateInfiniteQuestion] draft rejected` vs `generated` ratio — should improve
- [ ] If 204s persist, the structured logs will tell us whether it's rate-limit, factSource throwing, construction throwing, or genuine quality-gate exhaustion

🤖 Generated with [Claude Code](https://claude.com/claude-code)