### PR TITLE
fix: show report bonus toast instead of streak toast (#1299)

### DIFF
--- a/src/app/trivia/components/InfiniteGame.tsx
+++ b/src/app/trivia/components/InfiniteGame.tsx
@@ -43,6 +43,7 @@ export function InfiniteGame({ onBack, onViewStats, onViewLeaderboard, mode = 's
   const [bonusLifeToast, setBonusLifeToast] = useState<string | null>(null)
   const [medalToast, setMedalToast] = useState<string | null>(null)
   const prevLivesRef = useRef<number | null>(null)
+  const flagBonusRef = useRef(false)
   const lastMedalAnswerIdRef = useRef<string | null>(null)
 
   const categoryEntries = Object.entries(CATEGORY_META).map(([id, meta]) => ({
@@ -107,13 +108,15 @@ export function InfiniteGame({ onBack, onViewStats, onViewLeaderboard, mode = 's
     endRun()
   }, [endRun])
 
-  // Detect streak bonus life — compare lives before and after answering
+  // Detect streak bonus life — compare lives before and after answering.
+  // Skip when a flag bonus just granted the extra life (flagBonusRef).
   useEffect(() => {
     if (state.phase === 'answered' && state.lastAnswer?.correct && prevLivesRef.current !== null) {
-      if (state.livesRemaining > prevLivesRef.current) {
+      if (state.livesRemaining > prevLivesRef.current && !flagBonusRef.current) {
         setBonusLifeToast(`🔥 ${state.lastAnswer.currentStreak}-streak! +1 Bonus Life`)
         setTimeout(() => setBonusLifeToast(null), 3000)
       }
+      flagBonusRef.current = false
     }
     if (state.phase === 'playing' || state.phase === 'answered') {
       prevLivesRef.current = state.livesRemaining
@@ -484,6 +487,7 @@ export function InfiniteGame({ onBack, onViewStats, onViewLeaderboard, mode = 's
                 onFlagged={(result) => {
                   handleQuestionFlagged(qid, result)
                   if (result.bonusLifeGranted) {
+                    flagBonusRef.current = true
                     setBonusLifeToast('❤️ +1 Bonus Life for reporting!')
                     setTimeout(() => setBonusLifeToast(null), 3000)
                   }


### PR DESCRIPTION
## Summary

- When flagging a question that grants a bonus life, the toast now correctly shows "❤️ +1 Bonus Life for reporting!" instead of the streak message
- Added a `flagBonusRef` that the flag handler sets before the life increase, so the streak detection `useEffect` skips its toast when the extra life came from a flag

Closes #1299

## Test plan

- [ ] Play infinite trivia, answer 3+ questions correctly to build a streak
- [ ] Flag a question that grants a bonus life
- [ ] Verify the toast shows "❤️ +1 Bonus Life for reporting!" (not the streak message)
- [ ] Verify streak bonus toasts still work correctly on the 3rd correct answer in a row

🤖 Generated with [Claude Code](https://claude.com/claude-code)