### PR TITLE
Implement The Sun tarot card (#860)

### DIFF
--- a/src/app/daily-card-game/domain/consumable/tarot-cards.ts
+++ b/src/app/daily-card-game/domain/consumable/tarot-cards.ts
@@ -343,6 +343,34 @@ const theMoon: TarotCardDefinition = {
   ],
 }
 
+const theSun: TarotCardDefinition = {
+  type: 'tarotCard',
+  tarotType: 'theSun',
+  name: 'The Sun',
+  price: 2,
+  description: 'Converts suit of up to 3 selected cards to Hearts',
+  isPlayable: (game: GameState) => {
+    return game.gamePlayState.selectedCardIds.length >= 1
+  },
+  effects: [
+    {
+      event: { type: 'TAROT_CARD_USED' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        for (const cardId of ctx.game.gamePlayState.selectedCardIds.slice(0, 3)) {
+          const card = ctx.game.cards[cardId]
+          if (card) {
+            const cardDef = playingCards[card.playingCardId]
+            if (cardDef) {
+              card.playingCardId = `${cardDef.value}_hearts`
+            }
+          }
+        }
+      },
+    },
+  ],
+}
+
 const notImplemented: TarotCardDefinition = {
   price: 2,
   type: 'tarotCard',
@@ -374,7 +402,7 @@ export const tarotCards: Record<TarotCardDefinition['tarotType'], TarotCardDefin
   theTower,
   theStar,
   theMoon,
-  theSun: notImplemented,
+  theSun,
   judgement: notImplemented,
   theWorld: notImplemented,
 }

--- a/src/app/daily-card-game/domain/game/__tests__/the-sun.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/the-sun.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest'
+
+import { defaultGameState } from '@/app/daily-card-game/domain/game/default-game-state'
+import { reduceGame } from '@/app/daily-card-game/domain/game/reduce-game'
+import type { GameState } from '@/app/daily-card-game/domain/game/types'
+
+function makeGameWithSun(selectedCardIds: string[]): GameState {
+  const game: GameState = structuredClone(defaultGameState)
+  const sunCard = {
+    id: 'sun-1',
+    consumableType: 'tarotCard' as const,
+    name: 'The Sun',
+    isFaceUp: true,
+    tarotType: 'theSun' as const,
+  }
+  game.consumables = [sunCard]
+  game.gamePlayState.selectedConsumable = sunCard
+  game.gamePlayState.selectedCardIds = selectedCardIds
+  return game
+}
+
+describe('The Sun tarot card', () => {
+  it('converts the selected card suit to hearts', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    const cardId = game.ownedCardIds[0]
+    const originalPlayingCardId = game.cards[cardId].playingCardId
+    const value = originalPlayingCardId.split('_')[0]
+
+    const gameWithSun = makeGameWithSun([cardId])
+    const after = reduceGame(gameWithSun, { type: 'TAROT_CARD_USED' })
+
+    expect(after.cards[cardId].playingCardId).toBe(`${value}_hearts`)
+  })
+
+  it('converts up to 3 selected cards to hearts', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    const cardIds = game.ownedCardIds.slice(0, 3)
+
+    const gameWithSun = makeGameWithSun(cardIds)
+    const after = reduceGame(gameWithSun, { type: 'TAROT_CARD_USED' })
+
+    for (const cardId of cardIds) {
+      expect(after.cards[cardId].playingCardId).toMatch(/_hearts$/)
+    }
+  })
+})


### PR DESCRIPTION
## Summary
- Implements The Sun tarot card: converts up to 3 selected cards to Hearts
- Same suit-conversion pattern as Star/Moon
- Adds 2 unit tests

Closes #860

## Test plan
- [x] Unit tests pass (`npx vitest run the-sun`)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)