### PR TITLE
feat: Speck Wars camera bounds — clamp camera to prevent panning off the world

### DIFF
--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -3,7 +3,7 @@ import { tick } from './domain/simulation/tick'
 import type { SimulationState } from './domain/types'
 import { useSpeckWarsStore } from './store'
 import { Renderer } from './rendering/renderer'
-import { createCamera } from './rendering/camera'
+import { createCamera, clampCamera } from './rendering/camera'
 import { InputHandler } from './input/input-handler'
 import type { Camera } from './rendering/camera'
 import { AIController } from './domain/ai/ai-controller'
@@ -126,6 +126,9 @@ export class GameInstance {
       this.camera.x -= dx * this.camera.zoom
       this.camera.y -= dy * this.camera.zoom
     }
+
+    // Clamp camera so world doesn't disappear off-screen
+    clampCamera(this.camera, this.canvas.clientWidth, this.canvas.clientHeight)
 
     this.renderer.render(this.sim, this.camera, dt)
     this.rafId = requestAnimationFrame(this.loop)

--- a/src/app/speck-wars/rendering/camera.ts
+++ b/src/app/speck-wars/rendering/camera.ts
@@ -39,3 +39,16 @@ export function zoomAt(camera: Camera, screenX: number, screenY: number, factor:
     y: screenY - (screenY - camera.y) * scale,
   }
 }
+
+// Clamp camera so the world doesn't disappear off-screen completely.
+// MARGIN is the minimum world pixels that must remain visible on each side.
+const EDGE_MARGIN = 120  // px
+
+export function clampCamera(camera: Camera, canvasWidth: number, canvasHeight: number): void {
+  const ww = WORLD_WIDTH * camera.zoom
+  const wh = WORLD_HEIGHT * camera.zoom
+  camera.x = Math.min(camera.x, canvasWidth - EDGE_MARGIN)
+  camera.x = Math.max(camera.x, EDGE_MARGIN - ww)
+  camera.y = Math.min(camera.y, canvasHeight - EDGE_MARGIN)
+  camera.y = Math.max(camera.y, EDGE_MARGIN - wh)
+}


### PR DESCRIPTION
## Summary
- Camera can no longer be dragged/edge-panned/zoomed entirely off the 3000×3000 world
- `clampCamera(camera, canvasWidth, canvasHeight)` ensures ≥120px of world content is always visible on each screen edge
- Applied once per frame after all camera mutations (drag, edge-pan, zoom, C/D shortcuts)

## Implementation
- `camera.ts`: added `clampCamera` (mutates camera in-place) and `EDGE_MARGIN = 120` constant
- `game-instance.ts`: call `clampCamera` at end of loop before `renderer.render`

Closes #1790

## Test plan
- [ ] Drag camera all the way left — stops at 120px from world right edge
- [ ] Drag camera all the way right — stops at 120px from world left edge (which shows 120px of content)
- [ ] Zoom out far — camera still clamped within world bounds
- [ ] C key recenter — works correctly (base is well within bounds)

🤖 Generated with [Claude Code](https://claude.com/claude-code)