### PR TITLE
comet-cards: owner-gated sandbox with Firestore-backed validation state

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -23,6 +23,9 @@ service cloud.firestore {
       match /seenQuestions/{qid}     { allow read, write: if false; }
       match /triviaInfinite/{runId}  { allow read, write: if false; }
       match /triviaStats/{docId}     { allow read, write: if false; }
+
+      // Comet Cards sandbox — owner-only, accessed via /api/v1/comet-cards/sandbox/*
+      match /cometCardsSandbox/{docId} { allow read, write: if false; }
     }
 
     // Nicknames uniqueness index — server only

--- a/src/app/api/v1/comet-cards/sandbox/validations/route.ts
+++ b/src/app/api/v1/comet-cards/sandbox/validations/route.ts
@@ -1,0 +1,79 @@
+import { FieldValue } from 'firebase-admin/firestore'
+import { type NextRequest, NextResponse } from 'next/server'
+
+import { verifyRequestAuth } from '@/lib/api/auth'
+import { isOwnerEmail } from '@/lib/auth/owner'
+import { getFirestoreDb } from '@/lib/firebase/server'
+
+type ValidationStatus = 'validated' | 'failed'
+type ValidationKind = 'joker' | 'voucher' | 'tag' | 'bossBlind'
+
+interface ValidationState {
+  joker: Record<string, ValidationStatus>
+  voucher: Record<string, ValidationStatus>
+  tag: Record<string, ValidationStatus>
+  bossBlind: Record<string, ValidationStatus>
+}
+
+const KINDS: ValidationKind[] = ['joker', 'voucher', 'tag', 'bossBlind']
+const STATUSES: ValidationStatus[] = ['validated', 'failed']
+const EMPTY: ValidationState = { joker: {}, voucher: {}, tag: {}, bossBlind: {} }
+
+function docPath(uid: string) {
+  return `users/${uid}/cometCardsSandbox/validations`
+}
+
+function sanitize(raw: unknown): ValidationState {
+  const out: ValidationState = { joker: {}, voucher: {}, tag: {}, bossBlind: {} }
+  if (!raw || typeof raw !== 'object') return out
+  const obj = raw as Record<string, unknown>
+  for (const kind of KINDS) {
+    const entries = obj[kind]
+    if (!entries || typeof entries !== 'object') continue
+    for (const [id, status] of Object.entries(entries as Record<string, unknown>)) {
+      if (typeof id !== 'string' || id.length === 0 || id.length > 200) continue
+      if (typeof status !== 'string' || !STATUSES.includes(status as ValidationStatus)) continue
+      out[kind][id] = status as ValidationStatus
+    }
+  }
+  return out
+}
+
+async function authorize(request: NextRequest) {
+  const auth = await verifyRequestAuth(request)
+  if ('error' in auth) return { error: auth.error }
+  if (!isOwnerEmail(auth.claims.email)) {
+    return { error: NextResponse.json({ error: 'Forbidden.' }, { status: 403 }) }
+  }
+  return { uid: auth.claims.uid }
+}
+
+export async function GET(request: NextRequest) {
+  const res = await authorize(request)
+  if ('error' in res) return res.error
+
+  const db = getFirestoreDb()
+  const snap = await db.doc(docPath(res.uid)).get()
+  const state = snap.exists ? sanitize(snap.data()?.state) : EMPTY
+  return NextResponse.json({ state }, { status: 200 })
+}
+
+export async function PUT(request: NextRequest) {
+  const res = await authorize(request)
+  if ('error' in res) return res.error
+
+  let body: { state?: unknown }
+  try {
+    body = await request.json()
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON.' }, { status: 400 })
+  }
+
+  const state = sanitize(body.state)
+  const db = getFirestoreDb()
+  await db.doc(docPath(res.uid)).set(
+    { state, updatedAt: FieldValue.serverTimestamp() },
+    { merge: false }
+  )
+  return NextResponse.json({ state }, { status: 200 })
+}

--- a/src/app/comet-cards/sandbox/CollapsibleSection.tsx
+++ b/src/app/comet-cards/sandbox/CollapsibleSection.tsx
@@ -1,0 +1,78 @@
+'use client'
+
+import { useState, type ReactNode } from 'react'
+
+export function CollapsibleSection({
+  title,
+  subtitle,
+  defaultOpen = true,
+  children,
+}: {
+  title: string
+  subtitle?: string
+  defaultOpen?: boolean
+  children: ReactNode
+}) {
+  const [open, setOpen] = useState(defaultOpen)
+  return (
+    <div
+      className="rounded-lg border backdrop-blur-md"
+      style={{
+        background: 'linear-gradient(180deg, var(--cc-panel-grad-from), var(--cc-panel-grad-to))',
+        borderColor: 'var(--cc-panel-border)',
+      }}
+    >
+      <button
+        type="button"
+        onClick={() => setOpen(o => !o)}
+        className="flex w-full items-center justify-between px-4 py-2.5"
+        style={{
+          borderBottom: open ? '1px solid var(--cc-panel-divider)' : 'none',
+          background: 'transparent',
+          color: 'inherit',
+          cursor: 'pointer',
+        }}
+        aria-expanded={open}
+      >
+        <div className="flex items-center" style={{ gap: 8 }}>
+          <span
+            style={{
+              fontFamily: 'var(--cc-font-mono)',
+              fontSize: 10,
+              width: 10,
+              opacity: 0.7,
+              transform: open ? 'rotate(90deg)' : 'rotate(0deg)',
+              transition: 'transform 0.12s',
+              display: 'inline-block',
+            }}
+          >
+            ▶
+          </span>
+          <span
+            className="uppercase"
+            style={{
+              fontFamily: 'var(--cc-font-mono)',
+              fontSize: 10,
+              letterSpacing: 2,
+              opacity: 0.6,
+            }}
+          >
+            {title}
+          </span>
+        </div>
+        {subtitle && (
+          <span
+            style={{
+              fontFamily: 'var(--cc-font-mono)',
+              fontSize: 10,
+              opacity: 0.4,
+            }}
+          >
+            {subtitle}
+          </span>
+        )}
+      </button>
+      {open && children}
+    </div>
+  )
+}

