### PR TITLE
trivia: add player-initiated reset for daily and infinite stats

### DIFF
--- a/src/app/api/v1/trivia/reset/route.ts
+++ b/src/app/api/v1/trivia/reset/route.ts
@@ -1,0 +1,62 @@
+import { type NextRequest, NextResponse } from 'next/server'
+
+import { verifyRequestAuth } from '@/lib/api/auth'
+import {
+  type DailyResetResult,
+  type InfiniteResetResult,
+  resetDailyStats,
+  resetInfiniteStats,
+} from '@/lib/trivia/resetStats'
+
+interface Body {
+  daily?: boolean
+  infinite?: boolean
+}
+
+interface ResponsePayload {
+  daily?: DailyResetResult
+  infinite?: InfiniteResetResult
+  partialFailure?: { scope: 'daily' | 'infinite'; message: string }
+}
+
+export async function POST(request: NextRequest) {
+  const auth = await verifyRequestAuth(request)
+  if ('error' in auth) return auth.error
+
+  let body: Body
+  try {
+    body = (await request.json()) as Body
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body.' }, { status: 400 })
+  }
+
+  const wantDaily = body?.daily === true
+  const wantInfinite = body?.infinite === true
+  if (!wantDaily && !wantInfinite) {
+    return NextResponse.json({ error: 'Nothing to reset.' }, { status: 400 })
+  }
+
+  const payload: ResponsePayload = {}
+
+  if (wantDaily) {
+    try {
+      payload.daily = await resetDailyStats(auth.claims.uid)
+    } catch (err) {
+      console.error('resetDailyStats failed:', err)
+      payload.partialFailure = { scope: 'daily', message: 'Failed to reset daily stats.' }
+      return NextResponse.json(payload, { status: 500 })
+    }
+  }
+
+  if (wantInfinite) {
+    try {
+      payload.infinite = await resetInfiniteStats(auth.claims.uid)
+    } catch (err) {
+      console.error('resetInfiniteStats failed:', err)
+      payload.partialFailure = { scope: 'infinite', message: 'Failed to reset infinite stats.' }
+      return NextResponse.json(payload, { status: 500 })
+    }
+  }
+
+  return NextResponse.json(payload)
+}

