### PR TITLE
fix: distinguish owned jokers from for-sale cards in shop

### DIFF
--- a/src/app/comet-cards/components/cosmic/token-card.tsx
+++ b/src/app/comet-cards/components/cosmic/token-card.tsx
@@ -16,6 +16,7 @@ export function TokenCard({
   accent = 'var(--cc-mint)',
   selected = false,
   disabled = false,
+  muted = false,
   size = 'md',
   badge,
   onClick,
@@ -29,6 +30,7 @@ export function TokenCard({
   accent?: string
   selected?: boolean
   disabled?: boolean
+  muted?: boolean
   size?: TokenCardSize
   badge?: ReactNode
   onClick?: () => void
@@ -38,6 +40,29 @@ export function TokenCard({
 }) {
   const dims = SIZES[size]
   const isInteractive = !!onClick && !disabled
+
+  let border: string
+  let boxShadow: string
+  let opacity: number
+
+  if (muted && selected) {
+    border = `1px solid color-mix(in srgb, ${accent} 50%, transparent)`
+    boxShadow = `0 0 0 2px color-mix(in srgb, ${accent} 20%, transparent), var(--cc-card-shadow-base)`
+    opacity = 0.9
+  } else if (muted) {
+    border = `1px solid color-mix(in srgb, ${accent} 25%, transparent)`
+    boxShadow = 'var(--cc-card-shadow-base)'
+    opacity = 0.8
+  } else if (selected) {
+    border = `1px solid ${accent}`
+    boxShadow = `0 0 0 2px color-mix(in srgb, ${accent} 33%, transparent), 0 0 28px ${accent}, var(--cc-card-shadow-selected-tail)`
+    opacity = disabled ? 0.55 : 1
+  } else {
+    border = '1px solid var(--cc-card-border)'
+    boxShadow = `0 0 12px color-mix(in srgb, ${accent} 10%, transparent), var(--cc-card-shadow-base)`
+    opacity = disabled ? 0.55 : 1
+  }
+
   return (
     <button
       type="button"
@@ -55,12 +80,10 @@ export function TokenCard({
         textAlign: 'left',
         background: 'var(--cc-card-bg)',
         borderRadius: 12,
-        border: `1px solid ${selected ? accent : 'var(--cc-card-border)'}`,
-        boxShadow: selected
-          ? `0 0 0 2px color-mix(in srgb, ${accent} 33%, transparent), 0 0 28px ${accent}, var(--cc-card-shadow-selected-tail)`
-          : `0 0 12px color-mix(in srgb, ${accent} 10%, transparent), var(--cc-card-shadow-base)`,
+        border,
+        boxShadow,
         cursor: isInteractive ? 'pointer' : disabled ? 'not-allowed' : 'default',
-        opacity: disabled ? 0.55 : 1,
+        opacity,
         overflow: 'hidden',
         flex: 'none',
         padding: 0,

--- a/src/app/comet-cards/components/game-views/shop.tsx
+++ b/src/app/comet-cards/components/game-views/shop.tsx
@@ -90,11 +90,9 @@ export function ShopView() {
           subtitle={`$${game.money} on hand`}
         >
           <div className="flex flex-col" style={{ padding: 16, gap: 18 }}>
-            {game.jokers.length > 0 && (
-              <SectionHeader label="Jokers in Play">
-                <CurrentJokers />
-              </SectionHeader>
-            )}
+            <SectionHeader label="Your Jokers">
+              <CurrentJokers muted />
+            </SectionHeader>
 
             {/* Two-column grid: Cards for Sale (left) | Voucher + Booster Packs (right) */}
             <div

--- a/src/app/comet-cards/components/gameplay/joker.tsx
+++ b/src/app/comet-cards/components/gameplay/joker.tsx
@@ -48,6 +48,7 @@ export const Joker = ({
   gameSeed,
   roundIndex,
   activated,
+  muted,
 }: {
   joker: JokerState
   isSelected?: boolean
@@ -56,6 +57,7 @@ export const Joker = ({
   gameSeed?: string
   roundIndex?: number
   activated?: boolean
+  muted?: boolean
 }) => {
   const def = jokers[joker.jokerId]
   const accent = RARITY_ACCENT[def?.rarity ?? 'common'] ?? 'var(--cc-mint)'
@@ -209,6 +211,7 @@ export const Joker = ({
         glyph="✺"
         accent={accent}
         selected={isSelected}
+        muted={muted}
         size="sm"
         badge={badge}
         typeLabel="Joker"

--- a/src/app/comet-cards/components/joker/current-jokers.tsx
+++ b/src/app/comet-cards/components/joker/current-jokers.tsx
@@ -4,7 +4,7 @@ import { eventEmitter } from '@/app/comet-cards/domain/events/event-emitter'
 import { jokers } from '@/app/comet-cards/domain/joker/jokers'
 import { useGameState } from '@/app/comet-cards/useGameState'
 
-export const CurrentJokers = () => {
+export const CurrentJokers = ({ muted }: { muted?: boolean }) => {
   const { game } = useGameState()
   const selectedJoker = game.jokers.find(joker => joker.id === game.gamePlayState.selectedJokerId)
   const selectedJokerDefinition = selectedJoker ? jokers[selectedJoker.jokerId] : undefined
@@ -12,23 +12,37 @@ export const CurrentJokers = () => {
   return (
     <div className="flex flex-col gap-2">
       <div className="flex flex-wrap gap-3">
-        {game.jokers.map(joker => (
-          <Joker
-            key={joker.id}
-            joker={joker}
-            isSelected={game.gamePlayState.selectedJokerId === joker.id}
-            ownedCardCount={game.ownedCardIds.length}
-            gameSeed={game.gameSeed}
-            roundIndex={game.roundIndex}
-            onClick={(isSelected, id) => {
-              if (isSelected) {
-                eventEmitter.emit({ type: 'JOKER_DESELECTED', id })
-              } else {
-                eventEmitter.emit({ type: 'JOKER_SELECTED', id })
-              }
+        {game.jokers.length === 0 ? (
+          <div
+            style={{
+              fontFamily: 'var(--cc-font-mono)',
+              fontSize: 11,
+              opacity: 0.45,
+              letterSpacing: 0.5,
             }}
-          />
-        ))}
+          >
+            No jokers yet — buy one from the shop below
+          </div>
+        ) : (
+          game.jokers.map(joker => (
+            <Joker
+              key={joker.id}
+              joker={joker}
+              muted={muted}
+              isSelected={game.gamePlayState.selectedJokerId === joker.id}
+              ownedCardCount={game.ownedCardIds.length}
+              gameSeed={game.gameSeed}
+              roundIndex={game.roundIndex}
+              onClick={(isSelected, id) => {
+                if (isSelected) {
+                  eventEmitter.emit({ type: 'JOKER_DESELECTED', id })
+                } else {
+                  eventEmitter.emit({ type: 'JOKER_SELECTED', id })
+                }
+              }}
+            />
+          ))
+        )}
       </div>
       {selectedJokerDefinition && (
         <div>


### PR DESCRIPTION
## Summary
- Owned jokers in the shop now render with a **muted** visual treatment (reduced glow, subtler border, 0.8 opacity) so they're clearly distinct from the flashier for-sale cards
- The "Your Jokers" section always renders — when the player has zero jokers, a placeholder reads *"No jokers yet — buy one from the shop below"*
- Renamed section header from "Jokers in Play" → "Your Jokers" for clarity in the shop context

## Changes
| File | What |
|---|---|
| `token-card.tsx` | Added `muted` prop with subdued border/shadow/opacity |
| `joker.tsx` | Accepts + forwards `muted` to `TokenCard` |
| `current-jokers.tsx` | Passes `muted` to jokers, empty-state placeholder |
| `shop.tsx` | Always shows joker section, passes `muted` |

## Test plan
- [ ] Open the shop with 1+ jokers — owned jokers should appear visually muted compared to for-sale cards
- [ ] Click an owned joker to select it — should still highlight (slightly brighter than muted default) and show "Sell" button
- [ ] Open the shop with 0 jokers — "Your Jokers" section visible with "No jokers yet" message
- [ ] Open a booster pack — `CurrentJokers` there should render normally (not muted)

Closes #1562

🤖 Generated with [Claude Code](https://claude.com/claude-code)