### PR TITLE
fix(speck-wars): remove duplicate Minimap causing off-screen positioning

### DIFF
--- a/src/app/speck-wars/SpeckWarsGame.tsx
+++ b/src/app/speck-wars/SpeckWarsGame.tsx
@@ -5,7 +5,6 @@ import { GameInstance } from './game-instance'
 import { useSpeckWarsStore } from './store'
 import { HUD } from './components/hud'
 import { PhaseRouter } from './components/phase-router'
-import { Minimap } from './components/minimap'
 
 function GameCanvas() {
   const canvasRef = useRef<HTMLCanvasElement>(null)
@@ -39,7 +38,6 @@ function GameCanvas() {
         style={{ display: 'block', width: '100%', height: '100%' }}
       />
       <HUD />
-      <Minimap gameRef={gameRef} />
     </div>
   )
 }

--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -139,6 +139,64 @@ export function HUD() {
         )
       })()}
 
+      {/* Mini-map — top right, below difficulty badge */}
+      {hud && (() => {
+        const SCALE = 120 / 3000  // world→screen
+        return (
+          <div style={{
+            position: 'absolute', top: 72, right: 16,
+            width: 120, height: 120,
+            background: 'rgba(0,0,0,0.55)',
+            border: '1px solid rgba(255,255,255,0.12)',
+            borderRadius: 4,
+            overflow: 'hidden',
+            pointerEvents: 'none',
+          }}>
+            <svg width={120} height={120} style={{ display: 'block' }}>
+              {/* Speck dots */}
+              {hud.minimap.specks.map((s, i) => (
+                <circle
+                  key={i}
+                  cx={s.x * SCALE}
+                  cy={s.y * SCALE}
+                  r={1}
+                  fill={s.ownerId === 'player' ? colorHex(PLAYER_COLOR) : colorHex(AI_COLOR)}
+                  opacity={0.55}
+                />
+              ))}
+              {/* Buildings */}
+              {hud.minimap.buildings.map(b => {
+                const fill = b.ownerId === 'player' ? colorHex(PLAYER_COLOR)
+                  : b.ownerId === 'ai' ? colorHex(AI_COLOR)
+                  : '#888888'
+                const r = b.typeId === 'base' ? 4 : 2.5
+                return (
+                  <circle
+                    key={b.id}
+                    cx={b.x * SCALE}
+                    cy={b.y * SCALE}
+                    r={r}
+                    fill={fill}
+                    opacity={0.9}
+                  />
+                )
+              })}
+              {/* Rally point crosshair */}
+              {hud.minimap.rallyPoint && (() => {
+                const rx = hud.minimap.rallyPoint.x * SCALE
+                const ry = hud.minimap.rallyPoint.y * SCALE
+                return (
+                  <g>
+                    <line x1={rx - 4} y1={ry} x2={rx + 4} y2={ry} stroke="#ffffff" strokeWidth={1} opacity={0.6} />
+                    <line x1={rx} y1={ry - 4} x2={rx} y2={ry + 4} stroke="#ffffff" strokeWidth={1} opacity={0.6} />
+                  </g>
+                )
+              })()}
+            </svg>
+          </div>
+        )
+      })()}
+
       {/* Timer + Pause button — top bar */}
       <div style={{
         position: 'absolute', top: 12, left: 0, right: 0,

--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -650,9 +650,21 @@ export function HUD() {
       {phase === 'playing' && (
         <div style={{
           position: 'absolute', bottom: 16, right: 16,
-          display: 'flex', flexDirection: 'row', gap: 6,
+          display: 'flex', flexDirection: 'column', alignItems: 'flex-end', gap: 6,
           pointerEvents: 'auto',
         }}>
+          {/* Squad indicator: shown when player has specks selected */}
+          {hud && (hud.selectedSpeckCount ?? 0) > 0 && (
+            <div style={{
+              fontSize: 9, letterSpacing: 1.5, color: '#ffffff', opacity: 0.7,
+              textAlign: 'center', marginBottom: 4,
+            }}>
+              SQUAD: {hud.selectedSpeckCount} · Shift+drag to reselect · Esc to clear
+            </div>
+          )}
+          <div style={{
+            display: 'flex', gap: 6,
+          }}>
           <button
             onClick={() => gameActions.defend?.()}
             title="[D] Defend — rally to your base"
@@ -759,6 +771,7 @@ export function HUD() {
           >
             ✕ R
           </button>
+          </div>
         </div>
       )}
 

--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -424,7 +424,8 @@ export function HUD() {
             <span>Q — surge (2× spawn 8s)</span><span>V — snap camera to battle</span>
             <span>H — snap to home base</span><span>Minimap — click to rally</span>
             <span>E — select all specks</span><span>X — cycle speed (1×/2×/4×)</span>
-            <span>F — sacrifice 10 specks → +15 HP base</span><span>? — this help</span>
+            <span>F — sacrifice 10 specks → +15 HP base</span><span>Arrow keys — pan camera</span>
+            <span>? — this help</span><span></span>
             <span style={{ gridColumn: '1/-1', borderTop: '1px solid rgba(255,255,255,0.08)', paddingTop: 8, marginTop: 2, color: 'rgba(255,215,0,0.5)', fontSize: 11 }}>
               Daily map seed changes each day · modifier shown top-right (bulwark/blitz/siege)
             </span>

--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -62,6 +62,33 @@ export function HUD() {
       position: 'absolute', inset: 0, pointerEvents: 'none',
       fontFamily: 'monospace', fontSize: 13, color: '#fff',
     }}>
+      <style>{`
+        @keyframes pulse-red {
+          from { opacity: 0.5; }
+          to { opacity: 1; }
+        }
+      `}</style>
+      {hud?.baseUnderThreat && (
+        <div style={{
+          position: 'fixed',
+          inset: 0,
+          border: '4px solid rgba(255, 50, 50, 0.85)',
+          borderRadius: 2,
+          pointerEvents: 'none',
+          zIndex: 100,
+          animation: 'pulse-red 0.8s ease-in-out infinite alternate',
+          boxShadow: 'inset 0 0 40px rgba(255, 0, 0, 0.25)',
+        }} />
+      )}
+      {hud?.baseUnderThreat && (
+        <div style={{
+          position: 'fixed', top: 12, left: '50%', transform: 'translateX(-50%)',
+          background: 'rgba(200,0,0,0.9)', color: '#fff', fontWeight: 700,
+          padding: '4px 14px', borderRadius: 6, fontSize: 13, letterSpacing: 1,
+          zIndex: 110, pointerEvents: 'none',
+          animation: 'pulse-red 0.6s ease-in-out infinite alternate',
+        }}>⚠ BASE UNDER ATTACK</div>
+      )}
       {isDanger && (
         <>
           <style>{`

--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -340,6 +340,7 @@ export function HUD() {
             <span>B — rush enemy base</span><span>D — defend base</span>
             <span>Q — surge (2× spawn 8s)</span><span>V — snap camera to battle</span>
             <span>Shift+drag — select specks</span><span>Minimap — click to rally</span>
+            <span>E — select all specks</span><span>X — cycle speed (1×/2×/4×)</span>
             <span>? — this help</span>
             <span style={{ gridColumn: '1/-1', borderTop: '1px solid rgba(255,255,255,0.08)', paddingTop: 8, marginTop: 2, color: 'rgba(255,215,0,0.5)', fontSize: 11 }}>
               Daily map seed changes each day · modifier shown top-right (bulwark/blitz/siege)

--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -710,6 +710,20 @@ export function HUD() {
                 </span>
               </div>
             )}
+            {/* Production rate */}
+            {(hud.spawnRates?.player ?? 0) > 0 && (
+              <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+                <span style={{ fontSize: 9, color: colorHex(PLAYER_COLOR), opacity: 0.6, minWidth: 20, textAlign: 'right' }}>
+                  {hud.spawnRates.player}/m
+                </span>
+                <div style={{ width: 100, textAlign: 'center', fontSize: 8, letterSpacing: 0.5, color: 'rgba(255,255,255,0.3)' }}>
+                  ⚡prod
+                </div>
+                <span style={{ fontSize: 9, color: colorHex(AI_COLOR), opacity: 0.6, minWidth: 20 }}>
+                  {hud.spawnRates.ai}/m
+                </span>
+              </div>
+            )}
             {/* Army composition: heavy % indicator */}
             {(() => {
               const playerTypes = hud.players.player?.speckTypes ?? {}

--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -263,20 +263,20 @@ export function HUD() {
         </button>
         <button
           onClick={cycleSpawnMode}
-          title="H — toggle spawn mode"
+          title="H — cycle spawn mode (basic → heavy → scout)"
           style={{
             pointerEvents: 'auto',
             padding: '4px 14px',
             fontSize: 12,
             cursor: 'pointer',
-            background: spawnMode === 'heavy' ? 'rgba(255,160,50,0.15)' : 'rgba(0,0,0,0.5)',
-            border: `1px solid ${spawnMode === 'heavy' ? '#ffa032' : 'rgba(255,255,255,0.3)'}`,
+            background: spawnMode === 'heavy' ? 'rgba(255,160,50,0.15)' : spawnMode === 'scout' ? 'rgba(80,200,255,0.15)' : 'rgba(0,0,0,0.5)',
+            border: `1px solid ${spawnMode === 'heavy' ? '#ffa032' : spawnMode === 'scout' ? '#50c8ff' : 'rgba(255,255,255,0.3)'}`,
             borderRadius: 4,
-            color: spawnMode === 'heavy' ? '#ffa032' : '#fff',
+            color: spawnMode === 'heavy' ? '#ffa032' : spawnMode === 'scout' ? '#50c8ff' : '#fff',
             letterSpacing: 1,
           }}
         >
-          {spawnMode === 'heavy' ? '⬡ HEAVY' : '· BASIC'}
+          {spawnMode === 'heavy' ? '⬡ HEAVY' : spawnMode === 'scout' ? '→ SCOUT' : '· BASIC'}
         </button>
         <button
           onClick={() => setShowHelp(h => !h)}
@@ -320,7 +320,7 @@ export function HUD() {
           }}>
             <span>🖱 Click — rally specks</span><span>Space — pause</span>
             <span>Scroll — zoom</span><span>R / Right-click — clear rally</span>
-            <span>Drag — pan camera</span><span>H — heavy/basic mode</span>
+            <span>Drag — pan camera</span><span>H — cycle spawn (basic/heavy/scout)</span>
             <span>A — advance to outpost</span><span>C — center on base</span>
             <span>B — rush enemy base</span><span>D — defend base</span>
             <span>Q — surge (2× spawn 8s)</span><span>Shift+drag — select specks</span>
@@ -577,13 +577,16 @@ export function HUD() {
             const fmtTypes = (t: Record<string, number>) => {
               const basic = t['basic'] ?? 0
               const heavy = t['heavy'] ?? 0
-              if (basic === 0 && heavy === 0) return '—'
-              if (heavy === 0) return `${basic}× basic`
-              if (basic === 0) return `${heavy}× heavy`
-              return `${basic}× basic, ${heavy}× heavy`
+              const scout = t['scout'] ?? 0
+              const parts: string[] = []
+              if (heavy > 0) parts.push(`${heavy}× heavy`)
+              if (basic > 0) parts.push(`${basic}× basic`)
+              if (scout > 0) parts.push(`${scout}× dart`)
+              if (parts.length === 0) return '—'
+              return parts.join(', ')
             }
             // Production rate estimate
-            const BASE_MS = spawnMode === 'heavy' ? 1800 : 800
+            const BASE_MS = spawnMode === 'heavy' ? 1800 : spawnMode === 'scout' ? 500 : 800
             const OUTPOST_MS = 1200
             const playerTriple = hud.tripleOutpostOwner === 'player'
             const aiOutpostCount = Math.max(0, (hud.players.ai?.buildingCount ?? 0) - 1)

--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -371,25 +371,28 @@ export function HUD() {
         {(['basic', 'heavy', 'scout'] as const).map((type, idx) => {
           const active = spawnMode === type
           const color = type === 'heavy' ? '#ffa032' : type === 'scout' ? '#50c8ff' : '#ffffff'
-          const label = type === 'heavy' ? '⬡' : type === 'scout' ? '→' : '·'
+          const subtitle = type === 'heavy' ? 'slow · siege' : type === 'scout' ? 'fast · outpost' : 'balanced'
           return (
             <button
               key={type}
               onClick={() => gameActions?.setSpawnType?.(type)}
-              title={`[${idx + 1}] Spawn ${type}`}
+              title={`[${idx + 1}] Spawn ${type} — ${subtitle}`}
               style={{
                 pointerEvents: 'auto',
-                padding: '4px 9px',
-                fontSize: 13,
+                padding: '3px 8px',
+                fontSize: 10,
                 cursor: 'pointer',
                 background: active ? `${color}22` : 'rgba(0,0,0,0.5)',
                 border: `1px solid ${active ? color : 'rgba(255,255,255,0.2)'}`,
                 borderRadius: idx === 0 ? '4px 0 0 4px' : idx === 2 ? '0 4px 4px 0' : '0',
                 color: active ? color : 'rgba(255,255,255,0.4)',
                 marginLeft: idx === 0 ? 0 : -1,
+                lineHeight: 1.3,
+                textAlign: 'center',
               }}
             >
-              {label}
+              <div style={{ fontWeight: 700, letterSpacing: 0.5 }}>{idx + 1} {type.toUpperCase()}</div>
+              <div style={{ fontSize: 8, opacity: 0.7, letterSpacing: 0.3 }}>{subtitle}</div>
             </button>
           )
         })}

--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -345,7 +345,7 @@ export function HUD() {
             : isAiOwned ? hud.players.ai?.buildingHp[id]
             : undefined
           const hpFrac = hp !== undefined ? hp / OUTPOST_MAX_HP : undefined
-          return { color, isUnderAttack, isPlayerOwned, cap, hpFrac }
+          return { id, color, isUnderAttack, isPlayerOwned, cap, hpFrac }
         })
         const playerCount = dots.filter(d => d.isPlayerOwned).length
         return (
@@ -365,7 +365,7 @@ export function HUD() {
               <span style={{ fontSize: 10, letterSpacing: 1, opacity: 0.5, marginRight: 4 }}>
                 OUTPOSTS {playerCount}/{OUTPOST_IDS.length}
               </span>
-              {dots.map(({ color, isUnderAttack, isPlayerOwned, cap, hpFrac }, i) => {
+              {dots.map(({ id, color, isUnderAttack, isPlayerOwned, cap, hpFrac }, i) => {
                 const capColor = cap?.side === 'player' ? '#4af7c4' : '#ff4f7b'
                 return (
                   <div key={i} style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 2 }}>
@@ -393,6 +393,20 @@ export function HUD() {
                         }} />
                       </div>
                     ) : null}
+                    {/* Fortification indicator — gold bar for player-owned outposts with fortify progress */}
+                    {(() => {
+                      if (!isPlayerOwned) return null
+                      const level = hud.outpostFortify?.[id] ?? 0
+                      if (level <= 0) return null
+                      return (
+                        <div style={{ width: 14, height: 2, background: 'rgba(255,215,0,0.15)', borderRadius: 1 }}>
+                          <div style={{
+                            width: `${Math.round(level * 100)}%`,
+                            height: '100%', background: '#ffd700', borderRadius: 1, opacity: 0.7,
+                          }} />
+                        </div>
+                      )
+                    })()}
                   </div>
                 )
               })}

--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -111,6 +111,15 @@ export function HUD() {
           zIndex: 108, pointerEvents: 'none',
         }}>ENEMY ADVANCING</div>
       )}
+      {hud?.rallyCryActive && !hud?.baseUnderThreat && (
+        <div style={{
+          position: 'fixed', top: 108, left: '50%', transform: 'translateX(-50%)',
+          background: 'rgba(255,136,0,0.88)', color: '#fff', fontWeight: 700,
+          padding: '3px 12px', borderRadius: 6, fontSize: 11, letterSpacing: 1,
+          zIndex: 107, pointerEvents: 'none',
+          animation: 'pulse-red 0.9s ease-in-out infinite alternate',
+        }}>★ RALLY CRY — 1.5× SPAWN</div>
+      )}
       {isDanger && (
         <>
           <style>{`

--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -135,6 +135,11 @@ export function HUD() {
             <span style={{ color: 'rgba(255,255,255,0.18)', fontSize: 8, letterSpacing: 0.5 }}>
               DAILY MAP · {new Date().toLocaleDateString('en-US', { month: 'short', day: 'numeric' }).toUpperCase()}
             </span>
+            {hud?.dailyModifier && hud.dailyModifier !== 'standard' && (
+              <span style={{ color: '#ffd700', fontSize: 8, letterSpacing: 0.5, opacity: 0.7, textAlign: 'right' }}>
+                {hud.dailyModifier === 'bulwark' ? '⚔ BULWARK' : hud.dailyModifier === 'blitz' ? '⚡ BLITZ' : '🏰 SIEGE'}
+              </span>
+            )}
           </div>
         )
       })()}
@@ -325,6 +330,9 @@ export function HUD() {
             <span>B — rush enemy base</span><span>D — defend base</span>
             <span>Q — surge (2× spawn 8s)</span><span>Shift+drag — select specks</span>
             <span>Minimap — click to rally</span><span>? — this help</span>
+            <span style={{ gridColumn: '1/-1', borderTop: '1px solid rgba(255,255,255,0.08)', paddingTop: 8, marginTop: 2, color: 'rgba(255,215,0,0.5)', fontSize: 11 }}>
+              Daily map seed changes each day · modifier shown top-right (bulwark/blitz/siege)
+            </span>
           </div>
         </div>
       )}

--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -923,6 +923,22 @@ export function HUD() {
                 </div>
               )
             })()}
+            {/* Veteran / elite count */}
+            {(() => {
+              const vets = hud.players.player?.veteranCount ?? 0
+              const elites = hud.players.player?.eliteCount ?? 0
+              if (vets + elites === 0) return null
+              return (
+                <div style={{ display: 'flex', gap: 8, fontSize: 9, letterSpacing: 0.5 }}>
+                  {elites > 0 && (
+                    <span style={{ color: '#ffffff', opacity: 0.8 }}>✦ {elites} elite</span>
+                  )}
+                  {vets > 0 && (
+                    <span style={{ color: '#ffd700', opacity: 0.65 }}>⭐ {vets} vet</span>
+                  )}
+                </div>
+              )
+            })()}
             {/* Kill/loss + enemy base HP */}
             <div style={{ display: 'flex', gap: 10, fontSize: 10, letterSpacing: 0.5 }}>
               <span style={{ color: colorHex(PLAYER_COLOR), opacity: 0.7 }}>↑{kills} ↓{losses}</span>

--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -42,7 +42,7 @@ export function HUD() {
   const kills = useSpeckWarsStore(s => s.kills)
   const losses = useSpeckWarsStore(s => s.losses)
   const spawnMode = useSpeckWarsStore(s => s.spawnMode)
-  const cycleSpawnMode = useSpeckWarsStore(s => s.cycleSpawnMode)
+  const setSpawnMode = useSpeckWarsStore(s => s.setSpawnMode)
   const difficulty = useSpeckWarsStore(s => s.difficulty)
   const surrender = useSpeckWarsStore(s => s.surrender)
   const gameActions = useSpeckWarsStore(s => s.gameActions)
@@ -309,23 +309,32 @@ export function HUD() {
         >
           {speed}×
         </button>
-        <button
-          onClick={cycleSpawnMode}
-          title="H — cycle spawn mode (basic → heavy → scout)"
-          style={{
-            pointerEvents: 'auto',
-            padding: '4px 14px',
-            fontSize: 12,
-            cursor: 'pointer',
-            background: spawnMode === 'heavy' ? 'rgba(255,160,50,0.15)' : spawnMode === 'scout' ? 'rgba(80,200,255,0.15)' : 'rgba(0,0,0,0.5)',
-            border: `1px solid ${spawnMode === 'heavy' ? '#ffa032' : spawnMode === 'scout' ? '#50c8ff' : 'rgba(255,255,255,0.3)'}`,
-            borderRadius: 4,
-            color: spawnMode === 'heavy' ? '#ffa032' : spawnMode === 'scout' ? '#50c8ff' : '#fff',
-            letterSpacing: 1,
-          }}
-        >
-          {spawnMode === 'heavy' ? '⬡ HEAVY' : spawnMode === 'scout' ? '→ SCOUT' : '· BASIC'}
-        </button>
+        {/* Spawn type selector — 3 direct buttons instead of cycle */}
+        {(['basic', 'heavy', 'scout'] as const).map((type, idx) => {
+          const active = spawnMode === type
+          const color = type === 'heavy' ? '#ffa032' : type === 'scout' ? '#50c8ff' : '#ffffff'
+          const label = type === 'heavy' ? '⬡' : type === 'scout' ? '→' : '·'
+          return (
+            <button
+              key={type}
+              onClick={() => gameActions?.setSpawnType?.(type)}
+              title={`[${idx + 1}] Spawn ${type}`}
+              style={{
+                pointerEvents: 'auto',
+                padding: '4px 9px',
+                fontSize: 13,
+                cursor: 'pointer',
+                background: active ? `${color}22` : 'rgba(0,0,0,0.5)',
+                border: `1px solid ${active ? color : 'rgba(255,255,255,0.2)'}`,
+                borderRadius: idx === 0 ? '4px 0 0 4px' : idx === 2 ? '0 4px 4px 0' : '0',
+                color: active ? color : 'rgba(255,255,255,0.4)',
+                marginLeft: idx === 0 ? 0 : -1,
+              }}
+            >
+              {label}
+            </button>
+          )
+        })}
         <button
           onClick={() => setShowHelp(h => !h)}
           title="? — show controls"

--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -144,6 +144,39 @@ export function HUD() {
         )
       })()}
 
