### PR TITLE
trivia: scope warmer to categoryIds + widen sampler window for exhausted players

### DIFF
--- a/src/app/api/v1/trivia/infinite/next/route.ts
+++ b/src/app/api/v1/trivia/infinite/next/route.ts
@@ -109,11 +109,19 @@ export async function GET(request: NextRequest) {
 
     // Background top-up: keep the player ahead of pool exhaustion by
     // pre-generating questions when their unanswered pool drops below
-    // the target. Runs after the response is sent. Skipped for
-    // customCategory runs since there's no shared bank for arbitrary
-    // topics — warming has no value there.
+    // the target. Runs after the response is sent.
+    //
+    // Pass the active categoryIds so the warmer scopes its count and
+    // generation to one of the categories the player is actually
+    // running. A global warmer is a no-op for niche / exhausted
+    // single-category runs because it refills some other category and
+    // the player stays exhausted in the one they're playing.
+    //
+    // Skipped entirely for customCategory runs — no shared bank for
+    // arbitrary topics, so pre-generating ahead of the player has no
+    // value.
     if (!customCategory) {
-      after(() => warmQuestionPoolForUser(auth.claims.uid))
+      after(() => warmQuestionPoolForUser(auth.claims.uid, categoryIds))
     }
 
     return NextResponse.json(safeQuestion)

--- a/src/lib/trivia/sampler.ts
+++ b/src/lib/trivia/sampler.ts
@@ -19,11 +19,16 @@ export interface SamplerOptions {
   categoryIds?: number[]
 }
 
-// Number of candidates to fetch around a random cursor. Large enough that
-// difficulty bucketing + freshness bias still produces a reasonable
-// distribution; small enough that reads-per-/next stays in low double
-// digits. Tunable; bump if buckets routinely come back thin.
-const CANDIDATE_WINDOW = 100
+// Number of candidates to fetch around a random cursor on the all-
+// category / multi-category rebuild path. Power users with large seen
+// sets (e.g. seenCount > activeCount after flagging churn) exhaust a
+// small window almost entirely — a 100-doc window can easily land
+// fully inside the seen set even when a handful of unseen exist in the
+// global pool. We pay 500 reads once per rebuild and the result lands
+// in the per-player pool cache, so subsequent /next calls don't repeat
+// the cost. Matches POOL_CACHE_SIZE so we cap reads at exactly what we
+// can fit in the cache.
+const CANDIDATE_WINDOW = 500
 
 // Single-category runs use a larger one-shot fetch instead of the random
 // window. For categories with <= this many active docs the fetch is

--- a/src/lib/trivia/warmQuestionPool.ts
+++ b/src/lib/trivia/warmQuestionPool.ts
@@ -1,5 +1,6 @@
 import { getFirestoreDb } from '@/lib/firebase/server'
 import { saveAIQuestion } from '@/lib/trivia/aiQuestions'
+import { CATEGORY_META } from '@/lib/trivia/categories'
 import { generateInfiniteQuestion } from '@/lib/trivia/generateQuestion'
 import { readTriviaState } from '@/lib/trivia/triviaState'
 
@@ -9,21 +10,33 @@ import { readTriviaState } from '@/lib/trivia/triviaState'
 // drops below this threshold.
 const TARGET_UNANSWERED = 25
 
-// Module-memory cache for the active-question count. The number changes
-// only when admins flag/remove docs or the warmer itself adds one — both
-// rare on the timescale of /next requests. A cold serverless instance
-// pays one count() aggregation; subsequent hits are free.
+// Module-memory cache for active-question counts. Keys are category ids
+// (numbers) or 'all' for the global total. Counts change only when
+// admins flag/remove docs or the warmer itself adds one, so a 5-minute
+// TTL is plenty. A cold serverless instance pays the count() per scope
+// it touches; subsequent hits are free.
 const ACTIVE_COUNT_TTL_MS = 5 * 60 * 1000
-let activeCountCache: { value: number; expiresAt: number } | null = null
+type CountKey = number | 'all'
+const activeCountCache = new Map<CountKey, { value: number; expiresAt: number }>()
 
-async function getActiveCount(db: FirebaseFirestore.Firestore): Promise<number> {
+async function getActiveCount(
+  db: FirebaseFirestore.Firestore,
+  scope: CountKey,
+): Promise<number> {
   const now = Date.now()
-  if (activeCountCache && activeCountCache.expiresAt > now) {
-    return activeCountCache.value
+  const cached = activeCountCache.get(scope)
+  if (cached && cached.expiresAt > now) {
+    return cached.value
   }
-  const agg = await db.collection('aiQuestions').where('status', '==', 'active').count().get()
+  let q: FirebaseFirestore.Query = db.collection('aiQuestions').where('status', '==', 'active')
+  if (scope !== 'all') {
+    const name = CATEGORY_META[scope]?.name
+    if (!name) return 0
+    q = q.where('category', '==', name)
+  }
+  const agg = await q.count().get()
   const value = agg.data().count
-  activeCountCache = { value, expiresAt: now + ACTIVE_COUNT_TTL_MS }
+  activeCountCache.set(scope, { value, expiresAt: now + ACTIVE_COUNT_TTL_MS })
   return value
 }
 
@@ -31,17 +44,44 @@ async function getActiveCount(db: FirebaseFirestore.Firestore): Promise<number> 
 // player. Call from inside an `after()` block so it runs after the
 // /next response has been sent.
 //
-// Reads: 1 state doc (cheap) + an occasional cached count() aggregation.
-// Replaces the prior pattern of two count() aggregations per request.
+// When `categoryIds` is non-empty, warming is scoped to the categories
+// the player is actively running: pick one at random, count active
+// questions in just that category, and generate inside it if it's
+// running low. A global warmer was a no-op for niche / exhausted
+// single-category runs because it refilled some other category — the
+// player stayed exhausted in the one they were actually playing.
+//
+// The "running low" check is intentionally conservative: we use the
+// player's TOTAL seen count (not their per-category seen count) so a
+// player who has answered 1000 questions globally but only 5 in the
+// niche category they're now playing will look exhausted there even
+// when they aren't. The penalty is over-warming small categories;
+// under-warming drops them into the slow on-demand generation path,
+// so we err on the side of over-warm here.
+//
+// When `categoryIds` is empty (all-category runs), keeps the global
+// behavior: count() the whole bank, generate batched questions with
+// no category constraint.
 //
 // Errors are logged, not thrown — this is best-effort and must never
 // fail the request that scheduled it.
-export async function warmQuestionPoolForUser(uid: string): Promise<void> {
+export async function warmQuestionPoolForUser(
+  uid: string,
+  categoryIds: number[] = [],
+): Promise<void> {
   const db = getFirestoreDb()
 
   try {
+    // Pick a category to warm against, if any. Random pick among the
+    // active filters keeps multi-category runs from biasing toward the
+    // first id over many requests.
+    const targetCategoryId = categoryIds.length > 0
+      ? categoryIds[Math.floor(Math.random() * categoryIds.length)]
+      : null
+    const scope: CountKey = targetCategoryId ?? 'all'
+
     const [activeCount, state] = await Promise.all([
-      getActiveCount(db),
+      getActiveCount(db, scope),
       readTriviaState(uid),
     ])
 
@@ -67,23 +107,28 @@ export async function warmQuestionPoolForUser(uid: string): Promise<void> {
       seenCount,
       target: TARGET_UNANSWERED,
       toGenerate,
+      targetCategoryId,
     })
 
     const results = await Promise.allSettled(
-      Array.from({ length: toGenerate }, () =>
-        generateInfiniteQuestion({}).then((generated) =>
+      Array.from({ length: toGenerate }, () => {
+        const genOptions: Parameters<typeof generateInfiniteQuestion>[0] = {}
+        if (targetCategoryId !== null) genOptions.categoryId = targetCategoryId
+        return generateInfiniteQuestion(genOptions).then((generated) =>
           saveAIQuestion({ ...generated, createdBy: uid })
         )
-      )
+      })
     )
 
     const saved = results.filter((r) => r.status === 'fulfilled').length
     const failed = results.filter((r) => r.status === 'rejected').length
 
-    // Bust the cache so the next call sees the new total.
-    activeCountCache = null
+    // Bust the scoped count + the global count so the next call sees
+    // the new totals on whichever scope it queries next.
+    activeCountCache.delete(scope)
+    activeCountCache.delete('all')
 
-    console.info('[warmQuestionPool] batch done', { uid, saved, failed })
+    console.info('[warmQuestionPool] batch done', { uid, saved, failed, targetCategoryId })
   } catch (err) {
     console.warn('[warmQuestionPool] failed', {
       uid,


### PR DESCRIPTION
## Summary

Follow-up to #1397 after diagnostic logs showed the cache wasn't moving the needle for an exhausted-bank power user (seenCount 1076 > activeCount 854, 0 unanswered).

The cache only helps when the sampler can *find* unanswered questions. Two issues prevented that:

- **Warmer was global**, so it refilled random categories instead of the one the player was actively running. Niche or exhausted single-category runs stayed exhausted.
- **`CANDIDATE_WINDOW = 100`** is too narrow when the player's seen set is large — a 100-doc random window lands fully inside the seen set with high probability, so the rebuild returns 0 and we drop into the slow LLM-generation path on every `/next`.

### Changes
1. `warmQuestionPoolForUser` accepts `categoryIds[]` again; picks a random category from the player's active filter and scopes both the count and the generation to it. Empty array preserves the current global behavior. Per-scope count cache (Map keyed by `categoryId | 'all'`).
2. `route.ts` passes `categoryIds` to the warmer.
3. `CANDIDATE_WINDOW`: 100 → 500. Matches `POOL_CACHE_SIZE` so the rebuild fills the cache and pays back across many cache-hit `/next` calls.

## Test plan
- [x] Typecheck clean for changed files
- [x] 92 trivia tests pass
- [ ] Live: pick a category, drain its bank, observe warmer refilling *that* category in logs
- [ ] Live: confirm `/next` p50 drops for the all-category exhausted case

🤖 Generated with [Claude Code](https://claude.com/claude-code)