### PR TITLE
feat(speck-wars): map obstacles — terrain walls with wall-slide collision

### DIFF
--- a/src/app/speck-wars/domain/simulation/create-sim.ts
+++ b/src/app/speck-wars/domain/simulation/create-sim.ts
@@ -1,10 +1,31 @@
-import type { SimulationState, Player, BuildingEntity } from '../types'
+import type { SimulationState, Player, BuildingEntity, WallObstacle } from '../types'
 import { PLAYER_BASE_X, PLAYER_BASE_Y, AI_BASE_X, AI_BASE_Y, PLAYER_COLOR, AI_COLOR, BASE_HP, MAX_SPECKS, NEUTRAL_COLOR, MAP_LAYOUTS, DAILY_MODIFIER_POOL } from '../constants'
 import type { DailyModifier } from '../constants'
 import { SpatialGrid } from './spatial-grid'
 import { mulberry32 } from './prng'
 import type { Difficulty } from '../../store'
 import { spawnCampDefenders, spawnCommander } from './spawner'
+
+function generateObstacles(rng: () => number): WallObstacle[] {
+  const obstacles: WallObstacle[] = []
+  const count = 2 + Math.floor(rng() * 3)  // 2, 3, or 4
+  const BASE_A = { x: 600, y: 1500 }
+  const BASE_B = { x: 2400, y: 1500 }
+  const SAFE_RADIUS = 780  // keep obstacles away from bases
+
+  for (let attempt = 0; obstacles.length < count; attempt++) {
+    if (attempt > 60) break
+    const cx = 900 + rng() * 1200   // mid-field: 900–2100
+    const cy = 750 + rng() * 1500   // mid-field: 750–2250
+    const distA = Math.hypot(cx - BASE_A.x, cy - BASE_A.y)
+    const distB = Math.hypot(cx - BASE_B.x, cy - BASE_B.y)
+    if (distA < SAFE_RADIUS || distB < SAFE_RADIUS) continue
+    const w = 80 + rng() * 140     // 80–220px wide
+    const h = 60 + rng() * 100     // 60–160px tall
+    obstacles.push({ x: cx - w / 2, y: cy - h / 2, w, h })
+  }
+  return obstacles
+}
 
 const aiSpawnInterval: Record<Difficulty, number> = {
   easy: 2000,
@@ -99,9 +120,12 @@ export function createSim(seed: number = Date.now(), difficulty: Difficulty = 'm
     }
   }
 
-  // Pick daily modifier — LAST RNG call so it doesn't shift existing map layout or jitter
+  // Pick daily modifier — after layout and jitter RNG calls
   const modifierIndex = Math.floor(rng() * DAILY_MODIFIER_POOL.length)
   const dailyModifier: DailyModifier = DAILY_MODIFIER_POOL[modifierIndex]
