### PR TITLE
feat(speck-wars): show commander respawn countdown in HUD

### DIFF
--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -1801,7 +1801,29 @@ export function HUD() {
           })()}
           {(() => {
             const cmd = hud?.commander
-            if (!cmd || cmd.level < 2) return null
+            const respawnMs = hud?.commanderRespawnMs ?? 0
+            if (!cmd || cmd.level < 2) {
+              if (respawnMs > 0) {
+                return (
+                  <div style={{
+                    padding: '8px 12px',
+                    fontSize: 11,
+                    background: 'rgba(0,0,0,0.3)',
+                    border: '1px solid rgba(255,215,0,0.25)',
+                    borderRadius: 20,
+                    color: 'rgba(255,215,0,0.5)',
+                    letterSpacing: 1,
+                    fontFamily: 'monospace',
+                    minHeight: 44,
+                    display: 'flex',
+                    alignItems: 'center',
+                  }}>
+                    ★ {Math.ceil(respawnMs / 1000)}s
+                  </div>
+                )
+              }
+              return null
+            }
             const cd = cmd.abilityCooldown
             const active = cmd.abilityActive > 0
             const ready = cd <= 0 && !active

--- a/src/app/speck-wars/domain/simulation/tick.ts
+++ b/src/app/speck-wars/domain/simulation/tick.ts
@@ -756,5 +756,5 @@ function emitHudUpdate(sim: SimulationState) {
     }
   }
 
-  sim.events.push({ type: 'HUD_UPDATE', data: { players: data, attackedBuildingIds, tripleOutpostOwner, dominationProgress, captureInfo, surgeDuration: sim.surgeDuration, surgeCooldown: sim.surgeCooldown, selectedSpeckCount: sim.selectedSpeckIds.size, selectedComposition, spawnRates, minimap, outpostFortify, dailyModifier: sim.dailyModifier, waveCountdown: sim.waveCountdown, waveInProgress: sim.waveInProgress, sacrificeCooldown: sim.sacrificeCooldown, commander, baseUnderThreat, enemyAdvanceDetected, rallyCryActive, creepCampBoostMs: sim.players['player']?.creepCampBoostMs ?? 0, selectedBuilding } })
+  sim.events.push({ type: 'HUD_UPDATE', data: { players: data, attackedBuildingIds, tripleOutpostOwner, dominationProgress, captureInfo, surgeDuration: sim.surgeDuration, surgeCooldown: sim.surgeCooldown, selectedSpeckCount: sim.selectedSpeckIds.size, selectedComposition, spawnRates, minimap, outpostFortify, dailyModifier: sim.dailyModifier, waveCountdown: sim.waveCountdown, waveInProgress: sim.waveInProgress, sacrificeCooldown: sim.sacrificeCooldown, commander, baseUnderThreat, enemyAdvanceDetected, rallyCryActive, creepCampBoostMs: sim.players['player']?.creepCampBoostMs ?? 0, selectedBuilding, commanderRespawnMs: sim.heroRespawnTimer['player'] ?? 0 } })
 }

--- a/src/app/speck-wars/domain/types.ts
+++ b/src/app/speck-wars/domain/types.ts
@@ -189,6 +189,7 @@ export interface HudData {
   waveInProgress: boolean
   sacrificeCooldown: number
   commander: { level: number; abilityCooldown: number; abilityActive: number } | null
+  commanderRespawnMs: number   // ms until player commander respawns; 0 if alive or not yet spawned
   baseUnderThreat: boolean
   enemyAdvanceDetected: boolean
   rallyCryActive: boolean


### PR DESCRIPTION
## Summary
- When the player's commander dies, a gold **★ Ns** badge now counts down in the action bar until respawn (15s)
- Previously the slot went blank with no feedback — players had no idea the commander was dead or when it was coming back

## Changes
- `domain/types.ts`: add `commanderRespawnMs: number` to `HudData`
- `domain/simulation/tick.ts`: populate `commanderRespawnMs` from `sim.heroRespawnTimer['player']`
- `components/hud.tsx`: render countdown badge when commander is dead

🤖 Generated with [Claude Code](https://claude.com/claude-code)