### PR TITLE
feat: Speck Wars defend shortcut (D) + win streak counter on menu

### DIFF
--- a/src/app/speck-wars/components/phase-router.tsx
+++ b/src/app/speck-wars/components/phase-router.tsx
@@ -1,13 +1,14 @@
 'use client'
 import { useState, useEffect } from 'react'
 import { useSpeckWarsStore } from '../store'
-import { getBestTime } from '../lib/personal-best'
+import { getBestTime, getWinStreak } from '../lib/personal-best'
 import type { Difficulty } from '../store'
 
 export function PhaseRouter({ children }: { children: React.ReactNode }) {
   const { phase, winnerId, setPhase, difficulty, setDifficulty, elapsedMs, resetGame, kills, losses, isNewBest } = useSpeckWarsStore()
   const [copied, setCopied] = useState(false)
   const [bestTimes, setBestTimes] = useState<Partial<Record<Difficulty, number>>>({})
+  const [winStreak, setWinStreak] = useState(0)
 
   useEffect(() => {
     if (phase === 'menu') {
@@ -16,6 +17,7 @@ export function PhaseRouter({ children }: { children: React.ReactNode }) {
         medium: getBestTime('medium') ?? undefined,
         hard: getBestTime('hard') ?? undefined,
       })
+      setWinStreak(getWinStreak())
     }
   }, [phase])
 
@@ -30,6 +32,11 @@ export function PhaseRouter({ children }: { children: React.ReactNode }) {
       <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', height: '100%', gap: 16 }}>
         <h1 style={{ color: '#fff', fontSize: 48, margin: 0 }}>Speck Wars</h1>
         <p style={{ color: '#aaa', margin: 0 }}>Destroy the enemy base. Last base standing wins.</p>
+        {winStreak >= 2 && (
+          <div style={{ color: '#ffd700', fontSize: 14, letterSpacing: 2, fontWeight: 'bold' }}>
+            🔥 {winStreak} WIN STREAK
+          </div>
+        )}
         <div style={{ display: 'flex', gap: 8, marginBottom: 8 }}>
           {difficulties.map(d => (
             <button
@@ -90,6 +97,7 @@ export function PhaseRouter({ children }: { children: React.ReactNode }) {
           <span>Drag — pan camera</span>
           <span>H — heavy/basic mode</span>
           <span>C — center on base</span>
+          <span>D — defend base</span>
           <span>Minimap — click to rally</span>
         </div>
       </div>

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -7,7 +7,7 @@ import { createCamera } from './rendering/camera'
 import { InputHandler } from './input/input-handler'
 import type { Camera } from './rendering/camera'
 import { AIController } from './domain/ai/ai-controller'
-import { recordBestTime } from './lib/personal-best'
+import { recordBestTime, incrementWinStreak, resetWinStreak } from './lib/personal-best'
 
 export class GameInstance {
   private canvas: HTMLCanvasElement
@@ -52,6 +52,11 @@ export class GameInstance {
         this.camera.x = this.canvas.clientWidth / 2 - base.x * this.camera.zoom
         this.camera.y = this.canvas.clientHeight / 2 - base.y * this.camera.zoom
       },
+      () => {                                              // D — defend (rally to player base)
+        const base = Object.values(this.sim.buildings).find(b => b.ownerId === 'player' && b.typeId === 'base')
+        if (!base) return
+        this.rally(base.x, base.y)
+      },
     )
     this.lastTime = performance.now()
     this.loop(this.lastTime)
@@ -73,9 +78,11 @@ export class GameInstance {
         if (event.type === 'GAME_OVER') {
           if (event.winnerId === 'player') {
             const isNew = recordBestTime(store.difficulty, this.elapsedMs)
+            incrementWinStreak()
             store.setIsNewBest(isNew)
             store.setPhase('victory')
           } else {
+            resetWinStreak()
             store.setIsNewBest(false)
             store.setPhase('defeat')
           }

--- a/src/app/speck-wars/input/input-handler.ts
+++ b/src/app/speck-wars/input/input-handler.ts
@@ -9,6 +9,7 @@ export class InputHandler {
   private onClearRally?: () => void
   private onCycleSpawnMode?: () => void
   private onRecenterCamera?: () => void
+  private onDefend?: () => void
   private isDragging = false
   private lastX = 0
   private lastY = 0
@@ -25,6 +26,7 @@ export class InputHandler {
     onClearRally?: () => void,
     onCycleSpawnMode?: () => void,
     onRecenterCamera?: () => void,
+    onDefend?: () => void,
   ) {
     this.canvas = canvas
     this.camera = camera
@@ -33,6 +35,7 @@ export class InputHandler {
     this.onClearRally = onClearRally
     this.onCycleSpawnMode = onCycleSpawnMode
     this.onRecenterCamera = onRecenterCamera
+    this.onDefend = onDefend
     this.attach()
   }
 
@@ -130,6 +133,8 @@ export class InputHandler {
       this.onCycleSpawnMode?.()
     } else if (e.code === 'KeyC') {
       this.onRecenterCamera?.()
+    } else if (e.code === 'KeyD') {
+      this.onDefend?.()
     }
   }
 

--- a/src/app/speck-wars/lib/personal-best.ts
+++ b/src/app/speck-wars/lib/personal-best.ts
@@ -1,6 +1,7 @@
 import type { Difficulty } from '../store'
 
 const KEY = (d: Difficulty) => `speck-wars-best-${d}`
+const STREAK_KEY = 'speck-wars-win-streak'
 
 export function getBestTime(difficulty: Difficulty): number | null {
   if (typeof window === 'undefined') return null
@@ -17,4 +18,21 @@ export function recordBestTime(difficulty: Difficulty, ms: number): boolean {
     return true
   }
   return false
+}
+
+export function getWinStreak(): number {
+  if (typeof window === 'undefined') return 0
+  return Number(localStorage.getItem(STREAK_KEY) ?? '0') || 0
+}
+
+export function incrementWinStreak(): number {
+  if (typeof window === 'undefined') return 0
+  const next = getWinStreak() + 1
+  localStorage.setItem(STREAK_KEY, String(next))
+  return next
+}
+
+export function resetWinStreak() {
+  if (typeof window === 'undefined') return
+  localStorage.setItem(STREAK_KEY, '0')
 }


### PR DESCRIPTION
## Summary
- Press **D** to instantly rally all specks to your base for emergency defense (ping animation included)
- Win streaks tracked in localStorage — after 2+ consecutive wins a gold "🔥 N WIN STREAK" badge appears on the menu
- Streak resets to 0 on any defeat

## Changes
- `input/input-handler.ts`: `D` key triggers `onDefend` callback
- `game-instance.ts`: D callback uses existing `this.rally()` targeting player base; GAME_OVER event calls `incrementWinStreak()` on win, `resetWinStreak()` on loss
- `lib/personal-best.ts`: adds `getWinStreak()`, `incrementWinStreak()`, `resetWinStreak()`
- `components/phase-router.tsx`: reads streak on phase→'menu'; shows gold badge at ≥2; `D — defend base` added to controls legend

## Test plan
- [ ] Press D during play — specks route to player base, ping appears
- [ ] Win game — win streak stored; menu shows "🔥 2 WIN STREAK" after second consecutive win
- [ ] Lose a game — streak resets to 0, badge disappears
- [ ] Reload page — streak persists (localStorage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)