### PR TITLE
fix(speck-wars): clamp camera on battle snap; expand daily tips

### DIFF
--- a/src/app/speck-wars/components/phase-router.tsx
+++ b/src/app/speck-wars/components/phase-router.tsx
@@ -159,6 +159,9 @@ export function PhaseRouter({ children }: { children: React.ReactNode }) {
             'V key snaps the camera to where fighting is happening.',
             'Press ? in-game to see all hotkeys.',
             'Control groups: box-select specks, Ctrl+4 to save, press 4 to recall.',
+            'Hold A then right-click to issue an attack-move — specks fight enemies en route.',
+            'H key makes selected specks hold position — great for defending a chokepoint.',
+            'Elite specks (6+ kills) get a white diamond ring and deal +30% damage.',
           ]
           const tip = tips[Math.floor(Date.now() / 86400000) % tips.length]
           return (

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -669,6 +669,8 @@ export class GameInstance {
     const h = this.canvas.clientHeight
     this.camera.x = w / 2 - cx * this.camera.zoom
     this.camera.y = h / 2 - cy * this.camera.zoom
+    clampCamera(this.camera, w, h)
+    this.notify('⚔ Battle', '#ff8844', 700)
   }
 
   private snapToBase() {


### PR DESCRIPTION
## Summary

Two small but meaningful improvements:

**1. V key battle snap now clamps camera and notifies**
- `snapToAction()` wasn't calling `clampCamera()` after panning, so the camera could end up outside world boundaries when battles happened near the edge
- Added brief "⚔ Battle" notification so players know the snap fired (previously silent — hard to tell if V did anything)

**2. Three new daily tips on the menu screen**
- "Hold A then right-click to issue an attack-move — specks fight enemies en route"
- "H key makes selected specks hold position — great for defending a chokepoint"
- "Elite specks (6+ kills) get a white diamond ring and deal +30% damage"

These cover mechanics that exist but were undiscoverable from the existing tip pool.

## Test plan

- [ ] Press V during a game — camera snaps to battle centroid and "⚔ Battle" toast appears briefly
- [ ] V near map edge doesn't send camera off-world
- [ ] New tips appear (one per day via date-seeded rotation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)