### PR TITLE
Implement The High Priestess tarot card (#842)

### DIFF
--- a/src/app/daily-card-game/domain/consumable/tarot-cards.ts
+++ b/src/app/daily-card-game/domain/consumable/tarot-cards.ts
@@ -9,6 +9,8 @@ import {
   getRandomNumbersWithSeed,
 } from '@/app/daily-card-game/domain/randomness'
 
+import { celestialCards } from './celestial-cards'
+import { initializeCelestialCard } from './utils'
 import { TarotCardDefinition } from './types'
 
 const theFool: TarotCardDefinition = {
@@ -581,6 +583,41 @@ const wheelOfFortune: TarotCardDefinition = {
   ],
 }
 
+const theHighPriestess: TarotCardDefinition = {
+  type: 'tarotCard',
+  tarotType: 'theHighPriestess',
+  name: 'The High Priestess',
+  price: 2,
+  description: 'Creates up to 2 random Planet cards (must have room)',
+  isPlayable: (game: GameState) => game.consumables.length < game.maxConsumables,
+  effects: [
+    {
+      event: { type: 'TAROT_CARD_USED' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        const allCelestialDefs = Object.values(celestialCards)
+        const cardsToCreate = Math.min(2, ctx.game.maxConsumables - ctx.game.consumables.length)
+        const seed = buildSeedString([
+          ctx.game.gameSeed,
+          ctx.game.roundIndex.toString(),
+          'theHighPriestess',
+        ])
+        const indices = getRandomNumbersWithSeed({
+          seed,
+          min: 0,
+          max: allCelestialDefs.length - 1,
+          numberOfNumbers: cardsToCreate,
+        })
+        for (const index of indices) {
+          const celestialDef = allCelestialDefs[index]
+          const celestialState = initializeCelestialCard(celestialDef)
+          ctx.game.consumables.push(celestialState)
+        }
+      },
+    },
+  ],
+}
+
 const notImplemented: TarotCardDefinition = {
   price: 2,
   type: 'tarotCard',
@@ -595,7 +632,7 @@ export const tarotCards: Record<TarotCardDefinition['tarotType'], TarotCardDefin
   notImplemented,
   theFool,
   theMagician,
-  theHighPriestess: notImplemented,
+  theHighPriestess,
   theEmpress,
   theEmperor: notImplemented,
   theHierophant,

--- a/src/app/daily-card-game/domain/game/__tests__/the-high-priestess.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/the-high-priestess.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest'
+
+import { tarotCards } from '@/app/daily-card-game/domain/consumable/tarot-cards'
+import { defaultGameState } from '@/app/daily-card-game/domain/game/default-game-state'
+import { reduceGame } from '@/app/daily-card-game/domain/game/reduce-game'
+import type { GameState } from '@/app/daily-card-game/domain/game/types'
+
+function makeGameWithHighPriestess(overrides: Partial<GameState> = {}): GameState {
+  const game: GameState = structuredClone(defaultGameState)
+  const highPriestessCard = {
+    id: 'high-priestess-1',
+    consumableType: 'tarotCard' as const,
+    tarotType: 'theHighPriestess' as const,
+  }
+  game.consumables = [highPriestessCard]
+  game.gamePlayState.selectedConsumable = highPriestessCard
+  return { ...game, ...overrides }
+}
+
+describe('The High Priestess tarot card', () => {
+  it('creates 2 celestial cards when 2+ slots available after use', () => {
+    // maxConsumables=5, consumables starts with 1 (high priestess)
+    // after use: high priestess removed, 2 celestial cards added => 2 total
+    const game = makeGameWithHighPriestess({ maxConsumables: 5 })
+
+    const after = reduceGame(game, { type: 'TAROT_CARD_USED' })
+
+    expect(after.consumables.length).toBe(2)
+    expect(after.consumables.every(c => c.consumableType === 'celestialCard')).toBe(true)
+  })
+
+  it('creates only 1 celestial card when only 1 slot remains after use', () => {
+    // maxConsumables=1, consumables starts with 1 (high priestess)
+    // after use: high priestess removed (0 left), space for 1, adds 1 celestial card
+    const game = makeGameWithHighPriestess({ maxConsumables: 1 })
+
+    const after = reduceGame(game, { type: 'TAROT_CARD_USED' })
+
+    expect(after.consumables.length).toBe(1)
+    expect(after.consumables[0].consumableType).toBe('celestialCard')
+  })
+
+  it('creates no cards when maxConsumables is 0', () => {
+    // Effect guards with Math.min(2, maxConsumables - consumables.length)
+    // maxConsumables=0 => cardsToCreate=0
+    const game = makeGameWithHighPriestess({ maxConsumables: 0 })
+
+    const after = reduceGame(game, { type: 'TAROT_CARD_USED' })
+
+    expect(after.consumables.filter(c => c.consumableType === 'celestialCard').length).toBe(0)
+  })
+
+  it('is not playable when consumables are at max capacity', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.maxConsumables = 2
+    game.consumables = [
+      { id: 'card-1', consumableType: 'tarotCard', tarotType: 'theFool' },
+      { id: 'card-2', consumableType: 'tarotCard', tarotType: 'theFool' },
+    ]
+
+    expect(tarotCards.theHighPriestess.isPlayable(game)).toBe(false)
+  })
+
+  it('is playable when there is at least one free consumable slot', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.maxConsumables = 2
+    game.consumables = [{ id: 'card-1', consumableType: 'tarotCard', tarotType: 'theFool' }]
+
+    expect(tarotCards.theHighPriestess.isPlayable(game)).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary
- Implements The High Priestess tarot card: creates up to 2 random Planet cards
- Adds 5 unit tests covering creation, slot limits, and playability

Closes #842

## Test plan
- [x] Unit tests pass (`npx vitest run the-high-priestess`)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)