### PR TITLE
Implement The Hermit tarot card (#849)

### DIFF
--- a/src/app/daily-card-game/domain/consumable/tarot-cards.ts
+++ b/src/app/daily-card-game/domain/consumable/tarot-cards.ts
@@ -72,6 +72,25 @@ const theMagician: TarotCardDefinition = {
   ],
 }
 
+const theHermit: TarotCardDefinition = {
+  type: 'tarotCard',
+  tarotType: 'theHermit',
+  name: 'The Hermit',
+  price: 2,
+  description: 'Doubles your money (max $20 gain)',
+  isPlayable: () => true,
+  effects: [
+    {
+      event: { type: 'TAROT_CARD_USED' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        const gain = Math.min(Math.max(ctx.game.money, 0), 20)
+        ctx.game.money += gain
+      },
+    },
+  ],
+}
+
 const notImplemented: TarotCardDefinition = {
   price: 2,
   type: 'tarotCard',
@@ -93,7 +112,7 @@ export const tarotCards: Record<TarotCardDefinition['tarotType'], TarotCardDefin
   theLovers: notImplemented,
   theChariot: notImplemented,
   strength: notImplemented,
-  theHermit: notImplemented,
+  theHermit,
   wheelOfFortune: notImplemented,
   justice: notImplemented,
   theHangedMan: notImplemented,

--- a/src/app/daily-card-game/domain/game/__tests__/the-hermit.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/the-hermit.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest'
+
+import { defaultGameState } from '@/app/daily-card-game/domain/game/default-game-state'
+import { reduceGame } from '@/app/daily-card-game/domain/game/reduce-game'
+import type { GameState } from '@/app/daily-card-game/domain/game/types'
+
+function makeGameWithHermit(money: number): GameState {
+  const game: GameState = structuredClone(defaultGameState)
+  game.money = money
+  const hermitCard = {
+    id: 'hermit-1',
+    consumableType: 'tarotCard' as const,
+    name: 'The Hermit',
+    isFaceUp: true,
+    tarotType: 'theHermit' as const,
+  }
+  game.consumables = [hermitCard]
+  game.gamePlayState.selectedConsumable = hermitCard
+  return game
+}
+
+describe('The Hermit tarot card', () => {
+  it('doubles money from $10 to $20', () => {
+    const game = makeGameWithHermit(10)
+    const after = reduceGame(game, { type: 'TAROT_CARD_USED' })
+    expect(after.money).toBe(20)
+  })
+
+  it('caps gain at $20 when money is $30 (result is $50)', () => {
+    const game = makeGameWithHermit(30)
+    const after = reduceGame(game, { type: 'TAROT_CARD_USED' })
+    expect(after.money).toBe(50)
+  })
+
+  it('no gain when money is $0', () => {
+    const game = makeGameWithHermit(0)
+    const after = reduceGame(game, { type: 'TAROT_CARD_USED' })
+    expect(after.money).toBe(0)
+  })
+})


### PR DESCRIPTION
## Summary
- Implements The Hermit tarot card: doubles your money with $20 gain cap
- First tarot card implementation from epic #696
- Adds 3 unit tests covering doubling, cap, and zero money

Closes #849

## Test plan
- [x] Unit tests pass (`npx vitest run the-hermit`)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)