### PR TITLE
fix: reset game state on restart to return to blind selection

### DIFF
--- a/src/app/comet-cards/domain/game/__tests__/restart.test.ts
+++ b/src/app/comet-cards/domain/game/__tests__/restart.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest'
+import { defaultGameState } from '@/app/comet-cards/domain/game/default-game-state'
+import { reduceGame } from '@/app/comet-cards/domain/game/reduce-game'
+import type { GameState } from '@/app/comet-cards/domain/game/types'
+import { jokers } from '@/app/comet-cards/domain/joker/jokers'
+import { initializeJoker } from '@/app/comet-cards/domain/joker/utils'
+
+describe('restart (GAME_START from mid-run)', () => {
+  it('resets gamePhase to blindSelection', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.gamePhase = 'shop'
+    const after = reduceGame(game, { type: 'GAME_START' })
+    expect(after.gamePhase).toBe('blindSelection')
+  })
+
+  it('resets roundIndex to 1', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.roundIndex = 3
+    const after = reduceGame(game, { type: 'GAME_START' })
+    expect(after.roundIndex).toBe(1)
+  })
+
+  it('resets money to 0', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.money = 100
+    const after = reduceGame(game, { type: 'GAME_START' })
+    expect(after.money).toBe(0)
+  })
+
+  it('resets jokers to empty', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.jokers = [
+      initializeJoker(jokers.jokerJoker, game),
+      initializeJoker(jokers.halfJoker, game),
+    ]
+    const after = reduceGame(game, { type: 'GAME_START' })
+    expect(after.jokers).toHaveLength(0)
+  })
+
+  it('preserves selectedDeck', () => {
+    const game: GameState = structuredClone(defaultGameState)
+    game.selectedDeck = 'abandonedDeck'
+    const after = reduceGame(game, { type: 'GAME_START' })
+    expect(after.selectedDeck).toBe('abandonedDeck')
+  })
+})

--- a/src/app/comet-cards/domain/game/reduce-game.ts
+++ b/src/app/comet-cards/domain/game/reduce-game.ts
@@ -6,6 +6,7 @@ import { dealCardsFromDrawPile } from '@/app/comet-cards/domain/game/card-regist
 import { jokers } from '@/app/comet-cards/domain/joker/jokers'
 import { getJokerSellValue } from '@/app/comet-cards/domain/shop/sell-utils'
 
+import { createGameStateWithDeck } from './default-game-state'
 import { HAND_SIZE } from './constants'
 import { handleHandScoringEnd } from './handlers'
 import {
@@ -54,6 +55,8 @@ export function reduceGame(game: GameState, event: GameEvent): GameState {
        */
 
       case 'GAME_START': {
+        const freshState = createGameStateWithDeck(draft.selectedDeck)
+        Object.assign(draft, structuredClone(freshState))
         handleGameStart(draft, event)
         return
       }


### PR DESCRIPTION
## Summary
- Restart during a practice run was returning the player to the shop with stale state instead of starting a fresh run
- Root cause: `GAME_START` handler only set `gamePhase = 'blindSelection'` without resetting accumulated state (roundIndex, money, jokers, cards, etc.)
- Fix: reset the entire game state via `createGameStateWithDeck()` before calling `handleGameStart`, preserving only the selected deck
- Added 5 tests covering state reset and deck preservation

Closes #1642

## Test plan
- [ ] Start a Comet Cards run, progress a few rounds
- [ ] Click "Restart" during gameplay — should return to blind selection with fresh state (round 1, $0, no jokers)
- [ ] Start a new run from main menu — should work as before
- [ ] "Play Again" from main menu after completing a run — should work as before
- [ ] Run `npx vitest run src/app/comet-cards/domain/game/__tests__/restart.test.ts` — all 5 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)