### PR TITLE
fix: Turtle Bean joker decrement and display (#1420)

### DIFF
--- a/src/app/comet-cards/components/gameplay/joker.tsx
+++ b/src/app/comet-cards/components/gameplay/joker.tsx
@@ -23,6 +23,7 @@ export const Joker = ({
   const accent = RARITY_ACCENT[def?.rarity ?? 'common'] ?? 'var(--cc-mint)'
   const multBonus = joker.metadata?.multBonus as number | undefined
   const chipsBonus = joker.metadata?.chipsBonus as number | undefined
+  const handSizeBonus = joker.metadata?.handSizeBonus as number | undefined
 
   let badge: ReactNode = undefined
   if (multBonus != null && multBonus > 0) {
@@ -35,6 +36,12 @@ export const Joker = ({
     badge = (
       <span style={{ fontSize: 11, fontWeight: 700, color: 'var(--cc-mint)' }}>
         +{chipsBonus}
+      </span>
+    )
+  } else if (handSizeBonus != null && handSizeBonus > 0) {
+    badge = (
+      <span style={{ fontSize: 11, fontWeight: 700, color: 'var(--cc-gold)' }}>
+        +{handSizeBonus}
       </span>
     )
   }

--- a/src/app/comet-cards/domain/game/__tests__/turtle-bean.test.ts
+++ b/src/app/comet-cards/domain/game/__tests__/turtle-bean.test.ts
@@ -47,6 +47,30 @@ describe('Turtle Bean joker', () => {
     expect(game.jokers.some(j => j.jokerId === 'turtleBeanJoker')).toBe(false)
   })
 
+  it('decrements each instance independently with multiple Turtle Beans', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    const tb1 = initializeJoker(jokers.turtleBeanJoker, game)
+    tb1.metadata = { handSizeBonus: 5 }
+    const tb2 = initializeJoker(jokers.turtleBeanJoker, game)
+    tb2.metadata = { handSizeBonus: 5 }
+    game.jokers = [tb1, tb2]
+
+    const started = reduceGame(game, { type: 'GAME_START' })
+    expect(started.handSizeModifier).toBe(10)
+
+    const afterRound1 = reduceGame(started, { type: 'ROUND_END' })
+    expect(afterRound1.handSizeModifier).toBe(8) // each decremented by 1
+    expect(afterRound1.jokers.length).toBe(2)
+
+    // After 5 rounds both should be gone
+    let g = started
+    for (let i = 0; i < 5; i++) {
+      g = reduceGame(g, { type: 'ROUND_END' })
+    }
+    expect(g.handSizeModifier).toBe(0)
+    expect(g.jokers.some(j => j.jokerId === 'turtleBeanJoker')).toBe(false)
+  })
+
   it('reverts hand size modifier when sold', () => {
     const game = createGameWithTurtleBean()
     const started = reduceGame(game, { type: 'GAME_START' })

--- a/src/app/comet-cards/domain/joker/jokers.ts
+++ b/src/app/comet-cards/domain/joker/jokers.ts
@@ -491,24 +491,29 @@ export const turtleBeanJoker: JokerDefinition = {
     {
       event: { type: 'GAME_START' },
       priority: 1,
+      // Called once per instance by the effect system. Apply bonus for exactly one uninitialized instance.
       apply: (ctx: EffectContext) => {
-        const tb = ctx.game.jokers.find(j => j.jokerId === 'turtleBeanJoker')
-        if (tb) {
-          if (!tb.metadata?.handSizeBonus) {
-            tb.metadata = { ...tb.metadata, handSizeBonus: 5 }
-          }
-          const bonus = tb.metadata?.handSizeBonus ?? 5
-          ctx.game.handSizeModifier += bonus
+        const tb = ctx.game.jokers.find(
+          j => j.jokerId === 'turtleBeanJoker' && !(j.metadata as Record<string, unknown>)?.__gameStartApplied
+        )
+        if (!tb) return
+        if (!tb.metadata?.handSizeBonus) {
+          tb.metadata = { ...tb.metadata, handSizeBonus: 5 }
         }
+        const bonus = tb.metadata?.handSizeBonus ?? 5
+        ctx.game.handSizeModifier += bonus
+        ;(tb.metadata as Record<string, unknown>).__gameStartApplied = true
       },
     },
     {
       event: { type: 'JOKER_ADDED' },
       priority: 1,
       apply: (ctx: EffectContext) => {
-        const tb = ctx.game.jokers.find(j => j.jokerId === 'turtleBeanJoker')
-        if (tb) {
-          tb.metadata = { ...tb.metadata, handSizeBonus: 5 }
+        const newTb = ctx.game.jokers.find(
+          j => j.jokerId === 'turtleBeanJoker' && (!j.metadata || j.metadata.handSizeBonus === undefined)
+        )
+        if (newTb) {
+          newTb.metadata = { ...newTb.metadata, handSizeBonus: 5 }
           ctx.game.handSizeModifier += 5
         }
       },
@@ -516,16 +521,30 @@ export const turtleBeanJoker: JokerDefinition = {
     {
       event: { type: 'ROUND_END' },
       priority: 1,
+      // Called once per instance by the effect system. Use a per-dispatch marker to ensure each
+      // bean is decremented exactly once per ROUND_END dispatch, even with multiple instances.
       apply: (ctx: EffectContext) => {
-        const tb = ctx.game.jokers.find(j => j.jokerId === 'turtleBeanJoker')
+        const allBeans = ctx.game.jokers.filter(j => j.jokerId === 'turtleBeanJoker')
+        // On the first invocation of this dispatch, none will have __roundEndInProgress.
+        // On subsequent invocations, processed beans will have it set.
+        // If ALL beans already have the marker, this is a new dispatch — clear markers first.
+        const allMarked = allBeans.length > 0 && allBeans.every(j => (j.metadata as Record<string, unknown>)?.__roundEndInProgress)
+        if (allMarked) {
+          for (const b of allBeans) {
+            delete (b.metadata as Record<string, unknown>).__roundEndInProgress
+          }
+        }
+        const tb = ctx.game.jokers.find(
+          j => j.jokerId === 'turtleBeanJoker' && j.metadata && !(j.metadata as Record<string, unknown>).__roundEndInProgress
+        )
         if (!tb || !tb.metadata) return
-
         ctx.game.handSizeModifier -= 1
         tb.metadata.handSizeBonus -= 1
-
-        if (tb.metadata.handSizeBonus <= 0) {
-          ctx.game.jokers = ctx.game.jokers.filter(j => j.id !== tb.id)
-        }
+        ;(tb.metadata as Record<string, unknown>).__roundEndInProgress = true
+        // Remove instances that reached 0
+        ctx.game.jokers = ctx.game.jokers.filter(
+          j => j.jokerId !== 'turtleBeanJoker' || (j.metadata?.handSizeBonus ?? 0) > 0
+        ) as typeof ctx.game.jokers
       },
     },
     {


### PR DESCRIPTION
## Summary
- Fixes ROUND_END handler to iterate ALL Turtle Bean instances instead of only the first, using a per-dispatch marker (`__roundEndInProgress`) to ensure each instance is decremented exactly once per round even when the effect system calls the handler multiple times
- Fixes GAME_START handler similarly to apply the bonus once per instance per dispatch
- Fixes JOKER_ADDED handler to only initialize the newly-added instance (the one without metadata set)
- Adds `handSizeBonus` badge display on the joker card in gold (`var(--cc-gold)`) to differentiate from mult (pink) and chips (mint)

## Test plan
- [ ] All existing Turtle Bean tests pass (single-instance add, decrement, self-destruct, sell)
- [ ] New multi-instance test passes: two Turtle Beans both decrement correctly each round and both self-destruct after 5 rounds
- [ ] Run `npx vitest run src/app/comet-cards/domain/game/__tests__/turtle-bean.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)