### PR TITLE
feat: Speck Wars rage mode — 40% damage boost when base is at critical HP (<15%)

### DIFF
--- a/src/app/speck-wars/domain/simulation/combat.ts
+++ b/src/app/speck-wars/domain/simulation/combat.ts
@@ -4,6 +4,8 @@ import { BUILDING_TYPES } from '../config/building-types'
 
 const MORALE_RATIO = 2.0   // if your count > this × enemy count → morale bonus
 const MORALE_BONUS = 1.20  // 20% damage boost when morale is active
+const RAGE_HP_THRESHOLD = 0.15  // base HP fraction below which rage activates
+const RAGE_BONUS = 1.40         // 40% damage boost when base is critical
 
 export function resolveCombat(sim: SimulationState, dt: number) {
   const { speckIds, speckX, speckY, speckHp, speckMeta, buildings, spatialGrid } = sim
@@ -20,7 +22,13 @@ export function resolveCombat(sim: SimulationState, dt: number) {
     for (const [id, n] of Object.entries(speckCountByOwner)) {
       if (id !== ownerId && id !== 'neutral' && n > maxEnemyCount) maxEnemyCount = n
     }
-    return (maxEnemyCount > 0 && myCount > MORALE_RATIO * maxEnemyCount) ? MORALE_BONUS : 1.0
+    const moraleBonus = (maxEnemyCount > 0 && myCount > MORALE_RATIO * maxEnemyCount) ? MORALE_BONUS : 1.0
+
+    // Rage: if this owner's base is at critical HP, deal 40% more damage (desperation)
+    const base = Object.values(buildings).find(b => b.ownerId === ownerId && b.typeId === 'base')
+    const rageBonus = (base && base.hp / base.maxHp < RAGE_HP_THRESHOLD) ? RAGE_BONUS : 1.0
+
+    return Math.max(moraleBonus, rageBonus)  // apply highest active bonus (don't stack)
   }
 
   // --- Speck vs Speck combat ---


### PR DESCRIPTION
## Summary
- When a player (or AI) has their base below 15% HP, their specks enter **rage mode**: 40% damage boost
- Creates dramatic comeback potential when the vignette is pulsing red at critical HP
- **Does not stack multiplicatively** with morale bonus — uses `Math.max(moraleBonus, rageBonus)` to take the higher active bonus only

## Implementation
- `combat.ts`: extended `moraleMult()` to also check `base.hp / base.maxHp < RAGE_HP_THRESHOLD (0.15)` and return `RAGE_BONUS (1.40)` if active; else return morale (max of both)

Closes #1810

## Test plan
- [ ] Let base drop to <15% HP — specks should visibly kill enemy specks faster
- [ ] AI at <15% base HP also rages (symmetric mechanic)
- [ ] At ≥15% HP and < 2:1 ratio — no bonus (baseline 1.0)
- [ ] At 2:1 ratio AND <15% HP — morale vs rage: 1.40 wins (not stacked to 1.68)

🤖 Generated with [Claude Code](https://claude.com/claude-code)