### PR TITLE
Implement Death tarot card (#854)

### DIFF
--- a/src/app/daily-card-game/domain/consumable/tarot-cards.ts
+++ b/src/app/daily-card-game/domain/consumable/tarot-cards.ts
@@ -495,6 +495,33 @@ const theHangedMan: TarotCardDefinition = {
   ],
 }
 
+const death: TarotCardDefinition = {
+  type: 'tarotCard',
+  tarotType: 'death',
+  name: 'Death',
+  price: 2,
+  description: 'Converts the left selected card into the right selected card',
+  isPlayable: (game: GameState) => {
+    return game.gamePlayState.selectedCardIds.length >= 2
+  },
+  effects: [
+    {
+      event: { type: 'TAROT_CARD_USED' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        const [leftCardId, rightCardId] = ctx.game.gamePlayState.selectedCardIds
+        const leftCard = ctx.game.cards[leftCardId]
+        const rightCard = ctx.game.cards[rightCardId]
+        if (leftCard && rightCard) {
+          leftCard.playingCardId = rightCard.playingCardId
+          leftCard.flags = { ...rightCard.flags }
+          leftCard.bonusChips = rightCard.bonusChips
+        }
+      },
+    },
+  ],
+}
+
 const notImplemented: TarotCardDefinition = {
   price: 2,
   type: 'tarotCard',
@@ -520,7 +547,7 @@ export const tarotCards: Record<TarotCardDefinition['tarotType'], TarotCardDefin
   wheelOfFortune: notImplemented,
   justice,
   theHangedMan,
-  death: notImplemented,
+  death,
   temperance,
   theDevil,
   theTower,

--- a/src/app/daily-card-game/domain/game/__tests__/death.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/death.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest'
+
+import { tarotCards } from '@/app/daily-card-game/domain/consumable/tarot-cards'
+import { defaultGameState } from '@/app/daily-card-game/domain/game/default-game-state'
+import { reduceGame } from '@/app/daily-card-game/domain/game/reduce-game'
+import type { GameState } from '@/app/daily-card-game/domain/game/types'
+
+const deathCard = {
+  id: 'death-1',
+  consumableType: 'tarotCard' as const,
+  name: 'Death',
+  isFaceUp: true,
+  tarotType: 'death' as const,
+}
+
+function makeGameWithDeath(game: GameState, selectedCardIds: string[]): GameState {
+  game.consumables = [deathCard]
+  game.gamePlayState.selectedConsumable = deathCard
+  game.gamePlayState.selectedCardIds = selectedCardIds
+  return game
+}
+
+describe('Death tarot card', () => {
+  it('converts left card to have the same playingCardId as the right card', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    const leftCardId = game.ownedCardIds[0]
+    const rightCardId = game.ownedCardIds[1]
+
+    const rightPlayingCardId = game.cards[rightCardId].playingCardId
+
+    const gameWithDeath = makeGameWithDeath(game, [leftCardId, rightCardId])
+    const after = reduceGame(gameWithDeath, { type: 'TAROT_CARD_USED' })
+
+    expect(after.cards[leftCardId].playingCardId).toBe(rightPlayingCardId)
+  })
+
+  it('converts left card to have the same enchantment as the right card', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    const leftCardId = game.ownedCardIds[0]
+    const rightCardId = game.ownedCardIds[1]
+
+    game.cards[rightCardId].flags.enchantment = 'lucky'
+
+    const gameWithDeath = makeGameWithDeath(game, [leftCardId, rightCardId])
+    const after = reduceGame(gameWithDeath, { type: 'TAROT_CARD_USED' })
+
+    expect(after.cards[leftCardId].flags.enchantment).toBe('lucky')
+  })
+
+  it('converts left card to have the same bonusChips as the right card', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    const leftCardId = game.ownedCardIds[0]
+    const rightCardId = game.ownedCardIds[1]
+
+    game.cards[rightCardId].bonusChips = 15
+
+    const gameWithDeath = makeGameWithDeath(game, [leftCardId, rightCardId])
+    const after = reduceGame(gameWithDeath, { type: 'TAROT_CARD_USED' })
+
+    expect(after.cards[leftCardId].bonusChips).toBe(15)
+  })
+
+  it('does not modify the right card', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    const leftCardId = game.ownedCardIds[0]
+    const rightCardId = game.ownedCardIds[1]
+
+    const rightPlayingCardId = game.cards[rightCardId].playingCardId
+
+    const gameWithDeath = makeGameWithDeath(game, [leftCardId, rightCardId])
+    const after = reduceGame(gameWithDeath, { type: 'TAROT_CARD_USED' })
+
+    expect(after.cards[rightCardId].playingCardId).toBe(rightPlayingCardId)
+  })
+
+  it('is not playable with fewer than 2 cards selected', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    const cardId = game.ownedCardIds[0]
+    const gameWithDeath = makeGameWithDeath(game, [cardId])
+
+    expect(tarotCards.death.isPlayable(gameWithDeath)).toBe(false)
+  })
+
+  it('is playable with 2 or more cards selected', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    const leftCardId = game.ownedCardIds[0]
+    const rightCardId = game.ownedCardIds[1]
+    const gameWithDeath = makeGameWithDeath(game, [leftCardId, rightCardId])
+
+    expect(tarotCards.death.isPlayable(gameWithDeath)).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary
- Implements Death tarot card: converts left selected card into right selected card
- Copies playingCardId, flags, and bonusChips
- Adds 6 unit tests

Closes #854

## Test plan
- [x] Unit tests pass (`npx vitest run death`)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)