### PR TITLE
feat: implement Paint Brush and Palette vouchers (#909, #910)

### DIFF
--- a/src/app/daily-card-game/domain/game/__tests__/voucher-paint-brush.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/voucher-paint-brush.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest'
+import { defaultGameState } from '@/app/daily-card-game/domain/game/default-game-state'
+import { reduceGame } from '@/app/daily-card-game/domain/game/reduce-game'
+import type { GameState } from '@/app/daily-card-game/domain/game/types'
+
+describe('Paint Brush and Palette vouchers', () => {
+  it('Paint Brush adds +1 hand size on purchase', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.handSizeModifier = 0
+    game.shopState.voucher = 'paintBrush'
+
+    const after = reduceGame(game, { type: 'SHOP_BUY_VOUCHER', id: 'paintBrush' })
+    expect(after.handSizeModifier).toBe(1)
+  })
+
+  it('Palette adds +1 hand size on purchase', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.handSizeModifier = 1
+    game.shopState.voucher = 'palette'
+
+    const after = reduceGame(game, { type: 'SHOP_BUY_VOUCHER', id: 'palette' })
+    expect(after.handSizeModifier).toBe(2)
+  })
+})

--- a/src/app/daily-card-game/domain/voucher/vouchers.ts
+++ b/src/app/daily-card-game/domain/voucher/vouchers.ts
@@ -531,8 +531,7 @@ export const paintBrush: VoucherDefinition = {
       event: { type: 'SHOP_BUY_VOUCHER', id: 'paintBrush' },
       priority: 1,
       apply: (ctx: EffectContext) => {
-        // TODO: Implement paint brush effect
-        throw new Error('Not implemented' + JSON.stringify(ctx))
+        ctx.game.handSizeModifier += 1
       },
     },
   ],
@@ -548,8 +547,7 @@ export const palette: VoucherDefinition = {
       event: { type: 'SHOP_BUY_VOUCHER', id: 'palette' },
       priority: 1,
       apply: (ctx: EffectContext) => {
-        // TODO: Implement palette effect
-        throw new Error('Not implemented' + JSON.stringify(ctx))
+        ctx.game.handSizeModifier += 1
       },
     },
   ],


### PR DESCRIPTION
## Summary
- Implements Paint Brush voucher: +1 Hand Size
- Implements Palette voucher: +1 Hand Size (cumulative with Paint Brush)
- Replaced TODO throws with actual implementations

## Test plan
- [x] Paint Brush adds +1 handSizeModifier
- [x] Palette adds +1 handSizeModifier
- [x] All existing tests pass

Fixes #909
Fixes #910

🤖 Generated with [Claude Code](https://claude.com/claude-code)