### PR TITLE
Implement Cloud 9 uncommon joker (#780)

### DIFF
--- a/src/app/daily-card-game/domain/game/__tests__/cloud-9.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/cloud-9.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest'
+
+import { defaultGameState } from '@/app/daily-card-game/domain/game/default-game-state'
+import { reduceGame } from '@/app/daily-card-game/domain/game/reduce-game'
+import type { GameState } from '@/app/daily-card-game/domain/game/types'
+import { jokers } from '@/app/daily-card-game/domain/joker/jokers'
+import { initializeJoker } from '@/app/daily-card-game/domain/joker/utils'
+import { playingCards } from '@/app/daily-card-game/domain/playing-card/playing-cards'
+
+describe('Cloud 9 joker', () => {
+  it('earns $1 per 9 in deck at ROUND_END', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.jokers = [initializeJoker(jokers.cloud9Joker, game)]
+    const started = reduceGame(game, { type: 'GAME_START' })
+
+    // Count 9s in the default deck
+    const nineCount = started.ownedCardIds.filter(id => {
+      const card = started.cards[id]
+      return card && playingCards[card.playingCardId]?.value === '9'
+    }).length
+
+    expect(nineCount).toBe(4) // standard deck has 4 nines
+
+    const initialMoney = started.money
+    const afterRound = reduceGame(started, { type: 'ROUND_END' })
+    expect(afterRound.money).toBe(initialMoney + 4)
+  })
+
+  it('earns nothing if no 9s in deck', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.jokers = [initializeJoker(jokers.cloud9Joker, game)]
+    const started = reduceGame(game, { type: 'GAME_START' })
+
+    // Remove all 9s from owned cards
+    const nineIds = started.ownedCardIds.filter(id => {
+      const card = started.cards[id]
+      return card && playingCards[card.playingCardId]?.value === '9'
+    })
+
+    const noNines: GameState = {
+      ...started,
+      ownedCardIds: started.ownedCardIds.filter(id => !nineIds.includes(id)),
+    }
+
+    const initialMoney = noNines.money
+    const afterRound = reduceGame(noNines, { type: 'ROUND_END' })
+    expect(afterRound.money).toBe(initialMoney)
+  })
+})

--- a/src/app/daily-card-game/domain/joker/jokers.ts
+++ b/src/app/daily-card-game/domain/joker/jokers.ts
@@ -679,6 +679,34 @@ export const midasMaskJoker: JokerDefinition = {
   rarity: 'uncommon',
 }
 
+export const cloud9Joker: JokerDefinition = {
+  id: 'cloud9Joker',
+  name: 'Cloud 9',
+  description: 'Earn $1 for each 9 in your full deck at end of round',
+  price: 7,
+  effects: [
+    {
+      event: { type: 'ROUND_END' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        let nineCount = 0
+        for (const cardId of ctx.game.ownedCardIds) {
+          const cardState = ctx.game.cards[cardId]
+          if (!cardState) continue
+          const cardDef = playingCards[cardState.playingCardId]
+          if (cardDef && cardDef.value === '9') {
+            nineCount++
+          }
+        }
+        if (nineCount > 0) {
+          ctx.game.money += nineCount
+        }
+      },
+    },
+  ],
+  rarity: 'uncommon',
+}
+
 export const jokers: Record<JokerDefinition['id'], JokerDefinition> = {
   jokerJoker,
   greedyJoker,
@@ -699,6 +727,7 @@ export const jokers: Record<JokerDefinition['id'], JokerDefinition> = {
   toTheMoonJoker,
   rocketJoker,
   midasMaskJoker,
+  cloud9Joker,
 }
 
 /***


### PR DESCRIPTION
## Summary
- Adds **Cloud 9** uncommon joker: earns $1 for each 9 in the player's full deck at end of round
- Standard deck has 4 nines = $4/round base income

Closes #780

## Test plan
- [x] Earns $4 with standard deck (4 nines)
- [x] Earns $0 when no 9s remain in deck
- [x] All 1008 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)