### PR TITLE
feat: Speck Wars daily seeds — same map layout for all players each day

### DIFF
--- a/src/app/speck-wars/components/phase-router.tsx
+++ b/src/app/speck-wars/components/phase-router.tsx
@@ -141,9 +141,10 @@ export function PhaseRouter({ children }: { children: React.ReactNode }) {
     }
     const nextDiff = won ? nextDifficulty[difficulty] : null
 
+    const today = new Date().toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
     const shareText = won
-      ? `I defeated the AI in Speck Wars (${diffLabel}) in ${timeStr} — killed ${kills} specks! 🎮 Can you beat my time?`
-      : `The AI beat me in Speck Wars (${diffLabel}) in ${timeStr} — killed ${kills} specks. 🎮 Think you can do better?`
+      ? `I defeated the AI in Speck Wars (${diffLabel}) in ${timeStr} — killed ${kills} specks! 🎮 Daily map ${today} — can you beat my time?`
+      : `The AI beat me in Speck Wars (${diffLabel}) in ${timeStr} — killed ${kills} specks. 🎮 Daily map ${today} — think you can do better?`
 
     const handleShare = async () => {
       const url = typeof window !== 'undefined' ? window.location.href : ''

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -26,7 +26,11 @@ export class GameInstance {
     this.canvas = canvas
     const difficulty = useSpeckWarsStore.getState().difficulty
     const aiTickInterval: Record<string, number> = { easy: 60, medium: 30, hard: 15, 'very-hard': 6 }
-    this.sim = createSim(Date.now(), difficulty)
+    const now = new Date()
+    const dateKey = now.getFullYear() * 10000 + (now.getMonth() + 1) * 100 + now.getDate()
+    const diffHash = [...difficulty].reduce((acc, ch) => acc + ch.charCodeAt(0), 0)
+    const dailySeed = dateKey * 1000 + diffHash
+    this.sim = createSim(dailySeed, difficulty)
     this.renderer = new Renderer()
     this.camera = createCamera(canvas.clientWidth, canvas.clientHeight)
     this.aiController = new AIController('ai', aiTickInterval[difficulty] ?? 15, difficulty === 'hard' || difficulty === 'very-hard')


### PR DESCRIPTION
## Summary
- Replaces `Date.now()` seed with `dateKey × 1000 + diffHash` where `dateKey = YYYYMMDD`
- Different difficulties produce different seeds on the same day (via character-code hash of the difficulty string)
- All players on Medium on 2026-07-24 face identical outpost positions
- Share text updated to include `Daily map Jul 24` for social context

## Test plan
- [ ] Start two games on the same difficulty on the same day — outpost positions should be identical
- [ ] Start games on different difficulties — outpost positions differ
- [ ] The next calendar day, positions should be different from today
- [ ] Share text includes "Daily map [date]"

Closes #1840

🤖 Generated with [Claude Code](https://claude.com/claude-code)