### PR TITLE
feat: background-warm the question pool during play

### DIFF
--- a/src/app/api/v1/trivia/infinite/next/route.ts
+++ b/src/app/api/v1/trivia/infinite/next/route.ts
@@ -1,3 +1,4 @@
+import { after } from 'next/server'
 import { type NextRequest, NextResponse } from 'next/server'
 
 import { verifyRequestAuth } from '@/lib/api/auth'
@@ -8,6 +9,7 @@ import { generateInfiniteQuestion } from '@/lib/trivia/generateQuestion'
 import { MAX_GENERATIONS_PER_WINDOW, WINDOW_MS, checkAndIncrementGenerationLimit } from '@/lib/trivia/generationLimit'
 import { sampleNextQuestion } from '@/lib/trivia/sampler'
 import { trackExhaustion } from '@/lib/trivia/triviaStats'
+import { warmQuestionPoolForUser } from '@/lib/trivia/warmQuestionPool'
 
 // GET /api/v1/trivia/infinite/next?streak=N[&categoryIds=12,13,15]
 // Backward-compat: also accepts the legacy single ?categoryId=N param.
@@ -93,6 +95,11 @@ export async function GET(request: NextRequest) {
     // Strip correctAnswer before sending to client
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const { correctAnswer, ...safeQuestion }: AIQuestion = question
+
+    // Background top-up: keep the player ahead of pool exhaustion by
+    // pre-generating one question per /next when their unanswered
+    // pool drops below the target. Runs after the response is sent.
+    after(() => warmQuestionPoolForUser(auth.claims.uid))
 
     return NextResponse.json(safeQuestion)
   } catch (err) {

--- a/src/lib/trivia/warmQuestionPool.ts
+++ b/src/lib/trivia/warmQuestionPool.ts
@@ -1,0 +1,59 @@
+import { getFirestoreDb } from '@/lib/firebase/server'
+import { saveAIQuestion } from '@/lib/trivia/aiQuestions'
+import { generateInfiniteQuestion } from '@/lib/trivia/generateQuestion'
+
+// Target number of unanswered active questions a player should always
+// have available before they hit the on-demand generation path.
+// Background warming kicks in when their (approximate) unanswered count
+// drops below this threshold.
+const TARGET_UNANSWERED = 10
+
+// Fire-and-forget background top-up of the question pool for a single
+// player. Call from inside an `after()` block so it runs after the
+// /next response has been sent.
+//
+// Approximation rationale: counting "active questions this user has not
+// seen" exactly would require reading both collections in full. Instead
+// we use Firestore aggregation count() on each side and subtract — this
+// over-counts unanswered when the user has seen since-flagged
+// questions, which means we'll occasionally skip warming when we
+// shouldn't, but never warm when we shouldn't. Acceptable bias.
+//
+// Errors are logged, not thrown — this is best-effort and must never
+// fail the request that scheduled it.
+export async function warmQuestionPoolForUser(uid: string): Promise<void> {
+  const db = getFirestoreDb()
+
+  try {
+    const [activeAgg, seenAgg] = await Promise.all([
+      db.collection('aiQuestions').where('status', '==', 'active').count().get(),
+      db.collection(`users/${uid}/seenQuestions`).count().get(),
+    ])
+
+    const activeCount = activeAgg.data().count
+    const seenCount = seenAgg.data().count
+    const approxUnanswered = Math.max(0, activeCount - seenCount)
+
+    if (approxUnanswered >= TARGET_UNANSWERED) {
+      return
+    }
+
+    console.info('[warmQuestionPool] generating', {
+      uid,
+      approxUnanswered,
+      activeCount,
+      seenCount,
+      target: TARGET_UNANSWERED,
+    })
+
+    const generated = await generateInfiniteQuestion({})
+    await saveAIQuestion(generated)
+
+    console.info('[warmQuestionPool] saved', { uid, questionId: generated.id, category: generated.category })
+  } catch (err) {
+    console.warn('[warmQuestionPool] failed', {
+      uid,
+      error: err instanceof Error ? err.message : String(err),
+    })
+  }
+}


### PR DESCRIPTION
## Summary
After `/next` returns a successful question, schedule a fire-and-forget background top-up via Next.js `after()`. If the player has fewer than **10 unanswered active questions**, generate one before the next `/next` arrives.

The result: the pool gets fresher in the background while the player reads explanations, instead of forcing them to wait for generation when they finally hit exhaustion. The on-demand generation path stays as the fallback.

### How "unanswered" is approximated

```ts
approxUnanswered = activeCount - seenCount
```

Both via Firestore aggregation `count()` — fast, no doc reads. Slight bias when the user has seen since-flagged questions (which over-counts unanswered), so we may occasionally skip warming we should have done, but never warm needlessly. Fine as a trigger.

### Cost containment

The `TARGET_UNANSWERED = 10` cap is the natural rate limit. Once the pool has ≥10 unanswered for a player, warming returns early with no LLM calls. We only generate when we're below threshold, and only one per `/next` call.

### Robustness

- Errors are swallowed and logged — warming **must not** fail the request that scheduled it.
- Uses `after()` so it runs after the response is sent — no client-perceived latency.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run` — full suite green
- [x] `npx eslint` clean
- [ ] Manual: start an infinite run, watch server logs for `[warmQuestionPool] generating` and `saved` lines once your unanswered pool drops below 10
- [ ] Manual: confirm response latency is unchanged for the player

🤖 Generated with [Claude Code](https://claude.com/claude-code)