### PR TITLE
feat: implement Hone and Glow Up vouchers

### DIFF
--- a/src/app/daily-card-game/domain/game/__tests__/voucher-hone-glowup.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/voucher-hone-glowup.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+import { defaultGameState } from '@/app/daily-card-game/domain/game/default-game-state'
+import { reduceGame } from '@/app/daily-card-game/domain/game/reduce-game'
+import type { GameState } from '@/app/daily-card-game/domain/game/types'
+
+describe('Hone and Glow Up vouchers', () => {
+  it('Hone doubles edition weights and playing card edition chance', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    const origHolo = game.shopState.joker.editionWeights.holographic
+    const origFoil = game.shopState.joker.editionWeights.foil
+    const origPoly = game.shopState.joker.editionWeights.polychrome
+    const origEditionChance = game.shopState.playingCard.editionBaseChance
+    game.shopState.voucher = 'hone'
+
+    const after = reduceGame(game, { type: 'SHOP_BUY_VOUCHER', id: 'hone' })
+    expect(after.shopState.joker.editionWeights.holographic).toBe(origHolo * 2)
+    expect(after.shopState.joker.editionWeights.foil).toBe(origFoil * 2)
+    expect(after.shopState.joker.editionWeights.polychrome).toBe(origPoly * 2)
+    expect(after.shopState.playingCard.editionBaseChance).toBe(origEditionChance * 2)
+  })
+
+  it('Glow Up doubles again for cumulative 4x', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.shopState.joker.editionWeights.holographic *= 2
+    game.shopState.joker.editionWeights.foil *= 2
+    game.shopState.joker.editionWeights.polychrome *= 2
+    game.shopState.playingCard.editionBaseChance *= 2
+    const afterHoneHolo = game.shopState.joker.editionWeights.holographic
+    game.shopState.voucher = 'glowUp'
+
+    const after = reduceGame(game, { type: 'SHOP_BUY_VOUCHER', id: 'glowUp' })
+    expect(after.shopState.joker.editionWeights.holographic).toBe(afterHoneHolo * 2)
+  })
+})

--- a/src/app/daily-card-game/domain/voucher/vouchers.ts
+++ b/src/app/daily-card-game/domain/voucher/vouchers.ts
@@ -89,8 +89,10 @@ export const hone: VoucherDefinition = {
       event: { type: 'SHOP_BUY_VOUCHER', id: 'hone' },
       priority: 1,
       apply: (ctx: EffectContext) => {
-        // TODO: Implement hone effect
-        throw new Error('Not implemented' + JSON.stringify(ctx))
+        ctx.game.shopState.joker.editionWeights.holographic *= 2
+        ctx.game.shopState.joker.editionWeights.foil *= 2
+        ctx.game.shopState.joker.editionWeights.polychrome *= 2
+        ctx.game.shopState.playingCard.editionBaseChance *= 2
       },
     },
   ],
@@ -106,12 +108,14 @@ export const glowUp: VoucherDefinition = {
       event: { type: 'SHOP_BUY_VOUCHER', id: 'glowUp' },
       priority: 1,
       apply: (ctx: EffectContext) => {
-        // TODO: Implement glow up effect
-        throw new Error('Not implemented' + JSON.stringify(ctx))
+        ctx.game.shopState.joker.editionWeights.holographic *= 2
+        ctx.game.shopState.joker.editionWeights.foil *= 2
+        ctx.game.shopState.joker.editionWeights.polychrome *= 2
+        ctx.game.shopState.playingCard.editionBaseChance *= 2
       },
     },
   ],
-  dependentVoucher: null,
+  dependentVoucher: 'hone',
 }
 
 export const rerollSurplus: VoucherDefinition = {
@@ -565,6 +569,8 @@ export const implementedVouchers: VoucherType[] = [
   'paintBrush',
   'palette',
   'crystalBall',
+  'hone',
+  'glowUp',
 ]
 
 export const vouchers: Record<VoucherType, VoucherDefinition> = {


### PR DESCRIPTION
## Summary
- Implements Hone (#881) and Glow Up (#882) from epic #698 (Vouchers)
- Hone: doubles edition weights and playing card edition chance (2x)
- Glow Up: doubles again for cumulative 4x, depends on Hone

## Test plan
- [x] All tests pass

Closes #881
Closes #882

🤖 Generated with [Claude Code](https://claude.com/claude-code)