### PR TITLE
Implement Burglar uncommon joker (#762)

### DIFF
--- a/src/app/daily-card-game/domain/game/__tests__/burglar.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/burglar.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest'
+import { defaultGameState } from '@/app/daily-card-game/domain/game/default-game-state'
+import { reduceGame } from '@/app/daily-card-game/domain/game/reduce-game'
+import type { GameState } from '@/app/daily-card-game/domain/game/types'
+import { jokers } from '@/app/daily-card-game/domain/joker/jokers'
+import { initializeJoker } from '@/app/daily-card-game/domain/joker/utils'
+
+describe('Burglar joker', () => {
+  it('gains +3 maxHands when blind is selected', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.jokers = [initializeJoker(jokers.burglar, game)]
+    const after = reduceGame(game, { type: 'SMALL_BLIND_SELECTED' })
+    expect(after.maxHands).toBe(defaultGameState.maxHands + 3)
+    expect(after.gamePlayState.remainingHands).toBe(defaultGameState.gamePlayState.remainingHands + 3)
+  })
+
+  it('sets maxDiscards to 0 when blind is selected', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.jokers = [initializeJoker(jokers.burglar, game)]
+    const after = reduceGame(game, { type: 'SMALL_BLIND_SELECTED' })
+    expect(after.maxDiscards).toBe(0)
+    expect(after.gamePlayState.remainingDiscards).toBe(0)
+  })
+})

--- a/src/app/daily-card-game/domain/joker/jokers.ts
+++ b/src/app/daily-card-game/domain/joker/jokers.ts
@@ -4061,6 +4061,26 @@ export const chicot: JokerDefinition = {
   rarity: 'legendary',
 }
 
+function applyBurglar(ctx: EffectContext) {
+  ctx.game.maxHands += 3
+  ctx.game.gamePlayState.remainingHands += 3
+  ctx.game.maxDiscards = 0
+  ctx.game.gamePlayState.remainingDiscards = 0
+}
+
+export const burglar: JokerDefinition = {
+  id: 'burglar',
+  name: 'Burglar',
+  description: 'When Blind is selected, gain +3 Hands and lose all discards',
+  price: 6,
+  effects: [
+    { event: { type: 'SMALL_BLIND_SELECTED' }, priority: 1, apply: applyBurglar },
+    { event: { type: 'BIG_BLIND_SELECTED' }, priority: 1, apply: applyBurglar },
+    { event: { type: 'BOSS_BLIND_SELECTED' }, priority: 1, apply: applyBurglar },
+  ],
+  rarity: 'uncommon',
+}
+
 export const jokers: Record<JokerDefinition['id'], JokerDefinition> = {
   swashbucklerJoker,
   walkieTalkieJoker,
@@ -4178,6 +4198,7 @@ export const jokers: Record<JokerDefinition['id'], JokerDefinition> = {
   obelisk,
   triboulet,
   chicot,
+  burglar,
 }
 
 /***


### PR DESCRIPTION
## Summary
- Implements Burglar uncommon joker: gain +3 Hands and lose all discards on blind selection
- Adds 2 unit tests

Closes #762

## Test plan
- [x] Unit tests pass (`npx vitest run burglar`)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)