### PR TITLE
Implement Driver's License rare joker (#833)

### DIFF
--- a/src/app/daily-card-game/domain/game/__tests__/drivers-license.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/drivers-license.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest'
+import { defaultGameState } from '@/app/daily-card-game/domain/game/default-game-state'
+import { reduceGame } from '@/app/daily-card-game/domain/game/reduce-game'
+import type { GameState } from '@/app/daily-card-game/domain/game/types'
+import { jokers } from '@/app/daily-card-game/domain/joker/jokers'
+import { initializeJoker } from '@/app/daily-card-game/domain/joker/utils'
+
+describe("Driver's License joker", () => {
+  function setupGame(): GameState {
+    const game: GameState = structuredClone(defaultGameState)
+    game.jokers = [initializeJoker(jokers.driversLicense, game)]
+    game.rounds[game.roundIndex].smallBlind.status = 'inProgress'
+    game.gamePhase = 'gameplay'
+    return game
+  }
+
+  it('applies X3 Mult when 16 or more Enhanced cards are in the full deck', () => {
+    const game = setupGame()
+    // Enhance exactly 16 cards
+    const cardIds = game.ownedCardIds.slice(0, 16)
+    for (const id of cardIds) {
+      game.cards[id].flags.enchantment = 'bonus'
+    }
+    const after = reduceGame(game, { type: 'HAND_SCORING_FINALIZE' })
+    expect(
+      after.gamePlayState.scoringEvents.some(
+        e =>
+          'source' in e &&
+          e.source === "Driver's License" &&
+          'operator' in e &&
+          e.operator === 'x' &&
+          e.value === 3,
+      ),
+    ).toBe(true)
+  })
+
+  it('does not apply X3 Mult when fewer than 16 Enhanced cards are in the full deck', () => {
+    const game = setupGame()
+    // Enhance only 15 cards
+    const cardIds = game.ownedCardIds.slice(0, 15)
+    for (const id of cardIds) {
+      game.cards[id].flags.enchantment = 'bonus'
+    }
+    const after = reduceGame(game, { type: 'HAND_SCORING_FINALIZE' })
+    expect(
+      after.gamePlayState.scoringEvents.some(
+        e => 'source' in e && e.source === "Driver's License",
+      ),
+    ).toBe(false)
+  })
+})

--- a/src/app/daily-card-game/domain/joker/jokers.ts
+++ b/src/app/daily-card-game/domain/joker/jokers.ts
@@ -3893,6 +3893,39 @@ export const ancientJoker: JokerDefinition = {
   rarity: 'rare',
 }
 
+export const driversLicense: JokerDefinition = {
+  id: 'driversLicense',
+  name: "Driver's License",
+  description: 'X3 Mult if you have at least 16 Enhanced cards in your full deck',
+  price: 7,
+  effects: [
+    {
+      event: { type: 'HAND_SCORING_FINALIZE' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        let enhancedCount = 0
+        for (const cardId of ctx.game.ownedCardIds) {
+          const cardState = ctx.game.cards[cardId]
+          if (cardState && cardState.flags.enchantment !== 'none') {
+            enhancedCount++
+          }
+        }
+        if (enhancedCount >= 16) {
+          ctx.game.gamePlayState.scoringEvents.push({
+            id: uuid(),
+            type: 'mult',
+            operator: 'x',
+            value: 3,
+            source: "Driver's License",
+          })
+          ctx.game.gamePlayState.score.mult *= 3
+        }
+      },
+    },
+  ],
+  rarity: 'rare',
+}
+
 export const jokers: Record<JokerDefinition['id'], JokerDefinition> = {
   swashbucklerJoker,
   walkieTalkieJoker,
@@ -4005,6 +4038,7 @@ export const jokers: Record<JokerDefinition['id'], JokerDefinition> = {
   vagabond,
   hitTheRoad,
   ancientJoker,
+  driversLicense,
 }
 
 /***


### PR DESCRIPTION
## Summary
- Implements the Driver's License rare joker: X3 Mult if 16+ Enhanced cards in deck
- Adds 2 unit tests covering threshold met and not met

Closes #833

## Test plan
- [x] Unit tests pass (`npx vitest run drivers-license`)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)