### PR TITLE
fix(speck-wars): improve garrison/recall toast messages

### DIFF
--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -1094,13 +1094,13 @@ export class GameInstance {
     }
     if (speckIds.length === 0) return
     this.sim.inputQueue.push({ type: 'GARRISON', ownerId: 'player', buildingId, speckIds })
-    this.notify('GARRISON', '#44aaff', 1200)
+    this.notify(`⊡ GARRISONED ${speckIds.length} SPECK${speckIds.length !== 1 ? 'S' : ''}`, '#44aaff', 1200)
     navigator.vibrate?.([20, 40, 20])
   }
 
   recallGarrison(buildingId: string) {
     this.sim.inputQueue.push({ type: 'RECALL_GARRISON', ownerId: 'player', buildingId })
-    this.notify('RECALL', '#44aaff', 900)
+    this.notify('⊡ GARRISON RECALLED', '#44aaff', 900)
     navigator.vibrate?.([15, 30])
   }
 


### PR DESCRIPTION
## Summary
- 'GARRISON' → '⊡ GARRISONED N SPECKS': tells the player exactly how many units were posted, not just that the action fired
- 'RECALL' → '⊡ GARRISON RECALLED': consistent style, clearer than just 'RECALL'

## Metric
Session length — better action feedback means fewer "did that work?" doubts that cause players to retry unnecessarily.

🤖 Generated with [Claude Code](https://claude.com/claude-code)