### PR TITLE
feat(speck-wars): outpost supremacy bonus — +15% damage when owning 2+ more outposts

### DIFF
--- a/src/app/speck-wars/domain/simulation/combat.ts
+++ b/src/app/speck-wars/domain/simulation/combat.ts
@@ -7,6 +7,8 @@ const MORALE_RATIO = 2.0   // if your count > this × enemy count → morale bon
 const MORALE_BONUS = 1.20  // 20% damage boost when morale is active
 const RAGE_HP_THRESHOLD = 0.15  // base HP fraction below which rage activates
 const RAGE_BONUS = 1.40         // 40% damage boost when base is critical
+const SUPREMACY_OUTPOST_LEAD = 2   // outpost advantage needed for supremacy
+const SUPREMACY_BONUS = 1.15        // 15% damage boost for outpost supremacy
 
 export function resolveCombat(sim: SimulationState, dt: number) {
   const { speckIds, speckX, speckY, speckHp, speckMeta, buildings, spatialGrid } = sim
@@ -17,6 +19,14 @@ export function resolveCombat(sim: SimulationState, dt: number) {
     const ownerId = speckMeta[i]?.ownerId
     if (speckIds[i] && ownerId) speckCountByOwner[ownerId] = (speckCountByOwner[ownerId] ?? 0) + 1
   }
+
+  // Pre-compute outpost ownership counts for supremacy bonus
+  const outpostCountByOwner: Record<string, number> = {}
+  for (const b of Object.values(buildings)) {
+    if (b.typeId !== 'outpost' || b.ownerId === 'neutral') continue
+    outpostCountByOwner[b.ownerId] = (outpostCountByOwner[b.ownerId] ?? 0) + 1
+  }
+
   const moraleMult = (ownerId: string): number => {
     const myCount = speckCountByOwner[ownerId] ?? 0
     let maxEnemyCount = 0
@@ -29,7 +39,15 @@ export function resolveCombat(sim: SimulationState, dt: number) {
     const base = Object.values(buildings).find(b => b.ownerId === ownerId && b.typeId === 'base')
     const rageBonus = (base && base.hp / base.maxHp < RAGE_HP_THRESHOLD) ? RAGE_BONUS : 1.0
 
-    return Math.max(moraleBonus, rageBonus)  // apply highest active bonus (don't stack)
+    // Supremacy: owning 2+ more outposts than any enemy → +15% damage (territorial control)
+    const myOutposts = outpostCountByOwner[ownerId] ?? 0
+    let maxEnemyOutposts = 0
+    for (const [id, n] of Object.entries(outpostCountByOwner)) {
+      if (id !== ownerId && n > maxEnemyOutposts) maxEnemyOutposts = n
+    }
+    const supremacyBonus = (myOutposts - maxEnemyOutposts >= SUPREMACY_OUTPOST_LEAD) ? SUPREMACY_BONUS : 1.0
+
+    return Math.max(moraleBonus, rageBonus) * supremacyBonus  // supremacy stacks on top
   }
 
   // --- Speck vs Speck combat ---


### PR DESCRIPTION
## Summary

- Adds an **outpost supremacy bonus**: owning 2+ more outposts than the enemy grants +15% damage to all your specks
- Pre-computes outpost counts once per `resolveCombat` call (O(buildings)) rather than per-speck, keeping combat fast
- Stacks multiplicatively with existing morale/rage bonuses (takes max of morale/rage, then × supremacy)
- Creates a meaningful reward for aggressive outpost control beyond just spawner income

## Details

`domain/simulation/combat.ts`:
- `SUPREMACY_OUTPOST_LEAD = 2` — minimum outpost lead required
- `SUPREMACY_BONUS = 1.15` — 15% damage multiplier
- `outpostCountByOwner` computed once before speck loop; referenced inside `moraleMult` closure
- Return: `Math.max(moraleBonus, rageBonus) * supremacyBonus`

## Test plan
- [ ] Own 1 outpost vs 0 → no bonus (need ≥2 lead)
- [ ] Own 2 outposts vs 0 → +15% damage applied to all your specks
- [ ] Own all 3 outposts vs 0 → still +15% (supremacy only checks ≥2 lead)
- [ ] Enemy owns 1, you own 3 → 3-1=2 lead → bonus active
- [ ] Stacks with triple-outpost domination timer (separate systems)
- [ ] TypeScript: `npx tsc --noEmit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)