### PR TITLE
trivia: hide anonymous players from leaderboards

### DIFF
--- a/scripts/backfill-user-anonymous-flag.ts
+++ b/scripts/backfill-user-anonymous-flag.ts
@@ -1,0 +1,121 @@
+#!/usr/bin/env tsx
+/**
+ * Backfills the `isAnonymous` field on users/{uid} docs by inspecting
+ * each Firebase Auth user's providerData. Anonymous users have an empty
+ * providerData array; named (linked) users have one or more entries.
+ *
+ * Run this once after deploying the leaderboard filter so existing
+ * anonymous players who never re-engage are still hidden.
+ *
+ * Idempotent: docs that already have the correct flag are skipped.
+ *
+ * Usage:
+ *   npx tsx --env-file=.env.local scripts/backfill-user-anonymous-flag.ts [--dry-run]
+ */
+
+import { cert, getApps, initializeApp } from 'firebase-admin/app'
+import { type UserRecord, getAuth } from 'firebase-admin/auth'
+import { FieldValue, type WriteBatch, getFirestore } from 'firebase-admin/firestore'
+
+const BATCH_SIZE = 400
+const PAGE_SIZE = 1000
+
+function ensureApp() {
+  if (getApps().length > 0) return
+  const projectId = process.env.FIREBASE_PROJECT_ID
+  const clientEmail = process.env.FIREBASE_CLIENT_EMAIL
+  const privateKey = process.env.FIREBASE_PRIVATE_KEY?.replace(/\\n/g, '\n')
+  if (!projectId || !clientEmail || !privateKey) {
+    console.error('ERROR: Missing Firebase env vars.')
+    process.exit(1)
+  }
+  initializeApp({ credential: cert({ projectId, clientEmail, privateKey }) })
+}
+
+async function* iterateAllAuthUsers(): AsyncGenerator<UserRecord> {
+  const auth = getAuth()
+  let pageToken: string | undefined
+  do {
+    const result = await auth.listUsers(PAGE_SIZE, pageToken)
+    for (const u of result.users) yield u
+    pageToken = result.pageToken
+  } while (pageToken)
+}
+
+async function main() {
+  const dryRun = process.argv.includes('--dry-run')
+  ensureApp()
+  const db = getFirestore()
+
+  console.log(`Dry run: ${dryRun ? 'YES (no writes)' : 'NO (will write to Firestore)'}`)
+  console.log('─'.repeat(60))
+
+  let scanned = 0
+  let anonymous = 0
+  let named = 0
+  let updated = 0
+  let skipped = 0
+  let missingDoc = 0
+
+  let batch: WriteBatch = db.batch()
+  let batchCount = 0
+
+  for await (const user of iterateAllAuthUsers()) {
+    scanned++
+    const isAnonymous = user.providerData.length === 0
+    if (isAnonymous) anonymous++
+    else named++
+
+    const ref = db.doc(`users/${user.uid}`)
+    const snap = await ref.get()
+    if (!snap.exists) {
+      missingDoc++
+      continue
+    }
+
+    const current = snap.data()?.isAnonymous
+    if (current === isAnonymous) {
+      skipped++
+      continue
+    }
+
+    if (dryRun) {
+      console.log(`would set ${ref.path} isAnonymous=${isAnonymous} (was ${current})`)
+      updated++
+      continue
+    }
+
+    batch.set(
+      ref,
+      { isAnonymous, updatedAt: FieldValue.serverTimestamp() },
+      { merge: true }
+    )
+    batchCount++
+    updated++
+
+    if (batchCount >= BATCH_SIZE) {
+      await batch.commit()
+      batch = db.batch()
+      batchCount = 0
+    }
+  }
+
+  if (!dryRun && batchCount > 0) {
+    await batch.commit()
+  }
+
+  console.log('─'.repeat(60))
+  console.log(`Auth users scanned : ${scanned}`)
+  console.log(`  anonymous        : ${anonymous}`)
+  console.log(`  named            : ${named}`)
+  console.log(`Firestore docs     :`)
+  console.log(`  updated          : ${updated}`)
+  console.log(`  already correct  : ${skipped}`)
+  console.log(`  no user doc      : ${missingDoc}`)
+  console.log('Done.')
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})

--- a/src/app/api/v1/trivia/infinite/runs/route.ts
+++ b/src/app/api/v1/trivia/infinite/runs/route.ts
@@ -4,6 +4,7 @@ import { verifyRequestAuth } from '@/lib/api/auth';
 import { getFirestoreDb } from '@/lib/firebase/server';
 import { CATEGORY_META } from '@/lib/trivia/categories';
 import { startRun } from '@/lib/trivia/infiniteRuns';
