### PR TITLE
Implement Gros Michel common joker (#722)

### DIFF
--- a/src/app/daily-card-game/domain/game/__tests__/gros-michel.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/gros-michel.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest'
+import { defaultGameState } from '@/app/daily-card-game/domain/game/default-game-state'
+import { reduceGame } from '@/app/daily-card-game/domain/game/reduce-game'
+import type { GameState } from '@/app/daily-card-game/domain/game/types'
+import { jokers } from '@/app/daily-card-game/domain/joker/jokers'
+import { initializeJoker } from '@/app/daily-card-game/domain/joker/utils'
+
+// With gameSeed='seed-a', roundIndex=1 (default): roll=1 (self-destruct)
+// With gameSeed='test-seed', roundIndex=1 (default): roll=4 (survive)
+const DESTROY_SEED = 'seed-a'
+const SURVIVE_SEED = 'test-seed'
+
+describe('Gros Michel joker', () => {
+  it('gives +15 Mult on HAND_SCORING_FINALIZE', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.jokers = [initializeJoker(jokers.grosMichel, game)]
+    game.rounds[game.roundIndex].smallBlind.status = 'inProgress'
+    game.gamePhase = 'gameplay'
+    const after = reduceGame(game, { type: 'HAND_SCORING_FINALIZE' })
+    expect(after.gamePlayState.scoringEvents.some(
+      e => 'source' in e && e.source === 'Gros Michel' && e.value === 15
+    )).toBe(true)
+  })
+
+  it('self-destructs on ROUND_END when roll=1', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.gameSeed = DESTROY_SEED
+    game.jokers = [initializeJoker(jokers.grosMichel, game)]
+    const after = reduceGame(game, { type: 'ROUND_END' })
+    expect(after.jokers.some(j => j.jokerId === 'grosMichel')).toBe(false)
+  })
+
+  it('survives ROUND_END when roll!=1', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.gameSeed = SURVIVE_SEED
+    game.jokers = [initializeJoker(jokers.grosMichel, game)]
+    const after = reduceGame(game, { type: 'ROUND_END' })
+    expect(after.jokers.some(j => j.jokerId === 'grosMichel')).toBe(true)
+  })
+})

--- a/src/app/daily-card-game/domain/joker/jokers.ts
+++ b/src/app/daily-card-game/domain/joker/jokers.ts
@@ -2308,6 +2308,50 @@ export const delayedGratification: JokerDefinition = {
   rarity: 'common',
 }
 
+export const grosMichel: JokerDefinition = {
+  id: 'grosMichel',
+  name: 'Gros Michel',
+  description: '+15 Mult. 1 in 6 chance this is destroyed at the end of round.',
+  price: 5,
+  effects: [
+    {
+      event: { type: 'HAND_SCORING_FINALIZE' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        ctx.game.gamePlayState.scoringEvents.push({
+          id: uuid(),
+          type: 'mult',
+          value: 15,
+          source: 'Gros Michel',
+        })
+        ctx.game.gamePlayState.score.mult += 15
+      },
+    },
+    {
+      event: { type: 'ROUND_END' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        const seed = buildSeedString([
+          ctx.game.gameSeed,
+          ctx.game.roundIndex.toString(),
+          'grosMichel',
+          'destroy',
+        ])
+        const roll = getRandomNumbersWithSeed({
+          seed,
+          min: 1,
+          max: 6,
+          numberOfNumbers: 1,
+        })
+        if (roll[0] === 1) {
+          ctx.game.jokers = ctx.game.jokers.filter(j => j.jokerId !== 'grosMichel')
+        }
+      },
+    },
+  ],
+  rarity: 'common',
+}
+
 export const jokers: Record<JokerDefinition['id'], JokerDefinition> = {
   swashbucklerJoker,
   walkieTalkieJoker,
@@ -2377,6 +2421,7 @@ export const jokers: Record<JokerDefinition['id'], JokerDefinition> = {
   businessCard,
   creditCard,
   delayedGratification,
+  grosMichel,
 }
 
 /***


### PR DESCRIPTION
## Summary
- Implements the Gros Michel common joker: +15 Mult with 1 in 6 self-destruct chance at round end
- Adds 3 unit tests covering mult bonus, self-destruct, and survival scenarios

Closes #722

## Test plan
- [x] Unit tests pass (`npx vitest run gros-michel`)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)