### PR TITLE
fix(speck-wars): correct fortification progress display (20s → 30s)

### DIFF
--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -1,7 +1,7 @@
 'use client'
 import { useState, useEffect, useRef } from 'react'
 import { useSpeckWarsStore } from '../store'
-import { PLAYER_COLOR, AI_COLOR, DAILY_MODIFIER_LABELS } from '../domain/constants'
+import { PLAYER_COLOR, AI_COLOR, DAILY_MODIFIER_LABELS, FORTIFY_TIME } from '../domain/constants'
 import { getBestTime, getWinStreak } from '../lib/personal-best'
 import { onLongPressStart, onLongPressCancel, onTapRipple } from '../input/touch-feedback'
 
@@ -1336,9 +1336,9 @@ export function HUD() {
                 {/* Fortify status */}
                 {b.typeId === 'outpost' && b.ownerId === 'player' && (b.fortifyDuration ?? 0) > 0 && (
                   <div style={{ fontSize: 10, color: 'rgba(255,215,0,0.65)', letterSpacing: 0.5, marginBottom: 4 }}>
-                    {(b.fortifyDuration ?? 0) >= 20000
+                    {(b.fortifyDuration ?? 0) >= FORTIFY_TIME
                       ? '⚒ FORTIFIED — +25% DMG nearby'
-                      : `⚒ ${Math.round(((b.fortifyDuration ?? 0) / 20000) * 100)}% fortified`}
+                      : `⚒ ${Math.round(((b.fortifyDuration ?? 0) / FORTIFY_TIME) * 100)}% fortified`}
                   </div>
                 )}
                 {(b.typeId === 'base' || b.typeId === 'outpost') && b.ownerId === 'player' && (


### PR DESCRIPTION
## Summary
The outpost fortification panel used `20000ms` as the divisor for progress percentage AND as the threshold for showing 'FORTIFIED — +25% DMG nearby'. But `FORTIFY_TIME = 30000ms` (30s) is the actual full fortification time.

**Before:**
- `fortifyDuration = 20000ms` → showed '100% fortified' (wrong, only 67% complete)
- `fortifyDuration = 30000ms` → would show '150% fortified' (impossible, but panel gates at ≥20000ms so it was showing 'FORTIFIED' incorrectly)

**After:**
- `fortifyDuration = 20000ms` → shows '67% fortified' (correct — research unlocks here but bonus is only +16.7%)
- `fortifyDuration = 30000ms` → shows 'FORTIFIED — +25% DMG nearby' (correct — this is when full +25% bonus applies)

The research panel unlock condition (`≥20000ms`) is unchanged — research unlocks at 67% fortification by design.

## Metric
Session length — players who see accurate fortification progress engage with the mechanic intentionally instead of abandoning an outpost thinking it's "done" at 20s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)