### PR TITLE
feat(comet-cards): keyboard navigation for joker cards (#1519)

### DIFF
--- a/src/app/comet-cards/components/cosmic/token-card.tsx
+++ b/src/app/comet-cards/components/cosmic/token-card.tsx
@@ -22,6 +22,7 @@ export function TokenCard({
   footer,
   typeLabel,
   edition,
+  tabIndex,
 }: {
   title: string
   description?: string
@@ -35,6 +36,7 @@ export function TokenCard({
   footer?: ReactNode
   typeLabel?: string
   edition?: string
+  tabIndex?: number
 }) {
   const dims = SIZES[size]
   const isInteractive = !!onClick && !disabled
@@ -61,6 +63,7 @@ export function TokenCard({
       aria-disabled={disabled}
       onClick={onClick}
       disabled={disabled}
+      tabIndex={tabIndex}
       className="bc-card flex flex-col"
       data-selected={selected ? 'true' : 'false'}
       style={{

--- a/src/app/comet-cards/components/game-views/gameplay.tsx
+++ b/src/app/comet-cards/components/game-views/gameplay.tsx
@@ -37,6 +37,7 @@ import { useGameState } from '@/app/comet-cards/useGameState'
 import { useLandscapeMobile } from '@/app/comet-cards/hooks/useLandscapeMobile'
 import { useRunHistory } from '@/app/comet-cards/hooks/useRunHistory'
 import { useJokerActivationSequence } from '@/app/comet-cards/hooks/useJokerActivationSequence'
+import { useGridKeyboardNav } from '@/app/comet-cards/hooks/useGridKeyboardNav'
 
 const RARITY_ACCENT: Record<string, string> = {
   common: 'var(--cc-mint)',
@@ -142,6 +143,17 @@ export function GamePlayView() {
   const isPractice = todayRun !== null
 
   const { scoreHand } = useScoreHand()
+
+  const {
+    containerRef: jokerContainerRef,
+    handleKeyDown: jokerHandleKeyDown,
+    focusedIndexRef: jokerFocusedIndexRef,
+  } = useGridKeyboardNav()
+
+  const {
+    containerRef: mobileJokerContainerRef,
+    handleKeyDown: mobileJokerHandleKeyDown,
+  } = useGridKeyboardNav('button')
 
   useEffect(() => {
     eventEmitter.emit({ type: 'HAND_DEALT' })
@@ -375,6 +387,10 @@ export function GamePlayView() {
 
           {/* Compact jokers + consumables row */}
           <div
+            ref={mobileJokerContainerRef}
+            role="toolbar"
+            aria-label="Jokers"
+            onKeyDown={mobileJokerHandleKeyDown}
             style={{
               display: 'flex',
               overflowX: 'auto',
@@ -993,8 +1009,15 @@ export function GamePlayView() {
           {/* RIGHT rail */}
           <div className="flex flex-col gap-4" style={{ maxHeight: 'calc(100vh - 50px)', overflow: 'hidden' }}>
             <Panel title="Jokers" subtitle={`${game.jokers.length} / ${game.maxJokers} slots`}>
-              <div className="cc-scroll" style={{ padding: 14, display: 'flex', flexWrap: 'wrap', gap: 10, maxHeight: '45vh', overflowY: 'auto' }}>
-                {game.jokers.map(joker => {
+              <div
+                ref={jokerContainerRef}
+                role="toolbar"
+                aria-label="Jokers"
+                onKeyDown={jokerHandleKeyDown}
+                className="cc-scroll"
+                style={{ padding: 14, display: 'flex', flexWrap: 'wrap', gap: 10, maxHeight: '45vh', overflowY: 'auto' }}
+              >
+                {game.jokers.map((joker, i) => {
                   const def = jokerDefinitions[joker.jokerId]
                   const jokerName = def?.name ?? ''
                   const isJokerActive = activeJokerName === jokerName
@@ -1012,6 +1035,7 @@ export function GamePlayView() {
                         gameSeed={game.gameSeed}
                         roundIndex={game.roundIndex}
                         activated={isJokerActive}
+                        tabIndex={i === jokerFocusedIndexRef.current ? 0 : -1}
                         onClick={(isSelected, id) => {
                           if (isSelected) {
                             eventEmitter.emit({ type: 'JOKER_DESELECTED', id })

--- a/src/app/comet-cards/components/gameplay/joker.tsx
+++ b/src/app/comet-cards/components/gameplay/joker.tsx
@@ -49,6 +49,7 @@ export const Joker = ({
   gameSeed,
   roundIndex,
   activated,
+  tabIndex,
 }: {
   joker: JokerState
   isSelected?: boolean
@@ -58,6 +59,7 @@ export const Joker = ({
   gameSeed?: string
   roundIndex?: number
   activated?: boolean
+  tabIndex?: number
 }) => {
   const def = jokers[joker.jokerId]
   const accent = RARITY_ACCENT[def?.rarity ?? 'common'] ?? 'var(--cc-mint)'
@@ -227,6 +229,7 @@ export const Joker = ({
         typeLabel="Joker"
         edition={joker.edition}
         onClick={onClick ? () => onClick(isSelected ?? false, joker.id) : undefined}
+        tabIndex={tabIndex}
       />
     </div>
   )

--- a/src/app/comet-cards/components/joker/current-jokers.tsx
+++ b/src/app/comet-cards/components/joker/current-jokers.tsx
@@ -2,12 +2,19 @@ import { DangerButton } from '@/app/comet-cards/components/cosmic/buttons'
 import { Joker } from '@/app/comet-cards/components/gameplay/joker'
 import { eventEmitter } from '@/app/comet-cards/domain/events/event-emitter'
 import { jokers } from '@/app/comet-cards/domain/joker/jokers'
+import { useGridKeyboardNav } from '@/app/comet-cards/hooks/useGridKeyboardNav'
 import { useGameState } from '@/app/comet-cards/useGameState'
 
 export const CurrentJokers = () => {
   const { game } = useGameState()
   const selectedJoker = game.jokers.find(joker => joker.id === game.gamePlayState.selectedJokerId)
   const selectedJokerDefinition = selectedJoker ? jokers[selectedJoker.jokerId] : undefined
+
+  const {
+    containerRef: jokerContainerRef,
+    handleKeyDown: jokerHandleKeyDown,
+    focusedIndexRef: jokerFocusedIndexRef,
+  } = useGridKeyboardNav()
 
   return (
     <div
@@ -19,7 +26,13 @@ export const CurrentJokers = () => {
       }}
     >
       <div className="flex flex-col gap-2">
-        <div className="flex flex-wrap gap-3">
+        <div
+          ref={jokerContainerRef}
+          role="toolbar"
+          aria-label="Jokers"
+          onKeyDown={jokerHandleKeyDown}
+          className="flex flex-wrap gap-3"
+        >
           {game.jokers.length === 0 ? (
             <div
               style={{
@@ -32,7 +45,7 @@ export const CurrentJokers = () => {
               Your joker slots are empty
             </div>
           ) : (
-            game.jokers.map(joker => (
+            game.jokers.map((joker, i) => (
               <Joker
                 key={joker.id}
                 joker={joker}
@@ -41,6 +54,7 @@ export const CurrentJokers = () => {
                 ownedCardCount={game.ownedCardIds.length}
                 gameSeed={game.gameSeed}
                 roundIndex={game.roundIndex}
+                tabIndex={i === jokerFocusedIndexRef.current ? 0 : -1}
                 onClick={(isSelected, id) => {
                   if (isSelected) {
                     eventEmitter.emit({ type: 'JOKER_DESELECTED', id })

--- a/src/app/comet-cards/hooks/useGridKeyboardNav.ts
+++ b/src/app/comet-cards/hooks/useGridKeyboardNav.ts
@@ -10,6 +10,7 @@ import { useCallback, useRef } from 'react'
  */
 export function useGridKeyboardNav(selector = 'button.bc-card') {
   const containerRef = useRef<HTMLDivElement>(null)
+  const focusedIndexRef = useRef(0)
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
@@ -43,10 +44,11 @@ export function useGridKeyboardNav(selector = 'button.bc-card') {
         }
       }
 
+      focusedIndexRef.current = nextIndex
       buttons[nextIndex]?.focus()
     },
     [selector]
   )
 
-  return { containerRef, handleKeyDown }
+  return { containerRef, handleKeyDown, focusedIndexRef }
 }


### PR DESCRIPTION
## Summary

- Phase 1 of #1519: keyboard navigation for joker cards in gameplay and shop
- `TokenCard` now accepts a `tabIndex` prop, passed through to the underlying `<button>`
- `Joker` component now accepts and forwards `tabIndex` to `TokenCard`
- `useGridKeyboardNav` now returns `focusedIndexRef` to support roving tabindex patterns
- Desktop RIGHT rail joker panel in `gameplay.tsx` gets `role="toolbar"`, arrow-key nav, and roving tabindex via `useGridKeyboardNav`
- Landscape mobile compact joker row gets `role="toolbar"` and arrow-key nav via `useGridKeyboardNav`
- `CurrentJokers` (shop) gets the same treatment: `role="toolbar"`, `useGridKeyboardNav`, and roving tabindex on each `Joker`

## Test plan

- [ ] Tab into the desktop Jokers panel — first joker gets focus
- [ ] Arrow Left/Right/Up/Down moves focus between joker cards
- [ ] Enter/Space on a focused joker triggers selection (handled by browser for `<button>`)
- [ ] Tab into the shop CurrentJokers panel — same arrow-key nav works
- [ ] Landscape mobile toolbar: arrow keys move between joker/consumable chips
- [ ] TypeScript: `npx tsc --noEmit` passes with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)