### PR TITLE
feat: implement Uncommon Joker: Certificate (#794)

### DIFF
--- a/src/app/comet-cards/domain/game/__tests__/certificate.test.ts
+++ b/src/app/comet-cards/domain/game/__tests__/certificate.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest'
+import { defaultGameState } from '@/app/comet-cards/domain/game/default-game-state'
+import { reduceGame } from '@/app/comet-cards/domain/game/reduce-game'
+import type { GameState } from '@/app/comet-cards/domain/game/types'
+import { jokers } from '@/app/comet-cards/domain/joker/jokers'
+import { initializeJoker } from '@/app/comet-cards/domain/joker/utils'
+
+function setupGame(): GameState {
+  const game: GameState = structuredClone(defaultGameState)
+  game.jokers = [initializeJoker(jokers.certificate, game)]
+  game.gamePhase = 'blindSelection'
+  return game
+}
+
+describe('Certificate joker', () => {
+  it('adds a card with a seal to hand on small blind selection', () => {
+    const game = setupGame()
+    const initialHandCount = game.gamePlayState.handIds.length
+    const after = reduceGame(game, { type: 'SMALL_BLIND_SELECTED' })
+    expect(after.gamePlayState.handIds.length).toBe(initialHandCount + 1)
+    const newCardId = after.gamePlayState.handIds[after.gamePlayState.handIds.length - 1]
+    const newCard = after.cards[newCardId]
+    expect(newCard).toBeDefined()
+    expect(newCard.flags.seal).not.toBe('none')
+  })
+
+  it('works on big blind selection', () => {
+    const game = setupGame()
+    const initialHandCount = game.gamePlayState.handIds.length
+    const after = reduceGame(game, { type: 'BIG_BLIND_SELECTED' })
+    expect(after.gamePlayState.handIds.length).toBe(initialHandCount + 1)
+    const newCardId = after.gamePlayState.handIds[after.gamePlayState.handIds.length - 1]
+    const newCard = after.cards[newCardId]
+    expect(newCard).toBeDefined()
+    expect(newCard.flags.seal).not.toBe('none')
+  })
+
+  it('works on boss blind selection', () => {
+    const game = setupGame()
+    const initialHandCount = game.gamePlayState.handIds.length
+    const after = reduceGame(game, { type: 'BOSS_BLIND_SELECTED' })
+    expect(after.gamePlayState.handIds.length).toBe(initialHandCount + 1)
+    const newCardId = after.gamePlayState.handIds[after.gamePlayState.handIds.length - 1]
+    const newCard = after.cards[newCardId]
+    expect(newCard).toBeDefined()
+    expect(newCard.flags.seal).not.toBe('none')
+  })
+})

--- a/src/app/comet-cards/domain/joker/jokers.ts
+++ b/src/app/comet-cards/domain/joker/jokers.ts
@@ -8,7 +8,7 @@ import {
   twoPairHand,
 } from '@/app/comet-cards/domain/hand/hands'
 import { cardValuePriority, playingCards } from '@/app/comet-cards/domain/playing-card/playing-cards'
-import type { CardValue } from '@/app/comet-cards/domain/playing-card/types'
+import type { CardValue, PlayingCardState } from '@/app/comet-cards/domain/playing-card/types'
 import {
   buildSeedString,
   getRandomNumbersWithSeed,
@@ -4807,6 +4807,48 @@ export const smearedJoker: JokerDefinition = {
   rarity: 'uncommon',
 }
 
+function applyCertificateEffect(ctx: EffectContext) {
+  const allCards = Object.values(playingCards)
+  const seed = buildSeedString([ctx.game.gameSeed, ctx.game.roundIndex.toString(), 'certificate'])
+  const roll = getRandomNumbersWithSeed({ seed, min: 0, max: allCards.length - 1, numberOfNumbers: 1 })
+  const cardDef = allCards[roll[0]]
+  const newCard = initializePlayingCard(cardDef)
+
+  // Add random seal
+  const seals: PlayingCardState['flags']['seal'][] = ['blue', 'purple', 'gold', 'red']
+  const sealSeed = buildSeedString([seed, 'seal'])
+  const sealRoll = getRandomNumbersWithSeed({ seed: sealSeed, min: 0, max: 3, numberOfNumbers: 1 })
+  newCard.flags.seal = seals[sealRoll[0]]
+
+  addOwnedCard(ctx.game, newCard)
+  ctx.game.gamePlayState.handIds.push(newCard.id)
+}
+
+export const certificate: JokerDefinition = {
+  id: 'certificate',
+  name: 'Certificate',
+  description: 'When round begins, add a random playing card with a random seal to your hand',
+  price: 6,
+  effects: [
+    {
+      event: { type: 'SMALL_BLIND_SELECTED' },
+      priority: 1,
+      apply: (ctx: EffectContext) => applyCertificateEffect(ctx),
+    },
+    {
+      event: { type: 'BIG_BLIND_SELECTED' },
+      priority: 1,
+      apply: (ctx: EffectContext) => applyCertificateEffect(ctx),
+    },
+    {
+      event: { type: 'BOSS_BLIND_SELECTED' },
+      priority: 1,
+      apply: (ctx: EffectContext) => applyCertificateEffect(ctx),
+    },
+  ],
+  rarity: 'uncommon',
+}
+
 export const jokers: Record<JokerDefinition['id'], JokerDefinition> = {
   swashbucklerJoker,
   walkieTalkieJoker,
@@ -4948,6 +4990,7 @@ export const jokers: Record<JokerDefinition['id'], JokerDefinition> = {
   oopsAll6s,
   matador,
   smearedJoker,
+  certificate,
 }
 
 /***


### PR DESCRIPTION
## Summary
- Implements the **Certificate** uncommon joker: adds a random playing card with a random seal to the player's hand when a round begins
- Triggers on all three blind selection events (small, big, boss)
- Uses seeded randomness for deterministic card and seal selection (blue, purple, gold, or red)

Closes #794

## Test plan
- [x] Card with seal added to hand on small blind selection
- [x] Card with seal added to hand on big blind selection
- [x] Card with seal added to hand on boss blind selection
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)