### PR TITLE
feat: implement The House boss blind (#936)

### DIFF
--- a/src/app/daily-card-game/domain/game/__tests__/the-house.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/the-house.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest'
+import { defaultGameState } from '@/app/daily-card-game/domain/game/default-game-state'
+import { reduceGame } from '@/app/daily-card-game/domain/game/reduce-game'
+import type { GameState } from '@/app/daily-card-game/domain/game/types'
+
+describe('The House boss blind', () => {
+  function setupGame(overrides: Partial<GameState> = {}): GameState {
+    const game: GameState = structuredClone(defaultGameState)
+    game.rounds[game.roundIndex].bossBlindName = 'The House'
+    return { ...game, ...overrides }
+  }
+
+  it('flips all cards face down on BOSS_BLIND_SELECTED', () => {
+    const game = setupGame()
+    game.cards = {
+      'c1': { id: 'c1', playingCardId: 'A_spades', isFaceUp: true, flags: {} } as any,
+      'c2': { id: 'c2', playingCardId: '2_hearts', isFaceUp: true, flags: {} } as any,
+      'c3': { id: 'c3', playingCardId: 'K_diamonds', isFaceUp: true, flags: {} } as any,
+    }
+    game.ownedCardIds = ['c1', 'c2', 'c3']
+
+    const after = reduceGame(game, { type: 'BOSS_BLIND_SELECTED' })
+    expect(after.cards['c1'].isFaceUp).toBe(false)
+    expect(after.cards['c2'].isFaceUp).toBe(false)
+    expect(after.cards['c3'].isFaceUp).toBe(false)
+  })
+})

--- a/src/app/daily-card-game/domain/round/boss-blinds.ts
+++ b/src/app/daily-card-game/domain/round/boss-blinds.ts
@@ -484,7 +484,30 @@ const theWall: BossBlindDefinition = {
   effects: [],
 }
 
-export const bossBlinds: BossBlindDefinition[] = [theHook, theOx, theNeedle, thePillar, theSerpent, thePlant, theTooth, theFlint, theMark, theMouth, theEye, theManacle, theWater, thePsychic, theArm, theWheel, theHead, theWindow, theGoad, theClub, theWall]
+const theHouse: BossBlindDefinition = {
+  type: 'bossBlind',
+  status: 'notStarted',
+  anteMultiplier: 2,
+  name: 'The House',
+  description: 'First hand is drawn face down',
+  image: 'the-house.png',
+  minimumAnte: 2,
+  baseReward: 5,
+  effects: [
+    {
+      event: { type: 'BOSS_BLIND_SELECTED' },
+      priority: 1,
+      condition: (ctx: EffectContext) => ctx.event.type === 'BOSS_BLIND_SELECTED',
+      apply: (ctx: EffectContext) => {
+        for (const cardId of Object.keys(ctx.game.cards)) {
+          ctx.game.cards[cardId].isFaceUp = false
+        }
+      },
+    },
+  ],
+}
+
+export const bossBlinds: BossBlindDefinition[] = [theHook, theOx, theNeedle, thePillar, theSerpent, thePlant, theTooth, theFlint, theMark, theMouth, theEye, theManacle, theWater, thePsychic, theArm, theWheel, theHead, theWindow, theGoad, theClub, theWall, theHouse]
 
 /**
  


### PR DESCRIPTION
## Summary
- Adds The House boss blind: first hand is drawn face down (all cards flipped)
- On BOSS_BLIND_SELECTED, sets isFaceUp=false for all cards
- Minimum ante: 2, not Matador-compatible

## Test plan
- [x] All cards flipped face down on boss blind selection
- [x] All existing tests pass

Fixes #936

🤖 Generated with [Claude Code](https://claude.com/claude-code)