### PR TITLE
feat: implement Blank and Antimatter vouchers (#901, #902)

### DIFF
--- a/src/app/daily-card-game/domain/game/__tests__/voucher-antimatter.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/voucher-antimatter.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest'
+import { defaultGameState } from '@/app/daily-card-game/domain/game/default-game-state'
+import { reduceGame } from '@/app/daily-card-game/domain/game/reduce-game'
+import type { GameState } from '@/app/daily-card-game/domain/game/types'
+
+describe('Blank and Antimatter vouchers', () => {
+  it('Blank does nothing on purchase (no error)', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.shopState.voucher = 'blank'
+
+    const after = reduceGame(game, { type: 'SHOP_BUY_VOUCHER', id: 'blank' })
+    expect(after).toBeDefined()
+  })
+
+  it('Antimatter adds +1 joker slot on purchase', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.maxJokers = 5
+    game.shopState.voucher = 'antimatter'
+
+    const after = reduceGame(game, { type: 'SHOP_BUY_VOUCHER', id: 'antimatter' })
+    expect(after.maxJokers).toBe(6)
+  })
+})

--- a/src/app/daily-card-game/domain/voucher/vouchers.ts
+++ b/src/app/daily-card-game/domain/voucher/vouchers.ts
@@ -394,9 +394,8 @@ export const blank: VoucherDefinition = {
     {
       event: { type: 'SHOP_BUY_VOUCHER', id: 'blank' },
       priority: 1,
-      apply: (ctx: EffectContext) => {
-        // TODO: Implement blank effect
-        throw new Error('Not implemented' + JSON.stringify(ctx))
+      apply: () => {
+        // Blank does nothing - it's a prerequisite for Antimatter
       },
     },
   ],
@@ -412,8 +411,7 @@ export const antimatter: VoucherDefinition = {
       event: { type: 'SHOP_BUY_VOUCHER', id: 'antimatter' },
       priority: 1,
       apply: (ctx: EffectContext) => {
-        // TODO: Implement antimatter effect
-        throw new Error('Not implemented' + JSON.stringify(ctx))
+        ctx.game.maxJokers += 1
       },
     },
   ],


### PR DESCRIPTION
## Summary
- Implements Blank voucher: does nothing (prerequisite for Antimatter)
- Implements Antimatter voucher: +1 Joker slot

## Test plan
- [x] Blank doesn't throw on purchase
- [x] Antimatter adds +1 to maxJokers
- [x] All existing tests pass

Fixes #901
Fixes #902

🤖 Generated with [Claude Code](https://claude.com/claude-code)