### PR TITLE
feat: Speck Wars command feedback + speck composition breakdown

### DIFF
--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -388,6 +388,16 @@ export function HUD() {
             const playerOutpostCount = hud.players.player?.buildingCount
               ? hud.players.player.buildingCount - 1  // subtract base
               : 0
+            const playerTypes = hud.players.player?.speckTypes ?? {}
+            const aiTypes = hud.players.ai?.speckTypes ?? {}
+            const fmtTypes = (t: Record<string, number>) => {
+              const basic = t['basic'] ?? 0
+              const heavy = t['heavy'] ?? 0
+              if (basic === 0 && heavy === 0) return '—'
+              if (heavy === 0) return `${basic}× basic`
+              if (basic === 0) return `${heavy}× heavy`
+              return `${basic}× basic, ${heavy}× heavy`
+            }
             return (
               <div style={{
                 display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '8px 32px',
@@ -399,6 +409,8 @@ export function HUD() {
                 <span style={{ color: colorHex(AI_COLOR), opacity: 0.8 }}>ENEMY ARMY</span>
                 <span>{playerSpecks} specks</span>
                 <span>{aiSpecks} specks</span>
+                <span style={{ fontSize: 10, opacity: 0.7 }}>{fmtTypes(playerTypes)}</span>
+                <span style={{ fontSize: 10, opacity: 0.7 }}>{fmtTypes(aiTypes)}</span>
                 <span>Base: {Math.round(playerBaseHpVal)}HP</span>
                 <span>Base: {Math.round(aiBaseHpVal)}HP</span>
                 <span>Outposts: {playerOutpostCount}</span>

--- a/src/app/speck-wars/domain/simulation/tick.ts
+++ b/src/app/speck-wars/domain/simulation/tick.ts
@@ -105,18 +105,23 @@ function consumeInputs(sim: SimulationState) {
 }
 
 function emitHudUpdate(sim: SimulationState) {
-  const data: Record<string, { speckCount: number; buildingCount: number; buildingHp: Record<string, number> }> = {}
+  const data: Record<string, { speckCount: number; buildingCount: number; buildingHp: Record<string, number>; speckTypes: Record<string, number> }> = {}
   for (const [pid] of Object.entries(sim.players)) {
     const myBuildings = Object.values(sim.buildings).filter(b => b.ownerId === pid)
     let liveCount = 0
+    const speckTypes: Record<string, number> = {}
     for (let i = 0; i < sim.speckCount; i++) {
       const m = sim.speckMeta[i]
-      if (m && m.ownerId === pid) liveCount++
+      if (m && m.ownerId === pid) {
+        liveCount++
+        speckTypes[m.typeId] = (speckTypes[m.typeId] ?? 0) + 1
+      }
     }
     data[pid] = {
       speckCount: liveCount,
       buildingCount: myBuildings.length,
       buildingHp: Object.fromEntries(myBuildings.map(b => [b.id, b.hp])),
+      speckTypes,
     }
   }
   // Buildings that are owned but actively being captured by the enemy

--- a/src/app/speck-wars/domain/types.ts
+++ b/src/app/speck-wars/domain/types.ts
@@ -78,6 +78,7 @@ export interface HudData {
     speckCount: number
     buildingCount: number
     buildingHp: Record<string, number>
+    speckTypes: Record<string, number>  // typeId → count
   }>
   attackedBuildingIds: string[]
   tripleOutpostOwner: string | null  // player ID who owns all 3 outposts, or null

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -66,6 +66,9 @@ export class GameInstance {
       () => {                                              // H — cycle spawn mode
         const next = useSpeckWarsStore.getState().cycleSpawnMode()
         this.sim.inputQueue.push({ type: 'SET_SPAWN_TYPE', ownerId: 'player', speckTypeId: next })
+        const s = useSpeckWarsStore.getState()
+        s.setNotification({ message: `Spawn: ${next.toUpperCase()}`, color: next === 'heavy' ? '#ff8844' : '#4af7c4' })
+        setTimeout(() => useSpeckWarsStore.getState().setNotification(null), 1200)
       },
       () => {                                              // C — recenter camera on player base
         const base = Object.values(this.sim.buildings).find(b => b.ownerId === 'player' && b.typeId === 'base')
@@ -73,9 +76,9 @@ export class GameInstance {
         this.camera.x = this.canvas.clientWidth / 2 - base.x * this.camera.zoom
         this.camera.y = this.canvas.clientHeight / 2 - base.y * this.camera.zoom
       },
-      () => this.defend(),                                 // D — defend (rally to player base)
-      () => this.advance(),                                // A — advance to nearest non-player outpost
-      () => this.rush(),                                   // B — rush enemy base
+      () => { this.defend(); this.notify('🛡 DEFEND', '#4af7c4') },   // D — defend (rally to player base)
+      () => { this.advance(); this.notify('→ ADVANCE', '#ffd700') },  // A — advance to nearest non-player outpost
+      () => { this.rush(); this.notify('⚡ RUSH!', '#ff4f7b') },      // B — rush enemy base
     )
     this.lastTime = performance.now()
     this.loop(this.lastTime)
@@ -305,6 +308,11 @@ export class GameInstance {
 
   clearRally() {
     this.sim.rallyPoints['player'] = null
+  }
+
+  private notify(message: string, color: string) {
+    useSpeckWarsStore.getState().setNotification({ message, color })
+    setTimeout(() => useSpeckWarsStore.getState().setNotification(null), 1200)
   }
 
   getSim(): SimulationState {


### PR DESCRIPTION
## Summary
- **Command feedback**: Pressing hotkeys now shows a 1.2s notification confirming the command
  - `D` → "🛡 DEFEND" (teal)
  - `A` → "→ ADVANCE" (gold)
  - `B` → "⚡ RUSH!" (red)
  - `H` → "Spawn: HEAVY" or "Spawn: BASIC" (orange/teal)
- **Speck composition**: Pause screen now shows basic/heavy unit breakdown per army (e.g., "12× basic, 3× heavy")
  - Extends `HudData.players[id].speckTypes` with per-typeId counts
  - Displayed in the pause stats grid as a sub-row under total speck count

## Test plan
- [ ] Press D/A/B/H — confirm notification appears and auto-dismisses
- [ ] Pause mid-game — pause stats grid shows unit type breakdown for both armies
- [ ] Mixed army (basic + heavy) shows both counts; single-type army shows "N× basic"

🤖 Generated with [Claude Code](https://claude.com/claude-code)