### PR TITLE
feat: Speck Wars outpost capture/loss notifications

### DIFF
--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -20,6 +20,7 @@ export function HUD() {
   const elapsedMs = useSpeckWarsStore(s => s.elapsedMs)
   const speed = useSpeckWarsStore(s => s.speed)
   const cycleSpeed = useSpeckWarsStore(s => s.cycleSpeed)
+  const notification = useSpeckWarsStore(s => s.notification)
 
   return (
     <div style={{
@@ -93,6 +94,24 @@ export function HUD() {
           </div>
         )
       })()}
+
+      {/* Outpost capture/loss notification */}
+      {notification && (
+        <div style={{
+          position: 'absolute', top: 76, left: 0, right: 0,
+          display: 'flex', justifyContent: 'center',
+        }}>
+          <span style={{
+            color: notification.color,
+            fontSize: 13,
+            fontWeight: 'bold',
+            letterSpacing: 2,
+            textShadow: `0 0 12px ${notification.color}`,
+          }}>
+            {notification.message}
+          </span>
+        </div>
+      )}
 
       {/* Paused overlay */}
       {phase === 'paused' && (

--- a/src/app/speck-wars/domain/simulation/capture.ts
+++ b/src/app/speck-wars/domain/simulation/capture.ts
@@ -34,11 +34,18 @@ export function updateCapture(sim: SimulationState, dt: number) {
 
     building.captureProgress = (building.captureProgress ?? 0) + dt / CAPTURE_TIME
     if ((building.captureProgress ?? 0) >= 1) {
+      const previousOwner = building.ownerId
       building.ownerId = dominantOwner
       building.captureProgress = 0
       building.captureSide = null
       // Reset spawn timer so it starts fresh for the new owner
       building.spawnTimer = 0
+      sim.events.push({
+        type: 'OUTPOST_CAPTURED',
+        outpostId: building.id,
+        newOwner: dominantOwner,
+        previousOwner,
+      })
     }
   }
 }

--- a/src/app/speck-wars/domain/types.ts
+++ b/src/app/speck-wars/domain/types.ts
@@ -67,6 +67,7 @@ export type SimEvent =
   | { type: 'SPECK_SPAWNED'; speckId: string; buildingId: string }
   | { type: 'GAME_OVER'; winnerId: string }
   | { type: 'HUD_UPDATE'; data: HudData }
+  | { type: 'OUTPOST_CAPTURED'; outpostId: string; newOwner: string; previousOwner: string }
 
 export interface HudData {
   players: Record<string, {

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -66,6 +66,16 @@ export class GameInstance {
         if (event.type === 'HUD_UPDATE') {
           store.setHud(event.data)
         }
+        if (event.type === 'OUTPOST_CAPTURED') {
+          const isPlayerGain = event.newOwner === 'player'
+          const isPlayerLoss = event.previousOwner === 'player'
+          if (isPlayerGain || isPlayerLoss) {
+            const message = isPlayerGain ? '⬡ Outpost Captured!' : '⬡ Outpost Lost!'
+            const color = isPlayerGain ? '#4af7c4' : '#ff4f7b'
+            store.setNotification({ message, color })
+            setTimeout(() => useSpeckWarsStore.getState().setNotification(null), 2500)
+          }
+        }
       }
     }
 

--- a/src/app/speck-wars/store.ts
+++ b/src/app/speck-wars/store.ts
@@ -18,6 +18,8 @@ interface SpeckWarsStore {
   setElapsedMs: (ms: number) => void
   speed: 1 | 2 | 4
   cycleSpeed: () => void
+  notification: { message: string; color: string } | null
+  setNotification: (n: { message: string; color: string } | null) => void
 }
 
 export const useSpeckWarsStore = create<SpeckWarsStore>()(set => ({
@@ -38,4 +40,6 @@ export const useSpeckWarsStore = create<SpeckWarsStore>()(set => ({
   cycleSpeed: () => set(s => ({
     speed: s.speed === 1 ? 2 : s.speed === 2 ? 4 : 1,
   })),
+  notification: null,
+  setNotification: n => set({ notification: n }),
 }))


### PR DESCRIPTION
## Summary
Shows a brief colored flash message when an outpost changes ownership — creates moment-to-moment drama without requiring players to watch the minimap.

## Behavior
- **"⬡ Outpost Captured!"** (teal glow) — when player gains any outpost
- **"⬡ Outpost Lost!"** (pink glow) — when player loses an outpost to the AI
- AI-only ownership changes (neutral→AI) show no message (not player-relevant)
- Message auto-clears after 2.5 seconds
- Positioned below the outpost dots in the top HUD bar

## Technical (5 files)
- `types.ts` — added `OUTPOST_CAPTURED` to `SimEvent` union
- `capture.ts` — emits event when `building.ownerId` changes
- `store.ts` — added `notification: {message, color} | null` + `setNotification`
- `game-instance.ts` — handles `OUTPOST_CAPTURED` events, fires `setTimeout` to clear
- `hud.tsx` — renders notification with color + glow text-shadow

Closes #1738