### PR TITLE
feat: implement Immolate spectral card

### DIFF
--- a/src/app/daily-card-game/domain/game/__tests__/spectral-immolate.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/spectral-immolate.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest'
+import { defaultGameState } from '@/app/daily-card-game/domain/game/default-game-state'
+import { reduceGame } from '@/app/daily-card-game/domain/game/reduce-game'
+import type { GameState } from '@/app/daily-card-game/domain/game/types'
+
+describe('Immolate spectral card', () => {
+  it('destroys up to 5 cards from hand and gains $20', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.money = 10
+
+    // Put some owned card IDs into the hand
+    const handCardIds = game.ownedCardIds.slice(0, 8)
+    game.gamePlayState.handIds = handCardIds
+
+    game.shopState.openPackState = {
+      id: 'test-pack',
+      cards: [
+        {
+          card: { id: 'immolate-1', spectralType: 'immolate' } as any,
+          type: 'spectralCard',
+          cardType: 'spectralCard',
+          price: 0,
+        },
+      ],
+      rarity: 'normal',
+      remainingCardsToSelect: 1,
+    }
+
+    const initialOwned = game.ownedCardIds.length
+    const after = reduceGame(game, {
+      type: 'SHOP_USE_SPECTRAL_CARD_FROM_PACK',
+      id: 'immolate-1',
+    })
+
+    expect(after.ownedCardIds.length).toBe(initialOwned - 5)
+    expect(after.money).toBe(30) // 10 + 20
+  })
+})

--- a/src/app/daily-card-game/domain/spectral/spectal-cards.ts
+++ b/src/app/daily-card-game/domain/spectral/spectal-cards.ts
@@ -134,7 +134,33 @@ const immolate: SpectralCardDefinition = {
   spectralType: 'immolate',
   name: 'Immolate',
   description: 'Destroys 5 random cards in hand, but gain $20.',
-  effects: [],
+  isPlayable: (game: GameState) => game.gamePlayState.handIds.length > 0,
+  effects: [
+    {
+      event: { type: 'SPECTRAL_CARD_USED' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        const handIds = [...ctx.game.gamePlayState.handIds]
+        const cardsToDestroy = Math.min(5, handIds.length)
+
+        // Pick random unique indices to destroy
+        const idsToRemove: string[] = []
+        const remaining = [...handIds]
+        for (let i = 0; i < cardsToDestroy && remaining.length > 0; i++) {
+          const seed = buildSeedString([ctx.game.gameSeed, ctx.game.roundIndex.toString(), 'immolate', i.toString()])
+          const idx = getRandomNumberWithSeed(seed, 0, remaining.length - 1)
+          idsToRemove.push(remaining[idx])
+          remaining.splice(idx, 1)
+        }
+
+        for (const cardId of idsToRemove) {
+          removeOwnedCard(ctx.game, cardId)
+        }
+
+        ctx.game.money += 20
+      },
+    },
+  ],
 }
 
 const ankh: SpectralCardDefinition = {
@@ -230,6 +256,7 @@ export const spectralCards: Record<SpectralCardType, SpectralCardDefinition> = {
 export const implementedSpectralCards: Partial<typeof spectralCards> = {
   familiar,
   blackHole,
+  immolate,
 }
 
 /**


### PR DESCRIPTION
## Summary
- Implements Immolate spectral card (#872) from epic #697 (Spectral Cards)
- Destroys up to 5 random cards from hand and gains $20
- Uses seeded random for reproducibility

## Test plan
- [x] Unit test verifies 5 cards destroyed and $20 gained

Closes #872

🤖 Generated with [Claude Code](https://claude.com/claude-code)