### PR TITLE
feat(speck-wars): sub-group independent rally points persist after deselection

### DIFF
--- a/src/app/speck-wars/domain/simulation/speck-ai.ts
+++ b/src/app/speck-wars/domain/simulation/speck-ai.ts
@@ -24,6 +24,10 @@ export function runSpeckAI(sim: SimulationState) {
     // unselected specks with an active selection use no rally (auto-target)
     const getEffectiveRally = () => {
       if (meta.ownerId !== 'player') return sim.rallyPoints[meta.ownerId]
+      // Individual sub-group rally takes priority — persists across deselection
+      if (meta.assignedRallyX !== undefined && meta.assignedRallyY !== undefined) {
+        return { x: meta.assignedRallyX, y: meta.assignedRallyY }
+      }
       const hasSelection = sim.selectedSpeckIds.size > 0
       if (!hasSelection) return sim.rallyPoints['player']
       const isSelected = sim.selectedSpeckIds.has(meta.id)
@@ -55,6 +59,11 @@ export function runSpeckAI(sim: SimulationState) {
         meta.targetId = closeTarget  // null = pure move toward rally, non-null = attack en route
         meta.state = 'moving'
         continue
+      }
+      // Arrived at individual rally — clear assignment so speck reverts to normal AI
+      if (meta.assignedRallyX !== undefined) {
+        meta.assignedRallyX = undefined
+        meta.assignedRallyY = undefined
       }
     }
 

--- a/src/app/speck-wars/domain/simulation/tick.ts
+++ b/src/app/speck-wars/domain/simulation/tick.ts
@@ -162,6 +162,13 @@ function consumeInputs(sim: SimulationState) {
       const hasSelection = event.ownerId === 'player' && sim.selectedSpeckIds.size > 0
       if (hasSelection) {
         sim.rallyPoints['player-selected'] = { x: event.x, y: event.y }
+        // Stamp individual rally on each selected speck — persists after deselection
+        for (let i = 0; i < sim.speckCount; i++) {
+          const meta = sim.speckMeta[i]
+          if (!meta || !sim.speckIds[i] || !sim.selectedSpeckIds.has(meta.id)) continue
+          meta.assignedRallyX = event.x
+          meta.assignedRallyY = event.y
+        }
       } else {
         sim.rallyPoints[event.ownerId] = { x: event.x, y: event.y }
       }

--- a/src/app/speck-wars/domain/types.ts
+++ b/src/app/speck-wars/domain/types.ts
@@ -8,6 +8,8 @@ export interface SpeckMeta {
   targetId: string | null
   attackCooldown: number   // ms remaining until next attack
   kills: number            // enemies killed; 3+ = veteran (gold ring, +20% damage)
+  assignedRallyX?: number  // individual sub-group rally — persists after deselection
+  assignedRallyY?: number
 }
 
 export interface BuildingEntity {


### PR DESCRIPTION
Closes #2021

## Summary
- Box-select a group of specks → rally them → they remember the waypoint even after deselection
- Multiple independent groups can be moving to different destinations simultaneously (StarCraft-style)
- Individual rally (`assignedRallyX/Y` on `SpeckMeta`) clears automatically on arrival, reverting to normal AI
- No UX change needed — works transparently with existing drag-select and rally interactions

## How it works
- `RALLY` in tick.ts now stamps `assignedRallyX/Y` on every selected speck (in addition to setting `player-selected` rally)
- `getEffectiveRally()` in speck-ai.ts checks individual assignment first, before selection/global rally
- On arrival (dist ≤ threshold), the assignment is deleted and the speck resumes normal behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)