### PR TITLE
fix(speck-wars): add tooltip to daily modifier badge

### DIFF
--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -1,7 +1,7 @@
 'use client'
 import { useState, useEffect, useRef } from 'react'
 import { useSpeckWarsStore } from '../store'
-import { PLAYER_COLOR, AI_COLOR } from '../domain/constants'
+import { PLAYER_COLOR, AI_COLOR, DAILY_MODIFIER_LABELS } from '../domain/constants'
 import { getBestTime, getWinStreak } from '../lib/personal-best'
 import { onLongPressStart, onLongPressCancel, onTapRipple } from '../input/touch-feedback'
 
@@ -346,7 +346,10 @@ export function HUD() {
               DAILY MAP · {new Date().toLocaleDateString('en-US', { month: 'short', day: 'numeric' }).toUpperCase()}
             </span>
             {hud?.dailyModifier && hud.dailyModifier !== 'standard' && (
-              <span style={{ color: '#ffd700', fontSize: isTouchDevice ? 10 : 8, letterSpacing: 0.5, opacity: 0.7, textAlign: 'right' }}>
+              <span
+                title={DAILY_MODIFIER_LABELS[hud.dailyModifier]}
+                style={{ color: '#ffd700', fontSize: isTouchDevice ? 10 : 8, letterSpacing: 0.5, opacity: 0.7, textAlign: 'right', cursor: 'help' }}
+              >
                 {hud.dailyModifier === 'bulwark' ? '⚔ BULWARK' : hud.dailyModifier === 'blitz' ? '⚡ BLITZ' : '🏰 SIEGE'}
               </span>
             )}


### PR DESCRIPTION
## Summary
- Hovering the BULWARK/BLITZ/SIEGE badge now shows the full description
- Uses the existing `DAILY_MODIFIER_LABELS` record from `constants.ts`
- Added `cursor: 'help'` to signal it's hoverable

Example tooltips:
- `⚔ BULWARK — bases have 2× HP`
- `⚡ BLITZ — 1.5× production speed`
- `🏰 SIEGE — outposts take 2× longer to capture`

🤖 Generated with [Claude Code](https://claude.com/claude-code)