### PR TITLE
feat: Speck Wars AI targets outposts strategically

### DIFF
--- a/src/app/speck-wars/domain/ai/ai-controller.ts
+++ b/src/app/speck-wars/domain/ai/ai-controller.ts
@@ -1,8 +1,8 @@
-import type { SimulationState, InputEvent } from '../types'
+import type { SimulationState, InputEvent, BuildingEntity } from '../types'
 
 export class AIController {
   private playerId: string
-  private tickInterval: number  // how often AI makes decisions (every N ticks)
+  private tickInterval: number
   private lastDecisionTick: number = 0
 
   constructor(playerId: string, tickInterval: number = 30) {
@@ -10,26 +10,54 @@ export class AIController {
     this.tickInterval = tickInterval
   }
 
-  // Called once per sim tick — pushes InputEvents into sim.inputQueue
   update(sim: SimulationState) {
     if (sim.tick - this.lastDecisionTick < this.tickInterval) return
     this.lastDecisionTick = sim.tick
 
     if (sim.players[this.playerId]?.isDefeated) return
 
-    // Find the player's nearest base to rally toward
-    const enemyBase = Object.values(sim.buildings).find(
-      b => b.ownerId !== this.playerId
-    )
-    if (!enemyBase) return
-
-    // Rally all AI specks toward the enemy base
-    const rally: InputEvent = {
-      type: 'RALLY',
-      ownerId: this.playerId,
-      x: enemyBase.x,
-      y: enemyBase.y,
+    // Compute AI swarm centroid (or fall back to own base)
+    let cx = 0, cy = 0, count = 0
+    for (let i = 0; i < sim.speckCount; i++) {
+      const m = sim.speckMeta[i]
+      if (m && m.ownerId === this.playerId) {
+        cx += sim.speckX[i]
+        cy += sim.speckY[i]
+        count++
+      }
     }
-    sim.inputQueue.push(rally)
+    const myBase = Object.values(sim.buildings).find(b => b.ownerId === this.playerId && b.typeId === 'base')
+    if (count === 0) {
+      cx = myBase?.x ?? 0
+      cy = myBase?.y ?? 0
+    } else {
+      cx /= count
+      cy /= count
+    }
+
+    // Helper: nearest building matching predicate
+    const nearest = (pred: (b: BuildingEntity) => boolean): BuildingEntity | null => {
+      let best: BuildingEntity | null = null
+      let bestD2 = Infinity
+      for (const b of Object.values(sim.buildings)) {
+        if (!pred(b)) continue
+        const dx = b.x - cx, dy = b.y - cy
+        const d2 = dx * dx + dy * dy
+        if (d2 < bestD2) { bestD2 = d2; best = b }
+      }
+      return best
+    }
+
+    // Priority 1: recapture enemy-held outpost
+    // Priority 2: capture neutral outpost
+    // Priority 3: attack enemy base
+    const target =
+      nearest(b => b.typeId === 'outpost' && b.ownerId !== this.playerId && b.ownerId !== 'neutral') ??
+      nearest(b => b.typeId === 'outpost' && b.ownerId === 'neutral') ??
+      nearest(b => b.ownerId !== this.playerId && b.ownerId !== 'neutral' && b.typeId === 'base')
+
+    if (!target) return
+
+    sim.inputQueue.push({ type: 'RALLY', ownerId: this.playerId, x: target.x, y: target.y })
   }
 }


### PR DESCRIPTION
## Summary
The AI controller previously only rallied toward the player's main base, ignoring the 3 neutral outposts added in #1721. This PR teaches the AI to compete for mid-map objectives.

## Behavior
Priority order each AI decision tick:
1. **Recapture** — nearest outpost owned by the player (stolen back ASAP)
2. **Capture** — nearest neutral outpost (expand before the player does)
3. **Attack** — enemy main base (original fallback)

## Technical
- AI computes its swarm centroid (average x/y of all its specks) to determine "where it is" before picking the nearest objective — avoids rallying specks backward across the map
- Falls back to own base position if no specks exist yet (early game)
- Uses squared distance throughout (no sqrt overhead)
- Single-file change: `domain/ai/ai-controller.ts`

Closes #1724