+      {/* Wave countdown — only shows when wave is imminent or in progress */}
+      {hud && (hud.waveCountdown !== null || hud.waveInProgress) && (() => {
+        const countdown = hud.waveCountdown ?? 0
+        const inProgress = hud.waveInProgress
+        if (!inProgress && countdown > 30000) return null  // only show when < 30s
+        const secs = Math.ceil(countdown / 1000)
+        return (
+          <>
+            {inProgress && (
+              <style>{`
+                @keyframes danger-pulse {
+                  from { opacity: 0.4; }
+                  to   { opacity: 0.7; }
+                }
+              `}</style>
+            )}
+            <div style={{
+              position: 'absolute', top: 110, right: 16,
+              padding: '4px 10px',
+              background: inProgress ? 'rgba(255,80,80,0.25)' : 'rgba(255,140,0,0.15)',
+              border: `1px solid ${inProgress ? 'rgba(255,80,80,0.6)' : 'rgba(255,140,0,0.5)'}`,
+              borderRadius: 4,
+              fontSize: 10,
+              letterSpacing: 1.5,
+              color: inProgress ? '#ff5050' : '#ffa030',
+              animation: inProgress ? 'danger-pulse 0.6s ease-in-out infinite alternate' : 'none',
+            }}>
+              {inProgress ? '⚠ WAVE INCOMING!' : `⚠ WAVE IN ${secs}s`}
+            </div>
+          </>
+        )
+      })()}
+
       {/* Mini-map — top right, below difficulty badge */}
       {hud && (() => {
         const SCALE = 120 / 3000  // world→screen

--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -335,7 +335,7 @@ export function HUD() {
           }}>
             <span>🖱 Click — rally specks</span><span>Space — pause</span>
             <span>Scroll — zoom</span><span>R / Right-click — clear rally</span>
-            <span>Drag — pan camera</span><span>H — cycle spawn (basic/heavy/scout)</span>
+            <span>Drag — pan camera</span><span>1/2/3 or H — set/cycle spawn type</span>
             <span>A — advance to outpost</span><span>C — center on base</span>
             <span>B — rush enemy base</span><span>D — defend base</span>
             <span>Q — surge (2× spawn 8s)</span><span>V — snap camera to battle</span>

--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -328,8 +328,9 @@ export function HUD() {
             <span>Drag — pan camera</span><span>H — cycle spawn (basic/heavy/scout)</span>
             <span>A — advance to outpost</span><span>C — center on base</span>
             <span>B — rush enemy base</span><span>D — defend base</span>
-            <span>Q — surge (2× spawn 8s)</span><span>Shift+drag — select specks</span>
-            <span>Minimap — click to rally</span><span>? — this help</span>
+            <span>Q — surge (2× spawn 8s)</span><span>V — snap camera to battle</span>
+            <span>Shift+drag — select specks</span><span>Minimap — click to rally</span>
+            <span>? — this help</span>
             <span style={{ gridColumn: '1/-1', borderTop: '1px solid rgba(255,255,255,0.08)', paddingTop: 8, marginTop: 2, color: 'rgba(255,215,0,0.5)', fontSize: 11 }}>
               Daily map seed changes each day · modifier shown top-right (bulwark/blitz/siege)
             </span>

--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -155,9 +155,19 @@ export function HUD() {
             border: '1px solid rgba(255,255,255,0.12)',
             borderRadius: 4,
             overflow: 'hidden',
-            pointerEvents: 'none',
+            cursor: 'crosshair',
           }}>
-            <svg width={120} height={120} style={{ display: 'block' }}>
+            <svg width={120} height={120} style={{ display: 'block' }}
+              onClick={(e) => {
+                if (!gameActions?.rally) return
+                const rect = e.currentTarget.getBoundingClientRect()
+                const px = e.clientX - rect.left
+                const py = e.clientY - rect.top
+                const worldX = (px / 120) * 3000
+                const worldY = (py / 120) * 3000
+                gameActions.rally(worldX, worldY)
+              }}
+            >
               {/* Speck dots */}
               {hud.minimap.specks.map((s, i) => (
                 <circle

--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -89,6 +89,20 @@ export function HUD() {
           animation: 'pulse-red 0.6s ease-in-out infinite alternate',
         }}>⚠ BASE UNDER ATTACK</div>
       )}
+      {(() => {
+        const myCount = hud?.players?.player?.speckCount ?? 0
+        const aiCount = hud?.players?.ai?.speckCount ?? 0
+        const ratio = myCount > 0 ? aiCount / myCount : (aiCount > 0 ? 999 : 0)
+        if (ratio < 2.5) return null
+        return (
+          <div style={{
+            position: 'fixed', top: 44, left: '50%', transform: 'translateX(-50%)',
+            background: 'rgba(200,100,0,0.9)', color: '#fff', fontWeight: 700,
+            padding: '3px 12px', borderRadius: 6, fontSize: 12, letterSpacing: 1,
+            zIndex: 109, pointerEvents: 'none',
+          }}>OUTNUMBERED {Math.round(ratio)}:1</div>
+        )
+      })()}
       {isDanger && (
         <>
           <style>{`
@@ -404,11 +418,11 @@ export function HUD() {
           }}>
             <span>🖱 Click — rally specks</span><span>Space — pause</span>
             <span>Scroll — zoom</span><span>R / Right-click — clear rally</span>
-            <span>Drag — pan camera</span><span>1/2/3 or H — set/cycle spawn type</span>
+            <span>Drag — pan camera</span><span>1/2/3 — set spawn type</span>
             <span>A — advance to outpost</span><span>C — center on base</span>
             <span>B — rush enemy base</span><span>D — defend base</span>
             <span>Q — surge (2× spawn 8s)</span><span>V — snap camera to battle</span>
-            <span>Shift+drag — select specks</span><span>Minimap — click to rally</span>
+            <span>H — snap to home base</span><span>Minimap — click to rally</span>
             <span>E — select all specks</span><span>X — cycle speed (1×/2×/4×)</span>
             <span>F — sacrifice 10 specks → +15 HP base</span><span>? — this help</span>
             <span style={{ gridColumn: '1/-1', borderTop: '1px solid rgba(255,255,255,0.08)', paddingTop: 8, marginTop: 2, color: 'rgba(255,215,0,0.5)', fontSize: 11 }}>

--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -763,6 +763,16 @@ export function HUD() {
               textAlign: 'center', marginBottom: 4,
             }}>
               SQUAD: {hud.selectedSpeckCount} · Shift+drag to reselect · Esc to clear
+              {hud.selectedComposition && (
+                <div style={{ fontSize: 9, color: 'rgba(74,247,196,0.75)', marginTop: 2, letterSpacing: 1 }}>
+                  {Object.entries(hud.selectedComposition.types)
+                    .sort(([a], [b]) => a.localeCompare(b))
+                    .map(([typeId, count]) => `${count} ${typeId}`)
+                    .join(' · ')}
+                  {hud.selectedComposition.eliteCount > 0 && ` · ✦${hud.selectedComposition.eliteCount} elite`}
+                  {hud.selectedComposition.veteranCount > 0 && ` · ⭐${hud.selectedComposition.veteranCount} vet`}
+                </div>
+              )}
             </div>
           )}
           <div style={{

--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -374,7 +374,7 @@ export function HUD() {
             <span>Q — surge (2× spawn 8s)</span><span>V — snap camera to battle</span>
             <span>Shift+drag — select specks</span><span>Minimap — click to rally</span>
             <span>E — select all specks</span><span>X — cycle speed (1×/2×/4×)</span>
-            <span>? — this help</span>
+            <span>F — sacrifice 10 specks → +15 HP base</span><span>? — this help</span>
             <span style={{ gridColumn: '1/-1', borderTop: '1px solid rgba(255,255,255,0.08)', paddingTop: 8, marginTop: 2, color: 'rgba(255,215,0,0.5)', fontSize: 11 }}>
               Daily map seed changes each day · modifier shown top-right (bulwark/blitz/siege)
             </span>
@@ -794,6 +794,33 @@ export function HUD() {
                   : surgeCd > 0
                     ? `Q ${Math.ceil(surgeCd / 1000)}s`
                     : '★ Q'}
+              </button>
+            )
+          })()}
+          {(() => {
+            const cd = hud?.sacrificeCooldown ?? 0
+            const speckCount = hud?.players.player?.speckCount ?? 0
+            const baseHp = hud?.players.player?.buildingHp['building-player-base'] ?? 100
+            const ready = cd <= 0 && speckCount >= 10 && baseHp < 90
+            return (
+              <button
+                onClick={() => { if (ready) gameActions.sacrifice?.() }}
+                title="[F] Sacrifice 10 specks → repair +15 HP base (45s cooldown)"
+                style={{
+                  padding: '6px 10px',
+                  fontSize: 11,
+                  cursor: ready ? 'pointer' : 'default',
+                  background: ready ? 'rgba(100,200,100,0.12)' : 'rgba(100,200,100,0.04)',
+                  border: ready ? '1px solid rgba(100,200,100,0.5)' : '1px solid rgba(100,200,100,0.15)',
+                  borderRadius: 20,
+                  color: ready ? '#64c864' : 'rgba(100,200,100,0.35)',
+                  letterSpacing: 1,
+                  minHeight: 44,
+                  fontFamily: 'monospace',
+                  opacity: ready ? 1 : 0.6,
+                }}
+              >
+                {cd > 0 ? `F ${Math.ceil(cd / 1000)}s` : '🔧 F'}
               </button>
             )
           })()}

--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -103,6 +103,14 @@ export function HUD() {
           }}>OUTNUMBERED {Math.round(ratio)}:1</div>
         )
       })()}
+      {hud?.enemyAdvanceDetected && (
+        <div style={{
+          position: 'fixed', top: 76, left: '50%', transform: 'translateX(-50%)',
+          background: 'rgba(200,80,0,0.88)', color: '#ffe0c0', fontWeight: 700,
+          padding: '3px 12px', borderRadius: 6, fontSize: 12, letterSpacing: 1,
+          zIndex: 108, pointerEvents: 'none',
+        }}>ENEMY ADVANCING</div>
+      )}
       {isDanger && (
         <>
           <style>{`

--- a/src/app/speck-wars/components/phase-router.tsx
+++ b/src/app/speck-wars/components/phase-router.tsx
@@ -131,20 +131,46 @@ export function PhaseRouter({ children }: { children: React.ReactNode }) {
           fontSize: 11,
           letterSpacing: 0.5,
           textAlign: 'left',
-          maxWidth: 280,
+          maxWidth: 320,
         }}>
           <span>🖱 Click — rally specks</span>
-          <span>Space — pause</span>
-          <span>Scroll — zoom</span>
-          <span>R / Right-click — clear rally</span>
-          <span>Drag — pan camera</span>
-          <span>H — heavy/basic mode</span>
-          <span>A — advance to outpost</span>
-          <span>B — rush enemy base</span>
-          <span>C — center on base</span>
-          <span>D — defend base</span>
+          <span>Space — pause / ? — help</span>
+          <span>Shift+drag — box select</span>
+          <span>1/2/3 — spawn basic/heavy/scout</span>
+          <span>Q — surge (2× spawn 8s)</span>
+          <span>V — snap to battle</span>
+          <span>A — advance · B — rush · D — defend</span>
+          <span>X — game speed · E — select all</span>
           <span>Minimap — click to rally</span>
+          <span>C — center camera</span>
         </div>
+        {/* Daily tip */}
+        {(() => {
+          const tips = [
+            'Hold all 3 outposts for 60s to win by Domination.',
+            'Scouts (3) auto-target outposts — fast but fragile.',
+            'Veterans deal +20% damage after 3 kills. Protect them!',
+            'Fortify outposts by holding them 30s for a combat bonus.',
+            'Surge (Q) doubles production for 8s — use it before big pushes.',
+            'Box-select (Shift+drag) specks and right-click to send them anywhere.',
+            'Rally Cry: base below 25% HP activates 1.5× spawn automatically.',
+            'Heavy specks deal 2× damage but produce 2× slower.',
+            'V key snaps the camera to where fighting is happening.',
+            'Press ? in-game to see all hotkeys.',
+          ]
+          const tip = tips[Math.floor(Date.now() / 86400000) % tips.length]
+          return (
+            <div style={{
+              marginTop: 8, maxWidth: 320,
+              fontSize: 11, letterSpacing: 0.3,
+              color: 'rgba(255,215,0,0.45)',
+              textAlign: 'center',
+              fontStyle: 'italic',
+            }}>
+              💡 {tip}
+            </div>
+          )
+        })()}
       </div>
     )
   }

--- a/src/app/speck-wars/components/phase-router.tsx
+++ b/src/app/speck-wars/components/phase-router.tsx
@@ -340,6 +340,45 @@ export function PhaseRouter({ children }: { children: React.ReactNode }) {
           )
         })()}
 
+        {/* Contextual tactical tip */}
+        {(() => {
+          const eff = kills + losses > 0 ? kills / (kills + losses) : 0
+          const modifier = hud?.dailyModifier ?? 'standard'
+          let tip: string | null = null
+
+          if (won && elapsedMs < 180000) {
+            tip = difficulty === 'very-hard' ? '⚡ Incredible! That was master-level play.' : 'That was fast! Try a harder difficulty for more of a challenge.'
+          } else if (won && difficulty !== 'very-hard' && stars === 3) {
+            tip = `Perfect stars on ${diffLabel}! Ready to try ${nextDiff?.label ?? 'the next level'}?`
+          } else if (!won && kills < 30) {
+            tip = 'Tip: Scouts are fast and great for outpost rushes — press 3 to switch spawn type.'
+          } else if (!won && eff < 0.4) {
+            tip = 'Tip: Heavy specks deal 2× damage — switch with key 2 during big fights.'
+          } else if (!won && elapsedMs > 300000) {
+            tip = 'Tip: Press Q for Surge — doubles production for 8s. Use it when you\'re behind!'
+          } else if (!won) {
+            tip = 'Tip: Press F to sacrifice 10 specks and repair your base when HP is critical.'
+          } else if (won && modifier === 'siege') {
+            tip = '⬡ Siege modifier won — outposts were twice as hard to capture. Nice patience!'
+          }
+
+          if (!tip) return null
+          return (
+            <div style={{
+              maxWidth: 340, textAlign: 'center',
+              fontSize: 11, letterSpacing: 0.5,
+              color: 'rgba(255,255,255,0.5)',
+              fontStyle: 'italic',
+              padding: '8px 16px',
+              border: '1px solid rgba(255,255,255,0.08)',
+              borderRadius: 6,
+              background: 'rgba(255,255,255,0.03)',
+            }}>
+              {tip}
+            </div>
+          )
+        })()}
+
         <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 6, marginTop: 8 }}>
           <div style={{ display: 'flex', gap: 12 }}>
           <button

--- a/src/app/speck-wars/components/phase-router.tsx
+++ b/src/app/speck-wars/components/phase-router.tsx
@@ -5,7 +5,7 @@ import { getBestTime, getWinStreak, getRecentResults, hasWonToday } from '../lib
 import type { Difficulty } from '../store'
 
 export function PhaseRouter({ children }: { children: React.ReactNode }) {
-  const { phase, winnerId, setPhase, difficulty, setDifficulty, elapsedMs, resetGame, kills, losses, isNewBest, victoryType, hud } = useSpeckWarsStore()
+  const { phase, winnerId, setPhase, difficulty, setDifficulty, elapsedMs, resetGame, kills, losses, isNewBest, victoryType, hud, peakArmySize, outpostsCaptured } = useSpeckWarsStore()
   const [copied, setCopied] = useState(false)
   const [bestTimes, setBestTimes] = useState<Partial<Record<Difficulty, number>>>({})
   const [winStreak, setWinStreak] = useState(0)
@@ -261,6 +261,17 @@ export function PhaseRouter({ children }: { children: React.ReactNode }) {
             </span>
           )}
         </div>
