### PR TITLE
feat: Speck Wars game history — last 5 results shown on end screen

### DIFF
--- a/src/app/speck-wars/components/phase-router.tsx
+++ b/src/app/speck-wars/components/phase-router.tsx
@@ -1,7 +1,7 @@
 'use client'
 import { useState, useEffect } from 'react'
 import { useSpeckWarsStore } from '../store'
-import { getBestTime, getWinStreak } from '../lib/personal-best'
+import { getBestTime, getWinStreak, getRecentResults } from '../lib/personal-best'
 import type { Difficulty } from '../store'
 
 export function PhaseRouter({ children }: { children: React.ReactNode }) {
@@ -187,6 +187,32 @@ export function PhaseRouter({ children }: { children: React.ReactNode }) {
             </span>
           )}
         </div>
+
+        {/* Recent run history for this difficulty */}
+        {(() => {
+          const history = getRecentResults(difficulty)
+          if (history.length < 2) return null
+          return (
+            <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 6 }}>
+              <span style={{ fontSize: 10, letterSpacing: 2, color: 'rgba(255,255,255,0.3)' }}>
+                RECENT ({difficulty.toUpperCase()})
+              </span>
+              <div style={{ display: 'flex', gap: 6 }}>
+                {history.map((r, i) => {
+                  const mm = String(Math.floor(Math.floor(r.timeMs / 1000) / 60)).padStart(2, '0')
+                  const ss = String(Math.floor(r.timeMs / 1000) % 60).padStart(2, '0')
+                  return (
+                    <div key={i} title={`${r.won ? 'Win' : 'Loss'} — ${mm}:${ss} — ${r.kills} kills`} style={{
+                      width: 10, height: 10, borderRadius: '50%',
+                      background: r.won ? '#4af7c4' : '#ff4f7b',
+                      opacity: i === 0 ? 1 : 0.4 + (history.length - i) / history.length * 0.4,
+                    }} />
+                  )
+                })}
+              </div>
+            </div>
+          )
+        })()}
 
         <div style={{ display: 'flex', gap: 12, marginTop: 8 }}>
           <button

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -7,7 +7,7 @@ import { createCamera, clampCamera } from './rendering/camera'
 import { InputHandler } from './input/input-handler'
 import type { Camera } from './rendering/camera'
 import { AIController } from './domain/ai/ai-controller'
-import { recordBestTime, incrementWinStreak, resetWinStreak, isFirstGame, markFirstGameDone } from './lib/personal-best'
+import { recordBestTime, incrementWinStreak, resetWinStreak, isFirstGame, markFirstGameDone, recordGameResult } from './lib/personal-best'
 
 export class GameInstance {
   private canvas: HTMLCanvasElement
@@ -108,10 +108,12 @@ export class GameInstance {
           if (event.winnerId === 'player') {
             const isNew = recordBestTime(store.difficulty, this.elapsedMs)
             incrementWinStreak()
+            recordGameResult(store.difficulty, true, this.elapsedMs, store.kills)
             store.setIsNewBest(isNew)
             store.setPhase('victory')
           } else {
             resetWinStreak()
+            recordGameResult(store.difficulty, false, this.elapsedMs, store.kills)
             store.setIsNewBest(false)
             store.setPhase('defeat')
           }

--- a/src/app/speck-wars/lib/personal-best.ts
+++ b/src/app/speck-wars/lib/personal-best.ts
@@ -37,6 +37,27 @@ export function resetWinStreak() {
   localStorage.setItem(STREAK_KEY, '0')
 }
 
+interface GameResult { won: boolean; timeMs: number; kills: number }
+const HISTORY_KEY = (d: Difficulty) => `speck-wars-history-${d}`
+const HISTORY_LIMIT = 5
+
+export function recordGameResult(difficulty: Difficulty, won: boolean, timeMs: number, kills: number) {
+  if (typeof window === 'undefined') return
+  const prev = getRecentResults(difficulty)
+  const next: GameResult[] = [{ won, timeMs, kills }, ...prev].slice(0, HISTORY_LIMIT)
+  localStorage.setItem(HISTORY_KEY(difficulty), JSON.stringify(next))
+}
+
+export function getRecentResults(difficulty: Difficulty): GameResult[] {
+  if (typeof window === 'undefined') return []
+  try {
+    const raw = localStorage.getItem(HISTORY_KEY(difficulty))
+    return raw ? (JSON.parse(raw) as GameResult[]) : []
+  } catch {
+    return []
+  }
+}
+
 const FIRST_GAME_KEY = 'speck-wars-first-game-done'
 
 export function isFirstGame(): boolean {


### PR DESCRIPTION
## Summary
- Adds `recordGameResult(difficulty, won, timeMs, kills)` and `getRecentResults(difficulty)` to `personal-best.ts`; stores last 5 results per difficulty in localStorage
- `game-instance.ts` calls `recordGameResult` on GAME_OVER events (both win and loss)
- End screen in `phase-router.tsx` shows a row of colored dots (teal=win, red=loss) when 2+ games on that difficulty exist; dots are translucent for older games, full opacity for the most recent

## Test plan
- [ ] Play 2+ games on the same difficulty
- [ ] End screen should show colored history dots below the kill/loss stats
- [ ] Dots should be teal for wins and red for losses
- [ ] Only shows when 2+ results exist (not on first game)
- [ ] Different difficulties have independent histories
- [ ] History capped at 5 results (oldest dropped)

Closes #1826

🤖 Generated with [Claude Code](https://claude.com/claude-code)