### PR TITLE
feat(speck-wars): notify player when AI switches to heavy speck production

### DIFF
--- a/src/app/speck-wars/domain/ai/ai-controller.ts
+++ b/src/app/speck-wars/domain/ai/ai-controller.ts
@@ -235,6 +235,7 @@ export class AIController {
           if (next !== this.spawnMode) {
             this.spawnMode = next
             sim.inputQueue.push({ type: 'SET_SPAWN_TYPE', ownerId: this.playerId, speckTypeId: next })
+            if (next === 'heavy') sim.events.push({ type: 'AI_SPAWN_SWITCH', speckTypeId: 'heavy' })
           }
           this.spawnModeCountdown = 8 + Math.floor(Math.random() * 8)
         }
@@ -254,6 +255,7 @@ export class AIController {
         if (wantHeavy && this.spawnMode !== 'heavy') {
           this.spawnMode = 'heavy'
           sim.inputQueue.push({ type: 'SET_SPAWN_TYPE', ownerId: this.playerId, speckTypeId: 'heavy' })
+          sim.events.push({ type: 'AI_SPAWN_SWITCH', speckTypeId: 'heavy' })
         } else if (wantBasic && this.spawnMode !== 'basic') {
           this.spawnMode = 'basic'
           sim.inputQueue.push({ type: 'SET_SPAWN_TYPE', ownerId: this.playerId, speckTypeId: 'basic' })

--- a/src/app/speck-wars/domain/types.ts
+++ b/src/app/speck-wars/domain/types.ts
@@ -90,6 +90,7 @@ export type SimEvent =
   | { type: 'AI_WAVE_START'; waveNumber: number }
   | { type: 'VETERAN_FALLEN'; speckId: string; ownerId: string; kills: number; x: number; y: number }
   | { type: 'AI_LAST_STAND' }
+  | { type: 'AI_SPAWN_SWITCH'; speckTypeId: 'basic' | 'heavy' | 'scout' }
 
 export interface HudData {
   players: Record<string, {

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -479,6 +479,10 @@ export class GameInstance {
         if (event.type === 'AI_LAST_STAND') {
           this.notify('⚠ ENEMY LAST STAND', '#ff4444')
         }
+
+        if (event.type === 'AI_SPAWN_SWITCH' && event.speckTypeId === 'heavy') {
+          this.notify('⚠ ENEMY SWITCHING TO HEAVY', '#ff8844')
+        }
       }
 
       // Retreat wave warning: 10+ player specks retreating = notify


### PR DESCRIPTION
Closes #1918

## Summary
- Adds `AI_SPAWN_SWITCH` event type to `SimEvent` union
- Emits the event from both AI spawn-mode code paths (aggressive random switch + balanced/macro counter-spawn) when switching to `'heavy'`
- Handles the event in `game-instance.ts` with `'⚠ ENEMY SWITCHING TO HEAVY'` orange notification
- Gives the player intel to adapt strategy (e.g. counter with scouts or spread specks)