### PR TITLE
feat(trivia): past winners history page at /trivia/winners

### DIFF
--- a/src/app/api/v1/trivia/weekly-winners/route.ts
+++ b/src/app/api/v1/trivia/weekly-winners/route.ts
@@ -1,0 +1,25 @@
+import { NextResponse } from 'next/server'
+
+import { ensureCrownsAwarded } from '@/lib/trivia/crowns'
+
+export async function GET() {
+  try {
+    const crowns = await ensureCrownsAwarded()
+
+    const winners = crowns
+      .filter((c) => c.podium && c.podium.length > 0)
+      .sort((a, b) => b.weekKey.localeCompare(a.weekKey))
+      .map((c) => ({
+        weekKey: c.weekKey,
+        podium: c.podium,
+      }))
+
+    return NextResponse.json({ winners })
+  } catch (err) {
+    console.error('Failed to fetch weekly winners:', err)
+    return NextResponse.json(
+      { error: 'Failed to fetch weekly winners' },
+      { status: 500 }
+    )
+  }
+}

--- a/src/app/trivia/components/TriviaLanding.tsx
+++ b/src/app/trivia/components/TriviaLanding.tsx
@@ -275,6 +275,13 @@ export function TriviaLanding() {
         </ChunkyCard>
       </div>
 
+      <Link
+        href="/trivia/winners"
+        className="text-on-surface/50 hover:text-ds-tertiary text-sm underline-offset-4 hover:underline transition-colors"
+      >
+        View past weekly winners
+      </Link>
+
       <TriviaFooter current="home" />
 
       {nicknameDialogOpen && (

--- a/src/app/trivia/components/WeeklyWinnerBanner.tsx
+++ b/src/app/trivia/components/WeeklyWinnerBanner.tsx
@@ -2,6 +2,8 @@
 
 import { useEffect, useState } from 'react'
 
+import Link from 'next/link'
+
 import { ChunkyCard, ChunkyCardContent } from '@/components/ui/chunky-card'
 import { useAuth } from '@/hooks/useAuth'
 
@@ -122,6 +124,13 @@ export function WeeklyWinnerBanner() {
             Congratulations on making the podium!
           </p>
         )}
+
+        <Link
+          href="/trivia/winners"
+          className="block text-center text-xs text-on-surface/40 hover:text-ds-tertiary mt-3 underline-offset-4 hover:underline transition-colors"
+        >
+          See all past winners
+        </Link>
       </ChunkyCardContent>
     </ChunkyCard>
   )

--- a/src/app/trivia/winners/page.tsx
+++ b/src/app/trivia/winners/page.tsx
@@ -1,0 +1,134 @@
+'use client'
+
+import Link from 'next/link'
+import { useEffect, useState } from 'react'
+
+import { ChunkyCard, ChunkyCardContent } from '@/components/ui/chunky-card'
+import { useAuth } from '@/hooks/useAuth'
+
+import { TriviaFooter } from '../components/TriviaFooter'
+
+interface PodiumEntry {
+  uid: string
+  displayName: string
+  score: number
+  rank: 1 | 2 | 3
+}
+
+interface WeekWinner {
+  weekKey: string
+  podium: PodiumEntry[]
+}
+
+const RANK_STYLES = {
+  1: { color: 'text-yellow-400', bg: 'bg-yellow-400/10 border-yellow-400/30', icon: '🥇' },
+  2: { color: 'text-gray-300', bg: 'bg-gray-300/10 border-gray-300/20', icon: '🥈' },
+  3: { color: 'text-amber-600', bg: 'bg-amber-600/10 border-amber-600/20', icon: '🥉' },
+} as const
+
+function weekKeyToDateRange(weekKey: string): string {
+  // Parse "2026-W19" → date range like "May 5 – May 11, 2026"
+  const match = weekKey.match(/^(\d{4})-W(\d{2})$/)
+  if (!match) return weekKey
+
+  const year = parseInt(match[1])
+  const week = parseInt(match[2])
+
+  // ISO week date to calendar date
+  const jan1 = new Date(Date.UTC(year, 0, 1))
+  const jan1Day = jan1.getUTCDay() || 7
+  const mondayOfWeek1 = new Date(jan1)
+  mondayOfWeek1.setUTCDate(jan1.getUTCDate() + (1 - jan1Day))
+
+  const monday = new Date(mondayOfWeek1)
+  monday.setUTCDate(mondayOfWeek1.getUTCDate() + (week - 1) * 7)
+
+  const sunday = new Date(monday)
+  sunday.setUTCDate(monday.getUTCDate() + 6)
+
+  const fmt = (d: Date) =>
+    d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', timeZone: 'UTC' })
+
+  const yearStr = monday.getUTCFullYear()
+  return `${fmt(monday)} – ${fmt(sunday)}, ${yearStr}`
+}
+
+export default function WinnersPage() {
+  const { user } = useAuth()
+  const [winners, setWinners] = useState<WeekWinner[]>([])
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    fetch('/api/v1/trivia/weekly-winners')
+      .then((res) => res.json())
+      .then((data) => {
+        setWinners(data.winners ?? [])
+        setLoading(false)
+      })
+      .catch(() => setLoading(false))
+  }, [])
+
+  const currentUid = user?.uid
+
+  return (
+    <div className="flex flex-col items-center gap-6 max-w-lg mx-auto py-8">
+      <div className="w-full flex items-center justify-between">
+        <Link
+          href="/trivia"
+          className="text-ds-tertiary hover:text-ds-tertiary/80 transition-colors text-sm underline-offset-4 hover:underline"
+        >
+          ← Back
+        </Link>
+        <h1 className="font-headline text-headline-lg text-ds-tertiary">Past Winners</h1>
+        <div className="w-16" />
+      </div>
+
+      {loading && (
+        <p className="text-on-surface/50 text-sm">Loading...</p>
+      )}
+
+      {!loading && winners.length === 0 && (
+        <ChunkyCard variant="surface-variant" className="w-full bg-surface-container/80 border-outline-variant">
+          <ChunkyCardContent className="pt-6 pb-6 text-center">
+            <p className="text-on-surface/50">No weekly winners yet. Keep playing!</p>
+          </ChunkyCardContent>
+        </ChunkyCard>
+      )}
+
+      {winners.map((week) => (
+        <ChunkyCard key={week.weekKey} variant="surface-container-high" className="w-full">
+          <ChunkyCardContent className="pt-4 pb-4">
+            <h3 className="text-on-surface/70 text-xs font-semibold uppercase tracking-wide mb-3">
+              {weekKeyToDateRange(week.weekKey)}
+            </h3>
+            <div className="flex flex-col gap-2">
+              {week.podium.map((entry) => {
+                const style = RANK_STYLES[entry.rank]
+                const isCurrentUser = currentUid === entry.uid
+
+                return (
+                  <div
+                    key={entry.uid}
+                    className={`flex items-center justify-between px-3 py-2 rounded-lg border ${style.bg} ${isCurrentUser ? 'ring-1 ring-yellow-400/40' : ''}`}
+                  >
+                    <div className="flex items-center gap-2.5">
+                      <span className="text-lg">{style.icon}</span>
+                      <span className={`text-sm font-semibold ${isCurrentUser ? 'text-yellow-400' : 'text-on-surface'}`}>
+                        {isCurrentUser ? 'You!' : entry.displayName}
+                      </span>
+                    </div>
+                    <span className={`text-sm font-bold ${style.color}`}>
+                      {entry.score.toLocaleString()} pts
+                    </span>
+                  </div>
+                )
+              })}
+            </div>
+          </ChunkyCardContent>
+        </ChunkyCard>
+      ))}
+
+      <TriviaFooter />
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

Closes #1369

Adds a dedicated page showing the history of all past weekly winners, completing the weekly winner announcement epic (#1362).

## Changes

- **New:** `src/app/api/v1/trivia/weekly-winners/route.ts` — GET endpoint returning all crown docs with podiums, sorted newest first
- **New:** `src/app/trivia/winners/page.tsx` — Past winners page with chronological list, gold/silver/bronze podium entries, current user highlighting, empty state
- **Modified:** `src/app/trivia/components/TriviaLanding.tsx` — Added "View past weekly winners" link before the footer
- **Modified:** `src/app/trivia/components/WeeklyWinnerBanner.tsx` — Added "See all past winners" link at the bottom

## Features

- Week keys (e.g., "2026-W19") converted to readable date ranges (e.g., "May 5 – May 11, 2026")
- Current user's podium entries highlighted with ring and "You!" label
- Empty state when no crowns exist yet
- TriviaFooter included for consistent navigation

## Test plan

- [ ] `/trivia/winners` loads and shows all past weekly winners in reverse chronological order
- [ ] Each week shows top 3 with correct names, scores, and medal styling
- [ ] Current user's entries are highlighted
- [ ] Empty state shown when no crowns exist
- [ ] "View past weekly winners" link on landing page navigates correctly
- [ ] "See all past winners" link in banner navigates correctly
- [ ] Back link returns to `/trivia`

🤖 Generated with [Claude Code](https://claude.com/claude-code)