### PR TITLE
feat(speck-wars): outpost dots tappable on mobile — pan camera to outpost

### DIFF
--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -875,8 +875,23 @@ export function HUD() {
               </span>
               {dots.map(({ id, color, isUnderAttack, isPlayerOwned, cap, hpFrac }, i) => {
                 const capColor = cap?.side === 'player' ? '#4af7c4' : '#ff4f7b'
-                return (
-                  <div key={i} style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 2 }}>
+                const building = hud.minimap.buildings.find(b => b.id === id)
+                const canTap = isTouchDevice && !!building && !!gameActions?.panCamera
+                const sharedStyle = {
+                  display: 'flex', flexDirection: 'column' as const, alignItems: 'center', gap: 2,
+                }
+                const touchStyle = canTap ? {
+                  background: 'none', border: 'none', cursor: 'pointer',
+                  padding: '6px 8px', minWidth: 36, minHeight: 44, justifyContent: 'center',
+                  borderBottom: '1px dotted rgba(255,255,255,0.2)',
+                } : {}
+                const handleTap = () => {
+                  if (!building) return
+                  gameActions?.panCamera?.(building.x, building.y)
+                  navigator.vibrate?.(15)
+                }
+                const innerContent = (
+                  <>
                     <div style={{
                       width: 10, height: 10,
                       borderRadius: '50%',
@@ -915,6 +930,15 @@ export function HUD() {
                         </div>
                       )
                     })()}
+                  </>
+                )
+                return canTap ? (
+                  <button key={i} onClick={handleTap} style={{ ...sharedStyle, ...touchStyle }}>
+                    {innerContent}
+                  </button>
+                ) : (
+                  <div key={i} style={sharedStyle}>
+                    {innerContent}
                   </div>
                 )
               })}


### PR DESCRIPTION
## Summary
- Outpost indicator dots at top-center HUD are now tappable on touch devices
- Each dot becomes a 36×44px tap target (up from the non-interactive 10×10px dot)
- Tapping jumps the camera to that outpost's world position via `panCamera`
- Short haptic vibration (15ms) confirms the tap
- Faint dotted bottom border on each dot column signals interactivity on mobile
- Desktop behavior is completely unchanged — dots are still plain visual indicators

## Why
Previously on mobile there was no way to quickly navigate to a specific outpost — players had to swipe around the map or tap the minimap and hope they hit the right spot.

Moves: **session length** (players can track contested outposts without losing camera)

## Test plan
- [ ] On iPhone/Android: tap each outpost dot → confirm camera jumps to that outpost
- [ ] Confirm 44px touch target makes the dots easy to hit
- [ ] On desktop: confirm dots still render as before with no click behavior
- [ ] When `panCamera` is unavailable (before game starts), confirm no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)