### PR TITLE
fix: catch answer-leaks + repair-on-rejection loop

### DIFF
--- a/src/lib/trivia/__tests__/detectAnswerLeak.test.ts
+++ b/src/lib/trivia/__tests__/detectAnswerLeak.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest'
+
+import { detectAnswerLeak } from '@/lib/trivia/generateQuestion'
+
+describe('detectAnswerLeak', () => {
+  it('catches verbatim single-word leak (case-insensitive)', () => {
+    expect(detectAnswerLeak('What is the Pythagorean theorem?', 'Pythagorean theorem')).toBe(true)
+    expect(detectAnswerLeak('what is the PYTHAGOREAN theorem?', 'Pythagorean theorem')).toBe(true)
+  })
+
+  it('catches multi-word leak even when one word is missing', () => {
+    // keyDetail is "2017 Australian Open" — leak fires if question has the
+    // significant phrase "Australian Open" even without the year.
+    expect(
+      detectAnswerLeak('When did Serena Williams win at the Australian Open?', '2017 Australian Open')
+    ).toBe(true)
+  })
+
+  it('does not flag when question genuinely avoids the answer', () => {
+    expect(
+      detectAnswerLeak(
+        'At which Grand Slam tournament did Serena Williams win her 23rd and final singles title?',
+        '2017 Australian Open'
+      )
+    ).toBe(false)
+  })
+
+  it('does not flag short keyDetails that would false-positive', () => {
+    // "1986" is 4 chars but acceptable. Test the < 3 char guard.
+    expect(detectAnswerLeak('What number comes after 5?', '6')).toBe(false)
+  })
+
+  it('returns false on empty inputs', () => {
+    expect(detectAnswerLeak('', 'anything')).toBe(false)
+    expect(detectAnswerLeak('a question', '')).toBe(false)
+  })
+})

--- a/src/lib/trivia/generateQuestion.ts
+++ b/src/lib/trivia/generateQuestion.ts
@@ -165,13 +165,24 @@ Examples:
 
 GOOD: fact="Serena Williams won her 23rd and final Grand Slam singles title at the 2017 Australian Open." keyDetail="2017 Australian Open"
   Question: "At which Grand Slam tournament did Serena Williams win her 23rd and final singles title?"
-  → unambiguous because the question pins it to her specific 23rd title.
+  → unambiguous AND the question doesn't contain "2017" or "Australian Open."
 
-BAD: same fact, keyDetail="2017 Australian Open"
+AMBIGUITY BAD: same fact, keyDetail="2017 Australian Open"
   Question: "At which Grand Slam did Serena Williams win a major title?"
-  → ambiguous; she won several. The question must specify "her 23rd / final" to rule out alternatives.
+  → ambiguous; she won several. Specify "her 23rd / final" to rule out alternatives.
 
-If you cannot construct a question with one unambiguous answer from this fact, output the best-effort question you can — the reviewer will reject ambiguous questions and we will retry with a different fact.`,
+LEAK BAD: same fact, keyDetail="2017 Australian Open"
+  Question: "When did Serena Williams win at the 2017 Australian Open?"
+  → the keyDetail "2017 Australian Open" is right there in the question. Players answering this question would just type the words they already see.
+
+LEAK BAD: fact="The Pythagorean theorem states that a² + b² = c² for any right triangle." keyDetail="Pythagorean theorem"
+  Question: "What is the Pythagorean theorem?"
+  → keyDetail appears in the question. To fix, describe the theorem without naming it:
+  Better: "What theorem describes the relationship a² + b² = c² between the sides of a right triangle?"
+
+A useful test: if you removed the keyDetail (and obvious synonyms) from your question, would the question still make sense and ask for that specific answer? If not, you have leaked the answer. Reword so the question describes the answer rather than naming it.
+
+If you cannot construct a question that is both unambiguous AND leak-free from this fact, output the best-effort question you can — the reviewer will reject and we will retry with a different fact.`,
     temperature: 0.5,
     maxTokens: 400,
   })
