### PR TITLE
fix: respect prefers-reduced-motion on game-over + aria-label on ItemRow

### DIFF
--- a/src/app/comet-cards/components/cosmic/item-row.tsx
+++ b/src/app/comet-cards/components/cosmic/item-row.tsx
@@ -17,7 +17,8 @@ export function ItemRow({
     <button
       type="button"
       onClick={onClick}
-      className="flex w-full items-start gap-3 rounded-md p-2.5 text-left transition-colors"
+      aria-label={`${name}: ${description}`}
+      className="cc-btn flex w-full items-start gap-3 rounded-md p-2.5 text-left transition-colors"
       style={{
         background: selected
           ? `color-mix(in srgb, ${accent} 14%, transparent)`

--- a/src/app/comet-cards/components/game-views/game-over.tsx
+++ b/src/app/comet-cards/components/game-views/game-over.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { motion } from 'framer-motion'
+import { motion, useReducedMotion } from 'framer-motion'
 
 import { PrimaryButton } from '@/app/comet-cards/components/cosmic/buttons'
 import { Panel } from '@/app/comet-cards/components/cosmic/panel'
@@ -13,11 +13,12 @@ import { useRunHistory } from '@/app/comet-cards/hooks/useRunHistory'
 import { ViewTemplate } from './view-template'
 
 function FadeUp({ children, delay = 0 }: { children: React.ReactNode; delay?: number }) {
+  const reducedMotion = useReducedMotion()
   return (
     <motion.div
-      initial={{ opacity: 0, y: 16 }}
+      initial={reducedMotion ? false : { opacity: 0, y: 16 }}
       animate={{ opacity: 1, y: 0 }}
-      transition={{ duration: 0.4, delay, ease: [0.2, 0.9, 0.3, 1] }}
+      transition={reducedMotion ? { duration: 0 } : { duration: 0.4, delay, ease: [0.2, 0.9, 0.3, 1] }}
     >
       {children}
     </motion.div>
@@ -48,6 +49,7 @@ export function GameOverView() {
   const { game } = useGameState()
   const [hasCopied, setHasCopied] = useState(false)
   const { addRun, todayRun } = useRunHistory()
+  const reducedMotion = useReducedMotion()
 
   const totalRounds = 8
   const roundsCompleted = Math.max(0, Math.min(totalRounds, game.roundIndex - 1))
@@ -151,9 +153,9 @@ export function GameOverView() {
               </div>
             </FadeUp>
             <motion.div
-              initial={{ opacity: 0, y: 16, scale: 0.8 }}
+              initial={reducedMotion ? false : { opacity: 0, y: 16, scale: 0.8 }}
               animate={{ opacity: 1, y: 0, scale: 1 }}
-              transition={{ duration: 0.5, delay: 0.45, ease: [0.2, 0.9, 0.3, 1] }}
+              transition={reducedMotion ? { duration: 0 } : { duration: 0.5, delay: 0.45, ease: [0.2, 0.9, 0.3, 1] }}
             >
               <div
                 style={{


### PR DESCRIPTION
## Summary
- **Game-over screen** now respects `prefers-reduced-motion`: all `FadeUp` animations and the score reveal skip transitions when reduced motion is preferred
- **ItemRow** buttons now have `aria-label` built from name + description for screen reader users, plus the `cc-btn` class for focus indicators

## Why
UX Principle #8 requires "assume reduced-motion and silent device as baseline." The game-over screen — the most emotionally intense moment — was the one place that didn't honor this. Other views (shop, blind selection, blind rewards) already had this check.

## Test plan
- [ ] Enable `prefers-reduced-motion: reduce` in browser dev tools, trigger game over — elements should appear instantly without animation
- [ ] With reduced motion off, game over should animate as before
- [ ] Tab to an ItemRow (e.g., in consumables or joker list) — screen reader should announce name and description

🤖 Generated with [Claude Code](https://claude.com/claude-code)