### PR TITLE
feat(speck-wars): show veteran progression tutorial on first veteran

### DIFF
--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -7,7 +7,7 @@ import { createCamera, clampCamera, screenToWorld } from './rendering/camera'
 import { InputHandler } from './input/input-handler'
 import type { Camera } from './rendering/camera'
 import { AIController, type AIPersonality } from './domain/ai/ai-controller'
-import { recordBestTime, incrementWinStreak, resetWinStreak, isFirstGame, markFirstGameDone, recordGameResult, markWonToday, updateLifetimeStats, getWinStreak } from './lib/personal-best'
+import { recordBestTime, incrementWinStreak, resetWinStreak, isFirstGame, markFirstGameDone, recordGameResult, markWonToday, updateLifetimeStats, getWinStreak, hasSeenVeteranTip, markVeteranTipSeen } from './lib/personal-best'
 import { BUILDING_TYPES } from './domain/config/building-types'
 
 export class GameInstance {
@@ -628,7 +628,11 @@ export class GameInstance {
         }
         if (event.type === 'SPECK_VETERAN' && event.ownerId === 'player') {
           const now = Date.now()
-          if (now - this.firstVeteranNotifiedAt > 20000) {
+          if (!hasSeenVeteranTip()) {
+            markVeteranTipSeen()
+            this.firstVeteranNotifiedAt = now
+            this.notify('⭐ FIRST VETERAN! Keep them alive — 6 kills = ELITE, 12 = LEGEND', '#ffd700', 5000)
+          } else if (now - this.firstVeteranNotifiedAt > 20000) {
             this.firstVeteranNotifiedAt = now
             this.notify('⭐ VETERAN SPECK! +20% DAMAGE', '#ffd700', 2000)
           }

--- a/src/app/speck-wars/lib/personal-best.ts
+++ b/src/app/speck-wars/lib/personal-best.ts
@@ -117,3 +117,15 @@ export function updateLifetimeStats(kills: number, currentStreak: number) {
   }
   localStorage.setItem(LIFETIME_KEY, JSON.stringify(next))
 }
+
+const VETERAN_TIP_KEY = 'speck-wars-veteran-tip-seen'
+
+export function hasSeenVeteranTip(): boolean {
+  if (typeof window === 'undefined') return true
+  return !!localStorage.getItem(VETERAN_TIP_KEY)
+}
+
+export function markVeteranTipSeen() {
+  if (typeof window === 'undefined') return
+  localStorage.setItem(VETERAN_TIP_KEY, '1')
+}


### PR DESCRIPTION
## Summary

- On a player's very first veteran speck (tracked persistently via \`localStorage\` key \`speck-wars-veteran-tip-seen\`), show a richer 5-second notification: **"⭐ FIRST VETERAN! Keep them alive — 6 kills = ELITE, 12 = LEGEND"**
- On all subsequent veteran events the existing brief **"⭐ VETERAN SPECK! +20% DAMAGE"** notice (2 s, 20 s cooldown) is unchanged
- The tip flag is set once and never resets, so returning players see only the short notification

## Metric this moves

**Session length** — players who understand the progression chain (VETERAN → ELITE → LEGEND) are motivated to protect their veteran specks instead of rallying recklessly, which extends the mid/late-game phase and deepens engagement.

## Files changed

- \`src/app/speck-wars/lib/personal-best.ts\` — adds \`hasSeenVeteranTip()\` and \`markVeteranTipSeen()\` backed by localStorage
- \`src/app/speck-wars/game-instance.ts\` — imports both helpers and updates the \`SPECK_VETERAN\` event handler to branch on first-time vs. returning player

🤖 Generated with [Claude Code](https://claude.com/claude-code)