### PR TITLE
Implement Judgement tarot card (#861)

### DIFF
--- a/src/app/daily-card-game/domain/consumable/tarot-cards.ts
+++ b/src/app/daily-card-game/domain/consumable/tarot-cards.ts
@@ -1,7 +1,12 @@
 import { EffectContext } from '@/app/daily-card-game/domain/events/types'
 import type { GameState } from '@/app/daily-card-game/domain/game/types'
 import { jokers } from '@/app/daily-card-game/domain/joker/jokers'
+import { initializeJoker } from '@/app/daily-card-game/domain/joker/utils'
 import { playingCards } from '@/app/daily-card-game/domain/playing-card/playing-cards'
+import {
+  buildSeedString,
+  getRandomNumbersWithSeed,
+} from '@/app/daily-card-game/domain/randomness'
 
 import { TarotCardDefinition } from './types'
 
@@ -433,6 +438,39 @@ const strength: TarotCardDefinition = {
   ],
 }
 
+const judgement: TarotCardDefinition = {
+  type: 'tarotCard',
+  tarotType: 'judgement',
+  name: 'Judgement',
+  price: 2,
+  description: 'Creates a random Joker card (must have room)',
+  isPlayable: (game: GameState) => game.jokers.length < game.maxJokers,
+  effects: [
+    {
+      event: { type: 'TAROT_CARD_USED' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        if (ctx.game.jokers.length >= ctx.game.maxJokers) return
+        const allJokerDefs = Object.values(jokers)
+        const seed = buildSeedString([
+          ctx.game.gameSeed,
+          ctx.game.roundIndex.toString(),
+          'judgement',
+        ])
+        const indices = getRandomNumbersWithSeed({
+          seed,
+          min: 0,
+          max: allJokerDefs.length - 1,
+          numberOfNumbers: 1,
+        })
+        const jokerDef = allJokerDefs[indices[0]]
+        const jokerState = initializeJoker(jokerDef, ctx.game)
+        ctx.game.jokers.push(jokerState)
+      },
+    },
+  ],
+}
+
 const notImplemented: TarotCardDefinition = {
   price: 2,
   type: 'tarotCard',
@@ -465,7 +503,7 @@ export const tarotCards: Record<TarotCardDefinition['tarotType'], TarotCardDefin
   theStar,
   theMoon,
   theSun,
-  judgement: notImplemented,
+  judgement,
   theWorld,
 }
 

--- a/src/app/daily-card-game/domain/game/__tests__/judgement.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/judgement.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest'
+
+import { defaultGameState } from '@/app/daily-card-game/domain/game/default-game-state'
+import { reduceGame } from '@/app/daily-card-game/domain/game/reduce-game'
+import type { GameState } from '@/app/daily-card-game/domain/game/types'
+
+function makeGameWithJudgement(overrides: Partial<GameState> = {}): GameState {
+  const game: GameState = structuredClone(defaultGameState)
+  const judgementCard = {
+    id: 'judgement-1',
+    consumableType: 'tarotCard' as const,
+    name: 'Judgement',
+    isFaceUp: true,
+    tarotType: 'judgement' as const,
+  }
+  game.consumables = [judgementCard]
+  game.gamePlayState.selectedConsumable = judgementCard
+  return { ...game, ...overrides }
+}
+
+describe('Judgement tarot card', () => {
+  it('creates a joker when there is room', () => {
+    const game = makeGameWithJudgement()
+    expect(game.jokers.length).toBe(0)
+    expect(game.maxJokers).toBe(5)
+
+    const after = reduceGame(game, { type: 'TAROT_CARD_USED' })
+    expect(after.jokers.length).toBe(1)
+  })
+
+  it('does not create a joker when jokers are full', () => {
+    const game = makeGameWithJudgement({ maxJokers: 0 })
+    const after = reduceGame(game, { type: 'TAROT_CARD_USED' })
+    expect(after.jokers.length).toBe(0)
+  })
+})


### PR DESCRIPTION
## Summary
- Implements Judgement tarot card: creates a random Joker card (must have room)
- Adds 2 unit tests covering creation and full-slots guard

Closes #861

## Test plan
- [x] Unit tests pass (`npx vitest run judgement`)
- [x] Full test suite passes (1345 tests)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)