### PR TITLE
fix(speck-wars): survive React StrictMode's mount/unmount/remount

### DIFF
--- a/src/app/speck-wars/SpeckWarsGame.tsx
+++ b/src/app/speck-wars/SpeckWarsGame.tsx
@@ -7,12 +7,23 @@ import { HUD } from './components/hud'
 import { PhaseRouter } from './components/phase-router'
 
 function GameCanvas() {
-  const canvasRef = useRef<HTMLCanvasElement>(null)
+  const hostRef = useRef<HTMLDivElement>(null)
   const gameRef = useRef<GameInstance | null>(null)
 
   useEffect(() => {
-    const canvas = canvasRef.current
-    if (!canvas) return
+    const host = hostRef.current
+    if (!host) return
+
+    // Own the canvas element rather than letting React reuse one across mounts. Once a
+    // Pixi Application is destroyed its WebGL context is gone, and initialising a new
+    // one on the same canvas yields a context whose shaders fail to compile — a blank
+    // canvas. React StrictMode mounts, tears down and remounts this effect in
+    // development, so that path is hit on every dev page load.
+    const canvas = document.createElement('canvas')
+    canvas.style.display = 'block'
+    canvas.style.width = '100%'
+    canvas.style.height = '100%'
+    host.appendChild(canvas)
 
     const game = new GameInstance(canvas)
     gameRef.current = game
@@ -21,6 +32,7 @@ function GameCanvas() {
     return () => {
       game.destroy()
       gameRef.current = null
+      canvas.remove()
     }
   }, [])
 
@@ -33,10 +45,7 @@ function GameCanvas() {
         'radial-gradient(ellipse at 50% 50%, rgba(2,6,18,1) 0%, #010208 100%)',
       ].join(', '),
     }}>
