### PR TITLE
feat: implement D6 tag (#935)

### DIFF
--- a/src/app/daily-card-game/domain/game/__tests__/tag-d6.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/tag-d6.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+import { defaultGameState } from '@/app/daily-card-game/domain/game/default-game-state'
+import { reduceGame } from '@/app/daily-card-game/domain/game/reduce-game'
+import type { GameState } from '@/app/daily-card-game/domain/game/types'
+import { collectEffects } from '@/app/daily-card-game/domain/game/utils'
+
+describe('D6 tag', () => {
+  it('has effects registered in the tags definition', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.tags = [{ id: 'tag-1', tagType: 'd6', name: 'D6' } as any]
+    const effects = collectEffects(game)
+    const shopOpenEffects = effects.filter(e => e.event.type === 'SHOP_OPEN')
+    expect(shopOpenEffects.length).toBeGreaterThan(0)
+  })
+
+  it('grants free rerolls on SHOP_OPEN', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.tags = [{ id: 'tag-1', tagType: 'd6', name: 'D6' } as any]
+    game.shopState.freeRerolls = 0
+
+    const after = reduceGame(game, { type: 'SHOP_OPEN' })
+    expect(after.shopState.freeRerolls).toBeGreaterThanOrEqual(100)
+  })
+
+  it('removes the D6 tag after use', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.tags = [{ id: 'tag-1', tagType: 'd6', name: 'D6' } as any]
+
+    const after = reduceGame(game, { type: 'SHOP_OPEN' })
+    expect(after.tags.find(t => t.tagType === 'd6')).toBeUndefined()
+  })
+})

--- a/src/app/daily-card-game/domain/tag/tags.ts
+++ b/src/app/daily-card-game/domain/tag/tags.ts
@@ -182,7 +182,19 @@ const d6: TagDefinition = {
   name: 'D6',
   benefit: 'In the next Shop, Rerolls start at $0.',
   minimumAnte: 1,
-  effects: [],
+  effects: [
+    {
+      event: { type: 'SHOP_OPEN' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        ctx.game.shopState.freeRerolls += 100
+        const d6Tag = ctx.game.tags.find(tag => tag.tagType === 'd6')
+        if (d6Tag) {
+          ctx.game.tags = ctx.game.tags.filter(tag => tag.id !== d6Tag.id)
+        }
+      },
+    },
+  ],
 }
 
 const topUp: TagDefinition = {
@@ -245,6 +257,7 @@ export const tags: Record<TagType, TagDefinition> = {
 }
 export const implementedTags: Partial<Record<TagType, TagDefinition>> = {
   uncommon,
+  d6,
 }
 
 /* Tags


### PR DESCRIPTION
## Summary
- Implements D6 tag: in the next shop, rerolls start at $0
- On SHOP_OPEN, grants 100 free rerolls and removes the tag
- Added d6 to implementedTags registry

## Test plan
- [x] D6 effects registered in collectEffects
- [x] Free rerolls granted on shop open
- [x] Tag removed after use
- [x] All existing tests pass

Fixes #935

🤖 Generated with [Claude Code](https://claude.com/claude-code)