### PR TITLE
refactor(speck-wars): remove duplicate minimap from HUD

### DIFF
--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -1,7 +1,7 @@
 'use client'
-import { useState, useEffect, useRef } from 'react'
+import { useState, useEffect } from 'react'
 import { useSpeckWarsStore } from '../store'
-import { PLAYER_COLOR, AI_COLOR, WORLD_WIDTH, WORLD_HEIGHT } from '../domain/constants'
+import { PLAYER_COLOR, AI_COLOR } from '../domain/constants'
 import { getBestTime } from '../lib/personal-best'
 
 function colorHex(n: number) {
@@ -539,99 +539,6 @@ export function HUD() {
         )
       })()}
 
-      {/* Minimap — bottom right */}
-      {hud?.minimap && phase !== 'paused' && <Minimap minimap={hud.minimap} />}
     </div>
-  )
-}
-
-const MINIMAP_SIZE = 130
-
-function Minimap({ minimap }: { minimap: NonNullable<import('../domain/types').HudData['minimap']> }) {
-  const canvasRef = useRef<HTMLCanvasElement>(null)
-  const setPendingRally = useSpeckWarsStore(s => s.setPendingRally)
-
-  const handleClick = (e: React.MouseEvent<HTMLCanvasElement>) => {
-    const rect = (e.target as HTMLCanvasElement).getBoundingClientRect()
-    const cx = e.clientX - rect.left
-    const cy = e.clientY - rect.top
-    const wx = (cx / MINIMAP_SIZE) * WORLD_WIDTH
-    const wy = (cy / MINIMAP_SIZE) * WORLD_HEIGHT
-    setPendingRally({ x: wx, y: wy })
-  }
-
-  useEffect(() => {
-    const canvas = canvasRef.current
-    if (!canvas) return
-    const ctx = canvas.getContext('2d')
-    if (!ctx) return
-
-    const W = MINIMAP_SIZE, H = MINIMAP_SIZE
-    const scaleX = W / WORLD_WIDTH
-    const scaleY = H / WORLD_HEIGHT
-
-    ctx.clearRect(0, 0, W, H)
-
-    // Background
-    ctx.fillStyle = 'rgba(0,0,0,0.6)'
-    ctx.fillRect(0, 0, W, H)
-
-    // Specks
-    const playerHex = `#${PLAYER_COLOR.toString(16).padStart(6, '0')}`
-    const aiHex = `#${AI_COLOR.toString(16).padStart(6, '0')}`
-    for (const sp of minimap.specks) {
-      ctx.fillStyle = sp.ownerId === 'player' ? playerHex : aiHex
-      ctx.fillRect(Math.round(sp.x * scaleX) - 0.5, Math.round(sp.y * scaleY) - 0.5, 1.5, 1.5)
-    }
-
-    // Buildings
-    for (const b of minimap.buildings) {
-      const bx = b.x * scaleX, by = b.y * scaleY
-      const isBase = b.typeId === 'base'
-      const r = isBase ? 4 : 2.5
-      ctx.beginPath()
-      ctx.arc(bx, by, r, 0, Math.PI * 2)
-      ctx.fillStyle = b.ownerId === 'player' ? playerHex : b.ownerId === 'ai' ? aiHex : '#888888'
-      ctx.fill()
-      ctx.strokeStyle = 'rgba(255,255,255,0.5)'
-      ctx.lineWidth = 0.8
-      ctx.stroke()
-    }
-
-    // Rally point
-    if (minimap.rallyX !== null && minimap.rallyY !== null) {
-      const rx = minimap.rallyX * scaleX, ry = minimap.rallyY * scaleY
-      ctx.strokeStyle = playerHex
-      ctx.lineWidth = 1
-      ctx.globalAlpha = 0.8
-      ctx.beginPath()
-      ctx.moveTo(rx - 3, ry); ctx.lineTo(rx + 3, ry)
-      ctx.moveTo(rx, ry - 3); ctx.lineTo(rx, ry + 3)
-      ctx.stroke()
-      ctx.globalAlpha = 1
-    }
-
-    // Border
-    ctx.strokeStyle = 'rgba(255,255,255,0.15)'
-    ctx.lineWidth = 1
-    ctx.strokeRect(0.5, 0.5, W - 1, H - 1)
-  }, [minimap])
-
-  return (
-    <canvas
-      ref={canvasRef}
-      width={MINIMAP_SIZE}
-      height={MINIMAP_SIZE}
-      onClick={handleClick}
-      style={{
-        position: 'absolute',
-        bottom: 16,
-        right: 16,
-        borderRadius: 4,
-        imageRendering: 'pixelated',
-        cursor: 'crosshair',
-        pointerEvents: 'auto',
-      }}
-    />
   )
 }

