### PR TITLE
feat(speck-wars): AI wave assault system on hard/very-hard

### DIFF
--- a/src/app/speck-wars/domain/ai/ai-controller.ts
+++ b/src/app/speck-wars/domain/ai/ai-controller.ts
@@ -12,15 +12,34 @@ export class AIController {
   private spawnMode: 'basic' | 'heavy' | 'scout' = 'basic'
   private spawnModeCountdown: number = 0  // ticks until next spawn mode decision
   private dominanceTimer: number = 0  // ms enemy has held a 3:1 count advantage
+  private waveTimer: number  // ms until next wave
+  private waveRemainingMs = 0  // ms left in active wave (0 = not in wave)
+  private waveNumber = 0       // which wave this is (1, 2, 3...)
+  private waveEnabled: boolean  // only hard/very-hard get waves
 
   constructor(playerId: string, tickInterval: number = 30, personality: AIPersonality = 'balanced') {
     this.playerId = playerId
     this.tickInterval = tickInterval
     this.baseTickInterval = tickInterval
     this.personality = personality
+    this.waveTimer = 90000 + Math.random() * 30000  // stagger first wave: 90-120s
+    this.waveEnabled = tickInterval <= 15  // hard (15) and very-hard (6) only
   }
 
   update(sim: SimulationState, dt: number = 16) {
+    if (this.waveEnabled) {
+      this.waveTimer -= dt
+      if (this.waveRemainingMs > 0) {
+        this.waveRemainingMs = Math.max(0, this.waveRemainingMs - dt)
+      }
+      if (this.waveTimer <= 0) {
+        this.waveNumber++
+        this.waveRemainingMs = 15000
+        this.waveTimer = 90000
+        sim.events.push({ type: 'AI_WAVE_START', waveNumber: this.waveNumber })
+      }
+    }
+
     // Adaptive difficulty: if the enemy holds a 3:1 speck advantage for 30s, speed up AI decisions
     let aiCount = 0, enemyCount = 0
     for (let i = 0; i < sim.speckCount; i++) {
@@ -106,6 +125,15 @@ export class AIController {
           : (myBaseHpFrac < 0.3 ? 0.70 : 0.45)  // balanced
       if (Math.random() < defendChance) {
         sim.inputQueue.push({ type: 'RALLY', ownerId: this.playerId, x: myBase.x, y: myBase.y })
+        return
+      }
+    }
+
+    // Wave assault: during active wave, always rush the enemy base
+    if (this.waveRemainingMs > 0) {
+      const enemyBase = nearest(b => b.ownerId !== this.playerId && b.ownerId !== 'neutral' && b.typeId === 'base')
+      if (enemyBase) {
+        sim.inputQueue.push({ type: 'RALLY', ownerId: this.playerId, x: enemyBase.x, y: enemyBase.y })
         return
       }
     }

--- a/src/app/speck-wars/domain/types.ts
+++ b/src/app/speck-wars/domain/types.ts
@@ -82,6 +82,7 @@ export type SimEvent =
   | { type: 'HUD_UPDATE'; data: HudData }
   | { type: 'OUTPOST_CAPTURED'; outpostId: string; newOwner: string; previousOwner: string }
   | { type: 'SPECK_VETERAN'; speckId: string; ownerId: string }
+  | { type: 'AI_WAVE_START'; waveNumber: number }
 
 export interface HudData {
   players: Record<string, {

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -384,6 +384,12 @@ export class GameInstance {
             setTimeout(() => useSpeckWarsStore.getState().setNotification(null), 2000)
           }
         }
+        if (event.type === 'AI_WAVE_START') {
+          const waveColors = ['#ff4f7b', '#ff6b35', '#cc00ff']
+          const color = waveColors[(event.waveNumber - 1) % waveColors.length]
+          store.setNotification({ message: `⚠ WAVE ${event.waveNumber} ASSAULT!`, color })
+          setTimeout(() => useSpeckWarsStore.getState().setNotification(null), 3000)
+        }
       }
 
       // Retreat wave warning: 10+ player specks retreating = notify


### PR DESCRIPTION
Every 90s on hard/very-hard, AI forces a 15s wave where it ignores outposts and rushes the player base. Fires AI_WAVE_START event; game-instance shows colored notification.