### PR TITLE
trivia: add eval harness and bulk seeder for AI questions

### DIFF
--- a/evals/README.md
+++ b/evals/README.md
@@ -1,0 +1,52 @@
+# Trivia eval + seeding
+
+Two scripts share the same generation pipeline and judge:
+
+- `npm run eval:trivia:smoke` / `npm run eval:trivia` — measure quality (read-only)
+- `npm run seed-ai-questions` — bulk-write to Firestore (with optional judge filter)
+
+## Eval
+
+Replays `generateInfiniteQuestion` against a curated set of `(category, difficulty)` cells, scores each result with an OpenAI judge on **factual accuracy** and **difficulty calibration**, and prints a scorecard with deltas vs. the previous run.
+
+```
+npm run eval:trivia:smoke              # 15 cells × 1 trial, ~60s
+npm run eval:trivia                    # 51 cells × 3 trials, ~5min
+npm run eval:trivia:smoke -- --trials 3 --concurrency 4
+```
+
+Inner loop: baseline → change a prompt or model → run smoke → read deltas.
+
+Reading the scorecard:
+- `ship-worthy` line under "Quality (overall)" is the headline metric — % of generations the judge would let through.
+- `↑/↓` arrows show per-dimension deltas vs. `evals/runs/latest.json`.
+- "Worst-scoring questions" lists low-score examples with rationales.
+
+Persistence: each run writes a timestamped JSON to `evals/runs/`; `latest.json` is the rolling baseline (committed). Other run files are gitignored.
+
+Override the judge model with `OPENAI_EVAL_MODEL=gpt-4.1` (default `gpt-4o`).
+
+## Seeding
+
+Bulk-writes new questions to the live `aiQuestions` Firestore collection. Same pipeline as the runtime warmer (`src/lib/trivia/warmQuestionPool.ts`), including the duplicate-answer backstop.
+
+```
+npm run seed-ai-questions -- --count 20
+npm run seed-ai-questions -- --count 50 --difficulty easy
+npm run seed-ai-questions -- --count 100 --gate     # only save ship=true
+npm run seed-ai-questions -- --count 50 --no-judge  # skip judging entirely
+npm run seed-ai-questions -- --count 30 --category 17
+```
+
+Default behavior judges every question and saves all of them. Pass `--gate` to drop questions the judge wouldn't ship. Pass `--no-judge` to skip judging entirely (faster, no quality signal).
+
+End-of-run scorecard summarizes saved/gated/failed counts and the judge-score distribution. Worst-scoring examples are printed even without `--gate` so you know what kind of output the pipeline is letting through.
+
+## Required env
+
+Loaded from `.env.local` via `tsx --env-file`:
+
+- `ANTHROPIC_API_KEY` — generation pipeline
+- `PERPLEXITY_API_KEY` — fact source (if Perplexity is the configured `FactSource`)
+- `OPENAI_API_KEY` — judge (omit if `--no-judge` on the seeder)
+- `FIREBASE_PROJECT_ID`, `FIREBASE_CLIENT_EMAIL`, `FIREBASE_PRIVATE_KEY` — seeder only

--- a/evals/runs/.gitignore
+++ b/evals/runs/.gitignore
@@ -1,0 +1,5 @@
+# Persisted eval runs. latest.json is committed so the scorecard can
+# diff a fresh checkout against the most recent baseline; timestamped
+# run files stay local.
+*.json
+!latest.json

