### PR TITLE
fix: resolve TypeScript errors in comet-cards tests

### DIFF
--- a/src/app/comet-cards/domain/game/__tests__/dusk.test.ts
+++ b/src/app/comet-cards/domain/game/__tests__/dusk.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import { defaultGameState } from '@/app/comet-cards/domain/game/default-game-state'
 import { reduceGame } from '@/app/comet-cards/domain/game/reduce-game'
-import type { GameState } from '@/app/comet-cards/domain/game/types'
+import type { GameState, ScoringEvent } from '@/app/comet-cards/domain/game/types'
 import { jokers } from '@/app/comet-cards/domain/joker/jokers'
 import { initializeJoker } from '@/app/comet-cards/domain/joker/utils'
 import { playingCards } from '@/app/comet-cards/domain/playing-card/playing-cards'
@@ -33,8 +33,8 @@ describe('Dusk joker', () => {
     )
     expect(duskEvents).toHaveLength(1)
     // Ace baseChips = 11
-    expect(duskEvents[0].value).toBe(11)
-    expect(duskEvents[0].type).toBe('chips')
+    expect((duskEvents[0] as ScoringEvent).value).toBe(11)
+    expect((duskEvents[0] as ScoringEvent).type).toBe('chips')
   })
 
   it('does NOT retrigger when remainingHands is 1 (not final hand)', () => {

--- a/src/app/comet-cards/domain/game/__tests__/fibonacci.test.ts
+++ b/src/app/comet-cards/domain/game/__tests__/fibonacci.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import { defaultGameState } from '@/app/comet-cards/domain/game/default-game-state'
 import { reduceGame } from '@/app/comet-cards/domain/game/reduce-game'
-import type { GameState } from '@/app/comet-cards/domain/game/types'
+import type { GameState, ScoringEvent } from '@/app/comet-cards/domain/game/types'
 import { jokers } from '@/app/comet-cards/domain/joker/jokers'
 import { initializeJoker } from '@/app/comet-cards/domain/joker/utils'
 import { playingCards } from '@/app/comet-cards/domain/playing-card/playing-cards'
@@ -74,6 +74,6 @@ describe('Fibonacci joker', () => {
       e => 'source' in e && e.source === 'Fibonacci'
     )
     expect(event).toBeDefined()
-    expect(event?.type).toBe('mult')
+    expect((event as ScoringEvent | undefined)?.type).toBe('mult')
   })
 })

--- a/src/app/comet-cards/domain/game/__tests__/hack.test.ts
+++ b/src/app/comet-cards/domain/game/__tests__/hack.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import { defaultGameState } from '@/app/comet-cards/domain/game/default-game-state'
 import { reduceGame } from '@/app/comet-cards/domain/game/reduce-game'
-import type { GameState } from '@/app/comet-cards/domain/game/types'
+import type { GameState, ScoringEvent } from '@/app/comet-cards/domain/game/types'
 import { jokers } from '@/app/comet-cards/domain/joker/jokers'
 import { initializeJoker } from '@/app/comet-cards/domain/joker/utils'
 import { playingCards } from '@/app/comet-cards/domain/playing-card/playing-cards'
