### PR TITLE
feat(speck-wars): ambient starfield background

### DIFF
--- a/src/app/speck-wars/rendering/layers/starfield-layer.ts
+++ b/src/app/speck-wars/rendering/layers/starfield-layer.ts
@@ -1,0 +1,44 @@
+import { Graphics, Container } from 'pixi.js'
+
+// Simple deterministic pseudo-random (xorshift32) — fixed seed so stars are stable
+function xr(s: number) { s ^= s << 13; s ^= s >> 17; s ^= s << 5; return (s >>> 0) / 0x100000000 }
+
+export class StarfieldLayer {
+  readonly stage: Container
+
+  constructor() {
+    this.stage = new Container()
+    const gfx = new Graphics()
+
+    // Spread stars over an area larger than the 3000×3000 world
+    const AREA_X = -800, AREA_Y = -800, AREA_W = 4600, AREA_H = 4600
+    const STAR_COUNT = 420
+
+    let seed = 0xdeadbeef
+    const rng = () => { seed = (seed * 1664525 + 1013904223) >>> 0; return seed / 0x100000000 }
+
+    for (let i = 0; i < STAR_COUNT; i++) {
+      const x = AREA_X + rng() * AREA_W
+      const y = AREA_Y + rng() * AREA_H
+      const t = rng()          // type selector
+      const r = t < 0.75 ? 0.6 + rng() * 0.5     // small  (75%)
+              : t < 0.95 ? 1.2 + rng() * 0.8     // medium (20%)
+              :             2.0 + rng() * 1.2     // large  (5%)
+      const alpha = 0.08 + rng() * 0.36
+
+      // Subtle color variety: ~20% slightly blue-purple, rest white
+      const colorRoll = rng()
+      const color = colorRoll < 0.12 ? 0xaab8ff    // blue-white
+                  : colorRoll < 0.20 ? 0xddccff    // soft violet
+                  : 0xffffff                        // white
+
+      gfx.beginFill(color, alpha)
+      gfx.drawCircle(x, y, r)
+      gfx.endFill()
+    }
+
+    this.stage.addChild(gfx)
+  }
+
+  destroy() { this.stage.destroy({ children: true }) }
+}

--- a/src/app/speck-wars/rendering/renderer.ts
+++ b/src/app/speck-wars/rendering/renderer.ts
@@ -3,6 +3,7 @@ import { SpeckLayer } from './layers/speck-layer'
 import { BuildingLayer } from './layers/building-layer'
 import { GridLayer } from './layers/grid-layer'
 import { EffectsLayer } from './layers/effects-layer'
+import { StarfieldLayer } from './layers/starfield-layer'
 import { createSpeckTexture } from './textures'
 import type { SimulationState } from '../domain/types'
 import { PLAYER_COLOR, AI_COLOR } from '../domain/constants'
@@ -32,6 +33,7 @@ export class Renderer {
   private buildingLayer!: BuildingLayer
   private gridLayer!: GridLayer
   private effectsLayer!: EffectsLayer
+  private starfieldLayer!: StarfieldLayer
   private rallyGfx!: Graphics
 
   async init(canvas: HTMLCanvasElement) {
@@ -49,11 +51,13 @@ export class Renderer {
     this.app.stage.addChild(this.world)
 
     const texture = createSpeckTexture(this.app, 4)
+    this.starfieldLayer = new StarfieldLayer()
     this.gridLayer = new GridLayer()
     this.effectsLayer = new EffectsLayer()
     this.buildingLayer = new BuildingLayer()
     this.speckLayer = new SpeckLayer(texture, PLAYER_COLORS)
 
+    this.world.addChild(this.starfieldLayer.stage)
     this.world.addChild(this.gridLayer.stage)
     this.world.addChild(this.buildingLayer.stage)
     this.world.addChild(this.effectsLayer.stage)
@@ -144,6 +148,7 @@ export class Renderer {
   }
 
   destroy() {
+    this.starfieldLayer.destroy()
     this.gridLayer.destroy()
     this.effectsLayer.destroy()
     this.speckLayer.destroy()


### PR DESCRIPTION
## Summary

- Adds a new `StarfieldLayer` rendered beneath the game grid in world space
- 420 stars with deterministic placement (fixed-seed LCG) so the starfield is always identical
- Stars vary in size (small 75%, medium 20%, large 5%), alpha, and color (white, blue-white, soft violet)
- Gives the game its cosmic/space atmosphere consistent with CometCave branding
- Zero runtime cost: stars are drawn once at init and cached as a static Graphics object

Closes #1914

## Test plan
- [ ] Stars are visible when the game starts (faint dots behind buildings/specks)
- [ ] Stars don't move when panning/zooming (they're in world space, parallax from zoom is correct)
- [ ] No performance regression (stars are drawn once, not per-frame)
- [ ] Stars don't appear on the menu or victory/defeat screens
- [ ] TypeScript compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)