### PR TITLE
feat(speck-wars): motion trail effect on fast-moving specks

### DIFF
--- a/src/app/speck-wars/rendering/layers/speck-layer.ts
+++ b/src/app/speck-wars/rendering/layers/speck-layer.ts
@@ -89,6 +89,23 @@ export class SpeckLayer {
           this.gfx.drawCircle(sim.speckX[i], sim.speckY[i], 2)
           this.gfx.lineStyle(0)
         }
+
+        // Motion trail: 3 fading dots extrapolated backwards from velocity
+        const vx = sim.speckVx[i], vy = sim.speckVy[i]
+        if (vx * vx + vy * vy > 900) {  // only when moving faster than ~30 px/s
+          const color = this.playerColors[ownerId] ?? 0xffffff
+          const baseAlpha = spriteList[j].alpha
+          const trailAlphas = [0.18, 0.09, 0.04] as const
+          for (let t = 1; t <= 3; t++) {
+            this.gfx.beginFill(color, baseAlpha * trailAlphas[t - 1])
+            this.gfx.drawCircle(
+              sim.speckX[i] - vx * (t * 0.018),
+              sim.speckY[i] - vy * (t * 0.018),
+              1.2,
+            )
+            this.gfx.endFill()
+          }
+        }
       }
 
       // Hide excess sprites


### PR DESCRIPTION
## Summary
- Adds motion trails to fast-moving specks using velocity extrapolation
- Supersedes #1901 which conflicted with #1900 (both modified speck-layer.ts)
- This branch is based on the post-#1900 feat/1858 and adds trails on top of the heavy-ring Graphics overlay already there

## Changes
Three fading dots drawn behind each fast-moving speck (speed > ~30 px/s), alpha 0.18 → 0.09 → 0.04, extrapolated backwards from `speckVx[i]`/`speckVy[i]`. No per-frame history buffer needed.

## Test plan
- [ ] Rushing armies leave visible trails
- [ ] Idle/attacking specks have no trail
- [ ] Heavy specks show both the inner ring AND trails
- [ ] No performance regression at 200+ specks

🤖 Generated with [Claude Code](https://claude.com/claude-code)