### PR TITLE
feat: print-friendly view for Storybook Factory stories

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -657,3 +657,38 @@ body {
     @apply bg-background text-foreground;
   }
 }
+
+@media print {
+  /* Clean backgrounds */
+  body {
+    background: white !important;
+    color: black !important;
+  }
+
+  /* Story page breaks */
+  .print-story-page {
+    break-after: page;
+    page-break-after: always;
+    margin: 0 !important;
+    padding: 0 !important;
+  }
+
+  /* Avoid orphaned panels within a page */
+  .print-story-page:last-child {
+    break-after: avoid;
+    page-break-after: avoid;
+  }
+
+  /* Remove shadows, transitions, animations */
+  * {
+    box-shadow: none !important;
+    transition: none !important;
+    animation: none !important;
+  }
+
+  /* Ensure images print correctly */
+  img {
+    max-width: 100% !important;
+    break-inside: avoid;
+  }
+}

--- a/src/app/storybook-factory/components/step04-review-and-revise.tsx
+++ b/src/app/storybook-factory/components/step04-review-and-revise.tsx
@@ -486,6 +486,117 @@ function PanelRenderer({
   )
 }
 
+// --- Read-only panel renderer (for print view) ---
+
+function ReadOnlyPanelRenderer({
+  panel,
+  panelIndex,
+  page,
+  illustrationUrls,
+  isComicStyle,
+}: {
+  panel: StoryPanel
+  panelIndex: number
+  page: StoryPage
+  illustrationUrls: Record<string, string>
+  isComicStyle: boolean
+}) {
+  const imageKey = `page-${page.pageNumber}-panel-${panelIndex}`
+  const imageUrl = illustrationUrls[imageKey]
+
+  const positionStyle: React.CSSProperties = {
+    left: `${panel.position.x}%`,
+    top: `${panel.position.y}%`,
+    width: `${panel.position.width}%`,
+    height: `${panel.position.height}%`,
+  }
+
+  const borderClass = isComicStyle ? 'border-[3px] border-black' : 'border border-black/10'
+
+  return (
+    <div className="absolute" style={positionStyle}>
+      {panel.type === 'illustration' && (
+        imageUrl ? (
+          <img
+            src={imageUrl}
+            alt={panel.content}
+            className={`w-full h-full object-cover ${borderClass}`}
+            draggable={false}
+          />
+        ) : (
+          <div className={`w-full h-full flex flex-col items-center justify-center gap-2 bg-neutral-100 ${borderClass}`}>
+            <span
+              className="material-symbols-outlined text-[32px] text-neutral-400"
+              style={{ fontVariationSettings: "'FILL' 0" }}
+            >
+              image
+            </span>
+            <p className="font-body text-[10px] text-neutral-500 text-center px-2 leading-tight line-clamp-3">
+              {panel.content}
+            </p>
+          </div>
+        )
+      )}
+      {panel.type === 'text' && (
+        <div className={`w-full h-full flex items-center justify-center p-2 overflow-hidden ${isComicStyle ? 'bg-white border-[3px] border-black' : 'bg-white/80 rounded-xl shadow-sm'}`}>
+          <p className={`font-body leading-snug text-center ${isComicStyle ? 'text-xs text-black' : 'text-sm text-on-surface'}`}>
+            {panel.content}
+          </p>
+        </div>
+      )}
+      {panel.type === 'speech-bubble' && (
+        <div className={`w-full h-full flex flex-col p-2 overflow-hidden relative ${isComicStyle ? 'bg-white border-[2px] border-black rounded-2xl' : 'bg-white/90 border border-black/20 rounded-2xl shadow-md'}`}>
+          {panel.character && (
+            <p className={`font-body font-bold text-[10px] uppercase tracking-wide mb-1 ${isComicStyle ? 'text-black' : 'text-on-surface'}`}>
+              {panel.character}:
+            </p>
+          )}
+          <p className={`font-body text-xs leading-snug flex-1 overflow-hidden ${isComicStyle ? 'text-black' : 'text-on-surface'}`}>
+            {panel.content}
+          </p>
+          {/* Speech tail */}
+          <div
+            className="absolute bottom-[-10px] left-4 w-0 h-0"
+            style={{
+              borderLeft: '8px solid transparent',
+              borderRight: '4px solid transparent',
+              borderTop: isComicStyle ? '10px solid black' : '10px solid rgba(0,0,0,0.15)',
+            }}
+          />
+          <div
+            className="absolute bottom-[-7px] left-[18px] w-0 h-0"
+            style={{
+              borderLeft: '5px solid transparent',
+              borderRight: '3px solid transparent',
+              borderTop: '7px solid white',
+            }}
+          />
+        </div>
+      )}
+      {panel.type === 'narration-box' && (
+        <div className={`w-full h-full flex items-center justify-center p-2 overflow-hidden ${isComicStyle ? 'bg-amber-50 border-[2px] border-amber-800' : 'bg-amber-50/90 border border-amber-200 rounded-lg shadow-sm'}`}>
+          <p className={`font-body text-xs italic leading-snug text-center ${isComicStyle ? 'text-amber-900' : 'text-amber-800'}`}>
+            {panel.content}
+          </p>
+        </div>
+      )}
+      {panel.type === 'sound-effect' && (
+        <div className="w-full h-full flex items-center justify-center overflow-hidden">
+          <p
+            className="text-red-500 font-bold text-2xl uppercase tracking-wider select-none"
+            style={{
+              transform: 'rotate(-5deg)',
+              textShadow: '2px 2px 0 #000, -1px -1px 0 #000, 1px -1px 0 #000, -1px 1px 0 #000',
+            }}
+          >
+            {panel.content}
+          </p>
+        </div>
+      )}
+    </div>
+  )
+}
+
 // --- Page renderer ---
 
 function StoryPageRenderer({
@@ -680,147 +791,214 @@ export function Step04ReviewAndRevise({
               {layout.type} &middot; {totalPages} {totalPages === 1 ? 'page' : 'pages'}
             </p>
           </div>
-          <ChunkyButton
-            variant="secondary"
-            size="sm"
-            onClick={handleRegenerateAll}
-            disabled={isRegeneratingAll || isRevising}
-            title="Regenerate the entire story from scratch"
-          >
-            <span
-              className={`material-symbols-outlined text-[16px] ${isRegeneratingAll ? 'animate-spin' : ''}`}
-              style={{ fontVariationSettings: "'FILL' 0" }}
+          <div className="flex items-center gap-2 print:hidden">
+            <ChunkyButton
+              variant="secondary"
+              size="sm"
+              onClick={() => window.print()}
+              title="Print this story"
             >
-              autorenew
-            </span>
-            <span className="hidden sm:inline">Regenerate All</span>
-          </ChunkyButton>
+              <span
+                className="material-symbols-outlined text-[16px]"
+                style={{ fontVariationSettings: "'FILL' 0" }}
+              >
+                print
+              </span>
+              <span className="hidden sm:inline">Print</span>
+            </ChunkyButton>
+            <ChunkyButton
+              variant="secondary"
+              size="sm"
+              onClick={handleRegenerateAll}
+              disabled={isRegeneratingAll || isRevising}
+              title="Regenerate the entire story from scratch"
+            >
+              <span
+                className={`material-symbols-outlined text-[16px] ${isRegeneratingAll ? 'animate-spin' : ''}`}
+                style={{ fontVariationSettings: "'FILL' 0" }}
+              >
+                autorenew
+              </span>
+              <span className="hidden sm:inline">Regenerate All</span>
+            </ChunkyButton>
+          </div>
         </div>
       </div>
 
-      {/* Page navigation header */}
-      <div className="flex items-center justify-between gap-4 px-1">
-        <ChunkyButton
-          variant="secondary"
-          onClick={goToPrevPage}
-          disabled={currentPageIndex === 0}
-          aria-label="Previous page"
-        >
-          <span className="material-symbols-outlined">chevron_left</span>
-          <span className="hidden sm:inline ml-1">Previous</span>
-        </ChunkyButton>
-
-        <span className="font-body text-body-md text-on-surface-variant whitespace-nowrap">
-          Page {currentPageIndex + 1} of {totalPages}
-        </span>
-
-        <ChunkyButton
-          variant="secondary"
-          onClick={goToNextPage}
-          disabled={currentPageIndex === totalPages - 1}
-          aria-label="Next page"
-        >
-          <span className="hidden sm:inline mr-1">Next</span>
-          <span className="material-symbols-outlined">chevron_right</span>
-        </ChunkyButton>
-      </div>
-
-      {/* Page canvas */}
-      <div className="max-w-2xl mx-auto w-full">
-        <StoryPageRenderer
-          page={currentPage}
-          pageIndex={currentPageIndex}
-          illustrationUrls={illustrationUrls}
-          isComicStyle={isComicStyle}
-          editingPanel={editingPanel}
-          regeneratingPanels={regeneratingPanels}
-          onEditPanel={handleEditPanel}
-          onSavePanel={handleSavePanel}
-          onCancelEdit={() => setEditingPanel(null)}
-          onRegenerateIllustration={handleRegenerateIllustration}
-        />
-      </div>
-
-      {/* Revision prompt bar */}
-      <div className="max-w-2xl mx-auto w-full bg-surface-container-high p-4 rounded-xl space-y-3">
-        <p className="font-body text-body-sm text-on-surface-variant">
-          Describe a revision to apply to the whole story (e.g., &ldquo;make it funnier&rdquo;, &ldquo;add a dragon to page 3&rdquo;):
-        </p>
-        <form onSubmit={handleReviseSubmit} className="flex gap-2">
-          <Input
-            value={revisionPrompt}
-            onChange={e => setRevisionPrompt(e.target.value)}
-            placeholder="e.g., make the ending more dramatic…"
-            disabled={isRevising}
-            className="flex-1"
-          />
+      {/* Interactive carousel — hidden during print */}
+      <div className="print:hidden">
+        {/* Page navigation header */}
+        <div className="flex items-center justify-between gap-4 px-1">
           <ChunkyButton
-            type="submit"
-            variant="primary"
-            size="md"
-            disabled={isRevising || !revisionPrompt.trim()}
+            variant="secondary"
+            onClick={goToPrevPage}
+            disabled={currentPageIndex === 0}
+            aria-label="Previous page"
           >
-            {isRevising ? (
-              <>
-                <span
-                  className="material-symbols-outlined text-[16px] animate-spin"
-                  style={{ fontVariationSettings: "'FILL' 0" }}
-                >
-                  refresh
-                </span>
-                <span className="hidden sm:inline">Revising…</span>
-              </>
-            ) : (
-              <>
-                <span
-                  className="material-symbols-outlined text-[16px]"
-                  style={{ fontVariationSettings: "'FILL' 0" }}
-                >
-                  auto_fix_high
-                </span>
-                <span className="hidden sm:inline">Revise</span>
-              </>
-            )}
+            <span className="material-symbols-outlined">chevron_left</span>
+            <span className="hidden sm:inline ml-1">Previous</span>
           </ChunkyButton>
-        </form>
-        {revisionError && (
-          <p className="font-body text-body-sm text-ds-error">{revisionError}</p>
-        )}
+
+          <span className="font-body text-body-md text-on-surface-variant whitespace-nowrap">
+            Page {currentPageIndex + 1} of {totalPages}
+          </span>
+
+          <ChunkyButton
+            variant="secondary"
+            onClick={goToNextPage}
+            disabled={currentPageIndex === totalPages - 1}
+            aria-label="Next page"
+          >
+            <span className="hidden sm:inline mr-1">Next</span>
+            <span className="material-symbols-outlined">chevron_right</span>
+          </ChunkyButton>
+        </div>
+
+        {/* Page canvas */}
+        <div className="max-w-2xl mx-auto w-full mt-4">
+          <StoryPageRenderer
+            page={currentPage}
+            pageIndex={currentPageIndex}
+            illustrationUrls={illustrationUrls}
+            isComicStyle={isComicStyle}
+            editingPanel={editingPanel}
+            regeneratingPanels={regeneratingPanels}
+            onEditPanel={handleEditPanel}
+            onSavePanel={handleSavePanel}
+            onCancelEdit={() => setEditingPanel(null)}
+            onRegenerateIllustration={handleRegenerateIllustration}
+          />
+        </div>
       </div>
 
-      {/* Bottom navigation */}
-      <div className="flex items-center justify-between gap-4 px-1">
-        <ChunkyButton
-          variant="secondary"
-          onClick={goToPrevPage}
-          disabled={currentPageIndex === 0}
-          aria-label="Previous page"
-        >
-          <span className="material-symbols-outlined">chevron_left</span>
-          <span className="hidden sm:inline ml-1">Previous</span>
-        </ChunkyButton>
+      {/* Print-only: all pages rendered continuously */}
+      <div className="hidden print:block">
+        {/* Cover/title */}
+        <div className="text-center mb-8">
+          <h1 className="font-headline text-4xl text-on-surface">{layout.title}</h1>
+          <p className="font-body text-body-md text-on-surface-variant capitalize mt-2">
+            {layout.type} &middot; {totalPages} {totalPages === 1 ? 'page' : 'pages'}
+          </p>
+        </div>
+        {pages.map((page, pageIndex) => {
+          const isComicGrid = page.layout === 'comic-grid'
+          const pageStyle: React.CSSProperties = {}
+          if (page.backgroundColor) {
+            pageStyle.backgroundColor = page.backgroundColor
+          } else {
+            pageStyle.backgroundColor = isComicStyle ? '#ffffff' : '#faf7f2'
+          }
+          const pageBorderClass = isComicGrid
+            ? 'border-[4px] border-black'
+            : isComicStyle
+              ? 'border-[3px] border-black'
+              : 'border border-black/10 rounded-lg'
 
-        <span className="font-body text-body-sm text-on-surface-variant whitespace-nowrap">
-          Page {currentPageIndex + 1} of {totalPages}
-        </span>
-
-        <ChunkyButton
-          variant="secondary"
-          onClick={goToNextPage}
-          disabled={currentPageIndex === totalPages - 1}
-          aria-label="Next page"
-        >
-          <span className="hidden sm:inline mr-1">Next</span>
-          <span className="material-symbols-outlined">chevron_right</span>
-        </ChunkyButton>
+          return (
+            <div key={pageIndex} className="print-story-page">
+              <div
+                className={`relative w-full aspect-[3/4] overflow-hidden ${pageBorderClass}`}
+                style={pageStyle}
+              >
+                {page.panels.map((panel, panelIndex) => (
+                  <ReadOnlyPanelRenderer
+                    key={panelIndex}
+                    panel={panel}
+                    panelIndex={panelIndex}
+                    page={page}
+                    illustrationUrls={illustrationUrls}
+                    isComicStyle={isComicStyle}
+                  />
+                ))}
+              </div>
+            </div>
+          )
+        })}
       </div>
 
-      {/* Back to start */}
-      <div className="flex justify-start pb-8">
-        <ChunkyButton variant="secondary" onClick={onPrevious}>
-          <span className="material-symbols-outlined mr-2">arrow_back</span>
-          Back to Generation
-        </ChunkyButton>
+      {/* Interactive controls — hidden during print */}
+      <div className="print:hidden space-y-6">
+        {/* Revision prompt bar */}
+        <div className="max-w-2xl mx-auto w-full bg-surface-container-high p-4 rounded-xl space-y-3">
+          <p className="font-body text-body-sm text-on-surface-variant">
+            Describe a revision to apply to the whole story (e.g., &ldquo;make it funnier&rdquo;, &ldquo;add a dragon to page 3&rdquo;):
+          </p>
+          <form onSubmit={handleReviseSubmit} className="flex gap-2">
+            <Input
+              value={revisionPrompt}
+              onChange={e => setRevisionPrompt(e.target.value)}
+              placeholder="e.g., make the ending more dramatic…"
+              disabled={isRevising}
+              className="flex-1"
+            />
+            <ChunkyButton
+              type="submit"
+              variant="primary"
+              size="md"
+              disabled={isRevising || !revisionPrompt.trim()}
+            >
+              {isRevising ? (
+                <>
+                  <span
+                    className="material-symbols-outlined text-[16px] animate-spin"
+                    style={{ fontVariationSettings: "'FILL' 0" }}
+                  >
+                    refresh
+                  </span>
+                  <span className="hidden sm:inline">Revising…</span>
+                </>
+              ) : (
+                <>
+                  <span
+                    className="material-symbols-outlined text-[16px]"
+                    style={{ fontVariationSettings: "'FILL' 0" }}
+                  >
+                    auto_fix_high
+                  </span>
+                  <span className="hidden sm:inline">Revise</span>
+                </>
+              )}
+            </ChunkyButton>
+          </form>
+          {revisionError && (
+            <p className="font-body text-body-sm text-ds-error">{revisionError}</p>
+          )}
+        </div>
+
+        {/* Bottom navigation */}
+        <div className="flex items-center justify-between gap-4 px-1">
+          <ChunkyButton
+            variant="secondary"
+            onClick={goToPrevPage}
+            disabled={currentPageIndex === 0}
+            aria-label="Previous page"
+          >
+            <span className="material-symbols-outlined">chevron_left</span>
+            <span className="hidden sm:inline ml-1">Previous</span>
+          </ChunkyButton>
+
+          <span className="font-body text-body-sm text-on-surface-variant whitespace-nowrap">
+            Page {currentPageIndex + 1} of {totalPages}
+          </span>
+
+          <ChunkyButton
+            variant="secondary"
+            onClick={goToNextPage}
+            disabled={currentPageIndex === totalPages - 1}
+            aria-label="Next page"
+          >
+            <span className="hidden sm:inline mr-1">Next</span>
+            <span className="material-symbols-outlined">chevron_right</span>
+          </ChunkyButton>
+        </div>
+
+        {/* Back to start */}
+        <div className="flex justify-start pb-8">
+          <ChunkyButton variant="secondary" onClick={onPrevious}>
+            <span className="material-symbols-outlined mr-2">arrow_back</span>
+            Back to Generation
+          </ChunkyButton>
+        </div>
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary

- Adds a **Print button** (Material Symbols `print` icon + "Print" label) in the story header next to "Regenerate All", using `ChunkyButton` with secondary variant; calls `window.print()` on click
- Adds a **print-only continuous view** (`hidden print:block`) that renders all story pages sequentially using a new `ReadOnlyPanelRenderer` — no edit buttons, no hover effects, no regenerate controls; includes a cover title block on the first page
- Wraps the interactive carousel, revision bar, and navigation controls in `print:hidden` so they are suppressed during printing
- The buttons in the header (Print + Regenerate All) are also `print:hidden`
- Adds an `@media print` block to `globals.css` for page breaks (`break-after: page` via `.print-story-page`), `body` background/color reset, and suppression of shadows, transitions, and animations

## Test plan

- [ ] Open Storybook Factory, generate a story, reach Step 4 Review & Revise
- [ ] Confirm "Print" button appears in header next to "Regenerate All"
- [ ] Click Print — browser print dialog opens
- [ ] In print preview: all story pages appear continuously (not carousel), title and type badge visible at top, no navigation/edit/revision UI visible
- [ ] Each story page breaks to a new print page
- [ ] Images render correctly in print preview
- [ ] Comic-style and storybook-style stories both render with correct borders/backgrounds
- [ ] `npx tsc --noEmit` passes with no errors

Closes #1656

🤖 Generated with [Claude Code](https://claude.com/claude-code)