### PR TITLE
feat(speck-wars): tap base HP stats to snap camera to that base

### DIFF
--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -1828,13 +1828,30 @@ export function HUD() {
             {/* Kill/loss + enemy base HP */}
             <div style={{ display: 'flex', gap: 10, fontSize: isTouchDevice ? 12 : 10, letterSpacing: 0.5 }}>
               <span style={{ color: colorHex(PLAYER_COLOR), opacity: 0.7 }}>↑{kills} ↓{losses}</span>
-              {aiBaseHpVal > 0 && (
-                <span style={{ color: aiBaseColor, opacity: 0.8 }}>
-                  ENEMY BASE {Math.round(aiBaseHpFrac * 100)}%
-                </span>
-              )}
+              {aiBaseHpVal > 0 && (() => {
+                const aiBase = hud?.minimap?.buildings?.find(b => b.typeId === 'base' && b.ownerId === 'ai')
+                return (
+                  <span
+                    onClick={isTouchDevice && aiBase ? () => { gameActions?.panCamera?.(aiBase.x, aiBase.y); navigator.vibrate?.(15) } : undefined}
+                    style={{
+                      color: aiBaseColor, opacity: 0.8,
+                      ...(isTouchDevice && aiBase ? { cursor: 'pointer', textDecoration: 'underline', textDecorationStyle: 'dotted' } : {}),
+                    }}
+                    title={isTouchDevice ? 'Tap to jump to enemy base' : undefined}
+                  >
+                    ENEMY BASE {Math.round(aiBaseHpFrac * 100)}%
+                  </span>
+                )
+              })()}
               {playerBaseHpVal > 0 && (
-                <span style={{ color: hpFrac < 0.3 ? '#ff4f7b' : 'rgba(255,255,255,0.4)', opacity: 0.8 }}>
+                <span
+                  onClick={isTouchDevice ? () => { gameActions?.snapToBase?.(); navigator.vibrate?.(15) } : undefined}
+                  style={{
+                    color: hpFrac < 0.3 ? '#ff4f7b' : 'rgba(255,255,255,0.4)', opacity: 0.8,
+                    ...(isTouchDevice ? { cursor: 'pointer', textDecoration: 'underline', textDecorationStyle: 'dotted' } : {}),
+                  }}
+                  title={isTouchDevice ? 'Tap to jump to your base' : undefined}
+                >
                   BASE {Math.round(playerBaseHpVal)}HP
                 </span>
               )}


### PR DESCRIPTION
## Summary
- **"ENEMY BASE 45%"** in the bottom-left stats bar is now tappable on touch devices → snaps camera to enemy base
- **"BASE 67HP"** (your base) is tappable → snaps camera to your home base  
- Dotted underline signals tappability on touch (no underline on desktop)
- Haptic pulse on each tap

## Why this matters for mobile
The base HP readout is where players check the state of the game. When you see "ENEMY BASE 20%" you want to rush there. When your "BASE 35HP" is flashing red, you want to jump back. Making these stats themselves into camera shortcuts removes the need to find the HOME/FIGHT buttons.

## Test plan
- [ ] On touch device: tap "ENEMY BASE X%" → camera pans to enemy base
- [ ] Tap "BASE XHP" → camera snaps to your home base  
- [ ] Both have dotted underline on touch, normal text on desktop
- [ ] Haptic feedback on tap
- [ ] Desktop: no change (no onClick, no underline)

🤖 Generated with [Claude Code](https://claude.com/claude-code)