### PR TITLE
fix: more space above the submit answer button

### DIFF
--- a/src/app/trivia/components/InfiniteQuestionCard.tsx
+++ b/src/app/trivia/components/InfiniteQuestionCard.tsx
@@ -81,7 +81,7 @@ export function InfiniteQuestionCard({
         </p>
 
         {/* Free-text input */}
-        <div className="flex flex-col gap-4">
+        <div className="flex flex-col gap-6">
           <Input
             value={textAnswer}
             onChange={(e) => setTextAnswer(e.target.value)}


### PR DESCRIPTION
## Summary
gap-4 (16px) wasn't enough — bumping to gap-6 (24px) on the answer-input column.

🤖 Generated with [Claude Code](https://claude.com/claude-code)