### PR TITLE
Implement Arrowhead uncommon joker (#799)

### DIFF
--- a/src/app/daily-card-game/domain/game/__tests__/arrowhead.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/arrowhead.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest'
+import { defaultGameState } from '@/app/daily-card-game/domain/game/default-game-state'
+import { reduceGame } from '@/app/daily-card-game/domain/game/reduce-game'
+import type { GameState } from '@/app/daily-card-game/domain/game/types'
+import { jokers } from '@/app/daily-card-game/domain/joker/jokers'
+import { initializeJoker } from '@/app/daily-card-game/domain/joker/utils'
+import { playingCards } from '@/app/daily-card-game/domain/playing-card/playing-cards'
+
+describe('Arrowhead joker', () => {
+  it('gives +50 Chips when a Spade card is scored', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.jokers = [initializeJoker(jokers.arrowheadJoker, game)]
+    game.rounds[game.roundIndex].smallBlind.status = 'inProgress'
+    game.gamePhase = 'gameplay'
+    const spadeId = Object.keys(game.cards).find(id =>
+      playingCards[game.cards[id].playingCardId]?.suit === 'spades'
+    )!
+    const afterScore = reduceGame({
+      ...game,
+      gamePlayState: { ...game.gamePlayState, cardsToScore: [game.cards[spadeId]] },
+    }, { type: 'CARD_SCORED' })
+    expect(afterScore.gamePlayState.scoringEvents.some(
+      e => 'source' in e && e.source === 'Arrowhead' && e.value === 50
+    )).toBe(true)
+  })
+
+  it('does not give chips for non-Spade cards', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.jokers = [initializeJoker(jokers.arrowheadJoker, game)]
+    game.rounds[game.roundIndex].smallBlind.status = 'inProgress'
+    game.gamePhase = 'gameplay'
+    const heartsId = Object.keys(game.cards).find(id =>
+      playingCards[game.cards[id].playingCardId]?.suit === 'hearts'
+    )!
+    const afterScore = reduceGame({
+      ...game,
+      gamePlayState: { ...game.gamePlayState, cardsToScore: [game.cards[heartsId]] },
+    }, { type: 'CARD_SCORED' })
+    expect(afterScore.gamePlayState.scoringEvents.some(
+      e => 'source' in e && e.source === 'Arrowhead'
+    )).toBe(false)
+  })
+})

--- a/src/app/daily-card-game/domain/joker/jokers.ts
+++ b/src/app/daily-card-game/domain/joker/jokers.ts
@@ -1283,6 +1283,29 @@ export const roughGemJoker: JokerDefinition = {
   rarity: 'uncommon',
 }
 
+export const arrowheadJoker: JokerDefinition = {
+  id: 'arrowheadJoker',
+  name: 'Arrowhead',
+  description: 'Played cards with Spade suit give +50 Chips when scored',
+  price: 7,
+  effects: [
+    {
+      event: { type: 'CARD_SCORED' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        bonusOnCardScored({
+          ctx,
+          suit: 'spades',
+          type: 'chips',
+          value: 50,
+          source: 'Arrowhead',
+        })
+      },
+    },
+  ],
+  rarity: 'uncommon',
+}
+
 export const jokers: Record<JokerDefinition['id'], JokerDefinition> = {
   jokerJoker,
   greedyJoker,
@@ -1321,6 +1344,7 @@ export const jokers: Record<JokerDefinition['id'], JokerDefinition> = {
   steelJokerJoker,
   erosionJoker,
   roughGemJoker,
+  arrowheadJoker,
 }
 
 /***


### PR DESCRIPTION
## Summary
- Adds **Arrowhead** uncommon joker: Spade suit cards give +50 Chips when scored
- Uses `bonusOnCardScored` helper for clean implementation

Closes #799

## Test plan
- [x] Gives +50 Chips when Spade card scored
- [x] No bonus for non-Spade cards
- [x] All 1059 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)