### PR TITLE
feat: implement The Tooth boss blind (#955)

### DIFF
--- a/src/app/daily-card-game/domain/game/__tests__/the-tooth.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/the-tooth.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+import { defaultGameState } from '@/app/daily-card-game/domain/game/default-game-state'
+import { reduceGame } from '@/app/daily-card-game/domain/game/reduce-game'
+import type { GameState } from '@/app/daily-card-game/domain/game/types'
+
+describe('The Tooth boss blind', () => {
+  function setupGame(overrides: Partial<GameState> = {}): GameState {
+    const game: GameState = structuredClone(defaultGameState)
+    game.rounds[game.roundIndex].bossBlindName = 'The Tooth'
+    game.rounds[game.roundIndex].bossBlind.status = 'inProgress'
+    game.gamePhase = 'gameplay'
+    return { ...game, ...overrides }
+  }
+
+  it('loses $1 when a card is scored', () => {
+    const game = setupGame()
+    game.money = 10
+    const cardId = Object.keys(game.cards)[0]
+    game.gamePlayState.cardsToScore = [game.cards[cardId]]
+
+    const after = reduceGame(game, { type: 'CARD_SCORED' })
+    expect(after.money).toBe(9)
+  })
+
+  it('does not reduce money below minimum', () => {
+    const game = setupGame()
+    game.money = 0
+    const cardId = Object.keys(game.cards)[0]
+    game.gamePlayState.cardsToScore = [game.cards[cardId]]
+
+    const after = reduceGame(game, { type: 'CARD_SCORED' })
+    expect(after.money).toBe(0)
+  })
+})

--- a/src/app/daily-card-game/domain/round/boss-blinds.ts
+++ b/src/app/daily-card-game/domain/round/boss-blinds.ts
@@ -136,7 +136,28 @@ const thePlant: BossBlindDefinition = {
   ],
 }
 
-export const bossBlinds: BossBlindDefinition[] = [theHook, theOx, theNeedle, thePillar, theSerpent, thePlant]
+const theTooth: BossBlindDefinition = {
+  type: 'bossBlind',
+  status: 'notStarted',
+  anteMultiplier: 2,
+  name: 'The Tooth',
+  description: 'Lose $1 per card played',
+  image: 'the-tooth.png',
+  minimumAnte: 3,
+  baseReward: 5,
+  effects: [
+    {
+      event: { type: 'CARD_SCORED' },
+      priority: 1,
+      condition: (ctx: EffectContext) => ctx.event.type === 'CARD_SCORED',
+      apply: (ctx: EffectContext) => {
+        ctx.game.money = Math.max(ctx.game.minimumMoney, ctx.game.money - 1)
+      },
+    },
+  ],
+}
+
+export const bossBlinds: BossBlindDefinition[] = [theHook, theOx, theNeedle, thePillar, theSerpent, thePlant, theTooth]
 
 /**
  


### PR DESCRIPTION
## Summary
- Adds The Tooth boss blind: lose $1 per card scored
- Uses CARD_SCORED effect, respects minimumMoney floor
- Minimum ante: 3, not Matador-compatible

## Test plan
- [x] $1 deducted per card scored
- [x] Money doesn't drop below minimumMoney
- [x] All existing tests pass

Fixes #955

🤖 Generated with [Claude Code](https://claude.com/claude-code)