### PR TITLE
feat: track likeCount and dislikeCount on each question

### DIFF
--- a/scripts/backfill-question-rating-counts.ts
+++ b/scripts/backfill-question-rating-counts.ts
@@ -1,0 +1,113 @@
+#!/usr/bin/env tsx
+/**
+ * Backfill the likeCount and dislikeCount fields on aiQuestions docs
+ * by counting up/down votes in each question's ratings/ subcollection.
+ *
+ * Idempotent: each run computes the canonical counts from the
+ * subcollection and SETs them on the question doc, replacing whatever
+ * was there. Safe to re-run.
+ *
+ * Usage:
+ *   npx tsx --env-file=.env.local scripts/backfill-question-rating-counts.ts [--dry-run]
+ */
+
+import { cert, getApps, initializeApp } from 'firebase-admin/app'
+import { type WriteBatch, getFirestore } from 'firebase-admin/firestore'
+
+const BATCH_SIZE = 400
+
+function ensureApp() {
+  if (getApps().length > 0) return
+  const projectId = process.env.FIREBASE_PROJECT_ID
+  const clientEmail = process.env.FIREBASE_CLIENT_EMAIL
+  const privateKey = process.env.FIREBASE_PRIVATE_KEY?.replace(/\\n/g, '\n')
+  if (!projectId || !clientEmail || !privateKey) {
+    console.error('ERROR: Missing Firebase env vars.')
+    process.exit(1)
+  }
+  initializeApp({ credential: cert({ projectId, clientEmail, privateKey }) })
+}
+
+async function main() {
+  const dryRun = process.argv.includes('--dry-run')
+  ensureApp()
+  const db = getFirestore()
+
+  console.log(`Dry run: ${dryRun ? 'YES (no writes)' : 'NO (will write to Firestore)'}`)
+  console.log('─'.repeat(60))
+
+  // Fetch all rating docs once via a collection-group query — cheaper
+  // than walking each question's subcollection individually.
+  console.log('Reading ratings collection group...')
+  const ratingsSnap = await db.collectionGroup('ratings').get()
+
+  const counts = new Map<string, { up: number; down: number }>()
+  for (const doc of ratingsSnap.docs) {
+    const parent = doc.ref.parent.parent
+    if (!parent) continue
+    if (parent.parent.id !== 'aiQuestions') continue
+    const qid = parent.id
+    const vote = doc.data().vote
+    const cur = counts.get(qid) ?? { up: 0, down: 0 }
+    if (vote === 'up') cur.up += 1
+    else if (vote === 'down') cur.down += 1
+    counts.set(qid, cur)
+  }
+
+  console.log(`Found ${ratingsSnap.size} rating doc(s) across ${counts.size} unique question(s).`)
+
+  console.log('Reading aiQuestions...')
+  const qSnap = await db.collection('aiQuestions').get()
+  console.log(`Found ${qSnap.size} aiQuestions doc(s).`)
+
+  let batch: WriteBatch = db.batch()
+  let batchCount = 0
+  let updated = 0
+  let unchanged = 0
+
+  for (const doc of qSnap.docs) {
+    const data = doc.data()
+    const computed = counts.get(doc.id) ?? { up: 0, down: 0 }
+    const currentLike = data.likeCount ?? 0
+    const currentDislike = data.dislikeCount ?? 0
+
+    if (currentLike === computed.up && currentDislike === computed.down) {
+      unchanged++
+      continue
+    }
+
+    if (dryRun) {
+      console.log(
+        `would update ${doc.id}: likeCount ${currentLike}→${computed.up}, dislikeCount ${currentDislike}→${computed.down}`
+      )
+      updated++
+      continue
+    }
+
+    batch.update(doc.ref, {
+      likeCount: computed.up,
+      dislikeCount: computed.down,
+    })
+    batchCount++
+    updated++
+
+    if (batchCount >= BATCH_SIZE) {
+      await batch.commit()
+      batch = db.batch()
+      batchCount = 0
+    }
+  }
+
+  if (!dryRun && batchCount > 0) {
+    await batch.commit()
+  }
+
+  console.log('─'.repeat(60))
+  console.log(`Updated:   ${updated}`)
+  console.log(`Unchanged: ${unchanged}`)
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})

