### PR TITLE
feat(speck-wars): real patrol mode — P+right-click bounces specks between two points

### DIFF
--- a/src/app/speck-wars/domain/simulation/movement.ts
+++ b/src/app/speck-wars/domain/simulation/movement.ts
@@ -93,6 +93,16 @@ export function moveSpecks(sim: SimulationState, dt: number) {
         if (dist > stype.attackRange) {
           ax += (dx / dist) * stype.speed
           ay += (dy / dist) * stype.speed
+        } else if (meta.patrolDestX !== undefined && meta.patrolOriginX !== undefined) {
+          // Arrived at patrol leg — swap origin and destination to bounce back
+          const newDestX = meta.patrolOriginX
+          const newDestY = meta.patrolOriginY!
+          meta.patrolOriginX = meta.patrolDestX
+          meta.patrolOriginY = meta.patrolDestY!
+          meta.patrolDestX = newDestX
+          meta.patrolDestY = newDestY
+          meta.assignedRallyX = newDestX
+          meta.assignedRallyY = newDestY
         }
       } else {
         // Idle aggression: no target, no rally — pursue nearest enemy speck within detection range

--- a/src/app/speck-wars/domain/simulation/tick.ts
+++ b/src/app/speck-wars/domain/simulation/tick.ts
@@ -182,6 +182,11 @@ function consumeInputs(sim: SimulationState) {
           meta.assignedRallyX = event.x
           meta.assignedRallyY = event.y
           meta.holdPosition = false  // clear hold when a new rally is issued
+          // Rally cancels patrol
+          meta.patrolOriginX = undefined
+          meta.patrolOriginY = undefined
+          meta.patrolDestX = undefined
+          meta.patrolDestY = undefined
         }
       } else {
         sim.rallyPoints[event.ownerId] = { x: event.x, y: event.y }
@@ -259,6 +264,10 @@ function consumeInputs(sim: SimulationState) {
         meta.targetId = null
         meta.holdPosition = false
         meta.state = 'idle'
+        meta.patrolOriginX = undefined
+        meta.patrolOriginY = undefined
+        meta.patrolDestX = undefined
+        meta.patrolDestY = undefined
       }
       if (event.ownerId === 'player') {
         sim.rallyPoints['player-selected'] = null
@@ -276,9 +285,29 @@ function consumeInputs(sim: SimulationState) {
         meta.targetId = null
         meta.holdPosition = true
         meta.state = 'holding'
+        meta.patrolOriginX = undefined
+        meta.patrolOriginY = undefined
+        meta.patrolDestX = undefined
+        meta.patrolDestY = undefined
       }
       if (event.ownerId === 'player') {
         sim.rallyPoints['player-selected'] = null
+      }
+    }
+    if (event.type === 'SET_PATROL') {
+      const destSet = new Set(event.speckIds)
+      for (let i = 0; i < sim.speckCount; i++) {
+        const meta = sim.speckMeta[i]
+        if (!meta || !sim.speckIds[i] || meta.ownerId !== event.ownerId) continue
+        if (!destSet.has(meta.id)) continue
+        meta.patrolOriginX = sim.speckX[i]
+        meta.patrolOriginY = sim.speckY[i]
+        meta.patrolDestX = event.destX
+        meta.patrolDestY = event.destY
+        meta.assignedRallyX = event.destX
+        meta.assignedRallyY = event.destY
+        meta.holdPosition = false
+        meta.state = 'moving'
       }
     }
     if (event.type === 'BUILD') {

--- a/src/app/speck-wars/domain/types.ts
+++ b/src/app/speck-wars/domain/types.ts
@@ -13,6 +13,10 @@ export interface SpeckMeta {
   holdPosition?: boolean   // true = don't move, don't attack, wait for new order
   constructTargetId?: string | null   // building ID this speck is marching to sacrifice
   missionTargetId?: string | null     // for missiles: specific enemy speck ID to home into
+  patrolOriginX?: number  // patrol: leg start X (swaps with dest on arrival)
+  patrolOriginY?: number  // patrol: leg start Y
+  patrolDestX?: number    // patrol: leg destination X
+  patrolDestY?: number    // patrol: leg destination Y
 }
 
 export interface BuildingEntity {
@@ -92,6 +96,7 @@ export type InputEvent =
   | { type: 'HOLD'; ownerId: string }
   | { type: 'SELECT_BUILDING'; ownerId: string; buildingId: string | null }
   | { type: 'SET_BUILDING_RALLY'; ownerId: string; buildingId: string; x: number; y: number }
+  | { type: 'SET_PATROL'; ownerId: string; speckIds: string[]; destX: number; destY: number }
 
 export type SimEvent =
   | { type: 'SPECK_DIED'; speckId: string; x: number; y: number; killedOwnerId: string; killerOwnerId: string }

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -221,6 +221,21 @@ export class GameInstance {
         this.renderer.showRallyPing(wx, wy)
         this.notify('⚔ ATTACK MOVE!', '#ff4f7b', 900)
       },
+      (wx: number, wy: number) => {                                    // P + right-click — patrol
+        const speckIds: string[] = []
+        const useSelection = this.sim.selectedSpeckIds.size > 0
+        for (let i = 0; i < this.sim.speckCount; i++) {
+          if (!this.sim.speckIds[i]) continue
+          const m = this.sim.speckMeta[i]
+          if (!m || m.ownerId !== 'player') continue
+          if (useSelection && !this.sim.selectedSpeckIds.has(m.id)) continue
+          speckIds.push(m.id)
+        }
+        if (speckIds.length === 0) return
+        this.sim.inputQueue.push({ type: 'SET_PATROL', ownerId: 'player', speckIds, destX: wx, destY: wy })
+        this.renderer.showRallyPing(wx, wy)
+        this.notify('◎ PATROL', '#a0d0ff', 900)
+      },
     )
     useSpeckWarsStore.getState().setGameActions({
       defend: () => { this.defend(); this.notify('🛡 DEFEND', '#4af7c4') },

--- a/src/app/speck-wars/input/input-handler.ts
+++ b/src/app/speck-wars/input/input-handler.ts
@@ -30,6 +30,7 @@ export class InputHandler {
   private onStop?: () => void
   private onHold?: () => void
   private onAttackMove?: (worldX: number, worldY: number) => void
+  private onPatrol?: (worldX: number, worldY: number) => void
   private heldKeys = new Set<string>()
   private isDragging = false
   private lastX = 0
@@ -71,6 +72,7 @@ export class InputHandler {
     onStop?: () => void,
     onHold?: () => void,
     onAttackMove?: (worldX: number, worldY: number) => void,
+    onPatrol?: (worldX: number, worldY: number) => void,
   ) {
     this.canvas = canvas
     this.camera = camera
@@ -97,6 +99,7 @@ export class InputHandler {
     this.onStop = onStop
     this.onHold = onHold
     this.onAttackMove = onAttackMove
+    this.onPatrol = onPatrol
     this.attach()
   }
 
@@ -210,7 +213,7 @@ export class InputHandler {
     }
 
     if (e.button === 2 && dist < 5) {
-      // Right-click: issue move or attack-move command
+      // Right-click: issue move, attack-move, or patrol command
       const rect = this.canvas.getBoundingClientRect()
       const sx = e.clientX - rect.left
       const sy = e.clientY - rect.top
@@ -219,10 +222,12 @@ export class InputHandler {
         this.onAttackMove?.(world.x, world.y)
         this.pendingModifier = 'none'
         if (this.canvas) this.canvas.style.cursor = 'default'
+      } else if (this.pendingModifier === 'patrol') {
+        this.onPatrol?.(world.x, world.y)
+        this.pendingModifier = 'none'
+        if (this.canvas) this.canvas.style.cursor = 'default'
       } else {
-        // 'none' or 'patrol' (stub patrol as move for now)
         this.onRally?.(world.x, world.y)
-        if (this.pendingModifier === 'patrol') this.pendingModifier = 'none'
       }
       return
     }


### PR DESCRIPTION
Reimplements #2087 which had merge conflicts.

## Summary
- P key activates patrol modifier; right-click sets the patrol destination
- Selected specks bounce back and forth between current position and destination
- Patrol state stored per-speck (`patrolOriginX/Y`, `patrolDestX/Y` on SpeckMeta); arrival at destination triggers origin <-> destination swap via assignedRallyX/Y
- `SET_PATROL` input event type added; normal right-click/rally cancels patrol
- P key already documented in help overlay

## Test plan
- [ ] Select specks -> press P -> right-click destination -> specks patrol
- [ ] Specks bounce back and forth continuously
- [ ] Normal rally (right-click without P) cancels patrol
- [ ] S (stop) and H (hold) cancel patrol
- [ ] npx tsc --noEmit passes

Generated with Claude Code