### PR TITLE
feat: implement The Manacle boss blind (#947)

### DIFF
--- a/src/app/daily-card-game/domain/game/__tests__/the-manacle.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/the-manacle.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest'
+import { defaultGameState } from '@/app/daily-card-game/domain/game/default-game-state'
+import { reduceGame } from '@/app/daily-card-game/domain/game/reduce-game'
+import type { GameState } from '@/app/daily-card-game/domain/game/types'
+
+describe('The Manacle boss blind', () => {
+  function setupGame(overrides: Partial<GameState> = {}): GameState {
+    const game: GameState = structuredClone(defaultGameState)
+    game.rounds[game.roundIndex].bossBlindName = 'The Manacle'
+    return { ...game, ...overrides }
+  }
+
+  it('reduces handSizeModifier by 1 on BOSS_BLIND_SELECTED', () => {
+    const game = setupGame()
+    game.handSizeModifier = 0
+    const after = reduceGame(game, { type: 'BOSS_BLIND_SELECTED' })
+    expect(after.handSizeModifier).toBe(-1)
+  })
+
+  it('stacks with existing handSizeModifier', () => {
+    const game = setupGame()
+    game.handSizeModifier = 2
+    const after = reduceGame(game, { type: 'BOSS_BLIND_SELECTED' })
+    expect(after.handSizeModifier).toBe(1)
+  })
+})

--- a/src/app/daily-card-game/domain/round/boss-blinds.ts
+++ b/src/app/daily-card-game/domain/round/boss-blinds.ts
@@ -262,7 +262,28 @@ const theEye: BossBlindDefinition = {
   ],
 }
 
-export const bossBlinds: BossBlindDefinition[] = [theHook, theOx, theNeedle, thePillar, theSerpent, thePlant, theTooth, theFlint, theMark, theMouth, theEye]
+const theManacle: BossBlindDefinition = {
+  type: 'bossBlind',
+  status: 'notStarted',
+  anteMultiplier: 2,
+  name: 'The Manacle',
+  description: '-1 Hand Size',
+  image: 'the-manacle.png',
+  minimumAnte: 1,
+  baseReward: 5,
+  effects: [
+    {
+      event: { type: 'BOSS_BLIND_SELECTED' },
+      priority: 1,
+      condition: (ctx: EffectContext) => ctx.event.type === 'BOSS_BLIND_SELECTED',
+      apply: (ctx: EffectContext) => {
+        ctx.game.handSizeModifier -= 1
+      },
+    },
+  ],
+}
+
+export const bossBlinds: BossBlindDefinition[] = [theHook, theOx, theNeedle, thePillar, theSerpent, thePlant, theTooth, theFlint, theMark, theMouth, theEye, theManacle]
 
 /**
  


### PR DESCRIPTION
## Summary
- Adds The Manacle boss blind: -1 Hand Size
- On BOSS_BLIND_SELECTED, decrements handSizeModifier by 1
- Minimum ante: 1, not Matador-compatible

## Test plan
- [x] Reduces handSizeModifier by 1
- [x] Stacks with existing modifiers
- [x] All existing tests pass (413 total)

Fixes #947

🤖 Generated with [Claude Code](https://claude.com/claude-code)