### PR TITLE
fix: display active tags on shop page

### DIFF
--- a/src/app/comet-cards/components/game-views/shop.tsx
+++ b/src/app/comet-cards/components/game-views/shop.tsx
@@ -5,6 +5,7 @@ import { useEffect } from 'react'
 import { motion, useReducedMotion } from 'framer-motion'
 
 import { CurrentConsumables } from '@/app/comet-cards/components/consumables/current-consumables'
+import { Tag } from '@/app/comet-cards/components/gameplay/tag'
 import {
   DangerButton,
   GhostButton,
@@ -212,6 +213,16 @@ export function ShopView() {
             {game.consumables.length > 0 && (
               <SectionHeader label="Your Consumables">
                 <CurrentConsumables />
+              </SectionHeader>
+            )}
+
+            {game.tags.length > 0 && (
+              <SectionHeader label={`Active Tags (${game.tags.length})`}>
+                <div className="flex flex-wrap" style={{ gap: 8 }}>
+                  {game.tags.map(tag => (
+                    <Tag key={tag.id} tag={tag} />
+                  ))}
+                </div>
               </SectionHeader>
             )}
           </div>


### PR DESCRIPTION
## Summary
- Adds an "Active Tags" section to the shop page's main content area, so players can see which tags they earned from skipping blinds
- Tags have shop-relevant effects (discounts, free items, extra packs) that were invisible because they only appeared in a sidebar hidden on landscape/desktop mode
- Reuses the existing `Tag` component (TokenCard-based) for consistent styling

Closes #1637

## Test plan
- [ ] Start a Comet Cards run, skip a blind to earn a tag
- [ ] Navigate to the shop — verify the "Active Tags" section appears with the earned tag(s)
- [ ] Verify tags show name, benefit description, and minimum ante
- [ ] Check on both mobile/portrait and desktop/landscape — tags should be visible in both
- [ ] When no tags are active, the section should not appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)