### PR TITLE
Fix: Riff-raff and Cartomancer jokers always picking same cards

### DIFF
--- a/src/app/comet-cards/domain/joker/jokers.ts
+++ b/src/app/comet-cards/domain/joker/jokers.ts
@@ -3214,6 +3214,7 @@ function applyRiffRaff(ctx: EffectContext) {
   const seed = buildSeedString([
     ctx.game.gameSeed,
     ctx.game.roundIndex.toString(),
+    ctx.event.type,
     'riffRaff',
   ])
   const indices = getRandomNumbersWithSeed({
@@ -3352,7 +3353,7 @@ export const riffRaff: JokerDefinition = {
 
 function applyCartomancer(ctx: EffectContext) {
   if (ctx.game.consumables.length >= ctx.game.maxConsumables) return
-  const seed = buildSeedString([ctx.game.gameSeed, ctx.game.roundIndex.toString(), 'cartomancer'])
+  const seed = buildSeedString([ctx.game.gameSeed, ctx.game.roundIndex.toString(), ctx.event.type, 'cartomancer'])
   const tarotCard = getRandomTarotCards(1, seed)[0]
   ctx.game.consumables.push(initializeTarotCard(tarotCard))
 }


### PR DESCRIPTION
## Summary
Both Riff-raff and Cartomancer jokers used a seed of `gameSeed + roundIndex + jokerName`, but they fire on all 3 blind types (small/big/boss) within a round. Since `roundIndex` is the same for all 3 blinds, the seed was identical — producing the same random selections each activation.

**Fix:** Include `ctx.event.type` (the blind selection event name) in the seed string so each blind produces different deterministic results.

## Test plan
- [ ] Own Riff-raff, play through multiple blinds in a round — different common jokers should appear each time
- [ ] Own Cartomancer, play through multiple blinds — different tarot cards each time
- [ ] Same seed produces same results (determinism preserved)

Fixes #1529, fixes #1530

🤖 Generated with [Claude Code](https://claude.com/claude-code)