### PR TITLE
Implement Flash Card uncommon joker (#786)

### DIFF
--- a/src/app/daily-card-game/domain/game/__tests__/flash-card.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/flash-card.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+import { defaultGameState } from '@/app/daily-card-game/domain/game/default-game-state'
+import { reduceGame } from '@/app/daily-card-game/domain/game/reduce-game'
+import type { GameState } from '@/app/daily-card-game/domain/game/types'
+import { jokers } from '@/app/daily-card-game/domain/joker/jokers'
+import { initializeJoker } from '@/app/daily-card-game/domain/joker/utils'
+
+describe('Flash Card joker', () => {
+  it('gains +2 Mult on SHOP_REROLL', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.jokers = [initializeJoker(jokers.flashCardJoker, game)]
+    game.gamePhase = 'shop'
+    game.shopState.isOpen = true
+    const started = reduceGame(game, { type: 'GAME_START' })
+    const afterReroll = reduceGame({ ...started, gamePhase: 'shop', shopState: { ...started.shopState, isOpen: true } }, { type: 'SHOP_REROLL' })
+    const fc = afterReroll.jokers.find(j => j.jokerId === 'flashCardJoker')
+    expect(fc?.metadata?.multBonus).toBe(2)
+  })
+
+  it('does not add Mult on HAND_SCORING_FINALIZE when no rerolls', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.jokers = [initializeJoker(jokers.flashCardJoker, game)]
+    game.rounds[game.roundIndex].smallBlind.status = 'inProgress'
+    game.gamePhase = 'gameplay'
+    const started = reduceGame(game, { type: 'GAME_START' })
+    const afterScore = reduceGame(started, { type: 'HAND_SCORING_FINALIZE' })
+    expect(afterScore.gamePlayState.scoringEvents.some(
+      e => 'source' in e && e.source === 'Flash Card'
+    )).toBe(false)
+  })
+})

--- a/src/app/daily-card-game/domain/game/reduce-game.ts
+++ b/src/app/daily-card-game/domain/game/reduce-game.ts
@@ -215,6 +215,8 @@ export function reduceGame(game: GameState, event: GameEvent): GameState {
       }
       case 'SHOP_REROLL': {
         handleShopReroll(draft)
+        const ctx = getEffectContext(draft, event)
+        dispatchEffects(event, ctx, collectEffects(ctx.game))
         return
       }
       case 'SHOP_OPEN_PACK': {

--- a/src/app/daily-card-game/domain/joker/jokers.ts
+++ b/src/app/daily-card-game/domain/joker/jokers.ts
@@ -1375,6 +1375,62 @@ export const merryAndyJoker: JokerDefinition = {
   rarity: 'uncommon',
 }
 
+export const flashCardJoker: JokerDefinition = {
+  id: 'flashCardJoker',
+  name: 'Flash Card',
+  description: 'This Joker gains +2 Mult per reroll in the shop',
+  price: 5,
+  effects: [
+    {
+      event: { type: 'GAME_START' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        const fc = ctx.game.jokers.find(j => j.jokerId === 'flashCardJoker')
+        if (fc) {
+          fc.metadata = { ...fc.metadata, multBonus: fc.metadata?.multBonus ?? 0 }
+        }
+      },
+    },
+    {
+      event: { type: 'JOKER_ADDED' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        const fc = ctx.game.jokers.find(j => j.jokerId === 'flashCardJoker')
+        if (fc) {
+          fc.metadata = { ...fc.metadata, multBonus: 0 }
+        }
+      },
+    },
+    {
+      event: { type: 'SHOP_REROLL' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        const fc = ctx.game.jokers.find(j => j.jokerId === 'flashCardJoker')
+        if (fc) {
+          if (!fc.metadata) fc.metadata = { multBonus: 0 }
+          fc.metadata.multBonus += 2
+        }
+      },
+    },
+    {
+      event: { type: 'HAND_SCORING_FINALIZE' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        const fc = ctx.game.jokers.find(j => j.jokerId === 'flashCardJoker')
+        if (!fc || !fc.metadata || fc.metadata.multBonus <= 0) return
+        ctx.game.gamePlayState.scoringEvents.push({
+          id: uuid(),
+          type: 'mult',
+          value: fc.metadata.multBonus,
+          source: 'Flash Card',
+        })
+        ctx.game.gamePlayState.score.mult += fc.metadata.multBonus
+      },
+    },
+  ],
+  rarity: 'uncommon',
+}
+
 export const jokers: Record<JokerDefinition['id'], JokerDefinition> = {
   jokerJoker,
   greedyJoker,
@@ -1416,6 +1472,7 @@ export const jokers: Record<JokerDefinition['id'], JokerDefinition> = {
   arrowheadJoker,
   onyxAgateJoker,
   merryAndyJoker,
+  flashCardJoker,
 }
 
 /***


### PR DESCRIPTION
## Summary
- Adds **Flash Card** uncommon joker: gains +2 Mult per shop reroll
- Uses `metadata.multBonus` for persistent scaling
- Also fixes SHOP_REROLL event dispatching so joker effects fire on reroll

Closes #786

## Test plan
- [x] Gains +2 Mult on SHOP_REROLL
- [x] No Mult bonus when no rerolls occurred
- [x] All 1065 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)