### PR TITLE
feat: Speck Wars triple outpost bonus — own all 3 outposts = 2× base spawn rate

### DIFF
--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -152,6 +152,21 @@ export function HUD() {
         )
       })()}
 
+      {/* Triple outpost bonus indicator */}
+      {hud?.tripleOutpostOwner === 'player' && phase === 'playing' && (
+        <div style={{
+          position: 'absolute', top: 100, left: 0, right: 0,
+          display: 'flex', justifyContent: 'center',
+        }}>
+          <span style={{
+            fontSize: 11, letterSpacing: 2, fontWeight: 'bold',
+            color: '#ffd700', textShadow: '0 0 8px #ffd700',
+          }}>
+            ⬡⬡⬡ TRIPLE CONTROL — SPAWN ×2
+          </span>
+        </div>
+      )}
+
       {/* Outpost capture/loss notification */}
       {notification && (
         <div style={{

--- a/src/app/speck-wars/domain/simulation/spawner.ts
+++ b/src/app/speck-wars/domain/simulation/spawner.ts
@@ -40,7 +40,8 @@ export function updateSpawners(sim: SimulationState, dt: number) {
     building.spawnTimer -= dt
     if (building.spawnTimer > 0) continue
 
-    building.spawnTimer = building.spawnIntervalOverride ?? btype.spawnInterval
+    const baseInterval = building.spawnIntervalOverride ?? btype.spawnInterval
+    building.spawnTimer = building.tripleOutpostBonus ? baseInterval / 2 : baseInterval
 
     for (let i = 0; i < btype.spawnCount; i++) {
       // Spawn just outside the building radius with slight random offset

--- a/src/app/speck-wars/domain/simulation/tick.ts
+++ b/src/app/speck-wars/domain/simulation/tick.ts
@@ -36,6 +36,9 @@ export function tick(sim: SimulationState, dt: number): SimulationState {
   // 7b. HP regeneration for owned buildings when not under attack
   regenBuildingHp(sim, dt)
 
+  // 7c. Triple outpost bonus — control all 3 outposts = 2× base spawn speed
+  updateTripleOutpostBonus(sim)
+
   // 8. Check win/loss
   checkVictory(sim)
 
@@ -56,6 +59,20 @@ function regenBuildingHp(sim: SimulationState, dt: number) {
     // No regen while actively being captured
     if (building.captureProgress && building.captureProgress > 0) continue
     building.hp = Math.min(building.maxHp, building.hp + btype.hpRegen * dtSec)
+  }
+}
+
+function updateTripleOutpostBonus(sim: SimulationState) {
+  const outposts = Object.values(sim.buildings).filter(b => b.typeId === 'outpost')
+  if (outposts.length === 0) return
+
+  for (const [pid] of Object.entries(sim.players)) {
+    if (pid === 'neutral') continue
+    const ownsAll = outposts.every(o => o.ownerId === pid)
+    for (const building of Object.values(sim.buildings)) {
+      if (building.ownerId !== pid || building.typeId !== 'base') continue
+      building.tripleOutpostBonus = ownsAll
+    }
   }
 }
 
@@ -96,5 +113,15 @@ function emitHudUpdate(sim: SimulationState) {
     .filter(b => b.typeId === 'outpost' && b.ownerId !== 'neutral' && b.captureProgress && b.captureProgress > 0 && b.captureSide && b.captureSide !== b.ownerId)
     .map(b => b.id)
 
-  sim.events.push({ type: 'HUD_UPDATE', data: { players: data, attackedBuildingIds } })
+  // Which player (if any) owns all outposts and has the triple bonus
+  const outposts = Object.values(sim.buildings).filter(b => b.typeId === 'outpost')
+  let tripleOutpostOwner: string | null = null
+  if (outposts.length > 0) {
+    for (const [pid] of Object.entries(sim.players)) {
+      if (pid === 'neutral') continue
+      if (outposts.every(o => o.ownerId === pid)) { tripleOutpostOwner = pid; break }
+    }
+  }
+
+  sim.events.push({ type: 'HUD_UPDATE', data: { players: data, attackedBuildingIds, tripleOutpostOwner } })
 }

--- a/src/app/speck-wars/domain/types.ts
+++ b/src/app/speck-wars/domain/types.ts
@@ -18,6 +18,7 @@ export interface BuildingEntity {
   spawnTimer: number       // ms until next spawn
   spawnIntervalOverride?: number  // overrides BUILDING_TYPES spawnInterval when set
   spawnTypeOverride?: string      // overrides BUILDING_TYPES spawnTypeId when set
+  tripleOutpostBonus?: boolean    // true when owner controls all outposts (2× spawn)
   inputBuffer: Record<string, number>  // typeId → count (sacrifice system, future)
   captureProgress?: number      // 0..1 progress toward capture for captureSide
   captureSide?: string | null   // which player is currently winning capture
@@ -78,4 +79,5 @@ export interface HudData {
     buildingHp: Record<string, number>
   }>
   attackedBuildingIds: string[]
+  tripleOutpostOwner: string | null  // player ID who owns all 3 outposts, or null
 }


### PR DESCRIPTION
## Summary
- Owning all 3 outposts simultaneously halves the base's spawn interval (doubles output rate)
- HUD shows gold "⬡⬡⬡ TRIPLE CONTROL — SPAWN ×2" banner when player has the bonus
- Bonus applies to AI too (no banner shown for AI)
- Creates a powerful strategic incentive to capture all outposts, and a clear "winning" moment

## Changes
- `domain/types.ts`: `BuildingEntity` gets `tripleOutpostBonus?`; `HudData` gets `tripleOutpostOwner`
- `domain/simulation/tick.ts`: `updateTripleOutpostBonus()` sets flag on base buildings; `emitHudUpdate` computes `tripleOutpostOwner`
- `domain/simulation/spawner.ts`: halves `spawnTimer` when `building.tripleOutpostBonus` is true
- `components/hud.tsx`: gold banner shown when `hud.tripleOutpostOwner === 'player'`

## Test plan
- [ ] Capture all 3 outposts — gold "TRIPLE CONTROL" banner appears in HUD
- [ ] Spawn rate visibly doubles (specks come out faster)
- [ ] Lose one outpost — banner disappears, spawn rate returns to normal
- [ ] AI capturing all 3 also gets the bonus (no banner — purely mechanical)
- [ ] Easy mode + triple bonus stacks: 550ms → 275ms (very fast)

🤖 Generated with [Claude Code](https://claude.com/claude-code)