### PR TITLE
feat: roving tabIndex for shop and pack keyboard navigation

### DIFF
--- a/src/app/comet-cards/components/game-views/shop.tsx
+++ b/src/app/comet-cards/components/game-views/shop.tsx
@@ -34,7 +34,7 @@ export function ShopView() {
   const { game } = useGameState()
   const reducedMotion = useReducedMotion()
   const autoFocusRef = useAutoFocus()
-  const { containerRef: cardsForSaleRef, handleKeyDown: handleCardsKeyDown } = useGridKeyboardNav()
+  const { containerRef: cardsForSaleRef, handleKeyDown: handleCardsKeyDown, focusedIndexRef: cardsFocusedRef } = useGridKeyboardNav()
   useEffect(() => {
     if (!game.shopState.isOpen) {
       eventEmitter.emit({ type: 'SHOP_OPEN' })
@@ -133,6 +133,7 @@ export function ShopView() {
                         <BuyableCard
                           buyableCard={buyableCard}
                           isSelected={game.shopState.selectedCardId === buyableCard.card.id}
+                          tabIndex={i === cardsFocusedRef.current ? 0 : -1}
                         />
                         <span
                           style={{

--- a/src/app/comet-cards/components/gameplay/celestial-card.tsx
+++ b/src/app/comet-cards/components/gameplay/celestial-card.tsx
@@ -6,10 +6,12 @@ export const CelestialCard = ({
   celestialCard,
   isSelected,
   onClick,
+  tabIndex,
 }: {
   celestialCard: CelestialCardState
   isSelected?: boolean
   onClick?: (isSelected: boolean, id: string) => void
+  tabIndex?: number
 }) => {
   const def = celestialCards[celestialCard.handId]
   return (
@@ -23,6 +25,7 @@ export const CelestialCard = ({
       typeLabel="Celestial"
       edition={celestialCard.edition}
       onClick={onClick ? () => onClick(isSelected ?? false, celestialCard.id) : undefined}
+      tabIndex={tabIndex}
     />
   )
 }

--- a/src/app/comet-cards/components/gameplay/spectral-card.tsx
+++ b/src/app/comet-cards/components/gameplay/spectral-card.tsx
@@ -6,10 +6,12 @@ export const SpectralCard = ({
   spectralCard,
   isSelected,
   onClick,
+  tabIndex,
 }: {
   spectralCard: SpectralCardState
   isSelected?: boolean
   onClick?: (isSelected: boolean, id: string) => void
+  tabIndex?: number
 }) => {
   const def = spectralCards[spectralCard.spectralType]
   if (!def) {
@@ -21,6 +23,7 @@ export const SpectralCard = ({
         accent="var(--cc-mint)"
         size="sm"
         disabled
+        tabIndex={tabIndex}
       />
     )
   }
@@ -34,6 +37,7 @@ export const SpectralCard = ({
       size="sm"
       typeLabel="Spectral"
       onClick={onClick ? () => onClick(isSelected ?? false, spectralCard.id) : undefined}
+      tabIndex={tabIndex}
     />
   )
 }

--- a/src/app/comet-cards/components/gameplay/tarot-card.tsx
+++ b/src/app/comet-cards/components/gameplay/tarot-card.tsx
@@ -6,10 +6,12 @@ export const TarotCard = ({
   tarotCard,
   isSelected,
   onClick,
+  tabIndex,
 }: {
   tarotCard: TarotCardState
   isSelected?: boolean
   onClick?: (isSelected: boolean, id: string) => void
+  tabIndex?: number
 }) => {
   const def = tarotCards[tarotCard.tarotType]
   return (
@@ -23,6 +25,7 @@ export const TarotCard = ({
       typeLabel="Tarot"
       edition={tarotCard.edition}
       onClick={onClick ? () => onClick(isSelected ?? false, tarotCard.id) : undefined}
+      tabIndex={tabIndex}
     />
   )
 }

--- a/src/app/comet-cards/components/pack-open/celestial-card-open-booster-pack.tsx
+++ b/src/app/comet-cards/components/pack-open/celestial-card-open-booster-pack.tsx
@@ -28,7 +28,7 @@ const itemVariants = {
 export function CelestialCardOpenBoosterPack() {
   const reducedMotion = useReducedMotion()
   const { game } = useGameState()
-  const { containerRef, handleKeyDown } = useGridKeyboardNav()
+  const { containerRef, handleKeyDown, focusedIndexRef } = useGridKeyboardNav()
 
   const remainingCardsToSelect = game.shopState.openPackState?.remainingCardsToSelect
 
@@ -70,12 +70,13 @@ export function CelestialCardOpenBoosterPack() {
             animate="visible"
             onKeyDown={handleKeyDown}
           >
-            {cardsForSale.map(buyableCard => (
+            {cardsForSale.map((buyableCard, i) => (
               <motion.div key={buyableCard.card.id} variants={itemVariants} className="flex flex-col gap-2">
                 <BuyableCard
                   key={buyableCard.card.id}
                   buyableCard={buyableCard}
                   isSelected={game.shopState.selectedCardId === buyableCard.card.id}
+                  tabIndex={i === focusedIndexRef.current ? 0 : -1}
                 />
                 {game.shopState.selectedCardId === buyableCard.card.id && (
                   <Button

--- a/src/app/comet-cards/components/pack-open/joker-card-open-booster-pack.tsx
+++ b/src/app/comet-cards/components/pack-open/joker-card-open-booster-pack.tsx
@@ -28,7 +28,7 @@ const itemVariants = {
 export function JokerCardOpenBoosterPack() {
   const reducedMotion = useReducedMotion()
   const { game } = useGameState()
-  const { containerRef, handleKeyDown } = useGridKeyboardNav()
+  const { containerRef, handleKeyDown, focusedIndexRef } = useGridKeyboardNav()
 
   const remainingCardsToSelect = game.shopState.openPackState?.remainingCardsToSelect
 
@@ -78,12 +78,13 @@ export function JokerCardOpenBoosterPack() {
             animate="visible"
             onKeyDown={handleKeyDown}
           >
-            {cardsForSale.map(buyableCard => (
+            {cardsForSale.map((buyableCard, i) => (
               <motion.div key={buyableCard.card.id} variants={itemVariants} className="flex flex-col gap-2">
                 <BuyableCard
                   key={buyableCard.card.id}
                   buyableCard={buyableCard}
                   isSelected={game.shopState.selectedCardId === buyableCard.card.id}
+                  tabIndex={i === focusedIndexRef.current ? 0 : -1}
                 />
                 {game.shopState.selectedCardId === buyableCard.card.id && (
                   <Button

--- a/src/app/comet-cards/components/pack-open/playing-card-open-booster-pack.tsx
+++ b/src/app/comet-cards/components/pack-open/playing-card-open-booster-pack.tsx
@@ -26,7 +26,7 @@ const itemVariants = {
 export function PlayingCardOpenBoosterPack() {
   const reducedMotion = useReducedMotion()
   const { game } = useGameState()
-  const { containerRef, handleKeyDown } = useGridKeyboardNav()
+  const { containerRef, handleKeyDown, focusedIndexRef } = useGridKeyboardNav()
 
   const remainingCardsToSelect = game.shopState.openPackState?.remainingCardsToSelect
 
@@ -57,12 +57,13 @@ export function PlayingCardOpenBoosterPack() {
         animate="visible"
         onKeyDown={handleKeyDown}
       >
-        {cardsForSale.map(buyableCard => (
+        {cardsForSale.map((buyableCard, i) => (
           <motion.div key={buyableCard.card.id} variants={itemVariants} className="flex flex-col gap-2">
             <BuyableCard
               key={buyableCard.card.id}
               buyableCard={buyableCard}
               isSelected={game.shopState.selectedCardId === buyableCard.card.id}
+              tabIndex={i === focusedIndexRef.current ? 0 : -1}
             />
             {game.shopState.selectedCardId === buyableCard.card.id && (
               <Button

--- a/src/app/comet-cards/components/pack-open/spectral-card-open-booster-pack.tsx
+++ b/src/app/comet-cards/components/pack-open/spectral-card-open-booster-pack.tsx
@@ -30,7 +30,7 @@ const itemVariants = {
 export function SpectralCardOpenBoosterPack() {
   const reducedMotion = useReducedMotion()
   const { game } = useGameState()
-  const { containerRef, handleKeyDown } = useGridKeyboardNav()
+  const { containerRef, handleKeyDown, focusedIndexRef } = useGridKeyboardNav()
 
   const remainingCardsToSelect = game.shopState.openPackState?.remainingCardsToSelect
 
@@ -72,12 +72,13 @@ export function SpectralCardOpenBoosterPack() {
             animate="visible"
             onKeyDown={handleKeyDown}
           >
-            {cardsForSale.map(buyableCard => (
+            {cardsForSale.map((buyableCard, i) => (
               <motion.div key={buyableCard.card.id} variants={itemVariants} className="flex flex-col gap-2">
                 <BuyableCard
                   key={buyableCard.card.id}
                   buyableCard={buyableCard}
                   isSelected={game.shopState.selectedCardId === buyableCard.card.id}
+                  tabIndex={i === focusedIndexRef.current ? 0 : -1}
                 />
                 {game.shopState.selectedCardId === buyableCard.card.id && (
                   <Button

--- a/src/app/comet-cards/components/pack-open/tarot-card-open-booster-pack.tsx
+++ b/src/app/comet-cards/components/pack-open/tarot-card-open-booster-pack.tsx
@@ -30,7 +30,7 @@ const itemVariants = {
 export function TarotCardOpenBoosterPack() {
   const reducedMotion = useReducedMotion()
   const { game } = useGameState()
-  const { containerRef, handleKeyDown } = useGridKeyboardNav()
+  const { containerRef, handleKeyDown, focusedIndexRef } = useGridKeyboardNav()
 
   const remainingCardsToSelect = game.shopState.openPackState?.remainingCardsToSelect
 
@@ -72,12 +72,13 @@ export function TarotCardOpenBoosterPack() {
             animate="visible"
             onKeyDown={handleKeyDown}
           >
-            {cardsForSale.map(buyableCard => (
+            {cardsForSale.map((buyableCard, i) => (
               <motion.div key={buyableCard.card.id} variants={itemVariants} className="flex flex-col gap-2">
                 <BuyableCard
                   key={buyableCard.card.id}
                   buyableCard={buyableCard}
                   isSelected={game.shopState.selectedCardId === buyableCard.card.id}
+                  tabIndex={i === focusedIndexRef.current ? 0 : -1}
                 />
                 {game.shopState.selectedCardId === buyableCard.card.id && (
                   <Button

--- a/src/app/comet-cards/components/shop/buyable-card.tsx
+++ b/src/app/comet-cards/components/shop/buyable-card.tsx
@@ -24,9 +24,11 @@ function handleCardSelection(isSelected: boolean, id: string) {
 export function BuyableCard({
   buyableCard,
   isSelected,
+  tabIndex,
 }: {
   buyableCard: BuyableCard
   isSelected: boolean
+  tabIndex?: number
 }) {
   if (isCelestialCardState(buyableCard.card)) {
     return (
@@ -34,6 +36,7 @@ export function BuyableCard({
         celestialCard={buyableCard.card}
         isSelected={isSelected}
         onClick={handleCardSelection}
+        tabIndex={tabIndex}
       />
     )
   }
@@ -43,11 +46,12 @@ export function BuyableCard({
         tarotCard={buyableCard.card}
         isSelected={isSelected}
         onClick={handleCardSelection}
+        tabIndex={tabIndex}
       />
     )
   }
   if (isJokerState(buyableCard.card)) {
-    return <Joker joker={buyableCard.card} isSelected={isSelected} onClick={handleCardSelection} />
+    return <Joker joker={buyableCard.card} isSelected={isSelected} onClick={handleCardSelection} tabIndex={tabIndex} />
   }
   if (isPlayingCardState(buyableCard.card)) {
     return (
@@ -55,6 +59,7 @@ export function BuyableCard({
         playingCard={buyableCard.card}
         isSelected={isSelected}
         onClick={handleCardSelection}
+        tabIndex={tabIndex}
       />
     )
   }
@@ -64,6 +69,7 @@ export function BuyableCard({
         spectralCard={buyableCard.card}
         isSelected={isSelected}
         onClick={handleCardSelection}
+        tabIndex={tabIndex}
       />
     )
   }


### PR DESCRIPTION
## Summary

- Forwards `tabIndex` through `BuyableCard` and the three card components that were missing it (`TarotCard`, `CelestialCard`, `SpectralCard`) so `useGridKeyboardNav`'s roving tabindex pattern is complete.
- Destructures `focusedIndexRef` in `ShopView` and all five pack-open components, then passes `tabIndex={i === focusedIndexRef.current ? 0 : -1}` to each `BuyableCard`.
- Adds the map index `i` to the `cardsForSale.map()` calls in the five pack-open files where it was missing.

Partially addresses #1519.

## Test plan

- [ ] Open the shop — Tab into the "Cards for Sale" toolbar; confirm arrow keys move focus between cards without leaving the group.
- [ ] Open a playing-card booster pack — confirm same roving tabindex behavior.
- [ ] Open a tarot, celestial, spectral, and joker booster pack — confirm each.
- [ ] Verify no regression: mouse click and card selection still work normally.
- [ ] TypeScript: `npx tsc --noEmit` passes with no errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)