### PR TITLE
fix: implement Cerulean Bell boss blind

### DIFF
--- a/src/app/daily-card-game/domain/game/__tests__/cerulean-bell.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/cerulean-bell.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+import { defaultGameState } from '@/app/daily-card-game/domain/game/default-game-state'
+import { reduceGame } from '@/app/daily-card-game/domain/game/reduce-game'
+import type { GameState } from '@/app/daily-card-game/domain/game/types'
+
+describe('Cerulean Bell boss blind', () => {
+  function setupGame(): GameState {
+    const game: GameState = structuredClone(defaultGameState)
+    game.rounds[game.roundIndex].bossBlindName = 'Cerulean Bell'
+    game.gamePlayState.handIds = Object.keys(game.cards).slice(0, 5)
+    return game
+  }
+
+  it('selects one card from the hand when the boss blind starts', () => {
+    const game = setupGame()
+
+    const after = reduceGame(game, { type: 'BOSS_BLIND_SELECTED' })
+
+    expect(after.gamePlayState.selectedCardIds).toHaveLength(1)
+    expect(after.gamePlayState.handIds).toContain(after.gamePlayState.selectedCardIds[0])
+    expect(after.gamePlayState.selectedHand?.[1].map(card => card.id)).toEqual(
+      after.gamePlayState.selectedCardIds
+    )
+  })
+
+  it('keeps the forced card selected when trying to deselect it', () => {
+    const afterStart = reduceGame(setupGame(), { type: 'BOSS_BLIND_SELECTED' })
+    const forcedCardId = afterStart.gamePlayState.selectedCardIds[0]
+
+    const afterDeselect = reduceGame(afterStart, { type: 'CARD_DESELECTED', id: forcedCardId })
+
+    expect(afterDeselect.gamePlayState.selectedCardIds).toContain(forcedCardId)
+  })
+})

--- a/src/app/daily-card-game/domain/game/handlers/blind-selection.ts
+++ b/src/app/daily-card-game/domain/game/handlers/blind-selection.ts
@@ -1,7 +1,7 @@
 import { dispatchEffects } from '@/app/daily-card-game/domain/events/dispatch-effects'
 import type { GameEvent } from '@/app/daily-card-game/domain/events/types'
 import type { GameState } from '@/app/daily-card-game/domain/game/types'
-import { collectEffects, shuffleCardIds } from '@/app/daily-card-game/domain/game/utils'
+import { collectEffects, getBlindDefinition, shuffleCardIds } from '@/app/daily-card-game/domain/game/utils'
 import { buildSeedString } from '@/app/daily-card-game/domain/randomness'
 import { blindIndices, getNextBlind } from '@/app/daily-card-game/domain/round/blinds'
 import { initializeTag } from '@/app/daily-card-game/domain/tag/utils'
@@ -61,6 +61,18 @@ export function handleBossBlindSelected(draft: GameState) {
   })
   draft.gamePlayState.handIds = []
   draft.gamePlayState.discardPileIds = []
+
+  if (getBlindDefinition('bossBlind', draft.rounds[draft.roundIndex]).name === 'Cerulean Bell') {
+    const forcedCardId = draft.gamePlayState.drawPileIds[0]
+    const card = draft.cards[forcedCardId]
+    if (!forcedCardId || !card) return
+
+    draft.gamePlayState.handIds = [forcedCardId]
+    draft.gamePlayState.drawPileIds = draft.gamePlayState.drawPileIds.filter(id => id !== forcedCardId)
+    draft.gamePlayState.selectedCardIds = [forcedCardId]
+    draft.gamePlayState.forcedSelectedCardIds = [forcedCardId]
+    draft.gamePlayState.selectedHand = ['highCard', [card]]
+  }
 }
 
 export function handleBlindSkipped(draft: GameState, event: GameEvent) {

--- a/src/app/daily-card-game/domain/game/handlers/gameplay.ts
+++ b/src/app/daily-card-game/domain/game/handlers/gameplay.ts
@@ -47,6 +47,8 @@ export function handleCardDeselected(draft: GameState, event: CardDeselectedEven
   const gamePlayState = draft.gamePlayState
   if (!gamePlayState.selectedCardIds.includes(id)) return
 
+  if (gamePlayState.forcedSelectedCardIds?.includes(id)) return
+
   const selectedCardIds = gamePlayState.selectedCardIds.filter(cardId => cardId !== id)
   const selectedCards = getCards(draft as unknown as GameState, selectedCardIds)
 

--- a/src/app/daily-card-game/domain/game/types.ts
+++ b/src/app/daily-card-game/domain/game/types.ts
@@ -91,6 +91,7 @@ export interface GamePlayState {
   score: ScoreState
   scoringEvents: (ScoringEvent | CustomScoringEvent)[]
   selectedCardIds: string[]
+  forcedSelectedCardIds?: string[]
   selectedHand?: [PokerHandDefinition['id'], PlayingCardState[]]
   selectedConsumable?: CelestialCardState | TarotCardState
   selectedJokerId?: string

--- a/src/app/daily-card-game/domain/round/boss-blinds.ts
+++ b/src/app/daily-card-game/domain/round/boss-blinds.ts
@@ -54,7 +54,20 @@ const theOx: BossBlindDefinition = {
   ],
 }
 
-export const bossBlinds: BossBlindDefinition[] = [theHook, theOx]
+const ceruleanBell: BossBlindDefinition = {
+  type: 'bossBlind',
+  status: 'notStarted',
+  anteMultiplier: 2,
+  name: 'Cerulean Bell',
+  description: 'Forces 1 card to always be selected',
+  image: 'cerulean-bell.png',
+  minimumAnte: 8,
+  baseReward: 8,
+  effects: [],
+}
+
+
+export const bossBlinds: BossBlindDefinition[] = [theHook, theOx, ceruleanBell]
 
 /**
  


### PR DESCRIPTION
## Summary
- Add the Cerulean Bell showdown boss blind definition.
- Force one card to be selected when the boss blind starts.
- Prevent the forced Cerulean Bell card from being deselected.
- Add regression coverage for Cerulean Bell selection behavior.

Fixes #962

## Testing
- npm test -- --run src/app/daily-card-game/domain/game/__tests__/cerulean-bell.test.ts
- npm test -- --run src/app/daily-card-game/domain/game/__tests__
- npm test -- --run src/app/daily-card-game/domain/game/__tests__/cerulean-bell.test.ts src/app/daily-card-game/domain/game/__tests__/ride-the-bus.test.ts src/app/daily-card-game/domain/game/__tests__/ramen.test.ts
- git diff --check

Note: attempted npx tsc --noEmit, but the repository currently has pre-existing unrelated type errors in other test files (for example tap-tap-adventure fixtures missing newly required fields), so I verified with the targeted and daily-card-game Vitest suites instead.