### PR TITLE
feat(trivia): spoiler protection component and reveal API

### DIFF
--- a/src/app/api/v1/trivia/questions/[questionId]/reveal/route.ts
+++ b/src/app/api/v1/trivia/questions/[questionId]/reveal/route.ts
@@ -1,0 +1,41 @@
+import { FieldValue } from 'firebase-admin/firestore'
+import { type NextRequest, NextResponse } from 'next/server'
+
+import { verifyRequestAuth } from '@/lib/api/auth'
+import { getFirestoreDb } from '@/lib/firebase/server'
+import { buildMarkSeenWrite } from '@/lib/trivia/triviaState'
+
+// POST /api/v1/trivia/questions/{questionId}/reveal
+// Marks a question as "seen" so it won't appear in future infinite trivia runs.
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ questionId: string }> }
+) {
+  const auth = await verifyRequestAuth(request)
+  if ('error' in auth) return auth.error
+
+  const { questionId } = await params
+  const uid = auth.claims.uid
+
+  const db = getFirestoreDb()
+  const seenRef = db.doc(`users/${uid}/seenQuestions/${questionId}`)
+
+  try {
+    await seenRef.set(
+      {
+        at: FieldValue.serverTimestamp(),
+        correct: false,
+        source: 'explorer',
+      },
+      { merge: true }
+    )
+
+    const markSeen = buildMarkSeenWrite(uid, questionId)
+    await markSeen.ref.set(markSeen.data, { merge: true })
+
+    return NextResponse.json({ ok: true }, { status: 200 })
+  } catch (err) {
+    console.error('[reveal] Failed to mark question as seen:', err)
+    return NextResponse.json({ error: 'Failed to mark question as seen.' }, { status: 500 })
+  }
+}

--- a/src/app/trivia/components/SpoilerCard.tsx
+++ b/src/app/trivia/components/SpoilerCard.tsx
@@ -1,0 +1,91 @@
+'use client'
+
+import { useState } from 'react'
+
+import { ChunkyButton } from '@/components/ui/chunky-button'
+import { ChunkyCard, ChunkyCardContent } from '@/components/ui/chunky-card'
+
+interface SpoilerCardProps {
+  questionId: string
+  questionText: string
+  userHasSeen: boolean
+  children: React.ReactNode
+  onReveal?: (questionId: string) => void
+}
+
+export function SpoilerCard({
+  questionId,
+  questionText,
+  userHasSeen,
+  children,
+  onReveal,
+}: SpoilerCardProps) {
+  const [revealed, setRevealed] = useState(userHasSeen)
+  const [showConfirm, setShowConfirm] = useState(false)
+
+  const handleRevealClick = () => {
+    setShowConfirm(true)
+  }
+
+  const handleConfirm = () => {
+    setShowConfirm(false)
+    setRevealed(true)
+    onReveal?.(questionId)
+  }
+
+  const handleCancel = () => {
+    setShowConfirm(false)
+  }
+
+  return (
+    <>
+      <ChunkyCard>
+        <ChunkyCardContent>
+          <p
+            className={[
+              'text-on-surface text-base mb-3',
+              'transition-[filter] duration-500',
+              revealed ? '' : 'blur-[8px] select-none',
+            ]
+              .filter(Boolean)
+              .join(' ')}
+          >
+            {questionText}
+          </p>
+
+          {children}
+
+          {!revealed && (
+            <div className="mt-4">
+              <ChunkyButton variant="secondary" size="sm" onClick={handleRevealClick}>
+                Reveal Question
+              </ChunkyButton>
+            </div>
+          )}
+        </ChunkyCardContent>
+      </ChunkyCard>
+
+      {showConfirm && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm">
+          <div
+            className="bg-surface-container-high rounded-ds-lg p-6 max-w-sm mx-4 shadow-hero flex flex-col gap-4"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <p className="text-on-surface text-sm">
+              Revealing this question means it won&apos;t appear in your future trivia runs. Are you
+              sure?
+            </p>
+            <div className="flex gap-3 justify-end">
+              <ChunkyButton variant="secondary" size="sm" onClick={handleCancel}>
+                Cancel
+              </ChunkyButton>
+              <ChunkyButton variant="primary" size="sm" onClick={handleConfirm}>
+                Reveal
+              </ChunkyButton>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  )
+}


### PR DESCRIPTION
## Summary
Closes #1268 (child of Epic #1266 — Trivia Social & Discovery Features)

Adds a reusable `SpoilerCard` component that blurs unseen trivia questions, plus a reveal API endpoint. Shared by both the community explorer (#1264) and question library (#1265).

## What's included

### `SpoilerCard` component
- Blurs question text for unseen questions (`blur-[8px]`, `select-none`)
- Metadata (category, stats) always visible via children prop
- "Reveal Question" button with confirmation dialog warning users the question won't appear in future runs
- Smooth unblur transition on reveal (`transition-[filter] duration-500`)
- Follows existing modal pattern (FlagQuestion/ResetStatsDialog style)

### `POST /api/v1/trivia/questions/{questionId}/reveal` endpoint
- Marks a question as "seen" in Firestore
- Writes to `users/{uid}/seenQuestions/{questionId}` (source of truth)
- Updates hot-path cache via `buildMarkSeenWrite` (recentSeen array + totalSeenCount)
- Returns `{ ok: true }`

## Files added (2 new files, no existing files modified)
- `src/app/trivia/components/SpoilerCard.tsx`
- `src/app/api/v1/trivia/questions/[questionId]/reveal/route.ts`

## Test plan
- [ ] SpoilerCard blurs question text when `userHasSeen=false`
- [ ] SpoilerCard shows text normally when `userHasSeen=true`
- [ ] Clicking "Reveal" shows confirmation dialog
- [ ] Confirming reveal: text unblurs, `onReveal` callback fires
- [ ] Canceling dialog: question stays blurred
- [ ] POST reveal endpoint marks question in seenQuestions + state doc
- [ ] POST reveal requires auth (401 without token)
- [ ] Revealed question excluded from future infinite runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)