### PR TITLE
Implement Black Deck (#967)

### DIFF
--- a/src/app/daily-card-game/domain/decks/__tests__/black-deck.test.ts
+++ b/src/app/daily-card-game/domain/decks/__tests__/black-deck.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  createGameStateWithDeck,
+  defaultGameState,
+} from '@/app/daily-card-game/domain/game/default-game-state'
+import { blackDeck } from '@/app/daily-card-game/domain/decks/black-deck'
+
+describe('Black Deck', () => {
+  it('has 52 cards', () => {
+    expect(blackDeck.cards).toHaveLength(52)
+  })
+
+  it('has correct modifiers', () => {
+    expect(blackDeck.modifiers.maxJokers).toBe(1)
+    expect(blackDeck.modifiers.maxHands).toBe(-1)
+  })
+
+  it('createGameStateWithDeck has +1 joker slot and -1 hand', () => {
+    const state = createGameStateWithDeck('blackDeck')
+    const base = structuredClone(defaultGameState)
+    expect(state.maxJokers).toBe(base.maxJokers + 1)
+    expect(state.maxHands).toBe(base.maxHands - 1)
+  })
+})

--- a/src/app/daily-card-game/domain/decks/black-deck.ts
+++ b/src/app/daily-card-game/domain/decks/black-deck.ts
@@ -1,0 +1,13 @@
+import { pokerDeckDefinition } from './poker-deck'
+import { DeckDefinition } from './types'
+
+export const blackDeck: DeckDefinition = {
+  id: 'blackDeck',
+  name: 'Black Deck',
+  description: '+1 Joker slot, -1 hand per round',
+  cards: pokerDeckDefinition,
+  modifiers: {
+    maxJokers: 1,
+    maxHands: -1,
+  },
+}

--- a/src/app/daily-card-game/domain/decks/decks.ts
+++ b/src/app/daily-card-game/domain/decks/decks.ts
@@ -2,6 +2,7 @@ import { GameState } from '@/app/daily-card-game/domain/game/types'
 import { PlayingCardState } from '@/app/daily-card-game/domain/playing-card/types'
 import { initializePlayingCard } from '@/app/daily-card-game/domain/playing-card/utils'
 
+import { blackDeck } from './black-deck'
 import { blueDeck } from './blue-deck'
 import { pokerDeck } from './poker-deck'
 import { redDeck } from './red-deck'
@@ -13,6 +14,7 @@ export const decks: Record<string, DeckDefinition> = {
   redDeck: redDeck,
   blueDeck: blueDeck,
   yellowDeck: yellowDeck,
+  blackDeck: blackDeck,
 }
 
 export const initialDeckStates = (game: GameState): Record<string, PlayingCardState[]> => {


### PR DESCRIPTION
## Summary
- Implements the Black Deck: +1 Joker slot, -1 hand per round
- Adds 3 unit tests

Closes #967

## Test plan
- [x] Unit tests pass
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)