### PR TITLE
feat: staggered entrance animation for shop voucher and booster packs

### DIFF
--- a/src/app/comet-cards/components/game-views/shop.tsx
+++ b/src/app/comet-cards/components/game-views/shop.tsx
@@ -132,7 +132,16 @@ export function ShopView() {
               <div className="flex flex-col" style={{ gap: 18 }}>
                 {game.shopState.voucher && (
                   <SectionHeader label="Voucher">
-                    <div className="flex flex-wrap items-center gap-3">
+                    <motion.div
+                      className="flex flex-wrap items-center gap-3"
+                      initial={{ opacity: 0, y: 20, scale: 0.9 }}
+                      animate={{ opacity: 1, y: 0, scale: 1 }}
+                      transition={{
+                        duration: 0.3,
+                        delay: 0.1,
+                        ease: [0.2, 0.9, 0.3, 1],
+                      }}
+                    >
                       <Voucher voucher={game.shopState.voucher} />
                       <PrimaryButton
                         disabled={!canAffordVoucher}
@@ -145,7 +154,7 @@ export function ShopView() {
                       >
                         Buy · ${VOUCHER_PRICE}
                       </PrimaryButton>
-                    </div>
+                    </motion.div>
                   </SectionHeader>
                 )}
 

--- a/src/app/comet-cards/components/shop/booster-packs.tsx
+++ b/src/app/comet-cards/components/shop/booster-packs.tsx
@@ -1,3 +1,7 @@
+'use client'
+
+import { motion } from 'framer-motion'
+
 import { PrimaryButton } from '@/app/comet-cards/components/cosmic/buttons'
 import { TokenCard } from '@/app/comet-cards/components/cosmic/token-card'
 import { getPackDefinition } from '@/app/comet-cards/domain/booster-pack/utils'
@@ -68,8 +72,19 @@ export function BoosterPacksForSale() {
   if (boosterPacks.length === 0) return null
   return (
     <div className="flex flex-wrap items-stretch gap-3">
-      {boosterPacks.map(pack => (
-        <BoosterPackForSale key={pack.id} pack={pack} />
+      {boosterPacks.map((pack, i) => (
+        <motion.div
+          key={pack.id}
+          initial={{ opacity: 0, y: 20, scale: 0.9 }}
+          animate={{ opacity: 1, y: 0, scale: 1 }}
+          transition={{
+            duration: 0.3,
+            delay: 0.15 + i * 0.08,
+            ease: [0.2, 0.9, 0.3, 1],
+          }}
+        >
+          <BoosterPackForSale pack={pack} />
+        </motion.div>
       ))}
     </div>
   )


### PR DESCRIPTION
## Summary
- Add staggered fade-up entrance animation to **booster packs** (0.15s base delay + 80ms per pack)
- Add matching entrance animation to the **voucher** section (0.1s delay)
- Uses the same cosmic easing `[0.2, 0.9, 0.3, 1]` and pattern established by the existing cards-for-sale stagger
- Base delays offset so right column animates slightly after left column cards

## Test plan
- [ ] Enter shop — booster packs should cascade in with staggered timing
- [ ] Voucher should fade up smoothly when shop opens
- [ ] Cards for sale animation still works correctly
- [ ] Reroll should re-trigger card entrance animation (existing behavior)
- [ ] Mobile layout still looks correct

Closes #1476

🤖 Generated with [Claude Code](https://claude.com/claude-code)