### PR TITLE
feat: all Comet Cards views fit within viewport (#1406)

### DIFF
--- a/src/app/comet-cards/components/cosmic/shell.tsx
+++ b/src/app/comet-cards/components/cosmic/shell.tsx
@@ -10,7 +10,7 @@ export function CosmicShell({ children }: { children: ReactNode }) {
     <div
       className="cosmic-cards relative w-full overflow-hidden"
       style={{
-        minHeight: '100vh',
+        height: '100vh',
         background:
           'radial-gradient(ellipse at 15% 15%, var(--cc-bg-grad-1) 0%, var(--cc-bg-grad-2) 40%, var(--cc-bg-grad-3) 100%)',
         color: 'var(--cc-text-default)',
@@ -39,7 +39,7 @@ export function CosmicShell({ children }: { children: ReactNode }) {
       >
         ✕
       </Link>
-      <div className="relative z-10">{children}</div>
+      <div className="relative z-10" style={{ display: 'flex', flexDirection: 'column', height: '100%' }}>{children}</div>
     </div>
   )
 }

--- a/src/app/comet-cards/components/game-views/main-menu.tsx
+++ b/src/app/comet-cards/components/game-views/main-menu.tsx
@@ -21,12 +21,14 @@ export function MainMenuView() {
   const isLandscape = useLandscapeMobile()
   return (
     <div
-      className="relative mx-auto flex flex-col items-center"
+      className="cc-scroll relative mx-auto flex flex-col items-center"
       style={{
         padding: isLandscape ? '16px 16px' : '64px 24px',
         gap: isLandscape ? 12 : 28,
         maxWidth: 720,
         textAlign: 'center',
+        height: '100%',
+        overflowY: 'auto',
       }}
     >
       <div

--- a/src/app/comet-cards/components/game-views/view-template.tsx
+++ b/src/app/comet-cards/components/game-views/view-template.tsx
@@ -70,7 +70,7 @@ export function ViewTemplate({
     : 0n
 
   return (
-    <div className="relative">
+    <div className="relative" style={{ display: 'flex', flexDirection: 'column', height: '100%', overflow: 'hidden' }}>
       {/* Top stat strip — keeps every view aligned with gameplay */}
       <div
         className="relative z-10 flex flex-wrap items-center justify-between gap-4"
@@ -111,10 +111,13 @@ export function ViewTemplate({
           gap: 18,
           padding: isLandscape ? '8px 12px' : '14px 22px 22px',
           alignItems: 'start',
+          flex: 1,
+          minHeight: 0,
+          overflow: 'hidden',
         }}
       >
         {/* Sidebar */}
-        <aside id="game-sidebar" className="flex flex-col gap-4" style={{ display: isLandscape ? 'none' : undefined }}>
+        <aside id="game-sidebar" className="cc-scroll flex flex-col gap-4" style={{ display: isLandscape ? 'none' : undefined, overflowY: 'auto', minHeight: 0 }}>
           {sidebarContentTop}
 
           <Panel title="Run Stats">
@@ -220,7 +223,7 @@ export function ViewTemplate({
         </aside>
 
         {/* Main */}
-        <main id="game-content" className="min-w-0">
+        <main id="game-content" className="cc-scroll min-w-0" style={{ overflowY: 'auto', minHeight: 0 }}>
           {children}
         </main>
       </div>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -358,6 +358,26 @@ body {
   transform: translateY(var(--cc-card-lift, -16px));
 }
 
+/* Comet Cards — thin internal scrollbar utility */
+.cc-scroll {
+  overflow-y: auto;
+  scrollbar-width: thin;
+  scrollbar-color: rgba(94, 234, 212, 0.2) transparent;
+}
+
+.cc-scroll::-webkit-scrollbar {
+  width: 4px;
+}
+
+.cc-scroll::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.cc-scroll::-webkit-scrollbar-thumb {
+  background: rgba(94, 234, 212, 0.2);
+  border-radius: 4px;
+}
+
 /* When game is active on mobile, hide site chrome and fix scrolling */
 @media (max-width: 767px) {
   body.game-active header,


### PR DESCRIPTION
## Summary

- Makes `CosmicShell` a fixed `height: 100vh` container (was `minHeight: 100vh`) so the shell is the viewport boundary and no full-page scroll occurs
- Inner content div in `CosmicShell` becomes a flex column filling the full height
- `ViewTemplate` outer div is a flex column filling 100% height; the grid container takes `flex: 1` with `minHeight: 0` and `overflow: hidden`
- Sidebar `<aside>` and main `<main>` both get `overflowY: auto` / `minHeight: 0` so they scroll internally, not the page
- `MainMenuView` (renders without `ViewTemplate`) gets `height: 100%` and `overflowY: auto`
- All other views (`GameOverView`, `BlindRewardsView`, `BlindSelectionView`, `PackOpenView`) already use `ViewTemplate` — no changes needed
- Adds `.cc-scroll` CSS utility in `globals.css` for thin teal-tinted scrollbars applied to sidebar and main content

## Test plan

- [ ] Launch a new game — verify the whole page stays within the viewport on desktop (no outer scrollbar)
- [ ] Resize to mobile portrait — verify game content scrolls internally in the main area
- [ ] Resize to landscape mobile — sidebar hidden, single-column layout still fits within viewport
- [ ] Navigate to blind selection, blind rewards, pack open, game over — none trigger page-level scroll
- [ ] Main menu — no overflow beyond 100vh
- [ ] Sidebar with many panels (tags, vouchers) — scrolls internally with thin styled scrollbar

🤖 Generated with [Claude Code](https://claude.com/claude-code)