### PR TITLE
fix: upgrade construction/repair to gpt-4o, log full questions

### DIFF
--- a/src/lib/trivia/generateQuestion.ts
+++ b/src/lib/trivia/generateQuestion.ts
@@ -28,7 +28,15 @@ export interface GenerateInfiniteQuestionOptions {
   factSource?: FactSource
 }
 
-const QUESTION_MODEL = 'gpt-4o-mini'
+// Question construction needs to satisfy multiple constraints at once
+// (specific, leak-free, category-bound). gpt-4o-mini was repeatedly
+// oscillating between the constraints — fixing a leak would introduce
+// ambiguity, repairing the ambiguity would re-introduce the leak. Use
+// the full gpt-4o for construction and repair where instruction-
+// following matters; keep mini for the cheaper fact extraction and
+// reviewer stages.
+const QUESTION_MODEL = 'gpt-4o'
+const REPAIR_MODEL = 'gpt-4o'
 const REVIEW_MODEL = 'gpt-4o-mini'
 const FACTS_PER_FETCH = 5
 const MAX_GENERATION_ATTEMPTS = 3
@@ -222,7 +230,7 @@ async function repairDraft(
   const openaiClient = createOpenAI({ apiKey })
 
   const result = await generateObject({
-    model: openaiClient(QUESTION_MODEL),
+    model: openaiClient(REPAIR_MODEL),
     schema: QuestionSchema,
     system:
       'You are a trivia question writer fixing a previous draft that a reviewer rejected. You receive the original fact, the rejected draft, and the rejection reason. Produce a revised question that resolves the specific issue while staying faithful to the fact.',
@@ -461,6 +469,8 @@ export async function generateInfiniteQuestion(
         factSource: factSource.id,
         factSourceCitation: fact.source,
         reason: lastReason,
+        keyDetail: fact.keyDetail,
+        question: draft.question,
       })
 
       if (repair < MAX_REPAIRS_PER_DRAFT) {


### PR DESCRIPTION
## Summary
The repair loop from #996 is *correctly* using rejection reasons as feedback, but the LLM is **oscillating between failure modes**:

```
attempt: 3, repair: 1, reason: 'multiple equally-valid answers'
attempt: 3, repair: 2, reason: 'answer is unambiguously stated in question'
```

`gpt-4o-mini` cannot hold both constraints at once. Fixing the leak introduces ambiguity; repairing the ambiguity re-introduces the leak.

## Fix
Upgrade construction + repair to `gpt-4o` (the original choice in PR #981 before the cost-driven swap). Stronger instruction following, much higher chance of producing a draft that's specific, leak-free, and category-bound on the first try.

Keep `gpt-4o-mini` for the cheaper stages where it's clearly competent:
- Fact extraction (just listing facts)
- Quality review (binary accept/reject classification)

## Cost
- Old: ~3 gpt-4o-mini calls (~$0.0009 success-path)
- New: 1 gpt-4o + ~2 gpt-4o-mini (~$0.006 success-path)

~7× more expensive per question, but should *drastically* reduce 204s and the wasted repair churn we're paying for now anyway. On the failure path the difference shrinks because we're already burning multiple LLM calls today.

If reliability lands and we want to optimize cost later, options are:
1. Try `gpt-4o-mini` again with even stronger prompting (chain-of-thought, etc.)
2. Try reasoning-tuned models if/when they become available in the SDK
3. Cache facts more aggressively so the per-question cost amortizes

## Also in this PR
Rejection logs now include the actual question text and keyDetail, so we can see *what* the LLM is producing on failure without needing to reproduce locally.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run` — full suite green
- [x] `npx eslint` clean
- [ ] After deploy: watch the rejection log for question text — gives concrete evidence of what failure modes still slip through. First-attempt acceptance rate should climb meaningfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)