### PR TITLE
Implement The Hierophant tarot card (#845)

### DIFF
--- a/src/app/daily-card-game/domain/consumable/tarot-cards.ts
+++ b/src/app/daily-card-game/domain/consumable/tarot-cards.ts
@@ -261,6 +261,31 @@ const theEmpress: TarotCardDefinition = {
   ],
 }
 
+const theHierophant: TarotCardDefinition = {
+  type: 'tarotCard',
+  tarotType: 'theHierophant',
+  name: 'The Hierophant',
+  price: 2,
+  description: 'Enhances up to 2 selected cards to Bonus cards',
+  isPlayable: (game: GameState) => {
+    return game.gamePlayState.selectedCardIds.length >= 1
+  },
+  effects: [
+    {
+      event: { type: 'TAROT_CARD_USED' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        for (const cardId of ctx.game.gamePlayState.selectedCardIds.slice(0, 2)) {
+          const card = ctx.game.cards[cardId]
+          if (card) {
+            card.flags.enchantment = 'bonus'
+          }
+        }
+      },
+    },
+  ],
+}
+
 const notImplemented: TarotCardDefinition = {
   price: 2,
   type: 'tarotCard',
@@ -278,7 +303,7 @@ export const tarotCards: Record<TarotCardDefinition['tarotType'], TarotCardDefin
   theHighPriestess: notImplemented,
   theEmpress,
   theEmperor: notImplemented,
-  theHierophant: notImplemented,
+  theHierophant,
   theLovers,
   theChariot,
   strength: notImplemented,

--- a/src/app/daily-card-game/domain/game/__tests__/the-hierophant.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/the-hierophant.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest'
+
+import { defaultGameState } from '@/app/daily-card-game/domain/game/default-game-state'
+import { reduceGame } from '@/app/daily-card-game/domain/game/reduce-game'
+import type { GameState } from '@/app/daily-card-game/domain/game/types'
+
+function makeGameWithHierophant(selectedCardIds: string[]): GameState {
+  const game: GameState = structuredClone(defaultGameState)
+  const hierophantCard = {
+    id: 'hierophant-1',
+    consumableType: 'tarotCard' as const,
+    name: 'The Hierophant',
+    isFaceUp: true,
+    tarotType: 'theHierophant' as const,
+  }
+  game.consumables = [hierophantCard]
+  game.gamePlayState.selectedConsumable = hierophantCard
+  game.gamePlayState.selectedCardIds = selectedCardIds
+  return game
+}
+
+describe('The Hierophant tarot card', () => {
+  it('sets bonus enchantment on 1 selected card', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    const cardId = game.ownedCardIds[0]
+    const gameWithHierophant = makeGameWithHierophant([cardId])
+
+    const after = reduceGame(gameWithHierophant, { type: 'TAROT_CARD_USED' })
+    expect(after.cards[cardId].flags.enchantment).toBe('bonus')
+  })
+
+  it('sets bonus enchantment on up to 2 selected cards', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    const cardId1 = game.ownedCardIds[0]
+    const cardId2 = game.ownedCardIds[1]
+    const gameWithHierophant = makeGameWithHierophant([cardId1, cardId2])
+
+    const after = reduceGame(gameWithHierophant, { type: 'TAROT_CARD_USED' })
+    expect(after.cards[cardId1].flags.enchantment).toBe('bonus')
+    expect(after.cards[cardId2].flags.enchantment).toBe('bonus')
+  })
+})


### PR DESCRIPTION
## Summary
- Implements The Hierophant tarot card: enhances up to 2 selected cards to Bonus
- Same pattern as The Empress
- Adds 2 unit tests

Closes #845

## Test plan
- [x] Unit tests pass (`npx vitest run the-hierophant`)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)