### PR TITLE
Implement The Lovers tarot card (#846)

### DIFF
--- a/src/app/daily-card-game/domain/consumable/tarot-cards.ts
+++ b/src/app/daily-card-game/domain/consumable/tarot-cards.ts
@@ -212,6 +212,30 @@ const theChariot: TarotCardDefinition = {
   ],
 }
 
+const theLovers: TarotCardDefinition = {
+  type: 'tarotCard',
+  tarotType: 'theLovers',
+  name: 'The Lovers',
+  price: 2,
+  description: 'Enhances 1 selected card to a Wild card',
+  isPlayable: (game: GameState) => {
+    return game.gamePlayState.selectedCardIds.length >= 1
+  },
+  effects: [
+    {
+      event: { type: 'TAROT_CARD_USED' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        const cardId = ctx.game.gamePlayState.selectedCardIds[0]
+        const card = ctx.game.cards[cardId]
+        if (card) {
+          card.flags.enchantment = 'wild'
+        }
+      },
+    },
+  ],
+}
+
 const notImplemented: TarotCardDefinition = {
   price: 2,
   type: 'tarotCard',
@@ -230,7 +254,7 @@ export const tarotCards: Record<TarotCardDefinition['tarotType'], TarotCardDefin
   theEmpress: notImplemented,
   theEmperor: notImplemented,
   theHierophant: notImplemented,
-  theLovers: notImplemented,
+  theLovers,
   theChariot,
   strength: notImplemented,
   theHermit,

--- a/src/app/daily-card-game/domain/game/__tests__/the-lovers.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/the-lovers.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest'
+
+import { defaultGameState } from '@/app/daily-card-game/domain/game/default-game-state'
+import { reduceGame } from '@/app/daily-card-game/domain/game/reduce-game'
+import type { GameState } from '@/app/daily-card-game/domain/game/types'
+
+function makeGameWithLovers(selectedCardId: string): GameState {
+  const game: GameState = structuredClone(defaultGameState)
+  const loversCard = {
+    id: 'lovers-1',
+    consumableType: 'tarotCard' as const,
+    name: 'The Lovers',
+    isFaceUp: true,
+    tarotType: 'theLovers' as const,
+  }
+  game.consumables = [loversCard]
+  game.gamePlayState.selectedConsumable = loversCard
+  game.gamePlayState.selectedCardIds = [selectedCardId]
+  return game
+}
+
+describe('The Lovers tarot card', () => {
+  it('sets wild enchantment on the selected card', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    const cardId = game.ownedCardIds[0]
+    const gameWithLovers = makeGameWithLovers(cardId)
+
+    const after = reduceGame(gameWithLovers, { type: 'TAROT_CARD_USED' })
+    expect(after.cards[cardId].flags.enchantment).toBe('wild')
+  })
+
+  it('changes a card with an existing enchantment to wild', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    const cardId = game.ownedCardIds[0]
+    const gameWithLovers = makeGameWithLovers(cardId)
+    gameWithLovers.cards[cardId].flags.enchantment = 'lucky'
+
+    const after = reduceGame(gameWithLovers, { type: 'TAROT_CARD_USED' })
+    expect(after.cards[cardId].flags.enchantment).toBe('wild')
+  })
+})


### PR DESCRIPTION
## Summary
- Implements The Lovers tarot card: enhances 1 selected card to Wild
- Same enhancement tarot pattern
- Adds 2 unit tests

Closes #846

## Test plan
- [x] Unit tests pass (`npx vitest run the-lovers`)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)