### PR TITLE
fix(speck-wars): right-click drag pan, pinch zoom dampening, wider building click radius

### DIFF
--- a/src/app/speck-wars/domain/types.ts
+++ b/src/app/speck-wars/domain/types.ts
@@ -86,6 +86,7 @@ export interface SimulationState {
 
 export type InputEvent =
   | { type: 'RALLY'; ownerId: string; x: number; y: number }
+  | { type: 'ATTACK_MOVE'; ownerId: string; x: number; y: number }
   | { type: 'SET_SPAWN_TYPE'; ownerId: string; speckTypeId: string }
   | { type: 'BUILD'; ownerId: string; buildingTypeId: string; x: number; y: number }
   | { type: 'SACRIFICE'; ownerId: string; buildingId: string; typeId: string; count: number }

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -130,7 +130,7 @@ export class GameInstance {
           if (building.ownerId !== 'player') continue
           const btype = BUILDING_TYPES[building.typeId]
           const r = btype?.size ?? 20
-          if (Math.hypot(wx - building.x, wy - building.y) <= r + 5) {
+          if (Math.hypot(wx - building.x, wy - building.y) <= r + 20) {
             this.sim.inputQueue.push({ type: 'SELECT_BUILDING', ownerId: 'player', buildingId: building.id })
             return
           }
@@ -219,7 +219,7 @@ export class GameInstance {
       () => { this.sim.inputQueue.push({ type: 'STOP', ownerId: 'player' }); this.notify('■ STOP', '#aaaaaa', 700) },   // S — stop
       () => { this.sim.inputQueue.push({ type: 'HOLD', ownerId: 'player' }); this.notify('⊡ HOLD', '#aaaaaa', 700) },  // H — hold
       (wx: number, wy: number) => {                                    // A + right-click — attack-move
-        this.sim.inputQueue.push({ type: 'RALLY', ownerId: 'player', x: wx, y: wy })
+        this.sim.inputQueue.push({ type: 'ATTACK_MOVE', ownerId: 'player', x: wx, y: wy })
         this.renderer.showRallyPing(wx, wy)
         this.notify('⚔ ATTACK MOVE!', '#ff4f7b', 900)
       },

--- a/src/app/speck-wars/input/input-handler.ts
+++ b/src/app/speck-wars/input/input-handler.ts
@@ -26,6 +26,7 @@ export class InputHandler {
   private onRecallControlGroup?: (slot: number) => void
   private pendingModifier: 'none' | 'attack' | 'patrol' = 'none'
   private isPanDragging = false   // middle-mouse only
+  private isRightDragging = false
   private pendingBuildActive = false
   private onStop?: () => void
   private onHold?: () => void
@@ -160,6 +161,7 @@ export class InputHandler {
       this.mouseDownY = e.clientY
       this.lastX = e.clientX
       this.lastY = e.clientY
+      this.isRightDragging = true
     }
   }
 
@@ -168,6 +170,12 @@ export class InputHandler {
     this.mouseX = e.clientX - rect.left
     this.mouseY = e.clientY - rect.top
     if (this.isPanDragging) {
+      this.camera.x += e.clientX - this.lastX
+      this.camera.y += e.clientY - this.lastY
+      this.lastX = e.clientX
+      this.lastY = e.clientY
+    }
+    if (this.isRightDragging) {
       this.camera.x += e.clientX - this.lastX
       this.camera.y += e.clientY - this.lastY
       this.lastX = e.clientX
@@ -212,6 +220,9 @@ export class InputHandler {
       return
     }
 
+    if (e.button === 2) {
+      this.isRightDragging = false
+    }
     if (e.button === 2 && dist < 5) {
       // Right-click: issue move, attack-move, or patrol command
       const rect = this.canvas.getBoundingClientRect()
@@ -274,7 +285,8 @@ export class InputHandler {
       const dx = e.touches[1].clientX - e.touches[0].clientX
       const dy = e.touches[1].clientY - e.touches[0].clientY
       const newDist = Math.sqrt(dx * dx + dy * dy)
-      const factor = newDist / this.lastPinchDist
+      const rawFactor = newDist / this.lastPinchDist
+      const factor = 1 + (rawFactor - 1) * 0.4  // dampen to 40% of raw pinch speed
       const rect = this.canvas.getBoundingClientRect()
       const mx = ((e.touches[0].clientX + e.touches[1].clientX) / 2) - rect.left
       const my = ((e.touches[0].clientY + e.touches[1].clientY) / 2) - rect.top


### PR DESCRIPTION
## Summary
- Right-click drag now pans the camera (mirrors middle-mouse pan behavior)
- Pinch-to-zoom dampened to 40% of raw ratio — less frenetic on mobile
- Building click selection radius increased from `r+5` to `r+20` for more forgiving taps
- A+right-click now emits `ATTACK_MOVE` event (wired up to attack-move feature in #2105)

## Test plan
- [ ] Right-click + drag: camera pans without issuing a rally order
- [ ] Pinch zoom feels smoother/slower on mobile
- [ ] Clicking buildings selects them more reliably (larger hit target)
- [ ] TypeScript check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)