### PR TITLE
feat: Speck Wars surrender button — give up from the pause screen

### DIFF
--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -26,6 +26,7 @@ export function HUD() {
   const spawnMode = useSpeckWarsStore(s => s.spawnMode)
   const cycleSpawnMode = useSpeckWarsStore(s => s.cycleSpawnMode)
   const difficulty = useSpeckWarsStore(s => s.difficulty)
+  const surrender = useSpeckWarsStore(s => s.surrender)
 
   const BASE_MAX_HP = 100
   const playerBaseHp = hud?.players.player?.buildingHp['building-player-base']
@@ -248,11 +249,27 @@ export function HUD() {
         <div style={{
           position: 'absolute', inset: 0,
           background: 'rgba(0,0,0,0.45)',
-          display: 'flex', alignItems: 'center', justifyContent: 'center',
+          display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', gap: 24,
         }}>
           <span style={{ fontSize: 36, fontWeight: 'bold', letterSpacing: 4, opacity: 0.9 }}>
             PAUSED
           </span>
+          <button
+            onClick={surrender}
+            style={{
+              pointerEvents: 'auto',
+              padding: '8px 24px',
+              fontSize: 12,
+              cursor: 'pointer',
+              background: 'transparent',
+              border: '1px solid rgba(255,100,100,0.4)',
+              borderRadius: 4,
+              color: 'rgba(255,100,100,0.6)',
+              letterSpacing: 1,
+            }}
+          >
+            Give Up
+          </button>
         </div>
       )}
 

--- a/src/app/speck-wars/store.ts
+++ b/src/app/speck-wars/store.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand'
 import type { HudData } from './domain/types'
+import { resetWinStreak } from './lib/personal-best'
 
 type GamePhase = 'menu' | 'playing' | 'paused' | 'victory' | 'defeat'
 export type Difficulty = 'easy' | 'medium' | 'hard' | 'very-hard'
@@ -30,6 +31,7 @@ interface SpeckWarsStore {
   cycleSpawnMode: () => 'basic' | 'heavy'
   isNewBest: boolean
   setIsNewBest: (v: boolean) => void
+  surrender: () => void
   resetGame: () => void
 }
 
@@ -70,6 +72,10 @@ export const useSpeckWarsStore = create<SpeckWarsStore>()(set => ({
   },
   isNewBest: false,
   setIsNewBest: v => set({ isNewBest: v }),
+  surrender: () => {
+    resetWinStreak()
+    set({ phase: 'defeat', winnerId: 'ai', victoryType: 'destruction', isNewBest: false })
+  },
   resetGame: () => set(s => ({
     phase: 'menu' as GamePhase,
     winnerId: null,


### PR DESCRIPTION
## Summary
- A muted 'Give Up' button appears in the **pause overlay** (accessible via Space)
- Clicking concedes immediately: resets win streak, sets defeat screen, shows the AI as winner
- Styled low-contrast (muted red border, 0.6 opacity) so it doesn't distract during normal pause

## Implementation
- `store.ts`: `surrender()` imports `resetWinStreak` and calls `set({ phase: 'defeat', winnerId: 'ai', victoryType: 'destruction', isNewBest: false })`
- `hud.tsx`: subscribes to `surrender` from store, renders button in paused overlay

Closes #1794

## Test plan
- [ ] Pause the game → "Give Up" button appears below "PAUSED"
- [ ] Click Give Up → immediately goes to defeat screen with AI as winner
- [ ] Win streak resets (verify on menu after restart)
- [ ] Normal pause → resume → victory still works (regression)
- [ ] Button not visible while playing (only on pause)

🤖 Generated with [Claude Code](https://claude.com/claude-code)