### PR TITLE
feat: implement Uncommon Joker: Lucky Cat (#784)

### DIFF
--- a/src/app/comet-cards/domain/game/__tests__/lucky-cat.test.ts
+++ b/src/app/comet-cards/domain/game/__tests__/lucky-cat.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'vitest'
+import { defaultGameState } from '@/app/comet-cards/domain/game/default-game-state'
+import { reduceGame } from '@/app/comet-cards/domain/game/reduce-game'
+import type { GameState } from '@/app/comet-cards/domain/game/types'
+import { jokers } from '@/app/comet-cards/domain/joker/jokers'
+import { initializeJoker } from '@/app/comet-cards/domain/joker/utils'
+import { playingCards } from '@/app/comet-cards/domain/playing-card/playing-cards'
+
+describe('Lucky Cat joker', () => {
+  function setupGame(): GameState {
+    const game: GameState = structuredClone(defaultGameState)
+    game.jokers = [initializeJoker(jokers.luckyCat, game)]
+    game.rounds[game.roundIndex].smallBlind.status = 'inProgress'
+    game.gamePhase = 'gameplay'
+    return game
+  }
+
+  it('gains counter when Lucky card triggers', () => {
+    const game = setupGame()
+    const cardId = Object.keys(game.cards)[0]
+    game.cards[cardId].flags.enchantment = 'lucky'
+
+    // Simulate a Lucky trigger by adding a Lucky scoring event
+    game.gamePlayState.scoringEvents.push({
+      id: 'test-lucky',
+      type: 'mult',
+      value: 20,
+      source: 'Lucky',
+    })
+
+    const after = reduceGame(
+      {
+        ...game,
+        gamePlayState: {
+          ...game.gamePlayState,
+          cardsToScore: [game.cards[cardId]],
+        },
+      },
+      { type: 'CARD_SCORED' },
+    )
+
+    const lc = after.jokers.find(j => j.jokerId === 'luckyCat')
+    // Counter should be 5: initialized to 4 (X1.0) + 1 for the Lucky trigger
+    expect(lc?.counter).toBe(5)
+  })
+
+  it('does not gain counter on non-Lucky cards', () => {
+    const game = setupGame()
+    const cardId = Object.keys(game.cards).find(
+      id => playingCards[game.cards[id].playingCardId]?.value === '3',
+    )!
+
+    const after = reduceGame(
+      {
+        ...game,
+        gamePlayState: {
+          ...game.gamePlayState,
+          cardsToScore: [game.cards[cardId]],
+        },
+      },
+      { type: 'CARD_SCORED' },
+    )
+
+    const lc = after.jokers.find(j => j.jokerId === 'luckyCat')
+    // Counter initialized to 4 but unchanged (no Lucky card)
+    expect(lc?.counter).toBe(4)
+  })
+
+  it('applies X Mult during HAND_SCORING_FINALIZE when counter > 4', () => {
+    const game = setupGame()
+    // Manually set counter to 6 (X1.5 Mult)
+    const lc = game.jokers.find(j => j.jokerId === 'luckyCat')!
+    lc.counter = 6
+
+    game.gamePlayState.remainingHands = 5
+    game.gamePlayState.score = { chips: 10, mult: 10 }
+
+    const after = reduceGame(game, { type: 'HAND_SCORING_FINALIZE' })
+    expect(
+      after.gamePlayState.scoringEvents.some(
+        e => 'source' in e && e.source === 'Lucky Cat',
+      ),
+    ).toBe(true)
+  })
+
+  it('does not apply X Mult when counter is at base (4)', () => {
+    const game = setupGame()
+    const lc = game.jokers.find(j => j.jokerId === 'luckyCat')!
+    lc.counter = 4
+
+    game.gamePlayState.remainingHands = 5
+    game.gamePlayState.score = { chips: 10, mult: 10 }
+
+    const after = reduceGame(game, { type: 'HAND_SCORING_FINALIZE' })
+    expect(
+      after.gamePlayState.scoringEvents.some(
+        e => 'source' in e && e.source === 'Lucky Cat',
+      ),
+    ).toBe(false)
+  })
+})

--- a/src/app/comet-cards/domain/joker/jokers.ts
+++ b/src/app/comet-cards/domain/joker/jokers.ts
@@ -4876,6 +4876,62 @@ export const sockAndBuskin: JokerDefinition = {
   rarity: 'uncommon',
 }
 
+export const luckyCat: JokerDefinition = {
+  id: 'luckyCat',
+  name: 'Lucky Cat',
+  description:
+    'This Joker gains X0.25 Mult every time a Lucky card successfully triggers (Currently X1 Mult)',
+  price: 6,
+  effects: [
+    {
+      event: { type: 'CARD_SCORED' },
+      priority: 2, // Run after Lucky card enchantment effect
+      apply: (ctx: EffectContext) => {
+        const lc = ctx.game.jokers.find(j => j.jokerId === 'luckyCat')
+        if (!lc) return
+
+        // Initialize counter on first use (4 = X1.0)
+        if (lc.counter === 0) lc.counter = 4
+
+        const scoredCard = ctx.scoredCards?.[0]
+        if (!scoredCard) return
+        if (scoredCard.flags.enchantment !== 'lucky') return
+
+        // Check if Lucky triggered this scoring (Lucky-sourced events exist)
+        const luckyTriggers = ctx.game.gamePlayState.scoringEvents.filter(
+          e => 'source' in e && e.source === 'Lucky',
+        )
+        if (luckyTriggers.length > 0) {
+          lc.counter += 1 // +X0.25 per Lucky card that triggered
+        }
+      },
+    },
+    {
+      event: { type: 'HAND_SCORING_FINALIZE' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        const lc = ctx.game.jokers.find(j => j.jokerId === 'luckyCat')
+        if (!lc) return
+
+        // Initialize counter on first use (4 = X1.0)
+        if (lc.counter === 0) lc.counter = 4
+        if (lc.counter <= 4) return
+
+        const xMult = lc.counter / 4
+        ctx.game.gamePlayState.score.mult *= xMult
+        ctx.game.gamePlayState.scoringEvents.push({
+          id: uuid(),
+          type: 'mult',
+          operator: 'x',
+          value: xMult,
+          source: 'Lucky Cat',
+        })
+      },
+    },
+  ],
+  rarity: 'uncommon',
+}
+
 export const jokers: Record<JokerDefinition['id'], JokerDefinition> = {
   swashbucklerJoker,
   walkieTalkieJoker,
@@ -5019,6 +5075,7 @@ export const jokers: Record<JokerDefinition['id'], JokerDefinition> = {
   smearedJoker,
   certificate,
   sockAndBuskin,
+  luckyCat,
 }
 
 /***


### PR DESCRIPTION
## Summary
- Implements the **Lucky Cat** uncommon joker: gains X0.25 Mult every time a Lucky card successfully triggers
- Uses lazy counter initialization (4 = X1.0 Mult) following the Ice Cream / Popcorn joker pattern
- Detects Lucky triggers by checking for 'Lucky'-sourced scoring events on CARD_SCORED
- Applies accumulated X Mult multiplicatively on HAND_SCORING_FINALIZE

Closes #784

## Test plan
- [x] Counter increases when Lucky card triggers
- [x] Counter unchanged for non-Lucky cards
- [x] X Mult applied when counter > 4 (base)
- [x] No X Mult applied at base counter (4)
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)