### PR TITLE
feat: implement Juggle tag (#931)

### DIFF
--- a/src/app/daily-card-game/domain/game/__tests__/tag-juggle.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/tag-juggle.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest'
+import { defaultGameState } from '@/app/daily-card-game/domain/game/default-game-state'
+import { reduceGame } from '@/app/daily-card-game/domain/game/reduce-game'
+import type { GameState } from '@/app/daily-card-game/domain/game/types'
+
+describe('Juggle tag', () => {
+  it('adds +3 to handSizeModifier on SHOP_OPEN', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.tags = [{ id: 'tag-1', tagType: 'juggle', name: 'Juggle' } as any]
+    game.handSizeModifier = 0
+
+    const after = reduceGame(game, { type: 'SHOP_OPEN' })
+    expect(after.handSizeModifier).toBe(3)
+  })
+
+  it('removes the Juggle tag after use', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.tags = [{ id: 'tag-1', tagType: 'juggle', name: 'Juggle' } as any]
+
+    const after = reduceGame(game, { type: 'SHOP_OPEN' })
+    expect(after.tags.find(t => t.tagType === 'juggle')).toBeUndefined()
+  })
+})

--- a/src/app/daily-card-game/domain/tag/tags.ts
+++ b/src/app/daily-card-game/domain/tag/tags.ts
@@ -174,7 +174,19 @@ const juggle: TagDefinition = {
   name: 'Juggle',
   benefit: '+3 Hand Size for the next round only.',
   minimumAnte: 1,
-  effects: [],
+  effects: [
+    {
+      event: { type: 'SHOP_OPEN' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        ctx.game.handSizeModifier += 3
+        const juggleTag = ctx.game.tags.find(tag => tag.tagType === 'juggle')
+        if (juggleTag) {
+          ctx.game.tags = ctx.game.tags.filter(tag => tag.id !== juggleTag.id)
+        }
+      },
+    },
+  ],
 }
 
 const d6: TagDefinition = {
@@ -273,6 +285,7 @@ export const implementedTags: Partial<Record<TagType, TagDefinition>> = {
   d6,
   coupon,
   economy,
+  juggle,
 }
 
 /* Tags


### PR DESCRIPTION
## Summary
- Implements Juggle tag: +3 Hand Size for the next round
- On SHOP_OPEN, adds 3 to handSizeModifier
- Tag consumed after use

## Test plan
- [x] handSizeModifier increased by 3
- [x] Tag removed after use
- [x] All existing tests pass

Fixes #931

🤖 Generated with [Claude Code](https://claude.com/claude-code)