### PR TITLE
Implement Photograph common joker (#735)

### DIFF
--- a/src/app/daily-card-game/domain/game/__tests__/photograph.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/photograph.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest'
+import { defaultGameState } from '@/app/daily-card-game/domain/game/default-game-state'
+import { reduceGame } from '@/app/daily-card-game/domain/game/reduce-game'
+import type { GameState } from '@/app/daily-card-game/domain/game/types'
+import { jokers } from '@/app/daily-card-game/domain/joker/jokers'
+import { initializeJoker } from '@/app/daily-card-game/domain/joker/utils'
+import { playingCards } from '@/app/daily-card-game/domain/playing-card/playing-cards'
+
+describe('Photograph joker', () => {
+  it('first face card scored gives X2 Mult', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.jokers = [initializeJoker(jokers.photograph, game)]
+    game.rounds[game.roundIndex].smallBlind.status = 'inProgress'
+    game.gamePhase = 'gameplay'
+    game.gamePlayState.score = { chips: 10, mult: 5 }
+
+    const jackId = Object.keys(game.cards).find(id =>
+      playingCards[game.cards[id].playingCardId]?.value === 'J'
+    )!
+
+    const after = reduceGame({
+      ...game,
+      gamePlayState: { ...game.gamePlayState, cardsToScore: [game.cards[jackId]] },
+    }, { type: 'CARD_SCORED' })
+
+    expect(after.gamePlayState.scoringEvents.some(
+      e => 'source' in e && e.source === 'Photograph' && 'operator' in e && e.operator === 'x' && e.value === 2
+    )).toBe(true)
+    expect(after.gamePlayState.score.mult).toBe(10)
+  })
+
+  it('second face card does NOT give X2 Mult (only first per hand)', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.jokers = [initializeJoker(jokers.photograph, game)]
+    game.rounds[game.roundIndex].smallBlind.status = 'inProgress'
+    game.gamePhase = 'gameplay'
+    game.gamePlayState.score = { chips: 10, mult: 5 }
+
+    const faceCardIds = Object.keys(game.cards).filter(id =>
+      ['J', 'Q', 'K'].includes(playingCards[game.cards[id].playingCardId]?.value)
+    )
+    const [firstId, secondId] = faceCardIds
+
+    // Score first face card
+    const afterFirst = reduceGame({
+      ...game,
+      gamePlayState: { ...game.gamePlayState, cardsToScore: [game.cards[firstId]] },
+    }, { type: 'CARD_SCORED' })
+
+    // Score second face card
+    const afterSecond = reduceGame({
+      ...afterFirst,
+      gamePlayState: { ...afterFirst.gamePlayState, cardsToScore: [afterFirst.cards[secondId]] },
+    }, { type: 'CARD_SCORED' })
+
+    const photographEvents = afterSecond.gamePlayState.scoringEvents.filter(
+      e => 'source' in e && e.source === 'Photograph'
+    )
+    expect(photographEvents).toHaveLength(1)
+  })
+
+  it('non-face cards do not trigger', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.jokers = [initializeJoker(jokers.photograph, game)]
+    game.rounds[game.roundIndex].smallBlind.status = 'inProgress'
+    game.gamePhase = 'gameplay'
+
+    const fiveId = Object.keys(game.cards).find(id =>
+      playingCards[game.cards[id].playingCardId]?.value === '5'
+    )!
+
+    const after = reduceGame({
+      ...game,
+      gamePlayState: { ...game.gamePlayState, cardsToScore: [game.cards[fiveId]] },
+    }, { type: 'CARD_SCORED' })
+
+    expect(after.gamePlayState.scoringEvents.some(
+      e => 'source' in e && e.source === 'Photograph'
+    )).toBe(false)
+  })
+})

--- a/src/app/daily-card-game/domain/joker/jokers.ts
+++ b/src/app/daily-card-game/domain/joker/jokers.ts
@@ -2529,6 +2529,45 @@ export const egg: JokerDefinition = {
   rarity: 'common',
 }
 
+export const photograph: JokerDefinition = {
+  id: 'photograph',
+  name: 'Photograph',
+  description: 'First played face card gives X2 Mult when scored',
+  price: 5,
+  effects: [
+    {
+      event: { type: 'HAND_SCORING_START' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        const pj = ctx.game.jokers.find(j => j.jokerId === 'photograph')
+        if (pj) pj.counter = 0
+      },
+    },
+    {
+      event: { type: 'CARD_SCORED' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        const pj = ctx.game.jokers.find(j => j.jokerId === 'photograph')
+        if (!pj || pj.counter !== 0) return
+        const scoredCard = ctx.scoredCards?.[0]
+        if (!scoredCard) return
+        const cardDef = playingCards[scoredCard.playingCardId]
+        if (!['J', 'Q', 'K'].includes(cardDef.value)) return
+        pj.counter = 1
+        ctx.game.gamePlayState.scoringEvents.push({
+          id: uuid(),
+          type: 'mult',
+          operator: 'x',
+          value: 2,
+          source: 'Photograph',
+        })
+        ctx.game.gamePlayState.score.mult *= 2
+      },
+    },
+  ],
+  rarity: 'common',
+}
+
 export const splash: JokerDefinition = {
   id: 'splash',
   name: 'Splash',
@@ -2799,6 +2838,7 @@ export const jokers: Record<JokerDefinition['id'], JokerDefinition> = {
   redCard,
   iceCream,
   egg,
+  photograph,
   splash,
   greenJoker,
   superposition,


### PR DESCRIPTION
## Summary
- Implements the Photograph common joker: first played face card gives X2 Mult when scored
- Uses counter to track trigger state per hand (reset on HAND_SCORING_START)
- Adds 3 unit tests covering first face card trigger, second face card rejection, and non-face exclusion

Closes #735

## Test plan
- [x] Unit tests pass (`npx vitest run photograph`)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)