### PR TITLE
feat: document HP regeneration for base and outposts

### DIFF
--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -928,6 +928,7 @@ export function HUD() {
               <span style={{ color: 'rgba(160,220,255,0.7)' }}>2 creep camps on each map — contest to earn +25% spawn for 30s</span><span style={{ color: 'rgba(160,220,255,0.7)' }}>50/150/300 kills → BLOODED/HARDENED/VETERAN ARMY upgrades</span>
               <span style={{ color: 'rgba(160,220,255,0.7)' }}>Friendly outposts give +35% speed to specks within 160px</span><span style={{ color: 'rgba(160,220,255,0.7)' }}>Base below 25% HP → Rally Cry: +1.5× spawn (auto)</span>
               <span style={{ color: 'rgba(160,220,255,0.7)' }}>◇ Hero auto-spawns from base — 4× HP, 1.5× dmg, 15s respawn</span><span style={{ color: 'rgba(160,220,255,0.7)' }}>Hero 5+ kills: +15% spd · 15+ kills: AoE pulse every 3s</span>
+              <span style={{ color: 'rgba(160,220,255,0.7)' }}>Base regen: 0.5 HP/s · Outpost regen: 2 HP/s (when not under attack)</span><span style={{ color: 'rgba(160,220,255,0.7)' }}>Let outposts regen before re-contesting after a failed assault</span>
               <span style={{ gridColumn: '1/-1', borderTop: '1px solid rgba(255,255,255,0.08)', paddingTop: 8, marginTop: 2, color: 'rgba(255,215,0,0.5)', fontSize: 11 }}>
                 Daily map seed changes each day · modifier shown top-right (bulwark/blitz/siege) · hold all 3 outposts → +2× base production + 60s = domination win
               </span>

--- a/src/app/speck-wars/components/phase-router.tsx
+++ b/src/app/speck-wars/components/phase-router.tsx
@@ -340,6 +340,7 @@ export function PhaseRouter({ children }: { children: React.ReactNode }) {
             'Elite specks (6+ kills) get a white diamond ring and deal +35% damage.',
             'Friendly outposts give a +35% speed boost to nearby specks — holding them accelerates your attacks.',
             'A ◇ Hero auto-spawns from your base — 4× HP and 1.5× damage. Keep it alive; it gets stronger with kills.',
+            'Outposts regen 2 HP/s when not under attack — fall back, let them heal, then re-contest.',
           ] : [
             'Capture outposts to boost your production.',
             'Dart specks (3) auto-target outposts — fast but fragile.',
@@ -358,6 +359,7 @@ export function PhaseRouter({ children }: { children: React.ReactNode }) {
             'Elite specks (6+ kills) get a white diamond ring and deal +35% damage.',
             'Friendly outposts give a +35% speed boost to nearby specks — holding them accelerates your attacks.',
             'A ◇ Hero auto-spawns from your base — 4× HP and 1.5× damage. Keep it alive; it gets stronger with kills.',
+            'Outposts regen 2 HP/s when not under attack — fall back, let them heal, then re-contest.',
           ]
           const tip = tips[Math.floor(Date.now() / 86400000) % tips.length]
           return (

--- a/src/app/speck-wars/components/phase-router.tsx
+++ b/src/app/speck-wars/components/phase-router.tsx
@@ -210,6 +210,7 @@ export function PhaseRouter({ children }: { children: React.ReactNode }) {
         <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginTop: 4 }}>
           <button
             onClick={() => setFogEnabled(!fogEnabled)}
+            title="Fog of War: hides enemy specks and buildings outside your vision (specks 150px · base 300px · outposts 180px)"
             style={{
               padding: '4px 14px',
               fontSize: 12,


### PR DESCRIPTION
Base and outpost HP regeneration was completely undocumented:
- **Base**: 0.5 HP/s when not under attack (slow, rewards sacrifice healing)
- **Outpost**: 2 HP/s when not under attack (fast enough to influence contest timing)

Players making tactical decisions about re-contesting outposts or healing base have no visible signal that structures regenerate. This information directly affects decisions like "should I wait before re-attacking a contested outpost?" or "will my base survive without healing if I hold off for 10 seconds?"

Added to:
- Help panel (hud.tsx): new blue info row alongside other passive mechanics  
- Daily tips (phase-router.tsx): outpost regen tip in both touch and desktop tip pools