### PR TITLE
Fix: boss blind face-down effect no longer persists permanently (#1617)

### DIFF
--- a/src/app/comet-cards/domain/game/__tests__/face-down-cleanup.test.ts
+++ b/src/app/comet-cards/domain/game/__tests__/face-down-cleanup.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest'
+import { defaultGameState } from '@/app/comet-cards/domain/game/default-game-state'
+import { reduceGame } from '@/app/comet-cards/domain/game/reduce-game'
+import type { GameState } from '@/app/comet-cards/domain/game/types'
+
+const fakeCards = {
+  c1: { id: 'c1', playingCardId: '2_hearts', isFaceUp: true } as any,
+  c2: { id: 'c2', playingCardId: '5_clubs', isFaceUp: true } as any,
+  c3: { id: 'c3', playingCardId: '9_spades', isFaceUp: true } as any,
+}
+
+function setupGame(bossBlindName: string): GameState {
+  const game: GameState = structuredClone(defaultGameState)
+  game.rounds[game.roundIndex].bossBlindName = bossBlindName
+  game.cards = structuredClone(fakeCards)
+  return game
+}
+
+describe('face-down boss blind cleanup', () => {
+  describe('The Mark', () => {
+    it('restores all cards to face up after BLIND_REWARDS_END', () => {
+      const game = setupGame('The Mark')
+
+      const afterSelect = reduceGame(game, { type: 'BOSS_BLIND_SELECTED' })
+      const afterClear = reduceGame(afterSelect, { type: 'BLIND_REWARDS_END' })
+
+      for (const cardId of Object.keys(afterClear.cards)) {
+        expect(afterClear.cards[cardId].isFaceUp).toBe(true)
+      }
+    })
+  })
+
+  describe('The Wheel', () => {
+    it('restores all cards to face up after BLIND_REWARDS_END', () => {
+      const game = setupGame('The Wheel')
+
+      const afterSelect = reduceGame(game, { type: 'BOSS_BLIND_SELECTED' })
+      const afterClear = reduceGame(afterSelect, { type: 'BLIND_REWARDS_END' })
+
+      for (const cardId of Object.keys(afterClear.cards)) {
+        expect(afterClear.cards[cardId].isFaceUp).toBe(true)
+      }
+    })
+  })
+
+  describe('The House', () => {
+    it('restores all cards to face up after BLIND_REWARDS_END', () => {
+      const game = setupGame('The House')
+
+      const afterSelect = reduceGame(game, { type: 'BOSS_BLIND_SELECTED' })
+      // All cards should be face-down after blind is selected
+      for (const cardId of Object.keys(afterSelect.cards)) {
+        expect(afterSelect.cards[cardId].isFaceUp).toBe(false)
+      }
+
+      const afterClear = reduceGame(afterSelect, { type: 'BLIND_REWARDS_END' })
+      for (const cardId of Object.keys(afterClear.cards)) {
+        expect(afterClear.cards[cardId].isFaceUp).toBe(true)
+      }
+    })
+  })
+
+  describe('The Fish', () => {
+    it('restores all cards to face up after BLIND_REWARDS_END', () => {
+      const game = setupGame('The Fish')
+
+      // Manually flip some cards face-down as The Fish would during gameplay
+      game.cards['c1'].isFaceUp = false
+      game.cards['c2'].isFaceUp = false
+
+      // Set blind status to in-progress via BOSS_BLIND_SELECTED
+      const afterSelect = reduceGame(game, { type: 'BOSS_BLIND_SELECTED' })
+      const afterClear = reduceGame(afterSelect, { type: 'BLIND_REWARDS_END' })
+
+      for (const cardId of Object.keys(afterClear.cards)) {
+        expect(afterClear.cards[cardId].isFaceUp).toBe(true)
+      }
+    })
+  })
+})

--- a/src/app/comet-cards/domain/round/boss-blinds.ts
+++ b/src/app/comet-cards/domain/round/boss-blinds.ts
@@ -216,6 +216,11 @@ const theMark: BossBlindDefinition = {
       },
     },
   ],
+  onCleanup: (game) => {
+    for (const cardId of Object.keys(game.cards)) {
+      game.cards[cardId].isFaceUp = true
+    }
+  },
 }
 
 const theMouth: BossBlindDefinition = {
@@ -393,6 +398,11 @@ const theWheel: BossBlindDefinition = {
       },
     },
   ],
+  onCleanup: (game) => {
+    for (const cardId of Object.keys(game.cards)) {
+      game.cards[cardId].isFaceUp = true
+    }
+  },
 }
 
 const theHead: BossBlindDefinition = {
@@ -520,6 +530,11 @@ const theHouse: BossBlindDefinition = {
       },
     },
   ],
+  onCleanup: (game) => {
+    for (const cardId of Object.keys(game.cards)) {
+      game.cards[cardId].isFaceUp = true
+    }
+  },
 }
 
 const theFish: BossBlindDefinition = {
@@ -545,6 +560,11 @@ const theFish: BossBlindDefinition = {
       },
     },
   ],
+  onCleanup: (game) => {
+    for (const cardId of Object.keys(game.cards)) {
+      game.cards[cardId].isFaceUp = true
+    }
+  },
 }
 
 const violetVessel: BossBlindDefinition = {


### PR DESCRIPTION
## Summary

- Added `onCleanup` to 4 boss blinds (The Mark, The Wheel, The House, The Fish) that flip cards face-down
- When the boss blind round is cleared, all cards are restored to `isFaceUp = true`
- Follows the exact pattern established by Amber Acorn (which already cleans up face-down jokers)
- 4 tests covering each affected blind

This completes the face-down card bug cluster: #1614 (Steel), #1615 (reveal on play), #1616 (display preview), #1617 (cleanup).

Closes #1617

## Test plan

- [x] `face-down-cleanup.test.ts` — 4 tests pass (one per affected blind)
- [x] Full test suite — 707 tests pass
- [ ] Manual: play through a boss blind that flips cards face-down, beat it, verify cards are face-up in the next round

🤖 Generated with [Claude Code](https://claude.com/claude-code)