### PR TITLE
fix(comet-cards): emit ROUND_END event on cash out so joker payouts trigger

### DIFF
--- a/src/app/comet-cards/components/game-views/blind-rewards.tsx
+++ b/src/app/comet-cards/components/game-views/blind-rewards.tsx
@@ -126,6 +126,7 @@ export function BlindRewardsView() {
                 disabled={hasCashedOut}
                 onClick={() => {
                   setHasCashedOut(true)
+                  eventEmitter.emit({ type: 'ROUND_END' })
                   eventEmitter.emit({ type: 'BLIND_REWARDS_END' })
                 }}
               >


### PR DESCRIPTION
## Summary

- Closes #1586
- Adds `eventEmitter.emit({ type: 'ROUND_END' })` in `blind-rewards.tsx` before the existing `BLIND_REWARDS_END` emit when the player clicks "Cash Out"
- The `ROUND_END` reducer handler was already correct; the event was simply never being fired, preventing 14 jokers (Rocket and others) from triggering their end-of-round payouts

## Root cause

`ROUND_END` was defined in the type system and handled in `reduce-game.ts`, but no UI component ever emitted it. Clicking "Cash Out" only fired `BLIND_REWARDS_END`, which skips the joker effect dispatch.

## Test plan

- [x] `npx vitest run src/app/comet-cards/domain/game/__tests__/rocket.test.ts` — 4/4 pass
- [x] `npx vitest run src/app/comet-cards/domain/game/__tests__/golden-joker.test.ts` — 1/1 pass
- [x] `npx vitest run src/app/comet-cards/domain/game/__tests__/cloud-9.test.ts` — 2/2 pass
- [x] `npx tsc --noEmit` — no type errors
- [x] `npx vitest run` — 1715/1715 tests pass across 300 test files

🤖 Generated with [Claude Code](https://claude.com/claude-code)