### PR TITLE
fix(speck-wars): remove duplicate 'ENEMY BUILDING TANKS' notification

### DIFF
--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -893,17 +893,11 @@ export class GameInstance {
       }
     }
 
-    // Detect AI spawn mode changes and notify player
+    // Track AI spawn mode (notification handled by AI_SPAWN_SWITCH event to avoid duplicates)
     if (store.phase === 'playing') {
       const aiBase = this.sim.buildings['building-ai-base']
       const aiSpawnMode = aiBase?.spawnTypeOverride ?? 'basic'
-      if (aiSpawnMode !== this.lastAiSpawnMode && this.elapsedMs > 5000) {
-        this.lastAiSpawnMode = aiSpawnMode
-        if (aiSpawnMode === 'heavy') {
-          this.notify('⬡ ENEMY BUILDING TANKS', '#ffaa55', 2000)
-        }
-        // No notification when switching back to basic — less alarming
-      }
+      if (aiSpawnMode !== this.lastAiSpawnMode) this.lastAiSpawnMode = aiSpawnMode
     }
 
     // Idle army nudge: remind player to rally when specks sit idle


### PR DESCRIPTION
## Summary
AI switching to heavy specks triggered two notifications within the same tick:
- Event-based: `AI_SPAWN_SWITCH → '⚠ ENEMY SWITCHING TO HEAVY'`
- Polling-based: state change detect → `'⬡ ENEMY BUILDING TANKS'`

Players would see both back-to-back. Removed the polling notification; state tracking preserved (the lastAiSpawnMode variable is still updated, just silently).

## Metric
Session length — less notification spam means players focus on the signal not the noise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)