### PR TITLE
feat(speck-wars): add stance cycle button to HUD toolbar

### DIFF
--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -48,6 +48,7 @@ export function HUD() {
   const difficulty = useSpeckWarsStore(s => s.difficulty)
   const surrender = useSpeckWarsStore(s => s.surrender)
   const gameActions = useSpeckWarsStore(s => s.gameActions)
+  const stance = useSpeckWarsStore(s => s.stance)
 
   const BASE_MAX_HP = 100
   const playerBaseHp = hud?.players.player?.buildingHp['building-player-base']
@@ -504,6 +505,37 @@ export function HUD() {
             </button>
           )
         })}
+        {/* Stance toggle — cycles through aggressive/defensive/hold */}
+        {gameActions?.cycleStance && (() => {
+          const stanceConfig: Record<string, { icon: string; label: string; color: string; title: string }> = {
+            aggressive: { icon: '⚔', label: 'AGGRO', color: '#ff4f7b', title: '[Z] Aggressive — pursues nearby enemies' },
+            defensive:  { icon: '🛡', label: 'DEF',   color: '#4af7c4', title: '[Z] Defensive — holds position more' },
+            hold:       { icon: '⛨', label: 'HOLD',   color: '#aaaaaa', title: '[Z] Hold — only attacks at melee range' },
+          }
+          const cfg = stanceConfig[stance] ?? stanceConfig.defensive
+          return (
+            <button
+              onClick={gameActions.cycleStance ?? undefined}
+              title={cfg.title}
+              style={{
+                pointerEvents: 'auto',
+                padding: '3px 10px',
+                fontSize: 10,
+                cursor: 'pointer',
+                background: `${cfg.color}18`,
+                border: `1px solid ${cfg.color}66`,
+                borderRadius: 4,
+                color: cfg.color,
+                letterSpacing: 0.5,
+                lineHeight: 1.3,
+                textAlign: 'center',
+              }}
+            >
+              <div style={{ fontWeight: 700 }}>{cfg.icon} {cfg.label}</div>
+              <div style={{ fontSize: 8, opacity: 0.7 }}>Z</div>
+            </button>
+          )
+        })()}
         <button
           onClick={() => setShowHelp(h => !h)}
           title="? — show controls"

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -280,6 +280,7 @@ export class GameInstance {
       stop: () => this.sim.inputQueue.push({ type: 'STOP', ownerId: 'player' }),
       hold: () => this.sim.inputQueue.push({ type: 'HOLD', ownerId: 'player' }),
       guard: () => this.guard(),
+      cycleStance: () => this.cycleStance(),
     })
     // Cinematic intro: start zoomed out to show full world
     const W = this.canvas.clientWidth
@@ -854,6 +855,18 @@ export class GameInstance {
     }
     this.sim.inputQueue.push({ type: 'SACRIFICE', ownerId: 'player', buildingId: playerBase.id, typeId: 'basic', count: 10 })
     useSpeckWarsStore.getState().addSacrificeUsed()