--- a/evals/runs/latest.json
+++ b/evals/runs/latest.json
@@ -1,0 +1,363 @@
+{
+  "timestamp": "2026-05-03T04:50:17.169Z",
+  "appVersion": "8496c0d2fde2f27c66d7c7846a487da6e1902ebc",
+  "judgeModel": "gpt-4o",
+  "config": {
+    "cells": 51,
+    "trialsPerCell": 3,
+    "totalJobs": 153,
+    "concurrency": 4,
+    "smoke": false
+  },
+  "totals": {
+    "generated": 153,
+    "generationFailed": 0,
+    "judgeFailed": 0
+  },
+  "cost": {
+    "totalUsd": 2.721725999999999,
+    "perTrialUsd": 0.017789058823529404,
+    "byStage": {
+      "facts": 0.19065,
+      "factPicker": 0.069142,
+      "construct": 1.4810670000000001,
+      "review": 0.30166800000000005,
+      "judge": 0.43128500000000003,
+      "repair": 0.24791400000000008
+    },
+    "byModel": {
+      "sonar": 0.19065,
+      "claude-haiku-4-5-20251001": 0.3708100000000002,
+      "claude-sonnet-4-6": 1.728981,
+      "gpt-4o": 0.43128500000000003
+    },
+    "unknownModels": []
+  },
+  "overall": {
+    "total": 153,
+    "scored": 153,
+    "score3": 280,
+    "score2": 15,
+    "score1": 11,
+    "shipPct": 87.58169934640523,
+    "factualMean": 2.823529411764706,
+    "difficultyMean": 2.934640522875817
+  },
+  "byDifficulty": {
+    "easy": {
+      "total": 51,
+      "scored": 51,
+      "score3": 91,
+      "score2": 7,
+      "score1": 4,
+      "shipPct": 88.23529411764706,
+      "factualMean": 2.8627450980392157,
+      "difficultyMean": 2.843137254901961
+    },
+    "medium": {
+      "total": 51,
+      "scored": 51,
+      "score3": 97,
+      "score2": 3,
+      "score1": 2,
+      "shipPct": 94.11764705882354,
+      "factualMean": 2.9019607843137254,
+      "difficultyMean": 2.9607843137254903
+    },
+    "hard": {
+      "total": 51,
+      "scored": 51,
+      "score3": 92,
+      "score2": 5,
+      "score1": 5,
+      "shipPct": 80.3921568627451,
+      "factualMean": 2.7058823529411766,
+      "difficultyMean": 3
+    }
+  },
+  "byCategory": {
+    "General Knowledge": {
+      "total": 9,
+      "scored": 9,
+      "score3": 15,
+      "score2": 1,
+      "score1": 2,
+      "shipPct": 88.88888888888889,
+      "factualMean": 2.7777777777777777,
+      "difficultyMean": 2.6666666666666665
+    },
+    "Film": {
+      "total": 9,
+      "scored": 9,
+      "score3": 18,
+      "score2": 0,
+      "score1": 0,
+      "shipPct": 100,
+      "factualMean": 3,
+      "difficultyMean": 3
+    },
+    "Science & Nature": {
+      "total": 9,
+      "scored": 9,
+      "score3": 16,
+      "score2": 1,
+      "score1": 1,
+      "shipPct": 77.77777777777777,
+      "factualMean": 2.6666666666666665,
+      "difficultyMean": 3
+    },
+    "Geography": {
+      "total": 9,
+      "scored": 9,
+      "score3": 18,
+      "score2": 0,
+      "score1": 0,
+      "shipPct": 100,
+      "factualMean": 3,
+      "difficultyMean": 3
+    },
+    "History": {
+      "total": 9,
+      "scored": 9,
+      "score3": 15,
+      "score2": 2,
+      "score1": 1,
+      "shipPct": 66.66666666666667,
+      "factualMean": 2.5555555555555554,
+      "difficultyMean": 3
+    },
+    "Music": {
+      "total": 9,
+      "scored": 9,
+      "score3": 17,
+      "score2": 0,
+      "score1": 1,
+      "shipPct": 88.88888888888889,
+      "factualMean": 2.7777777777777777,
+      "difficultyMean": 3
+    },
+    "Television": {
+      "total": 9,
+      "scored": 9,
+      "score3": 18,
+      "score2": 0,
+      "score1": 0,
+      "shipPct": 100,
+      "factualMean": 3,
+      "difficultyMean": 3
+    },
+    "Video Games": {
+      "total": 9,
+      "scored": 9,
+      "score3": 16,
+      "score2": 2,
+      "score1": 0,
+      "shipPct": 88.88888888888889,
+      "factualMean": 2.888888888888889,
+      "difficultyMean": 2.888888888888889
+    },
+    "Sports": {
+      "total": 9,
+      "scored": 9,
+      "score3": 17,
+      "score2": 1,
+      "score1": 0,
+      "shipPct": 88.88888888888889,
+      "factualMean": 2.888888888888889,
+      "difficultyMean": 3
+    },
+    "Mythology": {
+      "total": 9,
+      "scored": 9,
+      "score3": 14,
+      "score2": 1,
+      "score1": 3,
+      "shipPct": 66.66666666666667,
+      "factualMean": 2.4444444444444446,
+      "difficultyMean": 2.7777777777777777
+    },
+    "Books": {
+      "total": 9,
+      "scored": 9,
+      "score3": 17,
+      "score2": 0,
+      "score1": 1,
+      "shipPct": 88.88888888888889,
+      "factualMean": 2.7777777777777777,
+      "difficultyMean": 3
+    },
+    "Computers": {
+      "total": 9,
+      "scored": 9,
+      "score3": 16,
+      "score2": 1,
+      "score1": 1,
+      "shipPct": 77.77777777777777,
+      "factualMean": 2.888888888888889,
+      "difficultyMean": 2.7777777777777777
+    },
+    "Animals": {
+      "total": 9,
+      "scored": 9,
+      "score3": 18,
+      "score2": 0,
+      "score1": 0,
+      "shipPct": 100,
+      "factualMean": 3,
+      "difficultyMean": 3
+    },
+    "Politics": {
+      "total": 9,
+      "scored": 9,
+      "score3": 15,
+      "score2": 2,
+      "score1": 1,
+      "shipPct": 77.77777777777777,
+      "factualMean": 2.5555555555555554,
+      "difficultyMean": 3
+    },
+    "Art": {
+      "total": 9,
+      "scored": 9,
+      "score3": 17,
+      "score2": 1,
+      "score1": 0,
+      "shipPct": 100,
+      "factualMean": 3,
+      "difficultyMean": 2.888888888888889
+    },
+    "Vehicles": {
+      "total": 9,
+      "scored": 9,
+      "score3": 16,
+      "score2": 2,
+      "score1": 0,
+      "shipPct": 88.88888888888889,
+      "factualMean": 2.888888888888889,
+      "difficultyMean": 2.888888888888889
+    },
+    "Cartoons & Animation": {
+      "total": 9,
+      "scored": 9,
+      "score3": 17,
+      "score2": 1,
+      "score1": 0,
+      "shipPct": 88.88888888888889,
+      "factualMean": 2.888888888888889,
+      "difficultyMean": 3
+    }
+  },
+  "worst": [
+    {
+      "category": "General Knowledge",
+      "difficulty": "easy",
+      "question": "According to a popular claim about the origins of table etiquette, in which ancient religious text is the rule of \"no elbows on the table\" said to have its earliest roots?",
+      "correctAnswer": "Old Testament",
+      "factualScore": 1,
+      "factualRationale": "There is no evidence or widely accepted claim that the 'no elbows on the table' rule originates from the Old Testament.",
+      "difficultyScore": 1,
+      "difficultyRationale": "The question is mis-tiered as 'easy' because the answer is not common knowledge and relies on a dubious claim.",
+      "sourceUrl": "https://interestingfacts.com/table-etiquette-facts/"
+    },
+    {
+      "category": "Mythology",
+      "difficulty": "medium",
+      "question": "In the Pyramid Texts, which spell stands as the sole individual spell to bear a title — specifically, the 'Opening of the Mouth'?",
+      "correctAnswer": "Spell 355",
+      "factualScore": 1,
+      "factualRationale": "The Pyramid Texts do not contain a spell numbered 355 with the title 'Opening of the Mouth'; this is a misattribution as the 'Opening of the Mouth' is a well-known ritual but not specifically numbered or titled as such in the Pyramid Texts.",
+      "difficultyScore": 1,
+      "difficultyRationale": "The question is mismatched for a medium difficulty as it requires specialist knowledge of the Pyramid Texts and misattributes a well-known ritual, making it confusing and misleading.",
+      "sourceUrl": "https://www.touregypt.net/featurestories/pyramidtext.htm"
+    },
+    {
+      "category": "Science & Nature",
+      "difficulty": "hard",
+      "question": "Which paleontologist accidentally discovered the dinosaur initially named Daptosaurus while searching for Tenontosaurus fossils in Wyoming during the 1930s — a find later reclassified as Deinonychus?",
+      "correctAnswer": "Barnum Brown",
+      "factualScore": 1,
+      "factualRationale": "The stated correct answer is incorrect; it was John Ostrom, not Barnum Brown, who discovered and named Deinonychus.",
+      "difficultyScore": 3,
+      "difficultyRationale": "The question is a genuine deep cut, requiring specific knowledge of paleontology history, fitting the 'hard' tier.",
+      "sourceUrl": "https://www.xprize.org/news/ten-major-breakthroughs-that-were-happy-accidents"
+    },
+    {
+      "category": "History",
+      "difficulty": "hard",
+      "question": "Saladin was widely praised for his disciplined and even chivalrous conduct in warfare, but there is one notable city in northwestern Iraq — historically a heartland of the Yazidi people — where his forces broke from that reputation and went on a rampage after its capture. What city is that?",
+      "correctAnswer": "Sinjar",
+      "factualScore": 1,
+      "factualRationale": "There is no historical evidence or widely accepted account of Saladin's forces rampaging in Sinjar, making the premise and answer incorrect.",
+      "difficultyScore": 3,
+      "difficultyRationale": "The question is appropriately difficult for a 'hard' tier, as it requires specific historical knowledge about Saladin's campaigns.",
+      "sourceUrl": "https://www.factinate.com/people/saladin-lionhearts-nemesis"
+    },
+    {
+      "category": "Music",
+      "difficulty": "hard",
+      "question": "Which American minimalist composer deliberately abandoned conventional rhythm and tempo, employing aleatoric techniques to introduce unpredictability into his performances?",
+      "correctAnswer": "La Monte Young",
+      "factualScore": 1,
+      "factualRationale": "La Monte Young is not primarily known for employing aleatoric techniques; John Cage is a more accurate answer for this description.",
+      "difficultyScore": 3,
+      "difficultyRationale": "The question is well-calibrated as hard, as it requires specific knowledge of minimalist composers and their techniques.",
+      "sourceUrl": "https://www.allclassical.org/the-story-of-minimalism-part-one-a-new-way-of-listening/"
+    },
+    {
+      "category": "Mythology",
+      "difficulty": "easy",
+      "question": "According to Greek mythology, which sporting event did Zeus create to celebrate his victory over the Titan Cronus?",
+      "correctAnswer": "Olympic Games",
+      "factualScore": 1,
+      "factualRationale": "There is no widely accepted myth that Zeus created the Olympic Games to celebrate his victory over Cronus; this is a misrepresentation of Greek mythology.",
+      "difficultyScore": 3,
+      "difficultyRationale": "The question is well-calibrated for an easy difficulty level, as the Olympic Games are a well-known event.",
+      "sourceUrl": "https://historyfacts.com/world-history/article/6-little-known-facts-about-greek-mythology/"
+    },
+    {
+      "category": "Books",
+      "difficulty": "hard",
+      "question": "In Arthur C. Clarke's novel \"Rendezvous with Rama,\" what type of geometric symmetry — found in three-sided figures — is pervasively exhibited throughout the alien vessel's internal structures?",
+      "correctAnswer": "trilateral symmetry",
+      "factualScore": 1,
+      "factualRationale": "The correct term for the symmetry in 'Rendezvous with Rama' is 'triangular symmetry,' not 'trilateral symmetry.'",
+      "difficultyScore": 3,
+      "difficultyRationale": "The question is well-calibrated as hard, as it requires specific knowledge of the book's details.",
+      "sourceUrl": "http://strakul.blogspot.com/2025/02/book-review-rendezvous-with-rama-by.html"
+    },
+    {
+      "category": "Computers",
+      "difficulty": "easy",
+      "question": "Who developed the MVC software design pattern in 1979?",
+      "correctAnswer": "Trygve Reenskaug",
+      "factualScore": 3,
+      "factualRationale": "The question correctly attributes the development of the MVC pattern to Trygve Reenskaug in 1979.",
+      "difficultyScore": 1,
+      "difficultyRationale": "The answer 'Trygve Reenskaug' is a specialist label not commonly known to the general public, making it unsuitable for an 'easy' difficulty level.",
+      "sourceUrl": "https://dev.to/dmitry-kabanov/model-view-controller-mvc-origins-of-design-pattern-1677"
+    },
+    {
+      "category": "Politics",
+      "difficulty": "hard",
+      "question": "According to human rights literature, critics have used a two-word architectural metaphor to describe the structural weakness built into the Universal Declaration of Human Rights from its very foundation — what is that metaphor?",
+      "correctAnswer": "fragile architecture",
+      "factualScore": 1,
+      "factualRationale": "The term 'fragile architecture' is not widely recognized or verifiable as a specific critique of the UDHR in human rights literature.",
+      "difficultyScore": 3,
+      "difficultyRationale": "The question is appropriately difficult for the 'hard' tier, as it requires specific knowledge of human rights literature.",
+      "sourceUrl": "https://pmc.ncbi.nlm.nih.gov/articles/PMC11464809/"
+    },
+    {
+      "category": "General Knowledge",
+      "difficulty": "easy",
+      "question": "In British rhyming slang, whose name is used as a term for 'starving,' as in 'I'm absolutely [name]'?",
+      "correctAnswer": "Hank Marvin",
+      "factualScore": 3,
+      "factualRationale": "The question correctly identifies Hank Marvin as the name used in Cockney rhyming slang for 'starving.'",
+      "difficultyScore": 2,
+      "difficultyRationale": "While Hank Marvin is a well-known figure in British music, the use of his name in rhyming slang may not be common knowledge for a typical adult, making it borderline for an 'easy' tier.",
+      "sourceUrl": "https://www.italki.com/en/article/1271/5-interesting-facts-about-english-slang"
+    }
+  ],
+  "generationFailures": []
+}

