### PR TITLE
feat: implement Uncommon Joker: Mr. Bones (#808)

### DIFF
--- a/src/app/comet-cards/domain/game/__tests__/mr-bones.test.ts
+++ b/src/app/comet-cards/domain/game/__tests__/mr-bones.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest'
+import { defaultGameState } from '@/app/comet-cards/domain/game/default-game-state'
+import { reduceGame } from '@/app/comet-cards/domain/game/reduce-game'
+import type { GameState } from '@/app/comet-cards/domain/game/types'
+import { jokers } from '@/app/comet-cards/domain/joker/jokers'
+import { initializeJoker } from '@/app/comet-cards/domain/joker/utils'
+
+describe('Mr. Bones joker', () => {
+  function setupGame(): GameState {
+    const game: GameState = structuredClone(defaultGameState)
+    game.jokers = [initializeJoker(jokers.mrBones, game)]
+    game.rounds[game.roundIndex].smallBlind.status = 'inProgress'
+    game.gamePhase = 'gameplay'
+    return game
+  }
+
+  it('prevents game over when score >= 25% of ante and destroys itself', () => {
+    const game = setupGame()
+    game.gamePlayState.remainingHands = 0
+    // Ante is 300 for default roundIndex. 25% of 300 = 75.
+    // chips*mult = 100 >= 75 → Mr. Bones should save
+    game.gamePlayState.score = { chips: 10, mult: 10 }
+
+    const after = reduceGame(game, { type: 'HAND_SCORING_FINALIZE' })
+    expect(after.gamePhase).not.toBe('gameOver')
+    expect(after.jokers.find(j => j.jokerId === 'mrBones')).toBeUndefined()
+  })
+
+  it('does not prevent game over when score < 25% of ante', () => {
+    const game = setupGame()
+    game.gamePlayState.remainingHands = 0
+    // chips*mult = 1, ante = 300, 25% = 75, 1 < 75 → game over
+    game.gamePlayState.score = { chips: 1, mult: 1 }
+
+    const after = reduceGame(game, { type: 'HAND_SCORING_FINALIZE' })
+    expect(after.gamePhase).toBe('gameOver')
+    expect(after.jokers.find(j => j.jokerId === 'mrBones')).toBeDefined()
+  })
+
+  it('does nothing when blind is met (no need to save)', () => {
+    const game = setupGame()
+    game.gamePlayState.remainingHands = 0
+    // chips*mult = 400 >= 300 (ante) → blind met, no save needed
+    game.gamePlayState.score = { chips: 20, mult: 20 }
+
+    const after = reduceGame(game, { type: 'HAND_SCORING_FINALIZE' })
+    expect(after.gamePhase).toBe('blindRewards')
+    expect(after.jokers.find(j => j.jokerId === 'mrBones')).toBeDefined()
+  })
+})

--- a/src/app/comet-cards/domain/game/handlers.ts
+++ b/src/app/comet-cards/domain/game/handlers.ts
@@ -120,6 +120,13 @@ export function handleHandScoringEnd(draft: Draft<GameState>, event: GameEvent) 
   draft.totalScore = newTotalScore
 
   if (outcome === 'gameOver') {
+    // Mr. Bones: prevent death if chips scored ≥ 25% of required, then self-destruct
+    const hasMrBones = draft.jokers.some(j => j.jokerId === 'mrBones')
+    if (hasMrBones && blindScore * 4n >= ante) {
+      draft.jokers = draft.jokers.filter(j => j.jokerId !== 'mrBones') as typeof draft.jokers
+      resetScoreForNextHand(draft.gamePlayState)
+      return
+    }
     draft.gamePhase = 'gameOver'
     draft.gamePlayState.isScoring = false
     return

--- a/src/app/comet-cards/domain/joker/jokers.ts
+++ b/src/app/comet-cards/domain/joker/jokers.ts
@@ -4718,6 +4718,15 @@ export const theIdol: JokerDefinition = {
   rarity: 'uncommon',
 }
 
+export const mrBones: JokerDefinition = {
+  id: 'mrBones',
+  name: 'Mr. Bones',
+  description: 'Prevents Death if chips scored are at least 25% of required chips. Self destructs.',
+  price: 5,
+  effects: [],
+  rarity: 'uncommon',
+}
+
 export const jokers: Record<JokerDefinition['id'], JokerDefinition> = {
   swashbucklerJoker,
   walkieTalkieJoker,
@@ -4855,6 +4864,7 @@ export const jokers: Record<JokerDefinition['id'], JokerDefinition> = {
   sixthSense,
   dna,
   theIdol,
+  mrBones,
 }
 
 /***


### PR DESCRIPTION
## Summary

- Implements Mr. Bones joker: "Prevents Death if chips scored are at least 25% of required chips. Self destructs."
- Death prevention check added in `handleHandScoringEnd` (handlers.ts) — after game-over decision, checks if Mr. Bones exists and blindScore >= 25% of ante
- If triggered: prevents game over, destroys Mr. Bones, resets score for next hand
- Price: $5, Rarity: Uncommon
- Includes 3 tests (saves when threshold met, doesn't save below threshold, not consumed when blind is met)

Closes #808

## Test plan

- [ ] `npx vitest run src/app/comet-cards/domain/game/__tests__/mr-bones.test.ts` — all 3 tests pass
- [ ] In-game: buy Mr. Bones, fail a blind with >= 25% chips — verify death prevented and Mr. Bones destroyed
- [ ] In-game: fail a blind with < 25% chips — verify game over still happens

🤖 Generated with [Claude Code](https://claude.com/claude-code)