### PR TITLE
Implement Stuntman and Baseball Card rare jokers (#828, #836)

### DIFF
--- a/src/app/daily-card-game/domain/game/__tests__/baseball-card.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/baseball-card.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+import { defaultGameState } from '@/app/daily-card-game/domain/game/default-game-state'
+import { reduceGame } from '@/app/daily-card-game/domain/game/reduce-game'
+import type { GameState } from '@/app/daily-card-game/domain/game/types'
+import { jokers } from '@/app/daily-card-game/domain/joker/jokers'
+import { initializeJoker } from '@/app/daily-card-game/domain/joker/utils'
+
+describe('Baseball Card joker', () => {
+  it('applies X1.5 Mult per uncommon joker owned', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    // Baseball Card + 2 uncommon jokers (toTheMoonJoker, bullJoker)
+    game.jokers = [
+      initializeJoker(jokers.baseballCardJoker, game),
+      initializeJoker(jokers.toTheMoonJoker, game),
+      initializeJoker(jokers.bullJoker, game),
+    ]
+    game.rounds[game.roundIndex].smallBlind.status = 'inProgress'
+    game.gamePhase = 'gameplay'
+    game.gamePlayState.score = { chips: 10, mult: 10 }
+    const after = reduceGame(game, { type: 'HAND_SCORING_FINALIZE' })
+    // 2 uncommon jokers = 2 X1.5 events
+    const bcEvents = after.gamePlayState.scoringEvents.filter(
+      e => 'source' in e && e.source === 'Baseball Card'
+    )
+    expect(bcEvents.length).toBe(2)
+  })
+
+  it('does not apply when no uncommon jokers', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.jokers = [initializeJoker(jokers.baseballCardJoker, game)]
+    game.rounds[game.roundIndex].smallBlind.status = 'inProgress'
+    game.gamePhase = 'gameplay'
+    game.gamePlayState.score = { chips: 10, mult: 10 }
+    const after = reduceGame(game, { type: 'HAND_SCORING_FINALIZE' })
+    expect(after.gamePlayState.scoringEvents.some(
+      e => 'source' in e && e.source === 'Baseball Card'
+    )).toBe(false)
+  })
+})

--- a/src/app/daily-card-game/domain/game/__tests__/stuntman.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/stuntman.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest'
+import { defaultGameState } from '@/app/daily-card-game/domain/game/default-game-state'
+import { reduceGame } from '@/app/daily-card-game/domain/game/reduce-game'
+import type { GameState } from '@/app/daily-card-game/domain/game/types'
+import { jokers } from '@/app/daily-card-game/domain/joker/jokers'
+import { initializeJoker } from '@/app/daily-card-game/domain/joker/utils'
+
+describe('Stuntman joker', () => {
+  it('reduces hand size by 2 on GAME_START', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.jokers = [initializeJoker(jokers.stuntmanJoker, game)]
+    const started = reduceGame(game, { type: 'GAME_START' })
+    expect(started.handSizeModifier).toBe(-2)
+  })
+
+  it('adds +250 Chips on HAND_SCORING_FINALIZE', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.jokers = [initializeJoker(jokers.stuntmanJoker, game)]
+    game.rounds[game.roundIndex].smallBlind.status = 'inProgress'
+    game.gamePhase = 'gameplay'
+    const started = reduceGame(game, { type: 'GAME_START' })
+    const afterScore = reduceGame(started, { type: 'HAND_SCORING_FINALIZE' })
+    expect(afterScore.gamePlayState.scoringEvents.some(
+      e => 'source' in e && e.source === 'Stuntman' && e.value === 250
+    )).toBe(true)
+  })
+
+  it('reverts hand size when sold', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.jokers = [initializeJoker(jokers.stuntmanJoker, game)]
+    const started = reduceGame(game, { type: 'GAME_START' })
+    expect(started.handSizeModifier).toBe(-2)
+    const instance = started.jokers.find(j => j.jokerId === 'stuntmanJoker')!
+    const selected = { ...started, gamePlayState: { ...started.gamePlayState, selectedJokerId: instance.id } }
+    const afterSale = reduceGame(selected, { type: 'JOKER_SOLD' })
+    expect(afterSale.handSizeModifier).toBe(0)
+  })
+})

