### PR TITLE
fix(comet-cards): pin joker sell action bar to bottom of viewport in landscape

### DIFF
--- a/src/app/comet-cards/components/game-views/gameplay.tsx
+++ b/src/app/comet-cards/components/game-views/gameplay.tsx
@@ -213,7 +213,7 @@ export function GamePlayView() {
 
       {isLandscape ? (
         /* ── LANDSCAPE MOBILE: single-column flex ── */
-        <div className="relative z-10 flex flex-col flex-1" style={{ gap: 0 }}>
+        <div className="relative z-10 flex flex-col flex-1" style={{ gap: 0, overflow: 'hidden' }}>
           {/* Compact info bar */}
           <div
             className="flex flex-wrap items-center justify-between"
@@ -329,7 +329,7 @@ export function GamePlayView() {
           </div>
 
           {/* Play area + Hand */}
-          <div className="flex-1 flex flex-col justify-end">
+          <div className="flex-1 flex flex-col justify-end" style={{ overflowY: 'auto' }}>
             <LayoutGroup>
               <PlayArea cards={playedCards} visible={isScoring} />
               <div className="flex items-end justify-center" style={{ paddingBottom: 4, paddingTop: 4 }}>
@@ -540,6 +540,11 @@ export function GamePlayView() {
                 borderTop: '1px solid var(--cc-panel-divider)',
                 fontFamily: 'var(--cc-font-mono)',
                 fontSize: 10,
+                position: 'sticky',
+                bottom: 0,
+                background: 'var(--cc-bg, #0a0a0f)',
+                zIndex: 20,
+                flexShrink: 0,
               }}
             >
               {selectedJoker && selectedJokerDefinition && (


### PR DESCRIPTION
## Summary

- Adds `overflow: hidden` to the landscape mobile container so it doesn't grow beyond the viewport
- Makes the selected item actions bar `position: sticky` at `bottom: 0` so it always remains visible regardless of how many cards are in hand
- Adds `overflow-y: auto` to the play area / hand section so it becomes the scrollable region while the action bar stays pinned

Closes #1589

## Test plan

- [ ] Open the game on a landscape mobile viewport (or resize browser to landscape orientation)
- [ ] Acquire several jokers so the hand area is tall
- [ ] Select a joker — confirm the "Sell $X" button is visible at the bottom without scrolling
- [ ] Select a consumable — confirm Use/Sell buttons are visible at the bottom
- [ ] Confirm the hand/play area scrolls independently above the pinned bar
- [ ] Confirm desktop layout is unaffected (the changes only apply inside the `isLandscape` branch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)