### PR TITLE
feat: Speck Wars capture progress bars under outpost dots

### DIFF
--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -226,12 +226,14 @@ export function HUD() {
       {hud && (() => {
         const OUTPOST_IDS = ['outpost-top', 'outpost-left', 'outpost-right'] as const
         const attacked = new Set(hud.attackedBuildingIds ?? [])
+        const captureInfo = hud.captureInfo ?? {}
         const dots = OUTPOST_IDS.map(id => {
           const isPlayerOwned = hud.players.player?.buildingHp[id] !== undefined
           const isAiOwned = hud.players.ai?.buildingHp[id] !== undefined
           const isUnderAttack = attacked.has(id)
           const color = isPlayerOwned ? '#4af7c4' : isAiOwned ? '#ff4f7b' : '#888888'
-          return { color, isUnderAttack, isPlayerOwned }
+          const cap = captureInfo[id] ?? null
+          return { color, isUnderAttack, isPlayerOwned, cap }
         })
         const playerCount = dots.filter(d => d.isPlayerOwned).length
         return (
@@ -251,15 +253,28 @@ export function HUD() {
               <span style={{ fontSize: 10, letterSpacing: 1, opacity: 0.5, marginRight: 4 }}>
                 OUTPOSTS {playerCount}/{OUTPOST_IDS.length}
               </span>
-              {dots.map(({ color, isUnderAttack, isPlayerOwned }, i) => (
-                <div key={i} style={{
-                  width: 10, height: 10,
-                  borderRadius: '50%',
-                  background: isUnderAttack && isPlayerOwned ? '#ff6b35' : color,
-                  boxShadow: color !== '#888888' ? `0 0 6px ${isUnderAttack && isPlayerOwned ? '#ff6b35' : color}` : 'none',
-                  animation: isUnderAttack && isPlayerOwned ? 'outpost-alert 0.6s ease-in-out infinite' : 'none',
-                }} />
-              ))}
+              {dots.map(({ color, isUnderAttack, isPlayerOwned, cap }, i) => {
+                const capColor = cap?.side === 'player' ? '#4af7c4' : '#ff4f7b'
+                return (
+                  <div key={i} style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 2 }}>
+                    <div style={{
+                      width: 10, height: 10,
+                      borderRadius: '50%',
+                      background: isUnderAttack && isPlayerOwned ? '#ff6b35' : color,
+                      boxShadow: color !== '#888888' ? `0 0 6px ${isUnderAttack && isPlayerOwned ? '#ff6b35' : color}` : 'none',
+                      animation: isUnderAttack && isPlayerOwned ? 'outpost-alert 0.6s ease-in-out infinite' : 'none',
+                    }} />
+                    {cap && cap.progress > 0 && (
+                      <div style={{ width: 14, height: 2, background: 'rgba(255,255,255,0.15)', borderRadius: 1 }}>
+                        <div style={{
+                          width: `${Math.round(cap.progress * 100)}%`,
+                          height: '100%', background: capColor, borderRadius: 1,
+                        }} />
+                      </div>
+                    )}
+                  </div>
+                )
+              })}
             </div>
           </>
         )

--- a/src/app/speck-wars/domain/simulation/tick.ts
+++ b/src/app/speck-wars/domain/simulation/tick.ts
@@ -141,6 +141,14 @@ function emitHudUpdate(sim: SimulationState) {
 
   const dominationProgress = tripleOutpostOwner ? Math.min(1, sim.dominationTimer / DOMINATION_TIME) : null
 
+  // Capture progress for each outpost
+  const captureInfo: Record<string, { progress: number; side: string } | null> = {}
+  for (const o of outposts) {
+    captureInfo[o.id] = (o.captureProgress && o.captureSide)
+      ? { progress: o.captureProgress, side: o.captureSide }
+      : null
+  }
+
   // Minimap: sample every 8th speck, capped at 300
   const minimapSpecks: Array<{ x: number; y: number; ownerId: string }> = []
   const step = Math.max(1, Math.floor(sim.speckCount / 300)) * 8
@@ -151,5 +159,5 @@ function emitHudUpdate(sim: SimulationState) {
   const minimapBuildings = Object.values(sim.buildings).map(b => ({ x: b.x, y: b.y, ownerId: b.ownerId, typeId: b.typeId }))
   const rp = sim.rallyPoints['player']
 
-  sim.events.push({ type: 'HUD_UPDATE', data: { players: data, attackedBuildingIds, tripleOutpostOwner, dominationProgress, minimap: { specks: minimapSpecks, buildings: minimapBuildings, rallyX: rp?.x ?? null, rallyY: rp?.y ?? null } } })
+  sim.events.push({ type: 'HUD_UPDATE', data: { players: data, attackedBuildingIds, tripleOutpostOwner, dominationProgress, captureInfo, minimap: { specks: minimapSpecks, buildings: minimapBuildings, rallyX: rp?.x ?? null, rallyY: rp?.y ?? null } } })
 }

--- a/src/app/speck-wars/domain/types.ts
+++ b/src/app/speck-wars/domain/types.ts
@@ -83,6 +83,7 @@ export interface HudData {
   attackedBuildingIds: string[]
   tripleOutpostOwner: string | null  // player ID who owns all 3 outposts, or null
   dominationProgress: number | null  // 0..1 fraction of DOMINATION_TIME elapsed; null if no triple holder
+  captureInfo: Record<string, { progress: number; side: string } | null>  // outpostId → active capture
   minimap: {
     specks: Array<{ x: number; y: number; ownerId: string }>  // sampled subset
     buildings: Array<{ x: number; y: number; ownerId: string; typeId: string }>


### PR DESCRIPTION
## Summary
Adds a thin 14×2px progress bar below each outpost ownership dot showing live capture progress.

- Colored by who's capturing: teal if player is taking it, pink if AI is taking it
- Only appears when `captureProgress > 0` (actively being captured)
- Disappears once capture completes

**Also includes minimap data from previous merge (conflicts resolved).**

## Test plan
- [ ] Capture an outpost — progress bar appears under its dot in teal
- [ ] Let AI capture an outpost — progress bar appears in pink
- [ ] Bar fills as capture progresses and disappears after capture completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)