### PR TITLE
feat: Speck Wars recapture celebration + enemy surge warning

### DIFF
--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -399,26 +399,55 @@ export function HUD() {
         </div>
       )}
 
-      {/* Player stats — bottom left */}
-      {hud && (
-        <div style={{ position: 'absolute', bottom: 16, left: 16 }}>
-          {Object.entries(hud.players)
-            .filter(([pid]) => pid !== 'neutral')
-            .map(([pid, data]) => {
-              const color = pid === 'player' ? colorHex(PLAYER_COLOR) : colorHex(AI_COLOR)
-              const label = pid === 'player' ? 'YOU' : 'AI'
-              const totalHp = Object.values(data.buildingHp).reduce((a, b) => a + b, 0)
-              return (
-                <div key={pid} style={{ marginBottom: 6, color }}>
-                  <strong>{label}</strong> — specks: {data.speckCount} | bases: {data.buildingCount} | HP: {totalHp}
-                  {pid === 'player' && (
-                    <span style={{ opacity: 0.7 }}> | ↑{kills} ↓{losses}</span>
-                  )}
+      {/* Player stats + force bar — bottom left */}
+      {hud && (() => {
+        const playerSpecks = hud.players.player?.speckCount ?? 0
+        const aiSpecks = hud.players.ai?.speckCount ?? 0
+        const total = playerSpecks + aiSpecks
+        const playerFrac = total > 0 ? playerSpecks / total : 0.5
+        const playerBaseHpVal = hud.players.player?.buildingHp['building-player-base'] ?? 0
+        const aiBaseHpVal = hud.players.ai?.buildingHp['building-ai-base'] ?? 0
+        const aiBaseHpFrac = aiBaseHpVal / 100
+        const aiBaseColor = aiBaseHpFrac > 0.5 ? '#ff4f7b' : aiBaseHpFrac > 0.2 ? '#ffaa44' : '#ff2200'
+        return (
+          <div style={{ position: 'absolute', bottom: 16, left: 16, display: 'flex', flexDirection: 'column', gap: 5 }}>
+            {/* Force ratio bar */}
+            {total >= 4 && (
+              <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+                <span style={{ fontSize: 9, letterSpacing: 1, color: colorHex(PLAYER_COLOR), opacity: 0.7, minWidth: 20, textAlign: 'right' }}>
+                  {playerSpecks}
+                </span>
+                <div style={{ width: 100, height: 5, background: 'rgba(255,79,123,0.4)', borderRadius: 3, overflow: 'hidden', position: 'relative' }}>
+                  <div style={{
+                    position: 'absolute', left: 0, top: 0, height: '100%',
+                    width: `${Math.round(playerFrac * 100)}%`,
+                    background: colorHex(PLAYER_COLOR),
+                    borderRadius: 3,
+                    transition: 'width 0.2s',
+                  }} />
                 </div>
-              )
-            })}
-        </div>
-      )}
+                <span style={{ fontSize: 9, letterSpacing: 1, color: colorHex(AI_COLOR), opacity: 0.7, minWidth: 20 }}>
+                  {aiSpecks}
+                </span>
+              </div>
+            )}
+            {/* Kill/loss + enemy base HP */}
+            <div style={{ display: 'flex', gap: 10, fontSize: 10, letterSpacing: 0.5 }}>
+              <span style={{ color: colorHex(PLAYER_COLOR), opacity: 0.7 }}>↑{kills} ↓{losses}</span>
+              {aiBaseHpVal > 0 && (
+                <span style={{ color: aiBaseColor, opacity: 0.8 }}>
+                  ENEMY BASE {Math.round(aiBaseHpFrac * 100)}%
+                </span>
+              )}
+              {playerBaseHpVal > 0 && (
+                <span style={{ color: hpFrac < 0.3 ? '#ff4f7b' : 'rgba(255,255,255,0.4)', opacity: 0.8 }}>
+                  BASE {Math.round(playerBaseHpVal)}HP
+                </span>
+              )}
+            </div>
+          </div>
+        )
+      })()}
     </div>
   )
 }

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -25,6 +25,7 @@ export class GameInstance {
   private shakeMaxMs = 300
   private shakeStrength = 0
   private enemyBaseWarnedAt = -30000
+  private outpostAttackWarnedAt: Record<string, number> = {}  // outpostId → timestamp
 
   constructor(canvas: HTMLCanvasElement) {
     this.canvas = canvas
@@ -135,6 +136,25 @@ export class GameInstance {
         }
         if (event.type === 'HUD_UPDATE') {
           store.setHud(event.data)
+          // Warn when an enemy starts capturing a player-owned outpost
+          const now = Date.now()
+          const playerBuildingHp = event.data.players.player?.buildingHp ?? {}
+          for (const outpostId of event.data.attackedBuildingIds) {
+            if (!(outpostId in playerBuildingHp)) continue  // not player-owned
+            const lastWarn = this.outpostAttackWarnedAt[outpostId] ?? -Infinity
+            if (now - lastWarn > 8000) {
+              this.outpostAttackWarnedAt[outpostId] = now
+              const name = outpostId.replace('outpost-', '').toUpperCase()
+              store.setNotification({ message: `⬡ ${name} UNDER ATTACK!`, color: '#ff8c00' })
+              setTimeout(() => useSpeckWarsStore.getState().setNotification(null), 2500)
+            }
+          }
+          // Clear warnings for outposts that are no longer under attack
+          for (const id of Object.keys(this.outpostAttackWarnedAt)) {
+            if (!event.data.attackedBuildingIds.includes(id)) {
+              delete this.outpostAttackWarnedAt[id]
+            }
+          }
         }
         if (event.type === 'SPECK_DIED') {
           if (event.killedOwnerId === 'ai' && event.killerOwnerId === 'player') {

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -26,6 +26,7 @@ export class GameInstance {
   private shakeStrength = 0
   private enemyBaseWarnedAt = -30000
   private outpostAttackWarnedAt: Record<string, number> = {}  // outpostId → timestamp
+  private enemySurgeWarnedAt = -30000
 
   constructor(canvas: HTMLCanvasElement) {
     this.canvas = canvas
@@ -155,6 +156,14 @@ export class GameInstance {
               delete this.outpostAttackWarnedAt[id]
             }
           }
+          // Enemy surge warning: AI has 2× the player's specks
+          const playerSpecks = event.data.players.player?.speckCount ?? 0
+          const aiSpecks = event.data.players.ai?.speckCount ?? 0
+          if (aiSpecks >= 2 * playerSpecks && playerSpecks > 5 && now - this.enemySurgeWarnedAt > 20000) {
+            this.enemySurgeWarnedAt = now
+            store.setNotification({ message: '⚠ ENEMY SURGE!', color: '#ff6b35' })
+            setTimeout(() => useSpeckWarsStore.getState().setNotification(null), 2500)
+          }
         }
         if (event.type === 'SPECK_DIED') {
           if (event.killedOwnerId === 'ai' && event.killerOwnerId === 'player') {
@@ -206,10 +215,13 @@ export class GameInstance {
         if (event.type === 'OUTPOST_CAPTURED') {
           const isPlayerGain = event.newOwner === 'player'
           const isPlayerLoss = event.previousOwner === 'player'
+          const isRecapture = isPlayerGain && event.previousOwner === 'ai'
           if (isPlayerGain || isPlayerLoss) {
             const outpostName = event.outpostId.replace('outpost-', '').toUpperCase()
-            const message = isPlayerGain ? `⬡ ${outpostName} CAPTURED` : `⬡ ${outpostName} LOST`
-            const color = isPlayerGain ? '#4af7c4' : '#ff4f7b'
+            const message = isPlayerLoss ? `⬡ ${outpostName} LOST`
+              : isRecapture ? `⬡ ${outpostName} RECAPTURED!`
+              : `⬡ ${outpostName} CAPTURED`
+            const color = isPlayerLoss ? '#ff4f7b' : isRecapture ? '#ffd700' : '#4af7c4'
             store.setNotification({ message, color })
             setTimeout(() => useSpeckWarsStore.getState().setNotification(null), 2500)
           }


### PR DESCRIPTION
Closes #1864

## Summary
- Recapturing an AI-owned outpost now shows `⬡ {NAME} RECAPTURED!` in gold instead of plain teal "CAPTURED"
- Added `enemySurgeWarnedAt` tracker — when AI has 2× player specks, fires `⚠ ENEMY SURGE!` with 20s cooldown

## Test plan
- [ ] Lose an outpost to AI, then retake it → gold "RECAPTURED!" notification
- [ ] Let AI build a large army → `⚠ ENEMY SURGE!` appears
- [ ] Surge warning has ~20s cooldown

🤖 Generated with [Claude Code](https://claude.com/claude-code)