### PR TITLE
feat: Speck Wars mobile action buttons — D/A/B/R accessible via touch

### DIFF
--- a/src/app/speck-wars/SpeckWarsGame.tsx
+++ b/src/app/speck-wars/SpeckWarsGame.tsx
@@ -25,6 +25,19 @@ function GameCanvas() {
     }
   }, [])
 
+  const btnStyle = {
+    pointerEvents: 'auto' as const,
+    padding: '10px 16px',
+    fontSize: 11,
+    cursor: 'pointer',
+    background: 'rgba(0,0,0,0.55)',
+    border: '1px solid rgba(255,255,255,0.25)',
+    borderRadius: 20,
+    color: 'rgba(255,255,255,0.8)',
+    letterSpacing: 1,
+    touchAction: 'manipulation' as const,
+  }
+
   return (
     <div style={{ position: 'relative', width: '100%', height: '100%' }}>
       <canvas
@@ -33,6 +46,17 @@ function GameCanvas() {
       />
       <HUD />
       <Minimap gameRef={gameRef} />
+      {/* Mobile action buttons */}
+      <div style={{
+        position: 'absolute', bottom: 16, left: '50%', transform: 'translateX(-50%)',
+        display: 'flex', gap: 8, pointerEvents: 'none',
+        marginRight: 180,  // avoid minimap overlap
+      }}>
+        <button style={btnStyle} onClick={() => gameRef.current?.defend()}>D: Defend</button>
+        <button style={btnStyle} onClick={() => gameRef.current?.advance()}>A: Advance</button>
+        <button style={btnStyle} onClick={() => gameRef.current?.rush()}>B: Rush</button>
+        <button style={btnStyle} onClick={() => gameRef.current?.clearRally()}>R: Clear</button>
+      </div>
     </div>
   )
 }

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -59,7 +59,7 @@ export class GameInstance {
         this.renderer.showRallyPing(wx, wy)
       },
       () => useSpeckWarsStore.getState().togglePause(),   // Space
-      () => { this.sim.rallyPoints['player'] = null },    // R — clear rally
+      () => this.clearRally(),                             // R — clear rally
       () => {                                              // H — cycle spawn mode
         const next = useSpeckWarsStore.getState().cycleSpawnMode()
         this.sim.inputQueue.push({ type: 'SET_SPAWN_TYPE', ownerId: 'player', speckTypeId: next })
@@ -70,27 +70,9 @@ export class GameInstance {
         this.camera.x = this.canvas.clientWidth / 2 - base.x * this.camera.zoom
         this.camera.y = this.canvas.clientHeight / 2 - base.y * this.camera.zoom
       },
-      () => {                                              // D — defend (rally to player base)
-        const base = Object.values(this.sim.buildings).find(b => b.ownerId === 'player' && b.typeId === 'base')
-        if (!base) return
-        this.rally(base.x, base.y)
-      },
-      () => {                                              // A — advance to nearest non-player outpost
-        const playerBase = Object.values(this.sim.buildings).find(b => b.ownerId === 'player' && b.typeId === 'base')
-        if (!playerBase) return
-        let best = null, bestD2 = Infinity
-        for (const b of Object.values(this.sim.buildings)) {
-          if (b.typeId !== 'outpost' || b.ownerId === 'player') continue
-          const dx = b.x - playerBase.x, dy = b.y - playerBase.y
-          const d2 = dx * dx + dy * dy
-          if (d2 < bestD2) { bestD2 = d2; best = b }
-        }
-        if (best) this.rally(best.x, best.y)
-      },
-      () => {                                              // B — rush enemy base
-        const enemyBase = Object.values(this.sim.buildings).find(b => b.ownerId === 'ai' && b.typeId === 'base')
-        if (enemyBase) this.rally(enemyBase.x, enemyBase.y)
-      },
+      () => this.defend(),                                 // D — defend (rally to player base)
+      () => this.advance(),                                // A — advance to nearest non-player outpost
+      () => this.rush(),                                   // B — rush enemy base
     )
     this.lastTime = performance.now()
     this.loop(this.lastTime)
@@ -239,6 +221,33 @@ export class GameInstance {
   rally(x: number, y: number) {
     this.sim.inputQueue.push({ type: 'RALLY', ownerId: 'player', x, y })
     this.renderer.showRallyPing(x, y)
+  }
+
+  defend() {
+    const base = Object.values(this.sim.buildings).find(b => b.ownerId === 'player' && b.typeId === 'base')
+    if (base) this.rally(base.x, base.y)
+  }
+
+  advance() {
+    const playerBase = Object.values(this.sim.buildings).find(b => b.ownerId === 'player' && b.typeId === 'base')
+    if (!playerBase) return
+    let best = null, bestD2 = Infinity
+    for (const b of Object.values(this.sim.buildings)) {
+      if (b.typeId !== 'outpost' || b.ownerId === 'player') continue
+      const dx = b.x - playerBase.x, dy = b.y - playerBase.y
+      const d2 = dx * dx + dy * dy
+      if (d2 < bestD2) { bestD2 = d2; best = b }
+    }
+    if (best) this.rally(best.x, best.y)
+  }
+
+  rush() {
+    const enemyBase = Object.values(this.sim.buildings).find(b => b.ownerId === 'ai' && b.typeId === 'base')
+    if (enemyBase) this.rally(enemyBase.x, enemyBase.y)
+  }
+
+  clearRally() {
+    this.sim.rallyPoints['player'] = null
   }
 
   getSim(): SimulationState {


### PR DESCRIPTION
## Summary
- `GameInstance` gains four public methods: `defend()`, `advance()`, `rush()`, `clearRally()` — extracted from the anonymous keyboard callbacks
- InputHandler's D/A/B/R callbacks now delegate to these methods
- `SpeckWarsGame.tsx` (`GameCanvas`) adds a row of semi-transparent pill buttons at bottom-center: `D: Defend`, `A: Advance`, `B: Rush`, `R: Clear`
- Buttons are positioned with `marginRight: 180` to avoid overlapping the minimap

## Test plan
- [ ] On mobile/touch: tap each button and verify it triggers the correct rally
- [ ] D → specks rally to player base
- [ ] A → specks advance to nearest uncaptured outpost
- [ ] B → specks rush enemy base
- [ ] R → rally point is cleared
- [ ] Buttons don't interfere with drag/pan or tap-to-rally on the canvas
- [ ] Desktop: keyboard shortcuts still work as before

Closes #1849

🤖 Generated with [Claude Code](https://claude.com/claude-code)