### PR TITLE
Fix: reveal face-down cards when played (#1615)

### DIFF
--- a/src/app/comet-cards/domain/game/__tests__/face-down-reveal.test.ts
+++ b/src/app/comet-cards/domain/game/__tests__/face-down-reveal.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+import { defaultGameState } from '@/app/comet-cards/domain/game/default-game-state'
+import { reduceGame } from '@/app/comet-cards/domain/game/reduce-game'
+import type { GameState } from '@/app/comet-cards/domain/game/types'
+
+describe('face-down card reveal on play', () => {
+  function setupGame(): GameState {
+    const game: GameState = structuredClone(defaultGameState)
+    game.gamePhase = 'gameplay'
+    game.rounds[game.roundIndex].smallBlind.status = 'inProgress'
+    game.cards = {
+      'c1': { id: 'c1', playingCardId: 'A_spades', isFaceUp: false, flags: {} } as any,
+      'c2': { id: 'c2', playingCardId: 'K_hearts', isFaceUp: true, flags: {} } as any,
+    }
+    game.gamePlayState.selectedCardIds = ['c1', 'c2']
+    game.gamePlayState.handIds = ['c1', 'c2']
+    game.ownedCardIds = ['c1', 'c2']
+    return game
+  }
+
+  it('flips face-down cards face-up when played', () => {
+    const game = setupGame()
+    const after = reduceGame(game, { type: 'HAND_SCORING_START' })
+    expect(after.cards['c1'].isFaceUp).toBe(true)
+  })
+
+  it('leaves already face-up cards face-up (no regression)', () => {
+    const game = setupGame()
+    const after = reduceGame(game, { type: 'HAND_SCORING_START' })
+    expect(after.cards['c2'].isFaceUp).toBe(true)
+  })
+})

--- a/src/app/comet-cards/domain/game/handlers/gameplay.ts
+++ b/src/app/comet-cards/domain/game/handlers/gameplay.ts
@@ -285,6 +285,13 @@ export function handleHandScoringStart(draft: GameState, event: GameEvent) {
   gamePlayState.cardsToScore = cardsToScore
   gamePlayState.playedCardIds = gamePlayState.selectedCardIds
 
+  // Reveal face-down cards when played
+  for (const cardId of gamePlayState.playedCardIds) {
+    if (draft.cards[cardId] && !draft.cards[cardId].isFaceUp) {
+      draft.cards[cardId].isFaceUp = true
+    }
+  }
+
   // Accumulate cards played this ante only during small/big blinds (for The Pillar)
   const currentBlindForTracking = getInProgressBlind(draft as unknown as GameState)
   if (currentBlindForTracking && currentBlindForTracking.type !== 'bossBlind') {


### PR DESCRIPTION
## Summary

- Face-down cards (from boss blind effects like The House, The Wheel, The Mark, The Fish) now flip face-up when the player plays them
- Added reveal logic in `handleHandScoringStart` right after `playedCardIds` is set — before scoring begins
- 2 tests: face-down card reveals on play, face-up card stays face-up

Closes #1615

## Test plan

- [x] `face-down-reveal.test.ts` — 2 tests pass
- [ ] Manual: start a boss blind that flips cards face-down, play face-down cards, verify they flip face-up when committed

🤖 Generated with [Claude Code](https://claude.com/claude-code)