### PR TITLE
fix(speck-wars): correct speck type tooltip descriptions in building panel

### DIFF
--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -1346,9 +1346,9 @@ export function HUD() {
                     <div style={{ fontSize: 8, letterSpacing: 1.5, color: 'rgba(255,255,255,0.35)', marginBottom: 4 }}>SPAWNING</div>
                     <div style={{ display: 'flex', gap: 3 }}>
                       {([
-                        { type: 'basic', label: isTouchDevice ? 'BSC' : '1 BASIC', color: '#4af7c4', title: 'Basic — balanced speed and HP' },
-                        { type: 'heavy', label: isTouchDevice ? 'HVY' : '2 HEAVY', color: '#ff8844', title: 'Heavy — 3× HP, 1.5× damage, spawns slower' },
-                        { type: 'scout', label: isTouchDevice ? 'DRT' : '3 DART', color: '#50c8ff', title: 'Dart — 2× speed, less HP, spawns faster' },
+                        { type: 'basic', label: isTouchDevice ? 'BSC' : '1 BASIC', color: '#4af7c4', title: 'Basic — balanced, beats Dart' },
+                        { type: 'heavy', label: isTouchDevice ? 'HVY' : '2 HEAVY', color: '#ff8844', title: 'Heavy — 5× HP, 2× damage, slow spawn, beats Basic' },
+                        { type: 'scout', label: isTouchDevice ? 'DRT' : '3 DART', color: '#50c8ff', title: 'Dart — 2× speed, half damage, fast spawn, beats Heavy' },
                       ] as const).map(({ type, label, color, title }) => {
                         const active = (b.spawnTypeOverride ?? 'basic') === type
                         return (


### PR DESCRIPTION
## Summary
The hover tooltips on the spawn type buttons had wrong stats:

- **Heavy**: 'Heavy — 3× HP, 1.5× damage, spawns slower'
  - Actual: hp=5 vs basic hp=1 → **5× HP** (not 3×)
  - Actual: damage=2 vs basic damage=1 → **2× damage** (not 1.5×)
- **Scout/Dart**: 'Dart — 2× speed, less HP, spawns faster'
  - Actual: hp=1, same as basic → **not less HP** (misleading — scout has same HP but half the damage)
  - Correct: **half damage** (damage=0.5 vs basic damage=1)

Also added the type-advantage hints ('beats Basic', 'beats Dart', 'beats Heavy') — the game has a rock-paper-scissors system that many players won't discover from the existing tooltips.

## Metric
Session length — players who understand type counters develop tactical unit composition instead of defaulting to all-basic armies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)