### PR TITLE
Fix: Hallucination joker effect never fires on pack open

### DIFF
--- a/src/app/comet-cards/domain/joker/jokers.ts
+++ b/src/app/comet-cards/domain/joker/jokers.ts
@@ -2189,7 +2189,7 @@ export const hallucination: JokerDefinition = {
   price: 4,
   effects: [
     {
-      event: { type: 'SHOP_OPEN_PACK', id: '' },
+      event: { type: 'SHOP_OPEN_PACK' } as any,
       priority: 1,
       apply: (ctx: EffectContext) => {
         if (ctx.game.consumables.length >= ctx.game.maxConsumables) return


### PR DESCRIPTION
## Summary
- Found during audit for #1543 — Hallucination joker's effect had `event: { type: 'SHOP_OPEN_PACK', id: '' }` which prevented it from ever matching real pack-open events
- `dispatchEffects` does strict ID comparison when both events have an `id` field: `'' !== 'pack-1'` always fails
- Fix: removed the `id` field from the effect's event pattern so it matches ANY `SHOP_OPEN_PACK` event

## Audit findings (#1543)
Audited all vouchers, jokers, and tags that should trigger pack opens or create consumables:

| Entity | Type | Status |
|--------|------|--------|
| **Hallucination** | Joker | **BROKEN** — fixed in this PR |
| Standard/Charm/Meteor/Buffoon/Ethereal tags | Tags | Fixed in #1544 |
| 8 Ball, Superposition, Cartomancer, Vagabond | Jokers (tarot creators) | Working |
| Séance, Sixth Sense | Jokers (spectral creators) | Working |
| Perkeo | Joker (consumable copier) | Working |
| Riff-raff | Joker (joker creator) | Working |
| All 32 vouchers | Vouchers | None create packs/consumables |

## Test plan
- [x] All 3 Hallucination tests pass (were previously failing)
- [ ] Manual: equip Hallucination, open a pack, verify tarot card creation

🤖 Generated with [Claude Code](https://claude.com/claude-code)