### PR TITLE
Implement Egg common joker (#723)

### DIFF
--- a/src/app/daily-card-game/domain/game/__tests__/egg.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/egg.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest'
+
+import { defaultGameState } from '@/app/daily-card-game/domain/game/default-game-state'
+import { reduceGame } from '@/app/daily-card-game/domain/game/reduce-game'
+import type { GameState } from '@/app/daily-card-game/domain/game/types'
+import { jokers } from '@/app/daily-card-game/domain/joker/jokers'
+import { initializeJoker } from '@/app/daily-card-game/domain/joker/utils'
+
+describe('Egg joker', () => {
+  it('increases bonusSellValue by 3 on ROUND_END', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.jokers = [initializeJoker(jokers.egg, game)]
+    const started = reduceGame(game, { type: 'GAME_START' })
+
+    const afterRound = reduceGame(started, { type: 'ROUND_END' })
+    const eggInstance = afterRound.jokers.find(j => j.jokerId === 'egg')
+    expect(eggInstance?.bonusSellValue).toBe(3)
+  })
+
+  it('accumulates bonusSellValue over multiple rounds', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.jokers = [initializeJoker(jokers.egg, game)]
+    const started = reduceGame(game, { type: 'GAME_START' })
+
+    let state = reduceGame(started, { type: 'ROUND_END' })
+    state = reduceGame(state, { type: 'ROUND_END' })
+
+    const eggInstance = state.jokers.find(j => j.jokerId === 'egg')
+    expect(eggInstance?.bonusSellValue).toBe(6)
+  })
+
+  it('adds bonusSellValue to sell price when sold', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.jokers = [initializeJoker(jokers.egg, game)]
+    const started = reduceGame(game, { type: 'GAME_START' })
+
+    let state = reduceGame(started, { type: 'ROUND_END' })
+    state = reduceGame(state, { type: 'ROUND_END' })
+
+    const eggInstance = state.jokers.find(j => j.jokerId === 'egg')!
+    const moneyBeforeSale = state.money
+    const selected = {
+      ...state,
+      gamePlayState: { ...state.gamePlayState, selectedJokerId: eggInstance.id },
+    }
+
+    const afterSale = reduceGame(selected, { type: 'JOKER_SOLD' })
+    // Egg price is $4, bonusSellValue after 2 rounds is $6, total = $10
+    expect(afterSale.money).toBe(moneyBeforeSale + jokers.egg.price + 6)
+    expect(afterSale.jokers.some(j => j.jokerId === 'egg')).toBe(false)
+  })
+})

--- a/src/app/daily-card-game/domain/game/reduce-game.ts
+++ b/src/app/daily-card-game/domain/game/reduce-game.ts
@@ -294,7 +294,7 @@ export function reduceGame(game: GameState, event: GameEvent): GameState {
           joker => joker.id === draft.gamePlayState.selectedJokerId
         )
         if (!selectedJoker) return
-        draft.money += jokers[selectedJoker.jokerId].price
+        draft.money += jokers[selectedJoker.jokerId].price + (selectedJoker.bonusSellValue ?? 0)
         removeJoker(draft, event, selectedJoker)
         return
       }

--- a/src/app/daily-card-game/domain/joker/jokers.ts
+++ b/src/app/daily-card-game/domain/joker/jokers.ts
@@ -2352,6 +2352,26 @@ export const grosMichel: JokerDefinition = {
   rarity: 'common',
 }
 
+export const egg: JokerDefinition = {
+  id: 'egg',
+  name: 'Egg',
+  description: 'Gains $3 of sell value at end of round',
+  price: 4,
+  effects: [
+    {
+      event: { type: 'ROUND_END' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        const eggJoker = ctx.game.jokers.find(j => j.jokerId === 'egg')
+        if (eggJoker) {
+          eggJoker.bonusSellValue += 3
+        }
+      },
+    },
+  ],
+  rarity: 'common',
+}
+
 export const jokers: Record<JokerDefinition['id'], JokerDefinition> = {
   swashbucklerJoker,
   walkieTalkieJoker,
@@ -2422,6 +2442,7 @@ export const jokers: Record<JokerDefinition['id'], JokerDefinition> = {
   creditCard,
   delayedGratification,
   grosMichel,
+  egg,
 }
 
 /***

--- a/src/app/daily-card-game/domain/joker/types.ts
+++ b/src/app/daily-card-game/domain/joker/types.ts
@@ -15,6 +15,7 @@ export interface JokerState {
   flags: JokerFlags
   edition: 'holographic' | 'foil' | 'polychrome' | 'negative' | 'normal'
   isFaceUp: boolean
+  bonusSellValue: number
   metadata?: Record<string, number>
 }
 

--- a/src/app/daily-card-game/domain/joker/utils.ts
+++ b/src/app/daily-card-game/domain/joker/utils.ts
@@ -121,6 +121,7 @@ export const initializeJoker = (joker: JokerDefinition, game: GameState): JokerS
     jokerId: joker.id,
     edition,
     isFaceUp: true,
+    bonusSellValue: 0,
     flags: {
       isRentable: flag === 'isRentable',
       isPerishable: flag === 'isPerishable',


### PR DESCRIPTION
## Summary
- Implements the Egg common joker: gains $3 sell value at end of each round
- Adds `bonusSellValue` infrastructure to JokerState for scaling sell values
- Updates sell price calculation to include bonus sell value
- Adds 3 unit tests covering value increment, accumulation, and sell price

Closes #723

## Test plan
- [x] Unit tests pass (`npx vitest run egg`)
- [x] No TypeScript errors
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)