### PR TITLE
fix(speck-wars): prevent silent build failure + R key clears per-building rally

### DIFF
--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -97,6 +97,22 @@ export class GameInstance {
         // Build placement mode: place the pending building at the clicked location
         if (this.pendingBuild) {
           const typeId = this.pendingBuild
+          const btype = BUILDING_TYPES[typeId]
+          const cost = btype?.sacrificeCost ?? 0
+          // Guard against silent build failure: check speck count before placing
+          const useSelection = this.sim.selectedSpeckIds.size > 0
+          let available = 0
+          for (let i = 0; i < this.sim.speckCount; i++) {
+            if (!this.sim.speckIds[i]) continue
+            const m = this.sim.speckMeta[i]
+            if (!m || m.ownerId !== 'player') continue
+            if (useSelection && !this.sim.selectedSpeckIds.has(m.id)) continue
+            available++
+          }
+          if (available < cost) {
+            this.notify(`Need ${cost} specks to build (have ${available})`, '#ff4f7b', 2000)
+            return  // stay in build mode so player can gather more specks
+          }
           this.pendingBuild = null
           this.sim.inputQueue.push({ type: 'BUILD', ownerId: 'player', buildingTypeId: typeId, x: wx, y: wy })
           this.notify('◆ TURRET PLACED', '#ffd700', 1500)
@@ -675,6 +691,10 @@ export class GameInstance {
 
   clearRally() {
     this.sim.rallyPoints['player'] = null
+    // Also clear per-building rally so R fully resets all spawn targeting
+    for (const building of Object.values(this.sim.buildings)) {
+      if (building.ownerId === 'player') building.rallyPoint = null
+    }
   }
 
   surge() {


### PR DESCRIPTION
## Summary

Two fixes in game-instance.ts:

### 1. Silent build failure (false TURRET PLACED notification)
- When clicking to place a turret, game-instance.ts immediately showed TURRET PLACED and cleared pendingBuild, then pushed the BUILD event
- tick.ts silently rejected the event if not enough specks (selectedCount < sacrificeCost)
- Player saw the success notification but no turret appeared
- Fix: check available speck count before placing; if insufficient, show error and stay in build mode

### 2. R key not clearing per-building rally
- clearRally() only cleared sim.rallyPoints player (global rally)
- Per-building rallyPoint set via SET_BUILDING_RALLY was untouched
- Newly spawned specks from buildings still marched to old rally after pressing R
- Fix: also null building.rallyPoint on all player buildings in clearRally()

## Test plan

- [ ] Enter build mode (T) with fewer than 20 specks, click to place — error notification shown, build mode stays active
- [ ] Enter build mode with 20+ specks, click to place — TURRET PLACED shown, turret appears
- [ ] Set per-building rally on outpost (select it, right-click), press R — next spawned specks from outpost have no assigned rally

🤖 Generated with [Claude Code](https://claude.com/claude-code)