### PR TITLE
fix: show user's ratings on Run Complete view (#1321)

### DIFF
--- a/src/app/trivia/components/InfiniteGame.tsx
+++ b/src/app/trivia/components/InfiniteGame.tsx
@@ -45,6 +45,7 @@ export function InfiniteGame({ onBack, onViewStats, onViewLeaderboard, mode = 's
   const prevLivesRef = useRef<number | null>(null)
   const flagBonusRef = useRef(false)
   const lastMedalAnswerIdRef = useRef<string | null>(null)
+  const ratingsRef = useRef<Map<string, 'up' | 'down'>>(new Map())
 
   const categoryEntries = Object.entries(CATEGORY_META).map(([id, meta]) => ({
     id: Number(id),
@@ -378,7 +379,7 @@ export function InfiniteGame({ onBack, onViewStats, onViewLeaderboard, mode = 's
 
   // End of run
   if (state.phase === 'ended') {
-    return <InfiniteRunSummary state={state} onPlayAgain={handlePlayAgain} onBack={onBack} onViewStats={onViewStats} onViewLeaderboard={onViewLeaderboard} mode={state.mode} runId={state.runId} onFlagged={handleQuestionFlagged} />
+    return <InfiniteRunSummary state={state} onPlayAgain={handlePlayAgain} onBack={onBack} onViewStats={onViewStats} onViewLeaderboard={onViewLeaderboard} mode={state.mode} runId={state.runId} onFlagged={handleQuestionFlagged} ratings={ratingsRef.current} />
   }
 
   // Playing or answered
@@ -484,6 +485,7 @@ export function InfiniteGame({ onBack, onViewStats, onViewLeaderboard, mode = 's
                 questionId={qid}
                 runId={state.runId}
                 onComplete={nextQuestion}
+                onRated={(id, vote) => ratingsRef.current.set(id, vote)}
                 onFlagged={(result) => {
                   handleQuestionFlagged(qid, result)
                   if (result.bonusLifeGranted) {

--- a/src/app/trivia/components/InfiniteRunSummary.tsx
+++ b/src/app/trivia/components/InfiniteRunSummary.tsx
@@ -24,6 +24,7 @@ interface Props {
   mode?: InfiniteMode
   runId?: string | null
   onFlagged?: (questionId: string, result: FlagResult) => void
+  ratings?: Map<string, 'up' | 'down'>
 }
 
 function formatTime(ms: number): string {
@@ -43,7 +44,7 @@ const ANSWERS_PAGE_SIZE = 20
 
 type AnswerEntry = InfiniteRunState['answers'][number]
 
-export function InfiniteRunSummary({ state, onPlayAgain, onBack, onViewStats, onViewLeaderboard, mode = 'scored', runId, onFlagged }: Props) {
+export function InfiniteRunSummary({ state, onPlayAgain, onBack, onViewStats, onViewLeaderboard, mode = 'scored', runId, onFlagged, ratings }: Props) {
   const { user } = useAuth()
   const [copied, setCopied] = useState(false)
   const [showAllAnswers, setShowAllAnswers] = useState(false)
@@ -158,7 +159,7 @@ export function InfiniteRunSummary({ state, onPlayAgain, onBack, onViewStats, on
                     <span className={`font-bold text-sm min-w-[4rem] text-right ${a.correct ? 'text-ds-tertiary' : 'text-on-surface/30'}`}>
                       +{a.points}
                     </span>
-                    <QuestionRating questionId={a.questionId} />
+                    <QuestionRating questionId={a.questionId} initialVote={ratings?.get(a.questionId) ?? null} />
                     <FlagQuestion
                       questionId={a.questionId}
                       runId={runId}

--- a/src/app/trivia/components/QuestionRating.tsx
+++ b/src/app/trivia/components/QuestionRating.tsx
@@ -5,11 +5,12 @@ import { useAuth } from '@/hooks/useAuth'
 
 interface Props {
   questionId: string
+  initialVote?: 'up' | 'down' | null
 }
 
-export function QuestionRating({ questionId }: Props) {
+export function QuestionRating({ questionId, initialVote = null }: Props) {
   const { user } = useAuth()
-  const [vote, setVote] = useState<'up' | 'down' | null>(null)
+  const [vote, setVote] = useState<'up' | 'down' | null>(initialVote)
 
   // Anonymous Firebase users still have a uid, so the rate API accepts
   // their vote — we just need to obtain a token. Truly logged-out users

--- a/src/app/trivia/components/RateGate.tsx
+++ b/src/app/trivia/components/RateGate.tsx
@@ -18,6 +18,9 @@ interface Props {
   // signals they're done with this question. The host decides whether
   // that means "next question" or "view run summary".
   onComplete: () => void
+  // Reports which vote the player cast so the host can carry the
+  // rating forward (e.g. into the run summary).
+  onRated?: (questionId: string, vote: 'up' | 'down') => void
   // Optional flag callback so the host can react to bonus-life rewards
   // before progression happens.
   onFlagged?: (result: FlagResult) => void
@@ -28,7 +31,7 @@ interface Props {
 // button. Best-effort against the rate API; we always advance even if
 // the network request fails so a flaky connection doesn't trap the
 // player on a question.
-export function RateGate({ questionId, runId, onComplete, onFlagged }: Props) {
+export function RateGate({ questionId, runId, onComplete, onRated, onFlagged }: Props) {
   const { user } = useAuth()
   const [submitting, setSubmitting] = useState<'up' | 'down' | null>(null)
 
@@ -48,6 +51,7 @@ export function RateGate({ questionId, runId, onComplete, onFlagged }: Props) {
         // summary lets them retry if they care.
       }
     }
+    onRated?.(questionId, vote)
     onComplete()
   }
 


### PR DESCRIPTION
## Summary

- RateGate now reports the vote via a new `onRated` callback
- InfiniteGame tracks votes in a ref Map during gameplay and passes them to InfiniteRunSummary
- QuestionRating accepts an `initialVote` prop so it renders the existing vote instead of empty buttons
- 4 files changed, 14 insertions, 6 deletions

Previously, QuestionRating always started with `vote = null` on mount, so any ratings cast during gameplay were lost when the run summary rendered.

Closes #1321

## Test plan

- [ ] Play an infinite trivia run, rate questions (thumbs up/down) via RateGate between questions
- [ ] When the run ends, verify the Run Complete view shows "👍 Liked" / "👎 Disliked" on previously rated questions
- [ ] Verify unrated questions still show the vote buttons in the summary
- [ ] Verify rating a question in the summary still works normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)