### PR TITLE
feat: implement Meteor tag

### DIFF
--- a/src/app/daily-card-game/domain/game/__tests__/tag-meteor.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/tag-meteor.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest'
+import { defaultGameState } from '@/app/daily-card-game/domain/game/default-game-state'
+import { reduceGame } from '@/app/daily-card-game/domain/game/reduce-game'
+import type { GameState } from '@/app/daily-card-game/domain/game/types'
+
+describe('Meteor tag', () => {
+  it('adds a Mega Celestial Pack to packsForSale on SHOP_OPEN', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.tags = [{ id: 'tag-1', tagType: 'meteor' } as any]
+
+    const after = reduceGame(game, { type: 'SHOP_OPEN' })
+    const megaPacks = after.shopState.packsForSale.filter(p => p.rarity === 'mega')
+    expect(megaPacks.length).toBeGreaterThanOrEqual(1)
+  })
+
+  it('removes the Meteor tag after use', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.tags = [{ id: 'tag-1', tagType: 'meteor' } as any]
+
+    const after = reduceGame(game, { type: 'SHOP_OPEN' })
+    expect(after.tags.find(t => t.tagType === 'meteor')).toBeUndefined()
+  })
+})

--- a/src/app/daily-card-game/domain/tag/tags.ts
+++ b/src/app/daily-card-game/domain/tag/tags.ts
@@ -291,7 +291,19 @@ const meteor: TagDefinition = {
   name: 'Meteor',
   benefit: 'Immediately open a free Mega Celestial Pack.',
   minimumAnte: 2,
-  effects: [],
+  effects: [
+    {
+      event: { type: 'SHOP_OPEN' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        const packDef = getPackDefinition('celestialCard', 'mega')
+        const pack = initializePackState(ctx.game, packDef)
+        ctx.game.shopState.packsForSale.push(pack)
+        const tag = ctx.game.tags.find(t => t.tagType === 'meteor')
+        if (tag) ctx.game.tags = ctx.game.tags.filter(t => t.id !== tag.id)
+      },
+    },
+  ],
 }
 
 const buffoon: TagDefinition = {
@@ -547,6 +559,7 @@ export const implementedTags: Partial<Record<TagType, TagDefinition>> = {
   double,
   standard,
   charm,
+  meteor,
 }
 
 /* Tags


### PR DESCRIPTION
## Summary
- Implements the Meteor tag (#922) from epic #699 (Tags)
- Adds a free Mega Celestial Pack to `packsForSale` on SHOP_OPEN
- Adds `meteor` to `implementedTags`

## Test plan
- [x] Unit test verifies mega pack added
- [x] Unit test verifies tag removed after use

Closes #922

🤖 Generated with [Claude Code](https://claude.com/claude-code)