### PR TITLE
Implement Chicot legendary joker (#840)

### DIFF
--- a/src/app/daily-card-game/domain/game/__tests__/chicot.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/chicot.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest'
+import { defaultGameState } from '@/app/daily-card-game/domain/game/default-game-state'
+import { reduceGame } from '@/app/daily-card-game/domain/game/reduce-game'
+import type { GameState } from '@/app/daily-card-game/domain/game/types'
+import { jokers } from '@/app/daily-card-game/domain/joker/jokers'
+import { initializeJoker } from '@/app/daily-card-game/domain/joker/utils'
+
+describe('Chicot joker', () => {
+  function setupGame(overrides: Partial<GameState> = {}): GameState {
+    const game: GameState = structuredClone(defaultGameState)
+    // Force the boss blind to The Hook for deterministic testing
+    game.rounds[game.roundIndex].bossBlindName = 'The Hook'
+    game.rounds[game.roundIndex].bossBlind.status = 'inProgress'
+    game.gamePhase = 'gameplay'
+    return { ...game, ...overrides }
+  }
+
+  it('disables boss blind effects when Chicot is present: The Hook does not discard cards', () => {
+    const game = setupGame()
+    game.jokers = [initializeJoker(jokers.chicot, game)]
+
+    // Add card IDs to hand so The Hook would have something to discard
+    const cardIds = ['card1', 'card2', 'card3']
+    game.gamePlayState = {
+      ...game.gamePlayState,
+      handIds: [...cardIds],
+    }
+
+    const after = reduceGame(game, { type: 'HAND_SCORING_DONE_CARD_SCORING' })
+
+    // With Chicot present, The Hook's effect should not fire — hand should be unchanged
+    expect(after.gamePlayState.handIds).toEqual(cardIds)
+  })
+
+  it('boss blind effects fire normally without Chicot: The Hook discards cards', () => {
+    const game = setupGame()
+    game.jokers = []
+
+    // Add card IDs to hand so The Hook can discard them
+    const cardIds = ['card1', 'card2', 'card3']
+    game.gamePlayState = {
+      ...game.gamePlayState,
+      handIds: [...cardIds],
+    }
+
+    const after = reduceGame(game, { type: 'HAND_SCORING_DONE_CARD_SCORING' })
+
+    // Without Chicot, The Hook's effect should fire — up to 2 cards discarded
+    expect(after.gamePlayState.handIds.length).toBeLessThan(cardIds.length)
+  })
+})

--- a/src/app/daily-card-game/domain/game/utils.ts
+++ b/src/app/daily-card-game/domain/game/utils.ts
@@ -48,8 +48,9 @@ export function getBlindDefinition(type: BlindState['type'], round: RoundState):
 export function collectEffects(game: GameState): Effect[] {
   const effects: Effect[] = []
 
+  const hasBossBlindDisabled = game.jokers.some(j => j.jokerId === 'chicot')
   const blind = getInProgressBlind(game)
-  if (blind && blind.type === 'bossBlind') {
+  if (blind && blind.type === 'bossBlind' && !hasBossBlindDisabled) {
     effects.push(...getBlindDefinition(blind.type, game.rounds[game.roundIndex]).effects)
   }
 

--- a/src/app/daily-card-game/domain/joker/jokers.ts
+++ b/src/app/daily-card-game/domain/joker/jokers.ts
@@ -4052,6 +4052,15 @@ export const triboulet: JokerDefinition = {
   rarity: 'legendary',
 }
 
+export const chicot: JokerDefinition = {
+  id: 'chicot',
+  name: 'Chicot',
+  description: 'Disables effect of every Boss Blind',
+  price: 20,
+  effects: [],
+  rarity: 'legendary',
+}
+
 export const jokers: Record<JokerDefinition['id'], JokerDefinition> = {
   swashbucklerJoker,
   walkieTalkieJoker,
@@ -4168,6 +4177,7 @@ export const jokers: Record<JokerDefinition['id'], JokerDefinition> = {
   campfire,
   obelisk,
   triboulet,
+  chicot,
 }
 
 /***


### PR DESCRIPTION
## Summary
- Implements the Chicot legendary joker: disables effect of every Boss Blind
- Modifies `collectEffects` to skip boss blind effects when Chicot is present
- Adds 2 unit tests verifying boss blind suppression with and without Chicot

Closes #840

## Test plan
- [x] Unit tests pass (`npx vitest run chicot`)
- [x] Full test suite passes (1308 tests)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)