### PR TITLE
feat: Speck Wars proper restart + controls legend on menu

### DIFF
--- a/src/app/speck-wars/components/phase-router.tsx
+++ b/src/app/speck-wars/components/phase-router.tsx
@@ -3,7 +3,7 @@ import { useState } from 'react'
 import { useSpeckWarsStore } from '../store'
 
 export function PhaseRouter({ children }: { children: React.ReactNode }) {
-  const { phase, winnerId, setPhase, difficulty, setDifficulty, elapsedMs } = useSpeckWarsStore()
+  const { phase, winnerId, setPhase, difficulty, setDifficulty, elapsedMs, resetGame } = useSpeckWarsStore()
   const [copied, setCopied] = useState(false)
 
   const difficulties: Array<{ key: 'easy' | 'medium' | 'hard'; label: string; color: string }> = [
@@ -44,6 +44,25 @@ export function PhaseRouter({ children }: { children: React.ReactNode }) {
         >
           Play
         </button>
+        {/* Controls hint */}
+        <div style={{
+          marginTop: 16,
+          display: 'grid',
+          gridTemplateColumns: '1fr 1fr',
+          gap: '4px 24px',
+          color: 'rgba(255,255,255,0.35)',
+          fontSize: 11,
+          letterSpacing: 0.5,
+          textAlign: 'left',
+          maxWidth: 280,
+        }}>
+          <span>🖱 Click — rally specks</span>
+          <span>Space — pause</span>
+          <span>Scroll — zoom</span>
+          <span>R — clear rally</span>
+          <span>Drag — pan camera</span>
+          <span>1×/2×/4× — speed</span>
+        </div>
       </div>
     )
   }
@@ -99,7 +118,7 @@ export function PhaseRouter({ children }: { children: React.ReactNode }) {
 
         <div style={{ display: 'flex', gap: 12, marginTop: 8 }}>
           <button
-            onClick={() => window.location.reload()}
+            onClick={resetGame}
             style={{
               padding: '12px 28px', fontSize: 16, cursor: 'pointer',
               background: accentColor, border: 'none', borderRadius: 8,

--- a/src/app/speck-wars/store.ts
+++ b/src/app/speck-wars/store.ts
@@ -20,6 +20,7 @@ interface SpeckWarsStore {
   cycleSpeed: () => void
   notification: { message: string; color: string } | null
   setNotification: (n: { message: string; color: string } | null) => void
+  resetGame: () => void
 }
 
 export const useSpeckWarsStore = create<SpeckWarsStore>()(set => ({
@@ -42,4 +43,13 @@ export const useSpeckWarsStore = create<SpeckWarsStore>()(set => ({
   })),
   notification: null,
   setNotification: n => set({ notification: n }),
+  resetGame: () => set(s => ({
+    phase: 'menu' as GamePhase,
+    winnerId: null,
+    hud: null,
+    elapsedMs: 0,
+    speed: 1 as 1 | 2 | 4,
+    notification: null,
+    difficulty: s.difficulty,
+  })),
 }))


### PR DESCRIPTION
## Summary
Two polish improvements that reduce friction and improve discoverability.

### Proper game restart
- Replaced `window.location.reload()` on "Play Again" with `resetGame()` store action
- `resetGame()` clears phase, winnerId, hud, elapsedMs, speed, notification back to defaults while **preserving the selected difficulty**
- Instant restart — no full page reload, no lost browser state

### Controls legend
- Small 2-column grid below the Play button on the menu screen
- Muted white (35% opacity), 11px — present but not dominant
- Lists all 6 controls: click-to-rally, Space=pause, Scroll=zoom, R=clear, Drag=pan, 1×/2×/4×=speed
- Reduces abandonment from players who don't discover the controls organically

Files changed: `store.ts`, `components/phase-router.tsx`

Closes #1740