### PR TITLE
feat: Speck Wars building damage flash — buildings flash red when taking hits

### DIFF
--- a/src/app/speck-wars/rendering/layers/building-layer.ts
+++ b/src/app/speck-wars/rendering/layers/building-layer.ts
@@ -3,9 +3,12 @@ import type { SimulationState } from '../../domain/types'
 import { BUILDING_TYPES } from '../../domain/config/building-types'
 import { NEUTRAL_COLOR, OUTPOST_AURA_RADIUS } from '../../domain/constants'
 
+const FLASH_DURATION = 200  // ms — how long a damage flash lasts
+
 export class BuildingLayer {
   readonly stage: Container
   private gfx: Graphics
+  private flashMap: Map<string, number> = new Map()  // buildingId → timestamp of last hit
 
   constructor() {
     this.stage = new Container()
@@ -13,7 +16,12 @@ export class BuildingLayer {
     this.stage.addChild(this.gfx)
   }
 
+  flashBuilding(buildingId: string) {
+    this.flashMap.set(buildingId, Date.now())
+  }
+
   update(sim: SimulationState, playerColors: Record<string, number>) {
+    const now = Date.now()
     this.gfx.clear()
 
     for (const building of Object.values(sim.buildings)) {
@@ -25,6 +33,20 @@ export class BuildingLayer {
       this.gfx.beginFill(color, 0.9)
       this.gfx.drawCircle(building.x, building.y, r)
       this.gfx.endFill()
+
+      // Damage flash overlay
+      const flashTs = this.flashMap.get(building.id)
+      if (flashTs !== undefined) {
+        const elapsed = now - flashTs
+        if (elapsed < FLASH_DURATION) {
+          const alpha = (1 - elapsed / FLASH_DURATION) * 0.7
+          this.gfx.beginFill(0xff2222, alpha)
+          this.gfx.drawCircle(building.x, building.y, r)
+          this.gfx.endFill()
+        } else {
+          this.flashMap.delete(building.id)
+        }
+      }
 
       // Stroke
       this.gfx.lineStyle(2, 0xffffff, 0.4)

--- a/src/app/speck-wars/rendering/renderer.ts
+++ b/src/app/speck-wars/rendering/renderer.ts
@@ -70,11 +70,14 @@ export class Renderer {
     this.buildingLayer.update(sim, PLAYER_COLORS)
     this.speckLayer.update(sim)
 
-    // Process death flash events from this tick
+    // Process events from this tick
     for (const event of sim.events) {
       if (event.type === 'SPECK_DIED') {
         const flashColor = PLAYER_COLORS[event.killedOwnerId] ?? 0xffffff
         this.effectsLayer.addDeathFlash(event.x, event.y, flashColor)
+      }
+      if (event.type === 'BUILDING_DAMAGED') {
+        this.buildingLayer.flashBuilding(event.buildingId)
       }
     }
     this.effectsLayer.update(dt)


### PR DESCRIPTION
## Summary
- Buildings briefly flash **red** (70%→0% alpha, 200ms) when hit
- Makes combat feel more visceral and helps players spot ongoing battles off-screen
- Flash uses a `Map<buildingId, hitTimestamp>` in `BuildingLayer`; old entries are cleaned up lazily when their duration expires

## Implementation
- `building-layer.ts`: `flashMap: Map<string, number>`, `flashBuilding(id)`, damage flash overlay drawn after base circle (before stroke)
- `renderer.ts`: checks all sim events for `BUILDING_DAMAGED` and calls `buildingLayer.flashBuilding(event.buildingId)`

Closes #1804

## Test plan
- [ ] Attack an enemy base — red flash visible on each hit
- [ ] Enemy attacks your base — your base flashes red
- [ ] Outpost attack — outpost flashes red while contested
- [ ] Flash fades smoothly (not a hard cut)
- [ ] No flash on neutral buildings (they don't get BUILDING_DAMAGED events)

🤖 Generated with [Claude Code](https://claude.com/claude-code)