### PR TITLE
feat: Speck Wars spawn flash — gold ring on speck production

### DIFF
--- a/src/app/speck-wars/domain/simulation/spawner.ts
+++ b/src/app/speck-wars/domain/simulation/spawner.ts
@@ -4,7 +4,7 @@ import { BUILDING_TYPES } from '../config/building-types'
 import { MAX_SPECKS } from '../constants'
 
 // Place a new speck into a recycled or fresh slot — never allocates new arrays
-function addSpeck(sim: SimulationState, meta: SpeckMeta, x: number, y: number) {
+function addSpeck(sim: SimulationState, meta: SpeckMeta, x: number, y: number, buildingId: string) {
   const hp = SPECK_TYPES[meta.typeId]?.hp ?? 1
 
   let slot: number
@@ -25,7 +25,7 @@ function addSpeck(sim: SimulationState, meta: SpeckMeta, x: number, y: number) {
   sim.speckIds[slot] = meta.id
   sim.speckMeta[slot] = meta
 
-  sim.events.push({ type: 'SPECK_SPAWNED', speckId: meta.id, buildingId: '' })
+  sim.events.push({ type: 'SPECK_SPAWNED', speckId: meta.id, buildingId })
 }
 
 let speckCounter = 0
@@ -58,7 +58,7 @@ export function updateSpawners(sim: SimulationState, dt: number) {
         targetId: null,
         attackCooldown: 0,
       }
-      addSpeck(sim, meta, sx, sy)
+      addSpeck(sim, meta, sx, sy, building.id)
     }
   }
 }

--- a/src/app/speck-wars/rendering/layers/building-layer.ts
+++ b/src/app/speck-wars/rendering/layers/building-layer.ts
@@ -3,12 +3,14 @@ import type { SimulationState } from '../../domain/types'
 import { BUILDING_TYPES } from '../../domain/config/building-types'
 import { NEUTRAL_COLOR, OUTPOST_AURA_RADIUS } from '../../domain/constants'
 
-const FLASH_DURATION = 200  // ms — how long a damage flash lasts
+const FLASH_DURATION = 200   // ms — how long a damage flash lasts
+const SPAWN_FLASH_DURATION = 250  // ms — brief golden ring when a speck spawns
 
 export class BuildingLayer {
   readonly stage: Container
   private gfx: Graphics
-  private flashMap: Map<string, number> = new Map()  // buildingId → timestamp of last hit
+  private flashMap: Map<string, number> = new Map()       // buildingId → timestamp of last hit
+  private spawnFlashMap: Map<string, number> = new Map()  // buildingId → timestamp of last spawn
 
   constructor() {
     this.stage = new Container()
@@ -18,6 +20,10 @@ export class BuildingLayer {
 
   flashBuilding(buildingId: string) {
     this.flashMap.set(buildingId, Date.now())
+  }
+
+  flashSpawn(buildingId: string) {
+    this.spawnFlashMap.set(buildingId, Date.now())
   }
 
   update(sim: SimulationState, playerColors: Record<string, number>) {
@@ -45,6 +51,22 @@ export class BuildingLayer {
           this.gfx.endFill()
         } else {
           this.flashMap.delete(building.id)
+        }
+      }
+
+      // Spawn flash: brief gold expanding ring when a speck is produced
+      const spawnTs = this.spawnFlashMap.get(building.id)
+      if (spawnTs !== undefined) {
+        const elapsed = now - spawnTs
+        if (elapsed < SPAWN_FLASH_DURATION) {
+          const t = elapsed / SPAWN_FLASH_DURATION
+          const alpha = (1 - t) * 0.6
+          const spawnR = r + 4 + t * 14  // expands from r+4 to r+18
+          this.gfx.lineStyle(1.5, 0xffd700, alpha)
+          this.gfx.drawCircle(building.x, building.y, spawnR)
+          this.gfx.lineStyle(0)
+        } else {
+          this.spawnFlashMap.delete(building.id)
         }
       }
 

--- a/src/app/speck-wars/rendering/renderer.ts
+++ b/src/app/speck-wars/rendering/renderer.ts
@@ -80,6 +80,9 @@ export class Renderer {
       if (event.type === 'BUILDING_DAMAGED') {
         this.buildingLayer.flashBuilding(event.buildingId)
       }
+      if (event.type === 'SPECK_SPAWNED' && event.buildingId.startsWith('building-player')) {
+        this.buildingLayer.flashSpawn(event.buildingId)
+      }
       if (event.type === 'BUILDING_DESTROYED') {
         const color = PLAYER_COLORS[event.ownerId] ?? 0xffffff
         this.effectsLayer.addDestructionBurst(event.x, event.y, color)


### PR DESCRIPTION
Closes #1874

## Summary
- Fixed `SPECK_SPAWNED` event to include actual `buildingId` (was empty string)
- Added `flashSpawn(buildingId)` to `BuildingLayer` and `spawnFlashMap` tracker
- Spawn flash: a gold ring expanding from r+4 to r+18 over 250ms, fading out
- `Renderer` triggers `flashSpawn` only for player buildings (prefix `building-player`)

## Test plan
- [ ] Watch player base — brief gold ring flashes each time a speck spawns (~800ms intervals for basic)
- [ ] No flash on AI buildings
- [ ] No flash on outposts (they don't spawn specks by default)
- [ ] Multiple flashes stack correctly if spawns happen in quick succession

🤖 Generated with [Claude Code](https://claude.com/claude-code)