### PR TITLE
feat: brief pause before leaving gameplay view after winning (#1408)

### DIFF
--- a/src/app/comet-cards/domain/game/score-hand.ts
+++ b/src/app/comet-cards/domain/game/score-hand.ts
@@ -53,6 +53,12 @@ export async function scoreHand({ getGameState }: ScoreHandOptions): Promise<voi
     // Brief pause before finalization
     await sleep(250)
     eventEmitter.emit({ type: 'HAND_SCORING_FINALIZE' })
+
+    // Let the player savor the result before transitioning
+    const finalState = getGameState()
+    if (finalState.gamePhase !== 'gameplay') {
+      await sleep(1500)
+    }
   } finally {
     isScoringInProgress = false
   }


### PR DESCRIPTION
Adds a 1.5s delay after HAND_SCORING_FINALIZE when the game phase changes (win/loss), so the player can see their final score before transitioning to the results view.