### PR TITLE
feat: highlight and animate jokers during scoring

### DIFF
--- a/src/app/comet-cards/components/game-views/gameplay.tsx
+++ b/src/app/comet-cards/components/game-views/gameplay.tsx
@@ -15,6 +15,7 @@ import { Panel } from '@/app/comet-cards/components/cosmic/panel'
 import { Hand, type HandSortKey } from '@/app/comet-cards/components/gameplay/hand'
 import { PlayArea } from '@/app/comet-cards/components/gameplay/play-area'
 import { Joker } from '@/app/comet-cards/components/gameplay/joker'
+import { JokerActivationLabel } from '@/app/comet-cards/components/gameplay/joker-activation-label'
 import { Deck } from '@/app/comet-cards/components/global/deck'
 import { Hands } from '@/app/comet-cards/components/hands/hands'
 import { TickingNumber } from '@/app/comet-cards/components/animations/ticking-number'
@@ -35,6 +36,7 @@ import { useCometCardsStore } from '@/app/comet-cards/store'
 import { useGameState } from '@/app/comet-cards/useGameState'
 import { useLandscapeMobile } from '@/app/comet-cards/hooks/useLandscapeMobile'
 import { useRunHistory } from '@/app/comet-cards/hooks/useRunHistory'
+import { useJokerActivationSequence } from '@/app/comet-cards/hooks/useJokerActivationSequence'
 
 const RARITY_ACCENT: Record<string, string> = {
   common: 'var(--cc-mint)',
@@ -98,16 +100,12 @@ export function GamePlayView() {
     return Math.min(100, Math.max(0, (numerator / denom) * 100))
   }, [currentBlind, targetScore])
 
-  const activatedJokerNames = useMemo(() => {
-    if (!isScoring) return new Set<string>()
-    const names = new Set<string>()
-    for (const evt of gamePlayState.scoringEvents) {
-      if ('source' in evt && evt.source) {
-        names.add(evt.source)
-      }
-    }
-    return names
-  }, [isScoring, gamePlayState.scoringEvents])
+  const {
+    activeJokerName,
+    activeJokerLabel,
+    firedJokerNames,
+    activationKey,
+  } = useJokerActivationSequence()
 
   const prevProgressRef = useRef(0)
   const [blindMet, setBlindMet] = useState(false)
