### PR TITLE
feat(speck-wars): Heavy Charge and Scout Cloak unit abilities

### DIFF
--- a/src/app/speck-wars/domain/simulation/combat.ts
+++ b/src/app/speck-wars/domain/simulation/combat.ts
@@ -69,6 +69,8 @@ export function resolveCombat(sim: SimulationState, dt: number) {
       if (i === j || speckHp[j] <= 0) continue
       const jMeta = speckMeta[j]
       if (!jMeta || jMeta.ownerId === meta.ownerId) continue  // dead slot or friendly
+      // Scout cloak: enemy cloaked scouts cannot be targeted
+      if (jMeta.cloakTimer && jMeta.cloakTimer > 0 && jMeta.ownerId !== meta.ownerId) continue
 
       const dx = speckX[j] - speckX[i]
       const dy = speckY[j] - speckY[i]
@@ -279,8 +281,11 @@ export function resolveCombat(sim: SimulationState, dt: number) {
       // Outposts are captured, not destroyed — immune to direct combat damage
       if (building.typeId === 'outpost') continue
       const siegeBonus = meta.typeId === 'heavy' ? 1.5 : 1.0
-      building.hp -= stype.damage * moraleMult(meta.ownerId) * siegeBonus
+      const chargeDmgMult = (meta.typeId === 'heavy' && (meta.chargeTimer ?? 0) > 0) ? 1.5 : 1.0
+      building.hp -= stype.damage * moraleMult(meta.ownerId) * siegeBonus * chargeDmgMult
       building.lastDamagedAt = Date.now()
+      // Heavy Charge: set chargeTimer after landing a building attack
+      if (meta.typeId === 'heavy') meta.chargeTimer = 1500
       meta.attackCooldown = stype.attackCooldown
       sim.events.push({ type: 'BUILDING_DAMAGED', buildingId: building.id, hp: building.hp })
 

--- a/src/app/speck-wars/domain/simulation/movement.ts
+++ b/src/app/speck-wars/domain/simulation/movement.ts
@@ -28,6 +28,7 @@ export function moveSpecks(sim: SimulationState, dt: number) {
     if (!stype) continue
 
     const speedMult = (meta.isHero && (meta.heroLevel ?? 0) >= 1) ? 1.15 : 1.0
+    const chargeMult = (meta.typeId === 'heavy' && (meta.chargeTimer ?? 0) > 0) ? 1.35 : 1.0
 
     // Retreating: flee to nearest friendly building
     if (meta.state === 'retreating') {
@@ -54,8 +55,8 @@ export function moveSpecks(sim: SimulationState, dt: number) {
           const dist = Math.sqrt(nearestDist2)
           const dx = nearestBuilding.x - speckX[i]
           const dy = nearestBuilding.y - speckY[i]
-          speckVx[i] = (dx / dist) * stype.speed * speedMult
-          speckVy[i] = (dy / dist) * stype.speed * speedMult
+          speckVx[i] = (dx / dist) * stype.speed * speedMult * chargeMult
+          speckVy[i] = (dy / dist) * stype.speed * speedMult * chargeMult
           speckX[i] = Math.max(0, Math.min(WORLD_WIDTH, speckX[i] + speckVx[i] * dtSec))
           speckY[i] = Math.max(0, Math.min(WORLD_HEIGHT, speckY[i] + speckVy[i] * dtSec))
         }
@@ -80,8 +81,8 @@ export function moveSpecks(sim: SimulationState, dt: number) {
         const dy = target.y - speckY[i]
         const dist = Math.sqrt(dx * dx + dy * dy)
         if (dist > stype.attackRange) {
-          ax += (dx / dist) * stype.speed * speedMult
-          ay += (dy / dist) * stype.speed * speedMult
+          ax += (dx / dist) * stype.speed * speedMult * chargeMult
+          ay += (dy / dist) * stype.speed * speedMult * chargeMult
         }
       }
     } else {
@@ -123,8 +124,8 @@ export function moveSpecks(sim: SimulationState, dt: number) {
         const dy = rally.y - speckY[i]
         const dist = Math.sqrt(dx * dx + dy * dy)
         if (dist > stype.attackRange) {
-          ax += (dx / dist) * stype.speed * speedMult
-          ay += (dy / dist) * stype.speed * speedMult
+          ax += (dx / dist) * stype.speed * speedMult * chargeMult
+          ay += (dy / dist) * stype.speed * speedMult * chargeMult
         } else if (meta.patrolDestX !== undefined && meta.patrolOriginX !== undefined) {
           // Arrived at patrol leg — swap origin and destination to bounce back
           const newDestX = meta.patrolOriginX
@@ -183,8 +184,8 @@ export function moveSpecks(sim: SimulationState, dt: number) {
         if (closestDist2 < Infinity) {
           const dist = Math.sqrt(closestDist2)
           if (dist > stype.attackRange) {
-            ax += ((closestX - speckX[i]) / dist) * stype.speed * speedMult
-            ay += ((closestY - speckY[i]) / dist) * stype.speed * speedMult
+            ax += ((closestX - speckX[i]) / dist) * stype.speed * speedMult * chargeMult
+            ay += ((closestY - speckY[i]) / dist) * stype.speed * speedMult * chargeMult
           }
         }
       }

--- a/src/app/speck-wars/domain/simulation/tick.ts
+++ b/src/app/speck-wars/domain/simulation/tick.ts
@@ -4,6 +4,7 @@ import { updateSpawners, spawnCampDefenders, spawnCommander } from './spawner'
 import { runSpeckAI } from './speck-ai'
 import { moveSpecks } from './movement'
 import { resolveCombat, removeDeadSpecks, updateHeroAbilities } from './combat'
+import { updateUnitAbilities } from './unit-abilities'
 import { checkVictory } from './victory'
 import { updateCapture } from './capture'
 import { BUILDING_TYPES } from '../config/building-types'
@@ -49,6 +50,8 @@ export function tick(sim: SimulationState, dt: number): SimulationState {
     if (sim.speckHp[i] / maxHp < 0.25) {
       meta.state = 'retreating'
       meta.targetId = null
+      // Scout Cloak: scouts become untargetable for 2000ms when retreating
+      if (meta.typeId === 'scout') meta.cloakTimer = 2000
     }
   }
 
@@ -61,6 +64,9 @@ export function tick(sim: SimulationState, dt: number): SimulationState {
 
   // 6a. Hero abilities (AoE pulse for level 2 Commanders)
   updateHeroAbilities(sim, dt)
+
+  // 6b. Unit type abilities: tick chargeTimer (heavy) and cloakTimer (scout)
+  updateUnitAbilities(sim, dt)
 
   // 7. Update outpost capture progress
   updateCapture(sim, dt)

--- a/src/app/speck-wars/domain/simulation/unit-abilities.ts
+++ b/src/app/speck-wars/domain/simulation/unit-abilities.ts
@@ -1,0 +1,14 @@
+import type { SimulationState } from '../types'
+
+export function updateUnitAbilities(sim: SimulationState, dt: number) {
+  for (let i = 0; i < sim.speckCount; i++) {
+    const meta = sim.speckMeta[i]
+    if (!meta) continue
+    if (meta.chargeTimer && meta.chargeTimer > 0) {
+      meta.chargeTimer = Math.max(0, meta.chargeTimer - dt)
+    }
+    if (meta.cloakTimer && meta.cloakTimer > 0) {
+      meta.cloakTimer = Math.max(0, meta.cloakTimer - dt)
+    }
+  }
+}

--- a/src/app/speck-wars/domain/types.ts
+++ b/src/app/speck-wars/domain/types.ts
@@ -27,6 +27,8 @@ export interface SpeckMeta {
   commanderXp?: number          // XP earned from nearby kills
   commanderLevel?: 0 | 1 | 2 | 3  // 0=base, 1=unused, 2=pulse, 3=aura
   pulseTimer?: number           // ms until next AoE pulse
+  chargeTimer?: number          // ms of heavy charge burst remaining
+  cloakTimer?: number           // ms of scout cloak remaining (enemy can't target)
 }
 
 export interface BuildingEntity {

--- a/src/app/speck-wars/rendering/layers/speck-layer.ts
+++ b/src/app/speck-wars/rendering/layers/speck-layer.ts
@@ -78,10 +78,18 @@ export class SpeckLayer {
             this.attackAnimByIndex.delete(i)
           }
         }
+        // Heavy Charge: scale to 1.4x briefly when chargeTimer is fresh (> 1400ms remaining)
+        if (typeMeta?.typeId === 'heavy' && typeMeta.chargeTimer && typeMeta.chargeTimer > 1400) {
+          scaleBoost = Math.max(scaleBoost, 1.4)
+        }
         spriteList[j].scale.set((stype ? stype.size / 4 : 0.75) * scaleBoost)
         // Fade speck as it takes damage — full HP = 1.0, near death = 0.35
         const hpFrac = stype ? Math.max(0, sim.speckHp[i] / stype.hp) : 1
         spriteList[j].alpha = 0.35 + 0.65 * hpFrac
+        // Scout cloak: override alpha to 0.25 when cloaked
+        if (typeMeta?.cloakTimer && typeMeta.cloakTimer > 0) {
+          spriteList[j].alpha = 0.25
+        }
 
         // Hero Commander: gold diamond + HP ring rendered before veteran/elite/legend rings
         if (typeMeta?.isHero) {
@@ -156,6 +164,34 @@ export class SpeckLayer {
             const critPulse = 0.5 + 0.5 * Math.sin(now / 120)  // fast pulse ~8Hz
             this.gfx.lineStyle(1.2, 0xff2222, critAlpha * critPulse)
             this.gfx.drawCircle(sim.speckX[i], sim.speckY[i], stype.size / 4 + 2)
+            this.gfx.lineStyle(0)
+          }
+          // Heavy Charge: orange/red glow ring during charge burst
+          if (typeMeta?.chargeTimer && typeMeta.chargeTimer > 0) {
+            const chargeRadius = (stype ? stype.size / 4 : 0.75) + 4
+            this.gfx.lineStyle(2, 0xff6600, spriteList[j].alpha * 0.9)
+            this.gfx.drawCircle(sim.speckX[i], sim.speckY[i], chargeRadius)
+            this.gfx.lineStyle(0)
+          }
+        }
+
+        // Scout Cloak: dashed ring indicator (4 short arc segments) when cloaked
+        if (typeMeta?.typeId === 'scout' && typeMeta.cloakTimer && typeMeta.cloakTimer > 0) {
+          const cloakRadius = (stype ? stype.size / 4 : 0.75) + 5
+          const cx = sim.speckX[i]
+          const cy = sim.speckY[i]
+          // Draw 4 short arc segments approximated as short line segments
+          const segCount = 4
+          const arcLen = Math.PI / 6  // each arc segment spans ~30 degrees
+          for (let s = 0; s < segCount; s++) {
+            const startAngle = (s / segCount) * Math.PI * 2
+            const steps = 4
+            this.gfx.lineStyle(1, 0xaaddff, 0.7)
+            this.gfx.moveTo(cx + Math.cos(startAngle) * cloakRadius, cy + Math.sin(startAngle) * cloakRadius)
+            for (let k = 1; k <= steps; k++) {
+              const a = startAngle + (k / steps) * arcLen
+              this.gfx.lineTo(cx + Math.cos(a) * cloakRadius, cy + Math.sin(a) * cloakRadius)
+            }
             this.gfx.lineStyle(0)
           }
         }


### PR DESCRIPTION
## Summary

- **Heavy Charge**: When a heavy speck lands an attack on a building, it gains a 1500ms burst: +35% movement speed, +50% building damage. Visual: 1.4x scale pulse on the charge frame, orange glow ring (`0xff6600`) while active.
- **Scout Cloak**: When a scout speck's HP drops below 25% and it enters the `retreating` state, it cloaks for 2000ms: enemy specks skip it when selecting attack targets, alpha renders at 0.25, and a dashed light-blue arc ring is drawn around it.

## Files changed

- `domain/types.ts` — added `chargeTimer?` and `cloakTimer?` to `SpeckMeta`
- `domain/simulation/unit-abilities.ts` — new file; `updateUnitAbilities()` decrements both timers each tick
- `domain/simulation/combat.ts` — cloak skip in speck-vs-speck neighbor loop; `chargeDmgMult` and `chargeTimer` set in speck-vs-building section
- `domain/simulation/movement.ts` — `chargeMult` applied to all velocity assignments (retreat, seek-target, rally, idle aggression)
- `domain/simulation/tick.ts` — `cloakTimer = 2000` set when scout enters retreating; `updateUnitAbilities` called after `updateHeroAbilities`
- `rendering/layers/speck-layer.ts` — cloak alpha override, cloak dashed ring, heavy charge glow ring, heavy charge scale boost

## Test plan

- [ ] Spawn heavy specks, order them to attack an enemy building — verify orange glow ring appears and they move/deal damage faster for ~1.5s
- [ ] Let scout specks take damage below 25% HP — verify they fade to near-invisible, enemies route around them, dashed ring is visible
- [ ] Confirm cloak expires after ~2s (scout returns to normal alpha and is targetable)
- [ ] Confirm charge expires after ~1.5s (heavy returns to normal speed/damage)
- [ ] Run vitest — all existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)