### PR TITLE
fix(comet-cards): narrow blind cards to fit 3 per row on smaller viewports

### DIFF
--- a/src/app/comet-cards/components/blind-selection/blind-card.tsx
+++ b/src/app/comet-cards/components/blind-selection/blind-card.tsx
@@ -34,7 +34,7 @@ export function BlindCard({
   const eyebrow = selectEventName === 'BOSS_BLIND_SELECTED' ? 'Boss Blind' : 'Blind'
 
   return (
-    <Panel className="flex w-full max-w-sm flex-col" title={eyebrow}>
+    <Panel className="flex w-full flex-col" title={eyebrow}>
       <div
         className="flex flex-col"
         style={{

--- a/src/app/comet-cards/components/game-views/blind-selection.tsx
+++ b/src/app/comet-cards/components/game-views/blind-selection.tsx
@@ -30,7 +30,7 @@ export function BlindSelectionView() {
 
   return (
     <ViewTemplate>
-      <div className="flex flex-wrap items-stretch gap-4 justify-center">
+      <div className="grid grid-cols-1 sm:grid-cols-3 items-stretch gap-4">
         <BlindCard
           name="Small Blind"
           reward={smallBlindDefinition.baseReward}

--- a/src/app/comet-cards/components/game-views/boss-blinds.tsx
+++ b/src/app/comet-cards/components/game-views/boss-blinds.tsx
@@ -9,7 +9,7 @@ export const BossBlindsView = () => {
       title="Boss Blinds"
       description="The third blind of every round. Each warps a different rule."
     >
-      <div className="flex flex-wrap gap-4">
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
         {bossBlinds.map(bossBlind => (
           <BlindCard
             key={bossBlind.name}


### PR DESCRIPTION
## Summary

Closes #1333

Makes blind cards fit 3 per row on sm+ viewports and stack vertically on mobile.

## Changes

- `blind-selection.tsx` — Switch from `flex flex-wrap` to `grid grid-cols-1 sm:grid-cols-3`
- `boss-blinds.tsx` — Same grid treatment for the boss blinds reference gallery
- `blind-card.tsx` — Remove `max-w-sm` constraint so cards fill their grid cells

## Test plan

- [ ] On sm+ viewport: 3 blind cards per row in the selection screen
- [ ] On mobile/xs viewport: cards stack vertically, full width
- [ ] Boss blinds reference view also responsive
- [ ] Cards don't overflow or overlap at any breakpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)