### PR TITLE
feat: implement Nebula Deck + starting vouchers infra

### DIFF
--- a/src/app/comet-cards/domain/decks/__tests__/nebula-deck.test.ts
+++ b/src/app/comet-cards/domain/decks/__tests__/nebula-deck.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+
+import { createGameStateWithDeck } from '@/app/comet-cards/domain/game/default-game-state'
+import { nebulaDeck } from '@/app/comet-cards/domain/decks/nebula-deck'
+
+describe('Nebula Deck', () => {
+  it('has correct metadata', () => {
+    expect(nebulaDeck.id).toBe('nebulaDeck')
+    expect(nebulaDeck.name).toBe('Nebula Deck')
+  })
+
+  it('has standard 52 cards', () => {
+    expect(nebulaDeck.cards).toHaveLength(52)
+  })
+
+  it('reduces consumable slots by 1', () => {
+    const gameState = createGameStateWithDeck('nebulaDeck')
+    // Default is 2, -1 = 1
+    expect(gameState.maxConsumables).toBe(1)
+  })
+
+  it('starts with Telescope voucher active', () => {
+    const gameState = createGameStateWithDeck('nebulaDeck')
+    expect(gameState.vouchers).toHaveLength(1)
+    expect(gameState.vouchers[0].type).toBe('telescope')
+    expect(gameState.staticRules.telescopeActive).toBe(true)
+  })
+})

--- a/src/app/comet-cards/domain/decks/decks.ts
+++ b/src/app/comet-cards/domain/decks/decks.ts
@@ -8,6 +8,7 @@ import { blueDeck } from './blue-deck'
 import { checkeredDeck } from './checkered-deck'
 import { erraticDeck, generateErraticDeckCards } from './erratic-deck'
 import { greenDeck } from './green-deck'
+import { nebulaDeck } from './nebula-deck'
 import { plasmaDeck } from './plasma-deck'
 import { paintedDeck } from './painted-deck'
 import { pokerDeck } from './poker-deck'
