### PR TITLE
feat(speck-wars): double-tap-to-zoom for mobile

### DIFF
--- a/src/app/speck-wars/input/input-handler.ts
+++ b/src/app/speck-wars/input/input-handler.ts
@@ -51,6 +51,9 @@ export class InputHandler {
   private longPressFired = false
   private dragSelectStartWorldX = 0
   private dragSelectStartWorldY = 0
+  private lastTapTime = 0
+  private lastTapX = 0
+  private lastTapY = 0
 
   constructor(
     canvas: HTMLCanvasElement,
@@ -337,8 +340,8 @@ export class InputHandler {
       clearTimeout(this.longPressTimer)
       this.longPressTimer = null
     }
-    // Tap-to-rally: only if long-press didn't fire
-    if (!this.longPressFired && this.lastPinchDist === 0 && e.changedTouches.length === 1 && this.onRally) {
+    // Tap-to-rally / double-tap-to-zoom: only if long-press didn't fire
+    if (!this.longPressFired && this.lastPinchDist === 0 && e.changedTouches.length === 1) {
       const touch = e.changedTouches[0]
       const dx = touch.clientX - this.touchStartX
       const dy = touch.clientY - this.touchStartY
@@ -347,9 +350,26 @@ export class InputHandler {
         const sx = touch.clientX - rect.left
         const sy = touch.clientY - rect.top
         if (sx >= 0 && sy >= 0 && sx <= rect.width && sy <= rect.height) {
-          const world = screenToWorld(sx, sy, this.camera)
-          navigator.vibrate?.(18)  // short pulse confirms rally
-          this.onRally(world.x, world.y)
+          const now = Date.now()
+          const tapDx = touch.clientX - this.lastTapX
+          const tapDy = touch.clientY - this.lastTapY
+          const isDoubleTap = now - this.lastTapTime < 300 && Math.sqrt(tapDx * tapDx + tapDy * tapDy) < 40
+          if (isDoubleTap) {
+            // Double-tap: zoom 1.5× toward tap point; if already zoomed in (≥1.5×), return to overview (0.7×)
+            const factor = this.camera.zoom >= 1.5 ? (0.7 / this.camera.zoom) : 1.5
+            Object.assign(this.camera, zoomAt(this.camera, sx, sy, factor))
+            navigator.vibrate?.([12, 40, 12])  // double-pulse distinguishes from rally
+            this.lastTapTime = 0  // reset so triple-tap doesn't chain
+          } else {
+            this.lastTapTime = now
+            this.lastTapX = touch.clientX
+            this.lastTapY = touch.clientY
+            if (this.onRally) {
+              const world = screenToWorld(sx, sy, this.camera)
+              navigator.vibrate?.(18)  // short pulse confirms rally
+              this.onRally(world.x, world.y)
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
## Summary
- Double-tap the canvas to zoom in 1.5× centered on the tap point
- Second double-tap returns to overview zoom (0.7×) — acts as a toggle
- Distinct haptic pattern `[12, 40, 12]` (double-pulse) so players know it's different from a rally tap
- `lastTapTime` resets after a double-tap so triple-taps don't accidentally chain

## Motivation
Mobile RTS players frequently need to swing between overview and close-up to see fights clearly. Pinch-to-zoom works but requires two hands. Double-tap is a natural, one-thumb gesture that makes the game significantly more playable on a phone.

## Test plan
- [ ] Single tap still issues a rally at the tapped world position
- [ ] Two quick taps at the same spot zoom in 1.5× centered on that spot
- [ ] Double-tap again zooms back out to ~0.7×
- [ ] Long-press still fires attack-move (unchanged)
- [ ] Pinch-to-zoom still works (unrelated code path, unchanged)
- [ ] No vibration on desktop (navigator.vibrate is undefined there)

🤖 Generated with [Claude Code](https://claude.com/claude-code)