### PR TITLE
feat: guarantee basic joker pack in first shop

### DIFF
--- a/src/app/comet-cards/domain/booster-pack/__tests__/first-shop-joker-pack.test.ts
+++ b/src/app/comet-cards/domain/booster-pack/__tests__/first-shop-joker-pack.test.ts
@@ -12,6 +12,27 @@ describe('first shop joker pack guarantee', () => {
     expect(hasJokerPack).toBe(true)
   })
 
+  it('guaranteed joker pack is always normal rarity', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.roundIndex = 1
+    // Test many seeds — whenever the guarantee fires (packs[0] replaced),
+    // the joker pack must be normal rarity
+    let guaranteeFired = 0
+    for (let i = 0; i < 50; i++) {
+      game.gameSeed = `rarity-test-${i}`
+      const packs = getRandomPacks(game, 2)
+      const pack0IsJoker = packs[0].cards.some(c => c.type === 'jokerCard')
+      const pack1IsJoker = packs[1].cards.some(c => c.type === 'jokerCard')
+      // If pack0 is joker but pack1 is not, the guarantee almost certainly fired
+      if (pack0IsJoker && !pack1IsJoker) {
+        guaranteeFired++
+        expect(packs[0].rarity).toBe('normal')
+      }
+    }
+    // The guarantee should fire for most seeds given ~8.7% natural joker chance
+    expect(guaranteeFired).toBeGreaterThan(0)
+  })
+
   it('does not force a joker pack in later rounds', () => {
     // Just verify the function doesn't error for round 2+
     const game: GameState = structuredClone(defaultGameState)

--- a/src/app/comet-cards/domain/booster-pack/utils.ts
+++ b/src/app/comet-cards/domain/booster-pack/utils.ts
@@ -189,23 +189,9 @@ const getRandomPack = (game: GameState, packIndex: number): PackState => {
 export const getRandomPacks = (game: GameState, numberOfPacks = 2): PackState[] => {
   const packs = Array.from({ length: numberOfPacks }, (_, index) => getRandomPack(game, index))
 
-  // First shop of the run: guarantee at least one joker pack
-  if (game.roundIndex === 1 && !packs.some(p => p.cards[0]?.type === 'jokerCard')) {
-    // Replace the first pack with a joker pack
-    const seed = buildSeedString([
-      game.gameSeed,
-      game.roundIndex.toString(),
-      game.shopState.rerollsUsed.toString(),
-      '0',
-      'packRarity',
-    ])
-    const rarityWeights = packRarityWeightsByType.jokerCard
-    const randomRarity =
-      getRandomWeightedChoiceWithSeed({
-        seed,
-        weightedOptions: rarityWeights,
-      }) ?? 'normal'
-    packs[0] = initializePackState(game, getPackDefinition('jokerCard', randomRarity))
+  // First shop of the run: guarantee a basic (normal-rarity) joker pack
+  if (game.roundIndex === 1 && !packs.some(p => p.cards[0]?.type === 'jokerCard' && p.rarity === 'normal')) {
+    packs[0] = initializePackState(game, getPackDefinition('jokerCard', 'normal'))
   }
 
   return packs


### PR DESCRIPTION
## Summary
- First shop of every run now always includes a **normal-rarity** (basic, $4) joker pack
- If no normal joker pack appears naturally among the random packs, `packs[0]` is replaced with one
- Added test verifying the guaranteed pack is always normal rarity

## Why
Starting a run without affordable joker access feels bad. A mega joker pack ($8) may appear but isn't always affordable early. Guaranteeing the basic pack ensures every run has a meaningful, accessible decision point in shop 1.

## Test plan
- [x] Existing tests pass (guarantees joker pack in round 1, no forced pack in later rounds)
- [x] New test: guaranteed pack is always normal rarity across 50 seeds
- [ ] Manual: start a new run — first shop should always show a basic joker pack

Closes #1564

🤖 Generated with [Claude Code](https://claude.com/claude-code)