### PR TITLE
feat(speck-wars): iOS safe area insets for bottom HUD elements

### DIFF
--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -108,7 +108,7 @@ export function HUD() {
       {/* Portrait mode hint — shown briefly for touch users in portrait orientation, auto-dismisses */}
       {isTouchDevice && isPortrait && showPortraitHint && phase === 'playing' && (
         <div style={{
-          position: 'absolute', bottom: 60, left: '50%', transform: 'translateX(-50%)',
+          position: 'absolute', bottom: 'calc(60px + env(safe-area-inset-bottom, 0px))', left: '50%', transform: 'translateX(-50%)',
           background: 'rgba(0,0,0,0.75)', border: '1px solid rgba(255,255,255,0.2)',
           borderRadius: 6, padding: '6px 14px', fontSize: 12, color: 'rgba(255,255,255,0.7)',
           letterSpacing: 0.5, pointerEvents: 'none', whiteSpace: 'nowrap', zIndex: 90,
@@ -1013,7 +1013,7 @@ export function HUD() {
 
         return (
           <div style={{
-            position: 'absolute', bottom: 16, left: 0, right: 0,
+            position: 'absolute', bottom: 'calc(16px + env(safe-area-inset-bottom, 0px))', left: 0, right: 0,
             display: 'flex', justifyContent: 'center', alignItems: 'center', gap: 12,
           }}>
             {status && (
@@ -1168,7 +1168,7 @@ export function HUD() {
       {phase === 'playing' && (
         <div style={{
           position: 'absolute',
-          bottom: 70,
+          bottom: 'calc(70px + env(safe-area-inset-bottom, 0px))',
           left: '50%',
           transform: 'translateX(-50%)',
           display: 'flex',
@@ -1487,7 +1487,7 @@ export function HUD() {
       {/* Mobile action buttons — bottom right */}
       {phase === 'playing' && (
         <div style={{
-          position: 'absolute', bottom: 16, right: 16,
+          position: 'absolute', bottom: 'calc(16px + env(safe-area-inset-bottom, 0px))', right: 16,
           display: 'flex', flexDirection: 'column', alignItems: 'flex-end', gap: 6,
           pointerEvents: 'auto',
         }}>
@@ -1739,7 +1739,7 @@ export function HUD() {
         const aiBaseHpFrac = aiBaseHpVal / 100
         const aiBaseColor = aiBaseHpFrac > 0.5 ? '#ff4f7b' : aiBaseHpFrac > 0.2 ? '#ffaa44' : '#ff2200'
         return (
-          <div style={{ position: 'absolute', bottom: 16, left: 16, display: 'flex', flexDirection: 'column', gap: 5 }}>
+          <div style={{ position: 'absolute', bottom: 'calc(16px + env(safe-area-inset-bottom, 0px))', left: 16, display: 'flex', flexDirection: 'column', gap: 5 }}>
             {/* Force ratio bar */}
             {total >= 4 && (
               <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>

--- a/src/app/speck-wars/layout.tsx
+++ b/src/app/speck-wars/layout.tsx
@@ -1,0 +1,10 @@
+import type { Viewport } from 'next'
+import type React from 'react'
+
+export const viewport: Viewport = {
+  viewportFit: 'cover',
+}
+
+export default function SpeckWarsLayout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>
+}


### PR DESCRIPTION
## Summary
- Creates `src/app/speck-wars/layout.tsx` with `viewport: { viewportFit: 'cover' }` so the app renders edge-to-edge behind the iPhone home indicator
- Updates all 5 bottom-positioned HUD containers to use `calc(Npx + env(safe-area-inset-bottom, 0px))` so they clear the ~34px home indicator on iPhone X+
- Affected elements: portrait hint, morale/status bar, command panel, mobile action buttons (bottom-right), stats panel (bottom-left)
- Falls back gracefully on non-iOS devices (`env(safe-area-inset-bottom, 0px)` resolves to `0px`)

## Test plan
- [ ] On iPhone X or later in Safari: confirm bottom action buttons are fully visible above the home indicator
- [ ] On Android/desktop: confirm layout is unchanged (all `env()` values resolve to 0px)
- [ ] In portrait mode on iPhone: confirm portrait hint is visible above home indicator

🤖 Generated with [Claude Code](https://claude.com/claude-code)