### PR TITLE
Implement Odd Todd common joker (#716)

### DIFF
--- a/src/app/daily-card-game/domain/game/__tests__/odd-todd.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/odd-todd.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest'
+import { defaultGameState } from '@/app/daily-card-game/domain/game/default-game-state'
+import { reduceGame } from '@/app/daily-card-game/domain/game/reduce-game'
+import type { GameState } from '@/app/daily-card-game/domain/game/types'
+import { jokers } from '@/app/daily-card-game/domain/joker/jokers'
+import { initializeJoker } from '@/app/daily-card-game/domain/joker/utils'
+import { playingCards } from '@/app/daily-card-game/domain/playing-card/playing-cards'
+
+describe('Odd Todd joker', () => {
+  it('gives +31 Chips on odd-rank cards', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.jokers = [initializeJoker(jokers.oddToddJoker, game)]
+    game.rounds[game.roundIndex].smallBlind.status = 'inProgress'
+    game.gamePhase = 'gameplay'
+    const sevenId = Object.keys(game.cards).find(id =>
+      playingCards[game.cards[id].playingCardId]?.value === '7'
+    )!
+    const after = reduceGame({
+      ...game,
+      gamePlayState: { ...game.gamePlayState, cardsToScore: [game.cards[sevenId]] },
+    }, { type: 'CARD_SCORED' })
+    expect(after.gamePlayState.scoringEvents.some(
+      e => 'source' in e && e.source === 'Odd Todd' && e.value === 31
+    )).toBe(true)
+  })
+
+  it('no effect on even-rank cards', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.jokers = [initializeJoker(jokers.oddToddJoker, game)]
+    game.rounds[game.roundIndex].smallBlind.status = 'inProgress'
+    game.gamePhase = 'gameplay'
+    const sixId = Object.keys(game.cards).find(id =>
+      playingCards[game.cards[id].playingCardId]?.value === '6'
+    )!
+    const after = reduceGame({
+      ...game,
+      gamePlayState: { ...game.gamePlayState, cardsToScore: [game.cards[sixId]] },
+    }, { type: 'CARD_SCORED' })
+    expect(after.gamePlayState.scoringEvents.some(
+      e => 'source' in e && e.source === 'Odd Todd'
+    )).toBe(false)
+  })
+})

--- a/src/app/daily-card-game/domain/joker/jokers.ts
+++ b/src/app/daily-card-game/domain/joker/jokers.ts
@@ -1965,6 +1965,36 @@ export const evenStevenJoker: JokerDefinition = {
   rarity: 'common',
 }
 
+export const oddToddJoker: JokerDefinition = {
+  id: 'oddToddJoker',
+  name: 'Odd Todd',
+  description: '+31 Chips if played card has odd rank',
+  price: 4,
+  effects: [
+    {
+      event: { type: 'CARD_SCORED' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        const scoredCard = ctx.scoredCards?.[0]
+        if (!scoredCard) return
+        const cardDef = playingCards[scoredCard.playingCardId]
+        if (!cardDef) return
+        const oddValues = ['A', '3', '5', '7', '9']
+        if (oddValues.includes(cardDef.value)) {
+          ctx.game.gamePlayState.scoringEvents.push({
+            id: uuid(),
+            type: 'chips',
+            value: 31,
+            source: 'Odd Todd',
+          })
+          ctx.game.gamePlayState.score.chips += 31
+        }
+      },
+    },
+  ],
+  rarity: 'common',
+}
+
 export const jokers: Record<JokerDefinition['id'], JokerDefinition> = {
   swashbucklerJoker,
   walkieTalkieJoker,
@@ -2023,6 +2053,7 @@ export const jokers: Record<JokerDefinition['id'], JokerDefinition> = {
   smileyFaceJoker,
   scholarJoker,
   evenStevenJoker,
+  oddToddJoker,
 }
 
 /***


### PR DESCRIPTION
## Summary
- Adds **Odd Todd** common joker: +31 Chips when odd-rank card (A, 3, 5, 7, 9) is scored
- Companion to Even Steven (#715)

Closes #716

## Test plan
- [x] Gives +31 Chips on odd-rank cards
- [x] No effect on even-rank cards
- [x] All tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)