### PR TITLE
feat: Speck Wars — Surge ability (Q, 2× production for 8s/45s CD)

### DIFF
--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -265,6 +265,7 @@ export function HUD() {
             <span>Drag — pan camera</span><span>H — heavy/basic mode</span>
             <span>A — advance to outpost</span><span>C — center on base</span>
             <span>B — rush enemy base</span><span>D — defend base</span>
+            <span>Q — surge (2× spawn 8s)</span><span>Shift+drag — select specks</span>
             <span>Minimap — click to rally</span><span>? — this help</span>
           </div>
         </div>
@@ -622,6 +623,40 @@ export function HUD() {
           >
             ⚡ B
           </button>
+          {(() => {
+            const surgeActive = (hud?.surgeDuration ?? 0) > 0
+            const surgeCd = hud?.surgeCooldown ?? 0
+            const surgeReady = !surgeActive && surgeCd <= 0
+            return (
+              <button
+                onClick={() => { if (surgeReady) gameActions.surge?.() }}
+                title="[Q] Surge — 2× production for 8s (45s cooldown)"
+                style={{
+                  padding: '6px 10px',
+                  fontSize: 11,
+                  cursor: surgeReady ? 'pointer' : 'default',
+                  background: surgeActive ? 'rgba(255,215,0,0.25)' : 'rgba(255,215,0,0.06)',
+                  border: surgeActive
+                    ? '1px solid rgba(255,215,0,0.9)'
+                    : surgeReady
+                      ? '1px solid rgba(255,215,0,0.4)'
+                      : '1px solid rgba(255,215,0,0.15)',
+                  borderRadius: 20,
+                  color: surgeActive ? '#ffd700' : surgeReady ? '#c8a800' : 'rgba(200,168,0,0.4)',
+                  letterSpacing: 1,
+                  minHeight: 44,
+                  fontFamily: 'monospace',
+                  opacity: surgeReady || surgeActive ? 1 : 0.6,
+                }}
+              >
+                {surgeActive
+                  ? `★ ${Math.ceil((hud?.surgeDuration ?? 0) / 1000)}s`
+                  : surgeCd > 0
+                    ? `Q ${Math.ceil(surgeCd / 1000)}s`
+                    : '★ Q'}
+              </button>
+            )
+          })()}
           <button
             onClick={() => gameActions.clearRally?.()}
             title="[R] Clear rally"

--- a/src/app/speck-wars/domain/simulation/create-sim.ts
+++ b/src/app/speck-wars/domain/simulation/create-sim.ts
@@ -90,5 +90,7 @@ export function createSim(seed: number = Date.now(), difficulty: Difficulty = 'm
     selectedSpeckIds: new Set<string>(),
     spatialGrid: new SpatialGrid(),
     dominationTimer: 0,
+    surgeDuration: 0,
+    surgeCooldown: 0,
   }
 }

--- a/src/app/speck-wars/domain/simulation/spawner.ts
+++ b/src/app/speck-wars/domain/simulation/spawner.ts
@@ -41,7 +41,9 @@ export function updateSpawners(sim: SimulationState, dt: number) {
     if (building.spawnTimer > 0) continue
 
     const baseInterval = building.spawnIntervalOverride ?? btype.spawnInterval
-    building.spawnTimer = building.tripleOutpostBonus ? baseInterval / 2 : baseInterval
+    const hasSurge = building.ownerId === 'player' && sim.surgeDuration > 0
+    const divisor = (building.tripleOutpostBonus ? 2 : 1) * (hasSurge ? 2 : 1)
+    building.spawnTimer = baseInterval / divisor
 
     for (let i = 0; i < btype.spawnCount; i++) {
       // Spawn just outside the building radius with slight random offset

--- a/src/app/speck-wars/domain/simulation/tick.ts
+++ b/src/app/speck-wars/domain/simulation/tick.ts
@@ -39,6 +39,10 @@ export function tick(sim: SimulationState, dt: number): SimulationState {
   // 7c. Triple outpost bonus — control all 3 outposts = 2× base spawn speed + domination timer
   updateTripleOutpostBonus(sim, dt)
 
+  // 7d. Surge timers
+  if (sim.surgeDuration > 0) sim.surgeDuration = Math.max(0, sim.surgeDuration - dt)
+  if (sim.surgeCooldown > 0) sim.surgeCooldown = Math.max(0, sim.surgeCooldown - dt)
+
   // 8. Check win/loss
   checkVictory(sim)
 
@@ -127,6 +131,12 @@ function consumeInputs(sim: SimulationState) {
       sim.selectedSpeckIds.clear()
       sim.rallyPoints['player-selected'] = null
     }
+    if (event.type === 'SURGE') {
+      if (event.ownerId === 'player' && sim.surgeCooldown <= 0) {
+        sim.surgeDuration = 8000
+        sim.surgeCooldown = 45000
+      }
+    }
   }
   sim.inputQueue = []
 }
@@ -176,5 +186,5 @@ function emitHudUpdate(sim: SimulationState) {
       : null
   }
 
-  sim.events.push({ type: 'HUD_UPDATE', data: { players: data, attackedBuildingIds, tripleOutpostOwner, dominationProgress, captureInfo } })
+  sim.events.push({ type: 'HUD_UPDATE', data: { players: data, attackedBuildingIds, tripleOutpostOwner, dominationProgress, captureInfo, surgeDuration: sim.surgeDuration, surgeCooldown: sim.surgeCooldown } })
 }

--- a/src/app/speck-wars/domain/types.ts
+++ b/src/app/speck-wars/domain/types.ts
@@ -57,6 +57,8 @@ export interface SimulationState {
   selectedSpeckIds: Set<string>  // IDs of player specks currently in selection
   spatialGrid: SpatialGrid
   dominationTimer: number    // ms of continuous triple-outpost control; resets on loss
+  surgeDuration: number      // ms remaining in active surge, 0 = inactive
+  surgeCooldown: number      // ms remaining before surge can be used again, 0 = ready
 }
 
 export type InputEvent =
@@ -66,6 +68,7 @@ export type InputEvent =
   | { type: 'SACRIFICE'; ownerId: string; buildingId: string; typeId: string; count: number }
   | { type: 'BOX_SELECT'; ownerId: string; x1: number; y1: number; x2: number; y2: number }
   | { type: 'CLEAR_SELECT'; ownerId: string }
+  | { type: 'SURGE'; ownerId: string }
 
 export type SimEvent =
   | { type: 'SPECK_DIED'; speckId: string; x: number; y: number; killedOwnerId: string; killerOwnerId: string }
@@ -87,4 +90,6 @@ export interface HudData {
   tripleOutpostOwner: string | null  // player ID who owns all 3 outposts, or null
   dominationProgress: number | null  // 0..1 fraction of DOMINATION_TIME elapsed; null if no triple holder
   captureInfo: Record<string, { progress: number; side: string } | null>  // outpostId → active capture
+  surgeDuration: number    // ms remaining in active surge
+  surgeCooldown: number    // ms remaining before surge can be used again
 }

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -96,12 +96,14 @@ export class GameInstance {
         this.sim.inputQueue.push({ type: 'CLEAR_SELECT', ownerId: 'player' })
         this.sim.rallyPoints['player-selected'] = null
       },
+      () => { this.surge(); this.notify('⚡ SURGE ACTIVE!', '#ffd700') },  // Q — production surge
     )
     useSpeckWarsStore.getState().setGameActions({
       defend: () => { this.defend(); this.notify('🛡 DEFEND', '#4af7c4') },
       advance: () => { this.advance(); this.notify('→ ADVANCE', '#ffd700') },
       rush: () => { this.rush(); this.notify('⚡ RUSH!', '#ff4f7b') },
       clearRally: () => this.clearRally(),
+      surge: () => { this.surge(); this.notify('⚡ SURGE ACTIVE!', '#ffd700') },
     })
     this.lastTime = performance.now()
     this.loop(this.lastTime)
