### PR TITLE
chore: gitignore Claude Code local state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,8 +39,6 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
-.claude/worktrees/
-.claude-scratch/
-.claude-scratch/
-.claude-scratch/
+# Claude Code local state (settings, scheduled tasks, worktrees)
+/.claude/
 .claude-scratch/


### PR DESCRIPTION
## Summary
- Ignore `/.claude/` so `settings.local.json`, `scheduled_tasks.lock`, and `worktrees/` stop showing up as untracked work.
- Dedupe the four `.claude-scratch/` lines that had accumulated at the bottom of the file.

## Test plan
- [ ] After merge, `git status` no longer shows `.claude/` as untracked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)