### PR TITLE
fix: steer generation away from year-guess questions

### DIFF
--- a/src/lib/trivia/factSources/llmFactSource.ts
+++ b/src/lib/trivia/factSources/llmFactSource.ts
@@ -63,7 +63,8 @@ Each fact must:
 - Be specifically about the category "${category}" — not adjacent topics.
 - State ONE specific, verifiable claim about ONE specific subject (a particular person, work, event, place, or thing — not a category of things).
 - Have a single concrete keyDetail (a name, date, number, place, or 1-3 word phrase) that is the UNIQUE answer to a question about this fact. If multiple things could plausibly be the answer (e.g. "a tennis player who won many Grand Slams" — there are several), the fact is too vague; pick a more specific subject.
-- The keyDetail must be the MINIMAL answer string — drop unit words and articles that the question would naturally contain. Use "40" not "40 novels" if the question would already say "how many novels"; use "1986" not "in 1986"; use "Mount Everest" not "the mountain Mount Everest." If the answer is fundamentally tied to a unit (e.g. an album title that contains the word "Album"), keep the unit.
+- The keyDetail must be the MINIMAL answer string — drop unit words and articles that the question would naturally contain. Use "40" not "40 novels" if the question would already say "how many novels"; use "Mount Everest" not "the mountain Mount Everest." If the answer is fundamentally tied to a unit (e.g. an album title that contains the word "Album"), keep the unit.
+- AVOID year-only keyDetails. A fact whose only specific detail is a year (like "1986" or "1492") makes for terrible free-text trivia — players have to guess an exact number with no skill signal. Instead, pick a DIFFERENT angle from the same subject: the person involved, the place, the work, the rule, the consequence. If the only interesting thing about a subject is a year, skip it and pick a different fact.
 - Have the keyDetail appear verbatim inside the claim sentence.
 - Reach for surprising or deep-cut angles rather than obvious common knowledge.
 - Be true. If you are uncertain, replace the fact with one you are confident about.
@@ -84,6 +85,9 @@ BAD: claim="The Basenji is known as the 'barkless dog'." keyDetail="Basenji"
 
 BAD: claim="The Discworld series has 41 novels." keyDetail="41 novels"
   → keyDetail includes "novels" which the question will naturally contain. Use just "41."
+
+BAD: claim="The first edition of 'The Dark Tower: The Gunslinger' by Stephen King was published in 1982." keyDetail="1982"
+  → year-only keyDetail. The resulting question is "what year did X happen?" which is a guessing game with no skill signal. Pick a different angle from the same subject — e.g. claim="'The Dark Tower: The Gunslinger' was Stephen King's first novel in his 'Dark Tower' series." keyDetail="The Gunslinger" (or "Stephen King" if the fact framed it that way).
 
 Avoid duplicates: each of the ${count} facts should be about a different subject.`,
       temperature: 0.7,

--- a/src/lib/trivia/generateQuestion.ts
+++ b/src/lib/trivia/generateQuestion.ts
@@ -163,9 +163,10 @@ Difficulty: ${ctx.difficulty.toUpperCase()}. ${DIFFICULTY_GUIDANCE[ctx.difficult
 
 Rules:
 - The question MUST have ONE unambiguous correct answer. If a knowledgeable person could plausibly give a different answer than the keyDetail, you must add identifying details to the question that rule out the alternatives. Do not write a question whose answer is "any X that fits Y" when many X fit Y.
-- The question must ask specifically for the keyDetail.
-- The question must NOT contain the keyDetail or a synonym/translation of it.
-- The correct_answer must equal the keyDetail or a clear variant (e.g. "1986" if the keyDetail is "February 21, 1986" and the question asks for the year).
+- AVOID "what year did X happen?" framings. Year-guess questions are weak free-text trivia — players just guess a number. If the keyDetail you've been given is a year, look for a different angle from the SAME fact: what was the person, place, work, rule, or consequence? Ask about that instead, and adjust correct_answer accordingly. Only ask for a year if the year is genuinely the most distinctive thing about the fact AND a knowledgeable person would actually know it (e.g. "1066" for the Battle of Hastings is fair; "1982" for an arbitrary book release is not).
+- The question must ask specifically for the keyDetail (or your repointed answer).
+- The question must NOT contain the answer or a synonym/translation of it.
+- The correct_answer must equal the keyDetail or a clear variant.
 - The explanation may elaborate beyond the fact (2-3 sentences).
 - Stay in the "${ctx.categoryName}" category. Do not drift.
 - Free-text answer; this is NOT a multiple-choice question.


### PR DESCRIPTION
## Summary
"What year did X happen?" is bad free-text trivia — players guess a number with no skill signal. Two prompt edits to discourage them:

**Fact extraction**: year-only keyDetails are now an explicit BAD example. The fact-source is told to pick a different angle from the same subject (the person, place, work, rule, consequence). Uses the Stephen King / Dark Tower 1982 case from production as the example.

**Question construction**: new rule that says avoid "what year" framings unless the year is genuinely distinctive AND a knowledgeable player would know it. ("1066" for Hastings is fair; "1982" for an arbitrary book release is not.) If the keyDetail handed in IS a year, the constructor is instructed to repoint to a different answer from the same fact.

## Test plan
- [x] Lint, typecheck, full suite green
- [ ] Watch new questions in production: should see fewer "what year did X happen?" patterns

🤖 Generated with [Claude Code](https://claude.com/claude-code)