### PR TITLE
infra: add SHOP_END game event

### DIFF
--- a/src/app/comet-cards/domain/events/__tests__/shop-end-event.test.ts
+++ b/src/app/comet-cards/domain/events/__tests__/shop-end-event.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest'
+
+import { dispatchEffects } from '@/app/comet-cards/domain/events/dispatch-effects'
+import type { Effect, EffectContext, ShopEndEvent } from '@/app/comet-cards/domain/events/types'
+
+describe('SHOP_END event', () => {
+  it('dispatches effects matching SHOP_END', () => {
+    const applied: string[] = []
+
+    const event: ShopEndEvent = { type: 'SHOP_END' }
+
+    const effects: Effect[] = [
+      {
+        event: { type: 'SHOP_END' },
+        priority: 1,
+        apply: () => { applied.push('shop-end-effect') },
+      },
+      {
+        event: { type: 'SHOP_OPEN' },
+        priority: 1,
+        apply: () => { applied.push('should-not-run') },
+      },
+    ]
+
+    dispatchEffects(event, {} as EffectContext, effects)
+
+    expect(applied).toEqual(['shop-end-effect'])
+  })
+
+  it('respects effect priority ordering', () => {
+    const applied: number[] = []
+
+    const event: ShopEndEvent = { type: 'SHOP_END' }
+
+    const effects: Effect[] = [
+      {
+        event: { type: 'SHOP_END' },
+        priority: 3,
+        apply: () => { applied.push(3) },
+      },
+      {
+        event: { type: 'SHOP_END' },
+        priority: 1,
+        apply: () => { applied.push(1) },
+      },
+      {
+        event: { type: 'SHOP_END' },
+        priority: 2,
+        apply: () => { applied.push(2) },
+      },
+    ]
+
+    dispatchEffects(event, {} as EffectContext, effects)
+
+    expect(applied).toEqual([1, 2, 3])
+  })
+})

--- a/src/app/comet-cards/domain/events/event-emitter.ts
+++ b/src/app/comet-cards/domain/events/event-emitter.ts
@@ -46,6 +46,7 @@ class EventEmitter {
     PACK_OPEN_SKIP: [],
     SHOP_BUY_AND_USE_CARD: [],
     SHOP_BUY_VOUCHER: [],
+    SHOP_END: [],
     DISPLAY_BOSS_BLINDS: [],
     DISPLAY_CELESTIALS: [],
     DISPLAY_SPECTRAL_CARDS: [],

--- a/src/app/comet-cards/domain/events/types.ts
+++ b/src/app/comet-cards/domain/events/types.ts
@@ -44,6 +44,7 @@ export type GameEvent =
   | ShopBuyAndUseCardEvent
   | ShopRerollEvent
   | ShopBuyVoucherEvent
+  | ShopEndEvent
   | DisplayBossBlindsEvent
   | DisplayCelestialsEvent
   | DisplaySpectralCardsEvent
@@ -205,6 +206,9 @@ export type ShopOpenPackEvent = {
 export type ShopBuyVoucherEvent = {
   type: 'SHOP_BUY_VOUCHER'
   id: VoucherType
+}
+export type ShopEndEvent = {
+  type: 'SHOP_END'
 }
 export type DisplayBossBlindsEvent = {
   type: 'DISPLAY_BOSS_BLINDS'

--- a/src/app/comet-cards/domain/game/reduce-game.ts
+++ b/src/app/comet-cards/domain/game/reduce-game.ts
@@ -172,7 +172,13 @@ export function reduceGame(game: GameState, event: GameEvent): GameState {
         return
       }
 
+      case 'SHOP_END': {
+        dispatchEffects(event, getEffectContext(draft as unknown as GameState, event), collectEffects(draft as unknown as GameState))
+        return
+      }
       case 'SHOP_SELECT_BLIND': {
+        // Dispatch SHOP_END effects before leaving the shop
+        dispatchEffects({ type: 'SHOP_END' }, getEffectContext(draft as unknown as GameState, { type: 'SHOP_END' }), collectEffects(draft as unknown as GameState))
         handleShopSelectBlind(draft)
         return
       }


### PR DESCRIPTION
## Summary
- Adds `ShopEndEvent` to the `GameEvent` union type
- Registers event in the event emitter
- Dispatches SHOP_END effects automatically when player exits shop (SHOP_SELECT_BLIND)
- Jokers like Perkeo (#841) can now register effects for `SHOP_END`

Closes #1276

## Test plan
- [x] 2 unit tests: effect dispatch matching, priority ordering
- [ ] Verify no regressions in shop flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)