### PR TITLE
feat(speck-wars): base HP regeneration

### DIFF
--- a/src/app/speck-wars/domain/config/building-types.ts
+++ b/src/app/speck-wars/domain/config/building-types.ts
@@ -13,6 +13,7 @@ export const BUILDING_TYPES: Record<string, BuildingTypeDefinition> = {
     maxHp: 100, size: 40,
     spawnTypeId: 'basic',
     spawnInterval: 800, spawnCount: 1,
+    hpRegen: 0.5,  // 0.5 HP/sec when not under attack — slow recovery rewards defensive play
   },
   outpost: {
     id: 'outpost', name: 'Outpost',


### PR DESCRIPTION
## Summary

- Adds `hpRegen: 0.5` to the base building type in `building-types.ts`
- Both player and AI bases recover 0.5 HP/sec when not under siege
- Leverages the existing `regenBuildingHp()` function in `tick.ts` (already powers outpost regen at 2 HP/sec)
- No simulation logic changes needed — it's a 1-line config change

### Why this helps
- Rewards **sustained pressure**: letting up on the enemy base gives them 30 HP back per minute
- Rewards **defensive play**: surviving an assault and repelling it lets the player's base heal
- The rate is low enough (0.5/sec vs 2/sec for outposts) that it won't make bases feel invincible

Closes #1932

## Test plan
- [ ] Damage player base, then repel the attack — HP gradually rises back
- [ ] Enemy base HP also recovers between assaults
- [ ] 0.5 HP/sec rate feels meaningful but not overpowered
- [ ] TypeScript compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)