### PR TITLE
Implement Spare Trousers uncommon joker (#787)

### DIFF
--- a/src/app/daily-card-game/domain/game/__tests__/spare-trousers.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/spare-trousers.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest'
+import { defaultGameState } from '@/app/daily-card-game/domain/game/default-game-state'
+import { reduceGame } from '@/app/daily-card-game/domain/game/reduce-game'
+import type { GameState } from '@/app/daily-card-game/domain/game/types'
+import { jokers } from '@/app/daily-card-game/domain/joker/jokers'
+import { initializeJoker } from '@/app/daily-card-game/domain/joker/utils'
+
+describe('Spare Trousers joker', () => {
+  it('gains +2 Mult after Two Pair is played', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.jokers = [initializeJoker(jokers.spareTrousersJoker, game)]
+    game.rounds[game.roundIndex].smallBlind.status = 'inProgress'
+    game.gamePhase = 'gameplay'
+    const started = reduceGame(game, { type: 'GAME_START' })
+
+    // First hand: play a Two Pair - no bonus yet (starts at 0), but gains +2
+    const hand1: GameState = { ...started, gamePlayState: { ...started.gamePlayState, selectedHand: ['twoPair', []], score: { chips: 10, mult: 5 } } }
+    const after1 = reduceGame(hand1, { type: 'HAND_SCORING_FINALIZE' })
+    const st1 = after1.jokers.find(j => j.jokerId === 'spareTrousersJoker')
+    expect(st1?.metadata?.multBonus).toBe(2)
+
+    // No Spare Trousers scoring event on first hand (bonus was 0)
+    expect(after1.gamePlayState.scoringEvents.some(
+      e => 'source' in e && e.source === 'Spare Trousers'
+    )).toBe(false)
+  })
+
+  it('does not gain when non-Two Pair hand played', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.jokers = [initializeJoker(jokers.spareTrousersJoker, game)]
+    game.rounds[game.roundIndex].smallBlind.status = 'inProgress'
+    game.gamePhase = 'gameplay'
+    const started = reduceGame(game, { type: 'GAME_START' })
+
+    const hand: GameState = { ...started, gamePlayState: { ...started.gamePlayState, selectedHand: ['pair', []], score: { chips: 10, mult: 5 } } }
+    const after = reduceGame(hand, { type: 'HAND_SCORING_FINALIZE' })
+    const st = after.jokers.find(j => j.jokerId === 'spareTrousersJoker')
+    expect(st?.metadata?.multBonus).toBe(0)
+  })
+})

--- a/src/app/daily-card-game/domain/joker/jokers.ts
+++ b/src/app/daily-card-game/domain/joker/jokers.ts
@@ -1107,6 +1107,64 @@ export const baseballCardJoker: JokerDefinition = {
   rarity: 'rare',
 }
 
+export const spareTrousersJoker: JokerDefinition = {
+  id: 'spareTrousersJoker',
+  name: 'Spare Trousers',
+  description: 'This Joker gains +2 Mult if played hand contains a Two Pair',
+  price: 6,
+  effects: [
+    {
+      event: { type: 'GAME_START' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        const st = ctx.game.jokers.find(j => j.jokerId === 'spareTrousersJoker')
+        if (st) {
+          st.metadata = { ...st.metadata, multBonus: st.metadata?.multBonus ?? 0 }
+        }
+      },
+    },
+    {
+      event: { type: 'JOKER_ADDED' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        const st = ctx.game.jokers.find(j => j.jokerId === 'spareTrousersJoker')
+        if (st) {
+          st.metadata = { ...st.metadata, multBonus: 0 }
+        }
+      },
+    },
+    {
+      event: { type: 'HAND_SCORING_FINALIZE' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        const st = ctx.game.jokers.find(j => j.jokerId === 'spareTrousersJoker')
+        if (!st || !st.metadata) return
+
+        // Apply accumulated mult bonus
+        if (st.metadata.multBonus > 0) {
+          ctx.game.gamePlayState.scoringEvents.push({
+            id: uuid(),
+            type: 'mult',
+            value: st.metadata.multBonus,
+            source: 'Spare Trousers',
+          })
+          ctx.game.gamePlayState.score.mult += st.metadata.multBonus
+        }
+
+        // Check if hand contains Two Pair and gain +2
+        const selectedHand = ctx.game.gamePlayState.selectedHand
+        if (!selectedHand) return
+        const handId = selectedHand[0]
+        const handsContainingTwoPair = ['twoPair', 'fullHouse', 'flushHouse']
+        if (handsContainingTwoPair.includes(handId)) {
+          st.metadata.multBonus += 2
+        }
+      },
+    },
+  ],
+  rarity: 'uncommon',
+}
+
 export const jokers: Record<JokerDefinition['id'], JokerDefinition> = {
   jokerJoker,
   greedyJoker,
@@ -1140,6 +1198,7 @@ export const jokers: Record<JokerDefinition['id'], JokerDefinition> = {
   theFamilyJoker,
   stuntmanJoker,
   baseballCardJoker,
+  spareTrousersJoker,
 }
 
 /***


### PR DESCRIPTION
## Summary
- Adds **Spare Trousers** uncommon joker: gains +2 Mult each time a Two Pair hand is played
- Uses `metadata.multBonus` for persistent scaling across the run
- Checks hand types: twoPair, fullHouse, flushHouse

Closes #787

## Test plan
- [x] Gains +2 Mult after Two Pair is played
- [x] Does not gain when non-Two Pair hand played
- [x] All tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)