### PR TITLE
feat: implement Garbage tag (#927)

### DIFF
--- a/src/app/daily-card-game/domain/game/__tests__/tag-garbage.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/tag-garbage.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest'
+import { defaultGameState } from '@/app/daily-card-game/domain/game/default-game-state'
+import { reduceGame } from '@/app/daily-card-game/domain/game/reduce-game'
+import type { GameState } from '@/app/daily-card-game/domain/game/types'
+
+describe('Garbage tag', () => {
+  it('gains $1 per remaining discard on SHOP_OPEN', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.tags = [{ id: 'tag-1', tagType: 'garbage', name: 'Garbage' } as any]
+    game.money = 5
+    game.gamePlayState.remainingDiscards = 4
+
+    const after = reduceGame(game, { type: 'SHOP_OPEN' })
+    expect(after.money).toBe(9) // 5 + 4
+  })
+
+  it('removes the Garbage tag after use', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.tags = [{ id: 'tag-1', tagType: 'garbage', name: 'Garbage' } as any]
+    game.gamePlayState.remainingDiscards = 2
+
+    const after = reduceGame(game, { type: 'SHOP_OPEN' })
+    expect(after.tags.find(t => t.tagType === 'garbage')).toBeUndefined()
+  })
+})

--- a/src/app/daily-card-game/domain/tag/tags.ts
+++ b/src/app/daily-card-game/domain/tag/tags.ts
@@ -154,7 +154,19 @@ const garbage: TagDefinition = {
   name: 'Garbage',
   benefit: 'Gain $1 for each unused discard this run.',
   minimumAnte: 2,
-  effects: [],
+  effects: [
+    {
+      event: { type: 'SHOP_OPEN' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        ctx.game.money += ctx.game.gamePlayState.remainingDiscards
+        const garbageTag = ctx.game.tags.find(tag => tag.tagType === 'garbage')
+        if (garbageTag) {
+          ctx.game.tags = ctx.game.tags.filter(tag => tag.id !== garbageTag.id)
+        }
+      },
+    },
+  ],
 }
 
 const ethereal: TagDefinition = {
@@ -299,6 +311,7 @@ export const implementedTags: Partial<Record<TagType, TagDefinition>> = {
   economy,
   juggle,
   handy,
+  garbage,
 }
 
 /* Tags


### PR DESCRIPTION
## Summary
- Implements Garbage tag: gain $1 for each unused discard
- On SHOP_OPEN, adds remainingDiscards to money
- Tag consumed after use

## Test plan
- [x] Money increased by remainingDiscards
- [x] Tag removed after use
- [x] All existing tests pass

Fixes #927

🤖 Generated with [Claude Code](https://claude.com/claude-code)