### PR TITLE
feat(storybook-factory): two-image upload component with captions

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -16,6 +16,7 @@ const games: readonly { title: string; icon: string; href: string; description: 
   { title: 'Whowouldwininator', icon: 'sports_mma', href: ROUTE_CONSTANTS.WHOWOULDWININATOR, description: 'Create two characters and see who would win' },
   { title: 'Chat Room of Infinity', icon: 'chat', href: ROUTE_CONSTANTS.CHAT_ROOM, description: 'Chat with fictional characters in a chat room' },
   { title: 'Avatar Maker', icon: 'face', href: ROUTE_CONSTANTS.AVATAR_MAKER, description: 'Create unique AI-powered avatars from your photos' },
+  { title: 'Storybook Factory', icon: 'auto_stories', href: ROUTE_CONSTANTS.STORYBOOK_FACTORY, description: 'Create illustrated comic books and storybooks from your pictures' },
 ]
 
 export default function Home() {

--- a/src/app/route-constants.ts
+++ b/src/app/route-constants.ts
@@ -10,4 +10,5 @@ export const ROUTE_CONSTANTS = {
   WHOWOULDWININATOR: '/whowouldwininator',
   TRIVIA: '/trivia',
   COMET_CARDS: '/comet-cards',
+  STORYBOOK_FACTORY: '/storybook-factory',
 }

--- a/src/app/storybook-factory/components/step01-upload-and-describe.tsx
+++ b/src/app/storybook-factory/components/step01-upload-and-describe.tsx
@@ -1,0 +1,33 @@
+import { ChunkyButton } from '@/components/ui/chunky-button'
+
+export function Step01UploadAndDescribe({ onNext }: { onNext: () => void }) {
+  return (
+    <div className="space-y-6 mt-6">
+      <div className="bg-surface-container rounded-lg p-6 space-y-2">
+        <h2 className="font-headline text-2xl text-on-surface">Upload &amp; Describe</h2>
+        <p className="font-body text-body-md text-on-surface-variant">
+          Upload two images and describe them to get started.
+        </p>
+      </div>
+
+      <div className="bg-surface-container rounded-lg p-6 flex flex-col items-center gap-4 text-center">
+        <span
+          className="material-symbols-outlined text-[48px] text-on-surface-variant"
+          style={{ fontVariationSettings: "'FILL' 0" }}
+        >
+          construction
+        </span>
+        <p className="font-body text-body-md text-on-surface-variant">
+          Coming soon — image upload and description will be here.
+        </p>
+      </div>
+
+      <div className="flex justify-end">
+        <ChunkyButton variant="primary" onClick={onNext}>
+          Next
+          <span className="material-symbols-outlined ml-2">arrow_forward</span>
+        </ChunkyButton>
+      </div>
+    </div>
+  )
+}

--- a/src/app/storybook-factory/components/step01-upload-and-describe.tsx
+++ b/src/app/storybook-factory/components/step01-upload-and-describe.tsx
@@ -1,31 +1,304 @@
-import { ChunkyButton } from '@/components/ui/chunky-button'
+'use client'
 
-export function Step01UploadAndDescribe({ onNext }: { onNext: () => void }) {
+import { useRef, useState } from 'react'
+
+import { ChunkyButton } from '@/components/ui/chunky-button'
+import { cn } from '@/lib/utils'
+
+interface ImageUploadZoneProps {
+  label: string
+  imageBase64: string | null
+  onImageSelect: (file: File) => void
+  onImageRemove: () => void
+}
+
+function ImageUploadZone({ label, imageBase64, onImageSelect, onImageRemove }: ImageUploadZoneProps) {
+  const fileInputRef = useRef<HTMLInputElement>(null)
+  const [isDragOver, setIsDragOver] = useState(false)
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0]
+    if (file) {
+      onImageSelect(file)
+      // Reset input so same file can be re-selected after removal
+      e.target.value = ''
+    }
+  }
+
+  const handleDrop = (e: React.DragEvent<HTMLDivElement>) => {
+    e.preventDefault()
+    setIsDragOver(false)
+    const file = e.dataTransfer.files?.[0]
+    if (file) {
+      onImageSelect(file)
+    }
+  }
+
+  const handleDragOver = (e: React.DragEvent<HTMLDivElement>) => {
+    e.preventDefault()
+    setIsDragOver(true)
+  }
+
+  const handleDragEnter = (e: React.DragEvent<HTMLDivElement>) => {
+    e.preventDefault()
+    setIsDragOver(true)
+  }
+
+  const handleDragLeave = (e: React.DragEvent<HTMLDivElement>) => {
+    e.preventDefault()
+    setIsDragOver(false)
+  }
+
+  return (
+    <div className="flex flex-col gap-3">
+      <p className="font-body text-body-sm text-on-surface-variant">{label}</p>
+
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept="image/*"
+        onChange={handleFileChange}
+        className="hidden"
+        aria-label={`Upload ${label}`}
+      />
+
+      {imageBase64 ? (
+        <div className="relative rounded-2xl overflow-hidden bg-surface-container-high border border-outline-variant">
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            src={imageBase64}
+            alt={`Preview for ${label}`}
+            className="w-full max-h-64 object-contain"
+          />
+          <button
+            type="button"
+            onClick={onImageRemove}
+            aria-label={`Remove ${label}`}
+            className={cn(
+              'absolute top-2 right-2 min-w-[48px] min-h-[48px] flex items-center justify-center',
+              'rounded-full bg-surface-container/90 border border-outline-variant',
+              'text-on-surface hover:bg-error-container hover:text-on-error-container',
+              'transition-colors cursor-pointer'
+            )}
+          >
+            <span className="material-symbols-outlined text-[20px]">close</span>
+          </button>
+        </div>
+      ) : (
+        <div
+          role="button"
+          tabIndex={0}
+          onClick={() => fileInputRef.current?.click()}
+          onKeyDown={e => {
+            if (e.key === 'Enter' || e.key === ' ') {
+              e.preventDefault()
+              fileInputRef.current?.click()
+            }
+          }}
+          onDragOver={handleDragOver}
+          onDragEnter={handleDragEnter}
+          onDragLeave={handleDragLeave}
+          onDrop={handleDrop}
+          className={cn(
+            'flex flex-col items-center justify-center gap-3 px-6 py-12 rounded-2xl',
+            'border-2 border-dashed transition-colors cursor-pointer',
+            'min-h-[180px]',
+            isDragOver
+              ? 'border-primary bg-primary-container/20'
+              : 'border-outline-variant hover:border-primary hover:bg-surface-container-high/50'
+          )}
+        >
+          <span
+            className="material-symbols-outlined text-[48px] text-on-surface-variant"
+            style={{ fontVariationSettings: "'FILL' 0" }}
+          >
+            add_photo_alternate
+          </span>
+          <p className="font-body text-body-sm text-on-surface-variant text-center">
+            Drop image here or click to upload
+          </p>
+          <p className="font-body text-body-sm text-on-surface-variant/60 text-center">
+            JPEG, PNG, GIF — max 5 MB
+          </p>
+        </div>
+      )}
+    </div>
+  )
+}
+
+export interface Step01Props {
+  onNext: () => void
+  image1Base64: string | null
+  image2Base64: string | null
+  caption1: string
+  caption2: string
+  storyDirectionPrompt: string
+  isLoading: boolean
+  error: string | null
+  setImage1: (file: File) => void
+  setImage2: (file: File) => void
+  clearImage1: () => void
+  clearImage2: () => void
+  setCaption1: (text: string) => void
+  setCaption2: (text: string) => void
+  setStoryDirectionPrompt: (text: string) => void
+  clearError: () => void
+  canProceedFromUpload: boolean
+}
+
+export function Step01UploadAndDescribe({
+  onNext,
+  image1Base64,
+  image2Base64,
+  caption1,
+  caption2,
+  storyDirectionPrompt,
+  isLoading,
+  error,
+  setImage1,
+  setImage2,
+  clearImage1,
+  clearImage2,
+  setCaption1,
+  setCaption2,
+  setStoryDirectionPrompt,
+  clearError,
+  canProceedFromUpload,
+}: Step01Props) {
   return (
     <div className="space-y-6 mt-6">
-      <div className="bg-surface-container rounded-lg p-6 space-y-2">
+      {/* Header */}
+      <div className="bg-surface-container rounded-2xl p-6 space-y-2">
         <h2 className="font-headline text-2xl text-on-surface">Upload &amp; Describe</h2>
         <p className="font-body text-body-md text-on-surface-variant">
-          Upload two images and describe them to get started.
+          Upload two images to inspire your story.
         </p>
       </div>
 
-      <div className="bg-surface-container rounded-lg p-6 flex flex-col items-center gap-4 text-center">
-        <span
-          className="material-symbols-outlined text-[48px] text-on-surface-variant"
-          style={{ fontVariationSettings: "'FILL' 0" }}
+      {/* Upload zones */}
+      <div className="bg-surface-container rounded-2xl p-6 space-y-6">
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+          {/* Image 1 */}
+          <div className="flex flex-col gap-3">
+            <ImageUploadZone
+              label="Image 1"
+              imageBase64={image1Base64}
+              onImageSelect={setImage1}
+              onImageRemove={clearImage1}
+            />
+            <textarea
+              value={caption1}
+              onChange={e => setCaption1(e.target.value)}
+              placeholder="Describe this image (optional)"
+              rows={2}
+              disabled={!image1Base64}
+              className={cn(
+                'w-full rounded-xl px-4 py-3 resize-none',
+                'bg-surface-container-high border border-outline-variant',
+                'font-body text-body-sm text-on-surface placeholder:text-on-surface-variant/60',
+                'focus:outline-none focus:border-primary',
+                'transition-colors',
+                !image1Base64 && 'opacity-40 cursor-not-allowed'
+              )}
+              aria-label="Caption for image 1"
+            />
+          </div>
+
+          {/* Image 2 */}
+          <div className="flex flex-col gap-3">
+            <ImageUploadZone
+              label="Image 2"
+              imageBase64={image2Base64}
+              onImageSelect={setImage2}
+              onImageRemove={clearImage2}
+            />
+            <textarea
+              value={caption2}
+              onChange={e => setCaption2(e.target.value)}
+              placeholder="Describe this image (optional)"
+              rows={2}
+              disabled={!image2Base64}
+              className={cn(
+                'w-full rounded-xl px-4 py-3 resize-none',
+                'bg-surface-container-high border border-outline-variant',
+                'font-body text-body-sm text-on-surface placeholder:text-on-surface-variant/60',
+                'focus:outline-none focus:border-primary',
+                'transition-colors',
+                !image2Base64 && 'opacity-40 cursor-not-allowed'
+              )}
+              aria-label="Caption for image 2"
+            />
+          </div>
+        </div>
+
+        {/* Story direction prompt */}
+        <div className="flex flex-col gap-2">
+          <label
+            htmlFor="story-direction"
+            className="font-body text-body-sm text-on-surface-variant"
+          >
+            What kind of story should this be? <span className="text-on-surface-variant/60">(optional)</span>
+          </label>
+          <textarea
+            id="story-direction"
+            value={storyDirectionPrompt}
+            onChange={e => setStoryDirectionPrompt(e.target.value)}
+            placeholder="e.g. A cozy adventure about friendship and discovery..."
+            rows={3}
+            className={cn(
+              'w-full rounded-xl px-4 py-3 resize-none',
+              'bg-surface-container-high border border-outline-variant',
+              'font-body text-body-sm text-on-surface placeholder:text-on-surface-variant/60',
+              'focus:outline-none focus:border-primary',
+              'transition-colors'
+            )}
+          />
+        </div>
+      </div>
+
+      {/* Error banner */}
+      {error && (
+        <div
+          role="alert"
+          className="flex items-start gap-3 bg-error-container text-on-error-container rounded-2xl px-5 py-4"
         >
-          construction
-        </span>
-        <p className="font-body text-body-md text-on-surface-variant">
-          Coming soon — image upload and description will be here.
-        </p>
-      </div>
+          <span className="material-symbols-outlined text-[20px] mt-0.5 shrink-0">error</span>
+          <p className="font-body text-body-sm flex-1">{error}</p>
+          <button
+            type="button"
+            onClick={clearError}
+            aria-label="Dismiss error"
+            className="shrink-0 hover:opacity-70 transition-opacity cursor-pointer"
+          >
+            <span className="material-symbols-outlined text-[20px]">close</span>
+          </button>
+        </div>
+      )}
 
+      {/* Next button */}
       <div className="flex justify-end">
-        <ChunkyButton variant="primary" onClick={onNext}>
-          Next
-          <span className="material-symbols-outlined ml-2">arrow_forward</span>
+        <ChunkyButton
+          variant="primary"
+          onClick={() => {
+            if (canProceedFromUpload && !isLoading) onNext()
+          }}
+          disabled={!canProceedFromUpload || isLoading}
+          aria-disabled={!canProceedFromUpload || isLoading}
+        >
+          {isLoading ? (
+            <>
+              <span
+                className="inline-block h-4 w-4 border-2 border-t-transparent border-on-primary-container rounded-full animate-spin"
+                aria-hidden="true"
+              />
+              Loading...
+            </>
+          ) : (
+            <>
+              Next
+              <span className="material-symbols-outlined ml-1 text-[18px]">arrow_forward</span>
+            </>
+          )}
         </ChunkyButton>
       </div>
     </div>

--- a/src/app/storybook-factory/components/step02-story-configuration.tsx
+++ b/src/app/storybook-factory/components/step02-story-configuration.tsx
@@ -1,0 +1,43 @@
+import { ChunkyButton } from '@/components/ui/chunky-button'
+
+export function Step02StoryConfiguration({
+  onNext,
+  onPrevious,
+}: {
+  onNext: () => void
+  onPrevious: () => void
+}) {
+  return (
+    <div className="space-y-6 mt-6">
+      <div className="bg-surface-container rounded-lg p-6 space-y-2">
+        <h2 className="font-headline text-2xl text-on-surface">Story Configuration</h2>
+        <p className="font-body text-body-md text-on-surface-variant">
+          Choose your story type and visual style.
+        </p>
+      </div>
+
+      <div className="bg-surface-container rounded-lg p-6 flex flex-col items-center gap-4 text-center">
+        <span
+          className="material-symbols-outlined text-[48px] text-on-surface-variant"
+          style={{ fontVariationSettings: "'FILL' 0" }}
+        >
+          construction
+        </span>
+        <p className="font-body text-body-md text-on-surface-variant">
+          Coming soon — story type and style selection will be here.
+        </p>
+      </div>
+
+      <div className="flex justify-between">
+        <ChunkyButton variant="secondary" onClick={onPrevious}>
+          <span className="material-symbols-outlined mr-2">arrow_back</span>
+          Back
+        </ChunkyButton>
+        <ChunkyButton variant="primary" onClick={onNext}>
+          Next
+          <span className="material-symbols-outlined ml-2">arrow_forward</span>
+        </ChunkyButton>
+      </div>
+    </div>
+  )
+}

--- a/src/app/storybook-factory/components/step03-generation.tsx
+++ b/src/app/storybook-factory/components/step03-generation.tsx
@@ -1,0 +1,43 @@
+import { ChunkyButton } from '@/components/ui/chunky-button'
+
+export function Step03Generation({
+  onNext,
+  onPrevious,
+}: {
+  onNext: () => void
+  onPrevious: () => void
+}) {
+  return (
+    <div className="space-y-6 mt-6">
+      <div className="bg-surface-container rounded-lg p-6 space-y-2">
+        <h2 className="font-headline text-2xl text-on-surface">Generating Your Story</h2>
+        <p className="font-body text-body-md text-on-surface-variant">
+          AI is crafting your illustrated story — sit tight!
+        </p>
+      </div>
+
+      <div className="bg-surface-container rounded-lg p-6 flex flex-col items-center gap-4 text-center">
+        <span
+          className="material-symbols-outlined text-[48px] text-on-surface-variant"
+          style={{ fontVariationSettings: "'FILL' 0" }}
+        >
+          construction
+        </span>
+        <p className="font-body text-body-md text-on-surface-variant">
+          Coming soon — story generation and progress display will be here.
+        </p>
+      </div>
+
+      <div className="flex justify-between">
+        <ChunkyButton variant="secondary" onClick={onPrevious}>
+          <span className="material-symbols-outlined mr-2">arrow_back</span>
+          Back
+        </ChunkyButton>
+        <ChunkyButton variant="primary" onClick={onNext}>
+          Next
+          <span className="material-symbols-outlined ml-2">arrow_forward</span>
+        </ChunkyButton>
+      </div>
+    </div>
+  )
+}

--- a/src/app/storybook-factory/components/step04-review-and-revise.tsx
+++ b/src/app/storybook-factory/components/step04-review-and-revise.tsx
@@ -1,0 +1,33 @@
+import { ChunkyButton } from '@/components/ui/chunky-button'
+
+export function Step04ReviewAndRevise({ onPrevious }: { onPrevious: () => void }) {
+  return (
+    <div className="space-y-6 mt-6">
+      <div className="bg-surface-container rounded-lg p-6 space-y-2">
+        <h2 className="font-headline text-2xl text-on-surface">Review &amp; Revise</h2>
+        <p className="font-body text-body-md text-on-surface-variant">
+          Review your illustrated story and make any final edits.
+        </p>
+      </div>
+
+      <div className="bg-surface-container rounded-lg p-6 flex flex-col items-center gap-4 text-center">
+        <span
+          className="material-symbols-outlined text-[48px] text-on-surface-variant"
+          style={{ fontVariationSettings: "'FILL' 0" }}
+        >
+          construction
+        </span>
+        <p className="font-body text-body-md text-on-surface-variant">
+          Coming soon — story viewer and revision tools will be here.
+        </p>
+      </div>
+
+      <div className="flex justify-start">
+        <ChunkyButton variant="secondary" onClick={onPrevious}>
+          <span className="material-symbols-outlined mr-2">arrow_back</span>
+          Back
+        </ChunkyButton>
+      </div>
+    </div>
+  )
+}

--- a/src/app/storybook-factory/components/useStorybookFactoryState.tsx
+++ b/src/app/storybook-factory/components/useStorybookFactoryState.tsx
@@ -1,7 +1,123 @@
+'use client'
+
+import { useState } from 'react'
+
 export interface StorybookFactoryState {
-  // Placeholder — real state will be added in a future iteration
+  image1Base64: string | null
+  image2Base64: string | null
+  caption1: string
+  caption2: string
+  storyDirectionPrompt: string
+  isLoading: boolean
+  error: string | null
+  setImage1: (file: File) => void
+  setImage2: (file: File) => void
+  clearImage1: () => void
+  clearImage2: () => void
+  setCaption1: (text: string) => void
+  setCaption2: (text: string) => void
+  setStoryDirectionPrompt: (text: string) => void
+  clearError: () => void
+  canProceedFromUpload: boolean
+}
+
+function fileToBase64(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader()
+    reader.onload = () => resolve(reader.result as string)
+    reader.onerror = () => reject(new Error('Failed to read file'))
+    reader.readAsDataURL(file)
+  })
+}
+
+function validateImageFile(file: File): string | null {
+  if (!file.type.startsWith('image/')) {
+    return 'Please upload an image file (JPEG, PNG, GIF, etc.)'
+  }
+  const maxSize = 5 * 1024 * 1024 // 5MB
+  if (file.size > maxSize) {
+    return `Image is too large (${(file.size / 1024 / 1024).toFixed(1)} MB). Please use an image under 5 MB.`
+  }
+  return null
 }
 
 export function useStorybookFactoryState(): StorybookFactoryState {
-  return {}
+  const [image1Base64, setImage1Base64] = useState<string | null>(null)
+  const [image2Base64, setImage2Base64] = useState<string | null>(null)
+  const [caption1, setCaption1State] = useState('')
+  const [caption2, setCaption2State] = useState('')
+  const [storyDirectionPrompt, setStoryDirectionPromptState] = useState('')
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const setImage1 = (file: File) => {
+    const validationError = validateImageFile(file)
+    if (validationError) {
+      setError(validationError)
+      return
+    }
+    setError(null)
+    setIsLoading(true)
+    fileToBase64(file)
+      .then(base64 => {
+        setImage1Base64(base64)
+      })
+      .catch(() => {
+        setError('Failed to read image. Please try again.')
+      })
+      .finally(() => {
+        setIsLoading(false)
+      })
+  }
+
+  const setImage2 = (file: File) => {
+    const validationError = validateImageFile(file)
+    if (validationError) {
+      setError(validationError)
+      return
+    }
+    setError(null)
+    setIsLoading(true)
+    fileToBase64(file)
+      .then(base64 => {
+        setImage2Base64(base64)
+      })
+      .catch(() => {
+        setError('Failed to read image. Please try again.')
+      })
+      .finally(() => {
+        setIsLoading(false)
+      })
+  }
+
+  const clearImage1 = () => {
+    setImage1Base64(null)
+    setCaption1State('')
+  }
+
+  const clearImage2 = () => {
+    setImage2Base64(null)
+    setCaption2State('')
+  }
+
+  const canProceedFromUpload = image1Base64 !== null && image2Base64 !== null
+
+  return {
+    image1Base64,
+    image2Base64,
+    caption1,
+    caption2,
+    storyDirectionPrompt,
+    isLoading,
+    error,
+    setImage1,
+    setImage2,
+    clearImage1,
+    clearImage2,
+    setCaption1: setCaption1State,
+    setCaption2: setCaption2State,
+    setStoryDirectionPrompt: setStoryDirectionPromptState,
+    clearError: () => setError(null),
+    canProceedFromUpload,
+  }
 }

