### PR TITLE
feat(speck-wars): notify on soft supply cap and improve hard cap color

### DIFF
--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -9,7 +9,7 @@ import type { Camera } from './rendering/camera'
 import { AIController, type AIPersonality } from './domain/ai/ai-controller'
 import { recordBestTime, incrementWinStreak, resetWinStreak, isFirstGame, markFirstGameDone, recordGameResult, markWonToday, updateLifetimeStats, getWinStreak, hasSeenVeteranTip, markVeteranTipSeen } from './lib/personal-best'
 import { BUILDING_TYPES } from './domain/config/building-types'
-import { DAILY_MODIFIER_LABELS } from './domain/constants'
+import { DAILY_MODIFIER_LABELS, SUPPLY_SOFT_CAP } from './domain/constants'
 
 export class GameInstance {
   private canvas: HTMLCanvasElement
@@ -57,6 +57,7 @@ export class GameInstance {
   private prevWaveCountdown: number | null = null  // track wave countdown for 30s pre-warning
   private prevWaveInProgress = false
   private prevAtSupplyCap = false              // notify once when player first hits hard supply cap
+  private prevAtSoftCap = false               // notify once when player first hits soft supply cap
   private fortifyResearchNotified = new Set<string>()  // outpost IDs for which research-ready was notified
   private controlGroups = new Map<number, string[]>()
   private lastAdvanceMs = 0
@@ -557,11 +558,18 @@ export class GameInstance {
             this.enemySurgeWarnedAt = now
             this.notify('⚠ ENEMY SURGE!', '#ff6b35', 2500)
           }
-          // Supply cap notification: fires once when player first hits hard cap (outpost spawn halts)
-          const atSupplyCap = (event.data.players.player?.supplyUsed ?? 0) >= (event.data.players.player?.supplyCap ?? 120)
-          if (atSupplyCap && !this.prevAtSupplyCap) {
-            this.notify('⚠ SUPPLY CAP — outpost spawn halted (use basic/dart)', '#ffaa44', 3500)
+          // Supply cap notifications: soft cap = spawn slows, hard cap = outpost spawn halts
+          const playerSupplyUsed = event.data.players.player?.supplyUsed ?? 0
+          const playerSupplyCap = event.data.players.player?.supplyCap ?? 120
+          const atSoftCap = playerSupplyUsed >= SUPPLY_SOFT_CAP
+          const atSupplyCap = playerSupplyUsed >= playerSupplyCap
+          if (atSoftCap && !this.prevAtSoftCap && !atSupplyCap) {
+            this.notify('⚡ SUPPLY SOFT CAP — spawn slowing (reduce heavies or capture outposts)', '#ffaa44', 3500)
           }
+          if (atSupplyCap && !this.prevAtSupplyCap) {
+            this.notify('⚠ SUPPLY CAP — outpost spawn halted (use basic/dart)', '#ff4f7b', 3500)
+          }
+          this.prevAtSoftCap = atSoftCap
           this.prevAtSupplyCap = atSupplyCap
           // Outpost HP critical: player outpost < 20% max HP (50)
           const OUTPOST_MAX_HP = 50


### PR DESCRIPTION
## Summary
- Fires a one-time orange notification when the player first hits the **soft supply cap** (60 specks): "SUPPLY SOFT CAP — spawn slowing (reduce heavies or capture outposts)" — explains why spawn rate drops without the player having to hover the supply bar
- Hard cap notification color changed from orange → red (`#ff4f7b`) to match the supply bar color scheme and make the severity difference clear at a glance
- Adds `SUPPLY_SOFT_CAP` to the existing constants import

## Why
The soft cap is a meaningful strategy signal (manage army composition, prioritize outpost captures) but was previously silent — players only saw spawn slowdowns with no explanation.

## Test plan
- [ ] Accumulate 60+ specks — confirm orange soft-cap notification fires once
- [ ] Accumulate 120 specks — confirm red hard-cap notification fires, supply bar goes red
- [ ] Drain back below 60, then back up — notification fires again (reset on new game)

🤖 Generated with [Claude Code](https://claude.com/claude-code)