### PR TITLE
fix: apply blades research and veteran bonus to garrison fire

### DIFF
--- a/src/app/speck-wars/domain/simulation/garrison.ts
+++ b/src/app/speck-wars/domain/simulation/garrison.ts
@@ -44,7 +44,10 @@ export function updateGarrison(sim: SimulationState, dt: number) {
       }
 
       if (nearestI < 0) continue
-      const damage = stype.damage * GARRISON_DAMAGE_MULT
+      const player = sim.players[building.ownerId]
+      const bladesBonus = player?.outpostUpgrades?.blades ? 1.15 : 1.0
+      const veteranBonus = garrisonedMeta.kills >= 12 ? 1.50 : garrisonedMeta.kills >= 6 ? 1.35 : garrisonedMeta.kills >= 3 ? 1.20 : 1.0
+      const damage = stype.damage * GARRISON_DAMAGE_MULT * bladesBonus * veteranBonus
       sim.speckHp[nearestI] -= damage
     }
   }


### PR DESCRIPTION
Garrison fire was applying only base damage × 0.75, ignoring:
- **Blades research** (+15% DMG) — the UI says research benefits 'all units' but garrisoned specks were excluded
- **Veteran/elite/legend damage bonuses** (3/6/12 kills = +20/35/50% dmg) — individual speck experience was silently ignored when garrisoned

Now garrison fire correctly applies both the owner's blades research and each speck's kill-based damage multiplier, consistent with how field combat calculates damage in combat.ts.