### PR TITLE
feat: implement The Psychic boss blind (#944)

### DIFF
--- a/src/app/daily-card-game/domain/game/__tests__/the-psychic.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/the-psychic.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest'
+import { defaultGameState } from '@/app/daily-card-game/domain/game/default-game-state'
+import { reduceGame } from '@/app/daily-card-game/domain/game/reduce-game'
+import type { GameState } from '@/app/daily-card-game/domain/game/types'
+
+describe('The Psychic boss blind', () => {
+  function setupGame(overrides: Partial<GameState> = {}): GameState {
+    const game: GameState = structuredClone(defaultGameState)
+    game.rounds[game.roundIndex].bossBlindName = 'The Psychic'
+    game.rounds[game.roundIndex].bossBlind.status = 'inProgress'
+    return { ...game, ...overrides }
+  }
+
+  it('zeroes out scoring when fewer than 5 cards are played', () => {
+    const game = setupGame()
+    // Set up 3 cards (fewer than 5)
+    game.cards = {
+      'c1': { id: 'c1', playingCardId: 'A_spades', isFaceUp: true, flags: {} } as any,
+      'c2': { id: 'c2', playingCardId: 'A_hearts', isFaceUp: true, flags: {} } as any,
+      'c3': { id: 'c3', playingCardId: 'A_diamonds', isFaceUp: true, flags: {} } as any,
+    }
+    game.gamePlayState.selectedCardIds = ['c1', 'c2', 'c3']
+    game.gamePlayState.handIds = ['c1', 'c2', 'c3']
+    game.ownedCardIds = ['c1', 'c2', 'c3']
+
+    const after = reduceGame(game, { type: 'HAND_SCORING_START' })
+    expect(after.gamePlayState.score.chips).toBe(0)
+    expect(after.gamePlayState.score.mult).toBe(0)
+    expect(after.gamePlayState.cardsToScore).toHaveLength(0)
+  })
+
+  it('allows scoring when exactly 5 cards are played', () => {
+    const game = setupGame()
+    game.cards = {
+      'c1': { id: 'c1', playingCardId: 'A_spades', isFaceUp: true, flags: {} } as any,
+      'c2': { id: 'c2', playingCardId: 'A_hearts', isFaceUp: true, flags: {} } as any,
+      'c3': { id: 'c3', playingCardId: '2_clubs', isFaceUp: true, flags: {} } as any,
+      'c4': { id: 'c4', playingCardId: '3_clubs', isFaceUp: true, flags: {} } as any,
+      'c5': { id: 'c5', playingCardId: '4_clubs', isFaceUp: true, flags: {} } as any,
+    }
+    game.gamePlayState.selectedCardIds = ['c1', 'c2', 'c3', 'c4', 'c5']
+    game.gamePlayState.handIds = ['c1', 'c2', 'c3', 'c4', 'c5']
+    game.ownedCardIds = ['c1', 'c2', 'c3', 'c4', 'c5']
+
+    const after = reduceGame(game, { type: 'HAND_SCORING_START' })
+    expect(after.gamePlayState.score.chips).toBeGreaterThan(0)
+  })
+})

--- a/src/app/daily-card-game/domain/round/boss-blinds.ts
+++ b/src/app/daily-card-game/domain/round/boss-blinds.ts
@@ -304,7 +304,31 @@ const theWater: BossBlindDefinition = {
   ],
 }
 
-export const bossBlinds: BossBlindDefinition[] = [theHook, theOx, theNeedle, thePillar, theSerpent, thePlant, theTooth, theFlint, theMark, theMouth, theEye, theManacle, theWater]
+const thePsychic: BossBlindDefinition = {
+  type: 'bossBlind',
+  status: 'notStarted',
+  anteMultiplier: 2,
+  name: 'The Psychic',
+  description: 'Must play 5 cards',
+  image: 'the-psychic.png',
+  minimumAnte: 1,
+  baseReward: 5,
+  effects: [
+    {
+      event: { type: 'HAND_SCORING_START' },
+      priority: 0,
+      condition: (ctx: EffectContext) => ctx.event.type === 'HAND_SCORING_START',
+      apply: (ctx: EffectContext) => {
+        if (ctx.game.gamePlayState.playedCardIds.length < 5) {
+          ctx.game.gamePlayState.score = { chips: 0, mult: 0 }
+          ctx.game.gamePlayState.cardsToScore = []
+        }
+      },
+    },
+  ],
+}
+
+export const bossBlinds: BossBlindDefinition[] = [theHook, theOx, theNeedle, thePillar, theSerpent, thePlant, theTooth, theFlint, theMark, theMouth, theEye, theManacle, theWater, thePsychic]
 
 /**
  


### PR DESCRIPTION
## Summary
- Adds The Psychic boss blind: must play 5 cards per hand
- On HAND_SCORING_START, zeroes out scoring if fewer than 5 cards played
- Minimum ante: 1, Matador-compatible

## Test plan
- [x] Fewer than 5 cards zeroes out scoring
- [x] Exactly 5 cards scores normally
- [x] All existing tests pass

Fixes #944

🤖 Generated with [Claude Code](https://claude.com/claude-code)