### PR TITLE
feat: animate game-over view elements with staggered entrance (#1409)

### DIFF
--- a/src/app/comet-cards/components/game-views/game-over.tsx
+++ b/src/app/comet-cards/components/game-views/game-over.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useCallback, useMemo, useState } from 'react'
+import { motion } from 'framer-motion'
 
 import { PrimaryButton } from '@/app/comet-cards/components/cosmic/buttons'
 import { Panel } from '@/app/comet-cards/components/cosmic/panel'
@@ -8,6 +9,18 @@ import { useGameState } from '@/app/comet-cards/useGameState'
 import { useLandscapeMobile } from '@/app/comet-cards/hooks/useLandscapeMobile'
 
 import { ViewTemplate } from './view-template'
+
+function FadeUp({ children, delay = 0 }: { children: React.ReactNode; delay?: number }) {
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 16 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.4, delay, ease: [0.2, 0.9, 0.3, 1] }}
+    >
+      {children}
+    </motion.div>
+  )
+}
 
 async function copyToClipboard(text: string) {
   if (typeof window === 'undefined') return
@@ -76,111 +89,129 @@ export function GameOverView() {
             className="flex flex-col items-center text-center"
             style={{ padding: isLandscape ? '12px 16px' : '28px 24px', gap: 16 }}
           >
-            <div
-              className="uppercase"
-              style={{
-                fontFamily: 'var(--cc-font-mono)',
-                fontSize: 11,
-                letterSpacing: 2.5,
-                opacity: 0.55,
-                color: accent,
-              }}
-            >
-              {didWin ? 'You Win' : 'Game Over'}
-            </div>
-            <div
-              style={{
-                fontSize: 28,
-                fontWeight: 300,
-                letterSpacing: -0.5,
-                lineHeight: 1.2,
-                color: 'var(--cc-text-default)',
-              }}
-            >
-              {headline}
-            </div>
-            <div
-              className="uppercase"
-              style={{
-                fontFamily: 'var(--cc-font-mono)',
-                fontSize: 10,
-                letterSpacing: 2,
-                opacity: 0.5,
-                marginTop: 8,
-              }}
-            >
-              Total Score
-            </div>
-            <div
-              style={{
-                fontSize: isLandscape ? 28 : 44,
-                fontWeight: 200,
-                letterSpacing: -1.5,
-                lineHeight: 1,
-                color: 'var(--cc-text-default)',
-                textShadow: '0 0 60px rgba(94,234,212,0.3)',
-              }}
-            >
-              {game.totalScore.toString()}
-            </div>
-            <div
-              className="flex items-center justify-center gap-1"
-              style={{ marginTop: 4 }}
-              role="img"
-              aria-label={`Rounds completed ${roundsCompleted} of ${totalRounds}`}
-            >
-              {Array.from({ length: totalRounds }).map((_, idx) => {
-                const isCompleted = idx < roundsCompleted
-                return (
-                  <span
-                    key={idx}
-                    className="inline-block"
-                    style={{
-                      width: 14,
-                      height: 14,
-                      borderRadius: 3,
-                      background: isCompleted
-                        ? 'color-mix(in srgb, var(--cc-mint) 65%, transparent)'
-                        : 'transparent',
-                      border: isCompleted
-                        ? '1px solid var(--cc-mint)'
-                        : '1px solid rgba(255,107,157,0.4)',
-                      boxShadow: isCompleted ? '0 0 10px rgba(94,234,212,0.45)' : 'none',
-                    }}
-                  />
-                )
-              })}
-            </div>
-            <div
-              className="uppercase"
-              style={{
-                fontFamily: 'var(--cc-font-mono)',
-                fontSize: 10,
-                letterSpacing: 2,
-                opacity: 0.45,
-              }}
-            >
-              {roundsCompleted} / {totalRounds} rounds
-            </div>
-            <div className="flex flex-col items-center" style={{ gap: 6, marginTop: 8 }}>
-              <div style={{ fontSize: 12, opacity: 0.7 }}>
-                Hands Played: <strong>{game.handsPlayed}</strong>
+            <FadeUp delay={0}>
+              <div
+                className="uppercase"
+                style={{
+                  fontFamily: 'var(--cc-font-mono)',
+                  fontSize: 11,
+                  letterSpacing: 2.5,
+                  opacity: 0.55,
+                  color: accent,
+                }}
+              >
+                {didWin ? 'You Win' : 'Game Over'}
               </div>
-            </div>
-            <PrimaryButton style={{ marginTop: 12 }} onClick={onShare}>
-              {hasCopied ? 'Copied' : 'Share Score'}
-            </PrimaryButton>
-            <div
-              style={{
-                fontSize: 12,
-                opacity: 0.55,
-                marginTop: 8,
-                color: 'var(--cc-gold)',
-                fontWeight: 600,
-              }}
+            </FadeUp>
+            <FadeUp delay={0.15}>
+              <div
+                style={{
+                  fontSize: 28,
+                  fontWeight: 300,
+                  letterSpacing: -0.5,
+                  lineHeight: 1.2,
+                  color: 'var(--cc-text-default)',
+                }}
+              >
+                {headline}
+              </div>
+            </FadeUp>
+            <FadeUp delay={0.3}>
+              <div
+                className="uppercase"
+                style={{
+                  fontFamily: 'var(--cc-font-mono)',
+                  fontSize: 10,
+                  letterSpacing: 2,
+                  opacity: 0.5,
+                  marginTop: 8,
+                }}
+              >
+                Total Score
+              </div>
+            </FadeUp>
+            <motion.div
+              initial={{ opacity: 0, y: 16, scale: 0.8 }}
+              animate={{ opacity: 1, y: 0, scale: 1 }}
+              transition={{ duration: 0.5, delay: 0.45, ease: [0.2, 0.9, 0.3, 1] }}
             >
-              Try again tomorrow for a new game.
-            </div>
+              <div
+                style={{
+                  fontSize: isLandscape ? 28 : 44,
+                  fontWeight: 200,
+                  letterSpacing: -1.5,
+                  lineHeight: 1,
+                  color: 'var(--cc-text-default)',
+                  textShadow: '0 0 60px rgba(94,234,212,0.3)',
+                }}
+              >
+                {game.totalScore.toString()}
+              </div>
+            </motion.div>
+            <FadeUp delay={0.6}>
+              <div
+                className="flex items-center justify-center gap-1"
+                style={{ marginTop: 4 }}
+                role="img"
+                aria-label={`Rounds completed ${roundsCompleted} of ${totalRounds}`}
+              >
+                {Array.from({ length: totalRounds }).map((_, idx) => {
+                  const isCompleted = idx < roundsCompleted
+                  return (
+                    <span
+                      key={idx}
+                      className="inline-block"
+                      style={{
+                        width: 14,
+                        height: 14,
+                        borderRadius: 3,
+                        background: isCompleted
+                          ? 'color-mix(in srgb, var(--cc-mint) 65%, transparent)'
+                          : 'transparent',
+                        border: isCompleted
+                          ? '1px solid var(--cc-mint)'
+                          : '1px solid rgba(255,107,157,0.4)',
+                        boxShadow: isCompleted ? '0 0 10px rgba(94,234,212,0.45)' : 'none',
+                      }}
+                    />
+                  )
+                })}
+              </div>
+              <div
+                className="uppercase"
+                style={{
+                  fontFamily: 'var(--cc-font-mono)',
+                  fontSize: 10,
+                  letterSpacing: 2,
+                  opacity: 0.45,
+                }}
+              >
+                {roundsCompleted} / {totalRounds} rounds
+              </div>
+            </FadeUp>
+            <FadeUp delay={0.75}>
+              <div className="flex flex-col items-center" style={{ gap: 6, marginTop: 8 }}>
+                <div style={{ fontSize: 12, opacity: 0.7 }}>
+                  Hands Played: <strong>{game.handsPlayed}</strong>
+                </div>
+              </div>
+            </FadeUp>
+            <FadeUp delay={0.9}>
+              <PrimaryButton style={{ marginTop: 12 }} onClick={onShare}>
+                {hasCopied ? 'Copied' : 'Share Score'}
+              </PrimaryButton>
+              <div
+                style={{
+                  fontSize: 12,
+                  opacity: 0.55,
+                  marginTop: 8,
+                  color: 'var(--cc-gold)',
+                  fontWeight: 600,
+                }}
+              >
+                Try again tomorrow for a new game.
+              </div>
+            </FadeUp>
           </div>
         </Panel>
       </div>


### PR DESCRIPTION
## Summary
- Adds staggered fade-up entrance animations to the game-over/congrats view using framer-motion
- Each element animates in sequence over ~1.2s with increasing delays (0, 0.15, 0.3, 0.45, 0.6, 0.75, 0.9)
- Score number has a subtle scale-in effect (0.8 → 1) in addition to the fade-up

## Changes
- Added `FadeUp` helper component at the top of `game-over.tsx` using `motion.div` with `initial`/`animate`/`transition`
- Wrapped 7 element groups in `<FadeUp delay={N}>` with staggered delays
- Score number uses a direct `motion.div` with extra `scale` animation for more drama
- framer-motion respects `prefers-reduced-motion` natively via its `ReducedMotion` context

## Test plan
- [ ] Navigate to game-over view (win or loss) and verify each element fades up in sequence
- [ ] Verify score number has a subtle scale-in effect
- [ ] Test with `prefers-reduced-motion: reduce` enabled in OS/browser — animations should be suppressed
- [ ] Verify landscape mobile layout still renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)