### PR TITLE
feat: implement Holographic tag (#914)

### DIFF
--- a/src/app/daily-card-game/domain/game/__tests__/tag-holographic.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/tag-holographic.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest'
+import { defaultGameState } from '@/app/daily-card-game/domain/game/default-game-state'
+import { reduceGame } from '@/app/daily-card-game/domain/game/reduce-game'
+import type { GameState } from '@/app/daily-card-game/domain/game/types'
+
+describe('Holographic tag', () => {
+  it('adds a free holographic joker to guaranteed shop items on SHOP_OPEN', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.tags = [{ id: 'tag-1', tagType: 'holographic', name: 'Holographic' } as any]
+
+    const after = reduceGame(game, { type: 'SHOP_OPEN' })
+    const jokerItems = after.shopState.cardsForSale.filter(
+      item => item.type === 'jokerCard' && item.price === 0
+    )
+    expect(jokerItems.length).toBeGreaterThanOrEqual(1)
+    expect((jokerItems[0].card as any).edition).toBe('holographic')
+  })
+
+  it('removes the Holographic tag after use', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.tags = [{ id: 'tag-1', tagType: 'holographic', name: 'Holographic' } as any]
+
+    const after = reduceGame(game, { type: 'SHOP_OPEN' })
+    expect(after.tags.find(t => t.tagType === 'holographic')).toBeUndefined()
+  })
+})

--- a/src/app/daily-card-game/domain/tag/tags.ts
+++ b/src/app/daily-card-game/domain/tag/tags.ts
@@ -63,7 +63,28 @@ const holographic: TagDefinition = {
   benefit:
     'The next base edition Joker you find in a Shop becomes Holographic (+10 Mult) and free.',
   minimumAnte: 1,
-  effects: [],
+  effects: [
+    {
+      event: { type: 'SHOP_OPEN' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        const randomJoker = getRandomCommonJoker(ctx.game, 'holographic')
+        if (randomJoker) {
+          const jokerState = initializeJoker(randomJoker, ctx.game)
+          jokerState.edition = 'holographic'
+          ctx.game.shopState.guaranteedForSaleItems.push({
+            type: 'jokerCard',
+            card: jokerState,
+            price: 0,
+          })
+        }
+        const holoTag = ctx.game.tags.find(tag => tag.tagType === 'holographic')
+        if (holoTag) {
+          ctx.game.tags = ctx.game.tags.filter(tag => tag.id !== holoTag.id)
+        }
+      },
+    },
+  ],
 }
 
 const polychrome: TagDefinition = {
@@ -406,6 +427,7 @@ export const implementedTags: Partial<Record<TagType, TagDefinition>> = {
   investment,
   boss,
   polychrome,
+  holographic,
 }
 
 /* Tags


### PR DESCRIPTION
## Summary
- Implements Holographic tag: next base Joker in shop becomes Holographic (+10 Mult) and free
- Same pattern as Polychrome tag but with holographic edition
- Tag consumed after use

## Test plan
- [x] Free holographic joker added to shop
- [x] Tag removed after use
- [x] All existing tests pass

Fixes #914

🤖 Generated with [Claude Code](https://claude.com/claude-code)