### PR TITLE
feat: Speck Wars production rate in pause screen stats

### DIFF
--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -447,6 +447,14 @@ export function HUD() {
               if (basic === 0) return `${heavy}× heavy`
               return `${basic}× basic, ${heavy}× heavy`
             }
+            // Production rate estimate
+            const BASE_MS = spawnMode === 'heavy' ? 1800 : 800
+            const OUTPOST_MS = 1800
+            const playerTriple = hud.tripleOutpostOwner === 'player'
+            const aiOutpostCount = Math.max(0, (hud.players.ai?.buildingCount ?? 0) - 1)
+            const aiTriple = hud.tripleOutpostOwner === 'ai'
+            const playerProd = ((1000/BASE_MS) + playerOutpostCount * (1000/OUTPOST_MS)) * (playerTriple ? 2 : 1)
+            const aiProd = ((1000/800) + aiOutpostCount * (1000/OUTPOST_MS)) * (aiTriple ? 2 : 1)
             return (
               <div style={{
                 display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '8px 32px',
@@ -460,6 +468,8 @@ export function HUD() {
                 <span>{aiSpecks} specks</span>
                 <span style={{ fontSize: 10, opacity: 0.7 }}>{fmtTypes(playerTypes)}</span>
                 <span style={{ fontSize: 10, opacity: 0.7 }}>{fmtTypes(aiTypes)}</span>
+                <span style={{ fontSize: 10, opacity: 0.6 }}>~{playerProd.toFixed(1)}/s prod</span>
+                <span style={{ fontSize: 10, opacity: 0.6 }}>~{aiProd.toFixed(1)}/s prod</span>
                 <span>Base: {Math.round(playerBaseHpVal)}HP</span>
                 <span>Base: {Math.round(aiBaseHpVal)}HP</span>
                 <span>Outposts: {playerOutpostCount}</span>


### PR DESCRIPTION
## Summary
The pause screen stats grid now shows estimated production rate (specks per second) for both armies.

Formula:
- Base: 1.25/s (basic) or 0.56/s (heavy mode)
- Each outpost: +0.56/s
- Triple outpost bonus: ×2 total rate

Example row: "~1.8/s prod" / "~2.4/s prod"

This helps players understand at a glance whether they're in a production deficit and should reconsider outpost control.

## Test plan
- [ ] Pause mid-game — production rate row appears below speck composition
- [ ] Switch to heavy spawn mode → player prod rate drops (~0.56 base instead of 1.25)
- [ ] Capture outpost → prod rate increases
- [ ] Triple outpost → rate doubles

🤖 Generated with [Claude Code](https://claude.com/claude-code)