### PR TITLE
feat: Speck Wars notification fade-in animation

### DIFF
--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -278,13 +278,23 @@ export function HUD() {
           position: 'absolute', top: 76, left: 0, right: 0,
           display: 'flex', justifyContent: 'center',
         }}>
-          <span style={{
-            color: notification.color,
-            fontSize: 13,
-            fontWeight: 'bold',
-            letterSpacing: 2,
-            textShadow: `0 0 12px ${notification.color}`,
-          }}>
+          <style>{`
+            @keyframes notif-in {
+              from { opacity: 0; transform: translateY(-8px) scale(0.92); }
+              to   { opacity: 1; transform: translateY(0)  scale(1); }
+            }
+          `}</style>
+          <span
+            key={notification.message + notification.color}
+            style={{
+              color: notification.color,
+              fontSize: 13,
+              fontWeight: 'bold',
+              letterSpacing: 2,
+              textShadow: `0 0 12px ${notification.color}`,
+              animation: 'notif-in 0.18s ease-out',
+            }}
+          >
             {notification.message}
           </span>
         </div>


### PR DESCRIPTION
## Summary
- Adds `@keyframes notif-in` CSS animation (slide from -8px + scale 0.92 → normal position in 0.18s ease-out)
- Adds `key={notification.message + notification.color}` to force React to remount the span on each new notification, re-triggering the animation
- The `<style>` tag is inside the conditional block so it only renders when a notification is showing

## Test plan
- [ ] Trigger any notification (outpost capture, first blood, kill milestone) — should see a quick slide-in from above
- [ ] Rapid consecutive notifications (outpost events) each animate fresh
- [ ] Animation is subtle (0.18s) and doesn't feel distracting in the heat of battle

Closes #1858

🤖 Generated with [Claude Code](https://claude.com/claude-code)