### PR TITLE
feat(speck-wars): lifetime stats on main menu

### DIFF
--- a/src/app/speck-wars/components/phase-router.tsx
+++ b/src/app/speck-wars/components/phase-router.tsx
@@ -1,7 +1,7 @@
 'use client'
 import { useState, useEffect } from 'react'
 import { useSpeckWarsStore } from '../store'
-import { getBestTime, getWinStreak, getRecentResults, hasWonToday } from '../lib/personal-best'
+import { getBestTime, getWinStreak, getRecentResults, hasWonToday, getLifetimeStats } from '../lib/personal-best'
 import type { Difficulty } from '../store'
 import { useAuth } from '@/hooks/useAuth'
 import Link from 'next/link'
@@ -11,6 +11,7 @@ export function PhaseRouter({ children }: { children: React.ReactNode }) {
   const [copied, setCopied] = useState(false)
   const [bestTimes, setBestTimes] = useState<Partial<Record<Difficulty, number>>>({})
   const [winStreak, setWinStreak] = useState(0)
+  const [lifetimeStats, setLifetimeStats] = useState({ gamesPlayed: 0, totalKills: 0, bestStreak: 0 })
   const { user } = useAuth()
 
   useEffect(() => {
@@ -21,6 +22,7 @@ export function PhaseRouter({ children }: { children: React.ReactNode }) {
         hard: getBestTime('hard') ?? undefined,
       })
       setWinStreak(getWinStreak())
+      setLifetimeStats(getLifetimeStats())
     }
   }, [phase])
 
@@ -118,6 +120,18 @@ export function PhaseRouter({ children }: { children: React.ReactNode }) {
             )
           })}
         </div>
+        {lifetimeStats.gamesPlayed > 0 && (
+          <div style={{
+            display: 'flex', gap: 20, fontSize: 10, letterSpacing: 1,
+            color: 'rgba(255,255,255,0.3)',
+          }}>
+            <span>{lifetimeStats.gamesPlayed} games</span>
+            <span>{lifetimeStats.totalKills.toLocaleString()} kills</span>
+            {lifetimeStats.bestStreak >= 2 && (
+              <span>best {lifetimeStats.bestStreak}-win streak</span>
+            )}
+          </div>
+        )}
         <button
           onClick={() => setPhase('playing')}
           style={{ padding: '12px 32px', fontSize: 18, cursor: 'pointer', background: '#4af7c4', border: 'none', borderRadius: 8, fontWeight: 'bold' }}

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -7,7 +7,7 @@ import { createCamera, clampCamera, screenToWorld } from './rendering/camera'
 import { InputHandler } from './input/input-handler'
 import type { Camera } from './rendering/camera'
 import { AIController, type AIPersonality } from './domain/ai/ai-controller'
-import { recordBestTime, incrementWinStreak, resetWinStreak, isFirstGame, markFirstGameDone, recordGameResult, markWonToday } from './lib/personal-best'
+import { recordBestTime, incrementWinStreak, resetWinStreak, isFirstGame, markFirstGameDone, recordGameResult, markWonToday, updateLifetimeStats, getWinStreak } from './lib/personal-best'
 import { BUILDING_TYPES } from './domain/config/building-types'
 
 export class GameInstance {
@@ -405,12 +405,14 @@ export class GameInstance {
               const isNew = recordBestTime(s.difficulty, elapsedAtEnd)
               incrementWinStreak()
               recordGameResult(s.difficulty, true, elapsedAtEnd, s.kills)
+              updateLifetimeStats(s.kills, getWinStreak())
               markWonToday(s.difficulty)
               s.setIsNewBest(isNew)
               s.setPhase('victory')
             } else {
               resetWinStreak()
               recordGameResult(s.difficulty, false, elapsedAtEnd, s.kills)
+              updateLifetimeStats(s.kills, getWinStreak())
               s.setIsNewBest(false)
               s.setPhase('defeat')
             }

--- a/src/app/speck-wars/lib/personal-best.ts
+++ b/src/app/speck-wars/lib/personal-best.ts
@@ -87,3 +87,33 @@ export function markWonToday(difficulty: Difficulty) {
   if (typeof window === 'undefined') return
   localStorage.setItem(DAILY_WIN_KEY(difficulty), todayKey())
 }
+
+// Lifetime stats: total games, total kills, best streak ever
+const LIFETIME_KEY = 'speck-wars-lifetime'
+
+interface LifetimeStats {
+  gamesPlayed: number
+  totalKills: number
+  bestStreak: number
+}
+
+export function getLifetimeStats(): LifetimeStats {
+  if (typeof window === 'undefined') return { gamesPlayed: 0, totalKills: 0, bestStreak: 0 }
+  try {
+    const raw = localStorage.getItem(LIFETIME_KEY)
+    return raw ? (JSON.parse(raw) as LifetimeStats) : { gamesPlayed: 0, totalKills: 0, bestStreak: 0 }
+  } catch {
+    return { gamesPlayed: 0, totalKills: 0, bestStreak: 0 }
+  }
+}
+
+export function updateLifetimeStats(kills: number, currentStreak: number) {
+  if (typeof window === 'undefined') return
+  const prev = getLifetimeStats()
+  const next: LifetimeStats = {
+    gamesPlayed: prev.gamesPlayed + 1,
+    totalKills: prev.totalKills + kills,
+    bestStreak: Math.max(prev.bestStreak, currentStreak),
+  }
+  localStorage.setItem(LIFETIME_KEY, JSON.stringify(next))
+}


### PR DESCRIPTION
## Summary
Tracks `gamesPlayed`, `totalKills`, and `bestStreak` across sessions in localStorage (`speck-wars-lifetime`). Updated after every game (win and loss). Main menu shows a quiet stats row beneath the difficulty win-rate table:

> `47 games · 1,234 kills · best 5-win streak`

Only renders after at least 1 game is played (no noise for first-time visitors).

## Why
"Design for the regular" (CometCave UX principle 3): returning players want to see their history. Lifetime stats create milestone-chasing ("I'm at 48 games, let me hit 50") and a personal story to share ("I've played 100 games of Speck Wars").

## Files changed
- `lib/personal-best.ts` — `getLifetimeStats()`, `updateLifetimeStats()` (SSR-safe, localStorage)
- `game-instance.ts` — call `updateLifetimeStats` after win/loss recording
- `phase-router.tsx` — load stats on menu phase, render stats row

Closes #2126

🤖 Generated with [Claude Code](https://claude.com/claude-code)