### PR TITLE
Implement Runner common joker (#724)

### DIFF
--- a/src/app/daily-card-game/domain/game/__tests__/runner.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/runner.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest'
+import { defaultGameState } from '@/app/daily-card-game/domain/game/default-game-state'
+import { reduceGame } from '@/app/daily-card-game/domain/game/reduce-game'
+import type { GameState } from '@/app/daily-card-game/domain/game/types'
+import { jokers } from '@/app/daily-card-game/domain/joker/jokers'
+import { initializeJoker } from '@/app/daily-card-game/domain/joker/utils'
+
+describe('Runner joker', () => {
+  it('increases counter by 15 when a Straight is played', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.jokers = [initializeJoker(jokers.runner, game)]
+    game.rounds[game.roundIndex].smallBlind.status = 'inProgress'
+    game.gamePhase = 'gameplay'
+    const started = reduceGame(game, { type: 'GAME_START' })
+
+    const hand: GameState = {
+      ...started,
+      gamePlayState: {
+        ...started.gamePlayState,
+        selectedHand: ['straight', []],
+        score: { chips: 10, mult: 5 },
+      },
+    }
+    const after = reduceGame(hand, { type: 'HAND_SCORING_FINALIZE' })
+    const runnerInstance = after.jokers.find(j => j.jokerId === 'runner')
+    expect(runnerInstance?.counter).toBe(15)
+  })
+
+  it('does not increase counter for non-Straight hands', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.jokers = [initializeJoker(jokers.runner, game)]
+    game.rounds[game.roundIndex].smallBlind.status = 'inProgress'
+    game.gamePhase = 'gameplay'
+    const started = reduceGame(game, { type: 'GAME_START' })
+
+    const hand: GameState = {
+      ...started,
+      gamePlayState: {
+        ...started.gamePlayState,
+        selectedHand: ['pair', []],
+        score: { chips: 10, mult: 5 },
+      },
+    }
+    const after = reduceGame(hand, { type: 'HAND_SCORING_FINALIZE' })
+    const runnerInstance = after.jokers.find(j => j.jokerId === 'runner')
+    expect(runnerInstance?.counter).toBe(0)
+  })
+
+  it('applies accumulated chips bonus on the hand where Straight is played', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.jokers = [initializeJoker(jokers.runner, game)]
+    game.rounds[game.roundIndex].smallBlind.status = 'inProgress'
+    game.gamePhase = 'gameplay'
+    const started = reduceGame(game, { type: 'GAME_START' })
+
+    // First straight: counter goes from 0 to 15, bonus of 15 is applied
+    const hand1: GameState = {
+      ...started,
+      gamePlayState: {
+        ...started.gamePlayState,
+        selectedHand: ['straight', []],
+        score: { chips: 10, mult: 5 },
+      },
+    }
+    const after1 = reduceGame(hand1, { type: 'HAND_SCORING_FINALIZE' })
+    expect(after1.gamePlayState.scoringEvents.some(
+      e => 'source' in e && e.source === 'Runner' && 'value' in e && e.value === 15
+    )).toBe(true)
+
+    // Second straight: counter goes to 30, bonus of 30 is applied
+    const runnerInstance = after1.jokers.find(j => j.jokerId === 'runner')!
+    const hand2: GameState = {
+      ...after1,
+      gamePlayState: {
+        ...after1.gamePlayState,
+        scoringEvents: [],
+        selectedHand: ['straight', []],
+        score: { chips: 10, mult: 5 },
+      },
+    }
+    const after2 = reduceGame(hand2, { type: 'HAND_SCORING_FINALIZE' })
+    const runnerInstance2 = after2.jokers.find(j => j.jokerId === 'runner')
+    expect(runnerInstance2?.counter).toBe(30)
+    expect(after2.gamePlayState.scoringEvents.some(
+      e => 'source' in e && e.source === 'Runner' && 'value' in e && e.value === 30
+    )).toBe(true)
+  })
+})

--- a/src/app/daily-card-game/domain/joker/jokers.ts
+++ b/src/app/daily-card-game/domain/joker/jokers.ts
@@ -2352,6 +2352,45 @@ export const grosMichel: JokerDefinition = {
   rarity: 'common',
 }
 
+export const runner: JokerDefinition = {
+  id: 'runner',
+  name: 'Runner',
+  description: 'Gains +15 Chips if played hand contains a Straight',
+  price: 5,
+  effects: [
+    {
+      event: { type: 'HAND_SCORING_FINALIZE' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        const runnerJoker = ctx.game.jokers.find(j => j.jokerId === 'runner')
+        if (!runnerJoker) return
+
+        // Check if hand contains a Straight and accumulate counter
+        const selectedHand = ctx.game.gamePlayState.selectedHand
+        if (selectedHand) {
+          const handId = selectedHand[0]
+          const straightHands = ['straight', 'straightFlush']
+          if (straightHands.includes(handId)) {
+            runnerJoker.counter += 15
+          }
+        }
+
+        // Apply accumulated bonus
+        if (runnerJoker.counter > 0) {
+          ctx.game.gamePlayState.scoringEvents.push({
+            id: uuid(),
+            type: 'chips',
+            value: runnerJoker.counter,
+            source: 'Runner',
+          })
+          ctx.game.gamePlayState.score.chips += runnerJoker.counter
+        }
+      },
+    },
+  ],
+  rarity: 'common',
+}
+
 export const egg: JokerDefinition = {
   id: 'egg',
   name: 'Egg',
@@ -2442,6 +2481,7 @@ export const jokers: Record<JokerDefinition['id'], JokerDefinition> = {
   creditCard,
   delayedGratification,
   grosMichel,
+  runner,
   egg,
 }
 

--- a/src/app/daily-card-game/domain/joker/types.ts
+++ b/src/app/daily-card-game/domain/joker/types.ts
@@ -16,6 +16,7 @@ export interface JokerState {
   edition: 'holographic' | 'foil' | 'polychrome' | 'negative' | 'normal'
   isFaceUp: boolean
   bonusSellValue: number
+  counter: number
   metadata?: Record<string, number>
 }
 

--- a/src/app/daily-card-game/domain/joker/utils.ts
+++ b/src/app/daily-card-game/domain/joker/utils.ts
@@ -122,6 +122,7 @@ export const initializeJoker = (joker: JokerDefinition, game: GameState): JokerS
     edition,
     isFaceUp: true,
     bonusSellValue: 0,
+    counter: 0,
     flags: {
       isRentable: flag === 'isRentable',
       isPerishable: flag === 'isPerishable',


### PR DESCRIPTION
## Summary
- Implements the Runner common joker: gains +15 Chips per Straight played (scaling)
- Adds `counter` infrastructure to JokerState for generic scaling jokers
- Adds 3 unit tests covering counter increment, non-straight rejection, and accumulation

Closes #724

## Test plan
- [x] Unit tests pass (`npx vitest run runner`)
- [x] No TypeScript errors
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)