@@ -27,8 +27,8 @@ describe('Hack joker', () => {
     )
     expect(hackEvents).toHaveLength(1)
     // 3 baseChips = 3
-    expect(hackEvents[0].value).toBe(3)
-    expect(hackEvents[0].type).toBe('chips')
+    expect((hackEvents[0] as ScoringEvent).value).toBe(3)
+    expect((hackEvents[0] as ScoringEvent).type).toBe('chips')
   })
 
   it('card with value K does NOT get retriggered', () => {

--- a/src/app/comet-cards/domain/game/__tests__/hanging-chad.test.ts
+++ b/src/app/comet-cards/domain/game/__tests__/hanging-chad.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import { defaultGameState } from '@/app/comet-cards/domain/game/default-game-state'
 import { reduceGame } from '@/app/comet-cards/domain/game/reduce-game'
-import type { GameState } from '@/app/comet-cards/domain/game/types'
+import type { GameState, ScoringEvent } from '@/app/comet-cards/domain/game/types'
 import { jokers } from '@/app/comet-cards/domain/joker/jokers'
 import { initializeJoker } from '@/app/comet-cards/domain/joker/utils'
 import { playingCards } from '@/app/comet-cards/domain/playing-card/playing-cards'
@@ -27,8 +27,8 @@ describe('Hanging Chad joker', () => {
     )
     expect(hangingChadEvents).toHaveLength(2)
     // Ace baseChips = 11
-    expect(hangingChadEvents[0].value).toBe(11)
-    expect(hangingChadEvents[1].value).toBe(11)
+    expect((hangingChadEvents[0] as ScoringEvent).value).toBe(11)
+    expect((hangingChadEvents[1] as ScoringEvent).value).toBe(11)
   })
 
   it('second scored card does NOT get extra triggers', () => {

--- a/src/app/comet-cards/domain/game/__tests__/luchador.test.ts
+++ b/src/app/comet-cards/domain/game/__tests__/luchador.test.ts
@@ -49,7 +49,7 @@ describe('Luchador joker', () => {
   it('bossBlindDisabled resets to false when small blind is selected', () => {
     const game: GameState = structuredClone(defaultGameState)
     game.staticRules.bossBlindDisabled = true
-    game.rounds[game.roundIndex].smallBlind.status = 'pending'
+    game.rounds[game.roundIndex].smallBlind.status = 'notStarted'
 
     const after = reduceGame(game, { type: 'SMALL_BLIND_SELECTED' })
 
@@ -59,7 +59,7 @@ describe('Luchador joker', () => {
   it('bossBlindDisabled resets to false when big blind is selected', () => {
     const game: GameState = structuredClone(defaultGameState)
     game.staticRules.bossBlindDisabled = true
-    game.rounds[game.roundIndex].bigBlind.status = 'pending'
+    game.rounds[game.roundIndex].bigBlind.status = 'notStarted'
 
     const after = reduceGame(game, { type: 'BIG_BLIND_SELECTED' })
 
@@ -69,7 +69,7 @@ describe('Luchador joker', () => {
   it('bossBlindDisabled resets to false when boss blind is selected', () => {
     const game: GameState = structuredClone(defaultGameState)
     game.staticRules.bossBlindDisabled = true
-    game.rounds[game.roundIndex].bossBlind.status = 'pending'
+    game.rounds[game.roundIndex].bossBlind.status = 'notStarted'
 
     const after = reduceGame(game, { type: 'BOSS_BLIND_SELECTED' })
 

--- a/src/app/comet-cards/domain/game/__tests__/seltzer.test.ts
+++ b/src/app/comet-cards/domain/game/__tests__/seltzer.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import { defaultGameState } from '@/app/comet-cards/domain/game/default-game-state'
 import { reduceGame } from '@/app/comet-cards/domain/game/reduce-game'
-import type { GameState } from '@/app/comet-cards/domain/game/types'
+import type { GameState, ScoringEvent } from '@/app/comet-cards/domain/game/types'
 import { jokers } from '@/app/comet-cards/domain/joker/jokers'
 import { initializeJoker } from '@/app/comet-cards/domain/joker/utils'
 import { playingCards } from '@/app/comet-cards/domain/playing-card/playing-cards'
@@ -34,8 +34,8 @@ describe('Seltzer joker', () => {
     )
     expect(seltzerEvents).toHaveLength(1)
     // Ace baseChips = 11
-    expect(seltzerEvents[0].value).toBe(11)
-    expect(seltzerEvents[0].type).toBe('chips')
+    expect((seltzerEvents[0] as ScoringEvent).value).toBe(11)
+    expect((seltzerEvents[0] as ScoringEvent).type).toBe('chips')
   })
 
   it('counter initializes to 10 and decrements by 1 on HAND_SCORING_FINALIZE', () => {

--- a/src/app/comet-cards/domain/game/__tests__/shortcut.test.ts
+++ b/src/app/comet-cards/domain/game/__tests__/shortcut.test.ts
@@ -113,6 +113,7 @@ describe('Shortcut Joker', () => {
       probabilityMultiplier: 1,
       smearedSuits: false,
       allowStraightGaps: true,
+      bossBlindDisabled: false,
     })
     expect(isStraightWithGaps).toBe(true)
 
@@ -128,6 +129,7 @@ describe('Shortcut Joker', () => {
       probabilityMultiplier: 1,
       smearedSuits: false,
       allowStraightGaps: false,
+      bossBlindDisabled: false,
     })
     expect(isStraightWithoutGaps).toBe(false)
   })

--- a/src/app/comet-cards/domain/game/__tests__/smeared-joker.test.ts
+++ b/src/app/comet-cards/domain/game/__tests__/smeared-joker.test.ts
@@ -82,6 +82,7 @@ describe('Smeared Joker', () => {
       probabilityMultiplier: 1,
       smearedSuits: true,
       allowStraightGaps: false,
+      bossBlindDisabled: false,
     }
 
     const mixedRedCards = [
@@ -109,6 +110,7 @@ describe('Smeared Joker', () => {
       probabilityMultiplier: 1,
       smearedSuits: true,
       allowStraightGaps: false,
+      bossBlindDisabled: false,
     }
 
     const mixedBlackCards = [
@@ -136,6 +138,7 @@ describe('Smeared Joker', () => {
       probabilityMultiplier: 1,
       smearedSuits: false,
       allowStraightGaps: false,
+      bossBlindDisabled: false,
     }
 
     const mixedColorCards = [
@@ -163,6 +166,7 @@ describe('Smeared Joker', () => {
       probabilityMultiplier: 1,
       smearedSuits: true,
       allowStraightGaps: false,
+      bossBlindDisabled: false,
     }
 
     const mixedColorCards = [

--- a/src/app/comet-cards/domain/game/__tests__/spectral-ankh.test.ts
+++ b/src/app/comet-cards/domain/game/__tests__/spectral-ankh.test.ts
@@ -18,7 +18,6 @@ describe('Ankh spectral card', () => {
         {
           card: { id: 'ankh-1', spectralType: 'ankh' } as any,
           type: 'spectralCard',
-          cardType: 'spectralCard',
           price: 0,
         },
       ],

--- a/src/app/comet-cards/domain/game/__tests__/spectral-black-hole.test.ts
+++ b/src/app/comet-cards/domain/game/__tests__/spectral-black-hole.test.ts
@@ -14,7 +14,6 @@ describe('Black Hole spectral card', () => {
         {
           card: { id: 'black-hole-1', spectralType: 'blackHole' } as any,
           type: 'spectralCard',
-          cardType: 'spectralCard',
           price: 0,
         },
       ],

--- a/src/app/comet-cards/domain/game/__tests__/spectral-ectoplasm.test.ts
+++ b/src/app/comet-cards/domain/game/__tests__/spectral-ectoplasm.test.ts
@@ -17,7 +17,6 @@ describe('Ectoplasm spectral card', () => {
         {
           card: { id: 'ecto-1', spectralType: 'ectoplasm' } as any,
           type: 'spectralCard',
-          cardType: 'spectralCard',
           price: 0,
         },
       ],

--- a/src/app/comet-cards/domain/game/__tests__/spectral-grim.test.ts
+++ b/src/app/comet-cards/domain/game/__tests__/spectral-grim.test.ts
@@ -10,7 +10,7 @@ describe('Grim spectral card', () => {
     const initialOwned = game.ownedCardIds.length
     game.shopState.openPackState = {
       id: 'test-pack',
-      cards: [{ card: { id: 'grim-1', spectralType: 'grim' } as any, type: 'spectralCard', cardType: 'spectralCard', price: 0 }],
+      cards: [{ card: { id: 'grim-1', spectralType: 'grim' } as any, type: 'spectralCard', price: 0 }],
       rarity: 'normal',
       remainingCardsToSelect: 1,
     }

--- a/src/app/comet-cards/domain/game/__tests__/spectral-hex.test.ts
+++ b/src/app/comet-cards/domain/game/__tests__/spectral-hex.test.ts
@@ -12,7 +12,7 @@ describe('Hex spectral card', () => {
     ]
     game.shopState.openPackState = {
       id: 'test-pack',
-      cards: [{ card: { id: 'hex-1', spectralType: 'hex' } as any, type: 'spectralCard', cardType: 'spectralCard', price: 0 }],
+      cards: [{ card: { id: 'hex-1', spectralType: 'hex' } as any, type: 'spectralCard', price: 0 }],
       rarity: 'normal',
       remainingCardsToSelect: 1,
     }

--- a/src/app/comet-cards/domain/game/__tests__/spectral-immolate.test.ts
+++ b/src/app/comet-cards/domain/game/__tests__/spectral-immolate.test.ts
@@ -15,7 +15,6 @@ describe('Immolate spectral card', () => {
         {
           card: { id: 'immolate-1', spectralType: 'immolate' } as any,
           type: 'spectralCard',
-          cardType: 'spectralCard',
           price: 0,
         },
       ],

--- a/src/app/comet-cards/domain/game/__tests__/spectral-incantation.test.ts
+++ b/src/app/comet-cards/domain/game/__tests__/spectral-incantation.test.ts
@@ -10,7 +10,7 @@ describe('Incantation spectral card', () => {
     const initialOwned = game.ownedCardIds.length
     game.shopState.openPackState = {
       id: 'test-pack',
-      cards: [{ card: { id: 'inc-1', spectralType: 'incantation' } as any, type: 'spectralCard', cardType: 'spectralCard', price: 0 }],
+      cards: [{ card: { id: 'inc-1', spectralType: 'incantation' } as any, type: 'spectralCard', price: 0 }],
       rarity: 'normal',
       remainingCardsToSelect: 1,
     }

--- a/src/app/comet-cards/domain/game/__tests__/spectral-ouija.test.ts
+++ b/src/app/comet-cards/domain/game/__tests__/spectral-ouija.test.ts
@@ -11,7 +11,7 @@ describe('Ouija spectral card', () => {
     const initialHandSize = game.handSizeModifier
     game.shopState.openPackState = {
       id: 'test-pack',
-      cards: [{ card: { id: 'ouija-1', spectralType: 'ouija' } as any, type: 'spectralCard', cardType: 'spectralCard', price: 0 }],
+      cards: [{ card: { id: 'ouija-1', spectralType: 'ouija' } as any, type: 'spectralCard', price: 0 }],
       rarity: 'normal',
       remainingCardsToSelect: 1,
     }

--- a/src/app/comet-cards/domain/game/__tests__/spectral-sigil.test.ts
+++ b/src/app/comet-cards/domain/game/__tests__/spectral-sigil.test.ts
@@ -10,7 +10,7 @@ describe('Sigil spectral card', () => {
     game.gamePlayState.handIds = game.ownedCardIds.slice(0, 5)
     game.shopState.openPackState = {
       id: 'test-pack',
-      cards: [{ card: { id: 'sigil-1', spectralType: 'sigil' } as any, type: 'spectralCard', cardType: 'spectralCard', price: 0 }],
+      cards: [{ card: { id: 'sigil-1', spectralType: 'sigil' } as any, type: 'spectralCard', price: 0 }],
       rarity: 'normal',
       remainingCardsToSelect: 1,
     }

--- a/src/app/comet-cards/domain/game/__tests__/spectral-wraith.test.ts
+++ b/src/app/comet-cards/domain/game/__tests__/spectral-wraith.test.ts
@@ -13,7 +13,6 @@ describe('Wraith spectral card', () => {
         {
           card: { id: 'wraith-1', spectralType: 'wraith' } as any,
           type: 'spectralCard',
-          cardType: 'spectralCard',
           price: 0,
         },
       ],

--- a/src/app/comet-cards/domain/game/__tests__/to-do-list.test.ts
+++ b/src/app/comet-cards/domain/game/__tests__/to-do-list.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import { defaultGameState } from '@/app/comet-cards/domain/game/default-game-state'
 import { reduceGame } from '@/app/comet-cards/domain/game/reduce-game'
 import type { GameState } from '@/app/comet-cards/domain/game/types'
+import type { PokerHandsState } from '@/app/comet-cards/domain/hand/types'
 import { jokers } from '@/app/comet-cards/domain/joker/jokers'
 import { initializeJoker } from '@/app/comet-cards/domain/joker/utils'
 
@@ -27,7 +28,7 @@ describe('To Do List joker', () => {
       ...started,
       gamePlayState: {
         ...started.gamePlayState,
-        selectedHand: [targetHandId, []],
+        selectedHand: [targetHandId as keyof PokerHandsState, []],
         score: { chips: 10, mult: 5 },
       },
     }
@@ -50,7 +51,7 @@ describe('To Do List joker', () => {
       ...started,
       gamePlayState: {
         ...started.gamePlayState,
-        selectedHand: [nonTargetHandId, []],
+        selectedHand: [nonTargetHandId as keyof PokerHandsState, []],
         score: { chips: 10, mult: 5 },
       },
     }

--- a/src/app/comet-cards/domain/hand/__tests__/hands.test.ts
+++ b/src/app/comet-cards/domain/hand/__tests__/hands.test.ts
@@ -130,7 +130,15 @@ describe('comet-cards hand checkers', () => {
       numberOfCardsRequiredForFlushAndStraight: 5,
       areAllCardsFaceCards: false,
       allowDuplicateJokersInShop: false,
+      bossBlindRerolls: 0,
+      bossBlindRerollCost: 0,
+      telescopeActive: false,
+      observatoryActive: false,
+      spectralInArcanaPacks: false,
+      probabilityMultiplier: 1,
+      smearedSuits: false,
       allowStraightGaps: false,
+      bossBlindDisabled: false,
     })
     expect(isStraight).toBe(true)
     // We return the straight cards in ascending value order.
@@ -142,6 +150,15 @@ describe('comet-cards hand checkers', () => {
         numberOfCardsRequiredForFlushAndStraight: 5,
         areAllCardsFaceCards: false,
         allowDuplicateJokersInShop: false,
+        bossBlindRerolls: 0,
+        bossBlindRerollCost: 0,
+        telescopeActive: false,
+        observatoryActive: false,
+        spectralInArcanaPacks: false,
+        probabilityMultiplier: 1,
+        smearedSuits: false,
+        allowStraightGaps: false,
+        bossBlindDisabled: false,
       }
     )
     expect(isNotStraight).toBe(false)
@@ -169,6 +186,15 @@ describe('comet-cards hand checkers', () => {
         numberOfCardsRequiredForFlushAndStraight: 5,
         areAllCardsFaceCards: false,
         allowDuplicateJokersInShop: false,
+        bossBlindRerolls: 0,
+        bossBlindRerollCost: 0,
+        telescopeActive: false,
+        observatoryActive: false,
+        spectralInArcanaPacks: false,
+        probabilityMultiplier: 1,
+        smearedSuits: false,
+        allowStraightGaps: false,
+        bossBlindDisabled: false,
       }
     )
     expect(isStraight).toBe(true)
@@ -196,6 +222,15 @@ describe('comet-cards hand checkers', () => {
         numberOfCardsRequiredForFlushAndStraight: 5,
         areAllCardsFaceCards: false,
         allowDuplicateJokersInShop: false,
+        bossBlindRerolls: 0,
+        bossBlindRerollCost: 0,
+        telescopeActive: false,
+        observatoryActive: false,
+        spectralInArcanaPacks: false,
+        probabilityMultiplier: 1,
+        smearedSuits: false,
+        allowStraightGaps: false,
+        bossBlindDisabled: false,
       }
     )
     expect(isStraight).toBe(true)
@@ -209,7 +244,15 @@ describe('comet-cards hand checkers', () => {
       numberOfCardsRequiredForFlushAndStraight: 4,
       areAllCardsFaceCards: false,
       allowDuplicateJokersInShop: false,
+      bossBlindRerolls: 0,
+      bossBlindRerollCost: 0,
+      telescopeActive: false,
+      observatoryActive: false,
+      spectralInArcanaPacks: false,
+      probabilityMultiplier: 1,
+      smearedSuits: false,
       allowStraightGaps: false,
+      bossBlindDisabled: false,
     })
     expect(isFlush).toBe(true)
     expect(
@@ -225,6 +268,15 @@ describe('comet-cards hand checkers', () => {
         numberOfCardsRequiredForFlushAndStraight: 5,
         areAllCardsFaceCards: false,
         allowDuplicateJokersInShop: false,
+        bossBlindRerolls: 0,
+        bossBlindRerollCost: 0,
+        telescopeActive: false,
+        observatoryActive: false,
+        spectralInArcanaPacks: false,
+        probabilityMultiplier: 1,
+        smearedSuits: false,
+        allowStraightGaps: false,
+        bossBlindDisabled: false,
       }
     )
     expect(isNotFlush).toBe(false)
@@ -280,7 +332,15 @@ describe('comet-cards hand checkers', () => {
       numberOfCardsRequiredForFlushAndStraight: 5,
       areAllCardsFaceCards: false,
       allowDuplicateJokersInShop: false,
+      bossBlindRerolls: 0,
+      bossBlindRerollCost: 0,
+      telescopeActive: false,
+      observatoryActive: false,
+      spectralInArcanaPacks: false,
+      probabilityMultiplier: 1,
+      smearedSuits: false,
       allowStraightGaps: false,
+      bossBlindDisabled: false,
     })
     expect(isStraightFlush).toBe(true)
     expect(straightFlushCards).toEqual(allSameSuitStraight)
@@ -298,7 +358,15 @@ describe('comet-cards hand checkers', () => {
       numberOfCardsRequiredForFlushAndStraight: 5,
       areAllCardsFaceCards: false,
       allowDuplicateJokersInShop: false,
+      bossBlindRerolls: 0,
+      bossBlindRerollCost: 0,
+      telescopeActive: false,
+      observatoryActive: false,
+      spectralInArcanaPacks: false,
+      probabilityMultiplier: 1,
+      smearedSuits: false,
       allowStraightGaps: false,
+      bossBlindDisabled: false,
     })
     expect(isFlushHouse).toBe(true)
     expect(flushHouseCards).toEqual(suitedStraight)
@@ -314,7 +382,15 @@ describe('comet-cards hand checkers', () => {
       numberOfCardsRequiredForFlushAndStraight: 5,
       areAllCardsFaceCards: false,
       allowDuplicateJokersInShop: false,
+      bossBlindRerolls: 0,
+      bossBlindRerollCost: 0,
+      telescopeActive: false,
+      observatoryActive: false,
+      spectralInArcanaPacks: false,
+      probabilityMultiplier: 1,
+      smearedSuits: false,
       allowStraightGaps: false,
+      bossBlindDisabled: false,
     })
     expect(isNotFlushHouse).toBe(false)
     expect(notFlushHouseCards).toEqual([])
@@ -326,7 +402,15 @@ describe('comet-cards hand checkers', () => {
       numberOfCardsRequiredForFlushAndStraight: 5,
       areAllCardsFaceCards: false,
       allowDuplicateJokersInShop: false,
+      bossBlindRerolls: 0,
+      bossBlindRerollCost: 0,
+      telescopeActive: false,
+      observatoryActive: false,
+      spectralInArcanaPacks: false,
+      probabilityMultiplier: 1,
+      smearedSuits: false,
       allowStraightGaps: false,
+      bossBlindDisabled: false,
     })
     expect(isFive).toBe(true)
     expect(fiveCards).toEqual(fiveAces)
@@ -337,6 +421,15 @@ describe('comet-cards hand checkers', () => {
         numberOfCardsRequiredForFlushAndStraight: 5,
         areAllCardsFaceCards: false,
         allowDuplicateJokersInShop: false,
+        bossBlindRerolls: 0,
+        bossBlindRerollCost: 0,
+        telescopeActive: false,
+        observatoryActive: false,
+        spectralInArcanaPacks: false,
+        probabilityMultiplier: 1,
+        smearedSuits: false,
+        allowStraightGaps: false,
+        bossBlindDisabled: false,
       }
     )
     expect(isNotFive).toBe(false)
@@ -348,6 +441,15 @@ describe('comet-cards hand checkers', () => {
         numberOfCardsRequiredForFlushAndStraight: 5,
         areAllCardsFaceCards: false,
         allowDuplicateJokersInShop: false,
+        bossBlindRerolls: 0,
+        bossBlindRerollCost: 0,
+        telescopeActive: false,
+        observatoryActive: false,
+        spectralInArcanaPacks: false,
+        probabilityMultiplier: 1,
+        smearedSuits: false,
+        allowStraightGaps: false,
+        bossBlindDisabled: false,
       }
     )
     expect(isNotExactlyFive).toBe(false)
@@ -359,8 +461,15 @@ describe('comet-cards hand checkers', () => {
       numberOfCardsRequiredForFlushAndStraight: 5,
       areAllCardsFaceCards: false,
       allowDuplicateJokersInShop: false,
+      bossBlindRerolls: 0,
+      bossBlindRerollCost: 0,
+      telescopeActive: false,
+      observatoryActive: false,
+      spectralInArcanaPacks: false,
+      probabilityMultiplier: 1,
       smearedSuits: false,
       allowStraightGaps: false,
+      bossBlindDisabled: false,
     }
     const flushFive = [c('7_hearts'), c('7_hearts'), c('7_hearts'), c('7_hearts'), c('7_hearts')]
     const [isFlushFive, flushFiveCards] = checkHandForFlushFive(flushFive, staticRules)


### PR DESCRIPTION
## Summary
- Fixes all 42 TypeScript compilation errors across 20 comet-cards test files
- No test logic changes — only type annotations, property renames, and missing fields
- Categories fixed:
  - ScoringEvent union narrowing (5 files)
  - Invalid "pending" status literal (1 file)
  - Missing StaticRulesState fields like `bossBlindDisabled` (3 files)
  - Removed invalid `cardType` prop on BuyableCard (10 files)
  - keyof PokerHandsState assertion (1 file)

## Test plan
- [ ] `npx tsc --noEmit` shows zero comet-cards errors
- [ ] Existing tests still pass (no logic changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)