### PR TITLE
feat(comet-cards): full round scoring log with per-hand event breakdown

### DIFF
--- a/src/app/comet-cards/components/mini-scoring-log.tsx
+++ b/src/app/comet-cards/components/mini-scoring-log.tsx
@@ -1,4 +1,7 @@
-import type { HandResult } from '@/app/comet-cards/domain/game/types'
+'use client'
+
+import { useState } from 'react'
+import type { HandResult, ScoringEvent } from '@/app/comet-cards/domain/game/types'
 
 const handIdToName: Record<string, string> = {
   highCard: 'High Card',
@@ -15,11 +18,46 @@ const handIdToName: Record<string, string> = {
   flushFive: 'Flush Five',
 }
 
+function ScoringEventRow({ event, isLast }: { event: ScoringEvent; isLast: boolean }) {
+  const prefix = isLast ? '└' : '├'
+  const isChips = event.type === 'chips'
+  const operator = event.operator ?? '+'
+  const color = isChips ? 'var(--cc-mint)' : 'var(--cc-pink)'
+
+  return (
+    <div
+      className="flex items-center justify-between gap-2"
+      style={{ fontSize: 9, opacity: 0.85, paddingLeft: 8 }}
+    >
+      <span style={{ fontFamily: 'var(--cc-font-mono)', color: 'rgba(255,255,255,0.4)', flexShrink: 0 }}>
+        {prefix}
+      </span>
+      <span
+        style={{
+          fontFamily: 'var(--cc-font-mono)',
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+          whiteSpace: 'nowrap',
+          flex: 1,
+          marginLeft: 4,
+        }}
+      >
+        {event.source}
+      </span>
+      <span style={{ flexShrink: 0, fontFamily: 'var(--cc-font-mono)', color }}>
+        {operator}{event.value} {event.type}
+      </span>
+    </div>
+  )
+}
+
 export function MiniScoringLog({ handResults }: { handResults: HandResult[] }) {
+  const [expandedIndex, setExpandedIndex] = useState<number | null>(null)
+
   if (handResults.length === 0) return null
 
-  // Show last 5 hands, most recent first
-  const recentHands = [...handResults].reverse().slice(0, 5)
+  // Show all hands, most recent first
+  const allHands = [...handResults].reverse()
 
   return (
     <div
@@ -27,26 +65,58 @@ export function MiniScoringLog({ handResults }: { handResults: HandResult[] }) {
         fontFamily: 'var(--cc-font-mono)',
         fontSize: 10,
         lineHeight: 1.6,
+        maxHeight: 200,
+        overflowY: 'auto',
+        scrollbarWidth: 'thin',
       }}
     >
-      {recentHands.map((hand, i) => (
-        <div
-          key={i}
-          className="flex items-center justify-between gap-2"
-          style={{ opacity: i === 0 ? 1 : 0.6 }}
-        >
-          <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-            {handIdToName[hand.handType] ?? hand.handType}
-          </span>
-          <span style={{ flexShrink: 0 }}>
-            <span style={{ color: 'var(--cc-mint)' }}>{hand.chips}</span>
-            <span style={{ opacity: 0.4, margin: '0 2px' }}>×</span>
-            <span style={{ color: 'var(--cc-pink)' }}>{hand.mult}</span>
-            <span style={{ opacity: 0.4, margin: '0 4px' }}>=</span>
-            <span style={{ fontWeight: 600 }}>{hand.score.toLocaleString()}</span>
-          </span>
-        </div>
-      ))}
+      {allHands.map((hand, i) => {
+        const isExpanded = expandedIndex === i
+        const hasEvents = hand.scoringEventLog && hand.scoringEventLog.length > 0
+
+        return (
+          <div key={i}>
+            <div
+              className="flex items-center justify-between gap-2"
+              style={{
+                opacity: i === 0 ? 1 : 0.6,
+                cursor: hasEvents ? 'pointer' : 'default',
+              }}
+              onClick={() => {
+                if (!hasEvents) return
+                setExpandedIndex(isExpanded ? null : i)
+              }}
+            >
+              <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', flex: 1 }}>
+                {hasEvents && (
+                  <span style={{ opacity: 0.4, marginRight: 4, fontSize: 8 }}>
+                    {isExpanded ? '▾' : '▸'}
+                  </span>
+                )}
+                {handIdToName[hand.handType] ?? hand.handType}
+              </span>
+              <span style={{ flexShrink: 0 }}>
+                <span style={{ color: 'var(--cc-mint)' }}>{hand.chips}</span>
+                <span style={{ opacity: 0.4, margin: '0 2px' }}>×</span>
+                <span style={{ color: 'var(--cc-pink)' }}>{hand.mult}</span>
+                <span style={{ opacity: 0.4, margin: '0 4px' }}>=</span>
+                <span style={{ fontWeight: 600 }}>{hand.score.toLocaleString()}</span>
+              </span>
+            </div>
+            {isExpanded && hasEvents && (
+              <div style={{ marginBottom: 2 }}>
+                {hand.scoringEventLog.map((event, ei) => (
+                  <ScoringEventRow
+                    key={event.id}
+                    event={event}
+                    isLast={ei === hand.scoringEventLog.length - 1}
+                  />
+                ))}
+              </div>
+            )}
+          </div>
+        )
+      })}
     </div>
   )
 }

