### PR TITLE
fix: compact shop actions on mobile landscape

### DIFF
--- a/src/app/comet-cards/components/game-views/shop.tsx
+++ b/src/app/comet-cards/components/game-views/shop.tsx
@@ -22,11 +22,13 @@ import {
   getIsSelectedCardPlayable,
 } from '@/app/comet-cards/domain/shop/utils'
 import { VOUCHER_PRICE } from '@/app/comet-cards/domain/voucher/constants'
+import { useLandscapeMobile } from '@/app/comet-cards/hooks/useLandscapeMobile'
 import { useGameState } from '@/app/comet-cards/useGameState'
 
 import { ViewTemplate } from './view-template'
 
 export function ShopView() {
+  const isLandscape = useLandscapeMobile()
   const { game } = useGameState()
   useEffect(() => {
     if (!game.shopState.isOpen) {
@@ -46,23 +48,39 @@ export function ShopView() {
   return (
     <ViewTemplate
       sidebarContentBottom={
-        <Panel title="Shop Actions">
-          <div className="flex flex-col" style={{ gap: 8, padding: '12px 16px' }}>
+        isLandscape ? (
+          <div className="flex items-center justify-center" style={{ gap: 8 }}>
             <PrimaryButton
-              style={{ width: '100%' }}
               onClick={() => eventEmitter.emit({ type: 'SHOP_SELECT_BLIND' })}
             >
               Continue → Blind
             </PrimaryButton>
             <DangerButton
-              style={{ width: '100%' }}
               disabled={game.money < rerollPrice}
               onClick={() => eventEmitter.emit({ type: 'SHOP_REROLL' })}
             >
               Reroll · ${rerollPrice}
             </DangerButton>
           </div>
-        </Panel>
+        ) : (
+          <Panel title="Shop Actions">
+            <div className="flex flex-col" style={{ gap: 8, padding: '12px 16px' }}>
+              <PrimaryButton
+                style={{ width: '100%' }}
+                onClick={() => eventEmitter.emit({ type: 'SHOP_SELECT_BLIND' })}
+              >
+                Continue → Blind
+              </PrimaryButton>
+              <DangerButton
+                style={{ width: '100%' }}
+                disabled={game.money < rerollPrice}
+                onClick={() => eventEmitter.emit({ type: 'SHOP_REROLL' })}
+              >
+                Reroll · ${rerollPrice}
+              </DangerButton>
+            </div>
+          </Panel>
+        )
       }
     >
       <div className="flex flex-col" style={{ gap: 18 }}>


### PR DESCRIPTION
## Summary
- On mobile landscape, renders Continue and Reroll buttons as a slim inline row (~40px) instead of a full Panel with header and padding (~130px)
- Desktop/portrait layout unchanged — still uses the Panel wrapper

Fixes #1509.

## Test plan
- [ ] Mobile landscape: shop actions are a thin bottom bar with inline buttons
- [ ] Desktop: shop actions still render in the sidebar Panel as before
- [ ] Both buttons remain functional (Continue, Reroll)

🤖 Generated with [Claude Code](https://claude.com/claude-code)