### PR TITLE
feat: add subtle type label to card faces (#1412)

### DIFF
--- a/src/app/comet-cards/components/cosmic/token-card.tsx
+++ b/src/app/comet-cards/components/cosmic/token-card.tsx
@@ -20,6 +20,7 @@ export function TokenCard({
   badge,
   onClick,
   footer,
+  typeLabel,
 }: {
   title: string
   description?: string
@@ -31,6 +32,7 @@ export function TokenCard({
   badge?: ReactNode
   onClick?: () => void
   footer?: ReactNode
+  typeLabel?: string
 }) {
   const dims = SIZES[size]
   const isInteractive = !!onClick && !disabled
@@ -94,6 +96,25 @@ export function TokenCard({
           }}
         >
           {badge}
+        </div>
+      )}
+
+      {typeLabel && (
+        <div
+          style={{
+            position: 'absolute',
+            top: 8,
+            left: 10,
+            zIndex: 2,
+            fontSize: 8,
+            fontWeight: 600,
+            letterSpacing: 1.5,
+            textTransform: 'uppercase',
+            color: accent,
+            opacity: 0.4,
+          }}
+        >
+          {typeLabel}
         </div>
       )}
 

--- a/src/app/comet-cards/components/gameplay/celestial-card.tsx
+++ b/src/app/comet-cards/components/gameplay/celestial-card.tsx
@@ -20,6 +20,7 @@ export const CelestialCard = ({
       accent="var(--cc-gold)"
       selected={isSelected}
       size="sm"
+      typeLabel="Celestial"
       onClick={onClick ? () => onClick(isSelected ?? false, celestialCard.id) : undefined}
     />
   )

--- a/src/app/comet-cards/components/gameplay/joker.tsx
+++ b/src/app/comet-cards/components/gameplay/joker.tsx
@@ -48,6 +48,7 @@ export const Joker = ({
       selected={isSelected}
       size="sm"
       badge={badge}
+      typeLabel="Joker"
       onClick={onClick ? () => onClick(isSelected ?? false, joker.id) : undefined}
     />
   )

--- a/src/app/comet-cards/components/gameplay/spectral-card.tsx
+++ b/src/app/comet-cards/components/gameplay/spectral-card.tsx
@@ -32,6 +32,7 @@ export const SpectralCard = ({
       accent="var(--cc-rarity-uncommon)"
       selected={isSelected}
       size="sm"
+      typeLabel="Spectral"
       onClick={onClick ? () => onClick(isSelected ?? false, spectralCard.id) : undefined}
     />
   )

--- a/src/app/comet-cards/components/gameplay/tarot-card.tsx
+++ b/src/app/comet-cards/components/gameplay/tarot-card.tsx
@@ -20,6 +20,7 @@ export const TarotCard = ({
       accent="var(--cc-pink)"
       selected={isSelected}
       size="sm"
+      typeLabel="Tarot"
       onClick={onClick ? () => onClick(isSelected ?? false, tarotCard.id) : undefined}
     />
   )

--- a/src/app/comet-cards/components/shop/voucher.tsx
+++ b/src/app/comet-cards/components/shop/voucher.tsx
@@ -11,6 +11,7 @@ export function Voucher({ voucher }: { voucher: VoucherType }) {
       glyph="❖"
       accent="var(--cc-gold)"
       size="sm"
+      typeLabel="Voucher"
     />
   )
 }


### PR DESCRIPTION
## Summary
- Adds an optional `typeLabel` prop to `TokenCard` rendered as a small, muted absolute-positioned label at top-left of each card face
- Passes type labels from all special card components: Joker, Tarot, Celestial, Spectral, Voucher
- Playing cards are unaffected

## Test plan
- [ ] Verify Joker cards show "JOKER" label at top-left in fine print
- [ ] Verify Tarot cards show "TAROT" label
- [ ] Verify Celestial cards show "CELESTIAL" label
- [ ] Verify Spectral cards show "SPECTRAL" label
- [ ] Verify Voucher cards show "VOUCHER" label
- [ ] Verify playing cards are unaffected (no label)
- [ ] Verify label uses accent color at low opacity (0.4), is uppercase, small (8px), letter-spaced
- [ ] Confirm the label does not interfere with the badge (badge is top-right, label is top-left)

🤖 Generated with [Claude Code](https://claude.com/claude-code)