### PR TITLE
fix(speck-wars): AI specks have 3× higher idle aggro range than player

### DIFF
--- a/src/app/speck-wars/domain/simulation/movement.ts
+++ b/src/app/speck-wars/domain/simulation/movement.ts
@@ -136,7 +136,8 @@ export function moveSpecks(sim: SimulationState, dt: number) {
         }
       } else {
         // Idle aggression: no target, no rally — pursue nearest enemy speck within detection range
-        const AGGRO_RANGE = 40  // px
+        // AI specks are more aggressive and hunt at a wider range than player specks
+        const AGGRO_RANGE = meta.ownerId === 'player' ? 40 : 120  // px
         const aggroR2 = AGGRO_RANGE * AGGRO_RANGE
         let closestDist2 = Infinity, closestX = 0, closestY = 0
         const neighbors = spatialGrid.query(speckX[i], speckY[i])


### PR DESCRIPTION
## Summary
- Player specks: 40px idle aggro range (won't chase unless directed with attack-move)
- AI specks: 120px idle aggro range (hunt player specks in a wider area, making AI pressure more natural)
- Makes the AI feel more threatening without requiring any player attention
- One-liner change in `movement.ts`

Closes #2101

## Test plan
- [ ] Play a game: AI specks actively hunt player specks that wander near them
- [ ] Player specks don't chase AI specks unless attack-move (A+click) is used
- [ ] Combat near AI-held areas feels more dangerous than player-held areas

🤖 Generated with [Claude Code](https://claude.com/claude-code)