### PR TITLE
feat(speck-wars): Ctrl+4-9 control groups — save and recall speck selections

### DIFF
--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -503,6 +503,7 @@ export function HUD() {
             <span>Scroll — zoom</span><span>R / Right-click — clear rally</span>
             <span>Drag — box select specks</span><span>1/2/3 — set spawn type</span>
             <span>E — select all · Esc — clear</span><span>Arrow keys / W S — pan camera</span>
+            <span>Ctrl+4-9 — save group</span><span>4-9 — recall group</span>
             <span style={{ color: 'rgba(74,247,196,0.7)' }}>Click rally with group → moves selected only</span><span style={{ color: 'rgba(74,247,196,0.7)' }}>Specks engage enemies en route (attack-move)</span>
             <span>A — attack-move mode + click</span><span>C — center on base</span>
             <span>B — rush enemy base</span><span>D — defend base</span>

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -48,6 +48,7 @@ export class GameInstance {
   private prevBaseUnderThreat = false
   private prevEnemyAdvance = false
   private attackMovePending = false
+  private controlGroups = new Map<number, string[]>()
   private cinematicMs = 0
 
   constructor(canvas: HTMLCanvasElement) {
@@ -151,6 +152,28 @@ export class GameInstance {
         this.sim.inputQueue.push({ type: 'BOX_SELECT', ownerId: 'player', x1: -1, y1: -1, x2: 3001, y2: 3001 })
       },
       () => { this.sacrifice() },                                       // F — sacrifice specks to repair base
+      (slot: number) => {                                               // Ctrl+4-9 — save control group
+        const saved = [...this.sim.selectedSpeckIds]
+        this.controlGroups.set(slot, saved)
+        if (saved.length > 0) {
+          useSpeckWarsStore.getState().setNotification({ message: `★ Group ${slot} — ${saved.length} specks`, color: '#4af7c4' })
+          setTimeout(() => useSpeckWarsStore.getState().setNotification(null), 900)
+        }
+      },
+      (slot: number) => {                                               // 4-9 — recall control group
+        const saved = this.controlGroups.get(slot)
+        if (!saved || saved.length === 0) return
+        // Filter to living specks
+        const aliveIds = new Set<string>()
+        for (let i = 0; i < this.sim.speckCount; i++) {
+          if (this.sim.speckIds[i] && this.sim.speckMeta[i]) aliveIds.add(this.sim.speckIds[i])
+        }
+        this.sim.selectedSpeckIds.clear()
+        for (const id of saved) {
+          if (aliveIds.has(id)) this.sim.selectedSpeckIds.add(id)
+        }
+        this.sim.rallyPoints['player-selected'] = this.sim.rallyPoints['player']
+      },
     )
     useSpeckWarsStore.getState().setGameActions({
       defend: () => { this.defend(); this.notify('🛡 DEFEND', '#4af7c4') },

--- a/src/app/speck-wars/input/input-handler.ts
+++ b/src/app/speck-wars/input/input-handler.ts
@@ -21,6 +21,8 @@ export class InputHandler {
   private onCycleSpeed?: () => void
   private onSelectAll?: () => void
   private onSacrifice?: () => void
+  private onSaveControlGroup?: (slot: number) => void
+  private onRecallControlGroup?: (slot: number) => void
   private heldKeys = new Set<string>()
   private isDragging = false
   private lastX = 0
@@ -56,6 +58,8 @@ export class InputHandler {
     onCycleSpeed?: () => void,
     onSelectAll?: () => void,
     onSacrifice?: () => void,
+    onSaveControlGroup?: (slot: number) => void,
+    onRecallControlGroup?: (slot: number) => void,
   ) {
     this.canvas = canvas
     this.camera = camera
@@ -76,6 +80,8 @@ export class InputHandler {
     this.onCycleSpeed = onCycleSpeed
     this.onSelectAll = onSelectAll
     this.onSacrifice = onSacrifice
+    this.onSaveControlGroup = onSaveControlGroup
+    this.onRecallControlGroup = onRecallControlGroup
     this.attach()
   }
 
@@ -300,6 +306,14 @@ export class InputHandler {
       this.onSelectAll?.()
     } else if (e.code === 'KeyF') {
       this.onSacrifice?.()
+    } else if (['Digit4','Digit5','Digit6','Digit7','Digit8','Digit9'].includes(e.code)) {
+      const slot = parseInt(e.code.replace('Digit', ''))
+      if (e.ctrlKey) {
+        e.preventDefault()
+        this.onSaveControlGroup?.(slot)
+      } else {
+        this.onRecallControlGroup?.(slot)
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
StarCraft-style control groups for multi-group speck management:

- **Ctrl+4-9**: Save current selection to group slot 4-9
- **4-9**: Recall group (filters out dead specks, clears old selection)
- Brief "★ Group 4 — 7 specks" notification on save

Works with the existing sub-group `assignedRallyX/Y` system — each recalled group can be rallied to an independent waypoint that persists even after deselecting.

## Example workflow
1. Select front-line specks → `Ctrl+4` to save
2. Select flanking specks → `Ctrl+5` to save
3. Rally group 4 to one outpost, group 5 to another
4. Press `4` / `5` at any time to reselect and redirect

## Help overlay updated
Added "Ctrl+4-9 — save group · 4-9 — recall group" to the in-game help overlay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)