### PR TITLE
feat: add prefers-reduced-motion accessibility support

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -230,6 +230,22 @@ body {
 }
 
 /* ───────────────────────────────────────────────────────────────────
+   Reduced motion — disable CSS animations and transitions for users
+   who prefer reduced motion. Framer Motion handles this automatically.
+   ─────────────────────────────────────────────────────────────────── */
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}
+
+/* ───────────────────────────────────────────────────────────────────
    Cosmic Cards palette — scoped to .cosmic-cards (daily card game)
    Hand-crafted, surreal, cosmic. Mint accent + cosmic-glowing suits.
    ─────────────────────────────────────────────────────────────────── */


### PR DESCRIPTION
## Summary
- Add global `@media (prefers-reduced-motion: reduce)` rule in `globals.css`
- Effectively disables all CSS animations, transitions, and scroll behavior for users who have reduced motion enabled in their OS settings
- Framer Motion (used in Comet Cards) automatically respects this preference via built-in detection — no component changes needed
- Covers all custom Tailwind keyframes (`float-up`, `combo-pulse`, `crit-flash`, `particle-burst`) and `.chunky-*` transitions

## Test plan
- [ ] Enable "Reduce motion" in OS accessibility settings
- [ ] Verify CSS animations (card dealing stagger, score display) are instant
- [ ] Verify Framer Motion animations are reduced/instant
- [ ] Verify `.chunky-*` press transitions are still functional (just instant)
- [ ] Disable "Reduce motion" — verify all animations work normally

## Priority
HIGH — per CLAUDE.md principle #8: "assume reduced-motion and silent device as the baseline experience"

Closes #1480

🤖 Generated with [Claude Code](https://claude.com/claude-code)