### PR TITLE
Fix: Meteor/Buffoon tags never adding packs to shop

### DIFF
--- a/src/app/comet-cards/domain/game/handlers/shop.ts
+++ b/src/app/comet-cards/domain/game/handlers/shop.ts
@@ -49,7 +49,11 @@ import { vouchers } from '@/app/comet-cards/domain/voucher/vouchers'
 export function handleShopOpen(draft: GameState, event: GameEvent) {
   draft.shopState.isOpen = true
   draft.shopState.cardsForSale = []
-  // dispatch first to use any tag effects
+  draft.shopState.packsForSale = getRandomPacks(draft, 2)
+
+  // Dispatch tag/voucher/joker effects after initializing packs so effects
+  // that add packs (Meteor, Buffoon tags) or guaranteed cards can append
+  // without being overwritten.
   const ctx = getEffectContext(draft, event)
   dispatchEffects(event, ctx, collectEffects(ctx.game))
 
@@ -76,7 +80,6 @@ export function handleShopOpen(draft: GameState, event: GameEvent) {
     )
     draft.shopState.cardsForSale.push(...additionalCards)
   }
-  draft.shopState.packsForSale = getRandomPacks(draft, 2)
 
   // Coupon tag: make all initial items free
   const couponTag = draft.tags.find(t => t.tagType === 'coupon')


### PR DESCRIPTION
## Summary
Tag effects that add packs (Meteor → celestial pack, Buffoon → joker pack) were dispatched before `getRandomPacks()`, which then overwrote `packsForSale` entirely. The tag-added packs were silently lost.

**Fix:** Reorder `handleShopOpen`:
1. Initialize packs with `getRandomPacks()` first
2. Dispatch tag/voucher/joker effects (can now append packs + push guaranteed cards)
3. Process guaranteed items and fill remaining card slots

This also fixes the Buffoon tag and any future pack-adding effects.

## Test plan
- [x] Meteor tag test passes — mega celestial pack appears in `packsForSale`
- [x] Meteor tag consumed after use
- [x] Negative tag test passes — free negative joker appears in shop
- [x] Negative tag consumed after use
- [ ] Manual: skip a blind with Meteor tag → shop shows 3+ packs (2 random + 1 mega celestial)

Fixes #1542

🤖 Generated with [Claude Code](https://claude.com/claude-code)