### PR TITLE
feat: add edition text labels to joker cards

### DIFF
--- a/src/app/comet-cards/components/cosmic/token-card.tsx
+++ b/src/app/comet-cards/components/cosmic/token-card.tsx
@@ -159,6 +159,33 @@ export function TokenCard({
         </div>
       )}
 
+      {edition && edition !== 'normal' && (
+        <div
+          style={{
+            position: 'absolute',
+            left: 0,
+            right: 0,
+            bottom: 0,
+            textAlign: 'center',
+            fontFamily: 'var(--cc-font-mono)',
+            fontSize: 9,
+            letterSpacing: 1.5,
+            textTransform: 'uppercase',
+            background: 'rgba(0,0,0,0.45)',
+            color: edition === 'negative' ? '#b0b0c0' :
+                   edition === 'foil' ? '#c8dcff' :
+                   edition === 'holographic' ? '#ffaaff' :
+                   edition === 'polychrome' ? '#aaffcc' :
+                   'var(--cc-text-default)',
+            padding: '3px 0',
+            zIndex: 3,
+            borderRadius: '0 0 11px 11px',
+          }}
+        >
+          {edition}
+        </div>
+      )}
+
       <div
         className="flex items-center justify-center"
         style={{

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -308,9 +308,10 @@ body {
   inset: 0;
   border-radius: inherit;
   pointer-events: none;
-  background: rgba(0, 0, 0, 0.15);
+  background: rgba(0, 0, 0, 0.22);
   mix-blend-mode: multiply;
-  border: 1px solid rgba(100, 100, 120, 0.3);
+  border: 1px solid rgba(100, 100, 120, 0.4);
+  box-shadow: inset 0 0 12px rgba(0, 0, 0, 0.3);
 }
 
 /* ───────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Jokers with non-normal editions (Negative, Foil, Holographic, Polychrome) now display a text label at the bottom of the card
- Each edition gets a distinct label color: gray-blue for Negative, cool blue for Foil, pink for Holographic, green for Polychrome
- Enhanced the Negative edition CSS overlay with stronger darkening (22% from 15%), more opaque border, and an inset shadow for better visual distinction
- Labels appear automatically everywhere TokenCard is used (gameplay, shop, pack opening)

Closes #1638

## Test plan
- [ ] Acquire a Negative edition joker (via Ectoplasm spectral card or Negative Tag) — verify the "NEGATIVE" label appears at the bottom of the card
- [ ] Verify other edition labels (Foil, Holographic, Polychrome) also display correctly
- [ ] Normal edition jokers should NOT show any label
- [ ] Check visibility on both mobile and desktop layouts
- [ ] Verify labels don't obscure joker name or state information

🤖 Generated with [Claude Code](https://claude.com/claude-code)