### PR TITLE
fix(speck-wars): clear outpost rallyPoint on ownership change

### DIFF
--- a/src/app/speck-wars/domain/simulation/capture.ts
+++ b/src/app/speck-wars/domain/simulation/capture.ts
@@ -61,6 +61,8 @@ export function updateCapture(sim: SimulationState, dt: number) {
       building.captureSide = null
       // Reset spawn timer so it starts fresh for the new owner
       building.spawnTimer = 0
+      // Clear previous owner's rally — new owner should not inherit it
+      building.rallyPoint = null
       sim.events.push({
         type: 'OUTPOST_CAPTURED',
         outpostId: building.id,


### PR DESCRIPTION
## Summary

- When an outpost is captured, `building.rallyPoint` was not reset
- The new owner's spawner (`spawner.ts:71-74`) stamps each new speck with the building's `rallyPoint` as `assignedRallyX/Y`
- Result: AI specks spawning from a newly captured player outpost would march to the player's old rally position instead of auto-targeting normally
- Fix: add `building.rallyPoint = null` in `capture.ts` when ownership changes

## Test plan

- [ ] Set a rally on an outpost you own, then let the AI capture it — verify AI specks from that outpost head toward the AI's rally/base, not your old rally position
- [ ] Capture a neutral or AI outpost — verify it starts with no pre-set rally (specks auto-target)
- [ ] Player recaptures an AI-held outpost — no stale AI rally inherited

🤖 Generated with [Claude Code](https://claude.com/claude-code)