### PR TITLE
fix(speck-wars): correct scout→dart naming in defeat screen contextual tip

### DIFF
--- a/src/app/speck-wars/components/phase-router.tsx
+++ b/src/app/speck-wars/components/phase-router.tsx
@@ -587,8 +587,8 @@ export function PhaseRouter({ children }: { children: React.ReactNode }) {
             tip = `Perfect stars on ${diffLabel}! Ready to try ${nextDiff?.label ?? 'the next level'}?`
           } else if (!won && kills < 30) {
             tip = isTouchDevice
-              ? 'Tip: Scouts are fast for outpost rushes — tap the 3rd spawn button (dart icon).'
-              : 'Tip: Scouts are fast and great for outpost rushes — press 3 to switch spawn type.'
+              ? 'Tip: Dart specks are fast for outpost rushes — tap the 3rd spawn button (dart icon).'
+              : 'Tip: Dart specks are fast for outpost rushes — press 3 to switch spawn type.'
           } else if (!won && eff < 0.4) {
             tip = isTouchDevice
               ? 'Tip: Heavy specks deal 2× damage — switch to Heavy spawn during big fights.'


### PR DESCRIPTION
Corrects the defeat screen contextual tip to use the in-game unit name 'Dart specks' instead of the outdated 'Scouts' name for the 3rd spawn type.

- Touch: 'Dart specks are fast for outpost rushes — tap the 3rd spawn button (dart icon).'
- Desktop: 'Dart specks are fast for outpost rushes — press 3 to switch spawn type.'