### PR TITLE
feat: add state displays for remaining stateful Jokers (batch 2)

### DIFF
--- a/src/app/comet-cards/components/gameplay/joker.tsx
+++ b/src/app/comet-cards/components/gameplay/joker.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from 'react'
 import { TokenCard } from '@/app/comet-cards/components/cosmic/token-card'
 import { jokers } from '@/app/comet-cards/domain/joker/jokers'
 import type { JokerState } from '@/app/comet-cards/domain/joker/types'
+import { buildSeedString, getRandomNumbersWithSeed } from '@/app/comet-cards/domain/randomness'
 
 const RARITY_ACCENT: Record<string, string> = {
   common: 'var(--cc-mint)',
@@ -37,16 +38,22 @@ const POKER_HAND_LABELS = [
   '5 of a Kind', 'Flush Five',
 ] as const
 
+const CASTLE_SUITS = ['\u2665', '\u2666', '\u2663', '\u2660'] as const
+
 export const Joker = ({
   joker,
   isSelected,
   onClick,
   ownedCardCount,
+  gameSeed,
+  roundIndex,
 }: {
   joker: JokerState
   isSelected?: boolean
   onClick?: (isSelected: boolean, id: string) => void
   ownedCardCount?: number
+  gameSeed?: string
+  roundIndex?: number
 }) => {
   const def = jokers[joker.jokerId]
   const accent = RARITY_ACCENT[def?.rarity ?? 'common'] ?? 'var(--cc-mint)'
@@ -120,6 +127,16 @@ export const Joker = ({
     badge = (
       <span style={{ fontSize: 11, fontWeight: 700, color: 'var(--cc-pink)' }}>
         +{joker.counter}
+      </span>
+    )
+  } else if (joker.jokerId === 'castle' && gameSeed != null && roundIndex != null) {
+    const seed = buildSeedString([gameSeed, roundIndex.toString(), 'castle', 'suit'])
+    const roll = getRandomNumbersWithSeed({ seed, min: 0, max: 3, numberOfNumbers: 1 })
+    const castleSuit = CASTLE_SUITS[roll[0]] ?? '?'
+    const suitColor = IDOL_SUIT_COLORS[castleSuit] ?? 'var(--cc-text-default)'
+    badge = (
+      <span style={{ fontSize: 11, fontWeight: 700, color: suitColor }}>
+        {castleSuit}{joker.counter > 0 ? ` +${joker.counter}` : ''}
       </span>
     )
   } else if (joker.jokerId === 'theIdol') {

--- a/src/app/comet-cards/components/gameplay/joker.tsx
+++ b/src/app/comet-cards/components/gameplay/joker.tsx
@@ -17,7 +17,13 @@ const COUNTER_XMULT_DIVISOR: Record<string, number> = {
   obelisk: 5,
   luckyCat: 4,
   ramen: 100,
+  madness: 2,
+  throwback: 4,
+  constellation: 10,
 }
+
+const COUNTER_CHIPS_JOKERS = new Set(['runner', 'squareJoker', 'iceCream'])
+const COUNTER_MULT_JOKERS = new Set(['greenJoker', 'redCard', 'rideTheBus', 'ceremonialDagger', 'popcorn'])
 
 const IDOL_VALUES = ['2','3','4','5','6','7','8','9','10','J','Q','K','A'] as const
 const IDOL_SUITS = ['\u2665','\u2666','\u2663','\u2660'] as const
@@ -104,13 +110,13 @@ export const Joker = ({
         </span>
       )
     }
-  } else if (joker.jokerId === 'iceCream' && joker.counter > 0) {
+  } else if (COUNTER_CHIPS_JOKERS.has(joker.jokerId) && joker.counter > 0) {
     badge = (
       <span style={{ fontSize: 11, fontWeight: 700, color: 'var(--cc-mint)' }}>
         +{joker.counter}
       </span>
     )
-  } else if (joker.jokerId === 'popcorn' && joker.counter > 0) {
+  } else if (COUNTER_MULT_JOKERS.has(joker.jokerId) && joker.counter > 0) {
     badge = (
       <span style={{ fontSize: 11, fontWeight: 700, color: 'var(--cc-pink)' }}>
         +{joker.counter}

--- a/src/app/comet-cards/components/joker/current-jokers.tsx
+++ b/src/app/comet-cards/components/joker/current-jokers.tsx
@@ -18,6 +18,8 @@ export const CurrentJokers = () => {
             joker={joker}
             isSelected={game.gamePlayState.selectedJokerId === joker.id}
             ownedCardCount={game.ownedCardIds.length}
+            gameSeed={game.gameSeed}
+            roundIndex={game.roundIndex}
             onClick={(isSelected, id) => {
               if (isSelected) {
                 eventEmitter.emit({ type: 'JOKER_DESELECTED', id })


### PR DESCRIPTION
## Summary
- Add X mult divisors for **Madness** (/2), **Throwback** (/4), **Constellation** (/10) — shows pink `×N` badge
- Add colored chip badges for **Runner** and **Square Joker** — shows mint `+N`
- Add colored mult badges for **Green Joker**, **Red Card**, **Ride the Bus**, **Ceremonial Dagger** — shows pink `+N`
- Add **Castle** suit display — shows current target suit symbol (♥♦♣♠) with accumulated chips
- Consolidate iceCream/popcorn into set-based lookups (same behavior, cleaner code)
- Closed **Flash Card** (#1439), **Wee Joker** (#1446), **Cartomancer** (#1447), **Spare Trousers** (#1438), **Turtle Bean** (#1437) — already working or stateless

## Test plan
- [ ] Verify Madness shows `×2` after accumulating
- [ ] Verify Throwback shows `×2` after skipping 4 blinds
- [ ] Verify Constellation shows `×1.5` after using 5 planet cards
- [ ] Verify Runner shows mint `+15` after a straight
- [ ] Verify Green Joker shows pink `+N` for accumulated mult
- [ ] Verify Castle shows suit symbol (e.g. `♥ +6`) with correct color
- [ ] Verify existing iceCream/popcorn badges still work correctly

Closes #1436, closes #1440, closes #1441, closes #1442, closes #1443, closes #1444, closes #1445, closes #1448, closes #1449, closes #1450

🤖 Generated with [Claude Code](https://claude.com/claude-code)