### PR TITLE
feat: Speck Wars — veteran specks (gold ring + 20% damage at 3 kills)

### DIFF
--- a/src/app/speck-wars/domain/simulation/combat.ts
+++ b/src/app/speck-wars/domain/simulation/combat.ts
@@ -55,10 +55,12 @@ export function resolveCombat(sim: SimulationState, dt: number) {
       const dy = speckY[j] - speckY[i]
       const dist = Math.sqrt(dx * dx + dy * dy)
       if (dist <= stype.attackRange) {
-        speckHp[j] -= stype.damage * moraleMult(meta.ownerId)
+        const veteranBonus = meta.kills >= 3 ? 1.20 : 1.0  // veterans deal +20% damage
+        speckHp[j] -= stype.damage * moraleMult(meta.ownerId) * veteranBonus
         meta.attackCooldown = stype.attackCooldown
         meta.state = 'attacking'
         if (speckHp[j] <= 0) {
+          meta.kills++  // attacker earns a kill
           sim.events.push({ type: 'SPECK_DIED', speckId: speckIds[j], x: speckX[j], y: speckY[j], killedOwnerId: jMeta.ownerId, killerOwnerId: meta.ownerId })
         }
         break  // one attack per cooldown

--- a/src/app/speck-wars/domain/simulation/spawner.ts
+++ b/src/app/speck-wars/domain/simulation/spawner.ts
@@ -57,6 +57,7 @@ export function updateSpawners(sim: SimulationState, dt: number) {
         state: 'idle',
         targetId: null,
         attackCooldown: 0,
+        kills: 0,
       }
       addSpeck(sim, meta, sx, sy, building.id)
     }

--- a/src/app/speck-wars/domain/types.ts
+++ b/src/app/speck-wars/domain/types.ts
@@ -7,6 +7,7 @@ export interface SpeckMeta {
   state: 'idle' | 'moving' | 'attacking' | 'carrying' | 'sacrificing'
   targetId: string | null
   attackCooldown: number   // ms remaining until next attack
+  kills: number            // enemies killed; 3+ = veteran (gold ring, +20% damage)
 }
 
 export interface BuildingEntity {

--- a/src/app/speck-wars/rendering/layers/speck-layer.ts
+++ b/src/app/speck-wars/rendering/layers/speck-layer.ts
@@ -83,6 +83,14 @@ export class SpeckLayer {
         const hpFrac = stype ? Math.max(0, sim.speckHp[i] / stype.hp) : 1
         spriteList[j].alpha = 0.35 + 0.65 * hpFrac
 
+        // Gold ring for veteran specks (3+ kills)
+        const isVeteran = (typeMeta?.kills ?? 0) >= 3
+        if (isVeteran) {
+          this.gfx.lineStyle(1.5, 0xffd700, spriteList[j].alpha * 0.9)
+          this.gfx.drawCircle(sim.speckX[i], sim.speckY[i], (stype ? stype.size / 4 : 0.75) + 2.5)
+          this.gfx.lineStyle(0)
+        }
+
         const isHeavy = typeMeta?.typeId === 'heavy'
         if (isHeavy) {
           this.gfx.lineStyle(1, 0xffffff, spriteList[j].alpha * 0.6)


### PR DESCRIPTION
Closes new issue (opened in same batch)

## Summary
Specks that kill 3+ enemies become veterans: gold ring + 20% damage bonus.
4-file change touching only kill tracking and rendering.

## Files changed
| File | Change |
|------|--------|
| `domain/types.ts` | Added `kills: number` to SpeckMeta |
| `domain/simulation/spawner.ts` | Initializes `kills: 0` on spawn |
| `domain/simulation/combat.ts` | `meta.kills++` on kill; `veteranBonus = 1.20` when `kills >= 3` |
| `rendering/layers/speck-layer.ts` | Gold ring drawn around veterans |

## Test plan
- [ ] Specks that kill 3+ enemies show a gold ring
- [ ] Non-veterans show no ring
- [ ] Veteran damage multiplier applies (visually confirm they kill faster)
- [ ] Kill counter resets to 0 on new game
- [ ] No performance regression with many veterans on screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)