### PR TITLE
feat(trivia): all-time leaderboards for total points and accuracy

### DIFF
--- a/src/app/api/v1/trivia/leaderboard/route.ts
+++ b/src/app/api/v1/trivia/leaderboard/route.ts
@@ -1,7 +1,7 @@
 import { type NextRequest, NextResponse } from 'next/server'
 
 import { getTodayPST, getWeekKey } from '@/lib/dates'
-import { getAllTimeTop, getDailyTop, getWeeklyTop } from '@/lib/trivia/queries'
+import { getAllTimeAccuracy, getAllTimePoints, getAllTimeTop, getDailyTop, getWeeklyTop } from '@/lib/trivia/queries'
 
 export async function GET(request: NextRequest) {
   const period = request.nextUrl.searchParams.get('period') || 'daily'
@@ -24,8 +24,18 @@ export async function GET(request: NextRequest) {
       return NextResponse.json({ period: 'alltime', entries })
     }
 
+    if (period === 'alltime-points') {
+      const entries = await getAllTimePoints(20)
+      return NextResponse.json({ period: 'alltime-points', entries })
+    }
+
+    if (period === 'alltime-accuracy') {
+      const entries = await getAllTimeAccuracy(20)
+      return NextResponse.json({ period: 'alltime-accuracy', entries })
+    }
+
     return NextResponse.json(
-      { error: 'Invalid period. Use daily, weekly, or alltime.' },
+      { error: 'Invalid period.' },
       { status: 400 }
     )
   } catch (error: unknown) {

--- a/src/app/trivia/components/TriviaLeaderboard.tsx
+++ b/src/app/trivia/components/TriviaLeaderboard.tsx
@@ -14,7 +14,9 @@ import { ResetNoticeButton } from './ResetNoticeButton'
 import { SignInBanner } from './SignInCTA'
 import { TriviaFooter } from './TriviaFooter'
 
-type Period = 'daily' | 'weekly' | 'alltime'
+type Period = 'daily' | 'weekly' | 'alltime' | 'alltime-points' | 'alltime-accuracy'
+type TopTab = 'daily' | 'weekly' | 'alltime'
+type AlltimeSubTab = 'alltime' | 'alltime-points' | 'alltime-accuracy'
 
 interface LeaderboardEntry {
   uid: string
@@ -33,6 +35,10 @@ interface LeaderboardResponse {
   period: Period
   entries: LeaderboardEntry[]
   notice?: string
+}
+
+function isAlltimePeriod(p: Period): p is AlltimeSubTab {
+  return p === 'alltime' || p === 'alltime-points' || p === 'alltime-accuracy'
 }
 
 export function TriviaLeaderboard({ onBack }: { onBack: () => void }) {
@@ -155,6 +161,35 @@ export function TriviaLeaderboard({ onBack }: { onBack: () => void }) {
       })
     }
 
+    if (period === 'alltime-points') {
+      return data.entries.map((entry, i) => (
+        <LeaderboardRow
+          key={entry.uid || `${entry.displayName}-${i}`}
+          rank={i + 1}
+          name={entry.displayName || 'Unknown'}
+          primary={(entry.totalScore ?? entry.score ?? 0).toLocaleString()}
+          secondary={`${entry.gamesPlayed ?? 0} games`}
+          isCurrentUser={!!currentUid && entry.uid === currentUid}
+        />
+      ))
+    }
+
+    if (period === 'alltime-accuracy') {
+      return data.entries.map((entry, i) => {
+        const pct = entry.score ?? 0
+        return (
+          <LeaderboardRow
+            key={entry.uid || `${entry.displayName}-${i}`}
+            rank={i + 1}
+            name={entry.displayName || 'Unknown'}
+            primary={`${pct}%`}
+            secondary={`${entry.gamesPlayed ?? 0} games`}
+            isCurrentUser={!!currentUid && entry.uid === currentUid}
+          />
+        )
+      })
+    }
+
     return null
   }
 
