### PR TITLE
feat(speck-wars): daily map layout + modifier preview on menu screen

### DIFF
--- a/src/app/speck-wars/components/phase-router.tsx
+++ b/src/app/speck-wars/components/phase-router.tsx
@@ -2,6 +2,8 @@
 import { useState, useEffect } from 'react'
 import { useSpeckWarsStore } from '../store'
 import { getBestTime, getWinStreak, getRecentResults, hasWonToday, getLifetimeStats } from '../lib/personal-best'
+import { getDailyInfo } from '../lib/daily-modifier'
+import { DAILY_MODIFIER_LABELS } from '../domain/constants'
 import type { Difficulty } from '../store'
 import { useAuth } from '@/hooks/useAuth'
 import Link from 'next/link'
@@ -99,6 +101,34 @@ export function PhaseRouter({ children }: { children: React.ReactNode }) {
             )
           })}
         </div>
+        {/* Daily info row — map layout + modifier badge */}
+        {(() => {
+          const { modifier, layoutName } = getDailyInfo(difficulty)
+          const color = modifier === 'bulwark' ? '#44aaff' : modifier === 'blitz' ? '#ffd700' : modifier === 'siege' ? '#ff8844' : 'rgba(255,255,255,0.25)'
+          const label = modifier !== 'standard' ? DAILY_MODIFIER_LABELS[modifier] : null
+          return (
+            <div style={{ display: 'flex', gap: 8, alignItems: 'center', marginBottom: 2 }}>
+              <div style={{
+                fontSize: 10, letterSpacing: 1,
+                color: 'rgba(255,255,255,0.3)',
+                border: '1px solid rgba(255,255,255,0.1)',
+                padding: '3px 8px', borderRadius: 4,
+              }}>
+                ⬡ {layoutName}
+              </div>
+              {label && (
+                <div style={{
+                  fontSize: 10, letterSpacing: 1,
+                  color,
+                  border: `1px solid ${color}44`,
+                  padding: '3px 8px', borderRadius: 4,
+                }}>
+                  {label}
+                </div>
+              )}
+            </div>
+          )
+        })()}
         {/* Best times + win rates per difficulty */}
         <div style={{ display: 'flex', gap: 16, fontSize: 11 }}>
           {difficulties.map(d => {

--- a/src/app/speck-wars/domain/constants.ts
+++ b/src/app/speck-wars/domain/constants.ts
@@ -48,6 +48,9 @@ export const MAP_LAYOUTS = [
 
 export const OUTPOST_POSITIONS = MAP_LAYOUTS[0]  // default — overridden by createSim seed
 
+// Human-readable names for each map layout (index matches MAP_LAYOUTS)
+export const MAP_LAYOUT_NAMES: string[] = ['Triangle', 'Corridor', 'Wings']
+
 export const FORTIFY_TIME = 30000        // ms to reach full fortification
 export const FORTIFY_RADIUS = 200        // px — combat bonus applies within this radius
 export const FORTIFY_DAMAGE_BONUS = 0.25 // max damage multiplier bonus when fully fortified

--- a/src/app/speck-wars/lib/daily-modifier.ts
+++ b/src/app/speck-wars/lib/daily-modifier.ts
@@ -1,0 +1,39 @@
+import { mulberry32 } from '../domain/simulation/prng'
+import { DAILY_MODIFIER_POOL, MAP_LAYOUTS, MAP_LAYOUT_NAMES } from '../domain/constants'
+import type { DailyModifier } from '../domain/constants'
+import type { Difficulty } from '../store'
+
+/**
+ * Returns today's map layout name and daily modifier for the given difficulty
+ * without running a full simulation. Replicates the exact RNG call sequence
+ * from createSim so the results always match the in-game values.
+ */
+export function getDailyInfo(
+  difficulty: Difficulty,
+  date: Date = new Date()
+): { modifier: DailyModifier; layoutName: string } {
+  const dateKey = date.getFullYear() * 10000 + (date.getMonth() + 1) * 100 + date.getDate()
+  const diffHash = [...difficulty].reduce((acc, ch) => acc + ch.charCodeAt(0), 0)
+  const seed = dateKey * 1000 + diffHash
+
+  const rng = mulberry32(seed)
+  // Call 1: layout index
+  const layoutIndex = Math.floor(rng() * MAP_LAYOUTS.length)
+  // Calls 2–7: jitter (2 per outpost, 3 outposts in every layout)
+  const outpostCount = MAP_LAYOUTS[layoutIndex].length
+  for (let i = 0; i < outpostCount; i++) {
+    rng(); rng()
+  }
+  // Call 8: modifier
+  const modifierIndex = Math.floor(rng() * DAILY_MODIFIER_POOL.length)
+
+  return {
+    modifier: DAILY_MODIFIER_POOL[modifierIndex],
+    layoutName: MAP_LAYOUT_NAMES[layoutIndex],
+  }
+}
+
+/** Convenience wrapper — returns only the modifier. */
+export function getDailyModifier(difficulty: Difficulty, date?: Date): DailyModifier {
+  return getDailyInfo(difficulty, date).modifier
+}


### PR DESCRIPTION
## Summary
- Returning players see today's map layout (**Triangle / Corridor / Wings**) and active modifier (**BULWARK / BLITZ / SIEGE**) on the menu before starting a game
- Info row sits between the difficulty buttons and best-times row; updates instantly when switching difficulty (modifier seed includes difficulty, so Easy/Medium/Hard/Brutal can differ)
- Layout badge always shown; modifier badge only appears when the modifier is non-standard (most days it's hidden)
- Badge colors match the in-game results screen for visual consistency

## New file
`lib/daily-modifier.ts` — pure utility, replicates `createSim`'s RNG sequence without running a simulation:
1. Call RNG once → layout index
2. Call RNG 6× → consume jitter for 3 outposts
3. Call RNG once → modifier index

## Test plan
- [ ] TypeScript compiles (`npx tsc --noEmit`)
- [ ] Layout badge renders on menu for all four difficulties
- [ ] On a non-standard modifier day: modifier badge appears with correct color
- [ ] Switching difficulty updates both badges instantly
- [ ] In-game modifier matches the preview shown on menu

🤖 Generated with [Claude Code](https://claude.com/claude-code)