### PR TITLE
feat: Speck Wars winning vignette — green glow when enemy base near death

### DIFF
--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -47,6 +47,10 @@ export function HUD() {
   const isDanger = phase === 'playing' && hpFrac < 0.3
   const isCritical = phase === 'playing' && hpFrac < 0.15
 
+  const aiBaseHp = hud?.players.ai?.buildingHp['building-ai-base']
+  const aiHpFrac = aiBaseHp !== undefined ? aiBaseHp / BASE_MAX_HP : 1
+  const isWinning = phase === 'playing' && aiHpFrac < 0.2 && aiHpFrac > 0  // enemy near death
+
   return (
     <div style={{
       position: 'absolute', inset: 0, pointerEvents: 'none',
@@ -64,6 +68,22 @@ export function HUD() {
             position: 'absolute', inset: 0,
             background: 'radial-gradient(ellipse at center, transparent 45%, rgba(220,30,30,1) 100%)',
             animation: `danger-pulse ${isCritical ? '0.5s' : '1s'} ease-in-out infinite alternate`,
+            pointerEvents: 'none',
+          }} />
+        </>
+      )}
+      {isWinning && (
+        <>
+          <style>{`
+            @keyframes win-pulse {
+              from { opacity: 0.1; }
+              to   { opacity: 0.28; }
+            }
+          `}</style>
+          <div style={{
+            position: 'absolute', inset: 0,
+            background: 'radial-gradient(ellipse at center, transparent 50%, rgba(20,220,120,1) 100%)',
+            animation: 'win-pulse 1.2s ease-in-out infinite alternate',
             pointerEvents: 'none',
           }} />
         </>


### PR DESCRIPTION
Closes #1878

## Summary
- Reads `hud.players.ai.buildingHp['building-ai-base']` to get enemy base HP fraction
- When `aiHpFrac < 0.2` (enemy below 20%), renders a green edge vignette
- Animation: 1.2s pulsing between 0.1–0.28 opacity, green radial gradient
- Mirrors the existing red danger-pulse vignette when player is losing

## Test plan
- [ ] Damage enemy base below 20% → see green edge glow
- [ ] Glow disappears if somehow enemy base heals above 20%
- [ ] Red and green vignettes don't overlap (they indicate opposite states)
- [ ] Doesn't affect paused state or menu

🤖 Generated with [Claude Code](https://claude.com/claude-code)