### PR TITLE
feat(speck-wars): haptic feedback for key game events on mobile

### DIFF
--- a/src/app/speck-wars/components/phase-router.tsx
+++ b/src/app/speck-wars/components/phase-router.tsx
@@ -397,12 +397,14 @@ export function PhaseRouter({ children }: { children: React.ReactNode }) {
       const url = typeof window !== 'undefined' ? window.location.href : ''
       if (typeof navigator !== 'undefined' && navigator.share) {
         try {
+          navigator.vibrate?.(8)
           await navigator.share({ title: 'Speck Wars', text: shareText, url })
         } catch {
           // user cancelled — no action needed
         }
       } else {
         await navigator.clipboard.writeText(`${shareText} ${url}`)
+        navigator.vibrate?.(12)
         setCopied(true)
         setTimeout(() => setCopied(false), 2000)
       }

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -341,6 +341,7 @@ export class GameInstance {
       useSpeckWarsStore.getState().setCountdown(null)
       this.cinematicMs = 0
       this.notify('⚔ FIGHT!', '#4af7c4', 800)
+      navigator.vibrate?.([50, 30, 50, 30, 100])
     }, 3000)
 
     // Show tutorial hints for first-time players
@@ -450,6 +451,7 @@ export class GameInstance {
           const bua = event.data.baseUnderThreat ?? false
           if (bua && !this.prevBaseUnderThreat) {
             this.notify('⚠ BASE UNDER ATTACK', '#ff3333')
+            navigator.vibrate?.([300, 100, 300])
           }
           this.prevBaseUnderThreat = bua
           const adv = event.data.enemyAdvanceDetected ?? false
@@ -473,6 +475,7 @@ export class GameInstance {
               this.outpostAttackWarnedAt[outpostId] = now
               const name = outpostId.replace('outpost-', '').toUpperCase()
               this.notify(`⬡ ${name} UNDER ATTACK!`, '#ff8c00', 2500)
+              navigator.vibrate?.([150, 50, 150])
             }
           }
           // Clear warnings for outposts that are no longer under attack
@@ -623,6 +626,7 @@ export class GameInstance {
         }
         if (event.type === 'CAMP_CAPTURED' && event.newOwner === 'player') {
           this.notify('◈ CAMP SEIZED! +25% SPAWN FOR 30s', '#ff9933', 3000)
+          navigator.vibrate?.([20, 30, 20, 30, 20])
           store.pushKillFeedEntry({ icon: '◈', label: 'CAMP SEIZED', color: '#ff9933' })
         }
         if (event.type === 'OUTPOST_UPGRADE_RESEARCHED' && event.ownerId === 'player') {
@@ -644,6 +648,9 @@ export class GameInstance {
               : `⬡ ${outpostName} CAPTURED`
             const color = isPlayerLoss ? '#ff4f7b' : isRecapture ? '#ffd700' : '#4af7c4'
             this.notify(message, color, 2500)
+            if (isPlayerLoss) navigator.vibrate?.(300)
+            else if (isRecapture) navigator.vibrate?.([30, 40, 30, 40, 60])
+            else navigator.vibrate?.([20, 30, 20])
             store.pushKillFeedEntry({ icon: '⬡', label: message.replace('⬡ ', ''), color })
           } else if (event.newOwner === 'ai' && event.previousOwner === 'neutral') {
             const outpostName = event.outpostId.replace('outpost-', '').toUpperCase()


### PR DESCRIPTION
## Summary
- Countdown "FIGHT!" → ascending triple-pulse `[50, 30, 50, 30, 100]` (game-start ceremony)
- Base under attack → heavy double-pulse `[300, 100, 300]` (urgent warning)
- Outpost under attack → medium warning `[150, 50, 150]`
- Camp captured → light celebratory `[20, 30, 20, 30, 20]`
- Outpost captured → light positive `[20, 30, 20]`, recapture → ascending `[30, 40, 30, 40, 60]`, lost → heavy `300`ms
- Share dialog → `8`ms; clipboard copy → `12`ms confirmation

All use optional chaining (`?.`) to degrade gracefully on non-vibrating devices.

## Metric
Improves perceived responsiveness and game-event awareness on mobile → session length / return rate.

## Test plan
- [ ] Game starts → feel triple-pulse at "FIGHT!"
- [ ] Base gets attacked → feel heavy double-pulse
- [ ] Outpost attacked → feel medium warning
- [ ] Capture a camp/outpost → feel positive feedback
- [ ] Lose an outpost → feel single long buzz
- [ ] Share button → feel confirmation on tap

🤖 Generated with [Claude Code](https://claude.com/claude-code)