### PR TITLE
feat: implement The Flint boss blind (#956)

### DIFF
--- a/src/app/daily-card-game/domain/game/__tests__/the-flint.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/the-flint.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest'
+import { defaultGameState } from '@/app/daily-card-game/domain/game/default-game-state'
+import { reduceGame } from '@/app/daily-card-game/domain/game/reduce-game'
+import type { GameState } from '@/app/daily-card-game/domain/game/types'
+import { playingCards } from '@/app/daily-card-game/domain/playing-card/playing-cards'
+
+describe('The Flint boss blind', () => {
+  function setupGame(): GameState {
+    const game: GameState = structuredClone(defaultGameState)
+    game.rounds[game.roundIndex].bossBlindName = 'The Flint'
+    game.rounds[game.roundIndex].bossBlind.status = 'inProgress'
+    game.gamePhase = 'gameplay'
+    return game
+  }
+
+  it('halves base chips and mult after HAND_SCORING_START for a Pair', () => {
+    const game = setupGame()
+
+    // Find two aces to form a Pair (baseChips=10, baseMult=2)
+    const aceIds = Object.keys(game.cards).filter(id =>
+      playingCards[game.cards[id].playingCardId]?.value === 'A'
+    )
+    const aceId1 = aceIds[0]!
+    const aceId2 = aceIds[1]!
+
+    const gameWithCards: GameState = {
+      ...game,
+      gamePlayState: {
+        ...game.gamePlayState,
+        selectedCardIds: [aceId1, aceId2],
+        handIds: [aceId1, aceId2],
+      },
+    }
+
+    const after = reduceGame(gameWithCards, { type: 'HAND_SCORING_START' })
+
+    // Pair: baseChips=10, baseMult=2 → halved: chips=5, mult=1
+    expect(after.gamePlayState.score.chips).toBe(5)
+    expect(after.gamePlayState.score.mult).toBe(1)
+  })
+
+  it('floors the halved value when the result is not a whole number', () => {
+    const game = setupGame()
+
+    // High Card has baseChips=5, baseMult=1
+    // After halving: chips=floor(5/2)=2, mult=floor(1/2)=0
+    const cardId = Object.keys(game.cards)[0]!
+
+    const gameWithCards: GameState = {
+      ...game,
+      gamePlayState: {
+        ...game.gamePlayState,
+        selectedCardIds: [cardId],
+        handIds: [cardId],
+      },
+    }
+
+    const after = reduceGame(gameWithCards, { type: 'HAND_SCORING_START' })
+
+    // High Card: baseChips=5, baseMult=1 → halved: chips=2, mult=0
+    expect(after.gamePlayState.score.chips).toBe(2)
+    expect(after.gamePlayState.score.mult).toBe(0)
+  })
+})

--- a/src/app/daily-card-game/domain/round/boss-blinds.ts
+++ b/src/app/daily-card-game/domain/round/boss-blinds.ts
@@ -157,7 +157,29 @@ const theTooth: BossBlindDefinition = {
   ],
 }
 
-export const bossBlinds: BossBlindDefinition[] = [theHook, theOx, theNeedle, thePillar, theSerpent, thePlant, theTooth]
+const theFlint: BossBlindDefinition = {
+  type: 'bossBlind',
+  status: 'notStarted',
+  anteMultiplier: 2,
+  name: 'The Flint',
+  description: 'Base Chips and Mult are halved',
+  image: 'the-flint.png',
+  minimumAnte: 2,
+  baseReward: 5,
+  effects: [
+    {
+      event: { type: 'HAND_SCORING_START' },
+      priority: 0,
+      condition: (ctx: EffectContext) => ctx.event.type === 'HAND_SCORING_START',
+      apply: (ctx: EffectContext) => {
+        ctx.game.gamePlayState.score.chips = Math.floor(ctx.game.gamePlayState.score.chips / 2)
+        ctx.game.gamePlayState.score.mult = Math.floor(ctx.game.gamePlayState.score.mult / 2)
+      },
+    },
+  ],
+}
+
+export const bossBlinds: BossBlindDefinition[] = [theHook, theOx, theNeedle, thePillar, theSerpent, thePlant, theTooth, theFlint]
 
 /**
  


### PR DESCRIPTION
## Summary
- Adds The Flint boss blind: base Chips and Mult from poker hands are halved
- Uses HAND_SCORING_START effect with Math.floor rounding
- Minimum ante: 2, Matador-compatible

## Test plan
- [x] Pair base chips (10) halved to 5, mult (2) halved to 1
- [x] Floor rounding works correctly (5/2 = 2, 1/2 = 0)
- [x] All existing tests pass

Fixes #956

🤖 Generated with [Claude Code](https://claude.com/claude-code)