### PR TITLE
feat: implement Negative tag (#912)

### DIFF
--- a/src/app/daily-card-game/domain/game/__tests__/tag-negative.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/tag-negative.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+import { defaultGameState } from '@/app/daily-card-game/domain/game/default-game-state'
+import { reduceGame } from '@/app/daily-card-game/domain/game/reduce-game'
+import type { GameState } from '@/app/daily-card-game/domain/game/types'
+
+describe('Negative tag', () => {
+  it('adds a free negative joker and +1 joker slot on SHOP_OPEN', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.tags = [{ id: 'tag-1', tagType: 'negative', name: 'Negative' } as any]
+    game.maxJokers = 5
+
+    const after = reduceGame(game, { type: 'SHOP_OPEN' })
+    const jokerItems = after.shopState.cardsForSale.filter(
+      item => item.type === 'jokerCard' && item.price === 0
+    )
+    expect(jokerItems.length).toBeGreaterThanOrEqual(1)
+    expect((jokerItems[0].card as any).edition).toBe('negative')
+    expect(after.maxJokers).toBe(6)
+  })
+
+  it('removes the Negative tag after use', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.tags = [{ id: 'tag-1', tagType: 'negative', name: 'Negative' } as any]
+
+    const after = reduceGame(game, { type: 'SHOP_OPEN' })
+    expect(after.tags.find(t => t.tagType === 'negative')).toBeUndefined()
+  })
+})

--- a/src/app/daily-card-game/domain/tag/tags.ts
+++ b/src/app/daily-card-game/domain/tag/tags.ts
@@ -46,7 +46,29 @@ const negative: TagDefinition = {
   benefit:
     'The next base edition Joker you find in a Shop becomes Negative (+1 joker slot) and free.',
   minimumAnte: 1,
-  effects: [],
+  effects: [
+    {
+      event: { type: 'SHOP_OPEN' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        const randomJoker = getRandomCommonJoker(ctx.game, 'negative')
+        if (randomJoker) {
+          const jokerState = initializeJoker(randomJoker, ctx.game)
+          jokerState.edition = 'negative'
+          ctx.game.shopState.guaranteedForSaleItems.push({
+            type: 'jokerCard',
+            card: jokerState,
+            price: 0,
+          })
+          ctx.game.maxJokers += 1
+        }
+        const negTag = ctx.game.tags.find(tag => tag.tagType === 'negative')
+        if (negTag) {
+          ctx.game.tags = ctx.game.tags.filter(tag => tag.id !== negTag.id)
+        }
+      },
+    },
+  ],
 }
 
 const foil: TagDefinition = {
@@ -450,6 +472,7 @@ export const implementedTags: Partial<Record<TagType, TagDefinition>> = {
   polychrome,
   holographic,
   foil,
+  negative,
 }
 
 /* Tags


### PR DESCRIPTION
## Summary
- Implements Negative tag: next base Joker in shop becomes Negative (+1 joker slot) and free
- Also increments maxJokers by 1 (negative edition grants extra slot)
- Tag consumed after use

## Test plan
- [x] Free negative joker added to shop
- [x] maxJokers increased by 1
- [x] Tag removed after use
- [x] All existing tests pass

Fixes #912

🤖 Generated with [Claude Code](https://claude.com/claude-code)