### PR TITLE
Implement Troubadour uncommon joker (#793)

### DIFF
--- a/src/app/daily-card-game/domain/game/__tests__/troubadour.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/troubadour.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest'
+
+import { defaultGameState } from '@/app/daily-card-game/domain/game/default-game-state'
+import { reduceGame } from '@/app/daily-card-game/domain/game/reduce-game'
+import type { GameState } from '@/app/daily-card-game/domain/game/types'
+import { jokers } from '@/app/daily-card-game/domain/joker/jokers'
+import { initializeJoker } from '@/app/daily-card-game/domain/joker/utils'
+import type { BuyableCard } from '@/app/daily-card-game/domain/shop/types'
+
+describe('Troubadour joker', () => {
+  it('increases handSizeModifier by 2 and decreases maxHands by 1 on JOKER_ADDED (purchase)', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.jokers = []
+
+    const troubadourState = initializeJoker(jokers.troubadour, game)
+    const buyable: BuyableCard = {
+      type: 'jokerCard',
+      card: troubadourState,
+      price: jokers.troubadour.price,
+    }
+
+    game.money = 999
+    game.shopState.cardsForSale = [buyable]
+    game.shopState.selectedCardId = troubadourState.id
+
+    const afterPurchase = reduceGame(game, { type: 'SHOP_BUY_CARD' })
+
+    expect(afterPurchase.jokers.some(j => j.jokerId === 'troubadour')).toBe(true)
+    expect(afterPurchase.handSizeModifier).toBe(defaultGameState.handSizeModifier + 2)
+    expect(afterPurchase.maxHands).toBe(defaultGameState.maxHands - 1)
+  })
+
+  it('reverts handSizeModifier and maxHands on JOKER_REMOVED', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    const troubadourInstance = initializeJoker(jokers.troubadour, game)
+    game.jokers = [troubadourInstance]
+    game.handSizeModifier = defaultGameState.handSizeModifier + 2
+    game.maxHands = defaultGameState.maxHands - 1
+
+    const selected: GameState = {
+      ...game,
+      gamePlayState: { ...game.gamePlayState, selectedJokerId: troubadourInstance.id },
+    }
+
+    const afterRemoval = reduceGame(selected, { type: 'JOKER_REMOVED' })
+
+    expect(afterRemoval.jokers.some(j => j.jokerId === 'troubadour')).toBe(false)
+    expect(afterRemoval.handSizeModifier).toBe(defaultGameState.handSizeModifier)
+    expect(afterRemoval.maxHands).toBe(defaultGameState.maxHands)
+  })
+
+  it('does not revert when another Troubadour remains after removal', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    const troubadour1 = initializeJoker(jokers.troubadour, game)
+    const troubadour2 = initializeJoker(jokers.troubadour, game)
+    game.jokers = [troubadour1, troubadour2]
+    game.handSizeModifier = defaultGameState.handSizeModifier + 4
+    game.maxHands = defaultGameState.maxHands - 2
+
+    const selected: GameState = {
+      ...game,
+      gamePlayState: { ...game.gamePlayState, selectedJokerId: troubadour1.id },
+    }
+
+    const afterRemoval = reduceGame(selected, { type: 'JOKER_REMOVED' })
+
+    expect(afterRemoval.jokers.filter(j => j.jokerId === 'troubadour')).toHaveLength(1)
+    expect(afterRemoval.handSizeModifier).toBe(defaultGameState.handSizeModifier + 4)
+    expect(afterRemoval.maxHands).toBe(defaultGameState.maxHands - 2)
+  })
+})

--- a/src/app/daily-card-game/domain/joker/jokers.ts
+++ b/src/app/daily-card-game/domain/joker/jokers.ts
@@ -4108,6 +4108,47 @@ export const burglar: JokerDefinition = {
   rarity: 'uncommon',
 }
 
+export const troubadour: JokerDefinition = {
+  id: 'troubadour',
+  name: 'Troubadour',
+  description: '+2 hand size, -1 hand per round',
+  price: 6,
+  effects: [
+    {
+      event: { type: 'JOKER_ADDED' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        ctx.game.handSizeModifier += 2
+        ctx.game.maxHands -= 1
+        ctx.game.gamePlayState.remainingHands = Math.max(0, ctx.game.gamePlayState.remainingHands - 1)
+      },
+    },
+    {
+      event: { type: 'JOKER_REMOVED' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        if (!ctx.game.jokers.some(j => j.jokerId === 'troubadour')) {
+          ctx.game.handSizeModifier -= 2
+          ctx.game.maxHands += 1
+          ctx.game.gamePlayState.remainingHands += 1
+        }
+      },
+    },
+    {
+      event: { type: 'JOKER_SOLD' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        if (!ctx.game.jokers.some(j => j.jokerId === 'troubadour')) {
+          ctx.game.handSizeModifier -= 2
+          ctx.game.maxHands += 1
+          ctx.game.gamePlayState.remainingHands += 1
+        }
+      },
+    },
+  ],
+  rarity: 'uncommon',
+}
+
 export const jokers: Record<JokerDefinition['id'], JokerDefinition> = {
   swashbucklerJoker,
   walkieTalkieJoker,
@@ -4227,6 +4268,7 @@ export const jokers: Record<JokerDefinition['id'], JokerDefinition> = {
   triboulet,
   chicot,
   burglar,
+  troubadour,
 }
 
 /***


### PR DESCRIPTION
## Summary
- Implements Troubadour uncommon joker: +2 hand size, -1 hand per round
- Uses JOKER_ADDED/REMOVED/SOLD for passive modifier management
- Adds 3 unit tests covering purchase, removal reversal, and multi-copy guard

Closes #793

## Test plan
- [x] Unit tests pass (`npx vitest run troubadour`)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)