### PR TITLE
fix: stronger uniqueness prompts to reduce reviewer rejections

### DIFF
--- a/src/lib/trivia/factSources/llmFactSource.ts
+++ b/src/lib/trivia/factSources/llmFactSource.ts
@@ -61,15 +61,26 @@ ${seedLine}Difficulty: ${difficulty.toUpperCase()}. ${DIFFICULTY_GUIDANCE[diffic
 
 Each fact must:
 - Be specifically about the category "${category}" — not adjacent topics.
-- State ONE specific, verifiable claim.
-- Have a single concrete keyDetail (a name, date, number, place, or 1-3 word phrase) that uniquely identifies the answer.
+- State ONE specific, verifiable claim about ONE specific subject (a particular person, work, event, place, or thing — not a category of things).
+- Have a single concrete keyDetail (a name, date, number, place, or 1-3 word phrase) that is the UNIQUE answer to a question about this fact. If multiple things could plausibly be the answer (e.g. "a tennis player who won many Grand Slams" — there are several), the fact is too vague; pick a more specific subject.
 - Have the keyDetail appear verbatim inside the claim sentence.
 - Reach for surprising or deep-cut angles rather than obvious common knowledge.
 - Be true. If you are uncertain, replace the fact with one you are confident about.
 
+Examples of good vs bad facts:
+
+GOOD: claim="Serena Williams won her 23rd and final Grand Slam singles title at the 2017 Australian Open." keyDetail="2017 Australian Open"
+  → unique because there's only one 23rd-Grand-Slam-win event for her.
+
+BAD: claim="Serena Williams is a tennis player who has won many Grand Slam titles." keyDetail="Serena Williams"
+  → degenerate; the keyDetail is named in the claim and the fact gives no specific answer.
+
+BAD: claim="The Basenji is known as the 'barkless dog'." keyDetail="Basenji"
+  → other quiet breeds could plausibly be called "barkless" too. Pick a more specific framing.
+
 Avoid duplicates: each of the ${count} facts should be about a different subject.`,
       temperature: 0.7,
-      maxTokens: 800,
+      maxTokens: 1000,
     })
 
     return result.object.facts.map((f) => ({

--- a/src/lib/trivia/generateQuestion.ts
+++ b/src/lib/trivia/generateQuestion.ts
@@ -153,12 +153,25 @@ Category: ${ctx.categoryName}
 Difficulty: ${ctx.difficulty.toUpperCase()}. ${DIFFICULTY_GUIDANCE[ctx.difficulty]}
 
 Rules:
+- The question MUST have ONE unambiguous correct answer. If a knowledgeable person could plausibly give a different answer than the keyDetail, you must add identifying details to the question that rule out the alternatives. Do not write a question whose answer is "any X that fits Y" when many X fit Y.
 - The question must ask specifically for the keyDetail.
 - The question must NOT contain the keyDetail or a synonym/translation of it.
-- The correct_answer should equal the keyDetail or an equivalent variant (e.g. "1986" if the keyDetail is "February 21, 1986" and the question asks for the year).
+- The correct_answer must equal the keyDetail or a clear variant (e.g. "1986" if the keyDetail is "February 21, 1986" and the question asks for the year).
 - The explanation may elaborate beyond the fact (2-3 sentences).
 - Stay in the "${ctx.categoryName}" category. Do not drift.
-- Free-text answer; this is NOT a multiple-choice question.`,
+- Free-text answer; this is NOT a multiple-choice question.
+
+Examples:
+
+GOOD: fact="Serena Williams won her 23rd and final Grand Slam singles title at the 2017 Australian Open." keyDetail="2017 Australian Open"
+  Question: "At which Grand Slam tournament did Serena Williams win her 23rd and final singles title?"
+  → unambiguous because the question pins it to her specific 23rd title.
+
+BAD: same fact, keyDetail="2017 Australian Open"
+  Question: "At which Grand Slam did Serena Williams win a major title?"
+  → ambiguous; she won several. The question must specify "her 23rd / final" to rule out alternatives.
+
+If you cannot construct a question with one unambiguous answer from this fact, output the best-effort question you can — the reviewer will reject ambiguous questions and we will retry with a different fact.`,
     temperature: 0.5,
     maxTokens: 400,
   })


### PR DESCRIPTION
## Summary
Production logs after PR #993 confirmed the 204 root cause:

```
[generateInfiniteQuestion] draft rejected
  reason: 'multiple equally-valid answers, as it could refer to any female tennis player with significant Grand Slam titles.'
  reason: "multiple equally-valid answers, as other breeds could also be considered 'barkless'."
```

The reviewer is doing its job — those rejections are *correct*. The problem is upstream: fact extraction and question construction were producing facts/questions whose answers aren't actually unique. This PR strengthens both prompts to enforce uniqueness at the source.

### Fact extraction (`LLMFactSource`)
Added concrete good/bad examples directly in the prompt:

```
GOOD: claim="Serena Williams won her 23rd and final Grand Slam singles title at the 2017 Australian Open." keyDetail="2017 Australian Open"
  → unique because there's only one 23rd-Grand-Slam-win event.

BAD: claim="The Basenji is known as the 'barkless dog'." keyDetail="Basenji"
  → other quiet breeds could plausibly be called "barkless" too.
```

Plus rewrote the rules to require ONE specific subject (a particular person/event/work, not "a category of things").

### Question construction
The construction prompt now explicitly tells the model to *add identifying details to rule out alternatives* when needed:

```
Question: "At which Grand Slam tournament did Serena Williams win her 23rd and final singles title?"
  → unambiguous because the question pins it to her specific 23rd title.

vs.

BAD: "At which Grand Slam did Serena Williams win a major title?"
  → ambiguous; she won several.
```

If the model can't write a unique question from a given fact, it does its best and we let the reviewer reject + retry — same retry loop as before, just with much higher first-attempt success rate.

## Why this should work
The reviewer was already catching these — the 3-attempt retry loop from #993 already gives us slack. This change moves the work upstream where it should be, reducing wasted LLM calls. Expected result: fewer 204s, lower per-question cost, faster generation.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run` — all tests pass
- [x] `npx eslint` clean
- [ ] After deploy, watch `[generateInfiniteQuestion] draft rejected` log frequency — should drop noticeably
- [ ] Watch `generated` info log to confirm successful first-attempt rate climbs

🤖 Generated with [Claude Code](https://claude.com/claude-code)