### PR TITLE
feat(speck-wars): two-stage enemy base destruction notifications

### DIFF
--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -225,9 +225,14 @@ export class GameInstance {
         }
         if (event.type === 'BUILDING_DAMAGED' && event.buildingId === 'building-ai-base') {
           const aiBase = this.sim.buildings['building-ai-base']
-          if (aiBase && event.hp / aiBase.maxHp < 0.2) {
+          if (aiBase) {
+            const hpFrac = event.hp / aiBase.maxHp
             const now = Date.now()
-            if (now - this.enemyBaseWarnedAt > 15000) {
+            if (hpFrac < 0.1 && now - this.enemyBaseWarnedAt > 8000) {
+              this.enemyBaseWarnedAt = now
+              store.setNotification({ message: '💥 ENEMY BASE COLLAPSING!', color: '#ff8844' })
+              setTimeout(() => useSpeckWarsStore.getState().setNotification(null), 3000)
+            } else if (hpFrac < 0.2 && hpFrac >= 0.1 && now - this.enemyBaseWarnedAt > 15000) {
               this.enemyBaseWarnedAt = now
               store.setNotification({ message: '⚔ ENEMY BASE CRITICAL!', color: '#ffd700' })
               setTimeout(() => useSpeckWarsStore.getState().setNotification(null), 3000)


### PR DESCRIPTION
## Summary
Previously `⚔ ENEMY BASE CRITICAL!` fired once when the AI base hit 20% HP and then wouldn't repeat for 15 seconds, meaning the death blow came silently. Now there are two escalating stages:

| HP threshold | Message | Color | Cooldown |
|---|---|---|---|
| < 20% (≥10%) | `⚔ ENEMY BASE CRITICAL!` | Gold | 15s |
| < 10% | `💥 ENEMY BASE COLLAPSING!` | Orange | 8s |

## Why
The final 10% of a base destroy is the most exciting part of the game. A second distinct notification at 10% creates a dramatic countdown feel without over-cluttering the notification slot.

## Test plan
- [ ] Push enemy base to 20% — gold CRITICAL notification fires
- [ ] Continue to 10% — orange COLLAPSING notification fires
- [ ] Both notifications respect their cooldowns (no spam)
- [ ] No TypeScript errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)