### PR TITLE
feat: implement Grim spectral card

### DIFF
--- a/src/app/daily-card-game/domain/game/__tests__/spectral-grim.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/spectral-grim.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest'
+import { defaultGameState } from '@/app/daily-card-game/domain/game/default-game-state'
+import { reduceGame } from '@/app/daily-card-game/domain/game/reduce-game'
+import type { GameState } from '@/app/daily-card-game/domain/game/types'
+
+describe('Grim spectral card', () => {
+  it('destroys 1 card and adds 2 enhanced Aces', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.gamePlayState.handIds = game.ownedCardIds.slice(0, 5)
+    const initialOwned = game.ownedCardIds.length
+
+    game.shopState.openPackState = {
+      id: 'test-pack',
+      cards: [
+        { card: { id: 'grim-1', spectralType: 'grim' } as any, type: 'spectralCard', cardType: 'spectralCard', price: 0 },
+      ],
+      rarity: 'normal',
+      remainingCardsToSelect: 1,
+    }
+
+    const after = reduceGame(game, { type: 'SHOP_USE_SPECTRAL_CARD_FROM_PACK', id: 'grim-1' })
+
+    // -1 destroyed + 2 added = net +1
+    expect(after.ownedCardIds.length).toBe(initialOwned + 1)
+  })
+})

--- a/src/app/daily-card-game/domain/spectral/spectal-cards.ts
+++ b/src/app/daily-card-game/domain/spectral/spectal-cards.ts
@@ -77,7 +77,42 @@ const grim: SpectralCardDefinition = {
   spectralType: 'grim',
   name: 'Grim',
   description: 'Destroy 1 random card in your hand, but add 2 random Enhanced Aces instead.',
-  effects: [],
+  isPlayable: (game: GameState) => game.gamePlayState.handIds.length > 0,
+  effects: [
+    {
+      event: { type: 'SPECTRAL_CARD_USED' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        const destructionSeed = buildSeedString([ctx.game.gameSeed, ctx.game.roundIndex.toString(), 'grim'])
+
+        // Generate 2 random enhanced Aces
+        const randomCards = getRandomPlayingCardsWithFilters({
+          game: ctx.game,
+          numberOfCards: 2,
+          values: ['A'],
+        })
+        const cardsToAdd = randomCards.map(card => {
+          const cardState = initializePlayingCard(card, ctx.game, true)
+          cardState.flags.enchantment =
+            cardState.flags.enchantment === 'none'
+              ? getRandomEnchantment(ctx.game, card.id, true)
+              : cardState.flags.enchantment
+          return cardState
+        })
+
+        // Select a random card from hand to remove
+        const randomIdx = getRandomNumberWithSeed(destructionSeed, 0, ctx.game.gamePlayState.handIds.length - 1)
+        const cardToRemoveId = ctx.game.gamePlayState.handIds[randomIdx]
+
+        removeOwnedCard(ctx.game, cardToRemoveId)
+
+        cardsToAdd.forEach(card => {
+          addOwnedCard(ctx.game, card)
+          ctx.game.gamePlayState.handIds.push(card.id)
+        })
+      },
+    },
+  ],
 }
 
 const incantation: SpectralCardDefinition = {
@@ -352,6 +387,7 @@ export const implementedSpectralCards: Partial<typeof spectralCards> = {
   sigil,
   ouija,
   ankh,
+  grim,
 }
 
 /**


### PR DESCRIPTION
## Summary
- Implements Grim spectral card (#863) from epic #697 (Spectral Cards)
- Destroys 1 random card from hand, adds 2 random enhanced Aces
- Same pattern as Familiar but with Aces instead of face cards

## Test plan
- [x] Unit test verifies net +1 owned card (1 destroyed, 2 added)

Closes #863

🤖 Generated with [Claude Code](https://claude.com/claude-code)