### PR TITLE
fix(speck-wars): clear selectedBuildingId when building is destroyed

### DIFF
--- a/src/app/speck-wars/domain/simulation/tick.ts
+++ b/src/app/speck-wars/domain/simulation/tick.ts
@@ -35,6 +35,11 @@ export function tick(sim: SimulationState, dt: number): SimulationState {
   // 5. Deal damage, destroy buildings/specks
   resolveCombat(sim, dt)
 
+  // 5a. Auto-clear selectedBuildingId if the building was destroyed this tick
+  if (sim.selectedBuildingId && !sim.buildings[sim.selectedBuildingId]) {
+    sim.selectedBuildingId = null
+  }
+
   // 5b. Mark low-HP specks as retreating
   for (let i = 0; i < sim.speckCount; i++) {
     const meta = sim.speckMeta[i]


### PR DESCRIPTION
## Summary

- When combat destroys a building, `sim.selectedBuildingId` was not cleared
- Subsequent right-clicks would issue `SET_BUILDING_RALLY` for the ghost building ID, silently no-op-ing instead of issuing a global `RALLY`
- Fix: after `resolveCombat`, auto-null `selectedBuildingId` if the building no longer exists in `sim.buildings`

## Test plan

- [ ] Select a player outpost, then let the AI capture/destroy it — verify right-click resumes global rally behavior immediately after
- [ ] Verify selecting a living building still works normally (SET_BUILDING_RALLY still fires)
- [ ] Verify `CLEAR_SELECT` still nulls `selectedBuildingId` as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)