### PR TITLE
feat(trivia): add dailyQuestions Firestore collection helper

### DIFF
--- a/src/lib/trivia/dailyQuestionsDb.ts
+++ b/src/lib/trivia/dailyQuestionsDb.ts
@@ -1,0 +1,44 @@
+import { FieldValue } from 'firebase-admin/firestore'
+
+import { getFirestoreDb } from '@/lib/firebase/server'
+import type { TriviaQuestionWithAnswer } from '@/app/trivia/models/questions'
+
+const COLLECTION = 'dailyQuestions'
+
+export interface DailyQuestionsDocument {
+  date: string
+  categoryId: number
+  categoryName: string
+  questions: TriviaQuestionWithAnswer[]
+  createdAt: FirebaseFirestore.Timestamp
+}
+
+export async function getDailyQuestions(date: string): Promise<DailyQuestionsDocument | null> {
+  const db = getFirestoreDb()
+  const snap = await db.collection(COLLECTION).doc(date).get()
+  if (!snap.exists) return null
+  return snap.data() as DailyQuestionsDocument
+}
+
+export async function setDailyQuestions(
+  date: string,
+  data: Omit<DailyQuestionsDocument, 'createdAt'>,
+): Promise<void> {
+  const db = getFirestoreDb()
+  await db.collection(COLLECTION).doc(date).set({
+    ...data,
+    createdAt: FieldValue.serverTimestamp(),
+  })
+}
+
+export async function getAvailableDates(startDate: string, endDate: string): Promise<string[]> {
+  const db = getFirestoreDb()
+  const snap = await db
+    .collection(COLLECTION)
+    .where('date', '>=', startDate)
+    .where('date', '<=', endDate)
+    .orderBy('date')
+    .select()
+    .get()
+  return snap.docs.map((doc) => doc.id)
+}


### PR DESCRIPTION
## Summary

- Creates `src/lib/trivia/dailyQuestionsDb.ts` with typed helpers for the `dailyQuestions` Firestore collection
- Exports `DailyQuestionsDocument` interface matching the existing JSON file structure
- Three helpers: `getDailyQuestions(date)`, `setDailyQuestions(date, data)`, `getAvailableDates(startDate, endDate)`
- Foundation for the Firebase migration epic (#1348) and calendar view (#1331)

Closes #1349

## Test plan

- [ ] Verify TypeScript compiles cleanly via Vercel build
- [ ] Subsequent PRs (#1350 bulk-upload script, #1351 API route update) will exercise these helpers end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)