### PR TITLE
Implement The World tarot card (#862)

### DIFF
--- a/src/app/daily-card-game/domain/consumable/tarot-cards.ts
+++ b/src/app/daily-card-game/domain/consumable/tarot-cards.ts
@@ -371,6 +371,34 @@ const theSun: TarotCardDefinition = {
   ],
 }
 
+const theWorld: TarotCardDefinition = {
+  type: 'tarotCard',
+  tarotType: 'theWorld',
+  name: 'The World',
+  price: 2,
+  description: 'Converts suit of up to 3 selected cards to Spades',
+  isPlayable: (game: GameState) => {
+    return game.gamePlayState.selectedCardIds.length >= 1
+  },
+  effects: [
+    {
+      event: { type: 'TAROT_CARD_USED' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        for (const cardId of ctx.game.gamePlayState.selectedCardIds.slice(0, 3)) {
+          const card = ctx.game.cards[cardId]
+          if (card) {
+            const cardDef = playingCards[card.playingCardId]
+            if (cardDef) {
+              card.playingCardId = `${cardDef.value}_spades`
+            }
+          }
+        }
+      },
+    },
+  ],
+}
+
 const notImplemented: TarotCardDefinition = {
   price: 2,
   type: 'tarotCard',
@@ -404,7 +432,7 @@ export const tarotCards: Record<TarotCardDefinition['tarotType'], TarotCardDefin
   theMoon,
   theSun,
   judgement: notImplemented,
-  theWorld: notImplemented,
+  theWorld,
 }
 
 export const implementedTarotCards: Record<TarotCardDefinition['tarotType'], TarotCardDefinition> =

--- a/src/app/daily-card-game/domain/game/__tests__/the-world.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/the-world.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest'
+
+import { defaultGameState } from '@/app/daily-card-game/domain/game/default-game-state'
+import { reduceGame } from '@/app/daily-card-game/domain/game/reduce-game'
+import type { GameState } from '@/app/daily-card-game/domain/game/types'
+
+function makeGameWithWorld(selectedCardIds: string[]): GameState {
+  const game: GameState = structuredClone(defaultGameState)
+  const worldCard = {
+    id: 'world-1',
+    consumableType: 'tarotCard' as const,
+    name: 'The World',
+    isFaceUp: true,
+    tarotType: 'theWorld' as const,
+  }
+  game.consumables = [worldCard]
+  game.gamePlayState.selectedConsumable = worldCard
+  game.gamePlayState.selectedCardIds = selectedCardIds
+  return game
+}
+
+describe('The World tarot card', () => {
+  it('converts the selected card suit to spades', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    const cardId = game.ownedCardIds[0]
+    const originalPlayingCardId = game.cards[cardId].playingCardId
+    const value = originalPlayingCardId.split('_')[0]
+
+    const gameWithWorld = makeGameWithWorld([cardId])
+    const after = reduceGame(gameWithWorld, { type: 'TAROT_CARD_USED' })
+
+    expect(after.cards[cardId].playingCardId).toBe(`${value}_spades`)
+  })
+
+  it('converts up to 3 selected cards to spades', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    const cardIds = game.ownedCardIds.slice(0, 3)
+
+    const gameWithWorld = makeGameWithWorld(cardIds)
+    const after = reduceGame(gameWithWorld, { type: 'TAROT_CARD_USED' })
+
+    for (const cardId of cardIds) {
+      expect(after.cards[cardId].playingCardId).toMatch(/_spades$/)
+    }
+  })
+})


### PR DESCRIPTION
## Summary
- Implements The World tarot card: converts up to 3 selected cards to Spades
- Completes all 4 suit-conversion tarots (Star=Diamonds, Moon=Clubs, Sun=Hearts, World=Spades)
- Adds 2 unit tests

Closes #862

## Test plan
- [x] Unit tests pass (`npx vitest run the-world`)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)