### PR TITLE
feat: add discard card animation

### DIFF
--- a/src/app/comet-cards/components/gameplay/hand.tsx
+++ b/src/app/comet-cards/components/gameplay/hand.tsx
@@ -27,6 +27,7 @@ export const Hand = ({ sortKey = 'value' }: { sortKey?: HandSortKey } = {}) => {
   const { game } = useGameState()
   const { gamePlayState } = game
   const { selectedCardIds } = gamePlayState
+  const isDiscarding = gamePlayState.isDiscarding
   const dealtCards = getHand(game)
 
   const sortedCards: PlayingCardState[] = useMemo(() => {
@@ -115,7 +116,10 @@ export const Hand = ({ sortKey = 'value' }: { sortKey?: HandSortKey } = {}) => {
                 y: 0,
                 scale: 1,
               }}
-              exit={{ opacity: 0, y: -30, scale: 0.9 }}
+              exit={isDiscarding
+                ? { opacity: 0, y: 80, scale: 0.6, rotate: (i - half) * 8 }
+                : { opacity: 0, y: -30, scale: 0.9 }
+              }
               transition={{
                 duration: 0.3,
                 delay: i * 0.05,

--- a/src/app/comet-cards/domain/game/default-game-state.ts
+++ b/src/app/comet-cards/domain/game/default-game-state.ts
@@ -40,6 +40,7 @@ const gameState: GameState = {
     drawPileIds: [],
     handIds: [],
     handTypesPlayedThisRound: [],
+    isDiscarding: false,
     isScoring: false,
     playedCardIds: [],
     remainingHands: 4,

--- a/src/app/comet-cards/domain/game/handlers/gameplay.ts
+++ b/src/app/comet-cards/domain/game/handlers/gameplay.ts
@@ -63,6 +63,7 @@ export function handleCardDeselected(draft: GameState, event: CardDeselectedEven
 
 export function handleDiscardSelectedCards(draft: GameState, event: GameEvent) {
   const gamePlayState = draft.gamePlayState
+  gamePlayState.isDiscarding = true
 
   // Find discarded cards before we clear selection
   const discardedCards = getCards(draft as unknown as GameState, gamePlayState.selectedCardIds)
@@ -274,6 +275,7 @@ export function handleCardScored(draft: GameState, event: GameEvent) {
 
 export function handleHandScoringStart(draft: GameState, event: GameEvent) {
   const gamePlayState = draft.gamePlayState
+  gamePlayState.isDiscarding = false
   const selectedCards = getSelectedCards(draft as unknown as GameState)
   const { hand: playedHand, handCards: cardsToScore } = findHighestPriorityHand(
     selectedCards,

--- a/src/app/comet-cards/domain/game/reduce-game.ts
+++ b/src/app/comet-cards/domain/game/reduce-game.ts
@@ -120,6 +120,7 @@ export function reduceGame(game: GameState, event: GameEvent): GameState {
       case 'HAND_DEALT': {
         if (draft.gamePlayState.handIds.length) return
         dealCardsFromDrawPile(draft, HAND_SIZE + draft.handSizeModifier)
+        draft.gamePlayState.isDiscarding = false
         return
       }
       case 'CARD_SELECTED': {

--- a/src/app/comet-cards/domain/game/types.ts
+++ b/src/app/comet-cards/domain/game/types.ts
@@ -96,6 +96,7 @@ export interface GamePlayState {
   // Track which hand types have been played this round (resets between blinds)
   handTypesPlayedThisRound: string[]
 
+  isDiscarding: boolean
   isScoring: boolean
   playedCardIds: string[]
   remainingDiscards: number


### PR DESCRIPTION
## Summary
- Adds a dedicated exit animation for discarded cards — they now scatter downward with rotation based on card position, instead of using the same generic upward fade as played cards
- Introduces `isDiscarding` state flag to `GamePlayState` so the Hand component can differentiate between discard and play exits
- Flag is set in the discard handler and cleared on scoring start and hand dealt

Partially addresses #1410 (highest-impact animations first).

## Test plan
- [ ] Play a hand — cards should animate upward/fade as before
- [ ] Discard cards — cards should scatter downward with slight rotation
- [ ] Verify animation feels snappy and doesn't slow down gameplay
- [ ] Test on mobile landscape layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)