### PR TITLE
feat(speck-wars): Snap to Battle (⚔ FIGHT) button in HUD for mobile

### DIFF
--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -550,6 +550,31 @@ export function HUD() {
             </button>
           )
         })()}
+        {/* Snap to battle button — mobile: jump camera to where the fight is (V key) */}
+        {gameActions?.snapToAction && (
+          <button
+            onClick={() => gameActions.snapToAction?.()}
+            title="[V] Snap camera to active battle"
+            aria-label="Snap camera to battle"
+            style={{
+              pointerEvents: 'auto',
+              padding: '8px 12px',
+              fontSize: 12,
+              cursor: 'pointer',
+              background: 'rgba(255,80,80,0.1)',
+              border: '1px solid rgba(255,80,80,0.35)',
+              borderRadius: 4,
+              color: 'rgba(255,120,80,0.9)',
+              letterSpacing: 0.5,
+              lineHeight: 1.3,
+              textAlign: 'center',
+              minHeight: 44,
+            }}
+          >
+            <div style={{ fontWeight: 700 }}>⚔ FIGHT</div>
+            <div style={{ fontSize: 8, opacity: 0.7 }}>V</div>
+          </button>
+        )}
         <button
           onClick={() => setShowHelp(h => !h)}
           title="? — show controls"

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -291,6 +291,7 @@ export class GameInstance {
       researchUpgrade: (buildingId: string, upgrade: 'carapace' | 'blades' | 'afterburners') => {
         this.sim.inputQueue.push({ type: 'RESEARCH_UPGRADE', ownerId: 'player', buildingId, upgrade })
       },
+      snapToAction: () => this.snapToAction(),
     })
     // Cinematic intro: start zoomed out to show full world
     const W = this.canvas.clientWidth

--- a/src/app/speck-wars/store.ts
+++ b/src/app/speck-wars/store.ts
@@ -67,8 +67,8 @@ interface SpeckWarsStore {
   setAiPersonality: (p: AIPersonality) => void
   fogEnabled: boolean
   setFogEnabled: (v: boolean) => void
-  gameActions: { defend: (() => void) | null; advance: (() => void) | null; rush: (() => void) | null; clearRally: (() => void) | null; surge: (() => void) | null; rally: ((x: number, y: number) => void) | null; sacrifice: (() => void) | null; setSpawnType: ((type: 'basic' | 'heavy' | 'scout') => void) | null; buildTurret?: (() => void) | null; panCamera: ((x: number, y: number) => void) | null; stop: (() => void) | null; hold: (() => void) | null; guard: (() => void) | null; cycleStance: (() => void) | null; researchUpgrade?: ((buildingId: string, upgrade: 'carapace' | 'blades' | 'afterburners') => void) | null }
-  setGameActions: (actions: { defend: () => void; advance: () => void; rush: () => void; clearRally: () => void; surge: () => void; rally: (x: number, y: number) => void; sacrifice: () => void; setSpawnType: (type: 'basic' | 'heavy' | 'scout') => void; buildTurret?: () => void; panCamera: (x: number, y: number) => void; stop: () => void; hold: () => void; guard: () => void; cycleStance: () => void; researchUpgrade?: (buildingId: string, upgrade: 'carapace' | 'blades' | 'afterburners') => void } | null) => void
+  gameActions: { defend: (() => void) | null; advance: (() => void) | null; rush: (() => void) | null; clearRally: (() => void) | null; surge: (() => void) | null; rally: ((x: number, y: number) => void) | null; sacrifice: (() => void) | null; setSpawnType: ((type: 'basic' | 'heavy' | 'scout') => void) | null; buildTurret?: (() => void) | null; panCamera: ((x: number, y: number) => void) | null; stop: (() => void) | null; hold: (() => void) | null; guard: (() => void) | null; cycleStance: (() => void) | null; researchUpgrade?: ((buildingId: string, upgrade: 'carapace' | 'blades' | 'afterburners') => void) | null; snapToAction?: (() => void) | null }
+  setGameActions: (actions: { defend: () => void; advance: () => void; rush: () => void; clearRally: () => void; surge: () => void; rally: (x: number, y: number) => void; sacrifice: () => void; setSpawnType: (type: 'basic' | 'heavy' | 'scout') => void; buildTurret?: () => void; panCamera: (x: number, y: number) => void; stop: () => void; hold: () => void; guard: () => void; cycleStance: () => void; researchUpgrade?: (buildingId: string, upgrade: 'carapace' | 'blades' | 'afterburners') => void; snapToAction?: () => void } | null) => void
   surrender: () => void
   resetGame: () => void
 }
@@ -144,8 +144,8 @@ export const useSpeckWarsStore = create<SpeckWarsStore>()((set, get) => ({
   setAiPersonality: p => set({ aiPersonality: p }),
   fogEnabled: false,
   setFogEnabled: v => set({ fogEnabled: v }),
-  gameActions: { defend: null, advance: null, rush: null, clearRally: null, surge: null, rally: null, sacrifice: null, setSpawnType: null, buildTurret: null, panCamera: null, stop: null, hold: null, guard: null, cycleStance: null, researchUpgrade: null },
-  setGameActions: (actions) => set({ gameActions: actions ?? { defend: null, advance: null, rush: null, clearRally: null, surge: null, rally: null, sacrifice: null, setSpawnType: null, buildTurret: null, panCamera: null, stop: null, hold: null, guard: null, cycleStance: null, researchUpgrade: null } }),
+  gameActions: { defend: null, advance: null, rush: null, clearRally: null, surge: null, rally: null, sacrifice: null, setSpawnType: null, buildTurret: null, panCamera: null, stop: null, hold: null, guard: null, cycleStance: null, researchUpgrade: null, snapToAction: null },
+  setGameActions: (actions) => set({ gameActions: actions ?? { defend: null, advance: null, rush: null, clearRally: null, surge: null, rally: null, sacrifice: null, setSpawnType: null, buildTurret: null, panCamera: null, stop: null, hold: null, guard: null, cycleStance: null, researchUpgrade: null, snapToAction: null } }),
   surrender: () => {
     const s = get()
     resetWinStreak()


### PR DESCRIPTION
## Summary
- Adds a **"⚔ FIGHT"** button to the top control bar — snaps camera to the active battle zone (centroid of recent deaths)
- Previously keyboard-only (`V` key), inaccessible on touchscreens
- Wires `gameActions.snapToAction` through the store to the existing `snapToAction()` method
- Styled in red/orange to visually indicate urgency — distinct from the teal HOME button

## Why it matters (session length metric)
After panning or zooming to spawn, players lose track of where the fight is happening. On desktop, `V` instantly snaps there. On mobile, players had to manually scan the minimap and drag the camera — a flow-breaking friction point. This button restores the battlefield-aware camera that makes Speck Wars feel responsive.

## Test plan
- [ ] "⚔ FIGHT" button appears in top control bar during gameplay
- [ ] Tapping it centers camera on the centroid of recent deaths with "⚔ Battle" notification
- [ ] Keyboard shortcut `V` still works as before
- [ ] Button not shown when `gameActions?.snapToAction` is null (menu/defeat/victory)
- [ ] If no recent battles (fresh game), button does nothing (matches existing behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)