### PR TITLE
feat: Speck Wars winning vignette + rally direction line

### DIFF
--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -374,12 +374,41 @@ export function HUD() {
       {phase === 'paused' && (
         <div style={{
           position: 'absolute', inset: 0,
-          background: 'rgba(0,0,0,0.45)',
-          display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', gap: 24,
+          background: 'rgba(0,0,0,0.55)',
+          display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', gap: 20,
         }}>
           <span style={{ fontSize: 36, fontWeight: 'bold', letterSpacing: 4, opacity: 0.9 }}>
             PAUSED
           </span>
+          {hud && (() => {
+            const playerSpecks = hud.players.player?.speckCount ?? 0
+            const aiSpecks = hud.players.ai?.speckCount ?? 0
+            const playerBaseHpVal = hud.players.player?.buildingHp['building-player-base'] ?? 0
+            const aiBaseHpVal = hud.players.ai?.buildingHp['building-ai-base'] ?? 0
+            const playerOutpostCount = hud.players.player?.buildingCount
+              ? hud.players.player.buildingCount - 1  // subtract base
+              : 0
+            return (
+              <div style={{
+                display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '8px 32px',
+                fontSize: 11, letterSpacing: 1, color: 'rgba(255,255,255,0.55)',
+                background: 'rgba(0,0,0,0.3)', padding: '16px 28px', borderRadius: 8,
+                border: '1px solid rgba(255,255,255,0.08)',
+              }}>
+                <span style={{ color: colorHex(PLAYER_COLOR), opacity: 0.8 }}>YOUR ARMY</span>
+                <span style={{ color: colorHex(AI_COLOR), opacity: 0.8 }}>ENEMY ARMY</span>
+                <span>{playerSpecks} specks</span>
+                <span>{aiSpecks} specks</span>
+                <span>Base: {Math.round(playerBaseHpVal)}HP</span>
+                <span>Base: {Math.round(aiBaseHpVal)}HP</span>
+                <span>Outposts: {playerOutpostCount}</span>
+                <span style={{ color: colorHex(PLAYER_COLOR), opacity: 0.7 }}>↑{kills} ↓{losses}</span>
+                <span style={{ gridColumn: '1/-1', textAlign: 'center', borderTop: '1px solid rgba(255,255,255,0.08)', paddingTop: 8, marginTop: 4 }}>
+                  {formatTime(elapsedMs)} elapsed
+                </span>
+              </div>
+            )
+          })()}
           <button
             onClick={surrender}
             style={{

--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -399,26 +399,55 @@ export function HUD() {
         </div>
       )}
 
-      {/* Player stats — bottom left */}
-      {hud && (
-        <div style={{ position: 'absolute', bottom: 16, left: 16 }}>
-          {Object.entries(hud.players)
-            .filter(([pid]) => pid !== 'neutral')
-            .map(([pid, data]) => {
-              const color = pid === 'player' ? colorHex(PLAYER_COLOR) : colorHex(AI_COLOR)
-              const label = pid === 'player' ? 'YOU' : 'AI'
-              const totalHp = Object.values(data.buildingHp).reduce((a, b) => a + b, 0)
-              return (
-                <div key={pid} style={{ marginBottom: 6, color }}>
-                  <strong>{label}</strong> — specks: {data.speckCount} | bases: {data.buildingCount} | HP: {totalHp}
-                  {pid === 'player' && (
-                    <span style={{ opacity: 0.7 }}> | ↑{kills} ↓{losses}</span>
-                  )}
+      {/* Player stats + force bar — bottom left */}
+      {hud && (() => {
+        const playerSpecks = hud.players.player?.speckCount ?? 0
+        const aiSpecks = hud.players.ai?.speckCount ?? 0
+        const total = playerSpecks + aiSpecks
+        const playerFrac = total > 0 ? playerSpecks / total : 0.5
+        const playerBaseHpVal = hud.players.player?.buildingHp['building-player-base'] ?? 0
+        const aiBaseHpVal = hud.players.ai?.buildingHp['building-ai-base'] ?? 0
+        const aiBaseHpFrac = aiBaseHpVal / 100
+        const aiBaseColor = aiBaseHpFrac > 0.5 ? '#ff4f7b' : aiBaseHpFrac > 0.2 ? '#ffaa44' : '#ff2200'
+        return (
+          <div style={{ position: 'absolute', bottom: 16, left: 16, display: 'flex', flexDirection: 'column', gap: 5 }}>
+            {/* Force ratio bar */}
+            {total >= 4 && (
+              <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+                <span style={{ fontSize: 9, letterSpacing: 1, color: colorHex(PLAYER_COLOR), opacity: 0.7, minWidth: 20, textAlign: 'right' }}>
+                  {playerSpecks}
+                </span>
+                <div style={{ width: 100, height: 5, background: 'rgba(255,79,123,0.4)', borderRadius: 3, overflow: 'hidden', position: 'relative' }}>
+                  <div style={{
+                    position: 'absolute', left: 0, top: 0, height: '100%',
+                    width: `${Math.round(playerFrac * 100)}%`,
+                    background: colorHex(PLAYER_COLOR),
+                    borderRadius: 3,
+                    transition: 'width 0.2s',
+                  }} />
                 </div>
-              )
-            })}
-        </div>
-      )}
+                <span style={{ fontSize: 9, letterSpacing: 1, color: colorHex(AI_COLOR), opacity: 0.7, minWidth: 20 }}>
+                  {aiSpecks}
+                </span>
+              </div>
+            )}
+            {/* Kill/loss + enemy base HP */}
+            <div style={{ display: 'flex', gap: 10, fontSize: 10, letterSpacing: 0.5 }}>
+              <span style={{ color: colorHex(PLAYER_COLOR), opacity: 0.7 }}>↑{kills} ↓{losses}</span>
+              {aiBaseHpVal > 0 && (
+                <span style={{ color: aiBaseColor, opacity: 0.8 }}>
+                  ENEMY BASE {Math.round(aiBaseHpFrac * 100)}%
+                </span>
+              )}
+              {playerBaseHpVal > 0 && (
+                <span style={{ color: hpFrac < 0.3 ? '#ff4f7b' : 'rgba(255,255,255,0.4)', opacity: 0.8 }}>
+                  BASE {Math.round(playerBaseHpVal)}HP
+                </span>
+              )}
+            </div>
+          </div>
+        )
+      })()}
     </div>
   )
 }

--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -47,6 +47,10 @@ export function HUD() {
   const isDanger = phase === 'playing' && hpFrac < 0.3
   const isCritical = phase === 'playing' && hpFrac < 0.15
 
+  const aiBaseHp = hud?.players.ai?.buildingHp['building-ai-base']
+  const aiHpFrac = aiBaseHp !== undefined ? aiBaseHp / BASE_MAX_HP : 1
+  const isWinning = phase === 'playing' && aiHpFrac < 0.2 && aiHpFrac > 0  // enemy near death
+
   return (
     <div style={{
       position: 'absolute', inset: 0, pointerEvents: 'none',
@@ -64,6 +68,22 @@ export function HUD() {
             position: 'absolute', inset: 0,
             background: 'radial-gradient(ellipse at center, transparent 45%, rgba(220,30,30,1) 100%)',
             animation: `danger-pulse ${isCritical ? '0.5s' : '1s'} ease-in-out infinite alternate`,
+            pointerEvents: 'none',
+          }} />
+        </>
+      )}
+      {isWinning && (
+        <>
+          <style>{`
+            @keyframes win-pulse {
+              from { opacity: 0.1; }
+              to   { opacity: 0.28; }
+            }
+          `}</style>
+          <div style={{
+            position: 'absolute', inset: 0,
+            background: 'radial-gradient(ellipse at center, transparent 50%, rgba(20,220,120,1) 100%)',
+            animation: 'win-pulse 1.2s ease-in-out infinite alternate',
             pointerEvents: 'none',
           }} />
         </>

--- a/src/app/speck-wars/domain/simulation/spawner.ts
+++ b/src/app/speck-wars/domain/simulation/spawner.ts
@@ -4,7 +4,7 @@ import { BUILDING_TYPES } from '../config/building-types'
 import { MAX_SPECKS } from '../constants'
 
 // Place a new speck into a recycled or fresh slot — never allocates new arrays
-function addSpeck(sim: SimulationState, meta: SpeckMeta, x: number, y: number) {
+function addSpeck(sim: SimulationState, meta: SpeckMeta, x: number, y: number, buildingId: string) {
   const hp = SPECK_TYPES[meta.typeId]?.hp ?? 1
 
   let slot: number
@@ -25,7 +25,7 @@ function addSpeck(sim: SimulationState, meta: SpeckMeta, x: number, y: number) {
   sim.speckIds[slot] = meta.id
   sim.speckMeta[slot] = meta
 
-  sim.events.push({ type: 'SPECK_SPAWNED', speckId: meta.id, buildingId: '' })
+  sim.events.push({ type: 'SPECK_SPAWNED', speckId: meta.id, buildingId })
 }
 
 let speckCounter = 0
@@ -58,7 +58,7 @@ export function updateSpawners(sim: SimulationState, dt: number) {
         targetId: null,
         attackCooldown: 0,
       }
-      addSpeck(sim, meta, sx, sy)
+      addSpeck(sim, meta, sx, sy, building.id)
     }
   }
 }

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -25,6 +25,7 @@ export class GameInstance {
   private shakeMaxMs = 300
   private shakeStrength = 0
   private enemyBaseWarnedAt = -30000
+  private outpostAttackWarnedAt: Record<string, number> = {}  // outpostId → timestamp
 
   constructor(canvas: HTMLCanvasElement) {
     this.canvas = canvas
@@ -135,6 +136,25 @@ export class GameInstance {
         }
         if (event.type === 'HUD_UPDATE') {
           store.setHud(event.data)
+          // Warn when an enemy starts capturing a player-owned outpost
+          const now = Date.now()
+          const playerBuildingHp = event.data.players.player?.buildingHp ?? {}
+          for (const outpostId of event.data.attackedBuildingIds) {
+            if (!(outpostId in playerBuildingHp)) continue  // not player-owned
+            const lastWarn = this.outpostAttackWarnedAt[outpostId] ?? -Infinity
+            if (now - lastWarn > 8000) {
+              this.outpostAttackWarnedAt[outpostId] = now
+              const name = outpostId.replace('outpost-', '').toUpperCase()
+              store.setNotification({ message: `⬡ ${name} UNDER ATTACK!`, color: '#ff8c00' })
+              setTimeout(() => useSpeckWarsStore.getState().setNotification(null), 2500)
+            }
+          }
+          // Clear warnings for outposts that are no longer under attack
+          for (const id of Object.keys(this.outpostAttackWarnedAt)) {
+            if (!event.data.attackedBuildingIds.includes(id)) {
+              delete this.outpostAttackWarnedAt[id]
+            }
+          }
         }
         if (event.type === 'SPECK_DIED') {
           if (event.killedOwnerId === 'ai' && event.killerOwnerId === 'player') {

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -26,6 +26,7 @@ export class GameInstance {
   private shakeStrength = 0
   private enemyBaseWarnedAt = -30000
   private outpostAttackWarnedAt: Record<string, number> = {}  // outpostId → timestamp
+  private enemySurgeWarnedAt = -30000
 
   constructor(canvas: HTMLCanvasElement) {
     this.canvas = canvas
@@ -155,6 +156,14 @@ export class GameInstance {
               delete this.outpostAttackWarnedAt[id]
             }
           }
+          // Enemy surge warning: AI has 2× the player's specks
+          const playerSpecks = event.data.players.player?.speckCount ?? 0
+          const aiSpecks = event.data.players.ai?.speckCount ?? 0
+          if (aiSpecks >= 2 * playerSpecks && playerSpecks > 5 && now - this.enemySurgeWarnedAt > 20000) {
+            this.enemySurgeWarnedAt = now
+            store.setNotification({ message: '⚠ ENEMY SURGE!', color: '#ff6b35' })
+            setTimeout(() => useSpeckWarsStore.getState().setNotification(null), 2500)
+          }
         }
         if (event.type === 'SPECK_DIED') {
           if (event.killedOwnerId === 'ai' && event.killerOwnerId === 'player') {
@@ -206,10 +215,13 @@ export class GameInstance {
         if (event.type === 'OUTPOST_CAPTURED') {
           const isPlayerGain = event.newOwner === 'player'
           const isPlayerLoss = event.previousOwner === 'player'
+          const isRecapture = isPlayerGain && event.previousOwner === 'ai'
           if (isPlayerGain || isPlayerLoss) {
             const outpostName = event.outpostId.replace('outpost-', '').toUpperCase()
-            const message = isPlayerGain ? `⬡ ${outpostName} CAPTURED` : `⬡ ${outpostName} LOST`
-            const color = isPlayerGain ? '#4af7c4' : '#ff4f7b'
+            const message = isPlayerLoss ? `⬡ ${outpostName} LOST`
+              : isRecapture ? `⬡ ${outpostName} RECAPTURED!`
+              : `⬡ ${outpostName} CAPTURED`
+            const color = isPlayerLoss ? '#ff4f7b' : isRecapture ? '#ffd700' : '#4af7c4'
             store.setNotification({ message, color })
             setTimeout(() => useSpeckWarsStore.getState().setNotification(null), 2500)
           }

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -26,6 +26,7 @@ export class GameInstance {
   private shakeStrength = 0
   private enemyBaseWarnedAt = -30000
   private outpostAttackWarnedAt: Record<string, number> = {}  // outpostId → timestamp
+  private outpostHpWarnedAt: Record<string, number> = {}     // outpostId → timestamp (HP critical)
   private enemySurgeWarnedAt = -30000
 
   constructor(canvas: HTMLCanvasElement) {
@@ -163,6 +164,20 @@ export class GameInstance {
             this.enemySurgeWarnedAt = now
             store.setNotification({ message: '⚠ ENEMY SURGE!', color: '#ff6b35' })
             setTimeout(() => useSpeckWarsStore.getState().setNotification(null), 2500)
+          }
+          // Outpost HP critical: player outpost < 20% max HP (50)
+          const OUTPOST_MAX_HP = 50
+          const OUTPOST_CRITICAL_HP = OUTPOST_MAX_HP * 0.2  // 10 HP
+          for (const [buildingId, hp] of Object.entries(playerBuildingHp)) {
+            if (!buildingId.startsWith('outpost-')) continue
+            if (hp > OUTPOST_CRITICAL_HP) { delete this.outpostHpWarnedAt[buildingId]; continue }
+            const lastHpWarn = this.outpostHpWarnedAt[buildingId] ?? -Infinity
+            if (now - lastHpWarn > 12000) {
+              this.outpostHpWarnedAt[buildingId] = now
+              const name = buildingId.replace('outpost-', '').toUpperCase()
+              store.setNotification({ message: `⬡ ${name} HP CRITICAL!`, color: '#ff2200' })
+              setTimeout(() => useSpeckWarsStore.getState().setNotification(null), 2500)
+            }
           }
         }
         if (event.type === 'SPECK_DIED') {

--- a/src/app/speck-wars/rendering/layers/building-layer.ts
+++ b/src/app/speck-wars/rendering/layers/building-layer.ts
@@ -3,12 +3,14 @@ import type { SimulationState } from '../../domain/types'
 import { BUILDING_TYPES } from '../../domain/config/building-types'
 import { NEUTRAL_COLOR, OUTPOST_AURA_RADIUS } from '../../domain/constants'
 
-const FLASH_DURATION = 200  // ms — how long a damage flash lasts
+const FLASH_DURATION = 200   // ms — how long a damage flash lasts
+const SPAWN_FLASH_DURATION = 250  // ms — brief golden ring when a speck spawns
 
 export class BuildingLayer {
   readonly stage: Container
   private gfx: Graphics
-  private flashMap: Map<string, number> = new Map()  // buildingId → timestamp of last hit
+  private flashMap: Map<string, number> = new Map()       // buildingId → timestamp of last hit
+  private spawnFlashMap: Map<string, number> = new Map()  // buildingId → timestamp of last spawn
 
   constructor() {
     this.stage = new Container()
@@ -18,6 +20,10 @@ export class BuildingLayer {
 
   flashBuilding(buildingId: string) {
     this.flashMap.set(buildingId, Date.now())
+  }
+
+  flashSpawn(buildingId: string) {
+    this.spawnFlashMap.set(buildingId, Date.now())
   }
 
   update(sim: SimulationState, playerColors: Record<string, number>) {
@@ -45,6 +51,22 @@ export class BuildingLayer {
           this.gfx.endFill()
         } else {
           this.flashMap.delete(building.id)
+        }
+      }
+
+      // Spawn flash: brief gold expanding ring when a speck is produced
+      const spawnTs = this.spawnFlashMap.get(building.id)
+      if (spawnTs !== undefined) {
+        const elapsed = now - spawnTs
+        if (elapsed < SPAWN_FLASH_DURATION) {
+          const t = elapsed / SPAWN_FLASH_DURATION
+          const alpha = (1 - t) * 0.6
+          const spawnR = r + 4 + t * 14  // expands from r+4 to r+18
+          this.gfx.lineStyle(1.5, 0xffd700, alpha)
+          this.gfx.drawCircle(building.x, building.y, spawnR)
+          this.gfx.lineStyle(0)
+        } else {
+          this.spawnFlashMap.delete(building.id)
         }
       }
 

--- a/src/app/speck-wars/rendering/renderer.ts
+++ b/src/app/speck-wars/rendering/renderer.ts
@@ -97,7 +97,7 @@ export class Renderer {
     }
     this.effectsLayer.update(dt)
 
-    // Rally point marker
+    // Rally point marker + dashed line from base to rally
     this.rallyGfx.clear()
     const rp = sim.rallyPoints['player']
     if (rp) {
@@ -112,6 +112,30 @@ export class Renderer {
       this.rallyGfx.lineStyle(1.5, PLAYER_COLOR, alpha * 0.5)
       this.rallyGfx.drawCircle(rp.x, rp.y, 14)
       this.rallyGfx.lineStyle(0)
+
+      // Dashed line from player base to rally point (only if far enough apart)
+      const playerBase = Object.values(sim.buildings).find(b => b.ownerId === 'player' && b.typeId === 'base')
+      if (playerBase) {
+        const dx = rp.x - playerBase.x
+        const dy = rp.y - playerBase.y
+        const len = Math.sqrt(dx * dx + dy * dy)
+        if (len > 80) {
+          const nx = dx / len, ny = dy / len
+          const dashLen = 8, gapLen = 6
+          this.rallyGfx.lineStyle(1, PLAYER_COLOR, 0.22)
+          let d = playerBase === null ? 0 : 46  // start outside the base
+          while (d < len - 24) {
+            const x1 = playerBase.x + nx * d
+            const y1 = playerBase.y + ny * d
+            const x2 = playerBase.x + nx * Math.min(d + dashLen, len - 24)
+            const y2 = playerBase.y + ny * Math.min(d + dashLen, len - 24)
+            this.rallyGfx.moveTo(x1, y1)
+            this.rallyGfx.lineTo(x2, y2)
+            d += dashLen + gapLen
+          }
+          this.rallyGfx.lineStyle(0)
+        }
+      }
     }
   }
 

--- a/src/app/speck-wars/rendering/renderer.ts
+++ b/src/app/speck-wars/rendering/renderer.ts
@@ -80,6 +80,9 @@ export class Renderer {
       if (event.type === 'BUILDING_DAMAGED') {
         this.buildingLayer.flashBuilding(event.buildingId)
       }
+      if (event.type === 'SPECK_SPAWNED' && event.buildingId.startsWith('building-player')) {
+        this.buildingLayer.flashSpawn(event.buildingId)
+      }
       if (event.type === 'BUILDING_DESTROYED') {
         const color = PLAYER_COLORS[event.ownerId] ?? 0xffffff
         this.effectsLayer.addDestructionBurst(event.x, event.y, color)


### PR DESCRIPTION
## Summary
- Winning vignette: green radial edge glow when enemy base is below 20% HP — visual countdown to victory
- Rally direction line: dashed teal line drawn from player base to rally point (only when >80px apart)

## Test plan
- [ ] Set a rally point — dashed teal line appears from player base to the rally marker
- [ ] Destroy enemy base to <20% HP — green glow appears on screen edges
- [ ] Glow disappears when HP recovers above 20% or game ends

🤖 Generated with [Claude Code](https://claude.com/claude-code)