### PR TITLE
feat: Speck Wars AI spawn mode variation — AI adapts its army composition on Hard/Brutal

### DIFF
--- a/src/app/speck-wars/domain/ai/ai-controller.ts
+++ b/src/app/speck-wars/domain/ai/ai-controller.ts
@@ -4,8 +4,10 @@ export class AIController {
   private playerId: string
   private tickInterval: number
   private lastDecisionTick: number = 0
-  private aggressive: boolean  // true = Hard mode: every 4th decision rushes base
+  private aggressive: boolean  // true = Hard/Brutal: every 4th decision rushes base
   private decisionCount: number = 0
+  private spawnMode: 'basic' | 'heavy' = 'basic'
+  private spawnModeCountdown: number = 0  // ticks until next spawn mode decision
 
   constructor(playerId: string, tickInterval: number = 30, aggressive = false) {
     this.playerId = playerId
@@ -52,6 +54,20 @@ export class AIController {
     }
 
     this.decisionCount++
+
+    // Hard/Brutal mode: vary spawn type to add unpredictability
+    if (this.aggressive) {
+      this.spawnModeCountdown--
+      if (this.spawnModeCountdown <= 0) {
+        // 40% chance to switch to heavy, 60% stay/go basic
+        const next = Math.random() < 0.4 ? 'heavy' : 'basic'
+        if (next !== this.spawnMode) {
+          this.spawnMode = next
+          sim.inputQueue.push({ type: 'SET_SPAWN_TYPE', ownerId: this.playerId, speckTypeId: next })
+        }
+        this.spawnModeCountdown = 8 + Math.floor(Math.random() * 8)  // re-evaluate in 8–16 decisions
+      }
+    }
 
     // Hard mode: every 4th decision, rush player base directly (pressure waves)
     const forceBaseRush = this.aggressive && this.decisionCount % 4 === 0


### PR DESCRIPTION
## Summary
- On Hard and Brutal difficulty, the AI periodically switches between basic and heavy speck production
- Re-evaluates spawn type every 8–16 AI decisions (randomized to prevent telegraphing)
- Chooses heavy 40% of the time, basic 60% — makes enemy army composition unpredictable
- Pushes `SET_SPAWN_TYPE` input event to the simulation (same mechanism as player)

## Implementation
- `ai-controller.ts`: added `spawnMode: 'basic' | 'heavy'` and `spawnModeCountdown: number` fields
- On each decision when `aggressive = true`, decrements countdown; when it reaches 0, randomly picks new spawn type and resets countdown to 8–16 decisions

Closes #1796

## Test plan
- [ ] Play Hard mode for 2+ minutes — AI army should sometimes be all heavy specks
- [ ] Play Brutal — AI variation should be noticeable and more frequent
- [ ] Easy and Medium unaffected (aggressive = false)
- [ ] AI still targets buildings correctly alongside spawn variation

🤖 Generated with [Claude Code](https://claude.com/claude-code)