### PR TITLE
feat: implement Sigil spectral card

### DIFF
--- a/src/app/daily-card-game/domain/game/__tests__/spectral-sigil.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/spectral-sigil.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest'
+import { defaultGameState } from '@/app/daily-card-game/domain/game/default-game-state'
+import { reduceGame } from '@/app/daily-card-game/domain/game/reduce-game'
+import type { GameState } from '@/app/daily-card-game/domain/game/types'
+import { playingCards } from '@/app/daily-card-game/domain/playing-card/playing-cards'
+
+describe('Sigil spectral card', () => {
+  it('converts all hand cards to the same suit', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    const handCardIds = game.ownedCardIds.slice(0, 5)
+    game.gamePlayState.handIds = handCardIds
+
+    game.shopState.openPackState = {
+      id: 'test-pack',
+      cards: [
+        {
+          card: { id: 'sigil-1', spectralType: 'sigil' } as any,
+          type: 'spectralCard',
+          cardType: 'spectralCard',
+          price: 0,
+        },
+      ],
+      rarity: 'normal',
+      remainingCardsToSelect: 1,
+    }
+
+    const after = reduceGame(game, {
+      type: 'SHOP_USE_SPECTRAL_CARD_FROM_PACK',
+      id: 'sigil-1',
+    })
+
+    const handSuits = after.gamePlayState.handIds.map(id => {
+      const card = after.cards[id]
+      if (!card || !('playingCardId' in card)) return null
+      return playingCards[card.playingCardId]?.suit
+    }).filter(Boolean)
+
+    const uniqueSuits = new Set(handSuits)
+    expect(uniqueSuits.size).toBe(1)
+  })
+})

--- a/src/app/daily-card-game/domain/spectral/spectal-cards.ts
+++ b/src/app/daily-card-game/domain/spectral/spectal-cards.ts
@@ -10,6 +10,7 @@ import {
   getRandomPlayingCardsWithFilters,
   initializePlayingCard,
 } from '@/app/daily-card-game/domain/playing-card/utils'
+import { playingCards } from '@/app/daily-card-game/domain/playing-card/playing-cards'
 import { buildSeedString, getRandomNumberWithSeed } from '@/app/daily-card-game/domain/randomness'
 
 import { SpectralCardDefinition, SpectralCardType } from './types'
@@ -128,7 +129,27 @@ const sigil: SpectralCardDefinition = {
   spectralType: 'sigil',
   name: 'Sigil',
   description: 'Converts all cards in hand to a single random suit.',
-  effects: [],
+  isPlayable: (game: GameState) => game.gamePlayState.handIds.length > 0,
+  effects: [
+    {
+      event: { type: 'SPECTRAL_CARD_USED' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        const suits = ['hearts', 'diamonds', 'clubs', 'spades'] as const
+        const seed = buildSeedString([ctx.game.gameSeed, ctx.game.roundIndex.toString(), 'sigil'])
+        const roll = getRandomNumberWithSeed(seed, 0, suits.length - 1)
+        const targetSuit = suits[roll]
+
+        for (const cardId of ctx.game.gamePlayState.handIds) {
+          const cardState = ctx.game.cards[cardId]
+          if (!cardState || !('playingCardId' in cardState)) continue
+          const cardDef = playingCards[cardState.playingCardId]
+          if (!cardDef) continue
+          cardState.playingCardId = `${cardDef.value}_${targetSuit}` as any
+        }
+      },
+    },
+  ],
 }
 
 const ouija: SpectralCardDefinition = {
@@ -285,6 +306,7 @@ export const implementedSpectralCards: Partial<typeof spectralCards> = {
   wraith,
   immolate,
   ectoplasm,
+  sigil,
 }
 
 /**


### PR DESCRIPTION
## Summary
- Implements Sigil spectral card (#869) from epic #697 (Spectral Cards)
- Converts all cards in hand to a single randomly selected suit (keeps ranks)
- Companion to Ouija (which converts ranks)

## Test plan
- [x] Unit test verifies all hand cards converted to same suit

Closes #869

🤖 Generated with [Claude Code](https://claude.com/claude-code)