### PR TITLE
feat(speck-wars): notify player when AI switches to heavy production

### DIFF
--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -33,6 +33,7 @@ export class GameInstance {
   private idleArmyTimer = 0              // ms with no rally point + specks available
   private lastIdleNudge = -30000         // allow nudge immediately if idle at game start
   private cachedPlayerSpeckCount = 0    // updated from HUD_UPDATE
+  private lastAiSpawnMode: string = 'basic'  // track AI spawn mode changes
 
   constructor(canvas: HTMLCanvasElement) {
     this.canvas = canvas
@@ -278,6 +279,20 @@ export class GameInstance {
             setTimeout(() => useSpeckWarsStore.getState().setNotification(null), 2500)
           }
         }
+      }
+    }
+
+    // Detect AI spawn mode changes and notify player
+    if (store.phase === 'playing') {
+      const aiBase = this.sim.buildings['building-ai-base']
+      const aiSpawnMode = aiBase?.spawnTypeOverride ?? 'basic'
+      if (aiSpawnMode !== this.lastAiSpawnMode && this.elapsedMs > 5000) {
+        this.lastAiSpawnMode = aiSpawnMode
+        if (aiSpawnMode === 'heavy') {
+          store.setNotification({ message: '⬡ ENEMY BUILDING TANKS', color: '#ffaa55' })
+          setTimeout(() => useSpeckWarsStore.getState().setNotification(null), 2000)
+        }
+        // No notification when switching back to basic — less alarming
       }
     }
 


### PR DESCRIPTION
## Summary

- Tracks `lastAiSpawnMode` and detects when the AI base's `spawnTypeOverride` changes to `'heavy'`
- Shows a brief amber `⬡ ENEMY BUILDING TANKS` notification (2s duration)
- Suppressed during the first 5s of gameplay to avoid noise at game start
- No notification when AI switches back to basic (less alarming event)
- Gives the player actionable intel to counter the AI's strategy

Closes #1918

## Test plan
- [ ] On easy/medium (non-aggressive AI): play until AI counter-spawns to heavy, notification appears
- [ ] On hard/brutal: AI randomly switches heavy — notification fires when it does
- [ ] Notification doesn't appear in the first 5s
- [ ] Notification auto-dismisses after 2s
- [ ] No TypeScript errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)