### PR TITLE
feat(trivia): question stats aggregation endpoint

### DIFF
--- a/src/app/api/v1/trivia/questions/stats/route.ts
+++ b/src/app/api/v1/trivia/questions/stats/route.ts
@@ -1,0 +1,27 @@
+import { NextResponse } from 'next/server'
+
+import { computeQuestionStats } from '@/lib/trivia/questionStats'
+
+// GET /api/v1/trivia/questions/stats
+// Returns aggregate statistics about the active question pool.
+// No auth required — public endpoint.
+export async function GET() {
+  try {
+    const stats = await computeQuestionStats()
+
+    const response = NextResponse.json({
+      ...stats,
+      cachedAt: new Date().toISOString(),
+    })
+
+    response.headers.set(
+      'Cache-Control',
+      'public, s-maxage=3600, stale-while-revalidate=1800'
+    )
+
+    return response
+  } catch (err) {
+    console.error('[trivia/questions/stats] Failed to compute stats:', err)
+    return NextResponse.json({ error: 'Failed to compute question stats.' }, { status: 500 })
+  }
+}

--- a/src/lib/trivia/questionStats.ts
+++ b/src/lib/trivia/questionStats.ts
@@ -1,0 +1,127 @@
+import { getFirestoreDb } from '@/lib/firebase/server'
+
+export interface CategoryStat {
+  category: string
+  count: number
+  avgAccuracy: number
+}
+
+export interface DifficultyStat {
+  count: number
+  avgAccuracy: number
+}
+
+export interface QuestionStats {
+  totalQuestions: number
+  totalAnswered: number
+  avgAccuracyPct: number
+  questionsAddedThisWeek: number
+  byCategory: CategoryStat[]
+  byDifficulty: {
+    easy: DifficultyStat
+    medium: DifficultyStat
+    hard: DifficultyStat
+  }
+}
+
+interface QuestionDoc {
+  category: string
+  difficulty: 'easy' | 'medium' | 'hard'
+  timesShown: number
+  timesCorrect: number
+  createdAt: { toDate?: () => Date } | string | null | undefined
+}
+
+export async function computeQuestionStats(): Promise<QuestionStats> {
+  const db = getFirestoreDb()
+
+  const snap = await db
+    .collection('aiQuestions')
+    .where('status', '==', 'active')
+    .where('type', '==', 'free-text')
+    .select('category', 'difficulty', 'timesShown', 'timesCorrect', 'createdAt')
+    .get()
+
+  const sevenDaysAgo = new Date()
+  sevenDaysAgo.setDate(sevenDaysAgo.getDate() - 7)
+
+  let totalAnswered = 0
+  let totalCorrect = 0
+  let questionsAddedThisWeek = 0
+
+  const categoryMap = new Map<string, { count: number; shown: number; correct: number }>()
+  const difficultyMap: Record<string, { count: number; shown: number; correct: number }> = {
+    easy: { count: 0, shown: 0, correct: 0 },
+    medium: { count: 0, shown: 0, correct: 0 },
+    hard: { count: 0, shown: 0, correct: 0 },
+  }
+
+  for (const doc of snap.docs) {
+    const data = doc.data() as QuestionDoc
+
+    const timesShown = data.timesShown ?? 0
+    const timesCorrect = data.timesCorrect ?? 0
+    totalAnswered += timesShown
+    totalCorrect += timesCorrect
+
+    // questionsAddedThisWeek
+    const createdAt = data.createdAt
+    if (createdAt) {
+      let createdDate: Date | null = null
+      if (typeof createdAt === 'object' && typeof createdAt.toDate === 'function') {
+        createdDate = createdAt.toDate()
+      } else if (typeof createdAt === 'string') {
+        createdDate = new Date(createdAt)
+      }
+      if (createdDate && createdDate >= sevenDaysAgo) {
+        questionsAddedThisWeek++
+      }
+    }
+
+    // byCategory
+    const category = data.category ?? 'Unknown'
+    const catEntry = categoryMap.get(category) ?? { count: 0, shown: 0, correct: 0 }
+    catEntry.count++
+    catEntry.shown += timesShown
+    catEntry.correct += timesCorrect
+    categoryMap.set(category, catEntry)
+
+    // byDifficulty
+    const difficulty = data.difficulty
+    if (difficulty && difficulty in difficultyMap) {
+      difficultyMap[difficulty].count++
+      difficultyMap[difficulty].shown += timesShown
+      difficultyMap[difficulty].correct += timesCorrect
+    }
+  }
+
+  const totalQuestions = snap.docs.length
+  const avgAccuracyPct =
+    totalAnswered > 0 ? Math.round((totalCorrect / totalAnswered) * 1000) / 10 : 0
+
+  const byCategory: CategoryStat[] = Array.from(categoryMap.entries())
+    .map(([category, { count, shown, correct }]) => ({
+      category,
+      count,
+      avgAccuracy: shown > 0 ? Math.round((correct / shown) * 1000) / 10 : 0,
+    }))
+    .sort((a, b) => b.count - a.count)
+
+  const toStat = (entry: { count: number; shown: number; correct: number }): DifficultyStat => ({
+    count: entry.count,
+    avgAccuracy: entry.shown > 0 ? Math.round((entry.correct / entry.shown) * 1000) / 10 : 0,
+  })
+
+  return {
+    totalQuestions,
+    totalAnswered,
+    avgAccuracyPct,
+    questionsAddedThisWeek,
+    byCategory,
+    byDifficulty: {
+      easy: toStat(difficultyMap.easy),
+      medium: toStat(difficultyMap.medium),
+      hard: toStat(difficultyMap.hard),
+    },
+  }
+}


### PR DESCRIPTION
## Summary
Closes #1269 (child of Epic #1266 — Trivia Social & Discovery Features)

Adds `GET /api/v1/trivia/questions/stats` — a public endpoint returning aggregate statistics about the question pool. Powers the future stats dashboard on the question library page (#1265).

## Response
Returns total questions, total answered, average accuracy, questions added this week, per-category breakdowns, and per-difficulty breakdowns.

## Implementation
- Single-pass aggregation over `aiQuestions` collection using `select()` for bandwidth optimization
- No auth required (public stats)
- `Cache-Control: public, s-maxage=3600, stale-while-revalidate=1800` (1hr CDN cache)
- Accuracy computed as `Math.round((correct/shown) * 1000) / 10` for 1 decimal precision

## Files added (2 new files, no existing files modified)
- `src/lib/trivia/questionStats.ts` — aggregation logic with typed interfaces
- `src/app/api/v1/trivia/questions/stats/route.ts` — GET handler with caching headers

## Test plan
- [ ] `GET /api/v1/trivia/questions/stats` returns valid JSON with all expected fields
- [ ] `totalQuestions` matches count of active free-text questions
- [ ] `byCategory` entries sorted by count descending
- [ ] `byDifficulty` has easy/medium/hard keys
- [ ] `questionsAddedThisWeek` only counts docs with createdAt within 7 days
- [ ] Response includes `Cache-Control` header
- [ ] No auth token needed (200 without Bearer header)

🤖 Generated with [Claude Code](https://claude.com/claude-code)