### PR TITLE
feat: implement Anaglyph Deck

### DIFF
--- a/src/app/comet-cards/domain/decks/anaglyph-deck.ts
+++ b/src/app/comet-cards/domain/decks/anaglyph-deck.ts
@@ -1,0 +1,10 @@
+import { pokerDeckDefinition } from './poker-deck'
+import { DeckDefinition } from './types'
+
+export const anaglyphDeck: DeckDefinition = {
+  id: 'anaglyphDeck',
+  name: 'Anaglyph Deck',
+  description: 'Every Boss Blind gives a Double Tag after defeating it',
+  cards: pokerDeckDefinition,
+  modifiers: {},
+}

--- a/src/app/comet-cards/domain/decks/decks.ts
+++ b/src/app/comet-cards/domain/decks/decks.ts
@@ -2,6 +2,7 @@ import { GameState } from '@/app/comet-cards/domain/game/types'
 import { PlayingCardState } from '@/app/comet-cards/domain/playing-card/types'
 import { initializePlayingCard } from '@/app/comet-cards/domain/playing-card/utils'
 
+import { anaglyphDeck } from './anaglyph-deck'
 import { abandonedDeck } from './abandoned-deck'
 import { blackDeck } from './black-deck'
 import { blueDeck } from './blue-deck'
@@ -35,6 +36,7 @@ export const decks: Record<string, DeckDefinition> = {
   magicDeck: magicDeck,
   zodiacDeck: zodiacDeck,
   ghostDeck: ghostDeck,
+  anaglyphDeck: anaglyphDeck,
 }
 
 export const initialDeckStates = (game: GameState): Record<string, PlayingCardState[]> => {

--- a/src/app/comet-cards/domain/game/handlers/gameplay.ts
+++ b/src/app/comet-cards/domain/game/handlers/gameplay.ts
@@ -26,6 +26,7 @@ import {
 } from '@/app/comet-cards/domain/randomness'
 import { getInProgressBlind } from '@/app/comet-cards/domain/round/blinds'
 import { getRandomTarotCards } from '@/app/comet-cards/domain/shop/utils'
+import { initializeTag } from '@/app/comet-cards/domain/tag/utils'
 import { getRandomVoucherType } from '@/app/comet-cards/domain/voucher/utils'
 
 export function handleCardSelected(draft: GameState, event: CardSelectedEvent) {
@@ -359,6 +360,9 @@ export function handleHandScoringDoneCardScoring(draft: GameState) {
   draft.gamePlayState.remainingHands = draft.maxHands
   if (currentBlind.type === 'bossBlind') {
     draft.gamePlayState.cardIdsPlayedThisAnte = []
+    if (draft.selectedDeck === 'anaglyphDeck') {
+      draft.tags.push(initializeTag('double'))
+    }
     draft.roundIndex += 1
   }
   draft.gamePlayState.scoringEvents = []


### PR DESCRIPTION
## Summary
- New **Anaglyph Deck**: standard 52 cards with a special rule — after defeating any Boss Blind, the player receives a Double Tag
- Double Tag copies the next tag selected (existing tag mechanic)
- Deck definition, registration, and boss blind completion hook

## Test plan
- [ ] Anaglyph Deck appears in deck selection
- [ ] Standard 52 cards are dealt
- [ ] After defeating a Boss Blind, a Double Tag is added to the player's tags
- [ ] Double Tag does NOT appear after Small or Big Blind
- [ ] Double Tag works correctly (copies next selected tag)
- [ ] No modifiers applied (standard hand/discard/money/joker limits)

Closes #976

🤖 Generated with [Claude Code](https://claude.com/claude-code)