### PR TITLE
fix: respect prefers-reduced-motion in game animations

### DIFF
--- a/src/app/comet-cards/components/animations/ticking-number.tsx
+++ b/src/app/comet-cards/components/animations/ticking-number.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useEffect, useRef, useState } from 'react'
+import { useReducedMotion } from 'framer-motion'
 
 export function TickingNumber({
   value,
@@ -11,6 +12,7 @@ export function TickingNumber({
   duration?: number
   format?: (n: number) => string
 }) {
+  const reducedMotion = useReducedMotion()
   const [display, setDisplay] = useState(value)
   const prev = useRef(value)
   const raf = useRef<number | undefined>(undefined)
@@ -20,7 +22,10 @@ export function TickingNumber({
     const to = value
     prev.current = value
 
-    if (from === to) return
+    if (from === to || reducedMotion) {
+      setDisplay(to)
+      return
+    }
 
     const start = performance.now()
     const tick = (now: number) => {
@@ -31,7 +36,7 @@ export function TickingNumber({
     }
     raf.current = requestAnimationFrame(tick)
     return () => { if (raf.current) cancelAnimationFrame(raf.current) }
-  }, [value, duration])
+  }, [value, duration, reducedMotion])
 
   return <>{format ? format(display) : display.toLocaleString()}</>
 }

--- a/src/app/comet-cards/components/cosmic/shell.tsx
+++ b/src/app/comet-cards/components/cosmic/shell.tsx
@@ -1,12 +1,14 @@
 'use client'
 
 import Link from 'next/link'
+import { MotionConfig } from 'framer-motion'
 import { AmbientBG } from './ambient-bg'
 
 import type { ReactNode } from 'react'
 
 export function CosmicShell({ children }: { children: ReactNode }) {
   return (
+    <MotionConfig reducedMotion="user">
     <div
       className="cosmic-cards relative w-full overflow-hidden"
       style={{
@@ -41,5 +43,6 @@ export function CosmicShell({ children }: { children: ReactNode }) {
       </Link>
       <div className="relative z-10" style={{ display: 'flex', flexDirection: 'column', height: '100%' }}>{children}</div>
     </div>
+    </MotionConfig>
   )
 }


### PR DESCRIPTION
## Summary
- Wraps CosmicShell in `MotionConfig reducedMotion="user"` — all Framer Motion animations in the game automatically respect `prefers-reduced-motion`
- Adds `useReducedMotion()` to TickingNumber to skip number interpolation when reduced motion is preferred (shows final value instantly)

Closes #1512.

## UX principle
> "Assume reduced-motion and silent device as the baseline experience" — CLAUDE.md #8

## Test plan
- [ ] Enable "Reduce motion" in OS settings — card animations should be instant, numbers should jump to final value
- [ ] With motion enabled — all animations unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)