--- a/src/app/comet-cards/sandbox/SandboxPanel.tsx
+++ b/src/app/comet-cards/sandbox/SandboxPanel.tsx
@@ -1,0 +1,680 @@
+'use client'
+
+import { useMemo, useState } from 'react'
+
+import { GhostButton, PrimaryButton } from '@/app/comet-cards/components/cosmic/buttons'
+import { decks } from '@/app/comet-cards/domain/decks/decks'
+import { eventEmitter } from '@/app/comet-cards/domain/events/event-emitter'
+import type { JokerState } from '@/app/comet-cards/domain/joker/types'
+import type { TagType } from '@/app/comet-cards/domain/tag/types'
+import type { VoucherType } from '@/app/comet-cards/domain/voucher/types'
+import { useCometCardsStore } from '@/app/comet-cards/store'
+
+import { CollapsibleSection } from './CollapsibleSection'
+import {
+  type SandboxConfig,
+  buildSandboxState,
+  defaultSandboxConfig,
+  listBossBlindOptions,
+  listJokerOptions,
+  listTagOptions,
+  listVoucherOptions,
+} from './seed'
+import { Tooltip } from './Tooltip'
+import { type ValidationKind, type ValidationStatus, useValidations } from './useValidations'
+
+const VALIDATED_PILL: React.CSSProperties = {
+  borderColor: 'rgba(94,234,212,0.65)',
+  boxShadow: '0 0 0 1px rgba(94,234,212,0.25) inset',
+}
+
+const FAILED_PILL: React.CSSProperties = {
+  borderColor: 'rgba(255,107,157,0.65)',
+  boxShadow: '0 0 0 1px rgba(255,107,157,0.25) inset',
+}
+
+const STATUS_PILL_STYLE: Record<ValidationStatus, React.CSSProperties> = {
+  validated: VALIDATED_PILL,
+  failed: FAILED_PILL,
+}
+
+const STATUS_PREFIX: Record<ValidationStatus, string> = {
+  validated: '✓ ',
+  failed: '✗ ',
+}
+
+const VALIDATE_LINK_BASE: React.CSSProperties = {
+  display: 'inline-block',
+  fontFamily: 'var(--cc-font-mono)',
+  fontSize: 10,
+  letterSpacing: 1,
+  textTransform: 'uppercase',
+  padding: '4px 8px',
+  borderRadius: 4,
+  border: '1px solid',
+  background: 'transparent',
+  cursor: 'pointer',
+}
+
+function StatusButtons({
+  status,
+  onSet,
+}: {
+  status: ValidationStatus | undefined
+  onSet: (s: ValidationStatus) => void
+}) {
+  const validated = status === 'validated'
+  const failed = status === 'failed'
+  return (
+    <div style={{ display: 'flex', gap: 6, marginTop: 8 }}>
+      <button
+        type="button"
+        onClick={e => {
+          e.stopPropagation()
+          onSet('validated')
+        }}
+        style={{
+          ...VALIDATE_LINK_BASE,
+          color: 'var(--cc-mint)',
+          borderColor: 'rgba(94,234,212,0.35)',
+          background: validated ? 'rgba(94,234,212,0.18)' : 'transparent',
+        }}
+      >
+        {validated ? '✓ Validated · Unmark' : '✓ Mark validated'}
+      </button>
+      <button
+        type="button"
+        onClick={e => {
+          e.stopPropagation()
+          onSet('failed')
+        }}
+        style={{
+          ...VALIDATE_LINK_BASE,
+          color: 'var(--cc-pink)',
+          borderColor: 'rgba(255,107,157,0.35)',
+          background: failed ? 'rgba(255,107,157,0.18)' : 'transparent',
+        }}
+      >
+        {failed ? '✗ Failed · Unmark' : '✗ Mark failed'}
+      </button>
+    </div>
+  )
+}
+
+const SECTION_LABEL: React.CSSProperties = {
+  fontFamily: 'var(--cc-font-mono)',
+  fontSize: 10,
+  letterSpacing: 2,
+  textTransform: 'uppercase',
+  opacity: 0.55,
+  marginBottom: 6,
+}
+
+const INPUT_BASE: React.CSSProperties = {
+  background: 'rgba(255,255,255,0.03)',
+  border: '1px solid var(--cc-panel-divider)',
+  borderRadius: 4,
+  color: 'var(--cc-text-default)',
+  fontFamily: 'var(--cc-font-mono)',
+  fontSize: 12,
+  padding: '6px 8px',
+  width: '100%',
+}
+
+const PILL_BASE: React.CSSProperties = {
+  fontFamily: 'var(--cc-font-mono)',
+  fontSize: 10,
+  letterSpacing: 1,
+  textTransform: 'uppercase',
+  padding: '4px 8px',
+  borderRadius: 999,
+  border: '1px solid rgba(94,234,212,0.25)',
+  background: 'transparent',
+  color: 'var(--cc-mint)',
+  cursor: 'pointer',
+}
+
+const PILL_REMOVE: React.CSSProperties = {
+  ...PILL_BASE,
+  color: 'var(--cc-pink)',
+  borderColor: 'rgba(255,107,157,0.35)',
+  background: 'rgba(255,107,157,0.08)',
+}
+
+const EDITION_OPTIONS: JokerState['edition'][] = [
+  'normal',
+  'foil',
+  'holographic',
+  'polychrome',
+  'negative',
+]
+
+export function SandboxPanel() {
+  const setGame = useCometCardsStore(state => state.setGame)
+  const clearGame = useCometCardsStore(state => state.clearGame)
+  const game = useCometCardsStore(state => state.game)
+
+  const [config, setConfig] = useState<SandboxConfig>(defaultSandboxConfig)
+  const [jokerSearch, setJokerSearch] = useState('')
+
+  const { getStatus, setStatus, counts: validatedCounts, clearKind } = useValidations()
+
+  const subtitleFor = (kind: ValidationKind, total: number) => {
+    const c = validatedCounts[kind]
+    return `${c.validated}✓ · ${c.failed}✗ / ${total}`
+  }
+
+  const jokerOptions = useMemo(() => listJokerOptions(), [])
+  const voucherOptions = useMemo(() => listVoucherOptions(), [])
+  const tagOptions = useMemo(() => listTagOptions(), [])
+  const bossOptions = useMemo(() => listBossBlindOptions(), [])
+
+  const filteredJokerOptions = useMemo(() => {
+    const q = jokerSearch.trim().toLowerCase()
+    if (!q) return jokerOptions
+    return jokerOptions.filter(j => j.name.toLowerCase().includes(q))
+  }, [jokerOptions, jokerSearch])
+
+  const apply = () => {
+    setGame(buildSandboxState(config))
+  }
+
+  const applyAndStart = (blindEvent: 'SMALL_BLIND_SELECTED' | 'BIG_BLIND_SELECTED' | 'BOSS_BLIND_SELECTED') => {
+    const next = buildSandboxState(config)
+    if (blindEvent === 'BIG_BLIND_SELECTED' || blindEvent === 'BOSS_BLIND_SELECTED') {
+      next.rounds[next.roundIndex].smallBlind.status = 'completed'
+    }
+    if (blindEvent === 'BOSS_BLIND_SELECTED') {
+      next.rounds[next.roundIndex].bigBlind.status = 'completed'
+    }
+    setGame(next)
+    queueMicrotask(() => eventEmitter.emit({ type: blindEvent }))
+  }
+
+  const update = <K extends keyof SandboxConfig>(key: K, value: SandboxConfig[K]) => {
+    setConfig(prev => ({ ...prev, [key]: value }))
+  }
+
+  const addJoker = (id: string) => {
+    if (config.jokerIds.includes(id)) return
+    update('jokerIds', [...config.jokerIds, id])
+  }
+
+  const removeJoker = (id: string) => {
+    update('jokerIds', config.jokerIds.filter(j => j !== id))
+  }
+
+  const toggleVoucher = (type: VoucherType) => {
+    update(
+      'vouchers',
+      config.vouchers.includes(type)
+        ? config.vouchers.filter(v => v !== type)
+        : [...config.vouchers, type]
+    )
+  }
+
+  const toggleTag = (type: TagType) => {
+    update(
+      'tags',
+      config.tags.includes(type)
+        ? config.tags.filter(t => t !== type)
+        : [...config.tags, type]
+    )
+  }
+
+  const isLive = game.gamePhase === 'gameplay' || game.gamePhase === 'blindSelection'
+
+  return (
+    <div className="flex flex-col gap-4">
+      <CollapsibleSection title="Sandbox">
+        <div style={{ padding: 14, display: 'flex', flexDirection: 'column', gap: 14 }}>
+          <div className="flex flex-wrap gap-2">
+            <PrimaryButton onClick={apply}>Apply</PrimaryButton>
+            <PrimaryButton onClick={() => applyAndStart('SMALL_BLIND_SELECTED')}>
+              Start Small
+            </PrimaryButton>
+            <PrimaryButton onClick={() => applyAndStart('BIG_BLIND_SELECTED')}>
+              Start Big
+            </PrimaryButton>
+            <PrimaryButton onClick={() => applyAndStart('BOSS_BLIND_SELECTED')}>
+              Start Boss
+            </PrimaryButton>
+            <GhostButton
+              onClick={() => {
+                clearGame()
+                setConfig(defaultSandboxConfig)
+              }}
+            >
+              Reset
+            </GhostButton>
+          </div>
+          <div
+            style={{
+              fontFamily: 'var(--cc-font-mono)',
+              fontSize: 10,
+              opacity: 0.55,
+              lineHeight: 1.5,
+            }}
+          >
+            Apply rebuilds state from config; Start * also dispatches the chosen blind event.{' '}
+            {isLive ? 'Game is live.' : 'No blind in progress.'}
+          </div>
+
+          <div
+            style={{
+              borderTop: '1px solid var(--cc-panel-divider)',
+              paddingTop: 10,
+              display: 'flex',
+              flexDirection: 'column',
+              gap: 6,
+            }}
+          >
+            <div
+              style={{
+                fontFamily: 'var(--cc-font-mono)',
+                fontSize: 10,
+                letterSpacing: 1.5,
+                textTransform: 'uppercase',
+                opacity: 0.7,
+                lineHeight: 1.6,
+              }}
+            >
+              <div>
+                <span style={{ color: 'var(--cc-mint)' }}>✓</span>{' '}
+                {validatedCounts.joker.validated}j ·{' '}
+                {validatedCounts.voucher.validated}v ·{' '}
+                {validatedCounts.tag.validated}t ·{' '}
+                {validatedCounts.bossBlind.validated}b
+              </div>
+              <div>
+                <span style={{ color: 'var(--cc-pink)' }}>✗</span>{' '}
+                {validatedCounts.joker.failed}j ·{' '}
+                {validatedCounts.voucher.failed}v ·{' '}
+                {validatedCounts.tag.failed}t ·{' '}
+                {validatedCounts.bossBlind.failed}b
+              </div>
+            </div>
+            <div className="flex flex-wrap gap-1">
+              {(['joker', 'voucher', 'tag', 'bossBlind'] as ValidationKind[]).map(kind => {
+                const c = validatedCounts[kind]
+                if (c.validated + c.failed === 0) return null
+                return (
+                  <button
+                    key={kind}
+                    type="button"
+                    onClick={() => clearKind(kind)}
+                    style={{
+                      ...VALIDATE_LINK_BASE,
+                      color: 'var(--cc-pink)',
+                      borderColor: 'rgba(255,107,157,0.35)',
+                    }}
+                  >
+                    Clear {kind}
+                  </button>
+                )
+              })}
+            </div>
+          </div>
+        </div>
+      </CollapsibleSection>
+
+      <CollapsibleSection title="Run Variables">
+        <div
+          style={{
+            padding: 14,
+            display: 'grid',
+            gridTemplateColumns: '1fr 1fr',
+            gap: 10,
+          }}
+        >
+          <Field label="Deck">
+            <select
+              style={INPUT_BASE}
+              value={config.deckId}
+              onChange={e => update('deckId', e.target.value)}
+            >
+              {Object.values(decks).map(d => (
+                <option key={d.id} value={d.id}>
+                  {d.name}
+                </option>
+              ))}
+            </select>
+          </Field>
+          <Field label="Ante (round index)">
+            <input
+              type="number"
+              min={0}
+              style={INPUT_BASE}
+              value={config.ante}
+              onChange={e => update('ante', Number(e.target.value) || 0)}
+            />
+          </Field>
+          <Field label="Money">
+            <input
+              type="number"
+              style={INPUT_BASE}
+              value={config.money}
+              onChange={e => update('money', Number(e.target.value) || 0)}
+            />
+          </Field>
+          <Field label="Max Jokers">
+            <input
+              type="number"
+              min={1}
+              style={INPUT_BASE}
+              value={config.maxJokers}
+              onChange={e => update('maxJokers', Number(e.target.value) || 1)}
+            />
+          </Field>
+          <Field label="Hands">
+            <input
+              type="number"
+              min={1}
+              style={INPUT_BASE}
+              value={config.maxHands}
+              onChange={e => update('maxHands', Number(e.target.value) || 1)}
+            />
+          </Field>
+          <Field label="Discards">
+            <input
+              type="number"
+              min={0}
+              style={INPUT_BASE}
+              value={config.maxDiscards}
+              onChange={e => update('maxDiscards', Number(e.target.value) || 0)}
+            />
+          </Field>
+        </div>
+      </CollapsibleSection>
+
+      <CollapsibleSection
+        title="Boss Blind"
+        subtitle={subtitleFor('bossBlind', bossOptions.length)}
+      >
+        <div style={{ padding: 14, display: 'flex', flexDirection: 'column', gap: 8 }}>
+          <select
+            style={INPUT_BASE}
+            value={config.forcedBossBlindName ?? ''}
+            onChange={e =>
+              update('forcedBossBlindName', e.target.value || undefined)
+            }
+          >
+            <option value="">— Random (per ante) —</option>
+            {bossOptions.map(b => {
+              const status = getStatus('bossBlind', b.name)
+              const prefix = status ? STATUS_PREFIX[status] : ''
+              return (
+                <option key={b.name} value={b.name}>
+                  {prefix}
+                  {b.name} (min ante {b.minimumAnte})
+                </option>
+              )
+            })}
+          </select>
+          {config.forcedBossBlindName && (
+            <>
+              <div style={{ fontSize: 11, opacity: 0.7, lineHeight: 1.5 }}>
+                {bossOptions.find(b => b.name === config.forcedBossBlindName)?.description}
+              </div>
+              <StatusButtons
+                status={getStatus('bossBlind', config.forcedBossBlindName)}
+                onSet={status =>
+                  setStatus('bossBlind', config.forcedBossBlindName!, status)
+                }
+              />
+            </>
+          )}
+        </div>
+      </CollapsibleSection>
+
+      <CollapsibleSection
+        title={`Jokers (${config.jokerIds.length})`}
+        subtitle={subtitleFor('joker', jokerOptions.length)}
+      >
+        <div style={{ padding: 14, display: 'flex', flexDirection: 'column', gap: 10 }}>
+          <div className="flex items-center gap-2">
+            <input
+              placeholder="Search jokers…"
+              style={INPUT_BASE}
+              value={jokerSearch}
+              onChange={e => setJokerSearch(e.target.value)}
+            />
+            <select
+              style={{ ...INPUT_BASE, width: 130 }}
+              value={config.jokerEdition}
+              onChange={e =>
+                update('jokerEdition', e.target.value as JokerState['edition'])
+              }
+            >
+              {EDITION_OPTIONS.map(ed => (
+                <option key={ed} value={ed}>
+                  {ed}
+                </option>
+              ))}
+            </select>
+          </div>
+          {config.jokerIds.length > 0 && (
+            <div>
+              <div style={SECTION_LABEL}>Selected</div>
+              <div className="flex flex-wrap gap-1">
+                {config.jokerIds.map(id => {
+                  const j = jokerOptions.find(o => o.id === id)
+                  const status = getStatus('joker', id)
+                  const tip = j ? (
+                    <span>
+                      <strong style={{ color: 'var(--cc-mint)' }}>{j.name}</strong>
+                      <span style={{ opacity: 0.55, marginLeft: 6 }}>· {j.rarity}</span>
+                      <div style={{ marginTop: 4 }}>{j.description}</div>
+                      <StatusButtons
+                        status={status}
+                        onSet={s => setStatus('joker', id, s)}
+                      />
+                    </span>
+                  ) : (
+                    id
+                  )
+                  return (
+                    <Tooltip key={id} content={tip} side="left">
+                      <button
+                        type="button"
+                        onClick={() => removeJoker(id)}
+                        style={{
+                          ...PILL_REMOVE,
+                          ...(status ? STATUS_PILL_STYLE[status] : null),
+                        }}
+                        title="Remove"
+                      >
+                        {status ? STATUS_PREFIX[status] : ''}
+                        {j?.name ?? id} ×
+                      </button>
+                    </Tooltip>
+                  )
+                })}
+              </div>
+            </div>
+          )}
+          <div>
+            <div style={SECTION_LABEL}>
+              Available ({filteredJokerOptions.length}/{jokerOptions.length})
+            </div>
+            <div
+              className="flex flex-wrap gap-1"
+              style={{
+                maxHeight: 280,
+                overflowY: 'auto',
+                paddingRight: 4,
+              }}
+            >
+              {filteredJokerOptions.map(j => {
+                const selected = config.jokerIds.includes(j.id)
+                const status = getStatus('joker', j.id)
+                const tip = (
+                  <span>
+                    <strong style={{ color: 'var(--cc-mint)' }}>{j.name}</strong>
+                    <span style={{ opacity: 0.55, marginLeft: 6 }}>· {j.rarity}</span>
+                    <div style={{ marginTop: 4 }}>{j.description}</div>
+                    <StatusButtons
+                      status={status}
+                      onSet={s => setStatus('joker', j.id, s)}
+                    />
+                  </span>
+                )
+                return (
+                  <Tooltip key={j.id} content={tip} side="left">
+                    <button
+                      type="button"
+                      disabled={selected}
+                      onClick={() => addJoker(j.id)}
+                      style={{
+                        ...PILL_BASE,
+                        ...(status ? STATUS_PILL_STYLE[status] : null),
+                        opacity: selected ? 0.35 : 1,
+                        cursor: selected ? 'default' : 'pointer',
+                      }}
+                    >
+                      {status ? STATUS_PREFIX[status] : '+ '}
+                      {j.name}
+                    </button>
+                  </Tooltip>
+                )
+              })}
+            </div>
+          </div>
+        </div>
+      </CollapsibleSection>
+
+      <CollapsibleSection
+        title={`Vouchers (${config.vouchers.length})`}
+        subtitle={subtitleFor('voucher', voucherOptions.length)}
+        defaultOpen={false}
+      >
+        <div className="flex flex-wrap gap-1" style={{ padding: 14 }}>
+          {voucherOptions.map(v => {
+            const selected = config.vouchers.includes(v.type)
+            const status = getStatus('voucher', v.type)
+            const tip = (
+              <span>
+                <strong style={{ color: 'var(--cc-mint)' }}>{v.name}</strong>
+                <div style={{ marginTop: 4 }}>{v.description}</div>
+                <StatusButtons
+                  status={status}
+                  onSet={s => setStatus('voucher', v.type, s)}
+                />
+              </span>
+            )
+            const prefix = status ? STATUS_PREFIX[status] : selected ? '● ' : '+ '
+            return (
+              <Tooltip key={v.type} content={tip} side="left">
+                <button
+                  type="button"
+                  onClick={() => toggleVoucher(v.type)}
+                  style={{
+                    ...PILL_BASE,
+                    ...(status ? STATUS_PILL_STYLE[status] : null),
+                    background: selected ? 'rgba(94,234,212,0.18)' : 'transparent',
+                  }}
+                >
+                  {prefix}
+                  {v.name}
+                </button>
+              </Tooltip>
+            )
+          })}
+        </div>
+      </CollapsibleSection>
+
+      <CollapsibleSection
+        title={`Tags (${config.tags.length})`}
+        subtitle={subtitleFor('tag', tagOptions.length)}
+        defaultOpen={false}
+      >
+        <div className="flex flex-wrap gap-1" style={{ padding: 14 }}>
+          {tagOptions.map(t => {
+            const selected = config.tags.includes(t.type)
+            const status = getStatus('tag', t.type)
+            const tip = (
+              <span>
+                <strong style={{ color: 'var(--cc-mint)' }}>{t.name}</strong>
+                <div style={{ marginTop: 4 }}>{t.benefit}</div>
+                <StatusButtons
+                  status={status}
+                  onSet={s => setStatus('tag', t.type, s)}
+                />
+              </span>
+            )
+            const prefix = status ? STATUS_PREFIX[status] : selected ? '● ' : '+ '
+            return (
+              <Tooltip key={t.type} content={tip} side="left">
+                <button
+                  type="button"
+                  onClick={() => toggleTag(t.type)}
+                  style={{
+                    ...PILL_BASE,
+                    ...(status ? STATUS_PILL_STYLE[status] : null),
+                    background: selected ? 'rgba(94,234,212,0.18)' : 'transparent',
+                  }}
+                >
+                  {prefix}
+                  {t.name}
+                </button>
+              </Tooltip>
+            )
+          })}
+        </div>
+      </CollapsibleSection>
+
+      <ScoringFeed />
+    </div>
+  )
+}
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <label className="flex flex-col" style={{ gap: 4 }}>
+      <span style={SECTION_LABEL}>{label}</span>
+      {children}
+    </label>
+  )
+}
+
+function ScoringFeed() {
+  const events = useCometCardsStore(state => state.game.gamePlayState.scoringEvents)
+  if (events.length === 0) {
+    return null
+  }
+  return (
+    <CollapsibleSection title={`Scoring Feed (${events.length})`}>
+      <div
+        className="flex flex-col gap-1"
+        style={{
+          padding: '10px 14px',
+          fontFamily: 'var(--cc-font-mono)',
+          fontSize: 11,
+          maxHeight: 240,
+          overflowY: 'auto',
+        }}
+      >
+        {events.map(event => {
+          if ('message' in event) {
+            return (
+              <div key={event.id} style={{ opacity: 0.75 }}>
+                {event.message}
+              </div>
+            )
+          }
+          const sign = event.operator ?? '+'
+          const isMult = event.type === 'mult'
+          return (
+            <div key={event.id} className="flex items-center justify-between gap-2">
+              <span style={{ opacity: 0.6 }}>{event.source}</span>
+              <span style={{ color: isMult ? 'var(--cc-pink)' : 'var(--cc-mint)' }}>
+                {sign}
+                {event.value} {isMult ? 'mult' : 'chips'}
+              </span>
+            </div>
+          )
+        })}
+      </div>
+    </CollapsibleSection>
+  )
+}

