### PR TITLE
feat: Speck Wars outpost under attack warning notification

### DIFF
--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -25,6 +25,7 @@ export class GameInstance {
   private shakeMaxMs = 300
   private shakeStrength = 0
   private enemyBaseWarnedAt = -30000
+  private outpostAttackWarnedAt: Record<string, number> = {}  // outpostId → timestamp
 
   constructor(canvas: HTMLCanvasElement) {
     this.canvas = canvas
@@ -135,6 +136,25 @@ export class GameInstance {
         }
         if (event.type === 'HUD_UPDATE') {
           store.setHud(event.data)
+          // Warn when an enemy starts capturing a player-owned outpost
+          const now = Date.now()
+          const playerBuildingHp = event.data.players.player?.buildingHp ?? {}
+          for (const outpostId of event.data.attackedBuildingIds) {
+            if (!(outpostId in playerBuildingHp)) continue  // not player-owned
+            const lastWarn = this.outpostAttackWarnedAt[outpostId] ?? -Infinity
+            if (now - lastWarn > 8000) {
+              this.outpostAttackWarnedAt[outpostId] = now
+              const name = outpostId.replace('outpost-', '').toUpperCase()
+              store.setNotification({ message: `⬡ ${name} UNDER ATTACK!`, color: '#ff8c00' })
+              setTimeout(() => useSpeckWarsStore.getState().setNotification(null), 2500)
+            }
+          }
+          // Clear warnings for outposts that are no longer under attack
+          for (const id of Object.keys(this.outpostAttackWarnedAt)) {
+            if (!event.data.attackedBuildingIds.includes(id)) {
+              delete this.outpostAttackWarnedAt[id]
+            }
+          }
         }
         if (event.type === 'SPECK_DIED') {
           if (event.killedOwnerId === 'ai' && event.killerOwnerId === 'player') {


### PR DESCRIPTION
Closes #1862

## Summary
- Added `outpostAttackWarnedAt: Record<string, number>` field to `GameInstance`
- In `HUD_UPDATE` handler: checks `attackedBuildingIds` against player-owned buildings, fires `⬡ {NAME} UNDER ATTACK!` (orange) with 8s cooldown per outpost
- Clears stale warnings when outpost is no longer under attack

## Test plan
- [ ] AI starts capturing your outpost → see `⬡ TOP UNDER ATTACK!` (or LEFT/RIGHT)
- [ ] Warning only fires every 8s per outpost (not every HUD tick)
- [ ] No warning fires for neutral or AI-owned outposts being captured
- [ ] Warning clears if capture stops

🤖 Generated with [Claude Code](https://claude.com/claude-code)