### PR TITLE
fix(speck-wars): enemy outpost count in pause screen

### DIFF
--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -884,7 +884,8 @@ export function HUD() {
                 <span>Base: {Math.round(playerBaseHpVal)}HP</span>
                 <span>Base: {Math.round(aiBaseHpVal)}HP</span>
                 <span>Outposts: {playerOutpostCount}</span>
-                <span style={{ color: colorHex(PLAYER_COLOR), opacity: 0.7 }}>↑{kills} ↓{losses}</span>
+                <span>Outposts: {aiOutpostCount}</span>
+                <span style={{ gridColumn: '1/-1', textAlign: 'center', color: colorHex(PLAYER_COLOR), opacity: 0.7 }}>↑{kills} kills · {losses} lost</span>
                 <span style={{ gridColumn: '1/-1', textAlign: 'center', borderTop: '1px solid rgba(255,255,255,0.08)', paddingTop: 8, marginTop: 4 }}>
                   {formatTime(elapsedMs)} elapsed
                 </span>


### PR DESCRIPTION
## Summary
The pause overlay stats grid had a misaligned last row: player outpost count was paired with the kill/loss counter (which belongs to the player, not enemy). Enemy outpost count was completely missing.

**Before:**
```
Outposts: 2    |  ↑42 ↓14
```

**After:**
```
Outposts: 2    |  Outposts: 1
       ↑42 kills · 14 lost
```

## Test plan
- [ ] Pause during a game, verify player and enemy outpost counts show on the same row
- [ ] Kill/loss counter shows below spanning full width
- [ ] All other stats (specks, army composition, production rate, base HP) still display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)