### PR TITLE
Implement Temperance tarot card (#855)

### DIFF
--- a/src/app/daily-card-game/domain/consumable/tarot-cards.ts
+++ b/src/app/daily-card-game/domain/consumable/tarot-cards.ts
@@ -1,5 +1,6 @@
 import { EffectContext } from '@/app/daily-card-game/domain/events/types'
 import type { GameState } from '@/app/daily-card-game/domain/game/types'
+import { jokers } from '@/app/daily-card-game/domain/joker/jokers'
 
 import { TarotCardDefinition } from './types'
 
@@ -91,6 +92,30 @@ const theHermit: TarotCardDefinition = {
   ],
 }
 
+const temperance: TarotCardDefinition = {
+  type: 'tarotCard',
+  tarotType: 'temperance',
+  name: 'Temperance',
+  price: 2,
+  description: 'Gives the total sell value of all current Jokers (max $50)',
+  isPlayable: () => true,
+  effects: [
+    {
+      event: { type: 'TAROT_CARD_USED' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        const totalSellValue = ctx.game.jokers.reduce((sum, jokerState) => {
+          const jokerDef = jokers[jokerState.jokerId]
+          if (!jokerDef) return sum
+          return sum + jokerDef.price + jokerState.bonusSellValue
+        }, 0)
+        const gain = Math.min(totalSellValue, 50)
+        ctx.game.money += gain
+      },
+    },
+  ],
+}
+
 const notImplemented: TarotCardDefinition = {
   price: 2,
   type: 'tarotCard',
@@ -117,7 +142,7 @@ export const tarotCards: Record<TarotCardDefinition['tarotType'], TarotCardDefin
   justice: notImplemented,
   theHangedMan: notImplemented,
   death: notImplemented,
-  temperance: notImplemented,
+  temperance,
   theDevil: notImplemented,
   theTower: notImplemented,
   theStar: notImplemented,

--- a/src/app/daily-card-game/domain/game/__tests__/temperance.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/temperance.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest'
+
+import { defaultGameState } from '@/app/daily-card-game/domain/game/default-game-state'
+import { reduceGame } from '@/app/daily-card-game/domain/game/reduce-game'
+import type { GameState } from '@/app/daily-card-game/domain/game/types'
+import { jokers } from '@/app/daily-card-game/domain/joker/jokers'
+import { initializeJoker } from '@/app/daily-card-game/domain/joker/utils'
+
+function makeGameWithTemperance(jokerIds: string[], bonusSellValues: number[] = []): GameState {
+  const game: GameState = structuredClone(defaultGameState)
+  game.money = 0
+  game.jokers = jokerIds.map((id, i) => {
+    const joker = initializeJoker(jokers[id], game)
+    if (bonusSellValues[i]) {
+      joker.bonusSellValue = bonusSellValues[i]
+    }
+    return joker
+  })
+  const temperanceCard = {
+    id: 'temperance-1',
+    consumableType: 'tarotCard' as const,
+    name: 'Temperance',
+    isFaceUp: true,
+    tarotType: 'temperance' as const,
+  }
+  game.consumables = [temperanceCard]
+  game.gamePlayState.selectedConsumable = temperanceCard
+  return game
+}
+
+describe('Temperance tarot card', () => {
+  it('gains the total sell value of all jokers', () => {
+    // jokerJoker has price 2, greedyJoker has price 5
+    const game = makeGameWithTemperance(['jokerJoker', 'greedyJoker'])
+    const jokerJokerPrice = jokers['jokerJoker'].price
+    const greedyJokerPrice = jokers['greedyJoker'].price
+    const expectedGain = jokerJokerPrice + greedyJokerPrice
+
+    const after = reduceGame(game, { type: 'TAROT_CARD_USED' })
+    expect(after.money).toBe(expectedGain)
+  })
+
+  it('includes bonusSellValue in total', () => {
+    const game = makeGameWithTemperance(['jokerJoker'], [3])
+    const jokerJokerPrice = jokers['jokerJoker'].price
+    const expectedGain = jokerJokerPrice + 3
+
+    const after = reduceGame(game, { type: 'TAROT_CARD_USED' })
+    expect(after.money).toBe(expectedGain)
+  })
+
+  it('caps gain at $50', () => {
+    // Use many jokers to exceed $50
+    const manyJokers = Array(10).fill('jokerJoker')
+    const game = makeGameWithTemperance(manyJokers, Array(10).fill(10))
+    // Each jokerJoker: price=2 + bonusSell=10 = 12, times 10 = 120 → capped at 50
+
+    const after = reduceGame(game, { type: 'TAROT_CARD_USED' })
+    expect(after.money).toBe(50)
+  })
+
+  it('gives $0 when no jokers are active', () => {
+    const game = makeGameWithTemperance([])
+    const after = reduceGame(game, { type: 'TAROT_CARD_USED' })
+    expect(after.money).toBe(0)
+  })
+})


### PR DESCRIPTION
## Summary
- Implements Temperance tarot card: gives total sell value of all Jokers (max $50)
- Adds 4 unit tests covering sell value sum, bonusSellValue inclusion, cap, and no-jokers case

Closes #855

## Test plan
- [x] Unit tests pass (`npx vitest run temperance`)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)