### PR TITLE
feat(trivia): next/previous day navigation on results view

### DIFF
--- a/src/app/trivia/components/TriviaResults.tsx
+++ b/src/app/trivia/components/TriviaResults.tsx
@@ -94,11 +94,14 @@ interface TriviaResultsProps {
   onViewStats?: () => void
   onViewLeaderboard?: () => void
   onStartInfinite?: () => void
+  onNextDay?: () => void
+  onPreviousDay?: () => void
+  isRetroactive?: boolean
   // Optional: pass questions data for difficulty display
   questionDifficulties?: Array<{ difficulty: string; source: string }>
 }
 
-export function TriviaResults({ result, onBack, onViewStats, onViewLeaderboard, onStartInfinite }: TriviaResultsProps) {
+export function TriviaResults({ result, onBack, onViewStats, onViewLeaderboard, onStartInfinite, onNextDay, onPreviousDay, isRetroactive }: TriviaResultsProps) {
   const [copied, setCopied] = useState(false)
   const { user } = useAuth()
   const { stats, displayName } = useTriviaUser()
@@ -149,6 +152,9 @@ export function TriviaResults({ result, onBack, onViewStats, onViewLeaderboard, 
           {getScoreRating(correctPercent)}
         </h2>
         <p className="text-on-surface/50 text-sm">{formatDisplayDate(result.date)}</p>
+        {isRetroactive && (
+          <Pill tone="info" icon="history" className="mt-1">Retroactive play</Pill>
+        )}
       </div>
 
       {/* Score card */}
@@ -252,6 +258,21 @@ export function TriviaResults({ result, onBack, onViewStats, onViewLeaderboard, 
       >
         {copied ? 'Copied!' : 'Share Score'}
       </ChunkyButton>
+
+      {isRetroactive && (onNextDay || onPreviousDay) && (
+        <div className="flex gap-2 w-full">
+          {onPreviousDay && (
+            <ChunkyButton variant="secondary" className="flex-1" onClick={onPreviousDay}>
+              ← Previous Day
+            </ChunkyButton>
+          )}
+          {onNextDay && (
+            <ChunkyButton variant="secondary" className="flex-1" onClick={onNextDay}>
+              Next Day →
+            </ChunkyButton>
+          )}
+        </div>
+      )}
 
       {onStartInfinite && (
         <ChunkyCard variant="surface-variant" className="w-full bg-surface-container/80 border-outline-variant">

--- a/src/app/trivia/daily/page.tsx
+++ b/src/app/trivia/daily/page.tsx
@@ -1,10 +1,11 @@
 'use client'
 
 import { useRouter, useSearchParams } from 'next/navigation'
-import { Suspense, useState } from 'react'
+import { Suspense, useMemo, useState } from 'react'
 
 import { TriviaGame } from '@/app/trivia/components/TriviaGame'
 import { TriviaResults } from '@/app/trivia/components/TriviaResults'
+import { useTriviaUser } from '@/app/trivia/hooks/useTriviaUser'
 import { submitGameToServer } from '@/app/trivia/lib/submitGame'
 import {
   clearTodayResult,
@@ -14,10 +15,17 @@ import type { TriviaGameResult } from '@/app/trivia/models/trivia'
 import { useAuth } from '@/hooks/useAuth'
 import { getTodayPST } from '@/lib/dates'
 
+function addDaysToDate(dateStr: string, days: number): string {
+  const d = new Date(dateStr + 'T12:00:00')
+  d.setDate(d.getDate() + days)
+  return d.toISOString().slice(0, 10)
+}
+
 function DailyTriviaPageInner() {
   const router = useRouter()
   const searchParams = useSearchParams()
   const { user } = useAuth()
+  const { history } = useTriviaUser()
 
   const dateParam = searchParams.get('date')
   const isPastDate = !!dateParam
@@ -26,6 +34,32 @@ function DailyTriviaPageInner() {
 
   const [view, setView] = useState<'playing' | 'results'>('playing')
   const [result, setResult] = useState<TriviaGameResult | null>(null)
+
+  const nextUnplayedDay = useMemo(() => {
+    if (!isPastDate) return null
+    const playedSet = new Set(history.map((h) => h.date))
+    // Include the date we just played (result may not be in history yet)
+    if (result) playedSet.add(result.date)
+    let candidate = addDaysToDate(playDate, 1)
+    while (playedSet.has(candidate) && candidate < today) {
+      candidate = addDaysToDate(candidate, 1)
+    }
+    if (candidate <= today && !playedSet.has(candidate)) return candidate
+    return null
+  }, [isPastDate, playDate, history, today, result])
+
+  const prevUnplayedDay = useMemo(() => {
+    if (!isPastDate) return null
+    const playedSet = new Set(history.map((h) => h.date))
+    if (result) playedSet.add(result.date)
+    const limit = addDaysToDate(today, -90)
+    let candidate = addDaysToDate(playDate, -1)
+    while (playedSet.has(candidate) && candidate > limit) {
+      candidate = addDaysToDate(candidate, -1)
+    }
+    if (candidate >= limit && !playedSet.has(candidate)) return candidate
+    return null
+  }, [isPastDate, playDate, history, today, result])
 
   function handleFinish(res: TriviaGameResult) {
     if (!isPastDate) {
@@ -56,10 +90,20 @@ function DailyTriviaPageInner() {
     return (
       <TriviaResults
         result={result}
-        onBack={() => router.push('/trivia')}
+        onBack={() => router.push(isPastDate ? '/trivia/calendar' : '/trivia')}
         onViewStats={() => router.push('/trivia/stats')}
         onViewLeaderboard={() => router.push('/trivia/leaderboard')}
         onStartInfinite={() => router.push('/trivia/infinite')}
+        isRetroactive={isPastDate}
+        onNextDay={nextUnplayedDay ? () => {
+          const path = nextUnplayedDay === today
+            ? '/trivia/daily'
+            : `/trivia/daily?date=${nextUnplayedDay}`
+          router.push(path)
+        } : undefined}
+        onPreviousDay={prevUnplayedDay ? () => {
+          router.push(`/trivia/daily?date=${prevUnplayedDay}`)
+        } : undefined}
       />
     )
   }


### PR DESCRIPTION
## Summary

Closes #1372

- When viewing results after playing a past day's trivia (via calendar), adds **Previous Day** and **Next Day** navigation buttons to quickly move to the next unplayed day
- Adds a "Retroactive play" pill indicator on the results header for calendar plays
- Back button now routes to the calendar (instead of landing) for retroactive plays
- Next/Previous buttons skip already-played days, with a 90-day lookback limit
- If the next day is today, navigates to today's daily trivia (no date param)

## Changes

- `src/app/trivia/daily/page.tsx` — Added `useTriviaUser` hook to access play history, `addDaysToDate` helper, `nextUnplayedDay`/`prevUnplayedDay` memos, and passes new props to `TriviaResults`
- `src/app/trivia/components/TriviaResults.tsx` — Added `onNextDay`, `onPreviousDay`, `isRetroactive` props with corresponding UI (day nav buttons + retroactive pill)

## Test plan

- [ ] Play today's daily trivia — verify no Previous/Next buttons or "Retroactive play" pill appear
- [ ] Navigate to calendar, click a missed past day, complete the quiz
- [ ] On results view: verify "Retroactive play" pill is shown
- [ ] Verify Previous Day / Next Day buttons appear (if adjacent unplayed days exist)
- [ ] Click Next Day — verify it loads the next unplayed day's trivia
- [ ] Click Previous Day — verify it loads the previous unplayed day's trivia
- [ ] Verify Back button returns to calendar (not landing) for retroactive plays
- [ ] Play all adjacent days — verify buttons disappear when no more unplayed days exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)