### PR TITLE
fix: include blind type in tag randomization seed

### DIFF
--- a/src/app/comet-cards/domain/game/utils.ts
+++ b/src/app/comet-cards/domain/game/utils.ts
@@ -169,8 +169,8 @@ export function calculateInterest(draft: GameState): number {
 }
 
 export function populateTags(draft: GameState): void {
-  const bigBlindTag = getRandomTag(draft)
-  const smallBlindTag = getRandomTag(draft)
+  const bigBlindTag = getRandomTag(draft, 'bigBlind')
+  const smallBlindTag = getRandomTag(draft, 'smallBlind')
   draft.rounds[draft.roundIndex].bigBlind.tag = bigBlindTag
   draft.rounds[draft.roundIndex].smallBlind.tag = smallBlindTag
 }

--- a/src/app/comet-cards/domain/tag/utils.ts
+++ b/src/app/comet-cards/domain/tag/utils.ts
@@ -9,8 +9,8 @@ import { implementedTags as tags } from './tags'
 
 import type { TagState, TagType } from './types'
 
-export function getRandomTag(game: GameState): TagType {
-  const seed = buildSeedString([game.gameSeed, game.roundIndex.toString()])
+export function getRandomTag(game: GameState, blindType: string): TagType {
+  const seed = buildSeedString([game.gameSeed, game.roundIndex.toString(), blindType])
   const randomTagType = getRandomWeightedChoiceWithSeed({
     seed,
     weightedOptions: Object.values(tags).reduce(


### PR DESCRIPTION
## Summary

- `getRandomTag()` was seeded with only `gameSeed` and `roundIndex`, causing the same tag to be returned for both Small Blind and Big Blind in the first round when players skip blinds to receive tags.
- Added a `blindType: string` parameter to `getRandomTag()` and included it in the seed, so each blind produces a distinct random tag.

## Changes

- `/workspace/cometcave/src/app/comet-cards/domain/tag/utils.ts` — added `blindType` param and included it in the seed string
- `/workspace/cometcave/src/app/comet-cards/domain/game/utils.ts` — passed `'bigBlind'` and `'smallBlind'` as the blind type at each call site in `populateTags()`

## Test plan

- [ ] Start a game and skip both the Small Blind and Big Blind — verify they receive different tags
- [ ] Confirm existing tests pass (only pre-existing unrelated failure in `mounts.test.ts`)

Fixes #1554

🤖 Generated with [Claude Code](https://claude.com/claude-code)