### PR TITLE
feat: implement The Pillar boss blind (#953)

### DIFF
--- a/src/app/daily-card-game/domain/game/__tests__/the-pillar.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/the-pillar.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest'
+import { defaultGameState } from '@/app/daily-card-game/domain/game/default-game-state'
+import { reduceGame } from '@/app/daily-card-game/domain/game/reduce-game'
+import type { GameState } from '@/app/daily-card-game/domain/game/types'
+
+describe('The Pillar boss blind', () => {
+  function setupGame(): GameState {
+    const game: GameState = structuredClone(defaultGameState)
+    game.rounds[game.roundIndex].bossBlindName = 'The Pillar'
+    game.rounds[game.roundIndex].bossBlind.status = 'inProgress'
+    game.rounds[game.roundIndex].smallBlind.status = 'completed'
+    game.rounds[game.roundIndex].bigBlind.status = 'completed'
+    game.gamePhase = 'gameplay'
+    return game
+  }
+
+  it('removes previously-played cards from cardsToScore at HAND_SCORING_START', () => {
+    const game = setupGame()
+    // Two cards played during small/big blinds earlier this ante
+    const cardAId = game.ownedCardIds[0]
+    const cardCId = game.ownedCardIds[1]
+    game.gamePlayState.cardIdsPlayedThisAnte = [cardAId]
+    game.gamePlayState.selectedCardIds = [cardAId, cardCId]
+    game.gamePlayState.handIds = [cardAId, cardCId]
+
+    const after = reduceGame(game, { type: 'HAND_SCORING_START' })
+
+    const scoredIds = after.gamePlayState.cardsToScore.map(c => c.id)
+    expect(scoredIds).not.toContain(cardAId)
+    expect(scoredIds).toContain(cardCId)
+  })
+
+  it('does not remove cards that were not played earlier this ante', () => {
+    const game = setupGame()
+    const cardCId = game.ownedCardIds[0]
+    game.gamePlayState.cardIdsPlayedThisAnte = [] // nothing played before
+    game.gamePlayState.selectedCardIds = [cardCId]
+    game.gamePlayState.handIds = [cardCId]
+
+    const after = reduceGame(game, { type: 'HAND_SCORING_START' })
+
+    const scoredIds = after.gamePlayState.cardsToScore.map(c => c.id)
+    expect(scoredIds).toContain(cardCId)
+  })
+
+  it('does not accumulate cards during boss blind plays', () => {
+    const game = setupGame()
+    const cardId = game.ownedCardIds[0]
+    game.gamePlayState.cardIdsPlayedThisAnte = ['some-earlier-card']
+    game.gamePlayState.selectedCardIds = [cardId]
+    game.gamePlayState.handIds = [cardId]
+
+    const after = reduceGame(game, { type: 'HAND_SCORING_START' })
+
+    // Boss blind cards should NOT be added to cardIdsPlayedThisAnte
+    expect(after.gamePlayState.cardIdsPlayedThisAnte).toEqual(['some-earlier-card'])
+  })
+
+  it('accumulates cards played in small blind into cardIdsPlayedThisAnte', () => {
+    const game = structuredClone(defaultGameState)
+    game.rounds[game.roundIndex].bossBlindName = 'The Pillar'
+    game.rounds[game.roundIndex].smallBlind.status = 'inProgress'
+    game.rounds[game.roundIndex].bigBlind.status = 'notStarted'
+    game.rounds[game.roundIndex].bossBlind.status = 'notStarted'
+    game.gamePhase = 'gameplay'
+
+    const cardId = game.ownedCardIds[0]
+    game.gamePlayState.cardIdsPlayedThisAnte = []
+    game.gamePlayState.selectedCardIds = [cardId]
+    game.gamePlayState.handIds = [cardId]
+
+    const after = reduceGame(game, { type: 'HAND_SCORING_START' })
+
+    expect(after.gamePlayState.cardIdsPlayedThisAnte).toContain(cardId)
+  })
+
+  it('resets cardIdsPlayedThisAnte when boss blind completes (BLIND_REWARDS_END)', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.rounds[game.roundIndex].bossBlind.status = 'inProgress'
+    game.rounds[game.roundIndex].smallBlind.status = 'completed'
+    game.rounds[game.roundIndex].bigBlind.status = 'completed'
+    game.gamePlayState.cardIdsPlayedThisAnte = ['card-a', 'card-b']
+    game.gamePhase = 'blindRewards'
+
+    const after = reduceGame(game, { type: 'BLIND_REWARDS_END' })
+
+    expect(after.gamePlayState.cardIdsPlayedThisAnte).toEqual([])
+  })
+})

