### PR TITLE
feat: implement Zodiac Deck

### DIFF
--- a/src/app/comet-cards/domain/decks/__tests__/zodiac-deck.test.ts
+++ b/src/app/comet-cards/domain/decks/__tests__/zodiac-deck.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+
+import { createGameStateWithDeck } from '@/app/comet-cards/domain/game/default-game-state'
+import { zodiacDeck } from '@/app/comet-cards/domain/decks/zodiac-deck'
+
+describe('Zodiac Deck', () => {
+  it('has correct metadata', () => {
+    expect(zodiacDeck.id).toBe('zodiacDeck')
+    expect(zodiacDeck.name).toBe('Zodiac Deck')
+  })
+
+  it('has standard 52 cards', () => {
+    expect(zodiacDeck.cards).toHaveLength(52)
+  })
+
+  it('starts with 3 vouchers', () => {
+    const gameState = createGameStateWithDeck('zodiacDeck')
+    expect(gameState.vouchers).toHaveLength(3)
+    const voucherTypes = gameState.vouchers.map(v => v.type)
+    expect(voucherTypes).toContain('tarotMerchant')
+    expect(voucherTypes).toContain('planetMerchant')
+    expect(voucherTypes).toContain('overstock')
+  })
+
+  it('applies Tarot Merchant effect (2x tarot frequency)', () => {
+    const gameState = createGameStateWithDeck('zodiacDeck')
+    expect(gameState.shopState.tarotCard.multiplier).toBe(2)
+  })
+
+  it('applies Planet Merchant effect (2x celestial frequency)', () => {
+    const gameState = createGameStateWithDeck('zodiacDeck')
+    expect(gameState.shopState.celestialMultiplier).toBe(2)
+  })
+
+  it('applies Overstock effect (+1 card slot in shop)', () => {
+    const gameState = createGameStateWithDeck('zodiacDeck')
+    expect(gameState.shopState.maxCardsForSale).toBe(3)
+  })
+})

--- a/src/app/comet-cards/domain/decks/decks.ts
+++ b/src/app/comet-cards/domain/decks/decks.ts
@@ -14,6 +14,7 @@ import { paintedDeck } from './painted-deck'
 import { pokerDeck } from './poker-deck'
 import { redDeck } from './red-deck'
 import { yellowDeck } from './yellow-deck'
+import { zodiacDeck } from './zodiac-deck'
 import { DeckDefinition } from './types'
 
 export const decks: Record<string, DeckDefinition> = {
@@ -29,6 +30,7 @@ export const decks: Record<string, DeckDefinition> = {
   erraticDeck: erraticDeck,
   plasmaDeck: plasmaDeck,
   nebulaDeck: nebulaDeck,
+  zodiacDeck: zodiacDeck,
 }
 
 export const initialDeckStates = (game: GameState): Record<string, PlayingCardState[]> => {

--- a/src/app/comet-cards/domain/decks/zodiac-deck.ts
+++ b/src/app/comet-cards/domain/decks/zodiac-deck.ts
@@ -1,0 +1,12 @@
+import { pokerDeckDefinition } from './poker-deck'
+import { DeckDefinition } from './types'
+
+export const zodiacDeck: DeckDefinition = {
+  id: 'zodiacDeck',
+  name: 'Zodiac Deck',
+  description: 'Start with Tarot Merchant, Planet Merchant, and Overstock vouchers',
+  cards: pokerDeckDefinition,
+  modifiers: {
+    startingVouchers: ['tarotMerchant', 'planetMerchant', 'overstock'],
+  },
+}

--- a/src/app/comet-cards/domain/game/default-game-state.ts
+++ b/src/app/comet-cards/domain/game/default-game-state.ts
@@ -204,9 +204,12 @@ export function createGameStateWithDeck(deckId: string): GameState {
     const voucherStates = deck.modifiers.startingVouchers.map(vType =>
       initializeVoucherState(vouchers[vType])
     )
+    // Deep clone shop state and static rules to avoid mutating the module-level base state
     stateWithModifiers = {
       ...stateWithModifiers,
       vouchers: [...stateWithModifiers.vouchers, ...voucherStates],
+      shopState: JSON.parse(JSON.stringify(stateWithModifiers.shopState)),
+      staticRules: { ...stateWithModifiers.staticRules },
     }
     // Apply voucher effects directly to game state
     for (const vType of deck.modifiers.startingVouchers) {


### PR DESCRIPTION
## Summary
- Implements Zodiac Deck (#973): starts with Tarot Merchant, Planet Merchant, and Overstock vouchers pre-purchased
- Fixes a mutation bug in the `startingVouchers` implementation: voucher effects were mutating the module-level base game state through shared object references. Now deep-clones `shopState` and `staticRules` before applying effects.

Closes #973

**Note:** Based on #1304 (Nebula Deck branch). Should be merged after that PR lands.

## Test plan
- [x] 6 unit tests passing: metadata, cards, 3 vouchers present, tarot 2x, celestial 2x, +1 shop slot
- [x] All 51 deck tests pass (no mutation leak between tests)
- [ ] Verify all 3 voucher effects visible in gameplay

🤖 Generated with [Claude Code](https://claude.com/claude-code)