### PR TITLE
feat: Speck Wars A key — advance to nearest uncaptured outpost

### DIFF
--- a/src/app/speck-wars/components/phase-router.tsx
+++ b/src/app/speck-wars/components/phase-router.tsx
@@ -106,6 +106,7 @@ export function PhaseRouter({ children }: { children: React.ReactNode }) {
           <span>R — clear rally</span>
           <span>Drag — pan camera</span>
           <span>H — heavy/basic mode</span>
+          <span>A — advance to outpost</span>
           <span>C — center on base</span>
           <span>D — defend base</span>
           <span>Minimap — click to rally</span>

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -58,6 +58,18 @@ export class GameInstance {
         if (!base) return
         this.rally(base.x, base.y)
       },
+      () => {                                              // A — advance to nearest non-player outpost
+        const playerBase = Object.values(this.sim.buildings).find(b => b.ownerId === 'player' && b.typeId === 'base')
+        if (!playerBase) return
+        let best = null, bestD2 = Infinity
+        for (const b of Object.values(this.sim.buildings)) {
+          if (b.typeId !== 'outpost' || b.ownerId === 'player') continue
+          const dx = b.x - playerBase.x, dy = b.y - playerBase.y
+          const d2 = dx * dx + dy * dy
+          if (d2 < bestD2) { bestD2 = d2; best = b }
+        }
+        if (best) this.rally(best.x, best.y)
+      },
     )
     this.lastTime = performance.now()
     this.loop(this.lastTime)

--- a/src/app/speck-wars/input/input-handler.ts
+++ b/src/app/speck-wars/input/input-handler.ts
@@ -10,6 +10,7 @@ export class InputHandler {
   private onCycleSpawnMode?: () => void
   private onRecenterCamera?: () => void
   private onDefend?: () => void
+  private onAdvance?: () => void
   private isDragging = false
   private lastX = 0
   private lastY = 0
@@ -28,6 +29,7 @@ export class InputHandler {
     onCycleSpawnMode?: () => void,
     onRecenterCamera?: () => void,
     onDefend?: () => void,
+    onAdvance?: () => void,
   ) {
     this.canvas = canvas
     this.camera = camera
@@ -37,6 +39,7 @@ export class InputHandler {
     this.onCycleSpawnMode = onCycleSpawnMode
     this.onRecenterCamera = onRecenterCamera
     this.onDefend = onDefend
+    this.onAdvance = onAdvance
     this.attach()
   }
 
@@ -157,6 +160,8 @@ export class InputHandler {
       this.onRecenterCamera?.()
     } else if (e.code === 'KeyD') {
       this.onDefend?.()
+    } else if (e.code === 'KeyA') {
+      this.onAdvance?.()
     }
   }
 


### PR DESCRIPTION
## Summary
- Press **A** to rally specks to the nearest outpost not yet owned by the player (neutral or enemy-owned)
- Distance measured from player base position for consistency
- If all outposts are player-owned, A does nothing (no neutral/enemy targets)
- Added to controls legend: "A — advance to outpost"

## Implementation
- `input-handler.ts`: added `onAdvance?: () => void` callback field, `KeyA` handler
- `game-instance.ts`: 8th callback to `InputHandler`; iterates `sim.buildings` to find nearest non-player outpost, calls `this.rally()`
- `phase-router.tsx`: controls grid updated

Closes #1812

## Test plan
- [ ] Press A at game start — specks rally to nearest neutral outpost
- [ ] Press A after capturing 2 outposts — rallies to last remaining non-player outpost
- [ ] Press A when owning all 3 outposts — no action
- [ ] D key still works (defend)

🤖 Generated with [Claude Code](https://claude.com/claude-code)