### PR TITLE
feat: implement Cerulean Bell showdown boss blind (#962)

### DIFF
--- a/src/app/daily-card-game/domain/game/__tests__/cerulean-bell.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/cerulean-bell.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest'
+import { defaultGameState } from '@/app/daily-card-game/domain/game/default-game-state'
+import { reduceGame } from '@/app/daily-card-game/domain/game/reduce-game'
+import type { GameState } from '@/app/daily-card-game/domain/game/types'
+
+describe('Cerulean Bell showdown boss blind', () => {
+  function setupGame(overrides: Partial<GameState> = {}): GameState {
+    const game: GameState = structuredClone(defaultGameState)
+    game.rounds[game.roundIndex].bossBlindName = 'Cerulean Bell'
+    return { ...game, ...overrides }
+  }
+
+  it('forces 1 card to be selected on BOSS_BLIND_SELECTED', () => {
+    const game = setupGame()
+    game.gamePlayState.handIds = ['c1', 'c2', 'c3']
+    game.gamePlayState.selectedCardIds = []
+    game.cards = {
+      'c1': { id: 'c1', playingCardId: 'A_spades', isFaceUp: true, flags: {} } as any,
+      'c2': { id: 'c2', playingCardId: '2_hearts', isFaceUp: true, flags: {} } as any,
+      'c3': { id: 'c3', playingCardId: '3_clubs', isFaceUp: true, flags: {} } as any,
+    }
+    game.ownedCardIds = ['c1', 'c2', 'c3']
+
+    const after = reduceGame(game, { type: 'BOSS_BLIND_SELECTED' })
+    expect(after.gamePlayState.selectedCardIds.length).toBe(1)
+    expect(game.gamePlayState.handIds).toContain(after.gamePlayState.selectedCardIds[0])
+  })
+
+  it('does not add duplicate if card already selected', () => {
+    const game = setupGame()
+    game.gamePlayState.handIds = ['c1']
+    game.gamePlayState.selectedCardIds = ['c1']
+    game.cards = {
+      'c1': { id: 'c1', playingCardId: 'A_spades', isFaceUp: true, flags: {} } as any,
+    }
+    game.ownedCardIds = ['c1']
+
+    const after = reduceGame(game, { type: 'BOSS_BLIND_SELECTED' })
+    expect(after.gamePlayState.selectedCardIds.length).toBe(1)
+  })
+})

--- a/src/app/daily-card-game/domain/round/boss-blinds.ts
+++ b/src/app/daily-card-game/domain/round/boss-blinds.ts
@@ -612,7 +612,37 @@ const crimsonHeart: BossBlindDefinition = {
   ],
 }
 
-export const bossBlinds: BossBlindDefinition[] = [theHook, theOx, theNeedle, thePillar, theSerpent, thePlant, theTooth, theFlint, theMark, theMouth, theEye, theManacle, theWater, thePsychic, theArm, theWheel, theHead, theWindow, theGoad, theClub, theWall, theHouse, theFish, violetVessel, amberAcorn, crimsonHeart]
+const ceruleanBell: BossBlindDefinition = {
+  type: 'bossBlind',
+  status: 'notStarted',
+  anteMultiplier: 2,
+  name: 'Cerulean Bell',
+  description: 'Forces 1 card to always be selected',
+  image: 'cerulean-bell.png',
+  minimumAnte: 8,
+  baseReward: 8,
+  effects: [
+    {
+      event: { type: 'BOSS_BLIND_SELECTED' },
+      priority: 1,
+      condition: (ctx: EffectContext) => ctx.event.type === 'BOSS_BLIND_SELECTED',
+      apply: (ctx: EffectContext) => {
+        // Force-select a random card from owned cards (hand isn't dealt yet at this point)
+        const cardIds = ctx.game.ownedCardIds
+        if (cardIds.length > 0) {
+          const seed = buildSeedString([ctx.game.gameSeed, ctx.game.roundIndex.toString(), 'cerulean-bell'])
+          const randomIndex = getRandomNumberWithSeed(seed, 0, cardIds.length - 1)
+          const forcedCardId = cardIds[randomIndex]
+          if (!ctx.game.gamePlayState.selectedCardIds.includes(forcedCardId)) {
+            ctx.game.gamePlayState.selectedCardIds.push(forcedCardId)
+          }
+        }
+      },
+    },
+  ],
+}
+
+export const bossBlinds: BossBlindDefinition[] = [theHook, theOx, theNeedle, thePillar, theSerpent, thePlant, theTooth, theFlint, theMark, theMouth, theEye, theManacle, theWater, thePsychic, theArm, theWheel, theHead, theWindow, theGoad, theClub, theWall, theHouse, theFish, violetVessel, amberAcorn, crimsonHeart, ceruleanBell]
 
 /**
  


### PR DESCRIPTION
## Summary
- Adds Cerulean Bell showdown boss blind: forces 1 card to always be selected
- On BOSS_BLIND_SELECTED, selects a random card from ownedCardIds
- Minimum ante: 8, base reward: $8, not Matador-compatible

## Test plan
- [x] Forces 1 card to be selected
- [x] No duplicate selection
- [x] All existing tests pass

Fixes #962

🤖 Generated with [Claude Code](https://claude.com/claude-code)