### PR TITLE
feat: visible focus indicators for all Comet Cards buttons

### DIFF
--- a/src/app/comet-cards/components/cosmic/buttons.tsx
+++ b/src/app/comet-cards/components/cosmic/buttons.tsx
@@ -15,7 +15,7 @@ export function PrimaryButton({
   return (
     <button
       type="button"
-      className={`disabled:cursor-not-allowed disabled:opacity-35 ${className}`}
+      className={`cc-btn disabled:cursor-not-allowed disabled:opacity-35 ${className}`}
       style={{
         ...monoLabel,
         background: 'linear-gradient(180deg, var(--cc-mint), var(--cc-mint-hi))',
@@ -44,7 +44,7 @@ export function DangerButton({
   return (
     <button
       type="button"
-      className={`disabled:cursor-not-allowed disabled:opacity-35 ${className}`}
+      className={`cc-btn disabled:cursor-not-allowed disabled:opacity-35 ${className}`}
       style={{
         ...monoLabel,
         background: 'var(--cc-pink-bg)',
@@ -72,7 +72,7 @@ export function GhostButton({
   return (
     <button
       type="button"
-      className={`disabled:cursor-not-allowed disabled:opacity-35 ${className}`}
+      className={`cc-btn disabled:cursor-not-allowed disabled:opacity-35 ${className}`}
       style={{
         ...monoLabel,
         fontWeight: 600,
@@ -104,6 +104,7 @@ export function SortPill({
   return (
     <button
       type="button"
+      className="cc-btn"
       onClick={onClick}
       style={{
         background: 'transparent',

--- a/src/app/comet-cards/components/cosmic/shell.tsx
+++ b/src/app/comet-cards/components/cosmic/shell.tsx
@@ -37,7 +37,7 @@ export function CosmicShell({ children }: { children: ReactNode }) {
           borderRadius: 6,
           transition: 'color 0.15s',
         }}
-        className="hover:!text-white"
+        className="cc-btn hover:!text-white"
       >
         ✕
       </Link>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -465,7 +465,8 @@ body {
   transform: translateY(var(--cc-card-lift, -16px));
 }
 
-.cosmic-cards .bc-card:focus-visible {
+.cosmic-cards .bc-card:focus-visible,
+.cosmic-cards .cc-btn:focus-visible {
   outline: 2px solid var(--cc-mint);
   outline-offset: 2px;
 }


### PR DESCRIPTION
## Summary
- Adds `:focus-visible` outline (2px mint, matching card focus style) to all action buttons and the exit link
- Introduces shared `cc-btn` class on PrimaryButton, DangerButton, GhostButton, SortPill, and exit link
- Cards already had focus styles via `.bc-card:focus-visible`; this extends coverage to all remaining interactive elements

## Why
Keyboard users couldn't see which button was focused. This is a baseline accessibility requirement per UX principle #8.

## Test plan
- [ ] Tab through the gameplay view — Play Hand, Discard, Sort buttons should show mint focus ring
- [ ] Tab through the shop view — Buy, Reroll, Continue buttons should show focus ring  
- [ ] Tab to the exit (✕) link — should show focus ring
- [ ] Cards still show their existing focus ring (no regression)
- [ ] Mouse clicks should NOT show focus ring (`:focus-visible` only triggers on keyboard)

Partial fix for #1519

🤖 Generated with [Claude Code](https://claude.com/claude-code)