### PR TITLE
Implement Triboulet legendary joker (#838)

### DIFF
--- a/src/app/daily-card-game/domain/game/__tests__/triboulet.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/triboulet.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest'
+import { defaultGameState } from '@/app/daily-card-game/domain/game/default-game-state'
+import { reduceGame } from '@/app/daily-card-game/domain/game/reduce-game'
+import type { GameState } from '@/app/daily-card-game/domain/game/types'
+import { jokers } from '@/app/daily-card-game/domain/joker/jokers'
+import { initializeJoker } from '@/app/daily-card-game/domain/joker/utils'
+import { playingCards } from '@/app/daily-card-game/domain/playing-card/playing-cards'
+
+describe('Triboulet joker', () => {
+  it('gives X2 Mult when a King is scored', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.jokers = [initializeJoker(jokers.triboulet, game)]
+    game.rounds[game.roundIndex].smallBlind.status = 'inProgress'
+    game.gamePhase = 'gameplay'
+    const kingId = Object.keys(game.cards).find(id =>
+      playingCards[game.cards[id].playingCardId]?.value === 'K'
+    )!
+    game.gamePlayState.score = { chips: 10, mult: 10 }
+    const after = reduceGame({
+      ...game,
+      gamePlayState: { ...game.gamePlayState, cardsToScore: [game.cards[kingId]] },
+    }, { type: 'CARD_SCORED' })
+    const tribouletEvents = after.gamePlayState.scoringEvents.filter(
+      e => 'source' in e && e.source === 'Triboulet'
+    )
+    expect(tribouletEvents.length).toBe(1)
+    expect(tribouletEvents[0]).toMatchObject({ operator: 'x', value: 2 })
+    expect(after.gamePlayState.score.mult).toBe(20)
+  })
+
+  it('gives X2 Mult when a Queen is scored', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.jokers = [initializeJoker(jokers.triboulet, game)]
+    game.rounds[game.roundIndex].smallBlind.status = 'inProgress'
+    game.gamePhase = 'gameplay'
+    const queenId = Object.keys(game.cards).find(id =>
+      playingCards[game.cards[id].playingCardId]?.value === 'Q'
+    )!
+    game.gamePlayState.score = { chips: 10, mult: 10 }
+    const after = reduceGame({
+      ...game,
+      gamePlayState: { ...game.gamePlayState, cardsToScore: [game.cards[queenId]] },
+    }, { type: 'CARD_SCORED' })
+    const tribouletEvents = after.gamePlayState.scoringEvents.filter(
+      e => 'source' in e && e.source === 'Triboulet'
+    )
+    expect(tribouletEvents.length).toBe(1)
+    expect(tribouletEvents[0]).toMatchObject({ operator: 'x', value: 2 })
+    expect(after.gamePlayState.score.mult).toBe(20)
+  })
+
+  it('does NOT give X2 Mult when a Jack is scored', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.jokers = [initializeJoker(jokers.triboulet, game)]
+    game.rounds[game.roundIndex].smallBlind.status = 'inProgress'
+    game.gamePhase = 'gameplay'
+    const jackId = Object.keys(game.cards).find(id =>
+      playingCards[game.cards[id].playingCardId]?.value === 'J'
+    )!
+    const after = reduceGame({
+      ...game,
+      gamePlayState: { ...game.gamePlayState, cardsToScore: [game.cards[jackId]] },
+    }, { type: 'CARD_SCORED' })
+    expect(after.gamePlayState.scoringEvents.some(
+      e => 'source' in e && e.source === 'Triboulet'
+    )).toBe(false)
+  })
+})

--- a/src/app/daily-card-game/domain/joker/jokers.ts
+++ b/src/app/daily-card-game/domain/joker/jokers.ts
@@ -4024,6 +4024,34 @@ export const obelisk: JokerDefinition = {
   rarity: 'rare',
 }
 
+export const triboulet: JokerDefinition = {
+  id: 'triboulet',
+  name: 'Triboulet',
+  description: 'Played Kings and Queens each give X2 Mult when scored',
+  price: 20,
+  effects: [
+    {
+      event: { type: 'CARD_SCORED' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        const scoredCard = ctx.scoredCards?.[0]
+        if (!scoredCard) return
+        const cardDef = playingCards[scoredCard.playingCardId]
+        if (cardDef.value !== 'K' && cardDef.value !== 'Q') return
+        ctx.game.gamePlayState.scoringEvents.push({
+          id: uuid(),
+          type: 'mult',
+          operator: 'x',
+          value: 2,
+          source: 'Triboulet',
+        })
+        ctx.game.gamePlayState.score.mult *= 2
+      },
+    },
+  ],
+  rarity: 'legendary',
+}
+
 export const jokers: Record<JokerDefinition['id'], JokerDefinition> = {
   swashbucklerJoker,
   walkieTalkieJoker,
@@ -4139,6 +4167,7 @@ export const jokers: Record<JokerDefinition['id'], JokerDefinition> = {
   driversLicense,
   campfire,
   obelisk,
+  triboulet,
 }
 
 /***


### PR DESCRIPTION
## Summary
- Implements the Triboulet legendary joker: Kings and Queens give X2 Mult when scored
- First legendary joker implementation from epic #705
- Adds 3 unit tests

Closes #838

## Test plan
- [x] Unit tests pass (`npx vitest run triboulet`)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)