### PR TITLE
fix: Spare Trousers joker mult accumulation (#1404)

### DIFF
--- a/src/app/comet-cards/components/gameplay/joker.tsx
+++ b/src/app/comet-cards/components/gameplay/joker.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from 'react'
 import { TokenCard } from '@/app/comet-cards/components/cosmic/token-card'
 import { jokers } from '@/app/comet-cards/domain/joker/jokers'
 import type { JokerState } from '@/app/comet-cards/domain/joker/types'
@@ -20,6 +21,24 @@ export const Joker = ({
 }) => {
   const def = jokers[joker.jokerId]
   const accent = RARITY_ACCENT[def?.rarity ?? 'common'] ?? 'var(--cc-mint)'
+  const multBonus = joker.metadata?.multBonus as number | undefined
+  const chipsBonus = joker.metadata?.chipsBonus as number | undefined
+
+  let badge: ReactNode = undefined
+  if (multBonus != null && multBonus > 0) {
+    badge = (
+      <span style={{ fontSize: 11, fontWeight: 700, color: 'var(--cc-pink)' }}>
+        +{multBonus}
+      </span>
+    )
+  } else if (chipsBonus != null && chipsBonus > 0) {
+    badge = (
+      <span style={{ fontSize: 11, fontWeight: 700, color: 'var(--cc-mint)' }}>
+        +{chipsBonus}
+      </span>
+    )
+  }
+
   return (
     <TokenCard
       title={def?.name ?? 'Unknown'}
@@ -28,6 +47,7 @@ export const Joker = ({
       accent={accent}
       selected={isSelected}
       size="sm"
+      badge={badge}
       onClick={onClick ? () => onClick(isSelected ?? false, joker.id) : undefined}
     />
   )

--- a/src/app/comet-cards/domain/game/__tests__/spare-trousers.test.ts
+++ b/src/app/comet-cards/domain/game/__tests__/spare-trousers.test.ts
@@ -6,23 +6,25 @@ import { jokers } from '@/app/comet-cards/domain/joker/jokers'
 import { initializeJoker } from '@/app/comet-cards/domain/joker/utils'
 
 describe('Spare Trousers joker', () => {
-  it('gains +2 Mult after Two Pair is played', () => {
+  it('gains +2 Mult and applies it on first Two Pair hand', () => {
     const game: GameState = structuredClone(defaultGameState)
     game.jokers = [initializeJoker(jokers.spareTrousersJoker, game)]
     game.rounds[game.roundIndex].smallBlind.status = 'inProgress'
     game.gamePhase = 'gameplay'
     const started = reduceGame(game, { type: 'GAME_START' })
 
-    // First hand: play a Two Pair - no bonus yet (starts at 0), but gains +2
+    // First hand: play a Two Pair - gains +2 and immediately applies it
     const hand1: GameState = { ...started, gamePlayState: { ...started.gamePlayState, selectedHand: ['twoPair', []], score: { chips: 10, mult: 5 } } }
     const after1 = reduceGame(hand1, { type: 'HAND_SCORING_FINALIZE' })
     const st1 = after1.jokers.find(j => j.jokerId === 'spareTrousersJoker')
     expect(st1?.metadata?.multBonus).toBe(2)
 
-    // No Spare Trousers scoring event on first hand (bonus was 0)
-    expect(after1.gamePlayState.scoringEvents.some(
+    // Spare Trousers scoring event IS present on first hand (bonus incremented first, then applied)
+    const spareEvent = after1.gamePlayState.scoringEvents.find(
       e => 'source' in e && e.source === 'Spare Trousers'
-    )).toBe(false)
+    )
+    expect(spareEvent).toBeDefined()
+    expect((spareEvent as { value: number }).value).toBe(2)
   })
 
   it('does not gain when non-Two Pair hand played', () => {
@@ -36,5 +38,29 @@ describe('Spare Trousers joker', () => {
     const after = reduceGame(hand, { type: 'HAND_SCORING_FINALIZE' })
     const st = after.jokers.find(j => j.jokerId === 'spareTrousersJoker')
     expect(st?.metadata?.multBonus).toBe(0)
+  })
+
+  it('applies +4 mult on second consecutive Two Pair hand', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.jokers = [initializeJoker(jokers.spareTrousersJoker, game)]
+    game.rounds[game.roundIndex].smallBlind.status = 'inProgress'
+    game.gamePhase = 'gameplay'
+    const started = reduceGame(game, { type: 'GAME_START' })
+
+    // First Two Pair hand: accumulates +2, applies +2
+    const hand1: GameState = { ...started, gamePlayState: { ...started.gamePlayState, selectedHand: ['twoPair', []], score: { chips: 10, mult: 5 } } }
+    const after1 = reduceGame(hand1, { type: 'HAND_SCORING_FINALIZE' })
+
+    // Second Two Pair hand: accumulates another +2 (total 4), applies +4
+    const hand2: GameState = { ...after1, gamePlayState: { ...after1.gamePlayState, selectedHand: ['twoPair', []], scoringEvents: [], score: { chips: 10, mult: 5 } } }
+    const after2 = reduceGame(hand2, { type: 'HAND_SCORING_FINALIZE' })
+    const st2 = after2.jokers.find(j => j.jokerId === 'spareTrousersJoker')
+    expect(st2?.metadata?.multBonus).toBe(4)
+
+    const spareEvent = after2.gamePlayState.scoringEvents.find(
+      e => 'source' in e && e.source === 'Spare Trousers'
+    )
+    expect(spareEvent).toBeDefined()
+    expect((spareEvent as { value: number }).value).toBe(4)
   })
 })

--- a/src/app/comet-cards/domain/joker/jokers.ts
+++ b/src/app/comet-cards/domain/joker/jokers.ts
@@ -1154,6 +1154,15 @@ export const spareTrousersJoker: JokerDefinition = {
         const st = ctx.game.jokers.find(j => j.jokerId === 'spareTrousersJoker')
         if (!st || !st.metadata) return
 
+        // Check if hand contains Two Pair and gain +2
+        const selectedHand = ctx.game.gamePlayState.selectedHand
+        if (!selectedHand) return
+        const handId = selectedHand[0]
+        const handsContainingTwoPair = ['twoPair', 'fullHouse', 'flushHouse']
+        if (handsContainingTwoPair.includes(handId)) {
+          st.metadata.multBonus += 2
+        }
+
         // Apply accumulated mult bonus
         if (st.metadata.multBonus > 0) {
           ctx.game.gamePlayState.scoringEvents.push({
@@ -1163,15 +1172,6 @@ export const spareTrousersJoker: JokerDefinition = {
             source: 'Spare Trousers',
           })
           ctx.game.gamePlayState.score.mult += st.metadata.multBonus
-        }
-
-        // Check if hand contains Two Pair and gain +2
-        const selectedHand = ctx.game.gamePlayState.selectedHand
-        if (!selectedHand) return
-        const handId = selectedHand[0]
-        const handsContainingTwoPair = ['twoPair', 'fullHouse', 'flushHouse']
-        if (handsContainingTwoPair.includes(handId)) {
-          st.metadata.multBonus += 2
         }
       },
     },


### PR DESCRIPTION
## Summary

- **Bug fix**: The Spare Trousers joker was applying its accumulated mult bonus *before* incrementing it, so the first Two Pair hand always scored +0 instead of +2.
- **Fix**: Swapped the order in `HAND_SCORING_FINALIZE` — now the joker first checks for Two Pair and increments `multBonus`, then applies the accumulated bonus. This means the mult bonus is active on the *same hand* that triggered it.
- **UI enhancement**: The `Joker` component now renders a badge on joker cards that have `metadata.multBonus > 0` (pink, for Spare Trousers-style jokers) or `metadata.chipsBonus > 0` (mint, for Wee Joker-style jokers), giving players live feedback on accumulated bonuses.

## Test plan

- [x] Existing "does not gain when non-Two Pair hand played" test still passes
- [x] Updated first test: first Two Pair hand now produces a Spare Trousers scoring event with value 2
- [x] New third test: two consecutive Two Pair hands yield `multBonus = 4` and a scoring event of value 4 on the second hand
- [x] Full test suite passes (one pre-existing unrelated failure in `hanging-chad.test.ts` exists on `main` before this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)