### PR TITLE
fix(speck-wars): add MAX_SPECKS guard to turret missile spawner

### DIFF
--- a/src/app/speck-wars/domain/simulation/turret.ts
+++ b/src/app/speck-wars/domain/simulation/turret.ts
@@ -1,6 +1,7 @@
 import type { SimulationState, SpeckMeta } from '../types'
 import { BUILDING_TYPES } from '../config/building-types'
 import { SPECK_TYPES } from '../config/speck-types'
+import { MAX_SPECKS } from '../constants'
 
 let missileCounter = 0
 
@@ -19,8 +20,10 @@ function spawnMissile(sim: SimulationState, bx: number, by: number, ownerId: str
   let slot: number
   if (sim.freeSlots.length > 0) {
     slot = sim.freeSlots.pop()!
-  } else {
+  } else if (sim.speckCount < MAX_SPECKS) {
     slot = sim.speckCount++
+  } else {
+    return  // at capacity, skip missile
   }
   sim.speckX[slot] = bx
   sim.speckY[slot] = by


### PR DESCRIPTION
## Summary

`turret.ts spawnMissile()` incremented `speckCount` without checking capacity, unlike `spawner.ts addSpeck()` which has a proper `< MAX_SPECKS` guard.

At 15,000 specks (unlikely in normal play but possible under sustained turret fire with many targets), missiles would attempt to write beyond the pre-allocated typed array bounds (`Float32Array(15000)`). JavaScript doesn't throw on out-of-bounds typed array writes — they silently become undefined/0 — but the slot would be corrupt and the missile would disappear without working correctly.

Now returns early when at capacity, matching the `addSpeck()` pattern in `spawner.ts`.

## Test plan
- [ ] Normal gameplay: turrets fire missiles and they correctly seek and destroy enemies
- [ ] Edge case (game at speck capacity): turrets skip missile spawn rather than corrupting array