### PR TITLE
feat: Speck Wars base low-HP vignette danger warning

### DIFF
--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -22,11 +22,33 @@ export function HUD() {
   const cycleSpeed = useSpeckWarsStore(s => s.cycleSpeed)
   const notification = useSpeckWarsStore(s => s.notification)
 
+  const BASE_MAX_HP = 100
+  const playerBaseHp = hud?.players.player?.buildingHp['building-player-base']
+  const hpFrac = playerBaseHp !== undefined ? playerBaseHp / BASE_MAX_HP : 1
+  const isDanger = phase === 'playing' && hpFrac < 0.3
+  const isCritical = phase === 'playing' && hpFrac < 0.15
+
   return (
     <div style={{
       position: 'absolute', inset: 0, pointerEvents: 'none',
       fontFamily: 'monospace', fontSize: 13, color: '#fff',
     }}>
+      {isDanger && (
+        <>
+          <style>{`
+            @keyframes danger-pulse {
+              from { opacity: ${isCritical ? 0.4 : 0.15}; }
+              to   { opacity: ${isCritical ? 0.7 : 0.35}; }
+            }
+          `}</style>
+          <div style={{
+            position: 'absolute', inset: 0,
+            background: 'radial-gradient(ellipse at center, transparent 45%, rgba(220,30,30,1) 100%)',
+            animation: `danger-pulse ${isCritical ? '0.5s' : '1s'} ease-in-out infinite alternate`,
+            pointerEvents: 'none',
+          }} />
+        </>
+      )}
       {/* Timer + Pause button — top bar */}
       <div style={{
         position: 'absolute', top: 12, left: 0, right: 0,


### PR DESCRIPTION
## Summary
- Adds red vignette overlay when player base HP drops below 30%
- Pulsing animation intensifies at critical HP (<15%): faster pulse rate and higher opacity
- Uses inline CSS `@keyframes danger-pulse` animation via `<style>` tag in HUD component
- Reads player base HP from existing `hud.players.player.buildingHp['building-player-base']`

## Details
- `isDanger` triggers at <30% base HP: 1s pulse, opacity 0.15→0.35
- `isCritical` triggers at <15% base HP: 0.5s pulse, opacity 0.40→0.70
- Red radial-gradient centered on canvas edges (transparent center, opaque rim)
- Only shows during `phase === 'playing'` (not paused/victory/defeat)

## Test plan
- [ ] Start a game, let AI damage your base — vignette appears below 30% HP
- [ ] Let damage continue — vignette pulses faster and brighter at ~15% HP
- [ ] Win or lose — vignette disappears on phase transition

🤖 Generated with [Claude Code](https://claude.com/claude-code)