### PR TITLE
fix(speck-wars): outpost dots clear top bar buttons on mobile

### DIFF
--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -240,7 +240,7 @@ export function HUD() {
               `}</style>
             )}
             <div style={{
-              position: 'absolute', top: 240, right: 16,
+              position: 'absolute', top: isTouchDevice ? 175 : 240, right: 16,
               padding: '4px 10px',
               background: inProgress ? 'rgba(255,80,80,0.25)' : 'rgba(255,140,0,0.15)',
               border: `1px solid ${inProgress ? 'rgba(255,80,80,0.6)' : 'rgba(255,140,0,0.5)'}`,

--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -780,7 +780,7 @@ export function HUD() {
               `}</style>
             )}
             <div style={{
-              position: 'absolute', top: 48, left: 0, right: 0,
+              position: 'absolute', top: isTouchDevice ? 68 : 48, left: 0, right: 0,
               display: 'flex', justifyContent: 'center', alignItems: 'center', gap: 8,
             }}>
               <span style={{ fontSize: 10, letterSpacing: 1, opacity: 0.5, marginRight: 4 }}>

--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -1257,7 +1257,7 @@ export function HUD() {
             pointerEvents: (hud?.selectedSpeckCount ?? 0) > 0 ? 'auto' : 'none',
           }}>
             <div style={{
-              fontSize: 9, letterSpacing: 2, color: '#ffffff', opacity: 0.9, marginBottom: 5,
+              fontSize: isTouchDevice ? 11 : 9, letterSpacing: 2, color: '#ffffff', opacity: 0.9, marginBottom: 5,
             }}>
               SELECTED {hud?.selectedSpeckCount ?? 0}
             </div>
@@ -1266,7 +1266,7 @@ export function HUD() {
               .map(([typeId, count]) => (
                 <div key={typeId} style={{
                   display: 'flex', alignItems: 'center', gap: 6,
-                  fontSize: 9, color: 'rgba(255,255,255,0.7)', marginBottom: 2,
+                  fontSize: isTouchDevice ? 11 : 9, color: 'rgba(255,255,255,0.7)', marginBottom: 2,
                 }}>
                   <span style={{
                     display: 'inline-block', width: 7, height: 7, flexShrink: 0,
@@ -1282,7 +1282,7 @@ export function HUD() {
               ))
             }
             {hud?.selectedComposition && (hud.selectedComposition.veteranCount > 0 || hud.selectedComposition.eliteCount > 0 || hud.selectedComposition.legendCount > 0) && (
-              <div style={{ fontSize: 8, color: 'rgba(255,215,0,0.7)', marginTop: 3, letterSpacing: 1 }}>
+              <div style={{ fontSize: isTouchDevice ? 10 : 8, color: 'rgba(255,215,0,0.7)', marginTop: 3, letterSpacing: 1 }}>
                 {hud.selectedComposition.legendCount > 0 && <span style={{ color: '#cc44ff' }}>{`✦✦ ${hud.selectedComposition.legendCount} legend  `}</span>}
                 {hud.selectedComposition.eliteCount > 0 && `✦ ${hud.selectedComposition.eliteCount} elite  `}
                 {hud.selectedComposition.veteranCount > 0 && `⭐ ${hud.selectedComposition.veteranCount} vet`}

--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -211,11 +211,11 @@ export function HUD() {
             <span style={{ color, opacity: 0.5, border: `1px solid ${color}`, borderRadius: 3, padding: '2px 6px' }}>
               {difficulty.toUpperCase()}
             </span>
-            <span style={{ color: 'rgba(255,255,255,0.18)', fontSize: 8, letterSpacing: 0.5 }}>
+            <span style={{ color: 'rgba(255,255,255,0.18)', fontSize: isTouchDevice ? 10 : 8, letterSpacing: 0.5 }}>
               DAILY MAP · {new Date().toLocaleDateString('en-US', { month: 'short', day: 'numeric' }).toUpperCase()}
             </span>
             {hud?.dailyModifier && hud.dailyModifier !== 'standard' && (
-              <span style={{ color: '#ffd700', fontSize: 8, letterSpacing: 0.5, opacity: 0.7, textAlign: 'right' }}>
+              <span style={{ color: '#ffd700', fontSize: isTouchDevice ? 10 : 8, letterSpacing: 0.5, opacity: 0.7, textAlign: 'right' }}>
                 {hud.dailyModifier === 'bulwark' ? '⚔ BULWARK' : hud.dailyModifier === 'blitz' ? '⚡ BLITZ' : '🏰 SIEGE'}
               </span>
             )}


### PR DESCRIPTION
Outpost ownership dots moved from top:48 to top:68 on touch devices — top bar buttons extend to ~56px so dots were partially obscured.