### PR TITLE
trivia: gate next-question on a vote (with skip + flag escape hatches)

### DIFF
--- a/src/app/trivia/components/InfiniteGame.tsx
+++ b/src/app/trivia/components/InfiniteGame.tsx
@@ -15,6 +15,7 @@ import { InfiniteHUD } from './InfiniteHUD'
 import { InfiniteLoadingState } from './InfiniteLoadingState'
 import { InfiniteQuestionCard } from './InfiniteQuestionCard'
 import { InfiniteRunSummary } from './InfiniteRunSummary'
+import { RateGate } from './RateGate'
 
 const TIME_LIMIT = 60 // 60 seconds for AI free-text
 const RULES_SEEN_KEY = 'cometcave-infinite-rules-seen-v1'
@@ -439,14 +440,6 @@ export function InfiniteGame({ onBack, onViewStats, onViewLeaderboard, mode = 's
         isSubmitting={state.phase === 'answering'}
         answerResult={state.lastAnswer}
         questionsAnswered={state.questionsAnswered}
-        runId={state.runId}
-        onFlagged={(questionId, result) => {
-          handleQuestionFlagged(questionId, result)
-          if (result.bonusLifeGranted) {
-            setBonusLifeToast('❤️ +1 Bonus Life for reporting!')
-            setTimeout(() => setBonusLifeToast(null), 3000)
-          }
-        }}
         skipsRemaining={state.skipsRemaining}
         onSkip={skipQuestion}
       />
@@ -471,13 +464,33 @@ export function InfiniteGame({ onBack, onViewStats, onViewLeaderboard, mode = 's
 
       {state.phase === 'answered' && (
         state.lastAnswer?.runOver ? (
+          // End-of-run is an emotional beat — let the player see their
+          // summary without a forced rating step. They can still rate
+          // each question inside the summary view.
           <ChunkyButton variant="primary" size="lg" className="w-full" onClick={endRun}>
             View Run Summary
           </ChunkyButton>
         ) : (
-          <ChunkyButton variant="primary" size="lg" className="w-full" onClick={nextQuestion}>
-            Next Question
-          </ChunkyButton>
+          (() => {
+            // Capture id outside the flag callback so the closure
+            // doesn't reach back into a possibly-null state.question
+            // after a phase transition.
+            const qid = state.question.id
+            return (
+              <RateGate
+                questionId={qid}
+                runId={state.runId}
+                onComplete={nextQuestion}
+                onFlagged={(result) => {
+                  handleQuestionFlagged(qid, result)
+                  if (result.bonusLifeGranted) {
+                    setBonusLifeToast('❤️ +1 Bonus Life for reporting!')
+                    setTimeout(() => setBonusLifeToast(null), 3000)
+                  }
+                }}
+              />
+            )
+          })()
         )
       )}
     </div>

--- a/src/app/trivia/components/InfiniteQuestionCard.tsx
+++ b/src/app/trivia/components/InfiniteQuestionCard.tsx
@@ -7,21 +7,12 @@ import { ChunkyButton } from '@/components/ui/chunky-button'
 import { ChunkyCard, ChunkyCardContent, ChunkyCardHeader } from '@/components/ui/chunky-card'
 import { Input } from '@/components/ui/input'
 
-import { FlagQuestion } from './FlagQuestion'
-import { QuestionRating } from './QuestionRating'
-
-interface FlagResult {
-  bonusLifeGranted: boolean
-}
-
 interface Props {
   question: InfiniteQuestion
   onSubmit: (answer: string) => void
   isSubmitting: boolean
   answerResult: (AnswerResult & { trailblazer: boolean; correctAnswer: string; explanation: string | null; timesShown?: number; timesCorrect?: number }) | null
   questionsAnswered: number
-  runId?: string | null
-  onFlagged?: (questionId: string, result: FlagResult) => void
   skipsRemaining?: number
   onSkip?: () => void
 }
@@ -38,8 +29,6 @@ export function InfiniteQuestionCard({
   isSubmitting,
   answerResult,
   questionsAnswered,
-  runId,
-  onFlagged,
   skipsRemaining,
   onSkip,
 }: Props) {
@@ -126,7 +115,7 @@ export function InfiniteQuestionCard({
                 : 'bg-ds-error/20 border border-ds-error/40'
             }`}
           >
-            <div className="font-bold mb-1 flex items-start justify-between gap-2">
+            <div className="font-bold mb-1">
               {answerResult.correct ? (
                 <span className="text-ds-primary">
                   Correct! +{answerResult.points} pts
@@ -137,14 +126,6 @@ export function InfiniteQuestionCard({
               ) : (
                 <span className="text-ds-error">Incorrect — 0 pts</span>
               )}
-              <div className="flex items-center gap-2 shrink-0">
-                <QuestionRating questionId={question.id} />
-                <FlagQuestion
-                  questionId={question.id}
-                  runId={runId}
-                  onFlagged={onFlagged ? (result) => onFlagged(question.id, result) : undefined}
-                />
-              </div>
             </div>
             {!answerResult.correct && (
               <div className="text-on-surface/70 text-sm">

--- a/src/app/trivia/components/QuestionRating.tsx
+++ b/src/app/trivia/components/QuestionRating.tsx
@@ -1,5 +1,6 @@
 'use client'
 import { useState } from 'react'
+
 import { useAuth } from '@/hooks/useAuth'
 
 interface Props {
@@ -10,7 +11,10 @@ export function QuestionRating({ questionId }: Props) {
   const { user } = useAuth()
   const [vote, setVote] = useState<'up' | 'down' | null>(null)
 
-  if (!user) return null  // logged-in only
+  // Anonymous Firebase users still have a uid, so the rate API accepts
+  // their vote — we just need to obtain a token. Truly logged-out users
+  // (no user object at all) cannot rate.
+  if (!user) return null
 
   const handleVote = async (newVote: 'up' | 'down') => {
     if (vote !== null) return // terminal — one vote per question per session

--- a/src/app/trivia/components/RateGate.tsx
+++ b/src/app/trivia/components/RateGate.tsx
@@ -1,0 +1,104 @@
+'use client'
+
+import { useState } from 'react'
+
+import { ChunkyButton } from '@/components/ui/chunky-button'
+import { useAuth } from '@/hooks/useAuth'
+
+import { FlagQuestion } from './FlagQuestion'
+
+interface FlagResult {
+  bonusLifeGranted: boolean
+}
+
+interface Props {
+  questionId: string
+  runId?: string | null
+  // Fired after the player rates, completes a flag, or otherwise
+  // signals they're done with this question. The host decides whether
+  // that means "next question" or "view run summary".
+  onComplete: () => void
+  // Optional flag callback so the host can react to bonus-life rewards
+  // before progression happens.
+  onFlagged?: (result: FlagResult) => void
+}
+
+// Forces the player to rate (or flag) before moving on. The vote
+// itself doubles as the advance click — single tap, no separate Next
+// button. Best-effort against the rate API; we always advance even if
+// the network request fails so a flaky connection doesn't trap the
+// player on a question.
+export function RateGate({ questionId, runId, onComplete, onFlagged }: Props) {
+  const { user } = useAuth()
+  const [submitting, setSubmitting] = useState<'up' | 'down' | null>(null)
+
+  const handleVote = async (vote: 'up' | 'down') => {
+    if (submitting) return
+    setSubmitting(vote)
+    if (user) {
+      try {
+        const token = await user.getIdToken()
+        await fetch(`/api/v1/trivia/questions/${questionId}/rate`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+          body: JSON.stringify({ vote }),
+        })
+      } catch {
+        // Best-effort — advance anyway. The rating UI in the run
+        // summary lets them retry if they care.
+      }
+    }
+    onComplete()
+  }
+
+  return (
+    <div className="flex flex-col items-center gap-2 w-full">
+      <p className="text-on-surface/60 text-xs uppercase tracking-widest">
+        How was this question?
+      </p>
+      <div className="flex w-full gap-2">
+        <ChunkyButton
+          variant="primary"
+          size="lg"
+          className="flex-1"
+          disabled={submitting !== null}
+          onClick={() => handleVote('up')}
+          aria-label="Good question — continue"
+        >
+          <span className="text-xl">👍</span>
+          <span>Good</span>
+        </ChunkyButton>
+        <ChunkyButton
+          variant="secondary"
+          size="lg"
+          className="flex-1"
+          disabled={submitting !== null}
+          onClick={() => handleVote('down')}
+          aria-label="Bad question — continue"
+        >
+          <span className="text-xl">👎</span>
+          <span>Bad</span>
+        </ChunkyButton>
+      </div>
+      <button
+        type="button"
+        onClick={onComplete}
+        disabled={submitting !== null}
+        className="mt-1 px-4 py-1.5 rounded-md text-xs text-on-surface/50 bg-surface-variant/20 border border-outline-variant/30 hover:text-on-surface/80 hover:bg-surface-variant/30 transition-colors disabled:opacity-50"
+      >
+        Skip rating and go to next question
+      </button>
+      <div className="flex items-center gap-1 text-on-surface/40 text-xs">
+        <FlagQuestion
+          questionId={questionId}
+          runId={runId}
+          onFlagged={(result) => {
+            onFlagged?.(result)
+            onComplete()
+          }}
+        />
+        <span>report a problem</span>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- Infinite mode: post-answer 'Next Question' button is replaced by a `RateGate`. 👍 and 👎 both record a vote and advance in a single tap.
- Below the thumbs, a small grey "Skip rating and go to next question" button covers neutral feelings.
- 🚩 report a problem still works — completing the flag also advances.
- End-of-run keeps going straight to the run summary; the gate doesn't apply there.
- Vote is best-effort against `/api/v1/trivia/questions/{id}/rate`; a failed request no longer traps the player.
- Removed the now-redundant inline rating + flag icons from `InfiniteQuestionCard`.

## Test plan
- [ ] Answer a question in infinite mode — verify thumbs are the next-action.
- [ ] 👍 records a vote, then advances to the next question.
- [ ] 👎 same.
- [ ] Skip advances without recording a vote.
- [ ] Flag → submit advances; cancel does not.
- [ ] On the final question of a run (lives = 0 after answer), 'View Run Summary' shows directly with no gate.
- [ ] Question Library / run summary rating UIs still function (`QuestionRating` unchanged in behavior).

🤖 Generated with [Claude Code](https://claude.com/claude-code)