### PR TITLE
feat: Storybook Factory inline text editing and prompt-based revision

### DIFF
--- a/src/app/api/v1/storybook-factory/revise-story/route.ts
+++ b/src/app/api/v1/storybook-factory/revise-story/route.ts
@@ -1,0 +1,109 @@
+import { createOpenAI } from '@ai-sdk/openai'
+import { generateObject } from 'ai'
+import { NextResponse } from 'next/server'
+import { z } from 'zod'
+
+export const maxDuration = 300
+
+const StoryPanelSchema = z.object({
+  type: z.enum(['illustration', 'text', 'speech-bubble', 'narration-box', 'sound-effect']),
+  content: z
+    .string()
+    .describe(
+      'For illustrations: detailed image generation prompt. For text/speech/narration: the actual text content.'
+    ),
+  character: z
+    .string()
+    .optional()
+    .describe('For speech bubbles: the name of the character speaking'),
+  position: z.object({
+    x: z.number().min(0).max(100).describe('Horizontal position as percentage'),
+    y: z.number().min(0).max(100).describe('Vertical position as percentage'),
+    width: z.number().min(0).max(100).describe('Width as percentage'),
+    height: z.number().min(0).max(100).describe('Height as percentage'),
+  }),
+})
+
+const StoryPageSchema = z.object({
+  pageNumber: z.number(),
+  layout: z.enum([
+    'full-image',
+    'image-left-text-right',
+    'text-over-image',
+    'comic-grid',
+    'split',
+  ]),
+  panels: z.array(StoryPanelSchema),
+  backgroundColor: z.string().optional(),
+})
+
+const StoryLayoutSchema = z.object({
+  title: z.string().describe('The title of the story'),
+  type: z.enum(['comic', 'storybook', 'fairy-tale', 'adventure']),
+  pages: z.array(StoryPageSchema),
+})
+
+export async function POST(request: Request) {
+  try {
+    const openaiClient = createOpenAI({
+      apiKey: process.env.OPENAI_API_KEY,
+    })
+
+    const { revisionPrompt, currentLayout, storyConfig } = await request.json()
+
+    if (!revisionPrompt || !currentLayout) {
+      return NextResponse.json(
+        { error: 'revisionPrompt and currentLayout are required' },
+        { status: 400 }
+      )
+    }
+
+    const configSummary = storyConfig
+      ? `Story configuration:
+- Story type: ${storyConfig.storyType}
+- Art style: ${storyConfig.artStyle}
+- Tone: ${storyConfig.tone}
+- Dialogue style: ${storyConfig.dialogueStyle}`
+      : ''
+
+    const currentLayoutJson = JSON.stringify(currentLayout, null, 2)
+
+    const prompt = `You are a creative story editor. You have a story layout in JSON format, and the user wants to revise it.
+
+Current story layout:
+${currentLayoutJson}
+
+${configSummary}
+
+User's revision request: "${revisionPrompt}"
+
+Instructions:
+- Apply the user's revision intelligently to the story
+- If the revision targets a specific page or character, focus changes there and keep other pages unchanged
+- If the revision is global (e.g., "make it funnier", "change the tone"), apply it throughout
+- Maintain the same story type, art style, and panel structure unless the revision explicitly requests changes
+- For illustration panels, update the image generation prompt to reflect the revision
+- For text panels, update the actual text content
+- Keep the same number of pages and panels unless revision explicitly asks for more/fewer
+- Return the COMPLETE revised story layout — all pages, all panels
+- Maintain story consistency: characters should remain consistent, narrative should flow
+
+Return the complete revised StoryLayout.`
+
+    const result = await generateObject({
+      model: openaiClient('gpt-4o-mini'),
+      schema: StoryLayoutSchema,
+      prompt,
+      temperature: 0.7,
+      maxTokens: 4096,
+    })
+
+    return NextResponse.json({
+      layout: result.object,
+      generatedAt: new Date().toISOString(),
+    })
+  } catch (error) {
+    console.error('Error revising story layout:', error)
+    return NextResponse.json({ error: 'Failed to revise story. Please try again.' }, { status: 500 })
+  }
+}

--- a/src/app/storybook-factory/components/step04-review-and-revise.tsx
+++ b/src/app/storybook-factory/components/step04-review-and-revise.tsx
@@ -1,8 +1,67 @@
 'use client'
 
-import { useState } from 'react'
+import { useRef, useState } from 'react'
 import { ChunkyButton } from '@/components/ui/chunky-button'
+import { Input } from '@/components/ui/input'
 import type { GeneratedStory, StoryPanel, StoryPage } from '../types'
