### PR TITLE
feat: Speck Wars battle status indicator — DOMINATING/WINNING/LOSING/CRITICAL in HUD

### DIFF
--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -170,6 +170,38 @@ export function HUD() {
         </div>
       )}
 
+      {/* Battle status indicator */}
+      {hud && phase === 'playing' && (() => {
+        const playerSpecks = hud.players.player?.speckCount ?? 0
+        const aiSpecks = hud.players.ai?.speckCount ?? 0
+        const total = playerSpecks + aiSpecks
+        if (total < 20) return null  // too few specks — don't show yet
+        const ratio = playerSpecks / total
+        const status =
+          ratio > 0.65 ? { label: 'DOMINATING', color: '#4af7c4' }
+          : ratio > 0.55 ? { label: 'WINNING', color: '#88ff44' }
+          : ratio < 0.35 ? { label: 'CRITICAL', color: '#ff4f7b' }
+          : ratio < 0.45 ? { label: 'LOSING', color: '#ffaa44' }
+          : null
+        if (!status) return null
+        return (
+          <div style={{
+            position: 'absolute', bottom: 16, left: 0, right: 0,
+            display: 'flex', justifyContent: 'center',
+          }}>
+            <span style={{
+              fontSize: 11,
+              letterSpacing: 2,
+              color: status.color,
+              opacity: 0.6,
+              textTransform: 'uppercase',
+            }}>
+              {status.label}
+            </span>
+          </div>
+        )
+      })()}
+
       {/* Paused overlay */}
       {phase === 'paused' && (
         <div style={{


### PR DESCRIPTION
## Summary
- Small status label at bottom-center of HUD shows tactical momentum
- Based on live speck count ratio (player vs AI)
- Thresholds: DOMINATING (>65%), WINNING (>55%), LOSING (<45%), CRITICAL (<35%)
- Only shows when total speck count ≥ 20 and ratio is clearly lopsided

## Changes
- `components/hud.tsx`: new IIFE block that computes ratio and renders colored label

## Test plan
- [ ] Early game (< 20 specks) — no status label
- [ ] Win a lopsided fight — "DOMINATING" or "WINNING" appears in teal/green
- [ ] Lose a lopsided fight — "LOSING" or "CRITICAL" appears in orange/red
- [ ] Near-even fights — no label (45–55% range)
- [ ] Status updates every HUD_UPDATE_INTERVAL ticks as specks die

🤖 Generated with [Claude Code](https://claude.com/claude-code)