### PR TITLE
feat: implement Black Hole spectral card

### DIFF
--- a/src/app/daily-card-game/domain/game/__tests__/spectral-black-hole.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/spectral-black-hole.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest'
+import { defaultGameState } from '@/app/daily-card-game/domain/game/default-game-state'
+import { reduceGame } from '@/app/daily-card-game/domain/game/reduce-game'
+import type { GameState } from '@/app/daily-card-game/domain/game/types'
+
+describe('Black Hole spectral card', () => {
+  it('upgrades every poker hand by 1 level', () => {
+    const game: GameState = structuredClone(defaultGameState)
+
+    // Set up a pack with a Black Hole spectral card
+    game.shopState.openPackState = {
+      id: 'test-pack',
+      cards: [
+        {
+          card: { id: 'black-hole-1', spectralType: 'blackHole' } as any,
+          type: 'spectralCard',
+          cardType: 'spectralCard',
+          price: 0,
+        },
+      ],
+      rarity: 'normal',
+      remainingCardsToSelect: 1,
+    }
+
+    // Record initial levels
+    const initialLevels: Record<string, number> = {}
+    for (const [handId, hand] of Object.entries(game.pokerHands)) {
+      initialLevels[handId] = hand.level
+    }
+
+    const after = reduceGame(game, {
+      type: 'SHOP_USE_SPECTRAL_CARD_FROM_PACK',
+      id: 'black-hole-1',
+    })
+
+    // Verify every poker hand level increased by 1
+    for (const [handId, hand] of Object.entries(after.pokerHands)) {
+      expect(hand.level).toBe(initialLevels[handId] + 1)
+    }
+  })
+})

--- a/src/app/daily-card-game/domain/spectral/spectal-cards.ts
+++ b/src/app/daily-card-game/domain/spectral/spectal-cards.ts
@@ -193,7 +193,18 @@ const blackHole: SpectralCardDefinition = {
   name: 'Black Hole',
   description:
     'Upgrades every poker hand (including secret hands not yet discovered) by one level.',
-  effects: [],
+  effects: [
+    {
+      event: { type: 'SPECTRAL_CARD_USED' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        for (const handId of Object.keys(ctx.game.pokerHands)) {
+          const hand = ctx.game.pokerHands[handId as keyof typeof ctx.game.pokerHands]
+          hand.level += 1
+        }
+      },
+    },
+  ],
 }
 
 export const spectralCards: Record<SpectralCardType, SpectralCardDefinition> = {
@@ -218,6 +229,7 @@ export const spectralCards: Record<SpectralCardType, SpectralCardDefinition> = {
 }
 export const implementedSpectralCards: Partial<typeof spectralCards> = {
   familiar,
+  blackHole,
 }
 
 /**


### PR DESCRIPTION
## Summary
- Implements Black Hole spectral card (#880) from epic #697 (Spectral Cards)
- Upgrades every poker hand (including secret hands) by 1 level when used
- Adds `blackHole` to `implementedSpectralCards`

## Test plan
- [x] Unit test verifies all poker hand levels increase by 1

Closes #880

🤖 Generated with [Claude Code](https://claude.com/claude-code)