### PR TITLE
feat(speck-wars): mobile action buttons for D/A/B/R shortcuts

### DIFF
--- a/src/app/speck-wars/SpeckWarsGame.tsx
+++ b/src/app/speck-wars/SpeckWarsGame.tsx
@@ -25,19 +25,6 @@ function GameCanvas() {
     }
   }, [])
 
-  const btnStyle = {
-    pointerEvents: 'auto' as const,
-    padding: '10px 16px',
-    fontSize: 11,
-    cursor: 'pointer',
-    background: 'rgba(0,0,0,0.55)',
-    border: '1px solid rgba(255,255,255,0.25)',
-    borderRadius: 20,
-    color: 'rgba(255,255,255,0.8)',
-    letterSpacing: 1,
-    touchAction: 'manipulation' as const,
-  }
-
   return (
     <div style={{ position: 'relative', width: '100%', height: '100%' }}>
       <canvas
@@ -46,17 +33,6 @@ function GameCanvas() {
       />
       <HUD />
       <Minimap gameRef={gameRef} />
-      {/* Mobile action buttons */}
-      <div style={{
-        position: 'absolute', bottom: 16, left: '50%', transform: 'translateX(-50%)',
-        display: 'flex', gap: 8, pointerEvents: 'none',
-        marginRight: 180,  // avoid minimap overlap
-      }}>
-        <button style={btnStyle} onClick={() => gameRef.current?.defend()}>D: Defend</button>
-        <button style={btnStyle} onClick={() => gameRef.current?.advance()}>A: Advance</button>
-        <button style={btnStyle} onClick={() => gameRef.current?.rush()}>B: Rush</button>
-        <button style={btnStyle} onClick={() => gameRef.current?.clearRally()}>R: Clear</button>
-      </div>
     </div>
   )
 }

--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -40,6 +40,7 @@ export function HUD() {
   const cycleSpawnMode = useSpeckWarsStore(s => s.cycleSpawnMode)
   const difficulty = useSpeckWarsStore(s => s.difficulty)
   const surrender = useSpeckWarsStore(s => s.surrender)
+  const gameActions = useSpeckWarsStore(s => s.gameActions)
 
   const BASE_MAX_HP = 100
   const playerBaseHp = hud?.players.player?.buildingHp['building-player-base']
@@ -512,6 +513,88 @@ export function HUD() {
             }}
           >
             Give Up
+          </button>
+        </div>
+      )}
+
+      {/* Mobile action buttons — bottom right */}
+      {phase === 'playing' && (
+        <div style={{
+          position: 'absolute', bottom: 16, right: 16,
+          display: 'flex', flexDirection: 'row', gap: 6,
+          pointerEvents: 'auto',
+        }}>
+          <button
+            onClick={() => gameActions.defend?.()}
+            title="[D] Defend — rally to your base"
+            style={{
+              padding: '6px 10px',
+              fontSize: 11,
+              cursor: 'pointer',
+              background: 'rgba(74,247,196,0.08)',
+              border: '1px solid rgba(74,247,196,0.4)',
+              borderRadius: 20,
+              color: '#4af7c4',
+              letterSpacing: 1,
+              minHeight: 44,
+              fontFamily: 'monospace',
+            }}
+          >
+            🛡 D
+          </button>
+          <button
+            onClick={() => gameActions.advance?.()}
+            title="[A] Advance — rally to nearest outpost"
+            style={{
+              padding: '6px 10px',
+              fontSize: 11,
+              cursor: 'pointer',
+              background: 'rgba(255,215,0,0.08)',
+              border: '1px solid rgba(255,215,0,0.4)',
+              borderRadius: 20,
+              color: '#ffd700',
+              letterSpacing: 1,
+              minHeight: 44,
+              fontFamily: 'monospace',
+            }}
+          >
+            → A
+          </button>
+          <button
+            onClick={() => gameActions.rush?.()}
+            title="[B] Rush — attack enemy base"
+            style={{
+              padding: '6px 10px',
+              fontSize: 11,
+              cursor: 'pointer',
+              background: 'rgba(255,79,123,0.08)',
+              border: '1px solid rgba(255,79,123,0.4)',
+              borderRadius: 20,
+              color: '#ff4f7b',
+              letterSpacing: 1,
+              minHeight: 44,
+              fontFamily: 'monospace',
+            }}
+          >
+            ⚡ B
+          </button>
+          <button
+            onClick={() => gameActions.clearRally?.()}
+            title="[R] Clear rally"
+            style={{
+              padding: '6px 10px',
+              fontSize: 11,
+              cursor: 'pointer',
+              background: 'rgba(0,0,0,0.4)',
+              border: '1px solid rgba(255,255,255,0.2)',
+              borderRadius: 20,
+              color: 'rgba(255,255,255,0.6)',
+              letterSpacing: 1,
+              minHeight: 44,
+              fontFamily: 'monospace',
+            }}
+          >
+            ✕ R
           </button>
         </div>
       )}

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -85,6 +85,12 @@ export class GameInstance {
       () => { this.advance(); this.notify('→ ADVANCE', '#ffd700') },  // A — advance to nearest non-player outpost
       () => { this.rush(); this.notify('⚡ RUSH!', '#ff4f7b') },      // B — rush enemy base
     )
