### PR TITLE
feat: implement Uncommon Joker: Luchador (#766)

### DIFF
--- a/src/app/comet-cards/domain/game/__tests__/luchador.test.ts
+++ b/src/app/comet-cards/domain/game/__tests__/luchador.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest'
+
+import { defaultGameState } from '@/app/comet-cards/domain/game/default-game-state'
+import { reduceGame } from '@/app/comet-cards/domain/game/reduce-game'
+import type { GameState } from '@/app/comet-cards/domain/game/types'
+import { jokers } from '@/app/comet-cards/domain/joker/jokers'
+import { initializeJoker } from '@/app/comet-cards/domain/joker/utils'
+
+describe('Luchador joker', () => {
+  it('selling Luchador sets bossBlindDisabled to true', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.jokers = [initializeJoker(jokers.luchador, game)]
+    const started = reduceGame(game, { type: 'GAME_START' })
+
+    const luchadorInstance = started.jokers.find(j => j.jokerId === 'luchador')
+    expect(luchadorInstance).toBeTruthy()
+
+    const selected = {
+      ...started,
+      gamePlayState: { ...started.gamePlayState, selectedJokerId: luchadorInstance!.id },
+    }
+
+    const afterSale = reduceGame(selected, { type: 'JOKER_SOLD' })
+
+    expect(afterSale.jokers.some(j => j.jokerId === 'luchador')).toBe(false)
+    expect(afterSale.staticRules.bossBlindDisabled).toBe(true)
+  })
+
+  it('bossBlindDisabled disables boss blind effects (like The Hook)', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.rounds[game.roundIndex].bossBlindName = 'The Hook'
+    game.rounds[game.roundIndex].bossBlind.status = 'inProgress'
+    game.gamePhase = 'gameplay'
+    game.staticRules.bossBlindDisabled = true
+    game.jokers = []
+
+    const cardIds = ['card1', 'card2', 'card3']
+    game.gamePlayState = {
+      ...game.gamePlayState,
+      handIds: [...cardIds],
+    }
+
+    const after = reduceGame(game, { type: 'HAND_SCORING_DONE_CARD_SCORING' })
+
+    // With bossBlindDisabled, The Hook's effect should not fire
+    expect(after.gamePlayState.handIds).toEqual(cardIds)
+  })
+
+  it('bossBlindDisabled resets to false when small blind is selected', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.staticRules.bossBlindDisabled = true
+    game.rounds[game.roundIndex].smallBlind.status = 'pending'
+
+    const after = reduceGame(game, { type: 'SMALL_BLIND_SELECTED' })
+
+    expect(after.staticRules.bossBlindDisabled).toBe(false)
+  })
+
+  it('bossBlindDisabled resets to false when big blind is selected', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.staticRules.bossBlindDisabled = true
+    game.rounds[game.roundIndex].bigBlind.status = 'pending'
+
+    const after = reduceGame(game, { type: 'BIG_BLIND_SELECTED' })
+
+    expect(after.staticRules.bossBlindDisabled).toBe(false)
+  })
+
+  it('bossBlindDisabled resets to false when boss blind is selected', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.staticRules.bossBlindDisabled = true
+    game.rounds[game.roundIndex].bossBlind.status = 'pending'
+
+    const after = reduceGame(game, { type: 'BOSS_BLIND_SELECTED' })
+
+    expect(after.staticRules.bossBlindDisabled).toBe(false)
+  })
+})

--- a/src/app/comet-cards/domain/game/default-game-state.ts
+++ b/src/app/comet-cards/domain/game/default-game-state.ts
@@ -141,6 +141,7 @@ const gameState: GameState = {
     probabilityMultiplier: 1,
     smearedSuits: false,
     allowStraightGaps: false,
+    bossBlindDisabled: false,
   },
   tags: [],
   totalScore: 0n,

