### PR TITLE
feat: load and play past daily trivia by date (#1345)

### DIFF
--- a/src/app/api/v1/trivia/check-answer/route.ts
+++ b/src/app/api/v1/trivia/check-answer/route.ts
@@ -20,19 +20,19 @@ export async function POST(request: NextRequest) {
     }
 
     const today = getTodayPST()
-    if (date !== today) {
+    if (date > today) {
       return NextResponse.json(
-        { error: "Can only check answers for today's trivia." },
+        { error: 'Cannot check answers for a future date.' },
         { status: 400 }
       )
     }
 
     // Look up the question in the shared cache, or load from disk
-    let cachedQuestions = dailyCache.get(today)
+    let cachedQuestions = dailyCache.get(date)
     if (!cachedQuestions) {
-      const fromDisk = loadDailyQuestionsFromDisk(today)
+      const fromDisk = loadDailyQuestionsFromDisk(date)
       if (fromDisk && fromDisk.length > 0) {
-        dailyCache.set(today, fromDisk)
+        dailyCache.set(date, fromDisk)
         cachedQuestions = fromDisk
       }
     }

--- a/src/app/api/v1/trivia/daily/route.ts
+++ b/src/app/api/v1/trivia/daily/route.ts
@@ -251,34 +251,36 @@ async function generateFallbackQuestions(
 export async function GET(request: NextRequest) {
   try {
     const today = getTodayPST()
+    const dateParam = request.nextUrl.searchParams.get('date')
+    const targetDate = dateParam && /^\d{4}-\d{2}-\d{2}$/.test(dateParam) ? dateParam : today
+
+    if (targetDate > today) {
+      return NextResponse.json({ error: 'Cannot load trivia for a future date.' }, { status: 400 })
+    }
 
     // Check cache first
-    if (dailyCache.has(today)) {
-      const cached = dailyCache.get(today)!
+    if (dailyCache.has(targetDate)) {
+      const cached = dailyCache.get(targetDate)!
       const questions: TriviaQuestion[] = cached.map(
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
         ({ correctAnswer, explanation, ...q }) => q
       )
-      return NextResponse.json({ date: today, questions })
+      return NextResponse.json({ date: targetDate, questions })
     }
 
     // PREFERRED: Load pre-generated questions from disk (static JSON files)
-    const preGenerated = loadDailyQuestionsFromDisk(today)
+    const preGenerated = loadDailyQuestionsFromDisk(targetDate)
     if (preGenerated && preGenerated.length > 0) {
-      dailyCache.set(today, preGenerated)
-      // Clean old cache entries
-      for (const key of dailyCache.keys()) {
-        if (key !== today) dailyCache.delete(key)
-      }
+      dailyCache.set(targetDate, preGenerated)
       const questions: TriviaQuestion[] = preGenerated.map(
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
         ({ correctAnswer, explanation, ...q }) => q
       )
-      return NextResponse.json({ date: today, questions })
+      return NextResponse.json({ date: targetDate, questions })
     }
 
     // FALLBACK: Generate questions on-the-fly if no pre-generated file exists
-    console.warn(`No pre-generated questions for ${today}, falling back to live generation`)
+    console.warn(`No pre-generated questions for ${targetDate}, falling back to live generation`)
 
     // Resolve API key for AI question
     let apiKey = process.env.NEXT_PUBLIC_OPENAI_API_KEY ?? process.env.OPENAI_API_KEY
@@ -286,12 +288,12 @@ export async function GET(request: NextRequest) {
     if (headerApiKey) apiKey = headerApiKey
 
     // Fetch OpenTDB questions
-    let opentdbQuestions = await fetchOpenTDBQuestions(today)
+    let opentdbQuestions = await fetchOpenTDBQuestions(targetDate)
 
     // If OpenTDB failed or returned too few, use AI fallback
     if (opentdbQuestions.length < 6 && apiKey) {
       const fallbacks = await generateFallbackQuestions(
-        today,
+        targetDate,
         6 - opentdbQuestions.length,
         apiKey
       )
@@ -303,7 +305,7 @@ export async function GET(request: NextRequest) {
     if (apiKey) {
       try {
         const aiQuestion = await generateAIQuestion(
-          today,
+          targetDate,
           opentdbQuestions[0]?.category || 'General Knowledge',
           apiKey
         )
@@ -315,23 +317,18 @@ export async function GET(request: NextRequest) {
     }
 
     // Shuffle question order deterministically
-    const seed = daysSinceEpoch(today)
+    const seed = daysSinceEpoch(targetDate)
     allQuestions = seededShuffle(allQuestions, seed)
 
     // Cache the full questions (with answers) server-side
-    dailyCache.set(today, allQuestions)
-
-    // Clean old cache entries
-    for (const key of dailyCache.keys()) {
-      if (key !== today) dailyCache.delete(key)
-    }
+    dailyCache.set(targetDate, allQuestions)
 
     // Return questions WITHOUT answers
     const questions: TriviaQuestion[] = allQuestions.map(
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       ({ correctAnswer, explanation, ...q }) => q
     )
-    return NextResponse.json({ date: today, questions })
+    return NextResponse.json({ date: targetDate, questions })
   } catch (error) {
     console.error('Error fetching daily trivia:', error)
     return NextResponse.json(

--- a/src/app/trivia/components/TriviaGame.tsx
+++ b/src/app/trivia/components/TriviaGame.tsx
@@ -30,7 +30,7 @@ function getQuestionConfig(q: TriviaQuestion) {
 
 type GamePhase = 'loading' | 'playing' | 'answered' | 'finished'
 
-export function TriviaGame({ onFinish, onFlee }: { onFinish: (result: TriviaGameResult) => void; onFlee?: () => void }) {
+export function TriviaGame({ onFinish, onFlee, date: dateProp }: { onFinish: (result: TriviaGameResult) => void; onFlee?: () => void; date?: string }) {
   const [questions, setQuestions] = useState<TriviaQuestion[]>([])
   const [currentIndex, setCurrentIndex] = useState(0)
   const [phase, setPhase] = useState<GamePhase>('loading')
@@ -55,11 +55,16 @@ export function TriviaGame({ onFinish, onFlee }: { onFinish: (result: TriviaGame
   const [answers, setAnswers] = useState<TriviaAnswer[]>([])
   const [totalScore, setTotalScore] = useState(0)
 
+  const gameDate = dateProp || getTodayPST()
+
   // Fetch questions on mount
   useEffect(() => {
     async function fetchQuestions() {
       try {
-        const res = await fetch('/api/v1/trivia/daily')
+        const url = gameDate === getTodayPST()
+          ? '/api/v1/trivia/daily'
+          : `/api/v1/trivia/daily?date=${gameDate}`
+        const res = await fetch(url)
         if (!res.ok) throw new Error('Failed to fetch questions')
         const data = await res.json()
         setQuestions(data.questions)
@@ -74,7 +79,7 @@ export function TriviaGame({ onFinish, onFlee }: { onFinish: (result: TriviaGame
       }
     }
     fetchQuestions()
-  }, [])
+  }, [gameDate])
 
   // Timer logic
   useEffect(() => {
@@ -129,7 +134,6 @@ export function TriviaGame({ onFinish, onFlee }: { onFinish: (result: TriviaGame
     setSelectedAnswer(answer)
 
     try {
-      const today = getTodayPST()
       const question = questions[currentIndex]
 
       const res = await fetch('/api/v1/trivia/check-answer', {
@@ -138,7 +142,7 @@ export function TriviaGame({ onFinish, onFlee }: { onFinish: (result: TriviaGame
         body: JSON.stringify({
           questionId: question.id,
           answer,
-          date: today,
+          date: gameDate,
         }),
       })
 
@@ -186,7 +190,7 @@ export function TriviaGame({ onFinish, onFlee }: { onFinish: (result: TriviaGame
       body: JSON.stringify({
         questionId: q.id,
         rating,
-        date: getTodayPST(),
+        date: gameDate,
         question: q.question,
         correctAnswer: answerResult?.correctAnswer ?? '',
         userAnswer: selectedAnswer,
@@ -201,14 +205,13 @@ export function TriviaGame({ onFinish, onFlee }: { onFinish: (result: TriviaGame
     setQuestionRating(null)
     if (currentIndex + 1 >= questions.length) {
       // Game over
-      const today = getTodayPST()
       const correctCount = answers.length > 0 ? answers.filter(a => a.correct).length : 0
       // Include the latest answer that was just added
       const allAnswers = answers
       const finalScore = allAnswers.reduce((sum, a) => sum + a.points, 0)
 
       const result: TriviaGameResult = {
-        date: today,
+        date: gameDate,
         score: finalScore,
         correct: correctCount,
         total: questions.length,

--- a/src/app/trivia/page.tsx
+++ b/src/app/trivia/page.tsx
@@ -26,7 +26,7 @@ import { UnifiedStats } from './components/UnifiedStats'
 import type { TriviaGameResult } from './models/trivia'
 import type { User } from 'firebase/auth'
 
-type View = 'landing' | 'playing' | 'results' | 'stats' | 'leaderboard' | 'infinite' | 'infinite-stats' | 'practice' | 'infinite-leaderboard' | 'library' | 'calendar'
+type View = 'landing' | 'playing' | 'playing-past' | 'results' | 'stats' | 'leaderboard' | 'infinite' | 'infinite-stats' | 'practice' | 'infinite-leaderboard' | 'library' | 'calendar'
 
 type StatsDefaultTab = 'daily' | 'infinite'
 
@@ -62,6 +62,7 @@ export default function TriviaPage() {
 
   const [view, setView] = useState<View>('landing')
   const [statsDefaultTab, setStatsDefaultTab] = useState<StatsDefaultTab>('daily')
+  const [playingDate, setPlayingDate] = useState<string | null>(null)
   const [lastResult, setLastResult] = useState<TriviaGameResult | null>(null)
   const [localToday, setLocalToday] = useState<TriviaGameResult | null>(null)
   const [autoResultsShown, setAutoResultsShown] = useState(false)
@@ -123,6 +124,28 @@ export default function TriviaPage() {
   const handleStartPractice = () => setView('practice')
   const handleViewInfiniteLeaderboard = () => setView('infinite-leaderboard')
 
+  const handleSelectPastDate = useCallback((date: string) => {
+    const alreadyPlayed = history.some((h) => h.date === date)
+    if (alreadyPlayed) return
+    setPlayingDate(date)
+    setView('playing-past')
+  }, [history])
+
+  const handleFinishPast = useCallback(
+    (result: TriviaGameResult) => {
+      setLastResult(result)
+      setView('results')
+      setPlayingDate(null)
+      if (user) {
+        submitGameToServer(user, result)
+          .catch((err) =>
+            console.error('Failed to submit retroactive game:', err)
+          )
+      }
+    },
+    [user]
+  )
+
   const handleStatsReset = useCallback(
     (scopes: { daily: boolean; infinite: boolean }) => {
       if (scopes.daily) {
@@ -182,6 +205,10 @@ export default function TriviaPage() {
     return <TriviaGame onFinish={handleFinish} />
   }
 
+  if (view === 'playing-past' && playingDate) {
+    return <TriviaGame date={playingDate} onFinish={handleFinishPast} onFlee={() => { setPlayingDate(null); setView('calendar') }} />
+  }
+
   if (view === 'results' && lastResult) {
     return (
       <TriviaResults
@@ -215,7 +242,7 @@ export default function TriviaPage() {
     return (
       <TriviaCalendar
         onPlayToday={handleStartGame}
-        onSelectDate={() => {}}
+        onSelectDate={handleSelectPastDate}
         onBack={handleBackToLanding}
         nav={nav}
       />


### PR DESCRIPTION
## Summary

- Daily trivia API now accepts `?date=YYYY-MM-DD` query param to load past questions
- Check-answer route accepts past dates (rejects future only)
- `TriviaGame` component accepts optional `date` prop for retroactive play
- Calendar view's `onSelectDate` launches past-date games (blocks already-played days)
- Flee button during past-date play returns to calendar view

Closes #1345

## Test plan

- [ ] Open calendar, click a missed past day — verify questions load for that date
- [ ] Play through all questions for a past day — verify results submit correctly
- [ ] Verify clicking "Flee" during past-date game returns to calendar
- [ ] Verify already-played days in calendar are not re-launchable
- [ ] Verify future dates return 400 from API
- [ ] Verify today's trivia still works unchanged via existing flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)