### PR TITLE
feat: smooth fade transitions between game phases

### DIFF
--- a/src/app/comet-cards/page.tsx
+++ b/src/app/comet-cards/page.tsx
@@ -1,4 +1,5 @@
 'use client'
+import { AnimatePresence, motion } from 'framer-motion'
 import { CosmicShell } from './components/cosmic/shell'
 import { BlindRewardsView } from './components/game-views/blind-rewards'
 import { BlindSelectionView } from './components/game-views/blind-selection'
@@ -17,48 +18,76 @@ import { VouchersView } from './components/game-views/vouchers'
 import { useGameEvents } from './useGameEvents'
 import { useGameState } from './useGameState'
 
-function PhaseRouter() {
+const phaseVariants = {
+  initial: { opacity: 0 },
+  animate: { opacity: 1 },
+  exit: { opacity: 0 },
+}
+
+const phaseTransition = {
+  duration: 0.15,
+  ease: [0.2, 0.9, 0.3, 1] as const,
+}
+
+function PhaseView() {
   const { game } = useGameState()
 
+  let view: React.ReactNode
   switch (game.gamePhase) {
     case 'mainMenu':
-      return <MainMenuView />
+      view = <MainMenuView />; break
     case 'shop':
-      return <ShopView />
+      view = <ShopView />; break
     case 'blindSelection':
-      return <BlindSelectionView />
+      view = <BlindSelectionView />; break
     case 'gameplay':
-      return <GamePlayView />
+      view = <GamePlayView />; break
     case 'packOpening':
-      return <PackOpenView />
+      view = <PackOpenView />; break
     case 'gameOver':
-      return <GameOverView />
+      view = <GameOverView />; break
     case 'blindRewards':
-      return <BlindRewardsView />
+      view = <BlindRewardsView />; break
     case 'jokers':
-      return <JokersView />
+      view = <JokersView />; break
     case 'vouchers':
-      return <VouchersView />
+      view = <VouchersView />; break
     case 'tarotCards':
-      return <TarotCardsView />
+      view = <TarotCardsView />; break
     case 'celestialCards':
-      return <CelestialsView />
+      view = <CelestialsView />; break
     case 'bossBlinds':
-      return <BossBlindsView />
+      view = <BossBlindsView />; break
     case 'spectralCards':
-      return <SpectralCardsView />
+      view = <SpectralCardsView />; break
     case 'tags':
-      return <TagsView />
+      view = <TagsView />; break
     default:
-      return <div>Error: Unknown game phase {game.gamePhase}</div>
+      view = <div>Error: Unknown game phase {game.gamePhase}</div>
   }
+
+  return (
+    <AnimatePresence mode="wait">
+      <motion.div
+        key={game.gamePhase}
+        variants={phaseVariants}
+        initial="initial"
+        animate="animate"
+        exit="exit"
+        transition={phaseTransition}
+        style={{ width: '100%', height: '100%' }}
+      >
+        {view}
+      </motion.div>
+    </AnimatePresence>
+  )
 }
 
 export default function CometCardsPage() {
   useGameEvents()
   return (
     <CosmicShell>
-      <PhaseRouter />
+      <PhaseView />
     </CosmicShell>
   )
 }


### PR DESCRIPTION
## Summary
- Wrap the `PhaseRouter` in Framer Motion `AnimatePresence` with `mode="wait"`
- Each phase change triggers a 150ms fade-out → 150ms fade-in transition
- Uses the cosmic easing curve `[0.2, 0.9, 0.3, 1]`
- Covers all phase transitions: mainMenu → blindSelection → gameplay → shop → packOpening → blindRewards → gameOver, etc.

## Test plan
- [ ] Transition from blind selection to gameplay — should fade smoothly
- [ ] Transition from gameplay to shop — should fade smoothly
- [ ] Transition from shop back to blind selection — should fade smoothly
- [ ] Pack opening and closing — should fade smoothly
- [ ] Game over transition — should fade smoothly
- [ ] Verify no layout shift during transitions (width/height: 100%)
- [ ] Verify prefers-reduced-motion users get instant transitions

Closes #1473

🤖 Generated with [Claude Code](https://claude.com/claude-code)