### PR TITLE
feat(speck-wars): mobile top-bar dedup, kill feed limit, stance touch target

### DIFF
--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -501,7 +501,7 @@ export function HUD() {
           pointerEvents: 'none',
           width: 140,
         }}>
-          {killFeed.map(entry => {
+          {killFeed.slice(0, isTouchDevice ? 3 : 6).map(entry => {
             const age = Date.now() - entry.ts
             const opacity = age > 3000 ? Math.max(0, 1 - (age - 3000) / 1500) : 1
             return (
@@ -616,8 +616,8 @@ export function HUD() {
             </button>
           )
         })}
-        {/* Stance toggle — cycles through aggressive/defensive/hold */}
-        {gameActions?.cycleStance && (() => {
+        {/* Stance toggle — cycles through aggressive/defensive/hold — hidden on touch (bottom-right panel has it) */}
+        {!isTouchDevice && gameActions?.cycleStance && (() => {
           const stanceConfig: Record<string, { icon: string; label: string; color: string; title: string }> = {
             aggressive: { icon: '⚔', label: 'AGGRO', color: '#ff4f7b', title: '[Z] Aggressive — pursues nearby enemies' },
             defensive:  { icon: '🛡', label: 'DEF',   color: '#4af7c4', title: '[Z] Defensive — holds position more' },
@@ -1547,7 +1547,7 @@ export function HUD() {
               fontSize: 11, letterSpacing: 1.5, opacity: 0.8,
               color: stance === 'aggressive' ? '#ff4f7b' : stance === 'hold' ? '#aaaaaa' : '#4af7c4',
               textAlign: 'right',
-              ...(isTouchDevice ? { cursor: 'pointer', padding: '4px 6px', minHeight: 32, display: 'flex', alignItems: 'center' } : {}),
+              ...(isTouchDevice ? { cursor: 'pointer', padding: '4px 8px', minHeight: 44, display: 'flex', alignItems: 'center' } : {}),
             }}
           >
             {stance === 'aggressive' ? 'AGGRO' : stance === 'hold' ? 'HOLD' : 'DEF'}


### PR DESCRIPTION
## Summary
Three targeted mobile polish improvements:

1. **Stance button removed from top bar on touch** — The top bar was wrapping on narrow phones (~375px) because it had too many items. The stance indicator in the bottom-right panel already cycles stance when tapped on mobile, so the top bar duplicate was removed. Saves ~70px, preventing a wrap.

2. **Stance tap target upgraded (32→44px)** — The bottom-right stance indicator now has `minHeight: 44` on touch (was 32), meeting the mobile touch-target minimum.

3. **Kill feed capped at 3 entries on mobile** — The kill feed was showing up to 6 entries (from the store's `.slice(0, 6)`), which could overlap mid-screen on small phones at `top: 210`. Now limited to 3 on touch devices.

## Test plan
- [ ] On mobile: confirm no stance button in top bar (should see only Timer, PAUSE, Speed, ALL, HOME, FIGHT, ?)
- [ ] On mobile: confirm bottom-right stance indicator (AGGRO/DEF/HOLD) is tappable and cycles stance
- [ ] On mobile: confirm kill feed shows at most 3 entries even with rapid kills
- [ ] On desktop: confirm stance button still appears in top bar, kill feed shows up to 6

🤖 Generated with [Claude Code](https://claude.com/claude-code)