### PR TITLE
feat: Speck Wars minimap — live battlefield overview in bottom-right corner

### DIFF
--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -1,7 +1,7 @@
 'use client'
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import { useSpeckWarsStore } from '../store'
-import { PLAYER_COLOR, AI_COLOR } from '../domain/constants'
+import { PLAYER_COLOR, AI_COLOR, WORLD_WIDTH, WORLD_HEIGHT } from '../domain/constants'
 import { getBestTime } from '../lib/personal-best'
 
 function colorHex(n: number) {
@@ -497,6 +497,87 @@ export function HUD() {
           </div>
         )
       })()}
+
+      {/* Minimap — bottom right */}
+      {hud?.minimap && phase !== 'paused' && <Minimap minimap={hud.minimap} />}
     </div>
+  )
+}
+
+const MINIMAP_SIZE = 130
+
+function Minimap({ minimap }: { minimap: NonNullable<import('../domain/types').HudData['minimap']> }) {
+  const canvasRef = useRef<HTMLCanvasElement>(null)
+
+  useEffect(() => {
+    const canvas = canvasRef.current
+    if (!canvas) return
+    const ctx = canvas.getContext('2d')
+    if (!ctx) return
+
+    const W = MINIMAP_SIZE, H = MINIMAP_SIZE
+    const scaleX = W / WORLD_WIDTH
+    const scaleY = H / WORLD_HEIGHT
+
+    ctx.clearRect(0, 0, W, H)
+
+    // Background
+    ctx.fillStyle = 'rgba(0,0,0,0.6)'
+    ctx.fillRect(0, 0, W, H)
+
+    // Specks
+    const playerHex = `#${PLAYER_COLOR.toString(16).padStart(6, '0')}`
+    const aiHex = `#${AI_COLOR.toString(16).padStart(6, '0')}`
+    for (const sp of minimap.specks) {
+      ctx.fillStyle = sp.ownerId === 'player' ? playerHex : aiHex
+      ctx.fillRect(Math.round(sp.x * scaleX) - 0.5, Math.round(sp.y * scaleY) - 0.5, 1.5, 1.5)
+    }
+
+    // Buildings
+    for (const b of minimap.buildings) {
+      const bx = b.x * scaleX, by = b.y * scaleY
+      const isBase = b.typeId === 'base'
+      const r = isBase ? 4 : 2.5
+      ctx.beginPath()
+      ctx.arc(bx, by, r, 0, Math.PI * 2)
+      ctx.fillStyle = b.ownerId === 'player' ? playerHex : b.ownerId === 'ai' ? aiHex : '#888888'
+      ctx.fill()
+      ctx.strokeStyle = 'rgba(255,255,255,0.5)'
+      ctx.lineWidth = 0.8
+      ctx.stroke()
+    }
+
+    // Rally point
+    if (minimap.rallyX !== null && minimap.rallyY !== null) {
+      const rx = minimap.rallyX * scaleX, ry = minimap.rallyY * scaleY
+      ctx.strokeStyle = playerHex
+      ctx.lineWidth = 1
+      ctx.globalAlpha = 0.8
+      ctx.beginPath()
+      ctx.moveTo(rx - 3, ry); ctx.lineTo(rx + 3, ry)
+      ctx.moveTo(rx, ry - 3); ctx.lineTo(rx, ry + 3)
+      ctx.stroke()
+      ctx.globalAlpha = 1
+    }
+
+    // Border
+    ctx.strokeStyle = 'rgba(255,255,255,0.15)'
+    ctx.lineWidth = 1
+    ctx.strokeRect(0.5, 0.5, W - 1, H - 1)
+  }, [minimap])
+
+  return (
+    <canvas
+      ref={canvasRef}
+      width={MINIMAP_SIZE}
+      height={MINIMAP_SIZE}
+      style={{
+        position: 'absolute',
+        bottom: 16,
+        right: 16,
+        borderRadius: 4,
+        imageRendering: 'pixelated',
+      }}
+    />
   )
 }

--- a/src/app/speck-wars/domain/simulation/tick.ts
+++ b/src/app/speck-wars/domain/simulation/tick.ts
@@ -135,5 +135,16 @@ function emitHudUpdate(sim: SimulationState) {
   }
 
   const dominationProgress = tripleOutpostOwner ? Math.min(1, sim.dominationTimer / DOMINATION_TIME) : null
-  sim.events.push({ type: 'HUD_UPDATE', data: { players: data, attackedBuildingIds, tripleOutpostOwner, dominationProgress } })
+
+  // Minimap: sample every 8th speck, capped at 300
+  const minimapSpecks: Array<{ x: number; y: number; ownerId: string }> = []
+  const step = Math.max(1, Math.floor(sim.speckCount / 300)) * 8
+  for (let i = 0; i < sim.speckCount && minimapSpecks.length < 300; i += step) {
+    const m = sim.speckMeta[i]
+    if (m) minimapSpecks.push({ x: sim.speckX[i], y: sim.speckY[i], ownerId: m.ownerId })
+  }
+  const minimapBuildings = Object.values(sim.buildings).map(b => ({ x: b.x, y: b.y, ownerId: b.ownerId, typeId: b.typeId }))
+  const rp = sim.rallyPoints['player']
+
+  sim.events.push({ type: 'HUD_UPDATE', data: { players: data, attackedBuildingIds, tripleOutpostOwner, dominationProgress, minimap: { specks: minimapSpecks, buildings: minimapBuildings, rallyX: rp?.x ?? null, rallyY: rp?.y ?? null } } })
 }

--- a/src/app/speck-wars/domain/types.ts
+++ b/src/app/speck-wars/domain/types.ts
@@ -82,4 +82,10 @@ export interface HudData {
   attackedBuildingIds: string[]
   tripleOutpostOwner: string | null  // player ID who owns all 3 outposts, or null
   dominationProgress: number | null  // 0..1 fraction of DOMINATION_TIME elapsed; null if no triple holder
+  minimap: {
+    specks: Array<{ x: number; y: number; ownerId: string }>  // sampled subset
+    buildings: Array<{ x: number; y: number; ownerId: string; typeId: string }>
+    rallyX: number | null
+    rallyY: number | null
+  }
 }


### PR DESCRIPTION
## Summary
Adds a 130×130px minimap canvas to the bottom-right corner of the HUD (hidden while paused).

**What it shows:**
- Sampled specks as 1.5px colored dots (player=teal, AI=pink), up to 300 sampled per tick
- Buildings as circles (base=4px, outpost=2.5px) with owner color + white outline
- Rally point as a small crosshair

**Implementation:**
- Extended `HudData.minimap` with `{ specks, buildings, rallyX, rallyY }` — populated every HUD tick (every 10 sim ticks, ~83ms)
- Specks sampled at adaptive stride (every 8th × scale factor, capped at 300) so performance is bounded regardless of army size
- Separate `Minimap` React component draws to a `<canvas>` ref on each HUD update

## Test plan
- [ ] Minimap appears in bottom-right during play
- [ ] Minimap hides when paused
- [ ] Player specks show as teal dots, AI as pink
- [ ] Buildings visible as circles with correct owner color
- [ ] Rally point shows as crosshair when set, disappears when cleared
- [ ] No visible performance impact during large battles

🤖 Generated with [Claude Code](https://claude.com/claude-code)