### PR TITLE
fix: spawn player at entry gate in new regions

### DIFF
--- a/src/app/api/v1/tap-tap-adventure/move-forward/services/moveForwardService.ts
+++ b/src/app/api/v1/tap-tap-adventure/move-forward/services/moveForwardService.ts
@@ -79,6 +79,13 @@ export async function moveForwardService(
       }
     })
 
+    // Spawn at the gate the player entered through (the exit leading back to their previous region)
+    const previousRegionId = existingLandmarkState?.regionId
+    const entryExit = previousRegionId
+      ? exitPositions.find(ep => ep.regionId === previousRegionId)
+      : undefined
+    const startPosition = entryExit?.position ?? { x: Math.round(regionSize / 2), y: Math.round(regionSize / 2) }
+
     const initializedCharacter: FantasyCharacter = {
       ...updatedCharacter,
       landmarkState: {
@@ -91,7 +98,7 @@ export async function moveForwardService(
         positionInRegion: 0,
         activeTargetIndex: 0,
         regionLength,
-        position: { x: Math.round(regionSize / 2), y: Math.round(regionSize / 2) },
+        position: startPosition,
         exitPosition: exitPositions[0]?.position ?? { x: Math.round(regionSize * 0.98), y: Math.round(regionSize / 2) },
         exitPositions,
         regionBounds: { width: regionSize, height: regionSize },


### PR DESCRIPTION
## Summary
- When entering a new region, the player now spawns at the gate they entered through instead of the center
- Uses the previous region's ID (from the old landmark state) to find the matching exit position in the new region
- Falls back to center for the very first region (no previous state)

Fixes #694.

## Test plan
- [ ] Enter a new region via an exit — player spawns at the border gate, not center
- [ ] First region (Green Meadows) still starts at center
- [ ] Exit positions remain correct and navigable

🤖 Generated with [Claude Code](https://claude.com/claude-code)