### PR TITLE
fix(speck-wars): clear stale targetId when building changes to friendly ownership

### DIFF
--- a/src/app/speck-wars/domain/simulation/speck-ai.ts
+++ b/src/app/speck-wars/domain/simulation/speck-ai.ts
@@ -46,8 +46,8 @@ export function runSpeckAI(sim: SimulationState) {
       continue
     }
 
-    // Clear dead or invalid targets
-    if (meta.targetId && !buildings[meta.targetId]) {
+    // Clear dead or invalid targets (also clear if building changed to friendly ownership)
+    if (meta.targetId && (!buildings[meta.targetId] || buildings[meta.targetId].ownerId === meta.ownerId)) {
       meta.targetId = null
     }
 


### PR DESCRIPTION
## Summary

- When an outpost changes ownership (player recaptures an AI-held post, or vice versa), specks that had that building as `targetId` kept targeting it even though it's now friendly
- In `speck-ai.ts` the `if (meta.targetId) continue` guard at line 152 prevented re-targeting, leaving the speck idle next to its now-friendly building indefinitely
- Fix: expand the existing dead-target check to also clear `targetId` when `building.ownerId === meta.ownerId`

## Test plan

- [ ] Player specks attacking an AI outpost that the player recaptures mid-attack — they should re-target the enemy base, not sit next to the now-friendly outpost
- [ ] AI specks targeting a player outpost that gets captured by the AI should clear their target and re-assign to a new enemy

🤖 Generated with [Claude Code](https://claude.com/claude-code)