### PR TITLE
feat(speck-wars): long-press attack-move gesture for mobile

### DIFF
--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -591,6 +591,7 @@ export function HUD() {
             <span>Ctrl+4-9 — save group</span><span>4-9 — recall group</span>
             <span style={{ color: 'rgba(74,247,196,0.7)' }}>Right-click with group selected → moves selected only</span><span style={{ color: 'rgba(74,247,196,0.7)' }}>Specks engage enemies en route (attack-move)</span>
             <span>A — attack-move modifier · P — patrol modifier</span><span>A/P + right-click — attack-move / patrol</span>
+            <span style={{ color: 'rgba(255,180,80,0.75)' }}>Long-press canvas → Attack Move (mobile)</span><span style={{ color: 'rgba(255,180,80,0.75)' }}>Tap canvas → Rally (mobile)</span>
             <span>S — stop · H — hold position</span><span>C — center on base</span>
             <span>N — advance to outpost · D — defend base</span><span>B — rush enemy base</span>
             <span>Q — surge (2× spawn 8s)</span><span>V — snap camera to battle</span>
@@ -1169,6 +1170,10 @@ export function HUD() {
                 ))}
               </div>
             )}
+            {/* Touch gesture hint */}
+            <div style={{ marginTop: 6, fontSize: 11, color: '#aaa', letterSpacing: 0.3, textAlign: 'center' }}>
+              Tap: rally &bull; Long-press: attack-move
+            </div>
           </div>
         </div>
       )}

--- a/src/app/speck-wars/input/input-handler.ts
+++ b/src/app/speck-wars/input/input-handler.ts
@@ -47,6 +47,8 @@ export class InputHandler {
   private touchStartX = 0
   private touchStartY = 0
   private isDragSelect = false
+  private longPressTimer: ReturnType<typeof setTimeout> | null = null
+  private longPressFired = false
   private dragSelectStartWorldX = 0
   private dragSelectStartWorldY = 0
 
@@ -273,6 +275,18 @@ export class InputHandler {
       this.lastY = e.touches[0].clientY
       this.touchStartX = e.touches[0].clientX
       this.touchStartY = e.touches[0].clientY
+      this.longPressFired = false
+      // Long-press: if finger stays >500ms without moving, fire attack-move
+      this.longPressTimer = setTimeout(() => {
+        const rect = this.canvas.getBoundingClientRect()
+        const sx = this.lastX - rect.left
+        const sy = this.lastY - rect.top
+        if (sx >= 0 && sy >= 0 && sx <= rect.width && sy <= rect.height) {
+          const world = screenToWorld(sx, sy, this.camera)
+          this.onAttackMove?.(world.x, world.y)
+          this.longPressFired = true
+        }
+      }, 500)
     } else if (e.touches.length === 2) {
       this.isDragging = false
       const dx = e.touches[1].clientX - e.touches[0].clientX
@@ -296,6 +310,16 @@ export class InputHandler {
       Object.assign(this.camera, zoomAt(this.camera, mx, my, factor))
       this.lastPinchDist = newDist
     } else if (this.isDragging && e.touches.length === 1) {
+      if (e.touches.length === 1) {
+        const moveDist = Math.sqrt(
+          (e.touches[0].clientX - this.touchStartX) ** 2 +
+          (e.touches[0].clientY - this.touchStartY) ** 2
+        )
+        if (moveDist > 12 && this.longPressTimer) {
+          clearTimeout(this.longPressTimer)
+          this.longPressTimer = null
+        }
+      }
       this.camera.x += e.touches[0].clientX - this.lastX
       this.camera.y += e.touches[0].clientY - this.lastY
       this.lastX = e.touches[0].clientX
@@ -304,8 +328,13 @@ export class InputHandler {
   }
 
   private onTouchEnd = (e: TouchEvent) => {
-    // Tap-to-rally: single finger tap (small movement) → set rally at tap position
-    if (this.lastPinchDist === 0 && e.changedTouches.length === 1 && this.onRally) {
+    // Cancel any pending long-press
+    if (this.longPressTimer) {
+      clearTimeout(this.longPressTimer)
+      this.longPressTimer = null
+    }
+    // Tap-to-rally: only if long-press didn't fire
+    if (!this.longPressFired && this.lastPinchDist === 0 && e.changedTouches.length === 1 && this.onRally) {
       const touch = e.changedTouches[0]
       const dx = touch.clientX - this.touchStartX
       const dy = touch.clientY - this.touchStartY
@@ -321,6 +350,7 @@ export class InputHandler {
     }
     this.isDragging = false
     this.lastPinchDist = 0
+    this.longPressFired = false
   }
 
   private onKeyUp = (e: KeyboardEvent) => {
@@ -433,6 +463,10 @@ export class InputHandler {
   }
 
   destroy() {
+    if (this.longPressTimer) {
+      clearTimeout(this.longPressTimer)
+      this.longPressTimer = null
+    }
     this.canvas.removeEventListener('mousedown', this.onMouseDown)
     window.removeEventListener('mousemove', this.onMouseMove)
     window.removeEventListener('mouseup', this.onMouseUp)


### PR DESCRIPTION
## Summary
- **Long-press canvas (500ms) → attack-move** to that world point — the most important missing mobile command, previously keyboard-only ('A' key)
- Cancels gracefully: panning (>12px movement) cancels the timer, so drag-to-pan never accidentally issues attack-move
- Updates help overlay with "Long-press canvas → Attack Move (mobile)" section
- Adds subtle `"Tap: rally • Long-press: attack-move"` hint below unit action buttons so players discover the gesture

## How it works
- `onTouchStart`: starts a 500ms timer using current finger position
- `onTouchMove`: cancels timer if finger travels >12px (user is panning)
- `onTouchEnd`: cancels timer; skips `onRally` if long-press already fired
- `destroy`: cleans up timer to prevent stale callbacks

## Test plan
- [ ] Long-press (hold ~500ms) on canvas → units issue attack-move to that location
- [ ] Short tap (<500ms) → normal rally (unchanged behavior)
- [ ] Drag to pan → does NOT trigger attack-move
- [ ] Pinch to zoom → does NOT trigger attack-move
- [ ] Help overlay shows the new mobile gesture section
- [ ] Unit action panel shows gesture hint text

🤖 Generated with [Claude Code](https://claude.com/claude-code)