### PR TITLE
feat: Speck Wars — full game MVP

### DIFF
--- a/src/app/speck-wars/SpeckWarsGame.tsx
+++ b/src/app/speck-wars/SpeckWarsGame.tsx
@@ -25,6 +25,19 @@ function GameCanvas() {
     }
   }, [])
 
+  const btnStyle = {
+    pointerEvents: 'auto' as const,
+    padding: '10px 16px',
+    fontSize: 11,
+    cursor: 'pointer',
+    background: 'rgba(0,0,0,0.55)',
+    border: '1px solid rgba(255,255,255,0.25)',
+    borderRadius: 20,
+    color: 'rgba(255,255,255,0.8)',
+    letterSpacing: 1,
+    touchAction: 'manipulation' as const,
+  }
+
   return (
     <div style={{ position: 'relative', width: '100%', height: '100%' }}>
       <canvas
@@ -33,6 +46,17 @@ function GameCanvas() {
       />
       <HUD />
       <Minimap gameRef={gameRef} />
+      {/* Mobile action buttons */}
+      <div style={{
+        position: 'absolute', bottom: 16, left: '50%', transform: 'translateX(-50%)',
+        display: 'flex', gap: 8, pointerEvents: 'none',
+        marginRight: 180,  // avoid minimap overlap
+      }}>
+        <button style={btnStyle} onClick={() => gameRef.current?.defend()}>D: Defend</button>
+        <button style={btnStyle} onClick={() => gameRef.current?.advance()}>A: Advance</button>
+        <button style={btnStyle} onClick={() => gameRef.current?.rush()}>B: Rush</button>
+        <button style={btnStyle} onClick={() => gameRef.current?.clearRally()}>R: Clear</button>
+      </div>
     </div>
   )
 }

--- a/src/app/speck-wars/SpeckWarsGame.tsx
+++ b/src/app/speck-wars/SpeckWarsGame.tsx
@@ -11,7 +11,7 @@ export function SpeckWarsGame() {
     if (!canvas) return
 
     const game = new GameInstance(canvas)
-    game.start()
+    game.start()  // fire-and-forget async (renderer inits then loop starts)
 
     return () => {
       game.destroy()

--- a/src/app/speck-wars/SpeckWarsGame.tsx
+++ b/src/app/speck-wars/SpeckWarsGame.tsx
@@ -5,19 +5,23 @@ import { GameInstance } from './game-instance'
 import { useSpeckWarsStore } from './store'
 import { HUD } from './components/hud'
 import { PhaseRouter } from './components/phase-router'
+import { Minimap } from './components/minimap'
 
 function GameCanvas() {
   const canvasRef = useRef<HTMLCanvasElement>(null)
+  const gameRef = useRef<GameInstance | null>(null)
 
   useEffect(() => {
     const canvas = canvasRef.current
     if (!canvas) return
 
     const game = new GameInstance(canvas)
+    gameRef.current = game
     game.start()
 
     return () => {
       game.destroy()
+      gameRef.current = null
     }
   }, [])
 
@@ -28,6 +32,7 @@ function GameCanvas() {
         style={{ display: 'block', width: '100%', height: '100%' }}
       />
       <HUD />
+      <Minimap gameRef={gameRef} />
     </div>
   )
 }

--- a/src/app/speck-wars/SpeckWarsGame.tsx
+++ b/src/app/speck-wars/SpeckWarsGame.tsx
@@ -26,7 +26,14 @@ function GameCanvas() {
   }, [])
 
   return (
-    <div style={{ position: 'relative', width: '100%', height: '100%' }}>
+    <div style={{
+      position: 'relative', width: '100%', height: '100%',
+      background: [
+        'radial-gradient(ellipse at 25% 75%, rgba(15,5,40,0.9) 0%, transparent 55%)',
+        'radial-gradient(ellipse at 75% 25%, rgba(5,15,35,0.7) 0%, transparent 50%)',
+        'radial-gradient(ellipse at 50% 50%, rgba(2,6,18,1) 0%, #010208 100%)',
+      ].join(', '),
+    }}>
       <canvas
         ref={canvasRef}
         style={{ display: 'block', width: '100%', height: '100%' }}

--- a/src/app/speck-wars/SpeckWarsGame.tsx
+++ b/src/app/speck-wars/SpeckWarsGame.tsx
@@ -43,7 +43,7 @@ export function SpeckWarsGame() {
   return (
     <div style={{ position: 'relative', width: '100%', height: '100%' }}>
       <PhaseRouter>
-        {phase === 'playing' && <GameCanvas />}
+        {(phase === 'playing' || phase === 'paused') && <GameCanvas />}
       </PhaseRouter>
     </div>
   )

--- a/src/app/speck-wars/SpeckWarsGame.tsx
+++ b/src/app/speck-wars/SpeckWarsGame.tsx
@@ -2,8 +2,11 @@
 
 import { useEffect, useRef } from 'react'
 import { GameInstance } from './game-instance'
+import { useSpeckWarsStore } from './store'
+import { HUD } from './components/hud'
+import { PhaseRouter } from './components/phase-router'
 
-export function SpeckWarsGame() {
+function GameCanvas() {
   const canvasRef = useRef<HTMLCanvasElement>(null)
 
   useEffect(() => {
@@ -11,7 +14,7 @@ export function SpeckWarsGame() {
     if (!canvas) return
 
     const game = new GameInstance(canvas)
-    game.start()  // fire-and-forget async (renderer inits then loop starts)
+    game.start()
 
     return () => {
       game.destroy()
@@ -24,19 +27,19 @@ export function SpeckWarsGame() {
         ref={canvasRef}
         style={{ display: 'block', width: '100%', height: '100%' }}
       />
-      <div
-        style={{
-          position: 'absolute',
-          top: 16,
-          left: 16,
-          color: 'rgba(255,255,255,0.8)',
-          fontSize: 24,
-          fontWeight: 'bold',
-          pointerEvents: 'none',
-        }}
-      >
-        Speck Wars
-      </div>
+      <HUD />
+    </div>
+  )
+}
+
+export function SpeckWarsGame() {
+  const phase = useSpeckWarsStore(s => s.phase)
+
+  return (
+    <div style={{ position: 'relative', width: '100%', height: '100%' }}>
+      <PhaseRouter>
+        {phase === 'playing' && <GameCanvas />}
+      </PhaseRouter>
     </div>
   )
 }

--- a/src/app/speck-wars/SpeckWarsGame.tsx
+++ b/src/app/speck-wars/SpeckWarsGame.tsx
@@ -25,19 +25,6 @@ function GameCanvas() {
     }
   }, [])
 
-  const btnStyle = {
-    pointerEvents: 'auto' as const,
-    padding: '10px 16px',
-    fontSize: 11,
-    cursor: 'pointer',
-    background: 'rgba(0,0,0,0.55)',
-    border: '1px solid rgba(255,255,255,0.25)',
-    borderRadius: 20,
-    color: 'rgba(255,255,255,0.8)',
-    letterSpacing: 1,
-    touchAction: 'manipulation' as const,
-  }
-
   return (
     <div style={{ position: 'relative', width: '100%', height: '100%' }}>
       <canvas
@@ -46,17 +33,6 @@ function GameCanvas() {
       />
       <HUD />
       <Minimap gameRef={gameRef} />
-      {/* Mobile action buttons */}
-      <div style={{
-        position: 'absolute', bottom: 16, left: '50%', transform: 'translateX(-50%)',
-        display: 'flex', gap: 8, pointerEvents: 'none',
-        marginRight: 180,  // avoid minimap overlap
-      }}>
-        <button style={btnStyle} onClick={() => gameRef.current?.defend()}>D: Defend</button>
-        <button style={btnStyle} onClick={() => gameRef.current?.advance()}>A: Advance</button>
-        <button style={btnStyle} onClick={() => gameRef.current?.rush()}>B: Rush</button>
-        <button style={btnStyle} onClick={() => gameRef.current?.clearRally()}>R: Clear</button>
-      </div>
     </div>
   )
 }

--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -26,6 +26,7 @@ export function HUD() {
   const spawnMode = useSpeckWarsStore(s => s.spawnMode)
   const cycleSpawnMode = useSpeckWarsStore(s => s.cycleSpawnMode)
   const difficulty = useSpeckWarsStore(s => s.difficulty)
+  const surrender = useSpeckWarsStore(s => s.surrender)
 
   const BASE_MAX_HP = 100
   const playerBaseHp = hud?.players.player?.buildingHp['building-player-base']
@@ -248,11 +249,27 @@ export function HUD() {
         <div style={{
           position: 'absolute', inset: 0,
           background: 'rgba(0,0,0,0.45)',
-          display: 'flex', alignItems: 'center', justifyContent: 'center',
+          display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', gap: 24,
         }}>
           <span style={{ fontSize: 36, fontWeight: 'bold', letterSpacing: 4, opacity: 0.9 }}>
             PAUSED
           </span>
+          <button
+            onClick={surrender}
+            style={{
+              pointerEvents: 'auto',
+              padding: '8px 24px',
+              fontSize: 12,
+              cursor: 'pointer',
+              background: 'transparent',
+              border: '1px solid rgba(255,100,100,0.4)',
+              borderRadius: 4,
+              color: 'rgba(255,100,100,0.6)',
+              letterSpacing: 1,
+            }}
+          >
+            Give Up
+          </button>
         </div>
       )}
 

--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -1,7 +1,7 @@
 'use client'
-import { useState, useEffect, useRef } from 'react'
+import { useState, useEffect } from 'react'
 import { useSpeckWarsStore } from '../store'
-import { PLAYER_COLOR, AI_COLOR, WORLD_WIDTH, WORLD_HEIGHT } from '../domain/constants'
+import { PLAYER_COLOR, AI_COLOR } from '../domain/constants'
 import { getBestTime } from '../lib/personal-best'
 
 function colorHex(n: number) {
@@ -549,99 +549,6 @@ export function HUD() {
         )
       })()}
 
-      {/* Minimap — bottom right */}
-      {hud?.minimap && phase !== 'paused' && <Minimap minimap={hud.minimap} />}
     </div>
-  )
-}
-
-const MINIMAP_SIZE = 130
-
-function Minimap({ minimap }: { minimap: NonNullable<import('../domain/types').HudData['minimap']> }) {
-  const canvasRef = useRef<HTMLCanvasElement>(null)
-  const setPendingRally = useSpeckWarsStore(s => s.setPendingRally)
-
-  const handleClick = (e: React.MouseEvent<HTMLCanvasElement>) => {
-    const rect = (e.target as HTMLCanvasElement).getBoundingClientRect()
-    const cx = e.clientX - rect.left
-    const cy = e.clientY - rect.top
-    const wx = (cx / MINIMAP_SIZE) * WORLD_WIDTH
-    const wy = (cy / MINIMAP_SIZE) * WORLD_HEIGHT
-    setPendingRally({ x: wx, y: wy })
-  }
-
-  useEffect(() => {
-    const canvas = canvasRef.current
-    if (!canvas) return
-    const ctx = canvas.getContext('2d')
-    if (!ctx) return
-
-    const W = MINIMAP_SIZE, H = MINIMAP_SIZE
-    const scaleX = W / WORLD_WIDTH
-    const scaleY = H / WORLD_HEIGHT
-
-    ctx.clearRect(0, 0, W, H)
-
-    // Background
-    ctx.fillStyle = 'rgba(0,0,0,0.6)'
-    ctx.fillRect(0, 0, W, H)
-
-    // Specks
-    const playerHex = `#${PLAYER_COLOR.toString(16).padStart(6, '0')}`
-    const aiHex = `#${AI_COLOR.toString(16).padStart(6, '0')}`
-    for (const sp of minimap.specks) {
-      ctx.fillStyle = sp.ownerId === 'player' ? playerHex : aiHex
-      ctx.fillRect(Math.round(sp.x * scaleX) - 0.5, Math.round(sp.y * scaleY) - 0.5, 1.5, 1.5)
-    }
-
-    // Buildings
-    for (const b of minimap.buildings) {
-      const bx = b.x * scaleX, by = b.y * scaleY
-      const isBase = b.typeId === 'base'
-      const r = isBase ? 4 : 2.5
-      ctx.beginPath()
-      ctx.arc(bx, by, r, 0, Math.PI * 2)
-      ctx.fillStyle = b.ownerId === 'player' ? playerHex : b.ownerId === 'ai' ? aiHex : '#888888'
-      ctx.fill()
-      ctx.strokeStyle = 'rgba(255,255,255,0.5)'
-      ctx.lineWidth = 0.8
-      ctx.stroke()
-    }
-
-    // Rally point
-    if (minimap.rallyX !== null && minimap.rallyY !== null) {
-      const rx = minimap.rallyX * scaleX, ry = minimap.rallyY * scaleY
-      ctx.strokeStyle = playerHex
-      ctx.lineWidth = 1
-      ctx.globalAlpha = 0.8
-      ctx.beginPath()
-      ctx.moveTo(rx - 3, ry); ctx.lineTo(rx + 3, ry)
-      ctx.moveTo(rx, ry - 3); ctx.lineTo(rx, ry + 3)
-      ctx.stroke()
-      ctx.globalAlpha = 1
-    }
-
-    // Border
-    ctx.strokeStyle = 'rgba(255,255,255,0.15)'
-    ctx.lineWidth = 1
-    ctx.strokeRect(0.5, 0.5, W - 1, H - 1)
-  }, [minimap])
-
-  return (
-    <canvas
-      ref={canvasRef}
-      width={MINIMAP_SIZE}
-      height={MINIMAP_SIZE}
-      onClick={handleClick}
-      style={{
-        position: 'absolute',
-        bottom: 16,
-        right: 16,
-        borderRadius: 4,
-        imageRendering: 'pixelated',
-        cursor: 'crosshair',
-        pointerEvents: 'auto',
-      }}
-    />
   )
 }

--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -94,6 +94,35 @@ export function HUD() {
           }} />
         </>
       )}
+      {/* Dual base HP bars — top edge, fighting-game style */}
+      {phase === 'playing' && (
+        <div style={{
+          position: 'absolute', top: 0, left: 0, right: 0,
+          display: 'flex', height: 3, pointerEvents: 'none',
+        }}>
+          {/* Player bar: left edge, grows right */}
+          <div style={{ flex: 1, background: 'rgba(0,0,0,0.4)', position: 'relative', overflow: 'hidden' }}>
+            <div style={{
+              position: 'absolute', top: 0, left: 0, bottom: 0,
+              width: `${Math.round(hpFrac * 100)}%`,
+              background: hpFrac > 0.5 ? '#4af7c4' : hpFrac > 0.25 ? '#ffcc44' : '#ff4f7b',
+              transition: 'width 0.3s ease, background 0.5s ease',
+            }} />
+          </div>
+          {/* 1px gap in center */}
+          <div style={{ width: 2, background: 'rgba(0,0,0,0.8)' }} />
+          {/* Enemy bar: right edge, grows left */}
+          <div style={{ flex: 1, background: 'rgba(0,0,0,0.4)', position: 'relative', overflow: 'hidden' }}>
+            <div style={{
+              position: 'absolute', top: 0, right: 0, bottom: 0,
+              width: `${Math.round(aiHpFrac * 100)}%`,
+              background: aiHpFrac > 0.5 ? '#ff4f7b' : aiHpFrac > 0.25 ? '#ffcc44' : '#ff2200',
+              transition: 'width 0.3s ease, background 0.5s ease',
+            }} />
+          </div>
+        </div>
+      )}
+
       {/* Difficulty badge — top right */}
       {(() => {
         const diffColors: Record<string, string> = { easy: '#44ff88', medium: '#ffcc44', hard: '#ff4f7b', 'very-hard': '#cc00ff' }

--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -1,6 +1,7 @@
 'use client'
 import { useSpeckWarsStore } from '../store'
 import { PLAYER_COLOR, AI_COLOR } from '../domain/constants'
+import { getBestTime } from '../lib/personal-best'
 
 function colorHex(n: number) {
   return `#${n.toString(16).padStart(6, '0')}`
@@ -75,6 +76,20 @@ export function HUD() {
       }}>
         <span style={{ fontSize: 15, letterSpacing: 2, opacity: 0.9 }}>
           {formatTime(elapsedMs)}
+          {(() => {
+            const pb = getBestTime(difficulty)
+            if (!pb) return null
+            const ahead = pb - elapsedMs
+            return (
+              <span style={{
+                fontSize: 10, letterSpacing: 1, marginLeft: 8,
+                color: ahead > 0 ? '#ffd700' : '#ff4f7b',
+                opacity: 0.7,
+              }}>
+                {ahead > 0 ? `−${formatTime(ahead)}` : `+${formatTime(-ahead)}`}
+              </span>
+            )
+          })()}
         </span>
         <button
           onClick={togglePause}

--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -20,6 +20,7 @@ export function HUD() {
   const elapsedMs = useSpeckWarsStore(s => s.elapsedMs)
   const speed = useSpeckWarsStore(s => s.speed)
   const cycleSpeed = useSpeckWarsStore(s => s.cycleSpeed)
+  const notification = useSpeckWarsStore(s => s.notification)
 
   return (
     <div style={{
@@ -93,6 +94,24 @@ export function HUD() {
           </div>
         )
       })()}
+
+      {/* Outpost capture/loss notification */}
+      {notification && (
+        <div style={{
+          position: 'absolute', top: 76, left: 0, right: 0,
+          display: 'flex', justifyContent: 'center',
+        }}>
+          <span style={{
+            color: notification.color,
+            fontSize: 13,
+            fontWeight: 'bold',
+            letterSpacing: 2,
+            textShadow: `0 0 12px ${notification.color}`,
+          }}>
+            {notification.message}
+          </span>
+        </div>
+      )}
 
       {/* Paused overlay */}
       {phase === 'paused' && (

--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -40,6 +40,7 @@ export function HUD() {
   const cycleSpawnMode = useSpeckWarsStore(s => s.cycleSpawnMode)
   const difficulty = useSpeckWarsStore(s => s.difficulty)
   const surrender = useSpeckWarsStore(s => s.surrender)
+  const gameActions = useSpeckWarsStore(s => s.gameActions)
 
   const BASE_MAX_HP = 100
   const playerBaseHp = hud?.players.player?.buildingHp['building-player-base']
@@ -512,6 +513,88 @@ export function HUD() {
             }}
           >
             Give Up
+          </button>
+        </div>
+      )}
+
+      {/* Mobile action buttons — bottom right */}
+      {phase === 'playing' && (
+        <div style={{
+          position: 'absolute', bottom: 16, right: 16,
+          display: 'flex', flexDirection: 'row', gap: 6,
+          pointerEvents: 'auto',
+        }}>
+          <button
+            onClick={() => gameActions.defend?.()}
+            title="[D] Defend — rally to your base"
+            style={{
+              padding: '6px 10px',
+              fontSize: 11,
+              cursor: 'pointer',
+              background: 'rgba(74,247,196,0.08)',
+              border: '1px solid rgba(74,247,196,0.4)',
+              borderRadius: 20,
+              color: '#4af7c4',
+              letterSpacing: 1,
+              minHeight: 44,
+              fontFamily: 'monospace',
+            }}
+          >
+            🛡 D
+          </button>
+          <button
+            onClick={() => gameActions.advance?.()}
+            title="[A] Advance — rally to nearest outpost"
+            style={{
+              padding: '6px 10px',
+              fontSize: 11,
+              cursor: 'pointer',
+              background: 'rgba(255,215,0,0.08)',
+              border: '1px solid rgba(255,215,0,0.4)',
+              borderRadius: 20,
+              color: '#ffd700',
+              letterSpacing: 1,
+              minHeight: 44,
+              fontFamily: 'monospace',
+            }}
+          >
+            → A
+          </button>
+          <button
+            onClick={() => gameActions.rush?.()}
+            title="[B] Rush — attack enemy base"
+            style={{
+              padding: '6px 10px',
+              fontSize: 11,
+              cursor: 'pointer',
+              background: 'rgba(255,79,123,0.08)',
+              border: '1px solid rgba(255,79,123,0.4)',
+              borderRadius: 20,
+              color: '#ff4f7b',
+              letterSpacing: 1,
+              minHeight: 44,
+              fontFamily: 'monospace',
+            }}
+          >
+            ⚡ B
+          </button>
+          <button
+            onClick={() => gameActions.clearRally?.()}
+            title="[R] Clear rally"
+            style={{
+              padding: '6px 10px',
+              fontSize: 11,
+              cursor: 'pointer',
+              background: 'rgba(0,0,0,0.4)',
+              border: '1px solid rgba(255,255,255,0.2)',
+              borderRadius: 20,
+              color: 'rgba(255,255,255,0.6)',
+              letterSpacing: 1,
+              minHeight: 44,
+              fontFamily: 'monospace',
+            }}
+          >
+            ✕ R
           </button>
         </div>
       )}

--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -226,12 +226,14 @@ export function HUD() {
       {hud && (() => {
         const OUTPOST_IDS = ['outpost-top', 'outpost-left', 'outpost-right'] as const
         const attacked = new Set(hud.attackedBuildingIds ?? [])
+        const captureInfo = hud.captureInfo ?? {}
         const dots = OUTPOST_IDS.map(id => {
           const isPlayerOwned = hud.players.player?.buildingHp[id] !== undefined
           const isAiOwned = hud.players.ai?.buildingHp[id] !== undefined
           const isUnderAttack = attacked.has(id)
           const color = isPlayerOwned ? '#4af7c4' : isAiOwned ? '#ff4f7b' : '#888888'
-          return { color, isUnderAttack, isPlayerOwned }
+          const cap = captureInfo[id] ?? null
+          return { color, isUnderAttack, isPlayerOwned, cap }
         })
         const playerCount = dots.filter(d => d.isPlayerOwned).length
         return (
@@ -251,15 +253,28 @@ export function HUD() {
               <span style={{ fontSize: 10, letterSpacing: 1, opacity: 0.5, marginRight: 4 }}>
                 OUTPOSTS {playerCount}/{OUTPOST_IDS.length}
               </span>
-              {dots.map(({ color, isUnderAttack, isPlayerOwned }, i) => (
-                <div key={i} style={{
-                  width: 10, height: 10,
-                  borderRadius: '50%',
-                  background: isUnderAttack && isPlayerOwned ? '#ff6b35' : color,
-                  boxShadow: color !== '#888888' ? `0 0 6px ${isUnderAttack && isPlayerOwned ? '#ff6b35' : color}` : 'none',
-                  animation: isUnderAttack && isPlayerOwned ? 'outpost-alert 0.6s ease-in-out infinite' : 'none',
-                }} />
-              ))}
+              {dots.map(({ color, isUnderAttack, isPlayerOwned, cap }, i) => {
+                const capColor = cap?.side === 'player' ? '#4af7c4' : '#ff4f7b'
+                return (
+                  <div key={i} style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 2 }}>
+                    <div style={{
+                      width: 10, height: 10,
+                      borderRadius: '50%',
+                      background: isUnderAttack && isPlayerOwned ? '#ff6b35' : color,
+                      boxShadow: color !== '#888888' ? `0 0 6px ${isUnderAttack && isPlayerOwned ? '#ff6b35' : color}` : 'none',
+                      animation: isUnderAttack && isPlayerOwned ? 'outpost-alert 0.6s ease-in-out infinite' : 'none',
+                    }} />
+                    {cap && cap.progress > 0 && (
+                      <div style={{ width: 14, height: 2, background: 'rgba(255,255,255,0.15)', borderRadius: 1 }}>
+                        <div style={{
+                          width: `${Math.round(cap.progress * 100)}%`,
+                          height: '100%', background: capColor, borderRadius: 1,
+                        }} />
+                      </div>
+                    )}
+                  </div>
+                )
+              })}
             </div>
           </>
         )

--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -193,7 +193,7 @@ export function HUD() {
             border: '1px solid rgba(255,255,255,0.15)',
           }}>
             <span>🖱 Click — rally specks</span><span>Space — pause</span>
-            <span>Scroll — zoom</span><span>R — clear rally</span>
+            <span>Scroll — zoom</span><span>R / Mid-click — clear rally</span>
             <span>Drag — pan camera</span><span>H — heavy/basic mode</span>
             <span>A — advance to outpost</span><span>C — center on base</span>
             <span>B — rush enemy base</span><span>D — defend base</span>

--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -534,6 +534,16 @@ const MINIMAP_SIZE = 130
 
 function Minimap({ minimap }: { minimap: NonNullable<import('../domain/types').HudData['minimap']> }) {
   const canvasRef = useRef<HTMLCanvasElement>(null)
+  const setPendingRally = useSpeckWarsStore(s => s.setPendingRally)
+
+  const handleClick = (e: React.MouseEvent<HTMLCanvasElement>) => {
+    const rect = (e.target as HTMLCanvasElement).getBoundingClientRect()
+    const cx = e.clientX - rect.left
+    const cy = e.clientY - rect.top
+    const wx = (cx / MINIMAP_SIZE) * WORLD_WIDTH
+    const wy = (cy / MINIMAP_SIZE) * WORLD_HEIGHT
+    setPendingRally({ x: wx, y: wy })
+  }
 
   useEffect(() => {
     const canvas = canvasRef.current
@@ -597,12 +607,15 @@ function Minimap({ minimap }: { minimap: NonNullable<import('../domain/types').H
       ref={canvasRef}
       width={MINIMAP_SIZE}
       height={MINIMAP_SIZE}
+      onClick={handleClick}
       style={{
         position: 'absolute',
         bottom: 16,
         right: 16,
         borderRadius: 4,
         imageRendering: 'pixelated',
+        cursor: 'crosshair',
+        pointerEvents: 'auto',
       }}
     />
   )

--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -1,0 +1,33 @@
+'use client'
+import { useSpeckWarsStore } from '../store'
+import { PLAYER_COLOR, AI_COLOR } from '../domain/constants'
+
+function colorHex(n: number) {
+  return `#${n.toString(16).padStart(6, '0')}`
+}
+
+export function HUD() {
+  const hud = useSpeckWarsStore(s => s.hud)
+  if (!hud) return null
+
+  return (
+    <div style={{
+      position: 'absolute', inset: 0, pointerEvents: 'none',
+      fontFamily: 'monospace', fontSize: 13, color: '#fff',
+    }}>
+      {/* Player stats — bottom left */}
+      <div style={{ position: 'absolute', bottom: 16, left: 16 }}>
+        {Object.entries(hud.players).map(([pid, data]) => {
+          const color = pid === 'player' ? colorHex(PLAYER_COLOR) : colorHex(AI_COLOR)
+          const label = pid === 'player' ? 'YOU' : 'AI'
+          const totalHp = Object.values(data.buildingHp).reduce((a, b) => a + b, 0)
+          return (
+            <div key={pid} style={{ marginBottom: 6, color }}>
+              <strong>{label}</strong> — specks: {data.speckCount} | bases: {data.buildingCount} | HP: {totalHp}
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -215,34 +215,61 @@ export function HUD() {
         </div>
       )}
 
-      {/* Battle status indicator */}
+      {/* Battle status indicator + morale badge */}
       {hud && phase === 'playing' && (() => {
         const playerSpecks = hud.players.player?.speckCount ?? 0
         const aiSpecks = hud.players.ai?.speckCount ?? 0
         const total = playerSpecks + aiSpecks
-        if (total < 20) return null  // too few specks — don't show yet
-        const ratio = playerSpecks / total
-        const status =
+        const moraleActive = aiSpecks > 0 && playerSpecks >= 2 * aiSpecks
+        const enemyMoraleActive = playerSpecks > 0 && aiSpecks >= 2 * playerSpecks
+
+        if (total < 20 && !moraleActive && !enemyMoraleActive) return null
+
+        const ratio = playerSpecks / (total || 1)
+        const status = total >= 20 ? (
           ratio > 0.65 ? { label: 'DOMINATING', color: '#4af7c4' }
           : ratio > 0.55 ? { label: 'WINNING', color: '#88ff44' }
           : ratio < 0.35 ? { label: 'CRITICAL', color: '#ff4f7b' }
           : ratio < 0.45 ? { label: 'LOSING', color: '#ffaa44' }
           : null
-        if (!status) return null
+        ) : null
+
         return (
           <div style={{
             position: 'absolute', bottom: 16, left: 0, right: 0,
-            display: 'flex', justifyContent: 'center',
+            display: 'flex', justifyContent: 'center', alignItems: 'center', gap: 12,
           }}>
-            <span style={{
-              fontSize: 11,
-              letterSpacing: 2,
-              color: status.color,
-              opacity: 0.6,
-              textTransform: 'uppercase',
-            }}>
-              {status.label}
-            </span>
+            {status && (
+              <span style={{
+                fontSize: 11,
+                letterSpacing: 2,
+                color: status.color,
+                opacity: 0.6,
+                textTransform: 'uppercase',
+              }}>
+                {status.label}
+              </span>
+            )}
+            {moraleActive && (
+              <span style={{
+                fontSize: 10, letterSpacing: 1,
+                color: '#ffd700', opacity: 0.75,
+                border: '1px solid rgba(255,215,0,0.4)', borderRadius: 3,
+                padding: '2px 6px',
+              }}>
+                ⚡ MORALE +20%
+              </span>
+            )}
+            {enemyMoraleActive && (
+              <span style={{
+                fontSize: 10, letterSpacing: 1,
+                color: '#ff6b35', opacity: 0.75,
+                border: '1px solid rgba(255,107,53,0.4)', borderRadius: 3,
+                padding: '2px 6px',
+              }}>
+                ⚡ ENEMY MORALE
+              </span>
+            )}
           </div>
         )
       })()}

--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -170,6 +170,38 @@ export function HUD() {
         </div>
       )}
 
+      {/* Battle status indicator */}
+      {hud && phase === 'playing' && (() => {
+        const playerSpecks = hud.players.player?.speckCount ?? 0
+        const aiSpecks = hud.players.ai?.speckCount ?? 0
+        const total = playerSpecks + aiSpecks
+        if (total < 20) return null  // too few specks — don't show yet
+        const ratio = playerSpecks / total
+        const status =
+          ratio > 0.65 ? { label: 'DOMINATING', color: '#4af7c4' }
+          : ratio > 0.55 ? { label: 'WINNING', color: '#88ff44' }
+          : ratio < 0.35 ? { label: 'CRITICAL', color: '#ff4f7b' }
+          : ratio < 0.45 ? { label: 'LOSING', color: '#ffaa44' }
+          : null
+        if (!status) return null
+        return (
+          <div style={{
+            position: 'absolute', bottom: 16, left: 0, right: 0,
+            display: 'flex', justifyContent: 'center',
+          }}>
+            <span style={{
+              fontSize: 11,
+              letterSpacing: 2,
+              color: status.color,
+              opacity: 0.6,
+              textTransform: 'uppercase',
+            }}>
+              {status.label}
+            </span>
+          </div>
+        )
+      })()}
+
       {/* Paused overlay */}
       {phase === 'paused' && (
         <div style={{

--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -531,6 +531,37 @@ export function HUD() {
                 </span>
               </div>
             )}
+            {/* Army composition: heavy % indicator */}
+            {(() => {
+              const playerTypes = hud.players.player?.speckTypes ?? {}
+              const aiTypes = hud.players.ai?.speckTypes ?? {}
+              const playerHeavy = playerTypes['heavy'] ?? 0
+              const playerBasic = playerTypes['basic'] ?? 0
+              const aiHeavy = aiTypes['heavy'] ?? 0
+              const aiBasic = aiTypes['basic'] ?? 0
+              const playerTotal = playerHeavy + playerBasic
+              const aiTotal = aiHeavy + aiBasic
+              if (playerTotal < 3 && aiTotal < 3) return null
+              const playerHeavyFrac = playerTotal > 0 ? playerHeavy / playerTotal : 0
+              const aiHeavyFrac = aiTotal > 0 ? aiHeavy / aiTotal : 0
+              return (
+                <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+                  <div title={`You: ${playerHeavy}⬡ heavy, ${playerBasic}· basic`} style={{ width: 20, textAlign: 'right' }}>
+                    {playerHeavy > 0 && <span style={{ fontSize: 8, color: '#ffa032', opacity: 0.7 }}>⬡{playerHeavy}</span>}
+                  </div>
+                  <div style={{ width: 100, height: 3, background: 'rgba(255,255,255,0.08)', borderRadius: 2, overflow: 'hidden', position: 'relative' }}>
+                    <div style={{
+                      position: 'absolute', left: 0, top: 0, height: '100%',
+                      width: `${Math.round(playerHeavyFrac * 100)}%`,
+                      background: '#ffa032', opacity: 0.5, borderRadius: 2,
+                    }} />
+                  </div>
+                  <div title={`Enemy: ${aiHeavy}⬡ heavy, ${aiBasic}· basic`} style={{ width: 20 }}>
+                    {aiHeavy > 0 && <span style={{ fontSize: 8, color: '#ff6b6b', opacity: 0.7 }}>⬡{aiHeavy}</span>}
+                  </div>
+                </div>
+              )
+            })()}
             {/* Kill/loss + enemy base HP */}
             <div style={{ display: 'flex', gap: 10, fontSize: 10, letterSpacing: 0.5 }}>
               <span style={{ color: colorHex(PLAYER_COLOR), opacity: 0.7 }}>↑{kills} ↓{losses}</span>

--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -166,20 +166,32 @@ export function HUD() {
         )
       })()}
 
-      {/* Triple outpost bonus indicator */}
-      {hud?.tripleOutpostOwner === 'player' && phase === 'playing' && (
-        <div style={{
-          position: 'absolute', top: 100, left: 0, right: 0,
-          display: 'flex', justifyContent: 'center',
-        }}>
-          <span style={{
-            fontSize: 11, letterSpacing: 2, fontWeight: 'bold',
-            color: '#ffd700', textShadow: '0 0 8px #ffd700',
+      {/* Triple outpost bonus indicator + domination countdown */}
+      {hud?.tripleOutpostOwner !== null && hud?.tripleOutpostOwner !== undefined && phase === 'playing' && (() => {
+        const isPlayer = hud.tripleOutpostOwner === 'player'
+        const color = isPlayer ? '#ffd700' : '#ff4f7b'
+        const secLeft = hud.dominationProgress != null
+          ? Math.ceil((1 - hud.dominationProgress) * 60)
+          : null
+        return (
+          <div style={{
+            position: 'absolute', top: 100, left: 0, right: 0,
+            display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 4,
           }}>
-            ⬡⬡⬡ TRIPLE CONTROL — SPAWN ×2
-          </span>
-        </div>
-      )}
+            <span style={{
+              fontSize: 11, letterSpacing: 2, fontWeight: 'bold',
+              color, textShadow: `0 0 8px ${color}`,
+            }}>
+              {isPlayer ? '⬡⬡⬡ TRIPLE CONTROL — SPAWN ×2' : '⬡⬡⬡ ENEMY TRIPLE CONTROL'}
+            </span>
+            {secLeft !== null && (
+              <span style={{ fontSize: 10, letterSpacing: 1, color, opacity: 0.7 }}>
+                {isPlayer ? `DOMINATION in ${secLeft}s` : `ENEMY DOMINATES in ${secLeft}s`}
+              </span>
+            )}
+          </div>
+        )
+      })()}
 
       {/* Outpost capture/loss notification */}
       {notification && (

--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -270,6 +270,17 @@ export function HUD() {
                 ⚡ ENEMY MORALE
               </span>
             )}
+            {isCritical && !moraleActive && (
+              <span style={{
+                fontSize: 10, letterSpacing: 1,
+                color: '#ff4f7b', opacity: 0.85,
+                border: '1px solid rgba(255,79,123,0.5)', borderRadius: 3,
+                padding: '2px 6px',
+                fontWeight: 'bold',
+              }}>
+                ⚡ RAGE +40%
+              </span>
+            )}
           </div>
         )
       })()}

--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -1,7 +1,7 @@
 'use client'
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import { useSpeckWarsStore } from '../store'
-import { PLAYER_COLOR, AI_COLOR } from '../domain/constants'
+import { PLAYER_COLOR, AI_COLOR, WORLD_WIDTH, WORLD_HEIGHT } from '../domain/constants'
 import { getBestTime } from '../lib/personal-best'
 
 function colorHex(n: number) {
@@ -509,6 +509,87 @@ export function HUD() {
           </div>
         )
       })()}
+
+      {/* Minimap — bottom right */}
+      {hud?.minimap && phase !== 'paused' && <Minimap minimap={hud.minimap} />}
     </div>
+  )
+}
+
+const MINIMAP_SIZE = 130
+
+function Minimap({ minimap }: { minimap: NonNullable<import('../domain/types').HudData['minimap']> }) {
+  const canvasRef = useRef<HTMLCanvasElement>(null)
+
+  useEffect(() => {
+    const canvas = canvasRef.current
+    if (!canvas) return
+    const ctx = canvas.getContext('2d')
+    if (!ctx) return
+
+    const W = MINIMAP_SIZE, H = MINIMAP_SIZE
+    const scaleX = W / WORLD_WIDTH
+    const scaleY = H / WORLD_HEIGHT
+
+    ctx.clearRect(0, 0, W, H)
+
+    // Background
+    ctx.fillStyle = 'rgba(0,0,0,0.6)'
+    ctx.fillRect(0, 0, W, H)
+
+    // Specks
+    const playerHex = `#${PLAYER_COLOR.toString(16).padStart(6, '0')}`
+    const aiHex = `#${AI_COLOR.toString(16).padStart(6, '0')}`
+    for (const sp of minimap.specks) {
+      ctx.fillStyle = sp.ownerId === 'player' ? playerHex : aiHex
+      ctx.fillRect(Math.round(sp.x * scaleX) - 0.5, Math.round(sp.y * scaleY) - 0.5, 1.5, 1.5)
+    }
+
+    // Buildings
+    for (const b of minimap.buildings) {
+      const bx = b.x * scaleX, by = b.y * scaleY
+      const isBase = b.typeId === 'base'
+      const r = isBase ? 4 : 2.5
+      ctx.beginPath()
+      ctx.arc(bx, by, r, 0, Math.PI * 2)
+      ctx.fillStyle = b.ownerId === 'player' ? playerHex : b.ownerId === 'ai' ? aiHex : '#888888'
+      ctx.fill()
+      ctx.strokeStyle = 'rgba(255,255,255,0.5)'
+      ctx.lineWidth = 0.8
+      ctx.stroke()
+    }
+
+    // Rally point
+    if (minimap.rallyX !== null && minimap.rallyY !== null) {
+      const rx = minimap.rallyX * scaleX, ry = minimap.rallyY * scaleY
+      ctx.strokeStyle = playerHex
+      ctx.lineWidth = 1
+      ctx.globalAlpha = 0.8
+      ctx.beginPath()
+      ctx.moveTo(rx - 3, ry); ctx.lineTo(rx + 3, ry)
+      ctx.moveTo(rx, ry - 3); ctx.lineTo(rx, ry + 3)
+      ctx.stroke()
+      ctx.globalAlpha = 1
+    }
+
+    // Border
+    ctx.strokeStyle = 'rgba(255,255,255,0.15)'
+    ctx.lineWidth = 1
+    ctx.strokeRect(0.5, 0.5, W - 1, H - 1)
+  }, [minimap])
+
+  return (
+    <canvas
+      ref={canvasRef}
+      width={MINIMAP_SIZE}
+      height={MINIMAP_SIZE}
+      style={{
+        position: 'absolute',
+        bottom: 16,
+        right: 16,
+        borderRadius: 4,
+        imageRendering: 'pixelated',
+      }}
+    />
   )
 }

--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -23,6 +23,8 @@ export function HUD() {
   const notification = useSpeckWarsStore(s => s.notification)
   const kills = useSpeckWarsStore(s => s.kills)
   const losses = useSpeckWarsStore(s => s.losses)
+  const spawnMode = useSpeckWarsStore(s => s.spawnMode)
+  const cycleSpawnMode = useSpeckWarsStore(s => s.cycleSpawnMode)
 
   const BASE_MAX_HP = 100
   const playerBaseHp = hud?.players.player?.buildingHp['building-player-base']
@@ -90,6 +92,23 @@ export function HUD() {
           }}
         >
           {speed}×
+        </button>
+        <button
+          onClick={cycleSpawnMode}
+          title="H — toggle spawn mode"
+          style={{
+            pointerEvents: 'auto',
+            padding: '4px 14px',
+            fontSize: 12,
+            cursor: 'pointer',
+            background: spawnMode === 'heavy' ? 'rgba(255,160,50,0.15)' : 'rgba(0,0,0,0.5)',
+            border: `1px solid ${spawnMode === 'heavy' ? '#ffa032' : 'rgba(255,255,255,0.3)'}`,
+            borderRadius: 4,
+            color: spawnMode === 'heavy' ? '#ffa032' : '#fff',
+            letterSpacing: 1,
+          }}
+        >
+          {spawnMode === 'heavy' ? '⬡ HEAVY' : '· BASIC'}
         </button>
       </div>
 

--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -447,6 +447,14 @@ export function HUD() {
               if (basic === 0) return `${heavy}× heavy`
               return `${basic}× basic, ${heavy}× heavy`
             }
+            // Production rate estimate
+            const BASE_MS = spawnMode === 'heavy' ? 1800 : 800
+            const OUTPOST_MS = 1800
+            const playerTriple = hud.tripleOutpostOwner === 'player'
+            const aiOutpostCount = Math.max(0, (hud.players.ai?.buildingCount ?? 0) - 1)
+            const aiTriple = hud.tripleOutpostOwner === 'ai'
+            const playerProd = ((1000/BASE_MS) + playerOutpostCount * (1000/OUTPOST_MS)) * (playerTriple ? 2 : 1)
+            const aiProd = ((1000/800) + aiOutpostCount * (1000/OUTPOST_MS)) * (aiTriple ? 2 : 1)
             return (
               <div style={{
                 display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '8px 32px',
@@ -460,6 +468,8 @@ export function HUD() {
                 <span>{aiSpecks} specks</span>
                 <span style={{ fontSize: 10, opacity: 0.7 }}>{fmtTypes(playerTypes)}</span>
                 <span style={{ fontSize: 10, opacity: 0.7 }}>{fmtTypes(aiTypes)}</span>
+                <span style={{ fontSize: 10, opacity: 0.6 }}>~{playerProd.toFixed(1)}/s prod</span>
+                <span style={{ fontSize: 10, opacity: 0.6 }}>~{aiProd.toFixed(1)}/s prod</span>
                 <span>Base: {Math.round(playerBaseHpVal)}HP</span>
                 <span>Base: {Math.round(aiBaseHpVal)}HP</span>
                 <span>Outposts: {playerOutpostCount}</span>

--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -374,12 +374,41 @@ export function HUD() {
       {phase === 'paused' && (
         <div style={{
           position: 'absolute', inset: 0,
-          background: 'rgba(0,0,0,0.45)',
-          display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', gap: 24,
+          background: 'rgba(0,0,0,0.55)',
+          display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', gap: 20,
         }}>
           <span style={{ fontSize: 36, fontWeight: 'bold', letterSpacing: 4, opacity: 0.9 }}>
             PAUSED
           </span>
+          {hud && (() => {
+            const playerSpecks = hud.players.player?.speckCount ?? 0
+            const aiSpecks = hud.players.ai?.speckCount ?? 0
+            const playerBaseHpVal = hud.players.player?.buildingHp['building-player-base'] ?? 0
+            const aiBaseHpVal = hud.players.ai?.buildingHp['building-ai-base'] ?? 0
+            const playerOutpostCount = hud.players.player?.buildingCount
+              ? hud.players.player.buildingCount - 1  // subtract base
+              : 0
+            return (
+              <div style={{
+                display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '8px 32px',
+                fontSize: 11, letterSpacing: 1, color: 'rgba(255,255,255,0.55)',
+                background: 'rgba(0,0,0,0.3)', padding: '16px 28px', borderRadius: 8,
+                border: '1px solid rgba(255,255,255,0.08)',
+              }}>
+                <span style={{ color: colorHex(PLAYER_COLOR), opacity: 0.8 }}>YOUR ARMY</span>
+                <span style={{ color: colorHex(AI_COLOR), opacity: 0.8 }}>ENEMY ARMY</span>
+                <span>{playerSpecks} specks</span>
+                <span>{aiSpecks} specks</span>
+                <span>Base: {Math.round(playerBaseHpVal)}HP</span>
+                <span>Base: {Math.round(aiBaseHpVal)}HP</span>
+                <span>Outposts: {playerOutpostCount}</span>
+                <span style={{ color: colorHex(PLAYER_COLOR), opacity: 0.7 }}>↑{kills} ↓{losses}</span>
+                <span style={{ gridColumn: '1/-1', textAlign: 'center', borderTop: '1px solid rgba(255,255,255,0.08)', paddingTop: 8, marginTop: 4 }}>
+                  {formatTime(elapsedMs)} elapsed
+                </span>
+              </div>
+            )
+          })()}
           <button
             onClick={surrender}
             style={{

--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -93,9 +93,12 @@ export function HUD() {
         const diffColors: Record<string, string> = { easy: '#44ff88', medium: '#ffcc44', hard: '#ff4f7b', 'very-hard': '#cc00ff' }
         const color = diffColors[difficulty] ?? '#ffffff'
         return (
-          <div style={{ position: 'absolute', top: 12, right: 16, fontSize: 10, letterSpacing: 1 }}>
+          <div style={{ position: 'absolute', top: 12, right: 16, fontSize: 10, letterSpacing: 1, display: 'flex', flexDirection: 'column', alignItems: 'flex-end', gap: 3 }}>
             <span style={{ color, opacity: 0.5, border: `1px solid ${color}`, borderRadius: 3, padding: '2px 6px' }}>
               {difficulty.toUpperCase()}
+            </span>
+            <span style={{ color: 'rgba(255,255,255,0.18)', fontSize: 8, letterSpacing: 0.5 }}>
+              DAILY MAP · {new Date().toLocaleDateString('en-US', { month: 'short', day: 'numeric' }).toUpperCase()}
             </span>
           </div>
         )
@@ -213,7 +216,7 @@ export function HUD() {
             border: '1px solid rgba(255,255,255,0.15)',
           }}>
             <span>🖱 Click — rally specks</span><span>Space — pause</span>
-            <span>Scroll — zoom</span><span>R / Mid-click — clear rally</span>
+            <span>Scroll — zoom</span><span>R / Right-click — clear rally</span>
             <span>Drag — pan camera</span><span>H — heavy/basic mode</span>
             <span>A — advance to outpost</span><span>C — center on base</span>
             <span>B — rush enemy base</span><span>D — defend base</span>

--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -138,6 +138,7 @@ export function HUD() {
           const color = isPlayerOwned ? '#4af7c4' : isAiOwned ? '#ff4f7b' : '#888888'
           return { color, isUnderAttack, isPlayerOwned }
         })
+        const playerCount = dots.filter(d => d.isPlayerOwned).length
         return (
           <>
             {dots.some(d => d.isUnderAttack && d.isPlayerOwned) && (
@@ -152,7 +153,9 @@ export function HUD() {
               position: 'absolute', top: 48, left: 0, right: 0,
               display: 'flex', justifyContent: 'center', alignItems: 'center', gap: 8,
             }}>
-              <span style={{ fontSize: 10, letterSpacing: 1, opacity: 0.5, marginRight: 4 }}>OUTPOSTS</span>
+              <span style={{ fontSize: 10, letterSpacing: 1, opacity: 0.5, marginRight: 4 }}>
+                OUTPOSTS {playerCount}/{OUTPOST_IDS.length}
+              </span>
               {dots.map(({ color, isUnderAttack, isPlayerOwned }, i) => (
                 <div key={i} style={{
                   width: 10, height: 10,

--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -399,26 +399,55 @@ export function HUD() {
         </div>
       )}
 
-      {/* Player stats — bottom left */}
-      {hud && (
-        <div style={{ position: 'absolute', bottom: 16, left: 16 }}>
-          {Object.entries(hud.players)
-            .filter(([pid]) => pid !== 'neutral')
-            .map(([pid, data]) => {
-              const color = pid === 'player' ? colorHex(PLAYER_COLOR) : colorHex(AI_COLOR)
-              const label = pid === 'player' ? 'YOU' : 'AI'
-              const totalHp = Object.values(data.buildingHp).reduce((a, b) => a + b, 0)
-              return (
-                <div key={pid} style={{ marginBottom: 6, color }}>
-                  <strong>{label}</strong> — specks: {data.speckCount} | bases: {data.buildingCount} | HP: {totalHp}
-                  {pid === 'player' && (
-                    <span style={{ opacity: 0.7 }}> | ↑{kills} ↓{losses}</span>
-                  )}
+      {/* Player stats + force bar — bottom left */}
+      {hud && (() => {
+        const playerSpecks = hud.players.player?.speckCount ?? 0
+        const aiSpecks = hud.players.ai?.speckCount ?? 0
+        const total = playerSpecks + aiSpecks
+        const playerFrac = total > 0 ? playerSpecks / total : 0.5
+        const playerBaseHpVal = hud.players.player?.buildingHp['building-player-base'] ?? 0
+        const aiBaseHpVal = hud.players.ai?.buildingHp['building-ai-base'] ?? 0
+        const aiBaseHpFrac = aiBaseHpVal / 100
+        const aiBaseColor = aiBaseHpFrac > 0.5 ? '#ff4f7b' : aiBaseHpFrac > 0.2 ? '#ffaa44' : '#ff2200'
+        return (
+          <div style={{ position: 'absolute', bottom: 16, left: 16, display: 'flex', flexDirection: 'column', gap: 5 }}>
+            {/* Force ratio bar */}
+            {total >= 4 && (
+              <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+                <span style={{ fontSize: 9, letterSpacing: 1, color: colorHex(PLAYER_COLOR), opacity: 0.7, minWidth: 20, textAlign: 'right' }}>
+                  {playerSpecks}
+                </span>
+                <div style={{ width: 100, height: 5, background: 'rgba(255,79,123,0.4)', borderRadius: 3, overflow: 'hidden', position: 'relative' }}>
+                  <div style={{
+                    position: 'absolute', left: 0, top: 0, height: '100%',
+                    width: `${Math.round(playerFrac * 100)}%`,
+                    background: colorHex(PLAYER_COLOR),
+                    borderRadius: 3,
+                    transition: 'width 0.2s',
+                  }} />
                 </div>
-              )
-            })}
-        </div>
-      )}
+                <span style={{ fontSize: 9, letterSpacing: 1, color: colorHex(AI_COLOR), opacity: 0.7, minWidth: 20 }}>
+                  {aiSpecks}
+                </span>
+              </div>
+            )}
+            {/* Kill/loss + enemy base HP */}
+            <div style={{ display: 'flex', gap: 10, fontSize: 10, letterSpacing: 0.5 }}>
+              <span style={{ color: colorHex(PLAYER_COLOR), opacity: 0.7 }}>↑{kills} ↓{losses}</span>
+              {aiBaseHpVal > 0 && (
+                <span style={{ color: aiBaseColor, opacity: 0.8 }}>
+                  ENEMY BASE {Math.round(aiBaseHpFrac * 100)}%
+                </span>
+              )}
+              {playerBaseHpVal > 0 && (
+                <span style={{ color: hpFrac < 0.3 ? '#ff4f7b' : 'rgba(255,255,255,0.4)', opacity: 0.8 }}>
+                  BASE {Math.round(playerBaseHpVal)}HP
+                </span>
+              )}
+            </div>
+          </div>
+        )
+      })()}
     </div>
   )
 }

--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -21,6 +21,8 @@ export function HUD() {
   const speed = useSpeckWarsStore(s => s.speed)
   const cycleSpeed = useSpeckWarsStore(s => s.cycleSpeed)
   const notification = useSpeckWarsStore(s => s.notification)
+  const kills = useSpeckWarsStore(s => s.kills)
+  const losses = useSpeckWarsStore(s => s.losses)
 
   const BASE_MAX_HP = 100
   const playerBaseHp = hud?.players.player?.buildingHp['building-player-base']
@@ -160,6 +162,9 @@ export function HUD() {
               return (
                 <div key={pid} style={{ marginBottom: 6, color }}>
                   <strong>{label}</strong> — specks: {data.speckCount} | bases: {data.buildingCount} | HP: {totalHp}
+                  {pid === 'player' && (
+                    <span style={{ opacity: 0.7 }}> | ↑{kills} ↓{losses}</span>
+                  )}
                 </div>
               )
             })}

--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -227,13 +227,18 @@ export function HUD() {
         const OUTPOST_IDS = ['outpost-top', 'outpost-left', 'outpost-right'] as const
         const attacked = new Set(hud.attackedBuildingIds ?? [])
         const captureInfo = hud.captureInfo ?? {}
+        const OUTPOST_MAX_HP = 50
         const dots = OUTPOST_IDS.map(id => {
           const isPlayerOwned = hud.players.player?.buildingHp[id] !== undefined
           const isAiOwned = hud.players.ai?.buildingHp[id] !== undefined
           const isUnderAttack = attacked.has(id)
           const color = isPlayerOwned ? '#4af7c4' : isAiOwned ? '#ff4f7b' : '#888888'
           const cap = captureInfo[id] ?? null
-          return { color, isUnderAttack, isPlayerOwned, cap }
+          const hp = isPlayerOwned ? hud.players.player?.buildingHp[id]
+            : isAiOwned ? hud.players.ai?.buildingHp[id]
+            : undefined
+          const hpFrac = hp !== undefined ? hp / OUTPOST_MAX_HP : undefined
+          return { color, isUnderAttack, isPlayerOwned, cap, hpFrac }
         })
         const playerCount = dots.filter(d => d.isPlayerOwned).length
         return (
@@ -253,7 +258,7 @@ export function HUD() {
               <span style={{ fontSize: 10, letterSpacing: 1, opacity: 0.5, marginRight: 4 }}>
                 OUTPOSTS {playerCount}/{OUTPOST_IDS.length}
               </span>
-              {dots.map(({ color, isUnderAttack, isPlayerOwned, cap }, i) => {
+              {dots.map(({ color, isUnderAttack, isPlayerOwned, cap, hpFrac }, i) => {
                 const capColor = cap?.side === 'player' ? '#4af7c4' : '#ff4f7b'
                 return (
                   <div key={i} style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 2 }}>
@@ -264,14 +269,23 @@ export function HUD() {
                       boxShadow: color !== '#888888' ? `0 0 6px ${isUnderAttack && isPlayerOwned ? '#ff6b35' : color}` : 'none',
                       animation: isUnderAttack && isPlayerOwned ? 'outpost-alert 0.6s ease-in-out infinite' : 'none',
                     }} />
-                    {cap && cap.progress > 0 && (
+                    {cap && cap.progress > 0 ? (
                       <div style={{ width: 14, height: 2, background: 'rgba(255,255,255,0.15)', borderRadius: 1 }}>
                         <div style={{
                           width: `${Math.round(cap.progress * 100)}%`,
                           height: '100%', background: capColor, borderRadius: 1,
                         }} />
                       </div>
-                    )}
+                    ) : hpFrac !== undefined && hpFrac < 0.99 ? (
+                      <div style={{ width: 14, height: 2, background: 'rgba(255,255,255,0.12)', borderRadius: 1 }}>
+                        <div style={{
+                          width: `${Math.round(hpFrac * 100)}%`,
+                          height: '100%',
+                          background: hpFrac > 0.5 ? color : hpFrac > 0.2 ? '#ffaa44' : '#ff2200',
+                          borderRadius: 1,
+                        }} />
+                      </div>
+                    ) : null}
                   </div>
                 )
               })}

--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -2,7 +2,7 @@
 import { useState, useEffect } from 'react'
 import { useSpeckWarsStore } from '../store'
 import { PLAYER_COLOR, AI_COLOR } from '../domain/constants'
-import { getBestTime } from '../lib/personal-best'
+import { getBestTime, getWinStreak } from '../lib/personal-best'
 
 function colorHex(n: number) {
   return `#${n.toString(16).padStart(6, '0')}`
@@ -17,6 +17,11 @@ function formatTime(ms: number): string {
 
 export function HUD() {
   const [showHelp, setShowHelp] = useState(false)
+  const [winStreak, setWinStreak] = useState(0)
+
+  useEffect(() => {
+    setWinStreak(getWinStreak())
+  }, [])
 
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
@@ -110,7 +115,7 @@ export function HUD() {
         position: 'absolute', top: 12, left: 0, right: 0,
         display: 'flex', justifyContent: 'center', alignItems: 'center', gap: 12,
       }}>
-        <span style={{ fontSize: 15, letterSpacing: 2, opacity: 0.9 }}>
+        <span style={{ fontSize: 15, letterSpacing: 2, opacity: 0.9, display: 'flex', alignItems: 'center', gap: 6 }}>
           {formatTime(elapsedMs)}
           {(() => {
             const pb = getBestTime(difficulty)
@@ -118,7 +123,7 @@ export function HUD() {
             const ahead = pb - elapsedMs
             return (
               <span style={{
-                fontSize: 10, letterSpacing: 1, marginLeft: 8,
+                fontSize: 10, letterSpacing: 1,
                 color: ahead > 0 ? '#ffd700' : '#ff4f7b',
                 opacity: 0.7,
               }}>
@@ -126,6 +131,16 @@ export function HUD() {
               </span>
             )
           })()}
+          {winStreak >= 2 && (
+            <span style={{
+              fontSize: 9, letterSpacing: 1,
+              color: '#ffd700', opacity: 0.65,
+              border: '1px solid rgba(255,215,0,0.35)',
+              borderRadius: 3, padding: '1px 5px',
+            }}>
+              🔥 ×{winStreak}
+            </span>
+          )}
         </span>
         <button
           onClick={togglePause}

--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -56,8 +56,8 @@ export function HUD() {
       )}
       {/* Difficulty badge — top right */}
       {(() => {
-        const diffColors = { easy: '#44ff88', medium: '#ffcc44', hard: '#ff4f7b' }
-        const color = diffColors[difficulty]
+        const diffColors: Record<string, string> = { easy: '#44ff88', medium: '#ffcc44', hard: '#ff4f7b', 'very-hard': '#cc00ff' }
+        const color = diffColors[difficulty] ?? '#ffffff'
         return (
           <div style={{ position: 'absolute', top: 12, right: 16, fontSize: 10, letterSpacing: 1 }}>
             <span style={{ color, opacity: 0.5, border: `1px solid ${color}`, borderRadius: 3, padding: '2px 6px' }}>

--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -22,11 +22,33 @@ export function HUD() {
   const cycleSpeed = useSpeckWarsStore(s => s.cycleSpeed)
   const notification = useSpeckWarsStore(s => s.notification)
 
+  const BASE_MAX_HP = 100
+  const playerBaseHp = hud?.players.player?.buildingHp['building-player-base']
+  const hpFrac = playerBaseHp !== undefined ? playerBaseHp / BASE_MAX_HP : 1
+  const isDanger = phase === 'playing' && hpFrac < 0.3
+  const isCritical = phase === 'playing' && hpFrac < 0.15
+
   return (
     <div style={{
       position: 'absolute', inset: 0, pointerEvents: 'none',
       fontFamily: 'monospace', fontSize: 13, color: '#fff',
     }}>
+      {isDanger && (
+        <>
+          <style>{`
+            @keyframes danger-pulse {
+              from { opacity: ${isCritical ? 0.4 : 0.15}; }
+              to   { opacity: ${isCritical ? 0.7 : 0.35}; }
+            }
+          `}</style>
+          <div style={{
+            position: 'absolute', inset: 0,
+            background: 'radial-gradient(ellipse at center, transparent 45%, rgba(220,30,30,1) 100%)',
+            animation: `danger-pulse ${isCritical ? '0.5s' : '1s'} ease-in-out infinite alternate`,
+            pointerEvents: 'none',
+          }} />
+        </>
+      )}
       {/* Timer + Pause button — top bar */}
       <div style={{
         position: 'absolute', top: 12, left: 0, right: 0,

--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -25,6 +25,7 @@ export function HUD() {
   const losses = useSpeckWarsStore(s => s.losses)
   const spawnMode = useSpeckWarsStore(s => s.spawnMode)
   const cycleSpawnMode = useSpeckWarsStore(s => s.cycleSpawnMode)
+  const difficulty = useSpeckWarsStore(s => s.difficulty)
 
   const BASE_MAX_HP = 100
   const playerBaseHp = hud?.players.player?.buildingHp['building-player-base']
@@ -53,6 +54,19 @@ export function HUD() {
           }} />
         </>
       )}
+      {/* Difficulty badge — top right */}
+      {(() => {
+        const diffColors = { easy: '#44ff88', medium: '#ffcc44', hard: '#ff4f7b' }
+        const color = diffColors[difficulty]
+        return (
+          <div style={{ position: 'absolute', top: 12, right: 16, fontSize: 10, letterSpacing: 1 }}>
+            <span style={{ color, opacity: 0.5, border: `1px solid ${color}`, borderRadius: 3, padding: '2px 6px' }}>
+              {difficulty.toUpperCase()}
+            </span>
+          </div>
+        )
+      })()}
+
       {/* Timer + Pause button — top bar */}
       <div style={{
         position: 'absolute', top: 12, left: 0, right: 0,

--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -283,10 +283,24 @@ export function HUD() {
             }}>
               {isPlayer ? '⬡⬡⬡ TRIPLE CONTROL — SPAWN ×2' : '⬡⬡⬡ ENEMY TRIPLE CONTROL'}
             </span>
-            {secLeft !== null && (
-              <span style={{ fontSize: 10, letterSpacing: 1, color, opacity: 0.7 }}>
-                {isPlayer ? `DOMINATION in ${secLeft}s` : `ENEMY DOMINATES in ${secLeft}s`}
-              </span>
+            {hud.dominationProgress !== null && (
+              <>
+                <div style={{ width: 160, height: 3, background: 'rgba(255,255,255,0.12)', borderRadius: 2, overflow: 'hidden' }}>
+                  <div style={{
+                    height: '100%',
+                    width: `${Math.round(hud.dominationProgress * 100)}%`,
+                    background: color,
+                    borderRadius: 2,
+                    boxShadow: `0 0 6px ${color}`,
+                    transition: 'width 0.3s',
+                  }} />
+                </div>
+                {secLeft !== null && (
+                  <span style={{ fontSize: 10, letterSpacing: 1, color, opacity: 0.7 }}>
+                    {isPlayer ? `DOMINATION in ${secLeft}s` : `ENEMY DOMINATES in ${secLeft}s`}
+                  </span>
+                )}
+              </>
             )}
           </div>
         )

--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -278,13 +278,23 @@ export function HUD() {
           position: 'absolute', top: 76, left: 0, right: 0,
           display: 'flex', justifyContent: 'center',
         }}>
-          <span style={{
-            color: notification.color,
-            fontSize: 13,
-            fontWeight: 'bold',
-            letterSpacing: 2,
-            textShadow: `0 0 12px ${notification.color}`,
-          }}>
+          <style>{`
+            @keyframes notif-in {
+              from { opacity: 0; transform: translateY(-8px) scale(0.92); }
+              to   { opacity: 1; transform: translateY(0)  scale(1); }
+            }
+          `}</style>
+          <span
+            key={notification.message + notification.color}
+            style={{
+              color: notification.color,
+              fontSize: 13,
+              fontWeight: 'bold',
+              letterSpacing: 2,
+              textShadow: `0 0 12px ${notification.color}`,
+              animation: 'notif-in 0.18s ease-out',
+            }}
+          >
             {notification.message}
           </span>
         </div>

--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -1,4 +1,5 @@
 'use client'
+import { useState, useEffect } from 'react'
 import { useSpeckWarsStore } from '../store'
 import { PLAYER_COLOR, AI_COLOR } from '../domain/constants'
 import { getBestTime } from '../lib/personal-best'
@@ -15,6 +16,17 @@ function formatTime(ms: number): string {
 }
 
 export function HUD() {
+  const [showHelp, setShowHelp] = useState(false)
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.code === 'Slash' && e.shiftKey) { e.preventDefault(); setShowHelp(h => !h) }
+      if (e.code === 'Escape') setShowHelp(false)
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [])
+
   const hud = useSpeckWarsStore(s => s.hud)
   const phase = useSpeckWarsStore(s => s.phase)
   const togglePause = useSpeckWarsStore(s => s.togglePause)
@@ -140,7 +152,55 @@ export function HUD() {
         >
           {spawnMode === 'heavy' ? '⬡ HEAVY' : '· BASIC'}
         </button>
+        <button
+          onClick={() => setShowHelp(h => !h)}
+          title="? — show controls"
+          style={{
+            pointerEvents: 'auto',
+            padding: '4px 10px',
+            fontSize: 12,
+            cursor: 'pointer',
+            background: showHelp ? 'rgba(255,255,255,0.15)' : 'rgba(0,0,0,0.5)',
+            border: `1px solid ${showHelp ? 'rgba(255,255,255,0.6)' : 'rgba(255,255,255,0.3)'}`,
+            borderRadius: 4,
+            color: '#fff',
+          }}
+        >
+          ?
+        </button>
       </div>
+
+      {/* Help overlay */}
+      {showHelp && (
+        <div
+          onClick={() => setShowHelp(false)}
+          style={{
+            position: 'absolute', inset: 0,
+            background: 'rgba(0,0,0,0.7)',
+            display: 'flex', alignItems: 'center', justifyContent: 'center',
+            pointerEvents: 'auto', cursor: 'default',
+          }}
+        >
+          <div style={{
+            display: 'grid', gridTemplateColumns: '1fr 1fr',
+            gap: '6px 32px',
+            color: 'rgba(255,255,255,0.8)',
+            fontSize: 13,
+            letterSpacing: 0.5,
+            background: 'rgba(0,0,0,0.5)',
+            padding: '24px 32px',
+            borderRadius: 8,
+            border: '1px solid rgba(255,255,255,0.15)',
+          }}>
+            <span>🖱 Click — rally specks</span><span>Space — pause</span>
+            <span>Scroll — zoom</span><span>R — clear rally</span>
+            <span>Drag — pan camera</span><span>H — heavy/basic mode</span>
+            <span>A — advance to outpost</span><span>C — center on base</span>
+            <span>B — rush enemy base</span><span>D — defend base</span>
+            <span>Minimap — click to rally</span><span>? — this help</span>
+          </div>
+        </div>
+      )}
 
       {/* Outpost ownership indicator dots */}
       {hud && (() => {

--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -18,6 +18,8 @@ export function HUD() {
   const phase = useSpeckWarsStore(s => s.phase)
   const togglePause = useSpeckWarsStore(s => s.togglePause)
   const elapsedMs = useSpeckWarsStore(s => s.elapsedMs)
+  const speed = useSpeckWarsStore(s => s.speed)
+  const cycleSpeed = useSpeckWarsStore(s => s.cycleSpeed)
 
   return (
     <div style={{
@@ -47,6 +49,22 @@ export function HUD() {
           }}
         >
           {phase === 'paused' ? 'RESUME' : 'PAUSE'}
+        </button>
+        <button
+          onClick={cycleSpeed}
+          style={{
+            pointerEvents: 'auto',
+            padding: '4px 14px',
+            fontSize: 12,
+            cursor: 'pointer',
+            background: speed > 1 ? 'rgba(74,247,196,0.15)' : 'rgba(0,0,0,0.5)',
+            border: `1px solid ${speed > 1 ? '#4af7c4' : 'rgba(255,255,255,0.3)'}`,
+            borderRadius: 4,
+            color: speed > 1 ? '#4af7c4' : '#fff',
+            letterSpacing: 1,
+          }}
+        >
+          {speed}×
         </button>
       </div>
 

--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -47,6 +47,10 @@ export function HUD() {
   const isDanger = phase === 'playing' && hpFrac < 0.3
   const isCritical = phase === 'playing' && hpFrac < 0.15
 
+  const aiBaseHp = hud?.players.ai?.buildingHp['building-ai-base']
+  const aiHpFrac = aiBaseHp !== undefined ? aiBaseHp / BASE_MAX_HP : 1
+  const isWinning = phase === 'playing' && aiHpFrac < 0.2 && aiHpFrac > 0  // enemy near death
+
   return (
     <div style={{
       position: 'absolute', inset: 0, pointerEvents: 'none',
@@ -64,6 +68,22 @@ export function HUD() {
             position: 'absolute', inset: 0,
             background: 'radial-gradient(ellipse at center, transparent 45%, rgba(220,30,30,1) 100%)',
             animation: `danger-pulse ${isCritical ? '0.5s' : '1s'} ease-in-out infinite alternate`,
+            pointerEvents: 'none',
+          }} />
+        </>
+      )}
+      {isWinning && (
+        <>
+          <style>{`
+            @keyframes win-pulse {
+              from { opacity: 0.1; }
+              to   { opacity: 0.28; }
+            }
+          `}</style>
+          <div style={{
+            position: 'absolute', inset: 0,
+            background: 'radial-gradient(ellipse at center, transparent 50%, rgba(20,220,120,1) 100%)',
+            animation: 'win-pulse 1.2s ease-in-out infinite alternate',
             pointerEvents: 'none',
           }} />
         </>

--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -6,28 +6,80 @@ function colorHex(n: number) {
   return `#${n.toString(16).padStart(6, '0')}`
 }
 
+function formatTime(ms: number): string {
+  const totalSec = Math.floor(ms / 1000)
+  const m = Math.floor(totalSec / 60)
+  const s = totalSec % 60
+  return `${m.toString().padStart(2, '0')}:${s.toString().padStart(2, '0')}`
+}
+
 export function HUD() {
   const hud = useSpeckWarsStore(s => s.hud)
-  if (!hud) return null
+  const phase = useSpeckWarsStore(s => s.phase)
+  const togglePause = useSpeckWarsStore(s => s.togglePause)
+  const elapsedMs = useSpeckWarsStore(s => s.elapsedMs)
 
   return (
     <div style={{
       position: 'absolute', inset: 0, pointerEvents: 'none',
       fontFamily: 'monospace', fontSize: 13, color: '#fff',
     }}>
-      {/* Player stats — bottom left */}
-      <div style={{ position: 'absolute', bottom: 16, left: 16 }}>
-        {Object.entries(hud.players).map(([pid, data]) => {
-          const color = pid === 'player' ? colorHex(PLAYER_COLOR) : colorHex(AI_COLOR)
-          const label = pid === 'player' ? 'YOU' : 'AI'
-          const totalHp = Object.values(data.buildingHp).reduce((a, b) => a + b, 0)
-          return (
-            <div key={pid} style={{ marginBottom: 6, color }}>
-              <strong>{label}</strong> — specks: {data.speckCount} | bases: {data.buildingCount} | HP: {totalHp}
-            </div>
-          )
-        })}
+      {/* Timer + Pause button — top bar */}
+      <div style={{
+        position: 'absolute', top: 12, left: 0, right: 0,
+        display: 'flex', justifyContent: 'center', alignItems: 'center', gap: 12,
+      }}>
+        <span style={{ fontSize: 15, letterSpacing: 2, opacity: 0.9 }}>
+          {formatTime(elapsedMs)}
+        </span>
+        <button
+          onClick={togglePause}
+          style={{
+            pointerEvents: 'auto',
+            padding: '4px 14px',
+            fontSize: 12,
+            cursor: 'pointer',
+            background: 'rgba(0,0,0,0.5)',
+            border: '1px solid rgba(255,255,255,0.3)',
+            borderRadius: 4,
+            color: '#fff',
+            letterSpacing: 1,
+          }}
+        >
+          {phase === 'paused' ? 'RESUME' : 'PAUSE'}
+        </button>
       </div>
+
+      {/* Paused overlay */}
+      {phase === 'paused' && (
+        <div style={{
+          position: 'absolute', inset: 0,
+          background: 'rgba(0,0,0,0.45)',
+          display: 'flex', alignItems: 'center', justifyContent: 'center',
+        }}>
+          <span style={{ fontSize: 36, fontWeight: 'bold', letterSpacing: 4, opacity: 0.9 }}>
+            PAUSED
+          </span>
+        </div>
+      )}
+
+      {/* Player stats — bottom left */}
+      {hud && (
+        <div style={{ position: 'absolute', bottom: 16, left: 16 }}>
+          {Object.entries(hud.players)
+            .filter(([pid]) => pid !== 'neutral')
+            .map(([pid, data]) => {
+              const color = pid === 'player' ? colorHex(PLAYER_COLOR) : colorHex(AI_COLOR)
+              const label = pid === 'player' ? 'YOU' : 'AI'
+              const totalHp = Object.values(data.buildingHp).reduce((a, b) => a + b, 0)
+              return (
+                <div key={pid} style={{ marginBottom: 6, color }}>
+                  <strong>{label}</strong> — specks: {data.speckCount} | bases: {data.buildingCount} | HP: {totalHp}
+                </div>
+              )
+            })}
+        </div>
+      )}
     </div>
   )
 }

--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -50,6 +50,32 @@ export function HUD() {
         </button>
       </div>
 
+      {/* Outpost ownership indicator dots */}
+      {hud && (() => {
+        const OUTPOST_IDS = ['outpost-top', 'outpost-left', 'outpost-right'] as const
+        const dots = OUTPOST_IDS.map(id => {
+          if (hud.players.player?.buildingHp[id] !== undefined) return '#4af7c4'
+          if (hud.players.ai?.buildingHp[id] !== undefined) return '#ff4f7b'
+          return '#888888'
+        })
+        return (
+          <div style={{
+            position: 'absolute', top: 48, left: 0, right: 0,
+            display: 'flex', justifyContent: 'center', alignItems: 'center', gap: 8,
+          }}>
+            <span style={{ fontSize: 10, letterSpacing: 1, opacity: 0.5, marginRight: 4 }}>OUTPOSTS</span>
+            {dots.map((color, i) => (
+              <div key={i} style={{
+                width: 10, height: 10,
+                borderRadius: '50%',
+                background: color,
+                boxShadow: color !== '#888888' ? `0 0 6px ${color}` : 'none',
+              }} />
+            ))}
+          </div>
+        )
+      })()}
+
       {/* Paused overlay */}
       {phase === 'paused' && (
         <div style={{

--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -96,26 +96,40 @@ export function HUD() {
       {/* Outpost ownership indicator dots */}
       {hud && (() => {
         const OUTPOST_IDS = ['outpost-top', 'outpost-left', 'outpost-right'] as const
+        const attacked = new Set(hud.attackedBuildingIds ?? [])
         const dots = OUTPOST_IDS.map(id => {
-          if (hud.players.player?.buildingHp[id] !== undefined) return '#4af7c4'
-          if (hud.players.ai?.buildingHp[id] !== undefined) return '#ff4f7b'
-          return '#888888'
+          const isPlayerOwned = hud.players.player?.buildingHp[id] !== undefined
+          const isAiOwned = hud.players.ai?.buildingHp[id] !== undefined
+          const isUnderAttack = attacked.has(id)
+          const color = isPlayerOwned ? '#4af7c4' : isAiOwned ? '#ff4f7b' : '#888888'
+          return { color, isUnderAttack, isPlayerOwned }
         })
         return (
-          <div style={{
-            position: 'absolute', top: 48, left: 0, right: 0,
-            display: 'flex', justifyContent: 'center', alignItems: 'center', gap: 8,
-          }}>
-            <span style={{ fontSize: 10, letterSpacing: 1, opacity: 0.5, marginRight: 4 }}>OUTPOSTS</span>
-            {dots.map((color, i) => (
-              <div key={i} style={{
-                width: 10, height: 10,
-                borderRadius: '50%',
-                background: color,
-                boxShadow: color !== '#888888' ? `0 0 6px ${color}` : 'none',
-              }} />
-            ))}
-          </div>
+          <>
+            {dots.some(d => d.isUnderAttack && d.isPlayerOwned) && (
+              <style>{`
+                @keyframes outpost-alert {
+                  0%, 100% { opacity: 1; transform: scale(1); }
+                  50% { opacity: 0.3; transform: scale(1.5); }
+                }
+              `}</style>
+            )}
+            <div style={{
+              position: 'absolute', top: 48, left: 0, right: 0,
+              display: 'flex', justifyContent: 'center', alignItems: 'center', gap: 8,
+            }}>
+              <span style={{ fontSize: 10, letterSpacing: 1, opacity: 0.5, marginRight: 4 }}>OUTPOSTS</span>
+              {dots.map(({ color, isUnderAttack, isPlayerOwned }, i) => (
+                <div key={i} style={{
+                  width: 10, height: 10,
+                  borderRadius: '50%',
+                  background: isUnderAttack && isPlayerOwned ? '#ff6b35' : color,
+                  boxShadow: color !== '#888888' ? `0 0 6px ${isUnderAttack && isPlayerOwned ? '#ff6b35' : color}` : 'none',
+                  animation: isUnderAttack && isPlayerOwned ? 'outpost-alert 0.6s ease-in-out infinite' : 'none',
+                }} />
+              ))}
+            </div>
+          </>
         )
       })()}
 

--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -152,6 +152,21 @@ export function HUD() {
         )
       })()}
 
+      {/* Triple outpost bonus indicator */}
+      {hud?.tripleOutpostOwner === 'player' && phase === 'playing' && (
+        <div style={{
+          position: 'absolute', top: 100, left: 0, right: 0,
+          display: 'flex', justifyContent: 'center',
+        }}>
+          <span style={{
+            fontSize: 11, letterSpacing: 2, fontWeight: 'bold',
+            color: '#ffd700', textShadow: '0 0 8px #ffd700',
+          }}>
+            ⬡⬡⬡ TRIPLE CONTROL — SPAWN ×2
+          </span>
+        </div>
+      )}
+
       {/* Outpost capture/loss notification */}
       {notification && (
         <div style={{

--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -408,6 +408,16 @@ export function HUD() {
             const playerOutpostCount = hud.players.player?.buildingCount
               ? hud.players.player.buildingCount - 1  // subtract base
               : 0
+            const playerTypes = hud.players.player?.speckTypes ?? {}
+            const aiTypes = hud.players.ai?.speckTypes ?? {}
+            const fmtTypes = (t: Record<string, number>) => {
+              const basic = t['basic'] ?? 0
+              const heavy = t['heavy'] ?? 0
+              if (basic === 0 && heavy === 0) return '—'
+              if (heavy === 0) return `${basic}× basic`
+              if (basic === 0) return `${heavy}× heavy`
+              return `${basic}× basic, ${heavy}× heavy`
+            }
             return (
               <div style={{
                 display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '8px 32px',
@@ -419,6 +429,8 @@ export function HUD() {
                 <span style={{ color: colorHex(AI_COLOR), opacity: 0.8 }}>ENEMY ARMY</span>
                 <span>{playerSpecks} specks</span>
                 <span>{aiSpecks} specks</span>
+                <span style={{ fontSize: 10, opacity: 0.7 }}>{fmtTypes(playerTypes)}</span>
+                <span style={{ fontSize: 10, opacity: 0.7 }}>{fmtTypes(aiTypes)}</span>
                 <span>Base: {Math.round(playerBaseHpVal)}HP</span>
                 <span>Base: {Math.round(aiBaseHpVal)}HP</span>
                 <span>Outposts: {playerOutpostCount}</span>

--- a/src/app/speck-wars/components/minimap.tsx
+++ b/src/app/speck-wars/components/minimap.tsx
@@ -59,6 +59,7 @@ export function Minimap({ gameRef }: MinimapProps) {
 
       // Draw buildings
       const neutralColor = '#888888'
+      const nowMs = Date.now()
       for (const building of Object.values(sim.buildings)) {
         ctx.fillStyle = building.ownerId === 'player' ? playerColor
           : building.ownerId === 'ai' ? aiColor
@@ -76,6 +77,21 @@ export function Minimap({ gameRef }: MinimapProps) {
         ctx.beginPath()
         ctx.arc(bx, by, 5, -Math.PI / 2, -Math.PI / 2 + Math.PI * 2 * hpFrac)
         ctx.stroke()
+        // Capture alert: pulsing colored ring around outpost being captured by enemy
+        if (building.typeId === 'outpost' && building.captureSide && building.captureSide !== 'neutral') {
+          const isEnemyCapturing = building.captureSide === 'ai'
+          if (isEnemyCapturing || (building.ownerId === 'ai' && building.captureSide === 'player')) {
+            const pulse = 0.4 + 0.6 * Math.abs(Math.sin(nowMs / 250))
+            const captureColor = building.captureSide === 'player' ? playerColor : aiColor
+            ctx.strokeStyle = captureColor
+            ctx.lineWidth = 1.5
+            ctx.globalAlpha = pulse * 0.85
+            ctx.beginPath()
+            ctx.arc(bx, by, 7, 0, Math.PI * 2)
+            ctx.stroke()
+            ctx.globalAlpha = 1
+          }
+        }
       }
 
       // Draw rally point

--- a/src/app/speck-wars/components/minimap.tsx
+++ b/src/app/speck-wars/components/minimap.tsx
@@ -78,6 +78,21 @@ export function Minimap({ gameRef }: MinimapProps) {
         ctx.stroke()
       }
 
+      // Draw rally point
+      const rp = sim.rallyPoints['player']
+      if (rp) {
+        const rx = rp.x * SCALE_X
+        const ry = rp.y * SCALE_Y
+        ctx.strokeStyle = playerColor
+        ctx.lineWidth = 1.5
+        ctx.globalAlpha = 0.7
+        ctx.beginPath()
+        ctx.moveTo(rx - 4, ry); ctx.lineTo(rx + 4, ry)
+        ctx.moveTo(rx, ry - 4); ctx.lineTo(rx, ry + 4)
+        ctx.stroke()
+        ctx.globalAlpha = 1
+      }
+
       // Draw viewport rectangle
       // The camera maps world→screen as: screenX = worldX * zoom + camera.x
       // Use window dimensions as the screen size approximation

--- a/src/app/speck-wars/components/minimap.tsx
+++ b/src/app/speck-wars/components/minimap.tsx
@@ -1,0 +1,123 @@
+'use client'
+import { useEffect, useRef } from 'react'
+import type { GameInstance } from '../game-instance'
+import { WORLD_WIDTH, WORLD_HEIGHT, PLAYER_COLOR, AI_COLOR } from '../domain/constants'
+
+const MAP_W = 160
+const MAP_H = 160
+const SCALE_X = MAP_W / WORLD_WIDTH
+const SCALE_Y = MAP_H / WORLD_HEIGHT
+
+function hexColor(n: number): string {
+  return `#${n.toString(16).padStart(6, '0')}`
+}
+
+interface MinimapProps {
+  gameRef: React.RefObject<GameInstance | null>
+}
+
+export function Minimap({ gameRef }: MinimapProps) {
+  const canvasRef = useRef<HTMLCanvasElement>(null)
+
+  useEffect(() => {
+    let rafId: number
+    let lastDraw = 0
+
+    const draw = (now: number) => {
+      rafId = requestAnimationFrame(draw)
+      if (now - lastDraw < 100) return  // ~10fps
+      lastDraw = now
+
+      const canvas = canvasRef.current
+      const game = gameRef.current
+      if (!canvas || !game) return
+
+      const ctx = canvas.getContext('2d')
+      if (!ctx) return
+
+      const sim = game.getSim()
+      const camera = game.getCamera()
+
+      // Clear
+      ctx.clearRect(0, 0, MAP_W, MAP_H)
+      ctx.fillStyle = 'rgba(0,0,0,0.65)'
+      ctx.fillRect(0, 0, MAP_W, MAP_H)
+
+      // Draw specks (sample every 4th for performance)
+      const playerColor = hexColor(PLAYER_COLOR)
+      const aiColor = hexColor(AI_COLOR)
+      for (let i = 0; i < sim.speckCount; i += 4) {
+        if (!sim.speckIds[i] || !sim.speckMeta[i]) continue
+        const ownerId = sim.speckMeta[i]!.ownerId
+        ctx.fillStyle = ownerId === 'player' ? playerColor : aiColor
+        ctx.fillRect(
+          sim.speckX[i] * SCALE_X,
+          sim.speckY[i] * SCALE_Y,
+          1.5, 1.5
+        )
+      }
+
+      // Draw buildings
+      for (const building of Object.values(sim.buildings)) {
+        ctx.fillStyle = building.ownerId === 'player' ? playerColor : aiColor
+        const bx = building.x * SCALE_X
+        const by = building.y * SCALE_Y
+        ctx.beginPath()
+        ctx.arc(bx, by, 4, 0, Math.PI * 2)
+        ctx.fill()
+        // HP ring
+        const hpFrac = building.hp / building.maxHp
+        ctx.strokeStyle = hpFrac > 0.5 ? '#44ff88' : '#ff4444'
+        ctx.lineWidth = 1
+        ctx.beginPath()
+        ctx.arc(bx, by, 5, -Math.PI / 2, -Math.PI / 2 + Math.PI * 2 * hpFrac)
+        ctx.stroke()
+      }
+
+      // Draw viewport rectangle
+      // The camera maps world→screen as: screenX = worldX * zoom + camera.x
+      // Use window dimensions as the screen size approximation
+      const sw = window.innerWidth
+      const sh = window.innerHeight
+      const wLeft = (0 - camera.x) / camera.zoom
+      const wTop = (0 - camera.y) / camera.zoom
+      const wRight = (sw - camera.x) / camera.zoom
+      const wBottom = (sh - camera.y) / camera.zoom
+
+      ctx.strokeStyle = 'rgba(255,255,255,0.5)'
+      ctx.lineWidth = 1
+      ctx.strokeRect(
+        wLeft * SCALE_X,
+        wTop * SCALE_Y,
+        (wRight - wLeft) * SCALE_X,
+        (wBottom - wTop) * SCALE_Y
+      )
+
+      // Border
+      ctx.strokeStyle = 'rgba(255,255,255,0.3)'
+      ctx.lineWidth = 1
+      ctx.strokeRect(0, 0, MAP_W, MAP_H)
+    }
+
+    rafId = requestAnimationFrame(draw)
+    return () => cancelAnimationFrame(rafId)
+  }, [gameRef])
+
+  return (
+    <canvas
+      ref={canvasRef}
+      width={MAP_W}
+      height={MAP_H}
+      style={{
+        position: 'absolute',
+        bottom: 16,
+        right: 16,
+        width: MAP_W,
+        height: MAP_H,
+        borderRadius: 4,
+        imageRendering: 'pixelated',
+        pointerEvents: 'none',
+      }}
+    />
+  )
+}

--- a/src/app/speck-wars/components/minimap.tsx
+++ b/src/app/speck-wars/components/minimap.tsx
@@ -122,11 +122,22 @@ export function Minimap({ gameRef }: MinimapProps) {
     return () => cancelAnimationFrame(rafId)
   }, [gameRef])
 
+  const handleClick = (e: React.MouseEvent<HTMLCanvasElement>) => {
+    const game = gameRef.current
+    if (!game) return
+    const rect = e.currentTarget.getBoundingClientRect()
+    const mx = e.clientX - rect.left
+    const my = e.clientY - rect.top
+    game.rally(mx / SCALE_X, my / SCALE_Y)
+  }
+
   return (
     <canvas
       ref={canvasRef}
       width={MAP_W}
       height={MAP_H}
+      onClick={handleClick}
+      title="Click to set rally point"
       style={{
         position: 'absolute',
         bottom: 16,
@@ -135,7 +146,7 @@ export function Minimap({ gameRef }: MinimapProps) {
         height: MAP_H,
         borderRadius: 4,
         imageRendering: 'pixelated',
-        pointerEvents: 'none',
+        cursor: 'crosshair',
       }}
     />
   )

--- a/src/app/speck-wars/components/minimap.tsx
+++ b/src/app/speck-wars/components/minimap.tsx
@@ -93,6 +93,21 @@ export function Minimap({ gameRef }: MinimapProps) {
         ctx.globalAlpha = 1
       }
 
+      // Draw AI rally point (where enemy force is heading)
+      const aiRp = sim.rallyPoints['ai']
+      if (aiRp) {
+        const rx = aiRp.x * SCALE_X
+        const ry = aiRp.y * SCALE_Y
+        ctx.strokeStyle = aiColor
+        ctx.lineWidth = 1
+        ctx.globalAlpha = 0.45
+        ctx.beginPath()
+        ctx.moveTo(rx - 3, ry); ctx.lineTo(rx + 3, ry)
+        ctx.moveTo(rx, ry - 3); ctx.lineTo(rx, ry + 3)
+        ctx.stroke()
+        ctx.globalAlpha = 1
+      }
+
       // Draw viewport rectangle
       // The camera maps world→screen as: screenX = worldX * zoom + camera.x
       // Use window dimensions as the screen size approximation

--- a/src/app/speck-wars/components/minimap.tsx
+++ b/src/app/speck-wars/components/minimap.tsx
@@ -58,12 +58,16 @@ export function Minimap({ gameRef }: MinimapProps) {
       }
 
       // Draw buildings
+      const neutralColor = '#888888'
       for (const building of Object.values(sim.buildings)) {
-        ctx.fillStyle = building.ownerId === 'player' ? playerColor : aiColor
+        ctx.fillStyle = building.ownerId === 'player' ? playerColor
+          : building.ownerId === 'ai' ? aiColor
+          : neutralColor
         const bx = building.x * SCALE_X
         const by = building.y * SCALE_Y
+        const buildingRadius = building.typeId === 'outpost' ? 3 : 4
         ctx.beginPath()
-        ctx.arc(bx, by, 4, 0, Math.PI * 2)
+        ctx.arc(bx, by, buildingRadius, 0, Math.PI * 2)
         ctx.fill()
         // HP ring
         const hpFrac = building.hp / building.maxHp

--- a/src/app/speck-wars/components/phase-router.tsx
+++ b/src/app/speck-wars/components/phase-router.tsx
@@ -1,10 +1,23 @@
 'use client'
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { useSpeckWarsStore } from '../store'
+import { getBestTime } from '../lib/personal-best'
+import type { Difficulty } from '../store'
 
 export function PhaseRouter({ children }: { children: React.ReactNode }) {
-  const { phase, winnerId, setPhase, difficulty, setDifficulty, elapsedMs, resetGame, kills, losses } = useSpeckWarsStore()
+  const { phase, winnerId, setPhase, difficulty, setDifficulty, elapsedMs, resetGame, kills, losses, isNewBest } = useSpeckWarsStore()
   const [copied, setCopied] = useState(false)
+  const [bestTimes, setBestTimes] = useState<Partial<Record<Difficulty, number>>>({})
+
+  useEffect(() => {
+    if (phase === 'menu') {
+      setBestTimes({
+        easy: getBestTime('easy') ?? undefined,
+        medium: getBestTime('medium') ?? undefined,
+        hard: getBestTime('hard') ?? undefined,
+      })
+    }
+  }, [phase])
 
   const difficulties: Array<{ key: 'easy' | 'medium' | 'hard'; label: string; color: string }> = [
     { key: 'easy', label: 'Easy', color: '#44ff88' },
@@ -37,6 +50,20 @@ export function PhaseRouter({ children }: { children: React.ReactNode }) {
               {d.label}
             </button>
           ))}
+        </div>
+        {/* Best times per difficulty */}
+        <div style={{ display: 'flex', gap: 16, fontSize: 11, color: 'rgba(255,255,255,0.4)' }}>
+          {difficulties.map(d => {
+            const best = bestTimes[d.key]
+            if (!best) return null
+            const mm = String(Math.floor(Math.floor(best / 1000) / 60)).padStart(2, '0')
+            const ss = String(Math.floor(best / 1000) % 60).padStart(2, '0')
+            return (
+              <span key={d.key} style={{ color: d.color, opacity: 0.6 }}>
+                {d.label}: {mm}:{ss}
+              </span>
+            )
+          })}
         </div>
         <button
           onClick={() => setPhase('playing')}
@@ -110,6 +137,11 @@ export function PhaseRouter({ children }: { children: React.ReactNode }) {
         <h1 style={{ color: accentColor, fontSize: 64, margin: 0, letterSpacing: 4 }}>
           {won ? 'VICTORY' : 'DEFEATED'}
         </h1>
+        {won && isNewBest && (
+          <div style={{ color: '#ffd700', fontSize: 16, letterSpacing: 3, fontWeight: 'bold', textShadow: '0 0 16px #ffd700' }}>
+            ★ NEW BEST TIME ★
+          </div>
+        )}
 
         <div style={{ display: 'flex', gap: 24, alignItems: 'center', color: 'rgba(255,255,255,0.7)', fontSize: 16 }}>
           <span>⏱ {timeStr}</span>

--- a/src/app/speck-wars/components/phase-router.tsx
+++ b/src/app/speck-wars/components/phase-router.tsx
@@ -5,7 +5,7 @@ import { getBestTime, getWinStreak, getRecentResults } from '../lib/personal-bes
 import type { Difficulty } from '../store'
 
 export function PhaseRouter({ children }: { children: React.ReactNode }) {
-  const { phase, winnerId, setPhase, difficulty, setDifficulty, elapsedMs, resetGame, kills, losses, isNewBest, victoryType } = useSpeckWarsStore()
+  const { phase, winnerId, setPhase, difficulty, setDifficulty, elapsedMs, resetGame, kills, losses, isNewBest, victoryType, hud } = useSpeckWarsStore()
   const [copied, setCopied] = useState(false)
   const [bestTimes, setBestTimes] = useState<Partial<Record<Difficulty, number>>>({})
   const [winStreak, setWinStreak] = useState(0)
@@ -128,6 +128,12 @@ export function PhaseRouter({ children }: { children: React.ReactNode }) {
     const difficultyColors: Record<string, string> = { easy: '#44ff88', medium: '#ffcc44', hard: '#ff4f7b', 'very-hard': '#cc00ff' }
     const diffLabel = difficulty === 'very-hard' ? 'Brutal' : difficulty.charAt(0).toUpperCase() + difficulty.slice(1)
     const diffColor = difficultyColors[difficulty]
+    const playerBaseHp = hud?.players?.player?.buildingHp?.['building-player-base'] ?? 0
+    const baseHpFrac = playerBaseHp / 100
+    const stars = won
+      ? baseHpFrac > 0.75 ? 3 : baseHpFrac > 0.5 ? 2 : 1
+      : 0
+
     const nextDifficulty: Partial<Record<string, { key: Difficulty; label: string; color: string }>> = {
       easy:   { key: 'medium',    label: 'Medium', color: '#ffcc44' },
       medium: { key: 'hard',      label: 'Hard',   color: '#ff4f7b' },
@@ -172,9 +178,14 @@ export function PhaseRouter({ children }: { children: React.ReactNode }) {
             {victoryType === 'domination' ? '⬡ by Domination' : '💥 by Destruction'}
           </div>
         )}
+        {won && (
+          <div style={{ fontSize: 28, letterSpacing: 4, color: '#ffd700', textShadow: stars === 3 ? '0 0 20px #ffd700' : 'none' }}>
+            {'★'.repeat(stars)}{'☆'.repeat(3 - stars)}
+          </div>
+        )}
         {won && isNewBest && (
-          <div style={{ color: '#ffd700', fontSize: 16, letterSpacing: 3, fontWeight: 'bold', textShadow: '0 0 16px #ffd700' }}>
-            ★ NEW BEST TIME ★
+          <div style={{ color: '#ffd700', fontSize: 14, letterSpacing: 3, fontWeight: 'bold', textShadow: '0 0 16px #ffd700' }}>
+            NEW BEST TIME
           </div>
         )}
 

--- a/src/app/speck-wars/components/phase-router.tsx
+++ b/src/app/speck-wars/components/phase-router.tsx
@@ -192,12 +192,24 @@ export function PhaseRouter({ children }: { children: React.ReactNode }) {
           {won ? 'VICTORY' : 'DEFEATED'}
         </h1>
         {victoryType && (
-          <div style={{
-            fontSize: 12, letterSpacing: 3, opacity: 0.6,
-            color: victoryType === 'domination' ? '#ffd700' : accentColor,
-            textTransform: 'uppercase',
-          }}>
-            {victoryType === 'domination' ? '⬡ by Domination' : '💥 by Destruction'}
+          <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 4 }}>
+            <div style={{
+              fontSize: 12, letterSpacing: 3, opacity: 0.6,
+              color: victoryType === 'domination' ? '#ffd700' : accentColor,
+              textTransform: 'uppercase',
+            }}>
+              {victoryType === 'domination' ? '⬡ by Domination' : '💥 by Destruction'}
+            </div>
+            <div style={{ fontSize: 10, letterSpacing: 1, opacity: 0.35, color: '#fff' }}>
+              {won
+                ? victoryType === 'domination'
+                  ? 'held all 3 outposts for 60 seconds'
+                  : 'destroyed the enemy base'
+                : victoryType === 'domination'
+                  ? 'enemy held all 3 outposts for 60 seconds'
+                  : 'your base was destroyed'
+              }
+            </div>
           </div>
         )}
         {won && (

--- a/src/app/speck-wars/components/phase-router.tsx
+++ b/src/app/speck-wars/components/phase-router.tsx
@@ -62,6 +62,8 @@ export function PhaseRouter({ children }: { children: React.ReactNode }) {
           <span>R — clear rally</span>
           <span>Drag — pan camera</span>
           <span>H — heavy/basic mode</span>
+          <span>C — center on base</span>
+          <span>Minimap — click to rally</span>
         </div>
       </div>
     )

--- a/src/app/speck-wars/components/phase-router.tsx
+++ b/src/app/speck-wars/components/phase-router.tsx
@@ -61,7 +61,7 @@ export function PhaseRouter({ children }: { children: React.ReactNode }) {
           <span>Scroll — zoom</span>
           <span>R — clear rally</span>
           <span>Drag — pan camera</span>
-          <span>1×/2×/4× — speed</span>
+          <span>H — heavy/basic mode</span>
         </div>
       </div>
     )

--- a/src/app/speck-wars/components/phase-router.tsx
+++ b/src/app/speck-wars/components/phase-router.tsx
@@ -5,7 +5,7 @@ import { getBestTime, getWinStreak } from '../lib/personal-best'
 import type { Difficulty } from '../store'
 
 export function PhaseRouter({ children }: { children: React.ReactNode }) {
-  const { phase, winnerId, setPhase, difficulty, setDifficulty, elapsedMs, resetGame, kills, losses, isNewBest } = useSpeckWarsStore()
+  const { phase, winnerId, setPhase, difficulty, setDifficulty, elapsedMs, resetGame, kills, losses, isNewBest, victoryType } = useSpeckWarsStore()
   const [copied, setCopied] = useState(false)
   const [bestTimes, setBestTimes] = useState<Partial<Record<Difficulty, number>>>({})
   const [winStreak, setWinStreak] = useState(0)
@@ -154,6 +154,15 @@ export function PhaseRouter({ children }: { children: React.ReactNode }) {
         <h1 style={{ color: accentColor, fontSize: 64, margin: 0, letterSpacing: 4 }}>
           {won ? 'VICTORY' : 'DEFEATED'}
         </h1>
+        {victoryType && (
+          <div style={{
+            fontSize: 12, letterSpacing: 3, opacity: 0.6,
+            color: victoryType === 'domination' ? '#ffd700' : accentColor,
+            textTransform: 'uppercase',
+          }}>
+            {victoryType === 'domination' ? '⬡ by Domination' : '💥 by Destruction'}
+          </div>
+        )}
         {won && isNewBest && (
           <div style={{ color: '#ffd700', fontSize: 16, letterSpacing: 3, fontWeight: 'bold', textShadow: '0 0 16px #ffd700' }}>
             ★ NEW BEST TIME ★

--- a/src/app/speck-wars/components/phase-router.tsx
+++ b/src/app/speck-wars/components/phase-router.tsx
@@ -30,10 +30,11 @@ export function PhaseRouter({ children }: { children: React.ReactNode }) {
     return () => window.removeEventListener('keydown', onKey)
   }, [phase, setPhase])
 
-  const difficulties: Array<{ key: 'easy' | 'medium' | 'hard'; label: string; color: string }> = [
+  const difficulties: Array<{ key: 'easy' | 'medium' | 'hard' | 'very-hard'; label: string; color: string }> = [
     { key: 'easy', label: 'Easy', color: '#44ff88' },
     { key: 'medium', label: 'Medium', color: '#ffcc44' },
     { key: 'hard', label: 'Hard', color: '#ff4f7b' },
+    { key: 'very-hard', label: 'Brutal', color: '#cc00ff' },
   ]
 
   if (phase === 'menu') {
@@ -122,8 +123,8 @@ export function PhaseRouter({ children }: { children: React.ReactNode }) {
     const ss = String(totalSec % 60).padStart(2, '0')
     const timeStr = `${mm}:${ss}`
 
-    const difficultyColors: Record<string, string> = { easy: '#44ff88', medium: '#ffcc44', hard: '#ff4f7b' }
-    const diffLabel = difficulty.charAt(0).toUpperCase() + difficulty.slice(1)
+    const difficultyColors: Record<string, string> = { easy: '#44ff88', medium: '#ffcc44', hard: '#ff4f7b', 'very-hard': '#cc00ff' }
+    const diffLabel = difficulty === 'very-hard' ? 'Brutal' : difficulty.charAt(0).toUpperCase() + difficulty.slice(1)
     const diffColor = difficultyColors[difficulty]
 
     const shareText = won

--- a/src/app/speck-wars/components/phase-router.tsx
+++ b/src/app/speck-wars/components/phase-router.tsx
@@ -1,7 +1,7 @@
 'use client'
 import { useState, useEffect } from 'react'
 import { useSpeckWarsStore } from '../store'
-import { getBestTime, getWinStreak } from '../lib/personal-best'
+import { getBestTime, getWinStreak, getRecentResults } from '../lib/personal-best'
 import type { Difficulty } from '../store'
 
 export function PhaseRouter({ children }: { children: React.ReactNode }) {
@@ -187,6 +187,32 @@ export function PhaseRouter({ children }: { children: React.ReactNode }) {
             </span>
           )}
         </div>
+
+        {/* Recent run history for this difficulty */}
+        {(() => {
+          const history = getRecentResults(difficulty)
+          if (history.length < 2) return null
+          return (
+            <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 6 }}>
+              <span style={{ fontSize: 10, letterSpacing: 2, color: 'rgba(255,255,255,0.3)' }}>
+                RECENT ({difficulty.toUpperCase()})
+              </span>
+              <div style={{ display: 'flex', gap: 6 }}>
+                {history.map((r, i) => {
+                  const mm = String(Math.floor(Math.floor(r.timeMs / 1000) / 60)).padStart(2, '0')
+                  const ss = String(Math.floor(r.timeMs / 1000) % 60).padStart(2, '0')
+                  return (
+                    <div key={i} title={`${r.won ? 'Win' : 'Loss'} — ${mm}:${ss} — ${r.kills} kills`} style={{
+                      width: 10, height: 10, borderRadius: '50%',
+                      background: r.won ? '#4af7c4' : '#ff4f7b',
+                      opacity: i === 0 ? 1 : 0.4 + (history.length - i) / history.length * 0.4,
+                    }} />
+                  )
+                })}
+              </div>
+            </div>
+          )
+        })()}
 
         <div style={{ display: 'flex', gap: 12, marginTop: 8 }}>
           <button

--- a/src/app/speck-wars/components/phase-router.tsx
+++ b/src/app/speck-wars/components/phase-router.tsx
@@ -2,13 +2,40 @@
 import { useSpeckWarsStore } from '../store'
 
 export function PhaseRouter({ children }: { children: React.ReactNode }) {
-  const { phase, winnerId, setPhase } = useSpeckWarsStore()
+  const { phase, winnerId, setPhase, difficulty, setDifficulty } = useSpeckWarsStore()
+
+  const difficulties: Array<{ key: 'easy' | 'medium' | 'hard'; label: string; color: string }> = [
+    { key: 'easy', label: 'Easy', color: '#44ff88' },
+    { key: 'medium', label: 'Medium', color: '#ffcc44' },
+    { key: 'hard', label: 'Hard', color: '#ff4f7b' },
+  ]
 
   if (phase === 'menu') {
     return (
       <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', height: '100%', gap: 16 }}>
         <h1 style={{ color: '#fff', fontSize: 48, margin: 0 }}>Speck Wars</h1>
         <p style={{ color: '#aaa', margin: 0 }}>Destroy the enemy base. Last base standing wins.</p>
+        <div style={{ display: 'flex', gap: 8, marginBottom: 8 }}>
+          {difficulties.map(d => (
+            <button
+              key={d.key}
+              onClick={() => setDifficulty(d.key)}
+              style={{
+                padding: '8px 20px',
+                fontSize: 14,
+                cursor: 'pointer',
+                border: `2px solid ${difficulty === d.key ? d.color : 'rgba(255,255,255,0.2)'}`,
+                borderRadius: 6,
+                background: difficulty === d.key ? `${d.color}22` : 'transparent',
+                color: difficulty === d.key ? d.color : 'rgba(255,255,255,0.5)',
+                fontWeight: difficulty === d.key ? 'bold' : 'normal',
+                transition: 'all 0.15s',
+              }}
+            >
+              {d.label}
+            </button>
+          ))}
+        </div>
         <button
           onClick={() => setPhase('playing')}
           style={{ padding: '12px 32px', fontSize: 18, cursor: 'pointer', background: '#4af7c4', border: 'none', borderRadius: 8, fontWeight: 'bold' }}

--- a/src/app/speck-wars/components/phase-router.tsx
+++ b/src/app/speck-wars/components/phase-router.tsx
@@ -142,8 +142,9 @@ export function PhaseRouter({ children }: { children: React.ReactNode }) {
     const nextDiff = won ? nextDifficulty[difficulty] : null
 
     const today = new Date().toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
+    const starStr = won ? '★'.repeat(stars) + '☆'.repeat(3 - stars) + ' ' : ''
     const shareText = won
-      ? `I defeated the AI in Speck Wars (${diffLabel}) in ${timeStr} — killed ${kills} specks! 🎮 Daily map ${today} — can you beat my time?`
+      ? `${starStr}I defeated the AI in Speck Wars (${diffLabel}) in ${timeStr} — killed ${kills} specks! 🎮 Daily map ${today} — can you beat my time?`
       : `The AI beat me in Speck Wars (${diffLabel}) in ${timeStr} — killed ${kills} specks. 🎮 Daily map ${today} — think you can do better?`
 
     const handleShare = async () => {

--- a/src/app/speck-wars/components/phase-router.tsx
+++ b/src/app/speck-wars/components/phase-router.tsx
@@ -1,0 +1,36 @@
+'use client'
+import { useSpeckWarsStore } from '../store'
+
+export function PhaseRouter({ children }: { children: React.ReactNode }) {
+  const { phase, winnerId, setPhase } = useSpeckWarsStore()
+
+  if (phase === 'menu') {
+    return (
+      <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', height: '100%', gap: 16 }}>
+        <h1 style={{ color: '#fff', fontSize: 48, margin: 0 }}>Speck Wars</h1>
+        <p style={{ color: '#aaa', margin: 0 }}>Destroy the enemy base. Last base standing wins.</p>
+        <button
+          onClick={() => setPhase('playing')}
+          style={{ padding: '12px 32px', fontSize: 18, cursor: 'pointer', background: '#4af7c4', border: 'none', borderRadius: 8, fontWeight: 'bold' }}
+        >
+          Play
+        </button>
+      </div>
+    )
+  }
+
+  if (phase === 'victory' || phase === 'defeat') {
+    const won = winnerId === 'player'
+    return (
+      <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', height: '100%', gap: 16 }}>
+        <h1 style={{ color: won ? '#4af7c4' : '#ff4f7b', fontSize: 48 }}>{won ? 'Victory' : 'Defeated'}</h1>
+        <button onClick={() => window.location.reload()} style={{ padding: '12px 32px', fontSize: 18, cursor: 'pointer' }}>
+          Play Again
+        </button>
+      </div>
+    )
+  }
+
+  // 'playing' — render game + HUD overlay
+  return <>{children}</>
+}

--- a/src/app/speck-wars/components/phase-router.tsx
+++ b/src/app/speck-wars/components/phase-router.tsx
@@ -21,6 +21,15 @@ export function PhaseRouter({ children }: { children: React.ReactNode }) {
     }
   }, [phase])
 
+  useEffect(() => {
+    if (phase !== 'menu') return
+    const onKey = (e: KeyboardEvent) => {
+      if (e.code === 'Enter') setPhase('playing')
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [phase, setPhase])
+
   const difficulties: Array<{ key: 'easy' | 'medium' | 'hard'; label: string; color: string }> = [
     { key: 'easy', label: 'Easy', color: '#44ff88' },
     { key: 'medium', label: 'Medium', color: '#ffcc44' },

--- a/src/app/speck-wars/components/phase-router.tsx
+++ b/src/app/speck-wars/components/phase-router.tsx
@@ -30,6 +30,19 @@ export function PhaseRouter({ children }: { children: React.ReactNode }) {
     return () => window.removeEventListener('keydown', onKey)
   }, [phase, setPhase])
 
+  useEffect(() => {
+    if (phase !== 'victory' && phase !== 'defeat') return
+    const onKey = (e: KeyboardEvent) => {
+      if (e.code === 'Enter' || e.code === 'Space') {
+        e.preventDefault()
+        resetGame()
+        setPhase('playing')
+      }
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [phase, resetGame, setPhase])
+
   const difficulties: Array<{ key: 'easy' | 'medium' | 'hard' | 'very-hard'; label: string; color: string }> = [
     { key: 'easy', label: 'Easy', color: '#44ff88' },
     { key: 'medium', label: 'Medium', color: '#ffcc44' },
@@ -246,7 +259,8 @@ export function PhaseRouter({ children }: { children: React.ReactNode }) {
           )
         })()}
 
-        <div style={{ display: 'flex', gap: 12, marginTop: 8 }}>
+        <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 6, marginTop: 8 }}>
+          <div style={{ display: 'flex', gap: 12 }}>
           <button
             onClick={resetGame}
             style={{
@@ -278,6 +292,10 @@ export function PhaseRouter({ children }: { children: React.ReactNode }) {
           >
             ← Cave
           </a>
+          </div>
+          <span style={{ fontSize: 10, letterSpacing: 1, color: 'rgba(255,255,255,0.25)' }}>
+            Enter / Space — play again
+          </span>
         </div>
         {nextDiff && (
           <button

--- a/src/app/speck-wars/components/phase-router.tsx
+++ b/src/app/speck-wars/components/phase-router.tsx
@@ -107,6 +107,7 @@ export function PhaseRouter({ children }: { children: React.ReactNode }) {
           <span>Drag — pan camera</span>
           <span>H — heavy/basic mode</span>
           <span>A — advance to outpost</span>
+          <span>B — rush enemy base</span>
           <span>C — center on base</span>
           <span>D — defend base</span>
           <span>Minimap — click to rally</span>

--- a/src/app/speck-wars/components/phase-router.tsx
+++ b/src/app/speck-wars/components/phase-router.tsx
@@ -1,7 +1,7 @@
 'use client'
 import { useState, useEffect } from 'react'
 import { useSpeckWarsStore } from '../store'
-import { getBestTime, getWinStreak, getRecentResults } from '../lib/personal-best'
+import { getBestTime, getWinStreak, getRecentResults, hasWonToday } from '../lib/personal-best'
 import type { Difficulty } from '../store'
 
 export function PhaseRouter({ children }: { children: React.ReactNode }) {
@@ -61,25 +61,38 @@ export function PhaseRouter({ children }: { children: React.ReactNode }) {
           </div>
         )}
         <div style={{ display: 'flex', gap: 8, marginBottom: 8 }}>
-          {difficulties.map(d => (
-            <button
-              key={d.key}
-              onClick={() => setDifficulty(d.key)}
-              style={{
-                padding: '8px 20px',
-                fontSize: 14,
-                cursor: 'pointer',
-                border: `2px solid ${difficulty === d.key ? d.color : 'rgba(255,255,255,0.2)'}`,
-                borderRadius: 6,
-                background: difficulty === d.key ? `${d.color}22` : 'transparent',
-                color: difficulty === d.key ? d.color : 'rgba(255,255,255,0.5)',
-                fontWeight: difficulty === d.key ? 'bold' : 'normal',
-                transition: 'all 0.15s',
-              }}
-            >
-              {d.label}
-            </button>
-          ))}
+          {difficulties.map(d => {
+            const wonToday = hasWonToday(d.key)
+            return (
+              <button
+                key={d.key}
+                onClick={() => setDifficulty(d.key)}
+                style={{
+                  padding: '8px 20px',
+                  fontSize: 14,
+                  cursor: 'pointer',
+                  border: `2px solid ${difficulty === d.key ? d.color : wonToday ? `${d.color}66` : 'rgba(255,255,255,0.2)'}`,
+                  borderRadius: 6,
+                  background: difficulty === d.key ? `${d.color}22` : 'transparent',
+                  color: difficulty === d.key ? d.color : wonToday ? `${d.color}99` : 'rgba(255,255,255,0.5)',
+                  fontWeight: difficulty === d.key ? 'bold' : 'normal',
+                  transition: 'all 0.15s',
+                  position: 'relative',
+                }}
+              >
+                {d.label}
+                {wonToday && (
+                  <span style={{
+                    position: 'absolute', top: -6, right: -6,
+                    fontSize: 10, background: d.color, color: '#000',
+                    borderRadius: '50%', width: 14, height: 14,
+                    display: 'flex', alignItems: 'center', justifyContent: 'center',
+                    fontWeight: 'bold',
+                  }}>✓</span>
+                )}
+              </button>
+            )
+          })}
         </div>
         {/* Best times + win rates per difficulty */}
         <div style={{ display: 'flex', gap: 16, fontSize: 11 }}>

--- a/src/app/speck-wars/components/phase-router.tsx
+++ b/src/app/speck-wars/components/phase-router.tsx
@@ -106,6 +106,7 @@ export function PhaseRouter({ children }: { children: React.ReactNode }) {
           <span>R — clear rally</span>
           <span>Drag — pan camera</span>
           <span>H — heavy/basic mode</span>
+          <span>A — advance to outpost</span>
           <span>C — center on base</span>
           <span>D — defend base</span>
           <span>Minimap — click to rally</span>

--- a/src/app/speck-wars/components/phase-router.tsx
+++ b/src/app/speck-wars/components/phase-router.tsx
@@ -1,4 +1,5 @@
 'use client'
+import { useState } from 'react'
 import { useSpeckWarsStore } from '../store'
 
 export function PhaseRouter({ children }: { children: React.ReactNode }) {
@@ -59,6 +60,27 @@ export function PhaseRouter({ children }: { children: React.ReactNode }) {
     const diffLabel = difficulty.charAt(0).toUpperCase() + difficulty.slice(1)
     const diffColor = difficultyColors[difficulty]
 
+    const shareText = won
+      ? `I defeated the AI in Speck Wars (${diffLabel}) in ${timeStr}! 🎮 Can you beat my time?`
+      : `The AI beat me in Speck Wars (${diffLabel}) in ${timeStr}! 🎮 Think you can do better?`
+
+    const [copied, setCopied] = useState(false)
+
+    const handleShare = async () => {
+      const url = typeof window !== 'undefined' ? window.location.href : ''
+      if (typeof navigator !== 'undefined' && navigator.share) {
+        try {
+          await navigator.share({ title: 'Speck Wars', text: shareText, url })
+        } catch {
+          // user cancelled — no action needed
+        }
+      } else {
+        await navigator.clipboard.writeText(`${shareText} ${url}`)
+        setCopied(true)
+        setTimeout(() => setCopied(false), 2000)
+      }
+    }
+
     return (
       <div style={{
         display: 'flex', flexDirection: 'column', alignItems: 'center',
@@ -86,6 +108,16 @@ export function PhaseRouter({ children }: { children: React.ReactNode }) {
             }}
           >
             Play Again
+          </button>
+          <button
+            onClick={handleShare}
+            style={{
+              padding: '12px 28px', fontSize: 16, cursor: 'pointer',
+              background: 'transparent', border: `2px solid ${accentColor}`,
+              borderRadius: 8, color: accentColor,
+            }}
+          >
+            {copied ? 'Copied!' : 'Share'}
           </button>
           <a
             href="/"

--- a/src/app/speck-wars/components/phase-router.tsx
+++ b/src/app/speck-wars/components/phase-router.tsx
@@ -141,9 +141,10 @@ export function PhaseRouter({ children }: { children: React.ReactNode }) {
     }
     const nextDiff = won ? nextDifficulty[difficulty] : null
 
+    const today = new Date().toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
     const shareText = won
-      ? `I defeated the AI in Speck Wars (${diffLabel}) in ${timeStr} — killed ${kills} specks! 🎮 Can you beat my time?`
-      : `The AI beat me in Speck Wars (${diffLabel}) in ${timeStr} — killed ${kills} specks. 🎮 Think you can do better?`
+      ? `I defeated the AI in Speck Wars (${diffLabel}) in ${timeStr} — killed ${kills} specks! 🎮 Daily map ${today} — can you beat my time?`
+      : `The AI beat me in Speck Wars (${diffLabel}) in ${timeStr} — killed ${kills} specks. 🎮 Daily map ${today} — think you can do better?`
 
     const handleShare = async () => {
       const url = typeof window !== 'undefined' ? window.location.href : ''

--- a/src/app/speck-wars/components/phase-router.tsx
+++ b/src/app/speck-wars/components/phase-router.tsx
@@ -197,6 +197,11 @@ export function PhaseRouter({ children }: { children: React.ReactNode }) {
             NEW BEST TIME
           </div>
         )}
+        {won && winStreak >= 2 && (
+          <div style={{ color: '#ffd700', fontSize: 13, letterSpacing: 2 }}>
+            🔥 {winStreak}-WIN STREAK
+          </div>
+        )}
 
         <div style={{ display: 'flex', gap: 24, alignItems: 'center', color: 'rgba(255,255,255,0.7)', fontSize: 16 }}>
           <span>⏱ {timeStr}</span>

--- a/src/app/speck-wars/components/phase-router.tsx
+++ b/src/app/speck-wars/components/phase-router.tsx
@@ -4,6 +4,7 @@ import { useSpeckWarsStore } from '../store'
 
 export function PhaseRouter({ children }: { children: React.ReactNode }) {
   const { phase, winnerId, setPhase, difficulty, setDifficulty, elapsedMs } = useSpeckWarsStore()
+  const [copied, setCopied] = useState(false)
 
   const difficulties: Array<{ key: 'easy' | 'medium' | 'hard'; label: string; color: string }> = [
     { key: 'easy', label: 'Easy', color: '#44ff88' },
@@ -63,8 +64,6 @@ export function PhaseRouter({ children }: { children: React.ReactNode }) {
     const shareText = won
       ? `I defeated the AI in Speck Wars (${diffLabel}) in ${timeStr}! 🎮 Can you beat my time?`
       : `The AI beat me in Speck Wars (${diffLabel}) in ${timeStr}! 🎮 Think you can do better?`
-
-    const [copied, setCopied] = useState(false)
 
     const handleShare = async () => {
       const url = typeof window !== 'undefined' ? window.location.href : ''

--- a/src/app/speck-wars/components/phase-router.tsx
+++ b/src/app/speck-wars/components/phase-router.tsx
@@ -127,6 +127,12 @@ export function PhaseRouter({ children }: { children: React.ReactNode }) {
     const difficultyColors: Record<string, string> = { easy: '#44ff88', medium: '#ffcc44', hard: '#ff4f7b', 'very-hard': '#cc00ff' }
     const diffLabel = difficulty === 'very-hard' ? 'Brutal' : difficulty.charAt(0).toUpperCase() + difficulty.slice(1)
     const diffColor = difficultyColors[difficulty]
+    const nextDifficulty: Partial<Record<string, { key: Difficulty; label: string; color: string }>> = {
+      easy:   { key: 'medium',    label: 'Medium', color: '#ffcc44' },
+      medium: { key: 'hard',      label: 'Hard',   color: '#ff4f7b' },
+      hard:   { key: 'very-hard', label: 'Brutal', color: '#cc00ff' },
+    }
+    const nextDiff = won ? nextDifficulty[difficulty] : null
 
     const shareText = won
       ? `I defeated the AI in Speck Wars (${diffLabel}) in ${timeStr} — killed ${kills} specks! 🎮 Can you beat my time?`
@@ -247,6 +253,20 @@ export function PhaseRouter({ children }: { children: React.ReactNode }) {
             ← Cave
           </a>
         </div>
+        {nextDiff && (
+          <button
+            onClick={() => { setDifficulty(nextDiff.key); resetGame(); setPhase('playing') }}
+            style={{
+              padding: '8px 24px', fontSize: 13, cursor: 'pointer',
+              background: 'transparent',
+              border: `1px solid ${nextDiff.color}`,
+              borderRadius: 6, color: nextDiff.color, opacity: 0.8,
+              letterSpacing: 1,
+            }}
+          >
+            Try {nextDiff.label} →
+          </button>
+        )}
       </div>
     )
   }

--- a/src/app/speck-wars/components/phase-router.tsx
+++ b/src/app/speck-wars/components/phase-router.tsx
@@ -3,7 +3,7 @@ import { useState } from 'react'
 import { useSpeckWarsStore } from '../store'
 
 export function PhaseRouter({ children }: { children: React.ReactNode }) {
-  const { phase, winnerId, setPhase, difficulty, setDifficulty, elapsedMs } = useSpeckWarsStore()
+  const { phase, winnerId, setPhase, difficulty, setDifficulty, elapsedMs, resetGame } = useSpeckWarsStore()
   const [copied, setCopied] = useState(false)
 
   const difficulties: Array<{ key: 'easy' | 'medium' | 'hard'; label: string; color: string }> = [
@@ -44,6 +44,25 @@ export function PhaseRouter({ children }: { children: React.ReactNode }) {
         >
           Play
         </button>
+        {/* Controls hint */}
+        <div style={{
+          marginTop: 16,
+          display: 'grid',
+          gridTemplateColumns: '1fr 1fr',
+          gap: '4px 24px',
+          color: 'rgba(255,255,255,0.35)',
+          fontSize: 11,
+          letterSpacing: 0.5,
+          textAlign: 'left',
+          maxWidth: 280,
+        }}>
+          <span>🖱 Click — rally specks</span>
+          <span>Space — pause</span>
+          <span>Scroll — zoom</span>
+          <span>R — clear rally</span>
+          <span>Drag — pan camera</span>
+          <span>1×/2×/4× — speed</span>
+        </div>
       </div>
     )
   }
@@ -99,7 +118,7 @@ export function PhaseRouter({ children }: { children: React.ReactNode }) {
 
         <div style={{ display: 'flex', gap: 12, marginTop: 8 }}>
           <button
-            onClick={() => window.location.reload()}
+            onClick={resetGame}
             style={{
               padding: '12px 28px', fontSize: 16, cursor: 'pointer',
               background: accentColor, border: 'none', borderRadius: 8,

--- a/src/app/speck-wars/components/phase-router.tsx
+++ b/src/app/speck-wars/components/phase-router.tsx
@@ -198,16 +198,20 @@ export function PhaseRouter({ children }: { children: React.ReactNode }) {
               color: victoryType === 'domination' ? '#ffd700' : accentColor,
               textTransform: 'uppercase',
             }}>
-              {victoryType === 'domination' ? '⬡ by Domination' : '💥 by Destruction'}
+              {victoryType === 'domination' ? '⬡ by Domination'
+                : victoryType === 'surrender' ? '🏳 Surrendered'
+                : '💥 by Destruction'}
             </div>
             <div style={{ fontSize: 10, letterSpacing: 1, opacity: 0.35, color: '#fff' }}>
               {won
                 ? victoryType === 'domination'
                   ? 'held all 3 outposts for 60 seconds'
                   : 'destroyed the enemy base'
-                : victoryType === 'domination'
-                  ? 'enemy held all 3 outposts for 60 seconds'
-                  : 'your base was destroyed'
+                : victoryType === 'surrender'
+                  ? 'you chose to give up'
+                  : victoryType === 'domination'
+                    ? 'enemy held all 3 outposts for 60 seconds'
+                    : 'your base was destroyed'
               }
             </div>
           </div>

--- a/src/app/speck-wars/components/phase-router.tsx
+++ b/src/app/speck-wars/components/phase-router.tsx
@@ -2,7 +2,7 @@
 import { useSpeckWarsStore } from '../store'
 
 export function PhaseRouter({ children }: { children: React.ReactNode }) {
-  const { phase, winnerId, setPhase, difficulty, setDifficulty } = useSpeckWarsStore()
+  const { phase, winnerId, setPhase, difficulty, setDifficulty, elapsedMs } = useSpeckWarsStore()
 
   const difficulties: Array<{ key: 'easy' | 'medium' | 'hard'; label: string; color: string }> = [
     { key: 'easy', label: 'Easy', color: '#44ff88' },
@@ -48,12 +48,57 @@ export function PhaseRouter({ children }: { children: React.ReactNode }) {
 
   if (phase === 'victory' || phase === 'defeat') {
     const won = winnerId === 'player'
+    const accentColor = won ? '#4af7c4' : '#ff4f7b'
+
+    const totalSec = Math.floor(elapsedMs / 1000)
+    const mm = String(Math.floor(totalSec / 60)).padStart(2, '0')
+    const ss = String(totalSec % 60).padStart(2, '0')
+    const timeStr = `${mm}:${ss}`
+
+    const difficultyColors: Record<string, string> = { easy: '#44ff88', medium: '#ffcc44', hard: '#ff4f7b' }
+    const diffLabel = difficulty.charAt(0).toUpperCase() + difficulty.slice(1)
+    const diffColor = difficultyColors[difficulty]
+
     return (
-      <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', height: '100%', gap: 16 }}>
-        <h1 style={{ color: won ? '#4af7c4' : '#ff4f7b', fontSize: 48 }}>{won ? 'Victory' : 'Defeated'}</h1>
-        <button onClick={() => window.location.reload()} style={{ padding: '12px 32px', fontSize: 18, cursor: 'pointer' }}>
-          Play Again
-        </button>
+      <div style={{
+        display: 'flex', flexDirection: 'column', alignItems: 'center',
+        justifyContent: 'center', height: '100%', gap: 20,
+        fontFamily: 'monospace',
+      }}>
+        <h1 style={{ color: accentColor, fontSize: 64, margin: 0, letterSpacing: 4 }}>
+          {won ? 'VICTORY' : 'DEFEATED'}
+        </h1>
+
+        <div style={{ display: 'flex', gap: 24, alignItems: 'center', color: 'rgba(255,255,255,0.7)', fontSize: 16 }}>
+          <span>⏱ {timeStr}</span>
+          <span style={{ color: diffColor, fontWeight: 'bold', border: `1px solid ${diffColor}`, padding: '2px 10px', borderRadius: 4 }}>
+            {diffLabel}
+          </span>
+        </div>
+
+        <div style={{ display: 'flex', gap: 12, marginTop: 8 }}>
+          <button
+            onClick={() => window.location.reload()}
+            style={{
+              padding: '12px 28px', fontSize: 16, cursor: 'pointer',
+              background: accentColor, border: 'none', borderRadius: 8,
+              fontWeight: 'bold', color: '#000',
+            }}
+          >
+            Play Again
+          </button>
+          <a
+            href="/"
+            style={{
+              padding: '12px 28px', fontSize: 16, cursor: 'pointer',
+              background: 'transparent', border: '2px solid rgba(255,255,255,0.3)',
+              borderRadius: 8, color: 'rgba(255,255,255,0.7)', textDecoration: 'none',
+              display: 'flex', alignItems: 'center',
+            }}
+          >
+            ← Cave
+          </a>
+        </div>
       </div>
     )
   }

--- a/src/app/speck-wars/components/phase-router.tsx
+++ b/src/app/speck-wars/components/phase-router.tsx
@@ -68,16 +68,23 @@ export function PhaseRouter({ children }: { children: React.ReactNode }) {
             </button>
           ))}
         </div>
-        {/* Best times per difficulty */}
-        <div style={{ display: 'flex', gap: 16, fontSize: 11, color: 'rgba(255,255,255,0.4)' }}>
+        {/* Best times + win rates per difficulty */}
+        <div style={{ display: 'flex', gap: 16, fontSize: 11 }}>
           {difficulties.map(d => {
             const best = bestTimes[d.key]
-            if (!best) return null
-            const mm = String(Math.floor(Math.floor(best / 1000) / 60)).padStart(2, '0')
-            const ss = String(Math.floor(best / 1000) % 60).padStart(2, '0')
+            const history = getRecentResults(d.key)
+            const wins = history.filter(r => r.won).length
+            if (!best && history.length === 0) return null
+            const mm = best ? String(Math.floor(Math.floor(best / 1000) / 60)).padStart(2, '0') : null
+            const ss = best ? String(Math.floor(best / 1000) % 60).padStart(2, '0') : null
             return (
-              <span key={d.key} style={{ color: d.color, opacity: 0.6 }}>
-                {d.label}: {mm}:{ss}
+              <span key={d.key} style={{ color: d.color, opacity: 0.6, display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 2 }}>
+                {mm && <span>{d.label}: {mm}:{ss}</span>}
+                {history.length > 0 && (
+                  <span style={{ opacity: 0.7, fontSize: 10, letterSpacing: 1 }}>
+                    {wins}/{history.length} W
+                  </span>
+                )}
               </span>
             )
           })}

--- a/src/app/speck-wars/components/phase-router.tsx
+++ b/src/app/speck-wars/components/phase-router.tsx
@@ -1,13 +1,14 @@
 'use client'
 import { useState, useEffect } from 'react'
 import { useSpeckWarsStore } from '../store'
-import { getBestTime } from '../lib/personal-best'
+import { getBestTime, getWinStreak } from '../lib/personal-best'
 import type { Difficulty } from '../store'
 
 export function PhaseRouter({ children }: { children: React.ReactNode }) {
   const { phase, winnerId, setPhase, difficulty, setDifficulty, elapsedMs, resetGame, kills, losses, isNewBest } = useSpeckWarsStore()
   const [copied, setCopied] = useState(false)
   const [bestTimes, setBestTimes] = useState<Partial<Record<Difficulty, number>>>({})
+  const [winStreak, setWinStreak] = useState(0)
 
   useEffect(() => {
     if (phase === 'menu') {
@@ -16,6 +17,7 @@ export function PhaseRouter({ children }: { children: React.ReactNode }) {
         medium: getBestTime('medium') ?? undefined,
         hard: getBestTime('hard') ?? undefined,
       })
+      setWinStreak(getWinStreak())
     }
   }, [phase])
 
@@ -30,6 +32,11 @@ export function PhaseRouter({ children }: { children: React.ReactNode }) {
       <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', height: '100%', gap: 16 }}>
         <h1 style={{ color: '#fff', fontSize: 48, margin: 0 }}>Speck Wars</h1>
         <p style={{ color: '#aaa', margin: 0 }}>Destroy the enemy base. Last base standing wins.</p>
+        {winStreak >= 2 && (
+          <div style={{ color: '#ffd700', fontSize: 14, letterSpacing: 2, fontWeight: 'bold' }}>
+            🔥 {winStreak} WIN STREAK
+          </div>
+        )}
         <div style={{ display: 'flex', gap: 8, marginBottom: 8 }}>
           {difficulties.map(d => (
             <button
@@ -90,6 +97,7 @@ export function PhaseRouter({ children }: { children: React.ReactNode }) {
           <span>Drag — pan camera</span>
           <span>H — heavy/basic mode</span>
           <span>C — center on base</span>
+          <span>D — defend base</span>
           <span>Minimap — click to rally</span>
         </div>
       </div>

--- a/src/app/speck-wars/components/phase-router.tsx
+++ b/src/app/speck-wars/components/phase-router.tsx
@@ -110,7 +110,7 @@ export function PhaseRouter({ children }: { children: React.ReactNode }) {
           <span>🖱 Click — rally specks</span>
           <span>Space — pause</span>
           <span>Scroll — zoom</span>
-          <span>R — clear rally</span>
+          <span>R / Right-click — clear rally</span>
           <span>Drag — pan camera</span>
           <span>H — heavy/basic mode</span>
           <span>A — advance to outpost</span>

--- a/src/app/speck-wars/components/phase-router.tsx
+++ b/src/app/speck-wars/components/phase-router.tsx
@@ -3,7 +3,7 @@ import { useState } from 'react'
 import { useSpeckWarsStore } from '../store'
 
 export function PhaseRouter({ children }: { children: React.ReactNode }) {
-  const { phase, winnerId, setPhase, difficulty, setDifficulty, elapsedMs, resetGame } = useSpeckWarsStore()
+  const { phase, winnerId, setPhase, difficulty, setDifficulty, elapsedMs, resetGame, kills, losses } = useSpeckWarsStore()
   const [copied, setCopied] = useState(false)
 
   const difficulties: Array<{ key: 'easy' | 'medium' | 'hard'; label: string; color: string }> = [
@@ -81,8 +81,8 @@ export function PhaseRouter({ children }: { children: React.ReactNode }) {
     const diffColor = difficultyColors[difficulty]
 
     const shareText = won
-      ? `I defeated the AI in Speck Wars (${diffLabel}) in ${timeStr}! 🎮 Can you beat my time?`
-      : `The AI beat me in Speck Wars (${diffLabel}) in ${timeStr}! 🎮 Think you can do better?`
+      ? `I defeated the AI in Speck Wars (${diffLabel}) in ${timeStr} — killed ${kills} specks! 🎮 Can you beat my time?`
+      : `The AI beat me in Speck Wars (${diffLabel}) in ${timeStr} — killed ${kills} specks. 🎮 Think you can do better?`
 
     const handleShare = async () => {
       const url = typeof window !== 'undefined' ? window.location.href : ''
@@ -114,6 +114,16 @@ export function PhaseRouter({ children }: { children: React.ReactNode }) {
           <span style={{ color: diffColor, fontWeight: 'bold', border: `1px solid ${diffColor}`, padding: '2px 10px', borderRadius: 4 }}>
             {diffLabel}
           </span>
+        </div>
+
+        <div style={{ display: 'flex', gap: 28, color: 'rgba(255,255,255,0.6)', fontSize: 14 }}>
+          <span style={{ color: '#4af7c4' }}>↑ {kills} killed</span>
+          <span style={{ color: '#ff4f7b' }}>↓ {losses} lost</span>
+          {kills + losses > 0 && (
+            <span style={{ color: 'rgba(255,255,255,0.4)' }}>
+              {Math.round((kills / (kills + losses)) * 100)}% efficiency
+            </span>
+          )}
         </div>
 
         <div style={{ display: 'flex', gap: 12, marginTop: 8 }}>

--- a/src/app/speck-wars/domain/ai/ai-controller.ts
+++ b/src/app/speck-wars/domain/ai/ai-controller.ts
@@ -79,6 +79,28 @@ export class AIController {
 
     this.decisionCount++
 
+    // Counter-spawn (non-aggressive only): mirror player's heavy ratio
+    if (!this.aggressive) {
+      let playerHeavy = 0, playerBasic = 0
+      for (let i = 0; i < sim.speckCount; i++) {
+        const m = sim.speckMeta[i]
+        if (!m || m.ownerId === this.playerId || m.ownerId === 'neutral') continue
+        if (m.typeId === 'heavy') playerHeavy++
+        else playerBasic++
+      }
+      const playerTotal = playerHeavy + playerBasic
+      const playerHeavyFrac = playerTotal > 0 ? playerHeavy / playerTotal : 0
+      const wantHeavy = playerHeavyFrac > 0.55
+      const wantBasic = playerHeavyFrac < 0.30
+      if (wantHeavy && this.spawnMode !== 'heavy') {
+        this.spawnMode = 'heavy'
+        sim.inputQueue.push({ type: 'SET_SPAWN_TYPE', ownerId: this.playerId, speckTypeId: 'heavy' })
+      } else if (wantBasic && this.spawnMode !== 'basic') {
+        this.spawnMode = 'basic'
+        sim.inputQueue.push({ type: 'SET_SPAWN_TYPE', ownerId: this.playerId, speckTypeId: 'basic' })
+      }
+    }
+
     // Hard/Brutal mode: vary spawn type to add unpredictability
     if (this.aggressive) {
       this.spawnModeCountdown--
@@ -95,6 +117,19 @@ export class AIController {
 
     // Hard mode: every 4th decision, rush player base directly (pressure waves)
     const forceBaseRush = this.aggressive && this.decisionCount % 4 === 0
+
+    // Defensive rally: when AI base is low HP, sometimes pull back to defend
+    const myBaseHpFrac = (myBase?.hp ?? 100) / (myBase?.maxHp ?? 100)
+    if (!forceBaseRush && myBaseHpFrac < 0.6 && myBase) {
+      // Aggressive AI defends reluctantly; easy/medium AI defends more readily
+      const defendChance = this.aggressive
+        ? (myBaseHpFrac < 0.3 ? 0.35 : 0.15)
+        : (myBaseHpFrac < 0.3 ? 0.70 : 0.45)
+      if (Math.random() < defendChance) {
+        sim.inputQueue.push({ type: 'RALLY', ownerId: this.playerId, x: myBase.x, y: myBase.y })
+        return
+      }
+    }
 
     // Priority 1 (always): recapture player-held outpost
     // Priority 2: capture neutral outpost

--- a/src/app/speck-wars/domain/ai/ai-controller.ts
+++ b/src/app/speck-wars/domain/ai/ai-controller.ts
@@ -4,8 +4,10 @@ export class AIController {
   private playerId: string
   private tickInterval: number
   private lastDecisionTick: number = 0
-  private aggressive: boolean  // true = Hard mode: every 4th decision rushes base
+  private aggressive: boolean  // true = Hard/Brutal: every 4th decision rushes base
   private decisionCount: number = 0
+  private spawnMode: 'basic' | 'heavy' = 'basic'
+  private spawnModeCountdown: number = 0  // ticks until next spawn mode decision
 
   constructor(playerId: string, tickInterval: number = 30, aggressive = false) {
     this.playerId = playerId
@@ -52,6 +54,20 @@ export class AIController {
     }
 
     this.decisionCount++
+
+    // Hard/Brutal mode: vary spawn type to add unpredictability
+    if (this.aggressive) {
+      this.spawnModeCountdown--
+      if (this.spawnModeCountdown <= 0) {
+        // 40% chance to switch to heavy, 60% stay/go basic
+        const next = Math.random() < 0.4 ? 'heavy' : 'basic'
+        if (next !== this.spawnMode) {
+          this.spawnMode = next
+          sim.inputQueue.push({ type: 'SET_SPAWN_TYPE', ownerId: this.playerId, speckTypeId: next })
+        }
+        this.spawnModeCountdown = 8 + Math.floor(Math.random() * 8)  // re-evaluate in 8–16 decisions
+      }
+    }
 
     // Hard mode: every 4th decision, rush player base directly (pressure waves)
     const forceBaseRush = this.aggressive && this.decisionCount % 4 === 0

--- a/src/app/speck-wars/domain/ai/ai-controller.ts
+++ b/src/app/speck-wars/domain/ai/ai-controller.ts
@@ -3,19 +3,43 @@ import type { SimulationState, InputEvent, BuildingEntity } from '../types'
 export class AIController {
   private playerId: string
   private tickInterval: number
+  private readonly baseTickInterval: number
   private lastDecisionTick: number = 0
   private aggressive: boolean  // true = Hard/Brutal: every 4th decision rushes base
   private decisionCount: number = 0
   private spawnMode: 'basic' | 'heavy' = 'basic'
   private spawnModeCountdown: number = 0  // ticks until next spawn mode decision
+  private dominanceTimer: number = 0  // ms enemy has held a 3:1 count advantage
 
   constructor(playerId: string, tickInterval: number = 30, aggressive = false) {
     this.playerId = playerId
     this.tickInterval = tickInterval
+    this.baseTickInterval = tickInterval
     this.aggressive = aggressive
   }
 
-  update(sim: SimulationState) {
+  update(sim: SimulationState, dt: number = 16) {
+    // Adaptive difficulty: if the enemy holds a 3:1 speck advantage for 30s, speed up AI decisions
+    let aiCount = 0, enemyCount = 0
+    for (let i = 0; i < sim.speckCount; i++) {
+      if (!sim.speckIds[i]) continue
+      const m = sim.speckMeta[i]
+      if (!m) continue
+      if (m.ownerId === this.playerId) aiCount++
+      else if (m.ownerId !== 'neutral') enemyCount++
+    }
+    if (enemyCount >= 3 * aiCount && aiCount > 0) {
+      this.dominanceTimer += dt
+      if (this.dominanceTimer > 30000) {
+        // Enemy has dominated for 30s — reduce tick interval by 25% (floor at 75% of base)
+        const floor = Math.max(Math.floor(this.baseTickInterval * 0.75), 4)
+        this.tickInterval = Math.max(Math.floor(this.tickInterval * 0.75), floor)
+      }
+    } else {
+      this.dominanceTimer = 0
+      this.tickInterval = this.baseTickInterval
+    }
+
     if (sim.tick - this.lastDecisionTick < this.tickInterval) return
     this.lastDecisionTick = sim.tick
 

--- a/src/app/speck-wars/domain/ai/ai-controller.ts
+++ b/src/app/speck-wars/domain/ai/ai-controller.ts
@@ -1,8 +1,8 @@
-import type { SimulationState, InputEvent } from '../types'
+import type { SimulationState, InputEvent, BuildingEntity } from '../types'
 
 export class AIController {
   private playerId: string
-  private tickInterval: number  // how often AI makes decisions (every N ticks)
+  private tickInterval: number
   private lastDecisionTick: number = 0
 
   constructor(playerId: string, tickInterval: number = 30) {
@@ -10,26 +10,54 @@ export class AIController {
     this.tickInterval = tickInterval
   }
 
-  // Called once per sim tick — pushes InputEvents into sim.inputQueue
   update(sim: SimulationState) {
     if (sim.tick - this.lastDecisionTick < this.tickInterval) return
     this.lastDecisionTick = sim.tick
 
     if (sim.players[this.playerId]?.isDefeated) return
 
-    // Find the player's nearest base to rally toward
-    const enemyBase = Object.values(sim.buildings).find(
-      b => b.ownerId !== this.playerId
-    )
-    if (!enemyBase) return
-
-    // Rally all AI specks toward the enemy base
-    const rally: InputEvent = {
-      type: 'RALLY',
-      ownerId: this.playerId,
-      x: enemyBase.x,
-      y: enemyBase.y,
+    // Compute AI swarm centroid (or fall back to own base)
+    let cx = 0, cy = 0, count = 0
+    for (let i = 0; i < sim.speckCount; i++) {
+      const m = sim.speckMeta[i]
+      if (m && m.ownerId === this.playerId) {
+        cx += sim.speckX[i]
+        cy += sim.speckY[i]
+        count++
+      }
     }
-    sim.inputQueue.push(rally)
+    const myBase = Object.values(sim.buildings).find(b => b.ownerId === this.playerId && b.typeId === 'base')
+    if (count === 0) {
+      cx = myBase?.x ?? 0
+      cy = myBase?.y ?? 0
+    } else {
+      cx /= count
+      cy /= count
+    }
+
+    // Helper: nearest building matching predicate
+    const nearest = (pred: (b: BuildingEntity) => boolean): BuildingEntity | null => {
+      let best: BuildingEntity | null = null
+      let bestD2 = Infinity
+      for (const b of Object.values(sim.buildings)) {
+        if (!pred(b)) continue
+        const dx = b.x - cx, dy = b.y - cy
+        const d2 = dx * dx + dy * dy
+        if (d2 < bestD2) { bestD2 = d2; best = b }
+      }
+      return best
+    }
+
+    // Priority 1: recapture enemy-held outpost
+    // Priority 2: capture neutral outpost
+    // Priority 3: attack enemy base
+    const target =
+      nearest(b => b.typeId === 'outpost' && b.ownerId !== this.playerId && b.ownerId !== 'neutral') ??
+      nearest(b => b.typeId === 'outpost' && b.ownerId === 'neutral') ??
+      nearest(b => b.ownerId !== this.playerId && b.ownerId !== 'neutral' && b.typeId === 'base')
+
+    if (!target) return
+
+    sim.inputQueue.push({ type: 'RALLY', ownerId: this.playerId, x: target.x, y: target.y })
   }
 }

--- a/src/app/speck-wars/domain/ai/ai-controller.ts
+++ b/src/app/speck-wars/domain/ai/ai-controller.ts
@@ -1,0 +1,35 @@
+import type { SimulationState, InputEvent } from '../types'
+
+export class AIController {
+  private playerId: string
+  private tickInterval: number  // how often AI makes decisions (every N ticks)
+  private lastDecisionTick: number = 0
+
+  constructor(playerId: string, tickInterval: number = 30) {
+    this.playerId = playerId
+    this.tickInterval = tickInterval
+  }
+
+  // Called once per sim tick — pushes InputEvents into sim.inputQueue
+  update(sim: SimulationState) {
+    if (sim.tick - this.lastDecisionTick < this.tickInterval) return
+    this.lastDecisionTick = sim.tick
+
+    if (sim.players[this.playerId]?.isDefeated) return
+
+    // Find the player's nearest base to rally toward
+    const enemyBase = Object.values(sim.buildings).find(
+      b => b.ownerId !== this.playerId
+    )
+    if (!enemyBase) return
+
+    // Rally all AI specks toward the enemy base
+    const rally: InputEvent = {
+      type: 'RALLY',
+      ownerId: this.playerId,
+      x: enemyBase.x,
+      y: enemyBase.y,
+    }
+    sim.inputQueue.push(rally)
+  }
+}

--- a/src/app/speck-wars/domain/ai/ai-controller.ts
+++ b/src/app/speck-wars/domain/ai/ai-controller.ts
@@ -4,10 +4,13 @@ export class AIController {
   private playerId: string
   private tickInterval: number
   private lastDecisionTick: number = 0
+  private aggressive: boolean  // true = Hard mode: every 4th decision rushes base
+  private decisionCount: number = 0
 
-  constructor(playerId: string, tickInterval: number = 30) {
+  constructor(playerId: string, tickInterval: number = 30, aggressive = false) {
     this.playerId = playerId
     this.tickInterval = tickInterval
+    this.aggressive = aggressive
   }
 
   update(sim: SimulationState) {
@@ -48,13 +51,22 @@ export class AIController {
       return best
     }
 
-    // Priority 1: recapture enemy-held outpost
+    this.decisionCount++
+
+    // Hard mode: every 4th decision, rush player base directly (pressure waves)
+    const forceBaseRush = this.aggressive && this.decisionCount % 4 === 0
+
+    // Priority 1 (always): recapture player-held outpost
     // Priority 2: capture neutral outpost
     // Priority 3: attack enemy base
-    const target =
-      nearest(b => b.typeId === 'outpost' && b.ownerId !== this.playerId && b.ownerId !== 'neutral') ??
-      nearest(b => b.typeId === 'outpost' && b.ownerId === 'neutral') ??
-      nearest(b => b.ownerId !== this.playerId && b.ownerId !== 'neutral' && b.typeId === 'base')
+    // Hard mode override: directly rush base on pressure-wave ticks
+    const target = forceBaseRush
+      ? nearest(b => b.ownerId !== this.playerId && b.ownerId !== 'neutral' && b.typeId === 'base')
+      : (
+          nearest(b => b.typeId === 'outpost' && b.ownerId !== this.playerId && b.ownerId !== 'neutral') ??
+          nearest(b => b.typeId === 'outpost' && b.ownerId === 'neutral') ??
+          nearest(b => b.ownerId !== this.playerId && b.ownerId !== 'neutral' && b.typeId === 'base')
+        )
 
     if (!target) return
 

--- a/src/app/speck-wars/domain/ai/ai-controller.ts
+++ b/src/app/speck-wars/domain/ai/ai-controller.ts
@@ -115,8 +115,21 @@ export class AIController {
       }
     }
 
+    // Emergency: detect if the enemy (player) is about to win by domination
+    const outposts = Object.values(sim.buildings).filter(b => b.typeId === 'outpost')
+    const enemyId = Object.keys(sim.players).find(pid => pid !== this.playerId) ?? null
+    const enemyHasAllOutposts = enemyId !== null && outposts.length > 0 && outposts.every(o => o.ownerId === enemyId)
+    // If enemy has all outposts, temporarily halve decision interval to react faster
+    if (enemyHasAllOutposts) {
+      this.tickInterval = Math.max(Math.floor(this.baseTickInterval * 0.5), 2)
+    } else if (this.dominanceTimer === 0) {
+      // Only restore base interval if not already tracking dominance-timer speedup
+      this.tickInterval = this.baseTickInterval
+    }
+
     // Hard mode: every 4th decision, rush player base directly (pressure waves)
-    const forceBaseRush = this.aggressive && this.decisionCount % 4 === 0
+    // Exception: never base-rush during enemy domination threat — must recapture
+    const forceBaseRush = this.aggressive && this.decisionCount % 4 === 0 && !enemyHasAllOutposts
 
     // Defensive rally: when AI base is low HP, sometimes pull back to defend
     const myBaseHpFrac = (myBase?.hp ?? 100) / (myBase?.maxHp ?? 100)

--- a/src/app/speck-wars/domain/config/building-types.ts
+++ b/src/app/speck-wars/domain/config/building-types.ts
@@ -16,7 +16,7 @@ export const BUILDING_TYPES: Record<string, BuildingTypeDefinition> = {
   outpost: {
     id: 'outpost', name: 'Outpost',
     maxHp: 50, size: 20,
-    spawnTypeId: 'basic',
+    spawnTypeId: 'heavy',
     spawnInterval: 1800, spawnCount: 1,
   },
 }

--- a/src/app/speck-wars/domain/config/building-types.ts
+++ b/src/app/speck-wars/domain/config/building-types.ts
@@ -13,6 +13,7 @@ export const BUILDING_TYPES: Record<string, BuildingTypeDefinition> = {
     maxHp: 100, size: 40,
     spawnTypeId: 'basic',
     spawnInterval: 800, spawnCount: 1,
+    hpRegen: 0.5,  // 0.5 HP/sec when not under attack — slow recovery rewards defensive play
   },
   outpost: {
     id: 'outpost', name: 'Outpost',

--- a/src/app/speck-wars/domain/config/building-types.ts
+++ b/src/app/speck-wars/domain/config/building-types.ts
@@ -13,4 +13,10 @@ export const BUILDING_TYPES: Record<string, BuildingTypeDefinition> = {
     spawnTypeId: 'basic',
     spawnInterval: 800, spawnCount: 1,
   },
+  outpost: {
+    id: 'outpost', name: 'Outpost',
+    maxHp: 50, size: 20,
+    spawnTypeId: 'basic',
+    spawnInterval: 1800, spawnCount: 1,
+  },
 }

--- a/src/app/speck-wars/domain/config/building-types.ts
+++ b/src/app/speck-wars/domain/config/building-types.ts
@@ -3,6 +3,7 @@ export interface BuildingTypeDefinition {
   maxHp: number; size: number
   spawnTypeId: string | null
   spawnInterval: number; spawnCount: number
+  hpRegen?: number   // HP per second, only when not under attack
   cost?: Array<{ typeId: string; count: number }>
 }
 
@@ -18,5 +19,6 @@ export const BUILDING_TYPES: Record<string, BuildingTypeDefinition> = {
     maxHp: 50, size: 20,
     spawnTypeId: 'heavy',
     spawnInterval: 1800, spawnCount: 1,
+    hpRegen: 2,  // 2 HP/sec when not under attack
   },
 }

--- a/src/app/speck-wars/domain/config/speck-types.ts
+++ b/src/app/speck-wars/domain/config/speck-types.ts
@@ -15,4 +15,11 @@ export const SPECK_TYPES: Record<string, SpeckTypeDefinition> = {
     size: 3, productionTime: 800,
     abilities: [],
   },
+  heavy: {
+    id: 'heavy', name: 'Tank',
+    hp: 5, damage: 2, speed: 60,
+    attackRange: 8, attackCooldown: 700,
+    size: 6, productionTime: 1800,
+    abilities: [],
+  },
 }

--- a/src/app/speck-wars/domain/constants.ts
+++ b/src/app/speck-wars/domain/constants.ts
@@ -12,3 +12,4 @@ export const AI_BASE_X = 2400
 export const AI_BASE_Y = 1500
 export const PLAYER_COLOR = 0x4af7c4
 export const AI_COLOR = 0xff4f7b
+export const MAX_SPECKS = 15000

--- a/src/app/speck-wars/domain/constants.ts
+++ b/src/app/speck-wars/domain/constants.ts
@@ -20,6 +20,7 @@ export const CAPTURE_RADIUS = 100            // px — specks within this distan
 export const CAPTURE_TIME = 5000             // ms to fully capture
 export const NEUTRAL_COLOR = 0x888888
 export const OUTPOST_AURA_RADIUS = 160  // px — specks within this radius of a friendly outpost move faster
+export const DOMINATION_TIME = 60000   // ms — hold all 3 outposts this long to win by domination
 
 // Triangle around center (1500, 1500), equidistant between the two bases
 export const OUTPOST_POSITIONS = [

--- a/src/app/speck-wars/domain/constants.ts
+++ b/src/app/speck-wars/domain/constants.ts
@@ -13,3 +13,16 @@ export const AI_BASE_Y = 1500
 export const PLAYER_COLOR = 0x4af7c4
 export const AI_COLOR = 0xff4f7b
 export const MAX_SPECKS = 15000
+
+export const OUTPOST_SIZE = 20
+export const OUTPOST_SPAWN_INTERVAL = 1800   // ms per speck (slower than base)
+export const CAPTURE_RADIUS = 100            // px — specks within this distance count toward capture
+export const CAPTURE_TIME = 5000             // ms to fully capture
+export const NEUTRAL_COLOR = 0x888888
+
+// Triangle around center (1500, 1500), equidistant between the two bases
+export const OUTPOST_POSITIONS = [
+  { id: 'outpost-top',   x: 1500, y: 700  },
+  { id: 'outpost-left',  x: 850,  y: 2200 },
+  { id: 'outpost-right', x: 2150, y: 2200 },
+] as const

--- a/src/app/speck-wars/domain/constants.ts
+++ b/src/app/speck-wars/domain/constants.ts
@@ -19,6 +19,7 @@ export const OUTPOST_SPAWN_INTERVAL = 1800   // ms per speck (slower than base)
 export const CAPTURE_RADIUS = 100            // px — specks within this distance count toward capture
 export const CAPTURE_TIME = 5000             // ms to fully capture
 export const NEUTRAL_COLOR = 0x888888
+export const OUTPOST_AURA_RADIUS = 160  // px — specks within this radius of a friendly outpost move faster
 
 // Triangle around center (1500, 1500), equidistant between the two bases
 export const OUTPOST_POSITIONS = [

--- a/src/app/speck-wars/domain/simulation/capture.ts
+++ b/src/app/speck-wars/domain/simulation/capture.ts
@@ -1,0 +1,44 @@
+import type { SimulationState } from '../types'
+import { CAPTURE_RADIUS, CAPTURE_TIME } from '../constants'
+
+export function updateCapture(sim: SimulationState, dt: number) {
+  for (const building of Object.values(sim.buildings)) {
+    if (building.typeId !== 'outpost') continue
+
+    // Count nearby specks by owner (not neutral)
+    const counts: Record<string, number> = {}
+    const nearby = sim.spatialGrid.query(building.x, building.y)
+    const r2 = CAPTURE_RADIUS * CAPTURE_RADIUS
+    for (const idx of nearby) {
+      const meta = sim.speckMeta[idx]
+      if (!meta || meta.ownerId === 'neutral') continue
+      const dx = sim.speckX[idx] - building.x
+      const dy = sim.speckY[idx] - building.y
+      if (dx * dx + dy * dy > r2) continue
+      counts[meta.ownerId] = (counts[meta.ownerId] ?? 0) + 1
+    }
+
+    // Find player-owned specks (exclude neutral)
+    const sides = Object.entries(counts).filter(([, n]) => n > 0)
+    if (sides.length === 0) return  // nobody near — decay progress slowly
+    if (sides.length > 1) continue  // contested — pause capture
+
+    const [dominantOwner] = sides[0]
+    if (dominantOwner === building.ownerId) continue  // already owned by them
+
+    // Start or continue capture
+    if (building.captureSide !== dominantOwner) {
+      building.captureSide = dominantOwner
+      building.captureProgress = 0
+    }
+
+    building.captureProgress = (building.captureProgress ?? 0) + dt / CAPTURE_TIME
+    if ((building.captureProgress ?? 0) >= 1) {
+      building.ownerId = dominantOwner
+      building.captureProgress = 0
+      building.captureSide = null
+      // Reset spawn timer so it starts fresh for the new owner
+      building.spawnTimer = 0
+    }
+  }
+}

--- a/src/app/speck-wars/domain/simulation/capture.ts
+++ b/src/app/speck-wars/domain/simulation/capture.ts
@@ -34,11 +34,18 @@ export function updateCapture(sim: SimulationState, dt: number) {
 
     building.captureProgress = (building.captureProgress ?? 0) + dt / CAPTURE_TIME
     if ((building.captureProgress ?? 0) >= 1) {
+      const previousOwner = building.ownerId
       building.ownerId = dominantOwner
       building.captureProgress = 0
       building.captureSide = null
       // Reset spawn timer so it starts fresh for the new owner
       building.spawnTimer = 0
+      sim.events.push({
+        type: 'OUTPOST_CAPTURED',
+        outpostId: building.id,
+        newOwner: dominantOwner,
+        previousOwner,
+      })
     }
   }
 }

--- a/src/app/speck-wars/domain/simulation/capture.ts
+++ b/src/app/speck-wars/domain/simulation/capture.ts
@@ -23,7 +23,7 @@ export function updateCapture(sim: SimulationState, dt: number) {
     if (sides.length === 0) return  // nobody near — decay progress slowly
     if (sides.length > 1) continue  // contested — pause capture
 
-    const [dominantOwner] = sides[0]
+    const [dominantOwner, dominantCount] = sides[0]
     if (dominantOwner === building.ownerId) continue  // already owned by them
 
     // Start or continue capture
@@ -32,7 +32,9 @@ export function updateCapture(sim: SimulationState, dt: number) {
       building.captureProgress = 0
     }
 
-    building.captureProgress = (building.captureProgress ?? 0) + dt / CAPTURE_TIME
+    // Scale capture speed with speck count: 5 specks = 1×, capped at 3× (15 specks)
+    const captureSpeed = Math.min(3, dominantCount / 5)
+    building.captureProgress = (building.captureProgress ?? 0) + (dt / CAPTURE_TIME) * captureSpeed
     if ((building.captureProgress ?? 0) >= 1) {
       const previousOwner = building.ownerId
       building.ownerId = dominantOwner

--- a/src/app/speck-wars/domain/simulation/combat.ts
+++ b/src/app/speck-wars/domain/simulation/combat.ts
@@ -91,7 +91,7 @@ export function resolveCombat(sim: SimulationState, dt: number) {
       sim.events.push({ type: 'BUILDING_DAMAGED', buildingId: building.id, hp: building.hp })
 
       if (building.hp <= 0) {
-        sim.events.push({ type: 'BUILDING_DESTROYED', buildingId: building.id, ownerId: building.ownerId })
+        sim.events.push({ type: 'BUILDING_DESTROYED', buildingId: building.id, ownerId: building.ownerId, x: building.x, y: building.y })
         delete sim.buildings[building.id]
         // Clear target for all specks pointing at this building
         for (let k = 0; k < sim.speckCount; k++) {

--- a/src/app/speck-wars/domain/simulation/combat.ts
+++ b/src/app/speck-wars/domain/simulation/combat.ts
@@ -6,9 +6,11 @@ export function resolveCombat(sim: SimulationState, dt: number) {
   const { speckIds, speckX, speckY, speckHp, speckMeta, buildings, spatialGrid } = sim
 
   // --- Speck vs Speck combat ---
-  for (let i = 0; i < speckIds.length; i++) {
+  for (let i = 0; i < sim.speckCount; i++) {
+    if (!speckIds[i]) continue
     if (speckHp[i] <= 0) continue
     const meta = speckMeta[i]
+    if (!meta) continue
     const stype = SPECK_TYPES[meta.typeId]
     if (!stype) continue
 
@@ -20,7 +22,8 @@ export function resolveCombat(sim: SimulationState, dt: number) {
     const neighbors = spatialGrid.query(speckX[i], speckY[i])
     for (const j of neighbors) {
       if (i === j || speckHp[j] <= 0) continue
-      if (speckMeta[j].ownerId === meta.ownerId) continue  // friendly
+      const jMeta = speckMeta[j]
+      if (!jMeta || jMeta.ownerId === meta.ownerId) continue  // dead slot or friendly
 
       const dx = speckX[j] - speckX[i]
       const dy = speckY[j] - speckY[i]
@@ -38,9 +41,11 @@ export function resolveCombat(sim: SimulationState, dt: number) {
   }
 
   // --- Speck vs Building combat ---
-  for (let i = 0; i < speckIds.length; i++) {
+  for (let i = 0; i < sim.speckCount; i++) {
+    if (!speckIds[i]) continue
     if (speckHp[i] <= 0) continue
     const meta = speckMeta[i]
+    if (!meta) continue
     if (!meta.targetId) continue
     const building = buildings[meta.targetId]
     if (!building) continue
@@ -63,42 +68,22 @@ export function resolveCombat(sim: SimulationState, dt: number) {
         sim.events.push({ type: 'BUILDING_DESTROYED', buildingId: building.id, ownerId: building.ownerId })
         delete sim.buildings[building.id]
         // Clear target for all specks pointing at this building
-        for (const m of sim.speckMeta) {
-          if (m.targetId === building.id) m.targetId = null
+        for (let k = 0; k < sim.speckCount; k++) {
+          const m = sim.speckMeta[k]
+          if (m && m.targetId === building.id) m.targetId = null
         }
       }
     }
   }
 }
 
-// Remove dead specks — compact all SOA arrays in one pass
+// Mark dead specks and push their slots onto the free-list — no array allocation
 export function removeDeadSpecks(sim: SimulationState) {
-  const alive: number[] = []
-  for (let i = 0; i < sim.speckIds.length; i++) {
-    if (sim.speckHp[i] > 0) alive.push(i)
+  for (let i = 0; i < sim.speckCount; i++) {
+    if (sim.speckIds[i] !== '' && sim.speckHp[i] <= 0) {
+      sim.freeSlots.push(i)
+      sim.speckIds[i] = ''
+      sim.speckMeta[i] = null
+    }
   }
-
-  if (alive.length === sim.speckIds.length) return  // nothing to remove
-
-  const n = alive.length
-  const newX = new Float32Array(n)
-  const newY = new Float32Array(n)
-  const newVx = new Float32Array(n)
-  const newVy = new Float32Array(n)
-  const newHp = new Float32Array(n)
-  const newIds: string[] = []
-  const newMeta: SimulationState['speckMeta'] = []
-
-  for (let j = 0; j < alive.length; j++) {
-    const i = alive[j]
-    newX[j] = sim.speckX[i]; newY[j] = sim.speckY[i]
-    newVx[j] = sim.speckVx[i]; newVy[j] = sim.speckVy[i]
-    newHp[j] = sim.speckHp[i]
-    newIds.push(sim.speckIds[i])
-    newMeta.push(sim.speckMeta[i])
-  }
-
-  sim.speckX = newX; sim.speckY = newY
-  sim.speckVx = newVx; sim.speckVy = newVy; sim.speckHp = newHp
-  sim.speckIds = newIds; sim.speckMeta = newMeta
 }

--- a/src/app/speck-wars/domain/simulation/combat.ts
+++ b/src/app/speck-wars/domain/simulation/combat.ts
@@ -33,7 +33,7 @@ export function resolveCombat(sim: SimulationState, dt: number) {
         meta.attackCooldown = stype.attackCooldown
         meta.state = 'attacking'
         if (speckHp[j] <= 0) {
-          sim.events.push({ type: 'SPECK_DIED', speckId: speckIds[j], x: speckX[j], y: speckY[j] })
+          sim.events.push({ type: 'SPECK_DIED', speckId: speckIds[j], x: speckX[j], y: speckY[j], killedOwnerId: jMeta.ownerId, killerOwnerId: meta.ownerId })
         }
         break  // one attack per cooldown
       }

--- a/src/app/speck-wars/domain/simulation/combat.ts
+++ b/src/app/speck-wars/domain/simulation/combat.ts
@@ -2,8 +2,26 @@ import type { SimulationState } from '../types'
 import { SPECK_TYPES } from '../config/speck-types'
 import { BUILDING_TYPES } from '../config/building-types'
 
+const MORALE_RATIO = 2.0   // if your count > this × enemy count → morale bonus
+const MORALE_BONUS = 1.20  // 20% damage boost when morale is active
+
 export function resolveCombat(sim: SimulationState, dt: number) {
   const { speckIds, speckX, speckY, speckHp, speckMeta, buildings, spatialGrid } = sim
+
+  // Compute morale multiplier: owner whose count > 2× all enemies gets +20% damage
+  const speckCountByOwner: Record<string, number> = {}
+  for (let i = 0; i < sim.speckCount; i++) {
+    const ownerId = speckMeta[i]?.ownerId
+    if (speckIds[i] && ownerId) speckCountByOwner[ownerId] = (speckCountByOwner[ownerId] ?? 0) + 1
+  }
+  const moraleMult = (ownerId: string): number => {
+    const myCount = speckCountByOwner[ownerId] ?? 0
+    let maxEnemyCount = 0
+    for (const [id, n] of Object.entries(speckCountByOwner)) {
+      if (id !== ownerId && id !== 'neutral' && n > maxEnemyCount) maxEnemyCount = n
+    }
+    return (maxEnemyCount > 0 && myCount > MORALE_RATIO * maxEnemyCount) ? MORALE_BONUS : 1.0
+  }
 
   // --- Speck vs Speck combat ---
   for (let i = 0; i < sim.speckCount; i++) {
@@ -29,7 +47,7 @@ export function resolveCombat(sim: SimulationState, dt: number) {
       const dy = speckY[j] - speckY[i]
       const dist = Math.sqrt(dx * dx + dy * dy)
       if (dist <= stype.attackRange) {
-        speckHp[j] -= stype.damage
+        speckHp[j] -= stype.damage * moraleMult(meta.ownerId)
         meta.attackCooldown = stype.attackCooldown
         meta.state = 'attacking'
         if (speckHp[j] <= 0) {
@@ -60,7 +78,7 @@ export function resolveCombat(sim: SimulationState, dt: number) {
     const attackDist = (btype?.size ?? 20) + stype.attackRange
 
     if (dist <= attackDist) {
-      building.hp -= stype.damage
+      building.hp -= stype.damage * moraleMult(meta.ownerId)
       meta.attackCooldown = stype.attackCooldown
       sim.events.push({ type: 'BUILDING_DAMAGED', buildingId: building.id, hp: building.hp })
 

--- a/src/app/speck-wars/domain/simulation/combat.ts
+++ b/src/app/speck-wars/domain/simulation/combat.ts
@@ -4,6 +4,8 @@ import { BUILDING_TYPES } from '../config/building-types'
 
 const MORALE_RATIO = 2.0   // if your count > this × enemy count → morale bonus
 const MORALE_BONUS = 1.20  // 20% damage boost when morale is active
+const RAGE_HP_THRESHOLD = 0.15  // base HP fraction below which rage activates
+const RAGE_BONUS = 1.40         // 40% damage boost when base is critical
 
 export function resolveCombat(sim: SimulationState, dt: number) {
   const { speckIds, speckX, speckY, speckHp, speckMeta, buildings, spatialGrid } = sim
@@ -20,7 +22,13 @@ export function resolveCombat(sim: SimulationState, dt: number) {
     for (const [id, n] of Object.entries(speckCountByOwner)) {
       if (id !== ownerId && id !== 'neutral' && n > maxEnemyCount) maxEnemyCount = n
     }
-    return (maxEnemyCount > 0 && myCount > MORALE_RATIO * maxEnemyCount) ? MORALE_BONUS : 1.0
+    const moraleBonus = (maxEnemyCount > 0 && myCount > MORALE_RATIO * maxEnemyCount) ? MORALE_BONUS : 1.0
+
+    // Rage: if this owner's base is at critical HP, deal 40% more damage (desperation)
+    const base = Object.values(buildings).find(b => b.ownerId === ownerId && b.typeId === 'base')
+    const rageBonus = (base && base.hp / base.maxHp < RAGE_HP_THRESHOLD) ? RAGE_BONUS : 1.0
+
+    return Math.max(moraleBonus, rageBonus)  // apply highest active bonus (don't stack)
   }
 
   // --- Speck vs Speck combat ---

--- a/src/app/speck-wars/domain/simulation/combat.ts
+++ b/src/app/speck-wars/domain/simulation/combat.ts
@@ -1,0 +1,104 @@
+import type { SimulationState } from '../types'
+import { SPECK_TYPES } from '../config/speck-types'
+import { BUILDING_TYPES } from '../config/building-types'
+
+export function resolveCombat(sim: SimulationState, dt: number) {
+  const { speckIds, speckX, speckY, speckHp, speckMeta, buildings, spatialGrid } = sim
+
+  // --- Speck vs Speck combat ---
+  for (let i = 0; i < speckIds.length; i++) {
+    if (speckHp[i] <= 0) continue
+    const meta = speckMeta[i]
+    const stype = SPECK_TYPES[meta.typeId]
+    if (!stype) continue
+
+    if (meta.attackCooldown > 0) {
+      meta.attackCooldown -= dt
+      continue
+    }
+
+    const neighbors = spatialGrid.query(speckX[i], speckY[i])
+    for (const j of neighbors) {
+      if (i === j || speckHp[j] <= 0) continue
+      if (speckMeta[j].ownerId === meta.ownerId) continue  // friendly
+
+      const dx = speckX[j] - speckX[i]
+      const dy = speckY[j] - speckY[i]
+      const dist = Math.sqrt(dx * dx + dy * dy)
+      if (dist <= stype.attackRange) {
+        speckHp[j] -= stype.damage
+        meta.attackCooldown = stype.attackCooldown
+        meta.state = 'attacking'
+        if (speckHp[j] <= 0) {
+          sim.events.push({ type: 'SPECK_DIED', speckId: speckIds[j], x: speckX[j], y: speckY[j] })
+        }
+        break  // one attack per cooldown
+      }
+    }
+  }
+
+  // --- Speck vs Building combat ---
+  for (let i = 0; i < speckIds.length; i++) {
+    if (speckHp[i] <= 0) continue
+    const meta = speckMeta[i]
+    if (!meta.targetId) continue
+    const building = buildings[meta.targetId]
+    if (!building) continue
+
+    const stype = SPECK_TYPES[meta.typeId]
+    if (!stype || meta.attackCooldown > 0) continue
+
+    const dx = building.x - speckX[i]
+    const dy = building.y - speckY[i]
+    const dist = Math.sqrt(dx * dx + dy * dy)
+    const btype = BUILDING_TYPES[building.typeId]
+    const attackDist = (btype?.size ?? 20) + stype.attackRange
+
+    if (dist <= attackDist) {
+      building.hp -= stype.damage
+      meta.attackCooldown = stype.attackCooldown
+      sim.events.push({ type: 'BUILDING_DAMAGED', buildingId: building.id, hp: building.hp })
+
+      if (building.hp <= 0) {
+        sim.events.push({ type: 'BUILDING_DESTROYED', buildingId: building.id, ownerId: building.ownerId })
+        delete sim.buildings[building.id]
+        // Clear target for all specks pointing at this building
+        for (const m of sim.speckMeta) {
+          if (m.targetId === building.id) m.targetId = null
+        }
+      }
+    }
+  }
+}
+
+// Remove dead specks — compact all SOA arrays in one pass
+export function removeDeadSpecks(sim: SimulationState) {
+  const alive: number[] = []
+  for (let i = 0; i < sim.speckIds.length; i++) {
+    if (sim.speckHp[i] > 0) alive.push(i)
+  }
+
+  if (alive.length === sim.speckIds.length) return  // nothing to remove
+
+  const n = alive.length
+  const newX = new Float32Array(n)
+  const newY = new Float32Array(n)
+  const newVx = new Float32Array(n)
+  const newVy = new Float32Array(n)
+  const newHp = new Float32Array(n)
+  const newIds: string[] = []
+  const newMeta: SimulationState['speckMeta'] = []
+
+  for (let j = 0; j < alive.length; j++) {
+    const i = alive[j]
+    newX[j] = sim.speckX[i]; newY[j] = sim.speckY[i]
+    newVx[j] = sim.speckVx[i]; newVy[j] = sim.speckVy[i]
+    newHp[j] = sim.speckHp[i]
+    newIds.push(sim.speckIds[i])
+    newMeta.push(sim.speckMeta[i])
+  }
+
+  sim.speckX = newX; sim.speckY = newY
+  sim.speckVx = newVx; sim.speckVy = newVy; sim.speckHp = newHp
+  sim.speckIds = newIds; sim.speckMeta = newMeta
+}

--- a/src/app/speck-wars/domain/simulation/create-sim.ts
+++ b/src/app/speck-wars/domain/simulation/create-sim.ts
@@ -45,6 +45,7 @@ export function createSim(seed: number = Date.now()): SimulationState {
     speckMeta: [],
     inputQueue: [],
     events: [],
+    rallyPoints: { player: null, ai: null },
     spatialGrid: new SpatialGrid(),
   }
 }

--- a/src/app/speck-wars/domain/simulation/create-sim.ts
+++ b/src/app/speck-wars/domain/simulation/create-sim.ts
@@ -84,5 +84,6 @@ export function createSim(seed: number = Date.now(), difficulty: Difficulty = 'm
     events: [],
     rallyPoints: { player: null, ai: null },
     spatialGrid: new SpatialGrid(),
+    dominationTimer: 0,
   }
 }

--- a/src/app/speck-wars/domain/simulation/create-sim.ts
+++ b/src/app/speck-wars/domain/simulation/create-sim.ts
@@ -1,5 +1,5 @@
 import type { SimulationState, Player, BuildingEntity } from '../types'
-import { PLAYER_BASE_X, PLAYER_BASE_Y, AI_BASE_X, AI_BASE_Y, PLAYER_COLOR, AI_COLOR, BASE_HP, MAX_SPECKS } from '../constants'
+import { PLAYER_BASE_X, PLAYER_BASE_Y, AI_BASE_X, AI_BASE_Y, PLAYER_COLOR, AI_COLOR, BASE_HP, MAX_SPECKS, NEUTRAL_COLOR, OUTPOST_POSITIONS } from '../constants'
 import { SpatialGrid } from './spatial-grid'
 import type { Difficulty } from '../../store'
 
@@ -38,12 +38,29 @@ export function createSim(seed: number = Date.now(), difficulty: Difficulty = 'm
     id: 'ai', name: 'AI',
     color: AI_COLOR, isAI: true, isDefeated: false, stockpile: {},
   }
+  const neutral: Player = {
+    id: 'neutral', name: 'Neutral',
+    color: NEUTRAL_COLOR, isAI: false, isDefeated: false, stockpile: {},
+  }
+
+  const outpostBuildings: Record<string, BuildingEntity> = {}
+  for (const pos of OUTPOST_POSITIONS) {
+    outpostBuildings[pos.id] = {
+      id: pos.id,
+      typeId: 'outpost',
+      ownerId: 'neutral',
+      x: pos.x, y: pos.y,
+      hp: 50, maxHp: 50,
+      spawnTimer: 0,
+      inputBuffer: {},
+    }
+  }
 
   return {
     tick: 0,
     rngState: seed,
-    players: { player, ai },
-    buildings: { 'building-player-base': playerBase, 'building-ai-base': aiBase },
+    players: { player, ai, neutral },
+    buildings: { 'building-player-base': playerBase, 'building-ai-base': aiBase, ...outpostBuildings },
     speckIds: new Array(MAX_SPECKS).fill(''),
     speckX: new Float32Array(MAX_SPECKS),
     speckY: new Float32Array(MAX_SPECKS),

--- a/src/app/speck-wars/domain/simulation/create-sim.ts
+++ b/src/app/speck-wars/domain/simulation/create-sim.ts
@@ -1,6 +1,7 @@
 import type { SimulationState, Player, BuildingEntity } from '../types'
 import { PLAYER_BASE_X, PLAYER_BASE_Y, AI_BASE_X, AI_BASE_Y, PLAYER_COLOR, AI_COLOR, BASE_HP, MAX_SPECKS, NEUTRAL_COLOR, OUTPOST_POSITIONS } from '../constants'
 import { SpatialGrid } from './spatial-grid'
+import { mulberry32 } from './prng'
 import type { Difficulty } from '../../store'
 
 const aiSpawnInterval: Record<Difficulty, number> = {
@@ -53,10 +54,11 @@ export function createSim(seed: number = Date.now(), difficulty: Difficulty = 'm
   }
 
   const JITTER = 200  // ± px of positional variation per game
+  const rng = mulberry32(seed)  // seeded so same date+difficulty = same map
   const outpostBuildings: Record<string, BuildingEntity> = {}
   for (const pos of OUTPOST_POSITIONS) {
-    const jx = (Math.random() * 2 - 1) * JITTER
-    const jy = (Math.random() * 2 - 1) * JITTER
+    const jx = (rng() * 2 - 1) * JITTER
+    const jy = (rng() * 2 - 1) * JITTER
     outpostBuildings[pos.id] = {
       id: pos.id,
       typeId: 'outpost',

--- a/src/app/speck-wars/domain/simulation/create-sim.ts
+++ b/src/app/speck-wars/domain/simulation/create-sim.ts
@@ -9,6 +9,12 @@ const aiSpawnInterval: Record<Difficulty, number> = {
   hard: 400,
 }
 
+const playerSpawnInterval: Record<Difficulty, number | undefined> = {
+  easy: 550,   // faster on easy — the AI is already slow, this ensures clear advantage
+  medium: undefined,  // use default (800ms)
+  hard: undefined,    // use default (800ms) — player skill must compensate
+}
+
 export function createSim(seed: number = Date.now(), difficulty: Difficulty = 'medium'): SimulationState {
   const playerBase: BuildingEntity = {
     id: 'building-player-base',
@@ -17,6 +23,7 @@ export function createSim(seed: number = Date.now(), difficulty: Difficulty = 'm
     x: PLAYER_BASE_X, y: PLAYER_BASE_Y,
     hp: BASE_HP, maxHp: BASE_HP,
     spawnTimer: 0,
+    spawnIntervalOverride: playerSpawnInterval[difficulty],
     inputBuffer: {},
   }
   const aiBase: BuildingEntity = {

--- a/src/app/speck-wars/domain/simulation/create-sim.ts
+++ b/src/app/speck-wars/domain/simulation/create-sim.ts
@@ -1,5 +1,5 @@
 import type { SimulationState, Player, BuildingEntity } from '../types'
-import { PLAYER_BASE_X, PLAYER_BASE_Y, AI_BASE_X, AI_BASE_Y, PLAYER_COLOR, AI_COLOR, BASE_HP } from '../constants'
+import { PLAYER_BASE_X, PLAYER_BASE_Y, AI_BASE_X, AI_BASE_Y, PLAYER_COLOR, AI_COLOR, BASE_HP, MAX_SPECKS } from '../constants'
 import { SpatialGrid } from './spatial-grid'
 
 export function createSim(seed: number = Date.now()): SimulationState {
@@ -36,13 +36,15 @@ export function createSim(seed: number = Date.now()): SimulationState {
     rngState: seed,
     players: { player, ai },
     buildings: { 'building-player-base': playerBase, 'building-ai-base': aiBase },
-    speckIds: [],
-    speckX: new Float32Array(0),
-    speckY: new Float32Array(0),
-    speckVx: new Float32Array(0),
-    speckVy: new Float32Array(0),
-    speckHp: new Float32Array(0),
-    speckMeta: [],
+    speckIds: new Array(MAX_SPECKS).fill(''),
+    speckX: new Float32Array(MAX_SPECKS),
+    speckY: new Float32Array(MAX_SPECKS),
+    speckVx: new Float32Array(MAX_SPECKS),
+    speckVy: new Float32Array(MAX_SPECKS),
+    speckHp: new Float32Array(MAX_SPECKS),
+    speckMeta: new Array(MAX_SPECKS).fill(null),
+    speckCount: 0,
+    freeSlots: [],
     inputQueue: [],
     events: [],
     rallyPoints: { player: null, ai: null },

--- a/src/app/speck-wars/domain/simulation/create-sim.ts
+++ b/src/app/speck-wars/domain/simulation/create-sim.ts
@@ -1,8 +1,15 @@
 import type { SimulationState, Player, BuildingEntity } from '../types'
 import { PLAYER_BASE_X, PLAYER_BASE_Y, AI_BASE_X, AI_BASE_Y, PLAYER_COLOR, AI_COLOR, BASE_HP, MAX_SPECKS } from '../constants'
 import { SpatialGrid } from './spatial-grid'
+import type { Difficulty } from '../../store'
 
-export function createSim(seed: number = Date.now()): SimulationState {
+const aiSpawnInterval: Record<Difficulty, number> = {
+  easy: 2000,
+  medium: 800,
+  hard: 400,
+}
+
+export function createSim(seed: number = Date.now(), difficulty: Difficulty = 'medium'): SimulationState {
   const playerBase: BuildingEntity = {
     id: 'building-player-base',
     typeId: 'base',
@@ -19,6 +26,7 @@ export function createSim(seed: number = Date.now()): SimulationState {
     x: AI_BASE_X, y: AI_BASE_Y,
     hp: BASE_HP, maxHp: BASE_HP,
     spawnTimer: 0,
+    spawnIntervalOverride: aiSpawnInterval[difficulty],
     inputBuffer: {},
   }
 

--- a/src/app/speck-wars/domain/simulation/create-sim.ts
+++ b/src/app/speck-wars/domain/simulation/create-sim.ts
@@ -50,13 +50,16 @@ export function createSim(seed: number = Date.now(), difficulty: Difficulty = 'm
     color: NEUTRAL_COLOR, isAI: false, isDefeated: false, stockpile: {},
   }
 
+  const JITTER = 200  // ± px of positional variation per game
   const outpostBuildings: Record<string, BuildingEntity> = {}
   for (const pos of OUTPOST_POSITIONS) {
+    const jx = (Math.random() * 2 - 1) * JITTER
+    const jy = (Math.random() * 2 - 1) * JITTER
     outpostBuildings[pos.id] = {
       id: pos.id,
       typeId: 'outpost',
       ownerId: 'neutral',
-      x: pos.x, y: pos.y,
+      x: pos.x + jx, y: pos.y + jy,
       hp: 50, maxHp: 50,
       spawnTimer: 0,
       inputBuffer: {},

--- a/src/app/speck-wars/domain/simulation/create-sim.ts
+++ b/src/app/speck-wars/domain/simulation/create-sim.ts
@@ -7,12 +7,14 @@ const aiSpawnInterval: Record<Difficulty, number> = {
   easy: 2000,
   medium: 800,
   hard: 400,
+  'very-hard': 180,  // blazing spawn rate — AI floods the map
 }
 
 const playerSpawnInterval: Record<Difficulty, number | undefined> = {
-  easy: 550,   // faster on easy — the AI is already slow, this ensures clear advantage
-  medium: undefined,  // use default (800ms)
-  hard: undefined,    // use default (800ms) — player skill must compensate
+  easy: 550,         // faster on easy — the AI is already slow, this ensures clear advantage
+  medium: undefined, // use default (800ms)
+  hard: undefined,   // use default (800ms) — player skill must compensate
+  'very-hard': undefined,  // same as hard — no advantage
 }
 
 export function createSim(seed: number = Date.now(), difficulty: Difficulty = 'medium'): SimulationState {

--- a/src/app/speck-wars/domain/simulation/movement.ts
+++ b/src/app/speck-wars/domain/simulation/movement.ts
@@ -1,13 +1,17 @@
 import type { SimulationState } from '../types'
 import { SPECK_TYPES } from '../config/speck-types'
-import { WORLD_WIDTH, WORLD_HEIGHT } from '../constants'
+import { WORLD_WIDTH, WORLD_HEIGHT, OUTPOST_AURA_RADIUS } from '../constants'
 
 const SEPARATION_RADIUS = 8   // px — keep specks this far apart
 const SEPARATION_FORCE = 120  // strength of push-apart
+const AURA_SPEED_MULT = 1.35  // 35% speed boost inside outpost aura
 
 export function moveSpecks(sim: SimulationState, dt: number) {
   const { speckIds, speckX, speckY, speckVx, speckVy, speckMeta, buildings, spatialGrid } = sim
   const dtSec = dt / 1000
+
+  // Cache outpost positions once per tick (only 3 buildings, negligible cost)
+  const outposts = Object.values(buildings).filter(b => b.typeId === 'outpost')
 
   // Rebuild grid with current positions before applying separation
   spatialGrid.clear()
@@ -60,6 +64,21 @@ export function moveSpecks(sim: SimulationState, dt: number) {
         const force = (SEPARATION_RADIUS - dist) / SEPARATION_RADIUS * SEPARATION_FORCE
         ax += (dx / dist) * force
         ay += (dy / dist) * force
+      }
+    }
+
+    // Outpost speed aura: boost movement if inside a friendly outpost's aura
+    if (ax !== 0 || ay !== 0) {
+      const auraR2 = OUTPOST_AURA_RADIUS * OUTPOST_AURA_RADIUS
+      for (const building of outposts) {
+        if (building.ownerId !== meta.ownerId) continue
+        const bdx = speckX[i] - building.x
+        const bdy = speckY[i] - building.y
+        if (bdx * bdx + bdy * bdy < auraR2) {
+          ax *= AURA_SPEED_MULT
+          ay *= AURA_SPEED_MULT
+          break
+        }
       }
     }
 

--- a/src/app/speck-wars/domain/simulation/movement.ts
+++ b/src/app/speck-wars/domain/simulation/movement.ts
@@ -34,6 +34,17 @@ export function moveSpecks(sim: SimulationState, dt: number) {
           ay += (dy / dist) * stype.speed
         }
       }
+    } else {
+      const rally = sim.rallyPoints[meta.ownerId]
+      if (rally) {
+        const dx = rally.x - speckX[i]
+        const dy = rally.y - speckY[i]
+        const dist = Math.sqrt(dx * dx + dy * dy)
+        if (dist > stype.attackRange) {
+          ax += (dx / dist) * stype.speed
+          ay += (dy / dist) * stype.speed
+        }
+      }
     }
 
     // Separation from nearby specks (same owner to avoid interleaving)

--- a/src/app/speck-wars/domain/simulation/movement.ts
+++ b/src/app/speck-wars/domain/simulation/movement.ts
@@ -1,0 +1,61 @@
+import type { SimulationState } from '../types'
+import { SPECK_TYPES } from '../config/speck-types'
+import { WORLD_WIDTH, WORLD_HEIGHT } from '../constants'
+
+const SEPARATION_RADIUS = 8   // px — keep specks this far apart
+const SEPARATION_FORCE = 120  // strength of push-apart
+
+export function moveSpecks(sim: SimulationState, dt: number) {
+  const { speckIds, speckX, speckY, speckVx, speckVy, speckMeta, buildings, spatialGrid } = sim
+  const dtSec = dt / 1000
+
+  // Rebuild grid with current positions before applying separation
+  spatialGrid.clear()
+  for (let i = 0; i < speckIds.length; i++) {
+    spatialGrid.insert(i, speckX[i], speckY[i])
+  }
+
+  for (let i = 0; i < speckIds.length; i++) {
+    const meta = speckMeta[i]
+    const stype = SPECK_TYPES[meta.typeId]
+    if (!stype) continue
+
+    let ax = 0, ay = 0
+
+    // Seek target
+    if (meta.targetId) {
+      const target = buildings[meta.targetId]
+      if (target) {
+        const dx = target.x - speckX[i]
+        const dy = target.y - speckY[i]
+        const dist = Math.sqrt(dx * dx + dy * dy)
+        if (dist > stype.attackRange) {
+          ax += (dx / dist) * stype.speed
+          ay += (dy / dist) * stype.speed
+        }
+      }
+    }
+
+    // Separation from nearby specks (same owner to avoid interleaving)
+    const neighbors = spatialGrid.query(speckX[i], speckY[i])
+    for (const j of neighbors) {
+      if (i === j) continue
+      const dx = speckX[i] - speckX[j]
+      const dy = speckY[i] - speckY[j]
+      const dist = Math.sqrt(dx * dx + dy * dy)
+      if (dist < SEPARATION_RADIUS && dist > 0) {
+        const force = (SEPARATION_RADIUS - dist) / SEPARATION_RADIUS * SEPARATION_FORCE
+        ax += (dx / dist) * force
+        ay += (dy / dist) * force
+      }
+    }
+
+    // Simple velocity (no mass — direct velocity override)
+    speckVx[i] = ax
+    speckVy[i] = ay
+
+    // Integrate position
+    speckX[i] = Math.max(0, Math.min(WORLD_WIDTH, speckX[i] + speckVx[i] * dtSec))
+    speckY[i] = Math.max(0, Math.min(WORLD_HEIGHT, speckY[i] + speckVy[i] * dtSec))
+  }
+}

--- a/src/app/speck-wars/domain/simulation/movement.ts
+++ b/src/app/speck-wars/domain/simulation/movement.ts
@@ -11,12 +11,14 @@ export function moveSpecks(sim: SimulationState, dt: number) {
 
   // Rebuild grid with current positions before applying separation
   spatialGrid.clear()
-  for (let i = 0; i < speckIds.length; i++) {
-    spatialGrid.insert(i, speckX[i], speckY[i])
+  for (let i = 0; i < sim.speckCount; i++) {
+    if (speckIds[i]) spatialGrid.insert(i, speckX[i], speckY[i])
   }
 
-  for (let i = 0; i < speckIds.length; i++) {
+  for (let i = 0; i < sim.speckCount; i++) {
+    if (!speckIds[i]) continue
     const meta = speckMeta[i]
+    if (!meta) continue
     const stype = SPECK_TYPES[meta.typeId]
     if (!stype) continue
 

--- a/src/app/speck-wars/domain/simulation/spawner.ts
+++ b/src/app/speck-wars/domain/simulation/spawner.ts
@@ -39,7 +39,7 @@ export function updateSpawners(sim: SimulationState, dt: number) {
     building.spawnTimer -= dt
     if (building.spawnTimer > 0) continue
 
-    building.spawnTimer = btype.spawnInterval
+    building.spawnTimer = building.spawnIntervalOverride ?? btype.spawnInterval
 
     for (let i = 0; i < btype.spawnCount; i++) {
       // Spawn just outside the building radius with slight random offset

--- a/src/app/speck-wars/domain/simulation/spawner.ts
+++ b/src/app/speck-wars/domain/simulation/spawner.ts
@@ -32,6 +32,7 @@ let speckCounter = 0
 
 export function updateSpawners(sim: SimulationState, dt: number) {
   for (const building of Object.values(sim.buildings)) {
+    if (building.ownerId === 'neutral') continue
     const btype = BUILDING_TYPES[building.typeId]
     if (!btype?.spawnTypeId) continue
     if (sim.players[building.ownerId]?.isDefeated) continue

--- a/src/app/speck-wars/domain/simulation/spawner.ts
+++ b/src/app/speck-wars/domain/simulation/spawner.ts
@@ -1,23 +1,29 @@
 import type { SimulationState, SpeckMeta } from '../types'
 import { SPECK_TYPES } from '../config/speck-types'
 import { BUILDING_TYPES } from '../config/building-types'
+import { MAX_SPECKS } from '../constants'
 
-// Resize all SOA arrays by 1 and insert a new speck at the end
+// Place a new speck into a recycled or fresh slot — never allocates new arrays
 function addSpeck(sim: SimulationState, meta: SpeckMeta, x: number, y: number) {
-  const n = sim.speckIds.length
+  const hp = SPECK_TYPES[meta.typeId]?.hp ?? 1
 
-  // Grow Float32Arrays
-  const newX = new Float32Array(n + 1); newX.set(sim.speckX); newX[n] = x
-  const newY = new Float32Array(n + 1); newY.set(sim.speckY); newY[n] = y
-  const newVx = new Float32Array(n + 1); newVx.set(sim.speckVx); newVx[n] = 0
-  const newVy = new Float32Array(n + 1); newVy.set(sim.speckVy); newVy[n] = 0
-  const newHp = new Float32Array(n + 1); newHp.set(sim.speckHp)
-  newHp[n] = SPECK_TYPES[meta.typeId]?.hp ?? 1
+  let slot: number
+  if (sim.freeSlots.length > 0) {
+    slot = sim.freeSlots.pop()!
+  } else if (sim.speckCount < MAX_SPECKS) {
+    slot = sim.speckCount
+    sim.speckCount++
+  } else {
+    return  // at capacity, drop spawn
+  }
 
-  sim.speckX = newX; sim.speckY = newY
-  sim.speckVx = newVx; sim.speckVy = newVy; sim.speckHp = newHp
-  sim.speckIds.push(meta.id)
-  sim.speckMeta.push(meta)
+  sim.speckX[slot] = x
+  sim.speckY[slot] = y
+  sim.speckVx[slot] = 0
+  sim.speckVy[slot] = 0
+  sim.speckHp[slot] = hp
+  sim.speckIds[slot] = meta.id
+  sim.speckMeta[slot] = meta
 
   sim.events.push({ type: 'SPECK_SPAWNED', speckId: meta.id, buildingId: '' })
 }

--- a/src/app/speck-wars/domain/simulation/spawner.ts
+++ b/src/app/speck-wars/domain/simulation/spawner.ts
@@ -40,7 +40,8 @@ export function updateSpawners(sim: SimulationState, dt: number) {
     building.spawnTimer -= dt
     if (building.spawnTimer > 0) continue
 
-    building.spawnTimer = building.spawnIntervalOverride ?? btype.spawnInterval
+    const baseInterval = building.spawnIntervalOverride ?? btype.spawnInterval
+    building.spawnTimer = building.tripleOutpostBonus ? baseInterval / 2 : baseInterval
 
     for (let i = 0; i < btype.spawnCount; i++) {
       // Spawn just outside the building radius with slight random offset

--- a/src/app/speck-wars/domain/simulation/spawner.ts
+++ b/src/app/speck-wars/domain/simulation/spawner.ts
@@ -4,7 +4,7 @@ import { BUILDING_TYPES } from '../config/building-types'
 import { MAX_SPECKS } from '../constants'
 
 // Place a new speck into a recycled or fresh slot — never allocates new arrays
-function addSpeck(sim: SimulationState, meta: SpeckMeta, x: number, y: number) {
+function addSpeck(sim: SimulationState, meta: SpeckMeta, x: number, y: number, buildingId: string) {
   const hp = SPECK_TYPES[meta.typeId]?.hp ?? 1
 
   let slot: number
@@ -25,7 +25,7 @@ function addSpeck(sim: SimulationState, meta: SpeckMeta, x: number, y: number) {
   sim.speckIds[slot] = meta.id
   sim.speckMeta[slot] = meta
 
-  sim.events.push({ type: 'SPECK_SPAWNED', speckId: meta.id, buildingId: '' })
+  sim.events.push({ type: 'SPECK_SPAWNED', speckId: meta.id, buildingId })
 }
 
 let speckCounter = 0
@@ -58,7 +58,7 @@ export function updateSpawners(sim: SimulationState, dt: number) {
         targetId: null,
         attackCooldown: 0,
       }
-      addSpeck(sim, meta, sx, sy)
+      addSpeck(sim, meta, sx, sy, building.id)
     }
   }
 }

--- a/src/app/speck-wars/domain/simulation/spawner.ts
+++ b/src/app/speck-wars/domain/simulation/spawner.ts
@@ -51,7 +51,7 @@ export function updateSpawners(sim: SimulationState, dt: number) {
 
       const meta: SpeckMeta = {
         id: `speck-${++speckCounter}`,
-        typeId: btype.spawnTypeId!,
+        typeId: building.spawnTypeOverride ?? btype.spawnTypeId!,
         ownerId: building.ownerId,
         state: 'idle',
         targetId: null,

--- a/src/app/speck-wars/domain/simulation/spawner.ts
+++ b/src/app/speck-wars/domain/simulation/spawner.ts
@@ -1,0 +1,56 @@
+import type { SimulationState, SpeckMeta } from '../types'
+import { SPECK_TYPES } from '../config/speck-types'
+import { BUILDING_TYPES } from '../config/building-types'
+
+// Resize all SOA arrays by 1 and insert a new speck at the end
+function addSpeck(sim: SimulationState, meta: SpeckMeta, x: number, y: number) {
+  const n = sim.speckIds.length
+
+  // Grow Float32Arrays
+  const newX = new Float32Array(n + 1); newX.set(sim.speckX); newX[n] = x
+  const newY = new Float32Array(n + 1); newY.set(sim.speckY); newY[n] = y
+  const newVx = new Float32Array(n + 1); newVx.set(sim.speckVx); newVx[n] = 0
+  const newVy = new Float32Array(n + 1); newVy.set(sim.speckVy); newVy[n] = 0
+  const newHp = new Float32Array(n + 1); newHp.set(sim.speckHp)
+  newHp[n] = SPECK_TYPES[meta.typeId]?.hp ?? 1
+
+  sim.speckX = newX; sim.speckY = newY
+  sim.speckVx = newVx; sim.speckVy = newVy; sim.speckHp = newHp
+  sim.speckIds.push(meta.id)
+  sim.speckMeta.push(meta)
+
+  sim.events.push({ type: 'SPECK_SPAWNED', speckId: meta.id, buildingId: '' })
+}
+
+let speckCounter = 0
+
+export function updateSpawners(sim: SimulationState, dt: number) {
+  for (const building of Object.values(sim.buildings)) {
+    const btype = BUILDING_TYPES[building.typeId]
+    if (!btype?.spawnTypeId) continue
+    if (sim.players[building.ownerId]?.isDefeated) continue
+
+    building.spawnTimer -= dt
+    if (building.spawnTimer > 0) continue
+
+    building.spawnTimer = btype.spawnInterval
+
+    for (let i = 0; i < btype.spawnCount; i++) {
+      // Spawn just outside the building radius with slight random offset
+      const angle = Math.random() * Math.PI * 2
+      const radius = btype.size + 8
+      const sx = building.x + Math.cos(angle) * radius
+      const sy = building.y + Math.sin(angle) * radius
+
+      const meta: SpeckMeta = {
+        id: `speck-${++speckCounter}`,
+        typeId: btype.spawnTypeId!,
+        ownerId: building.ownerId,
+        state: 'idle',
+        targetId: null,
+        attackCooldown: 0,
+      }
+      addSpeck(sim, meta, sx, sy)
+    }
+  }
+}

--- a/src/app/speck-wars/domain/simulation/speck-ai.ts
+++ b/src/app/speck-wars/domain/simulation/speck-ai.ts
@@ -1,0 +1,37 @@
+import type { SimulationState } from '../types'
+import { SPECK_TYPES } from '../config/speck-types'
+
+export function runSpeckAI(sim: SimulationState) {
+  const { speckIds, speckX, speckY, speckMeta, buildings } = sim
+
+  for (let i = 0; i < speckIds.length; i++) {
+    const meta = speckMeta[i]
+    const stype = SPECK_TYPES[meta.typeId]
+    if (!stype) continue
+
+    // Clear dead or invalid targets
+    if (meta.targetId && !buildings[meta.targetId]) {
+      meta.targetId = null
+    }
+
+    if (meta.targetId) continue  // already has a valid target
+
+    // Find nearest enemy building
+    let nearest: string | null = null
+    let nearestDist = Infinity
+
+    for (const [_bid, building] of Object.entries(buildings)) {
+      if (building.ownerId === meta.ownerId) continue  // skip friendly
+      const dx = building.x - speckX[i]
+      const dy = building.y - speckY[i]
+      const dist = Math.sqrt(dx * dx + dy * dy)
+      if (dist < nearestDist) {
+        nearestDist = dist
+        nearest = _bid
+      }
+    }
+
+    meta.targetId = nearest
+    meta.state = nearest ? 'moving' : 'idle'
+  }
+}

--- a/src/app/speck-wars/domain/simulation/speck-ai.ts
+++ b/src/app/speck-wars/domain/simulation/speck-ai.ts
@@ -4,8 +4,10 @@ import { SPECK_TYPES } from '../config/speck-types'
 export function runSpeckAI(sim: SimulationState) {
   const { speckIds, speckX, speckY, speckMeta, buildings } = sim
 
-  for (let i = 0; i < speckIds.length; i++) {
+  for (let i = 0; i < sim.speckCount; i++) {
+    if (!speckIds[i]) continue
     const meta = speckMeta[i]
+    if (!meta) continue
     const stype = SPECK_TYPES[meta.typeId]
     if (!stype) continue
 

--- a/src/app/speck-wars/domain/simulation/tick.ts
+++ b/src/app/speck-wars/domain/simulation/tick.ts
@@ -105,18 +105,23 @@ function consumeInputs(sim: SimulationState) {
 }
 
 function emitHudUpdate(sim: SimulationState) {
-  const data: Record<string, { speckCount: number; buildingCount: number; buildingHp: Record<string, number> }> = {}
+  const data: Record<string, { speckCount: number; buildingCount: number; buildingHp: Record<string, number>; speckTypes: Record<string, number> }> = {}
   for (const [pid] of Object.entries(sim.players)) {
     const myBuildings = Object.values(sim.buildings).filter(b => b.ownerId === pid)
     let liveCount = 0
+    const speckTypes: Record<string, number> = {}
     for (let i = 0; i < sim.speckCount; i++) {
       const m = sim.speckMeta[i]
-      if (m && m.ownerId === pid) liveCount++
+      if (m && m.ownerId === pid) {
+        liveCount++
+        speckTypes[m.typeId] = (speckTypes[m.typeId] ?? 0) + 1
+      }
     }
     data[pid] = {
       speckCount: liveCount,
       buildingCount: myBuildings.length,
       buildingHp: Object.fromEntries(myBuildings.map(b => [b.id, b.hp])),
+      speckTypes,
     }
   }
   // Buildings that are owned but actively being captured by the enemy

--- a/src/app/speck-wars/domain/simulation/tick.ts
+++ b/src/app/speck-wars/domain/simulation/tick.ts
@@ -140,5 +140,16 @@ function emitHudUpdate(sim: SimulationState) {
   }
 
   const dominationProgress = tripleOutpostOwner ? Math.min(1, sim.dominationTimer / DOMINATION_TIME) : null
-  sim.events.push({ type: 'HUD_UPDATE', data: { players: data, attackedBuildingIds, tripleOutpostOwner, dominationProgress } })
+
+  // Minimap: sample every 8th speck, capped at 300
+  const minimapSpecks: Array<{ x: number; y: number; ownerId: string }> = []
+  const step = Math.max(1, Math.floor(sim.speckCount / 300)) * 8
+  for (let i = 0; i < sim.speckCount && minimapSpecks.length < 300; i += step) {
+    const m = sim.speckMeta[i]
+    if (m) minimapSpecks.push({ x: sim.speckX[i], y: sim.speckY[i], ownerId: m.ownerId })
+  }
+  const minimapBuildings = Object.values(sim.buildings).map(b => ({ x: b.x, y: b.y, ownerId: b.ownerId, typeId: b.typeId }))
+  const rp = sim.rallyPoints['player']
+
+  sim.events.push({ type: 'HUD_UPDATE', data: { players: data, attackedBuildingIds, tripleOutpostOwner, dominationProgress, minimap: { specks: minimapSpecks, buildings: minimapBuildings, rallyX: rp?.x ?? null, rallyY: rp?.y ?? null } } })
 }

--- a/src/app/speck-wars/domain/simulation/tick.ts
+++ b/src/app/speck-wars/domain/simulation/tick.ts
@@ -36,6 +36,9 @@ export function tick(sim: SimulationState, dt: number): SimulationState {
   // 7b. HP regeneration for owned buildings when not under attack
   regenBuildingHp(sim, dt)
 
+  // 7c. Triple outpost bonus — control all 3 outposts = 2× base spawn speed
+  updateTripleOutpostBonus(sim)
+
   // 8. Check win/loss
   checkVictory(sim)
 
@@ -56,6 +59,20 @@ function regenBuildingHp(sim: SimulationState, dt: number) {
     // No regen while actively being captured
     if (building.captureProgress && building.captureProgress > 0) continue
     building.hp = Math.min(building.maxHp, building.hp + btype.hpRegen * dtSec)
+  }
+}
+
+function updateTripleOutpostBonus(sim: SimulationState) {
+  const outposts = Object.values(sim.buildings).filter(b => b.typeId === 'outpost')
+  if (outposts.length === 0) return
+
+  for (const [pid] of Object.entries(sim.players)) {
+    if (pid === 'neutral') continue
+    const ownsAll = outposts.every(o => o.ownerId === pid)
+    for (const building of Object.values(sim.buildings)) {
+      if (building.ownerId !== pid || building.typeId !== 'base') continue
+      building.tripleOutpostBonus = ownsAll
+    }
   }
 }
 
@@ -96,5 +113,15 @@ function emitHudUpdate(sim: SimulationState) {
     .filter(b => b.typeId === 'outpost' && b.ownerId !== 'neutral' && b.captureProgress && b.captureProgress > 0 && b.captureSide && b.captureSide !== b.ownerId)
     .map(b => b.id)
 
-  sim.events.push({ type: 'HUD_UPDATE', data: { players: data, attackedBuildingIds } })
+  // Which player (if any) owns all outposts and has the triple bonus
+  const outposts = Object.values(sim.buildings).filter(b => b.typeId === 'outpost')
+  let tripleOutpostOwner: string | null = null
+  if (outposts.length > 0) {
+    for (const [pid] of Object.entries(sim.players)) {
+      if (pid === 'neutral') continue
+      if (outposts.every(o => o.ownerId === pid)) { tripleOutpostOwner = pid; break }
+    }
+  }
+
+  sim.events.push({ type: 'HUD_UPDATE', data: { players: data, attackedBuildingIds, tripleOutpostOwner } })
 }

--- a/src/app/speck-wars/domain/simulation/tick.ts
+++ b/src/app/speck-wars/domain/simulation/tick.ts
@@ -6,6 +6,7 @@ import { moveSpecks } from './movement'
 import { resolveCombat, removeDeadSpecks } from './combat'
 import { checkVictory } from './victory'
 import { updateCapture } from './capture'
+import { BUILDING_TYPES } from '../config/building-types'
 import { HUD_UPDATE_INTERVAL } from '../constants'
 
 export function tick(sim: SimulationState, dt: number): SimulationState {
@@ -32,6 +33,9 @@ export function tick(sim: SimulationState, dt: number): SimulationState {
   // 7. Update outpost capture progress
   updateCapture(sim, dt)
 
+  // 7b. HP regeneration for owned buildings when not under attack
+  regenBuildingHp(sim, dt)
+
   // 8. Check win/loss
   checkVictory(sim)
 
@@ -40,6 +44,19 @@ export function tick(sim: SimulationState, dt: number): SimulationState {
   if (sim.tick % HUD_UPDATE_INTERVAL === 0) emitHudUpdate(sim)
 
   return sim
+}
+
+function regenBuildingHp(sim: SimulationState, dt: number) {
+  const dtSec = dt / 1000
+  for (const building of Object.values(sim.buildings)) {
+    if (building.hp >= building.maxHp) continue
+    if (building.ownerId === 'neutral') continue
+    const btype = BUILDING_TYPES[building.typeId]
+    if (!btype?.hpRegen) continue
+    // No regen while actively being captured
+    if (building.captureProgress && building.captureProgress > 0) continue
+    building.hp = Math.min(building.maxHp, building.hp + btype.hpRegen * dtSec)
+  }
 }
 
 function consumeInputs(sim: SimulationState) {

--- a/src/app/speck-wars/domain/simulation/tick.ts
+++ b/src/app/speck-wars/domain/simulation/tick.ts
@@ -38,8 +38,10 @@ export function tick(sim: SimulationState, dt: number): SimulationState {
 }
 
 function consumeInputs(sim: SimulationState) {
-  for (const _event of sim.inputQueue) {
-    // Future: handle RALLY, BUILD, SACRIFICE
+  for (const event of sim.inputQueue) {
+    if (event.type === 'RALLY') {
+      sim.rallyPoints[event.ownerId] = { x: event.x, y: event.y }
+    }
   }
   sim.inputQueue = []
 }

--- a/src/app/speck-wars/domain/simulation/tick.ts
+++ b/src/app/speck-wars/domain/simulation/tick.ts
@@ -7,7 +7,7 @@ import { resolveCombat, removeDeadSpecks } from './combat'
 import { checkVictory } from './victory'
 import { updateCapture } from './capture'
 import { BUILDING_TYPES } from '../config/building-types'
-import { HUD_UPDATE_INTERVAL } from '../constants'
+import { HUD_UPDATE_INTERVAL, DOMINATION_TIME } from '../constants'
 
 export function tick(sim: SimulationState, dt: number): SimulationState {
   sim.events = []  // clear outbound events from previous tick
@@ -36,8 +36,8 @@ export function tick(sim: SimulationState, dt: number): SimulationState {
   // 7b. HP regeneration for owned buildings when not under attack
   regenBuildingHp(sim, dt)
 
-  // 7c. Triple outpost bonus — control all 3 outposts = 2× base spawn speed
-  updateTripleOutpostBonus(sim)
+  // 7c. Triple outpost bonus — control all 3 outposts = 2× base spawn speed + domination timer
+  updateTripleOutpostBonus(sim, dt)
 
   // 8. Check win/loss
   checkVictory(sim)
@@ -62,10 +62,11 @@ function regenBuildingHp(sim: SimulationState, dt: number) {
   }
 }
 
-function updateTripleOutpostBonus(sim: SimulationState) {
+function updateTripleOutpostBonus(sim: SimulationState, dt: number) {
   const outposts = Object.values(sim.buildings).filter(b => b.typeId === 'outpost')
   if (outposts.length === 0) return
 
+  let tripleHolder: string | null = null
   for (const [pid] of Object.entries(sim.players)) {
     if (pid === 'neutral') continue
     const ownsAll = outposts.every(o => o.ownerId === pid)
@@ -73,6 +74,16 @@ function updateTripleOutpostBonus(sim: SimulationState) {
       if (building.ownerId !== pid || building.typeId !== 'base') continue
       building.tripleOutpostBonus = ownsAll
     }
+    if (ownsAll) tripleHolder = pid
+  }
+
+  if (tripleHolder) {
+    sim.dominationTimer += dt
+    if (sim.dominationTimer >= DOMINATION_TIME) {
+      sim.events.push({ type: 'GAME_OVER', winnerId: tripleHolder })
+    }
+  } else {
+    sim.dominationTimer = 0
   }
 }
 
@@ -123,5 +134,6 @@ function emitHudUpdate(sim: SimulationState) {
     }
   }
 
-  sim.events.push({ type: 'HUD_UPDATE', data: { players: data, attackedBuildingIds, tripleOutpostOwner } })
+  const dominationProgress = tripleOutpostOwner ? Math.min(1, sim.dominationTimer / DOMINATION_TIME) : null
+  sim.events.push({ type: 'HUD_UPDATE', data: { players: data, attackedBuildingIds, tripleOutpostOwner, dominationProgress } })
 }

--- a/src/app/speck-wars/domain/simulation/tick.ts
+++ b/src/app/speck-wars/domain/simulation/tick.ts
@@ -141,6 +141,14 @@ function emitHudUpdate(sim: SimulationState) {
 
   const dominationProgress = tripleOutpostOwner ? Math.min(1, sim.dominationTimer / DOMINATION_TIME) : null
 
+  // Capture progress for each outpost
+  const captureInfo: Record<string, { progress: number; side: string } | null> = {}
+  for (const o of outposts) {
+    captureInfo[o.id] = (o.captureProgress && o.captureSide)
+      ? { progress: o.captureProgress, side: o.captureSide }
+      : null
+  }
+
   // Minimap: sample every 8th speck, capped at 300
   const minimapSpecks: Array<{ x: number; y: number; ownerId: string }> = []
   const step = Math.max(1, Math.floor(sim.speckCount / 300)) * 8
@@ -151,5 +159,5 @@ function emitHudUpdate(sim: SimulationState) {
   const minimapBuildings = Object.values(sim.buildings).map(b => ({ x: b.x, y: b.y, ownerId: b.ownerId, typeId: b.typeId }))
   const rp = sim.rallyPoints['player']
 
-  sim.events.push({ type: 'HUD_UPDATE', data: { players: data, attackedBuildingIds, tripleOutpostOwner, dominationProgress, minimap: { specks: minimapSpecks, buildings: minimapBuildings, rallyX: rp?.x ?? null, rallyY: rp?.y ?? null } } })
+  sim.events.push({ type: 'HUD_UPDATE', data: { players: data, attackedBuildingIds, tripleOutpostOwner, dominationProgress, captureInfo, minimap: { specks: minimapSpecks, buildings: minimapBuildings, rallyX: rp?.x ?? null, rallyY: rp?.y ?? null } } })
 }

--- a/src/app/speck-wars/domain/simulation/tick.ts
+++ b/src/app/speck-wars/domain/simulation/tick.ts
@@ -80,7 +80,7 @@ function updateTripleOutpostBonus(sim: SimulationState, dt: number) {
   if (tripleHolder) {
     sim.dominationTimer += dt
     if (sim.dominationTimer >= DOMINATION_TIME) {
-      sim.events.push({ type: 'GAME_OVER', winnerId: tripleHolder })
+      sim.events.push({ type: 'GAME_OVER', winnerId: tripleHolder, victoryType: 'domination' })
     }
   } else {
     sim.dominationTimer = 0

--- a/src/app/speck-wars/domain/simulation/tick.ts
+++ b/src/app/speck-wars/domain/simulation/tick.ts
@@ -1,4 +1,5 @@
 import type { SimulationState } from '../types'
+import { SPECK_TYPES } from '../config/speck-types'
 import { updateSpawners } from './spawner'
 import { runSpeckAI } from './speck-ai'
 import { moveSpecks } from './movement'
@@ -45,6 +46,14 @@ function consumeInputs(sim: SimulationState) {
   for (const event of sim.inputQueue) {
     if (event.type === 'RALLY') {
       sim.rallyPoints[event.ownerId] = { x: event.x, y: event.y }
+    }
+    if (event.type === 'SET_SPAWN_TYPE') {
+      const stype = SPECK_TYPES[event.speckTypeId]
+      for (const building of Object.values(sim.buildings)) {
+        if (building.ownerId !== event.ownerId || building.typeId !== 'base') continue
+        building.spawnTypeOverride = event.speckTypeId
+        building.spawnIntervalOverride = stype?.productionTime
+      }
     }
   }
   sim.inputQueue = []

--- a/src/app/speck-wars/domain/simulation/tick.ts
+++ b/src/app/speck-wars/domain/simulation/tick.ts
@@ -50,8 +50,13 @@ function emitHudUpdate(sim: SimulationState) {
   const data: Record<string, { speckCount: number; buildingCount: number; buildingHp: Record<string, number> }> = {}
   for (const [pid] of Object.entries(sim.players)) {
     const myBuildings = Object.values(sim.buildings).filter(b => b.ownerId === pid)
+    let liveCount = 0
+    for (let i = 0; i < sim.speckCount; i++) {
+      const m = sim.speckMeta[i]
+      if (m && m.ownerId === pid) liveCount++
+    }
     data[pid] = {
-      speckCount: sim.speckMeta.filter(m => m.ownerId === pid).length,
+      speckCount: liveCount,
       buildingCount: myBuildings.length,
       buildingHp: Object.fromEntries(myBuildings.map(b => [b.id, b.hp])),
     }

--- a/src/app/speck-wars/domain/simulation/tick.ts
+++ b/src/app/speck-wars/domain/simulation/tick.ts
@@ -149,15 +149,5 @@ function emitHudUpdate(sim: SimulationState) {
       : null
   }
 
-  // Minimap: sample every 8th speck, capped at 300
-  const minimapSpecks: Array<{ x: number; y: number; ownerId: string }> = []
-  const step = Math.max(1, Math.floor(sim.speckCount / 300)) * 8
-  for (let i = 0; i < sim.speckCount && minimapSpecks.length < 300; i += step) {
-    const m = sim.speckMeta[i]
-    if (m) minimapSpecks.push({ x: sim.speckX[i], y: sim.speckY[i], ownerId: m.ownerId })
-  }
-  const minimapBuildings = Object.values(sim.buildings).map(b => ({ x: b.x, y: b.y, ownerId: b.ownerId, typeId: b.typeId }))
-  const rp = sim.rallyPoints['player']
-
-  sim.events.push({ type: 'HUD_UPDATE', data: { players: data, attackedBuildingIds, tripleOutpostOwner, dominationProgress, captureInfo, minimap: { specks: minimapSpecks, buildings: minimapBuildings, rallyX: rp?.x ?? null, rallyY: rp?.y ?? null } } })
+  sim.events.push({ type: 'HUD_UPDATE', data: { players: data, attackedBuildingIds, tripleOutpostOwner, dominationProgress, captureInfo } })
 }

--- a/src/app/speck-wars/domain/simulation/tick.ts
+++ b/src/app/speck-wars/domain/simulation/tick.ts
@@ -4,6 +4,7 @@ import { runSpeckAI } from './speck-ai'
 import { moveSpecks } from './movement'
 import { resolveCombat, removeDeadSpecks } from './combat'
 import { checkVictory } from './victory'
+import { updateCapture } from './capture'
 import { HUD_UPDATE_INTERVAL } from '../constants'
 
 export function tick(sim: SimulationState, dt: number): SimulationState {
@@ -27,10 +28,13 @@ export function tick(sim: SimulationState, dt: number): SimulationState {
   // 6. Remove dead specks (compact arrays)
   removeDeadSpecks(sim)
 
-  // 7. Check win/loss
+  // 7. Update outpost capture progress
+  updateCapture(sim, dt)
+
+  // 8. Check win/loss
   checkVictory(sim)
 
-  // 8. Emit HUD update every N ticks
+  // 9. Emit HUD update every N ticks
   sim.tick++
   if (sim.tick % HUD_UPDATE_INTERVAL === 0) emitHudUpdate(sim)
 

--- a/src/app/speck-wars/domain/simulation/tick.ts
+++ b/src/app/speck-wars/domain/simulation/tick.ts
@@ -65,5 +65,10 @@ function emitHudUpdate(sim: SimulationState) {
       buildingHp: Object.fromEntries(myBuildings.map(b => [b.id, b.hp])),
     }
   }
-  sim.events.push({ type: 'HUD_UPDATE', data: { players: data } })
+  // Buildings that are owned but actively being captured by the enemy
+  const attackedBuildingIds = Object.values(sim.buildings)
+    .filter(b => b.typeId === 'outpost' && b.ownerId !== 'neutral' && b.captureProgress && b.captureProgress > 0 && b.captureSide && b.captureSide !== b.ownerId)
+    .map(b => b.id)
+
+  sim.events.push({ type: 'HUD_UPDATE', data: { players: data, attackedBuildingIds } })
 }

--- a/src/app/speck-wars/domain/simulation/tick.ts
+++ b/src/app/speck-wars/domain/simulation/tick.ts
@@ -1,0 +1,58 @@
+import type { SimulationState } from '../types'
+import { updateSpawners } from './spawner'
+import { runSpeckAI } from './speck-ai'
+import { moveSpecks } from './movement'
+import { resolveCombat, removeDeadSpecks } from './combat'
+import { checkVictory } from './victory'
+import { HUD_UPDATE_INTERVAL } from '../constants'
+
+export function tick(sim: SimulationState, dt: number): SimulationState {
+  sim.events = []  // clear outbound events from previous tick
+
+  // 1. Process player/AI input commands
+  consumeInputs(sim)
+
+  // 2. Spawn new specks from buildings
+  updateSpawners(sim, dt)
+
+  // 3. Each speck picks/validates its target
+  runSpeckAI(sim)
+
+  // 4. Move specks + apply separation
+  moveSpecks(sim, dt)
+
+  // 5. Deal damage, destroy buildings/specks
+  resolveCombat(sim, dt)
+
+  // 6. Remove dead specks (compact arrays)
+  removeDeadSpecks(sim)
+
+  // 7. Check win/loss
+  checkVictory(sim)
+
+  // 8. Emit HUD update every N ticks
+  sim.tick++
+  if (sim.tick % HUD_UPDATE_INTERVAL === 0) emitHudUpdate(sim)
+
+  return sim
+}
+
+function consumeInputs(sim: SimulationState) {
+  for (const _event of sim.inputQueue) {
+    // Future: handle RALLY, BUILD, SACRIFICE
+  }
+  sim.inputQueue = []
+}
+
+function emitHudUpdate(sim: SimulationState) {
+  const data: Record<string, { speckCount: number; buildingCount: number; buildingHp: Record<string, number> }> = {}
+  for (const [pid] of Object.entries(sim.players)) {
+    const myBuildings = Object.values(sim.buildings).filter(b => b.ownerId === pid)
+    data[pid] = {
+      speckCount: sim.speckMeta.filter(m => m.ownerId === pid).length,
+      buildingCount: myBuildings.length,
+      buildingHp: Object.fromEntries(myBuildings.map(b => [b.id, b.hp])),
+    }
+  }
+  sim.events.push({ type: 'HUD_UPDATE', data: { players: data } })
+}

--- a/src/app/speck-wars/domain/simulation/victory.ts
+++ b/src/app/speck-wars/domain/simulation/victory.ts
@@ -3,13 +3,14 @@ import type { SimulationState } from '../types'
 export function checkVictory(sim: SimulationState) {
   for (const [pid, player] of Object.entries(sim.players)) {
     if (player.isDefeated) continue
+    if (pid === 'neutral') continue  // neutral is never defeated and never wins
     const hasBuildings = Object.values(sim.buildings).some(b => b.ownerId === pid)
     if (!hasBuildings) {
       player.isDefeated = true
     }
   }
 
-  const alive = Object.values(sim.players).filter(p => !p.isDefeated)
+  const alive = Object.values(sim.players).filter(p => !p.isDefeated && p.id !== 'neutral')
   if (alive.length === 1) {
     sim.events.push({ type: 'GAME_OVER', winnerId: alive[0].id })
   }

--- a/src/app/speck-wars/domain/simulation/victory.ts
+++ b/src/app/speck-wars/domain/simulation/victory.ts
@@ -12,6 +12,6 @@ export function checkVictory(sim: SimulationState) {
 
   const alive = Object.values(sim.players).filter(p => !p.isDefeated && p.id !== 'neutral')
   if (alive.length === 1) {
-    sim.events.push({ type: 'GAME_OVER', winnerId: alive[0].id })
+    sim.events.push({ type: 'GAME_OVER', winnerId: alive[0].id, victoryType: 'destruction' })
   }
 }

--- a/src/app/speck-wars/domain/simulation/victory.ts
+++ b/src/app/speck-wars/domain/simulation/victory.ts
@@ -1,0 +1,16 @@
+import type { SimulationState } from '../types'
+
+export function checkVictory(sim: SimulationState) {
+  for (const [pid, player] of Object.entries(sim.players)) {
+    if (player.isDefeated) continue
+    const hasBuildings = Object.values(sim.buildings).some(b => b.ownerId === pid)
+    if (!hasBuildings) {
+      player.isDefeated = true
+    }
+  }
+
+  const alive = Object.values(sim.players).filter(p => !p.isDefeated)
+  if (alive.length === 1) {
+    sim.events.push({ type: 'GAME_OVER', winnerId: alive[0].id })
+  }
+}

--- a/src/app/speck-wars/domain/types.ts
+++ b/src/app/speck-wars/domain/types.ts
@@ -61,7 +61,7 @@ export type InputEvent =
   | { type: 'SACRIFICE'; ownerId: string; buildingId: string; typeId: string; count: number }
 
 export type SimEvent =
-  | { type: 'SPECK_DIED'; speckId: string; x: number; y: number }
+  | { type: 'SPECK_DIED'; speckId: string; x: number; y: number; killedOwnerId: string; killerOwnerId: string }
   | { type: 'BUILDING_DAMAGED'; buildingId: string; hp: number }
   | { type: 'BUILDING_DESTROYED'; buildingId: string; ownerId: string }
   | { type: 'SPECK_SPAWNED'; speckId: string; buildingId: string }

--- a/src/app/speck-wars/domain/types.ts
+++ b/src/app/speck-wars/domain/types.ts
@@ -78,6 +78,7 @@ export interface HudData {
     speckCount: number
     buildingCount: number
     buildingHp: Record<string, number>
+    speckTypes: Record<string, number>  // typeId → count
   }>
   attackedBuildingIds: string[]
   tripleOutpostOwner: string | null  // player ID who owns all 3 outposts, or null

--- a/src/app/speck-wars/domain/types.ts
+++ b/src/app/speck-wars/domain/types.ts
@@ -18,6 +18,8 @@ export interface BuildingEntity {
   spawnTimer: number       // ms until next spawn
   spawnIntervalOverride?: number  // overrides BUILDING_TYPES spawnInterval when set
   inputBuffer: Record<string, number>  // typeId → count (sacrifice system, future)
+  captureProgress?: number      // 0..1 progress toward capture for captureSide
+  captureSide?: string | null   // which player is currently winning capture
 }
 
 export interface Player {

--- a/src/app/speck-wars/domain/types.ts
+++ b/src/app/speck-wars/domain/types.ts
@@ -16,6 +16,7 @@ export interface BuildingEntity {
   x: number; y: number
   hp: number; maxHp: number
   spawnTimer: number       // ms until next spawn
+  spawnIntervalOverride?: number  // overrides BUILDING_TYPES spawnInterval when set
   inputBuffer: Record<string, number>  // typeId → count (sacrifice system, future)
 }
 

--- a/src/app/speck-wars/domain/types.ts
+++ b/src/app/speck-wars/domain/types.ts
@@ -84,10 +84,4 @@ export interface HudData {
   tripleOutpostOwner: string | null  // player ID who owns all 3 outposts, or null
   dominationProgress: number | null  // 0..1 fraction of DOMINATION_TIME elapsed; null if no triple holder
   captureInfo: Record<string, { progress: number; side: string } | null>  // outpostId → active capture
-  minimap: {
-    specks: Array<{ x: number; y: number; ownerId: string }>  // sampled subset
-    buildings: Array<{ x: number; y: number; ownerId: string; typeId: string }>
-    rallyX: number | null
-    rallyY: number | null
-  }
 }

--- a/src/app/speck-wars/domain/types.ts
+++ b/src/app/speck-wars/domain/types.ts
@@ -46,6 +46,7 @@ export interface SimulationState {
 
   inputQueue: InputEvent[]
   events: SimEvent[]
+  rallyPoints: Record<string, { x: number; y: number } | null>
   spatialGrid: SpatialGrid
 }
 

--- a/src/app/speck-wars/domain/types.ts
+++ b/src/app/speck-wars/domain/types.ts
@@ -75,4 +75,5 @@ export interface HudData {
     buildingCount: number
     buildingHp: Record<string, number>
   }>
+  attackedBuildingIds: string[]
 }

--- a/src/app/speck-wars/domain/types.ts
+++ b/src/app/speck-wars/domain/types.ts
@@ -67,7 +67,7 @@ export type InputEvent =
 export type SimEvent =
   | { type: 'SPECK_DIED'; speckId: string; x: number; y: number; killedOwnerId: string; killerOwnerId: string }
   | { type: 'BUILDING_DAMAGED'; buildingId: string; hp: number }
-  | { type: 'BUILDING_DESTROYED'; buildingId: string; ownerId: string }
+  | { type: 'BUILDING_DESTROYED'; buildingId: string; ownerId: string; x: number; y: number }
   | { type: 'SPECK_SPAWNED'; speckId: string; buildingId: string }
   | { type: 'GAME_OVER'; winnerId: string; victoryType: 'destruction' | 'domination' }
   | { type: 'HUD_UPDATE'; data: HudData }

--- a/src/app/speck-wars/domain/types.ts
+++ b/src/app/speck-wars/domain/types.ts
@@ -17,6 +17,7 @@ export interface BuildingEntity {
   hp: number; maxHp: number
   spawnTimer: number       // ms until next spawn
   spawnIntervalOverride?: number  // overrides BUILDING_TYPES spawnInterval when set
+  spawnTypeOverride?: string      // overrides BUILDING_TYPES spawnTypeId when set
   inputBuffer: Record<string, number>  // typeId → count (sacrifice system, future)
   captureProgress?: number      // 0..1 progress toward capture for captureSide
   captureSide?: string | null   // which player is currently winning capture
@@ -57,6 +58,7 @@ export interface SimulationState {
 
 export type InputEvent =
   | { type: 'RALLY'; ownerId: string; x: number; y: number }
+  | { type: 'SET_SPAWN_TYPE'; ownerId: string; speckTypeId: string }
   | { type: 'BUILD'; ownerId: string; buildingTypeId: string; x: number; y: number }
   | { type: 'SACRIFICE'; ownerId: string; buildingId: string; typeId: string; count: number }
 

--- a/src/app/speck-wars/domain/types.ts
+++ b/src/app/speck-wars/domain/types.ts
@@ -42,7 +42,9 @@ export interface SimulationState {
   speckVx: Float32Array
   speckVy: Float32Array
   speckHp: Float32Array
-  speckMeta: SpeckMeta[]   // parallel to speckIds
+  speckMeta: (SpeckMeta | null)[]   // parallel to speckIds; null means dead/unused slot
+  speckCount: number       // high-water mark: indices 0..speckCount-1 may be live or freed
+  freeSlots: number[]      // recycled slot indices from dead specks
 
   inputQueue: InputEvent[]
   events: SimEvent[]

--- a/src/app/speck-wars/domain/types.ts
+++ b/src/app/speck-wars/domain/types.ts
@@ -55,6 +55,7 @@ export interface SimulationState {
   events: SimEvent[]
   rallyPoints: Record<string, { x: number; y: number } | null>
   spatialGrid: SpatialGrid
+  dominationTimer: number    // ms of continuous triple-outpost control; resets on loss
 }
 
 export type InputEvent =
@@ -80,4 +81,5 @@ export interface HudData {
   }>
   attackedBuildingIds: string[]
   tripleOutpostOwner: string | null  // player ID who owns all 3 outposts, or null
+  dominationProgress: number | null  // 0..1 fraction of DOMINATION_TIME elapsed; null if no triple holder
 }

--- a/src/app/speck-wars/domain/types.ts
+++ b/src/app/speck-wars/domain/types.ts
@@ -83,6 +83,7 @@ export interface HudData {
   attackedBuildingIds: string[]
   tripleOutpostOwner: string | null  // player ID who owns all 3 outposts, or null
   dominationProgress: number | null  // 0..1 fraction of DOMINATION_TIME elapsed; null if no triple holder
+  captureInfo: Record<string, { progress: number; side: string } | null>  // outpostId → active capture
   minimap: {
     specks: Array<{ x: number; y: number; ownerId: string }>  // sampled subset
     buildings: Array<{ x: number; y: number; ownerId: string; typeId: string }>

--- a/src/app/speck-wars/domain/types.ts
+++ b/src/app/speck-wars/domain/types.ts
@@ -18,6 +18,7 @@ export interface BuildingEntity {
   spawnTimer: number       // ms until next spawn
   spawnIntervalOverride?: number  // overrides BUILDING_TYPES spawnInterval when set
   spawnTypeOverride?: string      // overrides BUILDING_TYPES spawnTypeId when set
+  tripleOutpostBonus?: boolean    // true when owner controls all outposts (2× spawn)
   inputBuffer: Record<string, number>  // typeId → count (sacrifice system, future)
   captureProgress?: number      // 0..1 progress toward capture for captureSide
   captureSide?: string | null   // which player is currently winning capture
@@ -78,4 +79,5 @@ export interface HudData {
     buildingHp: Record<string, number>
   }>
   attackedBuildingIds: string[]
+  tripleOutpostOwner: string | null  // player ID who owns all 3 outposts, or null
 }

--- a/src/app/speck-wars/domain/types.ts
+++ b/src/app/speck-wars/domain/types.ts
@@ -83,4 +83,10 @@ export interface HudData {
   attackedBuildingIds: string[]
   tripleOutpostOwner: string | null  // player ID who owns all 3 outposts, or null
   dominationProgress: number | null  // 0..1 fraction of DOMINATION_TIME elapsed; null if no triple holder
+  minimap: {
+    specks: Array<{ x: number; y: number; ownerId: string }>  // sampled subset
+    buildings: Array<{ x: number; y: number; ownerId: string; typeId: string }>
+    rallyX: number | null
+    rallyY: number | null
+  }
 }

--- a/src/app/speck-wars/domain/types.ts
+++ b/src/app/speck-wars/domain/types.ts
@@ -67,6 +67,7 @@ export type SimEvent =
   | { type: 'SPECK_SPAWNED'; speckId: string; buildingId: string }
   | { type: 'GAME_OVER'; winnerId: string }
   | { type: 'HUD_UPDATE'; data: HudData }
+  | { type: 'OUTPOST_CAPTURED'; outpostId: string; newOwner: string; previousOwner: string }
 
 export interface HudData {
   players: Record<string, {

--- a/src/app/speck-wars/domain/types.ts
+++ b/src/app/speck-wars/domain/types.ts
@@ -69,7 +69,7 @@ export type SimEvent =
   | { type: 'BUILDING_DAMAGED'; buildingId: string; hp: number }
   | { type: 'BUILDING_DESTROYED'; buildingId: string; ownerId: string }
   | { type: 'SPECK_SPAWNED'; speckId: string; buildingId: string }
-  | { type: 'GAME_OVER'; winnerId: string }
+  | { type: 'GAME_OVER'; winnerId: string; victoryType: 'destruction' | 'domination' }
   | { type: 'HUD_UPDATE'; data: HudData }
   | { type: 'OUTPOST_CAPTURED'; outpostId: string; newOwner: string; previousOwner: string }
 

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -37,6 +37,7 @@ export class GameInstance {
   private dominationCountdownHolder: string | null = null  // who has triple outpost for countdown
   private dominationWarned10 = false    // notified at 10s remaining
   private dominationWarned5 = false     // notified at 5s remaining
+  private lastTripleHolder: string | null = null  // track triple-outpost ownership changes
 
   constructor(canvas: HTMLCanvasElement) {
     this.canvas = canvas
@@ -212,8 +213,21 @@ export class GameInstance {
               setTimeout(() => useSpeckWarsStore.getState().setNotification(null), 2500)
             }
           }
-          // Domination countdown: warn at 10s and 5s remaining
+          // Triple outpost notification: fire when ownership of all 3 outposts changes hands
           const holder = event.data.tripleOutpostOwner ?? null
+          if (holder !== this.lastTripleHolder) {
+            if (holder === 'player') {
+              store.setNotification({ message: '⬡ TRIPLE OUTPOST! Hold for 60s to win!', color: '#ffd700' })
+              setTimeout(() => useSpeckWarsStore.getState().setNotification(null), 4000)
+            } else if (holder === 'ai' && this.lastTripleHolder !== null) {
+              // AI reclaimed triple — only notify if player had just lost it
+              store.setNotification({ message: '⬡ ENEMY HAS ALL OUTPOSTS!', color: '#ff4f7b' })
+              setTimeout(() => useSpeckWarsStore.getState().setNotification(null), 3000)
+            }
+            this.lastTripleHolder = holder
+          }
+
+          // Domination countdown: warn at 10s and 5s remaining
           const dp = event.data.dominationProgress ?? null
           if (holder !== this.dominationCountdownHolder) {
             // Holder changed — reset countdown flags

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -160,7 +160,8 @@ export class GameInstance {
           const isPlayerGain = event.newOwner === 'player'
           const isPlayerLoss = event.previousOwner === 'player'
           if (isPlayerGain || isPlayerLoss) {
-            const message = isPlayerGain ? '⬡ Outpost Captured!' : '⬡ Outpost Lost!'
+            const outpostName = event.outpostId.replace('outpost-', '').toUpperCase()
+            const message = isPlayerGain ? `⬡ ${outpostName} CAPTURED` : `⬡ ${outpostName} LOST`
             const color = isPlayerGain ? '#4af7c4' : '#ff4f7b'
             store.setNotification({ message, color })
             setTimeout(() => useSpeckWarsStore.getState().setNotification(null), 2500)

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -102,6 +102,11 @@ export class GameInstance {
     console.log('GameInstance destroyed')
   }
 
+  rally(x: number, y: number) {
+    this.sim.inputQueue.push({ type: 'RALLY', ownerId: 'player', x, y })
+    this.renderer.showRallyPing(x, y)
+  }
+
   getSim(): SimulationState {
     return this.sim
   }

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -66,6 +66,10 @@ export class GameInstance {
         if (event.type === 'HUD_UPDATE') {
           store.setHud(event.data)
         }
+        if (event.type === 'SPECK_DIED') {
+          if (event.killedOwnerId === 'ai' && event.killerOwnerId === 'player') store.addKill()
+          else if (event.killedOwnerId === 'player' && event.killerOwnerId === 'ai') store.addLoss()
+        }
         if (event.type === 'OUTPOST_CAPTURED') {
           const isPlayerGain = event.newOwner === 'player'
           const isPlayerLoss = event.previousOwner === 'player'

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -19,6 +19,7 @@ export class GameInstance {
   private inputHandler!: InputHandler
   private aiController: AIController
   private elapsedMs = 0
+  private firstBloodDone = false
 
   constructor(canvas: HTMLCanvasElement) {
     this.canvas = canvas
@@ -94,6 +95,15 @@ export class GameInstance {
         if (event.type === 'SPECK_DIED') {
           if (event.killedOwnerId === 'ai' && event.killerOwnerId === 'player') store.addKill()
           else if (event.killedOwnerId === 'player' && event.killerOwnerId === 'ai') store.addLoss()
+          if (!this.firstBloodDone) {
+            this.firstBloodDone = true
+            const playerGotIt = event.killerOwnerId === 'player'
+            store.setNotification({
+              message: playerGotIt ? '⚔ FIRST BLOOD!' : '☠ FIRST BLOOD!',
+              color: playerGotIt ? '#4af7c4' : '#ff4f7b',
+            })
+            setTimeout(() => useSpeckWarsStore.getState().setNotification(null), 1800)
+          }
         }
         if (event.type === 'OUTPOST_CAPTURED') {
           const isPlayerGain = event.newOwner === 'player'

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -7,7 +7,7 @@ import { createCamera, clampCamera } from './rendering/camera'
 import { InputHandler } from './input/input-handler'
 import type { Camera } from './rendering/camera'
 import { AIController } from './domain/ai/ai-controller'
-import { recordBestTime, incrementWinStreak, resetWinStreak, isFirstGame, markFirstGameDone, recordGameResult } from './lib/personal-best'
+import { recordBestTime, incrementWinStreak, resetWinStreak, isFirstGame, markFirstGameDone, recordGameResult, markWonToday } from './lib/personal-best'
 
 export class GameInstance {
   private canvas: HTMLCanvasElement
@@ -157,6 +157,7 @@ export class GameInstance {
               const isNew = recordBestTime(s.difficulty, elapsedAtEnd)
               incrementWinStreak()
               recordGameResult(s.difficulty, true, elapsedAtEnd, s.kills)
+              markWonToday(s.difficulty)
               s.setIsNewBest(isNew)
               s.setPhase('victory')
             } else {

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -7,7 +7,7 @@ import { createCamera, clampCamera } from './rendering/camera'
 import { InputHandler } from './input/input-handler'
 import type { Camera } from './rendering/camera'
 import { AIController } from './domain/ai/ai-controller'
-import { recordBestTime, incrementWinStreak, resetWinStreak } from './lib/personal-best'
+import { recordBestTime, incrementWinStreak, resetWinStreak, isFirstGame, markFirstGameDone } from './lib/personal-best'
 
 export class GameInstance {
   private canvas: HTMLCanvasElement
@@ -61,6 +61,22 @@ export class GameInstance {
     )
     this.lastTime = performance.now()
     this.loop(this.lastTime)
+
+    // Show tutorial hints for first-time players
+    if (isFirstGame()) {
+      markFirstGameDone()
+      const hints = [
+        { delay: 1200, message: '💡 Click the map to rally your specks!', color: '#aaddff' },
+        { delay: 6000, message: '💡 Capture outposts to boost production!', color: '#aaddff' },
+        { delay: 13000, message: '💡 Hold all 3 outposts for 60s to dominate!', color: '#ffd700' },
+      ]
+      for (const { delay, message, color } of hints) {
+        setTimeout(() => {
+          useSpeckWarsStore.getState().setNotification({ message, color })
+          setTimeout(() => useSpeckWarsStore.getState().setNotification(null), 3000)
+        }, delay)
+      }
+    }
   }
 
   private loop = (now: number) => {

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -88,6 +88,7 @@ export class GameInstance {
             store.setPhase('defeat')
           }
           store.setWinnerId(event.winnerId)
+          store.setVictoryType(event.victoryType)
         }
         if (event.type === 'HUD_UPDATE') {
           store.setHud(event.data)

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -31,8 +31,16 @@ export class GameInstance {
     this.aiController = new AIController('ai', aiTickInterval[difficulty] ?? 15, difficulty === 'hard' || difficulty === 'very-hard')
   }
 
+  private onVisibilityChange = () => {
+    if (document.hidden) {
+      const store = useSpeckWarsStore.getState()
+      if (store.phase === 'playing') store.togglePause()
+    }
+  }
+
   async start() {
     console.log('GameInstance started')
+    document.addEventListener('visibilitychange', this.onVisibilityChange)
     await this.renderer.init(this.canvas)
     this.inputHandler = new InputHandler(
       this.canvas,
@@ -178,6 +186,7 @@ export class GameInstance {
 
   destroy() {
     if (this.rafId !== null) cancelAnimationFrame(this.rafId)
+    document.removeEventListener('visibilitychange', this.onVisibilityChange)
     this.renderer.destroy()
     this.inputHandler?.destroy()
     console.log('GameInstance destroyed')

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -95,6 +95,12 @@ export class GameInstance {
     this.lastTime = performance.now()
     this.loop(this.lastTime)
 
+    // Brief "BATTLE START" flash when game begins
+    setTimeout(() => {
+      useSpeckWarsStore.getState().setNotification({ message: '⚔ BATTLE START', color: '#4af7c4' })
+      setTimeout(() => useSpeckWarsStore.getState().setNotification(null), 900)
+    }, 200)
+
     // Show tutorial hints for first-time players
     if (isFirstGame()) {
       markFirstGameDone()

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -32,10 +32,16 @@ export class GameInstance {
   async start() {
     console.log('GameInstance started')
     await this.renderer.init(this.canvas)
-    this.inputHandler = new InputHandler(this.canvas, this.camera, (wx, wy) => {
-      this.sim.inputQueue.push({ type: 'RALLY', ownerId: 'player', x: wx, y: wy })
-      this.renderer.showRallyPing(wx, wy)
-    })
+    this.inputHandler = new InputHandler(
+      this.canvas,
+      this.camera,
+      (wx, wy) => {
+        this.sim.inputQueue.push({ type: 'RALLY', ownerId: 'player', x: wx, y: wy })
+        this.renderer.showRallyPing(wx, wy)
+      },
+      () => useSpeckWarsStore.getState().togglePause(),   // Space
+      () => { this.sim.rallyPoints['player'] = null },    // R — clear rally
+    )
     this.lastTime = performance.now()
     this.loop(this.lastTime)
   }

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -26,7 +26,11 @@ export class GameInstance {
     this.canvas = canvas
     const difficulty = useSpeckWarsStore.getState().difficulty
     const aiTickInterval: Record<string, number> = { easy: 60, medium: 30, hard: 15, 'very-hard': 6 }
-    this.sim = createSim(Date.now(), difficulty)
+    const now = new Date()
+    const dateKey = now.getFullYear() * 10000 + (now.getMonth() + 1) * 100 + now.getDate()
+    const diffHash = [...difficulty].reduce((acc, ch) => acc + ch.charCodeAt(0), 0)
+    const dailySeed = dateKey * 1000 + diffHash
+    this.sim = createSim(dailySeed, difficulty)
     this.renderer = new Renderer()
     this.camera = createCamera(canvas.clientWidth, canvas.clientHeight)
     this.aiController = new AIController('ai', aiTickInterval[difficulty] ?? 15, difficulty === 'hard' || difficulty === 'very-hard')

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -108,16 +108,6 @@ export class GameInstance {
 
     const store = useSpeckWarsStore.getState()
 
-    // Consume pending rally from minimap click
-    if (store.pendingRally) {
-      const { x, y } = store.pendingRally
-      store.setPendingRally(null)
-      if (store.phase === 'playing') {
-        this.sim.inputQueue.push({ type: 'RALLY', ownerId: 'player', x, y })
-        this.renderer.showRallyPing(x, y)
-      }
-    }
-
     if (store.phase === 'playing') {
       const scaledDt = dt * store.speed
       this.elapsedMs += scaledDt

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -59,7 +59,7 @@ export class GameInstance {
         this.renderer.showRallyPing(wx, wy)
       },
       () => useSpeckWarsStore.getState().togglePause(),   // Space
-      () => { this.sim.rallyPoints['player'] = null },    // R — clear rally
+      () => this.clearRally(),                             // R — clear rally
       () => {                                              // H — cycle spawn mode
         const next = useSpeckWarsStore.getState().cycleSpawnMode()
         this.sim.inputQueue.push({ type: 'SET_SPAWN_TYPE', ownerId: 'player', speckTypeId: next })
@@ -70,27 +70,9 @@ export class GameInstance {
         this.camera.x = this.canvas.clientWidth / 2 - base.x * this.camera.zoom
         this.camera.y = this.canvas.clientHeight / 2 - base.y * this.camera.zoom
       },
-      () => {                                              // D — defend (rally to player base)
-        const base = Object.values(this.sim.buildings).find(b => b.ownerId === 'player' && b.typeId === 'base')
-        if (!base) return
-        this.rally(base.x, base.y)
-      },
-      () => {                                              // A — advance to nearest non-player outpost
-        const playerBase = Object.values(this.sim.buildings).find(b => b.ownerId === 'player' && b.typeId === 'base')
-        if (!playerBase) return
-        let best = null, bestD2 = Infinity
-        for (const b of Object.values(this.sim.buildings)) {
-          if (b.typeId !== 'outpost' || b.ownerId === 'player') continue
-          const dx = b.x - playerBase.x, dy = b.y - playerBase.y
-          const d2 = dx * dx + dy * dy
-          if (d2 < bestD2) { bestD2 = d2; best = b }
-        }
-        if (best) this.rally(best.x, best.y)
-      },
-      () => {                                              // B — rush enemy base
-        const enemyBase = Object.values(this.sim.buildings).find(b => b.ownerId === 'ai' && b.typeId === 'base')
-        if (enemyBase) this.rally(enemyBase.x, enemyBase.y)
-      },
+      () => this.defend(),                                 // D — defend (rally to player base)
+      () => this.advance(),                                // A — advance to nearest non-player outpost
+      () => this.rush(),                                   // B — rush enemy base
     )
     this.lastTime = performance.now()
     this.loop(this.lastTime)
@@ -239,6 +221,33 @@ export class GameInstance {
   rally(x: number, y: number) {
     this.sim.inputQueue.push({ type: 'RALLY', ownerId: 'player', x, y })
     this.renderer.showRallyPing(x, y)
+  }
+
+  defend() {
+    const base = Object.values(this.sim.buildings).find(b => b.ownerId === 'player' && b.typeId === 'base')
+    if (base) this.rally(base.x, base.y)
+  }
+
+  advance() {
+    const playerBase = Object.values(this.sim.buildings).find(b => b.ownerId === 'player' && b.typeId === 'base')
+    if (!playerBase) return
+    let best = null, bestD2 = Infinity
+    for (const b of Object.values(this.sim.buildings)) {
+      if (b.typeId !== 'outpost' || b.ownerId === 'player') continue
+      const dx = b.x - playerBase.x, dy = b.y - playerBase.y
+      const d2 = dx * dx + dy * dy
+      if (d2 < bestD2) { bestD2 = d2; best = b }
+    }
+    if (best) this.rally(best.x, best.y)
+  }
+
+  rush() {
+    const enemyBase = Object.values(this.sim.buildings).find(b => b.ownerId === 'ai' && b.typeId === 'base')
+    if (enemyBase) this.rally(enemyBase.x, enemyBase.y)
+  }
+
+  clearRally() {
+    this.sim.rallyPoints['player'] = null
   }
 
   getSim(): SimulationState {

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -79,6 +79,14 @@ export class GameInstance {
       }
     }
 
+    // Edge pan (works in both playing and paused states)
+    if (this.inputHandler) {
+      const isPaused = store.phase === 'paused'
+      const { dx, dy } = this.inputHandler.getEdgePanDelta(dt, isPaused)
+      this.camera.x -= dx * this.camera.zoom
+      this.camera.y -= dy * this.camera.zoom
+    }
+
     this.renderer.render(this.sim, this.camera, dt)
     this.rafId = requestAnimationFrame(this.loop)
   }

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -25,6 +25,7 @@ export class GameInstance {
   private shakeMaxMs = 300
   private shakeStrength = 0
   private enemyBaseWarnedAt = -30000
+  private outpostAttackWarnedAt: Record<string, number> = {}  // outpostId → timestamp
 
   constructor(canvas: HTMLCanvasElement) {
     this.canvas = canvas
@@ -135,6 +136,25 @@ export class GameInstance {
         }
         if (event.type === 'HUD_UPDATE') {
           store.setHud(event.data)
+          // Warn when an enemy starts capturing a player-owned outpost
+          const now = Date.now()
+          const playerBuildingHp = event.data.players.player?.buildingHp ?? {}
+          for (const outpostId of event.data.attackedBuildingIds) {
+            if (!(outpostId in playerBuildingHp)) continue  // not player-owned
+            const lastWarn = this.outpostAttackWarnedAt[outpostId] ?? -Infinity
+            if (now - lastWarn > 8000) {
+              this.outpostAttackWarnedAt[outpostId] = now
+              const name = outpostId.replace('outpost-', '').toUpperCase()
+              store.setNotification({ message: `⬡ ${name} UNDER ATTACK!`, color: '#ff8c00' })
+              setTimeout(() => useSpeckWarsStore.getState().setNotification(null), 2500)
+            }
+          }
+          // Clear warnings for outposts that are no longer under attack
+          for (const id of Object.keys(this.outpostAttackWarnedAt)) {
+            if (!event.data.attackedBuildingIds.includes(id)) {
+              delete this.outpostAttackWarnedAt[id]
+            }
+          }
         }
         if (event.type === 'SPECK_DIED') {
           if (event.killedOwnerId === 'ai' && event.killerOwnerId === 'player') {

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -66,6 +66,16 @@ export class GameInstance {
         if (event.type === 'HUD_UPDATE') {
           store.setHud(event.data)
         }
+        if (event.type === 'OUTPOST_CAPTURED') {
+          const isPlayerGain = event.newOwner === 'player'
+          const isPlayerLoss = event.previousOwner === 'player'
+          if (isPlayerGain || isPlayerLoss) {
+            const message = isPlayerGain ? '⬡ Outpost Captured!' : '⬡ Outpost Lost!'
+            const color = isPlayerGain ? '#4af7c4' : '#ff4f7b'
+            store.setNotification({ message, color })
+            setTimeout(() => useSpeckWarsStore.getState().setNotification(null), 2500)
+          }
+        }
       }
     }
 

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -20,10 +20,12 @@ export class GameInstance {
 
   constructor(canvas: HTMLCanvasElement) {
     this.canvas = canvas
-    this.sim = createSim()
+    const difficulty = useSpeckWarsStore.getState().difficulty
+    const aiTickInterval: Record<'easy' | 'medium' | 'hard', number> = { easy: 60, medium: 30, hard: 15 }
+    this.sim = createSim(Date.now(), difficulty)
     this.renderer = new Renderer()
     this.camera = createCamera(canvas.clientWidth, canvas.clientHeight)
-    this.aiController = new AIController('ai')
+    this.aiController = new AIController('ai', aiTickInterval[difficulty])
   }
 
   async start() {

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -45,6 +45,12 @@ export class GameInstance {
         const next = useSpeckWarsStore.getState().cycleSpawnMode()
         this.sim.inputQueue.push({ type: 'SET_SPAWN_TYPE', ownerId: 'player', speckTypeId: next })
       },
+      () => {                                              // C — recenter camera on player base
+        const base = Object.values(this.sim.buildings).find(b => b.ownerId === 'player' && b.typeId === 'base')
+        if (!base) return
+        this.camera.x = this.canvas.clientWidth / 2 - base.x * this.camera.zoom
+        this.camera.y = this.canvas.clientHeight / 2 - base.y * this.camera.zoom
+      },
     )
     this.lastTime = performance.now()
     this.loop(this.lastTime)

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -68,6 +68,9 @@ export class GameInstance {
       () => {                                              // H — cycle spawn mode
         const next = useSpeckWarsStore.getState().cycleSpawnMode()
         this.sim.inputQueue.push({ type: 'SET_SPAWN_TYPE', ownerId: 'player', speckTypeId: next })
+        const s = useSpeckWarsStore.getState()
+        s.setNotification({ message: `Spawn: ${next.toUpperCase()}`, color: next === 'heavy' ? '#ff8844' : '#4af7c4' })
+        setTimeout(() => useSpeckWarsStore.getState().setNotification(null), 1200)
       },
       () => {                                              // C — recenter camera on player base
         const base = Object.values(this.sim.buildings).find(b => b.ownerId === 'player' && b.typeId === 'base')
@@ -75,9 +78,9 @@ export class GameInstance {
         this.camera.x = this.canvas.clientWidth / 2 - base.x * this.camera.zoom
         this.camera.y = this.canvas.clientHeight / 2 - base.y * this.camera.zoom
       },
-      () => this.defend(),                                 // D — defend (rally to player base)
-      () => this.advance(),                                // A — advance to nearest non-player outpost
-      () => this.rush(),                                   // B — rush enemy base
+      () => { this.defend(); this.notify('🛡 DEFEND', '#4af7c4') },   // D — defend (rally to player base)
+      () => { this.advance(); this.notify('→ ADVANCE', '#ffd700') },  // A — advance to nearest non-player outpost
+      () => { this.rush(); this.notify('⚡ RUSH!', '#ff4f7b') },      // B — rush enemy base
     )
     this.lastTime = performance.now()
     this.loop(this.lastTime)
@@ -319,6 +322,11 @@ export class GameInstance {
 
   clearRally() {
     this.sim.rallyPoints['player'] = null
+  }
+
+  private notify(message: string, color: string) {
+    useSpeckWarsStore.getState().setNotification({ message, color })
+    setTimeout(() => useSpeckWarsStore.getState().setNotification(null), 1200)
   }
 
   getSim(): SimulationState {

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -135,9 +135,11 @@ export class GameInstance {
           this.shakeMaxMs = won ? 700 : 450
           this.shakeStrength = won ? 14 : 9
           // Show dramatic notification, then transition to end screen after a brief delay
+          const playerBaseHp = this.sim.buildings['building-player-base']?.hp ?? 100
+          const isComeback = won && playerBaseHp < 20  // base barely survived
           store.setNotification({
-            message: won ? '⚡ VICTORY!' : '💀 DEFEATED',
-            color: won ? '#4af7c4' : '#ff4f7b',
+            message: isComeback ? '🏆 COMEBACK VICTORY!' : won ? '⚡ VICTORY!' : '💀 DEFEATED',
+            color: isComeback ? '#ffd700' : won ? '#4af7c4' : '#ff4f7b',
           })
           const elapsedAtEnd = this.elapsedMs
           setTimeout(() => {

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -29,7 +29,10 @@ export class GameInstance {
   async start() {
     console.log('GameInstance started')
     await this.renderer.init(this.canvas)
-    this.inputHandler = new InputHandler(this.canvas, this.camera)
+    this.inputHandler = new InputHandler(this.canvas, this.camera, (wx, wy) => {
+      this.sim.inputQueue.push({ type: 'RALLY', ownerId: 'player', x: wx, y: wy })
+      this.renderer.showRallyPing(wx, wy)
+    })
     this.lastTime = performance.now()
     this.loop(this.lastTime)
   }

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -17,6 +17,7 @@ export class GameInstance {
   private camera: Camera
   private inputHandler!: InputHandler
   private aiController: AIController
+  private elapsedMs = 0
 
   constructor(canvas: HTMLCanvasElement) {
     this.canvas = canvas
@@ -43,22 +44,25 @@ export class GameInstance {
     const dt = Math.min(now - this.lastTime, 50)
     this.lastTime = now
 
-    this.aiController.update(this.sim)
-    this.sim = tick(this.sim, dt)
+    const store = useSpeckWarsStore.getState()
+    if (store.phase === 'playing') {
+      this.elapsedMs += dt
+      store.setElapsedMs(this.elapsedMs)
+      this.aiController.update(this.sim)
+      this.sim = tick(this.sim, dt)
 
-    // Forward sim events to Zustand store
-    for (const event of this.sim.events) {
-      if (event.type === 'GAME_OVER') {
-        useSpeckWarsStore.getState().setPhase('victory')
-        useSpeckWarsStore.getState().setWinnerId(event.winnerId)
-      }
-      if (event.type === 'HUD_UPDATE') {
-        useSpeckWarsStore.getState().setHud(event.data)
+      for (const event of this.sim.events) {
+        if (event.type === 'GAME_OVER') {
+          store.setPhase('victory')
+          store.setWinnerId(event.winnerId)
+        }
+        if (event.type === 'HUD_UPDATE') {
+          store.setHud(event.data)
+        }
       }
     }
 
     this.renderer.render(this.sim, this.camera, dt)
-
     this.rafId = requestAnimationFrame(this.loop)
   }
 

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -3,7 +3,7 @@ import { tick } from './domain/simulation/tick'
 import type { SimulationState } from './domain/types'
 import { useSpeckWarsStore } from './store'
 import { Renderer } from './rendering/renderer'
-import { createCamera } from './rendering/camera'
+import { createCamera, clampCamera } from './rendering/camera'
 import { InputHandler } from './input/input-handler'
 import type { Camera } from './rendering/camera'
 import { AIController } from './domain/ai/ai-controller'
@@ -126,6 +126,9 @@ export class GameInstance {
       this.camera.x -= dx * this.camera.zoom
       this.camera.y -= dy * this.camera.zoom
     }
+
+    // Clamp camera so world doesn't disappear off-screen
+    clampCamera(this.camera, this.canvas.clientWidth, this.canvas.clientHeight)
 
     this.renderer.render(this.sim, this.camera, dt)
     this.rafId = requestAnimationFrame(this.loop)

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -7,6 +7,7 @@ import { createCamera } from './rendering/camera'
 import { InputHandler } from './input/input-handler'
 import type { Camera } from './rendering/camera'
 import { AIController } from './domain/ai/ai-controller'
+import { recordBestTime } from './lib/personal-best'
 
 export class GameInstance {
   private canvas: HTMLCanvasElement
@@ -70,7 +71,14 @@ export class GameInstance {
 
       for (const event of this.sim.events) {
         if (event.type === 'GAME_OVER') {
-          store.setPhase('victory')
+          if (event.winnerId === 'player') {
+            const isNew = recordBestTime(store.difficulty, this.elapsedMs)
+            store.setIsNewBest(isNew)
+            store.setPhase('victory')
+          } else {
+            store.setIsNewBest(false)
+            store.setPhase('defeat')
+          }
           store.setWinnerId(event.winnerId)
         }
         if (event.type === 'HUD_UPDATE') {

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -123,6 +123,10 @@ export class GameInstance {
           const won = event.winnerId === 'player'
           store.setWinnerId(event.winnerId)
           store.setVictoryType(event.victoryType)
+          // Dramatic camera shake on game-over
+          this.shakeMs = won ? 700 : 450
+          this.shakeMaxMs = won ? 700 : 450
+          this.shakeStrength = won ? 14 : 9
           // Show dramatic notification, then transition to end screen after a brief delay
           store.setNotification({
             message: won ? '⚡ VICTORY!' : '💀 DEFEATED',

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -52,7 +52,7 @@ export class GameInstance {
       }
     }
 
-    this.renderer.render(this.sim, this.camera)
+    this.renderer.render(this.sim, this.camera, dt)
 
     this.rafId = requestAnimationFrame(this.loop)
   }

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -24,11 +24,11 @@ export class GameInstance {
   constructor(canvas: HTMLCanvasElement) {
     this.canvas = canvas
     const difficulty = useSpeckWarsStore.getState().difficulty
-    const aiTickInterval: Record<'easy' | 'medium' | 'hard', number> = { easy: 60, medium: 30, hard: 15 }
+    const aiTickInterval: Record<string, number> = { easy: 60, medium: 30, hard: 15, 'very-hard': 6 }
     this.sim = createSim(Date.now(), difficulty)
     this.renderer = new Renderer()
     this.camera = createCamera(canvas.clientWidth, canvas.clientHeight)
-    this.aiController = new AIController('ai', aiTickInterval[difficulty], difficulty === 'hard')
+    this.aiController = new AIController('ai', aiTickInterval[difficulty] ?? 15, difficulty === 'hard' || difficulty === 'very-hard')
   }
 
   async start() {

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -52,10 +52,11 @@ export class GameInstance {
 
     const store = useSpeckWarsStore.getState()
     if (store.phase === 'playing') {
-      this.elapsedMs += dt
+      const scaledDt = dt * store.speed
+      this.elapsedMs += scaledDt
       store.setElapsedMs(this.elapsedMs)
       this.aiController.update(this.sim)
-      this.sim = tick(this.sim, dt)
+      this.sim = tick(this.sim, scaledDt)
 
       for (const event of this.sim.events) {
         if (event.type === 'GAME_OVER') {

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -7,7 +7,7 @@ import { createCamera, clampCamera } from './rendering/camera'
 import { InputHandler } from './input/input-handler'
 import type { Camera } from './rendering/camera'
 import { AIController } from './domain/ai/ai-controller'
-import { recordBestTime, incrementWinStreak, resetWinStreak, isFirstGame, markFirstGameDone } from './lib/personal-best'
+import { recordBestTime, incrementWinStreak, resetWinStreak, isFirstGame, markFirstGameDone, recordGameResult } from './lib/personal-best'
 
 export class GameInstance {
   private canvas: HTMLCanvasElement
@@ -108,10 +108,12 @@ export class GameInstance {
           if (event.winnerId === 'player') {
             const isNew = recordBestTime(store.difficulty, this.elapsedMs)
             incrementWinStreak()
+            recordGameResult(store.difficulty, true, this.elapsedMs, store.kills)
             store.setIsNewBest(isNew)
             store.setPhase('victory')
           } else {
             resetWinStreak()
+            recordGameResult(store.difficulty, false, this.elapsedMs, store.kills)
             store.setIsNewBest(false)
             store.setPhase('defeat')
           }

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -3,7 +3,9 @@ import { tick } from './domain/simulation/tick'
 import type { SimulationState } from './domain/types'
 import { useSpeckWarsStore } from './store'
 import { Renderer } from './rendering/renderer'
-import { WORLD_WIDTH, WORLD_HEIGHT } from './domain/constants'
+import { createCamera } from './rendering/camera'
+import { InputHandler } from './input/input-handler'
+import type { Camera } from './rendering/camera'
 
 export class GameInstance {
   private canvas: HTMLCanvasElement
@@ -11,22 +13,20 @@ export class GameInstance {
   private renderer: Renderer
   private rafId: number | null = null
   private lastTime: number = 0
-  private camera: { x: number; y: number; zoom: number }
+  private camera: Camera
+  private inputHandler!: InputHandler
 
   constructor(canvas: HTMLCanvasElement) {
     this.canvas = canvas
     this.sim = createSim()
     this.renderer = new Renderer()
-    this.camera = {
-      x: canvas.width / 2 - WORLD_WIDTH / 2,
-      y: canvas.height / 2 - WORLD_HEIGHT / 2,
-      zoom: 1,
-    }
+    this.camera = createCamera(canvas.clientWidth, canvas.clientHeight)
   }
 
   async start() {
     console.log('GameInstance started')
     await this.renderer.init(this.canvas)
+    this.inputHandler = new InputHandler(this.canvas, this.camera)
     this.lastTime = performance.now()
     this.loop(this.lastTime)
   }
@@ -52,6 +52,7 @@ export class GameInstance {
   destroy() {
     if (this.rafId !== null) cancelAnimationFrame(this.rafId)
     this.renderer.destroy()
+    this.inputHandler?.destroy()
     console.log('GameInstance destroyed')
   }
 
@@ -63,7 +64,7 @@ export class GameInstance {
     return this.camera
   }
 
-  setCamera(camera: { x: number; y: number; zoom: number }) {
+  setCamera(camera: Camera) {
     this.camera = camera
   }
 }

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -229,9 +229,14 @@ export class GameInstance {
         }
         if (event.type === 'BUILDING_DAMAGED' && event.buildingId === 'building-ai-base') {
           const aiBase = this.sim.buildings['building-ai-base']
-          if (aiBase && event.hp / aiBase.maxHp < 0.2) {
+          if (aiBase) {
+            const hpFrac = event.hp / aiBase.maxHp
             const now = Date.now()
-            if (now - this.enemyBaseWarnedAt > 15000) {
+            if (hpFrac < 0.1 && now - this.enemyBaseWarnedAt > 8000) {
+              this.enemyBaseWarnedAt = now
+              store.setNotification({ message: '💥 ENEMY BASE COLLAPSING!', color: '#ff8844' })
+              setTimeout(() => useSpeckWarsStore.getState().setNotification(null), 3000)
+            } else if (hpFrac < 0.2 && hpFrac >= 0.1 && now - this.enemyBaseWarnedAt > 15000) {
               this.enemyBaseWarnedAt = now
               store.setNotification({ message: '⚔ ENEMY BASE CRITICAL!', color: '#ffd700' })
               setTimeout(() => useSpeckWarsStore.getState().setNotification(null), 3000)

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -2,26 +2,37 @@ import { createSim } from './domain/simulation/create-sim'
 import { tick } from './domain/simulation/tick'
 import type { SimulationState } from './domain/types'
 import { useSpeckWarsStore } from './store'
+import { Renderer } from './rendering/renderer'
+import { WORLD_WIDTH, WORLD_HEIGHT } from './domain/constants'
 
 export class GameInstance {
   private canvas: HTMLCanvasElement
   private sim: SimulationState
+  private renderer: Renderer
   private rafId: number | null = null
   private lastTime: number = 0
+  private camera: { x: number; y: number; zoom: number }
 
   constructor(canvas: HTMLCanvasElement) {
     this.canvas = canvas
     this.sim = createSim()
+    this.renderer = new Renderer()
+    this.camera = {
+      x: canvas.width / 2 - WORLD_WIDTH / 2,
+      y: canvas.height / 2 - WORLD_HEIGHT / 2,
+      zoom: 1,
+    }
   }
 
-  start() {
+  async start() {
     console.log('GameInstance started')
+    await this.renderer.init(this.canvas)
     this.lastTime = performance.now()
     this.loop(this.lastTime)
   }
 
   private loop = (now: number) => {
-    const dt = Math.min(now - this.lastTime, 50)  // cap at 50ms to avoid spiral-of-death
+    const dt = Math.min(now - this.lastTime, 50)
     this.lastTime = now
 
     this.sim = tick(this.sim, dt)
@@ -33,15 +44,26 @@ export class GameInstance {
       }
     }
 
+    this.renderer.render(this.sim, this.camera)
+
     this.rafId = requestAnimationFrame(this.loop)
   }
 
   destroy() {
     if (this.rafId !== null) cancelAnimationFrame(this.rafId)
+    this.renderer.destroy()
     console.log('GameInstance destroyed')
   }
 
   getSim(): SimulationState {
     return this.sim
+  }
+
+  getCamera() {
+    return this.camera
+  }
+
+  setCamera(camera: { x: number; y: number; zoom: number }) {
+    this.camera = camera
   }
 }

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -58,6 +58,18 @@ export class GameInstance {
         if (!base) return
         this.rally(base.x, base.y)
       },
+      () => {                                              // A — advance to nearest non-player outpost
+        const playerBase = Object.values(this.sim.buildings).find(b => b.ownerId === 'player' && b.typeId === 'base')
+        if (!playerBase) return
+        let best = null, bestD2 = Infinity
+        for (const b of Object.values(this.sim.buildings)) {
+          if (b.typeId !== 'outpost' || b.ownerId === 'player') continue
+          const dx = b.x - playerBase.x, dy = b.y - playerBase.y
+          const d2 = dx * dx + dy * dy
+          if (d2 < bestD2) { bestD2 = d2; best = b }
+        }
+        if (best) this.rally(best.x, best.y)
+      },
     )
     this.lastTime = performance.now()
     this.loop(this.lastTime)

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -6,6 +6,7 @@ import { Renderer } from './rendering/renderer'
 import { createCamera } from './rendering/camera'
 import { InputHandler } from './input/input-handler'
 import type { Camera } from './rendering/camera'
+import { AIController } from './domain/ai/ai-controller'
 
 export class GameInstance {
   private canvas: HTMLCanvasElement
@@ -15,12 +16,14 @@ export class GameInstance {
   private lastTime: number = 0
   private camera: Camera
   private inputHandler!: InputHandler
+  private aiController: AIController
 
   constructor(canvas: HTMLCanvasElement) {
     this.canvas = canvas
     this.sim = createSim()
     this.renderer = new Renderer()
     this.camera = createCamera(canvas.clientWidth, canvas.clientHeight)
+    this.aiController = new AIController('ai')
   }
 
   async start() {
@@ -35,6 +38,7 @@ export class GameInstance {
     const dt = Math.min(now - this.lastTime, 50)
     this.lastTime = now
 
+    this.aiController.update(this.sim)
     this.sim = tick(this.sim, dt)
 
     // Forward sim events to Zustand store

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -33,6 +33,7 @@ export class GameInstance {
   private idleArmyTimer = 0              // ms with no rally point + specks available
   private lastIdleNudge = -30000         // allow nudge immediately if idle at game start
   private cachedPlayerSpeckCount = 0    // updated from HUD_UPDATE
+  private lastAiSpawnMode: string = 'basic'  // track AI spawn mode changes
 
   constructor(canvas: HTMLCanvasElement) {
     this.canvas = canvas
@@ -278,6 +279,20 @@ export class GameInstance {
             setTimeout(() => useSpeckWarsStore.getState().setNotification(null), 2500)
           }
         }
+      }
+    }
+
+    // Detect AI spawn mode changes and notify player
+    if (store.phase === 'playing') {
+      const aiBase = this.sim.buildings['building-ai-base']
+      const aiSpawnMode = aiBase?.spawnTypeOverride ?? 'basic'
+      if (aiSpawnMode !== this.lastAiSpawnMode && this.elapsedMs > 5000) {
+        this.lastAiSpawnMode = aiSpawnMode
+        if (aiSpawnMode === 'heavy') {
+          store.setNotification({ message: '⬡ ENEMY BUILDING TANKS', color: '#ffaa55' })
+          setTimeout(() => useSpeckWarsStore.getState().setNotification(null), 2000)
+        }
+        // No notification when switching back to basic — less alarming
       }
     }
 

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -7,7 +7,7 @@ import { createCamera } from './rendering/camera'
 import { InputHandler } from './input/input-handler'
 import type { Camera } from './rendering/camera'
 import { AIController } from './domain/ai/ai-controller'
-import { recordBestTime } from './lib/personal-best'
+import { recordBestTime, incrementWinStreak, resetWinStreak } from './lib/personal-best'
 
 export class GameInstance {
   private canvas: HTMLCanvasElement
@@ -52,6 +52,11 @@ export class GameInstance {
         this.camera.x = this.canvas.clientWidth / 2 - base.x * this.camera.zoom
         this.camera.y = this.canvas.clientHeight / 2 - base.y * this.camera.zoom
       },
+      () => {                                              // D — defend (rally to player base)
+        const base = Object.values(this.sim.buildings).find(b => b.ownerId === 'player' && b.typeId === 'base')
+        if (!base) return
+        this.rally(base.x, base.y)
+      },
     )
     this.lastTime = performance.now()
     this.loop(this.lastTime)
@@ -73,9 +78,11 @@ export class GameInstance {
         if (event.type === 'GAME_OVER') {
           if (event.winnerId === 'player') {
             const isNew = recordBestTime(store.difficulty, this.elapsedMs)
+            incrementWinStreak()
             store.setIsNewBest(isNew)
             store.setPhase('victory')
           } else {
+            resetWinStreak()
             store.setIsNewBest(false)
             store.setPhase('defeat')
           }

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -20,6 +20,7 @@ export class GameInstance {
   private aiController: AIController
   private elapsedMs = 0
   private firstBloodDone = false
+  private baseAttackWarnedAt = -30000  // allow warning immediately on first hit
 
   constructor(canvas: HTMLCanvasElement) {
     this.canvas = canvas
@@ -158,6 +159,14 @@ export class GameInstance {
               color: playerGotIt ? '#4af7c4' : '#ff4f7b',
             })
             setTimeout(() => useSpeckWarsStore.getState().setNotification(null), 1800)
+          }
+        }
+        if (event.type === 'BUILDING_DAMAGED' && event.buildingId === 'building-player-base') {
+          const now = Date.now()
+          if (now - this.baseAttackWarnedAt > 12000) {
+            this.baseAttackWarnedAt = now
+            store.setNotification({ message: '⚠ BASE UNDER ATTACK!', color: '#ff4f7b' })
+            setTimeout(() => useSpeckWarsStore.getState().setNotification(null), 2500)
           }
         }
         if (event.type === 'OUTPOST_CAPTURED') {

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -100,7 +100,7 @@ export class GameInstance {
       const scaledDt = dt * store.speed
       this.elapsedMs += scaledDt
       store.setElapsedMs(this.elapsedMs)
-      this.aiController.update(this.sim)
+      this.aiController.update(this.sim, scaledDt)
       this.sim = tick(this.sim, scaledDt)
 
       for (const event of this.sim.events) {

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -26,6 +26,7 @@ export class GameInstance {
   private shakeStrength = 0
   private enemyBaseWarnedAt = -30000
   private outpostAttackWarnedAt: Record<string, number> = {}  // outpostId → timestamp
+  private enemySurgeWarnedAt = -30000
 
   constructor(canvas: HTMLCanvasElement) {
     this.canvas = canvas
@@ -155,6 +156,14 @@ export class GameInstance {
               delete this.outpostAttackWarnedAt[id]
             }
           }
+          // Enemy surge warning: AI has 2× the player's specks
+          const playerSpecks = event.data.players.player?.speckCount ?? 0
+          const aiSpecks = event.data.players.ai?.speckCount ?? 0
+          if (aiSpecks >= 2 * playerSpecks && playerSpecks > 5 && now - this.enemySurgeWarnedAt > 20000) {
+            this.enemySurgeWarnedAt = now
+            store.setNotification({ message: '⚠ ENEMY SURGE!', color: '#ff6b35' })
+            setTimeout(() => useSpeckWarsStore.getState().setNotification(null), 2500)
+          }
         }
         if (event.type === 'SPECK_DIED') {
           if (event.killedOwnerId === 'ai' && event.killerOwnerId === 'player') {
@@ -206,10 +215,13 @@ export class GameInstance {
         if (event.type === 'OUTPOST_CAPTURED') {
           const isPlayerGain = event.newOwner === 'player'
           const isPlayerLoss = event.previousOwner === 'player'
+          const isRecapture = isPlayerGain && event.previousOwner === 'ai'
           if (isPlayerGain || isPlayerLoss) {
             const outpostName = event.outpostId.replace('outpost-', '').toUpperCase()
-            const message = isPlayerGain ? `⬡ ${outpostName} CAPTURED` : `⬡ ${outpostName} LOST`
-            const color = isPlayerGain ? '#4af7c4' : '#ff4f7b'
+            const message = isPlayerLoss ? `⬡ ${outpostName} LOST`
+              : isRecapture ? `⬡ ${outpostName} RECAPTURED!`
+              : `⬡ ${outpostName} CAPTURED`
+            const color = isPlayerLoss ? '#ff4f7b' : isRecapture ? '#ffd700' : '#4af7c4'
             store.setNotification({ message, color })
             setTimeout(() => useSpeckWarsStore.getState().setNotification(null), 2500)
           }

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -34,6 +34,9 @@ export class GameInstance {
   private lastIdleNudge = -30000         // allow nudge immediately if idle at game start
   private cachedPlayerSpeckCount = 0    // updated from HUD_UPDATE
   private lastAiSpawnMode: string = 'basic'  // track AI spawn mode changes
+  private dominationCountdownHolder: string | null = null  // who has triple outpost for countdown
+  private dominationWarned10 = false    // notified at 10s remaining
+  private dominationWarned5 = false     // notified at 5s remaining
 
   constructor(canvas: HTMLCanvasElement) {
     this.canvas = canvas
@@ -206,6 +209,34 @@ export class GameInstance {
               const name = buildingId.replace('outpost-', '').toUpperCase()
               store.setNotification({ message: `⬡ ${name} HP CRITICAL!`, color: '#ff2200' })
               setTimeout(() => useSpeckWarsStore.getState().setNotification(null), 2500)
+            }
+          }
+          // Domination countdown: warn at 10s and 5s remaining
+          const holder = event.data.tripleOutpostOwner ?? null
+          const dp = event.data.dominationProgress ?? null
+          if (holder !== this.dominationCountdownHolder) {
+            // Holder changed — reset countdown flags
+            this.dominationCountdownHolder = holder
+            this.dominationWarned10 = false
+            this.dominationWarned5 = false
+          }
+          if (holder !== null && dp !== null) {
+            const isPlayer = holder === 'player'
+            // 10s left threshold: 50/60 ≈ 0.833
+            if (!this.dominationWarned10 && dp >= 50 / 60) {
+              this.dominationWarned10 = true
+              const msg = isPlayer ? '⬡ DOMINATION IN 10s!' : '⬡ ENEMY DOMINATION IN 10s!'
+              const color = isPlayer ? '#4af7c4' : '#ff4f7b'
+              store.setNotification({ message: msg, color })
+              setTimeout(() => useSpeckWarsStore.getState().setNotification(null), 3000)
+            }
+            // 5s left threshold: 55/60 ≈ 0.917
+            if (!this.dominationWarned5 && dp >= 55 / 60) {
+              this.dominationWarned5 = true
+              const msg = isPlayer ? '⬡ DOMINATION IN 5s!' : '⬡ ENEMY DOMINATION IN 5s!'
+              const color = isPlayer ? '#ffd700' : '#ff2200'
+              store.setNotification({ message: msg, color })
+              setTimeout(() => useSpeckWarsStore.getState().setNotification(null), 4500)
             }
           }
         }

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -78,6 +78,10 @@ export class GameInstance {
         }
         if (best) this.rally(best.x, best.y)
       },
+      () => {                                              // B — rush enemy base
+        const enemyBase = Object.values(this.sim.buildings).find(b => b.ownerId === 'ai' && b.typeId === 'base')
+        if (enemyBase) this.rally(enemyBase.x, enemyBase.y)
+      },
     )
     this.lastTime = performance.now()
     this.loop(this.lastTime)

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -30,6 +30,9 @@ export class GameInstance {
   private enemySurgeWarnedAt = -30000
   private recentKillTimes: number[] = []  // timestamps of recent player kills (combo detection)
   private lastComboNotifiedAt = -5000
+  private idleArmyTimer = 0              // ms with no rally point + specks available
+  private lastIdleNudge = -30000         // allow nudge immediately if idle at game start
+  private cachedPlayerSpeckCount = 0    // updated from HUD_UPDATE
 
   constructor(canvas: HTMLCanvasElement) {
     this.canvas = canvas
@@ -144,6 +147,7 @@ export class GameInstance {
         }
         if (event.type === 'HUD_UPDATE') {
           store.setHud(event.data)
+          this.cachedPlayerSpeckCount = event.data.players.player?.speckCount ?? 0
           // Warn when an enemy starts capturing a player-owned outpost
           const now = Date.now()
           const playerBuildingHp = event.data.players.player?.buildingHp ?? {}
@@ -259,6 +263,22 @@ export class GameInstance {
             setTimeout(() => useSpeckWarsStore.getState().setNotification(null), 2500)
           }
         }
+      }
+    }
+
+    // Idle army nudge: remind player to rally when specks sit idle
+    if (store.phase === 'playing') {
+      const hasRally = !!this.sim.rallyPoints['player']
+      if (!hasRally && this.cachedPlayerSpeckCount >= 10) {
+        this.idleArmyTimer += dt
+        if (this.idleArmyTimer > 20000 && !store.notification
+            && Date.now() - this.lastIdleNudge > 30000) {
+          this.lastIdleNudge = Date.now()
+          store.setNotification({ message: '📍 Click to send your army!', color: '#aaddff' })
+          setTimeout(() => useSpeckWarsStore.getState().setNotification(null), 2500)
+        }
+      } else {
+        this.idleArmyTimer = 0
       }
     }
 

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -122,8 +122,20 @@ export class GameInstance {
           store.setHud(event.data)
         }
         if (event.type === 'SPECK_DIED') {
-          if (event.killedOwnerId === 'ai' && event.killerOwnerId === 'player') store.addKill()
-          else if (event.killedOwnerId === 'player' && event.killerOwnerId === 'ai') store.addLoss()
+          if (event.killedOwnerId === 'ai' && event.killerOwnerId === 'player') {
+            store.addKill()
+            const k = useSpeckWarsStore.getState().kills
+            const milestones: Record<number, { message: string; color: string }> = {
+              10:  { message: '💀 10 KILLS',  color: '#4af7c4' },
+              25:  { message: '💀 25 KILLS',  color: '#ffd700' },
+              50:  { message: '💀 50 KILLS',  color: '#ff8844' },
+              100: { message: '💀 100 KILLS', color: '#cc00ff' },
+            }
+            if (milestones[k]) {
+              store.setNotification(milestones[k])
+              setTimeout(() => useSpeckWarsStore.getState().setNotification(null), 2000)
+            }
+          } else if (event.killedOwnerId === 'player' && event.killerOwnerId === 'ai') store.addLoss()
           if (!this.firstBloodDone) {
             this.firstBloodDone = true
             const playerGotIt = event.killerOwnerId === 'player'

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -107,6 +107,17 @@ export class GameInstance {
     this.lastTime = now
 
     const store = useSpeckWarsStore.getState()
+
+    // Consume pending rally from minimap click
+    if (store.pendingRally) {
+      const { x, y } = store.pendingRally
+      store.setPendingRally(null)
+      if (store.phase === 'playing') {
+        this.sim.inputQueue.push({ type: 'RALLY', ownerId: 'player', x, y })
+        this.renderer.showRallyPing(x, y)
+      }
+    }
+
     if (store.phase === 'playing') {
       const scaledDt = dt * store.speed
       this.elapsedMs += scaledDt

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -27,7 +27,7 @@ export class GameInstance {
     this.sim = createSim(Date.now(), difficulty)
     this.renderer = new Renderer()
     this.camera = createCamera(canvas.clientWidth, canvas.clientHeight)
-    this.aiController = new AIController('ai', aiTickInterval[difficulty])
+    this.aiController = new AIController('ai', aiTickInterval[difficulty], difficulty === 'hard')
   }
 
   async start() {

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -26,6 +26,7 @@ export class GameInstance {
   private shakeStrength = 0
   private enemyBaseWarnedAt = -30000
   private outpostAttackWarnedAt: Record<string, number> = {}  // outpostId → timestamp
+  private outpostHpWarnedAt: Record<string, number> = {}     // outpostId → timestamp (HP critical)
   private enemySurgeWarnedAt = -30000
 
   constructor(canvas: HTMLCanvasElement) {
@@ -163,6 +164,20 @@ export class GameInstance {
             this.enemySurgeWarnedAt = now
             store.setNotification({ message: '⚠ ENEMY SURGE!', color: '#ff6b35' })
             setTimeout(() => useSpeckWarsStore.getState().setNotification(null), 2500)
+          }
+          // Outpost HP critical: player outpost < 20% max HP (50)
+          const OUTPOST_MAX_HP = 50
+          const OUTPOST_CRITICAL_HP = OUTPOST_MAX_HP * 0.2  // 10 HP
+          for (const [buildingId, hp] of Object.entries(playerBuildingHp)) {
+            if (!buildingId.startsWith('outpost-')) continue
+            if (hp > OUTPOST_CRITICAL_HP) { delete this.outpostHpWarnedAt[buildingId]; continue }
+            const lastHpWarn = this.outpostHpWarnedAt[buildingId] ?? -Infinity
+            if (now - lastHpWarn > 12000) {
+              this.outpostHpWarnedAt[buildingId] = now
+              const name = buildingId.replace('outpost-', '').toUpperCase()
+              store.setNotification({ message: `⬡ ${name} HP CRITICAL!`, color: '#ff2200' })
+              setTimeout(() => useSpeckWarsStore.getState().setNotification(null), 2500)
+            }
           }
         }
         if (event.type === 'SPECK_DIED') {

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -108,20 +108,30 @@ export class GameInstance {
 
       for (const event of this.sim.events) {
         if (event.type === 'GAME_OVER') {
-          if (event.winnerId === 'player') {
-            const isNew = recordBestTime(store.difficulty, this.elapsedMs)
-            incrementWinStreak()
-            recordGameResult(store.difficulty, true, this.elapsedMs, store.kills)
-            store.setIsNewBest(isNew)
-            store.setPhase('victory')
-          } else {
-            resetWinStreak()
-            recordGameResult(store.difficulty, false, this.elapsedMs, store.kills)
-            store.setIsNewBest(false)
-            store.setPhase('defeat')
-          }
+          const won = event.winnerId === 'player'
           store.setWinnerId(event.winnerId)
           store.setVictoryType(event.victoryType)
+          // Show dramatic notification, then transition to end screen after a brief delay
+          store.setNotification({
+            message: won ? '⚡ VICTORY!' : '💀 DEFEATED',
+            color: won ? '#4af7c4' : '#ff4f7b',
+          })
+          const elapsedAtEnd = this.elapsedMs
+          setTimeout(() => {
+            const s = useSpeckWarsStore.getState()
+            if (won) {
+              const isNew = recordBestTime(s.difficulty, elapsedAtEnd)
+              incrementWinStreak()
+              recordGameResult(s.difficulty, true, elapsedAtEnd, s.kills)
+              s.setIsNewBest(isNew)
+              s.setPhase('victory')
+            } else {
+              resetWinStreak()
+              recordGameResult(s.difficulty, false, elapsedAtEnd, s.kills)
+              s.setIsNewBest(false)
+              s.setPhase('defeat')
+            }
+          }, 1400)
         }
         if (event.type === 'HUD_UPDATE') {
           store.setHud(event.data)

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -41,6 +41,10 @@ export class GameInstance {
       },
       () => useSpeckWarsStore.getState().togglePause(),   // Space
       () => { this.sim.rallyPoints['player'] = null },    // R — clear rally
+      () => {                                              // H — cycle spawn mode
+        const next = useSpeckWarsStore.getState().cycleSpawnMode()
+        this.sim.inputQueue.push({ type: 'SET_SPAWN_TYPE', ownerId: 'player', speckTypeId: next })
+      },
     )
     this.lastTime = performance.now()
     this.loop(this.lastTime)

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -21,6 +21,9 @@ export class GameInstance {
   private elapsedMs = 0
   private firstBloodDone = false
   private baseAttackWarnedAt = -30000  // allow warning immediately on first hit
+  private shakeMs = 0
+  private shakeMaxMs = 300
+  private shakeStrength = 0
 
   constructor(canvas: HTMLCanvasElement) {
     this.canvas = canvas
@@ -166,6 +169,9 @@ export class GameInstance {
           }
         }
         if (event.type === 'BUILDING_DAMAGED' && event.buildingId === 'building-player-base') {
+          // Screen shake on base hit
+          this.shakeMs = this.shakeMaxMs
+          this.shakeStrength = 5
           const now = Date.now()
           if (now - this.baseAttackWarnedAt > 12000) {
             this.baseAttackWarnedAt = now
@@ -198,7 +204,15 @@ export class GameInstance {
     // Clamp camera so world doesn't disappear off-screen
     clampCamera(this.camera, this.canvas.clientWidth, this.canvas.clientHeight)
 
-    this.renderer.render(this.sim, this.camera, dt)
+    let shakeX = 0, shakeY = 0
+    if (this.shakeMs > 0) {
+      this.shakeMs -= dt
+      const t = Math.max(0, this.shakeMs / this.shakeMaxMs)
+      const s = this.shakeStrength * t
+      shakeX = (Math.random() * 2 - 1) * s
+      shakeY = (Math.random() * 2 - 1) * s
+    }
+    this.renderer.render(this.sim, this.camera, dt, shakeX, shakeY)
     this.rafId = requestAnimationFrame(this.loop)
   }
 

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -28,6 +28,8 @@ export class GameInstance {
   private outpostAttackWarnedAt: Record<string, number> = {}  // outpostId → timestamp
   private outpostHpWarnedAt: Record<string, number> = {}     // outpostId → timestamp (HP critical)
   private enemySurgeWarnedAt = -30000
+  private recentKillTimes: number[] = []  // timestamps of recent player kills (combo detection)
+  private lastComboNotifiedAt = -5000
 
   constructor(canvas: HTMLCanvasElement) {
     this.canvas = canvas
@@ -183,6 +185,18 @@ export class GameInstance {
         if (event.type === 'SPECK_DIED') {
           if (event.killedOwnerId === 'ai' && event.killerOwnerId === 'player') {
             store.addKill()
+            const nowTs = Date.now()
+            // Combo detection: 3+ kills within 2s
+            this.recentKillTimes.push(nowTs)
+            this.recentKillTimes = this.recentKillTimes.filter(t => nowTs - t < 2000)
+            if (this.recentKillTimes.length >= 3 && nowTs - this.lastComboNotifiedAt > 3000) {
+              this.lastComboNotifiedAt = nowTs
+              const count = this.recentKillTimes.length
+              const comboColors: Record<number, string> = { 3: '#4af7c4', 5: '#ffd700', 8: '#ff8844', 12: '#cc00ff' }
+              const color = count >= 12 ? '#cc00ff' : count >= 8 ? '#ff8844' : count >= 5 ? '#ffd700' : '#4af7c4'
+              store.setNotification({ message: `⚡ COMBO ×${count}!`, color })
+              setTimeout(() => useSpeckWarsStore.getState().setNotification(null), 1500)
+            }
             const k = useSpeckWarsStore.getState().kills
             const milestones: Record<number, { message: string; color: string }> = {
               10:  { message: '💀 10 KILLS',  color: '#4af7c4' },

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -45,6 +45,10 @@ export class GameInstance {
     for (const event of this.sim.events) {
       if (event.type === 'GAME_OVER') {
         useSpeckWarsStore.getState().setPhase('victory')
+        useSpeckWarsStore.getState().setWinnerId(event.winnerId)
+      }
+      if (event.type === 'HUD_UPDATE') {
+        useSpeckWarsStore.getState().setHud(event.data)
       }
     }
 

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -85,6 +85,12 @@ export class GameInstance {
       () => { this.advance(); this.notify('→ ADVANCE', '#ffd700') },  // A — advance to nearest non-player outpost
       () => { this.rush(); this.notify('⚡ RUSH!', '#ff4f7b') },      // B — rush enemy base
     )
+    useSpeckWarsStore.getState().setGameActions({
+      defend: () => { this.defend(); this.notify('🛡 DEFEND', '#4af7c4') },
+      advance: () => { this.advance(); this.notify('→ ADVANCE', '#ffd700') },
+      rush: () => { this.rush(); this.notify('⚡ RUSH!', '#ff4f7b') },
+      clearRally: () => this.clearRally(),
+    })
     this.lastTime = performance.now()
     this.loop(this.lastTime)
 
@@ -319,6 +325,7 @@ export class GameInstance {
     document.removeEventListener('visibilitychange', this.onVisibilityChange)
     this.renderer.destroy()
     this.inputHandler?.destroy()
+    useSpeckWarsStore.getState().setGameActions(null)
     console.log('GameInstance destroyed')
   }
 

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -1,29 +1,47 @@
+import { createSim } from './domain/simulation/create-sim'
+import { tick } from './domain/simulation/tick'
+import type { SimulationState } from './domain/types'
+import { useSpeckWarsStore } from './store'
+
 export class GameInstance {
   private canvas: HTMLCanvasElement
+  private sim: SimulationState
   private rafId: number | null = null
-  private tickCount = 0
+  private lastTime: number = 0
 
   constructor(canvas: HTMLCanvasElement) {
     this.canvas = canvas
+    this.sim = createSim()
   }
 
   start() {
     console.log('GameInstance started')
-    const loop = () => {
-      this.tickCount++
-      if (this.tickCount % 60 === 0) {
-        console.log(`GameInstance tick: ${this.tickCount}`)
+    this.lastTime = performance.now()
+    this.loop(this.lastTime)
+  }
+
+  private loop = (now: number) => {
+    const dt = Math.min(now - this.lastTime, 50)  // cap at 50ms to avoid spiral-of-death
+    this.lastTime = now
+
+    this.sim = tick(this.sim, dt)
+
+    // Forward sim events to Zustand store
+    for (const event of this.sim.events) {
+      if (event.type === 'GAME_OVER') {
+        useSpeckWarsStore.getState().setPhase('victory')
       }
-      this.rafId = requestAnimationFrame(loop)
     }
-    this.rafId = requestAnimationFrame(loop)
+
+    this.rafId = requestAnimationFrame(this.loop)
   }
 
   destroy() {
-    if (this.rafId !== null) {
-      cancelAnimationFrame(this.rafId)
-      this.rafId = null
-    }
+    if (this.rafId !== null) cancelAnimationFrame(this.rafId)
     console.log('GameInstance destroyed')
+  }
+
+  getSim(): SimulationState {
+    return this.sim
   }
 }

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -24,6 +24,7 @@ export class GameInstance {
   private shakeMs = 0
   private shakeMaxMs = 300
   private shakeStrength = 0
+  private enemyBaseWarnedAt = -30000
 
   constructor(canvas: HTMLCanvasElement) {
     this.canvas = canvas
@@ -166,6 +167,17 @@ export class GameInstance {
               color: playerGotIt ? '#4af7c4' : '#ff4f7b',
             })
             setTimeout(() => useSpeckWarsStore.getState().setNotification(null), 1800)
+          }
+        }
+        if (event.type === 'BUILDING_DAMAGED' && event.buildingId === 'building-ai-base') {
+          const aiBase = this.sim.buildings['building-ai-base']
+          if (aiBase && event.hp / aiBase.maxHp < 0.2) {
+            const now = Date.now()
+            if (now - this.enemyBaseWarnedAt > 15000) {
+              this.enemyBaseWarnedAt = now
+              store.setNotification({ message: '⚔ ENEMY BASE CRITICAL!', color: '#ffd700' })
+              setTimeout(() => useSpeckWarsStore.getState().setNotification(null), 3000)
+            }
           }
         }
         if (event.type === 'BUILDING_DAMAGED' && event.buildingId === 'building-player-base') {

--- a/src/app/speck-wars/input/input-handler.ts
+++ b/src/app/speck-wars/input/input-handler.ts
@@ -10,6 +10,7 @@ export class InputHandler {
   private onCycleSpawnMode?: () => void
   private onRecenterCamera?: () => void
   private onDefend?: () => void
+  private onAdvance?: () => void
   private isDragging = false
   private lastX = 0
   private lastY = 0
@@ -28,6 +29,7 @@ export class InputHandler {
     onCycleSpawnMode?: () => void,
     onRecenterCamera?: () => void,
     onDefend?: () => void,
+    onAdvance?: () => void,
   ) {
     this.canvas = canvas
     this.camera = camera
@@ -37,6 +39,7 @@ export class InputHandler {
     this.onCycleSpawnMode = onCycleSpawnMode
     this.onRecenterCamera = onRecenterCamera
     this.onDefend = onDefend
+    this.onAdvance = onAdvance
     this.attach()
   }
 
@@ -157,6 +160,8 @@ export class InputHandler {
       this.onRecenterCamera?.()
     } else if (e.code === 'KeyD') {
       this.onDefend?.()
+    } else if (e.code === 'KeyA') {
+      this.onAdvance?.()
     }
   }
 

--- a/src/app/speck-wars/input/input-handler.ts
+++ b/src/app/speck-wars/input/input-handler.ts
@@ -5,16 +5,26 @@ export class InputHandler {
   private canvas: HTMLCanvasElement
   private camera: Camera
   private onRally?: (worldX: number, worldY: number) => void
+  private onTogglePause?: () => void
+  private onClearRally?: () => void
   private isDragging = false
   private lastX = 0
   private lastY = 0
   private mouseDownX = 0
   private mouseDownY = 0
 
-  constructor(canvas: HTMLCanvasElement, camera: Camera, onRally?: (worldX: number, worldY: number) => void) {
+  constructor(
+    canvas: HTMLCanvasElement,
+    camera: Camera,
+    onRally?: (worldX: number, worldY: number) => void,
+    onTogglePause?: () => void,
+    onClearRally?: () => void,
+  ) {
     this.canvas = canvas
     this.camera = camera
     this.onRally = onRally
+    this.onTogglePause = onTogglePause
+    this.onClearRally = onClearRally
     this.attach()
   }
 
@@ -27,6 +37,7 @@ export class InputHandler {
     this.canvas.addEventListener('touchstart', this.onTouchStart, { passive: true })
     window.addEventListener('touchmove', this.onTouchMove, { passive: false })
     window.addEventListener('touchend', this.onTouchEnd)
+    window.addEventListener('keydown', this.onKeyDown)
   }
 
   private onMouseDown = (e: MouseEvent) => {
@@ -89,6 +100,17 @@ export class InputHandler {
 
   private onTouchEnd = () => { this.isDragging = false }
 
+  private onKeyDown = (e: KeyboardEvent) => {
+    // Don't fire when typing in an input
+    if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) return
+    if (e.code === 'Space') {
+      e.preventDefault()
+      this.onTogglePause?.()
+    } else if (e.code === 'KeyR') {
+      this.onClearRally?.()
+    }
+  }
+
   destroy() {
     this.canvas.removeEventListener('mousedown', this.onMouseDown)
     window.removeEventListener('mousemove', this.onMouseMove)
@@ -97,5 +119,6 @@ export class InputHandler {
     this.canvas.removeEventListener('touchstart', this.onTouchStart)
     window.removeEventListener('touchmove', this.onTouchMove)
     window.removeEventListener('touchend', this.onTouchEnd)
+    window.removeEventListener('keydown', this.onKeyDown)
   }
 }

--- a/src/app/speck-wars/input/input-handler.ts
+++ b/src/app/speck-wars/input/input-handler.ts
@@ -12,6 +12,8 @@ export class InputHandler {
   private lastY = 0
   private mouseDownX = 0
   private mouseDownY = 0
+  private mouseX = -1  // -1 means mouse not over canvas
+  private mouseY = -1
 
   constructor(
     canvas: HTMLCanvasElement,
@@ -38,7 +40,17 @@ export class InputHandler {
     window.addEventListener('touchmove', this.onTouchMove, { passive: false })
     window.addEventListener('touchend', this.onTouchEnd)
     window.addEventListener('keydown', this.onKeyDown)
+    this.canvas.addEventListener('mousemove', this.onCanvasMouseMove)
+    this.canvas.addEventListener('mouseleave', this.onMouseLeave)
   }
+
+  private onCanvasMouseMove = (e: MouseEvent) => {
+    const rect = this.canvas.getBoundingClientRect()
+    this.mouseX = e.clientX - rect.left
+    this.mouseY = e.clientY - rect.top
+  }
+
+  private onMouseLeave = () => { this.mouseX = -1; this.mouseY = -1 }
 
   private onMouseDown = (e: MouseEvent) => {
     this.isDragging = true
@@ -120,5 +132,31 @@ export class InputHandler {
     window.removeEventListener('touchmove', this.onTouchMove)
     window.removeEventListener('touchend', this.onTouchEnd)
     window.removeEventListener('keydown', this.onKeyDown)
+    this.canvas.removeEventListener('mousemove', this.onCanvasMouseMove)
+    this.canvas.removeEventListener('mouseleave', this.onMouseLeave)
+  }
+
+  getEdgePanDelta(dt: number, paused: boolean): { dx: number; dy: number } {
+    if (paused || this.mouseX < 0) return { dx: 0, dy: 0 }
+    const EDGE_ZONE = 40
+    const MAX_SPEED = 400  // px/sec in world space (before zoom)
+    const dtSec = dt / 1000
+    const w = this.canvas.clientWidth
+    const h = this.canvas.clientHeight
+
+    let dx = 0, dy = 0
+
+    if (this.mouseX < EDGE_ZONE) {
+      dx = -(1 - this.mouseX / EDGE_ZONE) * MAX_SPEED * dtSec
+    } else if (this.mouseX > w - EDGE_ZONE) {
+      dx = (1 - (w - this.mouseX) / EDGE_ZONE) * MAX_SPEED * dtSec
+    }
+    if (this.mouseY < EDGE_ZONE) {
+      dy = -(1 - this.mouseY / EDGE_ZONE) * MAX_SPEED * dtSec
+    } else if (this.mouseY > h - EDGE_ZONE) {
+      dy = (1 - (h - this.mouseY) / EDGE_ZONE) * MAX_SPEED * dtSec
+    }
+
+    return { dx, dy }
   }
 }

--- a/src/app/speck-wars/input/input-handler.ts
+++ b/src/app/speck-wars/input/input-handler.ts
@@ -1,0 +1,77 @@
+import type { Camera } from '../rendering/camera'
+import { zoomAt } from '../rendering/camera'
+
+export class InputHandler {
+  private canvas: HTMLCanvasElement
+  private camera: Camera
+  private isDragging = false
+  private lastX = 0
+  private lastY = 0
+
+  constructor(canvas: HTMLCanvasElement, camera: Camera) {
+    this.canvas = canvas
+    this.camera = camera
+    this.attach()
+  }
+
+  private attach() {
+    this.canvas.addEventListener('mousedown', this.onMouseDown)
+    window.addEventListener('mousemove', this.onMouseMove)
+    window.addEventListener('mouseup', this.onMouseUp)
+    this.canvas.addEventListener('wheel', this.onWheel, { passive: false })
+    // Touch support
+    this.canvas.addEventListener('touchstart', this.onTouchStart, { passive: true })
+    window.addEventListener('touchmove', this.onTouchMove, { passive: false })
+    window.addEventListener('touchend', this.onTouchEnd)
+  }
+
+  private onMouseDown = (e: MouseEvent) => {
+    this.isDragging = true
+    this.lastX = e.clientX
+    this.lastY = e.clientY
+  }
+  private onMouseMove = (e: MouseEvent) => {
+    if (!this.isDragging) return
+    this.camera.x += e.clientX - this.lastX
+    this.camera.y += e.clientY - this.lastY
+    this.lastX = e.clientX
+    this.lastY = e.clientY
+  }
+  private onMouseUp = () => { this.isDragging = false }
+
+  private onWheel = (e: WheelEvent) => {
+    e.preventDefault()
+    const factor = e.deltaY < 0 ? 1.1 : 0.9
+    const rect = this.canvas.getBoundingClientRect()
+    const sx = e.clientX - rect.left
+    const sy = e.clientY - rect.top
+    Object.assign(this.camera, zoomAt(this.camera, sx, sy, factor))
+  }
+
+  private onTouchStart = (e: TouchEvent) => {
+    if (e.touches.length === 1) {
+      this.isDragging = true
+      this.lastX = e.touches[0].clientX
+      this.lastY = e.touches[0].clientY
+    }
+  }
+  private onTouchMove = (e: TouchEvent) => {
+    if (!this.isDragging || e.touches.length !== 1) return
+    e.preventDefault()
+    this.camera.x += e.touches[0].clientX - this.lastX
+    this.camera.y += e.touches[0].clientY - this.lastY
+    this.lastX = e.touches[0].clientX
+    this.lastY = e.touches[0].clientY
+  }
+  private onTouchEnd = () => { this.isDragging = false }
+
+  destroy() {
+    this.canvas.removeEventListener('mousedown', this.onMouseDown)
+    window.removeEventListener('mousemove', this.onMouseMove)
+    window.removeEventListener('mouseup', this.onMouseUp)
+    this.canvas.removeEventListener('wheel', this.onWheel)
+    this.canvas.removeEventListener('touchstart', this.onTouchStart)
+    window.removeEventListener('touchmove', this.onTouchMove)
+    window.removeEventListener('touchend', this.onTouchEnd)
+  }
+}

--- a/src/app/speck-wars/input/input-handler.ts
+++ b/src/app/speck-wars/input/input-handler.ts
@@ -69,6 +69,7 @@ export class InputHandler {
   private onMouseLeave = () => { this.mouseX = -1; this.mouseY = -1 }
 
   private onMouseDown = (e: MouseEvent) => {
+    if (e.button === 1) e.preventDefault()  // prevent middle-click scroll
     this.isDragging = true
     this.lastX = e.clientX
     this.lastY = e.clientY
@@ -88,6 +89,13 @@ export class InputHandler {
     const dx = e.clientX - this.mouseDownX
     const dy = e.clientY - this.mouseDownY
     const dist = Math.sqrt(dx * dx + dy * dy)
+
+    // Middle-click: clear rally
+    if (e.button === 1 && dist < 5) {
+      this.onClearRally?.()
+      this.isDragging = false
+      return
+    }
 
     if (dist < 5 && this.onRally) {
       const rect = this.canvas.getBoundingClientRect()

--- a/src/app/speck-wars/input/input-handler.ts
+++ b/src/app/speck-wars/input/input-handler.ts
@@ -17,6 +17,7 @@ export class InputHandler {
   private mouseDownY = 0
   private mouseX = -1  // -1 means mouse not over canvas
   private mouseY = -1
+  private lastPinchDist = 0  // 0 = not pinching
 
   constructor(
     canvas: HTMLCanvasElement,
@@ -105,21 +106,42 @@ export class InputHandler {
   private onTouchStart = (e: TouchEvent) => {
     if (e.touches.length === 1) {
       this.isDragging = true
+      this.lastPinchDist = 0
+      this.lastX = e.touches[0].clientX
+      this.lastY = e.touches[0].clientY
+    } else if (e.touches.length === 2) {
+      this.isDragging = false
+      const dx = e.touches[1].clientX - e.touches[0].clientX
+      const dy = e.touches[1].clientY - e.touches[0].clientY
+      this.lastPinchDist = Math.sqrt(dx * dx + dy * dy)
+    }
+  }
+
+  private onTouchMove = (e: TouchEvent) => {
+    e.preventDefault()
+    if (e.touches.length === 2 && this.lastPinchDist > 0) {
+      // Pinch-to-zoom: compute new distance and zoom toward pinch midpoint
+      const dx = e.touches[1].clientX - e.touches[0].clientX
+      const dy = e.touches[1].clientY - e.touches[0].clientY
+      const newDist = Math.sqrt(dx * dx + dy * dy)
+      const factor = newDist / this.lastPinchDist
+      const rect = this.canvas.getBoundingClientRect()
+      const mx = ((e.touches[0].clientX + e.touches[1].clientX) / 2) - rect.left
+      const my = ((e.touches[0].clientY + e.touches[1].clientY) / 2) - rect.top
+      Object.assign(this.camera, zoomAt(this.camera, mx, my, factor))
+      this.lastPinchDist = newDist
+    } else if (this.isDragging && e.touches.length === 1) {
+      this.camera.x += e.touches[0].clientX - this.lastX
+      this.camera.y += e.touches[0].clientY - this.lastY
       this.lastX = e.touches[0].clientX
       this.lastY = e.touches[0].clientY
     }
   }
 
-  private onTouchMove = (e: TouchEvent) => {
-    if (!this.isDragging || e.touches.length !== 1) return
-    e.preventDefault()
-    this.camera.x += e.touches[0].clientX - this.lastX
-    this.camera.y += e.touches[0].clientY - this.lastY
-    this.lastX = e.touches[0].clientX
-    this.lastY = e.touches[0].clientY
+  private onTouchEnd = () => {
+    this.isDragging = false
+    this.lastPinchDist = 0
   }
-
-  private onTouchEnd = () => { this.isDragging = false }
 
   private onKeyDown = (e: KeyboardEvent) => {
     // Don't fire when typing in an input

--- a/src/app/speck-wars/input/input-handler.ts
+++ b/src/app/speck-wars/input/input-handler.ts
@@ -7,6 +7,7 @@ export class InputHandler {
   private onRally?: (worldX: number, worldY: number) => void
   private onTogglePause?: () => void
   private onClearRally?: () => void
+  private onCycleSpawnMode?: () => void
   private isDragging = false
   private lastX = 0
   private lastY = 0
@@ -21,12 +22,14 @@ export class InputHandler {
     onRally?: (worldX: number, worldY: number) => void,
     onTogglePause?: () => void,
     onClearRally?: () => void,
+    onCycleSpawnMode?: () => void,
   ) {
     this.canvas = canvas
     this.camera = camera
     this.onRally = onRally
     this.onTogglePause = onTogglePause
     this.onClearRally = onClearRally
+    this.onCycleSpawnMode = onCycleSpawnMode
     this.attach()
   }
 
@@ -120,6 +123,8 @@ export class InputHandler {
       this.onTogglePause?.()
     } else if (e.code === 'KeyR') {
       this.onClearRally?.()
+    } else if (e.code === 'KeyH') {
+      this.onCycleSpawnMode?.()
     }
   }
 

--- a/src/app/speck-wars/input/input-handler.ts
+++ b/src/app/speck-wars/input/input-handler.ts
@@ -1,16 +1,20 @@
 import type { Camera } from '../rendering/camera'
-import { zoomAt } from '../rendering/camera'
+import { zoomAt, screenToWorld } from '../rendering/camera'
 
 export class InputHandler {
   private canvas: HTMLCanvasElement
   private camera: Camera
+  private onRally?: (worldX: number, worldY: number) => void
   private isDragging = false
   private lastX = 0
   private lastY = 0
+  private mouseDownX = 0
+  private mouseDownY = 0
 
-  constructor(canvas: HTMLCanvasElement, camera: Camera) {
+  constructor(canvas: HTMLCanvasElement, camera: Camera, onRally?: (worldX: number, worldY: number) => void) {
     this.canvas = canvas
     this.camera = camera
+    this.onRally = onRally
     this.attach()
   }
 
@@ -29,7 +33,10 @@ export class InputHandler {
     this.isDragging = true
     this.lastX = e.clientX
     this.lastY = e.clientY
+    this.mouseDownX = e.clientX
+    this.mouseDownY = e.clientY
   }
+
   private onMouseMove = (e: MouseEvent) => {
     if (!this.isDragging) return
     this.camera.x += e.clientX - this.lastX
@@ -37,7 +44,22 @@ export class InputHandler {
     this.lastX = e.clientX
     this.lastY = e.clientY
   }
-  private onMouseUp = () => { this.isDragging = false }
+
+  private onMouseUp = (e: MouseEvent) => {
+    const dx = e.clientX - this.mouseDownX
+    const dy = e.clientY - this.mouseDownY
+    const dist = Math.sqrt(dx * dx + dy * dy)
+
+    if (dist < 5 && this.onRally) {
+      const rect = this.canvas.getBoundingClientRect()
+      const sx = e.clientX - rect.left
+      const sy = e.clientY - rect.top
+      const world = screenToWorld(sx, sy, this.camera)
+      this.onRally(world.x, world.y)
+    }
+
+    this.isDragging = false
+  }
 
   private onWheel = (e: WheelEvent) => {
     e.preventDefault()
@@ -55,6 +77,7 @@ export class InputHandler {
       this.lastY = e.touches[0].clientY
     }
   }
+
   private onTouchMove = (e: TouchEvent) => {
     if (!this.isDragging || e.touches.length !== 1) return
     e.preventDefault()
@@ -63,6 +86,7 @@ export class InputHandler {
     this.lastX = e.touches[0].clientX
     this.lastY = e.touches[0].clientY
   }
+
   private onTouchEnd = () => { this.isDragging = false }
 
   destroy() {

--- a/src/app/speck-wars/input/input-handler.ts
+++ b/src/app/speck-wars/input/input-handler.ts
@@ -9,6 +9,7 @@ export class InputHandler {
   private onClearRally?: () => void
   private onCycleSpawnMode?: () => void
   private onRecenterCamera?: () => void
+  private onDefend?: () => void
   private isDragging = false
   private lastX = 0
   private lastY = 0
@@ -25,6 +26,7 @@ export class InputHandler {
     onClearRally?: () => void,
     onCycleSpawnMode?: () => void,
     onRecenterCamera?: () => void,
+    onDefend?: () => void,
   ) {
     this.canvas = canvas
     this.camera = camera
@@ -33,6 +35,7 @@ export class InputHandler {
     this.onClearRally = onClearRally
     this.onCycleSpawnMode = onCycleSpawnMode
     this.onRecenterCamera = onRecenterCamera
+    this.onDefend = onDefend
     this.attach()
   }
 
@@ -130,6 +133,8 @@ export class InputHandler {
       this.onCycleSpawnMode?.()
     } else if (e.code === 'KeyC') {
       this.onRecenterCamera?.()
+    } else if (e.code === 'KeyD') {
+      this.onDefend?.()
     }
   }
 

--- a/src/app/speck-wars/input/input-handler.ts
+++ b/src/app/speck-wars/input/input-handler.ts
@@ -11,6 +11,7 @@ export class InputHandler {
   private onRecenterCamera?: () => void
   private onDefend?: () => void
   private onAdvance?: () => void
+  private onRush?: () => void
   private isDragging = false
   private lastX = 0
   private lastY = 0
@@ -30,6 +31,7 @@ export class InputHandler {
     onRecenterCamera?: () => void,
     onDefend?: () => void,
     onAdvance?: () => void,
+    onRush?: () => void,
   ) {
     this.canvas = canvas
     this.camera = camera
@@ -40,6 +42,7 @@ export class InputHandler {
     this.onRecenterCamera = onRecenterCamera
     this.onDefend = onDefend
     this.onAdvance = onAdvance
+    this.onRush = onRush
     this.attach()
   }
 
@@ -162,6 +165,8 @@ export class InputHandler {
       this.onDefend?.()
     } else if (e.code === 'KeyA') {
       this.onAdvance?.()
+    } else if (e.code === 'KeyB') {
+      this.onRush?.()
     }
   }
 

--- a/src/app/speck-wars/input/input-handler.ts
+++ b/src/app/speck-wars/input/input-handler.ts
@@ -8,6 +8,7 @@ export class InputHandler {
   private onTogglePause?: () => void
   private onClearRally?: () => void
   private onCycleSpawnMode?: () => void
+  private onRecenterCamera?: () => void
   private isDragging = false
   private lastX = 0
   private lastY = 0
@@ -23,6 +24,7 @@ export class InputHandler {
     onTogglePause?: () => void,
     onClearRally?: () => void,
     onCycleSpawnMode?: () => void,
+    onRecenterCamera?: () => void,
   ) {
     this.canvas = canvas
     this.camera = camera
@@ -30,6 +32,7 @@ export class InputHandler {
     this.onTogglePause = onTogglePause
     this.onClearRally = onClearRally
     this.onCycleSpawnMode = onCycleSpawnMode
+    this.onRecenterCamera = onRecenterCamera
     this.attach()
   }
 
@@ -125,6 +128,8 @@ export class InputHandler {
       this.onClearRally?.()
     } else if (e.code === 'KeyH') {
       this.onCycleSpawnMode?.()
+    } else if (e.code === 'KeyC') {
+      this.onRecenterCamera?.()
     }
   }
 

--- a/src/app/speck-wars/input/input-handler.ts
+++ b/src/app/speck-wars/input/input-handler.ts
@@ -20,6 +20,8 @@ export class InputHandler {
   private mouseX = -1  // -1 means mouse not over canvas
   private mouseY = -1
   private lastPinchDist = 0  // 0 = not pinching
+  private touchStartX = 0
+  private touchStartY = 0
 
   constructor(
     canvas: HTMLCanvasElement,
@@ -129,6 +131,8 @@ export class InputHandler {
       this.lastPinchDist = 0
       this.lastX = e.touches[0].clientX
       this.lastY = e.touches[0].clientY
+      this.touchStartX = e.touches[0].clientX
+      this.touchStartY = e.touches[0].clientY
     } else if (e.touches.length === 2) {
       this.isDragging = false
       const dx = e.touches[1].clientX - e.touches[0].clientX
@@ -158,7 +162,22 @@ export class InputHandler {
     }
   }
 
-  private onTouchEnd = () => {
+  private onTouchEnd = (e: TouchEvent) => {
+    // Tap-to-rally: single finger tap (small movement) → set rally at tap position
+    if (this.lastPinchDist === 0 && e.changedTouches.length === 1 && this.onRally) {
+      const touch = e.changedTouches[0]
+      const dx = touch.clientX - this.touchStartX
+      const dy = touch.clientY - this.touchStartY
+      if (Math.sqrt(dx * dx + dy * dy) < 12) {
+        const rect = this.canvas.getBoundingClientRect()
+        const sx = touch.clientX - rect.left
+        const sy = touch.clientY - rect.top
+        if (sx >= 0 && sy >= 0 && sx <= rect.width && sy <= rect.height) {
+          const world = screenToWorld(sx, sy, this.camera)
+          this.onRally(world.x, world.y)
+        }
+      }
+    }
     this.isDragging = false
     this.lastPinchDist = 0
   }

--- a/src/app/speck-wars/input/input-handler.ts
+++ b/src/app/speck-wars/input/input-handler.ts
@@ -51,6 +51,7 @@ export class InputHandler {
     window.addEventListener('mousemove', this.onMouseMove)
     window.addEventListener('mouseup', this.onMouseUp)
     this.canvas.addEventListener('wheel', this.onWheel, { passive: false })
+    this.canvas.addEventListener('contextmenu', this.onContextMenu)
     // Touch support
     this.canvas.addEventListener('touchstart', this.onTouchStart, { passive: true })
     window.addEventListener('touchmove', this.onTouchMove, { passive: false })
@@ -67,6 +68,11 @@ export class InputHandler {
   }
 
   private onMouseLeave = () => { this.mouseX = -1; this.mouseY = -1 }
+
+  private onContextMenu = (e: MouseEvent) => {
+    e.preventDefault()   // suppress browser context menu
+    this.onClearRally?.()
+  }
 
   private onMouseDown = (e: MouseEvent) => {
     if (e.button === 1) e.preventDefault()  // prevent middle-click scroll
@@ -97,7 +103,7 @@ export class InputHandler {
       return
     }
 
-    if (dist < 5 && this.onRally) {
+    if (e.button === 0 && dist < 5 && this.onRally) {
       const rect = this.canvas.getBoundingClientRect()
       const sx = e.clientX - rect.left
       const sy = e.clientY - rect.top
@@ -183,6 +189,7 @@ export class InputHandler {
     window.removeEventListener('mousemove', this.onMouseMove)
     window.removeEventListener('mouseup', this.onMouseUp)
     this.canvas.removeEventListener('wheel', this.onWheel)
+    this.canvas.removeEventListener('contextmenu', this.onContextMenu)
     this.canvas.removeEventListener('touchstart', this.onTouchStart)
     window.removeEventListener('touchmove', this.onTouchMove)
     window.removeEventListener('touchend', this.onTouchEnd)

--- a/src/app/speck-wars/lib/personal-best.ts
+++ b/src/app/speck-wars/lib/personal-best.ts
@@ -69,3 +69,21 @@ export function markFirstGameDone() {
   if (typeof window === 'undefined') return
   localStorage.setItem(FIRST_GAME_KEY, '1')
 }
+
+// Daily win tracking: store the date (YYYYMMDD) when a player wins each difficulty
+const DAILY_WIN_KEY = (d: Difficulty) => `speck-wars-daily-win-${d}`
+
+function todayKey(): string {
+  const now = new Date()
+  return `${now.getFullYear()}${String(now.getMonth() + 1).padStart(2, '0')}${String(now.getDate()).padStart(2, '0')}`
+}
+
+export function hasWonToday(difficulty: Difficulty): boolean {
+  if (typeof window === 'undefined') return false
+  return localStorage.getItem(DAILY_WIN_KEY(difficulty)) === todayKey()
+}
+
+export function markWonToday(difficulty: Difficulty) {
+  if (typeof window === 'undefined') return
+  localStorage.setItem(DAILY_WIN_KEY(difficulty), todayKey())
+}

--- a/src/app/speck-wars/lib/personal-best.ts
+++ b/src/app/speck-wars/lib/personal-best.ts
@@ -36,3 +36,15 @@ export function resetWinStreak() {
   if (typeof window === 'undefined') return
   localStorage.setItem(STREAK_KEY, '0')
 }
+
+const FIRST_GAME_KEY = 'speck-wars-first-game-done'
+
+export function isFirstGame(): boolean {
+  if (typeof window === 'undefined') return false
+  return !localStorage.getItem(FIRST_GAME_KEY)
+}
+
+export function markFirstGameDone() {
+  if (typeof window === 'undefined') return
+  localStorage.setItem(FIRST_GAME_KEY, '1')
+}

--- a/src/app/speck-wars/lib/personal-best.ts
+++ b/src/app/speck-wars/lib/personal-best.ts
@@ -1,6 +1,7 @@
 import type { Difficulty } from '../store'
 
 const KEY = (d: Difficulty) => `speck-wars-best-${d}`
+const STREAK_KEY = 'speck-wars-win-streak'
 
 export function getBestTime(difficulty: Difficulty): number | null {
   if (typeof window === 'undefined') return null
@@ -17,4 +18,21 @@ export function recordBestTime(difficulty: Difficulty, ms: number): boolean {
     return true
   }
   return false
+}
+
+export function getWinStreak(): number {
+  if (typeof window === 'undefined') return 0
+  return Number(localStorage.getItem(STREAK_KEY) ?? '0') || 0
+}
+
+export function incrementWinStreak(): number {
+  if (typeof window === 'undefined') return 0
+  const next = getWinStreak() + 1
+  localStorage.setItem(STREAK_KEY, String(next))
+  return next
+}
+
+export function resetWinStreak() {
+  if (typeof window === 'undefined') return
+  localStorage.setItem(STREAK_KEY, '0')
 }

--- a/src/app/speck-wars/lib/personal-best.ts
+++ b/src/app/speck-wars/lib/personal-best.ts
@@ -1,0 +1,20 @@
+import type { Difficulty } from '../store'
+
+const KEY = (d: Difficulty) => `speck-wars-best-${d}`
+
+export function getBestTime(difficulty: Difficulty): number | null {
+  if (typeof window === 'undefined') return null
+  const val = localStorage.getItem(KEY(difficulty))
+  const n = val ? Number(val) : NaN
+  return isNaN(n) ? null : n
+}
+
+export function recordBestTime(difficulty: Difficulty, ms: number): boolean {
+  if (typeof window === 'undefined') return false
+  const prev = getBestTime(difficulty)
+  if (prev === null || ms < prev) {
+    localStorage.setItem(KEY(difficulty), String(ms))
+    return true
+  }
+  return false
+}

--- a/src/app/speck-wars/lib/personal-best.ts
+++ b/src/app/speck-wars/lib/personal-best.ts
@@ -37,6 +37,27 @@ export function resetWinStreak() {
   localStorage.setItem(STREAK_KEY, '0')
 }
 
+interface GameResult { won: boolean; timeMs: number; kills: number }
+const HISTORY_KEY = (d: Difficulty) => `speck-wars-history-${d}`
+const HISTORY_LIMIT = 5
+
+export function recordGameResult(difficulty: Difficulty, won: boolean, timeMs: number, kills: number) {
+  if (typeof window === 'undefined') return
+  const prev = getRecentResults(difficulty)
+  const next: GameResult[] = [{ won, timeMs, kills }, ...prev].slice(0, HISTORY_LIMIT)
+  localStorage.setItem(HISTORY_KEY(difficulty), JSON.stringify(next))
+}
+
+export function getRecentResults(difficulty: Difficulty): GameResult[] {
+  if (typeof window === 'undefined') return []
+  try {
+    const raw = localStorage.getItem(HISTORY_KEY(difficulty))
+    return raw ? (JSON.parse(raw) as GameResult[]) : []
+  } catch {
+    return []
+  }
+}
+
 const FIRST_GAME_KEY = 'speck-wars-first-game-done'
 
 export function isFirstGame(): boolean {

--- a/src/app/speck-wars/rendering/_test11.ts
+++ b/src/app/speck-wars/rendering/_test11.ts
@@ -1,4 +1,0 @@
-import { Application } from 'pixi.js'
-type A = InstanceType<typeof Application>
-type Keys = keyof A
-declare const k: Keys

--- a/src/app/speck-wars/rendering/_test11.ts
+++ b/src/app/speck-wars/rendering/_test11.ts
@@ -1,0 +1,4 @@
+import { Application } from 'pixi.js'
+type A = InstanceType<typeof Application>
+type Keys = keyof A
+declare const k: Keys

--- a/src/app/speck-wars/rendering/camera.ts
+++ b/src/app/speck-wars/rendering/camera.ts
@@ -1,0 +1,41 @@
+import { WORLD_WIDTH, WORLD_HEIGHT } from '../domain/constants'
+
+export interface Camera {
+  x: number      // stage offset x (screen space)
+  y: number      // stage offset y (screen space)
+  zoom: number
+}
+
+export function createCamera(canvasWidth: number, canvasHeight: number): Camera {
+  // Start centered on the world midpoint
+  return {
+    x: canvasWidth / 2 - (WORLD_WIDTH / 2),
+    y: canvasHeight / 2 - (WORLD_HEIGHT / 2),
+    zoom: 1,
+  }
+}
+
+export function screenToWorld(sx: number, sy: number, camera: Camera): { x: number; y: number } {
+  return {
+    x: (sx - camera.x) / camera.zoom,
+    y: (sy - camera.y) / camera.zoom,
+  }
+}
+
+export function worldToScreen(wx: number, wy: number, camera: Camera): { x: number; y: number } {
+  return {
+    x: wx * camera.zoom + camera.x,
+    y: wy * camera.zoom + camera.y,
+  }
+}
+
+// Zoom toward screen point (pinch/scroll zoom)
+export function zoomAt(camera: Camera, screenX: number, screenY: number, factor: number): Camera {
+  const newZoom = Math.max(0.2, Math.min(4, camera.zoom * factor))
+  const scale = newZoom / camera.zoom
+  return {
+    zoom: newZoom,
+    x: screenX - (screenX - camera.x) * scale,
+    y: screenY - (screenY - camera.y) * scale,
+  }
+}

--- a/src/app/speck-wars/rendering/camera.ts
+++ b/src/app/speck-wars/rendering/camera.ts
@@ -39,3 +39,16 @@ export function zoomAt(camera: Camera, screenX: number, screenY: number, factor:
     y: screenY - (screenY - camera.y) * scale,
   }
 }
+
+// Clamp camera so the world doesn't disappear off-screen completely.
+// MARGIN is the minimum world pixels that must remain visible on each side.
+const EDGE_MARGIN = 120  // px
+
+export function clampCamera(camera: Camera, canvasWidth: number, canvasHeight: number): void {
+  const ww = WORLD_WIDTH * camera.zoom
+  const wh = WORLD_HEIGHT * camera.zoom
+  camera.x = Math.min(camera.x, canvasWidth - EDGE_MARGIN)
+  camera.x = Math.max(camera.x, EDGE_MARGIN - ww)
+  camera.y = Math.min(camera.y, canvasHeight - EDGE_MARGIN)
+  camera.y = Math.max(camera.y, EDGE_MARGIN - wh)
+}

--- a/src/app/speck-wars/rendering/layers/building-layer.ts
+++ b/src/app/speck-wars/rendering/layers/building-layer.ts
@@ -1,6 +1,7 @@
 import { Graphics, Container } from 'pixi.js'
 import type { SimulationState } from '../../domain/types'
 import { BUILDING_TYPES } from '../../domain/config/building-types'
+import { NEUTRAL_COLOR } from '../../domain/constants'
 
 export class BuildingLayer {
   readonly stage: Container
@@ -17,7 +18,7 @@ export class BuildingLayer {
 
     for (const building of Object.values(sim.buildings)) {
       const btype = BUILDING_TYPES[building.typeId]
-      const color = playerColors[building.ownerId] ?? 0xffffff
+      const color = building.ownerId === 'neutral' ? NEUTRAL_COLOR : (playerColors[building.ownerId] ?? 0xffffff)
       const r = btype?.size ?? 20
 
       // Base circle
@@ -50,6 +51,17 @@ export class BuildingLayer {
       this.gfx.beginFill(hpFrac > 0.5 ? 0x44ff88 : 0xff4444)
       this.gfx.drawRect(barX, barY, barW * hpFrac, barH)
       this.gfx.endFill()
+
+      // Capture progress ring
+      if (building.captureProgress && building.captureProgress > 0 && building.captureSide) {
+        const capColor = playerColors[building.captureSide] ?? 0xffffff
+        this.gfx.lineStyle(3, capColor, 0.9)
+        const startAngle = -Math.PI / 2
+        const endAngle = startAngle + Math.PI * 2 * building.captureProgress
+        this.gfx.moveTo(building.x + (r + 12) * Math.cos(startAngle), building.y + (r + 12) * Math.sin(startAngle))
+        this.gfx.arc(building.x, building.y, r + 12, startAngle, endAngle)
+        this.gfx.lineStyle(0)
+      }
     }
   }
 

--- a/src/app/speck-wars/rendering/layers/building-layer.ts
+++ b/src/app/speck-wars/rendering/layers/building-layer.ts
@@ -3,9 +3,12 @@ import type { SimulationState } from '../../domain/types'
 import { BUILDING_TYPES } from '../../domain/config/building-types'
 import { NEUTRAL_COLOR, OUTPOST_AURA_RADIUS } from '../../domain/constants'
 
+const FLASH_DURATION = 200  // ms — how long a damage flash lasts
+
 export class BuildingLayer {
   readonly stage: Container
   private gfx: Graphics
+  private flashMap: Map<string, number> = new Map()  // buildingId → timestamp of last hit
 
   constructor() {
     this.stage = new Container()
@@ -13,7 +16,12 @@ export class BuildingLayer {
     this.stage.addChild(this.gfx)
   }
 
+  flashBuilding(buildingId: string) {
+    this.flashMap.set(buildingId, Date.now())
+  }
+
   update(sim: SimulationState, playerColors: Record<string, number>) {
+    const now = Date.now()
     this.gfx.clear()
 
     for (const building of Object.values(sim.buildings)) {
@@ -25,6 +33,20 @@ export class BuildingLayer {
       this.gfx.beginFill(color, 0.9)
       this.gfx.drawCircle(building.x, building.y, r)
       this.gfx.endFill()
+
+      // Damage flash overlay
+      const flashTs = this.flashMap.get(building.id)
+      if (flashTs !== undefined) {
+        const elapsed = now - flashTs
+        if (elapsed < FLASH_DURATION) {
+          const alpha = (1 - elapsed / FLASH_DURATION) * 0.7
+          this.gfx.beginFill(0xff2222, alpha)
+          this.gfx.drawCircle(building.x, building.y, r)
+          this.gfx.endFill()
+        } else {
+          this.flashMap.delete(building.id)
+        }
+      }
 
       // Stroke
       this.gfx.lineStyle(2, 0xffffff, 0.4)

--- a/src/app/speck-wars/rendering/layers/building-layer.ts
+++ b/src/app/speck-wars/rendering/layers/building-layer.ts
@@ -3,6 +3,15 @@ import type { SimulationState } from '../../domain/types'
 import { BUILDING_TYPES } from '../../domain/config/building-types'
 import { NEUTRAL_COLOR, OUTPOST_AURA_RADIUS } from '../../domain/constants'
 
+function hexPoints(x: number, y: number, r: number): number[] {
+  const pts: number[] = []
+  for (let i = 0; i < 6; i++) {
+    const a = (i * Math.PI) / 3
+    pts.push(x + r * Math.cos(a), y + r * Math.sin(a))
+  }
+  return pts
+}
+
 const FLASH_DURATION = 200   // ms — how long a damage flash lasts
 const SPAWN_FLASH_DURATION = 250  // ms — brief golden ring when a speck spawns
 
@@ -35,9 +44,15 @@ export class BuildingLayer {
       const color = building.ownerId === 'neutral' ? NEUTRAL_COLOR : (playerColors[building.ownerId] ?? 0xffffff)
       const r = btype?.size ?? 20
 
-      // Base circle
+      const isOutpost = building.typeId === 'outpost'
+
+      // Base shape: hexagon for outposts, circle for bases
       this.gfx.beginFill(color, 0.9)
-      this.gfx.drawCircle(building.x, building.y, r)
+      if (isOutpost) {
+        this.gfx.drawPolygon(hexPoints(building.x, building.y, r))
+      } else {
+        this.gfx.drawCircle(building.x, building.y, r)
+      }
       this.gfx.endFill()
 
       // Damage flash overlay
@@ -47,7 +62,11 @@ export class BuildingLayer {
         if (elapsed < FLASH_DURATION) {
           const alpha = (1 - elapsed / FLASH_DURATION) * 0.7
           this.gfx.beginFill(0xff2222, alpha)
-          this.gfx.drawCircle(building.x, building.y, r)
+          if (isOutpost) {
+            this.gfx.drawPolygon(hexPoints(building.x, building.y, r))
+          } else {
+            this.gfx.drawCircle(building.x, building.y, r)
+          }
           this.gfx.endFill()
         } else {
           this.flashMap.delete(building.id)
@@ -72,7 +91,11 @@ export class BuildingLayer {
 
       // Stroke
       this.gfx.lineStyle(2, 0xffffff, 0.4)
-      this.gfx.drawCircle(building.x, building.y, r)
+      if (isOutpost) {
+        this.gfx.drawPolygon(hexPoints(building.x, building.y, r))
+      } else {
+        this.gfx.drawCircle(building.x, building.y, r)
+      }
       this.gfx.lineStyle(0)
 
       // Pulse ring

--- a/src/app/speck-wars/rendering/layers/building-layer.ts
+++ b/src/app/speck-wars/rendering/layers/building-layer.ts
@@ -1,7 +1,7 @@
 import { Graphics, Container } from 'pixi.js'
 import type { SimulationState } from '../../domain/types'
 import { BUILDING_TYPES } from '../../domain/config/building-types'
-import { NEUTRAL_COLOR } from '../../domain/constants'
+import { NEUTRAL_COLOR, OUTPOST_AURA_RADIUS } from '../../domain/constants'
 
 export class BuildingLayer {
   readonly stage: Container
@@ -51,6 +51,14 @@ export class BuildingLayer {
       this.gfx.beginFill(hpFrac > 0.5 ? 0x44ff88 : 0xff4444)
       this.gfx.drawRect(barX, barY, barW * hpFrac, barH)
       this.gfx.endFill()
+
+      // Outpost speed aura ring (faint pulsing circle showing boost radius)
+      if (building.typeId === 'outpost' && building.ownerId !== 'neutral') {
+        const auraPulse = Math.sin(Date.now() / 1200) * 0.5 + 0.5
+        this.gfx.lineStyle(1, color, auraPulse * 0.18 + 0.04)
+        this.gfx.drawCircle(building.x, building.y, OUTPOST_AURA_RADIUS)
+        this.gfx.lineStyle(0)
+      }
 
       // Capture progress ring
       if (building.captureProgress && building.captureProgress > 0 && building.captureSide) {

--- a/src/app/speck-wars/rendering/layers/building-layer.ts
+++ b/src/app/speck-wars/rendering/layers/building-layer.ts
@@ -52,6 +52,21 @@ export class BuildingLayer {
       this.gfx.drawRect(barX, barY, barW * hpFrac, barH)
       this.gfx.endFill()
 
+      // Spawn timer progress arc (clockwise fill inside building, shows time to next spawn)
+      if (building.ownerId !== 'neutral' && btype?.spawnInterval) {
+        const totalInterval = building.spawnIntervalOverride ?? btype.spawnInterval
+        const effectiveInterval = building.tripleOutpostBonus ? totalInterval / 2 : totalInterval
+        const progress = Math.max(0, Math.min(1, 1 - building.spawnTimer / effectiveInterval))
+        if (progress > 0) {
+          const startAngle = -Math.PI / 2
+          const endAngle = startAngle + Math.PI * 2 * progress
+          this.gfx.lineStyle(2, 0xffffff, 0.5)
+          this.gfx.moveTo(building.x + (r - 5) * Math.cos(startAngle), building.y + (r - 5) * Math.sin(startAngle))
+          this.gfx.arc(building.x, building.y, r - 5, startAngle, endAngle)
+          this.gfx.lineStyle(0)
+        }
+      }
+
       // Outpost speed aura ring (faint pulsing circle showing boost radius)
       if (building.typeId === 'outpost' && building.ownerId !== 'neutral') {
         const auraPulse = Math.sin(Date.now() / 1200) * 0.5 + 0.5

--- a/src/app/speck-wars/rendering/layers/building-layer.ts
+++ b/src/app/speck-wars/rendering/layers/building-layer.ts
@@ -127,7 +127,8 @@ export class BuildingLayer {
         if (progress > 0) {
           const startAngle = -Math.PI / 2
           const endAngle = startAngle + Math.PI * 2 * progress
-          this.gfx.lineStyle(2, 0xffffff, 0.5)
+          const arcColor = building.spawnTypeOverride === 'heavy' ? 0xffa032 : 0xffffff
+          this.gfx.lineStyle(2, arcColor, 0.5)
           this.gfx.moveTo(building.x + (r - 5) * Math.cos(startAngle), building.y + (r - 5) * Math.sin(startAngle))
           this.gfx.arc(building.x, building.y, r - 5, startAngle, endAngle)
           this.gfx.lineStyle(0)

--- a/src/app/speck-wars/rendering/layers/building-layer.ts
+++ b/src/app/speck-wars/rendering/layers/building-layer.ts
@@ -3,12 +3,14 @@ import type { SimulationState } from '../../domain/types'
 import { BUILDING_TYPES } from '../../domain/config/building-types'
 import { NEUTRAL_COLOR, OUTPOST_AURA_RADIUS } from '../../domain/constants'
 
-const FLASH_DURATION = 200  // ms — how long a damage flash lasts
+const FLASH_DURATION = 200   // ms — how long a damage flash lasts
+const SPAWN_FLASH_DURATION = 250  // ms — brief golden ring when a speck spawns
 
 export class BuildingLayer {
   readonly stage: Container
   private gfx: Graphics
-  private flashMap: Map<string, number> = new Map()  // buildingId → timestamp of last hit
+  private flashMap: Map<string, number> = new Map()       // buildingId → timestamp of last hit
+  private spawnFlashMap: Map<string, number> = new Map()  // buildingId → timestamp of last spawn
 
   constructor() {
     this.stage = new Container()
@@ -18,6 +20,10 @@ export class BuildingLayer {
 
   flashBuilding(buildingId: string) {
     this.flashMap.set(buildingId, Date.now())
+  }
+
+  flashSpawn(buildingId: string) {
+    this.spawnFlashMap.set(buildingId, Date.now())
   }
 
   update(sim: SimulationState, playerColors: Record<string, number>) {
@@ -45,6 +51,22 @@ export class BuildingLayer {
           this.gfx.endFill()
         } else {
           this.flashMap.delete(building.id)
+        }
+      }
+
+      // Spawn flash: brief gold expanding ring when a speck is produced
+      const spawnTs = this.spawnFlashMap.get(building.id)
+      if (spawnTs !== undefined) {
+        const elapsed = now - spawnTs
+        if (elapsed < SPAWN_FLASH_DURATION) {
+          const t = elapsed / SPAWN_FLASH_DURATION
+          const alpha = (1 - t) * 0.6
+          const spawnR = r + 4 + t * 14  // expands from r+4 to r+18
+          this.gfx.lineStyle(1.5, 0xffd700, alpha)
+          this.gfx.drawCircle(building.x, building.y, spawnR)
+          this.gfx.lineStyle(0)
+        } else {
+          this.spawnFlashMap.delete(building.id)
         }
       }
 

--- a/src/app/speck-wars/rendering/layers/building-layer.ts
+++ b/src/app/speck-wars/rendering/layers/building-layer.ts
@@ -104,6 +104,19 @@ export class BuildingLayer {
       this.gfx.drawCircle(building.x, building.y, r + 8)
       this.gfx.lineStyle(0)
 
+      // Critical HP warning ring — pulsing red when building HP is low
+      const hpFracEarly = building.hp / building.maxHp
+      if (hpFracEarly < 0.3) {
+        const isCrit = hpFracEarly < 0.15
+        const speed = isCrit ? 180 : 350
+        const critPulse = 0.5 + 0.5 * Math.sin(now / speed)
+        const baseAlpha = isCrit ? 0.75 : 0.45
+        const width = isCrit ? 2.5 : 1.8
+        this.gfx.lineStyle(width, 0xff2222, critPulse * baseAlpha)
+        this.gfx.drawCircle(building.x, building.y, r + 12)
+        this.gfx.lineStyle(0)
+      }
+
       // HP bar (above building)
       const barW = r * 2
       const barH = 4

--- a/src/app/speck-wars/rendering/layers/building-layer.ts
+++ b/src/app/speck-wars/rendering/layers/building-layer.ts
@@ -30,6 +30,12 @@ export class BuildingLayer {
       this.gfx.drawCircle(building.x, building.y, r)
       this.gfx.lineStyle(0)
 
+      // Pulse ring
+      const pulse = Math.sin(Date.now() / 800) * 0.3 + 0.7
+      this.gfx.lineStyle(2, color, pulse * 0.4)
+      this.gfx.drawCircle(building.x, building.y, r + 8)
+      this.gfx.lineStyle(0)
+
       // HP bar (above building)
       const barW = r * 2
       const barH = 4

--- a/src/app/speck-wars/rendering/layers/building-layer.ts
+++ b/src/app/speck-wars/rendering/layers/building-layer.ts
@@ -1,0 +1,53 @@
+import { Graphics, Container } from 'pixi.js'
+import type { SimulationState } from '../../domain/types'
+import { BUILDING_TYPES } from '../../domain/config/building-types'
+
+export class BuildingLayer {
+  readonly stage: Container
+  private gfx: Graphics
+
+  constructor() {
+    this.stage = new Container()
+    this.gfx = new Graphics()
+    this.stage.addChild(this.gfx)
+  }
+
+  update(sim: SimulationState, playerColors: Record<string, number>) {
+    this.gfx.clear()
+
+    for (const building of Object.values(sim.buildings)) {
+      const btype = BUILDING_TYPES[building.typeId]
+      const color = playerColors[building.ownerId] ?? 0xffffff
+      const r = btype?.size ?? 20
+
+      // Base circle
+      this.gfx.beginFill(color, 0.9)
+      this.gfx.drawCircle(building.x, building.y, r)
+      this.gfx.endFill()
+
+      // Stroke
+      this.gfx.lineStyle(2, 0xffffff, 0.4)
+      this.gfx.drawCircle(building.x, building.y, r)
+      this.gfx.lineStyle(0)
+
+      // HP bar (above building)
+      const barW = r * 2
+      const barH = 4
+      const barX = building.x - r
+      const barY = building.y - r - 10
+      const hpFrac = building.hp / building.maxHp
+
+      this.gfx.beginFill(0x333333)
+      this.gfx.drawRect(barX, barY, barW, barH)
+      this.gfx.endFill()
+
+      this.gfx.beginFill(hpFrac > 0.5 ? 0x44ff88 : 0xff4444)
+      this.gfx.drawRect(barX, barY, barW * hpFrac, barH)
+      this.gfx.endFill()
+    }
+  }
+
+  destroy() {
+    this.stage.destroy({ children: true })
+  }
+}

--- a/src/app/speck-wars/rendering/layers/effects-layer.ts
+++ b/src/app/speck-wars/rendering/layers/effects-layer.ts
@@ -24,7 +24,15 @@ export class EffectsLayer {
   }
 
   showRallyPing(x: number, y: number) {
-    this.pings.push({ x, y, life: 400, maxLife: 400 })
+    // Two rings: fast inner + slower outer
+    this.pings.push({ x, y, life: 320, maxLife: 320 })
+    this.pings.push({ x, y, life: 540, maxLife: 540 })
+    // 4 brief crosshair sparks
+    const S = 12
+    const dirs = [[1,0],[-1,0],[0,1],[0,-1]] as const
+    for (const [dx, dy] of dirs) {
+      this.particles.push({ x, y, vx: dx * S * 50, vy: dy * S * 50, life: 180, maxLife: 180, color: 0x4af7c4 })
+    }
   }
 
   addDeathParticles(x: number, y: number, color: number) {
@@ -62,10 +70,13 @@ export class EffectsLayer {
     for (const p of this.pings) {
       p.life -= dt
       const alpha = p.life / p.maxLife
-      const r = (1 - alpha) * 24 + 4   // expands from 4 to 28
-      this.gfx.lineStyle(2, 0x4af7c4, alpha * 0.8)
+      // Shorter-lived pings expand less; longer-lived ones expand further
+      const maxR = p.maxLife > 400 ? 44 : 26
+      const r = (1 - alpha) * maxR + 4
+      const thickness = p.maxLife > 400 ? 1.2 : 2
+      this.gfx.lineStyle(thickness, 0x4af7c4, alpha * 0.8)
       this.gfx.drawCircle(p.x, p.y, r)
-      this.gfx.lineStyle(0)  // reset
+      this.gfx.lineStyle(0)
     }
 
     this.flashes = this.flashes.filter(f => f.life > 0)

--- a/src/app/speck-wars/rendering/layers/effects-layer.ts
+++ b/src/app/speck-wars/rendering/layers/effects-layer.ts
@@ -1,6 +1,6 @@
 import { Graphics, Container } from 'pixi.js'
 
-interface Flash { x: number; y: number; life: number; maxLife: number }
+interface Flash { x: number; y: number; life: number; maxLife: number; color: number }
 interface Ping { x: number; y: number; life: number; maxLife: number }
 
 export class EffectsLayer {
@@ -15,8 +15,8 @@ export class EffectsLayer {
     this.stage.addChild(this.gfx)
   }
 
-  addDeathFlash(x: number, y: number) {
-    this.flashes.push({ x, y, life: 300, maxLife: 300 })
+  addDeathFlash(x: number, y: number, color = 0xffffff) {
+    this.flashes.push({ x, y, life: 300, maxLife: 300, color })
   }
 
   showRallyPing(x: number, y: number) {
@@ -41,7 +41,7 @@ export class EffectsLayer {
       f.life -= dt
       const alpha = f.life / f.maxLife
       const r = 3 + (1 - alpha) * 4
-      this.gfx.beginFill(0xffffff, alpha)
+      this.gfx.beginFill(f.color, alpha)
       this.gfx.drawCircle(f.x, f.y, r)
       this.gfx.endFill()
     }

--- a/src/app/speck-wars/rendering/layers/effects-layer.ts
+++ b/src/app/speck-wars/rendering/layers/effects-layer.ts
@@ -1,0 +1,34 @@
+import { Graphics, Container } from 'pixi.js'
+
+interface Flash { x: number; y: number; life: number; maxLife: number }
+
+export class EffectsLayer {
+  readonly stage: Container
+  private gfx: Graphics
+  private flashes: Flash[] = []
+
+  constructor() {
+    this.stage = new Container()
+    this.gfx = new Graphics()
+    this.stage.addChild(this.gfx)
+  }
+
+  addDeathFlash(x: number, y: number) {
+    this.flashes.push({ x, y, life: 300, maxLife: 300 })
+  }
+
+  update(dt: number) {
+    this.gfx.clear()
+    this.flashes = this.flashes.filter(f => f.life > 0)
+    for (const f of this.flashes) {
+      f.life -= dt
+      const alpha = f.life / f.maxLife
+      const r = 3 + (1 - alpha) * 4
+      this.gfx.beginFill(0xffffff, alpha)
+      this.gfx.drawCircle(f.x, f.y, r)
+      this.gfx.endFill()
+    }
+  }
+
+  destroy() { this.stage.destroy({ children: true }) }
+}

--- a/src/app/speck-wars/rendering/layers/effects-layer.ts
+++ b/src/app/speck-wars/rendering/layers/effects-layer.ts
@@ -3,6 +3,7 @@ import { Graphics, Container } from 'pixi.js'
 interface Flash { x: number; y: number; life: number; maxLife: number; color: number }
 interface Ping { x: number; y: number; life: number; maxLife: number }
 interface Ripple { x: number; y: number; life: number; maxLife: number; color: number }
+interface Particle { x: number; y: number; vx: number; vy: number; life: number; maxLife: number; color: number }
 
 export class EffectsLayer {
   readonly stage: Container
@@ -10,6 +11,7 @@ export class EffectsLayer {
   private flashes: Flash[] = []
   private pings: Ping[] = []
   private ripples: Ripple[] = []
+  private particles: Particle[] = []
 
   constructor() {
     this.stage = new Container()
@@ -23,6 +25,14 @@ export class EffectsLayer {
 
   showRallyPing(x: number, y: number) {
     this.pings.push({ x, y, life: 400, maxLife: 400 })
+  }
+
+  addDeathParticles(x: number, y: number, color: number) {
+    for (let i = 0; i < 5; i++) {
+      const angle = (i / 5) * Math.PI * 2 + (Math.random() - 0.5) * 0.8
+      const speed = 50 + Math.random() * 60  // px/sec
+      this.particles.push({ x, y, vx: Math.cos(angle) * speed, vy: Math.sin(angle) * speed, life: 280, maxLife: 280, color })
+    }
   }
 
   addCaptureRipple(x: number, y: number, color: number) {
@@ -52,6 +62,17 @@ export class EffectsLayer {
       const r = 3 + (1 - alpha) * 4
       this.gfx.beginFill(f.color, alpha)
       this.gfx.drawCircle(f.x, f.y, r)
+      this.gfx.endFill()
+    }
+
+    this.particles = this.particles.filter(p => p.life > 0)
+    for (const p of this.particles) {
+      p.x += p.vx * (dt / 1000)
+      p.y += p.vy * (dt / 1000)
+      p.life -= dt
+      const alpha = (p.life / p.maxLife) * 0.85
+      this.gfx.beginFill(p.color, alpha)
+      this.gfx.drawCircle(p.x, p.y, 1.5)
       this.gfx.endFill()
     }
 

--- a/src/app/speck-wars/rendering/layers/effects-layer.ts
+++ b/src/app/speck-wars/rendering/layers/effects-layer.ts
@@ -1,11 +1,13 @@
 import { Graphics, Container } from 'pixi.js'
 
 interface Flash { x: number; y: number; life: number; maxLife: number }
+interface Ping { x: number; y: number; life: number; maxLife: number }
 
 export class EffectsLayer {
   readonly stage: Container
   private gfx: Graphics
   private flashes: Flash[] = []
+  private pings: Ping[] = []
 
   constructor() {
     this.stage = new Container()
@@ -17,8 +19,23 @@ export class EffectsLayer {
     this.flashes.push({ x, y, life: 300, maxLife: 300 })
   }
 
+  showRallyPing(x: number, y: number) {
+    this.pings.push({ x, y, life: 400, maxLife: 400 })
+  }
+
   update(dt: number) {
     this.gfx.clear()
+
+    this.pings = this.pings.filter(p => p.life > 0)
+    for (const p of this.pings) {
+      p.life -= dt
+      const alpha = p.life / p.maxLife
+      const r = (1 - alpha) * 24 + 4   // expands from 4 to 28
+      this.gfx.lineStyle(2, 0x4af7c4, alpha * 0.8)
+      this.gfx.drawCircle(p.x, p.y, r)
+      this.gfx.lineStyle(0)  // reset
+    }
+
     this.flashes = this.flashes.filter(f => f.life > 0)
     for (const f of this.flashes) {
       f.life -= dt

--- a/src/app/speck-wars/rendering/layers/effects-layer.ts
+++ b/src/app/speck-wars/rendering/layers/effects-layer.ts
@@ -4,6 +4,10 @@ interface Flash { x: number; y: number; life: number; maxLife: number; color: nu
 interface Ping { x: number; y: number; life: number; maxLife: number }
 interface Ripple { x: number; y: number; life: number; maxLife: number; color: number }
 interface Particle { x: number; y: number; vx: number; vy: number; life: number; maxLife: number; color: number }
+interface CombatZone { x: number; y: number; life: number; maxLife: number }
+
+const COMBAT_ZONE_LIFE = 3000   // ms a zone persists with no new kills
+const COMBAT_ZONE_MERGE_DIST = 60  // px — nearby kills refresh existing zone
 
 export class EffectsLayer {
   readonly stage: Container
@@ -12,6 +16,7 @@ export class EffectsLayer {
   private pings: Ping[] = []
   private ripples: Ripple[] = []
   private particles: Particle[] = []
+  private combatZones: CombatZone[] = []
 
   constructor() {
     this.stage = new Container()
@@ -48,6 +53,18 @@ export class EffectsLayer {
     for (let i = 0; i < 3; i++) {
       this.ripples.push({ x, y, life: 800 - i * 200, maxLife: 800 - i * 200, color })
     }
+  }
+
+  markCombatAt(x: number, y: number) {
+    // Refresh or create a combat zone near this position
+    const md2 = COMBAT_ZONE_MERGE_DIST * COMBAT_ZONE_MERGE_DIST
+    for (const z of this.combatZones) {
+      if ((z.x - x) ** 2 + (z.y - y) ** 2 < md2) {
+        z.life = COMBAT_ZONE_LIFE  // refresh
+        return
+      }
+    }
+    this.combatZones.push({ x, y, life: COMBAT_ZONE_LIFE, maxLife: COMBAT_ZONE_LIFE })
   }
 
   addDestructionBurst(x: number, y: number, color: number) {
@@ -109,6 +126,24 @@ export class EffectsLayer {
       this.gfx.lineStyle(2, r.color, alpha)
       this.gfx.drawCircle(r.x, r.y, radius)
       this.gfx.lineStyle(0)
+    }
+
+    // Combat zone hazes — faint pulsing orange rings where battles are happening
+    this.combatZones = this.combatZones.filter(z => z.life > 0)
+    const now = Date.now()
+    for (const z of this.combatZones) {
+      z.life -= dt
+      const ageFrac = z.life / z.maxLife          // 1.0 (fresh) → 0.0 (expired)
+      const pulse = 0.5 + 0.5 * Math.sin(now / 350)  // ~2.8Hz pulse
+      const alpha = ageFrac * 0.12 * pulse
+      if (alpha > 0.005) {
+        this.gfx.lineStyle(1.5, 0xff6620, alpha)
+        this.gfx.drawCircle(z.x, z.y, 28)
+        this.gfx.lineStyle(0)
+        this.gfx.beginFill(0xff4400, ageFrac * 0.03 * pulse)
+        this.gfx.drawCircle(z.x, z.y, 22)
+        this.gfx.endFill()
+      }
     }
   }
 

--- a/src/app/speck-wars/rendering/layers/effects-layer.ts
+++ b/src/app/speck-wars/rendering/layers/effects-layer.ts
@@ -2,12 +2,14 @@ import { Graphics, Container } from 'pixi.js'
 
 interface Flash { x: number; y: number; life: number; maxLife: number; color: number }
 interface Ping { x: number; y: number; life: number; maxLife: number }
+interface Ripple { x: number; y: number; life: number; maxLife: number; color: number }
 
 export class EffectsLayer {
   readonly stage: Container
   private gfx: Graphics
   private flashes: Flash[] = []
   private pings: Ping[] = []
+  private ripples: Ripple[] = []
 
   constructor() {
     this.stage = new Container()
@@ -21,6 +23,13 @@ export class EffectsLayer {
 
   showRallyPing(x: number, y: number) {
     this.pings.push({ x, y, life: 400, maxLife: 400 })
+  }
+
+  addCaptureRipple(x: number, y: number, color: number) {
+    // Three concentric expanding rings for dramatic capture effect
+    for (let i = 0; i < 3; i++) {
+      this.ripples.push({ x, y, life: 800 - i * 200, maxLife: 800 - i * 200, color })
+    }
   }
 
   update(dt: number) {
@@ -44,6 +53,17 @@ export class EffectsLayer {
       this.gfx.beginFill(f.color, alpha)
       this.gfx.drawCircle(f.x, f.y, r)
       this.gfx.endFill()
+    }
+
+    this.ripples = this.ripples.filter(r => r.life > 0)
+    for (const r of this.ripples) {
+      r.life -= dt
+      const t = 1 - r.life / r.maxLife
+      const radius = 24 + t * 60  // expands from 24 to 84px
+      const alpha = (1 - t) * 0.6
+      this.gfx.lineStyle(2, r.color, alpha)
+      this.gfx.drawCircle(r.x, r.y, radius)
+      this.gfx.lineStyle(0)
     }
   }
 

--- a/src/app/speck-wars/rendering/layers/effects-layer.ts
+++ b/src/app/speck-wars/rendering/layers/effects-layer.ts
@@ -42,6 +42,19 @@ export class EffectsLayer {
     }
   }
 
+  addDestructionBurst(x: number, y: number, color: number) {
+    // 20 radial particles — fast, long-lived, large burst for building destruction
+    for (let i = 0; i < 20; i++) {
+      const angle = (i / 20) * Math.PI * 2 + (Math.random() - 0.5) * 0.5
+      const speed = 80 + Math.random() * 120  // px/sec
+      this.particles.push({ x, y, vx: Math.cos(angle) * speed, vy: Math.sin(angle) * speed, life: 600, maxLife: 600, color })
+    }
+    // Large shockwave rings
+    for (let i = 0; i < 3; i++) {
+      this.ripples.push({ x, y, life: 500 - i * 100, maxLife: 500 - i * 100, color: 0xffffff })
+    }
+  }
+
   update(dt: number) {
     this.gfx.clear()
 

--- a/src/app/speck-wars/rendering/layers/grid-layer.ts
+++ b/src/app/speck-wars/rendering/layers/grid-layer.ts
@@ -1,0 +1,40 @@
+import { Graphics, Container } from 'pixi.js'
+import { WORLD_WIDTH, WORLD_HEIGHT } from '../../domain/constants'
+
+const GRID_SIZE = 200   // px between grid lines
+
+export class GridLayer {
+  readonly stage: Container
+  private gfx: Graphics
+
+  constructor() {
+    this.stage = new Container()
+    this.gfx = new Graphics()
+    this.stage.addChild(this.gfx)
+    this.draw()
+  }
+
+  private draw() {
+    this.gfx.clear()
+
+    // Vertical grid lines
+    this.gfx.lineStyle(1, 0xffffff, 0.05)
+    for (let x = 0; x <= WORLD_WIDTH; x += GRID_SIZE) {
+      this.gfx.moveTo(x, 0)
+      this.gfx.lineTo(x, WORLD_HEIGHT)
+    }
+
+    // Horizontal grid lines
+    for (let y = 0; y <= WORLD_HEIGHT; y += GRID_SIZE) {
+      this.gfx.moveTo(0, y)
+      this.gfx.lineTo(WORLD_WIDTH, y)
+    }
+
+    // World border
+    this.gfx.lineStyle(2, 0xffffff, 0.2)
+    this.gfx.drawRect(0, 0, WORLD_WIDTH, WORLD_HEIGHT)
+    this.gfx.lineStyle(0)
+  }
+
+  destroy() { this.stage.destroy({ children: true }) }
+}

--- a/src/app/speck-wars/rendering/layers/speck-layer.ts
+++ b/src/app/speck-wars/rendering/layers/speck-layer.ts
@@ -1,4 +1,4 @@
-import { Container, Sprite } from 'pixi.js'
+import { Container, Graphics, Sprite } from 'pixi.js'
 import type { Texture } from 'pixi.js'
 import type { SimulationState } from '../../domain/types'
 import { SPECK_TYPES } from '../../domain/config/speck-types'
@@ -11,6 +11,7 @@ export class SpeckLayer {
   private texture: Texture
   private playerColors: Record<string, number>
   private attackAnimByIndex: Map<number, number> = new Map()
+  private gfx: Graphics
   readonly stage: Container
 
   constructor(texture: Texture, playerColors: Record<string, number>) {
@@ -27,9 +28,13 @@ export class SpeckLayer {
       this.containers.set(playerId, container)
       this.sprites.set(playerId, [])
     }
+
+    this.gfx = new Graphics()
+    this.stage.addChild(this.gfx)
   }
 
   update(sim: SimulationState) {
+    this.gfx.clear()
     // Group live speck indices by owner
     const byOwner: Record<string, number[]> = {}
     for (let i = 0; i < sim.speckCount; i++) {
@@ -77,6 +82,13 @@ export class SpeckLayer {
         // Fade speck as it takes damage — full HP = 1.0, near death = 0.35
         const hpFrac = stype ? Math.max(0, sim.speckHp[i] / stype.hp) : 1
         spriteList[j].alpha = 0.35 + 0.65 * hpFrac
+
+        const isHeavy = typeMeta?.typeId === 'heavy'
+        if (isHeavy) {
+          this.gfx.lineStyle(1, 0xffffff, spriteList[j].alpha * 0.6)
+          this.gfx.drawCircle(sim.speckX[i], sim.speckY[i], 2)
+          this.gfx.lineStyle(0)
+        }
       }
 
       // Hide excess sprites

--- a/src/app/speck-wars/rendering/layers/speck-layer.ts
+++ b/src/app/speck-wars/rendering/layers/speck-layer.ts
@@ -58,6 +58,9 @@ export class SpeckLayer {
         const typeMeta = sim.speckMeta[i]
         const stype = typeMeta ? SPECK_TYPES[typeMeta.typeId] : null
         spriteList[j].scale.set(stype ? stype.size / 4 : 0.75)
+        // Fade speck as it takes damage — full HP = 1.0, near death = 0.35
+        const hpFrac = stype ? Math.max(0, sim.speckHp[i] / stype.hp) : 1
+        spriteList[j].alpha = 0.35 + 0.65 * hpFrac
       }
 
       // Hide excess sprites

--- a/src/app/speck-wars/rendering/layers/speck-layer.ts
+++ b/src/app/speck-wars/rendering/layers/speck-layer.ts
@@ -3,11 +3,14 @@ import type { Texture } from 'pixi.js'
 import type { SimulationState } from '../../domain/types'
 import { SPECK_TYPES } from '../../domain/config/speck-types'
 
+const ATTACK_ANIM_MS = 120
+
 export class SpeckLayer {
   private containers: Map<string, Container> = new Map()
   private sprites: Map<string, Sprite[]> = new Map()
   private texture: Texture
   private playerColors: Record<string, number>
+  private attackAnimByIndex: Map<number, number> = new Map()
   readonly stage: Container
 
   constructor(texture: Texture, playerColors: Record<string, number>) {
@@ -51,13 +54,26 @@ export class SpeckLayer {
       }
 
       // Update visible sprites
+      const now = Date.now()
       for (let j = 0; j < indices.length; j++) {
         const i = indices[j]
         spriteList[j].position.set(sim.speckX[i], sim.speckY[i])
         spriteList[j].visible = true
         const typeMeta = sim.speckMeta[i]
         const stype = typeMeta ? SPECK_TYPES[typeMeta.typeId] : null
-        spriteList[j].scale.set(stype ? stype.size / 4 : 0.75)
+        // Track attack animation
+        if (typeMeta?.state === 'attacking') this.attackAnimByIndex.set(i, now)
+        const attackTs = this.attackAnimByIndex.get(i)
+        let scaleBoost = 1.0
+        if (attackTs !== undefined) {
+          const elapsed = now - attackTs
+          if (elapsed < ATTACK_ANIM_MS) {
+            scaleBoost = 1 + 0.3 * (1 - elapsed / ATTACK_ANIM_MS)  // 1.3x → 1.0x
+          } else {
+            this.attackAnimByIndex.delete(i)
+          }
+        }
+        spriteList[j].scale.set((stype ? stype.size / 4 : 0.75) * scaleBoost)
         // Fade speck as it takes damage — full HP = 1.0, near death = 0.35
         const hpFrac = stype ? Math.max(0, sim.speckHp[i] / stype.hp) : 1
         spriteList[j].alpha = 0.35 + 0.65 * hpFrac

--- a/src/app/speck-wars/rendering/layers/speck-layer.ts
+++ b/src/app/speck-wars/rendering/layers/speck-layer.ts
@@ -1,0 +1,66 @@
+import { Container, Sprite } from 'pixi.js'
+import type { Texture } from 'pixi.js'
+import type { SimulationState } from '../../domain/types'
+
+export class SpeckLayer {
+  private containers: Map<string, Container> = new Map()
+  private sprites: Map<string, Sprite[]> = new Map()
+  private texture: Texture
+  private playerColors: Record<string, number>
+  readonly stage: Container
+
+  constructor(texture: Texture, playerColors: Record<string, number>) {
+    this.texture = texture
+    this.playerColors = playerColors
+    this.stage = new Container()
+
+    for (const [playerId, color] of Object.entries(playerColors)) {
+      const container = new Container()
+      // tint exists on Container in Pixi 8 but is not visible in the TS type in
+      // this Next.js project context — cast to apply it
+      ;(container as Container & { tint: number }).tint = color
+      this.stage.addChild(container)
+      this.containers.set(playerId, container)
+      this.sprites.set(playerId, [])
+    }
+  }
+
+  update(sim: SimulationState) {
+    // Group speck indices by owner
+    const byOwner: Record<string, number[]> = {}
+    for (let i = 0; i < sim.speckIds.length; i++) {
+      const ownerId = sim.speckMeta[i].ownerId
+      if (!byOwner[ownerId]) byOwner[ownerId] = []
+      byOwner[ownerId].push(i)
+    }
+
+    for (const [ownerId, container] of this.containers) {
+      const indices = byOwner[ownerId] ?? []
+      const spriteList = this.sprites.get(ownerId)!
+
+      // Grow sprite pool if needed
+      while (spriteList.length < indices.length) {
+        const s = new Sprite(this.texture)
+        s.anchor.set(0.5)
+        container.addChild(s)
+        spriteList.push(s)
+      }
+
+      // Update visible sprites
+      for (let j = 0; j < indices.length; j++) {
+        const i = indices[j]
+        spriteList[j].position.set(sim.speckX[i], sim.speckY[i])
+        spriteList[j].visible = true
+      }
+
+      // Hide excess sprites
+      for (let j = indices.length; j < spriteList.length; j++) {
+        spriteList[j].visible = false
+      }
+    }
+  }
+
+  destroy() {
+    this.stage.destroy({ children: true })
+  }
+}

--- a/src/app/speck-wars/rendering/layers/speck-layer.ts
+++ b/src/app/speck-wars/rendering/layers/speck-layer.ts
@@ -88,6 +88,15 @@ export class SpeckLayer {
           this.gfx.lineStyle(1, 0xffffff, spriteList[j].alpha * 0.6)
           this.gfx.drawCircle(sim.speckX[i], sim.speckY[i], 2)
           this.gfx.lineStyle(0)
+          // Critical HP ring: red outline when heavy speck is at 40% HP or below
+          if (stype && hpFrac <= 0.4 && hpFrac > 0) {
+            const critIntensity = (0.4 - hpFrac) / 0.4   // 0.0 → 1.0 as HP drops
+            const critAlpha = critIntensity * 0.8 * spriteList[j].alpha
+            const critPulse = 0.5 + 0.5 * Math.sin(now / 120)  // fast pulse ~8Hz
+            this.gfx.lineStyle(1.2, 0xff2222, critAlpha * critPulse)
+            this.gfx.drawCircle(sim.speckX[i], sim.speckY[i], stype.size / 4 + 2)
+            this.gfx.lineStyle(0)
+          }
         }
 
         // Motion trail: 3 fading dots extrapolated backwards from velocity

--- a/src/app/speck-wars/rendering/layers/speck-layer.ts
+++ b/src/app/speck-wars/rendering/layers/speck-layer.ts
@@ -89,6 +89,23 @@ export class SpeckLayer {
           this.gfx.drawCircle(sim.speckX[i], sim.speckY[i], 2)
           this.gfx.lineStyle(0)
         }
+
+        // Motion trail: 3 fading dots extrapolated backwards from velocity
+        const vx = sim.speckVx[i], vy = sim.speckVy[i]
+        if (vx * vx + vy * vy > 900) {  // only when moving faster than ~30 px/s
+          const color = this.playerColors[ownerId] ?? 0xffffff
+          const baseAlpha = spriteList[j].alpha
+          const trailAlphas = [0.18, 0.09, 0.04] as const
+          for (let t = 1; t <= 3; t++) {
+            this.gfx.beginFill(color, baseAlpha * trailAlphas[t - 1])
+            this.gfx.drawCircle(
+              sim.speckX[i] - vx * (t * 0.018),
+              sim.speckY[i] - vy * (t * 0.018),
+              1.2,
+            )
+            this.gfx.endFill()
+          }
+        }
       }
 
       // Hide excess sprites

--- a/src/app/speck-wars/rendering/layers/speck-layer.ts
+++ b/src/app/speck-wars/rendering/layers/speck-layer.ts
@@ -1,6 +1,7 @@
 import { Container, Sprite } from 'pixi.js'
 import type { Texture } from 'pixi.js'
 import type { SimulationState } from '../../domain/types'
+import { SPECK_TYPES } from '../../domain/config/speck-types'
 
 export class SpeckLayer {
   private containers: Map<string, Container> = new Map()
@@ -54,6 +55,9 @@ export class SpeckLayer {
         const i = indices[j]
         spriteList[j].position.set(sim.speckX[i], sim.speckY[i])
         spriteList[j].visible = true
+        const typeMeta = sim.speckMeta[i]
+        const stype = typeMeta ? SPECK_TYPES[typeMeta.typeId] : null
+        spriteList[j].scale.set(stype ? stype.size / 4 : 0.75)
       }
 
       // Hide excess sprites

--- a/src/app/speck-wars/rendering/layers/speck-layer.ts
+++ b/src/app/speck-wars/rendering/layers/speck-layer.ts
@@ -26,10 +26,13 @@ export class SpeckLayer {
   }
 
   update(sim: SimulationState) {
-    // Group speck indices by owner
+    // Group live speck indices by owner
     const byOwner: Record<string, number[]> = {}
-    for (let i = 0; i < sim.speckIds.length; i++) {
-      const ownerId = sim.speckMeta[i].ownerId
+    for (let i = 0; i < sim.speckCount; i++) {
+      if (!sim.speckIds[i]) continue
+      const meta = sim.speckMeta[i]
+      if (!meta) continue
+      const ownerId = meta.ownerId
       if (!byOwner[ownerId]) byOwner[ownerId] = []
       byOwner[ownerId].push(i)
     }

--- a/src/app/speck-wars/rendering/layers/starfield-layer.ts
+++ b/src/app/speck-wars/rendering/layers/starfield-layer.ts
@@ -1,0 +1,44 @@
+import { Graphics, Container } from 'pixi.js'
+
+// Simple deterministic pseudo-random (xorshift32) — fixed seed so stars are stable
+function xr(s: number) { s ^= s << 13; s ^= s >> 17; s ^= s << 5; return (s >>> 0) / 0x100000000 }
+
+export class StarfieldLayer {
+  readonly stage: Container
+
+  constructor() {
+    this.stage = new Container()
+    const gfx = new Graphics()
+
+    // Spread stars over an area larger than the 3000×3000 world
+    const AREA_X = -800, AREA_Y = -800, AREA_W = 4600, AREA_H = 4600
+    const STAR_COUNT = 420
+
+    let seed = 0xdeadbeef
+    const rng = () => { seed = (seed * 1664525 + 1013904223) >>> 0; return seed / 0x100000000 }
+
+    for (let i = 0; i < STAR_COUNT; i++) {
+      const x = AREA_X + rng() * AREA_W
+      const y = AREA_Y + rng() * AREA_H
+      const t = rng()          // type selector
+      const r = t < 0.75 ? 0.6 + rng() * 0.5     // small  (75%)
+              : t < 0.95 ? 1.2 + rng() * 0.8     // medium (20%)
+              :             2.0 + rng() * 1.2     // large  (5%)
+      const alpha = 0.08 + rng() * 0.36
+
+      // Subtle color variety: ~20% slightly blue-purple, rest white
+      const colorRoll = rng()
+      const color = colorRoll < 0.12 ? 0xaab8ff    // blue-white
+                  : colorRoll < 0.20 ? 0xddccff    // soft violet
+                  : 0xffffff                        // white
+
+      gfx.beginFill(color, alpha)
+      gfx.drawCircle(x, y, r)
+      gfx.endFill()
+    }
+
+    this.stage.addChild(gfx)
+  }
+
+  destroy() { this.stage.destroy({ children: true }) }
+}

--- a/src/app/speck-wars/rendering/renderer.ts
+++ b/src/app/speck-wars/rendering/renderer.ts
@@ -79,6 +79,13 @@ export class Renderer {
       if (event.type === 'BUILDING_DAMAGED') {
         this.buildingLayer.flashBuilding(event.buildingId)
       }
+      if (event.type === 'OUTPOST_CAPTURED') {
+        const building = sim.buildings[event.outpostId]
+        const color = PLAYER_COLORS[event.newOwner] ?? 0xffffff
+        const x = building?.x ?? 0
+        const y = building?.y ?? 0
+        this.effectsLayer.addCaptureRipple(x, y, color)
+      }
     }
     this.effectsLayer.update(dt)
 

--- a/src/app/speck-wars/rendering/renderer.ts
+++ b/src/app/speck-wars/rendering/renderer.ts
@@ -1,4 +1,4 @@
-import { Application, Container } from 'pixi.js'
+import { Application, Container, Graphics } from 'pixi.js'
 import { SpeckLayer } from './layers/speck-layer'
 import { BuildingLayer } from './layers/building-layer'
 import { GridLayer } from './layers/grid-layer'
@@ -32,6 +32,7 @@ export class Renderer {
   private buildingLayer!: BuildingLayer
   private gridLayer!: GridLayer
   private effectsLayer!: EffectsLayer
+  private rallyGfx!: Graphics
 
   async init(canvas: HTMLCanvasElement) {
     const app = new Application() as PixiApplication
@@ -57,6 +58,9 @@ export class Renderer {
     this.world.addChild(this.buildingLayer.stage)
     this.world.addChild(this.effectsLayer.stage)
     this.world.addChild(this.speckLayer.stage)
+
+    this.rallyGfx = new Graphics()
+    this.world.addChild(this.rallyGfx)
   }
 
   render(sim: SimulationState, camera: { x: number; y: number; zoom: number }, dt: number) {
@@ -73,6 +77,23 @@ export class Renderer {
       }
     }
     this.effectsLayer.update(dt)
+
+    // Rally point marker
+    this.rallyGfx.clear()
+    const rp = sim.rallyPoints['player']
+    if (rp) {
+      const pulse = 0.5 + 0.5 * Math.sin(Date.now() / 400)
+      const alpha = 0.5 + 0.5 * pulse
+      this.rallyGfx.lineStyle(2, PLAYER_COLOR, alpha)
+      const s = 10
+      this.rallyGfx.moveTo(rp.x - s, rp.y)
+      this.rallyGfx.lineTo(rp.x + s, rp.y)
+      this.rallyGfx.moveTo(rp.x, rp.y - s)
+      this.rallyGfx.lineTo(rp.x, rp.y + s)
+      this.rallyGfx.lineStyle(1.5, PLAYER_COLOR, alpha * 0.5)
+      this.rallyGfx.drawCircle(rp.x, rp.y, 14)
+      this.rallyGfx.lineStyle(0)
+    }
   }
 
   showRallyPing(x: number, y: number) {
@@ -84,6 +105,7 @@ export class Renderer {
     this.effectsLayer.destroy()
     this.speckLayer.destroy()
     this.buildingLayer.destroy()
+    this.rallyGfx.destroy()
     this.app.destroy()
   }
 }

--- a/src/app/speck-wars/rendering/renderer.ts
+++ b/src/app/speck-wars/rendering/renderer.ts
@@ -73,7 +73,8 @@ export class Renderer {
     // Process death flash events from this tick
     for (const event of sim.events) {
       if (event.type === 'SPECK_DIED') {
-        this.effectsLayer.addDeathFlash(event.x, event.y)
+        const flashColor = PLAYER_COLORS[event.killedOwnerId] ?? 0xffffff
+        this.effectsLayer.addDeathFlash(event.x, event.y, flashColor)
       }
     }
     this.effectsLayer.update(dt)

--- a/src/app/speck-wars/rendering/renderer.ts
+++ b/src/app/speck-wars/rendering/renderer.ts
@@ -80,6 +80,7 @@ export class Renderer {
         const flashColor = PLAYER_COLORS[event.killedOwnerId] ?? 0xffffff
         this.effectsLayer.addDeathFlash(event.x, event.y, flashColor)
         this.effectsLayer.addDeathParticles(event.x, event.y, flashColor)
+        this.effectsLayer.markCombatAt(event.x, event.y)
       }
       if (event.type === 'BUILDING_DAMAGED') {
         this.buildingLayer.flashBuilding(event.buildingId)

--- a/src/app/speck-wars/rendering/renderer.ts
+++ b/src/app/speck-wars/rendering/renderer.ts
@@ -97,7 +97,7 @@ export class Renderer {
     }
     this.effectsLayer.update(dt)
 
-    // Rally point marker
+    // Rally point marker + dashed line from base to rally
     this.rallyGfx.clear()
     const rp = sim.rallyPoints['player']
     if (rp) {
@@ -112,6 +112,30 @@ export class Renderer {
       this.rallyGfx.lineStyle(1.5, PLAYER_COLOR, alpha * 0.5)
       this.rallyGfx.drawCircle(rp.x, rp.y, 14)
       this.rallyGfx.lineStyle(0)
+
+      // Dashed line from player base to rally point (only if far enough apart)
+      const playerBase = Object.values(sim.buildings).find(b => b.ownerId === 'player' && b.typeId === 'base')
+      if (playerBase) {
+        const dx = rp.x - playerBase.x
+        const dy = rp.y - playerBase.y
+        const len = Math.sqrt(dx * dx + dy * dy)
+        if (len > 80) {
+          const nx = dx / len, ny = dy / len
+          const dashLen = 8, gapLen = 6
+          this.rallyGfx.lineStyle(1, PLAYER_COLOR, 0.22)
+          let d = playerBase === null ? 0 : 46  // start outside the base
+          while (d < len - 24) {
+            const x1 = playerBase.x + nx * d
+            const y1 = playerBase.y + ny * d
+            const x2 = playerBase.x + nx * Math.min(d + dashLen, len - 24)
+            const y2 = playerBase.y + ny * Math.min(d + dashLen, len - 24)
+            this.rallyGfx.moveTo(x1, y1)
+            this.rallyGfx.lineTo(x2, y2)
+            d += dashLen + gapLen
+          }
+          this.rallyGfx.lineStyle(0)
+        }
+      }
     }
   }
 

--- a/src/app/speck-wars/rendering/renderer.ts
+++ b/src/app/speck-wars/rendering/renderer.ts
@@ -80,6 +80,10 @@ export class Renderer {
       if (event.type === 'BUILDING_DAMAGED') {
         this.buildingLayer.flashBuilding(event.buildingId)
       }
+      if (event.type === 'BUILDING_DESTROYED') {
+        const color = PLAYER_COLORS[event.ownerId] ?? 0xffffff
+        this.effectsLayer.addDestructionBurst(event.x, event.y, color)
+      }
       if (event.type === 'OUTPOST_CAPTURED') {
         const building = sim.buildings[event.outpostId]
         const color = PLAYER_COLORS[event.newOwner] ?? 0xffffff

--- a/src/app/speck-wars/rendering/renderer.ts
+++ b/src/app/speck-wars/rendering/renderer.ts
@@ -75,6 +75,10 @@ export class Renderer {
     this.effectsLayer.update(dt)
   }
 
+  showRallyPing(x: number, y: number) {
+    this.effectsLayer.showRallyPing(x, y)
+  }
+
   destroy() {
     this.gridLayer.destroy()
     this.effectsLayer.destroy()

--- a/src/app/speck-wars/rendering/renderer.ts
+++ b/src/app/speck-wars/rendering/renderer.ts
@@ -1,6 +1,8 @@
 import { Application, Container } from 'pixi.js'
 import { SpeckLayer } from './layers/speck-layer'
 import { BuildingLayer } from './layers/building-layer'
+import { GridLayer } from './layers/grid-layer'
+import { EffectsLayer } from './layers/effects-layer'
 import { createSpeckTexture } from './textures'
 import type { SimulationState } from '../domain/types'
 import { PLAYER_COLOR, AI_COLOR } from '../domain/constants'
@@ -28,6 +30,8 @@ export class Renderer {
   private world!: Container  // camera container
   private speckLayer!: SpeckLayer
   private buildingLayer!: BuildingLayer
+  private gridLayer!: GridLayer
+  private effectsLayer!: EffectsLayer
 
   async init(canvas: HTMLCanvasElement) {
     const app = new Application() as PixiApplication
@@ -44,22 +48,36 @@ export class Renderer {
     this.app.stage.addChild(this.world)
 
     const texture = createSpeckTexture(this.app, 4)
+    this.gridLayer = new GridLayer()
+    this.effectsLayer = new EffectsLayer()
     this.buildingLayer = new BuildingLayer()
     this.speckLayer = new SpeckLayer(texture, PLAYER_COLORS)
 
+    this.world.addChild(this.gridLayer.stage)
     this.world.addChild(this.buildingLayer.stage)
+    this.world.addChild(this.effectsLayer.stage)
     this.world.addChild(this.speckLayer.stage)
   }
 
-  render(sim: SimulationState, camera: { x: number; y: number; zoom: number }) {
+  render(sim: SimulationState, camera: { x: number; y: number; zoom: number }, dt: number) {
     this.world.position.set(camera.x, camera.y)
     this.world.scale.set(camera.zoom)
 
     this.buildingLayer.update(sim, PLAYER_COLORS)
     this.speckLayer.update(sim)
+
+    // Process death flash events from this tick
+    for (const event of sim.events) {
+      if (event.type === 'SPECK_DIED') {
+        this.effectsLayer.addDeathFlash(event.x, event.y)
+      }
+    }
+    this.effectsLayer.update(dt)
   }
 
   destroy() {
+    this.gridLayer.destroy()
+    this.effectsLayer.destroy()
     this.speckLayer.destroy()
     this.buildingLayer.destroy()
     this.app.destroy()

--- a/src/app/speck-wars/rendering/renderer.ts
+++ b/src/app/speck-wars/rendering/renderer.ts
@@ -3,6 +3,7 @@ import { SpeckLayer } from './layers/speck-layer'
 import { BuildingLayer } from './layers/building-layer'
 import { GridLayer } from './layers/grid-layer'
 import { EffectsLayer } from './layers/effects-layer'
+import { StarfieldLayer } from './layers/starfield-layer'
 import { createSpeckTexture } from './textures'
 import type { SimulationState } from '../domain/types'
 import { PLAYER_COLOR, AI_COLOR } from '../domain/constants'
@@ -32,6 +33,7 @@ export class Renderer {
   private buildingLayer!: BuildingLayer
   private gridLayer!: GridLayer
   private effectsLayer!: EffectsLayer
+  private starfieldLayer!: StarfieldLayer
   private rallyGfx!: Graphics
 
   async init(canvas: HTMLCanvasElement) {
@@ -49,11 +51,13 @@ export class Renderer {
     this.app.stage.addChild(this.world)
 
     const texture = createSpeckTexture(this.app, 4)
+    this.starfieldLayer = new StarfieldLayer()
     this.gridLayer = new GridLayer()
     this.effectsLayer = new EffectsLayer()
     this.buildingLayer = new BuildingLayer()
     this.speckLayer = new SpeckLayer(texture, PLAYER_COLORS)
 
+    this.world.addChild(this.starfieldLayer.stage)
     this.world.addChild(this.gridLayer.stage)
     this.world.addChild(this.buildingLayer.stage)
     this.world.addChild(this.effectsLayer.stage)
@@ -144,6 +148,7 @@ export class Renderer {
   }
 
   destroy() {
+    this.starfieldLayer.destroy()
     this.gridLayer.destroy()
     this.effectsLayer.destroy()
     this.speckLayer.destroy()

--- a/src/app/speck-wars/rendering/renderer.ts
+++ b/src/app/speck-wars/rendering/renderer.ts
@@ -1,0 +1,67 @@
+import { Application, Container } from 'pixi.js'
+import { SpeckLayer } from './layers/speck-layer'
+import { BuildingLayer } from './layers/building-layer'
+import { createSpeckTexture } from './textures'
+import type { SimulationState } from '../domain/types'
+import { PLAYER_COLOR, AI_COLOR } from '../domain/constants'
+
+export const PLAYER_COLORS: Record<string, number> = {
+  player: PLAYER_COLOR,
+  ai: AI_COLOR,
+}
+
+// Application.init exists at runtime in Pixi 8 but the TypeScript plugin
+// in this Next.js project incorrectly omits it from the inferred type.
+interface PixiApplication extends Application {
+  init(options?: {
+    canvas?: HTMLCanvasElement
+    resizeTo?: HTMLElement
+    backgroundAlpha?: number
+    antialias?: boolean
+    preference?: string
+    [key: string]: unknown
+  }): Promise<void>
+}
+
+export class Renderer {
+  app!: Application
+  private world!: Container  // camera container
+  private speckLayer!: SpeckLayer
+  private buildingLayer!: BuildingLayer
+
+  async init(canvas: HTMLCanvasElement) {
+    const app = new Application() as PixiApplication
+    await app.init({
+      canvas,
+      resizeTo: canvas,
+      backgroundAlpha: 0,
+      antialias: false,
+      preference: 'webgl',
+    })
+    this.app = app
+
+    this.world = new Container()
+    this.app.stage.addChild(this.world)
+
+    const texture = createSpeckTexture(this.app, 4)
+    this.buildingLayer = new BuildingLayer()
+    this.speckLayer = new SpeckLayer(texture, PLAYER_COLORS)
+
+    this.world.addChild(this.buildingLayer.stage)
+    this.world.addChild(this.speckLayer.stage)
+  }
+
+  render(sim: SimulationState, camera: { x: number; y: number; zoom: number }) {
+    this.world.position.set(camera.x, camera.y)
+    this.world.scale.set(camera.zoom)
+
+    this.buildingLayer.update(sim, PLAYER_COLORS)
+    this.speckLayer.update(sim)
+  }
+
+  destroy() {
+    this.speckLayer.destroy()
+    this.buildingLayer.destroy()
+    this.app.destroy()
+  }
+}

--- a/src/app/speck-wars/rendering/renderer.ts
+++ b/src/app/speck-wars/rendering/renderer.ts
@@ -80,6 +80,9 @@ export class Renderer {
       if (event.type === 'BUILDING_DAMAGED') {
         this.buildingLayer.flashBuilding(event.buildingId)
       }
+      if (event.type === 'SPECK_SPAWNED' && event.buildingId.startsWith('building-player')) {
+        this.buildingLayer.flashSpawn(event.buildingId)
+      }
       if (event.type === 'BUILDING_DESTROYED') {
         const color = PLAYER_COLORS[event.ownerId] ?? 0xffffff
         this.effectsLayer.addDestructionBurst(event.x, event.y, color)

--- a/src/app/speck-wars/rendering/renderer.ts
+++ b/src/app/speck-wars/rendering/renderer.ts
@@ -70,11 +70,14 @@ export class Renderer {
     this.buildingLayer.update(sim, PLAYER_COLORS)
     this.speckLayer.update(sim)
 
-    // Process death flash events from this tick
+    // Process events from this tick
     for (const event of sim.events) {
       if (event.type === 'SPECK_DIED') {
         const flashColor = PLAYER_COLORS[event.killedOwnerId] ?? 0xffffff
         this.effectsLayer.addDeathFlash(event.x, event.y, flashColor)
+      }
+      if (event.type === 'BUILDING_DAMAGED') {
+        this.buildingLayer.flashBuilding(event.buildingId)
       }
     }
     this.effectsLayer.update(dt)

--- a/src/app/speck-wars/rendering/renderer.ts
+++ b/src/app/speck-wars/rendering/renderer.ts
@@ -63,8 +63,8 @@ export class Renderer {
     this.world.addChild(this.rallyGfx)
   }
 
-  render(sim: SimulationState, camera: { x: number; y: number; zoom: number }, dt: number) {
-    this.world.position.set(camera.x, camera.y)
+  render(sim: SimulationState, camera: { x: number; y: number; zoom: number }, dt: number, shakeX = 0, shakeY = 0) {
+    this.world.position.set(camera.x + shakeX, camera.y + shakeY)
     this.world.scale.set(camera.zoom)
 
     this.buildingLayer.update(sim, PLAYER_COLORS)

--- a/src/app/speck-wars/rendering/renderer.ts
+++ b/src/app/speck-wars/rendering/renderer.ts
@@ -75,6 +75,7 @@ export class Renderer {
       if (event.type === 'SPECK_DIED') {
         const flashColor = PLAYER_COLORS[event.killedOwnerId] ?? 0xffffff
         this.effectsLayer.addDeathFlash(event.x, event.y, flashColor)
+        this.effectsLayer.addDeathParticles(event.x, event.y, flashColor)
       }
       if (event.type === 'BUILDING_DAMAGED') {
         this.buildingLayer.flashBuilding(event.buildingId)

--- a/src/app/speck-wars/rendering/textures.ts
+++ b/src/app/speck-wars/rendering/textures.ts
@@ -1,0 +1,12 @@
+import { Application, Graphics } from 'pixi.js'
+import type { RenderTexture } from 'pixi.js'
+
+export function createSpeckTexture(app: Application, radius: number = 4): RenderTexture {
+  const g = new Graphics()
+  // Use Pixi 8 compatible API (beginFill/drawCircle are still available as deprecated wrappers)
+  g.beginFill(0xffffff)
+  g.drawCircle(0, 0, radius)
+  g.endFill()
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return (app.renderer as any).generateTexture(g) as RenderTexture
+}

--- a/src/app/speck-wars/store.ts
+++ b/src/app/speck-wars/store.ts
@@ -9,8 +9,6 @@ interface SpeckWarsStore {
   phase: GamePhase
   setPhase: (phase: GamePhase) => void
   togglePause: () => void
-  pendingRally: { x: number; y: number } | null
-  setPendingRally: (pt: { x: number; y: number } | null) => void
   winnerId: string | null
   setWinnerId: (id: string) => void
   victoryType: 'destruction' | 'domination' | null
@@ -43,8 +41,6 @@ export const useSpeckWarsStore = create<SpeckWarsStore>()(set => ({
   togglePause: () => set(s => ({
     phase: s.phase === 'playing' ? 'paused' : s.phase === 'paused' ? 'playing' : s.phase,
   })),
-  pendingRally: null,
-  setPendingRally: pt => set({ pendingRally: pt }),
   winnerId: null,
   setWinnerId: winnerId => set({ winnerId }),
   victoryType: null,

--- a/src/app/speck-wars/store.ts
+++ b/src/app/speck-wars/store.ts
@@ -20,6 +20,10 @@ interface SpeckWarsStore {
   cycleSpeed: () => void
   notification: { message: string; color: string } | null
   setNotification: (n: { message: string; color: string } | null) => void
+  kills: number
+  losses: number
+  addKill: () => void
+  addLoss: () => void
   resetGame: () => void
 }
 
@@ -43,6 +47,10 @@ export const useSpeckWarsStore = create<SpeckWarsStore>()(set => ({
   })),
   notification: null,
   setNotification: n => set({ notification: n }),
+  kills: 0,
+  losses: 0,
+  addKill: () => set(s => ({ kills: s.kills + 1 })),
+  addLoss: () => set(s => ({ losses: s.losses + 1 })),
   resetGame: () => set(s => ({
     phase: 'menu' as GamePhase,
     winnerId: null,
@@ -50,6 +58,8 @@ export const useSpeckWarsStore = create<SpeckWarsStore>()(set => ({
     elapsedMs: 0,
     speed: 1 as 1 | 2 | 4,
     notification: null,
+    kills: 0,
+    losses: 0,
     difficulty: s.difficulty,
   })),
 }))

--- a/src/app/speck-wars/store.ts
+++ b/src/app/speck-wars/store.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand'
 import type { HudData } from './domain/types'
+import { resetWinStreak } from './lib/personal-best'
 
 type GamePhase = 'menu' | 'playing' | 'paused' | 'victory' | 'defeat'
 export type Difficulty = 'easy' | 'medium' | 'hard' | 'very-hard'
@@ -30,6 +31,7 @@ interface SpeckWarsStore {
   cycleSpawnMode: () => 'basic' | 'heavy'
   isNewBest: boolean
   setIsNewBest: (v: boolean) => void
+  surrender: () => void
   resetGame: () => void
 }
 
@@ -70,6 +72,10 @@ export const useSpeckWarsStore = create<SpeckWarsStore>()(set => ({
   },
   isNewBest: false,
   setIsNewBest: v => set({ isNewBest: v }),
+  surrender: () => {
+    resetWinStreak()
+    set({ phase: 'defeat', winnerId: 'ai', victoryType: 'destruction', isNewBest: false })
+  },
   resetGame: () => set(s => ({
     phase: 'menu' as GamePhase,
     winnerId: null,

--- a/src/app/speck-wars/store.ts
+++ b/src/app/speck-wars/store.ts
@@ -2,6 +2,7 @@ import { create } from 'zustand'
 import type { HudData } from './domain/types'
 
 type GamePhase = 'menu' | 'playing' | 'paused' | 'victory' | 'defeat'
+export type Difficulty = 'easy' | 'medium' | 'hard'
 
 interface SpeckWarsStore {
   phase: GamePhase
@@ -10,6 +11,8 @@ interface SpeckWarsStore {
   setWinnerId: (id: string) => void
   hud: HudData | null
   setHud: (data: HudData) => void
+  difficulty: Difficulty
+  setDifficulty: (d: Difficulty) => void
 }
 
 export const useSpeckWarsStore = create<SpeckWarsStore>()(set => ({
@@ -19,4 +22,6 @@ export const useSpeckWarsStore = create<SpeckWarsStore>()(set => ({
   setWinnerId: winnerId => set({ winnerId }),
   hud: null,
   setHud: hud => set({ hud }),
+  difficulty: 'medium',
+  setDifficulty: difficulty => set({ difficulty }),
 }))

--- a/src/app/speck-wars/store.ts
+++ b/src/app/speck-wars/store.ts
@@ -1,13 +1,22 @@
 import { create } from 'zustand'
+import type { HudData } from './domain/types'
 
 type GamePhase = 'menu' | 'playing' | 'paused' | 'victory' | 'defeat'
 
 interface SpeckWarsStore {
   phase: GamePhase
   setPhase: (phase: GamePhase) => void
+  winnerId: string | null
+  setWinnerId: (id: string) => void
+  hud: HudData | null
+  setHud: (data: HudData) => void
 }
 
 export const useSpeckWarsStore = create<SpeckWarsStore>()(set => ({
   phase: 'menu',
   setPhase: phase => set({ phase }),
+  winnerId: null,
+  setWinnerId: winnerId => set({ winnerId }),
+  hud: null,
+  setHud: hud => set({ hud }),
 }))

--- a/src/app/speck-wars/store.ts
+++ b/src/app/speck-wars/store.ts
@@ -20,6 +20,7 @@ interface SpeckWarsStore {
   cycleSpeed: () => void
   notification: { message: string; color: string } | null
   setNotification: (n: { message: string; color: string } | null) => void
+  resetGame: () => void
 }
 
 export const useSpeckWarsStore = create<SpeckWarsStore>()(set => ({
@@ -42,4 +43,13 @@ export const useSpeckWarsStore = create<SpeckWarsStore>()(set => ({
   })),
   notification: null,
   setNotification: n => set({ notification: n }),
+  resetGame: () => set(s => ({
+    phase: 'menu' as GamePhase,
+    winnerId: null,
+    hud: null,
+    elapsedMs: 0,
+    speed: 1 as 1 | 2 | 4,
+    notification: null,
+    difficulty: s.difficulty,
+  })),
 }))

--- a/src/app/speck-wars/store.ts
+++ b/src/app/speck-wars/store.ts
@@ -16,6 +16,8 @@ interface SpeckWarsStore {
   setDifficulty: (d: Difficulty) => void
   elapsedMs: number
   setElapsedMs: (ms: number) => void
+  speed: 1 | 2 | 4
+  cycleSpeed: () => void
 }
 
 export const useSpeckWarsStore = create<SpeckWarsStore>()(set => ({
@@ -32,4 +34,8 @@ export const useSpeckWarsStore = create<SpeckWarsStore>()(set => ({
   setDifficulty: difficulty => set({ difficulty }),
   elapsedMs: 0,
   setElapsedMs: elapsedMs => set({ elapsedMs }),
+  speed: 1 as 1 | 2 | 4,
+  cycleSpeed: () => set(s => ({
+    speed: s.speed === 1 ? 2 : s.speed === 2 ? 4 : 1,
+  })),
 }))

--- a/src/app/speck-wars/store.ts
+++ b/src/app/speck-wars/store.ts
@@ -9,6 +9,8 @@ interface SpeckWarsStore {
   phase: GamePhase
   setPhase: (phase: GamePhase) => void
   togglePause: () => void
+  pendingRally: { x: number; y: number } | null
+  setPendingRally: (pt: { x: number; y: number } | null) => void
   winnerId: string | null
   setWinnerId: (id: string) => void
   victoryType: 'destruction' | 'domination' | null
@@ -41,6 +43,8 @@ export const useSpeckWarsStore = create<SpeckWarsStore>()(set => ({
   togglePause: () => set(s => ({
     phase: s.phase === 'playing' ? 'paused' : s.phase === 'paused' ? 'playing' : s.phase,
   })),
+  pendingRally: null,
+  setPendingRally: pt => set({ pendingRally: pt }),
   winnerId: null,
   setWinnerId: winnerId => set({ winnerId }),
   victoryType: null,

--- a/src/app/speck-wars/store.ts
+++ b/src/app/speck-wars/store.ts
@@ -1,6 +1,6 @@
 import { create } from 'zustand'
 import type { HudData } from './domain/types'
-import { resetWinStreak } from './lib/personal-best'
+import { resetWinStreak, recordGameResult } from './lib/personal-best'
 
 type GamePhase = 'menu' | 'playing' | 'paused' | 'victory' | 'defeat'
 export type Difficulty = 'easy' | 'medium' | 'hard' | 'very-hard'
@@ -37,7 +37,7 @@ interface SpeckWarsStore {
   resetGame: () => void
 }
 
-export const useSpeckWarsStore = create<SpeckWarsStore>()(set => ({
+export const useSpeckWarsStore = create<SpeckWarsStore>()((set, get) => ({
   phase: 'menu',
   setPhase: phase => set({ phase }),
   togglePause: () => set(s => ({
@@ -77,7 +77,9 @@ export const useSpeckWarsStore = create<SpeckWarsStore>()(set => ({
   gameActions: { defend: null, advance: null, rush: null, clearRally: null },
   setGameActions: (actions) => set({ gameActions: actions ?? { defend: null, advance: null, rush: null, clearRally: null } }),
   surrender: () => {
+    const s = get()
     resetWinStreak()
+    recordGameResult(s.difficulty, false, s.elapsedMs, s.kills)
     set({ phase: 'defeat', winnerId: 'ai', victoryType: 'destruction', isNewBest: false })
   },
   resetGame: () => set(s => ({

--- a/src/app/speck-wars/store.ts
+++ b/src/app/speck-wars/store.ts
@@ -10,6 +10,8 @@ interface SpeckWarsStore {
   togglePause: () => void
   winnerId: string | null
   setWinnerId: (id: string) => void
+  victoryType: 'destruction' | 'domination' | null
+  setVictoryType: (t: 'destruction' | 'domination') => void
   hud: HudData | null
   setHud: (data: HudData) => void
   difficulty: Difficulty
@@ -39,6 +41,8 @@ export const useSpeckWarsStore = create<SpeckWarsStore>()(set => ({
   })),
   winnerId: null,
   setWinnerId: winnerId => set({ winnerId }),
+  victoryType: null,
+  setVictoryType: victoryType => set({ victoryType }),
   hud: null,
   setHud: hud => set({ hud }),
   difficulty: 'medium',
@@ -69,6 +73,7 @@ export const useSpeckWarsStore = create<SpeckWarsStore>()(set => ({
   resetGame: () => set(s => ({
     phase: 'menu' as GamePhase,
     winnerId: null,
+    victoryType: null,
     hud: null,
     elapsedMs: 0,
     speed: 1 as 1 | 2 | 4,

--- a/src/app/speck-wars/store.ts
+++ b/src/app/speck-wars/store.ts
@@ -24,6 +24,8 @@ interface SpeckWarsStore {
   losses: number
   addKill: () => void
   addLoss: () => void
+  spawnMode: 'basic' | 'heavy'
+  cycleSpawnMode: () => 'basic' | 'heavy'
   resetGame: () => void
 }
 
@@ -51,6 +53,15 @@ export const useSpeckWarsStore = create<SpeckWarsStore>()(set => ({
   losses: 0,
   addKill: () => set(s => ({ kills: s.kills + 1 })),
   addLoss: () => set(s => ({ losses: s.losses + 1 })),
+  spawnMode: 'basic' as 'basic' | 'heavy',
+  cycleSpawnMode: () => {
+    let next: 'basic' | 'heavy' = 'basic'
+    set(s => {
+      next = s.spawnMode === 'basic' ? 'heavy' : 'basic'
+      return { spawnMode: next }
+    })
+    return next
+  },
   resetGame: () => set(s => ({
     phase: 'menu' as GamePhase,
     winnerId: null,
@@ -60,6 +71,7 @@ export const useSpeckWarsStore = create<SpeckWarsStore>()(set => ({
     notification: null,
     kills: 0,
     losses: 0,
+    spawnMode: 'basic' as 'basic' | 'heavy',
     difficulty: s.difficulty,
   })),
 }))

--- a/src/app/speck-wars/store.ts
+++ b/src/app/speck-wars/store.ts
@@ -11,8 +11,8 @@ interface SpeckWarsStore {
   togglePause: () => void
   winnerId: string | null
   setWinnerId: (id: string) => void
-  victoryType: 'destruction' | 'domination' | null
-  setVictoryType: (t: 'destruction' | 'domination') => void
+  victoryType: 'destruction' | 'domination' | 'surrender' | null
+  setVictoryType: (t: 'destruction' | 'domination' | 'surrender') => void
   hud: HudData | null
   setHud: (data: HudData) => void
   difficulty: Difficulty
@@ -80,7 +80,7 @@ export const useSpeckWarsStore = create<SpeckWarsStore>()((set, get) => ({
     const s = get()
     resetWinStreak()
     recordGameResult(s.difficulty, false, s.elapsedMs, s.kills)
-    set({ phase: 'defeat', winnerId: 'ai', victoryType: 'destruction', isNewBest: false })
+    set({ phase: 'defeat', winnerId: 'ai', victoryType: 'surrender', isNewBest: false })
   },
   resetGame: () => set(s => ({
     phase: 'menu' as GamePhase,

--- a/src/app/speck-wars/store.ts
+++ b/src/app/speck-wars/store.ts
@@ -7,21 +7,29 @@ export type Difficulty = 'easy' | 'medium' | 'hard'
 interface SpeckWarsStore {
   phase: GamePhase
   setPhase: (phase: GamePhase) => void
+  togglePause: () => void
   winnerId: string | null
   setWinnerId: (id: string) => void
   hud: HudData | null
   setHud: (data: HudData) => void
   difficulty: Difficulty
   setDifficulty: (d: Difficulty) => void
+  elapsedMs: number
+  setElapsedMs: (ms: number) => void
 }
 
 export const useSpeckWarsStore = create<SpeckWarsStore>()(set => ({
   phase: 'menu',
   setPhase: phase => set({ phase }),
+  togglePause: () => set(s => ({
+    phase: s.phase === 'playing' ? 'paused' : s.phase === 'paused' ? 'playing' : s.phase,
+  })),
   winnerId: null,
   setWinnerId: winnerId => set({ winnerId }),
   hud: null,
   setHud: hud => set({ hud }),
   difficulty: 'medium',
   setDifficulty: difficulty => set({ difficulty }),
+  elapsedMs: 0,
+  setElapsedMs: elapsedMs => set({ elapsedMs }),
 }))

--- a/src/app/speck-wars/store.ts
+++ b/src/app/speck-wars/store.ts
@@ -18,6 +18,8 @@ interface SpeckWarsStore {
   setElapsedMs: (ms: number) => void
   speed: 1 | 2 | 4
   cycleSpeed: () => void
+  notification: { message: string; color: string } | null
+  setNotification: (n: { message: string; color: string } | null) => void
 }
 
 export const useSpeckWarsStore = create<SpeckWarsStore>()(set => ({
@@ -38,4 +40,6 @@ export const useSpeckWarsStore = create<SpeckWarsStore>()(set => ({
   cycleSpeed: () => set(s => ({
     speed: s.speed === 1 ? 2 : s.speed === 2 ? 4 : 1,
   })),
+  notification: null,
+  setNotification: n => set({ notification: n }),
 }))

--- a/src/app/speck-wars/store.ts
+++ b/src/app/speck-wars/store.ts
@@ -26,6 +26,8 @@ interface SpeckWarsStore {
   addLoss: () => void
   spawnMode: 'basic' | 'heavy'
   cycleSpawnMode: () => 'basic' | 'heavy'
+  isNewBest: boolean
+  setIsNewBest: (v: boolean) => void
   resetGame: () => void
 }
 
@@ -62,6 +64,8 @@ export const useSpeckWarsStore = create<SpeckWarsStore>()(set => ({
     })
     return next
   },
+  isNewBest: false,
+  setIsNewBest: v => set({ isNewBest: v }),
   resetGame: () => set(s => ({
     phase: 'menu' as GamePhase,
     winnerId: null,
@@ -72,6 +76,7 @@ export const useSpeckWarsStore = create<SpeckWarsStore>()(set => ({
     kills: 0,
     losses: 0,
     spawnMode: 'basic' as 'basic' | 'heavy',
+    isNewBest: false,
     difficulty: s.difficulty,
   })),
 }))

--- a/src/app/speck-wars/store.ts
+++ b/src/app/speck-wars/store.ts
@@ -31,6 +31,8 @@ interface SpeckWarsStore {
   cycleSpawnMode: () => 'basic' | 'heavy'
   isNewBest: boolean
   setIsNewBest: (v: boolean) => void
+  gameActions: { defend: (() => void) | null; advance: (() => void) | null; rush: (() => void) | null; clearRally: (() => void) | null }
+  setGameActions: (actions: { defend: () => void; advance: () => void; rush: () => void; clearRally: () => void } | null) => void
   surrender: () => void
   resetGame: () => void
 }
@@ -72,6 +74,8 @@ export const useSpeckWarsStore = create<SpeckWarsStore>()(set => ({
   },
   isNewBest: false,
   setIsNewBest: v => set({ isNewBest: v }),
+  gameActions: { defend: null, advance: null, rush: null, clearRally: null },
+  setGameActions: (actions) => set({ gameActions: actions ?? { defend: null, advance: null, rush: null, clearRally: null } }),
   surrender: () => {
     resetWinStreak()
     set({ phase: 'defeat', winnerId: 'ai', victoryType: 'destruction', isNewBest: false })

--- a/src/app/speck-wars/store.ts
+++ b/src/app/speck-wars/store.ts
@@ -2,7 +2,7 @@ import { create } from 'zustand'
 import type { HudData } from './domain/types'
 
 type GamePhase = 'menu' | 'playing' | 'paused' | 'victory' | 'defeat'
-export type Difficulty = 'easy' | 'medium' | 'hard'
+export type Difficulty = 'easy' | 'medium' | 'hard' | 'very-hard'
 
 interface SpeckWarsStore {
   phase: GamePhase


### PR DESCRIPTION
## Summary

Lands the complete Speck Wars MVP built by the auto loop (137 commits, 30 PRs chained across feature branches).

### What's included

**Core game engine**
- Full simulation loop: spawner, speck AI, movement with separation, spatial grid, combat resolution, death + SOA compaction
- PixiJS WebGL renderer: ParticleContainer speck layer (one draw call per player), building layer, effects layer
- Camera: drag to pan, scroll/pinch to zoom, edge scrolling, C to recenter, world bounds clamp
- Pre-allocated SOA buffer with free-list — eliminates Float32Array churn at high speck counts

**Game systems**
- Neutral capturable outposts (3 mid-map, each spawns specks for owner)
- Heavy speck type — tanks with more HP/damage, spawned from outposts
- Domination victory — hold all 3 outposts for 60s
- Destruction victory — destroy enemy base
- Difficulty selector: Easy / Medium / Hard / Brutal
- Daily seeds — same map layout for all players each day
- 1×/2×/4× game speed control
- Spawn mode toggle (H) — switch base between basic and heavy production
- Triple outpost bonus — holding all 3 doubles spawn rate

**AI**
- AI targets outposts strategically
- Hard/Brutal: pressure waves + counter-spawn behavior + responds to player domination
- Adaptive AI speeds up when player dominates 3:1 for 30s

**HUD & UI**
- Live speck counts, base HP bars (top edge), outpost ownership (N/3)
- Minimap (130px, bottom-right) — shows specks, buildings, rally point; clickable to rally
- Kill counter, game timer, PB delta (ahead/behind personal best)
- Battle status badge (DOMINATING/WINNING/LOSING/CRITICAL)
- Morale + rage mode badges
- Domination progress bar
- Capture progress bars on outpost dots
- Menu: difficulty selector, win rates per difficulty, win streak, personal bests
- Pause screen: surrender, production rate stats

**Visual effects**
- Ambient starfield + deep-space CSS background
- World grid + border
- Death particle bursts (5-fleck)
- Attack pulse (1.3× scale on strike)
- Motion trails on fast specks
- Critical HP outline on heavy specks
- Base pulse ring
- Combat zone haze at battle locations
- Screen shake on base damage + game-over
- Spawn flash (gold ring on production)
- Capture ripple (3 expanding rings)
- Building damage flash
- Destruction burst on building death
- Winning vignette
- Dual HP bars at top edge

**Notifications**
- FIRST BLOOD, kill milestones (10/25/50/100)
- Base under attack, enemy base critical
- Outpost captured/lost/under attack/recaptured
- Triple outpost ownership changes
- AI switches to heavy production
- Domination countdown (10s, 5s)
- Comeback victory, battle start flash

**Keyboard shortcuts**
- Space/R — rally to rally point
- D — defend (rally to base)
- A — advance (rally to nearest non-player outpost)
- B — rally to enemy base
- H — toggle spawn mode
- C — recenter camera
- ? — help overlay
- Enter/Space — start game / replay from end screen

**Mobile**
- Pinch-to-zoom
- Touch-to-rally
- Mobile action buttons (D/A/B/R)

**Meta**
- Personal best per difficulty
- Win streak + flame badge
- Game history (last 5 results)
- Star rating (1-3 stars based on HP preserved)
- Share button on end screen
- Daily challenge checkmarks on menu
- Auto-pause on tab blur
- Tutorial hints for first-time players

## Test plan
- [ ] `/speck-wars` loads, menu shows
- [ ] Can play a full game to victory/defeat on each difficulty
- [ ] Camera pan/zoom works
- [ ] Minimap clickable
- [ ] No regressions to other CometCave games

🤖 Generated with [Claude Code](https://claude.com/claude-code)