### PR TITLE
feat(speck-wars): per-building rally — no global player rally point

### DIFF
--- a/src/app/speck-wars/domain/simulation/movement.ts
+++ b/src/app/speck-wars/domain/simulation/movement.ts
@@ -171,7 +171,9 @@ export function moveSpecks(sim: SimulationState, dt: number) {
         ? { x: meta.attackMoveTargetX, y: meta.attackMoveTargetY! }
         : (meta.assignedRallyX !== undefined)
         ? { x: meta.assignedRallyX, y: meta.assignedRallyY! }
-        : sim.rallyPoints[meta.ownerId]
+        // Player specks always have assignedRallyX/Y set at spawn — skip global rally for them.
+        // AI and other owners may still use the global rally point as a fallback.
+        : (meta.ownerId !== 'player' ? sim.rallyPoints[meta.ownerId] : null)
       if (rally) {
         const dx = rally.x - speckX[i]
         const dy = rally.y - speckY[i]

--- a/src/app/speck-wars/domain/simulation/spawner.ts
+++ b/src/app/speck-wars/domain/simulation/spawner.ts
@@ -123,11 +123,25 @@ export function updateSpawners(sim: SimulationState, dt: number) {
           sim.events.push({ type: 'HERO_SPAWNED', ownerId: building.ownerId })
         }
       }
-      // Auto-assign the building's per-building rally point so the speck marches there on spawn
-      const sourceBuildingRally = building.rallyPoint
-      if (sourceBuildingRally) {
-        meta.assignedRallyX = sourceBuildingRally.x
-        meta.assignedRallyY = sourceBuildingRally.y
+      // Auto-assign the building's per-building rally point so the speck marches there on spawn.
+      // Non-AI player specks always get an explicit assignedRallyX/Y so they never fall through
+      // to the global rally lookup in movement.ts.
+      if (building.ownerId !== 'ai') {
+        const sourceBuildingRally = building.rallyPoint
+        if (sourceBuildingRally) {
+          meta.assignedRallyX = sourceBuildingRally.x
+          meta.assignedRallyY = sourceBuildingRally.y
+        } else {
+          meta.assignedRallyX = building.x
+          meta.assignedRallyY = building.y
+        }
+      } else {
+        // AI: keep existing behavior — use per-building rally if set
+        const sourceBuildingRally = building.rallyPoint
+        if (sourceBuildingRally) {
+          meta.assignedRallyX = sourceBuildingRally.x
+          meta.assignedRallyY = sourceBuildingRally.y
+        }
       }
       addSpeck(sim, meta, sx, sy, building.id)
     }

--- a/src/app/speck-wars/domain/simulation/tick.ts
+++ b/src/app/speck-wars/domain/simulation/tick.ts
@@ -289,17 +289,11 @@ function consumeInputs(sim: SimulationState) {
           meta.holdPosition = false  // clear hold when a new rally is issued
           meta.attackMoveMode = false  // normal move cancels attack-move
         }
-      } else {
+      } else if (event.ownerId !== 'player') {
+        // AI (and any non-player owner): keep global rally logic
         sim.rallyPoints[event.ownerId] = { x: event.x, y: event.y }
-        // Update per-building rally for all player buildings
-        if (event.ownerId === 'player') {
-          for (const building of Object.values(sim.buildings)) {
-            if (building.ownerId === 'player') {
-              building.rallyPoint = { x: event.x, y: event.y }
-            }
-          }
-        }
       }
