### PR TITLE
Implement Madness uncommon joker (#781)

### DIFF
--- a/src/app/daily-card-game/domain/game/__tests__/madness.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/madness.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from 'vitest'
+import { defaultGameState } from '@/app/daily-card-game/domain/game/default-game-state'
+import { reduceGame } from '@/app/daily-card-game/domain/game/reduce-game'
+import type { GameState } from '@/app/daily-card-game/domain/game/types'
+import { jokers } from '@/app/daily-card-game/domain/joker/jokers'
+import { initializeJoker } from '@/app/daily-card-game/domain/joker/utils'
+
+describe('Madness joker', () => {
+  function setupGame(overrides: Partial<GameState> = {}): GameState {
+    const game: GameState = structuredClone(defaultGameState)
+    return { ...game, ...overrides }
+  }
+
+  it('gains X0.5 Mult on SMALL_BLIND_SELECTED (counter goes from 2 to 3)', () => {
+    const game = setupGame()
+    const madness = initializeJoker(jokers.madness, game)
+    madness.counter = 2
+    game.jokers = [madness]
+
+    const after = reduceGame(game, { type: 'SMALL_BLIND_SELECTED' })
+
+    const madnessAfter = after.jokers.find(j => j.jokerId === 'madness')
+    expect(madnessAfter?.counter).toBe(3)
+  })
+
+  it('gains X0.5 Mult on BIG_BLIND_SELECTED (counter goes from 2 to 3)', () => {
+    const game = setupGame()
+    const madness = initializeJoker(jokers.madness, game)
+    madness.counter = 2
+    game.jokers = [madness]
+
+    const after = reduceGame(game, { type: 'BIG_BLIND_SELECTED' })
+
+    const madnessAfter = after.jokers.find(j => j.jokerId === 'madness')
+    expect(madnessAfter?.counter).toBe(3)
+  })
+
+  it('destroys a random other joker (not itself) on blind selection', () => {
+    const game = setupGame()
+    const madness = initializeJoker(jokers.madness, game)
+    const otherJoker = initializeJoker(jokers.jokerJoker, game)
+    madness.counter = 2
+    game.jokers = [madness, otherJoker]
+
+    const after = reduceGame(game, { type: 'SMALL_BLIND_SELECTED' })
+
+    // Madness should survive, the other joker should be destroyed
+    expect(after.jokers.length).toBe(1)
+    expect(after.jokers[0].jokerId).toBe('madness')
+  })
+
+  it('does not destroy itself when it is the only joker', () => {
+    const game = setupGame()
+    const madness = initializeJoker(jokers.madness, game)
+    madness.counter = 2
+    game.jokers = [madness]
+
+    const after = reduceGame(game, { type: 'SMALL_BLIND_SELECTED' })
+
+    expect(after.jokers.length).toBe(1)
+    expect(after.jokers[0].jokerId).toBe('madness')
+    // Counter should still increment
+    const madnessAfter = after.jokers.find(j => j.jokerId === 'madness')
+    expect(madnessAfter?.counter).toBe(3)
+  })
+
+  it('applies X Mult on HAND_SCORING_FINALIZE (counter/2 as multiplier)', () => {
+    const game = setupGame()
+    const madness = initializeJoker(jokers.madness, game)
+    madness.counter = 3
+    game.jokers = [madness]
+    game.rounds[game.roundIndex].smallBlind.status = 'inProgress'
+    game.gamePhase = 'gameplay'
+
+    const withHand: GameState = {
+      ...game,
+      gamePlayState: {
+        ...game.gamePlayState,
+        selectedHand: ['pair', []],
+        score: { chips: 10, mult: 5 },
+      },
+    }
+
+    const after = reduceGame(withHand, { type: 'HAND_SCORING_FINALIZE' })
+
+    // counter=3 → X1.5
+    expect(after.gamePlayState.scoringEvents.some(
+      e => 'source' in e && e.source === 'Madness' && 'operator' in e && e.operator === 'x' && e.value === 1.5
+    )).toBe(true)
+  })
+
+  it('lazy inits counter to 2 (X1.0) on HAND_SCORING_FINALIZE when counter is 0', () => {
+    const game = setupGame()
+    const madness = initializeJoker(jokers.madness, game)
+    madness.counter = 0
+    game.jokers = [madness]
+    game.rounds[game.roundIndex].smallBlind.status = 'inProgress'
+    game.gamePhase = 'gameplay'
+
+    const withHand: GameState = {
+      ...game,
+      gamePlayState: {
+        ...game.gamePlayState,
+        selectedHand: ['pair', []],
+        score: { chips: 10, mult: 5 },
+      },
+    }
+
+    const after = reduceGame(withHand, { type: 'HAND_SCORING_FINALIZE' })
+
+    // counter=0 → lazy init to 2 → X1.0
+    expect(after.gamePlayState.scoringEvents.some(
+      e => 'source' in e && e.source === 'Madness' && 'operator' in e && e.operator === 'x' && e.value === 1.0
+    )).toBe(true)
+  })
+})

--- a/src/app/daily-card-game/domain/joker/jokers.ts
+++ b/src/app/daily-card-game/domain/joker/jokers.ts
@@ -3208,6 +3208,57 @@ export const riffRaff: JokerDefinition = {
   rarity: 'common',
 }
 
+function applyMadnessBlindEffect(ctx: EffectContext) {
+  const m = ctx.game.jokers.find(j => j.jokerId === 'madness')
+  if (!m) return
+  if (m.counter === 0) m.counter = 2
+  m.counter += 1
+  const otherJokers = ctx.game.jokers.filter(j => j.jokerId !== 'madness')
+  if (otherJokers.length === 0) return
+  const seed = buildSeedString([ctx.game.gameSeed, ctx.game.roundIndex.toString(), 'madness', 'destroy'])
+  const roll = getRandomNumbersWithSeed({ seed, min: 0, max: otherJokers.length - 1, numberOfNumbers: 1 })
+  const victim = otherJokers[roll[0]]
+  ctx.game.jokers = ctx.game.jokers.filter(j => j.id !== victim.id)
+}
+
+export const madness: JokerDefinition = {
+  id: 'madness',
+  name: 'Madness',
+  description: 'When Small or Big Blind is selected, gain X0.5 Mult and destroy a random other Joker',
+  price: 7,
+  effects: [
+    {
+      event: { type: 'SMALL_BLIND_SELECTED' },
+      priority: 1,
+      apply: applyMadnessBlindEffect,
+    },
+    {
+      event: { type: 'BIG_BLIND_SELECTED' },
+      priority: 1,
+      apply: applyMadnessBlindEffect,
+    },
+    {
+      event: { type: 'HAND_SCORING_FINALIZE' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        const m = ctx.game.jokers.find(j => j.jokerId === 'madness')
+        if (!m) return
+        if (m.counter === 0) m.counter = 2
+        const xMult = m.counter / 2
+        ctx.game.gamePlayState.scoringEvents.push({
+          id: uuid(),
+          type: 'mult',
+          operator: 'x',
+          value: xMult,
+          source: 'Madness',
+        })
+        ctx.game.gamePlayState.score.mult *= xMult
+      },
+    },
+  ],
+  rarity: 'uncommon',
+}
+
 function applyCeremonialDagger(ctx: EffectContext) {
   const daggerIndex = ctx.game.jokers.findIndex(j => j.jokerId === 'ceremonialDagger')
   if (daggerIndex === -1) return
@@ -3468,6 +3519,7 @@ export const jokers: Record<JokerDefinition['id'], JokerDefinition> = {
   hack,
   riffRaff,
   ceremonialDagger,
+  madness,
   spaceJoker,
   cardSharp,
   loyaltyCard,


### PR DESCRIPTION
## Summary
- Implements the Madness uncommon joker: gain X0.5 Mult on small/big blind selection, destroy a random other joker
- Uses counter stored as halves (2=X1.0, 3=X1.5, etc.)
- Adds 6 unit tests covering X mult gain, joker destruction, scoring application, and edge cases

Closes #781

## Test plan
- [x] Unit tests pass (`npx vitest run madness`)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)