### PR TITLE
feat(speck-wars): hero Commander speck — XP leveling, AoE pulse, respawn

### DIFF
--- a/src/app/speck-wars/domain/simulation/combat.ts
+++ b/src/app/speck-wars/domain/simulation/combat.ts
@@ -75,6 +75,7 @@ export function resolveCombat(sim: SimulationState, dt: number) {
       const dist = Math.sqrt(dx * dx + dy * dy)
       if (dist <= stype.attackRange) {
         const veteranBonus = meta.kills >= 12 ? 1.50 : meta.kills >= 6 ? 1.35 : meta.kills >= 3 ? 1.20 : 1.0  // legend +50%, elite +35%, veteran +20%
+        const commanderBonus = meta.isCommander ? 2.0 : 1.0
         // Fortification bonus: if attacker is near a friendly fortified outpost, deal extra damage
         let fortifyBonus = 1.0
         for (const b of Object.values(buildings)) {
@@ -87,7 +88,7 @@ export function resolveCombat(sim: SimulationState, dt: number) {
           }
         }
         const upgradeBonus = (sim.players[meta.ownerId]?.upgradeLevel ?? 0) >= 3 ? 1.15 : 1.0
-        speckHp[j] -= stype.damage * moraleMult(meta.ownerId) * veteranBonus * fortifyBonus * upgradeBonus
+        speckHp[j] -= stype.damage * moraleMult(meta.ownerId) * veteranBonus * fortifyBonus * upgradeBonus * commanderBonus
         // Elite/Legend splash damage — inspired by CoH veteran abilities (issue #2145)
         // Elite (6+ kills): 18px radius, 50% damage; Legend (12+ kills): 28px radius, 75% damage
         const splashRadius = meta.kills >= 12 ? 28 : meta.kills >= 6 ? 18 : 0
@@ -106,6 +107,12 @@ export function resolveCombat(sim: SimulationState, dt: number) {
               if (speckHp[k] <= 0) {
                 if (kMeta.ownerId === 'player' && kMeta.kills >= 3) {
                   sim.events.push({ type: 'VETERAN_FALLEN', speckId: speckIds[k], ownerId: kMeta.ownerId, kills: kMeta.kills, x: speckX[k], y: speckY[k] })
+                }
+                // When commander is killed by splash damage, set commanderRespawnMs
+                if (kMeta.isCommander) {
+                  const ownerPlayer = sim.players[kMeta.ownerId]
+                  if (ownerPlayer) ownerPlayer.commanderRespawnMs = 15000
+                  sim.events.push({ type: 'COMMANDER_DIED', ownerId: kMeta.ownerId, xp: kMeta.commanderXp ?? 0 })
                 }
                 sim.events.push({ type: 'SPECK_DIED', speckId: speckIds[k], x: speckX[k], y: speckY[k], killedOwnerId: kMeta.ownerId, killerOwnerId: meta.ownerId })
                 meta.kills++
@@ -145,7 +152,34 @@ export function resolveCombat(sim: SimulationState, dt: number) {
               y: speckY[j],
             })
           }
+          // When commander is killed, set commanderRespawnMs
+          if (jMeta.isCommander) {
+            const ownerPlayer = sim.players[jMeta.ownerId]
+            if (ownerPlayer) ownerPlayer.commanderRespawnMs = 15000
+            sim.events.push({ type: 'COMMANDER_DIED', ownerId: jMeta.ownerId, xp: jMeta.commanderXp ?? 0 })
+          }
           sim.events.push({ type: 'SPECK_DIED', speckId: speckIds[j], x: speckX[j], y: speckY[j], killedOwnerId: jMeta.ownerId, killerOwnerId: meta.ownerId })
+          // Commander XP: award XP to commanders within 150px of the kill
+          {
+            const COMMANDER_XP_RANGE = 150
+            const xpR2 = COMMANDER_XP_RANGE * COMMANDER_XP_RANGE
+            for (let k = 0; k < sim.speckCount; k++) {
+              const cm = sim.speckMeta[k]
+              if (!cm?.isCommander || sim.speckHp[k] <= 0) continue
+              if (cm.ownerId === jMeta.ownerId) continue  // don't award XP for killing own team
+              const cdx = sim.speckX[k] - sim.speckX[j]
+              const cdy = sim.speckY[k] - sim.speckY[j]
+              if (cdx * cdx + cdy * cdy <= xpR2) {
+                cm.commanderXp = (cm.commanderXp ?? 0) + 1
+                const newLevel = (cm.commanderXp ?? 0) >= 15 ? 3 : (cm.commanderXp ?? 0) >= 5 ? 2 : 0
+                if (newLevel > (cm.commanderLevel ?? 0)) {
+                  cm.commanderLevel = newLevel as 0 | 1 | 2 | 3
+                  if (cm.pulseTimer === undefined) cm.pulseTimer = 3000
+                  sim.events.push({ type: 'COMMANDER_LEVEL_UP', ownerId: cm.ownerId, level: newLevel as 2 | 3 })
+                }
+              }
+            }
+          }
           if (meta.kills === 3) {
             sim.events.push({ type: 'SPECK_VETERAN', speckId: speckIds[i], ownerId: meta.ownerId })
           }

--- a/src/app/speck-wars/domain/simulation/create-sim.ts
+++ b/src/app/speck-wars/domain/simulation/create-sim.ts
@@ -4,7 +4,7 @@ import type { DailyModifier } from '../constants'
 import { SpatialGrid } from './spatial-grid'
 import { mulberry32 } from './prng'
 import type { Difficulty } from '../../store'
-import { spawnCampDefenders } from './spawner'
+import { spawnCampDefenders, spawnCommander } from './spawner'
 
 const aiSpawnInterval: Record<Difficulty, number> = {
   easy: 2000,
@@ -146,6 +146,10 @@ export function createSim(seed: number = Date.now(), difficulty: Difficulty = 'm
   for (const pos of campPositions) {
     spawnCampDefenders(sim, pos.id)
   }
+
+  // Spawn one commander per side
+  spawnCommander(sim, 'player')
+  spawnCommander(sim, 'ai')
 
   return sim
 }

--- a/src/app/speck-wars/domain/simulation/spawner.ts
+++ b/src/app/speck-wars/domain/simulation/spawner.ts
@@ -103,3 +103,37 @@ export function updateSpawners(sim: SimulationState, dt: number) {
     }
   }
 }
+
+export function spawnCommander(sim: SimulationState, ownerId: string) {
+  // Find owner's base
+  const base = Object.values(sim.buildings).find(b => b.ownerId === ownerId && b.typeId === 'base')
+  if (!base) return
+  // Spawn near base with slight offset
+  const offsetX = ownerId === 'player' ? 80 : -80
+  const meta: SpeckMeta = {
+    id: `commander-${ownerId}-${Date.now()}`,
+    typeId: 'basic',
+    ownerId,
+    state: 'idle',
+    targetId: null,
+    attackCooldown: 0,
+    kills: 0,
+    isCommander: true,
+    commanderXp: 0,
+    commanderLevel: 0,
+    pulseTimer: 3000,
+  }
+  // Use existing addSpeck-like logic: find free slot and place
+  const slot = sim.freeSlots.length > 0
+    ? sim.freeSlots.pop()!
+    : (sim.speckCount < MAX_SPECKS ? sim.speckCount++ : -1)
+  if (slot < 0) return
+  const speckId = meta.id
+  sim.speckIds[slot] = speckId
+  sim.speckX[slot] = base.x + offsetX
+  sim.speckY[slot] = base.y + (Math.random() * 40 - 20)
+  sim.speckVx[slot] = 0
+  sim.speckVy[slot] = 0
+  sim.speckHp[slot] = 3  // 3× base HP
+  sim.speckMeta[slot] = meta
+}

--- a/src/app/speck-wars/domain/simulation/tick.ts
+++ b/src/app/speck-wars/domain/simulation/tick.ts
@@ -1,6 +1,6 @@
 import type { SimulationState } from '../types'
 import { SPECK_TYPES } from '../config/speck-types'
-import { updateSpawners, spawnCampDefenders } from './spawner'
+import { updateSpawners, spawnCampDefenders, spawnCommander } from './spawner'
 import { runSpeckAI } from './speck-ai'
 import { moveSpecks } from './movement'
 import { resolveCombat, removeDeadSpecks } from './combat'
@@ -58,6 +58,9 @@ export function tick(sim: SimulationState, dt: number): SimulationState {
 
   // 6. Remove dead specks (compact arrays)
   removeDeadSpecks(sim)
+
+  // 6a. Commander: tick respawn timer and handle Level 2 AoE pulse
+  updateCommanders(sim, dt)
 
   // 7. Update outpost capture progress
   updateCapture(sim, dt)
@@ -184,6 +187,45 @@ function updateCreepCamps(sim: SimulationState, dt: number) {
       // Force the speck to return to camp
       meta.state = 'moving'
       meta.targetId = null
+    }
+  }
+}
+
+function updateCommanders(sim: SimulationState, dt: number) {
+  const PULSE_RANGE = 50
+  const PULSE_DAMAGE = 0.5
+  const PULSE_PERIOD = 3000
+
+  // Tick commanderRespawnMs for each player and respawn when ready
+  for (const [pid, player] of Object.entries(sim.players)) {
+    if ((player.commanderRespawnMs ?? 0) > 0) {
+      player.commanderRespawnMs = Math.max(0, (player.commanderRespawnMs ?? 0) - dt)
+      if (player.commanderRespawnMs <= 0) {
+        player.commanderRespawnMs = undefined
+        spawnCommander(sim, pid)
+      }
+    }
+  }
+
+  // AoE pulse for Level 2+ commanders
+  for (let i = 0; i < sim.speckCount; i++) {
+    const meta = sim.speckMeta[i]
+    if (!meta?.isCommander || sim.speckHp[i] <= 0) continue
+    if ((meta.commanderLevel ?? 0) < 2) continue
+
+    meta.pulseTimer = Math.max(0, (meta.pulseTimer ?? PULSE_PERIOD) - dt)
+    if (meta.pulseTimer <= 0) {
+      meta.pulseTimer = PULSE_PERIOD
+      const pr2 = PULSE_RANGE * PULSE_RANGE
+      for (let j = 0; j < sim.speckCount; j++) {
+        const jm = sim.speckMeta[j]
+        if (!jm || jm.ownerId === meta.ownerId || sim.speckHp[j] <= 0) continue
+        const dx = sim.speckX[j] - sim.speckX[i]
+        const dy = sim.speckY[j] - sim.speckY[i]
+        if (dx * dx + dy * dy <= pr2) {
+          sim.speckHp[j] -= PULSE_DAMAGE
+        }
+      }
     }
   }
 }

