### PR TITLE
feat: show card prices directly in shop

### DIFF
--- a/src/app/comet-cards/components/game-views/shop.tsx
+++ b/src/app/comet-cards/components/game-views/shop.tsx
@@ -112,6 +112,8 @@ export function ShopView() {
                     {game.shopState.cardsForSale.map((buyableCard, i) => (
                       <motion.div
                         key={buyableCard.card.id}
+                        className="flex flex-col items-center"
+                        style={{ gap: 4 }}
                         initial={reducedMotion ? false : { opacity: 0, y: 20, scale: 0.9 }}
                         animate={{ opacity: 1, y: 0, scale: 1 }}
                         transition={{
@@ -124,6 +126,21 @@ export function ShopView() {
                           buyableCard={buyableCard}
                           isSelected={game.shopState.selectedCardId === buyableCard.card.id}
                         />
+                        <span
+                          style={{
+                            fontFamily: 'var(--cc-font-mono)',
+                            fontSize: 11,
+                            fontWeight: 600,
+                            color: canAffordToBuy(Math.floor(buyableCard.price * game.shopState.priceMultiplier), game)
+                              ? 'var(--cc-gold)'
+                              : 'var(--cc-text-default)',
+                            opacity: canAffordToBuy(Math.floor(buyableCard.price * game.shopState.priceMultiplier), game)
+                              ? 1
+                              : 0.4,
+                          }}
+                        >
+                          ${Math.floor(buyableCard.price * game.shopState.priceMultiplier)}
+                        </span>
                       </motion.div>
                     ))}
                   </div>


### PR DESCRIPTION
## Summary
- Adds a small price badge below each card for sale in the shop view
- Affordable cards show the price in gold (`--cc-gold`), unaffordable cards are dimmed to 0.4 opacity
- `priceMultiplier` is applied so clearance sale discounts are reflected correctly

## Changes
- `/workspace/cometcave/src/app/comet-cards/components/game-views/shop.tsx` — wrapped each `BuyableCard` in a `flex-col` container and added an 11px mono `<span>` below showing the price

## Test plan
- [ ] Open the shop in-game and verify each card displays a price below it
- [ ] Verify gold price appears when player can afford the card
- [ ] Verify dimmed price appears when player cannot afford the card
- [ ] Verify price reflects the `priceMultiplier` (e.g. during a clearance sale voucher)
- [ ] TypeScript check passes (`npx tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)