--- a/src/app/api/v1/trivia/infinite/next/route.ts
+++ b/src/app/api/v1/trivia/infinite/next/route.ts
@@ -73,6 +73,8 @@ export async function GET(request: NextRequest) {
           timesShown: 0,
           timesCorrect: 0,
           avgTimeMs: null,
+          likeCount: 0,
+          dislikeCount: 0,
         }
       } catch (genErr) {
         console.error('[trivia/infinite/next] generation failed', {

--- a/src/app/api/v1/trivia/questions/[id]/rate/route.ts
+++ b/src/app/api/v1/trivia/questions/[id]/rate/route.ts
@@ -25,44 +25,79 @@ export async function POST(
     return NextResponse.json({ error: 'Invalid JSON.' }, { status: 400 });
   }
 
-  const { vote } = body;
+  const { vote: rawVote } = body;
 
-  if (vote !== null && !VALID_VOTES.includes(vote as Vote)) {
+  if (rawVote !== null && !VALID_VOTES.includes(rawVote as Vote)) {
     return NextResponse.json(
       { error: 'Invalid vote. Must be "up", "down", or null.' },
       { status: 400 }
     );
   }
+  const newVote: Vote | null = rawVote === null ? null : (rawVote as Vote);
 
   const db = getFirestoreDb();
+  const qRef = db.doc(`aiQuestions/${questionId}`);
   const ratingRef = db.doc(`aiQuestions/${questionId}/ratings/${uid}`);
 
   try {
-    const existingSnap = await ratingRef.get();
-    const hadPriorVote = existingSnap.exists;
+    // Read prior vote, then update rating doc + question counters atomically.
+    // Voice stats are computed from the same delta and updated outside the
+    // transaction (they live on a different doc owned by another writer).
+    const { priorVote, likeDelta, dislikeDelta } = await db.runTransaction(async (tx) => {
+      const ratingSnap = await tx.get(ratingRef);
+      const prior: Vote | null = ratingSnap.exists
+        ? ((ratingSnap.data()?.vote as Vote | undefined) ?? null)
+        : null;
 
-    if (vote === null) {
-      await ratingRef.delete();
-    } else {
-      // Store uid + questionId as fields so admin tooling and
-      // collection-group queries can find ratings by user.
-      await ratingRef.set({
-        uid,
-        questionId,
-        vote,
-        ratedAt: FieldValue.serverTimestamp(),
-      });
+      const beforeUp = prior === 'up' ? 1 : 0;
+      const beforeDown = prior === 'down' ? 1 : 0;
+      const afterUp = newVote === 'up' ? 1 : 0;
+      const afterDown = newVote === 'down' ? 1 : 0;
+      const likeDeltaLocal = afterUp - beforeUp;
+      const dislikeDeltaLocal = afterDown - beforeDown;
 
-      // Only increment lifetime counter for new votes (not updates)
-      if (!hadPriorVote) {
-        const field = vote === 'up' ? 'likesGiven' : 'dislikesGiven';
-        await incrementVoiceStat(uid, field).catch((err) =>
-          console.error('[rate] Failed to increment voice stat:', err)
-        );
+      // Write rating doc
+      if (newVote === null) {
+        if (ratingSnap.exists) tx.delete(ratingRef);
+      } else {
+        // Store uid + questionId as fields too — the doc id is already the
+        // uid, but having them as fields lets us do collection-group queries
+        // and lets admin tooling display them.
+        tx.set(ratingRef, {
+          uid,
+          questionId,
+          vote: newVote,
+          ratedAt: FieldValue.serverTimestamp(),
+        });
       }
+
+      // Update denormalized counters on the question doc
+      const counterUpdates: Record<string, FirebaseFirestore.FieldValue> = {};
+      if (likeDeltaLocal !== 0) counterUpdates.likeCount = FieldValue.increment(likeDeltaLocal);
+      if (dislikeDeltaLocal !== 0) counterUpdates.dislikeCount = FieldValue.increment(dislikeDeltaLocal);
+      if (Object.keys(counterUpdates).length > 0) {
+        tx.update(qRef, counterUpdates);
+      }
+
+      return { priorVote: prior, likeDelta: likeDeltaLocal, dislikeDelta: dislikeDeltaLocal };
+    });
+
+    // Voice stats reflect the user's CURRENT rating choices. Apply the same
+    // delta logic so changing a vote (up→down) correctly moves the count
+    // from likesGiven to dislikesGiven instead of being stuck at the
+    // first vote.
+    if (likeDelta !== 0) {
+      await incrementVoiceStat(uid, 'likesGiven', likeDelta).catch((err) =>
+        console.error('[rate] Failed to update likesGiven:', err)
+      );
+    }
+    if (dislikeDelta !== 0) {
+      await incrementVoiceStat(uid, 'dislikesGiven', dislikeDelta).catch((err) =>
+        console.error('[rate] Failed to update dislikesGiven:', err)
+      );
     }
 
-    return NextResponse.json({ ok: true }, { status: 200 });
+    return NextResponse.json({ ok: true, priorVote, vote: newVote }, { status: 200 });
   } catch (err) {
     console.error('Failed to rate question:', err);
     return NextResponse.json({ error: 'Failed to rate question.' }, { status: 500 });

--- a/src/lib/trivia/aiQuestions.ts
+++ b/src/lib/trivia/aiQuestions.ts
@@ -13,6 +13,13 @@ export interface AIQuestion {
   timesShown: number
   timesCorrect: number
   avgTimeMs: number | null
+  // Rating counters. Maintained transactionally by the rate route
+  // alongside the per-user rating doc at aiQuestions/{id}/ratings/{uid}.
+  // Source of truth is still the subcollection (one doc per voter); these
+  // are denormalized for cheap reads at display time. Backfill script
+  // exists in case they ever drift.
+  likeCount: number
+  dislikeCount: number
 }
 
 export interface SeenQuestion {
@@ -21,7 +28,7 @@ export interface SeenQuestion {
 }
 
 export async function saveAIQuestion(
-  question: Omit<AIQuestion, 'status' | 'timesShown' | 'timesCorrect' | 'avgTimeMs'>
+  question: Omit<AIQuestion, 'status' | 'timesShown' | 'timesCorrect' | 'avgTimeMs' | 'likeCount' | 'dislikeCount'>
 ): Promise<string> {
   const db = getFirestoreDb()
   const doc: AIQuestion = {
@@ -30,6 +37,8 @@ export async function saveAIQuestion(
     timesShown: 0,
     timesCorrect: 0,
     avgTimeMs: null,
+    likeCount: 0,
+    dislikeCount: 0,
   }
   const ref = db.collection('aiQuestions').doc(question.id)
   await ref.set(doc)

--- a/src/lib/trivia/generateQuestion.ts
+++ b/src/lib/trivia/generateQuestion.ts
@@ -16,7 +16,7 @@ import {
 
 export type GeneratedQuestion = Omit<
   AIQuestion,
-  'status' | 'timesShown' | 'timesCorrect' | 'avgTimeMs'
+  'status' | 'timesShown' | 'timesCorrect' | 'avgTimeMs' | 'likeCount' | 'dislikeCount'
 >
 
 export interface GenerateInfiniteQuestionOptions {

--- a/src/lib/trivia/triviaStats.ts
+++ b/src/lib/trivia/triviaStats.ts
@@ -200,12 +200,14 @@ export async function applyRunToAggregate(uid: string, runId: string): Promise<v
 
 export async function incrementVoiceStat(
   uid: string,
-  field: 'likesGiven' | 'dislikesGiven' | 'reportsFiled'
+  field: 'likesGiven' | 'dislikesGiven' | 'reportsFiled',
+  delta = 1
 ): Promise<void> {
+  if (delta === 0) return
   const db = getFirestoreDb()
   const aggRef = db.doc(`users/${uid}/triviaStats/aggregate`)
   await aggRef.set(
-    { [field]: FieldValue.increment(1), lastUpdatedAt: FieldValue.serverTimestamp() },
+    { [field]: FieldValue.increment(delta), lastUpdatedAt: FieldValue.serverTimestamp() },
     { merge: true }
   )
 }


### PR DESCRIPTION
## Summary
Adds denormalized rating counters (`likeCount`, `dislikeCount`) on `aiQuestions` docs, maintained transactionally by the rate route.

Different trade-off than flags (which we just de-denormalized in #985):

| | Flags | Ratings |
|---|---|---|
| Volume | 6 docs total | one per voting player per question — high |
| Read frequency | Rare (audit only) | Likely surfaced in UI |
| Source of truth | Subcollection | Subcollection |
| Counter | Derived on read | **Denormalized for cheap reads** |

The rating doc + counter write happen in a single Firestore transaction, so they always stay in sync. The backfill script can re-derive from the subcollection if they ever drift.

### Latent bug fix
Changing a vote (up → down) used to leave `likesGiven` and `dislikesGiven` stuck at the value from the user's *first* vote — `incrementVoiceStat` was only called when `!hadPriorVote`. The new transaction applies the same delta logic to both question counters and voice stats, so changing a vote now correctly moves the count between fields.

`incrementVoiceStat` gains an optional `delta` parameter to support decrement.

### Backfill
`npx tsx --env-file=.env.local scripts/backfill-question-rating-counts.ts --dry-run` walks the ratings collection-group, computes per-question counts, and SETs them on each question doc. Idempotent — safe to re-run if counters ever drift.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run` — full suite green
- [x] `npx eslint` clean
- [ ] After merge, run the backfill script (dry-run first, then live)
- [ ] Manual: vote up on a question, verify likeCount on the question doc increments by 1
- [ ] Manual: change vote to down, verify likeCount decrements by 1 AND dislikeCount increments by 1
- [ ] Manual: clear vote (vote=null), verify the appropriate counter decrements and the rating doc is deleted

🤖 Generated with [Claude Code](https://claude.com/claude-code)