### PR TITLE
Feature: allow replaying today's daily seed as practice

### DIFF
--- a/src/app/comet-cards/components/game-views/game-over.tsx
+++ b/src/app/comet-cards/components/game-views/game-over.tsx
@@ -46,15 +46,16 @@ async function copyToClipboard(text: string) {
 export function GameOverView() {
   const { game } = useGameState()
   const [hasCopied, setHasCopied] = useState(false)
-  const { addRun } = useRunHistory()
+  const { addRun, todayRun } = useRunHistory()
 
   const totalRounds = 8
   const roundsCompleted = Math.max(0, Math.min(totalRounds, game.roundIndex - 1))
   const didWin = roundsCompleted >= totalRounds
+  const isPractice = todayRun !== null
 
   const hasSaved = useRef(false)
   useEffect(() => {
-    if (hasSaved.current) return
+    if (hasSaved.current || isPractice) return
     hasSaved.current = true
     addRun({
       seed: game.gameSeed,
@@ -96,7 +97,7 @@ export function GameOverView() {
 
   const isLandscape = useLandscapeMobile()
   const accent = didWin ? 'var(--cc-mint)' : 'var(--cc-pink)'
-  const eyebrow = didWin ? 'Victory' : 'Run Ended'
+  const eyebrow = isPractice ? 'Practice Run' : didWin ? 'Victory' : 'Run Ended'
   const headline = didWin ? 'The cave aligns.' : 'The cave goes quiet.'
 
   return (

--- a/src/app/comet-cards/components/game-views/main-menu.tsx
+++ b/src/app/comet-cards/components/game-views/main-menu.tsx
@@ -70,7 +70,7 @@ export function MainMenuView() {
               fontStyle: 'italic',
             }}
           >
-            You've already walked today's path. Return tomorrow for a new run.
+            Today's path is walked. Play again to practice — your recorded score won't change.
           </p>
           <div
             className="flex flex-col items-center"
@@ -105,6 +105,24 @@ export function MainMenuView() {
             <div style={{ fontSize: 11, opacity: 0.5 }}>
               {todayRun.won ? 'Victory' : 'Defeated'} · {todayRun.roundsCompleted}/{todayRun.totalRounds} rounds · {todayRun.handsPlayed} hands
             </div>
+          </div>
+          <GhostButton
+            style={{ padding: '10px 24px', fontSize: 12, letterSpacing: 2 }}
+            onClick={() => eventEmitter.emit({ type: 'GAME_START' })}
+          >
+            Play Again
+          </GhostButton>
+          <div
+            style={{
+              fontFamily: 'var(--cc-font-mono)',
+              fontSize: 9,
+              letterSpacing: 1.5,
+              textTransform: 'uppercase',
+              opacity: 0.35,
+              marginTop: -12,
+            }}
+          >
+            Practice run — score won't be recorded
           </div>
         </>
       ) : (


### PR DESCRIPTION
## Summary
- "Play Again" button appears on the main menu after completing today's run
- Practice runs use the same daily seed but don't record a new score
- Clear labeling: "Practice run — score won't be recorded"
- Game-over screen shows "Practice Run" as the eyebrow for replay runs
- First completion remains the recorded daily score

## Test plan
- [ ] Complete today's run → main menu shows score + "Play Again" button
- [ ] Click Play Again → game starts with same seed
- [ ] Complete practice run → game-over shows "Practice Run" eyebrow
- [ ] Return to main menu → original score unchanged, stats unchanged
- [ ] First visit → normal "Start Run" flow (no practice label)

Closes #1538

🤖 Generated with [Claude Code](https://claude.com/claude-code)