### PR TITLE
feat: weekly scoring rules for retroactive plays (#1346)

### DIFF
--- a/src/lib/trivia/transactions.ts
+++ b/src/lib/trivia/transactions.ts
@@ -1,7 +1,7 @@
 import { FieldValue, Timestamp } from 'firebase-admin/firestore'
 
 import type { TriviaAnswer } from '@/app/trivia/models/trivia'
-import { getWeekKey, getYesterdayOf } from '@/lib/dates'
+import { getTodayPST, getWeekKey, getYesterdayOf } from '@/lib/dates'
 import { getFirestoreDb } from '@/lib/firebase/server'
 import { type AuthClaims, getOrCreateProfile } from '@/lib/users/profile'
 
@@ -89,15 +89,19 @@ export async function recordCompletedGame(
   const gameRef = triviaGameRef(input.uid, input.date)
   const dailyRef = triviaDailyRef(input.uid, input.date)
   const weekKey = getWeekKey(input.date)
+  const currentWeekKey = getWeekKey(getTodayPST())
+  const isRetro = input.isRetroactive ?? false
+  // Skip weekly leaderboard write for retroactive plays from past weeks
+  const shouldUpdateWeekly = !isRetro || weekKey === currentWeekKey
   const weeklyRef = triviaWeeklyRef(input.uid, weekKey)
 
   return db.runTransaction(async (tx) => {
-    const [userSnap, profileSnap, gameSnap, weeklySnap] = await Promise.all([
+    const [userSnap, profileSnap, gameSnap] = await Promise.all([
       tx.get(userRef),
       tx.get(profileRef),
       tx.get(gameRef),
-      tx.get(weeklyRef),
     ])
+    const weeklySnap = shouldUpdateWeekly ? await tx.get(weeklyRef) : null
 
     if (gameSnap.exists) {
       const existingProfile = profileSnap.exists
@@ -112,8 +116,6 @@ export async function recordCompletedGame(
     const existing = profileSnap.exists
       ? (profileSnap.data() as TriviaProfile)
       : EMPTY_TRIVIA_PROFILE
-
-    const isRetro = input.isRetroactive ?? false
 
     // Streak logic: only update for same-day (non-retroactive) plays
     let newStreak = existing.currentStreak
@@ -135,18 +137,21 @@ export async function recordCompletedGame(
       lastPlayedDate: newLastPlayed,
     }
 
-    const existingWeekly = weeklySnap.exists
-      ? (weeklySnap.data() as TriviaWeeklyEntry)
-      : null
-    const nextWeekly: TriviaWeeklyEntry = {
-      uid: input.uid,
-      weekKey,
-      totalScore: (existingWeekly?.totalScore ?? 0) + input.score,
-      gamesPlayed: (existingWeekly?.gamesPlayed ?? 0) + 1,
-      totalCorrect: (existingWeekly?.totalCorrect ?? 0) + input.correct,
-      totalQuestions: (existingWeekly?.totalQuestions ?? 0) + input.total,
-      nicknameSnapshot,
-      lastUpdated: FieldValue.serverTimestamp(),
+    let nextWeekly: TriviaWeeklyEntry | null = null
+    if (shouldUpdateWeekly && weeklySnap) {
+      const existingWeekly = weeklySnap.exists
+        ? (weeklySnap.data() as TriviaWeeklyEntry)
+        : null
+      nextWeekly = {
+        uid: input.uid,
+        weekKey,
+        totalScore: (existingWeekly?.totalScore ?? 0) + input.score,
+        gamesPlayed: (existingWeekly?.gamesPlayed ?? 0) + 1,
+        totalCorrect: (existingWeekly?.totalCorrect ?? 0) + input.correct,
+        totalQuestions: (existingWeekly?.totalQuestions ?? 0) + input.total,
+        nicknameSnapshot,
+        lastUpdated: FieldValue.serverTimestamp(),
+      }
     }
 
     tx.set(gameRef, {
@@ -173,7 +178,9 @@ export async function recordCompletedGame(
       playedAt: FieldValue.serverTimestamp(),
       isRetroactive: isRetro,
     })
-    tx.set(weeklyRef, nextWeekly)
+    if (nextWeekly) {
+      tx.set(weeklyRef, nextWeekly)
+    }
 
     return { alreadySubmitted: false, profile: nextProfile }
   })


### PR DESCRIPTION
## Summary

- Retroactive plays for dates within the **current week** count toward the weekly winner leaderboard (unchanged behavior)
- Retroactive plays for dates in **past weeks** are excluded from weekly aggregation entirely (no stale weekly writes)
- Non-retroactive (same-day) plays always count toward weekly leaderboard (unchanged)

Closes #1346

## Test plan

- [ ] Play today's trivia — verify weekly leaderboard updates normally
- [ ] Play a missed day from the current week — verify weekly leaderboard includes the score
- [ ] Play a missed day from a past week — verify NO weekly leaderboard write occurs
- [ ] Verify streaks are unaffected (still only updated for same-day plays)

🤖 Generated with [Claude Code](https://claude.com/claude-code)