### PR TITLE
A11y: arrow key navigation and focus outline for cards in hand

### DIFF
--- a/src/app/comet-cards/components/gameplay/hand.tsx
+++ b/src/app/comet-cards/components/gameplay/hand.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useMemo } from 'react'
+import { useCallback, useMemo, useRef } from 'react'
 
 import { AnimatePresence, motion } from 'framer-motion'
 
@@ -81,6 +81,22 @@ export const Hand = ({ sortKey = 'value' }: { sortKey?: HandSortKey } = {}) => {
     return ids
   }, [game, dealtCards])
 
+  const containerRef = useRef<HTMLDivElement>(null)
+
+  const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
+    if (e.key !== 'ArrowLeft' && e.key !== 'ArrowRight') return
+    const container = containerRef.current
+    if (!container) return
+    const buttons = Array.from(container.querySelectorAll<HTMLButtonElement>('button.bc-card'))
+    const currentIndex = buttons.indexOf(e.target as HTMLButtonElement)
+    if (currentIndex === -1) return
+    e.preventDefault()
+    const nextIndex = e.key === 'ArrowRight'
+      ? Math.min(currentIndex + 1, buttons.length - 1)
+      : Math.max(currentIndex - 1, 0)
+    buttons[nextIndex]?.focus()
+  }, [])
+
   const fanWidth = sortedCards.length
     ? CARD_W + (sortedCards.length - 1) * (CARD_W - OVERLAP)
     : CARD_W
@@ -88,6 +104,10 @@ export const Hand = ({ sortKey = 'value' }: { sortKey?: HandSortKey } = {}) => {
 
   return (
     <div
+      ref={containerRef}
+      role="toolbar"
+      aria-label="Cards in hand"
+      onKeyDown={handleKeyDown}
       className="relative mx-auto"
       style={
         {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -465,6 +465,11 @@ body {
   transform: translateY(var(--cc-card-lift, -16px));
 }
 
+.cosmic-cards .bc-card:focus-visible {
+  outline: 2px solid var(--cc-mint);
+  outline-offset: 2px;
+}
+
 /* Comet Cards — thin internal scrollbar utility */
 .cc-scroll {
   overflow-y: auto;


### PR DESCRIPTION
## Summary
- **Arrow Left/Right** moves keyboard focus between cards in the hand (toolbar pattern)
- **Focus-visible outline** (mint green, 2px) shows which card has keyboard focus
- Hand container has `role="toolbar"` and `aria-label="Cards in hand"` for screen readers
- Combined with aria-labels from #1522, keyboard-only users can now navigate, identify, and select cards

## Metric target
**Session length** — keyboard users who couldn't navigate cards can now fully play.

## Test plan
- [ ] Tab into the hand area — first card should receive focus with mint outline
- [ ] Press ArrowRight — focus moves to next card
- [ ] Press ArrowLeft — focus moves to previous card
- [ ] At first/last card, arrow key in that direction stays on current card (no wrap)
- [ ] Press Enter/Space on focused card — card toggles selection
- [ ] Mouse click still works normally (no regression)
- [ ] Focus outline only shows on keyboard navigation (not on mouse click)
- [ ] Mobile — no visual impact (focus-visible doesn't trigger on touch)

Part of #1519

🤖 Generated with [Claude Code](https://claude.com/claude-code)