### PR TITLE
feat(speck-wars): double/triple capture combo notifications

### DIFF
--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -43,6 +43,7 @@ export class GameInstance {
   private lastTripleHolder: string | null = null  // track triple-outpost ownership changes
   private rallyCryFired = false               // one-time Rally Cry notification per game
   private firstVeteranNotifiedAt = -30000   // allow veteran notification immediately
+  private recentPlayerCaptureTimes: number[] = []  // timestamps of recent player captures
   private retreatWarnedAt = -20000          // allow retreat warning after 20s
   private prevBaseUnderThreat = false
   private prevEnemyAdvance = false
@@ -434,6 +435,20 @@ export class GameInstance {
             const color = isPlayerLoss ? '#ff4f7b' : isRecapture ? '#ffd700' : '#4af7c4'
             store.setNotification({ message, color })
             setTimeout(() => useSpeckWarsStore.getState().setNotification(null), 2500)
+          }
+          // Track capture combos
+          if (event.newOwner === 'player') {
+            const now = Date.now()
+            const COMBO_WINDOW = 30_000  // 30 seconds
+            // Remove captures older than window
+            this.recentPlayerCaptureTimes = this.recentPlayerCaptureTimes.filter(t => now - t < COMBO_WINDOW)
+            this.recentPlayerCaptureTimes.push(now)
+            const count = this.recentPlayerCaptureTimes.length
+            if (count === 3) {
+              this.notify('★ TRIPLE CAPTURE! ★', '#ffffff')
+            } else if (count === 2) {
+              this.notify('DOUBLE CAPTURE!', '#ffd700')
+            }
           }
         }
         if (event.type === 'SPECK_VETERAN' && event.ownerId === 'player') {


### PR DESCRIPTION
## Summary

When the player captures multiple outposts within 30 seconds, a bonus notification fires — rewarding aggressive outpost rushes and multi-front pressure.

| Captures in 30s | Notification | Color |
|-----------------|-------------|-------|
| 2 | DOUBLE CAPTURE! | gold |
| 3 | ★ TRIPLE CAPTURE! ★ | white |

## Details

**`game-instance.ts`** only:
- `private recentPlayerCaptureTimes: number[] = []` — rolling timestamp array
- In `OUTPOST_CAPTURED` handler: filters timestamps to 30s window, pushes new timestamp, fires combo notification at count 2 and 3
- Window resets naturally (old captures expire)

## Test plan
- [ ] Capture one outpost → no combo notification (just normal "⬡ TOP CAPTURED")
- [ ] Capture second outpost within 30s → "DOUBLE CAPTURE!" gold toast fires after the individual capture notification
- [ ] Capture third within 30s → "★ TRIPLE CAPTURE! ★" white toast
- [ ] Wait 30s after a capture → timestamps expire, next capture starts fresh
- [ ] TypeScript: `npx tsc --noEmit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)