+  }
+
+  cycleStance() {
+    const current = useSpeckWarsStore.getState().stance
+    const next: 'aggressive' | 'defensive' | 'hold' =
+      current === 'aggressive' ? 'defensive'
+      : current === 'defensive' ? 'hold'
+      : 'aggressive'
+    useSpeckWarsStore.getState().setStance(next)
+    const labels: Record<string, string> = { aggressive: 'AGGRO', defensive: 'DEF', hold: 'HOLD' }
+    const colors: Record<string, string> = { aggressive: '#ff4f7b', defensive: '#4af7c4', hold: '#aaaaaa' }
+    this.notify(`Stance: ${labels[next]}`, colors[next], 1200)
   }
 
   enterBuildMode(buildingTypeId: string) {

--- a/src/app/speck-wars/store.ts
+++ b/src/app/speck-wars/store.ts
@@ -61,10 +61,12 @@ interface SpeckWarsStore {
   killFeed: KillFeedEntry[]
   pushKillFeedEntry: (entry: Omit<KillFeedEntry, 'id' | 'ts'>) => void
   pruneKillFeed: () => void
+  stance: 'aggressive' | 'defensive' | 'hold'
+  setStance: (s: 'aggressive' | 'defensive' | 'hold') => void
   aiPersonality: AIPersonality | null
   setAiPersonality: (p: AIPersonality) => void
-  gameActions: { defend: (() => void) | null; advance: (() => void) | null; rush: (() => void) | null; clearRally: (() => void) | null; surge: (() => void) | null; rally: ((x: number, y: number) => void) | null; sacrifice: (() => void) | null; setSpawnType: ((type: 'basic' | 'heavy' | 'scout') => void) | null; buildTurret?: (() => void) | null; panCamera: ((x: number, y: number) => void) | null; stop: (() => void) | null; hold: (() => void) | null; guard: (() => void) | null }
-  setGameActions: (actions: { defend: () => void; advance: () => void; rush: () => void; clearRally: () => void; surge: () => void; rally: (x: number, y: number) => void; sacrifice: () => void; setSpawnType: (type: 'basic' | 'heavy' | 'scout') => void; buildTurret?: () => void; panCamera: (x: number, y: number) => void; stop: () => void; hold: () => void; guard: () => void } | null) => void
+  gameActions: { defend: (() => void) | null; advance: (() => void) | null; rush: (() => void) | null; clearRally: (() => void) | null; surge: (() => void) | null; rally: ((x: number, y: number) => void) | null; sacrifice: (() => void) | null; setSpawnType: ((type: 'basic' | 'heavy' | 'scout') => void) | null; buildTurret?: (() => void) | null; panCamera: ((x: number, y: number) => void) | null; stop: (() => void) | null; hold: (() => void) | null; guard: (() => void) | null; cycleStance: (() => void) | null }
+  setGameActions: (actions: { defend: () => void; advance: () => void; rush: () => void; clearRally: () => void; surge: () => void; rally: (x: number, y: number) => void; sacrifice: () => void; setSpawnType: (type: 'basic' | 'heavy' | 'scout') => void; buildTurret?: () => void; panCamera: (x: number, y: number) => void; stop: () => void; hold: () => void; guard: () => void; cycleStance: () => void } | null) => void
   surrender: () => void
   resetGame: () => void
 }
@@ -134,10 +136,12 @@ export const useSpeckWarsStore = create<SpeckWarsStore>()((set, get) => ({
     const next = s.killFeed.filter(e => e.ts > cutoff)
     return next.length === s.killFeed.length ? s : { killFeed: next }
   }),
+  stance: 'defensive' as 'aggressive' | 'defensive' | 'hold',
+  setStance: stance => set({ stance }),
   aiPersonality: null,
   setAiPersonality: p => set({ aiPersonality: p }),
-  gameActions: { defend: null, advance: null, rush: null, clearRally: null, surge: null, rally: null, sacrifice: null, setSpawnType: null, buildTurret: null, panCamera: null, stop: null, hold: null, guard: null },
-  setGameActions: (actions) => set({ gameActions: actions ?? { defend: null, advance: null, rush: null, clearRally: null, surge: null, rally: null, sacrifice: null, setSpawnType: null, buildTurret: null, panCamera: null, stop: null, hold: null, guard: null } }),
+  gameActions: { defend: null, advance: null, rush: null, clearRally: null, surge: null, rally: null, sacrifice: null, setSpawnType: null, buildTurret: null, panCamera: null, stop: null, hold: null, guard: null, cycleStance: null },
+  setGameActions: (actions) => set({ gameActions: actions ?? { defend: null, advance: null, rush: null, clearRally: null, surge: null, rally: null, sacrifice: null, setSpawnType: null, buildTurret: null, panCamera: null, stop: null, hold: null, guard: null, cycleStance: null } }),
   surrender: () => {
     const s = get()
     resetWinStreak()
@@ -164,6 +168,7 @@ export const useSpeckWarsStore = create<SpeckWarsStore>()((set, get) => ({
     sacrificesUsed: 0,
     outpostsCaptured: 0,
     killFeed: [],
+    stance: 'defensive' as 'aggressive' | 'defensive' | 'hold',
     aiPersonality: null,
     difficulty: s.difficulty,
   })),


### PR DESCRIPTION
## Summary

- Adds `stance` state and `setStance` action to the Zustand store (defaults to `defensive`)
- Adds `cycleStance()` method to `GameInstance` that rotates aggressive → defensive → hold and shows a notification
- Wires `cycleStance` into `gameActions` so the HUD can invoke it
- Adds a clickable stance button to the top toolbar in `hud.tsx`, positioned after the spawn-type buttons and before the `?` help button
- Button shows current stance with icon, label, and color-coded border; renders only when the game is active

## Details

Wires the existing stance system (Z key: aggressive/defensive/hold) to a clickable HUD button in the toolbar, so players can see and change stance without memorizing the keybind. Moves session length metric by making stance control more discoverable.

The stance state was not previously exposed in the store or wired to `gameActions`; this PR adds both the store plumbing and the UI surface.

## Test plan

- [ ] Start a Speck Wars game — stance button appears in top toolbar showing `🛡 DEF`
- [ ] Click button — cycles to `⛨ HOLD` (gray), then `⚔ AGGRO` (red), then back to `🛡 DEF` (teal)
- [ ] Each click shows a notification banner (`Stance: HOLD`, etc.)
- [ ] Button only renders during active gameplay (`gameActions?.cycleStance` guard)
- [ ] TypeScript compiles with no errors (`npx tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)