### PR TITLE
feat: Speck Wars main simulation tick + wire into GameInstance

### DIFF
--- a/src/app/speck-wars/domain/simulation/combat.ts
+++ b/src/app/speck-wars/domain/simulation/combat.ts
@@ -1,0 +1,104 @@
+import type { SimulationState } from '../types'
+import { SPECK_TYPES } from '../config/speck-types'
+import { BUILDING_TYPES } from '../config/building-types'
+
+export function resolveCombat(sim: SimulationState, dt: number) {
+  const { speckIds, speckX, speckY, speckHp, speckMeta, buildings, spatialGrid } = sim
+
+  // --- Speck vs Speck combat ---
+  for (let i = 0; i < speckIds.length; i++) {
+    if (speckHp[i] <= 0) continue
+    const meta = speckMeta[i]
+    const stype = SPECK_TYPES[meta.typeId]
+    if (!stype) continue
+
+    if (meta.attackCooldown > 0) {
+      meta.attackCooldown -= dt
+      continue
+    }
+
+    const neighbors = spatialGrid.query(speckX[i], speckY[i])
+    for (const j of neighbors) {
+      if (i === j || speckHp[j] <= 0) continue
+      if (speckMeta[j].ownerId === meta.ownerId) continue  // friendly
+
+      const dx = speckX[j] - speckX[i]
+      const dy = speckY[j] - speckY[i]
+      const dist = Math.sqrt(dx * dx + dy * dy)
+      if (dist <= stype.attackRange) {
+        speckHp[j] -= stype.damage
+        meta.attackCooldown = stype.attackCooldown
+        meta.state = 'attacking'
+        if (speckHp[j] <= 0) {
+          sim.events.push({ type: 'SPECK_DIED', speckId: speckIds[j], x: speckX[j], y: speckY[j] })
+        }
+        break  // one attack per cooldown
+      }
+    }
+  }
+
+  // --- Speck vs Building combat ---
+  for (let i = 0; i < speckIds.length; i++) {
+    if (speckHp[i] <= 0) continue
+    const meta = speckMeta[i]
+    if (!meta.targetId) continue
+    const building = buildings[meta.targetId]
+    if (!building) continue
+
+    const stype = SPECK_TYPES[meta.typeId]
+    if (!stype || meta.attackCooldown > 0) continue
+
+    const dx = building.x - speckX[i]
+    const dy = building.y - speckY[i]
+    const dist = Math.sqrt(dx * dx + dy * dy)
+    const btype = BUILDING_TYPES[building.typeId]
+    const attackDist = (btype?.size ?? 20) + stype.attackRange
+
+    if (dist <= attackDist) {
+      building.hp -= stype.damage
+      meta.attackCooldown = stype.attackCooldown
+      sim.events.push({ type: 'BUILDING_DAMAGED', buildingId: building.id, hp: building.hp })
+
+      if (building.hp <= 0) {
+        sim.events.push({ type: 'BUILDING_DESTROYED', buildingId: building.id, ownerId: building.ownerId })
+        delete sim.buildings[building.id]
+        // Clear target for all specks pointing at this building
+        for (const m of sim.speckMeta) {
+          if (m.targetId === building.id) m.targetId = null
+        }
+      }
+    }
+  }
+}
+
+// Remove dead specks — compact all SOA arrays in one pass
+export function removeDeadSpecks(sim: SimulationState) {
+  const alive: number[] = []
+  for (let i = 0; i < sim.speckIds.length; i++) {
+    if (sim.speckHp[i] > 0) alive.push(i)
+  }
+
+  if (alive.length === sim.speckIds.length) return  // nothing to remove
+
+  const n = alive.length
+  const newX = new Float32Array(n)
+  const newY = new Float32Array(n)
+  const newVx = new Float32Array(n)
+  const newVy = new Float32Array(n)
+  const newHp = new Float32Array(n)
+  const newIds: string[] = []
+  const newMeta: SimulationState['speckMeta'] = []
+
+  for (let j = 0; j < alive.length; j++) {
+    const i = alive[j]
+    newX[j] = sim.speckX[i]; newY[j] = sim.speckY[i]
+    newVx[j] = sim.speckVx[i]; newVy[j] = sim.speckVy[i]
+    newHp[j] = sim.speckHp[i]
+    newIds.push(sim.speckIds[i])
+    newMeta.push(sim.speckMeta[i])
+  }
+
+  sim.speckX = newX; sim.speckY = newY
+  sim.speckVx = newVx; sim.speckVy = newVy; sim.speckHp = newHp
+  sim.speckIds = newIds; sim.speckMeta = newMeta
+}

