### PR TITLE
feat: Speck Wars 'Try next difficulty' CTA on victory screen

### DIFF
--- a/src/app/speck-wars/components/phase-router.tsx
+++ b/src/app/speck-wars/components/phase-router.tsx
@@ -127,6 +127,12 @@ export function PhaseRouter({ children }: { children: React.ReactNode }) {
     const difficultyColors: Record<string, string> = { easy: '#44ff88', medium: '#ffcc44', hard: '#ff4f7b', 'very-hard': '#cc00ff' }
     const diffLabel = difficulty === 'very-hard' ? 'Brutal' : difficulty.charAt(0).toUpperCase() + difficulty.slice(1)
     const diffColor = difficultyColors[difficulty]
+    const nextDifficulty: Partial<Record<string, { key: Difficulty; label: string; color: string }>> = {
+      easy:   { key: 'medium',    label: 'Medium', color: '#ffcc44' },
+      medium: { key: 'hard',      label: 'Hard',   color: '#ff4f7b' },
+      hard:   { key: 'very-hard', label: 'Brutal', color: '#cc00ff' },
+    }
+    const nextDiff = won ? nextDifficulty[difficulty] : null
 
     const shareText = won
       ? `I defeated the AI in Speck Wars (${diffLabel}) in ${timeStr} — killed ${kills} specks! 🎮 Can you beat my time?`
@@ -247,6 +253,20 @@ export function PhaseRouter({ children }: { children: React.ReactNode }) {
             ← Cave
           </a>
         </div>
+        {nextDiff && (
+          <button
+            onClick={() => { setDifficulty(nextDiff.key); resetGame(); setPhase('playing') }}
+            style={{
+              padding: '8px 24px', fontSize: 13, cursor: 'pointer',
+              background: 'transparent',
+              border: `1px solid ${nextDiff.color}`,
+              borderRadius: 6, color: nextDiff.color, opacity: 0.8,
+              letterSpacing: 1,
+            }}
+          >
+            Try {nextDiff.label} →
+          </button>
+        )}
       </div>
     )
   }


### PR DESCRIPTION
## Summary
- On the victory screen, computes `nextDifficulty` from the current difficulty (easy→medium→hard→very-hard)
- Shows a color-coded `Try [NextDiff] →` button below the main action buttons (only on wins, only when not already on Brutal)
- Clicking: sets difficulty, resets game state, and starts playing immediately — skips the menu

## Test plan
- [ ] Win on Easy — should see `Try Medium →` in yellow below the Play Again/Share buttons
- [ ] Win on Medium — `Try Hard →` in red
- [ ] Win on Hard — `Try Brutal →` in purple
- [ ] Win on Brutal — no next-difficulty button
- [ ] Defeat screen — no next-difficulty button
- [ ] Clicking the button skips the menu and starts a game at the next difficulty
- [ ] All game state resets correctly (kills/losses/timer)

Closes #1830

🤖 Generated with [Claude Code](https://claude.com/claude-code)