### PR TITLE
fix: crash in flush check when cards array is empty

### DIFF
--- a/src/app/comet-cards/domain/hand/hands.ts
+++ b/src/app/comet-cards/domain/hand/hands.ts
@@ -198,6 +198,7 @@ export const checkHandForStraight: HandCheckFunction<[StaticRulesState]> = (card
 }
 
 export const checkHandForFlush: HandCheckFunction<[StaticRulesState]> = (cards, staticRules) => {
+  if (cards.length === 0) return [false, []]
   const rankedCards = rankCardsByValueAndSuit(cards)
   const firstSuit = playingCards[rankedCards[0].playingCardId].suit
   const flush = rankedCards.filter(card =>


### PR DESCRIPTION
Adds early return guard to checkHandForFlush when called with empty cards array. Fixes pre-existing crash in hanging-chad test.