### PR TITLE
feat(speck-wars): control groups — Ctrl+4/5/6 save, 4/5/6 recall rally positions

### DIFF
--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -28,6 +28,7 @@ export class GameInstance {
   private enemyBaseWarnedAt = -30000
   private outpostAttackWarnedAt: Record<string, number> = {}  // outpostId → timestamp
   private outpostHpWarnedAt: Record<string, number> = {}     // outpostId → timestamp (HP critical)
+  private controlGroupRallies: Array<{ x: number; y: number } | null> = new Array(6).fill(null)  // slots 4-9
   private enemySurgeWarnedAt = -30000
   private recentKillTimes: number[] = []  // timestamps of recent player kills (combo detection)
   private recentDeathPositions: { x: number; y: number; ts: number }[] = []
@@ -252,6 +253,21 @@ export class GameInstance {
     this.inputHandler.onBuildTurret = () => this.enterBuildMode('turret')  // T — enter turret build mode
     this.inputHandler.onGuard = () => { this.guard(); this.notify('🛡 GUARD', '#4af7c4', 1000) }
     this.inputHandler.onCycleStance = () => this.cycleStance()  // Z — cycle stance
+    this.inputHandler.onSaveControlGroup = (slot: number) => {
+      const rp = this.sim.rallyPoints['player']
+      if (rp) {
+        this.controlGroupRallies[slot - 4] = { x: rp.x, y: rp.y }
+        this.notify(`◈ GROUP ${slot} SAVED`, '#a0d0ff', 1000)
+      }
+    }
+    this.inputHandler.onRecallControlGroup = (slot: number) => {
+      const saved = this.controlGroupRallies[slot - 4]
+      if (saved) {
+        this.rally(saved.x, saved.y)
+        this.renderer.showRallyPing(saved.x, saved.y)
+        this.notify(`◈ GROUP ${slot} RECALLED`, '#a0d0ff', 900)
+      }
+    }
     useSpeckWarsStore.getState().setGameActions({
       defend: () => { this.defend(); this.notify('🛡 DEFEND', '#4af7c4') },
       advance: () => { this.advance(); this.notify('→ ADVANCE', '#ffd700') },

--- a/src/app/speck-wars/input/input-handler.ts
+++ b/src/app/speck-wars/input/input-handler.ts
@@ -22,8 +22,8 @@ export class InputHandler {
   private onCycleSpeed?: () => void
   private onSelectAll?: () => void
   private onSacrifice?: () => void
-  private onSaveControlGroup?: (slot: number) => void
-  private onRecallControlGroup?: (slot: number) => void
+  public onSaveControlGroup?: (slot: number) => void
+  public onRecallControlGroup?: (slot: number) => void
   private pendingModifier: 'none' | 'attack' | 'patrol' = 'none'
   private isPanDragging = false   // middle-mouse only
   private isRightDragging = false


### PR DESCRIPTION
## Summary
- **Ctrl+4/5/6**: Save current rally position to that group slot
- **4/5/6**: Instantly recall all specks to the saved position
- Brief notification confirms save/recall (`◈ GROUP 4 SAVED`, `◈ GROUP 4 RECALLED`)
- 3 independent slots for multi-front management

## Technical
The callback wiring in `InputHandler` already existed (Ctrl+4..9 and 4..9 keybinds were there). This PR:
1. Makes `onSaveControlGroup` and `onRecallControlGroup` public properties (like existing `onCycleStance`)
2. Implements the handlers in `game-instance.ts` using `this.controlGroupRallies[]` array
3. Recall triggers existing `this.rally(x, y)` + `showRallyPing()`

## Strategic use
Multi-front management: Group 4 = enemy outpost, Group 5 = your base, Group 6 = center. React to flanking attacks with a single keypress.

Inspired by classic RTS control groups (SC2, AoE, C&C).

Closes #2164

🤖 Generated with [Claude Code](https://claude.com/claude-code)