### PR TITLE
feat: integrate retroactive plays into stats and calendar UI (#1347)

### DIFF
--- a/src/app/trivia/components/TriviaCalendar.tsx
+++ b/src/app/trivia/components/TriviaCalendar.tsx
@@ -44,6 +44,7 @@ export function TriviaCalendar({ onPlayToday, onSelectDate, onBack, nav }: Trivi
   const [viewDate, setViewDate] = useState(() => startOfMonth(todayDate))
 
   const playedSet = new Set(history.map((r) => r.date))
+  const retroactiveSet = new Set(history.filter((r) => r.isRetroactive).map((r) => r.date))
 
   const monthStart = startOfMonth(viewDate)
   const monthEnd = endOfMonth(viewDate)
@@ -132,6 +133,7 @@ export function TriviaCalendar({ onPlayToday, onSelectDate, onBack, nav }: Trivi
               const status = getDayStatus(day)
               const category = status === 'played' || status === 'today' ? getDailyCategory(str) : null
 
+              const isRetro = retroactiveSet.has(str)
               const isClickable = inMonth && (status === 'today' || status === 'missed')
 
               const cellBase =
@@ -161,7 +163,7 @@ export function TriviaCalendar({ onPlayToday, onSelectDate, onBack, nav }: Trivi
                       : status === 'missed'
                         ? `${format(day, 'MMMM d')} — missed`
                         : status === 'played'
-                          ? `${format(day, 'MMMM d')} — played`
+                          ? `${format(day, 'MMMM d')} — played${isRetro ? ' (retroactive)' : ''}`
                           : format(day, 'MMMM d')
                   }
                 >
@@ -176,6 +178,9 @@ export function TriviaCalendar({ onPlayToday, onSelectDate, onBack, nav }: Trivi
                       Today
                     </span>
                   )}
+                  {status === 'played' && isRetro && (
+                    <span className="absolute top-0.5 right-0.5 w-1.5 h-1.5 rounded-full bg-yellow-400/70" title="Played retroactively" />
+                  )}
                 </button>
               )
             })}
@@ -188,7 +193,7 @@ export function TriviaCalendar({ onPlayToday, onSelectDate, onBack, nav }: Trivi
             {pastDaysThisMonth} days this month
           </div>
 
-          <div className="mt-3 flex items-center justify-center gap-4 text-xs text-on-surface/50">
+          <div className="mt-3 flex items-center justify-center gap-4 text-xs text-on-surface/50 flex-wrap">
             <span className="flex items-center gap-1.5">
               <span className="w-3 h-3 rounded bg-ds-tertiary/20 inline-block" />
               Played
@@ -200,6 +205,12 @@ export function TriviaCalendar({ onPlayToday, onSelectDate, onBack, nav }: Trivi
             <span className="flex items-center gap-1.5">
               <span className="w-3 h-3 rounded bg-surface-variant/30 border border-outline-variant/40 inline-block" />
               Missed
+            </span>
+            <span className="flex items-center gap-1.5">
+              <span className="relative w-3 h-3 rounded bg-ds-tertiary/20 inline-block">
+                <span className="absolute top-0 right-0 w-1.5 h-1.5 rounded-full bg-yellow-400/70" />
+              </span>
+              Retroactive
             </span>
           </div>
         </ChunkyCardContent>

--- a/src/app/trivia/components/TriviaStats.tsx
+++ b/src/app/trivia/components/TriviaStats.tsx
@@ -137,6 +137,9 @@ export function TriviaStats({ onBack }: { onBack: () => void }) {
               <div className="text-on-surface/50 text-xs mt-1">Best Streak</div>
             </div>
           </div>
+          <p className="text-on-surface/30 text-[10px] text-center mt-2">
+            Streaks count same-day plays only. Retroactive games count toward other stats.
+          </p>
         </ChunkyCardContent>
       </ChunkyCard>
 
@@ -195,6 +198,11 @@ export function TriviaStats({ onBack }: { onBack: () => void }) {
                     <div className="flex flex-col">
                       <span className="text-on-surface text-sm font-medium">
                         {formatDisplayDate(game.date)}
+                        {game.isRetroactive && (
+                          <span className="ml-1.5 text-[10px] px-1.5 py-0.5 rounded bg-surface-variant/50 text-on-surface/40 uppercase tracking-wide">
+                            Retroactive
+                          </span>
+                        )}
                       </span>
                       <span className="text-on-surface/40 text-xs">
                         {game.correct}/{game.total} correct


### PR DESCRIPTION
## Summary

- Add "Retroactive" tag on games played retroactively in the Recent Games stats history
- Add small yellow dot indicator on retroactively-played calendar day cells
- Add "Retroactive" entry to the calendar legend
- Add clarification note under streaks: "Streaks count same-day plays only. Retroactive games count toward other stats."
- Updated aria-labels for retroactive calendar days

Closes #1347

## Test plan

- [ ] Play a past day's trivia from the calendar
- [ ] Verify "Retroactive" tag appears next to the game in My Stats → Recent Games
- [ ] Verify small yellow dot appears on the retroactively-played day in the calendar
- [ ] Verify the legend shows the "Retroactive" indicator
- [ ] Verify same-day plays do NOT show retroactive indicators
- [ ] Verify streak note text is visible under streak display

🤖 Generated with [Claude Code](https://claude.com/claude-code)