### PR TITLE
feat(speck-wars): kill milestone upgrades — spawn speed, HP, damage bonuses at 50/150/300 kills

### DIFF
--- a/src/app/speck-wars/domain/simulation/combat.ts
+++ b/src/app/speck-wars/domain/simulation/combat.ts
@@ -86,7 +86,8 @@ export function resolveCombat(sim: SimulationState, dt: number) {
             if (level > 0) { fortifyBonus = 1 + FORTIFY_DAMAGE_BONUS * level; break }
           }
         }
-        speckHp[j] -= stype.damage * moraleMult(meta.ownerId) * veteranBonus * fortifyBonus
+        const upgradeBonus = (sim.players[meta.ownerId]?.upgradeLevel ?? 0) >= 3 ? 1.15 : 1.0
+        speckHp[j] -= stype.damage * moraleMult(meta.ownerId) * veteranBonus * fortifyBonus * upgradeBonus
         // Elite/Legend splash damage — inspired by CoH veteran abilities (issue #2145)
         // Elite (6+ kills): 18px radius, 50% damage; Legend (12+ kills): 28px radius, 75% damage
         const splashRadius = meta.kills >= 12 ? 28 : meta.kills >= 6 ? 18 : 0
@@ -111,6 +112,16 @@ export function resolveCombat(sim: SimulationState, dt: number) {
                 if (meta.kills === 3) sim.events.push({ type: 'SPECK_VETERAN', speckId: speckIds[i], ownerId: meta.ownerId })
                 if (meta.kills === 6) sim.events.push({ type: 'SPECK_ELITE', speckId: speckIds[i], ownerId: meta.ownerId })
                 if (meta.kills === 12) sim.events.push({ type: 'SPECK_LEGEND', speckId: speckIds[i], ownerId: meta.ownerId })
+                // Kill milestone upgrades (splash kill)
+                const splashKillerPlayer = sim.players[meta.ownerId]
+                if (splashKillerPlayer) {
+                  splashKillerPlayer.totalKills++
+                  const splashNewLevel = splashKillerPlayer.totalKills >= 300 ? 3 : splashKillerPlayer.totalKills >= 150 ? 2 : splashKillerPlayer.totalKills >= 50 ? 1 : 0
+                  if (splashNewLevel > splashKillerPlayer.upgradeLevel) {
+                    splashKillerPlayer.upgradeLevel = splashNewLevel as 0 | 1 | 2 | 3
+                    sim.events.push({ type: 'UPGRADE_UNLOCKED', ownerId: meta.ownerId, level: splashNewLevel as 1 | 2 | 3 })
+                  }
+                }
               }
             }
           }
@@ -143,6 +154,16 @@ export function resolveCombat(sim: SimulationState, dt: number) {
           }
           if (meta.kills === 12) {
             sim.events.push({ type: 'SPECK_LEGEND', speckId: speckIds[i], ownerId: meta.ownerId })
+          }
+          // Kill milestone upgrades
+          const killerPlayer = sim.players[meta.ownerId]
+          if (killerPlayer) {
+            killerPlayer.totalKills++
+            const newLevel = killerPlayer.totalKills >= 300 ? 3 : killerPlayer.totalKills >= 150 ? 2 : killerPlayer.totalKills >= 50 ? 1 : 0
+            if (newLevel > killerPlayer.upgradeLevel) {
+              killerPlayer.upgradeLevel = newLevel as 0 | 1 | 2 | 3
+              sim.events.push({ type: 'UPGRADE_UNLOCKED', ownerId: meta.ownerId, level: newLevel as 1 | 2 | 3 })
+            }
           }
         }
         break  // one attack per cooldown

