### PR TITLE
fix: auto-expire stale Comet Cards sessions from previous days

### DIFF
--- a/src/app/comet-cards/domain/game/default-game-state.ts
+++ b/src/app/comet-cards/domain/game/default-game-state.ts
@@ -17,14 +17,14 @@ import {
   twoPairHand,
 } from '@/app/comet-cards/domain/hand/hands'
 import { initializeHand } from '@/app/comet-cards/domain/hand/utils'
-import { getCurrentDayAsSeedString } from '@/app/comet-cards/domain/randomness'
+import { getCurrentDayAsSeedStringPST } from '@/app/comet-cards/domain/randomness'
 import { initializeRounds } from '@/app/comet-cards/domain/round/rounds'
 import { generateStartingTarotCards } from '@/app/comet-cards/domain/decks/deck-consumables'
 import { applyStartingVouchers } from '@/app/comet-cards/domain/voucher/deck-vouchers'
 
 import { GameState } from './types'
 
-const gameSeed = getCurrentDayAsSeedString()
+const gameSeed = getCurrentDayAsSeedStringPST()
 
 const gameState: GameState = {
   allowedJokerFlags: [],

--- a/src/app/comet-cards/domain/randomness/index.ts
+++ b/src/app/comet-cards/domain/randomness/index.ts
@@ -125,6 +125,16 @@ export function getCurrentDayAsSeedString() {
   return new Date().toISOString().split('T')[0]
 }
 
+export function getCurrentDayAsSeedStringPST() {
+  const now = new Date()
+  const pstString = now.toLocaleString('en-US', { timeZone: 'America/Los_Angeles' })
+  const pstDate = new Date(pstString)
+  const y = pstDate.getFullYear()
+  const m = String(pstDate.getMonth() + 1).padStart(2, '0')
+  const d = String(pstDate.getDate()).padStart(2, '0')
+  return `${y}-${m}-${d}`
+}
+
 export function buildSeedString(strings: string[]) {
   return strings.join('-')
 }

--- a/src/app/comet-cards/hooks/useRunHistory.ts
+++ b/src/app/comet-cards/hooks/useRunHistory.ts
@@ -2,6 +2,8 @@
 
 import { useCallback, useSyncExternalStore } from 'react'
 
+import { getTodayPST } from '@/lib/dates'
+
 export interface RunSummary {
   seed: string
   date: string           // ISO date string (YYYY-MM-DD)
@@ -66,7 +68,7 @@ function emitChange() {
 export function useRunHistory() {
   const history = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot)
 
-  const today = typeof window !== 'undefined' ? new Date().toISOString().split('T')[0] : ''
+  const today = typeof window !== 'undefined' ? getTodayPST() : ''
   const todayRun = history.runs.find(r => r.date === today) ?? null
 
   const addRun = useCallback((run: RunSummary) => {

--- a/src/app/comet-cards/store.ts
+++ b/src/app/comet-cards/store.ts
@@ -5,10 +5,25 @@ import { persist } from 'zustand/middleware'
 
 import type { GameEvent } from '@/app/comet-cards/domain/events/types'
 import type { GamePhase, GameState } from '@/app/comet-cards/domain/game/types'
-import { getCurrentDayAsSeedString } from '@/app/comet-cards/domain/randomness'
+import { getCurrentDayAsSeedStringPST } from '@/app/comet-cards/domain/randomness'
 
 import { defaultGameState } from './domain/game/default-game-state'
 import { reduceGame } from './domain/game/reduce-game'
+
+interface StaleSessionData {
+  gameSeed: string
+  totalScore: bigint
+  handsPlayed: number
+  roundIndex: number
+}
+
+let _pendingStaleSession: StaleSessionData | null = null
+
+export function consumePendingStaleSession(): StaleSessionData | null {
+  const data = _pendingStaleSession
+  _pendingStaleSession = null
+  return data
+}
 
 export interface CometCardsStore {
   game: GameState
@@ -80,9 +95,19 @@ export const useCometCardsStore = create<CometCardsStore>()(
         const persistedState = persisted as { game?: GameState }
         if (!persistedState.game) return current
 
-        // If the persisted seed doesn't match today, start fresh
-        const todaySeed = getCurrentDayAsSeedString()
+        // If the persisted seed doesn't match today (PST), the session is stale
+        const todaySeed = getCurrentDayAsSeedStringPST()
         if (persistedState.game.gameSeed !== todaySeed) {
+          // If the player was mid-game, capture the session for score recording
+          const phase = persistedState.game.gamePhase
+          if (phase !== 'mainMenu' && phase !== 'gameOver') {
+            _pendingStaleSession = {
+              gameSeed: persistedState.game.gameSeed,
+              totalScore: persistedState.game.totalScore,
+              handsPlayed: persistedState.game.handsPlayed,
+              roundIndex: persistedState.game.roundIndex,
+            }
+          }
           return current
         }
 

--- a/src/app/comet-cards/useGameEvents.ts
+++ b/src/app/comet-cards/useGameEvents.ts
@@ -3,10 +3,44 @@
 import { useEffect } from 'react'
 
 import { eventEmitter } from '@/app/comet-cards/domain/events/event-emitter'
+import { useRunHistory } from '@/app/comet-cards/hooks/useRunHistory'
 import { useGameState } from '@/app/comet-cards/useGameState'
+import { consumePendingStaleSession } from '@/app/comet-cards/store'
+
+const STORAGE_KEY = 'comet-cards-run-history'
+const TOTAL_ROUNDS = 8
 
 export const useGameEvents = () => {
   const { dispatch } = useGameState()
+  const { addRun } = useRunHistory()
+
+  // Record score from a stale session that was expired on load
+  useEffect(() => {
+    const stale = consumePendingStaleSession()
+    if (!stale) return
+
+    // Check if there's already a recorded run for this seed (= practice run)
+    try {
+      const raw = localStorage.getItem(STORAGE_KEY)
+      if (raw) {
+        const history = JSON.parse(raw) as { runs: Array<{ seed: string }> }
+        if (history.runs.some(r => r.seed === stale.gameSeed)) return
+      }
+    } catch {
+      // If we can't read history, record the run to be safe
+    }
+
+    const roundsCompleted = Math.max(0, Math.min(TOTAL_ROUNDS, stale.roundIndex - 1))
+    addRun({
+      seed: stale.gameSeed,
+      date: stale.gameSeed, // The seed IS the PST date string
+      totalScore: stale.totalScore.toString(),
+      handsPlayed: stale.handsPlayed,
+      roundsCompleted,
+      totalRounds: TOTAL_ROUNDS,
+      won: roundsCompleted >= TOTAL_ROUNDS,
+    })
+  }, [addRun])
 
   useEffect(() => {
     return eventEmitter.onAny(event => dispatch(event))


### PR DESCRIPTION
## Summary
- Switches `getCurrentDayAsSeedString` from UTC to PST (`getCurrentDayAsSeedStringPST`) so the day boundary matches the rest of the app
- When the store detects a stale mid-game session on load, it captures it in `_pendingStaleSession` instead of silently discarding it
- `useGameEvents` reads and clears that pending stale session on mount, recording the score to run history (if no prior run exists for that seed)
- `useRunHistory` now uses `getTodayPST()` for "today" detection, keeping it consistent with the PST seed boundary

## Test plan
- [ ] Play partway through a game, then manually set the stored `gameSeed` to yesterday's date and reload — should see a fresh game start (no stale session)
- [ ] Verify a run history entry is recorded for the stale session's seed/score when the session was mid-game
- [ ] Verify no duplicate run is recorded if the seed already appears in run history (practice run protection)
- [ ] Verify normal same-day resume still works (session with today's PST seed restores correctly)
- [ ] Verify a player at 11 PM PST uses the correct PST date as seed (not UTC tomorrow)

Closes #1633