### PR TITLE
fix(speck-wars): remove misleading k suffix from army upgrade kill threshold display

### DIFF
--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -2095,7 +2095,7 @@ export function HUD() {
                     <span style={{ color: 'rgba(255,255,255,0.3)' }}>army upgrade: {kills}/50</span>
                   )}
                   {tier && nextKills && (
-                    <span style={{ color: 'rgba(255,255,255,0.25)' }}>→ {nextKills}k</span>
+                    <span style={{ color: 'rgba(255,255,255,0.25)' }}>→ {nextKills} kills</span>
                   )}
                 </div>
               )


### PR DESCRIPTION
Removes the misleading 'k' suffix from the army upgrade kill threshold display in the HUD. With nextKills=150, the old display showed '→ 150k' which players could misread as 150,000 kills. Now displays '→ 150 kills' for clarity.