### PR TITLE
infra: add CARD_DESTROYED game event

### DIFF
--- a/src/app/comet-cards/domain/events/__tests__/card-destroyed-event.test.ts
+++ b/src/app/comet-cards/domain/events/__tests__/card-destroyed-event.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest'
+
+import { dispatchEffects } from '@/app/comet-cards/domain/events/dispatch-effects'
+import type { CardDestroyedEvent, Effect, EffectContext } from '@/app/comet-cards/domain/events/types'
+
+describe('CARD_DESTROYED event', () => {
+  it('dispatches effects matching CARD_DESTROYED', () => {
+    const applied: string[] = []
+
+    const event: CardDestroyedEvent = {
+      type: 'CARD_DESTROYED',
+      cardId: 'card-1',
+      source: 'spectral',
+    }
+
+    const effects: Effect[] = [
+      {
+        event: { type: 'CARD_DESTROYED', cardId: '', source: 'spectral' },
+        priority: 1,
+        apply: () => { applied.push('effect-1') },
+      },
+      {
+        event: { type: 'CARD_SCORED' },
+        priority: 1,
+        apply: () => { applied.push('should-not-run') },
+      },
+    ]
+
+    dispatchEffects(event, {} as EffectContext, effects)
+
+    expect(applied).toEqual(['effect-1'])
+  })
+
+  it('supports glass_break source', () => {
+    const event: CardDestroyedEvent = {
+      type: 'CARD_DESTROYED',
+      cardId: 'card-2',
+      source: 'glass_break',
+    }
+
+    expect(event.type).toBe('CARD_DESTROYED')
+    expect(event.source).toBe('glass_break')
+    expect(event.cardId).toBe('card-2')
+  })
+
+  it('supports joker_effect source', () => {
+    const event: CardDestroyedEvent = {
+      type: 'CARD_DESTROYED',
+      cardId: 'card-3',
+      source: 'joker_effect',
+    }
+
+    expect(event.source).toBe('joker_effect')
+  })
+})

--- a/src/app/comet-cards/domain/events/event-emitter.ts
+++ b/src/app/comet-cards/domain/events/event-emitter.ts
@@ -11,6 +11,7 @@ class EventEmitter {
     CONSUMABLE_DESELECTED: [],
     CONSUMABLE_SELECTED: [],
     CONSUMABLE_SOLD: [],
+    CARD_DESTROYED: [],
     CARD_SCORED: [],
     CARD_SELECTED: [],
     CARD_DESELECTED: [],

--- a/src/app/comet-cards/domain/events/types.ts
+++ b/src/app/comet-cards/domain/events/types.ts
@@ -14,6 +14,7 @@ export type GameEvent =
   | BackToMenuEvent
   | BossBlindSelectedEvent
   | CardDeselectedEvent
+  | CardDestroyedEvent
   | CardScoredEvent
   | CardSelectedEvent
   | CelestialCardUsedEvent
@@ -109,6 +110,11 @@ export type BossBlindSelectedEvent = {
 export type CardDeselectedEvent = {
   type: 'CARD_DESELECTED'
   id: string
+}
+export type CardDestroyedEvent = {
+  type: 'CARD_DESTROYED'
+  cardId: string
+  source: 'glass_break' | 'spectral' | 'joker_effect' | 'other'
 }
 export type CardScoredEvent = {
   type: 'CARD_SCORED'

--- a/src/app/comet-cards/domain/game/reduce-game.ts
+++ b/src/app/comet-cards/domain/game/reduce-game.ts
@@ -275,6 +275,10 @@ export function reduceGame(game: GameState, event: GameEvent): GameState {
         // This case handles the event for effect dispatching purposes
         return
       }
+      case 'CARD_DESTROYED': {
+        dispatchEffects(event, getEffectContext(draft as unknown as GameState, event), collectEffects(draft as unknown as GameState))
+        return
+      }
       case 'CONSUMABLE_SOLD': {
         handleConsumableSold(draft)
         return


### PR DESCRIPTION
## Summary
- Adds `CardDestroyedEvent` to the `GameEvent` union type with `cardId` and `source` fields
- Source tracking: `glass_break`, `spectral`, `joker_effect`, `other`
- Registers event in the event emitter
- Adds dispatch handler in `reduce-game.ts`
- Jokers like Canio (#837) can now register effects for `CARD_DESTROYED`

Closes #1275

**Note:** The event type and dispatch infrastructure is complete. Spectral card effects that destroy cards (Familiar, Grim, Incantation, Immolate) will be wired up to emit this event in a follow-up when Canio joker is implemented.

## Test plan
- [x] 3 unit tests: effect dispatch matching, source types (glass_break, joker_effect, spectral)
- [ ] Verify no regressions in existing gameplay

🤖 Generated with [Claude Code](https://claude.com/claude-code)