### PR TITLE
fix(speck-wars): pulsing ring on minimap during active outpost capture

### DIFF
--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -73,6 +73,10 @@ export function HUD() {
           from { transform: scale(1.5); opacity: 0; }
           to { transform: scale(1); opacity: 1; }
         }
+        @keyframes minimap-capture-pulse {
+          0% { opacity: 0.8; transform: scale(0.85); }
+          100% { opacity: 0; transform: scale(1.6); }
+        }
       `}</style>
       {hud?.baseUnderThreat && (
         <div style={{
@@ -307,15 +311,31 @@ export function HUD() {
                     {ci && ci.progress > 0 && (() => {
                       const sideColor = ci.side === 'player' ? '#4af7c4' : '#ff5555'
                       return (
-                        <circle
-                          cx={bx} cy={by}
-                          r={4 + ci.progress * 3}
-                          fill="none"
-                          stroke={sideColor}
-                          strokeWidth={1}
-                          opacity={0.8 - ci.progress * 0.3}
-                          style={{ pointerEvents: 'none' }}
-                        />
+                        <>
+                          {/* Static capture progress ring */}
+                          <circle
+                            cx={bx} cy={by}
+                            r={4 + ci.progress * 3}
+                            fill="none"
+                            stroke={sideColor}
+                            strokeWidth={1}
+                            opacity={0.8 - ci.progress * 0.3}
+                            style={{ pointerEvents: 'none' }}
+                          />
+                          {/* Pulsing outward ring — draws attention to active capture */}
+                          <circle
+                            cx={bx} cy={by}
+                            r={4}
+                            fill="none"
+                            stroke={sideColor}
+                            strokeWidth={1.5}
+                            style={{
+                              pointerEvents: 'none',
+                              animation: `minimap-capture-pulse 1.1s ease-out infinite`,
+                              transformOrigin: `${bx}px ${by}px`,
+                            }}
+                          />
+                        </>
                       )
                     })()}
                   </g>


### PR DESCRIPTION
## Summary
- When an outpost is being captured, a colored ring now pulses outward from its dot on the minimap
- Teal ring = player capturing; Red ring = enemy capturing
- Keeps the existing static capture progress ring; adds a separate pulsing ring for eye-catching attention
- CSS `@keyframes` animation, no JS timer needed

Closes #1926

## Test plan
- [ ] Capture an outpost: teal pulsing ring appears on the minimap at that outpost
- [ ] Enemy captures an outpost: red pulsing ring appears
- [ ] When capture completes, pulsing ring disappears
- [ ] TypeScript check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)