### PR TITLE
Implement Hack uncommon joker (#759)

### DIFF
--- a/src/app/daily-card-game/domain/game/__tests__/hack.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/hack.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest'
+import { defaultGameState } from '@/app/daily-card-game/domain/game/default-game-state'
+import { reduceGame } from '@/app/daily-card-game/domain/game/reduce-game'
+import type { GameState } from '@/app/daily-card-game/domain/game/types'
+import { jokers } from '@/app/daily-card-game/domain/joker/jokers'
+import { initializeJoker } from '@/app/daily-card-game/domain/joker/utils'
+import { playingCards } from '@/app/daily-card-game/domain/playing-card/playing-cards'
+
+describe('Hack joker', () => {
+  it('card with value 3 gets retriggered (extra chips added)', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.jokers = [initializeJoker(jokers.hack, game)]
+    game.rounds[game.roundIndex].smallBlind.status = 'inProgress'
+    game.gamePhase = 'gameplay'
+
+    const threeId = Object.keys(game.cards).find(id =>
+      playingCards[game.cards[id].playingCardId]?.value === '3'
+    )!
+
+    const after = reduceGame({
+      ...game,
+      gamePlayState: { ...game.gamePlayState, cardsToScore: [game.cards[threeId]] },
+    }, { type: 'CARD_SCORED' })
+
+    const hackEvents = after.gamePlayState.scoringEvents.filter(
+      e => 'source' in e && e.source === 'Hack'
+    )
+    expect(hackEvents).toHaveLength(1)
+    // 3 baseChips = 3
+    expect(hackEvents[0].value).toBe(3)
+    expect(hackEvents[0].type).toBe('chips')
+  })
+
+  it('card with value K does NOT get retriggered', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.jokers = [initializeJoker(jokers.hack, game)]
+    game.rounds[game.roundIndex].smallBlind.status = 'inProgress'
+    game.gamePhase = 'gameplay'
+
+    const kingId = Object.keys(game.cards).find(id =>
+      playingCards[game.cards[id].playingCardId]?.value === 'K'
+    )!
+
+    const after = reduceGame({
+      ...game,
+      gamePlayState: { ...game.gamePlayState, cardsToScore: [game.cards[kingId]] },
+    }, { type: 'CARD_SCORED' })
+
+    const hackEvents = after.gamePlayState.scoringEvents.filter(
+      e => 'source' in e && e.source === 'Hack'
+    )
+    expect(hackEvents).toHaveLength(0)
+  })
+})

--- a/src/app/daily-card-game/domain/joker/jokers.ts
+++ b/src/app/daily-card-game/domain/joker/jokers.ts
@@ -3120,6 +3120,33 @@ function applyRiffRaff(ctx: EffectContext) {
   }
 }
 
+export const hack: JokerDefinition = {
+  id: 'hack',
+  name: 'Hack',
+  description: 'Retrigger each played 2, 3, 4, or 5',
+  price: 6,
+  effects: [
+    {
+      event: { type: 'CARD_SCORED' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        const scoredCard = ctx.scoredCards?.[0]
+        if (!scoredCard) return
+        const cardDef = playingCards[scoredCard.playingCardId]
+        if (!['2', '3', '4', '5'].includes(cardDef.value)) return
+        ctx.game.gamePlayState.scoringEvents.push({
+          id: uuid(),
+          type: 'chips',
+          value: cardDef.baseChips,
+          source: 'Hack',
+        })
+        ctx.game.gamePlayState.score.chips += cardDef.baseChips
+      },
+    },
+  ],
+  rarity: 'uncommon',
+}
+
 export const riffRaff: JokerDefinition = {
   id: 'riffRaff',
   name: 'Riff-raff',
@@ -3235,6 +3262,7 @@ export const jokers: Record<JokerDefinition['id'], JokerDefinition> = {
   hallucination,
   mailInRebate,
   hangingChad,
+  hack,
   riffRaff,
 }
 


### PR DESCRIPTION
## Summary
- Implements the Hack uncommon joker: retrigger each played 2, 3, 4, or 5
- Same retrigger pattern as Hanging Chad (adds base chips again)
- Adds 2 unit tests

Closes #759

## Test plan
- [x] Unit tests pass (`npx vitest run hack`)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)