### PR TITLE
feat(speck-wars): Elite/Legend specks deal splash damage

### DIFF
--- a/src/app/speck-wars/domain/simulation/combat.ts
+++ b/src/app/speck-wars/domain/simulation/combat.ts
@@ -87,6 +87,34 @@ export function resolveCombat(sim: SimulationState, dt: number) {
           }
         }
         speckHp[j] -= stype.damage * moraleMult(meta.ownerId) * veteranBonus * fortifyBonus
+        // Elite/Legend splash damage — inspired by CoH veteran abilities (issue #2145)
+        // Elite (6+ kills): 18px radius, 50% damage; Legend (12+ kills): 28px radius, 75% damage
+        const splashRadius = meta.kills >= 12 ? 28 : meta.kills >= 6 ? 18 : 0
+        if (splashRadius > 0) {
+          const splashDamage = stype.damage * moraleMult(meta.ownerId) * veteranBonus * (meta.kills >= 12 ? 0.75 : 0.50)
+          const splashNeighbors = spatialGrid.query(speckX[j], speckY[j])
+          for (const k of splashNeighbors) {
+            if (k === j || k === i) continue   // skip primary target and attacker
+            if (speckHp[k] <= 0) continue
+            const kMeta = speckMeta[k]
+            if (!kMeta || kMeta.ownerId === meta.ownerId) continue   // friendly
+            const sdx = speckX[k] - speckX[j]
+            const sdy = speckY[k] - speckY[j]
+            if (sdx * sdx + sdy * sdy <= splashRadius * splashRadius) {
+              speckHp[k] -= splashDamage
+              if (speckHp[k] <= 0) {
+                if (kMeta.ownerId === 'player' && kMeta.kills >= 3) {
+                  sim.events.push({ type: 'VETERAN_FALLEN', speckId: speckIds[k], ownerId: kMeta.ownerId, kills: kMeta.kills, x: speckX[k], y: speckY[k] })
+                }
+                sim.events.push({ type: 'SPECK_DIED', speckId: speckIds[k], x: speckX[k], y: speckY[k], killedOwnerId: kMeta.ownerId, killerOwnerId: meta.ownerId })
+                meta.kills++
+                if (meta.kills === 3) sim.events.push({ type: 'SPECK_VETERAN', speckId: speckIds[i], ownerId: meta.ownerId })
+                if (meta.kills === 6) sim.events.push({ type: 'SPECK_ELITE', speckId: speckIds[i], ownerId: meta.ownerId })
+                if (meta.kills === 12) sim.events.push({ type: 'SPECK_LEGEND', speckId: speckIds[i], ownerId: meta.ownerId })
+              }
+            }
+          }
+        }
         meta.attackCooldown = stype.attackCooldown
         meta.state = 'attacking'
         // die_on_impact: missile self-destructs after dealing damage

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -7,7 +7,7 @@ import { createCamera, clampCamera, screenToWorld } from './rendering/camera'
 import { InputHandler } from './input/input-handler'
 import type { Camera } from './rendering/camera'
 import { AIController, type AIPersonality } from './domain/ai/ai-controller'
-import { recordBestTime, incrementWinStreak, resetWinStreak, isFirstGame, markFirstGameDone, recordGameResult, markWonToday, updateLifetimeStats, getWinStreak } from './lib/personal-best'
+import { recordBestTime, incrementWinStreak, resetWinStreak, isFirstGame, markFirstGameDone, recordGameResult, markWonToday, updateLifetimeStats, getWinStreak, hasSeenVeteranTip, markVeteranTipSeen } from './lib/personal-best'
 import { BUILDING_TYPES } from './domain/config/building-types'
 
 export class GameInstance {
@@ -628,7 +628,11 @@ export class GameInstance {
         }
         if (event.type === 'SPECK_VETERAN' && event.ownerId === 'player') {
           const now = Date.now()
-          if (now - this.firstVeteranNotifiedAt > 20000) {
+          if (!hasSeenVeteranTip()) {
+            markVeteranTipSeen()
+            this.firstVeteranNotifiedAt = now
+            this.notify('⭐ FIRST VETERAN! Keep them alive — 6 kills = ELITE, 12 = LEGEND', '#ffd700', 5000)
+          } else if (now - this.firstVeteranNotifiedAt > 20000) {
             this.firstVeteranNotifiedAt = now
             this.notify('⭐ VETERAN SPECK! +20% DAMAGE', '#ffd700', 2000)
           }

--- a/src/app/speck-wars/lib/personal-best.ts
+++ b/src/app/speck-wars/lib/personal-best.ts
@@ -117,3 +117,15 @@ export function updateLifetimeStats(kills: number, currentStreak: number) {
   }
   localStorage.setItem(LIFETIME_KEY, JSON.stringify(next))
 }
+
+const VETERAN_TIP_KEY = 'speck-wars-veteran-tip-seen'
+
+export function hasSeenVeteranTip(): boolean {
+  if (typeof window === 'undefined') return true
+  return !!localStorage.getItem(VETERAN_TIP_KEY)
+}
+
+export function markVeteranTipSeen() {
+  if (typeof window === 'undefined') return
+  localStorage.setItem(VETERAN_TIP_KEY, '1')
+}


### PR DESCRIPTION
## Summary
Elite specks (6+ kills) and Legend specks (12+ kills) now deal splash damage to nearby enemies on each attack, inspired by Company of Heroes veteran squad abilities and StarCraft siege tank splash.

- **Elite (6+ kills)**: 18px splash radius, 50% of base damage
- **Legend (12+ kills)**: 28px splash radius, 75% of base damage  
- Splash hits all enemies near the primary target, not near the attacker
- Respects morale multiplier and veteran damage bonus
- Splash kills earn the attacker kills and can trigger veteran/elite/legend milestones
- No friendly fire

Closes #2145

🤖 Generated with [Claude Code](https://claude.com/claude-code)