### PR TITLE
feat(speck-wars): haptic feedback for spawn type + unit action buttons

### DIFF
--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -1424,7 +1424,7 @@ export function HUD() {
                 ].map(({ label, key, action }) => (
                   <button
                     key={label}
-                    onClick={() => { setTouchPatrolActive(false); action?.() }}
+                    onClick={() => { navigator.vibrate?.(8); setTouchPatrolActive(false); action?.() }}
                     style={{
                       background: 'rgba(255,255,255,0.07)',
                       border: '1px solid rgba(255,255,255,0.18)',
@@ -1522,7 +1522,7 @@ export function HUD() {
                 return (
                   <button
                     key={type}
-                    onClick={() => gameActions?.setSpawnType?.(type)}
+                    onClick={() => { navigator.vibrate?.(8); gameActions?.setSpawnType?.(type) }}
                     style={{
                       padding: '8px 10px', fontSize: 10,
                       cursor: 'pointer', letterSpacing: 1,


### PR DESCRIPTION
## Summary
Added short 8ms haptic vibration to the two remaining groups of HUD buttons that were missing it:

1. **Spawn type quick-select** (bottom-right): BASIC / HEAVY / DART buttons
2. **Command panel unit actions** (shown when specks are selected): Stop / Hold / Defend / Advance / Rush / Guard buttons

The large D/N/B action buttons, stance toggle, commander ability, surge, and minimap already had haptic feedback. This completes haptic coverage across all touch-interactive HUD elements.

Haptic pattern used: `vibrate(8)` — the lightest pattern, same as the passive acknowledge used by the large bottom-right action buttons.

## Test plan
- [ ] On Android (vibration API supported): tapping BASIC/HEAVY/DART produces a short pulse
- [ ] On Android: tapping Stop/Hold/Defend/Advance/Rush/Guard produces a short pulse
- [ ] On iOS (vibration API not supported): no error, graceful no-op via `?.`

🤖 Generated with [Claude Code](https://claude.com/claude-code)