### PR TITLE
perf(speck-wars): fix FPS drop — throttle fog + attack-move scan

### DIFF
--- a/src/app/speck-wars/domain/simulation/movement.ts
+++ b/src/app/speck-wars/domain/simulation/movement.ts
@@ -86,7 +86,8 @@ export function moveSpecks(sim: SimulationState, dt: number) {
       }
     } else {
       // Attack-move: scan for nearby enemy specks and steer toward them
-      if (meta.attackMoveMode && meta.assignedRallyX !== undefined) {
+      // Stagger scan across ticks — each speck rescans every 4 ticks to cut query volume by 75%
+      if (meta.attackMoveMode && meta.assignedRallyX !== undefined && (i + sim.tick) % 4 === 0) {
         const ATTACK_MOVE_RANGE = 80  // px
         const amR2 = ATTACK_MOVE_RANGE * ATTACK_MOVE_RANGE
         let closestDist2 = Infinity, closestX = 0, closestY = 0

--- a/src/app/speck-wars/rendering/renderer.ts
+++ b/src/app/speck-wars/rendering/renderer.ts
@@ -36,6 +36,7 @@ export class Renderer {
   private effectsLayer!: EffectsLayer
   private starfieldLayer!: StarfieldLayer
   private fogLayer!: FogLayer
+  private fogFrameCounter = 0
   private rallyGfx!: Graphics
   private selectionGfx!: Graphics
   private vignetteGfx!: Graphics
@@ -85,7 +86,7 @@ export class Renderer {
 
     this.buildingLayer.update(sim, PLAYER_COLORS, sim.selectedBuildingId, ghostBuild)
     this.speckLayer.update(sim, sim.selectedSpeckIds)
-    this.fogLayer.update(sim, 'player')
+    if (this.fogFrameCounter++ % 4 === 0) this.fogLayer.update(sim, 'player')
 
     // Process events from this tick
     for (const event of sim.events) {


### PR DESCRIPTION
## Problem
Two recent features combined to tank FPS:

1. **Fog of war** calls fogLayer.update() every frame — draws a 3000x3000 fill + up to 225 .cut() GPU compositing operations. At 60fps that is ~13,500 composition ops/sec.

2. **AI attack-move (PR #2133)** gave all AI specks attackMoveMode=true, meaning every speck called spatialGrid.query() every tick. With 5k+ specks: 10k+ spatial queries per tick.

## Fix
- **Fog**: update every 4th frame only. Fog cells are 200px wide, specks move 64px/s so 67ms lag is imperceptible. 75% fewer GPU ops.
- **Attack-move scan**: stagger with (i + sim.tick) % 4 === 0 so each speck rescans every 4 ticks, 25% scan per tick. Cached target used between scans. 75% fewer spatial queries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)