### PR TITLE
fix(speck-wars): freeze simulation during dramatic game-over delay

### DIFF
--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -53,6 +53,7 @@ export class GameInstance {
   private lastAdvanceMs = 0
   private lastAdvanceIdx = 0
   private cinematicMs = 0
+  private gameOverFreezeMs = 0  // freeze sim during dramatic game-over delay
   private pendingBuild: string | null = null  // building type ID awaiting placement click
 
   constructor(canvas: HTMLCanvasElement) {
@@ -264,6 +265,15 @@ export class GameInstance {
       return
     }
 
+    if (this.gameOverFreezeMs > 0) {
+      this.gameOverFreezeMs = Math.max(0, this.gameOverFreezeMs - dt)
+      const { shakeX, shakeY } = this.computeShake(dt)
+      const dragRect = this.inputHandler.getDragRect()
+      this.renderer.render(this.sim, this.camera, dt, shakeX, shakeY, dragRect)
+      this.rafId = requestAnimationFrame(this.loop)
+      return
+    }
+
     if (store.phase === 'playing') {
       const scaledDt = dt * store.speed
       this.elapsedMs += scaledDt
@@ -276,7 +286,8 @@ export class GameInstance {
           const won = event.winnerId === 'player'
           store.setWinnerId(event.winnerId)
           store.setVictoryType(event.victoryType)
-          // Dramatic camera shake on game-over
+          // Freeze sim and apply camera shake during dramatic game-over delay
+          this.gameOverFreezeMs = 1400
           this.shakeMs = won ? 700 : 450
           this.shakeMaxMs = won ? 700 : 450
           this.shakeStrength = won ? 14 : 9
@@ -614,17 +625,18 @@ export class GameInstance {
     // Clamp camera so world doesn't disappear off-screen
     clampCamera(this.camera, this.canvas.clientWidth, this.canvas.clientHeight)
 
-    let shakeX = 0, shakeY = 0
-    if (this.shakeMs > 0) {
-      this.shakeMs -= dt
-      const t = Math.max(0, this.shakeMs / this.shakeMaxMs)
-      const s = this.shakeStrength * t
-      shakeX = (Math.random() * 2 - 1) * s
-      shakeY = (Math.random() * 2 - 1) * s
-    }
+    const { shakeX, shakeY } = this.computeShake(dt)
     const dragRect = this.inputHandler.getDragRect()
     this.renderer.render(this.sim, this.camera, dt, shakeX, shakeY, dragRect)
     this.rafId = requestAnimationFrame(this.loop)
+  }
+
+  private computeShake(dt: number): { shakeX: number; shakeY: number } {
+    if (this.shakeMs <= 0) return { shakeX: 0, shakeY: 0 }
+    this.shakeMs -= dt
+    const t = Math.max(0, this.shakeMs / this.shakeMaxMs)
+    const s = this.shakeStrength * t
+    return { shakeX: (Math.random() * 2 - 1) * s, shakeY: (Math.random() * 2 - 1) * s }
   }
 
   destroy() {


### PR DESCRIPTION
## Summary

Replaces #2057 (which had stacking issues with other branches). Clean cherry-pick onto current main.

- Game previously kept ticking for 1.4s after GAME_OVER fired — specks still moved during the dramatic pause
- Now a `gameOverFreezeMs` counter stops the sim loop for 1.4s while camera shake and victory/defeat notification play out
- Also extracts shake calculation into `computeShake()` to remove duplication

## Test plan

- [ ] Win a game: specks and buildings freeze instantly when "⚡ VICTORY!" notification appears, then end screen shows after 1.4s
- [ ] Lose a game: same freeze effect with "💀 DEFEATED"
- [ ] Camera shake still plays during the freeze (just the scene is locked)

🤖 Generated with [Claude Code](https://claude.com/claude-code)