### PR TITLE
feat: Speck Wars rally direction line — dashed line from base to rally

### DIFF
--- a/src/app/speck-wars/rendering/renderer.ts
+++ b/src/app/speck-wars/rendering/renderer.ts
@@ -97,7 +97,7 @@ export class Renderer {
     }
     this.effectsLayer.update(dt)
 
-    // Rally point marker
+    // Rally point marker + dashed line from base to rally
     this.rallyGfx.clear()
     const rp = sim.rallyPoints['player']
     if (rp) {
@@ -112,6 +112,30 @@ export class Renderer {
       this.rallyGfx.lineStyle(1.5, PLAYER_COLOR, alpha * 0.5)
       this.rallyGfx.drawCircle(rp.x, rp.y, 14)
       this.rallyGfx.lineStyle(0)
+
+      // Dashed line from player base to rally point (only if far enough apart)
+      const playerBase = Object.values(sim.buildings).find(b => b.ownerId === 'player' && b.typeId === 'base')
+      if (playerBase) {
+        const dx = rp.x - playerBase.x
+        const dy = rp.y - playerBase.y
+        const len = Math.sqrt(dx * dx + dy * dy)
+        if (len > 80) {
+          const nx = dx / len, ny = dy / len
+          const dashLen = 8, gapLen = 6
+          this.rallyGfx.lineStyle(1, PLAYER_COLOR, 0.22)
+          let d = playerBase === null ? 0 : 46  // start outside the base
+          while (d < len - 24) {
+            const x1 = playerBase.x + nx * d
+            const y1 = playerBase.y + ny * d
+            const x2 = playerBase.x + nx * Math.min(d + dashLen, len - 24)
+            const y2 = playerBase.y + ny * Math.min(d + dashLen, len - 24)
+            this.rallyGfx.moveTo(x1, y1)
+            this.rallyGfx.lineTo(x2, y2)
+            d += dashLen + gapLen
+          }
+          this.rallyGfx.lineStyle(0)
+        }
+      }
     }
   }
 


### PR DESCRIPTION
Closes #1880

## Summary
- In `renderer.ts` rally marker section, finds player base position
- Draws a dashed teal line (alpha 0.22, 8px dash/6px gap) from base to rally point
- Only renders when distance > 80px (no noise for close rallies)
- Line starts outside base radius (46px from center) and stops before rally marker

## Test plan
- [ ] Click far from base → see dashed line to rally marker
- [ ] Line updates when rally changes
- [ ] No line when rally is very close (<80px) or cleared
- [ ] Line looks reasonable at different zoom levels

🤖 Generated with [Claude Code](https://claude.com/claude-code)