### PR TITLE
fix: implement crimson heart boss blind

### DIFF
--- a/src/app/daily-card-game/domain/events/dispatch-effects.ts
+++ b/src/app/daily-card-game/domain/events/dispatch-effects.ts
@@ -6,6 +6,10 @@ export function dispatchEffects(event: GameEvent, ctx: EffectContext, effects: E
     .sort((a, b) => a.priority - b.priority)
 
   for (const effect of matching) {
+    if (effect.source) {
+      const sourceJoker = ctx.game.jokers.find(joker => joker.id === effect.source)
+      if (!sourceJoker?.isFaceUp) continue
+    }
     if (effect.condition && !effect.condition(ctx)) continue
     effect.apply(ctx)
   }

--- a/src/app/daily-card-game/domain/events/types.ts
+++ b/src/app/daily-card-game/domain/events/types.ts
@@ -1,6 +1,6 @@
 import { TarotCardState } from '@/app/daily-card-game/domain/consumable/types'
 import type { GameState, ScoreState } from '@/app/daily-card-game/domain/game/types'
-import type { JokerState } from '@/app/daily-card-game/domain/joker/types'
+import type { JokerDefinition, JokerState } from '@/app/daily-card-game/domain/joker/types'
 import type { PlayingCardState } from '@/app/daily-card-game/domain/playing-card/types'
 import type { BlindState, RoundState } from '@/app/daily-card-game/domain/round/types'
 import type { TagState } from '@/app/daily-card-game/domain/tag/types'
@@ -241,6 +241,7 @@ export interface EffectContext {
 export interface Effect {
   event: GameEvent
   priority: number
+  source?: JokerDefinition['id']
   condition?: (ctx: EffectContext) => boolean
   apply: (ctx: EffectContext) => void
 }

--- a/src/app/daily-card-game/domain/game/__tests__/crimson-heart.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/crimson-heart.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest'
+import { defaultGameState } from '../default-game-state'
+import { reduceGame } from '../reduce-game'
+import type { GameState } from '../types'
+import { collectEffects } from '../utils'
+import { jokers } from '../../joker/jokers'
+import { initializeJoker } from '../../joker/utils'
+
+function createCrimsonHeartGame(): GameState {
+  const game: GameState = structuredClone(defaultGameState)
+  game.rounds[game.roundIndex].bossBlindName = 'Crimson Heart'
+  game.rounds[game.roundIndex].bossBlind.status = 'inProgress'
+  game.gamePhase = 'gameplay'
+  game.jokers = [
+    initializeJoker(jokers.halfJoker, game),
+    initializeJoker(jokers.splash, game),
+    initializeJoker(jokers.greenJoker, game),
+  ]
+  game.gamePlayState.selectedCardIds = Object.keys(game.cards).slice(0, 1)
+  game.gamePlayState.handIds = game.gamePlayState.selectedCardIds
+  game.gamePlayState.cardsToScore = game.gamePlayState.selectedCardIds
+    .map(cardId => game.cards[cardId])
+    .filter(card => card !== undefined)
+  return game
+}
+
+describe('Crimson Heart boss blind', () => {
+  it('turns exactly one random joker face down when scoring starts', () => {
+    const game = createCrimsonHeartGame()
+
+    const after = reduceGame(game, { type: 'HAND_SCORING_START' })
+
+    const faceDownJokers = after.jokers.filter(joker => !joker.isFaceUp)
+    const faceUpJokers = after.jokers.filter(joker => joker.isFaceUp)
+
+    expect(faceDownJokers).toHaveLength(1)
+    expect(faceUpJokers).toHaveLength(2)
+  })
+
+  it('excludes the face-down joker effects from the same scoring event', () => {
+    const game = createCrimsonHeartGame()
+    game.gamePlayState.selectedCardIds = Object.keys(game.cards).slice(0, 1)
+    game.gamePlayState.handIds = game.gamePlayState.selectedCardIds
+
+    const after = reduceGame(game, { type: 'HAND_SCORING_START' })
+    const faceDownJoker = after.jokers.find(joker => !joker.isFaceUp)
+
+    expect(faceDownJoker).toBeDefined()
+
+    if (faceDownJoker?.jokerId === 'halfJoker') {
+      expect(after.gamePlayState.score.mult).toBe(1)
+      expect(
+        after.gamePlayState.scoringEvents.some(
+          event => 'source' in event && event.source === 'Half Joker'
+        )
+      ).toBe(false)
+    }
+  })
+})
+
+describe('collectEffects', () => {
+  it('skips joker effects for face-down jokers while keeping boss blind effects', () => {
+    const game = createCrimsonHeartGame()
+    game.jokers[1].isFaceUp = false
+
+    const effects = collectEffects(game)
+    const handScoringStartEffects = effects.filter(effect => effect.event.type === 'HAND_SCORING_START')
+
+    expect(handScoringStartEffects.some(effect => effect === jokers.splash.effects?.[0])).toBe(false)
+    expect(handScoringStartEffects).toHaveLength(2)
+  })
+})

--- a/src/app/daily-card-game/domain/game/utils.ts
+++ b/src/app/daily-card-game/domain/game/utils.ts
@@ -53,7 +53,11 @@ export function collectEffects(game: GameState): Effect[] {
     effects.push(...getBlindDefinition(blind.type, game.rounds[game.roundIndex]).effects)
   }
 
-  effects.push(...game.jokers.flatMap(j => jokers[j.jokerId]?.effects || []))
+  effects.push(
+    ...game.jokers
+      .filter(joker => joker.isFaceUp)
+      .flatMap(j => jokers[j.jokerId]?.effects || [])
+  )
 
   effects.push(...game.vouchers.flatMap(v => vouchers[v.type]?.effects || []))
 

--- a/src/app/daily-card-game/domain/game/utils.ts
+++ b/src/app/daily-card-game/domain/game/utils.ts
@@ -56,7 +56,7 @@ export function collectEffects(game: GameState): Effect[] {
   effects.push(
     ...game.jokers
       .filter(joker => joker.isFaceUp)
-      .flatMap(j => jokers[j.jokerId]?.effects || [])
+      .flatMap(j => (jokers[j.jokerId]?.effects || []).map(effect => ({ ...effect, source: j.id })))
   )
 
   effects.push(...game.vouchers.flatMap(v => vouchers[v.type]?.effects || []))

--- a/src/app/daily-card-game/domain/round/boss-blinds.ts
+++ b/src/app/daily-card-game/domain/round/boss-blinds.ts
@@ -54,7 +54,35 @@ const theOx: BossBlindDefinition = {
   ],
 }
 
-export const bossBlinds: BossBlindDefinition[] = [theHook, theOx]
+const crimsonHeart: BossBlindDefinition = {
+  type: 'bossBlind',
+  status: 'notStarted',
+  anteMultiplier: 2,
+  name: 'Crimson Heart',
+  description: 'One random Joker disabled every hand (changes every hand)',
+  image: 'crimson-heart.png',
+  minimumAnte: 8,
+  baseReward: 8,
+  effects: [
+    {
+      event: { type: 'HAND_SCORING_START' },
+      priority: 0,
+      condition: (ctx: EffectContext) => ctx.event.type === 'HAND_SCORING_START',
+      apply: (ctx: EffectContext) => {
+        const faceUpJokers = ctx.game.jokers.filter(joker => joker.isFaceUp)
+        if (faceUpJokers.length === 0) return
+
+        const scoringSeed = `${ctx.game.seed}-${ctx.game.roundIndex}-${ctx.game.gamePlayState.handsPlayed}-crimson-heart`
+        const randomIndex = getRandomNumberWithSeed(scoringSeed, 0, faceUpJokers.length - 1)
+        const selectedJoker = faceUpJokers[randomIndex]
+        const jokerToDisable = ctx.game.jokers.find(joker => joker.id === selectedJoker.id)
+        if (jokerToDisable) jokerToDisable.isFaceUp = false
+      },
+    },
+  ],
+}
+
+export const bossBlinds: BossBlindDefinition[] = [theHook, theOx, crimsonHeart]
 
 /**
  

--- a/src/app/daily-card-game/domain/round/boss-blinds.ts
+++ b/src/app/daily-card-game/domain/round/boss-blinds.ts
@@ -72,7 +72,7 @@ const crimsonHeart: BossBlindDefinition = {
         const faceUpJokers = ctx.game.jokers.filter(joker => joker.isFaceUp)
         if (faceUpJokers.length === 0) return
 
-        const scoringSeed = `${ctx.game.seed}-${ctx.game.roundIndex}-${ctx.game.gamePlayState.handsPlayed}-crimson-heart`
+        const scoringSeed = `${ctx.game.gameSeed}-${ctx.game.roundIndex}-${ctx.game.handsPlayed}-crimson-heart`
         const randomIndex = getRandomNumberWithSeed(scoringSeed, 0, faceUpJokers.length - 1)
         const selectedJoker = faceUpJokers[randomIndex]
         const jokerToDisable = ctx.game.jokers.find(joker => joker.id === selectedJoker.id)


### PR DESCRIPTION
## Summary
- implement the missing Crimson Heart boss blind definition
- disable one random face-up Joker at hand-scoring start using a deterministic per-hand seed
- exclude face-down Joker effects from effect collection so the disabled Joker does not trigger during the same hand
- add focused regression tests for Crimson Heart behavior

## Testing
- `npx vitest run src/app/daily-card-game/domain/game/__tests__/crimson-heart.test.ts`
- `git diff --check`
- attempted `npm run typecheck` (currently fails in repo due to pre-existing TypeScript/module-resolution issues unrelated to this change)

Fixes #961
