### PR TITLE
fix: joker sell button shows correct sell value

### DIFF
--- a/src/app/comet-cards/components/joker/current-jokers.tsx
+++ b/src/app/comet-cards/components/joker/current-jokers.tsx
@@ -4,6 +4,7 @@ import { eventEmitter } from '@/app/comet-cards/domain/events/event-emitter'
 import { jokers } from '@/app/comet-cards/domain/joker/jokers'
 import { useGridKeyboardNav } from '@/app/comet-cards/hooks/useGridKeyboardNav'
 import { useGameState } from '@/app/comet-cards/useGameState'
+import { getJokerSellValue } from '@/app/comet-cards/domain/shop/sell-utils'
 
 export const CurrentJokers = () => {
   const { game } = useGameState()
@@ -71,7 +72,7 @@ export const CurrentJokers = () => {
         {selectedJokerDefinition && (
           <div>
             <DangerButton onClick={() => eventEmitter.emit({ type: 'JOKER_SOLD' })}>
-              Sell · ${selectedJokerDefinition.price}
+              Sell · ${getJokerSellValue(selectedJokerDefinition, selectedJoker!)}
             </DangerButton>
           </div>
         )}


### PR DESCRIPTION
Fixes #1625

The sell button was displaying the joker's purchase price instead of the calculated sell value. This change updates the button to use `getJokerSellValue()` which correctly computes the payout as floor(price/2) + bonusSellValue.

This ensures the displayed value matches what the player actually receives when selling the joker.