### PR TITLE
feat: Speck Wars React HUD overlay + phase routing

### DIFF
--- a/src/app/speck-wars/SpeckWarsGame.tsx
+++ b/src/app/speck-wars/SpeckWarsGame.tsx
@@ -2,8 +2,11 @@
 
 import { useEffect, useRef } from 'react'
 import { GameInstance } from './game-instance'
+import { useSpeckWarsStore } from './store'
+import { HUD } from './components/hud'
+import { PhaseRouter } from './components/phase-router'
 
-export function SpeckWarsGame() {
+function GameCanvas() {
   const canvasRef = useRef<HTMLCanvasElement>(null)
 
   useEffect(() => {
@@ -11,7 +14,7 @@ export function SpeckWarsGame() {
     if (!canvas) return
 
     const game = new GameInstance(canvas)
-    game.start()  // fire-and-forget async (renderer inits then loop starts)
+    game.start()
 
     return () => {
       game.destroy()
@@ -24,19 +27,19 @@ export function SpeckWarsGame() {
         ref={canvasRef}
         style={{ display: 'block', width: '100%', height: '100%' }}
       />
-      <div
-        style={{
-          position: 'absolute',
-          top: 16,
-          left: 16,
-          color: 'rgba(255,255,255,0.8)',
-          fontSize: 24,
-          fontWeight: 'bold',
-          pointerEvents: 'none',
-        }}
-      >
-        Speck Wars
-      </div>
+      <HUD />
+    </div>
+  )
+}
+
+export function SpeckWarsGame() {
+  const phase = useSpeckWarsStore(s => s.phase)
+
+  return (
+    <div style={{ position: 'relative', width: '100%', height: '100%' }}>
+      <PhaseRouter>
+        {phase === 'playing' && <GameCanvas />}
+      </PhaseRouter>
     </div>
   )
 }

--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -1,0 +1,33 @@
+'use client'
+import { useSpeckWarsStore } from '../store'
+import { PLAYER_COLOR, AI_COLOR } from '../domain/constants'
+
+function colorHex(n: number) {
+  return `#${n.toString(16).padStart(6, '0')}`
+}
+
+export function HUD() {
+  const hud = useSpeckWarsStore(s => s.hud)
+  if (!hud) return null
+
+  return (
+    <div style={{
+      position: 'absolute', inset: 0, pointerEvents: 'none',
+      fontFamily: 'monospace', fontSize: 13, color: '#fff',
+    }}>
+      {/* Player stats — bottom left */}
+      <div style={{ position: 'absolute', bottom: 16, left: 16 }}>
+        {Object.entries(hud.players).map(([pid, data]) => {
+          const color = pid === 'player' ? colorHex(PLAYER_COLOR) : colorHex(AI_COLOR)
+          const label = pid === 'player' ? 'YOU' : 'AI'
+          const totalHp = Object.values(data.buildingHp).reduce((a, b) => a + b, 0)
+          return (
+            <div key={pid} style={{ marginBottom: 6, color }}>
+              <strong>{label}</strong> — specks: {data.speckCount} | bases: {data.buildingCount} | HP: {totalHp}
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/src/app/speck-wars/components/phase-router.tsx
+++ b/src/app/speck-wars/components/phase-router.tsx
@@ -1,0 +1,36 @@
+'use client'
+import { useSpeckWarsStore } from '../store'
+
+export function PhaseRouter({ children }: { children: React.ReactNode }) {
+  const { phase, winnerId, setPhase } = useSpeckWarsStore()
+
+  if (phase === 'menu') {
+    return (
+      <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', height: '100%', gap: 16 }}>
+        <h1 style={{ color: '#fff', fontSize: 48, margin: 0 }}>Speck Wars</h1>
+        <p style={{ color: '#aaa', margin: 0 }}>Destroy the enemy base. Last base standing wins.</p>
+        <button
+          onClick={() => setPhase('playing')}
+          style={{ padding: '12px 32px', fontSize: 18, cursor: 'pointer', background: '#4af7c4', border: 'none', borderRadius: 8, fontWeight: 'bold' }}
+        >
+          Play
+        </button>
+      </div>
+    )
+  }
+
+  if (phase === 'victory' || phase === 'defeat') {
+    const won = winnerId === 'player'
+    return (
+      <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', height: '100%', gap: 16 }}>
+        <h1 style={{ color: won ? '#4af7c4' : '#ff4f7b', fontSize: 48 }}>{won ? 'Victory' : 'Defeated'}</h1>
+        <button onClick={() => window.location.reload()} style={{ padding: '12px 32px', fontSize: 18, cursor: 'pointer' }}>
+          Play Again
+        </button>
+      </div>
+    )
+  }
+
+  // 'playing' — render game + HUD overlay
+  return <>{children}</>
+}

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -45,6 +45,10 @@ export class GameInstance {
     for (const event of this.sim.events) {
       if (event.type === 'GAME_OVER') {
         useSpeckWarsStore.getState().setPhase('victory')
+        useSpeckWarsStore.getState().setWinnerId(event.winnerId)
+      }
+      if (event.type === 'HUD_UPDATE') {
+        useSpeckWarsStore.getState().setHud(event.data)
       }
     }
 

--- a/src/app/speck-wars/store.ts
+++ b/src/app/speck-wars/store.ts
@@ -1,13 +1,22 @@
 import { create } from 'zustand'
+import type { HudData } from './domain/types'
 
 type GamePhase = 'menu' | 'playing' | 'paused' | 'victory' | 'defeat'
 
 interface SpeckWarsStore {
   phase: GamePhase
   setPhase: (phase: GamePhase) => void
+  winnerId: string | null
+  setWinnerId: (id: string) => void
+  hud: HudData | null
+  setHud: (data: HudData) => void
 }
 
 export const useSpeckWarsStore = create<SpeckWarsStore>()(set => ({
   phase: 'menu',
   setPhase: phase => set({ phase }),
+  winnerId: null,
+  setWinnerId: winnerId => set({ winnerId }),
+  hud: null,
+  setHud: hud => set({ hud }),
 }))


### PR DESCRIPTION
## Summary
- `store.ts`: added `winnerId`/`setWinnerId` and `hud`/`setHud` (HudData) alongside existing `phase`
- `hud.tsx`: renders live speck counts + total base HP per player; updates at ~6hz via `HUD_UPDATE` store events
- `phase-router.tsx`: menu screen (Play button → `setPhase('playing')`), victory/defeat screen (Play Again → reload), pass-through when playing
- `game-instance.ts`: calls `setHud()` on `HUD_UPDATE` events, `setWinnerId()` on `GAME_OVER`
- `SpeckWarsGame.tsx`: refactored — `GameCanvas` (canvas + HUD) only mounted when `phase === 'playing'`

Closes #1693

Depends on: #1710

## Test plan
- [ ] Menu screen shows on first load
- [ ] Clicking Play starts the simulation
- [ ] HUD shows live speck/base counts, updating every ~1.5s
- [ ] When a base is destroyed, victory/defeat screen appears
- [ ] Play Again reloads cleanly
- [ ] `npx tsc --noEmit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)