### PR TITLE
feat: implement Incantation spectral card

### DIFF
--- a/src/app/daily-card-game/domain/game/__tests__/spectral-incantation.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/spectral-incantation.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest'
+import { defaultGameState } from '@/app/daily-card-game/domain/game/default-game-state'
+import { reduceGame } from '@/app/daily-card-game/domain/game/reduce-game'
+import type { GameState } from '@/app/daily-card-game/domain/game/types'
+
+describe('Incantation spectral card', () => {
+  it('destroys 1 card and adds 4 enhanced numbered cards', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.gamePlayState.handIds = game.ownedCardIds.slice(0, 5)
+    const initialOwned = game.ownedCardIds.length
+    game.shopState.openPackState = {
+      id: 'test-pack',
+      cards: [{ card: { id: 'inc-1', spectralType: 'incantation' } as any, type: 'spectralCard', cardType: 'spectralCard', price: 0 }],
+      rarity: 'normal',
+      remainingCardsToSelect: 1,
+    }
+    const after = reduceGame(game, { type: 'SHOP_USE_SPECTRAL_CARD_FROM_PACK', id: 'inc-1' })
+    // -1 destroyed + 4 added = net +3
+    expect(after.ownedCardIds.length).toBe(initialOwned + 3)
+  })
+})

--- a/src/app/daily-card-game/domain/spectral/spectal-cards.ts
+++ b/src/app/daily-card-game/domain/spectral/spectal-cards.ts
@@ -104,7 +104,30 @@ const incantation: SpectralCardDefinition = {
   name: 'Incantation',
   description:
     'Destroy 1 random card in your hand, but add 4 random Enhanced numbered cards instead.',
-  effects: [],
+  isPlayable: (game: GameState) => game.gamePlayState.handIds.length > 0,
+  effects: [
+    {
+      event: { type: 'SPECTRAL_CARD_USED' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        const destructionSeed = buildSeedString([ctx.game.gameSeed, ctx.game.roundIndex.toString(), 'incantation'])
+        const randomCards = getRandomPlayingCardsWithFilters({
+          game: ctx.game,
+          numberOfCards: 4,
+          values: ['2', '3', '4', '5', '6', '7', '8', '9', '10'],
+        })
+        const cardsToAdd = randomCards.map(card => {
+          const cardState = initializePlayingCard(card, ctx.game, true)
+          cardState.flags.enchantment = cardState.flags.enchantment === 'none'
+            ? getRandomEnchantment(ctx.game, card.id, true) : cardState.flags.enchantment
+          return cardState
+        })
+        const randomIdx = getRandomNumberWithSeed(destructionSeed, 0, ctx.game.gamePlayState.handIds.length - 1)
+        removeOwnedCard(ctx.game, ctx.game.gamePlayState.handIds[randomIdx])
+        cardsToAdd.forEach(card => { addOwnedCard(ctx.game, card); ctx.game.gamePlayState.handIds.push(card.id) })
+      },
+    },
+  ],
 }
 
 const talisman: SpectralCardDefinition = {
@@ -387,6 +410,7 @@ export const implementedSpectralCards: Partial<typeof spectralCards> = {
   ankh,
   grim,
   hex,
+  incantation,
 }
 
 /**


### PR DESCRIPTION
## Summary
- Implements Incantation spectral card (#864) from epic #697 (Spectral Cards)
- Destroys 1 random card, adds 4 random enhanced numbered cards (2-10)
- Completes the card-replacement trio: Familiar (face cards), Grim (Aces), Incantation (numbered)

## Test plan
- [x] Unit test verifies net +3 owned cards

Closes #864

🤖 Generated with [Claude Code](https://claude.com/claude-code)