### PR TITLE
feat: implement Voucher tag

### DIFF
--- a/src/app/daily-card-game/domain/game/__tests__/tag-voucher.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/tag-voucher.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest'
+import { defaultGameState } from '@/app/daily-card-game/domain/game/default-game-state'
+import { reduceGame } from '@/app/daily-card-game/domain/game/reduce-game'
+import type { GameState } from '@/app/daily-card-game/domain/game/types'
+
+describe('Voucher tag', () => {
+  it('adds an extra voucher slot on SHOP_OPEN', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.tags = [{ id: 'tag-1', tagType: 'voucher' } as any]
+    const initialVouchers = game.shopState.maxVouchersForSale
+
+    const after = reduceGame(game, { type: 'SHOP_OPEN' })
+    expect(after.shopState.maxVouchersForSale).toBe(initialVouchers + 1)
+  })
+
+  it('removes the Voucher tag after use', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.tags = [{ id: 'tag-1', tagType: 'voucher' } as any]
+
+    const after = reduceGame(game, { type: 'SHOP_OPEN' })
+    expect(after.tags.find(t => t.tagType === 'voucher')).toBeUndefined()
+  })
+})

--- a/src/app/daily-card-game/domain/tag/tags.ts
+++ b/src/app/daily-card-game/domain/tag/tags.ts
@@ -209,7 +209,17 @@ const voucher: TagDefinition = {
   name: 'Voucher',
   benefit: 'Adds a Voucher to the next Shop.',
   minimumAnte: 1,
-  effects: [],
+  effects: [
+    {
+      event: { type: 'SHOP_OPEN' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        ctx.game.shopState.maxVouchersForSale += 1
+        const tag = ctx.game.tags.find(t => t.tagType === 'voucher')
+        if (tag) ctx.game.tags = ctx.game.tags.filter(t => t.id !== tag.id)
+      },
+    },
+  ],
 }
 
 const boss: TagDefinition = {
@@ -494,6 +504,7 @@ export const implementedTags: Partial<Record<TagType, TagDefinition>> = {
   holographic,
   foil,
   negative,
+  voucher,
 }
 
 /* Tags


### PR DESCRIPTION
## Summary
- Implements the Voucher tag (#918) from epic #699 (Tags)
- Adds an extra voucher slot (`maxVouchersForSale += 1`) on SHOP_OPEN
- Tag removes itself after use
- Adds `voucher` to `implementedTags`

## Test plan
- [x] Unit test verifies maxVouchersForSale increments
- [x] Unit test verifies tag removed after use

Closes #918

🤖 Generated with [Claude Code](https://claude.com/claude-code)