### PR TITLE
Implement Faceless Joker common joker (#748)

### DIFF
--- a/src/app/daily-card-game/domain/game/__tests__/faceless-joker.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/faceless-joker.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest'
+import { defaultGameState } from '@/app/daily-card-game/domain/game/default-game-state'
+import { reduceGame } from '@/app/daily-card-game/domain/game/reduce-game'
+import type { GameState } from '@/app/daily-card-game/domain/game/types'
+import { jokers } from '@/app/daily-card-game/domain/joker/jokers'
+import { initializeJoker } from '@/app/daily-card-game/domain/joker/utils'
+import { playingCards } from '@/app/daily-card-game/domain/playing-card/playing-cards'
+
+describe('Faceless Joker', () => {
+  function getCardIdsByValue(game: GameState, value: string): string[] {
+    return Object.keys(game.cards).filter(
+      id => playingCards[game.cards[id].playingCardId]?.value === value
+    )
+  }
+
+  function makeGameWithFacelessJoker(): GameState {
+    const game: GameState = structuredClone(defaultGameState)
+    game.jokers = [initializeJoker(jokers.facelessJoker, game)]
+    game.rounds[game.roundIndex].smallBlind.status = 'inProgress'
+    game.gamePhase = 'gameplay'
+    return game
+  }
+
+  it('earns $5 when exactly 3 face cards are discarded', () => {
+    const game = makeGameWithFacelessJoker()
+    const jackIds = getCardIdsByValue(game, 'J')
+    const queenIds = getCardIdsByValue(game, 'Q')
+    const kingIds = getCardIdsByValue(game, 'K')
+
+    expect(jackIds.length).toBeGreaterThanOrEqual(1)
+    expect(queenIds.length).toBeGreaterThanOrEqual(1)
+    expect(kingIds.length).toBeGreaterThanOrEqual(1)
+
+    const selectedIds = [jackIds[0], queenIds[0], kingIds[0]]
+    game.gamePlayState.selectedCardIds = selectedIds
+
+    const initialMoney = game.money
+    const after = reduceGame(game, { type: 'DISCARD_SELECTED_CARDS' })
+    expect(after.money).toBe(initialMoney + 5)
+  })
+
+  it('earns $5 when more than 3 face cards are discarded', () => {
+    const game = makeGameWithFacelessJoker()
+    const jackIds = getCardIdsByValue(game, 'J')
+    const queenIds = getCardIdsByValue(game, 'Q')
+    const kingIds = getCardIdsByValue(game, 'K')
+
+    expect(jackIds.length).toBeGreaterThanOrEqual(2)
+    expect(queenIds.length).toBeGreaterThanOrEqual(1)
+    expect(kingIds.length).toBeGreaterThanOrEqual(1)
+
+    const selectedIds = [jackIds[0], jackIds[1], queenIds[0], kingIds[0]]
+    game.gamePlayState.selectedCardIds = selectedIds
+
+    const initialMoney = game.money
+    const after = reduceGame(game, { type: 'DISCARD_SELECTED_CARDS' })
+    expect(after.money).toBe(initialMoney + 5)
+  })
+
+  it('does not earn $5 when fewer than 3 face cards are discarded', () => {
+    const game = makeGameWithFacelessJoker()
+    const jackIds = getCardIdsByValue(game, 'J')
+    const aceIds = getCardIdsByValue(game, 'A')
+
+    expect(jackIds.length).toBeGreaterThanOrEqual(2)
+    expect(aceIds.length).toBeGreaterThanOrEqual(1)
+
+    // Only 2 face cards (Jacks), plus a non-face card (Ace)
+    const selectedIds = [jackIds[0], jackIds[1], aceIds[0]]
+    game.gamePlayState.selectedCardIds = selectedIds
+
+    const initialMoney = game.money
+    const after = reduceGame(game, { type: 'DISCARD_SELECTED_CARDS' })
+    expect(after.money).toBe(initialMoney)
+  })
+
+  it('does not earn $5 when no face cards are discarded', () => {
+    const game = makeGameWithFacelessJoker()
+    const aceIds = getCardIdsByValue(game, 'A')
+    const twoIds = getCardIdsByValue(game, '2')
+
+    expect(aceIds.length).toBeGreaterThanOrEqual(2)
+    expect(twoIds.length).toBeGreaterThanOrEqual(1)
+
+    const selectedIds = [aceIds[0], aceIds[1], twoIds[0]]
+    game.gamePlayState.selectedCardIds = selectedIds
+
+    const initialMoney = game.money
+    const after = reduceGame(game, { type: 'DISCARD_SELECTED_CARDS' })
+    expect(after.money).toBe(initialMoney)
+  })
+})

--- a/src/app/daily-card-game/domain/game/handlers/gameplay.ts
+++ b/src/app/daily-card-game/domain/game/handlers/gameplay.ts
@@ -70,6 +70,22 @@ export function handleDiscardSelectedCards(draft: GameState, event: GameEvent) {
   discardCardsFromHand(draft as unknown as GameState, gamePlayState.selectedCardIds)
 
   draft.discardsPlayed += 1
+
+  // Dispatch joker effects for DISCARD_SELECTED_CARDS before clearing selectedCardIds
+  // so effects can read which cards were discarded
+  const ctx: EffectContext = {
+    event,
+    game: draft as unknown as GameState,
+    score: gamePlayState.score,
+    playedCards: [],
+    round: draft.rounds[draft.roundIndex],
+    bossBlind: draft.rounds[draft.roundIndex].bossBlind,
+    jokers: draft.jokers,
+    vouchers: draft.vouchers,
+    tags: draft.tags,
+  }
+  dispatchEffects(event, ctx, collectEffects(ctx.game))
+
   gamePlayState.selectedCardIds = []
   gamePlayState.selectedHand = undefined
   gamePlayState.cardsToScore = []
@@ -93,20 +109,6 @@ export function handleDiscardSelectedCards(draft: GameState, event: GameEvent) {
       draft.consumables.push(initializeTarotCard(getRandomTarotCards(1, randomTarotCardsSeed)[0]))
     }
   }
-
-  // Dispatch joker effects for DISCARD_SELECTED_CARDS
-  const ctx: EffectContext = {
-    event,
-    game: draft as unknown as GameState,
-    score: gamePlayState.score,
-    playedCards: [],
-    round: draft.rounds[draft.roundIndex],
-    bossBlind: draft.rounds[draft.roundIndex].bossBlind,
-    jokers: draft.jokers,
-    vouchers: draft.vouchers,
-    tags: draft.tags,
-  }
-  dispatchEffects(event, ctx, collectEffects(ctx.game))
 }
 
 /**

--- a/src/app/daily-card-game/domain/joker/jokers.ts
+++ b/src/app/daily-card-game/domain/joker/jokers.ts
@@ -2808,6 +2808,35 @@ export const redCard: JokerDefinition = {
   rarity: 'common',
 }
 
+export const facelessJoker: JokerDefinition = {
+  id: 'facelessJoker',
+  name: 'Faceless Joker',
+  description: 'Earn $5 if 3 or more face cards are discarded at the same time',
+  price: 4,
+  effects: [
+    {
+      event: { type: 'DISCARD_SELECTED_CARDS' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        const faceValues = ['J', 'Q', 'K']
+        let faceCardCount = 0
+        for (const cardId of ctx.game.gamePlayState.selectedCardIds) {
+          const cardState = ctx.game.cards[cardId]
+          if (!cardState) continue
+          const cardDef = playingCards[cardState.playingCardId]
+          if (faceValues.includes(cardDef.value)) {
+            faceCardCount++
+          }
+        }
+        if (faceCardCount >= 3) {
+          ctx.game.money += 5
+        }
+      },
+    },
+  ],
+  rarity: 'common',
+}
+
 export const jokers: Record<JokerDefinition['id'], JokerDefinition> = {
   swashbucklerJoker,
   walkieTalkieJoker,
@@ -2890,6 +2919,7 @@ export const jokers: Record<JokerDefinition['id'], JokerDefinition> = {
   greenJoker,
   superposition,
   toDoList,
+  facelessJoker,
 }
 
 /***


### PR DESCRIPTION
## Summary
- Implements the Faceless Joker common joker: earn $5 if 3+ face cards discarded at once
- Fixes discard effect dispatch timing so effects can read selectedCardIds before it's cleared
- Adds 4 unit tests covering threshold conditions

Closes #748

## Test plan
- [x] Unit tests pass (`npx vitest run faceless-joker`)
- [x] Full test suite passes (1178 tests)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)