### PR TITLE
feat(speck-wars): include map layout in share text and results screen

### DIFF
--- a/src/app/speck-wars/components/phase-router.tsx
+++ b/src/app/speck-wars/components/phase-router.tsx
@@ -255,11 +255,12 @@ export function PhaseRouter({ children }: { children: React.ReactNode }) {
     const today = new Date().toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
     const starStr = won ? '★'.repeat(stars) + '☆'.repeat(3 - stars) : '✗✗✗'
     const modifier = hud?.dailyModifier && hud.dailyModifier !== 'standard' ? ` [${hud.dailyModifier.toUpperCase()}]` : ''
+    const { layoutName } = getDailyInfo(difficulty)
     const effPct = kills + losses > 0 ? Math.round((kills / (kills + losses)) * 100) : 0
     const statsLine = `⚔ ${kills} kills · ${losses} lost · ${effPct}% eff${peakArmySize > 0 ? ` · peak ${peakArmySize}` : ''}`
     const shareText = won
-      ? `${starStr} Speck Wars ${today}${modifier}\nVICTORY in ${timeStr} (${diffLabel})\n${statsLine}\nCan you do better? `
-      : `${starStr} Speck Wars ${today}${modifier}\nDEFEATED in ${timeStr} (${diffLabel})\n${statsLine}\nThink you can win? `
+      ? `${starStr} Speck Wars ${today} [${layoutName}]${modifier}\nVICTORY in ${timeStr} (${diffLabel})\n${statsLine}\nCan you do better? `
+      : `${starStr} Speck Wars ${today} [${layoutName}]${modifier}\nDEFEATED in ${timeStr} (${diffLabel})\n${statsLine}\nThink you can win? `
 
     const handleShare = async () => {
       const url = typeof window !== 'undefined' ? window.location.href : ''
@@ -325,6 +326,14 @@ export function PhaseRouter({ children }: { children: React.ReactNode }) {
           <span>⏱ {timeStr}</span>
           <span style={{ color: diffColor, fontWeight: 'bold', border: `1px solid ${diffColor}`, padding: '2px 10px', borderRadius: 4 }}>
             {diffLabel}
+          </span>
+          <span style={{
+            fontSize: 10, letterSpacing: 1,
+            color: 'rgba(255,255,255,0.3)',
+            border: '1px solid rgba(255,255,255,0.1)',
+            padding: '2px 8px', borderRadius: 4,
+          }}>
+            ⬡ {layoutName}
           </span>
           {hud?.dailyModifier && hud.dailyModifier !== 'standard' && (
             <span style={{


### PR DESCRIPTION
## Summary
The map layout name (Triangle / Corridor / Wings) now appears in two places:

1. **Share text**: `★★★ Speck Wars Jul 25 [Triangle] [BLITZ]\nVICTORY in 03:42 (Hard)...` — helps friends see whether they played the same layout when comparing scores; different difficulties can roll different layouts on the same day
2. **Results screen**: A subdued ⬡ Layout badge in the time/difficulty row, matching the style of the menu preview badge

Uses the existing `getDailyInfo()` utility already imported on this branch — no new computation needed.

## Test plan
- [ ] Play a game, check the results screen — layout badge appears in the time/difficulty row
- [ ] Click Share on the results screen — the share text includes `[Triangle]` (or Corridor/Wings)
- [ ] Verify TypeScript compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)