### PR TITLE
fix(speck-wars): notification polish — veteran duration, elite kill feed, AI last stand clarity

### DIFF
--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -822,6 +822,7 @@ export class GameInstance {
         }
         if (event.type === 'SPECK_ELITE' && event.ownerId === 'player') {
           this.notify('✦ ELITE SPECK! +35% DAMAGE', '#ffffff', 2500)
+          store.pushKillFeedEntry({ icon: '✦', label: 'ELITE SPECK', color: '#ffd700' })
         }
         if (event.type === 'SPECK_LEGEND' && event.ownerId === 'player') {
           this.notify('✦✦ LEGEND BORN — +50% DMG + AoE SPLASH! ✦✦', '#cc44ff', 3500)
@@ -841,7 +842,7 @@ export class GameInstance {
           const isElite = event.kills >= 6
           const label = isLegend ? '✦✦ LEGEND FALLEN' : isElite ? '✦ ELITE FALLEN' : '⭐ VETERAN FALLEN'
           const color = isLegend ? '#cc44ff' : isElite ? '#ff8844' : '#ffcc00'
-          this.notify(label, color)
+          this.notify(label, color, 2500)
         }
         if (event.type === 'AI_WAVE_START') {
           const waveColors = ['#ff4f7b', '#ff6b35', '#cc00ff']
@@ -849,7 +850,7 @@ export class GameInstance {
           this.notify(`⚠ WAVE ${event.waveNumber} ASSAULT!`, color, 3000)
         }
         if (event.type === 'AI_LAST_STAND') {
-          this.notify('⚠ ENEMY LAST STAND', '#ff4444')
+          this.notify('⚠ ENEMY LAST STAND — desperate all-in push!', '#ff4444', 3500)
         }
 
         if (event.type === 'AI_SPAWN_SWITCH' && event.speckTypeId === 'heavy') {


### PR DESCRIPTION
## Summary

- **VETERAN_FALLEN duration**: Extended all three tier notifications (Legend/Elite/Veteran fallen) from 1200ms default to 2500ms — these mark the loss of a valuable unit and deserve more screen time.
- **ELITE kill feed entry**: Added `store.pushKillFeedEntry(...)` to the `SPECK_ELITE` handler to match the pattern established by `SPECK_LEGEND`. Elite promotions now appear in the kill feed.
- **AI_LAST_STAND message**: Replaced the vague `'⚠ ENEMY LAST STAND'` toast with `'⚠ ENEMY LAST STAND — desperate all-in push!'` at 3500ms so the player understands the tactical significance and has time to react.

## Test plan

- [ ] Verify a veteran/elite/legend speck dies and the notification lingers ~2.5s
- [ ] Verify an elite promotion appears in the kill feed with gold `✦` icon
- [ ] Verify the AI last stand toast shows the expanded message and stays for ~3.5s
- [ ] No TypeScript errors on build

🤖 Generated with [Claude Code](https://claude.com/claude-code)