### PR TITLE
feat(speck-wars): turret build mode — ghost preview + left-click placement

### DIFF
--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -3,7 +3,7 @@ import { tick } from './domain/simulation/tick'
 import type { SimulationState } from './domain/types'
 import { useSpeckWarsStore } from './store'
 import { Renderer } from './rendering/renderer'
-import { createCamera, clampCamera } from './rendering/camera'
+import { createCamera, clampCamera, screenToWorld } from './rendering/camera'
 import { InputHandler } from './input/input-handler'
 import type { Camera } from './rendering/camera'
 import { AIController, type AIPersonality } from './domain/ai/ai-controller'
@@ -98,6 +98,7 @@ export class GameInstance {
         if (this.pendingBuild) {
           const typeId = this.pendingBuild
           this.pendingBuild = null
+          this.inputHandler?.setPendingBuildActive(false)
           this.sim.inputQueue.push({ type: 'BUILD', ownerId: 'player', buildingTypeId: typeId, x: wx, y: wy })
           this.notify('◆ TURRET PLACED', '#ffd700', 1500)
           return
@@ -148,6 +149,7 @@ export class GameInstance {
       () => {                                                          // Escape — clear selection / cancel build mode
         if (this.pendingBuild) {
           this.pendingBuild = null
+          this.inputHandler?.setPendingBuildActive(false)
           this.notify('Build cancelled', '#aaaaaa', 800)
           return
         }
@@ -623,7 +625,15 @@ export class GameInstance {
       shakeY = (Math.random() * 2 - 1) * s
     }
     const dragRect = this.inputHandler.getDragRect()
-    this.renderer.render(this.sim, this.camera, dt, shakeX, shakeY, dragRect)
+    let ghostBuild: { typeId: string; wx: number; wy: number } | null = null
+    if (this.pendingBuild) {
+      const mouse = this.inputHandler.getMouseScreenPos()
+      if (mouse) {
+        const wpos = screenToWorld(mouse.x, mouse.y, this.camera)
+        ghostBuild = { typeId: this.pendingBuild, wx: wpos.x, wy: wpos.y }
+      }
+    }
+    this.renderer.render(this.sim, this.camera, dt, shakeX, shakeY, dragRect, ghostBuild)
     this.rafId = requestAnimationFrame(this.loop)
   }
 
@@ -694,6 +704,7 @@ export class GameInstance {
 
   enterBuildMode(buildingTypeId: string) {
     this.pendingBuild = buildingTypeId
+    this.inputHandler?.setPendingBuildActive(true)
     this.notify('◆ CLICK TO PLACE TURRET', '#ffd700', 3000)
   }
 

--- a/src/app/speck-wars/input/input-handler.ts
+++ b/src/app/speck-wars/input/input-handler.ts
@@ -26,6 +26,7 @@ export class InputHandler {
   private onRecallControlGroup?: (slot: number) => void
   private pendingModifier: 'none' | 'attack' | 'patrol' = 'none'
   private isPanDragging = false   // middle-mouse only
+  private pendingBuildActive = false
   private onStop?: () => void
   private onHold?: () => void
   private onAttackMove?: (worldX: number, worldY: number) => void
@@ -193,8 +194,17 @@ export class InputHandler {
         const world = screenToWorld(sx, sy, this.camera)
         this.onBoxSelect?.(this.dragSelectStartWorldX, this.dragSelectStartWorldY, world.x, world.y)
       } else {
-        // Single left-click: deselect all
-        this.onClearSelect?.()
+        if (this.pendingBuildActive) {
+          // In build placement mode: left-click places the building
+          const rect = this.canvas.getBoundingClientRect()
+          const sx = e.clientX - rect.left
+          const sy = e.clientY - rect.top
+          const world = screenToWorld(sx, sy, this.camera)
+          this.onRally?.(world.x, world.y)
+        } else {
+          // Normal left-click: deselect all
+          this.onClearSelect?.()
+        }
       }
       return
     }
@@ -378,6 +388,12 @@ export class InputHandler {
       x2: this.mouseX,
       y2: this.mouseY,
     }
+  }
+
+  setPendingBuildActive(active: boolean) { this.pendingBuildActive = active }
+  getMouseScreenPos(): { x: number; y: number } | null {
+    if (this.mouseX < 0) return null
+    return { x: this.mouseX, y: this.mouseY }
   }
 
   destroy() {

--- a/src/app/speck-wars/rendering/layers/building-layer.ts
+++ b/src/app/speck-wars/rendering/layers/building-layer.ts
@@ -35,7 +35,7 @@ export class BuildingLayer {
     this.spawnFlashMap.set(buildingId, Date.now())
   }
 
-  update(sim: SimulationState, playerColors: Record<string, number>, selectedBuildingId: string | null = null) {
+  update(sim: SimulationState, playerColors: Record<string, number>, selectedBuildingId: string | null = null, ghostBuild?: { typeId: string; wx: number; wy: number } | null) {
     const now = Date.now()
     this.gfx.clear()
 
@@ -340,6 +340,26 @@ export class BuildingLayer {
           ])
           this.gfx.lineStyle(0)
         }
+      }
+    }
+
+    // Draw placement ghost for pending build
+    if (ghostBuild) {
+      const btype = BUILDING_TYPES[ghostBuild.typeId]
+      const r = btype?.size ?? 18
+      const pulse = 0.5 + 0.3 * Math.sin(now / 400)
+      const ghostColor = 0x4af7c4  // player color
+      this.gfx.beginFill(ghostColor, pulse * 0.2)
+      this.gfx.drawCircle(ghostBuild.wx, ghostBuild.wy, r)
+      this.gfx.endFill()
+      this.gfx.lineStyle(2, ghostColor, pulse)
+      this.gfx.drawCircle(ghostBuild.wx, ghostBuild.wy, r)
+      this.gfx.lineStyle(0)
+      const attackRange = (btype as { attackRange?: number })?.attackRange
+      if (attackRange) {
+        this.gfx.lineStyle(0.5, ghostColor, 0.15)
+        this.gfx.drawCircle(ghostBuild.wx, ghostBuild.wy, attackRange)
+        this.gfx.lineStyle(0)
       }
     }
   }

--- a/src/app/speck-wars/rendering/renderer.ts
+++ b/src/app/speck-wars/rendering/renderer.ts
@@ -71,11 +71,11 @@ export class Renderer {
     this.app.stage.addChild(this.selectionGfx)
   }
 
-  render(sim: SimulationState, camera: { x: number; y: number; zoom: number }, dt: number, shakeX = 0, shakeY = 0, dragRect?: { x1: number; y1: number; x2: number; y2: number } | null): void {
+  render(sim: SimulationState, camera: { x: number; y: number; zoom: number }, dt: number, shakeX = 0, shakeY = 0, dragRect?: { x1: number; y1: number; x2: number; y2: number } | null, ghostBuild?: { typeId: string; wx: number; wy: number } | null): void {
     this.world.position.set(camera.x + shakeX, camera.y + shakeY)
     this.world.scale.set(camera.zoom)
 
-    this.buildingLayer.update(sim, PLAYER_COLORS, sim.selectedBuildingId)
+    this.buildingLayer.update(sim, PLAYER_COLORS, sim.selectedBuildingId, ghostBuild)
     this.speckLayer.update(sim, sim.selectedSpeckIds)
 
     // Process events from this tick


### PR DESCRIPTION
## Summary

- When build mode is active (T key or build menu), the turret footprint follows the mouse as a pulsing ghost circle with its attack range ring shown at low opacity
- Left-click now places the building in addition to right-click, matching typical strategy game conventions
- InputHandler.setPendingBuildActive() gates the left-click routing so normal left-click (deselect) still works outside build mode
- getMouseScreenPos() exposes mouse screen coordinates so game-instance.ts can compute the world position for the ghost render

## Test plan

- [ ] Press T (or use build menu) to enter build mode — ghost circle should appear under cursor and move with the mouse; attack range ring visible at low opacity
- [ ] Left-click places the turret at cursor position
- [ ] Right-click also places the turret (existing behavior preserved)
- [ ] Escape cancels build mode and removes ghost
- [ ] Left-click outside build mode still deselects specks normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)