### PR TITLE
feat: animate blind score and total score with ticking counter

### DIFF
--- a/src/app/comet-cards/components/game-views/gameplay.tsx
+++ b/src/app/comet-cards/components/game-views/gameplay.tsx
@@ -237,7 +237,7 @@ export function GamePlayView() {
                   transform: isScoring ? 'scale(1.04)' : 'scale(1)',
                 }}
               >
-                {currentBlind.score.toString()}
+                <TickingNumber value={Number(currentBlind.score)} duration={400} />
               </div>
             )}
           </div>
@@ -617,7 +617,7 @@ export function GamePlayView() {
                       transform: isScoring ? 'scale(1.04)' : 'scale(1)',
                     }}
                   >
-                    {currentBlind.score.toString()}
+                    <TickingNumber value={Number(currentBlind.score)} duration={400} />
                     <span
                       style={{
                         fontSize: 20,
@@ -642,7 +642,7 @@ export function GamePlayView() {
                 }}
               >
                 <span>Total</span>
-                <span style={{ marginLeft: 6 }}>{totalScore.toString()}</span>
+                <span style={{ marginLeft: 6 }}><TickingNumber value={Number(totalScore)} duration={400} /></span>
               </div>
             </div>
 


### PR DESCRIPTION
## Summary
- Replace static `currentBlind.score.toString()` with `<TickingNumber>` on both mobile and desktop score displays
- Replace static `totalScore.toString()` with `<TickingNumber>`
- 400ms ease-out quad animation — smooth count-up when score changes
- Uses existing `TickingNumber` component (already used for chips/mult)

## Test plan
- [ ] Play a hand — blind score should tick up smoothly over 400ms
- [ ] Verify total score also ticks up
- [ ] Verify the scale pulse during scoring still works alongside the tick
- [ ] Verify mobile layout score display ticks correctly
- [ ] Verify desktop sidebar score display ticks correctly

Closes #1479

🤖 Generated with [Claude Code](https://claude.com/claude-code)