### PR TITLE
feat: Speck Wars morale indicator — HUD badge when 2:1 combat bonus is active

### DIFF
--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -215,34 +215,61 @@ export function HUD() {
         </div>
       )}
 
-      {/* Battle status indicator */}
+      {/* Battle status indicator + morale badge */}
       {hud && phase === 'playing' && (() => {
         const playerSpecks = hud.players.player?.speckCount ?? 0
         const aiSpecks = hud.players.ai?.speckCount ?? 0
         const total = playerSpecks + aiSpecks
-        if (total < 20) return null  // too few specks — don't show yet
-        const ratio = playerSpecks / total
-        const status =
+        const moraleActive = aiSpecks > 0 && playerSpecks >= 2 * aiSpecks
+        const enemyMoraleActive = playerSpecks > 0 && aiSpecks >= 2 * playerSpecks
+
+        if (total < 20 && !moraleActive && !enemyMoraleActive) return null
+
+        const ratio = playerSpecks / (total || 1)
+        const status = total >= 20 ? (
           ratio > 0.65 ? { label: 'DOMINATING', color: '#4af7c4' }
           : ratio > 0.55 ? { label: 'WINNING', color: '#88ff44' }
           : ratio < 0.35 ? { label: 'CRITICAL', color: '#ff4f7b' }
           : ratio < 0.45 ? { label: 'LOSING', color: '#ffaa44' }
           : null
-        if (!status) return null
+        ) : null
+
         return (
           <div style={{
             position: 'absolute', bottom: 16, left: 0, right: 0,
-            display: 'flex', justifyContent: 'center',
+            display: 'flex', justifyContent: 'center', alignItems: 'center', gap: 12,
           }}>
-            <span style={{
-              fontSize: 11,
-              letterSpacing: 2,
-              color: status.color,
-              opacity: 0.6,
-              textTransform: 'uppercase',
-            }}>
-              {status.label}
-            </span>
+            {status && (
+              <span style={{
+                fontSize: 11,
+                letterSpacing: 2,
+                color: status.color,
+                opacity: 0.6,
+                textTransform: 'uppercase',
+              }}>
+                {status.label}
+              </span>
+            )}
+            {moraleActive && (
+              <span style={{
+                fontSize: 10, letterSpacing: 1,
+                color: '#ffd700', opacity: 0.75,
+                border: '1px solid rgba(255,215,0,0.4)', borderRadius: 3,
+                padding: '2px 6px',
+              }}>
+                ⚡ MORALE +20%
+              </span>
+            )}
+            {enemyMoraleActive && (
+              <span style={{
+                fontSize: 10, letterSpacing: 1,
+                color: '#ff6b35', opacity: 0.75,
+                border: '1px solid rgba(255,107,53,0.4)', borderRadius: 3,
+                padding: '2px 6px',
+              }}>
+                ⚡ ENEMY MORALE
+              </span>
+            )}
           </div>
         )
       })()}


### PR DESCRIPTION
## Summary
- When the player holds a 2:1 or better speck count advantage, shows a gold `⚡ MORALE +20%` badge at the bottom center of the HUD
- When the AI holds the advantage, shows an orange `⚡ ENEMY MORALE` warning badge
- Both badges appear alongside the existing DOMINATING/WINNING/LOSING status text
- Pure HUD calculation — reads `hud.players` speck counts that are already available, no sim changes

## Test plan
- [ ] Get 2× more specks than the AI — gold morale badge should appear at bottom center
- [ ] Let AI build up to 2× your count — orange enemy morale warning should appear
- [ ] Badge disappears when ratio drops below 2:1
- [ ] Early game (<20 specks total) shows no status unless morale is active

Closes #1820

🤖 Generated with [Claude Code](https://claude.com/claude-code)