### PR TITLE
feat: implement Blueprint and Brainstorm jokers

### DIFF
--- a/src/app/comet-cards/domain/game/utils.ts
+++ b/src/app/comet-cards/domain/game/utils.ts
@@ -46,6 +46,31 @@ export function getBlindDefinition(type: BlindState['type'], round: RoundState):
   throw new Error(`Unknown blind type: ${type}`)
 }
 
+function resolveJokerEffects(
+  jokerIndex: number,
+  jokerStates: JokerState[],
+  depth: number = 0
+): Effect[] {
+  if (depth > 10) return []
+  const joker = jokerStates[jokerIndex]
+  if (!joker) return []
+  const def = jokers[joker.jokerId]
+  if (!def) return []
+
+  if (def.id === 'blueprint') {
+    const rightIndex = jokerIndex + 1
+    if (rightIndex >= jokerStates.length) return []
+    return resolveJokerEffects(rightIndex, jokerStates, depth + 1)
+  }
+
+  if (def.id === 'brainstorm') {
+    if (jokerStates.length === 0) return []
+    return resolveJokerEffects(0, jokerStates, depth + 1)
+  }
+
+  return def.effects
+}
+
 export function collectEffects(game: GameState): Effect[] {
   const effects: Effect[] = []
 
@@ -55,7 +80,7 @@ export function collectEffects(game: GameState): Effect[] {
     effects.push(...getBlindDefinition(blind.type, game.rounds[game.roundIndex]).effects)
   }
 
-  effects.push(...game.jokers.flatMap(j => jokers[j.jokerId]?.effects || []))
+  effects.push(...game.jokers.flatMap((_, i) => resolveJokerEffects(i, game.jokers)))
 
   effects.push(...game.vouchers.flatMap(v => vouchers[v.type]?.effects || []))
 

--- a/src/app/comet-cards/domain/joker/jokers.ts
+++ b/src/app/comet-cards/domain/joker/jokers.ts
@@ -5112,6 +5112,24 @@ export const mimeJoker: JokerDefinition = {
   rarity: 'uncommon',
 }
 
+export const blueprintJoker: JokerDefinition = {
+  id: 'blueprint',
+  name: 'Blueprint',
+  description: 'Copies ability of Joker to the right',
+  price: 10,
+  effects: [],
+  rarity: 'rare',
+}
+
+export const brainstormJoker: JokerDefinition = {
+  id: 'brainstorm',
+  name: 'Brainstorm',
+  description: 'Copies the ability of leftmost Joker',
+  price: 10,
+  effects: [],
+  rarity: 'rare',
+}
+
 export const jokers: Record<JokerDefinition['id'], JokerDefinition> = {
   swashbucklerJoker,
   walkieTalkieJoker,
@@ -5261,6 +5279,8 @@ export const jokers: Record<JokerDefinition['id'], JokerDefinition> = {
   luchador,
   pareidolia: pareidoliaJoker,
   mime: mimeJoker,
+  blueprint: blueprintJoker,
+  brainstorm: brainstormJoker,
 }
 
 /***


### PR DESCRIPTION
## Summary
- Adds `resolveJokerEffects()` function for dynamic joker effect copying with recursive chain resolution (depth limit: 10)
- Updates `collectEffects()` to use the resolver instead of direct effect lookup
- Implements Blueprint rare joker ($10): copies ability of joker to the right
- Implements Brainstorm rare joker ($10): copies ability of leftmost joker
- Both jokers have empty effects arrays — copying is handled transparently in the effect collection layer

Closes #1274, closes #829, closes #830.

## Edge cases handled
- Blueprint at rightmost position → no effect
- Brainstorm with empty joker list → no effect
- Blueprint → Blueprint → actual joker → chain resolves
- Blueprint → Brainstorm → leftmost joker → cross-reference resolves
- Depth > 10 → returns empty (prevents infinite loops)

## Test plan
- [ ] TypeScript compiles cleanly
- [ ] Blueprint copies right neighbor's effects during scoring
- [ ] Brainstorm copies leftmost joker's effects
- [ ] Existing jokers unaffected (resolveJokerEffects passes through non-copying jokers)
- [ ] Blueprint/Brainstorm chain resolution works

🤖 Generated with [Claude Code](https://claude.com/claude-code)