### PR TITLE
feat(speck-wars): Snap to Base (⌂ HOME) button in HUD for mobile

### DIFF
--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -550,6 +550,31 @@ export function HUD() {
             </button>
           )
         })()}
+        {/* Snap to base button — essential for mobile (no keyboard shortcut) */}
+        {gameActions?.snapToBase && (
+          <button
+            onClick={() => gameActions.snapToBase?.()}
+            title="[C] Center camera on home base"
+            aria-label="Snap camera to home base"
+            style={{
+              pointerEvents: 'auto',
+              padding: '8px 12px',
+              fontSize: 12,
+              cursor: 'pointer',
+              background: 'rgba(74,247,196,0.08)',
+              border: '1px solid rgba(74,247,196,0.3)',
+              borderRadius: 4,
+              color: 'rgba(74,247,196,0.8)',
+              letterSpacing: 0.5,
+              lineHeight: 1.3,
+              textAlign: 'center',
+              minHeight: 44,
+            }}
+          >
+            <div style={{ fontWeight: 700 }}>⌂ HOME</div>
+            <div style={{ fontSize: 8, opacity: 0.7 }}>C</div>
+          </button>
+        )}
         <button
           onClick={() => setShowHelp(h => !h)}
           title="? — show controls"

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -291,6 +291,7 @@ export class GameInstance {
       researchUpgrade: (buildingId: string, upgrade: 'carapace' | 'blades' | 'afterburners') => {
         this.sim.inputQueue.push({ type: 'RESEARCH_UPGRADE', ownerId: 'player', buildingId, upgrade })
       },
+      snapToBase: () => this.snapToBase(),
     })
     // Cinematic intro: start zoomed out to show full world
     const W = this.canvas.clientWidth

--- a/src/app/speck-wars/store.ts
+++ b/src/app/speck-wars/store.ts
@@ -67,8 +67,8 @@ interface SpeckWarsStore {
   setAiPersonality: (p: AIPersonality) => void
   fogEnabled: boolean
   setFogEnabled: (v: boolean) => void
-  gameActions: { defend: (() => void) | null; advance: (() => void) | null; rush: (() => void) | null; clearRally: (() => void) | null; surge: (() => void) | null; rally: ((x: number, y: number) => void) | null; sacrifice: (() => void) | null; setSpawnType: ((type: 'basic' | 'heavy' | 'scout') => void) | null; buildTurret?: (() => void) | null; panCamera: ((x: number, y: number) => void) | null; stop: (() => void) | null; hold: (() => void) | null; guard: (() => void) | null; cycleStance: (() => void) | null; researchUpgrade?: ((buildingId: string, upgrade: 'carapace' | 'blades' | 'afterburners') => void) | null }
-  setGameActions: (actions: { defend: () => void; advance: () => void; rush: () => void; clearRally: () => void; surge: () => void; rally: (x: number, y: number) => void; sacrifice: () => void; setSpawnType: (type: 'basic' | 'heavy' | 'scout') => void; buildTurret?: () => void; panCamera: (x: number, y: number) => void; stop: () => void; hold: () => void; guard: () => void; cycleStance: () => void; researchUpgrade?: (buildingId: string, upgrade: 'carapace' | 'blades' | 'afterburners') => void } | null) => void
+  gameActions: { defend: (() => void) | null; advance: (() => void) | null; rush: (() => void) | null; clearRally: (() => void) | null; surge: (() => void) | null; rally: ((x: number, y: number) => void) | null; sacrifice: (() => void) | null; setSpawnType: ((type: 'basic' | 'heavy' | 'scout') => void) | null; buildTurret?: (() => void) | null; panCamera: ((x: number, y: number) => void) | null; stop: (() => void) | null; hold: (() => void) | null; guard: (() => void) | null; cycleStance: (() => void) | null; researchUpgrade?: ((buildingId: string, upgrade: 'carapace' | 'blades' | 'afterburners') => void) | null; snapToBase?: (() => void) | null }
+  setGameActions: (actions: { defend: () => void; advance: () => void; rush: () => void; clearRally: () => void; surge: () => void; rally: (x: number, y: number) => void; sacrifice: () => void; setSpawnType: (type: 'basic' | 'heavy' | 'scout') => void; buildTurret?: () => void; panCamera: (x: number, y: number) => void; stop: () => void; hold: () => void; guard: () => void; cycleStance: () => void; researchUpgrade?: (buildingId: string, upgrade: 'carapace' | 'blades' | 'afterburners') => void; snapToBase?: () => void } | null) => void
   surrender: () => void
   resetGame: () => void
 }
@@ -144,8 +144,8 @@ export const useSpeckWarsStore = create<SpeckWarsStore>()((set, get) => ({
   setAiPersonality: p => set({ aiPersonality: p }),
   fogEnabled: false,
   setFogEnabled: v => set({ fogEnabled: v }),
-  gameActions: { defend: null, advance: null, rush: null, clearRally: null, surge: null, rally: null, sacrifice: null, setSpawnType: null, buildTurret: null, panCamera: null, stop: null, hold: null, guard: null, cycleStance: null, researchUpgrade: null },
-  setGameActions: (actions) => set({ gameActions: actions ?? { defend: null, advance: null, rush: null, clearRally: null, surge: null, rally: null, sacrifice: null, setSpawnType: null, buildTurret: null, panCamera: null, stop: null, hold: null, guard: null, cycleStance: null, researchUpgrade: null } }),
+  gameActions: { defend: null, advance: null, rush: null, clearRally: null, surge: null, rally: null, sacrifice: null, setSpawnType: null, buildTurret: null, panCamera: null, stop: null, hold: null, guard: null, cycleStance: null, researchUpgrade: null, snapToBase: null },
+  setGameActions: (actions) => set({ gameActions: actions ?? { defend: null, advance: null, rush: null, clearRally: null, surge: null, rally: null, sacrifice: null, setSpawnType: null, buildTurret: null, panCamera: null, stop: null, hold: null, guard: null, cycleStance: null, researchUpgrade: null, snapToBase: null } }),
   surrender: () => {
     const s = get()
     resetWinStreak()


### PR DESCRIPTION
## Summary
- Adds a **"⌂ HOME"** button to the top control bar — centers camera on the player's home base
- Previously keyboard-only (`C` key), inaccessible on touchscreens
- Wires `gameActions.snapToBase` through the store to the existing `snapToBase()` method (which was already implemented for keyboard use)
- Matches the 44px minimum tap target height and consistent styling

## Why it matters (session length metric)
After pinch-zooming into a battle or panning to an outpost, mobile players have no way to quickly find their base again. They have to manually drag and zoom until they locate it — breaking game flow. One-tap return to base restores the rhythm and keeps sessions moving.

## Test plan
- [ ] "⌂ HOME" button appears in top control bar during gameplay
- [ ] Tapping it centers camera on player's base with "⌂ Home" notification
- [ ] Keyboard shortcut `C` still works as before
- [ ] Button not shown on menu/defeat/victory screen (guarded by `gameActions?.snapToBase`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)