### PR TITLE
fix: show joker state badges in gameplay view, not just shop

### DIFF
--- a/src/app/comet-cards/components/game-views/gameplay.tsx
+++ b/src/app/comet-cards/components/game-views/gameplay.tsx
@@ -11,6 +11,7 @@ import {
 import { EmptySlot, ItemRow } from '@/app/comet-cards/components/cosmic/item-row'
 import { Panel } from '@/app/comet-cards/components/cosmic/panel'
 import { Hand, type HandSortKey } from '@/app/comet-cards/components/gameplay/hand'
+import { Joker } from '@/app/comet-cards/components/gameplay/joker'
 import { Deck } from '@/app/comet-cards/components/global/deck'
 import { Hands } from '@/app/comet-cards/components/hands/hands'
 import { TickingNumber } from '@/app/comet-cards/components/animations/ticking-number'
@@ -707,27 +708,24 @@ export function GamePlayView() {
           {/* RIGHT rail */}
           <div className="flex flex-col gap-4">
             <Panel title="Jokers" subtitle={`${game.jokers.length} / ${game.maxJokers} slots`}>
-              <div style={{ padding: 14, display: 'flex', flexDirection: 'column', gap: 10 }}>
-                {game.jokers.map(joker => {
-                  const def = jokerDefinitions[joker.jokerId]
-                  return (
-                    <ItemRow
-                      key={joker.id}
-                      name={def.name}
-                      description={def.description}
-                      accent={RARITY_ACCENT[def.rarity] ?? 'var(--cc-mint)'}
-                      glyph="✺"
-                      selected={gamePlayState.selectedJokerId === joker.id}
-                      onClick={() => {
-                        if (gamePlayState.selectedJokerId === joker.id) {
-                          eventEmitter.emit({ type: 'JOKER_DESELECTED', id: joker.id })
-                        } else {
-                          eventEmitter.emit({ type: 'JOKER_SELECTED', id: joker.id })
-                        }
-                      }}
-                    />
-                  )
-                })}
+              <div style={{ padding: 14, display: 'flex', flexWrap: 'wrap', gap: 10 }}>
+                {game.jokers.map(joker => (
+                  <Joker
+                    key={joker.id}
+                    joker={joker}
+                    isSelected={gamePlayState.selectedJokerId === joker.id}
+                    ownedCardCount={game.ownedCardIds.length}
+                    gameSeed={game.gameSeed}
+                    roundIndex={game.roundIndex}
+                    onClick={(isSelected, id) => {
+                      if (isSelected) {
+                        eventEmitter.emit({ type: 'JOKER_DESELECTED', id })
+                      } else {
+                        eventEmitter.emit({ type: 'JOKER_SELECTED', id })
+                      }
+                    }}
+                  />
+                ))}
                 {Array.from({ length: Math.max(0, game.maxJokers - game.jokers.length) }).map(
                   (_, i) => (
                     <EmptySlot key={`joker-empty-${i}`} />


### PR DESCRIPTION
## Summary
- Replace `ItemRow` rendering of jokers in the desktop gameplay sidebar with the `Joker` component
- The `Joker` component includes state display badges (X mult, chips, countdown, etc.)
- Passes `ownedCardCount`, `gameSeed`, and `roundIndex` props for full state display
- State badges now visible during gameplay where they matter most for decision-making

## Test plan
- [ ] During gameplay, joker cards in the sidebar should show state badges (e.g. Vampire shows `×1.5`)
- [ ] Joker selection/deselection still works
- [ ] Selling jokers still works when selected
- [ ] Empty slots still render correctly
- [ ] Badge values update live during scoring

Closes #1486

🤖 Generated with [Claude Code](https://claude.com/claude-code)