### PR TITLE
Feature: show scoring log on game over and blind cleared views

### DIFF
--- a/src/app/comet-cards/components/game-views/blind-rewards.tsx
+++ b/src/app/comet-cards/components/game-views/blind-rewards.tsx
@@ -5,6 +5,7 @@ import { useEffect, useState } from 'react'
 import { PrimaryButton } from '@/app/comet-cards/components/cosmic/buttons'
 import { Panel } from '@/app/comet-cards/components/cosmic/panel'
 import { ViewTemplate } from '@/app/comet-cards/components/game-views/view-template'
+import { MiniScoringLog } from '@/app/comet-cards/components/mini-scoring-log'
 import { eventEmitter } from '@/app/comet-cards/domain/events/event-emitter'
 import { getBlindDefinition } from '@/app/comet-cards/domain/game/utils'
 import { getInProgressBlind } from '@/app/comet-cards/domain/round/blinds'
@@ -110,6 +111,29 @@ export function BlindRewardsView() {
             >
               Cash Out
             </PrimaryButton>
+
+            {game.gamePlayState.handResults.length > 0 && (
+              <div
+                style={{
+                  borderTop: '1px solid var(--cc-panel-divider)',
+                  paddingTop: 14,
+                }}
+              >
+                <div
+                  className="uppercase"
+                  style={{
+                    fontFamily: 'var(--cc-font-mono)',
+                    fontSize: 10,
+                    letterSpacing: 2,
+                    opacity: 0.55,
+                    marginBottom: 8,
+                  }}
+                >
+                  Hands Played
+                </div>
+                <MiniScoringLog handResults={game.gamePlayState.handResults} />
+              </div>
+            )}
           </div>
         </Panel>
       </div>

--- a/src/app/comet-cards/components/game-views/game-over.tsx
+++ b/src/app/comet-cards/components/game-views/game-over.tsx
@@ -5,6 +5,7 @@ import { motion } from 'framer-motion'
 
 import { PrimaryButton } from '@/app/comet-cards/components/cosmic/buttons'
 import { Panel } from '@/app/comet-cards/components/cosmic/panel'
+import { MiniScoringLog } from '@/app/comet-cards/components/mini-scoring-log'
 import { useGameState } from '@/app/comet-cards/useGameState'
 import { useLandscapeMobile } from '@/app/comet-cards/hooks/useLandscapeMobile'
 import { useRunHistory } from '@/app/comet-cards/hooks/useRunHistory'
@@ -228,7 +229,33 @@ export function GameOverView() {
                 )}
               </div>
             </FadeUp>
-            <FadeUp delay={0.9}>
+            {game.gamePlayState.handResults.length > 0 && (
+              <FadeUp delay={0.8}>
+                <div
+                  style={{
+                    width: '100%',
+                    borderTop: '1px solid var(--cc-panel-divider)',
+                    paddingTop: 14,
+                    textAlign: 'left',
+                  }}
+                >
+                  <div
+                    className="uppercase"
+                    style={{
+                      fontFamily: 'var(--cc-font-mono)',
+                      fontSize: 10,
+                      letterSpacing: 2,
+                      opacity: 0.55,
+                      marginBottom: 8,
+                    }}
+                  >
+                    Final Hands
+                  </div>
+                  <MiniScoringLog handResults={game.gamePlayState.handResults} />
+                </div>
+              </FadeUp>
+            )}
+            <FadeUp delay={1.0}>
               <PrimaryButton style={{ marginTop: 12 }} onClick={onShare}>
                 {hasCopied ? 'Copied' : 'Share Score'}
               </PrimaryButton>


### PR DESCRIPTION
## Summary
- Fixes #1540 — scoring log now appears on both Blind Cleared and Game Over screens
- Reuses the `MiniScoringLog` component from #1547 to show hand-by-hand breakdown
- Blind Cleared: "Hands Played" section below Cash Out button
- Game Over: "Final Hands" section with fade-in animation, between stats and share button

## Changes
- `blind-rewards.tsx` — added MiniScoringLog after rewards breakdown
- `game-over.tsx` — added MiniScoringLog with FadeUp animation, adjusted share button delay

## Test plan
- [ ] Manual: lose a blind, verify scoring log appears on Game Over screen
- [ ] Manual: win a blind, verify scoring log appears on Blind Cleared screen
- [ ] Manual: check mobile landscape layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)