### PR TITLE
feat(speck-wars): tactical mini-map in top-right HUD corner

### DIFF
--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -303,6 +303,64 @@ export function HUD() {
         )
       })()}
 
+      {/* Mini-map — top right, below difficulty badge */}
+      {hud && (() => {
+        const SCALE = 120 / 3000  // world→screen
+        return (
+          <div style={{
+            position: 'absolute', top: 72, right: 16,
+            width: 120, height: 120,
+            background: 'rgba(0,0,0,0.55)',
+            border: '1px solid rgba(255,255,255,0.12)',
+            borderRadius: 4,
+            overflow: 'hidden',
+            pointerEvents: 'none',
+          }}>
+            <svg width={120} height={120} style={{ display: 'block' }}>
+              {/* Speck dots */}
+              {hud.minimap.specks.map((s, i) => (
+                <circle
+                  key={i}
+                  cx={s.x * SCALE}
+                  cy={s.y * SCALE}
+                  r={1}
+                  fill={s.ownerId === 'player' ? colorHex(PLAYER_COLOR) : colorHex(AI_COLOR)}
+                  opacity={0.55}
+                />
+              ))}
+              {/* Buildings */}
+              {hud.minimap.buildings.map(b => {
+                const fill = b.ownerId === 'player' ? colorHex(PLAYER_COLOR)
+                  : b.ownerId === 'ai' ? colorHex(AI_COLOR)
+                  : '#888888'
+                const r = b.typeId === 'base' ? 4 : 2.5
+                return (
+                  <circle
+                    key={b.id}
+                    cx={b.x * SCALE}
+                    cy={b.y * SCALE}
+                    r={r}
+                    fill={fill}
+                    opacity={0.9}
+                  />
+                )
+              })}
+              {/* Rally point crosshair */}
+              {hud.minimap.rallyPoint && (() => {
+                const rx = hud.minimap.rallyPoint.x * SCALE
+                const ry = hud.minimap.rallyPoint.y * SCALE
+                return (
+                  <g>
+                    <line x1={rx - 4} y1={ry} x2={rx + 4} y2={ry} stroke="#ffffff" strokeWidth={1} opacity={0.6} />
+                    <line x1={rx} y1={ry - 4} x2={rx} y2={ry + 4} stroke="#ffffff" strokeWidth={1} opacity={0.6} />
+                  </g>
+                )
+              })()}
+            </svg>
+          </div>
+        )
+      })()}
+
       {/* Timer + Pause button — top bar */}
       <div style={{
         position: 'absolute', top: 12, left: 0, right: 0,


### PR DESCRIPTION
## Summary

- Adds a 120×120 mini-map to the top-right corner (below the difficulty badge)
- Shows the full 3000×3000 battlefield at a glance without scrolling
- Displays speck swarms, building ownership, and the player's rally point

## Details

**Speck dots** — downsampled to ≤400 points per tick (every Nth speck), colored teal (player) or red (AI). Gives a real sense of where the fighting is and where each army is massing.

**Building circles** — all 7 buildings (2 bases + 3 outposts + any extras), colored by current owner. Base circles are slightly larger (r=4) than outposts (r=2.5).

**Rally point crosshair** — white ✕ at the player's current rally position. Updates as soon as a new rally is set.

**Non-interactive** — `pointer-events: none` on the container so all clicks pass through to the game canvas.

## Files changed

| File | Change |
|---|---|
| `domain/types.ts` | Added `minimap` field to HudData |
| `domain/simulation/tick.ts` | Downsample specks (≤400) + collect buildings in `emitHudUpdate` |
| `components/hud.tsx` | 120×120 SVG mini-map block inserted after difficulty badge |

## Test plan

- [ ] Start a game — mini-map appears top-right with two clusters of colored dots
- [ ] Scroll the main view — mini-map stays fixed and shows the full map
- [ ] Click to set a rally point — white crosshair appears on mini-map
- [ ] Capture an outpost — building circle changes color on mini-map
- [ ] Verify clicks on mini-map area still pan/zoom/rally the main canvas
- [ ] Verify TypeScript clean (`npx tsc --noEmit`)
- [ ] Verify Vercel preview deploys

🤖 Generated with [Claude Code](https://claude.com/claude-code)