### PR TITLE
Implement Campfire rare joker (#835)

### DIFF
--- a/src/app/daily-card-game/domain/game/__tests__/campfire.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/campfire.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest'
+import { defaultGameState } from '@/app/daily-card-game/domain/game/default-game-state'
+import { reduceGame } from '@/app/daily-card-game/domain/game/reduce-game'
+import type { GameState } from '@/app/daily-card-game/domain/game/types'
+import { jokers } from '@/app/daily-card-game/domain/joker/jokers'
+import { initializeJoker } from '@/app/daily-card-game/domain/joker/utils'
+
+describe('Campfire joker', () => {
+  function setupGame(overrides: Partial<GameState> = {}): GameState {
+    const game: GameState = structuredClone(defaultGameState)
+    return { ...game, ...overrides }
+  }
+
+  it('increases counter by 1 when a joker is sold via JOKER_SOLD', () => {
+    const game = setupGame()
+    const campfireInstance = initializeJoker(jokers.campfire, game)
+    const otherJoker = initializeJoker(jokers.jokerJoker, game)
+    game.jokers = [campfireInstance, otherJoker]
+
+    // Select the other joker to sell it
+    const selected: GameState = {
+      ...game,
+      gamePlayState: { ...game.gamePlayState, selectedJokerId: otherJoker.id },
+    }
+
+    const after = reduceGame(selected, { type: 'JOKER_SOLD' })
+
+    const cf = after.jokers.find(j => j.jokerId === 'campfire')
+    expect(cf).toBeTruthy()
+    // counter starts at 0, lazy init sets it to 4, then +1 = 5
+    expect(cf!.counter).toBe(5)
+  })
+
+  it('applies X Mult on HAND_SCORING_FINALIZE when counter > 4', () => {
+    const game = setupGame()
+    const campfireInstance = initializeJoker(jokers.campfire, game)
+    // counter = 8 means X2 Mult (8 / 4 = 2)
+    campfireInstance.counter = 8
+    game.jokers = [campfireInstance]
+    game.rounds[game.roundIndex].smallBlind.status = 'inProgress'
+    game.gamePhase = 'gameplay'
+
+    const withHand: GameState = {
+      ...game,
+      gamePlayState: {
+        ...game.gamePlayState,
+        selectedHand: ['pair', []],
+        score: { chips: 10, mult: 5 },
+      },
+    }
+
+    const after = reduceGame(withHand, { type: 'HAND_SCORING_FINALIZE' })
+
+    expect(after.gamePlayState.scoringEvents.some(
+      e => 'source' in e && e.source === 'Campfire' && 'operator' in e && e.operator === 'x' && 'value' in e && e.value === 2
+    )).toBe(true)
+  })
+
+  it('does not apply Mult on HAND_SCORING_FINALIZE when counter is exactly 4 (X1.0)', () => {
+    const game = setupGame()
+    const campfireInstance = initializeJoker(jokers.campfire, game)
+    campfireInstance.counter = 4
+    game.jokers = [campfireInstance]
+    game.rounds[game.roundIndex].smallBlind.status = 'inProgress'
+    game.gamePhase = 'gameplay'
+
+    const withHand: GameState = {
+      ...game,
+      gamePlayState: {
+        ...game.gamePlayState,
+        selectedHand: ['pair', []],
+        score: { chips: 10, mult: 5 },
+      },
+    }
+
+    const after = reduceGame(withHand, { type: 'HAND_SCORING_FINALIZE' })
+
+    expect(after.gamePlayState.scoringEvents.some(
+      e => 'source' in e && e.source === 'Campfire'
+    )).toBe(false)
+  })
+
+  it('resets counter to 4 on BOSS_BLIND_SELECTED', () => {
+    const game = setupGame()
+    const campfireInstance = initializeJoker(jokers.campfire, game)
+    // Simulate having sold 3 cards: lazy init 4 + 3 = 7
+    campfireInstance.counter = 7
+    game.jokers = [campfireInstance]
+
+    const after = reduceGame(game, { type: 'BOSS_BLIND_SELECTED' })
+
+    const cf = after.jokers.find(j => j.jokerId === 'campfire')
+    expect(cf!.counter).toBe(4)
+  })
+})

--- a/src/app/daily-card-game/domain/joker/jokers.ts
+++ b/src/app/daily-card-game/domain/joker/jokers.ts
@@ -3926,6 +3926,53 @@ export const driversLicense: JokerDefinition = {
   rarity: 'rare',
 }
 
+export const campfire: JokerDefinition = {
+  id: 'campfire',
+  name: 'Campfire',
+  description: 'Gains X0.25 Mult for each card sold, resets when Boss Blind is defeated',
+  price: 9,
+  effects: [
+    {
+      event: { type: 'JOKER_SOLD' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        const cf = ctx.game.jokers.find(j => j.jokerId === 'campfire')
+        if (!cf) return
+        if (cf.counter === 0) cf.counter = 4
+        cf.counter += 1
+      },
+    },
+    {
+      event: { type: 'HAND_SCORING_FINALIZE' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        const cf = ctx.game.jokers.find(j => j.jokerId === 'campfire')
+        if (!cf) return
+        if (cf.counter === 0) cf.counter = 4
+        if (cf.counter <= 4) return
+        const xMult = cf.counter / 4
+        ctx.game.gamePlayState.scoringEvents.push({
+          id: uuid(),
+          type: 'mult',
+          operator: 'x',
+          value: xMult,
+          source: 'Campfire',
+        })
+        ctx.game.gamePlayState.score.mult *= xMult
+      },
+    },
+    {
+      event: { type: 'BOSS_BLIND_SELECTED' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        const cf = ctx.game.jokers.find(j => j.jokerId === 'campfire')
+        if (cf) cf.counter = 4
+      },
+    },
+  ],
+  rarity: 'rare',
+}
+
 export const jokers: Record<JokerDefinition['id'], JokerDefinition> = {
   swashbucklerJoker,
   walkieTalkieJoker,
@@ -4039,6 +4086,7 @@ export const jokers: Record<JokerDefinition['id'], JokerDefinition> = {
   hitTheRoad,
   ancientJoker,
   driversLicense,
+  campfire,
 }
 
 /***


### PR DESCRIPTION
## Summary
- Implements the Campfire rare joker: gains X0.25 Mult per card sold, resets on Boss Blind
- Uses counter stored as quarters (4=X1.0)
- Adds 4 unit tests covering sell increment, X mult, no-op at baseline, and reset

Closes #835

## Test plan
- [x] Unit tests pass (`npx vitest run campfire`)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)