### PR TITLE
fix(speck-wars): default aggressive stance + outpost upgrade clarity

### DIFF
--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -1400,8 +1400,8 @@ export function HUD() {
                 {b.typeId === 'outpost' && b.ownerId === 'player' && (b.fortifyDuration ?? 0) >= 20000 && (() => {
                   if (b.researchedUpgrade) {
                     return (
-                      <div style={{ marginTop: 8, display: 'flex', alignItems: 'center', gap: 6, fontSize: 10, letterSpacing: 1, color: '#44aaff' }}>
-                        <span>⚗</span><span>{b.researchedUpgrade.toUpperCase()} researched</span>
+                      <div style={{ marginTop: 8, display: 'flex', alignItems: 'center', gap: 6, fontSize: 9, letterSpacing: 1, color: '#44aaff' }}>
+                        <span>⚗</span><span>{b.researchedUpgrade.toUpperCase()} — all units buffed</span>
                       </div>
                     )
                   }
@@ -1412,7 +1412,10 @@ export function HUD() {
                   ]
                   return (
                     <div style={{ marginTop: 8, borderTop: '1px solid rgba(255,255,255,0.07)', paddingTop: 8 }}>
-                      <div style={{ fontSize: 9, letterSpacing: 2, color: 'rgba(255,255,255,0.45)', marginBottom: 6 }}>⚗ RESEARCH</div>
+                      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', marginBottom: 6 }}>
+                        <div style={{ fontSize: 9, letterSpacing: 2, color: 'rgba(255,255,255,0.45)' }}>⚗ RESEARCH</div>
+                        <div style={{ fontSize: 8, color: 'rgba(255,255,255,0.25)', letterSpacing: 0.5 }}>global · pick 1</div>
+                      </div>
                       <div style={{ display: 'flex', gap: 4 }}>
                         {upgrades.map(u => (
                           <button key={u.id} onClick={() => gameActions?.researchUpgrade?.(b.id, u.id)} style={{

--- a/src/app/speck-wars/domain/simulation/create-sim.ts
+++ b/src/app/speck-wars/domain/simulation/create-sim.ts
@@ -94,7 +94,7 @@ export function createSim(seed: number = Date.now(), difficulty: Difficulty = 'm
   const player: Player = {
     id: 'player', name: 'Player',
     color: PLAYER_COLOR, isAI: false, isDefeated: false, stockpile: {},
-    totalKills: 0, upgradeLevel: 0, stance: 'defensive', creepCampBoostMs: 0,
+    totalKills: 0, upgradeLevel: 0, stance: 'aggressive', creepCampBoostMs: 0,
     outpostUpgrades: { carapace: false, blades: false, afterburners: false },
     supply: 0,
   }

--- a/src/app/speck-wars/store.ts
+++ b/src/app/speck-wars/store.ts
@@ -128,7 +128,7 @@ export const useSpeckWarsStore = create<SpeckWarsStore>()((set, get) => ({
     const next = s.killFeed.filter(e => e.ts > cutoff)
     return next.length === s.killFeed.length ? s : { killFeed: next }
   }),
-  stance: 'defensive' as 'aggressive' | 'defensive' | 'hold',
+  stance: 'aggressive' as 'aggressive' | 'defensive' | 'hold',
   setStance: stance => set({ stance }),
   aiPersonality: null,
   setAiPersonality: p => set({ aiPersonality: p }),
@@ -164,7 +164,7 @@ export const useSpeckWarsStore = create<SpeckWarsStore>()((set, get) => ({
     outpostsCaptured: 0,
     killFeed: [],
     aiPersonality: null,
-    stance: 'defensive' as 'aggressive' | 'defensive' | 'hold',
+    stance: 'aggressive' as 'aggressive' | 'defensive' | 'hold',
     difficulty: s.difficulty,
   })),
 }))


### PR DESCRIPTION
## Summary
- Changes default player stance from `defensive` to `aggressive` (150px aggro range vs 40px) — players can start fighting immediately without fiddling with the stance button
- Adds clarity to the outpost research panel: "global · pick 1" label and "all units buffed" feedback for already-researched upgrades

## Changes
- `store.ts`: default stance → `'aggressive'` (initial state + resetGame)
- `domain/simulation/create-sim.ts`: player spawn stance → `'aggressive'`
- `components/hud.tsx`: research panel header + researched state label

## Addresses
Part of #2259 (Speck Wars audit — simplify/polish items)

🤖 Generated with [Claude Code](https://claude.com/claude-code)