### PR TITLE
fix(cosmic-shell): enlarge exit ✕ button touch target to 44×44px

### DIFF
--- a/src/app/comet-cards/components/cosmic/shell.tsx
+++ b/src/app/comet-cards/components/cosmic/shell.tsx
@@ -24,11 +24,12 @@ export function CosmicShell({ children }: { children: ReactNode }) {
         aria-label="Exit to CometCave"
         style={{
           position: 'absolute',
-          top: 12,
-          left: 12,
+          top: 8,
+          left: 8,
           zIndex: 50,
           display: 'flex',
           alignItems: 'center',
+          justifyContent: 'center',
           gap: 4,
           fontSize: 13,
           color: 'var(--cc-text-muted, rgba(255,255,255,0.5))',
@@ -36,6 +37,8 @@ export function CosmicShell({ children }: { children: ReactNode }) {
           padding: '4px 8px',
           borderRadius: 6,
           transition: 'color 0.15s',
+          minWidth: 44,
+          minHeight: 44,
         }}
         className="cc-btn hover:!text-white"
       >


### PR DESCRIPTION
## Summary
The CosmicShell exit button (✕ → back to CometCave) had only `padding: '4px 8px'` — roughly 26×26px tap area, well below the 44px mobile accessibility minimum.

Changed to `minWidth: 44, minHeight: 44, justifyContent: 'center'` so thumbs can reliably tap it without hunting for the small target. Position adjusted slightly to `top: 8, left: 8` (was 12/12) to keep the center of the button in the same visual position.

Affects all games using `CosmicShell` (Speck Wars, Comet Cards).

## Test plan
- [ ] On mobile: ✕ exit button is easily tappable in the top-left corner
- [ ] On desktop: button still renders small and unobtrusive

🤖 Generated with [Claude Code](https://claude.com/claude-code)