--- a/package.json
+++ b/package.json
@@ -16,7 +16,10 @@
     "reset-trivia-firestore": "esbuild scripts/reset-trivia-firestore.ts --bundle --platform=node --format=esm --packages=external --outfile=/tmp/reset-trivia-firestore-bundle.mjs && node /tmp/reset-trivia-firestore-bundle.mjs",
     "backfill-legacy-trivia": "tsx --env-file=.env.local scripts/backfill-legacy-models.ts",
     "retire-active-trivia": "tsx --env-file=.env.local scripts/retire-active-trivia.ts",
-    "classify-seed-difficulty": "tsx --env-file=.env.local scripts/classify-seed-difficulty.ts"
+    "classify-seed-difficulty": "tsx --env-file=.env.local scripts/classify-seed-difficulty.ts",
+    "eval:trivia": "tsx --env-file=.env.local scripts/eval-trivia.ts",
+    "eval:trivia:smoke": "tsx --env-file=.env.local scripts/eval-trivia.ts --smoke",
+    "seed-ai-questions": "tsx --env-file=.env.local scripts/seed-ai-questions.ts"
   },
   "dependencies": {
     "@ai-sdk/anthropic": "^1.2.12",

--- a/scripts/eval-trivia.ts
+++ b/scripts/eval-trivia.ts
@@ -1,0 +1,127 @@
+#!/usr/bin/env tsx
+/**
+ * Trivia generation eval harness.
+ *
+ * Replays the live generateInfiniteQuestion() pipeline against a curated
+ * set of (category, difficulty) cells, then scores each generated
+ * question with an OpenAI judge on two dimensions: factual accuracy and
+ * difficulty calibration. Persists each run to evals/runs/, prints a
+ * scorecard with deltas vs. the previous run.
+ *
+ * Workflow:
+ *   make a change → npm run eval:trivia:smoke → check scorecard
+ *   pre-merge → npm run eval:trivia → check scorecard
+ *
+ * Usage:
+ *   npm run eval:trivia                    # full sweep (51 cells × 3 trials)
+ *   npm run eval:trivia:smoke              # smoke (15 cells × 1 trial)
+ *   npm run eval:trivia -- --trials 5      # override trial count
+ *   npm run eval:trivia -- --concurrency 2 # gentler on rate limits
+ *
+ * Required env (loaded from .env.local via tsx --env-file):
+ *   ANTHROPIC_API_KEY  — generation pipeline
+ *   OPENAI_API_KEY     — judge
+ *   PERPLEXITY_API_KEY — fact source (if Perplexity is the configured FactSource)
+ *
+ * Override the judge model with OPENAI_EVAL_MODEL=gpt-4.1 (default: gpt-4o).
+ */
+
+import { getGoldenCells } from './eval/golden-cells'
+import { JUDGE_MODEL_ID } from './eval/judge'
+import { runEval, type TrialResult } from './eval/runner'
+import { loadPreviousRun, persistRun, printScorecard, summarize } from './eval/scorecard'
+
+interface Args {
+  smoke: boolean
+  trialsOverride: number | null
+  concurrency: number
+}
+
+function parseArgs(): Args {
+  const args = process.argv.slice(2)
+  let smoke = false
+  let trialsOverride: number | null = null
+  let concurrency = 4
+
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i]
+    if (a === '--smoke') smoke = true
+    else if (a === '--trials' && args[i + 1]) {
+      trialsOverride = parseInt(args[++i], 10)
+    } else if (a === '--concurrency' && args[i + 1]) {
+      concurrency = parseInt(args[++i], 10)
+    } else if (a === '--help' || a === '-h') {
+      process.stdout.write(
+        'Usage: eval-trivia [--smoke] [--trials N] [--concurrency N]\n'
+      )
+      process.exit(0)
+    }
+  }
+
+  return { smoke, trialsOverride, concurrency }
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs()
+  const cells = getGoldenCells(args.smoke)
+  const trialsPerCell = args.trialsOverride ?? (args.smoke ? 1 : 3)
+  const totalJobs = cells.length * trialsPerCell
+
+  process.stdout.write(
+    `\nRunning ${args.smoke ? 'SMOKE' : 'FULL'} eval: ${cells.length} cells × ${trialsPerCell} trials = ${totalJobs} generations (concurrency=${args.concurrency})\n`
+  )
+  process.stdout.write(`Judge model: ${JUDGE_MODEL_ID}\n\n`)
+
+  const startedAt = Date.now()
+  const results = await runEval({
+    cells,
+    trialsPerCell,
+    concurrency: args.concurrency,
+    onProgress: (done, total, latest) => {
+      const tag = formatProgressTag(latest)
+      process.stdout.write(
+        `  [${String(done).padStart(3)}/${total}] ${tag}\n`
+      )
+    },
+  })
+  const elapsedSec = ((Date.now() - startedAt) / 1000).toFixed(1)
+  process.stdout.write(`\nFinished ${results.length} jobs in ${elapsedSec}s\n`)
+
+  const summary = summarize({
+    results,
+    cells,
+    trialsPerCell,
+    concurrency: args.concurrency,
+    smoke: args.smoke,
+    judgeModel: JUDGE_MODEL_ID,
+  })
+
+  const previous = loadPreviousRun()
+  printScorecard(summary, previous)
+
+  const { runPath } = persistRun(summary)
+  process.stdout.write(`Wrote ${runPath}\n\n`)
+}
+
+function formatProgressTag(r: TrialResult): string {
+  const cell = `${r.cell.categoryName}/${r.cell.difficulty}`
+  if (r.outcome.kind === 'generation_failed') {
+    return `${cell}  GEN-FAIL  ${truncate(r.outcome.error, 60)}`
+  }
+  if (r.outcome.kind === 'judge_failed') {
+    return `${cell}  JUDGE-FAIL  ${truncate(r.outcome.error, 60)}`
+  }
+  const v = r.outcome.verdict
+  const ship = v.ship ? 'ship' : '----'
+  return `${cell}  f=${v.factual_score} d=${v.difficulty_score} ${ship}  "${truncate(r.outcome.question, 50)}"`
+}
+
+function truncate(s: string, max: number): string {
+  if (s.length <= max) return s
+  return s.slice(0, max - 1) + '…'
+}
+
+main().catch((err) => {
+  process.stderr.write(`\nEval failed: ${err instanceof Error ? err.stack ?? err.message : String(err)}\n`)
+  process.exit(1)
+})

--- a/scripts/eval/cost.ts
+++ b/scripts/eval/cost.ts
@@ -1,0 +1,70 @@
+// Token-usage → USD rollup for the eval harness. Pricing table is
+// hand-maintained because the SDK doesn't surface unit prices and
+// because each provider lists rates in slightly different ways
+// (per-million tokens, per-call, etc.). Numbers are USD per million
+// tokens, sourced from each provider's public pricing page as of
+// 2026-05-02. Update if you swap models or vendors raise prices.
+//
+// Models not in the table contribute $0 — the eval logs unknown
+// models so we notice and add them, rather than silently mispricing.
+
+import type { UsageEvent } from '../../src/lib/trivia/usageRecorder'
+
+interface ModelPricing {
+  inputPerM: number
+  outputPerM: number
+}
+
+export const MODEL_PRICING: Record<string, ModelPricing> = {
+  // Anthropic — claude.ai/pricing
+  'claude-sonnet-4-6': { inputPerM: 3, outputPerM: 15 },
+  'claude-haiku-4-5-20251001': { inputPerM: 1, outputPerM: 5 },
+  // Perplexity — docs.perplexity.ai/guides/pricing (sonar = base tier)
+  // Per-search fee not modelled — it's a flat ~$5/1k requests on top of
+  // tokens, small relative to LLM cost at our scale.
+  sonar: { inputPerM: 1, outputPerM: 1 },
+  // OpenAI — openai.com/api/pricing
+  'gpt-4o': { inputPerM: 2.5, outputPerM: 10 },
+  'gpt-4o-mini': { inputPerM: 0.15, outputPerM: 0.6 },
+}
+
+export interface CostBreakdown {
+  totalUsd: number
+  byStage: Record<string, number>
+  byModel: Record<string, number>
+  unknownModels: string[]
+}
+
+export function computeCost(events: UsageEvent[]): CostBreakdown {
+  let totalUsd = 0
+  const byStage: Record<string, number> = {}
+  const byModel: Record<string, number> = {}
+  const unknownModels = new Set<string>()
+
+  for (const e of events) {
+    const pricing = MODEL_PRICING[e.model]
+    if (!pricing) {
+      unknownModels.add(e.model)
+      continue
+    }
+    const cost =
+      (e.inputTokens * pricing.inputPerM + e.outputTokens * pricing.outputPerM) /
+      1_000_000
+    totalUsd += cost
+    byStage[e.stage] = (byStage[e.stage] ?? 0) + cost
+    byModel[e.model] = (byModel[e.model] ?? 0) + cost
+  }
+
+  return {
+    totalUsd,
+    byStage,
+    byModel,
+    unknownModels: [...unknownModels],
+  }
+}
+
+export function formatUsd(usd: number): string {
+  if (usd < 0.01) return `$${usd.toFixed(4)}`
+  if (usd < 1) return `$${usd.toFixed(3)}`
+  return `$${usd.toFixed(2)}`
+}

