### PR TITLE
feat(trivia): community question explorer

### DIFF
--- a/src/app/trivia/components/QuestionExplorer.tsx
+++ b/src/app/trivia/components/QuestionExplorer.tsx
@@ -1,0 +1,238 @@
+'use client'
+
+import { useCallback, useEffect, useState } from 'react'
+
+import { ChunkyButton } from '@/components/ui/chunky-button'
+import { ChunkyCard, ChunkyCardContent } from '@/components/ui/chunky-card'
+import { useAuth } from '@/hooks/useAuth'
+import type { QuestionBrowseRow } from '@/lib/trivia/questionQueries'
+
+import { SpoilerCard } from './SpoilerCard'
+
+type SortTab = 'liked' | 'disliked' | 'trending'
+
+interface QuestionExplorerProps {
+  onBack: () => void
+}
+
+const TAB_LABELS: { key: SortTab; label: string }[] = [
+  { key: 'liked', label: 'Most Liked' },
+  { key: 'disliked', label: 'Most Disliked' },
+  { key: 'trending', label: 'Trending' },
+]
+
+const DIFFICULTY_COLORS: Record<string, string> = {
+  easy: 'bg-green-500/20 text-green-700 dark:text-green-400',
+  medium: 'bg-yellow-500/20 text-yellow-700 dark:text-yellow-400',
+  hard: 'bg-red-500/20 text-red-700 dark:text-red-400',
+}
+
+export function QuestionExplorer({ onBack }: QuestionExplorerProps) {
+  const { user } = useAuth()
+  const [activeTab, setActiveTab] = useState<SortTab>('liked')
+  const [questions, setQuestions] = useState<QuestionBrowseRow[]>([])
+  const [nextCursor, setNextCursor] = useState<string | null>(null)
+  const [hasMore, setHasMore] = useState(false)
+  const [loading, setLoading] = useState(false)
+  const [loadingMore, setLoadingMore] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const fetchQuestions = useCallback(
+    async (sort: SortTab, cursor?: string) => {
+      const isLoadMore = !!cursor
+      if (isLoadMore) {
+        setLoadingMore(true)
+      } else {
+        setLoading(true)
+        setError(null)
+      }
+
+      try {
+        const headers: Record<string, string> = {}
+        if (user) {
+          const token = await user.getIdToken()
+          headers['Authorization'] = `Bearer ${token}`
+        }
+
+        const params = new URLSearchParams({ sort, limit: '20' })
+        if (cursor) params.set('cursor', cursor)
+
+        const res = await fetch(`/api/v1/trivia/questions?${params.toString()}`, { headers })
+        if (!res.ok) {
+          throw new Error(`Failed to fetch questions: ${res.status}`)
+        }
+
+        const data = (await res.json()) as {
+          questions: QuestionBrowseRow[]
+          nextCursor: string | null
+          hasMore: boolean
+        }
+
+        if (isLoadMore) {
+          setQuestions((prev) => [...prev, ...data.questions])
+        } else {
+          setQuestions(data.questions)
+        }
+        setNextCursor(data.nextCursor)
+        setHasMore(data.hasMore)
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Something went wrong')
+      } finally {
+        setLoading(false)
+        setLoadingMore(false)
+      }
+    },
+    [user]
+  )
+
+  useEffect(() => {
+    setQuestions([])
+    setNextCursor(null)
+    setHasMore(false)
+    fetchQuestions(activeTab)
+  }, [activeTab, fetchQuestions])
+
+  const handleTabChange = (tab: SortTab) => {
+    if (tab === activeTab) return
+    setActiveTab(tab)
+  }
+
+  const handleLoadMore = () => {
+    if (!nextCursor || loadingMore) return
+    fetchQuestions(activeTab, nextCursor)
+  }
+
+  const handleReveal = async (questionId: string) => {
+    setQuestions((prev) =>
+      prev.map((q) => (q.id === questionId ? { ...q, userHasSeen: true } : q))
+    )
+    if (!user) return
+    try {
+      const token = await user.getIdToken()
+      await fetch(`/api/v1/trivia/questions/${questionId}/reveal`, {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${token}` },
+      })
+    } catch (err) {
+      console.error('Failed to record reveal:', err)
+    }
+  }
+
+  return (
+    <div className="flex flex-col items-center gap-6 max-w-lg mx-auto py-8">
+      {/* Header */}
+      <div className="w-full flex items-center gap-3">
+        <button
+          type="button"
+          onClick={onBack}
+          className="text-ds-tertiary hover:text-ds-tertiary/80 transition-colors underline-offset-4 hover:underline text-sm"
+        >
+          ← Back
+        </button>
+        <h1 className="font-headline text-headline-md text-ds-tertiary flex-1 text-center pr-12">
+          Explore Questions
+        </h1>
+      </div>
+
+      {/* Tab buttons */}
+      <div className="w-full flex gap-2">
+        {TAB_LABELS.map(({ key, label }) => (
+          <button
+            key={key}
+            type="button"
+            onClick={() => handleTabChange(key)}
+            className={[
+              'flex-1 py-2 px-3 rounded-full text-sm font-medium transition-colors',
+              activeTab === key
+                ? 'bg-ds-primary text-on-primary'
+                : 'bg-surface-container-highest text-on-surface hover:bg-surface-variant',
+            ].join(' ')}
+          >
+            {label}
+          </button>
+        ))}
+      </div>
+
+      {/* Content */}
+      {loading ? (
+        <div className="w-full flex justify-center py-12">
+          <span className="text-on-surface/50 text-sm">Loading questions…</span>
+        </div>
+      ) : error ? (
+        <div className="w-full flex flex-col items-center gap-4 py-12">
+          <span className="text-red-500 text-sm">{error}</span>
+          <ChunkyButton variant="secondary" size="sm" onClick={() => fetchQuestions(activeTab)}>
+            Try again
+          </ChunkyButton>
+        </div>
+      ) : questions.length === 0 ? (
+        <div className="w-full flex justify-center py-12">
+          <span className="text-on-surface/50 text-sm">No questions found.</span>
+        </div>
+      ) : (
+        <div className="w-full flex flex-col gap-4">
+          {questions.map((q) => (
+            <SpoilerCard
+              key={q.id}
+              questionId={q.id}
+              questionText={q.question}
+              userHasSeen={q.userHasSeen}
+              onReveal={handleReveal}
+            >
+              {/* Badges and stats shown inside the card */}
+              <div className="flex flex-wrap gap-2 mt-2 mb-3">
+                <span className="text-xs px-2 py-0.5 rounded-full bg-surface-variant text-on-surface-variant font-medium">
+                  {q.category}
+                </span>
+                <span
+                  className={[
+                    'text-xs px-2 py-0.5 rounded-full font-medium capitalize',
+                    DIFFICULTY_COLORS[q.difficulty] ?? 'bg-surface-variant text-on-surface-variant',
+                  ].join(' ')}
+                >
+                  {q.difficulty}
+                </span>
+              </div>
+              <ChunkyCard variant="surface-variant">
+                <ChunkyCardContent className="pt-4 pb-3">
+                  <div className="grid grid-cols-2 gap-x-4 gap-y-1 text-xs text-on-surface/70">
+                    <span>
+                      Likes:{' '}
+                      <span className="font-semibold text-on-surface">{q.likeCount}</span>
+                    </span>
+                    <span>
+                      Dislikes:{' '}
+                      <span className="font-semibold text-on-surface">{q.dislikeCount}</span>
+                    </span>
+                    <span>
+                      Shown:{' '}
+                      <span className="font-semibold text-on-surface">{q.timesShown}</span>
+                    </span>
+                    <span>
+                      Accuracy:{' '}
+                      <span className="font-semibold text-on-surface">{q.accuracyPct}%</span>
+                    </span>
+                  </div>
+                </ChunkyCardContent>
+              </ChunkyCard>
+            </SpoilerCard>
+          ))}
+
+          {/* Load More */}
+          {hasMore && (
+            <div className="flex justify-center mt-2">
+              <ChunkyButton
+                variant="secondary"
+                size="sm"
+                onClick={handleLoadMore}
+                disabled={loadingMore}
+              >
+                {loadingMore ? 'Loading…' : 'Load More'}
+              </ChunkyButton>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/app/trivia/components/TriviaLanding.tsx
+++ b/src/app/trivia/components/TriviaLanding.tsx
@@ -25,6 +25,7 @@ export function TriviaLanding({
   onViewInfiniteStats,
   onStartPractice,
   onViewInfiniteLeaderboard,
+  onExplore,
   onStatsReset,
   todayResult,
 }: {
@@ -35,6 +36,7 @@ export function TriviaLanding({
   onViewInfiniteStats?: () => void
   onStartPractice?: () => void
   onViewInfiniteLeaderboard?: () => void
+  onExplore?: () => void
   onStatsReset?: (scopes: ResetScopes) => void
   todayResult: TriviaGameResult | null
 }) {
@@ -252,6 +254,13 @@ export function TriviaLanding({
           className="text-ds-tertiary hover:text-ds-tertiary/80 transition-colors underline-offset-4 hover:underline"
         >
           Infinite Ranks
+        </button>
+        <span className="text-on-surface/20">·</span>
+        <button
+          onClick={onExplore}
+          className="text-ds-tertiary hover:text-ds-tertiary/80 transition-colors underline-offset-4 hover:underline"
+        >
+          Explore Questions
         </button>
       </div>
 

--- a/src/app/trivia/page.tsx
+++ b/src/app/trivia/page.tsx
@@ -15,6 +15,7 @@ import { getDailyCategory } from '@/lib/trivia/categories'
 
 import { InfiniteGame } from './components/InfiniteGame'
 import { InfiniteLeaderboard } from './components/InfiniteLeaderboard'
+import { QuestionExplorer } from './components/QuestionExplorer'
 import { UnifiedStats } from './components/UnifiedStats'
 import { TriviaGame } from './components/TriviaGame'
 import { TriviaLanding } from './components/TriviaLanding'
@@ -24,7 +25,7 @@ import { TriviaResults } from './components/TriviaResults'
 import type { TriviaGameResult } from './models/trivia'
 import type { User } from 'firebase/auth'
 
-type View = 'landing' | 'playing' | 'results' | 'stats' | 'leaderboard' | 'infinite' | 'infinite-stats' | 'practice' | 'infinite-leaderboard'
+type View = 'landing' | 'playing' | 'results' | 'stats' | 'leaderboard' | 'infinite' | 'infinite-stats' | 'practice' | 'infinite-leaderboard' | 'explore'
 
 type StatsDefaultTab = 'daily' | 'infinite'
 
@@ -147,6 +148,7 @@ export default function TriviaPage() {
     [user, today]
   )
 
+  const handleExplore = () => setView('explore')
   const handleBackToLanding = () => setView('landing')
 
   if (view === 'infinite') {
@@ -189,6 +191,10 @@ export default function TriviaPage() {
     return <InfiniteLeaderboard onBack={handleBackToLanding} />
   }
 
+  if (view === 'explore') {
+    return <QuestionExplorer onBack={handleBackToLanding} />
+  }
+
   return (
     <TriviaLanding
       onStartGame={handleStartGame}
@@ -198,6 +204,7 @@ export default function TriviaPage() {
       onViewInfiniteStats={handleViewInfiniteStats}
       onStartPractice={handleStartPractice}
       onViewInfiniteLeaderboard={handleViewInfiniteLeaderboard}
+      onExplore={handleExplore}
       onStatsReset={handleStatsReset}
       todayResult={todayResult}
     />


### PR DESCRIPTION
## Summary
Closes #1264 (child of Epic #1266 — Trivia Social & Discovery Features)

Adds an "Explore Questions" view to the trivia app where users can browse community-rated questions.

## Features
- **Three sort tabs**: Most Liked, Most Disliked, Trending
- **Question cards** with category badge, color-coded difficulty, and stats grid (likes, dislikes, times shown, accuracy %)
- **Spoiler protection**: Unseen questions are blurred via SpoilerCard with reveal confirmation
- **Pagination**: "Load More" button using cursor-based pagination from the browsing API
- **Navigation**: Accessible from trivia landing page via "Explore Questions" link

## Uses the Phase 1 infra we just built
- Browsing API (#1267) for paginated question fetching
- SpoilerCard (#1268) for spoiler protection
- Reveal API (#1268) for marking questions as seen

## Files changed
- **New**: `src/app/trivia/components/QuestionExplorer.tsx` — the explorer component (238 lines)
- **Modified**: `src/app/trivia/page.tsx` — added 'explore' view type (+9 lines)
- **Modified**: `src/app/trivia/components/TriviaLanding.tsx` — added "Explore Questions" link (+9 lines)

## Test plan
- [ ] "Explore Questions" link visible on trivia landing page
- [ ] Clicking it opens the explorer view
- [ ] Default tab is "Most Liked" with questions loaded
- [ ] Switching tabs fetches correct sort order
- [ ] Unseen questions show blurred with SpoilerCard
- [ ] Revealing a question unblurs it and calls reveal API
- [ ] "Load More" loads next page of results
- [ ] Back button returns to landing page
- [ ] Loading/empty/error states render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)