### PR TITLE
feat(speck-wars): flanking bonus — +20% damage attacking from behind/side

### DIFF
--- a/src/app/speck-wars/domain/simulation/combat.ts
+++ b/src/app/speck-wars/domain/simulation/combat.ts
@@ -89,7 +89,29 @@ export function resolveCombat(sim: SimulationState, dt: number) {
           }
         }
         const upgradeBonus = (sim.players[meta.ownerId]?.upgradeLevel ?? 0) >= 3 ? 1.15 : 1.0
-        speckHp[j] -= stype.damage * moraleMult(meta.ownerId) * veteranBonus * heroBonus * fortifyBonus * upgradeBonus * commanderBonus
+        // Flanking bonus: +20% damage when attacking from behind/side
+        // Check if attacker is approaching from behind target's movement direction
+        const tvx = sim.speckVx[j]  // target velocity
+        const tvy = sim.speckVy[j]
+        const targetSpeed2 = tvx * tvx + tvy * tvy
+
+        let flankMult = 1.0
+        if (targetSpeed2 > 25) {  // only applies when target is moving (>5 px/s)
+          // Vector from target to attacker
+          const fdx = sim.speckX[i] - sim.speckX[j]
+          const fdy = sim.speckY[i] - sim.speckY[j]
+          const fdist = Math.sqrt(fdx * fdx + fdy * fdy) || 1
+          // Normalized attack direction (from target's perspective, attacker comes FROM this direction)
+          const adx = fdx / fdist, ady = fdy / fdist
+          // Normalized target velocity direction
+          const tspeed = Math.sqrt(targetSpeed2)
+          const tdx = tvx / tspeed, tdy = tvy / tspeed
+          // Dot product: if positive, attacker is behind/beside the target
+          const dot = adx * tdx + ady * tdy
+          if (dot > 0.17)  // cos(80°) ≈ 0.17 — covers wide flank angle
+            flankMult = 1.2
+        }
+        speckHp[j] -= stype.damage * moraleMult(meta.ownerId) * veteranBonus * heroBonus * fortifyBonus * upgradeBonus * commanderBonus * flankMult
         // Elite/Legend splash damage — inspired by CoH veteran abilities (issue #2145)
         // Elite (6+ kills): 18px radius, 50% damage; Legend (12+ kills): 28px radius, 75% damage
         const splashRadius = meta.kills >= 12 ? 28 : meta.kills >= 6 ? 18 : 0


### PR DESCRIPTION
## Summary
Specks that attack a moving enemy from behind or the side deal **+20% damage**.

## How it works
1. When a speck attacks, compute the vector from target→attacker (attack approach direction)
2. Normalize both that vector and the target's velocity vector
3. Take dot product: if > 0.17 (cos 80°), attacker is within the 160° rear arc → flanking
4. Only applies when target is moving at >5 px/s (stationary targets don't grant flanking)

## Strategic impact
- Rewards splitting forces to attack from multiple directions
- Aggressive stance naturally creates flanking opportunities (specks spread out)
- Hold stance becomes more dangerous when surrounded (specks take flanking damage)
- Synergizes with scout specks (fast, can circle around to flank)

## Implementation
Single multiplier in `combat.ts`. No new fields, no new state. Pure geometric check.

Closes #2166

🤖 Generated with [Claude Code](https://claude.com/claude-code)