### PR TITLE
feat: Speck Wars Hard AI pressure waves — rushes player base every 4th decision

### DIFF
--- a/src/app/speck-wars/domain/ai/ai-controller.ts
+++ b/src/app/speck-wars/domain/ai/ai-controller.ts
@@ -4,10 +4,13 @@ export class AIController {
   private playerId: string
   private tickInterval: number
   private lastDecisionTick: number = 0
+  private aggressive: boolean  // true = Hard mode: every 4th decision rushes base
+  private decisionCount: number = 0
 
-  constructor(playerId: string, tickInterval: number = 30) {
+  constructor(playerId: string, tickInterval: number = 30, aggressive = false) {
     this.playerId = playerId
     this.tickInterval = tickInterval
+    this.aggressive = aggressive
   }
 
   update(sim: SimulationState) {
@@ -48,13 +51,22 @@ export class AIController {
       return best
     }
 
-    // Priority 1: recapture enemy-held outpost
+    this.decisionCount++
+
+    // Hard mode: every 4th decision, rush player base directly (pressure waves)
+    const forceBaseRush = this.aggressive && this.decisionCount % 4 === 0
+
+    // Priority 1 (always): recapture player-held outpost
     // Priority 2: capture neutral outpost
     // Priority 3: attack enemy base
-    const target =
-      nearest(b => b.typeId === 'outpost' && b.ownerId !== this.playerId && b.ownerId !== 'neutral') ??
-      nearest(b => b.typeId === 'outpost' && b.ownerId === 'neutral') ??
-      nearest(b => b.ownerId !== this.playerId && b.ownerId !== 'neutral' && b.typeId === 'base')
+    // Hard mode override: directly rush base on pressure-wave ticks
+    const target = forceBaseRush
+      ? nearest(b => b.ownerId !== this.playerId && b.ownerId !== 'neutral' && b.typeId === 'base')
+      : (
+          nearest(b => b.typeId === 'outpost' && b.ownerId !== this.playerId && b.ownerId !== 'neutral') ??
+          nearest(b => b.typeId === 'outpost' && b.ownerId === 'neutral') ??
+          nearest(b => b.ownerId !== this.playerId && b.ownerId !== 'neutral' && b.typeId === 'base')
+        )
 
     if (!target) return
 

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -27,7 +27,7 @@ export class GameInstance {
     this.sim = createSim(Date.now(), difficulty)
     this.renderer = new Renderer()
     this.camera = createCamera(canvas.clientWidth, canvas.clientHeight)
-    this.aiController = new AIController('ai', aiTickInterval[difficulty])
+    this.aiController = new AIController('ai', aiTickInterval[difficulty], difficulty === 'hard')
   }
 
   async start() {


### PR DESCRIPTION
## Summary
- Hard AI now sends periodic base-rush waves: every 4th decision it sends all specks directly at the player base, regardless of outpost state
- Between waves (3 out of 4 decisions), it still follows normal priority (recapture → neutral → base)
- Makes Hard mode feel qualitatively different from Medium (not just faster tick)

## Changes
- `domain/ai/ai-controller.ts`: adds `aggressive: boolean` constructor param, `decisionCount` tracker; on Hard, every 4th decision force-targets player base
- `game-instance.ts`: passes `difficulty === 'hard'` as `aggressive` arg

## Test plan
- [ ] Hard mode: AI alternates between outpost capture and direct base rushes
- [ ] Easy/Medium: AI behavior unchanged (pure outpost priority → base fallback)
- [ ] Hard is noticeably harder than Medium — player must actively defend base

🤖 Generated with [Claude Code](https://claude.com/claude-code)