### PR TITLE
Implement Vampire uncommon joker (#776)

### DIFF
--- a/src/app/daily-card-game/domain/game/__tests__/vampire.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/vampire.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest'
+import { defaultGameState } from '@/app/daily-card-game/domain/game/default-game-state'
+import { reduceGame } from '@/app/daily-card-game/domain/game/reduce-game'
+import type { GameState } from '@/app/daily-card-game/domain/game/types'
+import { jokers } from '@/app/daily-card-game/domain/joker/jokers'
+import { initializeJoker } from '@/app/daily-card-game/domain/joker/utils'
+
+describe('Vampire joker', () => {
+  function setupGame(): GameState {
+    const game: GameState = structuredClone(defaultGameState)
+    game.jokers = [initializeJoker(jokers.vampire, game)]
+    game.rounds[game.roundIndex].smallBlind.status = 'inProgress'
+    game.gamePhase = 'gameplay'
+    return game
+  }
+
+  it('increments counter and removes enchantment when enchanted card is scored', () => {
+    const game = setupGame()
+    const vampireJoker = game.jokers.find(j => j.jokerId === 'vampire')!
+    vampireJoker.counter = 10
+
+    // Get any card and give it an enchantment
+    const cardId = Object.keys(game.cards)[0]
+    game.cards[cardId].flags.enchantment = 'bonus'
+    game.gamePlayState.cardsToScore = [game.cards[cardId]]
+
+    const after = reduceGame(game, { type: 'CARD_SCORED' })
+
+    const vampireAfter = after.jokers.find(j => j.jokerId === 'vampire')!
+    expect(vampireAfter.counter).toBe(11)
+    expect(after.cards[cardId].flags.enchantment).toBe('none')
+  })
+
+  it('does not increment counter for non-enchanted cards', () => {
+    const game = setupGame()
+    const vampireJoker = game.jokers.find(j => j.jokerId === 'vampire')!
+    vampireJoker.counter = 10
+
+    const cardId = Object.keys(game.cards)[0]
+    game.cards[cardId].flags.enchantment = 'none'
+    game.gamePlayState.cardsToScore = [game.cards[cardId]]
+
+    const after = reduceGame(game, { type: 'CARD_SCORED' })
+
+    const vampireAfter = after.jokers.find(j => j.jokerId === 'vampire')!
+    expect(vampireAfter.counter).toBe(10)
+    expect(after.cards[cardId].flags.enchantment).toBe('none')
+  })
+
+  it('applies X Mult on HAND_SCORING_FINALIZE when counter > 10', () => {
+    const game = setupGame()
+    const vampireJoker = game.jokers.find(j => j.jokerId === 'vampire')!
+    // 3 enhanced cards scored => counter = 10 + 3 = 13 => X1.3
+    vampireJoker.counter = 13
+
+    game.gamePlayState.score = { chips: 0, mult: 1 }
+    const after = reduceGame(game, { type: 'HAND_SCORING_FINALIZE' })
+
+    expect(after.gamePlayState.scoringEvents.some(
+      e => 'source' in e && e.source === 'Vampire' && 'operator' in e && e.operator === 'x' && 'value' in e && Math.abs((e.value as number) - 1.3) < 0.0001
+    )).toBe(true)
+  })
+
+  it('does not apply X Mult on HAND_SCORING_FINALIZE when counter is exactly 10', () => {
+    const game = setupGame()
+    const vampireJoker = game.jokers.find(j => j.jokerId === 'vampire')!
+    vampireJoker.counter = 10
+
+    game.gamePlayState.score = { chips: 0, mult: 1 }
+    const after = reduceGame(game, { type: 'HAND_SCORING_FINALIZE' })
+
+    expect(after.gamePlayState.scoringEvents.some(
+      e => 'source' in e && e.source === 'Vampire'
+    )).toBe(false)
+  })
+
+  it('initializes counter to 10 on first HAND_SCORING_FINALIZE if counter is 0', () => {
+    const game = setupGame()
+    const vampireJoker = game.jokers.find(j => j.jokerId === 'vampire')!
+    expect(vampireJoker.counter).toBe(0)
+
+    game.gamePlayState.score = { chips: 0, mult: 1 }
+    const after = reduceGame(game, { type: 'HAND_SCORING_FINALIZE' })
+
+    // counter initialized to 10 (X1.0), which is not > 10, so no scoring event
+    expect(after.gamePlayState.scoringEvents.some(
+      e => 'source' in e && e.source === 'Vampire'
+    )).toBe(false)
+  })
+})

--- a/src/app/daily-card-game/domain/joker/jokers.ts
+++ b/src/app/daily-card-game/domain/joker/jokers.ts
@@ -3670,6 +3670,50 @@ export const satellite: JokerDefinition = {
   rarity: 'uncommon',
 }
 
+export const vampire: JokerDefinition = {
+  id: 'vampire',
+  name: 'Vampire',
+  description: 'Gains X0.1 Mult per Enhanced card scored, removes Enhancement',
+  price: 7,
+  effects: [
+    {
+      event: { type: 'CARD_SCORED' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        const v = ctx.game.jokers.find(j => j.jokerId === 'vampire')
+        if (!v) return
+        if (v.counter === 0) v.counter = 10
+        const scoredCard = ctx.scoredCards?.[0]
+        if (!scoredCard) return
+        const cardState = ctx.game.cards[scoredCard.id]
+        if (!cardState || cardState.flags.enchantment === 'none') return
+        v.counter += 1
+        cardState.flags.enchantment = 'none'
+      },
+    },
+    {
+      event: { type: 'HAND_SCORING_FINALIZE' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        const v = ctx.game.jokers.find(j => j.jokerId === 'vampire')
+        if (!v) return
+        if (v.counter === 0) v.counter = 10
+        if (v.counter <= 10) return
+        const xMult = v.counter / 10
+        ctx.game.gamePlayState.scoringEvents.push({
+          id: uuid(),
+          type: 'mult',
+          operator: 'x',
+          value: xMult,
+          source: 'Vampire',
+        })
+        ctx.game.gamePlayState.score.mult *= xMult
+      },
+    },
+  ],
+  rarity: 'uncommon',
+}
+
 export const jokers: Record<JokerDefinition['id'], JokerDefinition> = {
   swashbucklerJoker,
   walkieTalkieJoker,
@@ -3776,6 +3820,7 @@ export const jokers: Record<JokerDefinition['id'], JokerDefinition> = {
   throwback,
   constellation,
   satellite,
+  vampire,
 }
 
 /***


### PR DESCRIPTION
## Summary
- Implements the Vampire uncommon joker: gains X0.1 Mult per Enhanced card scored, removes Enhancement
- Uses counter stored as tenths (10=X1.0)
- Adds 5 unit tests covering enchantment removal, counter increment, non-enchanted skip, X mult application, and baseline

Closes #776

## Test plan
- [x] Unit tests pass (`npx vitest run vampire`)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)