### PR TITLE
Implement Stone Joker uncommon joker (#783)

### DIFF
--- a/src/app/daily-card-game/domain/game/__tests__/stone-joker.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/stone-joker.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest'
+import { defaultGameState } from '@/app/daily-card-game/domain/game/default-game-state'
+import { reduceGame } from '@/app/daily-card-game/domain/game/reduce-game'
+import type { GameState } from '@/app/daily-card-game/domain/game/types'
+import { jokers } from '@/app/daily-card-game/domain/joker/jokers'
+import { initializeJoker } from '@/app/daily-card-game/domain/joker/utils'
+
+describe('Stone Joker', () => {
+  it('adds +25 Chips per Stone Card in deck', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.jokers = [initializeJoker(jokers.stoneJokerJoker, game)]
+    game.rounds[game.roundIndex].smallBlind.status = 'inProgress'
+    game.gamePhase = 'gameplay'
+
+    // Make 2 cards stone enchantment
+    const cardIds = game.ownedCardIds.slice(0, 2)
+    for (const id of cardIds) {
+      game.cards[id].flags.enchantment = 'stone'
+    }
+
+    const afterScore = reduceGame(game, { type: 'HAND_SCORING_FINALIZE' })
+    expect(afterScore.gamePlayState.scoringEvents.some(
+      e => 'source' in e && e.source === 'Stone Joker' && e.value === 50
+    )).toBe(true)
+  })
+
+  it('adds 0 Chips when no Stone Cards', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.jokers = [initializeJoker(jokers.stoneJokerJoker, game)]
+    game.rounds[game.roundIndex].smallBlind.status = 'inProgress'
+    game.gamePhase = 'gameplay'
+
+    const afterScore = reduceGame(game, { type: 'HAND_SCORING_FINALIZE' })
+    expect(afterScore.gamePlayState.scoringEvents.some(
+      e => 'source' in e && e.source === 'Stone Joker'
+    )).toBe(false)
+  })
+})

--- a/src/app/daily-card-game/domain/joker/jokers.ts
+++ b/src/app/daily-card-game/domain/joker/jokers.ts
@@ -1165,6 +1165,39 @@ export const spareTrousersJoker: JokerDefinition = {
   rarity: 'uncommon',
 }
 
+export const stoneJokerJoker: JokerDefinition = {
+  id: 'stoneJokerJoker',
+  name: 'Stone Joker',
+  description: '+25 Chips for each Stone Card in your full deck',
+  price: 6,
+  effects: [
+    {
+      event: { type: 'HAND_SCORING_FINALIZE' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        let stoneCount = 0
+        for (const cardId of ctx.game.ownedCardIds) {
+          const cardState = ctx.game.cards[cardId]
+          if (cardState && cardState.flags.enchantment === 'stone') {
+            stoneCount++
+          }
+        }
+        if (stoneCount > 0) {
+          const chipsBonus = 25 * stoneCount
+          ctx.game.gamePlayState.scoringEvents.push({
+            id: uuid(),
+            type: 'chips',
+            value: chipsBonus,
+            source: 'Stone Joker',
+          })
+          ctx.game.gamePlayState.score.chips += chipsBonus
+        }
+      },
+    },
+  ],
+  rarity: 'uncommon',
+}
+
 export const jokers: Record<JokerDefinition['id'], JokerDefinition> = {
   jokerJoker,
   greedyJoker,
@@ -1199,6 +1232,7 @@ export const jokers: Record<JokerDefinition['id'], JokerDefinition> = {
   stuntmanJoker,
   baseballCardJoker,
   spareTrousersJoker,
+  stoneJokerJoker,
 }
 
 /***


### PR DESCRIPTION
## Summary
- Adds **Stone Joker** uncommon joker: +25 Chips for each Stone Card in your full deck
- Counts cards with `enchantment === 'stone'` at scoring time

Closes #783

## Test plan
- [x] Adds +50 Chips with 2 Stone Cards
- [x] No effect when no Stone Cards
- [x] All 1051 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)