### PR TITLE
feat: Speck Wars attack pulse — speck scales to 1.3× when it strikes

### DIFF
--- a/src/app/speck-wars/SpeckWarsGame.tsx
+++ b/src/app/speck-wars/SpeckWarsGame.tsx
@@ -25,6 +25,19 @@ function GameCanvas() {
     }
   }, [])
 
+  const btnStyle = {
+    pointerEvents: 'auto' as const,
+    padding: '10px 16px',
+    fontSize: 11,
+    cursor: 'pointer',
+    background: 'rgba(0,0,0,0.55)',
+    border: '1px solid rgba(255,255,255,0.25)',
+    borderRadius: 20,
+    color: 'rgba(255,255,255,0.8)',
+    letterSpacing: 1,
+    touchAction: 'manipulation' as const,
+  }
+
   return (
     <div style={{ position: 'relative', width: '100%', height: '100%' }}>
       <canvas
@@ -33,6 +46,17 @@ function GameCanvas() {
       />
       <HUD />
       <Minimap gameRef={gameRef} />
+      {/* Mobile action buttons */}
+      <div style={{
+        position: 'absolute', bottom: 16, left: '50%', transform: 'translateX(-50%)',
+        display: 'flex', gap: 8, pointerEvents: 'none',
+        marginRight: 180,  // avoid minimap overlap
+      }}>
+        <button style={btnStyle} onClick={() => gameRef.current?.defend()}>D: Defend</button>
+        <button style={btnStyle} onClick={() => gameRef.current?.advance()}>A: Advance</button>
+        <button style={btnStyle} onClick={() => gameRef.current?.rush()}>B: Rush</button>
+        <button style={btnStyle} onClick={() => gameRef.current?.clearRally()}>R: Clear</button>
+      </div>
     </div>
   )
 }

--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -1,4 +1,5 @@
 'use client'
+import { useState, useEffect } from 'react'
 import { useSpeckWarsStore } from '../store'
 import { PLAYER_COLOR, AI_COLOR } from '../domain/constants'
 import { getBestTime } from '../lib/personal-best'
@@ -15,6 +16,17 @@ function formatTime(ms: number): string {
 }
 
 export function HUD() {
+  const [showHelp, setShowHelp] = useState(false)
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.code === 'Slash' && e.shiftKey) { e.preventDefault(); setShowHelp(h => !h) }
+      if (e.code === 'Escape') setShowHelp(false)
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [])
+
   const hud = useSpeckWarsStore(s => s.hud)
   const phase = useSpeckWarsStore(s => s.phase)
   const togglePause = useSpeckWarsStore(s => s.togglePause)
