### PR TITLE
feat(speck-wars): update help screen with creep camps and kill milestone info

### DIFF
--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -597,7 +597,8 @@ export function HUD() {
             <span>1/2/3 — set spawn type</span><span>Minimap — left-click rally · right-click pan</span>
             <span>X — cycle speed (1×/2×/4×)</span><span>F — sacrifice 10 specks → +15 HP</span>
             <span>T — build turret (select 20+ specks first)</span><span>? — this help</span>
-            <span>Z — cycle stance (Aggressive/Defensive/Hold)</span><span></span>
+            <span>Z — cycle stance (Aggressive/Defensive/Hold)</span><span>G — guard mode (follow selected)</span>
+            <span style={{ color: 'rgba(160,220,255,0.7)' }}>2 creep camps on each map — contest to earn +25% spawn for 30s</span><span style={{ color: 'rgba(160,220,255,0.7)' }}>50/150/300 kills → BLOODED/HARDENED/VETERAN ARMY upgrades</span>
             <span style={{ gridColumn: '1/-1', borderTop: '1px solid rgba(255,255,255,0.08)', paddingTop: 8, marginTop: 2, color: 'rgba(255,215,0,0.5)', fontSize: 11 }}>
               Daily map seed changes each day · modifier shown top-right (bulwark/blitz/siege)
             </span>


### PR DESCRIPTION
Adds two info lines to the ? help overlay: creep camp capture mechanic (+25% spawn) and kill milestone upgrades (BLOODED/HARDENED/VETERAN ARMY). Also fills the empty second column next to the Z stance line with G guard mode hint.