### PR TITLE
feat(speck-wars): combat zone haze indicator

### DIFF
--- a/src/app/speck-wars/rendering/layers/effects-layer.ts
+++ b/src/app/speck-wars/rendering/layers/effects-layer.ts
@@ -4,6 +4,10 @@ interface Flash { x: number; y: number; life: number; maxLife: number; color: nu
 interface Ping { x: number; y: number; life: number; maxLife: number }
 interface Ripple { x: number; y: number; life: number; maxLife: number; color: number }
 interface Particle { x: number; y: number; vx: number; vy: number; life: number; maxLife: number; color: number }
+interface CombatZone { x: number; y: number; life: number; maxLife: number }
+
+const COMBAT_ZONE_LIFE = 3000   // ms a zone persists with no new kills
+const COMBAT_ZONE_MERGE_DIST = 60  // px — nearby kills refresh existing zone
 
 export class EffectsLayer {
   readonly stage: Container
@@ -12,6 +16,7 @@ export class EffectsLayer {
   private pings: Ping[] = []
   private ripples: Ripple[] = []
   private particles: Particle[] = []
+  private combatZones: CombatZone[] = []
 
   constructor() {
     this.stage = new Container()
@@ -48,6 +53,18 @@ export class EffectsLayer {
     for (let i = 0; i < 3; i++) {
       this.ripples.push({ x, y, life: 800 - i * 200, maxLife: 800 - i * 200, color })
     }
+  }
+
+  markCombatAt(x: number, y: number) {
+    // Refresh or create a combat zone near this position
+    const md2 = COMBAT_ZONE_MERGE_DIST * COMBAT_ZONE_MERGE_DIST
+    for (const z of this.combatZones) {
+      if ((z.x - x) ** 2 + (z.y - y) ** 2 < md2) {
+        z.life = COMBAT_ZONE_LIFE  // refresh
+        return
+      }
+    }
+    this.combatZones.push({ x, y, life: COMBAT_ZONE_LIFE, maxLife: COMBAT_ZONE_LIFE })
   }
 
   addDestructionBurst(x: number, y: number, color: number) {
@@ -109,6 +126,24 @@ export class EffectsLayer {
       this.gfx.lineStyle(2, r.color, alpha)
       this.gfx.drawCircle(r.x, r.y, radius)
       this.gfx.lineStyle(0)
+    }
+
+    // Combat zone hazes — faint pulsing orange rings where battles are happening
+    this.combatZones = this.combatZones.filter(z => z.life > 0)
+    const now = Date.now()
+    for (const z of this.combatZones) {
+      z.life -= dt
+      const ageFrac = z.life / z.maxLife          // 1.0 (fresh) → 0.0 (expired)
+      const pulse = 0.5 + 0.5 * Math.sin(now / 350)  // ~2.8Hz pulse
+      const alpha = ageFrac * 0.12 * pulse
+      if (alpha > 0.005) {
+        this.gfx.lineStyle(1.5, 0xff6620, alpha)
+        this.gfx.drawCircle(z.x, z.y, 28)
+        this.gfx.lineStyle(0)
+        this.gfx.beginFill(0xff4400, ageFrac * 0.03 * pulse)
+        this.gfx.drawCircle(z.x, z.y, 22)
+        this.gfx.endFill()
+      }
     }
   }
 

--- a/src/app/speck-wars/rendering/renderer.ts
+++ b/src/app/speck-wars/rendering/renderer.ts
@@ -80,6 +80,7 @@ export class Renderer {
         const flashColor = PLAYER_COLORS[event.killedOwnerId] ?? 0xffffff
         this.effectsLayer.addDeathFlash(event.x, event.y, flashColor)
         this.effectsLayer.addDeathParticles(event.x, event.y, flashColor)
+        this.effectsLayer.markCombatAt(event.x, event.y)
       }
       if (event.type === 'BUILDING_DAMAGED') {
         this.buildingLayer.flashBuilding(event.buildingId)


### PR DESCRIPTION
## Summary

- Adds `markCombatAt(x, y)` to `EffectsLayer` — creates or refreshes a `CombatZone` entry when specks die in battle
- Combat zones render as a faint pulsing orange ring (28px radius, ~2.8Hz pulse, max 12% alpha), fading over 3 seconds
- Zones within 60px of each other merge (life refreshes instead of stacking) to avoid visual clutter
- Called from `renderer.ts` alongside existing death flash/particle effects
- Zero simulation changes — purely visual

Closes #1920

## Test plan
- [ ] Faint orange pulsing haze appears where specks are fighting
- [ ] Haze fades within ~3s when combat stops in that area
- [ ] Multiple nearby kills don't create many overlapping rings (merging works)
- [ ] No visual noise when not in combat (zones expire cleanly)
- [ ] No performance regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)