### PR TITLE
feat(speck-wars): AI last stand — desperate all-out attack at <20% base HP

### DIFF
--- a/src/app/speck-wars/domain/ai/ai-controller.ts
+++ b/src/app/speck-wars/domain/ai/ai-controller.ts
@@ -10,6 +10,7 @@ export class AIController {
   private personality: AIPersonality
   private decisionCount: number = 0
   private spawnMode: 'basic' | 'heavy' | 'scout' = 'basic'
+  private lastStandTriggered = false
   private spawnModeCountdown: number = 0  // ticks until next spawn mode decision
   private dominanceTimer: number = 0  // ms enemy has held a 3:1 count advantage
   private waveTimer: number  // ms until next wave
@@ -117,6 +118,21 @@ export class AIController {
 
     // Defensive rally: when AI base is low HP, sometimes pull back to defend
     const myBaseHpFrac = (myBase?.hp ?? 100) / (myBase?.maxHp ?? 100)
+
+    // Last stand: AI base below 20% — all-out desperate assault, ignoring personality
+    if (myBaseHpFrac < 0.2) {
+      if (!this.lastStandTriggered) {
+        this.lastStandTriggered = true
+        sim.events.push({ type: 'AI_LAST_STAND' })
+      }
+      const playerBase = Object.values(sim.buildings).find(b => b.ownerId !== this.playerId && b.ownerId !== 'neutral' && b.typeId === 'base')
+      if (playerBase) {
+        sim.rallyPoints[this.playerId] = { x: playerBase.x, y: playerBase.y }
+        sim.inputQueue.push({ type: 'SET_SPAWN_TYPE', ownerId: this.playerId, speckTypeId: 'heavy' })
+      }
+      return
+    }
+
     if (!forceBaseRush && myBaseHpFrac < 0.6 && myBase) {
       const defendChance = this.personality === 'aggressive'
         ? (myBaseHpFrac < 0.3 ? 0.35 : 0.15)   // aggressive defends reluctantly

--- a/src/app/speck-wars/domain/types.ts
+++ b/src/app/speck-wars/domain/types.ts
@@ -88,6 +88,7 @@ export type SimEvent =
   | { type: 'SPECK_ELITE'; speckId: string; ownerId: string }
   | { type: 'AI_WAVE_START'; waveNumber: number }
   | { type: 'VETERAN_FALLEN'; speckId: string; ownerId: string; kills: number; x: number; y: number }
+  | { type: 'AI_LAST_STAND' }
 
 export interface HudData {
   players: Record<string, {

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -460,6 +460,9 @@ export class GameInstance {
           store.setNotification({ message: `⚠ WAVE ${event.waveNumber} ASSAULT!`, color })
           setTimeout(() => useSpeckWarsStore.getState().setNotification(null), 3000)
         }
+        if (event.type === 'AI_LAST_STAND') {
+          this.notify('⚠ ENEMY LAST STAND', '#ff4444')
+        }
       }
 
       // Retreat wave warning: 10+ player specks retreating = notify


### PR DESCRIPTION
## Summary

When the AI base drops below 20% HP, the AI enters **last stand mode** — abandoning outpost strategy, rally-pointing all specks directly at the player base, and switching to heavy spawn. Fires once per game with a "⚠ ENEMY LAST STAND" warning.

This makes endgame more dramatic: the AI fights desperately instead of continuing routine outpost captures as it dies.

## Details

**`domain/types.ts`** — `AI_LAST_STAND` added to SimEvent union

**`domain/ai/ai-controller.ts`**:
- `private lastStandTriggered = false` field
- After `myBaseHpFrac` computation, if `< 0.2`: fires event once, sets `sim.rallyPoints['ai']` directly to player base coords, pushes `SET_SPAWN_TYPE heavy`, returns early to bypass personality routing

**`game-instance.ts`** — handles `AI_LAST_STAND` with `notify('⚠ ENEMY LAST STAND', '#ff4444')`

## Gameplay impact
- Winning requires actually defeating the rush, not just letting time pass
- Creates a memorable "final push" moment that makes victories feel earned
- Notification warns player to defend/push back

## Test plan
- [ ] Reduce AI base to <20% HP → "⚠ ENEMY LAST STAND" notification fires once
- [ ] AI stops capturing outposts, all specks rush player base
- [ ] AI switches to heavy spawn (slow but tanky)
- [ ] Event only fires once (not every tick)
- [ ] TypeScript: `npx tsc --noEmit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)