--- a/scripts/eval/golden-cells.ts
+++ b/scripts/eval/golden-cells.ts
@@ -1,0 +1,60 @@
+// Stratified set of (categoryId, difficulty) cells the trivia generation
+// pipeline must handle. Each cell is replayed N times per eval run; the
+// pipeline picks its own seed/modifier internally, so trials against the
+// same cell sample the *distribution* of quality the generator produces
+// rather than testing one specific seed.
+//
+// Smoke covers the first SMOKE_CATEGORY_COUNT categories × all 3
+// difficulties for fast iteration. The full set covers the broad surface
+// for pre-merge regression checking.
+
+export type Difficulty = 'easy' | 'medium' | 'hard'
+
+export interface GoldenCell {
+  categoryId: number
+  categoryName: string
+  difficulty: Difficulty
+}
+
+const DIFFICULTIES: Difficulty[] = ['easy', 'medium', 'hard']
+
+// Ordered: smoke-relevant categories first. Picked for breadth of failure
+// modes — General Knowledge stresses the "what counts as easy" bar, Film
+// and Music churn through specialist labels, Science and Geography are
+// where factual errors bite hardest, History is where the "named entity
+// vs date" flip rule matters most.
+const GOLDEN_CATEGORIES: Array<{ id: number; name: string }> = [
+  { id: 9, name: 'General Knowledge' },
+  { id: 11, name: 'Film' },
+  { id: 17, name: 'Science & Nature' },
+  { id: 22, name: 'Geography' },
+  { id: 23, name: 'History' },
+  // ── smoke ends here (5 cats × 3 diffs = 15 cells) ──
+  { id: 12, name: 'Music' },
+  { id: 14, name: 'Television' },
+  { id: 15, name: 'Video Games' },
+  { id: 21, name: 'Sports' },
+  { id: 20, name: 'Mythology' },
+  { id: 10, name: 'Books' },
+  { id: 18, name: 'Computers' },
+  { id: 27, name: 'Animals' },
+  { id: 24, name: 'Politics' },
+  { id: 25, name: 'Art' },
+  { id: 28, name: 'Vehicles' },
+  { id: 32, name: 'Cartoons & Animation' },
+]
+
+const SMOKE_CATEGORY_COUNT = 5
+
+export function getGoldenCells(smoke: boolean): GoldenCell[] {
+  const cats = smoke
+    ? GOLDEN_CATEGORIES.slice(0, SMOKE_CATEGORY_COUNT)
+    : GOLDEN_CATEGORIES
+  return cats.flatMap((c) =>
+    DIFFICULTIES.map((d) => ({
+      categoryId: c.id,
+      categoryName: c.name,
+      difficulty: d,
+    }))
+  )
+}

--- a/scripts/eval/judge.ts
+++ b/scripts/eval/judge.ts
@@ -1,0 +1,156 @@
+// OpenAI-backed judge for trivia questions. Scores two dimensions the
+// pipeline cares most about: factual accuracy and difficulty calibration.
+// Deliberately uses an OpenAI model so the judge isn't grading the
+// Anthropic generator's own output.
+//
+// Uses the openai SDK's native structured-output helper (zodResponseFormat)
+// instead of the @ai-sdk/openai generateObject wrapper — the latter
+// rejects parsed responses on a regular cadence with "response did not
+// match schema" even when OpenAI's JSON schema mode is correct, and it
+// hides the raw response when it does. Going direct gives us reliability
+// + the raw text when something does go wrong.
+//
+// Override the model with OPENAI_EVAL_MODEL. Default is gpt-4o (full,
+// not -mini — judging needs better reasoning than the daily fallback).
+
+import { OpenAI } from 'openai'
+import { zodResponseFormat } from 'openai/helpers/zod'
+import { z } from 'zod'
+
+import { recordUsage } from '../../src/lib/trivia/usageRecorder'
+import type { Difficulty } from './golden-cells'
+
+const JUDGE_MODEL = process.env.OPENAI_EVAL_MODEL ?? 'gpt-4o'
+
+// All fields are required and use only types OpenAI's structured-output
+// mode supports (number, string, boolean) — no .int(), no .min/.max
+// constraints (those become JSON Schema keywords OpenAI's strict mode
+// doesn't always honor and that the SDK then rejects post-hoc). We
+// validate the integer/range invariants ourselves below.
+const VerdictSchema = z.object({
+  factual_score: z
+    .number()
+    .describe('Integer 1, 2, or 3. 1=wrong, 2=minor issue, 3=correct.'),
+  factual_rationale: z
+    .string()
+    .describe('One sentence on why you scored factual accuracy this way.'),
+  difficulty_score: z
+    .number()
+    .describe(
+      'Integer 1, 2, or 3. 1=clearly mismatched, 2=borderline, 3=well-calibrated.'
+    ),
+  difficulty_rationale: z
+    .string()
+    .describe('One sentence on why you scored difficulty this way.'),
+  ship: z
+    .boolean()
+    .describe(
+      'true only if both scores are 3, OR (one is 3 and the other is 2). Anything with a 1 must not ship.'
+    ),
+})
+
+export type Verdict = z.infer<typeof VerdictSchema>
+
+const DIFFICULTY_DEFINITIONS = `
+- easy: Casual party-trivia bar. The correct answer must be a string a typical adult (no special interest in the topic) would naturally type — household names, common short answers. Specialist labels for famous things ("Atomic Bomb Dome" instead of "Hiroshima"), regnal forms ("Constantine the Great" vs "Constantine"), or fragile multi-word strings ("Lifetime Achievement Grammy Award" vs "Lifetime Achievement Award") FAIL the easy bar.
+- medium: Beyond common knowledge but in reach for someone who follows the category casually. Not deep cuts.
+- hard: Genuine deep cuts. Real specific knowledge of the topic — challenging but fair. A "hard" question whose answer a child would know is mis-tiered.
+`.trim()
+
+export interface JudgeInput {
+  question: string
+  correctAnswer: string
+  explanation: string
+  category: string
+  difficulty: Difficulty
+  sourceUrl?: string
+}
+
+export async function judgeQuestion(input: JudgeInput): Promise<Verdict> {
+  const apiKey = process.env.OPENAI_API_KEY
+  if (!apiKey) throw new Error('OPENAI_API_KEY not set')
+
+  const client = new OpenAI({ apiKey })
+
+  const completion = await client.chat.completions.parse({
+    model: JUDGE_MODEL,
+    temperature: 0,
+    max_tokens: 500,
+    response_format: zodResponseFormat(VerdictSchema, 'verdict'),
+    messages: [
+      {
+        role: 'system',
+        content:
+          'You are a strict reviewer for a casual trivia game. You evaluate two dimensions only: factual accuracy of the question, and whether its difficulty is calibrated to the stated tier. Be strict — if you have meaningful doubt about the answer being correct, score it down. Do not be lenient because the question "feels well-written."',
+      },
+      {
+        role: 'user',
+        content: `Evaluate this trivia question.
+
+Question: ${input.question}
+Stated correct answer: ${input.correctAnswer}
+Explanation shown to the player after answering: ${input.explanation}
+Category: ${input.category}
+Target difficulty: ${input.difficulty.toUpperCase()}
+${input.sourceUrl ? `Source URL the generator used: ${input.sourceUrl}` : ''}
+
+DIFFICULTY DEFINITIONS:
+${DIFFICULTY_DEFINITIONS}
+
+Score each dimension 1–3:
+
+FACTUAL ACCURACY
+  3 — The premise of the question is correct AND the stated correct answer is correct AND no other answer is more correct.
+  2 — The answer is broadly right but there is a minor issue: a date/number is slightly off, framing is mildly misleading, OR another answer is also defensible.
+  1 — The stated correct answer is wrong, the premise is wrong, or the question is unanswerable as posed.
+
+DIFFICULTY CALIBRATION
+  3 — Clearly fits the target difficulty per the definitions above.
+  2 — Borderline — fits the difficulty for some players but not others, or sits between two tiers.
+  1 — Clearly mismatched (e.g. an "easy" question whose stated correct answer is a specialist label, a "hard" question whose answer a casual player would know).
+
+Set ship=true only if BOTH scores are 3, OR one is 3 and the other is 2. Anything with a 1 must not ship.
+
+Provide a one-sentence rationale for each score.`,
+      },
+    ],
+  })
+  recordUsage({
+    stage: 'judge',
+    model: JUDGE_MODEL,
+    inputTokens: completion.usage?.prompt_tokens ?? 0,
+    outputTokens: completion.usage?.completion_tokens ?? 0,
+  })
+
+  const parsed = completion.choices[0]?.message.parsed
+  if (!parsed) {
+    const refusal = completion.choices[0]?.message.refusal
+    throw new Error(
+      `Judge returned no parsed object${refusal ? ` (refusal: ${refusal})` : ''}`
+    )
+  }
+
+  // Belt-and-braces: the schema permits any number, but we treat 1/2/3
+  // as the only valid scores. Clamp + round so a stray "2.5" doesn't
+  // poison aggregation downstream.
+  const fScore = clampScore(parsed.factual_score)
+  const dScore = clampScore(parsed.difficulty_score)
+
+  return {
+    factual_score: fScore,
+    factual_rationale: parsed.factual_rationale,
+    difficulty_score: dScore,
+    difficulty_rationale: parsed.difficulty_rationale,
+    ship: parsed.ship,
+  }
+}
+
+function clampScore(n: number): number {
+  if (!Number.isFinite(n)) return 2
+  const r = Math.round(n)
+  if (r < 1) return 1
+  if (r > 3) return 3
+  return r
+}
+
+export const JUDGE_MODEL_ID = JUDGE_MODEL

