### PR TITLE
fix: remove false minimap right-click claim; clarify defensive stance tooltip

### DIFF
--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -712,7 +712,7 @@ export function HUD() {
         {!isTouchDevice && gameActions?.cycleStance && (() => {
           const stanceConfig: Record<string, { icon: string; label: string; color: string; title: string }> = {
             aggressive: { icon: '⚔', label: 'AGGRO', color: '#ff4f7b', title: '[Z] Aggressive — pursues nearby enemies' },
-            defensive:  { icon: '🛡', label: 'DEF',   color: '#4af7c4', title: '[Z] Defensive — holds position more' },
+            defensive:  { icon: '🛡', label: 'DEF',   color: '#4af7c4', title: '[Z] Defensive — 40px aggro range (vs 150px aggressive)' },
             hold:       { icon: '⛨', label: 'HOLD',   color: '#aaaaaa', title: '[Z] Hold — only attacks at melee range' },
           }
           const cfg = stanceConfig[stance] ?? stanceConfig.defensive
@@ -920,7 +920,7 @@ export function HUD() {
               <span>S — stop · H — hold position</span><span>C — center on base</span>
               <span>N — advance (repeat within 3s to cycle) · D — defend base</span><span>B — rush enemy base</span>
               <span>Q — surge (2× spawn 8s · 45s CD)</span><span>V — snap to recent kills</span>
-              <span>1/2/3 — set spawn type (click building first)</span><span>Minimap — left-click rally · right-click pan</span>
+              <span>1/2/3 — set spawn type (click building first)</span><span>Minimap — left-click to rally</span>
               <span>X — cycle speed (1×/2×/4×)</span><span>F — sacrifice 10 specks → +15 HP</span>
               <span>T — build turret (costs 20 selected specks)</span><span>? — this help</span>
               <span>Z — cycle stance (Aggressive/Defensive/Hold)</span><span>G — guard: rally to nearest friendly outpost</span>

--- a/src/app/speck-wars/components/phase-router.tsx
+++ b/src/app/speck-wars/components/phase-router.tsx
@@ -296,7 +296,7 @@ export function PhaseRouter({ children }: { children: React.ReactNode }) {
             <span>A(+click) — attack-move · N — advance · B — rush · D — defend</span>
             <span>X — speed · E — all · Esc — clear</span>
             <span>Ctrl+4-9 save group · 4-9 recall</span>
-            <span>Minimap — left-click rally · right-click pan</span>
+            <span>Minimap — left-click to rally</span>
             <span>Scroll — zoom · Shift+scroll — pan</span>
             <span>Arrow keys / W S — pan</span>
           </div>


### PR DESCRIPTION
- Minimap help text in both hud.tsx and phase-router.tsx claimed 'right-click pan' but right-click is not implemented — removed the false claim
- Defensive stance tooltip 'holds position more' was vague/misleading — it actually reduces enemy detection range from 150px → 40px; updated to '40px aggro range (vs 150px aggressive)'

Replaces #2310 (conflict with #2309 resolved).