### PR TITLE
feat(speck-wars): haptic feedback on victory and defeat

### DIFF
--- a/src/app/speck-wars/SpeckWarsGame.tsx
+++ b/src/app/speck-wars/SpeckWarsGame.tsx
@@ -157,6 +157,17 @@ function GameCanvas() {
 export function SpeckWarsGame() {
   const phase = useSpeckWarsStore(s => s.phase)
 
+  useEffect(() => {
+    document.body.classList.add('game-active')
+    document.documentElement.style.overscrollBehavior = 'none'
+    document.body.style.overscrollBehavior = 'none'
+    return () => {
+      document.body.classList.remove('game-active')
+      document.documentElement.style.overscrollBehavior = ''
+      document.body.style.overscrollBehavior = ''
+    }
+  }, [])
+
   return (
     <div style={{ position: 'relative', width: '100%', height: '100%' }}>
       <PhaseRouter>

--- a/src/app/speck-wars/components/phase-router.tsx
+++ b/src/app/speck-wars/components/phase-router.tsx
@@ -50,6 +50,14 @@ export function PhaseRouter({ children }: { children: React.ReactNode }) {
     return () => window.removeEventListener('keydown', onKey)
   }, [phase, resetGame, setPhase])
 
+  useEffect(() => {
+    if (phase === 'victory') {
+      navigator.vibrate?.([40, 80, 40, 80, 120])  // ascending triple-pulse: celebration
+    } else if (phase === 'defeat') {
+      navigator.vibrate?.([200, 60, 80])  // heavy thud then short pulse: loss
+    }
+  }, [phase])
+
   const difficulties: Array<{ key: 'easy' | 'medium' | 'hard' | 'very-hard'; label: string; color: string; desc: string }> = [
     { key: 'easy', label: 'Easy', color: '#44ff88', desc: 'slow AI, relaxed' },
     { key: 'medium', label: 'Medium', color: '#ffcc44', desc: 'standard challenge' },

--- a/src/app/speck-wars/input/input-handler.ts
+++ b/src/app/speck-wars/input/input-handler.ts
@@ -286,6 +286,7 @@ export class InputHandler {
         const sy = this.lastY - rect.top
         if (sx >= 0 && sy >= 0 && sx <= rect.width && sy <= rect.height) {
           const world = screenToWorld(sx, sy, this.camera)
+          navigator.vibrate?.([30, 60, 30])  // double-pulse distinguishes attack-move from rally
           this.onAttackMove?.(world.x, world.y)
           this.longPressFired = true
         }
@@ -347,6 +348,7 @@ export class InputHandler {
         const sy = touch.clientY - rect.top
         if (sx >= 0 && sy >= 0 && sx <= rect.width && sy <= rect.height) {
           const world = screenToWorld(sx, sy, this.camera)
+          navigator.vibrate?.(18)  // short pulse confirms rally
           this.onRally(world.x, world.y)
         }
       }


### PR DESCRIPTION
Victory triggers an ascending triple-pulse vibration pattern; defeat triggers a heavy thud followed by a short pulse. Both use navigator.vibrate with optional chaining so they silently do nothing on non-haptic devices.