### PR TITLE
fix(comet-cards): add left padding to stat strip so close button doesn't overlap

### DIFF
--- a/src/app/comet-cards/components/game-views/view-template.tsx
+++ b/src/app/comet-cards/components/game-views/view-template.tsx
@@ -76,7 +76,7 @@ export function ViewTemplate({
       <div
         className="relative z-10 flex flex-wrap items-center justify-between gap-4"
         style={{
-          padding: isLandscape ? '8px 12px' : '12px 22px',
+          padding: isLandscape ? '8px 12px 8px 40px' : '12px 22px 12px 40px',
           borderBottom: '1px solid var(--cc-panel-divider)',
         }}
       >


### PR DESCRIPTION
Closes #1588

The close button is absolutely positioned at top:12, left:12 in the shell, extending to approximately 36px from the left edge. 

This fix adds 40px left padding to the stat strip in both landscape and portrait modes, preventing text overlap with the close button.

**Changed:**
- Modified padding in view-template.tsx line 79:
  - Landscape: '8px 12px' → '8px 12px 8px 40px' (top right bottom left)
  - Portrait: '12px 22px' → '12px 22px 12px 40px' (top right bottom left)

**Verified:** TypeScript compilation with no errors.