### PR TITLE
rebalance: Speck Wars outpost spawn rate 1800→1200ms

### DIFF
--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -511,7 +511,7 @@ export function HUD() {
             }
             // Production rate estimate
             const BASE_MS = spawnMode === 'heavy' ? 1800 : 800
-            const OUTPOST_MS = 1800
+            const OUTPOST_MS = 1200
             const playerTriple = hud.tripleOutpostOwner === 'player'
             const aiOutpostCount = Math.max(0, (hud.players.ai?.buildingCount ?? 0) - 1)
             const aiTriple = hud.tripleOutpostOwner === 'ai'

--- a/src/app/speck-wars/domain/config/building-types.ts
+++ b/src/app/speck-wars/domain/config/building-types.ts
@@ -19,7 +19,7 @@ export const BUILDING_TYPES: Record<string, BuildingTypeDefinition> = {
     id: 'outpost', name: 'Outpost',
     maxHp: 50, size: 20,
     spawnTypeId: 'heavy',
-    spawnInterval: 1800, spawnCount: 1,
+    spawnInterval: 1200, spawnCount: 1,
     hpRegen: 2,  // 2 HP/sec when not under attack
   },
 }

--- a/src/app/speck-wars/domain/constants.ts
+++ b/src/app/speck-wars/domain/constants.ts
@@ -15,7 +15,7 @@ export const AI_COLOR = 0xff4f7b
 export const MAX_SPECKS = 15000
 
 export const OUTPOST_SIZE = 20
-export const OUTPOST_SPAWN_INTERVAL = 1800   // ms per speck (slower than base)
+export const OUTPOST_SPAWN_INTERVAL = 1200   // ms per speck — fast enough to make outpost control strategically decisive
 export const CAPTURE_RADIUS = 100            // px — specks within this distance count toward capture
 export const CAPTURE_TIME = 5000             // ms to fully capture
 export const NEUTRAL_COLOR = 0x888888


### PR DESCRIPTION
## Summary
- Fixes #1956
- Reduces outpost spawn interval from 1800ms → 1200ms (50% faster production)
- Each outpost now produces ~0.83 specks/sec vs 0.56/sec before (vs base at 1.25/sec)
- Outpost control now provides decisive production advantage

## Before vs After (production per second)

| Situation | Before | After |
|---|---|---|
| Base only | 1.25/s | 1.25/s |
| Base + 1 outpost | 1.81/s | 2.08/s |
| Base + 2 outposts | 2.36/s | 2.92/s |
| Base + 3 outposts | 2.92/s | 3.75/s |
| Triple bonus (3 outposts × 2) | 5.83/s | 7.50/s |

**vs. enemy with base only (1.25/s):** triple control is now 6× more productive rather than 4.7×.

## Why this makes outposts "necessary"
- Previously each outpost added ~0.56/s — roughly 45% of a base. Easy to ignore.
- Now each outpost adds ~0.83/s — roughly 67% of a base. Winning 2 outposts nearly doubles your production.
- The 3× outpost swing (3 vs 0) creates a 3:1 production advantage — game-deciding.

## Files changed
- `domain/constants.ts`: `OUTPOST_SPAWN_INTERVAL` 1800 → 1200 (reference constant)
- `domain/config/building-types.ts`: `outpost.spawnInterval` 1800 → 1200 (actual runtime value)
- `components/hud.tsx`: `OUTPOST_MS` 1800 → 1200 (pause overlay production estimate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)