### PR TITLE
Feature: add mini scoring log to gameplay view

### DIFF
--- a/src/app/comet-cards/components/game-views/gameplay.tsx
+++ b/src/app/comet-cards/components/game-views/gameplay.tsx
@@ -25,6 +25,7 @@ import { getJokerSellValue, getConsumableSellValue } from '@/app/comet-cards/dom
 import { eventEmitter } from '@/app/comet-cards/domain/events/event-emitter'
 import { scoreHand as domainScoreHand } from '@/app/comet-cards/domain/game/score-hand'
 import { isCustomScoringEvent } from '@/app/comet-cards/domain/game/types'
+import { MiniScoringLog } from '@/app/comet-cards/components/mini-scoring-log'
 import { calculateAnte, getBlindDefinition } from '@/app/comet-cards/domain/game/utils'
 import { pokerHands } from '@/app/comet-cards/domain/hand/hands'
 import { jokers as jokerDefinitions } from '@/app/comet-cards/domain/joker/jokers'
@@ -290,6 +291,17 @@ export function GamePlayView() {
               </span>
             )}
           </div>
+
+          {gamePlayState.handResults.length > 0 && (
+            <div
+              style={{
+                padding: '4px 12px',
+                borderBottom: '1px solid var(--cc-panel-divider)',
+              }}
+            >
+              <MiniScoringLog handResults={gamePlayState.handResults} />
+            </div>
+          )}
 
           {/* Score display */}
           <div className="flex flex-col items-center" style={{ paddingTop: 4 }}>
