### PR TITLE
feat: implement Speed and Ethereal tags

### DIFF
--- a/src/app/daily-card-game/domain/game/__tests__/tag-ethereal.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/tag-ethereal.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest'
+import { defaultGameState } from '@/app/daily-card-game/domain/game/default-game-state'
+import { reduceGame } from '@/app/daily-card-game/domain/game/reduce-game'
+import type { GameState } from '@/app/daily-card-game/domain/game/types'
+
+describe('Ethereal tag', () => {
+  it('adds a Spectral Pack to packsForSale on SHOP_OPEN', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.tags = [{ id: 'tag-1', tagType: 'ethereal' } as any]
+    const initialPacks = game.shopState.packsForSale.length
+
+    const after = reduceGame(game, { type: 'SHOP_OPEN' })
+    expect(after.shopState.packsForSale.length).toBeGreaterThan(initialPacks)
+  })
+
+  it('removes the Ethereal tag after use', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.tags = [{ id: 'tag-1', tagType: 'ethereal' } as any]
+
+    const after = reduceGame(game, { type: 'SHOP_OPEN' })
+    expect(after.tags.find(t => t.tagType === 'ethereal')).toBeUndefined()
+  })
+})

--- a/src/app/daily-card-game/domain/game/__tests__/tag-speed.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/tag-speed.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+import { defaultGameState } from '@/app/daily-card-game/domain/game/default-game-state'
+import { reduceGame } from '@/app/daily-card-game/domain/game/reduce-game'
+import type { GameState } from '@/app/daily-card-game/domain/game/types'
+
+describe('Speed tag', () => {
+  it('gives at least $5 even with no skipped blinds', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.tags = [{ id: 'tag-1', tagType: 'speed' } as any]
+    const initialMoney = game.money
+
+    const after = reduceGame(game, { type: 'SHOP_OPEN' })
+    expect(after.money).toBe(initialMoney + 5)
+  })
+
+  it('gives $5 per skipped blind', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.tags = [{ id: 'tag-1', tagType: 'speed' } as any]
+    game.rounds[0].smallBlind.status = 'skipped'
+    game.rounds[0].bigBlind.status = 'skipped'
+    const initialMoney = game.money
+
+    const after = reduceGame(game, { type: 'SHOP_OPEN' })
+    expect(after.money).toBe(initialMoney + 10)
+  })
+
+  it('removes the Speed tag after use', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.tags = [{ id: 'tag-1', tagType: 'speed' } as any]
+
+    const after = reduceGame(game, { type: 'SHOP_OPEN' })
+    expect(after.tags.find(t => t.tagType === 'speed')).toBeUndefined()
+  })
+})

--- a/src/app/daily-card-game/domain/tag/tags.ts
+++ b/src/app/daily-card-game/domain/tag/tags.ts
@@ -371,7 +371,19 @@ const ethereal: TagDefinition = {
   name: 'Ethereal',
   benefit: 'Immediately open a free Spectral Pack.',
   minimumAnte: 2,
-  effects: [],
+  effects: [
+    {
+      event: { type: 'SHOP_OPEN' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        const packDef = getPackDefinition('spectralCard', 'normal')
+        const pack = initializePackState(ctx.game, packDef)
+        ctx.game.shopState.packsForSale.push(pack)
+        const tag = ctx.game.tags.find(t => t.tagType === 'ethereal')
+        if (tag) ctx.game.tags = ctx.game.tags.filter(t => t.id !== tag.id)
+      },
+    },
+  ],
 }
 
 const coupon: TagDefinition = {
@@ -476,7 +488,22 @@ const speed: TagDefinition = {
   name: 'Speed',
   benefit: "Gives $5 for each Blind you've skipped this run.",
   minimumAnte: 1,
-  effects: [],
+  effects: [
+    {
+      event: { type: 'SHOP_OPEN' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        let skipped = 0
+        for (const round of ctx.game.rounds) {
+          if (round.smallBlind.status === 'skipped') skipped++
+          if (round.bigBlind.status === 'skipped') skipped++
+        }
+        ctx.game.money += 5 * Math.max(skipped, 1)
+        const tag = ctx.game.tags.find(t => t.tagType === 'speed')
+        if (tag) ctx.game.tags = ctx.game.tags.filter(t => t.id !== tag.id)
+      },
+    },
+  ],
 }
 
 const orbital: TagDefinition = {
@@ -573,6 +600,8 @@ export const implementedTags: Partial<Record<TagType, TagDefinition>> = {
   charm,
   meteor,
   buffoon,
+  speed,
+  ethereal,
 }
 
 /* Tags


### PR DESCRIPTION
## Summary
- Implements Speed tag (#928): $5 per blind skipped this run (minimum $5) on SHOP_OPEN
- Implements Ethereal tag (#924): free Spectral Pack (normal rarity) on SHOP_OPEN
- Both tags remove themselves after use
- Bundled to avoid repeated `implementedTags` merge conflicts

## Test plan
- [x] Speed: 3 tests pass (min $5, $5 per skip, tag removed)
- [x] Ethereal: 2 tests pass (pack added, tag removed)

Closes #928
Closes #924

🤖 Generated with [Claude Code](https://claude.com/claude-code)