### PR TITLE
trivia: make recentSeen filter exhaustive (drop 200-cap)

### DIFF
--- a/src/lib/trivia/__tests__/triviaState.test.ts
+++ b/src/lib/trivia/__tests__/triviaState.test.ts
@@ -1,30 +1,14 @@
 import { describe, expect, it } from 'vitest'
 
-import { MAX_RECENT_SEEN, computeTrim } from '@/lib/trivia/triviaState'
+import { CURRENT_MIGRATION_VERSION } from '@/lib/trivia/triviaState'
 
-describe('computeTrim', () => {
-  it('returns null when the array is at or below the cap', () => {
-    expect(computeTrim([])).toBeNull()
-    expect(computeTrim(['a', 'b', 'c'])).toBeNull()
-    expect(computeTrim(Array.from({ length: MAX_RECENT_SEEN }, (_, i) => `q${i}`))).toBeNull()
-  })
-
-  it('returns null while within the slack window', () => {
-    // MAX_RECENT_SEEN + 1 should not yet trigger a trim — the slack
-    // window is what amortizes trim writes.
-    const arr = Array.from({ length: MAX_RECENT_SEEN + 1 }, (_, i) => `q${i}`)
-    expect(computeTrim(arr)).toBeNull()
-  })
-
-  it('returns the eviction list once the array exceeds slack', () => {
-    // Push well past the slack window and verify the oldest entries are
-    // returned for eviction, leaving exactly MAX_RECENT_SEEN behind.
-    const overflow = 75 // > MAX_RECENT_SEEN + slack(50)
-    const arr = Array.from({ length: MAX_RECENT_SEEN + overflow }, (_, i) => `q${i}`)
-    const evict = computeTrim(arr)
-    expect(evict).not.toBeNull()
-    expect(evict).toHaveLength(overflow)
-    expect(evict?.[0]).toBe('q0')
-    expect(evict?.[evict.length - 1]).toBe(`q${overflow - 1}`)
+describe('triviaState constants', () => {
+  it('exposes a numeric migration version that increases monotonically', () => {
+    // Sentinel guard: bumping CURRENT_MIGRATION_VERSION is the trigger
+    // that re-pulls every user's seenQuestions onto the state doc on
+    // their next /next call. If you're touching the migration logic in
+    // ensureMigratedTriviaState, bump this number too.
+    expect(typeof CURRENT_MIGRATION_VERSION).toBe('number')
+    expect(CURRENT_MIGRATION_VERSION).toBeGreaterThanOrEqual(2)
   })
 })

--- a/src/lib/trivia/sampler.ts
+++ b/src/lib/trivia/sampler.ts
@@ -2,10 +2,9 @@ import { getFirestoreDb } from '@/lib/firebase/server'
 import type { AIQuestion } from '@/lib/trivia/aiQuestions'
 import { CATEGORY_META } from '@/lib/trivia/categories'
 import {
-  computeTrim,
+  CURRENT_MIGRATION_VERSION,
   ensureMigratedTriviaState,
   readTriviaState,
-  trimRecentSeen,
 } from '@/lib/trivia/triviaState'
 
 export interface SamplerOptions {
@@ -76,6 +75,11 @@ function buildCandidateQuery(
   type: 'free-text',
   categoryIds: number[] | undefined,
 ): FirebaseFirestore.Query {
+  // `status == 'active'` is the flag filter: when any user flags a
+  // question, the flag route flips status to 'flagged' atomically with
+  // creating the flag doc (see api/v1/trivia/questions/[id]/flag/route).
+  // So this single equality filter excludes everything in any question's
+  // /flags subcollection without a separate read per candidate.
   let query: FirebaseFirestore.Query = db
     .collection('aiQuestions')
     .where('status', '==', 'active')
@@ -131,13 +135,15 @@ export async function sampleNextQuestion(options: SamplerOptions): Promise<AIQue
   const { uid, streak, type = 'free-text', categoryIds } = options
   const db = getFirestoreDb()
 
-  // 1. Load the per-user state doc. Lazily migrate users who pre-date the
-  //    state doc (one-time full subcollection scan, then never again).
+  // 1. Load the per-user state doc. Lazily (re-)migrate users whose
+  //    state predates the current migration version — pays a one-time
+  //    full subcollection scan per migration bump, then every subsequent
+  //    /next is a single doc read.
   let state = await readTriviaState(uid)
-  if (state === null || state.migrated !== true) {
+  if (state === null || state.migrationVersion < CURRENT_MIGRATION_VERSION) {
     state = await ensureMigratedTriviaState(uid)
   }
-  const recentSeenSet = new Set(state.recentSeen)
+  const seenSet = new Set(state.recentSeen)
 
   // 2. Fetch a bounded candidate window around a random cursor instead of
   //    scanning the whole pool. Reads ~CANDIDATE_WINDOW docs regardless of
@@ -148,19 +154,12 @@ export async function sampleNextQuestion(options: SamplerOptions): Promise<AIQue
   const candidates = await fetchCandidateWindow(query, CANDIDATE_WINDOW)
   if (candidates.length === 0) return null
 
-  // 3. Filter out questions the user has recently seen.
-  const unseen = candidates.filter((q) => !recentSeenSet.has(q.id))
+  // 3. Filter out every question this user has previously seen. The
+  //    state doc holds the full set, so this filter is exhaustive.
+  const unseen = candidates.filter((q) => !seenSet.has(q.id))
   if (unseen.length === 0) return null
 
-  // 4. Opportunistically trim recentSeen if it has grown past the cap. Use
-  //    arrayRemove (not overwrite) so concurrent writes in flight aren't
-  //    clobbered. Fire-and-forget; never blocks the response.
-  const evict = computeTrim(state.recentSeen)
-  if (evict !== null) {
-    void trimRecentSeen(uid, evict)
-  }
-
-  // 5. Bucket by difficulty
+  // 4. Bucket by difficulty
   const byDifficulty: Record<'easy' | 'medium' | 'hard', AIQuestion[]> = {
     easy: [],
     medium: [],
@@ -170,7 +169,7 @@ export async function sampleNextQuestion(options: SamplerOptions): Promise<AIQue
     byDifficulty[q.difficulty].push(q)
   }
 
-  // 6. Determine which difficulty to pick from, weighted by streak
+  // 5. Determine which difficulty to pick from, weighted by streak
   const [easyW, mediumW, hardW] = getDifficultyWeights(streak)
 
   // Only include difficulty levels that have available questions
@@ -186,11 +185,11 @@ export async function sampleNextQuestion(options: SamplerOptions): Promise<AIQue
     availableDifficulties.map((d) => d.weight)
   )
 
-  // 7. Within the chosen bucket, apply freshness bias (lower timesShown → higher weight)
+  // 6. Within the chosen bucket, apply freshness bias (lower timesShown → higher weight)
   const bucket = byDifficulty[chosenDifficulty]
   const bucketWeights = bucket.map((q) => freshnessWeight(q.timesShown))
 
-  // 8. Select one question
+  // 7. Select one question
   const selected = weightedRandom(bucket, bucketWeights)
 
   return selected

--- a/src/lib/trivia/triviaState.ts
+++ b/src/lib/trivia/triviaState.ts
@@ -5,11 +5,12 @@ import { getFirestoreDb } from '@/lib/firebase/server'
 // Per-user hot-path state for the Infinite trivia sampler. Lives at
 // `users/{uid}/triviaInfiniteMeta/state` alongside `generationLimit`.
 //
-// Why this exists: the sampler needs to filter recently-seen questions
-// without scanning `users/{uid}/seenQuestions` on every /next, and the
-// warmer needs an unanswered-pool estimate without count() aggregations
-// per request. We mirror a bounded "recent" set + a monotonic seen
-// counter onto a single doc so /next reads are O(1) in user history.
+// Why this exists: the sampler needs to filter every previously-seen
+// question without scanning `users/{uid}/seenQuestions` on each /next,
+// and the warmer needs an unanswered-pool estimate without count()
+// aggregations per request. We mirror the full set of seen ids + a
+// monotonic counter onto a single doc so /next reads are O(1) in user
+// history.
 //
 // `seenQuestions` remains source of truth for analytics; this doc is a
 // denormalized cache of the bits the hot path needs.
@@ -17,55 +18,65 @@ import { getFirestoreDb } from '@/lib/firebase/server'
 export const TRIVIA_STATE_DOC_PATH = (uid: string) =>
   `users/${uid}/triviaInfiniteMeta/state`
 
-// Cap recentSeen at this length. Long enough to suppress repeats across
-// a typical session; short enough that the doc stays cheap to read.
-// Beyond this, the oldest entries are evicted; an extra-long-running
-// player may eventually see a question resurface — acceptable.
-export const MAX_RECENT_SEEN = 200
-
-// Slack before the sampler trims. Trimming on every read would thrash;
-// waiting until we're meaningfully over the cap amortizes the cost.
-const TRIM_SLACK = 50
+// Bump when the migration semantics change. Anything below this number
+// re-runs ensureMigratedTriviaState on the next /next.
+//   v1 — initial migration; capped recentSeen at 200, evicting older
+//        ids and letting them resurface (regression).
+//   v2 — store the full seen-id set so the filter is exhaustive.
+export const CURRENT_MIGRATION_VERSION = 2
 
 export interface TriviaState {
   recentSeen: string[]
   totalSeenCount: number
-  // Set true once we've migrated this user from full-subcollection scans.
-  migrated?: boolean
+  // Highest migration version this doc satisfies. Older docs (v1 only,
+  // which used the legacy `migrated: true` boolean) are treated as
+  // version 1 by readTriviaState and re-migrated to the current version.
+  migrationVersion: number
 }
 
 export async function readTriviaState(uid: string): Promise<TriviaState | null> {
   const db = getFirestoreDb()
   const snap = await db.doc(TRIVIA_STATE_DOC_PATH(uid)).get()
   if (!snap.exists) return null
-  const data = snap.data() as Partial<TriviaState>
+  const data = snap.data() as { recentSeen?: string[]; totalSeenCount?: number; migrationVersion?: number; migrated?: boolean }
+  // Legacy v1 docs only set `migrated: true`. Treat as version 1 so the
+  // sampler triggers a re-migration that fills in the rest of the seen ids.
+  const migrationVersion = typeof data.migrationVersion === 'number'
+    ? data.migrationVersion
+    : data.migrated === true ? 1 : 0
   return {
     recentSeen: data.recentSeen ?? [],
     totalSeenCount: data.totalSeenCount ?? 0,
-    migrated: data.migrated === true,
+    migrationVersion,
   }
 }
 
-// One-shot migration for users with a pre-existing `seenQuestions`
-// subcollection. Pays the full scan once per user, then every subsequent
-// /next reads only the state doc. Idempotent — setting `migrated: true`
-// prevents re-running.
+// One-shot migration: pulls every id from `seenQuestions` onto the state
+// doc so the sampler can filter exhaustively from a single read. Pays
+// the full subcollection scan once per user (or once per migration-
+// version bump); every subsequent /next is one doc read.
+//
+// Idempotent. Safe to call concurrently — last write wins, the result
+// is the same.
+//
+// Doc-size note: a typical user is well under 1 MiB even after years of
+// play (~25 bytes/id, ~30K ids = ~750 KB). If we ever need to support
+// users past that point, shard the array across `triviaInfiniteMeta/
+// seen-{n}` chunks.
 export async function ensureMigratedTriviaState(uid: string): Promise<TriviaState> {
   const db = getFirestoreDb()
   const ref = db.doc(TRIVIA_STATE_DOC_PATH(uid))
   const seenSnap = await db.collection(`users/${uid}/seenQuestions`).get()
-  const docs = seenSnap.docs
+  const recentSeen = seenSnap.docs.map((d) => d.id)
+  const totalSeenCount = recentSeen.length
 
-  const sorted = docs.slice().sort((a, b) => {
-    const ta = (a.data().at as FirebaseFirestore.Timestamp | undefined)?.toMillis() ?? 0
-    const tb = (b.data().at as FirebaseFirestore.Timestamp | undefined)?.toMillis() ?? 0
-    return ta - tb
-  })
-  const tail = sorted.slice(Math.max(0, sorted.length - MAX_RECENT_SEEN))
-  const recentSeen = tail.map((d) => d.id)
-  const totalSeenCount = docs.length
-
-  const state: TriviaState = { recentSeen, totalSeenCount, migrated: true }
+  const state: TriviaState = {
+    recentSeen,
+    totalSeenCount,
+    migrationVersion: CURRENT_MIGRATION_VERSION,
+  }
+  // `set` with `{ merge: true }` so we don't clobber any unrelated
+  // fields a future writer might add to the doc.
   await ref.set(state, { merge: true })
   return state
 }
@@ -92,33 +103,5 @@ export function buildMarkSeenWrite(
       recentSeen: FieldValue.arrayUnion(questionId),
       totalSeenCount: FieldValue.increment(1),
     },
-  }
-}
-
-// Returns the trimmed array if recentSeen has grown past MAX + slack;
-// returns null if no trim needed. The sampler calls this opportunistically
-// and writes back fire-and-forget. Concurrent arrayUnion writes from the
-// hot path are preserved across the trim window because we evict by value
-// (arrayRemove), not by overwriting the whole array.
-export function computeTrim(recentSeen: string[]): string[] | null {
-  if (recentSeen.length <= MAX_RECENT_SEEN + TRIM_SLACK) return null
-  const evictCount = recentSeen.length - MAX_RECENT_SEEN
-  return recentSeen.slice(0, evictCount)
-}
-
-// Fire-and-forget trim; never throws. Uses arrayRemove so concurrent
-// writes (which arrayUnion at the tail) are not clobbered.
-export async function trimRecentSeen(uid: string, evict: string[]): Promise<void> {
-  if (evict.length === 0) return
-  const db = getFirestoreDb()
-  try {
-    await db.doc(TRIVIA_STATE_DOC_PATH(uid)).update({
-      recentSeen: FieldValue.arrayRemove(...evict),
-    })
-  } catch (err) {
-    console.warn('[triviaState] trim failed', {
-      uid,
-      error: err instanceof Error ? err.message : String(err),
-    })
   }
 }


### PR DESCRIPTION
## Summary
- PR #1247 introduced a 200-id cap on `recentSeen` so the per-user state doc would stay small. The cap evicted older seen-ids, which let already-answered questions resurface for any player past 200 seen — a no-repeats regression that was visible in production.
- Removes the cap and stores the full set of seen-ids on the state doc. The exhaustive filter restores the original \"no repeats ever\" guarantee while keeping the constant-time read win from #1247.
- Bumps the migration version (1 → 2). v1 state docs are mapped to version 1 by `readTriviaState` and re-migrated on the user's next `/next` — same one-time cost as the original v1 migration.

## Flag filter
The user also asked to confirm flagged questions are excluded. Adds a comment to the sampler making the existing invariant explicit: `where('status', '==', 'active')` IS the flag filter — the flag route at `flag/route.ts` flips `status` to `'flagged'` atomically with creating the flag doc on the first flag from any user. No per-candidate read into `/flags` is needed.

## Doc-size trade-off
A power user playing daily for years tops out around ~30K seen ids (~750 KB at 25 bytes/id), well under Firestore's 1 MiB doc cap. If we ever need to support users past that point, shard `recentSeen` across `triviaInfiniteMeta/seen-{n}` chunks. Not worth doing now — would add complexity for a problem nobody has.

## Test plan
- [ ] `npm run typecheck` clean
- [ ] `npm run test` — full suite green
- [ ] Existing user with > 200 seen questions: first `/next` after deploy logs the v2 migration; subsequent `/next` reads only the state doc and `seenQuestions` count matches `recentSeen.length`
- [ ] Brand new user: first `/next` creates the state doc with `migrationVersion: 2` and an empty `recentSeen`; second `/next` after answering one question shows `recentSeen.length === 1`
- [ ] Flagged question (one user submits a flag during a run) does not appear in any other user's `/next` after the flag
- [ ] Long session: a user who has answered N questions never sees any of them resurface across the rest of the session

🤖 Generated with [Claude Code](https://claude.com/claude-code)