### PR TITLE
feat: implement Uncommon Joker: Hologram (#778)

### DIFF
--- a/src/app/comet-cards/domain/game/__tests__/hologram.test.ts
+++ b/src/app/comet-cards/domain/game/__tests__/hologram.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest'
+import { defaultGameState } from '@/app/comet-cards/domain/game/default-game-state'
+import { reduceGame } from '@/app/comet-cards/domain/game/reduce-game'
+import type { GameState } from '@/app/comet-cards/domain/game/types'
+import { jokers } from '@/app/comet-cards/domain/joker/jokers'
+import { initializeJoker } from '@/app/comet-cards/domain/joker/utils'
+import { playingCards } from '@/app/comet-cards/domain/playing-card/playing-cards'
+import { initializePlayingCard } from '@/app/comet-cards/domain/playing-card/utils'
+import { addOwnedCard } from '@/app/comet-cards/domain/game/card-registry-utils'
+
+describe('Hologram joker', () => {
+  function setupGame(): GameState {
+    const game: GameState = structuredClone(defaultGameState)
+    game.jokers = [initializeJoker(jokers.hologram, game)]
+    game.rounds[game.roundIndex].smallBlind.status = 'inProgress'
+    game.gamePhase = 'gameplay'
+    game.gamePlayState.remainingHands = 5
+    game.gamePlayState.score = { chips: 10, mult: 10 }
+    return game
+  }
+
+  it('applies X Mult based on cards added to deck', () => {
+    const game = setupGame()
+    // Initialize counter to current deck size by triggering first
+    const h = game.jokers.find(j => j.jokerId === 'hologram')!
+    h.counter = game.ownedCardIds.length
+
+    // Add 2 cards to the deck
+    const cardDef = Object.values(playingCards)[0]
+    const card1 = initializePlayingCard(cardDef)
+    const card2 = initializePlayingCard(cardDef)
+    addOwnedCard(game, card1)
+    addOwnedCard(game, card2)
+
+    const after = reduceGame(game, { type: 'HAND_SCORING_FINALIZE' })
+    // 2 cards added → X1.5 Mult
+    expect(
+      after.gamePlayState.scoringEvents.some(
+        e => 'source' in e && e.source === 'Hologram' && 'value' in e && e.value === 1.5,
+      ),
+    ).toBe(true)
+  })
+
+  it('no X Mult when no cards added', () => {
+    const game = setupGame()
+    // Set counter to current deck size (no cards added)
+    const h = game.jokers.find(j => j.jokerId === 'hologram')!
+    h.counter = game.ownedCardIds.length
+
+    const after = reduceGame(game, { type: 'HAND_SCORING_FINALIZE' })
+    expect(
+      after.gamePlayState.scoringEvents.some(
+        e => 'source' in e && e.source === 'Hologram',
+      ),
+    ).toBe(false)
+  })
+
+  it('initializes counter to deck size on first use', () => {
+    const game = setupGame()
+    // Counter starts at 0 (uninitialized)
+    expect(game.jokers[0].counter).toBe(0)
+
+    const after = reduceGame(game, { type: 'HAND_SCORING_FINALIZE' })
+    // Counter should now be set to deck size
+    const h = after.jokers.find(j => j.jokerId === 'hologram')!
+    expect(h.counter).toBe(game.ownedCardIds.length)
+  })
+})

--- a/src/app/comet-cards/domain/joker/jokers.ts
+++ b/src/app/comet-cards/domain/joker/jokers.ts
@@ -4932,6 +4932,42 @@ export const luckyCat: JokerDefinition = {
   rarity: 'uncommon',
 }
 
+export const hologram: JokerDefinition = {
+  id: 'hologram',
+  name: 'Hologram',
+  description:
+    'This Joker gains X0.25 Mult every time a playing card is added to your deck (Currently X1 Mult)',
+  price: 7,
+  effects: [
+    {
+      event: { type: 'HAND_SCORING_FINALIZE' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        const h = ctx.game.jokers.find(j => j.jokerId === 'hologram')
+        if (!h) return
+
+        // Initialize counter to baseline deck size on first use
+        if (h.counter === 0) h.counter = ctx.game.ownedCardIds.length
+
+        // Cards added since joker was acquired
+        const cardsAdded = Math.max(0, ctx.game.ownedCardIds.length - h.counter)
+        if (cardsAdded === 0) return
+
+        const xMult = 1 + cardsAdded * 0.25
+        ctx.game.gamePlayState.score.mult *= xMult
+        ctx.game.gamePlayState.scoringEvents.push({
+          id: uuid(),
+          type: 'mult',
+          operator: 'x',
+          value: xMult,
+          source: 'Hologram',
+        })
+      },
+    },
+  ],
+  rarity: 'uncommon',
+}
+
 export const jokers: Record<JokerDefinition['id'], JokerDefinition> = {
   swashbucklerJoker,
   walkieTalkieJoker,
@@ -5076,6 +5112,7 @@ export const jokers: Record<JokerDefinition['id'], JokerDefinition> = {
   certificate,
   sockAndBuskin,
   luckyCat,
+  hologram,
 }
 
 /***


### PR DESCRIPTION
## Summary
- Implements the **Hologram** uncommon joker: gains X0.25 Mult every time a playing card is added to the deck
- Uses deck-size baseline tracking (stores initial `ownedCardIds.length` in counter on first use)
- Dynamically computes X Mult from cards added since acquisition on HAND_SCORING_FINALIZE
- Avoids needing a new event type — tracks additions by comparing current vs baseline deck size

Closes #778

## Test plan
- [x] Applies X1.5 Mult when 2 cards added to deck
- [x] No X Mult when no cards added
- [x] Counter initializes to deck size on first use
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)