### PR TITLE
feat(speck-wars): per-building rally points — spawned specks auto-march on creation (#2023)

### DIFF
--- a/src/app/speck-wars/domain/simulation/spawner.ts
+++ b/src/app/speck-wars/domain/simulation/spawner.ts
@@ -66,6 +66,12 @@ export function updateSpawners(sim: SimulationState, dt: number) {
         attackCooldown: 0,
         kills: 0,
       }
+      // Auto-assign the building's per-building rally point so the speck marches there on spawn
+      const sourceBuildingRally = building.rallyPoint
+      if (sourceBuildingRally) {
+        meta.assignedRallyX = sourceBuildingRally.x
+        meta.assignedRallyY = sourceBuildingRally.y
+      }
       addSpeck(sim, meta, sx, sy, building.id)
     }
   }

--- a/src/app/speck-wars/domain/simulation/tick.ts
+++ b/src/app/speck-wars/domain/simulation/tick.ts
@@ -171,6 +171,14 @@ function consumeInputs(sim: SimulationState) {
         }
       } else {
         sim.rallyPoints[event.ownerId] = { x: event.x, y: event.y }
+        // Update per-building rally for all player buildings
+        if (event.ownerId === 'player') {
+          for (const building of Object.values(sim.buildings)) {
+            if (building.ownerId === 'player') {
+              building.rallyPoint = { x: event.x, y: event.y }
+            }
+          }
+        }
       }
     }
     if (event.type === 'SET_SPAWN_TYPE') {

--- a/src/app/speck-wars/domain/types.ts
+++ b/src/app/speck-wars/domain/types.ts
@@ -27,6 +27,7 @@ export interface BuildingEntity {
   captureSide?: string | null   // which player is currently winning capture
   fortifyDuration?: number      // ms continuously held — resets on capture
   lastDamagedAt?: number        // Date.now() timestamp of last damage taken (for regen cooldown)
+  rallyPoint?: { x: number; y: number } | null  // per-building rally; specks auto-march here on spawn
 }
 
 export interface Player {


### PR DESCRIPTION
## Summary
Setting a global rally (right-click in world space) now also stamps that rally point on every player-owned building. When a new speck spawns from a building with a rally set, it immediately receives `assignedRallyX/Y` and starts marching toward the rally destination without waiting for an explicit command.

This eliminates the "specks pool at base" problem — fresh units automatically fan out to wherever you last directed your forces.

Partial #2023 (building selection UI + per-building-independent rally is future work).

🤖 Generated with [Claude Code](https://claude.com/claude-code)