### PR TITLE
fix(speck-wars): show research buff amount in outpost panel

### DIFF
--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -1418,9 +1418,10 @@ export function HUD() {
                 {/* Research panel */}
                 {b.typeId === 'outpost' && b.ownerId === 'player' && (b.fortifyDuration ?? 0) >= 20000 && (() => {
                   if (b.researchedUpgrade) {
+                    const researchDescs: Record<string, string> = { carapace: '+1 HP', blades: '+15% DMG', afterburners: '+15% SPD' }
                     return (
                       <div style={{ marginTop: 8, display: 'flex', alignItems: 'center', gap: 6, fontSize: 9, letterSpacing: 1, color: '#44aaff' }}>
-                        <span>⚗</span><span>{b.researchedUpgrade.toUpperCase()} — all units buffed</span>
+                        <span>⚗</span><span>{b.researchedUpgrade.toUpperCase()} — all units {researchDescs[b.researchedUpgrade] ?? 'buffed'}</span>
                       </div>
                     )
                   }


### PR DESCRIPTION
## Summary
After researching an upgrade at an outpost, the panel showed 'CARAPACE — all units buffed'. The buff name was there but the amount wasn't — players who clicked away couldn't recall what AFTERBURNERS does vs BLADES without hovering.

Now shows:
- 'CARAPACE — all units +1 HP'
- 'BLADES — all units +15% DMG'
- 'AFTERBURNERS — all units +15% SPD'

These match the button labels shown during research selection, so the completed state is consistent with the selection state.

## Metric
Session length — players who know their buff is active and what it does engage more deliberately with unit composition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)