### PR TITLE
Implement Bull uncommon joker (#785)

### DIFF
--- a/src/app/daily-card-game/domain/game/__tests__/bull.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/bull.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest'
+
+import { defaultGameState } from '@/app/daily-card-game/domain/game/default-game-state'
+import { reduceGame } from '@/app/daily-card-game/domain/game/reduce-game'
+import type { GameState } from '@/app/daily-card-game/domain/game/types'
+import { jokers } from '@/app/daily-card-game/domain/joker/jokers'
+import { initializeJoker } from '@/app/daily-card-game/domain/joker/utils'
+
+describe('Bull joker', () => {
+  it('adds +2 Chips per $1 on HAND_SCORING_FINALIZE', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.jokers = [initializeJoker(jokers.bullJoker, game)]
+    game.money = 25
+
+    // Set up scoring state - need a blind in progress
+    game.rounds[game.roundIndex].smallBlind.status = 'inProgress'
+    game.gamePhase = 'gameplay'
+
+    const started = reduceGame(game, { type: 'GAME_START' })
+
+    // Trigger HAND_SCORING_FINALIZE
+    const withMoney: GameState = { ...started, money: 25 }
+    const afterScore = reduceGame(withMoney, { type: 'HAND_SCORING_FINALIZE' })
+
+    // Score is reset after HAND_SCORING_FINALIZE; verify via scoringEvents
+    expect(
+      afterScore.gamePlayState.scoringEvents.some(
+        e => 'source' in e && e.source === 'Bull' && e.value === 50
+      )
+    ).toBe(true)
+  })
+
+  it('adds 0 Chips when money is 0', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.jokers = [initializeJoker(jokers.bullJoker, game)]
+    game.money = 0
+    game.rounds[game.roundIndex].smallBlind.status = 'inProgress'
+    game.gamePhase = 'gameplay'
+
+    const started = reduceGame(game, { type: 'GAME_START' })
+    const withNoMoney: GameState = { ...started, money: 0 }
+    const afterScore = reduceGame(withNoMoney, { type: 'HAND_SCORING_FINALIZE' })
+
+    expect(afterScore.gamePlayState.score.chips).toBe(0)
+    expect(
+      afterScore.gamePlayState.scoringEvents.some(e => 'source' in e && e.source === 'Bull')
+    ).toBe(false)
+  })
+})

--- a/src/app/daily-card-game/domain/joker/jokers.ts
+++ b/src/app/daily-card-game/domain/joker/jokers.ts
@@ -729,6 +729,33 @@ export const cloud9Joker: JokerDefinition = {
   rarity: 'uncommon',
 }
 
+export const bullJoker: JokerDefinition = {
+  id: 'bullJoker',
+  name: 'Bull',
+  description: '+2 Chips for each $1 you have',
+  price: 6,
+  effects: [
+    {
+      event: { type: 'HAND_SCORING_FINALIZE' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        const money = Math.max(0, ctx.game.money)
+        const chipsBonus = 2 * money
+        if (chipsBonus > 0) {
+          ctx.game.gamePlayState.scoringEvents.push({
+            id: uuid(),
+            type: 'chips',
+            value: chipsBonus,
+            source: 'Bull',
+          })
+          ctx.game.gamePlayState.score.chips += chipsBonus
+        }
+      },
+    },
+  ],
+  rarity: 'uncommon',
+}
+
 export const jokers: Record<JokerDefinition['id'], JokerDefinition> = {
   jokerJoker,
   greedyJoker,
@@ -751,6 +778,7 @@ export const jokers: Record<JokerDefinition['id'], JokerDefinition> = {
   midasMaskJoker,
   dietColaJoker,
   cloud9Joker,
+  bullJoker,
 }
 
 /***


### PR DESCRIPTION
## Summary
- Adds **Bull** uncommon joker: +2 Chips for each $1 the player has
- Fires on HAND_SCORING_FINALIZE, using the same pattern as jokerJoker
- $25 money = +50 Chips, $50 = +100 Chips

Closes #785

## Test plan
- [x] Adds +50 chips when player has $25
- [x] Adds 0 chips when player has $0
- [x] All 1012 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)