### PR TITLE
feat: implement Erratic Deck

### DIFF
--- a/src/app/comet-cards/domain/decks/__tests__/erratic-deck.test.ts
+++ b/src/app/comet-cards/domain/decks/__tests__/erratic-deck.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest'
+
+import { erraticDeck, generateErraticDeckCards } from '@/app/comet-cards/domain/decks/erratic-deck'
+import { CardValue } from '@/app/comet-cards/domain/playing-card/types'
+
+const ALL_VALUES: CardValue[] = ['2', '3', '4', '5', '6', '7', '8', '9', '10', 'J', 'Q', 'K', 'A']
+const ALL_SUITS = ['hearts', 'diamonds', 'clubs', 'spades']
+
+describe('Erratic Deck', () => {
+  it('has correct metadata', () => {
+    expect(erraticDeck.id).toBe('erraticDeck')
+    expect(erraticDeck.name).toBe('Erratic Deck')
+    expect(erraticDeck.modifiers).toEqual({})
+  })
+
+  it('generates 52 cards', () => {
+    const cards = generateErraticDeckCards('test-seed')
+    expect(cards).toHaveLength(52)
+  })
+
+  it('generates cards with valid ranks and suits', () => {
+    const cards = generateErraticDeckCards('test-seed')
+    for (const card of cards) {
+      expect(ALL_VALUES).toContain(card.value)
+      expect(ALL_SUITS).toContain(card.suit)
+    }
+  })
+
+  it('generates deterministic cards for the same seed', () => {
+    const cards1 = generateErraticDeckCards('seed-abc')
+    const cards2 = generateErraticDeckCards('seed-abc')
+    expect(cards1).toEqual(cards2)
+  })
+
+  it('generates different cards for different seeds', () => {
+    const cards1 = generateErraticDeckCards('seed-one')
+    const cards2 = generateErraticDeckCards('seed-two')
+    const sameCount = cards1.filter(
+      (card, i) => card.value === cards2[i].value && card.suit === cards2[i].suit,
+    ).length
+    expect(sameCount).toBeLessThan(52)
+  })
+})

--- a/src/app/comet-cards/domain/decks/decks.ts
+++ b/src/app/comet-cards/domain/decks/decks.ts
@@ -6,6 +6,7 @@ import { abandonedDeck } from './abandoned-deck'
 import { blackDeck } from './black-deck'
 import { blueDeck } from './blue-deck'
 import { checkeredDeck } from './checkered-deck'
+import { erraticDeck, generateErraticDeckCards } from './erratic-deck'
 import { greenDeck } from './green-deck'
 import { paintedDeck } from './painted-deck'
 import { pokerDeck } from './poker-deck'
@@ -23,12 +24,16 @@ export const decks: Record<string, DeckDefinition> = {
   checkeredDeck: checkeredDeck,
   paintedDeck: paintedDeck,
   greenDeck: greenDeck,
+  erraticDeck: erraticDeck,
 }
 
 export const initialDeckStates = (game: GameState): Record<string, PlayingCardState[]> => {
   const result: Record<string, PlayingCardState[]> = {}
   for (const [key, deck] of Object.entries(decks)) {
-    result[key] = deck.cards.map(card => initializePlayingCard(card, game))
+    const cards = key === 'erraticDeck'
+      ? generateErraticDeckCards(game.gameSeed)
+      : deck.cards
+    result[key] = cards.map(card => initializePlayingCard(card, game))
   }
   return result
 }

--- a/src/app/comet-cards/domain/decks/erratic-deck.ts
+++ b/src/app/comet-cards/domain/decks/erratic-deck.ts
@@ -1,0 +1,40 @@
+import { getDefaultCard } from '@/app/comet-cards/domain/playing-card/playing-cards'
+import { CardValue, PlayingCardDefinition } from '@/app/comet-cards/domain/playing-card/types'
+import {
+  buildSeedString,
+  getRandomNumberWithSeed,
+} from '@/app/comet-cards/domain/randomness'
+
+import { DeckDefinition } from './types'
+
+const ALL_VALUES: CardValue[] = ['2', '3', '4', '5', '6', '7', '8', '9', '10', 'J', 'Q', 'K', 'A']
+const ALL_SUITS: PlayingCardDefinition['suit'][] = ['hearts', 'diamonds', 'clubs', 'spades']
+
+export function generateErraticDeckCards(gameSeed: string): PlayingCardDefinition[] {
+  const cards: PlayingCardDefinition[] = []
+
+  for (let i = 0; i < 52; i++) {
+    const seed = buildSeedString([gameSeed, 'erratic', i.toString()])
+    const valueIdx = getRandomNumberWithSeed(
+      buildSeedString([seed, 'value']),
+      0,
+      ALL_VALUES.length - 1
+    )
+    const suitIdx = getRandomNumberWithSeed(
+      buildSeedString([seed, 'suit']),
+      0,
+      ALL_SUITS.length - 1
+    )
+    cards.push(getDefaultCard(ALL_VALUES[valueIdx], ALL_SUITS[suitIdx]))
+  }
+
+  return cards
+}
+
+export const erraticDeck: DeckDefinition = {
+  id: 'erraticDeck',
+  name: 'Erratic Deck',
+  description: 'All ranks and suits in deck are randomized',
+  cards: [], // Cards are generated dynamically per game seed
+  modifiers: {},
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -14,8 +14,8 @@ export default defineConfig({
     include: [
       'src/app/api/v1/tap-tap-adventure/**/*.test.ts',
       'src/app/tap-tap-adventure/**/*.test.ts',
-      'src/app/daily-card-game/**/*.test.ts',
-      'src/app/daily-card-game/**/*.test.tsx',
+      'src/app/comet-cards/**/*.test.ts',
+      'src/app/comet-cards/**/*.test.tsx',
       'src/lib/trivia/**/*.test.ts',
       'src/app/trivia/**/*.test.ts',
     ],


### PR DESCRIPTION
## Summary
- Implements the Erratic Deck (#978): all 52 cards have randomly assigned ranks and suits
- Cards are generated deterministically from the game seed for reproducibility
- Also fixes `vitest.config.ts` to use the renamed `comet-cards` path (missed in rename PR)

Closes #978

## Test plan
- [x] 5 unit tests passing: correct count, valid values, deterministic generation, different seeds produce different decks
- [ ] Verify deck appears in deck selection UI
- [ ] Verify gameplay works with randomized card composition

🤖 Generated with [Claude Code](https://claude.com/claude-code)