### PR TITLE
fix: add Try Again and Go Back buttons to game over view

### DIFF
--- a/src/app/comet-cards/components/game-views/game-over.tsx
+++ b/src/app/comet-cards/components/game-views/game-over.tsx
@@ -3,12 +3,13 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { motion, useReducedMotion } from 'framer-motion'
 
-import { PrimaryButton } from '@/app/comet-cards/components/cosmic/buttons'
+import { GhostButton, PrimaryButton } from '@/app/comet-cards/components/cosmic/buttons'
 import { Panel } from '@/app/comet-cards/components/cosmic/panel'
 import { MiniScoringLog } from '@/app/comet-cards/components/mini-scoring-log'
 import { useGameState } from '@/app/comet-cards/useGameState'
 import { useLandscapeMobile } from '@/app/comet-cards/hooks/useLandscapeMobile'
 import { useRunHistory } from '@/app/comet-cards/hooks/useRunHistory'
+import { eventEmitter } from '@/app/comet-cards/domain/events/event-emitter'
 
 import { ViewTemplate } from './view-template'
 
@@ -275,6 +276,14 @@ export function GameOverView() {
                   : roundsCompleted >= 4
                     ? 'So close. Can you thread the needle tomorrow?'
                     : 'The cave awaits your return. Tomorrow brings fresh cards.'}
+              </div>
+              <div className="flex items-center justify-center" style={{ gap: 12, marginTop: 16 }}>
+                <PrimaryButton onClick={() => eventEmitter.emit({ type: 'GAME_START' })}>
+                  Try Again
+                </PrimaryButton>
+                <GhostButton onClick={() => eventEmitter.emit({ type: 'BACK_TO_MAIN_MENU' })}>
+                  Go Back
+                </GhostButton>
               </div>
             </FadeUp>
           </div>


### PR DESCRIPTION
## Summary
- Added **Try Again** (`PrimaryButton`) button that emits `GAME_START` via the event emitter
- Added **Go Back** (`GhostButton`) button that emits `BACK_TO_MAIN_MENU` via the event emitter
- Buttons are placed in a flex row after the existing Share Score button area in the game-over view

## Test plan
- [ ] Play a game to completion (or reach game over state) and verify both buttons appear
- [ ] Click "Try Again" — should start a new game
- [ ] Click "Go Back" — should return to the main menu
- [ ] Verify existing "Share Score" button still works correctly

Closes #1672

🤖 Generated with [Claude Code](https://claude.com/claude-code)