### PR TITLE
feat: Speck Wars base attack warning — '⚠ BASE UNDER ATTACK!' notification

### DIFF
--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -20,6 +20,7 @@ export class GameInstance {
   private aiController: AIController
   private elapsedMs = 0
   private firstBloodDone = false
+  private baseAttackWarnedAt = -30000  // allow warning immediately on first hit
 
   constructor(canvas: HTMLCanvasElement) {
     this.canvas = canvas
@@ -158,6 +159,14 @@ export class GameInstance {
               color: playerGotIt ? '#4af7c4' : '#ff4f7b',
             })
             setTimeout(() => useSpeckWarsStore.getState().setNotification(null), 1800)
+          }
+        }
+        if (event.type === 'BUILDING_DAMAGED' && event.buildingId === 'building-player-base') {
+          const now = Date.now()
+          if (now - this.baseAttackWarnedAt > 12000) {
+            this.baseAttackWarnedAt = now
+            store.setNotification({ message: '⚠ BASE UNDER ATTACK!', color: '#ff4f7b' })
+            setTimeout(() => useSpeckWarsStore.getState().setNotification(null), 2500)
           }
         }
         if (event.type === 'OUTPOST_CAPTURED') {


### PR DESCRIPTION
## Summary
- Tracks `baseAttackWarnedAt` timestamp in `GameInstance`
- On each `BUILDING_DAMAGED` event for `'building-player-base'`, checks if 12s have elapsed since the last warning
- If so, shows `⚠ BASE UNDER ATTACK!` in red for 2.5s and updates the debounce timestamp

## Test plan
- [ ] Let AI attack your base — `⚠ BASE UNDER ATTACK!` notification should appear
- [ ] Warning should not spam — no repeat notification within 12s of the previous one
- [ ] Warning clears after 2.5s
- [ ] No warning when outposts are damaged (only base)
- [ ] No warning when AI base is damaged

Closes #1834

🤖 Generated with [Claude Code](https://claude.com/claude-code)