### PR TITLE
feat(speck-wars): unit control panel + build mode cursor

### DIFF
--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -1011,7 +1011,7 @@ export function HUD() {
             borderRadius: 6,
             padding: '7px 12px',
             minWidth: 130,
-            pointerEvents: 'none',
+            pointerEvents: (hud?.selectedSpeckCount ?? 0) > 0 ? 'auto' : 'none',
           }}>
             <div style={{
               fontSize: 9, letterSpacing: 2, color: '#ffffff', opacity: 0.9, marginBottom: 5,
@@ -1042,6 +1042,41 @@ export function HUD() {
               <div style={{ fontSize: 8, color: 'rgba(255,215,0,0.7)', marginTop: 3, letterSpacing: 1 }}>
                 {hud.selectedComposition.eliteCount > 0 && `✦ ${hud.selectedComposition.eliteCount} elite  `}
                 {hud.selectedComposition.veteranCount > 0 && `⭐ ${hud.selectedComposition.veteranCount} vet`}
+              </div>
+            )}
+            {/* Unit action buttons */}
+            {(hud?.selectedSpeckCount ?? 0) > 0 && (
+              <div style={{
+                display: 'flex', flexWrap: 'wrap', gap: 4, marginTop: 8,
+              }}>
+                {[
+                  { label: 'Stop', key: 'S', action: gameActions.stop },
+                  { label: 'Hold', key: 'H', action: gameActions.hold },
+                  { label: 'Defend', key: 'D', action: gameActions.defend },
+                  { label: 'Advance', key: 'N', action: gameActions.advance },
+                  { label: 'Rush', key: 'B', action: gameActions.rush },
+                  { label: 'Guard', key: 'G', action: gameActions.guard },
+                ].map(({ label, key, action }) => (
+                  <button
+                    key={label}
+                    onClick={() => action?.()}
+                    style={{
+                      background: 'rgba(255,255,255,0.07)',
+                      border: '1px solid rgba(255,255,255,0.18)',
+                      borderRadius: 4,
+                      color: '#ddd',
+                      fontSize: 11,
+                      padding: '3px 7px',
+                      cursor: 'pointer',
+                      display: 'flex', alignItems: 'center', gap: 4,
+                      userSelect: 'none',
+                      fontFamily: 'monospace',
+                    }}
+                  >
+                    {label}
+                    <span style={{ color: '#888', fontSize: 10 }}>[{key}]</span>
+                  </button>
+                ))}
               </div>
             )}
           </div>

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -280,6 +280,9 @@ export class GameInstance {
         this.camera.y = this.canvas.clientHeight / 2 - wy * this.camera.zoom
         clampCamera(this.camera, this.canvas.clientWidth, this.canvas.clientHeight)
       },
+      stop: () => this.sim.inputQueue.push({ type: 'STOP', ownerId: 'player' }),
+      hold: () => this.sim.inputQueue.push({ type: 'HOLD', ownerId: 'player' }),
+      guard: () => this.guard(),
     })
     // Cinematic intro: start zoomed out to show full world
     const W = this.canvas.clientWidth

--- a/src/app/speck-wars/input/input-handler.ts
+++ b/src/app/speck-wars/input/input-handler.ts
@@ -420,7 +420,10 @@ export class InputHandler {
     }
   }
 
-  setPendingBuildActive(active: boolean) { this.pendingBuildActive = active }
+  setPendingBuildActive(active: boolean) {
+    this.pendingBuildActive = active
+    this.canvas.style.cursor = active ? 'crosshair' : 'default'
+  }
   getMouseScreenPos(): { x: number; y: number } | null {
     if (this.mouseX < 0) return null
     return { x: this.mouseX, y: this.mouseY }

--- a/src/app/speck-wars/store.ts
+++ b/src/app/speck-wars/store.ts
@@ -53,8 +53,8 @@ interface SpeckWarsStore {
   pruneKillFeed: () => void
   aiPersonality: AIPersonality | null
   setAiPersonality: (p: AIPersonality) => void
-  gameActions: { defend: (() => void) | null; advance: (() => void) | null; rush: (() => void) | null; clearRally: (() => void) | null; surge: (() => void) | null; rally: ((x: number, y: number) => void) | null; sacrifice: (() => void) | null; setSpawnType: ((type: 'basic' | 'heavy' | 'scout') => void) | null; buildTurret?: (() => void) | null; panCamera: ((x: number, y: number) => void) | null }
-  setGameActions: (actions: { defend: () => void; advance: () => void; rush: () => void; clearRally: () => void; surge: () => void; rally: (x: number, y: number) => void; sacrifice: () => void; setSpawnType: (type: 'basic' | 'heavy' | 'scout') => void; buildTurret?: () => void; panCamera: (x: number, y: number) => void } | null) => void
+  gameActions: { defend: (() => void) | null; advance: (() => void) | null; rush: (() => void) | null; clearRally: (() => void) | null; surge: (() => void) | null; rally: ((x: number, y: number) => void) | null; sacrifice: (() => void) | null; setSpawnType: ((type: 'basic' | 'heavy' | 'scout') => void) | null; buildTurret?: (() => void) | null; panCamera: ((x: number, y: number) => void) | null; stop: (() => void) | null; hold: (() => void) | null; guard: (() => void) | null }
+  setGameActions: (actions: { defend: () => void; advance: () => void; rush: () => void; clearRally: () => void; surge: () => void; rally: (x: number, y: number) => void; sacrifice: () => void; setSpawnType: (type: 'basic' | 'heavy' | 'scout') => void; buildTurret?: () => void; panCamera: (x: number, y: number) => void; stop: () => void; hold: () => void; guard: () => void } | null) => void
   surrender: () => void
   resetGame: () => void
 }
@@ -116,8 +116,8 @@ export const useSpeckWarsStore = create<SpeckWarsStore>()((set, get) => ({
   }),
   aiPersonality: null,
   setAiPersonality: p => set({ aiPersonality: p }),
-  gameActions: { defend: null, advance: null, rush: null, clearRally: null, surge: null, rally: null, sacrifice: null, setSpawnType: null, buildTurret: null, panCamera: null },
-  setGameActions: (actions) => set({ gameActions: actions ?? { defend: null, advance: null, rush: null, clearRally: null, surge: null, rally: null, sacrifice: null, setSpawnType: null, buildTurret: null, panCamera: null } }),
+  gameActions: { defend: null, advance: null, rush: null, clearRally: null, surge: null, rally: null, sacrifice: null, setSpawnType: null, buildTurret: null, panCamera: null, stop: null, hold: null, guard: null },
+  setGameActions: (actions) => set({ gameActions: actions ?? { defend: null, advance: null, rush: null, clearRally: null, surge: null, rally: null, sacrifice: null, setSpawnType: null, buildTurret: null, panCamera: null, stop: null, hold: null, guard: null } }),
   surrender: () => {
     const s = get()
     resetWinStreak()


### PR DESCRIPTION
## Summary
- **Unit action panel**: when specks are selected, a button strip appears showing Stop [S], Hold [H], Defend [D], Advance [N], Rush [B], Guard [G] — each clickable and labeled with its keyboard shortcut
- **Build mode cursor**: entering turret placement mode now switches cursor to crosshair; leaving restores default

## Changes
- `store.ts` — added `stop`, `hold`, `guard` to `gameActions`
- `game-instance.ts` — wired stop/hold/guard callbacks into `setGameActions`
- `input/input-handler.ts` — `setPendingBuildActive` now manages cursor state
- `components/hud.tsx` — action button strip in the selection panel; panel pointerEvents enabled when units are selected

🤖 Generated with [Claude Code](https://claude.com/claude-code)