### PR TITLE
feat: implement Illusion voucher

### DIFF
--- a/src/app/daily-card-game/domain/game/__tests__/voucher-illusion.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/voucher-illusion.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest'
+import { defaultGameState } from '@/app/daily-card-game/domain/game/default-game-state'
+import { reduceGame } from '@/app/daily-card-game/domain/game/reduce-game'
+import type { GameState } from '@/app/daily-card-game/domain/game/types'
+
+describe('Illusion voucher', () => {
+  it('guarantees enchantments and boosts edition/seal chances for playing cards in shop', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    const originalEditionChance = game.shopState.playingCard.editionBaseChance
+    const originalChipChance = game.shopState.playingCard.chipBaseChance
+    game.shopState.voucher = 'illusion'
+
+    const after = reduceGame(game, { type: 'SHOP_BUY_VOUCHER', id: 'illusion' })
+
+    expect(after.shopState.playingCard.enchantmentBaseChance).toBe(1)
+    expect(after.shopState.playingCard.editionBaseChance).toBe(originalEditionChance * 4)
+    expect(after.shopState.playingCard.chipBaseChance).toBe(originalChipChance * 4)
+  })
+})

--- a/src/app/daily-card-game/domain/voucher/vouchers.ts
+++ b/src/app/daily-card-game/domain/voucher/vouchers.ts
@@ -435,12 +435,13 @@ export const illusion: VoucherDefinition = {
       event: { type: 'SHOP_BUY_VOUCHER', id: 'illusion' },
       priority: 1,
       apply: (ctx: EffectContext) => {
-        // TODO: Implement illusion effect
-        throw new Error('Not implemented' + JSON.stringify(ctx))
+        ctx.game.shopState.playingCard.enchantmentBaseChance = 1
+        ctx.game.shopState.playingCard.editionBaseChance *= 4
+        ctx.game.shopState.playingCard.chipBaseChance *= 4
       },
     },
   ],
-  dependentVoucher: null,
+  dependentVoucher: 'magicTrick',
 }
 
 export const hieroglyph: VoucherDefinition = {
@@ -547,6 +548,7 @@ export const implementedVouchers: VoucherType[] = [
   'clearanceSale',
   'liquidation',
   'magicTrick',
+  'illusion',
 ]
 
 export const vouchers: Record<VoucherType, VoucherDefinition> = {


### PR DESCRIPTION
## Summary
- Implements the Illusion voucher (#904) from epic #698 (Vouchers)
- Guarantees enchantments (sets `enchantmentBaseChance` to 1) and quadruples edition and seal chances for playing cards in the shop
- Sets `dependentVoucher` to `magicTrick` (upgrade chain)
- Adds `illusion` to the `implementedVouchers` list

## Test plan
- [x] Unit test verifies enchantment chance set to 1, edition chance quadrupled, seal chance quadrupled
- [ ] Verify playing cards in shop show enhancements after voucher purchase (manual)

Closes #904

🤖 Generated with [Claude Code](https://claude.com/claude-code)