### PR TITLE
feat(speck-wars): show daily modifier on menu screen before game starts

### DIFF
--- a/src/app/speck-wars/components/phase-router.tsx
+++ b/src/app/speck-wars/components/phase-router.tsx
@@ -2,6 +2,8 @@
 import { useState, useEffect } from 'react'
 import { useSpeckWarsStore } from '../store'
 import { getBestTime, getWinStreak, getRecentResults, hasWonToday, getLifetimeStats } from '../lib/personal-best'
+import { getDailyModifier } from '../lib/daily-modifier'
+import { DAILY_MODIFIER_LABELS } from '../domain/constants'
 import type { Difficulty } from '../store'
 import { useAuth } from '@/hooks/useAuth'
 import Link from 'next/link'
@@ -99,6 +101,24 @@ export function PhaseRouter({ children }: { children: React.ReactNode }) {
             )
           })}
         </div>
+        {/* Daily modifier badge — shown when today's modifier is not standard */}
+        {(() => {
+          const mod = getDailyModifier(difficulty)
+          if (mod === 'standard') return null
+          const label = DAILY_MODIFIER_LABELS[mod]
+          const color = mod === 'bulwark' ? '#44aaff' : mod === 'blitz' ? '#ffd700' : '#ff8844'
+          return (
+            <div style={{
+              fontSize: 11, letterSpacing: 1.5,
+              color,
+              border: `1px solid ${color}44`,
+              padding: '4px 12px', borderRadius: 4,
+              marginBottom: 2,
+            }}>
+              {label}
+            </div>
+          )
+        })()}
         {/* Best times + win rates per difficulty */}
         <div style={{ display: 'flex', gap: 16, fontSize: 11 }}>
           {difficulties.map(d => {

--- a/src/app/speck-wars/lib/daily-modifier.ts
+++ b/src/app/speck-wars/lib/daily-modifier.ts
@@ -1,0 +1,27 @@
+import { mulberry32 } from '../domain/simulation/prng'
+import { DAILY_MODIFIER_POOL, MAP_LAYOUTS } from '../domain/constants'
+import type { DailyModifier } from '../domain/constants'
+import type { Difficulty } from '../store'
+
+/**
+ * Returns today's daily modifier for the given difficulty without running a
+ * full simulation. Replicates the exact RNG call sequence from createSim so
+ * the result always matches the in-game modifier.
+ */
+export function getDailyModifier(difficulty: Difficulty, date: Date = new Date()): DailyModifier {
+  const dateKey = date.getFullYear() * 10000 + (date.getMonth() + 1) * 100 + date.getDate()
+  const diffHash = [...difficulty].reduce((acc, ch) => acc + ch.charCodeAt(0), 0)
+  const seed = dateKey * 1000 + diffHash
+
+  const rng = mulberry32(seed)
+  // Call 1: layout index
+  const layoutIndex = Math.floor(rng() * MAP_LAYOUTS.length)
+  // Calls 2–7: jitter (2 per outpost, 3 outposts in every layout)
+  const outpostCount = MAP_LAYOUTS[layoutIndex].length
+  for (let i = 0; i < outpostCount; i++) {
+    rng(); rng()
+  }
+  // Call 8: modifier
+  const modifierIndex = Math.floor(rng() * DAILY_MODIFIER_POOL.length)
+  return DAILY_MODIFIER_POOL[modifierIndex]
+}


### PR DESCRIPTION
## Summary
- Players can now see today's active modifier (BULWARK / BLITZ / SIEGE) on the main menu alongside the difficulty selector, before committing to a game
- Badge updates reactively when switching difficulty (modifier seed includes difficulty hash, so Easy/Medium/Hard/Brutal can have different modifiers on the same day)
- No badge shown when today's modifier is 'standard' (majority of days)
- Badge colors match the in-game results screen for visual consistency (blue=bulwark, gold=blitz, orange=siege)

**New file:** `lib/daily-modifier.ts` — replicates the seeded RNG call sequence from `createSim` to compute the modifier without running a full simulation. Same seed formula: `dateKey * 1000 + diffHash`. Same RNG sequence: layout pick → 3×2 jitter calls → modifier pick.

## Test plan
- [ ] Verify TypeScript compiles cleanly
- [ ] On a day with a non-standard modifier: badge appears below difficulty buttons
- [ ] Switching difficulty updates the badge (or hides it if that difficulty gets 'standard')
- [ ] On standard days: no badge rendered
- [ ] In-game modifier matches the preview shown on menu

🤖 Generated with [Claude Code](https://claude.com/claude-code)