### PR TITLE
feat: Speck Wars speck AI targeting + movement with separation

### DIFF
--- a/src/app/speck-wars/domain/simulation/movement.ts
+++ b/src/app/speck-wars/domain/simulation/movement.ts
@@ -1,0 +1,61 @@
+import type { SimulationState } from '../types'
+import { SPECK_TYPES } from '../config/speck-types'
+import { WORLD_WIDTH, WORLD_HEIGHT } from '../constants'
+
+const SEPARATION_RADIUS = 8   // px — keep specks this far apart
+const SEPARATION_FORCE = 120  // strength of push-apart
+
+export function moveSpecks(sim: SimulationState, dt: number) {
+  const { speckIds, speckX, speckY, speckVx, speckVy, speckMeta, buildings, spatialGrid } = sim
+  const dtSec = dt / 1000
+
+  // Rebuild grid with current positions before applying separation
+  spatialGrid.clear()
+  for (let i = 0; i < speckIds.length; i++) {
+    spatialGrid.insert(i, speckX[i], speckY[i])
+  }
+
+  for (let i = 0; i < speckIds.length; i++) {
+    const meta = speckMeta[i]
+    const stype = SPECK_TYPES[meta.typeId]
+    if (!stype) continue
+
+    let ax = 0, ay = 0
+
+    // Seek target
+    if (meta.targetId) {
+      const target = buildings[meta.targetId]
+      if (target) {
+        const dx = target.x - speckX[i]
+        const dy = target.y - speckY[i]
+        const dist = Math.sqrt(dx * dx + dy * dy)
+        if (dist > stype.attackRange) {
+          ax += (dx / dist) * stype.speed
+          ay += (dy / dist) * stype.speed
+        }
+      }
+    }
+
+    // Separation from nearby specks (same owner to avoid interleaving)
+    const neighbors = spatialGrid.query(speckX[i], speckY[i])
+    for (const j of neighbors) {
+      if (i === j) continue
+      const dx = speckX[i] - speckX[j]
+      const dy = speckY[i] - speckY[j]
+      const dist = Math.sqrt(dx * dx + dy * dy)
+      if (dist < SEPARATION_RADIUS && dist > 0) {
+        const force = (SEPARATION_RADIUS - dist) / SEPARATION_RADIUS * SEPARATION_FORCE
+        ax += (dx / dist) * force
+        ay += (dy / dist) * force
+      }
+    }
+
+    // Simple velocity (no mass — direct velocity override)
+    speckVx[i] = ax
+    speckVy[i] = ay
+
+    // Integrate position
+    speckX[i] = Math.max(0, Math.min(WORLD_WIDTH, speckX[i] + speckVx[i] * dtSec))
+    speckY[i] = Math.max(0, Math.min(WORLD_HEIGHT, speckY[i] + speckVy[i] * dtSec))
+  }
+}

--- a/src/app/speck-wars/domain/simulation/speck-ai.ts
+++ b/src/app/speck-wars/domain/simulation/speck-ai.ts
@@ -1,0 +1,37 @@
+import type { SimulationState } from '../types'
+import { SPECK_TYPES } from '../config/speck-types'
+
+export function runSpeckAI(sim: SimulationState) {
+  const { speckIds, speckX, speckY, speckMeta, buildings } = sim
+
+  for (let i = 0; i < speckIds.length; i++) {
+    const meta = speckMeta[i]
+    const stype = SPECK_TYPES[meta.typeId]
+    if (!stype) continue
+
+    // Clear dead or invalid targets
+    if (meta.targetId && !buildings[meta.targetId]) {
+      meta.targetId = null
+    }
+
+    if (meta.targetId) continue  // already has a valid target
+
+    // Find nearest enemy building
+    let nearest: string | null = null
+    let nearestDist = Infinity
+
+    for (const [_bid, building] of Object.entries(buildings)) {
+      if (building.ownerId === meta.ownerId) continue  // skip friendly
+      const dx = building.x - speckX[i]
+      const dy = building.y - speckY[i]
+      const dist = Math.sqrt(dx * dx + dy * dy)
+      if (dist < nearestDist) {
+        nearestDist = dist
+        nearest = _bid
+      }
+    }
+
+    meta.targetId = nearest
+    meta.state = nearest ? 'moving' : 'idle'
+  }
+}


### PR DESCRIPTION
## Summary
- `runSpeckAI(sim)`: each speck picks nearest enemy building as target; stale targets (destroyed buildings) cleared each tick
- `moveSpecks(sim, dt)`: steers specks toward their target at `stype.speed`, stops within `attackRange`; applies separation force via `SpatialGrid` neighbor query to prevent clumping; world boundary clamped

Closes #1687

## Test plan
- [ ] Specks move toward enemy base after spawning
- [ ] Specks don't collapse to one point (separation working)
- [ ] Specks halt within attack range of their target
- [ ] `npx tsc --noEmit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)