### PR TITLE
feat: Speck Wars end screen shows win streak after victory

### DIFF
--- a/src/app/speck-wars/components/phase-router.tsx
+++ b/src/app/speck-wars/components/phase-router.tsx
@@ -197,6 +197,11 @@ export function PhaseRouter({ children }: { children: React.ReactNode }) {
             NEW BEST TIME
           </div>
         )}
+        {won && winStreak >= 2 && (
+          <div style={{ color: '#ffd700', fontSize: 13, letterSpacing: 2 }}>
+            🔥 {winStreak}-WIN STREAK
+          </div>
+        )}
 
         <div style={{ display: 'flex', gap: 24, alignItems: 'center', color: 'rgba(255,255,255,0.7)', fontSize: 16 }}>
           <span>⏱ {timeStr}</span>


### PR DESCRIPTION
## Summary
When winning a game, if the player is on a streak of 2+ wins, the victory screen now shows "🔥 N-WIN STREAK" in gold below the stars/new-best display.

Previously: streak was only shown on the menu screen (before starting a game)  
Now: also shown on the victory screen as immediate positive feedback

## Test plan
- [ ] Win 2 games in a row → victory screen shows "🔥 2-WIN STREAK"
- [ ] Single win with no streak → no streak badge shown
- [ ] Defeat screen → no streak badge (streak already reset to 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)