### PR TITLE
fix(speck-wars): use seeded RNG for outpost position jitter

### DIFF
--- a/src/app/speck-wars/domain/simulation/create-sim.ts
+++ b/src/app/speck-wars/domain/simulation/create-sim.ts
@@ -1,6 +1,7 @@
 import type { SimulationState, Player, BuildingEntity } from '../types'
 import { PLAYER_BASE_X, PLAYER_BASE_Y, AI_BASE_X, AI_BASE_Y, PLAYER_COLOR, AI_COLOR, BASE_HP, MAX_SPECKS, NEUTRAL_COLOR, OUTPOST_POSITIONS } from '../constants'
 import { SpatialGrid } from './spatial-grid'
+import { mulberry32 } from './prng'
 import type { Difficulty } from '../../store'
 
 const aiSpawnInterval: Record<Difficulty, number> = {
@@ -53,10 +54,11 @@ export function createSim(seed: number = Date.now(), difficulty: Difficulty = 'm
   }
 
   const JITTER = 200  // ± px of positional variation per game
+  const rng = mulberry32(seed)  // seeded so same date+difficulty = same map
   const outpostBuildings: Record<string, BuildingEntity> = {}
   for (const pos of OUTPOST_POSITIONS) {
-    const jx = (Math.random() * 2 - 1) * JITTER
-    const jy = (Math.random() * 2 - 1) * JITTER
+    const jx = (rng() * 2 - 1) * JITTER
+    const jy = (rng() * 2 - 1) * JITTER
     outpostBuildings[pos.id] = {
       id: pos.id,
       typeId: 'outpost',


### PR DESCRIPTION
## Summary
**Bug**: Outpost position jitter was computed using `Math.random()` (unseeded), so the "daily map" produced different outpost layouts on every page load — defeating the daily-map concept entirely.

**Fix**: Replace `Math.random()` with `mulberry32(seed)` (already exists at `domain/simulation/prng.ts`). The same `date × difficulty` seed now always produces the same outpost positions.

## Impact
- Daily map is actually consistent across sessions and users on the same day
- Players comparing times now see the same layout
- "Today's map" in share text is meaningful

## Test plan
- [ ] Reload game twice on same day/difficulty — outpost positions are identical
- [ ] Change date hash (or difficulty) — outpost positions change
- [ ] TypeScript: no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)