### PR TITLE
feat(speck-wars): contested outpost tug-of-war

### DIFF
--- a/src/app/speck-wars/domain/simulation/capture.ts
+++ b/src/app/speck-wars/domain/simulation/capture.ts
@@ -21,7 +21,24 @@ export function updateCapture(sim: SimulationState, dt: number) {
     // Find player-owned specks (exclude neutral)
     const sides = Object.entries(counts).filter(([, n]) => n > 0)
     if (sides.length === 0) continue  // nobody near — decay progress slowly
-    if (sides.length > 1) continue  // contested — pause capture
+    if (sides.length > 1) {
+      // Contested tug-of-war: dominant side (more specks) reverses enemy capture progress.
+      // Neither side can GAIN progress — only erase the enemy's progress.
+      sides.sort((a, b) => b[1] - a[1])
+      const [topOwner, topCount] = sides[0]
+      const [, secondCount] = sides[1]
+      if (topCount > secondCount) {
+        const hasEnemyProgress = (building.captureProgress ?? 0) > 0 &&
+          building.captureSide && building.captureSide !== topOwner
+        if (hasEnemyProgress) {
+          const captureTimeMs = sim.dailyModifier === 'siege' ? CAPTURE_TIME * 2 : CAPTURE_TIME
+          const reverseSpeed = Math.min(1.5, (topCount - secondCount) / 5)
+          building.captureProgress = Math.max(0, (building.captureProgress ?? 0) - (dt / captureTimeMs) * reverseSpeed * 0.5)
+          if ((building.captureProgress ?? 0) <= 0) building.captureSide = null
+        }
+      }
+      continue  // never allow capture completion when contested
+    }
 
     const [dominantOwner, dominantCount] = sides[0]
     if (dominantOwner === building.ownerId) continue  // already owned by them

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -31,6 +31,8 @@ export class GameInstance {
   private recentKillTimes: number[] = []  // timestamps of recent player kills (combo detection)
   private recentDeathPositions: { x: number; y: number; ts: number }[] = []
   private lastComboNotifiedAt = -5000
+  private recentKillTs: number[] = []        // timestamps of player kills in rolling window (kill streak)
+  private lastStreakNotifiedAt = 0            // prevent kill streak notification spam
   private idleArmyTimer = 0              // ms with no rally point + specks available
   private lastIdleNudge = -30000         // allow nudge immediately if idle at game start
   private cachedPlayerSpeckCount = 0    // updated from HUD_UPDATE
@@ -336,6 +338,26 @@ export class GameInstance {
           this.recentDeathPositions.push({ x: event.x, y: event.y, ts: Date.now() })
           // Keep only last 30 deaths
           if (this.recentDeathPositions.length > 30) this.recentDeathPositions.shift()
+          // Kill streak tracking for player killer
+          if (event.killerOwnerId === 'player') {
+            const now = Date.now()
+            this.recentKillTs.push(now)
+            // Keep only kills in last 8 seconds
+            this.recentKillTs = this.recentKillTs.filter(t => now - t < 8000)
+            const killCount = this.recentKillTs.length
+            if (now - this.lastStreakNotifiedAt > 4000) {
+              if (killCount >= 20) {
+                this.lastStreakNotifiedAt = now
+                this.notify('⚡ UNSTOPPABLE! ×' + killCount, '#ffffff')
+              } else if (killCount >= 10) {
+                this.lastStreakNotifiedAt = now
+                this.notify('⚡ RAMPAGE! ×' + killCount, '#ffd700')
+              } else if (killCount >= 5) {
+                this.lastStreakNotifiedAt = now
+                this.notify('⚡ KILLING SPREE ×' + killCount, '#ff8844')
+              }
+            }
+          }
         }
         if (event.type === 'BUILDING_DAMAGED' && event.buildingId === 'building-ai-base') {
           const aiBase = this.sim.buildings['building-ai-base']


### PR DESCRIPTION
When two sides contest an outpost, the dominant side (more specks) now reverses the enemy's capture progress at 0.5× reverse speed (scaled by numerical advantage). Neither side can complete a capture while contested. Makes frontline outpost fights feel more dynamic.