### PR TITLE
feat: Speck Wars outpost count in HUD — 'OUTPOSTS N/3' shows controlled count

### DIFF
--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -138,6 +138,7 @@ export function HUD() {
           const color = isPlayerOwned ? '#4af7c4' : isAiOwned ? '#ff4f7b' : '#888888'
           return { color, isUnderAttack, isPlayerOwned }
         })
+        const playerCount = dots.filter(d => d.isPlayerOwned).length
         return (
           <>
             {dots.some(d => d.isUnderAttack && d.isPlayerOwned) && (
@@ -152,7 +153,9 @@ export function HUD() {
               position: 'absolute', top: 48, left: 0, right: 0,
               display: 'flex', justifyContent: 'center', alignItems: 'center', gap: 8,
             }}>
-              <span style={{ fontSize: 10, letterSpacing: 1, opacity: 0.5, marginRight: 4 }}>OUTPOSTS</span>
+              <span style={{ fontSize: 10, letterSpacing: 1, opacity: 0.5, marginRight: 4 }}>
+                OUTPOSTS {playerCount}/{OUTPOST_IDS.length}
+              </span>
               {dots.map(({ color, isUnderAttack, isPlayerOwned }, i) => (
                 <div key={i} style={{
                   width: 10, height: 10,


### PR DESCRIPTION
## Summary
- The OUTPOSTS label in the dot strip now reads **"OUTPOSTS 2/3"** (or 0/3, 1/3, 3/3)
- Makes the strategic control state scannable without counting dots
- Zero extra complexity — computed from the same `dots` array that already exists

## Implementation
- `hud.tsx`: `const playerCount = dots.filter(d => d.isPlayerOwned).length` — appended to label span

Closes #1808

## Test plan
- [ ] Control 0 outposts → shows "OUTPOSTS 0/3"
- [ ] Capture one outpost → updates to "1/3"
- [ ] Control all 3 → shows "3/3" (should also show triple control banner)

🤖 Generated with [Claude Code](https://claude.com/claude-code)