### PR TITLE
feat(speck-wars): camera viewport rectangle on minimap

### DIFF
--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -332,6 +332,23 @@ export function HUD() {
                   </g>
                 )
               })()}
+              {/* Camera viewport rect */}
+              {hud.cameraViewport && (() => {
+                const vp = hud.cameraViewport
+                const vx = vp.x * SCALE
+                const vy = vp.y * SCALE
+                const vw = vp.w * SCALE
+                const vh = vp.h * SCALE
+                return (
+                  <rect
+                    x={vx} y={vy} width={vw} height={vh}
+                    fill="none"
+                    stroke="rgba(255,255,255,0.25)"
+                    strokeWidth={1}
+                    style={{ pointerEvents: 'none' }}
+                  />
+                )
+              })()}
             </svg>
           </div>
         )

--- a/src/app/speck-wars/domain/types.ts
+++ b/src/app/speck-wars/domain/types.ts
@@ -130,4 +130,5 @@ export interface HudData {
     rallyPoint: { x: number; y: number } | null
     aiRallyPoint: { x: number; y: number } | null
   }
+  cameraViewport?: { x: number; y: number; w: number; h: number }  // world-space viewport rect
 }

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -270,7 +270,13 @@ export class GameInstance {
           }, 1400)
         }
         if (event.type === 'HUD_UPDATE') {
-          store.setHud(event.data)
+          const cameraViewport = {
+            x: -this.camera.x / this.camera.zoom,
+            y: -this.camera.y / this.camera.zoom,
+            w: this.canvas.clientWidth / this.camera.zoom,
+            h: this.canvas.clientHeight / this.camera.zoom,
+          }
+          store.setHud({ ...event.data, cameraViewport })
           const bua = event.data.baseUnderThreat ?? false
           if (bua && !this.prevBaseUnderThreat) {
             this.notify('⚠ BASE UNDER ATTACK', '#ff3333')


### PR DESCRIPTION
## Summary

Adds a faint white rectangle on the minimap showing the portion of the world currently visible in the main canvas. Standard RTS feature that helps players orient themselves when zoomed in or panned away from base.

- Adds optional `cameraViewport` to `HudData` (world-space x/y/w/h)
- `game-instance.ts` supplements each `HUD_UPDATE` event with current camera bounds before passing to the store
- Minimap SVG draws a 25%-opacity white rectangle for the viewport

## Test plan

- [ ] Minimap shows a faint white rectangle indicating the current view area
- [ ] Rectangle moves/resizes as you pan and zoom the camera
- [ ] No visible jank or flicker
- [ ] TypeScript clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)