### PR TITLE
feat: Speck Wars outpost HP regeneration — heals 2 HP/sec when not under attack

### DIFF
--- a/src/app/speck-wars/domain/config/building-types.ts
+++ b/src/app/speck-wars/domain/config/building-types.ts
@@ -3,6 +3,7 @@ export interface BuildingTypeDefinition {
   maxHp: number; size: number
   spawnTypeId: string | null
   spawnInterval: number; spawnCount: number
+  hpRegen?: number   // HP per second, only when not under attack
   cost?: Array<{ typeId: string; count: number }>
 }
 
@@ -18,5 +19,6 @@ export const BUILDING_TYPES: Record<string, BuildingTypeDefinition> = {
     maxHp: 50, size: 20,
     spawnTypeId: 'heavy',
     spawnInterval: 1800, spawnCount: 1,
+    hpRegen: 2,  // 2 HP/sec when not under attack
   },
 }

--- a/src/app/speck-wars/domain/simulation/tick.ts
+++ b/src/app/speck-wars/domain/simulation/tick.ts
@@ -6,6 +6,7 @@ import { moveSpecks } from './movement'
 import { resolveCombat, removeDeadSpecks } from './combat'
 import { checkVictory } from './victory'
 import { updateCapture } from './capture'
+import { BUILDING_TYPES } from '../config/building-types'
 import { HUD_UPDATE_INTERVAL } from '../constants'
 
 export function tick(sim: SimulationState, dt: number): SimulationState {
@@ -32,6 +33,9 @@ export function tick(sim: SimulationState, dt: number): SimulationState {
   // 7. Update outpost capture progress
   updateCapture(sim, dt)
 
+  // 7b. HP regeneration for owned buildings when not under attack
+  regenBuildingHp(sim, dt)
+
   // 8. Check win/loss
   checkVictory(sim)
 
@@ -40,6 +44,19 @@ export function tick(sim: SimulationState, dt: number): SimulationState {
   if (sim.tick % HUD_UPDATE_INTERVAL === 0) emitHudUpdate(sim)
 
   return sim
+}
+
+function regenBuildingHp(sim: SimulationState, dt: number) {
+  const dtSec = dt / 1000
+  for (const building of Object.values(sim.buildings)) {
+    if (building.hp >= building.maxHp) continue
+    if (building.ownerId === 'neutral') continue
+    const btype = BUILDING_TYPES[building.typeId]
+    if (!btype?.hpRegen) continue
+    // No regen while actively being captured
+    if (building.captureProgress && building.captureProgress > 0) continue
+    building.hp = Math.min(building.maxHp, building.hp + btype.hpRegen * dtSec)
+  }
 }
 
 function consumeInputs(sim: SimulationState) {


### PR DESCRIPTION
## Summary
- Owned outposts regenerate 2 HP/sec when not actively being captured
- Rewards players who hold outposts for extended periods
- Regen pauses the moment an enemy starts capturing (`captureProgress > 0`)
- Bases do not regenerate (outpost-only mechanic)

## Changes
- `domain/config/building-types.ts`: `BuildingTypeDefinition` gets optional `hpRegen?: number`; outpost configured with `hpRegen: 2`
- `domain/simulation/tick.ts`: new `regenBuildingHp()` called after capture update; skips neutral, neutral buildings, and buildings under capture

## Test plan
- [ ] Let an outpost take combat damage — HP bar drops visibly
- [ ] Clear enemies from it — HP slowly climbs back to max
- [ ] Let enemy start capturing — regen pauses
- [ ] Retake it — regen resumes
- [ ] Bases never regen (only outposts have `hpRegen`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)