### PR TITLE
feat(speck-wars): cinematic 3-2-1 countdown on game start

### DIFF
--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -494,15 +494,16 @@ export function HUD() {
             borderRadius: 8,
             border: '1px solid rgba(255,255,255,0.15)',
           }}>
-            <span>🖱 Click — rally specks</span><span>Space — pause</span>
+            <span>🖱 Click — rally all specks</span><span>Space — pause</span>
             <span>Scroll — zoom</span><span>R / Right-click — clear rally</span>
-            <span>Drag — pan camera</span><span>1/2/3 — set spawn type</span>
+            <span>Drag — box select specks</span><span>1/2/3 — set spawn type</span>
+            <span>E — select all · Esc — clear</span><span>Arrow/WASD — pan camera</span>
+            <span style={{ color: 'rgba(74,247,196,0.7)' }}>Click rally with group → moves selected only</span><span style={{ color: 'rgba(74,247,196,0.7)' }}>Specks engage enemies en route (attack-move)</span>
             <span>A — advance to outpost</span><span>C — center on base</span>
             <span>B — rush enemy base</span><span>D — defend base</span>
             <span>Q — surge (2× spawn 8s)</span><span>V — snap camera to battle</span>
             <span>H — snap to home base</span><span>Minimap — click to rally</span>
-            <span>E — select all specks</span><span>X — cycle speed (1×/2×/4×)</span>
-            <span>F — sacrifice 10 specks → +15 HP base</span><span>Arrow keys — pan camera</span>
+            <span>X — cycle speed (1×/2×/4×)</span><span>F — sacrifice 10 specks → +15 HP</span>
             <span>? — this help</span><span></span>
             <span style={{ gridColumn: '1/-1', borderTop: '1px solid rgba(255,255,255,0.08)', paddingTop: 8, marginTop: 2, color: 'rgba(255,215,0,0.5)', fontSize: 11 }}>
               Daily map seed changes each day · modifier shown top-right (bulwark/blitz/siege)

