### PR TITLE
feat: Daily Trivia Calendar — play past days, retroactive stats, month view

### DIFF
--- a/src/app/api/v1/trivia/check-answer/route.ts
+++ b/src/app/api/v1/trivia/check-answer/route.ts
@@ -20,19 +20,19 @@ export async function POST(request: NextRequest) {
     }
 
     const today = getTodayPST()
-    if (date !== today) {
+    if (date > today) {
       return NextResponse.json(
-        { error: "Can only check answers for today's trivia." },
+        { error: 'Cannot check answers for a future date.' },
         { status: 400 }
       )
     }
 
     // Look up the question in the shared cache, or load from disk
-    let cachedQuestions = dailyCache.get(today)
+    let cachedQuestions = dailyCache.get(date)
     if (!cachedQuestions) {
-      const fromDisk = loadDailyQuestionsFromDisk(today)
+      const fromDisk = loadDailyQuestionsFromDisk(date)
       if (fromDisk && fromDisk.length > 0) {
-        dailyCache.set(today, fromDisk)
+        dailyCache.set(date, fromDisk)
         cachedQuestions = fromDisk
       }
     }

--- a/src/app/api/v1/trivia/complete-game/route.ts
+++ b/src/app/api/v1/trivia/complete-game/route.ts
@@ -30,9 +30,14 @@ export async function POST(request: NextRequest) {
 
   const { date, score, correct, total, answers, category } = body
 
-  if (date !== getTodayPST()) {
-    return NextResponse.json({ error: 'Can only submit scores for today.' }, { status: 400 })
+  const today = getTodayPST()
+  if (!date || !/^\d{4}-\d{2}-\d{2}$/.test(date)) {
+    return NextResponse.json({ error: 'date must be YYYY-MM-DD.' }, { status: 400 })
   }
+  if (date > today) {
+    return NextResponse.json({ error: 'Cannot submit scores for a future date.' }, { status: 400 })
+  }
+  const isRetroactive = date !== today
   if (typeof score !== 'number' || score < 0 || score > MAX_SCORE) {
     return NextResponse.json(
       { error: `score must be a number between 0 and ${MAX_SCORE}.` },
@@ -63,6 +68,7 @@ export async function POST(request: NextRequest) {
       total,
       answers,
       category,
+      isRetroactive,
     })
     return NextResponse.json(result, { status: result.alreadySubmitted ? 409 : 200 })
   } catch (err) {

--- a/src/app/api/v1/trivia/daily/route.ts
+++ b/src/app/api/v1/trivia/daily/route.ts
@@ -251,34 +251,36 @@ async function generateFallbackQuestions(
 export async function GET(request: NextRequest) {
   try {
     const today = getTodayPST()
+    const dateParam = request.nextUrl.searchParams.get('date')
+    const targetDate = dateParam && /^\d{4}-\d{2}-\d{2}$/.test(dateParam) ? dateParam : today
+
+    if (targetDate > today) {
+      return NextResponse.json({ error: 'Cannot load trivia for a future date.' }, { status: 400 })
+    }
 
     // Check cache first
-    if (dailyCache.has(today)) {
-      const cached = dailyCache.get(today)!
+    if (dailyCache.has(targetDate)) {
+      const cached = dailyCache.get(targetDate)!
       const questions: TriviaQuestion[] = cached.map(
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
         ({ correctAnswer, explanation, ...q }) => q
       )
-      return NextResponse.json({ date: today, questions })
+      return NextResponse.json({ date: targetDate, questions })
     }
 
     // PREFERRED: Load pre-generated questions from disk (static JSON files)
-    const preGenerated = loadDailyQuestionsFromDisk(today)
+    const preGenerated = loadDailyQuestionsFromDisk(targetDate)
     if (preGenerated && preGenerated.length > 0) {
-      dailyCache.set(today, preGenerated)
-      // Clean old cache entries
-      for (const key of dailyCache.keys()) {
-        if (key !== today) dailyCache.delete(key)
-      }
+      dailyCache.set(targetDate, preGenerated)
       const questions: TriviaQuestion[] = preGenerated.map(
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
         ({ correctAnswer, explanation, ...q }) => q
       )
-      return NextResponse.json({ date: today, questions })
+      return NextResponse.json({ date: targetDate, questions })
     }
 
     // FALLBACK: Generate questions on-the-fly if no pre-generated file exists
-    console.warn(`No pre-generated questions for ${today}, falling back to live generation`)
+    console.warn(`No pre-generated questions for ${targetDate}, falling back to live generation`)
 
     // Resolve API key for AI question
     let apiKey = process.env.NEXT_PUBLIC_OPENAI_API_KEY ?? process.env.OPENAI_API_KEY
@@ -286,12 +288,12 @@ export async function GET(request: NextRequest) {
     if (headerApiKey) apiKey = headerApiKey
 
     // Fetch OpenTDB questions
-    let opentdbQuestions = await fetchOpenTDBQuestions(today)
+    let opentdbQuestions = await fetchOpenTDBQuestions(targetDate)
 
     // If OpenTDB failed or returned too few, use AI fallback
     if (opentdbQuestions.length < 6 && apiKey) {
       const fallbacks = await generateFallbackQuestions(
-        today,
+        targetDate,
         6 - opentdbQuestions.length,
         apiKey
       )
@@ -303,7 +305,7 @@ export async function GET(request: NextRequest) {
     if (apiKey) {
       try {
         const aiQuestion = await generateAIQuestion(
-          today,
+          targetDate,
           opentdbQuestions[0]?.category || 'General Knowledge',
           apiKey
         )
@@ -315,23 +317,18 @@ export async function GET(request: NextRequest) {
     }
 
     // Shuffle question order deterministically
-    const seed = daysSinceEpoch(today)
+    const seed = daysSinceEpoch(targetDate)
     allQuestions = seededShuffle(allQuestions, seed)
 
     // Cache the full questions (with answers) server-side
-    dailyCache.set(today, allQuestions)
-
-    // Clean old cache entries
-    for (const key of dailyCache.keys()) {
-      if (key !== today) dailyCache.delete(key)
-    }
+    dailyCache.set(targetDate, allQuestions)
 
     // Return questions WITHOUT answers
     const questions: TriviaQuestion[] = allQuestions.map(
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       ({ correctAnswer, explanation, ...q }) => q
     )
-    return NextResponse.json({ date: today, questions })
+    return NextResponse.json({ date: targetDate, questions })
   } catch (error) {
     console.error('Error fetching daily trivia:', error)
     return NextResponse.json(

--- a/src/app/trivia/components/TriviaCalendar.tsx
+++ b/src/app/trivia/components/TriviaCalendar.tsx
@@ -44,6 +44,7 @@ export function TriviaCalendar({ onPlayToday, onSelectDate, onBack, nav }: Trivi
   const [viewDate, setViewDate] = useState(() => startOfMonth(todayDate))
 
   const playedSet = new Set(history.map((r) => r.date))
+  const retroactiveSet = new Set(history.filter((r) => r.isRetroactive).map((r) => r.date))
 
   const monthStart = startOfMonth(viewDate)
   const monthEnd = endOfMonth(viewDate)
@@ -132,6 +133,7 @@ export function TriviaCalendar({ onPlayToday, onSelectDate, onBack, nav }: Trivi
               const status = getDayStatus(day)
               const category = status === 'played' || status === 'today' ? getDailyCategory(str) : null
 
+              const isRetro = retroactiveSet.has(str)
               const isClickable = inMonth && (status === 'today' || status === 'missed')
 
               const cellBase =
@@ -161,7 +163,7 @@ export function TriviaCalendar({ onPlayToday, onSelectDate, onBack, nav }: Trivi
                       : status === 'missed'
                         ? `${format(day, 'MMMM d')} — missed`
                         : status === 'played'
-                          ? `${format(day, 'MMMM d')} — played`
+                          ? `${format(day, 'MMMM d')} — played${isRetro ? ' (retroactive)' : ''}`
                           : format(day, 'MMMM d')
                   }
                 >
@@ -176,6 +178,9 @@ export function TriviaCalendar({ onPlayToday, onSelectDate, onBack, nav }: Trivi
                       Today
                     </span>
                   )}
+                  {status === 'played' && isRetro && (
+                    <span className="absolute top-0.5 right-0.5 w-1.5 h-1.5 rounded-full bg-yellow-400/70" title="Played retroactively" />
+                  )}
                 </button>
               )
             })}
@@ -188,7 +193,7 @@ export function TriviaCalendar({ onPlayToday, onSelectDate, onBack, nav }: Trivi
             {pastDaysThisMonth} days this month
           </div>
 
-          <div className="mt-3 flex items-center justify-center gap-4 text-xs text-on-surface/50">
+          <div className="mt-3 flex items-center justify-center gap-4 text-xs text-on-surface/50 flex-wrap">
             <span className="flex items-center gap-1.5">
               <span className="w-3 h-3 rounded bg-ds-tertiary/20 inline-block" />
               Played
@@ -200,6 +205,12 @@ export function TriviaCalendar({ onPlayToday, onSelectDate, onBack, nav }: Trivi
             <span className="flex items-center gap-1.5">
               <span className="w-3 h-3 rounded bg-surface-variant/30 border border-outline-variant/40 inline-block" />
               Missed
+            </span>
+            <span className="flex items-center gap-1.5">
+              <span className="relative w-3 h-3 rounded bg-ds-tertiary/20 inline-block">
+                <span className="absolute top-0 right-0 w-1.5 h-1.5 rounded-full bg-yellow-400/70" />
+              </span>
+              Retroactive
             </span>
           </div>
         </ChunkyCardContent>

--- a/src/app/trivia/components/TriviaCalendar.tsx
+++ b/src/app/trivia/components/TriviaCalendar.tsx
@@ -1,0 +1,211 @@
+'use client'
+
+import {
+  addMonths,
+  eachDayOfInterval,
+  endOfMonth,
+  endOfWeek,
+  format,
+  isAfter,
+  isSameMonth,
+  startOfMonth,
+  startOfWeek,
+  subMonths,
+} from 'date-fns'
+import { useState } from 'react'
+
+import { useTriviaUser } from '@/app/trivia/hooks/useTriviaUser'
+import { ChunkyCard, ChunkyCardContent, ChunkyCardHeader, ChunkyCardTitle } from '@/components/ui/chunky-card'
+import { getTodayPST } from '@/lib/dates'
+import { getDailyCategory } from '@/lib/trivia/categories'
+
+import { TriviaFooter } from './TriviaFooter'
+
+import type { TriviaNav } from './TriviaFooter'
+
+interface TriviaCalendarProps {
+  onPlayToday: () => void
+  onSelectDate: (date: string) => void
+  onBack: () => void
+  nav: TriviaNav
+}
+
+type DayStatus = 'played' | 'missed' | 'today' | 'future'
+
+function toDateObj(dateStr: string): Date {
+  return new Date(dateStr + 'T12:00:00')
+}
+
+export function TriviaCalendar({ onPlayToday, onSelectDate, onBack, nav }: TriviaCalendarProps) {
+  const { history } = useTriviaUser()
+  const todayStr = getTodayPST()
+  const todayDate = toDateObj(todayStr)
+
+  const [viewDate, setViewDate] = useState(() => startOfMonth(todayDate))
+
+  const playedSet = new Set(history.map((r) => r.date))
+
+  const monthStart = startOfMonth(viewDate)
+  const monthEnd = endOfMonth(viewDate)
+  const gridStart = startOfWeek(monthStart, { weekStartsOn: 0 })
+  const gridEnd = endOfWeek(monthEnd, { weekStartsOn: 0 })
+  const allDays = eachDayOfInterval({ start: gridStart, end: gridEnd })
+
+  function getDayStatus(day: Date): DayStatus {
+    const str = format(day, 'yyyy-MM-dd')
+    if (str === todayStr) return 'today'
+    if (isAfter(day, todayDate)) return 'future'
+    if (playedSet.has(str)) return 'played'
+    return 'missed'
+  }
+
+  const daysInMonth = eachDayOfInterval({ start: monthStart, end: monthEnd })
+  const playedThisMonth = daysInMonth.filter((d) => playedSet.has(format(d, 'yyyy-MM-dd'))).length
+  const pastDaysThisMonth = daysInMonth.filter((d) => !isAfter(d, todayDate)).length
+
+  const isCurrentMonth = format(viewDate, 'yyyy-MM') === format(todayDate, 'yyyy-MM')
+
+  function handleDayClick(day: Date, status: DayStatus) {
+    if (status === 'today') {
+      onPlayToday()
+    } else if (status === 'missed') {
+      onSelectDate(format(day, 'yyyy-MM-dd'))
+    }
+  }
+
+  const DAY_LABELS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']
+
+  return (
+    <div className="flex flex-col items-center gap-6 max-w-lg mx-auto py-8">
+      <div className="w-full flex items-center justify-between">
+        <button
+          type="button"
+          onClick={onBack}
+          className="text-ds-tertiary hover:text-ds-tertiary/80 transition-colors text-sm underline-offset-4 hover:underline"
+        >
+          ← Back
+        </button>
+        <h1 className="font-headline text-headline-lg text-ds-tertiary">Calendar</h1>
+        <div className="w-16" />
+      </div>
+
+      <ChunkyCard variant="surface-container-high" className="w-full">
+        <ChunkyCardHeader>
+          <div className="flex items-center justify-between w-full">
+            <button
+              type="button"
+              onClick={() => setViewDate((d) => subMonths(d, 1))}
+              className="text-on-surface/60 hover:text-on-surface transition-colors px-2 py-1 rounded"
+              aria-label="Previous month"
+            >
+              ‹
+            </button>
+            <ChunkyCardTitle className="text-on-surface text-center">
+              {format(viewDate, 'MMMM yyyy')}
+            </ChunkyCardTitle>
+            <button
+              type="button"
+              onClick={() => setViewDate((d) => addMonths(d, 1))}
+              disabled={isCurrentMonth}
+              className="text-on-surface/60 hover:text-on-surface transition-colors px-2 py-1 rounded disabled:opacity-30 disabled:cursor-not-allowed"
+              aria-label="Next month"
+            >
+              ›
+            </button>
+          </div>
+        </ChunkyCardHeader>
+        <ChunkyCardContent>
+          <div className="grid grid-cols-7 gap-1 mb-2">
+            {DAY_LABELS.map((label) => (
+              <div
+                key={label}
+                className="text-center text-xs text-on-surface/40 font-medium py-1"
+              >
+                {label}
+              </div>
+            ))}
+          </div>
+          <div className="grid grid-cols-7 gap-1">
+            {allDays.map((day) => {
+              const str = format(day, 'yyyy-MM-dd')
+              const inMonth = isSameMonth(day, viewDate)
+              const status = getDayStatus(day)
+              const category = status === 'played' || status === 'today' ? getDailyCategory(str) : null
+
+              const isClickable = inMonth && (status === 'today' || status === 'missed')
+
+              const cellBase =
+                'relative flex flex-col items-center justify-center rounded-lg aspect-square text-xs transition-colors'
+
+              const cellStyle =
+                !inMonth
+                  ? 'opacity-20'
+                  : status === 'played'
+                    ? 'bg-ds-tertiary/20 text-ds-tertiary'
+                    : status === 'today'
+                      ? 'bg-ds-tertiary text-surface-container ring-2 ring-ds-tertiary ring-offset-1'
+                      : status === 'missed'
+                        ? 'bg-surface-variant/30 text-on-surface border border-outline-variant/40 hover:bg-surface-variant/50 cursor-pointer'
+                        : 'text-on-surface/30'
+
+              return (
+                <button
+                  key={str}
+                  type="button"
+                  disabled={!isClickable}
+                  onClick={() => isClickable && handleDayClick(day, status)}
+                  className={`${cellBase} ${cellStyle} ${!isClickable ? 'cursor-default' : ''}`}
+                  aria-label={
+                    status === 'today'
+                      ? `Today, ${format(day, 'MMMM d')} — play now`
+                      : status === 'missed'
+                        ? `${format(day, 'MMMM d')} — missed`
+                        : status === 'played'
+                          ? `${format(day, 'MMMM d')} — played`
+                          : format(day, 'MMMM d')
+                  }
+                >
+                  {status === 'played' && category && (
+                    <span className="text-base leading-none mb-0.5">{category.icon}</span>
+                  )}
+                  <span className={status === 'played' ? 'text-[10px]' : 'font-medium'}>
+                    {format(day, 'd')}
+                  </span>
+                  {status === 'today' && (
+                    <span className="text-[8px] leading-none mt-0.5 font-bold uppercase tracking-wide opacity-80">
+                      Today
+                    </span>
+                  )}
+                </button>
+              )
+            })}
+          </div>
+
+          <div className="mt-4 text-center text-sm text-on-surface/60 border-t border-outline-variant/20 pt-3">
+            Played{' '}
+            <span className="text-ds-tertiary font-semibold">{playedThisMonth}</span>
+            {' / '}
+            {pastDaysThisMonth} days this month
+          </div>
+
+          <div className="mt-3 flex items-center justify-center gap-4 text-xs text-on-surface/50">
+            <span className="flex items-center gap-1.5">
+              <span className="w-3 h-3 rounded bg-ds-tertiary/20 inline-block" />
+              Played
+            </span>
+            <span className="flex items-center gap-1.5">
+              <span className="w-3 h-3 rounded bg-ds-tertiary inline-block" />
+              Today
+            </span>
+            <span className="flex items-center gap-1.5">
+              <span className="w-3 h-3 rounded bg-surface-variant/30 border border-outline-variant/40 inline-block" />
+              Missed
+            </span>
+          </div>
+        </ChunkyCardContent>
+      </ChunkyCard>
+
+      <TriviaFooter current="calendar" {...nav} />
+    </div>
+  )
+}

--- a/src/app/trivia/components/TriviaFooter.tsx
+++ b/src/app/trivia/components/TriviaFooter.tsx
@@ -7,6 +7,7 @@ export type TriviaFooterTarget =
   | 'infinite-stats'
   | 'infinite-leaderboard'
   | 'library'
+  | 'calendar'
 
 export interface TriviaNav {
   onHome?: () => void
@@ -15,6 +16,7 @@ export interface TriviaNav {
   onViewInfiniteStats?: () => void
   onViewInfiniteLeaderboard?: () => void
   onLibrary?: () => void
+  onCalendar?: () => void
 }
 
 interface TriviaFooterProps extends TriviaNav {
@@ -31,6 +33,7 @@ export function TriviaFooter({
   onViewInfiniteStats,
   onViewInfiniteLeaderboard,
   onLibrary,
+  onCalendar,
   current,
 }: TriviaFooterProps) {
   const links: { key: TriviaFooterTarget; label: string; onClick?: () => void }[] = [
@@ -40,6 +43,7 @@ export function TriviaFooter({
     { key: 'infinite-stats', label: 'Infinite Stats', onClick: onViewInfiniteStats },
     { key: 'infinite-leaderboard', label: 'Infinite Ranks', onClick: onViewInfiniteLeaderboard },
     { key: 'library', label: 'Question Library', onClick: onLibrary },
+    { key: 'calendar', label: 'Calendar', onClick: onCalendar },
   ]
   const visible = links.filter((l) => l.onClick && l.key !== current)
 

--- a/src/app/trivia/components/TriviaGame.tsx
+++ b/src/app/trivia/components/TriviaGame.tsx
@@ -30,7 +30,7 @@ function getQuestionConfig(q: TriviaQuestion) {
 
 type GamePhase = 'loading' | 'playing' | 'answered' | 'finished'
 
-export function TriviaGame({ onFinish, onFlee }: { onFinish: (result: TriviaGameResult) => void; onFlee?: () => void }) {
+export function TriviaGame({ onFinish, onFlee, date: dateProp }: { onFinish: (result: TriviaGameResult) => void; onFlee?: () => void; date?: string }) {
   const [questions, setQuestions] = useState<TriviaQuestion[]>([])
   const [currentIndex, setCurrentIndex] = useState(0)
   const [phase, setPhase] = useState<GamePhase>('loading')
@@ -55,11 +55,16 @@ export function TriviaGame({ onFinish, onFlee }: { onFinish: (result: TriviaGame
   const [answers, setAnswers] = useState<TriviaAnswer[]>([])
   const [totalScore, setTotalScore] = useState(0)
 
+  const gameDate = dateProp || getTodayPST()
+
   // Fetch questions on mount
   useEffect(() => {
     async function fetchQuestions() {
       try {
-        const res = await fetch('/api/v1/trivia/daily')
+        const url = gameDate === getTodayPST()
+          ? '/api/v1/trivia/daily'
+          : `/api/v1/trivia/daily?date=${gameDate}`
+        const res = await fetch(url)
         if (!res.ok) throw new Error('Failed to fetch questions')
         const data = await res.json()
         setQuestions(data.questions)
@@ -74,7 +79,7 @@ export function TriviaGame({ onFinish, onFlee }: { onFinish: (result: TriviaGame
       }
     }
     fetchQuestions()
-  }, [])
+  }, [gameDate])
 
   // Timer logic
   useEffect(() => {
@@ -129,7 +134,6 @@ export function TriviaGame({ onFinish, onFlee }: { onFinish: (result: TriviaGame
     setSelectedAnswer(answer)
 
     try {
-      const today = getTodayPST()
       const question = questions[currentIndex]
 
       const res = await fetch('/api/v1/trivia/check-answer', {
@@ -138,7 +142,7 @@ export function TriviaGame({ onFinish, onFlee }: { onFinish: (result: TriviaGame
         body: JSON.stringify({
           questionId: question.id,
           answer,
-          date: today,
+          date: gameDate,
         }),
       })
 
@@ -186,7 +190,7 @@ export function TriviaGame({ onFinish, onFlee }: { onFinish: (result: TriviaGame
       body: JSON.stringify({
         questionId: q.id,
         rating,
-        date: getTodayPST(),
+        date: gameDate,
         question: q.question,
         correctAnswer: answerResult?.correctAnswer ?? '',
         userAnswer: selectedAnswer,
@@ -201,14 +205,13 @@ export function TriviaGame({ onFinish, onFlee }: { onFinish: (result: TriviaGame
     setQuestionRating(null)
     if (currentIndex + 1 >= questions.length) {
       // Game over
-      const today = getTodayPST()
       const correctCount = answers.length > 0 ? answers.filter(a => a.correct).length : 0
       // Include the latest answer that was just added
       const allAnswers = answers
       const finalScore = allAnswers.reduce((sum, a) => sum + a.points, 0)
 
       const result: TriviaGameResult = {
-        date: today,
+        date: gameDate,
         score: finalScore,
         correct: correctCount,
         total: questions.length,

--- a/src/app/trivia/components/TriviaLanding.tsx
+++ b/src/app/trivia/components/TriviaLanding.tsx
@@ -27,6 +27,7 @@ export function TriviaLanding({
   onStartPractice,
   onViewInfiniteLeaderboard,
   onLibrary,
+  onCalendar,
   onStatsReset,
   todayResult,
 }: {
@@ -38,6 +39,7 @@ export function TriviaLanding({
   onStartPractice?: () => void
   onViewInfiniteLeaderboard?: () => void
   onLibrary?: () => void
+  onCalendar?: () => void
   onStatsReset?: (scopes: ResetScopes) => void
   todayResult: TriviaGameResult | null
 }) {
@@ -113,6 +115,16 @@ export function TriviaLanding({
             </span>
           </span>
         </div>
+      )}
+
+      {onCalendar && (
+        <button
+          type="button"
+          onClick={onCalendar}
+          className="text-ds-tertiary/70 hover:text-ds-tertiary text-sm underline-offset-4 hover:underline transition-colors"
+        >
+          View monthly calendar →
+        </button>
       )}
 
       {showSignInPromos && (
@@ -234,6 +246,7 @@ export function TriviaLanding({
         onViewInfiniteStats={onViewInfiniteStats}
         onViewInfiniteLeaderboard={onViewInfiniteLeaderboard}
         onLibrary={onLibrary}
+        onCalendar={onCalendar}
       />
 
       {nicknameDialogOpen && (

--- a/src/app/trivia/components/TriviaStats.tsx
+++ b/src/app/trivia/components/TriviaStats.tsx
@@ -137,6 +137,9 @@ export function TriviaStats({ onBack }: { onBack: () => void }) {
               <div className="text-on-surface/50 text-xs mt-1">Best Streak</div>
             </div>
           </div>
+          <p className="text-on-surface/30 text-[10px] text-center mt-2">
+            Streaks count same-day plays only. Retroactive games count toward other stats.
+          </p>
         </ChunkyCardContent>
       </ChunkyCard>
 
@@ -195,6 +198,11 @@ export function TriviaStats({ onBack }: { onBack: () => void }) {
                     <div className="flex flex-col">
                       <span className="text-on-surface text-sm font-medium">
                         {formatDisplayDate(game.date)}
+                        {game.isRetroactive && (
+                          <span className="ml-1.5 text-[10px] px-1.5 py-0.5 rounded bg-surface-variant/50 text-on-surface/40 uppercase tracking-wide">
+                            Retroactive
+                          </span>
+                        )}
                       </span>
                       <span className="text-on-surface/40 text-xs">
                         {game.correct}/{game.total} correct

--- a/src/app/trivia/hooks/useTriviaUser.ts
+++ b/src/app/trivia/hooks/useTriviaUser.ts
@@ -74,6 +74,12 @@ function normalizeGame(data: DocumentData): TriviaGameResult {
   if (data.category && typeof data.category === 'object' && typeof data.category.name === 'string') {
     result.category = data.category
   }
+  if (data.playedAt?.toDate) {
+    result.playedAt = data.playedAt.toDate().toISOString()
+  }
+  if (typeof data.isRetroactive === 'boolean') {
+    result.isRetroactive = data.isRetroactive
+  }
   return result
 }
 

--- a/src/app/trivia/models/trivia.ts
+++ b/src/app/trivia/models/trivia.ts
@@ -12,6 +12,8 @@ export interface TriviaGameResult {
   total: number
   answers: TriviaAnswer[]
   category?: { id: number; name: string; icon: string }
+  playedAt?: string // ISO timestamp of when the game was actually played
+  isRetroactive?: boolean // true if played after the original date
 }
 
 export interface TriviaStats {

--- a/src/app/trivia/page.tsx
+++ b/src/app/trivia/page.tsx
@@ -26,7 +26,7 @@ import { UnifiedStats } from './components/UnifiedStats'
 import type { TriviaGameResult } from './models/trivia'
 import type { User } from 'firebase/auth'
 
-type View = 'landing' | 'playing' | 'results' | 'stats' | 'leaderboard' | 'infinite' | 'infinite-stats' | 'practice' | 'infinite-leaderboard' | 'library' | 'calendar'
+type View = 'landing' | 'playing' | 'playing-past' | 'results' | 'stats' | 'leaderboard' | 'infinite' | 'infinite-stats' | 'practice' | 'infinite-leaderboard' | 'library' | 'calendar'
 
 type StatsDefaultTab = 'daily' | 'infinite'
 
@@ -62,6 +62,7 @@ export default function TriviaPage() {
 
   const [view, setView] = useState<View>('landing')
   const [statsDefaultTab, setStatsDefaultTab] = useState<StatsDefaultTab>('daily')
+  const [playingDate, setPlayingDate] = useState<string | null>(null)
   const [lastResult, setLastResult] = useState<TriviaGameResult | null>(null)
   const [localToday, setLocalToday] = useState<TriviaGameResult | null>(null)
   const [autoResultsShown, setAutoResultsShown] = useState(false)
@@ -123,6 +124,28 @@ export default function TriviaPage() {
   const handleStartPractice = () => setView('practice')
   const handleViewInfiniteLeaderboard = () => setView('infinite-leaderboard')
 
+  const handleSelectPastDate = useCallback((date: string) => {
+    const alreadyPlayed = history.some((h) => h.date === date)
+    if (alreadyPlayed) return
+    setPlayingDate(date)
+    setView('playing-past')
+  }, [history])
+
+  const handleFinishPast = useCallback(
+    (result: TriviaGameResult) => {
+      setLastResult(result)
+      setView('results')
+      setPlayingDate(null)
+      if (user) {
+        submitGameToServer(user, result)
+          .catch((err) =>
+            console.error('Failed to submit retroactive game:', err)
+          )
+      }
+    },
+    [user]
+  )
+
   const handleStatsReset = useCallback(
     (scopes: { daily: boolean; infinite: boolean }) => {
       if (scopes.daily) {
@@ -182,6 +205,10 @@ export default function TriviaPage() {
     return <TriviaGame onFinish={handleFinish} />
   }
 
+  if (view === 'playing-past' && playingDate) {
+    return <TriviaGame date={playingDate} onFinish={handleFinishPast} onFlee={() => { setPlayingDate(null); setView('calendar') }} />
+  }
+
   if (view === 'results' && lastResult) {
     return (
       <TriviaResults
@@ -215,7 +242,7 @@ export default function TriviaPage() {
     return (
       <TriviaCalendar
         onPlayToday={handleStartGame}
-        onSelectDate={() => {}}
+        onSelectDate={handleSelectPastDate}
         onBack={handleBackToLanding}
         nav={nav}
       />

--- a/src/app/trivia/page.tsx
+++ b/src/app/trivia/page.tsx
@@ -16,6 +16,7 @@ import { getDailyCategory } from '@/lib/trivia/categories'
 import { InfiniteGame } from './components/InfiniteGame'
 import { InfiniteLeaderboard } from './components/InfiniteLeaderboard'
 import { QuestionLibrary } from './components/QuestionLibrary'
+import { TriviaCalendar } from './components/TriviaCalendar'
 import { TriviaGame } from './components/TriviaGame'
 import { TriviaLanding } from './components/TriviaLanding'
 import { TriviaLeaderboard } from './components/TriviaLeaderboard'
@@ -25,7 +26,7 @@ import { UnifiedStats } from './components/UnifiedStats'
 import type { TriviaGameResult } from './models/trivia'
 import type { User } from 'firebase/auth'
 
-type View = 'landing' | 'playing' | 'results' | 'stats' | 'leaderboard' | 'infinite' | 'infinite-stats' | 'practice' | 'infinite-leaderboard' | 'library'
+type View = 'landing' | 'playing' | 'results' | 'stats' | 'leaderboard' | 'infinite' | 'infinite-stats' | 'practice' | 'infinite-leaderboard' | 'library' | 'calendar'
 
 type StatsDefaultTab = 'daily' | 'infinite'
 
@@ -113,6 +114,7 @@ export default function TriviaPage() {
   }, [user, triviaLoading, firestoreToday, today])
 
   const handleLibrary = () => setView('library')
+  const handleViewCalendar = () => setView('calendar')
   const handleStartGame = () => setView('playing')
   const handleViewStats = () => { setStatsDefaultTab('daily'); setView('stats') }
   const handleViewLeaderboard = () => setView('leaderboard')
@@ -161,6 +163,7 @@ export default function TriviaPage() {
     onViewInfiniteStats: handleViewInfiniteStats,
     onViewInfiniteLeaderboard: handleViewInfiniteLeaderboard,
     onLibrary: handleLibrary,
+    onCalendar: handleViewCalendar,
   }
 
   if (view === 'infinite') {
@@ -208,6 +211,17 @@ export default function TriviaPage() {
     return <QuestionLibrary onBack={handleBackToLanding} nav={nav} />
   }
 
+  if (view === 'calendar') {
+    return (
+      <TriviaCalendar
+        onPlayToday={handleStartGame}
+        onSelectDate={() => {}}
+        onBack={handleBackToLanding}
+        nav={nav}
+      />
+    )
+  }
+
   return (
     <TriviaLanding
       onStartGame={handleStartGame}
@@ -218,6 +232,7 @@ export default function TriviaPage() {
       onStartPractice={handleStartPractice}
       onViewInfiniteLeaderboard={handleViewInfiniteLeaderboard}
       onLibrary={handleLibrary}
+      onCalendar={handleViewCalendar}
       onStatsReset={handleStatsReset}
       todayResult={todayResult}
     />

--- a/src/lib/trivia/transactions.ts
+++ b/src/lib/trivia/transactions.ts
@@ -1,7 +1,7 @@
 import { FieldValue, Timestamp } from 'firebase-admin/firestore'
 
 import type { TriviaAnswer } from '@/app/trivia/models/trivia'
-import { getWeekKey, getYesterdayOf } from '@/lib/dates'
+import { getTodayPST, getWeekKey, getYesterdayOf } from '@/lib/dates'
 import { getFirestoreDb } from '@/lib/firebase/server'
 import { type AuthClaims, getOrCreateProfile } from '@/lib/users/profile'
 
@@ -89,15 +89,19 @@ export async function recordCompletedGame(
   const gameRef = triviaGameRef(input.uid, input.date)
   const dailyRef = triviaDailyRef(input.uid, input.date)
   const weekKey = getWeekKey(input.date)
+  const currentWeekKey = getWeekKey(getTodayPST())
+  const isRetro = input.isRetroactive ?? false
+  // Skip weekly leaderboard write for retroactive plays from past weeks
+  const shouldUpdateWeekly = !isRetro || weekKey === currentWeekKey
   const weeklyRef = triviaWeeklyRef(input.uid, weekKey)
 
   return db.runTransaction(async (tx) => {
-    const [userSnap, profileSnap, gameSnap, weeklySnap] = await Promise.all([
+    const [userSnap, profileSnap, gameSnap] = await Promise.all([
       tx.get(userRef),
       tx.get(profileRef),
       tx.get(gameRef),
-      tx.get(weeklyRef),
     ])
+    const weeklySnap = shouldUpdateWeekly ? await tx.get(weeklyRef) : null
 
     if (gameSnap.exists) {
       const existingProfile = profileSnap.exists
@@ -112,8 +116,6 @@ export async function recordCompletedGame(
     const existing = profileSnap.exists
       ? (profileSnap.data() as TriviaProfile)
       : EMPTY_TRIVIA_PROFILE
-
-    const isRetro = input.isRetroactive ?? false
 
     // Streak logic: only update for same-day (non-retroactive) plays
     let newStreak = existing.currentStreak
@@ -135,18 +137,21 @@ export async function recordCompletedGame(
       lastPlayedDate: newLastPlayed,
     }
 
-    const existingWeekly = weeklySnap.exists
-      ? (weeklySnap.data() as TriviaWeeklyEntry)
-      : null
-    const nextWeekly: TriviaWeeklyEntry = {
-      uid: input.uid,
-      weekKey,
-      totalScore: (existingWeekly?.totalScore ?? 0) + input.score,
-      gamesPlayed: (existingWeekly?.gamesPlayed ?? 0) + 1,
-      totalCorrect: (existingWeekly?.totalCorrect ?? 0) + input.correct,
-      totalQuestions: (existingWeekly?.totalQuestions ?? 0) + input.total,
-      nicknameSnapshot,
-      lastUpdated: FieldValue.serverTimestamp(),
+    let nextWeekly: TriviaWeeklyEntry | null = null
+    if (shouldUpdateWeekly && weeklySnap) {
+      const existingWeekly = weeklySnap.exists
+        ? (weeklySnap.data() as TriviaWeeklyEntry)
+        : null
+      nextWeekly = {
+        uid: input.uid,
+        weekKey,
+        totalScore: (existingWeekly?.totalScore ?? 0) + input.score,
+        gamesPlayed: (existingWeekly?.gamesPlayed ?? 0) + 1,
+        totalCorrect: (existingWeekly?.totalCorrect ?? 0) + input.correct,
+        totalQuestions: (existingWeekly?.totalQuestions ?? 0) + input.total,
+        nicknameSnapshot,
+        lastUpdated: FieldValue.serverTimestamp(),
+      }
     }
 
     tx.set(gameRef, {
@@ -173,7 +178,9 @@ export async function recordCompletedGame(
       playedAt: FieldValue.serverTimestamp(),
       isRetroactive: isRetro,
     })
-    tx.set(weeklyRef, nextWeekly)
+    if (nextWeekly) {
+      tx.set(weeklyRef, nextWeekly)
+    }
 
     return { alreadySubmitted: false, profile: nextProfile }
   })

--- a/src/lib/trivia/transactions.ts
+++ b/src/lib/trivia/transactions.ts
@@ -45,6 +45,7 @@ export interface CompleteGameInput {
   total: number
   answers: TriviaAnswer[]
   category: { id: number; name: string; icon: string }
+  isRetroactive?: boolean
 }
 
 export interface CompleteGameResult {
@@ -111,9 +112,19 @@ export async function recordCompletedGame(
     const existing = profileSnap.exists
       ? (profileSnap.data() as TriviaProfile)
       : EMPTY_TRIVIA_PROFILE
-    const yesterday = getYesterdayOf(input.date)
-    const wasYesterday = existing.lastPlayedDate === yesterday
-    const newStreak = wasYesterday ? existing.currentStreak + 1 : 1
+
+    const isRetro = input.isRetroactive ?? false
+
+    // Streak logic: only update for same-day (non-retroactive) plays
+    let newStreak = existing.currentStreak
+    let newLastPlayed = existing.lastPlayedDate
+    if (!isRetro) {
+      const yesterday = getYesterdayOf(input.date)
+      const wasYesterday = existing.lastPlayedDate === yesterday
+      newStreak = wasYesterday ? existing.currentStreak + 1 : 1
+      newLastPlayed = input.date
+    }
+
     const nextProfile: TriviaProfile = {
       gamesPlayed: existing.gamesPlayed + 1,
       totalScore: existing.totalScore + input.score,
@@ -121,7 +132,7 @@ export async function recordCompletedGame(
       totalQuestions: existing.totalQuestions + input.total,
       currentStreak: newStreak,
       bestStreak: Math.max(newStreak, existing.bestStreak),
-      lastPlayedDate: input.date,
+      lastPlayedDate: newLastPlayed,
     }
 
     const existingWeekly = weeklySnap.exists
@@ -147,6 +158,8 @@ export async function recordCompletedGame(
       answers: input.answers,
       category: input.category,
       submittedAt: FieldValue.serverTimestamp(),
+      playedAt: FieldValue.serverTimestamp(),
+      isRetroactive: isRetro,
     })
     tx.set(profileRef, nextProfile)
     tx.set(dailyRef, {
@@ -157,6 +170,8 @@ export async function recordCompletedGame(
       total: input.total,
       nicknameSnapshot,
       submittedAt: FieldValue.serverTimestamp(),
+      playedAt: FieldValue.serverTimestamp(),
+      isRetroactive: isRetro,
     })
     tx.set(weeklyRef, nextWeekly)
 


### PR DESCRIPTION
## Summary
Integration branch for the daily trivia calendar feature:

- **Calendar month-view UI** — browse past daily trivia by date
- **Play past trivia** — load and play any past day's questions  
- **Completion tracking** — track which days have been completed retroactively
- **Retroactive scoring** — scores from past days integrated into stats
- **Weekly leaderboard guard** — old-week retroactive plays don't affect current leaderboard
- **Stats integration** — retroactive plays count in the calendar UI and stats page