### PR TITLE
feat: Speck Wars Brutal difficulty — very-hard mode for veterans

### DIFF
--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -56,8 +56,8 @@ export function HUD() {
       )}
       {/* Difficulty badge — top right */}
       {(() => {
-        const diffColors = { easy: '#44ff88', medium: '#ffcc44', hard: '#ff4f7b' }
-        const color = diffColors[difficulty]
+        const diffColors: Record<string, string> = { easy: '#44ff88', medium: '#ffcc44', hard: '#ff4f7b', 'very-hard': '#cc00ff' }
+        const color = diffColors[difficulty] ?? '#ffffff'
         return (
           <div style={{ position: 'absolute', top: 12, right: 16, fontSize: 10, letterSpacing: 1 }}>
             <span style={{ color, opacity: 0.5, border: `1px solid ${color}`, borderRadius: 3, padding: '2px 6px' }}>

--- a/src/app/speck-wars/components/phase-router.tsx
+++ b/src/app/speck-wars/components/phase-router.tsx
@@ -30,10 +30,11 @@ export function PhaseRouter({ children }: { children: React.ReactNode }) {
     return () => window.removeEventListener('keydown', onKey)
   }, [phase, setPhase])
 
-  const difficulties: Array<{ key: 'easy' | 'medium' | 'hard'; label: string; color: string }> = [
+  const difficulties: Array<{ key: 'easy' | 'medium' | 'hard' | 'very-hard'; label: string; color: string }> = [
     { key: 'easy', label: 'Easy', color: '#44ff88' },
     { key: 'medium', label: 'Medium', color: '#ffcc44' },
     { key: 'hard', label: 'Hard', color: '#ff4f7b' },
+    { key: 'very-hard', label: 'Brutal', color: '#cc00ff' },
   ]
 
   if (phase === 'menu') {
@@ -122,8 +123,8 @@ export function PhaseRouter({ children }: { children: React.ReactNode }) {
     const ss = String(totalSec % 60).padStart(2, '0')
     const timeStr = `${mm}:${ss}`
 
-    const difficultyColors: Record<string, string> = { easy: '#44ff88', medium: '#ffcc44', hard: '#ff4f7b' }
-    const diffLabel = difficulty.charAt(0).toUpperCase() + difficulty.slice(1)
+    const difficultyColors: Record<string, string> = { easy: '#44ff88', medium: '#ffcc44', hard: '#ff4f7b', 'very-hard': '#cc00ff' }
+    const diffLabel = difficulty === 'very-hard' ? 'Brutal' : difficulty.charAt(0).toUpperCase() + difficulty.slice(1)
     const diffColor = difficultyColors[difficulty]
 
     const shareText = won

--- a/src/app/speck-wars/domain/simulation/create-sim.ts
+++ b/src/app/speck-wars/domain/simulation/create-sim.ts
@@ -7,12 +7,14 @@ const aiSpawnInterval: Record<Difficulty, number> = {
   easy: 2000,
   medium: 800,
   hard: 400,
+  'very-hard': 180,  // blazing spawn rate — AI floods the map
 }
 
 const playerSpawnInterval: Record<Difficulty, number | undefined> = {
-  easy: 550,   // faster on easy — the AI is already slow, this ensures clear advantage
-  medium: undefined,  // use default (800ms)
-  hard: undefined,    // use default (800ms) — player skill must compensate
+  easy: 550,         // faster on easy — the AI is already slow, this ensures clear advantage
+  medium: undefined, // use default (800ms)
+  hard: undefined,   // use default (800ms) — player skill must compensate
+  'very-hard': undefined,  // same as hard — no advantage
 }
 
 export function createSim(seed: number = Date.now(), difficulty: Difficulty = 'medium'): SimulationState {

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -24,11 +24,11 @@ export class GameInstance {
   constructor(canvas: HTMLCanvasElement) {
     this.canvas = canvas
     const difficulty = useSpeckWarsStore.getState().difficulty
-    const aiTickInterval: Record<'easy' | 'medium' | 'hard', number> = { easy: 60, medium: 30, hard: 15 }
+    const aiTickInterval: Record<string, number> = { easy: 60, medium: 30, hard: 15, 'very-hard': 6 }
     this.sim = createSim(Date.now(), difficulty)
     this.renderer = new Renderer()
     this.camera = createCamera(canvas.clientWidth, canvas.clientHeight)
-    this.aiController = new AIController('ai', aiTickInterval[difficulty], difficulty === 'hard')
+    this.aiController = new AIController('ai', aiTickInterval[difficulty] ?? 15, difficulty === 'hard' || difficulty === 'very-hard')
   }
 
   async start() {

--- a/src/app/speck-wars/store.ts
+++ b/src/app/speck-wars/store.ts
@@ -2,7 +2,7 @@ import { create } from 'zustand'
 import type { HudData } from './domain/types'
 
 type GamePhase = 'menu' | 'playing' | 'paused' | 'victory' | 'defeat'
-export type Difficulty = 'easy' | 'medium' | 'hard'
+export type Difficulty = 'easy' | 'medium' | 'hard' | 'very-hard'
 
 interface SpeckWarsStore {
   phase: GamePhase


### PR DESCRIPTION
## Summary
- New 4th difficulty **Brutal** (stored as `'very-hard'`) in purple `#cc00ff`
- AI spawns every **180ms** (vs 400ms on Hard) — relentless flood
- AI makes decisions every **6 ticks** (vs 15 on Hard) — near-instant reactions
- AI is permanently aggressive (same as Hard's pressure-wave mode)
- No player spawn advantage (same as Hard)
- Best times, win streak, HUD badge, difficulty select all updated

## Implementation
- `store.ts`: `Difficulty = 'easy' | 'medium' | 'hard' | 'very-hard'`
- `create-sim.ts`: `aiSpawnInterval['very-hard'] = 180`
- `game-instance.ts`: `aiTickInterval['very-hard'] = 6`, aggressive = true
- `hud.tsx`: diffColors purple for `very-hard`
- `phase-router.tsx`: adds "Brutal" button, fixes diffLabel/diffColor for `very-hard`

Closes #1792

## Test plan
- [ ] Brutal appears in the difficulty picker with purple color
- [ ] Selecting Brutal starts game with extremely fast AI
- [ ] HUD badge shows "VERY-HARD" (or equivalent) in purple
- [ ] Best times tracked separately for Brutal
- [ ] Easy/Medium/Hard unaffected (regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)