+      // Player with no selection: do nothing — player rally is per-building only (SET_BUILDING_RALLY)
     }
     if (event.type === 'ATTACK_MOVE') {
       const hasSelection = event.ownerId === 'player' && sim.selectedSpeckIds.size > 0
@@ -383,6 +377,21 @@ function consumeInputs(sim: SimulationState) {
       const building = sim.buildings[event.buildingId]
       if (!building || building.ownerId !== event.ownerId) continue
       building.rallyPoint = { x: event.x, y: event.y }
+      // Send specks that are currently resting at this building to the new rally point.
+      // A speck is "resting at the building" if its assignedRallyX/Y is within 40px of the building.
+      const REST_RADIUS = 40
+      for (let i = 0; i < sim.speckCount; i++) {
+        const meta = sim.speckMeta[i]
+        if (!meta || meta.ownerId !== event.ownerId) continue
+        if (meta.assignedRallyX === undefined || meta.assignedRallyY === undefined) continue
+        const rdx = meta.assignedRallyX - building.x
+        const rdy = meta.assignedRallyY - building.y
+        if (Math.abs(rdx) <= REST_RADIUS && Math.abs(rdy) <= REST_RADIUS) {
+          meta.assignedRallyX = event.x
+          meta.assignedRallyY = event.y
+          meta.attackMoveMode = false
+        }
+      }
     }
     if (event.type === 'SURGE') {
       if (event.ownerId === 'player' && sim.surgeCooldown <= 0) {

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -166,16 +166,24 @@ export class GameInstance {
           }
         }
 
-        // If a building is selected, set its rally point
+        // If a building is selected and owned by player, set its rally point
         if (this.sim.selectedBuildingId) {
-          this.sim.inputQueue.push({ type: 'SET_BUILDING_RALLY', ownerId: 'player', buildingId: this.sim.selectedBuildingId, x: wx, y: wy })
+          const selBuilding = this.sim.buildings[this.sim.selectedBuildingId]
+          if (selBuilding && selBuilding.ownerId === 'player') {
+            this.sim.inputQueue.push({ type: 'SET_BUILDING_RALLY', ownerId: 'player', buildingId: this.sim.selectedBuildingId, x: wx, y: wy })
+            this.renderer.showRallyPing(wx, wy)
+            return
+          }
+        }
+
+        // If units are selected, move them to clicked location
+        if (this.sim.selectedSpeckIds.size > 0) {
+          this.sim.inputQueue.push({ type: 'RALLY', ownerId: 'player', x: wx, y: wy })
           this.renderer.showRallyPing(wx, wy)
           return
         }
 
-        // Default: global rally for all units
-        this.sim.inputQueue.push({ type: 'RALLY', ownerId: 'player', x: wx, y: wy })
-        this.renderer.showRallyPing(wx, wy)
+        // Nothing selected — do nothing
       },
       () => useSpeckWarsStore.getState().togglePause(),   // Space
       () => this.clearRally(),                             // R — clear rally

--- a/src/app/speck-wars/rendering/renderer.ts
+++ b/src/app/speck-wars/rendering/renderer.ts
@@ -137,10 +137,13 @@ export class Renderer {
     }
     this.effectsLayer.update(dt)
 
-    // Rally point marker + dashed line from base to rally
+    // Rally point marker: draw for selected player building's rally point only
     this.rallyGfx.clear()
-    const rp = sim.rallyPoints['player']
-    if (rp) {
+    const selectedBuilding = sim.selectedBuildingId ? sim.buildings[sim.selectedBuildingId] : null
+    const rp = (selectedBuilding && selectedBuilding.ownerId === 'player' && selectedBuilding.rallyPoint)
+      ? selectedBuilding.rallyPoint
+      : null
+    if (rp && selectedBuilding) {
       const pulse = 0.5 + 0.5 * Math.sin(Date.now() / 400)
       const alpha = 0.5 + 0.5 * pulse
       this.rallyGfx.lineStyle(2, PLAYER_COLOR, alpha)
@@ -153,30 +156,27 @@ export class Renderer {
       this.rallyGfx.drawCircle(rp.x, rp.y, 14)
       this.rallyGfx.lineStyle(0)
 
-      // Dashed line from player base to rally point (only if far enough apart)
-      const playerBase = Object.values(sim.buildings).find(b => b.ownerId === 'player' && b.typeId === 'base')
-      if (playerBase) {
-        const dx = rp.x - playerBase.x
-        const dy = rp.y - playerBase.y
-        const len = Math.sqrt(dx * dx + dy * dy)
-        if (len > 80) {
-          const nx = dx / len, ny = dy / len
-          const dashLen = 8, gapLen = 6
-          this.rallyGfx.lineStyle(1, PLAYER_COLOR, 0.22)
-          const dashCycle = dashLen + gapLen
-          const marchOffset = (Date.now() / 80) % dashCycle  // ~1.75 cycles/sec
-          let d = (playerBase === null ? 0 : 46) - marchOffset  // animated march toward rally
-          while (d < len - 24) {
-            const x1 = playerBase.x + nx * d
-            const y1 = playerBase.y + ny * d
-            const x2 = playerBase.x + nx * Math.min(d + dashLen, len - 24)
-            const y2 = playerBase.y + ny * Math.min(d + dashLen, len - 24)
-            this.rallyGfx.moveTo(x1, y1)
-            this.rallyGfx.lineTo(x2, y2)
-            d += dashLen + gapLen
-          }
-          this.rallyGfx.lineStyle(0)
+      // Dashed line from the selected building to its rally point (only if far enough apart)
+      const dx = rp.x - selectedBuilding.x
+      const dy = rp.y - selectedBuilding.y
+      const len = Math.sqrt(dx * dx + dy * dy)
+      if (len > 80) {
+        const nx = dx / len, ny = dy / len
+        const dashLen = 8, gapLen = 6
+        this.rallyGfx.lineStyle(1, PLAYER_COLOR, 0.22)
+        const dashCycle = dashLen + gapLen
+        const marchOffset = (Date.now() / 80) % dashCycle  // ~1.75 cycles/sec
+        let d = 46 - marchOffset  // animated march toward rally
+        while (d < len - 24) {
+          const x1 = selectedBuilding.x + nx * d
+          const y1 = selectedBuilding.y + ny * d
+          const x2 = selectedBuilding.x + nx * Math.min(d + dashLen, len - 24)
+          const y2 = selectedBuilding.y + ny * Math.min(d + dashLen, len - 24)
+          this.rallyGfx.moveTo(x1, y1)
+          this.rallyGfx.lineTo(x2, y2)
+          d += dashLen + gapLen
         }
+        this.rallyGfx.lineStyle(0)
       }
     }
 


### PR DESCRIPTION
## Summary

- Units spawn at their building and accumulate there until the player acts
- Select a building → click the map → sets that building's rally point; specks already parked at the building march out to it
- Select units → click the map → moves just those units
- Click with nothing selected → does nothing
- Rally marker only renders for the currently selected building (if it has a rally point set)

## Files changed

- `spawner.ts` — units always spawn with explicit `assignedRallyX/Y` (building rally point or building position)
- `tick.ts` — RALLY with no selection does nothing for player; SET_BUILDING_RALLY sends resting specks to new point
- `game-instance.ts` — click routing: building selected → SET_BUILDING_RALLY, units selected → RALLY, nothing → no-op
- `renderer.ts` — rally marker draws at selected building's rally point, not global player point
- `movement.ts` — player specks skip global rally fallback entirely

## Test plan
- [ ] Spawn units — they should stay at base, not march anywhere
- [ ] Select base, click map — units at base march to rally point, marker appears
- [ ] Select outpost, click map — units at outpost march to that rally point
- [ ] Box-select units, click map — only selected units move
- [ ] Click map with nothing selected — nothing happens

🤖 Generated with [Claude Code](https://claude.com/claude-code)