### PR TITLE
feat(speck-wars): announce daily modifier at game start

### DIFF
--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -9,6 +9,7 @@ import type { Camera } from './rendering/camera'
 import { AIController, type AIPersonality } from './domain/ai/ai-controller'
 import { recordBestTime, incrementWinStreak, resetWinStreak, isFirstGame, markFirstGameDone, recordGameResult, markWonToday, updateLifetimeStats, getWinStreak, hasSeenVeteranTip, markVeteranTipSeen } from './lib/personal-best'
 import { BUILDING_TYPES } from './domain/config/building-types'
+import { DAILY_MODIFIER_LABELS } from './domain/constants'
 
 export class GameInstance {
   private canvas: HTMLCanvasElement
@@ -392,6 +393,13 @@ export class GameInstance {
       this.notify('⚔ FIGHT!', '#4af7c4', 800)
       navigator.vibrate?.([50, 30, 50, 30, 100])
     }, 3000)
+
+    // Announce daily modifier so players know the active rule change
+    if (this.sim.dailyModifier !== 'standard') {
+      const modColor = this.sim.dailyModifier === 'bulwark' ? '#44aaff'
+        : this.sim.dailyModifier === 'blitz' ? '#ffd700' : '#ff8844'
+      setTimeout(() => this.notify(`📅 ${DAILY_MODIFIER_LABELS[this.sim.dailyModifier]}`, modColor, 4000), 3600)
+    }
 
     // Show tutorial hints for first-time players
     if (isFirstGame()) {


### PR DESCRIPTION
## Summary
- Fires a coloured in-game notification 600ms after the FIGHT! countdown announcing the active daily modifier (BULWARK/BLITZ/SIEGE) with its effect description
- Fixes the mobile UX gap where the HUD badge's `title` tooltip is inaccessible on touch devices
- Uses existing `DAILY_MODIFIER_LABELS` constants so descriptions stay in sync automatically

## Test plan
- [ ] Start a game on a BULWARK/BLITZ/SIEGE day — confirm notification fires after countdown
- [ ] Verify standard days show no modifier notification
- [ ] Check mobile — notification appears after FIGHT! with the right color

🤖 Generated with [Claude Code](https://claude.com/claude-code)