### PR TITLE
feat: Speck Wars pause button + game timer

### DIFF
--- a/src/app/speck-wars/SpeckWarsGame.tsx
+++ b/src/app/speck-wars/SpeckWarsGame.tsx
@@ -43,7 +43,7 @@ export function SpeckWarsGame() {
   return (
     <div style={{ position: 'relative', width: '100%', height: '100%' }}>
       <PhaseRouter>
-        {phase === 'playing' && <GameCanvas />}
+        {(phase === 'playing' || phase === 'paused') && <GameCanvas />}
       </PhaseRouter>
     </div>
   )

--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -6,28 +6,80 @@ function colorHex(n: number) {
   return `#${n.toString(16).padStart(6, '0')}`
 }
 
+function formatTime(ms: number): string {
+  const totalSec = Math.floor(ms / 1000)
+  const m = Math.floor(totalSec / 60)
+  const s = totalSec % 60
+  return `${m.toString().padStart(2, '0')}:${s.toString().padStart(2, '0')}`
+}
+
 export function HUD() {
   const hud = useSpeckWarsStore(s => s.hud)
-  if (!hud) return null
+  const phase = useSpeckWarsStore(s => s.phase)
+  const togglePause = useSpeckWarsStore(s => s.togglePause)
+  const elapsedMs = useSpeckWarsStore(s => s.elapsedMs)
 
   return (
     <div style={{
       position: 'absolute', inset: 0, pointerEvents: 'none',
       fontFamily: 'monospace', fontSize: 13, color: '#fff',
     }}>
-      {/* Player stats — bottom left */}
-      <div style={{ position: 'absolute', bottom: 16, left: 16 }}>
-        {Object.entries(hud.players).map(([pid, data]) => {
-          const color = pid === 'player' ? colorHex(PLAYER_COLOR) : colorHex(AI_COLOR)
-          const label = pid === 'player' ? 'YOU' : 'AI'
-          const totalHp = Object.values(data.buildingHp).reduce((a, b) => a + b, 0)
-          return (
-            <div key={pid} style={{ marginBottom: 6, color }}>
-              <strong>{label}</strong> — specks: {data.speckCount} | bases: {data.buildingCount} | HP: {totalHp}
-            </div>
-          )
-        })}
+      {/* Timer + Pause button — top bar */}
+      <div style={{
+        position: 'absolute', top: 12, left: 0, right: 0,
+        display: 'flex', justifyContent: 'center', alignItems: 'center', gap: 12,
+      }}>
+        <span style={{ fontSize: 15, letterSpacing: 2, opacity: 0.9 }}>
+          {formatTime(elapsedMs)}
+        </span>
+        <button
+          onClick={togglePause}
+          style={{
+            pointerEvents: 'auto',
+            padding: '4px 14px',
+            fontSize: 12,
+            cursor: 'pointer',
+            background: 'rgba(0,0,0,0.5)',
+            border: '1px solid rgba(255,255,255,0.3)',
+            borderRadius: 4,
+            color: '#fff',
+            letterSpacing: 1,
+          }}
+        >
+          {phase === 'paused' ? 'RESUME' : 'PAUSE'}
+        </button>
       </div>
+
+      {/* Paused overlay */}
+      {phase === 'paused' && (
+        <div style={{
+          position: 'absolute', inset: 0,
+          background: 'rgba(0,0,0,0.45)',
+          display: 'flex', alignItems: 'center', justifyContent: 'center',
+        }}>
+          <span style={{ fontSize: 36, fontWeight: 'bold', letterSpacing: 4, opacity: 0.9 }}>
+            PAUSED
+          </span>
+        </div>
+      )}
+
+      {/* Player stats — bottom left */}
+      {hud && (
+        <div style={{ position: 'absolute', bottom: 16, left: 16 }}>
+          {Object.entries(hud.players)
+            .filter(([pid]) => pid !== 'neutral')
+            .map(([pid, data]) => {
+              const color = pid === 'player' ? colorHex(PLAYER_COLOR) : colorHex(AI_COLOR)
+              const label = pid === 'player' ? 'YOU' : 'AI'
+              const totalHp = Object.values(data.buildingHp).reduce((a, b) => a + b, 0)
+              return (
+                <div key={pid} style={{ marginBottom: 6, color }}>
+                  <strong>{label}</strong> — specks: {data.speckCount} | bases: {data.buildingCount} | HP: {totalHp}
+                </div>
+              )
+            })}
+        </div>
+      )}
     </div>
   )
 }

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -17,6 +17,7 @@ export class GameInstance {
   private camera: Camera
   private inputHandler!: InputHandler
   private aiController: AIController
+  private elapsedMs = 0
 
   constructor(canvas: HTMLCanvasElement) {
     this.canvas = canvas
@@ -43,22 +44,25 @@ export class GameInstance {
     const dt = Math.min(now - this.lastTime, 50)
     this.lastTime = now
 
-    this.aiController.update(this.sim)
-    this.sim = tick(this.sim, dt)
+    const store = useSpeckWarsStore.getState()
+    if (store.phase === 'playing') {
+      this.elapsedMs += dt
+      store.setElapsedMs(this.elapsedMs)
+      this.aiController.update(this.sim)
+      this.sim = tick(this.sim, dt)
 
-    // Forward sim events to Zustand store
-    for (const event of this.sim.events) {
-      if (event.type === 'GAME_OVER') {
-        useSpeckWarsStore.getState().setPhase('victory')
-        useSpeckWarsStore.getState().setWinnerId(event.winnerId)
-      }
-      if (event.type === 'HUD_UPDATE') {
-        useSpeckWarsStore.getState().setHud(event.data)
+      for (const event of this.sim.events) {
+        if (event.type === 'GAME_OVER') {
+          store.setPhase('victory')
+          store.setWinnerId(event.winnerId)
+        }
+        if (event.type === 'HUD_UPDATE') {
+          store.setHud(event.data)
+        }
       }
     }
 
     this.renderer.render(this.sim, this.camera, dt)
-
     this.rafId = requestAnimationFrame(this.loop)
   }
 

--- a/src/app/speck-wars/store.ts
+++ b/src/app/speck-wars/store.ts
@@ -7,21 +7,29 @@ export type Difficulty = 'easy' | 'medium' | 'hard'
 interface SpeckWarsStore {
   phase: GamePhase
   setPhase: (phase: GamePhase) => void
+  togglePause: () => void
   winnerId: string | null
   setWinnerId: (id: string) => void
   hud: HudData | null
   setHud: (data: HudData) => void
   difficulty: Difficulty
   setDifficulty: (d: Difficulty) => void
+  elapsedMs: number
+  setElapsedMs: (ms: number) => void
 }
 
 export const useSpeckWarsStore = create<SpeckWarsStore>()(set => ({
   phase: 'menu',
   setPhase: phase => set({ phase }),
+  togglePause: () => set(s => ({
+    phase: s.phase === 'playing' ? 'paused' : s.phase === 'paused' ? 'playing' : s.phase,
+  })),
   winnerId: null,
   setWinnerId: winnerId => set({ winnerId }),
   hud: null,
   setHud: hud => set({ hud }),
   difficulty: 'medium',
   setDifficulty: difficulty => set({ difficulty }),
+  elapsedMs: 0,
+  setElapsedMs: elapsedMs => set({ elapsedMs }),
 }))


### PR DESCRIPTION
## Summary
- Adds a **pause button** to the HUD (top-center), satisfying the UX shared pact requirement for a pause/mute control in a consistent location
- Adds a **game timer** (MM:SS) displayed next to the pause button
- Shows a semi-transparent **PAUSED overlay** over the game when paused
- Filters `neutral` player out of the HUD stat rows (added alongside neutral outpost feature)

## Technical
- `store.ts`: added `togglePause()` (toggles 'playing' ↔ 'paused'), `elapsedMs`, `setElapsedMs`
- `game-instance.ts`: RAF loop always runs; ticking/AI only advance when `phase === 'playing'`; `lastTime` updates during pause to prevent dt spike on resume
- `SpeckWarsGame.tsx`: `GameCanvas` stays mounted during `'paused'` phase (prevent destroy/recreate)
- `hud.tsx`: pause button has `pointerEvents: 'auto'` override since parent has `none`

Closes #1722