### PR TITLE
feat(speck-wars): 3 direct spawn type buttons replace cycle button

### DIFF
--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -42,7 +42,7 @@ export function HUD() {
   const kills = useSpeckWarsStore(s => s.kills)
   const losses = useSpeckWarsStore(s => s.losses)
   const spawnMode = useSpeckWarsStore(s => s.spawnMode)
-  const cycleSpawnMode = useSpeckWarsStore(s => s.cycleSpawnMode)
+  const setSpawnMode = useSpeckWarsStore(s => s.setSpawnMode)
   const difficulty = useSpeckWarsStore(s => s.difficulty)
   const surrender = useSpeckWarsStore(s => s.surrender)
   const gameActions = useSpeckWarsStore(s => s.gameActions)
@@ -309,23 +309,32 @@ export function HUD() {
         >
           {speed}×
         </button>
-        <button
-          onClick={cycleSpawnMode}
-          title="H — cycle spawn mode (basic → heavy → scout)"
-          style={{
-            pointerEvents: 'auto',
-            padding: '4px 14px',
-            fontSize: 12,
-            cursor: 'pointer',
-            background: spawnMode === 'heavy' ? 'rgba(255,160,50,0.15)' : spawnMode === 'scout' ? 'rgba(80,200,255,0.15)' : 'rgba(0,0,0,0.5)',
-            border: `1px solid ${spawnMode === 'heavy' ? '#ffa032' : spawnMode === 'scout' ? '#50c8ff' : 'rgba(255,255,255,0.3)'}`,
-            borderRadius: 4,
-            color: spawnMode === 'heavy' ? '#ffa032' : spawnMode === 'scout' ? '#50c8ff' : '#fff',
-            letterSpacing: 1,
-          }}
-        >
-          {spawnMode === 'heavy' ? '⬡ HEAVY' : spawnMode === 'scout' ? '→ SCOUT' : '· BASIC'}
-        </button>
+        {/* Spawn type selector — 3 direct buttons instead of cycle */}
+        {(['basic', 'heavy', 'scout'] as const).map((type, idx) => {
+          const active = spawnMode === type
+          const color = type === 'heavy' ? '#ffa032' : type === 'scout' ? '#50c8ff' : '#ffffff'
+          const label = type === 'heavy' ? '⬡' : type === 'scout' ? '→' : '·'
+          return (
+            <button
+              key={type}
+              onClick={() => gameActions?.setSpawnType?.(type)}
+              title={`[${idx + 1}] Spawn ${type}`}
+              style={{
+                pointerEvents: 'auto',
+                padding: '4px 9px',
+                fontSize: 13,
+                cursor: 'pointer',
+                background: active ? `${color}22` : 'rgba(0,0,0,0.5)',
+                border: `1px solid ${active ? color : 'rgba(255,255,255,0.2)'}`,
+                borderRadius: idx === 0 ? '4px 0 0 4px' : idx === 2 ? '0 4px 4px 0' : '0',
+                color: active ? color : 'rgba(255,255,255,0.4)',
+                marginLeft: idx === 0 ? 0 : -1,
+              }}
+            >
+              {label}
+            </button>
+          )
+        })}
         <button
           onClick={() => setShowHelp(h => !h)}
           title="? — show controls"

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -137,6 +137,12 @@ export class GameInstance {
       surge: () => { this.surge(); this.notify('⚡ SURGE ACTIVE!', '#ffd700') },
       rally: (x: number, y: number) => this.rally(x, y),
       sacrifice: () => { this.sacrifice() },
+      setSpawnType: (typeId: 'basic' | 'heavy' | 'scout') => {
+        useSpeckWarsStore.getState().setSpawnMode(typeId)
+        this.sim.inputQueue.push({ type: 'SET_SPAWN_TYPE', ownerId: 'player', speckTypeId: typeId })
+        const color = typeId === 'heavy' ? '#ff8844' : typeId === 'scout' ? '#50c8ff' : '#4af7c4'
+        this.notify(`Spawn: ${typeId.toUpperCase()}`, color)
+      },
     })
     this.lastTime = performance.now()
     this.loop(this.lastTime)

--- a/src/app/speck-wars/store.ts
+++ b/src/app/speck-wars/store.ts
@@ -36,8 +36,8 @@ interface SpeckWarsStore {
   addOutpostCaptured: () => void
   isNewBest: boolean
   setIsNewBest: (v: boolean) => void
-  gameActions: { defend: (() => void) | null; advance: (() => void) | null; rush: (() => void) | null; clearRally: (() => void) | null; surge: (() => void) | null; rally: ((x: number, y: number) => void) | null; sacrifice: (() => void) | null }
-  setGameActions: (actions: { defend: () => void; advance: () => void; rush: () => void; clearRally: () => void; surge: () => void; rally: (x: number, y: number) => void; sacrifice: () => void } | null) => void
+  gameActions: { defend: (() => void) | null; advance: (() => void) | null; rush: (() => void) | null; clearRally: (() => void) | null; surge: (() => void) | null; rally: ((x: number, y: number) => void) | null; sacrifice: (() => void) | null; setSpawnType: ((type: 'basic' | 'heavy' | 'scout') => void) | null }
+  setGameActions: (actions: { defend: () => void; advance: () => void; rush: () => void; clearRally: () => void; surge: () => void; rally: (x: number, y: number) => void; sacrifice: () => void; setSpawnType: (type: 'basic' | 'heavy' | 'scout') => void } | null) => void
   surrender: () => void
   resetGame: () => void
 }
@@ -84,8 +84,8 @@ export const useSpeckWarsStore = create<SpeckWarsStore>()((set, get) => ({
   addOutpostCaptured: () => set(s => ({ outpostsCaptured: s.outpostsCaptured + 1 })),
   isNewBest: false,
   setIsNewBest: v => set({ isNewBest: v }),
-  gameActions: { defend: null, advance: null, rush: null, clearRally: null, surge: null, rally: null, sacrifice: null },
-  setGameActions: (actions) => set({ gameActions: actions ?? { defend: null, advance: null, rush: null, clearRally: null, surge: null, rally: null, sacrifice: null } }),
+  gameActions: { defend: null, advance: null, rush: null, clearRally: null, surge: null, rally: null, sacrifice: null, setSpawnType: null },
+  setGameActions: (actions) => set({ gameActions: actions ?? { defend: null, advance: null, rush: null, clearRally: null, surge: null, rally: null, sacrifice: null, setSpawnType: null } }),
   surrender: () => {
     const s = get()
     resetWinStreak()


### PR DESCRIPTION
Replaces the single 'cycle spawn mode' button with 3 compact direct-select buttons (·basic / ⬡heavy / →scout). Active type highlighted with color. Title hints show keyboard shortcuts [1][2][3]. Improves mobile UX — no longer need to tap multiple times to get to a specific type.