### PR TITLE
feat: joker activation glow/pulse during scoring

### DIFF
--- a/src/app/comet-cards/components/game-views/gameplay.tsx
+++ b/src/app/comet-cards/components/game-views/gameplay.tsx
@@ -86,6 +86,17 @@ export function GamePlayView() {
     return Math.min(100, Math.max(0, (numerator / denom) * 100))
   }, [currentBlind, targetScore])
 
+  const activatedJokerNames = useMemo(() => {
+    if (!isScoring) return new Set<string>()
+    const names = new Set<string>()
+    for (const evt of gamePlayState.scoringEvents) {
+      if ('source' in evt && evt.source) {
+        names.add(evt.source)
+      }
+    }
+    return names
+  }, [isScoring, gamePlayState.scoringEvents])
+
   const prevProgressRef = useRef(0)
   const [blindMet, setBlindMet] = useState(false)
 
@@ -328,6 +339,7 @@ export function GamePlayView() {
                 <button
                   key={joker.id}
                   type="button"
+                  className={activatedJokerNames.has(def.name) ? 'joker-activated' : undefined}
                   onClick={() => {
                     if (gamePlayState.selectedJokerId === joker.id) {
                       eventEmitter.emit({ type: 'JOKER_DESELECTED', id: joker.id })
@@ -345,6 +357,7 @@ export function GamePlayView() {
                     fontFamily: 'var(--cc-font-mono)',
                     fontSize: 10,
                     cursor: 'pointer',
+                    boxShadow: activatedJokerNames.has(def.name) ? `0 0 10px ${RARITY_ACCENT[def.rarity] ?? 'var(--cc-mint)'}` : undefined,
                   }}
                 >
                   ✺ {def.name}
@@ -757,6 +770,7 @@ export function GamePlayView() {
                     ownedCardCount={game.ownedCardIds.length}
                     gameSeed={game.gameSeed}
                     roundIndex={game.roundIndex}
+                    activated={activatedJokerNames.has(jokerDefinitions[joker.jokerId]?.name ?? '')}
                     onClick={(isSelected, id) => {
                       if (isSelected) {
                         eventEmitter.emit({ type: 'JOKER_DESELECTED', id })

--- a/src/app/comet-cards/components/gameplay/joker.tsx
+++ b/src/app/comet-cards/components/gameplay/joker.tsx
@@ -47,6 +47,7 @@ export const Joker = ({
   ownedCardCount,
   gameSeed,
   roundIndex,
+  activated,
 }: {
   joker: JokerState
   isSelected?: boolean
@@ -54,6 +55,7 @@ export const Joker = ({
   ownedCardCount?: number
   gameSeed?: string
   roundIndex?: number
+  activated?: boolean
 }) => {
   const def = jokers[joker.jokerId]
   const accent = RARITY_ACCENT[def?.rarity ?? 'common'] ?? 'var(--cc-mint)'
@@ -200,17 +202,19 @@ export const Joker = ({
   }
 
   return (
-    <TokenCard
-      title={def?.name ?? 'Unknown'}
-      description={def?.description}
-      glyph="✺"
-      accent={accent}
-      selected={isSelected}
-      size="sm"
-      badge={badge}
-      typeLabel="Joker"
-      edition={joker.edition}
-      onClick={onClick ? () => onClick(isSelected ?? false, joker.id) : undefined}
-    />
+    <div className={activated ? 'joker-activated' : undefined}>
+      <TokenCard
+        title={def?.name ?? 'Unknown'}
+        description={def?.description}
+        glyph="✺"
+        accent={accent}
+        selected={isSelected}
+        size="sm"
+        badge={badge}
+        typeLabel="Joker"
+        edition={joker.edition}
+        onClick={onClick ? () => onClick(isSelected ?? false, joker.id) : undefined}
+      />
+    </div>
   )
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -517,6 +517,33 @@ body {
   border-radius: inherit;
 }
 
+/* Joker activation pulse */
+@keyframes joker-pulse {
+  0% { transform: scale(1); filter: brightness(1); }
+  35% { transform: scale(1.06); filter: brightness(1.2); }
+  100% { transform: scale(1); filter: brightness(1); }
+}
+
+.joker-activated {
+  animation: joker-pulse 0.4s ease-out;
+  position: relative;
+}
+
+.joker-activated::after {
+  content: '';
+  position: absolute;
+  inset: -2px;
+  border-radius: 14px;
+  box-shadow: 0 0 12px 2px rgba(94, 234, 212, 0.5);
+  pointer-events: none;
+  animation: joker-glow-fade 0.6s ease-out forwards;
+}
+
+@keyframes joker-glow-fade {
+  0% { opacity: 1; }
+  100% { opacity: 0.4; }
+}
+
 @media (prefers-reduced-motion: reduce) {
   .blind-progress-fill {
     transition: none !important;
@@ -525,6 +552,12 @@ body {
     animation: none;
   }
   .blind-met-celebration::after {
+    animation: none;
+  }
+  .joker-activated {
+    animation: none;
+  }
+  .joker-activated::after {
     animation: none;
   }
 }


### PR DESCRIPTION
## Summary
- Jokers now pulse and glow when they contribute to scoring, giving players clear visual feedback on which jokers fired
- Derives activated state from `scoringEvents` source names — no domain/engine changes needed
- Applies to both desktop joker cards (scale + glow animation) and landscape compact joker buttons (box-shadow glow)
- Respects `prefers-reduced-motion`

## Test plan
- [ ] During scoring, jokers that contribute show a brief scale pulse (1.0 → 1.06 → 1.0)
- [ ] Active jokers get a mint glow ring around the card
- [ ] Jokers that don't fire remain static during scoring
- [ ] Landscape compact joker buttons also glow when activated
- [ ] Animation resets between scoring rounds
- [ ] Reduced-motion users see no animation

Closes #1474

🤖 Generated with [Claude Code](https://claude.com/claude-code)