### PR TITLE
feat: implement Investment tag (#917)

### DIFF
--- a/src/app/daily-card-game/domain/game/__tests__/tag-investment.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/tag-investment.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+import { defaultGameState } from '@/app/daily-card-game/domain/game/default-game-state'
+import { reduceGame } from '@/app/daily-card-game/domain/game/reduce-game'
+import type { GameState } from '@/app/daily-card-game/domain/game/types'
+
+describe('Investment tag', () => {
+  it('grants $25 on SHOP_OPEN after boss blind is defeated', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.tags = [{ id: 'tag-1', tagType: 'investment', name: 'Investment' } as any]
+    game.money = 10
+    // Simulate boss blind completed: roundIndex advanced to 1, prev round boss blind completed
+    game.roundIndex = 1
+    game.rounds[0].bossBlind.status = 'completed'
+
+    const after = reduceGame(game, { type: 'SHOP_OPEN' })
+    expect(after.money).toBe(35) // 10 + 25
+  })
+
+  it('does not grant $25 if boss blind not yet completed', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.tags = [{ id: 'tag-1', tagType: 'investment', name: 'Investment' } as any]
+    game.money = 10
+    // Still on round 0, no boss blind completed yet
+    game.roundIndex = 0
+
+    const after = reduceGame(game, { type: 'SHOP_OPEN' })
+    expect(after.money).toBe(10) // no change
+  })
+
+  it('removes the Investment tag after triggering', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.tags = [{ id: 'tag-1', tagType: 'investment', name: 'Investment' } as any]
+    game.roundIndex = 1
+    game.rounds[0].bossBlind.status = 'completed'
+
+    const after = reduceGame(game, { type: 'SHOP_OPEN' })
+    expect(after.tags.find(t => t.tagType === 'investment')).toBeUndefined()
+  })
+})

--- a/src/app/daily-card-game/domain/tag/tags.ts
+++ b/src/app/daily-card-game/domain/tag/tags.ts
@@ -79,7 +79,23 @@ const investment: TagDefinition = {
   name: 'Investment',
   benefit: 'Gain $25 after defeating the next Boss Blind.',
   minimumAnte: 1,
-  effects: [],
+  effects: [
+    {
+      event: { type: 'SHOP_OPEN' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        // Check if the boss blind was just completed (roundIndex advanced)
+        const prevRound = ctx.game.rounds[ctx.game.roundIndex - 1]
+        if (prevRound && prevRound.bossBlind.status === 'completed') {
+          ctx.game.money += 25
+          const investmentTag = ctx.game.tags.find(tag => tag.tagType === 'investment')
+          if (investmentTag) {
+            ctx.game.tags = ctx.game.tags.filter(tag => tag.id !== investmentTag.id)
+          }
+        }
+      },
+    },
+  ],
 }
 
 const voucher: TagDefinition = {
@@ -350,6 +366,7 @@ export const implementedTags: Partial<Record<TagType, TagDefinition>> = {
   garbage,
   topUp,
   orbital,
+  investment,
 }
 
 /* Tags


### PR DESCRIPTION
## Summary
- Implements Investment tag: gain $25 after defeating the next Boss Blind
- On SHOP_OPEN, checks if previous round's boss blind was completed
- Tag consumed after triggering

## Test plan
- [x] Grants $25 after boss blind defeated
- [x] Does not trigger before boss blind completion
- [x] Tag removed after use
- [x] All existing tests pass

Fixes #917

🤖 Generated with [Claude Code](https://claude.com/claude-code)