@@ -178,10 +213,10 @@ export function TriviaLeaderboard({ onBack }: { onBack: () => void }) {
 
       {/* Tabs */}
       <div className="grid grid-cols-3 gap-2">
-        {(['daily', 'weekly', 'alltime'] as Period[]).map((p) => (
+        {(['daily', 'weekly', 'alltime'] as TopTab[]).map((p) => (
           <ChunkyButton
             key={p}
-            variant={period === p ? 'primary' : 'secondary'}
+            variant={(p === 'alltime' ? isAlltimePeriod(period) : period === p) ? 'primary' : 'secondary'}
             onClick={() => setPeriod(p)}
             className="capitalize"
           >
@@ -189,6 +224,30 @@ export function TriviaLeaderboard({ onBack }: { onBack: () => void }) {
           </ChunkyButton>
         ))}
       </div>
+
+      {/* All-time sub-tabs */}
+      {isAlltimePeriod(period) && (
+        <div className="grid grid-cols-3 gap-1.5">
+          {([
+            { key: 'alltime' as const, label: 'Crowns' },
+            { key: 'alltime-points' as const, label: 'Points' },
+            { key: 'alltime-accuracy' as const, label: 'Accuracy' },
+          ]).map(({ key, label }) => (
+            <button
+              key={key}
+              type="button"
+              onClick={() => setPeriod(key)}
+              className={`text-sm py-1.5 rounded transition-colors ${
+                period === key
+                  ? 'bg-ds-tertiary/20 text-ds-tertiary font-semibold'
+                  : 'text-on-surface/50 hover:text-on-surface/70'
+              }`}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+      )}
 
       {/* Content */}
       <ChunkyCard variant="surface-container-high" className="bg-surface-container/80 border-outline-variant">

--- a/src/lib/trivia/queries.ts
+++ b/src/lib/trivia/queries.ts
@@ -35,6 +35,8 @@ interface WeeklyDoc {
 
 interface ProfileDoc {
   totalScore: number
+  totalCorrect: number
+  totalQuestions: number
   gamesPlayed: number
 }
 
@@ -168,4 +170,83 @@ export async function getAllTimeTop(limit = 20): Promise<TriviaLeaderboardEntry[
       score: count,
       crowns: count,
     }))
+}
+
+export async function getAllTimePoints(limit = 20): Promise<TriviaLeaderboardEntry[]> {
+  const db = getFirestoreDb()
+  const snap = await db
+    .collectionGroup('triviaProfile')
+    .orderBy('totalScore', 'desc')
+    .limit(limit * 2)
+    .get()
+
+  const docs: Array<{ uid: string; data: ProfileDoc }> = []
+  for (const d of snap.docs) {
+    // Path: users/{uid}/triviaProfile/current
+    const uid = d.ref.parent.parent?.id
+    if (!uid) continue
+    docs.push({ uid, data: d.data() as ProfileDoc })
+  }
+
+  const nicknames = await hydrateNicknames(docs.map((d) => d.uid))
+
+  const result: TriviaLeaderboardEntry[] = []
+  for (const { uid, data } of docs) {
+    const displayName = resolveDisplayName(uid, nicknames, null)
+    if (!displayName) continue
+    result.push({
+      uid,
+      displayName,
+      score: data.totalScore,
+      totalScore: data.totalScore,
+      gamesPlayed: data.gamesPlayed,
+      totalCorrect: data.totalCorrect,
+      totalQuestions: data.totalQuestions,
+    })
+    if (result.length >= limit) break
+  }
+  return result
+}
+
+const ACCURACY_MIN_GAMES = 10
+
+export async function getAllTimeAccuracy(limit = 20): Promise<TriviaLeaderboardEntry[]> {
+  const db = getFirestoreDb()
+  // Fetch all profiles with enough games, sorted by gamesPlayed desc to get active players
+  const snap = await db
+    .collectionGroup('triviaProfile')
+    .where('gamesPlayed', '>=', ACCURACY_MIN_GAMES)
+    .orderBy('gamesPlayed', 'desc')
+    .limit(limit * 4)
+    .get()
+
+  const docs: Array<{ uid: string; data: ProfileDoc }> = []
+  for (const d of snap.docs) {
+    const uid = d.ref.parent.parent?.id
+    if (!uid) continue
+    docs.push({ uid, data: d.data() as ProfileDoc })
+  }
+
+  const nicknames = await hydrateNicknames(docs.map((d) => d.uid))
+
+  // Calculate accuracy and sort
+  const withAccuracy = docs
+    .filter(({ uid }) => !!resolveDisplayName(uid, nicknames, null))
+    .map(({ uid, data }) => ({
+      uid,
+      data,
+      accuracy: data.totalQuestions > 0 ? data.totalCorrect / data.totalQuestions : 0,
+    }))
+    .sort((a, b) => b.accuracy - a.accuracy)
+    .slice(0, limit)
+
+  return withAccuracy.map(({ uid, data, accuracy }) => ({
+    uid,
+    displayName: resolveDisplayName(uid, nicknames, null) as string,
+    score: Math.round(accuracy * 1000) / 10,
+    totalScore: data.totalScore,
+    gamesPlayed: data.gamesPlayed,
+    totalCorrect: data.totalCorrect,
+    totalQuestions: data.totalQuestions,
+  }))
 }


### PR DESCRIPTION
## Summary

Closes #1371

Adds two new all-time leaderboard views alongside the existing Crowns tab: **Total Points** and **Accuracy**.

## Changes

- **`src/lib/trivia/queries.ts`**:
  - `getAllTimePoints()` — queries `collectionGroup('triviaProfile')` ordered by `totalScore` desc
  - `getAllTimeAccuracy()` — queries profiles with 10+ games, sorts by `totalCorrect/totalQuestions` ratio
  - Updated `ProfileDoc` interface to include `totalCorrect` and `totalQuestions`

- **`src/app/api/v1/trivia/leaderboard/route.ts`**:
  - Added `alltime-points` and `alltime-accuracy` period options

- **`src/app/trivia/components/TriviaLeaderboard.tsx`**:
  - Added sub-tabs (Crowns | Points | Accuracy) that appear when "All-Time" top tab is selected
  - Added render logic for points (total score + games played) and accuracy (percentage + games played)

## Design decisions

- **Accuracy minimum**: 10 games required to qualify (prevents 1-game 100% from topping the board)
- **Data source**: Uses `triviaProfile/current` which already aggregates all plays including retroactive
- **Sub-tabs**: Lightweight pill-style buttons below the main tab row, only visible in All-Time mode

## Test plan

- [ ] Click "All-Time" tab — sub-tabs appear (Crowns, Points, Accuracy)
- [ ] Crowns sub-tab shows existing crown count leaderboard
- [ ] Points sub-tab shows total score leaderboard with games played
- [ ] Accuracy sub-tab shows percentage with games played (only users with 10+ games)
- [ ] Switching between Daily/Weekly hides sub-tabs
- [ ] Current user highlighted on all views
- [ ] Note: `triviaProfile` collectionGroup may need a Firestore index — if the query fails, the error handler returns a friendly "initializing" message

🤖 Generated with [Claude Code](https://claude.com/claude-code)