### PR TITLE
feat: implement Ethereal tag

### DIFF
--- a/src/app/daily-card-game/domain/game/__tests__/tag-ethereal.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/tag-ethereal.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest'
+import { defaultGameState } from '@/app/daily-card-game/domain/game/default-game-state'
+import { reduceGame } from '@/app/daily-card-game/domain/game/reduce-game'
+import type { GameState } from '@/app/daily-card-game/domain/game/types'
+
+describe('Ethereal tag', () => {
+  it('adds a Spectral Pack to packsForSale on SHOP_OPEN', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.tags = [{ id: 'tag-1', tagType: 'ethereal' } as any]
+    const initialPacks = game.shopState.packsForSale.length
+
+    const after = reduceGame(game, { type: 'SHOP_OPEN' })
+    expect(after.shopState.packsForSale.length).toBeGreaterThan(initialPacks)
+  })
+
+  it('removes the Ethereal tag after use', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.tags = [{ id: 'tag-1', tagType: 'ethereal' } as any]
+
+    const after = reduceGame(game, { type: 'SHOP_OPEN' })
+    expect(after.tags.find(t => t.tagType === 'ethereal')).toBeUndefined()
+  })
+})

--- a/src/app/daily-card-game/domain/tag/tags.ts
+++ b/src/app/daily-card-game/domain/tag/tags.ts
@@ -371,7 +371,19 @@ const ethereal: TagDefinition = {
   name: 'Ethereal',
   benefit: 'Immediately open a free Spectral Pack.',
   minimumAnte: 2,
-  effects: [],
+  effects: [
+    {
+      event: { type: 'SHOP_OPEN' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        const packDef = getPackDefinition('spectralCard', 'normal')
+        const pack = initializePackState(ctx.game, packDef)
+        ctx.game.shopState.packsForSale.push(pack)
+        const tag = ctx.game.tags.find(t => t.tagType === 'ethereal')
+        if (tag) ctx.game.tags = ctx.game.tags.filter(t => t.id !== tag.id)
+      },
+    },
+  ],
 }
 
 const coupon: TagDefinition = {
@@ -573,6 +585,7 @@ export const implementedTags: Partial<Record<TagType, TagDefinition>> = {
   charm,
   meteor,
   buffoon,
+  ethereal,
 }
 
 /* Tags


### PR DESCRIPTION
## Summary
- Implements the Ethereal tag (#924) from epic #699 (Tags)
- Adds a free Spectral Pack (normal rarity) to `packsForSale` on SHOP_OPEN
- Completes all 5 pack-giving tags: Standard, Charm, Meteor, Buffoon, Ethereal
- Adds `ethereal` to `implementedTags`

## Test plan
- [x] Unit test verifies pack added to packsForSale
- [x] Unit test verifies tag removed after use

Closes #924

🤖 Generated with [Claude Code](https://claude.com/claude-code)