### PR TITLE
daily-card-game: floor chips*mult before BigInt to fix fractional mult crash

### DIFF
--- a/src/app/daily-card-game/domain/game/handlers.ts
+++ b/src/app/daily-card-game/domain/game/handlers.ts
@@ -26,8 +26,8 @@ function computeBlindScoreAndAnte(
 ) {
   if (!currentBlind) return null
 
-  // Convert hand score (chips * mult) to BigInt before adding to blind score
-  const handScore = BigInt(draft.gamePlayState.score.chips * draft.gamePlayState.score.mult)
+  // mult can be fractional (e.g. Bloodstone, Ancient Joker apply x1.5), so floor before BigInt
+  const handScore = BigInt(Math.floor(draft.gamePlayState.score.chips * draft.gamePlayState.score.mult))
   const blindScore = currentBlind.score + handScore
   const blindDefinition = getBlindDefinition(currentBlind.type, round)
   const ante = calculateAnte(round.baseAnte, blindDefinition.anteMultiplier)


### PR DESCRIPTION
## Summary
- `BigInt(chips * mult)` crashed with *\"229.5 cannot be converted to a BigInt because it is not an integer\"* when mult was fractional
- Bloodstone and Ancient Joker apply `*= 1.5` to mult, so the product can be a half-integer (e.g. 153 × 1.5 = 229.5)
- Wrap the product in `Math.floor` before `BigInt` — matches the existing daily-card-game convention (boss blinds, shop prices, interest all floor)

## Test plan
- [ ] Trigger Bloodstone or Ancient Joker proc on a hand and confirm scoring no longer throws
- [ ] Sanity-check existing scoring tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)