### PR TITLE
Implement Superposition common joker (#729)

### DIFF
--- a/src/app/daily-card-game/domain/game/__tests__/superposition.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/superposition.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from 'vitest'
+import { defaultGameState } from '@/app/daily-card-game/domain/game/default-game-state'
+import { reduceGame } from '@/app/daily-card-game/domain/game/reduce-game'
+import type { GameState } from '@/app/daily-card-game/domain/game/types'
+import { jokers } from '@/app/daily-card-game/domain/joker/jokers'
+import { initializeJoker } from '@/app/daily-card-game/domain/joker/utils'
+import type { PlayingCardState } from '@/app/daily-card-game/domain/playing-card/types'
+
+function makeCard(id: string, playingCardId: string): PlayingCardState {
+  return {
+    id,
+    playingCardId,
+    bonusChips: 0,
+    isFaceUp: true,
+    flags: { edition: 'normal', enchantment: 'none', seal: 'none' },
+  }
+}
+
+const aceCard = makeCard('card-ace', 'A_hearts')
+const twoCard = makeCard('card-two', '2_hearts')
+const threeCard = makeCard('card-three', '3_spades')
+
+function makeBaseGame(): GameState {
+  const game: GameState = structuredClone(defaultGameState)
+  game.jokers = [initializeJoker(jokers.superposition, game)]
+  game.rounds[game.roundIndex].smallBlind.status = 'inProgress'
+  game.gamePhase = 'gameplay'
+  game.gameSeed = 'test-seed'
+  game.handsPlayed = 0
+  game.cards['card-ace'] = aceCard
+  game.cards['card-two'] = twoCard
+  game.cards['card-three'] = threeCard
+  return game
+}
+
+describe('Superposition joker', () => {
+  it('creates a Tarot card when hand is a Straight with an Ace', () => {
+    const game = makeBaseGame()
+    const handCards = [aceCard, twoCard]
+    const after = reduceGame(
+      {
+        ...game,
+        gamePlayState: {
+          ...game.gamePlayState,
+          selectedHand: ['straight', handCards],
+          score: { chips: 10, mult: 5 },
+        },
+      },
+      { type: 'HAND_SCORING_FINALIZE' }
+    )
+    expect(after.consumables.length).toBe(1)
+    expect(after.consumables[0].consumableType).toBe('tarotCard')
+  })
+
+  it('creates a Tarot card when hand is a Straight Flush with an Ace', () => {
+    const game = makeBaseGame()
+    const handCards = [aceCard, twoCard]
+    const after = reduceGame(
+      {
+        ...game,
+        gamePlayState: {
+          ...game.gamePlayState,
+          selectedHand: ['straightFlush', handCards],
+          score: { chips: 10, mult: 5 },
+        },
+      },
+      { type: 'HAND_SCORING_FINALIZE' }
+    )
+    expect(after.consumables.length).toBe(1)
+    expect(after.consumables[0].consumableType).toBe('tarotCard')
+  })
+
+  it('does NOT create a Tarot card when hand is a Straight without an Ace', () => {
+    const game = makeBaseGame()
+    const handCards = [twoCard, threeCard]
+    const before = game.consumables.length
+    const after = reduceGame(
+      {
+        ...game,
+        gamePlayState: {
+          ...game.gamePlayState,
+          selectedHand: ['straight', handCards],
+          score: { chips: 10, mult: 5 },
+        },
+      },
+      { type: 'HAND_SCORING_FINALIZE' }
+    )
+    expect(after.consumables.length).toBe(before)
+  })
+
+  it('does NOT create a Tarot card when hand is not a Straight', () => {
+    const game = makeBaseGame()
+    const handCards = [aceCard, twoCard]
+    const before = game.consumables.length
+    const after = reduceGame(
+      {
+        ...game,
+        gamePlayState: {
+          ...game.gamePlayState,
+          selectedHand: ['pair', handCards],
+          score: { chips: 10, mult: 5 },
+        },
+      },
+      { type: 'HAND_SCORING_FINALIZE' }
+    )
+    expect(after.consumables.length).toBe(before)
+  })
+
+  it('does NOT create a Tarot card when consumables are full', () => {
+    const game = makeBaseGame()
+    game.consumables = Array.from({ length: game.maxConsumables }, (_, i) => ({
+      id: `tarot-${i}`,
+      consumableType: 'tarotCard' as const,
+      name: 'The Fool',
+      isFaceUp: true,
+      tarotType: 'theFool' as const,
+    }))
+    const handCards = [aceCard, twoCard]
+    const before = game.consumables.length
+    const after = reduceGame(
+      {
+        ...game,
+        gamePlayState: {
+          ...game.gamePlayState,
+          selectedHand: ['straight', handCards],
+          score: { chips: 10, mult: 5 },
+        },
+      },
+      { type: 'HAND_SCORING_FINALIZE' }
+    )
+    expect(after.consumables.length).toBe(before)
+  })
+})

--- a/src/app/daily-card-game/domain/joker/jokers.ts
+++ b/src/app/daily-card-game/domain/joker/jokers.ts
@@ -2519,6 +2519,50 @@ export const greenJoker: JokerDefinition = {
   rarity: 'common',
 }
 
+export const superposition: JokerDefinition = {
+  id: 'superposition',
+  name: 'Superposition',
+  description: 'Create a Tarot card if poker hand contains an Ace and a Straight (Must have room)',
+  price: 5,
+  effects: [
+    {
+      event: { type: 'HAND_SCORING_FINALIZE' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        // Check if there's room for consumables
+        if (ctx.game.consumables.length >= ctx.game.maxConsumables) return
+
+        const selectedHand = ctx.game.gamePlayState.selectedHand
+        if (!selectedHand) return
+
+        const handId = selectedHand[0]
+        const straightHands = ['straight', 'straightFlush']
+        if (!straightHands.includes(handId)) return
+
+        const handCards = selectedHand[1]
+        if (!handCards || handCards.length === 0) return
+
+        const hasAce = handCards.some(card => {
+          const cardDef = playingCards[card.playingCardId]
+          return cardDef?.value === 'A'
+        })
+        if (!hasAce) return
+
+        // Create a random tarot card
+        const seed = buildSeedString([
+          ctx.game.gameSeed,
+          ctx.game.roundIndex.toString(),
+          ctx.game.handsPlayed.toString(),
+          'superposition',
+        ])
+        const tarotCard = getRandomTarotCards(1, seed)[0]
+        ctx.game.consumables.push(initializeTarotCard(tarotCard))
+      },
+    },
+  ],
+  rarity: 'common',
+}
+
 export const jokers: Record<JokerDefinition['id'], JokerDefinition> = {
   swashbucklerJoker,
   walkieTalkieJoker,
@@ -2594,6 +2638,7 @@ export const jokers: Record<JokerDefinition['id'], JokerDefinition> = {
   egg,
   splash,
   greenJoker,
+  superposition,
 }
 
 /***


### PR DESCRIPTION
## Summary
- Implements the Superposition common joker: creates a Tarot card if hand is Straight with Ace
- Adds 5 unit tests covering all trigger conditions and edge cases

Closes #729

## Test plan
- [x] Unit tests pass (`npx vitest run superposition`)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)