### PR TITLE
feat(speck-wars): battle start notification on game begin

### DIFF
--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -95,6 +95,12 @@ export class GameInstance {
     this.lastTime = performance.now()
     this.loop(this.lastTime)
 
+    // Brief "BATTLE START" flash when game begins
+    setTimeout(() => {
+      useSpeckWarsStore.getState().setNotification({ message: '⚔ BATTLE START', color: '#4af7c4' })
+      setTimeout(() => useSpeckWarsStore.getState().setNotification(null), 900)
+    }, 200)
+
     // Show tutorial hints for first-time players
     if (isFirstGame()) {
       markFirstGameDone()


### PR DESCRIPTION
## Summary

- Shows `⚔ BATTLE START` notification 200ms after `GameInstance.start()` completes
- Clears after 900ms — brief, non-intrusive
- Only fires on initial game start, not on resume after pause
- 6-line addition to `game-instance.ts`

Closes #1930

## Test plan
- [ ] Start a game — brief teal `⚔ BATTLE START` flash appears and fades
- [ ] Pause and resume — no second `BATTLE START` notification
- [ ] Doesn't interfere with tutorial hints on first game

🤖 Generated with [Claude Code](https://claude.com/claude-code)