### PR TITLE
feat: Storybook Factory story + layout schema generation API (#1651)

### DIFF
--- a/src/app/api/v1/storybook-factory/generate-story/route.ts
+++ b/src/app/api/v1/storybook-factory/generate-story/route.ts
@@ -1,0 +1,120 @@
+import { createOpenAI } from '@ai-sdk/openai'
+import { generateObject } from 'ai'
+import { NextResponse } from 'next/server'
+import { z } from 'zod'
+
+export const maxDuration = 300
+
+const StoryPanelSchema = z.object({
+  type: z.enum(['illustration', 'text', 'speech-bubble', 'narration-box', 'sound-effect']),
+  content: z
+    .string()
+    .describe(
+      'For illustrations: detailed image generation prompt. For text/speech/narration: the actual text content.'
+    ),
+  character: z
+    .string()
+    .optional()
+    .describe('For speech bubbles: the name of the character speaking'),
+  position: z.object({
+    x: z.number().min(0).max(100).describe('Horizontal position as percentage'),
+    y: z.number().min(0).max(100).describe('Vertical position as percentage'),
+    width: z.number().min(0).max(100).describe('Width as percentage'),
+    height: z.number().min(0).max(100).describe('Height as percentage'),
+  }),
+})
+
+const StoryPageSchema = z.object({
+  pageNumber: z.number(),
+  layout: z.enum([
+    'full-image',
+    'image-left-text-right',
+    'text-over-image',
+    'comic-grid',
+    'split',
+  ]),
+  panels: z.array(StoryPanelSchema),
+  backgroundColor: z.string().optional(),
+})
+
+const StoryLayoutSchema = z.object({
+  title: z.string().describe('The title of the story'),
+  type: z.enum(['comic', 'storybook', 'fairy-tale', 'adventure']),
+  pages: z.array(StoryPageSchema),
+})
+
+export async function POST(request: Request) {
+  try {
+    const openaiClient = createOpenAI({
+      apiKey: process.env.OPENAI_API_KEY,
+    })
+
+    const { caption1, caption2, storyDirectionPrompt, storyConfig } = await request.json()
+
+    const imageDescriptions = [
+      caption1 ? `Image 1: "${caption1}"` : 'Image 1: (no caption provided)',
+      caption2 ? `Image 2: "${caption2}"` : 'Image 2: (no caption provided)',
+    ].join('\n')
+
+    const directionNote = storyDirectionPrompt
+      ? `Story direction: "${storyDirectionPrompt}"`
+      : 'Story direction: (none provided)'
+
+    const configSummary = storyConfig
+      ? `Story configuration:
+- Story type: ${storyConfig.storyType}
+- Art style: ${storyConfig.artStyle}
+- Page count: ${storyConfig.pageCount}
+- Tone: ${storyConfig.tone}
+- Panels per page: ${storyConfig.panelsPerPage}
+- Dialogue style: ${storyConfig.dialogueStyle}
+${storyConfig.additionalNotes ? `- Additional notes: ${storyConfig.additionalNotes}` : ''}`
+      : 'Story configuration: (use defaults)'
+
+    const prompt = `You are a creative story writer and layout artist. Generate a complete illustrated story broken into pages with detailed panel layouts.
+
+${imageDescriptions}
+${directionNote}
+
+${configSummary}
+
+Generate exactly ${storyConfig?.pageCount ?? 8} pages.
+
+LAYOUT RULES by story type:
+- comic: Use comic-grid layout. Include speech-bubble panels with character attribution, narration-box panels for scene setting, and sound-effect panels for action moments. Each page should have ${storyConfig?.panelsPerPage ?? 4} panels arranged in a grid.
+- storybook: Use full-image or image-left-text-right layouts. Include illustration panels (full or half page) with narration-box panels for storytelling text.
+- fairy-tale: Use text-over-image layouts. Include large illustration panels with elegant narration text overlaid or beneath.
+- adventure: Use split or image-left-text-right layouts. Mix illustration panels with text panels, occasional speech bubbles for key moments.
+
+DIALOGUE STYLE RULES:
+- speech-bubbles: Prefer speech-bubble type panels for character dialogue
+- narration-boxes: Prefer narration-box type panels for story text
+- mixed: Use both speech-bubble and narration-box panels
+
+PANEL RULES:
+- Each panel has a position with x, y, width, height as 0-100 percentages of the page
+- Panels should not overlap (or minimally for intentional layering effects)
+- illustration panel content must be a detailed image generation prompt that includes the art style: ${storyConfig?.artStyle ?? 'cartoon'}. Describe scene, characters, mood, lighting.
+- text/speech/narration/sound-effect panel content is the actual text to display
+
+TONE: ${storyConfig?.tone ?? 'funny'} — let this affect the story mood, dialogue, and illustration descriptions.
+
+Create a cohesive story with a beginning, middle, and end. Characters should be consistent across pages. The story should incorporate both subjects from the image descriptions.`
+
+    const result = await generateObject({
+      model: openaiClient('gpt-4o-mini'),
+      schema: StoryLayoutSchema,
+      prompt,
+      temperature: 0.8,
+      maxTokens: 4096,
+    })
+
+    return NextResponse.json({
+      layout: result.object,
+      generatedAt: new Date().toISOString(),
+    })
+  } catch (error) {
+    console.error('Error generating story layout:', error)
+    return NextResponse.json({ error: 'Failed to generate story. Please try again.' }, { status: 500 })
+  }
+}

--- a/src/app/api/v1/storybook-factory/suggest-configuration/route.ts
+++ b/src/app/api/v1/storybook-factory/suggest-configuration/route.ts
@@ -1,0 +1,74 @@
+import { createOpenAI } from '@ai-sdk/openai'
+import { generateObject } from 'ai'
+import { NextResponse } from 'next/server'
+import { z } from 'zod'
+
+const SuggestionSchema = z.object({
+  storyType: z.enum(['comic', 'storybook', 'fairy-tale', 'adventure']),
+  artStyle: z.enum(['cartoon', 'anime', 'watercolor', 'pixel-art', 'realistic']),
+  pageCount: z.number().min(4).max(24),
+  tone: z.enum(['funny', 'dramatic', 'scary', 'heartwarming']),
+  panelsPerPage: z.number().min(2).max(6),
+  dialogueStyle: z.enum(['speech-bubbles', 'narration-boxes', 'mixed']),
+  reasoning: z.string().describe('Brief explanation of why these settings suit the story'),
+})
+
+export async function POST(request: Request) {
+  try {
+    const openaiClient = createOpenAI({
+      apiKey: process.env.OPENAI_API_KEY,
+    })
+
+    const { caption1, caption2, storyDirectionPrompt } = await request.json()
+
+    const imageDescriptions = [
+      caption1 ? `Image 1: "${caption1}"` : 'Image 1: (no caption provided)',
+      caption2 ? `Image 2: "${caption2}"` : 'Image 2: (no caption provided)',
+    ].join('\n')
+
+    const directionNote = storyDirectionPrompt
+      ? `Story direction: "${storyDirectionPrompt}"`
+      : 'Story direction: (none provided)'
+
+    const prompt = `You are a creative story advisor helping someone create an illustrated story from their personal photos.
+
+Based on the image descriptions and story direction below, suggest the best configuration for their story. Comic book format is your default recommendation unless the content clearly calls for something else.
+
+${imageDescriptions}
+${directionNote}
+
+Choose settings that best suit the content and mood of the images. For example:
+- Pets or playful subjects → comic, cartoon, funny
+- Nature or landscapes → storybook or fairy-tale, watercolor, heartwarming
+- Action or adventure themes → comic or adventure, cartoon or anime, dramatic
+- Cute/wholesome subjects → storybook, watercolor or cartoon, heartwarming
+
+Suggest a page count appropriate for a personal illustrated story (8 is a good default; 4-6 for short stories, 12-16 for longer ones).
+
+Provide a brief, friendly reasoning (1-2 sentences) explaining your choices.`
+
+    const result = await generateObject({
+      model: openaiClient('gpt-4o-mini'),
+      schema: SuggestionSchema,
+      prompt,
+      temperature: 0.7,
+      maxTokens: 300,
+    })
+
+    return NextResponse.json({
+      storyType: result.object.storyType,
+      artStyle: result.object.artStyle,
+      pageCount: result.object.pageCount,
+      tone: result.object.tone,
+      panelsPerPage: result.object.panelsPerPage,
+      dialogueStyle: result.object.dialogueStyle,
+      reasoning: result.object.reasoning,
+    })
+  } catch (error) {
+    console.error('Error generating story configuration suggestions:', error)
+    return NextResponse.json(
+      { error: 'Failed to generate suggestions. Using default settings.' },
+      { status: 500 }
+    )
+  }
+}

--- a/src/app/storybook-factory/components/step02-story-configuration.tsx
+++ b/src/app/storybook-factory/components/step02-story-configuration.tsx
@@ -1,34 +1,259 @@
+'use client'
+
+import { useEffect } from 'react'
 import { ChunkyButton } from '@/components/ui/chunky-button'
+import type { StoryConfiguration } from './useStorybookFactoryState'
+
+// ─── Option Selector ──────────────────────────────────────────────────────────
+
+interface OptionItem<T extends string | number> {
+  value: T
+  label: string
+  emoji?: string
+}
+
+function OptionSelector<T extends string | number>({
+  options,
+  value,
+  onChange,
+}: {
+  options: OptionItem<T>[]
+  value: T
+  onChange: (v: T) => void
+}) {
+  return (
+    <div className="flex flex-wrap gap-3">
+      {options.map(opt => {
+        const selected = opt.value === value
+        return (
+          <button
+            key={String(opt.value)}
+            type="button"
+            onClick={() => onChange(opt.value)}
+            className={[
+              'flex items-center gap-2 px-4 py-2 rounded-lg border text-sm font-medium transition-colors',
+              selected
+                ? 'bg-primary text-on-primary border-primary'
+                : 'bg-surface-container text-on-surface border-surface-variant/40 hover:bg-surface-variant/20',
+            ].join(' ')}
+          >
+            {opt.emoji && <span>{opt.emoji}</span>}
+            {opt.label}
+          </button>
+        )
+      })}
+    </div>
+  )
+}
+
+// ─── Section label ────────────────────────────────────────────────────────────
+
+function SectionLabel({ children }: { children: React.ReactNode }) {
+  return (
+    <h3 className="font-headline text-base text-on-surface-variant uppercase tracking-wide mb-3">
+      {children}
+    </h3>
+  )
+}
+
+// ─── Main component ───────────────────────────────────────────────────────────
 
 export function Step02StoryConfiguration({
   onNext,
   onPrevious,
+  storyConfig,
+  setStoryConfig,
+  isSuggestionsLoading,
+  suggestionsError,
+  fetchSuggestions,
+  suggestionReasoning,
 }: {
   onNext: () => void
   onPrevious: () => void
+  storyConfig: StoryConfiguration
+  setStoryConfig: (updates: Partial<StoryConfiguration>) => void
+  isSuggestionsLoading: boolean
+  suggestionsError: string | null
+  fetchSuggestions: () => Promise<void>
+  suggestionReasoning: string | null
 }) {
+  // Fetch AI suggestions when user arrives at this step
+  useEffect(() => {
+    fetchSuggestions()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  const storyTypeOptions: OptionItem<StoryConfiguration['storyType']>[] = [
+    { value: 'comic', label: 'Comic Book', emoji: '⭐' },
+    { value: 'storybook', label: 'Storybook', emoji: '📖' },
+    { value: 'fairy-tale', label: 'Fairy Tale', emoji: '🏰' },
+    { value: 'adventure', label: 'Adventure', emoji: '🗺️' },
+  ]
+
+  const artStyleOptions: OptionItem<StoryConfiguration['artStyle']>[] = [
+    { value: 'cartoon', label: 'Cartoon', emoji: '🎨' },
+    { value: 'anime', label: 'Anime', emoji: '✨' },
+    { value: 'watercolor', label: 'Watercolor', emoji: '🖌️' },
+    { value: 'pixel-art', label: 'Pixel Art', emoji: '🕹️' },
+    { value: 'realistic', label: 'Realistic', emoji: '📸' },
+  ]
+
+  const toneOptions: OptionItem<StoryConfiguration['tone']>[] = [
+    { value: 'funny', label: 'Funny', emoji: '😄' },
+    { value: 'dramatic', label: 'Dramatic', emoji: '🎭' },
+    { value: 'scary', label: 'Scary', emoji: '👻' },
+    { value: 'heartwarming', label: 'Heartwarming', emoji: '💛' },
+  ]
+
+  const panelsOptions: OptionItem<number>[] = [2, 3, 4, 5, 6].map(n => ({
+    value: n,
+    label: String(n),
+  }))
+
+  const dialogueOptions: OptionItem<StoryConfiguration['dialogueStyle']>[] = [
+    { value: 'speech-bubbles', label: 'Speech Bubbles', emoji: '💬' },
+    { value: 'narration-boxes', label: 'Narration Boxes', emoji: '📝' },
+    { value: 'mixed', label: 'Mixed', emoji: '🔀' },
+  ]
+
   return (
     <div className="space-y-6 mt-6">
-      <div className="bg-surface-container rounded-lg p-6 space-y-2">
-        <h2 className="font-headline text-2xl text-on-surface">Story Configuration</h2>
+      {/* Header */}
+      <div className="bg-surface-container rounded-lg p-6 space-y-1">
+        <h2 className="font-headline text-2xl text-on-surface">Configure Your Story</h2>
         <p className="font-body text-body-md text-on-surface-variant">
-          Choose your story type and visual style.
+          Customize how your story will look and feel.
         </p>
       </div>
 
-      <div className="bg-surface-container rounded-lg p-6 flex flex-col items-center gap-4 text-center">
-        <span
-          className="material-symbols-outlined text-[48px] text-on-surface-variant"
-          style={{ fontVariationSettings: "'FILL' 0" }}
-        >
-          construction
-        </span>
-        <p className="font-body text-body-md text-on-surface-variant">
-          Coming soon — story type and style selection will be here.
-        </p>
+      {/* AI Suggestion Banner */}
+      <div className="bg-surface-container rounded-lg p-4">
+        {isSuggestionsLoading ? (
+          <div className="flex items-center gap-3 text-on-surface-variant">
+            <span
+              className="material-symbols-outlined animate-spin text-[20px]"
+              style={{ fontVariationSettings: "'FILL' 0" }}
+            >
+              progress_activity
+            </span>
+            <span className="font-body text-body-sm">
+              Analyzing your images to suggest settings…
+            </span>
+          </div>
+        ) : suggestionsError ? (
+          <div className="flex items-start gap-3 text-on-surface-variant">
+            <span
+              className="material-symbols-outlined text-[20px] mt-0.5 shrink-0"
+              style={{ fontVariationSettings: "'FILL' 0" }}
+            >
+              info
+            </span>
+            <span className="font-body text-body-sm">{suggestionsError}</span>
+          </div>
+        ) : suggestionReasoning ? (
+          <div className="flex items-start gap-3">
+            <span
+              className="material-symbols-outlined text-[20px] mt-0.5 shrink-0 text-primary"
+              style={{ fontVariationSettings: "'FILL' 1" }}
+            >
+              auto_awesome
+            </span>
+            <div>
+              <p className="font-body text-body-sm font-semibold text-on-surface mb-0.5">
+                AI suggestion
+              </p>
+              <p className="font-body text-body-sm text-on-surface-variant">
+                {suggestionReasoning}
+              </p>
+            </div>
+          </div>
+        ) : null}
       </div>
 
-      <div className="flex justify-between">
+      {/* Story Type */}
+      <div className="bg-surface-container rounded-lg p-6">
+        <SectionLabel>Story Type</SectionLabel>
+        <OptionSelector
+          options={storyTypeOptions}
+          value={storyConfig.storyType}
+          onChange={v => setStoryConfig({ storyType: v })}
+        />
+      </div>
+
+      {/* Art Style */}
+      <div className="bg-surface-container rounded-lg p-6">
+        <SectionLabel>Art Style</SectionLabel>
+        <OptionSelector
+          options={artStyleOptions}
+          value={storyConfig.artStyle}
+          onChange={v => setStoryConfig({ artStyle: v })}
+        />
+      </div>
+
+      {/* Length */}
+      <div className="bg-surface-container rounded-lg p-6">
+        <SectionLabel>Length — {storyConfig.pageCount} pages</SectionLabel>
+        <input
+          type="range"
+          min={4}
+          max={24}
+          step={2}
+          value={storyConfig.pageCount}
+          onChange={e => setStoryConfig({ pageCount: Number(e.target.value) })}
+          className="w-full accent-primary"
+        />
+        <div className="flex justify-between text-on-surface-variant font-body text-body-sm mt-1">
+          <span>4 pages</span>
+          <span>24 pages</span>
+        </div>
+      </div>
+
+      {/* Tone */}
+      <div className="bg-surface-container rounded-lg p-6">
+        <SectionLabel>Tone</SectionLabel>
+        <OptionSelector
+          options={toneOptions}
+          value={storyConfig.tone}
+          onChange={v => setStoryConfig({ tone: v })}
+        />
+      </div>
+
+      {/* Comic-specific options */}
+      {storyConfig.storyType === 'comic' && (
+        <div className="bg-surface-container rounded-lg p-6 space-y-6">
+          <div>
+            <SectionLabel>Panels per Page</SectionLabel>
+            <OptionSelector
+              options={panelsOptions}
+              value={storyConfig.panelsPerPage}
+              onChange={v => setStoryConfig({ panelsPerPage: v })}
+            />
+          </div>
+          <div>
+            <SectionLabel>Dialogue Style</SectionLabel>
+            <OptionSelector
+              options={dialogueOptions}
+              value={storyConfig.dialogueStyle}
+              onChange={v => setStoryConfig({ dialogueStyle: v })}
+            />
+          </div>
+        </div>
+      )}
+
+      {/* Additional Notes */}
+      <div className="bg-surface-container rounded-lg p-6">
+        <SectionLabel>Additional Notes</SectionLabel>
+        <textarea
+          placeholder="Any other details about your story? (optional)"
+          value={storyConfig.additionalNotes}
+          onChange={e => setStoryConfig({ additionalNotes: e.target.value })}
+          rows={3}
+          className="w-full bg-surface rounded-lg border border-surface-variant/40 px-4 py-3 font-body text-body-md text-on-surface placeholder:text-on-surface-variant resize-none focus:outline-none focus:ring-2 focus:ring-primary/50"
+        />
+      </div>
+
+      {/* Navigation */}
+      <div className="flex justify-between pb-6">
         <ChunkyButton variant="secondary" onClick={onPrevious}>
           <span className="material-symbols-outlined mr-2">arrow_back</span>
           Back

--- a/src/app/storybook-factory/components/step03-generation.tsx
+++ b/src/app/storybook-factory/components/step03-generation.tsx
@@ -1,12 +1,151 @@
+'use client'
+
+import { useEffect, useRef, useState } from 'react'
 import { ChunkyButton } from '@/components/ui/chunky-button'
+import type { GeneratedStory } from '../types'
+
+const STATUS_MESSAGES = [
+  'Writing the plot...',
+  'Designing the layouts...',
+  'Crafting dialogue...',
+  'Sketching the panels...',
+  'Adding the finishing touches...',
+  'Bringing characters to life...',
+  'Setting the scenes...',
+  'Choosing the perfect words...',
+]
+
+function GeneratingAnimation() {
+  const [messageIndex, setMessageIndex] = useState(0)
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setMessageIndex(prev => (prev + 1) % STATUS_MESSAGES.length)
+    }, 2200)
+    return () => clearInterval(interval)
+  }, [])
+
+  return (
+    <div className="flex flex-col items-center gap-6 py-8">
+      <div className="relative flex items-center justify-center w-20 h-20">
+        <div className="absolute inset-0 rounded-full border-4 border-primary/20" />
+        <div className="absolute inset-0 rounded-full border-4 border-transparent border-t-primary animate-spin" />
+        <span
+          className="material-symbols-outlined text-[32px] text-primary"
+          style={{ fontVariationSettings: "'FILL' 1" }}
+        >
+          auto_stories
+        </span>
+      </div>
+
+      <div className="text-center space-y-2">
+        <h3 className="font-headline text-xl text-on-surface">Creating Your Story...</h3>
+        <p className="font-body text-body-md text-on-surface-variant">
+          Our AI is crafting your illustrated story
+        </p>
+      </div>
+
+      <div className="bg-surface-container-high rounded-full px-5 py-2 min-w-[260px] text-center">
+        <p
+          key={messageIndex}
+          className="font-body text-body-sm text-on-surface-variant animate-pulse"
+        >
+          {STATUS_MESSAGES[messageIndex]}
+        </p>
+      </div>
+    </div>
+  )
+}
+
+function SuccessView({
+  generatedStory,
+  onNext,
+}: {
+  generatedStory: GeneratedStory
+  onNext: () => void
+}) {
+  const { layout } = generatedStory
+  const pageCount = layout.pages.length
+  const illustrationCount = layout.pages
+    .flatMap(p => p.panels)
+    .filter(panel => panel.type === 'illustration').length
+
+  return (
+    <div className="flex flex-col items-center gap-6 py-6 text-center">
+      <div className="flex items-center justify-center w-20 h-20 rounded-full bg-[color-mix(in_srgb,var(--color-primary)_15%,transparent)]">
+        <span
+          className="material-symbols-outlined text-[40px] text-primary"
+          style={{ fontVariationSettings: "'FILL' 1" }}
+        >
+          check_circle
+        </span>
+      </div>
+
+      <div className="space-y-2">
+        <h3 className="font-headline text-2xl text-on-surface">{layout.title}</h3>
+        <p className="font-body text-body-md text-on-surface-variant capitalize">
+          {layout.type} &middot; {pageCount} {pageCount === 1 ? 'page' : 'pages'} &middot;{' '}
+          {illustrationCount} illustrations
+        </p>
+      </div>
+
+      <div className="grid grid-cols-3 gap-3 w-full max-w-xs">
+        {[...Array(Math.min(pageCount, 6))].map((_, i) => (
+          <div
+            key={i}
+            className="aspect-[3/4] rounded bg-surface-container-high flex items-center justify-center"
+          >
+            <span className="font-headline text-xs text-on-surface-variant">
+              {i + 1}
+            </span>
+          </div>
+        ))}
+        {pageCount > 6 && (
+          <div className="aspect-[3/4] rounded bg-surface-container-high flex items-center justify-center">
+            <span className="font-body text-body-xs text-on-surface-variant">
+              +{pageCount - 6}
+            </span>
+          </div>
+        )}
+      </div>
+
+      <ChunkyButton variant="primary" onClick={onNext} className="w-full max-w-xs">
+        <span
+          className="material-symbols-outlined mr-2"
+          style={{ fontVariationSettings: "'FILL' 1" }}
+        >
+          menu_book
+        </span>
+        View Your Story
+      </ChunkyButton>
+    </div>
+  )
+}
 
 export function Step03Generation({
   onNext,
   onPrevious,
+  generatedStory,
+  isGenerating,
+  generationError,
+  generateStory,
 }: {
   onNext: () => void
   onPrevious: () => void
+  generatedStory: GeneratedStory | null
+  isGenerating: boolean
+  generationError: string | null
+  generateStory: () => Promise<void>
 }) {
+  const hasFiredRef = useRef(false)
+
+  useEffect(() => {
+    if (!hasFiredRef.current && !generatedStory && !isGenerating) {
+      hasFiredRef.current = true
+      generateStory()
+    }
+  }, [generatedStory, isGenerating, generateStory])
+
   return (
     <div className="space-y-6 mt-6">
       <div className="bg-surface-container rounded-lg p-6 space-y-2">
@@ -16,27 +155,63 @@ export function Step03Generation({
         </p>
       </div>
 
-      <div className="bg-surface-container rounded-lg p-6 flex flex-col items-center gap-4 text-center">
-        <span
-          className="material-symbols-outlined text-[48px] text-on-surface-variant"
-          style={{ fontVariationSettings: "'FILL' 0" }}
-        >
-          construction
-        </span>
-        <p className="font-body text-body-md text-on-surface-variant">
-          Coming soon — story generation and progress display will be here.
-        </p>
+      <div className="bg-surface-container rounded-lg p-6">
+        {isGenerating && <GeneratingAnimation />}
+
+        {!isGenerating && generationError && (
+          <div className="flex flex-col items-center gap-4 py-6 text-center">
+            <span
+              className="material-symbols-outlined text-[48px] text-error"
+              style={{ fontVariationSettings: "'FILL' 0" }}
+            >
+              error
+            </span>
+            <div className="space-y-1">
+              <p className="font-body text-body-md text-on-surface">{generationError}</p>
+            </div>
+            <ChunkyButton
+              variant="secondary"
+              onClick={() => {
+                hasFiredRef.current = true
+                generateStory()
+              }}
+            >
+              <span className="material-symbols-outlined mr-2">refresh</span>
+              Try Again
+            </ChunkyButton>
+          </div>
+        )}
+
+        {!isGenerating && !generationError && generatedStory && (
+          <SuccessView generatedStory={generatedStory} onNext={onNext} />
+        )}
+
+        {!isGenerating && !generationError && !generatedStory && (
+          <div className="flex flex-col items-center gap-4 py-6 text-center">
+            <span
+              className="material-symbols-outlined text-[48px] text-on-surface-variant"
+              style={{ fontVariationSettings: "'FILL' 0" }}
+            >
+              hourglass_empty
+            </span>
+            <p className="font-body text-body-md text-on-surface-variant">
+              Preparing to generate your story...
+            </p>
+          </div>
+        )}
       </div>
 
       <div className="flex justify-between">
-        <ChunkyButton variant="secondary" onClick={onPrevious}>
+        <ChunkyButton variant="secondary" onClick={onPrevious} disabled={isGenerating}>
           <span className="material-symbols-outlined mr-2">arrow_back</span>
           Back
         </ChunkyButton>
-        <ChunkyButton variant="primary" onClick={onNext}>
-          Next
-          <span className="material-symbols-outlined ml-2">arrow_forward</span>
-        </ChunkyButton>
+        {generatedStory && !isGenerating && (
+          <ChunkyButton variant="primary" onClick={onNext}>
+            Next
+            <span className="material-symbols-outlined ml-2">arrow_forward</span>
+          </ChunkyButton>
+        )}
       </div>
     </div>
   )

--- a/src/app/storybook-factory/components/useStorybookFactoryState.tsx
+++ b/src/app/storybook-factory/components/useStorybookFactoryState.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useState } from 'react'
+import type { GeneratedStory } from '../types'
 
 export interface StoryConfiguration {
   storyType: 'comic' | 'storybook' | 'fairy-tale' | 'adventure'
@@ -47,6 +48,12 @@ export interface StorybookFactoryState {
   suggestionsError: string | null
   fetchSuggestions: () => Promise<void>
   suggestionReasoning: string | null
+
+  // Story generation
+  generatedStory: GeneratedStory | null
+  isGenerating: boolean
+  generationError: string | null
+  generateStory: () => Promise<void>
 }
 
 function fileToBase64(file: File): Promise<string> {
@@ -83,6 +90,11 @@ export function useStorybookFactoryState(): StorybookFactoryState {
   const [isSuggestionsLoading, setIsSuggestionsLoading] = useState(false)
   const [suggestionsError, setSuggestionsError] = useState<string | null>(null)
   const [suggestionReasoning, setSuggestionReasoning] = useState<string | null>(null)
+
+  // Story generation state
+  const [generatedStory, setGeneratedStory] = useState<GeneratedStory | null>(null)
+  const [isGenerating, setIsGenerating] = useState(false)
+  const [generationError, setGenerationError] = useState<string | null>(null)
 
   const setImage1 = (file: File) => {
     const validationError = validateImageFile(file)
@@ -179,6 +191,37 @@ export function useStorybookFactoryState(): StorybookFactoryState {
     }
   }
 
+  const generateStory = async () => {
+    setIsGenerating(true)
+    setGenerationError(null)
+    try {
+      const response = await fetch('/api/v1/storybook-factory/generate-story', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          caption1,
+          caption2,
+          storyDirectionPrompt,
+          storyConfig,
+        }),
+      })
+
+      if (!response.ok) {
+        throw new Error('Failed to generate story')
+      }
+
+      const data = await response.json()
+      setGeneratedStory({
+        layout: data.layout,
+        generatedAt: data.generatedAt,
+      })
+    } catch {
+      setGenerationError('Something went wrong generating your story. Please try again.')
+    } finally {
+      setIsGenerating(false)
+    }
+  }
+
   const canProceedFromUpload = image1Base64 !== null && image2Base64 !== null
 
   return {
@@ -204,5 +247,9 @@ export function useStorybookFactoryState(): StorybookFactoryState {
     suggestionsError,
     fetchSuggestions,
     suggestionReasoning,
+    generatedStory,
+    isGenerating,
+    generationError,
+    generateStory,
   }
 }

--- a/src/app/storybook-factory/components/useStorybookFactoryState.tsx
+++ b/src/app/storybook-factory/components/useStorybookFactoryState.tsx
@@ -2,6 +2,26 @@
 
 import { useState } from 'react'
 
+export interface StoryConfiguration {
+  storyType: 'comic' | 'storybook' | 'fairy-tale' | 'adventure'
+  artStyle: 'cartoon' | 'anime' | 'watercolor' | 'pixel-art' | 'realistic'
+  pageCount: number
+  tone: 'funny' | 'dramatic' | 'scary' | 'heartwarming'
+  panelsPerPage: number
+  dialogueStyle: 'speech-bubbles' | 'narration-boxes' | 'mixed'
+  additionalNotes: string
+}
+
+const DEFAULT_STORY_CONFIG: StoryConfiguration = {
+  storyType: 'comic',
+  artStyle: 'cartoon',
+  pageCount: 8,
+  tone: 'funny',
+  panelsPerPage: 4,
+  dialogueStyle: 'speech-bubbles',
+  additionalNotes: '',
+}
+
 export interface StorybookFactoryState {
   image1Base64: string | null
   image2Base64: string | null
@@ -19,6 +39,14 @@ export interface StorybookFactoryState {
   setStoryDirectionPrompt: (text: string) => void
   clearError: () => void
   canProceedFromUpload: boolean
+
+  // Story configuration
+  storyConfig: StoryConfiguration
+  setStoryConfig: (updates: Partial<StoryConfiguration>) => void
+  isSuggestionsLoading: boolean
+  suggestionsError: string | null
+  fetchSuggestions: () => Promise<void>
+  suggestionReasoning: string | null
 }
 
 function fileToBase64(file: File): Promise<string> {
@@ -49,6 +77,12 @@ export function useStorybookFactoryState(): StorybookFactoryState {
   const [storyDirectionPrompt, setStoryDirectionPromptState] = useState('')
   const [isLoading, setIsLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
+
+  // Story configuration state
+  const [storyConfig, setStoryConfigState] = useState<StoryConfiguration>(DEFAULT_STORY_CONFIG)
+  const [isSuggestionsLoading, setIsSuggestionsLoading] = useState(false)
+  const [suggestionsError, setSuggestionsError] = useState<string | null>(null)
+  const [suggestionReasoning, setSuggestionReasoning] = useState<string | null>(null)
 
   const setImage1 = (file: File) => {
     const validationError = validateImageFile(file)
@@ -100,6 +134,51 @@ export function useStorybookFactoryState(): StorybookFactoryState {
     setCaption2State('')
   }
 
+  const setStoryConfig = (updates: Partial<StoryConfiguration>) => {
+    setStoryConfigState(prev => ({ ...prev, ...updates }))
+  }
+
+  const fetchSuggestions = async () => {
+    setIsSuggestionsLoading(true)
+    setSuggestionsError(null)
+    try {
+      const response = await fetch('/api/v1/storybook-factory/suggest-configuration', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          caption1,
+          caption2,
+          storyDirectionPrompt,
+        }),
+      })
+
+      if (!response.ok) {
+        throw new Error('Failed to fetch suggestions')
+      }
+
+      const data = await response.json()
+
+      // Merge suggestions into config (graceful: only update known fields)
+      const updates: Partial<StoryConfiguration> = {}
+      if (data.storyType) updates.storyType = data.storyType
+      if (data.artStyle) updates.artStyle = data.artStyle
+      if (data.pageCount) updates.pageCount = data.pageCount
+      if (data.tone) updates.tone = data.tone
+      if (data.panelsPerPage) updates.panelsPerPage = data.panelsPerPage
+      if (data.dialogueStyle) updates.dialogueStyle = data.dialogueStyle
+      setStoryConfigState(prev => ({ ...prev, ...updates }))
+
+      if (data.reasoning) {
+        setSuggestionReasoning(data.reasoning)
+      }
+    } catch {
+      // Graceful degradation: keep defaults, show no error to avoid blocking the user
+      setSuggestionsError('Could not load AI suggestions. Using defaults — feel free to customize.')
+    } finally {
+      setIsSuggestionsLoading(false)
+    }
+  }
+
   const canProceedFromUpload = image1Base64 !== null && image2Base64 !== null
 
   return {
@@ -119,5 +198,11 @@ export function useStorybookFactoryState(): StorybookFactoryState {
     setStoryDirectionPrompt: setStoryDirectionPromptState,
     clearError: () => setError(null),
     canProceedFromUpload,
+    storyConfig,
+    setStoryConfig,
+    isSuggestionsLoading,
+    suggestionsError,
+    fetchSuggestions,
+    suggestionReasoning,
   }
 }

--- a/src/app/storybook-factory/page.tsx
+++ b/src/app/storybook-factory/page.tsx
@@ -43,7 +43,16 @@ export default function StorybookFactory() {
           />
         )}
         {currentStep === 1 && (
-          <Step02StoryConfiguration onNext={nextStep} onPrevious={previousStep} />
+          <Step02StoryConfiguration
+            onNext={nextStep}
+            onPrevious={previousStep}
+            storyConfig={state.storyConfig}
+            setStoryConfig={state.setStoryConfig}
+            isSuggestionsLoading={state.isSuggestionsLoading}
+            suggestionsError={state.suggestionsError}
+            fetchSuggestions={state.fetchSuggestions}
+            suggestionReasoning={state.suggestionReasoning}
+          />
         )}
         {currentStep === 2 && <Step03Generation onNext={nextStep} onPrevious={previousStep} />}
         {currentStep === 3 && <Step04ReviewAndRevise onPrevious={previousStep} />}

--- a/src/app/storybook-factory/page.tsx
+++ b/src/app/storybook-factory/page.tsx
@@ -54,7 +54,16 @@ export default function StorybookFactory() {
             suggestionReasoning={state.suggestionReasoning}
           />
         )}
-        {currentStep === 2 && <Step03Generation onNext={nextStep} onPrevious={previousStep} />}
+        {currentStep === 2 && (
+          <Step03Generation
+            onNext={nextStep}
+            onPrevious={previousStep}
+            generatedStory={state.generatedStory}
+            isGenerating={state.isGenerating}
+            generationError={state.generationError}
+            generateStory={state.generateStory}
+          />
+        )}
         {currentStep === 3 && <Step04ReviewAndRevise onPrevious={previousStep} />}
       </div>
     </div>

--- a/src/app/storybook-factory/types.ts
+++ b/src/app/storybook-factory/types.ts
@@ -1,0 +1,29 @@
+export interface StoryPanel {
+  type: 'illustration' | 'text' | 'speech-bubble' | 'narration-box' | 'sound-effect'
+  content: string // For text/speech/narration: the text. For illustration: the image generation prompt.
+  character?: string // For speech bubbles: who is speaking
+  position: {
+    x: number // 0-100 relative percentage
+    y: number
+    width: number
+    height: number
+  }
+}
+
+export interface StoryPage {
+  pageNumber: number
+  layout: 'full-image' | 'image-left-text-right' | 'text-over-image' | 'comic-grid' | 'split'
+  panels: StoryPanel[]
+  backgroundColor?: string
+}
+
+export interface StoryLayout {
+  title: string
+  type: 'comic' | 'storybook' | 'fairy-tale' | 'adventure'
+  pages: StoryPage[]
+}
+
+export interface GeneratedStory {
+  layout: StoryLayout
+  generatedAt: string // ISO timestamp
+}


### PR DESCRIPTION
## Summary

- Adds `POST /api/v1/storybook-factory/generate-story` route using `generateObject` (Zod-validated structured output) to produce a full multi-page `StoryLayout` from captions, story direction, and `StoryConfiguration`
- Defines `StoryPanel`, `StoryPage`, `StoryLayout`, and `GeneratedStory` TypeScript interfaces in a new `types.ts` file
- Extends `useStorybookFactoryState` with `generatedStory`, `isGenerating`, `generationError`, and `generateStory` state + action
- Rewrites `step03-generation.tsx`: auto-triggers generation on mount, shows a spinner with rotating status messages, handles errors with a retry button, and displays a success summary (title, page/illustration counts) with a "View Your Story" CTA

## Depends on
- PR #1658 (Storybook Factory base)
- PR #1659 (Storybook Factory config QA)

Closes #1651

## Test plan

- [ ] Navigate to `/storybook-factory`, upload two images, fill captions, proceed through step 2
- [ ] On step 3, verify spinner appears immediately and status messages rotate
- [ ] Verify API call is made to `/api/v1/storybook-factory/generate-story`
- [ ] On success, verify story title and page count appear with "View Your Story" button
- [ ] Simulate error (kill network or break key): verify error message and "Try Again" button appear
- [ ] Click "Try Again" — verify generation retries
- [ ] Click "Back" from step 3 — verify it navigates back without re-triggering generation
- [ ] `npx tsc --noEmit` passes with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)