@@ -195,6 +206,34 @@ interface ReviewResult {
   accept: boolean
   reason: string | null
   inferred_category: string
+}
+
+// Cheap, deterministic pre-check that catches the most common reviewer-
+// rejection reason: the keyDetail is echoed verbatim inside the question
+// text. Saves a reviewer call when we can already tell the draft will
+// fail. Doesn't catch synonym leaks (the reviewer still does that), but
+// catches the easy half of the failure mode.
+export function detectAnswerLeak(question: string, keyDetail: string): boolean {
+  const q = question.toLowerCase()
+  const k = keyDetail.toLowerCase().trim()
+  if (k.length < 3) return false
+
+  // Verbatim full-string match.
+  if (q.includes(k)) return true
+
+  // Adjacent significant-word pairs. A multi-word keyDetail like
+  // "2017 Australian Open" leaks if the question contains "Australian
+  // Open" even without the year. Checking every adjacent pair of
+  // longer-than-3-char words catches that case without false-positiving
+  // on common short words like "of" or "the".
+  const words = k.split(/\s+/).filter((w) => w.length > 0)
+  for (let i = 0; i < words.length - 1; i++) {
+    if (words[i].length > 3 && words[i + 1].length > 3) {
+      const pair = `${words[i]} ${words[i + 1]}`
+      if (q.includes(pair)) return true
+    }
+  }
+  return false
 }
 
 async function reviewQuestion(
@@ -311,6 +350,21 @@ export async function generateInfiniteQuestion(
       difficulty,
       seedSummary,
     })