--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -39,6 +39,7 @@ export function HUD() {
   const speed = useSpeckWarsStore(s => s.speed)
   const cycleSpeed = useSpeckWarsStore(s => s.cycleSpeed)
   const notification = useSpeckWarsStore(s => s.notification)
+  const countdown = useSpeckWarsStore(s => s.countdown)
   const kills = useSpeckWarsStore(s => s.kills)
   const losses = useSpeckWarsStore(s => s.losses)
   const spawnMode = useSpeckWarsStore(s => s.spawnMode)
@@ -66,6 +67,10 @@ export function HUD() {
         @keyframes pulse-red {
           from { opacity: 0.5; }
           to { opacity: 1; }
+        }
+        @keyframes countdown-pop {
+          from { transform: scale(1.5); opacity: 0; }
+          to { transform: scale(1); opacity: 1; }
         }
       `}</style>
       {hud?.baseUnderThreat && (
@@ -638,6 +643,31 @@ export function HUD() {
           </div>
         )
       })()}
+
+      {/* Cinematic countdown overlay */}
+      {countdown !== null && (
+        <div style={{
+          position: 'absolute', inset: 0,
+          display: 'flex', alignItems: 'center', justifyContent: 'center',
+          pointerEvents: 'none',
+          zIndex: 100,
+        }}>
+          <div
+            key={countdown}
+            style={{
+              fontSize: 120,
+              fontWeight: 'bold',
+              color: countdown === 1 ? '#ff4f7b' : countdown === 2 ? '#ffcc44' : '#4af7c4',
+              textShadow: `0 0 40px currentColor, 0 0 80px currentColor`,
+              letterSpacing: 8,
+              lineHeight: 1,
+              animation: 'countdown-pop 0.9s ease-out forwards',
+            }}
+          >
+            {countdown}
+          </div>
+        </div>
+      )}
 
       {/* Outpost capture/loss notification */}
       {notification && (

--- a/src/app/speck-wars/components/phase-router.tsx
+++ b/src/app/speck-wars/components/phase-router.tsx
@@ -135,14 +135,14 @@ export function PhaseRouter({ children }: { children: React.ReactNode }) {
         }}>
           <span>🖱 Click — rally specks</span>
           <span>Space — pause / ? — help</span>
-          <span>Drag — box select</span>
+          <span>Drag — box select specks</span>
           <span>1/2/3 — spawn basic/heavy/scout</span>
           <span>Q — surge (2× spawn 8s)</span>
           <span>V — snap to battle</span>
           <span>A — advance · B — rush · D — defend</span>
-          <span>X — game speed · E — select all</span>
+          <span>X — speed · E — all · Esc — clear</span>
           <span>Minimap — click to rally</span>
-          <span>C — center camera</span>
+          <span>Arrow keys / WASD — pan</span>
         </div>
         {/* Daily tip */}
         {(() => {
@@ -152,7 +152,7 @@ export function PhaseRouter({ children }: { children: React.ReactNode }) {
             'Veterans deal +20% damage after 3 kills. Protect them!',
             'Fortify outposts by holding them 30s for a combat bonus.',
             'Surge (Q) doubles production for 8s — use it before big pushes.',
-            'Box-select (drag) specks and right-click to send them anywhere.',
+            'Drag to box-select specks, then click anywhere to rally only your selection.',
             'Rally Cry: base below 25% HP activates 1.5× spawn automatically.',
             'Heavy specks deal 2× damage but produce 2× slower.',
             'V key snaps the camera to where fighting is happening.',

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -47,6 +47,7 @@ export class GameInstance {
   private retreatWarnedAt = -20000          // allow retreat warning after 20s
   private prevBaseUnderThreat = false
   private prevEnemyAdvance = false
+  private cinematicMs = 0
 
   constructor(canvas: HTMLCanvasElement) {
     this.canvas = canvas
@@ -152,11 +153,18 @@ export class GameInstance {
     this.lastTime = performance.now()
     this.loop(this.lastTime)
 
-    // Brief "BATTLE START" flash when game begins
+    // Cinematic countdown: 3-2-1 before gameplay begins
+    // Freeze the sim for the countdown duration
+    this.cinematicMs = 3000  // 3 seconds total
+    useSpeckWarsStore.getState().setCountdown(3)
+    setTimeout(() => useSpeckWarsStore.getState().setCountdown(2), 1000)
+    setTimeout(() => useSpeckWarsStore.getState().setCountdown(1), 2000)
     setTimeout(() => {
-      useSpeckWarsStore.getState().setNotification({ message: '⚔ BATTLE START', color: '#4af7c4' })
-      setTimeout(() => useSpeckWarsStore.getState().setNotification(null), 900)
-    }, 200)
+      useSpeckWarsStore.getState().setCountdown(null)
+      this.cinematicMs = 0
+      useSpeckWarsStore.getState().setNotification({ message: '⚔ FIGHT!', color: '#4af7c4' })
+      setTimeout(() => useSpeckWarsStore.getState().setNotification(null), 800)
+    }, 3000)
 
     // Show tutorial hints for first-time players
     if (isFirstGame()) {
@@ -183,6 +191,15 @@ export class GameInstance {
     this.lastTime = now
 
     const store = useSpeckWarsStore.getState()
+
+    if (this.cinematicMs > 0) {
+      const dtMs = dt
+      this.cinematicMs = Math.max(0, this.cinematicMs - dtMs)
+      const dragRect = this.inputHandler.getDragRect()
+      this.renderer.render(this.sim, this.camera, dt, 0, 0, dragRect)
+      this.rafId = requestAnimationFrame(this.loop)
+      return
+    }
 
     if (store.phase === 'playing') {
       const scaledDt = dt * store.speed

--- a/src/app/speck-wars/store.ts
+++ b/src/app/speck-wars/store.ts
@@ -9,6 +9,8 @@ interface SpeckWarsStore {
   phase: GamePhase
   setPhase: (phase: GamePhase) => void
   togglePause: () => void
+  countdown: number | null
+  setCountdown: (n: number | null) => void
   winnerId: string | null
   setWinnerId: (id: string) => void
   victoryType: 'destruction' | 'domination' | 'surrender' | null
@@ -48,6 +50,8 @@ export const useSpeckWarsStore = create<SpeckWarsStore>()((set, get) => ({
   togglePause: () => set(s => ({
     phase: s.phase === 'playing' ? 'paused' : s.phase === 'paused' ? 'playing' : s.phase,
   })),
+  countdown: null,
+  setCountdown: n => set({ countdown: n }),
   winnerId: null,
   setWinnerId: winnerId => set({ winnerId }),
   victoryType: null,


### PR DESCRIPTION
Closes #2020

## Summary
- Adds a 3-second frozen countdown (3→2→1→FIGHT!) before gameplay begins
- Sim is frozen during countdown (no tick calls), so specks don't move until "FIGHT!" clears
- Each number re-animates with a pop/scale effect; colors: cyan (3), yellow (2), red (1)
- "FIGHT!" flash replaces the old "BATTLE START" notification
- Store gets `countdown: number | null` + `setCountdown()` setter