### PR TITLE
feat(speck-wars): base HP regeneration — 5s cooldown after last hit

### DIFF
--- a/src/app/speck-wars/domain/simulation/combat.ts
+++ b/src/app/speck-wars/domain/simulation/combat.ts
@@ -139,6 +139,7 @@ export function resolveCombat(sim: SimulationState, dt: number) {
       if (building.typeId === 'outpost') continue
       const siegeBonus = meta.typeId === 'heavy' ? 1.5 : 1.0
       building.hp -= stype.damage * moraleMult(meta.ownerId) * siegeBonus
+      building.lastDamagedAt = Date.now()
       meta.attackCooldown = stype.attackCooldown
       sim.events.push({ type: 'BUILDING_DAMAGED', buildingId: building.id, hp: building.hp })
 

--- a/src/app/speck-wars/domain/simulation/tick.ts
+++ b/src/app/speck-wars/domain/simulation/tick.ts
@@ -117,6 +117,7 @@ function regenRetreatingSpecks(sim: SimulationState, dt: number) {
 
 function regenBuildingHp(sim: SimulationState, dt: number) {
   const dtSec = dt / 1000
+  const REGEN_COOLDOWN_MS = 5000
   for (const building of Object.values(sim.buildings)) {
     if (building.hp >= building.maxHp) continue
     if (building.ownerId === 'neutral') continue
@@ -124,6 +125,8 @@ function regenBuildingHp(sim: SimulationState, dt: number) {
     if (!btype?.hpRegen) continue
     // No regen while actively being captured
     if (building.captureProgress && building.captureProgress > 0) continue
+    // No regen within 5 seconds of last taking damage
+    if (Date.now() - (building.lastDamagedAt ?? 0) < REGEN_COOLDOWN_MS) continue
     building.hp = Math.min(building.maxHp, building.hp + btype.hpRegen * dtSec)
   }
 }

--- a/src/app/speck-wars/domain/types.ts
+++ b/src/app/speck-wars/domain/types.ts
@@ -24,6 +24,7 @@ export interface BuildingEntity {
   captureProgress?: number      // 0..1 progress toward capture for captureSide
   captureSide?: string | null   // which player is currently winning capture
   fortifyDuration?: number      // ms continuously held — resets on capture
+  lastDamagedAt?: number        // Date.now() timestamp of last damage taken (for regen cooldown)
 }
 
 export interface Player {


### PR DESCRIPTION
Closes #1932

## Summary
- Adds `lastDamagedAt?: number` to `BuildingEntity` — stamped with `Date.now()` on every damage hit in `combat.ts`
- In `regenBuildingHp` (tick.ts), skips regen if the building was hit in the last 5 000 ms
- Existing regen rate (0.5 HP/s for base) is unchanged

## Effect
Bases now have a 5-second grace period after taking any damage before HP starts ticking back up, making "bunker down and recover" a real strategy — push the enemy back, then your base heals.