### PR TITLE
feat(speck-wars): minimap indicators — AI rally crosshair + capture progress ring (#1806 #1926 #2024)

### DIFF
--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -281,15 +281,33 @@ export function HUD() {
                   : b.ownerId === 'ai' ? colorHex(AI_COLOR)
                   : '#888888'
                 const r = b.typeId === 'base' ? 4 : 2.5
+                const ci = b.typeId === 'outpost' ? (hud.captureInfo?.[b.id] ?? null) : null
+                const bx = b.x * SCALE
+                const by = b.y * SCALE
                 return (
-                  <circle
-                    key={b.id}
-                    cx={b.x * SCALE}
-                    cy={b.y * SCALE}
-                    r={r}
-                    fill={fill}
-                    opacity={0.9}
-                  />
+                  <g key={b.id}>
+                    <circle
+                      cx={bx}
+                      cy={by}
+                      r={r}
+                      fill={fill}
+                      opacity={0.9}
+                    />
+                    {ci && ci.progress > 0 && (() => {
+                      const sideColor = ci.side === 'player' ? '#4af7c4' : '#ff5555'
+                      return (
+                        <circle
+                          cx={bx} cy={by}
+                          r={4 + ci.progress * 3}
+                          fill="none"
+                          stroke={sideColor}
+                          strokeWidth={1}
+                          opacity={0.8 - ci.progress * 0.3}
+                          style={{ pointerEvents: 'none' }}
+                        />
+                      )
+                    })()}
+                  </g>
                 )
               })}
               {/* Rally point crosshair */}
@@ -300,6 +318,17 @@ export function HUD() {
                   <g>
                     <line x1={rx - 4} y1={ry} x2={rx + 4} y2={ry} stroke="#ffffff" strokeWidth={1} opacity={0.6} />
                     <line x1={rx} y1={ry - 4} x2={rx} y2={ry + 4} stroke="#ffffff" strokeWidth={1} opacity={0.6} />
+                  </g>
+                )
+              })()}
+              {/* AI rally point crosshair */}
+              {hud.minimap.aiRallyPoint && (() => {
+                const ax = hud.minimap.aiRallyPoint.x * SCALE
+                const ay = hud.minimap.aiRallyPoint.y * SCALE
+                return (
+                  <g>
+                    <line x1={ax - 5} y1={ay} x2={ax + 5} y2={ay} stroke="rgba(255,80,80,0.7)" strokeWidth={1.5} />
+                    <line x1={ax} y1={ay - 5} x2={ax} y2={ay + 5} stroke="rgba(255,80,80,0.7)" strokeWidth={1.5} />
                   </g>
                 )
               })()}
@@ -339,15 +368,33 @@ export function HUD() {
                   : b.ownerId === 'ai' ? colorHex(AI_COLOR)
                   : '#888888'
                 const r = b.typeId === 'base' ? 4 : 2.5
+                const ci = b.typeId === 'outpost' ? (hud.captureInfo?.[b.id] ?? null) : null
+                const bx = b.x * SCALE
+                const by = b.y * SCALE
                 return (
-                  <circle
-                    key={b.id}
-                    cx={b.x * SCALE}
-                    cy={b.y * SCALE}
-                    r={r}
-                    fill={fill}
-                    opacity={0.9}
-                  />
+                  <g key={b.id}>
+                    <circle
+                      cx={bx}
+                      cy={by}
+                      r={r}
+                      fill={fill}
+                      opacity={0.9}
+                    />
+                    {ci && ci.progress > 0 && (() => {
+                      const sideColor = ci.side === 'player' ? '#4af7c4' : '#ff5555'
+                      return (
+                        <circle
+                          cx={bx} cy={by}
+                          r={4 + ci.progress * 3}
+                          fill="none"
+                          stroke={sideColor}
+                          strokeWidth={1}
+                          opacity={0.8 - ci.progress * 0.3}
+                          style={{ pointerEvents: 'none' }}
+                        />
+                      )
+                    })()}
+                  </g>
                 )
               })}
               {/* Rally point crosshair */}
@@ -358,6 +405,17 @@ export function HUD() {
                   <g>
                     <line x1={rx - 4} y1={ry} x2={rx + 4} y2={ry} stroke="#ffffff" strokeWidth={1} opacity={0.6} />
                     <line x1={rx} y1={ry - 4} x2={rx} y2={ry + 4} stroke="#ffffff" strokeWidth={1} opacity={0.6} />
+                  </g>
+                )
+              })()}
+              {/* AI rally point crosshair */}
+              {hud.minimap.aiRallyPoint && (() => {
+                const ax = hud.minimap.aiRallyPoint.x * SCALE
+                const ay = hud.minimap.aiRallyPoint.y * SCALE
+                return (
+                  <g>
+                    <line x1={ax - 5} y1={ay} x2={ax + 5} y2={ay} stroke="rgba(255,80,80,0.7)" strokeWidth={1.5} />
+                    <line x1={ax} y1={ay - 5} x2={ax} y2={ay + 5} stroke="rgba(255,80,80,0.7)" strokeWidth={1.5} />
                   </g>
                 )
               })()}

--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -851,6 +851,58 @@ export function HUD() {
         </div>
       )}
 