@@ -784,7 +796,19 @@ export function GamePlayView() {
               </div>
             </Panel>
 
-            {gamePlayState.scoringEvents.length > 0 && (
+            {gamePlayState.handResults.length > 0 && (
+              <Panel title="Scoring Log">
+                <div style={{ padding: '8px 16px' }}>
+                  <MiniScoringLog handResults={gamePlayState.handResults} />
+                </div>
+                <div style={{ padding: '4px 16px 8px' }}>
+                  <GhostButton onClick={() => setShowScoringFeed(true)} style={{ fontSize: 10, opacity: 0.6 }}>
+                    Full breakdown →
+                  </GhostButton>
+                </div>
+              </Panel>
+            )}
+            {gamePlayState.scoringEvents.length > 0 && gamePlayState.handResults.length === 0 && (
               <GhostButton onClick={() => setShowScoringFeed(true)}>
                 Scoring Feed ({gamePlayState.scoringEvents.length})
               </GhostButton>

--- a/src/app/comet-cards/components/mini-scoring-log.tsx
+++ b/src/app/comet-cards/components/mini-scoring-log.tsx
@@ -1,0 +1,52 @@
+import type { HandResult } from '@/app/comet-cards/domain/game/types'
+
+const handIdToName: Record<string, string> = {
+  highCard: 'High Card',
+  pair: 'Pair',
+  twoPair: 'Two Pair',
+  threeOfAKind: 'Three of a Kind',
+  straight: 'Straight',
+  flush: 'Flush',
+  fullHouse: 'Full House',
+  fourOfAKind: 'Four of a Kind',
+  straightFlush: 'Straight Flush',
+  flushHouse: 'Flush House',
+  fiveOfAKind: 'Five of a Kind',
+  flushFive: 'Flush Five',
+}
+
+export function MiniScoringLog({ handResults }: { handResults: HandResult[] }) {
+  if (handResults.length === 0) return null
+
+  // Show last 5 hands, most recent first
+  const recentHands = [...handResults].reverse().slice(0, 5)
+
+  return (
+    <div
+      style={{
+        fontFamily: 'var(--cc-font-mono)',
+        fontSize: 10,
+        lineHeight: 1.6,
+      }}
+    >
+      {recentHands.map((hand, i) => (
+        <div
+          key={i}
+          className="flex items-center justify-between gap-2"
+          style={{ opacity: i === 0 ? 1 : 0.6 }}
+        >
+          <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+            {handIdToName[hand.handType] ?? hand.handType}
+          </span>
+          <span style={{ flexShrink: 0 }}>
+            <span style={{ color: 'var(--cc-mint)' }}>{hand.chips}</span>
+            <span style={{ opacity: 0.4, margin: '0 2px' }}>×</span>
+            <span style={{ color: 'var(--cc-pink)' }}>{hand.mult}</span>
+            <span style={{ opacity: 0.4, margin: '0 4px' }}>=</span>
+            <span style={{ fontWeight: 600 }}>{hand.score.toLocaleString()}</span>
+          </span>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/src/app/comet-cards/domain/game/default-game-state.ts
+++ b/src/app/comet-cards/domain/game/default-game-state.ts
@@ -40,6 +40,7 @@ const gameState: GameState = {
     drawPileIds: [],
     handIds: [],
     handTypesPlayedThisRound: [],
+    handResults: [],
     handDealt: false,
     isDiscarding: false,
     isScoring: false,

--- a/src/app/comet-cards/domain/game/handlers.ts
+++ b/src/app/comet-cards/domain/game/handlers.ts
@@ -76,8 +76,14 @@ function decideHandEndOutcome(args: {
   return 'continue'
 }
 
-function resetScoreForNextHand(gamePlayState: Draft<GamePlayState>) {
+function resetScoreForNextHand(gamePlayState: Draft<GamePlayState>, handType?: string) {
   gamePlayState.isScoring = false
+  gamePlayState.handResults.push({
+    handType: handType ?? 'unknown',
+    chips: gamePlayState.score.chips,
+    mult: gamePlayState.score.mult,
+    score: Math.floor(gamePlayState.score.chips * gamePlayState.score.mult),
+  })
   gamePlayState.scoringEvents.push({
     id: uuid(),
     message: `Hand Score: ${gamePlayState.score.chips} x ${gamePlayState.score.mult}`,
@@ -124,7 +130,7 @@ export function handleHandScoringEnd(draft: Draft<GameState>, event: GameEvent) 
     const hasMrBones = draft.jokers.some(j => j.jokerId === 'mrBones')
     if (hasMrBones && blindScore * 4n >= ante) {
       draft.jokers = draft.jokers.filter(j => j.jokerId !== 'mrBones') as typeof draft.jokers
-      resetScoreForNextHand(draft.gamePlayState)
+      resetScoreForNextHand(draft.gamePlayState, playedHand)
       return
     }
     draft.gamePhase = 'gameOver'
@@ -167,7 +173,7 @@ export function handleHandScoringEnd(draft: Draft<GameState>, event: GameEvent) 
       currentBlind.additionalRewards.push(['Interest', interest])
     }
 
-    resetScoreForNextHand(draft.gamePlayState)
+    resetScoreForNextHand(draft.gamePlayState, playedHand)
 
     return
   }
@@ -178,5 +184,5 @@ export function handleHandScoringEnd(draft: Draft<GameState>, event: GameEvent) 
   const cardsNeeded = isSerpent ? 3 : HAND_SIZE + draft.handSizeModifier - draft.gamePlayState.handIds.length
   dealCardsFromDrawPile(draft as unknown as GameState, cardsNeeded)
   draft.gamePhase = 'gameplay'
-  resetScoreForNextHand(draft.gamePlayState)
+  resetScoreForNextHand(draft.gamePlayState, playedHand)
 }

--- a/src/app/comet-cards/domain/game/handlers/blind-selection.ts
+++ b/src/app/comet-cards/domain/game/handlers/blind-selection.ts
@@ -25,6 +25,7 @@ export function handleSmallBlindSelected(draft: GameState) {
   draft.gamePlayState.handIds = []
   draft.gamePlayState.handDealt = false
   draft.gamePlayState.discardPileIds = []
+  draft.gamePlayState.handResults = []
 }
 
 export function handleBigBlindSelected(draft: GameState) {
@@ -46,6 +47,7 @@ export function handleBigBlindSelected(draft: GameState) {
   draft.gamePlayState.handIds = []
   draft.gamePlayState.handDealt = false
   draft.gamePlayState.discardPileIds = []
+  draft.gamePlayState.handResults = []
 }
 
 export function handleBossBlindSelected(draft: GameState) {
@@ -67,6 +69,7 @@ export function handleBossBlindSelected(draft: GameState) {
   draft.gamePlayState.handIds = []
   draft.gamePlayState.handDealt = false
   draft.gamePlayState.discardPileIds = []
+  draft.gamePlayState.handResults = []
 }
 
 export function handleBlindSkipped(draft: GameState, event: GameEvent) {

--- a/src/app/comet-cards/domain/game/handlers/gameplay.ts
+++ b/src/app/comet-cards/domain/game/handlers/gameplay.ts
@@ -370,6 +370,7 @@ export function handleHandScoringDoneCardScoring(draft: GameState) {
   draft.gamePlayState.scoringEvents = []
   draft.gamePlayState.remainingDiscards = draft.maxDiscards
   draft.gamePlayState.handTypesPlayedThisRound = []
+  draft.gamePlayState.handResults = []
 
   // Reset shop state for the new shop session
   draft.shopState.isOpen = false

--- a/src/app/comet-cards/domain/game/types.ts
+++ b/src/app/comet-cards/domain/game/types.ts
@@ -96,6 +96,8 @@ export interface GamePlayState {
   // Track which hand types have been played this round (resets between blinds)
   handTypesPlayedThisRound: string[]
 
+  handResults: HandResult[]
+
   handDealt: boolean
   isDiscarding: boolean
   isScoring: boolean
@@ -132,6 +134,13 @@ export function isCustomScoringEvent(
 export interface ScoreState {
   chips: number
   mult: number
+}
+
+export interface HandResult {
+  handType: string  // e.g., 'pair', 'flush' — the PokerHandDefinition id
+  chips: number
+  mult: number
+  score: number  // chips * mult
 }
 
 export interface Stake {


### PR DESCRIPTION
## Summary
- Fixes #1547 — adds a compact, always-visible scoring log panel to the gameplay view
- Shows the last 5 hands played during the current blind with hand type, chips x mult = score
- Most recent hand highlighted, older hands dimmed
- Desktop: new "Scoring Log" panel in the left rail with "Full breakdown" link to the existing modal
- Mobile landscape: compact strip below the info bar

## Changes
- **Domain**: Added `HandResult` type and `handResults` array to `GamePlayState`, populated in `resetScoreForNextHand`, cleared on blind selection/clear
- **UI**: New `MiniScoringLog` component showing recent hands with color-coded chips/mult/score
- **Gameplay view**: Integrated into both desktop left rail and mobile landscape layouts

## Test plan
- [x] 594/595 tests pass (1 pre-existing failure unrelated)
- [ ] Manual: play a few hands, verify scoring log updates after each hand
- [ ] Manual: verify log clears when starting a new blind
- [ ] Manual: check mobile landscape layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)