### PR TITLE
feat: implement Reroll Surplus and Reroll Glut vouchers

### DIFF
--- a/src/app/daily-card-game/domain/game/__tests__/voucher-reroll.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/voucher-reroll.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest'
+import { defaultGameState } from '@/app/daily-card-game/domain/game/default-game-state'
+import { reduceGame } from '@/app/daily-card-game/domain/game/reduce-game'
+import type { GameState } from '@/app/daily-card-game/domain/game/types'
+
+describe('Reroll cost vouchers', () => {
+  it('Reroll Surplus reduces baseRerollPrice by 2', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.shopState.baseRerollPrice = 5
+    game.shopState.voucher = 'rerollSurplus'
+    const after = reduceGame(game, { type: 'SHOP_BUY_VOUCHER', id: 'rerollSurplus' })
+    expect(after.shopState.baseRerollPrice).toBe(3)
+  })
+
+  it('Reroll Glut reduces baseRerollPrice by another 2', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.shopState.baseRerollPrice = 3
+    game.shopState.voucher = 'rerollGlut'
+    const after = reduceGame(game, { type: 'SHOP_BUY_VOUCHER', id: 'rerollGlut' })
+    expect(after.shopState.baseRerollPrice).toBe(1)
+  })
+
+  it('does not go below 0', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.shopState.baseRerollPrice = 1
+    game.shopState.voucher = 'rerollSurplus'
+    const after = reduceGame(game, { type: 'SHOP_BUY_VOUCHER', id: 'rerollSurplus' })
+    expect(after.shopState.baseRerollPrice).toBe(0)
+  })
+})

--- a/src/app/daily-card-game/domain/voucher/vouchers.ts
+++ b/src/app/daily-card-game/domain/voucher/vouchers.ts
@@ -123,8 +123,7 @@ export const rerollSurplus: VoucherDefinition = {
       event: { type: 'SHOP_BUY_VOUCHER', id: 'rerollSurplus' },
       priority: 1,
       apply: (ctx: EffectContext) => {
-        // TODO: Implement reroll surplus effect
-        throw new Error('Not implemented' + JSON.stringify(ctx))
+        ctx.game.shopState.baseRerollPrice = Math.max(0, ctx.game.shopState.baseRerollPrice - 2)
       },
     },
   ],
@@ -140,8 +139,7 @@ export const rerollGlut: VoucherDefinition = {
       event: { type: 'SHOP_BUY_VOUCHER', id: 'rerollGlut' },
       priority: 1,
       apply: (ctx: EffectContext) => {
-        // TODO: Implement reroll glut effect
-        throw new Error('Not implemented' + JSON.stringify(ctx))
+        ctx.game.shopState.baseRerollPrice = Math.max(0, ctx.game.shopState.baseRerollPrice - 2)
       },
     },
   ],


### PR DESCRIPTION
## Summary
- Implements Reroll Surplus voucher: rerolls cost $2 less (reduces baseRerollPrice by 2)
- Implements Reroll Glut voucher: rerolls cost additional $2 less (cumulative)
- Floor at 0 to prevent negative prices

## Test plan
- [x] Reroll Surplus reduces baseRerollPrice by 2
- [x] Reroll Glut reduces baseRerollPrice by 2
- [x] Price doesn't go below 0
- [x] All existing tests pass

Fixes nickolu/CometCave#891
Fixes nickolu/CometCave#892

🤖 Generated with [Claude Code](https://claude.com/claude-code)