### PR TITLE
feat: implement seal spectral cards (Talisman, Deja Vu, Trance, Medium)

### DIFF
--- a/src/app/daily-card-game/domain/game/__tests__/spectral-seals.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/spectral-seals.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest'
+import { defaultGameState } from '@/app/daily-card-game/domain/game/default-game-state'
+import { reduceGame } from '@/app/daily-card-game/domain/game/reduce-game'
+import type { GameState } from '@/app/daily-card-game/domain/game/types'
+
+const makePackWithSpectral = (id: string, spectralType: string) => ({
+  id: 'test-pack',
+  cards: [{ card: { id, spectralType } as any, type: 'spectralCard' as const, cardType: 'spectralCard' as const, price: 0 }],
+  rarity: 'normal' as const,
+  remainingCardsToSelect: 1,
+})
+
+describe('Seal spectral cards', () => {
+  it('Talisman adds Gold seal', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.gamePlayState.handIds = [game.ownedCardIds[0]]
+    game.shopState.openPackState = makePackWithSpectral('t-1', 'talisman')
+    const after = reduceGame(game, { type: 'SHOP_USE_SPECTRAL_CARD_FROM_PACK', id: 't-1' })
+    const card = after.cards[game.ownedCardIds[0]]
+    expect('flags' in card && card.flags.seal).toBe('gold')
+  })
+
+  it('Deja Vu adds Red seal', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.gamePlayState.handIds = [game.ownedCardIds[0]]
+    game.shopState.openPackState = makePackWithSpectral('d-1', 'dejaVu')
+    const after = reduceGame(game, { type: 'SHOP_USE_SPECTRAL_CARD_FROM_PACK', id: 'd-1' })
+    const card = after.cards[game.ownedCardIds[0]]
+    expect('flags' in card && card.flags.seal).toBe('red')
+  })
+
+  it('Trance adds Blue seal', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.gamePlayState.handIds = [game.ownedCardIds[0]]
+    game.shopState.openPackState = makePackWithSpectral('tr-1', 'trance')
+    const after = reduceGame(game, { type: 'SHOP_USE_SPECTRAL_CARD_FROM_PACK', id: 'tr-1' })
+    const card = after.cards[game.ownedCardIds[0]]
+    expect('flags' in card && card.flags.seal).toBe('blue')
+  })
+
+  it('Medium adds Purple seal', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.gamePlayState.handIds = [game.ownedCardIds[0]]
+    game.shopState.openPackState = makePackWithSpectral('m-1', 'medium')
+    const after = reduceGame(game, { type: 'SHOP_USE_SPECTRAL_CARD_FROM_PACK', id: 'm-1' })
+    const card = after.cards[game.ownedCardIds[0]]
+    expect('flags' in card && card.flags.seal).toBe('purple')
+  })
+})

--- a/src/app/daily-card-game/domain/spectral/spectal-cards.ts
+++ b/src/app/daily-card-game/domain/spectral/spectal-cards.ts
@@ -134,7 +134,19 @@ const talisman: SpectralCardDefinition = {
   spectralType: 'talisman',
   name: 'Talisman',
   description: 'Add a Gold Seal to 1 selected card.',
-  effects: [],
+  isPlayable: (game: GameState) => game.gamePlayState.handIds.length > 0,
+  effects: [
+    {
+      event: { type: 'SPECTRAL_CARD_USED' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        const cardId = ctx.game.gamePlayState.selectedCardIds?.[0] ?? ctx.game.gamePlayState.handIds[0]
+        if (!cardId) return
+        const cardState = ctx.game.cards[cardId]
+        if (cardState && 'flags' in cardState) cardState.flags.seal = 'gold'
+      },
+    },
+  ],
 }
 
 const aura: SpectralCardDefinition = {
@@ -307,7 +319,19 @@ const dejaVu: SpectralCardDefinition = {
   spectralType: 'dejaVu',
   name: 'Deja Vu',
   description: 'Adds a Red Seal to 1 selected card.',
-  effects: [],
+  isPlayable: (game: GameState) => game.gamePlayState.handIds.length > 0,
+  effects: [
+    {
+      event: { type: 'SPECTRAL_CARD_USED' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        const cardId = ctx.game.gamePlayState.selectedCardIds?.[0] ?? ctx.game.gamePlayState.handIds[0]
+        if (!cardId) return
+        const cardState = ctx.game.cards[cardId]
+        if (cardState && 'flags' in cardState) cardState.flags.seal = 'red'
+      },
+    },
+  ],
 }
 
 const hex: SpectralCardDefinition = {
@@ -335,14 +359,38 @@ const trance: SpectralCardDefinition = {
   spectralType: 'trance',
   name: 'Trance',
   description: 'Adds a Blue Seal to 1 selected card.',
-  effects: [],
+  isPlayable: (game: GameState) => game.gamePlayState.handIds.length > 0,
+  effects: [
+    {
+      event: { type: 'SPECTRAL_CARD_USED' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        const cardId = ctx.game.gamePlayState.selectedCardIds?.[0] ?? ctx.game.gamePlayState.handIds[0]
+        if (!cardId) return
+        const cardState = ctx.game.cards[cardId]
+        if (cardState && 'flags' in cardState) cardState.flags.seal = 'blue'
+      },
+    },
+  ],
 }
 
 const medium: SpectralCardDefinition = {
   spectralType: 'medium',
   name: 'Medium',
   description: 'Adds a Purple Seal to 1 selected card.',
-  effects: [],
+  isPlayable: (game: GameState) => game.gamePlayState.handIds.length > 0,
+  effects: [
+    {
+      event: { type: 'SPECTRAL_CARD_USED' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        const cardId = ctx.game.gamePlayState.selectedCardIds?.[0] ?? ctx.game.gamePlayState.handIds[0]
+        if (!cardId) return
+        const cardState = ctx.game.cards[cardId]
+        if (cardState && 'flags' in cardState) cardState.flags.seal = 'purple'
+      },
+    },
+  ],
 }
 
 const cryptid: SpectralCardDefinition = {
@@ -411,6 +459,10 @@ export const implementedSpectralCards: Partial<typeof spectralCards> = {
   grim,
   hex,
   incantation,
+  talisman,
+  dejaVu,
+  trance,
+  medium,
 }
 
 /**


### PR DESCRIPTION
## Summary
- Implements 4 seal spectral cards from epic #697 (Spectral Cards):
  - Talisman (#866): Gold seal
  - Deja Vu (#874): Red seal
  - Trance (#876): Blue seal
  - Medium (#877): Purple seal
- All apply seal to selected card or first hand card as fallback

## Test plan
- [x] All 4 tests pass — each verifies correct seal applied

Closes #866
Closes #874
Closes #876
Closes #877

🤖 Generated with [Claude Code](https://claude.com/claude-code)