### PR TITLE
fix: apply VETERAN ARMY upgrade bonus to garrison fire

### DIFF
--- a/src/app/speck-wars/domain/simulation/garrison.ts
+++ b/src/app/speck-wars/domain/simulation/garrison.ts
@@ -46,8 +46,9 @@ export function updateGarrison(sim: SimulationState, dt: number) {
       if (nearestI < 0) continue
       const player = sim.players[building.ownerId]
       const bladesBonus = player?.outpostUpgrades?.blades ? 1.15 : 1.0
+      const upgradeBonus = (player?.upgradeLevel ?? 0) >= 3 ? 1.15 : 1.0  // VETERAN ARMY (+15% dmg at 300 kills)
       const veteranBonus = garrisonedMeta.kills >= 12 ? 1.50 : garrisonedMeta.kills >= 6 ? 1.35 : garrisonedMeta.kills >= 3 ? 1.20 : 1.0
-      const damage = stype.damage * GARRISON_DAMAGE_MULT * bladesBonus * veteranBonus
+      const damage = stype.damage * GARRISON_DAMAGE_MULT * bladesBonus * upgradeBonus * veteranBonus
       sim.speckHp[nearestI] -= damage
     }
   }


### PR DESCRIPTION
Garrison fire was missing the global VETERAN ARMY damage bonus (`upgradeLevel >= 3`, earned at 300 total kills, +15% damage to all specks).

`combat.ts` applies this via `upgradeBonus` on every field combat damage calculation, but `garrison.ts` was not including it.

This follows PR #2312 which added the blades research bonus and individual speck veteran/elite/legend bonuses to garrison fire. The only missing bonus at that time was this global army-level upgrade.