### PR TITLE
fix(speck-wars): correct elite speck damage in daily tip (+30% → +35%)

### DIFF
--- a/src/app/speck-wars/components/phase-router.tsx
+++ b/src/app/speck-wars/components/phase-router.tsx
@@ -335,7 +335,7 @@ export function PhaseRouter({ children }: { children: React.ReactNode }) {
             'Tap ⬡ ALL to select all your specks, then tap canvas to rally them together.',
             'Long-press canvas then lift — specks fight enemies on the way (attack-move).',
             'Tap Hold in the unit panel to make selected specks defend a position.',
-            'Elite specks (6+ kills) get a white diamond ring and deal +30% damage.',
+            'Elite specks (6+ kills) get a white diamond ring and deal +35% damage.',
           ] : [
             'Capture outposts to boost your production.',
             'Scouts (3) auto-target outposts — fast but fragile.',
@@ -350,7 +350,7 @@ export function PhaseRouter({ children }: { children: React.ReactNode }) {
             'Control groups: box-select specks, Ctrl+4 to save, press 4 to recall.',
             'Hold A then right-click to issue an attack-move — specks fight enemies en route.',
             'H key makes selected specks hold position — great for defending a chokepoint.',
-            'Elite specks (6+ kills) get a white diamond ring and deal +30% damage.',
+            'Elite specks (6+ kills) get a white diamond ring and deal +35% damage.',
           ]
           const tip = tips[Math.floor(Date.now() / 86400000) % tips.length]
           return (


### PR DESCRIPTION
Corrects the daily tip text to match the actual game value from combat.ts line 40 (1.35 multiplier = +35% damage).