### PR TITLE
feat: keyboard navigation for Comet Cards

### DIFF
--- a/src/app/comet-cards/components/game-views/blind-selection.tsx
+++ b/src/app/comet-cards/components/game-views/blind-selection.tsx
@@ -4,6 +4,7 @@ import { motion, useReducedMotion } from 'framer-motion'
 
 import { BlindCard } from '@/app/comet-cards/components/blind-selection/blind-card'
 import { calculateAnte, getBlindDefinition } from '@/app/comet-cards/domain/game/utils'
+import { useAutoFocus } from '@/app/comet-cards/hooks/useAutoFocus'
 import { useGameState } from '@/app/comet-cards/useGameState'
 
 import { ViewTemplate } from './view-template'
@@ -26,6 +27,7 @@ const itemVariants = {
 export function BlindSelectionView() {
   const { game } = useGameState()
   const reducedMotion = useReducedMotion()
+  const autoFocusRef = useAutoFocus()
   const currentRound = game.rounds[game.roundIndex]
   const blindsInCurrentRound = [
     currentRound.smallBlind,
@@ -48,6 +50,7 @@ export function BlindSelectionView() {
 
   return (
     <ViewTemplate>
+      <div ref={autoFocusRef}>
       <motion.div
         className="grid grid-cols-1 sm:grid-cols-3 items-stretch gap-4"
         variants={containerVariants}
@@ -94,6 +97,7 @@ export function BlindSelectionView() {
           />
         </motion.div>
       </motion.div>
+      </div>
     </ViewTemplate>
   )
 }

--- a/src/app/comet-cards/components/game-views/pack-open.tsx
+++ b/src/app/comet-cards/components/game-views/pack-open.tsx
@@ -1,5 +1,7 @@
 'use client'
 
+import { useEffect } from 'react'
+
 import { GhostButton } from '@/app/comet-cards/components/cosmic/buttons'
 import { Panel } from '@/app/comet-cards/components/cosmic/panel'
 import { CelestialCardOpenBoosterPack } from '@/app/comet-cards/components/pack-open/celestial-card-open-booster-pack'
@@ -9,6 +11,7 @@ import { SpectralCardOpenBoosterPack } from '@/app/comet-cards/components/pack-o
 import { TarotCardOpenBoosterPack } from '@/app/comet-cards/components/pack-open/tarot-card-open-booster-pack'
 import { eventEmitter } from '@/app/comet-cards/domain/events/event-emitter'
 import type { BuyableCard as BuyableCardType } from '@/app/comet-cards/domain/shop/types'
+import { useAutoFocus } from '@/app/comet-cards/hooks/useAutoFocus'
 import { useGameState } from '@/app/comet-cards/useGameState'
 
 import { ViewTemplate } from './view-template'
@@ -24,6 +27,16 @@ function OpenBoosterPack({ cardType }: { cardType: BuyableCardType['type'] }) {
 
 export function PackOpenView() {
   const { game } = useGameState()
+  const autoFocusRef = useAutoFocus()
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') eventEmitter.emit({ type: 'PACK_OPEN_SKIP' })
+    }
+    window.addEventListener('keydown', handler)
+    return () => window.removeEventListener('keydown', handler)
+  }, [])
+
   if (!game.shopState.openPackState) {
     return (
       <ViewTemplate>
@@ -38,7 +51,7 @@ export function PackOpenView() {
   return (
     <ViewTemplate>
       <Panel title="Booster Pack">
-        <div className="flex flex-col" style={{ padding: 16, gap: 14 }}>
+        <div ref={autoFocusRef} className="flex flex-col" style={{ padding: 16, gap: 14 }}>
           <OpenBoosterPack cardType={game.shopState.openPackState.cards[0].type} />
           <div>
             <GhostButton onClick={() => eventEmitter.emit({ type: 'PACK_OPEN_SKIP' })}>

--- a/src/app/comet-cards/components/game-views/shop.tsx
+++ b/src/app/comet-cards/components/game-views/shop.tsx
@@ -22,6 +22,8 @@ import {
   getIsSelectedCardPlayable,
 } from '@/app/comet-cards/domain/shop/utils'
 import { VOUCHER_PRICE } from '@/app/comet-cards/domain/voucher/constants'
+import { useAutoFocus } from '@/app/comet-cards/hooks/useAutoFocus'
+import { useGridKeyboardNav } from '@/app/comet-cards/hooks/useGridKeyboardNav'
 import { useLandscapeMobile } from '@/app/comet-cards/hooks/useLandscapeMobile'
 import { useGameState } from '@/app/comet-cards/useGameState'
 
@@ -31,6 +33,8 @@ export function ShopView() {
   const isLandscape = useLandscapeMobile()
   const { game } = useGameState()
   const reducedMotion = useReducedMotion()
+  const autoFocusRef = useAutoFocus()
+  const { containerRef: cardsForSaleRef, handleKeyDown: handleCardsKeyDown } = useGridKeyboardNav()
   useEffect(() => {
     if (!game.shopState.isOpen) {
       eventEmitter.emit({ type: 'SHOP_OPEN' })
@@ -84,7 +88,7 @@ export function ShopView() {
         )
       }
     >
-      <div className="flex flex-col" style={{ gap: 18 }}>
+      <div className="flex flex-col" ref={autoFocusRef} style={{ gap: 18 }}>
         <Panel
           title="Shop"
           subtitle={`$${game.money} on hand`}
@@ -106,7 +110,13 @@ export function ShopView() {
               {/* Left column: Cards for Sale */}
               <div className="flex flex-col" style={{ gap: 12 }}>
                 <SectionHeader label="Cards for Sale">
-                  <div className="flex flex-wrap items-stretch gap-3">
+                  <div
+                    ref={cardsForSaleRef}
+                    role="toolbar"
+                    aria-label="Cards for sale"
+                    className="flex flex-wrap items-stretch gap-3"
+                    onKeyDown={handleCardsKeyDown}
+                  >
                     {game.shopState.cardsForSale.map((buyableCard, i) => (
                       <motion.div
                         key={buyableCard.card.id}

--- a/src/app/comet-cards/components/pack-open/celestial-card-open-booster-pack.tsx
+++ b/src/app/comet-cards/components/pack-open/celestial-card-open-booster-pack.tsx
@@ -4,6 +4,7 @@ import { CurrentConsumables } from '@/app/comet-cards/components/consumables/cur
 import { CurrentJokers } from '@/app/comet-cards/components/joker/current-jokers'
 import { BuyableCard } from '@/app/comet-cards/components/shop/buyable-card'
 import { eventEmitter } from '@/app/comet-cards/domain/events/event-emitter'
+import { useGridKeyboardNav } from '@/app/comet-cards/hooks/useGridKeyboardNav'
 import { useGameState } from '@/app/comet-cards/useGameState'
 import { Button } from '@/components/ui/button'
 import { motion, useReducedMotion } from 'framer-motion'
@@ -26,6 +27,7 @@ const itemVariants = {
 export function CelestialCardOpenBoosterPack() {
   const reducedMotion = useReducedMotion()
   const { game } = useGameState()
+  const { containerRef, handleKeyDown } = useGridKeyboardNav()
   if (!game.shopState.openPackState) return <div>No pack open</div>
   const cardsForSale = game.shopState.openPackState.cards
 
@@ -46,10 +48,14 @@ export function CelestialCardOpenBoosterPack() {
             Select {game.shopState.openPackState.remainingCardsToSelect} cards
           </h2>
           <motion.div
+            ref={containerRef}
+            role="toolbar"
+            aria-label="Celestial cards"
             className="flex flex-wrap gap-2"
             variants={containerVariants}
             initial={reducedMotion ? false : 'hidden'}
             animate="visible"
+            onKeyDown={handleKeyDown}
           >
             {cardsForSale.map(buyableCard => (
               <motion.div key={buyableCard.card.id} variants={itemVariants} className="flex flex-col gap-2">

--- a/src/app/comet-cards/components/pack-open/joker-card-open-booster-pack.tsx
+++ b/src/app/comet-cards/components/pack-open/joker-card-open-booster-pack.tsx
@@ -4,6 +4,7 @@ import { CurrentConsumables } from '@/app/comet-cards/components/consumables/cur
 import { CurrentJokers } from '@/app/comet-cards/components/joker/current-jokers'
 import { BuyableCard } from '@/app/comet-cards/components/shop/buyable-card'
 import { eventEmitter } from '@/app/comet-cards/domain/events/event-emitter'
+import { useGridKeyboardNav } from '@/app/comet-cards/hooks/useGridKeyboardNav'
 import { useGameState } from '@/app/comet-cards/useGameState'
 import { Button } from '@/components/ui/button'
 import { motion, useReducedMotion } from 'framer-motion'
@@ -26,6 +27,7 @@ const itemVariants = {
 export function JokerCardOpenBoosterPack() {
   const reducedMotion = useReducedMotion()
   const { game } = useGameState()
+  const { containerRef, handleKeyDown } = useGridKeyboardNav()
   if (!game.shopState.openPackState) return <div>No pack open</div>
   const cardsForSale = game.shopState.openPackState.cards
 
@@ -47,10 +49,14 @@ export function JokerCardOpenBoosterPack() {
             {game.shopState.openPackState.remainingCardsToSelect > 1 ? 's' : ''}
           </h2>
           <motion.div
+            ref={containerRef}
+            role="toolbar"
+            aria-label="Joker cards"
             className="flex flex-wrap gap-2"
             variants={containerVariants}
             initial={reducedMotion ? false : 'hidden'}
             animate="visible"
+            onKeyDown={handleKeyDown}
           >
             {cardsForSale.map(buyableCard => (
               <motion.div key={buyableCard.card.id} variants={itemVariants} className="flex flex-col gap-2">

--- a/src/app/comet-cards/components/pack-open/playing-card-open-booster-pack.tsx
+++ b/src/app/comet-cards/components/pack-open/playing-card-open-booster-pack.tsx
@@ -2,6 +2,7 @@
 
 import { BuyableCard } from '@/app/comet-cards/components/shop/buyable-card'
 import { eventEmitter } from '@/app/comet-cards/domain/events/event-emitter'
+import { useGridKeyboardNav } from '@/app/comet-cards/hooks/useGridKeyboardNav'
 import { useGameState } from '@/app/comet-cards/useGameState'
 import { Button } from '@/components/ui/button'
 import { motion, useReducedMotion } from 'framer-motion'
@@ -24,6 +25,7 @@ const itemVariants = {
 export function PlayingCardOpenBoosterPack() {
   const reducedMotion = useReducedMotion()
   const { game } = useGameState()
+  const { containerRef, handleKeyDown } = useGridKeyboardNav()
   if (!game.shopState.openPackState) return <div>No pack open</div>
   const cardsForSale = game.shopState.openPackState.cards
 
@@ -33,10 +35,14 @@ export function PlayingCardOpenBoosterPack() {
         Choose {game.shopState.openPackState.remainingCardsToSelect} cards
       </h2>
       <motion.div
+        ref={containerRef}
+        role="toolbar"
+        aria-label="Playing cards"
         className="flex flex-wrap gap-2"
         variants={containerVariants}
         initial={reducedMotion ? false : 'hidden'}
         animate="visible"
+        onKeyDown={handleKeyDown}
       >
         {cardsForSale.map(buyableCard => (
           <motion.div key={buyableCard.card.id} variants={itemVariants} className="flex flex-col gap-2">

--- a/src/app/comet-cards/components/pack-open/spectral-card-open-booster-pack.tsx
+++ b/src/app/comet-cards/components/pack-open/spectral-card-open-booster-pack.tsx
@@ -6,6 +6,7 @@ import { CurrentJokers } from '@/app/comet-cards/components/joker/current-jokers
 import { BuyableCard } from '@/app/comet-cards/components/shop/buyable-card'
 import { eventEmitter } from '@/app/comet-cards/domain/events/event-emitter'
 import { getIsSpectralCardPlayable } from '@/app/comet-cards/domain/shop/utils'
+import { useGridKeyboardNav } from '@/app/comet-cards/hooks/useGridKeyboardNav'
 import { useGameState } from '@/app/comet-cards/useGameState'
 import { Button } from '@/components/ui/button'
 import { motion, useReducedMotion } from 'framer-motion'
@@ -28,6 +29,7 @@ const itemVariants = {
 export function SpectralCardOpenBoosterPack() {
   const reducedMotion = useReducedMotion()
   const { game } = useGameState()
+  const { containerRef, handleKeyDown } = useGridKeyboardNav()
   if (!game.shopState.openPackState) return <div>No pack open</div>
   const cardsForSale = game.shopState.openPackState.cards
 
@@ -48,10 +50,14 @@ export function SpectralCardOpenBoosterPack() {
             Select {game.shopState.openPackState.remainingCardsToSelect} cards
           </h2>
           <motion.div
+            ref={containerRef}
+            role="toolbar"
+            aria-label="Spectral cards"
             className="flex flex-wrap gap-2"
             variants={containerVariants}
             initial={reducedMotion ? false : 'hidden'}
             animate="visible"
+            onKeyDown={handleKeyDown}
           >
             {cardsForSale.map(buyableCard => (
               <motion.div key={buyableCard.card.id} variants={itemVariants} className="flex flex-col gap-2">

--- a/src/app/comet-cards/components/pack-open/tarot-card-open-booster-pack.tsx
+++ b/src/app/comet-cards/components/pack-open/tarot-card-open-booster-pack.tsx
@@ -6,6 +6,7 @@ import { CurrentJokers } from '@/app/comet-cards/components/joker/current-jokers
 import { BuyableCard } from '@/app/comet-cards/components/shop/buyable-card'
 import { eventEmitter } from '@/app/comet-cards/domain/events/event-emitter'
 import { getIsSelectedCardPlayable } from '@/app/comet-cards/domain/shop/utils'
+import { useGridKeyboardNav } from '@/app/comet-cards/hooks/useGridKeyboardNav'
 import { useGameState } from '@/app/comet-cards/useGameState'
 import { Button } from '@/components/ui/button'
 import { motion, useReducedMotion } from 'framer-motion'
@@ -28,6 +29,7 @@ const itemVariants = {
 export function TarotCardOpenBoosterPack() {
   const reducedMotion = useReducedMotion()
   const { game } = useGameState()
+  const { containerRef, handleKeyDown } = useGridKeyboardNav()
   if (!game.shopState.openPackState) return <div>No pack open</div>
   const cardsForSale = game.shopState.openPackState.cards
 
@@ -48,10 +50,14 @@ export function TarotCardOpenBoosterPack() {
             Select {game.shopState.openPackState.remainingCardsToSelect} cards
           </h2>
           <motion.div
+            ref={containerRef}
+            role="toolbar"
+            aria-label="Tarot cards"
             className="flex flex-wrap gap-2"
             variants={containerVariants}
             initial={reducedMotion ? false : 'hidden'}
             animate="visible"
+            onKeyDown={handleKeyDown}
           >
             {cardsForSale.map(buyableCard => (
               <motion.div key={buyableCard.card.id} variants={itemVariants} className="flex flex-col gap-2">

--- a/src/app/comet-cards/hooks/useAutoFocus.ts
+++ b/src/app/comet-cards/hooks/useAutoFocus.ts
@@ -1,0 +1,23 @@
+'use client'
+
+import { useEffect, useRef } from 'react'
+
+/**
+ * Focuses the first matching interactive element inside the container when the
+ * component mounts. A small delay allows any entry animations to settle first.
+ *
+ * @param selector - CSS selector for the element to focus (default: first enabled button)
+ */
+export function useAutoFocus(selector = 'button:not([disabled])') {
+  const containerRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      const el = containerRef.current?.querySelector<HTMLElement>(selector)
+      el?.focus()
+    }, 100)
+    return () => clearTimeout(timer)
+  }, [selector])
+
+  return containerRef
+}

--- a/src/app/comet-cards/hooks/useGridKeyboardNav.ts
+++ b/src/app/comet-cards/hooks/useGridKeyboardNav.ts
@@ -1,0 +1,52 @@
+'use client'
+
+import { useCallback, useRef } from 'react'
+
+/**
+ * Provides arrow-key navigation across a flat list or 2D grid of card buttons.
+ * Attach `containerRef` to the wrapper div and `handleKeyDown` to its onKeyDown.
+ *
+ * @param selector - CSS selector for focusable buttons inside the container
+ */
+export function useGridKeyboardNav(selector = 'button.bc-card') {
+  const containerRef = useRef<HTMLDivElement>(null)
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (!['ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown'].includes(e.key)) return
+      const container = containerRef.current
+      if (!container) return
+      const buttons = Array.from(container.querySelectorAll<HTMLElement>(selector))
+      const currentIndex = buttons.indexOf(e.target as HTMLElement)
+      if (currentIndex === -1) return
+      e.preventDefault()
+
+      let nextIndex = currentIndex
+
+      if (e.key === 'ArrowRight') {
+        nextIndex = Math.min(currentIndex + 1, buttons.length - 1)
+      } else if (e.key === 'ArrowLeft') {
+        nextIndex = Math.max(currentIndex - 1, 0)
+      } else {
+        // Estimate columns by counting buttons that share the same top position as current
+        const currentTop = buttons[currentIndex].getBoundingClientRect().top
+        let cols = 0
+        for (const btn of buttons) {
+          if (Math.abs(btn.getBoundingClientRect().top - currentTop) < 5) cols++
+          else if (cols > 0) break
+        }
+        if (cols === 0) cols = buttons.length
+        if (e.key === 'ArrowDown') {
+          nextIndex = Math.min(currentIndex + cols, buttons.length - 1)
+        } else {
+          nextIndex = Math.max(currentIndex - cols, 0)
+        }
+      }
+
+      buttons[nextIndex]?.focus()
+    },
+    [selector]
+  )
+
+  return { containerRef, handleKeyDown }
+}


### PR DESCRIPTION
## Summary

Partial fix for #1519

Adds keyboard navigation so keyboard-only users can play Comet Cards. All interactive elements were already proper `<button>` elements (Enter/Space works natively), but the game lacked arrow-key grid navigation and focus management between views.

## Changes

**New hooks:**
- `useGridKeyboardNav` — Arrow-key navigation (left/right/up/down) for card grids. Dynamically estimates columns from element positions for both single-row and wrapped layouts.
- `useAutoFocus` — Focuses the first non-disabled button in a container 100ms after mount (lets entry animations settle).

**Auto-focus on view transitions:**
- Shop view — focuses first shop card on mount
- Blind selection — focuses first blind card on mount  
- Pack opening — focuses first pack card on mount

**Arrow-key grid navigation:**
- Shop "Cards for Sale" — arrow keys navigate between cards (`role="toolbar"`, `aria-label`)
- All 5 pack-open views (joker, playing, tarot, celestial, spectral) — arrow keys navigate between revealed cards

**Escape key:**
- Pack opening — Escape skips/closes the pack

## Test plan

- [ ] Tab into hand cards, use arrow keys to navigate, Enter/Space to select cards
- [ ] Enter shop — verify focus auto-moves to first shop card
- [ ] Arrow keys navigate between shop cards, Enter to select, Tab to Buy button
- [ ] Open a booster pack — arrow keys navigate between revealed cards
- [ ] Press Escape during pack opening — pack is skipped
- [ ] Enter blind selection — focus auto-moves to first blind option
- [ ] Verify visible focus rings (mint outline) on all interactive cards
- [ ] Full game playable without mouse

🤖 Generated with [Claude Code](https://claude.com/claude-code)