### PR TITLE
feat: implement Amber Acorn showdown boss blind (#958)

### DIFF
--- a/src/app/daily-card-game/domain/game/__tests__/amber-acorn.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/amber-acorn.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest'
+import { defaultGameState } from '@/app/daily-card-game/domain/game/default-game-state'
+import { reduceGame } from '@/app/daily-card-game/domain/game/reduce-game'
+import type { GameState } from '@/app/daily-card-game/domain/game/types'
+
+describe('Amber Acorn showdown boss blind', () => {
+  function setupGame(overrides: Partial<GameState> = {}): GameState {
+    const game: GameState = structuredClone(defaultGameState)
+    game.rounds[game.roundIndex].bossBlindName = 'Amber Acorn'
+    return { ...game, ...overrides }
+  }
+
+  it('flips all jokers face down on BOSS_BLIND_SELECTED', () => {
+    const game = setupGame()
+    game.jokers = [
+      { id: 'j1', jokerId: 'joker', isFaceUp: true } as any,
+      { id: 'j2', jokerId: 'jolly', isFaceUp: true } as any,
+      { id: 'j3', jokerId: 'zany', isFaceUp: true } as any,
+    ]
+
+    const after = reduceGame(game, { type: 'BOSS_BLIND_SELECTED' })
+    for (const joker of after.jokers) {
+      expect(joker.isFaceUp).toBe(false)
+    }
+  })
+
+  it('shuffles joker order deterministically', () => {
+    const game = setupGame()
+    game.gameSeed = 'test-shuffle-seed'
+    game.jokers = [
+      { id: 'j1', jokerId: 'joker', isFaceUp: true } as any,
+      { id: 'j2', jokerId: 'jolly', isFaceUp: true } as any,
+      { id: 'j3', jokerId: 'zany', isFaceUp: true } as any,
+    ]
+
+    const after1 = reduceGame(game, { type: 'BOSS_BLIND_SELECTED' })
+
+    // Run again with same seed - should produce same shuffle
+    const game2 = setupGame()
+    game2.gameSeed = 'test-shuffle-seed'
+    game2.jokers = [
+      { id: 'j1', jokerId: 'joker', isFaceUp: true } as any,
+      { id: 'j2', jokerId: 'jolly', isFaceUp: true } as any,
+      { id: 'j3', jokerId: 'zany', isFaceUp: true } as any,
+    ]
+
+    const after2 = reduceGame(game2, { type: 'BOSS_BLIND_SELECTED' })
+    expect(after1.jokers.map(j => j.id)).toEqual(after2.jokers.map(j => j.id))
+  })
+})

--- a/src/app/daily-card-game/domain/round/boss-blinds.ts
+++ b/src/app/daily-card-game/domain/round/boss-blinds.ts
@@ -544,7 +544,41 @@ const violetVessel: BossBlindDefinition = {
   effects: [],
 }
 
-export const bossBlinds: BossBlindDefinition[] = [theHook, theOx, theNeedle, thePillar, theSerpent, thePlant, theTooth, theFlint, theMark, theMouth, theEye, theManacle, theWater, thePsychic, theArm, theWheel, theHead, theWindow, theGoad, theClub, theWall, theHouse, theFish, violetVessel]
+const amberAcorn: BossBlindDefinition = {
+  type: 'bossBlind',
+  status: 'notStarted',
+  anteMultiplier: 2,
+  name: 'Amber Acorn',
+  description: 'Flips and shuffles all Joker cards',
+  image: 'amber-acorn.png',
+  minimumAnte: 8,
+  baseReward: 8,
+  effects: [
+    {
+      event: { type: 'BOSS_BLIND_SELECTED' },
+      priority: 1,
+      condition: (ctx: EffectContext) => ctx.event.type === 'BOSS_BLIND_SELECTED',
+      apply: (ctx: EffectContext) => {
+        // Flip all jokers face down
+        for (const joker of ctx.game.jokers) {
+          joker.isFaceUp = false
+        }
+        // Shuffle jokers deterministically
+        const seed = buildSeedString([ctx.game.gameSeed, ctx.game.roundIndex.toString(), 'amber-acorn'])
+        for (let i = ctx.game.jokers.length - 1; i > 0; i--) {
+          const j = getRandomNumberWithSeed(
+            buildSeedString([seed, String(i)]),
+            0,
+            i
+          )
+          ;[ctx.game.jokers[i], ctx.game.jokers[j]] = [ctx.game.jokers[j], ctx.game.jokers[i]]
+        }
+      },
+    },
+  ],
+}
+
+export const bossBlinds: BossBlindDefinition[] = [theHook, theOx, theNeedle, thePillar, theSerpent, thePlant, theTooth, theFlint, theMark, theMouth, theEye, theManacle, theWater, thePsychic, theArm, theWheel, theHead, theWindow, theGoad, theClub, theWall, theHouse, theFish, violetVessel, amberAcorn]
 
 /**
  


### PR DESCRIPTION
## Summary
- Adds Amber Acorn showdown boss blind: flips and shuffles all Joker cards
- On BOSS_BLIND_SELECTED, sets all jokers isFaceUp=false and shuffles order deterministically
- Minimum ante: 8, base reward: $8, not Matador-compatible

## Test plan
- [x] All jokers flipped face down
- [x] Shuffle is deterministic with same seed
- [x] All existing tests pass

Fixes #958

🤖 Generated with [Claude Code](https://claude.com/claude-code)