### PR TITLE
feat: Speck Wars Enter key starts game + difficulty badge in HUD

### DIFF
--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -25,6 +25,7 @@ export function HUD() {
   const losses = useSpeckWarsStore(s => s.losses)
   const spawnMode = useSpeckWarsStore(s => s.spawnMode)
   const cycleSpawnMode = useSpeckWarsStore(s => s.cycleSpawnMode)
+  const difficulty = useSpeckWarsStore(s => s.difficulty)
 
   const BASE_MAX_HP = 100
   const playerBaseHp = hud?.players.player?.buildingHp['building-player-base']
@@ -53,6 +54,19 @@ export function HUD() {
           }} />
         </>
       )}
+      {/* Difficulty badge — top right */}
+      {(() => {
+        const diffColors = { easy: '#44ff88', medium: '#ffcc44', hard: '#ff4f7b' }
+        const color = diffColors[difficulty]
+        return (
+          <div style={{ position: 'absolute', top: 12, right: 16, fontSize: 10, letterSpacing: 1 }}>
+            <span style={{ color, opacity: 0.5, border: `1px solid ${color}`, borderRadius: 3, padding: '2px 6px' }}>
+              {difficulty.toUpperCase()}
+            </span>
+          </div>
+        )
+      })()}
+
       {/* Timer + Pause button — top bar */}
       <div style={{
         position: 'absolute', top: 12, left: 0, right: 0,

--- a/src/app/speck-wars/components/phase-router.tsx
+++ b/src/app/speck-wars/components/phase-router.tsx
@@ -21,6 +21,15 @@ export function PhaseRouter({ children }: { children: React.ReactNode }) {
     }
   }, [phase])
 
+  useEffect(() => {
+    if (phase !== 'menu') return
+    const onKey = (e: KeyboardEvent) => {
+      if (e.code === 'Enter') setPhase('playing')
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [phase, setPhase])
+
   const difficulties: Array<{ key: 'easy' | 'medium' | 'hard'; label: string; color: string }> = [
     { key: 'easy', label: 'Easy', color: '#44ff88' },
     { key: 'medium', label: 'Medium', color: '#ffcc44' },


### PR DESCRIPTION
## Summary
- Press Enter on menu to start immediately (no mouse click needed)
- Small color-coded difficulty badge in top-right HUD corner (EASY=green, MEDIUM=yellow, HARD=red)

## Changes
- `components/phase-router.tsx`: `useEffect` adds `keydown` listener for `Enter` on menu phase
- `components/hud.tsx`: difficulty badge element top-right; reads `difficulty` from store

## Test plan
- [ ] Menu: press Enter → game starts without clicking Play
- [ ] Menu: Enter respects currently selected difficulty
- [ ] During play: difficulty badge shows in top-right corner
- [ ] Badge uses correct color for each difficulty

🤖 Generated with [Claude Code](https://claude.com/claude-code)