### PR TITLE
feat(speck-wars): sign-up CTA on results screen

### DIFF
--- a/src/app/speck-wars/components/phase-router.tsx
+++ b/src/app/speck-wars/components/phase-router.tsx
@@ -3,12 +3,15 @@ import { useState, useEffect } from 'react'
 import { useSpeckWarsStore } from '../store'
 import { getBestTime, getWinStreak, getRecentResults, hasWonToday } from '../lib/personal-best'
 import type { Difficulty } from '../store'
+import { useAuth } from '@/hooks/useAuth'
+import Link from 'next/link'
 
 export function PhaseRouter({ children }: { children: React.ReactNode }) {
   const { phase, winnerId, setPhase, difficulty, setDifficulty, elapsedMs, resetGame, kills, losses, isNewBest, victoryType, hud, peakArmySize, outpostsCaptured } = useSpeckWarsStore()
   const [copied, setCopied] = useState(false)
   const [bestTimes, setBestTimes] = useState<Partial<Record<Difficulty, number>>>({})
   const [winStreak, setWinStreak] = useState(0)
+  const { user } = useAuth()
 
   useEffect(() => {
     if (phase === 'menu') {
@@ -383,6 +386,36 @@ export function PhaseRouter({ children }: { children: React.ReactNode }) {
             </div>
           )
         })()}
+
+        {/* Sign-up CTA — shared pact: show for unauthenticated users at end of session */}
+        {!user && (
+          <div style={{
+            maxWidth: 320, textAlign: 'center',
+            padding: '10px 18px',
+            border: '1px solid rgba(74,247,196,0.18)',
+            borderRadius: 6,
+            background: 'rgba(74,247,196,0.04)',
+          }}>
+            <div style={{ fontSize: 11, letterSpacing: 1, color: 'rgba(74,247,196,0.8)', marginBottom: 6 }}>
+              {won && winStreak >= 2
+                ? `Your ${winStreak}-win streak deserves a record.`
+                : won
+                  ? 'Track your wins and best times.'
+                  : 'Log your battles. Climb the ranks.'}
+            </div>
+            <Link
+              href="/auth?redirect=/speck-wars"
+              style={{
+                display: 'inline-block',
+                fontSize: 10, letterSpacing: 2,
+                color: '#4af7c4', textTransform: 'uppercase',
+                textDecoration: 'none', opacity: 0.85,
+              }}
+            >
+              Create account →
+            </Link>
+          </div>
+        )}
 
         <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 6, marginTop: 8 }}>
           <div style={{ display: 'flex', gap: 12 }}>


### PR DESCRIPTION
## Summary

Adds a contextual sign-up prompt to the Speck Wars results screen for unauthenticated users, fulfilling the CometCave shared pact requirement.

- Only shown to signed-out users (`useAuth` hook)
- Copy adapts to the moment:
  - Win streak ≥ 2: "Your N-win streak deserves a record."
  - Single win: "Track your wins and best times."
  - Defeat: "Log your battles. Climb the ranks."
- Links to `/auth?redirect=/speck-wars` so users return to the game after sign-up
- Styled in Speck Wars' dark sci-fi aesthetic (not the shared `SignInCard` component, to respect "game voice inside" principle)

## UX principle met

> **Shared pact:** Sign-up CTA at a consistent trigger (e.g., end of session)
> **Anonymous-first:** CTA is only surfaced post-game, never gated

**Metric targeted:** daily return rate (persistent streak/stats motivate revisits).

## Test plan

- [ ] Signed-out user sees CTA on results screen after win and loss
- [ ] Streak win shows streak-specific copy
- [ ] Signed-in user sees no CTA
- [ ] CTA link goes to `/auth?redirect=/speck-wars`
- [ ] `npx tsc --noEmit` passes

Closes #1 of "shared pact" gaps in Speck Wars.

🤖 Generated with [Claude Code](https://claude.com/claude-code)