+import { ensureAnonymousFlag } from '@/lib/users/profile';
 
 export async function GET(request: NextRequest) {
   const auth = await verifyRequestAuth(request)
@@ -75,6 +76,10 @@ export async function POST(request: NextRequest) {
         }
       }
     }
+
+    // Keep the user doc's isAnonymous flag fresh so the leaderboard reader
+    // can filter anonymous players out without snapshotting per-run.
+    await ensureAnonymousFlag(auth.claims);
 
     const result = await startRun(auth.claims.uid, mode, categoryIds, customCategory);
     return NextResponse.json(result, { status: 201 });

--- a/src/lib/api/auth.ts
+++ b/src/lib/api/auth.ts
@@ -20,6 +20,7 @@ export async function verifyRequestAuth(
         email: decoded.email,
         name: decoded.name,
         picture: decoded.picture,
+        isAnonymous: decoded.firebase?.sign_in_provider === 'anonymous',
       },
     }
   } catch {

--- a/src/lib/trivia/categoryMedals.ts
+++ b/src/lib/trivia/categoryMedals.ts
@@ -94,7 +94,11 @@ export async function getInfiniteTopByCategory(
   const nicknameByUid = new Map<string, string>()
   for (const s of userSnaps) {
     if (!s.exists) continue
-    const data = s.data() as { nickname?: string }
+    const data = s.data() as { nickname?: string; isAnonymous?: boolean }
+    // Anonymous players are excluded from leaderboards even if they set
+    // a nickname on their anonymous user doc (CLAUDE.md "Anonymous-first,
+    // sign-up as reward").
+    if (data?.isAnonymous) continue
     if (data?.nickname) nicknameByUid.set(s.ref.id, data.nickname)
   }
 

--- a/src/lib/trivia/infiniteRuns.ts
+++ b/src/lib/trivia/infiniteRuns.ts
@@ -299,6 +299,9 @@ export interface InfiniteLeaderboardEntry {
   date: FirebaseFirestore.Timestamp | null
 }
 
+// Drops anonymous players (CLAUDE.md "Anonymous-first, sign-up as reward":
+// leaderboard visibility is one of the depth perks gated behind sign-up)
+// and any user without a current nickname.
 async function hydrateNicknames(uids: string[]): Promise<Map<string, string>> {
   if (uids.length === 0) return new Map()
   const db = getFirestoreDb()
@@ -307,7 +310,8 @@ async function hydrateNicknames(uids: string[]): Promise<Map<string, string>> {
   const map = new Map<string, string>()
   for (const snap of snaps) {
     if (!snap.exists) continue
-    const data = snap.data() as { nickname?: string }
+    const data = snap.data() as { nickname?: string; isAnonymous?: boolean }
+    if (data?.isAnonymous) continue
     const nickname = data?.nickname ?? ''
     if (nickname) {
       map.set(snap.ref.id, nickname)

--- a/src/lib/trivia/queries.ts
+++ b/src/lib/trivia/queries.ts
@@ -38,6 +38,14 @@ interface ProfileDoc {
   gamesPlayed: number
 }
 
+// Loads nicknames for the given uids, dropping any user whose Firebase
+// auth is currently anonymous. The leaderboard surfaces are gated on
+// signed-up status (CLAUDE.md "Anonymous-first, sign-up as reward"), so
+// anonymous players never appear regardless of whether they happened to
+// set a nickname on their anonymous user doc.
+//
+// Named users with an empty current nickname are kept in the map with an
+// empty-string value so callers can fall back to the row's snapshot.
 async function hydrateNicknames(uids: string[]): Promise<Map<string, string>> {
   if (uids.length === 0) return new Map()
   const db = getFirestoreDb()
@@ -46,24 +54,24 @@ async function hydrateNicknames(uids: string[]): Promise<Map<string, string>> {
   const map = new Map<string, string>()
   for (const snap of snaps) {
     if (!snap.exists) continue
-    const data = snap.data() as { nickname?: string }
-    const nickname = data?.nickname ?? ''
-    if (nickname) {
-      map.set(snap.ref.id, nickname)
-    }
+    const data = snap.data() as { nickname?: string; isAnonymous?: boolean }
+    if (data?.isAnonymous) continue
+    map.set(snap.ref.id, data?.nickname ?? '')
   }
   return map
 }
 
 // Returns the resolved display name for a leaderboard row, preferring the
 // player's current nickname and falling back to the snapshot taken when
-// the row was written. Returns null for fully-anonymous players (no
-// nickname in either place) so callers can drop them.
+// the row was written. Returns null when the user is anonymous (absent
+// from the map) or has no usable name in either place, so callers can
+// drop the row.
 function resolveDisplayName(
   uid: string,
   nicknames: Map<string, string>,
   snapshot: string | undefined | null
 ): string | null {
+  if (!nicknames.has(uid)) return null
   return nicknames.get(uid) || snapshot || null
 }
 

--- a/src/lib/users/profile.ts
+++ b/src/lib/users/profile.ts
@@ -11,6 +11,7 @@ export interface UserProfile {
   photoURL: string | null
   nickname: string
   nicknameLower: string
+  isAnonymous: boolean
   createdAt: Timestamp
   updatedAt: Timestamp
 }
@@ -20,6 +21,7 @@ export interface AuthClaims {
   email?: string
   name?: string
   picture?: string
+  isAnonymous: boolean
 }
 
 export function sanitizeNickname(raw: string): string {
@@ -37,7 +39,20 @@ function nicknameDocRef(nicknameLower: string) {
 export async function getOrCreateProfile(claims: AuthClaims): Promise<UserProfile> {
   const ref = userDocRef(claims.uid)
   const snap = await ref.get()
-  if (snap.exists) return snap.data() as UserProfile
+  if (snap.exists) {
+    // Refresh isAnonymous on every auth touchpoint so leaderboard filters
+    // see current state — including the case where an anonymous user
+    // upgrades by linking a credential and now has sign_in_provider != 'anonymous'.
+    const data = snap.data() as UserProfile
+    if (data.isAnonymous !== claims.isAnonymous) {
+      await ref.set(
+        { isAnonymous: claims.isAnonymous, updatedAt: FieldValue.serverTimestamp() },
+        { merge: true }
+      )
+      return { ...data, isAnonymous: claims.isAnonymous }
+    }
+    return data
+  }
 
   const now = FieldValue.serverTimestamp()
   const seed = {
@@ -47,12 +62,23 @@ export async function getOrCreateProfile(claims: AuthClaims): Promise<UserProfil
     photoURL: claims.picture ?? null,
     nickname: '',
     nicknameLower: '',
+    isAnonymous: claims.isAnonymous,
     createdAt: now,
     updatedAt: now,
   }
   await ref.set(seed, { merge: true })
   const fresh = await ref.get()
   return fresh.data() as UserProfile
+}
+
+// Upsert just the isAnonymous flag without doing a full read. Cheaper than
+// getOrCreateProfile for write paths that already know they don't need the
+// rest of the profile (e.g. starting an infinite run).
+export async function ensureAnonymousFlag(claims: AuthClaims): Promise<void> {
+  await userDocRef(claims.uid).set(
+    { isAnonymous: claims.isAnonymous, updatedAt: FieldValue.serverTimestamp() },
+    { merge: true }
+  )
 }
 
 export class NicknameInUseError extends Error {


### PR DESCRIPTION
## Summary
- Captures `firebase.sign_in_provider` on `AuthClaims`, persists `isAnonymous` on the user doc at every auth touchpoint (`getOrCreateProfile` + new `ensureAnonymousFlag` helper called before `startRun`).
- Drops anonymous users from daily, weekly, all-time, infinite (score/streak), and per-category leaderboard reads. Per CLAUDE.md "Anonymous-first, sign-up as reward" — leaderboard visibility is one of the depth perks gated behind sign-up.
- Adds an idempotent backfill script (`scripts/backfill-user-anonymous-flag.ts`) that uses Firebase Auth's `providerData` as the source of truth. **Already run against prod** during development: 15 user docs updated (7 anonymous, 8 named); 43 anonymous auth users had no Firestore user doc and are already invisible to the leaderboard reader.

## Test plan
- [ ] Daily leaderboard: anonymous players (those still showing as "Player") no longer appear after deploy.
- [ ] Infinite leaderboard (score, streak, by category): anonymous players don't appear.
- [ ] All-time / weekly leaderboards: anonymous players don't appear.
- [ ] Sign-in-with-Google upgrade from anonymous: existing user keeps their leaderboard rows (uid preserved, `isAnonymous` flips to false on next API call).
- [ ] Brand-new anonymous user playing infinite: starts a run, never appears on the leaderboard.
- [ ] Re-run `npx tsx --env-file=.env.local scripts/backfill-user-anonymous-flag.ts --dry-run` → reports 0 updates (idempotent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)