### PR TITLE
feat(speck-wars): comeback victory notification

### DIFF
--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -135,9 +135,11 @@ export class GameInstance {
           this.shakeMaxMs = won ? 700 : 450
           this.shakeStrength = won ? 14 : 9
           // Show dramatic notification, then transition to end screen after a brief delay
+          const playerBaseHp = this.sim.buildings['building-player-base']?.hp ?? 100
+          const isComeback = won && playerBaseHp < 20  // base barely survived
           store.setNotification({
-            message: won ? '⚡ VICTORY!' : '💀 DEFEATED',
-            color: won ? '#4af7c4' : '#ff4f7b',
+            message: isComeback ? '🏆 COMEBACK VICTORY!' : won ? '⚡ VICTORY!' : '💀 DEFEATED',
+            color: isComeback ? '#ffd700' : won ? '#4af7c4' : '#ff4f7b',
           })
           const elapsedAtEnd = this.elapsedMs
           setTimeout(() => {


### PR DESCRIPTION
## Summary

- At GAME_OVER, checks player base HP before showing the victory notification
- If base HP < 20 (out of 100), shows gold `🏆 COMEBACK VICTORY!` instead of `⚡ VICTORY!`
- Creates a recognizable "barely survived" moment — more shareable, more memorable
- 3-line change in the existing GAME_OVER handler

Closes #1928

## Test plan
- [ ] Win normally — shows standard `⚡ VICTORY!` in teal
- [ ] Win with base at < 20HP — shows `🏆 COMEBACK VICTORY!` in gold
- [ ] No change to defeat behavior
- [ ] TypeScript compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)