### PR TITLE
fix: deterministic year-question rejection routes to repair

### DIFF
--- a/src/lib/trivia/__tests__/detectYearGuessQuestion.test.ts
+++ b/src/lib/trivia/__tests__/detectYearGuessQuestion.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest'
+
+import { detectYearGuessQuestion } from '@/lib/trivia/generateQuestion'
+
+describe('detectYearGuessQuestion', () => {
+  it('flags "in what year" with year answer', () => {
+    expect(detectYearGuessQuestion('In what year was The Gunslinger published?', '1982')).toBe(true)
+  })
+
+  it('flags "in which year" with year answer', () => {
+    expect(detectYearGuessQuestion('In which year did the Battle of Hastings occur?', '1066')).toBe(true)
+  })
+
+  it('flags "what year" anywhere in the question', () => {
+    expect(detectYearGuessQuestion('What year was Pulp Fiction released?', '1994')).toBe(true)
+  })
+
+  it('flags "when was" with a year answer', () => {
+    expect(detectYearGuessQuestion('When was the World Wide Web invented?', '1989')).toBe(true)
+  })
+
+  it('does not flag year-mentioning questions where the answer is not a year', () => {
+    expect(
+      detectYearGuessQuestion(
+        'What event in 1066 reshaped England?',
+        'Battle of Hastings'
+      )
+    ).toBe(false)
+  })
+
+  it('does not flag non-year questions even if the answer is a number', () => {
+    expect(
+      detectYearGuessQuestion('How many novels are in the Discworld series?', '41')
+    ).toBe(false)
+  })
+
+  it('accepts year suffixes (AD/BC/CE/BCE) on the answer', () => {
+    expect(detectYearGuessQuestion('In what year did Caesar cross the Rubicon?', '49 BC')).toBe(true)
+    expect(detectYearGuessQuestion('In what year was the calendar reform?', '1582 CE')).toBe(true)
+  })
+
+  it('does not flag answers that are clearly not years (5+ digit numbers)', () => {
+    expect(detectYearGuessQuestion('In what year did X happen?', '12345')).toBe(false)
+  })
+
+  it('does not flag questions about non-temporal "year" mentions', () => {
+    // "year of the rabbit" doesn't ask FOR a year
+    expect(detectYearGuessQuestion('Which animal represents the year 2023 in the Chinese zodiac?', 'Rabbit')).toBe(false)
+  })
+})

--- a/src/lib/trivia/generateQuestion.ts
+++ b/src/lib/trivia/generateQuestion.ts
@@ -306,6 +306,27 @@ export function detectAnswerLeak(question: string, keyDetail: string): boolean {
   return false
 }
 
+// Catch year-guess questions ("In what year did X happen?" with a
+// year-shaped answer) before they reach the player. The construction
+// prompt tells the LLM to avoid these, but the LLM sometimes ignores
+// the rule. This is the deterministic backstop — same pattern as
+// detectAnswerLeak.
+export function detectYearGuessQuestion(question: string, correctAnswer: string): boolean {
+  const q = question.toLowerCase()
+  const a = correctAnswer.trim()
+
+  const asksForYear =
+    /\b(in (what|which|the) year|what year|year (did|was|in which|that)|year of|when (was|did))\b/.test(q)
+  if (!asksForYear) return false
+
+  // Year-shaped: 1-4 digits, optionally with era suffix. Allows "49 BC"
+  // and "5 AD" as well as "1066", "1994". Won't false-positive on
+  // larger numbers like "12345" since the question-side filter only
+  // fires when the question asks "what year" / "when was".
+  const isYearLike = /^\s*\d{1,4}\s*(ad|bc|bce|ce)?\s*$/i.test(a)
+  return isYearLike
+}
+
 async function reviewQuestion(
   apiKey: string,
   draft: DraftQuestion
@@ -450,6 +471,32 @@ export async function generateInfiniteQuestion(
           repair,
           category: categoryName,
           keyDetail: fact.keyDetail,
+          question: draft.question,
+        })
+        if (repair < MAX_REPAIRS_PER_DRAFT) {
+          try {
+            draft = await repairDraft(apiKey, draft, reason)
+          } catch (err) {
+            lastReason = `repair failed: ${err instanceof Error ? err.message : String(err)}`
+            console.warn('[generateInfiniteQuestion] repair threw', { attempt, repair, reason: lastReason })
+            break
+          }
+          continue
+        }
+        break
+      }
+
+      // Deterministic pre-check: catch year-guess questions before
+      // they reach the player. The construction prompt is supposed to
+      // avoid these but the LLM sometimes ignores the rule.
+      if (detectYearGuessQuestion(draft.question, draft.correct_answer)) {
+        const reason = `The question is a year-guess ("what year did X happen?") with a year-shaped answer "${draft.correct_answer}". Reframe to ask about a different aspect of the same fact — the person, place, work, rule, or consequence — and adjust correct_answer accordingly. Do NOT ask for a year.`
+        lastReason = `pre-check year-guess: ${reason}`
+        console.warn('[generateInfiniteQuestion] draft rejected (pre-check year-guess)', {
+          attempt,
+          repair,
+          category: categoryName,
+          correctAnswer: draft.correct_answer,
           question: draft.question,
         })
         if (repair < MAX_REPAIRS_PER_DRAFT) {


### PR DESCRIPTION
## Summary
You're still seeing "in which year" questions slip through despite #1009 / #1013's prompt guidance. The LLM is just ignoring the rule. Time to stop relying on the prompt and add a **deterministic backstop**, same pattern as `detectAnswerLeak`.

## How it works
```ts
detectYearGuessQuestion(question, correctAnswer) → boolean
```

Returns true when **both** are true:
- Question contains: `"in (what|which|the) year"`, `"what year"`, `"year (did|was|in which|that)"`, `"year of"`, or `"when (was|did)"`
- Answer is year-shaped: 1-4 digits with optional `AD` / `BC` / `BCE` / `CE` suffix

When it fires, the rejection reason gets handed to `repairDraft()`, which has to reframe the question to ask about a *different aspect* of the same fact (the person, place, work, rule, consequence). Much harder for the LLM to ignore than a prompt rule.

## Trade-off
Legitimately fair year questions (e.g. 1066 Hastings, 1492 Columbus) also get rejected. Acceptable — the volume of bad year-guess questions far outweighs the few truly famous years, and players don't *need* to be quizzed on dates.

## Tests
9 unit tests cover the detector — `in what year`, `in which year`, `what year`, `when was`, year-mentioning questions where the *answer* isn't a year (must NOT flag), AD/BC/BCE/CE suffixes, etc.

## Test plan
- [x] `npx vitest run` — full suite green; 9 new tests pass
- [x] `npx tsc --noEmit` clean
- [x] `npx eslint` clean
- [ ] After deploy: watch for `[generateInfiniteQuestion] draft rejected (pre-check year-guess)` logs and confirm the proportion of year questions reaching players drops sharply

🤖 Generated with [Claude Code](https://claude.com/claude-code)