### PR TITLE
fix(comet-cards): delay pack exit so card effects are visible

### DIFF
--- a/src/app/comet-cards/components/pack-open/celestial-card-open-booster-pack.tsx
+++ b/src/app/comet-cards/components/pack-open/celestial-card-open-booster-pack.tsx
@@ -8,6 +8,7 @@ import { useGridKeyboardNav } from '@/app/comet-cards/hooks/useGridKeyboardNav'
 import { useGameState } from '@/app/comet-cards/useGameState'
 import { Button } from '@/components/ui/button'
 import { motion, useReducedMotion } from 'framer-motion'
+import { useEffect } from 'react'
 
 const containerVariants = {
   hidden: {},
@@ -28,6 +29,18 @@ export function CelestialCardOpenBoosterPack() {
   const reducedMotion = useReducedMotion()
   const { game } = useGameState()
   const { containerRef, handleKeyDown } = useGridKeyboardNav()
+
+  const remainingCardsToSelect = game.shopState.openPackState?.remainingCardsToSelect
+
+  useEffect(() => {
+    if (remainingCardsToSelect === 0) {
+      const timer = setTimeout(() => {
+        eventEmitter.emit({ type: 'SHOP_CLOSE_PACK' })
+      }, 1200)
+      return () => clearTimeout(timer)
+    }
+  }, [remainingCardsToSelect])
+
   if (!game.shopState.openPackState) return <div>No pack open</div>
   const cardsForSale = game.shopState.openPackState.cards
 

--- a/src/app/comet-cards/components/pack-open/joker-card-open-booster-pack.tsx
+++ b/src/app/comet-cards/components/pack-open/joker-card-open-booster-pack.tsx
@@ -8,6 +8,7 @@ import { useGridKeyboardNav } from '@/app/comet-cards/hooks/useGridKeyboardNav'
 import { useGameState } from '@/app/comet-cards/useGameState'
 import { Button } from '@/components/ui/button'
 import { motion, useReducedMotion } from 'framer-motion'
+import { useEffect } from 'react'
 
 const containerVariants = {
   hidden: {},
@@ -28,6 +29,18 @@ export function JokerCardOpenBoosterPack() {
   const reducedMotion = useReducedMotion()
   const { game } = useGameState()
   const { containerRef, handleKeyDown } = useGridKeyboardNav()
+
+  const remainingCardsToSelect = game.shopState.openPackState?.remainingCardsToSelect
+
+  useEffect(() => {
+    if (remainingCardsToSelect === 0) {
+      const timer = setTimeout(() => {
+        eventEmitter.emit({ type: 'SHOP_CLOSE_PACK' })
+      }, 1200)
+      return () => clearTimeout(timer)
+    }
+  }, [remainingCardsToSelect])
+
   if (!game.shopState.openPackState) return <div>No pack open</div>
   const cardsForSale = game.shopState.openPackState.cards
 

--- a/src/app/comet-cards/components/pack-open/playing-card-open-booster-pack.tsx
+++ b/src/app/comet-cards/components/pack-open/playing-card-open-booster-pack.tsx
@@ -6,6 +6,7 @@ import { useGridKeyboardNav } from '@/app/comet-cards/hooks/useGridKeyboardNav'
 import { useGameState } from '@/app/comet-cards/useGameState'
 import { Button } from '@/components/ui/button'
 import { motion, useReducedMotion } from 'framer-motion'
+import { useEffect } from 'react'
 
 const containerVariants = {
   hidden: {},
@@ -26,6 +27,18 @@ export function PlayingCardOpenBoosterPack() {
   const reducedMotion = useReducedMotion()
   const { game } = useGameState()
   const { containerRef, handleKeyDown } = useGridKeyboardNav()
+
+  const remainingCardsToSelect = game.shopState.openPackState?.remainingCardsToSelect
+
+  useEffect(() => {
+    if (remainingCardsToSelect === 0) {
+      const timer = setTimeout(() => {
+        eventEmitter.emit({ type: 'SHOP_CLOSE_PACK' })
+      }, 1200)
+      return () => clearTimeout(timer)
+    }
+  }, [remainingCardsToSelect])
+
   if (!game.shopState.openPackState) return <div>No pack open</div>
   const cardsForSale = game.shopState.openPackState.cards
 

--- a/src/app/comet-cards/components/pack-open/spectral-card-open-booster-pack.tsx
+++ b/src/app/comet-cards/components/pack-open/spectral-card-open-booster-pack.tsx
@@ -10,6 +10,7 @@ import { useGridKeyboardNav } from '@/app/comet-cards/hooks/useGridKeyboardNav'
 import { useGameState } from '@/app/comet-cards/useGameState'
 import { Button } from '@/components/ui/button'
 import { motion, useReducedMotion } from 'framer-motion'
+import { useEffect } from 'react'
 
 const containerVariants = {
   hidden: {},
@@ -30,6 +31,18 @@ export function SpectralCardOpenBoosterPack() {
   const reducedMotion = useReducedMotion()
   const { game } = useGameState()
   const { containerRef, handleKeyDown } = useGridKeyboardNav()
+
+  const remainingCardsToSelect = game.shopState.openPackState?.remainingCardsToSelect
+
+  useEffect(() => {
+    if (remainingCardsToSelect === 0) {
+      const timer = setTimeout(() => {
+        eventEmitter.emit({ type: 'SHOP_CLOSE_PACK' })
+      }, 1200)
+      return () => clearTimeout(timer)
+    }
+  }, [remainingCardsToSelect])
+
   if (!game.shopState.openPackState) return <div>No pack open</div>
   const cardsForSale = game.shopState.openPackState.cards
 

--- a/src/app/comet-cards/components/pack-open/tarot-card-open-booster-pack.tsx
+++ b/src/app/comet-cards/components/pack-open/tarot-card-open-booster-pack.tsx
@@ -10,6 +10,7 @@ import { useGridKeyboardNav } from '@/app/comet-cards/hooks/useGridKeyboardNav'
 import { useGameState } from '@/app/comet-cards/useGameState'
 import { Button } from '@/components/ui/button'
 import { motion, useReducedMotion } from 'framer-motion'
+import { useEffect } from 'react'
 
 const containerVariants = {
   hidden: {},
@@ -30,6 +31,18 @@ export function TarotCardOpenBoosterPack() {
   const reducedMotion = useReducedMotion()
   const { game } = useGameState()
   const { containerRef, handleKeyDown } = useGridKeyboardNav()
+
+  const remainingCardsToSelect = game.shopState.openPackState?.remainingCardsToSelect
+
+  useEffect(() => {
+    if (remainingCardsToSelect === 0) {
+      const timer = setTimeout(() => {
+        eventEmitter.emit({ type: 'SHOP_CLOSE_PACK' })
+      }, 1200)
+      return () => clearTimeout(timer)
+    }
+  }, [remainingCardsToSelect])
+
   if (!game.shopState.openPackState) return <div>No pack open</div>
   const cardsForSale = game.shopState.openPackState.cards
 

--- a/src/app/comet-cards/domain/events/event-emitter.ts
+++ b/src/app/comet-cards/domain/events/event-emitter.ts
@@ -47,6 +47,7 @@ class EventEmitter {
     SHOP_USE_SPECTRAL_CARD_FROM_PACK: [],
     PACK_OPEN_SKIP: [],
     GIVE_UP: [],
+    SHOP_CLOSE_PACK: [],
     SHOP_BUY_AND_USE_CARD: [],
     SHOP_BUY_VOUCHER: [],
     SHOP_END: [],

--- a/src/app/comet-cards/domain/events/types.ts
+++ b/src/app/comet-cards/domain/events/types.ts
@@ -62,6 +62,7 @@ export type GameEvent =
   | ShopUseSpectralCardFromPackEvent
   | PackOpenSkipEvent
   | GiveUpEvent
+  | ShopClosePackEvent
 
 export type ShopBuyCardEvent = {
   type: 'SHOP_BUY_CARD'
@@ -91,6 +92,9 @@ export type PackOpenSkipEvent = {
 }
 export type GiveUpEvent = {
   type: 'GIVE_UP'
+}
+export type ShopClosePackEvent = {
+  type: 'SHOP_CLOSE_PACK'
 }
 export type ShopBuyAndUseCardEvent = {
   type: 'SHOP_BUY_AND_USE_CARD'

--- a/src/app/comet-cards/domain/game/handlers/shop.ts
+++ b/src/app/comet-cards/domain/game/handlers/shop.ts
@@ -109,11 +109,8 @@ export function handleShopSelectPlayingCardFromPack(
   if (!draft.shopState.openPackState) return
 
   draft.shopState.openPackState.remainingCardsToSelect -= 1
-
-  if (draft.shopState.openPackState.remainingCardsToSelect === 0) {
-    draft.gamePhase = 'shop'
-    draft.shopState.openPackState = null
-  }
+  // Don't immediately close the pack — the UI will detect remainingCardsToSelect === 0
+  // and emit SHOP_CLOSE_PACK after a delay so the player can see the effect.
 }
 
 export function handleShopSelectJokerFromPack(
@@ -137,10 +134,8 @@ export function handleShopSelectJokerFromPack(
   const ctx = getEffectContext(draft, event)
   dispatchEffects(jokerAddedEvent, ctx, collectEffects(ctx.game))
 
-  if (draft.shopState.openPackState.remainingCardsToSelect === 0) {
-    draft.gamePhase = 'shop'
-    draft.shopState.openPackState = null
-  }
+  // Don't immediately close the pack — the UI will detect remainingCardsToSelect === 0
+  // and emit SHOP_CLOSE_PACK after a delay so the player can see the effect.
 }
 
 export function handleShopUseTarotCardFromPack(
@@ -161,8 +156,6 @@ export function handleShopUseTarotCardFromPack(
   if (!draft.shopState.openPackState) return
   removeCardFromPack(draft.shopState.openPackState, id)
 
-  const isLastCardToSelect = draft.shopState.openPackState.remainingCardsToSelect === 0
-
   // Create effect context for dispatching effects
   const tarotCardUsedEvent: GameEvent = { type: 'TAROT_CARD_USED' }
   const ctx = getEffectContext(draft, event)
@@ -175,10 +168,8 @@ export function handleShopUseTarotCardFromPack(
 
   // Clean up after effects have been applied
   draft.gamePlayState.selectedCardIds = []
-  if (isLastCardToSelect) {
-    draft.gamePhase = 'shop'
-    draft.shopState.openPackState = null
-  }
+  // Don't immediately close the pack — the UI will detect remainingCardsToSelect === 0
+  // and emit SHOP_CLOSE_PACK after a delay so the player can see the effect.
 }
 
 export function handleShopUseCelestialCardFromPack(
@@ -198,8 +189,6 @@ export function handleShopUseCelestialCardFromPack(
   if (!draft.shopState.openPackState) return
   removeCardFromPack(draft.shopState.openPackState, id)
 
-  const isLastCardToSelect = draft.shopState.openPackState.remainingCardsToSelect === 0
-
   // Create effect context for dispatching effects
   const celestialCardUsedEvent: GameEvent = { type: 'CELESTIAL_CARD_USED' }
   const ctx = getEffectContext(draft, event)
@@ -211,11 +200,9 @@ export function handleShopUseCelestialCardFromPack(
   dispatchEffects(celestialCardUsedEvent, ctx, collectEffects(ctx.game))
 
   // Clean up after effects have been applied
-  if (isLastCardToSelect) {
-    draft.gamePhase = 'shop'
-    draft.shopState.openPackState = null
-    draft.gamePlayState.selectedCardIds = []
-  }
+  draft.gamePlayState.selectedCardIds = []
+  // Don't immediately close the pack — the UI will detect remainingCardsToSelect === 0
+  // and emit SHOP_CLOSE_PACK after a delay so the player can see the effect.
 }
 
 export function handleShopUseSpectralCardFromPack(
@@ -232,8 +219,6 @@ export function handleShopUseSpectralCardFromPack(
   if (!draft.shopState.openPackState) return
   removeCardFromPack(draft.shopState.openPackState, id)
 
-  const isLastCardToSelect = draft.shopState.openPackState.remainingCardsToSelect === 0
-
   // Create effect context for dispatching effects
   const spectralCardUsedEvent: GameEvent = { type: 'SPECTRAL_CARD_USED' }
   const ctx = getEffectContext(draft, event)
@@ -248,11 +233,9 @@ export function handleShopUseSpectralCardFromPack(
   dispatchEffects(spectralCardUsedEvent, ctx, collectEffects(ctx.game))
 
   // Clean up after effects have been applied
-  if (isLastCardToSelect) {
-    draft.gamePhase = 'shop'
-    draft.shopState.openPackState = null
-    draft.gamePlayState.selectedCardIds = []
-  }
+  draft.gamePlayState.selectedCardIds = []
+  // Don't immediately close the pack — the UI will detect remainingCardsToSelect === 0
+  // and emit SHOP_CLOSE_PACK after a delay so the player can see the effect.
 }
 
 export function handleShopBuyCard(draft: GameState, event: ShopBuyCardEvent) {

--- a/src/app/comet-cards/domain/game/reduce-game.ts
+++ b/src/app/comet-cards/domain/game/reduce-game.ts
@@ -253,6 +253,11 @@ export function reduceGame(game: GameState, event: GameEvent): GameState {
         dispatchEffects(event, packSkipCtx, collectEffects(packSkipCtx.game))
         return
       }
+      case 'SHOP_CLOSE_PACK': {
+        draft.gamePhase = 'shop'
+        draft.shopState.openPackState = null
+        return
+      }
 
       /*
        * CONSUMABLE EVENTS


### PR DESCRIPTION
## Summary

- Closes #1602
- When the last card from any booster pack (tarot, celestial, spectral, joker, playing card) was used/selected, the game immediately transitioned to `gamePhase = 'shop'` before the player could see the card effect applied
- Removed the immediate `draft.gamePhase = 'shop'` / `draft.shopState.openPackState = null` transitions from all 5 pack handlers in `shop.ts`
- Added a new `SHOP_CLOSE_PACK` event type that performs the transition
- Each of the 5 pack opening components now has a `useEffect` that detects when `remainingCardsToSelect === 0` and emits `SHOP_CLOSE_PACK` after a 1.2 s delay, giving the player time to see the effect

## Test plan

- [ ] Open a tarot pack, use the last card — pack view should stay visible ~1.2 s showing the applied enhancement before closing
- [ ] Same for celestial, spectral, joker, and playing-card packs
- [ ] Packs with multiple cards to select still close immediately after each non-final pick (only the final pick is delayed)
- [ ] Skip button (`PACK_OPEN_SKIP`) still closes the pack immediately, unaffected
- [ ] `npx tsc --noEmit` passes (verified)
- [ ] `npx vitest run` passes — 1720 tests across 300 files (verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)