### PR TITLE
feat: Speck Wars combat resolution, death, and array compaction

### DIFF
--- a/src/app/speck-wars/domain/simulation/combat.ts
+++ b/src/app/speck-wars/domain/simulation/combat.ts
@@ -1,0 +1,104 @@
+import type { SimulationState } from '../types'
+import { SPECK_TYPES } from '../config/speck-types'
+import { BUILDING_TYPES } from '../config/building-types'
+
+export function resolveCombat(sim: SimulationState, dt: number) {
+  const { speckIds, speckX, speckY, speckHp, speckMeta, buildings, spatialGrid } = sim
+
+  // --- Speck vs Speck combat ---
+  for (let i = 0; i < speckIds.length; i++) {
+    if (speckHp[i] <= 0) continue
+    const meta = speckMeta[i]
+    const stype = SPECK_TYPES[meta.typeId]
+    if (!stype) continue
+
+    if (meta.attackCooldown > 0) {
+      meta.attackCooldown -= dt
+      continue
+    }
+
+    const neighbors = spatialGrid.query(speckX[i], speckY[i])
+    for (const j of neighbors) {
+      if (i === j || speckHp[j] <= 0) continue
+      if (speckMeta[j].ownerId === meta.ownerId) continue  // friendly
+
+      const dx = speckX[j] - speckX[i]
+      const dy = speckY[j] - speckY[i]
+      const dist = Math.sqrt(dx * dx + dy * dy)
+      if (dist <= stype.attackRange) {
+        speckHp[j] -= stype.damage
+        meta.attackCooldown = stype.attackCooldown
+        meta.state = 'attacking'
+        if (speckHp[j] <= 0) {
+          sim.events.push({ type: 'SPECK_DIED', speckId: speckIds[j], x: speckX[j], y: speckY[j] })
+        }
+        break  // one attack per cooldown
+      }
+    }
+  }
+
+  // --- Speck vs Building combat ---
+  for (let i = 0; i < speckIds.length; i++) {
+    if (speckHp[i] <= 0) continue
+    const meta = speckMeta[i]
+    if (!meta.targetId) continue
+    const building = buildings[meta.targetId]
+    if (!building) continue
+
+    const stype = SPECK_TYPES[meta.typeId]
+    if (!stype || meta.attackCooldown > 0) continue
+
+    const dx = building.x - speckX[i]
+    const dy = building.y - speckY[i]
+    const dist = Math.sqrt(dx * dx + dy * dy)
+    const btype = BUILDING_TYPES[building.typeId]
+    const attackDist = (btype?.size ?? 20) + stype.attackRange
+
+    if (dist <= attackDist) {
+      building.hp -= stype.damage
+      meta.attackCooldown = stype.attackCooldown
+      sim.events.push({ type: 'BUILDING_DAMAGED', buildingId: building.id, hp: building.hp })
+
+      if (building.hp <= 0) {
+        sim.events.push({ type: 'BUILDING_DESTROYED', buildingId: building.id, ownerId: building.ownerId })
+        delete sim.buildings[building.id]
+        // Clear target for all specks pointing at this building
+        for (const m of sim.speckMeta) {
+          if (m.targetId === building.id) m.targetId = null
+        }
+      }
+    }
+  }
+}
+
+// Remove dead specks — compact all SOA arrays in one pass
+export function removeDeadSpecks(sim: SimulationState) {
+  const alive: number[] = []
+  for (let i = 0; i < sim.speckIds.length; i++) {
+    if (sim.speckHp[i] > 0) alive.push(i)
+  }
+
+  if (alive.length === sim.speckIds.length) return  // nothing to remove
+
+  const n = alive.length
+  const newX = new Float32Array(n)
+  const newY = new Float32Array(n)
+  const newVx = new Float32Array(n)
+  const newVy = new Float32Array(n)
+  const newHp = new Float32Array(n)
+  const newIds: string[] = []
+  const newMeta: SimulationState['speckMeta'] = []
+
+  for (let j = 0; j < alive.length; j++) {
+    const i = alive[j]
+    newX[j] = sim.speckX[i]; newY[j] = sim.speckY[i]
+    newVx[j] = sim.speckVx[i]; newVy[j] = sim.speckVy[i]
+    newHp[j] = sim.speckHp[i]
+    newIds.push(sim.speckIds[i])
+    newMeta.push(sim.speckMeta[i])
+  }
+
+  sim.speckX = newX; sim.speckY = newY
+  sim.speckVx = newVx; sim.speckVy = newVy; sim.speckHp = newHp
+  sim.speckIds = newIds; sim.speckMeta = newMeta
+}

