### PR TITLE
feat(speck-wars): retreating specks heal at base and re-engage at 75% HP

### DIFF
--- a/src/app/speck-wars/domain/simulation/movement.ts
+++ b/src/app/speck-wars/domain/simulation/movement.ts
@@ -45,7 +45,9 @@ export function moveSpecks(sim: SimulationState, dt: number) {
         const btype = BUILDING_TYPES[nearestBuilding.typeId]
         const bRadius = btype?.size ?? 20
         if (nearestDist2 <= bRadius * bRadius) {
-          meta.state = 'idle'
+          // Retreating specks: stop movement, let regenRetreatingSpecks handle idle transition
+          sim.speckVx[i] = 0
+          sim.speckVy[i] = 0
         } else {
           const dist = Math.sqrt(nearestDist2)
           const dx = nearestBuilding.x - speckX[i]

--- a/src/app/speck-wars/domain/simulation/tick.ts
+++ b/src/app/speck-wars/domain/simulation/tick.ts
@@ -39,6 +39,9 @@ export function tick(sim: SimulationState, dt: number): SimulationState {
     }
   }
 
+  // 5c. Heal retreating specks that have reached a friendly building
+  regenRetreatingSpecks(sim, dt)
+
   // 6. Remove dead specks (compact arrays)
   removeDeadSpecks(sim)
 
@@ -74,6 +77,41 @@ export function tick(sim: SimulationState, dt: number): SimulationState {
   if (sim.tick % HUD_UPDATE_INTERVAL === 0) emitHudUpdate(sim)
 
   return sim
+}
+
+function regenRetreatingSpecks(sim: SimulationState, dt: number) {
+  const dtSec = dt / 1000
+  const REGEN_RATE = 2  // HP per second while sheltering at base
+  const REENGAGE_THRESHOLD = 0.75  // re-engage when HP is at 75% of max
+
+  for (let i = 0; i < sim.speckCount; i++) {
+    const meta = sim.speckMeta[i]
+    if (!meta || meta.state !== 'retreating') continue
+    if (sim.speckHp[i] <= 0) continue
+
+    // Only heal if within range of a friendly building
+    let nearFriendly = false
+    for (const building of Object.values(sim.buildings)) {
+      if (building.ownerId !== meta.ownerId) continue
+      const bsize = BUILDING_TYPES[building.typeId]?.size ?? 40
+      const dx = sim.speckX[i] - building.x
+      const dy = sim.speckY[i] - building.y
+      if (dx * dx + dy * dy <= (bsize + 30) * (bsize + 30)) {
+        nearFriendly = true
+        break
+      }
+    }
+
+    if (!nearFriendly) continue
+
+    const maxHp = SPECK_TYPES[meta.typeId]?.hp ?? 1
+    sim.speckHp[i] = Math.min(maxHp, sim.speckHp[i] + REGEN_RATE * dtSec)
+
+    // Re-engage once healed enough
+    if (sim.speckHp[i] >= maxHp * REENGAGE_THRESHOLD) {
+      meta.state = 'idle'
+    }
+  }
 }
 
 function regenBuildingHp(sim: SimulationState, dt: number) {


### PR DESCRIPTION
## Summary

- Retreating specks (HP < 25%) that reach a friendly building now shelter and heal at **2 HP/sec**, then automatically re-engage combat when HP reaches **75%**
- Previously specks retreated to base but immediately transitioned to `idle`, causing the AI to re-assign them to fight at near-zero HP — retreat was pointless
- Veterans and elites can now be saved by letting them retreat, adding meaningful tactical micro

## Details

### `domain/simulation/movement.ts`
When a retreating speck reaches its target building (distance ≤ building.size), instead of setting `meta.state = 'idle'`, it now zeroes velocity and returns — leaving the speck in `'retreating'` state so the regen function can handle the idle transition.

### `domain/simulation/tick.ts`
New **step 5c** function `regenRetreatingSpecks(sim, dt)`:
- Scans retreating specks within `building.size + 30` px of any friendly building
- Heals at 2 HP/sec (`sim.speckHp[i] += REGEN_RATE * dtSec`)
- Transitions to `'idle'` once HP ≥ 75% of max, allowing AI re-engagement

Called between step 5b (retreat marking) and step 6 (remove dead specks).

## Test plan
- [ ] Heavy speck at low HP retreats to base → pauses, heals, then attacks again
- [ ] Elite speck retreats → survives and returns to fight (saves your best units)
- [ ] Specks in the field (not near base) don't heal while retreating
- [ ] Outpost can also serve as shelter (heal near outpost)
- [ ] TypeScript: `npx tsc --noEmit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)