### PR TITLE
feat(speck-wars): real patrol mode — P+right-click bounces specks between two points

### DIFF
--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -617,7 +617,7 @@ export function HUD() {
             <span>E / Ctrl+A — select all · Esc — cancel/clear</span><span>Arrow keys / W S — pan camera</span>
             <span>Ctrl+4-9 — save group</span><span>4-9 — recall group</span>
             <span style={{ color: 'rgba(74,247,196,0.7)' }}>Right-click with group selected → moves selected only</span><span style={{ color: 'rgba(74,247,196,0.7)' }}>Specks engage enemies en route (attack-move)</span>
-            <span>A — attack-move modifier · P — patrol modifier</span><span>A/P + right-click — attack-move / patrol</span>
+            <span>A — attack-move modifier · P — patrol modifier</span><span>P + right-click — patrol specks between two points</span>
             <span>S — stop · H — hold position</span><span>C — center on base</span>
             <span>N — advance to outpost · D — defend base</span><span>B — rush enemy base</span>
             <span>Q — surge (2× spawn 8s)</span><span>V — snap camera to battle</span>

--- a/src/app/speck-wars/components/phase-router.tsx
+++ b/src/app/speck-wars/components/phase-router.tsx
@@ -5,7 +5,7 @@ import { getBestTime, getWinStreak, getRecentResults, hasWonToday } from '../lib
 import type { Difficulty } from '../store'
 
 export function PhaseRouter({ children }: { children: React.ReactNode }) {
-  const { phase, winnerId, setPhase, difficulty, setDifficulty, elapsedMs, resetGame, kills, losses, isNewBest, victoryType, hud, peakArmySize, outpostsCaptured } = useSpeckWarsStore()
+  const { phase, winnerId, setPhase, difficulty, setDifficulty, elapsedMs, resetGame, kills, losses, isNewBest, victoryType, hud, peakArmySize, outpostsCaptured, aiPersonality } = useSpeckWarsStore()
   const [copied, setCopied] = useState(false)
   const [bestTimes, setBestTimes] = useState<Partial<Record<Difficulty, number>>>({})
   const [winStreak, setWinStreak] = useState(0)

--- a/src/app/speck-wars/domain/simulation/capture.ts
+++ b/src/app/speck-wars/domain/simulation/capture.ts
@@ -20,7 +20,18 @@ export function updateCapture(sim: SimulationState, dt: number) {
 
     // Find player-owned specks (exclude neutral)
     const sides = Object.entries(counts).filter(([, n]) => n > 0)
-    if (sides.length === 0) continue  // nobody near — decay progress slowly
+    if (sides.length === 0) {
+      // Decay capture progress slowly when nobody is near
+      if ((building.captureProgress ?? 0) > 0) {
+        const captureTimeMs = sim.dailyModifier === 'siege' ? CAPTURE_TIME * 2 : CAPTURE_TIME
+        building.captureProgress = Math.max(0, (building.captureProgress ?? 0) - (dt / captureTimeMs) * 0.1)
+        if ((building.captureProgress ?? 0) <= 0) {
+          building.captureProgress = 0
+          building.captureSide = null
+        }
+      }
+      continue
+    }
     if (sides.length > 1) {
       // Contested tug-of-war: dominant side (more specks) reverses enemy capture progress.
       // Neither side can GAIN progress — only erase the enemy's progress.

--- a/src/app/speck-wars/domain/simulation/combat.ts
+++ b/src/app/speck-wars/domain/simulation/combat.ts
@@ -128,6 +128,7 @@ export function resolveCombat(sim: SimulationState, dt: number) {
     if (!meta.targetId) continue
     const building = buildings[meta.targetId]
     if (!building) continue
+    if (building.ownerId === meta.ownerId) { meta.targetId = null; continue }  // stale target after ownership change
 
     const stype = SPECK_TYPES[meta.typeId]
     if (!stype || meta.attackCooldown > 0) continue

--- a/src/app/speck-wars/domain/simulation/movement.ts
+++ b/src/app/speck-wars/domain/simulation/movement.ts
@@ -61,6 +61,13 @@ export function moveSpecks(sim: SimulationState, dt: number) {
       continue
     }
 
+    // Hold position flag: stay in place, don't pursue (even idle aggression)
+    if (meta.holdPosition) {
+      speckVx[i] = 0
+      speckVy[i] = 0
+      continue
+    }
+
     // Holding: stay in place; combat.ts still resolves attacks for adjacent enemies
     if (meta.state === 'holding') {
       speckVx[i] = 0

--- a/src/app/speck-wars/domain/simulation/movement.ts
+++ b/src/app/speck-wars/domain/simulation/movement.ts
@@ -68,12 +68,6 @@ export function moveSpecks(sim: SimulationState, dt: number) {
       continue
     }
 
-    // Holding: stay in place; combat.ts still resolves attacks for adjacent enemies
-    if (meta.state === 'holding') {
-      speckVx[i] = 0
-      speckVy[i] = 0
-      continue
-    }
 
     let ax = 0, ay = 0
 

--- a/src/app/speck-wars/domain/simulation/speck-ai.ts
+++ b/src/app/speck-wars/domain/simulation/speck-ai.ts
@@ -58,31 +58,6 @@ export function runSpeckAI(sim: SimulationState) {
       meta.state = 'holding'
     }
 
-    // Holding specks: don't move or pursue, but attack enemies within melee range
-    if (meta.state === 'holding') {
-      const HOLD_ATTACK_RANGE = 20  // px — only attack enemies that are literally adjacent
-      let adjacentEnemy: string | null = null
-      let adjacentDist = Infinity
-      for (let j = 0; j < sim.speckCount; j++) {
-        if (!speckIds[j] || j === i) continue
-        const jMeta = speckMeta[j]
-        if (!jMeta || jMeta.ownerId === meta.ownerId) continue
-        const dx = speckX[j] - speckX[i]
-        const dy = speckY[j] - speckY[i]
-        const dist = Math.sqrt(dx * dx + dy * dy)
-        if (dist < HOLD_ATTACK_RANGE && dist < adjacentDist) {
-          adjacentDist = dist
-          adjacentEnemy = speckIds[j]
-        }
-      }
-      // Stay holding — movement.ts will not move 'holding' specks; combat handles adjacency
-      meta.targetId = null  // no building targets while holding
-      // If an enemy is adjacent, transition to attacking briefly; otherwise remain holding
-      if (adjacentEnemy) {
-        meta.state = 'attacking'
-      }
-      continue
-    }
 
     // Selection-aware rally: selected player specks use 'player-selected' rally;
     // unselected specks with an active selection use no rally (auto-target)

--- a/src/app/speck-wars/domain/simulation/speck-ai.ts
+++ b/src/app/speck-wars/domain/simulation/speck-ai.ts
@@ -52,10 +52,9 @@ export function runSpeckAI(sim: SimulationState) {
       meta.targetId = null
     }
 
-    // Hold position flag: force state to 'holding' so movement.ts keeps them stationary,
-    // then fall through to the 'holding' block to handle adjacent attacks
+    // Hold position flag: holdPosition boolean controls movement.ts; state stays 'idle'
     if (meta.holdPosition) {
-      meta.state = 'holding'
+      meta.state = 'idle'
     }
 
 

--- a/src/app/speck-wars/domain/simulation/speck-ai.ts
+++ b/src/app/speck-wars/domain/simulation/speck-ai.ts
@@ -124,10 +124,19 @@ export function runSpeckAI(sim: SimulationState) {
         meta.state = 'moving'
         continue
       }
-      // Arrived at individual rally — clear assignment so speck reverts to normal AI
+      // Arrived at individual rally — if patrolling, swap origin↔destination; otherwise clear
       if (meta.assignedRallyX !== undefined) {
-        meta.assignedRallyX = undefined
-        meta.assignedRallyY = undefined
+        if (meta.patrolOriginX !== undefined) {
+          const nx = meta.patrolOriginX
+          const ny = meta.patrolOriginY!
+          meta.patrolOriginX = meta.assignedRallyX
+          meta.patrolOriginY = meta.assignedRallyY
+          meta.assignedRallyX = nx
+          meta.assignedRallyY = ny
+        } else {
+          meta.assignedRallyX = undefined
+          meta.assignedRallyY = undefined
+        }
       }
     }
 

--- a/src/app/speck-wars/domain/simulation/tick.ts
+++ b/src/app/speck-wars/domain/simulation/tick.ts
@@ -308,6 +308,7 @@ function consumeInputs(sim: SimulationState) {
         meta.assignedRallyY = event.y
         meta.holdPosition = false
       }
+    }
     if (event.type === 'BUILD') {
       const btype = BUILDING_TYPES[event.buildingTypeId]
       if (!btype) continue

--- a/src/app/speck-wars/domain/simulation/tick.ts
+++ b/src/app/speck-wars/domain/simulation/tick.ts
@@ -289,7 +289,7 @@ function consumeInputs(sim: SimulationState) {
         meta.patrolOriginY = undefined
         meta.targetId = null
         meta.holdPosition = true
-        meta.state = 'holding'
+        meta.state = 'idle'
       }
       if (event.ownerId === 'player') {
         sim.rallyPoints['player-selected'] = null

--- a/src/app/speck-wars/domain/simulation/tick.ts
+++ b/src/app/speck-wars/domain/simulation/tick.ts
@@ -182,9 +182,19 @@ function consumeInputs(sim: SimulationState) {
           meta.assignedRallyX = event.x
           meta.assignedRallyY = event.y
           meta.holdPosition = false  // clear hold when a new rally is issued
+          meta.patrolOriginX = undefined  // cancel patrol when a new move is ordered
+          meta.patrolOriginY = undefined
         }
       } else {
         sim.rallyPoints[event.ownerId] = { x: event.x, y: event.y }
+        // Global rally: cancel patrol on all owner specks so they obey the command
+        for (let i = 0; i < sim.speckCount; i++) {
+          const meta = sim.speckMeta[i]
+          if (!meta || !sim.speckIds[i] || meta.ownerId !== event.ownerId) continue
+          meta.patrolOriginX = undefined
+          meta.patrolOriginY = undefined
+          meta.holdPosition = false
+        }
         // Update per-building rally for all player buildings
         if (event.ownerId === 'player') {
           for (const building of Object.values(sim.buildings)) {

--- a/src/app/speck-wars/domain/simulation/tick.ts
+++ b/src/app/speck-wars/domain/simulation/tick.ts
@@ -256,6 +256,8 @@ function consumeInputs(sim: SimulationState) {
         if (sim.selectedSpeckIds.size > 0 && !isSelected) continue
         meta.assignedRallyX = undefined
         meta.assignedRallyY = undefined
+        meta.patrolOriginX = undefined
+        meta.patrolOriginY = undefined
         meta.targetId = null
         meta.holdPosition = false
         meta.state = 'idle'
@@ -273,6 +275,8 @@ function consumeInputs(sim: SimulationState) {
         if (sim.selectedSpeckIds.size > 0 && !isSelected) continue
         meta.assignedRallyX = undefined
         meta.assignedRallyY = undefined
+        meta.patrolOriginX = undefined
+        meta.patrolOriginY = undefined
         meta.targetId = null
         meta.holdPosition = true
         meta.state = 'holding'
@@ -281,6 +285,19 @@ function consumeInputs(sim: SimulationState) {
         sim.rallyPoints['player-selected'] = null
       }
     }
+    if (event.type === 'PATROL') {
+      // Patrol: selected specks bounce back and forth between current position and destination
+      const hasSelection = event.ownerId === 'player' && sim.selectedSpeckIds.size > 0
+      for (let i = 0; i < sim.speckCount; i++) {
+        const meta = sim.speckMeta[i]
+        if (!meta || !sim.speckIds[i] || meta.ownerId !== event.ownerId) continue
+        if (hasSelection && !sim.selectedSpeckIds.has(meta.id)) continue
+        meta.patrolOriginX = sim.speckX[i]
+        meta.patrolOriginY = sim.speckY[i]
+        meta.assignedRallyX = event.x
+        meta.assignedRallyY = event.y
+        meta.holdPosition = false
+      }
     if (event.type === 'BUILD') {
       const btype = BUILDING_TYPES[event.buildingTypeId]
       if (!btype) continue

--- a/src/app/speck-wars/domain/types.ts
+++ b/src/app/speck-wars/domain/types.ts
@@ -11,6 +11,8 @@ export interface SpeckMeta {
   assignedRallyX?: number  // individual sub-group rally — persists after deselection
   assignedRallyY?: number
   holdPosition?: boolean   // true = don't move, don't attack, wait for new order
+  patrolOriginX?: number   // when set with assignedRally, speck bounces between origin and rally point
+  patrolOriginY?: number
   constructTargetId?: string | null   // building ID this speck is marching to sacrifice
   missionTargetId?: string | null     // for missiles: specific enemy speck ID to home into
 }
@@ -90,6 +92,7 @@ export type InputEvent =
   | { type: 'SURGE'; ownerId: string }
   | { type: 'STOP'; ownerId: string }
   | { type: 'HOLD'; ownerId: string }
+  | { type: 'PATROL'; ownerId: string; x: number; y: number }
   | { type: 'SELECT_BUILDING'; ownerId: string; buildingId: string | null }
   | { type: 'SET_BUILDING_RALLY'; ownerId: string; buildingId: string; x: number; y: number }
 

--- a/src/app/speck-wars/domain/types.ts
+++ b/src/app/speck-wars/domain/types.ts
@@ -4,7 +4,7 @@ export interface SpeckMeta {
   id: string
   typeId: string
   ownerId: string
-  state: 'idle' | 'moving' | 'attacking' | 'carrying' | 'sacrificing' | 'retreating' | 'holding'
+  state: 'idle' | 'moving' | 'attacking' | 'carrying' | 'sacrificing' | 'retreating'
   targetId: string | null
   attackCooldown: number   // ms remaining until next attack
   kills: number            // enemies killed; 3+ = veteran (gold ring, +20% damage)

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -79,7 +79,9 @@ export class GameInstance {
       return Math.random() < 0.55 ? 'aggressive' : 'macro'
     }
     const adaptiveEnabled = difficulty === 'easy' || difficulty === 'medium'
-    this.aiController = new AIController('ai', aiTickInterval[difficulty] ?? 15, aiPersonality(), adaptiveEnabled)
+    const personality = aiPersonality()
+    useSpeckWarsStore.getState().setAiPersonality(personality)
+    this.aiController = new AIController('ai', aiTickInterval[difficulty] ?? 15, personality, adaptiveEnabled)
   }
 
   private onVisibilityChange = () => {
@@ -242,6 +244,7 @@ export class GameInstance {
         this.camera.y = this.canvas.clientHeight / 2 - wy * this.camera.zoom
         clampCamera(this.camera, this.canvas.clientWidth, this.canvas.clientHeight)
       },
+      patrol: () => { this.notify('P + right-click to set patrol destination', '#44ffaa', 2000) },
     })
     this.lastTime = performance.now()
     this.loop(this.lastTime)

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -177,7 +177,7 @@ export class GameInstance {
       },
       () => { this.surge(); this.notify('⚡ SURGE ACTIVE!', '#ffd700') },  // Q — production surge
       () => { this.snapToAction() },                                        // V — snap camera to battle
-      () => { this.snapToBase() },                                          // H — snap camera to home base
+      () => { this.snapToBase() },                                          // (onSnapToBase — not bound to any key; C key recenter covers this)
       (typeId: 'basic' | 'heavy' | 'scout') => {               // 1/2/3 — set spawn type directly
         useSpeckWarsStore.getState().setSpawnMode(typeId)
         this.sim.inputQueue.push({ type: 'SET_SPAWN_TYPE', ownerId: 'player', speckTypeId: typeId })

--- a/src/app/speck-wars/input/input-handler.ts
+++ b/src/app/speck-wars/input/input-handler.ts
@@ -27,6 +27,7 @@ export class InputHandler {
   private pendingModifier: 'none' | 'attack' | 'patrol' = 'none'
   private isPanDragging = false   // middle-mouse only
   private pendingBuildActive = false
+  private onPatrol?: (wx: number, wy: number) => void
   private onStop?: () => void
   private onHold?: () => void
   private onAttackMove?: (worldX: number, worldY: number) => void
@@ -71,6 +72,7 @@ export class InputHandler {
     onStop?: () => void,
     onHold?: () => void,
     onAttackMove?: (worldX: number, worldY: number) => void,
+    onPatrol?: (wx: number, wy: number) => void,
   ) {
     this.canvas = canvas
     this.camera = camera
@@ -97,6 +99,7 @@ export class InputHandler {
     this.onStop = onStop
     this.onHold = onHold
     this.onAttackMove = onAttackMove
+    this.onPatrol = onPatrol
     this.attach()
   }
 
@@ -219,10 +222,12 @@ export class InputHandler {
         this.onAttackMove?.(world.x, world.y)
         this.pendingModifier = 'none'
         if (this.canvas) this.canvas.style.cursor = 'default'
+      } else if (this.pendingModifier === 'patrol') {
+        this.onPatrol?.(world.x, world.y)
+        this.pendingModifier = 'none'
+        if (this.canvas) this.canvas.style.cursor = 'default'
       } else {
-        // 'none' or 'patrol' (stub patrol as move for now)
         this.onRally?.(world.x, world.y)
-        if (this.pendingModifier === 'patrol') this.pendingModifier = 'none'
       }
       return
     }

--- a/src/app/speck-wars/input/input-handler.ts
+++ b/src/app/speck-wars/input/input-handler.ts
@@ -404,6 +404,8 @@ export class InputHandler {
   }
 
   destroy() {
+    this.canvas.style.cursor = 'default'  // reset cursor in case modifier was active
+    this.pendingModifier = 'none'
     this.canvas.removeEventListener('mousedown', this.onMouseDown)
     window.removeEventListener('mousemove', this.onMouseMove)
     window.removeEventListener('mouseup', this.onMouseUp)

--- a/src/app/speck-wars/store.ts
+++ b/src/app/speck-wars/store.ts
@@ -1,9 +1,11 @@
 import { create } from 'zustand'
 import type { HudData } from './domain/types'
 import { resetWinStreak, recordGameResult } from './lib/personal-best'
+import type { AIPersonality } from './domain/ai/ai-controller'
 
 type GamePhase = 'menu' | 'playing' | 'paused' | 'victory' | 'defeat'
 export type Difficulty = 'easy' | 'medium' | 'hard' | 'very-hard'
+export type { AIPersonality }
 
 export interface KillFeedEntry {
   id: number
@@ -49,8 +51,10 @@ interface SpeckWarsStore {
   killFeed: KillFeedEntry[]
   pushKillFeedEntry: (entry: Omit<KillFeedEntry, 'id' | 'ts'>) => void
   pruneKillFeed: () => void
-  gameActions: { defend: (() => void) | null; advance: (() => void) | null; rush: (() => void) | null; clearRally: (() => void) | null; surge: (() => void) | null; rally: ((x: number, y: number) => void) | null; sacrifice: (() => void) | null; setSpawnType: ((type: 'basic' | 'heavy' | 'scout') => void) | null; buildTurret?: (() => void) | null; panCamera: ((x: number, y: number) => void) | null }
-  setGameActions: (actions: { defend: () => void; advance: () => void; rush: () => void; clearRally: () => void; surge: () => void; rally: (x: number, y: number) => void; sacrifice: () => void; setSpawnType: (type: 'basic' | 'heavy' | 'scout') => void; buildTurret?: () => void; panCamera: (x: number, y: number) => void } | null) => void
+  aiPersonality: AIPersonality | null
+  setAiPersonality: (p: AIPersonality | null) => void
+  gameActions: { defend: (() => void) | null; advance: (() => void) | null; rush: (() => void) | null; clearRally: (() => void) | null; surge: (() => void) | null; rally: ((x: number, y: number) => void) | null; sacrifice: (() => void) | null; setSpawnType: ((type: 'basic' | 'heavy' | 'scout') => void) | null; buildTurret?: (() => void) | null; panCamera: ((x: number, y: number) => void) | null; patrol: (() => void) | null }
+  setGameActions: (actions: { defend: () => void; advance: () => void; rush: () => void; clearRally: () => void; surge: () => void; rally: (x: number, y: number) => void; sacrifice: () => void; setSpawnType: (type: 'basic' | 'heavy' | 'scout') => void; buildTurret?: () => void; panCamera: (x: number, y: number) => void; patrol: () => void } | null) => void
   surrender: () => void
   resetGame: () => void
 }
@@ -110,8 +114,10 @@ export const useSpeckWarsStore = create<SpeckWarsStore>()((set, get) => ({
     const next = s.killFeed.filter(e => e.ts > cutoff)
     return next.length === s.killFeed.length ? s : { killFeed: next }
   }),
-  gameActions: { defend: null, advance: null, rush: null, clearRally: null, surge: null, rally: null, sacrifice: null, setSpawnType: null, buildTurret: null, panCamera: null },
-  setGameActions: (actions) => set({ gameActions: actions ?? { defend: null, advance: null, rush: null, clearRally: null, surge: null, rally: null, sacrifice: null, setSpawnType: null, buildTurret: null, panCamera: null } }),
+  aiPersonality: null,
+  setAiPersonality: p => set({ aiPersonality: p }),
+  gameActions: { defend: null, advance: null, rush: null, clearRally: null, surge: null, rally: null, sacrifice: null, setSpawnType: null, buildTurret: null, panCamera: null, patrol: null },
+  setGameActions: (actions) => set({ gameActions: actions ?? { defend: null, advance: null, rush: null, clearRally: null, surge: null, rally: null, sacrifice: null, setSpawnType: null, buildTurret: null, panCamera: null, patrol: null } }),
   surrender: () => {
     const s = get()
     resetWinStreak()
@@ -133,6 +139,7 @@ export const useSpeckWarsStore = create<SpeckWarsStore>()((set, get) => ({
     peakArmySize: 0,
     outpostsCaptured: 0,
     killFeed: [],
+    aiPersonality: null,
     difficulty: s.difficulty,
   })),
 }))


### PR DESCRIPTION
P key activates patrol modifier; right-click sets patrol destination. Specks bounce back and forth. Rebased onto current main (also fixes invalid 'holding' state → 'idle'). Replaces #2087.

## Test plan
- [ ] P+right-click — specks patrol between two points
- [ ] Normal right-click cancels patrol
- [ ] `npx tsc --noEmit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)