### PR TITLE
feat(trivia): add Firestore fallback to check-answer route

### DIFF
--- a/src/app/api/v1/trivia/check-answer/route.ts
+++ b/src/app/api/v1/trivia/check-answer/route.ts
@@ -6,6 +6,7 @@ import { z } from 'zod'
 import { loadDailyQuestionsFromDisk } from '@/app/trivia/lib/loadDailyQuestions'
 import { dailyCache } from '@/app/trivia/lib/questionCache'
 import { getTodayPST } from '@/lib/dates'
+import { getDailyQuestions } from '@/lib/trivia/dailyQuestionsDb'
 
 export async function POST(request: NextRequest) {
   try {
@@ -27,8 +28,15 @@ export async function POST(request: NextRequest) {
       )
     }
 
-    // Look up the question in the shared cache, or load from disk
+    // Look up the question in the shared cache, Firestore, or disk
     let cachedQuestions = dailyCache.get(date)
+    if (!cachedQuestions) {
+      const firestoreDoc = await getDailyQuestions(date)
+      if (firestoreDoc && firestoreDoc.questions.length > 0) {
+        dailyCache.set(date, firestoreDoc.questions)
+        cachedQuestions = firestoreDoc.questions
+      }
+    }
     if (!cachedQuestions) {
       const fromDisk = loadDailyQuestionsFromDisk(date)
       if (fromDisk && fromDisk.length > 0) {


### PR DESCRIPTION
## Summary

- Adds Firestore as a fallback in the check-answer route when the in-memory cache misses
- Loading priority: in-memory cache → Firestore → disk → 404
- Prevents answer validation failures after server restarts now that daily trivia is Firestore-backed (#1351)

Closes #1352

## Test plan

- [ ] Verify Vercel build passes
- [ ] Restart server, submit answer without loading daily route first — confirm it loads from Firestore and validates correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)