### PR TITLE
feat: implement The Water boss blind (#946)

### DIFF
--- a/src/app/daily-card-game/domain/game/__tests__/the-water.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/the-water.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest'
+import { defaultGameState } from '@/app/daily-card-game/domain/game/default-game-state'
+import { reduceGame } from '@/app/daily-card-game/domain/game/reduce-game'
+import type { GameState } from '@/app/daily-card-game/domain/game/types'
+
+describe('The Water boss blind', () => {
+  function setupGame(overrides: Partial<GameState> = {}): GameState {
+    const game: GameState = structuredClone(defaultGameState)
+    game.rounds[game.roundIndex].bossBlindName = 'The Water'
+    return { ...game, ...overrides }
+  }
+
+  it('sets remainingDiscards to 0 on BOSS_BLIND_SELECTED', () => {
+    const game = setupGame()
+    game.gamePlayState.remainingDiscards = 3
+    const after = reduceGame(game, { type: 'BOSS_BLIND_SELECTED' })
+    expect(after.gamePlayState.remainingDiscards).toBe(0)
+  })
+})

--- a/src/app/daily-card-game/domain/round/boss-blinds.ts
+++ b/src/app/daily-card-game/domain/round/boss-blinds.ts
@@ -283,7 +283,28 @@ const theManacle: BossBlindDefinition = {
   ],
 }
 
-export const bossBlinds: BossBlindDefinition[] = [theHook, theOx, theNeedle, thePillar, theSerpent, thePlant, theTooth, theFlint, theMark, theMouth, theEye, theManacle]
+const theWater: BossBlindDefinition = {
+  type: 'bossBlind',
+  status: 'notStarted',
+  anteMultiplier: 2,
+  name: 'The Water',
+  description: 'Start with 0 discards',
+  image: 'the-water.png',
+  minimumAnte: 2,
+  baseReward: 5,
+  effects: [
+    {
+      event: { type: 'BOSS_BLIND_SELECTED' },
+      priority: 1,
+      condition: (ctx: EffectContext) => ctx.event.type === 'BOSS_BLIND_SELECTED',
+      apply: (ctx: EffectContext) => {
+        ctx.game.gamePlayState.remainingDiscards = 0
+      },
+    },
+  ],
+}
+
+export const bossBlinds: BossBlindDefinition[] = [theHook, theOx, theNeedle, thePillar, theSerpent, thePlant, theTooth, theFlint, theMark, theMouth, theEye, theManacle, theWater]
 
 /**
  


### PR DESCRIPTION
## Summary
- Adds The Water boss blind: start with 0 discards
- On BOSS_BLIND_SELECTED, sets remainingDiscards to 0
- Minimum ante: 2, not Matador-compatible

## Test plan
- [x] Remaining discards set to 0 on boss blind selection
- [x] All existing tests pass

Fixes #946

🤖 Generated with [Claude Code](https://claude.com/claude-code)