### PR TITLE
trivia: bind Perplexity search to seed + add duplicate-answer backstop

### DIFF
--- a/src/app/trivia/data/seeds/09-general-knowledge.ts
+++ b/src/app/trivia/data/seeds/09-general-knowledge.ts
@@ -325,8 +325,8 @@ export const GENERAL_KNOWLEDGE_SEEDS: string[] = [
   'IMDB',
   'rotten tomatoes',
   'metacritic',
-  'pop quiz',
-  'rapid fire round',
-  'lightning round',
-  'final answer',
+  // Removed gameplay-meta seeds ("pop quiz", "rapid fire round",
+  // "lightning round", "final answer"): they're not topics, so the
+  // grounded fact source has nothing concrete to search for and
+  // converges on whatever generic "facts" listicle PageRank surfaces.
 ]

--- a/src/lib/trivia/aiQuestions.ts
+++ b/src/lib/trivia/aiQuestions.ts
@@ -59,6 +59,39 @@ export interface SeenQuestion {
   correct: boolean
 }
 
+// Backstop against the convergence pattern: different seeds returning
+// the same Perplexity listicle and producing many active questions
+// whose correctAnswer was the same name (e.g. "Mona Lisa" landing as
+// the answer for seeds across Art and General Knowledge). Returns the
+// id of any active question whose correctAnswer matches verbatim, so
+// the generator can re-roll instead of saving yet another copy.
+//
+// Single-field equality query → no composite index needed; we filter
+// by status in code. The same correctAnswer rarely shows up on more
+// than a handful of docs, so capping at 5 is plenty.
+//
+// Case-sensitive on purpose: the upstream LLM is consistent about
+// proper-noun casing, and lower-casing would require a parallel field.
+// If we start seeing case drift in practice we can layer normalization
+// then.
+export async function findActiveDuplicateAnswer(
+  correctAnswer: string
+): Promise<string | null> {
+  const trimmed = correctAnswer.trim()
+  if (!trimmed) return null
+  const db = getFirestoreDb()
+  const snap = await db
+    .collection('aiQuestions')
+    .where('correctAnswer', '==', trimmed)
+    .limit(5)
+    .get()
+  for (const doc of snap.docs) {
+    const status = (doc.data() as { status?: string }).status
+    if (status === 'active') return doc.id
+  }
+  return null
+}
+
 export async function saveAIQuestion(
   question: Omit<AIQuestion, 'status' | 'timesShown' | 'timesCorrect' | 'avgTimeMs' | 'likeCount' | 'dislikeCount' | 'random'>
 ): Promise<AIQuestion> {

--- a/src/lib/trivia/factSources/llmFactSource.ts
+++ b/src/lib/trivia/factSources/llmFactSource.ts
@@ -2,6 +2,7 @@ import { createAnthropic } from '@ai-sdk/anthropic'
 import { generateObject } from 'ai'
 import { z } from 'zod'
 
+import { recordUsage } from '../usageRecorder'
 import type { Fact, FactSource, FetchFactsOptions } from './types'
 
 // Sonnet without extended thinking. Fact extraction is mostly recall,
@@ -97,6 +98,12 @@ BAD: claim="The first edition of 'The Dark Tower: The Gunslinger' by Stephen Kin
 Avoid duplicates: each of the ${count} facts should be about a different subject.`,
       temperature: 0.7,
       maxTokens: 1500,
+    })
+    recordUsage({
+      stage: 'facts',
+      model: FACT_MODEL,
+      inputTokens: result.usage?.promptTokens ?? 0,
+      outputTokens: result.usage?.completionTokens ?? 0,
     })
 
     return result.object.facts.map((f) => ({

--- a/src/lib/trivia/factSources/perplexityFactSource.ts
+++ b/src/lib/trivia/factSources/perplexityFactSource.ts
@@ -77,7 +77,28 @@ export class PerplexityFactSource implements FactSource {
     difficulty,
     count,
   }: FetchFactsOptions): Promise<Fact[]> {
-    const seedLine = seed ? `Topical seed: ${seed}\n` : ''
+    // Seed format from the generator is "${seedWord} :: ${modifier}".
+    // We parse it back out so the prompt can make seedWord the primary
+    // search subject (binding) and modifier the framing (decorative).
+    // Without this, Perplexity treats the category as the binding
+    // constraint and the seed as flavor — converging on whatever
+    // generic "facts about ${category}" listicle has highest PageRank
+    // (e.g. every Art seed → the Mona Lisa listicle).
+    let seedWord: string | null = null
+    let modifier: string | null = null
+    if (seed) {
+      const parts = seed.split(' :: ')
+      seedWord = (parts[0] ?? '').trim() || null
+      modifier = (parts[1] ?? '').trim() || null
+    }
+
+    const subject = seedWord ? `"${seedWord}"` : `the category "${category}"`
+    const subjectLine = seedWord
+      ? `Find ${count} distinct, well-sourced trivia facts SPECIFICALLY about ${subject} within the broader category of "${category}".`
+      : `Find ${count} distinct, well-sourced trivia facts about the category "${category}".`
+    const modifierLine = modifier
+      ? `\nAngle / framing to emphasize: "${modifier}" — bias the facts toward this aspect of ${subject}.`
+      : ''
 
     const response = await this.client.chat.completions.create({
       model: FACT_MODEL,
@@ -89,11 +110,17 @@ export class PerplexityFactSource implements FactSource {
         },
         {
           role: 'user',
-          content: `Produce ${count} distinct, interesting, well-sourced facts about the category "${category}".
-${seedLine}Difficulty: ${difficulty.toUpperCase()}. ${DIFFICULTY_GUIDANCE[difficulty]}
+          content: `${subjectLine}${modifierLine}
+
+Difficulty: ${difficulty.toUpperCase()}. ${DIFFICULTY_GUIDANCE[difficulty]}
+
+CRITICAL — bind your search to ${subject}, not to "${category}" generically:
+- Every fact MUST be specifically about ${subject} (or something directly tied to it). Facts about other subjects in "${category}" do not count, even if they're famous and even if they appear in the same search results.
+- If a search result is a generic "facts about ${category}" listicle that isn't specifically about ${subject}, IGNORE it. Search again with more specific queries (e.g. ${seedWord ? `"${seedWord} interesting facts", "${seedWord} history", "${seedWord} trivia"` : `"${category} <specific subtopic>"`}) instead.
+- The ${count} facts should come from at least 3 different source domains. If your search keeps returning the same listicle, broaden your queries — do not pull multiple facts from a single listicle.
+- Concrete failure mode to avoid: when seeded with "Pablo Picasso" within the Art category, do NOT return a fact about the Mona Lisa just because it appears in a "famous artworks" listicle. Return facts about Picasso.
 
 Each fact must:
-- Be specifically about the category "${category}" — not adjacent topics.
 - State ONE specific, verifiable claim about ONE specific subject (a particular person, work, event, place, or thing — not a category of things).
 - The keyDetail must be a NAMED ENTITY — a person, place, work, event, organism, concept, or short proper-noun phrase. NEVER a number, year, date, percentage, or measurement on its own. Specific numbers and dates are unfair as trivia answers — players have to guess. If a fact's most surprising aspect is a number ("Lake Baikal is 1,642m deep"), use the named entity as the keyDetail ("Lake Baikal") and let the number live inside the claim — it will become a clue in the eventual question.
 - The keyDetail must be the MINIMAL answer string — drop articles and unit words the question would naturally contain ("Mount Everest" not "the mountain Mount Everest"). Names that legitimately contain a number ("Apollo 11", "Area 51", "Catch-22") are fine; the rule is about pure-numeric answers, not about names that happen to include digits.
@@ -103,7 +130,7 @@ Each fact must:
 - Be DIRECTLY supported by one of the search results you retrieved. If you couldn't find a search result that supports the claim, do not include it.
 - Set sourceUrl to the single most-authoritative search result URL that supports the claim.
 
-Avoid duplicates: each of the ${count} facts should be about a different subject.`,
+Avoid duplicates: each of the ${count} facts should be about a different subject within ${subject}.`,
         },
       ],
       response_format: {

--- a/src/lib/trivia/factSources/perplexityFactSource.ts
+++ b/src/lib/trivia/factSources/perplexityFactSource.ts
@@ -1,6 +1,7 @@
 import Perplexity from '@perplexity-ai/perplexity_ai'
 import { z } from 'zod'
 
+import { recordUsage } from '../usageRecorder'
 import type { Fact, FactSource, FetchFactsOptions } from './types'
 
 // Sonar is Perplexity's cheapest web-grounded model. Fact extraction
@@ -139,6 +140,12 @@ Avoid duplicates: each of the ${count} facts should be about a different subject
       },
       temperature: 0.7,
       max_tokens: 1500,
+    })
+    recordUsage({
+      stage: 'facts',
+      model: FACT_MODEL,
+      inputTokens: response.usage?.prompt_tokens ?? 0,
+      outputTokens: response.usage?.completion_tokens ?? 0,
     })
 
     const content = response.choices[0]?.message?.content

--- a/src/lib/trivia/generateQuestion.ts
+++ b/src/lib/trivia/generateQuestion.ts
@@ -9,6 +9,7 @@ import {
 import { MODIFIERS_BY_DIFFICULTY } from '@/app/trivia/data/seeds/modifiersByDifficulty'
 import { getSeedsForDifficulty } from '@/app/trivia/data/seedsByDifficulty'
 import type { AIQuestion, QuestionGenerationModels } from '@/lib/trivia/aiQuestions'
+import { findActiveDuplicateAnswer } from '@/lib/trivia/aiQuestions'
 import {
   type Fact,
   type FactSource,
@@ -717,6 +718,27 @@ export async function generateInfiniteQuestion(
     }
 
     if (acceptedDraft && acceptedReview) {
+      // Duplicate-answer backstop: even with the seed-bound Perplexity
+      // prompt, different seeds can still surface the same famous
+      // answer (e.g. multiple seeds in Art genuinely landing on
+      // "Mona Lisa"). If an active question with this exact answer
+      // already exists, fall through to the next outer attempt — that
+      // re-rolls the seed, which usually produces a different answer.
+      const dupeId = await findActiveDuplicateAnswer(acceptedDraft.correct_answer)
+      if (dupeId) {
+        lastReason = `duplicate answer: "${acceptedDraft.correct_answer}" already exists as active question ${dupeId}`
+        console.warn('[generateInfiniteQuestion] duplicate-answer rejection', {
+          attempt,
+          category: categoryName,
+          seed: seedSummary,
+          factSource: factSource.id,
+          factSourceCitation: fact.source,
+          correctAnswer: acceptedDraft.correct_answer,
+          duplicateId: dupeId,
+        })
+        continue
+      }
+
       const id = `ai-infinite-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`
       console.info('[generateInfiniteQuestion] generated', {
         id,

--- a/src/lib/trivia/generateQuestion.ts
+++ b/src/lib/trivia/generateQuestion.ts
@@ -15,6 +15,7 @@ import {
   type FactSource,
   getDefaultFactSource,
 } from '@/lib/trivia/factSources'
+import { recordUsage } from '@/lib/trivia/usageRecorder'
 import { APP_VERSION } from '@/lib/version'
 
 export type GeneratedQuestion = Omit<
@@ -226,6 +227,12 @@ If you cannot construct a question that is both unambiguous AND leak-free from t
     temperature: 0.5,
     maxTokens: 600,
   })
+  recordUsage({
+    stage: 'construct',
+    model: QUESTION_MODEL,
+    inputTokens: result.usage?.promptTokens ?? 0,
+    outputTokens: result.usage?.completionTokens ?? 0,
+  })
 
   if (!result.object.question || !result.object.correct_answer) {
     throw new Error('Question construction returned empty fields')
@@ -293,6 +300,12 @@ Rules for the fix:
 ${draft.difficulty === 'easy' ? `For EASY questions specifically: the correct_answer must be a string a casual party-trivia player would naturally produce. Specialist labels ("Atomic Bomb Dome" instead of "Hiroshima"; "Constantine the Great" instead of "Constantine"; "Lifetime Achievement Grammy Award" instead of "Lifetime Achievement Award") are unacceptable for easy. If the source fact's keyDetail is specialist, repoint per the exception above.\n\n` : ''}Output the revised question, the correct_answer, and an explanation. If you genuinely cannot fix this fact's question, output your best attempt — we will fall through to a fresh fact.`,
     temperature: 0.4,
     maxTokens: 600,
+  })
+  recordUsage({
+    stage: 'repair',
+    model: REPAIR_MODEL,
+    inputTokens: result.usage?.promptTokens ?? 0,
+    outputTokens: result.usage?.completionTokens ?? 0,
   })
 
   if (!result.object.question || !result.object.correct_answer) {
@@ -442,6 +455,12 @@ Set accept=true if all checks pass. If you reject, give a one-sentence rejection
     temperature: 0,
     maxTokens: 200,
   })
+  recordUsage({
+    stage: 'review',
+    model: REVIEW_MODEL,
+    inputTokens: result.usage?.promptTokens ?? 0,
+    outputTokens: result.usage?.completionTokens ?? 0,
+  })
 
   // Defense in depth: the prompt tells the LLM not to flag leaks, but
   // smaller models sometimes hallucinate one anyway by reading the
@@ -504,6 +523,12 @@ ${facts.map((f, i) => `[${i}] keyDetail: "${f.keyDetail}" — ${f.claim}`).join(
 Output the index (0-based) of the best fact for an easy question.`,
       temperature: 0,
       maxTokens: 50,
+    })
+    recordUsage({
+      stage: 'factPicker',
+      model: REVIEW_MODEL,
+      inputTokens: result.usage?.promptTokens ?? 0,
+      outputTokens: result.usage?.completionTokens ?? 0,
     })
     const idx = Math.max(0, Math.min(facts.length - 1, result.object.pickedIndex))
     return facts[idx]

