### PR TITLE
Implement The Hanged Man tarot card (#852)

### DIFF
--- a/src/app/daily-card-game/domain/consumable/tarot-cards.ts
+++ b/src/app/daily-card-game/domain/consumable/tarot-cards.ts
@@ -1,4 +1,5 @@
 import { EffectContext } from '@/app/daily-card-game/domain/events/types'
+import { removeOwnedCard } from '@/app/daily-card-game/domain/game/card-registry-utils'
 import type { GameState } from '@/app/daily-card-game/domain/game/types'
 import { jokers } from '@/app/daily-card-game/domain/joker/jokers'
 import { initializeJoker } from '@/app/daily-card-game/domain/joker/utils'
@@ -471,6 +472,29 @@ const judgement: TarotCardDefinition = {
   ],
 }
 
+const theHangedMan: TarotCardDefinition = {
+  type: 'tarotCard',
+  tarotType: 'theHangedMan',
+  name: 'The Hanged Man',
+  price: 2,
+  description: 'Destroys up to 2 selected cards',
+  isPlayable: (game: GameState) => {
+    return game.gamePlayState.selectedCardIds.length >= 1
+  },
+  effects: [
+    {
+      event: { type: 'TAROT_CARD_USED' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        for (const cardId of ctx.game.gamePlayState.selectedCardIds.slice(0, 2)) {
+          removeOwnedCard(ctx.game, cardId)
+        }
+        ctx.game.gamePlayState.selectedCardIds = []
+      },
+    },
+  ],
+}
+
 const notImplemented: TarotCardDefinition = {
   price: 2,
   type: 'tarotCard',
@@ -495,7 +519,7 @@ export const tarotCards: Record<TarotCardDefinition['tarotType'], TarotCardDefin
   theHermit,
   wheelOfFortune: notImplemented,
   justice,
-  theHangedMan: notImplemented,
+  theHangedMan,
   death: notImplemented,
   temperance,
   theDevil,

--- a/src/app/daily-card-game/domain/game/__tests__/the-hanged-man.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/the-hanged-man.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest'
+
+import { defaultGameState } from '@/app/daily-card-game/domain/game/default-game-state'
+import { reduceGame } from '@/app/daily-card-game/domain/game/reduce-game'
+import type { GameState } from '@/app/daily-card-game/domain/game/types'
+
+function makeGameWithHangedMan(selectedCardIds: string[]): GameState {
+  const game: GameState = structuredClone(defaultGameState)
+  const hangedManCard = {
+    id: 'hanged-man-1',
+    consumableType: 'tarotCard' as const,
+    name: 'The Hanged Man',
+    isFaceUp: true,
+    tarotType: 'theHangedMan' as const,
+  }
+  game.consumables = [hangedManCard]
+  game.gamePlayState.selectedConsumable = hangedManCard
+  game.gamePlayState.selectedCardIds = selectedCardIds
+  return game
+}
+
+describe('The Hanged Man tarot card', () => {
+  it('removes a selected card from ownedCardIds', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    const cardId = game.ownedCardIds[0]
+    const gameWithHangedMan = makeGameWithHangedMan([cardId])
+
+    const after = reduceGame(gameWithHangedMan, { type: 'TAROT_CARD_USED' })
+    expect(after.ownedCardIds).not.toContain(cardId)
+  })
+
+  it('removes a selected card from the cards registry', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    const cardId = game.ownedCardIds[0]
+    const gameWithHangedMan = makeGameWithHangedMan([cardId])
+
+    const after = reduceGame(gameWithHangedMan, { type: 'TAROT_CARD_USED' })
+    expect(after.cards[cardId]).toBeUndefined()
+  })
+
+  it('removes up to 2 selected cards', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    const cardId1 = game.ownedCardIds[0]
+    const cardId2 = game.ownedCardIds[1]
+    const gameWithHangedMan = makeGameWithHangedMan([cardId1, cardId2])
+
+    const after = reduceGame(gameWithHangedMan, { type: 'TAROT_CARD_USED' })
+    expect(after.ownedCardIds).not.toContain(cardId1)
+    expect(after.ownedCardIds).not.toContain(cardId2)
+    expect(after.cards[cardId1]).toBeUndefined()
+    expect(after.cards[cardId2]).toBeUndefined()
+  })
+
+  it('only removes the first 2 cards when more than 2 are selected', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    const cardId1 = game.ownedCardIds[0]
+    const cardId2 = game.ownedCardIds[1]
+    const cardId3 = game.ownedCardIds[2]
+    const gameWithHangedMan = makeGameWithHangedMan([cardId1, cardId2, cardId3])
+
+    const after = reduceGame(gameWithHangedMan, { type: 'TAROT_CARD_USED' })
+    expect(after.ownedCardIds).not.toContain(cardId1)
+    expect(after.ownedCardIds).not.toContain(cardId2)
+    expect(after.ownedCardIds).toContain(cardId3)
+  })
+})


### PR DESCRIPTION
## Summary
- Implements The Hanged Man tarot card: destroys up to 2 selected cards
- Uses removeOwnedCard for clean card removal
- Adds 4 unit tests covering single/double removal and limit

Closes #852

## Test plan
- [x] Unit tests pass (`npx vitest run the-hanged-man`)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)