### PR TITLE
fix(speck-wars): surrendered games show accurate defeat reason

### DIFF
--- a/src/app/speck-wars/components/phase-router.tsx
+++ b/src/app/speck-wars/components/phase-router.tsx
@@ -198,16 +198,20 @@ export function PhaseRouter({ children }: { children: React.ReactNode }) {
               color: victoryType === 'domination' ? '#ffd700' : accentColor,
               textTransform: 'uppercase',
             }}>
-              {victoryType === 'domination' ? '⬡ by Domination' : '💥 by Destruction'}
+              {victoryType === 'domination' ? '⬡ by Domination'
+                : victoryType === 'surrender' ? '🏳 Surrendered'
+                : '💥 by Destruction'}
             </div>
             <div style={{ fontSize: 10, letterSpacing: 1, opacity: 0.35, color: '#fff' }}>
               {won
                 ? victoryType === 'domination'
                   ? 'held all 3 outposts for 60 seconds'
                   : 'destroyed the enemy base'
-                : victoryType === 'domination'
-                  ? 'enemy held all 3 outposts for 60 seconds'
-                  : 'your base was destroyed'
+                : victoryType === 'surrender'
+                  ? 'you chose to give up'
+                  : victoryType === 'domination'
+                    ? 'enemy held all 3 outposts for 60 seconds'
+                    : 'your base was destroyed'
               }
             </div>
           </div>

--- a/src/app/speck-wars/store.ts
+++ b/src/app/speck-wars/store.ts
@@ -11,8 +11,8 @@ interface SpeckWarsStore {
   togglePause: () => void
   winnerId: string | null
   setWinnerId: (id: string) => void
-  victoryType: 'destruction' | 'domination' | null
-  setVictoryType: (t: 'destruction' | 'domination') => void
+  victoryType: 'destruction' | 'domination' | 'surrender' | null
+  setVictoryType: (t: 'destruction' | 'domination' | 'surrender') => void
   hud: HudData | null
   setHud: (data: HudData) => void
   difficulty: Difficulty
@@ -80,7 +80,7 @@ export const useSpeckWarsStore = create<SpeckWarsStore>()((set, get) => ({
     const s = get()
     resetWinStreak()
     recordGameResult(s.difficulty, false, s.elapsedMs, s.kills)
-    set({ phase: 'defeat', winnerId: 'ai', victoryType: 'destruction', isNewBest: false })
+    set({ phase: 'defeat', winnerId: 'ai', victoryType: 'surrender', isNewBest: false })
   },
   resetGame: () => set(s => ({
     phase: 'menu' as GamePhase,


### PR DESCRIPTION
## Summary
- Adds `'surrender'` to the `victoryType` union type
- Surrender sets `victoryType: 'surrender'` instead of `'destruction'`
- Defeat screen now shows "🏳 Surrendered / you chose to give up" for surrendered runs

## Before
When giving up, the screen showed "💥 by Destruction / your base was destroyed" — inaccurate.

## Metric
Accuracy improvement; no direct metric impact, but reduces cognitive friction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)