--- a/src/app/speck-wars/domain/simulation/movement.ts
+++ b/src/app/speck-wars/domain/simulation/movement.ts
@@ -1,0 +1,61 @@
+import type { SimulationState } from '../types'
+import { SPECK_TYPES } from '../config/speck-types'
+import { WORLD_WIDTH, WORLD_HEIGHT } from '../constants'
+
+const SEPARATION_RADIUS = 8   // px — keep specks this far apart
+const SEPARATION_FORCE = 120  // strength of push-apart
+
+export function moveSpecks(sim: SimulationState, dt: number) {
+  const { speckIds, speckX, speckY, speckVx, speckVy, speckMeta, buildings, spatialGrid } = sim
+  const dtSec = dt / 1000
+
+  // Rebuild grid with current positions before applying separation
+  spatialGrid.clear()
+  for (let i = 0; i < speckIds.length; i++) {
+    spatialGrid.insert(i, speckX[i], speckY[i])
+  }
+
+  for (let i = 0; i < speckIds.length; i++) {
+    const meta = speckMeta[i]
+    const stype = SPECK_TYPES[meta.typeId]
+    if (!stype) continue
+
+    let ax = 0, ay = 0
+
+    // Seek target
+    if (meta.targetId) {
+      const target = buildings[meta.targetId]
+      if (target) {
+        const dx = target.x - speckX[i]
+        const dy = target.y - speckY[i]
+        const dist = Math.sqrt(dx * dx + dy * dy)
+        if (dist > stype.attackRange) {
+          ax += (dx / dist) * stype.speed
+          ay += (dy / dist) * stype.speed
+        }
+      }
+    }
+
+    // Separation from nearby specks (same owner to avoid interleaving)
+    const neighbors = spatialGrid.query(speckX[i], speckY[i])
+    for (const j of neighbors) {
+      if (i === j) continue
+      const dx = speckX[i] - speckX[j]
+      const dy = speckY[i] - speckY[j]
+      const dist = Math.sqrt(dx * dx + dy * dy)
+      if (dist < SEPARATION_RADIUS && dist > 0) {
+        const force = (SEPARATION_RADIUS - dist) / SEPARATION_RADIUS * SEPARATION_FORCE
+        ax += (dx / dist) * force
+        ay += (dy / dist) * force
+      }
+    }
+
+    // Simple velocity (no mass — direct velocity override)
+    speckVx[i] = ax
+    speckVy[i] = ay
+
+    // Integrate position
+    speckX[i] = Math.max(0, Math.min(WORLD_WIDTH, speckX[i] + speckVx[i] * dtSec))
+    speckY[i] = Math.max(0, Math.min(WORLD_HEIGHT, speckY[i] + speckVy[i] * dtSec))
+  }
+}

