### PR TITLE
feat(speck-wars): N key restores advance-to-outpost shortcut

### DIFF
--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -504,7 +504,7 @@ export function HUD() {
             <span>Drag — box select specks</span><span>1/2/3 — set spawn type</span>
             <span>E — select all · Esc — clear</span><span>Arrow keys / W S — pan camera</span>
             <span style={{ color: 'rgba(74,247,196,0.7)' }}>Click rally with group → moves selected only</span><span style={{ color: 'rgba(74,247,196,0.7)' }}>Specks engage enemies en route (attack-move)</span>
-            <span>A — attack-move mode + click</span><span>C — center on base</span>
+            <span>A — attack-move + click · N — advance</span><span>C — center on base</span>
             <span>B — rush enemy base</span><span>D — defend base</span>
             <span>Q — surge (2× spawn 8s)</span><span>V — snap camera to battle</span>
             <span>H — snap to home base</span><span>Minimap — click to rally</span>
@@ -899,7 +899,7 @@ export function HUD() {
           </button>
           <button
             onClick={() => gameActions.advance?.()}
-            title="Advance — rally to nearest outpost"
+            title="[N] Advance — rally to nearest outpost"
             style={{
               padding: '6px 10px',
               fontSize: 11,

--- a/src/app/speck-wars/components/phase-router.tsx
+++ b/src/app/speck-wars/components/phase-router.tsx
@@ -139,7 +139,7 @@ export function PhaseRouter({ children }: { children: React.ReactNode }) {
           <span>1/2/3 — spawn basic/heavy/scout</span>
           <span>Q — surge (2× spawn 8s)</span>
           <span>V — snap to battle</span>
-          <span>A(+click) — attack-move · B — rush · D — defend</span>
+          <span>A(+click) — attack-move · N — advance · B — rush · D — defend</span>
           <span>X — speed · E — all · Esc — clear</span>
           <span>Minimap — click to rally</span>
           <span>Arrow keys / W S — pan</span>

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -117,6 +117,7 @@ export class GameInstance {
         if (this.canvas) this.canvas.style.cursor = 'crosshair'
         this.notify('⚔ ATTACK MOVE — click target', '#ff6b35', 1500)
       },
+      () => { this.advance(); this.notify('→ ADVANCE', '#ffd700') },  // N — advance to nearest outpost
       () => { this.rush(); this.notify('⚡ RUSH!', '#ff4f7b') },      // B — rush enemy base
       (x1, y1, x2, y2) => {                                           // drag — box-select specks
         this.sim.inputQueue.push({ type: 'BOX_SELECT', ownerId: 'player', x1, y1, x2, y2 })

--- a/src/app/speck-wars/input/input-handler.ts
+++ b/src/app/speck-wars/input/input-handler.ts
@@ -11,6 +11,7 @@ export class InputHandler {
   private onRecenterCamera?: () => void
   private onDefend?: () => void
   private onAdvance?: () => void
+  private onAdvanceOutpost?: () => void
   private onRush?: () => void
   private onBoxSelect?: (x1: number, y1: number, x2: number, y2: number) => void
   private onClearSelect?: () => void
@@ -46,6 +47,7 @@ export class InputHandler {
     onRecenterCamera?: () => void,
     onDefend?: () => void,
     onAdvance?: () => void,
+    onAdvanceOutpost?: () => void,
     onRush?: () => void,
     onBoxSelect?: (x1: number, y1: number, x2: number, y2: number) => void,
     onClearSelect?: () => void,
@@ -66,6 +68,7 @@ export class InputHandler {
     this.onRecenterCamera = onRecenterCamera
     this.onDefend = onDefend
     this.onAdvance = onAdvance
+    this.onAdvanceOutpost = onAdvanceOutpost
     this.onRush = onRush
     this.onBoxSelect = onBoxSelect
     this.onClearSelect = onClearSelect
@@ -282,6 +285,8 @@ export class InputHandler {
       this.onDefend?.()
     } else if (e.code === 'KeyA') {
       this.onAdvance?.()
+    } else if (e.code === 'KeyN') {
+      this.onAdvanceOutpost?.()
     } else if (e.code === 'KeyB') {
       this.onRush?.()
     } else if (e.code === 'KeyQ') {


### PR DESCRIPTION
## Summary
A was repurposed for attack-move mode in #2031. This adds **N** as the shortcut for "advance to nearest non-player outpost" (old A behavior).

- `N` → `advance()` → rally to nearest outpost
- Help overlay: "A — attack-move + click · N — advance"
- Phase-router hint: "A(+click) — attack-move · N — advance · B — rush · D — defend"
- Advance button tooltip updated to show `[N]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)