### PR TITLE
feat(speck-wars): selected building info panel in HUD

### DIFF
--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -921,7 +921,7 @@ export function HUD() {
           flexDirection: 'column',
           alignItems: 'center',
           gap: 6,
-          opacity: hud && (hud.selectedSpeckCount ?? 0) > 0 ? 1 : 0,
+          opacity: hud && ((hud.selectedSpeckCount ?? 0) > 0 || hud.selectedBuilding != null) ? 1 : 0,
           transition: 'opacity 150ms ease',
           fontFamily: 'monospace',
           whiteSpace: 'nowrap',
@@ -929,6 +929,7 @@ export function HUD() {
           {/* Build menu — only shows when specks are selected */}
           {(() => {
             const selectedCount = hud?.selectedSpeckCount ?? 0
+            if (selectedCount === 0) return null
             const TURRET_COST = 20
             const canBuild = selectedCount >= TURRET_COST
             const barFill = Math.min(1, selectedCount / TURRET_COST)
@@ -987,6 +988,36 @@ export function HUD() {
                     </span>
                   </div>
                 </button>
+              </div>
+            )
+          })()}
+
+          {/* Building info panel — shown when a building is selected and no specks are selected */}
+          {hud?.selectedBuilding && (hud.selectedSpeckCount ?? 0) === 0 && (() => {
+            const b = hud.selectedBuilding
+            const hpFrac = b.hp / b.maxHp
+            const hpColor = hpFrac > 0.5 ? '#4af7c4' : hpFrac > 0.2 ? '#ffaa44' : '#ff4f7b'
+            return (
+              <div style={{
+                background: 'rgba(0,0,0,0.65)',
+                border: '1px solid rgba(255,255,255,0.12)',
+                borderRadius: 6,
+                padding: '7px 12px',
+                minWidth: 160,
+                pointerEvents: 'none',
+              }}>
+                <div style={{ fontSize: 8, letterSpacing: 2, color: 'rgba(255,255,255,0.45)', marginBottom: 5 }}>
+                  {b.typeId.toUpperCase()}
+                </div>
+                <div style={{ fontSize: 9, color: hpColor, letterSpacing: 1, marginBottom: 4 }}>
+                  HP {Math.ceil(b.hp)} / {b.maxHp}
+                </div>
+                <div style={{ height: 3, background: 'rgba(255,255,255,0.1)', borderRadius: 2, overflow: 'hidden', marginBottom: 6 }}>
+                  <div style={{ height: '100%', width: `${hpFrac * 100}%`, background: hpColor, borderRadius: 2, transition: 'width 150ms' }} />
+                </div>
+                <div style={{ fontSize: 8, color: 'rgba(255,255,255,0.3)', letterSpacing: 0.5 }}>
+                  right-click to set rally
+                </div>
               </div>
             )
           })()}

--- a/src/app/speck-wars/domain/config/building-types.ts
+++ b/src/app/speck-wars/domain/config/building-types.ts
@@ -5,6 +5,9 @@ export interface BuildingTypeDefinition {
   spawnInterval: number; spawnCount: number
   hpRegen?: number   // HP per second, only when not under attack
   cost?: Array<{ typeId: string; count: number }>
+  sacrificeCost?: number        // basic specks required to build
+  attackRange?: number          // turret scan radius
+  fireInterval?: number         // ms between shots
 }
 
 export const BUILDING_TYPES: Record<string, BuildingTypeDefinition> = {
@@ -21,5 +24,14 @@ export const BUILDING_TYPES: Record<string, BuildingTypeDefinition> = {
     spawnTypeId: 'heavy',
     spawnInterval: 1200, spawnCount: 1,
     hpRegen: 2,  // 2 HP/sec when not under attack
+  },
+  turret: {
+    id: 'turret', name: 'Turret',
+    maxHp: 50, size: 18,
+    spawnTypeId: null,
+    spawnInterval: 0, spawnCount: 0,
+    sacrificeCost: 20,        // 20 specks to build
+    attackRange: 220,
+    fireInterval: 1200,
   },
 }

--- a/src/app/speck-wars/domain/config/speck-types.ts
+++ b/src/app/speck-wars/domain/config/speck-types.ts
@@ -29,4 +29,11 @@ export const SPECK_TYPES: Record<string, SpeckTypeDefinition> = {
     size: 2, productionTime: 500,
     abilities: [],
   },
+  missile: {
+    id: 'missile', name: 'Missile',
+    hp: 1, damage: 1, speed: 220,
+    attackRange: 6, attackCooldown: 0,
+    size: 2, productionTime: 0,
+    abilities: ['die_on_impact'],
+  },
 }

--- a/src/app/speck-wars/domain/simulation/combat.ts
+++ b/src/app/speck-wars/domain/simulation/combat.ts
@@ -89,6 +89,10 @@ export function resolveCombat(sim: SimulationState, dt: number) {
         speckHp[j] -= stype.damage * moraleMult(meta.ownerId) * veteranBonus * fortifyBonus
         meta.attackCooldown = stype.attackCooldown
         meta.state = 'attacking'
+        // die_on_impact: missile self-destructs after dealing damage
+        if (stype.abilities.includes('die_on_impact')) {
+          speckHp[i] = 0
+        }
         if (speckHp[j] <= 0) {
           meta.kills++  // attacker earns a kill
           // Notify when player loses a veteran or elite

--- a/src/app/speck-wars/domain/simulation/construction.ts
+++ b/src/app/speck-wars/domain/simulation/construction.ts
@@ -1,0 +1,45 @@
+import type { SimulationState } from '../types'
+
+export function updateConstruction(sim: SimulationState, dt: number) {
+  for (const building of Object.values(sim.buildings)) {
+    if (!building.underConstruction) continue
+
+    const sacrificeRadius = 40
+    const required = building.sacrificeRequired ?? 0
+
+    if ((building.sacrificeArrived ?? 0) < required) {
+      // Absorb specks that have arrived at the construction site
+      for (let i = 0; i < sim.speckCount; i++) {
+        if (!sim.speckIds[i]) continue
+        const meta = sim.speckMeta[i]
+        if (!meta || meta.constructTargetId !== building.id) continue
+        const dx = sim.speckX[i] - building.x
+        const dy = sim.speckY[i] - building.y
+        if (dx * dx + dy * dy > sacrificeRadius * sacrificeRadius) continue
+        // Sacrifice this speck
+        sim.speckHp[i] = 0  // mark for removal
+        building.sacrificeArrived = (building.sacrificeArrived ?? 0) + 1
+        sim.events.push({
+          type: 'SPECK_DIED',
+          speckId: meta.id, x: sim.speckX[i], y: sim.speckY[i],
+          killedOwnerId: building.ownerId, killerOwnerId: building.ownerId,
+        })
+      }
+    }
+
+    // Once all specks have arrived, start the construction timer
+    if ((building.sacrificeArrived ?? 0) >= required) {
+      if (building.constructionTimer === undefined) {
+        building.constructionTimer = 2000  // 2s build animation
+      }
+    }
+
+    if (building.constructionTimer !== undefined && building.constructionTimer > 0) {
+      building.constructionTimer = Math.max(0, building.constructionTimer - dt)
+      if (building.constructionTimer === 0) {
+        building.underConstruction = false
+        sim.events.push({ type: 'CONSTRUCTION_COMPLETE', buildingId: building.id, x: building.x, y: building.y })
+      }
+    }
+  }
+}

--- a/src/app/speck-wars/domain/simulation/create-sim.ts
+++ b/src/app/speck-wars/domain/simulation/create-sim.ts
@@ -108,6 +108,7 @@ export function createSim(seed: number = Date.now(), difficulty: Difficulty = 'm
     events: [],
     rallyPoints: { player: null, ai: null, 'player-selected': null },
     selectedSpeckIds: new Set<string>(),
+    selectedBuildingId: null,
     spatialGrid: new SpatialGrid(),
     dominationTimer: 0,
     surgeDuration: 0,

--- a/src/app/speck-wars/domain/simulation/speck-ai.ts
+++ b/src/app/speck-wars/domain/simulation/speck-ai.ts
@@ -15,6 +15,37 @@ export function runSpeckAI(sim: SimulationState) {
     const stype = SPECK_TYPES[meta.typeId]
     if (!stype) continue
 
+    // Missile: home directly toward mission target
+    if (meta.typeId === 'missile' && meta.missionTargetId) {
+      let ti = -1
+      for (let j = 0; j < sim.speckCount; j++) {
+        if (sim.speckIds[j] === meta.missionTargetId) { ti = j; break }
+      }
+      if (ti === -1) {
+        // Target dead — missile self-destructs
+        sim.speckHp[i] = 0
+      } else {
+        meta.state = 'moving'
+        meta.targetId = null
+        meta.assignedRallyX = sim.speckX[ti]
+        meta.assignedRallyY = sim.speckY[ti]
+      }
+      continue
+    }
+
+    // Construction march: selected specks march to construction site
+    if (meta.constructTargetId) {
+      const target = buildings[meta.constructTargetId]
+      if (!target || !target.underConstruction) {
+        meta.constructTargetId = null
+      } else {
+        meta.state = 'moving'
+        meta.assignedRallyX = target.x
+        meta.assignedRallyY = target.y
+      }
+      continue
+    }
+
     // Clear dead or invalid targets
     if (meta.targetId && !buildings[meta.targetId]) {
       meta.targetId = null

--- a/src/app/speck-wars/domain/simulation/tick.ts
+++ b/src/app/speck-wars/domain/simulation/tick.ts
@@ -8,6 +8,8 @@ import { checkVictory } from './victory'
 import { updateCapture } from './capture'
 import { BUILDING_TYPES } from '../config/building-types'
 import { HUD_UPDATE_INTERVAL, DOMINATION_TIME, RALLY_CRY_HP_THRESHOLD, FORTIFY_TIME } from '../constants'
+import { updateConstruction } from './construction'
+import { updateTurrets } from './turret'
 
 export function tick(sim: SimulationState, dt: number): SimulationState {
   sim.events = []  // clear outbound events from previous tick
@@ -17,6 +19,12 @@ export function tick(sim: SimulationState, dt: number): SimulationState {
 
   // 2. Spawn new specks from buildings
   updateSpawners(sim, dt)
+
+  // 2a. Construction: absorb sacrificing specks, count down build timer
+  updateConstruction(sim, dt)
+
+  // 2b. Turrets: fire missiles at nearby enemies
+  updateTurrets(sim, dt)
 
   // 3. Each speck picks/validates its target
   runSpeckAI(sim)
@@ -267,6 +275,53 @@ function consumeInputs(sim: SimulationState) {
       if (event.ownerId === 'player') {
         sim.rallyPoints['player-selected'] = null
       }
+    }
+    if (event.type === 'BUILD') {
+      const btype = BUILDING_TYPES[event.buildingTypeId]
+      if (!btype) continue
+      const sacrificeCost = btype.sacrificeCost ?? 0
+      // Count how many player specks are selected (or all if no selection)
+      let selectedCount = 0
+      const useSelection = sim.selectedSpeckIds.size > 0
+      for (let i = 0; i < sim.speckCount; i++) {
+        if (!sim.speckIds[i]) continue
+        const m = sim.speckMeta[i]
+        if (!m || m.ownerId !== event.ownerId) continue
+        if (useSelection && !sim.selectedSpeckIds.has(m.id)) continue
+        selectedCount++
+      }
+      if (selectedCount < sacrificeCost) continue  // not enough specks
+      // Create the construction site
+      const buildId = `building-${event.ownerId}-turret-${sim.tick}`
+      sim.buildings[buildId] = {
+        id: buildId,
+        typeId: event.buildingTypeId,
+        ownerId: event.ownerId,
+        x: event.x, y: event.y,
+        hp: btype.maxHp, maxHp: btype.maxHp,
+        spawnTimer: 0,
+        inputBuffer: {},
+        underConstruction: true,
+        sacrificeRequired: sacrificeCost,
+        sacrificeArrived: 0,
+      }
+      // Send selected (or all) specks to march
+      let sent = 0
+      for (let i = 0; i < sim.speckCount; i++) {
+        if (sent >= sacrificeCost) break
+        if (!sim.speckIds[i]) continue
+        const m = sim.speckMeta[i]
+        if (!m || m.ownerId !== event.ownerId) continue
+        if (useSelection && !sim.selectedSpeckIds.has(m.id)) continue
+        m.constructTargetId = buildId
+        m.assignedRallyX = event.x
+        m.assignedRallyY = event.y
+        m.holdPosition = false
+        sent++
+      }
+      // Clear selection after dispatching
+      sim.selectedSpeckIds.clear()
+      sim.rallyPoints['player-selected'] = null
     }
     if (event.type === 'SACRIFICE') {
       if (sim.sacrificeCooldown > 0) continue

--- a/src/app/speck-wars/domain/simulation/tick.ts
+++ b/src/app/speck-wars/domain/simulation/tick.ts
@@ -211,6 +211,22 @@ function consumeInputs(sim: SimulationState) {
     if (event.type === 'CLEAR_SELECT') {
       sim.selectedSpeckIds.clear()
       sim.rallyPoints['player-selected'] = null
+      sim.selectedBuildingId = null
+    }
+    if (event.type === 'SELECT_BUILDING') {
+      if (event.ownerId === 'player') {
+        sim.selectedBuildingId = event.buildingId
+        if (event.buildingId !== null) {
+          // Clear speck selection when selecting a building
+          sim.selectedSpeckIds.clear()
+          sim.rallyPoints['player-selected'] = null
+        }
+      }
+    }
+    if (event.type === 'SET_BUILDING_RALLY') {
+      const building = sim.buildings[event.buildingId]
+      if (!building || building.ownerId !== event.ownerId) continue
+      building.rallyPoint = { x: event.x, y: event.y }
     }
     if (event.type === 'SURGE') {
       if (event.ownerId === 'player' && sim.surgeCooldown <= 0) {

--- a/src/app/speck-wars/domain/simulation/tick.ts
+++ b/src/app/speck-wars/domain/simulation/tick.ts
@@ -503,5 +503,11 @@ function emitHudUpdate(sim: SimulationState) {
     selectedComposition = { types, veteranCount: selVet, eliteCount: selElite }
   }
 
-  sim.events.push({ type: 'HUD_UPDATE', data: { players: data, attackedBuildingIds, tripleOutpostOwner, dominationProgress, captureInfo, surgeDuration: sim.surgeDuration, surgeCooldown: sim.surgeCooldown, selectedSpeckCount: sim.selectedSpeckIds.size, selectedComposition, spawnRates, minimap, outpostFortify, dailyModifier: sim.dailyModifier, waveCountdown: sim.waveCountdown, waveInProgress: sim.waveInProgress, sacrificeCooldown: sim.sacrificeCooldown, baseUnderThreat, enemyAdvanceDetected, rallyCryActive } })
+  let selectedBuilding: { id: string; typeId: string; hp: number; maxHp: number } | null = null
+  if (sim.selectedBuildingId) {
+    const b = sim.buildings[sim.selectedBuildingId]
+    if (b) selectedBuilding = { id: b.id, typeId: b.typeId, hp: b.hp, maxHp: b.maxHp }
+  }
+
+  sim.events.push({ type: 'HUD_UPDATE', data: { players: data, attackedBuildingIds, tripleOutpostOwner, dominationProgress, captureInfo, surgeDuration: sim.surgeDuration, surgeCooldown: sim.surgeCooldown, selectedSpeckCount: sim.selectedSpeckIds.size, selectedComposition, spawnRates, minimap, outpostFortify, dailyModifier: sim.dailyModifier, waveCountdown: sim.waveCountdown, waveInProgress: sim.waveInProgress, sacrificeCooldown: sim.sacrificeCooldown, baseUnderThreat, enemyAdvanceDetected, rallyCryActive, selectedBuilding } })
 }

--- a/src/app/speck-wars/domain/simulation/turret.ts
+++ b/src/app/speck-wars/domain/simulation/turret.ts
@@ -1,0 +1,69 @@
+import type { SimulationState, SpeckMeta } from '../types'
+import { BUILDING_TYPES } from '../config/building-types'
+import { SPECK_TYPES } from '../config/speck-types'
+
+let missileCounter = 0
+
+function spawnMissile(sim: SimulationState, bx: number, by: number, ownerId: string, targetId: string) {
+  const meta: SpeckMeta = {
+    id: `missile-${++missileCounter}`,
+    typeId: 'missile',
+    ownerId,
+    state: 'moving',
+    targetId: null,
+    attackCooldown: 0,
+    kills: 0,
+    missionTargetId: targetId,
+  }
+  const hp = SPECK_TYPES['missile']?.hp ?? 1
+  let slot: number
+  if (sim.freeSlots.length > 0) {
+    slot = sim.freeSlots.pop()!
+  } else {
+    slot = sim.speckCount++
+  }
+  sim.speckX[slot] = bx
+  sim.speckY[slot] = by
+  sim.speckVx[slot] = 0
+  sim.speckVy[slot] = 0
+  sim.speckHp[slot] = hp
+  sim.speckIds[slot] = meta.id
+  sim.speckMeta[slot] = meta
+}
+
+export function updateTurrets(sim: SimulationState, dt: number) {
+  for (const building of Object.values(sim.buildings)) {
+    if (building.typeId !== 'turret') continue
+    if (building.underConstruction) continue
+    if (building.ownerId === 'neutral') continue
+
+    const btype = BUILDING_TYPES['turret']
+    const fireInterval = btype.fireInterval ?? 1200
+    const attackRange = btype.attackRange ?? 220
+
+    building.fireTimer = (building.fireTimer ?? 0) - dt
+    if (building.fireTimer > 0) continue
+    building.fireTimer = fireInterval
+
+    // Find nearest enemy speck in range
+    let nearestId: string | null = null
+    let nearestDist = Infinity
+    for (let i = 0; i < sim.speckCount; i++) {
+      if (!sim.speckIds[i]) continue
+      const meta = sim.speckMeta[i]
+      if (!meta || meta.ownerId === building.ownerId || meta.typeId === 'missile') continue
+      const dx = sim.speckX[i] - building.x
+      const dy = sim.speckY[i] - building.y
+      const d2 = dx * dx + dy * dy
+      if (d2 <= attackRange * attackRange) {
+        const dist = Math.sqrt(d2)
+        if (dist < nearestDist) {
+          nearestDist = dist
+          nearestId = sim.speckIds[i]
+        }
+      }
+    }
+    if (!nearestId) continue
+    spawnMissile(sim, building.x, building.y, building.ownerId, nearestId)
+  }
+}

--- a/src/app/speck-wars/domain/types.ts
+++ b/src/app/speck-wars/domain/types.ts
@@ -135,6 +135,7 @@ export interface HudData {
   enemyAdvanceDetected: boolean
   rallyCryActive: boolean
   outpostFortify: Record<string, number>  // outpostId → 0..1 fortification level
+  selectedBuilding: { id: string; typeId: string; hp: number; maxHp: number } | null
   minimap: {
     specks: { x: number; y: number; ownerId: string }[]
     buildings: { id: string; x: number; y: number; ownerId: string; typeId: string }[]

--- a/src/app/speck-wars/domain/types.ts
+++ b/src/app/speck-wars/domain/types.ts
@@ -11,6 +11,8 @@ export interface SpeckMeta {
   assignedRallyX?: number  // individual sub-group rally — persists after deselection
   assignedRallyY?: number
   holdPosition?: boolean   // true = don't move, don't attack, wait for new order
+  constructTargetId?: string | null   // building ID this speck is marching to sacrifice
+  missionTargetId?: string | null     // for missiles: specific enemy speck ID to home into
 }
 
 export interface BuildingEntity {
@@ -29,6 +31,11 @@ export interface BuildingEntity {
   fortifyDuration?: number      // ms continuously held — resets on capture
   lastDamagedAt?: number        // Date.now() timestamp of last damage taken (for regen cooldown)
   rallyPoint?: { x: number; y: number } | null  // per-building rally; specks auto-march here on spawn
+  underConstruction?: boolean
+  sacrificeRequired?: number
+  sacrificeArrived?: number
+  constructionTimer?: number    // ms remaining after all specks arrive
+  fireTimer?: number            // ms until next shot
 }
 
 export interface Player {
@@ -62,6 +69,7 @@ export interface SimulationState {
   events: SimEvent[]
   rallyPoints: Record<string, { x: number; y: number } | null>
   selectedSpeckIds: Set<string>  // IDs of player specks currently in selection
+  selectedBuildingId: string | null   // player building currently selected
   spatialGrid: SpatialGrid
   dominationTimer: number    // ms of continuous triple-outpost control; resets on loss
   surgeDuration: number      // ms remaining in active surge, 0 = inactive
@@ -82,6 +90,8 @@ export type InputEvent =
   | { type: 'SURGE'; ownerId: string }
   | { type: 'STOP'; ownerId: string }
   | { type: 'HOLD'; ownerId: string }
+  | { type: 'SELECT_BUILDING'; ownerId: string; buildingId: string | null }
+  | { type: 'SET_BUILDING_RALLY'; ownerId: string; buildingId: string; x: number; y: number }
 
 export type SimEvent =
   | { type: 'SPECK_DIED'; speckId: string; x: number; y: number; killedOwnerId: string; killerOwnerId: string }
@@ -97,6 +107,7 @@ export type SimEvent =
   | { type: 'VETERAN_FALLEN'; speckId: string; ownerId: string; kills: number; x: number; y: number }
   | { type: 'AI_LAST_STAND' }
   | { type: 'AI_SPAWN_SWITCH'; speckTypeId: 'basic' | 'heavy' | 'scout' }
+  | { type: 'CONSTRUCTION_COMPLETE'; buildingId: string; x: number; y: number }
 
 export interface HudData {
   players: Record<string, {

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -8,6 +8,7 @@ import { InputHandler } from './input/input-handler'
 import type { Camera } from './rendering/camera'
 import { AIController, type AIPersonality } from './domain/ai/ai-controller'
 import { recordBestTime, incrementWinStreak, resetWinStreak, isFirstGame, markFirstGameDone, recordGameResult, markWonToday } from './lib/personal-best'
+import { BUILDING_TYPES } from './domain/config/building-types'
 
 export class GameInstance {
   private canvas: HTMLCanvasElement
@@ -92,6 +93,30 @@ export class GameInstance {
       this.canvas,
       this.camera,
       (wx, wy) => {
+        // Check if click hit a player building — select it instead of rallying
+        for (const building of Object.values(this.sim.buildings)) {
+          if (building.ownerId !== 'player') continue
+          const btype = BUILDING_TYPES[building.typeId]
+          const r = btype?.size ?? 20
+          if (Math.hypot(wx - building.x, wy - building.y) <= r + 5) {
+            this.sim.inputQueue.push({ type: 'SELECT_BUILDING', ownerId: 'player', buildingId: building.id })
+            return
+          }
+        }
+
+        // If a building is selected, set its rally point
+        if (this.sim.selectedBuildingId) {
+          this.sim.inputQueue.push({ type: 'SET_BUILDING_RALLY', ownerId: 'player', buildingId: this.sim.selectedBuildingId, x: wx, y: wy })
+          this.renderer.showRallyPing(wx, wy)
+          if (this.attackMovePending) {
+            this.attackMovePending = false
+            if (this.canvas) this.canvas.style.cursor = 'default'
+            this.notify('⚔ ATTACK MOVE!', '#ff4f7b', 900)
+          }
+          return
+        }
+
+        // Default: global rally for all units
         this.sim.inputQueue.push({ type: 'RALLY', ownerId: 'player', x: wx, y: wy })
         this.renderer.showRallyPing(wx, wy)
       },

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -53,6 +53,7 @@ export class GameInstance {
   private lastAdvanceMs = 0
   private lastAdvanceIdx = 0
   private cinematicMs = 0
+  private pendingBuild: string | null = null  // building type ID awaiting placement click
 
   constructor(canvas: HTMLCanvasElement) {
     this.canvas = canvas
@@ -93,6 +94,15 @@ export class GameInstance {
       this.canvas,
       this.camera,
       (wx, wy) => {
+        // Build placement mode: place the pending building at the clicked location
+        if (this.pendingBuild) {
+          const typeId = this.pendingBuild
+          this.pendingBuild = null
+          this.sim.inputQueue.push({ type: 'BUILD', ownerId: 'player', buildingTypeId: typeId, x: wx, y: wy })
+          this.notify('◆ TURRET PLACED', '#ffd700', 1500)
+          return
+        }
+
         // Check if click hit a player building — select it instead of rallying
         for (const building of Object.values(this.sim.buildings)) {
           if (building.ownerId !== 'player') continue
@@ -108,11 +118,6 @@ export class GameInstance {
         if (this.sim.selectedBuildingId) {
           this.sim.inputQueue.push({ type: 'SET_BUILDING_RALLY', ownerId: 'player', buildingId: this.sim.selectedBuildingId, x: wx, y: wy })
           this.renderer.showRallyPing(wx, wy)
-          if (this.attackMovePending) {
-            this.attackMovePending = false
-            if (this.canvas) this.canvas.style.cursor = 'default'
-            this.notify('⚔ ATTACK MOVE!', '#ff4f7b', 900)
-          }
           return
         }
 
@@ -140,7 +145,12 @@ export class GameInstance {
       (x1, y1, x2, y2) => {                                           // drag — box-select specks
         this.sim.inputQueue.push({ type: 'BOX_SELECT', ownerId: 'player', x1, y1, x2, y2 })
       },
-      () => {                                                          // Escape — clear selection
+      () => {                                                          // Escape — clear selection / cancel build mode
+        if (this.pendingBuild) {
+          this.pendingBuild = null
+          this.notify('Build cancelled', '#aaaaaa', 800)
+          return
+        }
         this.sim.inputQueue.push({ type: 'CLEAR_SELECT', ownerId: 'player' })
         this.sim.rallyPoints['player-selected'] = null
       },
@@ -205,6 +215,7 @@ export class GameInstance {
         const color = typeId === 'heavy' ? '#ff8844' : typeId === 'scout' ? '#50c8ff' : '#4af7c4'
         this.notify(`Spawn: ${typeId.toUpperCase()}`, color)
       },
+      buildTurret: () => this.enterBuildMode('turret'),
     })
     this.lastTime = performance.now()
     this.loop(this.lastTime)
@@ -679,6 +690,11 @@ export class GameInstance {
       return
     }
     this.sim.inputQueue.push({ type: 'SACRIFICE', ownerId: 'player', buildingId: playerBase.id, typeId: 'basic', count: 10 })
+  }
+
+  enterBuildMode(buildingTypeId: string) {
+    this.pendingBuild = buildingTypeId
+    this.notify('◆ CLICK TO PLACE TURRET', '#ffd700', 3000)
   }
 
   snapToAction() {

--- a/src/app/speck-wars/rendering/layers/building-layer.ts
+++ b/src/app/speck-wars/rendering/layers/building-layer.ts
@@ -35,7 +35,7 @@ export class BuildingLayer {
     this.spawnFlashMap.set(buildingId, Date.now())
   }
 
-  update(sim: SimulationState, playerColors: Record<string, number>) {
+  update(sim: SimulationState, playerColors: Record<string, number>, selectedBuildingId: string | null = null) {
     const now = Date.now()
     this.gfx.clear()
 
@@ -186,6 +186,61 @@ export class BuildingLayer {
         this.gfx.moveTo(building.x + (r + 12) * Math.cos(startAngle), building.y + (r + 12) * Math.sin(startAngle))
         this.gfx.arc(building.x, building.y, r + 12, startAngle, endAngle)
         this.gfx.lineStyle(0)
+      }
+
+      // Selection ring: pulsing teal ring around selected building
+      if (building.id === selectedBuildingId && building.ownerId === 'player') {
+        const selPulse = 0.7 + 0.3 * Math.sin(now / 250)
+        this.gfx.lineStyle(2, color, selPulse)
+        this.gfx.drawCircle(building.x, building.y, r + 18)
+        this.gfx.lineStyle(0)
+      }
+
+      // Rally point indicator: thin dashed-style line from building to rally marker
+      if (building.ownerId === 'player' && building.rallyPoint) {
+        const rp = building.rallyPoint
+        const showLine = building.id === selectedBuildingId
+        if (showLine) {
+          // Draw segmented "dashed" line
+          const dx = rp.x - building.x
+          const dy = rp.y - building.y
+          const dist = Math.sqrt(dx * dx + dy * dy)
+          if (dist > 5) {
+            const nx = dx / dist, ny = dy / dist
+            const dashLen = 8, gapLen = 6, total = dashLen + gapLen
+            const startDist = r + 5
+            let d = startDist
+            while (d < dist - 5) {
+              const segEnd = Math.min(d + dashLen, dist - 5)
+              this.gfx.lineStyle(1, color, 0.5)
+              this.gfx.moveTo(building.x + nx * d, building.y + ny * d)
+              this.gfx.lineTo(building.x + nx * segEnd, building.y + ny * segEnd)
+              this.gfx.lineStyle(0)
+              d += total
+            }
+          }
+        }
+
+        // Rally marker: small diamond at rally point (only show when line visible)
+        if (showLine) {
+          const markerSize = 5
+          this.gfx.beginFill(color, 0.7)
+          this.gfx.drawPolygon([
+            rp.x, rp.y - markerSize,
+            rp.x + markerSize, rp.y,
+            rp.x, rp.y + markerSize,
+            rp.x - markerSize, rp.y,
+          ])
+          this.gfx.endFill()
+          this.gfx.lineStyle(1, 0xffffff, 0.4)
+          this.gfx.drawPolygon([
+            rp.x, rp.y - markerSize,
+            rp.x + markerSize, rp.y,
+            rp.x, rp.y + markerSize,
+            rp.x - markerSize, rp.y,
+          ])
+          this.gfx.lineStyle(0)
+        }
       }
     }
   }

--- a/src/app/speck-wars/rendering/layers/building-layer.ts
+++ b/src/app/speck-wars/rendering/layers/building-layer.ts
@@ -45,6 +45,105 @@ export class BuildingLayer {
       const r = btype?.size ?? 20
 
       const isOutpost = building.typeId === 'outpost'
+      const isTurret = building.typeId === 'turret'
+
+      // Turret: special rendering path
+      if (isTurret) {
+        if (building.underConstruction) {
+          // Ghost: faint pulsing circle + sacrifice progress ring + countdown arc
+          const ghostPulse = 0.3 + 0.2 * Math.sin(now / 600)
+          this.gfx.beginFill(color, ghostPulse * 0.4)
+          this.gfx.drawCircle(building.x, building.y, r)
+          this.gfx.endFill()
+          this.gfx.lineStyle(1.5, color, ghostPulse)
+          this.gfx.drawCircle(building.x, building.y, r)
+          this.gfx.lineStyle(0)
+
+          // Sacrifice progress: how many specks have arrived / required
+          const required = building.sacrificeRequired ?? 1
+          const arrived = building.sacrificeArrived ?? 0
+          const sacrificeFrac = Math.min(1, arrived / required)
+          if (sacrificeFrac > 0) {
+            const startAngle = -Math.PI / 2
+            const endAngle = startAngle + Math.PI * 2 * sacrificeFrac
+            this.gfx.lineStyle(2.5, 0xffd700, 0.8)
+            this.gfx.moveTo(building.x + (r + 6) * Math.cos(startAngle), building.y + (r + 6) * Math.sin(startAngle))
+            this.gfx.arc(building.x, building.y, r + 6, startAngle, endAngle)
+            this.gfx.lineStyle(0)
+          }
+
+          // Construction timer arc (after all specks arrived, 2s countdown)
+          if (building.constructionTimer !== undefined && building.constructionTimer > 0) {
+            const timerFrac = 1 - building.constructionTimer / 2000
+            const startAngle = -Math.PI / 2
+            const endAngle = startAngle + Math.PI * 2 * timerFrac
+            this.gfx.lineStyle(2, 0xffffff, 0.6)
+            this.gfx.moveTo(building.x + (r - 4) * Math.cos(startAngle), building.y + (r - 4) * Math.sin(startAngle))
+            this.gfx.arc(building.x, building.y, r - 4, startAngle, endAngle)
+            this.gfx.lineStyle(0)
+          }
+        } else {
+          // Live turret: diamond shape
+          const s = r
+          this.gfx.beginFill(color, 0.9)
+          this.gfx.drawPolygon([
+            building.x, building.y - s,
+            building.x + s, building.y,
+            building.x, building.y + s,
+            building.x - s, building.y,
+          ])
+          this.gfx.endFill()
+          // Damage flash
+          const flashTs = this.flashMap.get(building.id)
+          if (flashTs !== undefined) {
+            const elapsed = now - flashTs
+            if (elapsed < FLASH_DURATION) {
+              const alpha = (1 - elapsed / FLASH_DURATION) * 0.7
+              this.gfx.beginFill(0xff2222, alpha)
+              this.gfx.drawPolygon([
+                building.x, building.y - s,
+                building.x + s, building.y,
+                building.x, building.y + s,
+                building.x - s, building.y,
+              ])
+              this.gfx.endFill()
+            } else {
+              this.flashMap.delete(building.id)
+            }
+          }
+          // Stroke
+          this.gfx.lineStyle(2, 0xffffff, 0.4)
+          this.gfx.drawPolygon([
+            building.x, building.y - s,
+            building.x + s, building.y,
+            building.x, building.y + s,
+            building.x - s, building.y,
+          ])
+          this.gfx.lineStyle(0)
+          // Pulse ring
+          const pulse = Math.sin(now / 800) * 0.3 + 0.7
+          this.gfx.lineStyle(2, color, pulse * 0.4)
+          this.gfx.drawCircle(building.x, building.y, r + 8)
+          this.gfx.lineStyle(0)
+          // HP bar
+          const barW = r * 2
+          const barH = 4
+          const barX = building.x - r
+          const barY = building.y - r - 10
+          const hpFrac = building.hp / building.maxHp
+          this.gfx.beginFill(0x333333)
+          this.gfx.drawRect(barX, barY, barW, barH)
+          this.gfx.endFill()
+          this.gfx.beginFill(hpFrac > 0.5 ? 0x44ff88 : 0xff4444)
+          this.gfx.drawRect(barX, barY, barW * hpFrac, barH)
+          this.gfx.endFill()
+          // Attack range ring (faint)
+          this.gfx.lineStyle(1, color, 0.06)
+          this.gfx.drawCircle(building.x, building.y, 220)
+          this.gfx.lineStyle(0)
+        }
+        continue
+      }
 
       // Base shape: hexagon for outposts, circle for bases
       this.gfx.beginFill(color, 0.9)

--- a/src/app/speck-wars/rendering/renderer.ts
+++ b/src/app/speck-wars/rendering/renderer.ts
@@ -96,6 +96,9 @@ export class Renderer {
         const color = PLAYER_COLORS[event.ownerId] ?? 0xffffff
         this.effectsLayer.addDestructionBurst(event.x, event.y, color)
       }
+      if (event.type === 'CONSTRUCTION_COMPLETE') {
+        this.showRallyPing(event.x, event.y)
+      }
       if (event.type === 'OUTPOST_CAPTURED') {
         const building = sim.buildings[event.outpostId]
         const color = PLAYER_COLORS[event.newOwner] ?? 0xffffff

--- a/src/app/speck-wars/rendering/renderer.ts
+++ b/src/app/speck-wars/rendering/renderer.ts
@@ -75,7 +75,7 @@ export class Renderer {
     this.world.position.set(camera.x + shakeX, camera.y + shakeY)
     this.world.scale.set(camera.zoom)
 
-    this.buildingLayer.update(sim, PLAYER_COLORS)
+    this.buildingLayer.update(sim, PLAYER_COLORS, sim.selectedBuildingId)
     this.speckLayer.update(sim, sim.selectedSpeckIds)
 
     // Process events from this tick

--- a/src/app/speck-wars/store.ts
+++ b/src/app/speck-wars/store.ts
@@ -38,8 +38,8 @@ interface SpeckWarsStore {
   addOutpostCaptured: () => void
   isNewBest: boolean
   setIsNewBest: (v: boolean) => void
-  gameActions: { defend: (() => void) | null; advance: (() => void) | null; rush: (() => void) | null; clearRally: (() => void) | null; surge: (() => void) | null; rally: ((x: number, y: number) => void) | null; sacrifice: (() => void) | null; setSpawnType: ((type: 'basic' | 'heavy' | 'scout') => void) | null }
-  setGameActions: (actions: { defend: () => void; advance: () => void; rush: () => void; clearRally: () => void; surge: () => void; rally: (x: number, y: number) => void; sacrifice: () => void; setSpawnType: (type: 'basic' | 'heavy' | 'scout') => void } | null) => void
+  gameActions: { defend: (() => void) | null; advance: (() => void) | null; rush: (() => void) | null; clearRally: (() => void) | null; surge: (() => void) | null; rally: ((x: number, y: number) => void) | null; sacrifice: (() => void) | null; setSpawnType: ((type: 'basic' | 'heavy' | 'scout') => void) | null; buildTurret?: (() => void) | null }
+  setGameActions: (actions: { defend: () => void; advance: () => void; rush: () => void; clearRally: () => void; surge: () => void; rally: (x: number, y: number) => void; sacrifice: () => void; setSpawnType: (type: 'basic' | 'heavy' | 'scout') => void; buildTurret?: () => void } | null) => void
   surrender: () => void
   resetGame: () => void
 }
@@ -88,8 +88,8 @@ export const useSpeckWarsStore = create<SpeckWarsStore>()((set, get) => ({
   addOutpostCaptured: () => set(s => ({ outpostsCaptured: s.outpostsCaptured + 1 })),
   isNewBest: false,
   setIsNewBest: v => set({ isNewBest: v }),
-  gameActions: { defend: null, advance: null, rush: null, clearRally: null, surge: null, rally: null, sacrifice: null, setSpawnType: null },
-  setGameActions: (actions) => set({ gameActions: actions ?? { defend: null, advance: null, rush: null, clearRally: null, surge: null, rally: null, sacrifice: null, setSpawnType: null } }),
+  gameActions: { defend: null, advance: null, rush: null, clearRally: null, surge: null, rally: null, sacrifice: null, setSpawnType: null, buildTurret: null },
+  setGameActions: (actions) => set({ gameActions: actions ?? { defend: null, advance: null, rush: null, clearRally: null, surge: null, rally: null, sacrifice: null, setSpawnType: null, buildTurret: null } }),
   surrender: () => {
     const s = get()
     resetWinStreak()


### PR DESCRIPTION
## Summary

When a player building is selected (by clicking it), the bottom-center command panel now shows a building info panel instead of going blank:
- Building type label (BASE / OUTPOST / TURRET)
- HP counter with color-coded text (teal → yellow → red as HP drops)
- HP bar with 150ms smooth transition
- 'right-click to set rally' hint

Companion to the per-building rally PR (#2049) — without this, selecting a building gives no visual feedback in the HUD.

## Test plan
- [ ] Click player base → command panel shows "BASE", HP counter, HP bar, rally hint
- [ ] Box-select specks → build menu + selection info appear as before; building panel does not appear
- [ ] Take damage, then click base → HP value and bar reflect current health
- [ ] Click empty space to deselect → panel fades out

🤖 Generated with [Claude Code](https://claude.com/claude-code)