### PR TITLE
Implement Painted Deck (#974)

### DIFF
--- a/src/app/daily-card-game/domain/decks/__tests__/painted-deck.test.ts
+++ b/src/app/daily-card-game/domain/decks/__tests__/painted-deck.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  createGameStateWithDeck,
+  defaultGameState,
+} from '@/app/daily-card-game/domain/game/default-game-state'
+import { paintedDeck } from '@/app/daily-card-game/domain/decks/painted-deck'
+
+describe('Painted Deck', () => {
+  it('has 52 cards', () => {
+    expect(paintedDeck.cards).toHaveLength(52)
+  })
+
+  it('has correct modifiers', () => {
+    expect(paintedDeck.modifiers.handSizeModifier).toBe(2)
+    expect(paintedDeck.modifiers.maxJokers).toBe(-1)
+  })
+
+  it('createGameStateWithDeck has +2 hand size and -1 joker slot', () => {
+    const state = createGameStateWithDeck('paintedDeck')
+    const base = structuredClone(defaultGameState)
+    expect(state.handSizeModifier).toBe(base.handSizeModifier + 2)
+    expect(state.maxJokers).toBe(base.maxJokers - 1)
+  })
+})

--- a/src/app/daily-card-game/domain/decks/decks.ts
+++ b/src/app/daily-card-game/domain/decks/decks.ts
@@ -6,6 +6,7 @@ import { abandonedDeck } from './abandoned-deck'
 import { blackDeck } from './black-deck'
 import { blueDeck } from './blue-deck'
 import { checkeredDeck } from './checkered-deck'
+import { paintedDeck } from './painted-deck'
 import { pokerDeck } from './poker-deck'
 import { redDeck } from './red-deck'
 import { yellowDeck } from './yellow-deck'
@@ -19,6 +20,7 @@ export const decks: Record<string, DeckDefinition> = {
   blackDeck: blackDeck,
   abandonedDeck: abandonedDeck,
   checkeredDeck: checkeredDeck,
+  paintedDeck: paintedDeck,
 }
 
 export const initialDeckStates = (game: GameState): Record<string, PlayingCardState[]> => {

--- a/src/app/daily-card-game/domain/decks/painted-deck.ts
+++ b/src/app/daily-card-game/domain/decks/painted-deck.ts
@@ -1,0 +1,13 @@
+import { pokerDeckDefinition } from './poker-deck'
+import { DeckDefinition } from './types'
+
+export const paintedDeck: DeckDefinition = {
+  id: 'paintedDeck',
+  name: 'Painted Deck',
+  description: '+2 hand size, -1 Joker slot',
+  cards: pokerDeckDefinition,
+  modifiers: {
+    handSizeModifier: 2,
+    maxJokers: -1,
+  },
+}

--- a/src/app/daily-card-game/domain/decks/types.ts
+++ b/src/app/daily-card-game/domain/decks/types.ts
@@ -14,4 +14,5 @@ export interface DeckModifiers {
   money?: number
   maxJokers?: number
   maxConsumables?: number
+  handSizeModifier?: number
 }

--- a/src/app/daily-card-game/domain/game/default-game-state.ts
+++ b/src/app/daily-card-game/domain/game/default-game-state.ts
@@ -143,6 +143,7 @@ export function applyDeckModifiers(state: GameState, deck: DeckDefinition): Game
     money: state.money + (modifiers.money ?? 0),
     maxJokers: state.maxJokers + (modifiers.maxJokers ?? 0),
     maxConsumables: state.maxConsumables + (modifiers.maxConsumables ?? 0),
+    handSizeModifier: state.handSizeModifier + (modifiers.handSizeModifier ?? 0),
     gamePlayState: {
       ...state.gamePlayState,
       remainingDiscards:


### PR DESCRIPTION
## Summary
- Implements the Painted Deck: +2 hand size, -1 Joker slot
- Adds `handSizeModifier` support to DeckModifiers type and applyDeckModifiers
- Adds 3 unit tests

Closes #974

## Test plan
- [x] Unit tests pass
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)