### PR TITLE
Implement Onyx Agate uncommon joker (#800)

### DIFF
--- a/src/app/daily-card-game/domain/game/__tests__/onyx-agate.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/onyx-agate.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest'
+import { defaultGameState } from '@/app/daily-card-game/domain/game/default-game-state'
+import { reduceGame } from '@/app/daily-card-game/domain/game/reduce-game'
+import type { GameState } from '@/app/daily-card-game/domain/game/types'
+import { jokers } from '@/app/daily-card-game/domain/joker/jokers'
+import { initializeJoker } from '@/app/daily-card-game/domain/joker/utils'
+import { playingCards } from '@/app/daily-card-game/domain/playing-card/playing-cards'
+
+describe('Onyx Agate joker', () => {
+  it('gives +7 Mult when a Club card is scored', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.jokers = [initializeJoker(jokers.onyxAgateJoker, game)]
+    game.rounds[game.roundIndex].smallBlind.status = 'inProgress'
+    game.gamePhase = 'gameplay'
+    const clubId = Object.keys(game.cards).find(id =>
+      playingCards[game.cards[id].playingCardId]?.suit === 'clubs'
+    )!
+    const afterScore = reduceGame({
+      ...game,
+      gamePlayState: { ...game.gamePlayState, cardsToScore: [game.cards[clubId]] },
+    }, { type: 'CARD_SCORED' })
+    expect(afterScore.gamePlayState.scoringEvents.some(
+      e => 'source' in e && e.source === 'Onyx Agate' && e.value === 7
+    )).toBe(true)
+  })
+
+  it('does not give mult for non-Club cards', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.jokers = [initializeJoker(jokers.onyxAgateJoker, game)]
+    game.rounds[game.roundIndex].smallBlind.status = 'inProgress'
+    game.gamePhase = 'gameplay'
+    const spadesId = Object.keys(game.cards).find(id =>
+      playingCards[game.cards[id].playingCardId]?.suit === 'spades'
+    )!
+    const afterScore = reduceGame({
+      ...game,
+      gamePlayState: { ...game.gamePlayState, cardsToScore: [game.cards[spadesId]] },
+    }, { type: 'CARD_SCORED' })
+    expect(afterScore.gamePlayState.scoringEvents.some(
+      e => 'source' in e && e.source === 'Onyx Agate'
+    )).toBe(false)
+  })
+})

--- a/src/app/daily-card-game/domain/joker/jokers.ts
+++ b/src/app/daily-card-game/domain/joker/jokers.ts
@@ -1306,6 +1306,23 @@ export const arrowheadJoker: JokerDefinition = {
   rarity: 'uncommon',
 }
 
+export const onyxAgateJoker: JokerDefinition = {
+  id: 'onyxAgateJoker',
+  name: 'Onyx Agate',
+  description: 'Played cards with Club suit give +7 Mult when scored',
+  price: 7,
+  effects: [
+    {
+      event: { type: 'CARD_SCORED' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        bonusOnCardScored({ ctx, suit: 'clubs', type: 'mult', value: 7, source: 'Onyx Agate' })
+      },
+    },
+  ],
+  rarity: 'uncommon',
+}
+
 export const jokers: Record<JokerDefinition['id'], JokerDefinition> = {
   jokerJoker,
   greedyJoker,
@@ -1345,6 +1362,7 @@ export const jokers: Record<JokerDefinition['id'], JokerDefinition> = {
   erosionJoker,
   roughGemJoker,
   arrowheadJoker,
+  onyxAgateJoker,
 }
 
 /***


### PR DESCRIPTION
## Summary
- Adds **Onyx Agate** uncommon joker: Club suit cards give +7 Mult when scored
- Uses `bonusOnCardScored` helper, same pattern as Arrowhead

Closes #800

## Test plan
- [x] Gives +7 Mult when Club card scored
- [x] No bonus for non-Club cards
- [x] All tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)