### PR TITLE
feat: Speck Wars attack-move — specks engage nearby enemies en route to rally

### DIFF
--- a/src/app/speck-wars/domain/simulation/speck-ai.ts
+++ b/src/app/speck-wars/domain/simulation/speck-ai.ts
@@ -1,7 +1,8 @@
 import type { SimulationState } from '../types'
 import { SPECK_TYPES } from '../config/speck-types'
 
-const RALLY_ARRIVAL_THRESHOLD = 30 // px — how close before speck is considered "arrived"
+const RALLY_ARRIVAL_THRESHOLD = 30   // px — how close before speck is considered "arrived"
+const ATTACK_MOVE_PROXIMITY = 100    // px — attack enemy buildings within this range while moving to rally
 
 export function runSpeckAI(sim: SimulationState) {
   const { speckIds, speckX, speckY, speckMeta, buildings } = sim
@@ -25,7 +26,21 @@ export function runSpeckAI(sim: SimulationState) {
       const dy = rally.y - speckY[i]
       const dist = Math.sqrt(dx * dx + dy * dy)
       if (dist > RALLY_ARRIVAL_THRESHOLD) {
-        meta.targetId = null  // clear any target — movement.ts will seek rally
+        // Attack-move: find enemy building within proximity rather than pure move
+        let closeTarget: string | null = null
+        let closeDist = Infinity
+        for (const [bid, building] of Object.entries(buildings)) {
+          if (building.ownerId === meta.ownerId) continue   // skip friendly
+          if (building.ownerId === 'neutral') continue      // skip neutral — only capture those
+          const bdx = building.x - speckX[i]
+          const bdy = building.y - speckY[i]
+          const bdist = Math.sqrt(bdx * bdx + bdy * bdy)
+          if (bdist < ATTACK_MOVE_PROXIMITY && bdist < closeDist) {
+            closeDist = bdist
+            closeTarget = bid
+          }
+        }
+        meta.targetId = closeTarget  // null = pure move toward rally, non-null = attack en route
         meta.state = 'moving'
         continue
       }


### PR DESCRIPTION
## Summary
- Partially implements #1947
- When a rally point is active, specks now use **attack-move** instead of pure move: they move toward the rally but attack enemy buildings they pass close to (within 100px)
- Neutral buildings are skipped (those should only be captured, not destroyed)
- When no nearby enemy building exists, specks still pure-move toward rally
- Once a building target is destroyed or the speck moves past it, movement toward rally resumes

## Why
Previously, specks with a rally point completely ignored all buildings — they'd run past an enemy outpost right next to them to reach the rally. This felt unnatural and broke strategic intent.

## Supersedes
Replaces #1953 (which had a merge conflict due to concurrent changes to speck-ai.ts).

## Test Plan
- [ ] Set rally near enemy outpost — specks should stop and attack it when within 100px, then continue to rally once destroyed
- [ ] Set rally in open space — specks should move straight there without detours
- [ ] Rally still takes priority over distant buildings (unchanged)
- [ ] Neutral outposts are NOT attacked during attack-move

🤖 Generated with [Claude Code](https://claude.com/claude-code)