### PR TITLE
fix(speck-wars): notify player when a captured creep camp resets

### DIFF
--- a/src/app/speck-wars/domain/simulation/tick.ts
+++ b/src/app/speck-wars/domain/simulation/tick.ts
@@ -192,6 +192,7 @@ function updateCreepCamps(sim: SimulationState, dt: number) {
     building.campResetMs = (building.campResetMs ?? 0) - dt
     if (building.campResetMs <= 0) {
       building.campResetMs = 0
+      sim.events.push({ type: 'CAMP_RESET', campId: building.id, previousOwner: building.ownerId })
       building.ownerId = 'neutral'
       building.hp = building.maxHp
       building.captureProgress = 0

--- a/src/app/speck-wars/domain/types.ts
+++ b/src/app/speck-wars/domain/types.ts
@@ -157,6 +157,7 @@ export type SimEvent =
   | { type: 'CONSTRUCTION_COMPLETE'; buildingId: string; x: number; y: number }
   | { type: 'UPGRADE_UNLOCKED'; ownerId: string; level: 1 | 2 | 3 }
   | { type: 'CAMP_CAPTURED'; campId: string; newOwner: string }
+  | { type: 'CAMP_RESET'; campId: string; previousOwner: string }
   | { type: 'OUTPOST_UPGRADE_RESEARCHED'; buildingId: string; ownerId: string; upgrade: 'carapace' | 'blades' | 'afterburners' }
   | { type: 'HERO_LEVELED'; ownerId: string; heroLevel: 1 | 2 }
   | { type: 'HERO_DIED'; ownerId: string; kills: number }

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -775,6 +775,9 @@ export class GameInstance {
           navigator.vibrate?.([20, 30, 20, 30, 20])
           store.pushKillFeedEntry({ icon: '◈', label: 'CAMP SEIZED', color: '#ff9933' })
         }
+        if (event.type === 'CAMP_RESET' && event.previousOwner === 'player') {
+          this.notify('◈ CAMP RESET — defenders respawned', '#ff9933', 2000)
+        }
         if (event.type === 'OUTPOST_UPGRADE_RESEARCHED' && event.ownerId === 'player') {
           const labels = { carapace: 'CARAPACE — +1 HP', blades: 'BLADES — +15% DMG', afterburners: 'AFTERBURNERS — +15% SPD' }
           this.notify(`⚗ ${labels[event.upgrade as keyof typeof labels]}`, '#44aaff', 3000)


### PR DESCRIPTION
## Summary
- Adds `CAMP_RESET` to the `SimEvent` union type in `types.ts`
- Emits the event in `tick.ts` **before** `building.ownerId` is set to `'neutral'`, so `previousOwner` correctly captures the old owner
- Handles the event in `game-instance.ts` — shows `◈ CAMP RESET — defenders respawned` notification when the camp was previously owned by the player

## Test plan
- [ ] Capture a creep camp as the player and wait ~90s — notification `◈ CAMP RESET — defenders respawned` should appear
- [ ] Verify no notification fires when the AI's camp resets (previous owner is `'ai'`, not `'player'`)
- [ ] Verify existing camp capture notifications (`◈ CAMP SEIZED!`) are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)