--- a/src/app/comet-cards/domain/game/handlers/blind-selection.ts
+++ b/src/app/comet-cards/domain/game/handlers/blind-selection.ts
@@ -7,6 +7,7 @@ import { blindIndices, getNextBlind } from '@/app/comet-cards/domain/round/blind
 import { initializeTag } from '@/app/comet-cards/domain/tag/utils'
 
 export function handleSmallBlindSelected(draft: GameState) {
+  draft.staticRules.bossBlindDisabled = false
   const round = draft.rounds[draft.roundIndex]
   round.smallBlind.status = 'inProgress'
   draft.gamePhase = 'gameplay'
@@ -26,6 +27,7 @@ export function handleSmallBlindSelected(draft: GameState) {
 }
 
 export function handleBigBlindSelected(draft: GameState) {
+  draft.staticRules.bossBlindDisabled = false
   const round = draft.rounds[draft.roundIndex]
   round.bigBlind.status = 'inProgress'
   draft.gamePhase = 'gameplay'
@@ -45,6 +47,7 @@ export function handleBigBlindSelected(draft: GameState) {
 }
 
 export function handleBossBlindSelected(draft: GameState) {
+  draft.staticRules.bossBlindDisabled = false
   const round = draft.rounds[draft.roundIndex]
   round.bossBlind.status = 'inProgress'
   draft.gamePhase = 'gameplay'

--- a/src/app/comet-cards/domain/game/types.ts
+++ b/src/app/comet-cards/domain/game/types.ts
@@ -60,6 +60,7 @@ export interface StaticRulesState {
   probabilityMultiplier: number
   smearedSuits: boolean
   allowStraightGaps: boolean
+  bossBlindDisabled: boolean
 }
 
 export type GamePhase =

--- a/src/app/comet-cards/domain/game/utils.ts
+++ b/src/app/comet-cards/domain/game/utils.ts
@@ -48,7 +48,7 @@ export function getBlindDefinition(type: BlindState['type'], round: RoundState):
 export function collectEffects(game: GameState): Effect[] {
   const effects: Effect[] = []
 
-  const hasBossBlindDisabled = game.jokers.some(j => j.jokerId === 'chicot')
+  const hasBossBlindDisabled = game.jokers.some(j => j.jokerId === 'chicot') || game.staticRules.bossBlindDisabled
   const blind = getInProgressBlind(game)
   if (blind && blind.type === 'bossBlind' && !hasBossBlindDisabled) {
     effects.push(...getBlindDefinition(blind.type, game.rounds[game.roundIndex]).effects)

--- a/src/app/comet-cards/domain/joker/jokers.ts
+++ b/src/app/comet-cards/domain/joker/jokers.ts
@@ -4992,6 +4992,23 @@ export const shortcut: JokerDefinition = {
   rarity: 'uncommon',
 }
 
+export const luchador: JokerDefinition = {
+  id: 'luchador',
+  name: 'Luchador',
+  description: 'Sell this card to disable the current Boss Blind',
+  price: 5,
+  effects: [
+    {
+      event: { type: 'JOKER_SOLD' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        ctx.game.staticRules.bossBlindDisabled = true
+      },
+    },
+  ],
+  rarity: 'uncommon',
+}
+
 export const jokers: Record<JokerDefinition['id'], JokerDefinition> = {
   swashbucklerJoker,
   walkieTalkieJoker,
@@ -5138,6 +5155,7 @@ export const jokers: Record<JokerDefinition['id'], JokerDefinition> = {
   luckyCat,
   hologram,
   shortcut,
+  luchador,
 }
 
 /***


### PR DESCRIPTION
## Summary
- Implements the **Luchador** uncommon joker: sell to disable the current Boss Blind's effects
- Adds `bossBlindDisabled` flag to `StaticRulesState`, checked alongside Chicot in `collectEffects`
- Flag resets to `false` at each blind selection (small, big, boss) in blind-selection handlers

Closes #766

## Test plan
- [x] Selling Luchador sets `bossBlindDisabled` to true
- [x] Flag suppresses boss blind effects in collectEffects
- [x] Flag resets on small blind selection
- [x] Flag resets on big blind selection
- [x] Flag resets on boss blind selection
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)