### PR TITLE
feat(speck-wars): selection composition — type breakdown + vet/elite count for box-selected group

### DIFF
--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -763,6 +763,16 @@ export function HUD() {
               textAlign: 'center', marginBottom: 4,
             }}>
               SQUAD: {hud.selectedSpeckCount} · Shift+drag to reselect · Esc to clear
+              {hud.selectedComposition && (
+                <div style={{ fontSize: 9, color: 'rgba(74,247,196,0.75)', marginTop: 2, letterSpacing: 1 }}>
+                  {Object.entries(hud.selectedComposition.types)
+                    .sort(([a], [b]) => a.localeCompare(b))
+                    .map(([typeId, count]) => `${count} ${typeId}`)
+                    .join(' · ')}
+                  {hud.selectedComposition.eliteCount > 0 && ` · ✦${hud.selectedComposition.eliteCount} elite`}
+                  {hud.selectedComposition.veteranCount > 0 && ` · ⭐${hud.selectedComposition.veteranCount} vet`}
+                </div>
+              )}
             </div>
           )}
           <div style={{

--- a/src/app/speck-wars/domain/simulation/tick.ts
+++ b/src/app/speck-wars/domain/simulation/tick.ts
@@ -362,5 +362,20 @@ function emitHudUpdate(sim: SimulationState) {
   // Suppress "advance" when base is already under direct threat (avoid double-warning)
   if (baseUnderThreat) enemyAdvanceDetected = false
 
-  sim.events.push({ type: 'HUD_UPDATE', data: { players: data, attackedBuildingIds, tripleOutpostOwner, dominationProgress, captureInfo, surgeDuration: sim.surgeDuration, surgeCooldown: sim.surgeCooldown, selectedSpeckCount: sim.selectedSpeckIds.size, spawnRates, minimap, outpostFortify, dailyModifier: sim.dailyModifier, waveCountdown: sim.waveCountdown, waveInProgress: sim.waveInProgress, sacrificeCooldown: sim.sacrificeCooldown, baseUnderThreat, enemyAdvanceDetected } })
+  // Selection composition breakdown
+  let selectedComposition: { types: Record<string, number>; veteranCount: number; eliteCount: number } | null = null
+  if (sim.selectedSpeckIds.size > 0) {
+    const types: Record<string, number> = {}
+    let selVet = 0, selElite = 0
+    for (let i = 0; i < sim.speckCount; i++) {
+      const m = sim.speckMeta[i]
+      if (!m || !sim.speckIds[i] || !sim.selectedSpeckIds.has(sim.speckIds[i])) continue
+      types[m.typeId] = (types[m.typeId] ?? 0) + 1
+      if (m.kills >= 6) selElite++
+      else if (m.kills >= 3) selVet++
+    }
+    selectedComposition = { types, veteranCount: selVet, eliteCount: selElite }
+  }
+
+  sim.events.push({ type: 'HUD_UPDATE', data: { players: data, attackedBuildingIds, tripleOutpostOwner, dominationProgress, captureInfo, surgeDuration: sim.surgeDuration, surgeCooldown: sim.surgeCooldown, selectedSpeckCount: sim.selectedSpeckIds.size, selectedComposition, spawnRates, minimap, outpostFortify, dailyModifier: sim.dailyModifier, waveCountdown: sim.waveCountdown, waveInProgress: sim.waveInProgress, sacrificeCooldown: sim.sacrificeCooldown, baseUnderThreat, enemyAdvanceDetected } })
 }

--- a/src/app/speck-wars/domain/types.ts
+++ b/src/app/speck-wars/domain/types.ts
@@ -106,6 +106,7 @@ export interface HudData {
   surgeDuration: number    // ms remaining in active surge
   surgeCooldown: number    // ms remaining before surge can be used again
   selectedSpeckCount: number   // 0 when no selection active
+  selectedComposition: { types: Record<string, number>; veteranCount: number; eliteCount: number } | null
   spawnRates: Record<string, number>   // playerId → effective specks/min
   dailyModifier: 'standard' | 'bulwark' | 'blitz' | 'siege'
   waveCountdown: number | null


### PR DESCRIPTION
## Summary

When specks are box-selected, the SQUAD indicator now shows their **type breakdown and veteran/elite counts** — e.g. "5 basic · 2 heavy · 1 scout · ✦1 elite · ⭐2 vet". Gives players tactical awareness of what they've selected without needing to check the army panel.

## Details

**`domain/types.ts`** — `selectedComposition: { types: Record<string, number>; veteranCount: number; eliteCount: number } | null` added to `HudData`

**`domain/simulation/tick.ts`** — In `emitHudUpdate`, when `selectedSpeckIds.size > 0`, iterates specks to build type tally + veteran/elite counts; null otherwise

**`components/hud.tsx`** — Below "SQUAD: N" line, renders a cyan breakdown line when `selectedComposition` is non-null: sorts type entries alphabetically, appends elite/veteran counts with ✦/⭐ symbols

## Test plan
- [ ] Shift+drag select a group → "SQUAD: N" + cyan "3 basic · 1 heavy" breakdown appears
- [ ] Select group with veterans → "⭐2 vet" appended
- [ ] Select group with elites → "✦1 elite" appended
- [ ] Clear selection (Esc) → breakdown disappears
- [ ] TypeScript: `npx tsc --noEmit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)