--- a/src/app/comet-cards/sandbox/Tooltip.tsx
+++ b/src/app/comet-cards/sandbox/Tooltip.tsx
@@ -1,0 +1,160 @@
+'use client'
+
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+  type CSSProperties,
+  type ReactNode,
+} from 'react'
+import { createPortal } from 'react-dom'
+
+type Side = 'top' | 'left' | 'right' | 'bottom'
+
+interface Pos {
+  top: number
+  left: number
+  transform: string
+}
+
+const ZERO_POS: Pos = { top: 0, left: 0, transform: '' }
+
+function computePos(rect: DOMRect, side: Side, gap: number): Pos {
+  switch (side) {
+    case 'left':
+      return {
+        top: rect.top + rect.height / 2,
+        left: rect.left - gap,
+        transform: 'translate(-100%, -50%)',
+      }
+    case 'right':
+      return {
+        top: rect.top + rect.height / 2,
+        left: rect.right + gap,
+        transform: 'translateY(-50%)',
+      }
+    case 'top':
+      return {
+        top: rect.top - gap,
+        left: rect.left + rect.width / 2,
+        transform: 'translate(-50%, -100%)',
+      }
+    case 'bottom':
+      return {
+        top: rect.bottom + gap,
+        left: rect.left + rect.width / 2,
+        transform: 'translate(-50%, 0)',
+      }
+  }
+}
+
+export function Tooltip({
+  children,
+  content,
+  side = 'left',
+  width = 220,
+  className,
+  style,
+}: {
+  children: ReactNode
+  content: ReactNode
+  side?: Side
+  width?: number
+  className?: string
+  style?: CSSProperties
+}) {
+  const triggerRef = useRef<HTMLSpanElement>(null)
+  const closeTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const [open, setOpen] = useState(false)
+  const [pos, setPos] = useState<Pos>(ZERO_POS)
+
+  const measure = useCallback(() => {
+    const el = triggerRef.current
+    if (!el) return
+    setPos(computePos(el.getBoundingClientRect(), side, 6))
+  }, [side])
+
+  useLayoutEffect(() => {
+    if (!open) return
+    measure()
+    const onChange = () => measure()
+    window.addEventListener('scroll', onChange, true)
+    window.addEventListener('resize', onChange)
+    return () => {
+      window.removeEventListener('scroll', onChange, true)
+      window.removeEventListener('resize', onChange)
+    }
+  }, [open, measure])
+
+  const cancelClose = () => {
+    if (closeTimer.current) {
+      clearTimeout(closeTimer.current)
+      closeTimer.current = null
+    }
+  }
+
+  const scheduleClose = () => {
+    cancelClose()
+    closeTimer.current = setTimeout(() => setOpen(false), 120)
+  }
+
+  useEffect(() => () => cancelClose(), [])
+
+  // The cosmic theme's CSS custom properties are scoped to .cosmic-cards.
+  // Portalling into document.body strands the tooltip outside that scope,
+  // so re-apply the class on the portal root to pull the tokens back in.
+  const tooltipNode = open && typeof document !== 'undefined' && (
+    <span
+      className="cosmic-cards"
+      role="tooltip"
+      onMouseEnter={cancelClose}
+      onMouseLeave={scheduleClose}
+      style={{
+        position: 'fixed',
+        top: pos.top,
+        left: pos.left,
+        transform: pos.transform,
+        zIndex: 9999,
+        background: '#0f111c',
+        border: '1px solid rgba(94,234,212,0.3)',
+        color: '#e6fff7',
+        padding: '8px 10px',
+        borderRadius: 4,
+        fontSize: 11,
+        lineHeight: 1.45,
+        width,
+        boxShadow: '0 8px 24px rgba(0,0,0,0.55)',
+        whiteSpace: 'normal',
+        textAlign: 'left',
+        textTransform: 'none',
+        letterSpacing: 0,
+        fontFamily: 'system-ui, -apple-system, sans-serif',
+      }}
+    >
+      {content}
+    </span>
+  )
+
+  return (
+    <span
+      ref={triggerRef}
+      className={className}
+      style={{ position: 'relative', display: 'inline-flex', ...style }}
+      onMouseEnter={() => {
+        cancelClose()
+        setOpen(true)
+      }}
+      onMouseLeave={scheduleClose}
+      onFocus={() => {
+        cancelClose()
+        setOpen(true)
+      }}
+      onBlur={scheduleClose}
+    >
+      {children}
+      {tooltipNode && createPortal(tooltipNode, document.body)}
+    </span>
+  )
+}

