### PR TITLE
feat: Speck Wars star rating in share text

### DIFF
--- a/src/app/speck-wars/components/phase-router.tsx
+++ b/src/app/speck-wars/components/phase-router.tsx
@@ -142,8 +142,9 @@ export function PhaseRouter({ children }: { children: React.ReactNode }) {
     const nextDiff = won ? nextDifficulty[difficulty] : null
 
     const today = new Date().toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
+    const starStr = won ? '★'.repeat(stars) + '☆'.repeat(3 - stars) + ' ' : ''
     const shareText = won
-      ? `I defeated the AI in Speck Wars (${diffLabel}) in ${timeStr} — killed ${kills} specks! 🎮 Daily map ${today} — can you beat my time?`
+      ? `${starStr}I defeated the AI in Speck Wars (${diffLabel}) in ${timeStr} — killed ${kills} specks! 🎮 Daily map ${today} — can you beat my time?`
       : `The AI beat me in Speck Wars (${diffLabel}) in ${timeStr} — killed ${kills} specks. 🎮 Daily map ${today} — think you can do better?`
 
     const handleShare = async () => {


### PR DESCRIPTION
## Summary
- Computes `starStr` from the existing `stars` variable (1-3 filled ★ + empty ☆ to fill 3)
- Prepends it to the win share text: `★★★ I defeated the AI...`
- Defeat text unchanged (no stars for loss)

## Test plan
- [ ] Win with 3 stars — share text starts with `★★★`
- [ ] Win with 1 star — share text starts with `★☆☆`
- [ ] Defeat — share text unchanged (no stars)

Closes #1846

🤖 Generated with [Claude Code](https://claude.com/claude-code)