### PR TITLE
feat(trivia): shared question browsing API with pagination

### DIFF
--- a/src/app/api/v1/trivia/questions/route.ts
+++ b/src/app/api/v1/trivia/questions/route.ts
@@ -1,0 +1,171 @@
+import { type NextRequest, NextResponse } from 'next/server'
+
+import { verifyRequestAuth } from '@/lib/api/auth'
+import { getFirestoreDb } from '@/lib/firebase/server'
+import type { AIQuestion } from '@/lib/trivia/aiQuestions'
+import {
+  VALID_SORTS,
+  buildQuestionBrowseQuery,
+  computeAccuracy,
+  decodeCursor,
+  encodeCursor,
+  isAccuracySort,
+  toQuestionBrowseRow,
+} from '@/lib/trivia/questionQueries'
+import { TRIVIA_STATE_DOC_PATH } from '@/lib/trivia/triviaState'
+
+const MAX_LIMIT = 50
+const DEFAULT_LIMIT = 20
+
+// GET /api/v1/trivia/questions
+// Query params: sort, category, difficulty, cursor, limit
+export async function GET(request: NextRequest) {
+  const authResult = await verifyRequestAuth(request)
+  if ('error' in authResult) return authResult.error
+  const { claims } = authResult
+
+  const { searchParams } = new URL(request.url)
+
+  // ── Parse + validate query params ─────────────────────────────────────────
+
+  const sortParam = (searchParams.get('sort') ?? 'newest') as string
+  if (!VALID_SORTS.includes(sortParam as (typeof VALID_SORTS)[number])) {
+    return NextResponse.json(
+      {
+        error: `Invalid sort. Must be one of: ${VALID_SORTS.join(', ')}.`,
+      },
+      { status: 400 }
+    )
+  }
+  const sort = sortParam as (typeof VALID_SORTS)[number]
+
+  const category = searchParams.get('category') ?? undefined
+  const difficulty = searchParams.get('difficulty') ?? undefined
+
+  if (difficulty && !['easy', 'medium', 'hard'].includes(difficulty)) {
+    return NextResponse.json(
+      { error: 'Invalid difficulty. Must be one of: easy, medium, hard.' },
+      { status: 400 }
+    )
+  }
+
+  const limitParam = parseInt(searchParams.get('limit') ?? String(DEFAULT_LIMIT), 10)
+  const limit = isNaN(limitParam) || limitParam < 1 ? DEFAULT_LIMIT : Math.min(limitParam, MAX_LIMIT)
+
+  const cursorParam = searchParams.get('cursor')
+  const cursor = cursorParam ? decodeCursor(cursorParam) : undefined
+  if (cursorParam && !cursor) {
+    return NextResponse.json({ error: 'Invalid cursor.' }, { status: 400 })
+  }
+
+  try {
+    // ── Fetch seen question IDs from the user's state doc ──────────────────
+
+    const db = getFirestoreDb()
+    const stateSnap = await db.doc(TRIVIA_STATE_DOC_PATH(claims.uid)).get()
+    const recentSeen: string[] = stateSnap.exists
+      ? ((stateSnap.data() as { recentSeen?: string[] }).recentSeen ?? [])
+      : []
+    const seenSet = new Set(recentSeen)
+
+    // ── Build and execute Firestore query ──────────────────────────────────
+
+    // For accuracy sorts: over-fetch so we have enough data to sort in code.
+    const fetchLimit = isAccuracySort(sort) ? limit * 3 : limit + 1
+
+    const q = buildQuestionBrowseQuery({ sort, category, difficulty, cursor: cursor ?? undefined, fetchLimit })
+    const snap = await q.get()
+
+    // ── Transform docs ─────────────────────────────────────────────────────
+
+    type DocData = Omit<AIQuestion, 'correctAnswer' | 'seed'> & {
+      correctAnswer?: unknown
+      seed?: unknown
+      createdAt?: { toDate?: () => Date } | string | null
+    }
+
+    const rows = snap.docs.map((doc) =>
+      toQuestionBrowseRow(doc.id, doc.data() as DocData, seenSet)
+    )
+
+    // ── Accuracy sorts: sort + paginate in code ────────────────────────────
+
+    if (isAccuracySort(sort)) {
+      // Sort by computed accuracy
+      rows.sort((a, b) =>
+        sort === 'accuracy_asc'
+          ? a.accuracyPct - b.accuracyPct || a.id.localeCompare(b.id)
+          : b.accuracyPct - a.accuracyPct || a.id.localeCompare(b.id)
+      )
+
+      // Apply cursor offset in code
+      let startIndex = 0
+      if (cursor) {
+        const { sortValue: cursorAccuracy, docId: cursorDocId } = cursor
+        const idx = rows.findIndex(
+          (r) => r.id === cursorDocId && r.accuracyPct === cursorAccuracy
+        )
+        if (idx !== -1) startIndex = idx + 1
+      }
+
+      const page = rows.slice(startIndex, startIndex + limit)
+      const hasMore = startIndex + limit < rows.length
+
+      const lastRow = page[page.length - 1]
+      const nextCursor =
+        hasMore && lastRow
+          ? encodeCursor({ sortValue: lastRow.accuracyPct, docId: lastRow.id })
+          : null
+
+      return NextResponse.json({ questions: page, nextCursor, hasMore })
+    }
+
+    // ── Firestore-sorted result: detect hasMore via over-fetch ─────────────
+
+    // We fetched limit + 1 docs. If we got that many, there is a next page.
+    const hasMore = rows.length > limit
+    const page = hasMore ? rows.slice(0, limit) : rows
+
+    // Build the cursor from the last row on the page and the Firestore
+    // sort field value.
+    const lastDoc = hasMore ? snap.docs[limit - 1] : snap.docs[snap.docs.length - 1]
+    let nextCursor: string | null = null
+
+    if (hasMore && lastDoc) {
+      const lastData = lastDoc.data() as DocData & Record<string, unknown>
+      let sortValue: unknown
+
+      switch (sort) {
+        case 'liked':
+        case 'trending':
+          sortValue = lastData.likeCount ?? 0
+          break
+        case 'disliked':
+          sortValue = lastData.dislikeCount ?? 0
+          break
+        case 'newest':
+        case 'oldest': {
+          const cd = lastData.createdAt as { toDate?: () => Date } | string | null | undefined
+          if (cd && typeof cd === 'object' && typeof cd.toDate === 'function') {
+            sortValue = cd.toDate().toISOString()
+          } else {
+            sortValue = cd ?? null
+          }
+          break
+        }
+        case 'most_shown':
+          sortValue = lastData.timesShown ?? 0
+          break
+        default:
+          sortValue = null
+      }
+
+      nextCursor = encodeCursor({ sortValue, docId: lastDoc.id })
+    }
+
+    return NextResponse.json({ questions: page, nextCursor, hasMore })
+  } catch (err) {
+    console.error('[trivia/questions] Failed to fetch questions:', err)
+    return NextResponse.json({ error: 'Failed to fetch questions.' }, { status: 500 })
+  }
+}

