### PR TITLE
feat: complete Spectral Cards epic — implement Aura, Cryptid, The Soul

### DIFF
--- a/src/app/daily-card-game/domain/game/__tests__/spectral-final.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/spectral-final.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest'
+import { defaultGameState } from '@/app/daily-card-game/domain/game/default-game-state'
+import { reduceGame } from '@/app/daily-card-game/domain/game/reduce-game'
+import type { GameState } from '@/app/daily-card-game/domain/game/types'
+
+const makePackWithSpectral = (id: string, spectralType: string) => ({
+  id: 'test-pack',
+  cards: [{ card: { id, spectralType } as any, type: 'spectralCard' as const, cardType: 'spectralCard' as const, price: 0 }],
+  rarity: 'normal' as const,
+  remainingCardsToSelect: 1,
+})
+
+describe('Aura spectral card', () => {
+  it('adds a random edition to a card in hand', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.gamePlayState.handIds = [game.ownedCardIds[0]]
+    game.shopState.openPackState = makePackWithSpectral('aura-1', 'aura')
+    const after = reduceGame(game, { type: 'SHOP_USE_SPECTRAL_CARD_FROM_PACK', id: 'aura-1' })
+    const card = after.cards[game.ownedCardIds[0]]
+    expect('flags' in card && ['foil', 'holographic', 'polychrome'].includes(card.flags.edition)).toBe(true)
+  })
+})
+
+describe('Cryptid spectral card', () => {
+  it('creates 2 copies of a card in hand', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.gamePlayState.handIds = [game.ownedCardIds[0]]
+    const initialOwned = game.ownedCardIds.length
+    game.shopState.openPackState = makePackWithSpectral('crypt-1', 'cryptid')
+    const after = reduceGame(game, { type: 'SHOP_USE_SPECTRAL_CARD_FROM_PACK', id: 'crypt-1' })
+    expect(after.ownedCardIds.length).toBe(initialOwned + 2)
+  })
+})
+
+describe('The Soul spectral card', () => {
+  it('creates a legendary joker', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    const initialJokers = game.jokers.length
+    game.shopState.openPackState = makePackWithSpectral('soul-1', 'theSoul')
+    const after = reduceGame(game, { type: 'SHOP_USE_SPECTRAL_CARD_FROM_PACK', id: 'soul-1' })
+    expect(after.jokers.length).toBe(initialJokers + 1)
+  })
+})

--- a/src/app/daily-card-game/domain/spectral/spectal-cards.ts
+++ b/src/app/daily-card-game/domain/spectral/spectal-cards.ts
@@ -4,6 +4,7 @@ import {
   removeOwnedCard,
 } from '@/app/daily-card-game/domain/game/card-registry-utils'
 import { GameState } from '@/app/daily-card-game/domain/game/types'
+import { jokers as allJokerDefs } from '@/app/daily-card-game/domain/joker/jokers'
 import { getRandomRareJoker, initializeJoker } from '@/app/daily-card-game/domain/joker/utils'
 import {
   getRandomEnchantment,
@@ -154,7 +155,23 @@ const aura: SpectralCardDefinition = {
   name: 'Aura',
   description:
     'Add Foil, Holographic, or Polychrome edition (determined at random) to 1 selected card in hand.',
-  effects: [],
+  isPlayable: (game: GameState) => game.gamePlayState.handIds.length > 0,
+  effects: [
+    {
+      event: { type: 'SPECTRAL_CARD_USED' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        const cardId = ctx.game.gamePlayState.selectedCardIds?.[0] ?? ctx.game.gamePlayState.handIds[0]
+        if (!cardId) return
+        const cardState = ctx.game.cards[cardId]
+        if (!cardState || !('flags' in cardState)) return
+        const editions = ['foil', 'holographic', 'polychrome'] as const
+        const seed = buildSeedString([ctx.game.gameSeed, ctx.game.roundIndex.toString(), 'aura'])
+        const idx = getRandomNumberWithSeed(seed, 0, editions.length - 1)
+        cardState.flags.edition = editions[idx]
+      },
+    },
+  ],
 }
 
 const wraith: SpectralCardDefinition = {
@@ -398,14 +415,47 @@ const cryptid: SpectralCardDefinition = {
   name: 'Cryptid',
   description:
     'Creates 2 exact copies (including Enhancements, Editions and Seals) of a selected card in your hand.',
-  effects: [],
+  isPlayable: (game: GameState) => game.gamePlayState.handIds.length > 0,
+  effects: [
+    {
+      event: { type: 'SPECTRAL_CARD_USED' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        const cardId = ctx.game.gamePlayState.selectedCardIds?.[0] ?? ctx.game.gamePlayState.handIds[0]
+        if (!cardId) return
+        const cardState = ctx.game.cards[cardId]
+        if (!cardState || !('playingCardId' in cardState)) return
+
+        for (let i = 0; i < 2; i++) {
+          const copy = { ...cardState, id: uuid(), flags: { ...cardState.flags } }
+          addOwnedCard(ctx.game, copy)
+          ctx.game.gamePlayState.handIds.push(copy.id)
+        }
+      },
+    },
+  ],
 }
 
 const theSoul: SpectralCardDefinition = {
   spectralType: 'theSoul',
   name: 'The Soul',
   description: 'Creates a Legendary Joker.',
-  effects: [],
+  isPlayable: (game: GameState) => game.jokers.length < game.maxJokers,
+  effects: [
+    {
+      event: { type: 'SPECTRAL_CARD_USED' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        if (ctx.game.jokers.length >= ctx.game.maxJokers) return
+        const legendaryJokers = Object.values(allJokerDefs).filter(j => j.rarity === 'legendary')
+        if (legendaryJokers.length === 0) return
+        const seed = buildSeedString([ctx.game.gameSeed, ctx.game.roundIndex.toString(), 'theSoul'])
+        const idx = getRandomNumberWithSeed(seed, 0, legendaryJokers.length - 1)
+        const jokerState = initializeJoker(legendaryJokers[idx], ctx.game)
+        ctx.game.jokers.push(jokerState)
+      },
+    },
+  ],
 }
 
 const blackHole: SpectralCardDefinition = {
@@ -463,6 +513,9 @@ export const implementedSpectralCards: Partial<typeof spectralCards> = {
   dejaVu,
   trance,
   medium,
+  aura,
+  cryptid,
+  theSoul,
 }
 
 /**


### PR DESCRIPTION
## Summary
- Implements the final 3 spectral cards, completing epic #697 (Spectral Cards):
  - Aura (#867): adds random edition to selected card
  - Cryptid (#878): creates 2 exact copies of selected card
  - The Soul (#879): creates a random Legendary Joker
- **All 18 spectral cards are now implemented!**

## Test plan
- [x] Aura: card gets edition (foil/holo/polychrome)
- [x] Cryptid: 2 copies added to owned cards
- [x] The Soul: legendary joker added

Closes #867
Closes #878
Closes #879

🤖 Generated with [Claude Code](https://claude.com/claude-code)