### PR TITLE
feat: Speck Wars domination progress bar — visual fill during triple outpost hold

### DIFF
--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -283,10 +283,24 @@ export function HUD() {
             }}>
               {isPlayer ? '⬡⬡⬡ TRIPLE CONTROL — SPAWN ×2' : '⬡⬡⬡ ENEMY TRIPLE CONTROL'}
             </span>
-            {secLeft !== null && (
-              <span style={{ fontSize: 10, letterSpacing: 1, color, opacity: 0.7 }}>
-                {isPlayer ? `DOMINATION in ${secLeft}s` : `ENEMY DOMINATES in ${secLeft}s`}
-              </span>
+            {hud.dominationProgress !== null && (
+              <>
+                <div style={{ width: 160, height: 3, background: 'rgba(255,255,255,0.12)', borderRadius: 2, overflow: 'hidden' }}>
+                  <div style={{
+                    height: '100%',
+                    width: `${Math.round(hud.dominationProgress * 100)}%`,
+                    background: color,
+                    borderRadius: 2,
+                    boxShadow: `0 0 6px ${color}`,
+                    transition: 'width 0.3s',
+                  }} />
+                </div>
+                {secLeft !== null && (
+                  <span style={{ fontSize: 10, letterSpacing: 1, color, opacity: 0.7 }}>
+                    {isPlayer ? `DOMINATION in ${secLeft}s` : `ENEMY DOMINATES in ${secLeft}s`}
+                  </span>
+                )}
+              </>
             )}
           </div>
         )


### PR DESCRIPTION
## Summary
When a player holds all 3 outposts, the domination countdown indicator now includes a 160px progress bar that fills over 60 seconds — glowing gold (player) or red (enemy).

Previously: just text ("DOMINATION in 42s")
Now: text + a glowing fill bar showing how far along the 60s countdown is

## Test plan
- [ ] Capture all 3 outposts — gold bar appears and fills over 60s
- [ ] Lose an outpost — bar disappears (domination resets)
- [ ] AI holds all 3 — pink/red bar fills
- [ ] Bar reaches 100% fill → game ends by domination

🤖 Generated with [Claude Code](https://claude.com/claude-code)