### PR TITLE
feat: Speck Wars kill counter — live combat stats in HUD + victory screen

### DIFF
--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -21,6 +21,8 @@ export function HUD() {
   const speed = useSpeckWarsStore(s => s.speed)
   const cycleSpeed = useSpeckWarsStore(s => s.cycleSpeed)
   const notification = useSpeckWarsStore(s => s.notification)
+  const kills = useSpeckWarsStore(s => s.kills)
+  const losses = useSpeckWarsStore(s => s.losses)
 
   const BASE_MAX_HP = 100
   const playerBaseHp = hud?.players.player?.buildingHp['building-player-base']
@@ -160,6 +162,9 @@ export function HUD() {
               return (
                 <div key={pid} style={{ marginBottom: 6, color }}>
                   <strong>{label}</strong> — specks: {data.speckCount} | bases: {data.buildingCount} | HP: {totalHp}
+                  {pid === 'player' && (
+                    <span style={{ opacity: 0.7 }}> | ↑{kills} ↓{losses}</span>
+                  )}
                 </div>
               )
             })}

--- a/src/app/speck-wars/components/phase-router.tsx
+++ b/src/app/speck-wars/components/phase-router.tsx
@@ -3,7 +3,7 @@ import { useState } from 'react'
 import { useSpeckWarsStore } from '../store'
 
 export function PhaseRouter({ children }: { children: React.ReactNode }) {
-  const { phase, winnerId, setPhase, difficulty, setDifficulty, elapsedMs, resetGame } = useSpeckWarsStore()
+  const { phase, winnerId, setPhase, difficulty, setDifficulty, elapsedMs, resetGame, kills, losses } = useSpeckWarsStore()
   const [copied, setCopied] = useState(false)
 
   const difficulties: Array<{ key: 'easy' | 'medium' | 'hard'; label: string; color: string }> = [
@@ -81,8 +81,8 @@ export function PhaseRouter({ children }: { children: React.ReactNode }) {
     const diffColor = difficultyColors[difficulty]
 
     const shareText = won
-      ? `I defeated the AI in Speck Wars (${diffLabel}) in ${timeStr}! 🎮 Can you beat my time?`
-      : `The AI beat me in Speck Wars (${diffLabel}) in ${timeStr}! 🎮 Think you can do better?`
+      ? `I defeated the AI in Speck Wars (${diffLabel}) in ${timeStr} — killed ${kills} specks! 🎮 Can you beat my time?`
+      : `The AI beat me in Speck Wars (${diffLabel}) in ${timeStr} — killed ${kills} specks. 🎮 Think you can do better?`
 
     const handleShare = async () => {
       const url = typeof window !== 'undefined' ? window.location.href : ''
@@ -114,6 +114,16 @@ export function PhaseRouter({ children }: { children: React.ReactNode }) {
           <span style={{ color: diffColor, fontWeight: 'bold', border: `1px solid ${diffColor}`, padding: '2px 10px', borderRadius: 4 }}>
             {diffLabel}
           </span>
+        </div>
+
+        <div style={{ display: 'flex', gap: 28, color: 'rgba(255,255,255,0.6)', fontSize: 14 }}>
+          <span style={{ color: '#4af7c4' }}>↑ {kills} killed</span>
+          <span style={{ color: '#ff4f7b' }}>↓ {losses} lost</span>
+          {kills + losses > 0 && (
+            <span style={{ color: 'rgba(255,255,255,0.4)' }}>
+              {Math.round((kills / (kills + losses)) * 100)}% efficiency
+            </span>
+          )}
         </div>
 
         <div style={{ display: 'flex', gap: 12, marginTop: 8 }}>

--- a/src/app/speck-wars/domain/simulation/combat.ts
+++ b/src/app/speck-wars/domain/simulation/combat.ts
@@ -33,7 +33,7 @@ export function resolveCombat(sim: SimulationState, dt: number) {
         meta.attackCooldown = stype.attackCooldown
         meta.state = 'attacking'
         if (speckHp[j] <= 0) {
-          sim.events.push({ type: 'SPECK_DIED', speckId: speckIds[j], x: speckX[j], y: speckY[j] })
+          sim.events.push({ type: 'SPECK_DIED', speckId: speckIds[j], x: speckX[j], y: speckY[j], killedOwnerId: jMeta.ownerId, killerOwnerId: meta.ownerId })
         }
         break  // one attack per cooldown
       }

--- a/src/app/speck-wars/domain/types.ts
+++ b/src/app/speck-wars/domain/types.ts
@@ -61,7 +61,7 @@ export type InputEvent =
   | { type: 'SACRIFICE'; ownerId: string; buildingId: string; typeId: string; count: number }
 
 export type SimEvent =
-  | { type: 'SPECK_DIED'; speckId: string; x: number; y: number }
+  | { type: 'SPECK_DIED'; speckId: string; x: number; y: number; killedOwnerId: string; killerOwnerId: string }
   | { type: 'BUILDING_DAMAGED'; buildingId: string; hp: number }
   | { type: 'BUILDING_DESTROYED'; buildingId: string; ownerId: string }
   | { type: 'SPECK_SPAWNED'; speckId: string; buildingId: string }

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -66,6 +66,10 @@ export class GameInstance {
         if (event.type === 'HUD_UPDATE') {
           store.setHud(event.data)
         }
+        if (event.type === 'SPECK_DIED') {
+          if (event.killedOwnerId === 'ai' && event.killerOwnerId === 'player') store.addKill()
+          else if (event.killedOwnerId === 'player' && event.killerOwnerId === 'ai') store.addLoss()
+        }
         if (event.type === 'OUTPOST_CAPTURED') {
           const isPlayerGain = event.newOwner === 'player'
           const isPlayerLoss = event.previousOwner === 'player'

--- a/src/app/speck-wars/store.ts
+++ b/src/app/speck-wars/store.ts
@@ -20,6 +20,10 @@ interface SpeckWarsStore {
   cycleSpeed: () => void
   notification: { message: string; color: string } | null
   setNotification: (n: { message: string; color: string } | null) => void
+  kills: number
+  losses: number
+  addKill: () => void
+  addLoss: () => void
   resetGame: () => void
 }
 
@@ -43,6 +47,10 @@ export const useSpeckWarsStore = create<SpeckWarsStore>()(set => ({
   })),
   notification: null,
   setNotification: n => set({ notification: n }),
+  kills: 0,
+  losses: 0,
+  addKill: () => set(s => ({ kills: s.kills + 1 })),
+  addLoss: () => set(s => ({ losses: s.losses + 1 })),
   resetGame: () => set(s => ({
     phase: 'menu' as GamePhase,
     winnerId: null,
@@ -50,6 +58,8 @@ export const useSpeckWarsStore = create<SpeckWarsStore>()(set => ({
     elapsedMs: 0,
     speed: 1 as 1 | 2 | 4,
     notification: null,
+    kills: 0,
+    losses: 0,
     difficulty: s.difficulty,
   })),
 }))


### PR DESCRIPTION
## Summary
- Tracks enemy specks killed + friendly specks lost in real time during play
- Shows `↑{kills} ↓{losses}` inline in the HUD player stats row
- Victory/defeat screen shows full combat stats: killed, lost, efficiency %
- Kill count included in Share text for bragging rights

## Changes
- `domain/types.ts`: `SPECK_DIED` event now carries `killedOwnerId` + `killerOwnerId`
- `domain/simulation/combat.ts`: emits those fields from speck-vs-speck combat
- `store.ts`: adds `kills`, `losses`, `addKill()`, `addLoss()`; both reset on `resetGame`
- `game-instance.ts`: listens for `SPECK_DIED`, increments kills/losses per side
- `components/hud.tsx`: shows `↑N ↓N` in player stats row (muted, non-distracting)
- `components/phase-router.tsx`: shows expanded stats on victory/defeat screen + in share message

## Test plan
- [ ] Play a game — kills/losses tick up in HUD as specks die in battle
- [ ] Win — victory screen shows killed, lost, efficiency %
- [ ] Lose — defeat screen shows same stats
- [ ] Share text includes kill count
- [ ] Play Again resets counters to 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)