--- a/src/app/speck-wars/domain/simulation/spawner.ts
+++ b/src/app/speck-wars/domain/simulation/spawner.ts
@@ -5,7 +5,9 @@ import { MAX_SPECKS, RALLY_CRY_HP_THRESHOLD } from '../constants'
 
 // Place a new speck into a recycled or fresh slot — never allocates new arrays
 function addSpeck(sim: SimulationState, meta: SpeckMeta, x: number, y: number, buildingId: string) {
-  const hp = SPECK_TYPES[meta.typeId]?.hp ?? 1
+  const baseHp = SPECK_TYPES[meta.typeId]?.hp ?? 1
+  const upgradeHpBonus = (sim.players[meta.ownerId]?.upgradeLevel ?? 0) >= 2 ? 1 : 0
+  const hp = baseHp + upgradeHpBonus
 
   let slot: number
   if (sim.freeSlots.length > 0) {
@@ -47,7 +49,8 @@ export function updateSpawners(sim: SimulationState, dt: number) {
     const baseInterval = building.spawnIntervalOverride ?? btype.spawnInterval
     const hasSurge = building.ownerId === 'player' && sim.surgeDuration > 0
     const hasRallyCry = building.ownerId === 'player' && rallyCryActive
-    const divisor = (building.tripleOutpostBonus ? 2 : 1) * (hasSurge ? 2 : 1) * (hasRallyCry ? 1.5 : 1)
+    const upgradeSpawnBonus = (sim.players[building.ownerId]?.upgradeLevel ?? 0) >= 1 ? 1.1 : 1.0
+    const divisor = (building.tripleOutpostBonus ? 2 : 1) * (hasSurge ? 2 : 1) * (hasRallyCry ? 1.5 : 1) * upgradeSpawnBonus
     building.spawnTimer = baseInterval / divisor
 
     for (let i = 0; i < btype.spawnCount; i++) {

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -646,6 +646,15 @@ export class GameInstance {
           this.notify('✦✦ LEGEND BORN! ✦✦', '#cc44ff', 3000)
           store.pushKillFeedEntry({ icon: '✦✦', label: 'LEGEND BORN', color: '#cc44ff' })
         }
+        if (event.type === 'UPGRADE_UNLOCKED' && event.ownerId === 'player') {
+          const messages = [
+            '',
+            '⚡ BLOODED — Spawn Speed +10%',
+            '🛡 HARDENED — Units +1 HP',
+            '🔥 VETERAN ARMY — Damage +15%',
+          ]
+          this.notify(messages[event.level], '#ffd700', 3000)
+        }
         if (event.type === 'VETERAN_FALLEN') {
           const isLegend = event.kills >= 12
           const isElite = event.kills >= 6


### PR DESCRIPTION
## Summary

Wires in the actual game mechanics for kill milestone upgrades. The HUD tier badge (PR #2151) already shows the player's upgrade level — this PR adds the effects that badge represents.

**3 tiers unlocked by cumulative kill count:**

| Kills | Level | Effect |
|-------|-------|--------|
| 50    | 1 — BLOODED  | Spawn speed +10% across all buildings |
| 150   | 2 — HARDENED | New specks spawn with +1 HP |
| 300   | 3 — VETERAN ARMY | Damage +15% per attack |

Both direct kills and splash kills (from Elite/Legend AoE) count toward `totalKills`. Each tier unlock fires an `UPGRADE_UNLOCKED` event, which shows the player a gold toast notification.

**Files changed (3):**
- `src/app/speck-wars/domain/simulation/combat.ts` — upgrade damage multiplier (level 3) + kill tracking for direct and splash kills
- `src/app/speck-wars/domain/simulation/spawner.ts` — HP bonus on spawn (level 2) + spawn speed divisor (level 1)
- `src/app/speck-wars/game-instance.ts` — `UPGRADE_UNLOCKED` event handler → toast notification

Note: `types.ts` and `create-sim.ts` already have the `totalKills`/`upgradeLevel` fields and `UPGRADE_UNLOCKED` event type from PR #2151.

## Test plan

- [ ] Play to 50 kills; verify "⚡ BLOODED — Spawn Speed +10%" toast appears and buildings spawn noticeably faster
- [ ] Play to 150 kills; verify "🛡 HARDENED — Units +1 HP" toast appears and new specks have +1 HP
- [ ] Play to 300 kills; verify "🔥 VETERAN ARMY — Damage +15%" toast appears and specks deal more damage
- [ ] Confirm splash kills (from Elite/Legend specks) also count toward total
- [ ] Confirm upgrade level is shown correctly in HUD badge (pre-existing behavior)
- [ ] `npx tsc --noEmit` passes with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)