### PR TITLE
fix: show which joker Blueprint/Brainstorm are copying in tooltip

### DIFF
--- a/src/app/comet-cards/components/game-views/gameplay.tsx
+++ b/src/app/comet-cards/components/game-views/gameplay.tsx
@@ -30,6 +30,7 @@ import { MiniScoringLog } from '@/app/comet-cards/components/mini-scoring-log'
 import { calculateAnte, getBlindDefinition } from '@/app/comet-cards/domain/game/utils'
 import { pokerHands } from '@/app/comet-cards/domain/hand/hands'
 import { jokers as jokerDefinitions } from '@/app/comet-cards/domain/joker/jokers'
+import { getCopyJokerDescription } from '@/app/comet-cards/domain/joker/copy-joker-description'
 import { getScoringCards } from '@/app/comet-cards/domain/game/card-registry-utils'
 import { getInProgressBlind } from '@/app/comet-cards/domain/round/blinds'
 import { useCometCardsStore } from '@/app/comet-cards/store'
@@ -1029,6 +1030,7 @@ export function GamePlayView() {
                     >
                       <Joker
                         joker={joker}
+                        description={getCopyJokerDescription(joker.jokerId, i, game.jokers)}
                         isSelected={gamePlayState.selectedJokerId === joker.id}
                         isSwapTarget={!!gamePlayState.selectedJokerId && gamePlayState.selectedJokerId !== joker.id}
                         ownedCardCount={game.ownedCardIds.length}

--- a/src/app/comet-cards/components/gameplay/joker.tsx
+++ b/src/app/comet-cards/components/gameplay/joker.tsx
@@ -50,6 +50,7 @@ export const Joker = ({
   roundIndex,
   activated,
   tabIndex,
+  description,
 }: {
   joker: JokerState
   isSelected?: boolean
@@ -60,6 +61,7 @@ export const Joker = ({
   roundIndex?: number
   activated?: boolean
   tabIndex?: number
+  description?: string
 }) => {
   const def = jokers[joker.jokerId]
   const accent = RARITY_ACCENT[def?.rarity ?? 'common'] ?? 'var(--cc-mint)'
@@ -229,7 +231,7 @@ export const Joker = ({
     >
       <TokenCard
         title={def?.name ?? 'Unknown'}
-        description={def?.description}
+        description={description ?? def?.description}
         glyph="✺"
         accent={accent}
         selected={isSelected}

--- a/src/app/comet-cards/components/joker/current-jokers.tsx
+++ b/src/app/comet-cards/components/joker/current-jokers.tsx
@@ -2,6 +2,7 @@ import { DangerButton } from '@/app/comet-cards/components/cosmic/buttons'
 import { Joker } from '@/app/comet-cards/components/gameplay/joker'
 import { eventEmitter } from '@/app/comet-cards/domain/events/event-emitter'
 import { jokers } from '@/app/comet-cards/domain/joker/jokers'
+import { getCopyJokerDescription } from '@/app/comet-cards/domain/joker/copy-joker-description'
 import { useGridKeyboardNav } from '@/app/comet-cards/hooks/useGridKeyboardNav'
 import { useGameState } from '@/app/comet-cards/useGameState'
 import { getJokerSellValue } from '@/app/comet-cards/domain/shop/sell-utils'
@@ -50,6 +51,7 @@ export const CurrentJokers = () => {
               <Joker
                 key={joker.id}
                 joker={joker}
+                description={getCopyJokerDescription(joker.jokerId, i, game.jokers)}
                 isSelected={game.gamePlayState.selectedJokerId === joker.id}
                 isSwapTarget={!!game.gamePlayState.selectedJokerId && game.gamePlayState.selectedJokerId !== joker.id}
                 ownedCardCount={game.ownedCardIds.length}

--- a/src/app/comet-cards/domain/joker/copy-joker-description.ts
+++ b/src/app/comet-cards/domain/joker/copy-joker-description.ts
@@ -1,0 +1,20 @@
+import { jokers } from '@/app/comet-cards/domain/joker/jokers'
+import type { JokerState } from '@/app/comet-cards/domain/joker/types'
+
+export function getCopyJokerDescription(jokerId: string, index: number, allJokers: JokerState[]): string | undefined {
+  if (jokerId === 'blueprint') {
+    const rightJoker = allJokers[index + 1]
+    if (!rightJoker) return 'Copies ability of Joker to the right (no joker to copy)'
+    const rightDef = jokers[rightJoker.jokerId]
+    return `Copies ability of Joker to the right (currently: ${rightDef?.name ?? 'Unknown'})`
+  }
+  if (jokerId === 'brainstorm') {
+    const leftmostJoker = allJokers[0]
+    if (!leftmostJoker || leftmostJoker.jokerId === 'brainstorm') {
+      return 'Copies the ability of leftmost Joker (no joker to copy)'
+    }
+    const leftDef = jokers[leftmostJoker.jokerId]
+    return `Copies the ability of leftmost Joker (currently: ${leftDef?.name ?? 'Unknown'})`
+  }
+  return undefined
+}


### PR DESCRIPTION
## Summary
- Blueprint and Brainstorm joker tooltips now dynamically show which joker they're currently copying
- Blueprint: "Copies ability of Joker to the right (currently: **Campfire**)"
- Brainstorm: "Copies the ability of leftmost Joker (currently: **Baron**)"
- Shows "(no joker to copy)" when there's no valid target

## Changes
- New helper: `copy-joker-description.ts` — resolves the target joker name for Blueprint (right neighbor) and Brainstorm (leftmost joker)
- Added optional `description` prop to `Joker` component to allow overriding the static definition description
- Wired up in both `current-jokers.tsx` and `gameplay.tsx` desktop render

## Test plan
- [ ] Place Blueprint in various positions — tooltip updates to show the joker to its right
- [ ] Place Blueprint in the last position — tooltip shows "(no joker to copy)"
- [ ] Place Brainstorm anywhere — tooltip shows the leftmost joker
- [ ] Swap joker positions — tooltips update correctly
- [ ] Verify no regressions in shop/buyable joker cards (no description override passed)

Closes #1630

🤖 Generated with [Claude Code](https://claude.com/claude-code)