### PR TITLE
trivia: persist generation seed + duplicate flag reason

### DIFF
--- a/src/app/api/v1/trivia/infinite/next/route.ts
+++ b/src/app/api/v1/trivia/infinite/next/route.ts
@@ -83,11 +83,15 @@ export async function GET(request: NextRequest) {
       }
     }
 
-    // Strip correctAnswer before sending to client. The non-null assertion
-    // is safe: either the sampler returned a question, or the inner try
-    // assigned one (catch branch returns early).
+    // Strip correctAnswer before sending to client. Also strip `seed` —
+    // it often contains the answer word verbatim (e.g. seed
+    // "phoenix :: random" → answer "Phoenix"), so shipping it would leak
+    // the answer to the client. seed is server-only diagnostic data.
+    // The non-null assertion is safe: either the sampler returned a
+    // question, or the inner try assigned one (catch branch returns
+    // early).
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const { correctAnswer, ...safeQuestion }: AIQuestion = question!
+    const { correctAnswer, seed, ...safeQuestion }: AIQuestion = question!
 
     // Background top-up: keep the player ahead of pool exhaustion by
     // pre-generating one question per /next when their unanswered

--- a/src/app/api/v1/trivia/questions/[id]/flag/route.ts
+++ b/src/app/api/v1/trivia/questions/[id]/flag/route.ts
@@ -6,7 +6,7 @@ import { getFirestoreDb } from '@/lib/firebase/server';
 import { incrementVoiceStat } from '@/lib/trivia/triviaStats';
 
 const BONUS_LIVES_PER_RUN = 1;
-const VALID_REASONS = ['obvious', 'unanswerable', 'nonsense', 'inaccurate', 'difficulty_mismatch', 'other'] as const;
+const VALID_REASONS = ['obvious', 'unanswerable', 'nonsense', 'inaccurate', 'difficulty_mismatch', 'duplicate', 'other'] as const;
 type FlagReason = (typeof VALID_REASONS)[number];
 
 // One flag from any user is enough to remove a question from rotation.

--- a/src/app/trivia/components/FlagQuestion.tsx
+++ b/src/app/trivia/components/FlagQuestion.tsx
@@ -10,6 +10,7 @@ const FLAG_REASONS = [
   { value: 'nonsense', label: "Question doesn't make sense" },
   { value: 'inaccurate', label: 'Inaccurate or incorrect' },
   { value: 'difficulty_mismatch', label: "Difficulty doesn't match the challenge" },
+  { value: 'duplicate', label: "Duplicate question (I've seen this before)" },
   { value: 'other', label: 'Other' },
 ] as const
 

--- a/src/lib/trivia/aiQuestions.ts
+++ b/src/lib/trivia/aiQuestions.ts
@@ -40,11 +40,14 @@ export interface AIQuestion {
   // that produced the question (proxy for prompt version); `models` records
   // which LLM ran each stage; `sourceUrl` is the grounding citation from
   // the FactSource (set when the source is grounded — Perplexity, future
-  // Wikipedia/Wikidata — and absent for parametric LLM facts). Optional
-  // for backwards compatibility with pre-existing docs.
+  // Wikipedia/Wikidata — and absent for parametric LLM facts); `seed` is
+  // the "seedWord :: modifier" string fed to the FactSource, persisted so
+  // we can diagnose duplicate-answer clusters and (later) dedupe by seed.
+  // Optional for backwards compatibility with pre-existing docs.
   appVersion?: string
   models?: QuestionGenerationModels
   sourceUrl?: string
+  seed?: string
   // Uniform [0,1) value assigned at write time so the sampler can pick a
   // random window via `orderBy('random').startAt(r).limit(N)` instead of
   // scanning the full pool on every /next.

--- a/src/lib/trivia/generateQuestion.ts
+++ b/src/lib/trivia/generateQuestion.ts
@@ -739,6 +739,7 @@ export async function generateInfiniteQuestion(
         type: 'free-text',
         appVersion: APP_VERSION,
         models,
+        seed: seedSummary,
         ...(fact.source ? { sourceUrl: fact.source } : {}),
       }
     }


### PR DESCRIPTION
## Summary
- Persist generation seed on AIQuestion docs (07db5cf)
- Add "Duplicate question (I've seen this before)" flag reason to infinite trivia (154e3f5)

## Test plan
- [ ] Flag a question in infinite mode and confirm the new "Duplicate question" option appears
- [ ] Submit a duplicate flag and confirm the API accepts it (no 400)
- [ ] Confirm seed is persisted on newly generated AIQuestion docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)