+
+  // Generate obstacles AFTER modifier pick to avoid shifting existing RNG sequence
+  const obstacles = generateObstacles(rng)
 
   // Apply static modifier effects
   if (dailyModifier === 'bulwark') {
@@ -144,6 +168,7 @@ export function createSim(seed: number = Date.now(), difficulty: Difficulty = 'm
     waveCountdown: null,
     waveInProgress: false,
     sacrificeCooldown: 0,
+    obstacles,
   }
 
   // Spawn initial defenders for each creep camp

--- a/src/app/speck-wars/domain/simulation/movement.ts
+++ b/src/app/speck-wars/domain/simulation/movement.ts
@@ -1,4 +1,4 @@
-import type { SimulationState } from '../types'
+import type { SimulationState, WallObstacle } from '../types'
 import { SPECK_TYPES } from '../config/speck-types'
 import { BUILDING_TYPES } from '../config/building-types'
 import { WORLD_WIDTH, WORLD_HEIGHT, OUTPOST_AURA_RADIUS, CREEP_CAMP_ZONE_RADIUS } from '../constants'
@@ -6,7 +6,7 @@ import { WORLD_WIDTH, WORLD_HEIGHT, OUTPOST_AURA_RADIUS, CREEP_CAMP_ZONE_RADIUS 
 function resolveWallCollisions(
   nx: number, ny: number,
   vx: number, vy: number,
-  obstacles: import('../types').WallObstacle[],
+  obstacles: WallObstacle[],
   radius: number
 ): { x: number; y: number; vx: number; vy: number } {
   let rx = nx, ry = ny, rvx = vx, rvy = vy

--- a/src/app/speck-wars/domain/simulation/movement.ts
+++ b/src/app/speck-wars/domain/simulation/movement.ts
@@ -3,6 +3,39 @@ import { SPECK_TYPES } from '../config/speck-types'
 import { BUILDING_TYPES } from '../config/building-types'
 import { WORLD_WIDTH, WORLD_HEIGHT, OUTPOST_AURA_RADIUS, CREEP_CAMP_ZONE_RADIUS } from '../constants'
 
+function resolveWallCollisions(
+  nx: number, ny: number,
+  vx: number, vy: number,
+  obstacles: import('../types').WallObstacle[],
+  radius: number
+): { x: number; y: number; vx: number; vy: number } {
+  let rx = nx, ry = ny, rvx = vx, rvy = vy
+  for (const obs of obstacles) {
+    const left = obs.x - radius
+    const right = obs.x + obs.w + radius
+    const top = obs.y - radius
+    const bottom = obs.y + obs.h + radius
+    if (rx < left || rx > right || ry < top || ry > bottom) continue
+    // Find minimum penetration axis
+    const dLeft   = rx - left
+    const dRight  = right - rx
+    const dTop    = ry - top
+    const dBottom = bottom - ry
+    const minH = Math.min(dLeft, dRight)
+    const minV = Math.min(dTop, dBottom)
+    if (minH <= minV) {
+      // Push out horizontally, kill horizontal velocity
+      rx += dLeft < dRight ? -dLeft : dRight
+      rvx = 0
+    } else {
+      // Push out vertically, kill vertical velocity
+      ry += dTop < dBottom ? -dTop : dBottom
+      rvy = 0
+    }
+  }
+  return { x: rx, y: ry, vx: rvx, vy: rvy }
+}
+
 const SEPARATION_RADIUS = 8   // px — keep specks this far apart
 const SEPARATION_FORCE = 120  // strength of push-apart
 const AURA_SPEED_MULT = 1.35  // 35% speed boost inside outpost aura
@@ -58,8 +91,15 @@ export function moveSpecks(sim: SimulationState, dt: number) {
           const dy = nearestBuilding.y - speckY[i]
           speckVx[i] = (dx / dist) * stype.speed * speedMult * afterburnersMult * chargeMult
           speckVy[i] = (dy / dist) * stype.speed * speedMult * afterburnersMult * chargeMult
-          speckX[i] = Math.max(0, Math.min(WORLD_WIDTH, speckX[i] + speckVx[i] * dtSec))
-          speckY[i] = Math.max(0, Math.min(WORLD_HEIGHT, speckY[i] + speckVy[i] * dtSec))
+          {
+            const nx = Math.max(0, Math.min(WORLD_WIDTH, speckX[i] + speckVx[i] * dtSec))
+            const ny = Math.max(0, Math.min(WORLD_HEIGHT, speckY[i] + speckVy[i] * dtSec))
+            const r = resolveWallCollisions(nx, ny, speckVx[i], speckVy[i], sim.obstacles, 4)
+            speckX[i] = r.x
+            speckY[i] = r.y
+            speckVx[i] = r.vx
+            speckVy[i] = r.vy
+          }
         }
       }
       continue
@@ -155,8 +195,15 @@ export function moveSpecks(sim: SimulationState, dt: number) {
             if (rdist > 0) {
               speckVx[i] = (rdx / rdist) * stype.speed
               speckVy[i] = (rdy / rdist) * stype.speed
-              speckX[i] = Math.max(0, Math.min(WORLD_WIDTH, speckX[i] + speckVx[i] * dtSec))
-              speckY[i] = Math.max(0, Math.min(WORLD_HEIGHT, speckY[i] + speckVy[i] * dtSec))
+              {
+                const nx = Math.max(0, Math.min(WORLD_WIDTH, speckX[i] + speckVx[i] * dtSec))
+                const ny = Math.max(0, Math.min(WORLD_HEIGHT, speckY[i] + speckVy[i] * dtSec))
+                const r = resolveWallCollisions(nx, ny, speckVx[i], speckVy[i], sim.obstacles, 4)
+                speckX[i] = r.x
+                speckY[i] = r.y
+                speckVx[i] = r.vx
+                speckVy[i] = r.vy
+              }
             }
             continue
           }
@@ -233,7 +280,14 @@ export function moveSpecks(sim: SimulationState, dt: number) {
     speckVy[i] = ay
 
     // Integrate position
-    speckX[i] = Math.max(0, Math.min(WORLD_WIDTH, speckX[i] + speckVx[i] * dtSec))
-    speckY[i] = Math.max(0, Math.min(WORLD_HEIGHT, speckY[i] + speckVy[i] * dtSec))
+    {
+      const nx = Math.max(0, Math.min(WORLD_WIDTH, speckX[i] + speckVx[i] * dtSec))
+      const ny = Math.max(0, Math.min(WORLD_HEIGHT, speckY[i] + speckVy[i] * dtSec))
+      const r = resolveWallCollisions(nx, ny, speckVx[i], speckVy[i], sim.obstacles, 4)
+      speckX[i] = r.x
+      speckY[i] = r.y
+      speckVx[i] = r.vx
+      speckVy[i] = r.vy
+    }
   }
 }

--- a/src/app/speck-wars/domain/types.ts
+++ b/src/app/speck-wars/domain/types.ts
@@ -75,6 +75,13 @@ export interface Player {
   commanderRespawnMs?: number   // ms until commander respawns (undefined = alive or not spawned yet)
 }
 
+export interface WallObstacle {
+  x: number   // left edge (world px)
+  y: number   // top edge (world px)
+  w: number   // width
+  h: number   // height
+}
+
 // SOA (Structure of Arrays) for hot speck data — cache-friendly for tight loops
 export interface SimulationState {
   tick: number
@@ -107,6 +114,7 @@ export interface SimulationState {
   waveCountdown: number | null   // ms until next AI wave (null = waves disabled on this difficulty)
   waveInProgress: boolean        // true during the 15s wave assault
   sacrificeCooldown: number   // ms remaining before sacrifice can be used again, 0 = ready
+  obstacles: WallObstacle[]
 }
 
 export type InputEvent =

--- a/src/app/speck-wars/rendering/layers/building-layer.ts
+++ b/src/app/speck-wars/rendering/layers/building-layer.ts
@@ -421,6 +421,21 @@ export class BuildingLayer {
       }
     }
 
+    // Draw terrain wall obstacles
+    for (const obs of sim.obstacles) {
+      this.gfx.beginFill(0x3d3550, 0.9)
+      this.gfx.drawRect(obs.x, obs.y, obs.w, obs.h)
+      this.gfx.endFill()
+      this.gfx.lineStyle(2, 0x7766aa, 0.7)
+      this.gfx.drawRect(obs.x, obs.y, obs.w, obs.h)
+      this.gfx.lineStyle(0)
+      // Highlight ledge on top edge
+      this.gfx.lineStyle(1, 0xffffff, 0.15)
+      this.gfx.moveTo(obs.x + 3, obs.y + 3)
+      this.gfx.lineTo(obs.x + obs.w - 3, obs.y + 3)
+      this.gfx.lineStyle(0)
+    }
+
     // Draw placement ghost for pending build
     if (ghostBuild) {
       const btype = BUILDING_TYPES[ghostBuild.typeId]


### PR DESCRIPTION
## Summary
- 2–4 rectangular wall obstacles generated procedurally per daily seed in the mid-field zone (750px safe radius around both bases)
- Wall-slide collision: specks slide along wall surfaces instead of stopping dead or passing through
- Obstacles render as dark rock-colored rectangles with subtle edge highlights
- Collision applied at all 3 movement integration sites (main loop, retreating path, defender leash)

## Test plan
- [ ] Verify 2–4 obstacles appear in mid-field on game start
- [ ] Send specks into a wall — they should slide along it, not pass through
- [ ] Different seed → different obstacle placement
- [ ] No obstacles within ~800px of either base
- [ ] Performance acceptable with large armies (2–4 obstacles × N specks AABB checks)