### PR TITLE
feat: implement Handy tag (#925)

### DIFF
--- a/src/app/daily-card-game/domain/game/__tests__/tag-handy.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/tag-handy.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest'
+import { defaultGameState } from '@/app/daily-card-game/domain/game/default-game-state'
+import { reduceGame } from '@/app/daily-card-game/domain/game/reduce-game'
+import type { GameState } from '@/app/daily-card-game/domain/game/types'
+
+describe('Handy tag', () => {
+  it('gains $1 per hand played this run on SHOP_OPEN', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.tags = [{ id: 'tag-1', tagType: 'handy', name: 'Handy' } as any]
+    game.money = 5
+    game.handsPlayed = 12
+
+    const after = reduceGame(game, { type: 'SHOP_OPEN' })
+    expect(after.money).toBe(17) // 5 + 12
+  })
+
+  it('removes the Handy tag after use', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.tags = [{ id: 'tag-1', tagType: 'handy', name: 'Handy' } as any]
+    game.handsPlayed = 5
+
+    const after = reduceGame(game, { type: 'SHOP_OPEN' })
+    expect(after.tags.find(t => t.tagType === 'handy')).toBeUndefined()
+  })
+})

--- a/src/app/daily-card-game/domain/tag/tags.ts
+++ b/src/app/daily-card-game/domain/tag/tags.ts
@@ -134,7 +134,19 @@ const handy: TagDefinition = {
   name: 'Handy',
   benefit: 'Gain $1 for each hand played this run.',
   minimumAnte: 2,
-  effects: [],
+  effects: [
+    {
+      event: { type: 'SHOP_OPEN' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        ctx.game.money += ctx.game.handsPlayed
+        const handyTag = ctx.game.tags.find(tag => tag.tagType === 'handy')
+        if (handyTag) {
+          ctx.game.tags = ctx.game.tags.filter(tag => tag.id !== handyTag.id)
+        }
+      },
+    },
+  ],
 }
 
 const garbage: TagDefinition = {
@@ -286,6 +298,7 @@ export const implementedTags: Partial<Record<TagType, TagDefinition>> = {
   coupon,
   economy,
   juggle,
+  handy,
 }
 
 /* Tags


### PR DESCRIPTION
## Summary
- Implements Handy tag: gain $1 for each hand played this run
- On SHOP_OPEN, adds handsPlayed to money
- Tag consumed after use

## Test plan
- [x] Money increased by handsPlayed amount
- [x] Tag removed after use
- [x] All existing tests pass

Fixes #925

🤖 Generated with [Claude Code](https://claude.com/claude-code)