### PR TITLE
feat(speck-wars): specks prioritize enemy specks over buildings — clear defenders first

### DIFF
--- a/src/app/speck-wars/domain/simulation/speck-ai.ts
+++ b/src/app/speck-wars/domain/simulation/speck-ai.ts
@@ -3,6 +3,7 @@ import { SPECK_TYPES } from '../config/speck-types'
 
 const RALLY_ARRIVAL_THRESHOLD = 30   // px — how close before speck is considered "arrived"
 const ATTACK_MOVE_PROXIMITY = 100    // px — attack enemy buildings within this range while moving to rally
+const DEFENDER_PRIORITY_RANGE = 100 // px — clear enemy specks this close before attacking buildings
 
 export function runSpeckAI(sim: SimulationState) {
   const { speckIds, speckX, speckY, speckMeta, buildings } = sim
@@ -55,6 +56,24 @@ export function runSpeckAI(sim: SimulationState) {
         meta.state = 'moving'
         continue
       }
+    }
+
+    // Defender priority: if enemy specks are within range, fight them before attacking buildings
+    // This ensures specks clear defenders instead of running past them to hit the structure
+    let nearestEnemySpeckDist = Infinity
+    for (let j = 0; j < sim.speckCount; j++) {
+      if (!speckIds[j] || j === i) continue
+      const jMeta = speckMeta[j]
+      if (!jMeta || jMeta.ownerId === meta.ownerId) continue
+      const dx = speckX[j] - speckX[i]
+      const dy = speckY[j] - speckY[i]
+      const dist = dx * dx + dy * dy  // squared — avoid sqrt for perf
+      if (dist < nearestEnemySpeckDist) nearestEnemySpeckDist = dist
+    }
+    if (nearestEnemySpeckDist < DEFENDER_PRIORITY_RANGE * DEFENDER_PRIORITY_RANGE) {
+      meta.targetId = null  // engage defenders via idle aggression in movement.ts
+      meta.state = 'idle'
+      continue
     }
 
     if (meta.targetId) continue  // already has a valid target


### PR DESCRIPTION
Closes #1969

## Summary
- Adds `DEFENDER_PRIORITY_RANGE = 100px` constant in `speck-ai.ts`
- Before keeping or assigning any building target, each speck checks for the nearest enemy speck using squared-distance comparison (no sqrt, perf-friendly)
- If an enemy speck is within 100px, the building target is cleared and the speck enters `idle` state — movement.ts then runs idle-aggression which actively pursues the nearest enemy speck
- Once the local area is clear of defenders, the next AI tick assigns the nearest enemy building as the target and the speck resumes its advance

## Effect
Specks now behave like real soldiers: they engage and eliminate nearby enemy defenders before pushing forward to attack structures. Previously they ran past defenders to hit buildings.