### PR TITLE
feat: implement The Plant boss blind (#950)

### DIFF
--- a/src/app/daily-card-game/domain/game/__tests__/the-plant.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/the-plant.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest'
+import { defaultGameState } from '@/app/daily-card-game/domain/game/default-game-state'
+import { reduceGame } from '@/app/daily-card-game/domain/game/reduce-game'
+import type { GameState } from '@/app/daily-card-game/domain/game/types'
+import { playingCards } from '@/app/daily-card-game/domain/playing-card/playing-cards'
+
+describe('The Plant boss blind', () => {
+  function setupGame(): GameState {
+    const game: GameState = structuredClone(defaultGameState)
+    game.rounds[game.roundIndex].bossBlindName = 'The Plant'
+    game.rounds[game.roundIndex].bossBlind.status = 'inProgress'
+    game.gamePhase = 'gameplay'
+    return game
+  }
+
+  it('removes face cards (J, Q, K) from cardsToScore at HAND_SCORING_START', () => {
+    const game = setupGame()
+
+    const jackId = Object.keys(game.cards).find(id =>
+      playingCards[game.cards[id].playingCardId]?.value === 'J'
+    )!
+    const queenId = Object.keys(game.cards).find(id =>
+      playingCards[game.cards[id].playingCardId]?.value === 'Q'
+    )!
+    const kingId = Object.keys(game.cards).find(id =>
+      playingCards[game.cards[id].playingCardId]?.value === 'K'
+    )!
+    const aceId = Object.keys(game.cards).find(id =>
+      playingCards[game.cards[id].playingCardId]?.value === 'A'
+    )!
+
+    const gameWithCards: GameState = {
+      ...game,
+      gamePlayState: {
+        ...game.gamePlayState,
+        selectedCardIds: [jackId, queenId, kingId, aceId],
+        handIds: [jackId, queenId, kingId, aceId],
+        cardsToScore: [game.cards[jackId], game.cards[queenId], game.cards[kingId], game.cards[aceId]],
+      },
+    }
+
+    const after = reduceGame(gameWithCards, { type: 'HAND_SCORING_START' })
+
+    const scoredIds = after.gamePlayState.cardsToScore.map(c => c.id)
+    expect(scoredIds).not.toContain(jackId)
+    expect(scoredIds).not.toContain(queenId)
+    expect(scoredIds).not.toContain(kingId)
+    expect(scoredIds).toContain(aceId)
+  })
+
+  it('does not remove non-face cards from cardsToScore', () => {
+    const game = setupGame()
+
+    // Find two aces (same value to form a pair) so both score
+    const aceIds = Object.keys(game.cards).filter(id =>
+      playingCards[game.cards[id].playingCardId]?.value === 'A'
+    )
+    const aceId1 = aceIds[0]!
+    const aceId2 = aceIds[1]!
+
+    const gameWithCards: GameState = {
+      ...game,
+      gamePlayState: {
+        ...game.gamePlayState,
+        selectedCardIds: [aceId1, aceId2],
+        handIds: [aceId1, aceId2],
+      },
+    }
+
+    const after = reduceGame(gameWithCards, { type: 'HAND_SCORING_START' })
+
+    const scoredIds = after.gamePlayState.cardsToScore.map(c => c.id)
+    expect(scoredIds).toContain(aceId1)
+    expect(scoredIds).toContain(aceId2)
+  })
+})

--- a/src/app/daily-card-game/domain/round/boss-blinds.ts
+++ b/src/app/daily-card-game/domain/round/boss-blinds.ts
@@ -1,5 +1,6 @@
 import type { EffectContext } from '@/app/daily-card-game/domain/events/types'
 import { getMostPlayedHand } from '@/app/daily-card-game/domain/hand/utils'
+import { playingCards } from '@/app/daily-card-game/domain/playing-card/playing-cards'
 import { getRandomNumberWithSeed } from '@/app/daily-card-game/domain/randomness'
 import type { BossBlindDefinition } from '@/app/daily-card-game/domain/round/types'
 
@@ -112,7 +113,30 @@ const theSerpent: BossBlindDefinition = {
   effects: [],
 }
 
-export const bossBlinds: BossBlindDefinition[] = [theHook, theOx, theNeedle, thePillar, theSerpent]
+const thePlant: BossBlindDefinition = {
+  type: 'bossBlind',
+  status: 'notStarted',
+  anteMultiplier: 2,
+  name: 'The Plant',
+  description: 'All face cards are debuffed',
+  image: 'the-plant.png',
+  minimumAnte: 4,
+  baseReward: 5,
+  effects: [
+    {
+      event: { type: 'HAND_SCORING_START' },
+      priority: 0,
+      condition: (ctx: EffectContext) => ctx.event.type === 'HAND_SCORING_START',
+      apply: (ctx: EffectContext) => {
+        ctx.game.gamePlayState.cardsToScore = ctx.game.gamePlayState.cardsToScore.filter(
+          card => !['J', 'Q', 'K'].includes(playingCards[card.playingCardId].value)
+        )
+      },
+    },
+  ],
+}
+
+export const bossBlinds: BossBlindDefinition[] = [theHook, theOx, theNeedle, thePillar, theSerpent, thePlant]
 
 /**
  


### PR DESCRIPTION
## Summary
- Adds The Plant boss blind: all face cards (J, Q, K) are debuffed and don't score
- Uses HAND_SCORING_START effect to filter face cards from cardsToScore
- Minimum ante: 4, Matador-compatible

## Test plan
- [x] Face cards (J, Q, K) are removed from scoring
- [x] Non-face cards (A, number cards) score normally
- [x] All existing tests pass

Fixes #950

🤖 Generated with [Claude Code](https://claude.com/claude-code)