--- a/src/app/comet-cards/sandbox/page.tsx
+++ b/src/app/comet-cards/sandbox/page.tsx
@@ -1,0 +1,125 @@
+'use client'
+
+import { useState } from 'react'
+
+import { CosmicShell } from '@/app/comet-cards/components/cosmic/shell'
+import { BlindSelectionView } from '@/app/comet-cards/components/game-views/blind-selection'
+import { GamePlayView } from '@/app/comet-cards/components/game-views/gameplay'
+import { useGameEvents } from '@/app/comet-cards/useGameEvents'
+import { useGameState } from '@/app/comet-cards/useGameState'
+import { useIsOwner } from '@/hooks/useIsOwner'
+
+import { SandboxPanel } from './SandboxPanel'
+
+function PhaseSurface() {
+  const { game } = useGameState()
+  if (game.gamePhase === 'blindSelection') return <BlindSelectionView />
+  if (game.gamePhase === 'gameplay') return <GamePlayView />
+  return (
+    <div
+      style={{
+        padding: 32,
+        fontFamily: 'var(--cc-font-mono)',
+        fontSize: 12,
+        opacity: 0.55,
+        textAlign: 'center',
+      }}
+    >
+      Pick your config in the panel and hit Apply or Start to bring up the play surface.
+      <br />
+      (Current phase: <b>{game.gamePhase}</b>)
+    </div>
+  )
+}
+
+function SidebarToggle({
+  open,
+  onToggle,
+}: {
+  open: boolean
+  onToggle: () => void
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onToggle}
+      title={open ? 'Hide sandbox panel' : 'Show sandbox panel'}
+      aria-expanded={open}
+      style={{
+        position: 'fixed',
+        top: 80,
+        right: 20,
+        zIndex: 50,
+        background: 'var(--cc-pink-bg)',
+        border: '1px solid var(--cc-pink-border)',
+        color: 'var(--cc-pink)',
+        fontFamily: 'var(--cc-font-mono)',
+        fontSize: 10,
+        letterSpacing: 2,
+        textTransform: 'uppercase',
+        padding: '8px 12px',
+        borderRadius: 4,
+        cursor: 'pointer',
+      }}
+    >
+      {open ? 'Hide ▸' : '◂ Sandbox'}
+    </button>
+  )
+}
+
+function LockedView({ message }: { message: string }) {
+  return (
+    <CosmicShell>
+      <div
+        style={{
+          padding: '80px 24px',
+          textAlign: 'center',
+          fontFamily: 'var(--cc-font-mono)',
+          fontSize: 13,
+          letterSpacing: 1,
+          opacity: 0.6,
+        }}
+      >
+        {message}
+      </div>
+    </CosmicShell>
+  )
+}
+
+function SandboxContent() {
+  useGameEvents()
+  const [sidebarOpen, setSidebarOpen] = useState(true)
+
+  return (
+    <CosmicShell>
+      <SidebarToggle open={sidebarOpen} onToggle={() => setSidebarOpen(o => !o)} />
+      <div
+        className="grid"
+        style={{
+          gridTemplateColumns: sidebarOpen
+            ? 'minmax(0, 1fr) minmax(320px, 380px)'
+            : 'minmax(0, 1fr)',
+          gap: 18,
+          padding: '14px 22px 22px',
+          alignItems: 'start',
+        }}
+      >
+        <div className="min-w-0">
+          <PhaseSurface />
+        </div>
+        {sidebarOpen && (
+          <aside style={{ position: 'sticky', top: 12 }}>
+            <SandboxPanel />
+          </aside>
+        )}
+      </div>
+    </CosmicShell>
+  )
+}
+
+export default function SandboxPage() {
+  const { isOwner, loading } = useIsOwner()
+  if (loading) return <LockedView message="the cave is waking…" />
+  if (!isOwner) return <LockedView message="the cave is sleeping…" />
+  return <SandboxContent />
+}

