### PR TITLE
fix(speck-wars): larger building tap targets on mobile

### DIFF
--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -140,11 +140,14 @@ export class GameInstance {
         }
 
         // Check if click hit a player building — select it instead of rallying
+        // Touch devices get a larger buffer to ensure 44px+ screen hit area at default zoom
+        const isTouchDevice = typeof navigator !== 'undefined' && navigator.maxTouchPoints > 0
+        const hitBuffer = isTouchDevice ? 30 : 20
         for (const building of Object.values(this.sim.buildings)) {
           if (building.ownerId !== 'player') continue
           const btype = BUILDING_TYPES[building.typeId]
           const r = btype?.size ?? 20
-          if (Math.hypot(wx - building.x, wy - building.y) <= r + 20) {
+          if (Math.hypot(wx - building.x, wy - building.y) <= r + hitBuffer) {
             navigator.vibrate?.(10)
             this.sim.inputQueue.push({ type: 'SELECT_BUILDING', ownerId: 'player', buildingId: building.id })
             return


### PR DESCRIPTION
## Summary
Outpost buildings have `size=20`, giving a previous hit radius of 40px at zoom=1.0 — just below the 44px mobile touch minimum. Touch devices now get a 30px buffer (was 20px), giving:

| Building | Before | After (touch) |
|---|---|---|
| Base | 60px | 70px |
| Outpost | 40px | 50px |
| Turret | 38px | 48px |

Buildings are spaced 200+ world pixels apart so the larger buffer creates no selection ambiguity between adjacent buildings.

## Test plan
- [ ] On mobile at default zoom: tap near (but not directly on) an outpost to confirm building selection triggers
- [ ] On desktop: hit radius unchanged (20px buffer, same as before)
- [ ] When zoomed in (1.5×), outpost hit area is already 60px screen pixels — both before and after

🤖 Generated with [Claude Code](https://claude.com/claude-code)