### PR TITLE
feat: implement Uncommon Joker: Sock and Buskin (#792)

### DIFF
--- a/src/app/comet-cards/domain/game/__tests__/sock-and-buskin.test.ts
+++ b/src/app/comet-cards/domain/game/__tests__/sock-and-buskin.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest'
+import { defaultGameState } from '@/app/comet-cards/domain/game/default-game-state'
+import { reduceGame } from '@/app/comet-cards/domain/game/reduce-game'
+import type { GameState } from '@/app/comet-cards/domain/game/types'
+import { jokers } from '@/app/comet-cards/domain/joker/jokers'
+import { initializeJoker } from '@/app/comet-cards/domain/joker/utils'
+import { playingCards } from '@/app/comet-cards/domain/playing-card/playing-cards'
+
+describe('Sock and Buskin joker', () => {
+  it('retriggers face cards (J, Q, K)', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.jokers = [initializeJoker(jokers.sockAndBuskin, game)]
+    game.rounds[game.roundIndex].smallBlind.status = 'inProgress'
+    game.gamePhase = 'gameplay'
+    const queenId = Object.keys(game.cards).find(id =>
+      playingCards[game.cards[id].playingCardId]?.value === 'Q'
+    )!
+    const after = reduceGame({
+      ...game,
+      gamePlayState: { ...game.gamePlayState, cardsToScore: [game.cards[queenId]] },
+    }, { type: 'CARD_SCORED' })
+    expect(after.gamePlayState.scoringEvents.some(
+      e => 'source' in e && e.source === 'Sock and Buskin'
+    )).toBe(true)
+  })
+
+  it('does not retrigger non-face cards', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.jokers = [initializeJoker(jokers.sockAndBuskin, game)]
+    game.rounds[game.roundIndex].smallBlind.status = 'inProgress'
+    game.gamePhase = 'gameplay'
+    const threeId = Object.keys(game.cards).find(id =>
+      playingCards[game.cards[id].playingCardId]?.value === '3'
+    )!
+    const after = reduceGame({
+      ...game,
+      gamePlayState: { ...game.gamePlayState, cardsToScore: [game.cards[threeId]] },
+    }, { type: 'CARD_SCORED' })
+    expect(after.gamePlayState.scoringEvents.some(
+      e => 'source' in e && e.source === 'Sock and Buskin'
+    )).toBe(false)
+  })
+})

--- a/src/app/comet-cards/domain/joker/jokers.ts
+++ b/src/app/comet-cards/domain/joker/jokers.ts
@@ -4849,6 +4849,33 @@ export const certificate: JokerDefinition = {
   rarity: 'uncommon',
 }
 
+export const sockAndBuskin: JokerDefinition = {
+  id: 'sockAndBuskin',
+  name: 'Sock and Buskin',
+  description: 'Retrigger all played face cards',
+  price: 6,
+  effects: [
+    {
+      event: { type: 'CARD_SCORED' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        const scoredCard = ctx.scoredCards?.[0]
+        if (!scoredCard) return
+        const cardDef = playingCards[scoredCard.playingCardId]
+        if (!['J', 'Q', 'K'].includes(cardDef.value)) return
+        ctx.game.gamePlayState.scoringEvents.push({
+          id: uuid(),
+          type: 'chips',
+          value: cardDef.baseChips,
+          source: 'Sock and Buskin',
+        })
+        ctx.game.gamePlayState.score.chips += cardDef.baseChips
+      },
+    },
+  ],
+  rarity: 'uncommon',
+}
+
 export const jokers: Record<JokerDefinition['id'], JokerDefinition> = {
   swashbucklerJoker,
   walkieTalkieJoker,
@@ -4991,6 +5018,7 @@ export const jokers: Record<JokerDefinition['id'], JokerDefinition> = {
   matador,
   smearedJoker,
   certificate,
+  sockAndBuskin,
 }
 
 /***


### PR DESCRIPTION
## Summary
- Implements the **Sock and Buskin** uncommon joker: retriggers all played face cards (J, Q, K)
- Follows the same CARD_SCORED retrigger pattern as the Hack joker
- Adds base chips of the face card again when scored

Closes #792

## Test plan
- [x] Face cards (Q) are retriggered with bonus chips
- [x] Non-face cards (3) are NOT retriggered
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)