### PR TITLE
fix(speck-wars): fix commander ability cooldown message for level 3

### DIFF
--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -1138,7 +1138,8 @@ export class GameInstance {
     }
     if ((commanderMeta.commanderAbilityCooldown ?? 0) > 0) {
       const remaining = Math.ceil((commanderMeta.commanderAbilityCooldown ?? 0) / 1000)
-      this.notify(`Battle Roar ready in ${remaining}s`, 'rgba(255,180,0,0.7)', 1200)
+      const abilityName = level >= 3 ? 'Last Stand' : 'Battle Roar'
+      this.notify(`${abilityName} ready in ${remaining}s`, 'rgba(255,180,0,0.7)', 1200)
       return
     }
     this.sim.inputQueue.push({ type: 'COMMANDER_ABILITY', ownerId: 'player' })


### PR DESCRIPTION
## Summary
Pressing Y during cooldown at commander level 3 showed 'Battle Roar ready in Xs' — but at level 3 the ability is Last Stand, not Battle Roar. The cooldown duration is also different (60s vs 20s), so players would read 'Battle Roar ready in 58s' and think something was broken.

Fixed by reading the ability name dynamically from `level >= 3` at the point the message is constructed.

## Metric
Session length — players who understand their abilities stay engaged instead of questioning whether the long cooldown is a bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)