### PR TITLE
feat(speck-wars): reveal AI personality on results screen

### DIFF
--- a/src/app/speck-wars/components/phase-router.tsx
+++ b/src/app/speck-wars/components/phase-router.tsx
@@ -298,10 +298,10 @@ export function PhaseRouter({ children }: { children: React.ReactNode }) {
           )}
         </div>
 
-        {aiPersonality && aiPersonality !== 'balanced' && (
+        {aiPersonality && aiPersonality !== 'balanced' && (difficulty === 'hard' || difficulty === 'very-hard') && (
           <div style={{ fontSize: 10, letterSpacing: 2, opacity: 0.4, color: '#fff', textTransform: 'uppercase' }}>
             {aiPersonality === 'aggressive' ? '⚡ aggressive AI — frequent base rushes'
-              : 'macro AI — outpost control focus'}
+              : '🏭 macro AI — outpost economy focus'}
           </div>
         )}
 

--- a/src/app/speck-wars/components/phase-router.tsx
+++ b/src/app/speck-wars/components/phase-router.tsx
@@ -5,7 +5,7 @@ import { getBestTime, getWinStreak, getRecentResults, hasWonToday } from '../lib
 import type { Difficulty } from '../store'
 
 export function PhaseRouter({ children }: { children: React.ReactNode }) {
-  const { phase, winnerId, setPhase, difficulty, setDifficulty, elapsedMs, resetGame, kills, losses, isNewBest, victoryType, hud, peakArmySize, outpostsCaptured } = useSpeckWarsStore()
+  const { phase, winnerId, setPhase, difficulty, setDifficulty, elapsedMs, resetGame, kills, losses, isNewBest, victoryType, hud, peakArmySize, outpostsCaptured, aiPersonality } = useSpeckWarsStore()
   const [copied, setCopied] = useState(false)
   const [bestTimes, setBestTimes] = useState<Partial<Record<Difficulty, number>>>({})
   const [winStreak, setWinStreak] = useState(0)
@@ -297,6 +297,13 @@ export function PhaseRouter({ children }: { children: React.ReactNode }) {
             </span>
           )}
         </div>
+
+        {aiPersonality && aiPersonality !== 'balanced' && (
+          <div style={{ fontSize: 10, letterSpacing: 2, opacity: 0.4, color: '#fff', textTransform: 'uppercase' }}>
+            {aiPersonality === 'aggressive' ? '⚡ aggressive AI — frequent base rushes'
+              : 'macro AI — outpost control focus'}
+          </div>
+        )}
 
         <div style={{ display: 'flex', gap: 28, color: 'rgba(255,255,255,0.6)', fontSize: 14 }}>
           <span style={{ color: '#4af7c4' }}>↑ {kills} killed</span>

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -79,7 +79,9 @@ export class GameInstance {
       return Math.random() < 0.55 ? 'aggressive' : 'macro'
     }
     const adaptiveEnabled = difficulty === 'easy' || difficulty === 'medium'
-    this.aiController = new AIController('ai', aiTickInterval[difficulty] ?? 15, aiPersonality(), adaptiveEnabled)
+    const personality = aiPersonality()
+    useSpeckWarsStore.getState().setAiPersonality(personality)
+    this.aiController = new AIController('ai', aiTickInterval[difficulty] ?? 15, personality, adaptiveEnabled)
   }
 
   private onVisibilityChange = () => {

--- a/src/app/speck-wars/store.ts
+++ b/src/app/speck-wars/store.ts
@@ -1,9 +1,11 @@
 import { create } from 'zustand'
 import type { HudData } from './domain/types'
 import { resetWinStreak, recordGameResult } from './lib/personal-best'
+import type { AIPersonality } from './domain/ai/ai-controller'
 
 type GamePhase = 'menu' | 'playing' | 'paused' | 'victory' | 'defeat'
 export type Difficulty = 'easy' | 'medium' | 'hard' | 'very-hard'
+export type { AIPersonality }
 
 export interface KillFeedEntry {
   id: number
@@ -49,6 +51,8 @@ interface SpeckWarsStore {
   killFeed: KillFeedEntry[]
   pushKillFeedEntry: (entry: Omit<KillFeedEntry, 'id' | 'ts'>) => void
   pruneKillFeed: () => void
+  aiPersonality: AIPersonality | null
+  setAiPersonality: (p: AIPersonality) => void
   gameActions: { defend: (() => void) | null; advance: (() => void) | null; rush: (() => void) | null; clearRally: (() => void) | null; surge: (() => void) | null; rally: ((x: number, y: number) => void) | null; sacrifice: (() => void) | null; setSpawnType: ((type: 'basic' | 'heavy' | 'scout') => void) | null; buildTurret?: (() => void) | null; panCamera: ((x: number, y: number) => void) | null }
   setGameActions: (actions: { defend: () => void; advance: () => void; rush: () => void; clearRally: () => void; surge: () => void; rally: (x: number, y: number) => void; sacrifice: () => void; setSpawnType: (type: 'basic' | 'heavy' | 'scout') => void; buildTurret?: () => void; panCamera: (x: number, y: number) => void } | null) => void
   surrender: () => void
@@ -110,6 +114,8 @@ export const useSpeckWarsStore = create<SpeckWarsStore>()((set, get) => ({
     const next = s.killFeed.filter(e => e.ts > cutoff)
     return next.length === s.killFeed.length ? s : { killFeed: next }
   }),
+  aiPersonality: null,
+  setAiPersonality: p => set({ aiPersonality: p }),
   gameActions: { defend: null, advance: null, rush: null, clearRally: null, surge: null, rally: null, sacrifice: null, setSpawnType: null, buildTurret: null, panCamera: null },
   setGameActions: (actions) => set({ gameActions: actions ?? { defend: null, advance: null, rush: null, clearRally: null, surge: null, rally: null, sacrifice: null, setSpawnType: null, buildTurret: null, panCamera: null } }),
   surrender: () => {
@@ -133,6 +139,7 @@ export const useSpeckWarsStore = create<SpeckWarsStore>()((set, get) => ({
     peakArmySize: 0,
     outpostsCaptured: 0,
     killFeed: [],
+    aiPersonality: null,
     difficulty: s.difficulty,
   })),
 }))


### PR DESCRIPTION
Captures AI personality (aggressive/macro/balanced) in store; shows hint on post-game screen for hard/very-hard difficulty. Rebased onto current main. Replaces #2085.

## Test plan
- [ ] Hard/very-hard — personality hint shown on results screen
- [ ] Balanced — no hint
- [ ] Easy/medium — no hint
- [ ] `npx tsc --noEmit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)