### PR TITLE
feat(speck-wars): critical HP outline on damaged heavy specks

### DIFF
--- a/src/app/speck-wars/rendering/layers/speck-layer.ts
+++ b/src/app/speck-wars/rendering/layers/speck-layer.ts
@@ -88,6 +88,15 @@ export class SpeckLayer {
           this.gfx.lineStyle(1, 0xffffff, spriteList[j].alpha * 0.6)
           this.gfx.drawCircle(sim.speckX[i], sim.speckY[i], 2)
           this.gfx.lineStyle(0)
+          // Critical HP ring: red outline when heavy speck is at 40% HP or below
+          if (stype && hpFrac <= 0.4 && hpFrac > 0) {
+            const critIntensity = (0.4 - hpFrac) / 0.4   // 0.0 → 1.0 as HP drops
+            const critAlpha = critIntensity * 0.8 * spriteList[j].alpha
+            const critPulse = 0.5 + 0.5 * Math.sin(now / 120)  // fast pulse ~8Hz
+            this.gfx.lineStyle(1.2, 0xff2222, critAlpha * critPulse)
+            this.gfx.drawCircle(sim.speckX[i], sim.speckY[i], stype.size / 4 + 2)
+            this.gfx.lineStyle(0)
+          }
         }
 
         // Motion trail: 3 fading dots extrapolated backwards from velocity


### PR DESCRIPTION
## Summary

- Heavy specks at ≤40% HP (≤2/5) show a rapidly pulsing red outline ring
- Ring alpha and intensity scale with damage severity (more red = closer to death)
- Pulse frequency ~8Hz to draw the eye to critically wounded tanks
- Ring is drawn in the existing SpeckLayer `gfx` Graphics overlay, reusing the same per-frame clear/draw pattern

Closes #1922

## Test plan
- [ ] Play until some heavy specks take damage — red rings appear when they drop to 2HP or 1HP
- [ ] Red ring pulses visibly (not static)
- [ ] Ring disappears when speck dies
- [ ] Basic specks (1HP) never show red ring (they die in 1 hit)
- [ ] No TypeScript errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)