### PR TITLE
A11y: aria-label and aria-pressed on all card components

### DIFF
--- a/src/app/comet-cards/components/blind-selection/blind-card.tsx
+++ b/src/app/comet-cards/components/blind-selection/blind-card.tsx
@@ -33,7 +33,14 @@ export function BlindCard({
   const accent = BLIND_ACCENT[selectEventName] ?? 'var(--cc-mint)'
   const eyebrow = selectEventName === 'BOSS_BLIND_SELECTED' ? 'Boss Blind' : 'Blind'
 
+  const containerLabel = [
+    name,
+    `reward $${reward}`,
+    minimumScore !== undefined && `minimum score ${minimumScore.toString()}`,
+  ].filter(Boolean).join(', ')
+
   return (
+    <div role="region" aria-label={containerLabel}>
     <Panel className="flex w-full flex-col" title={eyebrow}>
       <div
         className="flex flex-col"
@@ -145,6 +152,7 @@ export function BlindCard({
         <PrimaryButton
           className="w-full"
           style={{ width: '100%' }}
+          aria-label={`Select ${name}`}
           disabled={disabled}
           onClick={() => eventEmitter.emit({ type: selectEventName })}
         >
@@ -154,6 +162,7 @@ export function BlindCard({
           <>
             <GhostButton
               style={{ width: '100%' }}
+              aria-label={`Skip ${name}, get ${tags[tag]?.name} tag`}
               disabled={disabled}
               onClick={() => eventEmitter.emit({ type: 'BLIND_SKIPPED' })}
             >
@@ -173,5 +182,6 @@ export function BlindCard({
         )}
       </div>
     </Panel>
+    </div>
   )
 }

--- a/src/app/comet-cards/components/cosmic/brand-card.tsx
+++ b/src/app/comet-cards/components/cosmic/brand-card.tsx
@@ -68,10 +68,20 @@ export function BrandCard({
 
   const borderColor = selected ? 'var(--cc-suit-color)' : 'var(--cc-card-border)'
 
+  const label = [
+    `${definition?.value ?? '?'} of ${suit}`,
+    debuffed && 'debuffed',
+    card.flags.enchantment !== 'none' && card.flags.enchantment,
+    card.flags.edition !== 'normal' && card.flags.edition,
+    card.flags.seal !== 'none' && `${card.flags.seal} seal`,
+  ].filter(Boolean).join(', ')
+
   if (isFaceDown) {
     return (
       <button
         type="button"
+        aria-label="Face-down card"
+        aria-pressed={selected}
         onClick={() => onClick?.(selected, card.id)}
         className="bc-card"
         data-selected={selected ? 'true' : 'false'}
@@ -129,6 +139,8 @@ export function BrandCard({
   return (
     <button
       type="button"
+      aria-label={label}
+      aria-pressed={selected}
       onClick={() => onClick?.(selected, card.id)}
       className="bc-card"
       data-selected={selected ? 'true' : 'false'}

--- a/src/app/comet-cards/components/cosmic/token-card.tsx
+++ b/src/app/comet-cards/components/cosmic/token-card.tsx
@@ -41,6 +41,9 @@ export function TokenCard({
   return (
     <button
       type="button"
+      aria-label={title}
+      aria-pressed={selected || undefined}
+      aria-disabled={disabled}
       onClick={onClick}
       disabled={disabled}
       className="bc-card flex flex-col"


### PR DESCRIPTION
## Summary
- **Playing cards** (`BrandCard`): announce value, suit, and modifiers to screen readers (e.g., "King of hearts, gold, foil, blue seal"). Face-down cards announce as "Face-down card". Selection state exposed via `aria-pressed`.
- **Token cards** (`TokenCard`): announce their title, expose selection via `aria-pressed`, mark disabled state with `aria-disabled`.
- **Blind selection**: cards wrapped in labeled regions ("Small Blind, reward $3, minimum score 300"). Select/Skip buttons have descriptive `aria-label`s.

## Metric target
**Session length** — keyboard/screen-reader users who couldn't identify cards can now play.

## Test plan
- [ ] Screen reader (VoiceOver/NVDA): navigate hand cards — each should announce value and suit
- [ ] Screen reader: select a card — "pressed" state should be announced
- [ ] Screen reader: navigate blind selection — blind name, reward, and score announced
- [ ] Screen reader: navigate shop jokers/consumables — title announced
- [ ] Visual regression: no visible changes to any card component

Part of #1519

🤖 Generated with [Claude Code](https://claude.com/claude-code)