### PR TITLE
feat(speck-wars): visual drag-selection box with corner brackets

### DIFF
--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -514,7 +514,8 @@ export class GameInstance {
       shakeX = (Math.random() * 2 - 1) * s
       shakeY = (Math.random() * 2 - 1) * s
     }
-    this.renderer.render(this.sim, this.camera, dt, shakeX, shakeY)
+    const dragRect = this.inputHandler.getDragRect()
+    this.renderer.render(this.sim, this.camera, dt, shakeX, shakeY, dragRect)
     this.rafId = requestAnimationFrame(this.loop)
   }
 

--- a/src/app/speck-wars/input/input-handler.ts
+++ b/src/app/speck-wars/input/input-handler.ts
@@ -126,6 +126,10 @@ export class InputHandler {
 
   private onMouseMove = (e: MouseEvent) => {
     if (!this.isDragging) return
+    // Update cursor position always (needed for selection box visual)
+    const rect = this.canvas.getBoundingClientRect()
+    this.mouseX = e.clientX - rect.left
+    this.mouseY = e.clientY - rect.top
     if (this.isShiftDrag) return  // skip pan during shift-drag
     this.camera.x += e.clientX - this.lastX
     this.camera.y += e.clientY - this.lastY
@@ -273,6 +277,17 @@ export class InputHandler {
       this.onSelectAll?.()
     } else if (e.code === 'KeyF') {
       this.onSacrifice?.()
+    }
+  }
+
+  getDragRect(): { x1: number; y1: number; x2: number; y2: number } | null {
+    if (!this.isShiftDrag) return null
+    const rect = this.canvas.getBoundingClientRect()
+    return {
+      x1: this.mouseDownX - rect.left,
+      y1: this.mouseDownY - rect.top,
+      x2: this.mouseX,
+      y2: this.mouseY,
     }
   }
 

--- a/src/app/speck-wars/rendering/renderer.ts
+++ b/src/app/speck-wars/rendering/renderer.ts
@@ -35,6 +35,7 @@ export class Renderer {
   private effectsLayer!: EffectsLayer
   private starfieldLayer!: StarfieldLayer
   private rallyGfx!: Graphics
+  private selectionGfx!: Graphics
 
   async init(canvas: HTMLCanvasElement) {
     const app = new Application() as PixiApplication
@@ -65,9 +66,12 @@ export class Renderer {
 
     this.rallyGfx = new Graphics()
     this.world.addChild(this.rallyGfx)
+
+    this.selectionGfx = new Graphics()
+    this.app.stage.addChild(this.selectionGfx)
   }
 
-  render(sim: SimulationState, camera: { x: number; y: number; zoom: number }, dt: number, shakeX = 0, shakeY = 0) {
+  render(sim: SimulationState, camera: { x: number; y: number; zoom: number }, dt: number, shakeX = 0, shakeY = 0, dragRect?: { x1: number; y1: number; x2: number; y2: number } | null): void {
     this.world.position.set(camera.x + shakeX, camera.y + shakeY)
     this.world.scale.set(camera.zoom)
 
@@ -144,6 +148,31 @@ export class Renderer {
         }
       }
     }
+
+    // Draw drag-selection box (screen space)
+    this.selectionGfx.clear()
+    if (dragRect) {
+      const { x1, y1, x2, y2 } = dragRect
+      const minX = Math.min(x1, x2), maxX = Math.max(x1, x2)
+      const minY = Math.min(y1, y2), maxY = Math.max(y1, y2)
+      const w = maxX - minX, h = maxY - minY
+      // Semi-transparent cyan fill
+      this.selectionGfx.beginFill(0x4af7c4, 0.08)
+      this.selectionGfx.lineStyle(1.5, 0x4af7c4, 0.9)
+      this.selectionGfx.drawRect(minX, minY, w, h)
+      this.selectionGfx.endFill()
+      // Corner brackets for RTS feel
+      const cs = Math.min(12, w / 3, h / 3)  // corner size
+      this.selectionGfx.lineStyle(2, 0x4af7c4, 1.0)
+      // Top-left
+      this.selectionGfx.moveTo(minX, minY + cs); this.selectionGfx.lineTo(minX, minY); this.selectionGfx.lineTo(minX + cs, minY)
+      // Top-right
+      this.selectionGfx.moveTo(maxX - cs, minY); this.selectionGfx.lineTo(maxX, minY); this.selectionGfx.lineTo(maxX, minY + cs)
+      // Bottom-left
+      this.selectionGfx.moveTo(minX, maxY - cs); this.selectionGfx.lineTo(minX, maxY); this.selectionGfx.lineTo(minX + cs, maxY)
+      // Bottom-right
+      this.selectionGfx.moveTo(maxX - cs, maxY); this.selectionGfx.lineTo(maxX, maxY); this.selectionGfx.lineTo(maxX, maxY - cs)
+    }
   }
 
   showRallyPing(x: number, y: number) {
@@ -157,6 +186,7 @@ export class Renderer {
     this.speckLayer.destroy()
     this.buildingLayer.destroy()
     this.rallyGfx.destroy()
+    this.selectionGfx.destroy()
     this.app.destroy()
   }
 }


### PR DESCRIPTION
## Summary

- When Shift+dragging to box-select specks, a glowing **cyan selection rectangle** now appears with corner brackets (classic RTS style)
- Previously no visual feedback existed during drag — players had no idea what area they were selecting

## Details

**`input/input-handler.ts`**
- `mouseX/Y` now update during shift-drag (moved before early return guard)
- Added `getDragRect()` public method returning canvas-relative `{x1,y1,x2,y2}` while dragging, `null` otherwise

**`rendering/renderer.ts`**
- `selectionGfx: Graphics` added to `app.stage` (screen space, not world container)
- Drawn each frame in `render()`: semi-transparent cyan fill (8% opacity) + 1.5px border + 2px corner brackets
- Cleared when not dragging; auto-destroyed on `destroy()`

**`game-instance.ts`**
- Fetches `inputHandler.getDragRect()` each loop frame and passes to `renderer.render()`

## Test plan
- [ ] Shift+drag → cyan rectangle tracks cursor with corner brackets visible
- [ ] Release mouse → rectangle disappears, specks in area are selected (highlighted)
- [ ] Small Shift+click (no drag) → selection cleared (existing behavior preserved)
- [ ] Rectangle correctly handles reversed drag (start bottom-right, drag top-left)
- [ ] TypeScript: `npx tsc --noEmit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)