### PR TITLE
feat(speck-wars): haptic feedback for touch gestures on mobile

### DIFF
--- a/src/app/speck-wars/input/input-handler.ts
+++ b/src/app/speck-wars/input/input-handler.ts
@@ -286,6 +286,7 @@ export class InputHandler {
         const sy = this.lastY - rect.top
         if (sx >= 0 && sy >= 0 && sx <= rect.width && sy <= rect.height) {
           const world = screenToWorld(sx, sy, this.camera)
+          navigator.vibrate?.([30, 60, 30])  // double-pulse distinguishes attack-move from rally
           this.onAttackMove?.(world.x, world.y)
           this.longPressFired = true
         }
@@ -347,6 +348,7 @@ export class InputHandler {
         const sy = touch.clientY - rect.top
         if (sx >= 0 && sy >= 0 && sx <= rect.width && sy <= rect.height) {
           const world = screenToWorld(sx, sy, this.camera)
+          navigator.vibrate?.(18)  // short pulse confirms rally
           this.onRally(world.x, world.y)
         }
       }


### PR DESCRIPTION
Short vibration on tap-to-rally (18ms) and double-pulse on long-press attack-move (30ms+60ms+30ms) so touch actions have distinct tactile confirmation on supported mobile devices.

## Changes

1. **Rally confirmation** - Added 18ms vibration pulse in `onTouchEnd` before `onRally()` is called
2. **Attack-move distinction** - Added double-pulse pattern (30ms+60ms+30ms) in the longPressTimer callback before `onAttackMove()` is called

Uses optional chaining with `navigator.vibrate?.()` to remain compatible with TypeScript's type system while safely handling devices without vibration support.