--- a/src/app/comet-cards/sandbox/seed.ts
+++ b/src/app/comet-cards/sandbox/seed.ts
@@ -1,0 +1,112 @@
+import { createGameStateWithDeck } from '@/app/comet-cards/domain/game/default-game-state'
+import type { GameState } from '@/app/comet-cards/domain/game/types'
+import { jokers as jokerRegistry } from '@/app/comet-cards/domain/joker/jokers'
+import type { JokerDefinition, JokerState } from '@/app/comet-cards/domain/joker/types'
+import { initializeJoker } from '@/app/comet-cards/domain/joker/utils'
+import { bossBlinds } from '@/app/comet-cards/domain/round/boss-blinds'
+import { implementedTags } from '@/app/comet-cards/domain/tag/tags'
+import type { TagType } from '@/app/comet-cards/domain/tag/types'
+import { initializeTag } from '@/app/comet-cards/domain/tag/utils'
+import type { VoucherType } from '@/app/comet-cards/domain/voucher/types'
+import { initializeVoucherState } from '@/app/comet-cards/domain/voucher/utils'
+import { vouchers as voucherRegistry } from '@/app/comet-cards/domain/voucher/vouchers'
+
+export interface SandboxConfig {
+  deckId: string
+  jokerIds: string[]
+  jokerEdition: JokerState['edition']
+  vouchers: VoucherType[]
+  tags: TagType[]
+  forcedBossBlindName?: string
+  ante: number
+  money: number
+  maxHands: number
+  maxDiscards: number
+  maxJokers: number
+}
+
+export const defaultSandboxConfig: SandboxConfig = {
+  deckId: 'pokerDeck',
+  jokerIds: [],
+  jokerEdition: 'normal',
+  vouchers: [],
+  tags: [],
+  forcedBossBlindName: undefined,
+  ante: 1,
+  money: 50,
+  maxHands: 4,
+  maxDiscards: 3,
+  maxJokers: 5,
+}
+
+export function buildSandboxState(config: SandboxConfig): GameState {
+  // Deep-clone: createGameStateWithDeck shallow-spreads a module-level state,
+  // so nested fields like `rounds` and `pokerHands` would otherwise be shared
+  // across sandbox sessions and leak mutations.
+  const state = structuredClone(createGameStateWithDeck(config.deckId))
+
+  state.gamePhase = 'blindSelection'
+  state.money = config.money
+  state.maxHands = config.maxHands
+  state.maxDiscards = config.maxDiscards
+  state.maxJokers = config.maxJokers
+  state.gamePlayState.remainingHands = config.maxHands
+  state.gamePlayState.remainingDiscards = config.maxDiscards
+
+  const targetAnte = Math.max(0, Math.min(config.ante, state.rounds.length - 1))
+  state.roundIndex = targetAnte
+
+  if (config.forcedBossBlindName) {
+    state.rounds[targetAnte].bossBlindName = config.forcedBossBlindName
+  }
+
+  state.jokers = config.jokerIds
+    .map(id => jokerRegistry[id])
+    .filter((def): def is JokerDefinition => Boolean(def))
+    .map(def => {
+      const joker = initializeJoker(def, state)
+      joker.edition = config.jokerEdition
+      return joker
+    })
+
+  state.vouchers = config.vouchers
+    .map(type => voucherRegistry[type])
+    .filter(Boolean)
+    .map(def => initializeVoucherState(def))
+
+  state.tags = config.tags
+    .filter(tag => implementedTags[tag])
+    .map(tag => initializeTag(tag))
+
+  return state
+}
+
+export function listJokerOptions(): {
+  id: string
+  name: string
+  rarity: string
+  description: string
+}[] {
+  return Object.values(jokerRegistry)
+    .map(j => ({ id: j.id, name: j.name, rarity: j.rarity, description: j.description }))
+    .sort((a, b) => a.name.localeCompare(b.name))
+}
+
+export function listVoucherOptions(): { type: VoucherType; name: string; description: string }[] {
+  return Object.values(voucherRegistry)
+    .map(v => ({ type: v.type, name: v.name, description: v.description }))
+    .sort((a, b) => a.name.localeCompare(b.name))
+}
+
+export function listTagOptions(): { type: TagType; name: string; benefit: string }[] {
+  return Object.values(implementedTags)
+    .filter((t): t is NonNullable<typeof t> => Boolean(t))
+    .map(t => ({ type: t.tagType, name: t.name, benefit: t.benefit }))
+    .sort((a, b) => a.name.localeCompare(b.name))
+}
+
+export function listBossBlindOptions(): { name: string; description: string; minimumAnte: number }[] {
+  return [...bossBlinds]
+    .sort((a, b) => a.name.localeCompare(b.name))
+    .map(b => ({ name: b.name, description: b.description, minimumAnte: b.minimumAnte }))
+}

