### PR TITLE
trivia: fix category-name mismatch in sampler + warmer queries

### DIFF
--- a/src/lib/trivia/sampler.ts
+++ b/src/lib/trivia/sampler.ts
@@ -1,3 +1,4 @@
+import { getOpenTDBCategoryName } from '@/app/trivia/data/seeds/categoryNames'
 import { getFirestoreDb } from '@/lib/firebase/server'
 import type { AIQuestion } from '@/lib/trivia/aiQuestions'
 import { CATEGORY_META } from '@/lib/trivia/categories'
@@ -102,13 +103,17 @@ function buildCandidateQuery(
     .where('status', '==', 'active')
     .where('type', '==', type)
 
-  // Resolve the optional category filter to category-name strings (the
-  // shape stored on aiQuestions docs). Firestore `in` clause caps at 30
-  // values, which is comfortably more than our 24 categories.
+  // Resolve the optional category filter to category-name strings.
+  // Questions are stored with the OpenTDB-prefixed name (e.g.
+  // "Entertainment: Film", not "Film") — see the note in
+  // categories.ts about the two naming conventions. CATEGORY_META is
+  // for UI display; getOpenTDBCategoryName is the storage format.
+  // Firestore `in` clause caps at 30 values, comfortably more than our
+  // 24 categories.
   if (categoryIds && categoryIds.length > 0) {
     const names = categoryIds
-      .map((id) => CATEGORY_META[id]?.name)
-      .filter((name): name is string => !!name)
+      .filter((id) => CATEGORY_META[id] !== undefined)
+      .map((id) => getOpenTDBCategoryName(id))
     if (names.length === 1) {
       query = query.where('category', '==', names[0])
     } else if (names.length > 1) {

--- a/src/lib/trivia/warmQuestionPool.ts
+++ b/src/lib/trivia/warmQuestionPool.ts
@@ -1,3 +1,4 @@
+import { getOpenTDBCategoryName } from '@/app/trivia/data/seeds/categoryNames'
 import { getFirestoreDb } from '@/lib/firebase/server'
 import { saveAIQuestion } from '@/lib/trivia/aiQuestions'
 import { CATEGORY_META } from '@/lib/trivia/categories'
@@ -30,9 +31,12 @@ async function getActiveCount(
   }
   let q: FirebaseFirestore.Query = db.collection('aiQuestions').where('status', '==', 'active')
   if (scope !== 'all') {
-    const name = CATEGORY_META[scope]?.name
-    if (!name) return 0
-    q = q.where('category', '==', name)
+    // Questions are stored under the OpenTDB-prefixed name (e.g.
+    // "Entertainment: Film"), not CATEGORY_META's short form. Filter
+    // out unknown ids via CATEGORY_META, then resolve the storage
+    // name via getOpenTDBCategoryName.
+    if (CATEGORY_META[scope] === undefined) return 0
+    q = q.where('category', '==', getOpenTDBCategoryName(scope))
   }
   const agg = await q.count().get()
   const value = agg.data().count


### PR DESCRIPTION
## Summary

Single-category Infinite Trivia runs have been silently broken for who knows how long. The sampler and warmer were filtering on the bare CATEGORY_META name (\`'Film'\`) but questions are stored with the OpenTDB-prefixed name (\`'Entertainment: Film'\`). \`where category == 'Film'\` matched zero docs, so:

- Sampler returned null on every \`/next\` for single-category runs → route generated fresh question (8-10s) every time.
- The new per-category warmer count() (from #1398) returned 0 → warmer always thought the category was empty → generated 3 fresh questions per /next as background work.

This is the root cause of the user-reported "0 unanswered" with \`activeCount: 0\` log even though the bank has 854 active questions in Film.

\`categories.ts:49\` already documents this trap. Fix is to call \`getOpenTDBCategoryName(id)\` — the same helper \`generateQuestion\` uses when **writing** the doc — in both query paths.

## Test plan
- [x] Typecheck clean
- [x] 92 trivia tests pass
- [ ] Live: in a single-category Film run, \`[warmQuestionPool] generating\` log should show \`activeCount > 0\` and \`approxUnanswered > 0\`; subsequent /next should return existing questions instead of generating fresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)