### PR TITLE
feat(speck-wars): adaptive difficulty — AI ramps up on easy/medium when player dominates

### DIFF
--- a/src/app/speck-wars/domain/ai/ai-controller.ts
+++ b/src/app/speck-wars/domain/ai/ai-controller.ts
@@ -17,8 +17,10 @@ export class AIController {
   private waveRemainingMs = 0  // ms left in active wave (0 = not in wave)
   private waveNumber = 0       // which wave this is (1, 2, 3...)
   private waveEnabled: boolean  // only hard/very-hard get waves
+  private adaptiveDominanceDuration = 0  // ms player has dominated ≥3:1
+  private adaptiveBaseInterval: number | null = null  // captured baseline spawn interval
 
-  constructor(playerId: string, tickInterval: number = 30, personality: AIPersonality = 'balanced') {
+  constructor(playerId: string, tickInterval: number = 30, personality: AIPersonality = 'balanced', private readonly adaptiveEnabled: boolean = false) {
     this.playerId = playerId
     this.tickInterval = tickInterval
     this.baseTickInterval = tickInterval
@@ -151,6 +153,34 @@ export class AIController {
       if (enemyBase) {
         sim.inputQueue.push({ type: 'RALLY', ownerId: this.playerId, x: enemyBase.x, y: enemyBase.y })
         return
+      }
+    }
+
+    // Adaptive difficulty: gradually speed up AI spawns when player dominates
+    if (this.adaptiveEnabled) {
+      let playerCount = 0, aiCount = 0
+      for (let i = 0; i < sim.speckCount; i++) {
+        const m = sim.speckMeta[i]
+        if (!m) continue
+        if (m.ownerId === 'player') playerCount++
+        else if (m.ownerId === 'ai') aiCount++
+      }
+      const ratio = aiCount > 0 ? playerCount / aiCount : (playerCount > 0 ? 9 : 1)
+      if (ratio >= 3.0) {
+        this.adaptiveDominanceDuration = Math.min(45_000, this.adaptiveDominanceDuration + dt)
+      } else {
+        this.adaptiveDominanceDuration = Math.max(0, this.adaptiveDominanceDuration - dt * 0.5)
+      }
+      const boostFraction = this.adaptiveDominanceDuration / 45_000  // 0 → 1 over 45s
+      if (boostFraction > 0) {
+        const aiBase = Object.values(sim.buildings).find(b => b.ownerId === 'ai' && b.typeId === 'base')
+        if (aiBase) {
+          if (this.adaptiveBaseInterval === null) {
+            this.adaptiveBaseInterval = aiBase.spawnIntervalOverride ?? 800
+          }
+          const speedMult = 1 + boostFraction * 0.3  // up to 30% faster
+          aiBase.spawnIntervalOverride = Math.max(400, this.adaptiveBaseInterval / speedMult)
+        }
       }
     }
 

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -68,7 +68,8 @@ export class GameInstance {
       // very-hard: no balanced — pure pressure or macro domination
       return Math.random() < 0.55 ? 'aggressive' : 'macro'
     }
-    this.aiController = new AIController('ai', aiTickInterval[difficulty] ?? 15, aiPersonality())
+    const adaptiveEnabled = difficulty === 'easy' || difficulty === 'medium'
+    this.aiController = new AIController('ai', aiTickInterval[difficulty] ?? 15, aiPersonality(), adaptiveEnabled)
   }
 
   private onVisibilityChange = () => {


### PR DESCRIPTION
## Summary

On **easy** and **medium** difficulty, when the player holds a ≥3:1 speck ratio for 45+ consecutive seconds, the AI's spawn interval gradually decreases by up to **30%** (floor: 400ms). This keeps the game feeling dynamic rather than steamrolled — the AI fights back harder the more you dominate.

The feature is **invisible to the player** — no UI indicator. Hard and very-hard are unaffected (already challenging enough).

## Details

**`domain/ai/ai-controller.ts`**:
- `private readonly adaptiveEnabled: boolean` (4th constructor param)
- `adaptiveDominanceDuration: number` — tracks consecutive ms at ≥3:1 ratio (caps at 45s, decays at 0.5× when ratio drops)
- `adaptiveBaseInterval: number | null` — captured on first adaptive tick as baseline
- Each tick: `spawnIntervalOverride = max(400, baseline / (1 + fraction * 0.3))`
- Runs inside decision gate (not every frame)

**`game-instance.ts`**:
- `adaptiveEnabled = difficulty === 'easy' || difficulty === 'medium'`
- Passed as 4th arg to `AIController` constructor

## Balance notes
- 45s ramp prevents immediate punishment for momentary dominance
- 30% max boost: medium AI at 800ms → ~615ms at peak (still slower than hard's 400ms)
- Boost decays when player loses the ratio lead
- Blitz modifier interaction: baseline captured after blitz modifier is applied

## Test plan
- [ ] Medium: dominate 3:1 ratio for 45+ seconds → AI visibly spawns faster
- [ ] Hard: AI spawn rate unchanged regardless of ratio
- [ ] Ratio drops below 3:1 → boost slowly fades back toward baseline
- [ ] TypeScript: `npx tsc --noEmit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)