### PR TITLE
fix: rebuild aggregate stats for incorrect category counts (#1323)

### DIFF
--- a/src/app/api/v1/trivia/stats/me/rebuild/route.ts
+++ b/src/app/api/v1/trivia/stats/me/rebuild/route.ts
@@ -1,0 +1,16 @@
+import { type NextRequest, NextResponse } from 'next/server'
+import { verifyRequestAuth } from '@/lib/api/auth'
+import { rebuildAggregateStats } from '@/lib/trivia/triviaStats'
+
+export async function POST(request: NextRequest) {
+  const auth = await verifyRequestAuth(request)
+  if ('error' in auth) return auth.error
+
+  try {
+    await rebuildAggregateStats(auth.claims.uid)
+    return NextResponse.json({ ok: true })
+  } catch (err) {
+    console.error('Failed to rebuild stats:', err)
+    return NextResponse.json({ error: 'Failed to rebuild stats.' }, { status: 500 })
+  }
+}

--- a/src/app/trivia/components/InfiniteStats.tsx
+++ b/src/app/trivia/components/InfiniteStats.tsx
@@ -92,6 +92,7 @@ export function InfiniteStats({ onBack }: { onBack: () => void }) {
   const [loading, setLoading] = useState(true)
   const [runs, setRuns] = useState<RunHistoryEntry[]>([])
   const [runsLoading, setRunsLoading] = useState(true)
+  const [rebuilding, setRebuilding] = useState(false)
 
   const fetchStats = useCallback(async () => {
     if (!user) {
@@ -583,6 +584,35 @@ export function InfiniteStats({ onBack }: { onBack: () => void }) {
           </ChunkyCardContent>
         </ChunkyCard>
       )}
+
+      <div className="flex flex-col items-center gap-1">
+        <ChunkyButton
+          variant="ghost"
+          disabled={rebuilding}
+          onClick={async () => {
+            if (!user) return
+            setRebuilding(true)
+            try {
+              const token = await user.getIdToken()
+              await fetch('/api/v1/trivia/stats/me/rebuild', {
+                method: 'POST',
+                headers: { Authorization: `Bearer ${token}` },
+              })
+              await fetchStats()
+            } catch {
+              // silent
+            } finally {
+              setRebuilding(false)
+            }
+          }}
+          className="w-full"
+        >
+          {rebuilding ? 'Recalculating...' : 'Recalculate stats'}
+        </ChunkyButton>
+        <p className="text-on-surface/30 text-xs text-center">
+          If your stats look wrong, recalculate from your run history
+        </p>
+      </div>
 
       <ChunkyButton variant="secondary" onClick={onBack} className="w-full">
         Back

--- a/src/lib/trivia/triviaStats.ts
+++ b/src/lib/trivia/triviaStats.ts
@@ -220,3 +220,130 @@ export async function trackExhaustion(uid: string): Promise<void> {
     { merge: true }
   )
 }
+
+export async function rebuildAggregateStats(uid: string): Promise<void> {
+  const db = getFirestoreDb()
+
+  const runsSnap = await db.collection(`users/${uid}/triviaInfinite`).get()
+  const runs = runsSnap.docs
+    .map((d) => d.data() as RunDoc & { statsApplied?: boolean })
+    .filter((r) => r.mode !== 'practice' && r.endedAt !== null)
+
+  // Collect all unique question IDs across all runs
+  const allQuestionIds = Array.from(
+    new Set(runs.flatMap((r) => r.answers.map((a) => a.questionId)))
+  )
+
+  // Batch-read question docs in chunks of 500 (Firestore getAll limit)
+  const questionMap = new Map<string, { category: string; difficulty: 'easy' | 'medium' | 'hard' }>()
+  for (let i = 0; i < allQuestionIds.length; i += 500) {
+    const chunk = allQuestionIds.slice(i, i + 500)
+    const refs = chunk.map((id) => db.doc(`aiQuestions/${id}`))
+    const snaps = await db.getAll(...refs)
+    for (const qs of snaps) {
+      if (qs.exists) {
+        const qd = qs.data()!
+        questionMap.set(qs.id, { category: qd.category, difficulty: qd.difficulty })
+      }
+    }
+  }
+
+  // Compute fresh totals from all runs
+  let totalAnswered = 0
+  let totalCorrect = 0
+  let totalScore = 0
+  let runsPlayed = 0
+  let bestStreak = 0
+  let trailblazerCount = 0
+  let totalTimeMs = 0
+  let bestRun: AggregateStats['bestRun'] = null
+  const byCategory: Record<string, { answered: number; correct: number; totalTimeMs: number }> = {}
+  const byDifficulty: AggregateStats['byDifficulty'] = {
+    easy: { answered: 0, correct: 0 },
+    medium: { answered: 0, correct: 0 },
+    hard: { answered: 0, correct: 0 },
+  }
+
+  for (const run of runs) {
+    runsPlayed += 1
+    totalScore += run.score
+    if (run.longestStreak > bestStreak) bestStreak = run.longestStreak
+    if (!bestRun || run.score > bestRun.score) {
+      bestRun = {
+        score: run.score,
+        longestStreak: run.longestStreak,
+        runId: run.runId,
+        endedAt: run.endedAt,
+      }
+    }
+
+    const flaggedSet = new Set<string>(run.flaggedQuestionIds ?? [])
+    for (const answer of run.answers) {
+      if (flaggedSet.has(answer.questionId)) continue
+
+      totalAnswered += 1
+      if (answer.correct) totalCorrect += 1
+      totalTimeMs += answer.timeMs
+      if (answer.trailblazer) trailblazerCount += 1
+
+      const qInfo = questionMap.get(answer.questionId)
+      if (qInfo) {
+        if (!byCategory[qInfo.category]) {
+          byCategory[qInfo.category] = { answered: 0, correct: 0, totalTimeMs: 0 }
+        }
+        byCategory[qInfo.category].answered += 1
+        if (answer.correct) byCategory[qInfo.category].correct += 1
+        byCategory[qInfo.category].totalTimeMs += answer.timeMs
+
+        byDifficulty[qInfo.difficulty].answered += 1
+        if (answer.correct) byDifficulty[qInfo.difficulty].correct += 1
+      }
+    }
+  }
+
+  // Read existing aggregate doc to preserve voice stats
+  const aggRef = db.doc(`users/${uid}/triviaStats/aggregate`)
+  const aggSnap = await aggRef.get()
+  const existing: Partial<AggregateStats> = aggSnap.exists ? (aggSnap.data() as Partial<AggregateStats>) : {}
+
+  const rebuilt: AggregateStats = {
+    totalAnswered,
+    totalCorrect,
+    totalScore,
+    runsPlayed,
+    bestRun,
+    bestStreak,
+    trailblazerCount,
+    totalTimeMs,
+    byCategory,
+    byDifficulty,
+    exhaustionCount: existing.exhaustionCount ?? 0,
+    likesGiven: existing.likesGiven ?? 0,
+    dislikesGiven: existing.dislikesGiven ?? 0,
+    reportsFiled: existing.reportsFiled ?? 0,
+    lastUpdatedAt: null,
+  }
+
+  // Firestore batches are limited to 500 operations
+  const BATCH_LIMIT = 499 // reserve 1 for the aggregate write
+  const firstBatch = db.batch()
+  firstBatch.set(aggRef, { ...rebuilt, lastUpdatedAt: FieldValue.serverTimestamp() })
+  let opsInBatch = 1
+  let currentBatch = firstBatch
+  const batches = [firstBatch]
+
+  for (const run of runs) {
+    if (opsInBatch >= BATCH_LIMIT) {
+      currentBatch = db.batch()
+      batches.push(currentBatch)
+      opsInBatch = 0
+    }
+    const runRef = db.doc(`users/${uid}/triviaInfinite/${run.runId}`)
+    currentBatch.update(runRef, { statsApplied: true })
+    opsInBatch += 1
+  }
+
+  for (const b of batches) {
+    await b.commit()
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `rebuildAggregateStats(uid)` function that recalculates all run-derived stats from scratch by iterating every completed scored run and their answers
- Adds `POST /api/v1/trivia/stats/me/rebuild` endpoint
- Adds "Recalculate stats" button at the bottom of the Infinite Stats page

The Category Constellation was showing incorrect question counts (e.g. "2 Q" when the user answered many more). The root cause is stale aggregate data in Firestore from before the switch from full-doc rewrites to merge-style `FieldValue.increment` updates (commit 3ee22f0). The rebuild function recalculates from the source of truth (individual run docs), preserving voice stats (likes/dislikes/reports/exhaustion) that aren't run-derived.

Closes #1323

## Test plan

- [ ] Open infinite trivia stats page, verify the "Recalculate stats" button appears at the bottom
- [ ] Click "Recalculate stats" — verify it shows "Recalculating..." while working
- [ ] After recalculation, verify category counts in the constellation match actual question history
- [ ] Verify voice stats (likes, dislikes, reports) are preserved after rebuild
- [ ] Verify practice-mode runs are still excluded from the rebuilt stats

🤖 Generated with [Claude Code](https://claude.com/claude-code)