### PR TITLE
Implement The Tower tarot card (#857)

### DIFF
--- a/src/app/daily-card-game/domain/consumable/tarot-cards.ts
+++ b/src/app/daily-card-game/domain/consumable/tarot-cards.ts
@@ -116,6 +116,30 @@ const temperance: TarotCardDefinition = {
   ],
 }
 
+const theTower: TarotCardDefinition = {
+  type: 'tarotCard',
+  tarotType: 'theTower',
+  name: 'The Tower',
+  price: 2,
+  description: 'Enhances 1 selected card to a Stone card',
+  isPlayable: (game: GameState) => {
+    return game.gamePlayState.selectedCardIds.length >= 1
+  },
+  effects: [
+    {
+      event: { type: 'TAROT_CARD_USED' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        const cardId = ctx.game.gamePlayState.selectedCardIds[0]
+        const card = ctx.game.cards[cardId]
+        if (card) {
+          card.flags.enchantment = 'stone'
+        }
+      },
+    },
+  ],
+}
+
 const notImplemented: TarotCardDefinition = {
   price: 2,
   type: 'tarotCard',
@@ -144,7 +168,7 @@ export const tarotCards: Record<TarotCardDefinition['tarotType'], TarotCardDefin
   death: notImplemented,
   temperance,
   theDevil: notImplemented,
-  theTower: notImplemented,
+  theTower,
   theStar: notImplemented,
   theMoon: notImplemented,
   theSun: notImplemented,

--- a/src/app/daily-card-game/domain/game/__tests__/the-tower.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/the-tower.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest'
+
+import { defaultGameState } from '@/app/daily-card-game/domain/game/default-game-state'
+import { reduceGame } from '@/app/daily-card-game/domain/game/reduce-game'
+import type { GameState } from '@/app/daily-card-game/domain/game/types'
+
+function makeGameWithTower(selectedCardId: string): GameState {
+  const game: GameState = structuredClone(defaultGameState)
+  const towerCard = {
+    id: 'tower-1',
+    consumableType: 'tarotCard' as const,
+    name: 'The Tower',
+    isFaceUp: true,
+    tarotType: 'theTower' as const,
+  }
+  game.consumables = [towerCard]
+  game.gamePlayState.selectedConsumable = towerCard
+  game.gamePlayState.selectedCardIds = [selectedCardId]
+  return game
+}
+
+describe('The Tower tarot card', () => {
+  it('sets stone enchantment on the selected card', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    const cardId = game.ownedCardIds[0]
+    const gameWithTower = makeGameWithTower(cardId)
+
+    const after = reduceGame(gameWithTower, { type: 'TAROT_CARD_USED' })
+    expect(after.cards[cardId].flags.enchantment).toBe('stone')
+  })
+
+  it('changes a card with an existing enchantment to stone', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    const cardId = game.ownedCardIds[0]
+    game.cards[cardId].flags.enchantment = 'lucky'
+    const gameWithTower = makeGameWithTower(cardId)
+    // Carry over the pre-set enchantment
+    gameWithTower.cards[cardId].flags.enchantment = 'lucky'
+
+    const after = reduceGame(gameWithTower, { type: 'TAROT_CARD_USED' })
+    expect(after.cards[cardId].flags.enchantment).toBe('stone')
+  })
+})


### PR DESCRIPTION
## Summary
- Implements The Tower tarot card: enhances 1 selected card to Stone
- Adds 2 unit tests covering enchantment set and overwrite

Closes #857

## Test plan
- [x] Unit tests pass (`npx vitest run the-tower`)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)