### PR TITLE
feat(trivia): custom categories for infinite trivia

### DIFF
--- a/src/app/api/v1/trivia/infinite/next/route.ts
+++ b/src/app/api/v1/trivia/infinite/next/route.ts
@@ -11,7 +11,7 @@ import { sampleNextQuestion } from '@/lib/trivia/sampler'
 import { trackExhaustion } from '@/lib/trivia/triviaStats'
 import { warmQuestionPoolForUser } from '@/lib/trivia/warmQuestionPool'
 
-// GET /api/v1/trivia/infinite/next?streak=N[&categoryIds=12,13,15]
+// GET /api/v1/trivia/infinite/next?streak=N[&categoryIds=12,13,15][&customCategory=roman+empire]
 // Backward-compat: also accepts the legacy single ?categoryId=N param.
 export async function GET(request: NextRequest) {
   const auth = await verifyRequestAuth(request)
@@ -22,13 +22,19 @@ export async function GET(request: NextRequest) {
   const streak = streakParam !== null ? parseInt(streakParam, 10) : 0
   const parsedStreak = isNaN(streak) || streak < 0 ? 0 : streak
 
+  // Parse optional customCategory param.
+  const customCategoryParam = searchParams.get('customCategory')
+  const customCategory = customCategoryParam && customCategoryParam.trim().length >= 3
+    ? customCategoryParam.trim()
+    : null
+
   // Parse optional categoryIds (comma-separated). Legacy single
-  // ?categoryId= is honored too.
+  // ?categoryId= is honored too. Ignored when customCategory is set.
   const categoryIdsParam = searchParams.get('categoryIds')
   const legacyCategoryIdParam = searchParams.get('categoryId')
-  const rawIds = categoryIdsParam !== null
+  const rawIds = !customCategory && categoryIdsParam !== null
     ? categoryIdsParam.split(',')
-    : legacyCategoryIdParam !== null
+    : !customCategory && legacyCategoryIdParam !== null
       ? [legacyCategoryIdParam]
       : []
   const categoryIds = rawIds
@@ -36,7 +42,9 @@ export async function GET(request: NextRequest) {
     .filter((n) => !isNaN(n) && n in CATEGORY_META)
 
   try {
-    let question = await sampleNextQuestion({
+    // Custom category runs always generate fresh questions — no pre-existing
+    // question pool exists for arbitrary topics.
+    let question = customCategory ? null : await sampleNextQuestion({
       uid: auth.claims.uid,
       streak: parsedStreak,
       type: 'free-text',
@@ -62,18 +70,24 @@ export async function GET(request: NextRequest) {
       }
 
       try {
-        // For multi-category runs, pick a random selected category to
-        // generate within. (Single-category runs reuse the same id.)
-        const generationCategoryId = categoryIds.length > 0
-          ? categoryIds[Math.floor(Math.random() * categoryIds.length)]
-          : undefined
-        const generated = await generateInfiniteQuestion({ streak: parsedStreak, categoryId: generationCategoryId })
+        const genOptions: Parameters<typeof generateInfiniteQuestion>[0] = { streak: parsedStreak }
+        if (customCategory) {
+          genOptions.customCategory = customCategory
+        } else {
+          // For multi-category runs, pick a random selected category to
+          // generate within. (Single-category runs reuse the same id.)
+          genOptions.categoryId = categoryIds.length > 0
+            ? categoryIds[Math.floor(Math.random() * categoryIds.length)]
+            : undefined
+        }
+        const generated = await generateInfiniteQuestion(genOptions)
         question = await saveAIQuestion(generated)
       } catch (genErr) {
         console.error('[trivia/infinite/next] generation failed', {
           uid: auth.claims.uid,
           streak: parsedStreak,
           requestedCategoryIds: categoryIds,
+          customCategory,
           rateRemaining: remaining,
           error: genErr instanceof Error ? genErr.message : String(genErr),
           stack: genErr instanceof Error ? genErr.stack : undefined,

--- a/src/app/api/v1/trivia/infinite/runs/route.ts
+++ b/src/app/api/v1/trivia/infinite/runs/route.ts
@@ -50,21 +50,33 @@ export async function POST(request: NextRequest) {
     const body = await request.json();
     const mode = body.mode === 'practice' ? 'practice' : 'scored';
 
-    // Parse and validate categoryIds (preferred) — falls back to the legacy
-    // single categoryId field for backward compatibility.
-    let categoryIds: number[] = []
-    if (Array.isArray(body.categoryIds)) {
-      categoryIds = body.categoryIds
-        .map((v: unknown) => Number(v))
-        .filter((n: number) => !isNaN(n) && n in CATEGORY_META)
-    } else if (body.categoryId !== undefined && body.categoryId !== null) {
-      const parsed = Number(body.categoryId)
-      if (!isNaN(parsed) && parsed in CATEGORY_META) {
-        categoryIds = [parsed]
+    // Parse and validate customCategory — mutually exclusive with preset categories.
+    let customCategory: string | null = null
+    if (typeof body.customCategory === 'string') {
+      const trimmed = body.customCategory.trim().toLowerCase()
+      if (trimmed.length >= 3) {
+        customCategory = trimmed
       }
     }
 
-    const result = await startRun(auth.claims.uid, mode, categoryIds);
+    // Parse and validate categoryIds (preferred) — falls back to the legacy
+    // single categoryId field for backward compatibility.
+    // Ignored when customCategory is set.
+    let categoryIds: number[] = []
+    if (!customCategory) {
+      if (Array.isArray(body.categoryIds)) {
+        categoryIds = body.categoryIds
+          .map((v: unknown) => Number(v))
+          .filter((n: number) => !isNaN(n) && n in CATEGORY_META)
+      } else if (body.categoryId !== undefined && body.categoryId !== null) {
+        const parsed = Number(body.categoryId)
+        if (!isNaN(parsed) && parsed in CATEGORY_META) {
+          categoryIds = [parsed]
+        }
+      }
+    }
+
+    const result = await startRun(auth.claims.uid, mode, categoryIds, customCategory);
     return NextResponse.json(result, { status: 201 });
   } catch (err) {
     console.error('Failed to start infinite run:', err);

--- a/src/app/trivia/components/InfiniteGame.tsx
+++ b/src/app/trivia/components/InfiniteGame.tsx
@@ -37,6 +37,7 @@ export function InfiniteGame({ onBack, onViewStats, onViewLeaderboard, mode = 's
   // Empty set = "All Categories" (no filter). Players toggle individual
   // tiles to build up a multi-category selection.
   const [selectedCategoryIds, setSelectedCategoryIds] = useState<Set<number>>(new Set())
+  const [customCategoryInput, setCustomCategoryInput] = useState('')
   const [showRulesOverlay, setShowRulesOverlay] = useState(false)
   const [bonusLifeToast, setBonusLifeToast] = useState<string | null>(null)
   const [medalToast, setMedalToast] = useState<string | null>(null)
@@ -61,10 +62,13 @@ export function InfiniteGame({ onBack, onViewStats, onViewLeaderboard, mode = 's
     }
     hasStartedRef.current = true
     setShowPreGame(false)
-    startRun(chosenMode, Array.from(selectedCategoryIds))
-  }, [mode, startRun, selectedCategoryIds])
+    const trimmedCustom = customCategoryInput.trim().toLowerCase()
+    const customCategory = trimmedCustom.length >= 3 ? trimmedCustom : null
+    startRun(chosenMode, customCategory ? [] : Array.from(selectedCategoryIds), customCategory)
+  }, [mode, startRun, selectedCategoryIds, customCategoryInput])
 
   const toggleCategoryId = useCallback((id: number) => {
+    setCustomCategoryInput('')
     setSelectedCategoryIds((prev) => {
       const next = new Set(prev)
       if (next.has(id)) next.delete(id)
@@ -141,10 +145,14 @@ export function InfiniteGame({ onBack, onViewStats, onViewLeaderboard, mode = 's
   // Pre-game screen — inline, not a modal
   if (showPreGame) {
     const selectionCount = selectedCategoryIds.size
-    const isAllMode = selectionCount === 0
-    const startLabel = isAllMode
-      ? 'Start'
-      : `Start (${selectionCount} categor${selectionCount === 1 ? 'y' : 'ies'})`
+    const trimmedCustom = customCategoryInput.trim()
+    const hasValidCustom = trimmedCustom.length >= 3
+    const isAllMode = selectionCount === 0 && !hasValidCustom
+    const startLabel = hasValidCustom
+      ? `Start: "${trimmedCustom}"`
+      : isAllMode
+        ? 'Start'
+        : `Start (${selectionCount} categor${selectionCount === 1 ? 'y' : 'ies'})`
     return (
       <div className="flex flex-col gap-4 max-w-lg mx-auto py-6">
         <div className="text-center">
@@ -162,7 +170,7 @@ export function InfiniteGame({ onBack, onViewStats, onViewLeaderboard, mode = 's
             it doesn't get hidden when the player scrolls through tiles. */}
         <button
           type="button"
-          onClick={() => setSelectedCategoryIds(new Set())}
+          onClick={() => { setSelectedCategoryIds(new Set()); setCustomCategoryInput('') }}
           className={`flex items-center justify-center gap-2 py-2 rounded-ds-md text-sm font-medium transition-colors ${
             isAllMode
               ? 'bg-ds-primary text-on-primary'
@@ -186,7 +194,7 @@ export function InfiniteGame({ onBack, onViewStats, onViewLeaderboard, mode = 's
                 </span>
               )}
             </p>
-            <div className="grid grid-cols-2 sm:grid-cols-3 gap-2 max-h-[50vh] overflow-y-auto pr-1">
+            <div className="grid grid-cols-2 sm:grid-cols-3 gap-2 max-h-[40vh] overflow-y-auto pr-1">
               {categoryEntries.map(({ id, name, icon }) => {
                 const medal = medalsByCategoryId.get(id)
                 const earnedTier = medal && medal.tier !== 'none' ? medal.tier : null
@@ -237,6 +245,24 @@ export function InfiniteGame({ onBack, onViewStats, onViewLeaderboard, mode = 's
                 )
               })}
             </div>
+            <div className="pt-2 border-t border-outline/20">
+              <p className="text-on-surface/70 text-sm font-medium mb-2">Or type your own topic:</p>
+              <input
+                type="text"
+                value={customCategoryInput}
+                onChange={(e) => {
+                  setCustomCategoryInput(e.target.value)
+                  if (e.target.value.trim().length > 0) {
+                    setSelectedCategoryIds(new Set())
+                  }
+                }}
+                placeholder="e.g. Roman Empire, Pokemon Gen 1"
+                className="w-full px-3 py-2 rounded-ds-md bg-surface-container-highest text-on-surface text-sm border border-outline/30 focus:outline-none focus:ring-2 focus:ring-ds-primary placeholder:text-on-surface/40"
+              />
+              {customCategoryInput.trim().length > 0 && customCategoryInput.trim().length < 3 && (
+                <p className="text-ds-error text-xs mt-1">Topic must be at least 3 characters.</p>
+              )}
+            </div>
           </ChunkyCardContent>
         </ChunkyCard>
 
@@ -244,10 +270,22 @@ export function InfiniteGame({ onBack, onViewStats, onViewLeaderboard, mode = 's
             grid's max-height keeps these buttons visible without
             requiring any page scroll. */}
         <div className="flex flex-col gap-2">
-          <ChunkyButton variant="primary" size="lg" className="w-full" onClick={() => handleStart(mode === 'practice' ? 'practice' : 'scored')}>
+          <ChunkyButton
+            variant="primary"
+            size="lg"
+            className="w-full"
+            onClick={() => handleStart(mode === 'practice' ? 'practice' : 'scored')}
+            disabled={trimmedCustom.length > 0 && !hasValidCustom}
+          >
             {startLabel}
           </ChunkyButton>
-          <ChunkyButton variant="secondary" size="sm" className="w-full" onClick={() => handleStart('practice')}>
+          <ChunkyButton
+            variant="secondary"
+            size="sm"
+            className="w-full"
+            onClick={() => handleStart('practice')}
+            disabled={trimmedCustom.length > 0 && !hasValidCustom}
+          >
             Practice Mode
           </ChunkyButton>
         </div>
@@ -382,11 +420,13 @@ export function InfiniteGame({ onBack, onViewStats, onViewLeaderboard, mode = 's
         isPlaying={state.phase === 'playing'}
         mode={state.mode}
         categoryName={
-          state.categoryIds.length === 1
-            ? CATEGORY_META[state.categoryIds[0]]?.name
-            : state.categoryIds.length > 1
-              ? `${state.categoryIds.length} categories`
-              : undefined
+          state.customCategory
+            ? state.customCategory
+            : state.categoryIds.length === 1
+              ? CATEGORY_META[state.categoryIds[0]]?.name
+              : state.categoryIds.length > 1
+                ? `${state.categoryIds.length} categories`
+                : undefined
         }
         categoryProgress={categoryProgress}
         skipsRemaining={state.skipsRemaining}

--- a/src/app/trivia/hooks/useInfiniteRun.ts
+++ b/src/app/trivia/hooks/useInfiniteRun.ts
@@ -27,6 +27,8 @@ export interface InfiniteRunState {
   mode: InfiniteMode
   // Empty array = all categories.
   categoryIds: number[]
+  // Custom topic for on-the-fly question generation. Mutually exclusive with categoryIds.
+  customCategory: string | null
   runId: string | null
   question: InfiniteQuestion | null
   livesRemaining: number
@@ -65,6 +67,7 @@ export function useInfiniteRun() {
     phase: 'idle',
     mode: 'scored',
     categoryIds: [],
+    customCategory: null,
     runId: null,
     question: null,
     livesRemaining: LIVES_START,
@@ -114,7 +117,7 @@ export function useInfiniteRun() {
     prefetchedQuestionRef.current = null
   }, [])
 
-  const startPrefetch = useCallback((streak: number, categoryIds: number[]) => {
+  const startPrefetch = useCallback((streak: number, categoryIds: number[], customCategory: string | null) => {
     cancelPrefetch()
     const controller = new AbortController()
     prefetchAbortRef.current = controller
@@ -122,7 +125,11 @@ export function useInfiniteRun() {
       try {
         const headers = await getAuthHeaders()
         const params = new URLSearchParams({ streak: String(streak) })
-        if (categoryIds.length > 0) params.set('categoryIds', categoryIds.join(','))
+        if (customCategory) {
+          params.set('customCategory', customCategory)
+        } else if (categoryIds.length > 0) {
+          params.set('categoryIds', categoryIds.join(','))
+        }
         const qRes = await fetch(`/api/v1/trivia/infinite/next?${params.toString()}`, {
           headers,
           signal: controller.signal,
@@ -141,22 +148,28 @@ export function useInfiniteRun() {
     })()
   }, [cancelPrefetch, getAuthHeaders])
 
-  const startRun = useCallback(async (mode: InfiniteMode = 'scored', categoryIds: number[] = []) => {
+  const startRun = useCallback(async (mode: InfiniteMode = 'scored', categoryIds: number[] = [], customCategory: string | null = null) => {
     cancelPrefetch()
-    setState(s => ({ ...s, phase: 'loading', mode, categoryIds, error: null }))
+    setState(s => ({ ...s, phase: 'loading', mode, categoryIds, customCategory, error: null }))
     try {
       const headers = await getAuthHeaders()
+      const body: Record<string, unknown> = { mode, categoryIds }
+      if (customCategory) body.customCategory = customCategory
       const res = await fetch('/api/v1/trivia/infinite/runs', {
         method: 'POST',
         headers,
-        body: JSON.stringify({ mode, categoryIds }),
+        body: JSON.stringify(body),
       })
       if (!res.ok) throw new Error('Failed to start run')
       const data = await res.json()
 
       // Immediately fetch first question
       const firstParams = new URLSearchParams({ streak: '0' })
-      if (categoryIds.length > 0) firstParams.set('categoryIds', categoryIds.join(','))
+      if (customCategory) {
+        firstParams.set('customCategory', customCategory)
+      } else if (categoryIds.length > 0) {
+        firstParams.set('categoryIds', categoryIds.join(','))
+      }
       const qRes = await fetch(`/api/v1/trivia/infinite/next?${firstParams.toString()}`, { headers })
       if (qRes.status === 204) {
         setState(s => ({ ...s, phase: 'exhausted', runId: data.runId }))
@@ -176,6 +189,7 @@ export function useInfiniteRun() {
         phase: 'awaiting-ready',
         mode,
         categoryIds,
+        customCategory,
         runId: data.runId,
         question,
         livesRemaining: data.livesRemaining,
@@ -228,7 +242,7 @@ export function useInfiniteRun() {
       // Kick off the next question fetch in the background while the player
       // reads their feedback — only when the run is continuing.
       if (!result.runOver) {
-        startPrefetch(result.currentStreak, state.categoryIds)
+        startPrefetch(result.currentStreak, state.categoryIds, state.customCategory)
       }
 
       // If this was a correct answer in scored mode, increment the live
@@ -272,7 +286,7 @@ export function useInfiniteRun() {
       console.error('[infinite] submitAnswer failed:', err)
       setState(s => ({ ...s, phase: 'error', error: 'Failed to submit answer.' }))
     }
-  }, [state.phase, state.runId, state.question, state.categoryIds, getAuthHeaders, startPrefetch, cancelPrefetch])
+  }, [state.phase, state.runId, state.question, state.categoryIds, state.customCategory, getAuthHeaders, startPrefetch, cancelPrefetch])
 
   const nextQuestion = useCallback(async () => {
     if (state.phase !== 'answered' || !state.runId) return
@@ -319,7 +333,11 @@ export function useInfiniteRun() {
       try {
         const headers = await getAuthHeaders()
         const nextParams = new URLSearchParams({ streak: String(state.currentStreak) })
-        if (state.categoryIds.length > 0) nextParams.set('categoryIds', state.categoryIds.join(','))
+        if (state.customCategory) {
+          nextParams.set('customCategory', state.customCategory)
+        } else if (state.categoryIds.length > 0) {
+          nextParams.set('categoryIds', state.categoryIds.join(','))
+        }
         const qRes = await fetch(`/api/v1/trivia/infinite/next?${nextParams.toString()}`, { headers })
         if (qRes.status === 204) {
           setState(s => ({ ...s, phase: 'exhausted' }))
@@ -340,7 +358,7 @@ export function useInfiniteRun() {
     } finally {
       nextQuestionInFlightRef.current = false
     }
-  }, [state.phase, state.runId, state.currentStreak, state.categoryIds, getAuthHeaders, cancelPrefetch])
+  }, [state.phase, state.runId, state.currentStreak, state.categoryIds, state.customCategory, getAuthHeaders, cancelPrefetch])
 
   // Player clicked "Ready" on the gated loading screen — start the
   // per-question timer now and reveal the question.

--- a/src/lib/trivia/factSources/types.ts
+++ b/src/lib/trivia/factSources/types.ts
@@ -35,7 +35,8 @@ export interface FetchFactsOptions {
   // Internal numeric category id (matches CATEGORY_META keys).
   // Sources may use this to scope their queries (e.g. Wikipedia
   // category trees) without doing their own string matching.
-  categoryId: number
+  // Null when the request is for a custom topic (no preset category id).
+  categoryId: number | null
 
   // Human-readable category name, e.g. "Music". Sources that don't
   // need a numeric id can use this directly in prompts.

--- a/src/lib/trivia/generateQuestion.ts
+++ b/src/lib/trivia/generateQuestion.ts
@@ -27,6 +27,8 @@ export interface GenerateInfiniteQuestionOptions {
   difficulty?: 'easy' | 'medium' | 'hard'
   categoryId?: number
   streak?: number
+  // When set, generate questions about this custom topic instead of a preset category.
+  customCategory?: string
   // Override for tests / future per-category source routing. Falls
   // back to getDefaultFactSource() when omitted.
   factSource?: FactSource
@@ -584,25 +586,38 @@ export async function generateInfiniteQuestion(
   let lastReason = 'unknown'
   for (let attempt = 1; attempt <= MAX_GENERATION_ATTEMPTS; attempt++) {
     const difficulty = options.difficulty ?? pickDifficulty()
-    const categoryId = options.categoryId ?? pickCategoryId()
-    const categoryName = getOpenTDBCategoryName(categoryId)
-    // Difficulty-aware seed + modifier selection. Easy generations
-    // pick from iconic / common-knowledge seeds and "origin / first /
-    // most famous" modifiers; hard generations pick from niche seeds
-    // and "cut content / exploit / headcanon" modifiers. Both pools
-    // fall back to broader buckets when their preferred bucket is
-    // empty for a category — see seedsByDifficulty.ts /
-    // modifiersByDifficulty.ts.
-    const seeds = getSeedsForDifficulty(categoryId, difficulty)
     const modifiers = MODIFIERS_BY_DIFFICULTY[difficulty]
-    const seedWord = pickRandom(seeds.length > 0 ? seeds : (CATEGORIZED_SEEDS[categoryId] ?? CATEGORIZED_SEEDS[9]))
     const modifier = pickRandom(modifiers)
-    const seedSummary = `${seedWord} :: ${modifier}`
+
+    let categoryName: string
+    let seedSummary: string
+    let resolvedCategoryId: number | null
+
+    if (options.customCategory) {
+      // Custom topic: use the topic name directly, skip preset category lookup
+      categoryName = options.customCategory
+      seedSummary = `${options.customCategory} :: ${modifier}`
+      resolvedCategoryId = null
+    } else {
+      const categoryId = options.categoryId ?? pickCategoryId()
+      resolvedCategoryId = categoryId
+      categoryName = getOpenTDBCategoryName(categoryId)
+      // Difficulty-aware seed + modifier selection. Easy generations
+      // pick from iconic / common-knowledge seeds and "origin / first /
+      // most famous" modifiers; hard generations pick from niche seeds
+      // and "cut content / exploit / headcanon" modifiers. Both pools
+      // fall back to broader buckets when their preferred bucket is
+      // empty for a category — see seedsByDifficulty.ts /
+      // modifiersByDifficulty.ts.
+      const seeds = getSeedsForDifficulty(categoryId, difficulty)
+      const seedWord = pickRandom(seeds.length > 0 ? seeds : (CATEGORIZED_SEEDS[categoryId] ?? CATEGORIZED_SEEDS[9]))
+      seedSummary = `${seedWord} :: ${modifier}`
+    }
 
     let facts: Fact[]
     try {
       facts = await factSource.fetchFacts({
-        categoryId,
+        categoryId: resolvedCategoryId,
         category: categoryName,
         seed: seedSummary,
         difficulty,

--- a/src/lib/trivia/infiniteRuns.ts
+++ b/src/lib/trivia/infiniteRuns.ts
@@ -19,6 +19,9 @@ export interface RunDoc {
   // Deprecated, kept for backward compatibility. Equals categoryFilters[0]
   // when there's exactly one filter, null otherwise.
   categoryFilter: number | null
+  // When set, the run generates questions about this custom topic on-the-fly.
+  // Mutually exclusive with categoryFilters (stored as [] when customCategory is set).
+  customCategory?: string | null
   score: number
   livesRemaining: number
   currentStreak: number
@@ -44,17 +47,19 @@ export interface RunAnswer {
 export async function startRun(
   uid: string,
   mode: 'scored' | 'practice' = 'scored',
-  categoryIds: number[] = []
+  categoryIds: number[] = [],
+  customCategory?: string | null
 ): Promise<{ runId: string; livesRemaining: number; currentStreak: number }> {
   const db = getFirestoreDb()
   const runRef = db.collection(`users/${uid}/triviaInfinite`).doc()
   const now = FieldValue.serverTimestamp()
-  await runRef.set({
+  const filters = customCategory ? [] : categoryIds
+  const docData: Record<string, unknown> = {
     runId: runRef.id,
     uid,
     mode,
-    categoryFilters: categoryIds,
-    categoryFilter: categoryIds.length === 1 ? categoryIds[0] : null,
+    categoryFilters: filters,
+    categoryFilter: filters.length === 1 ? filters[0] : null,
     score: 0,
     livesRemaining: LIVES_START,
     currentStreak: 0,
@@ -66,7 +71,11 @@ export async function startRun(
     flaggedQuestionIds: [],
     startedAt: now,
     endedAt: null,
-  })
+  }
+  if (customCategory) {
+    docData.customCategory = customCategory
+  }
+  await runRef.set(docData)
   return { runId: runRef.id, livesRemaining: LIVES_START, currentStreak: 0 }
 }
 
@@ -307,6 +316,8 @@ async function hydrateNicknames(uids: string[]): Promise<Map<string, string>> {
   return map
 }
 
+// TODO(#1263): Add getTopRunsByCustomCategory(customCategory, limit) for per-topic leaderboards.
+// This requires a composite index on (customCategory, mode, score) which isn't yet defined.
 export async function getInfiniteTopByScore(limit = 20): Promise<InfiniteLeaderboardEntry[]> {
   const db = getFirestoreDb()
   // Overfetch so that the post-hydration filter that drops players without


### PR DESCRIPTION
## Summary
Closes #1263

- Adds a text input on the infinite trivia pre-game screen ("Or type your own topic:") so players can play trivia about any topic they want (e.g., "Roman Empire", "Pokemon Gen 1", "90s Hip Hop")
- Custom topic is mutually exclusive with preset category chips — typing clears chip selection and vice versa
- Custom runs generate all questions on-the-fly via AI (skip the sampler/question pool)
- Run documents store `customCategory: string` when active, with `categoryFilters: []`
- HUD displays the custom topic name during gameplay
- Start button shows the topic name (e.g., `Start: "roman empire"`) and disables when input is 1-2 chars
- Medal system unaffected — custom runs don't earn category medals (by design, since custom difficulty varies wildly)

## Files changed (7)
- `src/lib/trivia/infiniteRuns.ts` — RunDoc interface + startRun param
- `src/lib/trivia/generateQuestion.ts` — custom topic generation path
- `src/lib/trivia/factSources/types.ts` — nullable categoryId
- `src/app/api/v1/trivia/infinite/runs/route.ts` — POST accepts customCategory
- `src/app/api/v1/trivia/infinite/next/route.ts` — GET accepts customCategory, skips sampler
- `src/app/trivia/hooks/useInfiniteRun.ts` — threads customCategory through state + API calls
- `src/app/trivia/components/InfiniteGame.tsx` — custom topic input UI + mutual exclusivity

## What's NOT included (future work)
- Custom category leaderboard (TODO left in code — needs Firestore composite index)
- Autocomplete for popular custom tags (needs new collection + API route)
- These are tracked in the parent epic #1266

## Test plan
- [ ] Type a custom topic (>= 3 chars) → preset chips deselect, start button shows topic name
- [ ] Select a preset chip → custom input clears
- [ ] Start with custom topic → questions generated about that topic
- [ ] HUD shows custom topic name during gameplay
- [ ] Custom run doesn't trigger medal toasts
- [ ] Type 1-2 chars → start button disabled with validation message
- [ ] "All Categories" button clears both chips and custom input

🤖 Generated with [Claude Code](https://claude.com/claude-code)