--- a/scripts/eval/runner.ts
+++ b/scripts/eval/runner.ts
@@ -1,0 +1,163 @@
+// Orchestrates the eval: for each (cell, trial), run the live generation
+// pipeline once, then run the OpenAI judge over the result. Concurrency-
+// limited because the underlying pipeline already burns multiple LLM
+// calls per generation (fact source, construction, optional repair,
+// review) and we'd rather not melt rate limits.
+
+import { generateInfiniteQuestion } from '../../src/lib/trivia/generateQuestion'
+import {
+  type UsageEvent,
+  withUsageRecording,
+} from '../../src/lib/trivia/usageRecorder'
+import type { GoldenCell } from './golden-cells'
+import { judgeQuestion, type Verdict } from './judge'
+
+export interface TrialResult {
+  cell: GoldenCell
+  trialIndex: number
+  // Generation either succeeded (question/answer/...) or failed with a
+  // reason. Failures are quality signals too — a change that increases
+  // the failure rate is a regression.
+  outcome:
+    | {
+        kind: 'generated'
+        question: string
+        correctAnswer: string
+        explanation: string
+        actualDifficulty: 'easy' | 'medium' | 'hard'
+        seed?: string
+        sourceUrl?: string
+        appVersion?: string
+        verdict: Verdict
+      }
+    | {
+        kind: 'generation_failed'
+        error: string
+      }
+    | {
+        kind: 'judge_failed'
+        question: string
+        correctAnswer: string
+        error: string
+      }
+  durationMs: number
+  // Token usage recorded per LLM call during this trial (generation +
+  // judge). Empty if the recorder caught no events (shouldn't happen
+  // during a normal trial). Used by the scorecard for cost rollups.
+  usageEvents: UsageEvent[]
+}
+
+export interface RunOptions {
+  cells: GoldenCell[]
+  trialsPerCell: number
+  concurrency: number
+  onProgress?: (done: number, total: number, latest: TrialResult) => void
+}
+
+interface Job {
+  cell: GoldenCell
+  trialIndex: number
+}
+
+export async function runEval(options: RunOptions): Promise<TrialResult[]> {
+  const jobs: Job[] = []
+  for (const cell of options.cells) {
+    for (let t = 0; t < options.trialsPerCell; t++) {
+      jobs.push({ cell, trialIndex: t })
+    }
+  }
+
+  const results: TrialResult[] = []
+  let cursor = 0
+  let done = 0
+
+  async function worker(): Promise<void> {
+    while (true) {
+      const idx = cursor++
+      if (idx >= jobs.length) return
+      const job = jobs[idx]
+      const result = await runOne(job)
+      results.push(result)
+      done++
+      options.onProgress?.(done, jobs.length, result)
+    }
+  }
+
+  const workers = Array.from(
+    { length: Math.min(options.concurrency, jobs.length) },
+    () => worker()
+  )
+  await Promise.all(workers)
+  return results
+}
+
+async function runOne(job: Job): Promise<TrialResult> {
+  const start = Date.now()
+  // One event buffer per trial. AsyncLocalStorage scopes recordUsage()
+  // calls inside generateInfiniteQuestion + judgeQuestion to this
+  // buffer, so concurrent trials don't pollute each other's totals.
+  const events: UsageEvent[] = []
+  return withUsageRecording(events, async () => {
+    try {
+      const generated = await generateInfiniteQuestion({
+        categoryId: job.cell.categoryId,
+        difficulty: job.cell.difficulty,
+      })
+
+      const explanation = generated.explanation ?? ''
+      let verdict: Verdict
+      try {
+        verdict = await judgeQuestion({
+          question: generated.question,
+          correctAnswer: generated.correctAnswer,
+          explanation,
+          category: job.cell.categoryName,
+          difficulty: job.cell.difficulty,
+          sourceUrl: generated.sourceUrl,
+        })
+      } catch (err) {
+        return {
+          cell: job.cell,
+          trialIndex: job.trialIndex,
+          outcome: {
+            kind: 'judge_failed',
+            question: generated.question,
+            correctAnswer: generated.correctAnswer,
+            error: err instanceof Error ? err.message : String(err),
+          },
+          durationMs: Date.now() - start,
+          usageEvents: events,
+        }
+      }
+
+      return {
+        cell: job.cell,
+        trialIndex: job.trialIndex,
+        outcome: {
+          kind: 'generated',
+          question: generated.question,
+          correctAnswer: generated.correctAnswer,
+          explanation,
+          actualDifficulty: generated.difficulty,
+          seed: generated.seed,
+          sourceUrl: generated.sourceUrl,
+          appVersion: generated.appVersion,
+          verdict,
+        },
+        durationMs: Date.now() - start,
+        usageEvents: events,
+      }
+    } catch (err) {
+      return {
+        cell: job.cell,
+        trialIndex: job.trialIndex,
+        outcome: {
+          kind: 'generation_failed',
+          error: err instanceof Error ? err.message : String(err),
+        },
+        durationMs: Date.now() - start,
+        usageEvents: events,
+      }
+    }
+  })
+}

