### PR TITLE
feat: Speck Wars speck AI targeting + movement with separation

### DIFF
--- a/src/app/speck-wars/domain/simulation/create-sim.ts
+++ b/src/app/speck-wars/domain/simulation/create-sim.ts
@@ -1,0 +1,50 @@
+import type { SimulationState, Player, BuildingEntity } from '../types'
+import { PLAYER_BASE_X, PLAYER_BASE_Y, AI_BASE_X, AI_BASE_Y, PLAYER_COLOR, AI_COLOR, BASE_HP } from '../constants'
+import { SpatialGrid } from './spatial-grid'
+
+export function createSim(seed: number = Date.now()): SimulationState {
+  const playerBase: BuildingEntity = {
+    id: 'building-player-base',
+    typeId: 'base',
+    ownerId: 'player',
+    x: PLAYER_BASE_X, y: PLAYER_BASE_Y,
+    hp: BASE_HP, maxHp: BASE_HP,
+    spawnTimer: 0,
+    inputBuffer: {},
+  }
+  const aiBase: BuildingEntity = {
+    id: 'building-ai-base',
+    typeId: 'base',
+    ownerId: 'ai',
+    x: AI_BASE_X, y: AI_BASE_Y,
+    hp: BASE_HP, maxHp: BASE_HP,
+    spawnTimer: 0,
+    inputBuffer: {},
+  }
+
+  const player: Player = {
+    id: 'player', name: 'Player',
+    color: PLAYER_COLOR, isAI: false, isDefeated: false, stockpile: {},
+  }
+  const ai: Player = {
+    id: 'ai', name: 'AI',
+    color: AI_COLOR, isAI: true, isDefeated: false, stockpile: {},
+  }
+
+  return {
+    tick: 0,
+    rngState: seed,
+    players: { player, ai },
+    buildings: { 'building-player-base': playerBase, 'building-ai-base': aiBase },
+    speckIds: [],
+    speckX: new Float32Array(0),
+    speckY: new Float32Array(0),
+    speckVx: new Float32Array(0),
+    speckVy: new Float32Array(0),
+    speckHp: new Float32Array(0),
+    speckMeta: [],
+    inputQueue: [],
+    events: [],
+    spatialGrid: new SpatialGrid(),
+  }
+}

--- a/src/app/speck-wars/domain/simulation/movement.ts
+++ b/src/app/speck-wars/domain/simulation/movement.ts
@@ -1,0 +1,61 @@
+import type { SimulationState } from '../types'
+import { SPECK_TYPES } from '../config/speck-types'
+import { WORLD_WIDTH, WORLD_HEIGHT } from '../constants'
+
+const SEPARATION_RADIUS = 8   // px — keep specks this far apart
+const SEPARATION_FORCE = 120  // strength of push-apart
+
+export function moveSpecks(sim: SimulationState, dt: number) {
+  const { speckIds, speckX, speckY, speckVx, speckVy, speckMeta, buildings, spatialGrid } = sim
+  const dtSec = dt / 1000
+
+  // Rebuild grid with current positions before applying separation
+  spatialGrid.clear()
+  for (let i = 0; i < speckIds.length; i++) {
+    spatialGrid.insert(i, speckX[i], speckY[i])
+  }
+
+  for (let i = 0; i < speckIds.length; i++) {
+    const meta = speckMeta[i]
+    const stype = SPECK_TYPES[meta.typeId]
+    if (!stype) continue
+
+    let ax = 0, ay = 0
+
+    // Seek target
+    if (meta.targetId) {
+      const target = buildings[meta.targetId]
+      if (target) {
+        const dx = target.x - speckX[i]
+        const dy = target.y - speckY[i]
+        const dist = Math.sqrt(dx * dx + dy * dy)
+        if (dist > stype.attackRange) {
+          ax += (dx / dist) * stype.speed
+          ay += (dy / dist) * stype.speed
+        }
+      }
+    }
+
+    // Separation from nearby specks (same owner to avoid interleaving)
+    const neighbors = spatialGrid.query(speckX[i], speckY[i])
+    for (const j of neighbors) {
+      if (i === j) continue
+      const dx = speckX[i] - speckX[j]
+      const dy = speckY[i] - speckY[j]
+      const dist = Math.sqrt(dx * dx + dy * dy)
+      if (dist < SEPARATION_RADIUS && dist > 0) {
+        const force = (SEPARATION_RADIUS - dist) / SEPARATION_RADIUS * SEPARATION_FORCE
+        ax += (dx / dist) * force
+        ay += (dy / dist) * force
+      }
+    }
+
+    // Simple velocity (no mass — direct velocity override)
+    speckVx[i] = ax
+    speckVy[i] = ay
+
+    // Integrate position
+    speckX[i] = Math.max(0, Math.min(WORLD_WIDTH, speckX[i] + speckVx[i] * dtSec))
+    speckY[i] = Math.max(0, Math.min(WORLD_HEIGHT, speckY[i] + speckVy[i] * dtSec))
+  }
+}

