### PR TITLE
feat: shimmer/holographic animations for card editions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "cometcave.com",
       "version": "0.1.0",
       "dependencies": {
+        "@ai-sdk/anthropic": "^1.2.12",
         "@ai-sdk/openai": "latest",
         "@emotion/cache": "^11.14.0",
         "@emotion/is-prop-valid": "latest",
@@ -18,6 +19,7 @@
         "@hookform/resolvers": "^3.9.1",
         "@mui/icons-material": "^7.0.2",
         "@mui/material": "^7.0.2",
+        "@perplexity-ai/perplexity_ai": "^0.27.0",
         "@pixi/react": "^8.0.0-beta.25",
         "@radix-ui/react-accordion": "1.2.2",
         "@radix-ui/react-alert-dialog": "1.1.4",
@@ -107,6 +109,22 @@
         "tsx": "^4.19.2",
         "typescript": "^5",
         "vitest": "^3.1.2"
+      }
+    },
+    "node_modules/@ai-sdk/anthropic": {
+      "version": "1.2.12",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/anthropic/-/anthropic-1.2.12.tgz",
+      "integrity": "sha512-YSzjlko7JvuiyQFmI9RN1tNZdEiZxc+6xld/0tq/VkJaHpEzGAb1yiNxxvmYVcjvfu/PcvCxAAYXmTYQQ63IHQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "1.1.3",
+        "@ai-sdk/provider-utils": "2.2.8"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.0.0"
       }
     },
     "node_modules/@ai-sdk/openai": {
@@ -4149,6 +4167,12 @@
       "engines": {
         "node": ">=8.0.0"
       }
+    },
+    "node_modules/@perplexity-ai/perplexity_ai": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@perplexity-ai/perplexity_ai/-/perplexity_ai-0.27.0.tgz",
+      "integrity": "sha512-iavFLkvSjuja81lSat6+Ewq1aDcxi5kierzhfcet9t2sKlsAXS208Nf+JcXzskquZlHkana3Impn69oMNYpg/w==",
+      "license": "Apache-2.0"
     },
     "node_modules/@pixi/colord": {
       "version": "2.9.6",

--- a/src/app/comet-cards/components/cosmic/brand-card.tsx
+++ b/src/app/comet-cards/components/cosmic/brand-card.tsx
@@ -286,6 +286,11 @@ export function BrandCard({
         </div>
       )}
 
+      {/* Edition shimmer overlay */}
+      {card.flags.edition !== 'normal' && (
+        <div className={`edition-${card.flags.edition}`} />
+      )}
+
       {/* Edition label */}
       {card.flags.edition !== 'normal' && (
         <div

--- a/src/app/comet-cards/components/cosmic/token-card.tsx
+++ b/src/app/comet-cards/components/cosmic/token-card.tsx
@@ -21,6 +21,7 @@ export function TokenCard({
   onClick,
   footer,
   typeLabel,
+  edition,
 }: {
   title: string
   description?: string

--- a/src/app/comet-cards/components/cosmic/token-card.tsx
+++ b/src/app/comet-cards/components/cosmic/token-card.tsx
@@ -33,6 +33,7 @@ export function TokenCard({
   onClick?: () => void
   footer?: ReactNode
   typeLabel?: string
+  edition?: string
 }) {
   const dims = SIZES[size]
   const isInteractive = !!onClick && !disabled
@@ -73,6 +74,10 @@ export function TokenCard({
           pointerEvents: 'none',
         }}
       />
+      {/* Edition shimmer overlay */}
+      {edition && edition !== 'normal' && (
+        <div className={`edition-${edition}`} />
+      )}
       {/* Inner border */}
       <div
         aria-hidden

--- a/src/app/comet-cards/components/gameplay/joker.tsx
+++ b/src/app/comet-cards/components/gameplay/joker.tsx
@@ -209,6 +209,7 @@ export const Joker = ({
       size="sm"
       badge={badge}
       typeLabel="Joker"
+      edition={joker.edition}
       onClick={onClick ? () => onClick(isSelected ?? false, joker.id) : undefined}
     />
   )

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -230,6 +230,90 @@ body {
 }
 
 /* ───────────────────────────────────────────────────────────────────
+   Card edition shimmer effects — foil, holographic, polychrome
+   ─────────────────────────────────────────────────────────────────── */
+
+@keyframes foil-sweep {
+  0% { background-position: -200% 0; }
+  100% { background-position: 200% 0; }
+}
+
+@keyframes holo-shift {
+  0% { background-position: 0% 50%; }
+  50% { background-position: 100% 50%; }
+  100% { background-position: 0% 50%; }
+}
+
+@keyframes poly-cycle {
+  0% { filter: hue-rotate(0deg); }
+  100% { filter: hue-rotate(360deg); }
+}
+
+.edition-foil {
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  pointer-events: none;
+  background: linear-gradient(
+    105deg,
+    transparent 30%,
+    rgba(200, 220, 255, 0.15) 45%,
+    rgba(255, 255, 255, 0.25) 50%,
+    rgba(200, 220, 255, 0.15) 55%,
+    transparent 70%
+  );
+  background-size: 200% 100%;
+  animation: foil-sweep 3s ease-in-out infinite;
+  mix-blend-mode: screen;
+}
+
+.edition-holographic {
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  pointer-events: none;
+  background: linear-gradient(
+    105deg,
+    rgba(255, 0, 0, 0.08),
+    rgba(255, 165, 0, 0.08),
+    rgba(255, 255, 0, 0.08),
+    rgba(0, 255, 0, 0.08),
+    rgba(0, 100, 255, 0.08),
+    rgba(150, 0, 255, 0.08),
+    rgba(255, 0, 0, 0.08)
+  );
+  background-size: 300% 100%;
+  animation: holo-shift 4s ease-in-out infinite;
+  mix-blend-mode: screen;
+}
+
+.edition-polychrome {
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  pointer-events: none;
+  background: linear-gradient(
+    135deg,
+    rgba(255, 100, 150, 0.12),
+    rgba(100, 200, 255, 0.12),
+    rgba(150, 255, 150, 0.12),
+    rgba(255, 200, 100, 0.12)
+  );
+  animation: poly-cycle 6s linear infinite;
+  mix-blend-mode: screen;
+}
+
+.edition-negative {
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  pointer-events: none;
+  background: rgba(0, 0, 0, 0.15);
+  mix-blend-mode: multiply;
+  border: 1px solid rgba(100, 100, 120, 0.3);
+}
+
+/* ───────────────────────────────────────────────────────────────────
    Reduced motion — disable CSS animations and transitions for users
    who prefer reduced motion. Framer Motion handles this automatically.
    ─────────────────────────────────────────────────────────────────── */


### PR DESCRIPTION
## Summary
- **Foil**: Metallic light sweep across the card (3s cycle, linear gradient animation)
- **Holographic**: Rainbow gradient shift effect (4s cycle, multi-color spectrum)
- **Polychrome**: Hue-rotate color cycling (6s cycle, smooth rotation)
- **Negative**: Dark multiply overlay with subtle border (static, no animation)
- Applied to both **playing cards** (`brand-card.tsx`) and **jokers** (`token-card.tsx` via new `edition` prop)
- All animations use `mix-blend-mode: screen` for subtle, non-intrusive effects
- Respects `prefers-reduced-motion` via the global CSS rule

## Test plan
- [ ] Foil edition cards show a sweeping metallic light effect
- [ ] Holographic cards show a rainbow gradient shifting across the surface
- [ ] Polychrome cards show smooth color cycling
- [ ] Negative cards have a darkened overlay
- [ ] Normal cards are unaffected
- [ ] Joker editions display correctly in both shop and gameplay
- [ ] Reduced-motion users see static cards (no animation)

Closes #1478

🤖 Generated with [Claude Code](https://claude.com/claude-code)