### PR TITLE
feat(speck-wars): daily map modifier — bulwark/blitz/siege/standard

### DIFF
--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -135,6 +135,11 @@ export function HUD() {
             <span style={{ color: 'rgba(255,255,255,0.18)', fontSize: 8, letterSpacing: 0.5 }}>
               DAILY MAP · {new Date().toLocaleDateString('en-US', { month: 'short', day: 'numeric' }).toUpperCase()}
             </span>
+            {hud?.dailyModifier && hud.dailyModifier !== 'standard' && (
+              <span style={{ color: '#ffd700', fontSize: 8, letterSpacing: 0.5, opacity: 0.7, textAlign: 'right' }}>
+                {hud.dailyModifier === 'bulwark' ? '⚔ BULWARK' : hud.dailyModifier === 'blitz' ? '⚡ BLITZ' : '🏰 SIEGE'}
+              </span>
+            )}
           </div>
         )
       })()}
@@ -325,6 +330,9 @@ export function HUD() {
             <span>B — rush enemy base</span><span>D — defend base</span>
             <span>Q — surge (2× spawn 8s)</span><span>Shift+drag — select specks</span>
             <span>Minimap — click to rally</span><span>? — this help</span>
+            <span style={{ gridColumn: '1/-1', borderTop: '1px solid rgba(255,255,255,0.08)', paddingTop: 8, marginTop: 2, color: 'rgba(255,215,0,0.5)', fontSize: 11 }}>
+              Daily map seed changes each day · modifier shown top-right (bulwark/blitz/siege)
+            </span>
           </div>
         </div>
       )}

--- a/src/app/speck-wars/components/phase-router.tsx
+++ b/src/app/speck-wars/components/phase-router.tsx
@@ -5,7 +5,7 @@ import { getBestTime, getWinStreak, getRecentResults, hasWonToday } from '../lib
 import type { Difficulty } from '../store'
 
 export function PhaseRouter({ children }: { children: React.ReactNode }) {
-  const { phase, winnerId, setPhase, difficulty, setDifficulty, elapsedMs, resetGame, kills, losses, isNewBest, victoryType, hud } = useSpeckWarsStore()
+  const { phase, winnerId, setPhase, difficulty, setDifficulty, elapsedMs, resetGame, kills, losses, isNewBest, victoryType, hud, peakArmySize, outpostsCaptured } = useSpeckWarsStore()
   const [copied, setCopied] = useState(false)
   const [bestTimes, setBestTimes] = useState<Partial<Record<Difficulty, number>>>({})
   const [winStreak, setWinStreak] = useState(0)
@@ -261,6 +261,17 @@ export function PhaseRouter({ children }: { children: React.ReactNode }) {
             </span>
           )}
         </div>
