### PR TITLE
fix(speck-wars): correct SACR→HEAL button label in defeat screen tip

### DIFF
--- a/src/app/speck-wars/components/phase-router.tsx
+++ b/src/app/speck-wars/components/phase-router.tsx
@@ -599,7 +599,7 @@ export function PhaseRouter({ children }: { children: React.ReactNode }) {
               : 'Tip: Press Q for Surge — doubles production for 8s. Use it when you\'re behind!'
           } else if (!won) {
             tip = isTouchDevice
-              ? 'Tip: Tap 🔧 SACR to sacrifice 10 specks and repair your base when HP is critical.'
+              ? 'Tip: Tap 🔧 HEAL to sacrifice 10 specks and repair your base when HP is critical.'
               : 'Tip: Press F to sacrifice 10 specks and repair your base when HP is critical.'
           } else if (won && modifier === 'siege') {
             tip = '⬡ Siege modifier won — outposts were twice as hard to capture. Nice patience!'


### PR DESCRIPTION
Fixes the defeat screen contextual tip that referenced the wrong button label. The in-game mobile button is labeled 🔧 HEAL, not 🔧 SACR.