### PR TITLE
Implement Popcorn common joker (#746)

### DIFF
--- a/src/app/daily-card-game/domain/game/__tests__/popcorn.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/popcorn.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest'
+import { defaultGameState } from '@/app/daily-card-game/domain/game/default-game-state'
+import { reduceGame } from '@/app/daily-card-game/domain/game/reduce-game'
+import type { GameState } from '@/app/daily-card-game/domain/game/types'
+import { jokers } from '@/app/daily-card-game/domain/joker/jokers'
+import { initializeJoker } from '@/app/daily-card-game/domain/joker/utils'
+
+describe('Popcorn joker', () => {
+  function setupGame(): GameState {
+    const game: GameState = structuredClone(defaultGameState)
+    game.jokers = [initializeJoker(jokers.popcorn, game)]
+    game.rounds[game.roundIndex].smallBlind.status = 'inProgress'
+    game.gamePhase = 'gameplay'
+    return reduceGame(game, { type: 'GAME_START' })
+  }
+
+  it('gives +20 Mult on first hand (counter initializes to 20)', () => {
+    const started = setupGame()
+    const hand: GameState = {
+      ...started,
+      gamePlayState: {
+        ...started.gamePlayState,
+        selectedHand: ['pair', []],
+        score: { chips: 0, mult: 1 },
+      },
+    }
+    const after = reduceGame(hand, { type: 'HAND_SCORING_FINALIZE' })
+    expect(after.gamePlayState.scoringEvents.some(
+      e => 'source' in e && e.source === 'Popcorn' && 'value' in e && e.value === 20
+    )).toBe(true)
+  })
+
+  it('decreases counter by 4 on ROUND_END', () => {
+    // First fire HAND_SCORING_FINALIZE to initialize counter to 20
+    const started = setupGame()
+    const hand: GameState = {
+      ...started,
+      gamePlayState: {
+        ...started.gamePlayState,
+        selectedHand: ['pair', []],
+        score: { chips: 0, mult: 1 },
+      },
+    }
+    const afterHand = reduceGame(hand, { type: 'HAND_SCORING_FINALIZE' })
+    const popcornBefore = afterHand.jokers.find(j => j.jokerId === 'popcorn')
+    expect(popcornBefore?.counter).toBe(20)
+
+    const after = reduceGame(afterHand, { type: 'ROUND_END' })
+    const popcornAfter = after.jokers.find(j => j.jokerId === 'popcorn')
+    expect(popcornAfter?.counter).toBe(16)
+  })
+
+  it('self-destructs when counter reaches 0', () => {
+    const started = setupGame()
+
+    // Play 5 rounds to deplete from 20 to 0 (20 / 4 = 5 rounds)
+    // First trigger HAND_SCORING_FINALIZE to initialize counter
+    const hand: GameState = {
+      ...started,
+      gamePlayState: {
+        ...started.gamePlayState,
+        selectedHand: ['pair', []],
+        score: { chips: 0, mult: 1 },
+      },
+    }
+    let state: GameState = reduceGame(hand, { type: 'HAND_SCORING_FINALIZE' })
+
+    for (let i = 0; i < 5; i++) {
+      state = reduceGame(state, { type: 'ROUND_END' })
+    }
+
+    const popcornInstance = state.jokers.find(j => j.jokerId === 'popcorn')
+    expect(popcornInstance).toBeUndefined()
+  })
+})

--- a/src/app/daily-card-game/domain/joker/jokers.ts
+++ b/src/app/daily-card-game/domain/joker/jokers.ts
@@ -2509,6 +2509,52 @@ export const iceCream: JokerDefinition = {
   rarity: 'common',
 }
 
+export const popcorn: JokerDefinition = {
+  id: 'popcorn',
+  name: 'Popcorn',
+  description: '+20 Mult. -4 Mult per round played',
+  price: 5,
+  effects: [
+    {
+      event: { type: 'HAND_SCORING_FINALIZE' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        const pj = ctx.game.jokers.find(j => j.jokerId === 'popcorn')
+        if (!pj) return
+
+        // Initialize counter to 20 on first use
+        if (pj.counter === 0) {
+          pj.counter = 20
+        }
+
+        // Apply current mult bonus
+        if (pj.counter > 0) {
+          ctx.game.gamePlayState.scoringEvents.push({
+            id: uuid(),
+            type: 'mult',
+            value: pj.counter,
+            source: 'Popcorn',
+          })
+          ctx.game.gamePlayState.score.mult += pj.counter
+        }
+      },
+    },
+    {
+      event: { type: 'ROUND_END' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        const pj = ctx.game.jokers.find(j => j.jokerId === 'popcorn')
+        if (!pj) return
+        pj.counter -= 4
+        if (pj.counter <= 0) {
+          ctx.game.jokers = ctx.game.jokers.filter(j => j.id !== pj.id)
+        }
+      },
+    },
+  ],
+  rarity: 'common',
+}
+
 export const egg: JokerDefinition = {
   id: 'egg',
   name: 'Egg',
@@ -2837,6 +2883,7 @@ export const jokers: Record<JokerDefinition['id'], JokerDefinition> = {
   squareJoker,
   redCard,
   iceCream,
+  popcorn,
   egg,
   photograph,
   splash,


### PR DESCRIPTION
## Summary
- Implements the Popcorn common joker: +20 Mult depleting by 4 per round, self-destructs at 0
- Uses lazy counter initialization (same pattern as Ice Cream)
- Adds 3 unit tests covering mult bonus, round depletion, and self-destruct

Closes #746

## Test plan
- [x] Unit tests pass (`npx vitest run popcorn`)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)