### PR TITLE
Implement Fortune Teller common joker (#750)

### DIFF
--- a/src/app/daily-card-game/domain/game/__tests__/fortune-teller.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/fortune-teller.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest'
+import { defaultGameState } from '@/app/daily-card-game/domain/game/default-game-state'
+import { reduceGame } from '@/app/daily-card-game/domain/game/reduce-game'
+import type { GameState } from '@/app/daily-card-game/domain/game/types'
+import { jokers } from '@/app/daily-card-game/domain/joker/jokers'
+import { initializeJoker } from '@/app/daily-card-game/domain/joker/utils'
+
+describe('Fortune Teller joker', () => {
+  it('gives +1 Mult per Tarot card used', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.jokers = [initializeJoker(jokers.fortuneTellerJoker, game)]
+    game.rounds[game.roundIndex].smallBlind.status = 'inProgress'
+    game.gamePhase = 'gameplay'
+    // Add 3 used tarot cards
+    game.consumablesUsed = [
+      { id: '1', type: 'tarotCard', name: 'The Fool', isFaceUp: true } as any,
+      { id: '2', type: 'tarotCard', name: 'The Magician', isFaceUp: true } as any,
+      { id: '3', type: 'tarotCard', name: 'The Empress', isFaceUp: true } as any,
+    ]
+    const after = reduceGame(game, { type: 'HAND_SCORING_FINALIZE' })
+    expect(after.gamePlayState.scoringEvents.some(
+      e => 'source' in e && e.source === 'Fortune Teller' && e.value === 3
+    )).toBe(true)
+  })
+
+  it('no effect when no Tarot cards used', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.jokers = [initializeJoker(jokers.fortuneTellerJoker, game)]
+    game.rounds[game.roundIndex].smallBlind.status = 'inProgress'
+    game.gamePhase = 'gameplay'
+    const after = reduceGame(game, { type: 'HAND_SCORING_FINALIZE' })
+    expect(after.gamePlayState.scoringEvents.some(
+      e => 'source' in e && e.source === 'Fortune Teller'
+    )).toBe(false)
+  })
+})

--- a/src/app/daily-card-game/domain/joker/jokers.ts
+++ b/src/app/daily-card-game/domain/joker/jokers.ts
@@ -1690,6 +1690,32 @@ export const shootTheMoonJoker: JokerDefinition = {
   rarity: 'common',
 }
 
+export const fortuneTellerJoker: JokerDefinition = {
+  id: 'fortuneTellerJoker',
+  name: 'Fortune Teller',
+  description: '+1 Mult per Tarot card used this run',
+  price: 6,
+  effects: [
+    {
+      event: { type: 'HAND_SCORING_FINALIZE' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        const tarotCount = ctx.game.consumablesUsed.filter(c => c.type === 'tarotCard').length
+        if (tarotCount > 0) {
+          ctx.game.gamePlayState.scoringEvents.push({
+            id: uuid(),
+            type: 'mult',
+            value: tarotCount,
+            source: 'Fortune Teller',
+          })
+          ctx.game.gamePlayState.score.mult += tarotCount
+        }
+      },
+    },
+  ],
+  rarity: 'common',
+}
+
 export const jokers: Record<JokerDefinition['id'], JokerDefinition> = {
   jokerJoker,
   greedyJoker,
@@ -1739,6 +1765,7 @@ export const jokers: Record<JokerDefinition['id'], JokerDefinition> = {
   jugglerJoker,
   goldenJokerJoker,
   shootTheMoonJoker,
+  fortuneTellerJoker,
 }
 
 /***


### PR DESCRIPTION
## Summary
- Adds **Fortune Teller** common joker: +1 Mult per Tarot card used this run
- Counts `tarotCard` entries in `consumablesUsed` at scoring time

Closes #750

## Test plan
- [x] Gives +3 Mult with 3 Tarot cards used
- [x] No effect when no Tarot cards used
- [x] All tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)