### PR TITLE
feat(speck-wars): surge/sacrifice usage count on results screen

### DIFF
--- a/src/app/speck-wars/components/phase-router.tsx
+++ b/src/app/speck-wars/components/phase-router.tsx
@@ -7,7 +7,7 @@ import { useAuth } from '@/hooks/useAuth'
 import Link from 'next/link'
 
 export function PhaseRouter({ children }: { children: React.ReactNode }) {
-  const { phase, winnerId, setPhase, difficulty, setDifficulty, elapsedMs, resetGame, kills, losses, isNewBest, victoryType, hud, peakArmySize, outpostsCaptured, aiPersonality, peakVeteranCount, peakEliteCount, peakLegendCount } = useSpeckWarsStore()
+  const { phase, winnerId, setPhase, difficulty, setDifficulty, elapsedMs, resetGame, kills, losses, isNewBest, victoryType, hud, peakArmySize, outpostsCaptured, aiPersonality, peakVeteranCount, peakEliteCount, peakLegendCount, surgesUsed, sacrificesUsed } = useSpeckWarsStore()
   const [copied, setCopied] = useState(false)
   const [bestTimes, setBestTimes] = useState<Partial<Record<Difficulty, number>>>({})
   const [winStreak, setWinStreak] = useState(0)
@@ -352,6 +352,17 @@ export function PhaseRouter({ children }: { children: React.ReactNode }) {
             )}
             {peakVeteranCount > 0 && (
               <span style={{ color: '#ffd700', opacity: 0.65 }}>⭐ {peakVeteranCount} veteran{peakVeteranCount !== 1 ? 's' : ''}</span>
+            )}
+          </div>
+        )}
+
+        {(surgesUsed > 0 || sacrificesUsed > 0) && (
+          <div style={{ display: 'flex', gap: 20, color: 'rgba(255,255,255,0.4)', fontSize: 12, letterSpacing: 0.5 }}>
+            {surgesUsed > 0 && (
+              <span>⚡ {surgesUsed} surge{surgesUsed !== 1 ? 's' : ''}</span>
+            )}
+            {sacrificesUsed > 0 && (
+              <span>☯ {sacrificesUsed} sacrifice{sacrificesUsed !== 1 ? 's' : ''}</span>
             )}
           </div>
         )}

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -865,6 +865,7 @@ export class GameInstance {
 
   surge() {
     this.sim.inputQueue.push({ type: 'SURGE', ownerId: 'player' })
+    useSpeckWarsStore.getState().addSurgeUsed()
   }
 
   private sacrifice() {
@@ -876,6 +877,7 @@ export class GameInstance {
       return
     }
     this.sim.inputQueue.push({ type: 'SACRIFICE', ownerId: 'player', buildingId: playerBase.id, typeId: 'basic', count: 10 })
+    useSpeckWarsStore.getState().addSacrificeUsed()
   }
 
   enterBuildMode(buildingTypeId: string) {

--- a/src/app/speck-wars/store.ts
+++ b/src/app/speck-wars/store.ts
@@ -50,6 +50,10 @@ interface SpeckWarsStore {
   setPeakEliteCount: (n: number) => void
   peakLegendCount: number
   setPeakLegendCount: (n: number) => void
+  surgesUsed: number
+  addSurgeUsed: () => void
+  sacrificesUsed: number
+  addSacrificeUsed: () => void
   outpostsCaptured: number
   addOutpostCaptured: () => void
   isNewBest: boolean
@@ -111,6 +115,10 @@ export const useSpeckWarsStore = create<SpeckWarsStore>()((set, get) => ({
   setPeakEliteCount: n => set(s => ({ peakEliteCount: Math.max(s.peakEliteCount, n) })),
   peakLegendCount: 0,
   setPeakLegendCount: n => set(s => ({ peakLegendCount: Math.max(s.peakLegendCount, n) })),
+  surgesUsed: 0,
+  addSurgeUsed: () => set(s => ({ surgesUsed: s.surgesUsed + 1 })),
+  sacrificesUsed: 0,
+  addSacrificeUsed: () => set(s => ({ sacrificesUsed: s.sacrificesUsed + 1 })),
   outpostsCaptured: 0,
   addOutpostCaptured: () => set(s => ({ outpostsCaptured: s.outpostsCaptured + 1 })),
   isNewBest: false,
@@ -152,6 +160,8 @@ export const useSpeckWarsStore = create<SpeckWarsStore>()((set, get) => ({
     peakVeteranCount: 0,
     peakEliteCount: 0,
     peakLegendCount: 0,
+    surgesUsed: 0,
+    sacrificesUsed: 0,
     outpostsCaptured: 0,
     killFeed: [],
     aiPersonality: null,


### PR DESCRIPTION
## Summary
- Adds `surgesUsed` and `sacrificesUsed` counters to the Zustand store with reset in `resetGame()`
- Increments `addSurgeUsed()` in `GameInstance.surge()` and `addSacrificeUsed()` in `GameInstance.sacrifice()` (only on successful sacrifice — after the speck count check)
- Displays `⚡ N surges · ☯ N sacrifices` row on the results screen (only when at least one was used)

## Test plan
- [ ] Play a game, press Q for Surge, check the results screen shows surge count
- [ ] Press F to sacrifice specks (need 10+), check sacrifice count appears on results
- [ ] Try F with < 10 specks — verify no count increment (aborted sacrifice)
- [ ] Start a new game after seeing results — verify counts reset to 0

Closes #2128

🤖 Generated with [Claude Code](https://claude.com/claude-code)