### PR TITLE
feat(speck-wars): fire wave pre-warning toast 30s before AI assault

### DIFF
--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -49,6 +49,7 @@ export class GameInstance {
   private prevEnemyAdvance = false
   private prevSurgeCooldown = 0
   private prevCommanderAbilityCooldown = 0
+  private prevWaveCountdown: number | null = null  // track wave countdown for 30s pre-warning
   private controlGroups = new Map<number, string[]>()
   private lastAdvanceMs = 0
   private lastAdvanceIdx = 0
@@ -564,6 +565,16 @@ export class GameInstance {
             }
             this.lastTripleHolder = holder
           }
+
+          // Wave pre-warning: fire a toast 30s before each AI wave
+          const waveCd = event.data.waveCountdown ?? null
+          const waveInProg = event.data.waveInProgress ?? false
+          if (!waveInProg && waveCd !== null && waveCd < 30000
+              && (this.prevWaveCountdown === null || this.prevWaveCountdown >= 30000)) {
+            const secs = Math.ceil(waveCd / 1000)
+            this.notify(`⚠ WAVE IN ${secs}s — PREPARE DEFENSES`, '#ff6b35', 2500)
+          }
+          this.prevWaveCountdown = waveCd
 
           // Surge cooldown ready notification
           const surgeCd = event.data.surgeCooldown ?? 0


### PR DESCRIPTION
## Summary
- Fires "⚠ WAVE IN {N}s — PREPARE DEFENSES" toast when AI wave countdown first drops below 30s
- Repeats each wave cycle (resets on wave start/reset)
- Does not fire if a wave is already in progress (the WAVE ASSAULT toast handles that)

## Why
Players watch the wave countdown bar appear in the HUD but get no proactive alert. The 30s window gives time to recall specks to base, use surge, or reposition before the WAVE ASSAULT toast fires at T=0.

## Test plan
- [ ] Play on hard/very-hard difficulty (waves enabled)
- [ ] ~30s before a wave: "⚠ WAVE IN 30s — PREPARE DEFENSES" toast should appear
- [ ] Wave starts: existing "⚠ WAVE N ASSAULT!" toast fires as before
- [ ] After wave: next cycle also triggers the 30s warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)