### PR TITLE
feat: document outpost speed aura and Rally Cry in help and tips

### DIFF
--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -926,6 +926,7 @@ export function HUD() {
               <span>Z — cycle stance (Aggressive/Defensive/Hold)</span><span>G — guard: rally to nearest friendly outpost</span>
               <span>Y — Battle Roar (lvl2 Cmdr) / Last Stand (lvl3)</span><span style={{ opacity: 0.5 }}>Commander levels up from nearby kills</span>
               <span style={{ color: 'rgba(160,220,255,0.7)' }}>2 creep camps on each map — contest to earn +25% spawn for 30s</span><span style={{ color: 'rgba(160,220,255,0.7)' }}>50/150/300 kills → BLOODED/HARDENED/VETERAN ARMY upgrades</span>
+              <span style={{ color: 'rgba(160,220,255,0.7)' }}>Friendly outposts give +35% speed to specks within 160px</span><span style={{ color: 'rgba(160,220,255,0.7)' }}>Base below 25% HP → Rally Cry: +1.5× spawn (auto)</span>
               <span style={{ gridColumn: '1/-1', borderTop: '1px solid rgba(255,255,255,0.08)', paddingTop: 8, marginTop: 2, color: 'rgba(255,215,0,0.5)', fontSize: 11 }}>
                 Daily map seed changes each day · modifier shown top-right (bulwark/blitz/siege) · hold all 3 outposts 60s = domination win
               </span>

--- a/src/app/speck-wars/components/phase-router.tsx
+++ b/src/app/speck-wars/components/phase-router.tsx
@@ -338,6 +338,7 @@ export function PhaseRouter({ children }: { children: React.ReactNode }) {
             'Long-press canvas then lift — specks fight enemies on the way (attack-move).',
             'Tap Hold in the unit panel to make selected specks defend a position.',
             'Elite specks (6+ kills) get a white diamond ring and deal +35% damage.',
+            'Friendly outposts give a +35% speed boost to nearby specks — holding them accelerates your attacks.',
           ] : [
             'Capture outposts to boost your production.',
             'Dart specks (3) auto-target outposts — fast but fragile.',
@@ -354,6 +355,7 @@ export function PhaseRouter({ children }: { children: React.ReactNode }) {
             'Hold A then right-click to issue an attack-move — specks fight enemies en route.',
             'H key makes selected specks hold position — great for defending a chokepoint.',
             'Elite specks (6+ kills) get a white diamond ring and deal +35% damage.',
+            'Friendly outposts give a +35% speed boost to nearby specks — holding them accelerates your attacks.',
           ]
           const tip = tips[Math.floor(Date.now() / 86400000) % tips.length]
           return (


### PR DESCRIPTION
Two completely undocumented mechanics now surfaced to players:

**Outpost speed aura** — friendly outposts give +35% movement speed to specks within 160px (rendered as a pulsing circle, but never explained). Added to:
- Help panel (hud.tsx): new row alongside other passive mechanics
- Daily tips (phase-router.tsx): both touch and desktop tip pools

**Rally Cry** — when base HP falls below 25%, spawn rate automatically increases 1.5× (already fires a toast notification mid-game, but wasn't in the help reference or desktop tips). Added to:
- Help panel (hud.tsx): same new row as outpost aura