--- a/src/lib/trivia/usageRecorder.ts
+++ b/src/lib/trivia/usageRecorder.ts
@@ -1,0 +1,43 @@
+// Eval-only observability for the question-generation pipeline. Lets a
+// caller (the eval harness) capture per-trial token usage from every LLM
+// call inside a single generateInfiniteQuestion() invocation, without
+// the pipeline knowing or caring whether anyone is listening.
+//
+// In production nobody calls withUsageRecording, so recordUsage is a
+// single AsyncLocalStorage `getStore()` lookup that returns undefined
+// and the call no-ops — no cost, no behavioral change.
+//
+// AsyncLocalStorage is what makes this work under the eval's parallel
+// concurrency: each trial's call to withUsageRecording installs a
+// separate event-buffer in async context, so two concurrent trials
+// don't bleed events into each other.
+
+import { AsyncLocalStorage } from 'node:async_hooks'
+
+export type GenerationStage =
+  | 'facts'
+  | 'factPicker'
+  | 'construct'
+  | 'repair'
+  | 'review'
+  | 'judge'
+
+export interface UsageEvent {
+  stage: GenerationStage
+  model: string
+  inputTokens: number
+  outputTokens: number
+}
+
+const storage = new AsyncLocalStorage<UsageEvent[]>()
+
+export function recordUsage(event: UsageEvent): void {
+  storage.getStore()?.push(event)
+}
+
+export function withUsageRecording<T>(
+  events: UsageEvent[],
+  fn: () => Promise<T>
+): Promise<T> {
+  return storage.run(events, fn)
+}


