### PR TITLE
feat: animate cards from hand to play area during scoring

### DIFF
--- a/src/app/comet-cards/components/game-views/gameplay.tsx
+++ b/src/app/comet-cards/components/game-views/gameplay.tsx
@@ -2,6 +2,8 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
+import { LayoutGroup } from 'framer-motion'
+
 import {
   DangerButton,
   GhostButton,
@@ -11,6 +13,7 @@ import {
 import { EmptySlot, ItemRow } from '@/app/comet-cards/components/cosmic/item-row'
 import { Panel } from '@/app/comet-cards/components/cosmic/panel'
 import { Hand, type HandSortKey } from '@/app/comet-cards/components/gameplay/hand'
+import { PlayArea } from '@/app/comet-cards/components/gameplay/play-area'
 import { Joker } from '@/app/comet-cards/components/gameplay/joker'
 import { Deck } from '@/app/comet-cards/components/global/deck'
 import { Hands } from '@/app/comet-cards/components/hands/hands'
@@ -24,6 +27,7 @@ import { isCustomScoringEvent } from '@/app/comet-cards/domain/game/types'
 import { calculateAnte, getBlindDefinition } from '@/app/comet-cards/domain/game/utils'
 import { pokerHands } from '@/app/comet-cards/domain/hand/hands'
 import { jokers as jokerDefinitions } from '@/app/comet-cards/domain/joker/jokers'
+import { getScoringCards } from '@/app/comet-cards/domain/game/card-registry-utils'
 import { getInProgressBlind } from '@/app/comet-cards/domain/round/blinds'
 import { useCometCardsStore } from '@/app/comet-cards/store'
 import { useGameState } from '@/app/comet-cards/useGameState'
@@ -77,6 +81,11 @@ export function GamePlayView() {
   const targetScore = currentBlind
     ? calculateAnte(currentRound.baseAnte, blindDefinition?.anteMultiplier ?? 1)
     : 0n
+
+  const playedCards = useMemo(() => {
+    if (!isScoring) return []
+    return getScoringCards(game)
+  }, [isScoring, game])
 
   const blindProgressPct = useMemo(() => {
     if (!currentBlind) return 0
@@ -277,10 +286,13 @@ export function GamePlayView() {
             )}
           </div>
 
-          {/* Hand */}
-          <div className="flex items-end justify-center" style={{ paddingBottom: 4, paddingTop: 4 }}>
-            <Hand sortKey={sortKey} />
-          </div>
+          {/* Play area + Hand */}
+          <LayoutGroup>
+            <PlayArea cards={playedCards} visible={isScoring} />
+            <div className="flex items-end justify-center" style={{ paddingBottom: 4, paddingTop: 4 }}>
+              <Hand sortKey={sortKey} />
+            </div>
+          </LayoutGroup>
 
           {/* Action bar */}
           <div
@@ -687,12 +699,15 @@ export function GamePlayView() {
               </div>
             </div>
 
-            <div
-              className="flex flex-1 items-end justify-center"
-              style={{ paddingBottom: 8, paddingTop: 12 }}
-            >
-              <Hand sortKey={sortKey} />
-            </div>
+            <LayoutGroup>
+              <PlayArea cards={playedCards} visible={isScoring} />
+              <div
+                className="flex flex-1 items-end justify-center"
+                style={{ paddingBottom: 8, paddingTop: 12 }}
+              >
+                <Hand sortKey={sortKey} />
+              </div>
+            </LayoutGroup>
 
             {/* Action bar */}
             <div

--- a/src/app/comet-cards/components/gameplay/hand.tsx
+++ b/src/app/comet-cards/components/gameplay/hand.tsx
@@ -107,6 +107,7 @@ export const Hand = ({ sortKey = 'value' }: { sortKey?: HandSortKey } = {}) => {
           return (
             <motion.div
               key={card.id}
+              layoutId={`playing-card-${card.id}`}
               layout
               initial={{ opacity: 0, y: 60, scale: 0.8 }}
               animate={{

--- a/src/app/comet-cards/components/gameplay/play-area.tsx
+++ b/src/app/comet-cards/components/gameplay/play-area.tsx
@@ -1,0 +1,57 @@
+'use client'
+
+import { AnimatePresence, motion } from 'framer-motion'
+
+import { useLandscapeMobile } from '@/app/comet-cards/hooks/useLandscapeMobile'
+import { PlayingCardState } from '@/app/comet-cards/domain/playing-card/types'
+
+import { PlayingCard } from './playing-card'
+
+export function PlayArea({
+  cards,
+  visible,
+}: {
+  cards: PlayingCardState[]
+  visible: boolean
+}) {
+  const isLandscape = useLandscapeMobile()
+  const CARD_W = isLandscape ? 52 : 80
+  const GAP = 8
+
+  if (!visible || cards.length === 0) return null
+
+  return (
+    <div
+      className="flex items-center justify-center"
+      style={{
+        minHeight: isLandscape ? 80 : 120,
+        gap: GAP,
+        padding: '8px 0',
+      }}
+    >
+      <AnimatePresence>
+        {cards.map((card, i) => (
+          <motion.div
+            key={card.id}
+            layoutId={`playing-card-${card.id}`}
+            initial={{ opacity: 0, scale: 0.85, y: 20 }}
+            animate={{ opacity: 1, scale: 1, y: 0 }}
+            transition={{
+              duration: 0.35,
+              delay: i * 0.05,
+              ease: [0.2, 0.9, 0.3, 1],
+              layout: { duration: 0.4, ease: [0.2, 0.9, 0.3, 1] },
+            }}
+            style={{ width: CARD_W, flexShrink: 0 }}
+          >
+            <PlayingCard
+              playingCard={card}
+              isSelected={false}
+              size={isLandscape ? 'xs' : 'sm'}
+            />
+          </motion.div>
+        ))}
+      </AnimatePresence>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- Cards now visually fly from the hand into a centered play area when a hand is played
- Uses Framer Motion `layoutId` for seamless position animation between Hand and PlayArea
- New `PlayArea` component renders played cards in a neat row during scoring
- Both landscape mobile and desktop views get the animation
- `LayoutGroup` scopes animations to prevent conflicts

## Test plan
- [ ] When playing a hand, selected cards animate from their fan position to a row above the hand
- [ ] Animation is smooth with staggered timing (50ms per card)
- [ ] Cards in the play area display at slightly smaller size
- [ ] Unplayed cards remain in the hand undisturbed
- [ ] Works correctly on mobile landscape
- [ ] No visual glitches when scoring completes and play area disappears

Closes #1475

🤖 Generated with [Claude Code](https://claude.com/claude-code)