--- a/scripts/eval/scorecard.ts
+++ b/scripts/eval/scorecard.ts
@@ -1,0 +1,415 @@
+// Aggregates raw trial results into the printable scorecard, persists
+// the run as JSON, and computes deltas vs. the previous run so a
+// regression jumps out without manual diffing.
+
+import fs from 'fs'
+import path from 'path'
+
+import { computeCost, formatUsd } from './cost'
+import type { Difficulty, GoldenCell } from './golden-cells'
+import type { TrialResult } from './runner'
+
+export interface DimensionBreakdown {
+  total: number
+  scored: number
+  score3: number
+  score2: number
+  score1: number
+  shipPct: number
+  factualMean: number
+  difficultyMean: number
+}
+
+export interface CostSummary {
+  totalUsd: number
+  perTrialUsd: number
+  byStage: Record<string, number>
+  byModel: Record<string, number>
+  unknownModels: string[]
+}
+
+export interface RunSummary {
+  timestamp: string
+  appVersion: string | null
+  judgeModel: string
+  config: {
+    cells: number
+    trialsPerCell: number
+    totalJobs: number
+    concurrency: number
+    smoke: boolean
+  }
+  totals: {
+    generated: number
+    generationFailed: number
+    judgeFailed: number
+  }
+  cost: CostSummary
+  overall: DimensionBreakdown
+  byDifficulty: Record<Difficulty, DimensionBreakdown>
+  byCategory: Record<string, DimensionBreakdown>
+  // Bottom-N worst results, kept inline so a single JSON file is enough
+  // to investigate regressions without re-running.
+  worst: Array<{
+    category: string
+    difficulty: Difficulty
+    question: string
+    correctAnswer: string
+    factualScore: number
+    factualRationale: string
+    difficultyScore: number
+    difficultyRationale: string
+    sourceUrl?: string
+  }>
+  generationFailures: Array<{
+    category: string
+    difficulty: Difficulty
+    error: string
+  }>
+}
+
+const RUNS_DIR = path.resolve(process.cwd(), 'evals/runs')
+const LATEST_PATH = path.join(RUNS_DIR, 'latest.json')
+
+export function summarize(args: {
+  results: TrialResult[]
+  cells: GoldenCell[]
+  trialsPerCell: number
+  concurrency: number
+  smoke: boolean
+  judgeModel: string
+}): RunSummary {
+  const { results, cells, trialsPerCell, concurrency, smoke, judgeModel } = args
+
+  const generated = results.filter((r) => r.outcome.kind === 'generated')
+  const generationFailed = results.filter(
+    (r) => r.outcome.kind === 'generation_failed'
+  )
+  const judgeFailed = results.filter((r) => r.outcome.kind === 'judge_failed')
+
+  const overall = computeBreakdown(results)
+  const byDifficulty: Record<Difficulty, DimensionBreakdown> = {
+    easy: computeBreakdown(filterByDifficulty(results, 'easy')),
+    medium: computeBreakdown(filterByDifficulty(results, 'medium')),
+    hard: computeBreakdown(filterByDifficulty(results, 'hard')),
+  }
+
+  const categoryNames = Array.from(new Set(cells.map((c) => c.categoryName)))
+  const byCategory: Record<string, DimensionBreakdown> = {}
+  for (const name of categoryNames) {
+    byCategory[name] = computeBreakdown(
+      results.filter((r) => r.cell.categoryName === name)
+    )
+  }
+
+  const worst = generated
+    .filter((r) => r.outcome.kind === 'generated')
+    .map((r) => {
+      if (r.outcome.kind !== 'generated') throw new Error('unreachable')
+      return {
+        category: r.cell.categoryName,
+        difficulty: r.cell.difficulty,
+        question: r.outcome.question,
+        correctAnswer: r.outcome.correctAnswer,
+        factualScore: r.outcome.verdict.factual_score,
+        factualRationale: r.outcome.verdict.factual_rationale,
+        difficultyScore: r.outcome.verdict.difficulty_score,
+        difficultyRationale: r.outcome.verdict.difficulty_rationale,
+        sourceUrl: r.outcome.sourceUrl,
+      }
+    })
+    .sort(
+      (a, b) =>
+        a.factualScore + a.difficultyScore - (b.factualScore + b.difficultyScore)
+    )
+    .slice(0, 10)
+
+  const generationFailures = generationFailed.map((r) => {
+    if (r.outcome.kind !== 'generation_failed') throw new Error('unreachable')
+    return {
+      category: r.cell.categoryName,
+      difficulty: r.cell.difficulty,
+      error: r.outcome.error,
+    }
+  })
+
+  const appVersion =
+    generated
+      .map((r) => (r.outcome.kind === 'generated' ? r.outcome.appVersion : null))
+      .find((v): v is string => Boolean(v)) ?? null
+
+  // Sum token-usage events across all trials. Failed trials still
+  // contribute (a generation_failed trial can still have burned
+  // construct + repair tokens before throwing) — important so cost
+  // doesn't look artificially low when a run has many failures.
+  const allEvents = results.flatMap((r) => r.usageEvents)
+  const breakdown = computeCost(allEvents)
+  const cost: CostSummary = {
+    totalUsd: breakdown.totalUsd,
+    perTrialUsd: results.length === 0 ? 0 : breakdown.totalUsd / results.length,
+    byStage: breakdown.byStage,
+    byModel: breakdown.byModel,
+    unknownModels: breakdown.unknownModels,
+  }
+
+  return {
+    timestamp: new Date().toISOString(),
+    appVersion,
+    judgeModel,
+    config: {
+      cells: cells.length,
+      trialsPerCell,
+      totalJobs: results.length,
+      concurrency,
+      smoke,
+    },
+    totals: {
+      generated: generated.length,
+      generationFailed: generationFailed.length,
+      judgeFailed: judgeFailed.length,
+    },
+    cost,
+    overall,
+    byDifficulty,
+    byCategory,
+    worst,
+    generationFailures,
+  }
+}
+
+function filterByDifficulty(
+  results: TrialResult[],
+  difficulty: Difficulty
+): TrialResult[] {
+  return results.filter((r) => r.cell.difficulty === difficulty)
+}
+
+function computeBreakdown(results: TrialResult[]): DimensionBreakdown {
+  const total = results.length
+  const judged = results.filter((r) => r.outcome.kind === 'generated')
+  const scored = judged.length
+
+  let f3 = 0
+  let f2 = 0
+  let f1 = 0
+  let d3 = 0
+  let d2 = 0
+  let d1 = 0
+  let ship = 0
+  let factualSum = 0
+  let difficultySum = 0
+
+  for (const r of judged) {
+    if (r.outcome.kind !== 'generated') continue
+    const v = r.outcome.verdict
+    if (v.factual_score === 3) f3++
+    else if (v.factual_score === 2) f2++
+    else f1++
+    if (v.difficulty_score === 3) d3++
+    else if (v.difficulty_score === 2) d2++
+    else d1++
+    if (v.ship) ship++
+    factualSum += v.factual_score
+    difficultySum += v.difficulty_score
+  }
+
+  return {
+    total,
+    scored,
+    score3: f3 + d3, // not used directly but kept for completeness
+    score2: f2 + d2,
+    score1: f1 + d1,
+    shipPct: scored === 0 ? 0 : (ship * 100) / scored,
+    factualMean: scored === 0 ? 0 : factualSum / scored,
+    difficultyMean: scored === 0 ? 0 : difficultySum / scored,
+  }
+}
+
+export function loadPreviousRun(): RunSummary | null {
+  if (!fs.existsSync(LATEST_PATH)) return null
+  try {
+    return JSON.parse(fs.readFileSync(LATEST_PATH, 'utf-8')) as RunSummary
+  } catch {
+    return null
+  }
+}
+
+export function persistRun(summary: RunSummary): { runPath: string; latestPath: string } {
+  fs.mkdirSync(RUNS_DIR, { recursive: true })
+  const stamp = summary.timestamp.replace(/[:.]/g, '-')
+  const runPath = path.join(RUNS_DIR, `${stamp}.json`)
+  const json = JSON.stringify(summary, null, 2)
+  fs.writeFileSync(runPath, json)
+  fs.writeFileSync(LATEST_PATH, json)
+  return { runPath, latestPath: LATEST_PATH }
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Pretty printing
+// ─────────────────────────────────────────────────────────────────────
+
+export function printScorecard(summary: RunSummary, previous: RunSummary | null): void {
+  const w = (s: string) => process.stdout.write(s)
+  const line = (s = '') => w(s + '\n')
+
+  line('')
+  line('═══════════════════════════════════════════════════════════════')
+  line(`  Trivia Eval — ${summary.timestamp}`)
+  line('═══════════════════════════════════════════════════════════════')
+  line(`  appVersion : ${summary.appVersion ?? '(unknown)'}`)
+  line(`  judge      : ${summary.judgeModel}`)
+  line(
+    `  config     : ${summary.config.cells} cells × ${summary.config.trialsPerCell} trials = ${summary.config.totalJobs} jobs (concurrency=${summary.config.concurrency}${summary.config.smoke ? ', smoke' : ''})`
+  )
+  if (previous) {
+    line(`  vs prev    : ${previous.timestamp} (${previous.appVersion ?? '?'})`)
+  } else {
+    line(`  vs prev    : (no previous run)`)
+  }
+  line('')
+
+  // Generation
+  line('Generation')
+  line(
+    `  succeeded : ${summary.totals.generated}/${summary.config.totalJobs}   ${pct(summary.totals.generated, summary.config.totalJobs)}${delta(pct(summary.totals.generated, summary.config.totalJobs), previous && pct(previous.totals.generated, previous.config.totalJobs))}`
+  )
+  line(
+    `  gen-fail  : ${summary.totals.generationFailed}   ${pct(summary.totals.generationFailed, summary.config.totalJobs)}`
+  )
+  line(
+    `  judge-fail: ${summary.totals.judgeFailed}   ${pct(summary.totals.judgeFailed, summary.config.totalJobs)}`
+  )
+  line('')
+
+  // Cost
+  line('Cost (USD)')
+  line(
+    `  total       : ${formatUsd(summary.cost.totalUsd).padStart(7)}${deltaUsd(summary.cost.totalUsd, previous?.cost?.totalUsd)}`
+  )
+  line(
+    `  per-trial   : ${formatUsd(summary.cost.perTrialUsd).padStart(7)}${deltaUsd(summary.cost.perTrialUsd, previous?.cost?.perTrialUsd)}`
+  )
+  if (Object.keys(summary.cost.byStage).length > 0) {
+    const stages = Object.entries(summary.cost.byStage).sort((a, b) => b[1] - a[1])
+    line('  by stage    :')
+    for (const [stage, usd] of stages) {
+      const prevUsd = previous?.cost?.byStage?.[stage]
+      const sharePct = summary.cost.totalUsd === 0 ? 0 : (usd * 100) / summary.cost.totalUsd
+      line(
+        `    ${stage.padEnd(10)}: ${formatUsd(usd).padStart(7)}  (${sharePct.toFixed(0)}%)${deltaUsd(usd, prevUsd)}`
+      )
+    }
+  }
+  if (summary.cost.unknownModels.length > 0) {
+    line(`  unpriced models : ${summary.cost.unknownModels.join(', ')} — add to MODEL_PRICING`)
+  }
+  line('')
+
+  // Overall quality
+  line('Quality (overall)')
+  printDimensionRow('  ship-worthy : ', summary.overall.shipPct, previous?.overall.shipPct)
+  printMeanRow('  factual μ   : ', summary.overall.factualMean, previous?.overall.factualMean)
+  printMeanRow('  difficulty μ: ', summary.overall.difficultyMean, previous?.overall.difficultyMean)
+  line('')
+
+  // By difficulty
+  line('Ship-worthy by difficulty')
+  for (const d of ['easy', 'medium', 'hard'] as const) {
+    const cur = summary.byDifficulty[d]
+    const prev = previous?.byDifficulty[d]
+    line(
+      `  ${d.padEnd(7)}: ${formatPct(cur.shipPct).padStart(7)}   (${cur.scored} scored)${delta(cur.shipPct, prev?.shipPct)}`
+    )
+  }
+  line('')
+
+  // By category — compact, sorted by ship%
+  line('Ship-worthy by category (sorted)')
+  const cats = Object.entries(summary.byCategory)
+    .filter(([, v]) => v.scored > 0)
+    .sort((a, b) => a[1].shipPct - b[1].shipPct)
+  for (const [name, v] of cats) {
+    const prev = previous?.byCategory[name]
+    line(
+      `  ${name.padEnd(24)}: ${formatPct(v.shipPct).padStart(7)}   (${v.scored} scored)${delta(v.shipPct, prev?.shipPct)}`
+    )
+  }
+  line('')
+
+  // Worst
+  if (summary.worst.length > 0) {
+    line('Worst-scoring questions (lowest combined score)')
+    for (const w of summary.worst.slice(0, 5)) {
+      line(`  [${w.difficulty}/${w.category}] f=${w.factualScore} d=${w.difficultyScore}`)
+      line(`     Q: ${truncate(w.question, 100)}`)
+      line(`     A: ${truncate(w.correctAnswer, 60)}`)
+      if (w.factualScore < 3) line(`     factual: ${truncate(w.factualRationale, 100)}`)
+      if (w.difficultyScore < 3) line(`     diff:    ${truncate(w.difficultyRationale, 100)}`)
+    }
+    line('')
+  }
+
+  if (summary.generationFailures.length > 0) {
+    line('Generation failures')
+    for (const f of summary.generationFailures.slice(0, 5)) {
+      line(`  [${f.difficulty}/${f.category}] ${truncate(f.error, 120)}`)
+    }
+    if (summary.generationFailures.length > 5) {
+      line(`  …and ${summary.generationFailures.length - 5} more`)
+    }
+    line('')
+  }
+}
+
+function printDimensionRow(label: string, value: number, prev: number | undefined): void {
+  process.stdout.write(`${label}${formatPct(value).padStart(7)}${delta(value, prev)}\n`)
+}
+
+function printMeanRow(label: string, value: number, prev: number | undefined): void {
+  process.stdout.write(`${label}${value.toFixed(2).padStart(5)}${deltaMean(value, prev)}\n`)
+}
+
+function pct(num: number, denom: number): string {
+  if (denom === 0) return '(n/a)'
+  return formatPct((num * 100) / denom)
+}
+
+function formatPct(n: number): string {
+  return `${n.toFixed(1)}%`
+}
+
+function delta(curPct: string | number, prevPct: string | number | undefined | null): string {
+  if (prevPct === undefined || prevPct === null) return ''
+  const cur = typeof curPct === 'string' ? parseFloat(curPct) : curPct
+  const prev = typeof prevPct === 'string' ? parseFloat(prevPct) : prevPct
+  if (Number.isNaN(cur) || Number.isNaN(prev)) return ''
+  const diff = cur - prev
+  if (Math.abs(diff) < 0.05) return '   (=)'
+  const sign = diff > 0 ? '+' : ''
+  const arrow = diff > 0 ? '↑' : '↓'
+  return `   ${arrow} ${sign}${diff.toFixed(1)} pts`
+}
+
+function deltaMean(cur: number, prev: number | undefined): string {
+  if (prev === undefined) return ''
+  const diff = cur - prev
+  if (Math.abs(diff) < 0.005) return '   (=)'
+  const sign = diff > 0 ? '+' : ''
+  const arrow = diff > 0 ? '↑' : '↓'
+  return `   ${arrow} ${sign}${diff.toFixed(2)}`
+}
+
+function deltaUsd(cur: number, prev: number | undefined | null): string {
+  if (prev === undefined || prev === null) return ''
+  const diff = cur - prev
+  // Threshold = 1¢ — anything smaller is noise.
+  if (Math.abs(diff) < 0.01) return '   (=)'
+  const sign = diff > 0 ? '+' : '-'
+  const arrow = diff > 0 ? '↑' : '↓'
+  return `   ${arrow} ${sign}${formatUsd(Math.abs(diff))}`
+}
+
+function truncate(s: string, max: number): string {
+  if (s.length <= max) return s
+  return s.slice(0, max - 1) + '…'
+}

--- a/scripts/seed-ai-questions.ts
+++ b/scripts/seed-ai-questions.ts
@@ -1,0 +1,290 @@
+#!/usr/bin/env tsx
+/**
+ * Bulk seed the aiQuestions Firestore collection.
+ *
+ * Generates N questions through the live infinite pipeline (same code
+ * path the runtime warmer and /next route use, including the duplicate-
+ * answer backstop), optionally judges each one with the eval rubric,
+ * optionally gates on the judge's ship verdict, then persists via
+ * saveAIQuestion. Prints a scorecard at the end summarizing what got
+ * saved and the quality distribution.
+ *
+ * Usage:
+ *   npm run seed-ai-questions -- --count 20
+ *   npm run seed-ai-questions -- --count 50 --difficulty easy
+ *   npm run seed-ai-questions -- --count 100 --gate     # only save ship=true
+ *   npm run seed-ai-questions -- --count 50 --no-judge  # skip judging entirely
+ *   npm run seed-ai-questions -- --count 30 --category 17
+ *
+ * Env (loaded from .env.local via tsx --env-file):
+ *   ANTHROPIC_API_KEY     — generation pipeline
+ *   PERPLEXITY_API_KEY    — fact source (if Perplexity is configured)
+ *   OPENAI_API_KEY        — judge (omit if --no-judge)
+ *   FIREBASE_PROJECT_ID, FIREBASE_CLIENT_EMAIL, FIREBASE_PRIVATE_KEY — Firestore
+ */
+
+import { saveAIQuestion } from '../src/lib/trivia/aiQuestions'
+import { generateInfiniteQuestion } from '../src/lib/trivia/generateQuestion'
+import { judgeQuestion, JUDGE_MODEL_ID, type Verdict } from './eval/judge'
+
+interface Args {
+  count: number
+  concurrency: number
+  category: number | null
+  difficulty: 'easy' | 'medium' | 'hard' | null
+  gate: boolean
+  judge: boolean
+}
+
+function parseArgs(): Args {
+  const args = process.argv.slice(2)
+  let count = 20
+  let concurrency = 3
+  let category: number | null = null
+  let difficulty: Args['difficulty'] = null
+  let gate = false
+  let judge = true
+
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i]
+    if (a === '--count' && args[i + 1]) count = parseInt(args[++i], 10)
+    else if (a === '--concurrency' && args[i + 1]) concurrency = parseInt(args[++i], 10)
+    else if (a === '--category' && args[i + 1]) category = parseInt(args[++i], 10)
+    else if (a === '--difficulty' && args[i + 1]) {
+      const d = args[++i]
+      if (d !== 'easy' && d !== 'medium' && d !== 'hard') {
+        throw new Error(`--difficulty must be easy|medium|hard, got "${d}"`)
+      }
+      difficulty = d
+    } else if (a === '--gate') gate = true
+    else if (a === '--no-judge') judge = false
+    else if (a === '--help' || a === '-h') {
+      process.stdout.write(
+        'Usage: seed-ai-questions [--count N] [--concurrency N] [--category ID] [--difficulty easy|medium|hard] [--gate] [--no-judge]\n'
+      )
+      process.exit(0)
+    } else if (a.startsWith('--')) {
+      throw new Error(`Unknown flag: ${a}`)
+    }
+  }
+
+  if (gate && !judge) throw new Error('--gate requires --judge (cannot gate without scoring)')
+  return { count, concurrency, category, difficulty, gate, judge }
+}
+
+interface SeedResult {
+  index: number
+  saved: boolean
+  skipped: boolean
+  questionId: string | null
+  category: string | null
+  difficulty: 'easy' | 'medium' | 'hard' | null
+  question: string | null
+  correctAnswer: string | null
+  verdict: Verdict | null
+  error: string | null
+  durationMs: number
+}
+
+async function seedOne(args: Args, index: number): Promise<SeedResult> {
+  const start = Date.now()
+  try {
+    const generated = await generateInfiniteQuestion({
+      ...(args.category != null ? { categoryId: args.category } : {}),
+      ...(args.difficulty != null ? { difficulty: args.difficulty } : {}),
+    })
+
+    let verdict: Verdict | null = null
+    if (args.judge) {
+      try {
+        verdict = await judgeQuestion({
+          question: generated.question,
+          correctAnswer: generated.correctAnswer,
+          explanation: generated.explanation ?? '',
+          category: generated.category,
+          difficulty: generated.difficulty,
+          sourceUrl: generated.sourceUrl,
+        })
+      } catch (err) {
+        // Judge failure is logged but doesn't block the save — the
+        // pipeline's own quality gate already passed, the judge is
+        // additional signal.
+        console.warn(`[seed:${index}] judge failed: ${err instanceof Error ? err.message : String(err)}`)
+      }
+    }
+
+    if (args.gate && verdict && !verdict.ship) {
+      return {
+        index,
+        saved: false,
+        skipped: true,
+        questionId: generated.id,
+        category: generated.category,
+        difficulty: generated.difficulty,
+        question: generated.question,
+        correctAnswer: generated.correctAnswer,
+        verdict,
+        error: null,
+        durationMs: Date.now() - start,
+      }
+    }
+
+    await saveAIQuestion(generated)
+    return {
+      index,
+      saved: true,
+      skipped: false,
+      questionId: generated.id,
+      category: generated.category,
+      difficulty: generated.difficulty,
+      question: generated.question,
+      correctAnswer: generated.correctAnswer,
+      verdict,
+      error: null,
+      durationMs: Date.now() - start,
+    }
+  } catch (err) {
+    return {
+      index,
+      saved: false,
+      skipped: false,
+      questionId: null,
+      category: null,
+      difficulty: null,
+      question: null,
+      correctAnswer: null,
+      verdict: null,
+      error: err instanceof Error ? err.message : String(err),
+      durationMs: Date.now() - start,
+    }
+  }
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs()
+  process.stdout.write(
+    `\nSeeding ${args.count} question(s)  concurrency=${args.concurrency}` +
+      `${args.category != null ? `  category=${args.category}` : ''}` +
+      `${args.difficulty != null ? `  difficulty=${args.difficulty}` : ''}` +
+      `${args.gate ? '  GATED (only save ship=true)' : ''}` +
+      `${!args.judge ? '  (no judge)' : `  judge=${JUDGE_MODEL_ID}`}\n\n`
+  )
+
+  const results: SeedResult[] = []
+  let cursor = 0
+  let completed = 0
+  const startedAt = Date.now()
+
+  async function worker(): Promise<void> {
+    while (true) {
+      const idx = cursor++
+      if (idx >= args.count) return
+      const r = await seedOne(args, idx)
+      results.push(r)
+      completed++
+      const tag = formatProgressTag(r)
+      process.stdout.write(`  [${String(completed).padStart(3)}/${args.count}] ${tag}\n`)
+    }
+  }
+
+  const workers = Array.from(
+    { length: Math.min(args.concurrency, args.count) },
+    () => worker()
+  )
+  await Promise.all(workers)
+
+  const elapsedSec = ((Date.now() - startedAt) / 1000).toFixed(1)
+  process.stdout.write(`\nFinished in ${elapsedSec}s\n`)
+  printScorecard(results, args)
+}
+
+function formatProgressTag(r: SeedResult): string {
+  if (r.error) return `FAIL  ${truncate(r.error, 100)}`
+  const cell = `${r.category}/${r.difficulty}`
+  const v = r.verdict
+  const judgeBit = v ? `f=${v.factual_score} d=${v.difficulty_score} ${v.ship ? 'ship' : '----'}` : '         (no judge)'
+  const dispo = r.saved ? 'SAVED  ' : r.skipped ? 'GATED  ' : 'FAIL   '
+  return `${dispo}${cell.padEnd(36)} ${judgeBit}  "${truncate(r.question ?? '', 50)}"`
+}
+
+function printScorecard(results: SeedResult[], args: Args): void {
+  const w = (s = '') => process.stdout.write(s + '\n')
+  const total = results.length
+  const saved = results.filter((r) => r.saved)
+  const gated = results.filter((r) => r.skipped)
+  const failed = results.filter((r) => r.error)
+  const judged = results.filter((r) => r.verdict != null)
+
+  w()
+  w('═══════════════════════════════════════════════════════════════')
+  w('  Seed Results')
+  w('═══════════════════════════════════════════════════════════════')
+  w(`  attempted : ${total}`)
+  w(`  saved     : ${saved.length}   ${pct(saved.length, total)}`)
+  if (args.gate) w(`  gated     : ${gated.length}   ${pct(gated.length, total)}   (judge.ship=false)`)
+  w(`  failed    : ${failed.length}   ${pct(failed.length, total)}`)
+  w()
+
+  if (args.judge && judged.length > 0) {
+    const f3 = judged.filter((r) => r.verdict!.factual_score === 3).length
+    const f2 = judged.filter((r) => r.verdict!.factual_score === 2).length
+    const f1 = judged.filter((r) => r.verdict!.factual_score === 1).length
+    const d3 = judged.filter((r) => r.verdict!.difficulty_score === 3).length
+    const d2 = judged.filter((r) => r.verdict!.difficulty_score === 2).length
+    const d1 = judged.filter((r) => r.verdict!.difficulty_score === 1).length
+    const ship = judged.filter((r) => r.verdict!.ship).length
+
+    w('Judge scores (across attempted, judged)')
+    w(`  factual    : 3=${f3}  2=${f2}  1=${f1}   ship-eligible=${pct(ship, judged.length)}`)
+    w(`  difficulty : 3=${d3}  2=${d2}  1=${d1}`)
+    w()
+
+    // Worst examples — useful even when --gate=false to know what kind
+    // of garbage the pipeline let through.
+    const worst = judged
+      .filter((r) => r.verdict!.factual_score < 3 || r.verdict!.difficulty_score < 3)
+      .sort((a, b) => {
+        const sa = a.verdict!.factual_score + a.verdict!.difficulty_score
+        const sb = b.verdict!.factual_score + b.verdict!.difficulty_score
+        return sa - sb
+      })
+      .slice(0, 5)
+    if (worst.length > 0) {
+      w('Worst-scoring saved/attempted')
+      for (const r of worst) {
+        const v = r.verdict!
+        const dispo = r.saved ? '[SAVED]' : r.skipped ? '[GATED]' : '[FAIL]'
+        w(`  ${dispo} [${r.difficulty}/${r.category}] f=${v.factual_score} d=${v.difficulty_score}`)
+        w(`    Q: ${truncate(r.question ?? '', 100)}`)
+        w(`    A: ${truncate(r.correctAnswer ?? '', 60)}`)
+        if (v.factual_score < 3) w(`    factual: ${truncate(v.factual_rationale, 100)}`)
+        if (v.difficulty_score < 3) w(`    diff:    ${truncate(v.difficulty_rationale, 100)}`)
+      }
+      w()
+    }
+  }
+
+  if (failed.length > 0) {
+    w('Failures')
+    for (const r of failed.slice(0, 5)) {
+      w(`  [${r.index}] ${truncate(r.error ?? '', 140)}`)
+    }
+    if (failed.length > 5) w(`  …and ${failed.length - 5} more`)
+    w()
+  }
+}
+
+function pct(num: number, denom: number): string {
+  if (denom === 0) return '(n/a)'
+  return `${((num * 100) / denom).toFixed(1)}%`
+}
+
+function truncate(s: string, max: number): string {
+  if (s.length <= max) return s
+  return s.slice(0, max - 1) + '…'
+}
+
+main().catch((err) => {
+  process.stderr.write(`\nSeed failed: ${err instanceof Error ? err.stack ?? err.message : String(err)}\n`)
+  process.exit(1)
+})


