### PR TITLE
Implement Card Sharp uncommon joker (#765)

### DIFF
--- a/src/app/daily-card-game/domain/game/__tests__/card-sharp.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/card-sharp.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+import { defaultGameState } from '@/app/daily-card-game/domain/game/default-game-state'
+import { reduceGame } from '@/app/daily-card-game/domain/game/reduce-game'
+import type { GameState } from '@/app/daily-card-game/domain/game/types'
+import { jokers } from '@/app/daily-card-game/domain/joker/jokers'
+import { initializeJoker } from '@/app/daily-card-game/domain/joker/utils'
+
+describe('Card Sharp joker', () => {
+  it('does not apply X3 Mult on first play of a hand type this round', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.jokers = [initializeJoker(jokers.cardSharp, game)]
+    game.rounds[game.roundIndex].smallBlind.status = 'inProgress'
+    game.gamePhase = 'gameplay'
+    game.gamePlayState.selectedHand = ['pair', []]
+    game.gamePlayState.handTypesPlayedThisRound = ['pair'] // played once this round
+    const after = reduceGame(game, { type: 'HAND_SCORING_FINALIZE' })
+    expect(after.gamePlayState.scoringEvents.some(
+      e => 'source' in e && e.source === 'Card Sharp'
+    )).toBe(false)
+  })
+
+  it('applies X3 Mult on second play of same hand type this round', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.jokers = [initializeJoker(jokers.cardSharp, game)]
+    game.rounds[game.roundIndex].smallBlind.status = 'inProgress'
+    game.gamePhase = 'gameplay'
+    game.gamePlayState.selectedHand = ['pair', []]
+    game.gamePlayState.handTypesPlayedThisRound = ['pair', 'pair'] // played twice this round
+    const after = reduceGame(game, { type: 'HAND_SCORING_FINALIZE' })
+    expect(after.gamePlayState.scoringEvents.some(
+      e => 'source' in e && e.source === 'Card Sharp' && 'operator' in e && e.operator === 'x' && e.value === 3
+    )).toBe(true)
+  })
+
+  it('does not apply X3 Mult when only a different hand type was played before', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.jokers = [initializeJoker(jokers.cardSharp, game)]
+    game.rounds[game.roundIndex].smallBlind.status = 'inProgress'
+    game.gamePhase = 'gameplay'
+    game.gamePlayState.selectedHand = ['pair', []]
+    game.gamePlayState.handTypesPlayedThisRound = ['flush', 'pair'] // flush played first, then pair once
+    const after = reduceGame(game, { type: 'HAND_SCORING_FINALIZE' })
+    expect(after.gamePlayState.scoringEvents.some(
+      e => 'source' in e && e.source === 'Card Sharp'
+    )).toBe(false)
+  })
+})

--- a/src/app/daily-card-game/domain/game/default-game-state.ts
+++ b/src/app/daily-card-game/domain/game/default-game-state.ts
@@ -34,6 +34,7 @@ const gameState: GameState = {
     discardPileIds: [],
     drawPileIds: [],
     handIds: [],
+    handTypesPlayedThisRound: [],
     isScoring: false,
     playedCardIds: [],
     remainingHands: 4,

--- a/src/app/daily-card-game/domain/game/handlers/gameplay.ts
+++ b/src/app/daily-card-game/domain/game/handlers/gameplay.ts
@@ -289,6 +289,9 @@ export function handleHandScoringStart(draft: GameState, event: GameEvent) {
   // increment the times the hand has been played
   draft.pokerHands[playedHand].timesPlayed += 1
 
+  // track which hand types have been played this round
+  gamePlayState.handTypesPlayedThisRound.push(playedHand)
+
   const handMult =
     pokerHands[playedHand].baseMult + pokerHands[playedHand].multIncreasePerLevel * playedHandLevel
   const handChips =
@@ -351,6 +354,7 @@ export function handleHandScoringDoneCardScoring(draft: GameState) {
   }
   draft.gamePlayState.scoringEvents = []
   draft.gamePlayState.remainingDiscards = draft.maxDiscards
+  draft.gamePlayState.handTypesPlayedThisRound = []
 
   // Reset shop state for the new shop session
   draft.shopState.cardsForSale = []

--- a/src/app/daily-card-game/domain/game/types.ts
+++ b/src/app/daily-card-game/domain/game/types.ts
@@ -81,6 +81,9 @@ export interface GamePlayState {
   // Current hand (card IDs)
   handIds: string[]
 
+  // Track which hand types have been played this round (resets between blinds)
+  handTypesPlayedThisRound: string[]
+
   isScoring: boolean
   playedCardIds: string[]
   remainingDiscards: number

--- a/src/app/daily-card-game/domain/joker/jokers.ts
+++ b/src/app/daily-card-game/domain/joker/jokers.ts
@@ -3236,6 +3236,37 @@ export const spaceJoker: JokerDefinition = {
   rarity: 'uncommon',
 }
 
+export const cardSharp: JokerDefinition = {
+  id: 'cardSharp',
+  name: 'Card Sharp',
+  description: 'X3 Mult if played poker hand has already been played this round',
+  price: 6,
+  effects: [
+    {
+      event: { type: 'HAND_SCORING_FINALIZE' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        const selectedHand = ctx.game.gamePlayState.selectedHand
+        if (!selectedHand) return
+        const handId = selectedHand[0]
+        // Count how many times this hand type appears (current play is already tracked)
+        const count = ctx.game.gamePlayState.handTypesPlayedThisRound.filter(h => h === handId).length
+        if (count > 1) {
+          ctx.game.gamePlayState.scoringEvents.push({
+            id: uuid(),
+            type: 'mult',
+            operator: 'x',
+            value: 3,
+            source: 'Card Sharp',
+          })
+          ctx.game.gamePlayState.score.mult *= 3
+        }
+      },
+    },
+  ],
+  rarity: 'uncommon',
+}
+
 export const jokers: Record<JokerDefinition['id'], JokerDefinition> = {
   swashbucklerJoker,
   walkieTalkieJoker,
@@ -3330,6 +3361,7 @@ export const jokers: Record<JokerDefinition['id'], JokerDefinition> = {
   hack,
   riffRaff,
   spaceJoker,
+  cardSharp,
 }
 
 /***


### PR DESCRIPTION
## Summary
- Implements the Card Sharp uncommon joker: X3 Mult if poker hand already played this round
- Adds `handTypesPlayedThisRound` tracking infrastructure to GamePlayState
- Adds 3 unit tests covering first play, repeat play, and different hand types

Closes #765

## Test plan
- [x] Unit tests pass (`npx vitest run card-sharp`)
- [x] Full test suite passes (1218 tests)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)