### PR TITLE
fix(speck-wars): align hero/commander level-up notifications with actual ability names

### DIFF
--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -853,11 +853,11 @@ export class GameInstance {
         }
         if (event.type === 'HERO_LEVELED' && event.ownerId === 'player') {
           if (event.heroLevel === 1) {
-            this.notify('⚔ COMMANDER BLOODED — +15% SPEED', '#ffd700', 3000)
+            this.notify('⚔ HERO BLOODED — +15% SPEED', '#ffd700', 3000)
           } else if (event.heroLevel === 2) {
-            this.notify('⚔ COMMANDER EMPOWERED — AoE PULSE ACTIVE', '#ffd700', 3000)
+            this.notify('⚔ HERO EMPOWERED — AoE PULSE ACTIVE', '#ffd700', 3000)
           }
-          store.pushKillFeedEntry({ icon: '⚔', label: 'COMMANDER LEVELS UP', color: '#ffd700' })
+          store.pushKillFeedEntry({ icon: '⚔', label: 'HERO LEVELS UP', color: '#ffd700' })
         }
         if (event.type === 'HERO_DIED' && event.ownerId === 'player') {
           this.notify('⚔ HERO FALLEN — respawning', '#ff8844', 3000)
@@ -867,7 +867,7 @@ export class GameInstance {
           this.notify('⚔ HERO REBORN', '#88ffdd', 2000)
         }
         if (event.type === 'COMMANDER_LEVEL_UP' && event.ownerId === 'player') {
-          const label = event.level === 2 ? '⚡ COMMANDER LVL 2 — AoE PULSE' : '🌟 COMMANDER LVL 3 — SPEED AURA'
+          const label = event.level === 2 ? '⚡ COMMANDER LVL 2 — BATTLE ROAR UNLOCKED' : '🌟 COMMANDER LVL 3 — LAST STAND UNLOCKED'
           this.notify(label, '#ffd700', 4000)
           store.pushKillFeedEntry({ icon: '⭐', label: label.split(' — ')[0].replace('⚡ ', '').replace('🌟 ', ''), color: '#ffd700' })
         }


### PR DESCRIPTION
## Summary
Two sets of level-up toast labels were describing abilities that don't exist:

**HERO_LEVELED:**
- 'COMMANDER BLOODED' → 'HERO BLOODED' — hero speck (isHero) is a different unit from the commander (isCommander)
- 'COMMANDER EMPOWERED' → 'HERO EMPOWERED' — same misidentification

**COMMANDER_LEVEL_UP:**
- Level 2: 'AoE PULSE' → 'BATTLE ROAR UNLOCKED' — the actual ability is Battle Roar (stun enemies in range), not a generic AoE pulse
- Level 3: 'SPEED AURA' → 'LAST STAND UNLOCKED' — the actual ability is Last Stand (commander invulnerable + 3× dmg + nearby speed boost), not a speed aura

Players who see 'AoE PULSE UNLOCKED' and then press Y would expect a visual pulse effect they'd never find. Naming matches what the HUD tooltip says.

## Metric
Session length — players who understand their abilities use them correctly instead of thinking they're broken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)