### PR TITLE
Feature: run history with best score and win/loss record

### DIFF
--- a/src/app/comet-cards/components/game-views/game-over.tsx
+++ b/src/app/comet-cards/components/game-views/game-over.tsx
@@ -1,12 +1,13 @@
 'use client'
 
-import { useCallback, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { motion } from 'framer-motion'
 
 import { PrimaryButton } from '@/app/comet-cards/components/cosmic/buttons'
 import { Panel } from '@/app/comet-cards/components/cosmic/panel'
 import { useGameState } from '@/app/comet-cards/useGameState'
 import { useLandscapeMobile } from '@/app/comet-cards/hooks/useLandscapeMobile'
+import { useRunHistory } from '@/app/comet-cards/hooks/useRunHistory'
 
 import { ViewTemplate } from './view-template'
 
@@ -45,10 +46,26 @@ async function copyToClipboard(text: string) {
 export function GameOverView() {
   const { game } = useGameState()
   const [hasCopied, setHasCopied] = useState(false)
+  const { addRun } = useRunHistory()
 
   const totalRounds = 8
   const roundsCompleted = Math.max(0, Math.min(totalRounds, game.roundIndex - 1))
   const didWin = roundsCompleted >= totalRounds
+
+  const hasSaved = useRef(false)
+  useEffect(() => {
+    if (hasSaved.current) return
+    hasSaved.current = true
+    addRun({
+      seed: game.gameSeed,
+      date: new Date().toISOString().split('T')[0],
+      totalScore: game.totalScore.toString(),
+      handsPlayed: game.handsPlayed,
+      roundsCompleted: Math.max(0, Math.min(totalRounds, game.roundIndex - 1)),
+      totalRounds,
+      won: didWin,
+    })
+  }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
   const shareText = useMemo(() => {
     const link = 'https://cometcave.com/comet-cards'

--- a/src/app/comet-cards/components/game-views/main-menu.tsx
+++ b/src/app/comet-cards/components/game-views/main-menu.tsx
@@ -6,6 +6,7 @@ import {
 } from '@/app/comet-cards/components/cosmic/buttons'
 import { eventEmitter } from '@/app/comet-cards/domain/events/event-emitter'
 import { useLandscapeMobile } from '@/app/comet-cards/hooks/useLandscapeMobile'
+import { useRunHistory } from '@/app/comet-cards/hooks/useRunHistory'
 
 const REFERENCE_BUTTONS = [
   { event: 'DISPLAY_JOKERS', label: 'Jokers' },
@@ -19,6 +20,7 @@ const REFERENCE_BUTTONS = [
 
 export function MainMenuView() {
   const isLandscape = useLandscapeMobile()
+  const { history } = useRunHistory()
   return (
     <div
       className="cc-scroll relative mx-auto flex flex-col items-center"
@@ -74,6 +76,39 @@ export function MainMenuView() {
       >
         Start Run
       </PrimaryButton>
+
+      {history.runs.length > 0 && (
+        <div
+          className="flex items-center justify-center gap-6"
+          style={{
+            fontFamily: 'var(--cc-font-mono)',
+            fontSize: 11,
+            opacity: 0.55,
+            letterSpacing: 1,
+          }}
+        >
+          <div>
+            <div style={{ fontSize: 18, fontWeight: 200, opacity: 1, color: 'var(--cc-mint)', letterSpacing: -0.5 }}>
+              {history.bestScore}
+            </div>
+            <div style={{ marginTop: 2 }}>Best Score</div>
+          </div>
+          <div style={{ width: 1, height: 28, background: 'var(--cc-panel-divider)' }} />
+          <div>
+            <div style={{ fontSize: 18, fontWeight: 200, opacity: 1, color: 'var(--cc-text-default)', letterSpacing: -0.5 }}>
+              {history.wins}–{history.losses}
+            </div>
+            <div style={{ marginTop: 2 }}>Record</div>
+          </div>
+          <div style={{ width: 1, height: 28, background: 'var(--cc-panel-divider)' }} />
+          <div>
+            <div style={{ fontSize: 18, fontWeight: 200, opacity: 1, color: 'var(--cc-text-default)', letterSpacing: -0.5 }}>
+              {history.runs.length}
+            </div>
+            <div style={{ marginTop: 2 }}>Runs</div>
+          </div>
+        </div>
+      )}
 
       <div
         className="w-full"

--- a/src/app/comet-cards/hooks/useRunHistory.ts
+++ b/src/app/comet-cards/hooks/useRunHistory.ts
@@ -1,0 +1,71 @@
+'use client'
+
+import { useCallback, useSyncExternalStore } from 'react'
+
+export interface RunSummary {
+  seed: string
+  date: string           // ISO date string (YYYY-MM-DD)
+  totalScore: string     // bigint stored as string for JSON safety
+  handsPlayed: number
+  roundsCompleted: number
+  totalRounds: number
+  won: boolean
+}
+
+export interface RunHistory {
+  runs: RunSummary[]
+  bestScore: string      // bigint as string
+  wins: number
+  losses: number
+}
+
+const STORAGE_KEY = 'comet-cards-run-history'
+const MAX_RUNS = 50
+
+function getRunHistory(): RunHistory {
+  if (typeof window === 'undefined') return { runs: [], bestScore: '0', wins: 0, losses: 0 }
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY)
+    if (!raw) return { runs: [], bestScore: '0', wins: 0, losses: 0 }
+    return JSON.parse(raw) as RunHistory
+  } catch {
+    return { runs: [], bestScore: '0', wins: 0, losses: 0 }
+  }
+}
+
+function saveRunHistory(history: RunHistory): void {
+  if (typeof window === 'undefined') return
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(history))
+}
+
+// Simple external store for useSyncExternalStore
+let listeners: Array<() => void> = []
+function subscribe(listener: () => void) {
+  listeners.push(listener)
+  return () => { listeners = listeners.filter(l => l !== listener) }
+}
+function emitChange() {
+  listeners.forEach(l => l())
+}
+
+export function useRunHistory() {
+  const history = useSyncExternalStore(subscribe, getRunHistory, () => ({ runs: [], bestScore: '0', wins: 0, losses: 0 }))
+
+  const addRun = useCallback((run: RunSummary) => {
+    const current = getRunHistory()
+    const newRuns = [run, ...current.runs].slice(0, MAX_RUNS)
+    const currentBest = BigInt(current.bestScore)
+    const runScore = BigInt(run.totalScore)
+    const newBest = runScore > currentBest ? run.totalScore : current.bestScore
+    const newHistory: RunHistory = {
+      runs: newRuns,
+      bestScore: newBest,
+      wins: current.wins + (run.won ? 1 : 0),
+      losses: current.losses + (run.won ? 0 : 1),
+    }
+    saveRunHistory(newHistory)
+    emitChange()
+  }, [])
+
+  return { history, addRun }
+}


### PR DESCRIPTION
## Summary
- Each completed run now saves a summary to localStorage (seed, score, rounds, win/loss, date)
- Main menu shows **Best Score**, **Win/Loss Record**, and **Total Runs** — only visible after at least one completed run
- Uses `useSyncExternalStore` for reactive reads from localStorage (lightweight, no extra Zustand store needed)
- Run history capped at 50 entries

## Design decisions
- **Separate from game store**: run history lives in its own localStorage key (`comet-cards-run-history`) to avoid coupling with the game state persistence
- **String scores**: bigint totalScore stored as string in JSON for safe serialization
- **One-time save**: `useRef` guard prevents double-saving on React strict mode re-renders
- **Progressive disclosure**: stats only appear after first run (per principle #1 — sign-up as reward)

## Metric target
**Daily return rate** — "beat my best score" and visible win/loss record create motivation to return.

## Test plan
- [ ] Complete a game → return to main menu → stats should appear (Best Score, Record, Runs)
- [ ] Complete another game with higher score → Best Score should update
- [ ] Complete a losing game → losses count increments
- [ ] Refresh page → stats persist from localStorage
- [ ] First visit (no history) → no stats section shown
- [ ] Mobile viewport → stats row wraps or fits cleanly

Closes #1521

🤖 Generated with [Claude Code](https://claude.com/claude-code)