### PR TITLE
feat: Speck Wars map variation — outposts randomly offset ±200px each game

### DIFF
--- a/src/app/speck-wars/domain/simulation/create-sim.ts
+++ b/src/app/speck-wars/domain/simulation/create-sim.ts
@@ -50,13 +50,16 @@ export function createSim(seed: number = Date.now(), difficulty: Difficulty = 'm
     color: NEUTRAL_COLOR, isAI: false, isDefeated: false, stockpile: {},
   }
 
+  const JITTER = 200  // ± px of positional variation per game
   const outpostBuildings: Record<string, BuildingEntity> = {}
   for (const pos of OUTPOST_POSITIONS) {
+    const jx = (Math.random() * 2 - 1) * JITTER
+    const jy = (Math.random() * 2 - 1) * JITTER
     outpostBuildings[pos.id] = {
       id: pos.id,
       typeId: 'outpost',
       ownerId: 'neutral',
-      x: pos.x, y: pos.y,
+      x: pos.x + jx, y: pos.y + jy,
       hp: 50, maxHp: 50,
       spawnTimer: 0,
       inputBuffer: {},


### PR DESCRIPTION
## Summary
- Each game starts with outposts at slightly different positions (±200px random jitter)
- The triangle layout is preserved — just enough variation to change optimal routes and make each game feel fresh
- Uses `Math.random()` at game creation time (non-deterministic by design)

## Changes
- `domain/simulation/create-sim.ts`: adds `JITTER = 200` constant, applies `(Math.random() * 2 - 1) * JITTER` to both x and y of each outpost

## Test plan
- [ ] Start game twice — outpost positions visibly differ between games
- [ ] Positions stay within sensible map bounds (base positions at 600/2400, outposts nominally at 1500 center — ±200 keeps them mid-map)
- [ ] Minimap and HUD correctly reflect the new positions (they use building data directly, so no hardcoded positions to update)

🤖 Generated with [Claude Code](https://claude.com/claude-code)