### PR TITLE
feat: Speck Wars visual combat feedback — HP-dimmed specks + colored death flashes

### DIFF
--- a/src/app/speck-wars/rendering/layers/effects-layer.ts
+++ b/src/app/speck-wars/rendering/layers/effects-layer.ts
@@ -1,6 +1,6 @@
 import { Graphics, Container } from 'pixi.js'
 
-interface Flash { x: number; y: number; life: number; maxLife: number }
+interface Flash { x: number; y: number; life: number; maxLife: number; color: number }
 interface Ping { x: number; y: number; life: number; maxLife: number }
 
 export class EffectsLayer {
@@ -15,8 +15,8 @@ export class EffectsLayer {
     this.stage.addChild(this.gfx)
   }
 
-  addDeathFlash(x: number, y: number) {
-    this.flashes.push({ x, y, life: 300, maxLife: 300 })
+  addDeathFlash(x: number, y: number, color = 0xffffff) {
+    this.flashes.push({ x, y, life: 300, maxLife: 300, color })
   }
 
   showRallyPing(x: number, y: number) {
@@ -41,7 +41,7 @@ export class EffectsLayer {
       f.life -= dt
       const alpha = f.life / f.maxLife
       const r = 3 + (1 - alpha) * 4
-      this.gfx.beginFill(0xffffff, alpha)
+      this.gfx.beginFill(f.color, alpha)
       this.gfx.drawCircle(f.x, f.y, r)
       this.gfx.endFill()
     }

--- a/src/app/speck-wars/rendering/layers/speck-layer.ts
+++ b/src/app/speck-wars/rendering/layers/speck-layer.ts
@@ -58,6 +58,9 @@ export class SpeckLayer {
         const typeMeta = sim.speckMeta[i]
         const stype = typeMeta ? SPECK_TYPES[typeMeta.typeId] : null
         spriteList[j].scale.set(stype ? stype.size / 4 : 0.75)
+        // Fade speck as it takes damage — full HP = 1.0, near death = 0.35
+        const hpFrac = stype ? Math.max(0, sim.speckHp[i] / stype.hp) : 1
+        spriteList[j].alpha = 0.35 + 0.65 * hpFrac
       }
 
       // Hide excess sprites

--- a/src/app/speck-wars/rendering/renderer.ts
+++ b/src/app/speck-wars/rendering/renderer.ts
@@ -73,7 +73,8 @@ export class Renderer {
     // Process death flash events from this tick
     for (const event of sim.events) {
       if (event.type === 'SPECK_DIED') {
-        this.effectsLayer.addDeathFlash(event.x, event.y)
+        const flashColor = PLAYER_COLORS[event.killedOwnerId] ?? 0xffffff
+        this.effectsLayer.addDeathFlash(event.x, event.y, flashColor)
       }
     }
     this.effectsLayer.update(dt)


### PR DESCRIPTION
## Summary
- Specks fade visually as their HP drops (alpha 1.0 → 0.35), giving heavy tank damage states visible feedback
- Death flash color now matches the killed speck's owner (teal = AI speck died, pink = player speck died), making the flow of battle readable at a glance

## Changes
- `effects-layer.ts`: `addDeathFlash(x, y, color?)` — accepts optional color, defaults to white
- `speck-layer.ts`: sets `sprite.alpha = 0.35 + 0.65 * (hp/maxHp)` per speck
- `renderer.ts`: passes `PLAYER_COLORS[killedOwnerId]` to `addDeathFlash`

## Test plan
- [ ] Watch a heavy tank (5 HP) take damage — it visibly fades as HP drops
- [ ] Basic specks die in one hit — they flash and disappear without intermediate state
- [ ] When your specks die, the flash is pink; when AI specks die, the flash is teal
- [ ] No perf regression — same alpha calculation is O(n) in speck count

🤖 Generated with [Claude Code](https://claude.com/claude-code)