### PR TITLE
fix(speck-wars): W/S camera pan + fix advance button tooltip

### DIFF
--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -502,7 +502,7 @@ export function HUD() {
             <span>🖱 Click — rally all specks</span><span>Space — pause</span>
             <span>Scroll — zoom</span><span>R / Right-click — clear rally</span>
             <span>Drag — box select specks</span><span>1/2/3 — set spawn type</span>
-            <span>E — select all · Esc — clear</span><span>Arrow/WASD — pan camera</span>
+            <span>E — select all · Esc — clear</span><span>Arrow keys / W S — pan camera</span>
             <span style={{ color: 'rgba(74,247,196,0.7)' }}>Click rally with group → moves selected only</span><span style={{ color: 'rgba(74,247,196,0.7)' }}>Specks engage enemies en route (attack-move)</span>
             <span>A — attack-move mode + click</span><span>C — center on base</span>
             <span>B — rush enemy base</span><span>D — defend base</span>
@@ -899,7 +899,7 @@ export function HUD() {
           </button>
           <button
             onClick={() => gameActions.advance?.()}
-            title="[A] Advance — rally to nearest outpost"
+            title="Advance — rally to nearest outpost"
             style={{
               padding: '6px 10px',
               fontSize: 11,

--- a/src/app/speck-wars/components/phase-router.tsx
+++ b/src/app/speck-wars/components/phase-router.tsx
@@ -142,7 +142,7 @@ export function PhaseRouter({ children }: { children: React.ReactNode }) {
           <span>A(+click) — attack-move · B — rush · D — defend</span>
           <span>X — speed · E — all · Esc — clear</span>
           <span>Minimap — click to rally</span>
-          <span>Arrow keys / WASD — pan</span>
+          <span>Arrow keys / W S — pan</span>
         </div>
         {/* Daily tip */}
         {(() => {

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -569,9 +569,9 @@ export class GameInstance {
     if (this.inputHandler) {
       const panSpeed = 450  // px/s in world space
       const dtSec = dt / 1000
-      if (this.inputHandler.isKeyHeld('ArrowUp'))
+      if (this.inputHandler.isKeyHeld('ArrowUp') || this.inputHandler.isKeyHeld('KeyW'))
         this.camera.y += panSpeed * dtSec
-      if (this.inputHandler.isKeyHeld('ArrowDown'))
+      if (this.inputHandler.isKeyHeld('ArrowDown') || this.inputHandler.isKeyHeld('KeyS'))
         this.camera.y -= panSpeed * dtSec
       if (this.inputHandler.isKeyHeld('ArrowLeft'))
         this.camera.x += panSpeed * dtSec


### PR DESCRIPTION
## Summary
- Add W/S keys as camera pan (arrow keys already worked; A/D are bound to attack-move and defend)
- Fix advance button tooltip: removed stale "[A] Advance" text since A now triggers attack-move mode
- Update HUD help overlay and phase-router controls hint to say "Arrow keys / W S — pan"

## Why
The help overlay claimed WASD pans the camera but only arrow keys worked. A and D can't pan since they're bound to attack-move and defend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)