### PR DESCRIPTION
## Summary

Two scripts share the same generation pipeline and judge, so iteration on prompt and model changes has fast, comparable signal.

### Eval (read-only)

`npm run eval:trivia[:smoke]` replays `generateInfiniteQuestion` against a curated set of (category, difficulty) cells, scores each result with an OpenAI judge on **factual accuracy** and **difficulty calibration**, and prints a scorecard with deltas vs. the previous run (persisted to `evals/runs/latest.json`).

- **Smoke**: 15 cells × 1 trial (~60s) for the inner loop
- **Full**: 51 cells × 3 trials (~5min) before merging
- Judge defaults to `gpt-4o` (override with `OPENAI_EVAL_MODEL`) so it isn't grading the Anthropic generator's own output
- Token usage per stage is captured via the existing `usageRecorder` + `AsyncLocalStorage`, so cost can be attributed to specific trials

### Seeder (writes to Firestore)

`npm run seed-ai-questions` bulk-seeds the `aiQuestions` collection through the same pipeline the runtime warmer uses, including the duplicate-answer backstop. Each generation is optionally judged.

- `--count N` (default 20)
- `--difficulty easy|medium|hard`, `--category ID` to constrain
- `--gate` drops questions the judge wouldn't ship
- `--no-judge` skips judging entirely (faster, no quality signal)
- End-of-run scorecard summarizes saved / gated / failed counts and the judge-score distribution

### Layout

```
scripts/eval-trivia.ts          — eval entry point
scripts/eval/golden-cells.ts    — curated (category, difficulty) set
scripts/eval/judge.ts           — OpenAI judge (zodResponseFormat)
scripts/eval/runner.ts          — concurrency-limited orchestrator
scripts/eval/scorecard.ts       — aggregation + delta-vs-previous
scripts/eval/cost.ts            — per-stage token-cost accounting
scripts/seed-ai-questions.ts    — bulk seeder
evals/README.md                 — usage doc
evals/runs/latest.json          — current scorecard baseline
```

Iteration loop: baseline → change a prompt or model → run smoke → read deltas → repeat.

## Test plan

- [ ] `npm run eval:trivia:smoke` — confirm 15/15 generations succeed and the scorecard renders with deltas vs. `latest.json`
- [ ] `npm run eval:trivia` — confirm the full sweep completes
- [ ] `npm run seed-ai-questions -- --count 2` — confirm 2 questions land in `aiQuestions`
- [ ] `npm run seed-ai-questions -- --count 5 --gate` — confirm gating drops anything the judge marks `ship: false`
- [ ] `npm run seed-ai-questions -- --count 3 --no-judge` — confirm seeding works without `OPENAI_API_KEY`