### PR TITLE
feat: implement Magic Deck + starting consumables infra

### DIFF
--- a/src/app/comet-cards/domain/decks/__tests__/magic-deck.test.ts
+++ b/src/app/comet-cards/domain/decks/__tests__/magic-deck.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest'
+
+import { createGameStateWithDeck } from '@/app/comet-cards/domain/game/default-game-state'
+import { magicDeck } from '@/app/comet-cards/domain/decks/magic-deck'
+
+describe('Magic Deck', () => {
+  it('has correct metadata', () => {
+    expect(magicDeck.id).toBe('magicDeck')
+    expect(magicDeck.name).toBe('Magic Deck')
+  })
+
+  it('has standard 52 cards', () => {
+    expect(magicDeck.cards).toHaveLength(52)
+  })
+
+  it('starts with Crystal Ball voucher (+1 consumable slot)', () => {
+    const gameState = createGameStateWithDeck('magicDeck')
+    expect(gameState.vouchers).toHaveLength(1)
+    expect(gameState.vouchers[0].type).toBe('crystalBall')
+    // Crystal Ball gives +1 consumable slot (default 2 → 3)
+    expect(gameState.maxConsumables).toBe(3)
+  })
+
+  it('starts with 2 tarot cards in consumables', () => {
+    const gameState = createGameStateWithDeck('magicDeck')
+    expect(gameState.consumables).toHaveLength(2)
+    expect(gameState.consumables[0].consumableType).toBe('tarotCard')
+    expect(gameState.consumables[1].consumableType).toBe('tarotCard')
+  })
+
+  it('generates deterministic tarot cards from game seed', () => {
+    const gs1 = createGameStateWithDeck('magicDeck')
+    const gs2 = createGameStateWithDeck('magicDeck')
+    const types1 = gs1.consumables.map(c => 'tarotType' in c ? c.tarotType : null)
+    const types2 = gs2.consumables.map(c => 'tarotType' in c ? c.tarotType : null)
+    expect(types1).toEqual(types2)
+  })
+})

--- a/src/app/comet-cards/domain/decks/deck-consumables.ts
+++ b/src/app/comet-cards/domain/decks/deck-consumables.ts
@@ -1,0 +1,43 @@
+import { TarotCardDefinition, TarotCardState } from '@/app/comet-cards/domain/consumable/types'
+import {
+  buildSeedString,
+  getRandomNumberWithSeed,
+  uuid,
+} from '@/app/comet-cards/domain/randomness'
+
+const TAROT_TYPES: TarotCardDefinition['tarotType'][] = [
+  'theFool', 'theMagician', 'theHighPriestess', 'theEmpress',
+  'theEmperor', 'theHierophant', 'theLovers', 'theChariot',
+  'strength', 'theHermit', 'wheelOfFortune', 'justice',
+  'theHangedMan', 'death', 'temperance', 'theDevil',
+  'theTower', 'theStar', 'theMoon', 'theSun',
+  'judgement', 'theWorld',
+]
+
+/**
+ * Generates starting tarot cards for deck initialization.
+ * Uses seeded randomness for deterministic results.
+ */
+export function generateStartingTarotCards(
+  gameSeed: string,
+  randomCount: number,
+  specificTypes?: TarotCardDefinition['tarotType'][],
+): TarotCardState[] {
+  const cards: TarotCardState[] = []
+
+  // Add specific tarot types if requested
+  if (specificTypes) {
+    for (const tarotType of specificTypes) {
+      cards.push({ id: uuid(), consumableType: 'tarotCard', tarotType })
+    }
+  }
+
+  // Add random tarot cards
+  for (let i = 0; i < randomCount; i++) {
+    const seed = buildSeedString([gameSeed, 'startingTarot', i.toString()])
+    const idx = getRandomNumberWithSeed(seed, 0, TAROT_TYPES.length - 1)
+    cards.push({ id: uuid(), consumableType: 'tarotCard', tarotType: TAROT_TYPES[idx] })
+  }
+
+  return cards
+}

--- a/src/app/comet-cards/domain/decks/decks.ts
+++ b/src/app/comet-cards/domain/decks/decks.ts
@@ -8,6 +8,7 @@ import { blueDeck } from './blue-deck'
 import { checkeredDeck } from './checkered-deck'
 import { erraticDeck, generateErraticDeckCards } from './erratic-deck'
 import { greenDeck } from './green-deck'
