### PR TITLE
feat: implement Grabber, Nacho Tong, Wasteful, Recyclomancy vouchers

### DIFF
--- a/src/app/daily-card-game/domain/game/__tests__/voucher-hands-discards.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/voucher-hands-discards.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest'
+import { defaultGameState } from '@/app/daily-card-game/domain/game/default-game-state'
+import { reduceGame } from '@/app/daily-card-game/domain/game/reduce-game'
+import type { GameState } from '@/app/daily-card-game/domain/game/types'
+
+describe('Hands and Discards vouchers', () => {
+  it('Grabber adds +1 maxHands', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.maxHands = 4
+    game.shopState.voucher = 'grabber'
+    const after = reduceGame(game, { type: 'SHOP_BUY_VOUCHER', id: 'grabber' })
+    expect(after.maxHands).toBe(5)
+  })
+
+  it('Nacho Tong adds +1 maxHands', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.maxHands = 5
+    game.shopState.voucher = 'nachoTong'
+    const after = reduceGame(game, { type: 'SHOP_BUY_VOUCHER', id: 'nachoTong' })
+    expect(after.maxHands).toBe(6)
+  })
+
+  it('Wasteful adds +1 maxDiscards', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.maxDiscards = 3
+    game.shopState.voucher = 'wasteful'
+    const after = reduceGame(game, { type: 'SHOP_BUY_VOUCHER', id: 'wasteful' })
+    expect(after.maxDiscards).toBe(4)
+  })
+
+  it('Recyclomancy adds +1 maxDiscards', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.maxDiscards = 4
+    game.shopState.voucher = 'recyclomancy'
+    const after = reduceGame(game, { type: 'SHOP_BUY_VOUCHER', id: 'recyclomancy' })
+    expect(after.maxDiscards).toBe(5)
+  })
+})

--- a/src/app/daily-card-game/domain/voucher/vouchers.ts
+++ b/src/app/daily-card-game/domain/voucher/vouchers.ts
@@ -225,8 +225,7 @@ export const grabber: VoucherDefinition = {
       event: { type: 'SHOP_BUY_VOUCHER', id: 'grabber' },
       priority: 1,
       apply: (ctx: EffectContext) => {
-        // TODO: Implement grabber effect
-        throw new Error('Not implemented' + JSON.stringify(ctx))
+        ctx.game.maxHands += 1
       },
     },
   ],
@@ -242,8 +241,7 @@ export const nachoTong: VoucherDefinition = {
       event: { type: 'SHOP_BUY_VOUCHER', id: 'nachoTong' },
       priority: 1,
       apply: (ctx: EffectContext) => {
-        // TODO: Implement nacho tong effect
-        throw new Error('Not implemented' + JSON.stringify(ctx))
+        ctx.game.maxHands += 1
       },
     },
   ],
@@ -259,8 +257,7 @@ export const wasteful: VoucherDefinition = {
       event: { type: 'SHOP_BUY_VOUCHER', id: 'wasteful' },
       priority: 1,
       apply: (ctx: EffectContext) => {
-        // TODO: Implement wasteful effect
-        throw new Error('Not implemented' + JSON.stringify(ctx))
+        ctx.game.maxDiscards += 1
       },
     },
   ],
@@ -276,8 +273,7 @@ export const recyclomancy: VoucherDefinition = {
       event: { type: 'SHOP_BUY_VOUCHER', id: 'recyclomancy' },
       priority: 1,
       apply: (ctx: EffectContext) => {
-        // TODO: Implement recyclomancy effect
-        throw new Error('Not implemented' + JSON.stringify(ctx))
+        ctx.game.maxDiscards += 1
       },
     },
   ],


### PR DESCRIPTION
## Summary
- Implements Grabber voucher: +1 hand per round
- Implements Nacho Tong voucher: +1 hand per round (cumulative)
- Implements Wasteful voucher: +1 discard per round
- Implements Recyclomancy voucher: +1 discard per round (cumulative)

## Test plan
- [x] Grabber adds +1 maxHands
- [x] Nacho Tong adds +1 maxHands
- [x] Wasteful adds +1 maxDiscards
- [x] Recyclomancy adds +1 maxDiscards
- [x] All existing tests pass

Fixes nickolu/CometCave#893
Fixes nickolu/CometCave#894
Fixes nickolu/CometCave#895
Fixes nickolu/CometCave#896

🤖 Generated with [Claude Code](https://claude.com/claude-code)