### PR TITLE
Implement Erosion uncommon joker (#779)

### DIFF
--- a/src/app/daily-card-game/domain/game/__tests__/erosion.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/erosion.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+import { defaultGameState } from '@/app/daily-card-game/domain/game/default-game-state'
+import { reduceGame } from '@/app/daily-card-game/domain/game/reduce-game'
+import type { GameState } from '@/app/daily-card-game/domain/game/types'
+import { jokers } from '@/app/daily-card-game/domain/joker/jokers'
+import { initializeJoker } from '@/app/daily-card-game/domain/joker/utils'
+
+describe('Erosion joker', () => {
+  it('adds +4 Mult per card below 52', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.jokers = [initializeJoker(jokers.erosionJoker, game)]
+    game.rounds[game.roundIndex].smallBlind.status = 'inProgress'
+    game.gamePhase = 'gameplay'
+    // Remove 3 cards from owned
+    game.ownedCardIds = game.ownedCardIds.slice(3)
+    const afterScore = reduceGame(game, { type: 'HAND_SCORING_FINALIZE' })
+    expect(afterScore.gamePlayState.scoringEvents.some(
+      e => 'source' in e && e.source === 'Erosion' && e.value === 12
+    )).toBe(true)
+  })
+
+  it('no effect with full 52-card deck', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.jokers = [initializeJoker(jokers.erosionJoker, game)]
+    game.rounds[game.roundIndex].smallBlind.status = 'inProgress'
+    game.gamePhase = 'gameplay'
+    // Default deck has 52 cards
+    const afterScore = reduceGame(game, { type: 'HAND_SCORING_FINALIZE' })
+    expect(afterScore.gamePlayState.scoringEvents.some(
+      e => 'source' in e && e.source === 'Erosion'
+    )).toBe(false)
+  })
+})

--- a/src/app/daily-card-game/domain/joker/jokers.ts
+++ b/src/app/daily-card-game/domain/joker/jokers.ts
@@ -1232,6 +1232,35 @@ export const steelJokerJoker: JokerDefinition = {
   rarity: 'uncommon',
 }
 
+export const erosionJoker: JokerDefinition = {
+  id: 'erosionJoker',
+  name: 'Erosion',
+  description: '+4 Mult for each card below starting deck size',
+  price: 6,
+  effects: [
+    {
+      event: { type: 'HAND_SCORING_FINALIZE' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        const startingDeckSize = 52
+        const currentDeckSize = ctx.game.ownedCardIds.length
+        const cardsBelow = Math.max(0, startingDeckSize - currentDeckSize)
+        if (cardsBelow > 0) {
+          const multBonus = 4 * cardsBelow
+          ctx.game.gamePlayState.scoringEvents.push({
+            id: uuid(),
+            type: 'mult',
+            value: multBonus,
+            source: 'Erosion',
+          })
+          ctx.game.gamePlayState.score.mult += multBonus
+        }
+      },
+    },
+  ],
+  rarity: 'uncommon',
+}
+
 export const jokers: Record<JokerDefinition['id'], JokerDefinition> = {
   jokerJoker,
   greedyJoker,
@@ -1268,6 +1297,7 @@ export const jokers: Record<JokerDefinition['id'], JokerDefinition> = {
   spareTrousersJoker,
   stoneJokerJoker,
   steelJokerJoker,
+  erosionJoker,
 }
 
 /***


### PR DESCRIPTION
## Summary
- Adds **Erosion** uncommon joker: +4 Mult for each card below the deck's starting size of 52
- Rewards card destruction strategies (3 cards destroyed = +12 Mult)

Closes #779

## Test plan
- [x] Adds +12 Mult when 3 cards removed from deck
- [x] No effect with full 52-card deck
- [x] All tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)