### PR TITLE
feat: Speck Wars kill milestones — notifications at 10, 25, 50, 100 kills

### DIFF
--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -122,8 +122,20 @@ export class GameInstance {
           store.setHud(event.data)
         }
         if (event.type === 'SPECK_DIED') {
-          if (event.killedOwnerId === 'ai' && event.killerOwnerId === 'player') store.addKill()
-          else if (event.killedOwnerId === 'player' && event.killerOwnerId === 'ai') store.addLoss()
+          if (event.killedOwnerId === 'ai' && event.killerOwnerId === 'player') {
+            store.addKill()
+            const k = useSpeckWarsStore.getState().kills
+            const milestones: Record<number, { message: string; color: string }> = {
+              10:  { message: '💀 10 KILLS',  color: '#4af7c4' },
+              25:  { message: '💀 25 KILLS',  color: '#ffd700' },
+              50:  { message: '💀 50 KILLS',  color: '#ff8844' },
+              100: { message: '💀 100 KILLS', color: '#cc00ff' },
+            }
+            if (milestones[k]) {
+              store.setNotification(milestones[k])
+              setTimeout(() => useSpeckWarsStore.getState().setNotification(null), 2000)
+            }
+          } else if (event.killedOwnerId === 'player' && event.killerOwnerId === 'ai') store.addLoss()
           if (!this.firstBloodDone) {
             this.firstBloodDone = true
             const playerGotIt = event.killerOwnerId === 'player'


### PR DESCRIPTION
## Summary
- After each player kill, reads the current kill count from the store and checks against milestone thresholds (10, 25, 50, 100)
- Each milestone shows a color-coded notification for 2 seconds: teal at 10, gold at 25, orange at 50, purple at 100
- No new state — uses existing `store.kills`, `store.addKill()`, and `store.setNotification()`

## Test plan
- [ ] Kill 10 AI specks — `💀 10 KILLS` toast in teal should appear briefly
- [ ] Kill 25 total — gold toast
- [ ] Kill 50 — orange toast
- [ ] Kill 100 — purple toast
- [ ] Non-milestone kills show no notification
- [ ] Milestone toast doesn't conflict with other notifications (first blood, outpost events)

Closes #1824

🤖 Generated with [Claude Code](https://claude.com/claude-code)