### PR TITLE
feat(speck-wars): tappable wave warning + larger turret build touch target

### DIFF
--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -322,19 +322,26 @@ export function HUD() {
                 }
               `}</style>
             )}
-            <div style={{
-              position: 'absolute', top: isTouchDevice ? 175 : 240, right: 16,
-              padding: '4px 10px',
-              background: inProgress ? 'rgba(255,80,80,0.25)' : 'rgba(255,140,0,0.15)',
-              border: `1px solid ${inProgress ? 'rgba(255,80,80,0.6)' : 'rgba(255,140,0,0.5)'}`,
-              borderRadius: 4,
-              fontSize: 10,
-              letterSpacing: 1.5,
-              color: inProgress ? '#ff5050' : '#ffa030',
-              animation: (!prefersReducedMotion && inProgress) ? 'danger-pulse 0.6s ease-in-out infinite alternate' : 'none',
-            }}>
-              {inProgress ? '⚠ WAVE INCOMING!' : `⚠ WAVE IN ${secs}s`}
-            </div>
+            <button
+              onClick={() => { gameActions?.snapToBase?.(); navigator.vibrate?.(inProgress ? [20, 30, 20] : 15) }}
+              style={{
+                position: 'absolute', top: isTouchDevice ? 175 : 240, right: 16,
+                padding: isTouchDevice ? '8px 12px' : '4px 10px',
+                background: inProgress ? 'rgba(255,80,80,0.25)' : 'rgba(255,140,0,0.15)',
+                border: `1px solid ${inProgress ? 'rgba(255,80,80,0.6)' : 'rgba(255,140,0,0.5)'}`,
+                borderRadius: 4,
+                fontSize: 10,
+                letterSpacing: 1.5,
+                color: inProgress ? '#ff5050' : '#ffa030',
+                animation: (!prefersReducedMotion && inProgress) ? 'danger-pulse 0.6s ease-in-out infinite alternate' : 'none',
+                cursor: 'pointer',
+                fontFamily: 'monospace',
+                minHeight: isTouchDevice ? 44 : undefined,
+                display: 'flex', alignItems: 'center',
+              }}
+            >
+              {inProgress ? '⚠ WAVE INCOMING! ↑' : `⚠ WAVE IN ${secs}s ↑`}
+            </button>
           </>
         )
       })()}
@@ -1201,13 +1208,14 @@ export function HUD() {
                   BUILD
                 </div>
                 <button
-                  onClick={() => { if (canBuild) (gameActions as { buildTurret?: () => void } | null)?.buildTurret?.() }}
+                  onClick={() => { if (canBuild) { (gameActions as { buildTurret?: () => void } | null)?.buildTurret?.(); navigator.vibrate?.(15) } }}
                   style={{
                     width: '100%',
                     background: canBuild ? 'rgba(255,215,0,0.08)' : 'rgba(255,255,255,0.03)',
                     border: `1px solid ${canBuild ? 'rgba(255,215,0,0.5)' : 'rgba(255,255,255,0.1)'}`,
                     borderRadius: 4,
-                    padding: '6px 8px',
+                    padding: isTouchDevice ? '10px 8px' : '6px 8px',
+                    minHeight: isTouchDevice ? 44 : undefined,
                     cursor: canBuild ? 'pointer' : 'default',
                     textAlign: 'left',
                     fontFamily: 'monospace',


### PR DESCRIPTION
## Summary
- **Wave countdown/incoming badge** is now a button: tap to snap camera to your base
  - Shows ↑ arrow to signal it's tappable
  - Haptic: double-pulse when wave is in progress, single pulse during countdown
  - Grows to 44px minimum height on touch devices
- **Turret BUILD button** now meets 44px minimum touch target size on mobile
  - Previous padding of 6px was too small for reliable thumb taps
  - Added haptic feedback on successful build trigger

## Why this matters for mobile
When you see "⚠ WAVE IN 10s" you want to immediately jump back to your base to prepare defense. Before, you had to find the HOME button in the top bar. Now the warning itself is the action button.

## Test plan
- [ ] On medium/hard difficulty: wave countdown appears → tap "⚠ WAVE IN Ns ↑" → camera snaps to base
- [ ] Wave in progress: "⚠ WAVE INCOMING! ↑" tappable, snaps to base
- [ ] Touch target at least 44px tall on mobile
- [ ] Desktop: badge still works when clicked
- [ ] SELECT 20+ specks → tap TURRET button → enters build mode with haptic

🤖 Generated with [Claude Code](https://claude.com/claude-code)