### PR TITLE
feat: implement Grim and Hex spectral cards

### DIFF
--- a/src/app/daily-card-game/domain/game/__tests__/spectral-grim.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/spectral-grim.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest'
+import { defaultGameState } from '@/app/daily-card-game/domain/game/default-game-state'
+import { reduceGame } from '@/app/daily-card-game/domain/game/reduce-game'
+import type { GameState } from '@/app/daily-card-game/domain/game/types'
+
+describe('Grim spectral card', () => {
+  it('destroys 1 card and adds 2 enhanced Aces', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.gamePlayState.handIds = game.ownedCardIds.slice(0, 5)
+    const initialOwned = game.ownedCardIds.length
+    game.shopState.openPackState = {
+      id: 'test-pack',
+      cards: [{ card: { id: 'grim-1', spectralType: 'grim' } as any, type: 'spectralCard', cardType: 'spectralCard', price: 0 }],
+      rarity: 'normal',
+      remainingCardsToSelect: 1,
+    }
+    const after = reduceGame(game, { type: 'SHOP_USE_SPECTRAL_CARD_FROM_PACK', id: 'grim-1' })
+    expect(after.ownedCardIds.length).toBe(initialOwned + 1)
+  })
+})

--- a/src/app/daily-card-game/domain/game/__tests__/spectral-hex.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/spectral-hex.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest'
+import { defaultGameState } from '@/app/daily-card-game/domain/game/default-game-state'
+import { reduceGame } from '@/app/daily-card-game/domain/game/reduce-game'
+import type { GameState } from '@/app/daily-card-game/domain/game/types'
+
+describe('Hex spectral card', () => {
+  it('adds Polychrome to a random joker and destroys the rest', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.jokers = [
+      { id: 'j1', jokerId: 'joker', edition: 'normal', counter: 0, flags: {} } as any,
+      { id: 'j2', jokerId: 'jolly', edition: 'normal', counter: 0, flags: {} } as any,
+    ]
+    game.shopState.openPackState = {
+      id: 'test-pack',
+      cards: [{ card: { id: 'hex-1', spectralType: 'hex' } as any, type: 'spectralCard', cardType: 'spectralCard', price: 0 }],
+      rarity: 'normal',
+      remainingCardsToSelect: 1,
+    }
+    const after = reduceGame(game, { type: 'SHOP_USE_SPECTRAL_CARD_FROM_PACK', id: 'hex-1' })
+    expect(after.jokers.length).toBe(1)
+    expect(after.jokers[0].edition).toBe('polychrome')
+  })
+})

--- a/src/app/daily-card-game/domain/spectral/spectal-cards.ts
+++ b/src/app/daily-card-game/domain/spectral/spectal-cards.ts
@@ -77,7 +77,26 @@ const grim: SpectralCardDefinition = {
   spectralType: 'grim',
   name: 'Grim',
   description: 'Destroy 1 random card in your hand, but add 2 random Enhanced Aces instead.',
-  effects: [],
+  isPlayable: (game: GameState) => game.gamePlayState.handIds.length > 0,
+  effects: [
+    {
+      event: { type: 'SPECTRAL_CARD_USED' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        const destructionSeed = buildSeedString([ctx.game.gameSeed, ctx.game.roundIndex.toString(), 'grim'])
+        const randomCards = getRandomPlayingCardsWithFilters({ game: ctx.game, numberOfCards: 2, values: ['A'] })
+        const cardsToAdd = randomCards.map(card => {
+          const cardState = initializePlayingCard(card, ctx.game, true)
+          cardState.flags.enchantment = cardState.flags.enchantment === 'none'
+            ? getRandomEnchantment(ctx.game, card.id, true) : cardState.flags.enchantment
+          return cardState
+        })
+        const randomIdx = getRandomNumberWithSeed(destructionSeed, 0, ctx.game.gamePlayState.handIds.length - 1)
+        removeOwnedCard(ctx.game, ctx.game.gamePlayState.handIds[randomIdx])
+        cardsToAdd.forEach(card => { addOwnedCard(ctx.game, card); ctx.game.gamePlayState.handIds.push(card.id) })
+      },
+    },
+  ],
 }
 
 const incantation: SpectralCardDefinition = {
@@ -272,7 +291,21 @@ const hex: SpectralCardDefinition = {
   spectralType: 'hex',
   name: 'Hex',
   description: 'Adds Polychrome to a random Joker, and destroys the rest.',
-  effects: [],
+  isPlayable: (game: GameState) => game.jokers.length > 0,
+  effects: [
+    {
+      event: { type: 'SPECTRAL_CARD_USED' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        if (ctx.game.jokers.length === 0) return
+        const seed = buildSeedString([ctx.game.gameSeed, ctx.game.roundIndex.toString(), 'hex'])
+        const idx = getRandomNumberWithSeed(seed, 0, ctx.game.jokers.length - 1)
+        const chosen = ctx.game.jokers[idx]
+        chosen.edition = 'polychrome'
+        ctx.game.jokers = [chosen]
+      },
+    },
+  ],
 }
 
 const trance: SpectralCardDefinition = {
@@ -352,6 +385,8 @@ export const implementedSpectralCards: Partial<typeof spectralCards> = {
   sigil,
   ouija,
   ankh,
+  grim,
+  hex,
 }
 
 /**


### PR DESCRIPTION
## Summary
- Implements Grim (#863): destroys 1 card, adds 2 enhanced Aces
- Implements Hex (#875): adds Polychrome to random joker, destroys others
- Bundled to avoid implementedSpectralCards conflicts

## Test plan
- [x] Grim: net +1 owned card
- [x] Hex: 1 joker remains with Polychrome

Closes #863
Closes #875

🤖 Generated with [Claude Code](https://claude.com/claude-code)