### PR TITLE
feat(speck-wars): rally cry HUD badge when base drops below 30% HP

### DIFF
--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -111,6 +111,15 @@ export function HUD() {
           zIndex: 108, pointerEvents: 'none',
         }}>ENEMY ADVANCING</div>
       )}
+      {hud?.rallyCryActive && !hud?.baseUnderThreat && (
+        <div style={{
+          position: 'fixed', top: 108, left: '50%', transform: 'translateX(-50%)',
+          background: 'rgba(255,136,0,0.88)', color: '#fff', fontWeight: 700,
+          padding: '3px 12px', borderRadius: 6, fontSize: 11, letterSpacing: 1,
+          zIndex: 107, pointerEvents: 'none',
+          animation: 'pulse-red 0.9s ease-in-out infinite alternate',
+        }}>★ RALLY CRY — 1.5× SPAWN</div>
+      )}
       {isDanger && (
         <>
           <style>{`

--- a/src/app/speck-wars/domain/simulation/tick.ts
+++ b/src/app/speck-wars/domain/simulation/tick.ts
@@ -377,5 +377,5 @@ function emitHudUpdate(sim: SimulationState) {
     selectedComposition = { types, veteranCount: selVet, eliteCount: selElite }
   }
 
-  sim.events.push({ type: 'HUD_UPDATE', data: { players: data, attackedBuildingIds, tripleOutpostOwner, dominationProgress, captureInfo, surgeDuration: sim.surgeDuration, surgeCooldown: sim.surgeCooldown, selectedSpeckCount: sim.selectedSpeckIds.size, selectedComposition, spawnRates, minimap, outpostFortify, dailyModifier: sim.dailyModifier, waveCountdown: sim.waveCountdown, waveInProgress: sim.waveInProgress, sacrificeCooldown: sim.sacrificeCooldown, baseUnderThreat, enemyAdvanceDetected } })
+  sim.events.push({ type: 'HUD_UPDATE', data: { players: data, attackedBuildingIds, tripleOutpostOwner, dominationProgress, captureInfo, surgeDuration: sim.surgeDuration, surgeCooldown: sim.surgeCooldown, selectedSpeckCount: sim.selectedSpeckIds.size, selectedComposition, spawnRates, minimap, outpostFortify, dailyModifier: sim.dailyModifier, waveCountdown: sim.waveCountdown, waveInProgress: sim.waveInProgress, sacrificeCooldown: sim.sacrificeCooldown, baseUnderThreat, enemyAdvanceDetected, rallyCryActive } })
 }

--- a/src/app/speck-wars/domain/types.ts
+++ b/src/app/speck-wars/domain/types.ts
@@ -114,6 +114,7 @@ export interface HudData {
   sacrificeCooldown: number
   baseUnderThreat: boolean
   enemyAdvanceDetected: boolean
+  rallyCryActive: boolean
   outpostFortify: Record<string, number>  // outpostId → 0..1 fortification level
   minimap: {
     specks: { x: number; y: number; ownerId: string }[]


### PR DESCRIPTION
## Summary

When the player base drops below 30% HP, a pulsing **"★ RALLY CRY — 1.5× SPAWN"** badge appears in the HUD. Rally cry was already active (speeding up spawn rate) but had no persistent visual indicator beyond the one-shot notification. Now players can clearly see the bonus is active.

The badge suppresses when BASE UNDER ATTACK is showing (top priority alert).

## Warning badge hierarchy (top-center)
| Condition | Badge | top |
|-----------|-------|-----|
| Enemy 280px from base | BASE UNDER ATTACK (red pulse) | 12 |
| Enemy ≥2.5× specks | OUTNUMBERED N:1 (orange) | 44 |
| 15+ enemy in player half | ENEMY ADVANCING (burnt orange) | 76 |
| Base < 30% HP | ★ RALLY CRY — 1.5× SPAWN (orange pulse) | 108 |

## Details

**`domain/types.ts`** — `rallyCryActive: boolean` added to `HudData`

**`domain/simulation/tick.ts`** — `rallyCryActive` (already computed) now included in HUD_UPDATE payload

**`components/hud.tsx`** — Pulsing orange badge at `top: 108` using existing `pulse-red` animation; shown only when `rallyCryActive && !baseUnderThreat`

## Test plan
- [ ] Let base drop below 30 HP → "★ RALLY CRY" badge appears, spawn rate visibly increases
- [ ] Base above 30 HP → badge gone
- [ ] BASE UNDER ATTACK fires simultaneously → only red alert shows (rally cry hidden)
- [ ] TypeScript: `npx tsc --noEmit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)