### PR TITLE
feat: Speck Wars SimulationState factory + spatial grid

### DIFF
--- a/src/app/speck-wars/domain/simulation/create-sim.ts
+++ b/src/app/speck-wars/domain/simulation/create-sim.ts
@@ -1,0 +1,50 @@
+import type { SimulationState, Player, BuildingEntity } from '../types'
+import { PLAYER_BASE_X, PLAYER_BASE_Y, AI_BASE_X, AI_BASE_Y, PLAYER_COLOR, AI_COLOR, BASE_HP } from '../constants'
+import { SpatialGrid } from './spatial-grid'
+
+export function createSim(seed: number = Date.now()): SimulationState {
+  const playerBase: BuildingEntity = {
+    id: 'building-player-base',
+    typeId: 'base',
+    ownerId: 'player',
+    x: PLAYER_BASE_X, y: PLAYER_BASE_Y,
+    hp: BASE_HP, maxHp: BASE_HP,
+    spawnTimer: 0,
+    inputBuffer: {},
+  }
+  const aiBase: BuildingEntity = {
+    id: 'building-ai-base',
+    typeId: 'base',
+    ownerId: 'ai',
+    x: AI_BASE_X, y: AI_BASE_Y,
+    hp: BASE_HP, maxHp: BASE_HP,
+    spawnTimer: 0,
+    inputBuffer: {},
+  }
+
+  const player: Player = {
+    id: 'player', name: 'Player',
+    color: PLAYER_COLOR, isAI: false, isDefeated: false, stockpile: {},
+  }
+  const ai: Player = {
+    id: 'ai', name: 'AI',
+    color: AI_COLOR, isAI: true, isDefeated: false, stockpile: {},
+  }
+
+  return {
+    tick: 0,
+    rngState: seed,
+    players: { player, ai },
+    buildings: { 'building-player-base': playerBase, 'building-ai-base': aiBase },
+    speckIds: [],
+    speckX: new Float32Array(0),
+    speckY: new Float32Array(0),
+    speckVx: new Float32Array(0),
+    speckVy: new Float32Array(0),
+    speckHp: new Float32Array(0),
+    speckMeta: [],
+    inputQueue: [],
+    events: [],
+    spatialGrid: new SpatialGrid(),
+  }
+}

--- a/src/app/speck-wars/domain/simulation/prng.ts
+++ b/src/app/speck-wars/domain/simulation/prng.ts
@@ -1,0 +1,9 @@
+// mulberry32 — fast, deterministic, good enough for game simulation
+export function mulberry32(seed: number) {
+  return function(): number {
+    seed |= 0; seed = seed + 0x6D2B79F5 | 0
+    let z = Math.imul(seed ^ (seed >>> 15), 1 | seed)
+    z = z + Math.imul(z ^ (z >>> 7), 61 | z) ^ z
+    return ((z ^ (z >>> 14)) >>> 0) / 4294967296
+  }
+}

--- a/src/app/speck-wars/domain/simulation/spatial-grid.ts
+++ b/src/app/speck-wars/domain/simulation/spatial-grid.ts
@@ -1,0 +1,37 @@
+import { GRID_COLS, GRID_ROWS, GRID_CELL_SIZE } from '../constants'
+
+export class SpatialGrid {
+  // cells[cellIndex] = array of speck array indices
+  private cells: number[][]
+
+  constructor() {
+    this.cells = Array.from({ length: GRID_COLS * GRID_ROWS }, () => [])
+  }
+
+  clear() {
+    for (const cell of this.cells) cell.length = 0
+  }
+
+  insert(i: number, x: number, y: number) {
+    const col = Math.floor(x / GRID_CELL_SIZE)
+    const row = Math.floor(y / GRID_CELL_SIZE)
+    if (col < 0 || col >= GRID_COLS || row < 0 || row >= GRID_ROWS) return
+    this.cells[row * GRID_COLS + col].push(i)
+  }
+
+  // Returns array indices of all specks in the cell at (x,y) and 8 neighbors
+  query(x: number, y: number): number[] {
+    const col = Math.floor(x / GRID_CELL_SIZE)
+    const row = Math.floor(y / GRID_CELL_SIZE)
+    const results: number[] = []
+    for (let dr = -1; dr <= 1; dr++) {
+      for (let dc = -1; dc <= 1; dc++) {
+        const c = col + dc, r = row + dr
+        if (c < 0 || c >= GRID_COLS || r < 0 || r >= GRID_ROWS) continue
+        const cell = this.cells[r * GRID_COLS + c]
+        for (const idx of cell) results.push(idx)
+      }
+    }
+    return results
+  }
+}

--- a/src/app/speck-wars/domain/types.ts
+++ b/src/app/speck-wars/domain/types.ts
@@ -1,3 +1,5 @@
+import type { SpatialGrid } from './simulation/spatial-grid'
+
 export interface SpeckMeta {
   id: string
   typeId: string
@@ -44,6 +46,7 @@ export interface SimulationState {
 
   inputQueue: InputEvent[]
   events: SimEvent[]
+  spatialGrid: SpatialGrid
 }
 
 export type InputEvent =


### PR DESCRIPTION
## Summary
- `SpatialGrid`: flat-array cell grid dividing the 3000×3000 world into 100px cells, O(1) insert and 9-cell neighbor queries
- `createSim(seed?)`: builds initial `SimulationState` with player/AI players, two base buildings, empty SOA speck arrays, and a fresh `SpatialGrid`
- `mulberry32`: deterministic PRNG for reproducible simulation randomness
- Updated `SimulationState` type to include `spatialGrid: SpatialGrid`

Closes #1685

## Test plan
- [ ] `createSim()` returns state with 2 buildings, 0 specks
- [ ] `SpatialGrid.query()` returns correct neighbors for edge cells
- [ ] `npx tsc --noEmit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)