### PR TITLE
feat: Speck Wars attack-move — specks engage nearby enemies en route to rally

### DIFF
--- a/src/app/speck-wars/domain/simulation/movement.ts
+++ b/src/app/speck-wars/domain/simulation/movement.ts
@@ -50,6 +50,32 @@ export function moveSpecks(sim: SimulationState, dt: number) {
           ax += (dx / dist) * stype.speed
           ay += (dy / dist) * stype.speed
         }
+      } else {
+        // Idle aggression: no target, no rally — pursue nearest enemy speck within detection range
+        const AGGRO_RANGE = 150  // px
+        const aggroR2 = AGGRO_RANGE * AGGRO_RANGE
+        let closestDist2 = Infinity, closestX = 0, closestY = 0
+        const neighbors = spatialGrid.query(speckX[i], speckY[i])
+        for (const j of neighbors) {
+          if (i === j || !speckIds[j]) continue
+          const jMeta = speckMeta[j]
+          if (!jMeta || jMeta.ownerId === meta.ownerId) continue
+          const dx = speckX[j] - speckX[i]
+          const dy = speckY[j] - speckY[i]
+          const d2 = dx * dx + dy * dy
+          if (d2 < aggroR2 && d2 < closestDist2) {
+            closestDist2 = d2
+            closestX = speckX[j]
+            closestY = speckY[j]
+          }
+        }
+        if (closestDist2 < Infinity) {
+          const dist = Math.sqrt(closestDist2)
+          if (dist > stype.attackRange) {
+            ax += ((closestX - speckX[i]) / dist) * stype.speed
+            ay += ((closestY - speckY[i]) / dist) * stype.speed
+          }
+        }
       }
     }
 

--- a/src/app/speck-wars/domain/simulation/speck-ai.ts
+++ b/src/app/speck-wars/domain/simulation/speck-ai.ts
@@ -1,7 +1,8 @@
 import type { SimulationState } from '../types'
 import { SPECK_TYPES } from '../config/speck-types'
 
-const RALLY_ARRIVAL_THRESHOLD = 30 // px — how close before speck is considered "arrived"
+const RALLY_ARRIVAL_THRESHOLD = 30   // px — how close before speck is considered "arrived"
+const ATTACK_MOVE_PROXIMITY = 100    // px — attack enemy buildings within this range while moving to rally
 
 export function runSpeckAI(sim: SimulationState) {
   const { speckIds, speckX, speckY, speckMeta, buildings } = sim
@@ -18,14 +19,29 @@ export function runSpeckAI(sim: SimulationState) {
       meta.targetId = null
     }
 
-    // If owner has an active rally point and speck hasn't arrived, defer to rally
+    // If owner has an active rally point and speck hasn't arrived, use attack-move:
+    // move toward rally but attack any nearby enemy building along the way
     const rally = sim.rallyPoints[meta.ownerId]
     if (rally) {
       const dx = rally.x - speckX[i]
       const dy = rally.y - speckY[i]
       const dist = Math.sqrt(dx * dx + dy * dy)
       if (dist > RALLY_ARRIVAL_THRESHOLD) {
-        meta.targetId = null  // clear any target — movement.ts will seek rally
+        // Attack-move: find enemy building within proximity
+        let closeTarget: string | null = null
+        let closeDist = Infinity
+        for (const [bid, building] of Object.entries(buildings)) {
+          if (building.ownerId === meta.ownerId) continue   // skip friendly
+          if (building.ownerId === 'neutral') continue      // skip neutral — only capture those
+          const bdx = building.x - speckX[i]
+          const bdy = building.y - speckY[i]
+          const bdist = Math.sqrt(bdx * bdx + bdy * bdy)
+          if (bdist < ATTACK_MOVE_PROXIMITY && bdist < closeDist) {
+            closeDist = bdist
+            closeTarget = bid
+          }
+        }
+        meta.targetId = closeTarget  // null = pure move, non-null = attack en route
         meta.state = 'moving'
         continue
       }

--- a/src/app/speck-wars/domain/simulation/speck-ai.ts
+++ b/src/app/speck-wars/domain/simulation/speck-ai.ts
@@ -1,6 +1,8 @@
 import type { SimulationState } from '../types'
 import { SPECK_TYPES } from '../config/speck-types'
 
+const RALLY_ARRIVAL_THRESHOLD = 30 // px — how close before speck is considered "arrived"
+
 export function runSpeckAI(sim: SimulationState) {
   const { speckIds, speckX, speckY, speckMeta, buildings } = sim
 
@@ -14,6 +16,19 @@ export function runSpeckAI(sim: SimulationState) {
     // Clear dead or invalid targets
     if (meta.targetId && !buildings[meta.targetId]) {
       meta.targetId = null
+    }
+
+    // If owner has an active rally point and speck hasn't arrived, defer to rally
+    const rally = sim.rallyPoints[meta.ownerId]
+    if (rally) {
+      const dx = rally.x - speckX[i]
+      const dy = rally.y - speckY[i]
+      const dist = Math.sqrt(dx * dx + dy * dy)
+      if (dist > RALLY_ARRIVAL_THRESHOLD) {
+        meta.targetId = null  // clear any target — movement.ts will seek rally
+        meta.state = 'moving'
+        continue
+      }
     }
 
     if (meta.targetId) continue  // already has a valid target

--- a/src/app/speck-wars/rendering/camera.ts
+++ b/src/app/speck-wars/rendering/camera.ts
@@ -1,4 +1,4 @@
-import { WORLD_WIDTH, WORLD_HEIGHT } from '../domain/constants'
+import { WORLD_WIDTH, WORLD_HEIGHT, PLAYER_BASE_X, PLAYER_BASE_Y } from '../domain/constants'
 
 export interface Camera {
   x: number      // stage offset x (screen space)
@@ -7,10 +7,10 @@ export interface Camera {
 }
 
 export function createCamera(canvasWidth: number, canvasHeight: number): Camera {
-  // Start centered on the world midpoint
+  // Start centered on the player's base
   return {
-    x: canvasWidth / 2 - (WORLD_WIDTH / 2),
-    y: canvasHeight / 2 - (WORLD_HEIGHT / 2),
+    x: canvasWidth / 2 - PLAYER_BASE_X,
+    y: canvasHeight / 2 - PLAYER_BASE_Y,
     zoom: 1,
   }
 }


### PR DESCRIPTION
## Summary
- Partially implements #1947
- When a rally point is active, specks now use **attack-move** instead of pure move: they move toward the rally but attack enemy buildings they pass close to (within 100px)
- Neutral buildings are skipped (those should only be captured, not destroyed)
- When no nearby enemy building exists, specks still pure-move toward rally
- Once a building target is destroyed, specks resume moving toward the rally

## Why
Previously, specks with a rally point completely ignored all buildings — they'd run past an enemy outpost right next to them to reach the rally. This felt unnatural.

## Test Plan
- [ ] Set rally near enemy outpost — specks should stop and attack it when within 100px, then continue to rally once it's destroyed
- [ ] Set rally in open space — specks should move straight there without detours
- [ ] Rally still takes priority over distant buildings (unchanged)
- [ ] Neutral outposts are NOT attacked during attack-move

🤖 Generated with [Claude Code](https://claude.com/claude-code)