### PR TITLE
feat(speck-wars): AI defensive rallying and counter-spawn behavior

### DIFF
--- a/src/app/speck-wars/domain/ai/ai-controller.ts
+++ b/src/app/speck-wars/domain/ai/ai-controller.ts
@@ -79,6 +79,28 @@ export class AIController {
 
     this.decisionCount++
 
+    // Counter-spawn (non-aggressive only): mirror player's heavy ratio
+    if (!this.aggressive) {
+      let playerHeavy = 0, playerBasic = 0
+      for (let i = 0; i < sim.speckCount; i++) {
+        const m = sim.speckMeta[i]
+        if (!m || m.ownerId === this.playerId || m.ownerId === 'neutral') continue
+        if (m.typeId === 'heavy') playerHeavy++
+        else playerBasic++
+      }
+      const playerTotal = playerHeavy + playerBasic
+      const playerHeavyFrac = playerTotal > 0 ? playerHeavy / playerTotal : 0
+      const wantHeavy = playerHeavyFrac > 0.55
+      const wantBasic = playerHeavyFrac < 0.30
+      if (wantHeavy && this.spawnMode !== 'heavy') {
+        this.spawnMode = 'heavy'
+        sim.inputQueue.push({ type: 'SET_SPAWN_TYPE', ownerId: this.playerId, speckTypeId: 'heavy' })
+      } else if (wantBasic && this.spawnMode !== 'basic') {
+        this.spawnMode = 'basic'
+        sim.inputQueue.push({ type: 'SET_SPAWN_TYPE', ownerId: this.playerId, speckTypeId: 'basic' })
+      }
+    }
+
     // Hard/Brutal mode: vary spawn type to add unpredictability
     if (this.aggressive) {
       this.spawnModeCountdown--
@@ -95,6 +117,19 @@ export class AIController {
 
     // Hard mode: every 4th decision, rush player base directly (pressure waves)
     const forceBaseRush = this.aggressive && this.decisionCount % 4 === 0
+
+    // Defensive rally: when AI base is low HP, sometimes pull back to defend
+    const myBaseHpFrac = (myBase?.hp ?? 100) / (myBase?.maxHp ?? 100)
+    if (!forceBaseRush && myBaseHpFrac < 0.6 && myBase) {
+      // Aggressive AI defends reluctantly; easy/medium AI defends more readily
+      const defendChance = this.aggressive
+        ? (myBaseHpFrac < 0.3 ? 0.35 : 0.15)
+        : (myBaseHpFrac < 0.3 ? 0.70 : 0.45)
+      if (Math.random() < defendChance) {
+        sim.inputQueue.push({ type: 'RALLY', ownerId: this.playerId, x: myBase.x, y: myBase.y })
+        return
+      }
+    }
 
     // Priority 1 (always): recapture player-held outpost
     // Priority 2: capture neutral outpost


### PR DESCRIPTION
## Summary
Two improvements to make the AI feel more reactive and tactical:

**1. Defensive rallying** — AI no longer blindly pushes forward when its base is under attack
- When AI base HP < 60%, the AI sometimes rallies back to defend
- Easy/Medium: 45% defend chance (rising to 70% when below 30% HP) — more panicky
- Hard/Brutal: 15% / 35% — stays aggressive but will occasionally retreat
- Hard mode force-rush ticks (every 4th decision) always override defense

**2. Counter-spawn (easy/medium only)** — AI mirrors player army composition
- If player has >55% heavy specks, AI switches to heavy to counter
- If player drops below 30% heavy, AI switches back to basic
- Hard/Brutal keeps its existing random spawn-variation logic (unpredictable by design)

## Why it matters
Previously the AI was a pure aggressor — it would keep sending specks forward even as its base burned. Now on easy/medium it will react defensively, giving players a more dynamic back-and-forth. On hard/brutal the AI remains relentlessly aggressive but still occasionally panics.

## Test plan
- [ ] Easy/Medium: push to AI base hard — watch AI rally back to defend rather than continuing to attack
- [ ] Switch to heavy spawn mode — on easy/medium, AI eventually mirrors with heavy
- [ ] Hard mode: AI defends much less; force-rush waves continue uninterrupted
- [ ] No TypeScript errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)