### PR TITLE
feat: implement Charm tag

### DIFF
--- a/src/app/daily-card-game/domain/game/__tests__/tag-charm.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/tag-charm.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest'
+import { defaultGameState } from '@/app/daily-card-game/domain/game/default-game-state'
+import { reduceGame } from '@/app/daily-card-game/domain/game/reduce-game'
+import type { GameState } from '@/app/daily-card-game/domain/game/types'
+
+describe('Charm tag', () => {
+  it('adds a Mega Arcana Pack to packsForSale on SHOP_OPEN', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.tags = [{ id: 'tag-1', tagType: 'charm' } as any]
+
+    const after = reduceGame(game, { type: 'SHOP_OPEN' })
+    const megaPacks = after.shopState.packsForSale.filter(p => p.rarity === 'mega')
+    expect(megaPacks.length).toBeGreaterThanOrEqual(1)
+  })
+
+  it('removes the Charm tag after use', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.tags = [{ id: 'tag-1', tagType: 'charm' } as any]
+
+    const after = reduceGame(game, { type: 'SHOP_OPEN' })
+    expect(after.tags.find(t => t.tagType === 'charm')).toBeUndefined()
+  })
+})

--- a/src/app/daily-card-game/domain/tag/tags.ts
+++ b/src/app/daily-card-game/domain/tag/tags.ts
@@ -271,7 +271,19 @@ const charm: TagDefinition = {
   name: 'Charm',
   benefit: 'Immediately open a free Mega Arcana Pack.',
   minimumAnte: 1,
-  effects: [],
+  effects: [
+    {
+      event: { type: 'SHOP_OPEN' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        const packDef = getPackDefinition('tarotCard', 'mega')
+        const pack = initializePackState(ctx.game, packDef)
+        ctx.game.shopState.packsForSale.push(pack)
+        const tag = ctx.game.tags.find(t => t.tagType === 'charm')
+        if (tag) ctx.game.tags = ctx.game.tags.filter(t => t.id !== tag.id)
+      },
+    },
+  ],
 }
 
 const meteor: TagDefinition = {
@@ -534,6 +546,7 @@ export const implementedTags: Partial<Record<TagType, TagDefinition>> = {
   voucher,
   double,
   standard,
+  charm,
 }
 
 /* Tags


### PR DESCRIPTION
## Summary
- Implements the Charm tag (#921) from epic #699 (Tags)
- Adds a free Mega Arcana Pack (tarot cards) to `packsForSale` on SHOP_OPEN
- Same pattern as Standard tag but with `tarotCard` type
- Adds `charm` to `implementedTags`

## Test plan
- [x] Unit test verifies mega pack added to packsForSale
- [x] Unit test verifies tag removed after use

Closes #921

🤖 Generated with [Claude Code](https://claude.com/claude-code)