### PR TITLE
feat: implement Planet Merchant voucher

### DIFF
--- a/src/app/daily-card-game/domain/game/__tests__/voucher-planet-merchant.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/voucher-planet-merchant.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest'
+import { defaultGameState } from '@/app/daily-card-game/domain/game/default-game-state'
+import { reduceGame } from '@/app/daily-card-game/domain/game/reduce-game'
+import type { GameState } from '@/app/daily-card-game/domain/game/types'
+
+describe('Planet Merchant voucher', () => {
+  it('doubles celestialMultiplier so planet cards appear 2x more frequently', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    expect(game.shopState.celestialMultiplier).toBe(1)
+    game.shopState.voucher = 'planetMerchant'
+
+    const after = reduceGame(game, { type: 'SHOP_BUY_VOUCHER', id: 'planetMerchant' })
+    expect(after.shopState.celestialMultiplier).toBe(2)
+  })
+})

--- a/src/app/daily-card-game/domain/voucher/vouchers.ts
+++ b/src/app/daily-card-game/domain/voucher/vouchers.ts
@@ -321,8 +321,7 @@ export const planetMerchant: VoucherDefinition = {
       event: { type: 'SHOP_BUY_VOUCHER', id: 'planetMerchant' },
       priority: 1,
       apply: (ctx: EffectContext) => {
-        // TODO: Implement planet merchant effect
-        throw new Error('Not implemented' + JSON.stringify(ctx))
+        ctx.game.shopState.celestialMultiplier *= 2
       },
     },
   ],
@@ -550,6 +549,7 @@ export const implementedVouchers: VoucherType[] = [
   'illusion',
   'planetTycoon',
   'directorsCut',
+  'planetMerchant',
 ]
 
 export const vouchers: Record<VoucherType, VoucherDefinition> = {


### PR DESCRIPTION
## Summary
- Implements the Planet Merchant voucher (#897) from epic #698 (Vouchers)
- Doubles `shopState.celestialMultiplier` so planet cards appear 2x more frequently

## Test plan
- [x] Unit test verifies celestialMultiplier goes from 1 to 2

Closes #897

🤖 Generated with [Claude Code](https://claude.com/claude-code)