### PR TITLE
trivia: swap Skip for Dunno when out of skips

### DIFF
--- a/src/app/trivia/components/InfiniteQuestionCard.tsx
+++ b/src/app/trivia/components/InfiniteQuestionCard.tsx
@@ -93,14 +93,29 @@ export function InfiniteQuestionCard({
               >
                 {isSubmitting ? 'Checking...' : 'Submit Answer'}
               </ChunkyButton>
-              {onSkip && skipsRemaining != null && skipsRemaining > 0 && !isSubmitting && (
-                <ChunkyButton
-                  variant="ghost"
-                  size="sm"
-                  onClick={onSkip}
-                >
-                  Skip
-                </ChunkyButton>
+              {/* Skip when the player still has skips banked; otherwise
+                  Dunno lets them concede the question without typing a
+                  throwaway answer. Submits an empty string, which the
+                  answer route already treats as incorrect (timeout
+                  path), so the run continues with 0 pts on this Q. */}
+              {!isSubmitting && skipsRemaining != null && (
+                skipsRemaining > 0 && onSkip ? (
+                  <ChunkyButton
+                    variant="ghost"
+                    size="sm"
+                    onClick={onSkip}
+                  >
+                    Skip
+                  </ChunkyButton>
+                ) : (
+                  <ChunkyButton
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => onSubmit('')}
+                  >
+                    Dunno
+                  </ChunkyButton>
+                )
               )}
             </div>
           )}


### PR DESCRIPTION
## Summary
- When `skipsRemaining > 0`, the existing Skip button still appears.
- When the player is out of skips, the same slot now shows a Dunno button instead. Tapping it submits an empty answer; the answer route already treats empty as incorrect (timeout path), so the run continues with 0 pts on this question and the player gets the normal answer feedback + RateGate flow.
- Single tap, no typing of throwaway text required.

## Test plan
- [ ] Start a run with skips banked → Skip button appears next to Submit.
- [ ] Burn through all skips → button label flips to Dunno.
- [ ] Click Dunno → answer marked incorrect, feedback shows correct answer + explanation, RateGate appears.
- [ ] After Dunno, voting/skipping in the gate works as expected and advances to the next question.

🤖 Generated with [Claude Code](https://claude.com/claude-code)