### PR TITLE
Implement Hanging Chad common joker (#737)

### DIFF
--- a/src/app/daily-card-game/domain/game/__tests__/hanging-chad.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/hanging-chad.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from 'vitest'
+import { defaultGameState } from '@/app/daily-card-game/domain/game/default-game-state'
+import { reduceGame } from '@/app/daily-card-game/domain/game/reduce-game'
+import type { GameState } from '@/app/daily-card-game/domain/game/types'
+import { jokers } from '@/app/daily-card-game/domain/joker/jokers'
+import { initializeJoker } from '@/app/daily-card-game/domain/joker/utils'
+import { playingCards } from '@/app/daily-card-game/domain/playing-card/playing-cards'
+
+describe('Hanging Chad joker', () => {
+  it('first scored card gets 2 extra chip scoring events', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.jokers = [initializeJoker(jokers.hangingChad, game)]
+    game.rounds[game.roundIndex].smallBlind.status = 'inProgress'
+    game.gamePhase = 'gameplay'
+
+    const aceId = Object.keys(game.cards).find(id =>
+      playingCards[game.cards[id].playingCardId]?.value === 'A'
+    )!
+
+    const after = reduceGame({
+      ...game,
+      gamePlayState: { ...game.gamePlayState, cardsToScore: [game.cards[aceId]] },
+    }, { type: 'CARD_SCORED' })
+
+    const hangingChadEvents = after.gamePlayState.scoringEvents.filter(
+      e => 'source' in e && e.source === 'Hanging Chad'
+    )
+    expect(hangingChadEvents).toHaveLength(2)
+    // Ace baseChips = 11
+    expect(hangingChadEvents[0].value).toBe(11)
+    expect(hangingChadEvents[1].value).toBe(11)
+  })
+
+  it('second scored card does NOT get extra triggers', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.jokers = [initializeJoker(jokers.hangingChad, game)]
+    game.rounds[game.roundIndex].smallBlind.status = 'inProgress'
+    game.gamePhase = 'gameplay'
+
+    const aceIds = Object.keys(game.cards).filter(id =>
+      playingCards[game.cards[id].playingCardId]?.value === 'A'
+    )
+    const [firstId, secondId] = aceIds
+
+    // Score first card
+    const afterFirst = reduceGame({
+      ...game,
+      gamePlayState: { ...game.gamePlayState, cardsToScore: [game.cards[firstId]] },
+    }, { type: 'CARD_SCORED' })
+
+    // Score second card
+    const afterSecond = reduceGame({
+      ...afterFirst,
+      gamePlayState: { ...afterFirst.gamePlayState, cardsToScore: [afterFirst.cards[secondId]] },
+    }, { type: 'CARD_SCORED' })
+
+    const hangingChadEvents = afterSecond.gamePlayState.scoringEvents.filter(
+      e => 'source' in e && e.source === 'Hanging Chad'
+    )
+    // Only 2 events (from the first card), not 4
+    expect(hangingChadEvents).toHaveLength(2)
+  })
+
+  it('counter resets on HAND_SCORING_START for new hand', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.jokers = [initializeJoker(jokers.hangingChad, game)]
+    game.rounds[game.roundIndex].smallBlind.status = 'inProgress'
+    game.gamePhase = 'gameplay'
+
+    const aceIds = Object.keys(game.cards).filter(id =>
+      playingCards[game.cards[id].playingCardId]?.value === 'A'
+    )
+    const [firstId, secondId] = aceIds
+
+    // Score first card to trigger hanging chad (counter becomes 1)
+    const afterFirst = reduceGame({
+      ...game,
+      gamePlayState: { ...game.gamePlayState, cardsToScore: [game.cards[firstId]] },
+    }, { type: 'CARD_SCORED' })
+
+    // Verify counter is 1
+    const hcAfterFirst = afterFirst.jokers.find(j => j.jokerId === 'hangingChad')
+    expect(hcAfterFirst?.counter).toBe(1)
+
+    // Reset via HAND_SCORING_START
+    const afterReset = reduceGame(afterFirst, { type: 'HAND_SCORING_START' })
+    const hcAfterReset = afterReset.jokers.find(j => j.jokerId === 'hangingChad')
+    expect(hcAfterReset?.counter).toBe(0)
+
+    // Score another card - should trigger again since counter was reset
+    const afterSecond = reduceGame({
+      ...afterReset,
+      gamePlayState: { ...afterReset.gamePlayState, cardsToScore: [afterReset.cards[secondId]] },
+    }, { type: 'CARD_SCORED' })
+
+    const hangingChadEvents = afterSecond.gamePlayState.scoringEvents.filter(
+      e => 'source' in e && e.source === 'Hanging Chad'
+    )
+    // Should have 2 new events after reset
+    expect(hangingChadEvents.length).toBeGreaterThanOrEqual(2)
+  })
+})

--- a/src/app/daily-card-game/domain/joker/jokers.ts
+++ b/src/app/daily-card-game/domain/joker/jokers.ts
@@ -2966,6 +2966,45 @@ export const reservedParking: JokerDefinition = {
   rarity: 'common',
 }
 
+export const hangingChad: JokerDefinition = {
+  id: 'hangingChad',
+  name: 'Hanging Chad',
+  description: 'Retrigger first played card used in scoring 2 additional times',
+  price: 4,
+  effects: [
+    {
+      event: { type: 'HAND_SCORING_START' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        const hc = ctx.game.jokers.find(j => j.jokerId === 'hangingChad')
+        if (hc) hc.counter = 0
+      },
+    },
+    {
+      event: { type: 'CARD_SCORED' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        const hc = ctx.game.jokers.find(j => j.jokerId === 'hangingChad')
+        if (!hc || hc.counter !== 0) return
+        hc.counter = 1
+        const scoredCard = ctx.scoredCards?.[0]
+        if (!scoredCard) return
+        const cardDef = playingCards[scoredCard.playingCardId]
+        for (let i = 0; i < 2; i++) {
+          ctx.game.gamePlayState.scoringEvents.push({
+            id: uuid(),
+            type: 'chips',
+            value: cardDef.baseChips,
+            source: 'Hanging Chad',
+          })
+          ctx.game.gamePlayState.score.chips += cardDef.baseChips
+        }
+      },
+    },
+  ],
+  rarity: 'common',
+}
+
 export const mailInRebate: JokerDefinition = {
   id: 'mailInRebate',
   name: 'Mail-In Rebate',
@@ -3090,6 +3129,7 @@ export const jokers: Record<JokerDefinition['id'], JokerDefinition> = {
   reservedParking,
   hallucination,
   mailInRebate,
+  hangingChad,
 }
 
 /***


### PR DESCRIPTION
## Summary
- Implements the Hanging Chad common joker: retrigger first scored card 2 additional times
- Uses counter to track first-card state per hand (reset on HAND_SCORING_START)
- Adds 3 unit tests covering retrigger, second card exclusion, and counter reset

Closes #737

## Test plan
- [x] Unit tests pass (`npx vitest run hanging-chad`)
- [x] Full test suite passes (1199 tests)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)