### PR TITLE
fix(speck-wars): disable already-researched upgrades in research panel

### DIFF
--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -1421,6 +1421,7 @@ export function HUD() {
                       </div>
                     )
                   }
+                  const globalUpgrades = hud.players.player?.outpostUpgrades ?? { carapace: false, blades: false, afterburners: false }
                   const upgrades: Array<{ id: 'carapace' | 'blades' | 'afterburners'; label: string; desc: string; color: string }> = [
                     { id: 'carapace', label: 'CARAPACE', desc: '+1 HP', color: '#44ff88' },
                     { id: 'blades', label: 'BLADES', desc: '+15% DMG', color: '#ff4f7b' },
@@ -1434,12 +1435,20 @@ export function HUD() {
                       </div>
                       <div style={{ display: 'flex', gap: 4 }}>
                         {upgrades.map(u => (
-                          <button key={u.id} onClick={() => gameActions?.researchUpgrade?.(b.id, u.id)} style={{
-                            flex: 1, padding: '4px 4px', fontSize: 9, letterSpacing: 0.5,
-                            background: 'rgba(0,0,0,0.5)', border: `1px solid ${u.color}44`,
-                            color: u.color, cursor: 'pointer', borderRadius: 4,
-                            fontFamily: 'monospace', minHeight: 40,
-                          }}>
+                          <button
+                            key={u.id}
+                            onClick={() => gameActions?.researchUpgrade?.(b.id, u.id)}
+                            disabled={globalUpgrades[u.id]}
+                            title={globalUpgrades[u.id] ? `${u.label} already active globally` : `${u.label}: ${u.desc} for all units`}
+                            style={{
+                              flex: 1, padding: '4px 4px', fontSize: 9, letterSpacing: 0.5,
+                              background: 'rgba(0,0,0,0.5)', border: `1px solid ${u.color}44`,
+                              color: u.color, borderRadius: 4,
+                              fontFamily: 'monospace', minHeight: 40,
+                              opacity: globalUpgrades[u.id] ? 0.35 : 1,
+                              cursor: globalUpgrades[u.id] ? 'not-allowed' : 'pointer',
+                            }}
+                          >
                             <div>{u.label}</div>
                             <div style={{ opacity: 0.7, fontSize: 8 }}>{u.desc}</div>
                           </button>

--- a/src/app/speck-wars/domain/simulation/tick.ts
+++ b/src/app/speck-wars/domain/simulation/tick.ts
@@ -596,7 +596,7 @@ function consumeInputs(sim: SimulationState) {
 }
 
 function emitHudUpdate(sim: SimulationState) {
-  const data: Record<string, { speckCount: number; buildingCount: number; buildingHp: Record<string, number>; speckTypes: Record<string, number>; veteranCount: number; eliteCount: number; legendCount: number; supplyUsed: number; supplyCap: number }> = {}
+  const data: Record<string, { speckCount: number; buildingCount: number; buildingHp: Record<string, number>; speckTypes: Record<string, number>; veteranCount: number; eliteCount: number; legendCount: number; supplyUsed: number; supplyCap: number; outpostUpgrades: { carapace: boolean; blades: boolean; afterburners: boolean } }> = {}
   for (const [pid] of Object.entries(sim.players)) {
     const myBuildings = Object.values(sim.buildings).filter(b => b.ownerId === pid)
     let liveCount = 0
@@ -622,6 +622,7 @@ function emitHudUpdate(sim: SimulationState) {
       legendCount,
       supplyUsed: sim.players[pid]?.supply ?? 0,
       supplyCap: SUPPLY_HARD_CAP,
+      outpostUpgrades: { ...(sim.players[pid].outpostUpgrades ?? { carapace: false, blades: false, afterburners: false }) },
     }
   }
   // Buildings that are owned but actively being captured by the enemy

--- a/src/app/speck-wars/domain/types.ts
+++ b/src/app/speck-wars/domain/types.ts
@@ -175,6 +175,7 @@ export interface HudData {
     legendCount: number   // specks with 12+ kills
     supplyUsed: number    // current supply in use
     supplyCap: number     // hard supply cap
+    outpostUpgrades: { carapace: boolean; blades: boolean; afterburners: boolean }
   }>
   attackedBuildingIds: string[]
   tripleOutpostOwner: string | null  // player ID who owns all 3 outposts, or null


### PR DESCRIPTION
## Summary

- Added `outpostUpgrades` field to `HudData.players` per-player record in `types.ts` so the UI can know global upgrade state
- Populated `outpostUpgrades` in `emitHudUpdate` in `tick.ts` by reading from `sim.players[pid].outpostUpgrades`
- Updated the research panel in `hud.tsx` to read `globalUpgrades` and render each upgrade button as `disabled` with 35% opacity, `not-allowed` cursor, and a `title` tooltip when the upgrade is already active globally

**Fixes:** When a player owns multiple outposts and has already researched an upgrade (e.g. carapace) at one, the same button at another outpost now appears grayed out and is non-interactive — preventing the silent no-op that was confusing players.

## Test plan

- [ ] Start a game, capture an outpost, hold it 20s, research an upgrade (e.g. CARAPACE)
- [ ] Capture a second outpost, hold it 20s — verify CARAPACE button is grayed out (35% opacity, `not-allowed` cursor) and shows tooltip "CARAPACE already active globally"
- [ ] Verify the other two upgrade buttons on the second outpost are still active and clickable
- [ ] Verify the first outpost still shows the "researched" label (existing behavior unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)