### PR TITLE
feat: add state display badges for stateful Jokers

### DIFF
--- a/src/app/comet-cards/components/gameplay/joker.tsx
+++ b/src/app/comet-cards/components/gameplay/joker.tsx
@@ -10,6 +10,15 @@ const RARITY_ACCENT: Record<string, string> = {
   legendary: 'var(--cc-gold)',
 }
 
+const COUNTER_XMULT_DIVISOR: Record<string, number> = {
+  vampire: 10,
+  hitTheRoad: 2,
+  campfire: 4,
+  obelisk: 5,
+  luckyCat: 4,
+  ramen: 100,
+}
+
 export const Joker = ({
   joker,
   isSelected,
@@ -26,6 +35,8 @@ export const Joker = ({
   const handSizeBonus = joker.metadata?.handSizeBonus as number | undefined
   const xMult = joker.metadata?.xMult as number | undefined
   const payout = joker.metadata?.payout as number | undefined
+
+  const xMultDivisor = COUNTER_XMULT_DIVISOR[joker.jokerId]
 
   let badge: ReactNode = undefined
   if (multBonus != null && multBonus > 0) {
@@ -56,6 +67,33 @@ export const Joker = ({
     badge = (
       <span style={{ fontSize: 11, fontWeight: 700, color: 'var(--cc-gold)' }}>
         ${payout}
+      </span>
+    )
+  } else if (xMultDivisor != null && joker.counter > 0) {
+    const computed = joker.counter / xMultDivisor
+    if (computed > 1) {
+      badge = (
+        <span style={{ fontSize: 11, fontWeight: 700, color: 'var(--cc-pink)' }}>
+          ×{computed % 1 === 0 ? computed.toString() : computed.toFixed(1)}
+        </span>
+      )
+    }
+  } else if (joker.jokerId === 'iceCream' && joker.counter > 0) {
+    badge = (
+      <span style={{ fontSize: 11, fontWeight: 700, color: 'var(--cc-mint)' }}>
+        +{joker.counter}
+      </span>
+    )
+  } else if (joker.jokerId === 'popcorn' && joker.counter > 0) {
+    badge = (
+      <span style={{ fontSize: 11, fontWeight: 700, color: 'var(--cc-pink)' }}>
+        +{joker.counter}
+      </span>
+    )
+  } else if (joker.jokerId === 'invisibleJoker') {
+    badge = (
+      <span style={{ fontSize: 11, fontWeight: 700, color: 'var(--cc-text-default)', opacity: 0.7 }}>
+        {joker.counter}/2
       </span>
     )
   } else if (joker.counter > 0) {

--- a/src/app/comet-cards/components/gameplay/joker.tsx
+++ b/src/app/comet-cards/components/gameplay/joker.tsx
@@ -25,6 +25,12 @@ const IDOL_SUIT_COLORS: Record<string, string> = { '\u2665': 'var(--cc-pink)', '
 
 const TRIGGERED_JOKERS = new Set(['photograph', 'hangingChad', 'burntJoker', 'tradingCard'])
 
+const POKER_HAND_LABELS = [
+  'High Card', 'Pair', 'Two Pair', '3 of a Kind', 'Straight',
+  'Flush', 'Full House', '4 of a Kind', 'Str. Flush', 'Flush House',
+  '5 of a Kind', 'Flush Five',
+] as const
+
 export const Joker = ({
   joker,
   isSelected,
@@ -117,6 +123,13 @@ export const Joker = ({
     badge = (
       <span style={{ fontSize: 11, fontWeight: 700, color: suitColor }}>
         {value}{suit}
+      </span>
+    )
+  } else if (joker.jokerId === 'toDoList') {
+    const handLabel = POKER_HAND_LABELS[joker.counter] ?? '?'
+    badge = (
+      <span style={{ fontSize: 10, fontWeight: 700, color: 'var(--cc-gold)' }}>
+        {handLabel}
       </span>
     )
   } else if (joker.jokerId === 'vagabond') {

--- a/src/app/comet-cards/components/gameplay/joker.tsx
+++ b/src/app/comet-cards/components/gameplay/joker.tsx
@@ -35,10 +35,12 @@ export const Joker = ({
   joker,
   isSelected,
   onClick,
+  ownedCardCount,
 }: {
   joker: JokerState
   isSelected?: boolean
   onClick?: (isSelected: boolean, id: string) => void
+  ownedCardCount?: number
 }) => {
   const def = jokers[joker.jokerId]
   const accent = RARITY_ACCENT[def?.rarity ?? 'common'] ?? 'var(--cc-mint)'
@@ -146,6 +148,18 @@ export const Joker = ({
     ) : (
       <span style={{ fontSize: 11, fontWeight: 700, color: 'var(--cc-text-default)', opacity: 0.5 }}>
         ○
+      </span>
+    )
+  } else if (joker.jokerId === 'hologram' && ownedCardCount != null && joker.counter > 0) {
+    const cardsAdded = Math.max(0, ownedCardCount - joker.counter)
+    const holoXMult = 1 + cardsAdded * 0.25
+    badge = holoXMult > 1 ? (
+      <span style={{ fontSize: 11, fontWeight: 700, color: 'var(--cc-pink)' }}>
+        ×{holoXMult % 1 === 0 ? holoXMult.toString() : holoXMult.toFixed(2)}
+      </span>
+    ) : (
+      <span style={{ fontSize: 11, fontWeight: 700, color: 'var(--cc-text-default)', opacity: 0.7 }}>
+        ×1
       </span>
     )
   } else if (joker.jokerId === 'invisibleJoker') {

--- a/src/app/comet-cards/components/gameplay/joker.tsx
+++ b/src/app/comet-cards/components/gameplay/joker.tsx
@@ -19,6 +19,12 @@ const COUNTER_XMULT_DIVISOR: Record<string, number> = {
   ramen: 100,
 }
 
+const IDOL_VALUES = ['2','3','4','5','6','7','8','9','10','J','Q','K','A'] as const
+const IDOL_SUITS = ['\u2665','\u2666','\u2663','\u2660'] as const
+const IDOL_SUIT_COLORS: Record<string, string> = { '\u2665': 'var(--cc-pink)', '\u2666': 'var(--cc-pink)', '\u2663': 'var(--cc-text-default)', '\u2660': 'var(--cc-text-default)' }
+
+const TRIGGERED_JOKERS = new Set(['photograph', 'hangingChad', 'burntJoker', 'tradingCard'])
+
 export const Joker = ({
   joker,
   isSelected,
@@ -57,6 +63,18 @@ export const Joker = ({
         +{handSizeBonus}
       </span>
     )
+  } else if (joker.jokerId === 'yorick') {
+    const yXMult = (xMult ?? 100) / 100
+    const countdown = joker.counter || 23
+    badge = yXMult > 1 ? (
+      <span style={{ fontSize: 11, fontWeight: 700, color: 'var(--cc-pink)' }}>
+        ×{yXMult % 1 === 0 ? yXMult.toString() : yXMult.toFixed(1)} <span style={{ opacity: 0.7 }}>⌛{countdown}</span>
+      </span>
+    ) : (
+      <span style={{ fontSize: 11, fontWeight: 700, color: 'var(--cc-text-default)', opacity: 0.7 }}>
+        ⌛{countdown}
+      </span>
+    )
   } else if (xMult != null && xMult > 100) {
     badge = (
       <span style={{ fontSize: 11, fontWeight: 700, color: 'var(--cc-pink)' }}>
@@ -88,6 +106,33 @@ export const Joker = ({
     badge = (
       <span style={{ fontSize: 11, fontWeight: 700, color: 'var(--cc-pink)' }}>
         +{joker.counter}
+      </span>
+    )
+  } else if (joker.jokerId === 'theIdol') {
+    const valueIdx = Math.floor(joker.counter / 4)
+    const suitIdx = joker.counter % 4
+    const value = IDOL_VALUES[valueIdx] ?? '?'
+    const suit = IDOL_SUITS[suitIdx] ?? '?'
+    const suitColor = IDOL_SUIT_COLORS[suit] ?? 'var(--cc-text-default)'
+    badge = (
+      <span style={{ fontSize: 11, fontWeight: 700, color: suitColor }}>
+        {value}{suit}
+      </span>
+    )
+  } else if (joker.jokerId === 'vagabond') {
+    badge = (
+      <span style={{ fontSize: 11, fontWeight: 700, color: 'var(--cc-gold)' }}>
+        ≤$4
+      </span>
+    )
+  } else if (TRIGGERED_JOKERS.has(joker.jokerId)) {
+    badge = joker.counter === 1 ? (
+      <span style={{ fontSize: 11, fontWeight: 700, color: 'var(--cc-mint)', opacity: 0.7 }}>
+        ✓
+      </span>
+    ) : (
+      <span style={{ fontSize: 11, fontWeight: 700, color: 'var(--cc-text-default)', opacity: 0.5 }}>
+        ○
       </span>
     )
   } else if (joker.jokerId === 'invisibleJoker') {

--- a/src/app/comet-cards/components/joker/current-jokers.tsx
+++ b/src/app/comet-cards/components/joker/current-jokers.tsx
@@ -17,6 +17,7 @@ export const CurrentJokers = () => {
             key={joker.id}
             joker={joker}
             isSelected={game.gamePlayState.selectedJokerId === joker.id}
+            ownedCardCount={game.ownedCardIds.length}
             onClick={(isSelected, id) => {
               if (isSelected) {
                 eventEmitter.emit({ type: 'JOKER_DESELECTED', id })


### PR DESCRIPTION
## Summary
- Show computed X mult values for counter-based Jokers (Vampire, Hit the Road, Campfire, Obelisk, Lucky Cat, Ramen) as pink `×N` badges instead of raw counter numbers
- Add specific badge displays for Ice Cream (mint `+N` remaining chips), Popcorn (pink `+N` remaining mult), and Invisible Joker (gray `N/2` copy progress)
- Yorick shows both X mult and countdown (`×2 ⌛15`)
- The Idol decodes and shows target card (e.g. `K♥` with suit-colored text)
- To Do List shows target hand type (e.g. `Full House`) in gold
- Hologram computes and shows X mult from cards added to deck (passes `ownedCardCount` prop)
- Triggered jokers (Photograph, Hanging Chad, Burnt Joker, Trading Card) show `✓`/`○` ready/used indicator
- Vagabond shows static `≤$4` threshold reminder
- Existing metadata-based displays (Glass Joker, Canio X mult; Rocket payout) already work correctly
- Generic counter fallback continues to serve Seltzer, Loyalty Card, and other countdown jokers

## Test plan
- [ ] Verify Vampire badge shows `×1.5` after scoring 5 enhanced cards
- [ ] Verify Campfire badge shows `×2` after selling 4 cards
- [ ] Verify Ice Cream shows mint `+100` initially, decreasing by 5 each hand
- [ ] Verify Popcorn shows pink `+20` initially, decreasing by 4 each round
- [ ] Verify Invisible Joker shows `0/2`, `1/2`, `2/2` progression
- [ ] Verify Yorick shows countdown and X mult when accumulated
- [ ] Verify The Idol shows target card like `K♥` with correct color
- [ ] Verify To Do List shows target hand type in gold
- [ ] Verify Hologram shows `×1` initially, increasing as cards are added
- [ ] Verify triggered jokers show `○` when ready, `✓` when used
- [ ] Verify Vagabond shows `≤$4` badge
- [ ] Verify Glass Joker (metadata.xMult) still shows correctly
- [ ] Verify generic counter fallback still works for other jokers

Closes #1451, closes #1452, closes #1453, closes #1454, closes #1455, closes #1456, closes #1457, closes #1458, closes #1459, closes #1460, closes #1461, closes #1462, closes #1463, closes #1464, closes #1465, closes #1466, closes #1467, closes #1468, closes #1469, closes #1470

🤖 Generated with [Claude Code](https://claude.com/claude-code)