### PR TITLE
feat: Speck Wars personal best — fastest win time per difficulty, shown on menu + victory

### DIFF
--- a/src/app/speck-wars/components/phase-router.tsx
+++ b/src/app/speck-wars/components/phase-router.tsx
@@ -1,10 +1,23 @@
 'use client'
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { useSpeckWarsStore } from '../store'
+import { getBestTime } from '../lib/personal-best'
+import type { Difficulty } from '../store'
 
 export function PhaseRouter({ children }: { children: React.ReactNode }) {
-  const { phase, winnerId, setPhase, difficulty, setDifficulty, elapsedMs, resetGame, kills, losses } = useSpeckWarsStore()
+  const { phase, winnerId, setPhase, difficulty, setDifficulty, elapsedMs, resetGame, kills, losses, isNewBest } = useSpeckWarsStore()
   const [copied, setCopied] = useState(false)
+  const [bestTimes, setBestTimes] = useState<Partial<Record<Difficulty, number>>>({})
+
+  useEffect(() => {
+    if (phase === 'menu') {
+      setBestTimes({
+        easy: getBestTime('easy') ?? undefined,
+        medium: getBestTime('medium') ?? undefined,
+        hard: getBestTime('hard') ?? undefined,
+      })
+    }
+  }, [phase])
 
   const difficulties: Array<{ key: 'easy' | 'medium' | 'hard'; label: string; color: string }> = [
     { key: 'easy', label: 'Easy', color: '#44ff88' },
@@ -37,6 +50,20 @@ export function PhaseRouter({ children }: { children: React.ReactNode }) {
               {d.label}
             </button>
           ))}
+        </div>
+        {/* Best times per difficulty */}
+        <div style={{ display: 'flex', gap: 16, fontSize: 11, color: 'rgba(255,255,255,0.4)' }}>
+          {difficulties.map(d => {
+            const best = bestTimes[d.key]
+            if (!best) return null
+            const mm = String(Math.floor(Math.floor(best / 1000) / 60)).padStart(2, '0')
+            const ss = String(Math.floor(best / 1000) % 60).padStart(2, '0')
+            return (
+              <span key={d.key} style={{ color: d.color, opacity: 0.6 }}>
+                {d.label}: {mm}:{ss}
+              </span>
+            )
+          })}
         </div>
         <button
           onClick={() => setPhase('playing')}
@@ -110,6 +137,11 @@ export function PhaseRouter({ children }: { children: React.ReactNode }) {
         <h1 style={{ color: accentColor, fontSize: 64, margin: 0, letterSpacing: 4 }}>
           {won ? 'VICTORY' : 'DEFEATED'}
         </h1>
+        {won && isNewBest && (
+          <div style={{ color: '#ffd700', fontSize: 16, letterSpacing: 3, fontWeight: 'bold', textShadow: '0 0 16px #ffd700' }}>
+            ★ NEW BEST TIME ★
+          </div>
+        )}
 
         <div style={{ display: 'flex', gap: 24, alignItems: 'center', color: 'rgba(255,255,255,0.7)', fontSize: 16 }}>
           <span>⏱ {timeStr}</span>

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -7,6 +7,7 @@ import { createCamera } from './rendering/camera'
 import { InputHandler } from './input/input-handler'
 import type { Camera } from './rendering/camera'
 import { AIController } from './domain/ai/ai-controller'
+import { recordBestTime } from './lib/personal-best'
 
 export class GameInstance {
   private canvas: HTMLCanvasElement
@@ -70,7 +71,14 @@ export class GameInstance {
 
       for (const event of this.sim.events) {
         if (event.type === 'GAME_OVER') {
-          store.setPhase('victory')
+          if (event.winnerId === 'player') {
+            const isNew = recordBestTime(store.difficulty, this.elapsedMs)
+            store.setIsNewBest(isNew)
+            store.setPhase('victory')
+          } else {
+            store.setIsNewBest(false)
+            store.setPhase('defeat')
+          }
           store.setWinnerId(event.winnerId)
         }
         if (event.type === 'HUD_UPDATE') {

--- a/src/app/speck-wars/lib/personal-best.ts
+++ b/src/app/speck-wars/lib/personal-best.ts
@@ -1,0 +1,20 @@
+import type { Difficulty } from '../store'
+
+const KEY = (d: Difficulty) => `speck-wars-best-${d}`
+
+export function getBestTime(difficulty: Difficulty): number | null {
+  if (typeof window === 'undefined') return null
+  const val = localStorage.getItem(KEY(difficulty))
+  const n = val ? Number(val) : NaN
+  return isNaN(n) ? null : n
+}
+
+export function recordBestTime(difficulty: Difficulty, ms: number): boolean {
+  if (typeof window === 'undefined') return false
+  const prev = getBestTime(difficulty)
+  if (prev === null || ms < prev) {
+    localStorage.setItem(KEY(difficulty), String(ms))
+    return true
+  }
+  return false
+}

--- a/src/app/speck-wars/store.ts
+++ b/src/app/speck-wars/store.ts
@@ -26,6 +26,8 @@ interface SpeckWarsStore {
   addLoss: () => void
   spawnMode: 'basic' | 'heavy'
   cycleSpawnMode: () => 'basic' | 'heavy'
+  isNewBest: boolean
+  setIsNewBest: (v: boolean) => void
   resetGame: () => void
 }
 
@@ -62,6 +64,8 @@ export const useSpeckWarsStore = create<SpeckWarsStore>()(set => ({
     })
     return next
   },
+  isNewBest: false,
+  setIsNewBest: v => set({ isNewBest: v }),
   resetGame: () => set(s => ({
     phase: 'menu' as GamePhase,
     winnerId: null,
@@ -72,6 +76,7 @@ export const useSpeckWarsStore = create<SpeckWarsStore>()(set => ({
     kills: 0,
     losses: 0,
     spawnMode: 'basic' as 'basic' | 'heavy',
+    isNewBest: false,
     difficulty: s.difficulty,
   })),
 }))


### PR DESCRIPTION
## Summary
- Fastest win time per difficulty saved to localStorage
- Menu screen shows best times color-coded per difficulty (only populated difficulties shown)
- Victory screen shows "★ NEW BEST TIME ★" in gold when player beats their record

## Changes
- `lib/personal-best.ts` (new): `getBestTime(d)` + `recordBestTime(d, ms)` with SSR guard
- `store.ts`: adds `isNewBest: boolean`, `setIsNewBest()`, resets in `resetGame`
- `game-instance.ts`: on GAME_OVER winner=player, calls `recordBestTime` and sets `isNewBest`
- `components/phase-router.tsx`: menu reads best times on mount (on phase→'menu'); victory shows gold star banner; uses `useEffect` for localStorage access (SSR-safe)

## Test plan
- [ ] Win on Easy — victory shows "★ NEW BEST TIME ★" (first win is always new best)
- [ ] Go to menu — Easy shows best time in green
- [ ] Win faster — "★ NEW BEST TIME ★" again
- [ ] Win slower — no banner
- [ ] Win on Medium/Hard — their times appear on menu in their colors
- [ ] Play Again — `isNewBest` resets (banner gone on next visit to victory without winning)
- [ ] SSR renders cleanly (no localStorage reference on server)

🤖 Generated with [Claude Code](https://claude.com/claude-code)