### PR TITLE
Implement Seeing Double uncommon joker (#805)

### DIFF
--- a/src/app/daily-card-game/domain/game/__tests__/seeing-double.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/seeing-double.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest'
+import { defaultGameState } from '@/app/daily-card-game/domain/game/default-game-state'
+import { reduceGame } from '@/app/daily-card-game/domain/game/reduce-game'
+import type { GameState } from '@/app/daily-card-game/domain/game/types'
+import { jokers } from '@/app/daily-card-game/domain/joker/jokers'
+import { initializeJoker } from '@/app/daily-card-game/domain/joker/utils'
+import { playingCards } from '@/app/daily-card-game/domain/playing-card/playing-cards'
+
+describe('Seeing Double joker', () => {
+  it('applies X2 Mult with Club and non-Club cards', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.jokers = [initializeJoker(jokers.seeingDoubleJoker, game)]
+    game.rounds[game.roundIndex].smallBlind.status = 'inProgress'
+    game.gamePhase = 'gameplay'
+
+    // Find a club card and a hearts card
+    const clubId = Object.keys(game.cards).find(id =>
+      playingCards[game.cards[id].playingCardId]?.suit === 'clubs'
+    )!
+    const heartsId = Object.keys(game.cards).find(id =>
+      playingCards[game.cards[id].playingCardId]?.suit === 'hearts'
+    )!
+
+    game.gamePlayState.selectedHand = ['pair', [game.cards[clubId], game.cards[heartsId]]]
+    game.gamePlayState.score = { chips: 10, mult: 5 }
+
+    const after = reduceGame(game, { type: 'HAND_SCORING_FINALIZE' })
+    expect(after.gamePlayState.scoringEvents.some(
+      e => 'source' in e && e.source === 'Seeing Double' && 'operator' in e && e.operator === 'x'
+    )).toBe(true)
+  })
+
+  it('does not apply with only Club cards', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.jokers = [initializeJoker(jokers.seeingDoubleJoker, game)]
+    game.rounds[game.roundIndex].smallBlind.status = 'inProgress'
+    game.gamePhase = 'gameplay'
+
+    const clubIds = Object.keys(game.cards).filter(id =>
+      playingCards[game.cards[id].playingCardId]?.suit === 'clubs'
+    ).slice(0, 2)
+
+    game.gamePlayState.selectedHand = ['pair', clubIds.map(id => game.cards[id])]
+    game.gamePlayState.score = { chips: 10, mult: 5 }
+
+    const after = reduceGame(game, { type: 'HAND_SCORING_FINALIZE' })
+    expect(after.gamePlayState.scoringEvents.some(
+      e => 'source' in e && e.source === 'Seeing Double'
+    )).toBe(false)
+  })
+})

--- a/src/app/daily-card-game/domain/joker/jokers.ts
+++ b/src/app/daily-card-game/domain/joker/jokers.ts
@@ -1466,6 +1466,49 @@ export const baronJoker: JokerDefinition = {
   rarity: 'rare',
 }
 
+export const seeingDoubleJoker: JokerDefinition = {
+  id: 'seeingDoubleJoker',
+  name: 'Seeing Double',
+  description: 'X2 Mult if played hand has a scoring Club card and a scoring card of any other suit',
+  price: 6,
+  effects: [
+    {
+      event: { type: 'HAND_SCORING_FINALIZE' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        const selectedHand = ctx.game.gamePlayState.selectedHand
+        if (!selectedHand) return
+        const handCards = selectedHand[1]
+        if (!handCards || handCards.length === 0) return
+
+        let hasClub = false
+        let hasOtherSuit = false
+        for (const card of handCards) {
+          const cardDef = playingCards[card.playingCardId]
+          if (!cardDef) continue
+          if (cardDef.suit === 'clubs') {
+            hasClub = true
+          } else {
+            hasOtherSuit = true
+          }
+        }
+
+        if (hasClub && hasOtherSuit) {
+          ctx.game.gamePlayState.scoringEvents.push({
+            id: uuid(),
+            type: 'mult',
+            operator: 'x',
+            value: 2,
+            source: 'Seeing Double',
+          })
+          ctx.game.gamePlayState.score.mult *= 2
+        }
+      },
+    },
+  ],
+  rarity: 'uncommon',
+}
+
 export const jokers: Record<JokerDefinition['id'], JokerDefinition> = {
   jokerJoker,
   greedyJoker,
@@ -1509,6 +1552,7 @@ export const jokers: Record<JokerDefinition['id'], JokerDefinition> = {
   merryAndyJoker,
   flashCardJoker,
   baronJoker,
+  seeingDoubleJoker,
 }
 
 /***


### PR DESCRIPTION
## Summary
- Adds **Seeing Double** uncommon joker: X2 Mult when played hand has a Club card and a card of any other suit
- Checks scored cards (selectedHand[1]) for suit diversity

Closes #805

## Test plan
- [x] Applies X2 Mult with Club + non-Club cards
- [x] Does not apply with only Club cards
- [x] All tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)