### PR TITLE
fix(speck-wars): add feedback when 1/2/3 pressed with no building selected

### DIFF
--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -916,7 +916,7 @@ export function HUD() {
               <span>S — stop · H — hold position</span><span>C — center on base</span>
               <span>N — advance to outpost · D — defend base</span><span>B — rush enemy base</span>
               <span>Q — surge (2× spawn 8s)</span><span>V — snap camera to battle</span>
-              <span>1/2/3 — set spawn type</span><span>Minimap — left-click rally · right-click pan</span>
+              <span>1/2/3 — set spawn type (click building first)</span><span>Minimap — left-click rally · right-click pan</span>
               <span>X — cycle speed (1×/2×/4×)</span><span>F — sacrifice 10 specks → +15 HP</span>
               <span>T — build turret (costs 20 selected specks)</span><span>? — this help</span>
               <span>Z — cycle stance (Aggressive/Defensive/Hold)</span><span>G — guard mode (follow selected)</span>

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -204,7 +204,10 @@ export class GameInstance {
       () => { this.snapToBase() },                                          // H — snap camera to home base
       (typeId: 'basic' | 'heavy' | 'scout') => {               // 1/2/3 — set spawn type for selected building only
         const selectedBuildingId = this.sim.selectedBuildingId
-        if (!selectedBuildingId) return  // per-building only; select a base/outpost first
+        if (!selectedBuildingId) {
+          this.notify('Click your base or an outpost first', 'rgba(255,255,255,0.45)', 1200)
+          return
+        }
         this.sim.inputQueue.push({
           type: 'SET_SPAWN_TYPE',
           ownerId: 'player',


### PR DESCRIPTION
## Summary
Pressing 1/2/3 to change spawn type silently did nothing when no building was selected. The keys only work per-building (base/outpost), but neither the notification nor the help panel said so.

- Added toast: 'Click your base or an outpost first' (1.2s) when 1/2/3 pressed with no selected building
- Updated help panel: '1/2/3 — set spawn type' → '1/2/3 — set spawn type (click building first)'

The menu hint for 1/2/3 already says '1/2/3 to switch spawn type (basic/heavy/scout)' which also omits the building-select prerequisite, but the tutorial hint runs at 22s so players may have already tried the keys by then and concluded they're non-functional.

## Metric
Session length — players who discover spawn type cycling stay engaged longer and develop tactics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)