### PR TITLE
feat: Speck Wars spawn timer progress ring — inner arc shows time to next spawn

### DIFF
--- a/src/app/speck-wars/rendering/layers/building-layer.ts
+++ b/src/app/speck-wars/rendering/layers/building-layer.ts
@@ -52,6 +52,21 @@ export class BuildingLayer {
       this.gfx.drawRect(barX, barY, barW * hpFrac, barH)
       this.gfx.endFill()
 
+      // Spawn timer progress arc (clockwise fill inside building, shows time to next spawn)
+      if (building.ownerId !== 'neutral' && btype?.spawnInterval) {
+        const totalInterval = building.spawnIntervalOverride ?? btype.spawnInterval
+        const effectiveInterval = building.tripleOutpostBonus ? totalInterval / 2 : totalInterval
+        const progress = Math.max(0, Math.min(1, 1 - building.spawnTimer / effectiveInterval))
+        if (progress > 0) {
+          const startAngle = -Math.PI / 2
+          const endAngle = startAngle + Math.PI * 2 * progress
+          this.gfx.lineStyle(2, 0xffffff, 0.5)
+          this.gfx.moveTo(building.x + (r - 5) * Math.cos(startAngle), building.y + (r - 5) * Math.sin(startAngle))
+          this.gfx.arc(building.x, building.y, r - 5, startAngle, endAngle)
+          this.gfx.lineStyle(0)
+        }
+      }
+
       // Outpost speed aura ring (faint pulsing circle showing boost radius)
       if (building.typeId === 'outpost' && building.ownerId !== 'neutral') {
         const auraPulse = Math.sin(Date.now() / 1200) * 0.5 + 0.5


### PR DESCRIPTION
## Summary
- A thin white arc (0.5 opacity) fills clockwise inside each non-neutral base/outpost as the next speck approaches spawn
- At 0% filled: timer just reset (speck just spawned)
- At 100% filled: next speck imminent
- Accounts for `spawnIntervalOverride` (difficulty/spawn-mode) and `tripleOutpostBonus` (halveds interval)

## Implementation
- `building-layer.ts`: before the aura ring and capture ring, compute `progress = 1 - building.spawnTimer / effectiveInterval` and draw a `lineStyle(2, 0xffffff, 0.5)` arc at `r - 5` radius

Closes #1800

## Test plan
- [ ] Base shows clockwise arc filling; resets when a speck spawns
- [ ] With heavy mode → different interval, still fills correctly
- [ ] With triple outpost bonus → arc fills twice as fast
- [ ] Outposts also show the ring (they spawn heavy specks)
- [ ] Neutral outposts do NOT show the ring

🤖 Generated with [Claude Code](https://claude.com/claude-code)