### PR TITLE
fix(speck-wars): two-finger trackpad swipe pans camera

### DIFF
--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -559,7 +559,7 @@ export function HUD() {
           }}>
             <span>Right-click — move · Left-click — deselect</span><span>Space — pause</span>
             <span>Left-drag — box select specks</span><span>Middle-drag — pan camera</span>
-            <span>Scroll — zoom</span><span>R — clear rally</span>
+            <span>Ctrl+scroll — zoom · scroll — pan</span><span>R — clear rally</span>
             <span>E / Ctrl+A — select all · Esc — cancel/clear</span><span>Arrow keys / W S — pan camera</span>
             <span>Ctrl+4-9 — save group</span><span>4-9 — recall group</span>
             <span style={{ color: 'rgba(74,247,196,0.7)' }}>Right-click with group selected → moves selected only</span><span style={{ color: 'rgba(74,247,196,0.7)' }}>Specks engage enemies en route (attack-move)</span>

--- a/src/app/speck-wars/input/input-handler.ts
+++ b/src/app/speck-wars/input/input-handler.ts
@@ -222,11 +222,18 @@ export class InputHandler {
 
   private onWheel = (e: WheelEvent) => {
     e.preventDefault()
-    const factor = e.deltaY < 0 ? 1.1 : 0.9
-    const rect = this.canvas.getBoundingClientRect()
-    const sx = e.clientX - rect.left
-    const sy = e.clientY - rect.top
-    Object.assign(this.camera, zoomAt(this.camera, sx, sy, factor))
+    if (e.ctrlKey) {
+      // Pinch-to-zoom (trackpad) or Ctrl+scroll — zoom toward cursor
+      const factor = e.deltaY < 0 ? 1.1 : 0.9
+      const rect = this.canvas.getBoundingClientRect()
+      const sx = e.clientX - rect.left
+      const sy = e.clientY - rect.top
+      Object.assign(this.camera, zoomAt(this.camera, sx, sy, factor))
+    } else {
+      // Two-finger swipe (trackpad) or scroll wheel — pan camera
+      this.camera.x -= e.deltaX
+      this.camera.y -= e.deltaY
+    }
   }
 
   private onTouchStart = (e: TouchEvent) => {


### PR DESCRIPTION
## Summary
- Two-finger trackpad swipe now pans the camera (deltaX/deltaY)
- Ctrl+scroll / Ctrl+pinch still zooms toward cursor (unchanged behaviour)
- Regular scroll wheel pans vertically (deltaY) — natural for mice too

## Why
Previously **all** wheel events triggered zoom, so trackpad two-finger swipe would zoom in/out rather than pan. This was the only way to navigate the map on a MacBook without using middle-mouse or WASD.

## Test plan
- [ ] Two-finger swipe on trackpad pans the map in all directions
- [ ] Ctrl+scroll (or pinch on trackpad) still zooms toward cursor
- [ ] Mouse scroll wheel pans camera vertically
- [ ] WASD + arrow keys still pan as expected
- [ ] Middle-mouse drag still pans

Closes the gap noted when closing #2048.

🤖 Generated with [Claude Code](https://claude.com/claude-code)