### PR TITLE
feat: implement Buffoon tag

### DIFF
--- a/src/app/daily-card-game/domain/game/__tests__/tag-buffoon.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/tag-buffoon.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest'
+import { defaultGameState } from '@/app/daily-card-game/domain/game/default-game-state'
+import { reduceGame } from '@/app/daily-card-game/domain/game/reduce-game'
+import type { GameState } from '@/app/daily-card-game/domain/game/types'
+
+describe('Buffoon tag', () => {
+  it('adds a Mega Buffoon Pack to packsForSale on SHOP_OPEN', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.tags = [{ id: 'tag-1', tagType: 'buffoon' } as any]
+
+    const after = reduceGame(game, { type: 'SHOP_OPEN' })
+    const megaPacks = after.shopState.packsForSale.filter(p => p.rarity === 'mega')
+    expect(megaPacks.length).toBeGreaterThanOrEqual(1)
+  })
+
+  it('removes the Buffoon tag after use', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.tags = [{ id: 'tag-1', tagType: 'buffoon' } as any]
+
+    const after = reduceGame(game, { type: 'SHOP_OPEN' })
+    expect(after.tags.find(t => t.tagType === 'buffoon')).toBeUndefined()
+  })
+})

--- a/src/app/daily-card-game/domain/tag/tags.ts
+++ b/src/app/daily-card-game/domain/tag/tags.ts
@@ -311,7 +311,19 @@ const buffoon: TagDefinition = {
   name: 'Buffoon',
   benefit: 'Immediately open a free Mega Buffoon Pack.',
   minimumAnte: 2,
-  effects: [],
+  effects: [
+    {
+      event: { type: 'SHOP_OPEN' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        const packDef = getPackDefinition('jokerCard', 'mega')
+        const pack = initializePackState(ctx.game, packDef)
+        ctx.game.shopState.packsForSale.push(pack)
+        const tag = ctx.game.tags.find(t => t.tagType === 'buffoon')
+        if (tag) ctx.game.tags = ctx.game.tags.filter(t => t.id !== tag.id)
+      },
+    },
+  ],
 }
 
 const handy: TagDefinition = {
@@ -560,6 +572,7 @@ export const implementedTags: Partial<Record<TagType, TagDefinition>> = {
   standard,
   charm,
   meteor,
+  buffoon,
 }
 
 /* Tags


### PR DESCRIPTION
## Summary
- Implements the Buffoon tag (#923) from epic #699 (Tags)
- Adds a free Mega Buffoon Pack (joker cards) to `packsForSale` on SHOP_OPEN
- Adds `buffoon` to `implementedTags`

## Test plan
- [x] Unit test verifies mega pack added
- [x] Unit test verifies tag removed after use

Closes #923

🤖 Generated with [Claude Code](https://claude.com/claude-code)