### PR TITLE
feat: Speck Wars PB delta in HUD timer — live ahead/behind indicator

### DIFF
--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -1,6 +1,7 @@
 'use client'
 import { useSpeckWarsStore } from '../store'
 import { PLAYER_COLOR, AI_COLOR } from '../domain/constants'
+import { getBestTime } from '../lib/personal-best'
 
 function colorHex(n: number) {
   return `#${n.toString(16).padStart(6, '0')}`
@@ -75,6 +76,20 @@ export function HUD() {
       }}>
         <span style={{ fontSize: 15, letterSpacing: 2, opacity: 0.9 }}>
           {formatTime(elapsedMs)}
+          {(() => {
+            const pb = getBestTime(difficulty)
+            if (!pb) return null
+            const ahead = pb - elapsedMs
+            return (
+              <span style={{
+                fontSize: 10, letterSpacing: 1, marginLeft: 8,
+                color: ahead > 0 ? '#ffd700' : '#ff4f7b',
+                opacity: 0.7,
+              }}>
+                {ahead > 0 ? `−${formatTime(ahead)}` : `+${formatTime(-ahead)}`}
+              </span>
+            )
+          })()}
         </span>
         <button
           onClick={togglePause}


### PR DESCRIPTION
## Summary
- Reads `getBestTime(difficulty)` inside the timer render
- Computes `ahead = pb - elapsedMs` (positive = ahead of PB, negative = behind)
- Shows a small `−MM:SS` in gold (ahead) or `+MM:SS` in red (behind) next to the main timer
- Only renders when a PB exists for the current difficulty

## Test plan
- [ ] Win a game to set a PB, then start a second game — delta should appear next to the timer
- [ ] If running ahead of PB, delta is gold `−01:23`
- [ ] If running behind, delta is red `+00:45`
- [ ] No delta shown on first game (no PB yet)
- [ ] Delta is specific to the current difficulty (Easy PB doesn't show on Hard)

Closes #1838

🤖 Generated with [Claude Code](https://claude.com/claude-code)