### PR TITLE
feat: track retroactive daily trivia completion (#1344)

### DIFF
--- a/src/app/api/v1/trivia/complete-game/route.ts
+++ b/src/app/api/v1/trivia/complete-game/route.ts
@@ -30,9 +30,14 @@ export async function POST(request: NextRequest) {
 
   const { date, score, correct, total, answers, category } = body
 
-  if (date !== getTodayPST()) {
-    return NextResponse.json({ error: 'Can only submit scores for today.' }, { status: 400 })
+  const today = getTodayPST()
+  if (!date || !/^\d{4}-\d{2}-\d{2}$/.test(date)) {
+    return NextResponse.json({ error: 'date must be YYYY-MM-DD.' }, { status: 400 })
   }
+  if (date > today) {
+    return NextResponse.json({ error: 'Cannot submit scores for a future date.' }, { status: 400 })
+  }
+  const isRetroactive = date !== today
   if (typeof score !== 'number' || score < 0 || score > MAX_SCORE) {
     return NextResponse.json(
       { error: `score must be a number between 0 and ${MAX_SCORE}.` },
@@ -63,6 +68,7 @@ export async function POST(request: NextRequest) {
       total,
       answers,
       category,
+      isRetroactive,
     })
     return NextResponse.json(result, { status: result.alreadySubmitted ? 409 : 200 })
   } catch (err) {

--- a/src/app/trivia/hooks/useTriviaUser.ts
+++ b/src/app/trivia/hooks/useTriviaUser.ts
@@ -74,6 +74,12 @@ function normalizeGame(data: DocumentData): TriviaGameResult {
   if (data.category && typeof data.category === 'object' && typeof data.category.name === 'string') {
     result.category = data.category
   }
+  if (data.playedAt?.toDate) {
+    result.playedAt = data.playedAt.toDate().toISOString()
+  }
+  if (typeof data.isRetroactive === 'boolean') {
+    result.isRetroactive = data.isRetroactive
+  }
   return result
 }
 

--- a/src/app/trivia/models/trivia.ts
+++ b/src/app/trivia/models/trivia.ts
@@ -12,6 +12,8 @@ export interface TriviaGameResult {
   total: number
   answers: TriviaAnswer[]
   category?: { id: number; name: string; icon: string }
+  playedAt?: string // ISO timestamp of when the game was actually played
+  isRetroactive?: boolean // true if played after the original date
 }
 
 export interface TriviaStats {

--- a/src/lib/trivia/transactions.ts
+++ b/src/lib/trivia/transactions.ts
@@ -45,6 +45,7 @@ export interface CompleteGameInput {
   total: number
   answers: TriviaAnswer[]
   category: { id: number; name: string; icon: string }
+  isRetroactive?: boolean
 }
 
 export interface CompleteGameResult {
@@ -111,9 +112,19 @@ export async function recordCompletedGame(
     const existing = profileSnap.exists
       ? (profileSnap.data() as TriviaProfile)
       : EMPTY_TRIVIA_PROFILE
-    const yesterday = getYesterdayOf(input.date)
-    const wasYesterday = existing.lastPlayedDate === yesterday
-    const newStreak = wasYesterday ? existing.currentStreak + 1 : 1
+
+    const isRetro = input.isRetroactive ?? false
+
+    // Streak logic: only update for same-day (non-retroactive) plays
+    let newStreak = existing.currentStreak
+    let newLastPlayed = existing.lastPlayedDate
+    if (!isRetro) {
+      const yesterday = getYesterdayOf(input.date)
+      const wasYesterday = existing.lastPlayedDate === yesterday
+      newStreak = wasYesterday ? existing.currentStreak + 1 : 1
+      newLastPlayed = input.date
+    }
+
     const nextProfile: TriviaProfile = {
       gamesPlayed: existing.gamesPlayed + 1,
       totalScore: existing.totalScore + input.score,
@@ -121,7 +132,7 @@ export async function recordCompletedGame(
       totalQuestions: existing.totalQuestions + input.total,
       currentStreak: newStreak,
       bestStreak: Math.max(newStreak, existing.bestStreak),
-      lastPlayedDate: input.date,
+      lastPlayedDate: newLastPlayed,
     }
 
     const existingWeekly = weeklySnap.exists
@@ -147,6 +158,8 @@ export async function recordCompletedGame(
       answers: input.answers,
       category: input.category,
       submittedAt: FieldValue.serverTimestamp(),
+      playedAt: FieldValue.serverTimestamp(),
+      isRetroactive: isRetro,
     })
     tx.set(profileRef, nextProfile)
     tx.set(dailyRef, {
@@ -157,6 +170,8 @@ export async function recordCompletedGame(
       total: input.total,
       nicknameSnapshot,
       submittedAt: FieldValue.serverTimestamp(),
+      playedAt: FieldValue.serverTimestamp(),
+      isRetroactive: isRetro,
     })
     tx.set(weeklyRef, nextWeekly)
 


### PR DESCRIPTION
## Summary

- Allow submitting game results for past dates (removes today-only constraint)
- Add `playedAt` timestamp and `isRetroactive` flag to `triviaGames` and `triviaDaily` Firestore writes
- Streak logic skips updates for retroactive plays — streaks only advance for same-day play
- Update `TriviaGameResult` model with optional `playedAt` and `isRetroactive` fields
- Hook `normalizeGame` extracts new fields from Firestore snapshots

Closes #1344

## Test plan

- [ ] Submit a game for today — verify `isRetroactive: false`, streak updates normally
- [ ] Submit a game for a past date — verify `isRetroactive: true`, streak unchanged
- [ ] Verify future dates are rejected (400 error)
- [ ] Verify duplicate submissions still return 409
- [ ] Check Firestore documents include `playedAt` and `isRetroactive` fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)