### PR TITLE
fix(speck-wars): remove misleading morale/rage percentages, clarify sacrifice cooldown

### DIFF
--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -1168,7 +1168,7 @@ export function HUD() {
                 border: '1px solid rgba(255,215,0,0.4)', borderRadius: 3,
                 padding: '2px 6px',
               }}>
-                ⚡ MORALE +20%
+                ⚡ MORALE SURGE
               </span>
             )}
             {enemyMoraleActive && (
@@ -1189,7 +1189,7 @@ export function HUD() {
                 padding: '2px 6px',
                 fontWeight: 'bold',
               }}>
-                ⚡ RAGE +40%
+                ⚡ LAST STAND
               </span>
             )}
           </div>

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -1075,7 +1075,7 @@ export class GameInstance {
     }
     this.sim.inputQueue.push({ type: 'SACRIFICE', ownerId: 'player', buildingId: playerBase.id, typeId: 'basic', count: 10 })
     useSpeckWarsStore.getState().addSacrificeUsed()
-    this.notify('⟡ SACRIFICE — +15 BASE HP', '#ff8844', 1500)
+    this.notify('⟡ SACRIFICE — +15 BASE HP (ready in 20s)', '#ff8844', 1800)
   }
 
   garrison(buildingId: string) {


### PR DESCRIPTION
## Summary
- `MORALE +20%` → `MORALE SURGE`: badge was cosmetic-only with no simulation effect; removing false percentage claim
- `RAGE +40%` → `LAST STAND`: same — no actual 40% bonus exists in simulation
- Sacrifice success toast now says "(ready in 20s)" so players understand why F doesn't immediately work again

## Why
The +20%/+40% labels implied gameplay bonuses that never fire. A player who reads them and looks for the mechanical effect finds nothing — trust erosion. Renaming to evocative terms keeps the atmosphere without the false promise.

## Metric
Session length — players who understand cooldowns are less likely to rage-quit when abilities appear broken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)