### PR TITLE
fix(speck-wars): real attack-move + reduce idle aggro range

### DIFF
--- a/src/app/speck-wars/domain/simulation/movement.ts
+++ b/src/app/speck-wars/domain/simulation/movement.ts
@@ -83,7 +83,37 @@ export function moveSpecks(sim: SimulationState, dt: number) {
         }
       }
     } else {
-      const rally = (meta.assignedRallyX !== undefined)
+      // Attack-move: scan for nearby enemy specks and steer toward them
+      if (meta.attackMoveMode && meta.assignedRallyX !== undefined) {
+        const ATTACK_MOVE_RANGE = 80  // px
+        const amR2 = ATTACK_MOVE_RANGE * ATTACK_MOVE_RANGE
+        let closestDist2 = Infinity, closestX = 0, closestY = 0
+        const amNeighbors = spatialGrid.query(speckX[i], speckY[i])
+        for (const j of amNeighbors) {
+          if (i === j || !speckIds[j]) continue
+          const jMeta = speckMeta[j]
+          if (!jMeta || jMeta.ownerId === meta.ownerId || jMeta.ownerId === 'neutral') continue
+          const dx = speckX[j] - speckX[i]
+          const dy = speckY[j] - speckY[i]
+          const d2 = dx * dx + dy * dy
+          if (d2 < amR2 && d2 < closestDist2) {
+            closestDist2 = d2
+            closestX = speckX[j]
+            closestY = speckY[j]
+          }
+        }
+        if (closestDist2 < Infinity) {
+          meta.attackMoveTargetX = closestX
+          meta.attackMoveTargetY = closestY
+        } else {
+          meta.attackMoveTargetX = undefined
+          meta.attackMoveTargetY = undefined
+        }
+      }
+
+      const rally = (meta.attackMoveTargetX !== undefined)
+        ? { x: meta.attackMoveTargetX, y: meta.attackMoveTargetY! }
+        : (meta.assignedRallyX !== undefined)
         ? { x: meta.assignedRallyX, y: meta.assignedRallyY! }
         : sim.rallyPoints[meta.ownerId]
       if (rally) {
@@ -106,7 +136,7 @@ export function moveSpecks(sim: SimulationState, dt: number) {
         }
       } else {
         // Idle aggression: no target, no rally — pursue nearest enemy speck within detection range
-        const AGGRO_RANGE = 150  // px
+        const AGGRO_RANGE = 40  // px
         const aggroR2 = AGGRO_RANGE * AGGRO_RANGE
         let closestDist2 = Infinity, closestX = 0, closestY = 0
         const neighbors = spatialGrid.query(speckX[i], speckY[i])

--- a/src/app/speck-wars/domain/simulation/tick.ts
+++ b/src/app/speck-wars/domain/simulation/tick.ts
@@ -182,11 +182,12 @@ function consumeInputs(sim: SimulationState) {
           meta.assignedRallyX = event.x
           meta.assignedRallyY = event.y
           meta.holdPosition = false  // clear hold when a new rally is issued
-          // Rally cancels patrol
+          // Rally cancels patrol and attack-move mode
           meta.patrolOriginX = undefined
           meta.patrolOriginY = undefined
           meta.patrolDestX = undefined
           meta.patrolDestY = undefined
+          meta.attackMoveMode = false  // normal move cancels attack-move
         }
       } else {
         sim.rallyPoints[event.ownerId] = { x: event.x, y: event.y }
@@ -238,7 +239,9 @@ function consumeInputs(sim: SimulationState) {
     if (event.type === 'SET_SPAWN_TYPE') {
       const stype = SPECK_TYPES[event.speckTypeId]
       for (const building of Object.values(sim.buildings)) {
-        if (building.ownerId !== event.ownerId || building.typeId !== 'base') continue
+        if (building.ownerId !== event.ownerId) continue
+        if (building.typeId !== 'base' && building.typeId !== 'outpost') continue
+        if (event.buildingId && building.id !== event.buildingId) continue  // skip if targeting specific building
         building.spawnTypeOverride = event.speckTypeId
         building.spawnIntervalOverride = stype?.productionTime
       }
@@ -298,6 +301,7 @@ function consumeInputs(sim: SimulationState) {
         meta.assignedRallyY = undefined
         meta.targetId = null
         meta.holdPosition = false
+        meta.attackMoveMode = false
         meta.state = 'idle'
         meta.patrolOriginX = undefined
         meta.patrolOriginY = undefined
@@ -319,6 +323,7 @@ function consumeInputs(sim: SimulationState) {
         meta.assignedRallyY = undefined
         meta.targetId = null
         meta.holdPosition = true
+        meta.attackMoveMode = false
         meta.state = 'holding'
         meta.patrolOriginX = undefined
         meta.patrolOriginY = undefined
@@ -572,10 +577,10 @@ function emitHudUpdate(sim: SimulationState) {
     selectedComposition = { types, veteranCount: selVet, eliteCount: selElite }
   }
 
-  let selectedBuilding: { id: string; typeId: string; hp: number; maxHp: number } | null = null
+  let selectedBuilding: { id: string; typeId: string; hp: number; maxHp: number; spawnTypeOverride?: string } | null = null
   if (sim.selectedBuildingId) {
     const b = sim.buildings[sim.selectedBuildingId]
-    if (b) selectedBuilding = { id: b.id, typeId: b.typeId, hp: b.hp, maxHp: b.maxHp }
+    if (b) selectedBuilding = { id: b.id, typeId: b.typeId, hp: b.hp, maxHp: b.maxHp, spawnTypeOverride: b.spawnTypeOverride }
   }
 
   sim.events.push({ type: 'HUD_UPDATE', data: { players: data, attackedBuildingIds, tripleOutpostOwner, dominationProgress, captureInfo, surgeDuration: sim.surgeDuration, surgeCooldown: sim.surgeCooldown, selectedSpeckCount: sim.selectedSpeckIds.size, selectedComposition, spawnRates, minimap, outpostFortify, dailyModifier: sim.dailyModifier, waveCountdown: sim.waveCountdown, waveInProgress: sim.waveInProgress, sacrificeCooldown: sim.sacrificeCooldown, baseUnderThreat, enemyAdvanceDetected, rallyCryActive, selectedBuilding } })

--- a/src/app/speck-wars/domain/simulation/tick.ts
+++ b/src/app/speck-wars/domain/simulation/tick.ts
@@ -200,6 +200,41 @@ function consumeInputs(sim: SimulationState) {
         }
       }
     }
+    if (event.type === 'ATTACK_MOVE') {
+      const hasSelection = event.ownerId === 'player' && sim.selectedSpeckIds.size > 0
+      if (hasSelection) {
+        sim.rallyPoints['player-selected'] = { x: event.x, y: event.y }
+        for (let i = 0; i < sim.speckCount; i++) {
+          const meta = sim.speckMeta[i]
+          if (!meta || !sim.speckIds[i] || !sim.selectedSpeckIds.has(meta.id)) continue
+          meta.assignedRallyX = event.x
+          meta.assignedRallyY = event.y
+          meta.holdPosition = false
+          meta.targetId = null
+          meta.state = 'moving'
+          meta.attackMoveMode = true
+        }
+      } else {
+        sim.rallyPoints[event.ownerId] = { x: event.x, y: event.y }
+        for (let i = 0; i < sim.speckCount; i++) {
+          const meta = sim.speckMeta[i]
+          if (!meta || !sim.speckIds[i] || meta.ownerId !== event.ownerId) continue
+          meta.assignedRallyX = event.x
+          meta.assignedRallyY = event.y
+          meta.holdPosition = false
+          meta.targetId = null
+          meta.state = 'moving'
+          meta.attackMoveMode = true
+        }
+        if (event.ownerId === 'player') {
+          for (const building of Object.values(sim.buildings)) {
+            if (building.ownerId === 'player') {
+              building.rallyPoint = { x: event.x, y: event.y }
+            }
+          }
+        }
+      }
+    }
     if (event.type === 'SET_SPAWN_TYPE') {
       const stype = SPECK_TYPES[event.speckTypeId]
       for (const building of Object.values(sim.buildings)) {

--- a/src/app/speck-wars/domain/types.ts
+++ b/src/app/speck-wars/domain/types.ts
@@ -11,6 +11,9 @@ export interface SpeckMeta {
   assignedRallyX?: number  // individual sub-group rally — persists after deselection
   assignedRallyY?: number
   holdPosition?: boolean   // true = don't move, don't attack, wait for new order
+  attackMoveMode?: boolean          // true = A-click move; engage enemy specks en route
+  attackMoveTargetX?: number        // temporary target speck position while attack-moving
+  attackMoveTargetY?: number
   constructTargetId?: string | null   // building ID this speck is marching to sacrifice
   missionTargetId?: string | null     // for missiles: specific enemy speck ID to home into
   patrolOriginX?: number  // patrol: leg start X (swaps with dest on arrival)
@@ -86,6 +89,7 @@ export interface SimulationState {
 
 export type InputEvent =
   | { type: 'RALLY'; ownerId: string; x: number; y: number }
+  | { type: 'ATTACK_MOVE'; ownerId: string; x: number; y: number }
   | { type: 'SET_SPAWN_TYPE'; ownerId: string; speckTypeId: string }
   | { type: 'BUILD'; ownerId: string; buildingTypeId: string; x: number; y: number }
   | { type: 'SACRIFICE'; ownerId: string; buildingId: string; typeId: string; count: number }

--- a/src/app/speck-wars/domain/types.ts
+++ b/src/app/speck-wars/domain/types.ts
@@ -90,7 +90,7 @@ export interface SimulationState {
 export type InputEvent =
   | { type: 'RALLY'; ownerId: string; x: number; y: number }
   | { type: 'ATTACK_MOVE'; ownerId: string; x: number; y: number }
-  | { type: 'SET_SPAWN_TYPE'; ownerId: string; speckTypeId: string }
+  | { type: 'SET_SPAWN_TYPE'; ownerId: string; speckTypeId: string; buildingId?: string }
   | { type: 'BUILD'; ownerId: string; buildingTypeId: string; x: number; y: number }
   | { type: 'SACRIFICE'; ownerId: string; buildingId: string; typeId: string; count: number }
   | { type: 'BOX_SELECT'; ownerId: string; x1: number; y1: number; x2: number; y2: number }

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -219,7 +219,7 @@ export class GameInstance {
       () => { this.sim.inputQueue.push({ type: 'STOP', ownerId: 'player' }); this.notify('■ STOP', '#aaaaaa', 700) },   // S — stop
       () => { this.sim.inputQueue.push({ type: 'HOLD', ownerId: 'player' }); this.notify('⊡ HOLD', '#aaaaaa', 700) },  // H — hold
       (wx: number, wy: number) => {                                    // A + right-click — attack-move
-        this.sim.inputQueue.push({ type: 'RALLY', ownerId: 'player', x: wx, y: wy })
+        this.sim.inputQueue.push({ type: 'ATTACK_MOVE', ownerId: 'player', x: wx, y: wy })
         this.renderer.showRallyPing(wx, wy)
         this.notify('⚔ ATTACK MOVE!', '#ff4f7b', 900)
       },


### PR DESCRIPTION
## Summary
- Implements true attack-move: A+right-click sets specks into `attackMoveMode`, which makes them engage enemy specks en route to their destination rather than ignoring them
- Reduces idle auto-targeting range from 150px to 40px — specks no longer chase enemies far away unprompted
- RALLY/STOP/HOLD commands clear `attackMoveMode`
- Adds `ATTACK_MOVE` to `InputEvent` types, `attackMoveMode`/`attackMoveTargetX/Y` to `SpeckMeta`
- Fixes `buildingId?` missing from `SET_SPAWN_TYPE` type (fixes TS error from per-building spawn PR)

Closes #2090, #2091, #2101

## Test plan
- [ ] A+right-click: selected specks move to destination while attacking any enemies they encounter en route
- [ ] Normal right-click: specks ignore enemies en route (no attack-move)
- [ ] Idle specks only auto-target enemies within ~40px (not 150px)
- [ ] RALLY/STOP/HOLD cancel attack-move mode
- [ ] TypeScript check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)