### PR TITLE
feat(speck-wars): G key guards nearest friendly outpost

### DIFF
--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -253,6 +253,7 @@ export class GameInstance {
       },
     )
     this.inputHandler.onBuildTurret = () => this.enterBuildMode('turret')  // T — enter turret build mode
+    this.inputHandler.onGuard = () => { this.guard(); this.notify('🛡 GUARD', '#4af7c4', 1000) }
     useSpeckWarsStore.getState().setGameActions({
       defend: () => { this.defend(); this.notify('🛡 DEFEND', '#4af7c4') },
       advance: () => { this.advance(); this.notify('→ ADVANCE', '#ffd700') },
@@ -809,6 +810,36 @@ export class GameInstance {
   rush() {
     const enemyBase = Object.values(this.sim.buildings).find(b => b.ownerId === 'ai' && b.typeId === 'base')
     if (enemyBase) this.rally(enemyBase.x, enemyBase.y)
+  }
+
+  guard() {
+    // Rally selected (or all) specks to nearest friendly outpost
+    const playerOutposts = Object.values(this.sim.buildings)
+      .filter(b => b.ownerId === 'player' && b.typeId === 'outpost')
+    if (playerOutposts.length === 0) {
+      this.notify('No friendly outpost to guard', '#aaaaaa', 1200)
+      return
+    }
+    // Use center of mass of selected specks (or player base) as reference point
+    let refX = 0, refY = 0, count = 0
+    for (let i = 0; i < this.sim.speckCount; i++) {
+      const meta = this.sim.speckMeta[i]
+      if (!meta || !this.sim.speckIds[i]) continue
+      if (this.sim.selectedSpeckIds.size > 0 && !this.sim.selectedSpeckIds.has(meta.id)) continue
+      if (meta.ownerId !== 'player') continue
+      refX += this.sim.speckX[i]; refY += this.sim.speckY[i]; count++
+    }
+    if (count > 0) { refX /= count; refY /= count }
+    else {
+      const base = Object.values(this.sim.buildings).find(b => b.ownerId === 'player' && b.typeId === 'base')
+      if (base) { refX = base.x; refY = base.y }
+    }
+    const nearest = playerOutposts.reduce((best, b) => {
+      const d = (b.x - refX) ** 2 + (b.y - refY) ** 2
+      const bd = (best.x - refX) ** 2 + (best.y - refY) ** 2
+      return d < bd ? b : best
+    })
+    this.rally(nearest.x, nearest.y)
   }
 
   clearRally() {

--- a/src/app/speck-wars/input/input-handler.ts
+++ b/src/app/speck-wars/input/input-handler.ts
@@ -32,6 +32,7 @@ export class InputHandler {
   private onAttackMove?: (worldX: number, worldY: number) => void
   private onPatrol?: (worldX: number, worldY: number) => void
   public onBuildTurret?: () => void
+  public onGuard?: () => void
   private heldKeys = new Set<string>()
   private isDragging = false
   private lastX = 0
@@ -377,6 +378,8 @@ export class InputHandler {
       this.onSetSpawnType?.('heavy')
     } else if (e.code === 'Digit3') {
       this.onSetSpawnType?.('scout')
+    } else if (e.code === 'KeyG') {
+      this.onGuard?.()
     } else if (e.code === 'KeyX') {
       this.onCycleSpeed?.()
     } else if (e.code === 'KeyE') {


### PR DESCRIPTION
## Summary
- Press **G** to rally selected specks (or all player specks if none selected) to the nearest player-owned outpost
- Finds "nearest" based on the center-of-mass of the selected group (or player base fallback)
- Shows a `🛡 GUARD` toast notification on use
- No-ops with a message if the player has no friendly outposts yet
- Only touches `input-handler.ts` and `game-instance.ts`

## Test plan
- [ ] Capture at least one outpost, then press G: specks rally to it
- [ ] With specks selected: G rallies to the outpost nearest to that selection
- [ ] With no specks selected: G rallies all specks to nearest outpost
- [ ] Before capturing any outpost: G shows "No friendly outpost to guard" message
- [ ] TypeScript check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)