### PR TITLE
feat: implement Violet Vessel showdown boss blind (#960)

### DIFF
--- a/src/app/daily-card-game/domain/game/__tests__/violet-vessel.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/violet-vessel.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest'
+import { bossBlinds } from '@/app/daily-card-game/domain/round/boss-blinds'
+
+describe('Violet Vessel showdown boss blind', () => {
+  const violetVessel = bossBlinds.find(b => b.name === 'Violet Vessel')
+
+  it('exists in the boss blinds registry', () => {
+    expect(violetVessel).toBeDefined()
+  })
+
+  it('has 6x ante multiplier (very large blind)', () => {
+    expect(violetVessel!.anteMultiplier).toBe(6)
+  })
+
+  it('has minimum ante of 8 (showdown boss)', () => {
+    expect(violetVessel!.minimumAnte).toBe(8)
+  })
+
+  it('has base reward of $8', () => {
+    expect(violetVessel!.baseReward).toBe(8)
+  })
+})

--- a/src/app/daily-card-game/domain/round/boss-blinds.ts
+++ b/src/app/daily-card-game/domain/round/boss-blinds.ts
@@ -532,7 +532,19 @@ const theFish: BossBlindDefinition = {
   ],
 }
 
-export const bossBlinds: BossBlindDefinition[] = [theHook, theOx, theNeedle, thePillar, theSerpent, thePlant, theTooth, theFlint, theMark, theMouth, theEye, theManacle, theWater, thePsychic, theArm, theWheel, theHead, theWindow, theGoad, theClub, theWall, theHouse, theFish]
+const violetVessel: BossBlindDefinition = {
+  type: 'bossBlind',
+  status: 'notStarted',
+  anteMultiplier: 6,
+  name: 'Violet Vessel',
+  description: 'Very large blind',
+  image: 'violet-vessel.png',
+  minimumAnte: 8,
+  baseReward: 8,
+  effects: [],
+}
+
+export const bossBlinds: BossBlindDefinition[] = [theHook, theOx, theNeedle, thePillar, theSerpent, thePlant, theTooth, theFlint, theMark, theMouth, theEye, theManacle, theWater, thePsychic, theArm, theWheel, theHead, theWindow, theGoad, theClub, theWall, theHouse, theFish, violetVessel]
 
 /**
  


### PR DESCRIPTION
## Summary
- Adds Violet Vessel showdown boss blind: very large blind (6x base)
- Minimum ante: 8, base reward: $8
- No effects, purely a higher score threshold (like The Wall but bigger)

## Test plan
- [x] Exists in registry
- [x] 6x ante multiplier
- [x] Minimum ante 8
- [x] Base reward $8
- [x] All existing tests pass

Fixes #960

🤖 Generated with [Claude Code](https://claude.com/claude-code)