### PR TITLE
feat(speck-wars): color spawn arc orange when building is in heavy mode

### DIFF
--- a/src/app/speck-wars/rendering/layers/building-layer.ts
+++ b/src/app/speck-wars/rendering/layers/building-layer.ts
@@ -127,7 +127,8 @@ export class BuildingLayer {
         if (progress > 0) {
           const startAngle = -Math.PI / 2
           const endAngle = startAngle + Math.PI * 2 * progress
-          this.gfx.lineStyle(2, 0xffffff, 0.5)
+          const arcColor = building.spawnTypeOverride === 'heavy' ? 0xffa032 : 0xffffff
+          this.gfx.lineStyle(2, arcColor, 0.5)
           this.gfx.moveTo(building.x + (r - 5) * Math.cos(startAngle), building.y + (r - 5) * Math.sin(startAngle))
           this.gfx.arc(building.x, building.y, r - 5, startAngle, endAngle)
           this.gfx.lineStyle(0)


### PR DESCRIPTION
## Summary
The spawn timer arc on buildings was always white, giving no indication of whether a building was queuing basic or heavy specks. Now the arc turns orange when `spawnTypeOverride === 'heavy'`, matching the orange color used in the HUD spawn mode button.

## Change
One color lookup: `const arcColor = building.spawnTypeOverride === 'heavy' ? 0xffa032 : 0xffffff`

## Why it helps
When toggling spawn modes (H key), the visual confirmation on the buildings makes it immediately clear that all buildings have switched to heavy mode — no need to read the HUD button to confirm.

## Test plan
- [ ] Press H to toggle to heavy mode — spawn arcs on all player buildings turn orange
- [ ] Press H back to basic — arcs return to white
- [ ] AI buildings also show orange arcs when AI is in heavy spawn mode
- [ ] No TypeScript errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)