### PR TITLE
feat(speck-wars): taller HP bars on mobile + camera resize on orientation change

### DIFF
--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -177,7 +177,7 @@ export function HUD() {
       {phase === 'playing' && (
         <div style={{
           position: 'absolute', top: 0, left: 0, right: 0,
-          display: 'flex', height: 3, pointerEvents: 'none',
+          display: 'flex', height: isTouchDevice ? 6 : 3, pointerEvents: 'none',
         }}>
           {/* Player bar: left edge, grows right */}
           <div style={{ flex: 1, background: 'rgba(0,0,0,0.4)', position: 'relative', overflow: 'hidden' }}>

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -62,6 +62,7 @@ export class GameInstance {
   private pendingBuild: string | null = null  // building type ID awaiting placement click
   private killFeedKillAt = 0    // last time we pushed a kill entry
   private killFeedLossAt = 0    // last time we pushed a loss entry
+  private onResize: (() => void) | null = null
 
   constructor(canvas: HTMLCanvasElement) {
     this.canvas = canvas
@@ -99,6 +100,8 @@ export class GameInstance {
   async start() {
     console.log('GameInstance started')
     document.addEventListener('visibilitychange', this.onVisibilityChange)
+    this.onResize = () => { clampCamera(this.camera, this.canvas.clientWidth, this.canvas.clientHeight) }
+    window.addEventListener('resize', this.onResize)
     await this.renderer.init(this.canvas)
     // destroy() ran while the renderer was initialising (React StrictMode mounts, tears
     // down and remounts the canvas effect). Bail out rather than wiring up input, the
@@ -821,6 +824,7 @@ export class GameInstance {
       this.rafId = null
     }
     document.removeEventListener('visibilitychange', this.onVisibilityChange)
+    if (this.onResize) window.removeEventListener('resize', this.onResize)
     this.renderer.destroy()
     this.inputHandler?.destroy()
     useSpeckWarsStore.getState().setGameActions(null)


### PR DESCRIPTION
## Summary
- HP bars at top edge now 6px tall on touch devices (was 3px) — dramatically more readable on small screens
- Added `window.addEventListener('resize', onResize)` so camera bounds re-clamp after orientation changes; prevents camera escaping world boundaries on mobile rotation

## Test plan
- [ ] Rotate phone during gameplay — camera should stay in bounds
- [ ] HP bars should be clearly visible on mobile viewport