### PR TITLE
fix: lenient answer judge — accept '3' for 'three', drop length floor

### DIFF
--- a/src/lib/trivia/answerJudge.ts
+++ b/src/lib/trivia/answerJudge.ts
@@ -8,8 +8,11 @@ const GAMING_PATTERNS = /^(correct|right|yes|true|the answer|answer|idk|i don'?t
 export async function judgeAnswer(question: string, correctAnswer: string, userAnswer: string): Promise<boolean> {
   const trimmed = userAnswer.trim()
 
-  // Pre-check: reject obviously non-answers and gaming attempts
-  if (!trimmed || trimmed.length < 2 || GAMING_PATTERNS.test(trimmed)) {
+  // Pre-check: reject empty input and obvious gaming attempts.
+  // (We deliberately don't enforce a minimum length — single-character
+  // answers like "3" or "C" are legitimate for "how many" / musical-key
+  // questions.)
+  if (!trimmed || GAMING_PATTERNS.test(trimmed)) {
     return false
   }
 
@@ -23,20 +26,29 @@ export async function judgeAnswer(question: string, correctAnswer: string, userA
 
   const result = await generateObject({
     model: openaiClient('gpt-4o-mini'),
-    schema: JudgeSchema,
-    prompt: `You are a strict trivia answer judge. Determine if the user's answer is correct.
+    prompt: `You are a friendly-but-fair trivia answer judge. Your job is to accept clearly-correct answers, including casual or shortened forms a person would naturally type when they know the answer. Reject only answers that genuinely don't match.
 
 Question: "${question}"
 Correct answer: "${correctAnswer}"
 User's answer: "${trimmed}"
 
-Rules:
-- Accept reasonable variations, minor spelling errors, and equivalent answers.
-- The user must provide a SPECIFIC answer that matches the correct answer.
-- Do NOT accept generic words like "correct", "right", "yes", "true", or meta-answers like "<correct>".
-- Do NOT accept answers that merely describe the category or topic without giving a specific answer.
-- If the answer is vague or could apply to many questions, mark it INCORRECT.`,
-    temperature: 0.1,
+ACCEPT (mark correct=true) when the user's answer matches the correct answer in any of these ways:
+- Numeric/word equivalence: "3" matches "three", "twelve" matches "12", "1.5 million" matches "1,500,000".
+- Spelling variations and minor typos: "Pythagoras" / "Pithagoras", "Caesar" / "Cesar".
+- Common abbreviations: "USA" / "United States", "WWII" / "World War 2" / "Second World War", "JFK" / "John F. Kennedy", "NYC" / "New York City".
+- Subset matches when the question implies the level of specificity: if the question asks "what year" and the correct answer is "February 21, 1986", accept "1986". If the question asks for a person's last name and the correct answer is "Albert Einstein", accept "Einstein".
+- Casing, punctuation, or article differences: "The Beatles" / "beatles", "Lord of the Rings" / "the lord of the rings".
+- Plural/singular when the question doesn't pin one or the other.
+
+REJECT (mark correct=false) when:
+- The user gave a different specific answer (wrong fact).
+- The user gave a vague/generic word that could apply to many questions: "correct", "right", "yes", "true", a category name, etc.
+- The user gave only a meta-answer (e.g. "<answer>", "the answer").
+- The user's answer is missing the key identifier the question asks for.
+
+Default to ACCEPTING when the user clearly knows the answer but typed a casual or numeric form. Trivia is about knowing the fact, not about formatting.`,
+    schema: JudgeSchema,
+    temperature: 0,
     maxTokens: 100,
   })
 


### PR DESCRIPTION
## Summary
User reported a question with correct answer **"three"** marking the input **"3"** incorrect. Two problems compounded:

### Bug: length floor short-circuited the LLM
```ts
if (!trimmed || trimmed.length < 2 || GAMING_PATTERNS.test(trimmed)) return false
```

The `trimmed.length < 2` check auto-rejected `"3"` *before the LLM was even called*. Single-character answers like `"3"`, `"C"` (musical key), `"0"` (count) are legitimate — drop the floor.

### Prompt was vague about acceptable variations
The old prompt said "accept reasonable variations and equivalent answers" but didn't specify what counts. The new prompt explicitly enumerates:

- **Numeric/word**: `"3"` ↔ `"three"`, `"twelve"` ↔ `"12"`
- **Spelling**: `"Pythagoras"` / `"Pithagoras"`
- **Abbreviations**: `"USA"` / `"United States"`, `"WWII"` / `"World War 2"` / `"Second World War"`
- **Subset matches**: question asks "what year" + correct answer is `"February 21, 1986"` → accept `"1986"`. Question asks for a last name + correct answer is `"Albert Einstein"` → accept `"Einstein"`.
- **Casing/punctuation/article**: `"The Beatles"` / `"beatles"`
- **Plural/singular** when the question doesn't pin one

Plus a default framing: *"Default to ACCEPTING when the user clearly knows the answer but typed a casual or numeric form. Trivia is about knowing the fact, not about formatting."*

Reject criteria stay tight: wrong fact, generic gaming words (`"correct"`, `"right"`, `"yes"`), meta-answers (`"<answer>"`), missing key identifier.

## Test plan
- [x] Lint, typecheck, tests green
- [ ] Manual: type `"3"` for a "how many" question whose canonical answer is `"three"` — should be accepted
- [ ] Manual: type `"USA"` for "United States" — should be accepted
- [ ] Manual: type `"correct"` — should still be rejected (gaming pattern)

🤖 Generated with [Claude Code](https://claude.com/claude-code)