--- a/src/app/storybook-factory/components/useStorybookFactoryState.tsx
+++ b/src/app/storybook-factory/components/useStorybookFactoryState.tsx
@@ -1,0 +1,7 @@
+export interface StorybookFactoryState {
+  // Placeholder — real state will be added in a future iteration
+}
+
+export function useStorybookFactoryState(): StorybookFactoryState {
+  return {}
+}

--- a/src/app/storybook-factory/components/useWorkflow.tsx
+++ b/src/app/storybook-factory/components/useWorkflow.tsx
@@ -1,0 +1,19 @@
+import { useState } from 'react'
+
+export function useWorkflow() {
+  const [currentStep, setCurrentStep] = useState(0)
+
+  const nextStep = () => {
+    setCurrentStep(prev => Math.min(prev + 1, 3))
+  }
+
+  const previousStep = () => {
+    setCurrentStep(prev => Math.max(prev - 1, 0))
+  }
+
+  return {
+    currentStep,
+    nextStep,
+    previousStep,
+  }
+}

--- a/src/app/storybook-factory/layout.tsx
+++ b/src/app/storybook-factory/layout.tsx
@@ -1,0 +1,42 @@
+import type { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  title: 'Storybook Factory - CometCave',
+  description:
+    'Generate illustrated comic books and storybooks from your pictures! Upload your images, choose a story style, and watch AI craft a unique illustrated story just for you.',
+  keywords: [
+    'storybook',
+    'comic book',
+    'illustrated stories',
+    'AI story generator',
+    'photo storybook',
+    'image to story',
+  ],
+  authors: [{ name: 'CometCave' }],
+  openGraph: {
+    title: 'Storybook Factory - CometCave',
+    description:
+      'Generate illustrated comic books and storybooks from your pictures! Upload images and watch AI craft a unique illustrated story.',
+    url: 'https://cometcave.com/storybook-factory',
+    siteName: 'CometCave - AI Galaxy Arcade',
+    type: 'website',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Storybook Factory - CometCave',
+    description:
+      'Generate illustrated comic books and storybooks from your pictures!',
+    creator: '@cometcave',
+  },
+  robots: {
+    index: true,
+    follow: true,
+  },
+  alternates: {
+    canonical: 'https://cometcave.com/storybook-factory',
+  },
+}
+
+export default function StorybookFactoryLayout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>
+}