--- a/src/lib/trivia/questionQueries.ts
+++ b/src/lib/trivia/questionQueries.ts
@@ -1,0 +1,213 @@
+import type { Query, CollectionReference } from 'firebase-admin/firestore'
+
+import { getFirestoreDb } from '@/lib/firebase/server'
+import type { AIQuestion } from '@/lib/trivia/aiQuestions'
+
+// ── Sort types ────────────────────────────────────────────────────────────────
+
+export type SortOption =
+  | 'liked'
+  | 'disliked'
+  | 'trending'
+  | 'accuracy_asc'
+  | 'accuracy_desc'
+  | 'newest'
+  | 'oldest'
+  | 'most_shown'
+
+export const VALID_SORTS: SortOption[] = [
+  'liked',
+  'disliked',
+  'trending',
+  'accuracy_asc',
+  'accuracy_desc',
+  'newest',
+  'oldest',
+  'most_shown',
+]
+
+// Whether a sort is computed in code rather than via a Firestore orderBy.
+export function isAccuracySort(sort: SortOption): boolean {
+  return sort === 'accuracy_asc' || sort === 'accuracy_desc'
+}
+
+// ── Cursor encoding / decoding ────────────────────────────────────────────────
+
+export interface BrowseCursor {
+  // The value of the sort field for the last document on the previous page
+  // (or the computed accuracyPct for accuracy sorts).
+  sortValue: unknown
+  docId: string
+}
+
+export function encodeCursor(cursor: BrowseCursor): string {
+  return Buffer.from(JSON.stringify(cursor)).toString('base64')
+}
+
+export function decodeCursor(raw: string): BrowseCursor | null {
+  try {
+    const parsed = JSON.parse(Buffer.from(raw, 'base64').toString('utf-8'))
+    if (
+      typeof parsed !== 'object' ||
+      parsed === null ||
+      !('docId' in parsed) ||
+      typeof parsed.docId !== 'string'
+    ) {
+      return null
+    }
+    return { sortValue: parsed.sortValue, docId: parsed.docId }
+  } catch {
+    return null
+  }
+}
+
+// ── Accuracy computation ──────────────────────────────────────────────────────
+
+export function computeAccuracy(timesShown: number, timesCorrect: number): number {
+  if (timesShown === 0) return 0
+  return Math.round((timesCorrect / timesShown) * 1000) / 10 // one decimal
+}
+
+// ── Query builder ─────────────────────────────────────────────────────────────
+
+export interface BuildQueryOptions {
+  sort: SortOption
+  category?: string
+  difficulty?: string
+  cursor?: BrowseCursor
+  // How many docs to fetch from Firestore. For accuracy sorts the caller
+  // passes limit * 3 so there is enough data to sort and slice in code.
+  fetchLimit: number
+}
+
+export function buildQuestionBrowseQuery(opts: BuildQueryOptions): Query {
+  const db = getFirestoreDb()
+  let q: Query | CollectionReference = db.collection('aiQuestions')
+
+  // Always filter to active free-text questions only.
+  q = q.where('status', '==', 'active').where('type', '==', 'free-text')
+
+  if (opts.category) {
+    q = q.where('category', '==', opts.category)
+  }
+  if (opts.difficulty) {
+    q = q.where('difficulty', '==', opts.difficulty)
+  }
+
+  // For accuracy sorts we fetch an over-sized batch and sort in code, so
+  // we don't apply a Firestore orderBy for the accuracy field (it doesn't
+  // exist on the doc). We still need a deterministic secondary sort by
+  // docId so we can paginate reliably with __name__.
+  if (isAccuracySort(opts.sort)) {
+    // No primary sort field — Firestore will use default doc order.
+    // Secondary __name__ sort is added by Firestore automatically when no
+    // orderBy is specified; we don't add cursor pagination here because
+    // accuracy pagination is done in code.
+    q = q.limit(opts.fetchLimit)
+    return q
+  }
+
+  // Map sort options to Firestore orderBy fields and directions.
+  let sortField: string
+  let sortDir: 'asc' | 'desc'
+
+  switch (opts.sort) {
+    case 'liked':
+    case 'trending': // Trending uses likeCount for now (no recent-rating data yet)
+      sortField = 'likeCount'
+      sortDir = 'desc'
+      break
+    case 'disliked':
+      sortField = 'dislikeCount'
+      sortDir = 'desc'
+      break
+    case 'newest':
+      sortField = 'createdAt'
+      sortDir = 'desc'
+      break
+    case 'oldest':
+      sortField = 'createdAt'
+      sortDir = 'asc'
+      break
+    case 'most_shown':
+      sortField = 'timesShown'
+      sortDir = 'desc'
+      break
+    case 'accuracy_asc':
+    case 'accuracy_desc':
+      // Should never reach here — isAccuracySort() returns early above.
+      sortField = 'likeCount'
+      sortDir = 'desc'
+      break
+    default: {
+      // Exhaustiveness check
+      const _exhaustive: never = opts.sort
+      void _exhaustive
+      sortField = 'likeCount'
+      sortDir = 'desc'
+      break
+    }
+  }
+
+  // Add __name__ as a tiebreaker so cursor pagination is stable.
+  q = q.orderBy(sortField, sortDir).orderBy('__name__', sortDir)
+
+  if (opts.cursor) {
+    q = q.startAfter(opts.cursor.sortValue, opts.cursor.docId)
+  }
+
+  q = q.limit(opts.fetchLimit)
+  return q
+}
+
+// ── Row type returned by the browse helpers ───────────────────────────────────
+
+export interface QuestionBrowseRow {
+  id: string
+  question: string
+  category: string
+  difficulty: 'easy' | 'medium' | 'hard'
+  timesShown: number
+  timesCorrect: number
+  accuracyPct: number
+  likeCount: number
+  dislikeCount: number
+  createdAt: string | null
+  userHasSeen: boolean
+}
+
+// ── Map a Firestore doc to a safe client row ──────────────────────────────────
+
+export function toQuestionBrowseRow(
+  id: string,
+  // Omit secret fields at the type level — we never touch them here.
+  data: Omit<AIQuestion, 'correctAnswer' | 'seed'> & { correctAnswer?: unknown; seed?: unknown; createdAt?: { toDate?: () => Date } | string | null },
+  seenSet: Set<string>
+): QuestionBrowseRow {
+  const timesShown = data.timesShown ?? 0
+  const timesCorrect = data.timesCorrect ?? 0
+  const accuracyPct = computeAccuracy(timesShown, timesCorrect)
+
+  let createdAt: string | null = null
+  if (data.createdAt) {
+    if (typeof data.createdAt === 'string') {
+      createdAt = data.createdAt
+    } else if (typeof (data.createdAt as { toDate?: () => Date }).toDate === 'function') {
+      createdAt = (data.createdAt as { toDate: () => Date }).toDate().toISOString()
+    }
+  }
+
+  return {
+    id,
+    question: data.question,
+    category: data.category,
+    difficulty: data.difficulty,
+    timesShown,
+    timesCorrect,
+    accuracyPct,
+    likeCount: data.likeCount ?? 0,
+    dislikeCount: data.dislikeCount ?? 0,
+    createdAt,
+    userHasSeen: seenSet.has(id),
+  }
+}


