### PR TITLE
fix(comet-cards): Rocket joker payout increment — check inProgress not completed

### DIFF
--- a/src/app/comet-cards/domain/game/__tests__/rocket.test.ts
+++ b/src/app/comet-cards/domain/game/__tests__/rocket.test.ts
@@ -38,7 +38,7 @@ describe('Rocket joker', () => {
       ...started,
       rounds: started.rounds.map((round, i) =>
         i === started.roundIndex
-          ? { ...round, bossBlind: { ...round.bossBlind, status: 'completed' as const } }
+          ? { ...round, bossBlind: { ...round.bossBlind, status: 'inProgress' as const } }
           : round
       ),
     }

--- a/src/app/comet-cards/domain/joker/jokers.ts
+++ b/src/app/comet-cards/domain/joker/jokers.ts
@@ -655,7 +655,7 @@ export const rocketJoker: JokerDefinition = {
       apply: (ctx: EffectContext) => {
         const rk = ctx.game.jokers.find(j => j.jokerId === 'rocketJoker')
         if (rk) {
-          rk.metadata = { ...rk.metadata, payout: 1, lastBossRound: -1 }
+          rk.metadata = { ...rk.metadata, payout: rk.metadata?.payout ?? 1, lastBossRound: rk.metadata?.lastBossRound ?? -1 }
         }
       },
     },
@@ -673,7 +673,7 @@ export const rocketJoker: JokerDefinition = {
         const round = ctx.game.rounds[ctx.game.roundIndex]
         if (
           round &&
-          round.bossBlind.status === 'completed' &&
+          round.bossBlind.status === 'inProgress' &&
           rk.metadata.lastBossRound !== ctx.game.roundIndex
         ) {
           rk.metadata.payout += 2


### PR DESCRIPTION
## Summary

- Fixes Rocket joker's `ROUND_END` handler to check `bossBlind.status === 'inProgress'` instead of `'completed'`. `ROUND_END` fires before `BLIND_REWARDS_END`, so the blind status is still `inProgress` at the time payout logic runs.
- Fixes `JOKER_ADDED` handler to preserve existing `payout` and `lastBossRound` metadata (using `?? default`) instead of unconditionally resetting them — same pattern as #1584 for Spare Trousers.
- Updates `rocket.test.ts` to set `bossBlind.status = 'inProgress'` to match the corrected behavior.

Closes #1597

## Test plan

- [ ] `npx vitest run src/app/comet-cards/domain/game/__tests__/rocket.test.ts` — all 4 tests pass
- [ ] Full `npx vitest run` — all tests pass
- [ ] `npx tsc --noEmit` — no type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)