--- a/src/app/storybook-factory/page.tsx
+++ b/src/app/storybook-factory/page.tsx
@@ -1,0 +1,33 @@
+'use client'
+
+import { Step01UploadAndDescribe } from './components/step01-upload-and-describe'
+import { Step02StoryConfiguration } from './components/step02-story-configuration'
+import { Step03Generation } from './components/step03-generation'
+import { Step04ReviewAndRevise } from './components/step04-review-and-revise'
+import { useStorybookFactoryState } from './components/useStorybookFactoryState'
+import { useWorkflow } from './components/useWorkflow'
+
+export default function StorybookFactory() {
+  const { currentStep, nextStep, previousStep } = useWorkflow()
+  const _state = useStorybookFactoryState()
+
+  return (
+    <div className="flex flex-col items-center justify-center">
+      <div className="w-full max-w-screen-lg mt-20">
+        <h1 className="font-headline text-4xl font-bold text-center text-on-surface">
+          Storybook Factory
+        </h1>
+        <p className="font-body text-body-lg text-center text-on-surface-variant mt-2">
+          Create illustrated stories from your pictures
+        </p>
+
+        {currentStep === 0 && <Step01UploadAndDescribe onNext={nextStep} />}
+        {currentStep === 1 && (
+          <Step02StoryConfiguration onNext={nextStep} onPrevious={previousStep} />
+        )}
+        {currentStep === 2 && <Step03Generation onNext={nextStep} onPrevious={previousStep} />}
+        {currentStep === 3 && <Step04ReviewAndRevise onPrevious={previousStep} />}
+      </div>
+    </div>
+  )
+}

