### PR TITLE
trivia: lock difficulty mix to 4:2:1 (easy:medium:hard)

### DIFF
--- a/src/lib/trivia/generateQuestion.ts
+++ b/src/lib/trivia/generateQuestion.ts
@@ -58,16 +58,15 @@ const DIFFICULTY_GUIDANCE: Record<'easy' | 'medium' | 'hard', string> = {
   hard: 'Should require real, specific knowledge of the topic — challenging but fair. Genuine deep cuts welcome here.',
 }
 
-function streakBiasedDifficulty(streak: number): 'easy' | 'medium' | 'hard' {
-  let weights: [number, number, number]
-  if (streak >= 20) weights = [0.05, 0.25, 0.7]
-  else if (streak >= 10) weights = [0.1, 0.3, 0.6]
-  else if (streak >= 5) weights = [0.3, 0.4, 0.3]
-  else weights = [0.6, 0.3, 0.1]
-
+// Difficulty mix for fresh generations. Fixed 4:2:1 (easy:medium:hard)
+// — ~57% / ~29% / ~14% — regardless of streak. Mirrors the sampler's
+// distribution; see getDifficultyWeights() in sampler.ts for the full
+// rationale. The streak option is still accepted on
+// GenerateInfiniteQuestionOptions so callers don't need to change.
+function pickDifficulty(): 'easy' | 'medium' | 'hard' {
   const r = Math.random()
-  if (r < weights[0]) return 'easy'
-  if (r < weights[0] + weights[1]) return 'medium'
+  if (r < 4 / 7) return 'easy'
+  if (r < 6 / 7) return 'medium'
   return 'hard'
 }
 
@@ -558,7 +557,7 @@ export async function generateInfiniteQuestion(
 
   let lastReason = 'unknown'
   for (let attempt = 1; attempt <= MAX_GENERATION_ATTEMPTS; attempt++) {
-    const difficulty = options.difficulty ?? streakBiasedDifficulty(options.streak ?? 0)
+    const difficulty = options.difficulty ?? pickDifficulty()
     const categoryId = options.categoryId ?? pickCategoryId()
     const categoryName = getOpenTDBCategoryName(categoryId)
     // Difficulty-aware seed + modifier selection. Easy generations

--- a/src/lib/trivia/sampler.ts
+++ b/src/lib/trivia/sampler.ts
@@ -23,32 +23,21 @@ export interface SamplerOptions {
 const CANDIDATE_WINDOW = 50
 
 /**
- * Difficulty-bias curve for the sampler.
+ * Difficulty mix for the sampler. Fixed 4:2:1 (easy:medium:hard) —
+ * roughly 57% / 29% / 14% — regardless of streak. Earlier versions
+ * ramped toward hard as streak grew (up to 70% hard at streak 20+),
+ * but observation showed easy questions weren't surfacing nearly
+ * often enough; players want easy to dominate even when streaking.
  *
- * Designed to feel progressively harder without sudden cliff-edges.
- * The bands are:
- *
- *   Streak 0-4   → 60% easy, 30% medium, 10% hard   (onboarding)
- *   Streak 5-9   → 30% easy, 40% medium, 30% hard   (warming up)
- *   Streak 10-19 → 10% easy, 30% medium, 60% hard   (challenge zone)
- *   Streak 20+   → 5% easy, 25% medium, 70% hard    (expert territory)
- *
- * Tuning notes (v1 — 2026-04-28):
- * - No telemetry data yet; these are design estimates.
- * - The 20+ band caps hard at 70% rather than 100% to prevent
- *   frustration spirals where a single hard miss ends a long run.
- * - Freshness bias (1/(1+timesShown)) ensures under-seen questions
- *   surface first, preventing "greatest hits" stagnation.
- * - Revisit after ~1 week of real run data using:
- *     SELECT difficulty, AVG(correct::int), COUNT(*)
- *     FROM answers JOIN questions ON ...
- *     GROUP BY difficulty, streak_band
+ * The streak param is preserved on the function signature so callers
+ * don't have to change; if we ever want streak progression back, this
+ * is the only place it needs to land. Freshness bias
+ * (1/(1+timesShown)) still surfaces under-seen questions within each
+ * difficulty bucket, so the pool doesn't stagnate on the 4-easy
+ * majority.
  */
-function getDifficultyWeights(streak: number): [number, number, number] {
-  if (streak >= 20) return [0.05, 0.25, 0.70]
-  if (streak >= 10) return [0.10, 0.30, 0.60]
-  if (streak >= 5)  return [0.30, 0.40, 0.30]
-  return [0.60, 0.30, 0.10]
+function getDifficultyWeights(_streak: number): [number, number, number] {
+  return [4, 2, 1]
 }
 
 // Weighted random selection over an array of items with numeric weights


### PR DESCRIPTION
## Summary

Both the sampler (`getDifficultyWeights` in `sampler.ts`) and the generator (`streakBiasedDifficulty` in `generateQuestion.ts`) previously ramped toward hard as streak grew — up to **70% hard at streak 20+**. The original design intent was a progression curve, but in practice easy questions weren't surfacing nearly often enough; players want easy to dominate even when they're streaking.

Both functions now return a fixed **4:2:1** (~57% / ~29% / ~14%) easy:medium:hard mix regardless of streak. The streak parameter is preserved on the function signatures so callers don't need to change — if we ever want streak progression back, these two functions are the only place it needs to land.

Freshness bias (`1/(1+timesShown)`) still surfaces under-seen questions within each difficulty bucket, so the easy majority doesn't stagnate on the same handful of questions.

## Why two places, kept in sync

- **Sampler** decides which existing pool question to serve.
- **Generator** decides what difficulty to use when creating fresh questions (on-demand exhaustion path + warm-pool top-up).

If only the sampler changes, fresh questions still skew hard at high streak and the pool composition tilts back toward hard over time. Both must move together. They've always had identical bands; this PR keeps them identical.

## Test plan
- [ ] Confirm new easy/medium/hard ratios show up in `/api/v1/trivia/infinite/next` over a session (sample ~30 questions, eyeball that ~17 are easy / ~9 medium / ~4 hard).
- [ ] Confirm freshness bias still works within difficulty bucket: repeat-correct an easy question and verify a different easy question surfaces next.
- [ ] No regression to streak/scoring math (streak is still tracked, just doesn't influence difficulty).

## Independent of #1254
This PR touches only `sampler.ts` and `generateQuestion.ts` and doesn't depend on the seed-binding changes in #1254. Lands clean off main; #1254 also lands clean off main; either order works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)