### PR TITLE
Implement Delayed Gratification common joker (#721)

### DIFF
--- a/src/app/daily-card-game/domain/game/__tests__/delayed-gratification.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/delayed-gratification.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest'
+import { defaultGameState } from '@/app/daily-card-game/domain/game/default-game-state'
+import { reduceGame } from '@/app/daily-card-game/domain/game/reduce-game'
+import type { GameState } from '@/app/daily-card-game/domain/game/types'
+import { jokers } from '@/app/daily-card-game/domain/joker/jokers'
+import { initializeJoker } from '@/app/daily-card-game/domain/joker/utils'
+
+describe('Delayed Gratification', () => {
+  it('earns $2 per maxDiscards when no discards are used by end of round', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.jokers = [initializeJoker(jokers.delayedGratification, game)]
+    game.maxDiscards = 3
+    game.discardsPlayed = 0
+    const started = reduceGame(game, { type: 'GAME_START' })
+    const initialMoney = started.money
+    const afterRound = reduceGame(started, { type: 'ROUND_END' })
+    expect(afterRound.money).toBe(initialMoney + 6)
+  })
+
+  it('earns $0 when any discards were used', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.jokers = [initializeJoker(jokers.delayedGratification, game)]
+    game.maxDiscards = 3
+    game.discardsPlayed = 1
+    const started = reduceGame(game, { type: 'GAME_START' })
+    const initialMoney = started.money
+    const afterRound = reduceGame(started, { type: 'ROUND_END' })
+    expect(afterRound.money).toBe(initialMoney)
+  })
+})

--- a/src/app/daily-card-game/domain/joker/jokers.ts
+++ b/src/app/daily-card-game/domain/joker/jokers.ts
@@ -2288,6 +2288,26 @@ export const creditCard: JokerDefinition = {
   rarity: 'common',
 }
 
+export const delayedGratification: JokerDefinition = {
+  id: 'delayedGratification',
+  name: 'Delayed Gratification',
+  description: 'Earn $2 per discard if no discards are used by end of the round',
+  price: 4,
+  effects: [
+    {
+      event: { type: 'ROUND_END' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        if (ctx.game.discardsPlayed === 0) {
+          const payout = 2 * ctx.game.maxDiscards
+          ctx.game.money += payout
+        }
+      },
+    },
+  ],
+  rarity: 'common',
+}
+
 export const jokers: Record<JokerDefinition['id'], JokerDefinition> = {
   swashbucklerJoker,
   walkieTalkieJoker,
@@ -2356,6 +2376,7 @@ export const jokers: Record<JokerDefinition['id'], JokerDefinition> = {
   chaosTheClown,
   businessCard,
   creditCard,
+  delayedGratification,
 }
 
 /***


### PR DESCRIPTION
## Summary
- Implements the Delayed Gratification common joker: earn $2 per discard if none used by round end
- Adds 2 unit tests covering payout and no-payout scenarios

Closes #721

## Test plan
- [x] Unit tests pass (`npx vitest run delayed-gratification`)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)