### PR TITLE
Implement Blue Deck (#964)

### DIFF
--- a/src/app/daily-card-game/domain/decks/blue-deck.ts
+++ b/src/app/daily-card-game/domain/decks/blue-deck.ts
@@ -1,0 +1,12 @@
+import { pokerDeckDefinition } from './poker-deck'
+import { DeckDefinition } from './types'
+
+export const blueDeck: DeckDefinition = {
+  id: 'blueDeck',
+  name: 'Blue Deck',
+  description: '+1 hand every round',
+  cards: pokerDeckDefinition,
+  modifiers: {
+    maxHands: 1,
+  },
+}

--- a/src/app/daily-card-game/domain/decks/decks.ts
+++ b/src/app/daily-card-game/domain/decks/decks.ts
@@ -2,6 +2,7 @@ import { GameState } from '@/app/daily-card-game/domain/game/types'
 import { PlayingCardState } from '@/app/daily-card-game/domain/playing-card/types'
 import { initializePlayingCard } from '@/app/daily-card-game/domain/playing-card/utils'
 
+import { blueDeck } from './blue-deck'
 import { pokerDeck } from './poker-deck'
 import { redDeck } from './red-deck'
 import { DeckDefinition } from './types'
@@ -9,6 +10,7 @@ import { DeckDefinition } from './types'
 export const decks: Record<string, DeckDefinition> = {
   pokerDeck: pokerDeck,
   redDeck: redDeck,
+  blueDeck: blueDeck,
 }
 
 export const initialDeckStates = (game: GameState): Record<string, PlayingCardState[]> => {

--- a/src/app/daily-card-game/domain/game/__tests__/blue-deck.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/blue-deck.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest'
+import { createGameStateWithDeck } from '@/app/daily-card-game/domain/game/default-game-state'
+
+describe('Blue Deck', () => {
+  it('gives maxHands = default + 1', () => {
+    const game = createGameStateWithDeck('blueDeck')
+    expect(game.maxHands).toBe(5)
+  })
+
+  it('gives remainingHands = default + 1 at game start', () => {
+    const game = createGameStateWithDeck('blueDeck')
+    expect(game.gamePlayState.remainingHands).toBe(5)
+  })
+})


### PR DESCRIPTION
## Summary
- Implements the Blue Deck: +1 hand every round
- First deck implementation from epic #701
- Adds 2 unit tests

Closes #964

## Test plan
- [x] Unit tests pass (`npx vitest run blue-deck`)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)