### PR TITLE
feat: Speck Wars domain types, constants, and config registries

### DIFF
--- a/src/app/speck-wars/domain/config/building-types.ts
+++ b/src/app/speck-wars/domain/config/building-types.ts
@@ -1,0 +1,16 @@
+export interface BuildingTypeDefinition {
+  id: string; name: string
+  maxHp: number; size: number
+  spawnTypeId: string | null
+  spawnInterval: number; spawnCount: number
+  cost?: Array<{ typeId: string; count: number }>
+}
+
+export const BUILDING_TYPES: Record<string, BuildingTypeDefinition> = {
+  base: {
+    id: 'base', name: 'Base',
+    maxHp: 100, size: 40,
+    spawnTypeId: 'basic',
+    spawnInterval: 800, spawnCount: 1,
+  },
+}

--- a/src/app/speck-wars/domain/config/recipes.ts
+++ b/src/app/speck-wars/domain/config/recipes.ts
@@ -1,0 +1,11 @@
+export interface CombineRecipe {
+  id: string
+  inputs: Array<{ typeId: string; count: number }>
+  output:
+    | { kind: 'specks'; typeId: string; count: number }
+    | { kind: 'building'; buildingTypeId: string }
+    | { kind: 'upgrade'; stat: string; delta: number; target: 'all' | string }
+  location: 'anywhere' | string
+}
+
+export const RECIPES: CombineRecipe[] = []  // populated as new types added

--- a/src/app/speck-wars/domain/config/speck-types.ts
+++ b/src/app/speck-wars/domain/config/speck-types.ts
@@ -1,0 +1,18 @@
+export interface SpeckTypeDefinition {
+  id: string; name: string
+  hp: number; damage: number; speed: number
+  attackRange: number; attackCooldown: number
+  size: number; productionTime: number
+  abilities: string[]
+  recipe?: { inputs: Array<{ typeId: string; count: number }>; location: string }
+}
+
+export const SPECK_TYPES: Record<string, SpeckTypeDefinition> = {
+  basic: {
+    id: 'basic', name: 'Speck',
+    hp: 1, damage: 1, speed: 80,
+    attackRange: 6, attackCooldown: 500,
+    size: 3, productionTime: 800,
+    abilities: [],
+  },
+}

--- a/src/app/speck-wars/domain/constants.ts
+++ b/src/app/speck-wars/domain/constants.ts
@@ -1,0 +1,14 @@
+export const WORLD_WIDTH = 3000
+export const WORLD_HEIGHT = 3000
+export const GRID_CELL_SIZE = 100
+export const GRID_COLS = Math.ceil(WORLD_WIDTH / GRID_CELL_SIZE)
+export const GRID_ROWS = Math.ceil(WORLD_HEIGHT / GRID_CELL_SIZE)
+export const HUD_UPDATE_INTERVAL = 10    // ticks
+export const BASE_HP = 100
+export const BASE_SIZE = 40
+export const PLAYER_BASE_X = 600
+export const PLAYER_BASE_Y = 1500
+export const AI_BASE_X = 2400
+export const AI_BASE_Y = 1500
+export const PLAYER_COLOR = 0x4af7c4
+export const AI_COLOR = 0xff4f7b

--- a/src/app/speck-wars/domain/types.ts
+++ b/src/app/speck-wars/domain/types.ts
@@ -1,0 +1,68 @@
+export interface SpeckMeta {
+  id: string
+  typeId: string
+  ownerId: string
+  state: 'idle' | 'moving' | 'attacking' | 'carrying' | 'sacrificing'
+  targetId: string | null
+  attackCooldown: number   // ms remaining until next attack
+}
+
+export interface BuildingEntity {
+  id: string
+  typeId: string
+  ownerId: string
+  x: number; y: number
+  hp: number; maxHp: number
+  spawnTimer: number       // ms until next spawn
+  inputBuffer: Record<string, number>  // typeId → count (sacrifice system, future)
+}
+
+export interface Player {
+  id: string
+  name: string
+  color: number            // pixi hex e.g. 0x4af7c4
+  isAI: boolean
+  isDefeated: boolean
+  stockpile: Record<string, number>  // typeId → count (resource form)
+}
+
+// SOA (Structure of Arrays) for hot speck data — cache-friendly for tight loops
+export interface SimulationState {
+  tick: number
+  rngState: number
+
+  players: Record<string, Player>
+  buildings: Record<string, BuildingEntity>
+
+  speckIds: string[]
+  speckX: Float32Array
+  speckY: Float32Array
+  speckVx: Float32Array
+  speckVy: Float32Array
+  speckHp: Float32Array
+  speckMeta: SpeckMeta[]   // parallel to speckIds
+
+  inputQueue: InputEvent[]
+  events: SimEvent[]
+}
+
+export type InputEvent =
+  | { type: 'RALLY'; ownerId: string; x: number; y: number }
+  | { type: 'BUILD'; ownerId: string; buildingTypeId: string; x: number; y: number }
+  | { type: 'SACRIFICE'; ownerId: string; buildingId: string; typeId: string; count: number }
+
+export type SimEvent =
+  | { type: 'SPECK_DIED'; speckId: string; x: number; y: number }
+  | { type: 'BUILDING_DAMAGED'; buildingId: string; hp: number }
+  | { type: 'BUILDING_DESTROYED'; buildingId: string; ownerId: string }
+  | { type: 'SPECK_SPAWNED'; speckId: string; buildingId: string }
+  | { type: 'GAME_OVER'; winnerId: string }
+  | { type: 'HUD_UPDATE'; data: HudData }
+
+export interface HudData {
+  players: Record<string, {
+    speckCount: number
+    buildingCount: number
+    buildingHp: Record<string, number>
+  }>
+}


### PR DESCRIPTION
## Summary
- Adds all TypeScript interfaces and data-driven config for Speck Wars
- `domain/types.ts`: `SpeckMeta`, `BuildingEntity`, `Player`, `SimulationState` (SOA layout), `InputEvent`, `SimEvent`, `HudData`
- `domain/constants.ts`: world dimensions (3000×3000), grid cell size, base positions, player colors
- `domain/config/speck-types.ts`: `SpeckTypeDefinition` interface + `SPECK_TYPES` registry (basic speck seed)
- `domain/config/building-types.ts`: `BuildingTypeDefinition` interface + `BUILDING_TYPES` registry (base building seed)
- `domain/config/recipes.ts`: `CombineRecipe` interface + empty `RECIPES` array

Pure types and plain data — no runtime logic. TypeScript compiles clean.

Closes #1684

## Test plan
- [ ] `npx tsc --noEmit` passes with zero errors
- [ ] All types are exportable and importable by subsequent Speck Wars modules

🤖 Generated with [Claude Code](https://claude.com/claude-code)