### PR TITLE
Implement Bootstraps uncommon joker (#811)

### DIFF
--- a/src/app/daily-card-game/domain/game/__tests__/bootstraps.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/bootstraps.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest'
+
+import { defaultGameState } from '@/app/daily-card-game/domain/game/default-game-state'
+import { reduceGame } from '@/app/daily-card-game/domain/game/reduce-game'
+import type { GameState } from '@/app/daily-card-game/domain/game/types'
+import { jokers } from '@/app/daily-card-game/domain/joker/jokers'
+import { initializeJoker } from '@/app/daily-card-game/domain/joker/utils'
+
+describe('Bootstraps joker', () => {
+  it('adds +2 Mult per $5 on HAND_SCORING_FINALIZE', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.jokers = [initializeJoker(jokers.bootstrapsJoker, game)]
+    game.rounds[game.roundIndex].smallBlind.status = 'inProgress'
+    game.gamePhase = 'gameplay'
+
+    const started = reduceGame(game, { type: 'GAME_START' })
+    const withMoney: GameState = { ...started, money: 25 }
+    const afterScore = reduceGame(withMoney, { type: 'HAND_SCORING_FINALIZE' })
+
+    // $25 / $5 = 5, * 2 = +10 Mult
+    expect(afterScore.gamePlayState.scoringEvents.some(
+      e => 'source' in e && e.source === 'Bootstraps' && e.value === 10
+    )).toBe(true)
+  })
+
+  it('adds 0 Mult when money is less than $5', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.jokers = [initializeJoker(jokers.bootstrapsJoker, game)]
+    game.rounds[game.roundIndex].smallBlind.status = 'inProgress'
+    game.gamePhase = 'gameplay'
+
+    const started = reduceGame(game, { type: 'GAME_START' })
+    const withLowMoney: GameState = { ...started, money: 3 }
+    const afterScore = reduceGame(withLowMoney, { type: 'HAND_SCORING_FINALIZE' })
+
+    expect(afterScore.gamePlayState.scoringEvents.some(
+      e => 'source' in e && e.source === 'Bootstraps'
+    )).toBe(false)
+  })
+})

--- a/src/app/daily-card-game/domain/joker/jokers.ts
+++ b/src/app/daily-card-game/domain/joker/jokers.ts
@@ -756,6 +756,33 @@ export const bullJoker: JokerDefinition = {
   rarity: 'uncommon',
 }
 
+export const bootstrapsJoker: JokerDefinition = {
+  id: 'bootstrapsJoker',
+  name: 'Bootstraps',
+  description: '+2 Mult for every $5 you have',
+  price: 7,
+  effects: [
+    {
+      event: { type: 'HAND_SCORING_FINALIZE' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        const money = Math.max(0, ctx.game.money)
+        const multBonus = 2 * Math.floor(money / 5)
+        if (multBonus > 0) {
+          ctx.game.gamePlayState.scoringEvents.push({
+            id: uuid(),
+            type: 'mult',
+            value: multBonus,
+            source: 'Bootstraps',
+          })
+          ctx.game.gamePlayState.score.mult += multBonus
+        }
+      },
+    },
+  ],
+  rarity: 'uncommon',
+}
+
 export const jokers: Record<JokerDefinition['id'], JokerDefinition> = {
   jokerJoker,
   greedyJoker,
@@ -779,6 +806,7 @@ export const jokers: Record<JokerDefinition['id'], JokerDefinition> = {
   dietColaJoker,
   cloud9Joker,
   bullJoker,
+  bootstrapsJoker,
 }
 
 /***


### PR DESCRIPTION
## Summary
- Adds **Bootstraps** uncommon joker: +2 Mult for every $5 the player has
- Companion to Bull joker (Chips equivalent). $25 = +10 Mult, $50 = +20 Mult

Closes #811

## Test plan
- [x] Adds +10 Mult when player has $25
- [x] Adds 0 Mult when player has less than $5
- [x] All 1019 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)