### PR TITLE
Implement Strength tarot card (#848)

### DIFF
--- a/src/app/daily-card-game/domain/consumable/tarot-cards.ts
+++ b/src/app/daily-card-game/domain/consumable/tarot-cards.ts
@@ -399,6 +399,40 @@ const theWorld: TarotCardDefinition = {
   ],
 }
 
+const RANK_ORDER = ['2', '3', '4', '5', '6', '7', '8', '9', '10', 'J', 'Q', 'K', 'A'] as const
+
+const strength: TarotCardDefinition = {
+  type: 'tarotCard',
+  tarotType: 'strength',
+  name: 'Strength',
+  price: 2,
+  description: 'Increases rank of up to 2 selected cards by 1',
+  isPlayable: (game: GameState) => {
+    return game.gamePlayState.selectedCardIds.length >= 1
+  },
+  effects: [
+    {
+      event: { type: 'TAROT_CARD_USED' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        for (const cardId of ctx.game.gamePlayState.selectedCardIds.slice(0, 2)) {
+          const card = ctx.game.cards[cardId]
+          if (card) {
+            const cardDef = playingCards[card.playingCardId]
+            if (cardDef) {
+              const currentIndex = RANK_ORDER.indexOf(cardDef.value as (typeof RANK_ORDER)[number])
+              const nextIndex = (currentIndex + 1) % RANK_ORDER.length
+              const newValue = RANK_ORDER[nextIndex]
+              const suit = cardDef.suit
+              card.playingCardId = `${newValue}_${suit}`
+            }
+          }
+        }
+      },
+    },
+  ],
+}
+
 const notImplemented: TarotCardDefinition = {
   price: 2,
   type: 'tarotCard',
@@ -419,7 +453,7 @@ export const tarotCards: Record<TarotCardDefinition['tarotType'], TarotCardDefin
   theHierophant,
   theLovers,
   theChariot,
-  strength: notImplemented,
+  strength,
   theHermit,
   wheelOfFortune: notImplemented,
   justice,

--- a/src/app/daily-card-game/domain/game/__tests__/strength.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/strength.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest'
+
+import { defaultGameState } from '@/app/daily-card-game/domain/game/default-game-state'
+import { reduceGame } from '@/app/daily-card-game/domain/game/reduce-game'
+import type { GameState } from '@/app/daily-card-game/domain/game/types'
+import { playingCards } from '@/app/daily-card-game/domain/playing-card/playing-cards'
+
+function makeGameWithStrength(selectedCardIds: string[]): GameState {
+  const game: GameState = structuredClone(defaultGameState)
+  const strengthCard = {
+    id: 'strength-1',
+    consumableType: 'tarotCard' as const,
+    name: 'Strength',
+    isFaceUp: true,
+    tarotType: 'strength' as const,
+  }
+  game.consumables = [strengthCard]
+  game.gamePlayState.selectedConsumable = strengthCard
+  game.gamePlayState.selectedCardIds = selectedCardIds
+  return game
+}
+
+function findCardByPlayingCardId(game: GameState, playingCardId: string): string | undefined {
+  return game.ownedCardIds.find(id => game.cards[id].playingCardId === playingCardId)
+}
+
+describe('Strength tarot card', () => {
+  it('increases rank of a selected card by 1 (e.g. 5 -> 6)', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    const cardId = findCardByPlayingCardId(game, '5_hearts')
+    expect(cardId).toBeTruthy()
+
+    const gameWithStrength = makeGameWithStrength([cardId!])
+    const after = reduceGame(gameWithStrength, { type: 'TAROT_CARD_USED' })
+
+    const suit = playingCards[game.cards[cardId!].playingCardId].suit
+    expect(after.cards[cardId!].playingCardId).toBe(`6_${suit}`)
+  })
+
+  it('King becomes Ace', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    const cardId = findCardByPlayingCardId(game, 'K_spades')
+    expect(cardId).toBeTruthy()
+
+    const gameWithStrength = makeGameWithStrength([cardId!])
+    const after = reduceGame(gameWithStrength, { type: 'TAROT_CARD_USED' })
+
+    expect(after.cards[cardId!].playingCardId).toBe('A_spades')
+  })
+
+  it('Ace wraps around to 2', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    const cardId = findCardByPlayingCardId(game, 'A_hearts')
+    expect(cardId).toBeTruthy()
+
+    const gameWithStrength = makeGameWithStrength([cardId!])
+    const after = reduceGame(gameWithStrength, { type: 'TAROT_CARD_USED' })
+
+    expect(after.cards[cardId!].playingCardId).toBe('2_hearts')
+  })
+
+  it('applies to up to 2 selected cards', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    const card1Id = findCardByPlayingCardId(game, '5_hearts')
+    const card2Id = findCardByPlayingCardId(game, '7_clubs')
+    expect(card1Id).toBeTruthy()
+    expect(card2Id).toBeTruthy()
+
+    const gameWithStrength = makeGameWithStrength([card1Id!, card2Id!])
+    const after = reduceGame(gameWithStrength, { type: 'TAROT_CARD_USED' })
+
+    expect(after.cards[card1Id!].playingCardId).toBe('6_hearts')
+    expect(after.cards[card2Id!].playingCardId).toBe('8_clubs')
+  })
+
+  it('only applies to first 2 cards when more than 2 are selected', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    const card1Id = findCardByPlayingCardId(game, '5_hearts')
+    const card2Id = findCardByPlayingCardId(game, '7_clubs')
+    const card3Id = findCardByPlayingCardId(game, '9_diamonds')
+    expect(card1Id).toBeTruthy()
+    expect(card2Id).toBeTruthy()
+    expect(card3Id).toBeTruthy()
+
+    const gameWithStrength = makeGameWithStrength([card1Id!, card2Id!, card3Id!])
+    const after = reduceGame(gameWithStrength, { type: 'TAROT_CARD_USED' })
+
+    expect(after.cards[card1Id!].playingCardId).toBe('6_hearts')
+    expect(after.cards[card2Id!].playingCardId).toBe('8_clubs')
+    expect(after.cards[card3Id!].playingCardId).toBe('9_diamonds')
+  })
+})


### PR DESCRIPTION
## Summary
- Implements Strength tarot card: increases rank of up to 2 selected cards by 1 (Ace wraps to 2)
- Adds 5 unit tests covering rank increase, King→Ace, Ace→2 wrap, multi-card, and limit

Closes #848

## Test plan
- [x] Unit tests pass (`npx vitest run strength`)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)