### PR TITLE
perf(speck-wars): fix fog of war tanking FPS to unplayable

### DIFF
--- a/src/app/speck-wars/rendering/layers/fog-layer.ts
+++ b/src/app/speck-wars/rendering/layers/fog-layer.ts
@@ -1,4 +1,4 @@
-import { Container, Graphics } from 'pixi.js'
+import { Container, Graphics, RenderTexture, Sprite, Texture } from 'pixi.js'
 import type { SimulationState } from '../../domain/types'
 import {
   WORLD_WIDTH, WORLD_HEIGHT,
@@ -8,52 +8,168 @@ import {
 
 const FOG_COLS = Math.ceil(WORLD_WIDTH / FOG_CELL_SIZE)
 const FOG_ROWS = Math.ceil(WORLD_HEIGHT / FOG_CELL_SIZE)
+const FOG_CELLS = FOG_COLS * FOG_ROWS
 
+// The vision mask lives in its own low-res texture: ~6 world px per texel. Upscaling it
+// to world size is what gives the reveal its soft edge, and it keeps the per-frame draw
+// into the mask tiny regardless of army size.
+const MASK_WIDTH = 512
+const MASK_HEIGHT = Math.round(MASK_WIDTH * (WORLD_HEIGHT / WORLD_WIDTH))
+const MASK_SCALE = MASK_WIDTH / WORLD_WIDTH
+
+// Radius revealed for one occupied speck cell — the vision radius plus half a cell, so
+// specks anywhere in the cell still see at least FOG_VISION_SPECK around themselves.
+const CELL_VISION_RADIUS = FOG_VISION_SPECK + FOG_CELL_SIZE * 0.5
+
+// Pixi's TS defs mark setMask optional on the effects mixin; it exists at runtime.
+type Maskable = { setMask(options: { mask: Container; inverse: boolean }): void }
+
+// Minimal shape of the Pixi renderer we need — the full type is not reliably inferred
+// in this Next.js project context (same reason textures.ts casts).
+export interface MaskRenderer {
+  render(options: { container: Container; target: RenderTexture; clear: boolean }): void
+}
+
+// White radial gradient: opaque core, soft falloff at the rim. The mask filter reads the
+// red channel, so white-on-transparent is what punches a hole in the fog.
+function createVisionTexture(): Texture {
+  const size = 128
+  const canvas = document.createElement('canvas')
+  canvas.width = size
+  canvas.height = size
+  const ctx = canvas.getContext('2d')
+  if (!ctx) return Texture.WHITE   // degenerate fallback: square vision, still playable
+  const r = size / 2
+  const gradient = ctx.createRadialGradient(r, r, 0, r, r, r)
+  gradient.addColorStop(0, 'rgba(255,255,255,1)')
+  gradient.addColorStop(0.62, 'rgba(255,255,255,1)')
+  gradient.addColorStop(1, 'rgba(255,255,255,0)')
+  ctx.fillStyle = gradient
+  ctx.fillRect(0, 0, size, size)
+  return Texture.from(canvas)
+}
+
+/**
+ * Fog of war.
+ *
+ * The fog is a single black rect, built once and never rebuilt. Vision is an inverse
+ * alpha mask: each frame we draw one soft circle per vision source into a low-res render
+ * texture, and the fog is hidden wherever that texture is bright.
+ *
+ * Per frame that costs one batched draw call plus a viewport-sized mask pass. The
+ * previous implementation rebuilt the fog geometry every frame with Graphics.cut(),
+ * which routes Pixi into an earcut triangulation of the rect plus every hole ring — and
+ * since adjacent vision circles overlap, earcut fell into its self-intersection recovery
+ * path: seconds per frame once a handful of cells were occupied.
+ */
 export class FogLayer {
   readonly stage: Container
-  private gfx: Graphics
+  private renderer: MaskRenderer
+  private fogGfx: Graphics
+  private maskRT: RenderTexture
+  private maskSprite: Sprite
+  private visionTexture: Texture
+  private visionScene: Container
+  private pool: Sprite[] = []
+  private activeCount = 0
 
-  constructor() {
+  // Per-cell speck accumulators, reused across frames to avoid per-frame allocation
+  private cellCount = new Int32Array(FOG_CELLS)
+  private cellSumX = new Float32Array(FOG_CELLS)
+  private cellSumY = new Float32Array(FOG_CELLS)
+  private occupied: number[] = []
+
+  constructor(renderer: MaskRenderer) {
+    this.renderer = renderer
     this.stage = new Container()
-    ;(this.stage as any).enableRenderGroup()  // isolate for compositing (Pixi v8)
-    this.gfx = new Graphics()
-    this.stage.addChild(this.gfx)
+
+    this.fogGfx = new Graphics()
+    // Cast for Pixi v8 fluent API (rect/fill) not in TS defs
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ;(this.fogGfx as any).rect(0, 0, WORLD_WIDTH, WORLD_HEIGHT).fill({ color: 0x000000, alpha: FOG_ALPHA })
+
+    // Cast for the Pixi v8 options signature (the stale @types/pixi.js@4 in devDeps
+    // shadows it with the v4 `create(width, height)` form)
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    this.maskRT = (RenderTexture as any).create({ width: MASK_WIDTH, height: MASK_HEIGHT }) as RenderTexture
+    this.maskSprite = new Sprite(this.maskRT)
+    this.maskSprite.width = WORLD_WIDTH
+    this.maskSprite.height = WORLD_HEIGHT
+
+    this.stage.addChild(this.fogGfx)
+    this.stage.addChild(this.maskSprite)   // in the tree so its transform stays current
+    ;(this.fogGfx as unknown as Maskable).setMask({ mask: this.maskSprite, inverse: true })
+
+    this.visionTexture = createVisionTexture()
+    this.visionScene = new Container()     // drawn into maskRT, never added to the stage
   }
 
   update(sim: SimulationState, playerId: string): void {
-    // Cast to any for Pixi v8 fluent API (rect/circle/cut/fill) not in TS defs
-    const gfx = this.gfx as any
-    gfx.clear()
-
-    // Dark fog overlay covering the whole world
-    gfx.rect(0, 0, WORLD_WIDTH, WORLD_HEIGHT).fill({ color: 0x000000, alpha: FOG_ALPHA })
+    let n = 0
 
     // --- Vision from buildings ---
     for (const building of Object.values(sim.buildings)) {
       if (building.ownerId !== playerId) continue
       const r = building.typeId === 'base' ? FOG_VISION_BASE : FOG_VISION_BUILDING
-      gfx.circle(building.x, building.y, r).cut()
+      n = this.stamp(n, building.x, building.y, r)
     }
 
-    // --- Vision from specks (coarse grid) ---
-    // Mark visible cells using a Set; draw one circle per unique cell center
-    const visibleCells = new Set<number>()
+    // --- Vision from specks ---
+    // Collapse specks onto a coarse grid so cost is O(cells), not O(specks). Each
+    // occupied cell reveals around its specks' centroid rather than the cell centre, so
+    // the reveal tracks the army instead of snapping from cell to cell.
+    const { cellCount, cellSumX, cellSumY, occupied } = this
+    occupied.length = 0
     for (let i = 0; i < sim.speckCount; i++) {
-      if (sim.speckMeta[i]?.ownerId !== playerId) continue
-      const col = Math.min(FOG_COLS - 1, Math.max(0, Math.floor(sim.speckX[i] / FOG_CELL_SIZE)))
-      const row = Math.min(FOG_ROWS - 1, Math.max(0, Math.floor(sim.speckY[i] / FOG_CELL_SIZE)))
-      visibleCells.add(row * FOG_COLS + col)
+      if (!sim.speckIds[i]) continue
+      const meta = sim.speckMeta[i]
+      if (!meta || meta.ownerId !== playerId) continue
+      const x = sim.speckX[i]
+      const y = sim.speckY[i]
+      const col = Math.min(FOG_COLS - 1, Math.max(0, Math.floor(x / FOG_CELL_SIZE)))
+      const row = Math.min(FOG_ROWS - 1, Math.max(0, Math.floor(y / FOG_CELL_SIZE)))
+      const idx = row * FOG_COLS + col
+      if (cellCount[idx] === 0) occupied.push(idx)
+      cellCount[idx]++
+      cellSumX[idx] += x
+      cellSumY[idx] += y
     }
-    for (const cellIdx of visibleCells) {
-      const col = cellIdx % FOG_COLS
-      const row = Math.floor(cellIdx / FOG_COLS)
-      const cx = (col + 0.5) * FOG_CELL_SIZE
-      const cy = (row + 0.5) * FOG_CELL_SIZE
-      gfx.circle(cx, cy, FOG_VISION_SPECK + FOG_CELL_SIZE * 0.5).cut()
+    for (const idx of occupied) {
+      const count = cellCount[idx]
+      n = this.stamp(n, cellSumX[idx] / count, cellSumY[idx] / count, CELL_VISION_RADIUS)
+      cellCount[idx] = 0
+      cellSumX[idx] = 0
+      cellSumY[idx] = 0
     }
+
+    // Retire sprites left over from a frame that had more vision sources
+    for (let i = n; i < this.activeCount; i++) this.pool[i].visible = false
+    this.activeCount = n
+
+    this.renderer.render({ container: this.visionScene, target: this.maskRT, clear: true })
+  }
+
+  /** Place pooled vision circle `n` at world (x, y) with radius r. Returns n + 1. */
+  private stamp(n: number, x: number, y: number, r: number): number {
+    let sprite = this.pool[n]
+    if (!sprite) {
+      sprite = new Sprite(this.visionTexture)
+      sprite.anchor.set(0.5)
+      this.pool[n] = sprite
+      this.visionScene.addChild(sprite)
+    }
+    sprite.visible = true
+    sprite.position.set(x * MASK_SCALE, y * MASK_SCALE)
+    const size = r * 2 * MASK_SCALE
+    sprite.width = size
+    sprite.height = size
+    return n + 1
   }
 
   destroy(): void {
     this.stage.destroy({ children: true })
+    this.visionScene.destroy({ children: true })
+    this.visionTexture.destroy(true)
+    this.maskRT.destroy(true)
   }
 }

--- a/src/app/speck-wars/rendering/layers/fog-layer.ts
+++ b/src/app/speck-wars/rendering/layers/fog-layer.ts
@@ -102,6 +102,10 @@ export class FogLayer {
 
     this.visionTexture = createVisionTexture()
     this.visionScene = new Container()     // drawn into maskRT, never added to the stage
+
+    // A fresh render texture is uninitialised; clear it so the first frame is fully
+    // fogged rather than whatever happened to be in the buffer.
+    this.renderer.render({ container: this.visionScene, target: this.maskRT, clear: true })
   }
 
   update(sim: SimulationState, playerId: string): void {

--- a/src/app/speck-wars/rendering/renderer.ts
+++ b/src/app/speck-wars/rendering/renderer.ts
@@ -5,6 +5,7 @@ import { GridLayer } from './layers/grid-layer'
 import { EffectsLayer } from './layers/effects-layer'
 import { StarfieldLayer } from './layers/starfield-layer'
 import { FogLayer } from './layers/fog-layer'
+import type { MaskRenderer } from './layers/fog-layer'
 import { createSpeckTexture } from './textures'
 import type { SimulationState } from '../domain/types'
 import { PLAYER_COLOR, AI_COLOR } from '../domain/constants'
@@ -60,7 +61,7 @@ export class Renderer {
     this.effectsLayer = new EffectsLayer()
     this.buildingLayer = new BuildingLayer()
     this.speckLayer = new SpeckLayer(texture, PLAYER_COLORS)
-    this.fogLayer = new FogLayer()
+    this.fogLayer = new FogLayer(this.app.renderer as unknown as MaskRenderer)
 
     this.world.addChild(this.starfieldLayer.stage)
     this.world.addChild(this.gridLayer.stage)


### PR DESCRIPTION
## Summary

Fog of war (#2158) made Speck Wars unplayable. `FogLayer.update()` ran every rAF frame and rebuilt the whole fog geometry: `gfx.clear()`, a world-sized rect fill, then one `circle().cut()` per vision source.

In Pixi v8 a fill *with holes* skips the cheap per-shape triangulator and routes through `earcut` over the outer ring plus every hole ring concatenated (`buildContextBatches.js:112`) — up to ~47k vertices re-triangulated per frame at 208 verts per circle.

The bigger problem: **the holes overlap.** Vision radius is `FOG_VISION_SPECK + FOG_CELL_SIZE * 0.5` = 250px, but cell centres are only 200px apart, so any two occupied cells within 500px produce intersecting hole rings. Pixi's `cut()` requires holes to be non-overlapping and fully contained; earcut instead falls into its self-intersection recovery path and goes quadratic.

Measured in isolation against Pixi's own `buildCircle` geometry + `earcut` 2.2.4:

| holes | vertices | earcut |
|---|---|---|
| 5 disjoint (r=90) | 624 | 2.6 ms |
| 100 disjoint (r=90) | 12404 | 23.9 ms |
| **3 overlapping (r=250)** | 628 | **36.7 ms** |
| **5 overlapping (r=250)** | 1044 | **256.2 ms** |
| **25 overlapping (r=250)** | 5204 | **2367.8 ms** |
| **50 overlapping (r=250)** | 10404 | **18128.1 ms** |

Specks spawn at your base, so the base circle overlaps nearby speck cells from the very first frame, and it degrades as the army spreads. The triangle counts also come back malformed (386 tris from 1044 verts), so the fog was rendering incorrectly on top of being slow.

## Fix

Inverse alpha mask instead of per-frame `cut()`:

- The fog is a single black rect, built once in the constructor and never rebuilt.
- Each frame draws one soft radial sprite per vision source into a 512×512 render texture; the fog is hidden wherever that texture is bright (`setMask({ mask, inverse: true })`).
- The mask is a plain `Sprite`, so Pixi takes the `renderMaskToTexture: false` path and skips the unclamped per-frame render-texture allocation a `Container` mask would trigger. The mask filter pass itself is clamped to the viewport (`FilterSystem.js:118`).

Per-frame cost is one batched draw call plus a viewport-sized mask pass, independent of army size. Vision sprites come from a pool, so a steady frame allocates nothing.

## Behaviour

- Vision radii unchanged (base 300, buildings 180, speck cells 150 + half-cell).
- The coarse 200px speck grid is kept, but each occupied cell now reveals around its specks' **centroid** rather than the cell centre, so the reveal tracks the army instead of snapping 200px at a time.
- Vision edges are soft rather than hard-cut circles — a consequence of the low-res mask, and closer to the intended look.

## Test plan

- [x] `tsc --noEmit` clean for `speck-wars`
- [ ] CI
- [ ] Visual check in-game: fog present, reveals follow army and buildings, no black screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)