### PR TITLE
feat: implement Seed Money and Money Tree vouchers (#899, #900)

### DIFF
--- a/src/app/daily-card-game/domain/game/__tests__/voucher-seed-money.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/voucher-seed-money.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest'
+import { defaultGameState } from '@/app/daily-card-game/domain/game/default-game-state'
+import { reduceGame } from '@/app/daily-card-game/domain/game/reduce-game'
+import type { GameState } from '@/app/daily-card-game/domain/game/types'
+
+describe('Seed Money and Money Tree vouchers', () => {
+  it('Seed Money raises maxInterest to 10', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.maxInterest = 5
+    game.shopState.voucher = 'seedMoney'
+
+    const after = reduceGame(game, { type: 'SHOP_BUY_VOUCHER', id: 'seedMoney' })
+    expect(after.maxInterest).toBe(10)
+  })
+
+  it('Money Tree raises maxInterest to 20', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.maxInterest = 10
+    game.shopState.voucher = 'moneyTree'
+
+    const after = reduceGame(game, { type: 'SHOP_BUY_VOUCHER', id: 'moneyTree' })
+    expect(after.maxInterest).toBe(20)
+  })
+})

--- a/src/app/daily-card-game/domain/voucher/vouchers.ts
+++ b/src/app/daily-card-game/domain/voucher/vouchers.ts
@@ -361,8 +361,7 @@ export const seedMoney: VoucherDefinition = {
       event: { type: 'SHOP_BUY_VOUCHER', id: 'seedMoney' },
       priority: 1,
       apply: (ctx: EffectContext) => {
-        // TODO: Implement seed money effect
-        throw new Error('Not implemented' + JSON.stringify(ctx))
+        ctx.game.maxInterest = 10
       },
     },
   ],
@@ -378,8 +377,7 @@ export const moneyTree: VoucherDefinition = {
       event: { type: 'SHOP_BUY_VOUCHER', id: 'moneyTree' },
       priority: 1,
       apply: (ctx: EffectContext) => {
-        // TODO: Implement money tree effect
-        throw new Error('Not implemented' + JSON.stringify(ctx))
+        ctx.game.maxInterest = 20
       },
     },
   ],


### PR DESCRIPTION
## Summary
- Implements Seed Money voucher: raises interest cap to $10/round
- Implements Money Tree voucher: raises interest cap to $20/round

## Test plan
- [x] Seed Money sets maxInterest to 10
- [x] Money Tree sets maxInterest to 20
- [x] All existing tests pass

Fixes #899
Fixes #900

🤖 Generated with [Claude Code](https://claude.com/claude-code)