### PR TITLE
feat: Speck Wars enemy base critical notification

### DIFF
--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -24,6 +24,7 @@ export class GameInstance {
   private shakeMs = 0
   private shakeMaxMs = 300
   private shakeStrength = 0
+  private enemyBaseWarnedAt = -30000
 
   constructor(canvas: HTMLCanvasElement) {
     this.canvas = canvas
@@ -166,6 +167,17 @@ export class GameInstance {
               color: playerGotIt ? '#4af7c4' : '#ff4f7b',
             })
             setTimeout(() => useSpeckWarsStore.getState().setNotification(null), 1800)
+          }
+        }
+        if (event.type === 'BUILDING_DAMAGED' && event.buildingId === 'building-ai-base') {
+          const aiBase = this.sim.buildings['building-ai-base']
+          if (aiBase && event.hp / aiBase.maxHp < 0.2) {
+            const now = Date.now()
+            if (now - this.enemyBaseWarnedAt > 15000) {
+              this.enemyBaseWarnedAt = now
+              store.setNotification({ message: '⚔ ENEMY BASE CRITICAL!', color: '#ffd700' })
+              setTimeout(() => useSpeckWarsStore.getState().setNotification(null), 3000)
+            }
           }
         }
         if (event.type === 'BUILDING_DAMAGED' && event.buildingId === 'building-player-base') {


### PR DESCRIPTION
## Summary
- Adds `enemyBaseWarnedAt` debounce tracker in `GameInstance`
- On each `BUILDING_DAMAGED` event for `'building-ai-base'`, checks if `event.hp / aiBase.maxHp < 0.2` and 15s have elapsed since last warning
- Shows `⚔ ENEMY BASE CRITICAL!` in gold for 3 seconds

## Test plan
- [ ] Deal significant damage to the AI base — should see gold `⚔ ENEMY BASE CRITICAL!` notification when below 20% HP
- [ ] Notification should not repeat within 15 seconds
- [ ] No notification fires for outpost damage or player base damage
- [ ] If AI base regenerates above 20% and gets hit below again after 15s, notification re-fires

Closes #1844

🤖 Generated with [Claude Code](https://claude.com/claude-code)