### PR TITLE
fix(speck-wars): reduce sacrifice cooldown from 45s to 20s

### DIFF
--- a/src/app/speck-wars/domain/simulation/tick.ts
+++ b/src/app/speck-wars/domain/simulation/tick.ts
@@ -571,7 +571,7 @@ function consumeInputs(sim: SimulationState) {
         sim.speckHp[i] = 0  // mark for removeDeadSpecks
       }
       building.hp = Math.min(building.maxHp, building.hp + event.count * 1.5)  // 10 specks → +15 HP
-      sim.sacrificeCooldown = 45000
+      sim.sacrificeCooldown = 20000
     }
   }
   sim.inputQueue = []


### PR DESCRIPTION
## Summary
Reduces the sacrifice/turret-build cooldown from 45 seconds to 20 seconds.

Turrets have low DPS (~0.83 dps) so the current 45s cooldown makes the mechanic feel unusable. 20s still prevents spam while rewarding active play.

## Addresses
Part of #2259 audit — sacrifice mechanic simplification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)