### PR TITLE
fix(speck-wars): HOLD command now actually stops specks from moving

### DIFF
--- a/src/app/speck-wars/domain/simulation/speck-ai.ts
+++ b/src/app/speck-wars/domain/simulation/speck-ai.ts
@@ -51,11 +51,10 @@ export function runSpeckAI(sim: SimulationState) {
       meta.targetId = null
     }
 
-    // Hold position flag: don't move or attack
+    // Hold position flag: force state to 'holding' so movement.ts keeps them stationary,
+    // then fall through to the 'holding' block to handle adjacent attacks
     if (meta.holdPosition) {
-      meta.state = 'idle'
-      meta.targetId = null
-      continue
+      meta.state = 'holding'
     }
 
     // Holding specks: don't move or pursue, but attack enemies within melee range

--- a/src/app/speck-wars/domain/simulation/tick.ts
+++ b/src/app/speck-wars/domain/simulation/tick.ts
@@ -270,7 +270,7 @@ function consumeInputs(sim: SimulationState) {
         meta.assignedRallyY = undefined
         meta.targetId = null
         meta.holdPosition = true
-        meta.state = 'idle'
+        meta.state = 'holding'
       }
       if (event.ownerId === 'player') {
         sim.rallyPoints['player-selected'] = null


### PR DESCRIPTION
## Summary
- HOLD command set `meta.state = 'idle'` but `movement.ts` checks for `state === 'holding'` to zero velocity — so held specks silently moved and attacked like normal idle specks
- Fixed by setting `state = 'holding'` both in `tick.ts` (initial command handler) and `speck-ai.ts` (per-tick maintenance)
- Removed the early `continue` from the `holdPosition` check in `speck-ai.ts` so held specks fall through to the `state === 'holding'` block, which handles adjacent-enemy attacks and keeps state in sync each tick (e.g. resetting to 'holding' after a brief 'attacking' transition)

## Root cause
Two separate places both set `state = 'idle'` instead of `'holding'`:
1. `tick.ts:273` — the HOLD event handler
2. `speck-ai.ts:56` — the per-tick `holdPosition` maintenance

The `movement.ts` hold check at line 65 (`if (meta.state === 'holding')`) was dead code because neither path ever set state to 'holding'.

## Test plan
- [ ] Issue HOLD command (H key) with specks selected — they should stop immediately and stay in place
- [ ] Held specks should not chase enemies or move toward rally points
- [ ] Held specks adjacent to enemies (within 20px) should still attack
- [ ] Issuing a RALLY after HOLD should clear the hold and resume normal movement

🤖 Generated with [Claude Code](https://claude.com/claude-code)