### PR TITLE
feat: Speck Wars minimap — real-time 160×160 world overview

### DIFF
--- a/src/app/speck-wars/SpeckWarsGame.tsx
+++ b/src/app/speck-wars/SpeckWarsGame.tsx
@@ -5,19 +5,23 @@ import { GameInstance } from './game-instance'
 import { useSpeckWarsStore } from './store'
 import { HUD } from './components/hud'
 import { PhaseRouter } from './components/phase-router'
+import { Minimap } from './components/minimap'
 
 function GameCanvas() {
   const canvasRef = useRef<HTMLCanvasElement>(null)
+  const gameRef = useRef<GameInstance | null>(null)
 
   useEffect(() => {
     const canvas = canvasRef.current
     if (!canvas) return
 
     const game = new GameInstance(canvas)
+    gameRef.current = game
     game.start()
 
     return () => {
       game.destroy()
+      gameRef.current = null
     }
   }, [])
 
@@ -28,6 +32,7 @@ function GameCanvas() {
         style={{ display: 'block', width: '100%', height: '100%' }}
       />
       <HUD />
+      <Minimap gameRef={gameRef} />
     </div>
   )
 }

--- a/src/app/speck-wars/components/minimap.tsx
+++ b/src/app/speck-wars/components/minimap.tsx
@@ -1,0 +1,123 @@
+'use client'
+import { useEffect, useRef } from 'react'
+import type { GameInstance } from '../game-instance'
+import { WORLD_WIDTH, WORLD_HEIGHT, PLAYER_COLOR, AI_COLOR } from '../domain/constants'
+
+const MAP_W = 160
+const MAP_H = 160
+const SCALE_X = MAP_W / WORLD_WIDTH
+const SCALE_Y = MAP_H / WORLD_HEIGHT
+
+function hexColor(n: number): string {
+  return `#${n.toString(16).padStart(6, '0')}`
+}
+
+interface MinimapProps {
+  gameRef: React.RefObject<GameInstance | null>
+}
+
+export function Minimap({ gameRef }: MinimapProps) {
+  const canvasRef = useRef<HTMLCanvasElement>(null)
+
+  useEffect(() => {
+    let rafId: number
+    let lastDraw = 0
+
+    const draw = (now: number) => {
+      rafId = requestAnimationFrame(draw)
+      if (now - lastDraw < 100) return  // ~10fps
+      lastDraw = now
+
+      const canvas = canvasRef.current
+      const game = gameRef.current
+      if (!canvas || !game) return
+
+      const ctx = canvas.getContext('2d')
+      if (!ctx) return
+
+      const sim = game.getSim()
+      const camera = game.getCamera()
+
+      // Clear
+      ctx.clearRect(0, 0, MAP_W, MAP_H)
+      ctx.fillStyle = 'rgba(0,0,0,0.65)'
+      ctx.fillRect(0, 0, MAP_W, MAP_H)
+
+      // Draw specks (sample every 4th for performance)
+      const playerColor = hexColor(PLAYER_COLOR)
+      const aiColor = hexColor(AI_COLOR)
+      for (let i = 0; i < sim.speckCount; i += 4) {
+        if (!sim.speckIds[i] || !sim.speckMeta[i]) continue
+        const ownerId = sim.speckMeta[i]!.ownerId
+        ctx.fillStyle = ownerId === 'player' ? playerColor : aiColor
+        ctx.fillRect(
+          sim.speckX[i] * SCALE_X,
+          sim.speckY[i] * SCALE_Y,
+          1.5, 1.5
+        )
+      }
+
+      // Draw buildings
+      for (const building of Object.values(sim.buildings)) {
+        ctx.fillStyle = building.ownerId === 'player' ? playerColor : aiColor
+        const bx = building.x * SCALE_X
+        const by = building.y * SCALE_Y
+        ctx.beginPath()
+        ctx.arc(bx, by, 4, 0, Math.PI * 2)
+        ctx.fill()
+        // HP ring
+        const hpFrac = building.hp / building.maxHp
+        ctx.strokeStyle = hpFrac > 0.5 ? '#44ff88' : '#ff4444'
+        ctx.lineWidth = 1
+        ctx.beginPath()
+        ctx.arc(bx, by, 5, -Math.PI / 2, -Math.PI / 2 + Math.PI * 2 * hpFrac)
+        ctx.stroke()
+      }
+
+      // Draw viewport rectangle
+      // The camera maps world→screen as: screenX = worldX * zoom + camera.x
+      // Use window dimensions as the screen size approximation
+      const sw = window.innerWidth
+      const sh = window.innerHeight
+      const wLeft = (0 - camera.x) / camera.zoom
+      const wTop = (0 - camera.y) / camera.zoom
+      const wRight = (sw - camera.x) / camera.zoom
+      const wBottom = (sh - camera.y) / camera.zoom
+
+      ctx.strokeStyle = 'rgba(255,255,255,0.5)'
+      ctx.lineWidth = 1
+      ctx.strokeRect(
+        wLeft * SCALE_X,
+        wTop * SCALE_Y,
+        (wRight - wLeft) * SCALE_X,
+        (wBottom - wTop) * SCALE_Y
+      )
+
+      // Border
+      ctx.strokeStyle = 'rgba(255,255,255,0.3)'
+      ctx.lineWidth = 1
+      ctx.strokeRect(0, 0, MAP_W, MAP_H)
+    }
+
+    rafId = requestAnimationFrame(draw)
+    return () => cancelAnimationFrame(rafId)
+  }, [gameRef])
+
+  return (
+    <canvas
+      ref={canvasRef}
+      width={MAP_W}
+      height={MAP_H}
+      style={{
+        position: 'absolute',
+        bottom: 16,
+        right: 16,
+        width: MAP_W,
+        height: MAP_H,
+        borderRadius: 4,
+        imageRendering: 'pixelated',
+        pointerEvents: 'none',
+      }}
+    />
+  )
+}


### PR DESCRIPTION
## Summary

Adds a 160×160 minimap in the bottom-right corner showing:
- Player specks (teal dots) and AI specks (pink dots) — every 4th speck sampled for perf
- Buildings as filled circles with HP arc rings (green → red)
- Camera viewport rectangle (white outline) updating as player pans/zooms

Renders at ~10fps via `requestAnimationFrame` throttle. Uses a raw `<canvas>` (not PixiJS) to keep it decoupled from the render pipeline.

Closes #1716

Depends on: #1715

## Test plan
- [ ] Minimap shows in bottom-right corner during gameplay
- [ ] Player specks (teal) and AI specks (pink) visible as clusters
- [ ] Buildings shown with HP rings
- [ ] Viewport rect updates on pan/zoom
- [ ] `npx tsc --noEmit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)