### PR TITLE
feat(speck-wars): right-click minimap to pan camera without rallying

### DIFF
--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -263,6 +263,16 @@ export function HUD() {
                 const worldY = (py / 120) * 3000
                 gameActions.rally(worldX, worldY)
               }}
+              onContextMenu={(e) => {
+                e.preventDefault()
+                if (!gameActions?.panCamera) return
+                const rect = e.currentTarget.getBoundingClientRect()
+                const px = e.clientX - rect.left
+                const py = e.clientY - rect.top
+                const worldX = (px / 120) * 3000
+                const worldY = (py / 120) * 3000
+                gameActions.panCamera(worldX, worldY)
+              }}
             >
               {/* Speck dots */}
               {hud.minimap.specks.map((s, i) => (
@@ -567,7 +577,7 @@ export function HUD() {
             <span>S — stop · H — hold position</span><span>C — center on base</span>
             <span>N — advance to outpost · D — defend base</span><span>B — rush enemy base</span>
             <span>Q — surge (2× spawn 8s)</span><span>V — snap camera to battle</span>
-            <span>1/2/3 — set spawn type</span><span>Minimap — click to move</span>
+            <span>1/2/3 — set spawn type</span><span>Minimap — left-click rally · right-click pan</span>
             <span>X — cycle speed (1×/2×/4×)</span><span>F — sacrifice 10 specks → +15 HP</span>
             <span>? — this help</span><span></span>
             <span style={{ gridColumn: '1/-1', borderTop: '1px solid rgba(255,255,255,0.08)', paddingTop: 8, marginTop: 2, color: 'rgba(255,215,0,0.5)', fontSize: 11 }}>

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -216,6 +216,11 @@ export class GameInstance {
         this.notify(`Spawn: ${typeId.toUpperCase()}`, color)
       },
       buildTurret: () => this.enterBuildMode('turret'),
+      panCamera: (wx: number, wy: number) => {
+        this.camera.x = this.canvas.clientWidth / 2 - wx * this.camera.zoom
+        this.camera.y = this.canvas.clientHeight / 2 - wy * this.camera.zoom
+        clampCamera(this.camera, this.canvas.clientWidth, this.canvas.clientHeight)
+      },
     })
     this.lastTime = performance.now()
     this.loop(this.lastTime)

--- a/src/app/speck-wars/store.ts
+++ b/src/app/speck-wars/store.ts
@@ -38,8 +38,8 @@ interface SpeckWarsStore {
   addOutpostCaptured: () => void
   isNewBest: boolean
   setIsNewBest: (v: boolean) => void
-  gameActions: { defend: (() => void) | null; advance: (() => void) | null; rush: (() => void) | null; clearRally: (() => void) | null; surge: (() => void) | null; rally: ((x: number, y: number) => void) | null; sacrifice: (() => void) | null; setSpawnType: ((type: 'basic' | 'heavy' | 'scout') => void) | null; buildTurret?: (() => void) | null }
-  setGameActions: (actions: { defend: () => void; advance: () => void; rush: () => void; clearRally: () => void; surge: () => void; rally: (x: number, y: number) => void; sacrifice: () => void; setSpawnType: (type: 'basic' | 'heavy' | 'scout') => void; buildTurret?: () => void } | null) => void
+  gameActions: { defend: (() => void) | null; advance: (() => void) | null; rush: (() => void) | null; clearRally: (() => void) | null; surge: (() => void) | null; rally: ((x: number, y: number) => void) | null; sacrifice: (() => void) | null; setSpawnType: ((type: 'basic' | 'heavy' | 'scout') => void) | null; buildTurret?: (() => void) | null; panCamera: ((x: number, y: number) => void) | null }
+  setGameActions: (actions: { defend: () => void; advance: () => void; rush: () => void; clearRally: () => void; surge: () => void; rally: (x: number, y: number) => void; sacrifice: () => void; setSpawnType: (type: 'basic' | 'heavy' | 'scout') => void; buildTurret?: () => void; panCamera: (x: number, y: number) => void } | null) => void
   surrender: () => void
   resetGame: () => void
 }
@@ -88,8 +88,8 @@ export const useSpeckWarsStore = create<SpeckWarsStore>()((set, get) => ({
   addOutpostCaptured: () => set(s => ({ outpostsCaptured: s.outpostsCaptured + 1 })),
   isNewBest: false,
   setIsNewBest: v => set({ isNewBest: v }),
-  gameActions: { defend: null, advance: null, rush: null, clearRally: null, surge: null, rally: null, sacrifice: null, setSpawnType: null, buildTurret: null },
-  setGameActions: (actions) => set({ gameActions: actions ?? { defend: null, advance: null, rush: null, clearRally: null, surge: null, rally: null, sacrifice: null, setSpawnType: null, buildTurret: null } }),
+  gameActions: { defend: null, advance: null, rush: null, clearRally: null, surge: null, rally: null, sacrifice: null, setSpawnType: null, buildTurret: null, panCamera: null },
+  setGameActions: (actions) => set({ gameActions: actions ?? { defend: null, advance: null, rush: null, clearRally: null, surge: null, rally: null, sacrifice: null, setSpawnType: null, buildTurret: null, panCamera: null } }),
   surrender: () => {
     const s = get()
     resetWinStreak()


### PR DESCRIPTION
## Summary

Adds a second minimap interaction: right-click pans the camera to that world position without issuing a rally command.

Previously, left-clicking the minimap was the only interaction, which both moved your army AND navigated the camera. Players who wanted to peek at a distant location had to either rally there (moving all specks) or manually drag the camera. Now:

- **Left-click minimap** → rally all specks to that location (unchanged)
- **Right-click minimap** → center camera on that location, no rally issued

## What changed

- `store.ts`: Added `panCamera: ((x, y) => void) | null` to `gameActions` type
- `game-instance.ts`: `panCamera` implementation centers camera on world coords + clamps
- `hud.tsx`: Minimap SVG now handles `onContextMenu` (prevents default, calls `panCamera`)
- Help overlay updated to "left-click rally · right-click pan"

## Test plan

- [ ] Right-click minimap → camera pans to that location, specks don't move
- [ ] Left-click minimap → specks rally as before
- [ ] Browser context menu does not appear when right-clicking minimap

> Rebased onto main (which now includes turret construction, building selection HUD, and per-building rally). Cherry-picked only the unique commit from the original PR #2060.