### PR TITLE
feat(comet-cards): tap-to-swap joker reordering

### DIFF
--- a/src/app/comet-cards/components/game-views/gameplay.tsx
+++ b/src/app/comet-cards/components/game-views/gameplay.tsx
@@ -390,6 +390,8 @@ export function GamePlayView() {
                   onClick={() => {
                     if (gamePlayState.selectedJokerId === joker.id) {
                       eventEmitter.emit({ type: 'JOKER_DESELECTED', id: joker.id })
+                    } else if (gamePlayState.selectedJokerId) {
+                      eventEmitter.emit({ type: 'JOKER_SWAP', fromId: gamePlayState.selectedJokerId, toId: joker.id })
                     } else {
                       eventEmitter.emit({ type: 'JOKER_SELECTED', id: joker.id })
                     }
@@ -399,7 +401,11 @@ export function GamePlayView() {
                     flexShrink: 0,
                     padding: '3px 8px',
                     borderRadius: 4,
-                    border: `1px solid ${gamePlayState.selectedJokerId === joker.id ? RARITY_ACCENT[def.rarity] ?? 'var(--cc-mint)' : 'rgba(94,234,212,0.2)'}`,
+                    border: gamePlayState.selectedJokerId === joker.id
+                      ? `1px solid ${RARITY_ACCENT[def.rarity] ?? 'var(--cc-mint)'}`
+                      : gamePlayState.selectedJokerId
+                        ? '1px dashed rgba(94,234,212,0.45)'
+                        : '1px solid rgba(94,234,212,0.2)',
                     background: gamePlayState.selectedJokerId === joker.id ? 'rgba(94,234,212,0.1)' : 'transparent',
                     color: RARITY_ACCENT[def.rarity] ?? 'var(--cc-mint)',
                     fontFamily: 'var(--cc-font-mono)',
@@ -975,6 +981,7 @@ export function GamePlayView() {
                       <Joker
                         joker={joker}
                         isSelected={gamePlayState.selectedJokerId === joker.id}
+                        isSwapTarget={!!gamePlayState.selectedJokerId && gamePlayState.selectedJokerId !== joker.id}
                         ownedCardCount={game.ownedCardIds.length}
                         gameSeed={game.gameSeed}
                         roundIndex={game.roundIndex}
@@ -982,6 +989,8 @@ export function GamePlayView() {
                         onClick={(isSelected, id) => {
                           if (isSelected) {
                             eventEmitter.emit({ type: 'JOKER_DESELECTED', id })
+                          } else if (gamePlayState.selectedJokerId) {
+                            eventEmitter.emit({ type: 'JOKER_SWAP', fromId: gamePlayState.selectedJokerId, toId: id })
                           } else {
                             eventEmitter.emit({ type: 'JOKER_SELECTED', id })
                           }

--- a/src/app/comet-cards/components/gameplay/joker.tsx
+++ b/src/app/comet-cards/components/gameplay/joker.tsx
@@ -43,6 +43,7 @@ const CASTLE_SUITS = ['\u2665', '\u2666', '\u2663', '\u2660'] as const
 export const Joker = ({
   joker,
   isSelected,
+  isSwapTarget,
   onClick,
   ownedCardCount,
   gameSeed,
@@ -51,6 +52,7 @@ export const Joker = ({
 }: {
   joker: JokerState
   isSelected?: boolean
+  isSwapTarget?: boolean
   onClick?: (isSelected: boolean, id: string) => void
   ownedCardCount?: number
   gameSeed?: string
@@ -206,7 +208,14 @@ export const Joker = ({
   ].filter(Boolean).join(' ') || undefined
 
   return (
-    <div className={wrapperClass}>
+    <div
+      className={wrapperClass}
+      style={isSwapTarget ? {
+        borderRadius: 14,
+        outline: '2px dashed rgba(94,234,212,0.5)',
+        outlineOffset: 2,
+      } : undefined}
+    >
       <TokenCard
         title={def?.name ?? 'Unknown'}
         description={def?.description}

--- a/src/app/comet-cards/components/joker/current-jokers.tsx
+++ b/src/app/comet-cards/components/joker/current-jokers.tsx
@@ -37,12 +37,15 @@ export const CurrentJokers = () => {
                 key={joker.id}
                 joker={joker}
                 isSelected={game.gamePlayState.selectedJokerId === joker.id}
+                isSwapTarget={!!game.gamePlayState.selectedJokerId && game.gamePlayState.selectedJokerId !== joker.id}
                 ownedCardCount={game.ownedCardIds.length}
                 gameSeed={game.gameSeed}
                 roundIndex={game.roundIndex}
                 onClick={(isSelected, id) => {
                   if (isSelected) {
                     eventEmitter.emit({ type: 'JOKER_DESELECTED', id })
+                  } else if (game.gamePlayState.selectedJokerId) {
+                    eventEmitter.emit({ type: 'JOKER_SWAP', fromId: game.gamePlayState.selectedJokerId, toId: id })
                   } else {
                     eventEmitter.emit({ type: 'JOKER_SELECTED', id })
                   }

--- a/src/app/comet-cards/domain/events/event-emitter.ts
+++ b/src/app/comet-cards/domain/events/event-emitter.ts
@@ -28,6 +28,7 @@ class EventEmitter {
     JOKER_SELECTED: [],
     JOKER_DESELECTED: [],
     JOKER_SOLD: [],
+    JOKER_SWAP: [],
     ROUND_END: [],
     SHOP_OPEN: [],
     SHOP_SELECT_CARD: [],

--- a/src/app/comet-cards/domain/events/types.ts
+++ b/src/app/comet-cards/domain/events/types.ts
@@ -32,6 +32,7 @@ export type GameEvent =
   | JokerSelectedEvent
   | JokerDeselectedEvent
   | JokerSoldEvent
+  | JokerSwapEvent
   | RoundEndEvent
   | RoundStartEvent
   | ShopSelectBlindEvent
@@ -176,6 +177,11 @@ export type JokerDeselectedEvent = {
 }
 export type JokerSoldEvent = {
   type: 'JOKER_SOLD'
+}
+export type JokerSwapEvent = {
+  type: 'JOKER_SWAP'
+  fromId: string
+  toId: string
 }
 export type RoundEndEvent = {
   type: 'ROUND_END'

--- a/src/app/comet-cards/domain/game/reduce-game.ts
+++ b/src/app/comet-cards/domain/game/reduce-game.ts
@@ -314,6 +314,17 @@ export function reduceGame(game: GameState, event: GameEvent): GameState {
         gamePlayState.selectedJokerId = undefined
         return
       }
+      case 'JOKER_SWAP': {
+        const fromIdx = draft.jokers.findIndex(j => j.id === event.fromId)
+        const toIdx = draft.jokers.findIndex(j => j.id === event.toId)
+        if (fromIdx !== -1 && toIdx !== -1 && fromIdx !== toIdx) {
+          const temp = draft.jokers[fromIdx]
+          draft.jokers[fromIdx] = draft.jokers[toIdx]
+          draft.jokers[toIdx] = temp
+        }
+        draft.gamePlayState.selectedJokerId = undefined
+        return
+      }
       case 'JOKER_SOLD': {
         const selectedJoker = draft.jokers.find(
           joker => joker.id === draft.gamePlayState.selectedJokerId


### PR DESCRIPTION
## Summary

- Adds a `JOKER_SWAP` event type that swaps two jokers by their `id` in `game.jokers`
- Handles `JOKER_SWAP` in the reducer (immer swap + clears `selectedJokerId`)
- Updates click handlers in both desktop and landscape-mobile gameplay views: clicking a second joker when one is already selected emits `JOKER_SWAP` instead of `JOKER_SELECTED`
- Adds a dashed outline visual hint on all swap-target jokers when one is selected (both via the `Joker` component and the inline landscape button border)
- Applies the same swap logic to `CurrentJokers` (shop view)

Closes #1580

## Test plan

- [x] `npx tsc --noEmit` — no type errors
- [x] `npx vitest run` — 300 test files, 1715 tests, all pass
- [ ] Manual: tap joker A → selected state + dashed outline on others → tap joker B → positions swap, selection clears
- [ ] Manual: tap same joker twice → deselects (existing behavior preserved)
- [ ] Manual: verify swap works in shop view (CurrentJokers)
- [ ] Manual: verify works on both desktop and landscape mobile layouts

🤖 Generated with [Claude Code](https://claude.com/claude-code)