### PR TITLE
Feature: daily replay prevention — show today's result on main menu

### DIFF
--- a/src/app/comet-cards/components/game-views/main-menu.tsx
+++ b/src/app/comet-cards/components/game-views/main-menu.tsx
@@ -20,7 +20,7 @@ const REFERENCE_BUTTONS = [
 
 export function MainMenuView() {
   const isLandscape = useLandscapeMobile()
-  const { history } = useRunHistory()
+  const { history, todayRun } = useRunHistory()
   return (
     <div
       className="cc-scroll relative mx-auto flex flex-col items-center"
@@ -58,24 +58,76 @@ export function MainMenuView() {
       >
         Daily Cards
       </h1>
-      <p
-        style={{
-          fontSize: 14,
-          opacity: 0.65,
-          maxWidth: 460,
-          lineHeight: 1.55,
-          margin: 0,
-        }}
-      >
-        A new run, every day. Stack chips, multiply, and bend the rules with jokers.
-      </p>
-
-      <PrimaryButton
-        style={{ padding: '14px 32px', fontSize: 13, letterSpacing: 3 }}
-        onClick={() => eventEmitter.emit({ type: 'GAME_START' })}
-      >
-        Start Run
-      </PrimaryButton>
+      {todayRun ? (
+        <>
+          <p
+            style={{
+              fontSize: 14,
+              opacity: 0.65,
+              maxWidth: 460,
+              lineHeight: 1.55,
+              margin: 0,
+              fontStyle: 'italic',
+            }}
+          >
+            You've already walked today's path. Return tomorrow for a new run.
+          </p>
+          <div
+            className="flex flex-col items-center"
+            style={{
+              fontFamily: 'var(--cc-font-mono)',
+              gap: 6,
+            }}
+          >
+            <div
+              style={{
+                fontSize: 11,
+                letterSpacing: 2,
+                textTransform: 'uppercase',
+                opacity: 0.45,
+              }}
+            >
+              Today's Score
+            </div>
+            <div
+              style={{
+                fontSize: 32,
+                fontWeight: 200,
+                letterSpacing: -1,
+                color: todayRun.won ? 'var(--cc-mint)' : 'var(--cc-pink)',
+                textShadow: todayRun.won
+                  ? '0 0 40px rgba(94,234,212,0.3)'
+                  : '0 0 40px rgba(255,107,157,0.3)',
+              }}
+            >
+              {todayRun.totalScore}
+            </div>
+            <div style={{ fontSize: 11, opacity: 0.5 }}>
+              {todayRun.won ? 'Victory' : 'Defeated'} · {todayRun.roundsCompleted}/{todayRun.totalRounds} rounds · {todayRun.handsPlayed} hands
+            </div>
+          </div>
+        </>
+      ) : (
+        <>
+          <p
+            style={{
+              fontSize: 14,
+              opacity: 0.65,
+              maxWidth: 460,
+              lineHeight: 1.55,
+              margin: 0,
+            }}
+          >
+            A new run, every day. Stack chips, multiply, and bend the rules with jokers.
+          </p>
+          <PrimaryButton
+            style={{ padding: '14px 32px', fontSize: 13, letterSpacing: 3 }}
+            onClick={() => eventEmitter.emit({ type: 'GAME_START' })}
+          >
+            Start Run
+          </PrimaryButton>
+        </>
+      )}
 
       {history.runs.length > 0 && (
         <div

--- a/src/app/comet-cards/hooks/useRunHistory.ts
+++ b/src/app/comet-cards/hooks/useRunHistory.ts
@@ -51,6 +51,9 @@ function emitChange() {
 export function useRunHistory() {
   const history = useSyncExternalStore(subscribe, getRunHistory, () => ({ runs: [], bestScore: '0', wins: 0, losses: 0 }))
 
+  const today = typeof window !== 'undefined' ? new Date().toISOString().split('T')[0] : ''
+  const todayRun = history.runs.find(r => r.date === today) ?? null
+
   const addRun = useCallback((run: RunSummary) => {
     const current = getRunHistory()
     const newRuns = [run, ...current.runs].slice(0, MAX_RUNS)
@@ -67,5 +70,5 @@ export function useRunHistory() {
     emitChange()
   }, [])
 
-  return { history, addRun }
+  return { history, todayRun, addRun }
 }


### PR DESCRIPTION
## Summary
- After completing today's daily run, the main menu replaces "Start Run" with today's score, win/loss status, and round progress
- Uses cosmic-narrator voice: *"You've already walked today's path. Return tomorrow for a new run."*
- Enforces one-shot-per-day gameplay (like Wordle) — each seed only playable once
- `useRunHistory` now exposes `todayRun` for easy date-based lookups

## Design decisions
- Score color: mint green for victory, pink for defeat — matches existing game-over styling
- Stats shown: score, win/loss, rounds completed, hands played — same data as share text
- No explicit "lock" — the Start button simply isn't rendered. Clean and honest.

## Metric target
**Daily return rate** — one-shot gameplay creates urgency ("I better focus") and reason to return tomorrow. This is the core daily-game mechanic.

## Test plan
- [ ] Complete a game → return to main menu → should show today's score, no Start Run button
- [ ] Win a game → "Victory" shown in mint green
- [ ] Lose a game → "Defeated" shown in pink
- [ ] New day (different date) → Start Run button reappears
- [ ] First visit (no history) → normal Start Run flow
- [ ] Stats row still shows below today's result
- [ ] Mobile viewport — today's result displays cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)