### PR TITLE
feat(trivia): add Firestore index for dailyQuestions date queries

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -97,6 +97,13 @@
         { "order": "ASCENDING", "queryScope": "COLLECTION_GROUP" },
         { "order": "DESCENDING", "queryScope": "COLLECTION_GROUP" }
       ]
+    },
+    {
+      "collectionGroup": "dailyQuestions",
+      "fieldPath": "date",
+      "indexes": [
+        { "order": "ASCENDING", "queryScope": "COLLECTION" }
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Adds explicit single-field index on `date` in the `dailyQuestions` collection to `firestore.indexes.json`
- Supports `getAvailableDates(startDate, endDate)` range queries for the calendar view (#1331)
- Deploy with `firebase deploy --only firestore:indexes`

Closes #1353

## Test plan

- [ ] Verify JSON is valid (validated locally)
- [ ] Deploy indexes and confirm `getAvailableDates` returns expected date ranges

🤖 Generated with [Claude Code](https://claude.com/claude-code)