### PR TITLE
Implement Splash common joker (#726)

### DIFF
--- a/src/app/daily-card-game/domain/game/__tests__/splash.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/splash.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest'
+import { defaultGameState } from '@/app/daily-card-game/domain/game/default-game-state'
+import { reduceGame } from '@/app/daily-card-game/domain/game/reduce-game'
+import type { GameState } from '@/app/daily-card-game/domain/game/types'
+import { jokers } from '@/app/daily-card-game/domain/joker/jokers'
+import { initializeJoker } from '@/app/daily-card-game/domain/joker/utils'
+import { playingCards } from '@/app/daily-card-game/domain/playing-card/playing-cards'
+
+describe('Splash joker', () => {
+  /**
+   * Helper that picks cards from the default game's card registry by value.
+   * Returns card IDs whose playing card has the given value.
+   */
+  function getCardIdsByValue(game: GameState, value: string): string[] {
+    return Object.keys(game.cards).filter(
+      id => playingCards[game.cards[id].playingCardId]?.value === value
+    )
+  }
+
+  it('expands cardsToScore to include all played cards, not just hand cards', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.jokers = [initializeJoker(jokers.splash, game)]
+    game.rounds[game.roundIndex].smallBlind.status = 'inProgress'
+    game.gamePhase = 'gameplay'
+
+    // Pick two Aces (they form a pair — the winning hand from 3 selected cards)
+    const aceIds = getCardIdsByValue(game, 'A')
+    // Pick one King (does not participate in the pair hand)
+    const kingIds = getCardIdsByValue(game, 'K')
+
+    expect(aceIds.length).toBeGreaterThanOrEqual(2)
+    expect(kingIds.length).toBeGreaterThanOrEqual(1)
+
+    const selectedIds = [aceIds[0], aceIds[1], kingIds[0]]
+
+    game.gamePlayState.selectedCardIds = selectedIds
+    game.gamePlayState.handIds = selectedIds
+
+    const after = reduceGame(game, { type: 'HAND_SCORING_START' })
+
+    // With Splash, all 3 played cards should be in cardsToScore
+    expect(after.gamePlayState.cardsToScore.length).toBe(3)
+    const scoredIds = after.gamePlayState.cardsToScore.map(c => c.id)
+    expect(scoredIds).toContain(aceIds[0])
+    expect(scoredIds).toContain(aceIds[1])
+    expect(scoredIds).toContain(kingIds[0])
+  })
+
+  it('without Splash, only hand cards (the pair) are in cardsToScore', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    // No Splash joker
+    game.rounds[game.roundIndex].smallBlind.status = 'inProgress'
+    game.gamePhase = 'gameplay'
+
+    const aceIds = getCardIdsByValue(game, 'A')
+    const kingIds = getCardIdsByValue(game, 'K')
+
+    const selectedIds = [aceIds[0], aceIds[1], kingIds[0]]
+
+    game.gamePlayState.selectedCardIds = selectedIds
+    game.gamePlayState.handIds = selectedIds
+
+    const after = reduceGame(game, { type: 'HAND_SCORING_START' })
+
+    // Without Splash, only the 2 Aces (the pair) should be in cardsToScore
+    expect(after.gamePlayState.cardsToScore.length).toBe(2)
+    const scoredIds = after.gamePlayState.cardsToScore.map(c => c.id)
+    expect(scoredIds).toContain(aceIds[0])
+    expect(scoredIds).toContain(aceIds[1])
+    expect(scoredIds).not.toContain(kingIds[0])
+  })
+
+  it('does not duplicate cards already in cardsToScore', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.jokers = [initializeJoker(jokers.splash, game)]
+    game.rounds[game.roundIndex].smallBlind.status = 'inProgress'
+    game.gamePhase = 'gameplay'
+
+    // Play a single high card — cardsToScore will already contain that card
+    const aceIds = getCardIdsByValue(game, 'A')
+    expect(aceIds.length).toBeGreaterThanOrEqual(1)
+
+    const selectedIds = [aceIds[0]]
+    game.gamePlayState.selectedCardIds = selectedIds
+    game.gamePlayState.handIds = selectedIds
+
+    const after = reduceGame(game, { type: 'HAND_SCORING_START' })
+
+    // Should still be exactly 1 card (no duplicate)
+    const scoredAceCount = after.gamePlayState.cardsToScore.filter(
+      c => c.id === aceIds[0]
+    ).length
+    expect(scoredAceCount).toBe(1)
+  })
+})

--- a/src/app/daily-card-game/domain/joker/jokers.ts
+++ b/src/app/daily-card-game/domain/joker/jokers.ts
@@ -2453,6 +2453,34 @@ export const egg: JokerDefinition = {
   rarity: 'common',
 }
 
+export const splash: JokerDefinition = {
+  id: 'splash',
+  name: 'Splash',
+  description: 'Every played card counts in scoring',
+  price: 3,
+  effects: [
+    {
+      event: { type: 'HAND_SCORING_START' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        const allPlayedIds = ctx.game.gamePlayState.selectedCardIds
+        const existingIds = new Set(
+          ctx.game.gamePlayState.cardsToScore.map(c => c.id)
+        )
+        for (const cardId of allPlayedIds) {
+          if (!existingIds.has(cardId)) {
+            const card = ctx.game.cards[cardId]
+            if (card) {
+              ctx.game.gamePlayState.cardsToScore.push(card)
+            }
+          }
+        }
+      },
+    },
+  ],
+  rarity: 'common',
+}
+
 export const jokers: Record<JokerDefinition['id'], JokerDefinition> = {
   swashbucklerJoker,
   walkieTalkieJoker,
@@ -2526,6 +2554,7 @@ export const jokers: Record<JokerDefinition['id'], JokerDefinition> = {
   runner,
   iceCream,
   egg,
+  splash,
 }
 
 /***


### PR DESCRIPTION
## Summary
- Implements the Splash common joker: every played card counts in scoring
- Hooks into HAND_SCORING_START to expand cardsToScore with all selected cards
- Adds 3 unit tests covering card expansion, baseline comparison, and no-duplication

Closes #726

## Test plan
- [x] Unit tests pass (`npx vitest run splash`)
- [x] Full test suite passes (1145 tests)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)