### PR TITLE
feat: implement Top-up tag (#932)

### DIFF
--- a/src/app/daily-card-game/domain/game/__tests__/tag-topup.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/tag-topup.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+import { defaultGameState } from '@/app/daily-card-game/domain/game/default-game-state'
+import { reduceGame } from '@/app/daily-card-game/domain/game/reduce-game'
+import type { GameState } from '@/app/daily-card-game/domain/game/types'
+
+describe('Top-up tag', () => {
+  it('adds up to 2 common jokers on SHOP_OPEN', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.tags = [{ id: 'tag-1', tagType: 'topUp', name: 'Top-up' } as any]
+    game.jokers = []
+    game.maxJokers = 5
+
+    const after = reduceGame(game, { type: 'SHOP_OPEN' })
+    expect(after.jokers.length).toBe(2)
+  })
+
+  it('respects max joker slots', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.tags = [{ id: 'tag-1', tagType: 'topUp', name: 'Top-up' } as any]
+    game.jokers = Array(4).fill({ jokerId: 'dummy' }) as any
+    game.maxJokers = 5
+
+    const after = reduceGame(game, { type: 'SHOP_OPEN' })
+    expect(after.jokers.length).toBe(5) // only 1 added (4 + 1 = 5 max)
+  })
+
+  it('removes the Top-up tag after use', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.tags = [{ id: 'tag-1', tagType: 'topUp', name: 'Top-up' } as any]
+
+    const after = reduceGame(game, { type: 'SHOP_OPEN' })
+    expect(after.tags.find(t => t.tagType === 'topUp')).toBeUndefined()
+  })
+})

--- a/src/app/daily-card-game/domain/joker/utils.ts
+++ b/src/app/daily-card-game/domain/joker/utils.ts
@@ -166,3 +166,36 @@ export const getRandomUncommonJoker = (
   })
   return filteredJokers[randomCardIndices[0]]
 }
+
+const isCommonPredicate: JokerPredicate = (joker: JokerDefinition): boolean => {
+  return joker.rarity === 'common'
+}
+
+export const getRandomCommonJoker = (
+  game: GameState,
+  seedSuffix: string = '',
+  allowDuplicates: boolean = false
+): JokerDefinition => {
+  const allJokers = Object.values(jokers)
+  const predicates: JokerPredicate[] = [isCommonPredicate]
+  if (!allowDuplicates) {
+    predicates.push(isNotOwnedPredicate)
+  }
+  const filteredJokers = allJokers.filter(joker =>
+    predicates.every(predicate => predicate(joker, game))
+  )
+  const seed = buildSeedString([
+    game.gameSeed,
+    game.roundIndex.toString(),
+    game.shopState.rerollsUsed.toString(),
+    'common',
+    seedSuffix,
+  ])
+  const randomCardIndices = getRandomNumbersWithSeed({
+    seed,
+    min: 0,
+    max: filteredJokers.length - 1,
+    numberOfNumbers: 1,
+  })
+  return filteredJokers[randomCardIndices[0]]
+}

--- a/src/app/daily-card-game/domain/tag/tags.ts
+++ b/src/app/daily-card-game/domain/tag/tags.ts
@@ -1,5 +1,5 @@
 import type { EffectContext } from '@/app/daily-card-game/domain/events/types'
-import { getRandomUncommonJoker, initializeJoker } from '@/app/daily-card-game/domain/joker/utils'
+import { getRandomCommonJoker, getRandomUncommonJoker, initializeJoker } from '@/app/daily-card-game/domain/joker/utils'
 
 import { TagDefinition, TagType } from './types'
 
@@ -238,7 +238,26 @@ const topUp: TagDefinition = {
   name: 'Top-up',
   benefit: 'Create up to 2 Common Jokers (if you have space).',
   minimumAnte: 2,
-  effects: [],
+  effects: [
+    {
+      event: { type: 'SHOP_OPEN' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        const jokersToAdd = Math.min(2, ctx.game.maxJokers - ctx.game.jokers.length)
+        for (let i = 0; i < jokersToAdd; i++) {
+          const jokerDef = getRandomCommonJoker(ctx.game, String(i))
+          if (jokerDef) {
+            const jokerState = initializeJoker(jokerDef, ctx.game)
+            ctx.game.jokers.push(jokerState)
+          }
+        }
+        const topUpTag = ctx.game.tags.find(tag => tag.tagType === 'topUp')
+        if (topUpTag) {
+          ctx.game.tags = ctx.game.tags.filter(tag => tag.id !== topUpTag.id)
+        }
+      },
+    },
+  ],
 }
 
 const speed: TagDefinition = {
@@ -312,6 +331,7 @@ export const implementedTags: Partial<Record<TagType, TagDefinition>> = {
   juggle,
   handy,
   garbage,
+  topUp,
 }
 
 /* Tags


### PR DESCRIPTION
## Summary
- Implements Top-up tag: create up to 2 free Common Jokers (if you have space)
- Added getRandomCommonJoker utility function
- On SHOP_OPEN, adds jokers directly to player's joker slots
- Tag consumed after use

## Test plan
- [x] Adds up to 2 common jokers
- [x] Respects max joker slots
- [x] Tag removed after use
- [x] All existing tests pass

Fixes #932

🤖 Generated with [Claude Code](https://claude.com/claude-code)