### PR TITLE
feat: Speck Wars Easy mode player spawn advantage — 550ms vs AI's 2000ms

### DIFF
--- a/src/app/speck-wars/domain/simulation/create-sim.ts
+++ b/src/app/speck-wars/domain/simulation/create-sim.ts
@@ -9,6 +9,12 @@ const aiSpawnInterval: Record<Difficulty, number> = {
   hard: 400,
 }
 
+const playerSpawnInterval: Record<Difficulty, number | undefined> = {
+  easy: 550,   // faster on easy — the AI is already slow, this ensures clear advantage
+  medium: undefined,  // use default (800ms)
+  hard: undefined,    // use default (800ms) — player skill must compensate
+}
+
 export function createSim(seed: number = Date.now(), difficulty: Difficulty = 'medium'): SimulationState {
   const playerBase: BuildingEntity = {
     id: 'building-player-base',
@@ -17,6 +23,7 @@ export function createSim(seed: number = Date.now(), difficulty: Difficulty = 'm
     x: PLAYER_BASE_X, y: PLAYER_BASE_Y,
     hp: BASE_HP, maxHp: BASE_HP,
     spawnTimer: 0,
+    spawnIntervalOverride: playerSpawnInterval[difficulty],
     inputBuffer: {},
   }
   const aiBase: BuildingEntity = {


### PR DESCRIPTION
## Summary
- On Easy, player base spawns every 550ms (vs default 800ms), giving a clear production edge
- AI on Easy still spawns every 2000ms — ratio is ~3.6x in player's favor
- Medium and Hard: player keeps default 800ms spawn rate, maintaining challenge

## Changes
- `domain/simulation/create-sim.ts`: adds `playerSpawnInterval` record; sets `spawnIntervalOverride` on playerBase entity for Easy (550ms)

## Test plan
- [ ] Easy: player swarm visibly grows faster than AI's
- [ ] Medium/Hard: player spawn rate unchanged (800ms)
- [ ] "DOMINATING" status indicator appears sooner on Easy

🤖 Generated with [Claude Code](https://claude.com/claude-code)