### PR TITLE
feat: implement Planet Tycoon voucher

### DIFF
--- a/src/app/daily-card-game/domain/game/__tests__/voucher-planet-tycoon.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/voucher-planet-tycoon.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest'
+import { defaultGameState } from '@/app/daily-card-game/domain/game/default-game-state'
+import { reduceGame } from '@/app/daily-card-game/domain/game/reduce-game'
+import type { GameState } from '@/app/daily-card-game/domain/game/types'
+
+describe('Planet Tycoon voucher', () => {
+  it('doubles celestialMultiplier for cumulative 4x with Planet Merchant', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    // Simulate Planet Merchant already purchased (celestialMultiplier = 2)
+    game.shopState.celestialMultiplier = 2
+    game.shopState.voucher = 'planetTycoon'
+
+    const after = reduceGame(game, { type: 'SHOP_BUY_VOUCHER', id: 'planetTycoon' })
+    expect(after.shopState.celestialMultiplier).toBe(4)
+  })
+})

--- a/src/app/daily-card-game/domain/voucher/vouchers.ts
+++ b/src/app/daily-card-game/domain/voucher/vouchers.ts
@@ -338,12 +338,11 @@ export const planetTycoon: VoucherDefinition = {
       event: { type: 'SHOP_BUY_VOUCHER', id: 'planetTycoon' },
       priority: 1,
       apply: (ctx: EffectContext) => {
-        // TODO: Implement planet tycoon effect
-        throw new Error('Not implemented' + JSON.stringify(ctx))
+        ctx.game.shopState.celestialMultiplier *= 2
       },
     },
   ],
-  dependentVoucher: null,
+  dependentVoucher: 'planetMerchant',
 }
 
 export const seedMoney: VoucherDefinition = {
@@ -549,6 +548,7 @@ export const implementedVouchers: VoucherType[] = [
   'liquidation',
   'magicTrick',
   'illusion',
+  'planetTycoon',
 ]
 
 export const vouchers: Record<VoucherType, VoucherDefinition> = {


### PR DESCRIPTION
## Summary
- Implements the Planet Tycoon voucher (#898) from epic #698 (Vouchers)
- Doubles `celestialMultiplier` again (cumulative 4x with Planet Merchant) for planet card frequency
- Sets `dependentVoucher` to `planetMerchant` (upgrade chain)
- Adds `planetTycoon` to the `implementedVouchers` list

## Test plan
- [x] Unit test verifies celestialMultiplier goes from 2 to 4 (simulating Planet Merchant already active)
- [ ] Verify planet cards appear ~4x more frequently (manual)

Closes #898

🤖 Generated with [Claude Code](https://claude.com/claude-code)