### PR TITLE
Implement Cartomancer uncommon joker (#813)

### DIFF
--- a/src/app/daily-card-game/domain/game/__tests__/cartomancer.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/cartomancer.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest'
+
+import { defaultGameState } from '@/app/daily-card-game/domain/game/default-game-state'
+import { reduceGame } from '@/app/daily-card-game/domain/game/reduce-game'
+import type { GameState } from '@/app/daily-card-game/domain/game/types'
+import { jokers } from '@/app/daily-card-game/domain/joker/jokers'
+import { initializeJoker } from '@/app/daily-card-game/domain/joker/utils'
+
+describe('Cartomancer joker', () => {
+  function setupGame(overrides: Partial<GameState> = {}): GameState {
+    const game: GameState = structuredClone(defaultGameState)
+    game.jokers = [initializeJoker(jokers.cartomancer, game)]
+    game.consumables = []
+    return { ...game, ...overrides }
+  }
+
+  it('creates a Tarot card when SMALL_BLIND_SELECTED and consumables has room', () => {
+    const game = setupGame()
+    expect(game.consumables.length).toBe(0)
+    const after = reduceGame(game, { type: 'SMALL_BLIND_SELECTED' })
+    expect(after.consumables.length).toBe(1)
+    expect(after.consumables[0].consumableType).toBe('tarotCard')
+  })
+
+  it('creates a Tarot card when BIG_BLIND_SELECTED and consumables has room', () => {
+    const game = setupGame()
+    const after = reduceGame(game, { type: 'BIG_BLIND_SELECTED' })
+    expect(after.consumables.length).toBe(1)
+    expect(after.consumables[0].consumableType).toBe('tarotCard')
+  })
+
+  it('creates a Tarot card when BOSS_BLIND_SELECTED and consumables has room', () => {
+    const game = setupGame()
+    const after = reduceGame(game, { type: 'BOSS_BLIND_SELECTED' })
+    expect(after.consumables.length).toBe(1)
+    expect(after.consumables[0].consumableType).toBe('tarotCard')
+  })
+
+  it('does not create a Tarot card when consumables are full', () => {
+    const game = setupGame({ maxConsumables: 2 })
+    // Fill consumables to capacity
+    const before = reduceGame(game, { type: 'SMALL_BLIND_SELECTED' })
+    // Now fill the remaining slot manually by triggering again with full consumables
+    const fullGame: GameState = { ...before, maxConsumables: before.consumables.length }
+    const after = reduceGame(fullGame, { type: 'SMALL_BLIND_SELECTED' })
+    expect(after.consumables.length).toBe(fullGame.consumables.length)
+  })
+})

--- a/src/app/daily-card-game/domain/joker/jokers.ts
+++ b/src/app/daily-card-game/domain/joker/jokers.ts
@@ -3252,6 +3252,26 @@ export const riffRaff: JokerDefinition = {
   rarity: 'common',
 }
 
+function applyCartomancer(ctx: EffectContext) {
+  if (ctx.game.consumables.length >= ctx.game.maxConsumables) return
+  const seed = buildSeedString([ctx.game.gameSeed, ctx.game.roundIndex.toString(), 'cartomancer'])
+  const tarotCard = getRandomTarotCards(1, seed)[0]
+  ctx.game.consumables.push(initializeTarotCard(tarotCard))
+}
+
+export const cartomancer: JokerDefinition = {
+  id: 'cartomancer',
+  name: 'Cartomancer',
+  description: 'Create a Tarot card when Blind is selected (Must have room)',
+  price: 6,
+  effects: [
+    { event: { type: 'SMALL_BLIND_SELECTED' }, priority: 1, apply: applyCartomancer },
+    { event: { type: 'BIG_BLIND_SELECTED' }, priority: 1, apply: applyCartomancer },
+    { event: { type: 'BOSS_BLIND_SELECTED' }, priority: 1, apply: applyCartomancer },
+  ],
+  rarity: 'uncommon',
+}
+
 function applyMadnessBlindEffect(ctx: EffectContext) {
   const m = ctx.game.jokers.find(j => j.jokerId === 'madness')
   if (!m) return
@@ -3744,6 +3764,7 @@ export const jokers: Record<JokerDefinition['id'], JokerDefinition> = {
   hack,
   seltzer,
   riffRaff,
+  cartomancer,
   ceremonialDagger,
   madness,
   spaceJoker,


### PR DESCRIPTION
## Summary
- Implements the Cartomancer uncommon joker: create Tarot card when Blind is selected
- Adds 4 unit tests covering all blind types and full consumables

Closes #813

## Test plan
- [x] Unit tests pass (`npx vitest run cartomancer`)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)