### PR TITLE
trivia: fix medal tracking for prefixed category names + add custom-topic medals

### DIFF
--- a/src/app/api/v1/trivia/infinite/category-stats/route.ts
+++ b/src/app/api/v1/trivia/infinite/category-stats/route.ts
@@ -1,15 +1,21 @@
 import { type NextRequest, NextResponse } from 'next/server'
 
 import { verifyRequestAuth } from '@/lib/api/auth'
-import { getCategoryMedalsForUser } from '@/lib/trivia/categoryMedals'
+import {
+  getCategoryMedalsForUser,
+  getCustomCategoryMedalsForUser,
+} from '@/lib/trivia/categoryMedals'
 
 export async function GET(request: NextRequest) {
   const auth = await verifyRequestAuth(request)
   if ('error' in auth) return auth.error
 
   try {
-    const medals = await getCategoryMedalsForUser(auth.claims.uid)
-    return NextResponse.json({ medals })
+    const [medals, customMedals] = await Promise.all([
+      getCategoryMedalsForUser(auth.claims.uid),
+      getCustomCategoryMedalsForUser(auth.claims.uid),
+    ])
+    return NextResponse.json({ medals, customMedals })
   } catch (err) {
     console.error('Failed to fetch category medals:', err)
     return NextResponse.json({ error: 'Failed to fetch category medals.' }, { status: 500 })

--- a/src/lib/trivia/__tests__/medals.test.ts
+++ b/src/lib/trivia/__tests__/medals.test.ts
@@ -3,8 +3,12 @@ import { describe, expect, it } from 'vitest'
 import { CATEGORY_META, getCategoryIdByName } from '@/lib/trivia/categories'
 import {
   CATEGORY_MEDAL_LADDERS,
+  CUSTOM_CATEGORY_MEDAL_LADDER,
   MEDAL_THRESHOLDS,
+  customCategorySlug,
+  detectCustomMedalEarned,
   detectMedalEarned,
+  getCustomCategoryMedalLabel,
   getMedalLabel,
   getMedalTier,
   getNextThreshold,
@@ -121,12 +125,76 @@ describe('detectMedalEarned', () => {
   })
 })
 
+describe('custom-topic medals', () => {
+  it('reuses the shared 5-tier threshold ladder', () => {
+    expect(CUSTOM_CATEGORY_MEDAL_LADDER).toHaveLength(5)
+  })
+
+  it('getCustomCategoryMedalLabel returns null for "none"', () => {
+    expect(getCustomCategoryMedalLabel('none')).toBeNull()
+  })
+
+  it('getCustomCategoryMedalLabel returns the same ladder for every topic', () => {
+    expect(getCustomCategoryMedalLabel('bronze')).toBe(CUSTOM_CATEGORY_MEDAL_LADDER[0])
+    expect(getCustomCategoryMedalLabel('diamond')).toBe(CUSTOM_CATEGORY_MEDAL_LADDER[4])
+  })
+
+  it('detectCustomMedalEarned mirrors detectMedalEarned at threshold crossings', () => {
+    expect(detectCustomMedalEarned(0, 1)).toBeNull()
+    expect(detectCustomMedalEarned(15, 16)).toEqual({
+      tier: 'bronze',
+      label: CUSTOM_CATEGORY_MEDAL_LADDER[0],
+    })
+    expect(detectCustomMedalEarned(4095, 4096)).toEqual({
+      tier: 'diamond',
+      label: CUSTOM_CATEGORY_MEDAL_LADDER[4],
+    })
+  })
+
+  describe('customCategorySlug', () => {
+    it('produces stable ids for plain topics', () => {
+      expect(customCategorySlug('norse mythology')).toBe('norse%20mythology')
+    })
+
+    it('escapes characters that Firestore cannot store in a doc id', () => {
+      expect(customCategorySlug('rock/pop')).not.toContain('/')
+      expect(customCategorySlug('a.b')).not.toContain('.')
+    })
+
+    it('never collides for distinct topics', () => {
+      const topics = ['music', 'Music', 'music ', 'mu/sic', 'mu.sic', '']
+      const slugs = new Set(topics.map(customCategorySlug))
+      expect(slugs.size).toBe(topics.length)
+    })
+  })
+})
+
 describe('getCategoryIdByName', () => {
   it('round-trips every CATEGORY_META entry', () => {
     for (const id of Object.keys(CATEGORY_META).map(Number)) {
       const name = CATEGORY_META[id].name
       expect(getCategoryIdByName(name)).toBe(id)
     }
+  })
+
+  // Questions are stamped with the OpenTDB-prefixed name from
+  // src/app/trivia/data/seeds/categoryNames.ts, not the bare CATEGORY_META
+  // name. Both must resolve to the same id or medal tracking silently
+  // skips most categories.
+  it('resolves OpenTDB-prefixed category names', () => {
+    expect(getCategoryIdByName('Entertainment: Books')).toBe(10)
+    expect(getCategoryIdByName('Entertainment: Film')).toBe(11)
+    expect(getCategoryIdByName('Entertainment: Music')).toBe(12)
+    expect(getCategoryIdByName('Entertainment: Musicals & Theatres')).toBe(13)
+    expect(getCategoryIdByName('Entertainment: Television')).toBe(14)
+    expect(getCategoryIdByName('Entertainment: Video Games')).toBe(15)
+    expect(getCategoryIdByName('Entertainment: Board Games')).toBe(16)
+    expect(getCategoryIdByName('Science: Computers')).toBe(18)
+    expect(getCategoryIdByName('Science: Mathematics')).toBe(19)
+    expect(getCategoryIdByName('Entertainment: Comics')).toBe(29)
+    expect(getCategoryIdByName('Science: Gadgets')).toBe(30)
+    expect(getCategoryIdByName('Entertainment: Japanese Anime & Manga')).toBe(31)
+    expect(getCategoryIdByName('Entertainment: Cartoon & Animations')).toBe(32)
   })
 
   it('returns null for unknown names', () => {

--- a/src/lib/trivia/__tests__/resetStats.test.ts
+++ b/src/lib/trivia/__tests__/resetStats.test.ts
@@ -230,4 +230,20 @@ describe('resetInfiniteStats', () => {
 
     expect(store.listCollection(`users/${UID}/triviaInfinite`)).toHaveLength(0)
   })
+
+  it('also wipes per-topic custom-category medal stats', async () => {
+    store.set(`users/${UID}/triviaCustomCategoryStats/norse%20mythology`, {
+      topic: 'norse mythology',
+      correctCount: 25,
+    })
+    store.set(`users/${UID}/triviaCustomCategoryStats/the%20office`, {
+      topic: 'the office',
+      correctCount: 8,
+    })
+
+    const res = await resetInfiniteStats(UID)
+
+    expect(res.deletedDocs).toBe(2)
+    expect(store.listCollection(`users/${UID}/triviaCustomCategoryStats`)).toHaveLength(0)
+  })
 })

--- a/src/lib/trivia/categories.ts
+++ b/src/lib/trivia/categories.ts
@@ -46,13 +46,32 @@ export function getDailyCategory(dateStr?: string): DailyCategory {
   return { id, name: meta.name, icon: meta.icon }
 }
 
-const CATEGORY_NAME_TO_ID: ReadonlyMap<string, number> = new Map(
-  Object.entries(CATEGORY_META).map(([id, meta]) => [meta.name, Number(id)])
-)
+// Questions store their category as the OpenTDB-prefixed name returned by
+// getOpenTDBCategoryName() in src/app/trivia/data/seeds/categoryNames.ts
+// (e.g. "Entertainment: Books", "Science: Computers"), not the bare
+// CATEGORY_META name. This map covers both forms so medal tracking matches
+// either spelling — including the OpenTDB pluralization quirks
+// ("Theatres", "Cartoon & Animations") that don't match CATEGORY_META.
+const CATEGORY_NAME_TO_ID: ReadonlyMap<string, number> = new Map<string, number>([
+  ...Object.entries(CATEGORY_META).map(([id, meta]) => [meta.name, Number(id)] as const),
+  ['Entertainment: Books', 10],
+  ['Entertainment: Film', 11],
+  ['Entertainment: Music', 12],
+  ['Entertainment: Musicals & Theatres', 13],
+  ['Entertainment: Television', 14],
+  ['Entertainment: Video Games', 15],
+  ['Entertainment: Board Games', 16],
+  ['Science: Computers', 18],
+  ['Science: Mathematics', 19],
+  ['Entertainment: Comics', 29],
+  ['Science: Gadgets', 30],
+  ['Entertainment: Japanese Anime & Manga', 31],
+  ['Entertainment: Cartoon & Animations', 32],
+])
 
 // Reverse lookup for the question.category string stored on aiQuestions docs.
-// Returns null when the name doesn't match a known category (e.g. legacy
-// questions tagged with a free-form topic).
+// Returns null when the name doesn't match a known category (e.g. a custom
+// free-form topic from an infinite run with customCategory set).
 export function getCategoryIdByName(name: string): number | null {
   return CATEGORY_NAME_TO_ID.get(name) ?? null
 }

--- a/src/lib/trivia/categoryMedals.ts
+++ b/src/lib/trivia/categoryMedals.ts
@@ -2,6 +2,7 @@ import { getFirestoreDb } from '@/lib/firebase/server'
 import { CATEGORY_META } from '@/lib/trivia/categories'
 import {
   type MedalTier,
+  getCustomCategoryMedalLabel,
   getMedalLabel,
   getMedalTier,
   getNextThreshold,
@@ -138,4 +139,41 @@ export async function getInfiniteLeaderboardAllCategories(
     })
   )
   return sections.filter((s) => s.entries.length > 0)
+}
+
+export interface CustomCategoryMedalSummary {
+  topic: string
+  correctCount: number
+  tier: MedalTier
+  label: string | null
+  nextThreshold: number | null
+}
+
+// Returns one summary per custom topic the user has played in scored mode,
+// sorted by correctCount descending. Unlike preset categories we don't
+// pre-seed empty entries — the set of topics is open-ended and only those
+// the user has actually played are meaningful.
+export async function getCustomCategoryMedalsForUser(
+  uid: string
+): Promise<CustomCategoryMedalSummary[]> {
+  const db = getFirestoreDb()
+  const snap = await db.collection(`users/${uid}/triviaCustomCategoryStats`).get()
+
+  const summaries: CustomCategoryMedalSummary[] = []
+  for (const doc of snap.docs) {
+    const data = doc.data() as { topic?: string; correctCount?: number }
+    const topic = typeof data.topic === 'string' ? data.topic : ''
+    if (!topic) continue
+    const correctCount = data.correctCount ?? 0
+    const tier = getMedalTier(correctCount)
+    summaries.push({
+      topic,
+      correctCount,
+      tier,
+      label: getCustomCategoryMedalLabel(tier),
+      nextThreshold: getNextThreshold(tier),
+    })
+  }
+  summaries.sort((a, b) => b.correctCount - a.correctCount)
+  return summaries
 }

--- a/src/lib/trivia/infiniteRuns.ts
+++ b/src/lib/trivia/infiniteRuns.ts
@@ -4,7 +4,12 @@ import { LIVES_START, applyAnswer } from '@/app/trivia/lib/infiniteScoring'
 import type { AnswerResult } from '@/app/trivia/lib/infiniteScoring'
 import { getFirestoreDb } from '@/lib/firebase/server'
 import { getCategoryIdByName } from '@/lib/trivia/categories'
-import { type MedalEarned, detectMedalEarned } from '@/lib/trivia/medals'
+import {
+  type MedalEarned,
+  customCategorySlug,
+  detectCustomMedalEarned,
+  detectMedalEarned,
+} from '@/lib/trivia/medals'
 import { buildMarkSeenWrite } from '@/lib/trivia/triviaState'
 import { applyRunToAggregate } from '@/lib/trivia/triviaStats'
 
@@ -108,13 +113,28 @@ export async function submitAnswer(params: {
     // Trailblazer: if timesShown was 0 before this answer
     const isTrailblazer = correct && (qData.timesShown ?? 0) === 0
 
-    // Resolve categoryId for medal tracking. Only correct answers in scored
-    // mode count toward medals; questions tagged with an unknown category
-    // string are silently skipped.
-    const categoryId = typeof qData.category === 'string' ? getCategoryIdByName(qData.category) : null
-    const eligibleForMedal = correct && run.mode === 'scored' && categoryId !== null
-    const medalStatsRef = eligibleForMedal
+    // Resolve the medal track for this answer. Only correct answers in
+    // scored mode count. Custom-topic runs win medals on their own per-topic
+    // track; preset-category runs win medals keyed by categoryId. The two
+    // paths are mutually exclusive — a run with run.customCategory set
+    // never produces preset-category medals, even if its question's category
+    // string happens to match a known preset.
+    const customTopic =
+      typeof run.customCategory === 'string' && run.customCategory.length > 0
+        ? run.customCategory
+        : null
+    const categoryId =
+      customTopic === null && typeof qData.category === 'string'
+        ? getCategoryIdByName(qData.category)
+        : null
+    const scoredAndCorrect = correct && run.mode === 'scored'
+    const eligibleForCategoryMedal = scoredAndCorrect && categoryId !== null
+    const eligibleForCustomMedal = scoredAndCorrect && customTopic !== null
+
+    const medalStatsRef = eligibleForCategoryMedal
       ? db.doc(`users/${uid}/triviaCategoryStats/${categoryId}`)
+      : eligibleForCustomMedal
+      ? db.doc(`users/${uid}/triviaCustomCategoryStats/${customCategorySlug(customTopic!)}`)
       : null
     const medalStatsSnap = medalStatsRef ? await tx.get(medalStatsRef) : null
     const prevCorrectCount = medalStatsSnap?.exists ? (medalStatsSnap.data()?.correctCount ?? 0) : 0
@@ -159,9 +179,9 @@ export async function submitAnswer(params: {
     // Write answeredBy reverse index
     tx.set(answeredByRef, { uid, runId, correct, at: now })
 
-    // Update or create the per-category medal aggregate.
+    // Update or create the medal aggregate for whichever track applies.
     let medalEarned: MedalEarned | null = null
-    if (eligibleForMedal && medalStatsRef && categoryId !== null) {
+    if (eligibleForCategoryMedal && medalStatsRef && categoryId !== null) {
       const newCorrectCount = prevCorrectCount + 1
       const earned = detectMedalEarned(prevCorrectCount, newCorrectCount, categoryId)
 
@@ -193,6 +213,40 @@ export async function submitAnswer(params: {
           categoryId,
           categoryName,
           correctCount: newCorrectCount,
+        }
+      }
+    } else if (eligibleForCustomMedal && medalStatsRef && customTopic !== null) {
+      const newCorrectCount = prevCorrectCount + 1
+      const earned = detectCustomMedalEarned(prevCorrectCount, newCorrectCount)
+
+      const baseUpdates: FirebaseFirestore.UpdateData<FirebaseFirestore.DocumentData> = {
+        topic: customTopic,
+        correctCount: FieldValue.increment(1),
+        lastAnswerAt: now,
+      }
+      if (earned) {
+        baseUpdates.lastTierEarnedAt = now
+      }
+
+      if (medalStatsSnap?.exists) {
+        tx.update(medalStatsRef, baseUpdates)
+      } else {
+        tx.set(medalStatsRef, {
+          topic: customTopic,
+          correctCount: 1,
+          lastAnswerAt: now,
+          lastTierEarnedAt: earned ? now : null,
+        })
+      }
+
+      if (earned) {
+        medalEarned = {
+          tier: earned.tier,
+          label: earned.label,
+          categoryId: null,
+          categoryName: customTopic,
+          correctCount: newCorrectCount,
+          customTopic,
         }
       }
     }

--- a/src/lib/trivia/medals.ts
+++ b/src/lib/trivia/medals.ts
@@ -109,10 +109,74 @@ export interface CategoryMedalStats {
 }
 
 // Returned from submitAnswer when an answer crosses a tier line. Client-safe.
+// Preset-category medals carry a categoryId; custom-topic medals leave it
+// null and supply customTopic. categoryName is whatever the UI should
+// display ("Music", or the user's topic string).
 export interface MedalEarned {
   tier: MedalTier
   label: string
-  categoryId: number
+  categoryId: number | null
   categoryName: string
   correctCount: number
+  customTopic?: string
+}
+
+// --- Custom-topic medals -------------------------------------------------
+//
+// Infinite runs can be played against a user-supplied topic instead of a
+// preset category. Those runs stamp their questions with `qData.category`
+// equal to the raw topic string, which getCategoryIdByName() (correctly)
+// won't resolve. We give those runs their own medal track keyed by topic.
+
+// Stored at users/{uid}/triviaCustomCategoryStats/{slug}. The original
+// topic string lives on the doc so callers don't have to round-trip the
+// slug. Same threshold ladder as preset categories — only the labels and
+// the keying differ.
+export interface CustomCategoryMedalStats {
+  topic: string
+  correctCount: number
+  lastAnswerAt: FirebaseFirestore.Timestamp | null
+  lastTierEarnedAt: FirebaseFirestore.Timestamp | null
+}
+
+// Single shared ladder for every custom topic. Preset categories get
+// bespoke honorifics; custom topics share this generic progression because
+// the topic itself is the personalization.
+export const CUSTOM_CATEGORY_MEDAL_LADDER: [string, string, string, string, string] = [
+  'Curious',
+  'Initiate',
+  'Devotee',
+  'Loremaster',
+  'Oracle',
+]
+
+// Build a Firestore-safe doc id from a free-form topic. encodeURIComponent
+// covers `/`, whitespace, and most punctuation; `.` is escaped explicitly
+// because Firestore rejects ids of `.` / `..` and we want stable behavior
+// for topics that contain dots. The encoding is reversible, so two
+// distinct topics never collide on the same slug.
+export function customCategorySlug(topic: string): string {
+  return encodeURIComponent(topic).replaceAll('.', '%2E')
+}
+
+export function getCustomCategoryMedalLabel(tier: MedalTier): string | null {
+  if (tier === 'none') return null
+  const idx = TIER_ORDER.indexOf(tier)
+  if (idx === -1) return null
+  return CUSTOM_CATEGORY_MEDAL_LADDER[idx]
+}
+
+// Pure tier-up detection for custom-topic runs. Mirrors detectMedalEarned
+// but pulls labels from the shared custom ladder.
+export function detectCustomMedalEarned(
+  prevCorrectCount: number,
+  newCorrectCount: number
+): { tier: MedalTier; label: string } | null {
+  const prevTier = getMedalTier(prevCorrectCount)
+  const newTier = getMedalTier(newCorrectCount)
+  if (newTier === prevTier) return null
+  if (newTier === 'none') return null
+  const label = getCustomCategoryMedalLabel(newTier)
+  if (!label) return null
+  return { tier: newTier, label }
 }

--- a/src/lib/trivia/resetStats.ts
+++ b/src/lib/trivia/resetStats.ts
@@ -88,9 +88,10 @@ export async function resetDailyStats(uid: string): Promise<DailyResetResult> {
 
 /**
  * Wipes a user's infinite-trivia stats: lifetime aggregate, all run docs
- * (including any in-progress run), and per-category medal counters. Leaves
- * `seenQuestions` intact so the no-repeat filter still works, and leaves the
- * `aiQuestions/{qid}/answeredBy` analytics breadcrumb alone.
+ * (including any in-progress run), per-category medal counters, and custom-
+ * topic medal counters. Leaves `seenQuestions` intact so the no-repeat
+ * filter still works, and leaves the `aiQuestions/{qid}/answeredBy`
+ * analytics breadcrumb alone.
  */
 export async function resetInfiniteStats(uid: string): Promise<InfiniteResetResult> {
   const db = getFirestoreDb()
@@ -105,6 +106,7 @@ export async function resetInfiniteStats(uid: string): Promise<InfiniteResetResu
 
   deletedDocs += await chunkedDeleteAll(db, db.collection(`users/${uid}/triviaInfinite`))
   deletedDocs += await chunkedDeleteAll(db, db.collection(`users/${uid}/triviaCategoryStats`))
+  deletedDocs += await chunkedDeleteAll(db, db.collection(`users/${uid}/triviaCustomCategoryStats`))
 
   return { deletedDocs }
 }


### PR DESCRIPTION
## Summary

- **Bug fix:** medal tracking silently skipped 13 of 24 preset categories. Questions are stamped with OpenTDB-prefixed names like \`Entertainment: Books\` and \`Science: Computers\`, but \`getCategoryIdByName()\` only knew the bare \`CATEGORY_META\` names — so only the 11 categories whose OpenTDB form happens to be unprefixed (General Knowledge, Science & Nature, Mythology, Sports, Geography, History, Politics, Art, Celebrities, Animals, Vehicles) ever wrote to \`triviaCategoryStats\`. The lookup now accepts both spellings.
- **New medal track for custom topics.** Custom-category infinite runs (\`run.customCategory\` set) now write to \`users/{uid}/triviaCustomCategoryStats/{slug}\`, keyed by an \`encodeURIComponent\`-based slug of the topic string. Same 16/64/256/1024/4096 thresholds; one shared ladder for all topics: **Curious / Initiate / Devotee / Loremaster / Oracle**. The preset and custom paths are mutually exclusive — a custom run never produces preset-category medals even if its topic string happens to match a preset name.
- \`MedalEarned\` is now \`categoryId: number | null\` + optional \`customTopic\`. The existing UI toast (\`\${earned.label} — \${earned.categoryName}\`) renders correctly for both: \`categoryName\` carries the topic for custom medals.
- \`GET /api/v1/trivia/infinite/category-stats\` now returns \`{ medals, customMedals }\`. Visual surfacing of \`customMedals\` is intentionally a follow-up.
- \`resetInfiniteStats\` wipes the new collection too.

## Test plan

- [x] \`npx vitest run src/lib/trivia src/app/trivia\` — all 99 tests pass; new coverage for OpenTDB-name resolution, the custom ladder, slug collision-resistance, and reset of \`triviaCustomCategoryStats\`.
- [x] \`npx tsc --noEmit\` — no type errors in any trivia or medal-related file (pre-existing daily-card-game errors are unrelated).
- [x] \`npx eslint\` on touched files — clean.
- [ ] Manual: play an infinite run in a previously-broken preset (e.g. Music) past 16 correct answers and confirm the bronze medal toast fires + \`triviaCategoryStats/12\` is written.
- [ ] Manual: play a custom-topic run past 16 correct answers and confirm the bronze toast fires (\`🥉 Curious — <topic>\`) + \`triviaCustomCategoryStats/<slug>\` is written.

🤖 Generated with [Claude Code](https://claude.com/claude-code)