### PR TITLE
Implement Fibonacci uncommon joker (#758)

### DIFF
--- a/src/app/daily-card-game/domain/game/__tests__/fibonacci.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/fibonacci.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest'
+import { defaultGameState } from '@/app/daily-card-game/domain/game/default-game-state'
+import { reduceGame } from '@/app/daily-card-game/domain/game/reduce-game'
+import type { GameState } from '@/app/daily-card-game/domain/game/types'
+import { jokers } from '@/app/daily-card-game/domain/joker/jokers'
+import { initializeJoker } from '@/app/daily-card-game/domain/joker/utils'
+import { playingCards } from '@/app/daily-card-game/domain/playing-card/playing-cards'
+
+describe('Fibonacci joker', () => {
+  it('gives +8 Mult when an Ace is scored', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.jokers = [initializeJoker(jokers.fibonacci, game)]
+    game.rounds[game.roundIndex].smallBlind.status = 'inProgress'
+    game.gamePhase = 'gameplay'
+    const aceId = Object.keys(game.cards).find(id =>
+      playingCards[game.cards[id].playingCardId]?.value === 'A'
+    )!
+    const after = reduceGame({
+      ...game,
+      gamePlayState: { ...game.gamePlayState, cardsToScore: [game.cards[aceId]] },
+    }, { type: 'CARD_SCORED' })
+    expect(after.gamePlayState.scoringEvents.some(
+      e => 'source' in e && e.source === 'Fibonacci' && e.value === 8
+    )).toBe(true)
+  })
+
+  it('gives +8 Mult when a 2 is scored', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.jokers = [initializeJoker(jokers.fibonacci, game)]
+    game.rounds[game.roundIndex].smallBlind.status = 'inProgress'
+    game.gamePhase = 'gameplay'
+    const twoId = Object.keys(game.cards).find(id =>
+      playingCards[game.cards[id].playingCardId]?.value === '2'
+    )!
+    const after = reduceGame({
+      ...game,
+      gamePlayState: { ...game.gamePlayState, cardsToScore: [game.cards[twoId]] },
+    }, { type: 'CARD_SCORED' })
+    expect(after.gamePlayState.scoringEvents.some(
+      e => 'source' in e && e.source === 'Fibonacci' && e.value === 8
+    )).toBe(true)
+  })
+
+  it('no effect on non-fibonacci rank cards (4, K)', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.jokers = [initializeJoker(jokers.fibonacci, game)]
+    game.rounds[game.roundIndex].smallBlind.status = 'inProgress'
+    game.gamePhase = 'gameplay'
+    const fourId = Object.keys(game.cards).find(id =>
+      playingCards[game.cards[id].playingCardId]?.value === '4'
+    )!
+    const after = reduceGame({
+      ...game,
+      gamePlayState: { ...game.gamePlayState, cardsToScore: [game.cards[fourId]] },
+    }, { type: 'CARD_SCORED' })
+    expect(after.gamePlayState.scoringEvents.some(
+      e => 'source' in e && e.source === 'Fibonacci'
+    )).toBe(false)
+  })
+
+  it('scoring event has source Fibonacci and type mult', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.jokers = [initializeJoker(jokers.fibonacci, game)]
+    game.rounds[game.roundIndex].smallBlind.status = 'inProgress'
+    game.gamePhase = 'gameplay'
+    const fiveId = Object.keys(game.cards).find(id =>
+      playingCards[game.cards[id].playingCardId]?.value === '5'
+    )!
+    const after = reduceGame({
+      ...game,
+      gamePlayState: { ...game.gamePlayState, cardsToScore: [game.cards[fiveId]] },
+    }, { type: 'CARD_SCORED' })
+    const event = after.gamePlayState.scoringEvents.find(
+      e => 'source' in e && e.source === 'Fibonacci'
+    )
+    expect(event).toBeDefined()
+    expect(event?.type).toBe('mult')
+  })
+})

--- a/src/app/daily-card-game/domain/joker/jokers.ts
+++ b/src/app/daily-card-game/domain/joker/jokers.ts
@@ -1972,6 +1972,35 @@ export const evenStevenJoker: JokerDefinition = {
   rarity: 'common',
 }
 
+export const fibonacci: JokerDefinition = {
+  id: 'fibonacci',
+  name: 'Fibonacci',
+  description: 'Each played Ace, 2, 3, 5, or 8 gives +8 Mult when scored',
+  price: 8,
+  effects: [
+    {
+      event: { type: 'CARD_SCORED' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        const scoredCard = ctx.scoredCards?.[0]
+        if (!scoredCard) return
+        const cardDef = playingCards[scoredCard.playingCardId]
+        if (!cardDef) return
+        if (['A', '2', '3', '5', '8'].includes(cardDef.value)) {
+          ctx.game.gamePlayState.scoringEvents.push({
+            id: uuid(),
+            type: 'mult',
+            value: 8,
+            source: 'Fibonacci',
+          })
+          ctx.game.gamePlayState.score.mult += 8
+        }
+      },
+    },
+  ],
+  rarity: 'uncommon',
+}
+
 export const oddToddJoker: JokerDefinition = {
   id: 'oddToddJoker',
   name: 'Odd Todd',
@@ -3174,6 +3203,7 @@ export const jokers: Record<JokerDefinition['id'], JokerDefinition> = {
   smileyFaceJoker,
   scholarJoker,
   evenStevenJoker,
+  fibonacci,
   oddToddJoker,
   scaryFaceJoker,
   banner,


### PR DESCRIPTION
## Summary
- Implements the Fibonacci uncommon joker: each played A, 2, 3, 5, or 8 gives +8 Mult when scored
- First uncommon joker implementation from epic #703
- Adds 4 unit tests

Closes #758

## Test plan
- [x] Unit tests pass (`npx vitest run fibonacci`)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)