### PR TITLE
feat: Speck Wars 1×/2×/4× game speed control

### DIFF
--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -18,6 +18,8 @@ export function HUD() {
   const phase = useSpeckWarsStore(s => s.phase)
   const togglePause = useSpeckWarsStore(s => s.togglePause)
   const elapsedMs = useSpeckWarsStore(s => s.elapsedMs)
+  const speed = useSpeckWarsStore(s => s.speed)
+  const cycleSpeed = useSpeckWarsStore(s => s.cycleSpeed)
 
   return (
     <div style={{
@@ -47,6 +49,22 @@ export function HUD() {
           }}
         >
           {phase === 'paused' ? 'RESUME' : 'PAUSE'}
+        </button>
+        <button
+          onClick={cycleSpeed}
+          style={{
+            pointerEvents: 'auto',
+            padding: '4px 14px',
+            fontSize: 12,
+            cursor: 'pointer',
+            background: speed > 1 ? 'rgba(74,247,196,0.15)' : 'rgba(0,0,0,0.5)',
+            border: `1px solid ${speed > 1 ? '#4af7c4' : 'rgba(255,255,255,0.3)'}`,
+            borderRadius: 4,
+            color: speed > 1 ? '#4af7c4' : '#fff',
+            letterSpacing: 1,
+          }}
+        >
+          {speed}×
         </button>
       </div>
 

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -52,10 +52,11 @@ export class GameInstance {
 
     const store = useSpeckWarsStore.getState()
     if (store.phase === 'playing') {
-      this.elapsedMs += dt
+      const scaledDt = dt * store.speed
+      this.elapsedMs += scaledDt
       store.setElapsedMs(this.elapsedMs)
       this.aiController.update(this.sim)
-      this.sim = tick(this.sim, dt)
+      this.sim = tick(this.sim, scaledDt)
 
       for (const event of this.sim.events) {
         if (event.type === 'GAME_OVER') {

--- a/src/app/speck-wars/store.ts
+++ b/src/app/speck-wars/store.ts
@@ -16,6 +16,8 @@ interface SpeckWarsStore {
   setDifficulty: (d: Difficulty) => void
   elapsedMs: number
   setElapsedMs: (ms: number) => void
+  speed: 1 | 2 | 4
+  cycleSpeed: () => void
 }
 
 export const useSpeckWarsStore = create<SpeckWarsStore>()(set => ({
@@ -32,4 +34,8 @@ export const useSpeckWarsStore = create<SpeckWarsStore>()(set => ({
   setDifficulty: difficulty => set({ difficulty }),
   elapsedMs: 0,
   setElapsedMs: elapsedMs => set({ elapsedMs }),
+  speed: 1 as 1 | 2 | 4,
+  cycleSpeed: () => set(s => ({
+    speed: s.speed === 1 ? 2 : s.speed === 2 ? 4 : 1,
+  })),
 }))


### PR DESCRIPTION
## Summary
Adds a speed multiplier button (1× → 2× → 4× → 1×) to the HUD top bar so players can fast-forward through the early game or finish matches faster.

## Behavior
- Clicking the button cycles: **1× → 2× → 4× → 1×**
- At 2×: simulation runs twice as fast, timer counts twice as fast
- At 4×: four times as fast — useful for watching hard-mode battles
- Visual effects (death particles, ping rings) remain at wall-clock speed since `renderer.render` uses real `dt`
- Button highlights in teal when speed > 1× so state is obvious

## Technical
- `store.ts`: added `speed: 1 | 2 | 4` and `cycleSpeed()` (cycles 1→2→4→1)
- `game-instance.ts`: `scaledDt = dt * store.speed` — applied to `tick()` and `elapsedMs`; renderer still gets real `dt`
- `hud.tsx`: speed button next to PAUSE in top bar

Metric: **session length** — players complete slow-start matches instead of abandoning.

Closes #1736