### PR TITLE
feat: Speck Wars minimap click-to-rally — click minimap to set world rally point

### DIFF
--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -520,6 +520,16 @@ const MINIMAP_SIZE = 130
 
 function Minimap({ minimap }: { minimap: NonNullable<import('../domain/types').HudData['minimap']> }) {
   const canvasRef = useRef<HTMLCanvasElement>(null)
+  const setPendingRally = useSpeckWarsStore(s => s.setPendingRally)
+
+  const handleClick = (e: React.MouseEvent<HTMLCanvasElement>) => {
+    const rect = (e.target as HTMLCanvasElement).getBoundingClientRect()
+    const cx = e.clientX - rect.left
+    const cy = e.clientY - rect.top
+    const wx = (cx / MINIMAP_SIZE) * WORLD_WIDTH
+    const wy = (cy / MINIMAP_SIZE) * WORLD_HEIGHT
+    setPendingRally({ x: wx, y: wy })
+  }
 
   useEffect(() => {
     const canvas = canvasRef.current
@@ -583,12 +593,15 @@ function Minimap({ minimap }: { minimap: NonNullable<import('../domain/types').H
       ref={canvasRef}
       width={MINIMAP_SIZE}
       height={MINIMAP_SIZE}
+      onClick={handleClick}
       style={{
         position: 'absolute',
         bottom: 16,
         right: 16,
         borderRadius: 4,
         imageRendering: 'pixelated',
+        cursor: 'crosshair',
+        pointerEvents: 'auto',
       }}
     />
   )

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -107,6 +107,17 @@ export class GameInstance {
     this.lastTime = now
 
     const store = useSpeckWarsStore.getState()
+
+    // Consume pending rally from minimap click
+    if (store.pendingRally) {
+      const { x, y } = store.pendingRally
+      store.setPendingRally(null)
+      if (store.phase === 'playing') {
+        this.sim.inputQueue.push({ type: 'RALLY', ownerId: 'player', x, y })
+        this.renderer.showRallyPing(x, y)
+      }
+    }
+
     if (store.phase === 'playing') {
       const scaledDt = dt * store.speed
       this.elapsedMs += scaledDt

--- a/src/app/speck-wars/store.ts
+++ b/src/app/speck-wars/store.ts
@@ -9,6 +9,8 @@ interface SpeckWarsStore {
   phase: GamePhase
   setPhase: (phase: GamePhase) => void
   togglePause: () => void
+  pendingRally: { x: number; y: number } | null
+  setPendingRally: (pt: { x: number; y: number } | null) => void
   winnerId: string | null
   setWinnerId: (id: string) => void
   victoryType: 'destruction' | 'domination' | null
@@ -41,6 +43,8 @@ export const useSpeckWarsStore = create<SpeckWarsStore>()(set => ({
   togglePause: () => set(s => ({
     phase: s.phase === 'playing' ? 'paused' : s.phase === 'paused' ? 'playing' : s.phase,
   })),
+  pendingRally: null,
+  setPendingRally: pt => set({ pendingRally: pt }),
   winnerId: null,
   setWinnerId: winnerId => set({ winnerId }),
   victoryType: null,


### PR DESCRIPTION
## Summary
Clicking the minimap now sets the player's rally point at the corresponding world position.

**Implementation:**
- Added `pendingRally: { x, y } | null` + `setPendingRally` to the Zustand store
- Minimap canvas gets `onClick` handler that converts canvas pixel coords to world coords (`wx = (cx/130) * 3000`)
- `GameInstance.loop()` checks `store.pendingRally` each frame, consumes it, dispatches `RALLY` input event + shows rally ping animation
- Canvas gets `cursor: crosshair` and `pointerEvents: auto` to signal interactivity

**Scope:** The help text already said "Minimap — click to rally" so this completes that promise.

## Test plan
- [ ] Click minimap during play — rally marker appears at clicked location in world
- [ ] Rally ping animation fires at the world location
- [ ] Clicking different minimap locations moves the rally point
- [ ] Click during pause is ignored (phase guard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)