### PR TITLE
fix(speck-wars): prevent browser from intercepting touch gestures on mobile

### DIFF
--- a/src/app/speck-wars/SpeckWarsGame.tsx
+++ b/src/app/speck-wars/SpeckWarsGame.tsx
@@ -120,6 +120,11 @@ function GameCanvas() {
     canvas.style.display = 'block'
     canvas.style.width = '100%'
     canvas.style.height = '100%'
+    // Prevent browser from intercepting touch gestures (context menu, text selection, scroll)
+    // so long-press attack-move and pinch-zoom work correctly on mobile.
+    canvas.style.touchAction = 'none'
+    canvas.style.userSelect = 'none'
+    ;(canvas.style as CSSStyleDeclaration & { webkitUserSelect: string }).webkitUserSelect = 'none'
     host.appendChild(canvas)
 
     const game = new GameInstance(canvas)

--- a/src/app/speck-wars/input/input-handler.ts
+++ b/src/app/speck-wars/input/input-handler.ts
@@ -116,7 +116,8 @@ export class InputHandler {
     this.canvas.addEventListener('wheel', this.onWheel, { passive: false })
     this.canvas.addEventListener('contextmenu', this.onContextMenu)
     // Touch support
-    this.canvas.addEventListener('touchstart', this.onTouchStart, { passive: true })
+    // passive: false required to allow preventDefault() in onTouchStart (blocks browser context menu)
+    this.canvas.addEventListener('touchstart', this.onTouchStart, { passive: false })
     window.addEventListener('touchmove', this.onTouchMove, { passive: false })
     window.addEventListener('touchend', this.onTouchEnd)
     window.addEventListener('keydown', this.onKeyDown)
@@ -268,6 +269,8 @@ export class InputHandler {
   }
 
   private onTouchStart = (e: TouchEvent) => {
+    // Prevent browser context menu and text selection on long-press (requires passive:false)
+    e.preventDefault()
     if (e.touches.length === 1) {
       this.isDragging = true
       this.lastPinchDist = 0


### PR DESCRIPTION
## Summary
- Switch `touchstart` listener from `passive:true` to `passive:false` so `e.preventDefault()` can be called in the handler, blocking the browser's native long-press context menu that was interfering with the attack-move gesture
- Add `e.preventDefault()` in `onTouchStart` to suppress context menus and text-selection popups
- Add `touch-action: none`, `user-select: none`, and `-webkit-user-select: none` to the canvas element so browser-level scroll/pan/zoom/text-selection are fully owned by the game engine

## Why this matters for mobile
Without these changes, a long-press on the game canvas (the attack-move gesture) would trigger a context menu on iOS Safari and Android Chrome, interrupting the action. The `passive:true` flag explicitly opts out of the ability to cancel touch events.

## Test plan
- [ ] Long-press on canvas in Safari/Chrome on iOS/Android — context menu should no longer appear
- [ ] Long-press fires attack-move correctly (red attack indicator appears)
- [ ] Single-tap still triggers rally (blue rally marker)
- [ ] Pinch-to-zoom still works correctly
- [ ] Desktop mouse interaction unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)