### PR TITLE
feat(speck-wars): full-size minimap on tablets (768px+)

### DIFF
--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -341,7 +341,8 @@ export function HUD() {
 
       {/* Mini-map — top right, below difficulty badge */}
       {hud && (() => {
-        const MINIMAP_SIZE = isTouchDevice ? 110 : 160
+        const isNarrowDevice = typeof window !== 'undefined' && window.innerWidth < 768
+        const MINIMAP_SIZE = isTouchDevice && isNarrowDevice ? 110 : 160
         const SCALE = MINIMAP_SIZE / 3000  // world→screen
         return (
           <div style={{


### PR DESCRIPTION
## Summary
Touch devices with screen width ≥ 768px (iPad, Android tablets in landscape) now use the 160px desktop-size minimap instead of the compact 110px phone minimap. Narrow phones (<768px, e.g., iPhone SE/14/15) keep the compact 110px size.

Benefits for tablet players:
- Better minimap fidelity — more distinct speck dots and building markers at 160px
- More precise tap targets when tapping outpost/base positions on the minimap
- Consistent with the desktop experience since tablets have the screen real estate for it

## Test plan
- [ ] On iPad (landscape): minimap renders at 160px
- [ ] On iPhone (landscape): minimap stays at 110px
- [ ] On desktop: minimap stays at 160px (unchanged — `isTouchDevice` is false)

🤖 Generated with [Claude Code](https://claude.com/claude-code)