### PR TITLE
Implement The Empress tarot card (#843)

### DIFF
--- a/src/app/daily-card-game/domain/consumable/tarot-cards.ts
+++ b/src/app/daily-card-game/domain/consumable/tarot-cards.ts
@@ -236,6 +236,31 @@ const theLovers: TarotCardDefinition = {
   ],
 }
 
+const theEmpress: TarotCardDefinition = {
+  type: 'tarotCard',
+  tarotType: 'theEmpress',
+  name: 'The Empress',
+  price: 2,
+  description: 'Enhances up to 2 selected cards to Mult cards',
+  isPlayable: (game: GameState) => {
+    return game.gamePlayState.selectedCardIds.length >= 1
+  },
+  effects: [
+    {
+      event: { type: 'TAROT_CARD_USED' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        for (const cardId of ctx.game.gamePlayState.selectedCardIds.slice(0, 2)) {
+          const card = ctx.game.cards[cardId]
+          if (card) {
+            card.flags.enchantment = 'mult'
+          }
+        }
+      },
+    },
+  ],
+}
+
 const notImplemented: TarotCardDefinition = {
   price: 2,
   type: 'tarotCard',
@@ -251,7 +276,7 @@ export const tarotCards: Record<TarotCardDefinition['tarotType'], TarotCardDefin
   theFool,
   theMagician,
   theHighPriestess: notImplemented,
-  theEmpress: notImplemented,
+  theEmpress,
   theEmperor: notImplemented,
   theHierophant: notImplemented,
   theLovers,

--- a/src/app/daily-card-game/domain/game/__tests__/the-empress.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/the-empress.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest'
+
+import { defaultGameState } from '@/app/daily-card-game/domain/game/default-game-state'
+import { reduceGame } from '@/app/daily-card-game/domain/game/reduce-game'
+import type { GameState } from '@/app/daily-card-game/domain/game/types'
+
+function makeGameWithEmpress(selectedCardIds: string[]): GameState {
+  const game: GameState = structuredClone(defaultGameState)
+  const empressCard = {
+    id: 'empress-1',
+    consumableType: 'tarotCard' as const,
+    name: 'The Empress',
+    isFaceUp: true,
+    tarotType: 'theEmpress' as const,
+  }
+  game.consumables = [empressCard]
+  game.gamePlayState.selectedConsumable = empressCard
+  game.gamePlayState.selectedCardIds = selectedCardIds
+  return game
+}
+
+describe('The Empress tarot card', () => {
+  it('sets mult enchantment on 1 selected card', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    const cardId = game.ownedCardIds[0]
+    const gameWithEmpress = makeGameWithEmpress([cardId])
+
+    const after = reduceGame(gameWithEmpress, { type: 'TAROT_CARD_USED' })
+    expect(after.cards[cardId].flags.enchantment).toBe('mult')
+  })
+
+  it('sets mult enchantment on up to 2 selected cards', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    const cardId1 = game.ownedCardIds[0]
+    const cardId2 = game.ownedCardIds[1]
+    const gameWithEmpress = makeGameWithEmpress([cardId1, cardId2])
+
+    const after = reduceGame(gameWithEmpress, { type: 'TAROT_CARD_USED' })
+    expect(after.cards[cardId1].flags.enchantment).toBe('mult')
+    expect(after.cards[cardId2].flags.enchantment).toBe('mult')
+  })
+})


### PR DESCRIPTION
## Summary
- Implements The Empress tarot card: enhances up to 2 selected cards to Mult
- Adds 2 unit tests covering single and double card enhancement

Closes #843

## Test plan
- [x] Unit tests pass (`npx vitest run the-empress`)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)