### PR TITLE
feat(speck-wars): show creep camp spawn boost timer in HUD

### DIFF
--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -131,6 +131,14 @@ export function HUD() {
           animation: 'pulse-red 0.9s ease-in-out infinite alternate',
         }}>★ RALLY CRY — 1.5× SPAWN</div>
       )}
+      {hud && (hud.creepCampBoostMs ?? 0) > 0 && phase === 'playing' && (
+        <div style={{
+          position: 'fixed', top: hud.rallyCryActive ? 138 : 108, left: '50%', transform: 'translateX(-50%)',
+          background: 'rgba(255,200,50,0.85)', color: '#000', fontWeight: 700,
+          padding: '3px 12px', borderRadius: 6, fontSize: 11, letterSpacing: 1,
+          zIndex: 106, pointerEvents: 'none',
+        }}>🏕 CAMP BOOST +25% SPAWN — {Math.ceil((hud.creepCampBoostMs ?? 0) / 1000)}s</div>
+      )}
       {isDanger && (
         <>
           <style>{`

--- a/src/app/speck-wars/domain/simulation/tick.ts
+++ b/src/app/speck-wars/domain/simulation/tick.ts
@@ -642,5 +642,5 @@ function emitHudUpdate(sim: SimulationState) {
     if (b) selectedBuilding = { id: b.id, typeId: b.typeId, hp: b.hp, maxHp: b.maxHp, spawnTypeOverride: b.spawnTypeOverride }
   }
 
-  sim.events.push({ type: 'HUD_UPDATE', data: { players: data, attackedBuildingIds, tripleOutpostOwner, dominationProgress, captureInfo, surgeDuration: sim.surgeDuration, surgeCooldown: sim.surgeCooldown, selectedSpeckCount: sim.selectedSpeckIds.size, selectedComposition, spawnRates, minimap, outpostFortify, dailyModifier: sim.dailyModifier, waveCountdown: sim.waveCountdown, waveInProgress: sim.waveInProgress, sacrificeCooldown: sim.sacrificeCooldown, baseUnderThreat, enemyAdvanceDetected, rallyCryActive, selectedBuilding } })
+  sim.events.push({ type: 'HUD_UPDATE', data: { players: data, attackedBuildingIds, tripleOutpostOwner, dominationProgress, captureInfo, surgeDuration: sim.surgeDuration, surgeCooldown: sim.surgeCooldown, selectedSpeckCount: sim.selectedSpeckIds.size, selectedComposition, spawnRates, minimap, outpostFortify, dailyModifier: sim.dailyModifier, waveCountdown: sim.waveCountdown, waveInProgress: sim.waveInProgress, sacrificeCooldown: sim.sacrificeCooldown, baseUnderThreat, enemyAdvanceDetected, rallyCryActive, creepCampBoostMs: sim.players['player']?.creepCampBoostMs ?? 0, selectedBuilding } })
 }

--- a/src/app/speck-wars/domain/types.ts
+++ b/src/app/speck-wars/domain/types.ts
@@ -153,6 +153,7 @@ export interface HudData {
   baseUnderThreat: boolean
   enemyAdvanceDetected: boolean
   rallyCryActive: boolean
+  creepCampBoostMs: number     // ms of +25% spawn boost remaining (from captured creep camp)
   outpostFortify: Record<string, number>  // outpostId → 0..1 fortification level
   selectedBuilding: { id: string; typeId: string; hp: number; maxHp: number; spawnTypeOverride?: string } | null
   minimap: {


### PR DESCRIPTION
## Summary

- Adds `creepCampBoostMs: number` field to `HudData` interface in `types.ts`, wiring the existing `Player.creepCampBoostMs` simulation state through to the HUD layer
- Includes `creepCampBoostMs` in the `HUD_UPDATE` event emitted from `emitHudUpdate` in `tick.ts`
- Renders a '🏕 CAMP BOOST +25% SPAWN — Xs' countdown badge in `hud.tsx` when the player has an active creep camp spawn boost, positioned below the rally cry badge if both are active simultaneously

## Test plan

- [ ] Verify TypeScript compiles without errors (`npx tsc --noEmit`)
- [ ] Capture a creep camp in-game and confirm the yellow countdown badge appears at top-center of HUD
- [ ] Confirm the badge counts down from 30s to 0 and disappears when boost expires
- [ ] Confirm badge shifts down to 138px top when rally cry is also active (base HP low)
- [ ] Confirm badge does not appear when no boost is active

🤖 Generated with [Claude Code](https://claude.com/claude-code)