### PR TITLE
Implement Even Steven common joker (#715)

### DIFF
--- a/src/app/daily-card-game/domain/game/__tests__/even-steven.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/even-steven.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest'
+import { defaultGameState } from '@/app/daily-card-game/domain/game/default-game-state'
+import { reduceGame } from '@/app/daily-card-game/domain/game/reduce-game'
+import type { GameState } from '@/app/daily-card-game/domain/game/types'
+import { jokers } from '@/app/daily-card-game/domain/joker/jokers'
+import { initializeJoker } from '@/app/daily-card-game/domain/joker/utils'
+import { playingCards } from '@/app/daily-card-game/domain/playing-card/playing-cards'
+
+describe('Even Steven joker', () => {
+  it('gives +4 Mult on even-rank cards', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.jokers = [initializeJoker(jokers.evenStevenJoker, game)]
+    game.rounds[game.roundIndex].smallBlind.status = 'inProgress'
+    game.gamePhase = 'gameplay'
+    const sixId = Object.keys(game.cards).find(id =>
+      playingCards[game.cards[id].playingCardId]?.value === '6'
+    )!
+    const after = reduceGame({
+      ...game,
+      gamePlayState: { ...game.gamePlayState, cardsToScore: [game.cards[sixId]] },
+    }, { type: 'CARD_SCORED' })
+    expect(after.gamePlayState.scoringEvents.some(
+      e => 'source' in e && e.source === 'Even Steven' && e.value === 4
+    )).toBe(true)
+  })
+
+  it('no effect on odd-rank cards', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.jokers = [initializeJoker(jokers.evenStevenJoker, game)]
+    game.rounds[game.roundIndex].smallBlind.status = 'inProgress'
+    game.gamePhase = 'gameplay'
+    const sevenId = Object.keys(game.cards).find(id =>
+      playingCards[game.cards[id].playingCardId]?.value === '7'
+    )!
+    const after = reduceGame({
+      ...game,
+      gamePlayState: { ...game.gamePlayState, cardsToScore: [game.cards[sevenId]] },
+    }, { type: 'CARD_SCORED' })
+    expect(after.gamePlayState.scoringEvents.some(
+      e => 'source' in e && e.source === 'Even Steven'
+    )).toBe(false)
+  })
+})

--- a/src/app/daily-card-game/domain/joker/jokers.ts
+++ b/src/app/daily-card-game/domain/joker/jokers.ts
@@ -1935,6 +1935,36 @@ export const scholarJoker: JokerDefinition = {
   rarity: 'common',
 }
 
+export const evenStevenJoker: JokerDefinition = {
+  id: 'evenStevenJoker',
+  name: 'Even Steven',
+  description: '+4 Mult if played card has even rank',
+  price: 4,
+  effects: [
+    {
+      event: { type: 'CARD_SCORED' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        const scoredCard = ctx.scoredCards?.[0]
+        if (!scoredCard) return
+        const cardDef = playingCards[scoredCard.playingCardId]
+        if (!cardDef) return
+        const evenValues = ['2', '4', '6', '8', '10']
+        if (evenValues.includes(cardDef.value)) {
+          ctx.game.gamePlayState.scoringEvents.push({
+            id: uuid(),
+            type: 'mult',
+            value: 4,
+            source: 'Even Steven',
+          })
+          ctx.game.gamePlayState.score.mult += 4
+        }
+      },
+    },
+  ],
+  rarity: 'common',
+}
+
 export const jokers: Record<JokerDefinition['id'], JokerDefinition> = {
   swashbucklerJoker,
   walkieTalkieJoker,
@@ -1992,6 +2022,7 @@ export const jokers: Record<JokerDefinition['id'], JokerDefinition> = {
   abstractJokerJoker,
   smileyFaceJoker,
   scholarJoker,
+  evenStevenJoker,
 }
 
 /***


### PR DESCRIPTION
## Summary
- Adds **Even Steven** common joker: +4 Mult when even-rank card (2, 4, 6, 8, 10) is scored

Closes #715

## Test plan
- [x] Gives +4 Mult on even-rank cards
- [x] No effect on odd-rank cards
- [x] All tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)