### PR TITLE
Implement Castle uncommon joker (#790)

### DIFF
--- a/src/app/daily-card-game/domain/game/__tests__/castle.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/castle.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from 'vitest'
+import { defaultGameState } from '@/app/daily-card-game/domain/game/default-game-state'
+import { reduceGame } from '@/app/daily-card-game/domain/game/reduce-game'
+import type { GameState } from '@/app/daily-card-game/domain/game/types'
+import { jokers } from '@/app/daily-card-game/domain/joker/jokers'
+import { initializeJoker } from '@/app/daily-card-game/domain/joker/utils'
+import { playingCards } from '@/app/daily-card-game/domain/playing-card/playing-cards'
+import {
+  buildSeedString,
+  getRandomNumbersWithSeed,
+} from '@/app/daily-card-game/domain/randomness'
+
+describe('Castle joker', () => {
+  const suits = ['hearts', 'diamonds', 'clubs', 'spades']
+
+  function makeGame(): GameState {
+    const game: GameState = structuredClone(defaultGameState)
+    game.jokers = [initializeJoker(jokers.castle, game)]
+    game.rounds[game.roundIndex].smallBlind.status = 'inProgress'
+    game.gamePhase = 'gameplay'
+    return game
+  }
+
+  function getTargetSuit(game: GameState): string {
+    const seed = buildSeedString([
+      game.gameSeed,
+      game.roundIndex.toString(),
+      'castle',
+      'suit',
+    ])
+    const roll = getRandomNumbersWithSeed({ seed, min: 0, max: 3, numberOfNumbers: 1 })
+    return suits[roll[0]]
+  }
+
+  function getCardIdsBySuit(game: GameState, suit: string): string[] {
+    return Object.keys(game.cards).filter(
+      id => playingCards[game.cards[id].playingCardId]?.suit === suit
+    )
+  }
+
+  it('counter increases by 3 per matching suit card discarded', () => {
+    const game = makeGame()
+    const targetSuit = getTargetSuit(game)
+    const matchingIds = getCardIdsBySuit(game, targetSuit)
+
+    expect(matchingIds.length).toBeGreaterThanOrEqual(1)
+
+    const selectedIds = matchingIds.slice(0, Math.min(2, matchingIds.length))
+    game.gamePlayState.selectedCardIds = selectedIds
+
+    const after = reduceGame(game, { type: 'DISCARD_SELECTED_CARDS' })
+    const c = after.jokers.find(j => j.jokerId === 'castle')
+    expect(c?.counter).toBe(3 * selectedIds.length)
+  })
+
+  it('non-matching suit cards do not increase counter', () => {
+    const game = makeGame()
+    const targetSuit = getTargetSuit(game)
+
+    const nonMatchingIds = Object.keys(game.cards).filter(id => {
+      const cardDef = playingCards[game.cards[id].playingCardId]
+      return cardDef?.suit !== targetSuit
+    })
+
+    expect(nonMatchingIds.length).toBeGreaterThanOrEqual(1)
+
+    game.gamePlayState.selectedCardIds = [nonMatchingIds[0]]
+
+    const after = reduceGame(game, { type: 'DISCARD_SELECTED_CARDS' })
+    const c = after.jokers.find(j => j.jokerId === 'castle')
+    expect(c?.counter).toBe(0)
+  })
+
+  it('accumulated chips apply on HAND_SCORING_FINALIZE', () => {
+    const game = makeGame()
+    const targetSuit = getTargetSuit(game)
+    const matchingIds = getCardIdsBySuit(game, targetSuit)
+
+    expect(matchingIds.length).toBeGreaterThanOrEqual(1)
+
+    // First discard two matching cards to accumulate counter
+    const selectedIds = matchingIds.slice(0, Math.min(2, matchingIds.length))
+    game.gamePlayState.selectedCardIds = selectedIds
+
+    const afterDiscard = reduceGame(game, { type: 'DISCARD_SELECTED_CARDS' })
+    const c = afterDiscard.jokers.find(j => j.jokerId === 'castle')
+    const expectedCounter = 3 * selectedIds.length
+    expect(c?.counter).toBe(expectedCounter)
+
+    // Now finalize scoring and verify accumulated chips are applied
+    const hand: GameState = {
+      ...afterDiscard,
+      gamePlayState: {
+        ...afterDiscard.gamePlayState,
+        scoringEvents: [],
+        score: { chips: 0, mult: 1 },
+      },
+    }
+    const afterScoring = reduceGame(hand, { type: 'HAND_SCORING_FINALIZE' })
+    expect(afterScoring.gamePlayState.scoringEvents.some(
+      e => 'source' in e && e.source === 'Castle' && 'value' in e && e.value === expectedCounter
+    )).toBe(true)
+  })
+})

--- a/src/app/daily-card-game/domain/joker/jokers.ts
+++ b/src/app/daily-card-game/domain/joker/jokers.ts
@@ -3108,6 +3108,56 @@ export const mailInRebate: JokerDefinition = {
   rarity: 'common',
 }
 
+export const castle: JokerDefinition = {
+  id: 'castle',
+  name: 'Castle',
+  description: 'Gains +3 Chips per discarded card of current suit, suit changes every round',
+  price: 6,
+  effects: [
+    {
+      event: { type: 'DISCARD_SELECTED_CARDS' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        const c = ctx.game.jokers.find(j => j.jokerId === 'castle')
+        if (!c) return
+        const suits = ['hearts', 'diamonds', 'clubs', 'spades']
+        const seed = buildSeedString([
+          ctx.game.gameSeed,
+          ctx.game.roundIndex.toString(),
+          'castle',
+          'suit',
+        ])
+        const roll = getRandomNumbersWithSeed({ seed, min: 0, max: 3, numberOfNumbers: 1 })
+        const targetSuit = suits[roll[0]]
+        for (const cardId of ctx.game.gamePlayState.selectedCardIds) {
+          const cardState = ctx.game.cards[cardId]
+          if (!cardState) continue
+          const cardDef = playingCards[cardState.playingCardId]
+          if (cardDef.suit === targetSuit) {
+            c.counter += 3
+          }
+        }
+      },
+    },
+    {
+      event: { type: 'HAND_SCORING_FINALIZE' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        const c = ctx.game.jokers.find(j => j.jokerId === 'castle')
+        if (!c || c.counter <= 0) return
+        ctx.game.gamePlayState.scoringEvents.push({
+          id: uuid(),
+          type: 'chips',
+          value: c.counter,
+          source: 'Castle',
+        })
+        ctx.game.gamePlayState.score.chips += c.counter
+      },
+    },
+  ],
+  rarity: 'uncommon',
+}
+
 function initializeJokerInline(jokerId: string, game: EffectContext['game']): JokerState {
   const editionSeed = buildSeedString([
     game.gameSeed,
@@ -3841,6 +3891,7 @@ export const jokers: Record<JokerDefinition['id'], JokerDefinition> = {
   satellite,
   vampire,
   giftCard,
+  castle,
 }
 
 /***


### PR DESCRIPTION
## Summary
- Implements the Castle uncommon joker: gains +3 Chips per discarded card of current suit (scaling)
- Target suit derived deterministically from seed+roundIndex
- Adds 3 unit tests covering suit match, non-match, and scoring

Closes #790

## Test plan
- [x] Unit tests pass (`npx vitest run castle`)
- [x] Full test suite passes (1276 tests)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)