### PR TITLE
fix: shop continue/reroll buttons visible on mobile landscape

### DIFF
--- a/src/app/comet-cards/components/game-views/view-template.tsx
+++ b/src/app/comet-cards/components/game-views/view-template.tsx
@@ -234,6 +234,13 @@ export function ViewTemplate({
         </main>
       </div>
 
+      {/* In landscape mode the sidebar is hidden, so render its bottom actions here */}
+      {isLandscape && sidebarContentBottom && (
+        <div style={{ padding: '6px 12px', borderTop: '1px solid var(--cc-panel-divider)', flexShrink: 0 }}>
+          {sidebarContentBottom}
+        </div>
+      )}
+
       {showHands && (
         <Modal eyebrow="Show Hands" title="Poker Hands" onClose={() => setShowHands(false)}>
           <Hands pokerHandsState={game.pokerHands} />


### PR DESCRIPTION
## Summary
- The sidebar is `display: none` in landscape mode, which also hid the `sidebarContentBottom` slot containing the Continue and Reroll buttons
- Now renders `sidebarContentBottom` below the main content grid when in landscape mode, as a pinned bottom bar
- Keeps critical shop actions always visible and reachable

## Test plan
- [ ] On mobile landscape (e.g. iPhone 13 Pro Max 926×428), Continue and Reroll buttons are visible in the shop
- [ ] Buttons function correctly (Continue advances to blind, Reroll refreshes shop)
- [ ] Desktop/portrait layout unchanged — sidebar still shows buttons normally
- [ ] Other views using `sidebarContentBottom` also render correctly in landscape

Closes #1492

🤖 Generated with [Claude Code](https://claude.com/claude-code)