### PR TITLE
Implement Golden Ticket common joker (#751)

### DIFF
--- a/src/app/daily-card-game/domain/game/__tests__/golden-ticket.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/golden-ticket.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest'
+import { defaultGameState } from '@/app/daily-card-game/domain/game/default-game-state'
+import { reduceGame } from '@/app/daily-card-game/domain/game/reduce-game'
+import type { GameState } from '@/app/daily-card-game/domain/game/types'
+import { jokers } from '@/app/daily-card-game/domain/joker/jokers'
+import { initializeJoker } from '@/app/daily-card-game/domain/joker/utils'
+import type { PlayingCardState } from '@/app/daily-card-game/domain/playing-card/types'
+
+function makeCard(id: string, enchantment: PlayingCardState['flags']['enchantment']): PlayingCardState {
+  return {
+    id,
+    playingCardId: '5_hearts',
+    bonusChips: 0,
+    isFaceUp: true,
+    flags: { edition: 'normal', enchantment, seal: 'none' },
+  }
+}
+
+describe('Golden Ticket joker', () => {
+  function createGame(): GameState {
+    const game: GameState = structuredClone(defaultGameState)
+    game.jokers = [initializeJoker(jokers.goldenTicket, game)]
+    game.rounds[game.roundIndex].smallBlind.status = 'inProgress'
+    game.gamePhase = 'gameplay'
+    return game
+  }
+
+  it('earns $4 when a Gold card is scored', () => {
+    const game = createGame()
+    const card = makeCard('card-gold', 'gold')
+    game.cards['card-gold'] = card
+
+    const moneyBefore = game.money
+    const after = reduceGame(
+      { ...game, gamePlayState: { ...game.gamePlayState, cardsToScore: [card] } },
+      { type: 'CARD_SCORED' }
+    )
+    expect(after.money).toBe(moneyBefore + 4)
+  })
+
+  it('earns nothing when a non-gold card is scored', () => {
+    const game = createGame()
+    const card = makeCard('card-bonus', 'bonus')
+    game.cards['card-bonus'] = card
+
+    const moneyBefore = game.money
+    const after = reduceGame(
+      { ...game, gamePlayState: { ...game.gamePlayState, cardsToScore: [card] } },
+      { type: 'CARD_SCORED' }
+    )
+    expect(after.money).toBe(moneyBefore)
+  })
+
+  it('earns $4 for each gold card scored separately', () => {
+    const game = createGame()
+    const card1 = makeCard('card-gold-1', 'gold')
+    const card2 = makeCard('card-gold-2', 'gold')
+    game.cards['card-gold-1'] = card1
+    game.cards['card-gold-2'] = card2
+
+    const moneyBefore = game.money
+
+    const afterFirst = reduceGame(
+      { ...game, gamePlayState: { ...game.gamePlayState, cardsToScore: [card1] } },
+      { type: 'CARD_SCORED' }
+    )
+    const afterSecond = reduceGame(
+      { ...afterFirst, gamePlayState: { ...afterFirst.gamePlayState, cardsToScore: [card2] } },
+      { type: 'CARD_SCORED' }
+    )
+    expect(afterSecond.money).toBe(moneyBefore + 8)
+  })
+})

--- a/src/app/daily-card-game/domain/joker/jokers.ts
+++ b/src/app/daily-card-game/domain/joker/jokers.ts
@@ -2877,6 +2877,26 @@ export const facelessJoker: JokerDefinition = {
   rarity: 'common',
 }
 
+export const goldenTicket: JokerDefinition = {
+  id: 'goldenTicket',
+  name: 'Golden Ticket',
+  description: 'Played Gold cards earn $4 when scored',
+  price: 5,
+  effects: [
+    {
+      event: { type: 'CARD_SCORED' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        const scoredCard = ctx.scoredCards?.[0]
+        if (!scoredCard) return
+        if (scoredCard.flags.enchantment !== 'gold') return
+        ctx.game.money += 4
+      },
+    },
+  ],
+  rarity: 'common',
+}
+
 export const jokers: Record<JokerDefinition['id'], JokerDefinition> = {
   swashbucklerJoker,
   walkieTalkieJoker,
@@ -2961,6 +2981,7 @@ export const jokers: Record<JokerDefinition['id'], JokerDefinition> = {
   toDoList,
   facelessJoker,
   rideTheBus,
+  goldenTicket,
 }
 
 /***


### PR DESCRIPTION
## Summary
- Implements the Golden Ticket common joker: Gold cards earn $4 when scored
- Adds 3 unit tests covering gold card trigger, non-gold rejection, and multiple gold cards

Closes #751

## Test plan
- [x] Unit tests pass (`npx vitest run golden-ticket`)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)