### PR TITLE
feat(speck-wars): G key guards nearest friendly outpost

### DIFF
--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -565,7 +565,7 @@ export function HUD() {
             <span style={{ color: 'rgba(74,247,196,0.7)' }}>Right-click with group selected → moves selected only</span><span style={{ color: 'rgba(74,247,196,0.7)' }}>Specks engage enemies en route (attack-move)</span>
             <span>A — attack-move modifier · P — patrol modifier</span><span>A/P + right-click — attack-move / patrol</span>
             <span>S — stop · H — hold position</span><span>C — center on base</span>
-            <span>N — advance to outpost · D — defend base</span><span>B — rush enemy base</span>
+            <span>N — advance to outpost · D — defend base</span><span>B — rush enemy base · G — guard outpost</span>
             <span>Q — surge (2× spawn 8s)</span><span>V — snap camera to battle</span>
             <span>1/2/3 — set spawn type</span><span>Minimap — click to move</span>
             <span>X — cycle speed (1×/2×/4×)</span><span>F — sacrifice 10 specks → +15 HP</span>
@@ -1098,6 +1098,24 @@ export function HUD() {
             }}
           >
             ⚡ B
+          </button>
+          <button
+            onClick={() => gameActions.guard?.()}
+            title="[G] Guard — rally to nearest friendly outpost"
+            style={{
+              padding: '6px 10px',
+              fontSize: 11,
+              cursor: 'pointer',
+              background: 'rgba(68,170,255,0.08)',
+              border: '1px solid rgba(68,170,255,0.4)',
+              borderRadius: 20,
+              color: '#44aaff',
+              letterSpacing: 1,
+              minHeight: 44,
+              fontFamily: 'monospace',
+            }}
+          >
+            ⬡ G
           </button>
           {(() => {
             const surgeActive = (hud?.surgeDuration ?? 0) > 0

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -51,6 +51,8 @@ export class GameInstance {
   private controlGroups = new Map<number, string[]>()
   private lastAdvanceMs = 0
   private lastAdvanceIdx = 0
+  private lastGuardMs = 0
+  private lastGuardIdx = 0
   private cinematicMs = 0
 
   constructor(canvas: HTMLCanvasElement) {
@@ -165,11 +167,13 @@ export class GameInstance {
         this.renderer.showRallyPing(wx, wy)
         this.notify('⚔ ATTACK MOVE!', '#ff4f7b', 900)
       },
+      () => { this.guard(); this.notify('⬡ GUARD', '#44aaff') },     // G — guard nearest player outpost
     )
     useSpeckWarsStore.getState().setGameActions({
       defend: () => { this.defend(); this.notify('🛡 DEFEND', '#4af7c4') },
       advance: () => { this.advance(); this.notify('→ ADVANCE', '#ffd700') },
       rush: () => { this.rush(); this.notify('⚡ RUSH!', '#ff4f7b') },
+      guard: () => { this.guard(); this.notify('⬡ GUARD', '#44aaff') },
       clearRally: () => this.clearRally(),
       surge: () => { this.surge(); this.notify('⚡ SURGE ACTIVE!', '#ffd700') },
       rally: (x: number, y: number) => this.rally(x, y),
@@ -630,6 +634,30 @@ export class GameInstance {
     this.lastAdvanceMs = now
     const target = targets[this.lastAdvanceIdx]
     this.rally(target.x, target.y)
+  }
+
+  guard() {
+    const playerBase = Object.values(this.sim.buildings).find(b => b.ownerId === 'player' && b.typeId === 'base')
+    if (!playerBase) return
+    const outposts = Object.values(this.sim.buildings)
+      .filter(b => b.typeId === 'outpost' && b.ownerId === 'player')
+      .sort((a, b) => {
+        const da = (a.x - playerBase.x) ** 2 + (a.y - playerBase.y) ** 2
+        const db = (b.x - playerBase.x) ** 2 + (b.y - playerBase.y) ** 2
+        return da - db
+      })
+    if (outposts.length === 0) {
+      this.defend()  // no owned outposts — fall back to defending base
+      return
+    }
+    const now = Date.now()
+    if (now - this.lastGuardMs < 3000 && outposts.length > 1) {
+      this.lastGuardIdx = (this.lastGuardIdx + 1) % outposts.length
+    } else {
+      this.lastGuardIdx = 0
+    }
+    this.lastGuardMs = now
+    this.rally(outposts[this.lastGuardIdx].x, outposts[this.lastGuardIdx].y)
   }
 
   rush() {

--- a/src/app/speck-wars/input/input-handler.ts
+++ b/src/app/speck-wars/input/input-handler.ts
@@ -29,6 +29,7 @@ export class InputHandler {
   private onStop?: () => void
   private onHold?: () => void
   private onAttackMove?: (worldX: number, worldY: number) => void
+  private onGuard?: () => void
   private heldKeys = new Set<string>()
   private isDragging = false
   private lastX = 0
@@ -70,6 +71,7 @@ export class InputHandler {
     onStop?: () => void,
     onHold?: () => void,
     onAttackMove?: (worldX: number, worldY: number) => void,
+    onGuard?: () => void,
   ) {
     this.canvas = canvas
     this.camera = camera
@@ -96,6 +98,7 @@ export class InputHandler {
     this.onStop = onStop
     this.onHold = onHold
     this.onAttackMove = onAttackMove
+    this.onGuard = onGuard
     this.attach()
   }
 
@@ -356,6 +359,8 @@ export class InputHandler {
       this.onCycleSpeed?.()
     } else if (e.code === 'KeyE') {
       this.onSelectAll?.()
+    } else if (e.code === 'KeyG') {
+      this.onGuard?.()
     } else if (e.code === 'KeyF') {
       this.onSacrifice?.()
     } else if (['Digit4','Digit5','Digit6','Digit7','Digit8','Digit9'].includes(e.code)) {

--- a/src/app/speck-wars/rendering/layers/speck-layer.ts
+++ b/src/app/speck-wars/rendering/layers/speck-layer.ts
@@ -2,6 +2,7 @@ import { Container, Graphics, Sprite } from 'pixi.js'
 import type { Texture } from 'pixi.js'
 import type { SimulationState } from '../../domain/types'
 import { SPECK_TYPES } from '../../domain/config/speck-types'
+import { RALLY_CRY_HP_THRESHOLD } from '../../domain/constants'
 
 const ATTACK_ANIM_MS = 120
 
@@ -35,6 +36,10 @@ export class SpeckLayer {
 
   update(sim: SimulationState, selectedSpeckIds?: Set<string>) {
     this.gfx.clear()
+    // Pre-compute once: surge active + rally cry active (used in tight speck loop below)
+    const surgeActive = sim.surgeDuration > 0
+    const playerBase = Object.values(sim.buildings).find(b => b.ownerId === 'player' && b.typeId === 'base')
+    const rallyCryActive = playerBase ? playerBase.hp / playerBase.maxHp < RALLY_CRY_HP_THRESHOLD : false
     // Group live speck indices by owner
     const byOwner: Record<string, number[]> = {}
     for (let i = 0; i < sim.speckCount; i++) {
@@ -139,6 +144,22 @@ export class SpeckLayer {
         if (selectedSpeckIds?.has(speckId)) {
           this.gfx.lineStyle(1.5, 0xffe066, 0.92)
           this.gfx.drawCircle(sim.speckX[i], sim.speckY[i], (stype ? stype.size / 4 : 0.75) + 4)
+          this.gfx.lineStyle(0)
+        }
+
+        // Surge aura: faint gold outer ring when surge is active
+        if (ownerId === 'player' && surgeActive) {
+          const surgePulse = 0.12 + 0.08 * Math.sin(now / 180)
+          this.gfx.lineStyle(0.8, 0xffaa00, surgePulse)
+          this.gfx.drawCircle(sim.speckX[i], sim.speckY[i], (stype ? stype.size / 4 : 0.75) + 7)
+          this.gfx.lineStyle(0)
+        }
+
+        // Rally cry aura: faint red ring when player base is at critical HP
+        if (ownerId === 'player' && rallyCryActive) {
+          const cryPulse = 0.12 + 0.10 * Math.sin(now / 300)
+          this.gfx.lineStyle(0.8, 0xff4400, cryPulse)
+          this.gfx.drawCircle(sim.speckX[i], sim.speckY[i], (stype ? stype.size / 4 : 0.75) + 9)
           this.gfx.lineStyle(0)
         }
       }

--- a/src/app/speck-wars/store.ts
+++ b/src/app/speck-wars/store.ts
@@ -38,8 +38,8 @@ interface SpeckWarsStore {
   addOutpostCaptured: () => void
   isNewBest: boolean
   setIsNewBest: (v: boolean) => void
-  gameActions: { defend: (() => void) | null; advance: (() => void) | null; rush: (() => void) | null; clearRally: (() => void) | null; surge: (() => void) | null; rally: ((x: number, y: number) => void) | null; sacrifice: (() => void) | null; setSpawnType: ((type: 'basic' | 'heavy' | 'scout') => void) | null }
-  setGameActions: (actions: { defend: () => void; advance: () => void; rush: () => void; clearRally: () => void; surge: () => void; rally: (x: number, y: number) => void; sacrifice: () => void; setSpawnType: (type: 'basic' | 'heavy' | 'scout') => void } | null) => void
+  gameActions: { defend: (() => void) | null; advance: (() => void) | null; rush: (() => void) | null; guard: (() => void) | null; clearRally: (() => void) | null; surge: (() => void) | null; rally: ((x: number, y: number) => void) | null; sacrifice: (() => void) | null; setSpawnType: ((type: 'basic' | 'heavy' | 'scout') => void) | null }
+  setGameActions: (actions: { defend: () => void; advance: () => void; rush: () => void; guard: () => void; clearRally: () => void; surge: () => void; rally: (x: number, y: number) => void; sacrifice: () => void; setSpawnType: (type: 'basic' | 'heavy' | 'scout') => void } | null) => void
   surrender: () => void
   resetGame: () => void
 }
@@ -88,8 +88,8 @@ export const useSpeckWarsStore = create<SpeckWarsStore>()((set, get) => ({
   addOutpostCaptured: () => set(s => ({ outpostsCaptured: s.outpostsCaptured + 1 })),
   isNewBest: false,
   setIsNewBest: v => set({ isNewBest: v }),
-  gameActions: { defend: null, advance: null, rush: null, clearRally: null, surge: null, rally: null, sacrifice: null, setSpawnType: null },
-  setGameActions: (actions) => set({ gameActions: actions ?? { defend: null, advance: null, rush: null, clearRally: null, surge: null, rally: null, sacrifice: null, setSpawnType: null } }),
+  gameActions: { defend: null, advance: null, rush: null, guard: null, clearRally: null, surge: null, rally: null, sacrifice: null, setSpawnType: null },
+  setGameActions: (actions) => set({ gameActions: actions ?? { defend: null, advance: null, rush: null, guard: null, clearRally: null, surge: null, rally: null, sacrifice: null, setSpawnType: null } }),
   surrender: () => {
     const s = get()
     resetWinStreak()


### PR DESCRIPTION
## Summary
Two related speck-level improvements:

### G key — Guard nearest friendly outpost
Completes the directional shortcut set:

| Key | Command |
|-----|---------|
| D | Defend — rally to your base |
| N | Advance — nearest non-player outpost |
| **G** | **Guard — nearest player-owned outpost** |
| B | Rush — enemy base |

- Rapid-pressing G cycles through multiple owned outposts
- Falls back to Defend if no outposts are held
- Added as mobile button (⬡ G) and help overlay entry

### Surge + rally cry aura on player specks
Subtle pulsing rings give instant visual feedback on active status effects:
- **Gold ring** (+7px): surge is active (Q key, 2× spawn for 8s)
- **Red ring** (+9px): rally cry triggered (base HP < 25%, 1.5× spawn)

Both are low-alpha (0.08–0.22) so they don't obscure the veteran gold ring.
Player base lookup hoisted outside the speck loop for O(1) per-speck cost.

## Files changed
- `input-handler.ts` — `onGuard` callback + KeyG binding
- `game-instance.ts` — `guard()` method; wired to G key and gameActions
- `store.ts` — `guard` field in gameActions type + default
- `hud.tsx` — mobile button + help overlay
- `speck-layer.ts` — surge gold ring + rally cry red ring during active effects

## Test plan
- [ ] Press G → specks rally to nearest owned outpost; falls back to base if none
- [ ] Press G rapidly → cycles through multiple outposts
- [ ] Press Q (surge) → faint gold rings appear on player specks, fade when surge ends
- [ ] Take heavy base damage (<25% HP) → rally cry triggers, faint red rings appear
- [ ] Rings don't conflict visually with veteran/elite/selection rings

🤖 Generated with [Claude Code](https://claude.com/claude-code)