### PR TITLE
feat(speck-wars): dramatic camera shake on game-over

### DIFF
--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -123,6 +123,10 @@ export class GameInstance {
           const won = event.winnerId === 'player'
           store.setWinnerId(event.winnerId)
           store.setVictoryType(event.victoryType)
+          // Dramatic camera shake on game-over
+          this.shakeMs = won ? 700 : 450
+          this.shakeMaxMs = won ? 700 : 450
+          this.shakeStrength = won ? 14 : 9
           // Show dramatic notification, then transition to end screen after a brief delay
           store.setNotification({
             message: won ? '⚡ VICTORY!' : '💀 DEFEATED',


### PR DESCRIPTION
## Summary
When the game ends (victory or defeat), the camera now shakes for emphasis during the 1.4s delay before transitioning to the end screen.

- **Victory**: 14px shake over 700ms (celebration impact)  
- **Defeat**: 9px shake over 450ms (defeat shock)

Uses the same shake system already in place for base-hit feedback. The 1.4s transition delay means the shake fully plays out before the game disappears.

## Test plan
- [ ] Destroy enemy base — strong shake before victory screen
- [ ] Let your base get destroyed — smaller shock before defeat screen
- [ ] Shake decays smoothly (existing linear decay)

🤖 Generated with [Claude Code](https://claude.com/claude-code)