### PR TITLE
feat: implement Double tag

### DIFF
--- a/src/app/daily-card-game/domain/game/__tests__/tag-double.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/tag-double.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest'
+import { defaultGameState } from '@/app/daily-card-game/domain/game/default-game-state'
+import { reduceGame } from '@/app/daily-card-game/domain/game/reduce-game'
+import type { GameState } from '@/app/daily-card-game/domain/game/types'
+
+describe('Double tag', () => {
+  it('copies the first non-Double tag on SHOP_OPEN', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.tags = [
+      { id: 'tag-double', tagType: 'double' } as any,
+      { id: 'tag-juggle', tagType: 'juggle' } as any,
+    ]
+
+    const after = reduceGame(game, { type: 'SHOP_OPEN' })
+    // Double copies juggle at priority 0, then juggle fires at priority 1
+    // and removes the original. The copy remains.
+    const juggleTags = after.tags.filter(t => t.tagType === 'juggle')
+    expect(juggleTags.length).toBeGreaterThanOrEqual(1)
+    // Verify the copy has a different ID than the original
+    expect(after.tags.find(t => t.id !== 'tag-juggle' && t.tagType === 'juggle')).toBeDefined()
+  })
+
+  it('removes the Double tag after use', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.tags = [
+      { id: 'tag-double', tagType: 'double' } as any,
+      { id: 'tag-economy', tagType: 'economy' } as any,
+    ]
+
+    const after = reduceGame(game, { type: 'SHOP_OPEN' })
+    expect(after.tags.find(t => t.tagType === 'double')).toBeUndefined()
+  })
+
+  it('does nothing if no other tags exist', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.tags = [{ id: 'tag-double', tagType: 'double' } as any]
+
+    const after = reduceGame(game, { type: 'SHOP_OPEN' })
+    expect(after.tags.find(t => t.tagType === 'double')).toBeUndefined()
+    expect(after.tags.length).toBe(0)
+  })
+})

--- a/src/app/daily-card-game/domain/tag/tags.ts
+++ b/src/app/daily-card-game/domain/tag/tags.ts
@@ -1,6 +1,6 @@
 import type { EffectContext } from '@/app/daily-card-game/domain/events/types'
 import { getRandomCommonJoker, getRandomRareJoker, getRandomUncommonJoker, initializeJoker } from '@/app/daily-card-game/domain/joker/utils'
-import { buildSeedString, getRandomNumberWithSeed } from '@/app/daily-card-game/domain/randomness'
+import { buildSeedString, getRandomNumberWithSeed, uuid } from '@/app/daily-card-game/domain/randomness'
 import { getRandomBossBlind } from '@/app/daily-card-game/domain/round/boss-blinds'
 
 import { TagDefinition, TagType } from './types'
@@ -338,7 +338,21 @@ const double: TagDefinition = {
   name: 'Double',
   benefit: 'Gives a copy of the next Tag selected (excluding Double Tags).',
   minimumAnte: 1,
-  effects: [],
+  effects: [
+    {
+      event: { type: 'SHOP_OPEN' },
+      priority: 0,
+      apply: (ctx: EffectContext) => {
+        const otherTags = ctx.game.tags.filter(t => t.tagType !== 'double')
+        if (otherTags.length > 0) {
+          const tagToCopy = otherTags[0]
+          ctx.game.tags.push({ ...tagToCopy, id: uuid() })
+        }
+        const doubleTag = ctx.game.tags.find(t => t.tagType === 'double')
+        if (doubleTag) ctx.game.tags = ctx.game.tags.filter(t => t.id !== doubleTag.id)
+      },
+    },
+  ],
 }
 
 const juggle: TagDefinition = {
@@ -505,6 +519,7 @@ export const implementedTags: Partial<Record<TagType, TagDefinition>> = {
   foil,
   negative,
   voucher,
+  double,
 }
 
 /* Tags


### PR DESCRIPTION
## Summary
- Implements the Double tag (#934) from epic #699 (Tags)
- Copies the first non-Double tag on SHOP_OPEN with a new unique ID
- Runs at priority 0 (before other tags fire)
- Tag removes itself after use
- Adds `double` to `implementedTags`

## Test plan
- [x] Unit test verifies a copy of the next non-Double tag is created
- [x] Unit test verifies Double tag removed after use
- [x] Unit test verifies no error when no other tags exist

Closes #934

🤖 Generated with [Claude Code](https://claude.com/claude-code)