### PR TITLE
feat: implement Retcon voucher

### DIFF
--- a/src/app/daily-card-game/domain/game/__tests__/voucher-retcon.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/voucher-retcon.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest'
+import { defaultGameState } from '@/app/daily-card-game/domain/game/default-game-state'
+import { reduceGame } from '@/app/daily-card-game/domain/game/reduce-game'
+import type { GameState } from '@/app/daily-card-game/domain/game/types'
+
+describe('Retcon voucher', () => {
+  it('enables unlimited boss blind rerolls at $10 per roll', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    // Simulate Director's Cut already purchased
+    game.staticRules.bossBlindRerolls = 1
+    game.staticRules.bossBlindRerollCost = 10
+    game.shopState.voucher = 'retcon'
+
+    const after = reduceGame(game, { type: 'SHOP_BUY_VOUCHER', id: 'retcon' })
+    expect(after.staticRules.bossBlindRerolls).toBe(Infinity)
+    expect(after.staticRules.bossBlindRerollCost).toBe(10)
+  })
+})

--- a/src/app/daily-card-game/domain/voucher/vouchers.ts
+++ b/src/app/daily-card-game/domain/voucher/vouchers.ts
@@ -501,12 +501,12 @@ export const retcon: VoucherDefinition = {
       event: { type: 'SHOP_BUY_VOUCHER', id: 'retcon' },
       priority: 1,
       apply: (ctx: EffectContext) => {
-        // TODO: Implement retcon effect
-        throw new Error('Not implemented' + JSON.stringify(ctx))
+        ctx.game.staticRules.bossBlindRerolls = Infinity
+        ctx.game.staticRules.bossBlindRerollCost = 10
       },
     },
   ],
-  dependentVoucher: null,
+  dependentVoucher: 'directorsCut',
 }
 
 export const paintBrush: VoucherDefinition = {
@@ -550,6 +550,7 @@ export const implementedVouchers: VoucherType[] = [
   'illusion',
   'planetTycoon',
   'directorsCut',
+  'retcon',
 ]
 
 export const vouchers: Record<VoucherType, VoucherDefinition> = {


### PR DESCRIPTION
## Summary
- Implements the Retcon voucher (#908) from epic #698 (Vouchers)
- Upgrades Director's Cut: allows unlimited boss blind rerolls at $10 per roll
- Sets `dependentVoucher` to `directorsCut` (upgrade chain)
- Adds `retcon` to the `implementedVouchers` list

## Test plan
- [x] Unit test verifies bossBlindRerolls set to Infinity and cost stays at 10

Closes #908

🤖 Generated with [Claude Code](https://claude.com/claude-code)