### PR TITLE
fix: Speck Wars rally commands — specks now obey player rally point

### DIFF
--- a/src/app/speck-wars/domain/simulation/speck-ai.ts
+++ b/src/app/speck-wars/domain/simulation/speck-ai.ts
@@ -1,6 +1,8 @@
 import type { SimulationState } from '../types'
 import { SPECK_TYPES } from '../config/speck-types'
 
+const RALLY_ARRIVAL_THRESHOLD = 30 // px — how close before speck is considered "arrived"
+
 export function runSpeckAI(sim: SimulationState) {
   const { speckIds, speckX, speckY, speckMeta, buildings } = sim
 
@@ -14,6 +16,19 @@ export function runSpeckAI(sim: SimulationState) {
     // Clear dead or invalid targets
     if (meta.targetId && !buildings[meta.targetId]) {
       meta.targetId = null
+    }
+
+    // If owner has an active rally point and speck hasn't arrived, defer to rally
+    const rally = sim.rallyPoints[meta.ownerId]
+    if (rally) {
+      const dx = rally.x - speckX[i]
+      const dy = rally.y - speckY[i]
+      const dist = Math.sqrt(dx * dx + dy * dy)
+      if (dist > RALLY_ARRIVAL_THRESHOLD) {
+        meta.targetId = null  // clear any target — movement.ts will seek rally
+        meta.state = 'moving'
+        continue
+      }
     }
 
     if (meta.targetId) continue  // already has a valid target


### PR DESCRIPTION
## Summary
- Fixes #1945
- Specks now move to the player's rally point instead of auto-targeting the nearest enemy building
- When a rally point is active and a speck hasn't arrived yet (>30px away), auto-targeting is skipped and the speck moves toward the rally point instead
- Once specks arrive at the rally point, they resume normal auto-targeting behavior

## Root Cause
`speck-ai.ts` always assigned `targetId` to the nearest enemy building. `movement.ts` only uses the rally point when `meta.targetId` is null. So specks never moved to the rally point.

## Fix
Check for an active rally point before auto-targeting in `speck-ai.ts`. If the speck hasn't arrived at the rally point, clear `targetId` so `movement.ts` can use the rally branch.

## Test Plan
- [ ] Set a rally point by clicking — specks should move there
- [ ] Once specks reach the rally point, they should auto-attack nearby enemies
- [ ] Right-click or press R to clear rally — specks should resume normal auto-attack
- [ ] No rally point set — behavior unchanged (specks auto-target nearest enemy building)

🤖 Generated with [Claude Code](https://claude.com/claude-code)