### PR TITLE
fix: shop empty after first visit — reset isOpen on blind complete

### DIFF
--- a/src/app/comet-cards/domain/game/handlers/gameplay.ts
+++ b/src/app/comet-cards/domain/game/handlers/gameplay.ts
@@ -366,6 +366,7 @@ export function handleHandScoringDoneCardScoring(draft: GameState) {
   draft.gamePlayState.handTypesPlayedThisRound = []
 
   // Reset shop state for the new shop session
+  draft.shopState.isOpen = false
   draft.shopState.cardsForSale = []
   draft.shopState.freeRerolls = 0
   draft.shopState.packsForSale = []


### PR DESCRIPTION
## Summary
**Root cause:** `handleHandScoringDoneCardScoring` in `gameplay.ts` resets shop inventory (`cardsForSale = []`, `packsForSale = []`) when transitioning to the shop phase after completing a blind, but was **not resetting `shopState.isOpen` to `false`**.

This meant the `ShopView` `useEffect` condition (`!game.shopState.isOpen`) was never `true` on subsequent shop visits, so `SHOP_OPEN` was never emitted and shop inventory was never regenerated.

**Fix:** Add `draft.shopState.isOpen = false` to the shop state reset block (1 line).

## Test plan
- [ ] Complete small blind → enter shop → cards and packs should appear
- [ ] Complete big blind → enter shop → cards and packs should appear
- [ ] Complete boss blind → enter shop → cards and packs should appear
- [ ] Open a booster pack → return to shop → remaining items still visible
- [ ] Reroll in shop → new cards should appear
- [ ] First shop visit still works correctly

Closes #1487

🤖 Generated with [Claude Code](https://claude.com/claude-code)