--- a/src/app/speck-wars/domain/simulation/prng.ts
+++ b/src/app/speck-wars/domain/simulation/prng.ts
@@ -1,0 +1,9 @@
+// mulberry32 — fast, deterministic, good enough for game simulation
+export function mulberry32(seed: number) {
+  return function(): number {
+    seed |= 0; seed = seed + 0x6D2B79F5 | 0
+    let z = Math.imul(seed ^ (seed >>> 15), 1 | seed)
+    z = z + Math.imul(z ^ (z >>> 7), 61 | z) ^ z
+    return ((z ^ (z >>> 14)) >>> 0) / 4294967296
+  }
+}

--- a/src/app/speck-wars/domain/simulation/spatial-grid.ts
+++ b/src/app/speck-wars/domain/simulation/spatial-grid.ts
@@ -1,0 +1,37 @@
+import { GRID_COLS, GRID_ROWS, GRID_CELL_SIZE } from '../constants'
+
+export class SpatialGrid {
+  // cells[cellIndex] = array of speck array indices
+  private cells: number[][]
+
+  constructor() {
+    this.cells = Array.from({ length: GRID_COLS * GRID_ROWS }, () => [])
+  }
+
+  clear() {
+    for (const cell of this.cells) cell.length = 0
+  }
+
+  insert(i: number, x: number, y: number) {
+    const col = Math.floor(x / GRID_CELL_SIZE)
+    const row = Math.floor(y / GRID_CELL_SIZE)
+    if (col < 0 || col >= GRID_COLS || row < 0 || row >= GRID_ROWS) return
+    this.cells[row * GRID_COLS + col].push(i)
+  }
+
+  // Returns array indices of all specks in the cell at (x,y) and 8 neighbors
+  query(x: number, y: number): number[] {
+    const col = Math.floor(x / GRID_CELL_SIZE)
+    const row = Math.floor(y / GRID_CELL_SIZE)
+    const results: number[] = []
+    for (let dr = -1; dr <= 1; dr++) {
+      for (let dc = -1; dc <= 1; dc++) {
+        const c = col + dc, r = row + dr
+        if (c < 0 || c >= GRID_COLS || r < 0 || r >= GRID_ROWS) continue
+        const cell = this.cells[r * GRID_COLS + c]
+        for (const idx of cell) results.push(idx)
+      }
+    }
+    return results
+  }
+}

