### PR TITLE
feat(storybook-factory): LLM-driven story configuration Q&A (#1650)

### DIFF
--- a/src/app/api/v1/storybook-factory/suggest-configuration/route.ts
+++ b/src/app/api/v1/storybook-factory/suggest-configuration/route.ts
@@ -1,0 +1,74 @@
+import { createOpenAI } from '@ai-sdk/openai'
+import { generateObject } from 'ai'
+import { NextResponse } from 'next/server'
+import { z } from 'zod'
+
+const SuggestionSchema = z.object({
+  storyType: z.enum(['comic', 'storybook', 'fairy-tale', 'adventure']),
+  artStyle: z.enum(['cartoon', 'anime', 'watercolor', 'pixel-art', 'realistic']),
+  pageCount: z.number().min(4).max(24),
+  tone: z.enum(['funny', 'dramatic', 'scary', 'heartwarming']),
+  panelsPerPage: z.number().min(2).max(6),
+  dialogueStyle: z.enum(['speech-bubbles', 'narration-boxes', 'mixed']),
+  reasoning: z.string().describe('Brief explanation of why these settings suit the story'),
+})
+
+export async function POST(request: Request) {
+  try {
+    const openaiClient = createOpenAI({
+      apiKey: process.env.OPENAI_API_KEY,
+    })
+
+    const { caption1, caption2, storyDirectionPrompt } = await request.json()
+
+    const imageDescriptions = [
+      caption1 ? `Image 1: "${caption1}"` : 'Image 1: (no caption provided)',
+      caption2 ? `Image 2: "${caption2}"` : 'Image 2: (no caption provided)',
+    ].join('\n')
+
+    const directionNote = storyDirectionPrompt
+      ? `Story direction: "${storyDirectionPrompt}"`
+      : 'Story direction: (none provided)'
+
+    const prompt = `You are a creative story advisor helping someone create an illustrated story from their personal photos.
+
+Based on the image descriptions and story direction below, suggest the best configuration for their story. Comic book format is your default recommendation unless the content clearly calls for something else.
+
+${imageDescriptions}
+${directionNote}
+
+Choose settings that best suit the content and mood of the images. For example:
+- Pets or playful subjects → comic, cartoon, funny
+- Nature or landscapes → storybook or fairy-tale, watercolor, heartwarming
+- Action or adventure themes → comic or adventure, cartoon or anime, dramatic
+- Cute/wholesome subjects → storybook, watercolor or cartoon, heartwarming
+
+Suggest a page count appropriate for a personal illustrated story (8 is a good default; 4-6 for short stories, 12-16 for longer ones).
+
+Provide a brief, friendly reasoning (1-2 sentences) explaining your choices.`
+
+    const result = await generateObject({
+      model: openaiClient('gpt-4o-mini'),
+      schema: SuggestionSchema,
+      prompt,
+      temperature: 0.7,
+      maxTokens: 300,
+    })
+
+    return NextResponse.json({
+      storyType: result.object.storyType,
+      artStyle: result.object.artStyle,
+      pageCount: result.object.pageCount,
+      tone: result.object.tone,
+      panelsPerPage: result.object.panelsPerPage,
+      dialogueStyle: result.object.dialogueStyle,
+      reasoning: result.object.reasoning,
+    })
+  } catch (error) {
+    console.error('Error generating story configuration suggestions:', error)
+    return NextResponse.json(
+      { error: 'Failed to generate suggestions. Using default settings.' },
+      { status: 500 }
+    )
+  }
+}

--- a/src/app/storybook-factory/components/step02-story-configuration.tsx
+++ b/src/app/storybook-factory/components/step02-story-configuration.tsx
@@ -1,34 +1,259 @@
+'use client'
+
+import { useEffect } from 'react'
 import { ChunkyButton } from '@/components/ui/chunky-button'
+import type { StoryConfiguration } from './useStorybookFactoryState'
+
+// ─── Option Selector ──────────────────────────────────────────────────────────
+
+interface OptionItem<T extends string | number> {
+  value: T
+  label: string
+  emoji?: string
+}
+
+function OptionSelector<T extends string | number>({
+  options,
+  value,
+  onChange,
+}: {
+  options: OptionItem<T>[]
+  value: T
+  onChange: (v: T) => void
+}) {
+  return (
+    <div className="flex flex-wrap gap-3">
+      {options.map(opt => {
+        const selected = opt.value === value
+        return (
+          <button
+            key={String(opt.value)}
+            type="button"
+            onClick={() => onChange(opt.value)}
+            className={[
+              'flex items-center gap-2 px-4 py-2 rounded-lg border text-sm font-medium transition-colors',
+              selected
+                ? 'bg-primary text-on-primary border-primary'
+                : 'bg-surface-container text-on-surface border-surface-variant/40 hover:bg-surface-variant/20',
+            ].join(' ')}
+          >
+            {opt.emoji && <span>{opt.emoji}</span>}
+            {opt.label}
+          </button>
+        )
+      })}
+    </div>
+  )
+}
+
+// ─── Section label ────────────────────────────────────────────────────────────
+
+function SectionLabel({ children }: { children: React.ReactNode }) {
+  return (
+    <h3 className="font-headline text-base text-on-surface-variant uppercase tracking-wide mb-3">
+      {children}
+    </h3>
+  )
+}
+
+// ─── Main component ───────────────────────────────────────────────────────────
 
 export function Step02StoryConfiguration({
   onNext,
   onPrevious,
+  storyConfig,
+  setStoryConfig,
+  isSuggestionsLoading,
+  suggestionsError,
+  fetchSuggestions,
+  suggestionReasoning,
 }: {
   onNext: () => void
   onPrevious: () => void
+  storyConfig: StoryConfiguration
+  setStoryConfig: (updates: Partial<StoryConfiguration>) => void
+  isSuggestionsLoading: boolean
+  suggestionsError: string | null
+  fetchSuggestions: () => Promise<void>
+  suggestionReasoning: string | null
 }) {
+  // Fetch AI suggestions when user arrives at this step
+  useEffect(() => {
+    fetchSuggestions()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  const storyTypeOptions: OptionItem<StoryConfiguration['storyType']>[] = [
+    { value: 'comic', label: 'Comic Book', emoji: '⭐' },
+    { value: 'storybook', label: 'Storybook', emoji: '📖' },
+    { value: 'fairy-tale', label: 'Fairy Tale', emoji: '🏰' },
+    { value: 'adventure', label: 'Adventure', emoji: '🗺️' },
+  ]
+
+  const artStyleOptions: OptionItem<StoryConfiguration['artStyle']>[] = [
+    { value: 'cartoon', label: 'Cartoon', emoji: '🎨' },
+    { value: 'anime', label: 'Anime', emoji: '✨' },
+    { value: 'watercolor', label: 'Watercolor', emoji: '🖌️' },
+    { value: 'pixel-art', label: 'Pixel Art', emoji: '🕹️' },
+    { value: 'realistic', label: 'Realistic', emoji: '📸' },
+  ]
+
+  const toneOptions: OptionItem<StoryConfiguration['tone']>[] = [
+    { value: 'funny', label: 'Funny', emoji: '😄' },
+    { value: 'dramatic', label: 'Dramatic', emoji: '🎭' },
+    { value: 'scary', label: 'Scary', emoji: '👻' },
+    { value: 'heartwarming', label: 'Heartwarming', emoji: '💛' },
+  ]
+
+  const panelsOptions: OptionItem<number>[] = [2, 3, 4, 5, 6].map(n => ({
+    value: n,
+    label: String(n),
+  }))
+
+  const dialogueOptions: OptionItem<StoryConfiguration['dialogueStyle']>[] = [
+    { value: 'speech-bubbles', label: 'Speech Bubbles', emoji: '💬' },
+    { value: 'narration-boxes', label: 'Narration Boxes', emoji: '📝' },
+    { value: 'mixed', label: 'Mixed', emoji: '🔀' },
+  ]
+
   return (
     <div className="space-y-6 mt-6">
-      <div className="bg-surface-container rounded-lg p-6 space-y-2">
-        <h2 className="font-headline text-2xl text-on-surface">Story Configuration</h2>
+      {/* Header */}
+      <div className="bg-surface-container rounded-lg p-6 space-y-1">
+        <h2 className="font-headline text-2xl text-on-surface">Configure Your Story</h2>
         <p className="font-body text-body-md text-on-surface-variant">
-          Choose your story type and visual style.
+          Customize how your story will look and feel.
         </p>
       </div>
 
-      <div className="bg-surface-container rounded-lg p-6 flex flex-col items-center gap-4 text-center">
-        <span
-          className="material-symbols-outlined text-[48px] text-on-surface-variant"
-          style={{ fontVariationSettings: "'FILL' 0" }}
-        >
-          construction
-        </span>
-        <p className="font-body text-body-md text-on-surface-variant">
-          Coming soon — story type and style selection will be here.
-        </p>
+      {/* AI Suggestion Banner */}
+      <div className="bg-surface-container rounded-lg p-4">
+        {isSuggestionsLoading ? (
+          <div className="flex items-center gap-3 text-on-surface-variant">
+            <span
+              className="material-symbols-outlined animate-spin text-[20px]"
+              style={{ fontVariationSettings: "'FILL' 0" }}
+            >
+              progress_activity
+            </span>
+            <span className="font-body text-body-sm">
+              Analyzing your images to suggest settings…
+            </span>
+          </div>
+        ) : suggestionsError ? (
+          <div className="flex items-start gap-3 text-on-surface-variant">
+            <span
+              className="material-symbols-outlined text-[20px] mt-0.5 shrink-0"
+              style={{ fontVariationSettings: "'FILL' 0" }}
+            >
+              info
+            </span>
+            <span className="font-body text-body-sm">{suggestionsError}</span>
+          </div>
+        ) : suggestionReasoning ? (
+          <div className="flex items-start gap-3">
+            <span
+              className="material-symbols-outlined text-[20px] mt-0.5 shrink-0 text-primary"
+              style={{ fontVariationSettings: "'FILL' 1" }}
+            >
+              auto_awesome
+            </span>
+            <div>
+              <p className="font-body text-body-sm font-semibold text-on-surface mb-0.5">
+                AI suggestion
+              </p>
+              <p className="font-body text-body-sm text-on-surface-variant">
+                {suggestionReasoning}
+              </p>
+            </div>
+          </div>
+        ) : null}
       </div>
 
-      <div className="flex justify-between">
+      {/* Story Type */}
+      <div className="bg-surface-container rounded-lg p-6">
+        <SectionLabel>Story Type</SectionLabel>
+        <OptionSelector
+          options={storyTypeOptions}
+          value={storyConfig.storyType}
+          onChange={v => setStoryConfig({ storyType: v })}
+        />
+      </div>
+
+      {/* Art Style */}
+      <div className="bg-surface-container rounded-lg p-6">
+        <SectionLabel>Art Style</SectionLabel>
+        <OptionSelector
+          options={artStyleOptions}
+          value={storyConfig.artStyle}
+          onChange={v => setStoryConfig({ artStyle: v })}
+        />
+      </div>
+
+      {/* Length */}
+      <div className="bg-surface-container rounded-lg p-6">
+        <SectionLabel>Length — {storyConfig.pageCount} pages</SectionLabel>
+        <input
+          type="range"
+          min={4}
+          max={24}
+          step={2}
+          value={storyConfig.pageCount}
+          onChange={e => setStoryConfig({ pageCount: Number(e.target.value) })}
+          className="w-full accent-primary"
+        />
+        <div className="flex justify-between text-on-surface-variant font-body text-body-sm mt-1">
+          <span>4 pages</span>
+          <span>24 pages</span>
+        </div>
+      </div>
+
+      {/* Tone */}
+      <div className="bg-surface-container rounded-lg p-6">
+        <SectionLabel>Tone</SectionLabel>
+        <OptionSelector
+          options={toneOptions}
+          value={storyConfig.tone}
+          onChange={v => setStoryConfig({ tone: v })}
+        />
+      </div>
+
+      {/* Comic-specific options */}
+      {storyConfig.storyType === 'comic' && (
+        <div className="bg-surface-container rounded-lg p-6 space-y-6">
+          <div>
+            <SectionLabel>Panels per Page</SectionLabel>
+            <OptionSelector
+              options={panelsOptions}
+              value={storyConfig.panelsPerPage}
+              onChange={v => setStoryConfig({ panelsPerPage: v })}
+            />
+          </div>
+          <div>
+            <SectionLabel>Dialogue Style</SectionLabel>
+            <OptionSelector
+              options={dialogueOptions}
+              value={storyConfig.dialogueStyle}
+              onChange={v => setStoryConfig({ dialogueStyle: v })}
+            />
+          </div>
+        </div>
+      )}
+
+      {/* Additional Notes */}
+      <div className="bg-surface-container rounded-lg p-6">
+        <SectionLabel>Additional Notes</SectionLabel>
+        <textarea
+          placeholder="Any other details about your story? (optional)"
+          value={storyConfig.additionalNotes}
+          onChange={e => setStoryConfig({ additionalNotes: e.target.value })}
+          rows={3}
+          className="w-full bg-surface rounded-lg border border-surface-variant/40 px-4 py-3 font-body text-body-md text-on-surface placeholder:text-on-surface-variant resize-none focus:outline-none focus:ring-2 focus:ring-primary/50"
+        />
+      </div>
+
+      {/* Navigation */}
+      <div className="flex justify-between pb-6">
         <ChunkyButton variant="secondary" onClick={onPrevious}>
           <span className="material-symbols-outlined mr-2">arrow_back</span>
           Back

--- a/src/app/storybook-factory/components/useStorybookFactoryState.tsx
+++ b/src/app/storybook-factory/components/useStorybookFactoryState.tsx
@@ -2,6 +2,26 @@
 
 import { useState } from 'react'
 
+export interface StoryConfiguration {
+  storyType: 'comic' | 'storybook' | 'fairy-tale' | 'adventure'
+  artStyle: 'cartoon' | 'anime' | 'watercolor' | 'pixel-art' | 'realistic'
+  pageCount: number
+  tone: 'funny' | 'dramatic' | 'scary' | 'heartwarming'
+  panelsPerPage: number
+  dialogueStyle: 'speech-bubbles' | 'narration-boxes' | 'mixed'
+  additionalNotes: string
+}
+
+const DEFAULT_STORY_CONFIG: StoryConfiguration = {
+  storyType: 'comic',
+  artStyle: 'cartoon',
+  pageCount: 8,
+  tone: 'funny',
+  panelsPerPage: 4,
+  dialogueStyle: 'speech-bubbles',
+  additionalNotes: '',
+}
+
 export interface StorybookFactoryState {
   image1Base64: string | null
   image2Base64: string | null
@@ -19,6 +39,14 @@ export interface StorybookFactoryState {
   setStoryDirectionPrompt: (text: string) => void
   clearError: () => void
   canProceedFromUpload: boolean
+
+  // Story configuration
+  storyConfig: StoryConfiguration
+  setStoryConfig: (updates: Partial<StoryConfiguration>) => void
+  isSuggestionsLoading: boolean
+  suggestionsError: string | null
+  fetchSuggestions: () => Promise<void>
+  suggestionReasoning: string | null
 }
 
 function fileToBase64(file: File): Promise<string> {
@@ -49,6 +77,12 @@ export function useStorybookFactoryState(): StorybookFactoryState {
   const [storyDirectionPrompt, setStoryDirectionPromptState] = useState('')
   const [isLoading, setIsLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
+
+  // Story configuration state
+  const [storyConfig, setStoryConfigState] = useState<StoryConfiguration>(DEFAULT_STORY_CONFIG)
+  const [isSuggestionsLoading, setIsSuggestionsLoading] = useState(false)
+  const [suggestionsError, setSuggestionsError] = useState<string | null>(null)
+  const [suggestionReasoning, setSuggestionReasoning] = useState<string | null>(null)
 
   const setImage1 = (file: File) => {
     const validationError = validateImageFile(file)
@@ -100,6 +134,51 @@ export function useStorybookFactoryState(): StorybookFactoryState {
     setCaption2State('')
   }
 
+  const setStoryConfig = (updates: Partial<StoryConfiguration>) => {
+    setStoryConfigState(prev => ({ ...prev, ...updates }))
+  }
+
+  const fetchSuggestions = async () => {
+    setIsSuggestionsLoading(true)
+    setSuggestionsError(null)
+    try {
+      const response = await fetch('/api/v1/storybook-factory/suggest-configuration', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          caption1,
+          caption2,
+          storyDirectionPrompt,
+        }),
+      })
+
+      if (!response.ok) {
+        throw new Error('Failed to fetch suggestions')
+      }
+
+      const data = await response.json()
+
+      // Merge suggestions into config (graceful: only update known fields)
+      const updates: Partial<StoryConfiguration> = {}
+      if (data.storyType) updates.storyType = data.storyType
+      if (data.artStyle) updates.artStyle = data.artStyle
+      if (data.pageCount) updates.pageCount = data.pageCount
+      if (data.tone) updates.tone = data.tone
+      if (data.panelsPerPage) updates.panelsPerPage = data.panelsPerPage
+      if (data.dialogueStyle) updates.dialogueStyle = data.dialogueStyle
+      setStoryConfigState(prev => ({ ...prev, ...updates }))
+
+      if (data.reasoning) {
+        setSuggestionReasoning(data.reasoning)
+      }
+    } catch {
+      // Graceful degradation: keep defaults, show no error to avoid blocking the user
+      setSuggestionsError('Could not load AI suggestions. Using defaults — feel free to customize.')
+    } finally {
+      setIsSuggestionsLoading(false)
+    }
+  }
+
   const canProceedFromUpload = image1Base64 !== null && image2Base64 !== null
 
   return {
@@ -119,5 +198,11 @@ export function useStorybookFactoryState(): StorybookFactoryState {
     setStoryDirectionPrompt: setStoryDirectionPromptState,
     clearError: () => setError(null),
     canProceedFromUpload,
+    storyConfig,
+    setStoryConfig,
+    isSuggestionsLoading,
+    suggestionsError,
+    fetchSuggestions,
+    suggestionReasoning,
   }
 }

--- a/src/app/storybook-factory/page.tsx
+++ b/src/app/storybook-factory/page.tsx
@@ -43,7 +43,16 @@ export default function StorybookFactory() {
           />
         )}
         {currentStep === 1 && (
-          <Step02StoryConfiguration onNext={nextStep} onPrevious={previousStep} />
+          <Step02StoryConfiguration
+            onNext={nextStep}
+            onPrevious={previousStep}
+            storyConfig={state.storyConfig}
+            setStoryConfig={state.setStoryConfig}
+            isSuggestionsLoading={state.isSuggestionsLoading}
+            suggestionsError={state.suggestionsError}
+            fetchSuggestions={state.fetchSuggestions}
+            suggestionReasoning={state.suggestionReasoning}
+          />
         )}
         {currentStep === 2 && <Step03Generation onNext={nextStep} onPrevious={previousStep} />}
         {currentStep === 3 && <Step04ReviewAndRevise onPrevious={previousStep} />}


### PR DESCRIPTION
## Summary

Implements issue #1650: LLM-driven story configuration Q&A for the Storybook Factory (Step 2).

- **State hook extended** (`useStorybookFactoryState`): adds `StoryConfiguration` interface with `storyType`, `artStyle`, `pageCount`, `tone`, `panelsPerPage`, `dialogueStyle`, `additionalNotes`; defaults strongly favour comic-book format. Adds `isSuggestionsLoading`, `suggestionsError`, `suggestionReasoning`, `fetchSuggestions`.
- **New API route** `POST /api/v1/storybook-factory/suggest-configuration`: calls `gpt-4o-mini` via `generateObject` + Zod schema; accepts `caption1`, `caption2`, `storyDirectionPrompt`; returns structured suggestions + `reasoning` string. Does NOT forward base64 images to keep token cost low.
- **Step02 rewritten** from placeholder to a full configuration form: `OptionSelector` card-grid components for storyType / artStyle / tone, range slider for page count, comic-only section (panelsPerPage + dialogueStyle) that appears/disappears based on selection, notes textarea, and an AI suggestion banner that shows loading/error/reasoning states. `fetchSuggestions` fires on mount; all fields remain user-overridable.
- **page.tsx updated** to forward new config props to Step02.

Closes #1650
Depends on PR #1657 and PR #1658

## Test plan

- [ ] Navigate to Storybook Factory, upload two images + captions + story direction, proceed to Step 2
- [ ] Verify AI suggestion banner shows loading spinner while API call is in flight
- [ ] Verify banner shows reasoning text after API responds
- [ ] Verify each config section is interactive (clicking options highlights them)
- [ ] Verify comic-specific options (panels, dialogue style) appear when storyType = Comic and disappear when another type is selected
- [ ] Verify page-count slider moves between 4 and 24
- [ ] Simulate API failure (disconnect network or mock 500): form shows graceful fallback message and remains fully usable with defaults
- [ ] Click Next and verify flow continues to Step 3
- [ ] Click Back and confirm navigation returns to Step 1
- [ ] TypeScript check: `npx tsc --noEmit` passes with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)