### PR TITLE
feat: implement Sigil and Ouija spectral cards

### DIFF
--- a/src/app/daily-card-game/domain/game/__tests__/spectral-ouija.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/spectral-ouija.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest'
+import { defaultGameState } from '@/app/daily-card-game/domain/game/default-game-state'
+import { reduceGame } from '@/app/daily-card-game/domain/game/reduce-game'
+import type { GameState } from '@/app/daily-card-game/domain/game/types'
+import { playingCards } from '@/app/daily-card-game/domain/playing-card/playing-cards'
+
+describe('Ouija spectral card', () => {
+  it('converts all hand cards to same rank and reduces hand size', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.gamePlayState.handIds = game.ownedCardIds.slice(0, 5)
+    const initialHandSize = game.handSizeModifier
+    game.shopState.openPackState = {
+      id: 'test-pack',
+      cards: [{ card: { id: 'ouija-1', spectralType: 'ouija' } as any, type: 'spectralCard', cardType: 'spectralCard', price: 0 }],
+      rarity: 'normal',
+      remainingCardsToSelect: 1,
+    }
+    const after = reduceGame(game, { type: 'SHOP_USE_SPECTRAL_CARD_FROM_PACK', id: 'ouija-1' })
+    const values = after.gamePlayState.handIds.map(id => {
+      const c = after.cards[id]
+      return c && 'playingCardId' in c ? playingCards[c.playingCardId]?.value : null
+    }).filter(Boolean)
+    expect(new Set(values).size).toBe(1)
+    expect(after.handSizeModifier).toBe(initialHandSize - 1)
+  })
+})

--- a/src/app/daily-card-game/domain/game/__tests__/spectral-sigil.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/spectral-sigil.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest'
+import { defaultGameState } from '@/app/daily-card-game/domain/game/default-game-state'
+import { reduceGame } from '@/app/daily-card-game/domain/game/reduce-game'
+import type { GameState } from '@/app/daily-card-game/domain/game/types'
+import { playingCards } from '@/app/daily-card-game/domain/playing-card/playing-cards'
+
+describe('Sigil spectral card', () => {
+  it('converts all hand cards to the same suit', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.gamePlayState.handIds = game.ownedCardIds.slice(0, 5)
+    game.shopState.openPackState = {
+      id: 'test-pack',
+      cards: [{ card: { id: 'sigil-1', spectralType: 'sigil' } as any, type: 'spectralCard', cardType: 'spectralCard', price: 0 }],
+      rarity: 'normal',
+      remainingCardsToSelect: 1,
+    }
+    const after = reduceGame(game, { type: 'SHOP_USE_SPECTRAL_CARD_FROM_PACK', id: 'sigil-1' })
+    const suits = after.gamePlayState.handIds.map(id => {
+      const c = after.cards[id]
+      return c && 'playingCardId' in c ? playingCards[c.playingCardId]?.suit : null
+    }).filter(Boolean)
+    expect(new Set(suits).size).toBe(1)
+  })
+})

--- a/src/app/daily-card-game/domain/spectral/spectal-cards.ts
+++ b/src/app/daily-card-game/domain/spectral/spectal-cards.ts
@@ -10,6 +10,7 @@ import {
   getRandomPlayingCardsWithFilters,
   initializePlayingCard,
 } from '@/app/daily-card-game/domain/playing-card/utils'
+import { playingCards } from '@/app/daily-card-game/domain/playing-card/playing-cards'
 import { buildSeedString, getRandomNumberWithSeed } from '@/app/daily-card-game/domain/randomness'
 
 import { SpectralCardDefinition, SpectralCardType } from './types'
@@ -128,14 +129,56 @@ const sigil: SpectralCardDefinition = {
   spectralType: 'sigil',
   name: 'Sigil',
   description: 'Converts all cards in hand to a single random suit.',
-  effects: [],
+  isPlayable: (game: GameState) => game.gamePlayState.handIds.length > 0,
+  effects: [
+    {
+      event: { type: 'SPECTRAL_CARD_USED' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        const suits = ['hearts', 'diamonds', 'clubs', 'spades'] as const
+        const seed = buildSeedString([ctx.game.gameSeed, ctx.game.roundIndex.toString(), 'sigil'])
+        const roll = getRandomNumberWithSeed(seed, 0, suits.length - 1)
+        const targetSuit = suits[roll]
+
+        for (const cardId of ctx.game.gamePlayState.handIds) {
+          const cardState = ctx.game.cards[cardId]
+          if (!cardState || !('playingCardId' in cardState)) continue
+          const cardDef = playingCards[cardState.playingCardId]
+          if (!cardDef) continue
+          cardState.playingCardId = `${cardDef.value}_${targetSuit}` as any
+        }
+      },
+    },
+  ],
 }
 
 const ouija: SpectralCardDefinition = {
   spectralType: 'ouija',
   name: 'Ouija',
   description: 'Converts all cards in hand to a single random rank, but -1 Hand Size.',
-  effects: [],
+  isPlayable: (game: GameState) => game.gamePlayState.handIds.length > 0,
+  effects: [
+    {
+      event: { type: 'SPECTRAL_CARD_USED' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        const allValues = ['2', '3', '4', '5', '6', '7', '8', '9', '10', 'J', 'Q', 'K', 'A']
+        const seed = buildSeedString([ctx.game.gameSeed, ctx.game.roundIndex.toString(), 'ouija'])
+        const roll = getRandomNumberWithSeed(seed, 0, allValues.length - 1)
+        const targetValue = allValues[roll]
+
+        for (const cardId of ctx.game.gamePlayState.handIds) {
+          const cardState = ctx.game.cards[cardId]
+          if (!cardState || !('playingCardId' in cardState)) continue
+          const cardDef = playingCards[cardState.playingCardId]
+          if (!cardDef) continue
+          cardState.playingCardId = `${targetValue}_${cardDef.suit}` as any
+        }
+
+        ctx.game.handSizeModifier -= 1
+      },
+    },
+  ],
 }
 
 const ectoplasm: SpectralCardDefinition = {
@@ -285,6 +328,8 @@ export const implementedSpectralCards: Partial<typeof spectralCards> = {
   wraith,
   immolate,
   ectoplasm,
+  sigil,
+  ouija,
 }
 
 /**


### PR DESCRIPTION
## Summary
- Implements Sigil (#869): converts all hand cards to a single random suit
- Implements Ouija (#870): converts all hand cards to a single random rank, -1 hand size
- Bundled to avoid implementedSpectralCards conflicts

## Test plan
- [x] Sigil: all hand cards same suit
- [x] Ouija: all hand cards same rank, hand size reduced

Closes #869
Closes #870

🤖 Generated with [Claude Code](https://claude.com/claude-code)