+
+        {(peakArmySize > 0 || outpostsCaptured > 0) && (
+          <div style={{ display: 'flex', gap: 28, color: 'rgba(255,255,255,0.45)', fontSize: 12, letterSpacing: 0.5 }}>
+            {peakArmySize > 0 && (
+              <span>⚔ peak {peakArmySize} specks</span>
+            )}
+            {outpostsCaptured > 0 && (
+              <span>⬡ {outpostsCaptured} outpost{outpostsCaptured !== 1 ? 's' : ''} captured</span>
+            )}
+          </div>
+        )}
 
         {/* Recent run history for this difficulty */}
         {(() => {

--- a/src/app/speck-wars/domain/constants.ts
+++ b/src/app/speck-wars/domain/constants.ts
@@ -51,3 +51,17 @@ export const OUTPOST_POSITIONS = MAP_LAYOUTS[0]  // default — overridden by cr
 export const FORTIFY_TIME = 30000        // ms to reach full fortification
 export const FORTIFY_RADIUS = 200        // px — combat bonus applies within this radius
 export const FORTIFY_DAMAGE_BONUS = 0.25 // max damage multiplier bonus when fully fortified
+
+export type DailyModifier = 'standard' | 'bulwark' | 'blitz' | 'siege'
+
+// Weighted array: standard appears 2× more often than others
+export const DAILY_MODIFIER_POOL: DailyModifier[] = [
+  'standard', 'standard', 'bulwark', 'blitz', 'siege'
+]
+
+export const DAILY_MODIFIER_LABELS: Record<DailyModifier, string> = {
+  standard: '',
+  bulwark:  '⚔ BULWARK — bases have 2× HP',
+  blitz:    '⚡ BLITZ — 1.5× production speed',
+  siege:    '🏰 SIEGE — outposts take 2× longer to capture',
+}

--- a/src/app/speck-wars/domain/simulation/capture.ts
+++ b/src/app/speck-wars/domain/simulation/capture.ts
@@ -33,8 +33,9 @@ export function updateCapture(sim: SimulationState, dt: number) {
     }
 
     // Scale capture speed with speck count: 5 specks = 1×, capped at 3× (15 specks)
+    const captureTimeMs = sim.dailyModifier === 'siege' ? CAPTURE_TIME * 2 : CAPTURE_TIME
     const captureSpeed = Math.min(3, dominantCount / 5)
-    building.captureProgress = (building.captureProgress ?? 0) + (dt / CAPTURE_TIME) * captureSpeed
+    building.captureProgress = (building.captureProgress ?? 0) + (dt / captureTimeMs) * captureSpeed
     if ((building.captureProgress ?? 0) >= 1) {
       const previousOwner = building.ownerId
       building.ownerId = dominantOwner

--- a/src/app/speck-wars/domain/simulation/create-sim.ts
+++ b/src/app/speck-wars/domain/simulation/create-sim.ts
@@ -1,5 +1,6 @@
 import type { SimulationState, Player, BuildingEntity } from '../types'
-import { PLAYER_BASE_X, PLAYER_BASE_Y, AI_BASE_X, AI_BASE_Y, PLAYER_COLOR, AI_COLOR, BASE_HP, MAX_SPECKS, NEUTRAL_COLOR, MAP_LAYOUTS } from '../constants'
+import { PLAYER_BASE_X, PLAYER_BASE_Y, AI_BASE_X, AI_BASE_Y, PLAYER_COLOR, AI_COLOR, BASE_HP, MAX_SPECKS, NEUTRAL_COLOR, MAP_LAYOUTS, DAILY_MODIFIER_POOL } from '../constants'
+import type { DailyModifier } from '../constants'
 import { SpatialGrid } from './spatial-grid'
 import { mulberry32 } from './prng'
 import type { Difficulty } from '../../store'
@@ -73,6 +74,22 @@ export function createSim(seed: number = Date.now(), difficulty: Difficulty = 'm
     }
   }
 
+  // Pick daily modifier — LAST RNG call so it doesn't shift existing map layout or jitter
+  const modifierIndex = Math.floor(rng() * DAILY_MODIFIER_POOL.length)
+  const dailyModifier: DailyModifier = DAILY_MODIFIER_POOL[modifierIndex]
+
+  // Apply static modifier effects
+  if (dailyModifier === 'bulwark') {
+    playerBase.hp = BASE_HP * 2
+    playerBase.maxHp = BASE_HP * 2
+    aiBase.hp = BASE_HP * 2
+    aiBase.maxHp = BASE_HP * 2
+  }
+  if (dailyModifier === 'blitz') {
+    if (playerBase.spawnIntervalOverride !== undefined) playerBase.spawnIntervalOverride *= 0.65
+    aiBase.spawnIntervalOverride = (aiBase.spawnIntervalOverride ?? 800) * 0.65
+  }
+
   return {
     tick: 0,
     rngState: seed,
@@ -95,5 +112,6 @@ export function createSim(seed: number = Date.now(), difficulty: Difficulty = 'm
     dominationTimer: 0,
     surgeDuration: 0,
     surgeCooldown: 0,
+    dailyModifier,
   }
 }

--- a/src/app/speck-wars/domain/simulation/tick.ts
+++ b/src/app/speck-wars/domain/simulation/tick.ts
@@ -256,5 +256,5 @@ function emitHudUpdate(sim: SimulationState) {
     outpostFortify[building.id] = Math.min(1, (building.fortifyDuration ?? 0) / FORTIFY_TIME)
   }
 
-  sim.events.push({ type: 'HUD_UPDATE', data: { players: data, attackedBuildingIds, tripleOutpostOwner, dominationProgress, captureInfo, surgeDuration: sim.surgeDuration, surgeCooldown: sim.surgeCooldown, spawnRates, minimap, outpostFortify } })
+  sim.events.push({ type: 'HUD_UPDATE', data: { players: data, attackedBuildingIds, tripleOutpostOwner, dominationProgress, captureInfo, surgeDuration: sim.surgeDuration, surgeCooldown: sim.surgeCooldown, spawnRates, minimap, outpostFortify, dailyModifier: sim.dailyModifier } })
 }

--- a/src/app/speck-wars/domain/types.ts
+++ b/src/app/speck-wars/domain/types.ts
@@ -61,6 +61,7 @@ export interface SimulationState {
   dominationTimer: number    // ms of continuous triple-outpost control; resets on loss
   surgeDuration: number      // ms remaining in active surge, 0 = inactive
   surgeCooldown: number      // ms remaining before surge can be used again, 0 = ready
+  dailyModifier: 'standard' | 'bulwark' | 'blitz' | 'siege'
 }
 
 export type InputEvent =
@@ -96,6 +97,7 @@ export interface HudData {
   surgeDuration: number    // ms remaining in active surge
   surgeCooldown: number    // ms remaining before surge can be used again
   spawnRates: Record<string, number>   // playerId → effective specks/min
+  dailyModifier: 'standard' | 'bulwark' | 'blitz' | 'siege'
   outpostFortify: Record<string, number>  // outpostId → 0..1 fortification level
   minimap: {
     specks: { x: number; y: number; ownerId: string }[]

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -193,6 +193,8 @@ export class GameInstance {
         if (event.type === 'HUD_UPDATE') {
           store.setHud(event.data)
           this.cachedPlayerSpeckCount = event.data.players.player?.speckCount ?? 0
+          const playerSpeckCount = event.data.players.player?.speckCount ?? 0
+          store.setPeakArmySize(playerSpeckCount)
           // Warn when an enemy starts capturing a player-owned outpost
           const now = Date.now()
           const playerBuildingHp = event.data.players.player?.buildingHp ?? {}
@@ -352,6 +354,9 @@ export class GameInstance {
           }
         }
         if (event.type === 'OUTPOST_CAPTURED') {
+          if (event.newOwner === 'player') {
+            store.addOutpostCaptured()
+          }
           const isPlayerGain = event.newOwner === 'player'
           const isPlayerLoss = event.previousOwner === 'player'
           const isRecapture = isPlayerGain && event.previousOwner === 'ai'

--- a/src/app/speck-wars/store.ts
+++ b/src/app/speck-wars/store.ts
@@ -29,6 +29,10 @@ interface SpeckWarsStore {
   addLoss: () => void
   spawnMode: 'basic' | 'heavy' | 'scout'
   cycleSpawnMode: () => 'basic' | 'heavy' | 'scout'
+  peakArmySize: number
+  setPeakArmySize: (n: number) => void
+  outpostsCaptured: number
+  addOutpostCaptured: () => void
   isNewBest: boolean
   setIsNewBest: (v: boolean) => void
   gameActions: { defend: (() => void) | null; advance: (() => void) | null; rush: (() => void) | null; clearRally: (() => void) | null; surge: (() => void) | null }
@@ -72,6 +76,10 @@ export const useSpeckWarsStore = create<SpeckWarsStore>()((set, get) => ({
     })
     return next
   },
+  peakArmySize: 0,
+  setPeakArmySize: n => set(s => ({ peakArmySize: Math.max(s.peakArmySize, n) })),
+  outpostsCaptured: 0,
+  addOutpostCaptured: () => set(s => ({ outpostsCaptured: s.outpostsCaptured + 1 })),
   isNewBest: false,
   setIsNewBest: v => set({ isNewBest: v }),
   gameActions: { defend: null, advance: null, rush: null, clearRally: null, surge: null },
@@ -94,6 +102,8 @@ export const useSpeckWarsStore = create<SpeckWarsStore>()((set, get) => ({
     losses: 0,
     spawnMode: 'basic' as 'basic' | 'heavy' | 'scout',
     isNewBest: false,
+    peakArmySize: 0,
+    outpostsCaptured: 0,
     difficulty: s.difficulty,
   })),
 }))


### PR DESCRIPTION
Seeded RNG picks a daily modifier. Bulwark=2× base HP, Blitz=0.65× spawn intervals, Siege=2× capture time, Standard=normal. Badge shown in HUD top-right.