### PR TITLE
feat(speck-wars): H key snaps to home base + OUTNUMBERED HUD badge

### DIFF
--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -89,6 +89,20 @@ export function HUD() {
           animation: 'pulse-red 0.6s ease-in-out infinite alternate',
         }}>⚠ BASE UNDER ATTACK</div>
       )}
+      {(() => {
+        const myCount = hud?.players?.player?.speckCount ?? 0
+        const aiCount = hud?.players?.ai?.speckCount ?? 0
+        const ratio = myCount > 0 ? aiCount / myCount : (aiCount > 0 ? 999 : 0)
+        if (ratio < 2.5) return null
+        return (
+          <div style={{
+            position: 'fixed', top: 44, left: '50%', transform: 'translateX(-50%)',
+            background: 'rgba(200,100,0,0.9)', color: '#fff', fontWeight: 700,
+            padding: '3px 12px', borderRadius: 6, fontSize: 12, letterSpacing: 1,
+            zIndex: 109, pointerEvents: 'none',
+          }}>OUTNUMBERED {Math.round(ratio)}:1</div>
+        )
+      })()}
       {isDanger && (
         <>
           <style>{`
@@ -404,11 +418,11 @@ export function HUD() {
           }}>
             <span>🖱 Click — rally specks</span><span>Space — pause</span>
             <span>Scroll — zoom</span><span>R / Right-click — clear rally</span>
-            <span>Drag — pan camera</span><span>1/2/3 or H — set/cycle spawn type</span>
+            <span>Drag — pan camera</span><span>1/2/3 — set spawn type</span>
             <span>A — advance to outpost</span><span>C — center on base</span>
             <span>B — rush enemy base</span><span>D — defend base</span>
             <span>Q — surge (2× spawn 8s)</span><span>V — snap camera to battle</span>
-            <span>Shift+drag — select specks</span><span>Minimap — click to rally</span>
+            <span>H — snap to home base</span><span>Minimap — click to rally</span>
             <span>E — select all specks</span><span>X — cycle speed (1×/2×/4×)</span>
             <span>F — sacrifice 10 specks → +15 HP base</span><span>? — this help</span>
             <span style={{ gridColumn: '1/-1', borderTop: '1px solid rgba(255,255,255,0.08)', paddingTop: 8, marginTop: 2, color: 'rgba(255,215,0,0.5)', fontSize: 11 }}>

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -114,6 +114,7 @@ export class GameInstance {
       },
       () => { this.surge(); this.notify('⚡ SURGE ACTIVE!', '#ffd700') },  // Q — production surge
       () => { this.snapToAction() },                                        // V — snap camera to battle
+      () => { this.snapToBase() },                                          // H — snap camera to home base
       (typeId: 'basic' | 'heavy' | 'scout') => {               // 1/2/3 — set spawn type directly
         useSpeckWarsStore.getState().setSpawnMode(typeId)
         this.sim.inputQueue.push({ type: 'SET_SPAWN_TYPE', ownerId: 'player', speckTypeId: typeId })
@@ -589,6 +590,17 @@ export class GameInstance {
     const h = this.canvas.clientHeight
     this.camera.x = w / 2 - cx * this.camera.zoom
     this.camera.y = h / 2 - cy * this.camera.zoom
+  }
+
+  private snapToBase() {
+    const playerBase = Object.values(this.sim.buildings).find(b => b.ownerId === 'player' && b.typeId === 'base')
+    if (!playerBase) return
+    const zoom = this.camera.zoom
+    const w = this.canvas.clientWidth
+    const h = this.canvas.clientHeight
+    this.camera.x = w / 2 - playerBase.x * zoom
+    this.camera.y = h / 2 - playerBase.y * zoom
+    this.notify('⌂ Home', '#4af7c4')
   }
 
   private notify(message: string, color: string) {

--- a/src/app/speck-wars/input/input-handler.ts
+++ b/src/app/speck-wars/input/input-handler.ts
@@ -16,6 +16,7 @@ export class InputHandler {
   private onClearSelect?: () => void
   private onSurge?: () => void
   private onSnapToAction?: () => void
+  private onSnapToBase?: () => void
   private onSetSpawnType?: (typeId: 'basic' | 'heavy' | 'scout') => void
   private onCycleSpeed?: () => void
   private onSelectAll?: () => void
@@ -49,6 +50,7 @@ export class InputHandler {
     onClearSelect?: () => void,
     onSurge?: () => void,
     onSnapToAction?: () => void,
+    onSnapToBase?: () => void,
     onSetSpawnType?: (typeId: 'basic' | 'heavy' | 'scout') => void,
     onCycleSpeed?: () => void,
     onSelectAll?: () => void,
@@ -68,6 +70,7 @@ export class InputHandler {
     this.onClearSelect = onClearSelect
     this.onSurge = onSurge
     this.onSnapToAction = onSnapToAction
+    this.onSnapToBase = onSnapToBase
     this.onSetSpawnType = onSetSpawnType
     this.onCycleSpeed = onCycleSpeed
     this.onSelectAll = onSelectAll
@@ -252,7 +255,7 @@ export class InputHandler {
     } else if (e.code === 'KeyR') {
       this.onClearRally?.()
     } else if (e.code === 'KeyH') {
-      this.onCycleSpawnMode?.()
+      this.onSnapToBase?.()
     } else if (e.code === 'KeyC') {
       this.onRecenterCamera?.()
     } else if (e.code === 'KeyD') {


### PR DESCRIPTION
## Summary

- **H key** snaps camera to player's home base (with ⌂ Home notification); H previously cycled spawn mode — replaced by cleaner home-snap since spawn type already has 1/2/3 keys
- **OUTNUMBERED badge** appears at top-center when enemy has ≥2.5× as many specks (shows exact ratio like "OUTNUMBERED 3:1")

## Details

**`input/input-handler.ts`**: `onSnapToBase` callback; `KeyH` now calls it (replacing `onCycleSpawnMode`)

**`game-instance.ts`**: `snapToBase()` finds player base building, centers camera (`w/2 - cx*zoom`, `h/2 - cy*zoom`), notifies "⌂ Home"

**`components/hud.tsx`**: OUTNUMBERED badge at `top: 44` (below BASE UNDER ATTACK badge at `top: 12`); shown when `aiCount/playerCount ≥ 2.5`; help overlay updated with H key

## Test plan
- [ ] Press H → camera jumps to player base, "⌂ Home" notification appears
- [ ] 1/2/3 spawn type keys still work (H no longer cycles spawn)
- [ ] Let AI build up 3× specks → orange "OUTNUMBERED 3:1" badge appears
- [ ] Win/equalize → badge disappears
- [ ] TypeScript: `npx tsc --noEmit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)