### PR TITLE
fix(speck-wars): pulsing glow selection indicator for selected specks

### DIFF
--- a/src/app/speck-wars/rendering/layers/speck-layer.ts
+++ b/src/app/speck-wars/rendering/layers/speck-layer.ts
@@ -134,11 +134,16 @@ export class SpeckLayer {
           }
         }
 
-        // Selection ring: warm yellow ring around selected specks (distinct from veteran gold/white)
+        // Selection indicator: pulsing filled glow + solid ring (must be large enough to see at low zoom)
         const speckId = sim.speckMeta[i]?.id ?? ''
         if (selectedSpeckIds?.has(speckId)) {
-          this.gfx.lineStyle(1.5, 0xffe066, 0.92)
-          this.gfx.drawCircle(sim.speckX[i], sim.speckY[i], (stype ? stype.size / 4 : 0.75) + 4)
+          const selPulse = 0.22 + 0.13 * Math.sin(now / 280)
+          const selRadius = (stype ? stype.size / 4 : 0.75) + 8
+          this.gfx.beginFill(0xffe066, selPulse)
+          this.gfx.drawCircle(sim.speckX[i], sim.speckY[i], selRadius)
+          this.gfx.endFill()
+          this.gfx.lineStyle(2, 0xffe066, 0.9)
+          this.gfx.drawCircle(sim.speckX[i], sim.speckY[i], selRadius)
           this.gfx.lineStyle(0)
         }
       }


### PR DESCRIPTION
## Summary
- Replaces the static thin yellow ring with a pulsing filled glow + solid 2px ring
- The fill uses a sine-wave pulse (0.22–0.35 alpha) to draw attention to selected specks
- Increases the indicator radius from `+4` to `+8` for better visibility at low zoom levels
- Only touches `speck-layer.ts`

## Test plan
- [ ] Select specks: a pulsing glow ring appears around them
- [ ] The ring pulses in and out subtly (sine-wave opacity)
- [ ] Ring is visible at normal and zoomed-out levels

🤖 Generated with [Claude Code](https://claude.com/claude-code)