### PR TITLE
ui(comet-cards): show joker count vs max in panel headers

### DIFF
--- a/src/app/comet-cards/components/game-views/shop.tsx
+++ b/src/app/comet-cards/components/game-views/shop.tsx
@@ -94,7 +94,7 @@ export function ShopView() {
           subtitle={`$${game.money} on hand`}
         >
           <div className="flex flex-col" style={{ padding: 16, gap: 18 }}>
-            <SectionHeader label="Your Jokers">
+            <SectionHeader label={`Your Jokers (${game.jokers.length}/${game.maxJokers})`}>
               <CurrentJokers />
             </SectionHeader>
 

--- a/src/app/comet-cards/components/pack-open/joker-card-open-booster-pack.tsx
+++ b/src/app/comet-cards/components/pack-open/joker-card-open-booster-pack.tsx
@@ -44,7 +44,7 @@ export function JokerCardOpenBoosterPack() {
             marginBottom: 8,
           }}
         >
-          Your Jokers
+          Your Jokers ({game.jokers.length}/{game.maxJokers})
         </div>
         <CurrentJokers />
       </div>


### PR DESCRIPTION
Closes #1594

## Summary
Add joker count display (current / max) to panel headers in two views to match the existing display in the gameplay panel.

## Changes
- **Shop view**: Updated "Your Jokers" header to show count
- **Pack opening view**: Updated "Your Jokers" text to show count

Both now display the format: "Your Jokers (X/Y)" to make it clear how many joker slots are available vs used.

## Type check
Verified with `npx tsc --noEmit` - no type errors.