### PR TITLE
trivia: add quality-sampling and pool-audit scripts

### DIFF
--- a/scripts/audit-question-mix.ts
+++ b/scripts/audit-question-mix.ts
@@ -1,0 +1,148 @@
+#!/usr/bin/env tsx
+/**
+ * Read-only audit of the aiQuestions pool composition. Reports:
+ *   - Counts by (status, difficulty)
+ *   - Active-pool difficulty mix as percentages, with deltas vs the
+ *     target 4:2:1 (~57% / ~29% / ~14%)
+ *   - Per-category active-pool difficulty mix (so we can see if some
+ *     categories are heavy on hard while others are heavy on easy)
+ *
+ * Useful right after a difficulty-policy change to see whether the
+ * existing pool still skews toward the old distribution and whether
+ * `yarn retire-active-trivia` is worth running.
+ *
+ * Usage:
+ *   npx tsx --env-file=.env.local scripts/audit-question-mix.ts
+ */
+
+import { cert, getApps, initializeApp } from 'firebase-admin/app'
+import { getFirestore } from 'firebase-admin/firestore'
+
+function ensureApp() {
+  if (getApps().length > 0) return
+  const projectId = process.env.FIREBASE_PROJECT_ID
+  const clientEmail = process.env.FIREBASE_CLIENT_EMAIL
+  const privateKey = process.env.FIREBASE_PRIVATE_KEY?.replace(/\\n/g, '\n')
+  if (!projectId || !clientEmail || !privateKey) {
+    console.error('ERROR: Missing Firebase env vars.')
+    process.exit(1)
+  }
+  initializeApp({ credential: cert({ projectId, clientEmail, privateKey }) })
+}
+
+type Difficulty = 'easy' | 'medium' | 'hard' | 'unknown'
+type Status = 'active' | 'legacy' | 'flagged' | 'removed' | 'unknown'
+
+const TARGETS: Record<Exclude<Difficulty, 'unknown'>, number> = {
+  easy: 4 / 7,
+  medium: 2 / 7,
+  hard: 1 / 7,
+}
+
+function pct(n: number, total: number): string {
+  if (total === 0) return '0.0%'
+  return `${((n * 100) / total).toFixed(1)}%`
+}
+
+function delta(actualFrac: number, targetFrac: number): string {
+  const d = (actualFrac - targetFrac) * 100
+  if (Math.abs(d) < 0.5) return '   (=)'
+  const sign = d > 0 ? '+' : ''
+  return `   (${sign}${d.toFixed(1)}pp)`
+}
+
+async function main() {
+  ensureApp()
+  const db = getFirestore()
+
+  console.log('Scanning aiQuestions collection (this is one full read pass)...')
+  const snap = await db.collection('aiQuestions').get()
+  console.log(`Total documents: ${snap.size}\n`)
+
+  const byStatusDifficulty = new Map<string, number>()
+  const activeByCategoryDifficulty = new Map<string, Map<Difficulty, number>>()
+
+  for (const doc of snap.docs) {
+    const data = doc.data() as {
+      status?: string
+      difficulty?: string
+      category?: string
+    }
+    const status = (data.status as Status) ?? 'unknown'
+    const difficulty = (data.difficulty as Difficulty) ?? 'unknown'
+    const key = `${status}|${difficulty}`
+    byStatusDifficulty.set(key, (byStatusDifficulty.get(key) ?? 0) + 1)
+
+    if (status === 'active') {
+      const cat = data.category ?? 'unknown'
+      if (!activeByCategoryDifficulty.has(cat)) {
+        activeByCategoryDifficulty.set(cat, new Map())
+      }
+      const cm = activeByCategoryDifficulty.get(cat)!
+      cm.set(difficulty, (cm.get(difficulty) ?? 0) + 1)
+    }
+  }
+
+  // Status × difficulty matrix
+  console.log('Counts by (status, difficulty):')
+  console.log('─'.repeat(60))
+  const statuses: Status[] = ['active', 'legacy', 'flagged', 'removed', 'unknown']
+  const difficulties: Difficulty[] = ['easy', 'medium', 'hard', 'unknown']
+  console.log(
+    `  ${'status'.padEnd(10)} ${difficulties.map((d) => d.padStart(8)).join(' ')}   total`
+  )
+  for (const s of statuses) {
+    const row: number[] = []
+    let rowTotal = 0
+    for (const d of difficulties) {
+      const c = byStatusDifficulty.get(`${s}|${d}`) ?? 0
+      row.push(c)
+      rowTotal += c
+    }
+    if (rowTotal === 0) continue
+    console.log(
+      `  ${s.padEnd(10)} ${row.map((c) => String(c).padStart(8)).join(' ')}   ${rowTotal}`
+    )
+  }
+
+  // Active pool difficulty mix
+  console.log('\nActive pool difficulty mix vs target 4:2:1:')
+  console.log('─'.repeat(60))
+  const activeTotal = (['easy', 'medium', 'hard'] as const).reduce(
+    (sum, d) => sum + (byStatusDifficulty.get(`active|${d}`) ?? 0),
+    0
+  )
+  for (const d of ['easy', 'medium', 'hard'] as const) {
+    const count = byStatusDifficulty.get(`active|${d}`) ?? 0
+    const actualFrac = activeTotal === 0 ? 0 : count / activeTotal
+    const targetFrac = TARGETS[d]
+    console.log(
+      `  ${d.padEnd(7)}: ${String(count).padStart(5)}   ${pct(count, activeTotal).padStart(6)}   target ${(targetFrac * 100).toFixed(1)}%${delta(actualFrac, targetFrac)}`
+    )
+  }
+  console.log(`  ${'total'.padEnd(7)}: ${String(activeTotal).padStart(5)}`)
+
+  // Per-category active mix (sorted by hard% — categories most over-skewed
+  // to hard show up at the top)
+  console.log('\nActive pool by category (sorted by hard% descending):')
+  console.log('─'.repeat(74))
+  console.log(`  ${'category'.padEnd(26)} ${'easy'.padStart(8)} ${'medium'.padStart(8)} ${'hard'.padStart(8)}   total   hard%`)
+  const catRows = [...activeByCategoryDifficulty.entries()].map(([cat, cm]) => {
+    const e = cm.get('easy') ?? 0
+    const m = cm.get('medium') ?? 0
+    const h = cm.get('hard') ?? 0
+    const total = e + m + h
+    return { cat, e, m, h, total, hardPct: total === 0 ? 0 : (h * 100) / total }
+  })
+  catRows.sort((a, b) => b.hardPct - a.hardPct)
+  for (const row of catRows) {
+    console.log(
+      `  ${row.cat.padEnd(26)} ${String(row.e).padStart(8)} ${String(row.m).padStart(8)} ${String(row.h).padStart(8)}   ${String(row.total).padStart(5)}   ${row.hardPct.toFixed(1)}%`
+    )
+  }
+}
+
+main().catch((err) => {
+  console.error('FAILED:', err)
+  process.exit(1)
+})

