### PR TITLE
trivia: cut /next reads from O(pool + history) to constant-time

### DIFF
--- a/scripts/backfill-aiquestion-fields.ts
+++ b/scripts/backfill-aiquestion-fields.ts
@@ -3,8 +3,14 @@
  * Backfill new infinite-mode fields onto existing aiQuestions documents.
  *
  * For each doc in the `aiQuestions` collection that is missing any of the new
- * fields (status, timesShown, timesCorrect, flaggedCount, avgTimeMs), this
- * script sets sensible defaults using batched writes.
+ * fields (status, timesShown, timesCorrect, flaggedCount, avgTimeMs, random),
+ * this script sets sensible defaults using batched writes.
+ *
+ * `random` is a uniform [0,1) value the sampler uses to draw a small candidate
+ * window via `orderBy('random').startAt(r).limit(N)` instead of scanning the
+ * full pool. Each missing doc gets a fresh Math.random() — must be set before
+ * the new sampler ships, since `orderBy('random')` excludes docs without the
+ * field.
  *
  * Idempotent — safe to re-run. Docs that already have all fields are skipped.
  *
@@ -18,7 +24,7 @@
  */
 
 import { cert, getApps, initializeApp } from 'firebase-admin/app'
-import { getFirestore, WriteBatch } from 'firebase-admin/firestore'
+import { WriteBatch, getFirestore } from 'firebase-admin/firestore'
 
 const BATCH_SIZE = 400 // Firestore max is 500; stay well under
 
