### PR TITLE
feat(trivia): read daily trivia from Firestore with disk fallback

### DIFF
--- a/src/app/api/v1/trivia/daily/route.ts
+++ b/src/app/api/v1/trivia/daily/route.ts
@@ -7,6 +7,7 @@ import { loadDailyQuestionsFromDisk } from '@/app/trivia/lib/loadDailyQuestions'
 import { dailyCache } from '@/app/trivia/lib/questionCache'
 import type { TriviaQuestion, TriviaQuestionWithAnswer } from '@/app/trivia/models/questions'
 import { getTodayPST } from '@/lib/dates'
+import { getDailyQuestions, setDailyQuestions } from '@/lib/trivia/dailyQuestionsDb'
 
 import type { NextRequest } from 'next/server'
 
@@ -268,7 +269,18 @@ export async function GET(request: NextRequest) {
       return NextResponse.json({ date: targetDate, questions })
     }
 
-    // PREFERRED: Load pre-generated questions from disk (static JSON files)
+    // PREFERRED: Load from Firestore
+    const firestoreDoc = await getDailyQuestions(targetDate)
+    if (firestoreDoc && firestoreDoc.questions.length > 0) {
+      dailyCache.set(targetDate, firestoreDoc.questions)
+      const questions: TriviaQuestion[] = firestoreDoc.questions.map(
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        ({ correctAnswer, explanation, ...q }) => q
+      )
+      return NextResponse.json({ date: targetDate, questions })
+    }
+
+    // LEGACY FALLBACK: Load pre-generated questions from disk (static JSON files)
     const preGenerated = loadDailyQuestionsFromDisk(targetDate)
     if (preGenerated && preGenerated.length > 0) {
       dailyCache.set(targetDate, preGenerated)
@@ -322,6 +334,20 @@ export async function GET(request: NextRequest) {
 
     // Cache the full questions (with answers) server-side
     dailyCache.set(targetDate, allQuestions)
+
+    // Persist to Firestore so future requests (and other instances) skip generation
+    const days = daysSinceEpoch(targetDate)
+    const categoryId = 9 + (days % 24)
+    try {
+      await setDailyQuestions(targetDate, {
+        date: targetDate,
+        categoryId,
+        categoryName: allQuestions[0]?.category || 'General Knowledge',
+        questions: allQuestions,
+      })
+    } catch (err) {
+      console.error('Failed to persist generated daily trivia to Firestore:', err)
+    }
 
     // Return questions WITHOUT answers
     const questions: TriviaQuestion[] = allQuestions.map(


### PR DESCRIPTION
## Summary

- Updates daily trivia GET route to load from Firestore as primary source (via `getDailyQuestions`)
- Keeps disk JSON loading as a legacy fallback until cleanup subtask (#1354)
- Live-generated questions are now auto-persisted to Firestore via `setDailyQuestions`, so other server instances see them immediately
- Loading priority: in-memory cache → Firestore → disk → live generation

Closes #1351

## Test plan

- [ ] Verify Vercel build passes
- [ ] After running `npm run migrate:daily-trivia`, confirm `/api/v1/trivia/daily` loads from Firestore
- [ ] Test with a date not in Firestore — verify generation + Firestore write
- [ ] Verify response shape is unchanged (same fields, answers stripped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)