### PR TITLE
feat(speck-wars): 1/2/3 hotkeys to set spawn type directly

### DIFF
--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -340,6 +340,7 @@ export function HUD() {
             <span>B — rush enemy base</span><span>D — defend base</span>
             <span>Q — surge (2× spawn 8s)</span><span>V — snap camera to battle</span>
             <span>Shift+drag — select specks</span><span>Minimap — click to rally</span>
+            <span>E — select all specks</span><span>X — cycle speed (1×/2×/4×)</span>
             <span>? — this help</span>
             <span style={{ gridColumn: '1/-1', borderTop: '1px solid rgba(255,255,255,0.08)', paddingTop: 8, marginTop: 2, color: 'rgba(255,215,0,0.5)', fontSize: 11 }}>
               Daily map seed changes each day · modifier shown top-right (bulwark/blitz/siege)

--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -335,7 +335,7 @@ export function HUD() {
           }}>
             <span>🖱 Click — rally specks</span><span>Space — pause</span>
             <span>Scroll — zoom</span><span>R / Right-click — clear rally</span>
-            <span>Drag — pan camera</span><span>H — cycle spawn (basic/heavy/scout)</span>
+            <span>Drag — pan camera</span><span>1/2/3 or H — set/cycle spawn type</span>
             <span>A — advance to outpost</span><span>C — center on base</span>
             <span>B — rush enemy base</span><span>D — defend base</span>
             <span>Q — surge (2× spawn 8s)</span><span>V — snap camera to battle</span>

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -111,6 +111,12 @@ export class GameInstance {
       },
       () => { this.surge(); this.notify('⚡ SURGE ACTIVE!', '#ffd700') },  // Q — production surge
       () => { this.snapToAction() },                                        // V — snap camera to battle
+      (typeId: 'basic' | 'heavy' | 'scout') => {               // 1/2/3 — set spawn type directly
+        useSpeckWarsStore.getState().setSpawnMode(typeId)
+        this.sim.inputQueue.push({ type: 'SET_SPAWN_TYPE', ownerId: 'player', speckTypeId: typeId })
+        const color = typeId === 'heavy' ? '#ff8844' : typeId === 'scout' ? '#50c8ff' : '#4af7c4'
+        this.notify(`Spawn: ${typeId.toUpperCase()}`, color)
+      },
     )
     useSpeckWarsStore.getState().setGameActions({
       defend: () => { this.defend(); this.notify('🛡 DEFEND', '#4af7c4') },

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -117,6 +117,14 @@ export class GameInstance {
         const color = typeId === 'heavy' ? '#ff8844' : typeId === 'scout' ? '#50c8ff' : '#4af7c4'
         this.notify(`Spawn: ${typeId.toUpperCase()}`, color)
       },
+      () => {                                                           // X — cycle game speed
+        useSpeckWarsStore.getState().cycleSpeed()
+        const spd = useSpeckWarsStore.getState().speed
+        this.notify(`Speed: ${spd}×`, spd > 1 ? '#4af7c4' : '#ffffff')
+      },
+      () => {                                                           // E — select all specks
+        this.sim.inputQueue.push({ type: 'BOX_SELECT', ownerId: 'player', x1: -1, y1: -1, x2: 3001, y2: 3001 })
+      },
     )
     useSpeckWarsStore.getState().setGameActions({
       defend: () => { this.defend(); this.notify('🛡 DEFEND', '#4af7c4') },

--- a/src/app/speck-wars/input/input-handler.ts
+++ b/src/app/speck-wars/input/input-handler.ts
@@ -16,6 +16,7 @@ export class InputHandler {
   private onClearSelect?: () => void
   private onSurge?: () => void
   private onSnapToAction?: () => void
+  private onSetSpawnType?: (typeId: 'basic' | 'heavy' | 'scout') => void
   private isDragging = false
   private lastX = 0
   private lastY = 0
@@ -45,6 +46,7 @@ export class InputHandler {
     onClearSelect?: () => void,
     onSurge?: () => void,
     onSnapToAction?: () => void,
+    onSetSpawnType?: (typeId: 'basic' | 'heavy' | 'scout') => void,
   ) {
     this.canvas = canvas
     this.camera = camera
@@ -60,6 +62,7 @@ export class InputHandler {
     this.onClearSelect = onClearSelect
     this.onSurge = onSurge
     this.onSnapToAction = onSnapToAction
+    this.onSetSpawnType = onSetSpawnType
     this.attach()
   }
 
@@ -249,6 +252,12 @@ export class InputHandler {
       this.onSurge?.()
     } else if (e.code === 'KeyV') {
       this.onSnapToAction?.()
+    } else if (e.code === 'Digit1') {
+      this.onSetSpawnType?.('basic')
+    } else if (e.code === 'Digit2') {
+      this.onSetSpawnType?.('heavy')
+    } else if (e.code === 'Digit3') {
+      this.onSetSpawnType?.('scout')
     }
   }
 

--- a/src/app/speck-wars/input/input-handler.ts
+++ b/src/app/speck-wars/input/input-handler.ts
@@ -17,6 +17,8 @@ export class InputHandler {
   private onSurge?: () => void
   private onSnapToAction?: () => void
   private onSetSpawnType?: (typeId: 'basic' | 'heavy' | 'scout') => void
+  private onCycleSpeed?: () => void
+  private onSelectAll?: () => void
   private isDragging = false
   private lastX = 0
   private lastY = 0
@@ -47,6 +49,8 @@ export class InputHandler {
     onSurge?: () => void,
     onSnapToAction?: () => void,
     onSetSpawnType?: (typeId: 'basic' | 'heavy' | 'scout') => void,
+    onCycleSpeed?: () => void,
+    onSelectAll?: () => void,
   ) {
     this.canvas = canvas
     this.camera = camera
@@ -63,6 +67,8 @@ export class InputHandler {
     this.onSurge = onSurge
     this.onSnapToAction = onSnapToAction
     this.onSetSpawnType = onSetSpawnType
+    this.onCycleSpeed = onCycleSpeed
+    this.onSelectAll = onSelectAll
     this.attach()
   }
 
@@ -258,6 +264,10 @@ export class InputHandler {
       this.onSetSpawnType?.('heavy')
     } else if (e.code === 'Digit3') {
       this.onSetSpawnType?.('scout')
+    } else if (e.code === 'KeyX') {
+      this.onCycleSpeed?.()
+    } else if (e.code === 'KeyE') {
+      this.onSelectAll?.()
     }
   }
 

--- a/src/app/speck-wars/store.ts
+++ b/src/app/speck-wars/store.ts
@@ -29,6 +29,7 @@ interface SpeckWarsStore {
   addLoss: () => void
   spawnMode: 'basic' | 'heavy' | 'scout'
   cycleSpawnMode: () => 'basic' | 'heavy' | 'scout'
+  setSpawnMode: (mode: 'basic' | 'heavy' | 'scout') => void
   peakArmySize: number
   setPeakArmySize: (n: number) => void
   outpostsCaptured: number
@@ -76,6 +77,7 @@ export const useSpeckWarsStore = create<SpeckWarsStore>()((set, get) => ({
     })
     return next
   },
+  setSpawnMode: mode => set({ spawnMode: mode }),
   peakArmySize: 0,
   setPeakArmySize: n => set(s => ({ peakArmySize: Math.max(s.peakArmySize, n) })),
   outpostsCaptured: 0,


### PR DESCRIPTION
Press 1=Basic, 2=Heavy, 3=Scout. Direct jump vs cycling with H. Color-coded notification on switch. Added setSpawnMode action to store.