--- a/src/app/speck-wars/domain/types.ts
+++ b/src/app/speck-wars/domain/types.ts
@@ -20,6 +20,10 @@ export interface SpeckMeta {
   patrolOriginY?: number  // patrol: leg start Y
   patrolDestX?: number    // patrol: leg destination X
   patrolDestY?: number    // patrol: leg destination Y
+  isCommander?: boolean         // this speck is the owner's hero unit
+  commanderXp?: number          // XP earned from nearby kills
+  commanderLevel?: 0 | 1 | 2 | 3  // 0=base, 1=unused, 2=pulse, 3=aura
+  pulseTimer?: number           // ms until next AoE pulse
 }
 
 export interface BuildingEntity {
@@ -57,6 +61,7 @@ export interface Player {
   upgradeLevel: 0 | 1 | 2 | 3 // 0=none, 1=spawn+10%, 2=+1HP, 3=+15% dmg
   stance: 'aggressive' | 'defensive' | 'hold'
   creepCampBoostMs: number     // ms of +25% spawn boost remaining (from captured creep camp)
+  commanderRespawnMs?: number   // ms until commander respawns (undefined = alive or not spawned yet)
 }
 
 // SOA (Structure of Arrays) for hot speck data — cache-friendly for tight loops
@@ -126,6 +131,8 @@ export type SimEvent =
   | { type: 'CONSTRUCTION_COMPLETE'; buildingId: string; x: number; y: number }
   | { type: 'UPGRADE_UNLOCKED'; ownerId: string; level: 1 | 2 | 3 }
   | { type: 'CAMP_CAPTURED'; campId: string; newOwner: string }
+  | { type: 'COMMANDER_LEVEL_UP'; ownerId: string; level: 2 | 3 }
+  | { type: 'COMMANDER_DIED'; ownerId: string; xp: number }
 
 export interface HudData {
   players: Record<string, {

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -678,6 +678,15 @@ export class GameInstance {
         if (event.type === 'AI_SPAWN_SWITCH' && event.speckTypeId === 'heavy') {
           this.notify('⚠ ENEMY SWITCHING TO HEAVY', '#ff8844')
         }
+        if (event.type === 'COMMANDER_LEVEL_UP' && event.ownerId === 'player') {
+          const label = event.level === 2 ? '⚡ COMMANDER LVL 2 — AoE PULSE' : '🌟 COMMANDER LVL 3 — SPEED AURA'
+          this.notify(label, '#ffd700', 4000)
+          store.pushKillFeedEntry({ icon: '⭐', label: label.split(' — ')[0].replace('⚡ ', '').replace('🌟 ', ''), color: '#ffd700' })
+        }
+        if (event.type === 'COMMANDER_DIED' && event.ownerId === 'player') {
+          this.notify('💀 COMMANDER FALLEN — respawning in 15s', '#ff6600', 3000)
+          store.pushKillFeedEntry({ icon: '💀', label: 'COMMANDER FALLEN', color: '#ff6600' })
+        }
       }
 
       // Retreat wave warning: 10+ player specks retreating = notify

--- a/src/app/speck-wars/rendering/layers/speck-layer.ts
+++ b/src/app/speck-wars/rendering/layers/speck-layer.ts
@@ -112,6 +112,20 @@ export class SpeckLayer {
           this.gfx.lineStyle(0)
         }
 
+        // Commander: large animated golden ring
+        if (typeMeta?.isCommander) {
+          const level = typeMeta?.commanderLevel ?? 0
+          const cmdPulse = 0.65 + 0.35 * Math.sin(now / 300)
+          const cmdColor = level >= 3 ? 0x00ffcc : level >= 2 ? 0xffd700 : 0xccaa00
+          this.gfx.lineStyle(2, cmdColor, cmdPulse * spriteList[j].alpha)
+          this.gfx.drawCircle(sim.speckX[i], sim.speckY[i], (stype ? stype.size / 4 : 0.75) + 10)
+          if (level >= 2) {
+            this.gfx.lineStyle(1.5, 0xffffff, 0.5 * spriteList[j].alpha)
+            this.gfx.drawCircle(sim.speckX[i], sim.speckY[i], (stype ? stype.size / 4 : 0.75) + 13)
+          }
+          this.gfx.lineStyle(0)
+        }
+
         const isHeavy = typeMeta?.typeId === 'heavy'
         if (isHeavy) {
           this.gfx.lineStyle(1, 0xffffff, spriteList[j].alpha * 0.6)


### PR DESCRIPTION
## Summary

- Spawns one Commander hero unit per side at game start with 3× HP and 2× damage
- Commander earns XP from enemy kills within 150px range; levels up at 5 XP (AoE pulse) and 15 XP (speed aura visual)
- On death: 15-second respawn cooldown at owner's base, then auto-respawns via `spawnCommander()`
- Animated golden ring visual (dull gold base → bright gold Lvl 2 → teal Lvl 3) distinguishes it on screen
- Player notified on level-up and death via HUD and kill-feed entries

## Files changed

| File | Change |
|---|---|
| `domain/types.ts` | `isCommander`, `commanderXp`, `commanderLevel`, `pulseTimer` on `SpeckMeta`; `commanderRespawnMs` on `Player`; `COMMANDER_LEVEL_UP` and `COMMANDER_DIED` in `SimEvent` |
| `domain/simulation/spawner.ts` | New `spawnCommander()` function — places Commander in a free slot near base |
| `domain/simulation/create-sim.ts` | Calls `spawnCommander()` for player and AI at game start |
| `domain/simulation/combat.ts` | 2× `commanderBonus` on attack damage; `COMMANDER_DIED` + `commanderRespawnMs = 15000` on death; XP loop awards 1 XP to nearby commanders on each kill |
| `domain/simulation/tick.ts` | `updateCommanders()` — ticks `commanderRespawnMs`, auto-respawns at 0; Level 2 AoE pulse (50px, 0.5 dmg, 3s period) |
| `rendering/layers/speck-layer.ts` | Pulsing commander ring: dim gold at base, bright gold at Lvl 2 + inner white ring, teal at Lvl 3 |
| `game-instance.ts` | `COMMANDER_LEVEL_UP` and `COMMANDER_DIED` notifications with kill-feed entries |

## Level progression

- **Level 1 (base)**: 3× HP, 2× damage, animated gold ring
- **Level 2 (5 XP)**: AoE pulse — damages all enemies within 50px every 3s, ring gains inner white halo
- **Level 3 (15 XP)**: Speed aura visual (teal ring) — aura effect visible but movement boost not yet applied to allies (follow-up)

## Metric impact

Targets **session length**: giving players a named unit they protect and level up creates emotional investment and micro-decisions (should I rush? protect the commander? heal it back?). The 15s respawn timer creates stakes.

## Test plan

- [ ] Start a game — both sides should have a larger gold-ringed speck near their base immediately
- [ ] Kill 5 enemies near the player Commander — level-up notification appears, AoE rings appear
- [ ] Commander should take 3 hits to kill (vs 1 for a basic speck)
- [ ] Commander attack should deal ~2× damage of a basic speck
- [ ] Kill the player Commander — "COMMANDER FALLEN — respawning in 15s" notification
- [ ] After ~15s the Commander should reappear near player base
- [ ] TypeScript: `npx tsc --noEmit` passes with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)