### PR TITLE
feat: improve DNA joker with counter-based tracking

### DIFF
--- a/src/app/comet-cards/domain/joker/jokers.ts
+++ b/src/app/comet-cards/domain/joker/jokers.ts
@@ -4637,32 +4637,47 @@ export const sixthSense: JokerDefinition = {
   rarity: 'uncommon',
 }
 
-export const dna: JokerDefinition = {
+const dnaBlindReset = {
+  priority: 1,
+  apply: (ctx: EffectContext) => {
+    const d = ctx.game.jokers.find(j => j.jokerId === 'dna')
+    if (d) d.counter = 0
+  },
+}
+
+export const dnaJoker: JokerDefinition = {
   id: 'dna',
   name: 'DNA',
   description: 'If first hand of round has only 1 card, add a permanent copy to deck and draw it to hand',
   price: 8,
   effects: [
+    { event: { type: 'SMALL_BLIND_SELECTED' }, ...dnaBlindReset },
+    { event: { type: 'BIG_BLIND_SELECTED' }, ...dnaBlindReset },
+    { event: { type: 'BOSS_BLIND_SELECTED' }, ...dnaBlindReset },
     {
       event: { type: 'HAND_SCORING_FINALIZE' },
       priority: 1,
       apply: (ctx: EffectContext) => {
-        if (ctx.game.handsPlayed !== 0) return
-        const selectedHand = ctx.game.gamePlayState.selectedHand
-        if (!selectedHand) return
-        const handCards = selectedHand[1]
-        if (!handCards || handCards.length !== 1) return
-        const originalCard = handCards[0]
-        const cardDef = playingCards[originalCard.playingCardId]
-        if (!cardDef) return
-        // Create a copy of the card
-        const newCard = initializePlayingCard(cardDef)
-        // Copy the original card's enchantment/edition/seal
-        newCard.flags = { ...originalCard.flags }
-        newCard.bonusChips = originalCard.bonusChips
-        addOwnedCard(ctx.game, newCard)
-        // Draw it to hand
-        ctx.game.gamePlayState.handIds.push(newCard.id)
+        const d = ctx.game.jokers.find(j => j.jokerId === 'dna')
+        if (!d || d.counter !== 0) return
+        d.counter = 1
+
+        if (ctx.game.gamePlayState.playedCardIds.length !== 1) return
+
+        const cardId = ctx.game.gamePlayState.playedCardIds[0]
+        const originalCard = ctx.game.cards[cardId]
+        if (!originalCard) return
+
+        const copyState: PlayingCardState = {
+          id: uuid(),
+          playingCardId: originalCard.playingCardId,
+          bonusChips: originalCard.bonusChips,
+          flags: { ...originalCard.flags },
+          isFaceUp: true,
+        }
+
+        addOwnedCard(ctx.game, copyState)
+        ctx.game.gamePlayState.handIds.push(copyState.id)
       },
     },
   ],
@@ -5232,7 +5247,7 @@ export const jokers: Record<JokerDefinition['id'], JokerDefinition> = {
   tradingCard,
   seance,
   sixthSense,
-  dna,
+  dna: dnaJoker,
   theIdol,
   mrBones,
   oopsAll6s,


### PR DESCRIPTION
## Summary
- Replaces the fragile `handsPlayed` check in the DNA joker with a counter-based approach
- Counter resets to 0 on each blind selection (SMALL/BIG/BOSS_BLIND_SELECTED)
- On HAND_SCORING_FINALIZE: if counter is 0 (first hand) and exactly 1 card played, clones card to deck and draws it to hand

Addresses #817.

## Test plan
- [ ] TypeScript compiles cleanly
- [ ] DNA triggers on first hand with 1 card played — card is cloned to deck and hand
- [ ] DNA does not trigger on subsequent hands
- [ ] DNA resets between blinds
- [ ] DNA does not trigger when more than 1 card is played

🤖 Generated with [Claude Code](https://claude.com/claude-code)