### PR TITLE
feat(speck-wars): plain drag box-selects specks — no Shift required

### DIFF
--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -832,7 +832,7 @@ export function HUD() {
               fontSize: 9, letterSpacing: 1.5, color: '#ffffff', opacity: 0.7,
               textAlign: 'center', marginBottom: 4,
             }}>
-              SQUAD: {hud.selectedSpeckCount} · Shift+drag to reselect · Esc to clear
+              SQUAD: {hud.selectedSpeckCount} · Drag to reselect · Esc to clear
               {hud.selectedComposition && (
                 <div style={{ fontSize: 9, color: 'rgba(74,247,196,0.75)', marginTop: 2, letterSpacing: 1 }}>
                   {Object.entries(hud.selectedComposition.types)

--- a/src/app/speck-wars/components/phase-router.tsx
+++ b/src/app/speck-wars/components/phase-router.tsx
@@ -135,7 +135,7 @@ export function PhaseRouter({ children }: { children: React.ReactNode }) {
         }}>
           <span>🖱 Click — rally specks</span>
           <span>Space — pause / ? — help</span>
-          <span>Shift+drag — box select</span>
+          <span>Drag — box select</span>
           <span>1/2/3 — spawn basic/heavy/scout</span>
           <span>Q — surge (2× spawn 8s)</span>
           <span>V — snap to battle</span>
@@ -152,7 +152,7 @@ export function PhaseRouter({ children }: { children: React.ReactNode }) {
             'Veterans deal +20% damage after 3 kills. Protect them!',
             'Fortify outposts by holding them 30s for a combat bonus.',
             'Surge (Q) doubles production for 8s — use it before big pushes.',
-            'Box-select (Shift+drag) specks and right-click to send them anywhere.',
+            'Box-select (drag) specks and right-click to send them anywhere.',
             'Rally Cry: base below 25% HP activates 1.5× spawn automatically.',
             'Heavy specks deal 2× damage but produce 2× slower.',
             'V key snaps the camera to where fighting is happening.',

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -108,10 +108,10 @@ export class GameInstance {
       () => { this.defend(); this.notify('🛡 DEFEND', '#4af7c4') },   // D — defend (rally to player base)
       () => { this.advance(); this.notify('→ ADVANCE', '#ffd700') },  // A — advance to nearest non-player outpost
       () => { this.rush(); this.notify('⚡ RUSH!', '#ff4f7b') },      // B — rush enemy base
-      (x1, y1, x2, y2) => {                                           // Shift+drag — box-select specks
+      (x1, y1, x2, y2) => {                                           // drag — box-select specks
         this.sim.inputQueue.push({ type: 'BOX_SELECT', ownerId: 'player', x1, y1, x2, y2 })
       },
-      () => {                                                          // Escape / Shift+click — clear selection
+      () => {                                                          // Escape — clear selection
         this.sim.inputQueue.push({ type: 'CLEAR_SELECT', ownerId: 'player' })
         this.sim.rallyPoints['player-selected'] = null
       },

--- a/src/app/speck-wars/input/input-handler.ts
+++ b/src/app/speck-wars/input/input-handler.ts
@@ -32,9 +32,9 @@ export class InputHandler {
   private lastPinchDist = 0  // 0 = not pinching
   private touchStartX = 0
   private touchStartY = 0
-  private isShiftDrag = false
-  private shiftDragStartWorldX = 0
-  private shiftDragStartWorldY = 0
+  private isDragSelect = false
+  private dragSelectStartWorldX = 0
+  private dragSelectStartWorldY = 0
 
   constructor(
     canvas: HTMLCanvasElement,
@@ -111,19 +111,22 @@ export class InputHandler {
 
   private onMouseDown = (e: MouseEvent) => {
     if (e.button === 1) e.preventDefault()  // prevent middle-click scroll
-    if (e.button === 0 && e.shiftKey) {
-      this.isShiftDrag = true
+    if (e.button === 0) {
+      this.isDragSelect = true
       const rect = this.canvas.getBoundingClientRect()
       const sx = e.clientX - rect.left
       const sy = e.clientY - rect.top
       const world = screenToWorld(sx, sy, this.camera)
-      this.shiftDragStartWorldX = world.x
-      this.shiftDragStartWorldY = world.y
+      this.dragSelectStartWorldX = world.x
+      this.dragSelectStartWorldY = world.y
       this.mouseDownX = e.clientX
       this.mouseDownY = e.clientY
-      return  // don't start pan
+      this.isDragging = true  // still track drag for HUD visual
+      this.lastX = e.clientX
+      this.lastY = e.clientY
+      return
     }
-    this.isDragging = true
+    this.isDragging = true  // non-left-button: camera pan
     this.lastX = e.clientX
     this.lastY = e.clientY
     this.mouseDownX = e.clientX
@@ -136,7 +139,7 @@ export class InputHandler {
     const rect = this.canvas.getBoundingClientRect()
     this.mouseX = e.clientX - rect.left
     this.mouseY = e.clientY - rect.top
-    if (this.isShiftDrag) return  // skip pan during shift-drag
+    if (this.isDragSelect) return  // skip pan during drag-select
     this.camera.x += e.clientX - this.lastX
     this.camera.y += e.clientY - this.lastY
     this.lastX = e.clientX
@@ -148,17 +151,22 @@ export class InputHandler {
     const dy = e.clientY - this.mouseDownY
     const dist = Math.sqrt(dx * dx + dy * dy)
 
-    if (this.isShiftDrag) {
-      this.isShiftDrag = false
+    if (this.isDragSelect) {
+      this.isDragSelect = false
+      this.isDragging = false
       if (dist > 10) {
         const rect = this.canvas.getBoundingClientRect()
         const sx = e.clientX - rect.left
         const sy = e.clientY - rect.top
         const world = screenToWorld(sx, sy, this.camera)
-        this.onBoxSelect?.(this.shiftDragStartWorldX, this.shiftDragStartWorldY, world.x, world.y)
-      } else {
-        // Tiny shift-click: clear selection
-        this.onClearSelect?.()
+        this.onBoxSelect?.(this.dragSelectStartWorldX, this.dragSelectStartWorldY, world.x, world.y)
+      } else if (dist < 5 && this.onRally) {
+        // Short click — set rally point
+        const rect = this.canvas.getBoundingClientRect()
+        const sx = e.clientX - rect.left
+        const sy = e.clientY - rect.top
+        const world = screenToWorld(sx, sy, this.camera)
+        this.onRally(world.x, world.y)
       }
       return
     }
@@ -296,7 +304,7 @@ export class InputHandler {
   }
 
   getDragRect(): { x1: number; y1: number; x2: number; y2: number } | null {
-    if (!this.isShiftDrag) return null
+    if (!this.isDragSelect) return null
     const rect = this.canvas.getBoundingClientRect()
     return {
       x1: this.mouseDownX - rect.left,


### PR DESCRIPTION
Closes #2015

## Summary
- Removes Shift key requirement for box-selection drag
- Any left-click drag now initiates a selection box (Starcraft ergonomics)
- Short clicks (< 5px movement) still set the rally point as before
- Camera panning remains available via arrow keys and WASD (already implemented)
- Updated all help text / tutorial copy to drop "Shift+" references