### PR TITLE
feat: implement Crystal Ball voucher

### DIFF
--- a/src/app/daily-card-game/domain/game/__tests__/voucher-crystal-ball.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/voucher-crystal-ball.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest'
+import { defaultGameState } from '@/app/daily-card-game/domain/game/default-game-state'
+import { reduceGame } from '@/app/daily-card-game/domain/game/reduce-game'
+import type { GameState } from '@/app/daily-card-game/domain/game/types'
+
+describe('Crystal Ball voucher', () => {
+  it('adds +1 consumable slot', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    const initialSlots = game.maxConsumables
+    game.shopState.voucher = 'crystalBall'
+
+    const after = reduceGame(game, { type: 'SHOP_BUY_VOUCHER', id: 'crystalBall' })
+    expect(after.maxConsumables).toBe(initialSlots + 1)
+  })
+})

--- a/src/app/daily-card-game/domain/voucher/vouchers.ts
+++ b/src/app/daily-card-game/domain/voucher/vouchers.ts
@@ -155,8 +155,7 @@ export const crystalBall: VoucherDefinition = {
       event: { type: 'SHOP_BUY_VOUCHER', id: 'crystalBall' },
       priority: 1,
       apply: (ctx: EffectContext) => {
-        // TODO: Implement crystal ball effect
-        throw new Error('Not implemented' + JSON.stringify(ctx))
+        ctx.game.maxConsumables += 1
       },
     },
   ],
@@ -565,6 +564,7 @@ export const implementedVouchers: VoucherType[] = [
   'retcon',
   'paintBrush',
   'palette',
+  'crystalBall',
 ]
 
 export const vouchers: Record<VoucherType, VoucherDefinition> = {


### PR DESCRIPTION
## Summary
- Implements the Crystal Ball voucher (#885) from epic #698 (Vouchers)
- Adds +1 consumable slot (`maxConsumables += 1`) when purchased
- Prerequisite for Magic Deck implementation

## Test plan
- [x] Unit test verifies maxConsumables increments by 1

Closes #885

🤖 Generated with [Claude Code](https://claude.com/claude-code)