--- a/src/app/daily-card-game/domain/game/default-game-state.ts
+++ b/src/app/daily-card-game/domain/game/default-game-state.ts
@@ -31,6 +31,7 @@ const gameState: GameState = {
   gamePhase: 'mainMenu',
   gamePlayState: {
     cardsToScore: [],
+    cardIdsPlayedThisAnte: [],
     discardPileIds: [],
     drawPileIds: [],
     handIds: [],

--- a/src/app/daily-card-game/domain/game/handlers/gameplay.ts
+++ b/src/app/daily-card-game/domain/game/handlers/gameplay.ts
@@ -279,6 +279,12 @@ export function handleHandScoringStart(draft: GameState, event: GameEvent) {
   gamePlayState.cardsToScore = cardsToScore
   gamePlayState.playedCardIds = gamePlayState.selectedCardIds
 
+  // Accumulate cards played this ante only during small/big blinds (for The Pillar)
+  const currentBlindForTracking = getInProgressBlind(draft as unknown as GameState)
+  if (currentBlindForTracking && currentBlindForTracking.type !== 'bossBlind') {
+    gamePlayState.cardIdsPlayedThisAnte.push(...gamePlayState.selectedCardIds)
+  }
+
   gamePlayState.remainingHands -= 1
 
   const playedHandLevel = draft.pokerHands[playedHand].level - 1
@@ -350,6 +356,7 @@ export function handleHandScoringDoneCardScoring(draft: GameState) {
   draft.gamePlayState.drawPileIds = draft.ownedCardIds
   draft.gamePlayState.remainingHands = draft.maxHands
   if (currentBlind.type === 'bossBlind') {
+    draft.gamePlayState.cardIdsPlayedThisAnte = []
     draft.roundIndex += 1
   }
   draft.gamePlayState.scoringEvents = []

--- a/src/app/daily-card-game/domain/game/types.ts
+++ b/src/app/daily-card-game/domain/game/types.ts
@@ -72,6 +72,9 @@ export type GamePhase =
 export interface GamePlayState {
   cardsToScore: PlayingCardState[]
 
+  // Track card IDs played across blinds in current ante (for The Pillar)
+  cardIdsPlayedThisAnte: string[]
+
   // Discard pile for current blind (card IDs)
   discardPileIds: string[]
 

--- a/src/app/daily-card-game/domain/round/boss-blinds.ts
+++ b/src/app/daily-card-game/domain/round/boss-blinds.ts
@@ -76,7 +76,31 @@ const theNeedle: BossBlindDefinition = {
   ],
 }
 
-export const bossBlinds: BossBlindDefinition[] = [theHook, theOx, theNeedle]
+const thePillar: BossBlindDefinition = {
+  type: 'bossBlind',
+  status: 'notStarted',
+  anteMultiplier: 2,
+  name: 'The Pillar',
+  description: 'Cards played previously this Ante are debuffed',
+  image: 'the-pillar.png',
+  minimumAnte: 1,
+  baseReward: 5,
+  effects: [
+    {
+      event: { type: 'HAND_SCORING_START' },
+      priority: 0,
+      condition: (ctx: EffectContext) => ctx.event.type === 'HAND_SCORING_START',
+      apply: (ctx: EffectContext) => {
+        const playedThisAnte = new Set(ctx.game.gamePlayState.cardIdsPlayedThisAnte)
+        ctx.game.gamePlayState.cardsToScore = ctx.game.gamePlayState.cardsToScore.filter(
+          card => !playedThisAnte.has(card.id)
+        )
+      },
+    },
+  ],
+}
+
+export const bossBlinds: BossBlindDefinition[] = [theHook, theOx, theNeedle, thePillar]
 
 /**
  


### PR DESCRIPTION
## Summary
- Adds The Pillar boss blind: cards played previously this Ante (during Small and Big Blinds) are debuffed during the Boss Blind
- Introduces `cardIdsPlayedThisAnte` tracking on GamePlayState to accumulate played card IDs across small/big blinds
- Debuffed cards are filtered from `cardsToScore` at HAND_SCORING_START so they contribute no chips/mult

## Test plan
- [x] Cards played in small/big blinds are excluded from scoring during boss blind
- [x] Cards not previously played score normally
- [x] No accumulation occurs during boss blind hands
- [x] Tracking resets when ante completes
- [x] All 1418 existing tests continue to pass

Fixes #953

🤖 Generated with [Claude Code](https://claude.com/claude-code)