### PR TITLE
feat: Speck Wars minimap AI rally indicator — faint crosshair shows enemy intent

### DIFF
--- a/src/app/speck-wars/components/minimap.tsx
+++ b/src/app/speck-wars/components/minimap.tsx
@@ -93,6 +93,21 @@ export function Minimap({ gameRef }: MinimapProps) {
         ctx.globalAlpha = 1
       }
 
+      // Draw AI rally point (where enemy force is heading)
+      const aiRp = sim.rallyPoints['ai']
+      if (aiRp) {
+        const rx = aiRp.x * SCALE_X
+        const ry = aiRp.y * SCALE_Y
+        ctx.strokeStyle = aiColor
+        ctx.lineWidth = 1
+        ctx.globalAlpha = 0.45
+        ctx.beginPath()
+        ctx.moveTo(rx - 3, ry); ctx.lineTo(rx + 3, ry)
+        ctx.moveTo(rx, ry - 3); ctx.lineTo(rx, ry + 3)
+        ctx.stroke()
+        ctx.globalAlpha = 1
+      }
+
       // Draw viewport rectangle
       // The camera maps world→screen as: screenX = worldX * zoom + camera.x
       // Use window dimensions as the screen size approximation


### PR DESCRIPTION
## Summary
- A small faint red crosshair (3px arms, 45% opacity) on the minimap shows the AI's current rally point
- Smaller and less prominent than the player's marker to maintain hierarchy
- Updates at the minimap's 10fps draw rate (polling `sim.rallyPoints['ai']`)

## Implementation
- `minimap.tsx`: added AI rally draw block between the player rally and the viewport rectangle

Closes #1806

## Test plan
- [ ] Start a game and wait for AI to rally — faint red crosshair appears on minimap
- [ ] AI changes target (e.g., switches from outpost to base) — crosshair updates position
- [ ] Player rally point still visible (teal, larger) — no visual conflict

🤖 Generated with [Claude Code](https://claude.com/claude-code)