### PR TITLE
Implement Wheel of Fortune tarot card (#850)

### DIFF
--- a/src/app/daily-card-game/domain/consumable/tarot-cards.ts
+++ b/src/app/daily-card-game/domain/consumable/tarot-cards.ts
@@ -522,6 +522,65 @@ const death: TarotCardDefinition = {
   ],
 }
 
+const wheelOfFortune: TarotCardDefinition = {
+  type: 'tarotCard',
+  tarotType: 'wheelOfFortune',
+  name: 'Wheel of Fortune',
+  price: 2,
+  description: '1 in 4 chance to add Foil, Holographic, or Polychrome edition to a random Joker',
+  isPlayable: (game: GameState) => {
+    return game.jokers.some(joker => joker.edition === 'normal')
+  },
+  effects: [
+    {
+      event: { type: 'TAROT_CARD_USED' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        const rollSeed = buildSeedString([
+          ctx.game.gameSeed,
+          ctx.game.roundIndex.toString(),
+          'wheelOfFortune',
+          'roll',
+        ])
+        const [roll] = getRandomNumbersWithSeed({ seed: rollSeed, min: 1, max: 4, numberOfNumbers: 1 })
+        if (roll !== 1) return
+
+        const normalJokers = ctx.game.jokers.filter(joker => joker.edition === 'normal')
+        if (normalJokers.length === 0) return
+
+        const jokerSeed = buildSeedString([
+          ctx.game.gameSeed,
+          ctx.game.roundIndex.toString(),
+          'wheelOfFortune',
+          'joker',
+        ])
+        const [jokerIdx] = getRandomNumbersWithSeed({
+          seed: jokerSeed,
+          min: 0,
+          max: normalJokers.length - 1,
+          numberOfNumbers: 1,
+        })
+        const targetJoker = normalJokers[jokerIdx]
+
+        const editions = ['foil', 'holographic', 'polychrome'] as const
+        const editionSeed = buildSeedString([
+          ctx.game.gameSeed,
+          ctx.game.roundIndex.toString(),
+          'wheelOfFortune',
+          'edition',
+        ])
+        const [editionIdx] = getRandomNumbersWithSeed({
+          seed: editionSeed,
+          min: 0,
+          max: editions.length - 1,
+          numberOfNumbers: 1,
+        })
+        targetJoker.edition = editions[editionIdx]
+      },
+    },
+  ],
+}
+
 const notImplemented: TarotCardDefinition = {
   price: 2,
   type: 'tarotCard',
@@ -544,7 +603,7 @@ export const tarotCards: Record<TarotCardDefinition['tarotType'], TarotCardDefin
   theChariot,
   strength,
   theHermit,
-  wheelOfFortune: notImplemented,
+  wheelOfFortune,
   justice,
   theHangedMan,
   death,

--- a/src/app/daily-card-game/domain/game/__tests__/wheel-of-fortune.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/wheel-of-fortune.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest'
+
+import { tarotCards } from '@/app/daily-card-game/domain/consumable/tarot-cards'
+import { defaultGameState } from '@/app/daily-card-game/domain/game/default-game-state'
+import { reduceGame } from '@/app/daily-card-game/domain/game/reduce-game'
+import type { GameState } from '@/app/daily-card-game/domain/game/types'
+import { jokers } from '@/app/daily-card-game/domain/joker/jokers'
+import { initializeJoker } from '@/app/daily-card-game/domain/joker/utils'
+
+// With gameSeed='success-seed', roundIndex=1:
+//   roll=1 (success), edition='foil'
+// With gameSeed='fail-seed', roundIndex=1:
+//   roll=4 (failure)
+
+function makeGame(overrides: Partial<GameState> = {}): GameState {
+  const game: GameState = structuredClone(defaultGameState)
+  const wheelOfFortuneCard = {
+    id: 'wheel-of-fortune-1',
+    consumableType: 'tarotCard' as const,
+    name: 'Wheel of Fortune',
+    isFaceUp: true,
+    tarotType: 'wheelOfFortune' as const,
+  }
+  game.consumables = [wheelOfFortuneCard]
+  game.gamePlayState.selectedConsumable = wheelOfFortuneCard
+  return { ...game, ...overrides }
+}
+
+describe('Wheel of Fortune tarot card', () => {
+  it('adds an edition to a normal joker when roll succeeds', () => {
+    // gameSeed='success-seed', roundIndex=1 -> roll=1 (success), edition='foil'
+    const game = makeGame({ gameSeed: 'success-seed' })
+    game.jokers = [initializeJoker(jokers.jokerJoker, game)]
+    expect(game.jokers[0].edition).toBe('normal')
+
+    const after = reduceGame(game, { type: 'TAROT_CARD_USED' })
+    expect(after.jokers[0].edition).not.toBe('normal')
+    expect(['foil', 'holographic', 'polychrome']).toContain(after.jokers[0].edition)
+  })
+
+  it('does not change joker edition when roll fails', () => {
+    // gameSeed='fail-seed', roundIndex=1 -> roll=4 (failure)
+    const game = makeGame({ gameSeed: 'fail-seed' })
+    game.jokers = [initializeJoker(jokers.jokerJoker, game)]
+    expect(game.jokers[0].edition).toBe('normal')
+
+    const after = reduceGame(game, { type: 'TAROT_CARD_USED' })
+    expect(after.jokers[0].edition).toBe('normal')
+  })
+
+  it('is not playable when there are no normal-edition jokers', () => {
+    const game = makeGame()
+    game.jokers = [{ ...initializeJoker(jokers.jokerJoker, game), edition: 'foil' }]
+
+    expect(tarotCards.wheelOfFortune.isPlayable(game)).toBe(false)
+  })
+
+  it('is playable when there is at least one normal-edition joker', () => {
+    const game = makeGame()
+    game.jokers = [initializeJoker(jokers.jokerJoker, game)]
+
+    expect(tarotCards.wheelOfFortune.isPlayable(game)).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary
- Implements Wheel of Fortune tarot card: 1 in 4 chance to add Foil/Holographic/Polychrome edition to random Joker
- Adds 4 unit tests covering success, failure, and playability checks

Closes #850

## Test plan
- [x] Unit tests pass (`npx vitest run wheel-of-fortune`)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)