### PR TITLE
feat(speck-wars): kill milestone upgrades at 50/150/300 kills

### DIFF
--- a/src/app/speck-wars/domain/simulation/combat.ts
+++ b/src/app/speck-wars/domain/simulation/combat.ts
@@ -86,7 +86,8 @@ export function resolveCombat(sim: SimulationState, dt: number) {
             if (level > 0) { fortifyBonus = 1 + FORTIFY_DAMAGE_BONUS * level; break }
           }
         }
-        speckHp[j] -= stype.damage * moraleMult(meta.ownerId) * veteranBonus * fortifyBonus
+        const upgradeBonus = (sim.players[meta.ownerId]?.upgradeLevel ?? 0) >= 3 ? 1.15 : 1.0
+        speckHp[j] -= stype.damage * moraleMult(meta.ownerId) * veteranBonus * fortifyBonus * upgradeBonus
         // Elite/Legend splash damage — inspired by CoH veteran abilities (issue #2145)
         // Elite (6+ kills): 18px radius, 50% damage; Legend (12+ kills): 28px radius, 75% damage
         const splashRadius = meta.kills >= 12 ? 28 : meta.kills >= 6 ? 18 : 0
@@ -111,6 +112,16 @@ export function resolveCombat(sim: SimulationState, dt: number) {
                 if (meta.kills === 3) sim.events.push({ type: 'SPECK_VETERAN', speckId: speckIds[i], ownerId: meta.ownerId })
                 if (meta.kills === 6) sim.events.push({ type: 'SPECK_ELITE', speckId: speckIds[i], ownerId: meta.ownerId })
                 if (meta.kills === 12) sim.events.push({ type: 'SPECK_LEGEND', speckId: speckIds[i], ownerId: meta.ownerId })
+                // Kill milestone upgrades (splash)
+                const splashKillerPlayer = sim.players[meta.ownerId]
+                if (splashKillerPlayer) {
+                  splashKillerPlayer.totalKills++
+                  const splashNewLevel = splashKillerPlayer.totalKills >= 300 ? 3 : splashKillerPlayer.totalKills >= 150 ? 2 : splashKillerPlayer.totalKills >= 50 ? 1 : 0
+                  if (splashNewLevel > splashKillerPlayer.upgradeLevel) {
+                    splashKillerPlayer.upgradeLevel = splashNewLevel as 0 | 1 | 2 | 3
+                    sim.events.push({ type: 'UPGRADE_UNLOCKED', ownerId: meta.ownerId, level: splashNewLevel as 1 | 2 | 3 })
+                  }
+                }
               }
             }
           }
@@ -143,6 +154,16 @@ export function resolveCombat(sim: SimulationState, dt: number) {
           }
           if (meta.kills === 12) {
             sim.events.push({ type: 'SPECK_LEGEND', speckId: speckIds[i], ownerId: meta.ownerId })
+          }
+          // Kill milestone upgrades
+          const killerPlayer = sim.players[meta.ownerId]
+          if (killerPlayer) {
+            killerPlayer.totalKills++
+            const newLevel = killerPlayer.totalKills >= 300 ? 3 : killerPlayer.totalKills >= 150 ? 2 : killerPlayer.totalKills >= 50 ? 1 : 0
+            if (newLevel > killerPlayer.upgradeLevel) {
+              killerPlayer.upgradeLevel = newLevel as 0 | 1 | 2 | 3
+              sim.events.push({ type: 'UPGRADE_UNLOCKED', ownerId: meta.ownerId, level: newLevel as 1 | 2 | 3 })
+            }
           }
         }
         break  // one attack per cooldown

--- a/src/app/speck-wars/domain/simulation/create-sim.ts
+++ b/src/app/speck-wars/domain/simulation/create-sim.ts
@@ -1,5 +1,5 @@
 import type { SimulationState, Player, BuildingEntity } from '../types'
-import { PLAYER_BASE_X, PLAYER_BASE_Y, AI_BASE_X, AI_BASE_Y, PLAYER_COLOR, AI_COLOR, BASE_HP, MAX_SPECKS, NEUTRAL_COLOR, MAP_LAYOUTS, DAILY_MODIFIER_POOL } from '../constants'
+import { PLAYER_BASE_X, PLAYER_BASE_Y, AI_BASE_X, AI_BASE_Y, PLAYER_COLOR, AI_COLOR, BASE_HP, MAX_SPECKS, NEUTRAL_COLOR, DAILY_MODIFIER_POOL } from '../constants'
 import type { DailyModifier } from '../constants'
 import { SpatialGrid } from './spatial-grid'
 import { mulberry32 } from './prng'
@@ -19,83 +19,141 @@ const playerSpawnInterval: Record<Difficulty, number | undefined> = {
   'very-hard': undefined,  // same as hard — no advantage
 }
 