--- a/src/app/trivia/components/ResetStatsDialog.tsx
+++ b/src/app/trivia/components/ResetStatsDialog.tsx
@@ -1,0 +1,140 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+
+import { clearTodayResult } from '@/app/trivia/lib/todayLocalStorage'
+import { ChunkyButton } from '@/components/ui/chunky-button'
+import { useAuth } from '@/hooks/useAuth'
+import { getTodayPST } from '@/lib/dates'
+
+export interface ResetScopes {
+  daily: boolean
+  infinite: boolean
+}
+
+interface Props {
+  onClose: () => void
+  onResetComplete?: (scopes: ResetScopes) => void
+}
+
+export function ResetStatsDialog({ onClose, onResetComplete }: Props) {
+  const { user } = useAuth()
+  const [daily, setDaily] = useState(false)
+  const [infinite, setInfinite] = useState(false)
+  const [pending, setPending] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    function onKeyDown(e: KeyboardEvent) {
+      if (e.key === 'Escape' && !pending) onClose()
+    }
+    window.addEventListener('keydown', onKeyDown)
+    return () => window.removeEventListener('keydown', onKeyDown)
+  }, [onClose, pending])
+
+  const canSubmit = (daily || infinite) && !pending && !!user
+
+  const handleSubmit = async () => {
+    if (!canSubmit || !user) return
+    setPending(true)
+    setError(null)
+    try {
+      const token = await user.getIdToken()
+      const res = await fetch('/api/v1/trivia/reset', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+        body: JSON.stringify({ daily, infinite }),
+      })
+      if (!res.ok) {
+        let detail = `${res.status}`
+        try {
+          const body = (await res.json()) as { error?: string; partialFailure?: { message?: string } }
+          if (body?.error) detail = body.error
+          else if (body?.partialFailure?.message) detail = body.partialFailure.message
+        } catch {
+          // fall through with status code
+        }
+        setError(`Couldn't reset (${detail}). Try again.`)
+        setPending(false)
+        return
+      }
+      if (daily) clearTodayResult(getTodayPST())
+      onResetComplete?.({ daily, infinite })
+      onClose()
+    } catch (err) {
+      setError(
+        `Couldn't reset (${err instanceof Error ? err.message : 'network error'}). Try again.`
+      )
+      setPending(false)
+    }
+  }
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="reset-stats-title"
+      className="fixed inset-0 bg-surface-dim/80 backdrop-blur-sm flex items-center justify-center z-50 px-4"
+      onClick={() => {
+        if (!pending) onClose()
+      }}
+    >
+      <div
+        className="w-full max-w-sm rounded-ds-lg border border-outline-variant bg-surface-container p-6 shadow-hero"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h2 id="reset-stats-title" className="text-lg font-bold text-ds-tertiary mb-3">
+          Begin again?
+        </h2>
+        <p className="text-on-surface/80 text-sm mb-4">
+          Pick what to dissolve. Streaks, runs, and leaderboard rank will scatter back into
+          the cave dust. Future games count toward fresh totals.
+        </p>
+
+        <div className="flex flex-col gap-3 mb-5">
+          <label className="flex items-start gap-3 cursor-pointer rounded-md p-2 -m-2 hover:bg-surface-variant/20 transition-colors">
+            <input
+              type="checkbox"
+              checked={daily}
+              onChange={(e) => setDaily(e.target.checked)}
+              disabled={pending}
+              className="mt-1 accent-ds-tertiary"
+            />
+            <span>
+              <span className="block text-on-surface text-sm font-semibold">Daily trivia</span>
+              <span className="block text-on-surface/60 text-xs">
+                Streaks, history, and leaderboard entries.
+              </span>
+            </span>
+          </label>
+          <label className="flex items-start gap-3 cursor-pointer rounded-md p-2 -m-2 hover:bg-surface-variant/20 transition-colors">
+            <input
+              type="checkbox"
+              checked={infinite}
+              onChange={(e) => setInfinite(e.target.checked)}
+              disabled={pending}
+              className="mt-1 accent-ds-tertiary"
+            />
+            <span>
+              <span className="block text-on-surface text-sm font-semibold">Infinite trivia</span>
+              <span className="block text-on-surface/60 text-xs">
+                Best runs, accuracy, and category medals.
+              </span>
+            </span>
+          </label>
+        </div>
+
+        {error && <p className="text-ds-error text-xs mb-3">{error}</p>}
+
+        <div className="flex gap-3 justify-end">
+          <ChunkyButton variant="secondary" size="sm" onClick={onClose} disabled={pending}>
+            Cancel
+          </ChunkyButton>
+          <ChunkyButton variant="exit" size="sm" onClick={handleSubmit} disabled={!canSubmit}>
+            {pending ? 'Dissolving…' : 'Reset'}
+          </ChunkyButton>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/app/trivia/components/TriviaLanding.tsx
+++ b/src/app/trivia/components/TriviaLanding.tsx
@@ -14,6 +14,7 @@ import { getDailyCategory } from '@/lib/trivia/categories'
 
 import { NicknameDialog } from './NicknameDialog'
 import { ResetNoticeButton } from './ResetNoticeButton'
