### PR TITLE
feat: Speck Wars heavy speck type — outposts spawn tanks

### DIFF
--- a/src/app/speck-wars/domain/config/building-types.ts
+++ b/src/app/speck-wars/domain/config/building-types.ts
@@ -16,7 +16,7 @@ export const BUILDING_TYPES: Record<string, BuildingTypeDefinition> = {
   outpost: {
     id: 'outpost', name: 'Outpost',
     maxHp: 50, size: 20,
-    spawnTypeId: 'basic',
+    spawnTypeId: 'heavy',
     spawnInterval: 1800, spawnCount: 1,
   },
 }

--- a/src/app/speck-wars/domain/config/speck-types.ts
+++ b/src/app/speck-wars/domain/config/speck-types.ts
@@ -15,4 +15,11 @@ export const SPECK_TYPES: Record<string, SpeckTypeDefinition> = {
     size: 3, productionTime: 800,
     abilities: [],
   },
+  heavy: {
+    id: 'heavy', name: 'Tank',
+    hp: 5, damage: 2, speed: 60,
+    attackRange: 8, attackCooldown: 700,
+    size: 6, productionTime: 1800,
+    abilities: [],
+  },
 }

--- a/src/app/speck-wars/rendering/layers/speck-layer.ts
+++ b/src/app/speck-wars/rendering/layers/speck-layer.ts
@@ -1,6 +1,7 @@
 import { Container, Sprite } from 'pixi.js'
 import type { Texture } from 'pixi.js'
 import type { SimulationState } from '../../domain/types'
+import { SPECK_TYPES } from '../../domain/config/speck-types'
 
 export class SpeckLayer {
   private containers: Map<string, Container> = new Map()
@@ -54,6 +55,9 @@ export class SpeckLayer {
         const i = indices[j]
         spriteList[j].position.set(sim.speckX[i], sim.speckY[i])
         spriteList[j].visible = true
+        const typeMeta = sim.speckMeta[i]
+        const stype = typeMeta ? SPECK_TYPES[typeMeta.typeId] : null
+        spriteList[j].scale.set(stype ? stype.size / 4 : 0.75)
       }
 
       // Hide excess sprites


### PR DESCRIPTION
## Summary
Introduces a second speck type — the **Heavy (Tank)** — that spawns from captured outposts. This makes outpost control feel strategically rewarding: instead of just getting more basic specks, you get tankier, harder-hitting units.

## Heavy vs Basic stats
| Stat | Basic | Heavy |
|---|---|---|
| HP | 1 | 5 |
| Damage | 1 | 2 |
| Speed | 80 | 60 |
| Attack range | 6 | 8 |
| Cooldown | 500ms | 700ms |
| Visual size | 3px | 6px (2×) |

## Technical
- `config/speck-types.ts` — added `heavy` entry
- `config/building-types.ts` — outpost `spawnTypeId` changed from `'basic'` to `'heavy'`
- `rendering/layers/speck-layer.ts` — sprites now scale per speck type (`size / 4` where 4 = texture radius); heavies render at 1.5× scale, basics at 0.75×

## Balance note
Outposts spawn 1 heavy every 1.8s. Main bases spawn 1 basic every 0.8s (player) or 0.4–2s (AI by difficulty). Heavies are slower but each one is worth ~5 basics in a fight.

Closes #1732