### PR TITLE
feat(speck-wars): idle army nudge when specks have no rally point

### DIFF
--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -30,6 +30,9 @@ export class GameInstance {
   private enemySurgeWarnedAt = -30000
   private recentKillTimes: number[] = []  // timestamps of recent player kills (combo detection)
   private lastComboNotifiedAt = -5000
+  private idleArmyTimer = 0              // ms with no rally point + specks available
+  private lastIdleNudge = -30000         // allow nudge immediately if idle at game start
+  private cachedPlayerSpeckCount = 0    // updated from HUD_UPDATE
 
   constructor(canvas: HTMLCanvasElement) {
     this.canvas = canvas
@@ -144,6 +147,7 @@ export class GameInstance {
         }
         if (event.type === 'HUD_UPDATE') {
           store.setHud(event.data)
+          this.cachedPlayerSpeckCount = event.data.players.player?.speckCount ?? 0
           // Warn when an enemy starts capturing a player-owned outpost
           const now = Date.now()
           const playerBuildingHp = event.data.players.player?.buildingHp ?? {}
@@ -259,6 +263,22 @@ export class GameInstance {
             setTimeout(() => useSpeckWarsStore.getState().setNotification(null), 2500)
           }
         }
+      }
+    }
+
+    // Idle army nudge: remind player to rally when specks sit idle
+    if (store.phase === 'playing') {
+      const hasRally = !!this.sim.rallyPoints['player']
+      if (!hasRally && this.cachedPlayerSpeckCount >= 10) {
+        this.idleArmyTimer += dt
+        if (this.idleArmyTimer > 20000 && !store.notification
+            && Date.now() - this.lastIdleNudge > 30000) {
+          this.lastIdleNudge = Date.now()
+          store.setNotification({ message: '📍 Click to send your army!', color: '#aaddff' })
+          setTimeout(() => useSpeckWarsStore.getState().setNotification(null), 2500)
+        }
+      } else {
+        this.idleArmyTimer = 0
       }
     }
 


### PR DESCRIPTION
## Summary
New players frequently build up specks at their base but don't know they need to click the map to send them. This adds a low-priority contextual reminder.

**Trigger conditions** (all must be true):
- 10+ player specks alive
- No rally point currently set
- Specks idle for 20+ continuous seconds
- No other notification currently showing
- At least 30 seconds since last nudge

**Message**: `📍 Click to send your army!` (blue-ish, 2.5s display)

## Why these thresholds
- 20s idle: long enough to not fire during normal micro-pauses, short enough to catch genuinely confused players
- 10 specks: ensures the player has a meaningful army before nagging them
- 30s repeat: won't spam; experienced players won't notice it at all since they rally regularly

## Test plan
- [ ] Let 10 specks accumulate with no rally — nudge fires after ~20s
- [ ] Set a rally point — timer resets, no nudge while rallied
- [ ] Nudge doesn't appear during other notifications (combo, under attack, etc.)
- [ ] No TypeScript errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)