### PR TITLE
UI: pack opening card reveal animations

### DIFF
--- a/src/app/comet-cards/components/pack-open/celestial-card-open-booster-pack.tsx
+++ b/src/app/comet-cards/components/pack-open/celestial-card-open-booster-pack.tsx
@@ -6,8 +6,25 @@ import { BuyableCard } from '@/app/comet-cards/components/shop/buyable-card'
 import { eventEmitter } from '@/app/comet-cards/domain/events/event-emitter'
 import { useGameState } from '@/app/comet-cards/useGameState'
 import { Button } from '@/components/ui/button'
+import { motion, useReducedMotion } from 'framer-motion'
+
+const containerVariants = {
+  hidden: {},
+  visible: { transition: { staggerChildren: 0.1 } },
+}
+
+const itemVariants = {
+  hidden: { opacity: 0, y: 24, scale: 0.85 },
+  visible: {
+    opacity: 1,
+    y: 0,
+    scale: 1,
+    transition: { duration: 0.4, ease: [0.2, 0.9, 0.3, 1] },
+  },
+}
 
 export function CelestialCardOpenBoosterPack() {
+  const reducedMotion = useReducedMotion()
   const { game } = useGameState()
   if (!game.shopState.openPackState) return <div>No pack open</div>
   const cardsForSale = game.shopState.openPackState.cards
@@ -28,9 +45,14 @@ export function CelestialCardOpenBoosterPack() {
           <h2 className="text-xl font-bold">
             Select {game.shopState.openPackState.remainingCardsToSelect} cards
           </h2>
-          <div className="flex flex-wrap gap-2">
+          <motion.div
+            className="flex flex-wrap gap-2"
+            variants={containerVariants}
+            initial={reducedMotion ? false : 'hidden'}
+            animate="visible"
+          >
             {cardsForSale.map(buyableCard => (
-              <div key={buyableCard.card.id} className="flex flex-col gap-2">
+              <motion.div key={buyableCard.card.id} variants={itemVariants} className="flex flex-col gap-2">
                 <BuyableCard
                   key={buyableCard.card.id}
                   buyableCard={buyableCard}
@@ -48,9 +70,9 @@ export function CelestialCardOpenBoosterPack() {
                     Use
                   </Button>
                 )}
-              </div>
+              </motion.div>
             ))}
-          </div>
+          </motion.div>
         </div>
         {game.consumables.length > 0 && (
           <div className="flex flex-col items-end gap-2 w-1/4">

--- a/src/app/comet-cards/components/pack-open/joker-card-open-booster-pack.tsx
+++ b/src/app/comet-cards/components/pack-open/joker-card-open-booster-pack.tsx
@@ -6,8 +6,25 @@ import { BuyableCard } from '@/app/comet-cards/components/shop/buyable-card'
 import { eventEmitter } from '@/app/comet-cards/domain/events/event-emitter'
 import { useGameState } from '@/app/comet-cards/useGameState'
 import { Button } from '@/components/ui/button'
+import { motion, useReducedMotion } from 'framer-motion'
+
+const containerVariants = {
+  hidden: {},
+  visible: { transition: { staggerChildren: 0.1 } },
+}
+
+const itemVariants = {
+  hidden: { opacity: 0, y: 24, scale: 0.85 },
+  visible: {
+    opacity: 1,
+    y: 0,
+    scale: 1,
+    transition: { duration: 0.4, ease: [0.2, 0.9, 0.3, 1] },
+  },
+}
 
 export function JokerCardOpenBoosterPack() {
+  const reducedMotion = useReducedMotion()
   const { game } = useGameState()
   if (!game.shopState.openPackState) return <div>No pack open</div>
   const cardsForSale = game.shopState.openPackState.cards
@@ -29,9 +46,14 @@ export function JokerCardOpenBoosterPack() {
             Select {game.shopState.openPackState.remainingCardsToSelect} joker
             {game.shopState.openPackState.remainingCardsToSelect > 1 ? 's' : ''}
           </h2>
-          <div className="flex flex-wrap gap-2">
+          <motion.div
+            className="flex flex-wrap gap-2"
+            variants={containerVariants}
+            initial={reducedMotion ? false : 'hidden'}
+            animate="visible"
+          >
             {cardsForSale.map(buyableCard => (
-              <div key={buyableCard.card.id} className="flex flex-col gap-2">
+              <motion.div key={buyableCard.card.id} variants={itemVariants} className="flex flex-col gap-2">
                 <BuyableCard
                   key={buyableCard.card.id}
                   buyableCard={buyableCard}
@@ -49,9 +71,9 @@ export function JokerCardOpenBoosterPack() {
                     Select
                   </Button>
                 )}
-              </div>
+              </motion.div>
             ))}
-          </div>
+          </motion.div>
         </div>
         {game.consumables.length > 0 && (
           <div className="flex flex-col items-end gap-2 w-1/4">

--- a/src/app/comet-cards/components/pack-open/playing-card-open-booster-pack.tsx
+++ b/src/app/comet-cards/components/pack-open/playing-card-open-booster-pack.tsx
@@ -4,8 +4,25 @@ import { BuyableCard } from '@/app/comet-cards/components/shop/buyable-card'
 import { eventEmitter } from '@/app/comet-cards/domain/events/event-emitter'
 import { useGameState } from '@/app/comet-cards/useGameState'
 import { Button } from '@/components/ui/button'
+import { motion, useReducedMotion } from 'framer-motion'
+
+const containerVariants = {
+  hidden: {},
+  visible: { transition: { staggerChildren: 0.1 } },
+}
+
+const itemVariants = {
+  hidden: { opacity: 0, y: 24, scale: 0.85 },
+  visible: {
+    opacity: 1,
+    y: 0,
+    scale: 1,
+    transition: { duration: 0.4, ease: [0.2, 0.9, 0.3, 1] },
+  },
+}
 
 export function PlayingCardOpenBoosterPack() {
+  const reducedMotion = useReducedMotion()
   const { game } = useGameState()
   if (!game.shopState.openPackState) return <div>No pack open</div>
   const cardsForSale = game.shopState.openPackState.cards
@@ -15,9 +32,14 @@ export function PlayingCardOpenBoosterPack() {
       <h2 className="text-xl font-bold">
         Choose {game.shopState.openPackState.remainingCardsToSelect} cards
       </h2>
-      <div className="flex flex-wrap gap-2">
+      <motion.div
+        className="flex flex-wrap gap-2"
+        variants={containerVariants}
+        initial={reducedMotion ? false : 'hidden'}
+        animate="visible"
+      >
         {cardsForSale.map(buyableCard => (
-          <div key={buyableCard.card.id} className="flex flex-col gap-2">
+          <motion.div key={buyableCard.card.id} variants={itemVariants} className="flex flex-col gap-2">
             <BuyableCard
               key={buyableCard.card.id}
               buyableCard={buyableCard}
@@ -35,9 +57,9 @@ export function PlayingCardOpenBoosterPack() {
                 Select
               </Button>
             )}
-          </div>
+          </motion.div>
         ))}
-      </div>
+      </motion.div>
     </div>
   )
 }

--- a/src/app/comet-cards/components/pack-open/spectral-card-open-booster-pack.tsx
+++ b/src/app/comet-cards/components/pack-open/spectral-card-open-booster-pack.tsx
@@ -8,8 +8,25 @@ import { eventEmitter } from '@/app/comet-cards/domain/events/event-emitter'
 import { getIsSpectralCardPlayable } from '@/app/comet-cards/domain/shop/utils'
 import { useGameState } from '@/app/comet-cards/useGameState'
 import { Button } from '@/components/ui/button'
+import { motion, useReducedMotion } from 'framer-motion'
+
+const containerVariants = {
+  hidden: {},
+  visible: { transition: { staggerChildren: 0.1 } },
+}
+
+const itemVariants = {
+  hidden: { opacity: 0, y: 24, scale: 0.85 },
+  visible: {
+    opacity: 1,
+    y: 0,
+    scale: 1,
+    transition: { duration: 0.4, ease: [0.2, 0.9, 0.3, 1] },
+  },
+}
 
 export function SpectralCardOpenBoosterPack() {
+  const reducedMotion = useReducedMotion()
   const { game } = useGameState()
   if (!game.shopState.openPackState) return <div>No pack open</div>
   const cardsForSale = game.shopState.openPackState.cards
@@ -30,9 +47,14 @@ export function SpectralCardOpenBoosterPack() {
           <h2 className="text-xl font-bold">
             Select {game.shopState.openPackState.remainingCardsToSelect} cards
           </h2>
-          <div className="flex flex-wrap gap-2">
+          <motion.div
+            className="flex flex-wrap gap-2"
+            variants={containerVariants}
+            initial={reducedMotion ? false : 'hidden'}
+            animate="visible"
+          >
             {cardsForSale.map(buyableCard => (
-              <div key={buyableCard.card.id} className="flex flex-col gap-2">
+              <motion.div key={buyableCard.card.id} variants={itemVariants} className="flex flex-col gap-2">
                 <BuyableCard
                   key={buyableCard.card.id}
                   buyableCard={buyableCard}
@@ -51,9 +73,9 @@ export function SpectralCardOpenBoosterPack() {
                     Use
                   </Button>
                 )}
-              </div>
+              </motion.div>
             ))}
-          </div>
+          </motion.div>
         </div>
         {game.consumables.length > 0 && (
           <div className="flex flex-col items-end gap-2 w-1/4">

--- a/src/app/comet-cards/components/pack-open/tarot-card-open-booster-pack.tsx
+++ b/src/app/comet-cards/components/pack-open/tarot-card-open-booster-pack.tsx
@@ -8,8 +8,25 @@ import { eventEmitter } from '@/app/comet-cards/domain/events/event-emitter'
 import { getIsSelectedCardPlayable } from '@/app/comet-cards/domain/shop/utils'
 import { useGameState } from '@/app/comet-cards/useGameState'
 import { Button } from '@/components/ui/button'
+import { motion, useReducedMotion } from 'framer-motion'
+
+const containerVariants = {
+  hidden: {},
+  visible: { transition: { staggerChildren: 0.1 } },
+}
+
+const itemVariants = {
+  hidden: { opacity: 0, y: 24, scale: 0.85 },
+  visible: {
+    opacity: 1,
+    y: 0,
+    scale: 1,
+    transition: { duration: 0.4, ease: [0.2, 0.9, 0.3, 1] },
+  },
+}
 
 export function TarotCardOpenBoosterPack() {
+  const reducedMotion = useReducedMotion()
   const { game } = useGameState()
   if (!game.shopState.openPackState) return <div>No pack open</div>
   const cardsForSale = game.shopState.openPackState.cards
@@ -30,9 +47,14 @@ export function TarotCardOpenBoosterPack() {
           <h2 className="text-xl font-bold">
             Select {game.shopState.openPackState.remainingCardsToSelect} cards
           </h2>
-          <div className="flex flex-wrap gap-2">
+          <motion.div
+            className="flex flex-wrap gap-2"
+            variants={containerVariants}
+            initial={reducedMotion ? false : 'hidden'}
+            animate="visible"
+          >
             {cardsForSale.map(buyableCard => (
-              <div key={buyableCard.card.id} className="flex flex-col gap-2">
+              <motion.div key={buyableCard.card.id} variants={itemVariants} className="flex flex-col gap-2">
                 <BuyableCard
                   key={buyableCard.card.id}
                   buyableCard={buyableCard}
@@ -51,9 +73,9 @@ export function TarotCardOpenBoosterPack() {
                     Use
                   </Button>
                 )}
-              </div>
+              </motion.div>
             ))}
-          </div>
+          </motion.div>
         </div>
         {game.consumables.length > 0 && (
           <div className="flex flex-col items-end gap-2 w-1/4">


### PR DESCRIPTION
## Summary
- Cards in booster pack opening views now animate in with a staggered reveal: scale (0.85→1) + fade + slide-up, 0.1s between each card
- Applied consistently to all 5 pack types: playing card, joker, tarot, celestial, spectral
- Respects `prefers-reduced-motion` — cards appear instantly when reduced motion is preferred

## Metric target
Average session length — pack openings are a key moment of delight; animated reveals add anticipation and ceremony.

## Test plan
- [ ] Open each pack type (joker, playing card, tarot, celestial, spectral) — cards should stagger in
- [ ] Verify stagger timing feels snappy (~0.1s between cards, ~0.4s per card)
- [ ] Enable reduced-motion in OS settings — cards should appear instantly
- [ ] Mobile viewport — animation works in compact layout
- [ ] Select a card after reveal — selection/button interaction still works normally

Part of #1410

🤖 Generated with [Claude Code](https://claude.com/claude-code)