### PR TITLE
fix: surge cooldown, V key desc, and mobile gesture docs

### DIFF
--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -916,9 +916,10 @@ export function HUD() {
               <span style={{ color: 'rgba(74,247,196,0.7)' }}>Left-click with group selected → moves selected only</span><span style={{ color: 'rgba(74,247,196,0.7)' }}>Specks engage enemies en route (attack-move)</span>
               <span>Garrison btn — post 5 specks at outpost to defend</span><span>Recall btn — release garrisoned specks</span>
               <span style={{ color: 'rgba(255,180,80,0.75)' }}>Long-press canvas → Attack Move (mobile)</span><span style={{ color: 'rgba(255,180,80,0.75)' }}>Tap canvas → Rally (mobile)</span>
+              <span style={{ color: 'rgba(255,180,80,0.75)' }}>Double-tap canvas → zoom toggle (mobile)</span><span style={{ color: 'rgba(255,180,80,0.75)' }}>2-finger tap → stop (mobile)</span>
               <span>S — stop · H — hold position</span><span>C — center on base</span>
               <span>N — advance (repeat within 3s to cycle) · D — defend base</span><span>B — rush enemy base</span>
-              <span>Q — surge (2× spawn 8s)</span><span>V — snap camera to battle</span>
+              <span>Q — surge (2× spawn 8s · 45s CD)</span><span>V — snap to recent kills</span>
               <span>1/2/3 — set spawn type (click building first)</span><span>Minimap — left-click rally · right-click pan</span>
               <span>X — cycle speed (1×/2×/4×)</span><span>F — sacrifice 10 specks → +15 HP</span>
               <span>T — build turret (costs 20 selected specks)</span><span>? — this help</span>


### PR DESCRIPTION
- Q key: add 45s cooldown to help text (was undocumented — players didn't know why surge wouldn't fire again)
- V key: 'snap to recent kills' is more accurate than 'snap camera to battle'
- Mobile: document double-tap zoom toggle and 2-finger tap-to-stop gestures

Replaces #2308 (merge conflict with #2307 resolved).