### PR TITLE
feat(speck-wars): scrolling kill feed below minimap

### DIFF
--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -42,6 +42,7 @@ export function HUD() {
   const countdown = useSpeckWarsStore(s => s.countdown)
   const kills = useSpeckWarsStore(s => s.kills)
   const losses = useSpeckWarsStore(s => s.losses)
+  const killFeed = useSpeckWarsStore(s => s.killFeed)
   const spawnMode = useSpeckWarsStore(s => s.spawnMode)
   const setSpawnMode = useSpeckWarsStore(s => s.setSpawnMode)
   const difficulty = useSpeckWarsStore(s => s.difficulty)
@@ -423,6 +424,32 @@ export function HUD() {
           </div>
         )
       })()}
+
+      {/* Kill feed — below minimap, top-right */}
+      {phase === 'playing' && killFeed.length > 0 && (
+        <div style={{
+          position: 'absolute', top: 210, right: 16,
+          display: 'flex', flexDirection: 'column', gap: 3,
+          pointerEvents: 'none',
+          width: 140,
+        }}>
+          {killFeed.map(entry => {
+            const age = Date.now() - entry.ts
+            const opacity = age > 3000 ? Math.max(0, 1 - (age - 3000) / 1500) : 1
+            return (
+              <div key={entry.id} style={{
+                display: 'flex', alignItems: 'center', gap: 5,
+                fontSize: 9, letterSpacing: 0.5,
+                opacity,
+                transition: 'opacity 150ms',
+              }}>
+                <span style={{ fontSize: 11 }}>{entry.icon}</span>
+                <span style={{ color: entry.color }}>{entry.label}</span>
+              </div>
+            )
+          })}
+        </div>
+      )}
 
       {/* Timer + Pause button — top bar */}
       <div style={{

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -54,6 +54,8 @@ export class GameInstance {
   private lastAdvanceIdx = 0
   private cinematicMs = 0
   private pendingBuild: string | null = null  // building type ID awaiting placement click
+  private killFeedKillAt = 0    // last time we pushed a kill entry
+  private killFeedLossAt = 0    // last time we pushed a loss entry
 
   constructor(canvas: HTMLCanvasElement) {
     this.canvas = canvas
@@ -268,6 +270,7 @@ export class GameInstance {
       const scaledDt = dt * store.speed
       this.elapsedMs += scaledDt
       store.setElapsedMs(this.elapsedMs)
+      store.pruneKillFeed()
       this.aiController.update(this.sim, scaledDt)
       this.sim = tick(this.sim, scaledDt)
 
@@ -356,6 +359,7 @@ export class GameInstance {
               this.outpostHpWarnedAt[buildingId] = now
               const name = buildingId.replace('outpost-', '').toUpperCase()
               this.notify(`⬡ ${name} HP CRITICAL!`, '#ff2200', 2500)
+              store.pushKillFeedEntry({ icon: '🏗', label: `${name} critical`, color: '#ff2200' })
             }
           }
           // Triple outpost notification: fire when ownership of all 3 outposts changes hands
@@ -400,6 +404,10 @@ export class GameInstance {
           if (event.killedOwnerId === 'ai' && event.killerOwnerId === 'player') {
             store.addKill()
             const nowTs = Date.now()
+            if (nowTs - this.killFeedKillAt > 700) {
+              this.killFeedKillAt = nowTs
+              store.pushKillFeedEntry({ icon: '⚔', label: 'enemy down', color: '#4af7c4' })
+            }
             // Combo detection: 3+ kills within 2s
             this.recentKillTimes.push(nowTs)
             this.recentKillTimes = this.recentKillTimes.filter(t => nowTs - t < 2000)
@@ -420,7 +428,14 @@ export class GameInstance {
             if (milestones[k]) {
               this.notify(milestones[k].message, milestones[k].color, 2000)
             }
-          } else if (event.killedOwnerId === 'player' && event.killerOwnerId === 'ai') store.addLoss()
+          } else if (event.killedOwnerId === 'player' && event.killerOwnerId === 'ai') {
+            store.addLoss()
+            const nowTs2 = Date.now()
+            if (nowTs2 - this.killFeedLossAt > 500) {
+              this.killFeedLossAt = nowTs2
+              store.pushKillFeedEntry({ icon: '💀', label: 'ally lost', color: '#ff4f7b' })
+            }
+          }
           if (!this.firstBloodDone) {
             this.firstBloodDone = true
             const playerGotIt = event.killerOwnerId === 'player'
@@ -500,6 +515,10 @@ export class GameInstance {
               : `⬡ ${outpostName} CAPTURED`
             const color = isPlayerLoss ? '#ff4f7b' : isRecapture ? '#ffd700' : '#4af7c4'
             this.notify(message, color, 2500)
+            store.pushKillFeedEntry({ icon: '⬡', label: message.replace('⬡ ', ''), color })
+          } else if (event.newOwner === 'ai' && event.previousOwner === 'neutral') {
+            const outpostName = event.outpostId.replace('outpost-', '').toUpperCase()
+            store.pushKillFeedEntry({ icon: '⬡', label: `${outpostName} → enemy`, color: '#ff8844' })
           }
           // Track capture combos
           if (event.newOwner === 'player') {

--- a/src/app/speck-wars/store.ts
+++ b/src/app/speck-wars/store.ts
@@ -5,6 +5,14 @@ import { resetWinStreak, recordGameResult } from './lib/personal-best'
 type GamePhase = 'menu' | 'playing' | 'paused' | 'victory' | 'defeat'
 export type Difficulty = 'easy' | 'medium' | 'hard' | 'very-hard'
 
+export interface KillFeedEntry {
+  id: number
+  ts: number
+  icon: string
+  label: string
+  color: string
+}
+
 interface SpeckWarsStore {
   phase: GamePhase
   setPhase: (phase: GamePhase) => void
@@ -38,6 +46,9 @@ interface SpeckWarsStore {
   addOutpostCaptured: () => void
   isNewBest: boolean
   setIsNewBest: (v: boolean) => void
+  killFeed: KillFeedEntry[]
+  pushKillFeedEntry: (entry: Omit<KillFeedEntry, 'id' | 'ts'>) => void
+  pruneKillFeed: () => void
   gameActions: { defend: (() => void) | null; advance: (() => void) | null; rush: (() => void) | null; clearRally: (() => void) | null; surge: (() => void) | null; rally: ((x: number, y: number) => void) | null; sacrifice: (() => void) | null; setSpawnType: ((type: 'basic' | 'heavy' | 'scout') => void) | null; buildTurret?: (() => void) | null }
   setGameActions: (actions: { defend: () => void; advance: () => void; rush: () => void; clearRally: () => void; surge: () => void; rally: (x: number, y: number) => void; sacrifice: () => void; setSpawnType: (type: 'basic' | 'heavy' | 'scout') => void; buildTurret?: () => void } | null) => void
   surrender: () => void
@@ -88,6 +99,17 @@ export const useSpeckWarsStore = create<SpeckWarsStore>()((set, get) => ({
   addOutpostCaptured: () => set(s => ({ outpostsCaptured: s.outpostsCaptured + 1 })),
   isNewBest: false,
   setIsNewBest: v => set({ isNewBest: v }),
+  killFeed: [],
+  pushKillFeedEntry: entry => set(s => {
+    const id = Date.now() + Math.random()
+    const next = [{ ...entry, id, ts: Date.now() }, ...s.killFeed].slice(0, 6)
+    return { killFeed: next }
+  }),
+  pruneKillFeed: () => set(s => {
+    const cutoff = Date.now() - 4500
+    const next = s.killFeed.filter(e => e.ts > cutoff)
+    return next.length === s.killFeed.length ? s : { killFeed: next }
+  }),
   gameActions: { defend: null, advance: null, rush: null, clearRally: null, surge: null, rally: null, sacrifice: null, setSpawnType: null, buildTurret: null },
   setGameActions: (actions) => set({ gameActions: actions ?? { defend: null, advance: null, rush: null, clearRally: null, surge: null, rally: null, sacrifice: null, setSpawnType: null, buildTurret: null } }),
   surrender: () => {
@@ -110,6 +132,7 @@ export const useSpeckWarsStore = create<SpeckWarsStore>()((set, get) => ({
     isNewBest: false,
     peakArmySize: 0,
     outpostsCaptured: 0,
+    killFeed: [],
     difficulty: s.difficulty,
   })),
 }))


### PR DESCRIPTION
## Summary
Closes #2061

Adds a scrolling event log in the top-right corner below the minimap showing the last 6 notable combat events:

- ⚔ **enemy down** — player scored a kill (throttled; max 1 entry per 700ms to avoid flood)
- 💀 **ally lost** — player speck killed by AI (throttled; max 1 per 500ms)
- ⬡ **outpost events** — every capture, recapture, or loss (always shown)
- 🏗 **outpost critical** — piggybacked on existing HP-critical warning throttle

Entries fade from full → transparent over 1.5s starting at 3s, and are pruned from the store at 4.5s. Max 6 entries; newest pushes oldest off.

## Implementation
- `store.ts`: new `KillFeedEntry` interface, `killFeed[]` array, `pushKillFeedEntry()`, `pruneKillFeed()`
- `game-instance.ts`: pushes entries on SPECK_DIED, OUTPOST_CAPTURED, and outpost-HP-critical; prunes once per game tick
- `hud.tsx`: renders the feed below the minimap (top: 210, right: 16)

## Test plan
- [ ] Kill entries appear when player kills enemies; not more than ~1 per second
- [ ] Loss entries appear when player specks die
- [ ] Outpost capture/loss shows immediately
- [ ] Entries fade and disappear after ~4.5s
- [ ] Max 6 entries visible at once
- [ ] No entries shown outside 'playing' phase

🤖 Generated with [Claude Code](https://claude.com/claude-code)