### PR TITLE
feat(speck-wars): Arrow key camera panning

### DIFF
--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -424,7 +424,8 @@ export function HUD() {
             <span>Q — surge (2× spawn 8s)</span><span>V — snap camera to battle</span>
             <span>H — snap to home base</span><span>Minimap — click to rally</span>
             <span>E — select all specks</span><span>X — cycle speed (1×/2×/4×)</span>
-            <span>F — sacrifice 10 specks → +15 HP base</span><span>? — this help</span>
+            <span>F — sacrifice 10 specks → +15 HP base</span><span>Arrow keys — pan camera</span>
+            <span>? — this help</span><span></span>
             <span style={{ gridColumn: '1/-1', borderTop: '1px solid rgba(255,255,255,0.08)', paddingTop: 8, marginTop: 2, color: 'rgba(255,215,0,0.5)', fontSize: 11 }}>
               Daily map seed changes each day · modifier shown top-right (bulwark/blitz/siege)
             </span>

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -496,6 +496,20 @@ export class GameInstance {
       }
     }
 
+    // Arrow key camera panning (works in both playing and paused states)
+    if (this.inputHandler) {
+      const panSpeed = 450  // px/s in world space
+      const dtSec = dt / 1000
+      if (this.inputHandler.isKeyHeld('ArrowUp'))
+        this.camera.y += panSpeed * dtSec
+      if (this.inputHandler.isKeyHeld('ArrowDown'))
+        this.camera.y -= panSpeed * dtSec
+      if (this.inputHandler.isKeyHeld('ArrowLeft'))
+        this.camera.x += panSpeed * dtSec
+      if (this.inputHandler.isKeyHeld('ArrowRight'))
+        this.camera.x -= panSpeed * dtSec
+    }
+
     // Edge pan (works in both playing and paused states)
     if (this.inputHandler) {
       const isPaused = store.phase === 'paused'

--- a/src/app/speck-wars/input/input-handler.ts
+++ b/src/app/speck-wars/input/input-handler.ts
@@ -21,6 +21,7 @@ export class InputHandler {
   private onCycleSpeed?: () => void
   private onSelectAll?: () => void
   private onSacrifice?: () => void
+  private heldKeys = new Set<string>()
   private isDragging = false
   private lastX = 0
   private lastY = 0
@@ -89,6 +90,8 @@ export class InputHandler {
     window.addEventListener('touchmove', this.onTouchMove, { passive: false })
     window.addEventListener('touchend', this.onTouchEnd)
     window.addEventListener('keydown', this.onKeyDown)
+    window.addEventListener('keyup', this.onKeyUp)
+    window.addEventListener('blur', () => this.heldKeys.clear())
     this.canvas.addEventListener('mousemove', this.onCanvasMouseMove)
     this.canvas.addEventListener('mouseleave', this.onMouseLeave)
   }
@@ -244,9 +247,18 @@ export class InputHandler {
     this.lastPinchDist = 0
   }
 
+  private onKeyUp = (e: KeyboardEvent) => {
+    this.heldKeys.delete(e.code)
+  }
+
+  isKeyHeld(code: string): boolean {
+    return this.heldKeys.has(code)
+  }
+
   private onKeyDown = (e: KeyboardEvent) => {
     // Don't fire when typing in an input
     if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) return
+    this.heldKeys.add(e.code)
     if (e.code === 'Space') {
       e.preventDefault()
       this.onTogglePause?.()
@@ -304,6 +316,7 @@ export class InputHandler {
     window.removeEventListener('touchmove', this.onTouchMove)
     window.removeEventListener('touchend', this.onTouchEnd)
     window.removeEventListener('keydown', this.onKeyDown)
+    window.removeEventListener('keyup', this.onKeyUp)
     this.canvas.removeEventListener('mousemove', this.onCanvasMouseMove)
     this.canvas.removeEventListener('mouseleave', this.onMouseLeave)
   }


### PR DESCRIPTION
## Summary

- **Arrow keys** pan the camera at 450 px/s (WASD was taken by Advance/Defend commands)
- **Mouse edge scrolling** was already implemented — no changes needed there
- **Camera clamping** was already implemented via `clampCamera()` — bounds enforced automatically
- Help overlay updated with "Arrow keys — pan camera"

## Details

**`input/input-handler.ts`**:
- Added `private heldKeys = new Set<string>()` with `keyup` listener + `blur` clear
- Added `isKeyHeld(code: string): boolean` public method
- `heldKeys.add(e.code)` at top of `onKeyDown`

**`game-instance.ts`**:
- Arrow key pan block in loop (before render): `±450 * dtSec` applied to `camera.x/y`; existing `clampCamera()` handles bounds

## Test plan
- [ ] ArrowUp/Down/Left/Right → camera pans smoothly at consistent speed
- [ ] Camera doesn't pan past world edges (clamped)
- [ ] A/D (Advance/Defend) still work as before
- [ ] WASD unaffected (no key conflicts)
- [ ] TypeScript: `npx tsc --noEmit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)