### PR TITLE
feat: implement Uncommon Joker: The Idol (#816)

### DIFF
--- a/src/app/comet-cards/domain/game/__tests__/the-idol.test.ts
+++ b/src/app/comet-cards/domain/game/__tests__/the-idol.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest'
+import { defaultGameState } from '@/app/comet-cards/domain/game/default-game-state'
+import { reduceGame } from '@/app/comet-cards/domain/game/reduce-game'
+import type { GameState } from '@/app/comet-cards/domain/game/types'
+import { jokers } from '@/app/comet-cards/domain/joker/jokers'
+import { initializeJoker } from '@/app/comet-cards/domain/joker/utils'
+import { playingCards } from '@/app/comet-cards/domain/playing-card/playing-cards'
+
+describe('The Idol joker', () => {
+  function setupGame(): GameState {
+    const game: GameState = structuredClone(defaultGameState)
+    game.jokers = [initializeJoker(jokers.theIdol, game)]
+    game.rounds[game.roundIndex].smallBlind.status = 'inProgress'
+    game.gamePhase = 'gameplay'
+    return game
+  }
+
+  it('gives X2 Mult when target card is scored', () => {
+    const game = setupGame()
+    // Set counter to encode Ace of Hearts: A is index 12, hearts is index 0 → 12*4+0 = 48
+    game.jokers[0].counter = 48
+
+    const aceOfHeartsId = Object.keys(game.cards).find(id => {
+      const card = playingCards[game.cards[id].playingCardId]
+      return card?.value === 'A' && card?.suit === 'hearts'
+    })!
+    expect(aceOfHeartsId).toBeDefined()
+
+    const afterScore = reduceGame({
+      ...game,
+      gamePlayState: {
+        ...game.gamePlayState,
+        cardsToScore: [game.cards[aceOfHeartsId]],
+        score: { chips: 10, mult: 5 },
+      },
+    }, { type: 'CARD_SCORED' })
+
+    expect(afterScore.gamePlayState.score.mult).toBe(10) // 5 * 2
+    const idolEvent = afterScore.gamePlayState.scoringEvents.find(
+      e => 'source' in e && e.source === 'The Idol'
+    )
+    expect(idolEvent).toBeDefined()
+  })
+
+  it('does not give bonus for wrong card', () => {
+    const game = setupGame()
+    // Target Ace of Hearts (counter = 48)
+    game.jokers[0].counter = 48
+
+    const twoOfSpadesId = Object.keys(game.cards).find(id => {
+      const card = playingCards[game.cards[id].playingCardId]
+      return card?.value === '2' && card?.suit === 'spades'
+    })!
+    expect(twoOfSpadesId).toBeDefined()
+
+    const afterScore = reduceGame({
+      ...game,
+      gamePlayState: {
+        ...game.gamePlayState,
+        cardsToScore: [game.cards[twoOfSpadesId]],
+        score: { chips: 10, mult: 5 },
+      },
+    }, { type: 'CARD_SCORED' })
+
+    // Mult unchanged (no idol event, but card's own scoring may add)
+    const idolEvent = afterScore.gamePlayState.scoringEvents.find(
+      e => 'source' in e && e.source === 'The Idol'
+    )
+    expect(idolEvent).toBeUndefined()
+  })
+
+  it('changes target on ROUND_END', () => {
+    const game = setupGame()
+    game.gameSeed = 'test-seed'
+    game.roundIndex = 0
+    game.jokers[0].counter = 10
+
+    const after = reduceGame(game, { type: 'ROUND_END' })
+    const idol = after.jokers.find(j => j.jokerId === 'theIdol')
+    expect(idol).toBeDefined()
+    expect(idol!.counter).toBeGreaterThanOrEqual(0)
+    expect(idol!.counter).toBeLessThanOrEqual(51)
+  })
+})

--- a/src/app/comet-cards/domain/joker/jokers.ts
+++ b/src/app/comet-cards/domain/joker/jokers.ts
@@ -8,6 +8,7 @@ import {
   twoPairHand,
 } from '@/app/comet-cards/domain/hand/hands'
 import { cardValuePriority, playingCards } from '@/app/comet-cards/domain/playing-card/playing-cards'
+import type { CardValue } from '@/app/comet-cards/domain/playing-card/types'
 import {
   buildSeedString,
   getRandomNumbersWithSeed,
@@ -4654,6 +4655,69 @@ export const dna: JokerDefinition = {
   rarity: 'rare',
 }
 
+const IDOL_VALUES: CardValue[] = ['2', '3', '4', '5', '6', '7', '8', '9', '10', 'J', 'Q', 'K', 'A']
+const IDOL_SUITS: ('hearts' | 'diamonds' | 'clubs' | 'spades')[] = ['hearts', 'diamonds', 'clubs', 'spades']
+
+function idolPickTarget(game: { gameSeed: string; roundIndex: number }, tag: string): number {
+  const seed = buildSeedString([game.gameSeed, game.roundIndex.toString(), 'theIdol', tag])
+  const rolls = getRandomNumbersWithSeed({ seed, min: 0, max: 51, numberOfNumbers: 1 })
+  return rolls[0]
+}
+
+export const theIdol: JokerDefinition = {
+  id: 'theIdol',
+  name: 'The Idol',
+  description: 'Each played [rank] of [suit] gives X2 Mult when scored. Card changes every round.',
+  price: 6,
+  effects: [
+    {
+      event: { type: 'JOKER_ADDED' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        const idol = ctx.game.jokers.find(j => j.jokerId === 'theIdol')
+        if (!idol) return
+        idol.counter = idolPickTarget(ctx.game, 'init')
+      },
+    },
+    {
+      event: { type: 'CARD_SCORED' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        const idol = ctx.game.jokers.find(j => j.jokerId === 'theIdol')
+        if (!idol) return
+        const scoredCard = ctx.scoredCards?.[0]
+        if (!scoredCard) return
+        const cardDef = playingCards[scoredCard.playingCardId]
+        if (!cardDef) return
+
+        const targetValueIdx = Math.floor(idol.counter / 4)
+        const targetSuitIdx = idol.counter % 4
+
+        if (cardDef.value === IDOL_VALUES[targetValueIdx] && cardDef.suit === IDOL_SUITS[targetSuitIdx]) {
+          ctx.game.gamePlayState.scoringEvents.push({
+            id: uuid(),
+            type: 'mult',
+            operator: 'x',
+            value: 2,
+            source: 'The Idol',
+          })
+          ctx.game.gamePlayState.score.mult *= 2
+        }
+      },
+    },
+    {
+      event: { type: 'ROUND_END' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        const idol = ctx.game.jokers.find(j => j.jokerId === 'theIdol')
+        if (!idol) return
+        idol.counter = idolPickTarget(ctx.game, 'rotate')
+      },
+    },
+  ],
+  rarity: 'uncommon',
+}
+
 export const jokers: Record<JokerDefinition['id'], JokerDefinition> = {
   swashbucklerJoker,
   walkieTalkieJoker,
@@ -4790,6 +4854,7 @@ export const jokers: Record<JokerDefinition['id'], JokerDefinition> = {
   seance,
   sixthSense,
   dna,
+  theIdol,
 }
 
 /***


### PR DESCRIPTION
## Summary

- Implements The Idol joker: "Each played [rank] of [suit] gives X2 Mult when scored. Card changes every round."
- Target card is encoded as counter (0-51: rank*4 + suit index), randomized via seeded RNG
- Effects: JOKER_ADDED (pick initial target), CARD_SCORED (apply X2 Mult on match), ROUND_END (rotate target)
- Price: $6, Rarity: Uncommon
- Includes 3 tests (target match gives X2, non-match no bonus, target rotates on round end)

Also closed #815 (Sixth Sense) and #817 (DNA) as already implemented.

Closes #816

## Test plan

- [ ] `npx vitest run src/app/comet-cards/domain/game/__tests__/the-idol.test.ts` — all 3 tests pass
- [ ] Verify The Idol appears in the jokers registry
- [ ] In-game: buy The Idol from shop, play target card, verify X2 Mult scoring event

🤖 Generated with [Claude Code](https://claude.com/claude-code)