### PR TITLE
feat: implement Pareidolia joker

### DIFF
--- a/src/app/comet-cards/components/gameplay/hand.tsx
+++ b/src/app/comet-cards/components/gameplay/hand.tsx
@@ -10,6 +10,7 @@ import { getHand } from '@/app/comet-cards/domain/game/card-registry-utils'
 import { cardValuePriority } from '@/app/comet-cards/domain/hand/constants'
 import { playingCards } from '@/app/comet-cards/domain/playing-card/playing-cards'
 import { PlayingCardState } from '@/app/comet-cards/domain/playing-card/types'
+import { isFaceCard } from '@/app/comet-cards/domain/playing-card/utils'
 import { getInProgressBlind } from '@/app/comet-cards/domain/round/blinds'
 import { useGameState } from '@/app/comet-cards/useGameState'
 
@@ -63,7 +64,7 @@ export const Hand = ({ sortKey = 'value' }: { sortKey?: HandSortKey } = {}) => {
 
       const suit = def.suit
       const value = def.value
-      const isFace = value === 'J' || value === 'Q' || value === 'K'
+      const isFace = isFaceCard(value, game)
 
       if (
         (bossName === 'The Club' && suit === 'clubs') ||

--- a/src/app/comet-cards/domain/joker/jokers.ts
+++ b/src/app/comet-cards/domain/joker/jokers.ts
@@ -21,7 +21,7 @@ import { getRandomTarotCards, getRandomSpectralCards } from '@/app/comet-cards/d
 import { initializeSpectralCard } from '@/app/comet-cards/domain/spectral/utils'
 
 import { addOwnedCard, removeOwnedCard } from '@/app/comet-cards/domain/game/card-registry-utils'
-import { initializePlayingCard } from '@/app/comet-cards/domain/playing-card/utils'
+import { initializePlayingCard, isFaceCard } from '@/app/comet-cards/domain/playing-card/utils'
 import { bossBlinds } from '@/app/comet-cards/domain/round/boss-blinds'
 import { JokerDefinition, JokerState } from './types'
 import { bonusOnCardScored, bonusOnHandPlayed, isJokerState } from './utils'
@@ -698,8 +698,7 @@ export const midasMaskJoker: JokerDefinition = {
         if (!scoredCard) return
         const cardDef = playingCards[scoredCard.playingCardId]
         if (!cardDef) return
-        const faceValues = ['J', 'Q', 'K']
-        if (!faceValues.includes(cardDef.value)) return
+        if (!isFaceCard(cardDef.value, ctx.game)) return
 
         // Convert to Gold enchantment permanently
         const cardState = ctx.game.cards[scoredCard.id]
@@ -1916,8 +1915,7 @@ export const smileyFaceJoker: JokerDefinition = {
         if (!scoredCard) return
         const cardDef = playingCards[scoredCard.playingCardId]
         if (!cardDef) return
-        const faceValues = ['J', 'Q', 'K']
-        if (faceValues.includes(cardDef.value)) {
+        if (isFaceCard(cardDef.value, ctx.game)) {
           ctx.game.gamePlayState.scoringEvents.push({
             id: uuid(),
             type: 'mult',
@@ -2071,7 +2069,7 @@ export const scaryFaceJoker: JokerDefinition = {
         if (!scoredCard) return
         const cardDef = playingCards[scoredCard.playingCardId]
         if (!cardDef) return
-        if (['J', 'Q', 'K'].includes(cardDef.value)) {
+        if (isFaceCard(cardDef.value, ctx.game)) {
           ctx.game.gamePlayState.scoringEvents.push({
             id: uuid(),
             type: 'chips',
@@ -2224,7 +2222,7 @@ export const businessCard: JokerDefinition = {
         const scoredCard = ctx.scoredCards?.[0]
         if (!scoredCard) return
         const cardDef = playingCards[scoredCard.playingCardId]
-        if (!['J', 'Q', 'K'].includes(cardDef.value)) return
+        if (!isFaceCard(cardDef.value, ctx.game)) return
 
         const seed = buildSeedString([
           ctx.game.gameSeed,
@@ -2718,7 +2716,7 @@ export const photograph: JokerDefinition = {
         const scoredCard = ctx.scoredCards?.[0]
         if (!scoredCard) return
         const cardDef = playingCards[scoredCard.playingCardId]
-        if (!['J', 'Q', 'K'].includes(cardDef.value)) return
+        if (!isFaceCard(cardDef.value, ctx.game)) return
         pj.counter = 1
         ctx.game.gamePlayState.scoringEvents.push({
           id: uuid(),
@@ -2943,10 +2941,9 @@ export const rideTheBus: JokerDefinition = {
         const selectedHand = ctx.game.gamePlayState.selectedHand
         if (!selectedHand) return
         const scoringCards = selectedHand[1]
-        const faceValues = ['J', 'Q', 'K']
         const hasFaceCard = scoringCards.some(card => {
           const cardDef = playingCards[card.playingCardId]
-          return faceValues.includes(cardDef.value)
+          return isFaceCard(cardDef.value, ctx.game)
         })
         if (hasFaceCard) {
           rtb.counter = 0
@@ -2978,13 +2975,12 @@ export const facelessJoker: JokerDefinition = {
       event: { type: 'DISCARD_SELECTED_CARDS' },
       priority: 1,
       apply: (ctx: EffectContext) => {
-        const faceValues = ['J', 'Q', 'K']
         let faceCardCount = 0
         for (const cardId of ctx.game.gamePlayState.selectedCardIds) {
           const cardState = ctx.game.cards[cardId]
           if (!cardState) continue
           const cardDef = playingCards[cardState.playingCardId]
-          if (faceValues.includes(cardDef.value)) {
+          if (isFaceCard(cardDef.value, ctx.game)) {
             faceCardCount++
           }
         }
@@ -3030,13 +3026,12 @@ export const reservedParking: JokerDefinition = {
         const heldCardIds = ctx.game.gamePlayState.handIds.filter(
           id => !ctx.game.gamePlayState.playedCardIds.includes(id)
         )
-        const faceValues = ['J', 'Q', 'K']
         let moneyEarned = 0
         for (const cardId of heldCardIds) {
           const cardState = ctx.game.cards[cardId]
           if (!cardState) continue
           const cardDef = playingCards[cardState.playingCardId]
-          if (!faceValues.includes(cardDef.value)) continue
+          if (!isFaceCard(cardDef.value, ctx.game)) continue
           const seed = buildSeedString([
             ctx.game.gameSeed,
             ctx.game.roundIndex.toString(),
@@ -4224,8 +4219,7 @@ export const canio: JokerDefinition = {
         if (!cardState) return
         const cardDef = playingCards[cardState.playingCardId]
         if (!cardDef) return
-        const faceValues = ['J', 'Q', 'K']
-        if (!faceValues.includes(cardDef.value)) return
+        if (!isFaceCard(cardDef.value, ctx.game)) return
         c.metadata.xMult += 100
       },
     },
@@ -4881,7 +4875,7 @@ export const sockAndBuskin: JokerDefinition = {
         const scoredCard = ctx.scoredCards?.[0]
         if (!scoredCard) return
         const cardDef = playingCards[scoredCard.playingCardId]
-        if (!['J', 'Q', 'K'].includes(cardDef.value)) return
+        if (!isFaceCard(cardDef.value, ctx.game)) return
         ctx.game.gamePlayState.scoringEvents.push({
           id: uuid(),
           type: 'chips',
@@ -5022,6 +5016,39 @@ export const luchador: JokerDefinition = {
       priority: 1,
       apply: (ctx: EffectContext) => {
         ctx.game.staticRules.bossBlindDisabled = true
+      },
+    },
+  ],
+  rarity: 'uncommon',
+}
+
+export const pareidoliaJoker: JokerDefinition = {
+  id: 'pareidolia',
+  name: 'Pareidolia',
+  description: 'All cards are considered face cards',
+  price: 5,
+  effects: [
+    {
+      event: { type: 'GAME_START' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        ctx.game.staticRules.areAllCardsFaceCards = true
+      },
+    },
+    {
+      event: { type: 'JOKER_ADDED' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        ctx.game.staticRules.areAllCardsFaceCards = true
+      },
+    },
+    {
+      event: { type: 'JOKER_REMOVED' },
+      priority: 1,
+      apply: (ctx: EffectContext) => {
+        if (!ctx.game.jokers.some(joker => joker.jokerId === 'pareidolia')) {
+          ctx.game.staticRules.areAllCardsFaceCards = false
+        }
       },
     },
   ],
@@ -5175,6 +5202,7 @@ export const jokers: Record<JokerDefinition['id'], JokerDefinition> = {
   hologram,
   shortcut,
   luchador,
+  pareidolia: pareidoliaJoker,
 }
 
 /***

--- a/src/app/comet-cards/domain/playing-card/utils.ts
+++ b/src/app/comet-cards/domain/playing-card/utils.ts
@@ -10,6 +10,11 @@ import {
 import { playingCards } from './playing-cards'
 import { CardValue, PlayingCardDefinition, PlayingCardState } from './types'
 
+export function isFaceCard(value: string, game: GameState): boolean {
+  if (game.staticRules.areAllCardsFaceCards) return true
+  return value === 'J' || value === 'Q' || value === 'K'
+}
+
 export function isPlayingCardState(card: unknown): card is PlayingCardState {
   return typeof card === 'object' && card !== null && 'playingCardId' in card
 }

--- a/src/app/comet-cards/domain/round/boss-blinds.ts
+++ b/src/app/comet-cards/domain/round/boss-blinds.ts
@@ -1,6 +1,7 @@
 import type { EffectContext } from '@/app/comet-cards/domain/events/types'
 import { getMostPlayedHand } from '@/app/comet-cards/domain/hand/utils'
 import { playingCards } from '@/app/comet-cards/domain/playing-card/playing-cards'
+import { isFaceCard } from '@/app/comet-cards/domain/playing-card/utils'
 import { buildSeedString, getRandomNumberWithSeed } from '@/app/comet-cards/domain/randomness'
 import type { BossBlindDefinition } from '@/app/comet-cards/domain/round/types'
 
@@ -129,7 +130,7 @@ const thePlant: BossBlindDefinition = {
       condition: (ctx: EffectContext) => ctx.event.type === 'HAND_SCORING_START',
       apply: (ctx: EffectContext) => {
         ctx.game.gamePlayState.cardsToScore = ctx.game.gamePlayState.cardsToScore.filter(
-          card => !['J', 'Q', 'K'].includes(playingCards[card.playingCardId].value)
+          card => !isFaceCard(playingCards[card.playingCardId].value, ctx.game)
         )
       },
     },
@@ -197,7 +198,7 @@ const theMark: BossBlindDefinition = {
         // Flip all face cards in the entire deck face down
         for (const cardId of Object.keys(ctx.game.cards)) {
           const card = ctx.game.cards[cardId]
-          if (['J', 'Q', 'K'].includes(playingCards[card.playingCardId].value)) {
+          if (isFaceCard(playingCards[card.playingCardId].value, ctx.game)) {
             card.isFaceUp = false
           }
         }


### PR DESCRIPTION
## Summary
- Implements Pareidolia uncommon joker ($5): "All cards are considered face cards"
- Creates `isFaceCard(value, game)` helper that respects `areAllCardsFaceCards` static rule
- Replaces all 12 inline `['J', 'Q', 'K'].includes()` checks with the new helper across jokers, boss blinds, and UI
- Joker follows the `fourFingersJoker` pattern: sets flag on GAME_START/JOKER_ADDED, clears on JOKER_REMOVED

Closes #760.

## Affected jokers/blinds
Scary Face, Smiley Face, Business Card, Photograph, Sock & Buskin, Faceless Joker, Reserved Parking, The Plant (boss), The Mark (boss), hand debuff display

## Test plan
- [ ] TypeScript compiles cleanly
- [ ] Pareidolia appears in shop rotation
- [ ] With Pareidolia: Scary Face/Smiley Face trigger on all cards, not just J/Q/K
- [ ] Selling Pareidolia reverts to normal face card behavior
- [ ] The Plant boss blind debuffs all cards when Pareidolia is active

🤖 Generated with [Claude Code](https://claude.com/claude-code)