### PR TITLE
Implement Vagabond rare joker (#818)

### DIFF
--- a/src/app/daily-card-game/domain/game/__tests__/vagabond.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/vagabond.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest'
+import { defaultGameState } from '@/app/daily-card-game/domain/game/default-game-state'
+import { reduceGame } from '@/app/daily-card-game/domain/game/reduce-game'
+import type { GameState } from '@/app/daily-card-game/domain/game/types'
+import { jokers } from '@/app/daily-card-game/domain/joker/jokers'
+import { initializeJoker } from '@/app/daily-card-game/domain/joker/utils'
+
+describe('Vagabond joker', () => {
+  function setupGame(overrides: Partial<GameState> = {}): GameState {
+    const game: GameState = structuredClone(defaultGameState)
+    game.jokers = [initializeJoker(jokers.vagabond, game)]
+    game.gamePhase = 'gameplay'
+    game.rounds = game.rounds.map((r, i) =>
+      i === game.roundIndex
+        ? { ...r, smallBlind: { ...r.smallBlind, status: 'inProgress' } }
+        : r
+    )
+    game.gamePlayState = {
+      ...game.gamePlayState,
+      selectedHand: ['pair', []],
+      score: { chips: 4, mult: 4 },
+    }
+    return { ...game, ...overrides }
+  }
+
+  it('creates a Tarot card when money is $4 or less', () => {
+    const game = setupGame({ money: 4 })
+    const before = game.consumables.length
+    const after = reduceGame(game, { type: 'HAND_SCORING_FINALIZE' })
+    expect(after.consumables.length).toBe(before + 1)
+    expect(after.consumables[after.consumables.length - 1].consumableType).toBe('tarotCard')
+  })
+
+  it('creates a Tarot card when money is $0', () => {
+    const game = setupGame({ money: 0 })
+    const before = game.consumables.length
+    const after = reduceGame(game, { type: 'HAND_SCORING_FINALIZE' })
+    expect(after.consumables.length).toBe(before + 1)
+    expect(after.consumables[after.consumables.length - 1].consumableType).toBe('tarotCard')
+  })
+
+  it('does not create a Tarot card when money is $5', () => {
+    const game = setupGame({ money: 5 })
+    const before = game.consumables.length
+    const after = reduceGame(game, { type: 'HAND_SCORING_FINALIZE' })
+    expect(after.consumables.length).toBe(before)
+  })
+
+  it('does not create a Tarot card when money is greater than $4', () => {
+    const game = setupGame({ money: 10 })
+    const before = game.consumables.length
+    const after = reduceGame(game, { type: 'HAND_SCORING_FINALIZE' })
+    expect(after.consumables.length).toBe(before)
+  })
+
+  it('does not create a Tarot card when consumables are full', () => {
+    const game = setupGame({ money: 3 })
+    game.consumables = Array.from({ length: game.maxConsumables }, (_, i) => ({
+      id: `tarot-${i}`,
+      consumableType: 'tarotCard' as const,
+      name: 'The Fool',
+      isFaceUp: true,
+      tarotType: 'theFool' as const,
+    }))
+    const before = game.consumables.length
+    const after = reduceGame(game, { type: 'HAND_SCORING_FINALIZE' })
+    expect(after.consumables.length).toBe(before)
+  })
+})

--- a/src/app/daily-card-game/domain/joker/jokers.ts
+++ b/src/app/daily-card-game/domain/joker/jokers.ts
@@ -3783,6 +3783,32 @@ export const giftCard: JokerDefinition = {
   rarity: 'uncommon',
 }
 
+export const vagabond: JokerDefinition = {
+  id: 'vagabond',
+  name: 'Vagabond',
+  description: 'Create a Tarot card if hand is played with $4 or less',
+  price: 8,
+  effects: [
+    {
+      event: { type: 'HAND_SCORING_FINALIZE' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        if (ctx.game.money > 4) return
+        if (ctx.game.consumables.length >= ctx.game.maxConsumables) return
+        const seed = buildSeedString([
+          ctx.game.gameSeed,
+          ctx.game.roundIndex.toString(),
+          ctx.game.handsPlayed.toString(),
+          'vagabond',
+        ])
+        const tarotCard = getRandomTarotCards(1, seed)[0]
+        ctx.game.consumables.push(initializeTarotCard(tarotCard))
+      },
+    },
+  ],
+  rarity: 'rare',
+}
+
 export const jokers: Record<JokerDefinition['id'], JokerDefinition> = {
   swashbucklerJoker,
   walkieTalkieJoker,
@@ -3892,6 +3918,7 @@ export const jokers: Record<JokerDefinition['id'], JokerDefinition> = {
   vampire,
   giftCard,
   castle,
+  vagabond,
 }
 
 /***


### PR DESCRIPTION
## Summary
- Implements the Vagabond rare joker: create Tarot card when hand played with $4 or less
- First rare joker implementation from epic #704
- Adds 5 unit tests covering money thresholds and full consumables

Closes #818

## Test plan
- [x] Unit tests pass (`npx vitest run vagabond`)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)