### PR TITLE
fix: boss blinds now vary per round via seeded rotation (#1425)

### DIFF
--- a/src/app/comet-cards/domain/round/boss-blinds.ts
+++ b/src/app/comet-cards/domain/round/boss-blinds.ts
@@ -708,7 +708,8 @@ frameless]	Violet Vessel	Very large blind	8	6x base	$8	✗ No
 
 export const getRandomBossBlind = (ante: number, seed: string): BossBlindDefinition => {
   const bossBlindsForAnte = bossBlinds.filter(blind => blind.minimumAnte <= ante)
-  const randomIndex = getRandomNumberWithSeed(seed, 0, bossBlindsForAnte.length - 1)
+  const roundSeed = buildSeedString([seed, ante.toString(), 'boss-blind'])
+  const randomIndex = getRandomNumberWithSeed(roundSeed, 0, bossBlindsForAnte.length - 1)
 
   if (bossBlindsForAnte.length === 0) {
     throw new Error(`No boss blind found for ante ${ante}`)


### PR DESCRIPTION
Includes ante and 'boss-blind' salt in the seed for getRandomBossBlind, producing different boss blinds per round while maintaining daily determinism.