### PR TITLE
Implement Merry Andy uncommon joker (#809)

### DIFF
--- a/src/app/daily-card-game/domain/game/__tests__/merry-andy.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/merry-andy.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest'
+import { defaultGameState } from '@/app/daily-card-game/domain/game/default-game-state'
+import { reduceGame } from '@/app/daily-card-game/domain/game/reduce-game'
+import type { GameState } from '@/app/daily-card-game/domain/game/types'
+import { jokers } from '@/app/daily-card-game/domain/joker/jokers'
+import { initializeJoker } from '@/app/daily-card-game/domain/joker/utils'
+
+describe('Merry Andy joker', () => {
+  it('adds +3 discards and -1 hand size on GAME_START', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.jokers = [initializeJoker(jokers.merryAndyJoker, game)]
+    const started = reduceGame(game, { type: 'GAME_START' })
+    expect(started.maxDiscards).toBe(defaultGameState.maxDiscards + 3)
+    expect(started.handSizeModifier).toBe(-1)
+  })
+
+  it('reverts when sold', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.jokers = [initializeJoker(jokers.merryAndyJoker, game)]
+    const started = reduceGame(game, { type: 'GAME_START' })
+    const instance = started.jokers.find(j => j.jokerId === 'merryAndyJoker')!
+    const selected = { ...started, gamePlayState: { ...started.gamePlayState, selectedJokerId: instance.id } }
+    const afterSale = reduceGame(selected, { type: 'JOKER_SOLD' })
+    expect(afterSale.maxDiscards).toBe(defaultGameState.maxDiscards)
+    expect(afterSale.handSizeModifier).toBe(0)
+  })
+})

--- a/src/app/daily-card-game/domain/joker/jokers.ts
+++ b/src/app/daily-card-game/domain/joker/jokers.ts
@@ -1323,6 +1323,58 @@ export const onyxAgateJoker: JokerDefinition = {
   rarity: 'uncommon',
 }
 
+export const merryAndyJoker: JokerDefinition = {
+  id: 'merryAndyJoker',
+  name: 'Merry Andy',
+  description: '+3 discards each round, -1 hand size',
+  price: 7,
+  effects: [
+    {
+      event: { type: 'GAME_START' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        if (ctx.game.jokers.some(j => j.jokerId === 'merryAndyJoker')) {
+          ctx.game.maxDiscards += 3
+          ctx.game.gamePlayState.remainingDiscards += 3
+          ctx.game.handSizeModifier -= 1
+        }
+      },
+    },
+    {
+      event: { type: 'JOKER_ADDED' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        ctx.game.maxDiscards += 3
+        ctx.game.gamePlayState.remainingDiscards += 3
+        ctx.game.handSizeModifier -= 1
+      },
+    },
+    {
+      event: { type: 'JOKER_SOLD' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        if (!ctx.game.jokers.some(j => j.jokerId === 'merryAndyJoker')) {
+          ctx.game.maxDiscards -= 3
+          ctx.game.gamePlayState.remainingDiscards = Math.max(0, ctx.game.gamePlayState.remainingDiscards - 3)
+          ctx.game.handSizeModifier += 1
+        }
+      },
+    },
+    {
+      event: { type: 'JOKER_REMOVED' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        if (!ctx.game.jokers.some(j => j.jokerId === 'merryAndyJoker')) {
+          ctx.game.maxDiscards -= 3
+          ctx.game.gamePlayState.remainingDiscards = Math.max(0, ctx.game.gamePlayState.remainingDiscards - 3)
+          ctx.game.handSizeModifier += 1
+        }
+      },
+    },
+  ],
+  rarity: 'uncommon',
+}
+
 export const jokers: Record<JokerDefinition['id'], JokerDefinition> = {
   jokerJoker,
   greedyJoker,
@@ -1363,6 +1415,7 @@ export const jokers: Record<JokerDefinition['id'], JokerDefinition> = {
   roughGemJoker,
   arrowheadJoker,
   onyxAgateJoker,
+  merryAndyJoker,
 }
 
 /***


### PR DESCRIPTION
## Summary
- Adds **Merry Andy** uncommon joker: +3 discards each round, -1 hand size
- Uses `maxDiscards` and `handSizeModifier`, properly reverted on sell/remove

Closes #809

## Test plan
- [x] Adds +3 discards and -1 hand size on GAME_START
- [x] Reverts when sold
- [x] All tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)