### PR TITLE
feat: Storybook Factory route, page shell, and step wizard

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -16,6 +16,7 @@ const games: readonly { title: string; icon: string; href: string; description: 
   { title: 'Whowouldwininator', icon: 'sports_mma', href: ROUTE_CONSTANTS.WHOWOULDWININATOR, description: 'Create two characters and see who would win' },
   { title: 'Chat Room of Infinity', icon: 'chat', href: ROUTE_CONSTANTS.CHAT_ROOM, description: 'Chat with fictional characters in a chat room' },
   { title: 'Avatar Maker', icon: 'face', href: ROUTE_CONSTANTS.AVATAR_MAKER, description: 'Create unique AI-powered avatars from your photos' },
+  { title: 'Storybook Factory', icon: 'auto_stories', href: ROUTE_CONSTANTS.STORYBOOK_FACTORY, description: 'Create illustrated comic books and storybooks from your pictures' },
 ]
 
 export default function Home() {

--- a/src/app/route-constants.ts
+++ b/src/app/route-constants.ts
@@ -10,4 +10,5 @@ export const ROUTE_CONSTANTS = {
   WHOWOULDWININATOR: '/whowouldwininator',
   TRIVIA: '/trivia',
   COMET_CARDS: '/comet-cards',
+  STORYBOOK_FACTORY: '/storybook-factory',
 }

--- a/src/app/storybook-factory/components/step01-upload-and-describe.tsx
+++ b/src/app/storybook-factory/components/step01-upload-and-describe.tsx
@@ -1,0 +1,33 @@
+import { ChunkyButton } from '@/components/ui/chunky-button'
+
+export function Step01UploadAndDescribe({ onNext }: { onNext: () => void }) {
+  return (
+    <div className="space-y-6 mt-6">
+      <div className="bg-surface-container rounded-lg p-6 space-y-2">
+        <h2 className="font-headline text-2xl text-on-surface">Upload &amp; Describe</h2>
+        <p className="font-body text-body-md text-on-surface-variant">
+          Upload two images and describe them to get started.
+        </p>
+      </div>
+
+      <div className="bg-surface-container rounded-lg p-6 flex flex-col items-center gap-4 text-center">
+        <span
+          className="material-symbols-outlined text-[48px] text-on-surface-variant"
+          style={{ fontVariationSettings: "'FILL' 0" }}
+        >
+          construction
+        </span>
+        <p className="font-body text-body-md text-on-surface-variant">
+          Coming soon — image upload and description will be here.
+        </p>
+      </div>
+
+      <div className="flex justify-end">
+        <ChunkyButton variant="primary" onClick={onNext}>
+          Next
+          <span className="material-symbols-outlined ml-2">arrow_forward</span>
+        </ChunkyButton>
+      </div>
+    </div>
+  )
+}

--- a/src/app/storybook-factory/components/step02-story-configuration.tsx
+++ b/src/app/storybook-factory/components/step02-story-configuration.tsx
@@ -1,0 +1,43 @@
+import { ChunkyButton } from '@/components/ui/chunky-button'
+
+export function Step02StoryConfiguration({
+  onNext,
+  onPrevious,
+}: {
+  onNext: () => void
+  onPrevious: () => void
+}) {
+  return (
+    <div className="space-y-6 mt-6">
+      <div className="bg-surface-container rounded-lg p-6 space-y-2">
+        <h2 className="font-headline text-2xl text-on-surface">Story Configuration</h2>
+        <p className="font-body text-body-md text-on-surface-variant">
+          Choose your story type and visual style.
+        </p>
+      </div>
+
+      <div className="bg-surface-container rounded-lg p-6 flex flex-col items-center gap-4 text-center">
+        <span
+          className="material-symbols-outlined text-[48px] text-on-surface-variant"
+          style={{ fontVariationSettings: "'FILL' 0" }}
+        >
+          construction
+        </span>
+        <p className="font-body text-body-md text-on-surface-variant">
+          Coming soon — story type and style selection will be here.
+        </p>
+      </div>
+
+      <div className="flex justify-between">
+        <ChunkyButton variant="secondary" onClick={onPrevious}>
+          <span className="material-symbols-outlined mr-2">arrow_back</span>
+          Back
+        </ChunkyButton>
+        <ChunkyButton variant="primary" onClick={onNext}>
+          Next
+          <span className="material-symbols-outlined ml-2">arrow_forward</span>
+        </ChunkyButton>
+      </div>
+    </div>
+  )
+}

--- a/src/app/storybook-factory/components/step03-generation.tsx
+++ b/src/app/storybook-factory/components/step03-generation.tsx
@@ -1,0 +1,43 @@
+import { ChunkyButton } from '@/components/ui/chunky-button'
+
+export function Step03Generation({
+  onNext,
+  onPrevious,
+}: {
+  onNext: () => void
+  onPrevious: () => void
+}) {
+  return (
+    <div className="space-y-6 mt-6">
+      <div className="bg-surface-container rounded-lg p-6 space-y-2">
+        <h2 className="font-headline text-2xl text-on-surface">Generating Your Story</h2>
+        <p className="font-body text-body-md text-on-surface-variant">
+          AI is crafting your illustrated story — sit tight!
+        </p>
+      </div>
+
+      <div className="bg-surface-container rounded-lg p-6 flex flex-col items-center gap-4 text-center">
+        <span
+          className="material-symbols-outlined text-[48px] text-on-surface-variant"
+          style={{ fontVariationSettings: "'FILL' 0" }}
+        >
+          construction
+        </span>
+        <p className="font-body text-body-md text-on-surface-variant">
+          Coming soon — story generation and progress display will be here.
+        </p>
+      </div>
+
+      <div className="flex justify-between">
+        <ChunkyButton variant="secondary" onClick={onPrevious}>
+          <span className="material-symbols-outlined mr-2">arrow_back</span>
+          Back
+        </ChunkyButton>
+        <ChunkyButton variant="primary" onClick={onNext}>
+          Next
+          <span className="material-symbols-outlined ml-2">arrow_forward</span>
+        </ChunkyButton>
+      </div>
+    </div>
+  )
+}

--- a/src/app/storybook-factory/components/step04-review-and-revise.tsx
+++ b/src/app/storybook-factory/components/step04-review-and-revise.tsx
@@ -1,0 +1,33 @@
+import { ChunkyButton } from '@/components/ui/chunky-button'
+
+export function Step04ReviewAndRevise({ onPrevious }: { onPrevious: () => void }) {
+  return (
+    <div className="space-y-6 mt-6">
+      <div className="bg-surface-container rounded-lg p-6 space-y-2">
+        <h2 className="font-headline text-2xl text-on-surface">Review &amp; Revise</h2>
+        <p className="font-body text-body-md text-on-surface-variant">
+          Review your illustrated story and make any final edits.
+        </p>
+      </div>
+
+      <div className="bg-surface-container rounded-lg p-6 flex flex-col items-center gap-4 text-center">
+        <span
+          className="material-symbols-outlined text-[48px] text-on-surface-variant"
+          style={{ fontVariationSettings: "'FILL' 0" }}
+        >
+          construction
+        </span>
+        <p className="font-body text-body-md text-on-surface-variant">
+          Coming soon — story viewer and revision tools will be here.
+        </p>
+      </div>
+
+      <div className="flex justify-start">
+        <ChunkyButton variant="secondary" onClick={onPrevious}>
+          <span className="material-symbols-outlined mr-2">arrow_back</span>
+          Back
+        </ChunkyButton>
+      </div>
+    </div>
+  )
+}

--- a/src/app/storybook-factory/components/useStorybookFactoryState.tsx
+++ b/src/app/storybook-factory/components/useStorybookFactoryState.tsx
@@ -1,0 +1,7 @@
+export interface StorybookFactoryState {
+  // Placeholder — real state will be added in a future iteration
+}
+
+export function useStorybookFactoryState(): StorybookFactoryState {
+  return {}
+}

--- a/src/app/storybook-factory/components/useWorkflow.tsx
+++ b/src/app/storybook-factory/components/useWorkflow.tsx
@@ -1,0 +1,19 @@
+import { useState } from 'react'
+
+export function useWorkflow() {
+  const [currentStep, setCurrentStep] = useState(0)
+
+  const nextStep = () => {
+    setCurrentStep(prev => Math.min(prev + 1, 3))
+  }
+
+  const previousStep = () => {
+    setCurrentStep(prev => Math.max(prev - 1, 0))
+  }
+
+  return {
+    currentStep,
+    nextStep,
+    previousStep,
+  }
+}

--- a/src/app/storybook-factory/layout.tsx
+++ b/src/app/storybook-factory/layout.tsx
@@ -1,0 +1,42 @@
+import type { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  title: 'Storybook Factory - CometCave',
+  description:
+    'Generate illustrated comic books and storybooks from your pictures! Upload your images, choose a story style, and watch AI craft a unique illustrated story just for you.',
+  keywords: [
+    'storybook',
+    'comic book',
+    'illustrated stories',
+    'AI story generator',
+    'photo storybook',
+    'image to story',
+  ],
+  authors: [{ name: 'CometCave' }],
+  openGraph: {
+    title: 'Storybook Factory - CometCave',
+    description:
+      'Generate illustrated comic books and storybooks from your pictures! Upload images and watch AI craft a unique illustrated story.',
+    url: 'https://cometcave.com/storybook-factory',
+    siteName: 'CometCave - AI Galaxy Arcade',
+    type: 'website',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Storybook Factory - CometCave',
+    description:
+      'Generate illustrated comic books and storybooks from your pictures!',
+    creator: '@cometcave',
+  },
+  robots: {
+    index: true,
+    follow: true,
+  },
+  alternates: {
+    canonical: 'https://cometcave.com/storybook-factory',
+  },
+}
+
+export default function StorybookFactoryLayout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>
+}