+
+        {(peakArmySize > 0 || outpostsCaptured > 0) && (
+          <div style={{ display: 'flex', gap: 28, color: 'rgba(255,255,255,0.45)', fontSize: 12, letterSpacing: 0.5 }}>
+            {peakArmySize > 0 && (
+              <span>⚔ peak {peakArmySize} specks</span>
+            )}
+            {outpostsCaptured > 0 && (
+              <span>⬡ {outpostsCaptured} outpost{outpostsCaptured !== 1 ? 's' : ''} captured</span>
+            )}
+          </div>
+        )}
 
         {/* Recent run history for this difficulty */}
         {(() => {

--- a/src/app/speck-wars/components/phase-router.tsx
+++ b/src/app/speck-wars/components/phase-router.tsx
@@ -201,10 +201,13 @@ export function PhaseRouter({ children }: { children: React.ReactNode }) {
     const nextDiff = won ? nextDifficulty[difficulty] : null
 
     const today = new Date().toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
-    const starStr = won ? '★'.repeat(stars) + '☆'.repeat(3 - stars) + ' ' : ''
+    const starStr = won ? '★'.repeat(stars) + '☆'.repeat(3 - stars) : '✗✗✗'
+    const modifier = hud?.dailyModifier && hud.dailyModifier !== 'standard' ? ` [${hud.dailyModifier.toUpperCase()}]` : ''
+    const effPct = kills + losses > 0 ? Math.round((kills / (kills + losses)) * 100) : 0
+    const statsLine = `⚔ ${kills} kills · ${losses} lost · ${effPct}% eff${peakArmySize > 0 ? ` · peak ${peakArmySize}` : ''}`
     const shareText = won
-      ? `${starStr}I defeated the AI in Speck Wars (${diffLabel}) in ${timeStr} — killed ${kills} specks! 🎮 Daily map ${today} — can you beat my time?`
-      : `The AI beat me in Speck Wars (${diffLabel}) in ${timeStr} — killed ${kills} specks. 🎮 Daily map ${today} — think you can do better?`
+      ? `${starStr} Speck Wars ${today}${modifier}\nVICTORY in ${timeStr} (${diffLabel})\n${statsLine}\nCan you do better? `
+      : `${starStr} Speck Wars ${today}${modifier}\nDEFEATED in ${timeStr} (${diffLabel})\n${statsLine}\nThink you can win? `
 
     const handleShare = async () => {
       const url = typeof window !== 'undefined' ? window.location.href : ''
@@ -271,11 +274,23 @@ export function PhaseRouter({ children }: { children: React.ReactNode }) {
           </div>
         )}
 
-        <div style={{ display: 'flex', gap: 24, alignItems: 'center', color: 'rgba(255,255,255,0.7)', fontSize: 16 }}>
+        <div style={{ display: 'flex', gap: 12, alignItems: 'center', color: 'rgba(255,255,255,0.7)', fontSize: 16, flexWrap: 'wrap', justifyContent: 'center' }}>
           <span>⏱ {timeStr}</span>
           <span style={{ color: diffColor, fontWeight: 'bold', border: `1px solid ${diffColor}`, padding: '2px 10px', borderRadius: 4 }}>
             {diffLabel}
           </span>
+          {hud?.dailyModifier && hud.dailyModifier !== 'standard' && (
+            <span style={{
+              fontSize: 11, letterSpacing: 1.5,
+              color: hud.dailyModifier === 'bulwark' ? '#44aaff'
+                : hud.dailyModifier === 'blitz' ? '#ffd700'
+                : '#ff8844',
+              border: `1px solid ${hud.dailyModifier === 'bulwark' ? '#44aaff44' : hud.dailyModifier === 'blitz' ? '#ffd70044' : '#ff884444'}`,
+              padding: '2px 8px', borderRadius: 4,
+            }}>
+              {hud.dailyModifier.toUpperCase()}
+            </span>
+          )}
         </div>
 
         <div style={{ display: 'flex', gap: 28, color: 'rgba(255,255,255,0.6)', fontSize: 14 }}>

--- a/src/app/speck-wars/domain/ai/ai-controller.ts
+++ b/src/app/speck-wars/domain/ai/ai-controller.ts
@@ -12,15 +12,34 @@ export class AIController {
   private spawnMode: 'basic' | 'heavy' | 'scout' = 'basic'
   private spawnModeCountdown: number = 0  // ticks until next spawn mode decision
   private dominanceTimer: number = 0  // ms enemy has held a 3:1 count advantage
+  private waveTimer: number  // ms until next wave
+  private waveRemainingMs = 0  // ms left in active wave (0 = not in wave)
+  private waveNumber = 0       // which wave this is (1, 2, 3...)
+  private waveEnabled: boolean  // only hard/very-hard get waves
 
   constructor(playerId: string, tickInterval: number = 30, personality: AIPersonality = 'balanced') {
     this.playerId = playerId
     this.tickInterval = tickInterval
     this.baseTickInterval = tickInterval
     this.personality = personality
+    this.waveTimer = 90000 + Math.random() * 30000  // stagger first wave: 90-120s
+    this.waveEnabled = tickInterval <= 15  // hard (15) and very-hard (6) only
   }
 
   update(sim: SimulationState, dt: number = 16) {
+    if (this.waveEnabled) {
+      this.waveTimer -= dt
+      if (this.waveRemainingMs > 0) {
+        this.waveRemainingMs = Math.max(0, this.waveRemainingMs - dt)
+      }
+      if (this.waveTimer <= 0) {
+        this.waveNumber++
+        this.waveRemainingMs = 15000
+        this.waveTimer = 90000
+        sim.events.push({ type: 'AI_WAVE_START', waveNumber: this.waveNumber })
+      }
+    }
+
     // Adaptive difficulty: if the enemy holds a 3:1 speck advantage for 30s, speed up AI decisions
     let aiCount = 0, enemyCount = 0
     for (let i = 0; i < sim.speckCount; i++) {
@@ -106,6 +125,15 @@ export class AIController {
           : (myBaseHpFrac < 0.3 ? 0.70 : 0.45)  // balanced
       if (Math.random() < defendChance) {
         sim.inputQueue.push({ type: 'RALLY', ownerId: this.playerId, x: myBase.x, y: myBase.y })
+        return
+      }
+    }
+
+    // Wave assault: during active wave, always rush the enemy base
+    if (this.waveRemainingMs > 0) {
+      const enemyBase = nearest(b => b.ownerId !== this.playerId && b.ownerId !== 'neutral' && b.typeId === 'base')
+      if (enemyBase) {
+        sim.inputQueue.push({ type: 'RALLY', ownerId: this.playerId, x: enemyBase.x, y: enemyBase.y })
         return
       }
     }

--- a/src/app/speck-wars/domain/ai/ai-controller.ts
+++ b/src/app/speck-wars/domain/ai/ai-controller.ts
@@ -17,8 +17,10 @@ export class AIController {
   private waveRemainingMs = 0  // ms left in active wave (0 = not in wave)
   private waveNumber = 0       // which wave this is (1, 2, 3...)
   private waveEnabled: boolean  // only hard/very-hard get waves
+  private adaptiveDominanceDuration = 0  // ms player has dominated ≥3:1
+  private adaptiveBaseInterval: number | null = null  // captured baseline spawn interval
 
-  constructor(playerId: string, tickInterval: number = 30, personality: AIPersonality = 'balanced') {
+  constructor(playerId: string, tickInterval: number = 30, personality: AIPersonality = 'balanced', private readonly adaptiveEnabled: boolean = false) {
     this.playerId = playerId
     this.tickInterval = tickInterval
     this.baseTickInterval = tickInterval
@@ -151,6 +153,34 @@ export class AIController {
       if (enemyBase) {
         sim.inputQueue.push({ type: 'RALLY', ownerId: this.playerId, x: enemyBase.x, y: enemyBase.y })
         return
+      }
+    }
+
+    // Adaptive difficulty: gradually speed up AI spawns when player dominates
+    if (this.adaptiveEnabled) {
+      let playerCount = 0, aiCount = 0
+      for (let i = 0; i < sim.speckCount; i++) {
+        const m = sim.speckMeta[i]
+        if (!m) continue
+        if (m.ownerId === 'player') playerCount++
+        else if (m.ownerId === 'ai') aiCount++
+      }
+      const ratio = aiCount > 0 ? playerCount / aiCount : (playerCount > 0 ? 9 : 1)
+      if (ratio >= 3.0) {
+        this.adaptiveDominanceDuration = Math.min(45_000, this.adaptiveDominanceDuration + dt)
+      } else {
+        this.adaptiveDominanceDuration = Math.max(0, this.adaptiveDominanceDuration - dt * 0.5)
+      }
+      const boostFraction = this.adaptiveDominanceDuration / 45_000  // 0 → 1 over 45s
+      if (boostFraction > 0) {
+        const aiBase = Object.values(sim.buildings).find(b => b.ownerId === 'ai' && b.typeId === 'base')
+        if (aiBase) {
+          if (this.adaptiveBaseInterval === null) {
+            this.adaptiveBaseInterval = aiBase.spawnIntervalOverride ?? 800
+          }
+          const speedMult = 1 + boostFraction * 0.3  // up to 30% faster
+          aiBase.spawnIntervalOverride = Math.max(400, this.adaptiveBaseInterval / speedMult)
+        }
       }
     }
 

--- a/src/app/speck-wars/domain/ai/ai-controller.ts
+++ b/src/app/speck-wars/domain/ai/ai-controller.ts
@@ -10,6 +10,7 @@ export class AIController {
   private personality: AIPersonality
   private decisionCount: number = 0
   private spawnMode: 'basic' | 'heavy' | 'scout' = 'basic'
+  private lastStandTriggered = false
   private spawnModeCountdown: number = 0  // ticks until next spawn mode decision
   private dominanceTimer: number = 0  // ms enemy has held a 3:1 count advantage
   private waveTimer: number  // ms until next wave
@@ -117,6 +118,21 @@ export class AIController {
 
     // Defensive rally: when AI base is low HP, sometimes pull back to defend
     const myBaseHpFrac = (myBase?.hp ?? 100) / (myBase?.maxHp ?? 100)
+
+    // Last stand: AI base below 20% — all-out desperate assault, ignoring personality
+    if (myBaseHpFrac < 0.2) {
+      if (!this.lastStandTriggered) {
+        this.lastStandTriggered = true
+        sim.events.push({ type: 'AI_LAST_STAND' })
+      }
+      const playerBase = Object.values(sim.buildings).find(b => b.ownerId !== this.playerId && b.ownerId !== 'neutral' && b.typeId === 'base')
+      if (playerBase) {
+        sim.rallyPoints[this.playerId] = { x: playerBase.x, y: playerBase.y }
+        sim.inputQueue.push({ type: 'SET_SPAWN_TYPE', ownerId: this.playerId, speckTypeId: 'heavy' })
+      }
+      return
+    }
+
     if (!forceBaseRush && myBaseHpFrac < 0.6 && myBase) {
       const defendChance = this.personality === 'aggressive'
         ? (myBaseHpFrac < 0.3 ? 0.35 : 0.15)   // aggressive defends reluctantly

--- a/src/app/speck-wars/domain/ai/ai-controller.ts
+++ b/src/app/speck-wars/domain/ai/ai-controller.ts
@@ -216,5 +216,9 @@ export class AIController {
     }
 
     sim.inputQueue.push({ type: 'RALLY', ownerId: this.playerId, x: target.x, y: target.y })
+
+    // Expose wave state to sim so HUD can display it
+    sim.waveCountdown = this.waveEnabled ? this.waveTimer : null
+    sim.waveInProgress = this.waveRemainingMs > 0
   }
 }

--- a/src/app/speck-wars/domain/ai/ai-controller.ts
+++ b/src/app/speck-wars/domain/ai/ai-controller.ts
@@ -9,7 +9,7 @@ export class AIController {
   private lastDecisionTick: number = 0
   private personality: AIPersonality
   private decisionCount: number = 0
-  private spawnMode: 'basic' | 'heavy' = 'basic'
+  private spawnMode: 'basic' | 'heavy' | 'scout' = 'basic'
   private spawnModeCountdown: number = 0  // ticks until next spawn mode decision
   private dominanceTimer: number = 0  // ms enemy has held a 3:1 count advantage
 
@@ -81,40 +81,6 @@ export class AIController {
 
     this.decisionCount++
 
-    // Spawn mode decisions
-    if (this.personality === 'aggressive') {
-      // Aggressive: unpredictable spawn mix — re-evaluate every 8–16 decisions
-      this.spawnModeCountdown--
-      if (this.spawnModeCountdown <= 0) {
-        const next = Math.random() < 0.45 ? 'heavy' : 'basic'
-        if (next !== this.spawnMode) {
-          this.spawnMode = next
-          sim.inputQueue.push({ type: 'SET_SPAWN_TYPE', ownerId: this.playerId, speckTypeId: next })
-        }
-        this.spawnModeCountdown = 8 + Math.floor(Math.random() * 8)
-      }
-    } else {
-      // Balanced + Macro: counter-spawn — mirror player's heavy ratio
-      let playerHeavy = 0, playerBasic = 0
-      for (let i = 0; i < sim.speckCount; i++) {
-        const m = sim.speckMeta[i]
-        if (!m || m.ownerId === this.playerId || m.ownerId === 'neutral') continue
-        if (m.typeId === 'heavy') playerHeavy++
-        else playerBasic++
-      }
-      const playerTotal = playerHeavy + playerBasic
-      const playerHeavyFrac = playerTotal > 0 ? playerHeavy / playerTotal : 0
-      const wantHeavy = playerHeavyFrac > 0.55
-      const wantBasic = playerHeavyFrac < 0.30
-      if (wantHeavy && this.spawnMode !== 'heavy') {
-        this.spawnMode = 'heavy'
-        sim.inputQueue.push({ type: 'SET_SPAWN_TYPE', ownerId: this.playerId, speckTypeId: 'heavy' })
-      } else if (wantBasic && this.spawnMode !== 'basic') {
-        this.spawnMode = 'basic'
-        sim.inputQueue.push({ type: 'SET_SPAWN_TYPE', ownerId: this.playerId, speckTypeId: 'basic' })
-      }
-    }
-
     // Emergency: detect if the enemy (player) is about to win by domination
     const outposts = Object.values(sim.buildings).filter(b => b.typeId === 'outpost')
     const enemyId = Object.keys(sim.players).find(pid => pid !== this.playerId && pid !== 'neutral') ?? null
@@ -172,6 +138,54 @@ export class AIController {
     }
 
     if (!target) return
+
+    // Spawn mode decisions (runs after target is known so it can react to what we're targeting)
+    // Scout rush: when targeting an outpost, use scouts (they arrive faster)
+    const rushingOutpost = target.typeId === 'outpost'
+    if (rushingOutpost) {
+      if (this.spawnMode !== 'scout') {
+        this.spawnMode = 'scout'
+        sim.inputQueue.push({ type: 'SET_SPAWN_TYPE', ownerId: this.playerId, speckTypeId: 'scout' })
+      }
+    } else {
+      // Not rushing an outpost — exit scout mode, run normal spawn logic
+      if (this.spawnMode === 'scout') {
+        this.spawnMode = 'basic'
+        sim.inputQueue.push({ type: 'SET_SPAWN_TYPE', ownerId: this.playerId, speckTypeId: 'basic' })
+      }
+      if (this.personality === 'aggressive') {
+        // Aggressive: unpredictable spawn mix — re-evaluate every 8–16 decisions
+        this.spawnModeCountdown--
+        if (this.spawnModeCountdown <= 0) {
+          const next = Math.random() < 0.45 ? 'heavy' : 'basic'
+          if (next !== this.spawnMode) {
+            this.spawnMode = next
+            sim.inputQueue.push({ type: 'SET_SPAWN_TYPE', ownerId: this.playerId, speckTypeId: next })
+          }
+          this.spawnModeCountdown = 8 + Math.floor(Math.random() * 8)
+        }
+      } else {
+        // Balanced + Macro: counter-spawn — mirror player's heavy ratio
+        let playerHeavy = 0, playerBasic = 0
+        for (let i = 0; i < sim.speckCount; i++) {
+          const m = sim.speckMeta[i]
+          if (!m || m.ownerId === this.playerId || m.ownerId === 'neutral') continue
+          if (m.typeId === 'heavy') playerHeavy++
+          else playerBasic++
+        }
+        const playerTotal = playerHeavy + playerBasic
+        const playerHeavyFrac = playerTotal > 0 ? playerHeavy / playerTotal : 0
+        const wantHeavy = playerHeavyFrac > 0.55
+        const wantBasic = playerHeavyFrac < 0.30
+        if (wantHeavy && this.spawnMode !== 'heavy') {
+          this.spawnMode = 'heavy'
+          sim.inputQueue.push({ type: 'SET_SPAWN_TYPE', ownerId: this.playerId, speckTypeId: 'heavy' })
+        } else if (wantBasic && this.spawnMode !== 'basic') {
+          this.spawnMode = 'basic'
+          sim.inputQueue.push({ type: 'SET_SPAWN_TYPE', ownerId: this.playerId, speckTypeId: 'basic' })
+        }
+      }
+    }
 
     sim.inputQueue.push({ type: 'RALLY', ownerId: this.playerId, x: target.x, y: target.y })
   }

--- a/src/app/speck-wars/domain/config/speck-types.ts
+++ b/src/app/speck-wars/domain/config/speck-types.ts
@@ -22,4 +22,11 @@ export const SPECK_TYPES: Record<string, SpeckTypeDefinition> = {
     size: 6, productionTime: 1800,
     abilities: [],
   },
+  scout: {
+    id: 'scout', name: 'Dart',
+    hp: 1, damage: 0.5, speed: 150,
+    attackRange: 4, attackCooldown: 600,
+    size: 2, productionTime: 500,
+    abilities: [],
+  },
 }

--- a/src/app/speck-wars/domain/constants.ts
+++ b/src/app/speck-wars/domain/constants.ts
@@ -47,3 +47,7 @@ export const MAP_LAYOUTS = [
 ] as const
 
 export const OUTPOST_POSITIONS = MAP_LAYOUTS[0]  // default — overridden by createSim seed
+
+export const FORTIFY_TIME = 30000        // ms to reach full fortification
+export const FORTIFY_RADIUS = 200        // px — combat bonus applies within this radius
+export const FORTIFY_DAMAGE_BONUS = 0.25 // max damage multiplier bonus when fully fortified

--- a/src/app/speck-wars/domain/constants.ts
+++ b/src/app/speck-wars/domain/constants.ts
@@ -51,3 +51,17 @@ export const OUTPOST_POSITIONS = MAP_LAYOUTS[0]  // default — overridden by cr
 export const FORTIFY_TIME = 30000        // ms to reach full fortification
 export const FORTIFY_RADIUS = 200        // px — combat bonus applies within this radius
 export const FORTIFY_DAMAGE_BONUS = 0.25 // max damage multiplier bonus when fully fortified
+
+export type DailyModifier = 'standard' | 'bulwark' | 'blitz' | 'siege'
+
+// Weighted array: standard appears 2× more often than others
+export const DAILY_MODIFIER_POOL: DailyModifier[] = [
+  'standard', 'standard', 'bulwark', 'blitz', 'siege'
+]
+
+export const DAILY_MODIFIER_LABELS: Record<DailyModifier, string> = {
+  standard: '',
+  bulwark:  '⚔ BULWARK — bases have 2× HP',
+  blitz:    '⚡ BLITZ — 1.5× production speed',
+  siege:    '🏰 SIEGE — outposts take 2× longer to capture',
+}

--- a/src/app/speck-wars/domain/constants.ts
+++ b/src/app/speck-wars/domain/constants.ts
@@ -21,6 +21,7 @@ export const CAPTURE_TIME = 5000             // ms to fully capture
 export const NEUTRAL_COLOR = 0x888888
 export const OUTPOST_AURA_RADIUS = 160  // px — specks within this radius of a friendly outpost move faster
 export const DOMINATION_TIME = 60000   // ms — hold all 3 outposts this long to win by domination
+export const RALLY_CRY_HP_THRESHOLD = 0.25  // base HP fraction below which Rally Cry activates (1.5× spawn)
 
 // Three map layouts — one is picked per game using the daily seed.
 // All layouts use the same outpost IDs so the rest of the codebase is layout-agnostic.

--- a/src/app/speck-wars/domain/simulation/capture.ts
+++ b/src/app/speck-wars/domain/simulation/capture.ts
@@ -38,6 +38,7 @@ export function updateCapture(sim: SimulationState, dt: number) {
     if ((building.captureProgress ?? 0) >= 1) {
       const previousOwner = building.ownerId
       building.ownerId = dominantOwner
+      building.fortifyDuration = 0
       building.captureProgress = 0
       building.captureSide = null
       // Reset spawn timer so it starts fresh for the new owner

--- a/src/app/speck-wars/domain/simulation/capture.ts
+++ b/src/app/speck-wars/domain/simulation/capture.ts
@@ -21,7 +21,24 @@ export function updateCapture(sim: SimulationState, dt: number) {
     // Find player-owned specks (exclude neutral)
     const sides = Object.entries(counts).filter(([, n]) => n > 0)
     if (sides.length === 0) continue  // nobody near — decay progress slowly
-    if (sides.length > 1) continue  // contested — pause capture
+    if (sides.length > 1) {
+      // Contested tug-of-war: dominant side (more specks) reverses enemy capture progress.
+      // Neither side can GAIN progress — only erase the enemy's progress.
+      sides.sort((a, b) => b[1] - a[1])
+      const [topOwner, topCount] = sides[0]
+      const [, secondCount] = sides[1]
+      if (topCount > secondCount) {
+        const hasEnemyProgress = (building.captureProgress ?? 0) > 0 &&
+          building.captureSide && building.captureSide !== topOwner
+        if (hasEnemyProgress) {
+          const captureTimeMs = sim.dailyModifier === 'siege' ? CAPTURE_TIME * 2 : CAPTURE_TIME
+          const reverseSpeed = Math.min(1.5, (topCount - secondCount) / 5)
+          building.captureProgress = Math.max(0, (building.captureProgress ?? 0) - (dt / captureTimeMs) * reverseSpeed * 0.5)
+          if ((building.captureProgress ?? 0) <= 0) building.captureSide = null
+        }
+      }
+      continue  // never allow capture completion when contested
+    }
 
     const [dominantOwner, dominantCount] = sides[0]
     if (dominantOwner === building.ownerId) continue  // already owned by them

--- a/src/app/speck-wars/domain/simulation/capture.ts
+++ b/src/app/speck-wars/domain/simulation/capture.ts
@@ -20,7 +20,7 @@ export function updateCapture(sim: SimulationState, dt: number) {
 
     // Find player-owned specks (exclude neutral)
     const sides = Object.entries(counts).filter(([, n]) => n > 0)
-    if (sides.length === 0) return  // nobody near — decay progress slowly
+    if (sides.length === 0) continue  // nobody near — decay progress slowly
     if (sides.length > 1) continue  // contested — pause capture
 
     const [dominantOwner, dominantCount] = sides[0]

--- a/src/app/speck-wars/domain/simulation/capture.ts
+++ b/src/app/speck-wars/domain/simulation/capture.ts
@@ -33,8 +33,9 @@ export function updateCapture(sim: SimulationState, dt: number) {
     }
 
     // Scale capture speed with speck count: 5 specks = 1×, capped at 3× (15 specks)
+    const captureTimeMs = sim.dailyModifier === 'siege' ? CAPTURE_TIME * 2 : CAPTURE_TIME
     const captureSpeed = Math.min(3, dominantCount / 5)
-    building.captureProgress = (building.captureProgress ?? 0) + (dt / CAPTURE_TIME) * captureSpeed
+    building.captureProgress = (building.captureProgress ?? 0) + (dt / captureTimeMs) * captureSpeed
     if ((building.captureProgress ?? 0) >= 1) {
       const previousOwner = building.ownerId
       building.ownerId = dominantOwner

--- a/src/app/speck-wars/domain/simulation/combat.ts
+++ b/src/app/speck-wars/domain/simulation/combat.ts
@@ -7,6 +7,8 @@ const MORALE_RATIO = 2.0   // if your count > this × enemy count → morale bon
 const MORALE_BONUS = 1.20  // 20% damage boost when morale is active
 const RAGE_HP_THRESHOLD = 0.15  // base HP fraction below which rage activates
 const RAGE_BONUS = 1.40         // 40% damage boost when base is critical
+const SUPREMACY_OUTPOST_LEAD = 2   // outpost advantage needed for supremacy
+const SUPREMACY_BONUS = 1.15        // 15% damage boost for outpost supremacy
 
 export function resolveCombat(sim: SimulationState, dt: number) {
   const { speckIds, speckX, speckY, speckHp, speckMeta, buildings, spatialGrid } = sim
@@ -17,6 +19,14 @@ export function resolveCombat(sim: SimulationState, dt: number) {
     const ownerId = speckMeta[i]?.ownerId
     if (speckIds[i] && ownerId) speckCountByOwner[ownerId] = (speckCountByOwner[ownerId] ?? 0) + 1
   }
+
+  // Pre-compute outpost ownership counts for supremacy bonus
+  const outpostCountByOwner: Record<string, number> = {}
+  for (const b of Object.values(buildings)) {
+    if (b.typeId !== 'outpost' || b.ownerId === 'neutral') continue
+    outpostCountByOwner[b.ownerId] = (outpostCountByOwner[b.ownerId] ?? 0) + 1
+  }
+
   const moraleMult = (ownerId: string): number => {
     const myCount = speckCountByOwner[ownerId] ?? 0
     let maxEnemyCount = 0
@@ -29,7 +39,15 @@ export function resolveCombat(sim: SimulationState, dt: number) {
     const base = Object.values(buildings).find(b => b.ownerId === ownerId && b.typeId === 'base')
     const rageBonus = (base && base.hp / base.maxHp < RAGE_HP_THRESHOLD) ? RAGE_BONUS : 1.0
 
-    return Math.max(moraleBonus, rageBonus)  // apply highest active bonus (don't stack)
+    // Supremacy: owning 2+ more outposts than any enemy → +15% damage (territorial control)
+    const myOutposts = outpostCountByOwner[ownerId] ?? 0
+    let maxEnemyOutposts = 0
+    for (const [id, n] of Object.entries(outpostCountByOwner)) {
+      if (id !== ownerId && n > maxEnemyOutposts) maxEnemyOutposts = n
+    }
+    const supremacyBonus = (myOutposts - maxEnemyOutposts >= SUPREMACY_OUTPOST_LEAD) ? SUPREMACY_BONUS : 1.0
+
+    return Math.max(moraleBonus, rageBonus) * supremacyBonus  // supremacy stacks on top
   }
 
   // --- Speck vs Speck combat ---

--- a/src/app/speck-wars/domain/simulation/combat.ts
+++ b/src/app/speck-wars/domain/simulation/combat.ts
@@ -91,6 +91,17 @@ export function resolveCombat(sim: SimulationState, dt: number) {
         meta.state = 'attacking'
         if (speckHp[j] <= 0) {
           meta.kills++  // attacker earns a kill
+          // Notify when player loses a veteran or elite
+          if (jMeta.ownerId === 'player' && jMeta.kills >= 3) {
+            sim.events.push({
+              type: 'VETERAN_FALLEN',
+              speckId: speckIds[j],
+              ownerId: jMeta.ownerId,
+              kills: jMeta.kills,
+              x: speckX[j],
+              y: speckY[j],
+            })
+          }
           sim.events.push({ type: 'SPECK_DIED', speckId: speckIds[j], x: speckX[j], y: speckY[j], killedOwnerId: jMeta.ownerId, killerOwnerId: meta.ownerId })
           if (meta.kills === 3) {
             sim.events.push({ type: 'SPECK_VETERAN', speckId: speckIds[i], ownerId: meta.ownerId })

--- a/src/app/speck-wars/domain/simulation/combat.ts
+++ b/src/app/speck-wars/domain/simulation/combat.ts
@@ -56,7 +56,7 @@ export function resolveCombat(sim: SimulationState, dt: number) {
       const dy = speckY[j] - speckY[i]
       const dist = Math.sqrt(dx * dx + dy * dy)
       if (dist <= stype.attackRange) {
-        const veteranBonus = meta.kills >= 3 ? 1.20 : 1.0  // veterans deal +20% damage
+        const veteranBonus = meta.kills >= 6 ? 1.35 : meta.kills >= 3 ? 1.20 : 1.0  // elite +35%, veteran +20%
         // Fortification bonus: if attacker is near a friendly fortified outpost, deal extra damage
         let fortifyBonus = 1.0
         for (const b of Object.values(buildings)) {
@@ -76,6 +76,9 @@ export function resolveCombat(sim: SimulationState, dt: number) {
           sim.events.push({ type: 'SPECK_DIED', speckId: speckIds[j], x: speckX[j], y: speckY[j], killedOwnerId: jMeta.ownerId, killerOwnerId: meta.ownerId })
           if (meta.kills === 3) {
             sim.events.push({ type: 'SPECK_VETERAN', speckId: speckIds[i], ownerId: meta.ownerId })
+          }
+          if (meta.kills === 6) {
+            sim.events.push({ type: 'SPECK_ELITE', speckId: speckIds[i], ownerId: meta.ownerId })
           }
         }
         break  // one attack per cooldown

--- a/src/app/speck-wars/domain/simulation/combat.ts
+++ b/src/app/speck-wars/domain/simulation/combat.ts
@@ -74,6 +74,9 @@ export function resolveCombat(sim: SimulationState, dt: number) {
         if (speckHp[j] <= 0) {
           meta.kills++  // attacker earns a kill
           sim.events.push({ type: 'SPECK_DIED', speckId: speckIds[j], x: speckX[j], y: speckY[j], killedOwnerId: jMeta.ownerId, killerOwnerId: meta.ownerId })
+          if (meta.kills === 3) {
+            sim.events.push({ type: 'SPECK_VETERAN', speckId: speckIds[i], ownerId: meta.ownerId })
+          }
         }
         break  // one attack per cooldown
       }

--- a/src/app/speck-wars/domain/simulation/combat.ts
+++ b/src/app/speck-wars/domain/simulation/combat.ts
@@ -126,7 +126,8 @@ export function resolveCombat(sim: SimulationState, dt: number) {
     if (dist <= attackDist) {
       // Outposts are captured, not destroyed — immune to direct combat damage
       if (building.typeId === 'outpost') continue
-      building.hp -= stype.damage * moraleMult(meta.ownerId)
+      const siegeBonus = meta.typeId === 'heavy' ? 1.5 : 1.0
+      building.hp -= stype.damage * moraleMult(meta.ownerId) * siegeBonus
       meta.attackCooldown = stype.attackCooldown
       sim.events.push({ type: 'BUILDING_DAMAGED', buildingId: building.id, hp: building.hp })
 

--- a/src/app/speck-wars/domain/simulation/combat.ts
+++ b/src/app/speck-wars/domain/simulation/combat.ts
@@ -1,6 +1,7 @@
 import type { SimulationState } from '../types'
 import { SPECK_TYPES } from '../config/speck-types'
 import { BUILDING_TYPES } from '../config/building-types'
+import { FORTIFY_RADIUS, FORTIFY_TIME, FORTIFY_DAMAGE_BONUS } from '../constants'
 
 const MORALE_RATIO = 2.0   // if your count > this × enemy count → morale bonus
 const MORALE_BONUS = 1.20  // 20% damage boost when morale is active
@@ -56,7 +57,18 @@ export function resolveCombat(sim: SimulationState, dt: number) {
       const dist = Math.sqrt(dx * dx + dy * dy)
       if (dist <= stype.attackRange) {
         const veteranBonus = meta.kills >= 3 ? 1.20 : 1.0  // veterans deal +20% damage
-        speckHp[j] -= stype.damage * moraleMult(meta.ownerId) * veteranBonus
+        // Fortification bonus: if attacker is near a friendly fortified outpost, deal extra damage
+        let fortifyBonus = 1.0
+        for (const b of Object.values(buildings)) {
+          if (b.typeId !== 'outpost' || b.ownerId !== meta.ownerId) continue
+          const fdx = speckX[i] - b.x
+          const fdy = speckY[i] - b.y
+          if (fdx * fdx + fdy * fdy <= FORTIFY_RADIUS * FORTIFY_RADIUS) {
+            const level = Math.min(1, (b.fortifyDuration ?? 0) / FORTIFY_TIME)
+            if (level > 0) { fortifyBonus = 1 + FORTIFY_DAMAGE_BONUS * level; break }
+          }
+        }
+        speckHp[j] -= stype.damage * moraleMult(meta.ownerId) * veteranBonus * fortifyBonus
         meta.attackCooldown = stype.attackCooldown
         meta.state = 'attacking'
         if (speckHp[j] <= 0) {

--- a/src/app/speck-wars/domain/simulation/combat.ts
+++ b/src/app/speck-wars/domain/simulation/combat.ts
@@ -88,6 +88,8 @@ export function resolveCombat(sim: SimulationState, dt: number) {
     const attackDist = (btype?.size ?? 20) + stype.attackRange
 
     if (dist <= attackDist) {
+      // Outposts are captured, not destroyed — immune to direct combat damage
+      if (building.typeId === 'outpost') continue
       building.hp -= stype.damage * moraleMult(meta.ownerId)
       meta.attackCooldown = stype.attackCooldown
       sim.events.push({ type: 'BUILDING_DAMAGED', buildingId: building.id, hp: building.hp })

--- a/src/app/speck-wars/domain/simulation/create-sim.ts
+++ b/src/app/speck-wars/domain/simulation/create-sim.ts
@@ -115,5 +115,6 @@ export function createSim(seed: number = Date.now(), difficulty: Difficulty = 'm
     dailyModifier,
     waveCountdown: null,
     waveInProgress: false,
+    sacrificeCooldown: 0,
   }
 }

--- a/src/app/speck-wars/domain/simulation/create-sim.ts
+++ b/src/app/speck-wars/domain/simulation/create-sim.ts
@@ -1,5 +1,6 @@
 import type { SimulationState, Player, BuildingEntity } from '../types'
-import { PLAYER_BASE_X, PLAYER_BASE_Y, AI_BASE_X, AI_BASE_Y, PLAYER_COLOR, AI_COLOR, BASE_HP, MAX_SPECKS, NEUTRAL_COLOR, MAP_LAYOUTS } from '../constants'
+import { PLAYER_BASE_X, PLAYER_BASE_Y, AI_BASE_X, AI_BASE_Y, PLAYER_COLOR, AI_COLOR, BASE_HP, MAX_SPECKS, NEUTRAL_COLOR, MAP_LAYOUTS, DAILY_MODIFIER_POOL } from '../constants'
+import type { DailyModifier } from '../constants'
 import { SpatialGrid } from './spatial-grid'
 import { mulberry32 } from './prng'
 import type { Difficulty } from '../../store'
@@ -73,6 +74,22 @@ export function createSim(seed: number = Date.now(), difficulty: Difficulty = 'm
     }
   }
 
+  // Pick daily modifier — LAST RNG call so it doesn't shift existing map layout or jitter
+  const modifierIndex = Math.floor(rng() * DAILY_MODIFIER_POOL.length)
+  const dailyModifier: DailyModifier = DAILY_MODIFIER_POOL[modifierIndex]
+
+  // Apply static modifier effects
+  if (dailyModifier === 'bulwark') {
+    playerBase.hp = BASE_HP * 2
+    playerBase.maxHp = BASE_HP * 2
+    aiBase.hp = BASE_HP * 2
+    aiBase.maxHp = BASE_HP * 2
+  }
+  if (dailyModifier === 'blitz') {
+    if (playerBase.spawnIntervalOverride !== undefined) playerBase.spawnIntervalOverride *= 0.65
+    aiBase.spawnIntervalOverride = (aiBase.spawnIntervalOverride ?? 800) * 0.65
+  }
+
   return {
     tick: 0,
     rngState: seed,
@@ -95,5 +112,6 @@ export function createSim(seed: number = Date.now(), difficulty: Difficulty = 'm
     dominationTimer: 0,
     surgeDuration: 0,
     surgeCooldown: 0,
+    dailyModifier,
   }
 }

--- a/src/app/speck-wars/domain/simulation/create-sim.ts
+++ b/src/app/speck-wars/domain/simulation/create-sim.ts
@@ -113,5 +113,7 @@ export function createSim(seed: number = Date.now(), difficulty: Difficulty = 'm
     surgeDuration: 0,
     surgeCooldown: 0,
     dailyModifier,
+    waveCountdown: null,
+    waveInProgress: false,
   }
 }

--- a/src/app/speck-wars/domain/simulation/movement.ts
+++ b/src/app/speck-wars/domain/simulation/movement.ts
@@ -1,5 +1,6 @@
 import type { SimulationState } from '../types'
 import { SPECK_TYPES } from '../config/speck-types'
+import { BUILDING_TYPES } from '../config/building-types'
 import { WORLD_WIDTH, WORLD_HEIGHT, OUTPOST_AURA_RADIUS } from '../constants'
 
 const SEPARATION_RADIUS = 8   // px — keep specks this far apart
@@ -25,6 +26,38 @@ export function moveSpecks(sim: SimulationState, dt: number) {
     if (!meta) continue
     const stype = SPECK_TYPES[meta.typeId]
     if (!stype) continue
+
+    // Retreating: flee to nearest friendly building
+    if (meta.state === 'retreating') {
+      let nearestBuilding = null
+      let nearestDist2 = Infinity
+      for (const b of Object.values(buildings)) {
+        if (b.ownerId !== meta.ownerId) continue
+        const dx = b.x - speckX[i]
+        const dy = b.y - speckY[i]
+        const d2 = dx * dx + dy * dy
+        if (d2 < nearestDist2) {
+          nearestDist2 = d2
+          nearestBuilding = b
+        }
+      }
+      if (nearestBuilding) {
+        const btype = BUILDING_TYPES[nearestBuilding.typeId]
+        const bRadius = btype?.size ?? 20
+        if (nearestDist2 <= bRadius * bRadius) {
+          meta.state = 'idle'
+        } else {
+          const dist = Math.sqrt(nearestDist2)
+          const dx = nearestBuilding.x - speckX[i]
+          const dy = nearestBuilding.y - speckY[i]
+          speckVx[i] = (dx / dist) * stype.speed
+          speckVy[i] = (dy / dist) * stype.speed
+          speckX[i] = Math.max(0, Math.min(WORLD_WIDTH, speckX[i] + speckVx[i] * dtSec))
+          speckY[i] = Math.max(0, Math.min(WORLD_HEIGHT, speckY[i] + speckVy[i] * dtSec))
+        }
+      }
+      continue
+    }
 
     let ax = 0, ay = 0
 

--- a/src/app/speck-wars/domain/simulation/movement.ts
+++ b/src/app/speck-wars/domain/simulation/movement.ts
@@ -45,7 +45,9 @@ export function moveSpecks(sim: SimulationState, dt: number) {
         const btype = BUILDING_TYPES[nearestBuilding.typeId]
         const bRadius = btype?.size ?? 20
         if (nearestDist2 <= bRadius * bRadius) {
-          meta.state = 'idle'
+          // Retreating specks: stop movement, let regenRetreatingSpecks handle idle transition
+          sim.speckVx[i] = 0
+          sim.speckVy[i] = 0
         } else {
           const dist = Math.sqrt(nearestDist2)
           const dx = nearestBuilding.x - speckX[i]

--- a/src/app/speck-wars/domain/simulation/spawner.ts
+++ b/src/app/speck-wars/domain/simulation/spawner.ts
@@ -1,7 +1,7 @@
 import type { SimulationState, SpeckMeta } from '../types'
 import { SPECK_TYPES } from '../config/speck-types'
 import { BUILDING_TYPES } from '../config/building-types'
-import { MAX_SPECKS } from '../constants'
+import { MAX_SPECKS, RALLY_CRY_HP_THRESHOLD } from '../constants'
 
 // Place a new speck into a recycled or fresh slot — never allocates new arrays
 function addSpeck(sim: SimulationState, meta: SpeckMeta, x: number, y: number, buildingId: string) {
@@ -31,6 +31,10 @@ function addSpeck(sim: SimulationState, meta: SpeckMeta, x: number, y: number, b
 let speckCounter = 0
 
 export function updateSpawners(sim: SimulationState, dt: number) {
+  // Rally Cry: player base at critical HP spawns 1.5× faster (desperation comeback bonus)
+  const playerBase = Object.values(sim.buildings).find(b => b.ownerId === 'player' && b.typeId === 'base')
+  const rallyCryActive = playerBase ? playerBase.hp / playerBase.maxHp < RALLY_CRY_HP_THRESHOLD : false
+
   for (const building of Object.values(sim.buildings)) {
     if (building.ownerId === 'neutral') continue
     const btype = BUILDING_TYPES[building.typeId]
@@ -42,7 +46,8 @@ export function updateSpawners(sim: SimulationState, dt: number) {
 
     const baseInterval = building.spawnIntervalOverride ?? btype.spawnInterval
     const hasSurge = building.ownerId === 'player' && sim.surgeDuration > 0
-    const divisor = (building.tripleOutpostBonus ? 2 : 1) * (hasSurge ? 2 : 1)
+    const hasRallyCry = building.ownerId === 'player' && rallyCryActive
+    const divisor = (building.tripleOutpostBonus ? 2 : 1) * (hasSurge ? 2 : 1) * (hasRallyCry ? 1.5 : 1)
     building.spawnTimer = baseInterval / divisor
 
     for (let i = 0; i < btype.spawnCount; i++) {

--- a/src/app/speck-wars/domain/simulation/speck-ai.ts
+++ b/src/app/speck-wars/domain/simulation/speck-ai.ts
@@ -74,6 +74,23 @@ export function runSpeckAI(sim: SimulationState) {
       }
     }
 
+    // Scout specks prefer outpost targets — they're too fragile to assault the enemy base
+    // but excel at rapid outpost capturing. Override the nearest target with the nearest
+    // non-friendly outpost if one exists.
+    if (meta.typeId === 'scout') {
+      let outpostNearest: string | null = null
+      let outpostNearestDist = Infinity
+      for (const [bid, building] of Object.entries(buildings)) {
+        if (building.typeId !== 'outpost') continue
+        if (building.ownerId === meta.ownerId) continue
+        const odx = building.x - speckX[i]
+        const ody = building.y - speckY[i]
+        const odist = Math.sqrt(odx * odx + ody * ody)
+        if (odist < outpostNearestDist) { outpostNearestDist = odist; outpostNearest = bid }
+      }
+      if (outpostNearest) nearest = outpostNearest
+    }
+
     meta.targetId = nearest
     meta.state = nearest ? 'moving' : 'idle'
   }

--- a/src/app/speck-wars/domain/simulation/tick.ts
+++ b/src/app/speck-wars/domain/simulation/tick.ts
@@ -222,5 +222,23 @@ function emitHudUpdate(sim: SimulationState) {
     spawnRates[pid] = Math.round(totalRate)
   }
 
-  sim.events.push({ type: 'HUD_UPDATE', data: { players: data, attackedBuildingIds, tripleOutpostOwner, dominationProgress, captureInfo, surgeDuration: sim.surgeDuration, surgeCooldown: sim.surgeCooldown, spawnRates } })
+  // Mini-map data: downsampled specks + all buildings + rally point
+  const minimapBuildings = Object.values(sim.buildings).map(b => ({
+    id: b.id, x: b.x, y: b.y, ownerId: b.ownerId, typeId: b.typeId,
+  }))
+  const step = Math.max(1, Math.ceil(sim.speckCount / 400))
+  const minimapSpecks: { x: number; y: number; ownerId: string }[] = []
+  for (let i = 0; i < sim.speckCount; i += step) {
+    const meta = sim.speckMeta[i]
+    if (meta && sim.speckHp[i] > 0) {
+      minimapSpecks.push({ x: sim.speckX[i], y: sim.speckY[i], ownerId: meta.ownerId })
+    }
+  }
+  const minimap = {
+    specks: minimapSpecks,
+    buildings: minimapBuildings,
+    rallyPoint: sim.rallyPoints['player'] ?? null,
+  }
+
+  sim.events.push({ type: 'HUD_UPDATE', data: { players: data, attackedBuildingIds, tripleOutpostOwner, dominationProgress, captureInfo, surgeDuration: sim.surgeDuration, surgeCooldown: sim.surgeCooldown, spawnRates, minimap } })
 }

--- a/src/app/speck-wars/domain/simulation/tick.ts
+++ b/src/app/speck-wars/domain/simulation/tick.ts
@@ -256,5 +256,5 @@ function emitHudUpdate(sim: SimulationState) {
     outpostFortify[building.id] = Math.min(1, (building.fortifyDuration ?? 0) / FORTIFY_TIME)
   }
 
-  sim.events.push({ type: 'HUD_UPDATE', data: { players: data, attackedBuildingIds, tripleOutpostOwner, dominationProgress, captureInfo, surgeDuration: sim.surgeDuration, surgeCooldown: sim.surgeCooldown, spawnRates, minimap, outpostFortify } })
+  sim.events.push({ type: 'HUD_UPDATE', data: { players: data, attackedBuildingIds, tripleOutpostOwner, dominationProgress, captureInfo, surgeDuration: sim.surgeDuration, surgeCooldown: sim.surgeCooldown, spawnRates, minimap, outpostFortify, dailyModifier: sim.dailyModifier } })
 }

--- a/src/app/speck-wars/domain/simulation/tick.ts
+++ b/src/app/speck-wars/domain/simulation/tick.ts
@@ -362,5 +362,20 @@ function emitHudUpdate(sim: SimulationState) {
   // Suppress "advance" when base is already under direct threat (avoid double-warning)
   if (baseUnderThreat) enemyAdvanceDetected = false
 
-  sim.events.push({ type: 'HUD_UPDATE', data: { players: data, attackedBuildingIds, tripleOutpostOwner, dominationProgress, captureInfo, surgeDuration: sim.surgeDuration, surgeCooldown: sim.surgeCooldown, selectedSpeckCount: sim.selectedSpeckIds.size, spawnRates, minimap, outpostFortify, dailyModifier: sim.dailyModifier, waveCountdown: sim.waveCountdown, waveInProgress: sim.waveInProgress, sacrificeCooldown: sim.sacrificeCooldown, baseUnderThreat, enemyAdvanceDetected } })
+  // Selection composition breakdown
+  let selectedComposition: { types: Record<string, number>; veteranCount: number; eliteCount: number } | null = null
+  if (sim.selectedSpeckIds.size > 0) {
+    const types: Record<string, number> = {}
+    let selVet = 0, selElite = 0
+    for (let i = 0; i < sim.speckCount; i++) {
+      const m = sim.speckMeta[i]
+      if (!m || !sim.speckIds[i] || !sim.selectedSpeckIds.has(sim.speckIds[i])) continue
+      types[m.typeId] = (types[m.typeId] ?? 0) + 1
+      if (m.kills >= 6) selElite++
+      else if (m.kills >= 3) selVet++
+    }
+    selectedComposition = { types, veteranCount: selVet, eliteCount: selElite }
+  }
+
+  sim.events.push({ type: 'HUD_UPDATE', data: { players: data, attackedBuildingIds, tripleOutpostOwner, dominationProgress, captureInfo, surgeDuration: sim.surgeDuration, surgeCooldown: sim.surgeCooldown, selectedSpeckCount: sim.selectedSpeckIds.size, selectedComposition, spawnRates, minimap, outpostFortify, dailyModifier: sim.dailyModifier, waveCountdown: sim.waveCountdown, waveInProgress: sim.waveInProgress, sacrificeCooldown: sim.sacrificeCooldown, baseUnderThreat, enemyAdvanceDetected } })
 }

--- a/src/app/speck-wars/domain/simulation/tick.ts
+++ b/src/app/speck-wars/domain/simulation/tick.ts
@@ -7,7 +7,7 @@ import { resolveCombat, removeDeadSpecks } from './combat'
 import { checkVictory } from './victory'
 import { updateCapture } from './capture'
 import { BUILDING_TYPES } from '../config/building-types'
-import { HUD_UPDATE_INTERVAL, DOMINATION_TIME, RALLY_CRY_HP_THRESHOLD } from '../constants'
+import { HUD_UPDATE_INTERVAL, DOMINATION_TIME, RALLY_CRY_HP_THRESHOLD, FORTIFY_TIME } from '../constants'
 
 export function tick(sim: SimulationState, dt: number): SimulationState {
   sim.events = []  // clear outbound events from previous tick
@@ -44,6 +44,16 @@ export function tick(sim: SimulationState, dt: number): SimulationState {
 
   // 7. Update outpost capture progress
   updateCapture(sim, dt)
+
+  // 7a. Fortification: outposts held continuously accumulate a combat bonus
+  for (const building of Object.values(sim.buildings)) {
+    if (building.typeId !== 'outpost') continue
+    if (building.ownerId === 'neutral') { building.fortifyDuration = 0; continue }
+    // Pause fortification while actively under capture
+    const underCapture = (building.captureProgress ?? 0) > 0 && building.captureSide && building.captureSide !== building.ownerId
+    if (underCapture) continue
+    building.fortifyDuration = Math.min(FORTIFY_TIME, (building.fortifyDuration ?? 0) + dt)
+  }
 
   // 7b. HP regeneration for owned buildings when not under attack
   regenBuildingHp(sim, dt)
@@ -240,5 +250,11 @@ function emitHudUpdate(sim: SimulationState) {
     rallyPoint: sim.rallyPoints['player'] ?? null,
   }
 
-  sim.events.push({ type: 'HUD_UPDATE', data: { players: data, attackedBuildingIds, tripleOutpostOwner, dominationProgress, captureInfo, surgeDuration: sim.surgeDuration, surgeCooldown: sim.surgeCooldown, spawnRates, minimap } })
+  const outpostFortify: Record<string, number> = {}
+  for (const building of Object.values(sim.buildings)) {
+    if (building.typeId !== 'outpost') continue
+    outpostFortify[building.id] = Math.min(1, (building.fortifyDuration ?? 0) / FORTIFY_TIME)
+  }
+
+  sim.events.push({ type: 'HUD_UPDATE', data: { players: data, attackedBuildingIds, tripleOutpostOwner, dominationProgress, captureInfo, surgeDuration: sim.surgeDuration, surgeCooldown: sim.surgeCooldown, spawnRates, minimap, outpostFortify } })
 }

--- a/src/app/speck-wars/domain/simulation/tick.ts
+++ b/src/app/speck-wars/domain/simulation/tick.ts
@@ -39,6 +39,9 @@ export function tick(sim: SimulationState, dt: number): SimulationState {
     }
   }
 
+  // 5c. Heal retreating specks that have reached a friendly building
+  regenRetreatingSpecks(sim, dt)
+
   // 6. Remove dead specks (compact arrays)
   removeDeadSpecks(sim)
 
@@ -74,6 +77,41 @@ export function tick(sim: SimulationState, dt: number): SimulationState {
   if (sim.tick % HUD_UPDATE_INTERVAL === 0) emitHudUpdate(sim)
 
   return sim
+}
+
+function regenRetreatingSpecks(sim: SimulationState, dt: number) {
+  const dtSec = dt / 1000
+  const REGEN_RATE = 2  // HP per second while sheltering at base
+  const REENGAGE_THRESHOLD = 0.75  // re-engage when HP is at 75% of max
+
+  for (let i = 0; i < sim.speckCount; i++) {
+    const meta = sim.speckMeta[i]
+    if (!meta || meta.state !== 'retreating') continue
+    if (sim.speckHp[i] <= 0) continue
+
+    // Only heal if within range of a friendly building
+    let nearFriendly = false
+    for (const building of Object.values(sim.buildings)) {
+      if (building.ownerId !== meta.ownerId) continue
+      const bsize = BUILDING_TYPES[building.typeId]?.size ?? 40
+      const dx = sim.speckX[i] - building.x
+      const dy = sim.speckY[i] - building.y
+      if (dx * dx + dy * dy <= (bsize + 30) * (bsize + 30)) {
+        nearFriendly = true
+        break
+      }
+    }
+
+    if (!nearFriendly) continue
+
+    const maxHp = SPECK_TYPES[meta.typeId]?.hp ?? 1
+    sim.speckHp[i] = Math.min(maxHp, sim.speckHp[i] + REGEN_RATE * dtSec)
+
+    // Re-engage once healed enough
+    if (sim.speckHp[i] >= maxHp * REENGAGE_THRESHOLD) {
+      meta.state = 'idle'
+    }
+  }
 }
 
 function regenBuildingHp(sim: SimulationState, dt: number) {

--- a/src/app/speck-wars/domain/simulation/tick.ts
+++ b/src/app/speck-wars/domain/simulation/tick.ts
@@ -336,5 +336,31 @@ function emitHudUpdate(sim: SimulationState) {
     }
   }
 
-  sim.events.push({ type: 'HUD_UPDATE', data: { players: data, attackedBuildingIds, tripleOutpostOwner, dominationProgress, captureInfo, surgeDuration: sim.surgeDuration, surgeCooldown: sim.surgeCooldown, selectedSpeckCount: sim.selectedSpeckIds.size, spawnRates, minimap, outpostFortify, dailyModifier: sim.dailyModifier, waveCountdown: sim.waveCountdown, waveInProgress: sim.waveInProgress, sacrificeCooldown: sim.sacrificeCooldown, baseUnderThreat } })
+  let enemyAdvanceDetected = false
+  const aiBase = sim.buildings['building-ai-base']
+  if (playerBase && aiBase) {
+    // Midpoint between the two bases — defines "player's half"
+    const midX = (playerBase.x + aiBase.x) / 2
+    const midY = (playerBase.y + aiBase.y) / 2
+    const ADVANCE_THRESHOLD = 15  // enemy specks needed in player half
+    let enemySpecksInPlayerHalf = 0
+    for (let i = 0; i < sim.speckCount; i++) {
+      const m = sim.speckMeta[i]
+      if (!m || m.ownerId !== 'ai') continue
+      if (sim.speckHp[i] <= 0) continue
+      // Is this speck closer to player base than to midpoint?
+      const dxP = sim.speckX[i] - playerBase.x
+      const dyP = sim.speckY[i] - playerBase.y
+      const dxM = sim.speckX[i] - midX
+      const dyM = sim.speckY[i] - midY
+      if (dxP * dxP + dyP * dyP < dxM * dxM + dyM * dyM) {
+        enemySpecksInPlayerHalf++
+        if (enemySpecksInPlayerHalf >= ADVANCE_THRESHOLD) { enemyAdvanceDetected = true; break }
+      }
+    }
+  }
+  // Suppress "advance" when base is already under direct threat (avoid double-warning)
+  if (baseUnderThreat) enemyAdvanceDetected = false
+
+  sim.events.push({ type: 'HUD_UPDATE', data: { players: data, attackedBuildingIds, tripleOutpostOwner, dominationProgress, captureInfo, surgeDuration: sim.surgeDuration, surgeCooldown: sim.surgeCooldown, selectedSpeckCount: sim.selectedSpeckIds.size, spawnRates, minimap, outpostFortify, dailyModifier: sim.dailyModifier, waveCountdown: sim.waveCountdown, waveInProgress: sim.waveInProgress, sacrificeCooldown: sim.sacrificeCooldown, baseUnderThreat, enemyAdvanceDetected } })
 }

--- a/src/app/speck-wars/domain/simulation/tick.ts
+++ b/src/app/speck-wars/domain/simulation/tick.ts
@@ -7,7 +7,7 @@ import { resolveCombat, removeDeadSpecks } from './combat'
 import { checkVictory } from './victory'
 import { updateCapture } from './capture'
 import { BUILDING_TYPES } from '../config/building-types'
-import { HUD_UPDATE_INTERVAL, DOMINATION_TIME } from '../constants'
+import { HUD_UPDATE_INTERVAL, DOMINATION_TIME, RALLY_CRY_HP_THRESHOLD } from '../constants'
 
 export function tick(sim: SimulationState, dt: number): SimulationState {
   sim.events = []  // clear outbound events from previous tick
@@ -198,5 +198,29 @@ function emitHudUpdate(sim: SimulationState) {
       : null
   }
 
-  sim.events.push({ type: 'HUD_UPDATE', data: { players: data, attackedBuildingIds, tripleOutpostOwner, dominationProgress, captureInfo, surgeDuration: sim.surgeDuration, surgeCooldown: sim.surgeCooldown } })
+  // Compute effective spawn rate (specks/min) for each player
+  const playerBaseBuilding = Object.values(sim.buildings).find(b => b.ownerId === 'player' && b.typeId === 'base')
+  const rallyCryActive = playerBaseBuilding
+    ? playerBaseBuilding.hp / playerBaseBuilding.maxHp < RALLY_CRY_HP_THRESHOLD
+    : false
+
+  const spawnRates: Record<string, number> = {}
+  for (const [pid] of Object.entries(sim.players)) {
+    if (pid === 'neutral') continue
+    let totalRate = 0
+    const hasSurge = pid === 'player' && sim.surgeDuration > 0
+    const hasRallyCry = pid === 'player' && rallyCryActive
+    for (const building of Object.values(sim.buildings)) {
+      if (building.ownerId !== pid) continue
+      const btype = BUILDING_TYPES[building.typeId]
+      if (!btype?.spawnTypeId) continue
+      const baseInterval = building.spawnIntervalOverride ?? btype.spawnInterval
+      const divisor = (building.tripleOutpostBonus ? 2 : 1) * (hasSurge ? 2 : 1) * (hasRallyCry ? 1.5 : 1)
+      const effectiveInterval = baseInterval / divisor
+      totalRate += (btype.spawnCount ?? 1) * 60000 / effectiveInterval
+    }
+    spawnRates[pid] = Math.round(totalRate)
+  }
+
+  sim.events.push({ type: 'HUD_UPDATE', data: { players: data, attackedBuildingIds, tripleOutpostOwner, dominationProgress, captureInfo, surgeDuration: sim.surgeDuration, surgeCooldown: sim.surgeCooldown, spawnRates } })
 }

--- a/src/app/speck-wars/domain/simulation/tick.ts
+++ b/src/app/speck-wars/domain/simulation/tick.ts
@@ -64,6 +64,7 @@ export function tick(sim: SimulationState, dt: number): SimulationState {
   // 7d. Surge timers
   if (sim.surgeDuration > 0) sim.surgeDuration = Math.max(0, sim.surgeDuration - dt)
   if (sim.surgeCooldown > 0) sim.surgeCooldown = Math.max(0, sim.surgeCooldown - dt)
+  if (sim.sacrificeCooldown > 0) sim.sacrificeCooldown = Math.max(0, sim.sacrificeCooldown - dt)
 
   // 8. Check win/loss
   checkVictory(sim)
@@ -158,6 +159,28 @@ function consumeInputs(sim: SimulationState) {
         sim.surgeDuration = 8000
         sim.surgeCooldown = 45000
       }
+    }
+    if (event.type === 'SACRIFICE') {
+      if (sim.sacrificeCooldown > 0) continue
+      const building = sim.buildings[event.buildingId]
+      if (!building || building.ownerId !== event.ownerId || building.typeId !== 'base') continue
+      // Collect player specks, sorted by lowest HP first (weakest give their life)
+      const candidates: Array<{ i: number; hp: number }> = []
+      for (let i = 0; i < sim.speckCount; i++) {
+        if (!sim.speckIds[i]) continue
+        const m = sim.speckMeta[i]
+        if (!m || m.ownerId !== event.ownerId) continue
+        candidates.push({ i, hp: sim.speckHp[i] })
+      }
+      if (candidates.length < event.count) continue  // not enough specks
+      candidates.sort((a, b) => a.hp - b.hp)
+      const toSacrifice = candidates.slice(0, event.count)
+      for (const { i } of toSacrifice) {
+        sim.events.push({ type: 'SPECK_DIED', speckId: sim.speckIds[i], x: sim.speckX[i], y: sim.speckY[i], killedOwnerId: event.ownerId, killerOwnerId: event.ownerId })
+        sim.speckHp[i] = 0  // mark for removeDeadSpecks
+      }
+      building.hp = Math.min(building.maxHp, building.hp + event.count * 1.5)  // 10 specks → +15 HP
+      sim.sacrificeCooldown = 45000
     }
   }
   sim.inputQueue = []
@@ -256,5 +279,5 @@ function emitHudUpdate(sim: SimulationState) {
     outpostFortify[building.id] = Math.min(1, (building.fortifyDuration ?? 0) / FORTIFY_TIME)
   }
 
-  sim.events.push({ type: 'HUD_UPDATE', data: { players: data, attackedBuildingIds, tripleOutpostOwner, dominationProgress, captureInfo, surgeDuration: sim.surgeDuration, surgeCooldown: sim.surgeCooldown, selectedSpeckCount: sim.selectedSpeckIds.size, spawnRates, minimap, outpostFortify, dailyModifier: sim.dailyModifier, waveCountdown: sim.waveCountdown, waveInProgress: sim.waveInProgress } })
+  sim.events.push({ type: 'HUD_UPDATE', data: { players: data, attackedBuildingIds, tripleOutpostOwner, dominationProgress, captureInfo, surgeDuration: sim.surgeDuration, surgeCooldown: sim.surgeCooldown, selectedSpeckCount: sim.selectedSpeckIds.size, spawnRates, minimap, outpostFortify, dailyModifier: sim.dailyModifier, waveCountdown: sim.waveCountdown, waveInProgress: sim.waveInProgress, sacrificeCooldown: sim.sacrificeCooldown } })
 }

--- a/src/app/speck-wars/domain/simulation/tick.ts
+++ b/src/app/speck-wars/domain/simulation/tick.ts
@@ -27,6 +27,18 @@ export function tick(sim: SimulationState, dt: number): SimulationState {
   // 5. Deal damage, destroy buildings/specks
   resolveCombat(sim, dt)
 
+  // 5b. Mark low-HP specks as retreating
+  for (let i = 0; i < sim.speckCount; i++) {
+    const meta = sim.speckMeta[i]
+    if (!meta || sim.speckHp[i] <= 0) continue
+    if (meta.state === 'retreating') continue  // already retreating
+    const maxHp = SPECK_TYPES[meta.typeId]?.hp ?? 1
+    if (sim.speckHp[i] / maxHp < 0.25) {
+      meta.state = 'retreating'
+      meta.targetId = null
+    }
+  }
+
   // 6. Remove dead specks (compact arrays)
   removeDeadSpecks(sim)
 

--- a/src/app/speck-wars/domain/simulation/tick.ts
+++ b/src/app/speck-wars/domain/simulation/tick.ts
@@ -187,16 +187,19 @@ function consumeInputs(sim: SimulationState) {
 }
 
 function emitHudUpdate(sim: SimulationState) {
-  const data: Record<string, { speckCount: number; buildingCount: number; buildingHp: Record<string, number>; speckTypes: Record<string, number> }> = {}
+  const data: Record<string, { speckCount: number; buildingCount: number; buildingHp: Record<string, number>; speckTypes: Record<string, number>; veteranCount: number; eliteCount: number }> = {}
   for (const [pid] of Object.entries(sim.players)) {
     const myBuildings = Object.values(sim.buildings).filter(b => b.ownerId === pid)
     let liveCount = 0
+    let veteranCount = 0, eliteCount = 0
     const speckTypes: Record<string, number> = {}
     for (let i = 0; i < sim.speckCount; i++) {
       const m = sim.speckMeta[i]
       if (m && m.ownerId === pid) {
         liveCount++
         speckTypes[m.typeId] = (speckTypes[m.typeId] ?? 0) + 1
+        if (m.kills >= 6) eliteCount++
+        else if (m.kills >= 3) veteranCount++
       }
     }
     data[pid] = {
@@ -204,6 +207,8 @@ function emitHudUpdate(sim: SimulationState) {
       buildingCount: myBuildings.length,
       buildingHp: Object.fromEntries(myBuildings.map(b => [b.id, b.hp])),
       speckTypes,
+      veteranCount,
+      eliteCount,
     }
   }
   // Buildings that are owned but actively being captured by the enemy

--- a/src/app/speck-wars/domain/simulation/tick.ts
+++ b/src/app/speck-wars/domain/simulation/tick.ts
@@ -377,5 +377,5 @@ function emitHudUpdate(sim: SimulationState) {
     selectedComposition = { types, veteranCount: selVet, eliteCount: selElite }
   }
 
-  sim.events.push({ type: 'HUD_UPDATE', data: { players: data, attackedBuildingIds, tripleOutpostOwner, dominationProgress, captureInfo, surgeDuration: sim.surgeDuration, surgeCooldown: sim.surgeCooldown, selectedSpeckCount: sim.selectedSpeckIds.size, selectedComposition, spawnRates, minimap, outpostFortify, dailyModifier: sim.dailyModifier, waveCountdown: sim.waveCountdown, waveInProgress: sim.waveInProgress, sacrificeCooldown: sim.sacrificeCooldown, baseUnderThreat, enemyAdvanceDetected } })
+  sim.events.push({ type: 'HUD_UPDATE', data: { players: data, attackedBuildingIds, tripleOutpostOwner, dominationProgress, captureInfo, surgeDuration: sim.surgeDuration, surgeCooldown: sim.surgeCooldown, selectedSpeckCount: sim.selectedSpeckIds.size, selectedComposition, spawnRates, minimap, outpostFortify, dailyModifier: sim.dailyModifier, waveCountdown: sim.waveCountdown, waveInProgress: sim.waveInProgress, sacrificeCooldown: sim.sacrificeCooldown, baseUnderThreat, enemyAdvanceDetected, rallyCryActive } })
 }

--- a/src/app/speck-wars/domain/simulation/tick.ts
+++ b/src/app/speck-wars/domain/simulation/tick.ts
@@ -284,5 +284,19 @@ function emitHudUpdate(sim: SimulationState) {
     outpostFortify[building.id] = Math.min(1, (building.fortifyDuration ?? 0) / FORTIFY_TIME)
   }
 
-  sim.events.push({ type: 'HUD_UPDATE', data: { players: data, attackedBuildingIds, tripleOutpostOwner, dominationProgress, captureInfo, surgeDuration: sim.surgeDuration, surgeCooldown: sim.surgeCooldown, selectedSpeckCount: sim.selectedSpeckIds.size, spawnRates, minimap, outpostFortify, dailyModifier: sim.dailyModifier, waveCountdown: sim.waveCountdown, waveInProgress: sim.waveInProgress, sacrificeCooldown: sim.sacrificeCooldown } })
+  let baseUnderThreat = false
+  const playerBase = Object.values(sim.buildings).find(b => b.ownerId === 'player' && b.typeId === 'base')
+  if (playerBase) {
+    const threatRange = 280
+    for (let i = 0; i < sim.speckCount; i++) {
+      const m = sim.speckMeta[i]
+      if (!m || m.ownerId !== 'ai') continue
+      if (sim.speckHp[i] <= 0) continue
+      const dx = sim.speckX[i] - playerBase.x
+      const dy = sim.speckY[i] - playerBase.y
+      if (dx * dx + dy * dy <= threatRange * threatRange) { baseUnderThreat = true; break }
+    }
+  }
+
+  sim.events.push({ type: 'HUD_UPDATE', data: { players: data, attackedBuildingIds, tripleOutpostOwner, dominationProgress, captureInfo, surgeDuration: sim.surgeDuration, surgeCooldown: sim.surgeCooldown, selectedSpeckCount: sim.selectedSpeckIds.size, spawnRates, minimap, outpostFortify, dailyModifier: sim.dailyModifier, waveCountdown: sim.waveCountdown, waveInProgress: sim.waveInProgress, sacrificeCooldown: sim.sacrificeCooldown, baseUnderThreat } })
 }

--- a/src/app/speck-wars/domain/simulation/tick.ts
+++ b/src/app/speck-wars/domain/simulation/tick.ts
@@ -256,5 +256,5 @@ function emitHudUpdate(sim: SimulationState) {
     outpostFortify[building.id] = Math.min(1, (building.fortifyDuration ?? 0) / FORTIFY_TIME)
   }
 
-  sim.events.push({ type: 'HUD_UPDATE', data: { players: data, attackedBuildingIds, tripleOutpostOwner, dominationProgress, captureInfo, surgeDuration: sim.surgeDuration, surgeCooldown: sim.surgeCooldown, selectedSpeckCount: sim.selectedSpeckIds.size, spawnRates, minimap, outpostFortify, dailyModifier: sim.dailyModifier } })
+  sim.events.push({ type: 'HUD_UPDATE', data: { players: data, attackedBuildingIds, tripleOutpostOwner, dominationProgress, captureInfo, surgeDuration: sim.surgeDuration, surgeCooldown: sim.surgeCooldown, selectedSpeckCount: sim.selectedSpeckIds.size, spawnRates, minimap, outpostFortify, dailyModifier: sim.dailyModifier, waveCountdown: sim.waveCountdown, waveInProgress: sim.waveInProgress } })
 }

--- a/src/app/speck-wars/domain/simulation/tick.ts
+++ b/src/app/speck-wars/domain/simulation/tick.ts
@@ -256,5 +256,5 @@ function emitHudUpdate(sim: SimulationState) {
     outpostFortify[building.id] = Math.min(1, (building.fortifyDuration ?? 0) / FORTIFY_TIME)
   }
 
-  sim.events.push({ type: 'HUD_UPDATE', data: { players: data, attackedBuildingIds, tripleOutpostOwner, dominationProgress, captureInfo, surgeDuration: sim.surgeDuration, surgeCooldown: sim.surgeCooldown, spawnRates, minimap, outpostFortify, dailyModifier: sim.dailyModifier } })
+  sim.events.push({ type: 'HUD_UPDATE', data: { players: data, attackedBuildingIds, tripleOutpostOwner, dominationProgress, captureInfo, surgeDuration: sim.surgeDuration, surgeCooldown: sim.surgeCooldown, selectedSpeckCount: sim.selectedSpeckIds.size, spawnRates, minimap, outpostFortify, dailyModifier: sim.dailyModifier } })
 }

--- a/src/app/speck-wars/domain/types.ts
+++ b/src/app/speck-wars/domain/types.ts
@@ -109,6 +109,7 @@ export interface HudData {
   waveCountdown: number | null
   waveInProgress: boolean
   sacrificeCooldown: number
+  baseUnderThreat: boolean
   outpostFortify: Record<string, number>  // outpostId → 0..1 fortification level
   minimap: {
     specks: { x: number; y: number; ownerId: string }[]

--- a/src/app/speck-wars/domain/types.ts
+++ b/src/app/speck-wars/domain/types.ts
@@ -93,4 +93,5 @@ export interface HudData {
   captureInfo: Record<string, { progress: number; side: string } | null>  // outpostId → active capture
   surgeDuration: number    // ms remaining in active surge
   surgeCooldown: number    // ms remaining before surge can be used again
+  spawnRates: Record<string, number>   // playerId → effective specks/min
 }

--- a/src/app/speck-wars/domain/types.ts
+++ b/src/app/speck-wars/domain/types.ts
@@ -23,6 +23,7 @@ export interface BuildingEntity {
   inputBuffer: Record<string, number>  // typeId → count (sacrifice system, future)
   captureProgress?: number      // 0..1 progress toward capture for captureSide
   captureSide?: string | null   // which player is currently winning capture
+  fortifyDuration?: number      // ms continuously held — resets on capture
 }
 
 export interface Player {
@@ -94,6 +95,7 @@ export interface HudData {
   surgeDuration: number    // ms remaining in active surge
   surgeCooldown: number    // ms remaining before surge can be used again
   spawnRates: Record<string, number>   // playerId → effective specks/min
+  outpostFortify: Record<string, number>  // outpostId → 0..1 fortification level
   minimap: {
     specks: { x: number; y: number; ownerId: string }[]
     buildings: { id: string; x: number; y: number; ownerId: string; typeId: string }[]

--- a/src/app/speck-wars/domain/types.ts
+++ b/src/app/speck-wars/domain/types.ts
@@ -96,6 +96,7 @@ export interface HudData {
   captureInfo: Record<string, { progress: number; side: string } | null>  // outpostId → active capture
   surgeDuration: number    // ms remaining in active surge
   surgeCooldown: number    // ms remaining before surge can be used again
+  selectedSpeckCount: number   // 0 when no selection active
   spawnRates: Record<string, number>   // playerId → effective specks/min
   dailyModifier: 'standard' | 'bulwark' | 'blitz' | 'siege'
   outpostFortify: Record<string, number>  // outpostId → 0..1 fortification level

--- a/src/app/speck-wars/domain/types.ts
+++ b/src/app/speck-wars/domain/types.ts
@@ -61,6 +61,7 @@ export interface SimulationState {
   dominationTimer: number    // ms of continuous triple-outpost control; resets on loss
   surgeDuration: number      // ms remaining in active surge, 0 = inactive
   surgeCooldown: number      // ms remaining before surge can be used again, 0 = ready
+  dailyModifier: 'standard' | 'bulwark' | 'blitz' | 'siege'
 }
 
 export type InputEvent =
@@ -96,6 +97,7 @@ export interface HudData {
   surgeDuration: number    // ms remaining in active surge
   surgeCooldown: number    // ms remaining before surge can be used again
   spawnRates: Record<string, number>   // playerId → effective specks/min
+  dailyModifier: 'standard' | 'bulwark' | 'blitz' | 'siege'
   outpostFortify: Record<string, number>  // outpostId → 0..1 fortification level
   minimap: {
     specks: { x: number; y: number; ownerId: string }[]

--- a/src/app/speck-wars/domain/types.ts
+++ b/src/app/speck-wars/domain/types.ts
@@ -94,6 +94,8 @@ export interface HudData {
     buildingCount: number
     buildingHp: Record<string, number>
     speckTypes: Record<string, number>  // typeId → count
+    veteranCount: number  // specks with 3+ kills
+    eliteCount: number    // specks with 6+ kills
   }>
   attackedBuildingIds: string[]
   tripleOutpostOwner: string | null  // player ID who owns all 3 outposts, or null

--- a/src/app/speck-wars/domain/types.ts
+++ b/src/app/speck-wars/domain/types.ts
@@ -88,6 +88,7 @@ export type SimEvent =
   | { type: 'SPECK_ELITE'; speckId: string; ownerId: string }
   | { type: 'AI_WAVE_START'; waveNumber: number }
   | { type: 'VETERAN_FALLEN'; speckId: string; ownerId: string; kills: number; x: number; y: number }
+  | { type: 'AI_LAST_STAND' }
 
 export interface HudData {
   players: Record<string, {

--- a/src/app/speck-wars/domain/types.ts
+++ b/src/app/speck-wars/domain/types.ts
@@ -94,4 +94,9 @@ export interface HudData {
   surgeDuration: number    // ms remaining in active surge
   surgeCooldown: number    // ms remaining before surge can be used again
   spawnRates: Record<string, number>   // playerId → effective specks/min
+  minimap: {
+    specks: { x: number; y: number; ownerId: string }[]
+    buildings: { id: string; x: number; y: number; ownerId: string; typeId: string }[]
+    rallyPoint: { x: number; y: number } | null
+  }
 }

--- a/src/app/speck-wars/domain/types.ts
+++ b/src/app/speck-wars/domain/types.ts
@@ -80,6 +80,7 @@ export type SimEvent =
   | { type: 'GAME_OVER'; winnerId: string; victoryType: 'destruction' | 'domination' }
   | { type: 'HUD_UPDATE'; data: HudData }
   | { type: 'OUTPOST_CAPTURED'; outpostId: string; newOwner: string; previousOwner: string }
+  | { type: 'SPECK_VETERAN'; speckId: string; ownerId: string }
 
 export interface HudData {
   players: Record<string, {

--- a/src/app/speck-wars/domain/types.ts
+++ b/src/app/speck-wars/domain/types.ts
@@ -114,6 +114,7 @@ export interface HudData {
   sacrificeCooldown: number
   baseUnderThreat: boolean
   enemyAdvanceDetected: boolean
+  rallyCryActive: boolean
   outpostFortify: Record<string, number>  // outpostId → 0..1 fortification level
   minimap: {
     specks: { x: number; y: number; ownerId: string }[]

--- a/src/app/speck-wars/domain/types.ts
+++ b/src/app/speck-wars/domain/types.ts
@@ -62,6 +62,8 @@ export interface SimulationState {
   surgeDuration: number      // ms remaining in active surge, 0 = inactive
   surgeCooldown: number      // ms remaining before surge can be used again, 0 = ready
   dailyModifier: 'standard' | 'bulwark' | 'blitz' | 'siege'
+  waveCountdown: number | null   // ms until next AI wave (null = waves disabled on this difficulty)
+  waveInProgress: boolean        // true during the 15s wave assault
 }
 
 export type InputEvent =
@@ -100,6 +102,8 @@ export interface HudData {
   selectedSpeckCount: number   // 0 when no selection active
   spawnRates: Record<string, number>   // playerId → effective specks/min
   dailyModifier: 'standard' | 'bulwark' | 'blitz' | 'siege'
+  waveCountdown: number | null
+  waveInProgress: boolean
   outpostFortify: Record<string, number>  // outpostId → 0..1 fortification level
   minimap: {
     specks: { x: number; y: number; ownerId: string }[]

--- a/src/app/speck-wars/domain/types.ts
+++ b/src/app/speck-wars/domain/types.ts
@@ -82,6 +82,7 @@ export type SimEvent =
   | { type: 'HUD_UPDATE'; data: HudData }
   | { type: 'OUTPOST_CAPTURED'; outpostId: string; newOwner: string; previousOwner: string }
   | { type: 'SPECK_VETERAN'; speckId: string; ownerId: string }
+  | { type: 'AI_WAVE_START'; waveNumber: number }
 
 export interface HudData {
   players: Record<string, {

--- a/src/app/speck-wars/domain/types.ts
+++ b/src/app/speck-wars/domain/types.ts
@@ -110,6 +110,7 @@ export interface HudData {
   waveInProgress: boolean
   sacrificeCooldown: number
   baseUnderThreat: boolean
+  enemyAdvanceDetected: boolean
   outpostFortify: Record<string, number>  // outpostId → 0..1 fortification level
   minimap: {
     specks: { x: number; y: number; ownerId: string }[]

--- a/src/app/speck-wars/domain/types.ts
+++ b/src/app/speck-wars/domain/types.ts
@@ -84,6 +84,7 @@ export type SimEvent =
   | { type: 'HUD_UPDATE'; data: HudData }
   | { type: 'OUTPOST_CAPTURED'; outpostId: string; newOwner: string; previousOwner: string }
   | { type: 'SPECK_VETERAN'; speckId: string; ownerId: string }
+  | { type: 'SPECK_ELITE'; speckId: string; ownerId: string }
   | { type: 'AI_WAVE_START'; waveNumber: number }
 
 export interface HudData {

--- a/src/app/speck-wars/domain/types.ts
+++ b/src/app/speck-wars/domain/types.ts
@@ -4,7 +4,7 @@ export interface SpeckMeta {
   id: string
   typeId: string
   ownerId: string
-  state: 'idle' | 'moving' | 'attacking' | 'carrying' | 'sacrificing'
+  state: 'idle' | 'moving' | 'attacking' | 'carrying' | 'sacrificing' | 'retreating'
   targetId: string | null
   attackCooldown: number   // ms remaining until next attack
   kills: number            // enemies killed; 3+ = veteran (gold ring, +20% damage)

--- a/src/app/speck-wars/domain/types.ts
+++ b/src/app/speck-wars/domain/types.ts
@@ -106,6 +106,7 @@ export interface HudData {
   surgeDuration: number    // ms remaining in active surge
   surgeCooldown: number    // ms remaining before surge can be used again
   selectedSpeckCount: number   // 0 when no selection active
+  selectedComposition: { types: Record<string, number>; veteranCount: number; eliteCount: number } | null
   spawnRates: Record<string, number>   // playerId → effective specks/min
   dailyModifier: 'standard' | 'bulwark' | 'blitz' | 'siege'
   waveCountdown: number | null

--- a/src/app/speck-wars/domain/types.ts
+++ b/src/app/speck-wars/domain/types.ts
@@ -87,6 +87,7 @@ export type SimEvent =
   | { type: 'SPECK_VETERAN'; speckId: string; ownerId: string }
   | { type: 'SPECK_ELITE'; speckId: string; ownerId: string }
   | { type: 'AI_WAVE_START'; waveNumber: number }
+  | { type: 'VETERAN_FALLEN'; speckId: string; ownerId: string; kills: number; x: number; y: number }
 
 export interface HudData {
   players: Record<string, {

--- a/src/app/speck-wars/domain/types.ts
+++ b/src/app/speck-wars/domain/types.ts
@@ -64,6 +64,7 @@ export interface SimulationState {
   dailyModifier: 'standard' | 'bulwark' | 'blitz' | 'siege'
   waveCountdown: number | null   // ms until next AI wave (null = waves disabled on this difficulty)
   waveInProgress: boolean        // true during the 15s wave assault
+  sacrificeCooldown: number   // ms remaining before sacrifice can be used again, 0 = ready
 }
 
 export type InputEvent =
@@ -105,6 +106,7 @@ export interface HudData {
   dailyModifier: 'standard' | 'bulwark' | 'blitz' | 'siege'
   waveCountdown: number | null
   waveInProgress: boolean
+  sacrificeCooldown: number
   outpostFortify: Record<string, number>  // outpostId → 0..1 fortification level
   minimap: {
     specks: { x: number; y: number; ownerId: string }[]

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -514,7 +514,8 @@ export class GameInstance {
       shakeX = (Math.random() * 2 - 1) * s
       shakeY = (Math.random() * 2 - 1) * s
     }
-    this.renderer.render(this.sim, this.camera, dt, shakeX, shakeY)
+    const dragRect = this.inputHandler.getDragRect()
+    this.renderer.render(this.sim, this.camera, dt, shakeX, shakeY, dragRect)
     this.rafId = requestAnimationFrame(this.loop)
   }
 

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -45,6 +45,7 @@ export class GameInstance {
   private firstVeteranNotifiedAt = -30000   // allow veteran notification immediately
   private retreatWarnedAt = -20000          // allow retreat warning after 20s
   private prevBaseUnderThreat = false
+  private prevEnemyAdvance = false
 
   constructor(canvas: HTMLCanvasElement) {
     this.canvas = canvas
@@ -229,6 +230,11 @@ export class GameInstance {
             this.notify('⚠ BASE UNDER ATTACK', '#ff3333')
           }
           this.prevBaseUnderThreat = bua
+          const adv = event.data.enemyAdvanceDetected ?? false
+          if (adv && !this.prevEnemyAdvance && !event.data.baseUnderThreat) {
+            this.notify('⚠ ENEMY ADVANCING', '#ff8844')
+          }
+          this.prevEnemyAdvance = adv
           this.cachedPlayerSpeckCount = event.data.players.player?.speckCount ?? 0
           const playerSpeckCount = event.data.players.player?.speckCount ?? 0
           store.setPeakArmySize(playerSpeckCount)

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -31,6 +31,8 @@ export class GameInstance {
   private recentKillTimes: number[] = []  // timestamps of recent player kills (combo detection)
   private recentDeathPositions: { x: number; y: number; ts: number }[] = []
   private lastComboNotifiedAt = -5000
+  private recentKillTs: number[] = []        // timestamps of player kills in rolling window (kill streak)
+  private lastStreakNotifiedAt = 0            // prevent kill streak notification spam
   private idleArmyTimer = 0              // ms with no rally point + specks available
   private lastIdleNudge = -30000         // allow nudge immediately if idle at game start
   private cachedPlayerSpeckCount = 0    // updated from HUD_UPDATE
@@ -336,6 +338,26 @@ export class GameInstance {
           this.recentDeathPositions.push({ x: event.x, y: event.y, ts: Date.now() })
           // Keep only last 30 deaths
           if (this.recentDeathPositions.length > 30) this.recentDeathPositions.shift()
+          // Kill streak tracking for player killer
+          if (event.killerOwnerId === 'player') {
+            const now = Date.now()
+            this.recentKillTs.push(now)
+            // Keep only kills in last 8 seconds
+            this.recentKillTs = this.recentKillTs.filter(t => now - t < 8000)
+            const killCount = this.recentKillTs.length
+            if (now - this.lastStreakNotifiedAt > 4000) {
+              if (killCount >= 20) {
+                this.lastStreakNotifiedAt = now
+                this.notify('⚡ UNSTOPPABLE! ×' + killCount, '#ffffff')
+              } else if (killCount >= 10) {
+                this.lastStreakNotifiedAt = now
+                this.notify('⚡ RAMPAGE! ×' + killCount, '#ffd700')
+              } else if (killCount >= 5) {
+                this.lastStreakNotifiedAt = now
+                this.notify('⚡ KILLING SPREE ×' + killCount, '#ff8844')
+              }
+            }
+          }
         }
         if (event.type === 'BUILDING_DAMAGED' && event.buildingId === 'building-ai-base') {
           const aiBase = this.sim.buildings['building-ai-base']

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -114,6 +114,7 @@ export class GameInstance {
       },
       () => { this.surge(); this.notify('⚡ SURGE ACTIVE!', '#ffd700') },  // Q — production surge
       () => { this.snapToAction() },                                        // V — snap camera to battle
+      () => { this.snapToBase() },                                          // H — snap camera to home base
       (typeId: 'basic' | 'heavy' | 'scout') => {               // 1/2/3 — set spawn type directly
         useSpeckWarsStore.getState().setSpawnMode(typeId)
         this.sim.inputQueue.push({ type: 'SET_SPAWN_TYPE', ownerId: 'player', speckTypeId: typeId })
@@ -589,6 +590,17 @@ export class GameInstance {
     const h = this.canvas.clientHeight
     this.camera.x = w / 2 - cx * this.camera.zoom
     this.camera.y = h / 2 - cy * this.camera.zoom
+  }
+
+  private snapToBase() {
+    const playerBase = Object.values(this.sim.buildings).find(b => b.ownerId === 'player' && b.typeId === 'base')
+    if (!playerBase) return
+    const zoom = this.camera.zoom
+    const w = this.canvas.clientWidth
+    const h = this.canvas.clientHeight
+    this.camera.x = w / 2 - playerBase.x * zoom
+    this.camera.y = h / 2 - playerBase.y * zoom
+    this.notify('⌂ Home', '#4af7c4')
   }
 
   private notify(message: string, color: string) {

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -460,6 +460,9 @@ export class GameInstance {
           store.setNotification({ message: `⚠ WAVE ${event.waveNumber} ASSAULT!`, color })
           setTimeout(() => useSpeckWarsStore.getState().setNotification(null), 3000)
         }
+        if (event.type === 'AI_LAST_STAND') {
+          this.notify('⚠ ENEMY LAST STAND', '#ff4444')
+        }
       }
 
       // Retreat wave warning: 10+ player specks retreating = notify

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -496,6 +496,20 @@ export class GameInstance {
       }
     }
 
+    // Arrow key camera panning (works in both playing and paused states)
+    if (this.inputHandler) {
+      const panSpeed = 450  // px/s in world space
+      const dtSec = dt / 1000
+      if (this.inputHandler.isKeyHeld('ArrowUp'))
+        this.camera.y += panSpeed * dtSec
+      if (this.inputHandler.isKeyHeld('ArrowDown'))
+        this.camera.y -= panSpeed * dtSec
+      if (this.inputHandler.isKeyHeld('ArrowLeft'))
+        this.camera.x += panSpeed * dtSec
+      if (this.inputHandler.isKeyHeld('ArrowRight'))
+        this.camera.x -= panSpeed * dtSec
+    }
+
     // Edge pan (works in both playing and paused states)
     if (this.inputHandler) {
       const isPaused = store.phase === 'paused'

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -39,6 +39,8 @@ export class GameInstance {
   private dominationWarned5 = false     // notified at 5s remaining
   private lastTripleHolder: string | null = null  // track triple-outpost ownership changes
   private rallyCryFired = false               // one-time Rally Cry notification per game
+  private firstVeteranNotifiedAt = -30000   // allow veteran notification immediately
+  private retreatWarnedAt = -20000          // allow retreat warning after 20s
 
   constructor(canvas: HTMLCanvasElement) {
     this.canvas = canvas
@@ -362,6 +364,29 @@ export class GameInstance {
             store.setNotification({ message, color })
             setTimeout(() => useSpeckWarsStore.getState().setNotification(null), 2500)
           }
+        }
+        if (event.type === 'SPECK_VETERAN' && event.ownerId === 'player') {
+          const now = Date.now()
+          if (now - this.firstVeteranNotifiedAt > 20000) {
+            this.firstVeteranNotifiedAt = now
+            store.setNotification({ message: '⭐ VETERAN SPECK! +20% DAMAGE', color: '#ffd700' })
+            setTimeout(() => useSpeckWarsStore.getState().setNotification(null), 2000)
+          }
+        }
+      }
+
+      // Retreat wave warning: 10+ player specks retreating = notify
+      const nowTs = Date.now()
+      if (nowTs - this.retreatWarnedAt > 15000) {
+        let retreatingCount = 0
+        for (let i = 0; i < this.sim.speckCount; i++) {
+          const m = this.sim.speckMeta[i]
+          if (m && m.ownerId === 'player' && m.state === 'retreating') retreatingCount++
+        }
+        if (retreatingCount >= 10) {
+          this.retreatWarnedAt = nowTs
+          store.setNotification({ message: `⚡ ${retreatingCount} SPECKS RETREATING!`, color: '#ff8844' })
+          setTimeout(() => useSpeckWarsStore.getState().setNotification(null), 2000)
         }
       }
     }

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -151,9 +151,12 @@ export class GameInstance {
     if (isFirstGame()) {
       markFirstGameDone()
       const hints = [
-        { delay: 1200, message: '💡 Click the map to rally your specks!', color: '#aaddff' },
-        { delay: 6000, message: '💡 Capture outposts to boost production!', color: '#aaddff' },
-        { delay: 13000, message: '💡 Hold all 3 outposts for 60s to dominate!', color: '#ffd700' },
+        { delay: 1200,  message: '💡 Click the map to rally your specks!', color: '#aaddff' },
+        { delay: 6000,  message: '💡 Capture outposts to boost production!', color: '#aaddff' },
+        { delay: 13000, message: '💡 Press Q for Surge — doubles production for 8s!', color: '#ffd700' },
+        { delay: 22000, message: '💡 Press 1/2/3 to switch spawn type (basic/heavy/scout)', color: '#aaddff' },
+        { delay: 32000, message: '💡 Hold all 3 outposts for 60s to win by domination!', color: '#ffd700' },
+        { delay: 45000, message: '💡 Press F to sacrifice 10 specks and repair your base!', color: '#64c864' },
       ]
       for (const { delay, message, color } of hints) {
         setTimeout(() => {

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -68,7 +68,8 @@ export class GameInstance {
       // very-hard: no balanced — pure pressure or macro domination
       return Math.random() < 0.55 ? 'aggressive' : 'macro'
     }
-    this.aiController = new AIController('ai', aiTickInterval[difficulty] ?? 15, aiPersonality())
+    const adaptiveEnabled = difficulty === 'easy' || difficulty === 'medium'
+    this.aiController = new AIController('ai', aiTickInterval[difficulty] ?? 15, aiPersonality(), adaptiveEnabled)
   }
 
   private onVisibilityChange = () => {

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -118,6 +118,7 @@ export class GameInstance {
       rush: () => { this.rush(); this.notify('⚡ RUSH!', '#ff4f7b') },
       clearRally: () => this.clearRally(),
       surge: () => { this.surge(); this.notify('⚡ SURGE ACTIVE!', '#ffd700') },
+      rally: (x: number, y: number) => this.rally(x, y),
     })
     this.lastTime = performance.now()
     this.loop(this.lastTime)

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -111,6 +111,12 @@ export class GameInstance {
       },
       () => { this.surge(); this.notify('⚡ SURGE ACTIVE!', '#ffd700') },  // Q — production surge
       () => { this.snapToAction() },                                        // V — snap camera to battle
+      (typeId: 'basic' | 'heavy' | 'scout') => {               // 1/2/3 — set spawn type directly
+        useSpeckWarsStore.getState().setSpawnMode(typeId)
+        this.sim.inputQueue.push({ type: 'SET_SPAWN_TYPE', ownerId: 'player', speckTypeId: typeId })
+        const color = typeId === 'heavy' ? '#ff8844' : typeId === 'scout' ? '#50c8ff' : '#4af7c4'
+        this.notify(`Spawn: ${typeId.toUpperCase()}`, color)
+      },
     )
     useSpeckWarsStore.getState().setGameActions({
       defend: () => { this.defend(); this.notify('🛡 DEFEND', '#4af7c4') },

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -137,6 +137,12 @@ export class GameInstance {
       surge: () => { this.surge(); this.notify('⚡ SURGE ACTIVE!', '#ffd700') },
       rally: (x: number, y: number) => this.rally(x, y),
       sacrifice: () => { this.sacrifice() },
+      setSpawnType: (typeId: 'basic' | 'heavy' | 'scout') => {
+        useSpeckWarsStore.getState().setSpawnMode(typeId)
+        this.sim.inputQueue.push({ type: 'SET_SPAWN_TYPE', ownerId: 'player', speckTypeId: typeId })
+        const color = typeId === 'heavy' ? '#ff8844' : typeId === 'scout' ? '#50c8ff' : '#4af7c4'
+        this.notify(`Spawn: ${typeId.toUpperCase()}`, color)
+      },
     })
     this.lastTime = performance.now()
     this.loop(this.lastTime)

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -29,6 +29,7 @@ export class GameInstance {
   private outpostHpWarnedAt: Record<string, number> = {}     // outpostId → timestamp (HP critical)
   private enemySurgeWarnedAt = -30000
   private recentKillTimes: number[] = []  // timestamps of recent player kills (combo detection)
+  private recentDeathPositions: { x: number; y: number; ts: number }[] = []
   private lastComboNotifiedAt = -5000
   private idleArmyTimer = 0              // ms with no rally point + specks available
   private lastIdleNudge = -30000         // allow nudge immediately if idle at game start
@@ -109,6 +110,7 @@ export class GameInstance {
         this.sim.rallyPoints['player-selected'] = null
       },
       () => { this.surge(); this.notify('⚡ SURGE ACTIVE!', '#ffd700') },  // Q — production surge
+      () => { this.snapToAction() },                                        // V — snap camera to battle
     )
     useSpeckWarsStore.getState().setGameActions({
       defend: () => { this.defend(); this.notify('🛡 DEFEND', '#4af7c4') },
@@ -314,6 +316,9 @@ export class GameInstance {
             })
             setTimeout(() => useSpeckWarsStore.getState().setNotification(null), 1800)
           }
+          this.recentDeathPositions.push({ x: event.x, y: event.y, ts: Date.now() })
+          // Keep only last 30 deaths
+          if (this.recentDeathPositions.length > 30) this.recentDeathPositions.shift()
         }
         if (event.type === 'BUILDING_DAMAGED' && event.buildingId === 'building-ai-base') {
           const aiBase = this.sim.buildings['building-ai-base']
@@ -492,6 +497,21 @@ export class GameInstance {
 
   surge() {
     this.sim.inputQueue.push({ type: 'SURGE', ownerId: 'player' })
+  }
+
+  snapToAction() {
+    const now = Date.now()
+    // Use deaths from the last 5 seconds; fall back to all recent deaths
+    let positions = this.recentDeathPositions.filter(p => now - p.ts < 5000)
+    if (positions.length < 3) positions = this.recentDeathPositions
+    if (positions.length === 0) return
+    const cx = positions.reduce((s, p) => s + p.x, 0) / positions.length
+    const cy = positions.reduce((s, p) => s + p.y, 0) / positions.length
+    // Convert world centroid to camera position
+    const w = this.canvas.clientWidth
+    const h = this.canvas.clientHeight
+    this.camera.x = w / 2 - cx * this.camera.zoom
+    this.camera.y = h / 2 - cy * this.camera.zoom
   }
 
   private notify(message: string, color: string) {

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -43,6 +43,7 @@ export class GameInstance {
   private lastTripleHolder: string | null = null  // track triple-outpost ownership changes
   private rallyCryFired = false               // one-time Rally Cry notification per game
   private firstVeteranNotifiedAt = -30000   // allow veteran notification immediately
+  private recentPlayerCaptureTimes: number[] = []  // timestamps of recent player captures
   private retreatWarnedAt = -20000          // allow retreat warning after 20s
   private prevBaseUnderThreat = false
   private prevEnemyAdvance = false
@@ -434,6 +435,20 @@ export class GameInstance {
             const color = isPlayerLoss ? '#ff4f7b' : isRecapture ? '#ffd700' : '#4af7c4'
             store.setNotification({ message, color })
             setTimeout(() => useSpeckWarsStore.getState().setNotification(null), 2500)
+          }
+          // Track capture combos
+          if (event.newOwner === 'player') {
+            const now = Date.now()
+            const COMBO_WINDOW = 30_000  // 30 seconds
+            // Remove captures older than window
+            this.recentPlayerCaptureTimes = this.recentPlayerCaptureTimes.filter(t => now - t < COMBO_WINDOW)
+            this.recentPlayerCaptureTimes.push(now)
+            const count = this.recentPlayerCaptureTimes.length
+            if (count === 3) {
+              this.notify('★ TRIPLE CAPTURE! ★', '#ffffff')
+            } else if (count === 2) {
+              this.notify('DOUBLE CAPTURE!', '#ffd700')
+            }
           }
         }
         if (event.type === 'SPECK_VETERAN' && event.ownerId === 'player') {

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -117,6 +117,14 @@ export class GameInstance {
         const color = typeId === 'heavy' ? '#ff8844' : typeId === 'scout' ? '#50c8ff' : '#4af7c4'
         this.notify(`Spawn: ${typeId.toUpperCase()}`, color)
       },
+      () => {                                                           // X — cycle game speed
+        useSpeckWarsStore.getState().cycleSpeed()
+        const spd = useSpeckWarsStore.getState().speed
+        this.notify(`Speed: ${spd}×`, spd > 1 ? '#4af7c4' : '#ffffff')
+      },
+      () => {                                                           // E — select all specks
+        this.sim.inputQueue.push({ type: 'BOX_SELECT', ownerId: 'player', x1: -1, y1: -1, x2: 3001, y2: 3001 })
+      },
     )
     useSpeckWarsStore.getState().setGameActions({
       defend: () => { this.defend(); this.notify('🛡 DEFEND', '#4af7c4') },

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -384,6 +384,12 @@ export class GameInstance {
             setTimeout(() => useSpeckWarsStore.getState().setNotification(null), 2000)
           }
         }
+        if (event.type === 'AI_WAVE_START') {
+          const waveColors = ['#ff4f7b', '#ff6b35', '#cc00ff']
+          const color = waveColors[(event.waveNumber - 1) % waveColors.length]
+          store.setNotification({ message: `⚠ WAVE ${event.waveNumber} ASSAULT!`, color })
+          setTimeout(() => useSpeckWarsStore.getState().setNotification(null), 3000)
+        }
       }
 
       // Retreat wave warning: 10+ player specks retreating = notify

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -193,6 +193,8 @@ export class GameInstance {
         if (event.type === 'HUD_UPDATE') {
           store.setHud(event.data)
           this.cachedPlayerSpeckCount = event.data.players.player?.speckCount ?? 0
+          const playerSpeckCount = event.data.players.player?.speckCount ?? 0
+          store.setPeakArmySize(playerSpeckCount)
           // Warn when an enemy starts capturing a player-owned outpost
           const now = Date.now()
           const playerBuildingHp = event.data.players.player?.buildingHp ?? {}
@@ -352,6 +354,9 @@ export class GameInstance {
           }
         }
         if (event.type === 'OUTPOST_CAPTURED') {
+          if (event.newOwner === 'player') {
+            store.addOutpostCaptured()
+          }
           const isPlayerGain = event.newOwner === 'player'
           const isPlayerLoss = event.previousOwner === 'player'
           const isRecapture = isPlayerGain && event.previousOwner === 'ai'

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -398,6 +398,10 @@ export class GameInstance {
             setTimeout(() => useSpeckWarsStore.getState().setNotification(null), 2000)
           }
         }
+        if (event.type === 'SPECK_ELITE' && event.ownerId === 'player') {
+          store.setNotification({ message: '✦ ELITE SPECK! +35% DAMAGE', color: '#ffffff' })
+          setTimeout(() => useSpeckWarsStore.getState().setNotification(null), 2500)
+        }
         if (event.type === 'AI_WAVE_START') {
           const waveColors = ['#ff4f7b', '#ff6b35', '#cc00ff']
           const color = waveColors[(event.waveNumber - 1) % waveColors.length]

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -44,6 +44,7 @@ export class GameInstance {
   private rallyCryFired = false               // one-time Rally Cry notification per game
   private firstVeteranNotifiedAt = -30000   // allow veteran notification immediately
   private retreatWarnedAt = -20000          // allow retreat warning after 20s
+  private prevBaseUnderThreat = false
 
   constructor(canvas: HTMLCanvasElement) {
     this.canvas = canvas
@@ -222,6 +223,11 @@ export class GameInstance {
         }
         if (event.type === 'HUD_UPDATE') {
           store.setHud(event.data)
+          const bua = event.data.baseUnderThreat ?? false
+          if (bua && !this.prevBaseUnderThreat) {
+            this.notify('⚠ BASE UNDER ATTACK', '#ff3333')
+          }
+          this.prevBaseUnderThreat = bua
           this.cachedPlayerSpeckCount = event.data.players.player?.speckCount ?? 0
           const playerSpeckCount = event.data.players.player?.speckCount ?? 0
           store.setPeakArmySize(playerSpeckCount)

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -448,6 +448,12 @@ export class GameInstance {
           store.setNotification({ message: '✦ ELITE SPECK! +35% DAMAGE', color: '#ffffff' })
           setTimeout(() => useSpeckWarsStore.getState().setNotification(null), 2500)
         }
+        if (event.type === 'VETERAN_FALLEN') {
+          const isElite = event.kills >= 6
+          const label = isElite ? '✦ ELITE FALLEN' : '⭐ VETERAN FALLEN'
+          const color = isElite ? '#ff8844' : '#ffcc00'
+          this.notify(label, color)
+        }
         if (event.type === 'AI_WAVE_START') {
           const waveColors = ['#ff4f7b', '#ff6b35', '#cc00ff']
           const color = waveColors[(event.waveNumber - 1) % waveColors.length]

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -125,6 +125,7 @@ export class GameInstance {
       () => {                                                           // E — select all specks
         this.sim.inputQueue.push({ type: 'BOX_SELECT', ownerId: 'player', x1: -1, y1: -1, x2: 3001, y2: 3001 })
       },
+      () => { this.sacrifice() },                                       // F — sacrifice specks to repair base
     )
     useSpeckWarsStore.getState().setGameActions({
       defend: () => { this.defend(); this.notify('🛡 DEFEND', '#4af7c4') },
@@ -133,6 +134,7 @@ export class GameInstance {
       clearRally: () => this.clearRally(),
       surge: () => { this.surge(); this.notify('⚡ SURGE ACTIVE!', '#ffd700') },
       rally: (x: number, y: number) => this.rally(x, y),
+      sacrifice: () => { this.sacrifice() },
     })
     this.lastTime = performance.now()
     this.loop(this.lastTime)
@@ -522,6 +524,18 @@ export class GameInstance {
 
   surge() {
     this.sim.inputQueue.push({ type: 'SURGE', ownerId: 'player' })
+  }
+
+  private sacrifice() {
+    const playerBase = Object.values(this.sim.buildings).find(b => b.ownerId === 'player' && b.typeId === 'base')
+    if (!playerBase) return
+    const speckCount = this.sim.speckMeta.filter((m, i) => m && m.ownerId === 'player' && this.sim.speckIds[i]).length
+    if (speckCount < 10) {
+      useSpeckWarsStore.getState().setNotification({ message: 'Not enough specks to sacrifice!', color: '#ff4f7b' })
+      setTimeout(() => useSpeckWarsStore.getState().setNotification(null), 1500)
+      return
+    }
+    this.sim.inputQueue.push({ type: 'SACRIFICE', ownerId: 'player', buildingId: playerBase.id, typeId: 'basic', count: 10 })
   }
 
   snapToAction() {

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -38,6 +38,7 @@ export class GameInstance {
   private dominationWarned10 = false    // notified at 10s remaining
   private dominationWarned5 = false     // notified at 5s remaining
   private lastTripleHolder: string | null = null  // track triple-outpost ownership changes
+  private rallyCryFired = false               // one-time Rally Cry notification per game
 
   constructor(canvas: HTMLCanvasElement) {
     this.canvas = canvas
@@ -335,6 +336,17 @@ export class GameInstance {
             this.baseAttackWarnedAt = now
             store.setNotification({ message: '⚠ BASE UNDER ATTACK!', color: '#ff4f7b' })
             setTimeout(() => useSpeckWarsStore.getState().setNotification(null), 2500)
+          }
+          // Rally Cry: one-time notification when base drops to 25% HP
+          if (!this.rallyCryFired) {
+            const playerBase = this.sim.buildings['building-player-base']
+            if (playerBase && playerBase.hp / playerBase.maxHp < 0.25) {
+              this.rallyCryFired = true
+              setTimeout(() => {
+                useSpeckWarsStore.getState().setNotification({ message: '🔥 RALLY CRY! 1.5× PRODUCTION!', color: '#ff8844' })
+                setTimeout(() => useSpeckWarsStore.getState().setNotification(null), 3000)
+              }, 500)
+            }
           }
         }
         if (event.type === 'OUTPOST_CAPTURED') {

--- a/src/app/speck-wars/input/input-handler.ts
+++ b/src/app/speck-wars/input/input-handler.ts
@@ -21,6 +21,7 @@ export class InputHandler {
   private onCycleSpeed?: () => void
   private onSelectAll?: () => void
   private onSacrifice?: () => void
+  private heldKeys = new Set<string>()
   private isDragging = false
   private lastX = 0
   private lastY = 0
@@ -89,6 +90,8 @@ export class InputHandler {
     window.addEventListener('touchmove', this.onTouchMove, { passive: false })
     window.addEventListener('touchend', this.onTouchEnd)
     window.addEventListener('keydown', this.onKeyDown)
+    window.addEventListener('keyup', this.onKeyUp)
+    window.addEventListener('blur', () => this.heldKeys.clear())
     this.canvas.addEventListener('mousemove', this.onCanvasMouseMove)
     this.canvas.addEventListener('mouseleave', this.onMouseLeave)
   }
@@ -244,9 +247,18 @@ export class InputHandler {
     this.lastPinchDist = 0
   }
 
+  private onKeyUp = (e: KeyboardEvent) => {
+    this.heldKeys.delete(e.code)
+  }
+
+  isKeyHeld(code: string): boolean {
+    return this.heldKeys.has(code)
+  }
+
   private onKeyDown = (e: KeyboardEvent) => {
     // Don't fire when typing in an input
     if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) return
+    this.heldKeys.add(e.code)
     if (e.code === 'Space') {
       e.preventDefault()
       this.onTogglePause?.()
@@ -304,6 +316,7 @@ export class InputHandler {
     window.removeEventListener('touchmove', this.onTouchMove)
     window.removeEventListener('touchend', this.onTouchEnd)
     window.removeEventListener('keydown', this.onKeyDown)
+    window.removeEventListener('keyup', this.onKeyUp)
     this.canvas.removeEventListener('mousemove', this.onCanvasMouseMove)
     this.canvas.removeEventListener('mouseleave', this.onMouseLeave)
   }

--- a/src/app/speck-wars/input/input-handler.ts
+++ b/src/app/speck-wars/input/input-handler.ts
@@ -126,6 +126,10 @@ export class InputHandler {
 
   private onMouseMove = (e: MouseEvent) => {
     if (!this.isDragging) return
+    // Update cursor position always (needed for selection box visual)
+    const rect = this.canvas.getBoundingClientRect()
+    this.mouseX = e.clientX - rect.left
+    this.mouseY = e.clientY - rect.top
     if (this.isShiftDrag) return  // skip pan during shift-drag
     this.camera.x += e.clientX - this.lastX
     this.camera.y += e.clientY - this.lastY
@@ -273,6 +277,17 @@ export class InputHandler {
       this.onSelectAll?.()
     } else if (e.code === 'KeyF') {
       this.onSacrifice?.()
+    }
+  }
+
+  getDragRect(): { x1: number; y1: number; x2: number; y2: number } | null {
+    if (!this.isShiftDrag) return null
+    const rect = this.canvas.getBoundingClientRect()
+    return {
+      x1: this.mouseDownX - rect.left,
+      y1: this.mouseDownY - rect.top,
+      x2: this.mouseX,
+      y2: this.mouseY,
     }
   }
 

--- a/src/app/speck-wars/input/input-handler.ts
+++ b/src/app/speck-wars/input/input-handler.ts
@@ -15,6 +15,7 @@ export class InputHandler {
   private onBoxSelect?: (x1: number, y1: number, x2: number, y2: number) => void
   private onClearSelect?: () => void
   private onSurge?: () => void
+  private onSnapToAction?: () => void
   private isDragging = false
   private lastX = 0
   private lastY = 0
@@ -43,6 +44,7 @@ export class InputHandler {
     onBoxSelect?: (x1: number, y1: number, x2: number, y2: number) => void,
     onClearSelect?: () => void,
     onSurge?: () => void,
+    onSnapToAction?: () => void,
   ) {
     this.canvas = canvas
     this.camera = camera
@@ -57,6 +59,7 @@ export class InputHandler {
     this.onBoxSelect = onBoxSelect
     this.onClearSelect = onClearSelect
     this.onSurge = onSurge
+    this.onSnapToAction = onSnapToAction
     this.attach()
   }
 
@@ -244,6 +247,8 @@ export class InputHandler {
       this.onRush?.()
     } else if (e.code === 'KeyQ') {
       this.onSurge?.()
+    } else if (e.code === 'KeyV') {
+      this.onSnapToAction?.()
     }
   }
 

--- a/src/app/speck-wars/input/input-handler.ts
+++ b/src/app/speck-wars/input/input-handler.ts
@@ -16,6 +16,7 @@ export class InputHandler {
   private onClearSelect?: () => void
   private onSurge?: () => void
   private onSnapToAction?: () => void
+  private onSnapToBase?: () => void
   private onSetSpawnType?: (typeId: 'basic' | 'heavy' | 'scout') => void
   private onCycleSpeed?: () => void
   private onSelectAll?: () => void
@@ -49,6 +50,7 @@ export class InputHandler {
     onClearSelect?: () => void,
     onSurge?: () => void,
     onSnapToAction?: () => void,
+    onSnapToBase?: () => void,
     onSetSpawnType?: (typeId: 'basic' | 'heavy' | 'scout') => void,
     onCycleSpeed?: () => void,
     onSelectAll?: () => void,
@@ -68,6 +70,7 @@ export class InputHandler {
     this.onClearSelect = onClearSelect
     this.onSurge = onSurge
     this.onSnapToAction = onSnapToAction
+    this.onSnapToBase = onSnapToBase
     this.onSetSpawnType = onSetSpawnType
     this.onCycleSpeed = onCycleSpeed
     this.onSelectAll = onSelectAll
@@ -252,7 +255,7 @@ export class InputHandler {
     } else if (e.code === 'KeyR') {
       this.onClearRally?.()
     } else if (e.code === 'KeyH') {
-      this.onCycleSpawnMode?.()
+      this.onSnapToBase?.()
     } else if (e.code === 'KeyC') {
       this.onRecenterCamera?.()
     } else if (e.code === 'KeyD') {

--- a/src/app/speck-wars/input/input-handler.ts
+++ b/src/app/speck-wars/input/input-handler.ts
@@ -19,6 +19,7 @@ export class InputHandler {
   private onSetSpawnType?: (typeId: 'basic' | 'heavy' | 'scout') => void
   private onCycleSpeed?: () => void
   private onSelectAll?: () => void
+  private onSacrifice?: () => void
   private isDragging = false
   private lastX = 0
   private lastY = 0
@@ -51,6 +52,7 @@ export class InputHandler {
     onSetSpawnType?: (typeId: 'basic' | 'heavy' | 'scout') => void,
     onCycleSpeed?: () => void,
     onSelectAll?: () => void,
+    onSacrifice?: () => void,
   ) {
     this.canvas = canvas
     this.camera = camera
@@ -69,6 +71,7 @@ export class InputHandler {
     this.onSetSpawnType = onSetSpawnType
     this.onCycleSpeed = onCycleSpeed
     this.onSelectAll = onSelectAll
+    this.onSacrifice = onSacrifice
     this.attach()
   }
 
@@ -268,6 +271,8 @@ export class InputHandler {
       this.onCycleSpeed?.()
     } else if (e.code === 'KeyE') {
       this.onSelectAll?.()
+    } else if (e.code === 'KeyF') {
+      this.onSacrifice?.()
     }
   }
 

--- a/src/app/speck-wars/input/input-handler.ts
+++ b/src/app/speck-wars/input/input-handler.ts
@@ -16,6 +16,7 @@ export class InputHandler {
   private onClearSelect?: () => void
   private onSurge?: () => void
   private onSnapToAction?: () => void
+  private onSetSpawnType?: (typeId: 'basic' | 'heavy' | 'scout') => void
   private isDragging = false
   private lastX = 0
   private lastY = 0
@@ -45,6 +46,7 @@ export class InputHandler {
     onClearSelect?: () => void,
     onSurge?: () => void,
     onSnapToAction?: () => void,
+    onSetSpawnType?: (typeId: 'basic' | 'heavy' | 'scout') => void,
   ) {
     this.canvas = canvas
     this.camera = camera
@@ -60,6 +62,7 @@ export class InputHandler {
     this.onClearSelect = onClearSelect
     this.onSurge = onSurge
     this.onSnapToAction = onSnapToAction
+    this.onSetSpawnType = onSetSpawnType
     this.attach()
   }
 
@@ -249,6 +252,12 @@ export class InputHandler {
       this.onSurge?.()
     } else if (e.code === 'KeyV') {
       this.onSnapToAction?.()
+    } else if (e.code === 'Digit1') {
+      this.onSetSpawnType?.('basic')
+    } else if (e.code === 'Digit2') {
+      this.onSetSpawnType?.('heavy')
+    } else if (e.code === 'Digit3') {
+      this.onSetSpawnType?.('scout')
     }
   }
 

--- a/src/app/speck-wars/input/input-handler.ts
+++ b/src/app/speck-wars/input/input-handler.ts
@@ -17,6 +17,8 @@ export class InputHandler {
   private onSurge?: () => void
   private onSnapToAction?: () => void
   private onSetSpawnType?: (typeId: 'basic' | 'heavy' | 'scout') => void
+  private onCycleSpeed?: () => void
+  private onSelectAll?: () => void
   private isDragging = false
   private lastX = 0
   private lastY = 0
@@ -47,6 +49,8 @@ export class InputHandler {
     onSurge?: () => void,
     onSnapToAction?: () => void,
     onSetSpawnType?: (typeId: 'basic' | 'heavy' | 'scout') => void,
+    onCycleSpeed?: () => void,
+    onSelectAll?: () => void,
   ) {
     this.canvas = canvas
     this.camera = camera
@@ -63,6 +67,8 @@ export class InputHandler {
     this.onSurge = onSurge
     this.onSnapToAction = onSnapToAction
     this.onSetSpawnType = onSetSpawnType
+    this.onCycleSpeed = onCycleSpeed
+    this.onSelectAll = onSelectAll
     this.attach()
   }
 
@@ -258,6 +264,10 @@ export class InputHandler {
       this.onSetSpawnType?.('heavy')
     } else if (e.code === 'Digit3') {
       this.onSetSpawnType?.('scout')
+    } else if (e.code === 'KeyX') {
+      this.onCycleSpeed?.()
+    } else if (e.code === 'KeyE') {
+      this.onSelectAll?.()
     }
   }
 

--- a/src/app/speck-wars/rendering/layers/building-layer.ts
+++ b/src/app/speck-wars/rendering/layers/building-layer.ts
@@ -117,6 +117,14 @@ export class BuildingLayer {
         this.gfx.lineStyle(0)
       }
 
+      // Surge active: fast-pulsing gold outer ring on player base
+      if (!isOutpost && building.ownerId === 'player' && sim.surgeDuration > 0) {
+        const surgePulse = 0.5 + 0.5 * Math.sin(now / 120)
+        this.gfx.lineStyle(2.5, 0xffd700, surgePulse * 0.85)
+        this.gfx.drawCircle(building.x, building.y, r + 22)
+        this.gfx.lineStyle(0)
+      }
+
       // HP bar (above building)
       const barW = r * 2
       const barH = 4

--- a/src/app/speck-wars/rendering/layers/building-layer.ts
+++ b/src/app/speck-wars/rendering/layers/building-layer.ts
@@ -1,7 +1,7 @@
 import { Graphics, Container } from 'pixi.js'
 import type { SimulationState } from '../../domain/types'
 import { BUILDING_TYPES } from '../../domain/config/building-types'
-import { NEUTRAL_COLOR, OUTPOST_AURA_RADIUS } from '../../domain/constants'
+import { NEUTRAL_COLOR, OUTPOST_AURA_RADIUS, FORTIFY_TIME } from '../../domain/constants'
 
 function hexPoints(x: number, y: number, r: number): number[] {
   const pts: number[] = []
@@ -140,7 +140,9 @@ export class BuildingLayer {
         if (progress > 0) {
           const startAngle = -Math.PI / 2
           const endAngle = startAngle + Math.PI * 2 * progress
-          const arcColor = building.spawnTypeOverride === 'heavy' ? 0xffa032 : 0xffffff
+          const arcColor = building.spawnTypeOverride === 'heavy' ? 0xffa032
+            : building.spawnTypeOverride === 'scout' ? 0x50c8ff
+            : 0xffffff
           this.gfx.lineStyle(2, arcColor, 0.5)
           this.gfx.moveTo(building.x + (r - 5) * Math.cos(startAngle), building.y + (r - 5) * Math.sin(startAngle))
           this.gfx.arc(building.x, building.y, r - 5, startAngle, endAngle)
@@ -154,6 +156,17 @@ export class BuildingLayer {
         this.gfx.lineStyle(1, color, auraPulse * 0.18 + 0.04)
         this.gfx.drawCircle(building.x, building.y, OUTPOST_AURA_RADIUS)
         this.gfx.lineStyle(0)
+      }
+
+      // Fortification ring: gold glow when outpost has been held and is fortifying
+      if (building.typeId === 'outpost' && building.ownerId !== 'neutral') {
+        const fortLevel = Math.min(1, (building.fortifyDuration ?? 0) / FORTIFY_TIME)
+        if (fortLevel > 0.05) {  // only show when at least 5% fortified
+          const fortPulse = Math.sin(now / 1500) * 0.2 + 0.8
+          this.gfx.lineStyle(1.5, 0xffd700, fortLevel * fortPulse * 0.55)
+          this.gfx.drawCircle(building.x, building.y, r + 16)
+          this.gfx.lineStyle(0)
+        }
       }
 
       // Capture progress ring

--- a/src/app/speck-wars/rendering/layers/speck-layer.ts
+++ b/src/app/speck-wars/rendering/layers/speck-layer.ts
@@ -83,9 +83,19 @@ export class SpeckLayer {
         const hpFrac = stype ? Math.max(0, sim.speckHp[i] / stype.hp) : 1
         spriteList[j].alpha = 0.35 + 0.65 * hpFrac
 
-        // Gold ring for veteran specks (3+ kills)
-        const isVeteran = (typeMeta?.kills ?? 0) >= 3
-        if (isVeteran) {
+        // Gold ring for veteran specks (3+ kills), bright white diamond ring for elite (6+ kills)
+        const kills = typeMeta?.kills ?? 0
+        const isVeteran = kills >= 3
+        const isElite = kills >= 6
+        if (isElite) {
+          // Bright white outer ring + gold inner ring for elite
+          const elitePulse = 0.7 + 0.3 * Math.sin(now / 200)
+          this.gfx.lineStyle(2, 0xffffff, elitePulse * spriteList[j].alpha)
+          this.gfx.drawCircle(sim.speckX[i], sim.speckY[i], (stype ? stype.size / 4 : 0.75) + 5)
+          this.gfx.lineStyle(1.5, 0xffd700, spriteList[j].alpha * 0.9)
+          this.gfx.drawCircle(sim.speckX[i], sim.speckY[i], (stype ? stype.size / 4 : 0.75) + 2.5)
+          this.gfx.lineStyle(0)
+        } else if (isVeteran) {
           this.gfx.lineStyle(1.5, 0xffd700, spriteList[j].alpha * 0.9)
           this.gfx.drawCircle(sim.speckX[i], sim.speckY[i], (stype ? stype.size / 4 : 0.75) + 2.5)
           this.gfx.lineStyle(0)

--- a/src/app/speck-wars/rendering/renderer.ts
+++ b/src/app/speck-wars/rendering/renderer.ts
@@ -35,6 +35,7 @@ export class Renderer {
   private effectsLayer!: EffectsLayer
   private starfieldLayer!: StarfieldLayer
   private rallyGfx!: Graphics
+  private selectionGfx!: Graphics
 
   async init(canvas: HTMLCanvasElement) {
     const app = new Application() as PixiApplication
@@ -65,9 +66,12 @@ export class Renderer {
 
     this.rallyGfx = new Graphics()
     this.world.addChild(this.rallyGfx)
+
+    this.selectionGfx = new Graphics()
+    this.app.stage.addChild(this.selectionGfx)
   }
 
-  render(sim: SimulationState, camera: { x: number; y: number; zoom: number }, dt: number, shakeX = 0, shakeY = 0) {
+  render(sim: SimulationState, camera: { x: number; y: number; zoom: number }, dt: number, shakeX = 0, shakeY = 0, dragRect?: { x1: number; y1: number; x2: number; y2: number } | null): void {
     this.world.position.set(camera.x + shakeX, camera.y + shakeY)
     this.world.scale.set(camera.zoom)
 
@@ -144,6 +148,31 @@ export class Renderer {
         }
       }
     }
+
+    // Draw drag-selection box (screen space)
+    this.selectionGfx.clear()
+    if (dragRect) {
+      const { x1, y1, x2, y2 } = dragRect
+      const minX = Math.min(x1, x2), maxX = Math.max(x1, x2)
+      const minY = Math.min(y1, y2), maxY = Math.max(y1, y2)
+      const w = maxX - minX, h = maxY - minY
+      // Semi-transparent cyan fill
+      this.selectionGfx.beginFill(0x4af7c4, 0.08)
+      this.selectionGfx.lineStyle(1.5, 0x4af7c4, 0.9)
+      this.selectionGfx.drawRect(minX, minY, w, h)
+      this.selectionGfx.endFill()
+      // Corner brackets for RTS feel
+      const cs = Math.min(12, w / 3, h / 3)  // corner size
+      this.selectionGfx.lineStyle(2, 0x4af7c4, 1.0)
+      // Top-left
+      this.selectionGfx.moveTo(minX, minY + cs); this.selectionGfx.lineTo(minX, minY); this.selectionGfx.lineTo(minX + cs, minY)
+      // Top-right
+      this.selectionGfx.moveTo(maxX - cs, minY); this.selectionGfx.lineTo(maxX, minY); this.selectionGfx.lineTo(maxX, minY + cs)
+      // Bottom-left
+      this.selectionGfx.moveTo(minX, maxY - cs); this.selectionGfx.lineTo(minX, maxY); this.selectionGfx.lineTo(minX + cs, maxY)
+      // Bottom-right
+      this.selectionGfx.moveTo(maxX - cs, maxY); this.selectionGfx.lineTo(maxX, maxY); this.selectionGfx.lineTo(maxX, maxY - cs)
+    }
   }
 
   showRallyPing(x: number, y: number) {
@@ -157,6 +186,7 @@ export class Renderer {
     this.speckLayer.destroy()
     this.buildingLayer.destroy()
     this.rallyGfx.destroy()
+    this.selectionGfx.destroy()
     this.app.destroy()
   }
 }

--- a/src/app/speck-wars/rendering/renderer.ts
+++ b/src/app/speck-wars/rendering/renderer.ts
@@ -128,7 +128,9 @@ export class Renderer {
           const nx = dx / len, ny = dy / len
           const dashLen = 8, gapLen = 6
           this.rallyGfx.lineStyle(1, PLAYER_COLOR, 0.22)
-          let d = playerBase === null ? 0 : 46  // start outside the base
+          const dashCycle = dashLen + gapLen
+          const marchOffset = (Date.now() / 80) % dashCycle  // ~1.75 cycles/sec
+          let d = (playerBase === null ? 0 : 46) - marchOffset  // animated march toward rally
           while (d < len - 24) {
             const x1 = playerBase.x + nx * d
             const y1 = playerBase.y + ny * d

--- a/src/app/speck-wars/store.ts
+++ b/src/app/speck-wars/store.ts
@@ -35,8 +35,8 @@ interface SpeckWarsStore {
   addOutpostCaptured: () => void
   isNewBest: boolean
   setIsNewBest: (v: boolean) => void
-  gameActions: { defend: (() => void) | null; advance: (() => void) | null; rush: (() => void) | null; clearRally: (() => void) | null; surge: (() => void) | null }
-  setGameActions: (actions: { defend: () => void; advance: () => void; rush: () => void; clearRally: () => void; surge: () => void } | null) => void
+  gameActions: { defend: (() => void) | null; advance: (() => void) | null; rush: (() => void) | null; clearRally: (() => void) | null; surge: (() => void) | null; rally: ((x: number, y: number) => void) | null }
+  setGameActions: (actions: { defend: () => void; advance: () => void; rush: () => void; clearRally: () => void; surge: () => void; rally: (x: number, y: number) => void } | null) => void
   surrender: () => void
   resetGame: () => void
 }
@@ -82,8 +82,8 @@ export const useSpeckWarsStore = create<SpeckWarsStore>()((set, get) => ({
   addOutpostCaptured: () => set(s => ({ outpostsCaptured: s.outpostsCaptured + 1 })),
   isNewBest: false,
   setIsNewBest: v => set({ isNewBest: v }),
-  gameActions: { defend: null, advance: null, rush: null, clearRally: null, surge: null },
-  setGameActions: (actions) => set({ gameActions: actions ?? { defend: null, advance: null, rush: null, clearRally: null, surge: null } }),
+  gameActions: { defend: null, advance: null, rush: null, clearRally: null, surge: null, rally: null },
+  setGameActions: (actions) => set({ gameActions: actions ?? { defend: null, advance: null, rush: null, clearRally: null, surge: null, rally: null } }),
   surrender: () => {
     const s = get()
     resetWinStreak()

--- a/src/app/speck-wars/store.ts
+++ b/src/app/speck-wars/store.ts
@@ -27,8 +27,8 @@ interface SpeckWarsStore {
   losses: number
   addKill: () => void
   addLoss: () => void
-  spawnMode: 'basic' | 'heavy'
-  cycleSpawnMode: () => 'basic' | 'heavy'
+  spawnMode: 'basic' | 'heavy' | 'scout'
+  cycleSpawnMode: () => 'basic' | 'heavy' | 'scout'
   isNewBest: boolean
   setIsNewBest: (v: boolean) => void
   gameActions: { defend: (() => void) | null; advance: (() => void) | null; rush: (() => void) | null; clearRally: (() => void) | null; surge: (() => void) | null }
@@ -63,11 +63,11 @@ export const useSpeckWarsStore = create<SpeckWarsStore>()((set, get) => ({
   losses: 0,
   addKill: () => set(s => ({ kills: s.kills + 1 })),
   addLoss: () => set(s => ({ losses: s.losses + 1 })),
-  spawnMode: 'basic' as 'basic' | 'heavy',
+  spawnMode: 'basic' as 'basic' | 'heavy' | 'scout',
   cycleSpawnMode: () => {
-    let next: 'basic' | 'heavy' = 'basic'
+    let next: 'basic' | 'heavy' | 'scout' = 'basic'
     set(s => {
-      next = s.spawnMode === 'basic' ? 'heavy' : 'basic'
+      next = s.spawnMode === 'basic' ? 'heavy' : s.spawnMode === 'heavy' ? 'scout' : 'basic'
       return { spawnMode: next }
     })
     return next
@@ -92,7 +92,7 @@ export const useSpeckWarsStore = create<SpeckWarsStore>()((set, get) => ({
     notification: null,
     kills: 0,
     losses: 0,
-    spawnMode: 'basic' as 'basic' | 'heavy',
+    spawnMode: 'basic' as 'basic' | 'heavy' | 'scout',
     isNewBest: false,
     difficulty: s.difficulty,
   })),

--- a/src/app/speck-wars/store.ts
+++ b/src/app/speck-wars/store.ts
@@ -36,8 +36,8 @@ interface SpeckWarsStore {
   addOutpostCaptured: () => void
   isNewBest: boolean
   setIsNewBest: (v: boolean) => void
-  gameActions: { defend: (() => void) | null; advance: (() => void) | null; rush: (() => void) | null; clearRally: (() => void) | null; surge: (() => void) | null; rally: ((x: number, y: number) => void) | null }
-  setGameActions: (actions: { defend: () => void; advance: () => void; rush: () => void; clearRally: () => void; surge: () => void; rally: (x: number, y: number) => void } | null) => void
+  gameActions: { defend: (() => void) | null; advance: (() => void) | null; rush: (() => void) | null; clearRally: (() => void) | null; surge: (() => void) | null; rally: ((x: number, y: number) => void) | null; sacrifice: (() => void) | null }
+  setGameActions: (actions: { defend: () => void; advance: () => void; rush: () => void; clearRally: () => void; surge: () => void; rally: (x: number, y: number) => void; sacrifice: () => void } | null) => void
   surrender: () => void
   resetGame: () => void
 }
@@ -84,8 +84,8 @@ export const useSpeckWarsStore = create<SpeckWarsStore>()((set, get) => ({
   addOutpostCaptured: () => set(s => ({ outpostsCaptured: s.outpostsCaptured + 1 })),
   isNewBest: false,
   setIsNewBest: v => set({ isNewBest: v }),
-  gameActions: { defend: null, advance: null, rush: null, clearRally: null, surge: null, rally: null },
-  setGameActions: (actions) => set({ gameActions: actions ?? { defend: null, advance: null, rush: null, clearRally: null, surge: null, rally: null } }),
+  gameActions: { defend: null, advance: null, rush: null, clearRally: null, surge: null, rally: null, sacrifice: null },
+  setGameActions: (actions) => set({ gameActions: actions ?? { defend: null, advance: null, rush: null, clearRally: null, surge: null, rally: null, sacrifice: null } }),
   surrender: () => {
     const s = get()
     resetWinStreak()

--- a/src/app/speck-wars/store.ts
+++ b/src/app/speck-wars/store.ts
@@ -36,8 +36,8 @@ interface SpeckWarsStore {
   addOutpostCaptured: () => void
   isNewBest: boolean
   setIsNewBest: (v: boolean) => void
-  gameActions: { defend: (() => void) | null; advance: (() => void) | null; rush: (() => void) | null; clearRally: (() => void) | null; surge: (() => void) | null; rally: ((x: number, y: number) => void) | null; sacrifice: (() => void) | null }
-  setGameActions: (actions: { defend: () => void; advance: () => void; rush: () => void; clearRally: () => void; surge: () => void; rally: (x: number, y: number) => void; sacrifice: () => void } | null) => void
+  gameActions: { defend: (() => void) | null; advance: (() => void) | null; rush: (() => void) | null; clearRally: (() => void) | null; surge: (() => void) | null; rally: ((x: number, y: number) => void) | null; sacrifice: (() => void) | null; setSpawnType: ((type: 'basic' | 'heavy' | 'scout') => void) | null }
+  setGameActions: (actions: { defend: () => void; advance: () => void; rush: () => void; clearRally: () => void; surge: () => void; rally: (x: number, y: number) => void; sacrifice: () => void; setSpawnType: (type: 'basic' | 'heavy' | 'scout') => void } | null) => void
   surrender: () => void
   resetGame: () => void
 }
@@ -84,8 +84,8 @@ export const useSpeckWarsStore = create<SpeckWarsStore>()((set, get) => ({
   addOutpostCaptured: () => set(s => ({ outpostsCaptured: s.outpostsCaptured + 1 })),
   isNewBest: false,
   setIsNewBest: v => set({ isNewBest: v }),
-  gameActions: { defend: null, advance: null, rush: null, clearRally: null, surge: null, rally: null, sacrifice: null },
-  setGameActions: (actions) => set({ gameActions: actions ?? { defend: null, advance: null, rush: null, clearRally: null, surge: null, rally: null, sacrifice: null } }),
+  gameActions: { defend: null, advance: null, rush: null, clearRally: null, surge: null, rally: null, sacrifice: null, setSpawnType: null },
+  setGameActions: (actions) => set({ gameActions: actions ?? { defend: null, advance: null, rush: null, clearRally: null, surge: null, rally: null, sacrifice: null, setSpawnType: null } }),
   surrender: () => {
     const s = get()
     resetWinStreak()

--- a/src/app/speck-wars/store.ts
+++ b/src/app/speck-wars/store.ts
@@ -29,6 +29,10 @@ interface SpeckWarsStore {
   addLoss: () => void
   spawnMode: 'basic' | 'heavy' | 'scout'
   cycleSpawnMode: () => 'basic' | 'heavy' | 'scout'
+  peakArmySize: number
+  setPeakArmySize: (n: number) => void
+  outpostsCaptured: number
+  addOutpostCaptured: () => void
   isNewBest: boolean
   setIsNewBest: (v: boolean) => void
   gameActions: { defend: (() => void) | null; advance: (() => void) | null; rush: (() => void) | null; clearRally: (() => void) | null; surge: (() => void) | null }
@@ -72,6 +76,10 @@ export const useSpeckWarsStore = create<SpeckWarsStore>()((set, get) => ({
     })
     return next
   },
+  peakArmySize: 0,
+  setPeakArmySize: n => set(s => ({ peakArmySize: Math.max(s.peakArmySize, n) })),
+  outpostsCaptured: 0,
+  addOutpostCaptured: () => set(s => ({ outpostsCaptured: s.outpostsCaptured + 1 })),
   isNewBest: false,
   setIsNewBest: v => set({ isNewBest: v }),
   gameActions: { defend: null, advance: null, rush: null, clearRally: null, surge: null },
@@ -94,6 +102,8 @@ export const useSpeckWarsStore = create<SpeckWarsStore>()((set, get) => ({
     losses: 0,
     spawnMode: 'basic' as 'basic' | 'heavy' | 'scout',
     isNewBest: false,
+    peakArmySize: 0,
+    outpostsCaptured: 0,
     difficulty: s.difficulty,
   })),
 }))

--- a/src/app/speck-wars/store.ts
+++ b/src/app/speck-wars/store.ts
@@ -29,6 +29,7 @@ interface SpeckWarsStore {
   addLoss: () => void
   spawnMode: 'basic' | 'heavy' | 'scout'
   cycleSpawnMode: () => 'basic' | 'heavy' | 'scout'
+  setSpawnMode: (mode: 'basic' | 'heavy' | 'scout') => void
   peakArmySize: number
   setPeakArmySize: (n: number) => void
   outpostsCaptured: number
@@ -76,6 +77,7 @@ export const useSpeckWarsStore = create<SpeckWarsStore>()((set, get) => ({
     })
     return next
   },
+  setSpawnMode: mode => set({ spawnMode: mode }),
   peakArmySize: 0,
   setPeakArmySize: n => set(s => ({ peakArmySize: Math.max(s.peakArmySize, n) })),
   outpostsCaptured: 0,


### PR DESCRIPTION
Two minimaps were being rendered: one inside HUD (top-right, SVG) and a standalone canvas Minimap component (bottom: 16, right: 16). The standalone one was left over from a refactor and was rendering outside the viewport. Removed the import and JSX usage from SpeckWarsGame.tsx.