### PR TITLE
Fix: Astronomer joker makes celestial cards and packs free (#1612)

### DIFF
--- a/src/app/comet-cards/components/shop/booster-packs.tsx
+++ b/src/app/comet-cards/components/shop/booster-packs.tsx
@@ -44,7 +44,12 @@ function BoosterPackForSale({ pack }: { pack: PackState }) {
   const { game } = useGameState()
   const cardType = pack.cards[0].type
   const packDefinition = getPackDefinition(cardType, pack.rarity)
-  const discountedPrice = Math.floor(packDefinition.price * game.shopState.priceMultiplier)
+  const isCelestialPack = packDefinition.cardType === 'celestialCard'
+  const hasAstronomer = game.jokers.some(j => j.jokerId === 'astronomer')
+  const discountedPrice =
+    isCelestialPack && hasAstronomer
+      ? 0
+      : Math.floor(packDefinition.price * game.shopState.priceMultiplier)
   const canAffordPack = canAffordToBuy(discountedPrice, game)
   return (
     <div className="flex flex-col items-stretch gap-2">

--- a/src/app/comet-cards/domain/game/__tests__/joker-astronomer.test.ts
+++ b/src/app/comet-cards/domain/game/__tests__/joker-astronomer.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from 'vitest'
+
+import { defaultGameState } from '@/app/comet-cards/domain/game/default-game-state'
+import { reduceGame } from '@/app/comet-cards/domain/game/reduce-game'
+import type { GameState } from '@/app/comet-cards/domain/game/types'
 import { astronomer, jokers } from '@/app/comet-cards/domain/joker/jokers'
+import { initializeJoker } from '@/app/comet-cards/domain/joker/utils'
+import type { BuyableCard, PackState } from '@/app/comet-cards/domain/shop/types'
 
 describe('Astronomer joker', () => {
   it('is defined with correct properties', () => {
@@ -7,12 +13,97 @@ describe('Astronomer joker', () => {
     expect(astronomer.name).toBe('Astronomer')
     expect(astronomer.rarity).toBe('uncommon')
     expect(astronomer.price).toBe(8)
-    expect(astronomer.effects.length).toBe(1)
-    expect(astronomer.effects[0].event.type).toBe('SHOP_OPEN')
+    expect(astronomer.effects.length).toBe(0)
   })
 
   it('is registered in the jokers record', () => {
     expect(jokers.astronomer).toBeDefined()
     expect(jokers.astronomer.id).toBe('astronomer')
+  })
+
+  it('makes celestial cards in cardsForSale free after SHOP_OPEN', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.jokers = [initializeJoker(jokers.astronomer, game)]
+
+    const celestialCard: BuyableCard = {
+      type: 'celestialCard',
+      card: { id: 'c1', consumableType: 'celestialCard', handId: 'highCard' } as any,
+      price: 3,
+    }
+    // Pre-populate guaranteedForSaleItems so SHOP_OPEN includes it
+    game.shopState.guaranteedForSaleItems = [celestialCard]
+    game.shopState.maxCardsForSale = 1
+
+    const afterOpen = reduceGame(game, { type: 'SHOP_OPEN' })
+    const celestialForSale = afterOpen.shopState.cardsForSale.find(
+      c => c.card.id === 'c1'
+    )
+    expect(celestialForSale).toBeDefined()
+    expect(celestialForSale?.price).toBe(0)
+  })
+
+  it('does not make non-celestial cards free after SHOP_OPEN', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.jokers = [initializeJoker(jokers.astronomer, game)]
+
+    const tarotCard: BuyableCard = {
+      type: 'tarotCard',
+      card: { id: 't1', consumableType: 'tarotCard', tarotType: 'theFool' } as any,
+      price: 3,
+    }
+    game.shopState.guaranteedForSaleItems = [tarotCard]
+    game.shopState.maxCardsForSale = 1
+
+    const afterOpen = reduceGame(game, { type: 'SHOP_OPEN' })
+    const tarotForSale = afterOpen.shopState.cardsForSale.find(c => c.card.id === 't1')
+    expect(tarotForSale).toBeDefined()
+    expect(tarotForSale?.price).toBe(3)
+  })
+
+  it('does not deduct money when opening a celestial pack', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.jokers = [initializeJoker(jokers.astronomer, game)]
+    game.money = 10
+
+    const celestialPack: PackState = {
+      id: 'pack-1',
+      rarity: 'normal',
+      remainingCardsToSelect: 1,
+      cards: [
+        {
+          type: 'celestialCard',
+          card: { id: 'cp1', consumableType: 'celestialCard', handId: 'highCard' } as any,
+          price: 0,
+        },
+      ],
+    }
+    game.shopState.packsForSale = [celestialPack]
+
+    const afterOpen = reduceGame(game, { type: 'SHOP_OPEN_PACK', id: 'pack-1' })
+    expect(afterOpen.money).toBe(10)
+  })
+
+  it('still charges money for non-celestial packs', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.jokers = [initializeJoker(jokers.astronomer, game)]
+    game.money = 10
+
+    const tarotPack: PackState = {
+      id: 'pack-2',
+      rarity: 'normal',
+      remainingCardsToSelect: 1,
+      cards: [
+        {
+          type: 'tarotCard',
+          card: { id: 'tp1', consumableType: 'tarotCard', tarotType: 'theFool' } as any,
+          price: 0,
+        },
+      ],
+    }
+    game.shopState.packsForSale = [tarotPack]
+
+    const afterOpen = reduceGame(game, { type: 'SHOP_OPEN_PACK', id: 'pack-2' })
+    // Normal pack price should be deducted (price comes from pack definition, priceMultiplier = 1)
+    expect(afterOpen.money).toBeLessThan(10)
   })
 })

--- a/src/app/comet-cards/domain/game/handlers/shop.ts
+++ b/src/app/comet-cards/domain/game/handlers/shop.ts
@@ -81,6 +81,16 @@ export function handleShopOpen(draft: GameState, event: GameEvent) {
     draft.shopState.cardsForSale.push(...additionalCards)
   }
 
+  // Astronomer joker: make all celestial cards free
+  const hasAstronomer = draft.jokers.some(j => j.jokerId === 'astronomer')
+  if (hasAstronomer) {
+    for (const card of draft.shopState.cardsForSale) {
+      if (card.type === 'celestialCard') {
+        card.price = 0
+      }
+    }
+  }
+
   // Coupon tag: make all initial items free
   const couponTag = draft.tags.find(t => t.tagType === 'coupon')
   if (couponTag) {
@@ -304,6 +314,15 @@ export function handleShopReroll(draft: GameState) {
     draft.shopState.maxCardsForSale,
     randomBuyableCardsSeed
   )
+  // Astronomer joker: make all celestial cards free after reroll
+  const hasAstronomer = draft.jokers.some(j => j.jokerId === 'astronomer')
+  if (hasAstronomer) {
+    for (const card of draft.shopState.cardsForSale) {
+      if (card.type === 'celestialCard') {
+        card.price = 0
+      }
+    }
+  }
   if (draft.shopState.freeRerolls > 0) {
     draft.shopState.freeRerolls -= 1
   } else {
@@ -317,7 +336,12 @@ export function handleShopOpenPack(draft: GameState, event: ShopOpenPackEvent) {
   if (!pack) return
   const packDefinition = getPackDefinition(pack.cards[0].type, pack.rarity)
   if (!pack) return
-  draft.money -= Math.floor(packDefinition.price * draft.shopState.priceMultiplier)
+  // Astronomer joker: celestial packs are free
+  const isCelestialPack = packDefinition.cardType === 'celestialCard'
+  const hasAstronomer = draft.jokers.some(j => j.jokerId === 'astronomer')
+  if (!(isCelestialPack && hasAstronomer)) {
+    draft.money -= Math.floor(packDefinition.price * draft.shopState.priceMultiplier)
+  }
   draft.shopState.packsForSale = draft.shopState.packsForSale.filter(pack => pack.id !== id)
   draft.gamePhase = 'packOpening'
   draft.shopState.openPackState = pack

--- a/src/app/comet-cards/domain/joker/jokers.ts
+++ b/src/app/comet-cards/domain/joker/jokers.ts
@@ -4439,19 +4439,7 @@ export const astronomer: JokerDefinition = {
   name: 'Astronomer',
   description: 'All Planet cards and Celestial Packs in the shop are free',
   price: 8,
-  effects: [
-    {
-      event: { type: 'SHOP_OPEN' },
-      priority: 2,
-      apply: (ctx: EffectContext) => {
-        for (const card of ctx.game.shopState.cardsForSale) {
-          if (card.type === 'celestialCard') {
-            card.price = 0
-          }
-        }
-      },
-    },
-  ],
+  effects: [],
   rarity: 'uncommon',
 }
 


### PR DESCRIPTION
## Summary

- **Root cause**: Astronomer's `SHOP_OPEN` effect fired before random shop cards were populated, so it was setting prices to $0 on an empty array
- Moved Astronomer pricing logic into `handleShopOpen` and `handleShopReroll`, running after all cards are generated
- Celestial packs are now free to open (handler skips charge, UI shows $0)
- Removed the now-redundant effect from the Astronomer joker definition
- 6 tests covering: celestial cards free, non-celestial cards unchanged, celestial packs free, non-celestial packs still charged

Closes #1612

## Test plan

- [x] `joker-astronomer.test.ts` — 6 tests pass
- [ ] Manual: equip Astronomer, open shop, verify celestial cards show $0 and celestial packs show $0

🤖 Generated with [Claude Code](https://claude.com/claude-code)