### PR TITLE
feat: add deck runtime effects system

### DIFF
--- a/src/app/comet-cards/domain/decks/types.ts
+++ b/src/app/comet-cards/domain/decks/types.ts
@@ -1,4 +1,5 @@
 import { TarotCardDefinition } from '@/app/comet-cards/domain/consumable/types'
+import { Effect } from '@/app/comet-cards/domain/events/types'
 import { PlayingCardDefinition } from '@/app/comet-cards/domain/playing-card/types'
 import { VoucherType } from '@/app/comet-cards/domain/voucher/types'
 
@@ -8,6 +9,7 @@ export interface DeckDefinition {
   description: string
   cards: PlayingCardDefinition[]
   modifiers: DeckModifiers
+  effects?: Effect[]
 }
 
 export interface DeckModifiers {

--- a/src/app/comet-cards/domain/game/utils.ts
+++ b/src/app/comet-cards/domain/game/utils.ts
@@ -1,3 +1,4 @@
+import { decks } from '@/app/comet-cards/domain/decks/decks'
 import { dispatchEffects } from '@/app/comet-cards/domain/events/dispatch-effects'
 import type { Effect, EffectContext, GameEvent } from '@/app/comet-cards/domain/events/types'
 import { jokers } from '@/app/comet-cards/domain/joker/jokers'
@@ -59,6 +60,11 @@ export function collectEffects(game: GameState): Effect[] {
   effects.push(...game.vouchers.flatMap(v => vouchers[v.type]?.effects || []))
 
   effects.push(...game.tags.flatMap(t => tags[t.tagType]?.effects || []))
+
+  const deckDef = decks[game.selectedDeck]
+  if (deckDef?.effects) {
+    effects.push(...deckDef.effects)
+  }
 
   return effects
 }


### PR DESCRIPTION
## Summary
- Adds optional `effects?: Effect[]` field to `DeckDefinition` type
- Wires deck effects into `collectEffects()` so they participate in the event dispatch system alongside joker, boss blind, voucher, and tag effects
- Minimal change (2 files, 8 lines added) — no behavior change for existing decks since none define effects yet

Closes #1273. Unblocks Plasma Deck (#977) and Anaglyph Deck runtime effects.

## Test plan
- [ ] TypeScript compiles cleanly
- [ ] Existing decks unchanged (no effects defined)
- [ ] `collectEffects()` returns deck effects when present

🤖 Generated with [Claude Code](https://claude.com/claude-code)