### PR TITLE
Fix: consumables hidden below fold on desktop

### DIFF
--- a/src/app/comet-cards/components/game-views/gameplay.tsx
+++ b/src/app/comet-cards/components/game-views/gameplay.tsx
@@ -894,9 +894,9 @@ export function GamePlayView() {
           </div>
 
           {/* RIGHT rail */}
-          <div className="flex flex-col gap-4">
+          <div className="flex flex-col gap-4" style={{ maxHeight: 'calc(100vh - 50px)', overflow: 'hidden' }}>
             <Panel title="Jokers" subtitle={`${game.jokers.length} / ${game.maxJokers} slots`}>
-              <div style={{ padding: 14, display: 'flex', flexWrap: 'wrap', gap: 10 }}>
+              <div className="cc-scroll" style={{ padding: 14, display: 'flex', flexWrap: 'wrap', gap: 10, maxHeight: '45vh', overflowY: 'auto' }}>
                 {game.jokers.map(joker => (
                   <Joker
                     key={joker.id}
@@ -935,7 +935,7 @@ export function GamePlayView() {
               title="Consumables"
               subtitle={`${countConsumableSlots(game.consumables)} / ${game.maxConsumables} slots`}
             >
-              <div style={{ padding: 14, display: 'flex', flexDirection: 'column', gap: 10 }}>
+              <div className="cc-scroll" style={{ padding: 14, display: 'flex', flexDirection: 'column', gap: 10, maxHeight: '35vh', overflowY: 'auto' }}>
                 {game.consumables.map(consumable => {
                   const def = getConsumableDefinition(consumable)
                   const isTarot = consumable.consumableType === 'tarotCard'


### PR DESCRIPTION
## Summary
- Right rail jokers panel capped at `max-height: 45vh` with internal scroll
- Consumables panel capped at `max-height: 35vh` with internal scroll
- Right rail container capped at `calc(100vh - 50px)` to prevent overflow
- Both panels use `.cc-scroll` for consistent thin scrollbar styling

## Root cause
The jokers panel had no height constraint, so wrapping joker cards pushed the consumables panel below the viewport. Since page scrolling is disabled (#1406), consumables became unreachable.

## Test plan
- [ ] Desktop with 5+ jokers — jokers panel scrolls internally, consumables visible below
- [ ] Desktop with few jokers — no scroll needed, layout unchanged
- [ ] Desktop with many consumables — consumables panel scrolls internally
- [ ] Scrollbar styling matches the cosmic theme (thin, mint-tinted)
- [ ] Mobile/landscape — no impact (different layout branch)

Fixes #1527

🤖 Generated with [Claude Code](https://claude.com/claude-code)