### PR TITLE
feat: implement Polychrome tag (#915)

### DIFF
--- a/src/app/daily-card-game/domain/game/__tests__/tag-polychrome.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/tag-polychrome.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+import { defaultGameState } from '@/app/daily-card-game/domain/game/default-game-state'
+import { reduceGame } from '@/app/daily-card-game/domain/game/reduce-game'
+import type { GameState } from '@/app/daily-card-game/domain/game/types'
+
+describe('Polychrome tag', () => {
+  it('adds a free polychrome joker to guaranteed shop items on SHOP_OPEN', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.tags = [{ id: 'tag-1', tagType: 'polychrome', name: 'Polychrome' } as any]
+
+    const after = reduceGame(game, { type: 'SHOP_OPEN' })
+    const jokerItems = after.shopState.cardsForSale.filter(
+      item => item.type === 'jokerCard' && item.price === 0
+    )
+    expect(jokerItems.length).toBeGreaterThanOrEqual(1)
+    // Check that the free joker has polychrome edition
+    const freeJoker = jokerItems[0]
+    expect((freeJoker.card as any).edition).toBe('polychrome')
+  })
+
+  it('removes the Polychrome tag after use', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.tags = [{ id: 'tag-1', tagType: 'polychrome', name: 'Polychrome' } as any]
+
+    const after = reduceGame(game, { type: 'SHOP_OPEN' })
+    expect(after.tags.find(t => t.tagType === 'polychrome')).toBeUndefined()
+  })
+})

--- a/src/app/daily-card-game/domain/tag/tags.ts
+++ b/src/app/daily-card-game/domain/tag/tags.ts
@@ -72,7 +72,28 @@ const polychrome: TagDefinition = {
   benefit:
     'The next base edition Joker you find in a Shop becomes Polychrome (X1.5 Mult) and free.',
   minimumAnte: 1,
-  effects: [],
+  effects: [
+    {
+      event: { type: 'SHOP_OPEN' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        const randomJoker = getRandomCommonJoker(ctx.game, 'polychrome')
+        if (randomJoker) {
+          const jokerState = initializeJoker(randomJoker, ctx.game)
+          jokerState.edition = 'polychrome'
+          ctx.game.shopState.guaranteedForSaleItems.push({
+            type: 'jokerCard',
+            card: jokerState,
+            price: 0,
+          })
+        }
+        const polyTag = ctx.game.tags.find(tag => tag.tagType === 'polychrome')
+        if (polyTag) {
+          ctx.game.tags = ctx.game.tags.filter(tag => tag.id !== polyTag.id)
+        }
+      },
+    },
+  ],
 }
 
 const investment: TagDefinition = {
@@ -384,6 +405,7 @@ export const implementedTags: Partial<Record<TagType, TagDefinition>> = {
   orbital,
   investment,
   boss,
+  polychrome,
 }
 
 /* Tags


### PR DESCRIPTION
## Summary
- Implements Polychrome tag: next base Joker in shop becomes Polychrome (X1.5 Mult) and free
- On SHOP_OPEN, adds a random common joker with polychrome edition at $0 to guaranteed items
- Tag consumed after use

## Test plan
- [x] Free polychrome joker added to shop
- [x] Tag removed after use
- [x] All existing tests pass

Fixes #915

🤖 Generated with [Claude Code](https://claude.com/claude-code)