### PR TITLE
fix(speck-wars): add desktop attack-move tutorial hint; clarify legend toast

### DIFF
--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -404,7 +404,8 @@ export class GameInstance {
         { delay: 6000,  message: '💡 Capture outposts to boost production!', color: '#aaddff' },
         { delay: 13000, message: '💡 Press Q for Surge — doubles production for 8s!', color: '#ffd700' },
         { delay: 22000, message: '💡 Press 1/2/3 to switch spawn type (basic/heavy/scout)', color: '#aaddff' },
-        { delay: 45000, message: '💡 Press F to sacrifice 10 specks and repair your base!', color: '#64c864' },
+        { delay: 32000, message: '💡 Press A then click to attack-move — specks engage enemies en route!', color: '#ff8c44' },
+        { delay: 50000, message: '💡 Press F to sacrifice 10 specks and repair your base!', color: '#64c864' },
       ]
       for (const { delay, message, color } of hints) {
         setTimeout(() => this.notify(message, color, 3000), delay)
@@ -820,7 +821,7 @@ export class GameInstance {
           this.notify('✦ ELITE SPECK! +35% DAMAGE', '#ffffff', 2500)
         }
         if (event.type === 'SPECK_LEGEND' && event.ownerId === 'player') {
-          this.notify('✦✦ LEGEND BORN! ✦✦', '#cc44ff', 3000)
+          this.notify('✦✦ LEGEND BORN — +50% DMG + AoE SPLASH! ✦✦', '#cc44ff', 3500)
           store.pushKillFeedEntry({ icon: '✦✦', label: 'LEGEND BORN', color: '#cc44ff' })
         }
         if (event.type === 'UPGRADE_UNLOCKED' && event.ownerId === 'player') {


### PR DESCRIPTION
## Summary
- Desktop first-game hints were missing attack-move entirely. Touch already had long-press for attack-move at 13s. Added desktop hint 'Press A then click to attack-move' at 32s — after spawn type hint, before sacrifice
- LEGEND BORN toast now says '+50% DMG + AoE SPLASH' to match veteran (+20% DAMAGE) and elite (+35% DAMAGE) format. Players previously saw a celebratory toast with no info about what changed

## Metric
Session length — players who discover attack-move survive longer and engage more tactically. Legend players who know their unit has AoE splash will position them deliberately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)