### PR TITLE
feat(speck-wars): deep-space CSS background

### DIFF
--- a/src/app/speck-wars/SpeckWarsGame.tsx
+++ b/src/app/speck-wars/SpeckWarsGame.tsx
@@ -39,7 +39,14 @@ function GameCanvas() {
   }
 
   return (
-    <div style={{ position: 'relative', width: '100%', height: '100%' }}>
+    <div style={{
+      position: 'relative', width: '100%', height: '100%',
+      background: [
+        'radial-gradient(ellipse at 25% 75%, rgba(15,5,40,0.9) 0%, transparent 55%)',
+        'radial-gradient(ellipse at 75% 25%, rgba(5,15,35,0.7) 0%, transparent 50%)',
+        'radial-gradient(ellipse at 50% 50%, rgba(2,6,18,1) 0%, #010208 100%)',
+      ].join(', '),
+    }}>
       <canvas
         ref={canvasRef}
         style={{ display: 'block', width: '100%', height: '100%' }}


### PR DESCRIPTION
## Summary

- Adds three overlapping CSS radial gradients to the game canvas container div
- Creates a deep-space nebula atmosphere (dark purple/blue on near-black `#010208`)
- Shows through the transparent PixiJS canvas (`backgroundAlpha: 0`) wherever no game elements are drawn
- Pure CSS — zero runtime cost, no PixiJS changes needed

Closes #1916

## Test plan
- [ ] Game area has a deep-space background instead of pitch black
- [ ] Subtle purple/blue nebula gradients visible especially around edges
- [ ] Menu, HUD, and minimap elements are unaffected
- [ ] No performance impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)