--- a/src/app/storybook-factory/page.tsx
+++ b/src/app/storybook-factory/page.tsx
@@ -9,7 +9,7 @@ import { useWorkflow } from './components/useWorkflow'
 
 export default function StorybookFactory() {
   const { currentStep, nextStep, previousStep } = useWorkflow()
-  const _state = useStorybookFactoryState()
+  const state = useStorybookFactoryState()
 
   return (
     <div className="flex flex-col items-center justify-center">
@@ -21,7 +21,27 @@ export default function StorybookFactory() {
           Create illustrated stories from your pictures
         </p>
 
-        {currentStep === 0 && <Step01UploadAndDescribe onNext={nextStep} />}
+        {currentStep === 0 && (
+          <Step01UploadAndDescribe
+            onNext={nextStep}
+            image1Base64={state.image1Base64}
+            image2Base64={state.image2Base64}
+            caption1={state.caption1}
+            caption2={state.caption2}
+            storyDirectionPrompt={state.storyDirectionPrompt}
+            isLoading={state.isLoading}
+            error={state.error}
+            setImage1={state.setImage1}
+            setImage2={state.setImage2}
+            clearImage1={state.clearImage1}
+            clearImage2={state.clearImage2}
+            setCaption1={state.setCaption1}
+            setCaption2={state.setCaption2}
+            setStoryDirectionPrompt={state.setStoryDirectionPrompt}
+            clearError={state.clearError}
+            canProceedFromUpload={state.canProceedFromUpload}
+          />
+        )}
         {currentStep === 1 && (
           <Step02StoryConfiguration onNext={nextStep} onPrevious={previousStep} />
         )}


### PR DESCRIPTION
## Summary

- Implements `useStorybookFactoryState` hook with full image state management: base64 conversion via `FileReader`, file validation (type check + 5 MB size limit), caption and story-direction prompt fields, loading/error states, and a `canProceedFromUpload` computed flag
- Replaces the `Step01UploadAndDescribe` placeholder with a functional two-zone upload UI: drag-and-drop or click-to-upload, image preview with remove button, per-image caption textareas, a full-width story direction prompt, an error banner, and a Next button that is disabled until both images are present
- Updates `page.tsx` to instantiate `useStorybookFactoryState` and pass all required props down to `Step01UploadAndDescribe`

## Test plan

- [ ] Click each dropzone → file picker opens → select image → preview appears
- [ ] Drag an image file onto a zone → preview appears
- [ ] Remove an image → preview disappears and its caption clears
- [ ] Upload a non-image file → error banner appears with a clear message
- [ ] Upload a file over 5 MB → error banner appears with size info
- [ ] Both images uploaded → Next button becomes enabled, click advances to Step 2
- [ ] Only one image uploaded → Next button remains disabled
- [ ] Verify responsive layout: two columns on desktop (`md:grid-cols-2`), stacked on mobile
- [ ] Verify story direction prompt saves and is optional (no validation error)

Closes #1649
Depends on PR #1657 (storybook-factory shell)

🤖 Generated with [Claude Code](https://claude.com/claude-code)