### PR TITLE
feat: use Web Share API on mobile for score sharing

### DIFF
--- a/src/app/comet-cards/components/game-views/game-over.tsx
+++ b/src/app/comet-cards/components/game-views/game-over.tsx
@@ -90,6 +90,14 @@ export function GameOverView() {
   }, [didWin, game.handsPlayed, game.gameSeed, game.totalScore, roundsCompleted, totalRounds])
 
   const onShare = useCallback(async () => {
+    if (navigator.share) {
+      try {
+        await navigator.share({ text: shareText })
+        return
+      } catch {
+        // User cancelled or share failed — fall through to clipboard
+      }
+    }
     try {
       await copyToClipboard(shareText)
       setHasCopied(true)


### PR DESCRIPTION
Use the native Web Share API on mobile devices for sharing scores, with graceful fallback to clipboard copy.

## Changes
- Updated the `onShare` callback in the game-over view to try `navigator.share` first
- Falls back to the existing clipboard copy behavior if the API is unavailable or user cancels
- No breaking changes; maintains current UX for desktop and unsupported browsers

## Testing
- Verified TypeScript builds with no errors
- Manual testing on mobile devices to confirm native share sheet appears