--- a/src/app/storybook-factory/page.tsx
+++ b/src/app/storybook-factory/page.tsx
@@ -1,0 +1,33 @@
+'use client'
+
+import { Step01UploadAndDescribe } from './components/step01-upload-and-describe'
+import { Step02StoryConfiguration } from './components/step02-story-configuration'
+import { Step03Generation } from './components/step03-generation'
+import { Step04ReviewAndRevise } from './components/step04-review-and-revise'
+import { useStorybookFactoryState } from './components/useStorybookFactoryState'
+import { useWorkflow } from './components/useWorkflow'
+
+export default function StorybookFactory() {
+  const { currentStep, nextStep, previousStep } = useWorkflow()
+  const _state = useStorybookFactoryState()
+
+  return (
+    <div className="flex flex-col items-center justify-center">
+      <div className="w-full max-w-screen-lg mt-20">
+        <h1 className="font-headline text-4xl font-bold text-center text-on-surface">
+          Storybook Factory
+        </h1>
+        <p className="font-body text-body-lg text-center text-on-surface-variant mt-2">
+          Create illustrated stories from your pictures
+        </p>
+
+        {currentStep === 0 && <Step01UploadAndDescribe onNext={nextStep} />}
+        {currentStep === 1 && (
+          <Step02StoryConfiguration onNext={nextStep} onPrevious={previousStep} />
+        )}
+        {currentStep === 2 && <Step03Generation onNext={nextStep} onPrevious={previousStep} />}
+        {currentStep === 3 && <Step04ReviewAndRevise onPrevious={previousStep} />}
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

- Adds `/storybook-factory` route following the whowouldwininator pattern exactly
- Creates `layout.tsx` (server component with metadata), `page.tsx` (client component with 4-step wizard), `useWorkflow.tsx` (4-step navigation hook), and `useStorybookFactoryState.tsx` (placeholder state hook)
- Adds four placeholder step components: Upload & Describe, Story Configuration, Generating Your Story, and Review & Revise — each with a "Coming soon" message and appropriate Back/Next buttons using ChunkyButton
- Registers `STORYBOOK_FACTORY: '/storybook-factory'` in `route-constants.ts`
- Adds Storybook Factory to the home page games grid with the `auto_stories` icon

Closes #1648

## Test plan

- [ ] Visit `/storybook-factory` — page renders with title "Storybook Factory" and subtitle
- [ ] Step 0 (Upload & Describe) shows with a Next button; clicking Next advances to step 1
- [ ] Step 1 (Story Configuration) shows Back and Next buttons; both navigate correctly
- [ ] Step 2 (Generating Your Story) shows Back and Next buttons; both navigate correctly
- [ ] Step 3 (Review & Revise) shows only a Back button
- [ ] Home page shows Storybook Factory card with `auto_stories` icon
- [ ] TypeScript compiles with no import errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)