@@ -140,7 +152,55 @@ export function HUD() {
         >
           {spawnMode === 'heavy' ? '⬡ HEAVY' : '· BASIC'}
         </button>
+        <button
+          onClick={() => setShowHelp(h => !h)}
+          title="? — show controls"
+          style={{
+            pointerEvents: 'auto',
+            padding: '4px 10px',
+            fontSize: 12,
+            cursor: 'pointer',
+            background: showHelp ? 'rgba(255,255,255,0.15)' : 'rgba(0,0,0,0.5)',
+            border: `1px solid ${showHelp ? 'rgba(255,255,255,0.6)' : 'rgba(255,255,255,0.3)'}`,
+            borderRadius: 4,
+            color: '#fff',
+          }}
+        >
+          ?
+        </button>
       </div>
+
+      {/* Help overlay */}
+      {showHelp && (
+        <div
+          onClick={() => setShowHelp(false)}
+          style={{
+            position: 'absolute', inset: 0,
+            background: 'rgba(0,0,0,0.7)',
+            display: 'flex', alignItems: 'center', justifyContent: 'center',
+            pointerEvents: 'auto', cursor: 'default',
+          }}
+        >
+          <div style={{
+            display: 'grid', gridTemplateColumns: '1fr 1fr',
+            gap: '6px 32px',
+            color: 'rgba(255,255,255,0.8)',
+            fontSize: 13,
+            letterSpacing: 0.5,
+            background: 'rgba(0,0,0,0.5)',
+            padding: '24px 32px',
+            borderRadius: 8,
+            border: '1px solid rgba(255,255,255,0.15)',
+          }}>
+            <span>🖱 Click — rally specks</span><span>Space — pause</span>
+            <span>Scroll — zoom</span><span>R — clear rally</span>
+            <span>Drag — pan camera</span><span>H — heavy/basic mode</span>
+            <span>A — advance to outpost</span><span>C — center on base</span>
+            <span>B — rush enemy base</span><span>D — defend base</span>
+            <span>Minimap — click to rally</span><span>? — this help</span>
+          </div>
+        </div>
+      )}
 
       {/* Outpost ownership indicator dots */}
       {hud && (() => {

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -59,7 +59,7 @@ export class GameInstance {
         this.renderer.showRallyPing(wx, wy)
       },
       () => useSpeckWarsStore.getState().togglePause(),   // Space
-      () => { this.sim.rallyPoints['player'] = null },    // R — clear rally
+      () => this.clearRally(),                             // R — clear rally
       () => {                                              // H — cycle spawn mode
         const next = useSpeckWarsStore.getState().cycleSpawnMode()
         this.sim.inputQueue.push({ type: 'SET_SPAWN_TYPE', ownerId: 'player', speckTypeId: next })
@@ -70,27 +70,9 @@ export class GameInstance {
         this.camera.x = this.canvas.clientWidth / 2 - base.x * this.camera.zoom
         this.camera.y = this.canvas.clientHeight / 2 - base.y * this.camera.zoom
       },
-      () => {                                              // D — defend (rally to player base)
-        const base = Object.values(this.sim.buildings).find(b => b.ownerId === 'player' && b.typeId === 'base')
-        if (!base) return
-        this.rally(base.x, base.y)
-      },
-      () => {                                              // A — advance to nearest non-player outpost
-        const playerBase = Object.values(this.sim.buildings).find(b => b.ownerId === 'player' && b.typeId === 'base')
-        if (!playerBase) return
-        let best = null, bestD2 = Infinity
-        for (const b of Object.values(this.sim.buildings)) {
-          if (b.typeId !== 'outpost' || b.ownerId === 'player') continue
-          const dx = b.x - playerBase.x, dy = b.y - playerBase.y
-          const d2 = dx * dx + dy * dy
-          if (d2 < bestD2) { bestD2 = d2; best = b }
-        }
-        if (best) this.rally(best.x, best.y)
-      },
-      () => {                                              // B — rush enemy base
-        const enemyBase = Object.values(this.sim.buildings).find(b => b.ownerId === 'ai' && b.typeId === 'base')
-        if (enemyBase) this.rally(enemyBase.x, enemyBase.y)
-      },
+      () => this.defend(),                                 // D — defend (rally to player base)
+      () => this.advance(),                                // A — advance to nearest non-player outpost
+      () => this.rush(),                                   // B — rush enemy base
     )
     this.lastTime = performance.now()
     this.loop(this.lastTime)
@@ -239,6 +221,33 @@ export class GameInstance {
   rally(x: number, y: number) {
     this.sim.inputQueue.push({ type: 'RALLY', ownerId: 'player', x, y })
     this.renderer.showRallyPing(x, y)
+  }
+
+  defend() {
+    const base = Object.values(this.sim.buildings).find(b => b.ownerId === 'player' && b.typeId === 'base')
+    if (base) this.rally(base.x, base.y)
+  }
+
+  advance() {
+    const playerBase = Object.values(this.sim.buildings).find(b => b.ownerId === 'player' && b.typeId === 'base')
+    if (!playerBase) return
+    let best = null, bestD2 = Infinity
+    for (const b of Object.values(this.sim.buildings)) {
+      if (b.typeId !== 'outpost' || b.ownerId === 'player') continue
+      const dx = b.x - playerBase.x, dy = b.y - playerBase.y
+      const d2 = dx * dx + dy * dy
+      if (d2 < bestD2) { bestD2 = d2; best = b }
+    }
+    if (best) this.rally(best.x, best.y)
+  }
+
+  rush() {
+    const enemyBase = Object.values(this.sim.buildings).find(b => b.ownerId === 'ai' && b.typeId === 'base')
+    if (enemyBase) this.rally(enemyBase.x, enemyBase.y)
+  }
+
+  clearRally() {
+    this.sim.rallyPoints['player'] = null
   }
 
   getSim(): SimulationState {

--- a/src/app/speck-wars/rendering/layers/speck-layer.ts
+++ b/src/app/speck-wars/rendering/layers/speck-layer.ts
@@ -3,11 +3,14 @@ import type { Texture } from 'pixi.js'
 import type { SimulationState } from '../../domain/types'
 import { SPECK_TYPES } from '../../domain/config/speck-types'
 
+const ATTACK_ANIM_MS = 120
+
 export class SpeckLayer {
   private containers: Map<string, Container> = new Map()
   private sprites: Map<string, Sprite[]> = new Map()
   private texture: Texture
   private playerColors: Record<string, number>
+  private attackAnimByIndex: Map<number, number> = new Map()
   readonly stage: Container
 
   constructor(texture: Texture, playerColors: Record<string, number>) {
@@ -51,13 +54,26 @@ export class SpeckLayer {
       }
 
       // Update visible sprites
+      const now = Date.now()
       for (let j = 0; j < indices.length; j++) {
         const i = indices[j]
         spriteList[j].position.set(sim.speckX[i], sim.speckY[i])
         spriteList[j].visible = true
         const typeMeta = sim.speckMeta[i]
         const stype = typeMeta ? SPECK_TYPES[typeMeta.typeId] : null
-        spriteList[j].scale.set(stype ? stype.size / 4 : 0.75)
+        // Track attack animation
+        if (typeMeta?.state === 'attacking') this.attackAnimByIndex.set(i, now)
+        const attackTs = this.attackAnimByIndex.get(i)
+        let scaleBoost = 1.0
+        if (attackTs !== undefined) {
+          const elapsed = now - attackTs
+          if (elapsed < ATTACK_ANIM_MS) {
+            scaleBoost = 1 + 0.3 * (1 - elapsed / ATTACK_ANIM_MS)  // 1.3x → 1.0x
+          } else {
+            this.attackAnimByIndex.delete(i)
+          }
+        }
+        spriteList[j].scale.set((stype ? stype.size / 4 : 0.75) * scaleBoost)
         // Fade speck as it takes damage — full HP = 1.0, near death = 0.35
         const hpFrac = stype ? Math.max(0, sim.speckHp[i] / stype.hp) : 1
         spriteList[j].alpha = 0.35 + 0.65 * hpFrac


### PR DESCRIPTION
## Summary
- `SpeckLayer` tracks `attackAnimByIndex: Map<number, number>` (slot index → last attack timestamp)
- Each frame: if `meta.state === 'attacking'`, record `now` in the map
- When rendering, compute `scaleBoost = 1 + 0.3 × (1 − elapsed/120ms)` for active animations; delete stale entries
- Scale applied as `(baseSize / 4) × scaleBoost` per sprite

## Test plan
- [ ] Watch specks fight — each one should briefly pulse larger (≈1.3×) when it lands a hit
- [ ] Heavy specks pulse too (larger base size, same multiplier)
- [ ] Pulse is short-lived (~120ms) and doesn't create visual clutter
- [ ] No visual glitches when a speck dies mid-pulse and its slot is reused

Closes #1848

🤖 Generated with [Claude Code](https://claude.com/claude-code)