### PR TITLE
fix: Diet Cola joker creates Double Tag when sold

### DIFF
--- a/src/app/comet-cards/domain/events/types.ts
+++ b/src/app/comet-cards/domain/events/types.ts
@@ -260,6 +260,7 @@ export interface EffectContext {
   scoredCards?: PlayingCardState[]
   tarotCards?: TarotCardState[]
   vouchers: VoucherState[]
+  removedJoker?: JokerState
 }
 
 export interface Effect {

--- a/src/app/comet-cards/domain/game/utils.ts
+++ b/src/app/comet-cards/domain/game/utils.ts
@@ -152,6 +152,7 @@ export function removeJoker(draft: GameState, event: GameEvent, selectedJoker: J
     vouchers: draft.vouchers,
     tags: draft.tags,
   }
+  ctx.removedJoker = selectedJoker
   // Collect effects *before* removing the joker so "on sold/removed" effects that live on the
   // removed joker itself still get a chance to run. Then dispatch *after* removal so effects
   // can observe the post-removal game state.

--- a/src/app/comet-cards/domain/joker/jokers.ts
+++ b/src/app/comet-cards/domain/joker/jokers.ts
@@ -723,7 +723,7 @@ export const dietColaJoker: JokerDefinition = {
       event: { type: 'JOKER_SOLD' },
       priority: 1,
       apply: (ctx: EffectContext) => {
-        if (!ctx.game.jokers.some(j => j.jokerId === 'dietColaJoker')) {
+        if (ctx.removedJoker?.jokerId === 'dietColaJoker') {
           ctx.game.tags.push({
             id: uuid(),
             tagType: 'double',


### PR DESCRIPTION
## Summary

- Fixes #1611: Diet Cola joker was not creating a Double Tag when sold
- Added `removedJoker` field to `EffectContext` so effects can identify which joker triggered the sale
- Set `ctx.removedJoker = selectedJoker` in `removeJoker` before dispatching effects
- Replaced the fragile `!ctx.game.jokers.some(j => j.jokerId === 'dietColaJoker')` check in Diet Cola's effect with the explicit `ctx.removedJoker?.jokerId === 'dietColaJoker'`

The old condition relied on `removeJoker` having already spliced Diet Cola out of the array before dispatching effects. This worked by accident due to timing, but would silently break if Blueprint or Brainstorm ever copied Diet Cola's effect (they'd fire on another joker's sale and find Diet Cola still in the array, incorrectly suppressing the tag).

## Test plan

- [x] `diet-cola.test.ts` — "creates a Double Tag when sold" passes
- [x] `diet-cola.test.ts` — "does not create a tag when another joker is sold" passes
- [x] Full `game/__tests__/` suite — all tests pass, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)