@@ -382,11 +380,13 @@ export function GamePlayView() {
           >
             {game.jokers.map(joker => {
               const def = jokerDefinitions[joker.jokerId]
+              const isJokerActive = activeJokerName === def.name
+              const isJokerMuted = isScoring && firedJokerNames.size > 0 && !firedJokerNames.has(def.name) && activeJokerName !== def.name
               return (
                 <button
                   key={joker.id}
                   type="button"
-                  className={activatedJokerNames.has(def.name) ? 'joker-activated' : undefined}
+                  className={isJokerActive ? 'joker-activated' : undefined}
                   onClick={() => {
                     if (gamePlayState.selectedJokerId === joker.id) {
                       eventEmitter.emit({ type: 'JOKER_DESELECTED', id: joker.id })
@@ -395,6 +395,7 @@ export function GamePlayView() {
                     }
                   }}
                   style={{
+                    position: 'relative',
                     flexShrink: 0,
                     padding: '3px 8px',
                     borderRadius: 4,
@@ -404,10 +405,18 @@ export function GamePlayView() {
                     fontFamily: 'var(--cc-font-mono)',
                     fontSize: 10,
                     cursor: 'pointer',
-                    boxShadow: activatedJokerNames.has(def.name) ? `0 0 10px ${RARITY_ACCENT[def.rarity] ?? 'var(--cc-mint)'}` : undefined,
+                    boxShadow: isJokerActive ? `0 0 10px ${RARITY_ACCENT[def.rarity] ?? 'var(--cc-mint)'}` : undefined,
+                    opacity: isJokerMuted ? 0.35 : 1,
+                    transition: 'opacity 0.2s',
                   }}
                 >
                   ✺ {def.name}
+                  {isJokerActive && activeJokerLabel && (
+                    <JokerActivationLabel
+                      label={activeJokerLabel}
+                      activationKey={activationKey}
+                    />
+                  )}
                 </button>
               )
             })}
@@ -948,24 +957,41 @@ export function GamePlayView() {
           <div className="flex flex-col gap-4" style={{ maxHeight: 'calc(100vh - 50px)', overflow: 'hidden' }}>
             <Panel title="Jokers" subtitle={`${game.jokers.length} / ${game.maxJokers} slots`}>
               <div className="cc-scroll" style={{ padding: 14, display: 'flex', flexWrap: 'wrap', gap: 10, maxHeight: '45vh', overflowY: 'auto' }}>
-                {game.jokers.map(joker => (
-                  <Joker
-                    key={joker.id}
-                    joker={joker}
-                    isSelected={gamePlayState.selectedJokerId === joker.id}
-                    ownedCardCount={game.ownedCardIds.length}
-                    gameSeed={game.gameSeed}
-                    roundIndex={game.roundIndex}
-                    activated={activatedJokerNames.has(jokerDefinitions[joker.jokerId]?.name ?? '')}
-                    onClick={(isSelected, id) => {
-                      if (isSelected) {
-                        eventEmitter.emit({ type: 'JOKER_DESELECTED', id })
-                      } else {
-                        eventEmitter.emit({ type: 'JOKER_SELECTED', id })
-                      }
-                    }}
-                  />
-                ))}
+                {game.jokers.map(joker => {
+                  const def = jokerDefinitions[joker.jokerId]
+                  const jokerName = def?.name ?? ''
+                  const isJokerActive = activeJokerName === jokerName
+                  const isJokerMuted = isScoring && firedJokerNames.size > 0 && !firedJokerNames.has(jokerName) && activeJokerName !== jokerName
+                  return (
+                    <div
+                      key={isJokerActive ? `${joker.id}-${activationKey}` : joker.id}
+                      style={{ position: 'relative' }}
+                    >
+                      <Joker
+                        joker={joker}
+                        isSelected={gamePlayState.selectedJokerId === joker.id}
+                        ownedCardCount={game.ownedCardIds.length}
+                        gameSeed={game.gameSeed}
+                        roundIndex={game.roundIndex}
+                        activated={isJokerActive}
+                        muted={isJokerMuted}
+                        onClick={(isSelected, id) => {
+                          if (isSelected) {
+                            eventEmitter.emit({ type: 'JOKER_DESELECTED', id })
+                          } else {
+                            eventEmitter.emit({ type: 'JOKER_SELECTED', id })
+                          }
+                        }}
+                      />
+                      {isJokerActive && activeJokerLabel && (
+                        <JokerActivationLabel
+                          label={activeJokerLabel}
+                          activationKey={activationKey}
+                        />
+                      )}
+                    </div>
+                  )
+                })}
                 {Array.from({ length: Math.max(0, game.maxJokers - game.jokers.length) }).map(
                   (_, i) => (
                     <EmptySlot key={`joker-empty-${i}`} />

--- a/src/app/comet-cards/components/gameplay/joker-activation-label.tsx
+++ b/src/app/comet-cards/components/gameplay/joker-activation-label.tsx
@@ -1,0 +1,108 @@
+'use client'
+
+import { useReducedMotion } from 'framer-motion'
+
+export type JokerLabelType = 'chips' | 'mult' | 'xmult' | 'mixed'
+
+interface JokerActivationLabelProps {
+  label: string
+  activationKey: number
+}
+
+/**
+ * Derives a label type from the label string for color selection.
+ * Checks for prefix patterns: "x" → xmult, "+N chips" → chips, "+N mult" → mult, else mixed.
+ */
+function getLabelType(label: string): JokerLabelType {
+  const trimmed = label.trim()
+  if (trimmed.startsWith('x')) return 'xmult'
+  if (trimmed.includes('chips') && !trimmed.includes('mult')) return 'chips'
+  if (trimmed.includes('mult') && !trimmed.includes('chips')) return 'mult'
+  return 'mixed'
+}
+
+/**
+ * Floating pill that appears above a joker card when it activates during scoring.
+ * Animates upward and fades out. Under prefers-reduced-motion, shows a static badge instead.
+ */
+export function JokerActivationLabel({ label, activationKey }: JokerActivationLabelProps) {
+  const reducedMotion = useReducedMotion()
+  const type = getLabelType(label)
+
+  const colorMap: Record<JokerLabelType, string> = {
+    chips: 'var(--cc-mint)',
+    mult: 'var(--cc-pink)',
+    xmult: 'var(--cc-gold)',
+    mixed: 'var(--cc-mint)',
+  }
+
+  const bgMap: Record<JokerLabelType, string> = {
+    chips: 'rgba(94, 234, 212, 0.18)',
+    mult: 'rgba(255, 107, 157, 0.18)',
+    xmult: 'rgba(255, 209, 102, 0.18)',
+    mixed: 'rgba(94, 234, 212, 0.12)',
+  }
+
+  const color = colorMap[type]
+  const bg = bgMap[type]
+
+  if (reducedMotion) {
+    // Static badge — no animation, just a visible pill
+    return (
+      <div
+        aria-hidden
+        style={{
+          position: 'absolute',
+          bottom: 'calc(100% + 4px)',
+          left: '50%',
+          transform: 'translateX(-50%)',
+          zIndex: 20,
+          pointerEvents: 'none',
+          padding: '2px 7px',
+          borderRadius: 999,
+          background: bg,
+          border: `1px solid ${color}`,
+          color,
+          fontFamily: 'var(--cc-font-mono)',
+          fontSize: 11,
+          fontWeight: 700,
+          whiteSpace: 'nowrap',
+          letterSpacing: 0.3,
+        }}
+      >
+        {label}
+      </div>
+    )
+  }
+
+  return (
+    <div
+      // Use activationKey in the element key (via parent) so React remounts for re-trigger.
+      // The aria-hidden prevents screen readers from announcing floating decorations.
+      aria-hidden
+      key={activationKey}
+      className="animate-float-up"
+      style={{
+        position: 'absolute',
+        bottom: 'calc(100% + 4px)',
+        left: '50%',
+        transform: 'translateX(-50%)',
+        zIndex: 20,
+        pointerEvents: 'none',
+        padding: '2px 7px',
+        borderRadius: 999,
+        background: bg,
+        border: `1px solid ${color}`,
+        color,
+        fontFamily: 'var(--cc-font-mono)',
+        fontSize: 11,
+        fontWeight: 700,
+        whiteSpace: 'nowrap',
+        letterSpacing: 0.3,
+        textShadow: `0 0 8px ${color}`,
+      }}
+    >
+      {label}
+    </div>
+  )
+}

--- a/src/app/comet-cards/components/gameplay/joker.tsx
+++ b/src/app/comet-cards/components/gameplay/joker.tsx
@@ -203,8 +203,13 @@ export const Joker = ({
     )
   }
 
+  const wrapperClass = [
+    activated ? 'joker-activated' : undefined,
+    muted ? 'joker-muted' : undefined,
+  ].filter(Boolean).join(' ') || undefined
+
   return (
-    <div className={activated ? 'joker-activated' : undefined}>
+    <div className={wrapperClass}>
       <TokenCard
         title={def?.name ?? 'Unknown'}
         description={def?.description}

--- a/src/app/comet-cards/hooks/useJokerActivationSequence.ts
+++ b/src/app/comet-cards/hooks/useJokerActivationSequence.ts
@@ -1,0 +1,186 @@
+'use client'
+
+import { useEffect, useRef, useState } from 'react'
+
+import { jokers as jokerDefinitions } from '@/app/comet-cards/domain/joker/jokers'
+import { isCustomScoringEvent } from '@/app/comet-cards/domain/game/types'
+import type { ScoringEvent } from '@/app/comet-cards/domain/game/types'
+import { useCometCardsStore } from '@/app/comet-cards/store'
+
+export interface JokerActivationState {
+  /** Which joker name is currently mid-animation (null when idle) */
+  activeJokerName: string | null
+  /** The contribution label to show for the active joker, e.g. "+4 mult" or "x2 mult" */
+  activeJokerLabel: string | null
+  /** Set of all joker names that have fired (for dimming non-active jokers) */
+  firedJokerNames: Set<string>
+  /** Increments each time ANY joker activates (forces React key remount for CSS re-trigger) */
+  activationKey: number
+}
+
+interface QueueEntry {
+  name: string
+  label: string
+}
+
+const STAGGER_MS = 120
+
+/**
+ * Formats a group of scoring events for one joker into a human-readable label.
+ * Groups chips and mult contributions together.
+ */
+function buildLabel(events: ScoringEvent[]): string {
+  let chipsTotal = 0
+  let multTotal = 0
+  let xMultTotal = 0
+
+  for (const evt of events) {
+    if (evt.type === 'chips') {
+      chipsTotal += evt.value
+    } else if (evt.type === 'mult') {
+      if (evt.operator === 'x') {
+        xMultTotal += evt.value
+      } else {
+        multTotal += evt.value
+      }
+    }
+  }
+
+  const parts: string[] = []
+  if (chipsTotal > 0) parts.push(`+${chipsTotal} chips`)
+  if (multTotal > 0) parts.push(`+${multTotal} mult`)
+  if (xMultTotal > 0) parts.push(`x${xMultTotal} mult`)
+
+  return parts.join('  ') || '+?'
+}
+
+export function useJokerActivationSequence(): JokerActivationState {
+  const scoringEvents = useCometCardsStore(state => state.game.gamePlayState.scoringEvents)
+  const jokers = useCometCardsStore(state => state.game.jokers)
+
+  const [activeJokerName, setActiveJokerName] = useState<string | null>(null)
+  const [activeJokerLabel, setActiveJokerLabel] = useState<string | null>(null)
+  const [firedJokerNames, setFiredJokerNames] = useState<Set<string>>(new Set())
+  const [activationKey, setActivationKey] = useState(0)
+
+  // Ref to track which event IDs we've already processed
+  const seenEventIdsRef = useRef<Set<string>>(new Set())
+  // Ref for the pending queue (not state, so no re-renders on enqueue)
+  const pendingQueueRef = useRef<QueueEntry[]>([])
+  // Ref to track if the drain timer is running
+  const drainTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  // Ref to know if we're currently draining
+  const isDrainingRef = useRef(false)
+
+  // Build a set of known joker names from the current jokers list (for filtering)
+  const jokerNameToPositionRef = useRef<Map<string, number>>(new Map())
+  useEffect(() => {
+    const map = new Map<string, number>()
+    jokers.forEach((joker, idx) => {
+      const def = jokerDefinitions[joker.jokerId]
+      if (def) map.set(def.name, idx)
+    })
+    jokerNameToPositionRef.current = map
+  }, [jokers])
+
+  // Drain function: pop one entry from the queue, set active joker, schedule next
+  const drainQueue = () => {
+    const queue = pendingQueueRef.current
+    if (queue.length === 0) {
+      isDrainingRef.current = false
+      setActiveJokerName(null)
+      setActiveJokerLabel(null)
+      return
+    }
+
+    const entry = queue.shift()!
+    isDrainingRef.current = true
+
+    setFiredJokerNames(prev => {
+      const next = new Set(prev)
+      next.add(entry.name)
+      return next
+    })
+    setActiveJokerName(entry.name)
+    setActiveJokerLabel(entry.label)
+    setActivationKey(prev => prev + 1)
+
+    drainTimerRef.current = setTimeout(() => {
+      drainQueue()
+    }, STAGGER_MS)
+  }
+
+  // When scoringEvents resets to empty, clear all state
+  useEffect(() => {
+    if (scoringEvents.length === 0) {
+      seenEventIdsRef.current.clear()
+      pendingQueueRef.current = []
+      isDrainingRef.current = false
+      if (drainTimerRef.current !== null) {
+        clearTimeout(drainTimerRef.current)
+        drainTimerRef.current = null
+      }
+      setActiveJokerName(null)
+      setActiveJokerLabel(null)
+      setFiredJokerNames(new Set())
+      // Don't reset activationKey — keep it incrementing across hands
+    }
+  }, [scoringEvents.length])
+
+  // When new scoring events arrive, detect new joker-sourced ones and enqueue
+  useEffect(() => {
+    if (scoringEvents.length === 0) return
+
+    const jokerNameToPosition = jokerNameToPositionRef.current
+
+    // Group new events by joker name
+    const newByJoker = new Map<string, ScoringEvent[]>()
+
+    for (const evt of scoringEvents) {
+      if (isCustomScoringEvent(evt)) continue
+      if (seenEventIdsRef.current.has(evt.id)) continue
+      seenEventIdsRef.current.add(evt.id)
+
+      // Only process if source matches a known joker name
+      if (!jokerNameToPosition.has(evt.source)) continue
+
+      const group = newByJoker.get(evt.source)
+      if (group) {
+        group.push(evt)
+      } else {
+        newByJoker.set(evt.source, [evt])
+      }
+    }
+
+    if (newByJoker.size === 0) return
+
+    // Sort by joker position (left-to-right)
+    const sorted = Array.from(newByJoker.entries()).sort(([nameA], [nameB]) => {
+      const posA = jokerNameToPosition.get(nameA) ?? 999
+      const posB = jokerNameToPosition.get(nameB) ?? 999
+      return posA - posB
+    })
+
+    // Enqueue
+    for (const [name, events] of sorted) {
+      pendingQueueRef.current.push({ name, label: buildLabel(events) })
+    }
+
+    // Start draining if not already
+    if (!isDrainingRef.current) {
+      drainQueue()
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [scoringEvents])
+
+  // Cleanup on unmount
+  useEffect(() => {
+    return () => {
+      if (drainTimerRef.current !== null) {
+        clearTimeout(drainTimerRef.current)
+      }
+    }
+  }, [])
+
+  return { activeJokerName, activeJokerLabel, firedJokerNames, activationKey }
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -550,6 +550,11 @@ body {
   100% { opacity: 0.4; }
 }
 
+.joker-muted {
+  opacity: 0.35;
+  transition: opacity 0.2s;
+}
+
 @media (prefers-reduced-motion: reduce) {
   .blind-progress-fill {
     transition: none !important;
@@ -565,6 +570,9 @@ body {
   }
   .joker-activated::after {
     animation: none;
+  }
+  .joker-muted {
+    transition: none;
   }
 }
 


### PR DESCRIPTION
## Summary

Closes #1569

- Jokers now highlight and animate **sequentially** (left-to-right, 120ms stagger) as their effects fire during hand scoring
- Each activated joker shows a **floating contribution label** (e.g. "+4 mult", "+30 chips", "x2 mult") that animates upward
- Non-firing jokers **dim to 35% opacity** during the scoring sequence so the player can focus on what's activating
- Multi-activation jokers (e.g. Greedy Joker with multiple diamonds) re-trigger the animation for each batch
- All animations respect `prefers-reduced-motion` — static badges instead of floats, no transitions

## Changes

- **New:** `useJokerActivationSequence` hook — watches scoring events, queues joker activations by position, drains sequentially
- **New:** `JokerActivationLabel` component — floating pill with color-coded contribution values (mint=chips, pink=mult, gold=x-mult)
- **Modified:** `gameplay.tsx` — wired hook into both desktop and mobile joker renders
- **Modified:** `joker.tsx` — added `joker-muted` CSS class support
- **Modified:** `globals.css` — added `.joker-muted` class with reduced-motion support

## Test plan

- [ ] Play a hand with jokers equipped — verify jokers light up left-to-right during scoring
- [ ] Verify floating labels show correct values (+chips, +mult, x-mult)
- [ ] Verify non-triggering jokers dim during scoring
- [ ] Verify multi-activation jokers (e.g. Greedy Joker with multiple matching cards) pulse multiple times
- [ ] Test with `prefers-reduced-motion: reduce` — labels should be static, no pulse animation
- [ ] Test on mobile landscape view
- [ ] Verify no regressions in scoring totals

🤖 Generated with [Claude Code](https://claude.com/claude-code)