### PR TITLE
feat(speck-wars): elite specks at 6 kills — white ring + 35% damage

### DIFF
--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -374,7 +374,7 @@ export function HUD() {
             <span>Q — surge (2× spawn 8s)</span><span>V — snap camera to battle</span>
             <span>Shift+drag — select specks</span><span>Minimap — click to rally</span>
             <span>E — select all specks</span><span>X — cycle speed (1×/2×/4×)</span>
-            <span>? — this help</span>
+            <span>F — sacrifice 10 specks → +15 HP base</span><span>? — this help</span>
             <span style={{ gridColumn: '1/-1', borderTop: '1px solid rgba(255,255,255,0.08)', paddingTop: 8, marginTop: 2, color: 'rgba(255,215,0,0.5)', fontSize: 11 }}>
               Daily map seed changes each day · modifier shown top-right (bulwark/blitz/siege)
             </span>
@@ -794,6 +794,33 @@ export function HUD() {
                   : surgeCd > 0
                     ? `Q ${Math.ceil(surgeCd / 1000)}s`
                     : '★ Q'}
+              </button>
+            )
+          })()}
+          {(() => {
+            const cd = hud?.sacrificeCooldown ?? 0
+            const speckCount = hud?.players.player?.speckCount ?? 0
+            const baseHp = hud?.players.player?.buildingHp['building-player-base'] ?? 100
+            const ready = cd <= 0 && speckCount >= 10 && baseHp < 90
+            return (
+              <button
+                onClick={() => { if (ready) gameActions.sacrifice?.() }}
+                title="[F] Sacrifice 10 specks → repair +15 HP base (45s cooldown)"
+                style={{
+                  padding: '6px 10px',
+                  fontSize: 11,
+                  cursor: ready ? 'pointer' : 'default',
+                  background: ready ? 'rgba(100,200,100,0.12)' : 'rgba(100,200,100,0.04)',
+                  border: ready ? '1px solid rgba(100,200,100,0.5)' : '1px solid rgba(100,200,100,0.15)',
+                  borderRadius: 20,
+                  color: ready ? '#64c864' : 'rgba(100,200,100,0.35)',
+                  letterSpacing: 1,
+                  minHeight: 44,
+                  fontFamily: 'monospace',
+                  opacity: ready ? 1 : 0.6,
+                }}
+              >
+                {cd > 0 ? `F ${Math.ceil(cd / 1000)}s` : '🔧 F'}
               </button>
             )
           })()}

