### PR TITLE
feat(speck-wars): right-click minimap to pan camera without rallying

### DIFF
--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -264,6 +264,16 @@ export function HUD() {
                 const worldY = (py / 120) * 3000
                 gameActions.rally(worldX, worldY)
               }}
+              onContextMenu={(e) => {
+                e.preventDefault()
+                if (!gameActions?.panCamera) return
+                const rect = e.currentTarget.getBoundingClientRect()
+                const px = e.clientX - rect.left
+                const py = e.clientY - rect.top
+                const worldX = (px / 120) * 3000
+                const worldY = (py / 120) * 3000
+                gameActions.panCamera(worldX, worldY)
+              }}
             >
               {/* Speck dots */}
               {hud.minimap.specks.map((s, i) => (
@@ -611,7 +621,7 @@ export function HUD() {
             <span>S — stop · H — hold position</span><span>C — center on base</span>
             <span>N — advance to outpost · D — defend base</span><span>B — rush enemy base</span>
             <span>Q — surge (2× spawn 8s)</span><span>V — snap camera to battle</span>
-            <span>1/2/3 — set spawn type</span><span>Minimap — click to move</span>
+            <span>1/2/3 — set spawn type</span><span>Minimap — left-click rally · right-click pan</span>
             <span>X — cycle speed (1×/2×/4×)</span><span>F — sacrifice 10 specks → +15 HP</span>
             <span>? — this help</span><span></span>
             <span style={{ gridColumn: '1/-1', borderTop: '1px solid rgba(255,255,255,0.08)', paddingTop: 8, marginTop: 2, color: 'rgba(255,215,0,0.5)', fontSize: 11 }}>

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -221,6 +221,11 @@ export class GameInstance {
         this.notify(`Spawn: ${typeId.toUpperCase()}`, color)
       },
       buildTurret: () => this.enterBuildMode('turret'),
+      panCamera: (wx: number, wy: number) => {
+        this.camera.x = this.canvas.clientWidth / 2 - wx * this.camera.zoom
+        this.camera.y = this.canvas.clientHeight / 2 - wy * this.camera.zoom
+        clampCamera(this.camera, this.canvas.clientWidth, this.canvas.clientHeight)
+      },
     })
     this.lastTime = performance.now()
     this.loop(this.lastTime)

--- a/src/app/speck-wars/store.ts
+++ b/src/app/speck-wars/store.ts
@@ -49,8 +49,8 @@ interface SpeckWarsStore {
   killFeed: KillFeedEntry[]
   pushKillFeedEntry: (entry: Omit<KillFeedEntry, 'id' | 'ts'>) => void
   pruneKillFeed: () => void
-  gameActions: { defend: (() => void) | null; advance: (() => void) | null; rush: (() => void) | null; clearRally: (() => void) | null; surge: (() => void) | null; rally: ((x: number, y: number) => void) | null; sacrifice: (() => void) | null; setSpawnType: ((type: 'basic' | 'heavy' | 'scout') => void) | null; buildTurret?: (() => void) | null }
-  setGameActions: (actions: { defend: () => void; advance: () => void; rush: () => void; clearRally: () => void; surge: () => void; rally: (x: number, y: number) => void; sacrifice: () => void; setSpawnType: (type: 'basic' | 'heavy' | 'scout') => void; buildTurret?: () => void } | null) => void
+  gameActions: { defend: (() => void) | null; advance: (() => void) | null; rush: (() => void) | null; clearRally: (() => void) | null; surge: (() => void) | null; rally: ((x: number, y: number) => void) | null; sacrifice: (() => void) | null; setSpawnType: ((type: 'basic' | 'heavy' | 'scout') => void) | null; buildTurret?: (() => void) | null; panCamera: ((x: number, y: number) => void) | null }
+  setGameActions: (actions: { defend: () => void; advance: () => void; rush: () => void; clearRally: () => void; surge: () => void; rally: (x: number, y: number) => void; sacrifice: () => void; setSpawnType: (type: 'basic' | 'heavy' | 'scout') => void; buildTurret?: () => void; panCamera: (x: number, y: number) => void } | null) => void
   surrender: () => void
   resetGame: () => void
 }
@@ -110,8 +110,8 @@ export const useSpeckWarsStore = create<SpeckWarsStore>()((set, get) => ({
     const next = s.killFeed.filter(e => e.ts > cutoff)
     return next.length === s.killFeed.length ? s : { killFeed: next }
   }),
-  gameActions: { defend: null, advance: null, rush: null, clearRally: null, surge: null, rally: null, sacrifice: null, setSpawnType: null, buildTurret: null },
-  setGameActions: (actions) => set({ gameActions: actions ?? { defend: null, advance: null, rush: null, clearRally: null, surge: null, rally: null, sacrifice: null, setSpawnType: null, buildTurret: null } }),
+  gameActions: { defend: null, advance: null, rush: null, clearRally: null, surge: null, rally: null, sacrifice: null, setSpawnType: null, buildTurret: null, panCamera: null },
+  setGameActions: (actions) => set({ gameActions: actions ?? { defend: null, advance: null, rush: null, clearRally: null, surge: null, rally: null, sacrifice: null, setSpawnType: null, buildTurret: null, panCamera: null } }),
   surrender: () => {
     const s = get()
     resetWinStreak()


### PR DESCRIPTION
## Summary

- Right-click on the minimap now pans the camera to that world position instead of setting a rally point
- Left-click on minimap still sets rally as before
- Help overlay updated: "Minimap — left-click rally · right-click pan"

Rebased onto current main (includes kill feed + turret changes). Replaces #2068.

## Test plan

- [ ] Right-click minimap — camera pans to that location
- [ ] Left-click minimap — rally point is set as before
- [ ] Help overlay (? key) shows updated minimap text

🤖 Generated with [Claude Code](https://claude.com/claude-code)