### PR TITLE
trivia: flip to 'loading' before awaiting next-question prefetch

### DIFF
--- a/src/app/trivia/hooks/useInfiniteRun.ts
+++ b/src/app/trivia/hooks/useInfiniteRun.ts
@@ -283,6 +283,13 @@ export function useInfiniteRun() {
       })
     }
 
+    // Flip to 'loading' synchronously so the answered card disappears the
+    // instant the player taps Next Question. Without this the prefetch
+    // await below blocks for seconds while the answered view stays on
+    // screen, then the loading state renders already-resolved (jumping
+    // straight to awaiting-ready/Ready).
+    setState(s => (s.phase === 'answered' ? { ...s, phase: 'loading' } : s))
+
     try {
       const fetchStartedAt = Date.now()
 
@@ -299,7 +306,6 @@ export function useInfiniteRun() {
         }
       }
 
-      setState(s => (s.phase === 'answered' ? { ...s, phase: 'loading' } : s))
       try {
         const headers = await getAuthHeaders()
         const nextParams = new URLSearchParams({ streak: String(state.currentStreak) })


### PR DESCRIPTION
## Summary
- Fixes a delay between clicking **Next Question** and the loading screen appearing. Previously the answered card stayed on screen for the full prefetch duration (seconds for slow AI-gen), then jumped straight to the Ready CTA — making the loading screen look "already done loading."
- The fix flips phase to `'loading'` synchronously at the top of `nextQuestion` before awaiting the prefetch. `InfiniteLoadingState` already escalates from a small spinner to the research treatment after 900ms, so a fast prefetch only flashes a tiny spinner.

## Repro
1. Answer an infinite-mode question.
2. Click **Next Question** immediately while the background prefetch is still loading.
3. Before: long delay on the answered card, then the Ready screen appears already settled.
4. After: instant transition to the loading state.

## Test plan
- [ ] Manual: answer a question, click Next Question right away — view changes instantly to the loading state, then to the question (or Ready CTA if the wait crossed the gate threshold).
- [ ] Manual: with a slow prefetch (throttle network to slow 3G), confirm the loading screen escalates to the research treatment as expected.
- [ ] Manual: with a fast prefetch, confirm only a brief small-spinner flash, no jarring flicker.
- [ ] Confirm double-tap still no-ops via the existing `nextQuestionInFlightRef` guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)