### PR TITLE
Implement Wee Joker rare joker (#831)

### DIFF
--- a/src/app/daily-card-game/domain/game/__tests__/wee-joker.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/wee-joker.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+import { defaultGameState } from '@/app/daily-card-game/domain/game/default-game-state'
+import { reduceGame } from '@/app/daily-card-game/domain/game/reduce-game'
+import type { GameState } from '@/app/daily-card-game/domain/game/types'
+import { jokers } from '@/app/daily-card-game/domain/joker/jokers'
+import { initializeJoker } from '@/app/daily-card-game/domain/joker/utils'
+
+describe('Wee Joker', () => {
+  it('initializes with 0 chips bonus', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.jokers = [initializeJoker(jokers.weeJokerJoker, game)]
+    const started = reduceGame(game, { type: 'GAME_START' })
+    const wj = started.jokers.find(j => j.jokerId === 'weeJokerJoker')
+    expect(wj?.metadata?.chipsBonus).toBe(0)
+  })
+
+  it('does not add chips on HAND_SCORING_FINALIZE when no 2s scored', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.jokers = [initializeJoker(jokers.weeJokerJoker, game)]
+    game.rounds[game.roundIndex].smallBlind.status = 'inProgress'
+    game.gamePhase = 'gameplay'
+    const started = reduceGame(game, { type: 'GAME_START' })
+    const afterScore = reduceGame(started, { type: 'HAND_SCORING_FINALIZE' })
+    expect(afterScore.gamePlayState.scoringEvents.some(
+      e => 'source' in e && e.source === 'Wee Joker'
+    )).toBe(false)
+  })
+})

--- a/src/app/daily-card-game/domain/joker/jokers.ts
+++ b/src/app/daily-card-game/domain/joker/jokers.ts
@@ -929,6 +929,65 @@ export const theTribeJoker: JokerDefinition = {
   rarity: 'rare',
 }
 
+export const weeJokerJoker: JokerDefinition = {
+  id: 'weeJokerJoker',
+  name: 'Wee Joker',
+  description: 'This Joker gains +8 Chips when each played 2 is scored',
+  price: 8,
+  effects: [
+    {
+      event: { type: 'GAME_START' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        const wj = ctx.game.jokers.find(j => j.jokerId === 'weeJokerJoker')
+        if (wj) {
+          wj.metadata = { ...wj.metadata, chipsBonus: wj.metadata?.chipsBonus ?? 0 }
+        }
+      },
+    },
+    {
+      event: { type: 'JOKER_ADDED' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        const wj = ctx.game.jokers.find(j => j.jokerId === 'weeJokerJoker')
+        if (wj) {
+          wj.metadata = { ...wj.metadata, chipsBonus: 0 }
+        }
+      },
+    },
+    {
+      event: { type: 'CARD_SCORED' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        const wj = ctx.game.jokers.find(j => j.jokerId === 'weeJokerJoker')
+        if (!wj || !wj.metadata) return
+        const scoredCard = ctx.scoredCards?.[0]
+        if (!scoredCard) return
+        const cardDef = playingCards[scoredCard.playingCardId]
+        if (cardDef && cardDef.value === '2') {
+          wj.metadata.chipsBonus += 8
+        }
+      },
+    },
+    {
+      event: { type: 'HAND_SCORING_FINALIZE' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        const wj = ctx.game.jokers.find(j => j.jokerId === 'weeJokerJoker')
+        if (!wj || !wj.metadata || wj.metadata.chipsBonus <= 0) return
+        ctx.game.gamePlayState.scoringEvents.push({
+          id: uuid(),
+          type: 'chips',
+          value: wj.metadata.chipsBonus,
+          source: 'Wee Joker',
+        })
+        ctx.game.gamePlayState.score.chips += wj.metadata.chipsBonus
+      },
+    },
+  ],
+  rarity: 'rare',
+}
+
 export const jokers: Record<JokerDefinition['id'], JokerDefinition> = {
   jokerJoker,
   greedyJoker,
@@ -958,6 +1017,7 @@ export const jokers: Record<JokerDefinition['id'], JokerDefinition> = {
   theDuoJoker,
   theOrderJoker,
   theTribeJoker,
+  weeJokerJoker,
 }
 
 /***


### PR DESCRIPTION
## Summary
- Adds **Wee Joker** rare joker: gains +8 Chips each time a played 2 is scored
- Uses `metadata.chipsBonus` for persistent scaling across the run
- Applies accumulated chips bonus on HAND_SCORING_FINALIZE

Closes #831

## Test plan
- [x] Initializes with 0 chips bonus
- [x] No scoring event when no 2s scored
- [x] All 1031 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)