@@ -59,14 +65,20 @@ async function main() {
 
   for (const doc of snap.docs) {
     const data = doc.data()
-    const missing: Partial<typeof DEFAULTS> = {}
+    const missing: Record<string, unknown> = {}
 
     for (const [field, defaultValue] of Object.entries(DEFAULTS) as Array<
       [keyof typeof DEFAULTS, (typeof DEFAULTS)[keyof typeof DEFAULTS]]
     >) {
       if (!(field in data)) {
-        ;(missing as Record<string, unknown>)[field] = defaultValue
+        missing[field] = defaultValue
       }
+    }
+
+    // `random` needs a fresh draw per doc, so it lives outside the
+    // static DEFAULTS map. Skipped if the field already exists.
+    if (!('random' in data)) {
+      missing.random = Math.random()
     }
 
     if (Object.keys(missing).length === 0) {
@@ -74,7 +86,7 @@ async function main() {
       continue
     }
 
-    batch.update(doc.ref, missing)
+    batch.update(doc.ref, missing as FirebaseFirestore.UpdateData<FirebaseFirestore.DocumentData>)
     batchCount++
     updatedTotal++
 

--- a/src/app/api/v1/trivia/infinite/next/route.ts
+++ b/src/app/api/v1/trivia/infinite/next/route.ts
@@ -68,16 +68,7 @@ export async function GET(request: NextRequest) {
           ? categoryIds[Math.floor(Math.random() * categoryIds.length)]
           : undefined
         const generated = await generateInfiniteQuestion({ streak: parsedStreak, categoryId: generationCategoryId })
-        await saveAIQuestion(generated)
-        question = {
-          ...generated,
-          status: 'active',
-          timesShown: 0,
-          timesCorrect: 0,
-          avgTimeMs: null,
-          likeCount: 0,
-          dislikeCount: 0,
-        }
+        question = await saveAIQuestion(generated)
       } catch (genErr) {
         console.error('[trivia/infinite/next] generation failed', {
           uid: auth.claims.uid,
@@ -92,9 +83,11 @@ export async function GET(request: NextRequest) {
       }
     }
 
-    // Strip correctAnswer before sending to client
+    // Strip correctAnswer before sending to client. The non-null assertion
+    // is safe: either the sampler returned a question, or the inner try
+    // assigned one (catch branch returns early).
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const { correctAnswer, ...safeQuestion }: AIQuestion = question
+    const { correctAnswer, ...safeQuestion }: AIQuestion = question!
 
     // Background top-up: keep the player ahead of pool exhaustion by
     // pre-generating one question per /next when their unanswered

--- a/src/lib/trivia/__tests__/triviaState.test.ts
+++ b/src/lib/trivia/__tests__/triviaState.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest'
+
+import { MAX_RECENT_SEEN, computeTrim } from '@/lib/trivia/triviaState'
+
+describe('computeTrim', () => {
+  it('returns null when the array is at or below the cap', () => {
+    expect(computeTrim([])).toBeNull()
+    expect(computeTrim(['a', 'b', 'c'])).toBeNull()
+    expect(computeTrim(Array.from({ length: MAX_RECENT_SEEN }, (_, i) => `q${i}`))).toBeNull()
+  })
+
+  it('returns null while within the slack window', () => {
+    // MAX_RECENT_SEEN + 1 should not yet trigger a trim — the slack
+    // window is what amortizes trim writes.
+    const arr = Array.from({ length: MAX_RECENT_SEEN + 1 }, (_, i) => `q${i}`)
+    expect(computeTrim(arr)).toBeNull()
+  })
+
+  it('returns the eviction list once the array exceeds slack', () => {
+    // Push well past the slack window and verify the oldest entries are
+    // returned for eviction, leaving exactly MAX_RECENT_SEEN behind.
+    const overflow = 75 // > MAX_RECENT_SEEN + slack(50)
+    const arr = Array.from({ length: MAX_RECENT_SEEN + overflow }, (_, i) => `q${i}`)
+    const evict = computeTrim(arr)
+    expect(evict).not.toBeNull()
+    expect(evict).toHaveLength(overflow)
+    expect(evict?.[0]).toBe('q0')
+    expect(evict?.[evict.length - 1]).toBe(`q${overflow - 1}`)
+  })
+})

--- a/src/lib/trivia/aiQuestions.ts
+++ b/src/lib/trivia/aiQuestions.ts
@@ -44,6 +44,10 @@ export interface AIQuestion {
   appVersion?: string
   models?: QuestionGenerationModels
   sourceUrl?: string
+  // Uniform [0,1) value assigned at write time so the sampler can pick a
+  // random window via `orderBy('random').startAt(r).limit(N)` instead of
+  // scanning the full pool on every /next.
+  random: number
 }
 
 export interface SeenQuestion {
@@ -52,8 +56,8 @@ export interface SeenQuestion {
 }
 
 export async function saveAIQuestion(
-  question: Omit<AIQuestion, 'status' | 'timesShown' | 'timesCorrect' | 'avgTimeMs' | 'likeCount' | 'dislikeCount'>
-): Promise<string> {
+  question: Omit<AIQuestion, 'status' | 'timesShown' | 'timesCorrect' | 'avgTimeMs' | 'likeCount' | 'dislikeCount' | 'random'>
+): Promise<AIQuestion> {
   const db = getFirestoreDb()
   const doc: AIQuestion = {
     ...question,
@@ -63,6 +67,7 @@ export async function saveAIQuestion(
     avgTimeMs: null,
     likeCount: 0,
     dislikeCount: 0,
+    random: Math.random(),
   }
   const ref = db.collection('aiQuestions').doc(question.id)
   // Firestore rejects `undefined` values; strip optional provenance fields
@@ -72,5 +77,5 @@ export async function saveAIQuestion(
     if (v !== undefined) cleaned[k] = v
   }
   await ref.set(cleaned)
-  return ref.id
+  return doc
 }

--- a/src/lib/trivia/generateQuestion.ts
+++ b/src/lib/trivia/generateQuestion.ts
@@ -18,7 +18,7 @@ import { APP_VERSION } from '@/lib/version'
 
 export type GeneratedQuestion = Omit<
   AIQuestion,
-  'status' | 'timesShown' | 'timesCorrect' | 'avgTimeMs' | 'likeCount' | 'dislikeCount'
+  'status' | 'timesShown' | 'timesCorrect' | 'avgTimeMs' | 'likeCount' | 'dislikeCount' | 'random'
 >
 
 export interface GenerateInfiniteQuestionOptions {

--- a/src/lib/trivia/infiniteRuns.ts
+++ b/src/lib/trivia/infiniteRuns.ts
@@ -5,6 +5,7 @@ import type { AnswerResult } from '@/app/trivia/lib/infiniteScoring'
 import { getFirestoreDb } from '@/lib/firebase/server'
 import { getCategoryIdByName } from '@/lib/trivia/categories'
 import { type MedalEarned, detectMedalEarned } from '@/lib/trivia/medals'
+import { buildMarkSeenWrite } from '@/lib/trivia/triviaState'
 import { applyRunToAggregate } from '@/lib/trivia/triviaStats'
 
 export interface RunDoc {
@@ -138,8 +139,13 @@ export async function submitAnswer(params: {
 
     tx.update(questionRef, qUpdates)
 
-    // Write seenQuestions
+    // Write seenQuestions (source of truth for analytics)
     tx.set(seenRef, { at: now, correct })
+
+    // Mirror onto the per-user state doc so the sampler doesn't have to
+    // scan the seenQuestions subcollection on every /next.
+    const markSeen = buildMarkSeenWrite(uid, questionId)
+    tx.set(markSeen.ref, markSeen.data, { merge: true })
 
     // Write answeredBy reverse index
     tx.set(answeredByRef, { uid, runId, correct, at: now })
@@ -249,6 +255,8 @@ export async function recordSkip(uid: string, runId: string, questionId: string)
       correct: false,
       skipped: true,
     })
+    const markSeen = buildMarkSeenWrite(uid, questionId)
+    await markSeen.ref.set(markSeen.data, { merge: true })
   }
 }
 

--- a/src/lib/trivia/sampler.ts
+++ b/src/lib/trivia/sampler.ts
@@ -1,6 +1,12 @@
 import { getFirestoreDb } from '@/lib/firebase/server'
 import type { AIQuestion } from '@/lib/trivia/aiQuestions'
 import { CATEGORY_META } from '@/lib/trivia/categories'
+import {
+  computeTrim,
+  ensureMigratedTriviaState,
+  readTriviaState,
+  trimRecentSeen,
+} from '@/lib/trivia/triviaState'
 
 export interface SamplerOptions {
   uid: string
@@ -10,6 +16,12 @@ export interface SamplerOptions {
   // Single-element arrays behave the same as the old single-category mode.
   categoryIds?: number[]
 }
+
+// Number of candidates to fetch around a random cursor. Large enough that
+// difficulty bucketing + freshness bias still produces a reasonable
+// distribution; small enough that reads-per-/next stays in low double
+// digits. Tunable; bump if buckets routinely come back thin.
+const CANDIDATE_WINDOW = 50
 
 /**
  * Difficulty-bias curve for the sampler.
@@ -57,12 +69,14 @@ function freshnessWeight(timesShown: number): number {
   return 1 / (1 + timesShown)
 }
 
-export async function sampleNextQuestion(options: SamplerOptions): Promise<AIQuestion | null> {
-  const { uid, streak, type = 'free-text', categoryIds } = options
-  const db = getFirestoreDb()
-
-  // 1. Query active questions of the requested type
-  let query = db
+// Build the base candidate query (status + type + optional category filter).
+// Returned as a Query so callers can layer ordering/cursors on top.
+function buildCandidateQuery(
+  db: FirebaseFirestore.Firestore,
+  type: 'free-text',
+  categoryIds: number[] | undefined,
+): FirebaseFirestore.Query {
+  let query: FirebaseFirestore.Query = db
     .collection('aiQuestions')
     .where('status', '==', 'active')
     .where('type', '==', type)
@@ -80,23 +94,73 @@ export async function sampleNextQuestion(options: SamplerOptions): Promise<AIQue
       query = query.where('category', 'in', names)
     }
   }
+  return query
+}
 
-  const questionsSnap = await query.get()
+// Fetch up to LIMIT candidates near a random cursor, wrapping around to
+// the start of the random ordering if the forward window comes back short
+// (happens when r is close to 1 or the pool is small). De-dupes by id.
+async function fetchCandidateWindow(
+  query: FirebaseFirestore.Query,
+  limit: number,
+): Promise<AIQuestion[]> {
+  const r = Math.random()
+  const fwd = await query.orderBy('random').startAt(r).limit(limit).get()
 
-  if (questionsSnap.empty) return null
+  const seen = new Set<string>()
+  const out: AIQuestion[] = []
+  for (const d of fwd.docs) {
+    if (seen.has(d.id)) continue
+    seen.add(d.id)
+    out.push({ id: d.id, ...(d.data() as Omit<AIQuestion, 'id'>) })
+  }
 
-  // 2. Get IDs already seen by this user
-  const seenSnap = await db.collection(`users/${uid}/seenQuestions`).get()
-  const seenIds = new Set(seenSnap.docs.map((d) => d.id))
+  if (out.length < limit) {
+    const more = await query.orderBy('random').limit(limit - out.length).get()
+    for (const d of more.docs) {
+      if (seen.has(d.id)) continue
+      seen.add(d.id)
+      out.push({ id: d.id, ...(d.data() as Omit<AIQuestion, 'id'>) })
+    }
+  }
 
-  // 3. Filter out seen questions
-  const unseen = questionsSnap.docs
-    .map((d) => ({ id: d.id, ...(d.data() as Omit<AIQuestion, 'id'>) }))
-    .filter((q) => !seenIds.has(q.id))
+  return out
+}
 
+export async function sampleNextQuestion(options: SamplerOptions): Promise<AIQuestion | null> {
+  const { uid, streak, type = 'free-text', categoryIds } = options
+  const db = getFirestoreDb()
+
+  // 1. Load the per-user state doc. Lazily migrate users who pre-date the
+  //    state doc (one-time full subcollection scan, then never again).
+  let state = await readTriviaState(uid)
+  if (state === null || state.migrated !== true) {
+    state = await ensureMigratedTriviaState(uid)
+  }
+  const recentSeenSet = new Set(state.recentSeen)
+
+  // 2. Fetch a bounded candidate window around a random cursor instead of
+  //    scanning the whole pool. Reads ~CANDIDATE_WINDOW docs regardless of
+  //    pool size. Selection precision drops slightly — freshness bias now
+  //    ranks within the window, not globally — but with a 1000-doc pool
+  //    the effect is small.
+  const query = buildCandidateQuery(db, type, categoryIds)
+  const candidates = await fetchCandidateWindow(query, CANDIDATE_WINDOW)
+  if (candidates.length === 0) return null
+
+  // 3. Filter out questions the user has recently seen.
+  const unseen = candidates.filter((q) => !recentSeenSet.has(q.id))
   if (unseen.length === 0) return null
 
-  // 4. Bucket by difficulty
+  // 4. Opportunistically trim recentSeen if it has grown past the cap. Use
+  //    arrayRemove (not overwrite) so concurrent writes in flight aren't
+  //    clobbered. Fire-and-forget; never blocks the response.
+  const evict = computeTrim(state.recentSeen)
+  if (evict !== null) {
+    void trimRecentSeen(uid, evict)
+  }
+
+  // 5. Bucket by difficulty
   const byDifficulty: Record<'easy' | 'medium' | 'hard', AIQuestion[]> = {
     easy: [],
     medium: [],
@@ -106,7 +170,7 @@ export async function sampleNextQuestion(options: SamplerOptions): Promise<AIQue
     byDifficulty[q.difficulty].push(q)
   }
 
-  // 5. Determine which difficulty to pick from, weighted by streak
+  // 6. Determine which difficulty to pick from, weighted by streak
   const [easyW, mediumW, hardW] = getDifficultyWeights(streak)
 
   // Only include difficulty levels that have available questions
@@ -122,11 +186,11 @@ export async function sampleNextQuestion(options: SamplerOptions): Promise<AIQue
     availableDifficulties.map((d) => d.weight)
   )
 
-  // 6. Within the chosen bucket, apply freshness bias (lower timesShown → higher weight)
+  // 7. Within the chosen bucket, apply freshness bias (lower timesShown → higher weight)
   const bucket = byDifficulty[chosenDifficulty]
   const bucketWeights = bucket.map((q) => freshnessWeight(q.timesShown))
 
-  // 7. Select one question
+  // 8. Select one question
   const selected = weightedRandom(bucket, bucketWeights)
 
   return selected

--- a/src/lib/trivia/triviaState.ts
+++ b/src/lib/trivia/triviaState.ts
@@ -1,0 +1,124 @@
+import { FieldValue } from 'firebase-admin/firestore'
+
+import { getFirestoreDb } from '@/lib/firebase/server'
+
+// Per-user hot-path state for the Infinite trivia sampler. Lives at
+// `users/{uid}/triviaInfiniteMeta/state` alongside `generationLimit`.
+//
+// Why this exists: the sampler needs to filter recently-seen questions
+// without scanning `users/{uid}/seenQuestions` on every /next, and the
+// warmer needs an unanswered-pool estimate without count() aggregations
+// per request. We mirror a bounded "recent" set + a monotonic seen
+// counter onto a single doc so /next reads are O(1) in user history.
+//
+// `seenQuestions` remains source of truth for analytics; this doc is a
+// denormalized cache of the bits the hot path needs.
+
+export const TRIVIA_STATE_DOC_PATH = (uid: string) =>
+  `users/${uid}/triviaInfiniteMeta/state`
+
+// Cap recentSeen at this length. Long enough to suppress repeats across
+// a typical session; short enough that the doc stays cheap to read.
+// Beyond this, the oldest entries are evicted; an extra-long-running
+// player may eventually see a question resurface — acceptable.
+export const MAX_RECENT_SEEN = 200
+
+// Slack before the sampler trims. Trimming on every read would thrash;
+// waiting until we're meaningfully over the cap amortizes the cost.
+const TRIM_SLACK = 50
+
+export interface TriviaState {
+  recentSeen: string[]
+  totalSeenCount: number
+  // Set true once we've migrated this user from full-subcollection scans.
+  migrated?: boolean
+}
+
+export async function readTriviaState(uid: string): Promise<TriviaState | null> {
+  const db = getFirestoreDb()
+  const snap = await db.doc(TRIVIA_STATE_DOC_PATH(uid)).get()
+  if (!snap.exists) return null
+  const data = snap.data() as Partial<TriviaState>
+  return {
+    recentSeen: data.recentSeen ?? [],
+    totalSeenCount: data.totalSeenCount ?? 0,
+    migrated: data.migrated === true,
+  }
+}
+
+// One-shot migration for users with a pre-existing `seenQuestions`
+// subcollection. Pays the full scan once per user, then every subsequent
+// /next reads only the state doc. Idempotent — setting `migrated: true`
+// prevents re-running.
+export async function ensureMigratedTriviaState(uid: string): Promise<TriviaState> {
+  const db = getFirestoreDb()
+  const ref = db.doc(TRIVIA_STATE_DOC_PATH(uid))
+  const seenSnap = await db.collection(`users/${uid}/seenQuestions`).get()
+  const docs = seenSnap.docs
+
+  const sorted = docs.slice().sort((a, b) => {
+    const ta = (a.data().at as FirebaseFirestore.Timestamp | undefined)?.toMillis() ?? 0
+    const tb = (b.data().at as FirebaseFirestore.Timestamp | undefined)?.toMillis() ?? 0
+    return ta - tb
+  })
+  const tail = sorted.slice(Math.max(0, sorted.length - MAX_RECENT_SEEN))
+  const recentSeen = tail.map((d) => d.id)
+  const totalSeenCount = docs.length
+
+  const state: TriviaState = { recentSeen, totalSeenCount, migrated: true }
+  await ref.set(state, { merge: true })
+  return state
+}
+
+// Build the write update that records a question as seen on the state
+// doc. Caller passes this into a transaction's `tx.set(ref, update,
+// { merge: true })` or a plain `ref.set(update, { merge: true })`.
+// Uses arrayUnion + increment so no read is required on the write path.
+//
+// `set` with `{ merge: true }` rather than `update` so the first write
+// for a brand-new user creates the doc; `update` would throw.
+export function buildMarkSeenWrite(
+  uid: string,
+  questionId: string
+): {
+  ref: FirebaseFirestore.DocumentReference
+  data: { recentSeen: FirebaseFirestore.FieldValue; totalSeenCount: FirebaseFirestore.FieldValue }
+} {
+  const db = getFirestoreDb()
+  const ref = db.doc(TRIVIA_STATE_DOC_PATH(uid))
+  return {
+    ref,
+    data: {
+      recentSeen: FieldValue.arrayUnion(questionId),
+      totalSeenCount: FieldValue.increment(1),
+    },
+  }
+}
+
+// Returns the trimmed array if recentSeen has grown past MAX + slack;
+// returns null if no trim needed. The sampler calls this opportunistically
+// and writes back fire-and-forget. Concurrent arrayUnion writes from the
+// hot path are preserved across the trim window because we evict by value
+// (arrayRemove), not by overwriting the whole array.
+export function computeTrim(recentSeen: string[]): string[] | null {
+  if (recentSeen.length <= MAX_RECENT_SEEN + TRIM_SLACK) return null
+  const evictCount = recentSeen.length - MAX_RECENT_SEEN
+  return recentSeen.slice(0, evictCount)
+}
+
+// Fire-and-forget trim; never throws. Uses arrayRemove so concurrent
+// writes (which arrayUnion at the tail) are not clobbered.
+export async function trimRecentSeen(uid: string, evict: string[]): Promise<void> {
+  if (evict.length === 0) return
+  const db = getFirestoreDb()
+  try {
+    await db.doc(TRIVIA_STATE_DOC_PATH(uid)).update({
+      recentSeen: FieldValue.arrayRemove(...evict),
+    })
+  } catch (err) {
+    console.warn('[triviaState] trim failed', {
+      uid,
+      error: err instanceof Error ? err.message : String(err),
+    })
+  }
+}

--- a/src/lib/trivia/warmQuestionPool.ts
+++ b/src/lib/trivia/warmQuestionPool.ts
@@ -1,6 +1,7 @@
 import { getFirestoreDb } from '@/lib/firebase/server'
 import { saveAIQuestion } from '@/lib/trivia/aiQuestions'
 import { generateInfiniteQuestion } from '@/lib/trivia/generateQuestion'
+import { readTriviaState } from '@/lib/trivia/triviaState'
 
 // Target number of unanswered active questions a player should always
 // have available before they hit the on-demand generation path.
@@ -8,16 +9,30 @@ import { generateInfiniteQuestion } from '@/lib/trivia/generateQuestion'
 // drops below this threshold.
 const TARGET_UNANSWERED = 10
 
+// Module-memory cache for the active-question count. The number changes
+// only when admins flag/remove docs or the warmer itself adds one — both
+// rare on the timescale of /next requests. A cold serverless instance
+// pays one count() aggregation; subsequent hits are free.
+const ACTIVE_COUNT_TTL_MS = 5 * 60 * 1000
+let activeCountCache: { value: number; expiresAt: number } | null = null
+
+async function getActiveCount(db: FirebaseFirestore.Firestore): Promise<number> {
+  const now = Date.now()
+  if (activeCountCache && activeCountCache.expiresAt > now) {
+    return activeCountCache.value
+  }
+  const agg = await db.collection('aiQuestions').where('status', '==', 'active').count().get()
+  const value = agg.data().count
+  activeCountCache = { value, expiresAt: now + ACTIVE_COUNT_TTL_MS }
+  return value
+}
+
 // Fire-and-forget background top-up of the question pool for a single
 // player. Call from inside an `after()` block so it runs after the
 // /next response has been sent.
 //
-// Approximation rationale: counting "active questions this user has not
-// seen" exactly would require reading both collections in full. Instead
-// we use Firestore aggregation count() on each side and subtract — this
-// over-counts unanswered when the user has seen since-flagged
-// questions, which means we'll occasionally skip warming when we
-// shouldn't, but never warm when we shouldn't. Acceptable bias.
+// Reads: 1 state doc (cheap) + an occasional cached count() aggregation.
+// Replaces the prior pattern of two count() aggregations per request.
 //
 // Errors are logged, not thrown — this is best-effort and must never
 // fail the request that scheduled it.
@@ -25,13 +40,15 @@ export async function warmQuestionPoolForUser(uid: string): Promise<void> {
   const db = getFirestoreDb()
 
   try {
-    const [activeAgg, seenAgg] = await Promise.all([
-      db.collection('aiQuestions').where('status', '==', 'active').count().get(),
-      db.collection(`users/${uid}/seenQuestions`).count().get(),
+    const [activeCount, state] = await Promise.all([
+      getActiveCount(db),
+      readTriviaState(uid),
     ])
 
-    const activeCount = activeAgg.data().count
-    const seenCount = seenAgg.data().count
+    // If the state doc isn't materialized yet, the sampler will populate
+    // it on the next /next call. Skip warming until we have a real
+    // totalSeenCount — over-warming a brand-new user has no value.
+    const seenCount = state?.totalSeenCount ?? 0
     const approxUnanswered = Math.max(0, activeCount - seenCount)
 
     if (approxUnanswered >= TARGET_UNANSWERED) {
@@ -48,6 +65,10 @@ export async function warmQuestionPoolForUser(uid: string): Promise<void> {
 
     const generated = await generateInfiniteQuestion({})
     await saveAIQuestion(generated)
+
+    // The pool just grew. Bust the cache so the next call sees the new
+    // total instead of waiting for TTL.
+    activeCountCache = null
 
     console.info('[warmQuestionPool] saved', { uid, questionId: generated.id, category: generated.category })
   } catch (err) {


### PR DESCRIPTION
## Summary
- The Infinite sampler scanned every active question and the user's full `seenQuestions` subcollection on every `/next`, scaling reads linearly with both pool size and per-user history (~300+ reads for a long-running player). This swaps in a random-cursor candidate window plus a bounded `recentSeen` cache on a per-user state doc, dropping the steady state to ~50 reads regardless of pool or history size.
- Adds a `random: number` field to `aiQuestions` (set at write time) and a new `users/{uid}/triviaInfiniteMeta/state` doc holding `recentSeen` (capped at 200) and `totalSeenCount`. The `seenQuestions` subcollection remains source of truth; the state doc is a denormalized hot-path cache. Pre-existing users migrate lazily on their first sampler call after deploy — one full subcollection scan per user, then never again.
- Replaces the per-request `count()` aggregations in `warmQuestionPoolForUser` with a 5-min in-memory TTL cache for `activeCount` and a single state-doc read for `seenCount`. The warmer also busts the cache when it generates a new question so the next read sees the new total.

## Trade-offs and notes
- **Selection precision:** freshness bias (`1/(1+timesShown)`) now ranks within the 50-doc candidate window instead of globally. With ~1000 active questions and uniform `random`, the practical effect is small; bump `CANDIDATE_WINDOW` if difficulty buckets routinely come back thin.
- **Index requirement:** Firestore needs a composite index for `(status, type, category, random asc)` (and the no-category variant). The first query in each environment will surface a console link to create it.
- **Pre-deploy step:** run `npx tsx --env-file=.env.local scripts/backfill-aiquestion-fields.ts` to populate `random` on existing docs. `orderBy('random')` excludes any doc missing the field, so unbackfilled questions become invisible to the new sampler.

## Test plan
- [ ] `npm run typecheck` clean
- [ ] `npm run test` — full suite green (incl. new `computeTrim` cases in `triviaState.test.ts`)
- [ ] Backfill script runs against a staging dataset; verify `random ∈ [0,1)` on every doc and existing fields untouched
- [ ] First `/next` for an existing player triggers the lazy migration (single full scan); state doc materialized with `migrated: true`
- [ ] Second `/next` for the same player reads only the state doc + ~50 candidates (verify in Firestore console request count)
- [ ] Pool-exhaustion path still triggers on-demand generation via the rate-limited fallback
- [ ] `recentSeen` stays ≤ 250 entries (cap + slack) across a long session; opportunistic trim fires when oversized
- [ ] Warmer runs at most once per `ACTIVE_COUNT_TTL_MS` per cold instance under steady traffic

🤖 Generated with [Claude Code](https://claude.com/claude-code)