### PR TITLE
fix(speck-wars): improve difficulty descriptions with accurate mechanic hints

### DIFF
--- a/src/app/speck-wars/components/phase-router.tsx
+++ b/src/app/speck-wars/components/phase-router.tsx
@@ -60,10 +60,10 @@ export function PhaseRouter({ children }: { children: React.ReactNode }) {
   }, [phase])
 
   const difficulties: Array<{ key: 'easy' | 'medium' | 'hard' | 'very-hard'; label: string; color: string; desc: string }> = [
-    { key: 'easy', label: 'Easy', color: '#44ff88', desc: 'slow AI, relaxed' },
+    { key: 'easy', label: 'Easy', color: '#44ff88', desc: 'slow AI · player spawn bonus' },
     { key: 'medium', label: 'Medium', color: '#ffcc44', desc: 'standard challenge' },
-    { key: 'hard', label: 'Hard', color: '#ff4f7b', desc: 'fast AI, high pressure' },
-    { key: 'very-hard', label: 'Brutal', color: '#cc00ff', desc: 'overwhelming flood' },
+    { key: 'hard', label: 'Hard', color: '#ff4f7b', desc: 'fast AI · waves enabled' },
+    { key: 'very-hard', label: 'Brutal', color: '#cc00ff', desc: 'relentless flood · waves' },
   ]
 
   if (phase === 'menu') {


### PR DESCRIPTION
## Summary
Three difficulty labels were missing key game mechanic information:

- **Easy**: description said 'slow AI, relaxed' — never mentioned the player also gets a 33% spawn speed bonus (1200ms vs 1800ms). Updated to 'slow AI · player spawn bonus'
- **Hard**: 'high pressure' didn't explain *why* — Hard enables the AI wave system (tickInterval ≤ 15). Players would hit Hard and be surprised by waves. Updated to 'fast AI · waves enabled'
- **Brutal**: Same waves omission. Updated to 'relentless flood · waves'

Medium unchanged — it's accurate.

## Metric
Return rate — players who understand what they're getting into on Hard/Brutal are less likely to ragequit and never return. Setting correct expectations at selection time = higher completion rate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)