### PR TITLE
feat: implement The Mark boss blind (#957)

### DIFF
--- a/src/app/daily-card-game/domain/game/__tests__/the-mark.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/the-mark.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest'
+import { defaultGameState } from '@/app/daily-card-game/domain/game/default-game-state'
+import { reduceGame } from '@/app/daily-card-game/domain/game/reduce-game'
+import type { GameState } from '@/app/daily-card-game/domain/game/types'
+import { playingCards } from '@/app/daily-card-game/domain/playing-card/playing-cards'
+
+describe('The Mark boss blind', () => {
+  function setupGame(): GameState {
+    const game: GameState = structuredClone(defaultGameState)
+    game.rounds[game.roundIndex].bossBlindName = 'The Mark'
+    return game
+  }
+
+  it('flips face cards face down on BOSS_BLIND_SELECTED', () => {
+    const game = setupGame()
+
+    const jackId = Object.keys(game.cards).find(id =>
+      playingCards[game.cards[id].playingCardId]?.value === 'J'
+    )!
+    const aceId = Object.keys(game.cards).find(id =>
+      playingCards[game.cards[id].playingCardId]?.value === 'A'
+    )!
+
+    // Ensure both cards start face up
+    game.cards[jackId] = { ...game.cards[jackId], isFaceUp: true }
+    game.cards[aceId] = { ...game.cards[aceId], isFaceUp: true }
+
+    const after = reduceGame(game, { type: 'BOSS_BLIND_SELECTED' })
+
+    expect(after.cards[jackId].isFaceUp).toBe(false)
+    expect(after.cards[aceId].isFaceUp).toBe(true)
+  })
+
+  it('flips all J, Q, K cards face down on BOSS_BLIND_SELECTED', () => {
+    const game = setupGame()
+
+    const jackId = Object.keys(game.cards).find(id =>
+      playingCards[game.cards[id].playingCardId]?.value === 'J'
+    )!
+    const queenId = Object.keys(game.cards).find(id =>
+      playingCards[game.cards[id].playingCardId]?.value === 'Q'
+    )!
+    const kingId = Object.keys(game.cards).find(id =>
+      playingCards[game.cards[id].playingCardId]?.value === 'K'
+    )!
+
+    game.cards[jackId] = { ...game.cards[jackId], isFaceUp: true }
+    game.cards[queenId] = { ...game.cards[queenId], isFaceUp: true }
+    game.cards[kingId] = { ...game.cards[kingId], isFaceUp: true }
+
+    const after = reduceGame(game, { type: 'BOSS_BLIND_SELECTED' })
+
+    expect(after.cards[jackId].isFaceUp).toBe(false)
+    expect(after.cards[queenId].isFaceUp).toBe(false)
+    expect(after.cards[kingId].isFaceUp).toBe(false)
+  })
+
+  it('does not flip non-face cards', () => {
+    const game = setupGame()
+
+    const twoId = Object.keys(game.cards).find(id =>
+      playingCards[game.cards[id].playingCardId]?.value === '2'
+    )!
+    const tenId = Object.keys(game.cards).find(id =>
+      playingCards[game.cards[id].playingCardId]?.value === '10'
+    )!
+
+    game.cards[twoId] = { ...game.cards[twoId], isFaceUp: true }
+    game.cards[tenId] = { ...game.cards[tenId], isFaceUp: true }
+
+    const after = reduceGame(game, { type: 'BOSS_BLIND_SELECTED' })
+
+    expect(after.cards[twoId].isFaceUp).toBe(true)
+    expect(after.cards[tenId].isFaceUp).toBe(true)
+  })
+})

--- a/src/app/daily-card-game/domain/round/boss-blinds.ts
+++ b/src/app/daily-card-game/domain/round/boss-blinds.ts
@@ -179,7 +179,34 @@ const theFlint: BossBlindDefinition = {
   ],
 }
 
-export const bossBlinds: BossBlindDefinition[] = [theHook, theOx, theNeedle, thePillar, theSerpent, thePlant, theTooth, theFlint]
+const theMark: BossBlindDefinition = {
+  type: 'bossBlind',
+  status: 'notStarted',
+  anteMultiplier: 2,
+  name: 'The Mark',
+  description: 'All face cards are drawn face down',
+  image: 'the-mark.png',
+  minimumAnte: 2,
+  baseReward: 5,
+  effects: [
+    {
+      event: { type: 'BOSS_BLIND_SELECTED' },
+      priority: 1,
+      condition: (ctx: EffectContext) => ctx.event.type === 'BOSS_BLIND_SELECTED',
+      apply: (ctx: EffectContext) => {
+        // Flip all face cards in the entire deck face down
+        for (const cardId of Object.keys(ctx.game.cards)) {
+          const card = ctx.game.cards[cardId]
+          if (['J', 'Q', 'K'].includes(playingCards[card.playingCardId].value)) {
+            card.isFaceUp = false
+          }
+        }
+      },
+    },
+  ],
+}
+
+export const bossBlinds: BossBlindDefinition[] = [theHook, theOx, theNeedle, thePillar, theSerpent, thePlant, theTooth, theFlint, theMark]
 
 /**
  


### PR DESCRIPTION
## Summary
- Adds The Mark boss blind: all face cards (J, Q, K) are drawn face down
- On BOSS_BLIND_SELECTED, iterates all cards and sets isFaceUp=false for face cards
- Minimum ante: 2, not Matador-compatible

## Test plan
- [x] Face cards (J, Q, K) are flipped face down
- [x] Non-face cards remain face up
- [x] All existing tests pass (405 total)

Fixes #957

🤖 Generated with [Claude Code](https://claude.com/claude-code)