### PR TITLE
feat: Speck Wars rally point crosshair on minimap

### DIFF
--- a/src/app/speck-wars/components/minimap.tsx
+++ b/src/app/speck-wars/components/minimap.tsx
@@ -78,6 +78,21 @@ export function Minimap({ gameRef }: MinimapProps) {
         ctx.stroke()
       }
 
+      // Draw rally point
+      const rp = sim.rallyPoints['player']
+      if (rp) {
+        const rx = rp.x * SCALE_X
+        const ry = rp.y * SCALE_Y
+        ctx.strokeStyle = playerColor
+        ctx.lineWidth = 1.5
+        ctx.globalAlpha = 0.7
+        ctx.beginPath()
+        ctx.moveTo(rx - 4, ry); ctx.lineTo(rx + 4, ry)
+        ctx.moveTo(rx, ry - 4); ctx.lineTo(rx, ry + 4)
+        ctx.stroke()
+        ctx.globalAlpha = 1
+      }
+
       // Draw viewport rectangle
       // The camera maps world→screen as: screenX = worldX * zoom + camera.x
       // Use window dimensions as the screen size approximation


### PR DESCRIPTION
## Summary
- Minimap now shows a small crosshair at the player's active rally point
- Makes it easy to see where your specks are heading when zoomed out or looking at the minimap

## Changes
- `components/minimap.tsx`: reads `sim.rallyPoints['player']`, draws crosshair at scaled position before the viewport rect

## Test plan
- [ ] Click to set a rally — crosshair appears on minimap at that location
- [ ] Press R to clear rally — crosshair disappears
- [ ] Move rally to different outpost — crosshair moves
- [ ] No crosshair when no rally is set

🤖 Generated with [Claude Code](https://claude.com/claude-code)