### PR TITLE
feat(speck-wars): A-click attack-move command (Starcraft style)

### DIFF
--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -499,7 +499,7 @@ export function HUD() {
             <span>Drag — box select specks</span><span>1/2/3 — set spawn type</span>
             <span>E — select all · Esc — clear</span><span>Arrow/WASD — pan camera</span>
             <span style={{ color: 'rgba(74,247,196,0.7)' }}>Click rally with group → moves selected only</span><span style={{ color: 'rgba(74,247,196,0.7)' }}>Specks engage enemies en route (attack-move)</span>
-            <span>A — advance to outpost</span><span>C — center on base</span>
+            <span>A — attack-move mode + click</span><span>C — center on base</span>
             <span>B — rush enemy base</span><span>D — defend base</span>
             <span>Q — surge (2× spawn 8s)</span><span>V — snap camera to battle</span>
             <span>H — snap to home base</span><span>Minimap — click to rally</span>

--- a/src/app/speck-wars/components/phase-router.tsx
+++ b/src/app/speck-wars/components/phase-router.tsx
@@ -139,7 +139,7 @@ export function PhaseRouter({ children }: { children: React.ReactNode }) {
           <span>1/2/3 — spawn basic/heavy/scout</span>
           <span>Q — surge (2× spawn 8s)</span>
           <span>V — snap to battle</span>
-          <span>A — advance · B — rush · D — defend</span>
+          <span>A(+click) — attack-move · B — rush · D — defend</span>
           <span>X — speed · E — all · Esc — clear</span>
           <span>Minimap — click to rally</span>
           <span>Arrow keys / WASD — pan</span>

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -47,6 +47,7 @@ export class GameInstance {
   private retreatWarnedAt = -20000          // allow retreat warning after 20s
   private prevBaseUnderThreat = false
   private prevEnemyAdvance = false
+  private attackMovePending = false
 
   constructor(canvas: HTMLCanvasElement) {
     this.canvas = canvas
@@ -89,6 +90,12 @@ export class GameInstance {
       (wx, wy) => {
         this.sim.inputQueue.push({ type: 'RALLY', ownerId: 'player', x: wx, y: wy })
         this.renderer.showRallyPing(wx, wy)
+        if (this.attackMovePending) {
+          this.attackMovePending = false
+          if (this.canvas) this.canvas.style.cursor = 'default'
+          this.notify('⚔ ATTACK MOVE!', '#ff4f7b')
+          setTimeout(() => useSpeckWarsStore.getState().setNotification(null), 900)
+        }
       },
       () => useSpeckWarsStore.getState().togglePause(),   // Space
       () => this.clearRally(),                             // R — clear rally
@@ -106,7 +113,12 @@ export class GameInstance {
         this.camera.y = this.canvas.clientHeight / 2 - base.y * this.camera.zoom
       },
       () => { this.defend(); this.notify('🛡 DEFEND', '#4af7c4') },   // D — defend (rally to player base)
-      () => { this.advance(); this.notify('→ ADVANCE', '#ffd700') },  // A — advance to nearest non-player outpost
+      () => {                                              // A — enter attack-move mode
+        this.attackMovePending = true
+        if (this.canvas) this.canvas.style.cursor = 'crosshair'
+        this.notify('⚔ ATTACK MOVE — click target', '#ff6b35')
+        setTimeout(() => useSpeckWarsStore.getState().setNotification(null), 1500)
+      },
       () => { this.rush(); this.notify('⚡ RUSH!', '#ff4f7b') },      // B — rush enemy base
       (x1, y1, x2, y2) => {                                           // drag — box-select specks
         this.sim.inputQueue.push({ type: 'BOX_SELECT', ownerId: 'player', x1, y1, x2, y2 })
@@ -114,6 +126,11 @@ export class GameInstance {
       () => {                                                          // Escape — clear selection
         this.sim.inputQueue.push({ type: 'CLEAR_SELECT', ownerId: 'player' })
         this.sim.rallyPoints['player-selected'] = null
+        if (this.attackMovePending) {
+          this.attackMovePending = false
+          if (this.canvas) this.canvas.style.cursor = 'default'
+          useSpeckWarsStore.getState().setNotification(null)
+        }
       },
       () => { this.surge(); this.notify('⚡ SURGE ACTIVE!', '#ffd700') },  // Q — production surge
       () => { this.snapToAction() },                                        // V — snap camera to battle


### PR DESCRIPTION
Closes #2022

## Summary
- Press **A** to enter attack-move mode: canvas cursor → crosshair, notification shows "⚔ ATTACK MOVE — click target"
- Next left-click issues a normal rally (all rallies already engage enemies en route via `ATTACK_MOVE_PROXIMITY`) and confirms with "⚔ ATTACK MOVE!" flash
- **Escape** cancels attack-move mode and clears the prompt
- A key no longer triggers "advance to nearest outpost" macro (replaced by the Starcraft-ergonomic A+click pattern)
- Updated `?` help overlay and pre-game controls hint