### PR TITLE
feat: implement Tarot Merchant and Tarot Tycoon vouchers

### DIFF
--- a/src/app/daily-card-game/domain/game/__tests__/voucher-tarot-merchant.test.ts
+++ b/src/app/daily-card-game/domain/game/__tests__/voucher-tarot-merchant.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest'
+import { defaultGameState } from '@/app/daily-card-game/domain/game/default-game-state'
+import { reduceGame } from '@/app/daily-card-game/domain/game/reduce-game'
+import type { GameState } from '@/app/daily-card-game/domain/game/types'
+
+describe('Tarot Merchant and Tarot Tycoon vouchers', () => {
+  it('Tarot Merchant doubles tarotCard multiplier', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    expect(game.shopState.tarotCard.multiplier).toBe(1)
+    game.shopState.voucher = 'tarotMerchant'
+
+    const after = reduceGame(game, { type: 'SHOP_BUY_VOUCHER', id: 'tarotMerchant' })
+    expect(after.shopState.tarotCard.multiplier).toBe(2)
+  })
+
+  it('Tarot Tycoon doubles again for cumulative 4x', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.shopState.tarotCard.multiplier = 2
+    game.shopState.voucher = 'tarotTycoon'
+
+    const after = reduceGame(game, { type: 'SHOP_BUY_VOUCHER', id: 'tarotTycoon' })
+    expect(after.shopState.tarotCard.multiplier).toBe(4)
+  })
+})

--- a/src/app/daily-card-game/domain/voucher/vouchers.ts
+++ b/src/app/daily-card-game/domain/voucher/vouchers.ts
@@ -290,8 +290,7 @@ export const tarotMerchant: VoucherDefinition = {
       event: { type: 'SHOP_BUY_VOUCHER', id: 'tarotMerchant' },
       priority: 1,
       apply: (ctx: EffectContext) => {
-        // TODO: Implement tarot merchant effect
-        throw new Error('Not implemented' + JSON.stringify(ctx))
+        ctx.game.shopState.tarotCard.multiplier *= 2
       },
     },
   ],
@@ -307,12 +306,11 @@ export const tarotTycoon: VoucherDefinition = {
       event: { type: 'SHOP_BUY_VOUCHER', id: 'tarotTycoon' },
       priority: 1,
       apply: (ctx: EffectContext) => {
-        // TODO: Implement tarot tycoon effect
-        throw new Error('Not implemented' + JSON.stringify(ctx))
+        ctx.game.shopState.tarotCard.multiplier *= 2
       },
     },
   ],
-  dependentVoucher: null,
+  dependentVoucher: 'tarotMerchant',
 }
 
 export const planetMerchant: VoucherDefinition = {
@@ -571,6 +569,8 @@ export const implementedVouchers: VoucherType[] = [
   'crystalBall',
   'hone',
   'glowUp',
+  'tarotMerchant',
+  'tarotTycoon',
 ]
 
 export const vouchers: Record<VoucherType, VoucherDefinition> = {


### PR DESCRIPTION
## Summary
- Implements Tarot Merchant: doubles tarot card frequency in shop (2x)
- Implements Tarot Tycoon: doubles again for cumulative 4x, depends on Tarot Merchant
- Adds both to `implementedVouchers`

## Test plan
- [x] Tarot Merchant doubles multiplier from 1 to 2
- [x] Tarot Tycoon doubles from 2 to 4

🤖 Generated with [Claude Code](https://claude.com/claude-code)