### PR TITLE
feat(speck-wars): mobile-aware daily tips + HUD double-tap prevention

### DIFF
--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -584,7 +584,7 @@ export function HUD() {
             }}
           >
             <div style={{ fontWeight: 700 }}>⬡ ALL</div>
-            <div style={{ fontSize: 8, opacity: 0.7 }}>E</div>
+            {!isTouchDevice && <div style={{ fontSize: 8, opacity: 0.7 }}>E</div>}
           </button>
         )}
         {/* Snap to base button — essential for mobile (no keyboard shortcut) */}
@@ -609,7 +609,7 @@ export function HUD() {
             }}
           >
             <div style={{ fontWeight: 700 }}>⌂ HOME</div>
-            <div style={{ fontSize: 8, opacity: 0.7 }}>C</div>
+            {!isTouchDevice && <div style={{ fontSize: 8, opacity: 0.7 }}>C</div>}
           </button>
         )}
         {/* Snap to battle button — mobile: jump camera to where the fight is (V key) */}
@@ -634,7 +634,7 @@ export function HUD() {
             }}
           >
             <div style={{ fontWeight: 700 }}>⚔ FIGHT</div>
-            <div style={{ fontSize: 8, opacity: 0.7 }}>V</div>
+            {!isTouchDevice && <div style={{ fontSize: 8, opacity: 0.7 }}>V</div>}
           </button>
         )}
         <button
@@ -1307,15 +1307,15 @@ export function HUD() {
                     }}
                   >
                     {label}
-                    <span style={{ color: '#888', fontSize: 10 }}>[{key}]</span>
+                    {!isTouchDevice && <span style={{ color: '#888', fontSize: 10 }}>[{key}]</span>}
                   </button>
                 ))}
               </div>
             )}
             {/* Touch gesture hint */}
-            <div style={{ marginTop: 6, fontSize: 11, color: '#aaa', letterSpacing: 0.3, textAlign: 'center' }}>
+            {isTouchDevice && <div style={{ marginTop: 6, fontSize: 11, color: '#aaa', letterSpacing: 0.3, textAlign: 'center' }}>
               Tap: rally &bull; Long-press: attack-move
-            </div>
+            </div>}
           </div>
         </div>
       )}
@@ -1330,7 +1330,7 @@ export function HUD() {
           {/* Stance indicator */}
           <div style={{ fontSize: 11, letterSpacing: 1.5, opacity: 0.8, color: stance === 'aggressive' ? '#ff4f7b' : stance === 'hold' ? '#aaaaaa' : '#4af7c4', textAlign: 'right' }}>
             {stance === 'aggressive' ? 'AGGRO' : stance === 'hold' ? 'HOLD' : 'DEF'}
-            <span style={{ opacity: 0.5, marginLeft: 4 }}>[Z]</span>
+            {!isTouchDevice && <span style={{ opacity: 0.5, marginLeft: 4 }}>[Z]</span>}
           </div>
           <div style={{
             display: 'flex', gap: 6,

--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -65,6 +65,7 @@ export function HUD() {
     <div style={{
       position: 'absolute', inset: 0, pointerEvents: 'none',
       fontFamily: 'monospace', fontSize: 13, color: '#fff',
+      touchAction: 'manipulation',
     }}>
       <style>{`
         @keyframes pulse-red {

--- a/src/app/speck-wars/components/phase-router.tsx
+++ b/src/app/speck-wars/components/phase-router.tsx
@@ -276,7 +276,22 @@ export function PhaseRouter({ children }: { children: React.ReactNode }) {
         )}
         {/* Daily tip */}
         {(() => {
-          const tips = [
+          const tips = isTouchDevice ? [
+            'Capture outposts to boost your production.',
+            'Scouts auto-target outposts — tap the Scout spawn button (3rd) for fast flanking.',
+            'Veterans deal +20% damage after 3 kills. Protect them!',
+            'Fortify outposts by holding them 30s for a combat bonus.',
+            'Tap ★ SURGE for 2× production 8s — use it before big pushes.',
+            'Tap canvas to rally · long-press canvas to attack-move (aggressive advance).',
+            'Rally Cry: base below 25% HP activates 1.5× spawn automatically.',
+            'Heavy specks deal 2× damage but produce 2× slower.',
+            'Tap ⚔ FIGHT to snap the camera to where the fighting is happening.',
+            'Tap ? in-game to see all touch controls.',
+            'Tap ⬡ ALL to select all your specks, then tap canvas to rally them together.',
+            'Long-press canvas then lift — specks fight enemies on the way (attack-move).',
+            'Tap Hold in the unit panel to make selected specks defend a position.',
+            'Elite specks (6+ kills) get a white diamond ring and deal +30% damage.',
+          ] : [
             'Capture outposts to boost your production.',
             'Scouts (3) auto-target outposts — fast but fragile.',
             'Veterans deal +20% damage after 3 kills. Protect them!',
@@ -520,13 +535,21 @@ export function PhaseRouter({ children }: { children: React.ReactNode }) {
           } else if (won && difficulty !== 'very-hard' && stars === 3) {
             tip = `Perfect stars on ${diffLabel}! Ready to try ${nextDiff?.label ?? 'the next level'}?`
           } else if (!won && kills < 30) {
-            tip = 'Tip: Scouts are fast and great for outpost rushes — press 3 to switch spawn type.'
+            tip = isTouchDevice
+              ? 'Tip: Scouts are fast for outpost rushes — tap the 3rd spawn button (dart icon).'
+              : 'Tip: Scouts are fast and great for outpost rushes — press 3 to switch spawn type.'
           } else if (!won && eff < 0.4) {
-            tip = 'Tip: Heavy specks deal 2× damage — switch with key 2 during big fights.'
+            tip = isTouchDevice
+              ? 'Tip: Heavy specks deal 2× damage — switch to Heavy spawn during big fights.'
+              : 'Tip: Heavy specks deal 2× damage — switch with key 2 during big fights.'
           } else if (!won && elapsedMs > 300000) {
-            tip = 'Tip: Press Q for Surge — doubles production for 8s. Use it when you\'re behind!'
+            tip = isTouchDevice
+              ? 'Tip: Tap ★ SURGE for 2× production 8s. Use it when you\'re behind!'
+              : 'Tip: Press Q for Surge — doubles production for 8s. Use it when you\'re behind!'
           } else if (!won) {
-            tip = 'Tip: Press F to sacrifice 10 specks and repair your base when HP is critical.'
+            tip = isTouchDevice
+              ? 'Tip: Tap 🔧 SACR to sacrifice 10 specks and repair your base when HP is critical.'
+              : 'Tip: Press F to sacrifice 10 specks and repair your base when HP is critical.'
           } else if (won && modifier === 'siege') {
             tip = '⬡ Siege modifier won — outposts were twice as hard to capture. Nice patience!'
           }


### PR DESCRIPTION
## Summary
- Add `touch-action: manipulation` to the HUD root div so mobile buttons don't trigger browser double-tap zoom, while single-tap and pinch-zoom still work naturally
- Daily tips on menu screen now show touch-specific wording on touch devices: button names instead of keyboard keys (★ SURGE, ⚔ FIGHT, ⬡ ALL instead of Q, V, E)
- Post-game tactical tips also adapt: Scout spawn button instead of key 3, SURGE button instead of Q, SACR button instead of F

## Why
Keyboard shortcut tips like "press 3", "press Q", "press V" are actively confusing on mobile. Touch users now get tips that match their actual controls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)