### PR TITLE
feat: implement Standard tag

### DIFF
--- a/src/app/daily-card-game/domain/booster-pack/utils.ts
+++ b/src/app/daily-card-game/domain/booster-pack/utils.ts
@@ -46,7 +46,7 @@ export const getPackDefinition = (
   }
 }
 
-const initializePackState = (game: GameState, packDefinition: PackDefinition): PackState => {
+export const initializePackState = (game: GameState, packDefinition: PackDefinition): PackState => {
   const id = uuid()
   const rarity = packDefinition.rarity
   const numberOfCardsToSelect = packDefinition.numberOfCardsToSelect

--- a/src/app/daily-card-game/domain/game/__tests__/tag-standard.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/tag-standard.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest'
+import { defaultGameState } from '@/app/daily-card-game/domain/game/default-game-state'
+import { reduceGame } from '@/app/daily-card-game/domain/game/reduce-game'
+import type { GameState } from '@/app/daily-card-game/domain/game/types'
+
+describe('Standard tag', () => {
+  it('adds a Mega Standard Pack to packsForSale on SHOP_OPEN', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.tags = [{ id: 'tag-1', tagType: 'standard' } as any]
+
+    const after = reduceGame(game, { type: 'SHOP_OPEN' })
+    const megaPacks = after.shopState.packsForSale.filter(p => p.rarity === 'mega')
+    expect(megaPacks.length).toBeGreaterThanOrEqual(1)
+  })
+
+  it('removes the Standard tag after use', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.tags = [{ id: 'tag-1', tagType: 'standard' } as any]
+
+    const after = reduceGame(game, { type: 'SHOP_OPEN' })
+    expect(after.tags.find(t => t.tagType === 'standard')).toBeUndefined()
+  })
+})

--- a/src/app/daily-card-game/domain/tag/tags.ts
+++ b/src/app/daily-card-game/domain/tag/tags.ts
@@ -1,4 +1,5 @@
 import type { EffectContext } from '@/app/daily-card-game/domain/events/types'
+import { getPackDefinition, initializePackState } from '@/app/daily-card-game/domain/booster-pack/utils'
 import { getRandomCommonJoker, getRandomRareJoker, getRandomUncommonJoker, initializeJoker } from '@/app/daily-card-game/domain/joker/utils'
 import { buildSeedString, getRandomNumberWithSeed, uuid } from '@/app/daily-card-game/domain/randomness'
 import { getRandomBossBlind } from '@/app/daily-card-game/domain/round/boss-blinds'
@@ -250,7 +251,19 @@ const standard: TagDefinition = {
   name: 'Standard',
   benefit: 'Immediately open a free Mega Standard Pack.',
   minimumAnte: 2,
-  effects: [],
+  effects: [
+    {
+      event: { type: 'SHOP_OPEN' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        const packDef = getPackDefinition('playingCard', 'mega')
+        const pack = initializePackState(ctx.game, packDef)
+        ctx.game.shopState.packsForSale.push(pack)
+        const tag = ctx.game.tags.find(t => t.tagType === 'standard')
+        if (tag) ctx.game.tags = ctx.game.tags.filter(t => t.id !== tag.id)
+      },
+    },
+  ],
 }
 
 const charm: TagDefinition = {
@@ -520,6 +533,7 @@ export const implementedTags: Partial<Record<TagType, TagDefinition>> = {
   negative,
   voucher,
   double,
+  standard,
 }
 
 /* Tags


### PR DESCRIPTION
## Summary
- Implements the Standard tag (#920) from epic #699 (Tags)
- Adds a free Mega Standard Pack to `packsForSale` on SHOP_OPEN
- Exports `initializePackState` from booster-pack utils (enables future pack tags: Charm, Meteor, Buffoon, Ethereal)
- Tag removes itself after use

## Test plan
- [x] Unit test verifies mega pack added to packsForSale
- [x] Unit test verifies tag removed after use

Closes #920

🤖 Generated with [Claude Code](https://claude.com/claude-code)