@@ -435,6 +437,10 @@ export class GameInstance {
 
   clearRally() {
     this.sim.rallyPoints['player'] = null
+  }
+
+  surge() {
+    this.sim.inputQueue.push({ type: 'SURGE', ownerId: 'player' })
   }
 
   private notify(message: string, color: string) {

--- a/src/app/speck-wars/input/input-handler.ts
+++ b/src/app/speck-wars/input/input-handler.ts
@@ -14,6 +14,7 @@ export class InputHandler {
   private onRush?: () => void
   private onBoxSelect?: (x1: number, y1: number, x2: number, y2: number) => void
   private onClearSelect?: () => void
+  private onSurge?: () => void
   private isDragging = false
   private lastX = 0
   private lastY = 0
@@ -41,6 +42,7 @@ export class InputHandler {
     onRush?: () => void,
     onBoxSelect?: (x1: number, y1: number, x2: number, y2: number) => void,
     onClearSelect?: () => void,
+    onSurge?: () => void,
   ) {
     this.canvas = canvas
     this.camera = camera
@@ -54,6 +56,7 @@ export class InputHandler {
     this.onRush = onRush
     this.onBoxSelect = onBoxSelect
     this.onClearSelect = onClearSelect
+    this.onSurge = onSurge
     this.attach()
   }
 
@@ -239,6 +242,8 @@ export class InputHandler {
       this.onAdvance?.()
     } else if (e.code === 'KeyB') {
       this.onRush?.()
+    } else if (e.code === 'KeyQ') {
+      this.onSurge?.()
     }
   }
 

--- a/src/app/speck-wars/store.ts
+++ b/src/app/speck-wars/store.ts
@@ -31,8 +31,8 @@ interface SpeckWarsStore {
   cycleSpawnMode: () => 'basic' | 'heavy'
   isNewBest: boolean
   setIsNewBest: (v: boolean) => void
-  gameActions: { defend: (() => void) | null; advance: (() => void) | null; rush: (() => void) | null; clearRally: (() => void) | null }
-  setGameActions: (actions: { defend: () => void; advance: () => void; rush: () => void; clearRally: () => void } | null) => void
+  gameActions: { defend: (() => void) | null; advance: (() => void) | null; rush: (() => void) | null; clearRally: (() => void) | null; surge: (() => void) | null }
+  setGameActions: (actions: { defend: () => void; advance: () => void; rush: () => void; clearRally: () => void; surge: () => void } | null) => void
   surrender: () => void
   resetGame: () => void
 }
@@ -74,8 +74,8 @@ export const useSpeckWarsStore = create<SpeckWarsStore>()((set, get) => ({
   },
   isNewBest: false,
   setIsNewBest: v => set({ isNewBest: v }),
-  gameActions: { defend: null, advance: null, rush: null, clearRally: null },
-  setGameActions: (actions) => set({ gameActions: actions ?? { defend: null, advance: null, rush: null, clearRally: null } }),
+  gameActions: { defend: null, advance: null, rush: null, clearRally: null, surge: null },
+  setGameActions: (actions) => set({ gameActions: actions ?? { defend: null, advance: null, rush: null, clearRally: null, surge: null } }),
   surrender: () => {
     const s = get()
     resetWinStreak()


### PR DESCRIPTION
Closes #1960

## Summary
- Adds a Surge ability to Speck Wars: Q key instantly doubles all friendly building spawn rates for 8 seconds
- 45-second cooldown; stacks with triple-outpost bonus (4× total)
- HUD button shows live countdown during surge and cooldown
- Available on keyboard (Q) and mobile button bar

## Files changed

| File | Change |
|------|--------|
| `domain/types.ts` | Added `surgeDuration/surgeCooldown` to `SimulationState` and `HudData`; `SURGE` to `InputEvent` |
| `domain/simulation/create-sim.ts` | Initialized surge fields to 0 |
| `domain/simulation/tick.ts` | Handles `SURGE` input event; decays timers each tick; includes surge state in HUD_UPDATE |
| `domain/simulation/spawner.ts` | Applies 2× divisor to spawn interval when surge is active |
| `input/input-handler.ts` | Added `onSurge` callback; Q key fires it |
| `game-instance.ts` | Added `surge()` method; registered Q callback; wired into `setGameActions` |
| `store.ts` | Added `surge` to `gameActions` interface |
| `components/hud.tsx` | Added surge button with live countdown; Q entry in help overlay |

## Test plan
- [ ] Press Q during gameplay — buildings spawn noticeably faster
- [ ] Surge expires after ~8 seconds
- [ ] Q is blocked during cooldown; button shows remaining seconds
- [ ] Mobile surge button works
- [ ] Surge + triple-outpost bonus stacks (4× rate)
- [ ] Help overlay shows Q entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)