### PR TITLE
fix(speck-wars): clarify Battle Roar/Last Stand ability tooltips

### DIFF
--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -1832,7 +1832,7 @@ export function HUD() {
             return (
               <button
                 onClick={() => { if (ready) { navigator.vibrate?.([30, 40, 50]); gameActions.commanderAbility?.() } }}
-                title={`[Y] ${isLastStand ? 'Last Stand' : 'Battle Roar'} — ${isLastStand ? 'invuln + 3× dmg + speed (60s)' : 'stun enemies 80px (20s)'}`}
+                title={`[Y] ${isLastStand ? 'Last Stand' : 'Battle Roar'} — ${isLastStand ? '5s: invuln + 3× dmg + nearby speed · 60s CD' : 'stun 1.5s in 80px · 20s CD'}`}
                 style={{
                   padding: '8px 12px',
                   fontSize: 11,


### PR DESCRIPTION
## Summary

- Rewrites the `title` attribute on the Commander ability button to disambiguate the parenthesised number that previously read as either duration or cooldown.
- Battle Roar now reads: `stun 1.5s in 80px · 20s CD`
- Last Stand now reads: `5s: invuln + 3× dmg + nearby speed · 60s CD`

Single-line change in `/src/app/speck-wars/components/hud.tsx` line 1835.

## Test plan

- [ ] Load Speck Wars in a browser, spawn a Commander unit (level < 3 for Battle Roar, level >= 3 for Last Stand)
- [ ] Hover the ability button and confirm the tooltip matches the new strings above
- [ ] Verify the ability still fires correctly on click/Y key

🤖 Generated with [Claude Code](https://claude.com/claude-code)