### PR TITLE
feat: implement Magic Trick voucher

### DIFF
--- a/src/app/daily-card-game/domain/game/__tests__/voucher-magic-trick.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/voucher-magic-trick.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest'
+import { defaultGameState } from '@/app/daily-card-game/domain/game/default-game-state'
+import { reduceGame } from '@/app/daily-card-game/domain/game/reduce-game'
+import type { GameState } from '@/app/daily-card-game/domain/game/types'
+
+describe('Magic Trick voucher', () => {
+  it('enables playing cards in the shop by setting multiplier to 1', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    expect(game.shopState.playingCard.multiplier).toBe(0)
+    game.shopState.voucher = 'magicTrick'
+
+    const after = reduceGame(game, { type: 'SHOP_BUY_VOUCHER', id: 'magicTrick' })
+    expect(after.shopState.playingCard.multiplier).toBe(1)
+  })
+})

--- a/src/app/daily-card-game/domain/voucher/vouchers.ts
+++ b/src/app/daily-card-game/domain/voucher/vouchers.ts
@@ -419,8 +419,7 @@ export const magicTrick: VoucherDefinition = {
       event: { type: 'SHOP_BUY_VOUCHER', id: 'magicTrick' },
       priority: 1,
       apply: (ctx: EffectContext) => {
-        // TODO: Implement magic trick effect
-        throw new Error('Not implemented' + JSON.stringify(ctx))
+        ctx.game.shopState.playingCard.multiplier += 1
       },
     },
   ],
@@ -547,6 +546,7 @@ export const implementedVouchers: VoucherType[] = [
   'overstockPlus',
   'clearanceSale',
   'liquidation',
+  'magicTrick',
 ]
 
 export const vouchers: Record<VoucherType, VoucherDefinition> = {


### PR DESCRIPTION
## Summary
- Implements the Magic Trick voucher (#903) from epic #698 (Vouchers)
- Sets `shopState.playingCard.multiplier += 1` when purchased, enabling playing cards to appear in the shop
- Adds `magicTrick` to the `implementedVouchers` list

## Test plan
- [x] Unit test verifies multiplier goes from 0 to 1 after buying the voucher
- [ ] Verify playing cards appear in shop after voucher purchase (manual)

Closes #903

🤖 Generated with [Claude Code](https://claude.com/claude-code)