### PR TITLE
feat: implement Hex spectral card

### DIFF
--- a/src/app/daily-card-game/domain/game/__tests__/spectral-hex.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/spectral-hex.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+import { defaultGameState } from '@/app/daily-card-game/domain/game/default-game-state'
+import { reduceGame } from '@/app/daily-card-game/domain/game/reduce-game'
+import type { GameState } from '@/app/daily-card-game/domain/game/types'
+
+describe('Hex spectral card', () => {
+  it('adds Polychrome to a random joker and destroys the rest', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.jokers = [
+      { id: 'j1', jokerId: 'joker', edition: 'normal', counter: 0, flags: {} } as any,
+      { id: 'j2', jokerId: 'jolly', edition: 'normal', counter: 0, flags: {} } as any,
+      { id: 'j3', jokerId: 'zany', edition: 'normal', counter: 0, flags: {} } as any,
+    ]
+
+    game.shopState.openPackState = {
+      id: 'test-pack',
+      cards: [
+        { card: { id: 'hex-1', spectralType: 'hex' } as any, type: 'spectralCard', cardType: 'spectralCard', price: 0 },
+      ],
+      rarity: 'normal',
+      remainingCardsToSelect: 1,
+    }
+
+    const after = reduceGame(game, { type: 'SHOP_USE_SPECTRAL_CARD_FROM_PACK', id: 'hex-1' })
+
+    expect(after.jokers.length).toBe(1)
+    expect(after.jokers[0].edition).toBe('polychrome')
+  })
+})

--- a/src/app/daily-card-game/domain/spectral/spectal-cards.ts
+++ b/src/app/daily-card-game/domain/spectral/spectal-cards.ts
@@ -251,7 +251,23 @@ const hex: SpectralCardDefinition = {
   spectralType: 'hex',
   name: 'Hex',
   description: 'Adds Polychrome to a random Joker, and destroys the rest.',
-  effects: [],
+  isPlayable: (game: GameState) => game.jokers.length > 0,
+  effects: [
+    {
+      event: { type: 'SPECTRAL_CARD_USED' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        if (ctx.game.jokers.length === 0) return
+
+        const seed = buildSeedString([ctx.game.gameSeed, ctx.game.roundIndex.toString(), 'hex'])
+        const idx = getRandomNumberWithSeed(seed, 0, ctx.game.jokers.length - 1)
+        const chosen = ctx.game.jokers[idx]
+        chosen.edition = 'polychrome'
+
+        ctx.game.jokers = [chosen]
+      },
+    },
+  ],
 }
 
 const trance: SpectralCardDefinition = {
@@ -330,6 +346,7 @@ export const implementedSpectralCards: Partial<typeof spectralCards> = {
   ectoplasm,
   sigil,
   ouija,
+  hex,
 }
 
 /**


### PR DESCRIPTION
## Summary
- Implements Hex spectral card (#875) from epic #697 (Spectral Cards)
- Adds Polychrome edition to a random joker, destroys all others

## Test plan
- [x] Unit test verifies 1 joker remains with Polychrome edition

Closes #875

🤖 Generated with [Claude Code](https://claude.com/claude-code)