### PR TITLE
Implement Green Joker common joker (#728)

### DIFF
--- a/src/app/daily-card-game/domain/game/__tests__/green-joker.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/green-joker.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest'
+import { defaultGameState } from '@/app/daily-card-game/domain/game/default-game-state'
+import { reduceGame } from '@/app/daily-card-game/domain/game/reduce-game'
+import type { GameState } from '@/app/daily-card-game/domain/game/types'
+import { jokers } from '@/app/daily-card-game/domain/joker/jokers'
+import { initializeJoker } from '@/app/daily-card-game/domain/joker/utils'
+
+describe('Green Joker', () => {
+  function makeGameWithGreenJoker(): GameState {
+    const game: GameState = structuredClone(defaultGameState)
+    game.jokers = [initializeJoker(jokers.greenJoker, game)]
+    game.rounds[game.roundIndex].smallBlind.status = 'inProgress'
+    game.gamePhase = 'gameplay'
+    return game
+  }
+
+  it('counter increases by 1 on HAND_SCORING_FINALIZE and applies mult', () => {
+    const game = makeGameWithGreenJoker()
+    const after = reduceGame(game, { type: 'HAND_SCORING_FINALIZE' })
+    const gj = after.jokers.find(j => j.jokerId === 'greenJoker')
+    expect(gj?.counter).toBe(1)
+    expect(after.gamePlayState.scoringEvents.some(
+      e => 'source' in e && e.source === 'Green Joker' && e.value === 1
+    )).toBe(true)
+  })
+
+  it('accumulates mult across multiple hands', () => {
+    const game = makeGameWithGreenJoker()
+    const after1 = reduceGame(game, { type: 'HAND_SCORING_FINALIZE' })
+    const after2 = reduceGame(after1, { type: 'HAND_SCORING_FINALIZE' })
+    const gj = after2.jokers.find(j => j.jokerId === 'greenJoker')
+    expect(gj?.counter).toBe(2)
+    // second HAND_SCORING_FINALIZE should add +2 Mult
+    const events = after2.gamePlayState.scoringEvents.filter(
+      e => 'source' in e && e.source === 'Green Joker'
+    )
+    expect(events.some(e => 'value' in e && e.value === 2)).toBe(true)
+  })
+
+  it('counter decreases by 1 on DISCARD_SELECTED_CARDS', () => {
+    const game = makeGameWithGreenJoker()
+    // Build counter to 2 first
+    const after1 = reduceGame(game, { type: 'HAND_SCORING_FINALIZE' })
+    const after2 = reduceGame(after1, { type: 'HAND_SCORING_FINALIZE' })
+    const gj2 = after2.jokers.find(j => j.jokerId === 'greenJoker')
+    expect(gj2?.counter).toBe(2)
+    // Discard should reduce counter
+    const afterDiscard = reduceGame(after2, { type: 'DISCARD_SELECTED_CARDS' })
+    const gjAfterDiscard = afterDiscard.jokers.find(j => j.jokerId === 'greenJoker')
+    expect(gjAfterDiscard?.counter).toBe(1)
+  })
+
+  it('counter does not go below 0 on DISCARD_SELECTED_CARDS', () => {
+    const game = makeGameWithGreenJoker()
+    // Counter starts at 0, discard should not make it negative
+    const afterDiscard = reduceGame(game, { type: 'DISCARD_SELECTED_CARDS' })
+    const gj = afterDiscard.jokers.find(j => j.jokerId === 'greenJoker')
+    expect(gj?.counter).toBe(0)
+  })
+})

--- a/src/app/daily-card-game/domain/game/handlers/gameplay.ts
+++ b/src/app/daily-card-game/domain/game/handlers/gameplay.ts
@@ -60,7 +60,7 @@ export function handleCardDeselected(draft: GameState, event: CardDeselectedEven
   gamePlayState.selectedHand = selectedHand
 }
 
-export function handleDiscardSelectedCards(draft: GameState) {
+export function handleDiscardSelectedCards(draft: GameState, event: GameEvent) {
   const gamePlayState = draft.gamePlayState
 
   // Find discarded cards before we clear selection
@@ -93,6 +93,20 @@ export function handleDiscardSelectedCards(draft: GameState) {
       draft.consumables.push(initializeTarotCard(getRandomTarotCards(1, randomTarotCardsSeed)[0]))
     }
   }
+
+  // Dispatch joker effects for DISCARD_SELECTED_CARDS
+  const ctx: EffectContext = {
+    event,
+    game: draft as unknown as GameState,
+    score: gamePlayState.score,
+    playedCards: [],
+    round: draft.rounds[draft.roundIndex],
+    bossBlind: draft.rounds[draft.roundIndex].bossBlind,
+    jokers: draft.jokers,
+    vouchers: draft.vouchers,
+    tags: draft.tags,
+  }
+  dispatchEffects(event, ctx, collectEffects(ctx.game))
 }
 
 /**

--- a/src/app/daily-card-game/domain/game/reduce-game.ts
+++ b/src/app/daily-card-game/domain/game/reduce-game.ts
@@ -128,7 +128,7 @@ export function reduceGame(game: GameState, event: GameEvent): GameState {
         return
       }
       case 'DISCARD_SELECTED_CARDS': {
-        handleDiscardSelectedCards(draft)
+        handleDiscardSelectedCards(draft, event)
         return
       }
 

--- a/src/app/daily-card-game/domain/joker/jokers.ts
+++ b/src/app/daily-card-game/domain/joker/jokers.ts
@@ -2481,6 +2481,44 @@ export const splash: JokerDefinition = {
   rarity: 'common',
 }
 
+export const greenJoker: JokerDefinition = {
+  id: 'greenJoker',
+  name: 'Green Joker',
+  description: '+1 Mult per hand played, -1 Mult per discard',
+  price: 4,
+  effects: [
+    {
+      event: { type: 'HAND_SCORING_FINALIZE' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        const gj = ctx.game.jokers.find(j => j.jokerId === 'greenJoker')
+        if (!gj) return
+        gj.counter += 1
+
+        if (gj.counter > 0) {
+          ctx.game.gamePlayState.scoringEvents.push({
+            id: uuid(),
+            type: 'mult',
+            value: gj.counter,
+            source: 'Green Joker',
+          })
+          ctx.game.gamePlayState.score.mult += gj.counter
+        }
+      },
+    },
+    {
+      event: { type: 'DISCARD_SELECTED_CARDS' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        const gj = ctx.game.jokers.find(j => j.jokerId === 'greenJoker')
+        if (!gj) return
+        gj.counter = Math.max(0, gj.counter - 1)
+      },
+    },
+  ],
+  rarity: 'common',
+}
+
 export const jokers: Record<JokerDefinition['id'], JokerDefinition> = {
   swashbucklerJoker,
   walkieTalkieJoker,
@@ -2555,6 +2593,7 @@ export const jokers: Record<JokerDefinition['id'], JokerDefinition> = {
   iceCream,
   egg,
   splash,
+  greenJoker,
 }
 
 /***


### PR DESCRIPTION
## Summary
- Implements the Green Joker common joker: +1 Mult per hand played, -1 Mult per discard (scaling)
- Adds dispatchEffects hook to discard handler for joker effect support
- Adds 4 unit tests covering increment, accumulation, decrement, and floor at 0

Closes #728

## Test plan
- [x] Unit tests pass (`npx vitest run green-joker`)
- [x] Full test suite passes (1149 tests)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)