### PR TITLE
feat: Speck Wars B key — rally directly to enemy base

### DIFF
--- a/src/app/speck-wars/components/phase-router.tsx
+++ b/src/app/speck-wars/components/phase-router.tsx
@@ -107,6 +107,7 @@ export function PhaseRouter({ children }: { children: React.ReactNode }) {
           <span>Drag — pan camera</span>
           <span>H — heavy/basic mode</span>
           <span>A — advance to outpost</span>
+          <span>B — rush enemy base</span>
           <span>C — center on base</span>
           <span>D — defend base</span>
           <span>Minimap — click to rally</span>

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -78,6 +78,10 @@ export class GameInstance {
         }
         if (best) this.rally(best.x, best.y)
       },
+      () => {                                              // B — rush enemy base
+        const enemyBase = Object.values(this.sim.buildings).find(b => b.ownerId === 'ai' && b.typeId === 'base')
+        if (enemyBase) this.rally(enemyBase.x, enemyBase.y)
+      },
     )
     this.lastTime = performance.now()
     this.loop(this.lastTime)

--- a/src/app/speck-wars/input/input-handler.ts
+++ b/src/app/speck-wars/input/input-handler.ts
@@ -11,6 +11,7 @@ export class InputHandler {
   private onRecenterCamera?: () => void
   private onDefend?: () => void
   private onAdvance?: () => void
+  private onRush?: () => void
   private isDragging = false
   private lastX = 0
   private lastY = 0
@@ -30,6 +31,7 @@ export class InputHandler {
     onRecenterCamera?: () => void,
     onDefend?: () => void,
     onAdvance?: () => void,
+    onRush?: () => void,
   ) {
     this.canvas = canvas
     this.camera = camera
@@ -40,6 +42,7 @@ export class InputHandler {
     this.onRecenterCamera = onRecenterCamera
     this.onDefend = onDefend
     this.onAdvance = onAdvance
+    this.onRush = onRush
     this.attach()
   }
 
@@ -162,6 +165,8 @@ export class InputHandler {
       this.onDefend?.()
     } else if (e.code === 'KeyA') {
       this.onAdvance?.()
+    } else if (e.code === 'KeyB') {
+      this.onRush?.()
     }
   }
 


### PR DESCRIPTION
## Summary
- Adds `onRush` callback to `InputHandler` constructor (8th positional param, after `onAdvance`)
- `KeyB` handler calls `onRush?.()`
- `game-instance.ts` finds the AI base building and calls `this.rally()` on it
- Controls legend in `phase-router.tsx` updated: `B — rush enemy base`

## Test plan
- [ ] Press `B` during a game — all specks should rally to the enemy base location
- [ ] Press `B` when enemy base is already destroyed — no crash (building not found, no rally issued)
- [ ] Controls hint on menu now shows 'B — rush enemy base'
- [ ] Existing shortcuts (A/D/C/H/R/Space) still work

Closes #1832

🤖 Generated with [Claude Code](https://claude.com/claude-code)