### PR TITLE
feat: implement The Arm boss blind (#943)

### DIFF
--- a/src/app/daily-card-game/domain/game/__tests__/the-arm.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/the-arm.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest'
+import { defaultGameState } from '@/app/daily-card-game/domain/game/default-game-state'
+import { reduceGame } from '@/app/daily-card-game/domain/game/reduce-game'
+import type { GameState } from '@/app/daily-card-game/domain/game/types'
+
+describe('The Arm boss blind', () => {
+  function setupGame(overrides: Partial<GameState> = {}): GameState {
+    const game: GameState = structuredClone(defaultGameState)
+    game.rounds[game.roundIndex].bossBlindName = 'The Arm'
+    game.rounds[game.roundIndex].bossBlind.status = 'inProgress'
+    return { ...game, ...overrides }
+  }
+
+  it('decreases played poker hand level by 1', () => {
+    const game = setupGame()
+    game.pokerHands.pair.level = 3
+    // Set up cards for a pair
+    game.cards = {
+      'c1': { id: 'c1', playingCardId: 'A_spades', isFaceUp: true, flags: {} } as any,
+      'c2': { id: 'c2', playingCardId: 'A_hearts', isFaceUp: true, flags: {} } as any,
+    }
+    game.gamePlayState.selectedCardIds = ['c1', 'c2']
+    game.gamePlayState.handIds = ['c1', 'c2']
+    game.ownedCardIds = ['c1', 'c2']
+
+    const after = reduceGame(game, { type: 'HAND_SCORING_START' })
+    expect(after.pokerHands.pair.level).toBe(2)
+  })
+
+  it('does not decrease below level 1', () => {
+    const game = setupGame()
+    game.pokerHands.pair.level = 1
+    game.cards = {
+      'c1': { id: 'c1', playingCardId: 'A_spades', isFaceUp: true, flags: {} } as any,
+      'c2': { id: 'c2', playingCardId: 'A_hearts', isFaceUp: true, flags: {} } as any,
+    }
+    game.gamePlayState.selectedCardIds = ['c1', 'c2']
+    game.gamePlayState.handIds = ['c1', 'c2']
+    game.ownedCardIds = ['c1', 'c2']
+
+    const after = reduceGame(game, { type: 'HAND_SCORING_START' })
+    expect(after.pokerHands.pair.level).toBe(1)
+  })
+})

--- a/src/app/daily-card-game/domain/round/boss-blinds.ts
+++ b/src/app/daily-card-game/domain/round/boss-blinds.ts
@@ -328,7 +328,32 @@ const thePsychic: BossBlindDefinition = {
   ],
 }
 
-export const bossBlinds: BossBlindDefinition[] = [theHook, theOx, theNeedle, thePillar, theSerpent, thePlant, theTooth, theFlint, theMark, theMouth, theEye, theManacle, theWater, thePsychic]
+const theArm: BossBlindDefinition = {
+  type: 'bossBlind',
+  status: 'notStarted',
+  anteMultiplier: 2,
+  name: 'The Arm',
+  description: 'Decrease level of played poker hand by 1',
+  image: 'the-arm.png',
+  minimumAnte: 2,
+  baseReward: 5,
+  effects: [
+    {
+      event: { type: 'HAND_SCORING_START' },
+      priority: 0,
+      condition: (ctx: EffectContext) => ctx.event.type === 'HAND_SCORING_START',
+      apply: (ctx: EffectContext) => {
+        const handId = ctx.game.gamePlayState.selectedHand?.[0]
+        if (!handId) return
+        if (ctx.game.pokerHands[handId].level > 1) {
+          ctx.game.pokerHands[handId].level -= 1
+        }
+      },
+    },
+  ],
+}
+
+export const bossBlinds: BossBlindDefinition[] = [theHook, theOx, theNeedle, thePillar, theSerpent, thePlant, theTooth, theFlint, theMark, theMouth, theEye, theManacle, theWater, thePsychic, theArm]
 
 /**
  


### PR DESCRIPTION
## Summary
- Adds The Arm boss blind: decrease level of played poker hand by 1 (min Level 1)
- Level reduction is permanent and happens before scoring
- Minimum ante: 2, Matador-compatible

## Test plan
- [x] Hand level decreases by 1 when played
- [x] Cannot go below Level 1
- [x] All existing tests pass

Fixes #943

🤖 Generated with [Claude Code](https://claude.com/claude-code)