### PR TITLE
fix: reviewer rejecting good descriptive questions as leaks

### DIFF
--- a/src/lib/trivia/factSources/llmFactSource.ts
+++ b/src/lib/trivia/factSources/llmFactSource.ts
@@ -63,6 +63,7 @@ Each fact must:
 - Be specifically about the category "${category}" — not adjacent topics.
 - State ONE specific, verifiable claim about ONE specific subject (a particular person, work, event, place, or thing — not a category of things).
 - Have a single concrete keyDetail (a name, date, number, place, or 1-3 word phrase) that is the UNIQUE answer to a question about this fact. If multiple things could plausibly be the answer (e.g. "a tennis player who won many Grand Slams" — there are several), the fact is too vague; pick a more specific subject.
+- The keyDetail must be the MINIMAL answer string — drop unit words and articles that the question would naturally contain. Use "40" not "40 novels" if the question would already say "how many novels"; use "1986" not "in 1986"; use "Mount Everest" not "the mountain Mount Everest." If the answer is fundamentally tied to a unit (e.g. an album title that contains the word "Album"), keep the unit.
 - Have the keyDetail appear verbatim inside the claim sentence.
 - Reach for surprising or deep-cut angles rather than obvious common knowledge.
 - Be true. If you are uncertain, replace the fact with one you are confident about.
@@ -72,11 +73,17 @@ Examples of good vs bad facts:
 GOOD: claim="Serena Williams won her 23rd and final Grand Slam singles title at the 2017 Australian Open." keyDetail="2017 Australian Open"
   → unique because there's only one 23rd-Grand-Slam-win event for her.
 
+GOOD: claim="The Discworld series by Terry Pratchett comprises 41 novels published between 1983 and 2015." keyDetail="41"
+  → minimal; the question will naturally say "how many novels," so the keyDetail is just the number.
+
 BAD: claim="Serena Williams is a tennis player who has won many Grand Slam titles." keyDetail="Serena Williams"
   → degenerate; the keyDetail is named in the claim and the fact gives no specific answer.
 
 BAD: claim="The Basenji is known as the 'barkless dog'." keyDetail="Basenji"
   → other quiet breeds could plausibly be called "barkless" too. Pick a more specific framing.
+
+BAD: claim="The Discworld series has 41 novels." keyDetail="41 novels"
+  → keyDetail includes "novels" which the question will naturally contain. Use just "41."
 
 Avoid duplicates: each of the ${count} facts should be about a different subject.`,
       temperature: 0.7,

--- a/src/lib/trivia/generateQuestion.ts
+++ b/src/lib/trivia/generateQuestion.ts
@@ -310,28 +310,41 @@ async function reviewQuestion(
     model: openaiClient(REVIEW_MODEL),
     schema: ReviewSchema,
     system:
-      'You are a strict quality reviewer for trivia questions. You reject anything that would frustrate a player.',
+      'You are a quality reviewer for trivia questions. Your job is to catch GENUINE problems, not to second-guess perfectly-good descriptive questions. A great trivia question describes its answer without naming it — that is the whole point of trivia.',
     prompt: `Review this trivia question for the category "${draft.categoryName}".
 
 Source fact: ${draft.fact.claim}
 Question: ${draft.question}
-Correct answer: ${draft.correct_answer}
+Expected answer: ${draft.correct_answer}
 Explanation: ${draft.explanation}
 
-Reject the question if ANY of these are true:
-- The answer is unambiguously stated (or trivially translated) inside the question text.
-- The question has multiple equally-valid answers — it must have ONE specific answer.
-- The question is too vague to answer without options.
-- The question is nonsensical, broken, or contradicts itself.
-- The "correct answer" doesn't actually answer the question.
-- The question's claim contradicts the source fact, or the answer doesn't match what the source fact supports.
-- The question doesn't belong to the category "${draft.categoryName}" — pick the best-fitting category from this list:
-  ${KNOWN_CATEGORIES.join(', ')}
+A question is a LEAK only if the expected answer string (or a clear synonym/translation of it) appears in the question text. Describing the answer is NOT a leak — it's good trivia.
 
