### PR TITLE
fix(speck-wars): missile homing and construction march broken

### DIFF
--- a/src/app/speck-wars/domain/simulation/movement.ts
+++ b/src/app/speck-wars/domain/simulation/movement.ts
@@ -83,7 +83,9 @@ export function moveSpecks(sim: SimulationState, dt: number) {
         }
       }
     } else {
-      const rally = sim.rallyPoints[meta.ownerId]
+      const rally = (meta.assignedRallyX !== undefined)
+        ? { x: meta.assignedRallyX, y: meta.assignedRallyY! }
+        : sim.rallyPoints[meta.ownerId]
       if (rally) {
         const dx = rally.x - speckX[i]
         const dy = rally.y - speckY[i]

--- a/src/app/speck-wars/domain/simulation/speck-ai.ts
+++ b/src/app/speck-wars/domain/simulation/speck-ai.ts
@@ -40,6 +40,7 @@ export function runSpeckAI(sim: SimulationState) {
         meta.constructTargetId = null
       } else {
         meta.state = 'moving'
+        meta.targetId = null  // don't chase enemy buildings while marching to construction site
         meta.assignedRallyX = target.x
         meta.assignedRallyY = target.y
       }


### PR DESCRIPTION
## Root cause

`speck-ai.ts` stored the movement destination in `meta.assignedRallyX/Y` for two subsystems:

- **Missiles** — set to the target speck's current position each tick (for homing)
- **Construction march** — set to the build site position so sacrificing specks march there

But `movement.ts` never checked `meta.assignedRallyX/Y`. It only read `sim.rallyPoints[meta.ownerId]`. So missiles flew toward the owner's global rally point (or wandered via idle aggression) instead of homing in on the target. Construction specks chased their last enemy building target instead of marching to the build site.

## Changes

**`movement.ts`**: When `meta.targetId` is null, prefer `meta.assignedRallyX/Y` over `sim.rallyPoints` when the individual destination is set. This fixes both missiles and construction march in one line.

**`speck-ai.ts`**: Clear `meta.targetId = null` when entering construction march mode. Previously, specks kept their old enemy building target, causing movement.ts to send them toward the enemy instead of the build site.

## Test plan
- [ ] Build a turret: sacrifice 5 specks at a BUILD marker, verify they march to the site and not toward the enemy
- [ ] Confirm turret fires a missile at an enemy speck in range; missile visibly homes to that speck, not toward the player's rally point
- [ ] Set a rally point and confirm normal specks still march to it
- [ ] Confirm construction completes and turret fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)