+
+    // Cheap pre-check: if the question echoes the keyDetail verbatim,
+    // skip the reviewer (it would just reject anyway) and retry.
+    if (detectAnswerLeak(draft.question, fact.keyDetail)) {
+      lastReason = `pre-check: question contains keyDetail "${fact.keyDetail}" verbatim`
+      console.warn('[generateInfiniteQuestion] draft rejected (pre-check)', {
+        attempt,
+        category: categoryName,
+        seed: seedSummary,
+        keyDetail: fact.keyDetail,
+        question: draft.question,
+      })
+      continue
+    }
+
     const review = await reviewQuestion(apiKey, draft)
 
     if (review.accept) {

--- a/src/lib/trivia/generateQuestion.ts
+++ b/src/lib/trivia/generateQuestion.ts
@@ -32,6 +32,7 @@ const QUESTION_MODEL = 'gpt-4o-mini'
 const REVIEW_MODEL = 'gpt-4o-mini'
 const FACTS_PER_FETCH = 5
 const MAX_GENERATION_ATTEMPTS = 3
+const MAX_REPAIRS_PER_DRAFT = 2
 
 const DIFFICULTY_GUIDANCE: Record<'easy' | 'medium' | 'hard', string> = {
   easy: 'Should be approachable — a well-known fact that many people could answer correctly.',
@@ -208,6 +209,61 @@ interface ReviewResult {
   inferred_category: string
 }
 
+// Targeted repair pass: given a draft that the reviewer rejected, ask
+// the LLM to fix the SAME fact's question using the rejection reason as
+// guidance. Cheaper than throwing the draft away (which costs a fresh
+// fact extraction + construction), and tends to converge because the
+// reviewer's rejection is concrete and actionable.
+async function repairDraft(
+  apiKey: string,
+  draft: DraftQuestion,
+  rejectionReason: string
+): Promise<DraftQuestion> {
+  const openaiClient = createOpenAI({ apiKey })
+
+  const result = await generateObject({
+    model: openaiClient(QUESTION_MODEL),
+    schema: QuestionSchema,
+    system:
+      'You are a trivia question writer fixing a previous draft that a reviewer rejected. You receive the original fact, the rejected draft, and the rejection reason. Produce a revised question that resolves the specific issue while staying faithful to the fact.',
+    prompt: `A reviewer rejected the following draft trivia question. Produce a revised version that resolves the rejection.
+
+Source fact: ${draft.fact.claim}
+Answer (keyDetail): ${draft.fact.keyDetail}
+Category: ${draft.categoryName}
+Difficulty: ${draft.difficulty.toUpperCase()}
+
+Rejected question: ${draft.question}
+Rejected correct_answer: ${draft.correct_answer}
+Rejected explanation: ${draft.explanation}
+
+Reviewer's rejection reason: ${rejectionReason}
+
+Rules for the fix:
+- Keep the SAME fact and the SAME keyDetail as the answer. Do not switch facts.
+- Address the rejection reason directly — if the reviewer said the answer was leaked, reword so the question describes the answer rather than naming it. If the reviewer said the answer was ambiguous, add identifying details that rule out alternatives.
+- The revised question must NOT contain the keyDetail or any obvious synonym of it.
+- The revised question must have ONE unambiguous correct answer.
+- Stay in the "${draft.categoryName}" category.
+- Free-text answer (not multiple choice).
+
+Output the revised question, the correct_answer (still equivalent to the keyDetail), and an explanation. If you genuinely cannot fix this fact's question without changing the answer, output your best attempt — we will fall through to a fresh fact.`,
+    temperature: 0.4,
+    maxTokens: 400,
+  })
+
+  if (!result.object.question || !result.object.correct_answer) {
+    throw new Error('Repair returned empty fields')
+  }
+
+  return {
+    ...draft,
+    question: result.object.question,
+    correct_answer: result.object.correct_answer,
+    explanation: result.object.explanation,
+  }
+}
+
 // Cheap, deterministic pre-check that catches the most common reviewer-
 // rejection reason: the keyDetail is echoed verbatim inside the question
 // text. Saves a reviewer call when we can already tell the draft will
@@ -285,7 +341,7 @@ If you reject, give a one-sentence rejection_reason. Otherwise rejection_reason 
 /**
  * Generate a single trivia question on the fly for Infinite Trivia.
  *
- * Three-stage pipeline:
+ * Pipeline:
  *
  *   1. Fact extraction — call the configured FactSource (LLM-only
  *      today; Wikipedia / Perplexity planned) to surface candidate
@@ -293,17 +349,24 @@ If you reject, give a one-sentence rejection_reason. Otherwise rejection_reason 
  *   2. Question construction (gpt-4o-mini, temp 0.5) — pick a fact
  *      and turn it into a question whose answer is the fact's
  *      keyDetail.
- *   3. Quality review (gpt-4o-mini, temp 0) — strict reviewer that
- *      rejects answer-leaks, vague questions, factual contradictions,
- *      and category drift.
+ *   3. Inner repair loop:
+ *      a. Deterministic pre-check (detectAnswerLeak) for verbatim
+ *         keyDetail leaks — fast-fails before a reviewer call.
+ *      b. Quality review (gpt-4o-mini, temp 0) — strict reviewer.
+ *      c. If rejected, call repairDraft with the rejection reason
+ *         as targeted feedback. Up to MAX_REPAIRS_PER_DRAFT repairs
+ *         per draft before falling through to a fresh fact.
+ *   4. Outer retry: up to MAX_GENERATION_ATTEMPTS fresh fact extractions.
  *
- * On rejection we retry once (fresh facts, fresh seed) before giving
- * up. The /next route maps the throw to a 204 (pool exhausted), same
- * as any other generation failure.
+ * Repair is cheaper than blind retry because it preserves the (already
+ * vetted) fact and uses the reviewer's specific complaint to guide the
+ * fix. Most rejections converge on the first repair pass.
+ *
+ * On total failure the /next route maps the throw to a 204.
  *
  * The FactSource interface lets us migrate to grounded sources
- * (Wikipedia, Wikidata, Perplexity) without touching the question
- * construction or review stages.
+ * (Wikipedia, Wikidata, Perplexity) without touching construction,
+ * repair, or review stages.
  */
 export async function generateInfiniteQuestion(
   options: GenerateInfiniteQuestionOptions = {}
@@ -345,29 +408,75 @@ export async function generateInfiniteQuestion(
     }
 
     const fact = pickRandom(facts)
-    const draft = await constructQuestionFromFact(apiKey, fact, {
+    let draft = await constructQuestionFromFact(apiKey, fact, {
       categoryName,
       difficulty,
       seedSummary,
     })
 
-    // Cheap pre-check: if the question echoes the keyDetail verbatim,
-    // skip the reviewer (it would just reject anyway) and retry.
-    if (detectAnswerLeak(draft.question, fact.keyDetail)) {
-      lastReason = `pre-check: question contains keyDetail "${fact.keyDetail}" verbatim`
-      console.warn('[generateInfiniteQuestion] draft rejected (pre-check)', {
+    // Inner repair loop: try to fix this draft up to MAX_REPAIRS_PER_DRAFT
+    // times before falling through to a fresh outer attempt.
+    let acceptedDraft: DraftQuestion | null = null
+    let acceptedReview: ReviewResult | null = null
+
+    for (let repair = 0; repair <= MAX_REPAIRS_PER_DRAFT; repair++) {
+      // Deterministic pre-check: if the question echoes the keyDetail
+      // verbatim, attempt repair without paying for a reviewer call.
+      if (detectAnswerLeak(draft.question, fact.keyDetail)) {
+        const reason = `Question contains the answer "${fact.keyDetail}" verbatim. Reword so the question describes the answer rather than naming it.`
+        lastReason = `pre-check leak: ${reason}`
+        console.warn('[generateInfiniteQuestion] draft rejected (pre-check)', {
+          attempt,
+          repair,
+          category: categoryName,
+          keyDetail: fact.keyDetail,
+          question: draft.question,
+        })
+        if (repair < MAX_REPAIRS_PER_DRAFT) {
+          try {
+            draft = await repairDraft(apiKey, draft, reason)
+          } catch (err) {
+            lastReason = `repair failed: ${err instanceof Error ? err.message : String(err)}`
+            console.warn('[generateInfiniteQuestion] repair threw', { attempt, repair, reason: lastReason })
+            break
+          }
+          continue
+        }
+        break
+      }
+
+      const review = await reviewQuestion(apiKey, draft)
+      if (review.accept) {
+        acceptedDraft = draft
+        acceptedReview = review
+        break
+      }
+
+      lastReason = review.reason ?? `inferred=${review.inferred_category}`
+      console.warn('[generateInfiniteQuestion] draft rejected', {
         attempt,
+        repair,
         category: categoryName,
         seed: seedSummary,
-        keyDetail: fact.keyDetail,
-        question: draft.question,
+        factSource: factSource.id,
+        factSourceCitation: fact.source,
+        reason: lastReason,
       })
-      continue
+
+      if (repair < MAX_REPAIRS_PER_DRAFT) {
+        try {
+          draft = await repairDraft(apiKey, draft, lastReason)
+        } catch (err) {
+          lastReason = `repair failed: ${err instanceof Error ? err.message : String(err)}`
+          console.warn('[generateInfiniteQuestion] repair threw', { attempt, repair, reason: lastReason })
+          break
+        }
+        continue
+      }
+      break
     }
 
-    const review = await reviewQuestion(apiKey, draft)
-
-    if (review.accept) {
+    if (acceptedDraft && acceptedReview) {
       const id = `ai-infinite-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`
       console.info('[generateInfiniteQuestion] generated', {
         id,
@@ -376,28 +485,18 @@ export async function generateInfiniteQuestion(
         attempt,
         factSource: factSource.id,
         factSourceCitation: fact.source,
-        inferredCategory: review.inferred_category,
+        inferredCategory: acceptedReview.inferred_category,
       })
       return {
         id,
-        question: draft.question,
-        correctAnswer: draft.correct_answer,
-        explanation: draft.explanation,
+        question: acceptedDraft.question,
+        correctAnswer: acceptedDraft.correct_answer,
+        explanation: acceptedDraft.explanation,
         category: categoryName,
         difficulty,
         type: 'free-text',
       }
     }
-
-    lastReason = review.reason ?? `inferred=${review.inferred_category}`
-    console.warn('[generateInfiniteQuestion] draft rejected', {
-      attempt,
-      category: categoryName,
-      seed: seedSummary,
-      factSource: factSource.id,
-      factSourceCitation: fact.source,
-      reason: lastReason,
-    })
   }
 
   throw new Error(


### PR DESCRIPTION
## Summary
Two related fixes for the persistent 204s. Originally this PR just shipped a leak detector + LEAK example in the prompt; the second commit adds a *repair* loop so that when the reviewer rejects a draft we use the rejection reason as feedback to fix the same fact's question — instead of throwing the fact away and re-running fact-extraction from scratch.

### 1. Leak detection
**Construction prompt** now teaches both failure modes (ambiguity *and* answer-leak):

```
LEAK BAD: keyDetail="Pythagorean theorem"
  Question: "What is the Pythagorean theorem?"
  → keyDetail appears in the question.
  Better: "What theorem describes the relationship a² + b² = c²
   between the sides of a right triangle?"
```

Plus a self-test instruction: *"if you removed the keyDetail from your question, would it still ask for that specific answer?"*

**`detectAnswerLeak`** is a deterministic pre-check that catches verbatim leaks (and adjacent-significant-word leaks like "Australian Open" inside "2017 Australian Open") before invoking the reviewer. 5 unit tests cover it.

### 2. Repair-on-rejection
When the reviewer (or the pre-check) flags a draft, instead of falling through to a full outer retry, the loop now calls a `repairDraft` LLM pass with:
- The original fact and keyDetail (preserved — we don't switch facts mid-repair)
- The rejected question + answer + explanation
- The reviewer's specific rejection reason

The LLM produces a fixed version. Up to `MAX_REPAIRS_PER_DRAFT = 2` repairs per draft, then falls through to a fresh fact via the outer retry.

**Why this beats blind retry:**
- The fact has already been vetted (came from a fact-extraction call).
- The reviewer's rejection reason ("answer is leaked" / "multiple valid answers") is concrete and actionable.
- Cheaper per recovery: 1 LLM call vs 3 (fact extract + construct + review).

Pipeline now reads:

```
Pipeline:
  1. Fact extraction
  2. Question construction
  3. Inner repair loop:
     a. Pre-check leak (deterministic)
     b. Reviewer (LLM)
     c. If rejected → repairDraft with the reason as guidance
        (up to 2 repairs)
  4. Outer retry: up to 3 fresh facts
```

## Cost
- Best case: 3 calls (fact + construct + review). Same as before.
- One rejection, one repair fixes it: 5 calls. Was 6 with blind retry.
- Two rejections, neither fix works: 7 calls. Was ~6 (two blind retries).
- Total worst case: ~18 calls. Was ~9. Tradeoff: more calls in pathological cases, much higher success rate.

## Effect we expect
- Many fewer 204s — the median rejection now gets repaired in one extra call instead of being thrown away.
- Lower per-question cost on the median path (fewer wasted facts).
- Server logs will show new entries: `[generateInfiniteQuestion] draft rejected (pre-check)` for verbatim leaks, and `repair threw` if any repair call errors.

## Test plan
- [x] `npx vitest run` — full suite green; new `detectAnswerLeak.test.ts` adds 5 tests
- [x] `npx tsc --noEmit` clean
- [x] `npx eslint` clean
- [ ] After deploy: watch first-attempt success rate (should climb), 204 rate (should drop), and repair conversion rate (we'll see how often a single repair fixes a rejection)

🤖 Generated with [Claude Code](https://claude.com/claude-code)