### PR TITLE
feat: Speck Wars FIRST BLOOD notification — first kill of the game

### DIFF
--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -19,6 +19,7 @@ export class GameInstance {
   private inputHandler!: InputHandler
   private aiController: AIController
   private elapsedMs = 0
+  private firstBloodDone = false
 
   constructor(canvas: HTMLCanvasElement) {
     this.canvas = canvas
@@ -94,6 +95,15 @@ export class GameInstance {
         if (event.type === 'SPECK_DIED') {
           if (event.killedOwnerId === 'ai' && event.killerOwnerId === 'player') store.addKill()
           else if (event.killedOwnerId === 'player' && event.killerOwnerId === 'ai') store.addLoss()
+          if (!this.firstBloodDone) {
+            this.firstBloodDone = true
+            const playerGotIt = event.killerOwnerId === 'player'
+            store.setNotification({
+              message: playerGotIt ? '⚔ FIRST BLOOD!' : '☠ FIRST BLOOD!',
+              color: playerGotIt ? '#4af7c4' : '#ff4f7b',
+            })
+            setTimeout(() => useSpeckWarsStore.getState().setNotification(null), 1800)
+          }
         }
         if (event.type === 'OUTPOST_CAPTURED') {
           const isPlayerGain = event.newOwner === 'player'


### PR DESCRIPTION
## Summary
- First speck kill of each game triggers a "FIRST BLOOD!" notification
- Teal `⚔ FIRST BLOOD!` if player gets it, pink `☠ FIRST BLOOD!` if AI does
- Disappears after 1.8s, uses existing notification slot
- `firstBloodDone` flag resets each game (new GameInstance on play)

## Changes
- `game-instance.ts`: adds `firstBloodDone = false`; on first `SPECK_DIED` event sets flag and shows notification

## Test plan
- [ ] Start game — first kill shows the appropriate message
- [ ] Player kills first — teal banner
- [ ] AI kills first — pink banner
- [ ] Play Again — first blood triggers fresh on new game
- [ ] Notification disappears after 1.8s

🤖 Generated with [Claude Code](https://claude.com/claude-code)