### PR TITLE
feat(speck-wars): surge glow — fast-pulsing gold ring on player base during Q surge

### DIFF
--- a/src/app/speck-wars/rendering/layers/building-layer.ts
+++ b/src/app/speck-wars/rendering/layers/building-layer.ts
@@ -117,6 +117,14 @@ export class BuildingLayer {
         this.gfx.lineStyle(0)
       }
 
+      // Surge active: fast-pulsing gold outer ring on player base
+      if (!isOutpost && building.ownerId === 'player' && sim.surgeDuration > 0) {
+        const surgePulse = 0.5 + 0.5 * Math.sin(now / 120)
+        this.gfx.lineStyle(2.5, 0xffd700, surgePulse * 0.85)
+        this.gfx.drawCircle(building.x, building.y, r + 22)
+        this.gfx.lineStyle(0)
+      }
+
       // HP bar (above building)
       const barW = r * 2
       const barH = 4


### PR DESCRIPTION
## Summary

When the player activates Surge (Q key — 2× spawn speed for 8s), the player base now shows a **fast-pulsing gold outer ring** in world space. Previously the only visual feedback was the HUD button and spawn rate change; this makes surge visually obvious even when looking at the base on the map.

## Details

Single change in `rendering/layers/building-layer.ts` — after the critical HP warning ring block, when `!isOutpost && building.ownerId === 'player' && sim.surgeDuration > 0`:
- Draws a 2.5px gold (`0xffd700`) circle at `r + 22` (just outside the existing pulse ring)
- Alpha: `(0.5 + 0.5 * sin(t/120)) * 0.85` — fast 120ms pulse

The `sim.surgeDuration` field is already on `SimulationState`, so no data model changes needed.

## Test plan
- [ ] Activate surge (Q) → gold ring appears and pulses fast around base
- [ ] Surge expires after 8s → ring disappears
- [ ] Ring doesn't show when surge is on cooldown (only when `surgeDuration > 0`)
- [ ] AI base unaffected (only player base)
- [ ] TypeScript: `npx tsc --noEmit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)