### PR TITLE
feat(speck-wars): soft supply pressure system

### DIFF
--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -203,6 +203,54 @@ export function HUD() {
         </div>
       )}
 
+      {/* Supply bars — below HP bars, two-side player/enemy */}
+      {phase === 'playing' && hud && (
+        <div style={{
+          position: 'absolute', top: isTouchDevice ? 6 : 3, left: 0, right: 0,
+          display: 'flex', height: 2, pointerEvents: 'none',
+        }}>
+          {(() => {
+            const supplyUsed = hud.players.player?.supplyUsed ?? 0
+            const supplyCap = hud.players.player?.supplyCap ?? 120
+            const SOFT_CAP = 60
+            const frac = Math.min(1, supplyUsed / supplyCap)
+            const color = supplyUsed >= supplyCap ? '#ff4f7b'
+              : supplyUsed >= SOFT_CAP ? '#ffaa44' : '#4af7c4'
+            return (
+              <div style={{ flex: 1, background: 'rgba(0,0,0,0.3)', position: 'relative', overflow: 'hidden' }}>
+                <div style={{
+                  position: 'absolute', top: 0, left: 0, bottom: 0,
+                  width: `${frac * 100}%`,
+                  background: color,
+                  transition: 'width 0.5s ease, background 0.3s ease',
+                  opacity: 0.7,
+                }} />
+              </div>
+            )
+          })()}
+          <div style={{ width: 2, background: 'rgba(0,0,0,0.6)' }} />
+          {(() => {
+            const supplyUsed = hud.players.ai?.supplyUsed ?? 0
+            const supplyCap = hud.players.ai?.supplyCap ?? 120
+            const SOFT_CAP = 60
+            const frac = Math.min(1, supplyUsed / supplyCap)
+            const color = supplyUsed >= supplyCap ? '#ff4f7b'
+              : supplyUsed >= SOFT_CAP ? '#ffaa44' : '#ff4f7b'
+            return (
+              <div style={{ flex: 1, background: 'rgba(0,0,0,0.3)', position: 'relative', overflow: 'hidden' }}>
+                <div style={{
+                  position: 'absolute', top: 0, right: 0, bottom: 0,
+                  width: `${frac * 100}%`,
+                  background: color,
+                  transition: 'width 0.5s ease, background 0.3s ease',
+                  opacity: 0.5,
+                }} />
+              </div>
+            )
+          })()}
+        </div>
+      )}
+
       {/* Difficulty badge — top right */}
       {(() => {
         const diffColors: Record<string, string> = { easy: '#44ff88', medium: '#ffcc44', hard: '#ff4f7b', 'very-hard': '#cc00ff' }
@@ -990,6 +1038,9 @@ export function HUD() {
           {hud && (() => {
             const playerSpecks = hud.players.player?.speckCount ?? 0
             const aiSpecks = hud.players.ai?.speckCount ?? 0
+            const playerSupply = hud.players.player?.supplyUsed ?? 0
+            const aiSupply = hud.players.ai?.supplyUsed ?? 0
+            const supplyCap = hud.players.player?.supplyCap ?? 120
             const playerBaseHpVal = hud.players.player?.buildingHp['building-player-base'] ?? 0
             const aiBaseHpVal = hud.players.ai?.buildingHp['building-ai-base'] ?? 0
             const playerOutpostCount = hud.players.player?.buildingCount
@@ -1035,6 +1086,12 @@ export function HUD() {
                 <span style={{ fontSize: 10, opacity: 0.7 }}>{fmtTypes(aiTypes)}</span>
                 <span style={{ fontSize: 10, opacity: 0.6 }}>~{playerProd.toFixed(1)}/s prod</span>
                 <span style={{ fontSize: 10, opacity: 0.6 }}>~{aiProd.toFixed(1)}/s prod</span>
+                <span style={{ fontSize: 10, color: playerSupply >= supplyCap ? '#ff4f7b' : playerSupply >= 60 ? '#ffaa44' : undefined }}>
+                  Supply: {Math.round(playerSupply)}/{supplyCap}
+                </span>
+                <span style={{ fontSize: 10, opacity: 0.5 }}>
+                  Supply: {Math.round(aiSupply)}/{supplyCap}
+                </span>
                 <span>Base: {Math.round(playerBaseHpVal)}HP</span>
                 <span>Base: {Math.round(aiBaseHpVal)}HP</span>
                 <span>Outposts: {playerOutpostCount}</span>
@@ -1340,6 +1397,25 @@ export function HUD() {
           display: 'flex', flexDirection: 'column', alignItems: 'flex-end', gap: 6,
           pointerEvents: 'auto',
         }}>
+          {/* Supply indicator — above spawn buttons */}
+          {isTouchDevice && hud && (() => {
+            const supplyUsed = hud.players.player?.supplyUsed ?? 0
+            const supplyCap = hud.players.player?.supplyCap ?? 120
+            const SOFT_CAP = 60
+            const atHardCap = supplyUsed >= supplyCap
+            const inPressure = supplyUsed >= SOFT_CAP
+            const color = atHardCap ? '#ff4f7b' : inPressure ? '#ffaa44' : '#4af7c4'
+            return (
+              <div style={{ fontSize: 9, letterSpacing: 1, color, opacity: 0.75, textAlign: 'right', display: 'flex', alignItems: 'center', gap: 4 }}>
+                <div style={{ width: 32, height: 3, background: 'rgba(255,255,255,0.15)', borderRadius: 2, overflow: 'hidden' }}>
+                  <div style={{ width: `${Math.min(100, supplyUsed / supplyCap * 100)}%`, height: '100%', background: color, transition: 'width 0.4s' }} />
+                </div>
+                <span style={{ color: atHardCap ? '#ff4f7b' : inPressure ? '#ffaa44' : 'rgba(255,255,255,0.45)' }}>
+                  {atHardCap ? 'SUP CAP!' : inPressure ? `SUP ${Math.round(supplyUsed)}` : `SUP ${Math.round(supplyUsed)}`}
+                </span>
+              </div>
+            )
+          })()}
           {/* Spawn type quick-select — bottom-right for thumb reach on mobile */}
           {isTouchDevice && (
             <div style={{ display: 'flex', gap: 4 }}>

--- a/src/app/speck-wars/domain/config/speck-types.ts
+++ b/src/app/speck-wars/domain/config/speck-types.ts
@@ -3,6 +3,7 @@ export interface SpeckTypeDefinition {
   hp: number; damage: number; speed: number
   attackRange: number; attackCooldown: number
   size: number; productionTime: number
+  supplyCost: number  // supply slots consumed while alive
   abilities: string[]
   recipe?: { inputs: Array<{ typeId: string; count: number }>; location: string }
 }
@@ -13,6 +14,7 @@ export const SPECK_TYPES: Record<string, SpeckTypeDefinition> = {
     hp: 1, damage: 1, speed: 64,
     attackRange: 6, attackCooldown: 500,
     size: 3, productionTime: 800,
+    supplyCost: 1,
     abilities: [],
   },
   heavy: {
@@ -20,6 +22,7 @@ export const SPECK_TYPES: Record<string, SpeckTypeDefinition> = {
     hp: 5, damage: 2, speed: 48,
     attackRange: 8, attackCooldown: 700,
     size: 6, productionTime: 1800,
+    supplyCost: 3,
     abilities: [],
   },
   scout: {
@@ -27,6 +30,7 @@ export const SPECK_TYPES: Record<string, SpeckTypeDefinition> = {
     hp: 1, damage: 0.5, speed: 120,
     attackRange: 4, attackCooldown: 600,
     size: 2, productionTime: 500,
+    supplyCost: 0.5,
     abilities: [],
   },
   missile: {
@@ -34,6 +38,7 @@ export const SPECK_TYPES: Record<string, SpeckTypeDefinition> = {
     hp: 1, damage: 1, speed: 220,
     attackRange: 6, attackCooldown: 0,
     size: 2, productionTime: 0,
+    supplyCost: 0,
     abilities: ['die_on_impact'],
   },
   defender: {
@@ -41,6 +46,7 @@ export const SPECK_TYPES: Record<string, SpeckTypeDefinition> = {
     hp: 3, damage: 1.5, speed: 50,
     attackRange: 25, attackCooldown: 900,
     size: 5, productionTime: 0,
+    supplyCost: 1,
     abilities: [],
   },
 }

--- a/src/app/speck-wars/domain/constants.ts
+++ b/src/app/speck-wars/domain/constants.ts
@@ -28,6 +28,10 @@ export const OUTPOST_AURA_RADIUS = 160  // px — specks within this radius of a
 export const DOMINATION_TIME = 60000   // ms — hold all 3 outposts this long to win by domination
 export const RALLY_CRY_HP_THRESHOLD = 0.25  // base HP fraction below which Rally Cry activates (1.5× spawn)
 
+// Supply pressure thresholds
+export const SUPPLY_SOFT_CAP = 60   // above this: spawn timers scale up
+export const SUPPLY_HARD_CAP = 120  // above this: non-base spawning halted
+
 // Three map layouts — one is picked per game using the daily seed.
 // All layouts use the same outpost IDs so the rest of the codebase is layout-agnostic.
 export const MAP_LAYOUTS = [

--- a/src/app/speck-wars/domain/simulation/combat.ts
+++ b/src/app/speck-wars/domain/simulation/combat.ts
@@ -370,6 +370,12 @@ export function removeDeadSpecks(sim: SimulationState) {
   for (let i = 0; i < sim.speckCount; i++) {
     if (sim.speckIds[i] !== '' && sim.speckHp[i] <= 0) {
       const deadId = sim.speckIds[i]  // save before clearing
+      const deadMeta = sim.speckMeta[i]
+      // Return supply to owner
+      if (deadMeta && deadMeta.ownerId !== 'neutral' && sim.players[deadMeta.ownerId]) {
+        const cost = SPECK_TYPES[deadMeta.typeId]?.supplyCost ?? 1
+        sim.players[deadMeta.ownerId].supply = Math.max(0, (sim.players[deadMeta.ownerId].supply ?? 0) - cost)
+      }
       sim.selectedSpeckIds.delete(deadId)
       sim.freeSlots.push(i)
       sim.speckIds[i] = ''

--- a/src/app/speck-wars/domain/simulation/create-sim.ts
+++ b/src/app/speck-wars/domain/simulation/create-sim.ts
@@ -68,18 +68,21 @@ export function createSim(seed: number = Date.now(), difficulty: Difficulty = 'm
     color: PLAYER_COLOR, isAI: false, isDefeated: false, stockpile: {},
     totalKills: 0, upgradeLevel: 0, stance: 'defensive', creepCampBoostMs: 0,
     outpostUpgrades: { carapace: false, blades: false, afterburners: false },
+    supply: 0,
   }
   const ai: Player = {
     id: 'ai', name: 'AI',
     color: AI_COLOR, isAI: true, isDefeated: false, stockpile: {},
     totalKills: 0, upgradeLevel: 0, stance: 'defensive', creepCampBoostMs: 0,
     outpostUpgrades: { carapace: false, blades: false, afterburners: false },
+    supply: 0,
   }
   const neutral: Player = {
     id: 'neutral', name: 'Neutral',
     color: NEUTRAL_COLOR, isAI: false, isDefeated: false, stockpile: {},
     totalKills: 0, upgradeLevel: 0, stance: 'defensive', creepCampBoostMs: 0,
     outpostUpgrades: { carapace: false, blades: false, afterburners: false },
+    supply: 0,
   }
 
   const JITTER = 150  // ± px of positional variation per game

--- a/src/app/speck-wars/domain/simulation/spawner.ts
+++ b/src/app/speck-wars/domain/simulation/spawner.ts
@@ -1,7 +1,7 @@
 import type { SimulationState, SpeckMeta } from '../types'
 import { SPECK_TYPES } from '../config/speck-types'
 import { BUILDING_TYPES } from '../config/building-types'
-import { MAX_SPECKS, RALLY_CRY_HP_THRESHOLD, CREEP_CAMP_DEFENDER_COUNT, CREEP_CAMP_BOOST_MULT } from '../constants'
+import { MAX_SPECKS, RALLY_CRY_HP_THRESHOLD, CREEP_CAMP_DEFENDER_COUNT, CREEP_CAMP_BOOST_MULT, SUPPLY_SOFT_CAP, SUPPLY_HARD_CAP } from '../constants'
 
 // Place a new speck into a recycled or fresh slot — never allocates new arrays
 function addSpeck(sim: SimulationState, meta: SpeckMeta, x: number, y: number, buildingId: string) {
@@ -27,6 +27,12 @@ function addSpeck(sim: SimulationState, meta: SpeckMeta, x: number, y: number, b
   sim.speckHp[slot] = hp
   sim.speckIds[slot] = meta.id
   sim.speckMeta[slot] = meta
+
+  // Track supply for non-neutral owners
+  if (meta.ownerId !== 'neutral' && sim.players[meta.ownerId]) {
+    const cost = SPECK_TYPES[meta.typeId]?.supplyCost ?? 1
+    sim.players[meta.ownerId].supply = (sim.players[meta.ownerId].supply ?? 0) + cost
+  }
 
   sim.events.push({ type: 'SPECK_SPAWNED', speckId: meta.id, buildingId })
 }
@@ -70,7 +76,19 @@ export function updateSpawners(sim: SimulationState, dt: number) {
     building.spawnTimer -= dt
     if (building.spawnTimer > 0) continue
 
-    const baseInterval = building.spawnIntervalOverride ?? btype.spawnInterval
+    // Supply pressure: non-base buildings halt at hard cap; all buildings slow between soft and hard cap
+    const supplyUsed = sim.players[building.ownerId]?.supply ?? 0
+    const isBase = building.typeId === 'base'
+    if (!isBase && supplyUsed >= SUPPLY_HARD_CAP) {
+      // Outpost spawn halted — reset timer so we check again next tick
+      building.spawnTimer = 500
+      continue
+    }
+    const supplyPressureMult = supplyUsed <= SUPPLY_SOFT_CAP ? 1.0
+      : supplyUsed <= SUPPLY_HARD_CAP ? 1 + ((supplyUsed - SUPPLY_SOFT_CAP) / (SUPPLY_HARD_CAP - SUPPLY_SOFT_CAP)) * 0.6
+      : 1.6  // base at hard cap gets 60% penalty
+
+    const baseInterval = (building.spawnIntervalOverride ?? btype.spawnInterval) * supplyPressureMult
     const hasSurge = building.ownerId === 'player' && sim.surgeDuration > 0
     const hasRallyCry = building.ownerId === 'player' && rallyCryActive
     const upgradeSpawnBonus = sim.players[building.ownerId]?.upgradeLevel && sim.players[building.ownerId].upgradeLevel >= 1 ? 1.1 : 1

--- a/src/app/speck-wars/domain/simulation/tick.ts
+++ b/src/app/speck-wars/domain/simulation/tick.ts
@@ -8,7 +8,7 @@ import { updateUnitAbilities } from './unit-abilities'
 import { checkVictory } from './victory'
 import { updateCapture } from './capture'
 import { BUILDING_TYPES } from '../config/building-types'
-import { HUD_UPDATE_INTERVAL, RALLY_CRY_HP_THRESHOLD, FORTIFY_TIME, CREEP_CAMP_ZONE_RADIUS } from '../constants'
+import { HUD_UPDATE_INTERVAL, RALLY_CRY_HP_THRESHOLD, FORTIFY_TIME, CREEP_CAMP_ZONE_RADIUS, SUPPLY_HARD_CAP } from '../constants'
 import { updateConstruction } from './construction'
 import { updateTurrets } from './turret'
 
@@ -541,7 +541,7 @@ function consumeInputs(sim: SimulationState) {
 }
 
 function emitHudUpdate(sim: SimulationState) {
-  const data: Record<string, { speckCount: number; buildingCount: number; buildingHp: Record<string, number>; speckTypes: Record<string, number>; veteranCount: number; eliteCount: number; legendCount: number }> = {}
+  const data: Record<string, { speckCount: number; buildingCount: number; buildingHp: Record<string, number>; speckTypes: Record<string, number>; veteranCount: number; eliteCount: number; legendCount: number; supplyUsed: number; supplyCap: number }> = {}
   for (const [pid] of Object.entries(sim.players)) {
     const myBuildings = Object.values(sim.buildings).filter(b => b.ownerId === pid)
     let liveCount = 0
@@ -565,6 +565,8 @@ function emitHudUpdate(sim: SimulationState) {
       veteranCount,
       eliteCount,
       legendCount,
+      supplyUsed: sim.players[pid]?.supply ?? 0,
+      supplyCap: SUPPLY_HARD_CAP,
     }
   }
   // Buildings that are owned but actively being captured by the enemy

--- a/src/app/speck-wars/domain/types.ts
+++ b/src/app/speck-wars/domain/types.ts
@@ -73,6 +73,7 @@ export interface Player {
     afterburners: boolean
   }
   commanderRespawnMs?: number   // ms until commander respawns (undefined = alive or not spawned yet)
+  supply: number                // total supply slots currently in use
 }
 
 export interface WallObstacle {
@@ -168,6 +169,8 @@ export interface HudData {
     veteranCount: number  // specks with 3+ kills
     eliteCount: number    // specks with 6+ kills
     legendCount: number   // specks with 12+ kills
+    supplyUsed: number    // current supply in use
+    supplyCap: number     // hard supply cap
   }>
   attackedBuildingIds: string[]
   tripleOutpostOwner: string | null  // player ID who owns all 3 outposts, or null


### PR DESCRIPTION
## Summary
- **Supply costs**: Heavy=3, Basic=1, Scout=0.5, Missile=0, Defender=1
- **Soft cap (60 supply)**: spawn timers increase up to 60% as supply rises toward hard cap — mass-heavy builds slow down reinforcements
- **Hard cap (120 supply)**: non-base building spawning halted; player base always keeps spawning
- **Supply return**: when a speck dies, its supply cost is returned to the owner pool

## HUD
- Thin 2px supply bar just below the HP bars (green → orange → red as supply fills)
- Pause screen stats grid now shows `Supply: X/120` per side
- Mobile: compact supply counter above spawn buttons (color-coded, with mini fill bar)

## Closes
Resolves #2174

## Test plan
- [ ] Verify heavy-only build slows down at >60 supply (spawn timers visibly longer)
- [ ] Verify outpost spawning halts above 120 for heavies, resumes as they die
- [ ] Verify base always keeps spawning regardless of supply
- [ ] Verify supply bar renders below HP bars without overlapping
- [ ] Verify supply counter appears above mobile spawn buttons
- [ ] Verify supply decrements correctly on speck death

🤖 Generated with [Claude Code](https://claude.com/claude-code)