### PR TITLE
feat: document the Hero unit in help panel and daily tips

### DIFF
--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -927,6 +927,7 @@ export function HUD() {
               <span>Y — Battle Roar (lvl2 Cmdr) / Last Stand (lvl3)</span><span style={{ opacity: 0.5 }}>Commander levels up from nearby kills</span>
               <span style={{ color: 'rgba(160,220,255,0.7)' }}>2 creep camps on each map — contest to earn +25% spawn for 30s</span><span style={{ color: 'rgba(160,220,255,0.7)' }}>50/150/300 kills → BLOODED/HARDENED/VETERAN ARMY upgrades</span>
               <span style={{ color: 'rgba(160,220,255,0.7)' }}>Friendly outposts give +35% speed to specks within 160px</span><span style={{ color: 'rgba(160,220,255,0.7)' }}>Base below 25% HP → Rally Cry: +1.5× spawn (auto)</span>
+              <span style={{ color: 'rgba(160,220,255,0.7)' }}>◇ Hero auto-spawns from base — 4× HP, 1.5× dmg, 15s respawn</span><span style={{ color: 'rgba(160,220,255,0.7)' }}>Hero 5+ kills: +15% spd · 15+ kills: AoE pulse every 3s</span>
               <span style={{ gridColumn: '1/-1', borderTop: '1px solid rgba(255,255,255,0.08)', paddingTop: 8, marginTop: 2, color: 'rgba(255,215,0,0.5)', fontSize: 11 }}>
                 Daily map seed changes each day · modifier shown top-right (bulwark/blitz/siege) · hold all 3 outposts 60s = domination win
               </span>

--- a/src/app/speck-wars/components/phase-router.tsx
+++ b/src/app/speck-wars/components/phase-router.tsx
@@ -339,6 +339,7 @@ export function PhaseRouter({ children }: { children: React.ReactNode }) {
             'Tap Hold in the unit panel to make selected specks defend a position.',
             'Elite specks (6+ kills) get a white diamond ring and deal +35% damage.',
             'Friendly outposts give a +35% speed boost to nearby specks — holding them accelerates your attacks.',
+            'A ◇ Hero auto-spawns from your base — 4× HP and 1.5× damage. Keep it alive; it gets stronger with kills.',
           ] : [
             'Capture outposts to boost your production.',
             'Dart specks (3) auto-target outposts — fast but fragile.',
@@ -356,6 +357,7 @@ export function PhaseRouter({ children }: { children: React.ReactNode }) {
             'H key makes selected specks hold position — great for defending a chokepoint.',
             'Elite specks (6+ kills) get a white diamond ring and deal +35% damage.',
             'Friendly outposts give a +35% speed boost to nearby specks — holding them accelerates your attacks.',
+            'A ◇ Hero auto-spawns from your base — 4× HP and 1.5× damage. Keep it alive; it gets stronger with kills.',
           ]
           const tip = tips[Math.floor(Date.now() / 86400000) % tips.length]
           return (


### PR DESCRIPTION
The Hero is a completely undocumented mechanic: a special speck (gold diamond ◇) that auto-spawns from the player's base with 4× HP and 1.5× damage. It respawns automatically 15s after death and has its own level-up system:
- 5+ kills → +15% speed  
- 15+ kills → AoE energy pulse every 3s (deals 50% damage to nearby enemies)

The game already fires toast notifications for hero events (REBORN, FALLEN, level-up), but the help panel and daily tips gave zero context about what the Hero is. New players see "⚔ HERO REBORN" and have no idea what changed.

Added to:
- Help panel (hud.tsx): two-column info row in the passive mechanics section
- Daily tips (phase-router.tsx): one new tip added to both touch and desktop pools