+
+// --- Editable text wrapper ---
+
+function EditableTextContent({
+  content,
+  displayClassName,
+  onSave,
+  onCancel,
+}: {
+  content: string
+  displayClassName: string
+  onSave: (newContent: string) => void
+  onCancel: () => void
+}) {
+  const [draft, setDraft] = useState(content)
+  const textareaRef = useRef<HTMLTextAreaElement>(null)
+
+  return (
+    <div className="w-full h-full flex flex-col gap-1 p-1">
+      <textarea
+        ref={textareaRef}
+        value={draft}
+        onChange={e => setDraft(e.target.value)}
+        className={`w-full flex-1 resize-none border-2 border-primary rounded-lg bg-transparent p-1 focus:outline-none ${displayClassName}`}
+        autoFocus
+        onKeyDown={e => {
+          if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+            onSave(draft)
+          } else if (e.key === 'Escape') {
+            onCancel()
+          }
+        }}
+      />
+      <div className="flex gap-1 justify-end flex-shrink-0">
+        <button
+          onClick={() => onSave(draft)}
+          className="bg-primary text-on-primary rounded-full w-6 h-6 flex items-center justify-center hover:opacity-90"
+          title="Save (Cmd+Enter)"
+          aria-label="Save edit"
+        >
+          <span className="material-symbols-outlined text-[14px]" style={{ fontVariationSettings: "'FILL' 1" }}>
+            check
+          </span>
+        </button>
+        <button
+          onClick={onCancel}
+          className="bg-surface-container-high text-on-surface rounded-full w-6 h-6 flex items-center justify-center hover:opacity-90"
+          title="Cancel (Esc)"
+          aria-label="Cancel edit"
+        >
+          <span className="material-symbols-outlined text-[14px]" style={{ fontVariationSettings: "'FILL' 0" }}>
+            close
+          </span>
+        </button>
+      </div>
+    </div>
+  )
+}
 
 // --- Panel renderers ---
 
