### PR TITLE
feat: Speck Wars outpost under-attack alert — HUD dot pulses when enemy capturing

### DIFF
--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -96,26 +96,40 @@ export function HUD() {
       {/* Outpost ownership indicator dots */}
       {hud && (() => {
         const OUTPOST_IDS = ['outpost-top', 'outpost-left', 'outpost-right'] as const
+        const attacked = new Set(hud.attackedBuildingIds ?? [])
         const dots = OUTPOST_IDS.map(id => {
-          if (hud.players.player?.buildingHp[id] !== undefined) return '#4af7c4'
-          if (hud.players.ai?.buildingHp[id] !== undefined) return '#ff4f7b'
-          return '#888888'
+          const isPlayerOwned = hud.players.player?.buildingHp[id] !== undefined
+          const isAiOwned = hud.players.ai?.buildingHp[id] !== undefined
+          const isUnderAttack = attacked.has(id)
+          const color = isPlayerOwned ? '#4af7c4' : isAiOwned ? '#ff4f7b' : '#888888'
+          return { color, isUnderAttack, isPlayerOwned }
         })
         return (
-          <div style={{
-            position: 'absolute', top: 48, left: 0, right: 0,
-            display: 'flex', justifyContent: 'center', alignItems: 'center', gap: 8,
-          }}>
-            <span style={{ fontSize: 10, letterSpacing: 1, opacity: 0.5, marginRight: 4 }}>OUTPOSTS</span>
-            {dots.map((color, i) => (
-              <div key={i} style={{
-                width: 10, height: 10,
-                borderRadius: '50%',
-                background: color,
-                boxShadow: color !== '#888888' ? `0 0 6px ${color}` : 'none',
-              }} />
-            ))}
-          </div>
+          <>
+            {dots.some(d => d.isUnderAttack && d.isPlayerOwned) && (
+              <style>{`
+                @keyframes outpost-alert {
+                  0%, 100% { opacity: 1; transform: scale(1); }
+                  50% { opacity: 0.3; transform: scale(1.5); }
+                }
+              `}</style>
+            )}
+            <div style={{
+              position: 'absolute', top: 48, left: 0, right: 0,
+              display: 'flex', justifyContent: 'center', alignItems: 'center', gap: 8,
+            }}>
+              <span style={{ fontSize: 10, letterSpacing: 1, opacity: 0.5, marginRight: 4 }}>OUTPOSTS</span>
+              {dots.map(({ color, isUnderAttack, isPlayerOwned }, i) => (
+                <div key={i} style={{
+                  width: 10, height: 10,
+                  borderRadius: '50%',
+                  background: isUnderAttack && isPlayerOwned ? '#ff6b35' : color,
+                  boxShadow: color !== '#888888' ? `0 0 6px ${isUnderAttack && isPlayerOwned ? '#ff6b35' : color}` : 'none',
+                  animation: isUnderAttack && isPlayerOwned ? 'outpost-alert 0.6s ease-in-out infinite' : 'none',
+                }} />
+              ))}
+            </div>
+          </>
         )
       })()}
 

--- a/src/app/speck-wars/domain/simulation/tick.ts
+++ b/src/app/speck-wars/domain/simulation/tick.ts
@@ -65,5 +65,10 @@ function emitHudUpdate(sim: SimulationState) {
       buildingHp: Object.fromEntries(myBuildings.map(b => [b.id, b.hp])),
     }
   }
-  sim.events.push({ type: 'HUD_UPDATE', data: { players: data } })
+  // Buildings that are owned but actively being captured by the enemy
+  const attackedBuildingIds = Object.values(sim.buildings)
+    .filter(b => b.typeId === 'outpost' && b.ownerId !== 'neutral' && b.captureProgress && b.captureProgress > 0 && b.captureSide && b.captureSide !== b.ownerId)
+    .map(b => b.id)
+
+  sim.events.push({ type: 'HUD_UPDATE', data: { players: data, attackedBuildingIds } })
 }

--- a/src/app/speck-wars/domain/types.ts
+++ b/src/app/speck-wars/domain/types.ts
@@ -75,4 +75,5 @@ export interface HudData {
     buildingCount: number
     buildingHp: Record<string, number>
   }>
+  attackedBuildingIds: string[]
 }


### PR DESCRIPTION
## Summary
- Owned outpost HUD dots turn orange and pulse fast when an enemy is actively capturing them
- Zero new state: reads directly from `captureProgress` + `captureSide` already tracked in sim
- Gives tactical signal without requiring the player to watch the minimap

## Changes
- `domain/types.ts`: `HudData` gets `attackedBuildingIds: string[]`
- `domain/simulation/tick.ts`: `emitHudUpdate()` populates list from outposts where `captureSide !== ownerId`
- `components/hud.tsx`: Outpost dot turns `#ff6b35` + `outpost-alert` keyframe animation when attacked

## Test plan
- [ ] Let AI approach and start capturing one of your outposts — that HUD dot turns orange and pulses
- [ ] Retake the outpost — dot returns to teal, animation stops
- [ ] AI-owned outposts being captured by you don't trigger the alert (player-only guard)
- [ ] Neutral outposts never alert

🤖 Generated with [Claude Code](https://claude.com/claude-code)