### PR TITLE
feat: implement Economy tag (#929)

### DIFF
--- a/src/app/daily-card-game/domain/game/__tests__/tag-economy.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/tag-economy.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+import { defaultGameState } from '@/app/daily-card-game/domain/game/default-game-state'
+import { reduceGame } from '@/app/daily-card-game/domain/game/reduce-game'
+import type { GameState } from '@/app/daily-card-game/domain/game/types'
+
+describe('Economy tag', () => {
+  it('doubles money on SHOP_OPEN (max +$40)', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.tags = [{ id: 'tag-1', tagType: 'economy', name: 'Economy' } as any]
+    game.money = 20
+
+    const after = reduceGame(game, { type: 'SHOP_OPEN' })
+    expect(after.money).toBe(40) // 20 + 20
+  })
+
+  it('caps gain at $40', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.tags = [{ id: 'tag-1', tagType: 'economy', name: 'Economy' } as any]
+    game.money = 60
+
+    const after = reduceGame(game, { type: 'SHOP_OPEN' })
+    expect(after.money).toBe(100) // 60 + 40 (capped)
+  })
+
+  it('removes the Economy tag after use', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.tags = [{ id: 'tag-1', tagType: 'economy', name: 'Economy' } as any]
+    game.money = 10
+
+    const after = reduceGame(game, { type: 'SHOP_OPEN' })
+    expect(after.tags.find(t => t.tagType === 'economy')).toBeUndefined()
+  })
+})

--- a/src/app/daily-card-game/domain/tag/tags.ts
+++ b/src/app/daily-card-game/domain/tag/tags.ts
@@ -226,7 +226,20 @@ const economy: TagDefinition = {
   name: 'Economy',
   benefit: 'Doubles your money (adds a maximum of $40).',
   minimumAnte: 1,
-  effects: [],
+  effects: [
+    {
+      event: { type: 'SHOP_OPEN' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        const gain = Math.min(ctx.game.money, 40)
+        ctx.game.money += gain
+        const economyTag = ctx.game.tags.find(tag => tag.tagType === 'economy')
+        if (economyTag) {
+          ctx.game.tags = ctx.game.tags.filter(tag => tag.id !== economyTag.id)
+        }
+      },
+    },
+  ],
 }
 
 export const tags: Record<TagType, TagDefinition> = {
@@ -259,6 +272,7 @@ export const implementedTags: Partial<Record<TagType, TagDefinition>> = {
   uncommon,
   d6,
   coupon,
+  economy,
 }
 
 /* Tags


### PR DESCRIPTION
## Summary
- Implements Economy tag: doubles your money (max +$40)
- On SHOP_OPEN, adds min(currentMoney, 40) to money
- Tag consumed after use

## Test plan
- [x] Doubles money ($20 → $40)
- [x] Caps gain at $40 ($60 → $100, not $120)
- [x] Tag removed after use
- [x] All existing tests pass

Fixes #929

🤖 Generated with [Claude Code](https://claude.com/claude-code)