--- a/scripts/sample-trivia-quality.ts
+++ b/scripts/sample-trivia-quality.ts
@@ -1,0 +1,179 @@
+#!/usr/bin/env tsx
+/**
+ * One-shot quality sampler. Generates a small grid of Infinite-pipeline
+ * questions across difficulties + categories so we can eyeball whether
+ * a prompt change regressed quality or difficulty calibration.
+ *
+ * NOT idempotent against prod Firestore: calls the same generation
+ * path the live route does, including the duplicate-answer backstop
+ * (which reads from prod). It does NOT save anything.
+ *
+ * Usage:
+ *   yarn tsx --env-file=.env.local scripts/sample-trivia-quality.ts
+ *   yarn tsx --env-file=.env.local scripts/sample-trivia-quality.ts \
+ *     reps=3 categories=9,20,25
+ */
+import { readFileSync } from 'node:fs'
+
+async function main() {
+  // Load .env.local manually (the rest of scripts/ does this too;
+  // staying consistent so the file works whether invoked via `yarn
+  // tsx` directly or the existing tsx --env-file path).
+  for (const line of readFileSync('.env.local', 'utf8').split('\n')) {
+    const m = line.match(/^([A-Z_][A-Z0-9_]*)=(.*)$/)
+    if (m) process.env[m[1]] = m[2].replace(/^"(.*)"$/, '$1')
+  }
+
+  const args = Object.fromEntries(
+    process.argv.slice(2).map((a) => {
+      const [k, v] = a.split('=')
+      return [k, v]
+    })
+  )
+  const reps = args.reps ? parseInt(args.reps, 10) : 2
+  const categoryIds = args.categories
+    ? args.categories.split(',').map((s: string) => parseInt(s, 10))
+    : [9, 20, 25] // general knowledge, mythology, art
+  const difficulties: Array<'easy' | 'medium' | 'hard'> = ['easy', 'medium', 'hard']
+
+  const { generateInfiniteQuestion } = await import('../src/lib/trivia/generateQuestion')
+  const { getOpenTDBCategoryName } = await import('../src/app/trivia/data/seeds')
+
+  // Build the full job list, then run with bounded parallelism.
+  // Bounded so we don't accidentally swamp Perplexity / Anthropic
+  // rate limits while sampling.
+  const PARALLELISM = 6
+  type Job = { difficulty: 'easy' | 'medium' | 'hard'; categoryId: number; rep: number }
+  const jobs: Job[] = []
+  for (const difficulty of difficulties) {
+    for (const categoryId of categoryIds) {
+      for (let rep = 0; rep < reps; rep++) {
+        jobs.push({ difficulty, categoryId, rep })
+      }
+    }
+  }
+
+  console.log(
+    `Sampling ${jobs.length} questions: ${difficulties.length} difficulties × ${categoryIds.length} categories × ${reps} reps. Parallelism=${PARALLELISM}.`
+  )
+  console.log('─'.repeat(72))
+
+  type Result = {
+    job: Job
+    question?: string
+    answer?: string
+    seed?: string
+    sourceUrl?: string
+    explanation?: string
+    elapsedMs: number
+    error?: string
+  }
+
+  const results: Result[] = new Array(jobs.length)
+  let next = 0
+
+  async function worker() {
+    while (true) {
+      const idx = next++
+      if (idx >= jobs.length) return
+      const job = jobs[idx]
+      const t0 = Date.now()
+      try {
+        const q = await generateInfiniteQuestion({
+          categoryId: job.categoryId,
+          difficulty: job.difficulty,
+        })
+        results[idx] = {
+          job,
+          question: q.question,
+          answer: q.correctAnswer,
+          seed: q.seed,
+          sourceUrl: q.sourceUrl,
+          explanation: q.explanation,
+          elapsedMs: Date.now() - t0,
+        }
+        process.stdout.write('.')
+      } catch (err) {
+        results[idx] = {
+          job,
+          elapsedMs: Date.now() - t0,
+          error: err instanceof Error ? err.message : String(err),
+        }
+        process.stdout.write('x')
+      }
+    }
+  }
+
+  const t0 = Date.now()
+  await Promise.all(Array.from({ length: PARALLELISM }, () => worker()))
+  process.stdout.write('\n')
+  const totalMs = Date.now() - t0
+
+  // Group by difficulty for easy human comparison.
+  const byDifficulty: Record<string, Result[]> = { easy: [], medium: [], hard: [] }
+  for (const r of results) byDifficulty[r.job.difficulty].push(r)
+
+  for (const difficulty of difficulties) {
+    console.log(`\n=== ${difficulty.toUpperCase()} ===`)
+    for (const r of byDifficulty[difficulty]) {
+      const cat = getOpenTDBCategoryName(r.job.categoryId)
+      if (r.error) {
+        console.log(`[${cat}] FAILED in ${r.elapsedMs}ms: ${r.error}`)
+        continue
+      }
+      console.log(`[${cat}] (${r.elapsedMs}ms)`)
+      console.log(`  seed:   ${r.seed ?? '<none>'}`)
+      console.log(`  Q:      ${r.question}`)
+      console.log(`  A:      ${r.answer}`)
+      if (r.sourceUrl) console.log(`  source: ${r.sourceUrl}`)
+      if (r.explanation) console.log(`  expl:   ${r.explanation}`)
+    }
+  }
+
+  // Quick aggregate signals.
+  const ok = results.filter((r) => !r.error)
+  const failed = results.filter((r) => r.error)
+  const answers = ok.map((r) => (r.answer ?? '').toLowerCase().trim())
+  const answerCounts = new Map<string, number>()
+  for (const a of answers) answerCounts.set(a, (answerCounts.get(a) ?? 0) + 1)
+  const dupes = [...answerCounts.entries()].filter(([, n]) => n > 1)
+
+  const sources = ok.map((r) => {
+    if (!r.sourceUrl) return null
+    try {
+      return new URL(r.sourceUrl).hostname.replace(/^www\./, '')
+    } catch {
+      return null
+    }
+  })
+  const sourceCounts = new Map<string, number>()
+  for (const s of sources) {
+    if (!s) continue
+    sourceCounts.set(s, (sourceCounts.get(s) ?? 0) + 1)
+  }
+  const topSources = [...sourceCounts.entries()].sort((a, b) => b[1] - a[1]).slice(0, 5)
+
+  console.log('\n─'.repeat(72))
+  console.log(`Summary: ${ok.length}/${results.length} succeeded in ${totalMs}ms wall clock.`)
+  if (failed.length) {
+    console.log(`Failed: ${failed.length}`)
+    for (const r of failed) {
+      console.log(`  - [${getOpenTDBCategoryName(r.job.categoryId)} ${r.job.difficulty}] ${r.error}`)
+    }
+  }
+  if (dupes.length) {
+    console.log('Duplicate answers in this batch:')
+    for (const [a, n] of dupes) console.log(`  ${n}× "${a}"`)
+  } else {
+    console.log('No duplicate answers in this batch.')
+  }
+  if (topSources.length) {
+    console.log('Top source domains:')
+    for (const [s, n] of topSources) console.log(`  ${n}× ${s}`)
+  }
+}
+
+main().catch((err) => {
+  console.error('FAILED:', err)
+  process.exit(1)
+})


### PR DESCRIPTION
## Summary

Two read-only ops scripts for diagnosing the AI trivia pipeline.

- **`scripts/sample-trivia-quality.ts`** — Replays the live `generateInfiniteQuestion` path across a small grid of (difficulty × category) cells with bounded parallelism and prints each result so quality can be eyeballed after a prompt change. Calls the production pipeline including the duplicate-answer backstop, but never persists.
  ```
  yarn tsx --env-file=.env.local scripts/sample-trivia-quality.ts
  yarn tsx --env-file=.env.local scripts/sample-trivia-quality.ts reps=3 categories=9,20,25
  ```

- **`scripts/audit-question-mix.ts`** — Reads the `aiQuestions` collection and reports the active pool's difficulty composition versus the 4:2:1 target (easy / medium / hard), broken down per category. Useful right after a difficulty-policy change to see whether the existing pool still skews toward the old distribution and whether `retire-active-trivia` is worth running.
  ```
  npx tsx --env-file=.env.local scripts/audit-question-mix.ts
  ```

## Test plan

- [ ] Run `sample-trivia-quality.ts` and confirm a grid of generations prints with categories labeled
- [ ] Run `audit-question-mix.ts` against prod-data Firestore and confirm the per-category and overall mix percentages render with deltas vs. target