### PR TITLE
feat: implement Ankh spectral card

### DIFF
--- a/src/app/daily-card-game/domain/game/__tests__/spectral-ankh.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/spectral-ankh.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest'
+import { defaultGameState } from '@/app/daily-card-game/domain/game/default-game-state'
+import { reduceGame } from '@/app/daily-card-game/domain/game/reduce-game'
+import type { GameState } from '@/app/daily-card-game/domain/game/types'
+
+describe('Ankh spectral card', () => {
+  it('keeps one random joker and creates a copy, destroying all others', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.jokers = [
+      { id: 'j1', jokerId: 'joker', edition: 'normal', counter: 0, flags: {} } as any,
+      { id: 'j2', jokerId: 'jolly', edition: 'foil', counter: 0, flags: {} } as any,
+      { id: 'j3', jokerId: 'zany', edition: 'normal', counter: 0, flags: {} } as any,
+    ]
+
+    game.shopState.openPackState = {
+      id: 'test-pack',
+      cards: [
+        {
+          card: { id: 'ankh-1', spectralType: 'ankh' } as any,
+          type: 'spectralCard',
+          cardType: 'spectralCard',
+          price: 0,
+        },
+      ],
+      rarity: 'normal',
+      remainingCardsToSelect: 1,
+    }
+
+    const after = reduceGame(game, {
+      type: 'SHOP_USE_SPECTRAL_CARD_FROM_PACK',
+      id: 'ankh-1',
+    })
+
+    expect(after.jokers.length).toBe(2)
+    expect(after.jokers[0].jokerId).toBe(after.jokers[1].jokerId)
+    expect(after.jokers[0].id).not.toBe(after.jokers[1].id)
+  })
+})

--- a/src/app/daily-card-game/domain/spectral/spectal-cards.ts
+++ b/src/app/daily-card-game/domain/spectral/spectal-cards.ts
@@ -11,7 +11,7 @@ import {
   initializePlayingCard,
 } from '@/app/daily-card-game/domain/playing-card/utils'
 import { playingCards } from '@/app/daily-card-game/domain/playing-card/playing-cards'
-import { buildSeedString, getRandomNumberWithSeed } from '@/app/daily-card-game/domain/randomness'
+import { buildSeedString, getRandomNumberWithSeed, uuid } from '@/app/daily-card-game/domain/randomness'
 
 import { SpectralCardDefinition, SpectralCardType } from './types'
 
@@ -237,7 +237,28 @@ const ankh: SpectralCardDefinition = {
   name: 'Ankh',
   description:
     'Creates a copy of 1 of your Jokers at random, then destroys the others, leaving you with two identical Jokers. (Editions are also copied, except Negative)',
-  effects: [],
+  isPlayable: (game: GameState) => game.jokers.length > 0,
+  effects: [
+    {
+      event: { type: 'SPECTRAL_CARD_USED' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        if (ctx.game.jokers.length === 0) return
+
+        const seed = buildSeedString([ctx.game.gameSeed, ctx.game.roundIndex.toString(), 'ankh'])
+        const idx = getRandomNumberWithSeed(seed, 0, ctx.game.jokers.length - 1)
+        const chosen = ctx.game.jokers[idx]
+
+        const copy = {
+          ...chosen,
+          id: uuid(),
+          edition: chosen.edition === 'negative' ? 'normal' as const : chosen.edition,
+        }
+
+        ctx.game.jokers = [chosen, copy]
+      },
+    },
+  ],
 }
 
 const dejaVu: SpectralCardDefinition = {
@@ -330,6 +351,7 @@ export const implementedSpectralCards: Partial<typeof spectralCards> = {
   ectoplasm,
   sigil,
   ouija,
+  ankh,
 }
 
 /**


### PR DESCRIPTION
## Summary
- Implements Ankh spectral card (#873) from epic #697 (Spectral Cards)
- Copies a random joker, destroys all others, leaving two identical jokers
- Negative edition stripped from copy per Balatro rules

## Test plan
- [x] Unit test verifies 2 jokers remain with same jokerId but different ids

Closes #873

🤖 Generated with [Claude Code](https://claude.com/claude-code)