### PR TITLE
feat(trivia): add weekly winner API endpoint

### DIFF
--- a/src/app/api/v1/trivia/weekly-winner/route.ts
+++ b/src/app/api/v1/trivia/weekly-winner/route.ts
@@ -1,0 +1,38 @@
+import { NextResponse } from 'next/server'
+
+import { ensureCrownsAwarded } from '@/lib/trivia/crowns'
+import { getFirestoreDb } from '@/lib/firebase/server'
+import { getTodayPST, getWeekKey } from '@/lib/dates'
+
+function getPreviousWeekKey(): string {
+  const today = getTodayPST()
+  const d = new Date(today + 'T12:00:00')
+  d.setDate(d.getDate() - 7)
+  return getWeekKey(d.toISOString().slice(0, 10))
+}
+
+export async function GET() {
+  try {
+    await ensureCrownsAwarded()
+
+    const previousWeekKey = getPreviousWeekKey()
+    const db = getFirestoreDb()
+    const crownSnap = await db.doc(`weeklyCrowns/${previousWeekKey}`).get()
+
+    if (!crownSnap.exists) {
+      return NextResponse.json({ weekKey: null, podium: [] })
+    }
+
+    const data = crownSnap.data()!
+    return NextResponse.json({
+      weekKey: previousWeekKey,
+      podium: data.podium ?? [],
+    })
+  } catch (err) {
+    console.error('Failed to fetch weekly winner:', err)
+    return NextResponse.json(
+      { error: 'Failed to fetch weekly winner' },
+      { status: 500 }
+    )
+  }
+}


### PR DESCRIPTION
## Summary

Closes #1366

Adds `GET /api/v1/trivia/weekly-winner` endpoint that returns the previous week's crown data (top-3 podium) for use by the weekly winner announcement banner (#1362).

## Changes

- New file: `src/app/api/v1/trivia/weekly-winner/route.ts`
  - Calls `ensureCrownsAwarded()` to ensure lazy crown computation is triggered
  - Computes previous week's key by subtracting 7 days from today (PST)
  - Fetches `weeklyCrowns/{previousWeekKey}` from Firestore
  - Returns `{ weekKey, podium }` or `{ weekKey: null, podium: [] }` if none exists

## Response shape

```json
{
  "weekKey": "2026-W19",
  "podium": [
    { "uid": "abc", "displayName": "Player1", "score": 1200, "rank": 1 },
    { "uid": "def", "displayName": "Player2", "score": 1100, "rank": 2 },
    { "uid": "ghi", "displayName": "Player3", "score": 900, "rank": 3 }
  ]
}
```

## Test plan

- [ ] `GET /api/v1/trivia/weekly-winner` returns 200 with podium data when a previous week crown exists
- [ ] Returns `{ weekKey: null, podium: [] }` when no crown exists for the previous week
- [ ] Verify `ensureCrownsAwarded()` is called (crowns computed lazily)

🤖 Generated with [Claude Code](https://claude.com/claude-code)