### PR TITLE
feat: Speck Wars camera — pan (drag), zoom (scroll), screen↔world transforms

### DIFF
--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -3,7 +3,9 @@ import { tick } from './domain/simulation/tick'
 import type { SimulationState } from './domain/types'
 import { useSpeckWarsStore } from './store'
 import { Renderer } from './rendering/renderer'
-import { WORLD_WIDTH, WORLD_HEIGHT } from './domain/constants'
+import { createCamera } from './rendering/camera'
+import { InputHandler } from './input/input-handler'
+import type { Camera } from './rendering/camera'
 
 export class GameInstance {
   private canvas: HTMLCanvasElement
@@ -11,22 +13,20 @@ export class GameInstance {
   private renderer: Renderer
   private rafId: number | null = null
   private lastTime: number = 0
-  private camera: { x: number; y: number; zoom: number }
+  private camera: Camera
+  private inputHandler!: InputHandler
 
   constructor(canvas: HTMLCanvasElement) {
     this.canvas = canvas
     this.sim = createSim()
     this.renderer = new Renderer()
-    this.camera = {
-      x: canvas.width / 2 - WORLD_WIDTH / 2,
-      y: canvas.height / 2 - WORLD_HEIGHT / 2,
-      zoom: 1,
-    }
+    this.camera = createCamera(canvas.clientWidth, canvas.clientHeight)
   }
 
   async start() {
     console.log('GameInstance started')
     await this.renderer.init(this.canvas)
+    this.inputHandler = new InputHandler(this.canvas, this.camera)
     this.lastTime = performance.now()
     this.loop(this.lastTime)
   }
@@ -52,6 +52,7 @@ export class GameInstance {
   destroy() {
     if (this.rafId !== null) cancelAnimationFrame(this.rafId)
     this.renderer.destroy()
+    this.inputHandler?.destroy()
     console.log('GameInstance destroyed')
   }
 
@@ -63,7 +64,7 @@ export class GameInstance {
     return this.camera
   }
 
-  setCamera(camera: { x: number; y: number; zoom: number }) {
+  setCamera(camera: Camera) {
     this.camera = camera
   }
 }

--- a/src/app/speck-wars/input/input-handler.ts
+++ b/src/app/speck-wars/input/input-handler.ts
@@ -1,0 +1,77 @@
+import type { Camera } from '../rendering/camera'
+import { zoomAt } from '../rendering/camera'
+
+export class InputHandler {
+  private canvas: HTMLCanvasElement
+  private camera: Camera
+  private isDragging = false
+  private lastX = 0
+  private lastY = 0
+
+  constructor(canvas: HTMLCanvasElement, camera: Camera) {
+    this.canvas = canvas
+    this.camera = camera
+    this.attach()
+  }
+
+  private attach() {
+    this.canvas.addEventListener('mousedown', this.onMouseDown)
+    window.addEventListener('mousemove', this.onMouseMove)
+    window.addEventListener('mouseup', this.onMouseUp)
+    this.canvas.addEventListener('wheel', this.onWheel, { passive: false })
+    // Touch support
+    this.canvas.addEventListener('touchstart', this.onTouchStart, { passive: true })
+    window.addEventListener('touchmove', this.onTouchMove, { passive: false })
+    window.addEventListener('touchend', this.onTouchEnd)
+  }
+
+  private onMouseDown = (e: MouseEvent) => {
+    this.isDragging = true
+    this.lastX = e.clientX
+    this.lastY = e.clientY
+  }
+  private onMouseMove = (e: MouseEvent) => {
+    if (!this.isDragging) return
+    this.camera.x += e.clientX - this.lastX
+    this.camera.y += e.clientY - this.lastY
+    this.lastX = e.clientX
+    this.lastY = e.clientY
+  }
+  private onMouseUp = () => { this.isDragging = false }
+
+  private onWheel = (e: WheelEvent) => {
+    e.preventDefault()
+    const factor = e.deltaY < 0 ? 1.1 : 0.9
+    const rect = this.canvas.getBoundingClientRect()
+    const sx = e.clientX - rect.left
+    const sy = e.clientY - rect.top
+    Object.assign(this.camera, zoomAt(this.camera, sx, sy, factor))
+  }
+
+  private onTouchStart = (e: TouchEvent) => {
+    if (e.touches.length === 1) {
+      this.isDragging = true
+      this.lastX = e.touches[0].clientX
+      this.lastY = e.touches[0].clientY
+    }
+  }
+  private onTouchMove = (e: TouchEvent) => {
+    if (!this.isDragging || e.touches.length !== 1) return
+    e.preventDefault()
+    this.camera.x += e.touches[0].clientX - this.lastX
+    this.camera.y += e.touches[0].clientY - this.lastY
+    this.lastX = e.touches[0].clientX
+    this.lastY = e.touches[0].clientY
+  }
+  private onTouchEnd = () => { this.isDragging = false }
+
+  destroy() {
+    this.canvas.removeEventListener('mousedown', this.onMouseDown)
+    window.removeEventListener('mousemove', this.onMouseMove)
+    window.removeEventListener('mouseup', this.onMouseUp)
+    this.canvas.removeEventListener('wheel', this.onWheel)
+    this.canvas.removeEventListener('touchstart', this.onTouchStart)
+    window.removeEventListener('touchmove', this.onTouchMove)
+    window.removeEventListener('touchend', this.onTouchEnd)
+  }
+}

--- a/src/app/speck-wars/rendering/camera.ts
+++ b/src/app/speck-wars/rendering/camera.ts
@@ -1,0 +1,41 @@
+import { WORLD_WIDTH, WORLD_HEIGHT } from '../domain/constants'
+
+export interface Camera {
+  x: number      // stage offset x (screen space)
+  y: number      // stage offset y (screen space)
+  zoom: number
+}
+
+export function createCamera(canvasWidth: number, canvasHeight: number): Camera {
+  // Start centered on the world midpoint
+  return {
+    x: canvasWidth / 2 - (WORLD_WIDTH / 2),
+    y: canvasHeight / 2 - (WORLD_HEIGHT / 2),
+    zoom: 1,
+  }
+}
+
+export function screenToWorld(sx: number, sy: number, camera: Camera): { x: number; y: number } {
+  return {
+    x: (sx - camera.x) / camera.zoom,
+    y: (sy - camera.y) / camera.zoom,
+  }
+}
+
+export function worldToScreen(wx: number, wy: number, camera: Camera): { x: number; y: number } {
+  return {
+    x: wx * camera.zoom + camera.x,
+    y: wy * camera.zoom + camera.y,
+  }
+}
+
+// Zoom toward screen point (pinch/scroll zoom)
+export function zoomAt(camera: Camera, screenX: number, screenY: number, factor: number): Camera {
+  const newZoom = Math.max(0.2, Math.min(4, camera.zoom * factor))
+  const scale = newZoom / camera.zoom
+  return {
+    zoom: newZoom,
+    x: screenX - (screenX - camera.x) * scale,
+    y: screenY - (screenY - camera.y) * scale,
+  }
+}


### PR DESCRIPTION
## Summary
- `camera.ts`: `Camera` interface, `createCamera()` (world-centered start), `screenToWorld`/`worldToScreen` helpers, `zoomAt()` (clamped 0.2×–4×)
- `input-handler.ts`: drag-to-pan (mouse + single-finger touch), scroll-to-zoom toward cursor; all listeners cleaned up in `destroy()`
- `game-instance.ts`: uses `createCamera()`, wires `InputHandler` after renderer init, destroys on cleanup

Closes #1691

Depends on: #1707

## Test plan
- [ ] Drag canvas pans the world
- [ ] Scroll zooms in/out toward cursor
- [ ] Touch drag works on mobile
- [ ] Zoom clamped 0.2×–4×
- [ ] Camera starts centered on world midpoint
- [ ] `npx tsc --noEmit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)