### PR TITLE
Implement Ancient Joker rare joker (#826)

### DIFF
--- a/src/app/daily-card-game/domain/game/__tests__/ancient-joker.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/ancient-joker.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest'
+import { defaultGameState } from '@/app/daily-card-game/domain/game/default-game-state'
+import { reduceGame } from '@/app/daily-card-game/domain/game/reduce-game'
+import type { GameState } from '@/app/daily-card-game/domain/game/types'
+import { jokers } from '@/app/daily-card-game/domain/joker/jokers'
+import { initializeJoker } from '@/app/daily-card-game/domain/joker/utils'
+import { playingCards } from '@/app/daily-card-game/domain/playing-card/playing-cards'
+import {
+  buildSeedString,
+  getRandomNumbersWithSeed,
+} from '@/app/daily-card-game/domain/randomness'
+
+describe('Ancient Joker', () => {
+  const suits = ['hearts', 'diamonds', 'clubs', 'spades']
+
+  function makeGame(): GameState {
+    const game: GameState = structuredClone(defaultGameState)
+    game.jokers = [initializeJoker(jokers.ancientJoker, game)]
+    game.rounds[game.roundIndex].smallBlind.status = 'inProgress'
+    game.gamePhase = 'gameplay'
+    return game
+  }
+
+  function getTargetSuit(game: GameState): string {
+    const seed = buildSeedString([
+      game.gameSeed,
+      game.roundIndex.toString(),
+      'ancientJoker',
+      'suit',
+    ])
+    const roll = getRandomNumbersWithSeed({ seed, min: 0, max: 3, numberOfNumbers: 1 })
+    return suits[roll[0]]
+  }
+
+  it('gives X1.5 Mult when a card of the target suit is scored', () => {
+    const game = makeGame()
+    const targetSuit = getTargetSuit(game)
+
+    const matchingCardId = Object.keys(game.cards).find(
+      id => playingCards[game.cards[id].playingCardId]?.suit === targetSuit
+    )!
+
+    expect(matchingCardId).toBeDefined()
+
+    const card = game.cards[matchingCardId]
+    const multBefore = game.gamePlayState.score.mult
+
+    const after = reduceGame(
+      { ...game, gamePlayState: { ...game.gamePlayState, cardsToScore: [card] } },
+      { type: 'CARD_SCORED' }
+    )
+
+    expect(after.gamePlayState.scoringEvents.some(
+      e => 'source' in e && e.source === 'Ancient Joker' && 'operator' in e && e.operator === 'x' && e.value === 1.5
+    )).toBe(true)
+    expect(after.gamePlayState.score.mult).toBe(multBefore * 1.5)
+  })
+
+  it('gives no bonus when a card of a non-matching suit is scored', () => {
+    const game = makeGame()
+    const targetSuit = getTargetSuit(game)
+
+    const nonMatchingCardId = Object.keys(game.cards).find(
+      id => playingCards[game.cards[id].playingCardId]?.suit !== targetSuit
+    )!
+
+    expect(nonMatchingCardId).toBeDefined()
+
+    const card = game.cards[nonMatchingCardId]
+    const multBefore = game.gamePlayState.score.mult
+
+    const after = reduceGame(
+      { ...game, gamePlayState: { ...game.gamePlayState, cardsToScore: [card] } },
+      { type: 'CARD_SCORED' }
+    )
+
+    expect(after.gamePlayState.scoringEvents.some(
+      e => 'source' in e && e.source === 'Ancient Joker'
+    )).toBe(false)
+    expect(after.gamePlayState.score.mult).toBe(multBefore)
+  })
+})

--- a/src/app/daily-card-game/domain/joker/jokers.ts
+++ b/src/app/daily-card-game/domain/joker/jokers.ts
@@ -3861,6 +3861,38 @@ export const hitTheRoad: JokerDefinition = {
   rarity: 'rare',
 }
 
+export const ancientJoker: JokerDefinition = {
+  id: 'ancientJoker',
+  name: 'Ancient Joker',
+  description: 'Each played card with target suit gives X1.5 Mult when scored, suit changes each round',
+  price: 8,
+  effects: [
+    {
+      event: { type: 'CARD_SCORED' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        const scoredCard = ctx.scoredCards?.[0]
+        if (!scoredCard) return
+        const cardDef = playingCards[scoredCard.playingCardId]
+        const suits = ['hearts', 'diamonds', 'clubs', 'spades']
+        const seed = buildSeedString([ctx.game.gameSeed, ctx.game.roundIndex.toString(), 'ancientJoker', 'suit'])
+        const roll = getRandomNumbersWithSeed({ seed, min: 0, max: 3, numberOfNumbers: 1 })
+        const targetSuit = suits[roll[0]]
+        if (cardDef.suit !== targetSuit) return
+        ctx.game.gamePlayState.scoringEvents.push({
+          id: uuid(),
+          type: 'mult',
+          operator: 'x',
+          value: 1.5,
+          source: 'Ancient Joker',
+        })
+        ctx.game.gamePlayState.score.mult *= 1.5
+      },
+    },
+  ],
+  rarity: 'rare',
+}
+
 export const jokers: Record<JokerDefinition['id'], JokerDefinition> = {
   swashbucklerJoker,
   walkieTalkieJoker,
@@ -3972,6 +4004,7 @@ export const jokers: Record<JokerDefinition['id'], JokerDefinition> = {
   castle,
   vagabond,
   hitTheRoad,
+  ancientJoker,
 }
 
 /***


### PR DESCRIPTION
## Summary
- Implements the Ancient Joker rare joker: X1.5 Mult per scored card of target suit, suit changes each round
- Target suit derived deterministically from seed (no stored state needed)
- Adds 2 unit tests

Closes #826

## Test plan
- [x] Unit tests pass (`npx vitest run ancient-joker`)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)