### PR TITLE
feat(speck-wars): veteran and elite fallen notifications

### DIFF
--- a/src/app/speck-wars/domain/simulation/combat.ts
+++ b/src/app/speck-wars/domain/simulation/combat.ts
@@ -91,6 +91,17 @@ export function resolveCombat(sim: SimulationState, dt: number) {
         meta.state = 'attacking'
         if (speckHp[j] <= 0) {
           meta.kills++  // attacker earns a kill
+          // Notify when player loses a veteran or elite
+          if (jMeta.ownerId === 'player' && jMeta.kills >= 3) {
+            sim.events.push({
+              type: 'VETERAN_FALLEN',
+              speckId: speckIds[j],
+              ownerId: jMeta.ownerId,
+              kills: jMeta.kills,
+              x: speckX[j],
+              y: speckY[j],
+            })
+          }
           sim.events.push({ type: 'SPECK_DIED', speckId: speckIds[j], x: speckX[j], y: speckY[j], killedOwnerId: jMeta.ownerId, killerOwnerId: meta.ownerId })
           if (meta.kills === 3) {
             sim.events.push({ type: 'SPECK_VETERAN', speckId: speckIds[i], ownerId: meta.ownerId })

--- a/src/app/speck-wars/domain/types.ts
+++ b/src/app/speck-wars/domain/types.ts
@@ -87,6 +87,7 @@ export type SimEvent =
   | { type: 'SPECK_VETERAN'; speckId: string; ownerId: string }
   | { type: 'SPECK_ELITE'; speckId: string; ownerId: string }
   | { type: 'AI_WAVE_START'; waveNumber: number }
+  | { type: 'VETERAN_FALLEN'; speckId: string; ownerId: string; kills: number; x: number; y: number }
 
 export interface HudData {
   players: Record<string, {

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -448,6 +448,12 @@ export class GameInstance {
           store.setNotification({ message: '✦ ELITE SPECK! +35% DAMAGE', color: '#ffffff' })
           setTimeout(() => useSpeckWarsStore.getState().setNotification(null), 2500)
         }
+        if (event.type === 'VETERAN_FALLEN') {
+          const isElite = event.kills >= 6
+          const label = isElite ? '✦ ELITE FALLEN' : '⭐ VETERAN FALLEN'
+          const color = isElite ? '#ff8844' : '#ffcc00'
+          this.notify(label, color)
+        }
         if (event.type === 'AI_WAVE_START') {
           const waveColors = ['#ff4f7b', '#ff6b35', '#cc00ff']
           const color = waveColors[(event.waveNumber - 1) % waveColors.length]


### PR DESCRIPTION
## Summary

When a player-owned veteran (3+ kills) or elite (6+ kills) speck dies in combat, a brief notification fires to acknowledge the loss — creating emotional investment in high-value units.

| Unit | Kills | Notification | Color |
|------|-------|-------------|-------|
| Veteran | 3–5 | ⭐ VETERAN FALLEN | gold |
| Elite | 6+ | ✦ ELITE FALLEN | orange |

## Details

**`domain/types.ts`** — `VETERAN_FALLEN` added to SimEvent union with `speckId`, `ownerId`, `kills`, `x`, `y`

**`domain/simulation/combat.ts`** — In the speck-vs-speck death block, checks if dying speck (index j) is player-owned with kills ≥ 3 before pushing SPECK_DIED; emits `VETERAN_FALLEN` event with full position data

**`game-instance.ts`** — Handler after SPECK_ELITE block; routes 3–5 kills to gold "⭐ VETERAN FALLEN" and 6+ kills to orange "✦ ELITE FALLEN" via existing `notify()`

## Test plan
- [ ] Build up a veteran speck (3+ kills) → lose it in combat → "⭐ VETERAN FALLEN" toast
- [ ] Build up an elite speck (6+ kills) → lose it → "✦ ELITE FALLEN" toast in orange
- [ ] Sacrificing player specks does NOT trigger veteran fallen (sacrifice has ownerId === killerOwnerId)
- [ ] AI veterans dying don't trigger (ownerId check: `'player'` only)
- [ ] TypeScript: `npx tsc --noEmit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)