### PR TITLE
feat(speck-wars): two-finger tap to stop specks on mobile

### DIFF
--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -767,6 +767,7 @@ export function HUD() {
                 ['Tap canvas', 'Rally units to that spot'],
                 ['Double-tap canvas', 'Zoom in / out (toggle)'],
                 ['Long-press canvas', 'Attack Move (aggressive)'],
+                ['Two-finger tap', 'Stop specks in place'],
                 ['Pinch', 'Zoom in / out (precise)'],
                 ['Drag', 'Pan camera'],
                 ['Tap minimap', 'Navigate camera there'],

--- a/src/app/speck-wars/input/input-handler.ts
+++ b/src/app/speck-wars/input/input-handler.ts
@@ -56,6 +56,9 @@ export class InputHandler {
   private lastTapX = 0
   private lastTapY = 0
   private touchPatrolPending = false
+  private twoFingerActive = false      // true while 2 fingers are on canvas
+  private twoFingerMoved = false       // true if pinch changed significantly (not a tap)
+  private twoFingerTapStartDist = 0   // initial pinch distance when 2nd finger touched
 
   constructor(
     canvas: HTMLCanvasElement,
@@ -297,10 +300,19 @@ export class InputHandler {
         }
       }, 500)
     } else if (e.touches.length === 2) {
+      // Cancel any pending long-press from the first finger
+      if (this.longPressTimer) {
+        clearTimeout(this.longPressTimer)
+        this.longPressTimer = null
+      }
       this.isDragging = false
-      const dx = e.touches[1].clientX - e.touches[0].clientX
-      const dy = e.touches[1].clientY - e.touches[0].clientY
-      this.lastPinchDist = Math.sqrt(dx * dx + dy * dy)
+      const dx2 = e.touches[1].clientX - e.touches[0].clientX
+      const dy2 = e.touches[1].clientY - e.touches[0].clientY
+      const initDist = Math.sqrt(dx2 * dx2 + dy2 * dy2)
+      this.lastPinchDist = initDist
+      this.twoFingerTapStartDist = initDist
+      this.twoFingerActive = true
+      this.twoFingerMoved = false
     }
   }
 
@@ -311,6 +323,10 @@ export class InputHandler {
       const dx = e.touches[1].clientX - e.touches[0].clientX
       const dy = e.touches[1].clientY - e.touches[0].clientY
       const newDist = Math.sqrt(dx * dx + dy * dy)
+      // If pinch distance changed significantly, this is a pinch not a tap
+      if (Math.abs(newDist - this.twoFingerTapStartDist) > 15) {
+        this.twoFingerMoved = true
+      }
       const rawFactor = newDist / this.lastPinchDist
       const factor = 1 + (rawFactor - 1) * 0.4  // dampen to 40% of raw pinch speed
       const rect = this.canvas.getBoundingClientRect()
@@ -380,6 +396,16 @@ export class InputHandler {
           }
         }
       }
+    }
+    // Two-finger tap → stop selected specks
+    if (this.twoFingerActive && !this.twoFingerMoved && e.touches.length === 0) {
+      navigator.vibrate?.([20, 30, 20])  // double-tap pattern — distinct from rally (18ms) and attack-move ([30,60,30])
+      this.onStop?.()
+    }
+    // Reset two-finger state when all fingers lifted
+    if (e.touches.length === 0) {
+      this.twoFingerActive = false
+      this.twoFingerMoved = false
     }
     this.isDragging = false
     this.lastPinchDist = 0


### PR DESCRIPTION
## Summary
Adds a new touch gesture: **two-finger tap** fires the stop command, halting all selected specks in place (equivalent to the 'S' key on desktop).

**Detection logic:**
- Two fingers touch down → `twoFingerActive = true`, initial pinch distance recorded
- If fingers move significantly (pinch change > 15px) → `twoFingerMoved = true` (this is a pinch zoom, not a tap)
- When all fingers lift and `twoFingerActive && !twoFingerMoved` → fire stop

**Bonus fix:** When a second finger touches down, any pending long-press timer from the first finger is now cancelled, preventing accidental attack-move + pinch combinations.

**Haptic:** `[20, 30, 20]` double-pulse, distinct from:
- Single rally: 18ms
- Attack-move: `[30, 60, 30]`
- Double-tap zoom: `[12, 40, 12]`

**Help overlay:** Updated to include "Two-finger tap → Stop specks in place"

## Test plan
- [ ] Two-finger tap without movement → specks halt
- [ ] Pinch to zoom still works without triggering stop
- [ ] Long-press with two fingers (first finger long-press then second touches) → no attack-move fires (timer is cancelled)
- [ ] Stop fires even when no specks are selected (no-op gracefully)

🤖 Generated with [Claude Code](https://claude.com/claude-code)