### PR TITLE
feat: implement The Goad boss blind (#939)

### DIFF
--- a/src/app/daily-card-game/domain/game/__tests__/the-goad.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/the-goad.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest'
+import { defaultGameState } from '@/app/daily-card-game/domain/game/default-game-state'
+import { reduceGame } from '@/app/daily-card-game/domain/game/reduce-game'
+import type { GameState } from '@/app/daily-card-game/domain/game/types'
+
+describe('The Goad boss blind', () => {
+  function setupGame(overrides: Partial<GameState> = {}): GameState {
+    const game: GameState = structuredClone(defaultGameState)
+    game.rounds[game.roundIndex].bossBlindName = 'The Goad'
+    game.rounds[game.roundIndex].bossBlind.status = 'inProgress'
+    return { ...game, ...overrides }
+  }
+
+  it('removes Spade cards from cardsToScore', () => {
+    const game = setupGame()
+    game.cards = {
+      'c1': { id: 'c1', playingCardId: 'A_spades', isFaceUp: true, flags: {} } as any,
+      'c2': { id: 'c2', playingCardId: 'A_hearts', isFaceUp: true, flags: {} } as any,
+    }
+    game.gamePlayState.selectedCardIds = ['c1', 'c2']
+    game.gamePlayState.handIds = ['c1', 'c2']
+    game.ownedCardIds = ['c1', 'c2']
+
+    const after = reduceGame(game, { type: 'HAND_SCORING_START' })
+    const scoredIds = after.gamePlayState.cardsToScore.map(c => c.id)
+    expect(scoredIds).not.toContain('c1')
+    expect(scoredIds).toContain('c2')
+  })
+
+  it('does not remove non-Spade cards', () => {
+    const game = setupGame()
+    game.cards = {
+      'c1': { id: 'c1', playingCardId: 'A_hearts', isFaceUp: true, flags: {} } as any,
+      'c2': { id: 'c2', playingCardId: 'A_diamonds', isFaceUp: true, flags: {} } as any,
+    }
+    game.gamePlayState.selectedCardIds = ['c1', 'c2']
+    game.gamePlayState.handIds = ['c1', 'c2']
+    game.ownedCardIds = ['c1', 'c2']
+
+    const after = reduceGame(game, { type: 'HAND_SCORING_START' })
+    const scoredIds = after.gamePlayState.cardsToScore.map(c => c.id)
+    expect(scoredIds).toContain('c1')
+    expect(scoredIds).toContain('c2')
+  })
+})

--- a/src/app/daily-card-game/domain/round/boss-blinds.ts
+++ b/src/app/daily-card-game/domain/round/boss-blinds.ts
@@ -426,7 +426,30 @@ const theWindow: BossBlindDefinition = {
   ],
 }
 
-export const bossBlinds: BossBlindDefinition[] = [theHook, theOx, theNeedle, thePillar, theSerpent, thePlant, theTooth, theFlint, theMark, theMouth, theEye, theManacle, theWater, thePsychic, theArm, theWheel, theHead, theWindow]
+const theGoad: BossBlindDefinition = {
+  type: 'bossBlind',
+  status: 'notStarted',
+  anteMultiplier: 2,
+  name: 'The Goad',
+  description: 'All Spade cards are debuffed',
+  image: 'the-goad.png',
+  minimumAnte: 1,
+  baseReward: 5,
+  effects: [
+    {
+      event: { type: 'HAND_SCORING_START' },
+      priority: 0,
+      condition: (ctx: EffectContext) => ctx.event.type === 'HAND_SCORING_START',
+      apply: (ctx: EffectContext) => {
+        ctx.game.gamePlayState.cardsToScore = ctx.game.gamePlayState.cardsToScore.filter(
+          card => playingCards[card.playingCardId].suit !== 'spades'
+        )
+      },
+    },
+  ],
+}
+
+export const bossBlinds: BossBlindDefinition[] = [theHook, theOx, theNeedle, thePillar, theSerpent, thePlant, theTooth, theFlint, theMark, theMouth, theEye, theManacle, theWater, thePsychic, theArm, theWheel, theHead, theWindow, theGoad]
 
 /**
  


### PR DESCRIPTION
## Summary
- Adds The Goad boss blind: all Spade cards are debuffed (don't score)
- Uses HAND_SCORING_START to filter spades from cardsToScore
- Minimum ante: 1, Matador-compatible

## Test plan
- [x] Spade cards removed from scoring
- [x] Non-Spade cards score normally
- [x] All existing tests pass

Fixes #939

🤖 Generated with [Claude Code](https://claude.com/claude-code)