### PR TITLE
Implement Satellite uncommon joker (#812)

### DIFF
--- a/src/app/daily-card-game/domain/game/__tests__/satellite.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/satellite.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest'
+
+import { defaultGameState } from '@/app/daily-card-game/domain/game/default-game-state'
+import { reduceGame } from '@/app/daily-card-game/domain/game/reduce-game'
+import type { GameState } from '@/app/daily-card-game/domain/game/types'
+import { jokers } from '@/app/daily-card-game/domain/joker/jokers'
+import { initializeJoker } from '@/app/daily-card-game/domain/joker/utils'
+
+describe('Satellite joker', () => {
+  it('earns $1 per unique Planet card used at ROUND_END', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.jokers = [initializeJoker(jokers.satellite, game)]
+    game.consumablesUsed = [
+      { id: '1', consumableType: 'celestialCard', handId: 'highCard' },
+      { id: '2', consumableType: 'celestialCard', handId: 'pair' },
+      { id: '3', consumableType: 'celestialCard', handId: 'twoPair' },
+    ]
+    const started = reduceGame(game, { type: 'GAME_START' })
+    const initialMoney = started.money
+    const afterRound = reduceGame(started, { type: 'ROUND_END' })
+    expect(afterRound.money).toBe(initialMoney + 3)
+  })
+
+  it('earns $0 when no Planet cards used', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.jokers = [initializeJoker(jokers.satellite, game)]
+    game.consumablesUsed = []
+    const started = reduceGame(game, { type: 'GAME_START' })
+    const initialMoney = started.money
+    const afterRound = reduceGame(started, { type: 'ROUND_END' })
+    expect(afterRound.money).toBe(initialMoney)
+  })
+
+  it('counts duplicate Planet cards only once', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.jokers = [initializeJoker(jokers.satellite, game)]
+    game.consumablesUsed = [
+      { id: '1', consumableType: 'celestialCard', handId: 'pair' },
+      { id: '2', consumableType: 'celestialCard', handId: 'pair' },
+      { id: '3', consumableType: 'celestialCard', handId: 'pair' },
+    ]
+    const started = reduceGame(game, { type: 'GAME_START' })
+    const initialMoney = started.money
+    const afterRound = reduceGame(started, { type: 'ROUND_END' })
+    expect(afterRound.money).toBe(initialMoney + 1)
+  })
+
+  it('ignores Tarot cards when counting', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.jokers = [initializeJoker(jokers.satellite, game)]
+    game.consumablesUsed = [
+      { id: '1', consumableType: 'celestialCard', handId: 'flush' },
+      { id: '2', consumableType: 'tarotCard', tarotType: 'theFool' } as any,
+    ]
+    const started = reduceGame(game, { type: 'GAME_START' })
+    const initialMoney = started.money
+    const afterRound = reduceGame(started, { type: 'ROUND_END' })
+    expect(afterRound.money).toBe(initialMoney + 1)
+  })
+})

--- a/src/app/daily-card-game/domain/joker/jokers.ts
+++ b/src/app/daily-card-game/domain/joker/jokers.ts
@@ -13,6 +13,7 @@ import {
   getRandomWeightedChoiceWithSeed,
   uuid,
 } from '@/app/daily-card-game/domain/randomness'
+import type { CelestialCardState } from '@/app/daily-card-game/domain/consumable/types'
 import { initializeTarotCard } from '@/app/daily-card-game/domain/consumable/utils'
 import { getRandomTarotCards } from '@/app/daily-card-game/domain/shop/utils'
 
@@ -3624,6 +3625,31 @@ export const constellation: JokerDefinition = {
   rarity: 'uncommon',
 }
 
+export const satellite: JokerDefinition = {
+  id: 'satellite',
+  name: 'Satellite',
+  description: 'Earn $1 at end of round per unique Planet card used this run',
+  price: 6,
+  effects: [
+    {
+      event: { type: 'ROUND_END' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        const uniquePlanets = new Set(
+          ctx.game.consumablesUsed
+            .filter(c => c.consumableType === 'celestialCard')
+            .map(c => (c as CelestialCardState).handId)
+        )
+        const payout = uniquePlanets.size
+        if (payout > 0) {
+          ctx.game.money += payout
+        }
+      },
+    },
+  ],
+  rarity: 'uncommon',
+}
+
 export const jokers: Record<JokerDefinition['id'], JokerDefinition> = {
   swashbucklerJoker,
   walkieTalkieJoker,
@@ -3728,6 +3754,7 @@ export const jokers: Record<JokerDefinition['id'], JokerDefinition> = {
   bloodstone,
   throwback,
   constellation,
+  satellite,
 }
 
 /***


### PR DESCRIPTION
## Summary
- Implements the Satellite uncommon joker: $1 per unique Planet card used this run at round end
- Adds 4 unit tests covering payout, no-planet case, deduplication, and tarot exclusion

Closes #812

## Test plan
- [x] Unit tests pass (`npx vitest run satellite`)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)