### PR TITLE
fix(speck-wars): guard surge and sacrifice against silent cooldown failures

### DIFF
--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -191,7 +191,7 @@ export class GameInstance {
         this.sim.inputQueue.push({ type: 'CLEAR_SELECT', ownerId: 'player' })
         this.sim.rallyPoints['player-selected'] = null
       },
-      () => { this.surge(); this.notify('⚡ SURGE ACTIVE!', '#ffd700') },  // Q — production surge
+      () => { this.surge() },  // Q — production surge
       () => { this.snapToAction() },                                        // V — snap camera to battle
       () => { this.snapToBase() },                                          // H — snap camera to home base
       (typeId: 'basic' | 'heavy' | 'scout') => {               // 1/2/3 — set spawn type for selected building only
@@ -277,7 +277,7 @@ export class GameInstance {
         this.sim.inputQueue.push({ type: 'CLEAR_SELECT', ownerId: 'player' })
         this.sim.rallyPoints['player-selected'] = null
       },
-      surge: () => { this.surge(); this.notify('⚡ SURGE ACTIVE!', '#ffd700') },
+      surge: () => { this.surge() },
       rally: (x: number, y: number) => this.rally(x, y),
       sacrifice: () => { this.sacrifice() },
       setSpawnType: (typeId: 'basic' | 'heavy' | 'scout') => {
@@ -969,11 +969,23 @@ export class GameInstance {
   }
 
   surge() {
+    if (this.sim.surgeDuration > 0) return  // already active — do nothing
+    if (this.sim.surgeCooldown > 0) {
+      const remaining = Math.ceil(this.sim.surgeCooldown / 1000)
+      this.notify(`Surge ready in ${remaining}s`, 'rgba(255,215,0,0.65)', 1200)
+      return
+    }
     this.sim.inputQueue.push({ type: 'SURGE', ownerId: 'player' })
     useSpeckWarsStore.getState().addSurgeUsed()
+    this.notify('⚡ SURGE ACTIVE!', '#ffd700')
   }
 
   private sacrifice() {
+    if (this.sim.sacrificeCooldown > 0) {
+      const remaining = Math.ceil(this.sim.sacrificeCooldown / 1000)
+      this.notify(`Sacrifice ready in ${remaining}s`, 'rgba(255,100,100,0.65)', 1200)
+      return
+    }
     const playerBase = Object.values(this.sim.buildings).find(b => b.ownerId === 'player' && b.typeId === 'base')
     if (!playerBase) return
     const speckCount = this.sim.speckMeta.filter((m, i) => m && m.ownerId === 'player' && this.sim.speckIds[i]).length


### PR DESCRIPTION
## Summary
- `surge()` now checks `sim.surgeDuration` and `sim.surgeCooldown` before queuing — shows "Surge ready in Ns" feedback if on cooldown, no-ops silently if already active
- `sacrifice()` now checks `sim.sacrificeCooldown` — shows "Sacrifice ready in Ns" feedback
- "⚡ SURGE ACTIVE!" notification moved inside `surge()` so it only fires when the surge actually activates (previously it fired unconditionally even when the tick silently rejected the input)
- Stat counters (`addSurgeUsed`, `addSacrificeUsed`) no longer inflate on rejected calls

## Why this matters
Previously spam-pressing Q while surge was on cooldown would silently fail, increment the surge-used counter, and show no feedback. This made it seem like the key binding was broken.

## Test plan
- [ ] Press Q while surge is active — no notification, no stat bump
- [ ] Press Q while surge is on cooldown — "Surge ready in Ns" toast
- [ ] Press Q when surge is ready — "⚡ SURGE ACTIVE!" toast, surge activates
- [ ] Try sacrifice (E) while on cooldown — "Sacrifice ready in Ns" toast

🤖 Generated with [Claude Code](https://claude.com/claude-code)