### PR TITLE
feat: implement The Window boss blind (#940)

### DIFF
--- a/src/app/daily-card-game/domain/game/__tests__/the-window.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/the-window.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest'
+import { defaultGameState } from '@/app/daily-card-game/domain/game/default-game-state'
+import { reduceGame } from '@/app/daily-card-game/domain/game/reduce-game'
+import type { GameState } from '@/app/daily-card-game/domain/game/types'
+
+describe('The Window boss blind', () => {
+  function setupGame(overrides: Partial<GameState> = {}): GameState {
+    const game: GameState = structuredClone(defaultGameState)
+    game.rounds[game.roundIndex].bossBlindName = 'The Window'
+    game.rounds[game.roundIndex].bossBlind.status = 'inProgress'
+    return { ...game, ...overrides }
+  }
+
+  it('removes Diamond cards from cardsToScore', () => {
+    const game = setupGame()
+    game.cards = {
+      'c1': { id: 'c1', playingCardId: 'A_diamonds', isFaceUp: true, flags: {} } as any,
+      'c2': { id: 'c2', playingCardId: 'A_spades', isFaceUp: true, flags: {} } as any,
+    }
+    game.gamePlayState.selectedCardIds = ['c1', 'c2']
+    game.gamePlayState.handIds = ['c1', 'c2']
+    game.ownedCardIds = ['c1', 'c2']
+
+    const after = reduceGame(game, { type: 'HAND_SCORING_START' })
+    const scoredIds = after.gamePlayState.cardsToScore.map(c => c.id)
+    expect(scoredIds).not.toContain('c1')
+    expect(scoredIds).toContain('c2')
+  })
+
+  it('does not remove non-Diamond cards', () => {
+    const game = setupGame()
+    game.cards = {
+      'c1': { id: 'c1', playingCardId: 'A_spades', isFaceUp: true, flags: {} } as any,
+      'c2': { id: 'c2', playingCardId: 'A_hearts', isFaceUp: true, flags: {} } as any,
+    }
+    game.gamePlayState.selectedCardIds = ['c1', 'c2']
+    game.gamePlayState.handIds = ['c1', 'c2']
+    game.ownedCardIds = ['c1', 'c2']
+
+    const after = reduceGame(game, { type: 'HAND_SCORING_START' })
+    const scoredIds = after.gamePlayState.cardsToScore.map(c => c.id)
+    expect(scoredIds).toContain('c1')
+    expect(scoredIds).toContain('c2')
+  })
+})

--- a/src/app/daily-card-game/domain/round/boss-blinds.ts
+++ b/src/app/daily-card-game/domain/round/boss-blinds.ts
@@ -403,7 +403,30 @@ const theHead: BossBlindDefinition = {
   ],
 }
 
-export const bossBlinds: BossBlindDefinition[] = [theHook, theOx, theNeedle, thePillar, theSerpent, thePlant, theTooth, theFlint, theMark, theMouth, theEye, theManacle, theWater, thePsychic, theArm, theWheel, theHead]
+const theWindow: BossBlindDefinition = {
+  type: 'bossBlind',
+  status: 'notStarted',
+  anteMultiplier: 2,
+  name: 'The Window',
+  description: 'All Diamond cards are debuffed',
+  image: 'the-window.png',
+  minimumAnte: 1,
+  baseReward: 5,
+  effects: [
+    {
+      event: { type: 'HAND_SCORING_START' },
+      priority: 0,
+      condition: (ctx: EffectContext) => ctx.event.type === 'HAND_SCORING_START',
+      apply: (ctx: EffectContext) => {
+        ctx.game.gamePlayState.cardsToScore = ctx.game.gamePlayState.cardsToScore.filter(
+          card => playingCards[card.playingCardId].suit !== 'diamonds'
+        )
+      },
+    },
+  ],
+}
+
+export const bossBlinds: BossBlindDefinition[] = [theHook, theOx, theNeedle, thePillar, theSerpent, thePlant, theTooth, theFlint, theMark, theMouth, theEye, theManacle, theWater, thePsychic, theArm, theWheel, theHead, theWindow]
 
 /**
  


### PR DESCRIPTION
## Summary
- Adds The Window boss blind: all Diamond cards are debuffed (don't score)
- Uses HAND_SCORING_START to filter diamonds from cardsToScore
- Minimum ante: 1, Matador-compatible

## Test plan
- [x] Diamond cards removed from scoring
- [x] Non-Diamond cards score normally
- [x] All existing tests pass

Fixes #940

🤖 Generated with [Claude Code](https://claude.com/claude-code)