### PR TITLE
feat: display internal state on all stateful jokers (#1422)

### DIFF
--- a/src/app/comet-cards/components/gameplay/joker.tsx
+++ b/src/app/comet-cards/components/gameplay/joker.tsx
@@ -24,6 +24,8 @@ export const Joker = ({
   const multBonus = joker.metadata?.multBonus as number | undefined
   const chipsBonus = joker.metadata?.chipsBonus as number | undefined
   const handSizeBonus = joker.metadata?.handSizeBonus as number | undefined
+  const xMult = joker.metadata?.xMult as number | undefined
+  const payout = joker.metadata?.payout as number | undefined
 
   let badge: ReactNode = undefined
   if (multBonus != null && multBonus > 0) {
@@ -42,6 +44,24 @@ export const Joker = ({
     badge = (
       <span style={{ fontSize: 11, fontWeight: 700, color: 'var(--cc-gold)' }}>
         +{handSizeBonus}
+      </span>
+    )
+  } else if (xMult != null && xMult > 100) {
+    badge = (
+      <span style={{ fontSize: 11, fontWeight: 700, color: 'var(--cc-pink)' }}>
+        ×{(xMult / 100).toFixed(xMult % 100 === 0 ? 0 : 2)}
+      </span>
+    )
+  } else if (payout != null && payout > 0) {
+    badge = (
+      <span style={{ fontSize: 11, fontWeight: 700, color: 'var(--cc-gold)' }}>
+        ${payout}
+      </span>
+    )
+  } else if (joker.counter > 0) {
+    badge = (
+      <span style={{ fontSize: 11, fontWeight: 700, color: 'var(--cc-text-default)', opacity: 0.7 }}>
+        {joker.counter}
       </span>
     )
   }


### PR DESCRIPTION
Extends the joker badge to display counter, xMult, and payout state. Now all 34+ stateful jokers show their current value on the card face. Priority: multBonus > chipsBonus > handSizeBonus > xMult > payout > counter.