### PR TITLE
feat: implement Speed tag

### DIFF
--- a/src/app/daily-card-game/domain/game/__tests__/tag-speed.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/tag-speed.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+import { defaultGameState } from '@/app/daily-card-game/domain/game/default-game-state'
+import { reduceGame } from '@/app/daily-card-game/domain/game/reduce-game'
+import type { GameState } from '@/app/daily-card-game/domain/game/types'
+
+describe('Speed tag', () => {
+  it('gives at least $5 even with no skipped blinds', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.tags = [{ id: 'tag-1', tagType: 'speed' } as any]
+    const initialMoney = game.money
+
+    const after = reduceGame(game, { type: 'SHOP_OPEN' })
+    expect(after.money).toBe(initialMoney + 5)
+  })
+
+  it('gives $5 per skipped blind', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.tags = [{ id: 'tag-1', tagType: 'speed' } as any]
+    game.rounds[0].smallBlind.status = 'skipped'
+    game.rounds[0].bigBlind.status = 'skipped'
+    const initialMoney = game.money
+
+    const after = reduceGame(game, { type: 'SHOP_OPEN' })
+    expect(after.money).toBe(initialMoney + 10)
+  })
+
+  it('removes the Speed tag after use', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.tags = [{ id: 'tag-1', tagType: 'speed' } as any]
+
+    const after = reduceGame(game, { type: 'SHOP_OPEN' })
+    expect(after.tags.find(t => t.tagType === 'speed')).toBeUndefined()
+  })
+})

--- a/src/app/daily-card-game/domain/tag/tags.ts
+++ b/src/app/daily-card-game/domain/tag/tags.ts
@@ -452,7 +452,22 @@ const speed: TagDefinition = {
   name: 'Speed',
   benefit: "Gives $5 for each Blind you've skipped this run.",
   minimumAnte: 1,
-  effects: [],
+  effects: [
+    {
+      event: { type: 'SHOP_OPEN' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        let skipped = 0
+        for (const round of ctx.game.rounds) {
+          if (round.smallBlind.status === 'skipped') skipped++
+          if (round.bigBlind.status === 'skipped') skipped++
+        }
+        ctx.game.money += 5 * Math.max(skipped, 1)
+        const tag = ctx.game.tags.find(t => t.tagType === 'speed')
+        if (tag) ctx.game.tags = ctx.game.tags.filter(t => t.id !== tag.id)
+      },
+    },
+  ],
 }
 
 const orbital: TagDefinition = {
@@ -547,6 +562,7 @@ export const implementedTags: Partial<Record<TagType, TagDefinition>> = {
   double,
   standard,
   charm,
+  speed,
 }
 
 /* Tags


### PR DESCRIPTION
## Summary
- Implements the Speed tag (#928) from epic #699 (Tags)
- Gives $5 per blind skipped this run on SHOP_OPEN (minimum $5)
- Adds `speed` to `implementedTags`

## Test plan
- [x] Unit test verifies minimum $5
- [x] Unit test verifies $5 per skipped blind
- [x] Unit test verifies tag removed after use

Closes #928

🤖 Generated with [Claude Code](https://claude.com/claude-code)