### PR TITLE
feat(speck-wars): peak veteran/elite/legend counts on results screen

### DIFF
--- a/src/app/speck-wars/components/phase-router.tsx
+++ b/src/app/speck-wars/components/phase-router.tsx
@@ -7,7 +7,7 @@ import { useAuth } from '@/hooks/useAuth'
 import Link from 'next/link'
 
 export function PhaseRouter({ children }: { children: React.ReactNode }) {
-  const { phase, winnerId, setPhase, difficulty, setDifficulty, elapsedMs, resetGame, kills, losses, isNewBest, victoryType, hud, peakArmySize, outpostsCaptured, aiPersonality } = useSpeckWarsStore()
+  const { phase, winnerId, setPhase, difficulty, setDifficulty, elapsedMs, resetGame, kills, losses, isNewBest, victoryType, hud, peakArmySize, outpostsCaptured, aiPersonality, peakVeteranCount, peakEliteCount, peakLegendCount } = useSpeckWarsStore()
   const [copied, setCopied] = useState(false)
   const [bestTimes, setBestTimes] = useState<Partial<Record<Difficulty, number>>>({})
   const [winStreak, setWinStreak] = useState(0)
@@ -325,6 +325,19 @@ export function PhaseRouter({ children }: { children: React.ReactNode }) {
             )}
             {outpostsCaptured > 0 && (
               <span>⬡ {outpostsCaptured} outpost{outpostsCaptured !== 1 ? 's' : ''} captured</span>
+            )}
+          </div>
+        )}
+        {(peakVeteranCount > 0 || peakEliteCount > 0 || peakLegendCount > 0) && (
+          <div style={{ display: 'flex', gap: 20, color: 'rgba(255,255,255,0.45)', fontSize: 12, letterSpacing: 0.5 }}>
+            {peakLegendCount > 0 && (
+              <span style={{ color: '#cc44ff', opacity: 0.8 }}>✦✦ {peakLegendCount} legend{peakLegendCount !== 1 ? 's' : ''}</span>
+            )}
+            {peakEliteCount > 0 && (
+              <span style={{ color: '#ffffff', opacity: 0.7 }}>✦ {peakEliteCount} elite{peakEliteCount !== 1 ? 's' : ''}</span>
+            )}
+            {peakVeteranCount > 0 && (
+              <span style={{ color: '#ffd700', opacity: 0.65 }}>⭐ {peakVeteranCount} veteran{peakVeteranCount !== 1 ? 's' : ''}</span>
             )}
           </div>
         )}

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -437,6 +437,9 @@ export class GameInstance {
           this.cachedPlayerSpeckCount = event.data.players.player?.speckCount ?? 0
           const playerSpeckCount = event.data.players.player?.speckCount ?? 0
           store.setPeakArmySize(playerSpeckCount)
+          store.setPeakVeteranCount(event.data.players.player?.veteranCount ?? 0)
+          store.setPeakEliteCount(event.data.players.player?.eliteCount ?? 0)
+          // legendCount not yet in HudData — skipped until legend branch merges
           // Warn when an enemy starts capturing a player-owned outpost
           const now = Date.now()
           const playerBuildingHp = event.data.players.player?.buildingHp ?? {}

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -439,7 +439,7 @@ export class GameInstance {
           store.setPeakArmySize(playerSpeckCount)
           store.setPeakVeteranCount(event.data.players.player?.veteranCount ?? 0)
           store.setPeakEliteCount(event.data.players.player?.eliteCount ?? 0)
-          // legendCount not yet in HudData — skipped until legend branch merges
+          store.setPeakLegendCount(event.data.players.player?.legendCount ?? 0)
           // Warn when an enemy starts capturing a player-owned outpost
           const now = Date.now()
           const playerBuildingHp = event.data.players.player?.buildingHp ?? {}

--- a/src/app/speck-wars/store.ts
+++ b/src/app/speck-wars/store.ts
@@ -44,6 +44,12 @@ interface SpeckWarsStore {
   setSpawnMode: (mode: 'basic' | 'heavy' | 'scout') => void
   peakArmySize: number
   setPeakArmySize: (n: number) => void
+  peakVeteranCount: number
+  setPeakVeteranCount: (n: number) => void
+  peakEliteCount: number
+  setPeakEliteCount: (n: number) => void
+  peakLegendCount: number
+  setPeakLegendCount: (n: number) => void
   outpostsCaptured: number
   addOutpostCaptured: () => void
   isNewBest: boolean
@@ -99,6 +105,12 @@ export const useSpeckWarsStore = create<SpeckWarsStore>()((set, get) => ({
   setSpawnMode: mode => set({ spawnMode: mode }),
   peakArmySize: 0,
   setPeakArmySize: n => set(s => ({ peakArmySize: Math.max(s.peakArmySize, n) })),
+  peakVeteranCount: 0,
+  setPeakVeteranCount: n => set(s => ({ peakVeteranCount: Math.max(s.peakVeteranCount, n) })),
+  peakEliteCount: 0,
+  setPeakEliteCount: n => set(s => ({ peakEliteCount: Math.max(s.peakEliteCount, n) })),
+  peakLegendCount: 0,
+  setPeakLegendCount: n => set(s => ({ peakLegendCount: Math.max(s.peakLegendCount, n) })),
   outpostsCaptured: 0,
   addOutpostCaptured: () => set(s => ({ outpostsCaptured: s.outpostsCaptured + 1 })),
   isNewBest: false,
@@ -137,6 +149,9 @@ export const useSpeckWarsStore = create<SpeckWarsStore>()((set, get) => ({
     spawnMode: 'basic' as 'basic' | 'heavy' | 'scout',
     isNewBest: false,
     peakArmySize: 0,
+    peakVeteranCount: 0,
+    peakEliteCount: 0,
+    peakLegendCount: 0,
     outpostsCaptured: 0,
     killFeed: [],
     aiPersonality: null,


### PR DESCRIPTION
## Summary
- Tracks `peakVeteranCount`, `peakEliteCount`, `peakLegendCount` in Zustand store (max-value semantics like `peakArmySize`)
- Updated from `HUD_UPDATE` events every tick
- Results screen shows a new row: ✦✦ legends (purple) · ✦ elites (white) · ⭐ veterans (gold)
- Only renders when at least one veteran exists — no noise for quick/casual runs

## Files changed
- `store.ts` — new peak vet/elite/legend state, setters, and reset
- `game-instance.ts` — update peaks in HUD_UPDATE handler (same location as peakArmySize)
- `phase-router.tsx` — new display row on results screen after peak army size row

Closes #2123
Requires #2122 (legend tier) — now merged to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)