### PR TITLE
feat(speck-wars): veteran + elite speck counts in HUD army section

### DIFF
--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -923,6 +923,22 @@ export function HUD() {
                 </div>
               )
             })()}
+            {/* Veteran / elite count */}
+            {(() => {
+              const vets = hud.players.player?.veteranCount ?? 0
+              const elites = hud.players.player?.eliteCount ?? 0
+              if (vets + elites === 0) return null
+              return (
+                <div style={{ display: 'flex', gap: 8, fontSize: 9, letterSpacing: 0.5 }}>
+                  {elites > 0 && (
+                    <span style={{ color: '#ffffff', opacity: 0.8 }}>✦ {elites} elite</span>
+                  )}
+                  {vets > 0 && (
+                    <span style={{ color: '#ffd700', opacity: 0.65 }}>⭐ {vets} vet</span>
+                  )}
+                </div>
+              )
+            })()}
             {/* Kill/loss + enemy base HP */}
             <div style={{ display: 'flex', gap: 10, fontSize: 10, letterSpacing: 0.5 }}>
               <span style={{ color: colorHex(PLAYER_COLOR), opacity: 0.7 }}>↑{kills} ↓{losses}</span>

--- a/src/app/speck-wars/domain/simulation/tick.ts
+++ b/src/app/speck-wars/domain/simulation/tick.ts
@@ -187,16 +187,19 @@ function consumeInputs(sim: SimulationState) {
 }
 
 function emitHudUpdate(sim: SimulationState) {
-  const data: Record<string, { speckCount: number; buildingCount: number; buildingHp: Record<string, number>; speckTypes: Record<string, number> }> = {}
+  const data: Record<string, { speckCount: number; buildingCount: number; buildingHp: Record<string, number>; speckTypes: Record<string, number>; veteranCount: number; eliteCount: number }> = {}
   for (const [pid] of Object.entries(sim.players)) {
     const myBuildings = Object.values(sim.buildings).filter(b => b.ownerId === pid)
     let liveCount = 0
+    let veteranCount = 0, eliteCount = 0
     const speckTypes: Record<string, number> = {}
     for (let i = 0; i < sim.speckCount; i++) {
       const m = sim.speckMeta[i]
       if (m && m.ownerId === pid) {
         liveCount++
         speckTypes[m.typeId] = (speckTypes[m.typeId] ?? 0) + 1
+        if (m.kills >= 6) eliteCount++
+        else if (m.kills >= 3) veteranCount++
       }
     }
     data[pid] = {
@@ -204,6 +207,8 @@ function emitHudUpdate(sim: SimulationState) {
       buildingCount: myBuildings.length,
       buildingHp: Object.fromEntries(myBuildings.map(b => [b.id, b.hp])),
       speckTypes,
+      veteranCount,
+      eliteCount,
     }
   }
   // Buildings that are owned but actively being captured by the enemy

--- a/src/app/speck-wars/domain/types.ts
+++ b/src/app/speck-wars/domain/types.ts
@@ -94,6 +94,8 @@ export interface HudData {
     buildingCount: number
     buildingHp: Record<string, number>
     speckTypes: Record<string, number>  // typeId → count
+    veteranCount: number  // specks with 3+ kills
+    eliteCount: number    // specks with 6+ kills
   }>
   attackedBuildingIds: string[]
   tripleOutpostOwner: string | null  // player ID who owns all 3 outposts, or null


### PR DESCRIPTION
Shows ✦ N elite (white) and ⭐ N vet (gold) below army composition when any veteran/elite specks are alive. Driven by new veteranCount/eliteCount fields in HudData, computed per-tick in emitHudUpdate by checking speckMeta.kills.