### PR TITLE
Implement Business Card common joker (#718)

### DIFF
--- a/src/app/daily-card-game/domain/game/__tests__/business-card.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/business-card.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from 'vitest'
+import { defaultGameState } from '@/app/daily-card-game/domain/game/default-game-state'
+import { reduceGame } from '@/app/daily-card-game/domain/game/reduce-game'
+import type { GameState } from '@/app/daily-card-game/domain/game/types'
+import { jokers } from '@/app/daily-card-game/domain/joker/jokers'
+import { initializeJoker } from '@/app/daily-card-game/domain/joker/utils'
+import type { PlayingCardState } from '@/app/daily-card-game/domain/playing-card/types'
+import { playingCards } from '@/app/daily-card-game/domain/playing-card/playing-cards'
+
+// With gameSeed='test-seed', roundIndex=1 (default game state starts at roundIndex 1):
+// card id 'card-1' produces roll=1 (success)
+// card id 'card-0' produces roll=2 (failure)
+const GAME_SEED = 'test-seed'
+
+function makeFaceCard(id: string, playingCardId: string = 'J_hearts'): PlayingCardState {
+  return {
+    id,
+    playingCardId,
+    bonusChips: 0,
+    isFaceUp: true,
+    flags: { edition: 'normal', enchantment: 'none', seal: 'none' },
+  }
+}
+
+describe('Business Card joker', () => {
+  it('does not trigger on non-face cards', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.jokers = [initializeJoker(jokers.businessCard, game)]
+    game.rounds[game.roundIndex].smallBlind.status = 'inProgress'
+    game.gamePhase = 'gameplay'
+    game.gameSeed = GAME_SEED
+
+    const eightId = Object.keys(game.cards).find(
+      id => playingCards[game.cards[id].playingCardId]?.value === '8'
+    )!
+
+    const moneyBefore = game.money
+    const after = reduceGame(
+      { ...game, gamePlayState: { ...game.gamePlayState, cardsToScore: [game.cards[eightId]] } },
+      { type: 'CARD_SCORED' }
+    )
+    expect(after.money).toBe(moneyBefore)
+  })
+
+  it('does not trigger on Ace', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.jokers = [initializeJoker(jokers.businessCard, game)]
+    game.rounds[game.roundIndex].smallBlind.status = 'inProgress'
+    game.gamePhase = 'gameplay'
+    game.gameSeed = GAME_SEED
+
+    const aceId = Object.keys(game.cards).find(
+      id => playingCards[game.cards[id].playingCardId]?.value === 'A'
+    )!
+
+    const moneyBefore = game.money
+    const after = reduceGame(
+      { ...game, gamePlayState: { ...game.gamePlayState, cardsToScore: [game.cards[aceId]] } },
+      { type: 'CARD_SCORED' }
+    )
+    expect(after.money).toBe(moneyBefore)
+  })
+
+  it('gives $2 when a face card is scored and roll succeeds (roll=1)', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.jokers = [initializeJoker(jokers.businessCard, game)]
+    game.rounds[game.roundIndex].smallBlind.status = 'inProgress'
+    game.gamePhase = 'gameplay'
+    game.gameSeed = GAME_SEED
+
+    // card-1 with gameSeed=test-seed, roundIndex=1 produces roll=1 (success)
+    const card = makeFaceCard('card-1', 'J_hearts')
+    game.cards['card-1'] = card
+
+    const moneyBefore = game.money
+    const after = reduceGame(
+      { ...game, gamePlayState: { ...game.gamePlayState, cardsToScore: [card] } },
+      { type: 'CARD_SCORED' }
+    )
+    expect(after.money).toBe(moneyBefore + 2)
+  })
+
+  it('does not give money when roll fails (roll!=1)', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.jokers = [initializeJoker(jokers.businessCard, game)]
+    game.rounds[game.roundIndex].smallBlind.status = 'inProgress'
+    game.gamePhase = 'gameplay'
+    game.gameSeed = GAME_SEED
+
+    // card-0 with gameSeed=test-seed, roundIndex=1 produces roll=2 (failure)
+    const card = makeFaceCard('card-0', 'Q_spades')
+    game.cards['card-0'] = card
+
+    const moneyBefore = game.money
+    const after = reduceGame(
+      { ...game, gamePlayState: { ...game.gamePlayState, cardsToScore: [card] } },
+      { type: 'CARD_SCORED' }
+    )
+    expect(after.money).toBe(moneyBefore)
+  })
+
+  it('triggers on K (King) cards when roll succeeds', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.jokers = [initializeJoker(jokers.businessCard, game)]
+    game.rounds[game.roundIndex].smallBlind.status = 'inProgress'
+    game.gamePhase = 'gameplay'
+    game.gameSeed = GAME_SEED
+
+    // card-1 with gameSeed=test-seed, roundIndex=1 produces roll=1 (success)
+    const card = makeFaceCard('card-1', 'K_clubs')
+    game.cards['card-1'] = card
+
+    const moneyBefore = game.money
+    const after = reduceGame(
+      { ...game, gamePlayState: { ...game.gamePlayState, cardsToScore: [card] } },
+      { type: 'CARD_SCORED' }
+    )
+    expect(after.money).toBe(moneyBefore + 2)
+  })
+})

--- a/src/app/daily-card-game/domain/joker/jokers.ts
+++ b/src/app/daily-card-game/domain/joker/jokers.ts
@@ -2127,6 +2127,42 @@ export const eightBall: JokerDefinition = {
   rarity: 'common',
 }
 
+export const businessCard: JokerDefinition = {
+  id: 'businessCard',
+  name: 'Business Card',
+  description: 'Played face cards have a 1 in 2 chance to give $2 when scored',
+  price: 4,
+  effects: [
+    {
+      event: { type: 'CARD_SCORED' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        const scoredCard = ctx.scoredCards?.[0]
+        if (!scoredCard) return
+        const cardDef = playingCards[scoredCard.playingCardId]
+        if (!['J', 'Q', 'K'].includes(cardDef.value)) return
+
+        const seed = buildSeedString([
+          ctx.game.gameSeed,
+          ctx.game.roundIndex.toString(),
+          scoredCard.id,
+          'businessCard',
+        ])
+        const roll = getRandomNumbersWithSeed({
+          seed,
+          min: 1,
+          max: 2,
+          numberOfNumbers: 1,
+        })
+        if (roll[0] !== 1) return
+
+        ctx.game.money += 2
+      },
+    },
+  ],
+  rarity: 'common',
+}
+
 export const misprint: JokerDefinition = {
   id: 'misprint',
   name: 'Misprint',
@@ -2290,6 +2326,7 @@ export const jokers: Record<JokerDefinition['id'], JokerDefinition> = {
   misprint,
   raisedFist,
   chaosTheClown,
+  businessCard,
 }
 
 /***


### PR DESCRIPTION
## Summary
- Implements the Business Card common joker: face cards have 1 in 2 chance to give $2 when scored
- Adds 5 unit tests covering face card triggers, non-face exclusions, and random roll outcomes

Closes #718

## Test plan
- [x] Unit tests pass (`npx vitest run business-card`)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)