### PR TITLE
Implement Chaos the Clown common joker (#713)

### DIFF
--- a/src/app/daily-card-game/domain/game/__tests__/chaos-the-clown.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/chaos-the-clown.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest'
+
+import { defaultGameState } from '@/app/daily-card-game/domain/game/default-game-state'
+import { reduceGame } from '@/app/daily-card-game/domain/game/reduce-game'
+import type { GameState } from '@/app/daily-card-game/domain/game/types'
+import { jokers } from '@/app/daily-card-game/domain/joker/jokers'
+import { initializeJoker } from '@/app/daily-card-game/domain/joker/utils'
+
+describe('Chaos the Clown joker', () => {
+  it('adds 1 freeReroll when the shop opens', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.jokers = [initializeJoker(jokers.chaosTheClown, game)]
+    const started = reduceGame(game, { type: 'GAME_START' })
+
+    expect(started.shopState.freeRerolls).toBe(0)
+
+    const afterShopOpen = reduceGame(started, { type: 'SHOP_OPEN' })
+    expect(afterShopOpen.shopState.freeRerolls).toBe(1)
+  })
+
+  it('allows one free reroll before charging money', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.jokers = [initializeJoker(jokers.chaosTheClown, game)]
+    game.money = 10
+
+    const started = reduceGame(game, { type: 'GAME_START' })
+    const afterShopOpen = reduceGame(started, { type: 'SHOP_OPEN' })
+
+    expect(afterShopOpen.shopState.freeRerolls).toBe(1)
+    const moneyBeforeReroll = afterShopOpen.money
+
+    // First reroll should be free
+    const afterFreeReroll = reduceGame(afterShopOpen, { type: 'SHOP_REROLL' })
+    expect(afterFreeReroll.money).toBe(moneyBeforeReroll)
+    expect(afterFreeReroll.shopState.freeRerolls).toBe(0)
+
+    // Second reroll should cost money
+    const moneyAfterFreeReroll = afterFreeReroll.money
+    const afterPaidReroll = reduceGame(afterFreeReroll, { type: 'SHOP_REROLL' })
+    expect(afterPaidReroll.money).toBeLessThan(moneyAfterFreeReroll)
+  })
+
+  it('does not grant a free reroll without the joker', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.money = 10
+
+    const started = reduceGame(game, { type: 'GAME_START' })
+    const afterShopOpen = reduceGame(started, { type: 'SHOP_OPEN' })
+
+    expect(afterShopOpen.shopState.freeRerolls).toBe(0)
+  })
+})

--- a/src/app/daily-card-game/domain/game/default-game-state.ts
+++ b/src/app/daily-card-game/domain/game/default-game-state.ts
@@ -95,6 +95,7 @@ const gameState: GameState = {
         polychrome: 0.15,
       },
     },
+    freeRerolls: 0,
     priceMultiplier: 1,
     rerollsUsed: 0,
     selectedCardId: null,

--- a/src/app/daily-card-game/domain/game/handlers/gameplay.ts
+++ b/src/app/daily-card-game/domain/game/handlers/gameplay.ts
@@ -338,6 +338,7 @@ export function handleHandScoringDoneCardScoring(draft: GameState) {
 
   // Reset shop state for the new shop session
   draft.shopState.cardsForSale = []
+  draft.shopState.freeRerolls = 0
   draft.shopState.packsForSale = []
   draft.shopState.rerollsUsed = 0
   draft.shopState.selectedCardId = null

--- a/src/app/daily-card-game/domain/game/handlers/shop.ts
+++ b/src/app/daily-card-game/domain/game/handlers/shop.ts
@@ -309,7 +309,11 @@ export function handleShopReroll(draft: GameState) {
     draft.shopState.maxCardsForSale,
     randomBuyableCardsSeed
   )
-  draft.money -= draft.shopState.baseRerollPrice + draft.shopState.rerollsUsed
+  if (draft.shopState.freeRerolls > 0) {
+    draft.shopState.freeRerolls -= 1
+  } else {
+    draft.money -= draft.shopState.baseRerollPrice + draft.shopState.rerollsUsed
+  }
 }
 
 export function handleShopOpenPack(draft: GameState, event: ShopOpenPackEvent) {

--- a/src/app/daily-card-game/domain/joker/jokers.ts
+++ b/src/app/daily-card-game/domain/joker/jokers.ts
@@ -2207,6 +2207,23 @@ export const raisedFist: JokerDefinition = {
   rarity: 'common',
 }
 
+export const chaosTheClown: JokerDefinition = {
+  id: 'chaosTheClown',
+  name: 'Chaos the Clown',
+  description: '1 free Reroll per shop',
+  price: 4,
+  effects: [
+    {
+      event: { type: 'SHOP_OPEN' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        ctx.game.shopState.freeRerolls += 1
+      },
+    },
+  ],
+  rarity: 'common',
+}
+
 export const jokers: Record<JokerDefinition['id'], JokerDefinition> = {
   swashbucklerJoker,
   walkieTalkieJoker,
@@ -2272,6 +2289,7 @@ export const jokers: Record<JokerDefinition['id'], JokerDefinition> = {
   eightBall,
   misprint,
   raisedFist,
+  chaosTheClown,
 }
 
 /***

--- a/src/app/daily-card-game/domain/shop/types.ts
+++ b/src/app/daily-card-game/domain/shop/types.ts
@@ -28,6 +28,7 @@ export interface ShopState {
       polychrome: number
     }
   }
+  freeRerolls: number
   priceMultiplier: number
   rerollsUsed: number
   selectedCardId: string | null


### PR DESCRIPTION
## Summary
- Implements the Chaos the Clown common joker: 1 free Reroll per shop visit
- Adds `freeRerolls` infrastructure to ShopState for reusable free reroll mechanics
- Modifies shop reroll handler to consume free rerolls before charging money
- Resets freeRerolls on round end alongside other shop state
- Adds 3 unit tests

Closes #713

## Test plan
- [x] Unit tests pass (`npx vitest run chaos-the-clown`)
- [x] No TypeScript errors in modified files
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)