### PR TITLE
feat(speck-wars): HP bars on outpost dots in HUD

### DIFF
--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -227,13 +227,18 @@ export function HUD() {
         const OUTPOST_IDS = ['outpost-top', 'outpost-left', 'outpost-right'] as const
         const attacked = new Set(hud.attackedBuildingIds ?? [])
         const captureInfo = hud.captureInfo ?? {}
+        const OUTPOST_MAX_HP = 50
         const dots = OUTPOST_IDS.map(id => {
           const isPlayerOwned = hud.players.player?.buildingHp[id] !== undefined
           const isAiOwned = hud.players.ai?.buildingHp[id] !== undefined
           const isUnderAttack = attacked.has(id)
           const color = isPlayerOwned ? '#4af7c4' : isAiOwned ? '#ff4f7b' : '#888888'
           const cap = captureInfo[id] ?? null
-          return { color, isUnderAttack, isPlayerOwned, cap }
+          const hp = isPlayerOwned ? hud.players.player?.buildingHp[id]
+            : isAiOwned ? hud.players.ai?.buildingHp[id]
+            : undefined
+          const hpFrac = hp !== undefined ? hp / OUTPOST_MAX_HP : undefined
+          return { color, isUnderAttack, isPlayerOwned, cap, hpFrac }
         })
         const playerCount = dots.filter(d => d.isPlayerOwned).length
         return (
@@ -253,7 +258,7 @@ export function HUD() {
               <span style={{ fontSize: 10, letterSpacing: 1, opacity: 0.5, marginRight: 4 }}>
                 OUTPOSTS {playerCount}/{OUTPOST_IDS.length}
               </span>
-              {dots.map(({ color, isUnderAttack, isPlayerOwned, cap }, i) => {
+              {dots.map(({ color, isUnderAttack, isPlayerOwned, cap, hpFrac }, i) => {
                 const capColor = cap?.side === 'player' ? '#4af7c4' : '#ff4f7b'
                 return (
                   <div key={i} style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 2 }}>
@@ -264,14 +269,23 @@ export function HUD() {
                       boxShadow: color !== '#888888' ? `0 0 6px ${isUnderAttack && isPlayerOwned ? '#ff6b35' : color}` : 'none',
                       animation: isUnderAttack && isPlayerOwned ? 'outpost-alert 0.6s ease-in-out infinite' : 'none',
                     }} />
-                    {cap && cap.progress > 0 && (
+                    {cap && cap.progress > 0 ? (
                       <div style={{ width: 14, height: 2, background: 'rgba(255,255,255,0.15)', borderRadius: 1 }}>
                         <div style={{
                           width: `${Math.round(cap.progress * 100)}%`,
                           height: '100%', background: capColor, borderRadius: 1,
                         }} />
                       </div>
-                    )}
+                    ) : hpFrac !== undefined && hpFrac < 0.99 ? (
+                      <div style={{ width: 14, height: 2, background: 'rgba(255,255,255,0.12)', borderRadius: 1 }}>
+                        <div style={{
+                          width: `${Math.round(hpFrac * 100)}%`,
+                          height: '100%',
+                          background: hpFrac > 0.5 ? color : hpFrac > 0.2 ? '#ffaa44' : '#ff2200',
+                          borderRadius: 1,
+                        }} />
+                      </div>
+                    ) : null}
                   </div>
                 )
               })}


### PR DESCRIPTION
## Summary
- Outpost dots in the HUD showed ownership (color) and attack state (animation) but not health
- Players had to zoom into the building to see outpost HP, or wait for the "HP CRITICAL" notification
- Adds a 14×2px HP bar under each outpost dot when the outpost is damaged

## Behavior
- **Visible**: when owned outpost HP < 99% (i.e. has taken any damage)
- **Color**: green > 50% HP, orange 20–50%, red < 20%
- **Priority**: capture progress bar still shows when a capture is active (replaces HP bar)
- **Hidden**: when at full health — keeps the UI clean during early game

## Test plan
- [ ] Take damage on a player outpost — HP bar appears under dot, fades through green → orange → red
- [ ] Let AI outpost take damage — HP bar appears in red on the AI-colored dot
- [ ] Neutral outpost — no HP bar
- [ ] Outpost being captured — capture progress bar shows instead of HP bar
- [ ] No TypeScript errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)