### PR TITLE
Implement Hiker uncommon joker (#764)

### DIFF
--- a/src/app/daily-card-game/domain/game/__tests__/hiker.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/hiker.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest'
+
+import { defaultGameState } from '@/app/daily-card-game/domain/game/default-game-state'
+import { reduceGame } from '@/app/daily-card-game/domain/game/reduce-game'
+import type { GameState } from '@/app/daily-card-game/domain/game/types'
+import { jokers } from '@/app/daily-card-game/domain/joker/jokers'
+import { initializeJoker } from '@/app/daily-card-game/domain/joker/utils'
+
+describe('Hiker joker', () => {
+  function createGameWithHiker(): GameState {
+    const game: GameState = structuredClone(defaultGameState)
+    game.jokers = [initializeJoker(jokers.hiker, game)]
+    game.rounds[game.roundIndex].smallBlind.status = 'inProgress'
+    game.gamePhase = 'gameplay'
+    return game
+  }
+
+  function getFirstCardId(game: GameState): string {
+    return Object.keys(game.cards)[0]
+  }
+
+  it('scored card permanently gains +5 bonusChips', () => {
+    const game = createGameWithHiker()
+    const cardId = getFirstCardId(game)
+    const initialBonusChips = game.cards[cardId].bonusChips
+
+    const withScoring: GameState = {
+      ...game,
+      gamePlayState: {
+        ...game.gamePlayState,
+        cardsToScore: [game.cards[cardId]],
+      },
+    }
+
+    const afterScore = reduceGame(withScoring, { type: 'CARD_SCORED' })
+
+    expect(afterScore.cards[cardId].bonusChips).toBe(initialBonusChips + 5)
+  })
+
+  it('bonus accumulates when card is scored twice', () => {
+    const game = createGameWithHiker()
+    const cardId = getFirstCardId(game)
+    const initialBonusChips = game.cards[cardId].bonusChips
+
+    const withScoring1: GameState = {
+      ...game,
+      gamePlayState: {
+        ...game.gamePlayState,
+        cardsToScore: [game.cards[cardId]],
+      },
+    }
+
+    const afterScore1 = reduceGame(withScoring1, { type: 'CARD_SCORED' })
+
+    const withScoring2: GameState = {
+      ...afterScore1,
+      gamePlayState: {
+        ...afterScore1.gamePlayState,
+        cardsToScore: [afterScore1.cards[cardId]],
+      },
+    }
+
+    const afterScore2 = reduceGame(withScoring2, { type: 'CARD_SCORED' })
+
+    expect(afterScore2.cards[cardId].bonusChips).toBe(initialBonusChips + 10)
+  })
+})

--- a/src/app/daily-card-game/domain/joker/jokers.ts
+++ b/src/app/daily-card-game/domain/joker/jokers.ts
@@ -3352,6 +3352,28 @@ export const loyaltyCard: JokerDefinition = {
   rarity: 'uncommon',
 }
 
+export const hiker: JokerDefinition = {
+  id: 'hiker',
+  name: 'Hiker',
+  description: 'Every played card permanently gains +5 Chips when scored',
+  price: 5,
+  effects: [
+    {
+      event: { type: 'CARD_SCORED' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        const scoredCard = ctx.scoredCards?.[0]
+        if (!scoredCard) return
+        const cardState = ctx.game.cards[scoredCard.id]
+        if (cardState) {
+          cardState.bonusChips += 5
+        }
+      },
+    },
+  ],
+  rarity: 'uncommon',
+}
+
 export const jokers: Record<JokerDefinition['id'], JokerDefinition> = {
   swashbucklerJoker,
   walkieTalkieJoker,
@@ -3449,6 +3471,7 @@ export const jokers: Record<JokerDefinition['id'], JokerDefinition> = {
   spaceJoker,
   cardSharp,
   loyaltyCard,
+  hiker,
 }
 
 /***


### PR DESCRIPTION
## Summary
- Implements the Hiker uncommon joker: every played card permanently gains +5 Chips when scored
- Uses existing `bonusChips` field on PlayingCardState
- Adds 2 unit tests covering bonus application and accumulation

Closes #764

## Test plan
- [x] Unit tests pass (`npx vitest run hiker`)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)