### PR TITLE
fix(speck-wars): clarify research-available notification (remove false 'FORTIFIED' claim)

### DIFF
--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -628,7 +628,7 @@ export class GameInstance {
             if (fortLevel >= RESEARCH_FORTIFY_THRESHOLD && !this.fortifyResearchNotified.has(outpostId)) {
               this.fortifyResearchNotified.add(outpostId)
               const name = outpostId.replace('outpost-', '').toUpperCase()
-              this.notify(`⚗ ${name} FORTIFIED — upgrade research available`, '#44aaff', 3500)
+              this.notify(`⚗ ${name} OUTPOST — research available! (select to choose upgrade)`, '#44aaff', 3500)
             }
           }
 


### PR DESCRIPTION
## Summary
The notification 'TOP FORTIFIED — upgrade research available' fired when the outpost reached 20000ms (67% of full fortification). Saying 'FORTIFIED' was incorrect because the outpost was still hardening toward full +25% DMG at 30000ms.

New message: 'TOP OUTPOST — research available! (select to choose upgrade)' — accurate, tells the player which outpost it is and what action to take.

## Metric
Session length — players who receive an accurate call-to-action (select the outpost) engage with the upgrade system vs. players confused by 'FORTIFIED' when the outpost is still at partial strength.

🤖 Generated with [Claude Code](https://claude.com/claude-code)