### PR TITLE
fix(speck-wars): sync waveCountdown every frame for smooth HUD display

### DIFF
--- a/src/app/speck-wars/domain/ai/ai-controller.ts
+++ b/src/app/speck-wars/domain/ai/ai-controller.ts
@@ -41,6 +41,9 @@ export class AIController {
         this.waveTimer = 90000
         sim.events.push({ type: 'AI_WAVE_START', waveNumber: this.waveNumber })
       }
+      // Keep waveCountdown fresh every frame (not just during decisions) for smooth HUD display
+      sim.waveCountdown = this.waveTimer
+      sim.waveInProgress = this.waveRemainingMs > 0
     }
 
     // Adaptive difficulty: if the enemy holds a 3:1 speck advantage for 30s, speed up AI decisions


### PR DESCRIPTION
## Summary
- `sim.waveCountdown` was only written during AI decision ticks (every 6–15 game ticks depending on difficulty), causing the wave timer in the HUD to stutter or appear frozen between updates
- Moved the `sim.waveCountdown` and `sim.waveInProgress` assignments into the top of the `waveEnabled` block so they run on every `update()` call (every frame)
- No logic change — only the sync cadence changes; the timer itself (`this.waveTimer`) already decremented every frame

## Test plan
- [ ] Start a Hard or Very Hard game (wave system only activates on those difficulties)
- [ ] Observe the wave countdown HUD — timer should decrement smoothly at ~60fps instead of jumping in discrete steps every ~0.5s
- [ ] Confirm wave still triggers correctly after countdown reaches zero
- [ ] Confirm `waveInProgress` banner appears and disappears on time

🤖 Generated with [Claude Code](https://claude.com/claude-code)