--- a/src/app/comet-cards/sandbox/useValidations.ts
+++ b/src/app/comet-cards/sandbox/useValidations.ts
@@ -1,0 +1,173 @@
+'use client'
+
+import { useCallback, useEffect, useState } from 'react'
+
+import { useAuth } from '@/hooks/useAuth'
+import { useIsOwner } from '@/hooks/useIsOwner'
+
+export type ValidationKind = 'joker' | 'voucher' | 'tag' | 'bossBlind'
+export type ValidationStatus = 'validated' | 'failed'
+
+interface ValidationState {
+  joker: Record<string, ValidationStatus>
+  voucher: Record<string, ValidationStatus>
+  tag: Record<string, ValidationStatus>
+  bossBlind: Record<string, ValidationStatus>
+}
+
+const LEGACY_KEY = 'dcg.sandbox.validations.v2'
+const ENDPOINT = '/api/v1/comet-cards/sandbox/validations'
+const EMPTY: ValidationState = { joker: {}, voucher: {}, tag: {}, bossBlind: {} }
+
+function isEmpty(state: ValidationState) {
+  return (
+    Object.keys(state.joker).length === 0 &&
+    Object.keys(state.voucher).length === 0 &&
+    Object.keys(state.tag).length === 0 &&
+    Object.keys(state.bossBlind).length === 0
+  )
+}
+
+function readLegacyLocalStorage(): ValidationState | null {
+  if (typeof window === 'undefined') return null
+  try {
+    const raw = window.localStorage.getItem(LEGACY_KEY)
+    if (!raw) return null
+    const parsed = JSON.parse(raw) as Partial<ValidationState>
+    return {
+      joker: parsed.joker ?? {},
+      voucher: parsed.voucher ?? {},
+      tag: parsed.tag ?? {},
+      bossBlind: parsed.bossBlind ?? {},
+    }
+  } catch {
+    return null
+  }
+}
+
+function clearLegacyLocalStorage() {
+  if (typeof window === 'undefined') return
+  try {
+    window.localStorage.removeItem(LEGACY_KEY)
+  } catch {
+    /* ignore */
+  }
+}
+
+function countByStatus(map: Record<string, ValidationStatus>) {
+  let validated = 0
+  let failed = 0
+  for (const status of Object.values(map)) {
+    if (status === 'validated') validated++
+    else if (status === 'failed') failed++
+  }
+  return { validated, failed }
+}
+
+export function useValidations() {
+  const { user } = useAuth()
+  const { isOwner } = useIsOwner()
+  const [state, setState] = useState<ValidationState>(EMPTY)
+  // Tracks whether the local `state` reflects a known-good source (server
+  // doc or migrated legacy data). Until hydrated, the push-on-change effect
+  // stays quiet so we don't clobber the server with the initial EMPTY.
+  const [hydrated, setHydrated] = useState(false)
+
+  // Hydrate from Firestore on owner login. If the remote doc is empty but
+  // legacy localStorage has data, seed the state from localStorage — the
+  // push effect below will write it up and we clear the local key.
+  //
+  // The hook unmounts when the owner gate flips (see sandbox/page.tsx), so
+  // we don't need to reset local state mid-effect for sign-out.
+  useEffect(() => {
+    if (!user || !isOwner) return
+    let cancelled = false
+    void (async () => {
+      try {
+        const token = await user.getIdToken()
+        const res = await fetch(ENDPOINT, {
+          headers: { Authorization: `Bearer ${token}` },
+        })
+        if (!res.ok || cancelled) return
+        const data = (await res.json()) as { state: ValidationState }
+        const remote = data.state ?? EMPTY
+        if (isEmpty(remote)) {
+          const legacy = readLegacyLocalStorage()
+          if (legacy && !isEmpty(legacy)) {
+            setState(legacy)
+            clearLegacyLocalStorage()
+            setHydrated(true)
+            return
+          }
+        }
+        setState(remote)
+        setHydrated(true)
+      } catch (err) {
+        console.error('[sandbox] failed to load validations:', err)
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [user, isOwner])
+
+  // Push changes to the server whenever the hydrated state changes.
+  useEffect(() => {
+    if (!hydrated || !user || !isOwner) return
+    let cancelled = false
+    void (async () => {
+      try {
+        const token = await user.getIdToken()
+        if (cancelled) return
+        await fetch(ENDPOINT, {
+          method: 'PUT',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${token}`,
+          },
+          body: JSON.stringify({ state }),
+        })
+      } catch (err) {
+        console.error('[sandbox] failed to persist validations:', err)
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [state, hydrated, user, isOwner])
+
+  const getStatus = useCallback(
+    (kind: ValidationKind, id: string): ValidationStatus | undefined => state[kind][id],
+    [state]
+  )
+
+  // Setting status to the current value clears it (so clicking "Mark validated"
+  // on an already-validated item unmarks it). Otherwise sets to the new status.
+  const setStatus = useCallback(
+    (kind: ValidationKind, id: string, status: ValidationStatus) => {
+      setState(prev => {
+        const next: ValidationState = { ...prev, [kind]: { ...prev[kind] } }
+        if (next[kind][id] === status) {
+          delete next[kind][id]
+        } else {
+          next[kind][id] = status
+        }
+        return next
+      })
+    },
+    []
+  )
+
+  const clearKind = useCallback((kind: ValidationKind) => {
+    setState(prev => ({ ...prev, [kind]: {} }))
+  }, [])
+
+  const counts = {
+    joker: countByStatus(state.joker),
+    voucher: countByStatus(state.voucher),
+    tag: countByStatus(state.tag),
+    bossBlind: countByStatus(state.bossBlind),
+  }
+
+  return { getStatus, setStatus, counts, clearKind }
+}

--- a/src/hooks/useIsOwner.ts
+++ b/src/hooks/useIsOwner.ts
@@ -1,0 +1,10 @@
+'use client'
+
+import { isOwnerEmail } from '@/lib/auth/owner'
+
+import { useAuth } from './useAuth'
+
+export function useIsOwner(): { isOwner: boolean; loading: boolean } {
+  const { user, loading } = useAuth()
+  return { isOwner: isOwnerEmail(user?.email), loading }
+}

--- a/src/lib/auth/owner.ts
+++ b/src/lib/auth/owner.ts
@@ -1,0 +1,10 @@
+// Single owner of the cave. Used to gate the Comet Cards sandbox (and any
+// other future internal-only surfaces) on both the server and client.
+//
+// The email is the source of truth — uids differ across anonymous→Google
+// upgrades, but the Google account email is stable.
+export const OWNER_EMAIL = 'nickolusroy@gmail.com'
+
+export function isOwnerEmail(email: string | null | undefined): boolean {
+  return typeof email === 'string' && email.toLowerCase() === OWNER_EMAIL
+}


### PR DESCRIPTION
## Summary
- Adds `/comet-cards/sandbox` — a forced-state testing surface (deck, jokers, vouchers, tags, boss blind, ante, money) with per-item validated/failed tracking.
- Moves that tracking off `localStorage` into Firestore at `users/{uid}/cometCardsSandbox/validations` so progress carries across browsers / devices.
- Gates the page and the `/api/v1/comet-cards/sandbox/validations` route on `OWNER_EMAIL`. Anonymous and non-owner visitors get an on-brand "the cave is sleeping…" screen; the API returns 403.
- One-time migration: on first owner load, any data left in the legacy `dcg.sandbox.validations.v2` localStorage key seeds the Firestore doc and the local key is cleared.
- Firestore rules updated: new `users/{uid}/cometCardsSandbox/{docId}` subcollection is admin-SDK-only, matching the existing pattern. Rules already deployed.

## Test plan
- [ ] Visit `/comet-cards/sandbox` while signed out (anonymous) — see the locked "cave is sleeping" view.
- [ ] Sign in with a non-owner Google account — still locked.
- [ ] Sign in as the owner — sandbox renders; mark a few jokers/vouchers/tags/boss blinds as validated and failed.
- [ ] Reload the page — selections persist (loaded from Firestore, not localStorage).
- [ ] Open the same URL in a different browser, sign in as owner — same selections appear.
- [ ] If the legacy `dcg.sandbox.validations.v2` key is present and the Firestore doc is empty, first owner load migrates the data and clears the local key.
- [ ] Hit `GET /api/v1/comet-cards/sandbox/validations` without auth → 401; with non-owner token → 403; with owner token → 200 + state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)