--- a/src/app/speck-wars/domain/simulation/spawner.ts
+++ b/src/app/speck-wars/domain/simulation/spawner.ts
@@ -1,0 +1,56 @@
+import type { SimulationState, SpeckMeta } from '../types'
+import { SPECK_TYPES } from '../config/speck-types'
+import { BUILDING_TYPES } from '../config/building-types'
+
+// Resize all SOA arrays by 1 and insert a new speck at the end
+function addSpeck(sim: SimulationState, meta: SpeckMeta, x: number, y: number) {
+  const n = sim.speckIds.length
+
+  // Grow Float32Arrays
+  const newX = new Float32Array(n + 1); newX.set(sim.speckX); newX[n] = x
+  const newY = new Float32Array(n + 1); newY.set(sim.speckY); newY[n] = y
+  const newVx = new Float32Array(n + 1); newVx.set(sim.speckVx); newVx[n] = 0
+  const newVy = new Float32Array(n + 1); newVy.set(sim.speckVy); newVy[n] = 0
+  const newHp = new Float32Array(n + 1); newHp.set(sim.speckHp)
+  newHp[n] = SPECK_TYPES[meta.typeId]?.hp ?? 1
+
+  sim.speckX = newX; sim.speckY = newY
+  sim.speckVx = newVx; sim.speckVy = newVy; sim.speckHp = newHp
+  sim.speckIds.push(meta.id)
+  sim.speckMeta.push(meta)
+
+  sim.events.push({ type: 'SPECK_SPAWNED', speckId: meta.id, buildingId: '' })
+}
+
+let speckCounter = 0
+
+export function updateSpawners(sim: SimulationState, dt: number) {
+  for (const building of Object.values(sim.buildings)) {
+    const btype = BUILDING_TYPES[building.typeId]
+    if (!btype?.spawnTypeId) continue
+    if (sim.players[building.ownerId]?.isDefeated) continue
+
+    building.spawnTimer -= dt
+    if (building.spawnTimer > 0) continue
+
+    building.spawnTimer = btype.spawnInterval
+
+    for (let i = 0; i < btype.spawnCount; i++) {
+      // Spawn just outside the building radius with slight random offset
+      const angle = Math.random() * Math.PI * 2
+      const radius = btype.size + 8
+      const sx = building.x + Math.cos(angle) * radius
+      const sy = building.y + Math.sin(angle) * radius
+
+      const meta: SpeckMeta = {
+        id: `speck-${++speckCounter}`,
+        typeId: btype.spawnTypeId!,
+        ownerId: building.ownerId,
+        state: 'idle',
+        targetId: null,
+        attackCooldown: 0,
+      }
+      addSpeck(sim, meta, sx, sy)
+    }
+  }
+}

--- a/src/app/speck-wars/domain/simulation/speck-ai.ts
+++ b/src/app/speck-wars/domain/simulation/speck-ai.ts
@@ -1,0 +1,37 @@
+import type { SimulationState } from '../types'
+import { SPECK_TYPES } from '../config/speck-types'
+
+export function runSpeckAI(sim: SimulationState) {
+  const { speckIds, speckX, speckY, speckMeta, buildings } = sim
+
+  for (let i = 0; i < speckIds.length; i++) {
+    const meta = speckMeta[i]
+    const stype = SPECK_TYPES[meta.typeId]
+    if (!stype) continue
+
+    // Clear dead or invalid targets
+    if (meta.targetId && !buildings[meta.targetId]) {
+      meta.targetId = null
+    }
+
+    if (meta.targetId) continue  // already has a valid target
+
+    // Find nearest enemy building
+    let nearest: string | null = null
+    let nearestDist = Infinity
+
+    for (const [_bid, building] of Object.entries(buildings)) {
+      if (building.ownerId === meta.ownerId) continue  // skip friendly
+      const dx = building.x - speckX[i]
+      const dy = building.y - speckY[i]
+      const dist = Math.sqrt(dx * dx + dy * dy)
+      if (dist < nearestDist) {
+        nearestDist = dist
+        nearest = _bid
+      }
+    }
+
+    meta.targetId = nearest
+    meta.state = nearest ? 'moving' : 'idle'
+  }
+}


### PR DESCRIPTION
## Summary
- `resolveCombat(sim, dt)`: speck-vs-speck combat using `SpatialGrid` neighbor query with per-speck attack cooldown; speck-vs-building when within `buildingSize + attackRange`, building removed on death with all targeting cleared
- `removeDeadSpecks(sim)`: single-pass SOA compaction — copies alive indices into fresh Float32Arrays; called once per tick after combat

Events emitted: `SPECK_DIED`, `BUILDING_DAMAGED`, `BUILDING_DESTROYED`

Depends on: #1702
Closes #1688

## Test plan
- [ ] Enemy specks deal damage to each other on contact
- [ ] Specks die at HP ≤ 0 and are removed from arrays
- [ ] Buildings lose HP when specks reach them; deleted from `sim.buildings` at HP ≤ 0
- [ ] `SPECK_DIED` / `BUILDING_DESTROYED` events emitted correctly
- [ ] `npx tsc --noEmit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)