### PR TITLE
Implement Constellation uncommon joker (#807)

### DIFF
--- a/src/app/daily-card-game/domain/game/__tests__/constellation.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/constellation.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from 'vitest'
+
+import { initializeCelestialCard } from '@/app/daily-card-game/domain/consumable/utils'
+import { celestialCards } from '@/app/daily-card-game/domain/consumable/celestial-cards'
+import { defaultGameState } from '@/app/daily-card-game/domain/game/default-game-state'
+import { reduceGame } from '@/app/daily-card-game/domain/game/reduce-game'
+import type { GameState } from '@/app/daily-card-game/domain/game/types'
+import { jokers } from '@/app/daily-card-game/domain/joker/jokers'
+import { initializeJoker } from '@/app/daily-card-game/domain/joker/utils'
+
+describe('Constellation joker', () => {
+  function createGameWithConstellation(): GameState {
+    const game: GameState = structuredClone(defaultGameState)
+    game.jokers = [initializeJoker(jokers.constellation, game)]
+    return game
+  }
+
+  function addCelestialCard(game: GameState): GameState {
+    const celestialCard = initializeCelestialCard(celestialCards.pair)
+    return {
+      ...game,
+      consumables: [...game.consumables, celestialCard],
+      gamePlayState: {
+        ...game.gamePlayState,
+        selectedConsumable: celestialCard,
+      },
+    }
+  }
+
+  it('increases counter by 1 on CELESTIAL_CARD_USED (lazy init from 0 to 10, then +1)', () => {
+    const game = addCelestialCard(createGameWithConstellation())
+
+    const after = reduceGame(game, { type: 'CELESTIAL_CARD_USED' })
+    const c = after.jokers.find(j => j.jokerId === 'constellation')
+    // starts at 0, lazy init sets to 10, then +1 = 11
+    expect(c?.counter).toBe(11)
+  })
+
+  it('accumulates counter across multiple planet card uses', () => {
+    const game = createGameWithConstellation()
+
+    const after1 = reduceGame(addCelestialCard(game), { type: 'CELESTIAL_CARD_USED' })
+    // counter = 11 after first use (10 + 1)
+
+    const after2 = reduceGame(addCelestialCard(after1), { type: 'CELESTIAL_CARD_USED' })
+    const c = after2.jokers.find(j => j.jokerId === 'constellation')
+    // counter = 12 after second use
+    expect(c?.counter).toBe(12)
+  })
+
+  it('applies X Mult scoring event on HAND_SCORING_FINALIZE when counter > 10', () => {
+    const game = createGameWithConstellation()
+
+    // Use one celestial card to set counter to 11 (X1.1)
+    const afterCelestial = reduceGame(addCelestialCard(game), { type: 'CELESTIAL_CARD_USED' })
+
+    const hand: GameState = {
+      ...afterCelestial,
+      gamePhase: 'gameplay',
+      rounds: afterCelestial.rounds.map((r, i) =>
+        i === afterCelestial.roundIndex
+          ? { ...r, smallBlind: { ...r.smallBlind, status: 'inProgress' } }
+          : r
+      ),
+      gamePlayState: {
+        ...afterCelestial.gamePlayState,
+        selectedHand: ['pair', []],
+        score: { chips: 10, mult: 10 },
+      },
+    }
+
+    const after = reduceGame(hand, { type: 'HAND_SCORING_FINALIZE' })
+    const scoringEvent = after.gamePlayState.scoringEvents.find(
+      e => 'source' in e && e.source === 'Constellation'
+    )
+    expect(scoringEvent).toBeDefined()
+    // counter = 11, xMult = 11/10 = 1.1
+    expect('value' in scoringEvent! && scoringEvent.value).toBe(1.1)
+  })
+
+  it('does not apply X Mult scoring event when counter is 10 (no planet cards used)', () => {
+    const game = createGameWithConstellation()
+
+    const hand: GameState = {
+      ...game,
+      gamePhase: 'gameplay',
+      rounds: game.rounds.map((r, i) =>
+        i === game.roundIndex
+          ? { ...r, smallBlind: { ...r.smallBlind, status: 'inProgress' } }
+          : r
+      ),
+      gamePlayState: {
+        ...game.gamePlayState,
+        selectedHand: ['pair', []],
+        score: { chips: 4, mult: 4 },
+      },
+    }
+
+    const after = reduceGame(hand, { type: 'HAND_SCORING_FINALIZE' })
+    const scoringEvent = after.gamePlayState.scoringEvents.find(
+      e => 'source' in e && e.source === 'Constellation'
+    )
+    expect(scoringEvent).toBeUndefined()
+  })
+})

--- a/src/app/daily-card-game/domain/game/reduce-game.ts
+++ b/src/app/daily-card-game/domain/game/reduce-game.ts
@@ -263,6 +263,7 @@ export function reduceGame(game: GameState, event: GameEvent): GameState {
       }
       case 'CELESTIAL_CARD_USED': {
         handleUseConsumableCelestialCard(draft, event)
+        dispatchEffects(event, getEffectContext(draft as unknown as GameState, event), collectEffects(draft as unknown as GameState))
         return
       }
       case 'TAROT_CARD_USED': {

--- a/src/app/daily-card-game/domain/joker/jokers.ts
+++ b/src/app/daily-card-game/domain/joker/jokers.ts
@@ -3585,6 +3585,45 @@ export const throwback: JokerDefinition = {
   rarity: 'uncommon',
 }
 
+export const constellation: JokerDefinition = {
+  id: 'constellation',
+  name: 'Constellation',
+  description: 'This Joker gains X0.1 Mult every time a Planet card is used',
+  price: 6,
+  effects: [
+    {
+      event: { type: 'CELESTIAL_CARD_USED' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        const c = ctx.game.jokers.find(j => j.jokerId === 'constellation')
+        if (!c) return
+        if (c.counter === 0) c.counter = 10
+        c.counter += 1
+      },
+    },
+    {
+      event: { type: 'HAND_SCORING_FINALIZE' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        const c = ctx.game.jokers.find(j => j.jokerId === 'constellation')
+        if (!c) return
+        if (c.counter === 0) c.counter = 10
+        if (c.counter <= 10) return
+        const xMult = c.counter / 10
+        ctx.game.gamePlayState.scoringEvents.push({
+          id: uuid(),
+          type: 'mult',
+          operator: 'x',
+          value: xMult,
+          source: 'Constellation',
+        })
+        ctx.game.gamePlayState.score.mult *= xMult
+      },
+    },
+  ],
+  rarity: 'uncommon',
+}
+
 export const jokers: Record<JokerDefinition['id'], JokerDefinition> = {
   swashbucklerJoker,
   walkieTalkieJoker,
@@ -3688,6 +3727,7 @@ export const jokers: Record<JokerDefinition['id'], JokerDefinition> = {
   ramen,
   bloodstone,
   throwback,
+  constellation,
 }
 
 /***


### PR DESCRIPTION
## Summary
- Implements the Constellation uncommon joker: gains X0.1 Mult per Planet card used
- Adds dispatchEffects to CELESTIAL_CARD_USED handler
- Adds 4 unit tests covering counter increment, accumulation, X mult application, and baseline

Closes #807

## Test plan
- [x] Unit tests pass (`npx vitest run constellation`)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)