### PR TITLE
Implement Credit Card common joker (#720)

### DIFF
--- a/src/app/daily-card-game/domain/game/__tests__/credit-card.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/credit-card.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest'
+
+import { defaultGameState } from '@/app/daily-card-game/domain/game/default-game-state'
+import { reduceGame } from '@/app/daily-card-game/domain/game/reduce-game'
+import type { GameState } from '@/app/daily-card-game/domain/game/types'
+import { jokers } from '@/app/daily-card-game/domain/joker/jokers'
+import { initializeJoker } from '@/app/daily-card-game/domain/joker/utils'
+import type { BuyableCard } from '@/app/daily-card-game/domain/shop/types'
+
+describe('Credit Card joker', () => {
+  it('sets minimumMoney to -20 when Credit Card is purchased (JOKER_ADDED)', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.jokers = []
+
+    const creditCardState = initializeJoker(jokers.creditCard, game)
+    const buyable: BuyableCard = {
+      type: 'jokerCard',
+      card: creditCardState,
+      price: jokers.creditCard.price,
+    }
+
+    game.money = 999
+    game.shopState.cardsForSale = [buyable]
+    game.shopState.selectedCardId = creditCardState.id
+
+    const afterPurchase = reduceGame(game, { type: 'SHOP_BUY_CARD' })
+
+    expect(afterPurchase.jokers.some(j => j.jokerId === 'creditCard')).toBe(true)
+    expect(afterPurchase.minimumMoney).toBe(-20)
+  })
+
+  it('resets minimumMoney to 0 when Credit Card is removed (JOKER_REMOVED)', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    const creditCardInstance = initializeJoker(jokers.creditCard, game)
+    game.jokers = [creditCardInstance]
+    game.minimumMoney = -20
+
+    const selected: GameState = {
+      ...game,
+      gamePlayState: { ...game.gamePlayState, selectedJokerId: creditCardInstance.id },
+    }
+
+    const afterRemoval = reduceGame(selected, { type: 'JOKER_REMOVED' })
+
+    expect(afterRemoval.jokers.some(j => j.jokerId === 'creditCard')).toBe(false)
+    expect(afterRemoval.minimumMoney).toBe(0)
+  })
+
+  it('does not reset minimumMoney when another Credit Card remains after removal', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    const creditCard1 = initializeJoker(jokers.creditCard, game)
+    const creditCard2 = initializeJoker(jokers.creditCard, game)
+    game.jokers = [creditCard1, creditCard2]
+    game.minimumMoney = -20
+
+    const selected: GameState = {
+      ...game,
+      gamePlayState: { ...game.gamePlayState, selectedJokerId: creditCard1.id },
+    }
+
+    const afterRemoval = reduceGame(selected, { type: 'JOKER_REMOVED' })
+
+    expect(afterRemoval.jokers.filter(j => j.jokerId === 'creditCard')).toHaveLength(1)
+    expect(afterRemoval.minimumMoney).toBe(-20)
+  })
+})

--- a/src/app/daily-card-game/domain/joker/jokers.ts
+++ b/src/app/daily-card-game/domain/joker/jokers.ts
@@ -2260,6 +2260,34 @@ export const chaosTheClown: JokerDefinition = {
   rarity: 'common',
 }
 
+export const creditCard: JokerDefinition = {
+  id: 'creditCard',
+  name: 'Credit Card',
+  description: 'Go up to -$20 in debt',
+  price: 1,
+  effects: [
+    {
+      event: { type: 'JOKER_ADDED' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        ctx.game.minimumMoney = -20
+      },
+    },
+    {
+      event: { type: 'JOKER_REMOVED' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        // Only reset if no other Credit Card joker exists
+        const hasCreditCard = ctx.game.jokers.some(j => j.jokerId === 'creditCard')
+        if (!hasCreditCard) {
+          ctx.game.minimumMoney = 0
+        }
+      },
+    },
+  ],
+  rarity: 'common',
+}
+
 export const jokers: Record<JokerDefinition['id'], JokerDefinition> = {
   swashbucklerJoker,
   walkieTalkieJoker,
@@ -2327,6 +2355,7 @@ export const jokers: Record<JokerDefinition['id'], JokerDefinition> = {
   raisedFist,
   chaosTheClown,
   businessCard,
+  creditCard,
 }
 
 /***


### PR DESCRIPTION
## Summary
- Implements the Credit Card common joker: allows going up to -$20 in debt
- Sets `minimumMoney = -20` on JOKER_ADDED, resets to 0 on JOKER_REMOVED
- Adds 3 unit tests covering add, remove, and duplicate removal edge case

Closes #720

## Test plan
- [x] Unit tests pass (`npx vitest run credit-card`)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)