### PR TITLE
rebalance(speck-wars): reduce unit movement speed by 20%

### DIFF
--- a/src/app/speck-wars/domain/config/speck-types.ts
+++ b/src/app/speck-wars/domain/config/speck-types.ts
@@ -10,21 +10,21 @@ export interface SpeckTypeDefinition {
 export const SPECK_TYPES: Record<string, SpeckTypeDefinition> = {
   basic: {
     id: 'basic', name: 'Speck',
-    hp: 1, damage: 1, speed: 80,
+    hp: 1, damage: 1, speed: 64,
     attackRange: 6, attackCooldown: 500,
     size: 3, productionTime: 800,
     abilities: [],
   },
   heavy: {
     id: 'heavy', name: 'Tank',
-    hp: 5, damage: 2, speed: 60,
+    hp: 5, damage: 2, speed: 48,
     attackRange: 8, attackCooldown: 700,
     size: 6, productionTime: 1800,
     abilities: [],
   },
   scout: {
     id: 'scout', name: 'Dart',
-    hp: 1, damage: 0.5, speed: 150,
+    hp: 1, damage: 0.5, speed: 120,
     attackRange: 4, attackCooldown: 600,
     size: 2, productionTime: 500,
     abilities: [],


### PR DESCRIPTION
## Summary
- `basic`: 80 → 64 px/s
- `heavy`: 60 → 48 px/s
- `scout`: 150 → 120 px/s
- Missile speed unchanged
- Only touches `speck-types.ts`

## Why
Units felt too fast at the current resolution/zoom level; engagements end too quickly and positioning matters less than it should.

## Test plan
- [ ] Play a game: units feel noticeably slower and battles feel more positional
- [ ] AI still functional at new speeds
- [ ] TypeScript check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)