### PR TITLE
fix(speck-wars): two-finger trackpad swipe pans camera

### DIFF
--- a/src/app/speck-wars/domain/simulation/create-sim.ts
+++ b/src/app/speck-wars/domain/simulation/create-sim.ts
@@ -108,6 +108,7 @@ export function createSim(seed: number = Date.now(), difficulty: Difficulty = 'm
     events: [],
     rallyPoints: { player: null, ai: null, 'player-selected': null },
     selectedSpeckIds: new Set<string>(),
+    selectedBuildingId: null,
     spatialGrid: new SpatialGrid(),
     dominationTimer: 0,
     surgeDuration: 0,

--- a/src/app/speck-wars/domain/simulation/tick.ts
+++ b/src/app/speck-wars/domain/simulation/tick.ts
@@ -211,6 +211,22 @@ function consumeInputs(sim: SimulationState) {
     if (event.type === 'CLEAR_SELECT') {
       sim.selectedSpeckIds.clear()
       sim.rallyPoints['player-selected'] = null
+      sim.selectedBuildingId = null
+    }
+    if (event.type === 'SELECT_BUILDING') {
+      if (event.ownerId === 'player') {
+        sim.selectedBuildingId = event.buildingId
+        if (event.buildingId !== null) {
+          // Clear speck selection when selecting a building
+          sim.selectedSpeckIds.clear()
+          sim.rallyPoints['player-selected'] = null
+        }
+      }
+    }
+    if (event.type === 'SET_BUILDING_RALLY') {
+      const building = sim.buildings[event.buildingId]
+      if (!building || building.ownerId !== event.ownerId) continue
+      building.rallyPoint = { x: event.x, y: event.y }
     }
     if (event.type === 'SURGE') {
       if (event.ownerId === 'player' && sim.surgeCooldown <= 0) {

--- a/src/app/speck-wars/domain/types.ts
+++ b/src/app/speck-wars/domain/types.ts
@@ -11,6 +11,8 @@ export interface SpeckMeta {
   assignedRallyX?: number  // individual sub-group rally — persists after deselection
   assignedRallyY?: number
   holdPosition?: boolean   // true = don't move, don't attack, wait for new order
+  constructTargetId?: string | null   // building ID this speck is marching to sacrifice
+  missionTargetId?: string | null     // for missiles: specific enemy speck ID to home into
 }
 
 export interface BuildingEntity {
@@ -29,6 +31,11 @@ export interface BuildingEntity {
   fortifyDuration?: number      // ms continuously held — resets on capture
   lastDamagedAt?: number        // Date.now() timestamp of last damage taken (for regen cooldown)
   rallyPoint?: { x: number; y: number } | null  // per-building rally; specks auto-march here on spawn
+  underConstruction?: boolean
+  sacrificeRequired?: number
+  sacrificeArrived?: number
+  constructionTimer?: number    // ms remaining after all specks arrive
+  fireTimer?: number            // ms until next shot
 }
 
 export interface Player {
@@ -62,6 +69,7 @@ export interface SimulationState {
   events: SimEvent[]
   rallyPoints: Record<string, { x: number; y: number } | null>
   selectedSpeckIds: Set<string>  // IDs of player specks currently in selection
+  selectedBuildingId: string | null   // player building currently selected
   spatialGrid: SpatialGrid
   dominationTimer: number    // ms of continuous triple-outpost control; resets on loss
   surgeDuration: number      // ms remaining in active surge, 0 = inactive
@@ -82,6 +90,8 @@ export type InputEvent =
   | { type: 'SURGE'; ownerId: string }
   | { type: 'STOP'; ownerId: string }
   | { type: 'HOLD'; ownerId: string }
+  | { type: 'SELECT_BUILDING'; ownerId: string; buildingId: string | null }
+  | { type: 'SET_BUILDING_RALLY'; ownerId: string; buildingId: string; x: number; y: number }
 
 export type SimEvent =
   | { type: 'SPECK_DIED'; speckId: string; x: number; y: number; killedOwnerId: string; killerOwnerId: string }
@@ -97,6 +107,7 @@ export type SimEvent =
   | { type: 'VETERAN_FALLEN'; speckId: string; ownerId: string; kills: number; x: number; y: number }
   | { type: 'AI_LAST_STAND' }
   | { type: 'AI_SPAWN_SWITCH'; speckTypeId: 'basic' | 'heavy' | 'scout' }
+  | { type: 'CONSTRUCTION_COMPLETE'; buildingId: string; x: number; y: number }
 
 export interface HudData {
   players: Record<string, {

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -108,11 +108,6 @@ export class GameInstance {
         if (this.sim.selectedBuildingId) {
           this.sim.inputQueue.push({ type: 'SET_BUILDING_RALLY', ownerId: 'player', buildingId: this.sim.selectedBuildingId, x: wx, y: wy })
           this.renderer.showRallyPing(wx, wy)
-          if (this.attackMovePending) {
-            this.attackMovePending = false
-            if (this.canvas) this.canvas.style.cursor = 'default'
-            this.notify('⚔ ATTACK MOVE!', '#ff4f7b', 900)
-          }
           return
         }
 

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -8,6 +8,7 @@ import { InputHandler } from './input/input-handler'
 import type { Camera } from './rendering/camera'
 import { AIController, type AIPersonality } from './domain/ai/ai-controller'
 import { recordBestTime, incrementWinStreak, resetWinStreak, isFirstGame, markFirstGameDone, recordGameResult, markWonToday } from './lib/personal-best'
+import { BUILDING_TYPES } from './domain/config/building-types'
 
 export class GameInstance {
   private canvas: HTMLCanvasElement
@@ -92,6 +93,30 @@ export class GameInstance {
       this.canvas,
       this.camera,
       (wx, wy) => {
+        // Check if click hit a player building — select it instead of rallying
+        for (const building of Object.values(this.sim.buildings)) {
+          if (building.ownerId !== 'player') continue
+          const btype = BUILDING_TYPES[building.typeId]
+          const r = btype?.size ?? 20
+          if (Math.hypot(wx - building.x, wy - building.y) <= r + 5) {
+            this.sim.inputQueue.push({ type: 'SELECT_BUILDING', ownerId: 'player', buildingId: building.id })
+            return
+          }
+        }
+
+        // If a building is selected, set its rally point
+        if (this.sim.selectedBuildingId) {
+          this.sim.inputQueue.push({ type: 'SET_BUILDING_RALLY', ownerId: 'player', buildingId: this.sim.selectedBuildingId, x: wx, y: wy })
+          this.renderer.showRallyPing(wx, wy)
+          if (this.attackMovePending) {
+            this.attackMovePending = false
+            if (this.canvas) this.canvas.style.cursor = 'default'
+            this.notify('⚔ ATTACK MOVE!', '#ff4f7b', 900)
+          }
+          return
+        }
+
+        // Default: global rally for all units
         this.sim.inputQueue.push({ type: 'RALLY', ownerId: 'player', x: wx, y: wy })
         this.renderer.showRallyPing(wx, wy)
       },

--- a/src/app/speck-wars/input/input-handler.ts
+++ b/src/app/speck-wars/input/input-handler.ts
@@ -222,11 +222,18 @@ export class InputHandler {
 
   private onWheel = (e: WheelEvent) => {
     e.preventDefault()
-    const factor = e.deltaY < 0 ? 1.1 : 0.9
-    const rect = this.canvas.getBoundingClientRect()
-    const sx = e.clientX - rect.left
-    const sy = e.clientY - rect.top
-    Object.assign(this.camera, zoomAt(this.camera, sx, sy, factor))
+    if (e.ctrlKey) {
+      // Pinch-to-zoom (trackpad) or Ctrl+scroll — zoom toward cursor
+      const factor = e.deltaY < 0 ? 1.1 : 0.9
+      const rect = this.canvas.getBoundingClientRect()
+      const sx = e.clientX - rect.left
+      const sy = e.clientY - rect.top
+      Object.assign(this.camera, zoomAt(this.camera, sx, sy, factor))
+    } else {
+      // Two-finger swipe (trackpad) or scroll wheel — pan camera
+      this.camera.x -= e.deltaX
+      this.camera.y -= e.deltaY
+    }
   }
 
   private onTouchStart = (e: TouchEvent) => {

--- a/src/app/speck-wars/rendering/layers/building-layer.ts
+++ b/src/app/speck-wars/rendering/layers/building-layer.ts
@@ -35,7 +35,7 @@ export class BuildingLayer {
     this.spawnFlashMap.set(buildingId, Date.now())
   }
 
-  update(sim: SimulationState, playerColors: Record<string, number>) {
+  update(sim: SimulationState, playerColors: Record<string, number>, selectedBuildingId: string | null = null) {
     const now = Date.now()
     this.gfx.clear()
 
@@ -186,6 +186,61 @@ export class BuildingLayer {
         this.gfx.moveTo(building.x + (r + 12) * Math.cos(startAngle), building.y + (r + 12) * Math.sin(startAngle))
         this.gfx.arc(building.x, building.y, r + 12, startAngle, endAngle)
         this.gfx.lineStyle(0)
+      }
+
+      // Selection ring: pulsing teal ring around selected building
+      if (building.id === selectedBuildingId && building.ownerId === 'player') {
+        const selPulse = 0.7 + 0.3 * Math.sin(now / 250)
+        this.gfx.lineStyle(2, color, selPulse)
+        this.gfx.drawCircle(building.x, building.y, r + 18)
+        this.gfx.lineStyle(0)
+      }
+
+      // Rally point indicator: thin dashed-style line from building to rally marker
+      if (building.ownerId === 'player' && building.rallyPoint) {
+        const rp = building.rallyPoint
+        const showLine = building.id === selectedBuildingId
+        if (showLine) {
+          // Draw segmented "dashed" line
+          const dx = rp.x - building.x
+          const dy = rp.y - building.y
+          const dist = Math.sqrt(dx * dx + dy * dy)
+          if (dist > 5) {
+            const nx = dx / dist, ny = dy / dist
+            const dashLen = 8, gapLen = 6, total = dashLen + gapLen
+            const startDist = r + 5
+            let d = startDist
+            while (d < dist - 5) {
+              const segEnd = Math.min(d + dashLen, dist - 5)
+              this.gfx.lineStyle(1, color, 0.5)
+              this.gfx.moveTo(building.x + nx * d, building.y + ny * d)
+              this.gfx.lineTo(building.x + nx * segEnd, building.y + ny * segEnd)
+              this.gfx.lineStyle(0)
+              d += total
+            }
+          }
+        }
+
+        // Rally marker: small diamond at rally point (only show when line visible)
+        if (showLine) {
+          const markerSize = 5
+          this.gfx.beginFill(color, 0.7)
+          this.gfx.drawPolygon([
+            rp.x, rp.y - markerSize,
+            rp.x + markerSize, rp.y,
+            rp.x, rp.y + markerSize,
+            rp.x - markerSize, rp.y,
+          ])
+          this.gfx.endFill()
+          this.gfx.lineStyle(1, 0xffffff, 0.4)
+          this.gfx.drawPolygon([
+            rp.x, rp.y - markerSize,
+            rp.x + markerSize, rp.y,
+            rp.x, rp.y + markerSize,
+            rp.x - markerSize, rp.y,
+          ])
+          this.gfx.lineStyle(0)
+        }
       }
     }
   }

--- a/src/app/speck-wars/rendering/renderer.ts
+++ b/src/app/speck-wars/rendering/renderer.ts
@@ -75,7 +75,7 @@ export class Renderer {
     this.world.position.set(camera.x + shakeX, camera.y + shakeY)
     this.world.scale.set(camera.zoom)
 
-    this.buildingLayer.update(sim, PLAYER_COLORS)
+    this.buildingLayer.update(sim, PLAYER_COLORS, sim.selectedBuildingId)
     this.speckLayer.update(sim, sim.selectedSpeckIds)
 
     // Process events from this tick


### PR DESCRIPTION
Browsers set `ctrlKey=true` on pinch-gesture wheel events and `ctrlKey=false` on two-finger scroll. Split `onWheel` to pan on scroll and zoom on pinch/ctrl+scroll.