### PR TITLE
feat: Speck Wars neutral outposts — capturable mid-map spawn points

### DIFF
--- a/src/app/speck-wars/components/minimap.tsx
+++ b/src/app/speck-wars/components/minimap.tsx
@@ -58,12 +58,16 @@ export function Minimap({ gameRef }: MinimapProps) {
       }
 
       // Draw buildings
+      const neutralColor = '#888888'
       for (const building of Object.values(sim.buildings)) {
-        ctx.fillStyle = building.ownerId === 'player' ? playerColor : aiColor
+        ctx.fillStyle = building.ownerId === 'player' ? playerColor
+          : building.ownerId === 'ai' ? aiColor
+          : neutralColor
         const bx = building.x * SCALE_X
         const by = building.y * SCALE_Y
+        const buildingRadius = building.typeId === 'outpost' ? 3 : 4
         ctx.beginPath()
-        ctx.arc(bx, by, 4, 0, Math.PI * 2)
+        ctx.arc(bx, by, buildingRadius, 0, Math.PI * 2)
         ctx.fill()
         // HP ring
         const hpFrac = building.hp / building.maxHp

--- a/src/app/speck-wars/domain/config/building-types.ts
+++ b/src/app/speck-wars/domain/config/building-types.ts
@@ -13,4 +13,10 @@ export const BUILDING_TYPES: Record<string, BuildingTypeDefinition> = {
     spawnTypeId: 'basic',
     spawnInterval: 800, spawnCount: 1,
   },
+  outpost: {
+    id: 'outpost', name: 'Outpost',
+    maxHp: 50, size: 20,
+    spawnTypeId: 'basic',
+    spawnInterval: 1800, spawnCount: 1,
+  },
 }

--- a/src/app/speck-wars/domain/constants.ts
+++ b/src/app/speck-wars/domain/constants.ts
@@ -13,3 +13,16 @@ export const AI_BASE_Y = 1500
 export const PLAYER_COLOR = 0x4af7c4
 export const AI_COLOR = 0xff4f7b
 export const MAX_SPECKS = 15000
+
+export const OUTPOST_SIZE = 20
+export const OUTPOST_SPAWN_INTERVAL = 1800   // ms per speck (slower than base)
+export const CAPTURE_RADIUS = 100            // px — specks within this distance count toward capture
+export const CAPTURE_TIME = 5000             // ms to fully capture
+export const NEUTRAL_COLOR = 0x888888
+
+// Triangle around center (1500, 1500), equidistant between the two bases
+export const OUTPOST_POSITIONS = [
+  { id: 'outpost-top',   x: 1500, y: 700  },
+  { id: 'outpost-left',  x: 850,  y: 2200 },
+  { id: 'outpost-right', x: 2150, y: 2200 },
+] as const

--- a/src/app/speck-wars/domain/simulation/capture.ts
+++ b/src/app/speck-wars/domain/simulation/capture.ts
@@ -1,0 +1,44 @@
+import type { SimulationState } from '../types'
+import { CAPTURE_RADIUS, CAPTURE_TIME } from '../constants'
+
+export function updateCapture(sim: SimulationState, dt: number) {
+  for (const building of Object.values(sim.buildings)) {
+    if (building.typeId !== 'outpost') continue
+
+    // Count nearby specks by owner (not neutral)
+    const counts: Record<string, number> = {}
+    const nearby = sim.spatialGrid.query(building.x, building.y)
+    const r2 = CAPTURE_RADIUS * CAPTURE_RADIUS
+    for (const idx of nearby) {
+      const meta = sim.speckMeta[idx]
+      if (!meta || meta.ownerId === 'neutral') continue
+      const dx = sim.speckX[idx] - building.x
+      const dy = sim.speckY[idx] - building.y
+      if (dx * dx + dy * dy > r2) continue
+      counts[meta.ownerId] = (counts[meta.ownerId] ?? 0) + 1
+    }
+
+    // Find player-owned specks (exclude neutral)
+    const sides = Object.entries(counts).filter(([, n]) => n > 0)
+    if (sides.length === 0) return  // nobody near — decay progress slowly
+    if (sides.length > 1) continue  // contested — pause capture
+
+    const [dominantOwner] = sides[0]
+    if (dominantOwner === building.ownerId) continue  // already owned by them
+
+    // Start or continue capture
+    if (building.captureSide !== dominantOwner) {
+      building.captureSide = dominantOwner
+      building.captureProgress = 0
+    }
+
+    building.captureProgress = (building.captureProgress ?? 0) + dt / CAPTURE_TIME
+    if ((building.captureProgress ?? 0) >= 1) {
+      building.ownerId = dominantOwner
+      building.captureProgress = 0
+      building.captureSide = null
+      // Reset spawn timer so it starts fresh for the new owner
+      building.spawnTimer = 0
+    }
+  }
+}

