### PR TITLE
feat(speck-wars): mobile-aware tutorial hints and clearer button labels

### DIFF
--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -1478,7 +1478,7 @@ export function HUD() {
             )}
             {/* Touch gesture hint */}
             {isTouchDevice && <div style={{ marginTop: 6, fontSize: 11, color: '#aaa', letterSpacing: 0.3, textAlign: 'center' }}>
-              Tap: rally &bull; Long-press: attack-move &bull; Patrol: tap ◎ then tap target
+              Tap: rally &bull; Long-press: attack-move &bull; Double-tap: zoom &bull; 2-finger: zoom+pan
             </div>}
           </div>
         </div>
@@ -1592,7 +1592,7 @@ export function HUD() {
               fontFamily: 'monospace',
             }}
           >
-            → N
+            {isTouchDevice ? '→ ADV' : '→ N'}
           </button>
           <button
             onClick={() => { navigator.vibrate?.(20); gameActions.rush?.() }}
@@ -1610,7 +1610,7 @@ export function HUD() {
               fontFamily: 'monospace',
             }}
           >
-            ⚡ B
+            {isTouchDevice ? '⚡ RUSH' : '⚡ B'}
           </button>
           {(() => {
             const surgeActive = (hud?.surgeDuration ?? 0) > 0
@@ -1641,8 +1641,8 @@ export function HUD() {
                 {surgeActive
                   ? `★ ${Math.ceil((hud?.surgeDuration ?? 0) / 1000)}s`
                   : surgeCd > 0
-                    ? `Q ${Math.ceil(surgeCd / 1000)}s`
-                    : '★ Q'}
+                    ? `${isTouchDevice ? 'SURGE' : 'Q'} ${Math.ceil(surgeCd / 1000)}s`
+                    : isTouchDevice ? '⚡ SURGE' : '★ Q'}
               </button>
             )
           })()}
@@ -1669,7 +1669,7 @@ export function HUD() {
                   opacity: ready ? 1 : 0.6,
                 }}
               >
-                {cd > 0 ? `F ${Math.ceil(cd / 1000)}s` : '🔧 F'}
+                {cd > 0 ? `${isTouchDevice ? 'HEAL' : 'F'} ${Math.ceil(cd / 1000)}s` : isTouchDevice ? '🔧 HEAL' : '🔧 F'}
               </button>
             )
           })()}

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -346,7 +346,15 @@ export class GameInstance {
     // Show tutorial hints for first-time players
     if (isFirstGame()) {
       markFirstGameDone()
-      const hints = [
+      const touch = typeof navigator !== 'undefined' && navigator.maxTouchPoints > 0
+      const hints = touch ? [
+        { delay: 1200,  message: '💡 Tap the map to rally your specks!', color: '#aaddff' },
+        { delay: 6000,  message: '💡 Capture outposts to boost production!', color: '#aaddff' },
+        { delay: 13000, message: '💡 Long-press for attack-move — hold 0.5s!', color: '#ff8c44' },
+        { delay: 22000, message: '💡 Use ⚡ SURGE button — doubles production for 8s!', color: '#ffd700' },
+        { delay: 38000, message: '💡 Double-tap canvas to zoom in/out!', color: '#aaddff' },
+        { delay: 50000, message: '💡 Use 🔧 HEAL to sacrifice 10 specks → repair base!', color: '#64c864' },
+      ] : [
         { delay: 1200,  message: '💡 Click the map to rally your specks!', color: '#aaddff' },
         { delay: 6000,  message: '💡 Capture outposts to boost production!', color: '#aaddff' },
         { delay: 13000, message: '💡 Press Q for Surge — doubles production for 8s!', color: '#ffd700' },


### PR DESCRIPTION
## Summary
- First-time tutorial hints now show touch-specific guidance on mobile (tap/long-press/double-tap/SURGE button/HEAL button) vs keyboard shortcuts on desktop
- Action button labels: Advance `→ ADV`, Rush `⚡ RUSH`, Surge `⚡ SURGE`, Sacrifice `🔧 HEAL` — no more meaningless keyboard shortcuts (N, B, Q, F) on touch
- Gesture hint updated to mention double-tap zoom and two-finger zoom+pan

## Metric
Improves new-player discoverability on mobile → return rate / session length.

## Test plan
- [ ] First-time game on mobile → hints mention gestures not keyboard shortcuts
- [ ] First-time game on desktop → hints still show Q/F/1-2-3 shortcuts
- [ ] Mobile HUD: Advance shows "→ ADV", Rush shows "⚡ RUSH"
- [ ] Surge on cooldown: shows "SURGE 42s" not "Q 42s"
- [ ] Heal on cooldown: shows "HEAL 32s" not "F 32s"
- [ ] Gesture hint at bottom of command panel: includes double-tap and 2-finger

🤖 Generated with [Claude Code](https://claude.com/claude-code)