### PR TITLE
feat(speck-wars): long-press ring + tap ripple for mobile touch feedback

### DIFF
--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -1,8 +1,9 @@
 'use client'
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import { useSpeckWarsStore } from '../store'
 import { PLAYER_COLOR, AI_COLOR } from '../domain/constants'
 import { getBestTime, getWinStreak } from '../lib/personal-best'
+import { onLongPressStart, onLongPressCancel, onTapRipple } from '../input/touch-feedback'
 
 function colorHex(n: number) {
   return `#${n.toString(16).padStart(6, '0')}`
@@ -23,6 +24,9 @@ export function HUD() {
     typeof window !== 'undefined' ? window.innerWidth < window.innerHeight : false
   )
   const [showPortraitHint, setShowPortraitHint] = useState(true)
+  const [longPressRing, setLongPressRing] = useState<{ x: number; y: number } | null>(null)
+  const [tapRippleState, setTapRippleState] = useState<{ x: number; y: number; key: number } | null>(null)
+  const tapRippleKeyRef = useRef(0)
   const isTouchDevice = typeof navigator !== 'undefined' && navigator.maxTouchPoints > 0
   const prefersReducedMotion = typeof window !== 'undefined' && window.matchMedia('(prefers-reduced-motion: reduce)').matches
 
@@ -56,6 +60,17 @@ export function HUD() {
     window.addEventListener('keydown', onKey)
     return () => window.removeEventListener('keydown', onKey)
   }, [])
+
+  useEffect(() => {
+    if (!isTouchDevice) return
+    const unsub1 = onLongPressStart((x, y) => setLongPressRing({ x, y }))
+    const unsub2 = onLongPressCancel(() => setLongPressRing(null))
+    const unsub3 = onTapRipple((x, y) => {
+      tapRippleKeyRef.current += 1
+      setTapRippleState({ x, y, key: tapRippleKeyRef.current })
+    })
+    return () => { unsub1(); unsub2(); unsub3() }
+  }, [isTouchDevice])
 
   const hud = useSpeckWarsStore(s => s.hud)
   const phase = useSpeckWarsStore(s => s.phase)
