### PR TITLE
feat: implement Ouija spectral card

### DIFF
--- a/src/app/daily-card-game/domain/game/__tests__/spectral-ouija.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/spectral-ouija.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest'
+import { defaultGameState } from '@/app/daily-card-game/domain/game/default-game-state'
+import { reduceGame } from '@/app/daily-card-game/domain/game/reduce-game'
+import type { GameState } from '@/app/daily-card-game/domain/game/types'
+import { playingCards } from '@/app/daily-card-game/domain/playing-card/playing-cards'
+
+describe('Ouija spectral card', () => {
+  it('converts all hand cards to same rank and reduces hand size by 1', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    const handCardIds = game.ownedCardIds.slice(0, 5)
+    game.gamePlayState.handIds = handCardIds
+    const initialHandSize = game.handSizeModifier
+
+    game.shopState.openPackState = {
+      id: 'test-pack',
+      cards: [
+        {
+          card: { id: 'ouija-1', spectralType: 'ouija' } as any,
+          type: 'spectralCard',
+          cardType: 'spectralCard',
+          price: 0,
+        },
+      ],
+      rarity: 'normal',
+      remainingCardsToSelect: 1,
+    }
+
+    const after = reduceGame(game, {
+      type: 'SHOP_USE_SPECTRAL_CARD_FROM_PACK',
+      id: 'ouija-1',
+    })
+
+    // All hand cards should have the same value
+    const handValues = after.gamePlayState.handIds.map(id => {
+      const card = after.cards[id]
+      if (!card || !('playingCardId' in card)) return null
+      return playingCards[card.playingCardId]?.value
+    }).filter(Boolean)
+
+    const uniqueValues = new Set(handValues)
+    expect(uniqueValues.size).toBe(1)
+
+    // Hand size reduced
+    expect(after.handSizeModifier).toBe(initialHandSize - 1)
+  })
+})

--- a/src/app/daily-card-game/domain/spectral/spectal-cards.ts
+++ b/src/app/daily-card-game/domain/spectral/spectal-cards.ts
@@ -10,6 +10,7 @@ import {
   getRandomPlayingCardsWithFilters,
   initializePlayingCard,
 } from '@/app/daily-card-game/domain/playing-card/utils'
+import { playingCards } from '@/app/daily-card-game/domain/playing-card/playing-cards'
 import { buildSeedString, getRandomNumberWithSeed } from '@/app/daily-card-game/domain/randomness'
 
 import { SpectralCardDefinition, SpectralCardType } from './types'
@@ -135,7 +136,29 @@ const ouija: SpectralCardDefinition = {
   spectralType: 'ouija',
   name: 'Ouija',
   description: 'Converts all cards in hand to a single random rank, but -1 Hand Size.',
-  effects: [],
+  isPlayable: (game: GameState) => game.gamePlayState.handIds.length > 0,
+  effects: [
+    {
+      event: { type: 'SPECTRAL_CARD_USED' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        const allValues = ['2', '3', '4', '5', '6', '7', '8', '9', '10', 'J', 'Q', 'K', 'A']
+        const seed = buildSeedString([ctx.game.gameSeed, ctx.game.roundIndex.toString(), 'ouija'])
+        const roll = getRandomNumberWithSeed(seed, 0, allValues.length - 1)
+        const targetValue = allValues[roll]
+
+        for (const cardId of ctx.game.gamePlayState.handIds) {
+          const cardState = ctx.game.cards[cardId]
+          if (!cardState || !('playingCardId' in cardState)) continue
+          const cardDef = playingCards[cardState.playingCardId]
+          if (!cardDef) continue
+          cardState.playingCardId = `${targetValue}_${cardDef.suit}` as any
+        }
+
+        ctx.game.handSizeModifier -= 1
+      },
+    },
+  ],
 }
 
 const ectoplasm: SpectralCardDefinition = {
@@ -247,6 +270,7 @@ export const implementedSpectralCards: Partial<typeof spectralCards> = {
   familiar,
   blackHole,
   wraith,
+  ouija,
 }
 
 /**


### PR DESCRIPTION
## Summary
- Implements Ouija spectral card (#870) from epic #697 (Spectral Cards)
- Converts all cards in hand to a single randomly selected rank (keeps suits)
- Permanently reduces hand size by 1

## Test plan
- [x] Unit test verifies all hand cards converted to same rank and hand size reduced

Closes #870

🤖 Generated with [Claude Code](https://claude.com/claude-code)