### PR TITLE
feat: implement Wraith spectral card

### DIFF
--- a/src/app/daily-card-game/domain/game/__tests__/spectral-wraith.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/spectral-wraith.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+import { defaultGameState } from '@/app/daily-card-game/domain/game/default-game-state'
+import { reduceGame } from '@/app/daily-card-game/domain/game/reduce-game'
+import type { GameState } from '@/app/daily-card-game/domain/game/types'
+
+describe('Wraith spectral card', () => {
+  it('creates a rare joker and sets money to $0', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.money = 50
+    game.shopState.openPackState = {
+      id: 'test-pack',
+      cards: [
+        {
+          card: { id: 'wraith-1', spectralType: 'wraith' } as any,
+          type: 'spectralCard',
+          cardType: 'spectralCard',
+          price: 0,
+        },
+      ],
+      rarity: 'normal',
+      remainingCardsToSelect: 1,
+    }
+
+    const initialJokers = game.jokers.length
+    const after = reduceGame(game, {
+      type: 'SHOP_USE_SPECTRAL_CARD_FROM_PACK',
+      id: 'wraith-1',
+    })
+
+    expect(after.jokers.length).toBe(initialJokers + 1)
+    expect(after.money).toBe(0)
+  })
+})

--- a/src/app/daily-card-game/domain/spectral/spectal-cards.ts
+++ b/src/app/daily-card-game/domain/spectral/spectal-cards.ts
@@ -4,6 +4,7 @@ import {
   removeOwnedCard,
 } from '@/app/daily-card-game/domain/game/card-registry-utils'
 import { GameState } from '@/app/daily-card-game/domain/game/types'
+import { getRandomRareJoker, initializeJoker } from '@/app/daily-card-game/domain/joker/utils'
 import {
   getRandomEnchantment,
   getRandomPlayingCardsWithFilters,
@@ -105,7 +106,22 @@ const wraith: SpectralCardDefinition = {
   spectralType: 'wraith',
   name: 'Wraith',
   description: 'Creates a random Rare Joker (must have room), but sets money to $0.',
-  effects: [],
+  isPlayable: (game: GameState) => game.jokers.length < game.maxJokers,
+  effects: [
+    {
+      event: { type: 'SPECTRAL_CARD_USED' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        if (ctx.game.jokers.length >= ctx.game.maxJokers) return
+        const rareJokerDef = getRandomRareJoker(ctx.game)
+        if (rareJokerDef) {
+          const jokerState = initializeJoker(rareJokerDef, ctx.game)
+          ctx.game.jokers.push(jokerState)
+        }
+        ctx.game.money = 0
+      },
+    },
+  ],
 }
 
 const sigil: SpectralCardDefinition = {
@@ -230,6 +246,7 @@ export const spectralCards: Record<SpectralCardType, SpectralCardDefinition> = {
 export const implementedSpectralCards: Partial<typeof spectralCards> = {
   familiar,
   blackHole,
+  wraith,
 }
 
 /**


### PR DESCRIPTION
## Summary
- Implements Wraith spectral card (#868) from epic #697 (Spectral Cards)
- Creates a random Rare Joker and sets money to $0
- Only playable when there's room for another joker

## Test plan
- [x] Unit test verifies joker added and money set to $0

Closes #868

🤖 Generated with [Claude Code](https://claude.com/claude-code)