--- a/src/app/speck-wars/domain/simulation/tick.ts
+++ b/src/app/speck-wars/domain/simulation/tick.ts
@@ -149,15 +149,5 @@ function emitHudUpdate(sim: SimulationState) {
       : null
   }
 
-  // Minimap: sample every 8th speck, capped at 300
-  const minimapSpecks: Array<{ x: number; y: number; ownerId: string }> = []
-  const step = Math.max(1, Math.floor(sim.speckCount / 300)) * 8
-  for (let i = 0; i < sim.speckCount && minimapSpecks.length < 300; i += step) {
-    const m = sim.speckMeta[i]
-    if (m) minimapSpecks.push({ x: sim.speckX[i], y: sim.speckY[i], ownerId: m.ownerId })
-  }
-  const minimapBuildings = Object.values(sim.buildings).map(b => ({ x: b.x, y: b.y, ownerId: b.ownerId, typeId: b.typeId }))
-  const rp = sim.rallyPoints['player']
-
-  sim.events.push({ type: 'HUD_UPDATE', data: { players: data, attackedBuildingIds, tripleOutpostOwner, dominationProgress, captureInfo, minimap: { specks: minimapSpecks, buildings: minimapBuildings, rallyX: rp?.x ?? null, rallyY: rp?.y ?? null } } })
+  sim.events.push({ type: 'HUD_UPDATE', data: { players: data, attackedBuildingIds, tripleOutpostOwner, dominationProgress, captureInfo } })
 }

--- a/src/app/speck-wars/domain/types.ts
+++ b/src/app/speck-wars/domain/types.ts
@@ -84,10 +84,4 @@ export interface HudData {
   tripleOutpostOwner: string | null  // player ID who owns all 3 outposts, or null
   dominationProgress: number | null  // 0..1 fraction of DOMINATION_TIME elapsed; null if no triple holder
   captureInfo: Record<string, { progress: number; side: string } | null>  // outpostId → active capture
-  minimap: {
-    specks: Array<{ x: number; y: number; ownerId: string }>  // sampled subset
-    buildings: Array<{ x: number; y: number; ownerId: string; typeId: string }>
-    rallyX: number | null
-    rallyY: number | null
-  }
 }

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -108,16 +108,6 @@ export class GameInstance {
 
     const store = useSpeckWarsStore.getState()
 
-    // Consume pending rally from minimap click
-    if (store.pendingRally) {
-      const { x, y } = store.pendingRally
-      store.setPendingRally(null)
-      if (store.phase === 'playing') {
-        this.sim.inputQueue.push({ type: 'RALLY', ownerId: 'player', x, y })
-        this.renderer.showRallyPing(x, y)
-      }
-    }
-
     if (store.phase === 'playing') {
       const scaledDt = dt * store.speed
       this.elapsedMs += scaledDt

--- a/src/app/speck-wars/store.ts
+++ b/src/app/speck-wars/store.ts
@@ -9,8 +9,6 @@ interface SpeckWarsStore {
   phase: GamePhase
   setPhase: (phase: GamePhase) => void
   togglePause: () => void
-  pendingRally: { x: number; y: number } | null
-  setPendingRally: (pt: { x: number; y: number } | null) => void
   winnerId: string | null
   setWinnerId: (id: string) => void
   victoryType: 'destruction' | 'domination' | null
@@ -43,8 +41,6 @@ export const useSpeckWarsStore = create<SpeckWarsStore>()(set => ({
   togglePause: () => set(s => ({
     phase: s.phase === 'playing' ? 'paused' : s.phase === 'paused' ? 'playing' : s.phase,
   })),
-  pendingRally: null,
-  setPendingRally: pt => set({ pendingRally: pt }),
   winnerId: null,
   setWinnerId: winnerId => set({ winnerId }),
   victoryType: null,


### PR DESCRIPTION
## Summary
- `SpeckWarsGame.tsx` already renders the superior `Minimap` component (160×160, direct sim access, viewport rect, AI rally crosshair, HP rings around buildings) at `bottom:16, right:16`
- PR #1890 added a second inline `Minimap` inside `hud.tsx` (130×130, HUD-event based with sampling lag) at the same position, causing visual overlap
- This PR removes the duplicate: inline `Minimap` function, its render call, `minimap` field from `HudData`, minimap sampling in `emitHudUpdate`, and the `pendingRally` store bridge (the real minimap calls `game.rally()` directly)

## Test plan
- [ ] Launch game — single minimap visible at bottom-right (no overlap)
- [ ] Click minimap to rally specks (works via `components/minimap.tsx` direct path)
- [ ] TypeScript: `npx tsc --noEmit` passes with zero errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)