+      {/* Selection info panel — bottom center */}
+      {phase === 'playing' && (
+        <div style={{
+          position: 'absolute',
+          bottom: 70,
+          left: '50%',
+          transform: 'translateX(-50%)',
+          opacity: hud && (hud.selectedSpeckCount ?? 0) > 0 ? 1 : 0,
+          transition: 'opacity 150ms ease',
+          pointerEvents: 'none',
+          background: 'rgba(0,0,0,0.65)',
+          border: '1px solid rgba(255,255,255,0.12)',
+          borderRadius: 6,
+          padding: '7px 12px',
+          minWidth: 130,
+          fontFamily: 'monospace',
+          whiteSpace: 'nowrap',
+        }}>
+          <div style={{
+            fontSize: 9, letterSpacing: 2, color: '#ffffff', opacity: 0.9, marginBottom: 5,
+          }}>
+            SELECTED {hud?.selectedSpeckCount ?? 0}
+          </div>
+          {hud?.selectedComposition && Object.entries(hud.selectedComposition.types)
+            .sort(([a], [b]) => a.localeCompare(b))
+            .map(([typeId, count]) => (
+              <div key={typeId} style={{
+                display: 'flex', alignItems: 'center', gap: 6,
+                fontSize: 9, color: 'rgba(255,255,255,0.7)', marginBottom: 2,
+              }}>
+                <span style={{
+                  display: 'inline-block', width: 7, height: 7, flexShrink: 0,
+                  borderRadius: typeId === 'heavy' ? 1 : '50%',
+                  background: '#4af7c4',
+                  transform: typeId === 'heavy' ? 'rotate(45deg)' : 'none',
+                }} />
+                <span style={{ flex: 1, letterSpacing: 1 }}>
+                  {typeId.charAt(0).toUpperCase() + typeId.slice(1)}
+                </span>
+                <span style={{ color: '#ffffff' }}>{count}</span>
+              </div>
+            ))
+          }
+          {hud?.selectedComposition && (hud.selectedComposition.veteranCount > 0 || hud.selectedComposition.eliteCount > 0) && (
+            <div style={{ fontSize: 8, color: 'rgba(255,215,0,0.7)', marginTop: 3, letterSpacing: 1 }}>
+              {hud.selectedComposition.eliteCount > 0 && `✦ ${hud.selectedComposition.eliteCount} elite  `}
+              {hud.selectedComposition.veteranCount > 0 && `⭐ ${hud.selectedComposition.veteranCount} vet`}
+            </div>
+          )}
+        </div>
+      )}
+
       {/* Mobile action buttons — bottom right */}
       {phase === 'playing' && (
         <div style={{
@@ -858,25 +910,6 @@ export function HUD() {
           display: 'flex', flexDirection: 'column', alignItems: 'flex-end', gap: 6,
           pointerEvents: 'auto',
         }}>
-          {/* Squad indicator: shown when player has specks selected */}
-          {hud && (hud.selectedSpeckCount ?? 0) > 0 && (
-            <div style={{
-              fontSize: 9, letterSpacing: 1.5, color: '#ffffff', opacity: 0.7,
-              textAlign: 'center', marginBottom: 4,
-            }}>
-              SQUAD: {hud.selectedSpeckCount} · Drag to reselect · Esc to clear
-              {hud.selectedComposition && (
-                <div style={{ fontSize: 9, color: 'rgba(74,247,196,0.75)', marginTop: 2, letterSpacing: 1 }}>
-                  {Object.entries(hud.selectedComposition.types)
-                    .sort(([a], [b]) => a.localeCompare(b))
-                    .map(([typeId, count]) => `${count} ${typeId}`)
-                    .join(' · ')}
-                  {hud.selectedComposition.eliteCount > 0 && ` · ✦${hud.selectedComposition.eliteCount} elite`}
-                  {hud.selectedComposition.veteranCount > 0 && ` · ⭐${hud.selectedComposition.veteranCount} vet`}
-                </div>
-              )}
-            </div>
-          )}
           <div style={{
             display: 'flex', gap: 6,
           }}>

--- a/src/app/speck-wars/domain/simulation/tick.ts
+++ b/src/app/speck-wars/domain/simulation/tick.ts
@@ -325,6 +325,7 @@ function emitHudUpdate(sim: SimulationState) {
     specks: minimapSpecks,
     buildings: minimapBuildings,
     rallyPoint: sim.rallyPoints['player'] ?? null,
+    aiRallyPoint: sim.rallyPoints['ai'] ?? null,
   }
 
   const outpostFortify: Record<string, number> = {}

--- a/src/app/speck-wars/domain/types.ts
+++ b/src/app/speck-wars/domain/types.ts
@@ -124,5 +124,6 @@ export interface HudData {
     specks: { x: number; y: number; ownerId: string }[]
     buildings: { id: string; x: number; y: number; ownerId: string; typeId: string }[]
     rallyPoint: { x: number; y: number } | null
+    aiRallyPoint: { x: number; y: number } | null
   }
 }

--- a/src/app/speck-wars/rendering/layers/speck-layer.ts
+++ b/src/app/speck-wars/rendering/layers/speck-layer.ts
@@ -134,10 +134,10 @@ export class SpeckLayer {
           }
         }
 
-        // Selection ring: bright white ring around selected specks
+        // Selection ring: warm yellow ring around selected specks (distinct from veteran gold/white)
         const speckId = sim.speckMeta[i]?.id ?? ''
         if (selectedSpeckIds?.has(speckId)) {
-          this.gfx.lineStyle(1.5, 0xffffff, 0.9)
+          this.gfx.lineStyle(1.5, 0xffe066, 0.92)
           this.gfx.drawCircle(sim.speckX[i], sim.speckY[i], (stype ? stype.size / 4 : 0.75) + 4)
           this.gfx.lineStyle(0)
         }


### PR DESCRIPTION
## Summary
- **#2024** Selection info panel: warm-yellow selection ring, dedicated bottom-center SELECTED panel with per-type breakdown and veteran/elite badges (150ms opacity fade)
- **#1806** Minimap AI rally indicator: red crosshair on both minimap instances shows where the AI is sending its forces
- **#1926** Minimap capture alert: a ring grows around contested outpost dots as capture progresses (teal = player capturing, red = AI capturing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)