@@ -27,6 +28,7 @@ export const decks: Record<string, DeckDefinition> = {
   greenDeck: greenDeck,
   erraticDeck: erraticDeck,
   plasmaDeck: plasmaDeck,
+  nebulaDeck: nebulaDeck,
 }
 
 export const initialDeckStates = (game: GameState): Record<string, PlayingCardState[]> => {

--- a/src/app/comet-cards/domain/decks/nebula-deck.ts
+++ b/src/app/comet-cards/domain/decks/nebula-deck.ts
@@ -1,0 +1,13 @@
+import { pokerDeckDefinition } from './poker-deck'
+import { DeckDefinition } from './types'
+
+export const nebulaDeck: DeckDefinition = {
+  id: 'nebulaDeck',
+  name: 'Nebula Deck',
+  description: 'Start with the Telescope voucher, -1 consumable slot',
+  cards: pokerDeckDefinition,
+  modifiers: {
+    maxConsumables: -1,
+    startingVouchers: ['telescope'],
+  },
+}

--- a/src/app/comet-cards/domain/decks/types.ts
+++ b/src/app/comet-cards/domain/decks/types.ts
@@ -1,4 +1,5 @@
 import { PlayingCardDefinition } from '@/app/comet-cards/domain/playing-card/types'
+import { VoucherType } from '@/app/comet-cards/domain/voucher/types'
 
 export interface DeckDefinition {
   id: string
@@ -16,4 +17,5 @@ export interface DeckModifiers {
   maxConsumables?: number
   handSizeModifier?: number
   maxInterest?: number
+  startingVouchers?: VoucherType[]
 }

--- a/src/app/comet-cards/domain/game/default-game-state.ts
+++ b/src/app/comet-cards/domain/game/default-game-state.ts
@@ -204,9 +204,12 @@ export function createGameStateWithDeck(deckId: string): GameState {
     const voucherStates = deck.modifiers.startingVouchers.map(vType =>
       initializeVoucherState(vouchers[vType])
     )
+    // Deep clone shop state and static rules to avoid mutating the module-level base state
     stateWithModifiers = {
       ...stateWithModifiers,
       vouchers: [...stateWithModifiers.vouchers, ...voucherStates],
+      shopState: JSON.parse(JSON.stringify(stateWithModifiers.shopState)),
+      staticRules: { ...stateWithModifiers.staticRules },
     }
     // Apply voucher effects directly to game state
     for (const vType of deck.modifiers.startingVouchers) {

--- a/src/app/comet-cards/domain/game/default-game-state.ts
+++ b/src/app/comet-cards/domain/game/default-game-state.ts
@@ -17,6 +17,8 @@ import {
 import { initializeHand } from '@/app/comet-cards/domain/hand/utils'
 import { getCurrentDayAsSeedString } from '@/app/comet-cards/domain/randomness'
 import { initializeRounds } from '@/app/comet-cards/domain/round/rounds'
+import { initializeVoucherState } from '@/app/comet-cards/domain/voucher/utils'
+import { vouchers } from '@/app/comet-cards/domain/voucher/vouchers'
 
 import { GameState } from './types'
 
@@ -194,6 +196,29 @@ export function createGameStateWithDeck(deckId: string): GameState {
     stateWithModifiers = {
       ...stateWithModifiers,
       rounds: initializeRounds(stateWithModifiers.gameSeed, 2n),
+    }
+  }
+
+  // Apply starting vouchers
+  if (deck.modifiers.startingVouchers?.length) {
+    const voucherStates = deck.modifiers.startingVouchers.map(vType =>
+      initializeVoucherState(vouchers[vType])
+    )
+    stateWithModifiers = {
+      ...stateWithModifiers,
+      vouchers: [...stateWithModifiers.vouchers, ...voucherStates],
+    }
+    // Apply voucher effects directly to game state
+    for (const vType of deck.modifiers.startingVouchers) {
+      const voucherDef = vouchers[vType]
+      for (const effect of voucherDef.effects) {
+        effect.apply({
+          game: stateWithModifiers,
+          event: effect.event,
+          tags: [],
+          score: stateWithModifiers.gamePlayState.score,
+        })
+      }
     }
   }
 

--- a/src/app/comet-cards/domain/game/default-game-state.ts
+++ b/src/app/comet-cards/domain/game/default-game-state.ts
@@ -17,8 +17,7 @@ import {
 import { initializeHand } from '@/app/comet-cards/domain/hand/utils'
 import { getCurrentDayAsSeedString } from '@/app/comet-cards/domain/randomness'
 import { initializeRounds } from '@/app/comet-cards/domain/round/rounds'
-import { initializeVoucherState } from '@/app/comet-cards/domain/voucher/utils'
-import { vouchers } from '@/app/comet-cards/domain/voucher/vouchers'
+import { applyStartingVouchers } from '@/app/comet-cards/domain/voucher/deck-vouchers'
 
 import { GameState } from './types'
 
@@ -201,28 +200,7 @@ export function createGameStateWithDeck(deckId: string): GameState {
 
   // Apply starting vouchers
   if (deck.modifiers.startingVouchers?.length) {
-    const voucherStates = deck.modifiers.startingVouchers.map(vType =>
-      initializeVoucherState(vouchers[vType])
-    )
-    // Deep clone shop state and static rules to avoid mutating the module-level base state
-    stateWithModifiers = {
-      ...stateWithModifiers,
-      vouchers: [...stateWithModifiers.vouchers, ...voucherStates],
-      shopState: JSON.parse(JSON.stringify(stateWithModifiers.shopState)),
-      staticRules: { ...stateWithModifiers.staticRules },
-    }
-    // Apply voucher effects directly to game state
-    for (const vType of deck.modifiers.startingVouchers) {
-      const voucherDef = vouchers[vType]
-      for (const effect of voucherDef.effects) {
-        effect.apply({
-          game: stateWithModifiers,
-          event: effect.event,
-          tags: [],
-          score: stateWithModifiers.gamePlayState.score,
-        })
-      }
-    }
+    stateWithModifiers = applyStartingVouchers(stateWithModifiers, deck.modifiers.startingVouchers)
   }
 
   const deckCards = initialDeckStates(stateWithModifiers)[deckId]

--- a/src/app/comet-cards/domain/voucher/deck-vouchers.ts
+++ b/src/app/comet-cards/domain/voucher/deck-vouchers.ts
@@ -1,0 +1,83 @@
+import { uuid } from '@/app/comet-cards/domain/randomness'
+
+import type { GameState } from '@/app/comet-cards/domain/game/types'
+import type { VoucherType } from './types'
+
+/**
+ * Applies starting vouchers to game state during deck initialization.
+ * This module intentionally avoids importing vouchers.ts to prevent
+ * pulling in heavy shop/utils dependencies during the build.
+ */
+export function applyStartingVouchers(state: GameState, voucherTypes: VoucherType[]): GameState {
+  const result = {
+    ...state,
+    vouchers: [
+      ...state.vouchers,
+      ...voucherTypes.map(type => ({ id: uuid(), type })),
+    ],
+    shopState: JSON.parse(JSON.stringify(state.shopState)),
+    staticRules: { ...state.staticRules },
+  }
+
+  for (const vType of voucherTypes) {
+    applyVoucherEffect(result, vType)
+  }
+
+  return result
+}
+
+function applyVoucherEffect(state: GameState, vType: VoucherType): void {
+  switch (vType) {
+    case 'crystalBall':
+      state.maxConsumables += 1
+      break
+    case 'omenGlobe':
+      state.staticRules.spectralInArcanaPacks = true
+      break
+    case 'telescope':
+      state.staticRules.telescopeActive = true
+      break
+    case 'overstock':
+    case 'overstockPlus':
+      state.shopState.maxCardsForSale += 1
+      break
+    case 'tarotMerchant':
+      state.shopState.tarotCard.multiplier *= 2
+      break
+    case 'tarotTycoon':
+      state.shopState.tarotCard.multiplier *= 4
+      break
+    case 'planetMerchant':
+      state.shopState.celestialMultiplier *= 2
+      break
+    case 'planetTycoon':
+      state.shopState.celestialMultiplier *= 4
+      break
+    case 'grabber':
+    case 'nachoTong':
+      state.maxHands += 1
+      state.gamePlayState.remainingHands += 1
+      break
+    case 'wasteful':
+    case 'recyclomancy':
+      state.maxDiscards += 1
+      state.gamePlayState.remainingDiscards += 1
+      break
+    case 'antimatter':
+      state.maxJokers += 1
+      break
+    case 'paintBrush':
+    case 'palette':
+      state.handSizeModifier += 1
+      break
+    case 'seedMoney':
+      state.maxInterest = 10
+      break
+    case 'moneyTree':
+      state.maxInterest = 20
+      break
+    // Other vouchers have shop-only effects that don't need init-time application
+    default:
+      break
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `startingVouchers` field to `DeckModifiers` type, enabling any deck to pre-purchase vouchers at game init
- Implements Nebula Deck (#969): starts with Telescope voucher active, -1 consumable slot
- Voucher effects are applied directly during `createGameStateWithDeck` so their state changes take effect immediately

Closes #969

## Test plan
- [x] 4 unit tests passing: metadata, card count, reduced consumable slots, telescope voucher active
- [ ] Verify Telescope behavior (celestial packs contain planet for most-played hand)
- [ ] Verify only 1 consumable slot in UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)