### PR TITLE
Implement The Emperor tarot card (#844)

### DIFF
--- a/src/app/daily-card-game/domain/consumable/tarot-cards.ts
+++ b/src/app/daily-card-game/domain/consumable/tarot-cards.ts
@@ -10,7 +10,7 @@ import {
 } from '@/app/daily-card-game/domain/randomness'
 
 import { celestialCards } from './celestial-cards'
-import { initializeCelestialCard } from './utils'
+import { initializeCelestialCard, initializeTarotCard } from './utils'
 import { TarotCardDefinition } from './types'
 
 const theFool: TarotCardDefinition = {
@@ -618,6 +618,43 @@ const theHighPriestess: TarotCardDefinition = {
   ],
 }
 
+const theEmperor: TarotCardDefinition = {
+  type: 'tarotCard',
+  tarotType: 'theEmperor',
+  name: 'The Emperor',
+  price: 2,
+  description: 'Creates up to 2 random Tarot cards (must have room)',
+  isPlayable: (game: GameState) => game.consumables.length < game.maxConsumables,
+  effects: [
+    {
+      event: { type: 'TAROT_CARD_USED' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        const cardsToCreate = Math.min(2, ctx.game.maxConsumables - ctx.game.consumables.length)
+        const allTarotDefs = Object.values(implementedTarotCards).filter(
+          def => def.tarotType !== 'theEmperor'
+        )
+        const seed = buildSeedString([
+          ctx.game.gameSeed,
+          ctx.game.roundIndex.toString(),
+          'theEmperor',
+        ])
+        const indices = getRandomNumbersWithSeed({
+          seed,
+          min: 0,
+          max: allTarotDefs.length - 1,
+          numberOfNumbers: cardsToCreate,
+        })
+        for (const index of indices) {
+          const tarotDef = allTarotDefs[index]
+          const tarotState = initializeTarotCard(tarotDef)
+          ctx.game.consumables.push(tarotState)
+        }
+      },
+    },
+  ],
+}
+
 const notImplemented: TarotCardDefinition = {
   price: 2,
   type: 'tarotCard',
@@ -634,7 +671,7 @@ export const tarotCards: Record<TarotCardDefinition['tarotType'], TarotCardDefin
   theMagician,
   theHighPriestess,
   theEmpress,
-  theEmperor: notImplemented,
+  theEmperor,
   theHierophant,
   theLovers,
   theChariot,

--- a/src/app/daily-card-game/domain/game/__tests__/the-emperor.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/the-emperor.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest'
+
+import { tarotCards } from '@/app/daily-card-game/domain/consumable/tarot-cards'
+import { defaultGameState } from '@/app/daily-card-game/domain/game/default-game-state'
+import { reduceGame } from '@/app/daily-card-game/domain/game/reduce-game'
+import type { GameState } from '@/app/daily-card-game/domain/game/types'
+
+function makeGameWithEmperor(overrides: Partial<GameState> = {}): GameState {
+  const game: GameState = structuredClone(defaultGameState)
+  const emperorCard = {
+    id: 'emperor-1',
+    consumableType: 'tarotCard' as const,
+    tarotType: 'theEmperor' as const,
+  }
+  game.consumables = [emperorCard]
+  game.gamePlayState.selectedConsumable = emperorCard
+  return { ...game, ...overrides }
+}
+
+describe('The Emperor tarot card', () => {
+  it('creates 2 tarot cards when 2+ slots available after use', () => {
+    // maxConsumables=5, consumables starts with 1 (the emperor)
+    // after use: emperor removed, 2 tarot cards added => 2 total
+    const game = makeGameWithEmperor({ maxConsumables: 5 })
+
+    const after = reduceGame(game, { type: 'TAROT_CARD_USED' })
+
+    expect(after.consumables.length).toBe(2)
+    expect(after.consumables.every(c => c.consumableType === 'tarotCard')).toBe(true)
+  })
+
+  it('creates only 1 tarot card when only 1 slot remains after use', () => {
+    // maxConsumables=1, consumables starts with 1 (the emperor)
+    // after use: emperor removed (0 left), space for 1, adds 1 tarot card
+    const game = makeGameWithEmperor({ maxConsumables: 1 })
+
+    const after = reduceGame(game, { type: 'TAROT_CARD_USED' })
+
+    expect(after.consumables.length).toBe(1)
+    expect(after.consumables[0].consumableType).toBe('tarotCard')
+  })
+
+  it('creates no cards when maxConsumables is 0', () => {
+    // Effect guards with Math.min(2, maxConsumables - consumables.length)
+    // maxConsumables=0 => cardsToCreate=0
+    const game = makeGameWithEmperor({ maxConsumables: 0 })
+
+    const after = reduceGame(game, { type: 'TAROT_CARD_USED' })
+
+    expect(after.consumables.filter(c => c.consumableType === 'tarotCard').length).toBe(0)
+  })
+
+  it('does not create The Emperor itself', () => {
+    const game = makeGameWithEmperor({ maxConsumables: 5 })
+
+    const after = reduceGame(game, { type: 'TAROT_CARD_USED' })
+
+    const createdCards = after.consumables.filter(c => c.consumableType === 'tarotCard')
+    expect(
+      createdCards.every(c => c.consumableType === 'tarotCard' && c.tarotType !== 'theEmperor')
+    ).toBe(true)
+  })
+
+  it('is not playable when consumables are at max capacity', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.maxConsumables = 2
+    game.consumables = [
+      { id: 'card-1', consumableType: 'tarotCard', tarotType: 'theFool' },
+      { id: 'card-2', consumableType: 'tarotCard', tarotType: 'theFool' },
+    ]
+
+    expect(tarotCards.theEmperor.isPlayable(game)).toBe(false)
+  })
+
+  it('is playable when there is at least one free consumable slot', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.maxConsumables = 2
+    game.consumables = [{ id: 'card-1', consumableType: 'tarotCard', tarotType: 'theFool' }]
+
+    expect(tarotCards.theEmperor.isPlayable(game)).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary
- Implements The Emperor tarot card: creates up to 2 random Tarot cards
- Completes the Tarot Cards epic (#696) - all 20 tarot cards now implemented!
- Adds 6 unit tests

Closes #844

## Test plan
- [x] Unit tests pass (`npx vitest run the-emperor`)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)