### PR TITLE
feat(trivia): render weekly winner banner on landing page

### DIFF
--- a/src/app/trivia/components/TriviaLanding.tsx
+++ b/src/app/trivia/components/TriviaLanding.tsx
@@ -23,6 +23,7 @@ import { ResetNoticeButton } from './ResetNoticeButton'
 import { ResetStatsDialog } from './ResetStatsDialog'
 import { SignInBanner } from './SignInCTA'
 import { TriviaFooter } from './TriviaFooter'
+import { WeeklyWinnerBanner } from './WeeklyWinnerBanner'
 
 export function TriviaLanding() {
   const { user, loading: authLoading, configured: authConfigured, signOut } = useAuth()
@@ -111,6 +112,8 @@ export function TriviaLanding() {
           </Link>
         )}
       </div>
+
+      <WeeklyWinnerBanner />
 
       <div className="text-center">
         <h1 className="font-headline text-headline-lg text-ds-tertiary drop-shadow-[0_4px_0_var(--surface-container-lowest)] mb-2 inline-flex items-center gap-2">


### PR DESCRIPTION
## Summary

Closes #1368

Renders the `WeeklyWinnerBanner` component on the trivia landing page, above the title. This is the final wiring step for the weekly winner announcement feature.

## Changes

- `src/app/trivia/components/TriviaLanding.tsx` — import and render `<WeeklyWinnerBanner />` above the "Daily Trivia" heading

## Test plan

- [ ] Visit `/trivia` — banner appears above title if there's an unseen weekly winner
- [ ] Banner doesn't appear when no winner exists (no layout shift)
- [ ] Dismissing the banner works and persists across page refreshes
- [ ] Existing layout and functionality is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)