+import { magicDeck } from './magic-deck'
 import { nebulaDeck } from './nebula-deck'
 import { plasmaDeck } from './plasma-deck'
 import { paintedDeck } from './painted-deck'
@@ -29,6 +30,7 @@ export const decks: Record<string, DeckDefinition> = {
   erraticDeck: erraticDeck,
   plasmaDeck: plasmaDeck,
   nebulaDeck: nebulaDeck,
+  magicDeck: magicDeck,
 }
 
 export const initialDeckStates = (game: GameState): Record<string, PlayingCardState[]> => {

--- a/src/app/comet-cards/domain/decks/magic-deck.ts
+++ b/src/app/comet-cards/domain/decks/magic-deck.ts
@@ -1,0 +1,13 @@
+import { pokerDeckDefinition } from './poker-deck'
+import { DeckDefinition } from './types'
+
+export const magicDeck: DeckDefinition = {
+  id: 'magicDeck',
+  name: 'Magic Deck',
+  description: 'Start with the Crystal Ball voucher and 2 Tarot cards',
+  cards: pokerDeckDefinition,
+  modifiers: {
+    startingVouchers: ['crystalBall'],
+    startingTarotCards: 2,
+  },
+}

--- a/src/app/comet-cards/domain/decks/types.ts
+++ b/src/app/comet-cards/domain/decks/types.ts
@@ -1,3 +1,4 @@
+import { TarotCardDefinition } from '@/app/comet-cards/domain/consumable/types'
 import { PlayingCardDefinition } from '@/app/comet-cards/domain/playing-card/types'
 import { VoucherType } from '@/app/comet-cards/domain/voucher/types'
 
@@ -18,4 +19,6 @@ export interface DeckModifiers {
   handSizeModifier?: number
   maxInterest?: number
   startingVouchers?: VoucherType[]
+  startingTarotCards?: number
+  startingTarotTypes?: TarotCardDefinition['tarotType'][]
 }

--- a/src/app/comet-cards/domain/game/default-game-state.ts
+++ b/src/app/comet-cards/domain/game/default-game-state.ts
@@ -17,6 +17,7 @@ import {
 import { initializeHand } from '@/app/comet-cards/domain/hand/utils'
 import { getCurrentDayAsSeedString } from '@/app/comet-cards/domain/randomness'
 import { initializeRounds } from '@/app/comet-cards/domain/round/rounds'
+import { generateStartingTarotCards } from '@/app/comet-cards/domain/decks/deck-consumables'
 import { applyStartingVouchers } from '@/app/comet-cards/domain/voucher/deck-vouchers'
 
 import { GameState } from './types'
@@ -201,6 +202,19 @@ export function createGameStateWithDeck(deckId: string): GameState {
   // Apply starting vouchers
   if (deck.modifiers.startingVouchers?.length) {
     stateWithModifiers = applyStartingVouchers(stateWithModifiers, deck.modifiers.startingVouchers)
+  }
+
+  // Apply starting tarot cards
+  if (deck.modifiers.startingTarotCards || deck.modifiers.startingTarotTypes?.length) {
+    const tarotCards = generateStartingTarotCards(
+      stateWithModifiers.gameSeed,
+      deck.modifiers.startingTarotCards ?? 0,
+      deck.modifiers.startingTarotTypes,
+    )
+    stateWithModifiers = {
+      ...stateWithModifiers,
+      consumables: [...stateWithModifiers.consumables, ...tarotCards],
+    }
   }
 
   const deckCards = initialDeckStates(stateWithModifiers)[deckId]


### PR DESCRIPTION
## Summary
- Implements Magic Deck (#968): starts with Crystal Ball voucher (+1 consumable slot) and 2 random Tarot cards
- Adds `startingTarotCards` and `startingTarotTypes` fields to `DeckModifiers` for any deck to include starting tarot cards
- Creates lightweight `deck-consumables.ts` module with seeded random tarot generation (avoids heavy imports)

Closes #968

## Test plan
- [x] 5 unit tests passing: metadata, cards, Crystal Ball voucher active, 2 tarot cards in consumables, deterministic generation
- [ ] Verify 3 consumable slots in UI (Crystal Ball effect)
- [ ] Verify 2 tarot cards usable at game start

🤖 Generated with [Claude Code](https://claude.com/claude-code)