### PR TITLE
Implement Swashbuckler common joker (#736)

### DIFF
--- a/src/app/daily-card-game/domain/game/__tests__/swashbuckler.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/swashbuckler.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest'
+import { defaultGameState } from '@/app/daily-card-game/domain/game/default-game-state'
+import { reduceGame } from '@/app/daily-card-game/domain/game/reduce-game'
+import type { GameState } from '@/app/daily-card-game/domain/game/types'
+import { jokers } from '@/app/daily-card-game/domain/joker/jokers'
+import { initializeJoker } from '@/app/daily-card-game/domain/joker/utils'
+
+describe('Swashbuckler joker', () => {
+  it('adds sell value of other jokers as Mult', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    // Swashbuckler ($4, sell=2) + jokerJoker ($2, sell=1) + halfJoker ($5, sell=2)
+    game.jokers = [
+      initializeJoker(jokers.swashbucklerJoker, game),
+      initializeJoker(jokers.jokerJoker, game),
+      initializeJoker(jokers.halfJoker, game),
+    ]
+    game.rounds[game.roundIndex].smallBlind.status = 'inProgress'
+    game.gamePhase = 'gameplay'
+    const after = reduceGame(game, { type: 'HAND_SCORING_FINALIZE' })
+    // jokerJoker sell = floor(2/2)=1, halfJoker sell = floor(5/2)=2, total=3
+    expect(after.gamePlayState.scoringEvents.some(
+      e => 'source' in e && e.source === 'Swashbuckler' && e.value === 3
+    )).toBe(true)
+  })
+
+  it('gives minimum +1 Mult when alone', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.jokers = [initializeJoker(jokers.swashbucklerJoker, game)]
+    game.rounds[game.roundIndex].smallBlind.status = 'inProgress'
+    game.gamePhase = 'gameplay'
+    const after = reduceGame(game, { type: 'HAND_SCORING_FINALIZE' })
+    expect(after.gamePlayState.scoringEvents.some(
+      e => 'source' in e && e.source === 'Swashbuckler' && e.value === 1
+    )).toBe(true)
+  })
+})

--- a/src/app/daily-card-game/domain/joker/jokers.ts
+++ b/src/app/daily-card-game/domain/joker/jokers.ts
@@ -1801,7 +1801,40 @@ export const abstractJokerJoker: JokerDefinition = {
   rarity: 'common',
 }
 
+export const swashbucklerJoker: JokerDefinition = {
+  id: 'swashbucklerJoker',
+  name: 'Swashbuckler',
+  description: 'Adds the sell value of all other owned Jokers to Mult',
+  price: 4,
+  effects: [
+    {
+      event: { type: 'HAND_SCORING_FINALIZE' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        let totalSellValue = 0
+        for (const jokerState of ctx.game.jokers) {
+          if (jokerState.jokerId === 'swashbucklerJoker') continue
+          const jokerDef = jokers[jokerState.jokerId]
+          if (jokerDef) {
+            totalSellValue += Math.floor(jokerDef.price / 2)
+          }
+        }
+        const multBonus = Math.max(1, totalSellValue)
+        ctx.game.gamePlayState.scoringEvents.push({
+          id: uuid(),
+          type: 'mult',
+          value: multBonus,
+          source: 'Swashbuckler',
+        })
+        ctx.game.gamePlayState.score.mult += multBonus
+      },
+    },
+  ],
+  rarity: 'common',
+}
+
 export const jokers: Record<JokerDefinition['id'], JokerDefinition> = {
+  swashbucklerJoker,
   jokerJoker,
   greedyJoker,
   jollyJoker,


### PR DESCRIPTION
## Summary
- Adds **Swashbuckler** common joker: adds sell value of all other owned Jokers to Mult (min +1)

Closes #736

## Test plan
- [x] Adds correct sell value sum as Mult with multiple jokers
- [x] Gives minimum +1 Mult when alone
- [x] All 1087 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)