### PR TITLE
feat: Speck Wars destruction burst — particle explosion on building destroyed

### DIFF
--- a/src/app/speck-wars/domain/simulation/combat.ts
+++ b/src/app/speck-wars/domain/simulation/combat.ts
@@ -91,7 +91,7 @@ export function resolveCombat(sim: SimulationState, dt: number) {
       sim.events.push({ type: 'BUILDING_DAMAGED', buildingId: building.id, hp: building.hp })
 
       if (building.hp <= 0) {
-        sim.events.push({ type: 'BUILDING_DESTROYED', buildingId: building.id, ownerId: building.ownerId })
+        sim.events.push({ type: 'BUILDING_DESTROYED', buildingId: building.id, ownerId: building.ownerId, x: building.x, y: building.y })
         delete sim.buildings[building.id]
         // Clear target for all specks pointing at this building
         for (let k = 0; k < sim.speckCount; k++) {

--- a/src/app/speck-wars/domain/types.ts
+++ b/src/app/speck-wars/domain/types.ts
@@ -67,7 +67,7 @@ export type InputEvent =
 export type SimEvent =
   | { type: 'SPECK_DIED'; speckId: string; x: number; y: number; killedOwnerId: string; killerOwnerId: string }
   | { type: 'BUILDING_DAMAGED'; buildingId: string; hp: number }
-  | { type: 'BUILDING_DESTROYED'; buildingId: string; ownerId: string }
+  | { type: 'BUILDING_DESTROYED'; buildingId: string; ownerId: string; x: number; y: number }
   | { type: 'SPECK_SPAWNED'; speckId: string; buildingId: string }
   | { type: 'GAME_OVER'; winnerId: string; victoryType: 'destruction' | 'domination' }
   | { type: 'HUD_UPDATE'; data: HudData }

--- a/src/app/speck-wars/rendering/layers/effects-layer.ts
+++ b/src/app/speck-wars/rendering/layers/effects-layer.ts
@@ -42,6 +42,19 @@ export class EffectsLayer {
     }
   }
 
+  addDestructionBurst(x: number, y: number, color: number) {
+    // 20 radial particles — fast, long-lived, large burst for building destruction
+    for (let i = 0; i < 20; i++) {
+      const angle = (i / 20) * Math.PI * 2 + (Math.random() - 0.5) * 0.5
+      const speed = 80 + Math.random() * 120  // px/sec
+      this.particles.push({ x, y, vx: Math.cos(angle) * speed, vy: Math.sin(angle) * speed, life: 600, maxLife: 600, color })
+    }
+    // Large shockwave rings
+    for (let i = 0; i < 3; i++) {
+      this.ripples.push({ x, y, life: 500 - i * 100, maxLife: 500 - i * 100, color: 0xffffff })
+    }
+  }
+
   update(dt: number) {
     this.gfx.clear()
 

--- a/src/app/speck-wars/rendering/renderer.ts
+++ b/src/app/speck-wars/rendering/renderer.ts
@@ -80,6 +80,10 @@ export class Renderer {
       if (event.type === 'BUILDING_DAMAGED') {
         this.buildingLayer.flashBuilding(event.buildingId)
       }
+      if (event.type === 'BUILDING_DESTROYED') {
+        const color = PLAYER_COLORS[event.ownerId] ?? 0xffffff
+        this.effectsLayer.addDestructionBurst(event.x, event.y, color)
+      }
       if (event.type === 'OUTPOST_CAPTURED') {
         const building = sim.buildings[event.outpostId]
         const color = PLAYER_COLORS[event.newOwner] ?? 0xffffff


### PR DESCRIPTION
Closes #1860

## Summary
- Added `x`/`y` to `BUILDING_DESTROYED` sim event (captured before the building is deleted)
- New `addDestructionBurst(x, y, color)` in `EffectsLayer`: 20 radial particles at 80–200 px/s with 600ms lifetime + 3 white shockwave ripple rings
- `Renderer` now handles `BUILDING_DESTROYED` → calls `addDestructionBurst`

## Test plan
- [ ] Kill an outpost — see particle burst at its location
- [ ] Win/lose game — see explosion at the destroyed base
- [ ] Particles should fan outward and fade, rings expand and fade

🤖 Generated with [Claude Code](https://claude.com/claude-code)