### PR TITLE
trivia: dedupe infinite leaderboards by uid (one row per player)

### DIFF
--- a/src/lib/trivia/infiniteRuns.ts
+++ b/src/lib/trivia/infiniteRuns.ts
@@ -374,18 +374,32 @@ async function hydrateNicknames(uids: string[]): Promise<Map<string, string>> {
   return map
 }
 
+// Keeps only the first entry per uid. Inputs must already be sorted so that
+// each player's best run appears before their lesser ones.
+function dedupeByUid<T extends { uid: string }>(entries: T[]): T[] {
+  const seen = new Set<string>()
+  const out: T[] = []
+  for (const entry of entries) {
+    if (seen.has(entry.uid)) continue
+    seen.add(entry.uid)
+    out.push(entry)
+  }
+  return out
+}
+
 // TODO(#1263): Add getTopRunsByCustomCategory(customCategory, limit) for per-topic leaderboards.
 // This requires a composite index on (customCategory, mode, score) which isn't yet defined.
 export async function getInfiniteTopByScore(limit = 20): Promise<InfiniteLeaderboardEntry[]> {
   const db = getFirestoreDb()
-  // Overfetch so that the post-hydration filter that drops players without
-  // a nickname still returns up to `limit` entries.
+  // Overfetch to absorb (a) runs from anonymous/nicknameless players that get
+  // dropped post-hydration and (b) repeat runs from the same player that get
+  // collapsed by the per-uid dedupe below.
   const snap = await db
     .collectionGroup('triviaInfinite')
     .where('mode', '==', 'scored')
     .where('endedAt', '!=', null)
     .orderBy('score', 'desc')
-    .limit(limit * 2)
+    .limit(limit * 10)
     .get()
 
   const entries = snap.docs.map((d) => {
@@ -394,8 +408,7 @@ export async function getInfiniteTopByScore(limit = 20): Promise<InfiniteLeaderb
     return { uid, score: run.score, longestStreak: run.longestStreak, questionsAnswered: run.answers?.length ?? 0, date: run.endedAt }
   })
   const nicknames = await hydrateNicknames(entries.map((e) => e.uid))
-  return entries
-    .filter((e) => !!nicknames.get(e.uid))
+  return dedupeByUid(entries.filter((e) => !!nicknames.get(e.uid)))
     .slice(0, limit)
     .map((e) => ({
       ...e,
@@ -410,7 +423,7 @@ export async function getInfiniteTopByStreak(limit = 20): Promise<InfiniteLeader
     .where('mode', '==', 'scored')
     .where('endedAt', '!=', null)
     .orderBy('longestStreak', 'desc')
-    .limit(limit * 2)
+    .limit(limit * 10)
     .get()
 
   const entries = snap.docs.map((d) => {
@@ -419,8 +432,7 @@ export async function getInfiniteTopByStreak(limit = 20): Promise<InfiniteLeader
     return { uid, score: run.score, longestStreak: run.longestStreak, questionsAnswered: run.answers?.length ?? 0, date: run.endedAt }
   })
   const nicknames = await hydrateNicknames(entries.map((e) => e.uid))
-  return entries
-    .filter((e) => !!nicknames.get(e.uid))
+  return dedupeByUid(entries.filter((e) => !!nicknames.get(e.uid)))
     .slice(0, limit)
     .map((e) => ({
       ...e,


### PR DESCRIPTION
## Summary
- On the **Top Score** and **Top Streak** infinite-trivia leaderboards, each player now appears at most once — their personal best.
- The **By Category** leaderboards are intentionally untouched: a player can still surface as the leader of multiple categories (each \`triviaCategoryStats\` doc is already per-uid-per-category, so no dedupe needed there).
- Implementation: added a small \`dedupeByUid\` helper that keeps the first occurrence per uid in an already-sorted list, and bumped the over-fetch from \`limit * 2\` to \`limit * 10\` to absorb both anonymous-user filtering and the new collapse of repeat runs from the same player.

## Test plan
- [x] \`npm run typecheck\` — no new errors in trivia (pre-existing failures are all in \`tap-tap-adventure\` tests, unrelated).
- [x] \`npx vitest run src/lib/trivia\` — all 93 tests pass.
- [ ] Manual: visit the infinite-trivia leaderboards in dev, confirm the same player no longer occupies multiple rows on Top Score / Top Streak, and confirm a single player can still show up in multiple categories on the By Category view.

🤖 Generated with [Claude Code](https://claude.com/claude-code)