### PR TITLE
feat: expanded daily trivia stats — pace, consistency, completion

### DIFF
--- a/src/app/trivia/components/TriviaStats.tsx
+++ b/src/app/trivia/components/TriviaStats.tsx
@@ -69,6 +69,73 @@ export function TriviaStats() {
     return days.map((label, i) => ({ label, count: counts[i], pct: Math.round((counts[i] / max) * 100) }))
   }, [history])
 
+  // Speed stats — computed from answer timeMs data
+  const speedStats = useMemo(() => {
+    const allAnswers = history.flatMap((g) => g.answers ?? [])
+    const withTime = allAnswers.filter((a) => (a.timeMs ?? 0) > 0)
+    if (withTime.length === 0) return null
+
+    const totalMs = withTime.reduce((s, a) => s + a.timeMs, 0)
+    const avgMs = totalMs / withTime.length
+
+    const correctAnswers = withTime.filter((a) => a.correct)
+    const incorrectAnswers = withTime.filter((a) => !a.correct)
+
+    const fastestCorrectMs = correctAnswers.length > 0
+      ? Math.min(...correctAnswers.map((a) => a.timeMs))
+      : null
+
+    const avgCorrectMs = correctAnswers.length > 0
+      ? correctAnswers.reduce((s, a) => s + a.timeMs, 0) / correctAnswers.length
+      : null
+
+    const avgIncorrectMs = incorrectAnswers.length > 0
+      ? incorrectAnswers.reduce((s, a) => s + a.timeMs, 0) / incorrectAnswers.length
+      : null
+
+    const fmt = (ms: number) => `${(ms / 1000).toFixed(1)}s`
+
+    return {
+      avg: fmt(avgMs),
+      fastestCorrect: fastestCorrectMs !== null ? fmt(fastestCorrectMs) : null,
+      avgCorrect: avgCorrectMs !== null ? fmt(avgCorrectMs) : null,
+      avgIncorrect: avgIncorrectMs !== null ? fmt(avgIncorrectMs) : null,
+    }
+  }, [history])
+
+  // Score consistency — median and coefficient of variation
+  const consistencyStats = useMemo(() => {
+    if (history.length < 5) return null
+    const scores = [...history.map((g) => g.score)].sort((a, b) => a - b)
+    const mid = Math.floor(scores.length / 2)
+    const median = scores.length % 2 === 0
+      ? Math.round((scores[mid - 1] + scores[mid]) / 2)
+      : scores[mid]
+
+    const mean = scores.reduce((s, v) => s + v, 0) / scores.length
+    const variance = scores.reduce((s, v) => s + Math.pow(v - mean, 2), 0) / scores.length
+    const stdDev = Math.sqrt(variance)
+    const cv = mean > 0 ? stdDev / mean : 0
+    const consistency = Math.max(0, Math.round((1 - cv) * 100))
+
+    return { median, consistency, avg: Math.round(mean) }
+  }, [history])
+
+  // Completion rate — games played vs days since first game
+  const completionStats = useMemo(() => {
+    if (history.length < 7) return null
+    // history is sorted desc; oldest is last
+    const oldest = history[history.length - 1]
+    if (!oldest) return null
+    const firstDate = new Date(oldest.date + 'T12:00:00')
+    const today = new Date()
+    today.setHours(12, 0, 0, 0)
+    const diffMs = today.getTime() - firstDate.getTime()
+    const daysAvailable = Math.max(1, Math.round(diffMs / (1000 * 60 * 60 * 24)) + 1)
+    const rate = Math.min(100, Math.round((history.length / daysAvailable) * 100))
+    return { gamesPlayed: history.length, daysAvailable, rate }
+  }, [history])
+
   // Category performance
   const categoryStats = useMemo(() => {
     const cats = new Map<string, { name: string; icon: string; correct: number; total: number }>()
@@ -219,6 +286,90 @@ export function TriviaStats() {
           </div>
         </ChunkyCardContent>
       </ChunkyCard>
+
+      {/* Your Pace — speed stats */}
+      {speedStats && (
+        <ChunkyCard variant="surface-variant" className="bg-surface-container/80 border-outline-variant">
+          <ChunkyCardContent className="pt-5 pb-5">
+            <h3 className="text-on-surface/70 text-sm font-semibold mb-3 uppercase tracking-wide">
+              Your Pace
+            </h3>
+            <div className="grid grid-cols-2 gap-3">
+              <div className="text-center">
+                <div className="text-2xl font-bold text-ds-tertiary">{speedStats.avg}</div>
+                <div className="text-on-surface/50 text-xs mt-1">Avg answer time</div>
+              </div>
+              {speedStats.fastestCorrect && (
+                <div className="text-center">
+                  <div className="text-2xl font-bold text-ds-tertiary">{speedStats.fastestCorrect}</div>
+                  <div className="text-on-surface/50 text-xs mt-1">Fastest correct</div>
+                </div>
+              )}
+              {speedStats.avgCorrect && (
+                <div className="text-center">
+                  <div className="text-2xl font-bold text-ds-primary">{speedStats.avgCorrect}</div>
+                  <div className="text-on-surface/50 text-xs mt-1">Avg time (correct)</div>
+                </div>
+              )}
+              {speedStats.avgIncorrect && (
+                <div className="text-center">
+                  <div className="text-2xl font-bold text-ds-error">{speedStats.avgIncorrect}</div>
+                  <div className="text-on-surface/50 text-xs mt-1">Avg time (incorrect)</div>
+                </div>
+              )}
+            </div>
+          </ChunkyCardContent>
+        </ChunkyCard>
+      )}
+
+      {/* Your Rhythm — score consistency */}
+      {consistencyStats && (
+        <ChunkyCard variant="surface-variant" className="bg-surface-container/80 border-outline-variant">
+          <ChunkyCardContent className="pt-5 pb-5">
+            <h3 className="text-on-surface/70 text-sm font-semibold mb-3 uppercase tracking-wide">
+              Your Rhythm
+            </h3>
+            <div className="grid grid-cols-2 gap-3">
+              <div className="text-center">
+                <div className="text-2xl font-bold text-ds-tertiary">{consistencyStats.median.toLocaleString()}</div>
+                <div className="text-on-surface/50 text-xs mt-1">Median score</div>
+              </div>
+              <div className="text-center">
+                <div className="text-2xl font-bold text-on-surface">{consistencyStats.avg.toLocaleString()}</div>
+                <div className="text-on-surface/50 text-xs mt-1">Average score</div>
+              </div>
+              <div className="col-span-2 text-center mt-1">
+                <div className="text-2xl font-bold text-ds-tertiary">{consistencyStats.consistency}% consistent</div>
+                <div className="text-on-surface/50 text-xs mt-1">Higher means steadier performance</div>
+              </div>
+            </div>
+          </ChunkyCardContent>
+        </ChunkyCard>
+      )}
+
+      {/* Your Orbit — completion rate */}
+      {completionStats && (
+        <ChunkyCard variant="surface-variant" className="bg-surface-container/80 border-outline-variant">
+          <ChunkyCardContent className="pt-5 pb-5">
+            <h3 className="text-on-surface/70 text-sm font-semibold mb-3 uppercase tracking-wide">
+              Your Orbit
+            </h3>
+            <div className="mb-2">
+              <div className="text-on-surface/70 text-sm">
+                {completionStats.gamesPlayed} of {completionStats.daysAvailable} days —{' '}
+                <span className="text-ds-tertiary font-bold">{completionStats.rate}%</span>
+              </div>
+            </div>
+            <div className="w-full h-2 bg-outline-variant rounded-full overflow-hidden">
+              <div
+                className="h-full bg-ds-tertiary rounded-full transition-all"
+                style={{ width: `${completionStats.rate}%` }}
+              />
+            </div>
+            <div className="text-on-surface/40 text-xs mt-2">Days played since your first game</div>
+          </ChunkyCardContent>
+        </ChunkyCard>
+      )}
 
       {/* Score trend */}
       {scoreTrend && (


### PR DESCRIPTION
## Summary

Partial fix for #1370

Adds three new stat sections to the daily trivia stats page, computed entirely from existing game data (no DB or API changes).

## New sections

### Your Pace (speed stats)
- Average answer time across all games
- Fastest correct answer
- Avg time for correct vs incorrect answers (color-coded green/red)
- Only shown if answer timing data exists

### Your Rhythm (score consistency)  
- Median score vs average score (side-by-side)
- Consistency percentage (based on coefficient of variation — higher = steadier performance)
- Only shown if 5+ games played

### Your Orbit (completion rate)
- Days played / days available since first game
- Progress bar visualization
- Only shown if 7+ games played

## Design choices

- Matches existing ChunkyCard patterns exactly (same variants, classes, heading styles)
- Uses cosmic-narrator voice for section headers ("Your Pace", "Your Rhythm", "Your Orbit")
- Each section guards on minimum data requirements
- All computations are `useMemo`-wrapped, matching existing patterns
- No new dependencies

## Test plan

- [ ] Play 5+ daily trivia games, visit stats page — all 3 new sections should appear
- [ ] With <5 games, "Your Rhythm" and "Your Orbit" should be hidden
- [ ] Verify speed stats show correct values (cross-check with game timer)
- [ ] Verify consistency % makes sense (100% = same score every game)
- [ ] Verify completion rate calculates correctly (games played / days since first game)
- [ ] Check mobile layout — 2-column grid should stack appropriately
- [ ] Verify no regressions in existing stats sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)