--- a/src/app/comet-cards/domain/game/handlers.ts
+++ b/src/app/comet-cards/domain/game/handlers.ts
@@ -10,7 +10,7 @@ import { dealCardsFromDrawPile, getHand } from './card-registry-utils'
 import { HAND_SIZE } from './constants'
 import { calculateAnte, calculateInterest, collectEffects, getBlindDefinition } from './utils'
 
-import type { GamePlayState, GameState } from './types'
+import type { GamePlayState, GameState, ScoringEvent } from './types'
 import type { Draft } from 'immer'
 
 type HandEndOutcome = 'gameOver' | 'blindRewards' | 'continue'
@@ -78,11 +78,18 @@ function decideHandEndOutcome(args: {
 
 function resetScoreForNextHand(gamePlayState: Draft<GamePlayState>, handType?: string) {
   gamePlayState.isScoring = false
+
+  // Capture scoring events that are ScoringEvents (have 'source'), not CustomScoringEvents
+  const scoringEventLog = gamePlayState.scoringEvents.filter(
+    (e): e is ScoringEvent => 'source' in e
+  )
+
   gamePlayState.handResults.push({
     handType: handType ?? 'unknown',
     chips: gamePlayState.score.chips,
     mult: gamePlayState.score.mult,
     score: Math.floor(gamePlayState.score.chips * gamePlayState.score.mult),
+    scoringEventLog: scoringEventLog.map(e => ({ ...e })),
   })
   gamePlayState.scoringEvents.push({
     id: uuid(),

--- a/src/app/comet-cards/domain/game/types.ts
+++ b/src/app/comet-cards/domain/game/types.ts
@@ -141,6 +141,7 @@ export interface HandResult {
   chips: number
   mult: number
   score: number  // chips * mult
+  scoringEventLog: ScoringEvent[]  // joker activations for this hand
 }
 
 export interface Stake {


### PR DESCRIPTION
## Summary

- Adds `scoringEventLog: ScoringEvent[]` to the `HandResult` interface so each played hand carries its full list of joker/card scoring events
- In `resetScoreForNextHand()`, filters `scoringEvents` to only `ScoringEvent` entries (those with a `source` field, not `CustomScoringEvent`) and deep-copies them into the hand result before the score is cleared
- Rewrites `MiniScoringLog` to: show all hands (no 5-hand cap), scroll with `maxHeight: 200px` / `scrollbar-width: thin`, and support click-to-expand each hand row to reveal its per-event breakdown (`├`/`└` tree style, mint for chips, pink for mult)

Closes #1579

## Test plan

- [x] `npx vitest run src/app/comet-cards/domain/game/__tests__/` — 220 test files, 598 tests, all pass
- [x] `npx tsc --noEmit` — no type errors
- [ ] Manual: play a hand with jokers active, verify scoring log row is expandable and shows the correct joker activations

🤖 Generated with [Claude Code](https://claude.com/claude-code)