### PR TITLE
feat: add edition support for consumables

### DIFF
--- a/src/app/comet-cards/components/game-views/gameplay.tsx
+++ b/src/app/comet-cards/components/game-views/gameplay.tsx
@@ -20,7 +20,7 @@ import { Hands } from '@/app/comet-cards/components/hands/hands'
 import { TickingNumber } from '@/app/comet-cards/components/animations/ticking-number'
 import { Modal } from '@/app/comet-cards/components/ui/modal'
 import { Vouchers } from '@/app/comet-cards/components/voucher/vouchers'
-import { getConsumableDefinition } from '@/app/comet-cards/domain/consumable/utils'
+import { countConsumableSlots, getConsumableDefinition } from '@/app/comet-cards/domain/consumable/utils'
 import { eventEmitter } from '@/app/comet-cards/domain/events/event-emitter'
 import { scoreHand as domainScoreHand } from '@/app/comet-cards/domain/game/score-hand'
 import { isCustomScoringEvent } from '@/app/comet-cards/domain/game/types'
@@ -930,7 +930,7 @@ export function GamePlayView() {
 
             <Panel
               title="Consumables"
-              subtitle={`${game.consumables.length} / ${game.maxConsumables} slots`}
+              subtitle={`${countConsumableSlots(game.consumables)} / ${game.maxConsumables} slots`}
             >
               <div style={{ padding: 14, display: 'flex', flexDirection: 'column', gap: 10 }}>
                 {game.consumables.map(consumable => {

--- a/src/app/comet-cards/components/gameplay/celestial-card.tsx
+++ b/src/app/comet-cards/components/gameplay/celestial-card.tsx
@@ -21,6 +21,7 @@ export const CelestialCard = ({
       selected={isSelected}
       size="sm"
       typeLabel="Celestial"
+      edition={celestialCard.edition}
       onClick={onClick ? () => onClick(isSelected ?? false, celestialCard.id) : undefined}
     />
   )

--- a/src/app/comet-cards/components/gameplay/tarot-card.tsx
+++ b/src/app/comet-cards/components/gameplay/tarot-card.tsx
@@ -21,6 +21,7 @@ export const TarotCard = ({
       selected={isSelected}
       size="sm"
       typeLabel="Tarot"
+      edition={tarotCard.edition}
       onClick={onClick ? () => onClick(isSelected ?? false, tarotCard.id) : undefined}
     />
   )

--- a/src/app/comet-cards/domain/consumable/types.ts
+++ b/src/app/comet-cards/domain/consumable/types.ts
@@ -46,9 +46,12 @@ export interface TarotCardDefinition extends ConsumableDefinition {
   effects: Effect[]
 }
 
+export type ConsumableEdition = 'holographic' | 'foil' | 'polychrome' | 'negative'
+
 export interface ConsumableState {
   id: string
   consumableType: ConsumableDefinition['type']
+  edition?: ConsumableEdition
 }
 
 export interface CelestialCardState extends ConsumableState {

--- a/src/app/comet-cards/domain/consumable/utils.ts
+++ b/src/app/comet-cards/domain/consumable/utils.ts
@@ -5,6 +5,8 @@ import { tarotCards } from './tarot-cards'
 import {
   CelestialCardDefinition,
   CelestialCardState,
+  ConsumableEdition,
+  ConsumableState,
   TarotCardDefinition,
   TarotCardState,
 } from './types'
@@ -28,18 +30,29 @@ export const findLastTarotOrCelestialCard = (
 }
 
 export const initializeCelestialCard = (
-  consumable: CelestialCardDefinition
+  consumable: CelestialCardDefinition,
+  edition?: ConsumableEdition
 ): CelestialCardState => ({
   id: uuid(),
   consumableType: 'celestialCard',
   handId: consumable.handId,
+  ...(edition && { edition }),
 })
 
-export const initializeTarotCard = (consumable: TarotCardDefinition): TarotCardState => ({
+export const initializeTarotCard = (
+  consumable: TarotCardDefinition,
+  edition?: ConsumableEdition
+): TarotCardState => ({
   id: uuid(),
   consumableType: 'tarotCard',
   tarotType: consumable.tarotType,
+  ...(edition && { edition }),
 })
+
+/** Count consumables that occupy a slot (excludes Negative edition) */
+export function countConsumableSlots(consumables: ConsumableState[]): number {
+  return consumables.filter(c => c.edition !== 'negative').length
+}
 
 export const isCelestialCardState = (card: unknown): card is CelestialCardState => {
   return (

--- a/src/app/comet-cards/domain/game/handlers.ts
+++ b/src/app/comet-cards/domain/game/handlers.ts
@@ -1,5 +1,5 @@
 import { celestialCards } from '@/app/comet-cards/domain/consumable/celestial-cards'
-import { initializeCelestialCard } from '@/app/comet-cards/domain/consumable/utils'
+import { countConsumableSlots, initializeCelestialCard } from '@/app/comet-cards/domain/consumable/utils'
 import { dispatchEffects } from '@/app/comet-cards/domain/events/dispatch-effects'
 import type { EffectContext, GameEvent } from '@/app/comet-cards/domain/events/types'
 import { uuid } from '@/app/comet-cards/domain/randomness'
@@ -140,7 +140,7 @@ export function handleHandScoringEnd(draft: Draft<GameState>, event: GameEvent) 
     const cardsInHandWithBlueSeal = cardsInHand.filter(card => card.flags.seal === 'blue')
     if (playedHand) {
       for (let i = 0; i < cardsInHandWithBlueSeal.length; i++) {
-        if (draft.consumables.length < draft.maxConsumables) {
+        if (countConsumableSlots(draft.consumables) < draft.maxConsumables) {
           draft.consumables.push(initializeCelestialCard(celestialCards[playedHand]))
         }
       }

--- a/src/app/comet-cards/domain/game/handlers/gameplay.ts
+++ b/src/app/comet-cards/domain/game/handlers/gameplay.ts
@@ -1,4 +1,4 @@
-import { initializeTarotCard } from '@/app/comet-cards/domain/consumable/utils'
+import { countConsumableSlots, initializeTarotCard } from '@/app/comet-cards/domain/consumable/utils'
 import { dispatchEffects } from '@/app/comet-cards/domain/events/dispatch-effects'
 import type {
   CardDeselectedEvent,
@@ -103,7 +103,7 @@ export function handleDiscardSelectedCards(draft: GameState, event: GameEvent) {
   // Purple seal: add a tarot card for each discarded card with purple seal
   const purpleSealCount = discardedCards.filter(card => card.flags.seal === 'purple').length
   for (let i = 0; i < purpleSealCount; i++) {
-    if (draft.consumables.length < draft.maxConsumables) {
+    if (countConsumableSlots(draft.consumables) < draft.maxConsumables) {
       const randomTarotCardsSeed = buildSeedString([
         draft.gameSeed,
         draft.roundIndex.toString(),

--- a/src/app/comet-cards/domain/shop/utils.ts
+++ b/src/app/comet-cards/domain/shop/utils.ts
@@ -12,6 +12,7 @@ import {
   isCelestialCardDefinition,
   isCelestialCardState,
   isTarotCardDefinition,
+  countConsumableSlots,
   isTarotCardState,
 } from '@/app/comet-cards/domain/consumable/utils'
 import { GameState } from '@/app/comet-cards/domain/game/types'
@@ -284,7 +285,7 @@ export function getIsRoomForSelectedCard(
     isCelestialCardDefinition(selectedCardDefinition) ||
     isTarotCardDefinition(selectedCardDefinition)
   ) {
-    return game.consumables.length < game.maxConsumables
+    return countConsumableSlots(game.consumables) < game.maxConsumables
   }
 
   return isPlayingCardDefinition(selectedCardDefinition)


### PR DESCRIPTION
## Summary
- Adds optional `edition` field (`holographic | foil | polychrome | negative`) to `ConsumableState` type
- Negative-edition consumables don't count toward the slot limit via `countConsumableSlots()` utility
- Tarot and celestial card components now pass edition to TokenCard for visual rendering (CSS styles already exist)
- Updated key slot checks in handlers, shop, and UI display

Closes #1277. Unblocks Perkeo joker (#841).

## Test plan
- [ ] Type-check passes (`npx tsc --noEmit` — zero comet-cards errors)
- [ ] Consumable slot display shows correct count
- [ ] Existing consumable behavior unchanged (edition is optional, defaults to undefined)
- [ ] TokenCard renders edition overlay when edition is set

🤖 Generated with [Claude Code](https://claude.com/claude-code)