### PR TITLE
fix: implement The House boss blind

### DIFF
--- a/src/app/daily-card-game/domain/game/__tests__/the-house.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/the-house.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest'
+
+import { defaultGameState } from '@/app/daily-card-game/domain/game/default-game-state'
+import { reduceGame } from '@/app/daily-card-game/domain/game/reduce-game'
+import type { GameState } from '@/app/daily-card-game/domain/game/types'
+
+describe('The House boss blind', () => {
+  function setupGame(overrides: Partial<GameState> = {}): GameState {
+    const game: GameState = structuredClone(defaultGameState)
+    game.rounds[game.roundIndex].bossBlindName = 'The House'
+    game.rounds[game.roundIndex].bossBlind.status = 'inProgress'
+    game.gamePhase = 'gameplay'
+    game.gamePlayState.drawPileIds = [...game.ownedCardIds]
+    return { ...game, ...overrides }
+  }
+
+  it('draws the first boss blind hand face down', () => {
+    const game = setupGame()
+
+    const after = reduceGame(game, { type: 'HAND_DEALT' })
+    const dealtCards = after.gamePlayState.handIds.map(id => after.cards[id])
+
+    expect(dealtCards.length).toBeGreaterThan(0)
+    expect(dealtCards.every(card => card.isFaceUp === false)).toBe(true)
+  })
+
+  it('does not draw later hands face down', () => {
+    const game = setupGame({ handsPlayed: 1 })
+
+    const after = reduceGame(game, { type: 'HAND_DEALT' })
+    const dealtCards = after.gamePlayState.handIds.map(id => after.cards[id])
+
+    expect(dealtCards.length).toBeGreaterThan(0)
+    expect(dealtCards.every(card => card.isFaceUp === true)).toBe(true)
+  })
+
+  it('does not affect non-House boss blinds', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.rounds[game.roundIndex].bossBlindName = 'The Needle'
+    game.rounds[game.roundIndex].bossBlind.status = 'inProgress'
+    game.gamePhase = 'gameplay'
+    game.gamePlayState.drawPileIds = [...game.ownedCardIds]
+
+    const after = reduceGame(game, { type: 'HAND_DEALT' })
+    const dealtCards = after.gamePlayState.handIds.map(id => after.cards[id])
+
+    expect(dealtCards.length).toBeGreaterThan(0)
+    expect(dealtCards.every(card => card.isFaceUp === true)).toBe(true)
+  })
+})

--- a/src/app/daily-card-game/domain/game/reduce-game.ts
+++ b/src/app/daily-card-game/domain/game/reduce-game.ts
@@ -2,7 +2,7 @@ import { produce } from 'immer'
 
 import { dispatchEffects } from '@/app/daily-card-game/domain/events/dispatch-effects'
 import type { GameEvent } from '@/app/daily-card-game/domain/events/types'
-import { dealCardsFromDrawPile } from '@/app/daily-card-game/domain/game/card-registry-utils'
+import { dealCardsFromDrawPile, updateCard } from '@/app/daily-card-game/domain/game/card-registry-utils'
 import { jokers } from '@/app/daily-card-game/domain/joker/jokers'
 
 import { HAND_SIZE } from './constants'
@@ -119,7 +119,19 @@ export function reduceGame(game: GameState, event: GameEvent): GameState {
 
       case 'HAND_DEALT': {
         if (draft.gamePlayState.handIds.length) return
-        dealCardsFromDrawPile(draft, HAND_SIZE + draft.handSizeModifier)
+        const dealtCardIds = dealCardsFromDrawPile(draft, HAND_SIZE + draft.handSizeModifier)
+
+        const currentRound = draft.rounds[draft.roundIndex]
+        const isTheHouseFirstHand =
+          currentRound.bossBlindName === 'The House' &&
+          currentRound.bossBlind.status === 'inProgress' &&
+          draft.handsPlayed === 0
+
+        if (isTheHouseFirstHand) {
+          dealtCardIds.forEach(cardId => {
+            updateCard(draft, cardId, { isFaceUp: false })
+          })
+        }
         return
       }
       case 'CARD_SELECTED': {

--- a/src/app/daily-card-game/domain/round/boss-blinds.ts
+++ b/src/app/daily-card-game/domain/round/boss-blinds.ts
@@ -100,6 +100,18 @@ const thePillar: BossBlindDefinition = {
   ],
 }
 
+const theHouse: BossBlindDefinition = {
+  type: 'bossBlind',
+  status: 'notStarted',
+  anteMultiplier: 2,
+  name: 'The House',
+  description: 'First hand is drawn face down',
+  image: 'the-house.png',
+  minimumAnte: 2,
+  baseReward: 5,
+  effects: [],
+}
+
 const theSerpent: BossBlindDefinition = {
   type: 'bossBlind',
   status: 'notStarted',
@@ -112,7 +124,7 @@ const theSerpent: BossBlindDefinition = {
   effects: [],
 }
 
-export const bossBlinds: BossBlindDefinition[] = [theHook, theOx, theNeedle, thePillar, theSerpent]
+export const bossBlinds: BossBlindDefinition[] = [theHook, theOx, theNeedle, thePillar, theHouse, theSerpent]
 
 /**
  


### PR DESCRIPTION
## Summary
- add The House boss blind definition to the available boss blind list
- draw the first hand of an in-progress The House boss blind face down
- add focused regression coverage for first-hand and non-House behavior

## Testing
- npm test -- src/app/daily-card-game/domain/game/__tests__/the-house.test.ts src/app/daily-card-game/domain/game/__tests__/the-needle.test.ts src/app/daily-card-game/domain/game/__tests__/the-pillar.test.ts src/app/daily-card-game/domain/game/__tests__/the-serpent.test.ts
- npm run typecheck *(currently fails due to pre-existing repo/environment TypeScript/module-resolution issues in node_modules and path alias resolution)*

Fixes #936