### PR TITLE
Implement Loyalty Card uncommon joker (#756)

### DIFF
--- a/src/app/daily-card-game/domain/game/__tests__/loyalty-card.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/loyalty-card.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest'
+import { defaultGameState } from '@/app/daily-card-game/domain/game/default-game-state'
+import { reduceGame } from '@/app/daily-card-game/domain/game/reduce-game'
+import type { GameState } from '@/app/daily-card-game/domain/game/types'
+import { jokers } from '@/app/daily-card-game/domain/joker/jokers'
+import { initializeJoker } from '@/app/daily-card-game/domain/joker/utils'
+
+describe('Loyalty Card joker', () => {
+  function setupGame(): GameState {
+    const game: GameState = structuredClone(defaultGameState)
+    game.jokers = [initializeJoker(jokers.loyaltyCard, game)]
+    game.rounds[game.roundIndex].smallBlind.status = 'inProgress'
+    game.gamePhase = 'gameplay'
+    return reduceGame(game, { type: 'GAME_START' })
+  }
+
+  function playHand(state: GameState): GameState {
+    return reduceGame(
+      {
+        ...state,
+        gamePlayState: {
+          ...state.gamePlayState,
+          scoringEvents: [],
+          score: { chips: 0, mult: 1 },
+          selectedHand: ['pair', []],
+        },
+      },
+      { type: 'HAND_SCORING_FINALIZE' }
+    )
+  }
+
+  it('does not apply X4 Mult on hands 1 through 5', () => {
+    let state = setupGame()
+    for (let i = 0; i < 5; i++) {
+      state = playHand(state)
+      expect(
+        state.gamePlayState.scoringEvents.some(
+          e => 'source' in e && e.source === 'Loyalty Card'
+        )
+      ).toBe(false)
+    }
+  })
+
+  it('applies X4 Mult on hand 6', () => {
+    let state = setupGame()
+    for (let i = 0; i < 6; i++) {
+      state = playHand(state)
+    }
+    expect(
+      state.gamePlayState.scoringEvents.some(
+        e =>
+          'source' in e &&
+          e.source === 'Loyalty Card' &&
+          'operator' in e &&
+          e.operator === 'x' &&
+          'value' in e &&
+          e.value === 4
+      )
+    ).toBe(true)
+  })
+
+  it('counter resets and X4 fires again on hand 12', () => {
+    let state = setupGame()
+    for (let i = 0; i < 12; i++) {
+      state = playHand(state)
+    }
+    expect(
+      state.gamePlayState.scoringEvents.some(
+        e =>
+          'source' in e &&
+          e.source === 'Loyalty Card' &&
+          'operator' in e &&
+          e.operator === 'x' &&
+          'value' in e &&
+          e.value === 4
+      )
+    ).toBe(true)
+  })
+})

--- a/src/app/daily-card-game/domain/joker/jokers.ts
+++ b/src/app/daily-card-game/domain/joker/jokers.ts
@@ -3267,6 +3267,38 @@ export const cardSharp: JokerDefinition = {
   rarity: 'uncommon',
 }
 
+export const loyaltyCard: JokerDefinition = {
+  id: 'loyaltyCard',
+  name: 'Loyalty Card',
+  description: 'X4 Mult every 6 hands played',
+  price: 5,
+  effects: [
+    {
+      event: { type: 'HAND_SCORING_FINALIZE' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        const lc = ctx.game.jokers.find(j => j.jokerId === 'loyaltyCard')
+        if (!lc) return
+        // Lazy init
+        if (lc.counter === 0) lc.counter = 6
+        lc.counter -= 1
+        if (lc.counter === 0) {
+          ctx.game.gamePlayState.scoringEvents.push({
+            id: uuid(),
+            type: 'mult',
+            operator: 'x',
+            value: 4,
+            source: 'Loyalty Card',
+          })
+          ctx.game.gamePlayState.score.mult *= 4
+          lc.counter = 6
+        }
+      },
+    },
+  ],
+  rarity: 'uncommon',
+}
+
 export const jokers: Record<JokerDefinition['id'], JokerDefinition> = {
   swashbucklerJoker,
   walkieTalkieJoker,
@@ -3362,6 +3394,7 @@ export const jokers: Record<JokerDefinition['id'], JokerDefinition> = {
   riffRaff,
   spaceJoker,
   cardSharp,
+  loyaltyCard,
 }
 
 /***


### PR DESCRIPTION
## Summary
- Implements the Loyalty Card uncommon joker: X4 Mult every 6 hands played
- Uses lazy-init counter countdown pattern
- Adds 3 unit tests covering no-trigger, trigger, and reset cycle

Closes #756

## Test plan
- [x] Unit tests pass (`npx vitest run loyalty-card`)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)