### PR TITLE
ui: add Comet Cards to nav and home page, remove Secret Word and Chat from nav

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8,6 +8,7 @@ import { ROUTE_CONSTANTS } from './route-constants'
 
 const games: readonly { title: string; icon: string; href: string; description: string; hot?: boolean }[] = [
   { title: 'Daily Trivia', icon: 'quiz', href: ROUTE_CONSTANTS.TRIVIA, description: 'Test your knowledge with daily AI-curated questions', hot: true },
+  { title: 'Comet Cards', icon: 'style', href: ROUTE_CONSTANTS.COMET_CARDS, description: 'Daily Cards — Stack chips, multiply, and bend the rules with jokers' },
   { title: 'I-Ching Oracle', icon: 'auto_awesome', href: ROUTE_CONSTANTS.ORACLE, description: 'Seek wisdom and guidance from the ancient I-Ching' },
   { title: 'Tap Tap Adventure', icon: 'swords', href: ROUTE_CONSTANTS.TAP_TAP_ADVENTURE, description: 'Tap to travel, fight monsters, and collect loot' },
   { title: 'Secret Word', icon: 'lock', href: ROUTE_CONSTANTS.SECRET_WORD, description: 'Guess the secret word!' },

--- a/src/components/top-nav-bar.tsx
+++ b/src/components/top-nav-bar.tsx
@@ -13,8 +13,7 @@ const navItems: readonly { href: string; label: string; exact?: boolean }[] = [
   { href: ROUTE_CONSTANTS.TRIVIA, label: 'TRIVIA' },
   { href: ROUTE_CONSTANTS.ORACLE, label: 'ORACLE' },
   { href: ROUTE_CONSTANTS.TAP_TAP_ADVENTURE, label: 'TAP TAP' },
-  { href: ROUTE_CONSTANTS.CHAT_ROOM, label: 'CHAT' },
-  { href: ROUTE_CONSTANTS.SECRET_WORD, label: 'SECRET WORD' },
+  { href: ROUTE_CONSTANTS.COMET_CARDS, label: 'COMET CARDS' },
   { href: ROUTE_CONSTANTS.VOTERS, label: 'VOTERS' },
 ]
 


### PR DESCRIPTION
## Summary

- Added "COMET CARDS" nav link (pointing to `/comet-cards`) to the main nav, replacing the removed "SECRET WORD" and "CHAT" links
- Added Comet Cards game tile to the home page Arcade Floor grid with description "Daily Cards — Stack chips, multiply, and bend the rules with jokers"
- Secret Word and Chat Room of Infinity remain on the home page; only removed from nav

## Test plan

- [ ] Nav shows: HOME, TRIVIA, ORACLE, TAP TAP, COMET CARDS, VOTERS (no SECRET WORD or CHAT)
- [ ] COMET CARDS nav link routes to `/comet-cards`
- [ ] Home page Arcade Floor grid includes a Comet Cards tile
- [ ] Secret Word and Chat Room of Infinity tiles remain on home page
- [ ] `npm run build` passes with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)