### PR TITLE
fix(comet-cards): prevent duplicate cards in booster packs

### DIFF
--- a/src/app/comet-cards/domain/randomness/index.ts
+++ b/src/app/comet-cards/domain/randomness/index.ts
@@ -52,15 +52,28 @@ export function getRandomNumbersWithSeed({
   min,
   max,
   numberOfNumbers,
+  unique = false,
 }: {
   seed: string
   min: number
   max: number
   numberOfNumbers: number
+  unique?: boolean
 }) {
   const seedFn = xmur3(seed)
   const rng = mulberry32(seedFn())
-  return Array.from({ length: numberOfNumbers }, () => Math.floor(rng() * (max - min + 1)) + min)
+  if (!unique) {
+    return Array.from({ length: numberOfNumbers }, () => Math.floor(rng() * (max - min + 1)) + min)
+  }
+  // Unique selection: Fisher-Yates partial shuffle
+  const range = max - min + 1
+  const count = Math.min(numberOfNumbers, range)
+  const pool = Array.from({ length: range }, (_, i) => i + min)
+  for (let i = 0; i < count; i++) {
+    const j = i + Math.floor(rng() * (range - i))
+    ;[pool[i], pool[j]] = [pool[j], pool[i]]
+  }
+  return pool.slice(0, count)
 }
 
 export function getRandomWeightedNumberWithSeed({

--- a/src/app/comet-cards/domain/shop/utils.ts
+++ b/src/app/comet-cards/domain/shop/utils.ts
@@ -117,6 +117,7 @@ export function getRandomCelestialCards(
     min: 0,
     max: allCelestialCards.length - 1,
     numberOfNumbers: numberOfCards,
+    unique: true,
   })
   return randomCardIndices.map(index => allCelestialCards[index])
 }
@@ -128,6 +129,7 @@ export function getRandomTarotCards(numberOfCards: number, seed: string): TarotC
     min: 0,
     max: allTarotCards.length - 1,
     numberOfNumbers: numberOfCards,
+    unique: true,
   })
   return randomCardIndices.map(index => allTarotCards[index])
 }
@@ -142,6 +144,7 @@ export function getRandomPlayingCards(
     min: 0,
     max: allPlayingCards.length - 1,
     numberOfNumbers: numberOfCards,
+    unique: true,
   })
   return randomCardIndices.map(index => allPlayingCards[index])
 }
@@ -153,6 +156,7 @@ export function getRandomJokers(numberOfCards: number, seed: string, excludeIds:
     min: 0,
     max: allJokers.length - 1,
     numberOfNumbers: numberOfCards,
+    unique: true,
   })
   return randomCardIndices.map(index => allJokers[index])
 }


### PR DESCRIPTION
## Summary

- Closes #1598
- `getRandomNumbersWithSeed` in `randomness/index.ts` now accepts a `unique?: boolean` option; when `true`, it uses a Fisher-Yates partial shuffle to guarantee no repeated indices
- `getRandomCelestialCards`, `getRandomTarotCards`, `getRandomPlayingCards`, and `getRandomJokers` in `shop/utils.ts` all pass `unique: true`, eliminating duplicate cards from booster packs

## Test plan

- [x] `npx vitest run` — all tests pass
- [x] `npx tsc --noEmit` — no type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)