+    useSpeckWarsStore.getState().setGameActions({
+      defend: () => { this.defend(); this.notify('🛡 DEFEND', '#4af7c4') },
+      advance: () => { this.advance(); this.notify('→ ADVANCE', '#ffd700') },
+      rush: () => { this.rush(); this.notify('⚡ RUSH!', '#ff4f7b') },
+      clearRally: () => this.clearRally(),
+    })
     this.lastTime = performance.now()
     this.loop(this.lastTime)
 
@@ -319,6 +325,7 @@ export class GameInstance {
     document.removeEventListener('visibilitychange', this.onVisibilityChange)
     this.renderer.destroy()
     this.inputHandler?.destroy()
+    useSpeckWarsStore.getState().setGameActions(null)
     console.log('GameInstance destroyed')
   }
 

--- a/src/app/speck-wars/store.ts
+++ b/src/app/speck-wars/store.ts
@@ -31,6 +31,8 @@ interface SpeckWarsStore {
   cycleSpawnMode: () => 'basic' | 'heavy'
   isNewBest: boolean
   setIsNewBest: (v: boolean) => void
+  gameActions: { defend: (() => void) | null; advance: (() => void) | null; rush: (() => void) | null; clearRally: (() => void) | null }
+  setGameActions: (actions: { defend: () => void; advance: () => void; rush: () => void; clearRally: () => void } | null) => void
   surrender: () => void
   resetGame: () => void
 }
@@ -72,6 +74,8 @@ export const useSpeckWarsStore = create<SpeckWarsStore>()(set => ({
   },
   isNewBest: false,
   setIsNewBest: v => set({ isNewBest: v }),
+  gameActions: { defend: null, advance: null, rush: null, clearRally: null },
+  setGameActions: (actions) => set({ gameActions: actions ?? { defend: null, advance: null, rush: null, clearRally: null } }),
   surrender: () => {
     resetWinStreak()
     set({ phase: 'defeat', winnerId: 'ai', victoryType: 'destruction', isNewBest: false })


### PR DESCRIPTION
## Summary

- Adds 4 touch-friendly pill buttons (Defend/Advance/Rush/Clear) at the bottom-right of the game HUD
- Keyboard shortcuts D/A/B/R are now accessible on mobile/touch devices
- Game actions (defend, advance, rush, clearRally) are registered in the Zustand store by `GameInstance.start()` and cleared on `GameInstance.destroy()`
- Buttons are only visible during active play (`phase === 'playing'`)
- Min tap target of 44px height; each button has a descriptive tooltip

Closes #1849

## Test plan
- [ ] Keyboard shortcuts D/A/B/R still work as before
- [ ] Tapping Defend rallies specks to player base and shows 🛡 DEFEND notification
- [ ] Tapping Advance rallies specks to nearest outpost and shows → ADVANCE notification
- [ ] Tapping Rush rallies specks to enemy base and shows ⚡ RUSH! notification
- [ ] Tapping Clear removes the rally point
- [ ] Buttons disappear when game is paused or over
- [ ] Buttons don't overlap the force ratio / kill stats in the bottom-left

🤖 Generated with [Claude Code](https://claude.com/claude-code)