### PR TITLE
fix: Five of a Kind hand uses correct chip scaling

### DIFF
--- a/src/app/comet-cards/domain/hand/hands.ts
+++ b/src/app/comet-cards/domain/hand/hands.ts
@@ -110,9 +110,9 @@ export const fiveOfAKindHand: PokerHandDefinition = {
   id: 'fiveOfAKind',
   baseChips: 120,
   baseMult: 12,
-  chipIncreasePerLevel: 40, // TODO: Add correct value
+  chipIncreasePerLevel: 35,
   isSecret: true,
-  multIncreasePerLevel: 3, // TODO: Add correct value
+  multIncreasePerLevel: 3,
   name: 'Five of a Kind',
 }
 


### PR DESCRIPTION
Fixes #1629

Replace placeholder scaling values with Balatro-accurate numbers:
- chipIncreasePerLevel: 40 → 35 per level
- multIncreasePerLevel: 3 (unchanged, already correct)

Removed both TODO comments that were flagging the incorrect placeholder values.