### PR TITLE
feat(speck-wars): notify player when surge and ability cooldowns expire

### DIFF
--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -47,6 +47,8 @@ export class GameInstance {
   private notifGen = 0
   private prevBaseUnderThreat = false
   private prevEnemyAdvance = false
+  private prevSurgeCooldown = 0
+  private prevCommanderAbilityCooldown = 0
   private controlGroups = new Map<number, string[]>()
   private lastAdvanceMs = 0
   private lastAdvanceIdx = 0
@@ -563,6 +565,22 @@ export class GameInstance {
             this.lastTripleHolder = holder
           }
 
+          // Surge cooldown ready notification
+          const surgeCd = event.data.surgeCooldown ?? 0
+          const surgeActive = (event.data.surgeDuration ?? 0) > 0
+          if (!surgeActive && surgeCd === 0 && this.prevSurgeCooldown > 0) {
+            this.notify('⚡ SURGE READY', '#ffd700', 2000)
+          }
+          this.prevSurgeCooldown = surgeCd
+
+          // Commander ability cooldown ready notification
+          const cmdData = event.data.commander
+          const cmdCd = cmdData?.abilityCooldown ?? 0
+          const commanderAlive = cmdData !== null && (event.data.commanderRespawnMs ?? 0) === 0
+          if (commanderAlive && cmdCd === 0 && this.prevCommanderAbilityCooldown > 0) {
+            this.notify('★ ABILITY READY', 'rgba(255,215,0,0.85)', 2000)
+          }
+          this.prevCommanderAbilityCooldown = commanderAlive ? cmdCd : 0
 
         }
         if (event.type === 'SPECK_DIED') {


### PR DESCRIPTION
## Summary
- Adds **⚡ SURGE READY** toast when the production surge cooldown (Q) hits zero
- Adds **★ ABILITY READY** toast when the commander's Battle Roar / Last Stand cooldown (Y) hits zero
- Both fire only on the `> 0 → 0` transition — no spurious notifications at game start or after commander respawn

## Why
Players miss action windows because Surge (~60s cooldown) and Commander Ability (~30s cooldown) expire silently. These are long enough that players forget about them mid-battle. A brief toast closes the feedback loop without adding persistent UI.

## Test plan
- [ ] Use Surge (Q), wait for cooldown — toast should appear when it expires
- [ ] Level commander to 2+, use ability (Y), wait for cooldown — toast should appear
- [ ] Verify no spurious toast fires at game start (both timers already at 0)
- [ ] Verify no spurious toast fires immediately after commander respawn

🤖 Generated with [Claude Code](https://claude.com/claude-code)