### PR TITLE
fix(speck-wars): tap-to-rally on mobile/touch devices

### DIFF
--- a/src/app/speck-wars/input/input-handler.ts
+++ b/src/app/speck-wars/input/input-handler.ts
@@ -20,6 +20,8 @@ export class InputHandler {
   private mouseX = -1  // -1 means mouse not over canvas
   private mouseY = -1
   private lastPinchDist = 0  // 0 = not pinching
+  private touchStartX = 0
+  private touchStartY = 0
 
   constructor(
     canvas: HTMLCanvasElement,
@@ -123,6 +125,8 @@ export class InputHandler {
       this.lastPinchDist = 0
       this.lastX = e.touches[0].clientX
       this.lastY = e.touches[0].clientY
+      this.touchStartX = e.touches[0].clientX
+      this.touchStartY = e.touches[0].clientY
     } else if (e.touches.length === 2) {
       this.isDragging = false
       const dx = e.touches[1].clientX - e.touches[0].clientX
@@ -152,7 +156,22 @@ export class InputHandler {
     }
   }
 
-  private onTouchEnd = () => {
+  private onTouchEnd = (e: TouchEvent) => {
+    // Tap-to-rally: single finger tap (small movement) → set rally at tap position
+    if (this.lastPinchDist === 0 && e.changedTouches.length === 1 && this.onRally) {
+      const touch = e.changedTouches[0]
+      const dx = touch.clientX - this.touchStartX
+      const dy = touch.clientY - this.touchStartY
+      if (Math.sqrt(dx * dx + dy * dy) < 12) {
+        const rect = this.canvas.getBoundingClientRect()
+        const sx = touch.clientX - rect.left
+        const sy = touch.clientY - rect.top
+        if (sx >= 0 && sy >= 0 && sx <= rect.width && sy <= rect.height) {
+          const world = screenToWorld(sx, sy, this.camera)
+          this.onRally(world.x, world.y)
+        }
+      }
+    }
     this.isDragging = false
     this.lastPinchDist = 0
   }


### PR DESCRIPTION
## Summary
On mobile, tapping the game canvas had no effect — `onTouchEnd` only reset dragging state without dispatching a rally. The game was essentially unplayable on touch devices.

## Fix
When a single-finger touch ends with movement < 12px (a tap, not a drag):
- Convert the touch position to world coordinates
- Call `onRally()` — same path as left-click on desktop
- Bounds check ensures taps that drift outside the canvas bounds don't accidentally dispatch
- Pinch-to-zoom (`lastPinchDist > 0`) and multi-touch gestures are excluded

## What still works
- Single-finger drag = pan camera (unchanged)
- Two-finger pinch = zoom (unchanged)
- Long-press drag = pan (unchanged, since movement > 12px)

## Test plan
- [ ] On mobile: tap canvas → rally marker appears at tap position
- [ ] On mobile: drag finger to pan — no accidental rally triggered
- [ ] On mobile: pinch-to-zoom — no rally triggered
- [ ] Desktop: behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)