### PR TITLE
feat(speck-wars): layout-specific strategy tip on menu screen

### DIFF
--- a/src/app/speck-wars/components/phase-router.tsx
+++ b/src/app/speck-wars/components/phase-router.tsx
@@ -129,6 +129,28 @@ export function PhaseRouter({ children }: { children: React.ReactNode }) {
             </div>
           )
         })()}
+        {/* Layout strategy tip */}
+        {(() => {
+          const { layoutName } = getDailyInfo(difficulty)
+          const layoutTips: Record<string, string> = {
+            Triangle: 'Triangle: the top outpost commands the map — contest it early for reach to both flanks.',
+            Corridor: 'Corridor: fight hard for the middle outpost, it splits the lane and cuts off retreats.',
+            Wings: 'Wings: forces split attention — consider scouting both flanks before committing.',
+          }
+          const tip = layoutTips[layoutName]
+          if (!tip) return null
+          return (
+            <div style={{
+              fontSize: 10, letterSpacing: 0.3,
+              color: 'rgba(255,255,255,0.28)',
+              textAlign: 'center',
+              fontStyle: 'italic',
+              maxWidth: 280,
+            }}>
+              {tip}
+            </div>
+          )
+        })()}
         {/* Best times + win rates per difficulty */}
         <div style={{ display: 'flex', gap: 16, fontSize: 11 }}>
           {difficulties.map(d => {


### PR DESCRIPTION
## Summary
A small contextual tip appears below the layout badge on the menu screen, giving returning players a quick strategic framing before they start:

- **Triangle**: "the top outpost commands the map — contest it early for reach to both flanks"
- **Corridor**: "fight hard for the middle outpost, it splits the lane and cuts off retreats"
- **Wings**: "forces split attention — consider scouting both flanks before committing"

The tip updates instantly when switching difficulty (since layout depends on difficulty seed). Displayed in dim italic text below the daily info row — visible but not distracting.

## Metrics target
- **Session length** — players who know the layout's strategic character may engage more deliberately rather than experimenting by trial and error

## Test plan
- [ ] TypeScript compiles cleanly
- [ ] Layout tip updates when switching difficulty
- [ ] All three layouts show appropriate tips

🤖 Generated with [Claude Code](https://claude.com/claude-code)