+import { type ResetScopes, ResetStatsDialog } from './ResetStatsDialog'
 import { SignInBanner } from './SignInCTA'
 
 export function TriviaLanding({
@@ -24,6 +25,7 @@ export function TriviaLanding({
   onViewInfiniteStats,
   onStartPractice,
   onViewInfiniteLeaderboard,
+  onStatsReset,
   todayResult,
 }: {
   onStartGame?: () => void
@@ -33,6 +35,7 @@ export function TriviaLanding({
   onViewInfiniteStats?: () => void
   onStartPractice?: () => void
   onViewInfiniteLeaderboard?: () => void
+  onStatsReset?: (scopes: ResetScopes) => void
   todayResult: TriviaGameResult | null
 }) {
   const { user, loading: authLoading, configured: authConfigured, signOut } = useAuth()
@@ -45,6 +48,7 @@ export function TriviaLanding({
     setNickname,
   } = useTriviaUser()
   const [nicknameDialogOpen, setNicknameDialogOpen] = useState(false)
+  const [resetDialogOpen, setResetDialogOpen] = useState(false)
 
   const todayStr = getTodayPST()
   const alreadyPlayed = !!todayResult
@@ -66,6 +70,7 @@ export function TriviaLanding({
             photoURL={user.photoURL}
             onSignOut={signOut}
             onEditNickname={() => setNicknameDialogOpen(true)}
+            onResetStats={() => setResetDialogOpen(true)}
           />
         ) : (
           <Link
@@ -257,6 +262,13 @@ export function TriviaLanding({
           onSave={setNickname}
         />
       )}
+
+      {resetDialogOpen && (
+        <ResetStatsDialog
+          onClose={() => setResetDialogOpen(false)}
+          onResetComplete={(scopes) => onStatsReset?.(scopes)}
+        />
+      )}
     </div>
   )
 }
@@ -266,11 +278,13 @@ function UserMenu({
   photoURL,
   onSignOut,
   onEditNickname,
+  onResetStats,
 }: {
   displayName: string
   photoURL: string | null
   onSignOut: () => Promise<void>
   onEditNickname: () => void
+  onResetStats: () => void
 }) {
   const [open, setOpen] = useState(false)
   const containerRef = useRef<HTMLDivElement | null>(null)
@@ -330,6 +344,17 @@ function UserMenu({
             className="w-full text-left px-3 py-2 text-sm text-on-surface/80 hover:bg-surface-variant/20 hover:text-on-surface transition-colors"
           >
             Edit nickname
+          </button>
+          <button
+            type="button"
+            role="menuitem"
+            onClick={() => {
+              setOpen(false)
+              onResetStats()
+            }}
+            className="w-full text-left px-3 py-2 text-sm text-on-surface/80 hover:bg-surface-variant/20 hover:text-on-surface transition-colors"
+          >
+            Reset stats…
           </button>
           <button
             type="button"

--- a/src/app/trivia/lib/__tests__/accuracyBadge.test.ts
+++ b/src/app/trivia/lib/__tests__/accuracyBadge.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest'
+
+import { getAccuracyBadge } from '@/app/trivia/lib/accuracyBadge'
+
+describe('getAccuracyBadge', () => {
+  it('returns null with no prior plays (trailblazer covers it)', () => {
+    expect(getAccuracyBadge(0, 0)).toBeNull()
+  })
+
+  it('returns null when priorTimesShown is negative (defensive)', () => {
+    expect(getAccuracyBadge(-1, 0)).toBeNull()
+  })
+
+  it('shows count-only for 1 prior play', () => {
+    expect(getAccuracyBadge(1, 1)).toBe('1 of 1 got this right')
+    expect(getAccuracyBadge(1, 0)).toBe('0 of 1 got this right')
+  })
+
+  it('shows count-only for 4 prior plays (just under threshold)', () => {
+    expect(getAccuracyBadge(4, 3)).toBe('3 of 4 got this right')
+  })
+
+  it('switches to percentage at exactly 5 prior plays', () => {
+    expect(getAccuracyBadge(5, 3)).toBe('60% got this right · 5 plays')
+  })
+
+  it('rounds the percentage to the nearest integer', () => {
+    // 12 / 18 = 66.66...% → 67
+    expect(getAccuracyBadge(18, 12)).toBe('67% got this right · 18 plays')
+    // 1 / 3 wouldn't apply here (under threshold), but 33 / 100 = 33%
+    expect(getAccuracyBadge(100, 33)).toBe('33% got this right · 100 plays')
+  })
+
+  it('handles 0% and 100% extremes for large samples', () => {
+    expect(getAccuracyBadge(20, 0)).toBe('0% got this right · 20 plays')
+    expect(getAccuracyBadge(20, 20)).toBe('100% got this right · 20 plays')
+  })
+})

--- a/src/app/trivia/lib/accuracyBadge.ts
+++ b/src/app/trivia/lib/accuracyBadge.ts
@@ -1,0 +1,13 @@
+// Post-answer community-accuracy line for infinite-mode trivia.
+// Uses pre-increment counts so the badge reflects "the players who came
+// before you," not the current player's own answer feeding back in.
+// Returns null when there's no prior history (the trailblazer headline
+// covers that case in the UI).
+export function getAccuracyBadge(priorTimesShown: number, priorTimesCorrect: number): string | null {
+  if (priorTimesShown <= 0) return null
+  if (priorTimesShown < 5) {
+    return `${priorTimesCorrect} of ${priorTimesShown} got this right`
+  }
+  const pct = Math.round((priorTimesCorrect / priorTimesShown) * 100)
+  return `${pct}% got this right · ${priorTimesShown} plays`
+}

--- a/src/app/trivia/page.tsx
+++ b/src/app/trivia/page.tsx
@@ -119,6 +119,17 @@ export default function TriviaPage() {
   const handleStartPractice = () => setView('practice')
   const handleViewInfiniteLeaderboard = () => setView('infinite-leaderboard')
 
+  const handleStatsReset = useCallback(
+    (scopes: { daily: boolean; infinite: boolean }) => {
+      if (scopes.daily) {
+        setLocalToday(null)
+        setLastResult(null)
+        setAutoResultsShown(true)
+      }
+    },
+    []
+  )
+
   const handleFinish = useCallback(
     (result: TriviaGameResult) => {
       saveTodayResult(result)
@@ -187,6 +198,7 @@ export default function TriviaPage() {
       onViewInfiniteStats={handleViewInfiniteStats}
       onStartPractice={handleStartPractice}
       onViewInfiniteLeaderboard={handleViewInfiniteLeaderboard}
+      onStatsReset={handleStatsReset}
       todayResult={todayResult}
     />
   )

--- a/src/lib/trivia/__tests__/resetStats.test.ts
+++ b/src/lib/trivia/__tests__/resetStats.test.ts
@@ -1,0 +1,233 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+interface FakeDoc {
+  data: Record<string, unknown>
+}
+
+class FakeStore {
+  docs = new Map<string, FakeDoc>()
+
+  set(path: string, data: Record<string, unknown>): void {
+    this.docs.set(path, { data })
+  }
+
+  has(path: string): boolean {
+    return this.docs.has(path)
+  }
+
+  get(path: string): FakeDoc | undefined {
+    return this.docs.get(path)
+  }
+
+  delete(path: string): void {
+    this.docs.delete(path)
+  }
+
+  listCollection(collectionPath: string): Array<{ id: string; path: string; data: Record<string, unknown> }> {
+    const prefix = `${collectionPath}/`
+    const results: Array<{ id: string; path: string; data: Record<string, unknown> }> = []
+    for (const [path, doc] of this.docs) {
+      if (!path.startsWith(prefix)) continue
+      const remainder = path.slice(prefix.length)
+      if (remainder.includes('/')) continue
+      results.push({ id: remainder, path, data: doc.data })
+    }
+    return results
+  }
+}
+
+const store = new FakeStore()
+
+class FakeDocRef {
+  constructor(
+    public path: string,
+    private s: FakeStore
+  ) {}
+
+  async get() {
+    const doc = this.s.get(this.path)
+    return {
+      exists: doc !== undefined,
+      data: () => doc?.data,
+      ref: this,
+    }
+  }
+
+  async delete() {
+    this.s.delete(this.path)
+  }
+}
+
+class FakeQuerySnap {
+  constructor(public docs: Array<{ id: string; ref: FakeDocRef; data: () => Record<string, unknown> }>) {}
+  get empty() {
+    return this.docs.length === 0
+  }
+  get size() {
+    return this.docs.length
+  }
+}
+
+class FakeCollectionRef {
+  constructor(
+    public path: string,
+    private s: FakeStore,
+    private _limit: number | null = null
+  ) {}
+
+  limit(n: number): FakeCollectionRef {
+    return new FakeCollectionRef(this.path, this.s, n)
+  }
+
+  async get(): Promise<FakeQuerySnap> {
+    const all = this.s.listCollection(this.path)
+    const slice = this._limit !== null ? all.slice(0, this._limit) : all
+    return new FakeQuerySnap(
+      slice.map((d) => ({
+        id: d.id,
+        ref: new FakeDocRef(d.path, this.s),
+        data: () => d.data,
+      }))
+    )
+  }
+}
+
+class FakeBatch {
+  private ops: Array<() => void> = []
+  constructor(private s: FakeStore) {}
+  delete(ref: FakeDocRef) {
+    this.ops.push(() => this.s.delete(ref.path))
+  }
+  async commit() {
+    for (const op of this.ops) op()
+    this.ops = []
+  }
+}
+
+class FakeFirestore {
+  constructor(private s: FakeStore) {}
+  doc(path: string): FakeDocRef {
+    return new FakeDocRef(path, this.s)
+  }
+  collection(path: string): FakeCollectionRef {
+    return new FakeCollectionRef(path, this.s)
+  }
+  batch(): FakeBatch {
+    return new FakeBatch(this.s)
+  }
+}
+
+vi.mock('@/lib/firebase/server', () => ({
+  getFirestoreDb: () => new FakeFirestore(store),
+}))
+
+import { resetDailyStats, resetInfiniteStats } from '@/lib/trivia/resetStats'
+
+const UID = 'user-1'
+const OTHER_UID = 'user-2'
+
+beforeEach(() => {
+  store.docs.clear()
+})
+
+describe('resetDailyStats', () => {
+  it('deletes profile, games, daily, and weekly entries for the user', async () => {
+    store.set(`users/${UID}/triviaProfile/current`, { gamesPlayed: 7 })
+    store.set(`users/${UID}/triviaGames/2026-04-30`, { score: 100 })
+    store.set(`users/${UID}/triviaGames/2026-05-01`, { score: 200 })
+    store.set(`users/${UID}/triviaDaily/2026-04-30`, { score: 100 })
+    store.set(`users/${UID}/triviaDaily/2026-05-01`, { score: 200 })
+    store.set(`users/${UID}/triviaWeekly/2026-W18`, { weekKey: '2026-W18', totalScore: 300 })
+
+    const res = await resetDailyStats(UID)
+
+    expect(res.deletedDocs).toBe(6)
+    expect(store.has(`users/${UID}/triviaProfile/current`)).toBe(false)
+    expect(store.listCollection(`users/${UID}/triviaGames`)).toHaveLength(0)
+    expect(store.listCollection(`users/${UID}/triviaDaily`)).toHaveLength(0)
+    expect(store.listCollection(`users/${UID}/triviaWeekly`)).toHaveLength(0)
+  })
+
+  it('revokes only crowns where winnerUid matches the user', async () => {
+    store.set(`users/${UID}/triviaWeekly/2026-W18`, { weekKey: '2026-W18', totalScore: 300 })
+    store.set(`users/${UID}/triviaWeekly/2026-W19`, { weekKey: '2026-W19', totalScore: 200 })
+    store.set(`weeklyCrowns/2026-W18`, { weekKey: '2026-W18', winnerUid: UID, winnerScore: 300 })
+    store.set(`weeklyCrowns/2026-W19`, { weekKey: '2026-W19', winnerUid: OTHER_UID, winnerScore: 250 })
+
+    const res = await resetDailyStats(UID)
+
+    expect(res.crownsRevoked).toBe(1)
+    expect(store.has(`weeklyCrowns/2026-W18`)).toBe(false)
+    expect(store.has(`weeklyCrowns/2026-W19`)).toBe(true)
+  })
+
+  it('does not touch another user\'s data', async () => {
+    store.set(`users/${UID}/triviaGames/2026-05-01`, { score: 100 })
+    store.set(`users/${OTHER_UID}/triviaGames/2026-05-01`, { score: 999 })
+    store.set(`users/${OTHER_UID}/triviaProfile/current`, { gamesPlayed: 99 })
+
+    await resetDailyStats(UID)
+
+    expect(store.listCollection(`users/${OTHER_UID}/triviaGames`)).toHaveLength(1)
+    expect(store.has(`users/${OTHER_UID}/triviaProfile/current`)).toBe(true)
+  })
+
+  it('is idempotent — second call deletes nothing and reports zeros', async () => {
+    store.set(`users/${UID}/triviaProfile/current`, { gamesPlayed: 1 })
+    await resetDailyStats(UID)
+    const second = await resetDailyStats(UID)
+    expect(second.deletedDocs).toBe(0)
+    expect(second.crownsRevoked).toBe(0)
+  })
+})
+
+describe('resetInfiniteStats', () => {
+  it('deletes aggregate, runs, and category stats — but preserves seenQuestions', async () => {
+    store.set(`users/${UID}/triviaStats/aggregate`, { runsPlayed: 10 })
+    store.set(`users/${UID}/triviaInfinite/run-a`, { runId: 'run-a', score: 500 })
+    store.set(`users/${UID}/triviaInfinite/run-b`, { runId: 'run-b', score: 700 })
+    store.set(`users/${UID}/triviaCategoryStats/9`, { categoryId: 9, correctCount: 50 })
+    store.set(`users/${UID}/seenQuestions/q-123`, { at: 1, correct: true })
+    store.set(`users/${UID}/seenQuestions/q-456`, { at: 2, correct: false })
+
+    const res = await resetInfiniteStats(UID)
+
+    expect(res.deletedDocs).toBe(4)
+    expect(store.has(`users/${UID}/triviaStats/aggregate`)).toBe(false)
+    expect(store.listCollection(`users/${UID}/triviaInfinite`)).toHaveLength(0)
+    expect(store.listCollection(`users/${UID}/triviaCategoryStats`)).toHaveLength(0)
+    expect(store.listCollection(`users/${UID}/seenQuestions`)).toHaveLength(2)
+  })
+
+  it('does not touch aiQuestions analytics breadcrumbs', async () => {
+    store.set(`users/${UID}/triviaInfinite/run-a`, { runId: 'run-a' })
+    store.set(`aiQuestions/q-123/answeredBy/${UID}_run-a`, { uid: UID, correct: true })
+
+    await resetInfiniteStats(UID)
+
+    expect(store.has(`aiQuestions/q-123/answeredBy/${UID}_run-a`)).toBe(true)
+  })
+
+  it('does not touch another user\'s data', async () => {
+    store.set(`users/${UID}/triviaInfinite/run-a`, { runId: 'run-a' })
+    store.set(`users/${OTHER_UID}/triviaInfinite/run-x`, { runId: 'run-x' })
+    store.set(`users/${OTHER_UID}/triviaStats/aggregate`, { runsPlayed: 5 })
+
+    await resetInfiniteStats(UID)
+
+    expect(store.listCollection(`users/${OTHER_UID}/triviaInfinite`)).toHaveLength(1)
+    expect(store.has(`users/${OTHER_UID}/triviaStats/aggregate`)).toBe(true)
+  })
+
+  it('deletes in-progress runs (endedAt: null) too', async () => {
+    store.set(`users/${UID}/triviaInfinite/in-progress`, {
+      runId: 'in-progress',
+      endedAt: null,
+      score: 0,
+    })
+
+    await resetInfiniteStats(UID)
+
+    expect(store.listCollection(`users/${UID}/triviaInfinite`)).toHaveLength(0)
+  })
+})

--- a/src/lib/trivia/resetStats.ts
+++ b/src/lib/trivia/resetStats.ts
@@ -1,0 +1,110 @@
+import { getFirestoreDb } from '@/lib/firebase/server'
+
+import type { CollectionReference, Firestore } from 'firebase-admin/firestore'
+
+const BATCH_SIZE = 400
+
+async function chunkedDeleteAll(
+  db: Firestore,
+  collectionRef: CollectionReference
+): Promise<number> {
+  let deleted = 0
+  for (;;) {
+    const snap = await collectionRef.limit(BATCH_SIZE).get()
+    if (snap.empty) break
+    const batch = db.batch()
+    for (const doc of snap.docs) batch.delete(doc.ref)
+    await batch.commit()
+    deleted += snap.size
+    if (snap.size < BATCH_SIZE) break
+  }
+  return deleted
+}
+
+export interface DailyResetResult {
+  deletedDocs: number
+  crownsRevoked: number
+}
+
+export interface InfiniteResetResult {
+  deletedDocs: number
+}
+
+/**
+ * Wipes a user's daily-trivia stats: profile aggregate, per-day game records,
+ * leaderboard entries, and any weekly crowns they currently hold. The next
+ * call to `ensureCrownsAwarded` will reassign revoked crowns to the next-best
+ * remaining player automatically.
+ */
+export async function resetDailyStats(uid: string): Promise<DailyResetResult> {
+  const db = getFirestoreDb()
+  let deletedDocs = 0
+
+  const profileRef = db.doc(`users/${uid}/triviaProfile/current`)
+  const profileSnap = await profileRef.get()
+  if (profileSnap.exists) {
+    await profileRef.delete()
+    deletedDocs += 1
+  }
+
+  deletedDocs += await chunkedDeleteAll(db, db.collection(`users/${uid}/triviaGames`))
+  deletedDocs += await chunkedDeleteAll(db, db.collection(`users/${uid}/triviaDaily`))
+
+  const weeklyCol = db.collection(`users/${uid}/triviaWeekly`)
+  const weeklySnap = await weeklyCol.get()
+  const weekKeys = new Set<string>()
+  for (const doc of weeklySnap.docs) {
+    const data = doc.data() as { weekKey?: string }
+    if (typeof data.weekKey === 'string' && data.weekKey.length > 0) {
+      weekKeys.add(data.weekKey)
+    } else {
+      weekKeys.add(doc.id)
+    }
+  }
+  if (!weeklySnap.empty) {
+    for (let i = 0; i < weeklySnap.docs.length; i += BATCH_SIZE) {
+      const batch = db.batch()
+      for (const doc of weeklySnap.docs.slice(i, i + BATCH_SIZE)) batch.delete(doc.ref)
+      await batch.commit()
+    }
+    deletedDocs += weeklySnap.size
+  }
+
+  let crownsRevoked = 0
+  for (const weekKey of weekKeys) {
+    const crownRef = db.doc(`weeklyCrowns/${weekKey}`)
+    const crownSnap = await crownRef.get()
+    if (!crownSnap.exists) continue
+    const data = crownSnap.data() as { winnerUid?: string }
+    if (data.winnerUid === uid) {
+      await crownRef.delete()
+      crownsRevoked += 1
+      deletedDocs += 1
+    }
+  }
+
+  return { deletedDocs, crownsRevoked }
+}
+
+/**
+ * Wipes a user's infinite-trivia stats: lifetime aggregate, all run docs
+ * (including any in-progress run), and per-category medal counters. Leaves
+ * `seenQuestions` intact so the no-repeat filter still works, and leaves the
+ * `aiQuestions/{qid}/answeredBy` analytics breadcrumb alone.
+ */
+export async function resetInfiniteStats(uid: string): Promise<InfiniteResetResult> {
+  const db = getFirestoreDb()
+  let deletedDocs = 0
+
+  const aggregateRef = db.doc(`users/${uid}/triviaStats/aggregate`)
+  const aggregateSnap = await aggregateRef.get()
+  if (aggregateSnap.exists) {
+    await aggregateRef.delete()
+    deletedDocs += 1
+  }
+
+  deletedDocs += await chunkedDeleteAll(db, db.collection(`users/${uid}/triviaInfinite`))
+  deletedDocs += await chunkedDeleteAll(db, db.collection(`users/${uid}/triviaCategoryStats`))
+
+  return { deletedDocs }
+}


### PR DESCRIPTION
## Summary

Self-serve reset flow accessible from the trivia landing page. Players pick which scopes to wipe (daily, infinite, or both), confirm in a modal showing their current accuracy, and the server tears down their stats.

- `POST /api/v1/trivia/reset { daily?: bool, infinite?: bool }` — auth required, deletes only the caller's own data.
- **Daily reset**: deletes the user's profile aggregate, per-day game records, leaderboard entries, and revokes any weekly crowns they hold. The next `ensureCrownsAwarded` reassigns revoked crowns to the next-best remaining player.
- **Infinite reset**: deletes the per-user stats aggregate, all per-question seen records (`triviaInfinite/`), and per-category stats (`triviaCategoryStats/`).
- Either scope can fail independently; a partial-failure response is returned with the scope and message so the dialog can surface what still needs to be retried.
- Adds a small `accuracyBadge` helper (with tests) used by the dialog to surface the player's current accuracy before they confirm a wipe.

## Test plan

- [ ] As an authenticated user, open the dialog from the trivia landing page
- [ ] Reset daily-only → confirm aggregate, per-day docs, and leaderboard entries are gone
- [ ] Reset infinite-only → confirm seen records, category stats, and aggregate are gone
- [ ] Reset both at once → confirm both succeed in one request
- [ ] Hold a weekly crown, reset daily → confirm the crown is revoked and a new player gets it on the next sweep
- [ ] Test cancel/escape behavior on the dialog
- [ ] Confirm un-authenticated request returns 401, empty body returns 400