### PR TITLE
feat: Speck Wars dramatic game-over — 1.4s cinematic pause before end screen

### DIFF
--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -108,20 +108,30 @@ export class GameInstance {
 
       for (const event of this.sim.events) {
         if (event.type === 'GAME_OVER') {
-          if (event.winnerId === 'player') {
-            const isNew = recordBestTime(store.difficulty, this.elapsedMs)
-            incrementWinStreak()
-            recordGameResult(store.difficulty, true, this.elapsedMs, store.kills)
-            store.setIsNewBest(isNew)
-            store.setPhase('victory')
-          } else {
-            resetWinStreak()
-            recordGameResult(store.difficulty, false, this.elapsedMs, store.kills)
-            store.setIsNewBest(false)
-            store.setPhase('defeat')
-          }
+          const won = event.winnerId === 'player'
           store.setWinnerId(event.winnerId)
           store.setVictoryType(event.victoryType)
+          // Show dramatic notification, then transition to end screen after a brief delay
+          store.setNotification({
+            message: won ? '⚡ VICTORY!' : '💀 DEFEATED',
+            color: won ? '#4af7c4' : '#ff4f7b',
+          })
+          const elapsedAtEnd = this.elapsedMs
+          setTimeout(() => {
+            const s = useSpeckWarsStore.getState()
+            if (won) {
+              const isNew = recordBestTime(s.difficulty, elapsedAtEnd)
+              incrementWinStreak()
+              recordGameResult(s.difficulty, true, elapsedAtEnd, s.kills)
+              s.setIsNewBest(isNew)
+              s.setPhase('victory')
+            } else {
+              resetWinStreak()
+              recordGameResult(s.difficulty, false, elapsedAtEnd, s.kills)
+              s.setIsNewBest(false)
+              s.setPhase('defeat')
+            }
+          }, 1400)
         }
         if (event.type === 'HUD_UPDATE') {
           store.setHud(event.data)


### PR DESCRIPTION
## Summary
- On `GAME_OVER` event, immediately shows `⚡ VICTORY!` (teal) or `💀 DEFEATED` (red) as a full notification
- Defers the phase transition (and all end-game stats recording) to a 1.4s `setTimeout`
- During the delay, the game world is still visible: base is destroyed, particles are clearing
- `elapsedMs` captured at the moment of game over (not when setTimeout fires) to avoid drift

## Test plan
- [ ] Destroy the AI base — should see `⚡ VICTORY!` in teal for ~1.4s before victory screen
- [ ] Let AI destroy your base — `💀 DEFEATED` in red before defeat screen
- [ ] Best time / win streak / game history all record correctly (same values as before)
- [ ] Surrender via "Give Up" still works (doesn't go through GAME_OVER — immediate phase change)

Closes #1856

🤖 Generated with [Claude Code](https://claude.com/claude-code)