### PR TITLE
feat(speck-wars): expand first-game tutorial hints

### DIFF
--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -151,9 +151,12 @@ export class GameInstance {
     if (isFirstGame()) {
       markFirstGameDone()
       const hints = [
-        { delay: 1200, message: '💡 Click the map to rally your specks!', color: '#aaddff' },
-        { delay: 6000, message: '💡 Capture outposts to boost production!', color: '#aaddff' },
-        { delay: 13000, message: '💡 Hold all 3 outposts for 60s to dominate!', color: '#ffd700' },
+        { delay: 1200,  message: '💡 Click the map to rally your specks!', color: '#aaddff' },
+        { delay: 6000,  message: '💡 Capture outposts to boost production!', color: '#aaddff' },
+        { delay: 13000, message: '💡 Press Q for Surge — doubles production for 8s!', color: '#ffd700' },
+        { delay: 22000, message: '💡 Press 1/2/3 to switch spawn type (basic/heavy/scout)', color: '#aaddff' },
+        { delay: 32000, message: '💡 Hold all 3 outposts for 60s to win by domination!', color: '#ffd700' },
+        { delay: 45000, message: '💡 Press F to sacrifice 10 specks and repair your base!', color: '#64c864' },
       ]
       for (const { delay, message, color } of hints) {
         setTimeout(() => {


### PR DESCRIPTION
First-game tutorial now covers 6 mechanics instead of 3: rally, outposts, Surge (Q), spawn types (1/2/3), domination, and sacrifice repair (F). Hints fire at 1s, 6s, 13s, 22s, 32s, 45s intervals during the first game.