### PR TITLE
Implement Burnt Joker rare joker (#834)

### DIFF
--- a/src/app/daily-card-game/domain/game/__tests__/burnt-joker.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/burnt-joker.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'vitest'
+import { defaultGameState } from '@/app/daily-card-game/domain/game/default-game-state'
+import { reduceGame } from '@/app/daily-card-game/domain/game/reduce-game'
+import type { GameState } from '@/app/daily-card-game/domain/game/types'
+import { jokers } from '@/app/daily-card-game/domain/joker/jokers'
+import { initializeJoker } from '@/app/daily-card-game/domain/joker/utils'
+
+describe('Burnt Joker', () => {
+  function setupGame(): GameState {
+    const game: GameState = structuredClone(defaultGameState)
+    game.jokers = [initializeJoker(jokers.burntJoker, game)]
+    game.rounds[game.roundIndex].smallBlind.status = 'inProgress'
+    game.gamePhase = 'gameplay'
+    return game
+  }
+
+  it('upgrades hand level on first discard of the round', () => {
+    const game = setupGame()
+    const cardIds = Object.keys(game.cards).slice(0, 2)
+    game.gamePlayState.selectedCardIds = cardIds
+
+    const pairLevelBefore = game.pokerHands.pair.level
+    const highCardLevelBefore = game.pokerHands.highCard.level
+
+    const after = reduceGame(game, { type: 'DISCARD_SELECTED_CARDS' })
+
+    // One poker hand level must have increased by 1
+    const pairLevelAfter = after.pokerHands.pair.level
+    const highCardLevelAfter = after.pokerHands.highCard.level
+    const anyHandUpgraded =
+      pairLevelAfter > pairLevelBefore || highCardLevelAfter > highCardLevelBefore
+
+    expect(anyHandUpgraded).toBe(true)
+  })
+
+  it('sets counter to 1 after first discard', () => {
+    const game = setupGame()
+    const bj = game.jokers.find(j => j.jokerId === 'burntJoker')!
+    expect(bj.counter).toBe(0)
+
+    const cardIds = Object.keys(game.cards).slice(0, 1)
+    game.gamePlayState.selectedCardIds = cardIds
+
+    const after = reduceGame(game, { type: 'DISCARD_SELECTED_CARDS' })
+    const bjAfter = after.jokers.find(j => j.jokerId === 'burntJoker')
+    expect(bjAfter?.counter).toBe(1)
+  })
+
+  it('does not upgrade hand level on second discard of the round', () => {
+    const game = setupGame()
+    const bj = game.jokers.find(j => j.jokerId === 'burntJoker')!
+    bj.counter = 1
+
+    const cardIds = Object.keys(game.cards).slice(0, 2)
+    game.gamePlayState.selectedCardIds = cardIds
+
+    const levelsBefore = Object.fromEntries(
+      Object.entries(game.pokerHands).map(([hand, state]) => [hand, state.level])
+    )
+
+    const after = reduceGame(game, { type: 'DISCARD_SELECTED_CARDS' })
+
+    const anyHandUpgraded = Object.entries(after.pokerHands).some(
+      ([hand, state]) => state.level > levelsBefore[hand]
+    )
+    expect(anyHandUpgraded).toBe(false)
+  })
+
+  it('resets counter to 0 on SMALL_BLIND_SELECTED', () => {
+    const game = setupGame()
+    const bj = game.jokers.find(j => j.jokerId === 'burntJoker')!
+    bj.counter = 1
+
+    const after = reduceGame(game, { type: 'SMALL_BLIND_SELECTED' })
+    const bjAfter = after.jokers.find(j => j.jokerId === 'burntJoker')
+    expect(bjAfter?.counter).toBe(0)
+  })
+
+  it('resets counter to 0 on BIG_BLIND_SELECTED', () => {
+    const game = setupGame()
+    const bj = game.jokers.find(j => j.jokerId === 'burntJoker')!
+    bj.counter = 1
+
+    const after = reduceGame(game, { type: 'BIG_BLIND_SELECTED' })
+    const bjAfter = after.jokers.find(j => j.jokerId === 'burntJoker')
+    expect(bjAfter?.counter).toBe(0)
+  })
+
+  it('resets counter to 0 on BOSS_BLIND_SELECTED', () => {
+    const game = setupGame()
+    const bj = game.jokers.find(j => j.jokerId === 'burntJoker')!
+    bj.counter = 1
+
+    const after = reduceGame(game, { type: 'BOSS_BLIND_SELECTED' })
+    const bjAfter = after.jokers.find(j => j.jokerId === 'burntJoker')
+    expect(bjAfter?.counter).toBe(0)
+  })
+})

--- a/src/app/daily-card-game/domain/joker/jokers.ts
+++ b/src/app/daily-card-game/domain/joker/jokers.ts
@@ -1,5 +1,6 @@
 import type { EffectContext } from '@/app/daily-card-game/domain/events/types'
 import {
+  findHighestPriorityHand,
   flushHand,
   pairHand,
   straightHand,
@@ -4149,6 +4150,44 @@ export const troubadour: JokerDefinition = {
   rarity: 'uncommon',
 }
 
+function resetBurntJoker(ctx: EffectContext) {
+  const bj = ctx.game.jokers.find(j => j.jokerId === 'burntJoker')
+  if (bj) bj.counter = 0
+}
+
+export const burntJoker: JokerDefinition = {
+  id: 'burntJoker',
+  name: 'Burnt Joker',
+  description: 'Upgrade the level of the first discarded poker hand each round',
+  price: 8,
+  effects: [
+    {
+      event: { type: 'DISCARD_SELECTED_CARDS' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        const bj = ctx.game.jokers.find(j => j.jokerId === 'burntJoker')
+        if (!bj) return
+        if (bj.counter !== 0) return
+
+        const discardedCards = ctx.game.gamePlayState.selectedCardIds
+          .map(id => ctx.game.cards[id])
+          .filter(Boolean)
+
+        if (discardedCards.length === 0) return
+
+        const { hand } = findHighestPriorityHand(discardedCards, ctx.game.staticRules)
+        ctx.game.pokerHands[hand].level += 1
+
+        bj.counter = 1
+      },
+    },
+    { event: { type: 'SMALL_BLIND_SELECTED' }, priority: 1, apply: resetBurntJoker },
+    { event: { type: 'BIG_BLIND_SELECTED' }, priority: 1, apply: resetBurntJoker },
+    { event: { type: 'BOSS_BLIND_SELECTED' }, priority: 1, apply: resetBurntJoker },
+  ],
+  rarity: 'rare',
+}
+
 export const showman: JokerDefinition = {
   id: 'showman',
   name: 'Showman',
@@ -4298,6 +4337,7 @@ export const jokers: Record<JokerDefinition['id'], JokerDefinition> = {
   burglar,
   troubadour,
   showman,
+  burntJoker,
 }
 
 /***


### PR DESCRIPTION
## Summary
- Implements Burnt Joker rare joker: upgrades first discarded poker hand level each round
- Uses findHighestPriorityHand to evaluate discarded cards
- Adds 6 unit tests covering upgrade, no-double-fire, and counter reset

Closes #834

## Test plan
- [x] Unit tests pass (`npx vitest run burnt-joker`)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)