### PR TITLE
Implement Ice Cream common joker (#725)

### DIFF
--- a/src/app/daily-card-game/domain/game/__tests__/ice-cream.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/ice-cream.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest'
+import { defaultGameState } from '@/app/daily-card-game/domain/game/default-game-state'
+import { reduceGame } from '@/app/daily-card-game/domain/game/reduce-game'
+import type { GameState } from '@/app/daily-card-game/domain/game/types'
+import { jokers } from '@/app/daily-card-game/domain/joker/jokers'
+import { initializeJoker } from '@/app/daily-card-game/domain/joker/utils'
+
+describe('Ice Cream joker', () => {
+  function setupGame(): GameState {
+    const game: GameState = structuredClone(defaultGameState)
+    game.jokers = [initializeJoker(jokers.iceCream, game)]
+    game.rounds[game.roundIndex].smallBlind.status = 'inProgress'
+    game.gamePhase = 'gameplay'
+    return reduceGame(game, { type: 'GAME_START' })
+  }
+
+  it('gives +100 Chips on first hand (counter initializes to 100)', () => {
+    const started = setupGame()
+    const hand: GameState = {
+      ...started,
+      gamePlayState: {
+        ...started.gamePlayState,
+        selectedHand: ['pair', []],
+        score: { chips: 0, mult: 1 },
+      },
+    }
+    const after = reduceGame(hand, { type: 'HAND_SCORING_FINALIZE' })
+    expect(after.gamePlayState.scoringEvents.some(
+      e => 'source' in e && e.source === 'Ice Cream' && 'value' in e && e.value === 100
+    )).toBe(true)
+  })
+
+  it('gives +95 Chips on second hand (counter decremented to 95 after first)', () => {
+    const started = setupGame()
+    const hand1: GameState = {
+      ...started,
+      gamePlayState: {
+        ...started.gamePlayState,
+        selectedHand: ['pair', []],
+        score: { chips: 0, mult: 1 },
+      },
+    }
+    const after1 = reduceGame(hand1, { type: 'HAND_SCORING_FINALIZE' })
+
+    const hand2: GameState = {
+      ...after1,
+      gamePlayState: {
+        ...after1.gamePlayState,
+        scoringEvents: [],
+        score: { chips: 0, mult: 1 },
+      },
+    }
+    const after2 = reduceGame(hand2, { type: 'HAND_SCORING_FINALIZE' })
+
+    expect(after2.gamePlayState.scoringEvents.some(
+      e => 'source' in e && e.source === 'Ice Cream' && 'value' in e && e.value === 95
+    )).toBe(true)
+  })
+
+  it('self-destructs when counter reaches 0', () => {
+    const started = setupGame()
+
+    // Play 20 hands to deplete from 100 to 0 (100 / 5 = 20 hands)
+    let state: GameState = started
+    for (let i = 0; i < 20; i++) {
+      state = reduceGame(
+        {
+          ...state,
+          gamePlayState: {
+            ...state.gamePlayState,
+            scoringEvents: [],
+            score: { chips: 0, mult: 1 },
+            selectedHand: ['pair', []],
+          },
+        },
+        { type: 'HAND_SCORING_FINALIZE' }
+      )
+    }
+
+    const iceCreamInstance = state.jokers.find(j => j.jokerId === 'iceCream')
+    expect(iceCreamInstance).toBeUndefined()
+  })
+})

--- a/src/app/daily-card-game/domain/joker/jokers.ts
+++ b/src/app/daily-card-game/domain/joker/jokers.ts
@@ -2391,6 +2391,48 @@ export const runner: JokerDefinition = {
   rarity: 'common',
 }
 
+export const iceCream: JokerDefinition = {
+  id: 'iceCream',
+  name: 'Ice Cream',
+  description: '+100 Chips. -5 Chips for every hand played',
+  price: 5,
+  effects: [
+    {
+      event: { type: 'HAND_SCORING_FINALIZE' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        const iceCreamJoker = ctx.game.jokers.find(j => j.jokerId === 'iceCream')
+        if (!iceCreamJoker) return
+
+        // Initialize counter to 100 on first use
+        if (iceCreamJoker.counter === 0) {
+          iceCreamJoker.counter = 100
+        }
+
+        // Apply current chips bonus
+        if (iceCreamJoker.counter > 0) {
+          ctx.game.gamePlayState.scoringEvents.push({
+            id: uuid(),
+            type: 'chips',
+            value: iceCreamJoker.counter,
+            source: 'Ice Cream',
+          })
+          ctx.game.gamePlayState.score.chips += iceCreamJoker.counter
+        }
+
+        // Reduce by 5 after applying
+        iceCreamJoker.counter -= 5
+
+        // Destroy if chips reach 0 or below
+        if (iceCreamJoker.counter <= 0) {
+          ctx.game.jokers = ctx.game.jokers.filter(j => j.id !== iceCreamJoker.id)
+        }
+      },
+    },
+  ],
+  rarity: 'common',
+}
+
 export const egg: JokerDefinition = {
   id: 'egg',
   name: 'Egg',
@@ -2482,6 +2524,7 @@ export const jokers: Record<JokerDefinition['id'], JokerDefinition> = {
   delayedGratification,
   grosMichel,
   runner,
+  iceCream,
   egg,
 }
 


### PR DESCRIPTION
## Summary
- Implements the Ice Cream common joker: +100 Chips depleting by 5 per hand, self-destructs at 0
- Uses the `counter` field on JokerState (from Runner infrastructure)
- Adds 3 unit tests covering chip bonus, depletion, and self-destruct

Closes #725

## Test plan
- [x] Unit tests pass (`npx vitest run ice-cream`)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)