### PR TITLE
feat: implement Orbital tag (#933)

### DIFF
--- a/src/app/daily-card-game/domain/game/__tests__/tag-orbital.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/tag-orbital.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest'
+import { defaultGameState } from '@/app/daily-card-game/domain/game/default-game-state'
+import { reduceGame } from '@/app/daily-card-game/domain/game/reduce-game'
+import type { GameState } from '@/app/daily-card-game/domain/game/types'
+
+describe('Orbital tag', () => {
+  it('upgrades a random poker hand by 3 levels on SHOP_OPEN', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.tags = [{ id: 'tag-1', tagType: 'orbital', name: 'Orbital' } as any]
+
+    // Record initial total levels
+    const initialTotalLevel = Object.values(game.pokerHands).reduce((sum, h) => sum + h.level, 0)
+
+    const after = reduceGame(game, { type: 'SHOP_OPEN' })
+    const afterTotalLevel = Object.values(after.pokerHands).reduce((sum, h) => sum + h.level, 0)
+
+    expect(afterTotalLevel).toBe(initialTotalLevel + 3)
+  })
+
+  it('removes the Orbital tag after use', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.tags = [{ id: 'tag-1', tagType: 'orbital', name: 'Orbital' } as any]
+
+    const after = reduceGame(game, { type: 'SHOP_OPEN' })
+    expect(after.tags.find(t => t.tagType === 'orbital')).toBeUndefined()
+  })
+})

--- a/src/app/daily-card-game/domain/tag/tags.ts
+++ b/src/app/daily-card-game/domain/tag/tags.ts
@@ -1,5 +1,6 @@
 import type { EffectContext } from '@/app/daily-card-game/domain/events/types'
 import { getRandomCommonJoker, getRandomUncommonJoker, initializeJoker } from '@/app/daily-card-game/domain/joker/utils'
+import { buildSeedString, getRandomNumberWithSeed } from '@/app/daily-card-game/domain/randomness'
 
 import { TagDefinition, TagType } from './types'
 
@@ -273,7 +274,23 @@ const orbital: TagDefinition = {
   name: 'Orbital',
   benefit: 'Upgrades a specified random Poker Hand by three levels.',
   minimumAnte: 2,
-  effects: [],
+  effects: [
+    {
+      event: { type: 'SHOP_OPEN' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        const handIds = Object.keys(ctx.game.pokerHands)
+        const seed = buildSeedString([ctx.game.gameSeed, ctx.game.roundIndex.toString(), 'orbital'])
+        const randomIndex = getRandomNumberWithSeed(seed, 0, handIds.length - 1)
+        const handId = handIds[randomIndex]
+        ctx.game.pokerHands[handId as keyof typeof ctx.game.pokerHands].level += 3
+        const orbitalTag = ctx.game.tags.find(tag => tag.tagType === 'orbital')
+        if (orbitalTag) {
+          ctx.game.tags = ctx.game.tags.filter(tag => tag.id !== orbitalTag.id)
+        }
+      },
+    },
+  ],
 }
 
 const economy: TagDefinition = {
@@ -332,6 +349,7 @@ export const implementedTags: Partial<Record<TagType, TagDefinition>> = {
   handy,
   garbage,
   topUp,
+  orbital,
 }
 
 /* Tags


### PR DESCRIPTION
## Summary
- Implements Orbital tag: upgrades a random poker hand by 3 levels
- On SHOP_OPEN, picks a random hand using seeded RNG and adds 3 levels
- Tag consumed after use

## Test plan
- [x] Total poker hand levels increase by 3
- [x] Tag removed after use
- [x] All existing tests pass

Fixes #933

🤖 Generated with [Claude Code](https://claude.com/claude-code)