@@ -10,65 +69,183 @@ function IllustrationPanel({
   panel,
   imageUrl,
   isComicStyle,
+  isRegenerating,
+  onRegenerate,
 }: {
   panel: StoryPanel
   imageUrl: string | undefined
   isComicStyle: boolean
+  isRegenerating: boolean
+  onRegenerate: () => void
 }) {
   const borderClass = isComicStyle ? 'border-[3px] border-black' : 'border border-black/10'
 
-  if (imageUrl) {
+  return (
+    <div className="relative w-full h-full group">
+      {imageUrl ? (
+        <img
+          src={imageUrl}
+          alt={panel.content}
+          className={`w-full h-full object-cover ${borderClass}`}
+          draggable={false}
+        />
+      ) : (
+        <div
+          className={`w-full h-full flex flex-col items-center justify-center gap-2 bg-neutral-100 ${borderClass}`}
+        >
+          <span
+            className="material-symbols-outlined text-[32px] text-neutral-400"
+            style={{ fontVariationSettings: "'FILL' 0" }}
+          >
+            image
+          </span>
+          <p className="font-body text-[10px] text-neutral-500 text-center px-2 leading-tight line-clamp-3">
+            {panel.content}
+          </p>
+        </div>
+      )}
+
+      {/* Regenerate button — shown on hover */}
+      <button
+        onClick={e => {
+          e.stopPropagation()
+          onRegenerate()
+        }}
+        disabled={isRegenerating}
+        className="absolute top-1.5 right-1.5 bg-surface-container hover:bg-primary text-on-surface hover:text-on-primary rounded-full p-1.5 opacity-0 group-hover:opacity-100 transition-opacity shadow-md disabled:opacity-60"
+        title="Regenerate illustration"
+        aria-label="Regenerate illustration"
+      >
+        <span
+          className={`material-symbols-outlined text-[16px] ${isRegenerating ? 'animate-spin' : ''}`}
+          style={{ fontVariationSettings: "'FILL' 0" }}
+        >
+          refresh
+        </span>
+      </button>
+
+      {/* Loading overlay when regenerating */}
+      {isRegenerating && (
+        <div className="absolute inset-0 bg-black/30 flex items-center justify-center">
+          <span
+            className="material-symbols-outlined text-white text-[32px] animate-spin"
+            style={{ fontVariationSettings: "'FILL' 0" }}
+          >
+            refresh
+          </span>
+        </div>
+      )}
+    </div>
+  )
+}
+
+function TextPanel({
+  panel,
+  isComicStyle,
+  isEditing,
+  onEdit,
+  onSave,
+  onCancel,
+}: {
+  panel: StoryPanel
+  isComicStyle: boolean
+  isEditing: boolean
+  onEdit: () => void
+  onSave: (content: string) => void
+  onCancel: () => void
+}) {
+  if (isEditing) {
+    const cls = isComicStyle
+      ? 'font-body text-xs text-black leading-snug text-center'
+      : 'font-body text-sm text-on-surface leading-relaxed text-center'
     return (
-      <img
-        src={imageUrl}
-        alt={panel.content}
-        className={`w-full h-full object-cover ${borderClass}`}
-        draggable={false}
-      />
+      <div
+        className={`w-full h-full ${isComicStyle ? 'bg-white border-[3px] border-black' : 'bg-white/80 backdrop-blur-sm rounded-xl shadow-sm'}`}
+      >
+        <EditableTextContent content={panel.content} displayClassName={cls} onSave={onSave} onCancel={onCancel} />
+      </div>
+    )
+  }
+
+  if (isComicStyle) {
+    return (
+      <div
+        className="w-full h-full flex items-center justify-center bg-white border-[3px] border-black p-2 overflow-hidden cursor-pointer group border-dashed hover:border-primary/50 transition-colors"
+        onClick={onEdit}
+        title="Click to edit text"
+      >
+        <p className="font-body text-xs text-black leading-snug text-center">{panel.content}</p>
+        <span
+          className="material-symbols-outlined text-[12px] text-primary/60 opacity-0 group-hover:opacity-100 ml-1 flex-shrink-0"
+          style={{ fontVariationSettings: "'FILL' 0" }}
+        >
+          edit
+        </span>
+      </div>
+    )
+  }
+  return (
+    <div
+      className="w-full h-full flex items-center justify-center bg-white/80 backdrop-blur-sm rounded-xl p-4 overflow-hidden shadow-sm cursor-pointer group hover:ring-2 hover:ring-dashed hover:ring-outline-variant/50 transition-all"
+      onClick={onEdit}
+      title="Click to edit text"
+    >
+      <p className="font-body text-sm text-on-surface leading-relaxed text-center">{panel.content}</p>
+      <span
+        className="material-symbols-outlined text-[12px] text-on-surface-variant/60 opacity-0 group-hover:opacity-100 ml-1 flex-shrink-0"
+        style={{ fontVariationSettings: "'FILL' 0" }}
+      >
+        edit
+      </span>
+    </div>
+  )
+}
+
+function SpeechBubblePanel({
+  panel,
+  isComicStyle,
+  isEditing,
+  onEdit,
+  onSave,
+  onCancel,
+}: {
+  panel: StoryPanel
+  isComicStyle: boolean
+  isEditing: boolean
+  onEdit: () => void
+  onSave: (content: string) => void
+  onCancel: () => void
+}) {
+  const containerClass = isComicStyle
+    ? 'bg-white border-[2px] border-black rounded-2xl'
+    : 'bg-white/90 border border-black/20 rounded-2xl shadow-md'
+
+  if (isEditing) {
+    return (
+      <div className={`w-full h-full flex flex-col p-2 overflow-hidden relative ${containerClass}`}>
+        {panel.character && (
+          <p
+            className={`font-body font-bold text-[10px] uppercase tracking-wide mb-1 ${isComicStyle ? 'text-black' : 'text-on-surface'}`}
+          >
+            {panel.character}:
+          </p>
+        )}
+        <EditableTextContent
+          content={panel.content}
+          displayClassName={`font-body text-xs leading-snug ${isComicStyle ? 'text-black' : 'text-on-surface'}`}
+          onSave={onSave}
+          onCancel={onCancel}
+        />
+      </div>
     )
   }
 
   return (
     <div
-      className={`w-full h-full flex flex-col items-center justify-center gap-2 bg-neutral-100 ${borderClass}`}
+      className={`w-full h-full flex flex-col p-2 overflow-hidden relative ${containerClass} cursor-pointer group hover:ring-2 hover:ring-dashed hover:ring-outline-variant/50 transition-all`}
+      onClick={onEdit}
+      title="Click to edit speech"
     >
-      <span
-        className="material-symbols-outlined text-[32px] text-neutral-400"
-        style={{ fontVariationSettings: "'FILL' 0" }}
-      >
-        image
-      </span>
-      <p className="font-body text-[10px] text-neutral-500 text-center px-2 leading-tight line-clamp-3">
-        {panel.content}
-      </p>
-    </div>
-  )
-}
-
-function TextPanel({ panel, isComicStyle }: { panel: StoryPanel; isComicStyle: boolean }) {
-  if (isComicStyle) {
-    return (
-      <div className="w-full h-full flex items-center justify-center bg-white border-[3px] border-black p-2 overflow-hidden">
-        <p className="font-body text-xs text-black leading-snug text-center">{panel.content}</p>
-      </div>
-    )
-  }
-  return (
-    <div className="w-full h-full flex items-center justify-center bg-white/80 backdrop-blur-sm rounded-xl p-4 overflow-hidden shadow-sm">
-      <p className="font-body text-sm text-on-surface leading-relaxed text-center">
-        {panel.content}
-      </p>
-    </div>
-  )
-}
-
-function SpeechBubblePanel({ panel, isComicStyle }: { panel: StoryPanel; isComicStyle: boolean }) {
-  const containerClass = isComicStyle
-    ? 'bg-white border-[2px] border-black rounded-2xl'
-    : 'bg-white/90 border border-black/20 rounded-2xl shadow-md'
-
-  return (
-    <div className={`w-full h-full flex flex-col p-2 overflow-hidden relative ${containerClass}`}>
       {panel.character && (
         <p
           className={`font-body font-bold text-[10px] uppercase tracking-wide mb-1 ${isComicStyle ? 'text-black' : 'text-on-surface'}`}
@@ -76,12 +253,20 @@ function SpeechBubblePanel({ panel, isComicStyle }: { panel: StoryPanel; isComic
           {panel.character}:
         </p>
       )}
-      <p
-        className={`font-body text-xs leading-snug flex-1 overflow-hidden ${isComicStyle ? 'text-black' : 'text-on-surface'}`}
-      >
-        {panel.content}
-      </p>
-      {/* Speech tail — simple triangle at bottom-left */}
+      <div className="flex items-start gap-1 flex-1 overflow-hidden">
+        <p
+          className={`font-body text-xs leading-snug flex-1 overflow-hidden ${isComicStyle ? 'text-black' : 'text-on-surface'}`}
+        >
+          {panel.content}
+        </p>
+        <span
+          className="material-symbols-outlined text-[12px] text-on-surface-variant/60 opacity-0 group-hover:opacity-100 flex-shrink-0"
+          style={{ fontVariationSettings: "'FILL' 0" }}
+        >
+          edit
+        </span>
+      </div>
+      {/* Speech tail */}
       <div
         className="absolute bottom-[-10px] left-4 w-0 h-0"
         style={{
@@ -102,25 +287,93 @@ function SpeechBubblePanel({ panel, isComicStyle }: { panel: StoryPanel; isComic
   )
 }
 
-function NarrationBoxPanel({ panel, isComicStyle }: { panel: StoryPanel; isComicStyle: boolean }) {
+function NarrationBoxPanel({
+  panel,
+  isComicStyle,
+  isEditing,
+  onEdit,
+  onSave,
+  onCancel,
+}: {
+  panel: StoryPanel
+  isComicStyle: boolean
+  isEditing: boolean
+  onEdit: () => void
+  onSave: (content: string) => void
+  onCancel: () => void
+}) {
   const containerClass = isComicStyle
     ? 'bg-amber-50 border-[2px] border-amber-800'
     : 'bg-amber-50/90 border border-amber-200 rounded-lg shadow-sm'
 
+  if (isEditing) {
+    return (
+      <div className={`w-full h-full flex items-center justify-center p-2 overflow-hidden ${containerClass}`}>
+        <EditableTextContent
+          content={panel.content}
+          displayClassName={`font-body text-xs italic leading-snug text-center ${isComicStyle ? 'text-amber-900' : 'text-amber-800'}`}
+          onSave={onSave}
+          onCancel={onCancel}
+        />
+      </div>
+    )
+  }
+
   return (
-    <div className={`w-full h-full flex items-center justify-center p-2 overflow-hidden ${containerClass}`}>
-      <p
-        className={`font-body text-xs italic leading-snug text-center ${isComicStyle ? 'text-amber-900' : 'text-amber-800'}`}
-      >
-        {panel.content}
-      </p>
+    <div
+      className={`w-full h-full flex items-center justify-center p-2 overflow-hidden ${containerClass} cursor-pointer group hover:ring-2 hover:ring-dashed hover:ring-amber-400/50 transition-all`}
+      onClick={onEdit}
+      title="Click to edit narration"
+    >
+      <div className="flex items-center gap-1">
+        <p
+          className={`font-body text-xs italic leading-snug text-center ${isComicStyle ? 'text-amber-900' : 'text-amber-800'}`}
+        >
+          {panel.content}
+        </p>
+        <span
+          className="material-symbols-outlined text-[12px] text-amber-600/60 opacity-0 group-hover:opacity-100 flex-shrink-0"
+          style={{ fontVariationSettings: "'FILL' 0" }}
+        >
+          edit
+        </span>
+      </div>
     </div>
   )
 }
 
-function SoundEffectPanel({ panel }: { panel: StoryPanel }) {
+function SoundEffectPanel({
+  panel,
+  isEditing,
+  onEdit,
+  onSave,
+  onCancel,
+}: {
+  panel: StoryPanel
+  isEditing: boolean
+  onEdit: () => void
+  onSave: (content: string) => void
+  onCancel: () => void
+}) {
+  if (isEditing) {
+    return (
+      <div className="w-full h-full flex items-center justify-center overflow-hidden p-1">
+        <EditableTextContent
+          content={panel.content}
+          displayClassName="text-red-500 font-bold text-2xl uppercase tracking-wider text-center"
+          onSave={onSave}
+          onCancel={onCancel}
+        />
+      </div>
+    )
+  }
+
   return (
-    <div className="w-full h-full flex items-center justify-center overflow-hidden">
+    <div
+      className="w-full h-full flex items-center justify-center overflow-hidden cursor-pointer group hover:opacity-80 transition-opacity"
+      onClick={onEdit}
+      title="Click to edit sound effect"
+    >
       <p
         className="text-red-500 font-bold text-2xl uppercase tracking-wider select-none"
         style={{
@@ -130,6 +383,12 @@ function SoundEffectPanel({ panel }: { panel: StoryPanel }) {
       >
         {panel.content}
       </p>
+      <span
+        className="material-symbols-outlined text-[12px] text-on-surface-variant/60 opacity-0 group-hover:opacity-100 ml-1 flex-shrink-0"
+        style={{ fontVariationSettings: "'FILL' 0" }}
+      >
+        edit
+      </span>
     </div>
   )
 }
@@ -139,15 +398,29 @@ function SoundEffectPanel({ panel }: { panel: StoryPanel }) {
 function PanelRenderer({
   panel,
   panelIndex,
+  pageIndex,
   page,
   illustrationUrls,
   isComicStyle,
+  isEditing,
+  isRegeneratingIllustration,
+  onEdit,
+  onSave,
+  onCancel,
+  onRegenerateIllustration,
 }: {
   panel: StoryPanel
   panelIndex: number
+  pageIndex: number
   page: StoryPage
   illustrationUrls: Record<string, string>
   isComicStyle: boolean
+  isEditing: boolean
+  isRegeneratingIllustration: boolean
+  onEdit: () => void
+  onSave: (content: string) => void
+  onCancel: () => void
+  onRegenerateIllustration: () => void
 }) {
   const imageKey = `page-${page.pageNumber}-panel-${panelIndex}`
   const imageUrl = illustrationUrls[imageKey]
@@ -162,16 +435,53 @@ function PanelRenderer({
   return (
     <div className="absolute" style={positionStyle}>
       {panel.type === 'illustration' && (
-        <IllustrationPanel panel={panel} imageUrl={imageUrl} isComicStyle={isComicStyle} />
+        <IllustrationPanel
+          panel={panel}
+          imageUrl={imageUrl}
+          isComicStyle={isComicStyle}
+          isRegenerating={isRegeneratingIllustration}
+          onRegenerate={onRegenerateIllustration}
+        />
       )}
-      {panel.type === 'text' && <TextPanel panel={panel} isComicStyle={isComicStyle} />}
+      {panel.type === 'text' && (
+        <TextPanel
+          panel={panel}
+          isComicStyle={isComicStyle}
+          isEditing={isEditing}
+          onEdit={onEdit}
+          onSave={onSave}
+          onCancel={onCancel}
+        />
+      )}
       {panel.type === 'speech-bubble' && (
-        <SpeechBubblePanel panel={panel} isComicStyle={isComicStyle} />
+        <SpeechBubblePanel
+          panel={panel}
+          isComicStyle={isComicStyle}
+          isEditing={isEditing}
+          onEdit={onEdit}
+          onSave={onSave}
+          onCancel={onCancel}
+        />
       )}
       {panel.type === 'narration-box' && (
-        <NarrationBoxPanel panel={panel} isComicStyle={isComicStyle} />
+        <NarrationBoxPanel
+          panel={panel}
+          isComicStyle={isComicStyle}
+          isEditing={isEditing}
+          onEdit={onEdit}
+          onSave={onSave}
+          onCancel={onCancel}
+        />
       )}
-      {panel.type === 'sound-effect' && <SoundEffectPanel panel={panel} />}
+      {panel.type === 'sound-effect' && (
+        <SoundEffectPanel
+          panel={panel}
+          isEditing={isEditing}
+          onEdit={onEdit}
+          onSave={onSave}
+          onCancel={onCancel}
+        />
+      )}
     </div>
   )
 }
@@ -180,12 +490,26 @@ function PanelRenderer({
 
 function StoryPageRenderer({
   page,
+  pageIndex,
   illustrationUrls,
   isComicStyle,
+  editingPanel,
+  regeneratingPanels,
+  onEditPanel,
+  onSavePanel,
+  onCancelEdit,
+  onRegenerateIllustration,
 }: {
   page: StoryPage
+  pageIndex: number
   illustrationUrls: Record<string, string>
   isComicStyle: boolean
+  editingPanel: { pageIndex: number; panelIndex: number } | null
+  regeneratingPanels: Set<string>
+  onEditPanel: (pageIndex: number, panelIndex: number) => void
+  onSavePanel: (pageIndex: number, panelIndex: number, content: string) => void
+  onCancelEdit: () => void
+  onRegenerateIllustration: (pageIndex: number, panelIndex: number, prompt: string) => void
 }) {
   const isComicGrid = page.layout === 'comic-grid'
 
@@ -207,16 +531,28 @@ function StoryPageRenderer({
       className={`relative w-full aspect-[3/4] overflow-hidden ${pageBorderClass}`}
       style={pageStyle}
     >
-      {page.panels.map((panel, idx) => (
-        <PanelRenderer
-          key={idx}
-          panel={panel}
-          panelIndex={idx}
-          page={page}
-          illustrationUrls={illustrationUrls}
-          isComicStyle={isComicStyle}
-        />
-      ))}
+      {page.panels.map((panel, idx) => {
+        const regenKey = `page-${page.pageNumber}-panel-${idx}`
+        const isThisPanelEditing =
+          editingPanel?.pageIndex === pageIndex && editingPanel?.panelIndex === idx
+        return (
+          <PanelRenderer
+            key={idx}
+            panel={panel}
+            panelIndex={idx}
+            pageIndex={pageIndex}
+            page={page}
+            illustrationUrls={illustrationUrls}
+            isComicStyle={isComicStyle}
+            isEditing={isThisPanelEditing}
+            isRegeneratingIllustration={regeneratingPanels.has(regenKey)}
+            onEdit={() => onEditPanel(pageIndex, idx)}
+            onSave={content => onSavePanel(pageIndex, idx, content)}
+            onCancel={onCancelEdit}
+            onRegenerateIllustration={() => onRegenerateIllustration(pageIndex, idx, panel.content)}
+          />
+        )
+      })}
     </div>
   )
 }
@@ -226,11 +562,37 @@ function StoryPageRenderer({
 interface Step04Props {
   generatedStory: GeneratedStory | null
   illustrationUrls: Record<string, string>
+  editingPanel: { pageIndex: number; panelIndex: number } | null
+  setEditingPanel: (panel: { pageIndex: number; panelIndex: number } | null) => void
+  updatePanelContent: (pageIndex: number, panelIndex: number, content: string) => void
+  revisionPrompt: string
+  setRevisionPrompt: (prompt: string) => void
+  isRevising: boolean
+  revisionError: string | null
+  reviseStory: () => Promise<void>
+  regenerateStory: () => Promise<void>
+  regenerateIllustration: (pageNumber: number, panelIndex: number, prompt: string) => Promise<void>
   onPrevious: () => void
 }
 
-export function Step04ReviewAndRevise({ generatedStory, illustrationUrls, onPrevious }: Step04Props) {
+export function Step04ReviewAndRevise({
+  generatedStory,
+  illustrationUrls,
+  editingPanel,
+  setEditingPanel,
+  updatePanelContent,
+  revisionPrompt,
+  setRevisionPrompt,
+  isRevising,
+  revisionError,
+  reviseStory,
+  regenerateStory,
+  regenerateIllustration,
+  onPrevious,
+}: Step04Props) {
   const [currentPageIndex, setCurrentPageIndex] = useState(0)
+  const [regeneratingPanels, setRegeneratingPanels] = useState<Set<string>>(new Set())
+  const [isRegeneratingAll, setIsRegeneratingAll] = useState(false)
 
   if (!generatedStory) {
     return (
@@ -257,17 +619,83 @@ export function Step04ReviewAndRevise({ generatedStory, illustrationUrls, onPrev
   const currentPage = pages[currentPageIndex]
   const isComicStyle = layout.type === 'comic'
 
-  const goToPrevPage = () => setCurrentPageIndex(i => Math.max(0, i - 1))
-  const goToNextPage = () => setCurrentPageIndex(i => Math.min(totalPages - 1, i + 1))
+  const goToPrevPage = () => {
+    setEditingPanel(null)
+    setCurrentPageIndex(i => Math.max(0, i - 1))
+  }
+  const goToNextPage = () => {
+    setEditingPanel(null)
+    setCurrentPageIndex(i => Math.min(totalPages - 1, i + 1))
+  }
+
+  const handleEditPanel = (pageIndex: number, panelIndex: number) => {
+    setEditingPanel({ pageIndex, panelIndex })
+  }
+
+  const handleSavePanel = (pageIndex: number, panelIndex: number, content: string) => {
+    updatePanelContent(pageIndex, panelIndex, content)
+    setEditingPanel(null)
+  }
+
+  const handleRegenerateIllustration = async (pageIndex: number, panelIndex: number, prompt: string) => {
+    const page = pages[pageIndex]
+    if (!page) return
+    const key = `page-${page.pageNumber}-panel-${panelIndex}`
+    setRegeneratingPanels(prev => new Set(prev).add(key))
+    try {
+      await regenerateIllustration(page.pageNumber, panelIndex, prompt)
+    } finally {
+      setRegeneratingPanels(prev => {
+        const next = new Set(prev)
+        next.delete(key)
+        return next
+      })
+    }
+  }
+
+  const handleRegenerateAll = async () => {
+    if (!window.confirm('Regenerate the entire story? This will replace all pages and panels.')) return
+    setIsRegeneratingAll(true)
+    try {
+      await regenerateStory()
+      setCurrentPageIndex(0)
+    } finally {
+      setIsRegeneratingAll(false)
+    }
+  }
+
+  const handleReviseSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    await reviseStory()
+  }
 
   return (
     <div className="space-y-6 mt-6">
-      {/* Header */}
+      {/* Header with title and Regenerate All */}
       <div className="bg-surface-container rounded-lg p-6 space-y-1">
-        <h2 className="font-headline text-2xl text-on-surface">{layout.title}</h2>
-        <p className="font-body text-body-sm text-on-surface-variant capitalize">
-          {layout.type} &middot; {totalPages} {totalPages === 1 ? 'page' : 'pages'}
-        </p>
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <h2 className="font-headline text-2xl text-on-surface">{layout.title}</h2>
+            <p className="font-body text-body-sm text-on-surface-variant capitalize">
+              {layout.type} &middot; {totalPages} {totalPages === 1 ? 'page' : 'pages'}
+            </p>
+          </div>
+          <ChunkyButton
+            variant="secondary"
+            size="sm"
+            onClick={handleRegenerateAll}
+            disabled={isRegeneratingAll || isRevising}
+            title="Regenerate the entire story from scratch"
+          >
+            <span
+              className={`material-symbols-outlined text-[16px] ${isRegeneratingAll ? 'animate-spin' : ''}`}
+              style={{ fontVariationSettings: "'FILL' 0" }}
+            >
+              autorenew
+            </span>
+            <span className="hidden sm:inline">Regenerate All</span>
+          </ChunkyButton>
+        </div>
       </div>
 
       {/* Page navigation header */}
@@ -301,9 +729,63 @@ export function Step04ReviewAndRevise({ generatedStory, illustrationUrls, onPrev
       <div className="max-w-2xl mx-auto w-full">
         <StoryPageRenderer
           page={currentPage}
+          pageIndex={currentPageIndex}
           illustrationUrls={illustrationUrls}
           isComicStyle={isComicStyle}
+          editingPanel={editingPanel}
+          regeneratingPanels={regeneratingPanels}
+          onEditPanel={handleEditPanel}
+          onSavePanel={handleSavePanel}
+          onCancelEdit={() => setEditingPanel(null)}
+          onRegenerateIllustration={handleRegenerateIllustration}
         />
+      </div>
+
+      {/* Revision prompt bar */}
+      <div className="max-w-2xl mx-auto w-full bg-surface-container-high p-4 rounded-xl space-y-3">
+        <p className="font-body text-body-sm text-on-surface-variant">
+          Describe a revision to apply to the whole story (e.g., &ldquo;make it funnier&rdquo;, &ldquo;add a dragon to page 3&rdquo;):
+        </p>
+        <form onSubmit={handleReviseSubmit} className="flex gap-2">
+          <Input
+            value={revisionPrompt}
+            onChange={e => setRevisionPrompt(e.target.value)}
+            placeholder="e.g., make the ending more dramatic…"
+            disabled={isRevising}
+            className="flex-1"
+          />
+          <ChunkyButton
+            type="submit"
+            variant="primary"
+            size="md"
+            disabled={isRevising || !revisionPrompt.trim()}
+          >
+            {isRevising ? (
+              <>
+                <span
+                  className="material-symbols-outlined text-[16px] animate-spin"
+                  style={{ fontVariationSettings: "'FILL' 0" }}
+                >
+                  refresh
+                </span>
+                <span className="hidden sm:inline">Revising…</span>
+              </>
+            ) : (
+              <>
+                <span
+                  className="material-symbols-outlined text-[16px]"
+                  style={{ fontVariationSettings: "'FILL' 0" }}
+                >
+                  auto_fix_high
+                </span>
+                <span className="hidden sm:inline">Revise</span>
+              </>
+            )}
+          </ChunkyButton>
+        </form>
+        {revisionError && (
+          <p className="font-body text-body-sm text-ds-error">{revisionError}</p>
+        )}
       </div>
 
       {/* Bottom navigation */}

--- a/src/app/storybook-factory/components/useStorybookFactoryState.tsx
+++ b/src/app/storybook-factory/components/useStorybookFactoryState.tsx
@@ -61,6 +61,18 @@ export interface StorybookFactoryState {
   illustrationProgress: { completed: number; total: number }
   illustrationError: string | null
   generateIllustrations: () => Promise<void>
+  regenerateIllustration: (pageNumber: number, panelIndex: number, prompt: string) => Promise<void>
+
+  // Inline editing & revision
+  editingPanel: { pageIndex: number; panelIndex: number } | null
+  setEditingPanel: (panel: { pageIndex: number; panelIndex: number } | null) => void
+  updatePanelContent: (pageIndex: number, panelIndex: number, content: string) => void
+  revisionPrompt: string
+  setRevisionPrompt: (prompt: string) => void
+  isRevising: boolean
+  revisionError: string | null
+  reviseStory: () => Promise<void>
+  regenerateStory: () => Promise<void>
 }
 
 function fileToBase64(file: File): Promise<string> {
@@ -108,6 +120,12 @@ export function useStorybookFactoryState(): StorybookFactoryState {
   const [isGeneratingIllustrations, setIsGeneratingIllustrations] = useState(false)
   const [illustrationProgress, setIllustrationProgress] = useState({ completed: 0, total: 0 })
   const [illustrationError, setIllustrationError] = useState<string | null>(null)
+
+  // Inline editing & revision state
+  const [editingPanel, setEditingPanel] = useState<{ pageIndex: number; panelIndex: number } | null>(null)
+  const [revisionPrompt, setRevisionPromptState] = useState('')
+  const [isRevising, setIsRevising] = useState(false)
+  const [revisionError, setRevisionError] = useState<string | null>(null)
 
   const setImage1 = (file: File) => {
     const validationError = validateImageFile(file)
@@ -287,6 +305,79 @@ export function useStorybookFactoryState(): StorybookFactoryState {
     setIsGeneratingIllustrations(false)
   }
 
+  const updatePanelContent = (pageIndex: number, panelIndex: number, content: string) => {
+    setGeneratedStory(prev => {
+      if (!prev) return prev
+      const newLayout = JSON.parse(JSON.stringify(prev.layout)) // deep copy
+      if (newLayout.pages[pageIndex]?.panels[panelIndex]) {
+        newLayout.pages[pageIndex].panels[panelIndex].content = content
+      }
+      return { ...prev, layout: newLayout }
+    })
+  }
+
+  const reviseStory = async () => {
+    if (!generatedStory || !revisionPrompt.trim()) return
+    setIsRevising(true)
+    setRevisionError(null)
+    try {
+      const response = await fetch('/api/v1/storybook-factory/revise-story', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          revisionPrompt: revisionPrompt.trim(),
+          currentLayout: generatedStory.layout,
+          storyConfig,
+        }),
+      })
+
+      if (!response.ok) {
+        throw new Error('Failed to revise story')
+      }
+
+      const data = await response.json()
+      setGeneratedStory({
+        layout: data.layout,
+        generatedAt: data.generatedAt,
+      })
+      setRevisionPromptState('')
+    } catch {
+      setRevisionError('Something went wrong revising your story. Please try again.')
+    } finally {
+      setIsRevising(false)
+    }
+  }
+
+  const regenerateStory = async () => {
+    setGeneratedStory(null)
+    setIllustrationUrls({})
+    await generateStory()
+  }
+
+  const regenerateIllustration = async (pageNumber: number, panelIndex: number, prompt: string) => {
+    const key = `page-${pageNumber}-panel-${panelIndex}`
+    const storyContext = generatedStory
+      ? `A ${generatedStory.layout.type} story called "${generatedStory.layout.title}"`
+      : ''
+    try {
+      const response = await fetch('/api/v1/storybook-factory/generate-illustration', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          prompt,
+          artStyle: storyConfig.artStyle,
+          storyContext,
+        }),
+      })
+      if (response.ok) {
+        const data = await response.json()
+        setIllustrationUrls(prev => ({ ...prev, [key]: data.imageUrl }))
+      }
+    } catch (err) {
+      console.error(`Failed to regenerate illustration for ${key}:`, err)
+    }
+  }
+
   const canProceedFromUpload = image1Base64 !== null && image2Base64 !== null
 
   return {
@@ -321,5 +412,15 @@ export function useStorybookFactoryState(): StorybookFactoryState {
     illustrationProgress,
     illustrationError,
     generateIllustrations,
+    regenerateIllustration,
+    editingPanel,
+    setEditingPanel,
+    updatePanelContent,
+    revisionPrompt,
+    setRevisionPrompt: setRevisionPromptState,
+    isRevising,
+    revisionError,
+    reviseStory,
+    regenerateStory,
   }
 }

--- a/src/app/storybook-factory/page.tsx
+++ b/src/app/storybook-factory/page.tsx
@@ -74,6 +74,16 @@ export default function StorybookFactory() {
             onPrevious={previousStep}
             generatedStory={state.generatedStory}
             illustrationUrls={state.illustrationUrls}
+            editingPanel={state.editingPanel}
+            setEditingPanel={state.setEditingPanel}
+            updatePanelContent={state.updatePanelContent}
+            revisionPrompt={state.revisionPrompt}
+            setRevisionPrompt={state.setRevisionPrompt}
+            isRevising={state.isRevising}
+            revisionError={state.revisionError}
+            reviseStory={state.reviseStory}
+            regenerateStory={state.regenerateStory}
+            regenerateIllustration={state.regenerateIllustration}
           />
         )}
       </div>


### PR DESCRIPTION
## Summary

- **New API route** `/api/v1/storybook-factory/revise-story`: accepts a `revisionPrompt`, the current `StoryLayout`, and `storyConfig`; returns a revised `StoryLayout` using `generateObject` with the same Zod schema as `generate-story` (gpt-4o-mini, maxDuration=300)
- **State hook extensions** (`useStorybookFactoryState`): adds `editingPanel`, `revisionPrompt`, `isRevising`, `revisionError` state plus `setEditingPanel`, `updatePanelContent`, `reviseStory`, `regenerateStory`, `regenerateIllustration` functions
- **Interactive Step04 renderer**: text/speech-bubble/narration-box/sound-effect panels are now clickable inline editors (textarea with Save/Cancel); illustration panels have a hover-visible refresh button; revision prompt bar at the bottom; "Regenerate All" button in the header with confirmation dialog
- **page.tsx**: passes all new editing state and callbacks to Step04

## Details

### Inline text editing
- Clicking any text panel replaces the display with a textarea pre-filled with the current content
- Save with the checkmark button or Cmd+Enter; cancel with X or Escape
- Calls `updatePanelContent` which deep-copies the layout and updates the specific panel in state
- Only one panel editable at a time; navigating pages clears the editing state

### Per-panel illustration regeneration
- Small refresh icon button appears on hover at the top-right of illustration panels
- Calls the existing `generate-illustration` API for just that panel
- Shows a spinner overlay while regenerating; button is disabled during regen

### Prompt-based revision
- Revision bar below the page canvas: text input + "Revise" button
- Submits to the new `revise-story` API with the full current layout and story config
- On success, replaces `generatedStory` state with the revised layout and clears the prompt
- Error message displayed inline if revision fails

### Full regeneration
- "Regenerate All" button in the header triggers a `window.confirm` then calls `regenerateStory` (clears state and calls `generate-story` again)

## Test plan

- [ ] Navigate to Step 4 (Review & Revise) with a generated story
- [ ] Click a text/speech/narration/sound-effect panel — verify textarea appears with current content
- [ ] Edit text, press Cmd+Enter or click checkmark — verify content updates in the panel
- [ ] Press Escape or click X — verify edit is cancelled
- [ ] Hover an illustration panel — verify refresh button appears
- [ ] Click refresh on illustration — verify spinner overlay, then new image loads
- [ ] Enter a revision prompt, click Revise — verify loading state, then story updates
- [ ] Verify revision prompt clears after successful revision
- [ ] Click Regenerate All, confirm — verify story re-generates from scratch
- [ ] `npx tsc --noEmit` passes (verified: no output = clean)

## Dependencies

Depends on PR #1662 (storybook-factory-layout-renderer branch). This PR is branched from `feature/storybook-factory-layout-renderer`.

Closes #1654

🤖 Generated with [Claude Code](https://claude.com/claude-code)