### PR TITLE
feat: implement The Mouth boss blind (#949)

### DIFF
--- a/src/app/daily-card-game/domain/game/__tests__/the-mouth.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/the-mouth.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest'
+import { defaultGameState } from '@/app/daily-card-game/domain/game/default-game-state'
+import { reduceGame } from '@/app/daily-card-game/domain/game/reduce-game'
+import type { GameState } from '@/app/daily-card-game/domain/game/types'
+import { playingCards } from '@/app/daily-card-game/domain/playing-card/playing-cards'
+
+describe('The Mouth boss blind', () => {
+  function setupGame(): GameState {
+    const game: GameState = structuredClone(defaultGameState)
+    game.rounds[game.roundIndex].bossBlindName = 'The Mouth'
+    game.rounds[game.roundIndex].bossBlind.status = 'inProgress'
+    game.gamePhase = 'gameplay'
+    return game
+  }
+
+  it('allows first hand of the round to score normally', () => {
+    const game = setupGame()
+
+    // handTypesPlayedThisRound is empty - this is the first hand
+    const aceIds = Object.keys(game.cards).filter(id =>
+      playingCards[game.cards[id].playingCardId]?.value === 'A'
+    )
+    const aceId1 = aceIds[0]!
+    const aceId2 = aceIds[1]!
+
+    const gameWithCards: GameState = {
+      ...game,
+      gamePlayState: {
+        ...game.gamePlayState,
+        selectedCardIds: [aceId1, aceId2],
+        handIds: [aceId1, aceId2],
+        handTypesPlayedThisRound: [],
+      },
+    }
+
+    const after = reduceGame(gameWithCards, { type: 'HAND_SCORING_START' })
+
+    // Pair: baseChips=10, baseMult=2 - should score normally
+    expect(after.gamePlayState.score.chips).toBeGreaterThan(0)
+    expect(after.gamePlayState.score.mult).toBeGreaterThan(0)
+  })
+
+  it('allows same hand type as first hand to score normally', () => {
+    const game = setupGame()
+
+    // Simulate pair was already played this round
+    const aceIds = Object.keys(game.cards).filter(id =>
+      playingCards[game.cards[id].playingCardId]?.value === 'A'
+    )
+    const aceId1 = aceIds[0]!
+    const aceId2 = aceIds[1]!
+
+    const gameWithCards: GameState = {
+      ...game,
+      gamePlayState: {
+        ...game.gamePlayState,
+        selectedCardIds: [aceId1, aceId2],
+        handIds: [aceId1, aceId2],
+        handTypesPlayedThisRound: ['pair'], // pair was played before
+      },
+    }
+
+    const after = reduceGame(gameWithCards, { type: 'HAND_SCORING_START' })
+
+    // Playing another pair - should score normally
+    expect(after.gamePlayState.score.chips).toBeGreaterThan(0)
+    expect(after.gamePlayState.score.mult).toBeGreaterThan(0)
+  })
+
+  it('zeros out score when a different hand type is played after the first', () => {
+    const game = setupGame()
+
+    // Simulate pair was already played this round; now play a high card
+    const cardId = Object.keys(game.cards)[0]!
+
+    const gameWithCards: GameState = {
+      ...game,
+      gamePlayState: {
+        ...game.gamePlayState,
+        selectedCardIds: [cardId],
+        handIds: [cardId],
+        handTypesPlayedThisRound: ['pair'], // pair was played first, now playing highCard
+      },
+    }
+
+    const after = reduceGame(gameWithCards, { type: 'HAND_SCORING_START' })
+
+    // Different hand type - should be zeroed out
+    expect(after.gamePlayState.score.chips).toBe(0)
+    expect(after.gamePlayState.score.mult).toBe(0)
+    expect(after.gamePlayState.cardsToScore).toHaveLength(0)
+  })
+})

--- a/src/app/daily-card-game/domain/round/boss-blinds.ts
+++ b/src/app/daily-card-game/domain/round/boss-blinds.ts
@@ -206,7 +206,33 @@ const theMark: BossBlindDefinition = {
   ],
 }
 
-export const bossBlinds: BossBlindDefinition[] = [theHook, theOx, theNeedle, thePillar, theSerpent, thePlant, theTooth, theFlint, theMark]
+const theMouth: BossBlindDefinition = {
+  type: 'bossBlind',
+  status: 'notStarted',
+  anteMultiplier: 2,
+  name: 'The Mouth',
+  description: 'Only one hand type can be played this round',
+  image: 'the-mouth.png',
+  minimumAnte: 2,
+  baseReward: 5,
+  effects: [
+    {
+      event: { type: 'HAND_SCORING_START' },
+      priority: 0,
+      condition: (ctx: EffectContext) => ctx.event.type === 'HAND_SCORING_START',
+      apply: (ctx: EffectContext) => {
+        const playedTypes = ctx.game.gamePlayState.handTypesPlayedThisRound
+        if (playedTypes.length > 1 && ctx.game.gamePlayState.selectedHand?.[0] !== playedTypes[0]) {
+          // Wrong hand type - zero out scoring
+          ctx.game.gamePlayState.score = { chips: 0, mult: 0 }
+          ctx.game.gamePlayState.cardsToScore = []
+        }
+      },
+    },
+  ],
+}
+
+export const bossBlinds: BossBlindDefinition[] = [theHook, theOx, theNeedle, thePillar, theSerpent, thePlant, theTooth, theFlint, theMark, theMouth]
 
 /**
  


### PR DESCRIPTION
## Summary
- Adds The Mouth boss blind: only one hand type can be played per round
- First hand type locks in; subsequent different hand types get zeroed out (no scoring)
- Minimum ante: 2, Matador-compatible

## Test plan
- [x] First hand scores normally
- [x] Same hand type on subsequent hands scores normally
- [x] Different hand type zeroes out scoring
- [x] All existing tests pass (408 total)

Fixes #949

🤖 Generated with [Claude Code](https://claude.com/claude-code)