--- a/src/app/speck-wars/domain/simulation/spawner.ts
+++ b/src/app/speck-wars/domain/simulation/spawner.ts
@@ -1,0 +1,56 @@
+import type { SimulationState, SpeckMeta } from '../types'
+import { SPECK_TYPES } from '../config/speck-types'
+import { BUILDING_TYPES } from '../config/building-types'
+
+// Resize all SOA arrays by 1 and insert a new speck at the end
+function addSpeck(sim: SimulationState, meta: SpeckMeta, x: number, y: number) {
+  const n = sim.speckIds.length
+
+  // Grow Float32Arrays
+  const newX = new Float32Array(n + 1); newX.set(sim.speckX); newX[n] = x
+  const newY = new Float32Array(n + 1); newY.set(sim.speckY); newY[n] = y
+  const newVx = new Float32Array(n + 1); newVx.set(sim.speckVx); newVx[n] = 0
+  const newVy = new Float32Array(n + 1); newVy.set(sim.speckVy); newVy[n] = 0
+  const newHp = new Float32Array(n + 1); newHp.set(sim.speckHp)
+  newHp[n] = SPECK_TYPES[meta.typeId]?.hp ?? 1
+
+  sim.speckX = newX; sim.speckY = newY
+  sim.speckVx = newVx; sim.speckVy = newVy; sim.speckHp = newHp
+  sim.speckIds.push(meta.id)
+  sim.speckMeta.push(meta)
+
+  sim.events.push({ type: 'SPECK_SPAWNED', speckId: meta.id, buildingId: '' })
+}
+
+let speckCounter = 0
+
+export function updateSpawners(sim: SimulationState, dt: number) {
+  for (const building of Object.values(sim.buildings)) {
+    const btype = BUILDING_TYPES[building.typeId]
+    if (!btype?.spawnTypeId) continue
+    if (sim.players[building.ownerId]?.isDefeated) continue
+
+    building.spawnTimer -= dt
+    if (building.spawnTimer > 0) continue
+
+    building.spawnTimer = btype.spawnInterval
+
+    for (let i = 0; i < btype.spawnCount; i++) {
+      // Spawn just outside the building radius with slight random offset
+      const angle = Math.random() * Math.PI * 2
+      const radius = btype.size + 8
+      const sx = building.x + Math.cos(angle) * radius
+      const sy = building.y + Math.sin(angle) * radius
+
+      const meta: SpeckMeta = {
+        id: `speck-${++speckCounter}`,
+        typeId: btype.spawnTypeId!,
+        ownerId: building.ownerId,
+        state: 'idle',
+        targetId: null,
+        attackCooldown: 0,
+      }
+      addSpeck(sim, meta, sx, sy)
+    }
+  }
+}

--- a/src/app/speck-wars/domain/simulation/speck-ai.ts
+++ b/src/app/speck-wars/domain/simulation/speck-ai.ts
@@ -1,0 +1,37 @@
+import type { SimulationState } from '../types'
+import { SPECK_TYPES } from '../config/speck-types'
+
+export function runSpeckAI(sim: SimulationState) {
+  const { speckIds, speckX, speckY, speckMeta, buildings } = sim
+
+  for (let i = 0; i < speckIds.length; i++) {
+    const meta = speckMeta[i]
+    const stype = SPECK_TYPES[meta.typeId]
+    if (!stype) continue
+
+    // Clear dead or invalid targets
+    if (meta.targetId && !buildings[meta.targetId]) {
+      meta.targetId = null
+    }
+
+    if (meta.targetId) continue  // already has a valid target
+
+    // Find nearest enemy building
+    let nearest: string | null = null
+    let nearestDist = Infinity
+
+    for (const [_bid, building] of Object.entries(buildings)) {
+      if (building.ownerId === meta.ownerId) continue  // skip friendly
+      const dx = building.x - speckX[i]
+      const dy = building.y - speckY[i]
+      const dist = Math.sqrt(dx * dx + dy * dy)
+      if (dist < nearestDist) {
+        nearestDist = dist
+        nearest = _bid
+      }
+    }
+
+    meta.targetId = nearest
+    meta.state = nearest ? 'moving' : 'idle'
+  }
+}

--- a/src/app/speck-wars/domain/types.ts
+++ b/src/app/speck-wars/domain/types.ts
@@ -1,3 +1,5 @@
+import type { SpatialGrid } from './simulation/spatial-grid'
+
 export interface SpeckMeta {
   id: string
   typeId: string
@@ -44,6 +46,7 @@ export interface SimulationState {
 
   inputQueue: InputEvent[]
   events: SimEvent[]
+  spatialGrid: SpatialGrid
 }
 
 export type InputEvent =


### PR DESCRIPTION
## Summary
- `runSpeckAI(sim)`: each speck picks nearest enemy building as target; stale targets (destroyed buildings) cleared each tick
- `moveSpecks(sim, dt)`: steers specks toward their target at `stype.speed`, stops within `attackRange`; applies separation force via `SpatialGrid` neighbor query to prevent clumping; world boundary clamped

Depends on: #1701
Closes #1687

## Test plan
- [ ] Specks move toward enemy base after spawning
- [ ] Specks don't all collapse to one point (separation working)
- [ ] Specks halt within attack range of their target
- [ ] Destroyed target → specks re-target next tick
- [ ] No specks escape world bounds
- [ ] `npx tsc --noEmit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)