### PR TITLE
Fix: add scoring log button to mobile landscape

### DIFF
--- a/src/app/comet-cards/components/game-views/gameplay.tsx
+++ b/src/app/comet-cards/components/game-views/gameplay.tsx
@@ -482,6 +482,26 @@ export function GamePlayView() {
                 Vouchers
               </button>
             )}
+            {gamePlayState.scoringEvents.length > 0 && (
+              <button
+                type="button"
+                onClick={() => setShowScoringFeed(true)}
+                style={{
+                  flexShrink: 0,
+                  padding: '3px 8px',
+                  borderRadius: 4,
+                  border: '1px solid rgba(94,234,212,0.15)',
+                  background: 'transparent',
+                  color: 'var(--cc-text-default)',
+                  fontFamily: 'var(--cc-font-mono)',
+                  fontSize: 10,
+                  cursor: 'pointer',
+                  opacity: 0.6,
+                }}
+              >
+                Score Log ({gamePlayState.scoringEvents.length})
+              </button>
+            )}
           </div>
           {/* Selected item actions */}
           {(selectedJoker || selectedConsumable) && (


### PR DESCRIPTION
## Summary
The scoring feed was only accessible from the desktop left sidebar. On mobile landscape, there was no way to view it.

Now a "Score Log" button appears in the mobile landscape button bar (alongside Deck, Hands, Vouchers) when scoring events exist. It opens the same scoring feed modal used on desktop.

## Test plan
- [ ] Mobile landscape — "Score Log (N)" button appears after scoring a hand
- [ ] Tap button — scoring feed modal opens with chips × mult breakdown
- [ ] No scoring events — button hidden
- [ ] Desktop — no change (existing GhostButton in sidebar unchanged)

Fixes #1528

🤖 Generated with [Claude Code](https://claude.com/claude-code)