### PR TITLE
feat(speck-wars): Select All button in HUD for mobile players

### DIFF
--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -544,6 +544,30 @@ export function HUD() {
             </button>
           )
         })()}
+        {/* Select All button — critical for mobile (no keyboard shortcut available) */}
+        {gameActions?.selectAll && (
+          <button
+            onClick={() => gameActions.selectAll?.()}
+            title="[E] Select all friendly specks"
+            style={{
+              pointerEvents: 'auto',
+              padding: '8px 12px',
+              fontSize: 12,
+              cursor: 'pointer',
+              background: 'rgba(74,247,196,0.12)',
+              border: '1px solid rgba(74,247,196,0.4)',
+              borderRadius: 4,
+              color: '#4af7c4',
+              letterSpacing: 0.5,
+              lineHeight: 1.3,
+              textAlign: 'center',
+              minHeight: 44,
+            }}
+          >
+            <div style={{ fontWeight: 700 }}>⬡ ALL</div>
+            <div style={{ fontSize: 8, opacity: 0.7 }}>E</div>
+          </button>
+        )}
         <button
           onClick={() => setShowHelp(h => !h)}
           title="? — show controls"

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -291,6 +291,9 @@ export class GameInstance {
       researchUpgrade: (buildingId: string, upgrade: 'carapace' | 'blades' | 'afterburners') => {
         this.sim.inputQueue.push({ type: 'RESEARCH_UPGRADE', ownerId: 'player', buildingId, upgrade })
       },
+      selectAll: () => {
+        this.sim.inputQueue.push({ type: 'BOX_SELECT', ownerId: 'player', x1: -1, y1: -1, x2: 3001, y2: 3001 })
+      },
     })
     // Cinematic intro: start zoomed out to show full world
     const W = this.canvas.clientWidth

--- a/src/app/speck-wars/store.ts
+++ b/src/app/speck-wars/store.ts
@@ -65,8 +65,8 @@ interface SpeckWarsStore {
   setStance: (s: 'aggressive' | 'defensive' | 'hold') => void
   aiPersonality: AIPersonality | null
   setAiPersonality: (p: AIPersonality) => void
-  gameActions: { defend: (() => void) | null; advance: (() => void) | null; rush: (() => void) | null; clearRally: (() => void) | null; surge: (() => void) | null; rally: ((x: number, y: number) => void) | null; sacrifice: (() => void) | null; setSpawnType: ((type: 'basic' | 'heavy' | 'scout') => void) | null; buildTurret?: (() => void) | null; panCamera: ((x: number, y: number) => void) | null; stop: (() => void) | null; hold: (() => void) | null; guard: (() => void) | null; cycleStance: (() => void) | null; researchUpgrade?: ((buildingId: string, upgrade: 'carapace' | 'blades' | 'afterburners') => void) | null }
-  setGameActions: (actions: { defend: () => void; advance: () => void; rush: () => void; clearRally: () => void; surge: () => void; rally: (x: number, y: number) => void; sacrifice: () => void; setSpawnType: (type: 'basic' | 'heavy' | 'scout') => void; buildTurret?: () => void; panCamera: (x: number, y: number) => void; stop: () => void; hold: () => void; guard: () => void; cycleStance: () => void; researchUpgrade?: (buildingId: string, upgrade: 'carapace' | 'blades' | 'afterburners') => void } | null) => void
+  gameActions: { defend: (() => void) | null; advance: (() => void) | null; rush: (() => void) | null; clearRally: (() => void) | null; surge: (() => void) | null; rally: ((x: number, y: number) => void) | null; sacrifice: (() => void) | null; setSpawnType: ((type: 'basic' | 'heavy' | 'scout') => void) | null; buildTurret?: (() => void) | null; panCamera: ((x: number, y: number) => void) | null; stop: (() => void) | null; hold: (() => void) | null; guard: (() => void) | null; cycleStance: (() => void) | null; researchUpgrade?: ((buildingId: string, upgrade: 'carapace' | 'blades' | 'afterburners') => void) | null; selectAll?: (() => void) | null }
+  setGameActions: (actions: { defend: () => void; advance: () => void; rush: () => void; clearRally: () => void; surge: () => void; rally: (x: number, y: number) => void; sacrifice: () => void; setSpawnType: (type: 'basic' | 'heavy' | 'scout') => void; buildTurret?: () => void; panCamera: (x: number, y: number) => void; stop: () => void; hold: () => void; guard: () => void; cycleStance: () => void; researchUpgrade?: (buildingId: string, upgrade: 'carapace' | 'blades' | 'afterburners') => void; selectAll?: () => void } | null) => void
   surrender: () => void
   resetGame: () => void
 }
@@ -140,8 +140,8 @@ export const useSpeckWarsStore = create<SpeckWarsStore>()((set, get) => ({
   setStance: stance => set({ stance }),
   aiPersonality: null,
   setAiPersonality: p => set({ aiPersonality: p }),
-  gameActions: { defend: null, advance: null, rush: null, clearRally: null, surge: null, rally: null, sacrifice: null, setSpawnType: null, buildTurret: null, panCamera: null, stop: null, hold: null, guard: null, cycleStance: null, researchUpgrade: null },
-  setGameActions: (actions) => set({ gameActions: actions ?? { defend: null, advance: null, rush: null, clearRally: null, surge: null, rally: null, sacrifice: null, setSpawnType: null, buildTurret: null, panCamera: null, stop: null, hold: null, guard: null, cycleStance: null, researchUpgrade: null } }),
+  gameActions: { defend: null, advance: null, rush: null, clearRally: null, surge: null, rally: null, sacrifice: null, setSpawnType: null, buildTurret: null, panCamera: null, stop: null, hold: null, guard: null, cycleStance: null, researchUpgrade: null, selectAll: null },
+  setGameActions: (actions) => set({ gameActions: actions ?? { defend: null, advance: null, rush: null, clearRally: null, surge: null, rally: null, sacrifice: null, setSpawnType: null, buildTurret: null, panCamera: null, stop: null, hold: null, guard: null, cycleStance: null, researchUpgrade: null, selectAll: null } }),
   surrender: () => {
     const s = get()
     resetWinStreak()


### PR DESCRIPTION
## Summary
- Adds a **"⬡ ALL"** button to the top control bar — selects all friendly specks with one tap
- Previously keyboard-only (`E` / `Ctrl+A`), making it impossible to use on touchscreens
- Wires `gameActions.selectAll` through the store and game-instance to the existing `BOX_SELECT` input queue action
- Button matches the mobile-friendly 44px minimum height standard set in PR #2179

## Why this matters
Select-all is the first thing any RTS player does: rally all forces to a new position. Without it, mobile players can only move whatever specks happen to be auto-selected. This single button unlocks the core mobile gameplay loop.

## Test plan
- [ ] "⬡ ALL" button visible in top bar when game is active
- [ ] Tapping it selects all player specks (verified by unit action buttons appearing)
- [ ] Keyboard shortcut `E` still works as before
- [ ] Button not shown on menu/defeat/victory screen (guarded by `gameActions?.selectAll`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)