### PR TITLE
feat: implement Uncommon Joker: Shortcut (#777)

### DIFF
--- a/src/app/comet-cards/domain/game/__tests__/shortcut.test.ts
+++ b/src/app/comet-cards/domain/game/__tests__/shortcut.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from 'vitest'
+import { defaultGameState } from '@/app/comet-cards/domain/game/default-game-state'
+import { reduceGame } from '@/app/comet-cards/domain/game/reduce-game'
+import type { GameState } from '@/app/comet-cards/domain/game/types'
+import { checkHandForStraight } from '@/app/comet-cards/domain/hand/hands'
+import { findAllStraights } from '@/app/comet-cards/domain/hand/utils'
+import { jokers } from '@/app/comet-cards/domain/joker/jokers'
+import { initializeJoker } from '@/app/comet-cards/domain/joker/utils'
+import type { BuyableCard } from '@/app/comet-cards/domain/shop/types'
+import type { PlayingCardDefinition, PlayingCardState } from '@/app/comet-cards/domain/playing-card/types'
+import { uuid } from '@/app/comet-cards/domain/randomness'
+
+const c = (cardDefinitionId: PlayingCardDefinition['id']): PlayingCardState => ({
+  id: uuid(),
+  playingCardId: cardDefinitionId,
+  bonusChips: 0,
+  flags: {
+    edition: 'normal',
+    enchantment: 'none',
+    seal: 'none',
+  },
+  isFaceUp: true,
+})
+
+function buyShortcutJoker(game: GameState): GameState {
+  const jokerState = initializeJoker(jokers.shortcut, game)
+  const buyable: BuyableCard = {
+    type: 'jokerCard',
+    card: jokerState,
+    price: jokers.shortcut.price,
+  }
+  const withShop: GameState = {
+    ...game,
+    money: 999,
+    shopState: { ...game.shopState, cardsForSale: [buyable], selectedCardId: jokerState.id },
+  }
+  return reduceGame(withShop, { type: 'SHOP_BUY_CARD' })
+}
+
+describe('Shortcut Joker', () => {
+  function setupGame(): GameState {
+    const game: GameState = structuredClone(defaultGameState)
+    game.rounds[game.roundIndex].smallBlind.status = 'inProgress'
+    game.gamePhase = 'gameplay'
+    return game
+  }
+
+  it('sets allowStraightGaps to true when the joker is added (via shop purchase)', () => {
+    const game = setupGame()
+    const after = buyShortcutJoker(game)
+    expect(after.staticRules.allowStraightGaps).toBe(true)
+  })
+
+  it('sets allowStraightGaps to false when the joker is removed', () => {
+    const game = setupGame()
+    const jokerInstance = initializeJoker(jokers.shortcut, game)
+    game.jokers = [jokerInstance]
+    game.staticRules = { ...game.staticRules, allowStraightGaps: true }
+
+    const selected: GameState = {
+      ...game,
+      gamePlayState: { ...game.gamePlayState, selectedJokerId: jokerInstance.id },
+    }
+    const after = reduceGame(selected, { type: 'JOKER_REMOVED' })
+
+    expect(after.jokers.some(j => j.jokerId === 'shortcut')).toBe(false)
+    expect(after.staticRules.allowStraightGaps).toBe(false)
+  })
+
+  it('findAllStraights detects a straight with gaps of 1 rank when allowGaps is true', () => {
+    // Cards: 3(p2), 5(p4), 6(p5), 8(p7), 10(p9) — gaps in priority: 2, 1, 2, 2 (all <= 2)
+    const cards = [c('3_hearts'), c('5_clubs'), c('6_spades'), c('8_diamonds'), c('10_hearts')]
+    const straights = findAllStraights(cards, 5, true)
+    expect(straights.length).toBeGreaterThan(0)
+    expect(straights[0].length).toBe(5)
+  })
+
+  it('findAllStraights does NOT detect a straight with gaps of 1 rank when allowGaps is false', () => {
+    // Same cards: 3, 5, 6, 8, 10 — NOT consecutive without gaps
+    const cards = [c('3_hearts'), c('5_clubs'), c('6_spades'), c('8_diamonds'), c('10_hearts')]
+    const straights = findAllStraights(cards, 5, false)
+    expect(straights.length).toBe(0)
+  })
+
+  it('findAllStraights still detects a normal consecutive straight when allowGaps is true', () => {
+    // 5,6,7,8,9 — all consecutive, no gaps
+    const cards = [c('5_hearts'), c('6_clubs'), c('7_spades'), c('8_diamonds'), c('9_hearts')]
+    const straights = findAllStraights(cards, 5, true)
+    expect(straights.length).toBeGreaterThan(0)
+    expect(straights[0].length).toBe(5)
+  })
+
+  it('findAllStraights does NOT detect a gap of 2+ ranks even with allowGaps true', () => {
+    // Cards: 3(p2), 6(p5) — priority gap is 3, which exceeds maxGap=2
+    // Full hand: 3, 6, 7, 8, 9 — the run [6,7,8,9] is only 4 cards, not enough for 5
+    const cards = [c('3_hearts'), c('6_clubs'), c('7_spades'), c('8_diamonds'), c('9_hearts')]
+    const straights = findAllStraights(cards, 5, true)
+    expect(straights.length).toBe(0)
+  })
+
+  it('checkHandForStraight uses allowStraightGaps from staticRules', () => {
+    const gappyCards = [c('3_hearts'), c('5_clubs'), c('6_spades'), c('8_diamonds'), c('10_hearts')]
+
+    const [isStraightWithGaps] = checkHandForStraight(gappyCards, {
+      numberOfCardsRequiredForFlushAndStraight: 5,
+      areAllCardsFaceCards: false,
+      allowDuplicateJokersInShop: false,
+      bossBlindRerolls: 0,
+      bossBlindRerollCost: 0,
+      telescopeActive: false,
+      observatoryActive: false,
+      spectralInArcanaPacks: false,
+      probabilityMultiplier: 1,
+      smearedSuits: false,
+      allowStraightGaps: true,
+    })
+    expect(isStraightWithGaps).toBe(true)
+
+    const [isStraightWithoutGaps] = checkHandForStraight(gappyCards, {
+      numberOfCardsRequiredForFlushAndStraight: 5,
+      areAllCardsFaceCards: false,
+      allowDuplicateJokersInShop: false,
+      bossBlindRerolls: 0,
+      bossBlindRerollCost: 0,
+      telescopeActive: false,
+      observatoryActive: false,
+      spectralInArcanaPacks: false,
+      probabilityMultiplier: 1,
+      smearedSuits: false,
+      allowStraightGaps: false,
+    })
+    expect(isStraightWithoutGaps).toBe(false)
+  })
+})

--- a/src/app/comet-cards/domain/game/__tests__/smeared-joker.test.ts
+++ b/src/app/comet-cards/domain/game/__tests__/smeared-joker.test.ts
@@ -81,6 +81,7 @@ describe('Smeared Joker', () => {
       spectralInArcanaPacks: false,
       probabilityMultiplier: 1,
       smearedSuits: true,
+      allowStraightGaps: false,
     }
 
     const mixedRedCards = [
@@ -107,6 +108,7 @@ describe('Smeared Joker', () => {
       spectralInArcanaPacks: false,
       probabilityMultiplier: 1,
       smearedSuits: true,
+      allowStraightGaps: false,
     }
 
     const mixedBlackCards = [
@@ -133,6 +135,7 @@ describe('Smeared Joker', () => {
       spectralInArcanaPacks: false,
       probabilityMultiplier: 1,
       smearedSuits: false,
+      allowStraightGaps: false,
     }
 
     const mixedColorCards = [
@@ -159,6 +162,7 @@ describe('Smeared Joker', () => {
       spectralInArcanaPacks: false,
       probabilityMultiplier: 1,
       smearedSuits: true,
+      allowStraightGaps: false,
     }
 
     const mixedColorCards = [

--- a/src/app/comet-cards/domain/game/default-game-state.ts
+++ b/src/app/comet-cards/domain/game/default-game-state.ts
@@ -140,6 +140,7 @@ const gameState: GameState = {
     spectralInArcanaPacks: false,
     probabilityMultiplier: 1,
     smearedSuits: false,
+    allowStraightGaps: false,
   },
   tags: [],
   totalScore: 0n,

--- a/src/app/comet-cards/domain/game/types.ts
+++ b/src/app/comet-cards/domain/game/types.ts
@@ -59,6 +59,7 @@ export interface StaticRulesState {
   spectralInArcanaPacks: boolean
   probabilityMultiplier: number
   smearedSuits: boolean
+  allowStraightGaps: boolean
 }
 
 export type GamePhase =

--- a/src/app/comet-cards/domain/hand/__tests__/hands.test.ts
+++ b/src/app/comet-cards/domain/hand/__tests__/hands.test.ts
@@ -130,6 +130,7 @@ describe('comet-cards hand checkers', () => {
       numberOfCardsRequiredForFlushAndStraight: 5,
       areAllCardsFaceCards: false,
       allowDuplicateJokersInShop: false,
+      allowStraightGaps: false,
     })
     expect(isStraight).toBe(true)
     // We return the straight cards in ascending value order.
@@ -208,6 +209,7 @@ describe('comet-cards hand checkers', () => {
       numberOfCardsRequiredForFlushAndStraight: 4,
       areAllCardsFaceCards: false,
       allowDuplicateJokersInShop: false,
+      allowStraightGaps: false,
     })
     expect(isFlush).toBe(true)
     expect(
@@ -278,6 +280,7 @@ describe('comet-cards hand checkers', () => {
       numberOfCardsRequiredForFlushAndStraight: 5,
       areAllCardsFaceCards: false,
       allowDuplicateJokersInShop: false,
+      allowStraightGaps: false,
     })
     expect(isStraightFlush).toBe(true)
     expect(straightFlushCards).toEqual(allSameSuitStraight)
@@ -295,6 +298,7 @@ describe('comet-cards hand checkers', () => {
       numberOfCardsRequiredForFlushAndStraight: 5,
       areAllCardsFaceCards: false,
       allowDuplicateJokersInShop: false,
+      allowStraightGaps: false,
     })
     expect(isFlushHouse).toBe(true)
     expect(flushHouseCards).toEqual(suitedStraight)
@@ -310,6 +314,7 @@ describe('comet-cards hand checkers', () => {
       numberOfCardsRequiredForFlushAndStraight: 5,
       areAllCardsFaceCards: false,
       allowDuplicateJokersInShop: false,
+      allowStraightGaps: false,
     })
     expect(isNotFlushHouse).toBe(false)
     expect(notFlushHouseCards).toEqual([])
@@ -321,6 +326,7 @@ describe('comet-cards hand checkers', () => {
       numberOfCardsRequiredForFlushAndStraight: 5,
       areAllCardsFaceCards: false,
       allowDuplicateJokersInShop: false,
+      allowStraightGaps: false,
     })
     expect(isFive).toBe(true)
     expect(fiveCards).toEqual(fiveAces)
@@ -354,6 +360,7 @@ describe('comet-cards hand checkers', () => {
       areAllCardsFaceCards: false,
       allowDuplicateJokersInShop: false,
       smearedSuits: false,
+      allowStraightGaps: false,
     }
     const flushFive = [c('7_hearts'), c('7_hearts'), c('7_hearts'), c('7_hearts'), c('7_hearts')]
     const [isFlushFive, flushFiveCards] = checkHandForFlushFive(flushFive, staticRules)

--- a/src/app/comet-cards/domain/hand/hands.ts
+++ b/src/app/comet-cards/domain/hand/hands.ts
@@ -190,7 +190,7 @@ export const checkHandForThreeOfAKind: HandCheckFunction = cards => {
 }
 
 export const checkHandForStraight: HandCheckFunction<[StaticRulesState]> = (cards, staticRules) => {
-  const straights = findAllStraights(cards, staticRules.numberOfCardsRequiredForFlushAndStraight)
+  const straights = findAllStraights(cards, staticRules.numberOfCardsRequiredForFlushAndStraight, staticRules.allowStraightGaps)
   if (straights.length > 0) {
     return [true, straights[0]]
   }
@@ -240,7 +240,7 @@ export const checkHandForStraightFlush: HandCheckFunction<[StaticRulesState]> = 
   cards,
   staticRules
 ) => {
-  const straights = findAllStraights(cards, staticRules.numberOfCardsRequiredForFlushAndStraight)
+  const straights = findAllStraights(cards, staticRules.numberOfCardsRequiredForFlushAndStraight, staticRules.allowStraightGaps)
   if (straights.length > 0) {
     const flush = areAllCardsSameSuit(straights[0], staticRules)
     if (flush) {
@@ -254,7 +254,7 @@ export const checkHandForFlushHouse: HandCheckFunction<[StaticRulesState]> = (
   cards,
   staticRules
 ) => {
-  const straights = findAllStraights(cards, staticRules.numberOfCardsRequiredForFlushAndStraight)
+  const straights = findAllStraights(cards, staticRules.numberOfCardsRequiredForFlushAndStraight, staticRules.allowStraightGaps)
   if (straights.length > 0) {
     const flush = areAllCardsSameSuit(straights[0], staticRules)
     if (flush) {

--- a/src/app/comet-cards/domain/hand/utils.ts
+++ b/src/app/comet-cards/domain/hand/utils.ts
@@ -66,7 +66,8 @@ export const findAllThreeOfAKinds = (cards: PlayingCardState[]): PlayingCardStat
 
 export const findAllStraights = (
   cards: PlayingCardState[],
-  minLength = 5
+  minLength = 5,
+  allowGaps = false,
 ): PlayingCardState[][] => {
   if (cards.length < minLength) return []
 
@@ -124,7 +125,8 @@ export const findAllStraights = (
     }
 
     const prev = currentRun[currentRun.length - 1]
-    if (pr === prev + 1) {
+    const maxGap = allowGaps ? 2 : 1
+    if (pr <= prev + maxGap) {
       currentRun.push(pr)
     } else {
       pushWindowsForRun(currentRun)

--- a/src/app/comet-cards/domain/joker/jokers.ts
+++ b/src/app/comet-cards/domain/joker/jokers.ts
@@ -4968,6 +4968,30 @@ export const hologram: JokerDefinition = {
   rarity: 'uncommon',
 }
 
+export const shortcut: JokerDefinition = {
+  id: 'shortcut',
+  name: 'Shortcut',
+  description: 'Allows Straights to be made with gaps of 1 rank (ex: 10 8 6 5 3)',
+  price: 7,
+  effects: [
+    {
+      event: { type: 'JOKER_ADDED' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        ctx.game.staticRules.allowStraightGaps = true
+      },
+    },
+    {
+      event: { type: 'JOKER_REMOVED' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        ctx.game.staticRules.allowStraightGaps = false
+      },
+    },
+  ],
+  rarity: 'uncommon',
+}
+
 export const jokers: Record<JokerDefinition['id'], JokerDefinition> = {
   swashbucklerJoker,
   walkieTalkieJoker,
@@ -5113,6 +5137,7 @@ export const jokers: Record<JokerDefinition['id'], JokerDefinition> = {
   sockAndBuskin,
   luckyCat,
   hologram,
+  shortcut,
 }
 
 /***


### PR DESCRIPTION
## Summary
- Implements the **Shortcut** uncommon joker: allows straights to be made with gaps of 1 rank (e.g., 10-8-6-5-3)
- Adds `allowStraightGaps` flag to `StaticRulesState` (default: false)
- Modifies `findAllStraights` to allow consecutive priorities with gap of up to 2 when enabled
- Updates all callers (checkHandForStraight, checkHandForStraightFlush, checkHandForFlushHouse)

Closes #777

## Test plan
- [x] Joker sets `allowStraightGaps=true` on add, `false` on remove
- [x] Gap-of-1-rank straights detected when enabled
- [x] Gap-of-1-rank straights NOT detected when disabled
- [x] Normal consecutive straights still work
- [x] Gap-of-2-ranks does not qualify
- [x] All existing hand evaluation and joker tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)