### PR TITLE
feat: Speck Wars rally point marker + keyboard shortcuts (Space/R)

### DIFF
--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -32,10 +32,16 @@ export class GameInstance {
   async start() {
     console.log('GameInstance started')
     await this.renderer.init(this.canvas)
-    this.inputHandler = new InputHandler(this.canvas, this.camera, (wx, wy) => {
-      this.sim.inputQueue.push({ type: 'RALLY', ownerId: 'player', x: wx, y: wy })
-      this.renderer.showRallyPing(wx, wy)
-    })
+    this.inputHandler = new InputHandler(
+      this.canvas,
+      this.camera,
+      (wx, wy) => {
+        this.sim.inputQueue.push({ type: 'RALLY', ownerId: 'player', x: wx, y: wy })
+        this.renderer.showRallyPing(wx, wy)
+      },
+      () => useSpeckWarsStore.getState().togglePause(),   // Space
+      () => { this.sim.rallyPoints['player'] = null },    // R — clear rally
+    )
     this.lastTime = performance.now()
     this.loop(this.lastTime)
   }

--- a/src/app/speck-wars/input/input-handler.ts
+++ b/src/app/speck-wars/input/input-handler.ts
@@ -5,16 +5,26 @@ export class InputHandler {
   private canvas: HTMLCanvasElement
   private camera: Camera
   private onRally?: (worldX: number, worldY: number) => void
+  private onTogglePause?: () => void
+  private onClearRally?: () => void
   private isDragging = false
   private lastX = 0
   private lastY = 0
   private mouseDownX = 0
   private mouseDownY = 0
 
-  constructor(canvas: HTMLCanvasElement, camera: Camera, onRally?: (worldX: number, worldY: number) => void) {
+  constructor(
+    canvas: HTMLCanvasElement,
+    camera: Camera,
+    onRally?: (worldX: number, worldY: number) => void,
+    onTogglePause?: () => void,
+    onClearRally?: () => void,
+  ) {
     this.canvas = canvas
     this.camera = camera
     this.onRally = onRally
+    this.onTogglePause = onTogglePause
+    this.onClearRally = onClearRally
     this.attach()
   }
 
@@ -27,6 +37,7 @@ export class InputHandler {
     this.canvas.addEventListener('touchstart', this.onTouchStart, { passive: true })
     window.addEventListener('touchmove', this.onTouchMove, { passive: false })
     window.addEventListener('touchend', this.onTouchEnd)
+    window.addEventListener('keydown', this.onKeyDown)
   }
 
   private onMouseDown = (e: MouseEvent) => {
@@ -89,6 +100,17 @@ export class InputHandler {
 
   private onTouchEnd = () => { this.isDragging = false }
 
+  private onKeyDown = (e: KeyboardEvent) => {
+    // Don't fire when typing in an input
+    if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) return
+    if (e.code === 'Space') {
+      e.preventDefault()
+      this.onTogglePause?.()
+    } else if (e.code === 'KeyR') {
+      this.onClearRally?.()
+    }
+  }
+
   destroy() {
     this.canvas.removeEventListener('mousedown', this.onMouseDown)
     window.removeEventListener('mousemove', this.onMouseMove)
@@ -97,5 +119,6 @@ export class InputHandler {
     this.canvas.removeEventListener('touchstart', this.onTouchStart)
     window.removeEventListener('touchmove', this.onTouchMove)
     window.removeEventListener('touchend', this.onTouchEnd)
+    window.removeEventListener('keydown', this.onKeyDown)
   }
 }

--- a/src/app/speck-wars/rendering/renderer.ts
+++ b/src/app/speck-wars/rendering/renderer.ts
@@ -1,4 +1,4 @@
-import { Application, Container } from 'pixi.js'
+import { Application, Container, Graphics } from 'pixi.js'
 import { SpeckLayer } from './layers/speck-layer'
 import { BuildingLayer } from './layers/building-layer'
 import { GridLayer } from './layers/grid-layer'
@@ -32,6 +32,7 @@ export class Renderer {
   private buildingLayer!: BuildingLayer
   private gridLayer!: GridLayer
   private effectsLayer!: EffectsLayer
+  private rallyGfx!: Graphics
 
   async init(canvas: HTMLCanvasElement) {
     const app = new Application() as PixiApplication
@@ -57,6 +58,9 @@ export class Renderer {
     this.world.addChild(this.buildingLayer.stage)
     this.world.addChild(this.effectsLayer.stage)
     this.world.addChild(this.speckLayer.stage)
+
+    this.rallyGfx = new Graphics()
+    this.world.addChild(this.rallyGfx)
   }
 
   render(sim: SimulationState, camera: { x: number; y: number; zoom: number }, dt: number) {
@@ -73,6 +77,23 @@ export class Renderer {
       }
     }
     this.effectsLayer.update(dt)
+
+    // Rally point marker
+    this.rallyGfx.clear()
+    const rp = sim.rallyPoints['player']
+    if (rp) {
+      const pulse = 0.5 + 0.5 * Math.sin(Date.now() / 400)
+      const alpha = 0.5 + 0.5 * pulse
+      this.rallyGfx.lineStyle(2, PLAYER_COLOR, alpha)
+      const s = 10
+      this.rallyGfx.moveTo(rp.x - s, rp.y)
+      this.rallyGfx.lineTo(rp.x + s, rp.y)
+      this.rallyGfx.moveTo(rp.x, rp.y - s)
+      this.rallyGfx.lineTo(rp.x, rp.y + s)
+      this.rallyGfx.lineStyle(1.5, PLAYER_COLOR, alpha * 0.5)
+      this.rallyGfx.drawCircle(rp.x, rp.y, 14)
+      this.rallyGfx.lineStyle(0)
+    }
   }
 
   showRallyPing(x: number, y: number) {
@@ -84,6 +105,7 @@ export class Renderer {
     this.effectsLayer.destroy()
     this.speckLayer.destroy()
     this.buildingLayer.destroy()
+    this.rallyGfx.destroy()
     this.app.destroy()
   }
 }


### PR DESCRIPTION
## Summary
Two UX clarity improvements that help players track and control their specks.

### Rally point marker
- Persistent animated crosshair drawn at the player's active rally point in world space
- Pulses with a sine wave (opacity 0.5–1.0, period ~800ms)
- Disappears when rally is cleared (R key or when specks reach target and retarget)
- Implemented as a `Graphics` object on top of the world container, redrawn each frame

### Keyboard shortcuts
- **Space** — toggle pause/resume (calls `togglePause()` from store)
- **R** — clear rally point (`sim.rallyPoints['player'] = null`)
- Both skip when focus is on an `<input>` or `<textarea>` to avoid conflicts

## Files changed
- `rendering/renderer.ts` — `rallyGfx: Graphics`, drawn in `render()`, destroyed in `destroy()`
- `input/input-handler.ts` — added `onTogglePause`, `onClearRally` optional callbacks + `onKeyDown` handler
- `game-instance.ts` — wires up the two new callbacks when creating `InputHandler`

Closes #1726