### PR TITLE
feat: Speck Wars player click-to-rally — left-click to redirect specks

### DIFF
--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -29,7 +29,10 @@ export class GameInstance {
   async start() {
     console.log('GameInstance started')
     await this.renderer.init(this.canvas)
-    this.inputHandler = new InputHandler(this.canvas, this.camera)
+    this.inputHandler = new InputHandler(this.canvas, this.camera, (wx, wy) => {
+      this.sim.inputQueue.push({ type: 'RALLY', ownerId: 'player', x: wx, y: wy })
+      this.renderer.showRallyPing(wx, wy)
+    })
     this.lastTime = performance.now()
     this.loop(this.lastTime)
   }

--- a/src/app/speck-wars/input/input-handler.ts
+++ b/src/app/speck-wars/input/input-handler.ts
@@ -1,16 +1,20 @@
 import type { Camera } from '../rendering/camera'
-import { zoomAt } from '../rendering/camera'
+import { zoomAt, screenToWorld } from '../rendering/camera'
 
 export class InputHandler {
   private canvas: HTMLCanvasElement
   private camera: Camera
+  private onRally?: (worldX: number, worldY: number) => void
   private isDragging = false
   private lastX = 0
   private lastY = 0
+  private mouseDownX = 0
+  private mouseDownY = 0
 
-  constructor(canvas: HTMLCanvasElement, camera: Camera) {
+  constructor(canvas: HTMLCanvasElement, camera: Camera, onRally?: (worldX: number, worldY: number) => void) {
     this.canvas = canvas
     this.camera = camera
+    this.onRally = onRally
     this.attach()
   }
 
@@ -29,7 +33,10 @@ export class InputHandler {
     this.isDragging = true
     this.lastX = e.clientX
     this.lastY = e.clientY
+    this.mouseDownX = e.clientX
+    this.mouseDownY = e.clientY
   }
+
   private onMouseMove = (e: MouseEvent) => {
     if (!this.isDragging) return
     this.camera.x += e.clientX - this.lastX
@@ -37,7 +44,22 @@ export class InputHandler {
     this.lastX = e.clientX
     this.lastY = e.clientY
   }
-  private onMouseUp = () => { this.isDragging = false }
+
+  private onMouseUp = (e: MouseEvent) => {
+    const dx = e.clientX - this.mouseDownX
+    const dy = e.clientY - this.mouseDownY
+    const dist = Math.sqrt(dx * dx + dy * dy)
+
+    if (dist < 5 && this.onRally) {
+      const rect = this.canvas.getBoundingClientRect()
+      const sx = e.clientX - rect.left
+      const sy = e.clientY - rect.top
+      const world = screenToWorld(sx, sy, this.camera)
+      this.onRally(world.x, world.y)
+    }
+
+    this.isDragging = false
+  }
 
   private onWheel = (e: WheelEvent) => {
     e.preventDefault()
@@ -55,6 +77,7 @@ export class InputHandler {
       this.lastY = e.touches[0].clientY
     }
   }
+
   private onTouchMove = (e: TouchEvent) => {
     if (!this.isDragging || e.touches.length !== 1) return
     e.preventDefault()
@@ -63,6 +86,7 @@ export class InputHandler {
     this.lastX = e.touches[0].clientX
     this.lastY = e.touches[0].clientY
   }
+
   private onTouchEnd = () => { this.isDragging = false }
 
   destroy() {

--- a/src/app/speck-wars/rendering/layers/effects-layer.ts
+++ b/src/app/speck-wars/rendering/layers/effects-layer.ts
@@ -1,11 +1,13 @@
 import { Graphics, Container } from 'pixi.js'
 
 interface Flash { x: number; y: number; life: number; maxLife: number }
+interface Ping { x: number; y: number; life: number; maxLife: number }
 
 export class EffectsLayer {
   readonly stage: Container
   private gfx: Graphics
   private flashes: Flash[] = []
+  private pings: Ping[] = []
 
   constructor() {
     this.stage = new Container()
@@ -17,8 +19,23 @@ export class EffectsLayer {
     this.flashes.push({ x, y, life: 300, maxLife: 300 })
   }
 
+  showRallyPing(x: number, y: number) {
+    this.pings.push({ x, y, life: 400, maxLife: 400 })
+  }
+
   update(dt: number) {
     this.gfx.clear()
+
+    this.pings = this.pings.filter(p => p.life > 0)
+    for (const p of this.pings) {
+      p.life -= dt
+      const alpha = p.life / p.maxLife
+      const r = (1 - alpha) * 24 + 4   // expands from 4 to 28
+      this.gfx.lineStyle(2, 0x4af7c4, alpha * 0.8)
+      this.gfx.drawCircle(p.x, p.y, r)
+      this.gfx.lineStyle(0)  // reset
+    }
+
     this.flashes = this.flashes.filter(f => f.life > 0)
     for (const f of this.flashes) {
       f.life -= dt

--- a/src/app/speck-wars/rendering/renderer.ts
+++ b/src/app/speck-wars/rendering/renderer.ts
@@ -75,6 +75,10 @@ export class Renderer {
     this.effectsLayer.update(dt)
   }
 
+  showRallyPing(x: number, y: number) {
+    this.effectsLayer.showRallyPing(x, y)
+  }
+
   destroy() {
     this.gridLayer.destroy()
     this.effectsLayer.destroy()


### PR DESCRIPTION
## Summary

Makes the game interactive — the player can now click anywhere on the canvas to redirect their specks to that world position.

- `input-handler.ts`: tracks drag distance on mousedown/mouseup; fires `onRally(worldX, worldY)` callback if distance < 5px (distinguishes click from pan drag); converts screen → world via `screenToWorld()`
- `effects-layer.ts`: `showRallyPing(x, y)` draws an expanding teal ring (radius 4→28) fading over 400ms for visual click feedback
- `renderer.ts`: exposes `showRallyPing()` delegating to `effectsLayer`
- `game-instance.ts`: `InputHandler` receives `onRally` callback that pushes `RALLY` `InputEvent` to `sim.inputQueue` + triggers ping

Closes #1714

Depends on: #1713

## Test plan
- [ ] Clicking on the canvas redirects player specks toward the click position
- [ ] Teal expanding ring appears at click position
- [ ] Dragging still pans (no accidental rallies)
- [ ] `npx tsc --noEmit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)