### PR TITLE
fix(speck-wars): blitz modifier skips player spawn boost on med/hard/very-hard

### DIFF
--- a/src/app/speck-wars/domain/simulation/create-sim.ts
+++ b/src/app/speck-wars/domain/simulation/create-sim.ts
@@ -86,8 +86,9 @@ export function createSim(seed: number = Date.now(), difficulty: Difficulty = 'm
     aiBase.maxHp = BASE_HP * 2
   }
   if (dailyModifier === 'blitz') {
-    if (playerBase.spawnIntervalOverride !== undefined) playerBase.spawnIntervalOverride *= 0.65
-    aiBase.spawnIntervalOverride = (aiBase.spawnIntervalOverride ?? 800) * 0.65
+    const DEFAULT_BASE_INTERVAL = 800  // BUILDING_TYPES.base.spawnInterval
+    playerBase.spawnIntervalOverride = (playerBase.spawnIntervalOverride ?? DEFAULT_BASE_INTERVAL) * 0.65
+    aiBase.spawnIntervalOverride = (aiBase.spawnIntervalOverride ?? DEFAULT_BASE_INTERVAL) * 0.65
   }
 
   return {


### PR DESCRIPTION
## Root cause

In `create-sim.ts`, the blitz daily modifier applied a 1.5× spawn-rate boost like this:

```ts
if (playerBase.spawnIntervalOverride !== undefined) playerBase.spawnIntervalOverride *= 0.65
aiBase.spawnIntervalOverride = (aiBase.spawnIntervalOverride ?? 800) * 0.65
```

`playerSpawnInterval` is `undefined` on medium/hard/very-hard (the player uses the default 800 ms from `BUILDING_TYPES`). So the guard `!== undefined` silently skipped the player on all but easy difficulty.

The AI always has an override set from `aiSpawnInterval`, so it always received the boost.

**Effect**: on a blitz day at medium/hard/very-hard, the AI spawned 1.5× faster but the player did not — an unintended 1.5× production disadvantage for the player.

## Fix

Match the `(value ?? DEFAULT) * 0.65` pattern used for the AI:

```ts
const DEFAULT_BASE_INTERVAL = 800
playerBase.spawnIntervalOverride = (playerBase.spawnIntervalOverride ?? DEFAULT_BASE_INTERVAL) * 0.65
aiBase.spawnIntervalOverride = (aiBase.spawnIntervalOverride ?? DEFAULT_BASE_INTERVAL) * 0.65
```

## Test plan
- [ ] Start a game with blitz modifier (edit `DAILY_MODIFIER_POOL` to force it, or wait for the right day)
- [ ] Confirm both bases produce specks at ~1.5× normal rate (520 ms at medium vs normal 800 ms)
- [ ] Confirm easy difficulty still works (550 ms → ~357 ms on blitz)

🤖 Generated with [Claude Code](https://claude.com/claude-code)