-      <canvas
-        ref={canvasRef}
-        style={{ display: 'block', width: '100%', height: '100%' }}
-      />
+      <div ref={hostRef} style={{ position: 'absolute', inset: 0 }} />
       <HUD />
     </div>
   )

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -15,6 +15,7 @@ export class GameInstance {
   private sim: SimulationState
   private renderer: Renderer
   private rafId: number | null = null
+  private destroyed = false
   private lastTime: number = 0
   private camera: Camera
   private inputHandler!: InputHandler
@@ -99,6 +100,11 @@ export class GameInstance {
     console.log('GameInstance started')
     document.addEventListener('visibilitychange', this.onVisibilityChange)
     await this.renderer.init(this.canvas)
+    // destroy() ran while the renderer was initialising (React StrictMode mounts, tears
+    // down and remounts the canvas effect). Bail out rather than wiring up input, the
+    // store and a render loop that nothing owns — the renderer has already cleaned
+    // itself up, and a second GameInstance is running by now.
+    if (this.destroyed) return
     this.inputHandler = new InputHandler(
       this.canvas,
       this.camera,
@@ -338,6 +344,7 @@ export class GameInstance {
   }
 
   private loop = (now: number) => {
+    if (this.destroyed) return   // a frame queued before destroy() can still fire
     const dt = Math.min(now - this.lastTime, 50)
     this.lastTime = now
 
@@ -795,7 +802,11 @@ export class GameInstance {
   }
 
   destroy() {
-    if (this.rafId !== null) cancelAnimationFrame(this.rafId)
+    this.destroyed = true
+    if (this.rafId !== null) {
+      cancelAnimationFrame(this.rafId)
+      this.rafId = null
+    }
     document.removeEventListener('visibilitychange', this.onVisibilityChange)
     this.renderer.destroy()
     this.inputHandler?.destroy()

--- a/src/app/speck-wars/rendering/renderer.ts
+++ b/src/app/speck-wars/rendering/renderer.ts
@@ -40,6 +40,8 @@ export class Renderer {
   private rallyGfx!: Graphics
   private selectionGfx!: Graphics
   private vignetteGfx!: Graphics
+  private ready = false        // layers built — everything below is safe to touch
+  private destroyed = false    // destroy() was called, possibly mid-init
 
   async init(canvas: HTMLCanvasElement) {
     const app = new Application() as PixiApplication
@@ -50,6 +52,13 @@ export class Renderer {
       antialias: false,
       preference: 'webgl',
     })
+    // We were destroyed while app.init() was in flight (React StrictMode remounts the
+    // canvas effect immediately). The app owns a live WebGL context, so tear it down
+    // here — destroy() could not, because it had nothing to tear down yet.
+    if (this.destroyed) {
+      app.destroy()
+      return
+    }
     this.app = app
 
     this.world = new Container()
@@ -78,6 +87,13 @@ export class Renderer {
 
     this.vignetteGfx = new Graphics()
     this.app.stage.addChild(this.vignetteGfx)
+
+    this.ready = true
+  }
+
+  /** True once init() has finished building the layers. */
+  get isReady(): boolean {
+    return this.ready
   }
 
   render(sim: SimulationState, camera: { x: number; y: number; zoom: number }, dt: number, shakeX = 0, shakeY = 0, dragRect?: { x1: number; y1: number; x2: number; y2: number } | null, ghostBuild?: { typeId: string; wx: number; wy: number } | null): void {
@@ -212,6 +228,12 @@ export class Renderer {
   }
 
   destroy() {
+    this.destroyed = true
+    // Nothing was built yet — either init() has not run, or it is still awaiting
+    // app.init() and will clean up after itself when it resumes.
+    if (!this.ready) return
+    this.ready = false
+
     this.starfieldLayer.destroy()
     this.gridLayer.destroy()
     this.effectsLayer.destroy()


### PR DESCRIPTION
## Summary

Speck Wars was unusable in `npm run dev`. React StrictMode mounts the canvas effect, tears it down and remounts it, and the game did not survive that. Three separate failures, each hidden behind the previous one:

1. **Crash.** `GameInstance.start()` awaits `renderer.init()`. StrictMode's cleanup fires during that await, so `Renderer.destroy()` ran against layers that did not exist yet and threw on `this.starfieldLayer.destroy()` (`renderer.ts:215`). The page fell into the error boundary.
2. **Orphan loop.** The aborted `start()` then resumed past its await and built an input handler, registered store actions and started a render loop that nothing owned. It kept running for the life of the page — the React tree was gone, but the sim was still ticking.
3. **Blank canvas.** Both instances shared a single `<canvas>`. Once a Pixi `Application` is destroyed its WebGL context is gone, and initialising a second one on the same element yields a context whose shaders fail to compile (`logPrettyShaderError` → `TypeError: Cannot read properties of null (reading 'split')`). Result: a white canvas.

## Fixes

- **`Renderer`** tracks `ready`/`destroyed`. `destroy()` is idempotent and returns early when nothing was built. `init()` checks `destroyed` after its await and disposes the half-built `Application` itself — `destroy()` could not, because at that point there was nothing to tear down but a live WebGL context did exist.
- **`GameInstance`** tracks `destroyed`, returns from `start()` if it was torn down during init, nulls `rafId`, and bails out of a frame that was queued before `destroy()`.
- **`GameCanvas`** creates and removes its own `<canvas>` per mount, so each `Application` gets a fresh context instead of reusing a destroyed one.

## Scope

Dev-only in practice. Production builds do not double-invoke effects, and a normal unmount/remount (victory → play again) makes React build a new `<canvas>` anyway. Nothing here changes gameplay or the render path.

## Verification

Headless Chromium, StrictMode on, against the dev server:

| | before | after |
|---|---|---|
| enters error boundary | yes | **no** |
| page errors | `TypeError: ...(reading 'destroy')` | **none** |
| instance lifecycle | started → destroyed → started, first loop orphaned | **started → destroyed → started, one live** |
| canvas | blank white (once the crash was fixed) | **renders** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)