### PR TITLE
feat: implement Green Deck (#966)

### DIFF
--- a/src/app/daily-card-game/domain/decks/__tests__/green-deck.test.ts
+++ b/src/app/daily-card-game/domain/decks/__tests__/green-deck.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest'
+import { applyDeckModifiers, defaultGameState } from '@/app/daily-card-game/domain/game/default-game-state'
+import { decks } from '@/app/daily-card-game/domain/decks/decks'
+
+describe('Green Deck', () => {
+  it('exists in the decks registry', () => {
+    expect(decks.greenDeck).toBeDefined()
+    expect(decks.greenDeck.name).toBe('Green Deck')
+  })
+
+  it('sets maxInterest to 0', () => {
+    const game = applyDeckModifiers(structuredClone(defaultGameState), decks.greenDeck)
+    expect(game.maxInterest).toBe(0)
+  })
+
+  it('uses standard 52 cards', () => {
+    expect(decks.greenDeck.cards.length).toBe(52)
+  })
+})

--- a/src/app/daily-card-game/domain/decks/decks.ts
+++ b/src/app/daily-card-game/domain/decks/decks.ts
@@ -6,6 +6,7 @@ import { abandonedDeck } from './abandoned-deck'
 import { blackDeck } from './black-deck'
 import { blueDeck } from './blue-deck'
 import { checkeredDeck } from './checkered-deck'
+import { greenDeck } from './green-deck'
 import { paintedDeck } from './painted-deck'
 import { pokerDeck } from './poker-deck'
 import { redDeck } from './red-deck'
@@ -21,6 +22,7 @@ export const decks: Record<string, DeckDefinition> = {
   abandonedDeck: abandonedDeck,
   checkeredDeck: checkeredDeck,
   paintedDeck: paintedDeck,
+  greenDeck: greenDeck,
 }
 
 export const initialDeckStates = (game: GameState): Record<string, PlayingCardState[]> => {

--- a/src/app/daily-card-game/domain/decks/green-deck.ts
+++ b/src/app/daily-card-game/domain/decks/green-deck.ts
@@ -1,0 +1,13 @@
+import { pokerDeckDefinition } from './poker-deck'
+import { DeckDefinition } from './types'
+
+export const greenDeck: DeckDefinition = {
+  id: 'greenDeck',
+  name: 'Green Deck',
+  description:
+    'No interest at end of round. Earn $1 for each remaining hand and $1 for each remaining discard at end of round.',
+  cards: pokerDeckDefinition,
+  modifiers: {
+    maxInterest: -5, // Sets maxInterest to 0 (default is 5)
+  },
+}

--- a/src/app/daily-card-game/domain/decks/types.ts
+++ b/src/app/daily-card-game/domain/decks/types.ts
@@ -15,4 +15,5 @@ export interface DeckModifiers {
   maxJokers?: number
   maxConsumables?: number
   handSizeModifier?: number
+  maxInterest?: number
 }

--- a/src/app/daily-card-game/domain/game/default-game-state.ts
+++ b/src/app/daily-card-game/domain/game/default-game-state.ts
@@ -145,6 +145,7 @@ export function applyDeckModifiers(state: GameState, deck: DeckDefinition): Game
     maxJokers: state.maxJokers + (modifiers.maxJokers ?? 0),
     maxConsumables: state.maxConsumables + (modifiers.maxConsumables ?? 0),
     handSizeModifier: state.handSizeModifier + (modifiers.handSizeModifier ?? 0),
+    maxInterest: state.maxInterest + (modifiers.maxInterest ?? 0),
     gamePlayState: {
       ...state.gamePlayState,
       remainingDiscards:

--- a/src/app/daily-card-game/domain/game/handlers.ts
+++ b/src/app/daily-card-game/domain/game/handlers.ts
@@ -143,6 +143,10 @@ export function handleHandScoringEnd(draft: Draft<GameState>, event: GameEvent) 
     if (draft.gamePlayState.remainingHands > 0) {
       currentBlind.additionalRewards.push(['Remaining Hands', draft.gamePlayState.remainingHands])
     }
+    // Green Deck: earn $1 per remaining discard
+    if (draft.selectedDeck === 'greenDeck' && draft.gamePlayState.remainingDiscards > 0) {
+      currentBlind.additionalRewards.push(['Remaining Discards', draft.gamePlayState.remainingDiscards])
+    }
     const interest = calculateInterest(draft)
 
     if (interest > 0) {


### PR DESCRIPTION
## Summary
- Adds Green Deck: no interest, earn $1 per remaining hand and discard at end of round
- Added maxInterest to DeckModifiers type
- Green Deck sets maxInterest to 0 (via -5 modifier)
- Added remaining discards payout in blind rewards handler for Green Deck

## Test plan
- [x] Green Deck exists in registry
- [x] maxInterest set to 0 when Green Deck modifiers applied
- [x] Standard 52 cards
- [x] All existing tests pass

Fixes #966

🤖 Generated with [Claude Code](https://claude.com/claude-code)