### PR TITLE
fix: gameplay fills viewport height on mobile landscape

### DIFF
--- a/src/app/comet-cards/components/cosmic/shell.tsx
+++ b/src/app/comet-cards/components/cosmic/shell.tsx
@@ -10,7 +10,7 @@ export function CosmicShell({ children }: { children: ReactNode }) {
     <div
       className="cosmic-cards relative w-full overflow-hidden"
       style={{
-        height: '100vh',
+        height: '100dvh',
         background:
           'radial-gradient(ellipse at 15% 15%, var(--cc-bg-grad-1) 0%, var(--cc-bg-grad-2) 40%, var(--cc-bg-grad-3) 100%)',
         color: 'var(--cc-text-default)',

--- a/src/app/comet-cards/components/game-views/gameplay.tsx
+++ b/src/app/comet-cards/components/game-views/gameplay.tsx
@@ -206,7 +206,7 @@ export function GamePlayView() {
 
       {isLandscape ? (
         /* ── LANDSCAPE MOBILE: single-column flex ── */
-        <div className="relative z-10 flex flex-col" style={{ gap: 0 }}>
+        <div className="relative z-10 flex flex-col flex-1" style={{ gap: 0 }}>
           {/* Compact info bar */}
           <div
             className="flex flex-wrap items-center justify-between"
@@ -311,12 +311,14 @@ export function GamePlayView() {
           </div>
 
           {/* Play area + Hand */}
-          <LayoutGroup>
-            <PlayArea cards={playedCards} visible={isScoring} />
-            <div className="flex items-end justify-center" style={{ paddingBottom: 4, paddingTop: 4 }}>
-              <Hand sortKey={sortKey} />
-            </div>
-          </LayoutGroup>
+          <div className="flex-1 flex flex-col justify-end">
+            <LayoutGroup>
+              <PlayArea cards={playedCards} visible={isScoring} />
+              <div className="flex items-end justify-center" style={{ paddingBottom: 4, paddingTop: 4 }}>
+                <Hand sortKey={sortKey} />
+              </div>
+            </LayoutGroup>
+          </div>
 
           {/* Action bar */}
           <div


### PR DESCRIPTION
## Summary
- Uses `100dvh` instead of `100vh` in CosmicShell for accurate mobile viewport height (accounts for address bar)
- Makes landscape gameplay container flex-fill its parent
- Wraps play area + hand in a flex-grow container that pushes action buttons to the bottom

Fixes #1503.

## Test plan
- [ ] iPhone landscape: play/discard buttons sit at bottom of viewport, no dead space below
- [ ] Desktop layout unchanged (separate JSX branch)
- [ ] Other game phases (shop, blind select) still render correctly within CosmicShell

🤖 Generated with [Claude Code](https://claude.com/claude-code)