### PR TITLE
feat: hide nav and footer when Comet Cards is open (#1405)

### DIFF
--- a/src/app/comet-cards/components/cosmic/shell.tsx
+++ b/src/app/comet-cards/components/cosmic/shell.tsx
@@ -1,25 +1,44 @@
 'use client'
 
+import Link from 'next/link'
 import { AmbientBG } from './ambient-bg'
-import { useLandscapeMobile } from '@/app/comet-cards/hooks/useLandscapeMobile'
 
 import type { ReactNode } from 'react'
 
 export function CosmicShell({ children }: { children: ReactNode }) {
-  const isLandscape = useLandscapeMobile()
   return (
     <div
       className="cosmic-cards relative w-full overflow-hidden"
       style={{
-        minHeight: isLandscape ? '100vh' : 'calc(100vh - 8rem)',
+        minHeight: '100vh',
         background:
           'radial-gradient(ellipse at 15% 15%, var(--cc-bg-grad-1) 0%, var(--cc-bg-grad-2) 40%, var(--cc-bg-grad-3) 100%)',
         color: 'var(--cc-text-default)',
-        borderRadius: isLandscape ? 0 : 12,
-        border: isLandscape ? 'none' : '1px solid rgba(94,234,212,0.08)',
       }}
     >
       <AmbientBG />
+      <Link
+        href="/"
+        aria-label="Exit to CometCave"
+        style={{
+          position: 'absolute',
+          top: 12,
+          left: 12,
+          zIndex: 50,
+          display: 'flex',
+          alignItems: 'center',
+          gap: 4,
+          fontSize: 13,
+          color: 'var(--cc-text-muted, rgba(255,255,255,0.5))',
+          textDecoration: 'none',
+          padding: '4px 8px',
+          borderRadius: 6,
+          transition: 'color 0.15s',
+        }}
+        className="hover:!text-white"
+      >
+        ✕
+      </Link>
       <div className="relative z-10">{children}</div>
     </div>
   )

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import { Plus_Jakarta_Sans, Be_Vietnam_Pro, Lexend } from 'next/font/google'
 
 import { AmbientOrbs } from '@/components/ambient-orbs'
 import { Footer } from '@/components/footer'
+import { LayoutShell } from '@/components/layout-shell'
 import { TopNavBar } from '@/components/top-nav-bar'
 
 import './globals.css'
@@ -57,9 +58,9 @@ export default function RootLayout({
         <body className={`${plusJakartaSans.variable} ${beVietnamPro.variable} ${lexend.variable} ${beVietnamPro.className}`}>
           <div id="site-wrapper" className="min-h-screen flex flex-col bg-surface-dim text-on-surface relative overflow-hidden">
             <AmbientOrbs palette={['primary', 'secondary', 'tertiary']} intensity="medium" />
-            <TopNavBar />
-            <main className="flex-1 container mx-auto p-4 z-20 relative">{children}</main>
-            <Footer />
+            <LayoutShell nav={<TopNavBar />} footer={<Footer />}>
+              {children}
+            </LayoutShell>
           </div>
         </body>
       </html>

--- a/src/app/route-constants.ts
+++ b/src/app/route-constants.ts
@@ -9,4 +9,5 @@ export const ROUTE_CONSTANTS = {
   AVATAR_MAKER: '/avatar-maker',
   WHOWOULDWININATOR: '/whowouldwininator',
   TRIVIA: '/trivia',
+  COMET_CARDS: '/comet-cards',
 }

--- a/src/components/layout-shell.tsx
+++ b/src/components/layout-shell.tsx
@@ -1,0 +1,32 @@
+'use client'
+
+import { usePathname } from 'next/navigation'
+import { ROUTE_CONSTANTS } from '@/app/route-constants'
+import type { ReactNode } from 'react'
+
+const IMMERSIVE_ROUTES = [ROUTE_CONSTANTS.COMET_CARDS]
+
+export function LayoutShell({
+  children,
+  nav,
+  footer,
+}: {
+  children: ReactNode
+  nav: ReactNode
+  footer: ReactNode
+}) {
+  const pathname = usePathname()
+  const isImmersive = IMMERSIVE_ROUTES.some(r => pathname.startsWith(r))
+
+  if (isImmersive) {
+    return <main className="flex-1 z-20 relative">{children}</main>
+  }
+
+  return (
+    <>
+      {nav}
+      <main className="flex-1 container mx-auto p-4 z-20 relative">{children}</main>
+      {footer}
+    </>
+  )
+}


### PR DESCRIPTION
## Summary

- Adds `COMET_CARDS` to `ROUTE_CONSTANTS` so immersive route detection uses the shared constant
- Introduces `LayoutShell` (new client component at `src/components/layout-shell.tsx`) that uses `usePathname()` to conditionally hide nav/footer on immersive routes — keeping `layout.tsx` a server component
- On `/comet-cards`, nav and footer are hidden and content fills the viewport; all other routes render normally
- Updates `CosmicShell` to always use `minHeight: 100vh` (removes the conditional landscape logic), strips border/borderRadius for true edge-to-edge display, and adds a small ✕ exit button in the top-left corner linking back to home

The `IMMERSIVE_ROUTES` array in `LayoutShell` is easy to extend for future full-screen game experiences.

## Test plan

- [ ] Visit `/comet-cards` — nav bar and footer should not be visible; game fills the full viewport
- [ ] ✕ button in top-left of game shell navigates back to `/`
- [ ] Visit any other route (e.g. `/`, `/trivia`) — nav and footer render as before
- [ ] Verify no visual regressions on mobile and desktop

🤖 Generated with [Claude Code](https://claude.com/claude-code)