### PR TITLE
feat: Speck Wars share button on end screen

### DIFF
--- a/src/app/speck-wars/components/phase-router.tsx
+++ b/src/app/speck-wars/components/phase-router.tsx
@@ -1,4 +1,5 @@
 'use client'
+import { useState } from 'react'
 import { useSpeckWarsStore } from '../store'
 
 export function PhaseRouter({ children }: { children: React.ReactNode }) {
@@ -59,6 +60,27 @@ export function PhaseRouter({ children }: { children: React.ReactNode }) {
     const diffLabel = difficulty.charAt(0).toUpperCase() + difficulty.slice(1)
     const diffColor = difficultyColors[difficulty]
 
+    const shareText = won
+      ? `I defeated the AI in Speck Wars (${diffLabel}) in ${timeStr}! 🎮 Can you beat my time?`
+      : `The AI beat me in Speck Wars (${diffLabel}) in ${timeStr}! 🎮 Think you can do better?`
+
+    const [copied, setCopied] = useState(false)
+
+    const handleShare = async () => {
+      const url = typeof window !== 'undefined' ? window.location.href : ''
+      if (typeof navigator !== 'undefined' && navigator.share) {
+        try {
+          await navigator.share({ title: 'Speck Wars', text: shareText, url })
+        } catch {
+          // user cancelled — no action needed
+        }
+      } else {
+        await navigator.clipboard.writeText(`${shareText} ${url}`)
+        setCopied(true)
+        setTimeout(() => setCopied(false), 2000)
+      }
+    }
+
     return (
       <div style={{
         display: 'flex', flexDirection: 'column', alignItems: 'center',
@@ -86,6 +108,16 @@ export function PhaseRouter({ children }: { children: React.ReactNode }) {
             }}
           >
             Play Again
+          </button>
+          <button
+            onClick={handleShare}
+            style={{
+              padding: '12px 28px', fontSize: 16, cursor: 'pointer',
+              background: 'transparent', border: `2px solid ${accentColor}`,
+              borderRadius: 8, color: accentColor,
+            }}
+          >
+            {copied ? 'Copied!' : 'Share'}
           </button>
           <a
             href="/"

--- a/src/app/speck-wars/components/phase-router.tsx
+++ b/src/app/speck-wars/components/phase-router.tsx
@@ -4,6 +4,7 @@ import { useSpeckWarsStore } from '../store'
 
 export function PhaseRouter({ children }: { children: React.ReactNode }) {
   const { phase, winnerId, setPhase, difficulty, setDifficulty, elapsedMs } = useSpeckWarsStore()
+  const [copied, setCopied] = useState(false)
 
   const difficulties: Array<{ key: 'easy' | 'medium' | 'hard'; label: string; color: string }> = [
     { key: 'easy', label: 'Easy', color: '#44ff88' },
@@ -63,8 +64,6 @@ export function PhaseRouter({ children }: { children: React.ReactNode }) {
     const shareText = won
       ? `I defeated the AI in Speck Wars (${diffLabel}) in ${timeStr}! 🎮 Can you beat my time?`
       : `The AI beat me in Speck Wars (${diffLabel}) in ${timeStr}! 🎮 Think you can do better?`
-
-    const [copied, setCopied] = useState(false)
 
     const handleShare = async () => {
       const url = typeof window !== 'undefined' ? window.location.href : ''


### PR DESCRIPTION
## Summary
Adds a Share button to the victory/defeat end screen, satisfying the UX shared pact requirement: *Share button on every game*.

## Behavior
- **Mobile**: uses native `navigator.share()` (share sheet)
- **Desktop**: copies to clipboard, button flips to "Copied!" for 2 seconds
- **Win text**: "I defeated the AI in Speck Wars (Hard) in 2:34! 🎮 Can you beat my time?"
- **Lose text**: "The AI beat me in Speck Wars (Medium) in 1:47! 🎮 Think you can do better?"

## Fix included
`useState` was initially placed inside a conditional block (React hooks violation). Fixed by hoisting it to the top of the component.

Single file changed: `components/phase-router.tsx`

Closes #1730