### PR TITLE
fix(speck-wars): use simulation spawn rates for accurate production display in stats panel

### DIFF
--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -1234,14 +1234,7 @@ export function HUD() {
               if (parts.length === 0) return '—'
               return parts.join(', ')
             }
-            // Production rate estimate
-            const BASE_MS = 800 // base interval for 'basic' type; spawn type is now set per-building
-            const OUTPOST_MS = 1200
-            const playerTriple = hud.tripleOutpostOwner === 'player'
             const aiOutpostCount = Math.max(0, (hud.players.ai?.buildingCount ?? 0) - 1)
-            const aiTriple = hud.tripleOutpostOwner === 'ai'
-            const playerProd = ((1000/BASE_MS) + playerOutpostCount * (1000/OUTPOST_MS)) * (playerTriple ? 2 : 1)
-            const aiProd = ((1000/800) + aiOutpostCount * (1000/OUTPOST_MS)) * (aiTriple ? 2 : 1)
             return (
               <div style={{
                 display: 'grid', gridTemplateColumns: '1fr 1fr',
@@ -1259,8 +1252,8 @@ export function HUD() {
                 <span>{aiSpecks} specks</span>
                 <span style={{ fontSize: 10, opacity: 0.7 }}>{fmtTypes(playerTypes)}</span>
                 <span style={{ fontSize: 10, opacity: 0.7 }}>{fmtTypes(aiTypes)}</span>
-                <span style={{ fontSize: 10, opacity: 0.6 }}>~{playerProd.toFixed(1)}/s prod</span>
-                <span style={{ fontSize: 10, opacity: 0.6 }}>~{aiProd.toFixed(1)}/s prod</span>
+                <span style={{ fontSize: 10, opacity: 0.6 }}>{((hud.spawnRates?.player ?? 0) / 60).toFixed(1)}/s prod</span>
+                <span style={{ fontSize: 10, opacity: 0.6 }}>{((hud.spawnRates?.ai ?? 0) / 60).toFixed(1)}/s prod</span>
                 <span style={{ fontSize: 10, color: playerSupply >= supplyCap ? '#ff4f7b' : playerSupply >= 60 ? '#ffaa44' : undefined }}>
                   Supply: {Math.round(playerSupply)}/{supplyCap}
                 </span>


### PR DESCRIPTION
## Summary
- Removes 7 lines of hardcoded wrong production rate estimates (`BASE_MS`, `OUTPOST_MS`, `playerTriple`, `aiTriple`, `playerProd`, `aiProd`)
- Replaces the two prod display spans with values sourced directly from `hud.spawnRates` (already accurately computed in tick.ts using real building intervals, in specks/minute)
- Converts from specks/minute to specks/second by dividing by 60
- Keeps `aiOutpostCount` as it is still used for the `Outposts: {aiOutpostCount}` display row

## Test plan
- [ ] Launch a Speck Wars match and open the army stats panel
- [ ] Verify player and enemy production rates update dynamically and reflect actual spawn rates (not hardcoded estimates)
- [ ] Verify `Outposts:` row still displays correctly for both player and enemy

🤖 Generated with [Claude Code](https://claude.com/claude-code)