### PR TITLE
feat: implement Foil tag (#913)

### DIFF
--- a/src/app/daily-card-game/domain/game/__tests__/tag-foil.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/tag-foil.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest'
+import { defaultGameState } from '@/app/daily-card-game/domain/game/default-game-state'
+import { reduceGame } from '@/app/daily-card-game/domain/game/reduce-game'
+import type { GameState } from '@/app/daily-card-game/domain/game/types'
+
+describe('Foil tag', () => {
+  it('adds a free foil joker to guaranteed shop items on SHOP_OPEN', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.tags = [{ id: 'tag-1', tagType: 'foil', name: 'Foil' } as any]
+
+    const after = reduceGame(game, { type: 'SHOP_OPEN' })
+    const jokerItems = after.shopState.cardsForSale.filter(
+      item => item.type === 'jokerCard' && item.price === 0
+    )
+    expect(jokerItems.length).toBeGreaterThanOrEqual(1)
+    expect((jokerItems[0].card as any).edition).toBe('foil')
+  })
+
+  it('removes the Foil tag after use', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.tags = [{ id: 'tag-1', tagType: 'foil', name: 'Foil' } as any]
+
+    const after = reduceGame(game, { type: 'SHOP_OPEN' })
+    expect(after.tags.find(t => t.tagType === 'foil')).toBeUndefined()
+  })
+})

--- a/src/app/daily-card-game/domain/tag/tags.ts
+++ b/src/app/daily-card-game/domain/tag/tags.ts
@@ -54,7 +54,28 @@ const foil: TagDefinition = {
   name: 'Foil',
   benefit: 'The next base edition Joker you find in a Shop becomes Foil (+50 Chips) and free.',
   minimumAnte: 1,
-  effects: [],
+  effects: [
+    {
+      event: { type: 'SHOP_OPEN' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        const randomJoker = getRandomCommonJoker(ctx.game, 'foil')
+        if (randomJoker) {
+          const jokerState = initializeJoker(randomJoker, ctx.game)
+          jokerState.edition = 'foil'
+          ctx.game.shopState.guaranteedForSaleItems.push({
+            type: 'jokerCard',
+            card: jokerState,
+            price: 0,
+          })
+        }
+        const foilTag = ctx.game.tags.find(tag => tag.tagType === 'foil')
+        if (foilTag) {
+          ctx.game.tags = ctx.game.tags.filter(tag => tag.id !== foilTag.id)
+        }
+      },
+    },
+  ],
 }
 
 const holographic: TagDefinition = {
@@ -428,6 +449,7 @@ export const implementedTags: Partial<Record<TagType, TagDefinition>> = {
   boss,
   polychrome,
   holographic,
+  foil,
 }
 
 /* Tags


### PR DESCRIPTION
## Summary
- Implements Foil tag: next base Joker in shop becomes Foil (+50 Chips) and free
- Same pattern as Polychrome/Holographic tags but with foil edition
- Tag consumed after use

## Test plan
- [x] Free foil joker added to shop
- [x] Tag removed after use
- [x] All existing tests pass

Fixes #913

🤖 Generated with [Claude Code](https://claude.com/claude-code)