### PR TITLE
perf: Speck Wars pre-allocated SOA buffer + free-list — eliminates Float32Array churn

### DIFF
--- a/src/app/speck-wars/domain/constants.ts
+++ b/src/app/speck-wars/domain/constants.ts
@@ -12,3 +12,4 @@ export const AI_BASE_X = 2400
 export const AI_BASE_Y = 1500
 export const PLAYER_COLOR = 0x4af7c4
 export const AI_COLOR = 0xff4f7b
+export const MAX_SPECKS = 15000

--- a/src/app/speck-wars/domain/simulation/combat.ts
+++ b/src/app/speck-wars/domain/simulation/combat.ts
@@ -6,9 +6,11 @@ export function resolveCombat(sim: SimulationState, dt: number) {
   const { speckIds, speckX, speckY, speckHp, speckMeta, buildings, spatialGrid } = sim
 
   // --- Speck vs Speck combat ---
-  for (let i = 0; i < speckIds.length; i++) {
+  for (let i = 0; i < sim.speckCount; i++) {
+    if (!speckIds[i]) continue
     if (speckHp[i] <= 0) continue
     const meta = speckMeta[i]
+    if (!meta) continue
     const stype = SPECK_TYPES[meta.typeId]
     if (!stype) continue
 
@@ -20,7 +22,8 @@ export function resolveCombat(sim: SimulationState, dt: number) {
     const neighbors = spatialGrid.query(speckX[i], speckY[i])
     for (const j of neighbors) {
       if (i === j || speckHp[j] <= 0) continue
-      if (speckMeta[j].ownerId === meta.ownerId) continue  // friendly
+      const jMeta = speckMeta[j]
+      if (!jMeta || jMeta.ownerId === meta.ownerId) continue  // dead slot or friendly
 
       const dx = speckX[j] - speckX[i]
       const dy = speckY[j] - speckY[i]
@@ -38,9 +41,11 @@ export function resolveCombat(sim: SimulationState, dt: number) {
   }
 
   // --- Speck vs Building combat ---
-  for (let i = 0; i < speckIds.length; i++) {
+  for (let i = 0; i < sim.speckCount; i++) {
+    if (!speckIds[i]) continue
     if (speckHp[i] <= 0) continue
     const meta = speckMeta[i]
+    if (!meta) continue
     if (!meta.targetId) continue
     const building = buildings[meta.targetId]
     if (!building) continue
@@ -63,42 +68,22 @@ export function resolveCombat(sim: SimulationState, dt: number) {
         sim.events.push({ type: 'BUILDING_DESTROYED', buildingId: building.id, ownerId: building.ownerId })
         delete sim.buildings[building.id]
         // Clear target for all specks pointing at this building
-        for (const m of sim.speckMeta) {
-          if (m.targetId === building.id) m.targetId = null
+        for (let k = 0; k < sim.speckCount; k++) {
+          const m = sim.speckMeta[k]
+          if (m && m.targetId === building.id) m.targetId = null
         }
       }
     }
   }
 }
 
-// Remove dead specks — compact all SOA arrays in one pass
+// Mark dead specks and push their slots onto the free-list — no array allocation
 export function removeDeadSpecks(sim: SimulationState) {
-  const alive: number[] = []
-  for (let i = 0; i < sim.speckIds.length; i++) {
-    if (sim.speckHp[i] > 0) alive.push(i)
+  for (let i = 0; i < sim.speckCount; i++) {
+    if (sim.speckIds[i] !== '' && sim.speckHp[i] <= 0) {
+      sim.freeSlots.push(i)
+      sim.speckIds[i] = ''
+      sim.speckMeta[i] = null
+    }
   }
-
-  if (alive.length === sim.speckIds.length) return  // nothing to remove
-
-  const n = alive.length
-  const newX = new Float32Array(n)
-  const newY = new Float32Array(n)
-  const newVx = new Float32Array(n)
-  const newVy = new Float32Array(n)
-  const newHp = new Float32Array(n)
-  const newIds: string[] = []
-  const newMeta: SimulationState['speckMeta'] = []
-
-  for (let j = 0; j < alive.length; j++) {
-    const i = alive[j]
-    newX[j] = sim.speckX[i]; newY[j] = sim.speckY[i]
-    newVx[j] = sim.speckVx[i]; newVy[j] = sim.speckVy[i]
-    newHp[j] = sim.speckHp[i]
-    newIds.push(sim.speckIds[i])
-    newMeta.push(sim.speckMeta[i])
-  }
-
-  sim.speckX = newX; sim.speckY = newY
-  sim.speckVx = newVx; sim.speckVy = newVy; sim.speckHp = newHp
-  sim.speckIds = newIds; sim.speckMeta = newMeta
 }

--- a/src/app/speck-wars/domain/simulation/create-sim.ts
+++ b/src/app/speck-wars/domain/simulation/create-sim.ts
@@ -1,5 +1,5 @@
 import type { SimulationState, Player, BuildingEntity } from '../types'
-import { PLAYER_BASE_X, PLAYER_BASE_Y, AI_BASE_X, AI_BASE_Y, PLAYER_COLOR, AI_COLOR, BASE_HP } from '../constants'
+import { PLAYER_BASE_X, PLAYER_BASE_Y, AI_BASE_X, AI_BASE_Y, PLAYER_COLOR, AI_COLOR, BASE_HP, MAX_SPECKS } from '../constants'
 import { SpatialGrid } from './spatial-grid'
 
 export function createSim(seed: number = Date.now()): SimulationState {
@@ -36,13 +36,15 @@ export function createSim(seed: number = Date.now()): SimulationState {
     rngState: seed,
     players: { player, ai },
     buildings: { 'building-player-base': playerBase, 'building-ai-base': aiBase },
-    speckIds: [],
-    speckX: new Float32Array(0),
-    speckY: new Float32Array(0),
-    speckVx: new Float32Array(0),
-    speckVy: new Float32Array(0),
-    speckHp: new Float32Array(0),
-    speckMeta: [],
+    speckIds: new Array(MAX_SPECKS).fill(''),
+    speckX: new Float32Array(MAX_SPECKS),
+    speckY: new Float32Array(MAX_SPECKS),
+    speckVx: new Float32Array(MAX_SPECKS),
+    speckVy: new Float32Array(MAX_SPECKS),
+    speckHp: new Float32Array(MAX_SPECKS),
+    speckMeta: new Array(MAX_SPECKS).fill(null),
+    speckCount: 0,
+    freeSlots: [],
     inputQueue: [],
     events: [],
     rallyPoints: { player: null, ai: null },

--- a/src/app/speck-wars/domain/simulation/movement.ts
+++ b/src/app/speck-wars/domain/simulation/movement.ts
@@ -11,12 +11,14 @@ export function moveSpecks(sim: SimulationState, dt: number) {
 
   // Rebuild grid with current positions before applying separation
   spatialGrid.clear()
-  for (let i = 0; i < speckIds.length; i++) {
-    spatialGrid.insert(i, speckX[i], speckY[i])
+  for (let i = 0; i < sim.speckCount; i++) {
+    if (speckIds[i]) spatialGrid.insert(i, speckX[i], speckY[i])
   }
 
-  for (let i = 0; i < speckIds.length; i++) {
+  for (let i = 0; i < sim.speckCount; i++) {
+    if (!speckIds[i]) continue
     const meta = speckMeta[i]
+    if (!meta) continue
     const stype = SPECK_TYPES[meta.typeId]
     if (!stype) continue
 

--- a/src/app/speck-wars/domain/simulation/spawner.ts
+++ b/src/app/speck-wars/domain/simulation/spawner.ts
@@ -1,23 +1,29 @@
 import type { SimulationState, SpeckMeta } from '../types'
 import { SPECK_TYPES } from '../config/speck-types'
 import { BUILDING_TYPES } from '../config/building-types'
+import { MAX_SPECKS } from '../constants'
 
-// Resize all SOA arrays by 1 and insert a new speck at the end
+// Place a new speck into a recycled or fresh slot — never allocates new arrays
 function addSpeck(sim: SimulationState, meta: SpeckMeta, x: number, y: number) {
-  const n = sim.speckIds.length
+  const hp = SPECK_TYPES[meta.typeId]?.hp ?? 1
 
-  // Grow Float32Arrays
-  const newX = new Float32Array(n + 1); newX.set(sim.speckX); newX[n] = x
-  const newY = new Float32Array(n + 1); newY.set(sim.speckY); newY[n] = y
-  const newVx = new Float32Array(n + 1); newVx.set(sim.speckVx); newVx[n] = 0
-  const newVy = new Float32Array(n + 1); newVy.set(sim.speckVy); newVy[n] = 0
-  const newHp = new Float32Array(n + 1); newHp.set(sim.speckHp)
-  newHp[n] = SPECK_TYPES[meta.typeId]?.hp ?? 1
+  let slot: number
+  if (sim.freeSlots.length > 0) {
+    slot = sim.freeSlots.pop()!
+  } else if (sim.speckCount < MAX_SPECKS) {
+    slot = sim.speckCount
+    sim.speckCount++
+  } else {
+    return  // at capacity, drop spawn
+  }
 
-  sim.speckX = newX; sim.speckY = newY
-  sim.speckVx = newVx; sim.speckVy = newVy; sim.speckHp = newHp
-  sim.speckIds.push(meta.id)
-  sim.speckMeta.push(meta)
+  sim.speckX[slot] = x
+  sim.speckY[slot] = y
+  sim.speckVx[slot] = 0
+  sim.speckVy[slot] = 0
+  sim.speckHp[slot] = hp
+  sim.speckIds[slot] = meta.id
+  sim.speckMeta[slot] = meta
 
   sim.events.push({ type: 'SPECK_SPAWNED', speckId: meta.id, buildingId: '' })
 }

--- a/src/app/speck-wars/domain/simulation/speck-ai.ts
+++ b/src/app/speck-wars/domain/simulation/speck-ai.ts
@@ -4,8 +4,10 @@ import { SPECK_TYPES } from '../config/speck-types'
 export function runSpeckAI(sim: SimulationState) {
   const { speckIds, speckX, speckY, speckMeta, buildings } = sim
 
-  for (let i = 0; i < speckIds.length; i++) {
+  for (let i = 0; i < sim.speckCount; i++) {
+    if (!speckIds[i]) continue
     const meta = speckMeta[i]
+    if (!meta) continue
     const stype = SPECK_TYPES[meta.typeId]
     if (!stype) continue
 

--- a/src/app/speck-wars/domain/simulation/tick.ts
+++ b/src/app/speck-wars/domain/simulation/tick.ts
@@ -50,8 +50,13 @@ function emitHudUpdate(sim: SimulationState) {
   const data: Record<string, { speckCount: number; buildingCount: number; buildingHp: Record<string, number> }> = {}
   for (const [pid] of Object.entries(sim.players)) {
     const myBuildings = Object.values(sim.buildings).filter(b => b.ownerId === pid)
+    let liveCount = 0
+    for (let i = 0; i < sim.speckCount; i++) {
+      const m = sim.speckMeta[i]
+      if (m && m.ownerId === pid) liveCount++
+    }
     data[pid] = {
-      speckCount: sim.speckMeta.filter(m => m.ownerId === pid).length,
+      speckCount: liveCount,
       buildingCount: myBuildings.length,
       buildingHp: Object.fromEntries(myBuildings.map(b => [b.id, b.hp])),
     }

--- a/src/app/speck-wars/domain/types.ts
+++ b/src/app/speck-wars/domain/types.ts
@@ -42,7 +42,9 @@ export interface SimulationState {
   speckVx: Float32Array
   speckVy: Float32Array
   speckHp: Float32Array
-  speckMeta: SpeckMeta[]   // parallel to speckIds
+  speckMeta: (SpeckMeta | null)[]   // parallel to speckIds; null means dead/unused slot
+  speckCount: number       // high-water mark: indices 0..speckCount-1 may be live or freed
+  freeSlots: number[]      // recycled slot indices from dead specks
 
   inputQueue: InputEvent[]
   events: SimEvent[]

--- a/src/app/speck-wars/rendering/layers/speck-layer.ts
+++ b/src/app/speck-wars/rendering/layers/speck-layer.ts
@@ -26,10 +26,13 @@ export class SpeckLayer {
   }
 
   update(sim: SimulationState) {
-    // Group speck indices by owner
+    // Group live speck indices by owner
     const byOwner: Record<string, number[]> = {}
-    for (let i = 0; i < sim.speckIds.length; i++) {
-      const ownerId = sim.speckMeta[i].ownerId
+    for (let i = 0; i < sim.speckCount; i++) {
+      if (!sim.speckIds[i]) continue
+      const meta = sim.speckMeta[i]
+      if (!meta) continue
+      const ownerId = meta.ownerId
       if (!byOwner[ownerId]) byOwner[ownerId] = []
       byOwner[ownerId].push(i)
     }


### PR DESCRIPTION
## Summary

Eliminates GC pressure from Float32Array allocation at high speck counts.

**Before:** `addSpeck()` created 5 new `Float32Array(n+1)` per spawn; `removeDeadSpecks()` created 5 new arrays per death pass. At high spawn/death rates → GC spikes.

**After:** All 6 SOA arrays pre-allocated to `MAX_SPECKS = 15_000` at startup. Zero allocations during normal gameplay:
- `addSpeck()`: pops from `freeSlots[]` or advances `speckCount` high-water mark, writes into existing slot
- `removeDeadSpecks()`: marks slots dead (`speckIds[i] = ''`, `speckMeta[i] = null`), pushes to `freeSlots[]`

All iteration loops updated to iterate `0..speckCount` and skip empty slots (`!speckIds[i]` guard).

Closes #1694

Depends on: #1711

## Test plan
- [ ] Game plays correctly with many specks (no missing/ghost sprites)
- [ ] Chrome DevTools shows no GC spikes during active gameplay
- [ ] `speckCount` grows monotonically; `freeSlots` shrinks as specks die and get recycled
- [ ] `npx tsc --noEmit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)