### PR TITLE
Feature: persist Comet Cards game state in localStorage

### DIFF
--- a/src/app/comet-cards/store.ts
+++ b/src/app/comet-cards/store.ts
@@ -1,9 +1,11 @@
 'use client'
 
 import { create } from 'zustand'
+import { persist } from 'zustand/middleware'
 
 import type { GameEvent } from '@/app/comet-cards/domain/events/types'
 import type { GamePhase, GameState } from '@/app/comet-cards/domain/game/types'
+import { getCurrentDayAsSeedString } from '@/app/comet-cards/domain/randomness'
 
 import { defaultGameState } from './domain/game/default-game-state'
 import { reduceGame } from './domain/game/reduce-game'
@@ -17,12 +19,83 @@ export interface CometCardsStore {
   dispatch: (event: GameEvent) => void
 }
 
-export const useCometCardsStore = create<CometCardsStore>()(set => ({
-  game: defaultGameState,
-  setGame: game => set({ game }),
-  clearGame: () => set({ game: defaultGameState }),
-  setGamePhase: (gamePhase: GamePhase) => set(state => ({ game: { ...state.game, gamePhase } })),
-  addMoney: (amount: number) =>
-    set(state => ({ game: { ...state.game, money: state.game.money + amount } })),
-  dispatch: (event: GameEvent) => set(state => ({ game: reduceGame(state.game, event) })),
-}))
+/**
+ * Custom JSON serialization that handles bigint values.
+ * bigint is stored as `{ __bigint: "123" }` and restored on parse.
+ */
+function serialize(state: unknown): string {
+  return JSON.stringify(state, (_key, value) =>
+    typeof value === 'bigint' ? { __bigint: value.toString() } : value
+  )
+}
+
+function deserialize(str: string): unknown {
+  return JSON.parse(str, (_key, value) => {
+    if (value && typeof value === 'object' && '__bigint' in value) {
+      return BigInt(value.__bigint)
+    }
+    return value
+  })
+}
+
+export const useCometCardsStore = create<CometCardsStore>()(
+  persist(
+    set => ({
+      game: defaultGameState,
+      setGame: game => set({ game }),
+      clearGame: () => set({ game: defaultGameState }),
+      setGamePhase: (gamePhase: GamePhase) =>
+        set(state => ({ game: { ...state.game, gamePhase } })),
+      addMoney: (amount: number) =>
+        set(state => ({ game: { ...state.game, money: state.game.money + amount } })),
+      dispatch: (event: GameEvent) => set(state => ({ game: reduceGame(state.game, event) })),
+    }),
+    {
+      name: 'comet-cards-game',
+      partialize: state => ({ game: state.game }),
+      storage: {
+        getItem: name => {
+          if (typeof window === 'undefined') return null
+          const str = localStorage.getItem(name)
+          if (!str) return null
+          return deserialize(str) as { state: { game: GameState }; version: number }
+        },
+        setItem: (name, value) => {
+          if (typeof window === 'undefined') return
+          localStorage.setItem(name, serialize(value))
+        },
+        removeItem: name => {
+          if (typeof window === 'undefined') return
+          localStorage.removeItem(name)
+        },
+      },
+      version: 1,
+      migrate: (persisted, version) => {
+        if (version === 0 || !persisted) return { game: defaultGameState }
+        return persisted as { game: GameState }
+      },
+      merge: (persisted, current) => {
+        if (!persisted || typeof persisted !== 'object') return current
+
+        const persistedState = persisted as { game?: GameState }
+        if (!persistedState.game) return current
+
+        // If the persisted seed doesn't match today, start fresh
+        const todaySeed = getCurrentDayAsSeedString()
+        if (persistedState.game.gameSeed !== todaySeed) {
+          return current
+        }
+
+        // If the game was on mainMenu or gameOver, start fresh
+        if (
+          persistedState.game.gamePhase === 'mainMenu' ||
+          persistedState.game.gamePhase === 'gameOver'
+        ) {
+          return current
+        }
+
+        return { ...current, game: persistedState.game }
+      },
+    }
+  )
+)


### PR DESCRIPTION
## Summary
- Mid-game progress now survives page refresh via Zustand persist middleware with localStorage
- Custom serialization handles `bigint` (totalScore) — stored as `{ __bigint: "value" }` and restored on parse
- Smart hydration: stale seeds (different day) start fresh; mainMenu/gameOver states are not restored; only active games with today's seed are resumed
- Schema versioned (v1) for future migrations

## Design decisions
- **No hydration loading state**: initial render shows mainMenu (default), then hydration swaps to persisted phase via the existing AnimatePresence transition — feels natural, not jarring
- **Daily seed check**: ensures players can't resume yesterday's game on a new day
- **mainMenu/gameOver excluded**: no point persisting a completed or not-yet-started game

## Metric target
**Session length + daily return rate** — players who accidentally close the tab can resume their run. Foundation for run history tracking (#1521).

## Test plan
- [ ] Start a game, navigate to blind selection, refresh page — game should resume at blind selection
- [ ] Start a game, play through to shop, refresh — shop state preserved
- [ ] Complete a game (gameOver), refresh — should show mainMenu (fresh start)
- [ ] Play on day 1, come back day 2 — should show mainMenu (stale seed discarded)
- [ ] Open in incognito (no localStorage) — normal fresh start
- [ ] Check localStorage in DevTools — `comet-cards-game` key should exist with serialized state

Closes #1520

🤖 Generated with [Claude Code](https://claude.com/claude-code)