### PR TITLE
feat: implement The Fish boss blind (#945)

### DIFF
--- a/src/app/daily-card-game/domain/game/__tests__/the-fish.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/the-fish.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+import { defaultGameState } from '@/app/daily-card-game/domain/game/default-game-state'
+import { reduceGame } from '@/app/daily-card-game/domain/game/reduce-game'
+import type { GameState } from '@/app/daily-card-game/domain/game/types'
+
+describe('The Fish boss blind', () => {
+  function setupGame(overrides: Partial<GameState> = {}): GameState {
+    const game: GameState = structuredClone(defaultGameState)
+    game.rounds[game.roundIndex].bossBlindName = 'The Fish'
+    game.rounds[game.roundIndex].bossBlind.status = 'inProgress'
+    return { ...game, ...overrides }
+  }
+
+  it('flips hand cards face down after HAND_SCORING_DONE_CARD_SCORING', () => {
+    const game = setupGame()
+    game.cards = {
+      'c1': { id: 'c1', playingCardId: 'A_spades', isFaceUp: true, flags: {} } as any,
+      'c2': { id: 'c2', playingCardId: '2_hearts', isFaceUp: true, flags: {} } as any,
+      'c3': { id: 'c3', playingCardId: '3_clubs', isFaceUp: true, flags: {} } as any,
+    }
+    game.gamePlayState.handIds = ['c1', 'c2']
+    game.gamePlayState.selectedHand = ['pair', []]
+    game.ownedCardIds = ['c1', 'c2', 'c3']
+
+    const after = reduceGame(game, { type: 'HAND_SCORING_DONE_CARD_SCORING' })
+    // Cards in hand should be face down
+    expect(after.cards['c1'].isFaceUp).toBe(false)
+    expect(after.cards['c2'].isFaceUp).toBe(false)
+    // Card not in hand should remain face up
+    expect(after.cards['c3'].isFaceUp).toBe(true)
+  })
+})

--- a/src/app/daily-card-game/domain/round/boss-blinds.ts
+++ b/src/app/daily-card-game/domain/round/boss-blinds.ts
@@ -507,7 +507,32 @@ const theHouse: BossBlindDefinition = {
   ],
 }
 
-export const bossBlinds: BossBlindDefinition[] = [theHook, theOx, theNeedle, thePillar, theSerpent, thePlant, theTooth, theFlint, theMark, theMouth, theEye, theManacle, theWater, thePsychic, theArm, theWheel, theHead, theWindow, theGoad, theClub, theWall, theHouse]
+const theFish: BossBlindDefinition = {
+  type: 'bossBlind',
+  status: 'notStarted',
+  anteMultiplier: 2,
+  name: 'The Fish',
+  description: 'Cards drawn face down after each hand played',
+  image: 'the-fish.png',
+  minimumAnte: 2,
+  baseReward: 5,
+  effects: [
+    {
+      event: { type: 'HAND_SCORING_DONE_CARD_SCORING' },
+      priority: 1,
+      condition: (ctx: EffectContext) => ctx.event.type === 'HAND_SCORING_DONE_CARD_SCORING',
+      apply: (ctx: EffectContext) => {
+        for (const cardId of ctx.game.gamePlayState.handIds) {
+          if (ctx.game.cards[cardId]) {
+            ctx.game.cards[cardId].isFaceUp = false
+          }
+        }
+      },
+    },
+  ],
+}
+
+export const bossBlinds: BossBlindDefinition[] = [theHook, theOx, theNeedle, thePillar, theSerpent, thePlant, theTooth, theFlint, theMark, theMouth, theEye, theManacle, theWater, thePsychic, theArm, theWheel, theHead, theWindow, theGoad, theClub, theWall, theHouse, theFish]
 
 /**
  


### PR DESCRIPTION
## Summary
- Adds The Fish boss blind: cards drawn face down after each hand played
- On HAND_SCORING_DONE_CARD_SCORING, flips all cards in hand face down
- Minimum ante: 2, not Matador-compatible

## Test plan
- [x] Cards in hand flipped face down after scoring
- [x] Cards not in hand remain unaffected
- [x] All existing tests pass

Fixes #945

🤖 Generated with [Claude Code](https://claude.com/claude-code)