### PR TITLE
feat: Speck Wars scaffold — route, page, and GameInstance skeleton

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -18,6 +18,7 @@ const games: readonly { title: string; icon: string; href: string; description: 
   { title: 'Chat Room of Infinity', icon: 'chat', href: ROUTE_CONSTANTS.CHAT_ROOM, description: 'Chat with fictional characters in a chat room' },
   { title: 'Avatar Maker', icon: 'face', href: ROUTE_CONSTANTS.AVATAR_MAKER, description: 'Create unique AI-powered avatars from your photos' },
   { title: 'Storybook Factory', icon: 'auto_stories', href: ROUTE_CONSTANTS.STORYBOOK_FACTORY, description: 'Create illustrated comic books and storybooks from your pictures' },
+  { title: 'Speck Wars', icon: 'bug_report', href: ROUTE_CONSTANTS.SPECK_WARS, description: 'Command your specks to capture enemy bases in this real-time strategy micro-battle' },
 ]
 
 export default function Home() {

--- a/src/app/route-constants.ts
+++ b/src/app/route-constants.ts
@@ -12,4 +12,5 @@ export const ROUTE_CONSTANTS = {
   STARMATCH: '/starmatch',
   COMET_CARDS: '/comet-cards',
   STORYBOOK_FACTORY: '/storybook-factory',
+  SPECK_WARS: '/speck-wars',
 }

--- a/src/app/speck-wars/SpeckWarsGame.tsx
+++ b/src/app/speck-wars/SpeckWarsGame.tsx
@@ -1,0 +1,42 @@
+'use client'
+
+import { useEffect, useRef } from 'react'
+import { GameInstance } from './game-instance'
+
+export function SpeckWarsGame() {
+  const canvasRef = useRef<HTMLCanvasElement>(null)
+
+  useEffect(() => {
+    const canvas = canvasRef.current
+    if (!canvas) return
+
+    const game = new GameInstance(canvas)
+    game.start()
+
+    return () => {
+      game.destroy()
+    }
+  }, [])
+
+  return (
+    <div style={{ position: 'relative', width: '100%', height: '100%' }}>
+      <canvas
+        ref={canvasRef}
+        style={{ display: 'block', width: '100%', height: '100%' }}
+      />
+      <div
+        style={{
+          position: 'absolute',
+          top: 16,
+          left: 16,
+          color: 'rgba(255,255,255,0.8)',
+          fontSize: 24,
+          fontWeight: 'bold',
+          pointerEvents: 'none',
+        }}
+      >
+        Speck Wars
+      </div>
+    </div>
+  )
+}

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -1,0 +1,29 @@
+export class GameInstance {
+  private canvas: HTMLCanvasElement
+  private rafId: number | null = null
+  private tickCount = 0
+
+  constructor(canvas: HTMLCanvasElement) {
+    this.canvas = canvas
+  }
+
+  start() {
+    console.log('GameInstance started')
+    const loop = () => {
+      this.tickCount++
+      if (this.tickCount % 60 === 0) {
+        console.log(`GameInstance tick: ${this.tickCount}`)
+      }
+      this.rafId = requestAnimationFrame(loop)
+    }
+    this.rafId = requestAnimationFrame(loop)
+  }
+
+  destroy() {
+    if (this.rafId !== null) {
+      cancelAnimationFrame(this.rafId)
+      this.rafId = null
+    }
+    console.log('GameInstance destroyed')
+  }
+}

--- a/src/app/speck-wars/page.tsx
+++ b/src/app/speck-wars/page.tsx
@@ -1,0 +1,14 @@
+'use client'
+
+import { CosmicShell } from '../comet-cards/components/cosmic/shell'
+import { SpeckWarsGame } from './SpeckWarsGame'
+
+export default function SpeckWarsPage() {
+  return (
+    <CosmicShell>
+      <div style={{ position: 'relative', width: '100%', height: '100%' }}>
+        <SpeckWarsGame />
+      </div>
+    </CosmicShell>
+  )
+}

--- a/src/app/speck-wars/store.ts
+++ b/src/app/speck-wars/store.ts
@@ -1,0 +1,13 @@
+import { create } from 'zustand'
+
+type GamePhase = 'menu' | 'playing' | 'paused' | 'victory' | 'defeat'
+
+interface SpeckWarsStore {
+  phase: GamePhase
+  setPhase: (phase: GamePhase) => void
+}
+
+export const useSpeckWarsStore = create<SpeckWarsStore>()(set => ({
+  phase: 'menu',
+  setPhase: phase => set({ phase }),
+}))


### PR DESCRIPTION
## Summary
- Adds `SPECK_WARS: '/speck-wars'` route constant and home page game grid entry
- Creates `/speck-wars` page wrapped in `CosmicShell`
- `SpeckWarsGame` component mounts a `<canvas>` and runs `GameInstance` lifecycle via `useEffect`
- `GameInstance` class has a `requestAnimationFrame` stub that logs tick count every 60 ticks
- Minimal Zustand store (`phase: GamePhase`, `setPhase`) for future phase routing

No simulation, no PixiJS, no game logic — skeleton only per issue spec.

Closes #1683

## Test plan
- [ ] `/speck-wars` loads without errors
- [ ] Canvas element fills the CosmicShell
- [ ] Console shows "GameInstance started" on load and tick logs every ~1s
- [ ] Speck Wars appears in the home page game grid
- [ ] TypeScript compiles clean (`npx tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)