--- a/src/app/speck-wars/domain/simulation/movement.ts
+++ b/src/app/speck-wars/domain/simulation/movement.ts
@@ -1,0 +1,61 @@
+import type { SimulationState } from '../types'
+import { SPECK_TYPES } from '../config/speck-types'
+import { WORLD_WIDTH, WORLD_HEIGHT } from '../constants'
+
+const SEPARATION_RADIUS = 8   // px — keep specks this far apart
+const SEPARATION_FORCE = 120  // strength of push-apart
+
+export function moveSpecks(sim: SimulationState, dt: number) {
+  const { speckIds, speckX, speckY, speckVx, speckVy, speckMeta, buildings, spatialGrid } = sim
+  const dtSec = dt / 1000
+
+  // Rebuild grid with current positions before applying separation
+  spatialGrid.clear()
+  for (let i = 0; i < speckIds.length; i++) {
+    spatialGrid.insert(i, speckX[i], speckY[i])
+  }
+
+  for (let i = 0; i < speckIds.length; i++) {
+    const meta = speckMeta[i]
+    const stype = SPECK_TYPES[meta.typeId]
+    if (!stype) continue
+
+    let ax = 0, ay = 0
+
+    // Seek target
+    if (meta.targetId) {
+      const target = buildings[meta.targetId]
+      if (target) {
+        const dx = target.x - speckX[i]
+        const dy = target.y - speckY[i]
+        const dist = Math.sqrt(dx * dx + dy * dy)
+        if (dist > stype.attackRange) {
+          ax += (dx / dist) * stype.speed
+          ay += (dy / dist) * stype.speed
+        }
+      }
+    }
+
+    // Separation from nearby specks (same owner to avoid interleaving)
+    const neighbors = spatialGrid.query(speckX[i], speckY[i])
+    for (const j of neighbors) {
+      if (i === j) continue
+      const dx = speckX[i] - speckX[j]
+      const dy = speckY[i] - speckY[j]
+      const dist = Math.sqrt(dx * dx + dy * dy)
+      if (dist < SEPARATION_RADIUS && dist > 0) {
+        const force = (SEPARATION_RADIUS - dist) / SEPARATION_RADIUS * SEPARATION_FORCE
+        ax += (dx / dist) * force
+        ay += (dy / dist) * force
+      }
+    }
+
+    // Simple velocity (no mass — direct velocity override)
+    speckVx[i] = ax
+    speckVy[i] = ay
+
+    // Integrate position
+    speckX[i] = Math.max(0, Math.min(WORLD_WIDTH, speckX[i] + speckVx[i] * dtSec))
+    speckY[i] = Math.max(0, Math.min(WORLD_HEIGHT, speckY[i] + speckVy[i] * dtSec))
+  }
+}

--- a/src/app/speck-wars/domain/simulation/spawner.ts
+++ b/src/app/speck-wars/domain/simulation/spawner.ts
@@ -1,0 +1,56 @@
+import type { SimulationState, SpeckMeta } from '../types'
+import { SPECK_TYPES } from '../config/speck-types'
+import { BUILDING_TYPES } from '../config/building-types'
+
+// Resize all SOA arrays by 1 and insert a new speck at the end
+function addSpeck(sim: SimulationState, meta: SpeckMeta, x: number, y: number) {
+  const n = sim.speckIds.length
+
+  // Grow Float32Arrays
+  const newX = new Float32Array(n + 1); newX.set(sim.speckX); newX[n] = x
+  const newY = new Float32Array(n + 1); newY.set(sim.speckY); newY[n] = y
+  const newVx = new Float32Array(n + 1); newVx.set(sim.speckVx); newVx[n] = 0
+  const newVy = new Float32Array(n + 1); newVy.set(sim.speckVy); newVy[n] = 0
+  const newHp = new Float32Array(n + 1); newHp.set(sim.speckHp)
+  newHp[n] = SPECK_TYPES[meta.typeId]?.hp ?? 1
+
+  sim.speckX = newX; sim.speckY = newY
+  sim.speckVx = newVx; sim.speckVy = newVy; sim.speckHp = newHp
+  sim.speckIds.push(meta.id)
+  sim.speckMeta.push(meta)
+
+  sim.events.push({ type: 'SPECK_SPAWNED', speckId: meta.id, buildingId: '' })
+}
+
+let speckCounter = 0
+
+export function updateSpawners(sim: SimulationState, dt: number) {
+  for (const building of Object.values(sim.buildings)) {
+    const btype = BUILDING_TYPES[building.typeId]
+    if (!btype?.spawnTypeId) continue
+    if (sim.players[building.ownerId]?.isDefeated) continue
+
+    building.spawnTimer -= dt
+    if (building.spawnTimer > 0) continue
+
+    building.spawnTimer = btype.spawnInterval
+
+    for (let i = 0; i < btype.spawnCount; i++) {
+      // Spawn just outside the building radius with slight random offset
+      const angle = Math.random() * Math.PI * 2
+      const radius = btype.size + 8
+      const sx = building.x + Math.cos(angle) * radius
+      const sy = building.y + Math.sin(angle) * radius
+
+      const meta: SpeckMeta = {
+        id: `speck-${++speckCounter}`,
+        typeId: btype.spawnTypeId!,
+        ownerId: building.ownerId,
+        state: 'idle',
+        targetId: null,
+        attackCooldown: 0,
+      }
+      addSpeck(sim, meta, sx, sy)
+    }
+  }
+}

