### PR TITLE
Implement Showman uncommon joker (#803)

### DIFF
--- a/src/app/daily-card-game/domain/game/__tests__/showman.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/showman.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest'
+
+import { defaultGameState } from '@/app/daily-card-game/domain/game/default-game-state'
+import { reduceGame } from '@/app/daily-card-game/domain/game/reduce-game'
+import type { GameState } from '@/app/daily-card-game/domain/game/types'
+import { jokers } from '@/app/daily-card-game/domain/joker/jokers'
+import { initializeJoker } from '@/app/daily-card-game/domain/joker/utils'
+import type { BuyableCard } from '@/app/daily-card-game/domain/shop/types'
+
+describe('Showman joker', () => {
+  it('sets allowDuplicateJokersInShop to true when Showman is purchased (JOKER_ADDED)', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.jokers = []
+    game.staticRules.allowDuplicateJokersInShop = false
+
+    const showmanState = initializeJoker(jokers.showman, game)
+    const buyable: BuyableCard = {
+      type: 'jokerCard',
+      card: showmanState,
+      price: jokers.showman.price,
+    }
+
+    game.money = 999
+    game.shopState.cardsForSale = [buyable]
+    game.shopState.selectedCardId = showmanState.id
+
+    const afterPurchase = reduceGame(game, { type: 'SHOP_BUY_CARD' })
+
+    expect(afterPurchase.jokers.some(j => j.jokerId === 'showman')).toBe(true)
+    expect(afterPurchase.staticRules.allowDuplicateJokersInShop).toBe(true)
+  })
+
+  it('resets allowDuplicateJokersInShop to false when Showman is removed (JOKER_REMOVED)', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    const showmanInstance = initializeJoker(jokers.showman, game)
+    game.jokers = [showmanInstance]
+    game.staticRules.allowDuplicateJokersInShop = true
+
+    const selected: GameState = {
+      ...game,
+      gamePlayState: { ...game.gamePlayState, selectedJokerId: showmanInstance.id },
+    }
+
+    const afterRemoval = reduceGame(selected, { type: 'JOKER_REMOVED' })
+
+    expect(afterRemoval.jokers.some(j => j.jokerId === 'showman')).toBe(false)
+    expect(afterRemoval.staticRules.allowDuplicateJokersInShop).toBe(false)
+  })
+
+  it('does not reset allowDuplicateJokersInShop when another Showman remains after removal', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    const showman1 = initializeJoker(jokers.showman, game)
+    const showman2 = initializeJoker(jokers.showman, game)
+    game.jokers = [showman1, showman2]
+    game.staticRules.allowDuplicateJokersInShop = true
+
+    const selected: GameState = {
+      ...game,
+      gamePlayState: { ...game.gamePlayState, selectedJokerId: showman1.id },
+    }
+
+    const afterRemoval = reduceGame(selected, { type: 'JOKER_REMOVED' })
+
+    expect(afterRemoval.jokers.filter(j => j.jokerId === 'showman')).toHaveLength(1)
+    expect(afterRemoval.staticRules.allowDuplicateJokersInShop).toBe(true)
+  })
+})

--- a/src/app/daily-card-game/domain/joker/jokers.ts
+++ b/src/app/daily-card-game/domain/joker/jokers.ts
@@ -4149,6 +4149,34 @@ export const troubadour: JokerDefinition = {
   rarity: 'uncommon',
 }
 
+export const showman: JokerDefinition = {
+  id: 'showman',
+  name: 'Showman',
+  description: 'Joker, Tarot, Planet, and Spectral cards may appear multiple times',
+  price: 5,
+  effects: [
+    {
+      event: { type: 'JOKER_ADDED' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        ctx.game.staticRules.allowDuplicateJokersInShop = true
+      },
+    },
+    {
+      event: { type: 'JOKER_REMOVED' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        // Only reset if no other Showman joker exists
+        const hasShowman = ctx.game.jokers.some(j => j.jokerId === 'showman')
+        if (!hasShowman) {
+          ctx.game.staticRules.allowDuplicateJokersInShop = false
+        }
+      },
+    },
+  ],
+  rarity: 'uncommon',
+}
+
 export const jokers: Record<JokerDefinition['id'], JokerDefinition> = {
   swashbucklerJoker,
   walkieTalkieJoker,
@@ -4269,6 +4297,7 @@ export const jokers: Record<JokerDefinition['id'], JokerDefinition> = {
   chicot,
   burglar,
   troubadour,
+  showman,
 }
 
 /***


### PR DESCRIPTION
## Summary
- Implements Showman uncommon joker: allows duplicate Jokers in shop
- Uses existing `allowDuplicateJokersInShop` flag in staticRules
- Adds 3 unit tests

Closes #803

## Test plan
- [x] Unit tests pass (`npx vitest run showman`)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)