@@ -103,6 +118,14 @@ export function HUD() {
         @keyframes minimap-capture-pulse {
           0% { opacity: 0.8; transform: scale(0.85); }
           100% { opacity: 0; transform: scale(1.6); }
+        }
+        @keyframes long-press-ring {
+          from { stroke-dashoffset: 126; }
+          to   { stroke-dashoffset: 0; }
+        }
+        @keyframes tap-ripple-expand {
+          from { transform: scale(1); opacity: 0.8; }
+          to   { transform: scale(4); opacity: 0; }
         }
       `}</style>
       {/* Portrait mode hint — shown briefly for touch users in portrait orientation, auto-dismisses */}
@@ -1866,6 +1889,55 @@ export function HUD() {
           </div>
         )
       })()}
+
+      {/* Long-press ring */}
+      {longPressRing && isTouchDevice && (
+        <svg
+          key={`lp-${longPressRing.x}-${longPressRing.y}`}
+          style={{
+            position: 'fixed',
+            left: longPressRing.x - 24,
+            top: longPressRing.y - 24,
+            width: 48,
+            height: 48,
+            pointerEvents: 'none',
+            zIndex: 200,
+            overflow: 'visible',
+          }}
+        >
+          <circle
+            cx="24" cy="24" r="20"
+            fill="none"
+            stroke="rgba(255, 100, 50, 0.9)"
+            strokeWidth="3"
+            strokeDasharray="126"
+            strokeDashoffset="126"
+            transform="rotate(-90, 24, 24)"
+            style={{ animation: 'long-press-ring 500ms linear forwards' }}
+            onAnimationEnd={() => setLongPressRing(null)}
+          />
+        </svg>
+      )}
+
+      {/* Tap ripple */}
+      {tapRippleState && isTouchDevice && (
+        <div
+          key={tapRippleState.key}
+          style={{
+            position: 'fixed',
+            left: tapRippleState.x - 30,
+            top: tapRippleState.y - 30,
+            width: 60,
+            height: 60,
+            borderRadius: '50%',
+            border: '2px solid rgba(74, 247, 196, 0.8)',
+            pointerEvents: 'none',
+            zIndex: 200,
+            animation: 'tap-ripple-expand 300ms ease-out forwards',
+          }}
+          onAnimationEnd={() => setTapRippleState(null)}
+        />
+      )}
 
     </div>
   )

--- a/src/app/speck-wars/input/input-handler.ts
+++ b/src/app/speck-wars/input/input-handler.ts
@@ -1,5 +1,6 @@
 import type { Camera } from '../rendering/camera'
 import { zoomAt, screenToWorld } from '../rendering/camera'
+import { emitLongPressStart, emitLongPressCancel, emitTapRipple } from './touch-feedback'
 
 export class InputHandler {
   private canvas: HTMLCanvasElement
@@ -296,6 +297,7 @@ export class InputHandler {
           this.longPressFired = true
         }
       }, 500)
+      emitLongPressStart(e.touches[0].clientX, e.touches[0].clientY)
     } else if (e.touches.length === 2) {
       this.isDragging = false
       const dx = e.touches[1].clientX - e.touches[0].clientX
@@ -327,6 +329,7 @@ export class InputHandler {
         if (moveDist > 12 && this.longPressTimer) {
           clearTimeout(this.longPressTimer)
           this.longPressTimer = null
+          emitLongPressCancel()
         }
       }
       this.camera.x += e.touches[0].clientX - this.lastX
@@ -341,6 +344,7 @@ export class InputHandler {
     if (this.longPressTimer) {
       clearTimeout(this.longPressTimer)
       this.longPressTimer = null
+      emitLongPressCancel()
     }
     // Tap-to-rally / double-tap-to-zoom: only if long-press didn't fire
     if (!this.longPressFired && this.lastPinchDist === 0 && e.changedTouches.length === 1) {
@@ -362,6 +366,7 @@ export class InputHandler {
             const world = screenToWorld(sx, sy, this.camera)
             navigator.vibrate?.([10, 30, 10, 30, 10])  // triple-pulse for patrol
             this.onPatrol?.(world.x, world.y)
+            emitTapRipple(touch.clientX, touch.clientY)
           } else if (isDoubleTap) {
             // Double-tap: zoom 1.5× toward tap point; if already zoomed in (≥1.5×), return to overview (0.7×)
             const factor = this.camera.zoom >= 1.5 ? (0.7 / this.camera.zoom) : 1.5
@@ -376,6 +381,7 @@ export class InputHandler {
               const world = screenToWorld(sx, sy, this.camera)
               navigator.vibrate?.(18)  // short pulse confirms rally
               this.onRally(world.x, world.y)
+              emitTapRipple(touch.clientX, touch.clientY)
             }
           }
         }

--- a/src/app/speck-wars/input/touch-feedback.ts
+++ b/src/app/speck-wars/input/touch-feedback.ts
@@ -1,0 +1,20 @@
+type Listener<T extends unknown[]> = (...args: T) => void
+
+function createEmitter<T extends unknown[]>() {
+  const listeners = new Set<Listener<T>>()
+  return {
+    emit: (...args: T) => listeners.forEach(fn => fn(...args)),
+    subscribe: (fn: Listener<T>) => { listeners.add(fn); return () => listeners.delete(fn) },
+  }
+}
+
+const longPressStart = createEmitter<[x: number, y: number]>()
+const longPressCancel = createEmitter<[]>()
+const tapRipple = createEmitter<[x: number, y: number]>()
+
+export const emitLongPressStart = (x: number, y: number) => longPressStart.emit(x, y)
+export const emitLongPressCancel = () => longPressCancel.emit()
+export const emitTapRipple = (x: number, y: number) => tapRipple.emit(x, y)
+export const onLongPressStart = (fn: (x: number, y: number) => void) => longPressStart.subscribe(fn)
+export const onLongPressCancel = (fn: () => void) => longPressCancel.subscribe(fn)
+export const onTapRipple = (fn: (x: number, y: number) => void) => tapRipple.subscribe(fn)


### PR DESCRIPTION
## Summary
- Adds a radial SVG ring that fills clockwise over 500ms at the touch point during long-press (attack-move), so players can see the gesture progressing
- Ring cancels immediately if the finger moves >12px or lifts before 500ms
- Adds a tap ripple (expanding circle, fades in 300ms) at the touch point when a rally or patrol tap is confirmed
- Both effects are touch-only and use CSS keyframe animations with `onAnimationEnd` cleanup — no Zustand updates at 60fps

## Metric
Improves discoverability of long-press attack-move for new mobile players (session length / return rate).

## Test plan
- [ ] Long-press on canvas — ring fills clockwise over 500ms, disappears when attack-move fires
- [ ] Drag finger >12px mid-long-press — ring cancels immediately
- [ ] Lift finger before 500ms — ring cancels, rally fires instead, ripple appears
- [ ] Single tap to rally — ripple expands and fades at tap point
- [ ] Double-tap to zoom — no ripple appears
- [ ] Desktop — no overlays rendered (guarded by `isTouchDevice`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)