### PR TITLE
feat(speck-wars): legend speck tier — 12+ kills, purple ring, +50% damage

### DIFF
--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -1058,8 +1058,9 @@ export function HUD() {
                 </div>
               ))
             }
-            {hud?.selectedComposition && (hud.selectedComposition.veteranCount > 0 || hud.selectedComposition.eliteCount > 0) && (
+            {hud?.selectedComposition && (hud.selectedComposition.veteranCount > 0 || hud.selectedComposition.eliteCount > 0 || hud.selectedComposition.legendCount > 0) && (
               <div style={{ fontSize: 8, color: 'rgba(255,215,0,0.7)', marginTop: 3, letterSpacing: 1 }}>
+                {hud.selectedComposition.legendCount > 0 && <span style={{ color: '#cc44ff' }}>{`✦✦ ${hud.selectedComposition.legendCount} legend  `}</span>}
                 {hud.selectedComposition.eliteCount > 0 && `✦ ${hud.selectedComposition.eliteCount} elite  `}
                 {hud.selectedComposition.veteranCount > 0 && `⭐ ${hud.selectedComposition.veteranCount} vet`}
               </div>
@@ -1327,13 +1328,17 @@ export function HUD() {
                 </div>
               )
             })()}
-            {/* Veteran / elite count */}
+            {/* Veteran / elite / legend count */}
             {(() => {
               const vets = hud.players.player?.veteranCount ?? 0
               const elites = hud.players.player?.eliteCount ?? 0
-              if (vets + elites === 0) return null
+              const legends = hud.players.player?.legendCount ?? 0
+              if (vets + elites + legends === 0) return null
               return (
                 <div style={{ display: 'flex', gap: 8, fontSize: 9, letterSpacing: 0.5 }}>
+                  {legends > 0 && (
+                    <span style={{ color: '#cc44ff', opacity: 0.9 }}>✦✦ {legends} legend</span>
+                  )}
                   {elites > 0 && (
                     <span style={{ color: '#ffffff', opacity: 0.8 }}>✦ {elites} elite</span>
                   )}

--- a/src/app/speck-wars/domain/simulation/combat.ts
+++ b/src/app/speck-wars/domain/simulation/combat.ts
@@ -74,7 +74,7 @@ export function resolveCombat(sim: SimulationState, dt: number) {
       const dy = speckY[j] - speckY[i]
       const dist = Math.sqrt(dx * dx + dy * dy)
       if (dist <= stype.attackRange) {
-        const veteranBonus = meta.kills >= 6 ? 1.35 : meta.kills >= 3 ? 1.20 : 1.0  // elite +35%, veteran +20%
+        const veteranBonus = meta.kills >= 12 ? 1.50 : meta.kills >= 6 ? 1.35 : meta.kills >= 3 ? 1.20 : 1.0  // legend +50%, elite +35%, veteran +20%
         // Fortification bonus: if attacker is near a friendly fortified outpost, deal extra damage
         let fortifyBonus = 1.0
         for (const b of Object.values(buildings)) {
@@ -112,6 +112,9 @@ export function resolveCombat(sim: SimulationState, dt: number) {
           }
           if (meta.kills === 6) {
             sim.events.push({ type: 'SPECK_ELITE', speckId: speckIds[i], ownerId: meta.ownerId })
+          }
+          if (meta.kills === 12) {
+            sim.events.push({ type: 'SPECK_LEGEND', speckId: speckIds[i], ownerId: meta.ownerId })
           }
         }
         break  // one attack per cooldown

--- a/src/app/speck-wars/domain/simulation/tick.ts
+++ b/src/app/speck-wars/domain/simulation/tick.ts
@@ -440,18 +440,19 @@ function consumeInputs(sim: SimulationState) {
 }
 
 function emitHudUpdate(sim: SimulationState) {
-  const data: Record<string, { speckCount: number; buildingCount: number; buildingHp: Record<string, number>; speckTypes: Record<string, number>; veteranCount: number; eliteCount: number }> = {}
+  const data: Record<string, { speckCount: number; buildingCount: number; buildingHp: Record<string, number>; speckTypes: Record<string, number>; veteranCount: number; eliteCount: number; legendCount: number }> = {}
   for (const [pid] of Object.entries(sim.players)) {
     const myBuildings = Object.values(sim.buildings).filter(b => b.ownerId === pid)
     let liveCount = 0
-    let veteranCount = 0, eliteCount = 0
+    let veteranCount = 0, eliteCount = 0, legendCount = 0
     const speckTypes: Record<string, number> = {}
     for (let i = 0; i < sim.speckCount; i++) {
       const m = sim.speckMeta[i]
       if (m && m.ownerId === pid) {
         liveCount++
         speckTypes[m.typeId] = (speckTypes[m.typeId] ?? 0) + 1
-        if (m.kills >= 6) eliteCount++
+        if (m.kills >= 12) legendCount++
+        else if (m.kills >= 6) eliteCount++
         else if (m.kills >= 3) veteranCount++
       }
     }
@@ -462,6 +463,7 @@ function emitHudUpdate(sim: SimulationState) {
       speckTypes,
       veteranCount,
       eliteCount,
+      legendCount,
     }
   }
   // Buildings that are owned but actively being captured by the enemy
@@ -579,18 +581,19 @@ function emitHudUpdate(sim: SimulationState) {
   if (baseUnderThreat) enemyAdvanceDetected = false
 
   // Selection composition breakdown
-  let selectedComposition: { types: Record<string, number>; veteranCount: number; eliteCount: number } | null = null
+  let selectedComposition: { types: Record<string, number>; veteranCount: number; eliteCount: number; legendCount: number } | null = null
   if (sim.selectedSpeckIds.size > 0) {
     const types: Record<string, number> = {}
-    let selVet = 0, selElite = 0
+    let selVet = 0, selElite = 0, selLegend = 0
     for (let i = 0; i < sim.speckCount; i++) {
       const m = sim.speckMeta[i]
       if (!m || !sim.speckIds[i] || !sim.selectedSpeckIds.has(sim.speckIds[i])) continue
       types[m.typeId] = (types[m.typeId] ?? 0) + 1
-      if (m.kills >= 6) selElite++
+      if (m.kills >= 12) selLegend++
+      else if (m.kills >= 6) selElite++
       else if (m.kills >= 3) selVet++
     }
-    selectedComposition = { types, veteranCount: selVet, eliteCount: selElite }
+    selectedComposition = { types, veteranCount: selVet, eliteCount: selElite, legendCount: selLegend }
   }
 
   let selectedBuilding: { id: string; typeId: string; hp: number; maxHp: number; spawnTypeOverride?: string } | null = null

--- a/src/app/speck-wars/domain/types.ts
+++ b/src/app/speck-wars/domain/types.ts
@@ -112,6 +112,7 @@ export type SimEvent =
   | { type: 'OUTPOST_CAPTURED'; outpostId: string; newOwner: string; previousOwner: string }
   | { type: 'SPECK_VETERAN'; speckId: string; ownerId: string }
   | { type: 'SPECK_ELITE'; speckId: string; ownerId: string }
+  | { type: 'SPECK_LEGEND'; speckId: string; ownerId: string }
   | { type: 'AI_WAVE_START'; waveNumber: number }
   | { type: 'VETERAN_FALLEN'; speckId: string; ownerId: string; kills: number; x: number; y: number }
   | { type: 'AI_LAST_STAND' }
@@ -126,6 +127,7 @@ export interface HudData {
     speckTypes: Record<string, number>  // typeId → count
     veteranCount: number  // specks with 3+ kills
     eliteCount: number    // specks with 6+ kills
+    legendCount: number   // specks with 12+ kills
   }>
   attackedBuildingIds: string[]
   tripleOutpostOwner: string | null  // player ID who owns all 3 outposts, or null
@@ -134,7 +136,7 @@ export interface HudData {
   surgeDuration: number    // ms remaining in active surge
   surgeCooldown: number    // ms remaining before surge can be used again
   selectedSpeckCount: number   // 0 when no selection active
-  selectedComposition: { types: Record<string, number>; veteranCount: number; eliteCount: number } | null
+  selectedComposition: { types: Record<string, number>; veteranCount: number; eliteCount: number; legendCount: number } | null
   spawnRates: Record<string, number>   // playerId → effective specks/min
   dailyModifier: 'standard' | 'bulwark' | 'blitz' | 'siege'
   waveCountdown: number | null

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -659,10 +659,15 @@ export class GameInstance {
         if (event.type === 'SPECK_ELITE' && event.ownerId === 'player') {
           this.notify('✦ ELITE SPECK! +35% DAMAGE', '#ffffff', 2500)
         }
+        if (event.type === 'SPECK_LEGEND' && event.ownerId === 'player') {
+          this.notify('✦✦ LEGEND BORN! ✦✦', '#cc44ff', 3000)
+          store.pushKillFeedEntry({ icon: '✦✦', label: 'LEGEND BORN', color: '#cc44ff' })
+        }
         if (event.type === 'VETERAN_FALLEN') {
+          const isLegend = event.kills >= 12
           const isElite = event.kills >= 6
-          const label = isElite ? '✦ ELITE FALLEN' : '⭐ VETERAN FALLEN'
-          const color = isElite ? '#ff8844' : '#ffcc00'
+          const label = isLegend ? '✦✦ LEGEND FALLEN' : isElite ? '✦ ELITE FALLEN' : '⭐ VETERAN FALLEN'
+          const color = isLegend ? '#cc44ff' : isElite ? '#ff8844' : '#ffcc00'
           this.notify(label, color)
         }
         if (event.type === 'AI_WAVE_START') {

--- a/src/app/speck-wars/rendering/layers/speck-layer.ts
+++ b/src/app/speck-wars/rendering/layers/speck-layer.ts
@@ -83,11 +83,22 @@ export class SpeckLayer {
         const hpFrac = stype ? Math.max(0, sim.speckHp[i] / stype.hp) : 1
         spriteList[j].alpha = 0.35 + 0.65 * hpFrac
 
-        // Gold ring for veteran specks (3+ kills), bright white diamond ring for elite (6+ kills)
+        // Gold ring for veteran specks (3+ kills), bright white+gold ring for elite (6+ kills), purple+white ring for legend (12+ kills)
         const kills = typeMeta?.kills ?? 0
         const isVeteran = kills >= 3
         const isElite = kills >= 6
-        if (isElite) {
+        const isLegend = kills >= 12
+        if (isLegend) {
+          // Purple outer ring + pulsing white inner ring for legend
+          const legendPulse = 0.6 + 0.4 * Math.sin(now / 160)  // faster pulse ~6Hz
+          this.gfx.lineStyle(2.5, 0xcc44ff, legendPulse * spriteList[j].alpha)  // purple outer
+          this.gfx.drawCircle(sim.speckX[i], sim.speckY[i], (stype ? stype.size / 4 : 0.75) + 7)
+          this.gfx.lineStyle(2, 0xffffff, spriteList[j].alpha * 0.95)  // white inner
+          this.gfx.drawCircle(sim.speckX[i], sim.speckY[i], (stype ? stype.size / 4 : 0.75) + 4)
+          this.gfx.lineStyle(1.5, 0xcc44ff, spriteList[j].alpha * 0.6)  // faint purple core
+          this.gfx.drawCircle(sim.speckX[i], sim.speckY[i], (stype ? stype.size / 4 : 0.75) + 1.5)
+          this.gfx.lineStyle(0)
+        } else if (isElite) {
           // Bright white outer ring + gold inner ring for elite
           const elitePulse = 0.7 + 0.3 * Math.sin(now / 200)
           this.gfx.lineStyle(2, 0xffffff, elitePulse * spriteList[j].alpha)


### PR DESCRIPTION
## Summary
- Adds a third veterancy tier above Elite (6 kills): **Legend** at 12+ kills
- +50% damage bonus (vs Elite's +35%, Veteran's +20%)
- Distinct visual: pulsing purple outer ring + white inner ring + faint purple core ring
- `SPECK_LEGEND` event fires at kill 12 → `'✦✦ LEGEND BORN! ✦✦'` notification in purple
- `VETERAN_FALLEN` handler updated to use legend label/color at 12+ kills
- `legendCount` tracked in HudData and shown in bottom-left HUD badge row

## Files changed
- `domain/types.ts` — `SPECK_LEGEND` event, `legendCount` in player stats + selectedComposition
- `domain/simulation/combat.ts` — veteranBonus tier at 1.50×, emit SPECK_LEGEND at kill 12
- `domain/simulation/tick.ts` — exclusive tier counting (legend ≠ elite ≠ veteran in aggregates)
- `rendering/layers/speck-layer.ts` — isLegend visual branch before isElite
- `game-instance.ts` — SPECK_LEGEND notification + VETERAN_FALLEN legend tier
- `components/hud.tsx` — legend count in bottom-left badge + selected composition panel

Closes #2120
Replaces #2121 (rebased after #2119 merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)