### PR TITLE
Implement Hallucination common joker (#743)

### DIFF
--- a/src/app/daily-card-game/domain/game/__tests__/hallucination.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/hallucination.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest'
+import { defaultGameState } from '@/app/daily-card-game/domain/game/default-game-state'
+import { reduceGame } from '@/app/daily-card-game/domain/game/reduce-game'
+import type { GameState } from '@/app/daily-card-game/domain/game/types'
+import { jokers } from '@/app/daily-card-game/domain/joker/jokers'
+import { initializeJoker } from '@/app/daily-card-game/domain/joker/utils'
+import type { PackState } from '@/app/daily-card-game/domain/shop/types'
+
+// With gameSeed='test-seed-1', roundIndex=1: roll=1 (success)
+// With gameSeed='test-seed', roundIndex=1:   roll=2 (failure)
+const SUCCESS_SEED = 'test-seed-1'
+const FAILURE_SEED = 'test-seed'
+
+function makeJokerPack(): PackState {
+  return {
+    id: 'pack-1',
+    rarity: 'normal',
+    remainingCardsToSelect: 1,
+    cards: [
+      {
+        type: 'jokerCard',
+        card: {} as any,
+        price: 4,
+      },
+    ],
+  }
+}
+
+function makeGame(gameSeed: string): GameState {
+  const game: GameState = structuredClone(defaultGameState)
+  game.gameSeed = gameSeed
+  game.jokers = [initializeJoker(jokers.hallucination, game)]
+  game.money = 100
+  game.shopState.packsForSale = [makeJokerPack()]
+  return game
+}
+
+describe('Hallucination joker', () => {
+  it('creates a Tarot card when roll succeeds and room is available', () => {
+    const game = makeGame(SUCCESS_SEED)
+    const before = game.consumables.length
+
+    const after = reduceGame(game, { type: 'SHOP_OPEN_PACK', id: 'pack-1' })
+
+    expect(after.consumables.length).toBe(before + 1)
+    expect(after.consumables[after.consumables.length - 1].consumableType).toBe('tarotCard')
+  })
+
+  it('does not create a Tarot card when roll fails', () => {
+    const game = makeGame(FAILURE_SEED)
+    const before = game.consumables.length
+
+    const after = reduceGame(game, { type: 'SHOP_OPEN_PACK', id: 'pack-1' })
+
+    expect(after.consumables.length).toBe(before)
+  })
+
+  it('does not create a Tarot card when consumables are full', () => {
+    const game = makeGame(SUCCESS_SEED)
+
+    // Fill consumables to capacity
+    game.consumables = Array.from({ length: game.maxConsumables }, (_, i) => ({
+      id: `tarot-${i}`,
+      consumableType: 'tarotCard' as const,
+      name: 'The Fool',
+      isFaceUp: true,
+      tarotType: 'theFool' as const,
+    }))
+
+    const before = game.consumables.length
+    const after = reduceGame(game, { type: 'SHOP_OPEN_PACK', id: 'pack-1' })
+
+    expect(after.consumables.length).toBe(before)
+  })
+})

--- a/src/app/daily-card-game/domain/game/reduce-game.ts
+++ b/src/app/daily-card-game/domain/game/reduce-game.ts
@@ -221,6 +221,8 @@ export function reduceGame(game: GameState, event: GameEvent): GameState {
       }
       case 'SHOP_OPEN_PACK': {
         handleShopOpenPack(draft, event)
+        const ctx = getEffectContext(draft, event)
+        dispatchEffects(event, ctx, collectEffects(ctx.game))
         return
       }
       case 'SHOP_BUY_VOUCHER': {

--- a/src/app/daily-card-game/domain/joker/jokers.ts
+++ b/src/app/daily-card-game/domain/joker/jokers.ts
@@ -2127,6 +2127,34 @@ export const eightBall: JokerDefinition = {
   rarity: 'common',
 }
 
+export const hallucination: JokerDefinition = {
+  id: 'hallucination',
+  name: 'Hallucination',
+  description: '1 in 2 chance to create a Tarot card when any Booster Pack is opened (Must have room)',
+  price: 4,
+  effects: [
+    {
+      event: { type: 'SHOP_OPEN_PACK' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        if (ctx.game.consumables.length >= ctx.game.maxConsumables) return
+        const seed = buildSeedString([
+          ctx.game.gameSeed,
+          ctx.game.roundIndex.toString(),
+          'hallucination',
+          'chance',
+        ])
+        const roll = getRandomNumbersWithSeed({ seed, min: 1, max: 2, numberOfNumbers: 1 })
+        if (roll[0] !== 1) return
+        const tarotSeed = buildSeedString([seed, 'tarot'])
+        const tarotCard = getRandomTarotCards(1, tarotSeed)[0]
+        ctx.game.consumables.push(initializeTarotCard(tarotCard))
+      },
+    },
+  ],
+  rarity: 'common',
+}
+
 export const businessCard: JokerDefinition = {
   id: 'businessCard',
   name: 'Business Card',
@@ -3024,6 +3052,7 @@ export const jokers: Record<JokerDefinition['id'], JokerDefinition> = {
   rideTheBus,
   goldenTicket,
   reservedParking,
+  hallucination,
 }
 
 /***

--- a/src/app/daily-card-game/domain/joker/jokers.ts
+++ b/src/app/daily-card-game/domain/joker/jokers.ts
@@ -2134,7 +2134,7 @@ export const hallucination: JokerDefinition = {
   price: 4,
   effects: [
     {
-      event: { type: 'SHOP_OPEN_PACK' },
+      event: { type: 'SHOP_OPEN_PACK', id: '' },
       priority: 1,
       apply: (ctx: EffectContext) => {
         if (ctx.game.consumables.length >= ctx.game.maxConsumables) return


### PR DESCRIPTION
## Summary
- Implements the Hallucination common joker: 1 in 2 chance for Tarot on booster pack open
- Adds dispatchEffects to SHOP_OPEN_PACK handler for joker effect support
- Adds 3 unit tests covering success, failure, and full consumables

Closes #743

## Test plan
- [x] Unit tests pass (`npx vitest run hallucination`)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)