### PR TITLE
feat(speck-wars): help overlay — drag select, subselection, attack-move docs

### DIFF
--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -494,15 +494,16 @@ export function HUD() {
             borderRadius: 8,
             border: '1px solid rgba(255,255,255,0.15)',
           }}>
-            <span>🖱 Click — rally specks</span><span>Space — pause</span>
+            <span>🖱 Click — rally all specks</span><span>Space — pause</span>
             <span>Scroll — zoom</span><span>R / Right-click — clear rally</span>
-            <span>Drag — pan camera</span><span>1/2/3 — set spawn type</span>
+            <span>Drag — box select specks</span><span>1/2/3 — set spawn type</span>
+            <span>E — select all · Esc — clear</span><span>Arrow/WASD — pan camera</span>
+            <span style={{ color: 'rgba(74,247,196,0.7)' }}>Click rally with group → moves selected only</span><span style={{ color: 'rgba(74,247,196,0.7)' }}>Specks engage enemies en route (attack-move)</span>
             <span>A — advance to outpost</span><span>C — center on base</span>
             <span>B — rush enemy base</span><span>D — defend base</span>
             <span>Q — surge (2× spawn 8s)</span><span>V — snap camera to battle</span>
             <span>H — snap to home base</span><span>Minimap — click to rally</span>
-            <span>E — select all specks</span><span>X — cycle speed (1×/2×/4×)</span>
-            <span>F — sacrifice 10 specks → +15 HP base</span><span>Arrow keys — pan camera</span>
+            <span>X — cycle speed (1×/2×/4×)</span><span>F — sacrifice 10 specks → +15 HP</span>
             <span>? — this help</span><span></span>
             <span style={{ gridColumn: '1/-1', borderTop: '1px solid rgba(255,255,255,0.08)', paddingTop: 8, marginTop: 2, color: 'rgba(255,215,0,0.5)', fontSize: 11 }}>
               Daily map seed changes each day · modifier shown top-right (bulwark/blitz/siege)

--- a/src/app/speck-wars/components/phase-router.tsx
+++ b/src/app/speck-wars/components/phase-router.tsx
@@ -135,14 +135,14 @@ export function PhaseRouter({ children }: { children: React.ReactNode }) {
         }}>
           <span>🖱 Click — rally specks</span>
           <span>Space — pause / ? — help</span>
-          <span>Drag — box select</span>
+          <span>Drag — box select specks</span>
           <span>1/2/3 — spawn basic/heavy/scout</span>
           <span>Q — surge (2× spawn 8s)</span>
           <span>V — snap to battle</span>
           <span>A — advance · B — rush · D — defend</span>
-          <span>X — game speed · E — select all</span>
+          <span>X — speed · E — all · Esc — clear</span>
           <span>Minimap — click to rally</span>
-          <span>C — center camera</span>
+          <span>Arrow keys / WASD — pan</span>
         </div>
         {/* Daily tip */}
         {(() => {
@@ -152,7 +152,7 @@ export function PhaseRouter({ children }: { children: React.ReactNode }) {
             'Veterans deal +20% damage after 3 kills. Protect them!',
             'Fortify outposts by holding them 30s for a combat bonus.',
             'Surge (Q) doubles production for 8s — use it before big pushes.',
-            'Box-select (drag) specks and right-click to send them anywhere.',
+            'Drag to box-select specks, then click anywhere to rally only your selection.',
             'Rally Cry: base below 25% HP activates 1.5× spawn automatically.',
             'Heavy specks deal 2× damage but produce 2× slower.',
             'V key snaps the camera to where fighting is happening.',


### PR DESCRIPTION
Closes #2016

Supersedes #2026 (rebased cleanly after #2025 merge).

## Summary
- Fixes stale "Drag — pan camera" → "Drag — box select specks" in `?` help overlay
- Adds `E — select all · Esc — clear` shortcut row
- Adds subselection tip row: "Click rally with group → moves selected only"
- Adds attack-move note: "Specks engage enemies en route (attack-move)"
- Updates pre-game controls hint: drag, Esc, WASD pan
- Updates daily tip to drop Shift+drag reference