### PR TITLE
Implement The Moon tarot card (#859)

### DIFF
--- a/src/app/daily-card-game/domain/consumable/tarot-cards.ts
+++ b/src/app/daily-card-game/domain/consumable/tarot-cards.ts
@@ -315,6 +315,34 @@ const theStar: TarotCardDefinition = {
   ],
 }
 
+const theMoon: TarotCardDefinition = {
+  type: 'tarotCard',
+  tarotType: 'theMoon',
+  name: 'The Moon',
+  price: 2,
+  description: 'Converts suit of up to 3 selected cards to Clubs',
+  isPlayable: (game: GameState) => {
+    return game.gamePlayState.selectedCardIds.length >= 1
+  },
+  effects: [
+    {
+      event: { type: 'TAROT_CARD_USED' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        for (const cardId of ctx.game.gamePlayState.selectedCardIds.slice(0, 3)) {
+          const card = ctx.game.cards[cardId]
+          if (card) {
+            const cardDef = playingCards[card.playingCardId]
+            if (cardDef) {
+              card.playingCardId = `${cardDef.value}_clubs`
+            }
+          }
+        }
+      },
+    },
+  ],
+}
+
 const notImplemented: TarotCardDefinition = {
   price: 2,
   type: 'tarotCard',
@@ -345,7 +373,7 @@ export const tarotCards: Record<TarotCardDefinition['tarotType'], TarotCardDefin
   theDevil,
   theTower,
   theStar,
-  theMoon: notImplemented,
+  theMoon,
   theSun: notImplemented,
   judgement: notImplemented,
   theWorld: notImplemented,

--- a/src/app/daily-card-game/domain/game/__tests__/the-moon.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/the-moon.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest'
+
+import { defaultGameState } from '@/app/daily-card-game/domain/game/default-game-state'
+import { reduceGame } from '@/app/daily-card-game/domain/game/reduce-game'
+import type { GameState } from '@/app/daily-card-game/domain/game/types'
+
+function makeGameWithMoon(selectedCardIds: string[]): GameState {
+  const game: GameState = structuredClone(defaultGameState)
+  const moonCard = {
+    id: 'moon-1',
+    consumableType: 'tarotCard' as const,
+    name: 'The Moon',
+    isFaceUp: true,
+    tarotType: 'theMoon' as const,
+  }
+  game.consumables = [moonCard]
+  game.gamePlayState.selectedConsumable = moonCard
+  game.gamePlayState.selectedCardIds = selectedCardIds
+  return game
+}
+
+describe('The Moon tarot card', () => {
+  it('converts the selected card suit to clubs', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    const cardId = game.ownedCardIds[0]
+    const originalPlayingCardId = game.cards[cardId].playingCardId
+    const value = originalPlayingCardId.split('_')[0]
+
+    const gameWithMoon = makeGameWithMoon([cardId])
+    const after = reduceGame(gameWithMoon, { type: 'TAROT_CARD_USED' })
+
+    expect(after.cards[cardId].playingCardId).toBe(`${value}_clubs`)
+  })
+
+  it('converts up to 3 selected cards to clubs', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    const cardIds = game.ownedCardIds.slice(0, 3)
+
+    const gameWithMoon = makeGameWithMoon(cardIds)
+    const after = reduceGame(gameWithMoon, { type: 'TAROT_CARD_USED' })
+
+    for (const cardId of cardIds) {
+      expect(after.cards[cardId].playingCardId).toMatch(/_clubs$/)
+    }
+  })
+})


### PR DESCRIPTION
## Summary
- Implements The Moon tarot card: converts up to 3 selected cards to Clubs
- Same suit-conversion pattern as The Star
- Adds 2 unit tests

Closes #859

## Test plan
- [x] Unit tests pass (`npx vitest run the-moon`)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)