### PR TITLE
feat: Speck Wars difficulty selector — Easy / Medium / Hard AI

### DIFF
--- a/src/app/speck-wars/components/phase-router.tsx
+++ b/src/app/speck-wars/components/phase-router.tsx
@@ -2,13 +2,40 @@
 import { useSpeckWarsStore } from '../store'
 
 export function PhaseRouter({ children }: { children: React.ReactNode }) {
-  const { phase, winnerId, setPhase } = useSpeckWarsStore()
+  const { phase, winnerId, setPhase, difficulty, setDifficulty } = useSpeckWarsStore()
+
+  const difficulties: Array<{ key: 'easy' | 'medium' | 'hard'; label: string; color: string }> = [
+    { key: 'easy', label: 'Easy', color: '#44ff88' },
+    { key: 'medium', label: 'Medium', color: '#ffcc44' },
+    { key: 'hard', label: 'Hard', color: '#ff4f7b' },
+  ]
 
   if (phase === 'menu') {
     return (
       <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', height: '100%', gap: 16 }}>
         <h1 style={{ color: '#fff', fontSize: 48, margin: 0 }}>Speck Wars</h1>
         <p style={{ color: '#aaa', margin: 0 }}>Destroy the enemy base. Last base standing wins.</p>
+        <div style={{ display: 'flex', gap: 8, marginBottom: 8 }}>
+          {difficulties.map(d => (
+            <button
+              key={d.key}
+              onClick={() => setDifficulty(d.key)}
+              style={{
+                padding: '8px 20px',
+                fontSize: 14,
+                cursor: 'pointer',
+                border: `2px solid ${difficulty === d.key ? d.color : 'rgba(255,255,255,0.2)'}`,
+                borderRadius: 6,
+                background: difficulty === d.key ? `${d.color}22` : 'transparent',
+                color: difficulty === d.key ? d.color : 'rgba(255,255,255,0.5)',
+                fontWeight: difficulty === d.key ? 'bold' : 'normal',
+                transition: 'all 0.15s',
+              }}
+            >
+              {d.label}
+            </button>
+          ))}
+        </div>
         <button
           onClick={() => setPhase('playing')}
           style={{ padding: '12px 32px', fontSize: 18, cursor: 'pointer', background: '#4af7c4', border: 'none', borderRadius: 8, fontWeight: 'bold' }}

--- a/src/app/speck-wars/domain/simulation/create-sim.ts
+++ b/src/app/speck-wars/domain/simulation/create-sim.ts
@@ -1,8 +1,15 @@
 import type { SimulationState, Player, BuildingEntity } from '../types'
 import { PLAYER_BASE_X, PLAYER_BASE_Y, AI_BASE_X, AI_BASE_Y, PLAYER_COLOR, AI_COLOR, BASE_HP, MAX_SPECKS } from '../constants'
 import { SpatialGrid } from './spatial-grid'
+import type { Difficulty } from '../../store'
 
-export function createSim(seed: number = Date.now()): SimulationState {
+const aiSpawnInterval: Record<Difficulty, number> = {
+  easy: 2000,
+  medium: 800,
+  hard: 400,
+}
+
+export function createSim(seed: number = Date.now(), difficulty: Difficulty = 'medium'): SimulationState {
   const playerBase: BuildingEntity = {
     id: 'building-player-base',
     typeId: 'base',
@@ -19,6 +26,7 @@ export function createSim(seed: number = Date.now()): SimulationState {
     x: AI_BASE_X, y: AI_BASE_Y,
     hp: BASE_HP, maxHp: BASE_HP,
     spawnTimer: 0,
+    spawnIntervalOverride: aiSpawnInterval[difficulty],
     inputBuffer: {},
   }
 

--- a/src/app/speck-wars/domain/simulation/spawner.ts
+++ b/src/app/speck-wars/domain/simulation/spawner.ts
@@ -39,7 +39,7 @@ export function updateSpawners(sim: SimulationState, dt: number) {
     building.spawnTimer -= dt
     if (building.spawnTimer > 0) continue
 
-    building.spawnTimer = btype.spawnInterval
+    building.spawnTimer = building.spawnIntervalOverride ?? btype.spawnInterval
 
     for (let i = 0; i < btype.spawnCount; i++) {
       // Spawn just outside the building radius with slight random offset

--- a/src/app/speck-wars/domain/types.ts
+++ b/src/app/speck-wars/domain/types.ts
@@ -16,6 +16,7 @@ export interface BuildingEntity {
   x: number; y: number
   hp: number; maxHp: number
   spawnTimer: number       // ms until next spawn
+  spawnIntervalOverride?: number  // overrides BUILDING_TYPES spawnInterval when set
   inputBuffer: Record<string, number>  // typeId → count (sacrifice system, future)
 }
 

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -20,10 +20,12 @@ export class GameInstance {
 
   constructor(canvas: HTMLCanvasElement) {
     this.canvas = canvas
-    this.sim = createSim()
+    const difficulty = useSpeckWarsStore.getState().difficulty
+    const aiTickInterval: Record<'easy' | 'medium' | 'hard', number> = { easy: 60, medium: 30, hard: 15 }
+    this.sim = createSim(Date.now(), difficulty)
     this.renderer = new Renderer()
     this.camera = createCamera(canvas.clientWidth, canvas.clientHeight)
-    this.aiController = new AIController('ai')
+    this.aiController = new AIController('ai', aiTickInterval[difficulty])
   }
 
   async start() {

--- a/src/app/speck-wars/store.ts
+++ b/src/app/speck-wars/store.ts
@@ -2,6 +2,7 @@ import { create } from 'zustand'
 import type { HudData } from './domain/types'
 
 type GamePhase = 'menu' | 'playing' | 'paused' | 'victory' | 'defeat'
+export type Difficulty = 'easy' | 'medium' | 'hard'
 
 interface SpeckWarsStore {
   phase: GamePhase
@@ -10,6 +11,8 @@ interface SpeckWarsStore {
   setWinnerId: (id: string) => void
   hud: HudData | null
   setHud: (data: HudData) => void
+  difficulty: Difficulty
+  setDifficulty: (d: Difficulty) => void
 }
 
 export const useSpeckWarsStore = create<SpeckWarsStore>()(set => ({
@@ -19,4 +22,6 @@ export const useSpeckWarsStore = create<SpeckWarsStore>()(set => ({
   setWinnerId: winnerId => set({ winnerId }),
   hud: null,
   setHud: hud => set({ hud }),
+  difficulty: 'medium',
+  setDifficulty: difficulty => set({ difficulty }),
 }))


### PR DESCRIPTION
## Summary
- `store.ts`: `Difficulty` type + `difficulty`/`setDifficulty` in store
- `phase-router.tsx`: three styled toggle buttons in menu (Easy=green, Medium=yellow, Hard=pink) with active state highlighting
- `types.ts`: `spawnIntervalOverride?` optional field on `BuildingEntity`
- `create-sim.ts`: AI base gets `spawnIntervalOverride` from difficulty map (Easy: 2000ms, Medium: 800ms, Hard: 400ms)
- `spawner.ts`: uses `building.spawnIntervalOverride ?? btype.spawnInterval`
- `game-instance.ts`: reads difficulty from store at construction time; passes to `createSim()` and derives `AIController` tick interval (Easy: 60t, Med: 30t, Hard: 15t)

Closes #1718

Depends on: #1717

## Test plan
- [ ] Menu shows Easy/Medium/Hard buttons, selected is highlighted
- [ ] Easy: AI spawns specks noticeably slower, less reactive
- [ ] Hard: AI spawns faster and rallies more aggressively
- [ ] `npx tsc --noEmit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)