### PR TITLE
fix(speck-wars): prevent pull-to-refresh and apply game-active on mobile

### DIFF
--- a/src/app/speck-wars/SpeckWarsGame.tsx
+++ b/src/app/speck-wars/SpeckWarsGame.tsx
@@ -157,6 +157,17 @@ function GameCanvas() {
 export function SpeckWarsGame() {
   const phase = useSpeckWarsStore(s => s.phase)
 
+  useEffect(() => {
+    document.body.classList.add('game-active')
+    document.documentElement.style.overscrollBehavior = 'none'
+    document.body.style.overscrollBehavior = 'none'
+    return () => {
+      document.body.classList.remove('game-active')
+      document.documentElement.style.overscrollBehavior = ''
+      document.body.style.overscrollBehavior = ''
+    }
+  }, [])
+
   return (
     <div style={{ position: 'relative', width: '100%', height: '100%' }}>
       <PhaseRouter>

--- a/src/app/speck-wars/input/input-handler.ts
+++ b/src/app/speck-wars/input/input-handler.ts
@@ -286,6 +286,7 @@ export class InputHandler {
         const sy = this.lastY - rect.top
         if (sx >= 0 && sy >= 0 && sx <= rect.width && sy <= rect.height) {
           const world = screenToWorld(sx, sy, this.camera)
+          navigator.vibrate?.([30, 60, 30])  // double-pulse distinguishes attack-move from rally
           this.onAttackMove?.(world.x, world.y)
           this.longPressFired = true
         }
@@ -347,6 +348,7 @@ export class InputHandler {
         const sy = touch.clientY - rect.top
         if (sx >= 0 && sy >= 0 && sx <= rect.width && sy <= rect.height) {
           const world = screenToWorld(sx, sy, this.camera)
+          navigator.vibrate?.(18)  // short pulse confirms rally
           this.onRally(world.x, world.y)
         }
       }


### PR DESCRIPTION
Applies the game-active CSS class so site chrome hides on mobile during play, and sets overscroll-behavior:none to prevent browser pull-to-refresh from interrupting gameplay.