### PR TITLE
fix: dedicated container for owned jokers in shop and pack views

### DIFF
--- a/src/app/comet-cards/components/cosmic/token-card.tsx
+++ b/src/app/comet-cards/components/cosmic/token-card.tsx
@@ -16,7 +16,6 @@ export function TokenCard({
   accent = 'var(--cc-mint)',
   selected = false,
   disabled = false,
-  muted = false,
   size = 'md',
   badge,
   onClick,
@@ -30,7 +29,6 @@ export function TokenCard({
   accent?: string
   selected?: boolean
   disabled?: boolean
-  muted?: boolean
   size?: TokenCardSize
   badge?: ReactNode
   onClick?: () => void
@@ -45,15 +43,7 @@ export function TokenCard({
   let boxShadow: string
   let opacity: number
 
-  if (muted && selected) {
-    border = `1px solid color-mix(in srgb, ${accent} 50%, transparent)`
-    boxShadow = `0 0 0 2px color-mix(in srgb, ${accent} 20%, transparent), var(--cc-card-shadow-base)`
-    opacity = 0.9
-  } else if (muted) {
-    border = `1px solid color-mix(in srgb, ${accent} 25%, transparent)`
-    boxShadow = 'var(--cc-card-shadow-base)'
-    opacity = 0.8
-  } else if (selected) {
+  if (selected) {
     border = `1px solid ${accent}`
     boxShadow = `0 0 0 2px color-mix(in srgb, ${accent} 33%, transparent), 0 0 28px ${accent}, var(--cc-card-shadow-selected-tail)`
     opacity = disabled ? 0.55 : 1

--- a/src/app/comet-cards/components/game-views/gameplay.tsx
+++ b/src/app/comet-cards/components/game-views/gameplay.tsx
@@ -965,7 +965,7 @@ export function GamePlayView() {
                   return (
                     <div
                       key={isJokerActive ? `${joker.id}-${activationKey}` : joker.id}
-                      style={{ position: 'relative' }}
+                      style={{ position: 'relative', opacity: isJokerMuted ? 0.35 : 1, transition: 'opacity 0.2s' }}
                     >
                       <Joker
                         joker={joker}
@@ -974,7 +974,6 @@ export function GamePlayView() {
                         gameSeed={game.gameSeed}
                         roundIndex={game.roundIndex}
                         activated={isJokerActive}
-                        muted={isJokerMuted}
                         onClick={(isSelected, id) => {
                           if (isSelected) {
                             eventEmitter.emit({ type: 'JOKER_DESELECTED', id })

--- a/src/app/comet-cards/components/game-views/shop.tsx
+++ b/src/app/comet-cards/components/game-views/shop.tsx
@@ -95,7 +95,7 @@ export function ShopView() {
         >
           <div className="flex flex-col" style={{ padding: 16, gap: 18 }}>
             <SectionHeader label="Your Jokers">
-              <CurrentJokers muted />
+              <CurrentJokers />
             </SectionHeader>
 
             {/* Two-column grid: Cards for Sale (left) | Voucher + Booster Packs (right) */}

--- a/src/app/comet-cards/components/gameplay/joker.tsx
+++ b/src/app/comet-cards/components/gameplay/joker.tsx
@@ -48,7 +48,6 @@ export const Joker = ({
   gameSeed,
   roundIndex,
   activated,
-  muted,
 }: {
   joker: JokerState
   isSelected?: boolean
@@ -57,7 +56,6 @@ export const Joker = ({
   gameSeed?: string
   roundIndex?: number
   activated?: boolean
-  muted?: boolean
 }) => {
   const def = jokers[joker.jokerId]
   const accent = RARITY_ACCENT[def?.rarity ?? 'common'] ?? 'var(--cc-mint)'
@@ -205,7 +203,6 @@ export const Joker = ({
 
   const wrapperClass = [
     activated ? 'joker-activated' : undefined,
-    muted ? 'joker-muted' : undefined,
   ].filter(Boolean).join(' ') || undefined
 
   return (
@@ -216,7 +213,6 @@ export const Joker = ({
         glyph="✺"
         accent={accent}
         selected={isSelected}
-        muted={muted}
         size="sm"
         badge={badge}
         typeLabel="Joker"

--- a/src/app/comet-cards/components/joker/current-jokers.tsx
+++ b/src/app/comet-cards/components/joker/current-jokers.tsx
@@ -4,53 +4,61 @@ import { eventEmitter } from '@/app/comet-cards/domain/events/event-emitter'
 import { jokers } from '@/app/comet-cards/domain/joker/jokers'
 import { useGameState } from '@/app/comet-cards/useGameState'
 
-export const CurrentJokers = ({ muted }: { muted?: boolean }) => {
+export const CurrentJokers = () => {
   const { game } = useGameState()
   const selectedJoker = game.jokers.find(joker => joker.id === game.gamePlayState.selectedJokerId)
   const selectedJokerDefinition = selectedJoker ? jokers[selectedJoker.jokerId] : undefined
 
   return (
-    <div className="flex flex-col gap-2">
-      <div className="flex flex-wrap gap-3">
-        {game.jokers.length === 0 ? (
-          <div
-            style={{
-              fontFamily: 'var(--cc-font-mono)',
-              fontSize: 11,
-              opacity: 0.45,
-              letterSpacing: 0.5,
-            }}
-          >
-            No jokers yet — buy one from the shop below
-          </div>
-        ) : (
-          game.jokers.map(joker => (
-            <Joker
-              key={joker.id}
-              joker={joker}
-              muted={muted}
-              isSelected={game.gamePlayState.selectedJokerId === joker.id}
-              ownedCardCount={game.ownedCardIds.length}
-              gameSeed={game.gameSeed}
-              roundIndex={game.roundIndex}
-              onClick={(isSelected, id) => {
-                if (isSelected) {
-                  eventEmitter.emit({ type: 'JOKER_DESELECTED', id })
-                } else {
-                  eventEmitter.emit({ type: 'JOKER_SELECTED', id })
-                }
+    <div
+      style={{
+        background: 'rgba(255, 255, 255, 0.04)',
+        border: '1px solid rgba(255, 255, 255, 0.1)',
+        borderRadius: 10,
+        padding: '12px 14px',
+      }}
+    >
+      <div className="flex flex-col gap-2">
+        <div className="flex flex-wrap gap-3">
+          {game.jokers.length === 0 ? (
+            <div
+              style={{
+                fontFamily: 'var(--cc-font-mono)',
+                fontSize: 11,
+                opacity: 0.45,
+                letterSpacing: 0.5,
               }}
-            />
-          ))
+            >
+              Your joker slots are empty
+            </div>
+          ) : (
+            game.jokers.map(joker => (
+              <Joker
+                key={joker.id}
+                joker={joker}
+                isSelected={game.gamePlayState.selectedJokerId === joker.id}
+                ownedCardCount={game.ownedCardIds.length}
+                gameSeed={game.gameSeed}
+                roundIndex={game.roundIndex}
+                onClick={(isSelected, id) => {
+                  if (isSelected) {
+                    eventEmitter.emit({ type: 'JOKER_DESELECTED', id })
+                  } else {
+                    eventEmitter.emit({ type: 'JOKER_SELECTED', id })
+                  }
+                }}
+              />
+            ))
+          )}
+        </div>
+        {selectedJokerDefinition && (
+          <div>
+            <DangerButton onClick={() => eventEmitter.emit({ type: 'JOKER_SOLD' })}>
+              Sell · ${selectedJokerDefinition.price}
+            </DangerButton>
+          </div>
         )}
       </div>
-      {selectedJokerDefinition && (
-        <div>
-          <DangerButton onClick={() => eventEmitter.emit({ type: 'JOKER_SOLD' })}>
-            Sell · ${selectedJokerDefinition.price}
-          </DangerButton>
-        </div>
-      )}
     </div>
   )
 }

--- a/src/app/comet-cards/components/pack-open/joker-card-open-booster-pack.tsx
+++ b/src/app/comet-cards/components/pack-open/joker-card-open-booster-pack.tsx
@@ -33,14 +33,21 @@ export function JokerCardOpenBoosterPack() {
 
   return (
     <div className="flex flex-col gap-2">
-      {game.jokers.length > 0 && (
-        <div className="mt-4">
-          <h3 className="mb-2">Current Jokers</h3>
-          <div className="flex flex-wrap">
-            <CurrentJokers />
-          </div>
+      <div className="mt-4">
+        <div
+          className="uppercase"
+          style={{
+            fontFamily: 'var(--cc-font-mono)',
+            fontSize: 10,
+            letterSpacing: 2,
+            opacity: 0.55,
+            marginBottom: 8,
+          }}
+        >
+          Your Jokers
         </div>
-      )}
+        <CurrentJokers />
+      </div>
 
       <div className="flex">
         <div className="flex flex-col gap-2 w-3/4">


### PR DESCRIPTION
## Summary
- Owned jokers now render inside a distinct inventory panel (subtle background + border), clearly separating them from cards for sale
- Removes the previous opacity-dimming approach (`muted` prop on TokenCard/Joker) — jokers always render at full opacity for readability
- Joker container is always visible, even when empty ("Your joker slots are empty" placeholder)
- Pack opening view now shows the "Your Jokers" section consistently, matching the shop layout

Closes #1576
Closes #1575

## Test plan
- [ ] Open the shop — "Your Jokers" section has its own container with visible border/background, distinct from "Cards for Sale"
- [ ] Owned jokers render at full opacity (no dimming)
- [ ] With zero jokers, the container still shows with "Your joker slots are empty"
- [ ] Open a joker booster pack — "Your Jokers" container is visible during pack selection
- [ ] During gameplay scoring animation, joker dimming still works (opacity on wrapper div)

🤖 Generated with [Claude Code](https://claude.com/claude-code)