### PR TITLE
feat(speck-wars): ENEMY ADVANCING warning when hostile force enters player territory

### DIFF
--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -103,6 +103,14 @@ export function HUD() {
           }}>OUTNUMBERED {Math.round(ratio)}:1</div>
         )
       })()}
+      {hud?.enemyAdvanceDetected && (
+        <div style={{
+          position: 'fixed', top: 76, left: '50%', transform: 'translateX(-50%)',
+          background: 'rgba(200,80,0,0.88)', color: '#ffe0c0', fontWeight: 700,
+          padding: '3px 12px', borderRadius: 6, fontSize: 12, letterSpacing: 1,
+          zIndex: 108, pointerEvents: 'none',
+        }}>ENEMY ADVANCING</div>
+      )}
       {isDanger && (
         <>
           <style>{`

--- a/src/app/speck-wars/domain/simulation/tick.ts
+++ b/src/app/speck-wars/domain/simulation/tick.ts
@@ -336,5 +336,31 @@ function emitHudUpdate(sim: SimulationState) {
     }
   }
 
-  sim.events.push({ type: 'HUD_UPDATE', data: { players: data, attackedBuildingIds, tripleOutpostOwner, dominationProgress, captureInfo, surgeDuration: sim.surgeDuration, surgeCooldown: sim.surgeCooldown, selectedSpeckCount: sim.selectedSpeckIds.size, spawnRates, minimap, outpostFortify, dailyModifier: sim.dailyModifier, waveCountdown: sim.waveCountdown, waveInProgress: sim.waveInProgress, sacrificeCooldown: sim.sacrificeCooldown, baseUnderThreat } })
+  let enemyAdvanceDetected = false
+  const aiBase = sim.buildings['building-ai-base']
+  if (playerBase && aiBase) {
+    // Midpoint between the two bases — defines "player's half"
+    const midX = (playerBase.x + aiBase.x) / 2
+    const midY = (playerBase.y + aiBase.y) / 2
+    const ADVANCE_THRESHOLD = 15  // enemy specks needed in player half
+    let enemySpecksInPlayerHalf = 0
+    for (let i = 0; i < sim.speckCount; i++) {
+      const m = sim.speckMeta[i]
+      if (!m || m.ownerId !== 'ai') continue
+      if (sim.speckHp[i] <= 0) continue
+      // Is this speck closer to player base than to midpoint?
+      const dxP = sim.speckX[i] - playerBase.x
+      const dyP = sim.speckY[i] - playerBase.y
+      const dxM = sim.speckX[i] - midX
+      const dyM = sim.speckY[i] - midY
+      if (dxP * dxP + dyP * dyP < dxM * dxM + dyM * dyM) {
+        enemySpecksInPlayerHalf++
+        if (enemySpecksInPlayerHalf >= ADVANCE_THRESHOLD) { enemyAdvanceDetected = true; break }
+      }
+    }
+  }
+  // Suppress "advance" when base is already under direct threat (avoid double-warning)
+  if (baseUnderThreat) enemyAdvanceDetected = false
+
+  sim.events.push({ type: 'HUD_UPDATE', data: { players: data, attackedBuildingIds, tripleOutpostOwner, dominationProgress, captureInfo, surgeDuration: sim.surgeDuration, surgeCooldown: sim.surgeCooldown, selectedSpeckCount: sim.selectedSpeckIds.size, spawnRates, minimap, outpostFortify, dailyModifier: sim.dailyModifier, waveCountdown: sim.waveCountdown, waveInProgress: sim.waveInProgress, sacrificeCooldown: sim.sacrificeCooldown, baseUnderThreat, enemyAdvanceDetected } })
 }

--- a/src/app/speck-wars/domain/types.ts
+++ b/src/app/speck-wars/domain/types.ts
@@ -110,6 +110,7 @@ export interface HudData {
   waveInProgress: boolean
   sacrificeCooldown: number
   baseUnderThreat: boolean
+  enemyAdvanceDetected: boolean
   outpostFortify: Record<string, number>  // outpostId → 0..1 fortification level
   minimap: {
     specks: { x: number; y: number; ownerId: string }[]

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -45,6 +45,7 @@ export class GameInstance {
   private firstVeteranNotifiedAt = -30000   // allow veteran notification immediately
   private retreatWarnedAt = -20000          // allow retreat warning after 20s
   private prevBaseUnderThreat = false
+  private prevEnemyAdvance = false
 
   constructor(canvas: HTMLCanvasElement) {
     this.canvas = canvas
@@ -229,6 +230,11 @@ export class GameInstance {
             this.notify('⚠ BASE UNDER ATTACK', '#ff3333')
           }
           this.prevBaseUnderThreat = bua
+          const adv = event.data.enemyAdvanceDetected ?? false
+          if (adv && !this.prevEnemyAdvance && !event.data.baseUnderThreat) {
+            this.notify('⚠ ENEMY ADVANCING', '#ff8844')
+          }
+          this.prevEnemyAdvance = adv
           this.cachedPlayerSpeckCount = event.data.players.player?.speckCount ?? 0
           const playerSpeckCount = event.data.players.player?.speckCount ?? 0
           store.setPeakArmySize(playerSpeckCount)


### PR DESCRIPTION
## Summary

Adds an "ENEMY ADVANCING" early-warning system that fires when ≥15 enemy specks cross into player territory — distinct from the existing `baseUnderThreat` alert (280px from base). Gives players time to react before their base is under direct siege.

## Warning hierarchy

| Condition | Badge | Color | Position |
|-----------|-------|-------|----------|
| Enemy force in player half (≥15 specks) | ENEMY ADVANCING | burnt orange | top: 76 |
| Enemy specks within 280px of base | BASE UNDER ATTACK | red pulse | top: 12 |
| Enemy has ≥2.5× your specks | OUTNUMBERED N:1 | orange | top: 44 |

ADVANCING suppresses when BASE UNDER ATTACK is active (no double-warning).

## Details

**`domain/types.ts`** — `enemyAdvanceDetected: boolean` added to `HudData`

**`domain/simulation/tick.ts`** — `emitHudUpdate` computes advance detection using perpendicular bisector between player and AI base; counts AI specks in player half; threshold 15 specks; suppressed when `baseUnderThreat`

**`components/hud.tsx`** — burnt-orange badge at `top: 76`

**`game-instance.ts`** — rising-edge notification `'⚠ ENEMY ADVANCING'` (only when not already under direct attack)

## Test plan
- [ ] Let AI build 15+ specks and rally past midpoint → "ENEMY ADVANCING" badge + notification
- [ ] Let those specks reach base (280px) → badge switches to "BASE UNDER ATTACK" (no double-warning)
- [ ] Rally them back → both badges disappear
- [ ] TypeScript: `npx tsc --noEmit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)