### PR TITLE
Implement The Needle boss blind (#954)

### DIFF
--- a/src/app/daily-card-game/domain/game/__tests__/the-needle.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/the-needle.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest'
+import { defaultGameState } from '@/app/daily-card-game/domain/game/default-game-state'
+import { reduceGame } from '@/app/daily-card-game/domain/game/reduce-game'
+import type { GameState } from '@/app/daily-card-game/domain/game/types'
+
+describe('The Needle boss blind', () => {
+  function setupGame(overrides: Partial<GameState> = {}): GameState {
+    const game: GameState = structuredClone(defaultGameState)
+    game.rounds[game.roundIndex].bossBlindName = 'The Needle'
+    return { ...game, ...overrides }
+  }
+
+  it('sets maxHands to 1 when boss blind is selected', () => {
+    const game = setupGame()
+    const after = reduceGame(game, { type: 'BOSS_BLIND_SELECTED' })
+    expect(after.maxHands).toBe(1)
+  })
+
+  it('sets remainingHands to 1 when boss blind is selected', () => {
+    const game = setupGame()
+    const after = reduceGame(game, { type: 'BOSS_BLIND_SELECTED' })
+    expect(after.gamePlayState.remainingHands).toBe(1)
+  })
+})

--- a/src/app/daily-card-game/domain/round/boss-blinds.ts
+++ b/src/app/daily-card-game/domain/round/boss-blinds.ts
@@ -54,7 +54,29 @@ const theOx: BossBlindDefinition = {
   ],
 }
 
-export const bossBlinds: BossBlindDefinition[] = [theHook, theOx]
+const theNeedle: BossBlindDefinition = {
+  type: 'bossBlind',
+  status: 'notStarted',
+  anteMultiplier: 1,
+  name: 'The Needle',
+  description: 'Play only 1 hand.',
+  image: 'the-needle.png',
+  minimumAnte: 2,
+  baseReward: 5,
+  effects: [
+    {
+      event: { type: 'BOSS_BLIND_SELECTED' },
+      priority: 1,
+      condition: (ctx: EffectContext) => ctx.event.type === 'BOSS_BLIND_SELECTED',
+      apply: (ctx: EffectContext) => {
+        ctx.game.maxHands = 1
+        ctx.game.gamePlayState.remainingHands = 1
+      },
+    },
+  ],
+}
+
+export const bossBlinds: BossBlindDefinition[] = [theHook, theOx, theNeedle]
 
 /**
  


### PR DESCRIPTION
## Summary
- Implements The Needle boss blind: play only 1 hand
- First boss blind from epic #700
- Sets maxHands and remainingHands to 1 on BOSS_BLIND_SELECTED
- Adds 2 unit tests

Closes #954

## Test plan
- [x] Unit tests pass
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)