### PR TITLE
feat(trivia): expand weeklyCrowns to store top-3 podium

### DIFF
--- a/src/lib/trivia/crowns.ts
+++ b/src/lib/trivia/crowns.ts
@@ -1,8 +1,17 @@
 import { getFirestoreDb } from '@/lib/firebase/server'
 import { getWeekKey, getTodayPST } from '@/lib/dates'
 
-interface CrownDoc {
+export interface PodiumEntry {
+  uid: string
+  displayName: string
+  score: number
+  rank: 1 | 2 | 3
+}
+
+export interface CrownDoc {
   weekKey: string
+  podium: PodiumEntry[]
+  // Legacy fields preserved for backward compat
   winnerUid: string
   winnerScore: number
 }
@@ -30,8 +39,8 @@ export async function ensureCrownsAwarded(): Promise<CrownDoc[]> {
   // 3. Get all triviaWeekly docs to find un-awarded weeks
   const weeklySnap = await db.collectionGroup('triviaWeekly').get()
 
-  // 4. Group by weekKey, track the top scorer for each un-awarded past week
-  const weekWinners = new Map<string, { uid: string; totalScore: number }>()
+  // 4. Group by weekKey, track the top 3 scorers for each un-awarded past week
+  const weekPlayers = new Map<string, Array<{ uid: string; totalScore: number; displayName: string }>>()
   for (const doc of weeklySnap.docs) {
     const data = doc.data()
     const weekKey = data.weekKey as string
@@ -40,20 +49,32 @@ export async function ensureCrownsAwarded(): Promise<CrownDoc[]> {
 
     const uid = data.uid as string
     const totalScore = data.totalScore as number
-    const current = weekWinners.get(weekKey)
-    if (!current || totalScore > current.totalScore) {
-      weekWinners.set(weekKey, { uid, totalScore })
-    }
+    const displayName = (data.nicknameSnapshot as string) || ''
+    const players = weekPlayers.get(weekKey) ?? []
+    players.push({ uid, totalScore, displayName })
+    weekPlayers.set(weekKey, players)
   }
 
   // 5. Write new crown docs (batch write for efficiency)
-  if (weekWinners.size > 0) {
+  if (weekPlayers.size > 0) {
     const batch = db.batch()
-    for (const [weekKey, winner] of weekWinners) {
+    for (const [weekKey, players] of weekPlayers) {
+      const top3 = players
+        .sort((a, b) => b.totalScore - a.totalScore)
+        .slice(0, 3)
+
+      const podium: PodiumEntry[] = top3.map((p, i) => ({
+        uid: p.uid,
+        displayName: p.displayName,
+        score: p.totalScore,
+        rank: (i + 1) as 1 | 2 | 3,
+      }))
+
       const crownDoc: CrownDoc = {
         weekKey,
-        winnerUid: winner.uid,
-        winnerScore: winner.totalScore,
+        podium,
+        winnerUid: top3[0].uid,
+        winnerScore: top3[0].totalScore,
       }
       batch.set(db.collection('weeklyCrowns').doc(weekKey), crownDoc)
       existing.set(weekKey, crownDoc)


### PR DESCRIPTION
## Summary

Closes #1365

Expands the `weeklyCrowns` Firestore documents to store the top 3 scorers per week (podium) instead of just the single winner, as needed by the weekly winner announcement banner epic (#1362).

## Changes

- `src/lib/trivia/crowns.ts`:
  - Added `PodiumEntry` interface (`uid`, `displayName`, `score`, `rank`)
  - Updated `CrownDoc` to include `podium: PodiumEntry[]` array
  - Modified `ensureCrownsAwarded()` to collect all players per week, sort by score, and store top 3
  - `displayName` sourced from `nicknameSnapshot` on `triviaWeekly` entries
  - Legacy `winnerUid` and `winnerScore` fields preserved for backward compatibility
  - Both types exported for downstream use (API endpoint in #1366)

## Backward compatibility

- `winnerUid` / `winnerScore` remain on all crown docs (set from `podium[0]`)
- `getAllTimeTop()` in `queries.ts` uses `crown.winnerUid` — works unchanged
- `resetStats.ts` uses `winnerUid` for crown revocation — works unchanged
- Existing crown docs without `podium` continue to work (already computed, never recomputed)

## Test plan

- [ ] Verify TypeScript compilation passes (no errors in trivia files)
- [ ] Verify existing `resetStats` tests pass (crown revocation logic unchanged)
- [ ] After deploy: trigger `ensureCrownsAwarded()` and check a Firestore `weeklyCrowns` doc has `podium` array with up to 3 entries
- [ ] Verify all-time leaderboard still renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)