### PR DESCRIPTION
## Summary
Closes #1267 (child of Epic #1266 — Trivia Social & Discovery Features)

Adds `GET /api/v1/trivia/questions` — a paginated API endpoint that will power both the community explorer (#1264) and question library (#1265).

## Features
- **8 sort modes**: liked, disliked, trending, accuracy_asc, accuracy_desc, newest, oldest, most_shown
- **Filters**: by category name, by difficulty (easy/medium/hard)
- **Cursor-based pagination**: base64-encoded JSON cursors with sort field value + doc ID
- **Seen tracking**: each question includes `userHasSeen` boolean checked against the user's state doc
- **Security**: `correctAnswer` and `seed` fields are never returned to the client

## Files added (2 new files, no existing files modified)
- `src/lib/trivia/questionQueries.ts` — Query builder, cursor codec, accuracy computation, row mapper
- `src/app/api/v1/trivia/questions/route.ts` — GET handler with auth, validation, pagination

## Implementation notes
- Accuracy sorts (accuracy_asc/desc) are computed in code since `accuracyPct` isn't a stored field — over-fetches 3x and sorts/paginates in-memory (acceptable for <10K question pool)
- Firestore sorts use `orderBy(field) + orderBy('__name__')` for stable cursor pagination
- Trending uses `likeCount` for now — true trending would need recent-rating timestamps (future work)
- `TRIVIA_STATE_DOC_PATH` reused from existing `triviaState.ts` for seen-set lookup

## Test plan
- [ ] `GET /api/v1/trivia/questions` returns paginated questions with default sort (newest)
- [ ] `?sort=liked` returns questions ordered by like count desc
- [ ] `?category=Science&difficulty=hard` filters correctly
- [ ] `?cursor=<nextCursor>` returns the next page
- [ ] `?limit=5` returns at most 5 questions
- [ ] Response never contains `correctAnswer` or `seed`
- [ ] `userHasSeen` is true for questions the user has answered
- [ ] 401 returned without auth token
- [ ] 400 returned for invalid sort/difficulty/cursor

🤖 Generated with [Claude Code](https://claude.com/claude-code)