### PR TITLE
fix: implement Amber Acorn boss blind

### DIFF
--- a/src/app/daily-card-game/domain/game/__tests__/amber-acorn.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/amber-acorn.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest'
+
+import { defaultGameState } from '@/app/daily-card-game/domain/game/default-game-state'
+import { reduceGame } from '@/app/daily-card-game/domain/game/reduce-game'
+import type { GameState } from '@/app/daily-card-game/domain/game/types'
+import { greedyJoker, lustyJoker, wrathfulJoker } from '@/app/daily-card-game/domain/joker/jokers'
+import { initializeJoker } from '@/app/daily-card-game/domain/joker/utils'
+
+const GREEDY_JOKER = greedyJoker
+const LUSTY_JOKER = lustyJoker
+const WRATHFUL_JOKER = wrathfulJoker
+
+if (!GREEDY_JOKER || !LUSTY_JOKER || !WRATHFUL_JOKER) {
+  throw new Error('Required joker definitions are missing for Amber Acorn tests')
+}
+
+describe('Amber Acorn boss blind', () => {
+  function setupGame(overrides: Partial<GameState> = {}): GameState {
+    const game: GameState = structuredClone(defaultGameState)
+    game.gameSeed = 'amber-acorn-seed'
+    game.roundIndex = 8
+    game.rounds[game.roundIndex].bossBlindName = 'Amber Acorn'
+    game.jokers = [
+      initializeJoker(GREEDY_JOKER, game),
+      initializeJoker(LUSTY_JOKER, game),
+      initializeJoker(WRATHFUL_JOKER, game),
+    ]
+
+    return { ...game, ...overrides }
+  }
+
+  it('flips all jokers face down when the boss blind is selected', () => {
+    const game = setupGame()
+
+    const after = reduceGame(game, { type: 'BOSS_BLIND_SELECTED' })
+
+    expect(after.jokers).toHaveLength(3)
+    expect(after.jokers.every(joker => joker.isFaceUp === false)).toBe(true)
+  })
+
+  it('shuffles jokers deterministically when the boss blind is selected', () => {
+    const game = setupGame()
+    const beforeOrder = game.jokers.map(joker => joker.id)
+
+    const after1 = reduceGame(game, { type: 'BOSS_BLIND_SELECTED' })
+    const after2 = reduceGame(game, { type: 'BOSS_BLIND_SELECTED' })
+
+    const afterOrder1 = after1.jokers.map(joker => joker.id)
+    const afterOrder2 = after2.jokers.map(joker => joker.id)
+
+    expect(afterOrder1).toEqual(afterOrder2)
+    expect(afterOrder1).not.toEqual(beforeOrder)
+  })
+
+  it('does not flip or shuffle jokers for other boss blinds', () => {
+    const game = setupGame()
+    game.rounds[game.roundIndex].bossBlindName = 'The Ox'
+    const beforeOrder = game.jokers.map(joker => joker.id)
+
+    const after = reduceGame(game, { type: 'BOSS_BLIND_SELECTED' })
+
+    expect(after.jokers.map(joker => joker.id)).toEqual(beforeOrder)
+    expect(after.jokers.every(joker => joker.isFaceUp)).toBe(true)
+  })
+})

--- a/src/app/daily-card-game/domain/round/boss-blinds.ts
+++ b/src/app/daily-card-game/domain/round/boss-blinds.ts
@@ -1,5 +1,6 @@
 import type { EffectContext } from '@/app/daily-card-game/domain/events/types'
 import { getMostPlayedHand } from '@/app/daily-card-game/domain/hand/utils'
+import { shuffleCardIds } from '@/app/daily-card-game/domain/game/utils'
 import { getRandomNumberWithSeed } from '@/app/daily-card-game/domain/randomness'
 import type { BossBlindDefinition } from '@/app/daily-card-game/domain/round/types'
 
@@ -54,7 +55,47 @@ const theOx: BossBlindDefinition = {
   ],
 }
 
-export const bossBlinds: BossBlindDefinition[] = [theHook, theOx]
+const amberAcorn: BossBlindDefinition = {
+  type: 'bossBlind',
+  status: 'notStarted',
+  anteMultiplier: 2,
+  name: 'Amber Acorn',
+  description: 'Flips and shuffles all Joker cards',
+  image: 'amber-acorn.png',
+  minimumAnte: 8,
+  baseReward: 8,
+  effects: [
+    {
+      event: { type: 'BOSS_BLIND_SELECTED' },
+      priority: 1,
+      condition: (ctx: EffectContext) =>
+        ctx.event.type === 'BOSS_BLIND_SELECTED' && ctx.round?.bossBlindName === 'Amber Acorn',
+      apply: (ctx: EffectContext) => {
+        ctx.game.jokers.forEach(joker => {
+          joker.isFaceUp = false
+        })
+
+        if (ctx.game.jokers.length <= 1) {
+          return
+        }
+
+        const shuffledJokers = shuffleCardIds({
+          cardIds: ctx.game.jokers.map(joker => joker.id),
+          seed: ctx.game.gameSeed,
+          iteration: ctx.game.roundIndex,
+        })
+
+        const jokerMap = new Map(ctx.game.jokers.map(joker => [joker.id, joker]))
+        ctx.game.jokers = shuffledJokers.flatMap(jokerId => {
+          const joker = jokerMap.get(jokerId)
+          return joker ? [joker] : []
+        })
+      },
+    },
+  ],
+}
+
+export const bossBlinds: BossBlindDefinition[] = [theHook, theOx, amberAcorn]
 
 /**
  


### PR DESCRIPTION
## Summary
- add the Amber Acorn boss blind definition to the round pool
- flip all jokers face down and deterministically shuffle them when the boss blind is selected
- cover the new boss blind behavior with focused vitest coverage

## Testing
- npm test -- --run src/app/daily-card-game/domain/game/__tests__/amber-acorn.test.ts
- git diff --check

Fixes #958