--- a/src/app/speck-wars/domain/simulation/speck-ai.ts
+++ b/src/app/speck-wars/domain/simulation/speck-ai.ts
@@ -1,0 +1,37 @@
+import type { SimulationState } from '../types'
+import { SPECK_TYPES } from '../config/speck-types'
+
+export function runSpeckAI(sim: SimulationState) {
+  const { speckIds, speckX, speckY, speckMeta, buildings } = sim
+
+  for (let i = 0; i < speckIds.length; i++) {
+    const meta = speckMeta[i]
+    const stype = SPECK_TYPES[meta.typeId]
+    if (!stype) continue
+
+    // Clear dead or invalid targets
+    if (meta.targetId && !buildings[meta.targetId]) {
+      meta.targetId = null
+    }
+
+    if (meta.targetId) continue  // already has a valid target
+
+    // Find nearest enemy building
+    let nearest: string | null = null
+    let nearestDist = Infinity
+
+    for (const [_bid, building] of Object.entries(buildings)) {
+      if (building.ownerId === meta.ownerId) continue  // skip friendly
+      const dx = building.x - speckX[i]
+      const dy = building.y - speckY[i]
+      const dist = Math.sqrt(dx * dx + dy * dy)
+      if (dist < nearestDist) {
+        nearestDist = dist
+        nearest = _bid
+      }
+    }
+
+    meta.targetId = nearest
+    meta.state = nearest ? 'moving' : 'idle'
+  }
+}

--- a/src/app/speck-wars/domain/simulation/tick.ts
+++ b/src/app/speck-wars/domain/simulation/tick.ts
@@ -1,0 +1,58 @@
+import type { SimulationState } from '../types'
+import { updateSpawners } from './spawner'
+import { runSpeckAI } from './speck-ai'
+import { moveSpecks } from './movement'
+import { resolveCombat, removeDeadSpecks } from './combat'
+import { checkVictory } from './victory'
+import { HUD_UPDATE_INTERVAL } from '../constants'
+
+export function tick(sim: SimulationState, dt: number): SimulationState {
+  sim.events = []  // clear outbound events from previous tick
+
+  // 1. Process player/AI input commands
+  consumeInputs(sim)
+
+  // 2. Spawn new specks from buildings
+  updateSpawners(sim, dt)
+
+  // 3. Each speck picks/validates its target
+  runSpeckAI(sim)
+
+  // 4. Move specks + apply separation
+  moveSpecks(sim, dt)
+
+  // 5. Deal damage, destroy buildings/specks
+  resolveCombat(sim, dt)
+
+  // 6. Remove dead specks (compact arrays)
+  removeDeadSpecks(sim)
+
+  // 7. Check win/loss
+  checkVictory(sim)
+
+  // 8. Emit HUD update every N ticks
+  sim.tick++
+  if (sim.tick % HUD_UPDATE_INTERVAL === 0) emitHudUpdate(sim)
+
+  return sim
+}
+
+function consumeInputs(sim: SimulationState) {
+  for (const _event of sim.inputQueue) {
+    // Future: handle RALLY, BUILD, SACRIFICE
+  }
+  sim.inputQueue = []
+}
+
+function emitHudUpdate(sim: SimulationState) {
+  const data: Record<string, { speckCount: number; buildingCount: number; buildingHp: Record<string, number> }> = {}
+  for (const [pid] of Object.entries(sim.players)) {
+    const myBuildings = Object.values(sim.buildings).filter(b => b.ownerId === pid)
+    data[pid] = {
+      speckCount: sim.speckMeta.filter(m => m.ownerId === pid).length,
+      buildingCount: myBuildings.length,
+      buildingHp: Object.fromEntries(myBuildings.map(b => [b.id, b.hp])),
+    }
+  }
+  sim.events.push({ type: 'HUD_UPDATE', data: { players: data } })
+}

