### PR TITLE
feat(speck-wars): victory/defeat buttons wrap on narrow mobile screens

### DIFF
--- a/src/app/speck-wars/components/phase-router.tsx
+++ b/src/app/speck-wars/components/phase-router.tsx
@@ -645,13 +645,13 @@ export function PhaseRouter({ children }: { children: React.ReactNode }) {
             borderTop: '1px solid rgba(255,255,255,0.08)',
           } : {}),
         }}>
-          <div style={{ display: 'flex', gap: 12 }}>
+          <div style={{ display: 'flex', gap: 12, flexWrap: 'wrap', justifyContent: 'center' }}>
           <button
             onClick={resetGame}
             style={{
               padding: '12px 28px', fontSize: 16, cursor: 'pointer',
               background: accentColor, border: 'none', borderRadius: 8,
-              fontWeight: 'bold', color: '#000',
+              fontWeight: 'bold', color: '#000', minHeight: 52,
             }}
           >
             Play Again
@@ -661,7 +661,7 @@ export function PhaseRouter({ children }: { children: React.ReactNode }) {
             style={{
               padding: '12px 28px', fontSize: 16, cursor: 'pointer',
               background: 'transparent', border: `2px solid ${accentColor}`,
-              borderRadius: 8, color: accentColor,
+              borderRadius: 8, color: accentColor, minHeight: 52,
             }}
           >
             {copied ? 'Copied!' : 'Share'}
@@ -672,7 +672,7 @@ export function PhaseRouter({ children }: { children: React.ReactNode }) {
               padding: '12px 28px', fontSize: 16, cursor: 'pointer',
               background: 'transparent', border: '2px solid rgba(255,255,255,0.3)',
               borderRadius: 8, color: 'rgba(255,255,255,0.7)', textDecoration: 'none',
-              display: 'flex', alignItems: 'center',
+              display: 'flex', alignItems: 'center', minHeight: 52,
             }}
           >
             ← Cave
@@ -692,7 +692,7 @@ export function PhaseRouter({ children }: { children: React.ReactNode }) {
               background: 'transparent',
               border: `1px solid ${nextDiff.color}`,
               borderRadius: 6, color: nextDiff.color, opacity: 0.8,
-              letterSpacing: 1,
+              letterSpacing: 1, minHeight: isTouchDevice ? 44 : undefined,
             }}
           >
             Try {nextDiff.label} →


### PR DESCRIPTION
## Summary
- Added `flexWrap: 'wrap'` + `justifyContent: 'center'` to the Play Again / Share / ← Cave button row so the three buttons wrap to a second line on narrow screens (iPhone SE = 375px) instead of overflowing
- Added `minHeight: 52` to all three primary action buttons for consistent large touch targets
- Added `minHeight: 44` on touch to the "Try Harder difficulty" button which was previously only 40px tall

## Test plan
- [ ] On iPhone SE (375px): Play Again / Share / ← Cave wrap cleanly to two lines
- [ ] On wider phones (390px+): three buttons fit in one row
- [ ] "Try Medium / Hard / Brutal" button is easily tappable on mobile
- [ ] Desktop layout unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)