### PR TITLE
Implement Abandoned Deck (#971)

### DIFF
--- a/src/app/daily-card-game/domain/decks/__tests__/abandoned-deck.test.ts
+++ b/src/app/daily-card-game/domain/decks/__tests__/abandoned-deck.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest'
+
+import { abandonedDeck } from '@/app/daily-card-game/domain/decks/abandoned-deck'
+
+describe('Abandoned Deck', () => {
+  it('has 40 cards', () => {
+    expect(abandonedDeck.cards).toHaveLength(40)
+  })
+
+  it('has no face cards (J, Q, K)', () => {
+    const faceValues = ['J', 'Q', 'K']
+    const faceCards = abandonedDeck.cards.filter(card => faceValues.includes(card.value))
+    expect(faceCards).toHaveLength(0)
+  })
+
+  it('has all 4 suits for each value 2-10 and A', () => {
+    const suits = ['hearts', 'diamonds', 'clubs', 'spades']
+    const values = ['2', '3', '4', '5', '6', '7', '8', '9', '10', 'A']
+    for (const value of values) {
+      for (const suit of suits) {
+        const found = abandonedDeck.cards.find(card => card.value === value && card.suit === suit)
+        expect(found).toBeDefined()
+      }
+    }
+  })
+
+  it('has empty modifiers', () => {
+    expect(abandonedDeck.modifiers).toEqual({})
+  })
+})

--- a/src/app/daily-card-game/domain/decks/abandoned-deck.ts
+++ b/src/app/daily-card-game/domain/decks/abandoned-deck.ts
@@ -1,0 +1,55 @@
+import { getDefaultCard } from '@/app/daily-card-game/domain/playing-card/playing-cards'
+import { PlayingCardDefinition } from '@/app/daily-card-game/domain/playing-card/types'
+
+import { DeckDefinition } from './types'
+
+export const abandonedDeckDefinition: PlayingCardDefinition[] = [
+  getDefaultCard('2', 'hearts'),
+  getDefaultCard('2', 'diamonds'),
+  getDefaultCard('2', 'clubs'),
+  getDefaultCard('2', 'spades'),
+  getDefaultCard('3', 'hearts'),
+  getDefaultCard('3', 'diamonds'),
+  getDefaultCard('3', 'clubs'),
+  getDefaultCard('3', 'spades'),
+  getDefaultCard('4', 'hearts'),
+  getDefaultCard('4', 'diamonds'),
+  getDefaultCard('4', 'clubs'),
+  getDefaultCard('4', 'spades'),
+  getDefaultCard('5', 'hearts'),
+  getDefaultCard('5', 'diamonds'),
+  getDefaultCard('5', 'clubs'),
+  getDefaultCard('5', 'spades'),
+  getDefaultCard('6', 'hearts'),
+  getDefaultCard('6', 'diamonds'),
+  getDefaultCard('6', 'clubs'),
+  getDefaultCard('6', 'spades'),
+  getDefaultCard('7', 'hearts'),
+  getDefaultCard('7', 'diamonds'),
+  getDefaultCard('7', 'clubs'),
+  getDefaultCard('7', 'spades'),
+  getDefaultCard('8', 'hearts'),
+  getDefaultCard('8', 'diamonds'),
+  getDefaultCard('8', 'clubs'),
+  getDefaultCard('8', 'spades'),
+  getDefaultCard('9', 'hearts'),
+  getDefaultCard('9', 'diamonds'),
+  getDefaultCard('9', 'clubs'),
+  getDefaultCard('9', 'spades'),
+  getDefaultCard('10', 'hearts'),
+  getDefaultCard('10', 'diamonds'),
+  getDefaultCard('10', 'clubs'),
+  getDefaultCard('10', 'spades'),
+  getDefaultCard('A', 'hearts'),
+  getDefaultCard('A', 'diamonds'),
+  getDefaultCard('A', 'clubs'),
+  getDefaultCard('A', 'spades'),
+]
+
+export const abandonedDeck: DeckDefinition = {
+  id: 'abandonedDeck',
+  name: 'Abandoned Deck',
+  description: 'A worn deck missing all face cards — 40 cards: 2–10 and A in all 4 suits',
+  cards: abandonedDeckDefinition,
+  modifiers: {},
+}

--- a/src/app/daily-card-game/domain/decks/decks.ts
+++ b/src/app/daily-card-game/domain/decks/decks.ts
@@ -2,6 +2,7 @@ import { GameState } from '@/app/daily-card-game/domain/game/types'
 import { PlayingCardState } from '@/app/daily-card-game/domain/playing-card/types'
 import { initializePlayingCard } from '@/app/daily-card-game/domain/playing-card/utils'
 
+import { abandonedDeck } from './abandoned-deck'
 import { blackDeck } from './black-deck'
 import { blueDeck } from './blue-deck'
 import { pokerDeck } from './poker-deck'
@@ -15,6 +16,7 @@ export const decks: Record<string, DeckDefinition> = {
   blueDeck: blueDeck,
   yellowDeck: yellowDeck,
   blackDeck: blackDeck,
+  abandonedDeck: abandonedDeck,
 }
 
 export const initialDeckStates = (game: GameState): Record<string, PlayingCardState[]> => {


### PR DESCRIPTION
## Summary
- Implements the Abandoned Deck: 40 cards with no face cards (J/Q/K removed)
- Custom card list with 2-10 and A in all 4 suits
- Adds 4 unit tests

Closes #971

## Test plan
- [x] Unit tests pass
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)