### PR TITLE
Implement The Chariot tarot card (#847)

### DIFF
--- a/src/app/daily-card-game/domain/consumable/tarot-cards.ts
+++ b/src/app/daily-card-game/domain/consumable/tarot-cards.ts
@@ -188,6 +188,30 @@ const justice: TarotCardDefinition = {
   ],
 }
 
+const theChariot: TarotCardDefinition = {
+  type: 'tarotCard',
+  tarotType: 'theChariot',
+  name: 'The Chariot',
+  price: 2,
+  description: 'Enhances 1 selected card to a Steel card',
+  isPlayable: (game: GameState) => {
+    return game.gamePlayState.selectedCardIds.length >= 1
+  },
+  effects: [
+    {
+      event: { type: 'TAROT_CARD_USED' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        const cardId = ctx.game.gamePlayState.selectedCardIds[0]
+        const card = ctx.game.cards[cardId]
+        if (card) {
+          card.flags.enchantment = 'steel'
+        }
+      },
+    },
+  ],
+}
+
 const notImplemented: TarotCardDefinition = {
   price: 2,
   type: 'tarotCard',
@@ -207,7 +231,7 @@ export const tarotCards: Record<TarotCardDefinition['tarotType'], TarotCardDefin
   theEmperor: notImplemented,
   theHierophant: notImplemented,
   theLovers: notImplemented,
-  theChariot: notImplemented,
+  theChariot,
   strength: notImplemented,
   theHermit,
   wheelOfFortune: notImplemented,

--- a/src/app/daily-card-game/domain/game/__tests__/the-chariot.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/the-chariot.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest'
+
+import { defaultGameState } from '@/app/daily-card-game/domain/game/default-game-state'
+import { reduceGame } from '@/app/daily-card-game/domain/game/reduce-game'
+import type { GameState } from '@/app/daily-card-game/domain/game/types'
+
+function makeGameWithChariot(selectedCardId: string): GameState {
+  const game: GameState = structuredClone(defaultGameState)
+  const chariotCard = {
+    id: 'chariot-1',
+    consumableType: 'tarotCard' as const,
+    name: 'The Chariot',
+    isFaceUp: true,
+    tarotType: 'theChariot' as const,
+  }
+  game.consumables = [chariotCard]
+  game.gamePlayState.selectedConsumable = chariotCard
+  game.gamePlayState.selectedCardIds = [selectedCardId]
+  return game
+}
+
+describe('The Chariot tarot card', () => {
+  it('sets steel enchantment on the selected card', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    const cardId = game.ownedCardIds[0]
+    const gameWithChariot = makeGameWithChariot(cardId)
+
+    const after = reduceGame(gameWithChariot, { type: 'TAROT_CARD_USED' })
+    expect(after.cards[cardId].flags.enchantment).toBe('steel')
+  })
+
+  it('changes a card with an existing enchantment to steel', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    const cardId = game.ownedCardIds[0]
+    const gameWithChariot = makeGameWithChariot(cardId)
+    gameWithChariot.cards[cardId].flags.enchantment = 'lucky'
+
+    const after = reduceGame(gameWithChariot, { type: 'TAROT_CARD_USED' })
+    expect(after.cards[cardId].flags.enchantment).toBe('steel')
+  })
+})


### PR DESCRIPTION
## Summary
- Implements The Chariot tarot card: enhances 1 selected card to Steel
- Same enhancement tarot pattern
- Adds 2 unit tests

Closes #847

## Test plan
- [x] Unit tests pass (`npx vitest run the-chariot`)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)