### PR TITLE
feat: Speck Wars screen shake when base takes damage

### DIFF
--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -21,6 +21,9 @@ export class GameInstance {
   private elapsedMs = 0
   private firstBloodDone = false
   private baseAttackWarnedAt = -30000  // allow warning immediately on first hit
+  private shakeMs = 0
+  private shakeMaxMs = 300
+  private shakeStrength = 0
 
   constructor(canvas: HTMLCanvasElement) {
     this.canvas = canvas
@@ -166,6 +169,9 @@ export class GameInstance {
           }
         }
         if (event.type === 'BUILDING_DAMAGED' && event.buildingId === 'building-player-base') {
+          // Screen shake on base hit
+          this.shakeMs = this.shakeMaxMs
+          this.shakeStrength = 5
           const now = Date.now()
           if (now - this.baseAttackWarnedAt > 12000) {
             this.baseAttackWarnedAt = now
@@ -198,7 +204,15 @@ export class GameInstance {
     // Clamp camera so world doesn't disappear off-screen
     clampCamera(this.camera, this.canvas.clientWidth, this.canvas.clientHeight)
 
-    this.renderer.render(this.sim, this.camera, dt)
+    let shakeX = 0, shakeY = 0
+    if (this.shakeMs > 0) {
+      this.shakeMs -= dt
+      const t = Math.max(0, this.shakeMs / this.shakeMaxMs)
+      const s = this.shakeStrength * t
+      shakeX = (Math.random() * 2 - 1) * s
+      shakeY = (Math.random() * 2 - 1) * s
+    }
+    this.renderer.render(this.sim, this.camera, dt, shakeX, shakeY)
     this.rafId = requestAnimationFrame(this.loop)
   }
 

--- a/src/app/speck-wars/rendering/renderer.ts
+++ b/src/app/speck-wars/rendering/renderer.ts
@@ -63,8 +63,8 @@ export class Renderer {
     this.world.addChild(this.rallyGfx)
   }
 
-  render(sim: SimulationState, camera: { x: number; y: number; zoom: number }, dt: number) {
-    this.world.position.set(camera.x, camera.y)
+  render(sim: SimulationState, camera: { x: number; y: number; zoom: number }, dt: number, shakeX = 0, shakeY = 0) {
+    this.world.position.set(camera.x + shakeX, camera.y + shakeY)
     this.world.scale.set(camera.zoom)
 
     this.buildingLayer.update(sim, PLAYER_COLORS)


### PR DESCRIPTION
## Summary
- `GameInstance` tracks `shakeMs`, `shakeMaxMs` (300ms), and `shakeStrength` (5px)
- On each `BUILDING_DAMAGED` event for `'building-player-base'`, resets shake to full
- Each frame, if shake is active: decrements `shakeMs`, computes a random offset decaying proportionally to remaining time, passes `shakeX/shakeY` to `renderer.render()`
- `Renderer.render()` now accepts optional `shakeX`/`shakeY` params (default 0); applies them to `world.position.set(camera.x + shakeX, camera.y + shakeY)`

## Test plan
- [ ] Let AI attack your base — screen should visibly jitter for ~300ms per hit
- [ ] Shake decays to zero smoothly (not an abrupt cut)
- [ ] Camera true position is not changed — panning/zooming still works after shake
- [ ] No shake when outposts are damaged
- [ ] Very-hard difficulty with frequent base hits should feel intense but not disorienting

Closes #1842

🤖 Generated with [Claude Code](https://claude.com/claude-code)