--- a/src/app/daily-card-game/domain/joker/jokers.ts
+++ b/src/app/daily-card-game/domain/joker/jokers.ts
@@ -1018,6 +1018,95 @@ export const theFamilyJoker: JokerDefinition = {
   rarity: 'rare',
 }
 
+export const stuntmanJoker: JokerDefinition = {
+  id: 'stuntmanJoker',
+  name: 'Stuntman',
+  description: '+250 Chips, -2 hand size',
+  price: 7,
+  effects: [
+    {
+      event: { type: 'GAME_START' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        if (ctx.game.jokers.some(j => j.jokerId === 'stuntmanJoker')) {
+          ctx.game.handSizeModifier -= 2
+        }
+      },
+    },
+    {
+      event: { type: 'JOKER_ADDED' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        ctx.game.handSizeModifier -= 2
+      },
+    },
+    {
+      event: { type: 'JOKER_SOLD' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        if (!ctx.game.jokers.some(j => j.jokerId === 'stuntmanJoker')) {
+          ctx.game.handSizeModifier += 2
+        }
+      },
+    },
+    {
+      event: { type: 'JOKER_REMOVED' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        if (!ctx.game.jokers.some(j => j.jokerId === 'stuntmanJoker')) {
+          ctx.game.handSizeModifier += 2
+        }
+      },
+    },
+    {
+      event: { type: 'HAND_SCORING_FINALIZE' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        ctx.game.gamePlayState.scoringEvents.push({
+          id: uuid(),
+          type: 'chips',
+          value: 250,
+          source: 'Stuntman',
+        })
+        ctx.game.gamePlayState.score.chips += 250
+      },
+    },
+  ],
+  rarity: 'rare',
+}
+
+export const baseballCardJoker: JokerDefinition = {
+  id: 'baseballCardJoker',
+  name: 'Baseball Card',
+  description: 'Uncommon Jokers each give X1.5 Mult',
+  price: 8,
+  effects: [
+    {
+      event: { type: 'HAND_SCORING_FINALIZE' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        let uncommonCount = 0
+        for (const jokerState of ctx.game.jokers) {
+          if (jokerState.jokerId === 'baseballCardJoker') continue
+          const jokerDef = jokers[jokerState.jokerId]
+          if (jokerDef?.rarity === 'uncommon') uncommonCount++
+        }
+        for (let i = 0; i < uncommonCount; i++) {
+          ctx.game.gamePlayState.scoringEvents.push({
+            id: uuid(),
+            type: 'mult',
+            operator: 'x',
+            value: 1.5,
+            source: 'Baseball Card',
+          })
+          ctx.game.gamePlayState.score.mult *= 1.5
+        }
+      },
+    },
+  ],
+  rarity: 'rare',
+}
+
 export const jokers: Record<JokerDefinition['id'], JokerDefinition> = {
   jokerJoker,
   greedyJoker,
@@ -1049,6 +1138,8 @@ export const jokers: Record<JokerDefinition['id'], JokerDefinition> = {
   theTribeJoker,
   weeJokerJoker,
   theFamilyJoker,
+  stuntmanJoker,
+  baseballCardJoker,
 }
 
 /***


### PR DESCRIPTION
## Summary
- **Stuntman** (#828): +250 Chips, -2 hand size. Uses `handSizeModifier` for hand size penalty, properly reverted on sell/remove.
- **Baseball Card** (#836): Uncommon Jokers each give X1.5 Mult. Counts uncommon jokers at scoring time and applies multiplier for each.

Bundled to avoid the persistent merge conflict pattern from sequential single-joker PRs.

Closes #828
Closes #836

## Test plan
- [x] Stuntman: reduces hand size by 2, adds +250 Chips, reverts on sell
- [x] Baseball Card: applies X1.5 Mult per uncommon joker, no effect with 0 uncommon
- [x] All tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)