### PR TITLE
feat(speck-wars): notify when outpost fortification unlocks research

### DIFF
--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -567,7 +567,6 @@ export class GameInstance {
           }
 
           // Research available notification: outpost held 20s+ unlocks upgrade research
-          const playerBuildingHp = event.data.players.player?.buildingHp ?? {}
           const RESEARCH_FORTIFY_THRESHOLD = 20000 / 30000  // 0.667 — matches tick.ts gate
           for (const [outpostId, fortLevel] of Object.entries(event.data.outpostFortify ?? {})) {
             if (!(outpostId in playerBuildingHp)) {

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -49,6 +49,7 @@ export class GameInstance {
   private prevEnemyAdvance = false
   private prevSurgeCooldown = 0
   private prevCommanderAbilityCooldown = 0
+  private fortifyResearchNotified = new Set<string>()  // outpost IDs for which research-ready was notified
   private controlGroups = new Map<number, string[]>()
   private lastAdvanceMs = 0
   private lastAdvanceIdx = 0
@@ -563,6 +564,22 @@ export class GameInstance {
               this.notify('⬡ ENEMY HAS ALL OUTPOSTS — 60s TO WIN!', '#ff4f7b', 5000)
             }
             this.lastTripleHolder = holder
+          }
+
+          // Research available notification: outpost held 20s+ unlocks upgrade research
+          const playerBuildingHp = event.data.players.player?.buildingHp ?? {}
+          const RESEARCH_FORTIFY_THRESHOLD = 20000 / 30000  // 0.667 — matches tick.ts gate
+          for (const [outpostId, fortLevel] of Object.entries(event.data.outpostFortify ?? {})) {
+            if (!(outpostId in playerBuildingHp)) {
+              // Lost the outpost — reset so we can re-notify if recaptured
+              this.fortifyResearchNotified.delete(outpostId)
+              continue
+            }
+            if (fortLevel >= RESEARCH_FORTIFY_THRESHOLD && !this.fortifyResearchNotified.has(outpostId)) {
+              this.fortifyResearchNotified.add(outpostId)
+              const name = outpostId.replace('outpost-', '').toUpperCase()
+              this.notify(`⚗ ${name} FORTIFIED — upgrade research available`, '#44aaff', 3500)
+            }
           }
 
           // Surge cooldown ready notification


### PR DESCRIPTION
## Summary
- Fires "⚗ {OUTPOST} FORTIFIED — upgrade research available" toast when a player-owned outpost reaches 20s continuous hold
- Resets per-outpost when lost, so the notification re-fires on recapture
- Helps players discover the upgrade research panel, which is easy to miss since it only appears after 20s of holding

## Why this matters
The research panel (Carapace / Blades / Afterburners) is a significant game mechanic that many players never encounter because it silently appears in the building panel after 20s. This toast draws attention at the exact moment research becomes available, without being repeated noise.

## Test plan
- [ ] Capture an outpost and hold for 20s — toast should fire once
- [ ] Open the outpost building panel — research options should be available
- [ ] Lose the outpost and recapture — toast should fire again after another 20s hold

🤖 Generated with [Claude Code](https://claude.com/claude-code)