### PR TITLE
feat: Speck Wars visual polish — world grid, death flash effects, base pulse

### DIFF
--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -52,7 +52,7 @@ export class GameInstance {
       }
     }
 
-    this.renderer.render(this.sim, this.camera)
+    this.renderer.render(this.sim, this.camera, dt)
 
     this.rafId = requestAnimationFrame(this.loop)
   }

--- a/src/app/speck-wars/rendering/layers/building-layer.ts
+++ b/src/app/speck-wars/rendering/layers/building-layer.ts
@@ -30,6 +30,12 @@ export class BuildingLayer {
       this.gfx.drawCircle(building.x, building.y, r)
       this.gfx.lineStyle(0)
 
+      // Pulse ring
+      const pulse = Math.sin(Date.now() / 800) * 0.3 + 0.7
+      this.gfx.lineStyle(2, color, pulse * 0.4)
+      this.gfx.drawCircle(building.x, building.y, r + 8)
+      this.gfx.lineStyle(0)
+
       // HP bar (above building)
       const barW = r * 2
       const barH = 4

--- a/src/app/speck-wars/rendering/layers/effects-layer.ts
+++ b/src/app/speck-wars/rendering/layers/effects-layer.ts
@@ -1,0 +1,34 @@
+import { Graphics, Container } from 'pixi.js'
+
+interface Flash { x: number; y: number; life: number; maxLife: number }
+
+export class EffectsLayer {
+  readonly stage: Container
+  private gfx: Graphics
+  private flashes: Flash[] = []
+
+  constructor() {
+    this.stage = new Container()
+    this.gfx = new Graphics()
+    this.stage.addChild(this.gfx)
+  }
+
+  addDeathFlash(x: number, y: number) {
+    this.flashes.push({ x, y, life: 300, maxLife: 300 })
+  }
+
+  update(dt: number) {
+    this.gfx.clear()
+    this.flashes = this.flashes.filter(f => f.life > 0)
+    for (const f of this.flashes) {
+      f.life -= dt
+      const alpha = f.life / f.maxLife
+      const r = 3 + (1 - alpha) * 4
+      this.gfx.beginFill(0xffffff, alpha)
+      this.gfx.drawCircle(f.x, f.y, r)
+      this.gfx.endFill()
+    }
+  }
+
+  destroy() { this.stage.destroy({ children: true }) }
+}

--- a/src/app/speck-wars/rendering/layers/grid-layer.ts
+++ b/src/app/speck-wars/rendering/layers/grid-layer.ts
@@ -1,0 +1,40 @@
+import { Graphics, Container } from 'pixi.js'
+import { WORLD_WIDTH, WORLD_HEIGHT } from '../../domain/constants'
+
+const GRID_SIZE = 200   // px between grid lines
+
+export class GridLayer {
+  readonly stage: Container
+  private gfx: Graphics
+
+  constructor() {
+    this.stage = new Container()
+    this.gfx = new Graphics()
+    this.stage.addChild(this.gfx)
+    this.draw()
+  }
+
+  private draw() {
+    this.gfx.clear()
+
+    // Vertical grid lines
+    this.gfx.lineStyle(1, 0xffffff, 0.05)
+    for (let x = 0; x <= WORLD_WIDTH; x += GRID_SIZE) {
+      this.gfx.moveTo(x, 0)
+      this.gfx.lineTo(x, WORLD_HEIGHT)
+    }
+
+    // Horizontal grid lines
+    for (let y = 0; y <= WORLD_HEIGHT; y += GRID_SIZE) {
+      this.gfx.moveTo(0, y)
+      this.gfx.lineTo(WORLD_WIDTH, y)
+    }
+
+    // World border
+    this.gfx.lineStyle(2, 0xffffff, 0.2)
+    this.gfx.drawRect(0, 0, WORLD_WIDTH, WORLD_HEIGHT)
+    this.gfx.lineStyle(0)
+  }
+
+  destroy() { this.stage.destroy({ children: true }) }
+}

--- a/src/app/speck-wars/rendering/renderer.ts
+++ b/src/app/speck-wars/rendering/renderer.ts
@@ -1,6 +1,8 @@
 import { Application, Container } from 'pixi.js'
 import { SpeckLayer } from './layers/speck-layer'
 import { BuildingLayer } from './layers/building-layer'
+import { GridLayer } from './layers/grid-layer'
+import { EffectsLayer } from './layers/effects-layer'
 import { createSpeckTexture } from './textures'
 import type { SimulationState } from '../domain/types'
 import { PLAYER_COLOR, AI_COLOR } from '../domain/constants'
@@ -28,6 +30,8 @@ export class Renderer {
   private world!: Container  // camera container
   private speckLayer!: SpeckLayer
   private buildingLayer!: BuildingLayer
+  private gridLayer!: GridLayer
+  private effectsLayer!: EffectsLayer
 
   async init(canvas: HTMLCanvasElement) {
     const app = new Application() as PixiApplication
@@ -44,22 +48,36 @@ export class Renderer {
     this.app.stage.addChild(this.world)
 
     const texture = createSpeckTexture(this.app, 4)
+    this.gridLayer = new GridLayer()
+    this.effectsLayer = new EffectsLayer()
     this.buildingLayer = new BuildingLayer()
     this.speckLayer = new SpeckLayer(texture, PLAYER_COLORS)
 
+    this.world.addChild(this.gridLayer.stage)
     this.world.addChild(this.buildingLayer.stage)
+    this.world.addChild(this.effectsLayer.stage)
     this.world.addChild(this.speckLayer.stage)
   }
 
-  render(sim: SimulationState, camera: { x: number; y: number; zoom: number }) {
+  render(sim: SimulationState, camera: { x: number; y: number; zoom: number }, dt: number) {
     this.world.position.set(camera.x, camera.y)
     this.world.scale.set(camera.zoom)
 
     this.buildingLayer.update(sim, PLAYER_COLORS)
     this.speckLayer.update(sim)
+
+    // Process death flash events from this tick
+    for (const event of sim.events) {
+      if (event.type === 'SPECK_DIED') {
+        this.effectsLayer.addDeathFlash(event.x, event.y)
+      }
+    }
+    this.effectsLayer.update(dt)
   }
 
   destroy() {
+    this.gridLayer.destroy()
+    this.effectsLayer.destroy()
     this.speckLayer.destroy()
     this.buildingLayer.destroy()
     this.app.destroy()


### PR DESCRIPTION
## Summary
- `grid-layer.ts`: static 200px faint grid + world border drawn once at init; gives spatial reference while panning/zooming
- `effects-layer.ts`: white flash circles at each `SPECK_DIED` position, expanding radius 3→7 and fading over 300ms; zero allocations per frame when idle
- `building-layer.ts`: pulsing outer ring on each base using `Math.sin(Date.now()/800)` for organic oscillation
- `renderer.ts`: layer order grid → buildings → effects → specks; death flash events consumed from `sim.events` each render call; `dt` added to `render()` signature
- `game-instance.ts`: passes `dt` to `renderer.render()`

Closes #1695

Depends on: #1712

## Test plan
- [ ] Grid lines visible at all zoom levels (faint, not distracting)
- [ ] World border clearly visible at edges
- [ ] White flashes appear at speck death positions
- [ ] Bases have animated outer ring
- [ ] No performance regression
- [ ] `npx tsc --noEmit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)