### PR TITLE
feat: Speck Wars clickable minimap — click to set rally without panning

### DIFF
--- a/src/app/speck-wars/components/minimap.tsx
+++ b/src/app/speck-wars/components/minimap.tsx
@@ -122,11 +122,22 @@ export function Minimap({ gameRef }: MinimapProps) {
     return () => cancelAnimationFrame(rafId)
   }, [gameRef])
 
+  const handleClick = (e: React.MouseEvent<HTMLCanvasElement>) => {
+    const game = gameRef.current
+    if (!game) return
+    const rect = e.currentTarget.getBoundingClientRect()
+    const mx = e.clientX - rect.left
+    const my = e.clientY - rect.top
+    game.rally(mx / SCALE_X, my / SCALE_Y)
+  }
+
   return (
     <canvas
       ref={canvasRef}
       width={MAP_W}
       height={MAP_H}
+      onClick={handleClick}
+      title="Click to set rally point"
       style={{
         position: 'absolute',
         bottom: 16,
@@ -135,7 +146,7 @@ export function Minimap({ gameRef }: MinimapProps) {
         height: MAP_H,
         borderRadius: 4,
         imageRendering: 'pixelated',
-        pointerEvents: 'none',
+        cursor: 'crosshair',
       }}
     />
   )

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -102,6 +102,11 @@ export class GameInstance {
     console.log('GameInstance destroyed')
   }
 
+  rally(x: number, y: number) {
+    this.sim.inputQueue.push({ type: 'RALLY', ownerId: 'player', x, y })
+    this.renderer.showRallyPing(x, y)
+  }
+
   getSim(): SimulationState {
     return this.sim
   }


### PR DESCRIPTION
## Summary
- Minimap is now interactive: click anywhere on it to set your rally point at that world position
- Cursor changes to crosshair when hovering the minimap, signaling interactivity
- Combines with the crosshair overlay (PR #1753) for a complete minimap command experience

## Changes
- `game-instance.ts`: adds public `rally(x, y)` method that queues a RALLY input and shows a ping
- `components/minimap.tsx`: removes `pointerEvents: 'none'`, adds `onClick` handler that converts minimap coords → world coords → `game.rally()`

## Test plan
- [ ] Click on minimap — specks rally to that world position, ping appears on main canvas
- [ ] Click outpost on minimap — specks route there without needing to scroll camera
- [ ] Crosshair cursor appears on minimap hover
- [ ] Main canvas click still works normally (minimap doesn't interfere)

🤖 Generated with [Claude Code](https://claude.com/claude-code)