### PR TITLE
Fix: face-down cards don't leak hand type in preview (#1616)

### DIFF
--- a/src/app/comet-cards/domain/game/__tests__/face-down-hand-display.test.ts
+++ b/src/app/comet-cards/domain/game/__tests__/face-down-hand-display.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest'
+import { defaultGameState } from '@/app/comet-cards/domain/game/default-game-state'
+import { reduceGame } from '@/app/comet-cards/domain/game/reduce-game'
+import type { GameState } from '@/app/comet-cards/domain/game/types'
+
+describe('face-down cards and Selected Hand display (bug #1616)', () => {
+  function setupGame(): GameState {
+    const game: GameState = structuredClone(defaultGameState)
+    game.rounds[game.roundIndex].bossBlind.status = 'inProgress'
+    game.gamePhase = 'gameplay'
+
+    // Set up three cards: two Kings (face-up) and one 5 (face-down)
+    game.cards = {
+      'c1': { id: 'c1', playingCardId: 'K_spades', isFaceUp: true, flags: {} } as any,
+      'c2': { id: 'c2', playingCardId: 'K_hearts', isFaceUp: true, flags: {} } as any,
+      'c3': { id: 'c3', playingCardId: '5_clubs', isFaceUp: false, flags: {} } as any,
+    }
+    game.gamePlayState.handIds = ['c1', 'c2', 'c3']
+    game.ownedCardIds = ['c1', 'c2', 'c3']
+    game.gamePlayState.selectedCardIds = []
+    game.gamePlayState.selectedHand = undefined
+
+    return game
+  }
+
+  it('shows Pair (from two face-up Kings) when a face-down card is also selected', () => {
+    const game = setupGame()
+
+    // Select K♠ (face-up)
+    const after1 = reduceGame(game, { type: 'CARD_SELECTED', id: 'c1' })
+    // Select K♥ (face-up)
+    const after2 = reduceGame(after1, { type: 'CARD_SELECTED', id: 'c2' })
+    // Select 5♣ (face-down)
+    const after3 = reduceGame(after2, { type: 'CARD_SELECTED', id: 'c3' })
+
+    expect(after3.gamePlayState.selectedHand).toBeDefined()
+    // Hand ID should be 'pair' — determined only from the two face-up Kings
+    expect(after3.gamePlayState.selectedHand![0]).toBe('pair')
+    // All three cards (including face-down) are in the hand for scoring
+    expect(after3.gamePlayState.selectedHand![1]).toHaveLength(3)
+  })
+
+  it('selectedHand is undefined when only face-down cards are selected', () => {
+    const game = setupGame()
+
+    // Select only the face-down 5♣
+    const after = reduceGame(game, { type: 'CARD_SELECTED', id: 'c3' })
+
+    expect(after.gamePlayState.selectedHand).toBeUndefined()
+  })
+
+  it('shows Pair after deselecting the face-down card leaves two face-up Kings', () => {
+    const game = setupGame()
+
+    // Select all three cards
+    const after1 = reduceGame(game, { type: 'CARD_SELECTED', id: 'c1' })
+    const after2 = reduceGame(after1, { type: 'CARD_SELECTED', id: 'c2' })
+    const after3 = reduceGame(after2, { type: 'CARD_SELECTED', id: 'c3' })
+
+    // Now deselect the face-down card
+    const after4 = reduceGame(after3, { type: 'CARD_DESELECTED', id: 'c3' })
+
+    expect(after4.gamePlayState.selectedHand).toBeDefined()
+    expect(after4.gamePlayState.selectedHand![0]).toBe('pair')
+    expect(after4.gamePlayState.selectedHand![1]).toHaveLength(2)
+  })
+
+  it('selectedHand is undefined after deselecting to leave only face-down cards', () => {
+    const game = setupGame()
+
+    // Select K♠ (face-up) and 5♣ (face-down)
+    const after1 = reduceGame(game, { type: 'CARD_SELECTED', id: 'c1' })
+    const after2 = reduceGame(after1, { type: 'CARD_SELECTED', id: 'c3' })
+
+    // Deselect K♠ — only face-down 5♣ remains
+    const after3 = reduceGame(after2, { type: 'CARD_DESELECTED', id: 'c1' })
+
+    expect(after3.gamePlayState.selectedHand).toBeUndefined()
+  })
+})

--- a/src/app/comet-cards/domain/game/handlers/gameplay.ts
+++ b/src/app/comet-cards/domain/game/handlers/gameplay.ts
@@ -38,10 +38,13 @@ export function handleCardSelected(draft: GameState, event: CardSelectedEvent) {
 
   const selectedCardIds = [...gamePlayState.selectedCardIds, id]
   const selectedCards = getCards(draft as unknown as GameState, selectedCardIds)
-  const selectedHandId = findHighestPriorityHand(selectedCards, draft.staticRules).hand
+  const visibleCards = selectedCards.filter(c => c.isFaceUp)
+  const selectedHandId = visibleCards.length > 0
+    ? findHighestPriorityHand(visibleCards, draft.staticRules).hand
+    : undefined
 
   gamePlayState.selectedCardIds = selectedCardIds
-  gamePlayState.selectedHand = [selectedHandId, selectedCards]
+  gamePlayState.selectedHand = selectedHandId ? [selectedHandId, selectedCards] : undefined
 }
 
 export function handleCardDeselected(draft: GameState, event: CardDeselectedEvent) {
@@ -54,8 +57,11 @@ export function handleCardDeselected(draft: GameState, event: CardDeselectedEven
 
   let selectedHand: [PokerHandDefinition['id'], PlayingCardState[]] | undefined = undefined
   if (selectedCards.length > 0) {
-    const selectedHandId = findHighestPriorityHand(selectedCards, draft.staticRules).hand
-    selectedHand = [selectedHandId, selectedCards]
+    const visibleCards = selectedCards.filter(c => c.isFaceUp)
+    if (visibleCards.length > 0) {
+      const selectedHandId = findHighestPriorityHand(visibleCards, draft.staticRules).hand
+      selectedHand = [selectedHandId, selectedCards]
+    }
   }
 
   gamePlayState.selectedCardIds = selectedCardIds


### PR DESCRIPTION
## Summary

- Selected Hand display now only considers face-up cards when detecting the hand type preview
- Face-down cards are still included in `selectedHand[1]` for scoring — no scoring behavior change
- Scoring path (`handleHandScoringStart`) is untouched
- 4 tests covering: mixed face-up/down selection, all-face-down selection, deselection scenarios

Closes #1616

## Test plan

- [x] `face-down-hand-display.test.ts` — 4 tests pass
- [ ] Manual: trigger a boss blind that flips cards face-down, select a mix of face-up and face-down cards, verify the hand preview only reflects visible cards

🤖 Generated with [Claude Code](https://claude.com/claude-code)