### PR TITLE
Implement Seltzer uncommon joker (#789)

### DIFF
--- a/src/app/daily-card-game/domain/game/__tests__/seltzer.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/seltzer.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from 'vitest'
+import { defaultGameState } from '@/app/daily-card-game/domain/game/default-game-state'
+import { reduceGame } from '@/app/daily-card-game/domain/game/reduce-game'
+import type { GameState } from '@/app/daily-card-game/domain/game/types'
+import { jokers } from '@/app/daily-card-game/domain/joker/jokers'
+import { initializeJoker } from '@/app/daily-card-game/domain/joker/utils'
+import { playingCards } from '@/app/daily-card-game/domain/playing-card/playing-cards'
+
+describe('Seltzer joker', () => {
+  function setupGame(): GameState {
+    const game: GameState = structuredClone(defaultGameState)
+    game.jokers = [initializeJoker(jokers.seltzer, game)]
+    game.rounds[game.roundIndex].smallBlind.status = 'inProgress'
+    game.gamePhase = 'gameplay'
+    return game
+  }
+
+  it('retriggered scored card adds baseChips again', () => {
+    const game = setupGame()
+    // Set counter > 0 so seltzer is active
+    game.jokers[0].counter = 5
+
+    const aceId = Object.keys(game.cards).find(id =>
+      playingCards[game.cards[id].playingCardId]?.value === 'A'
+    )!
+
+    const after = reduceGame({
+      ...game,
+      gamePlayState: { ...game.gamePlayState, cardsToScore: [game.cards[aceId]] },
+    }, { type: 'CARD_SCORED' })
+
+    const seltzerEvents = after.gamePlayState.scoringEvents.filter(
+      e => 'source' in e && e.source === 'Seltzer'
+    )
+    expect(seltzerEvents).toHaveLength(1)
+    // Ace baseChips = 11
+    expect(seltzerEvents[0].value).toBe(11)
+    expect(seltzerEvents[0].type).toBe('chips')
+  })
+
+  it('counter initializes to 10 and decrements by 1 on HAND_SCORING_FINALIZE', () => {
+    const game = setupGame()
+    // counter starts at 0 (lazy init)
+
+    const after = reduceGame({
+      ...game,
+      gamePlayState: { ...game.gamePlayState, selectedHand: ['pair', []], score: { chips: 0, mult: 1 } },
+    }, { type: 'HAND_SCORING_FINALIZE' })
+
+    const seltzer = after.jokers.find(j => j.jokerId === 'seltzer')
+    // 10 initialized, then decremented by 1 = 9
+    expect(seltzer?.counter).toBe(9)
+  })
+
+  it('self-destructs when counter reaches 0 after 10 hands', () => {
+    const game = setupGame()
+    // counter starts at 0 (lazy init), will become 10 then count down
+
+    let state: GameState = game
+
+    for (let i = 0; i < 10; i++) {
+      state = reduceGame({
+        ...state,
+        gamePlayState: { ...state.gamePlayState, selectedHand: ['pair', []], score: { chips: 0, mult: 1 } },
+      }, { type: 'HAND_SCORING_FINALIZE' })
+    }
+
+    const seltzerInstance = state.jokers.find(j => j.jokerId === 'seltzer')
+    expect(seltzerInstance).toBeUndefined()
+  })
+
+  it('does not retrigger when counter is 0 (destroyed)', () => {
+    const game = setupGame()
+    // counter explicitly 0 = inactive (before lazy init or after destruction)
+    // Simulate already-destroyed by having no counter > 0 and calling CARD_SCORED
+    // We do NOT set counter here so it's 0 (uninitialised)
+
+    const aceId = Object.keys(game.cards).find(id =>
+      playingCards[game.cards[id].playingCardId]?.value === 'A'
+    )!
+
+    // Manually deplete seltzer counter to 0 by running 10 HAND_SCORING_FINALIZE events
+    let state: GameState = game
+    for (let i = 0; i < 10; i++) {
+      state = reduceGame({
+        ...state,
+        gamePlayState: { ...state.gamePlayState, selectedHand: ['pair', []], score: { chips: 0, mult: 1 } },
+      }, { type: 'HAND_SCORING_FINALIZE' })
+    }
+
+    // Seltzer should be gone - CARD_SCORED should not produce any Seltzer events
+    const after = reduceGame({
+      ...state,
+      gamePlayState: { ...state.gamePlayState, cardsToScore: [game.cards[aceId]] },
+    }, { type: 'CARD_SCORED' })
+
+    const seltzerEvents = after.gamePlayState.scoringEvents.filter(
+      e => 'source' in e && e.source === 'Seltzer'
+    )
+    expect(seltzerEvents).toHaveLength(0)
+  })
+})

--- a/src/app/daily-card-game/domain/joker/jokers.ts
+++ b/src/app/daily-card-game/domain/joker/jokers.ts
@@ -3183,6 +3183,49 @@ export const hack: JokerDefinition = {
   rarity: 'uncommon',
 }
 
+export const seltzer: JokerDefinition = {
+  id: 'seltzer',
+  name: 'Seltzer',
+  description: 'Retrigger all cards played for the next 10 hands',
+  price: 6,
+  effects: [
+    {
+      event: { type: 'CARD_SCORED' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        const s = ctx.game.jokers.find(j => j.jokerId === 'seltzer')
+        if (!s) return
+        if (s.counter === 0) s.counter = 10
+        if (s.counter <= 0) return
+        const scoredCard = ctx.scoredCards?.[0]
+        if (!scoredCard) return
+        const cardDef = playingCards[scoredCard.playingCardId]
+        ctx.game.gamePlayState.scoringEvents.push({
+          id: uuid(),
+          type: 'chips',
+          value: cardDef.baseChips,
+          source: 'Seltzer',
+        })
+        ctx.game.gamePlayState.score.chips += cardDef.baseChips
+      },
+    },
+    {
+      event: { type: 'HAND_SCORING_FINALIZE' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        const s = ctx.game.jokers.find(j => j.jokerId === 'seltzer')
+        if (!s) return
+        if (s.counter === 0) s.counter = 10
+        s.counter -= 1
+        if (s.counter <= 0) {
+          ctx.game.jokers = ctx.game.jokers.filter(j => j.id !== s.id)
+        }
+      },
+    },
+  ],
+  rarity: 'uncommon',
+}
+
 export const riffRaff: JokerDefinition = {
   id: 'riffRaff',
   name: 'Riff-raff',
@@ -3559,6 +3602,7 @@ export const jokers: Record<JokerDefinition['id'], JokerDefinition> = {
   mailInRebate,
   hangingChad,
   hack,
+  seltzer,
   riffRaff,
   ceremonialDagger,
   madness,


### PR DESCRIPTION
## Summary
- Implements the Seltzer uncommon joker: retrigger all cards for 10 hands, then self-destruct
- Uses counter for hand countdown with lazy initialization
- Adds 4 unit tests covering retrigger, countdown, self-destruct, and post-destruction

Closes #789

## Test plan
- [x] Unit tests pass (`npx vitest run seltzer`)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)