--- a/src/app/speck-wars/domain/simulation/create-sim.ts
+++ b/src/app/speck-wars/domain/simulation/create-sim.ts
@@ -1,5 +1,5 @@
 import type { SimulationState, Player, BuildingEntity } from '../types'
-import { PLAYER_BASE_X, PLAYER_BASE_Y, AI_BASE_X, AI_BASE_Y, PLAYER_COLOR, AI_COLOR, BASE_HP, MAX_SPECKS } from '../constants'
+import { PLAYER_BASE_X, PLAYER_BASE_Y, AI_BASE_X, AI_BASE_Y, PLAYER_COLOR, AI_COLOR, BASE_HP, MAX_SPECKS, NEUTRAL_COLOR, OUTPOST_POSITIONS } from '../constants'
 import { SpatialGrid } from './spatial-grid'
 import type { Difficulty } from '../../store'
 
@@ -38,12 +38,29 @@ export function createSim(seed: number = Date.now(), difficulty: Difficulty = 'm
     id: 'ai', name: 'AI',
     color: AI_COLOR, isAI: true, isDefeated: false, stockpile: {},
   }
+  const neutral: Player = {
+    id: 'neutral', name: 'Neutral',
+    color: NEUTRAL_COLOR, isAI: false, isDefeated: false, stockpile: {},
+  }
+
+  const outpostBuildings: Record<string, BuildingEntity> = {}
+  for (const pos of OUTPOST_POSITIONS) {
+    outpostBuildings[pos.id] = {
+      id: pos.id,
+      typeId: 'outpost',
+      ownerId: 'neutral',
+      x: pos.x, y: pos.y,
+      hp: 50, maxHp: 50,
+      spawnTimer: 0,
+      inputBuffer: {},
+    }
+  }
 
   return {
     tick: 0,
     rngState: seed,
-    players: { player, ai },
-    buildings: { 'building-player-base': playerBase, 'building-ai-base': aiBase },
+    players: { player, ai, neutral },
+    buildings: { 'building-player-base': playerBase, 'building-ai-base': aiBase, ...outpostBuildings },
     speckIds: new Array(MAX_SPECKS).fill(''),
     speckX: new Float32Array(MAX_SPECKS),
     speckY: new Float32Array(MAX_SPECKS),

--- a/src/app/speck-wars/domain/simulation/spawner.ts
+++ b/src/app/speck-wars/domain/simulation/spawner.ts
@@ -32,6 +32,7 @@ let speckCounter = 0
 
 export function updateSpawners(sim: SimulationState, dt: number) {
   for (const building of Object.values(sim.buildings)) {
+    if (building.ownerId === 'neutral') continue
     const btype = BUILDING_TYPES[building.typeId]
     if (!btype?.spawnTypeId) continue
     if (sim.players[building.ownerId]?.isDefeated) continue

--- a/src/app/speck-wars/domain/simulation/tick.ts
+++ b/src/app/speck-wars/domain/simulation/tick.ts
@@ -4,6 +4,7 @@ import { runSpeckAI } from './speck-ai'
 import { moveSpecks } from './movement'
 import { resolveCombat, removeDeadSpecks } from './combat'
 import { checkVictory } from './victory'
+import { updateCapture } from './capture'
 import { HUD_UPDATE_INTERVAL } from '../constants'
 
 export function tick(sim: SimulationState, dt: number): SimulationState {
@@ -27,10 +28,13 @@ export function tick(sim: SimulationState, dt: number): SimulationState {
   // 6. Remove dead specks (compact arrays)
   removeDeadSpecks(sim)
 
-  // 7. Check win/loss
+  // 7. Update outpost capture progress
+  updateCapture(sim, dt)
+
+  // 8. Check win/loss
   checkVictory(sim)
 
-  // 8. Emit HUD update every N ticks
+  // 9. Emit HUD update every N ticks
   sim.tick++
   if (sim.tick % HUD_UPDATE_INTERVAL === 0) emitHudUpdate(sim)
 

--- a/src/app/speck-wars/domain/simulation/victory.ts
+++ b/src/app/speck-wars/domain/simulation/victory.ts
@@ -3,13 +3,14 @@ import type { SimulationState } from '../types'
 export function checkVictory(sim: SimulationState) {
   for (const [pid, player] of Object.entries(sim.players)) {
     if (player.isDefeated) continue
+    if (pid === 'neutral') continue  // neutral is never defeated and never wins
     const hasBuildings = Object.values(sim.buildings).some(b => b.ownerId === pid)
     if (!hasBuildings) {
       player.isDefeated = true
     }
   }
 
-  const alive = Object.values(sim.players).filter(p => !p.isDefeated)
+  const alive = Object.values(sim.players).filter(p => !p.isDefeated && p.id !== 'neutral')
   if (alive.length === 1) {
     sim.events.push({ type: 'GAME_OVER', winnerId: alive[0].id })
   }

--- a/src/app/speck-wars/domain/types.ts
+++ b/src/app/speck-wars/domain/types.ts
@@ -18,6 +18,8 @@ export interface BuildingEntity {
   spawnTimer: number       // ms until next spawn
   spawnIntervalOverride?: number  // overrides BUILDING_TYPES spawnInterval when set
   inputBuffer: Record<string, number>  // typeId → count (sacrifice system, future)
+  captureProgress?: number      // 0..1 progress toward capture for captureSide
+  captureSide?: string | null   // which player is currently winning capture
 }
 
 export interface Player {

--- a/src/app/speck-wars/rendering/layers/building-layer.ts
+++ b/src/app/speck-wars/rendering/layers/building-layer.ts
@@ -1,6 +1,7 @@
 import { Graphics, Container } from 'pixi.js'
 import type { SimulationState } from '../../domain/types'
 import { BUILDING_TYPES } from '../../domain/config/building-types'
+import { NEUTRAL_COLOR } from '../../domain/constants'
 
 export class BuildingLayer {
   readonly stage: Container
@@ -17,7 +18,7 @@ export class BuildingLayer {
 
     for (const building of Object.values(sim.buildings)) {
       const btype = BUILDING_TYPES[building.typeId]
-      const color = playerColors[building.ownerId] ?? 0xffffff
+      const color = building.ownerId === 'neutral' ? NEUTRAL_COLOR : (playerColors[building.ownerId] ?? 0xffffff)
       const r = btype?.size ?? 20
 
       // Base circle
@@ -50,6 +51,17 @@ export class BuildingLayer {
       this.gfx.beginFill(hpFrac > 0.5 ? 0x44ff88 : 0xff4444)
       this.gfx.drawRect(barX, barY, barW * hpFrac, barH)
       this.gfx.endFill()
+
+      // Capture progress ring
+      if (building.captureProgress && building.captureProgress > 0 && building.captureSide) {
+        const capColor = playerColors[building.captureSide] ?? 0xffffff
+        this.gfx.lineStyle(3, capColor, 0.9)
+        const startAngle = -Math.PI / 2
+        const endAngle = startAngle + Math.PI * 2 * building.captureProgress
+        this.gfx.moveTo(building.x + (r + 12) * Math.cos(startAngle), building.y + (r + 12) * Math.sin(startAngle))
+        this.gfx.arc(building.x, building.y, r + 12, startAngle, endAngle)
+        this.gfx.lineStyle(0)
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- Adds 3 neutral outpost buildings in a triangle around the center of the 3000×3000 world (top: 1500,700; bottom-left: 850,2200; bottom-right: 2150,2200)
- Either player can capture an outpost by having their specks nearby uncontested for 5 seconds
- Captured outposts spawn extra specks (1 every 1.8s) for the capturing player
- Enemy can recapture by surrounding the outpost (capture progress resets and starts for new side)
- Contested outposts (both sides present) pause capture progress

## Rendering
- Neutral outposts shown in grey; captured outposts show in owner color
- Capture-progress arc (colored ring, r+12 from outpost) fills as capture advances
- Minimap shows outposts as smaller dots (r=3 vs r=4 for bases) in owner color

## Technical
- New `capture.ts` system queries spatial grid for nearby specks each tick
- `victory.ts` excludes neutral from defeat check and win condition
- `spawner.ts` skips neutral-owned buildings (no spawning until captured)
- `BuildingEntity` gains optional `captureProgress` and `captureSide` fields

Closes #1720