### PR TITLE
feat: implement The Wall boss blind (#937)

### DIFF
--- a/src/app/daily-card-game/domain/game/__tests__/the-wall.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/the-wall.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest'
+import { bossBlinds } from '@/app/daily-card-game/domain/round/boss-blinds'
+
+describe('The Wall boss blind', () => {
+  const theWall = bossBlinds.find(b => b.name === 'The Wall')
+
+  it('exists in the boss blinds registry', () => {
+    expect(theWall).toBeDefined()
+  })
+
+  it('has 4x ante multiplier (extra large blind)', () => {
+    expect(theWall!.anteMultiplier).toBe(4)
+  })
+
+  it('has no effects (purely a score threshold increase)', () => {
+    expect(theWall!.effects).toHaveLength(0)
+  })
+})

--- a/src/app/daily-card-game/domain/round/boss-blinds.ts
+++ b/src/app/daily-card-game/domain/round/boss-blinds.ts
@@ -472,7 +472,19 @@ const theClub: BossBlindDefinition = {
   ],
 }
 
-export const bossBlinds: BossBlindDefinition[] = [theHook, theOx, theNeedle, thePillar, theSerpent, thePlant, theTooth, theFlint, theMark, theMouth, theEye, theManacle, theWater, thePsychic, theArm, theWheel, theHead, theWindow, theGoad, theClub]
+const theWall: BossBlindDefinition = {
+  type: 'bossBlind',
+  status: 'notStarted',
+  anteMultiplier: 4,
+  name: 'The Wall',
+  description: 'Extra large blind',
+  image: 'the-wall.png',
+  minimumAnte: 2,
+  baseReward: 5,
+  effects: [],
+}
+
+export const bossBlinds: BossBlindDefinition[] = [theHook, theOx, theNeedle, thePillar, theSerpent, thePlant, theTooth, theFlint, theMark, theMouth, theEye, theManacle, theWater, thePsychic, theArm, theWheel, theHead, theWindow, theGoad, theClub, theWall]
 
 /**
  


### PR DESCRIPTION
## Summary
- Adds The Wall boss blind: extra large blind (4x base instead of 2x)
- No effects, purely a higher score threshold
- Minimum ante: 2, not Matador-compatible

## Test plan
- [x] Exists in boss blinds registry
- [x] Has 4x ante multiplier
- [x] Has no effects
- [x] All existing tests pass

Fixes #937

🤖 Generated with [Claude Code](https://claude.com/claude-code)