### PR TITLE
feat: Speck Wars outpost speed aura — 35% movement boost near friendly outposts

### DIFF
--- a/src/app/speck-wars/domain/constants.ts
+++ b/src/app/speck-wars/domain/constants.ts
@@ -19,6 +19,7 @@ export const OUTPOST_SPAWN_INTERVAL = 1800   // ms per speck (slower than base)
 export const CAPTURE_RADIUS = 100            // px — specks within this distance count toward capture
 export const CAPTURE_TIME = 5000             // ms to fully capture
 export const NEUTRAL_COLOR = 0x888888
+export const OUTPOST_AURA_RADIUS = 160  // px — specks within this radius of a friendly outpost move faster
 
 // Triangle around center (1500, 1500), equidistant between the two bases
 export const OUTPOST_POSITIONS = [

--- a/src/app/speck-wars/domain/simulation/movement.ts
+++ b/src/app/speck-wars/domain/simulation/movement.ts
@@ -1,13 +1,17 @@
 import type { SimulationState } from '../types'
 import { SPECK_TYPES } from '../config/speck-types'
-import { WORLD_WIDTH, WORLD_HEIGHT } from '../constants'
+import { WORLD_WIDTH, WORLD_HEIGHT, OUTPOST_AURA_RADIUS } from '../constants'
 
 const SEPARATION_RADIUS = 8   // px — keep specks this far apart
 const SEPARATION_FORCE = 120  // strength of push-apart
+const AURA_SPEED_MULT = 1.35  // 35% speed boost inside outpost aura
 
 export function moveSpecks(sim: SimulationState, dt: number) {
   const { speckIds, speckX, speckY, speckVx, speckVy, speckMeta, buildings, spatialGrid } = sim
   const dtSec = dt / 1000
+
+  // Cache outpost positions once per tick (only 3 buildings, negligible cost)
+  const outposts = Object.values(buildings).filter(b => b.typeId === 'outpost')
 
   // Rebuild grid with current positions before applying separation
   spatialGrid.clear()
@@ -60,6 +64,21 @@ export function moveSpecks(sim: SimulationState, dt: number) {
         const force = (SEPARATION_RADIUS - dist) / SEPARATION_RADIUS * SEPARATION_FORCE
         ax += (dx / dist) * force
         ay += (dy / dist) * force
+      }
+    }
+
+    // Outpost speed aura: boost movement if inside a friendly outpost's aura
+    if (ax !== 0 || ay !== 0) {
+      const auraR2 = OUTPOST_AURA_RADIUS * OUTPOST_AURA_RADIUS
+      for (const building of outposts) {
+        if (building.ownerId !== meta.ownerId) continue
+        const bdx = speckX[i] - building.x
+        const bdy = speckY[i] - building.y
+        if (bdx * bdx + bdy * bdy < auraR2) {
+          ax *= AURA_SPEED_MULT
+          ay *= AURA_SPEED_MULT
+          break
+        }
       }
     }
 

--- a/src/app/speck-wars/rendering/layers/building-layer.ts
+++ b/src/app/speck-wars/rendering/layers/building-layer.ts
@@ -1,7 +1,7 @@
 import { Graphics, Container } from 'pixi.js'
 import type { SimulationState } from '../../domain/types'
 import { BUILDING_TYPES } from '../../domain/config/building-types'
-import { NEUTRAL_COLOR } from '../../domain/constants'
+import { NEUTRAL_COLOR, OUTPOST_AURA_RADIUS } from '../../domain/constants'
 
 export class BuildingLayer {
   readonly stage: Container
@@ -51,6 +51,14 @@ export class BuildingLayer {
       this.gfx.beginFill(hpFrac > 0.5 ? 0x44ff88 : 0xff4444)
       this.gfx.drawRect(barX, barY, barW * hpFrac, barH)
       this.gfx.endFill()
+
+      // Outpost speed aura ring (faint pulsing circle showing boost radius)
+      if (building.typeId === 'outpost' && building.ownerId !== 'neutral') {
+        const auraPulse = Math.sin(Date.now() / 1200) * 0.5 + 0.5
+        this.gfx.lineStyle(1, color, auraPulse * 0.18 + 0.04)
+        this.gfx.drawCircle(building.x, building.y, OUTPOST_AURA_RADIUS)
+        this.gfx.lineStyle(0)
+      }
 
       // Capture progress ring
       if (building.captureProgress && building.captureProgress > 0 && building.captureSide) {


### PR DESCRIPTION
## Summary
- Specks within 160px of a friendly owned outpost move 35% faster (`AURA_SPEED_MULT = 1.35`)
- A faint pulsing aura ring is rendered around non-neutral outposts to visually signal the boost radius
- Makes outpost control more tactically interesting — fast pushes from controlled territory, quicker reinforcement of threatened outposts

## Implementation
- `constants.ts`: added `OUTPOST_AURA_RADIUS = 160`
- `movement.ts`: after seek/separation forces, checks if speck is within aura radius of a friendly outpost and applies multiplier; outposts are cached once per tick outside the hot loop
- `building-layer.ts`: renders a faint colored circle (opacity 0.04–0.22, pulsing) around owned outposts at `OUTPOST_AURA_RADIUS`

Closes #1784

## Test plan
- [ ] Start a game and capture an outpost — specks near it should visibly move faster
- [ ] Aura ring appears around owned outposts, disappears (becomes neutral gray ring) when captured
- [ ] AI specks also benefit from the aura near their outposts
- [ ] No perf regression with many specks

🤖 Generated with [Claude Code](https://claude.com/claude-code)