--- a/src/app/speck-wars/components/phase-router.tsx
+++ b/src/app/speck-wars/components/phase-router.tsx
@@ -201,10 +201,13 @@ export function PhaseRouter({ children }: { children: React.ReactNode }) {
     const nextDiff = won ? nextDifficulty[difficulty] : null
 
     const today = new Date().toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
-    const starStr = won ? '★'.repeat(stars) + '☆'.repeat(3 - stars) + ' ' : ''
+    const starStr = won ? '★'.repeat(stars) + '☆'.repeat(3 - stars) : '✗✗✗'
+    const modifier = hud?.dailyModifier && hud.dailyModifier !== 'standard' ? ` [${hud.dailyModifier.toUpperCase()}]` : ''
+    const effPct = kills + losses > 0 ? Math.round((kills / (kills + losses)) * 100) : 0
+    const statsLine = `⚔ ${kills} kills · ${losses} lost · ${effPct}% eff${peakArmySize > 0 ? ` · peak ${peakArmySize}` : ''}`
     const shareText = won
-      ? `${starStr}I defeated the AI in Speck Wars (${diffLabel}) in ${timeStr} — killed ${kills} specks! 🎮 Daily map ${today} — can you beat my time?`
-      : `The AI beat me in Speck Wars (${diffLabel}) in ${timeStr} — killed ${kills} specks. 🎮 Daily map ${today} — think you can do better?`
+      ? `${starStr} Speck Wars ${today}${modifier}\nVICTORY in ${timeStr} (${diffLabel})\n${statsLine}\nCan you do better? `
+      : `${starStr} Speck Wars ${today}${modifier}\nDEFEATED in ${timeStr} (${diffLabel})\n${statsLine}\nThink you can win? `
 
     const handleShare = async () => {
       const url = typeof window !== 'undefined' ? window.location.href : ''
@@ -271,11 +274,23 @@ export function PhaseRouter({ children }: { children: React.ReactNode }) {
           </div>
         )}
 
-        <div style={{ display: 'flex', gap: 24, alignItems: 'center', color: 'rgba(255,255,255,0.7)', fontSize: 16 }}>
+        <div style={{ display: 'flex', gap: 12, alignItems: 'center', color: 'rgba(255,255,255,0.7)', fontSize: 16, flexWrap: 'wrap', justifyContent: 'center' }}>
           <span>⏱ {timeStr}</span>
           <span style={{ color: diffColor, fontWeight: 'bold', border: `1px solid ${diffColor}`, padding: '2px 10px', borderRadius: 4 }}>
             {diffLabel}
           </span>
+          {hud?.dailyModifier && hud.dailyModifier !== 'standard' && (
+            <span style={{
+              fontSize: 11, letterSpacing: 1.5,
+              color: hud.dailyModifier === 'bulwark' ? '#44aaff'
+                : hud.dailyModifier === 'blitz' ? '#ffd700'
+                : '#ff8844',
+              border: `1px solid ${hud.dailyModifier === 'bulwark' ? '#44aaff44' : hud.dailyModifier === 'blitz' ? '#ffd70044' : '#ff884444'}`,
+              padding: '2px 8px', borderRadius: 4,
+            }}>
+              {hud.dailyModifier.toUpperCase()}
+            </span>
+          )}
         </div>
 
         <div style={{ display: 'flex', gap: 28, color: 'rgba(255,255,255,0.6)', fontSize: 14 }}>

--- a/src/app/speck-wars/domain/simulation/combat.ts
+++ b/src/app/speck-wars/domain/simulation/combat.ts
@@ -56,7 +56,7 @@ export function resolveCombat(sim: SimulationState, dt: number) {
       const dy = speckY[j] - speckY[i]
       const dist = Math.sqrt(dx * dx + dy * dy)
       if (dist <= stype.attackRange) {
-        const veteranBonus = meta.kills >= 3 ? 1.20 : 1.0  // veterans deal +20% damage
+        const veteranBonus = meta.kills >= 6 ? 1.35 : meta.kills >= 3 ? 1.20 : 1.0  // elite +35%, veteran +20%
         // Fortification bonus: if attacker is near a friendly fortified outpost, deal extra damage
         let fortifyBonus = 1.0
         for (const b of Object.values(buildings)) {
@@ -76,6 +76,9 @@ export function resolveCombat(sim: SimulationState, dt: number) {
           sim.events.push({ type: 'SPECK_DIED', speckId: speckIds[j], x: speckX[j], y: speckY[j], killedOwnerId: jMeta.ownerId, killerOwnerId: meta.ownerId })
           if (meta.kills === 3) {
             sim.events.push({ type: 'SPECK_VETERAN', speckId: speckIds[i], ownerId: meta.ownerId })
+          }
+          if (meta.kills === 6) {
+            sim.events.push({ type: 'SPECK_ELITE', speckId: speckIds[i], ownerId: meta.ownerId })
           }
         }
         break  // one attack per cooldown

--- a/src/app/speck-wars/domain/simulation/create-sim.ts
+++ b/src/app/speck-wars/domain/simulation/create-sim.ts
@@ -115,5 +115,6 @@ export function createSim(seed: number = Date.now(), difficulty: Difficulty = 'm
     dailyModifier,
     waveCountdown: null,
     waveInProgress: false,
+    sacrificeCooldown: 0,
   }
 }

--- a/src/app/speck-wars/domain/simulation/tick.ts
+++ b/src/app/speck-wars/domain/simulation/tick.ts
@@ -64,6 +64,7 @@ export function tick(sim: SimulationState, dt: number): SimulationState {
   // 7d. Surge timers
   if (sim.surgeDuration > 0) sim.surgeDuration = Math.max(0, sim.surgeDuration - dt)
   if (sim.surgeCooldown > 0) sim.surgeCooldown = Math.max(0, sim.surgeCooldown - dt)
+  if (sim.sacrificeCooldown > 0) sim.sacrificeCooldown = Math.max(0, sim.sacrificeCooldown - dt)
 
   // 8. Check win/loss
   checkVictory(sim)
@@ -158,6 +159,28 @@ function consumeInputs(sim: SimulationState) {
         sim.surgeDuration = 8000
         sim.surgeCooldown = 45000
       }
+    }
+    if (event.type === 'SACRIFICE') {
+      if (sim.sacrificeCooldown > 0) continue
+      const building = sim.buildings[event.buildingId]
+      if (!building || building.ownerId !== event.ownerId || building.typeId !== 'base') continue
+      // Collect player specks, sorted by lowest HP first (weakest give their life)
+      const candidates: Array<{ i: number; hp: number }> = []
+      for (let i = 0; i < sim.speckCount; i++) {
+        if (!sim.speckIds[i]) continue
+        const m = sim.speckMeta[i]
+        if (!m || m.ownerId !== event.ownerId) continue
+        candidates.push({ i, hp: sim.speckHp[i] })
+      }
+      if (candidates.length < event.count) continue  // not enough specks
+      candidates.sort((a, b) => a.hp - b.hp)
+      const toSacrifice = candidates.slice(0, event.count)
+      for (const { i } of toSacrifice) {
+        sim.events.push({ type: 'SPECK_DIED', speckId: sim.speckIds[i], x: sim.speckX[i], y: sim.speckY[i], killedOwnerId: event.ownerId, killerOwnerId: event.ownerId })
+        sim.speckHp[i] = 0  // mark for removeDeadSpecks
+      }
+      building.hp = Math.min(building.maxHp, building.hp + event.count * 1.5)  // 10 specks → +15 HP
+      sim.sacrificeCooldown = 45000
     }
   }
   sim.inputQueue = []
@@ -256,5 +279,5 @@ function emitHudUpdate(sim: SimulationState) {
     outpostFortify[building.id] = Math.min(1, (building.fortifyDuration ?? 0) / FORTIFY_TIME)
   }
 
-  sim.events.push({ type: 'HUD_UPDATE', data: { players: data, attackedBuildingIds, tripleOutpostOwner, dominationProgress, captureInfo, surgeDuration: sim.surgeDuration, surgeCooldown: sim.surgeCooldown, selectedSpeckCount: sim.selectedSpeckIds.size, spawnRates, minimap, outpostFortify, dailyModifier: sim.dailyModifier, waveCountdown: sim.waveCountdown, waveInProgress: sim.waveInProgress } })
+  sim.events.push({ type: 'HUD_UPDATE', data: { players: data, attackedBuildingIds, tripleOutpostOwner, dominationProgress, captureInfo, surgeDuration: sim.surgeDuration, surgeCooldown: sim.surgeCooldown, selectedSpeckCount: sim.selectedSpeckIds.size, spawnRates, minimap, outpostFortify, dailyModifier: sim.dailyModifier, waveCountdown: sim.waveCountdown, waveInProgress: sim.waveInProgress, sacrificeCooldown: sim.sacrificeCooldown } })
 }

--- a/src/app/speck-wars/domain/types.ts
+++ b/src/app/speck-wars/domain/types.ts
@@ -84,6 +84,7 @@ export type SimEvent =
   | { type: 'HUD_UPDATE'; data: HudData }
   | { type: 'OUTPOST_CAPTURED'; outpostId: string; newOwner: string; previousOwner: string }
   | { type: 'SPECK_VETERAN'; speckId: string; ownerId: string }
+  | { type: 'SPECK_ELITE'; speckId: string; ownerId: string }
   | { type: 'AI_WAVE_START'; waveNumber: number }
 
 export interface HudData {

--- a/src/app/speck-wars/domain/types.ts
+++ b/src/app/speck-wars/domain/types.ts
@@ -64,6 +64,7 @@ export interface SimulationState {
   dailyModifier: 'standard' | 'bulwark' | 'blitz' | 'siege'
   waveCountdown: number | null   // ms until next AI wave (null = waves disabled on this difficulty)
   waveInProgress: boolean        // true during the 15s wave assault
+  sacrificeCooldown: number   // ms remaining before sacrifice can be used again, 0 = ready
 }
 
 export type InputEvent =
@@ -105,6 +106,7 @@ export interface HudData {
   dailyModifier: 'standard' | 'bulwark' | 'blitz' | 'siege'
   waveCountdown: number | null
   waveInProgress: boolean
+  sacrificeCooldown: number
   outpostFortify: Record<string, number>  // outpostId → 0..1 fortification level
   minimap: {
     specks: { x: number; y: number; ownerId: string }[]

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -398,6 +398,10 @@ export class GameInstance {
             setTimeout(() => useSpeckWarsStore.getState().setNotification(null), 2000)
           }
         }
+        if (event.type === 'SPECK_ELITE' && event.ownerId === 'player') {
+          store.setNotification({ message: '✦ ELITE SPECK! +35% DAMAGE', color: '#ffffff' })
+          setTimeout(() => useSpeckWarsStore.getState().setNotification(null), 2500)
+        }
         if (event.type === 'AI_WAVE_START') {
           const waveColors = ['#ff4f7b', '#ff6b35', '#cc00ff']
           const color = waveColors[(event.waveNumber - 1) % waveColors.length]

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -125,6 +125,7 @@ export class GameInstance {
       () => {                                                           // E — select all specks
         this.sim.inputQueue.push({ type: 'BOX_SELECT', ownerId: 'player', x1: -1, y1: -1, x2: 3001, y2: 3001 })
       },
+      () => { this.sacrifice() },                                       // F — sacrifice specks to repair base
     )
     useSpeckWarsStore.getState().setGameActions({
       defend: () => { this.defend(); this.notify('🛡 DEFEND', '#4af7c4') },
@@ -133,6 +134,7 @@ export class GameInstance {
       clearRally: () => this.clearRally(),
       surge: () => { this.surge(); this.notify('⚡ SURGE ACTIVE!', '#ffd700') },
       rally: (x: number, y: number) => this.rally(x, y),
+      sacrifice: () => { this.sacrifice() },
     })
     this.lastTime = performance.now()
     this.loop(this.lastTime)
@@ -522,6 +524,18 @@ export class GameInstance {
 
   surge() {
     this.sim.inputQueue.push({ type: 'SURGE', ownerId: 'player' })
+  }
+
+  private sacrifice() {
+    const playerBase = Object.values(this.sim.buildings).find(b => b.ownerId === 'player' && b.typeId === 'base')
+    if (!playerBase) return
+    const speckCount = this.sim.speckMeta.filter((m, i) => m && m.ownerId === 'player' && this.sim.speckIds[i]).length
+    if (speckCount < 10) {
+      useSpeckWarsStore.getState().setNotification({ message: 'Not enough specks to sacrifice!', color: '#ff4f7b' })
+      setTimeout(() => useSpeckWarsStore.getState().setNotification(null), 1500)
+      return
+    }
+    this.sim.inputQueue.push({ type: 'SACRIFICE', ownerId: 'player', buildingId: playerBase.id, typeId: 'basic', count: 10 })
   }
 
   snapToAction() {

--- a/src/app/speck-wars/input/input-handler.ts
+++ b/src/app/speck-wars/input/input-handler.ts
@@ -19,6 +19,7 @@ export class InputHandler {
   private onSetSpawnType?: (typeId: 'basic' | 'heavy' | 'scout') => void
   private onCycleSpeed?: () => void
   private onSelectAll?: () => void
+  private onSacrifice?: () => void
   private isDragging = false
   private lastX = 0
   private lastY = 0
@@ -51,6 +52,7 @@ export class InputHandler {
     onSetSpawnType?: (typeId: 'basic' | 'heavy' | 'scout') => void,
     onCycleSpeed?: () => void,
     onSelectAll?: () => void,
+    onSacrifice?: () => void,
   ) {
     this.canvas = canvas
     this.camera = camera
@@ -69,6 +71,7 @@ export class InputHandler {
     this.onSetSpawnType = onSetSpawnType
     this.onCycleSpeed = onCycleSpeed
     this.onSelectAll = onSelectAll
+    this.onSacrifice = onSacrifice
     this.attach()
   }
 
@@ -268,6 +271,8 @@ export class InputHandler {
       this.onCycleSpeed?.()
     } else if (e.code === 'KeyE') {
       this.onSelectAll?.()
+    } else if (e.code === 'KeyF') {
+      this.onSacrifice?.()
     }
   }
 

--- a/src/app/speck-wars/rendering/layers/speck-layer.ts
+++ b/src/app/speck-wars/rendering/layers/speck-layer.ts
@@ -83,9 +83,19 @@ export class SpeckLayer {
         const hpFrac = stype ? Math.max(0, sim.speckHp[i] / stype.hp) : 1
         spriteList[j].alpha = 0.35 + 0.65 * hpFrac
 
-        // Gold ring for veteran specks (3+ kills)
-        const isVeteran = (typeMeta?.kills ?? 0) >= 3
-        if (isVeteran) {
+        // Gold ring for veteran specks (3+ kills), bright white diamond ring for elite (6+ kills)
+        const kills = typeMeta?.kills ?? 0
+        const isVeteran = kills >= 3
+        const isElite = kills >= 6
+        if (isElite) {
+          // Bright white outer ring + gold inner ring for elite
+          const elitePulse = 0.7 + 0.3 * Math.sin(now / 200)
+          this.gfx.lineStyle(2, 0xffffff, elitePulse * spriteList[j].alpha)
+          this.gfx.drawCircle(sim.speckX[i], sim.speckY[i], (stype ? stype.size / 4 : 0.75) + 5)
+          this.gfx.lineStyle(1.5, 0xffd700, spriteList[j].alpha * 0.9)
+          this.gfx.drawCircle(sim.speckX[i], sim.speckY[i], (stype ? stype.size / 4 : 0.75) + 2.5)
+          this.gfx.lineStyle(0)
+        } else if (isVeteran) {
           this.gfx.lineStyle(1.5, 0xffd700, spriteList[j].alpha * 0.9)
           this.gfx.drawCircle(sim.speckX[i], sim.speckY[i], (stype ? stype.size / 4 : 0.75) + 2.5)
           this.gfx.lineStyle(0)

--- a/src/app/speck-wars/store.ts
+++ b/src/app/speck-wars/store.ts
@@ -36,8 +36,8 @@ interface SpeckWarsStore {
   addOutpostCaptured: () => void
   isNewBest: boolean
   setIsNewBest: (v: boolean) => void
-  gameActions: { defend: (() => void) | null; advance: (() => void) | null; rush: (() => void) | null; clearRally: (() => void) | null; surge: (() => void) | null; rally: ((x: number, y: number) => void) | null }
-  setGameActions: (actions: { defend: () => void; advance: () => void; rush: () => void; clearRally: () => void; surge: () => void; rally: (x: number, y: number) => void } | null) => void
+  gameActions: { defend: (() => void) | null; advance: (() => void) | null; rush: (() => void) | null; clearRally: (() => void) | null; surge: (() => void) | null; rally: ((x: number, y: number) => void) | null; sacrifice: (() => void) | null }
+  setGameActions: (actions: { defend: () => void; advance: () => void; rush: () => void; clearRally: () => void; surge: () => void; rally: (x: number, y: number) => void; sacrifice: () => void } | null) => void
   surrender: () => void
   resetGame: () => void
 }
@@ -84,8 +84,8 @@ export const useSpeckWarsStore = create<SpeckWarsStore>()((set, get) => ({
   addOutpostCaptured: () => set(s => ({ outpostsCaptured: s.outpostsCaptured + 1 })),
   isNewBest: false,
   setIsNewBest: v => set({ isNewBest: v }),
-  gameActions: { defend: null, advance: null, rush: null, clearRally: null, surge: null, rally: null },
-  setGameActions: (actions) => set({ gameActions: actions ?? { defend: null, advance: null, rush: null, clearRally: null, surge: null, rally: null } }),
+  gameActions: { defend: null, advance: null, rush: null, clearRally: null, surge: null, rally: null, sacrifice: null },
+  setGameActions: (actions) => set({ gameActions: actions ?? { defend: null, advance: null, rush: null, clearRally: null, surge: null, rally: null, sacrifice: null } }),
   surrender: () => {
     const s = get()
     resetWinStreak()


### PR DESCRIPTION
Adds elite tier above veteran. 3 kills → veteran (gold ring, +20% damage). 6 kills → elite (pulsing white+gold rings, +35% damage). Fires SPECK_ELITE event; player gets white notification.