### PR TITLE
feat(speck-wars): warn player at 15s and 10s when enemy is about to win by domination

### DIFF
--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -49,8 +49,9 @@ export class GameInstance {
   private prevEnemyAdvance = false
   private prevSurgeCooldown = 0
   private prevCommanderAbilityCooldown = 0
-  private dominationWarnedAt15s = false   // true once "15s left" AI domination warning fires
-  private dominationWarnedAt10s = false   // true once "10s left" AI domination warning fires
+  private dominationWarnedAt15s = false         // true once "15s left" AI domination warning fires
+  private dominationWarnedAt10s = false         // true once "10s left" AI domination warning fires
+  private dominationPlayerWarnedAt15s = false   // true once "15s left" player domination win warning fires
   private controlGroups = new Map<number, string[]>()
   private lastAdvanceMs = 0
   private lastAdvanceIdx = 0
@@ -570,6 +571,9 @@ export class GameInstance {
               this.dominationWarnedAt15s = false
               this.dominationWarnedAt10s = false
             }
+            if (holder !== 'player') {
+              this.dominationPlayerWarnedAt15s = false
+            }
           }
           // Domination critical warnings: AI is about to win
           if (holder === 'ai' && event.data.dominationProgress !== null) {
@@ -583,6 +587,16 @@ export class GameInstance {
               this.dominationWarnedAt10s = true
               this.notify('⬡ DOMINATION IMMINENT!', '#ff0055', 3000)
               navigator.vibrate?.([400, 100, 400])
+            }
+          }
+          // Domination win approaching: player is about to win
+          if (holder === 'player' && event.data.dominationProgress !== null) {
+            const progress = event.data.dominationProgress
+            const secsLeft = Math.ceil((1 - progress) * 60)
+            if (secsLeft <= 15 && !this.dominationPlayerWarnedAt15s) {
+              this.dominationPlayerWarnedAt15s = true
+              this.notify(`⬡ DOMINATION IN ${secsLeft}s — HOLD THE LINE!`, '#ffd700', 3000)
+              navigator.vibrate?.([100, 50, 100])
             }
           }
 

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -49,6 +49,8 @@ export class GameInstance {
   private prevEnemyAdvance = false
   private prevSurgeCooldown = 0
   private prevCommanderAbilityCooldown = 0
+  private dominationWarnedAt15s = false   // true once "15s left" AI domination warning fires
+  private dominationWarnedAt10s = false   // true once "10s left" AI domination warning fires
   private controlGroups = new Map<number, string[]>()
   private lastAdvanceMs = 0
   private lastAdvanceIdx = 0
@@ -563,6 +565,25 @@ export class GameInstance {
               this.notify('⬡ ENEMY HAS ALL OUTPOSTS — 60s TO WIN!', '#ff4f7b', 5000)
             }
             this.lastTripleHolder = holder
+            // Reset domination warnings when control changes
+            if (holder !== 'ai') {
+              this.dominationWarnedAt15s = false
+              this.dominationWarnedAt10s = false
+            }
+          }
+          // Domination critical warnings: AI is about to win
+          if (holder === 'ai' && event.data.dominationProgress !== null) {
+            const progress = event.data.dominationProgress
+            const secsLeft = Math.ceil((1 - progress) * 60)
+            if (secsLeft <= 15 && !this.dominationWarnedAt15s) {
+              this.dominationWarnedAt15s = true
+              this.notify(`⬡ ENEMY WINS IN ${secsLeft}s — RECAPTURE NOW!`, '#ff0055', 3000)
+              navigator.vibrate?.([200, 100, 200, 100, 200])
+            } else if (secsLeft <= 10 && !this.dominationWarnedAt10s) {
+              this.dominationWarnedAt10s = true
+              this.notify('⬡ DOMINATION IMMINENT!', '#ff0055', 3000)
+              navigator.vibrate?.([400, 100, 400])
+            }
           }
 
           // Surge cooldown ready notification


### PR DESCRIPTION
## Summary
- Fires "⬡ ENEMY WINS IN 15s — RECAPTURE NOW!" toast + vibrate pattern when AI domination reaches 45s
- Fires "⬡ DOMINATION IMMINENT!" toast + stronger vibrate at 50s
- Warning thresholds reset when the AI loses triple outpost control, so they can re-fire if AI regains all outposts

## Why
The domination progress bar fills silently. In practice, players often lose by domination without realizing they were close to the 60s threshold until the GAME OVER screen appears. These two warnings give enough time to react and send an army to recapture.

## Test plan
- [ ] Let the AI capture all 3 outposts in a medium+ game
- [ ] Wait ~45s — "⬡ ENEMY WINS IN 15s" toast should appear with strong vibration
- [ ] If not recaptured, at ~50s "⬡ DOMINATION IMMINENT!" should appear
- [ ] Recapture an outpost, wait for AI to retake triple — warnings should fire again

🤖 Generated with [Claude Code](https://claude.com/claude-code)