### PR TITLE
feat(trivia): question library with stats dashboard

### DIFF
--- a/src/app/trivia/components/QuestionLibrary.tsx
+++ b/src/app/trivia/components/QuestionLibrary.tsx
@@ -1,0 +1,329 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+
+import { ChunkyButton } from '@/components/ui/chunky-button'
+import { ChunkyCard, ChunkyCardContent, ChunkyCardHeader, ChunkyCardTitle } from '@/components/ui/chunky-card'
+import { useAuth } from '@/hooks/useAuth'
+import type { QuestionStats } from '@/lib/trivia/questionStats'
+import type { QuestionBrowseRow, SortOption } from '@/lib/trivia/questionQueries'
+
+import { SpoilerCard } from './SpoilerCard'
+
+interface QuestionLibraryProps {
+  onBack: () => void
+}
+
+const SORT_OPTIONS: { value: SortOption; label: string }[] = [
+  { value: 'newest', label: 'Newest' },
+  { value: 'oldest', label: 'Oldest' },
+  { value: 'most_shown', label: 'Most Shown' },
+  { value: 'liked', label: 'Most Liked' },
+  { value: 'disliked', label: 'Most Disliked' },
+  { value: 'accuracy_asc', label: 'Hardest' },
+  { value: 'accuracy_desc', label: 'Easiest' },
+]
+
+const DIFFICULTY_OPTIONS = ['easy', 'medium', 'hard'] as const
+type Difficulty = (typeof DIFFICULTY_OPTIONS)[number]
+
+const DIFFICULTY_COLORS: Record<Difficulty, string> = {
+  easy: 'bg-emerald-500/20 text-emerald-300 border-emerald-500/30',
+  medium: 'bg-amber-500/20 text-amber-300 border-amber-500/30',
+  hard: 'bg-red-500/20 text-red-300 border-red-500/30',
+}
+
+interface BrowseResponse {
+  questions: QuestionBrowseRow[]
+  nextCursor: string | null
+}
+
+export function QuestionLibrary({ onBack }: QuestionLibraryProps) {
+  const { user } = useAuth()
+
+  // Stats state
+  const [stats, setStats] = useState<QuestionStats | null>(null)
+  const [statsLoading, setStatsLoading] = useState(true)
+  const [statsError, setStatsError] = useState<string | null>(null)
+
+  // Browser state
+  const [questions, setQuestions] = useState<QuestionBrowseRow[]>([])
+  const [browseLoading, setBrowseLoading] = useState(false)
+  const [browseError, setBrowseError] = useState<string | null>(null)
+  const [nextCursor, setNextCursor] = useState<string | null>(null)
+  const [hasLoaded, setHasLoaded] = useState(false)
+
+  // Filter/sort state
+  const [sort, setSort] = useState<SortOption>('newest')
+  const [category, setCategory] = useState<string>('')
+  const [difficulty, setDifficulty] = useState<Difficulty | ''>('')
+
+  // Load stats (no auth needed)
+  useEffect(() => {
+    async function loadStats() {
+      setStatsLoading(true)
+      setStatsError(null)
+      try {
+        const res = await fetch('/api/v1/trivia/questions/stats')
+        if (!res.ok) throw new Error('Failed to load stats')
+        const json = await res.json()
+        setStats(json)
+      } catch {
+        setStatsError('Failed to load stats.')
+      } finally {
+        setStatsLoading(false)
+      }
+    }
+    void loadStats()
+  }, [])
+
+  // Load questions (requires auth token)
+  async function loadQuestions(replace: boolean) {
+    setBrowseLoading(true)
+    setBrowseError(null)
+    try {
+      let token: string | null = null
+      if (user) {
+        token = await user.getIdToken()
+      }
+
+      const params = new URLSearchParams()
+      params.set('sort', sort)
+      params.set('limit', '20')
+      if (category) params.set('category', category)
+      if (difficulty) params.set('difficulty', difficulty)
+      if (!replace && nextCursor) params.set('cursor', nextCursor)
+
+      const res = await fetch(`/api/v1/trivia/questions?${params.toString()}`, {
+        headers: token ? { Authorization: `Bearer ${token}` } : {},
+      })
+      if (!res.ok) throw new Error('Failed to load questions')
+      const json: BrowseResponse = await res.json()
+
+      setQuestions((prev) => (replace ? json.questions : [...prev, ...json.questions]))
+      setNextCursor(json.nextCursor)
+      setHasLoaded(true)
+    } catch {
+      setBrowseError('Failed to load questions.')
+    } finally {
+      setBrowseLoading(false)
+    }
+  }
+
+  // Reload when filters/sort change
+  useEffect(() => {
+    void loadQuestions(true)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [sort, category, difficulty])
+
+  const categoryOptions = stats?.byCategory.map((c) => c.category) ?? []
+
+  return (
+    <div className="flex flex-col gap-6 max-w-2xl mx-auto py-8 px-4">
+      {/* Header */}
+      <div className="flex items-center gap-3">
+        <ChunkyButton variant="ghost" size="sm" onClick={onBack}>
+          ← Back
+        </ChunkyButton>
+        <h1 className="font-headline text-headline-md text-ds-tertiary">Question Library</h1>
+      </div>
+
+      {/* Stats Dashboard */}
+      <ChunkyCard variant="surface-container-high" cornerGlow="tertiary">
+        <ChunkyCardHeader>
+          <ChunkyCardTitle className="text-on-surface">Stats Dashboard</ChunkyCardTitle>
+        </ChunkyCardHeader>
+        <ChunkyCardContent>
+          {statsLoading && (
+            <p className="text-on-surface/50 text-sm">Loading stats…</p>
+          )}
+          {statsError && (
+            <p className="text-ds-error text-sm">{statsError}</p>
+          )}
+          {stats && (
+            <div className="flex flex-col gap-4">
+              {/* Top-level stats grid */}
+              <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+                <StatCell label="Total Questions" value={stats.totalQuestions.toLocaleString()} />
+                <StatCell label="Total Answered" value={stats.totalAnswered.toLocaleString()} />
+                <StatCell label="Avg Accuracy" value={`${stats.avgAccuracyPct}%`} />
+                <StatCell label="Added This Week" value={stats.questionsAddedThisWeek.toLocaleString()} />
+              </div>
+
+              {/* Difficulty breakdown */}
+              <div className="grid grid-cols-3 gap-3">
+                {DIFFICULTY_OPTIONS.map((diff) => {
+                  const d = stats.byDifficulty[diff]
+                  return (
+                    <div
+                      key={diff}
+                      className={`rounded-lg px-3 py-2 border text-center ${DIFFICULTY_COLORS[diff]}`}
+                    >
+                      <div className="text-xs uppercase tracking-widest mb-1 opacity-70">
+                        {diff}
+                      </div>
+                      <div className="font-bold text-lg">{d.count}</div>
+                      <div className="text-xs opacity-60">{d.avgAccuracy}% acc</div>
+                    </div>
+                  )
+                })}
+              </div>
+            </div>
+          )}
+        </ChunkyCardContent>
+      </ChunkyCard>
+
+      {/* Question Browser */}
+      <ChunkyCard variant="surface-container-high">
+        <ChunkyCardHeader>
+          <ChunkyCardTitle className="text-on-surface">Browse Questions</ChunkyCardTitle>
+        </ChunkyCardHeader>
+        <ChunkyCardContent>
+          <div className="flex flex-col gap-4">
+            {/* Sort + Filters */}
+            <div className="flex flex-wrap gap-2 items-center">
+              {/* Sort dropdown */}
+              <div className="flex items-center gap-1.5">
+                <label className="text-xs text-on-surface/50 uppercase tracking-widest whitespace-nowrap">
+                  Sort
+                </label>
+                <select
+                  value={sort}
+                  onChange={(e) => setSort(e.target.value as SortOption)}
+                  className="rounded-md bg-surface-variant/30 border border-outline-variant/40 text-on-surface text-sm px-2 py-1 focus:outline-none focus:border-ds-tertiary/60"
+                >
+                  {SORT_OPTIONS.map((opt) => (
+                    <option key={opt.value} value={opt.value}>
+                      {opt.label}
+                    </option>
+                  ))}
+                </select>
+              </div>
+
+              {/* Category filter */}
+              {categoryOptions.length > 0 && (
+                <div className="flex items-center gap-1.5">
+                  <label className="text-xs text-on-surface/50 uppercase tracking-widest whitespace-nowrap">
+                    Category
+                  </label>
+                  <select
+                    value={category}
+                    onChange={(e) => setCategory(e.target.value)}
+                    className="rounded-md bg-surface-variant/30 border border-outline-variant/40 text-on-surface text-sm px-2 py-1 focus:outline-none focus:border-ds-tertiary/60"
+                  >
+                    <option value="">All</option>
+                    {categoryOptions.map((cat) => (
+                      <option key={cat} value={cat}>
+                        {cat}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+              )}
+
+              {/* Difficulty chips */}
+              <div className="flex gap-1.5">
+                <button
+                  onClick={() => setDifficulty('')}
+                  className={`text-xs px-2.5 py-1 rounded-full border transition-colors ${
+                    difficulty === ''
+                      ? 'bg-ds-tertiary/20 text-ds-tertiary border-ds-tertiary/40'
+                      : 'bg-transparent text-on-surface/50 border-outline-variant/30 hover:border-outline-variant/60'
+                  }`}
+                >
+                  All
+                </button>
+                {DIFFICULTY_OPTIONS.map((diff) => (
+                  <button
+                    key={diff}
+                    onClick={() => setDifficulty(diff === difficulty ? '' : diff)}
+                    className={`text-xs px-2.5 py-1 rounded-full border transition-colors capitalize ${
+                      difficulty === diff
+                        ? DIFFICULTY_COLORS[diff]
+                        : 'bg-transparent text-on-surface/50 border-outline-variant/30 hover:border-outline-variant/60'
+                    }`}
+                  >
+                    {diff}
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            {/* Questions list */}
+            {browseLoading && !hasLoaded && (
+              <p className="text-on-surface/50 text-sm">Loading questions…</p>
+            )}
+            {browseError && (
+              <p className="text-ds-error text-sm">{browseError}</p>
+            )}
+
+            {!user && hasLoaded && (
+              <p className="text-on-surface/50 text-sm italic">
+                Sign in to see personalized spoiler protection.
+              </p>
+            )}
+
+            {hasLoaded && questions.length === 0 && !browseLoading && (
+              <p className="text-on-surface/50 text-sm">No questions found with these filters.</p>
+            )}
+
+            <div className="flex flex-col gap-3">
+              {questions.map((q) => (
+                <SpoilerCard
+                  key={q.id}
+                  questionId={q.id}
+                  questionText={q.question}
+                  userHasSeen={q.userHasSeen}
+                >
+                  <div className="flex flex-wrap items-center gap-2 mt-2">
+                    {/* Category badge */}
+                    <span className="text-xs px-2 py-0.5 rounded-full bg-surface-variant/40 text-on-surface/60 border border-outline-variant/30">
+                      {q.category}
+                    </span>
+                    {/* Difficulty badge */}
+                    <span
+                      className={`text-xs px-2 py-0.5 rounded-full border capitalize ${DIFFICULTY_COLORS[q.difficulty]}`}
+                    >
+                      {q.difficulty}
+                    </span>
+                    {/* Stats */}
+                    <div className="ml-auto flex gap-3 text-xs text-on-surface/50">
+                      <span title="Times shown">👁 {q.timesShown}</span>
+                      <span title="Accuracy">{q.accuracyPct}%</span>
+                      <span title="Likes">👍 {q.likeCount}</span>
+                      <span title="Dislikes">👎 {q.dislikeCount}</span>
+                    </div>
+                  </div>
+                </SpoilerCard>
+              ))}
+            </div>
+
+            {/* Load More */}
+            {nextCursor && !browseLoading && (
+              <ChunkyButton
+                variant="secondary"
+                size="md"
+                className="w-full"
+                onClick={() => void loadQuestions(false)}
+              >
+                Load More
+              </ChunkyButton>
+            )}
+            {browseLoading && hasLoaded && (
+              <p className="text-on-surface/50 text-sm text-center">Loading…</p>
+            )}
+          </div>
+        </ChunkyCardContent>
+      </ChunkyCard>
+    </div>
+  )
+}
+
+function StatCell({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-lg bg-surface-variant/20 px-3 py-3 text-center border border-outline-variant/20">
+      <div className="text-xl font-bold text-ds-tertiary">{value}</div>
+      <div className="text-xs text-on-surface/50 mt-0.5">{label}</div>
+    </div>
+  )
+}

--- a/src/app/trivia/components/TriviaLanding.tsx
+++ b/src/app/trivia/components/TriviaLanding.tsx
@@ -25,6 +25,7 @@ export function TriviaLanding({
   onViewInfiniteStats,
   onStartPractice,
   onViewInfiniteLeaderboard,
+  onLibrary,
   onStatsReset,
   todayResult,
 }: {
@@ -35,6 +36,7 @@ export function TriviaLanding({
   onViewInfiniteStats?: () => void
   onStartPractice?: () => void
   onViewInfiniteLeaderboard?: () => void
+  onLibrary?: () => void
   onStatsReset?: (scopes: ResetScopes) => void
   todayResult: TriviaGameResult | null
 }) {
@@ -252,6 +254,13 @@ export function TriviaLanding({
           className="text-ds-tertiary hover:text-ds-tertiary/80 transition-colors underline-offset-4 hover:underline"
         >
           Infinite Ranks
+        </button>
+        <span className="text-on-surface/20">·</span>
+        <button
+          onClick={onLibrary}
+          className="text-ds-tertiary hover:text-ds-tertiary/80 transition-colors underline-offset-4 hover:underline"
+        >
+          Question Library
         </button>
       </div>
 

--- a/src/app/trivia/page.tsx
+++ b/src/app/trivia/page.tsx
@@ -15,6 +15,7 @@ import { getDailyCategory } from '@/lib/trivia/categories'
 
 import { InfiniteGame } from './components/InfiniteGame'
 import { InfiniteLeaderboard } from './components/InfiniteLeaderboard'
+import { QuestionLibrary } from './components/QuestionLibrary'
 import { UnifiedStats } from './components/UnifiedStats'
 import { TriviaGame } from './components/TriviaGame'
 import { TriviaLanding } from './components/TriviaLanding'
@@ -24,7 +25,7 @@ import { TriviaResults } from './components/TriviaResults'
 import type { TriviaGameResult } from './models/trivia'
 import type { User } from 'firebase/auth'
 
-type View = 'landing' | 'playing' | 'results' | 'stats' | 'leaderboard' | 'infinite' | 'infinite-stats' | 'practice' | 'infinite-leaderboard'
+type View = 'landing' | 'playing' | 'results' | 'stats' | 'leaderboard' | 'infinite' | 'infinite-stats' | 'practice' | 'infinite-leaderboard' | 'library'
 
 type StatsDefaultTab = 'daily' | 'infinite'
 
@@ -111,6 +112,7 @@ export default function TriviaPage() {
       )
   }, [user, triviaLoading, firestoreToday, today])
 
+  const handleLibrary = () => setView('library')
   const handleStartGame = () => setView('playing')
   const handleViewStats = () => { setStatsDefaultTab('daily'); setView('stats') }
   const handleViewLeaderboard = () => setView('leaderboard')
@@ -189,6 +191,10 @@ export default function TriviaPage() {
     return <InfiniteLeaderboard onBack={handleBackToLanding} />
   }
 
+  if (view === 'library') {
+    return <QuestionLibrary onBack={handleBackToLanding} />
+  }
+
   return (
     <TriviaLanding
       onStartGame={handleStartGame}
@@ -198,6 +204,7 @@ export default function TriviaPage() {
       onViewInfiniteStats={handleViewInfiniteStats}
       onStartPractice={handleStartPractice}
       onViewInfiniteLeaderboard={handleViewInfiniteLeaderboard}
+      onLibrary={handleLibrary}
       onStatsReset={handleStatsReset}
       todayResult={todayResult}
     />


### PR DESCRIPTION
## Summary
Closes #1265 (child of Epic #1266 — Trivia Social & Discovery Features)

Adds a "Question Library" view — a browsable, filterable database of all AI-generated questions with a stats dashboard.

## Features

### Stats Dashboard
- Total questions, total answered, average accuracy, questions added this week
- Difficulty breakdown: easy/medium/hard counts with accuracy percentages
- Fetched from public stats API (no auth required)

### Question Browser
- **7 sort modes**: newest, oldest, most shown, liked, disliked, accuracy asc/desc
- **Category filter**: dropdown populated from stats data
- **Difficulty filter**: chip buttons (easy/medium/hard/All)
- **Spoiler protection**: unseen questions blurred via SpoilerCard
- **Pagination**: "Load More" with cursor-based API
- **Stats per question**: times shown, accuracy %, likes, dislikes

## Uses all Phase 1 infra
- Browsing API (#1267) for paginated question fetching
- Stats API (#1269) for the dashboard
- SpoilerCard (#1268) for spoiler protection

## Files changed
- **New**: `src/app/trivia/components/QuestionLibrary.tsx` (329 lines)
- **Modified**: `src/app/trivia/page.tsx` (+9 lines — added 'library' view)
- **Modified**: `src/app/trivia/components/TriviaLanding.tsx` (+9 lines — added "Question Library" link)

## Test plan
- [ ] "Question Library" link visible on trivia landing page
- [ ] Stats dashboard loads and displays all metrics
- [ ] Difficulty breakdown shows easy/medium/hard with counts
- [ ] Questions load with default sort (newest)
- [ ] Sort dropdown changes order correctly
- [ ] Category filter narrows results
- [ ] Difficulty chips filter correctly
- [ ] Unseen questions show blurred, revealable
- [ ] "Load More" paginates correctly
- [ ] Back button returns to landing

🤖 Generated with [Claude Code](https://claude.com/claude-code)