### PR TITLE
feat(speck-wars): remove domination win condition — destruction only

### DIFF
--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -650,46 +650,21 @@ export function HUD() {
         )
       })()}
 
-      {/* Triple outpost bonus indicator + domination countdown */}
-      {hud?.tripleOutpostOwner !== null && hud?.tripleOutpostOwner !== undefined && phase === 'playing' && (() => {
-        const isPlayer = hud.tripleOutpostOwner === 'player'
-        const color = isPlayer ? '#ffd700' : '#ff4f7b'
-        const secLeft = hud.dominationProgress != null
-          ? Math.ceil((1 - hud.dominationProgress) * 60)
-          : null
-        return (
-          <div style={{
-            position: 'absolute', top: 100, left: 0, right: 0,
-            display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 4,
+      {/* Triple outpost bonus indicator */}
+      {hud?.tripleOutpostOwner === 'player' && phase === 'playing' && (
+        <div style={{
+          position: 'absolute', top: 100, left: 0, right: 0,
+          display: 'flex', justifyContent: 'center',
+        }}>
+          <span style={{
+            fontSize: 11, letterSpacing: 2, fontWeight: 'bold',
+            color: '#ffd700', textShadow: '0 0 8px #ffd700',
+            background: 'rgba(0,0,0,0.4)', padding: '2px 10px', borderRadius: 4,
           }}>
-            <span style={{
-              fontSize: 11, letterSpacing: 2, fontWeight: 'bold',
-              color, textShadow: `0 0 8px ${color}`,
-            }}>
-              {isPlayer ? '⬡⬡⬡ TRIPLE CONTROL — SPAWN ×2' : '⬡⬡⬡ ENEMY TRIPLE CONTROL'}
-            </span>
-            {hud.dominationProgress !== null && (
-              <>
-                <div style={{ width: 160, height: 3, background: 'rgba(255,255,255,0.12)', borderRadius: 2, overflow: 'hidden' }}>
-                  <div style={{
-                    height: '100%',
-                    width: `${Math.round(hud.dominationProgress * 100)}%`,
-                    background: color,
-                    borderRadius: 2,
-                    boxShadow: `0 0 6px ${color}`,
-                    transition: 'width 0.3s',
-                  }} />
-                </div>
-                {secLeft !== null && (
-                  <span style={{ fontSize: 10, letterSpacing: 1, color, opacity: 0.7 }}>
-                    {isPlayer ? `DOMINATION in ${secLeft}s` : `ENEMY DOMINATES in ${secLeft}s`}
-                  </span>
-                )}
-              </>
-            )}
-          </div>
-        )
-      })()}
+            ⬡ +PROD
+          </span>
+        </div>
+      )}
 
       {/* Cinematic countdown overlay */}
       {countdown !== null && (

--- a/src/app/speck-wars/components/phase-router.tsx
+++ b/src/app/speck-wars/components/phase-router.tsx
@@ -195,7 +195,7 @@ export function PhaseRouter({ children }: { children: React.ReactNode }) {
         {/* Daily tip */}
         {(() => {
           const tips = [
-            'Hold all 3 outposts for 60s to win by Domination.',
+            'Capture outposts to boost your production.',
             'Scouts (3) auto-target outposts — fast but fragile.',
             'Veterans deal +20% damage after 3 kills. Protect them!',
             'Fortify outposts by holding them 30s for a combat bonus.',
@@ -289,23 +289,18 @@ export function PhaseRouter({ children }: { children: React.ReactNode }) {
           <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 4 }}>
             <div style={{
               fontSize: 12, letterSpacing: 3, opacity: 0.6,
-              color: victoryType === 'domination' ? '#ffd700' : accentColor,
+              color: accentColor,
               textTransform: 'uppercase',
             }}>
-              {victoryType === 'domination' ? '⬡ by Domination'
-                : victoryType === 'surrender' ? '🏳 Surrendered'
+              {victoryType === 'surrender' ? '🏳 Surrendered'
                 : '💥 by Destruction'}
             </div>
             <div style={{ fontSize: 10, letterSpacing: 1, opacity: 0.35, color: '#fff' }}>
               {won
-                ? victoryType === 'domination'
-                  ? 'held all 3 outposts for 60 seconds'
-                  : 'destroyed the enemy base'
+                ? 'destroyed the enemy base'
                 : victoryType === 'surrender'
                   ? 'you chose to give up'
-                  : victoryType === 'domination'
-                    ? 'enemy held all 3 outposts for 60 seconds'
-                    : 'your base was destroyed'
+                  : 'your base was destroyed'
               }
             </div>
           </div>

--- a/src/app/speck-wars/domain/ai/ai-controller.ts
+++ b/src/app/speck-wars/domain/ai/ai-controller.ts
@@ -106,20 +106,10 @@ export class AIController {
 
     this.decisionCount++
 
-    // Emergency: detect if the enemy (player) is about to win by domination
     const outposts = Object.values(sim.buildings).filter(b => b.typeId === 'outpost')
-    const enemyId = Object.keys(sim.players).find(pid => pid !== this.playerId && pid !== 'neutral') ?? null
-    const enemyHasAllOutposts = enemyId !== null && outposts.length > 0 && outposts.every(o => o.ownerId === enemyId)
-    // If enemy has all outposts, temporarily halve decision interval to react faster
-    if (enemyHasAllOutposts) {
-      this.tickInterval = Math.max(Math.floor(this.baseTickInterval * 0.5), 2)
-    } else if (this.dominanceTimer === 0) {
-      this.tickInterval = this.baseTickInterval
-    }
 
     // Aggressive: every 4th decision, rush player base directly (pressure waves)
-    // Exception: never base-rush during enemy domination threat — must recapture outposts
-    const forceBaseRush = this.personality === 'aggressive' && this.decisionCount % 4 === 0 && !enemyHasAllOutposts
+    const forceBaseRush = this.personality === 'aggressive' && this.decisionCount % 4 === 0
 
     // Defensive rally: when AI base is low HP, sometimes pull back to defend
     const myBaseHpFrac = (myBase?.hp ?? 100) / (myBase?.maxHp ?? 100)

--- a/src/app/speck-wars/domain/simulation/tick.ts
+++ b/src/app/speck-wars/domain/simulation/tick.ts
@@ -7,7 +7,7 @@ import { resolveCombat, removeDeadSpecks } from './combat'
 import { checkVictory } from './victory'
 import { updateCapture } from './capture'
 import { BUILDING_TYPES } from '../config/building-types'
-import { HUD_UPDATE_INTERVAL, DOMINATION_TIME, RALLY_CRY_HP_THRESHOLD, FORTIFY_TIME } from '../constants'
+import { HUD_UPDATE_INTERVAL, RALLY_CRY_HP_THRESHOLD, FORTIFY_TIME } from '../constants'
 import { updateConstruction } from './construction'
 import { updateTurrets } from './turret'
 
@@ -159,14 +159,6 @@ function updateTripleOutpostBonus(sim: SimulationState, dt: number) {
     if (ownsAll) tripleHolder = pid
   }
 
-  if (tripleHolder) {
-    sim.dominationTimer += dt
-    if (sim.dominationTimer >= DOMINATION_TIME) {
-      sim.events.push({ type: 'GAME_OVER', winnerId: tripleHolder, victoryType: 'domination' })
-    }
-  } else {
-    sim.dominationTimer = 0
-  }
 }
 
 function consumeInputs(sim: SimulationState) {
@@ -481,7 +473,7 @@ function emitHudUpdate(sim: SimulationState) {
     }
   }
 
-  const dominationProgress = tripleOutpostOwner ? Math.min(1, sim.dominationTimer / DOMINATION_TIME) : null
+  const dominationProgress = null
 
   // Capture progress for each outpost
   const captureInfo: Record<string, { progress: number; side: string } | null> = {}

--- a/src/app/speck-wars/domain/types.ts
+++ b/src/app/speck-wars/domain/types.ts
@@ -107,7 +107,7 @@ export type SimEvent =
   | { type: 'BUILDING_DAMAGED'; buildingId: string; hp: number }
   | { type: 'BUILDING_DESTROYED'; buildingId: string; ownerId: string; x: number; y: number }
   | { type: 'SPECK_SPAWNED'; speckId: string; buildingId: string }
-  | { type: 'GAME_OVER'; winnerId: string; victoryType: 'destruction' | 'domination' }
+  | { type: 'GAME_OVER'; winnerId: string; victoryType: 'destruction' }
   | { type: 'HUD_UPDATE'; data: HudData }
   | { type: 'OUTPOST_CAPTURED'; outpostId: string; newOwner: string; previousOwner: string }
   | { type: 'SPECK_VETERAN'; speckId: string; ownerId: string }

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -38,9 +38,6 @@ export class GameInstance {
   private lastIdleNudge = -30000         // allow nudge immediately if idle at game start
   private cachedPlayerSpeckCount = 0    // updated from HUD_UPDATE
   private lastAiSpawnMode: string = 'basic'  // track AI spawn mode changes
-  private dominationCountdownHolder: string | null = null  // who has triple outpost for countdown
-  private dominationWarned10 = false    // notified at 10s remaining
-  private dominationWarned5 = false     // notified at 5s remaining
   private lastTripleHolder: string | null = null  // track triple-outpost ownership changes
   private rallyCryFired = false               // one-time Rally Cry notification per game
   private firstVeteranNotifiedAt = -30000   // allow veteran notification immediately
@@ -330,7 +327,7 @@ export class GameInstance {
         { delay: 6000,  message: '💡 Capture outposts to boost production!', color: '#aaddff' },
         { delay: 13000, message: '💡 Press Q for Surge — doubles production for 8s!', color: '#ffd700' },
         { delay: 22000, message: '💡 Press 1/2/3 to switch spawn type (basic/heavy/scout)', color: '#aaddff' },
-        { delay: 32000, message: '💡 Hold all 3 outposts for 60s to win by domination!', color: '#ffd700' },
+        { delay: 32000, message: '💡 Hold all 3 outposts for 2× production boost!', color: '#ffd700' },
         { delay: 45000, message: '💡 Press F to sacrifice 10 specks and repair your base!', color: '#64c864' },
       ]
       for (const { delay, message, color } of hints) {
@@ -485,38 +482,12 @@ export class GameInstance {
           const holder = event.data.tripleOutpostOwner ?? null
           if (holder !== this.lastTripleHolder) {
             if (holder === 'player') {
-              this.notify('⬡ TRIPLE OUTPOST! Hold for 60s to win!', '#ffd700', 4000)
+              this.notify('⬡ TRIPLE OUTPOST! 2× production boost!', '#ffd700', 4000)
             } else if (holder === 'ai' && this.lastTripleHolder !== null) {
               // AI reclaimed triple — only notify if player had just lost it
               this.notify('⬡ ENEMY HAS ALL OUTPOSTS!', '#ff4f7b', 3000)
             }
             this.lastTripleHolder = holder
-          }
-
-          // Domination countdown: warn at 10s and 5s remaining
-          const dp = event.data.dominationProgress ?? null
-          if (holder !== this.dominationCountdownHolder) {
-            // Holder changed — reset countdown flags
-            this.dominationCountdownHolder = holder
-            this.dominationWarned10 = false
-            this.dominationWarned5 = false
-          }
-          if (holder !== null && dp !== null) {
-            const isPlayer = holder === 'player'
-            // 10s left threshold: 50/60 ≈ 0.833
-            if (!this.dominationWarned10 && dp >= 50 / 60) {
-              this.dominationWarned10 = true
-              const msg = isPlayer ? '⬡ DOMINATION IN 10s!' : '⬡ ENEMY DOMINATION IN 10s!'
-              const color = isPlayer ? '#4af7c4' : '#ff4f7b'
-              this.notify(msg, color, 3000)
-            }
-            // 5s left threshold: 55/60 ≈ 0.917
-            if (!this.dominationWarned5 && dp >= 55 / 60) {
-              this.dominationWarned5 = true
-              const msg = isPlayer ? '⬡ DOMINATION IN 5s!' : '⬡ ENEMY DOMINATION IN 5s!'
-              const color = isPlayer ? '#ffd700' : '#ff2200'
-              this.notify(msg, color, 4500)
-            }
           }
         }
         if (event.type === 'SPECK_DIED') {

--- a/src/app/speck-wars/store.ts
+++ b/src/app/speck-wars/store.ts
@@ -23,8 +23,8 @@ interface SpeckWarsStore {
   setCountdown: (n: number | null) => void
   winnerId: string | null
   setWinnerId: (id: string) => void
-  victoryType: 'destruction' | 'domination' | 'surrender' | null
-  setVictoryType: (t: 'destruction' | 'domination' | 'surrender') => void
+  victoryType: 'destruction' | 'surrender' | null
+  setVictoryType: (t: 'destruction' | 'surrender') => void
   hud: HudData | null
   setHud: (data: HudData) => void
   difficulty: Difficulty


### PR DESCRIPTION
## Summary
Outposts remain as strategic production tools — holding all 3 now gives **2× production** — but no longer serve as a win condition. The only path to victory is destroying the enemy base.

This simplifies the strategic loop: players contest outposts for economy, not as an alternative win route.

## Changes
- **tick.ts**: remove `dominationTimer` increment and `GAME_OVER` emission via domination; `dominationProgress` always `null` in HUD update
- **types.ts / store.ts**: remove `'domination'` from `victoryType` union
- **game-instance.ts**: remove `dominationCountdownHolder` / `Warned10` / `Warned5` private fields and all countdown notifications; update triple-outpost message to convey production bonus
- **hud.tsx**: replace domination countdown bar with simple ⬡ +PROD badge shown only when player holds all 3 outposts
- **phase-router.tsx**: update tip to "Capture outposts to boost your production"; remove domination branches from victory/defeat screen
- **ai-controller.ts**: remove enemy domination threat detection and base-rush exception it gated

## Test plan
- [ ] Win a game by destroying the enemy base — confirm victory screen shows "by Destruction"
- [ ] Hold all 3 outposts simultaneously — confirm ⬡ +PROD badge appears in HUD; no countdown or win condition triggers
- [ ] Verify no TypeScript errors (`npx tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)