### PR TITLE
fix(speck-wars): advance button label → N (was → A)

### DIFF
--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -914,7 +914,7 @@ export function HUD() {
               fontFamily: 'monospace',
             }}
           >
-            → A
+            → N
           </button>
           <button
             onClick={() => gameActions.rush?.()}


### PR DESCRIPTION
The advance HUD button showed "→ A" but A now triggers attack-move mode. N is the new advance shortcut. Updates the button label to "→ N".

🤖 Generated with [Claude Code](https://claude.com/claude-code)