### PR TITLE
feat: Speck Wars rage indicator — HUD badge when base is critical (<15% HP)

### DIFF
--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -270,6 +270,17 @@ export function HUD() {
                 ⚡ ENEMY MORALE
               </span>
             )}
+            {isCritical && !moraleActive && (
+              <span style={{
+                fontSize: 10, letterSpacing: 1,
+                color: '#ff4f7b', opacity: 0.85,
+                border: '1px solid rgba(255,79,123,0.5)', borderRadius: 3,
+                padding: '2px 6px',
+                fontWeight: 'bold',
+              }}>
+                ⚡ RAGE +40%
+              </span>
+            )}
           </div>
         )
       })()}


### PR DESCRIPTION
## Summary
- When the player's base HP drops below 15%, the rage combat bonus (+40% damage) is now visible as a red `⚡ RAGE +40%` badge in the battle status strip
- Badge is suppressed if morale bonus is already showing (combat.ts uses `Math.max`, so morale and rage can't stack anyway)
- Gives players actionable awareness: "I'm about to lose but my specks hit harder — fight back!"

## Test plan
- [ ] Let the AI damage your base below 15% HP — the `⚡ RAGE +40%` badge should appear at bottom center
- [ ] Badge should disappear if base HP recovers above 15%
- [ ] If you simultaneously have 2:1 speck advantage, only morale badge shows (not rage)
- [ ] Badge should appear alongside or instead of other status labels (CRITICAL, LOSING)

Closes #1822

🤖 Generated with [Claude Code](https://claude.com/claude-code)