### PR TITLE
feat(speck-wars): end screen peak army + outposts captured stats

### DIFF
--- a/src/app/speck-wars/components/phase-router.tsx
+++ b/src/app/speck-wars/components/phase-router.tsx
@@ -5,7 +5,7 @@ import { getBestTime, getWinStreak, getRecentResults, hasWonToday } from '../lib
 import type { Difficulty } from '../store'
 
 export function PhaseRouter({ children }: { children: React.ReactNode }) {
-  const { phase, winnerId, setPhase, difficulty, setDifficulty, elapsedMs, resetGame, kills, losses, isNewBest, victoryType, hud } = useSpeckWarsStore()
+  const { phase, winnerId, setPhase, difficulty, setDifficulty, elapsedMs, resetGame, kills, losses, isNewBest, victoryType, hud, peakArmySize, outpostsCaptured } = useSpeckWarsStore()
   const [copied, setCopied] = useState(false)
   const [bestTimes, setBestTimes] = useState<Partial<Record<Difficulty, number>>>({})
   const [winStreak, setWinStreak] = useState(0)
@@ -261,6 +261,17 @@ export function PhaseRouter({ children }: { children: React.ReactNode }) {
             </span>
           )}
         </div>
+
+        {(peakArmySize > 0 || outpostsCaptured > 0) && (
+          <div style={{ display: 'flex', gap: 28, color: 'rgba(255,255,255,0.45)', fontSize: 12, letterSpacing: 0.5 }}>
+            {peakArmySize > 0 && (
+              <span>⚔ peak {peakArmySize} specks</span>
+            )}
+            {outpostsCaptured > 0 && (
+              <span>⬡ {outpostsCaptured} outpost{outpostsCaptured !== 1 ? 's' : ''} captured</span>
+            )}
+          </div>
+        )}
 
         {/* Recent run history for this difficulty */}
         {(() => {

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -193,6 +193,8 @@ export class GameInstance {
         if (event.type === 'HUD_UPDATE') {
           store.setHud(event.data)
           this.cachedPlayerSpeckCount = event.data.players.player?.speckCount ?? 0
+          const playerSpeckCount = event.data.players.player?.speckCount ?? 0
+          store.setPeakArmySize(playerSpeckCount)
           // Warn when an enemy starts capturing a player-owned outpost
           const now = Date.now()
           const playerBuildingHp = event.data.players.player?.buildingHp ?? {}
@@ -352,6 +354,9 @@ export class GameInstance {
           }
         }
         if (event.type === 'OUTPOST_CAPTURED') {
+          if (event.newOwner === 'player') {
+            store.addOutpostCaptured()
+          }
           const isPlayerGain = event.newOwner === 'player'
           const isPlayerLoss = event.previousOwner === 'player'
           const isRecapture = isPlayerGain && event.previousOwner === 'ai'

--- a/src/app/speck-wars/store.ts
+++ b/src/app/speck-wars/store.ts
@@ -29,6 +29,10 @@ interface SpeckWarsStore {
   addLoss: () => void
   spawnMode: 'basic' | 'heavy' | 'scout'
   cycleSpawnMode: () => 'basic' | 'heavy' | 'scout'
+  peakArmySize: number
+  setPeakArmySize: (n: number) => void
+  outpostsCaptured: number
+  addOutpostCaptured: () => void
   isNewBest: boolean
   setIsNewBest: (v: boolean) => void
   gameActions: { defend: (() => void) | null; advance: (() => void) | null; rush: (() => void) | null; clearRally: (() => void) | null; surge: (() => void) | null }
@@ -72,6 +76,10 @@ export const useSpeckWarsStore = create<SpeckWarsStore>()((set, get) => ({
     })
     return next
   },
+  peakArmySize: 0,
+  setPeakArmySize: n => set(s => ({ peakArmySize: Math.max(s.peakArmySize, n) })),
+  outpostsCaptured: 0,
+  addOutpostCaptured: () => set(s => ({ outpostsCaptured: s.outpostsCaptured + 1 })),
   isNewBest: false,
   setIsNewBest: v => set({ isNewBest: v }),
   gameActions: { defend: null, advance: null, rush: null, clearRally: null, surge: null },
@@ -94,6 +102,8 @@ export const useSpeckWarsStore = create<SpeckWarsStore>()((set, get) => ({
     losses: 0,
     spawnMode: 'basic' as 'basic' | 'heavy' | 'scout',
     isNewBest: false,
+    peakArmySize: 0,
+    outpostsCaptured: 0,
     difficulty: s.difficulty,
   })),
 }))


### PR DESCRIPTION
Tracks peakArmySize (max simultaneous specks) and outpostsCaptured per game. Both shown on victory/defeat screen below kills/losses.