### PR TITLE
Implement The Star tarot card (#858)

### DIFF
--- a/src/app/daily-card-game/domain/consumable/tarot-cards.ts
+++ b/src/app/daily-card-game/domain/consumable/tarot-cards.ts
@@ -1,6 +1,7 @@
 import { EffectContext } from '@/app/daily-card-game/domain/events/types'
 import type { GameState } from '@/app/daily-card-game/domain/game/types'
 import { jokers } from '@/app/daily-card-game/domain/joker/jokers'
+import { playingCards } from '@/app/daily-card-game/domain/playing-card/playing-cards'
 
 import { TarotCardDefinition } from './types'
 
@@ -286,6 +287,34 @@ const theHierophant: TarotCardDefinition = {
   ],
 }
 
+const theStar: TarotCardDefinition = {
+  type: 'tarotCard',
+  tarotType: 'theStar',
+  name: 'The Star',
+  price: 2,
+  description: 'Converts suit of up to 3 selected cards to Diamonds',
+  isPlayable: (game: GameState) => {
+    return game.gamePlayState.selectedCardIds.length >= 1
+  },
+  effects: [
+    {
+      event: { type: 'TAROT_CARD_USED' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        for (const cardId of ctx.game.gamePlayState.selectedCardIds.slice(0, 3)) {
+          const card = ctx.game.cards[cardId]
+          if (card) {
+            const cardDef = playingCards[card.playingCardId]
+            if (cardDef) {
+              card.playingCardId = `${cardDef.value}_diamonds`
+            }
+          }
+        }
+      },
+    },
+  ],
+}
+
 const notImplemented: TarotCardDefinition = {
   price: 2,
   type: 'tarotCard',
@@ -315,7 +344,7 @@ export const tarotCards: Record<TarotCardDefinition['tarotType'], TarotCardDefin
   temperance,
   theDevil,
   theTower,
-  theStar: notImplemented,
+  theStar,
   theMoon: notImplemented,
   theSun: notImplemented,
   judgement: notImplemented,

--- a/src/app/daily-card-game/domain/game/__tests__/the-star.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/the-star.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest'
+
+import { defaultGameState } from '@/app/daily-card-game/domain/game/default-game-state'
+import { reduceGame } from '@/app/daily-card-game/domain/game/reduce-game'
+import type { GameState } from '@/app/daily-card-game/domain/game/types'
+
+function makeGameWithStar(selectedCardIds: string[]): GameState {
+  const game: GameState = structuredClone(defaultGameState)
+  const starCard = {
+    id: 'star-1',
+    consumableType: 'tarotCard' as const,
+    name: 'The Star',
+    isFaceUp: true,
+    tarotType: 'theStar' as const,
+  }
+  game.consumables = [starCard]
+  game.gamePlayState.selectedConsumable = starCard
+  game.gamePlayState.selectedCardIds = selectedCardIds
+  return game
+}
+
+describe('The Star tarot card', () => {
+  it('converts the selected card suit to diamonds', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    const cardId = game.ownedCardIds[0]
+    const originalPlayingCardId = game.cards[cardId].playingCardId
+    const value = originalPlayingCardId.split('_')[0]
+
+    const gameWithStar = makeGameWithStar([cardId])
+    const after = reduceGame(gameWithStar, { type: 'TAROT_CARD_USED' })
+
+    expect(after.cards[cardId].playingCardId).toBe(`${value}_diamonds`)
+  })
+
+  it('converts up to 3 selected cards to diamonds', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    const cardIds = game.ownedCardIds.slice(0, 3)
+
+    const gameWithStar = makeGameWithStar(cardIds)
+    const after = reduceGame(gameWithStar, { type: 'TAROT_CARD_USED' })
+
+    for (const cardId of cardIds) {
+      expect(after.cards[cardId].playingCardId).toMatch(/_diamonds$/)
+    }
+  })
+
+  it('only converts the first 3 cards when more than 3 are selected', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    const cardIds = game.ownedCardIds.slice(0, 4)
+    const fourthCardId = cardIds[3]
+    const originalFourthPlayingCardId = game.cards[fourthCardId].playingCardId
+
+    const gameWithStar = makeGameWithStar(cardIds)
+    const after = reduceGame(gameWithStar, { type: 'TAROT_CARD_USED' })
+
+    // First 3 should be diamonds
+    for (const cardId of cardIds.slice(0, 3)) {
+      expect(after.cards[cardId].playingCardId).toMatch(/_diamonds$/)
+    }
+    // Fourth should be unchanged
+    expect(after.cards[fourthCardId].playingCardId).toBe(originalFourthPlayingCardId)
+  })
+})


### PR DESCRIPTION
## Summary
- Implements The Star tarot card: converts up to 3 selected cards to Diamonds
- Adds 3 unit tests covering single card, 3 cards, and 4th card exclusion

Closes #858

## Test plan
- [x] Unit tests pass (`npx vitest run the-star`)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)