-Set accept=true ONLY if every check passes AND inferred_category equals "${draft.categoryName}".
-If you reject, give a one-sentence rejection_reason. Otherwise rejection_reason is null.`,
+LEAK examples (REJECT):
+  Question: "What is the Pythagorean theorem?" Answer: "Pythagorean theorem"
+    → "Pythagorean theorem" appears verbatim. Leak.
+  Question: "When did the Lincoln Futura concept car appear in the 1966 Batman series?" Answer: "Lincoln Futura"
+    → "Lincoln Futura" appears verbatim. Leak.
+
+NOT-A-LEAK examples (ACCEPT, do not flag as leak):
+  Question: "Which early arcade video game, released by Atari in 1972, simulated table tennis?" Answer: "Pong"
+    → "Pong" does not appear. The question describes Pong via its features. ACCEPT.
+  Question: "How many novels are in Terry Pratchett's Discworld series?" Answer: "41"
+    → "41" does not appear. The word "novels" is in the question, but that's the unit, not the answer. ACCEPT.
+  Question: "What 2019 anthology explores the worldbuilding of Robert Jordan's Wheel of Time series?" Answer: "The World of the Wheel of Time"
+    → The phrase "Wheel of Time" appears in the question, but it refers to the SERIES being described, not the ANTHOLOGY. The answer (the anthology title) does not appear as the answer. ACCEPT.
+
+Then check the OTHER failure modes:
+- The question has multiple equally-valid answers (must have ONE specific answer).
+- The question is too vague to answer without options.
+- The question is nonsensical or contradicts itself.
+- The "expected answer" doesn't actually answer the question.
+- The question's claim contradicts the source fact, or the answer doesn't match what the fact supports.
+- The question doesn't belong to category "${draft.categoryName}" — pick the best fit from: ${KNOWN_CATEGORIES.join(', ')}
+
+Set accept=true if all checks pass. If you reject, give a one-sentence rejection_reason naming the specific failure. inferred_category is the category you think the question best belongs to.`,
     temperature: 0,
-    maxTokens: 150,
+    maxTokens: 200,
   })
 
   // Trust the LLM's overall accept signal. We previously also required


### PR DESCRIPTION
## Summary
Logs from production showed the reviewer rejecting **correct** trivia questions:

| keyDetail | Question | Reviewer |
|---|---|---|
| `Pong` | "Which early arcade video game, released by Atari in 1972, simulated table tennis?" | "answer is in the question" ❌ |
| `40 novels` | "How many novels are in Terry Pratchett's Discworld?" | "answer is in the question" ❌ |
| `The World of the Wheel of Time` | "What 2019 anthology explores Robert Jordan's Wheel of Time series?" | "answer is in the question" ❌ |

The reviewer conflated **describing the answer** (the entire point of trivia) with **leaking the answer**. None of those questions actually contain their answer; the construction was fine.

## Two fixes

**1. Reviewer prompt rewritten with TRUE/FALSE LEAK examples**
The system role now says: *"your job is to catch GENUINE problems, not to second-guess perfectly-good descriptive questions."* Then walks through both leak patterns and not-a-leak patterns concretely:

```
LEAK examples (REJECT):
  Question: "What is the Pythagorean theorem?" Answer: "Pythagorean theorem"
    → appears verbatim. Leak.

NOT-A-LEAK examples (ACCEPT):
  Question: "Which early arcade video game from 1972 simulated table tennis?" Answer: "Pong"
    → "Pong" does not appear. Question describes via features. ACCEPT.
  Question: "How many novels are in Discworld?" Answer: "41"
    → "41" does not appear. "novels" is the unit, not the answer. ACCEPT.
```

**2. Fact extraction asks for minimal keyDetails**
"Use `41` not `41 novels`. Use `1986` not `in 1986`. Use `Mount Everest` not `the mountain Mount Everest`." — eliminates the unit-overlap false positives at the source.

## Effect
Should be a step-change. Most rejections we've been seeing in logs were false positives caused by these two issues.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run` — full suite green
- [x] `npx eslint` clean
- [ ] After deploy: rejection rate should drop substantially. The questions that DO get rejected should have genuine issues (not just "answer described")

🤖 Generated with [Claude Code](https://claude.com/claude-code)