### PR TITLE
feat: mystical empty state for first-time players

### DIFF
--- a/src/app/comet-cards/components/game-views/main-menu.tsx
+++ b/src/app/comet-cards/components/game-views/main-menu.tsx
@@ -153,6 +153,21 @@ export function MainMenuView() {
         </>
       )}
 
+      {history.runs.length === 0 && (
+        <div
+          style={{
+            fontFamily: 'var(--cc-font-mono)',
+            fontSize: 11,
+            opacity: 0.4,
+            letterSpacing: 1,
+            textAlign: 'center',
+            lineHeight: 1.6,
+          }}
+        >
+          Your first hand awaits. The cave remembers every run.
+        </div>
+      )}
+
       {history.runs.length > 0 && (
         <div
           className="flex items-center justify-center gap-6"


### PR DESCRIPTION
## Summary
- First-time visitors see "Your first hand awaits. The cave remembers every run." on the main menu where returning players see their stats
- Cosmic-narrator voice per UX principle #4
- Hand-crafted empty state per UX principle #7

## Test plan
- [ ] Load main menu with no run history — verify empty state text appears
- [ ] Complete a run — verify stats replace the empty state text

🤖 Generated with [Claude Code](https://claude.com/claude-code)