### PR TITLE
feat: Speck Wars capture speed scales with speck count — up to 3× faster at 15 specks

### DIFF
--- a/src/app/speck-wars/domain/simulation/capture.ts
+++ b/src/app/speck-wars/domain/simulation/capture.ts
@@ -23,7 +23,7 @@ export function updateCapture(sim: SimulationState, dt: number) {
     if (sides.length === 0) return  // nobody near — decay progress slowly
     if (sides.length > 1) continue  // contested — pause capture
 
-    const [dominantOwner] = sides[0]
+    const [dominantOwner, dominantCount] = sides[0]
     if (dominantOwner === building.ownerId) continue  // already owned by them
 
     // Start or continue capture
@@ -32,7 +32,9 @@ export function updateCapture(sim: SimulationState, dt: number) {
       building.captureProgress = 0
     }
 
-    building.captureProgress = (building.captureProgress ?? 0) + dt / CAPTURE_TIME
+    // Scale capture speed with speck count: 5 specks = 1×, capped at 3× (15 specks)
+    const captureSpeed = Math.min(3, dominantCount / 5)
+    building.captureProgress = (building.captureProgress ?? 0) + (dt / CAPTURE_TIME) * captureSpeed
     if ((building.captureProgress ?? 0) >= 1) {
       const previousOwner = building.ownerId
       building.ownerId = dominantOwner


### PR DESCRIPTION
## Summary
- Outpost capture speed now scales with the number of specks in capture radius
- 5 specks = 1× (5000ms baseline), 10 specks = 2× (2500ms), 15+ specks = 3× max (1666ms)
- Makes large army investments in capture feel rewarding; creates faster capture races

## Changes
- `domain/simulation/capture.ts`: reads `dominantCount` from `sides[0]`, computes `captureSpeed = Math.min(3, count/5)`, multiplies progress increment

## Test plan
- [ ] Send 5 specks to neutral outpost — captures in ~5s as before
- [ ] Send 15 specks — captures in ~1.7s
- [ ] AI on Hard sends large waves — captures outposts faster (tension!)
- [ ] Contested outpost (both sides have specks) still pauses

🤖 Generated with [Claude Code](https://claude.com/claude-code)