--- a/src/app/speck-wars/domain/simulation/victory.ts
+++ b/src/app/speck-wars/domain/simulation/victory.ts
@@ -1,0 +1,16 @@
+import type { SimulationState } from '../types'
+
+export function checkVictory(sim: SimulationState) {
+  for (const [pid, player] of Object.entries(sim.players)) {
+    if (player.isDefeated) continue
+    const hasBuildings = Object.values(sim.buildings).some(b => b.ownerId === pid)
+    if (!hasBuildings) {
+      player.isDefeated = true
+    }
+  }
+
+  const alive = Object.values(sim.players).filter(p => !p.isDefeated)
+  if (alive.length === 1) {
+    sim.events.push({ type: 'GAME_OVER', winnerId: alive[0].id })
+  }
+}

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -1,29 +1,47 @@
+import { createSim } from './domain/simulation/create-sim'
+import { tick } from './domain/simulation/tick'
+import type { SimulationState } from './domain/types'
+import { useSpeckWarsStore } from './store'
+
 export class GameInstance {
   private canvas: HTMLCanvasElement
+  private sim: SimulationState
   private rafId: number | null = null
-  private tickCount = 0
+  private lastTime: number = 0
 
   constructor(canvas: HTMLCanvasElement) {
     this.canvas = canvas
+    this.sim = createSim()
   }
 
   start() {
     console.log('GameInstance started')
-    const loop = () => {
-      this.tickCount++
-      if (this.tickCount % 60 === 0) {
-        console.log(`GameInstance tick: ${this.tickCount}`)
+    this.lastTime = performance.now()
+    this.loop(this.lastTime)
+  }
+
+  private loop = (now: number) => {
+    const dt = Math.min(now - this.lastTime, 50)  // cap at 50ms to avoid spiral-of-death
+    this.lastTime = now
+
+    this.sim = tick(this.sim, dt)
+
+    // Forward sim events to Zustand store
+    for (const event of this.sim.events) {
+      if (event.type === 'GAME_OVER') {
+        useSpeckWarsStore.getState().setPhase('victory')
       }
-      this.rafId = requestAnimationFrame(loop)
     }
-    this.rafId = requestAnimationFrame(loop)
+
+    this.rafId = requestAnimationFrame(this.loop)
   }
 
   destroy() {
-    if (this.rafId !== null) {
-      cancelAnimationFrame(this.rafId)
-      this.rafId = null
-    }
+    if (this.rafId !== null) cancelAnimationFrame(this.rafId)
     console.log('GameInstance destroyed')
+  }
+
+  getSim(): SimulationState {
+    return this.sim
   }
 }


### PR DESCRIPTION
## Summary
- `tick.ts`: full sim step orchestrator — consumeInputs → spawners → AI targeting → movement → combat → removeDeadSpecks → victory check → periodic HUD update (every `HUD_UPDATE_INTERVAL` ticks)
- `victory.ts`: marks players defeated when buildings gone; emits `GAME_OVER` when one player remains alive
- `game-instance.ts`: replaces rAF stub with real sim loop; `dt` capped at 50ms; `GAME_OVER` forwarded to Zustand store phase transition

After this PR the world is running end-to-end — specks spawn, move, fight, and die — even before rendering.

Depends on: #1704
Closes #1689

## Test plan
- [ ] Game loop runs at ~60fps (DevTools performance panel)
- [ ] `sim.speckIds.length` grows over time (add console.log temporarily)
- [ ] When a base is destroyed, store phase transitions to `'victory'`
- [ ] dt is capped — no runaway simulation after tab loses focus
- [ ] `npx tsc --noEmit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)