### PR TITLE
feat(speck-wars): mention domination in triple outpost notifications

### DIFF
--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -553,10 +553,12 @@ export class GameInstance {
           const holder = event.data.tripleOutpostOwner ?? null
           if (holder !== this.lastTripleHolder) {
             if (holder === 'player') {
-              this.notify('⬡ TRIPLE OUTPOST! 2× PRODUCTION ACTIVE', '#ffd700', 4000)
+              this.notify('⬡ TRIPLE OUTPOST — 2× PRODUCTION + DOMINATION IN 60s!', '#ffd700', 5000)
             } else if (holder === 'ai' && this.lastTripleHolder !== null) {
               // AI reclaimed triple — only notify if player had just lost it
-              this.notify('⬡ ENEMY HAS ALL OUTPOSTS!', '#ff4f7b', 3000)
+              this.notify('⬡ ENEMY DOMINATES — 60s TO WIN! RECAPTURE!', '#ff4f7b', 5000)
+            } else if (holder === 'ai') {
+              this.notify('⬡ ENEMY HAS ALL OUTPOSTS — 60s TO WIN!', '#ff4f7b', 5000)
             }
             this.lastTripleHolder = holder
           }


### PR DESCRIPTION
## Summary
Updates triple-outpost notifications to mention the 60-second domination win condition.

- Player gains all outposts: "⬡ TRIPLE OUTPOST — 2× PRODUCTION + DOMINATION IN 60s!"
- AI gains all outposts: "⬡ ENEMY HAS ALL OUTPOSTS — 60s TO WIN!" or "DOMINATE — 60s TO WIN! RECAPTURE!"

🤖 Generated with [Claude Code](https://claude.com/claude-code)