-export function createSim(seed: number = Date.now(), difficulty: Difficulty = 'medium'): SimulationState {
-  const playerBase: BuildingEntity = {
-    id: 'building-player-base',
+function generateOutpostPositions(count: number, rng: () => number) {
+  // Outposts spread across the center zone, avoiding base flanks
+  const X_MIN = 850, X_MAX = 2150
+  const Y_MIN = 550, Y_MAX = 2450
+
+  const cols = Math.ceil(Math.sqrt(count * 1.5))
+  const rows = Math.ceil(count / cols)
+  const cellW = (X_MAX - X_MIN) / cols
+  const cellH = (Y_MAX - Y_MIN) / rows
+
+  // Build all cells
+  const cells: { x: number; y: number }[] = []
+  for (let row = 0; row < rows; row++) {
+    for (let col = 0; col < cols; col++) {
+      cells.push({
+        x: X_MIN + cellW * (col + 0.5),
+        y: Y_MIN + cellH * (row + 0.5),
+      })
+    }
+  }
+
+  // Fisher-Yates shuffle with seeded rng
+  for (let i = cells.length - 1; i > 0; i--) {
+    const j = Math.floor(rng() * (i + 1));
+    [cells[i], cells[j]] = [cells[j], cells[i]]
+  }
+
+  // Take first `count`, add jitter up to 30% of cell size
+  const jitter = Math.min(cellW, cellH) * 0.3
+  return cells.slice(0, count).map(c => ({
+    x: Math.round(c.x + (rng() * 2 - 1) * jitter),
+    y: Math.round(c.y + (rng() * 2 - 1) * jitter),
+  }))
+}
+
+function generateBasePositions(count: number, isPlayer: boolean) {
+  const x = isPlayer ? PLAYER_BASE_X : AI_BASE_X
+  if (count === 1) return [{ x, y: 1500 }]
+  const spacing = Math.min(500, 2000 / (count + 1))
+  return Array.from({ length: count }, (_, i) => ({
+    x,
+    y: Math.round(1500 - (spacing * (count - 1) / 2) + spacing * i),
+  }))
+}
+
+export function createSim(seed: number = Date.now(), difficulty: Difficulty = 'medium', outpostCount = 3, baseCount = 1): SimulationState {
+  const rng = mulberry32(seed)  // seeded so same date+difficulty = same map
+
+  // Generate base positions for both sides
+  const playerBasePositions = generateBasePositions(baseCount, true)
+  const aiBasePositions = generateBasePositions(baseCount, false)
+
+  const playerBases: BuildingEntity[] = playerBasePositions.map((pos, i) => ({
+    id: i === 0 ? 'building-player-base' : `building-player-base-${i}`,
     typeId: 'base',
     ownerId: 'player',
-    x: PLAYER_BASE_X, y: PLAYER_BASE_Y,
+    x: pos.x, y: pos.y,
     hp: BASE_HP, maxHp: BASE_HP,
     spawnTimer: 0,
     spawnIntervalOverride: playerSpawnInterval[difficulty],
     inputBuffer: {},
-  }
-  const aiBase: BuildingEntity = {
-    id: 'building-ai-base',
+  }))
+
+  const aiBases: BuildingEntity[] = aiBasePositions.map((pos, i) => ({
+    id: i === 0 ? 'building-ai-base' : `building-ai-base-${i}`,
     typeId: 'base',
     ownerId: 'ai',
-    x: AI_BASE_X, y: AI_BASE_Y,
+    x: pos.x, y: pos.y,
     hp: BASE_HP, maxHp: BASE_HP,
     spawnTimer: 0,
     spawnIntervalOverride: aiSpawnInterval[difficulty],
     inputBuffer: {},
-  }
+  }))
 
   const player: Player = {
     id: 'player', name: 'Player',
     color: PLAYER_COLOR, isAI: false, isDefeated: false, stockpile: {},
+    totalKills: 0, upgradeLevel: 0,
   }
   const ai: Player = {
     id: 'ai', name: 'AI',
     color: AI_COLOR, isAI: true, isDefeated: false, stockpile: {},
+    totalKills: 0, upgradeLevel: 0,
   }
   const neutral: Player = {
     id: 'neutral', name: 'Neutral',
     color: NEUTRAL_COLOR, isAI: false, isDefeated: false, stockpile: {},
+    totalKills: 0, upgradeLevel: 0,
   }
 
-  const JITTER = 150  // ± px of positional variation per game
-  const rng = mulberry32(seed)  // seeded so same date+difficulty = same map
-  // Pick layout using first RNG call so same seed = same layout + same jitter
-  const layoutIndex = Math.floor(rng() * MAP_LAYOUTS.length)
-  const outpostPositions = MAP_LAYOUTS[layoutIndex]
+  // Generate outpost positions using seeded rng
+  const outpostPositions = generateOutpostPositions(outpostCount, rng)
   const outpostBuildings: Record<string, BuildingEntity> = {}
-  for (const pos of outpostPositions) {
-    const jx = (rng() * 2 - 1) * JITTER
-    const jy = (rng() * 2 - 1) * JITTER
-    outpostBuildings[pos.id] = {
-      id: pos.id,
+  outpostPositions.forEach((pos, i) => {
+    const id = `outpost-${i}`
+    outpostBuildings[id] = {
+      id,
       typeId: 'outpost',
       ownerId: 'neutral',
-      x: pos.x + jx, y: pos.y + jy,
+      x: pos.x, y: pos.y,
       hp: 50, maxHp: 50,
       spawnTimer: 0,
       inputBuffer: {},
     }
-  }
+  })
 
-  // Pick daily modifier — LAST RNG call so it doesn't shift existing map layout or jitter
+  // Pick daily modifier — LAST RNG call so it doesn't shift outpost layout
   const modifierIndex = Math.floor(rng() * DAILY_MODIFIER_POOL.length)
   const dailyModifier: DailyModifier = DAILY_MODIFIER_POOL[modifierIndex]
 
-  // Apply static modifier effects
+  // Build the buildings record with bases first then outposts
+  const buildingsRecord: Record<string, BuildingEntity> = {}
+  for (const b of playerBases) buildingsRecord[b.id] = b
+  for (const b of aiBases) buildingsRecord[b.id] = b
+  Object.assign(buildingsRecord, outpostBuildings)
+
+  // Apply static modifier effects to all bases
   if (dailyModifier === 'bulwark') {
-    playerBase.hp = BASE_HP * 2
-    playerBase.maxHp = BASE_HP * 2
-    aiBase.hp = BASE_HP * 2
-    aiBase.maxHp = BASE_HP * 2
+    for (const b of [...playerBases, ...aiBases]) {
+      b.hp = BASE_HP * 2
+      b.maxHp = BASE_HP * 2
+    }
   }
   if (dailyModifier === 'blitz') {
     const DEFAULT_BASE_INTERVAL = 800  // BUILDING_TYPES.base.spawnInterval
-    playerBase.spawnIntervalOverride = (playerBase.spawnIntervalOverride ?? DEFAULT_BASE_INTERVAL) * 0.65
-    aiBase.spawnIntervalOverride = (aiBase.spawnIntervalOverride ?? DEFAULT_BASE_INTERVAL) * 0.65
+    for (const b of [...playerBases, ...aiBases]) {
+      b.spawnIntervalOverride = (b.spawnIntervalOverride ?? DEFAULT_BASE_INTERVAL) * 0.65
+    }
   }
 
   return {
     tick: 0,
     rngState: seed,
     players: { player, ai, neutral },
-    buildings: { 'building-player-base': playerBase, 'building-ai-base': aiBase, ...outpostBuildings },
+    buildings: buildingsRecord,
     speckIds: new Array(MAX_SPECKS).fill(''),
     speckX: new Float32Array(MAX_SPECKS),
     speckY: new Float32Array(MAX_SPECKS),

--- a/src/app/speck-wars/domain/simulation/spawner.ts
+++ b/src/app/speck-wars/domain/simulation/spawner.ts
@@ -5,7 +5,9 @@ import { MAX_SPECKS, RALLY_CRY_HP_THRESHOLD } from '../constants'
 
 // Place a new speck into a recycled or fresh slot — never allocates new arrays
 function addSpeck(sim: SimulationState, meta: SpeckMeta, x: number, y: number, buildingId: string) {
-  const hp = SPECK_TYPES[meta.typeId]?.hp ?? 1
+  const baseHp = SPECK_TYPES[meta.typeId]?.hp ?? 1
+  const upgradeHpBonus = (sim.players[meta.ownerId]?.upgradeLevel ?? 0) >= 2 ? 1 : 0
+  const hp = baseHp + upgradeHpBonus
 
   let slot: number
   if (sim.freeSlots.length > 0) {
@@ -47,7 +49,8 @@ export function updateSpawners(sim: SimulationState, dt: number) {
     const baseInterval = building.spawnIntervalOverride ?? btype.spawnInterval
     const hasSurge = building.ownerId === 'player' && sim.surgeDuration > 0
     const hasRallyCry = building.ownerId === 'player' && rallyCryActive
-    const divisor = (building.tripleOutpostBonus ? 2 : 1) * (hasSurge ? 2 : 1) * (hasRallyCry ? 1.5 : 1)
+    const upgradeSpawnBonus = (sim.players[building.ownerId]?.upgradeLevel ?? 0) >= 1 ? 1.1 : 1.0
+    const divisor = (building.tripleOutpostBonus ? 2 : 1) * (hasSurge ? 2 : 1) * (hasRallyCry ? 1.5 : 1) * upgradeSpawnBonus
     building.spawnTimer = baseInterval / divisor
 
     for (let i = 0; i < btype.spawnCount; i++) {

--- a/src/app/speck-wars/domain/types.ts
+++ b/src/app/speck-wars/domain/types.ts
@@ -52,6 +52,8 @@ export interface Player {
   isAI: boolean
   isDefeated: boolean
   stockpile: Record<string, number>  // typeId → count (resource form)
+  totalKills: number           // cumulative kills for upgrade milestones
+  upgradeLevel: 0 | 1 | 2 | 3 // 0=none, 1=spawn+10%, 2=+1HP, 3=+15% dmg
 }
 
 // SOA (Structure of Arrays) for hot speck data — cache-friendly for tight loops
@@ -118,6 +120,7 @@ export type SimEvent =
   | { type: 'AI_LAST_STAND' }
   | { type: 'AI_SPAWN_SWITCH'; speckTypeId: 'basic' | 'heavy' | 'scout' }
   | { type: 'CONSTRUCTION_COMPLETE'; buildingId: string; x: number; y: number }
+  | { type: 'UPGRADE_UNLOCKED'; ownerId: string; level: 1 | 2 | 3 }
 
 export interface HudData {
   players: Record<string, {

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -64,13 +64,13 @@ export class GameInstance {
 
   constructor(canvas: HTMLCanvasElement) {
     this.canvas = canvas
-    const { difficulty, outpostCount, baseCount } = useSpeckWarsStore.getState()
+    const { difficulty } = useSpeckWarsStore.getState()
     const aiTickInterval: Record<string, number> = { easy: 60, medium: 30, hard: 15, 'very-hard': 6 }
     const now = new Date()
     const dateKey = now.getFullYear() * 10000 + (now.getMonth() + 1) * 100 + now.getDate()
     const diffHash = [...difficulty].reduce((acc, ch) => acc + ch.charCodeAt(0), 0)
     const dailySeed = dateKey * 1000 + diffHash
-    this.sim = createSim(dailySeed, difficulty, outpostCount, baseCount)
+    this.sim = createSim(dailySeed, difficulty)
     this.renderer = new Renderer()
     this.camera = createCamera(canvas.clientWidth, canvas.clientHeight)
     const aiPersonality = (): AIPersonality => {

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -64,13 +64,13 @@ export class GameInstance {
 
   constructor(canvas: HTMLCanvasElement) {
     this.canvas = canvas
-    const difficulty = useSpeckWarsStore.getState().difficulty
+    const { difficulty, outpostCount, baseCount } = useSpeckWarsStore.getState()
     const aiTickInterval: Record<string, number> = { easy: 60, medium: 30, hard: 15, 'very-hard': 6 }
     const now = new Date()
     const dateKey = now.getFullYear() * 10000 + (now.getMonth() + 1) * 100 + now.getDate()
     const diffHash = [...difficulty].reduce((acc, ch) => acc + ch.charCodeAt(0), 0)
     const dailySeed = dateKey * 1000 + diffHash
-    this.sim = createSim(dailySeed, difficulty)
+    this.sim = createSim(dailySeed, difficulty, outpostCount, baseCount)
     this.renderer = new Renderer()
     this.camera = createCamera(canvas.clientWidth, canvas.clientHeight)
     const aiPersonality = (): AIPersonality => {
@@ -643,6 +643,15 @@ export class GameInstance {
         if (event.type === 'SPECK_LEGEND' && event.ownerId === 'player') {
           this.notify('✦✦ LEGEND BORN! ✦✦', '#cc44ff', 3000)
           store.pushKillFeedEntry({ icon: '✦✦', label: 'LEGEND BORN', color: '#cc44ff' })
+        }
+        if (event.type === 'UPGRADE_UNLOCKED' && event.ownerId === 'player') {
+          const messages = [
+            '',
+            '⚡ BLOODED — Spawn Speed +10%',
+            '🛡 HARDENED — Units +1 HP',
+            '🔥 VETERAN ARMY — Damage +15%',
+          ]
+          this.notify(messages[event.level], '#ffd700', 3000)
         }
         if (event.type === 'VETERAN_FALLEN') {
           const isLegend = event.kills >= 12


### PR DESCRIPTION
## Summary
At 50, 150, and 300 cumulative kills, players (and AI) unlock passive upgrades:

- **Level 1 — Blooded (50 kills)**: Spawn speed +10%
- **Level 2 — Hardened (150 kills)**: All newly spawned units gain +1 HP
- **Level 3 — Veteran Army (300 kills)**: All unit damage +15%

Both players earn upgrades independently based on their own kill counts. The AI also benefits, which creates parity and tension.

A gold notification flashes when the player unlocks a new level.

Closes #2143

🤖 Generated with [Claude Code](https://claude.com/claude-code)