### PR TITLE
feat: Speck Wars camera recenter — press C to snap view to player base

### DIFF
--- a/src/app/speck-wars/components/phase-router.tsx
+++ b/src/app/speck-wars/components/phase-router.tsx
@@ -62,6 +62,8 @@ export function PhaseRouter({ children }: { children: React.ReactNode }) {
           <span>R — clear rally</span>
           <span>Drag — pan camera</span>
           <span>H — heavy/basic mode</span>
+          <span>C — center on base</span>
+          <span>Minimap — click to rally</span>
         </div>
       </div>
     )

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -45,6 +45,12 @@ export class GameInstance {
         const next = useSpeckWarsStore.getState().cycleSpawnMode()
         this.sim.inputQueue.push({ type: 'SET_SPAWN_TYPE', ownerId: 'player', speckTypeId: next })
       },
+      () => {                                              // C — recenter camera on player base
+        const base = Object.values(this.sim.buildings).find(b => b.ownerId === 'player' && b.typeId === 'base')
+        if (!base) return
+        this.camera.x = this.canvas.clientWidth / 2 - base.x * this.camera.zoom
+        this.camera.y = this.canvas.clientHeight / 2 - base.y * this.camera.zoom
+      },
     )
     this.lastTime = performance.now()
     this.loop(this.lastTime)

--- a/src/app/speck-wars/input/input-handler.ts
+++ b/src/app/speck-wars/input/input-handler.ts
@@ -8,6 +8,7 @@ export class InputHandler {
   private onTogglePause?: () => void
   private onClearRally?: () => void
   private onCycleSpawnMode?: () => void
+  private onRecenterCamera?: () => void
   private isDragging = false
   private lastX = 0
   private lastY = 0
@@ -23,6 +24,7 @@ export class InputHandler {
     onTogglePause?: () => void,
     onClearRally?: () => void,
     onCycleSpawnMode?: () => void,
+    onRecenterCamera?: () => void,
   ) {
     this.canvas = canvas
     this.camera = camera
@@ -30,6 +32,7 @@ export class InputHandler {
     this.onTogglePause = onTogglePause
     this.onClearRally = onClearRally
     this.onCycleSpawnMode = onCycleSpawnMode
+    this.onRecenterCamera = onRecenterCamera
     this.attach()
   }
 
@@ -125,6 +128,8 @@ export class InputHandler {
       this.onClearRally?.()
     } else if (e.code === 'KeyH') {
       this.onCycleSpawnMode?.()
+    } else if (e.code === 'KeyC') {
+      this.onRecenterCamera?.()
     }
   }
 


### PR DESCRIPTION
## Summary
- Press C to instantly center the camera on your base building
- Quick recovery when you've panned far away to check outposts
- Menu controls legend updated with C and minimap-click hints

## Changes
- `input/input-handler.ts`: `C` key triggers new `onRecenterCamera` callback
- `game-instance.ts`: callback finds player base, computes `camera.x/y` to center it in viewport
- `components/phase-router.tsx`: menu legend now shows `C — center on base` and `Minimap — click to rally`

## Test plan
- [ ] Pan camera to far corner, press C — camera snaps back to player base
- [ ] Works at any zoom level (camera centers correctly)
- [ ] Works while paused
- [ ] Menu shows updated controls legend (8 entries)

🤖 Generated with [Claude Code](https://claude.com/claude-code)