### PR TITLE
fix: shop cards cut off — enable scroll within viewport (#1423)

### DIFF
--- a/src/app/comet-cards/components/game-views/view-template.tsx
+++ b/src/app/comet-cards/components/game-views/view-template.tsx
@@ -110,7 +110,7 @@ export function ViewTemplate({
           gridTemplateColumns: isLandscape ? '1fr' : 'minmax(240px, 280px) minmax(0, 1fr)',
           gap: 18,
           padding: isLandscape ? '8px 12px' : '14px 22px 22px',
-          alignItems: 'start',
+          alignItems: 'stretch',
           flex: 1,
           minHeight: 0,
           overflow: 'hidden',


### PR DESCRIPTION
Changes grid alignItems from 'start' to 'stretch' so content areas fill the grid cell height and scroll internally instead of overflowing and being clipped.