### PR TITLE
feat: Speck Wars — 3 map layouts for daily replay variety

### DIFF
--- a/src/app/speck-wars/domain/constants.ts
+++ b/src/app/speck-wars/domain/constants.ts
@@ -22,9 +22,27 @@ export const NEUTRAL_COLOR = 0x888888
 export const OUTPOST_AURA_RADIUS = 160  // px — specks within this radius of a friendly outpost move faster
 export const DOMINATION_TIME = 60000   // ms — hold all 3 outposts this long to win by domination
 
-// Triangle around center (1500, 1500), equidistant between the two bases
-export const OUTPOST_POSITIONS = [
-  { id: 'outpost-top',   x: 1500, y: 700  },
-  { id: 'outpost-left',  x: 850,  y: 2200 },
-  { id: 'outpost-right', x: 2150, y: 2200 },
+// Three map layouts — one is picked per game using the daily seed.
+// All layouts use the same outpost IDs so the rest of the codebase is layout-agnostic.
+export const MAP_LAYOUTS = [
+  // Layout 0 — Triangle: top-center sentinel + two base-side flanks
+  [
+    { id: 'outpost-top',   x: 1500, y: 700  },
+    { id: 'outpost-left',  x: 850,  y: 2200 },
+    { id: 'outpost-right', x: 2150, y: 2200 },
+  ],
+  // Layout 1 — Corridor: diagonal lane from player corner to AI corner
+  [
+    { id: 'outpost-top',   x: 1050, y: 1100 },
+    { id: 'outpost-left',  x: 1500, y: 1500 },
+    { id: 'outpost-right', x: 1950, y: 1900 },
+  ],
+  // Layout 2 — Wings: horizontal spread, forces split attention
+  [
+    { id: 'outpost-top',   x: 1500, y: 950  },
+    { id: 'outpost-left',  x: 950,  y: 1500 },
+    { id: 'outpost-right', x: 2050, y: 1500 },
+  ],
 ] as const
+
+export const OUTPOST_POSITIONS = MAP_LAYOUTS[0]  // default — overridden by createSim seed

--- a/src/app/speck-wars/domain/simulation/create-sim.ts
+++ b/src/app/speck-wars/domain/simulation/create-sim.ts
@@ -1,5 +1,5 @@
 import type { SimulationState, Player, BuildingEntity } from '../types'
-import { PLAYER_BASE_X, PLAYER_BASE_Y, AI_BASE_X, AI_BASE_Y, PLAYER_COLOR, AI_COLOR, BASE_HP, MAX_SPECKS, NEUTRAL_COLOR, OUTPOST_POSITIONS } from '../constants'
+import { PLAYER_BASE_X, PLAYER_BASE_Y, AI_BASE_X, AI_BASE_Y, PLAYER_COLOR, AI_COLOR, BASE_HP, MAX_SPECKS, NEUTRAL_COLOR, MAP_LAYOUTS } from '../constants'
 import { SpatialGrid } from './spatial-grid'
 import { mulberry32 } from './prng'
 import type { Difficulty } from '../../store'
@@ -53,10 +53,13 @@ export function createSim(seed: number = Date.now(), difficulty: Difficulty = 'm
     color: NEUTRAL_COLOR, isAI: false, isDefeated: false, stockpile: {},
   }
 
-  const JITTER = 200  // ± px of positional variation per game
+  const JITTER = 150  // ± px of positional variation per game
   const rng = mulberry32(seed)  // seeded so same date+difficulty = same map
+  // Pick layout using first RNG call so same seed = same layout + same jitter
+  const layoutIndex = Math.floor(rng() * MAP_LAYOUTS.length)
+  const outpostPositions = MAP_LAYOUTS[layoutIndex]
   const outpostBuildings: Record<string, BuildingEntity> = {}
-  for (const pos of OUTPOST_POSITIONS) {
+  for (const pos of outpostPositions) {
     const jx = (rng() * 2 - 1) * JITTER
     const jy = (rng() * 2 - 1) * JITTER
     outpostBuildings[pos.id] = {


### PR DESCRIPTION
Closes #1958

## Summary
- Adds two new outpost map layouts alongside the existing Triangle
- Daily seed picks which layout to play — same date+difficulty = same map for everyone
- No changes to any other systems: AI, rendering, HUD, and capture logic are all layout-agnostic

## Layouts

| # | Name | Outpost positions | Strategic feel |
|---|------|-------------------|----------------|
| 0 | **Triangle** | Top-center + 2 bottom corners | Existing layout — asymmetric pressure |
| 1 | **Corridor** | Diagonal NW→SE line | Race for nearest outpost; center is the key contest |
| 2 | **Wings** | Top-center + left-mid + right-mid | Horizontal spread; forces split attention |

## Implementation
- `constants.ts`: `OUTPOST_POSITIONS` → `MAP_LAYOUTS` (3-element array of position sets); `OUTPOST_POSITIONS` kept as alias to `MAP_LAYOUTS[0]` for backward compat
- `create-sim.ts`: first seeded RNG call picks `layoutIndex`; subsequent calls apply ±150px jitter (reduced from 200 to keep corridor outposts well-spaced)

## Test plan
- [ ] Play a game — outposts appear in a valid position, game runs normally
- [ ] Restart several times — different seeds yield different layouts
- [ ] Same date+difficulty consistently produces the same layout (verify determinism)
- [ ] All three win conditions (destruction, domination, surrender) still function

🤖 Generated with [Claude Code](https://claude.com/claude-code)