### PR TITLE
feat: Speck Wars victory type — show 'by Domination' or 'by Destruction' on result screen

### DIFF
--- a/src/app/speck-wars/components/phase-router.tsx
+++ b/src/app/speck-wars/components/phase-router.tsx
@@ -5,7 +5,7 @@ import { getBestTime, getWinStreak } from '../lib/personal-best'
 import type { Difficulty } from '../store'
 
 export function PhaseRouter({ children }: { children: React.ReactNode }) {
-  const { phase, winnerId, setPhase, difficulty, setDifficulty, elapsedMs, resetGame, kills, losses, isNewBest } = useSpeckWarsStore()
+  const { phase, winnerId, setPhase, difficulty, setDifficulty, elapsedMs, resetGame, kills, losses, isNewBest, victoryType } = useSpeckWarsStore()
   const [copied, setCopied] = useState(false)
   const [bestTimes, setBestTimes] = useState<Partial<Record<Difficulty, number>>>({})
   const [winStreak, setWinStreak] = useState(0)
@@ -154,6 +154,15 @@ export function PhaseRouter({ children }: { children: React.ReactNode }) {
         <h1 style={{ color: accentColor, fontSize: 64, margin: 0, letterSpacing: 4 }}>
           {won ? 'VICTORY' : 'DEFEATED'}
         </h1>
+        {victoryType && (
+          <div style={{
+            fontSize: 12, letterSpacing: 3, opacity: 0.6,
+            color: victoryType === 'domination' ? '#ffd700' : accentColor,
+            textTransform: 'uppercase',
+          }}>
+            {victoryType === 'domination' ? '⬡ by Domination' : '💥 by Destruction'}
+          </div>
+        )}
         {won && isNewBest && (
           <div style={{ color: '#ffd700', fontSize: 16, letterSpacing: 3, fontWeight: 'bold', textShadow: '0 0 16px #ffd700' }}>
             ★ NEW BEST TIME ★

--- a/src/app/speck-wars/domain/simulation/tick.ts
+++ b/src/app/speck-wars/domain/simulation/tick.ts
@@ -80,7 +80,7 @@ function updateTripleOutpostBonus(sim: SimulationState, dt: number) {
   if (tripleHolder) {
     sim.dominationTimer += dt
     if (sim.dominationTimer >= DOMINATION_TIME) {
-      sim.events.push({ type: 'GAME_OVER', winnerId: tripleHolder })
+      sim.events.push({ type: 'GAME_OVER', winnerId: tripleHolder, victoryType: 'domination' })
     }
   } else {
     sim.dominationTimer = 0

--- a/src/app/speck-wars/domain/simulation/victory.ts
+++ b/src/app/speck-wars/domain/simulation/victory.ts
@@ -12,6 +12,6 @@ export function checkVictory(sim: SimulationState) {
 
   const alive = Object.values(sim.players).filter(p => !p.isDefeated && p.id !== 'neutral')
   if (alive.length === 1) {
-    sim.events.push({ type: 'GAME_OVER', winnerId: alive[0].id })
+    sim.events.push({ type: 'GAME_OVER', winnerId: alive[0].id, victoryType: 'destruction' })
   }
 }

--- a/src/app/speck-wars/domain/types.ts
+++ b/src/app/speck-wars/domain/types.ts
@@ -69,7 +69,7 @@ export type SimEvent =
   | { type: 'BUILDING_DAMAGED'; buildingId: string; hp: number }
   | { type: 'BUILDING_DESTROYED'; buildingId: string; ownerId: string }
   | { type: 'SPECK_SPAWNED'; speckId: string; buildingId: string }
-  | { type: 'GAME_OVER'; winnerId: string }
+  | { type: 'GAME_OVER'; winnerId: string; victoryType: 'destruction' | 'domination' }
   | { type: 'HUD_UPDATE'; data: HudData }
   | { type: 'OUTPOST_CAPTURED'; outpostId: string; newOwner: string; previousOwner: string }
 

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -88,6 +88,7 @@ export class GameInstance {
             store.setPhase('defeat')
           }
           store.setWinnerId(event.winnerId)
+          store.setVictoryType(event.victoryType)
         }
         if (event.type === 'HUD_UPDATE') {
           store.setHud(event.data)

--- a/src/app/speck-wars/store.ts
+++ b/src/app/speck-wars/store.ts
@@ -10,6 +10,8 @@ interface SpeckWarsStore {
   togglePause: () => void
   winnerId: string | null
   setWinnerId: (id: string) => void
+  victoryType: 'destruction' | 'domination' | null
+  setVictoryType: (t: 'destruction' | 'domination') => void
   hud: HudData | null
   setHud: (data: HudData) => void
   difficulty: Difficulty
@@ -39,6 +41,8 @@ export const useSpeckWarsStore = create<SpeckWarsStore>()(set => ({
   })),
   winnerId: null,
   setWinnerId: winnerId => set({ winnerId }),
+  victoryType: null,
+  setVictoryType: victoryType => set({ victoryType }),
   hud: null,
   setHud: hud => set({ hud }),
   difficulty: 'medium',
@@ -69,6 +73,7 @@ export const useSpeckWarsStore = create<SpeckWarsStore>()(set => ({
   resetGame: () => set(s => ({
     phase: 'menu' as GamePhase,
     winnerId: null,
+    victoryType: null,
     hud: null,
     elapsedMs: 0,
     speed: 1 as 1 | 2 | 4,


### PR DESCRIPTION
## Summary
- `GAME_OVER` sim event now carries `victoryType: 'destruction' | 'domination'`
- Result screen shows a subtle badge below the VICTORY/DEFEATED title
  - Gold `⬡ by Domination` when won/lost via triple-outpost timer
  - Accent-colored `💥 by Destruction` when won/lost via base elimination
- Store tracks `victoryType`, reset on `resetGame`

## Implementation
- `types.ts`: added `victoryType` field to `GAME_OVER` event
- `victory.ts`: emits `victoryType: 'destruction'`
- `tick.ts`: emits `victoryType: 'domination'` in domination GAME_OVER
- `store.ts`: `victoryType` + `setVictoryType`
- `game-instance.ts`: calls `store.setVictoryType(event.victoryType)` on GAME_OVER
- `phase-router.tsx`: badge shown between the title and the NEW BEST banner

Closes #1788

## Test plan
- [ ] Win by destroying base → result shows "💥 by Destruction"
- [ ] Win by domination timer → result shows "⬡ by Domination"
- [ ] Lose either way → defeat screen shows correct type
- [ ] Play Again → victoryType resets, no stale badge on next game

🤖 Generated with [Claude Code](https://claude.com/claude-code)