### PR TITLE
Implement Justice tarot card (#851)

### DIFF
--- a/src/app/daily-card-game/domain/consumable/tarot-cards.ts
+++ b/src/app/daily-card-game/domain/consumable/tarot-cards.ts
@@ -164,6 +164,30 @@ const theDevil: TarotCardDefinition = {
   ],
 }
 
+const justice: TarotCardDefinition = {
+  type: 'tarotCard',
+  tarotType: 'justice',
+  name: 'Justice',
+  price: 2,
+  description: 'Enhances 1 selected card to a Glass card',
+  isPlayable: (game: GameState) => {
+    return game.gamePlayState.selectedCardIds.length >= 1
+  },
+  effects: [
+    {
+      event: { type: 'TAROT_CARD_USED' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        const cardId = ctx.game.gamePlayState.selectedCardIds[0]
+        const card = ctx.game.cards[cardId]
+        if (card) {
+          card.flags.enchantment = 'glass'
+        }
+      },
+    },
+  ],
+}
+
 const notImplemented: TarotCardDefinition = {
   price: 2,
   type: 'tarotCard',
@@ -187,7 +211,7 @@ export const tarotCards: Record<TarotCardDefinition['tarotType'], TarotCardDefin
   strength: notImplemented,
   theHermit,
   wheelOfFortune: notImplemented,
-  justice: notImplemented,
+  justice,
   theHangedMan: notImplemented,
   death: notImplemented,
   temperance,

--- a/src/app/daily-card-game/domain/game/__tests__/justice.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/justice.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest'
+
+import { defaultGameState } from '@/app/daily-card-game/domain/game/default-game-state'
+import { reduceGame } from '@/app/daily-card-game/domain/game/reduce-game'
+import type { GameState } from '@/app/daily-card-game/domain/game/types'
+
+function makeGameWithJustice(selectedCardId: string): GameState {
+  const game: GameState = structuredClone(defaultGameState)
+  const justiceCard = {
+    id: 'justice-1',
+    consumableType: 'tarotCard' as const,
+    name: 'Justice',
+    isFaceUp: true,
+    tarotType: 'justice' as const,
+  }
+  game.consumables = [justiceCard]
+  game.gamePlayState.selectedConsumable = justiceCard
+  game.gamePlayState.selectedCardIds = [selectedCardId]
+  return game
+}
+
+describe('Justice tarot card', () => {
+  it('sets glass enchantment on the selected card', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    const cardId = game.ownedCardIds[0]
+    const gameWithJustice = makeGameWithJustice(cardId)
+
+    const after = reduceGame(gameWithJustice, { type: 'TAROT_CARD_USED' })
+    expect(after.cards[cardId].flags.enchantment).toBe('glass')
+  })
+
+  it('changes a card with an existing enchantment to glass', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    const cardId = game.ownedCardIds[0]
+    const gameWithJustice = makeGameWithJustice(cardId)
+    gameWithJustice.cards[cardId].flags.enchantment = 'lucky'
+
+    const after = reduceGame(gameWithJustice, { type: 'TAROT_CARD_USED' })
+    expect(after.cards[cardId].flags.enchantment).toBe('glass')
+  })
+})


### PR DESCRIPTION
## Summary
- Implements Justice tarot card: enhances 1 selected card to Glass
- Same pattern as Tower/Devil enhancement tarots
- Adds 2 unit tests

Closes #851

## Test plan
- [x] Unit tests pass (`npx vitest run justice`)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)