### PR TITLE
trivia: persist generation seed on AIQuestion docs

### DIFF
--- a/src/app/api/v1/trivia/infinite/next/route.ts
+++ b/src/app/api/v1/trivia/infinite/next/route.ts
@@ -83,11 +83,15 @@ export async function GET(request: NextRequest) {
       }
     }
 
-    // Strip correctAnswer before sending to client. The non-null assertion
-    // is safe: either the sampler returned a question, or the inner try
-    // assigned one (catch branch returns early).
+    // Strip correctAnswer before sending to client. Also strip `seed` —
+    // it often contains the answer word verbatim (e.g. seed
+    // "phoenix :: random" → answer "Phoenix"), so shipping it would leak
+    // the answer to the client. seed is server-only diagnostic data.
+    // The non-null assertion is safe: either the sampler returned a
+    // question, or the inner try assigned one (catch branch returns
+    // early).
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const { correctAnswer, ...safeQuestion }: AIQuestion = question!
+    const { correctAnswer, seed, ...safeQuestion }: AIQuestion = question!
 
     // Background top-up: keep the player ahead of pool exhaustion by
     // pre-generating one question per /next when their unanswered

--- a/src/lib/trivia/aiQuestions.ts
+++ b/src/lib/trivia/aiQuestions.ts
@@ -40,11 +40,14 @@ export interface AIQuestion {
   // that produced the question (proxy for prompt version); `models` records
   // which LLM ran each stage; `sourceUrl` is the grounding citation from
   // the FactSource (set when the source is grounded — Perplexity, future
-  // Wikipedia/Wikidata — and absent for parametric LLM facts). Optional
-  // for backwards compatibility with pre-existing docs.
+  // Wikipedia/Wikidata — and absent for parametric LLM facts); `seed` is
+  // the "seedWord :: modifier" string fed to the FactSource, persisted so
+  // we can diagnose duplicate-answer clusters and (later) dedupe by seed.
+  // Optional for backwards compatibility with pre-existing docs.
   appVersion?: string
   models?: QuestionGenerationModels
   sourceUrl?: string
+  seed?: string
   // Uniform [0,1) value assigned at write time so the sampler can pick a
   // random window via `orderBy('random').startAt(r).limit(N)` instead of
   // scanning the full pool on every /next.

--- a/src/lib/trivia/generateQuestion.ts
+++ b/src/lib/trivia/generateQuestion.ts
@@ -739,6 +739,7 @@ export async function generateInfiniteQuestion(
         type: 'free-text',
         appVersion: APP_VERSION,
         models,
+        seed: seedSummary,
         ...(fact.source ? { sourceUrl: fact.source } : {}),
       }
     }


### PR DESCRIPTION
## Summary
- Save the `seedWord :: modifier` string fed to the fact source on each `AIQuestion` document, so we can diagnose duplicate-answer clusters (e.g. mythology runs that repeatedly land on "phoenix") and later dedupe by seed.
- Strip `seed` alongside `correctAnswer` in the `/infinite/next` response — the seed often contains the answer word verbatim (e.g. seed `"phoenix :: random"` → answer "Phoenix"), so shipping it would leak the answer to the client.
- Field is optional; pre-existing docs without a seed are unaffected.

## Why
A user reported repeated "phoenix" answers in the mythology category with different question wording but the same `sourceUrl`. Without the seed persisted, we can't tell whether the duplicates share one seed (suggests the seed list / picker is the culprit) or many seeds (suggests `pickEasiestFact` is funneling toward famous answers). Persisting the seed unlocks that diagnosis.

## Test plan
- [ ] Generate a fresh infinite question and confirm the new doc in `aiQuestions` Firestore collection has a `seed` field populated with `seedWord :: modifier`.
- [ ] Hit `/api/v1/trivia/infinite/next` and confirm the response body does **not** contain `seed` or `correctAnswer`.
- [ ] Confirm pre-existing docs (no `seed` field) still load via the sampler without errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)