### PR TITLE
Implement Ceremonial Dagger uncommon joker (#754)

### DIFF
--- a/src/app/daily-card-game/domain/game/__tests__/ceremonial-dagger.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/ceremonial-dagger.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from 'vitest'
+import { defaultGameState } from '@/app/daily-card-game/domain/game/default-game-state'
+import { reduceGame } from '@/app/daily-card-game/domain/game/reduce-game'
+import type { GameState } from '@/app/daily-card-game/domain/game/types'
+import { jokers } from '@/app/daily-card-game/domain/joker/jokers'
+import { initializeJoker } from '@/app/daily-card-game/domain/joker/utils'
+
+describe('Ceremonial Dagger joker', () => {
+  function setupGame(overrides: Partial<GameState> = {}): GameState {
+    const game: GameState = structuredClone(defaultGameState)
+    return { ...game, ...overrides }
+  }
+
+  it('destroys joker to the right and gains double its sell value as counter on SMALL_BLIND_SELECTED', () => {
+    const game = setupGame()
+    const dagger = initializeJoker(jokers.ceremonialDagger, game)
+    const rightJoker = initializeJoker(jokers.jokerJoker, game)
+    // jokerJoker price is 2, bonusSellValue is 0, so sell value = 2, double = 4
+    game.jokers = [dagger, rightJoker]
+
+    const after = reduceGame(game, { type: 'SMALL_BLIND_SELECTED' })
+
+    // Right joker should be destroyed
+    expect(after.jokers.length).toBe(1)
+    expect(after.jokers[0].jokerId).toBe('ceremonialDagger')
+
+    // Counter should be double the sell value (2 * 2 = 4)
+    const daggerAfter = after.jokers.find(j => j.jokerId === 'ceremonialDagger')
+    expect(daggerAfter?.counter).toBe(4)
+  })
+
+  it('destroys joker to the right and gains double its sell value on BIG_BLIND_SELECTED', () => {
+    const game = setupGame()
+    const dagger = initializeJoker(jokers.ceremonialDagger, game)
+    const rightJoker = initializeJoker(jokers.jokerJoker, game)
+    game.jokers = [dagger, rightJoker]
+
+    const after = reduceGame(game, { type: 'BIG_BLIND_SELECTED' })
+
+    expect(after.jokers.length).toBe(1)
+    const daggerAfter = after.jokers.find(j => j.jokerId === 'ceremonialDagger')
+    expect(daggerAfter?.counter).toBe(4)
+  })
+
+  it('destroys joker to the right and gains double its sell value on BOSS_BLIND_SELECTED', () => {
+    const game = setupGame()
+    const dagger = initializeJoker(jokers.ceremonialDagger, game)
+    const rightJoker = initializeJoker(jokers.jokerJoker, game)
+    game.jokers = [dagger, rightJoker]
+
+    const after = reduceGame(game, { type: 'BOSS_BLIND_SELECTED' })
+
+    expect(after.jokers.length).toBe(1)
+    const daggerAfter = after.jokers.find(j => j.jokerId === 'ceremonialDagger')
+    expect(daggerAfter?.counter).toBe(4)
+  })
+
+  it('includes bonusSellValue in the sell value calculation', () => {
+    const game = setupGame()
+    const dagger = initializeJoker(jokers.ceremonialDagger, game)
+    const rightJoker = initializeJoker(jokers.jokerJoker, game)
+    rightJoker.bonusSellValue = 3
+    // jokerJoker price is 2, bonusSellValue is 3, so sell value = 5, double = 10
+    game.jokers = [dagger, rightJoker]
+
+    const after = reduceGame(game, { type: 'SMALL_BLIND_SELECTED' })
+
+    const daggerAfter = after.jokers.find(j => j.jokerId === 'ceremonialDagger')
+    expect(daggerAfter?.counter).toBe(10)
+  })
+
+  it('does nothing if no joker to the right', () => {
+    const game = setupGame()
+    const dagger = initializeJoker(jokers.ceremonialDagger, game)
+    game.jokers = [dagger]
+
+    const after = reduceGame(game, { type: 'SMALL_BLIND_SELECTED' })
+
+    expect(after.jokers.length).toBe(1)
+    const daggerAfter = after.jokers.find(j => j.jokerId === 'ceremonialDagger')
+    expect(daggerAfter?.counter).toBe(0)
+  })
+
+  it('applies accumulated Mult on HAND_SCORING_FINALIZE', () => {
+    const game = setupGame()
+    const dagger = initializeJoker(jokers.ceremonialDagger, game)
+    dagger.counter = 8
+    game.jokers = [dagger]
+    game.rounds[game.roundIndex].smallBlind.status = 'inProgress'
+    game.gamePhase = 'gameplay'
+
+    const withHand: GameState = {
+      ...game,
+      gamePlayState: {
+        ...game.gamePlayState,
+        selectedHand: ['pair', []],
+        score: { chips: 10, mult: 5 },
+      },
+    }
+
+    const after = reduceGame(withHand, { type: 'HAND_SCORING_FINALIZE' })
+
+    expect(after.gamePlayState.scoringEvents.some(
+      e => 'source' in e && e.source === 'Ceremonial Dagger' && 'value' in e && e.value === 8
+    )).toBe(true)
+  })
+
+  it('does not add Mult on HAND_SCORING_FINALIZE when counter is 0', () => {
+    const game = setupGame()
+    const dagger = initializeJoker(jokers.ceremonialDagger, game)
+    dagger.counter = 0
+    game.jokers = [dagger]
+    game.rounds[game.roundIndex].smallBlind.status = 'inProgress'
+    game.gamePhase = 'gameplay'
+
+    const withHand: GameState = {
+      ...game,
+      gamePlayState: {
+        ...game.gamePlayState,
+        selectedHand: ['pair', []],
+        score: { chips: 10, mult: 5 },
+      },
+    }
+
+    const after = reduceGame(withHand, { type: 'HAND_SCORING_FINALIZE' })
+
+    expect(after.gamePlayState.scoringEvents.some(
+      e => 'source' in e && e.source === 'Ceremonial Dagger'
+    )).toBe(false)
+  })
+})

--- a/src/app/daily-card-game/domain/joker/jokers.ts
+++ b/src/app/daily-card-game/domain/joker/jokers.ts
@@ -3208,6 +3208,59 @@ export const riffRaff: JokerDefinition = {
   rarity: 'common',
 }
 
+function applyCeremonialDagger(ctx: EffectContext) {
+  const daggerIndex = ctx.game.jokers.findIndex(j => j.jokerId === 'ceremonialDagger')
+  if (daggerIndex === -1) return
+  const rightJoker = ctx.game.jokers[daggerIndex + 1]
+  if (!rightJoker) return
+  const rightJokerDef = jokers[rightJoker.jokerId]
+  if (!rightJokerDef) return
+  const sellValue = rightJokerDef.price + rightJoker.bonusSellValue
+  ctx.game.jokers[daggerIndex].counter += sellValue * 2
+  ctx.game.jokers.splice(daggerIndex + 1, 1)
+}
+
+export const ceremonialDagger: JokerDefinition = {
+  id: 'ceremonialDagger',
+  name: 'Ceremonial Dagger',
+  description:
+    'When Blind is selected, destroy Joker to the right and permanently add double its sell value to this Joker\'s Mult',
+  price: 6,
+  effects: [
+    {
+      event: { type: 'SMALL_BLIND_SELECTED' },
+      priority: 1,
+      apply: applyCeremonialDagger,
+    },
+    {
+      event: { type: 'BIG_BLIND_SELECTED' },
+      priority: 1,
+      apply: applyCeremonialDagger,
+    },
+    {
+      event: { type: 'BOSS_BLIND_SELECTED' },
+      priority: 1,
+      apply: applyCeremonialDagger,
+    },
+    {
+      event: { type: 'HAND_SCORING_FINALIZE' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        const dagger = ctx.game.jokers.find(j => j.jokerId === 'ceremonialDagger')
+        if (!dagger || dagger.counter === 0) return
+        ctx.game.gamePlayState.scoringEvents.push({
+          id: uuid(),
+          type: 'mult',
+          value: dagger.counter,
+          source: 'Ceremonial Dagger',
+        })
+        ctx.game.gamePlayState.score.mult += dagger.counter
+      },
+    },
+  ],
+  rarity: 'uncommon',
+}
+
 export const spaceJoker: JokerDefinition = {
   id: 'spaceJoker',
   name: 'Space Joker',
@@ -3392,6 +3445,7 @@ export const jokers: Record<JokerDefinition['id'], JokerDefinition> = {
   hangingChad,
   hack,
   riffRaff,
+  ceremonialDagger,
   spaceJoker,
   cardSharp,
   loyaltyCard,


### PR DESCRIPTION
## Summary
- Implements the Ceremonial Dagger uncommon joker: destroy right joker on blind selection, gain double sell value as permanent Mult
- Adds 7 unit tests covering all blind types, bonusSellValue, no-right-joker edge case, and Mult application

Closes #754

## Test plan
- [x] Unit tests pass (`npx vitest run ceremonial-dagger`)
- [x] Full test suite passes (1228 tests)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)