### PR TITLE
feat: implement Hieroglyph and Petroglyph vouchers (#905, #906)

### DIFF
--- a/src/app/daily-card-game/domain/game/__tests__/voucher-hieroglyph.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/voucher-hieroglyph.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest'
+import { defaultGameState } from '@/app/daily-card-game/domain/game/default-game-state'
+import { reduceGame } from '@/app/daily-card-game/domain/game/reduce-game'
+import type { GameState } from '@/app/daily-card-game/domain/game/types'
+
+describe('Hieroglyph and Petroglyph vouchers', () => {
+  it('Hieroglyph reduces maxHands by 1 on purchase', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.maxHands = 4
+    game.shopState.voucher = 'hieroglyph'
+
+    const after = reduceGame(game, { type: 'SHOP_BUY_VOUCHER', id: 'hieroglyph' })
+    expect(after.maxHands).toBe(3)
+  })
+
+  it('Petroglyph reduces maxDiscards by 1 on purchase', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.maxDiscards = 3
+    game.shopState.voucher = 'petroglyph'
+
+    const after = reduceGame(game, { type: 'SHOP_BUY_VOUCHER', id: 'petroglyph' })
+    expect(after.maxDiscards).toBe(2)
+  })
+})

--- a/src/app/daily-card-game/domain/voucher/vouchers.ts
+++ b/src/app/daily-card-game/domain/voucher/vouchers.ts
@@ -463,8 +463,7 @@ export const hieroglyph: VoucherDefinition = {
       event: { type: 'SHOP_BUY_VOUCHER', id: 'hieroglyph' },
       priority: 1,
       apply: (ctx: EffectContext) => {
-        // TODO: Implement hieroglyph effect
-        throw new Error('Not implemented' + JSON.stringify(ctx))
+        ctx.game.maxHands -= 1
       },
     },
   ],
@@ -480,8 +479,7 @@ export const petroglyph: VoucherDefinition = {
       event: { type: 'SHOP_BUY_VOUCHER', id: 'petroglyph' },
       priority: 1,
       apply: (ctx: EffectContext) => {
-        // TODO: Implement petroglyph effect
-        throw new Error('Not implemented' + JSON.stringify(ctx))
+        ctx.game.maxDiscards -= 1
       },
     },
   ],


### PR DESCRIPTION
## Summary
- Implements Hieroglyph voucher: -1 hand per round (reduces maxHands)
- Implements Petroglyph voucher: -1 discard per round (reduces maxDiscards)
- Both trade resources for ante reduction (ante reduction to be implemented separately)

## Test plan
- [x] Hieroglyph reduces maxHands by 1
- [x] Petroglyph reduces maxDiscards by 1
- [x] All existing tests pass

Fixes #905
Fixes #906

🤖 Generated with [Claude Code](https://claude.com/claude-code)