### PR TITLE
feat(speck-wars): click mini-map to set rally point

### DIFF
--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -155,9 +155,19 @@ export function HUD() {
             border: '1px solid rgba(255,255,255,0.12)',
             borderRadius: 4,
             overflow: 'hidden',
-            pointerEvents: 'none',
+            cursor: 'crosshair',
           }}>
-            <svg width={120} height={120} style={{ display: 'block' }}>
+            <svg width={120} height={120} style={{ display: 'block' }}
+              onClick={(e) => {
+                if (!gameActions?.rally) return
+                const rect = e.currentTarget.getBoundingClientRect()
+                const px = e.clientX - rect.left
+                const py = e.clientY - rect.top
+                const worldX = (px / 120) * 3000
+                const worldY = (py / 120) * 3000
+                gameActions.rally(worldX, worldY)
+              }}
+            >
               {/* Speck dots */}
               {hud.minimap.specks.map((s, i) => (
                 <circle

--- a/src/app/speck-wars/domain/ai/ai-controller.ts
+++ b/src/app/speck-wars/domain/ai/ai-controller.ts
@@ -12,15 +12,34 @@ export class AIController {
   private spawnMode: 'basic' | 'heavy' | 'scout' = 'basic'
   private spawnModeCountdown: number = 0  // ticks until next spawn mode decision
   private dominanceTimer: number = 0  // ms enemy has held a 3:1 count advantage
+  private waveTimer: number  // ms until next wave
+  private waveRemainingMs = 0  // ms left in active wave (0 = not in wave)
+  private waveNumber = 0       // which wave this is (1, 2, 3...)
+  private waveEnabled: boolean  // only hard/very-hard get waves
 
   constructor(playerId: string, tickInterval: number = 30, personality: AIPersonality = 'balanced') {
     this.playerId = playerId
     this.tickInterval = tickInterval
     this.baseTickInterval = tickInterval
     this.personality = personality
+    this.waveTimer = 90000 + Math.random() * 30000  // stagger first wave: 90-120s
+    this.waveEnabled = tickInterval <= 15  // hard (15) and very-hard (6) only
   }
 
   update(sim: SimulationState, dt: number = 16) {
+    if (this.waveEnabled) {
+      this.waveTimer -= dt
+      if (this.waveRemainingMs > 0) {
+        this.waveRemainingMs = Math.max(0, this.waveRemainingMs - dt)
+      }
+      if (this.waveTimer <= 0) {
+        this.waveNumber++
+        this.waveRemainingMs = 15000
+        this.waveTimer = 90000
+        sim.events.push({ type: 'AI_WAVE_START', waveNumber: this.waveNumber })
+      }
+    }
+
     // Adaptive difficulty: if the enemy holds a 3:1 speck advantage for 30s, speed up AI decisions
     let aiCount = 0, enemyCount = 0
     for (let i = 0; i < sim.speckCount; i++) {
@@ -106,6 +125,15 @@ export class AIController {
           : (myBaseHpFrac < 0.3 ? 0.70 : 0.45)  // balanced
       if (Math.random() < defendChance) {
         sim.inputQueue.push({ type: 'RALLY', ownerId: this.playerId, x: myBase.x, y: myBase.y })
+        return
+      }
+    }
+
+    // Wave assault: during active wave, always rush the enemy base
+    if (this.waveRemainingMs > 0) {
+      const enemyBase = nearest(b => b.ownerId !== this.playerId && b.ownerId !== 'neutral' && b.typeId === 'base')
+      if (enemyBase) {
+        sim.inputQueue.push({ type: 'RALLY', ownerId: this.playerId, x: enemyBase.x, y: enemyBase.y })
         return
       }
     }

--- a/src/app/speck-wars/domain/types.ts
+++ b/src/app/speck-wars/domain/types.ts
@@ -82,6 +82,7 @@ export type SimEvent =
   | { type: 'HUD_UPDATE'; data: HudData }
   | { type: 'OUTPOST_CAPTURED'; outpostId: string; newOwner: string; previousOwner: string }
   | { type: 'SPECK_VETERAN'; speckId: string; ownerId: string }
+  | { type: 'AI_WAVE_START'; waveNumber: number }
 
 export interface HudData {
   players: Record<string, {

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -118,6 +118,7 @@ export class GameInstance {
       rush: () => { this.rush(); this.notify('⚡ RUSH!', '#ff4f7b') },
       clearRally: () => this.clearRally(),
       surge: () => { this.surge(); this.notify('⚡ SURGE ACTIVE!', '#ffd700') },
+      rally: (x: number, y: number) => this.rally(x, y),
     })
     this.lastTime = performance.now()
     this.loop(this.lastTime)

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -384,6 +384,12 @@ export class GameInstance {
             setTimeout(() => useSpeckWarsStore.getState().setNotification(null), 2000)
           }
         }
+        if (event.type === 'AI_WAVE_START') {
+          const waveColors = ['#ff4f7b', '#ff6b35', '#cc00ff']
+          const color = waveColors[(event.waveNumber - 1) % waveColors.length]
+          store.setNotification({ message: `⚠ WAVE ${event.waveNumber} ASSAULT!`, color })
+          setTimeout(() => useSpeckWarsStore.getState().setNotification(null), 3000)
+        }
       }
 
       // Retreat wave warning: 10+ player specks retreating = notify

--- a/src/app/speck-wars/store.ts
+++ b/src/app/speck-wars/store.ts
@@ -35,8 +35,8 @@ interface SpeckWarsStore {
   addOutpostCaptured: () => void
   isNewBest: boolean
   setIsNewBest: (v: boolean) => void
-  gameActions: { defend: (() => void) | null; advance: (() => void) | null; rush: (() => void) | null; clearRally: (() => void) | null; surge: (() => void) | null }
-  setGameActions: (actions: { defend: () => void; advance: () => void; rush: () => void; clearRally: () => void; surge: () => void } | null) => void
+  gameActions: { defend: (() => void) | null; advance: (() => void) | null; rush: (() => void) | null; clearRally: (() => void) | null; surge: (() => void) | null; rally: ((x: number, y: number) => void) | null }
+  setGameActions: (actions: { defend: () => void; advance: () => void; rush: () => void; clearRally: () => void; surge: () => void; rally: (x: number, y: number) => void } | null) => void
   surrender: () => void
   resetGame: () => void
 }
@@ -82,8 +82,8 @@ export const useSpeckWarsStore = create<SpeckWarsStore>()((set, get) => ({
   addOutpostCaptured: () => set(s => ({ outpostsCaptured: s.outpostsCaptured + 1 })),
   isNewBest: false,
   setIsNewBest: v => set({ isNewBest: v }),
-  gameActions: { defend: null, advance: null, rush: null, clearRally: null, surge: null },
-  setGameActions: (actions) => set({ gameActions: actions ?? { defend: null, advance: null, rush: null, clearRally: null, surge: null } }),
+  gameActions: { defend: null, advance: null, rush: null, clearRally: null, surge: null, rally: null },
+  setGameActions: (actions) => set({ gameActions: actions ?? { defend: null, advance: null, rush: null, clearRally: null, surge: null, rally: null } }),
   surrender: () => {
     const s = get()
     resetWinStreak()


### PR DESCRIPTION
Mini-map is now clickable. Click position is converted from minimap coords to world coords and dispatched as a RALLY event. Cursor changes to crosshair.