### PR TITLE
feat: ticking score animation during hand scoring (#1410)

### DIFF
--- a/src/app/comet-cards/components/animations/ticking-number.tsx
+++ b/src/app/comet-cards/components/animations/ticking-number.tsx
@@ -1,0 +1,37 @@
+'use client'
+
+import { useEffect, useRef, useState } from 'react'
+
+export function TickingNumber({
+  value,
+  duration = 200,
+  format,
+}: {
+  value: number
+  duration?: number
+  format?: (n: number) => string
+}) {
+  const [display, setDisplay] = useState(value)
+  const prev = useRef(value)
+  const raf = useRef<number | undefined>(undefined)
+
+  useEffect(() => {
+    const from = prev.current
+    const to = value
+    prev.current = value
+
+    if (from === to) return
+
+    const start = performance.now()
+    const tick = (now: number) => {
+      const t = Math.min((now - start) / duration, 1)
+      const eased = 1 - (1 - t) * (1 - t) // ease-out quad
+      setDisplay(Math.round(from + (to - from) * eased))
+      if (t < 1) raf.current = requestAnimationFrame(tick)
+    }
+    raf.current = requestAnimationFrame(tick)
+    return () => { if (raf.current) cancelAnimationFrame(raf.current) }
+  }, [value, duration])
+
+  return <>{format ? format(display) : display.toLocaleString()}</>
+}

--- a/src/app/comet-cards/components/game-views/gameplay.tsx
+++ b/src/app/comet-cards/components/game-views/gameplay.tsx
@@ -13,6 +13,7 @@ import { Panel } from '@/app/comet-cards/components/cosmic/panel'
 import { Hand, type HandSortKey } from '@/app/comet-cards/components/gameplay/hand'
 import { Deck } from '@/app/comet-cards/components/global/deck'
 import { Hands } from '@/app/comet-cards/components/hands/hands'
+import { TickingNumber } from '@/app/comet-cards/components/animations/ticking-number'
 import { Modal } from '@/app/comet-cards/components/ui/modal'
 import { Vouchers } from '@/app/comet-cards/components/voucher/vouchers'
 import { getConsumableDefinition } from '@/app/comet-cards/domain/consumable/utils'
@@ -204,7 +205,7 @@ export function GamePlayView() {
                   marginRight: 4,
                 }}
               >
-                {score.chips || displayHandChips}
+                {score.chips > 0 ? <TickingNumber value={score.chips} /> : displayHandChips}
               </span>
               ×
               <span
@@ -216,7 +217,7 @@ export function GamePlayView() {
                   marginLeft: 4,
                 }}
               >
-                {score.mult || displayHandMult}
+                {score.mult > 0 ? <TickingNumber value={score.mult} /> : displayHandMult}
               </span>
             </span>
           </div>
@@ -484,7 +485,7 @@ export function GamePlayView() {
                       opacity: hasSelectedHand || score.chips > 0 ? 1 : 0.45,
                     }}
                   >
-                    {score.chips || displayHandChips}
+                    {score.chips > 0 ? <TickingNumber value={score.chips} /> : displayHandChips}
                   </span>
                   <span style={{ opacity: 0.4 }}>×</span>
                   <span
@@ -498,7 +499,7 @@ export function GamePlayView() {
                       opacity: hasSelectedHand || score.mult > 0 ? 1 : 0.45,
                     }}
                   >
-                    {score.mult || displayHandMult}
+                    {score.mult > 0 ? <TickingNumber value={score.mult} /> : displayHandMult}
                   </span>
                   <span
                     style={{
@@ -510,7 +511,7 @@ export function GamePlayView() {
                       visibility: score.chips > 0 || score.mult > 0 ? 'visible' : 'hidden',
                     }}
                   >
-                    = {(score.chips * score.mult).toLocaleString()}
+                    = <TickingNumber value={score.chips * score.mult} />
                   </span>
                 </div>
                 <div


### PR DESCRIPTION
## Summary
- Score values (chips, mult, total) now animate with a counting/ticking effect during scoring instead of jumping instantly
- Uses requestAnimationFrame with ease-out quadratic easing for smooth 200ms transitions
- Applied to both desktop panel and mobile/landscape score displays
- Partial implementation of #1410

## Changes
- New file: `src/app/comet-cards/components/animations/ticking-number.tsx` — reusable `TickingNumber` component with configurable duration and optional format function
- Updated `src/app/comet-cards/components/game-views/gameplay.tsx` — replaced static chip, mult, and total displays with `TickingNumber` in both the main panel and mobile layout

## Test plan
- [ ] Play a hand and observe chips/mult/total animate smoothly when scoring runs
- [ ] Confirm that before scoring (no chips/mult), the display shows the hand's base values (no animation applied)
- [ ] Verify mobile/landscape layout also shows animated values
- [ ] Check no regressions in other score display areas

🤖 Generated with [Claude Code](https://claude.com/claude-code)