### PR TITLE
feat: animated money display with tick and flash (#1410)

### DIFF
--- a/src/app/comet-cards/components/animations/animated-money.tsx
+++ b/src/app/comet-cards/components/animations/animated-money.tsx
@@ -1,0 +1,35 @@
+'use client'
+
+import { useEffect, useRef, useState } from 'react'
+import { TickingNumber } from './ticking-number'
+
+export function AnimatedMoney({ value }: { value: number }) {
+  const prev = useRef(value)
+  const [flash, setFlash] = useState<'gain' | 'loss' | null>(null)
+
+  useEffect(() => {
+    if (value !== prev.current) {
+      setFlash(value > prev.current ? 'gain' : 'loss')
+      prev.current = value
+      const timer = setTimeout(() => setFlash(null), 600)
+      return () => clearTimeout(timer)
+    }
+  }, [value])
+
+  const color = flash === 'gain'
+    ? 'var(--cc-mint)'
+    : flash === 'loss'
+    ? 'var(--cc-pink)'
+    : 'var(--cc-gold)'
+
+  return (
+    <span
+      style={{
+        color,
+        transition: 'color 0.3s',
+      }}
+    >
+      $<TickingNumber value={value} duration={300} />
+    </span>
+  )
+}

--- a/src/app/comet-cards/components/animations/ticking-number.tsx
+++ b/src/app/comet-cards/components/animations/ticking-number.tsx
@@ -1,0 +1,53 @@
+'use client'
+
+import { useEffect, useRef, useState } from 'react'
+
+export function TickingNumber({
+  value,
+  duration = 300,
+}: {
+  value: number
+  duration?: number
+}) {
+  const [displayed, setDisplayed] = useState(value)
+  const startRef = useRef(value)
+  const endRef = useRef(value)
+  const startTimeRef = useRef<number | null>(null)
+  const rafRef = useRef<number | null>(null)
+
+  useEffect(() => {
+    if (value === endRef.current) return
+
+    startRef.current = displayed
+    endRef.current = value
+    startTimeRef.current = null
+
+    if (rafRef.current !== null) {
+      cancelAnimationFrame(rafRef.current)
+    }
+
+    function tick(now: number) {
+      if (startTimeRef.current === null) {
+        startTimeRef.current = now
+      }
+      const elapsed = now - startTimeRef.current
+      const progress = Math.min(elapsed / duration, 1)
+      const current = Math.round(startRef.current + (endRef.current - startRef.current) * progress)
+      setDisplayed(current)
+      if (progress < 1) {
+        rafRef.current = requestAnimationFrame(tick)
+      }
+    }
+
+    rafRef.current = requestAnimationFrame(tick)
+
+    return () => {
+      if (rafRef.current !== null) {
+        cancelAnimationFrame(rafRef.current)
+      }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [value, duration])
+
+  return <>{displayed}</>
+}

--- a/src/app/comet-cards/components/game-views/view-template.tsx
+++ b/src/app/comet-cards/components/game-views/view-template.tsx
@@ -10,6 +10,7 @@ import { Vouchers } from '@/app/comet-cards/components/voucher/vouchers'
 import { calculateAnte, getBlindDefinition } from '@/app/comet-cards/domain/game/utils'
 import { getInProgressBlind } from '@/app/comet-cards/domain/round/blinds'
 import { implementedTags as tags } from '@/app/comet-cards/domain/tag/tags'
+import { AnimatedMoney } from '@/app/comet-cards/components/animations/animated-money'
 import { useGameState } from '@/app/comet-cards/useGameState'
 import { useLandscapeMobile } from '@/app/comet-cards/hooks/useLandscapeMobile'
 
@@ -99,7 +100,12 @@ export function ViewTemplate({
           }}
         >
           <Stat label="Round" value={`${game.roundIndex + 1}/${game.rounds.length}`} />
-          <Stat label="Money" value={`$${game.money}`} accent="var(--cc-gold)" />
+          <div className="flex flex-col" style={{ gap: 2 }}>
+            <div style={{ opacity: 0.45, fontSize: 10 }}>Money</div>
+            <div style={{ fontWeight: 600, fontSize: 13 }}>
+              <AnimatedMoney value={game.money} />
+            </div>
+          </div>
           <Stat label="Hands" value={String(game.handsPlayed)} />
         </div>
       </div>


### PR DESCRIPTION
## Summary

Money in the top stat bar now ticks up/down when it changes and briefly flashes green (gain) or red (loss). Uses the TickingNumber component for smooth counting. Partial implementation of #1410.

- New `TickingNumber` component: smoothly counts from old value to new value using `requestAnimationFrame`
- New `AnimatedMoney` component: wraps `TickingNumber` with a color flash (mint = gain, pink = loss, gold = neutral)
- `ViewTemplate` top bar now uses `AnimatedMoney` instead of a static `$${game.money}` string

## Test plan

- [ ] Play a hand and verify the money value counts up/down smoothly when it changes
- [ ] Verify the stat briefly turns green on a money gain, red on a loss, then returns to gold
- [ ] Verify the Round and Hands stats in the top bar are unaffected
- [ ] Verify sidebar Run Stats money row is unchanged (static display as designed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)