### PR TITLE
feat(speck-wars): larger notifications on mobile + action buttons flex-wrap

### DIFF
--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -1225,7 +1225,7 @@ export function HUD() {
                 pointerEvents: 'auto',
               }}>
                 <div style={{ fontSize: 10, letterSpacing: 2, color: 'rgba(255,255,255,0.5)' }}>⚗ RESEARCH UPGRADE</div>
-                <div style={{ display: 'flex', gap: 6 }}>
+                <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap', justifyContent: 'center' }}>
                   {upgrades.map(u => (
                     <button key={u.id} onClick={() => gameActions?.researchUpgrade?.(hud.selectedBuilding!.id, u.id)} style={{
                       padding: '4px 10px', fontSize: 10, letterSpacing: 1,

--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -258,7 +258,7 @@ export function HUD() {
 
       {/* Mini-map — top right, below difficulty badge */}
       {hud && (() => {
-        const MINIMAP_SIZE = 160
+        const MINIMAP_SIZE = isTouchDevice ? 110 : 160
         const SCALE = MINIMAP_SIZE / 3000  // world→screen
         return (
           <div style={{
@@ -413,7 +413,7 @@ export function HUD() {
       {/* Kill feed — below minimap, top-right */}
       {phase === 'playing' && killFeed.length > 0 && (
         <div style={{
-          position: 'absolute', top: 250, right: 16,
+          position: 'absolute', top: isTouchDevice ? 210 : 250, right: 16,
           display: 'flex', flexDirection: 'column', gap: 3,
           pointerEvents: 'none',
           width: 140,

--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -893,7 +893,7 @@ export function HUD() {
             key={notification.message + notification.color}
             style={{
               color: notification.color,
-              fontSize: 13,
+              fontSize: isTouchDevice ? 15 : 13,
               fontWeight: 'bold',
               letterSpacing: 2,
               textShadow: `0 0 12px ${notification.color}`,
@@ -1380,7 +1380,7 @@ export function HUD() {
               : <span style={{ opacity: 0.5, marginLeft: 4 }}>[Z]</span>}
           </div>
           <div style={{
-            display: 'flex', gap: 6,
+            display: 'flex', gap: 6, flexWrap: 'wrap', justifyContent: 'flex-end',
           }}>
           <button
             onClick={() => gameActions.defend?.()}

--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -503,8 +503,8 @@ export function HUD() {
         >
           {speed}×
         </button>
-        {/* Spawn type selector — 3 direct buttons instead of cycle */}
-        {(['basic', 'heavy', 'scout'] as const).map((type, idx) => {
+        {/* Spawn type selector — hidden on touch (bottom-right panel has it) */}
+        {!isTouchDevice && (['basic', 'heavy', 'scout'] as const).map((type, idx) => {
           const active = spawnMode === type
           const color = type === 'heavy' ? '#ffa032' : type === 'scout' ? '#50c8ff' : '#ffffff'
           const subtitle = type === 'heavy' ? 'slow · siege' : type === 'scout' ? 'fast · outpost' : 'balanced'
@@ -1364,10 +1364,20 @@ export function HUD() {
               })}
             </div>
           )}
-          {/* Stance indicator */}
-          <div style={{ fontSize: 11, letterSpacing: 1.5, opacity: 0.8, color: stance === 'aggressive' ? '#ff4f7b' : stance === 'hold' ? '#aaaaaa' : '#4af7c4', textAlign: 'right' }}>
+          {/* Stance indicator — tappable on mobile to cycle stance */}
+          <div
+            onClick={isTouchDevice ? (gameActions?.cycleStance ?? undefined) : undefined}
+            style={{
+              fontSize: 11, letterSpacing: 1.5, opacity: 0.8,
+              color: stance === 'aggressive' ? '#ff4f7b' : stance === 'hold' ? '#aaaaaa' : '#4af7c4',
+              textAlign: 'right',
+              ...(isTouchDevice ? { cursor: 'pointer', padding: '4px 6px', minHeight: 32, display: 'flex', alignItems: 'center' } : {}),
+            }}
+          >
             {stance === 'aggressive' ? 'AGGRO' : stance === 'hold' ? 'HOLD' : 'DEF'}
-            {!isTouchDevice && <span style={{ opacity: 0.5, marginLeft: 4 }}>[Z]</span>}
+            {isTouchDevice
+              ? <span style={{ opacity: 0.4, marginLeft: 4, fontSize: 9 }}>tap</span>
+              : <span style={{ opacity: 0.5, marginLeft: 4 }}>[Z]</span>}
           </div>
           <div style={{
             display: 'flex', gap: 6,

--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -177,7 +177,7 @@ export function HUD() {
       {phase === 'playing' && (
         <div style={{
           position: 'absolute', top: 0, left: 0, right: 0,
-          display: 'flex', height: 3, pointerEvents: 'none',
+          display: 'flex', height: isTouchDevice ? 6 : 3, pointerEvents: 'none',
         }}>
           {/* Player bar: left edge, grows right */}
           <div style={{ flex: 1, background: 'rgba(0,0,0,0.4)', position: 'relative', overflow: 'hidden' }}>

--- a/src/app/speck-wars/components/phase-router.tsx
+++ b/src/app/speck-wars/components/phase-router.tsx
@@ -377,10 +377,10 @@ export function PhaseRouter({ children }: { children: React.ReactNode }) {
     return (
       <div style={{
         display: 'flex', flexDirection: 'column', alignItems: 'center',
-        justifyContent: 'center', height: '100%', gap: 20,
-        fontFamily: 'monospace', overflowY: 'auto', padding: '16px 0',
+        justifyContent: isTouchDevice ? 'flex-start' : 'center', height: '100%', gap: isTouchDevice ? 10 : 20,
+        fontFamily: 'monospace', overflowY: 'auto', padding: isTouchDevice ? '12px 0 80px' : '16px 0',
       }}>
-        <h1 style={{ color: accentColor, fontSize: 64, margin: 0, letterSpacing: 4 }}>
+        <h1 style={{ color: accentColor, fontSize: isTouchDevice ? 44 : 64, margin: 0, letterSpacing: 4 }}>
           {won ? 'VICTORY' : 'DEFEATED'}
         </h1>
         {victoryType && (
@@ -601,7 +601,16 @@ export function PhaseRouter({ children }: { children: React.ReactNode }) {
           </div>
         )}
 
-        <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 6, marginTop: 8 }}>
+        <div style={{
+          display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 6, marginTop: 8,
+          ...(isTouchDevice ? {
+            position: 'sticky', bottom: 0,
+            background: 'rgba(0,0,0,0.92)',
+            padding: '10px 0 12px',
+            width: '100%',
+            borderTop: '1px solid rgba(255,255,255,0.08)',
+          } : {}),
+        }}>
           <div style={{ display: 'flex', gap: 12 }}>
           <button
             onClick={resetGame}

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -62,6 +62,7 @@ export class GameInstance {
   private pendingBuild: string | null = null  // building type ID awaiting placement click
   private killFeedKillAt = 0    // last time we pushed a kill entry
   private killFeedLossAt = 0    // last time we pushed a loss entry
+  private onResize: (() => void) | null = null
 
   constructor(canvas: HTMLCanvasElement) {
     this.canvas = canvas
@@ -99,6 +100,8 @@ export class GameInstance {
   async start() {
     console.log('GameInstance started')
     document.addEventListener('visibilitychange', this.onVisibilityChange)
+    this.onResize = () => { clampCamera(this.camera, this.canvas.clientWidth, this.canvas.clientHeight) }
+    window.addEventListener('resize', this.onResize)
     await this.renderer.init(this.canvas)
     // destroy() ran while the renderer was initialising (React StrictMode mounts, tears
     // down and remounts the canvas effect). Bail out rather than wiring up input, the
@@ -821,6 +824,7 @@ export class GameInstance {
       this.rafId = null
     }
     document.removeEventListener('visibilitychange', this.onVisibilityChange)
+    if (this.onResize) window.removeEventListener('resize', this.onResize)
     this.renderer.destroy()
     this.inputHandler?.destroy()
     useSpeckWarsStore.getState().setGameActions(null)

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -144,6 +144,7 @@ export class GameInstance {
           const btype = BUILDING_TYPES[building.typeId]
           const r = btype?.size ?? 20
           if (Math.hypot(wx - building.x, wy - building.y) <= r + 20) {
+            navigator.vibrate?.(10)
             this.sim.inputQueue.push({ type: 'SELECT_BUILDING', ownerId: 'player', buildingId: building.id })
             return
           }
@@ -527,6 +528,7 @@ export class GameInstance {
               const count = this.recentKillTimes.length
               const comboColors: Record<number, string> = { 3: '#4af7c4', 5: '#ffd700', 8: '#ff8844', 12: '#cc00ff' }
               const color = count >= 12 ? '#cc00ff' : count >= 8 ? '#ff8844' : count >= 5 ? '#ffd700' : '#4af7c4'
+              navigator.vibrate?.(count >= 8 ? [30, 30, 30] : 25)
               this.notify(`⚡ COMBO ×${count}!`, color, 1500)
             }
             const k = useSpeckWarsStore.getState().kills
@@ -569,12 +571,15 @@ export class GameInstance {
             if (now - this.lastStreakNotifiedAt > 4000) {
               if (killCount >= 20) {
                 this.lastStreakNotifiedAt = now
+                navigator.vibrate?.([25, 30, 40, 30, 25])
                 this.notify('⚡ UNSTOPPABLE! ×' + killCount, '#ffffff')
               } else if (killCount >= 10) {
                 this.lastStreakNotifiedAt = now
+                navigator.vibrate?.([25, 30, 25])
                 this.notify('⚡ RAMPAGE! ×' + killCount, '#ffd700')
               } else if (killCount >= 5) {
                 this.lastStreakNotifiedAt = now
+                navigator.vibrate?.(25)
                 this.notify('⚡ KILLING SPREE ×' + killCount, '#ff8844')
               }
             }


### PR DESCRIPTION
Notification text 13→15px on touch devices for readability. Bottom-right action buttons wrap on narrow phones (iPhone SE 320px) instead of overflowing off-screen.