### PR TITLE
Implement Cavendish common joker (#731)

### DIFF
--- a/src/app/daily-card-game/domain/game/__tests__/cavendish.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/cavendish.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest'
+import { defaultGameState } from '@/app/daily-card-game/domain/game/default-game-state'
+import { reduceGame } from '@/app/daily-card-game/domain/game/reduce-game'
+import type { GameState } from '@/app/daily-card-game/domain/game/types'
+import { jokers } from '@/app/daily-card-game/domain/joker/jokers'
+import { initializeJoker } from '@/app/daily-card-game/domain/joker/utils'
+
+// With gameSeed='seed-1784', roundIndex=1 (default): roll=1 (self-destruct)
+// With gameSeed='test-seed', roundIndex=1 (default): roll=652 (survive)
+const DESTROY_SEED = 'seed-1784'
+const SURVIVE_SEED = 'test-seed'
+
+describe('Cavendish joker', () => {
+  it('gives X3 Mult on HAND_SCORING_FINALIZE', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.jokers = [initializeJoker(jokers.cavendish, game)]
+    game.rounds[game.roundIndex].smallBlind.status = 'inProgress'
+    game.gamePhase = 'gameplay'
+    const before = game.gamePlayState.score.mult
+    const after = reduceGame(game, { type: 'HAND_SCORING_FINALIZE' })
+    expect(after.gamePlayState.score.mult).toBe(before * 3)
+  })
+
+  it('scoring event has operator x, value 3, source Cavendish', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.jokers = [initializeJoker(jokers.cavendish, game)]
+    game.rounds[game.roundIndex].smallBlind.status = 'inProgress'
+    game.gamePhase = 'gameplay'
+    const after = reduceGame(game, { type: 'HAND_SCORING_FINALIZE' })
+    expect(after.gamePlayState.scoringEvents.some(
+      e => 'source' in e && e.source === 'Cavendish' && e.value === 3 && 'operator' in e && e.operator === 'x'
+    )).toBe(true)
+  })
+
+  it('self-destructs on ROUND_END when roll=1', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.gameSeed = DESTROY_SEED
+    game.jokers = [initializeJoker(jokers.cavendish, game)]
+    const after = reduceGame(game, { type: 'ROUND_END' })
+    expect(after.jokers.some(j => j.jokerId === 'cavendish')).toBe(false)
+  })
+
+  it('survives ROUND_END when roll!=1', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.gameSeed = SURVIVE_SEED
+    game.jokers = [initializeJoker(jokers.cavendish, game)]
+    const after = reduceGame(game, { type: 'ROUND_END' })
+    expect(after.jokers.some(j => j.jokerId === 'cavendish')).toBe(true)
+  })
+})

--- a/src/app/daily-card-game/domain/joker/jokers.ts
+++ b/src/app/daily-card-game/domain/joker/jokers.ts
@@ -2352,6 +2352,51 @@ export const grosMichel: JokerDefinition = {
   rarity: 'common',
 }
 
+export const cavendish: JokerDefinition = {
+  id: 'cavendish',
+  name: 'Cavendish',
+  description: 'X3 Mult. 1 in 1000 chance this card is destroyed at the end of round',
+  price: 4,
+  effects: [
+    {
+      event: { type: 'HAND_SCORING_FINALIZE' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        ctx.game.gamePlayState.scoringEvents.push({
+          id: uuid(),
+          type: 'mult',
+          operator: 'x',
+          value: 3,
+          source: 'Cavendish',
+        })
+        ctx.game.gamePlayState.score.mult *= 3
+      },
+    },
+    {
+      event: { type: 'ROUND_END' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        const seed = buildSeedString([
+          ctx.game.gameSeed,
+          ctx.game.roundIndex.toString(),
+          'cavendish',
+          'destroy',
+        ])
+        const roll = getRandomNumbersWithSeed({
+          seed,
+          min: 1,
+          max: 1000,
+          numberOfNumbers: 1,
+        })
+        if (roll[0] === 1) {
+          ctx.game.jokers = ctx.game.jokers.filter(j => j.jokerId !== 'cavendish')
+        }
+      },
+    },
+  ],
+  rarity: 'common',
+}
+
 export const runner: JokerDefinition = {
   id: 'runner',
   name: 'Runner',
@@ -2682,6 +2727,7 @@ export const jokers: Record<JokerDefinition['id'], JokerDefinition> = {
   creditCard,
   delayedGratification,
   grosMichel,
+  cavendish,
   runner,
   iceCream,
   egg,


### PR DESCRIPTION
## Summary
- Implements the Cavendish common joker: X3 Mult with 1 in 1000 self-destruct chance at round end
- Adds 4 unit tests covering X mult effect, scoring event format, self-destruct, and survival

Closes #731

## Test plan
- [x] Unit tests pass (`npx vitest run cavendish`)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)