### PR TITLE
feat: Speck Wars domination victory — hold all 3 outposts for 60s to win

### DIFF
--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -166,20 +166,32 @@ export function HUD() {
         )
       })()}
 
-      {/* Triple outpost bonus indicator */}
-      {hud?.tripleOutpostOwner === 'player' && phase === 'playing' && (
-        <div style={{
-          position: 'absolute', top: 100, left: 0, right: 0,
-          display: 'flex', justifyContent: 'center',
-        }}>
-          <span style={{
-            fontSize: 11, letterSpacing: 2, fontWeight: 'bold',
-            color: '#ffd700', textShadow: '0 0 8px #ffd700',
+      {/* Triple outpost bonus indicator + domination countdown */}
+      {hud?.tripleOutpostOwner !== null && hud?.tripleOutpostOwner !== undefined && phase === 'playing' && (() => {
+        const isPlayer = hud.tripleOutpostOwner === 'player'
+        const color = isPlayer ? '#ffd700' : '#ff4f7b'
+        const secLeft = hud.dominationProgress != null
+          ? Math.ceil((1 - hud.dominationProgress) * 60)
+          : null
+        return (
+          <div style={{
+            position: 'absolute', top: 100, left: 0, right: 0,
+            display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 4,
           }}>
-            ⬡⬡⬡ TRIPLE CONTROL — SPAWN ×2
-          </span>
-        </div>
-      )}
+            <span style={{
+              fontSize: 11, letterSpacing: 2, fontWeight: 'bold',
+              color, textShadow: `0 0 8px ${color}`,
+            }}>
+              {isPlayer ? '⬡⬡⬡ TRIPLE CONTROL — SPAWN ×2' : '⬡⬡⬡ ENEMY TRIPLE CONTROL'}
+            </span>
+            {secLeft !== null && (
+              <span style={{ fontSize: 10, letterSpacing: 1, color, opacity: 0.7 }}>
+                {isPlayer ? `DOMINATION in ${secLeft}s` : `ENEMY DOMINATES in ${secLeft}s`}
+              </span>
+            )}
+          </div>
+        )
+      })()}
 
       {/* Outpost capture/loss notification */}
       {notification && (

--- a/src/app/speck-wars/domain/constants.ts
+++ b/src/app/speck-wars/domain/constants.ts
@@ -20,6 +20,7 @@ export const CAPTURE_RADIUS = 100            // px — specks within this distan
 export const CAPTURE_TIME = 5000             // ms to fully capture
 export const NEUTRAL_COLOR = 0x888888
 export const OUTPOST_AURA_RADIUS = 160  // px — specks within this radius of a friendly outpost move faster
+export const DOMINATION_TIME = 60000   // ms — hold all 3 outposts this long to win by domination
 
 // Triangle around center (1500, 1500), equidistant between the two bases
 export const OUTPOST_POSITIONS = [

--- a/src/app/speck-wars/domain/simulation/create-sim.ts
+++ b/src/app/speck-wars/domain/simulation/create-sim.ts
@@ -84,5 +84,6 @@ export function createSim(seed: number = Date.now(), difficulty: Difficulty = 'm
     events: [],
     rallyPoints: { player: null, ai: null },
     spatialGrid: new SpatialGrid(),
+    dominationTimer: 0,
   }
 }

--- a/src/app/speck-wars/domain/simulation/tick.ts
+++ b/src/app/speck-wars/domain/simulation/tick.ts
@@ -7,7 +7,7 @@ import { resolveCombat, removeDeadSpecks } from './combat'
 import { checkVictory } from './victory'
 import { updateCapture } from './capture'
 import { BUILDING_TYPES } from '../config/building-types'
-import { HUD_UPDATE_INTERVAL } from '../constants'
+import { HUD_UPDATE_INTERVAL, DOMINATION_TIME } from '../constants'
 
 export function tick(sim: SimulationState, dt: number): SimulationState {
   sim.events = []  // clear outbound events from previous tick
@@ -36,8 +36,8 @@ export function tick(sim: SimulationState, dt: number): SimulationState {
   // 7b. HP regeneration for owned buildings when not under attack
   regenBuildingHp(sim, dt)
 
-  // 7c. Triple outpost bonus — control all 3 outposts = 2× base spawn speed
-  updateTripleOutpostBonus(sim)
+  // 7c. Triple outpost bonus — control all 3 outposts = 2× base spawn speed + domination timer
+  updateTripleOutpostBonus(sim, dt)
 
   // 8. Check win/loss
   checkVictory(sim)
@@ -62,10 +62,11 @@ function regenBuildingHp(sim: SimulationState, dt: number) {
   }
 }
 
-function updateTripleOutpostBonus(sim: SimulationState) {
+function updateTripleOutpostBonus(sim: SimulationState, dt: number) {
   const outposts = Object.values(sim.buildings).filter(b => b.typeId === 'outpost')
   if (outposts.length === 0) return
 
+  let tripleHolder: string | null = null
   for (const [pid] of Object.entries(sim.players)) {
     if (pid === 'neutral') continue
     const ownsAll = outposts.every(o => o.ownerId === pid)
@@ -73,6 +74,16 @@ function updateTripleOutpostBonus(sim: SimulationState) {
       if (building.ownerId !== pid || building.typeId !== 'base') continue
       building.tripleOutpostBonus = ownsAll
     }
+    if (ownsAll) tripleHolder = pid
+  }
+
+  if (tripleHolder) {
+    sim.dominationTimer += dt
+    if (sim.dominationTimer >= DOMINATION_TIME) {
+      sim.events.push({ type: 'GAME_OVER', winnerId: tripleHolder })
+    }
+  } else {
+    sim.dominationTimer = 0
   }
 }
 
@@ -123,5 +134,6 @@ function emitHudUpdate(sim: SimulationState) {
     }
   }
 
-  sim.events.push({ type: 'HUD_UPDATE', data: { players: data, attackedBuildingIds, tripleOutpostOwner } })
+  const dominationProgress = tripleOutpostOwner ? Math.min(1, sim.dominationTimer / DOMINATION_TIME) : null
+  sim.events.push({ type: 'HUD_UPDATE', data: { players: data, attackedBuildingIds, tripleOutpostOwner, dominationProgress } })
 }

--- a/src/app/speck-wars/domain/types.ts
+++ b/src/app/speck-wars/domain/types.ts
@@ -55,6 +55,7 @@ export interface SimulationState {
   events: SimEvent[]
   rallyPoints: Record<string, { x: number; y: number } | null>
   spatialGrid: SpatialGrid
+  dominationTimer: number    // ms of continuous triple-outpost control; resets on loss
 }
 
 export type InputEvent =
@@ -80,4 +81,5 @@ export interface HudData {
   }>
   attackedBuildingIds: string[]
   tripleOutpostOwner: string | null  // player ID who owns all 3 outposts, or null
+  dominationProgress: number | null  // 0..1 fraction of DOMINATION_TIME elapsed; null if no triple holder
 }


### PR DESCRIPTION
## Summary
- Holding all 3 outposts continuously for 60 seconds now triggers a **domination victory**, even if the enemy base is alive
- A live countdown ("DOMINATION in 42s") appears in the HUD under the triple-control banner
- The AI's triple control also shows a warning countdown ("ENEMY DOMINATES in 15s") to create urgent defensive tension
- Losing any outpost resets the domination timer to zero

## Implementation
- `constants.ts`: `DOMINATION_TIME = 60000` ms
- `types.ts`: added `dominationTimer: number` to `SimulationState`; `dominationProgress: number | null` to `HudData`
- `create-sim.ts`: initializes `dominationTimer: 0`
- `tick.ts`: `updateTripleOutpostBonus` now advances/resets `dominationTimer` each tick and emits `GAME_OVER` when time expires; `emitHudUpdate` passes `dominationProgress` to the HUD
- `hud.tsx`: triple-control banner now shows player label, enemy label, and live countdown; uses color-coded urgency

Closes #1786

## Test plan
- [ ] Hold all 3 outposts — counter starts at "DOMINATION in 60s" and counts down
- [ ] Lose an outpost — counter resets to 60s
- [ ] Let the timer expire — VICTORY screen appears even with enemy base alive
- [ ] Let AI hold all 3 — warning "ENEMY DOMINATES in Xs" shows; AI wins if countdown hits 0
- [ ] Normal base-destruction victory still works (regression check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)