### PR TITLE
fix: add visual debuff indicator for boss blind cards (#1246)

### DIFF
--- a/src/app/comet-cards/components/cosmic/brand-card.tsx
+++ b/src/app/comet-cards/components/cosmic/brand-card.tsx
@@ -45,12 +45,14 @@ export function BrandCard({
   size = 'md',
   onClick,
   faceDown,
+  debuffed,
 }: {
   card: PlayingCardState
   selected?: boolean
   size?: Size
   onClick?: (isSelected: boolean, id: string) => void
   faceDown?: boolean
+  debuffed?: boolean
 }) {
   const dims = SIZES[size]
   const definition = playingCards[card.playingCardId]
@@ -264,6 +266,24 @@ export function BrandCard({
           pointerEvents: 'none',
         }}
       />
+
+      {/* Debuff overlay */}
+      {debuffed && (
+        <div
+          style={{
+            position: 'absolute',
+            inset: 0,
+            background: 'rgba(0,0,0,0.55)',
+            borderRadius: 14,
+            pointerEvents: 'none',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+          }}
+        >
+          <span style={{ fontSize: dims.pip * 0.6, opacity: 0.7 }}>🚫</span>
+        </div>
+      )}
 
       {/* Edition label */}
       {card.flags.edition !== 'normal' && (

--- a/src/app/comet-cards/components/gameplay/hand.tsx
+++ b/src/app/comet-cards/components/gameplay/hand.tsx
@@ -7,6 +7,7 @@ import { getHand } from '@/app/comet-cards/domain/game/card-registry-utils'
 import { cardValuePriority } from '@/app/comet-cards/domain/hand/constants'
 import { playingCards } from '@/app/comet-cards/domain/playing-card/playing-cards'
 import { PlayingCardState } from '@/app/comet-cards/domain/playing-card/types'
+import { getInProgressBlind } from '@/app/comet-cards/domain/round/blinds'
 import { useGameState } from '@/app/comet-cards/useGameState'
 
 import { PlayingCard } from './playing-card'
@@ -40,6 +41,37 @@ export const Hand = ({ sortKey = 'value' }: { sortKey?: HandSortKey } = {}) => {
       )
     })
   }, [dealtCards, sortKey])
+
+  const debuffedIds = useMemo(() => {
+    const blind = getInProgressBlind(game)
+    if (!blind || blind.type !== 'bossBlind') return new Set<string>()
+
+    const round = game.rounds[game.roundIndex]
+    const bossName = round.bossBlindName
+
+    const ids = new Set<string>()
+    for (const card of dealtCards) {
+      const def = playingCards[card.playingCardId]
+      if (!def) continue
+
+      const suit = def.suit
+      const value = def.value
+      const isFace = value === 'J' || value === 'Q' || value === 'K'
+
+      if (
+        (bossName === 'The Club' && suit === 'clubs') ||
+        (bossName === 'The Goad' && suit === 'spades') ||
+        (bossName === 'The Window' && suit === 'diamonds') ||
+        (bossName === 'The Head' && suit === 'hearts') ||
+        (bossName === 'The Plant' && isFace) ||
+        (bossName === 'The Pillar' && game.gamePlayState.cardIdsPlayedThisAnte.includes(card.id)) ||
+        bossName === 'Verdant Leaf'
+      ) {
+        ids.add(card.id)
+      }
+    }
+    return ids
+  }, [game, dealtCards])
 
   const fanWidth = sortedCards.length
     ? CARD_W + (sortedCards.length - 1) * (CARD_W - OVERLAP)
@@ -85,6 +117,7 @@ export const Hand = ({ sortKey = 'value' }: { sortKey?: HandSortKey } = {}) => {
             <PlayingCard
               playingCard={card}
               isSelected={isSelected}
+              debuffed={debuffedIds.has(card.id)}
               onClick={(wasSelected, id) => {
                 if (wasSelected) {
                   eventEmitter.emit({ type: 'CARD_DESELECTED', id })

--- a/src/app/comet-cards/components/gameplay/playing-card.tsx
+++ b/src/app/comet-cards/components/gameplay/playing-card.tsx
@@ -5,10 +5,12 @@ export const PlayingCard = ({
   playingCard,
   isSelected,
   onClick,
+  debuffed,
 }: {
   playingCard: PlayingCardState
   isSelected?: boolean
   onClick?: (isSelected: boolean, id: string) => void
+  debuffed?: boolean
 }) => {
-  return <BrandCard card={playingCard} selected={isSelected} onClick={onClick} size="md" />
+  return <BrandCard card={playingCard} selected={isSelected} onClick={onClick} size="md" debuffed={debuffed} />
 }


### PR DESCRIPTION
## Summary

- Cards debuffed by a boss blind now show a dark overlay with a 🚫 icon
- Covers all suit-debuff blinds (The Club, The Goad, The Window, The Head), face-card debuffs (The Plant), previously-played-card debuffs (The Pillar), and full debuffs (Verdant Leaf)
- The scoring logic was already correct — clubs were properly filtered from `cardsToScore` — but the lack of visual feedback made it look like the blind wasn't working

Closes #1246

## Test plan

- [ ] Start a card game run, reach a boss blind that debuffs cards (The Club, The Goad, etc.)
- [ ] Verify debuffed cards in hand show a dark overlay with 🚫 icon
- [ ] Verify non-debuffed cards appear normal
- [ ] Verify debuffed cards don't contribute chip values during scoring
- [ ] Run existing boss blind tests: `npx vitest run src/app/comet-cards/domain/game/__tests__/the-club.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)