### PR TITLE
fix(speck-wars): correct hero vs commander death/respawn notifications

### DIFF
--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -49,6 +49,7 @@ export class GameInstance {
   private prevEnemyAdvance = false
   private prevSurgeCooldown = 0
   private prevCommanderAbilityCooldown = 0
+  private prevCommanderRespawnMs = 0
   private dominationWarnedAt15s = false         // true once "15s left" AI domination warning fires
   private dominationWarnedAt10s = false         // true once "10s left" AI domination warning fires
   private dominationPlayerWarnedAt15s = false   // true once "15s left" player domination win warning fires
@@ -638,11 +639,18 @@ export class GameInstance {
           // Commander ability cooldown ready notification
           const cmdData = event.data.commander
           const cmdCd = cmdData?.abilityCooldown ?? 0
-          const commanderAlive = cmdData !== null && (event.data.commanderRespawnMs ?? 0) === 0
+          const respawnMs = event.data.commanderRespawnMs ?? 0
+          const commanderAlive = cmdData !== null && respawnMs === 0
           if (commanderAlive && cmdCd === 0 && this.prevCommanderAbilityCooldown > 0) {
             this.notify('★ ABILITY READY', 'rgba(255,215,0,0.85)', 2000)
           }
           this.prevCommanderAbilityCooldown = commanderAlive ? cmdCd : 0
+
+          // Commander respawn notification
+          if (respawnMs === 0 && this.prevCommanderRespawnMs > 0) {
+            this.notify('⚔ COMMANDER REBORN', '#4af7c4', 2000)
+          }
+          this.prevCommanderRespawnMs = respawnMs
 
         }
         if (event.type === 'SPECK_DIED') {
@@ -852,11 +860,11 @@ export class GameInstance {
           store.pushKillFeedEntry({ icon: '⚔', label: 'COMMANDER LEVELS UP', color: '#ffd700' })
         }
         if (event.type === 'HERO_DIED' && event.ownerId === 'player') {
-          this.notify('⚔ COMMANDER FALLEN — RESPAWNING IN 15s', '#ff4f7b', 4000)
-          store.pushKillFeedEntry({ icon: '†', label: `COMMANDER FALLEN (${event.kills} kills)`, color: '#ff4f7b' })
+          this.notify('⚔ HERO FALLEN — respawning', '#ff8844', 3000)
+          store.pushKillFeedEntry({ icon: '†', label: `HERO FALLEN (${event.kills} kills)`, color: '#ff8844' })
         }
         if (event.type === 'HERO_SPAWNED' && event.ownerId === 'player') {
-          this.notify('⚔ COMMANDER REBORN', '#4af7c4', 2000)
+          this.notify('⚔ HERO REBORN', '#88ffdd', 2000)
         }
         if (event.type === 'COMMANDER_LEVEL_UP' && event.ownerId === 'player') {
           const label = event.level === 2 ? '⚡ COMMANDER LVL 2 — AoE PULSE' : '🌟 COMMANDER LVL 3 — SPEED AURA'


### PR DESCRIPTION
## Summary
- `HERO_DIED` was incorrectly showing "COMMANDER FALLEN" — the hero speck (old hero system, `isHero`) and the commander unit (`isCommander`) are two distinct entities; the messages were treating them as the same
- Kill feed also showed "COMMANDER FALLEN" for hero speck deaths, misleading players whose commander was still alive
- `HERO_SPAWNED` said "COMMANDER REBORN" — same misidentification
- Commander had **no** respawn notification at all (the commander spawn path pushes no sim event), so players had no toast when their commander came back

## Fixes
- `HERO_DIED` → `⚔ HERO FALLEN — respawning` (orange, distinct from commander death)
- `HERO_SPAWNED` → `⚔ HERO REBORN` (teal variant)
- Commander respawn detected via `prevCommanderRespawnMs` transition in the HUD_UPDATE handler (mirrors the surge/sacrifice cooldown pattern already used)

## Metric
Session length — players who understand their units aren't confused by false "commander dead" signals when pushing aggressively.

🤖 Generated with [Claude Code](https://claude.com/claude-code)