### PR TITLE
feat: custom 404 page with cosmic-narrator voice

### DIFF
--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,21 @@
+import Link from 'next/link'
+import { ChunkyButton } from '@/components/ui/chunky-button'
+
+export default function NotFound() {
+  return (
+    <div className="flex flex-col items-center justify-center min-h-[60vh] px-6 text-center">
+      <div className="text-8xl font-bold text-on-surface/10 select-none mb-2">404</div>
+      <h1 className="text-2xl font-bold text-on-surface mb-3">
+        The cave has no memory of this path
+      </h1>
+      <p className="text-on-surface/50 text-sm max-w-sm mb-8">
+        You've wandered beyond the mapped corridors. The walls here are smooth and unmarked — nothing echoes back.
+      </p>
+      <Link href="/">
+        <ChunkyButton variant="primary" size="md">
+          Return to the cave
+        </ChunkyButton>
+      </Link>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

Closes #1573

Adds a custom 404 page so lost visitors get the cosmic-narrator treatment instead of Next.js defaults.

**UX principles addressed:**
- #7 (Hand-crafted, not templated): "Even small surfaces — 404s — deserve personality"
- #4 (Mystical voice in the chrome): "Stay in character even in error states"

## Changes

Single new file: `src/app/not-found.tsx`

- Large faded "404" backdrop
- Mystical copy: "The cave has no memory of this path"
- Atmospheric subtext: "You've wandered beyond the mapped corridors..."
- "Return to the cave" button linking home
- Inherits nav/footer from root layout

## Test plan

- [ ] Visit any non-existent URL (e.g., `/asdfgh`) — should see custom 404
- [ ] "Return to the cave" button navigates to home
- [ ] Verify page looks correct on mobile
- [ ] Verify nav bar and footer are present

🤖 Generated with [Claude Code](https://claude.com/claude-code)