### PR DESCRIPTION
## Summary

Different seeds were converging on the same Perplexity listicle and producing many active questions whose `correctAnswer` was the same name — Mona Lisa came up for seeds across both Art and General Knowledge, including `"Pablo Picasso :: best known"` (literally a different artist). The seed data we just started persisting (#1252) made the convergence visible.

Two upstream fixes plus a backstop:

1. **Bind Perplexity search to the seed.** The seed was previously appended as a decorative `Topical seed: X` line; the binding constraint was the category. Now `seedWord` is the primary search subject and the prompt explicitly tells Perplexity to ignore generic "facts about \<category\>" listicles, broaden queries when the same listicle keeps coming back, and pull from at least 3 source domains. The Picasso → Mona Lisa failure is called out as a concrete example. Implemented by parsing the existing `"seedWord :: modifier"` seed string inside `perplexityFactSource.ts` so the FactSource interface stays unchanged.

2. **Drop gameplay-meta seeds.** Removed `pop quiz`, `rapid fire round`, `lightning round`, `final answer` from `09-general-knowledge.ts`. They aren't topics, so the grounded source has nothing concrete to search for and degenerates to whatever generic "facts" listicle PageRank surfaces.

3. **Duplicate-answer backstop.** After the reviewer accepts a draft, query for an active question with the same `correctAnswer`; if one exists, log and fall through to a fresh outer attempt (which re-rolls the seed). Single-field equality query — no composite index needed. Case-sensitive on purpose; the upstream LLM is consistent about proper-noun casing.

4. **Token-usage instrumentation** (new commit \`e7d551a\`). AsyncLocalStorage-based `recordUsage` hook called after each LLM call in the pipeline. In production it's a no-op (no `getStore()` context). The eval harness uses `withUsageRecording()` to capture per-trial token counts and roll them up to USD cost per run / stage / model. Lets us track whether prompt changes move cost.

## Eval results (153 trials × 2 runs, full eval)

| Metric | BEFORE (main) | AFTER (this PR) | Delta |
|---|---|---|---|
| Ship-worthy overall | 87.6% | 87.6% | (=) |
| Factual μ | 2.82 | 2.82 | (=) |
| Difficulty μ | 2.95 | 2.93 | −0.02 |
| Easy ship | 90.2% | 88.2% | −2.0 pts |
| Medium ship | 84.3% | 94.1% | **+9.8 pts** |
| Hard ship | 88.2% | 80.4% | **−7.8 pts** |
| Total cost | $2.50 | $2.72 | +$0.22 (+8.7%) |
| Per-trial cost | $0.016 | $0.018 | +$0.002 |

**Headline ship rate is identical** (87.6% → 87.6%) — no regression to aggregate quality. The convergence problem is fixed: Art moves from one of the worst categories to 100% ship, no Mona Lisa monoculture in the worst-case list.

Per-difficulty there's a genuine trade: **medium calibration improved meaningfully (+9.8 pts)** at the cost of **hard calibration (−7.8 pts)**. A plausible story: tighter seed-binding helps medium stay on-topic, but pushes hard into deeper-cut sources where Perplexity occasionally fabricates specifics it can't actually verify (worst-case AFTER hards include a few wrong-attribution errors). Worth a follow-up — adding "do not include facts you cannot directly cite" to the hard-difficulty Perplexity prompt is the obvious next try.

Cost is up 8.7% — concentrated in repair (+50% relative) and facts (+33% relative). Longer Perplexity prompt + occasional extra repair cycles. Manageable.

## Test plan
- [ ] Generate 10+ infinite questions in the Art category and confirm answers are spread across many subjects (no Mona Lisa monoculture).
- [ ] Generate questions seeded with `"Pablo Picasso :: best known"` and confirm answers are about Picasso, not other famous artworks.
- [ ] Confirm general-knowledge generations no longer attempt to use the dropped seeds.
- [ ] Trigger the duplicate-answer backstop by generating until the same answer appears twice; verify the second generation logs `[generateInfiniteQuestion] duplicate-answer rejection` and falls through.
- [ ] Confirm \`tsc\` is clean for the touched files.

## Follow-ups
- Once deployed, run \`yarn retire-active-trivia\` to flip the existing pre-#1254 questions to \`legacy\` so the new pipeline can refill the active pool.
- Investigate the hard-difficulty fabrication pattern (separate PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)