### PR TITLE
Implement Riff-Raff common joker (#734)

### DIFF
--- a/src/app/daily-card-game/domain/game/__tests__/riff-raff.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/riff-raff.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest'
+import { defaultGameState } from '@/app/daily-card-game/domain/game/default-game-state'
+import { reduceGame } from '@/app/daily-card-game/domain/game/reduce-game'
+import type { GameState } from '@/app/daily-card-game/domain/game/types'
+import { jokers } from '@/app/daily-card-game/domain/joker/jokers'
+import { initializeJoker } from '@/app/daily-card-game/domain/joker/utils'
+
+describe('Riff-Raff joker', () => {
+  function setupGame(overrides: Partial<GameState> = {}): GameState {
+    const game: GameState = structuredClone(defaultGameState)
+    game.jokers = [initializeJoker(jokers.riffRaff, game)]
+    return { ...game, ...overrides }
+  }
+
+  it('creates 2 common jokers when SMALL_BLIND_SELECTED and 2+ slots available', () => {
+    const game = setupGame()
+    // 1 joker (riff-raff itself), maxJokers is 5, so 4 slots available
+    expect(game.jokers.length).toBe(1)
+    const after = reduceGame(game, { type: 'SMALL_BLIND_SELECTED' })
+    expect(after.jokers.length).toBe(3)
+    // The 2 new jokers should be common
+    const newJokers = after.jokers.slice(1)
+    for (const j of newJokers) {
+      const def = Object.values(jokers).find(d => d.id === j.jokerId)
+      expect(def?.rarity).toBe('common')
+    }
+  })
+
+  it('creates 2 common jokers when BIG_BLIND_SELECTED and 2+ slots available', () => {
+    const game = setupGame()
+    const after = reduceGame(game, { type: 'BIG_BLIND_SELECTED' })
+    expect(after.jokers.length).toBe(3)
+  })
+
+  it('creates 2 common jokers when BOSS_BLIND_SELECTED and 2+ slots available', () => {
+    const game = setupGame()
+    const after = reduceGame(game, { type: 'BOSS_BLIND_SELECTED' })
+    expect(after.jokers.length).toBe(3)
+  })
+
+  it('creates only 1 joker if only 1 slot available', () => {
+    const game = setupGame({ maxJokers: 2 })
+    // 1 riff-raff + maxJokers=2 → 1 slot available
+    expect(game.jokers.length).toBe(1)
+    const after = reduceGame(game, { type: 'SMALL_BLIND_SELECTED' })
+    expect(after.jokers.length).toBe(2)
+  })
+
+  it('creates 0 jokers if no slots available', () => {
+    const game = setupGame({ maxJokers: 1 })
+    // 1 riff-raff + maxJokers=1 → 0 slots available
+    const after = reduceGame(game, { type: 'SMALL_BLIND_SELECTED' })
+    expect(after.jokers.length).toBe(1)
+  })
+})

--- a/src/app/daily-card-game/domain/game/reduce-game.ts
+++ b/src/app/daily-card-game/domain/game/reduce-game.ts
@@ -95,14 +95,17 @@ export function reduceGame(game: GameState, event: GameEvent): GameState {
 
       case 'SMALL_BLIND_SELECTED': {
         handleSmallBlindSelected(draft)
+        dispatchEffects(event, getEffectContext(draft as unknown as GameState, event), collectEffects(draft as unknown as GameState))
         return
       }
       case 'BIG_BLIND_SELECTED': {
         handleBigBlindSelected(draft)
+        dispatchEffects(event, getEffectContext(draft as unknown as GameState, event), collectEffects(draft as unknown as GameState))
         return
       }
       case 'BOSS_BLIND_SELECTED': {
         handleBossBlindSelected(draft)
+        dispatchEffects(event, getEffectContext(draft as unknown as GameState, event), collectEffects(draft as unknown as GameState))
         return
       }
       case 'BLIND_SKIPPED': {

--- a/src/app/daily-card-game/domain/joker/jokers.ts
+++ b/src/app/daily-card-game/domain/joker/jokers.ts
@@ -10,12 +10,13 @@ import { cardValuePriority, playingCards } from '@/app/daily-card-game/domain/pl
 import {
   buildSeedString,
   getRandomNumbersWithSeed,
+  getRandomWeightedChoiceWithSeed,
   uuid,
 } from '@/app/daily-card-game/domain/randomness'
 import { initializeTarotCard } from '@/app/daily-card-game/domain/consumable/utils'
 import { getRandomTarotCards } from '@/app/daily-card-game/domain/shop/utils'
 
-import { JokerDefinition } from './types'
+import { JokerDefinition, JokerState } from './types'
 import { bonusOnCardScored, bonusOnHandPlayed, isJokerState } from './utils'
 
 export const jokerJoker: JokerDefinition = {
@@ -3041,6 +3042,80 @@ export const mailInRebate: JokerDefinition = {
   rarity: 'common',
 }
 
+function initializeJokerInline(jokerId: string, game: EffectContext['game']): JokerState {
+  const editionSeed = buildSeedString([
+    game.gameSeed,
+    game.roundIndex.toString(),
+    game.shopState.rerollsUsed.toString(),
+    'edition',
+    jokerId,
+  ])
+  const edition = getRandomWeightedChoiceWithSeed({
+    seed: editionSeed,
+    weightedOptions: game.shopState.joker.editionWeights,
+  }) ?? 'normal'
+  return {
+    id: uuid(),
+    jokerId,
+    edition,
+    isFaceUp: true,
+    bonusSellValue: 0,
+    counter: 0,
+    flags: {
+      isRentable: false,
+      isPerishable: false,
+      isEternal: false,
+    },
+  }
+}
+
+function applyRiffRaff(ctx: EffectContext) {
+  const availableSlots = ctx.game.maxJokers - ctx.game.jokers.length
+  if (availableSlots <= 0) return
+  const slotsToFill = Math.min(2, availableSlots)
+  const commonJokers = Object.values(jokers).filter(j => j.rarity === 'common')
+  const seed = buildSeedString([
+    ctx.game.gameSeed,
+    ctx.game.roundIndex.toString(),
+    'riffRaff',
+  ])
+  const indices = getRandomNumbersWithSeed({
+    seed,
+    min: 0,
+    max: commonJokers.length - 1,
+    numberOfNumbers: slotsToFill,
+  })
+  for (let i = 0; i < slotsToFill; i++) {
+    const jokerDef = commonJokers[indices[i]]
+    ctx.game.jokers.push(initializeJokerInline(jokerDef.id, ctx.game))
+  }
+}
+
+export const riffRaff: JokerDefinition = {
+  id: 'riffRaff',
+  name: 'Riff-raff',
+  description: 'When Blind is selected, create 2 Common Jokers (Must have room)',
+  price: 6,
+  effects: [
+    {
+      event: { type: 'SMALL_BLIND_SELECTED' },
+      priority: 1,
+      apply: applyRiffRaff,
+    },
+    {
+      event: { type: 'BIG_BLIND_SELECTED' },
+      priority: 1,
+      apply: applyRiffRaff,
+    },
+    {
+      event: { type: 'BOSS_BLIND_SELECTED' },
+      priority: 1,
+      apply: applyRiffRaff,
+    },
+  ],
+  rarity: 'common',
+}
+
 export const jokers: Record<JokerDefinition['id'], JokerDefinition> = {
   swashbucklerJoker,
   walkieTalkieJoker,
@@ -3130,6 +3205,7 @@ export const jokers: Record<JokerDefinition['id'], JokerDefinition> = {
   hallucination,
   mailInRebate,
   hangingChad,
+  riffRaff,
 }
 
 /***


### PR DESCRIPTION
## Summary
- Implements the Riff-Raff common joker: create 2 Common Jokers when Blind is selected
- Adds dispatchEffects to all blind selection event handlers (SMALL/BIG/BOSS_BLIND_SELECTED)
- Adds 5 unit tests covering all blind types, partial slots, and no slots

Closes #734

## Test plan
- [x] Unit tests pass (`npx vitest run riff-raff`)
- [x] Full test suite passes (1204 tests)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)