### PR TITLE
feat: simplify speck AI — remove auto-retreat and scout priority (Speck Wars #2338)

### DIFF
--- a/src/app/speck-wars/domain/simulation/movement.ts
+++ b/src/app/speck-wars/domain/simulation/movement.ts
@@ -62,47 +62,6 @@ export function moveSpecks(sim: SimulationState, dt: number) {
     const stype = SPECK_TYPES[meta.typeId]
     if (!stype) continue
 
-    // Retreating: flee to nearest friendly building
-    if (meta.state === 'retreating') {
-      let nearestBuilding = null
-      let nearestDist2 = Infinity
-      for (const b of Object.values(buildings)) {
-        if (b.ownerId !== meta.ownerId) continue
-        const dx = b.x - speckX[i]
-        const dy = b.y - speckY[i]
-        const d2 = dx * dx + dy * dy
-        if (d2 < nearestDist2) {
-          nearestDist2 = d2
-          nearestBuilding = b
-        }
-      }
-      if (nearestBuilding) {
-        const btype = BUILDING_TYPES[nearestBuilding.typeId]
-        const bRadius = btype?.size ?? 20
-        if (nearestDist2 <= bRadius * bRadius) {
-          // Retreating specks: stop movement, let regenRetreatingSpecks handle idle transition
-          sim.speckVx[i] = 0
-          sim.speckVy[i] = 0
-        } else {
-          const dist = Math.sqrt(nearestDist2)
-          const dx = nearestBuilding.x - speckX[i]
-          const dy = nearestBuilding.y - speckY[i]
-          speckVx[i] = (dx / dist) * stype.speed
-          speckVy[i] = (dy / dist) * stype.speed
-          {
-            const nx = Math.max(0, Math.min(WORLD_WIDTH, speckX[i] + speckVx[i] * dtSec))
-            const ny = Math.max(0, Math.min(WORLD_HEIGHT, speckY[i] + speckVy[i] * dtSec))
-            const r = resolveWallCollisions(nx, ny, speckVx[i], speckVy[i], sim.obstacles, 4)
-            speckX[i] = r.x
-            speckY[i] = r.y
-            speckVx[i] = r.vx
-            speckVy[i] = r.vy
-          }
-        }
-      }
-      continue
-    }
-
     // Holding: stay in place; combat.ts still resolves attacks for adjacent enemies
     if (meta.state === 'holding') {
       speckVx[i] = 0

--- a/src/app/speck-wars/domain/simulation/speck-ai.ts
+++ b/src/app/speck-wars/domain/simulation/speck-ai.ts
@@ -192,23 +192,6 @@ export function runSpeckAI(sim: SimulationState) {
       }
     }
 
-    // Scout specks prefer outpost targets — they're too fragile to assault the enemy base
-    // but excel at rapid outpost capturing. Override the nearest target with the nearest
-    // non-friendly outpost if one exists.
-    if (meta.typeId === 'scout') {
-      let outpostNearest: string | null = null
-      let outpostNearestDist = Infinity
-      for (const [bid, building] of Object.entries(buildings)) {
-        if (building.typeId !== 'outpost') continue
-        if (building.ownerId === meta.ownerId) continue
-        const odx = building.x - speckX[i]
-        const ody = building.y - speckY[i]
-        const odist = Math.sqrt(odx * odx + ody * ody)
-        if (odist < outpostNearestDist) { outpostNearestDist = odist; outpostNearest = bid }
-      }
-      if (outpostNearest) nearest = outpostNearest
-    }
-
     meta.targetId = nearest
     meta.state = nearest ? 'moving' : 'idle'
   }

--- a/src/app/speck-wars/domain/simulation/tick.ts
+++ b/src/app/speck-wars/domain/simulation/tick.ts
@@ -36,22 +36,6 @@ export function tick(sim: SimulationState, dt: number): SimulationState {
     sim.selectedBuildingId = null
   }
 
-  // 5b. Mark low-HP specks as retreating
-  for (let i = 0; i < sim.speckCount; i++) {
-    const meta = sim.speckMeta[i]
-    if (!meta || sim.speckHp[i] <= 0) continue
-    if (meta.state === 'retreating') continue  // already retreating
-    const maxHp = SPECK_TYPES[meta.typeId]?.hp ?? 1
-    if (sim.speckHp[i] / maxHp < 0.25) {
-      meta.state = 'retreating'
-      meta.targetId = null
-    }
-  }
-
-  // 5c. Heal retreating specks that have reached a friendly building
-  regenRetreatingSpecks(sim, dt)
-
-
   // 6. Remove dead specks (compact arrays)
   removeDeadSpecks(sim)
 
@@ -95,41 +79,6 @@ export function tick(sim: SimulationState, dt: number): SimulationState {
   if (sim.tick % HUD_UPDATE_INTERVAL === 0) emitHudUpdate(sim)
 
   return sim
-}
-
-function regenRetreatingSpecks(sim: SimulationState, dt: number) {
-  const dtSec = dt / 1000
-  const REGEN_RATE = 2  // HP per second while sheltering at base
-  const REENGAGE_THRESHOLD = 0.75  // re-engage when HP is at 75% of max
-
-  for (let i = 0; i < sim.speckCount; i++) {
-    const meta = sim.speckMeta[i]
-    if (!meta || meta.state !== 'retreating') continue
-    if (sim.speckHp[i] <= 0) continue
-
-    // Only heal if within range of a friendly building
-    let nearFriendly = false
-    for (const building of Object.values(sim.buildings)) {
-      if (building.ownerId !== meta.ownerId) continue
-      const bsize = BUILDING_TYPES[building.typeId]?.size ?? 40
-      const dx = sim.speckX[i] - building.x
-      const dy = sim.speckY[i] - building.y
-      if (dx * dx + dy * dy <= (bsize + 30) * (bsize + 30)) {
-        nearFriendly = true
-        break
-      }
-    }
-
-    if (!nearFriendly) continue
-
-    const maxHp = SPECK_TYPES[meta.typeId]?.hp ?? 1
-    sim.speckHp[i] = Math.min(maxHp, sim.speckHp[i] + REGEN_RATE * dtSec)
-
-    // Re-engage once healed enough
-    if (sim.speckHp[i] >= maxHp * REENGAGE_THRESHOLD) {
-      meta.state = 'idle'
-    }
-  }
 }
 
 function regenBuildingHp(sim: SimulationState, dt: number) {

--- a/src/app/speck-wars/domain/types.ts
+++ b/src/app/speck-wars/domain/types.ts
@@ -4,7 +4,7 @@ export interface SpeckMeta {
   id: string
   typeId: string
   ownerId: string
-  state: 'idle' | 'moving' | 'attacking' | 'carrying' | 'retreating' | 'holding'
+  state: 'idle' | 'moving' | 'attacking' | 'carrying' | 'holding'
   targetId: string | null
   attackCooldown: number   // ms remaining until next attack
   kills: number            // enemies killed; 3+ = veteran (gold ring, +20% damage)

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -44,7 +44,6 @@ export class GameInstance {
   private rallyCryFired = false               // one-time Rally Cry notification per game
   private firstVeteranNotifiedAt = -30000   // allow veteran notification immediately
   private recentPlayerCaptureTimes: number[] = []  // timestamps of recent player captures
-  private retreatWarnedAt = -20000          // allow retreat warning after 20s
   private notifGen = 0
   private prevBaseUnderThreat = false
   private prevEnemyAdvance = false
@@ -776,19 +775,7 @@ export class GameInstance {
         }
       }
 
-      // Retreat wave warning: 10+ player specks retreating = notify
-      const nowTs = Date.now()
-      if (nowTs - this.retreatWarnedAt > 15000) {
-        let retreatingCount = 0
-        for (let i = 0; i < this.sim.speckCount; i++) {
-          const m = this.sim.speckMeta[i]
-          if (m && m.ownerId === 'player' && m.state === 'retreating') retreatingCount++
-        }
-        if (retreatingCount >= 10) {
-          this.retreatWarnedAt = nowTs
-          this.notify(`⚡ ${retreatingCount} SPECKS RETREATING!`, '#ff8844', 2000)
-        }
-      }
+
     }
 
     // Track AI spawn mode (notification handled by AI_SPAWN_SWITCH event to avoid duplicates)


### PR DESCRIPTION
Removes two special AI behaviors:

1. **Auto-retreat**: when a speck dropped below 25% HP it would flee to the nearest friendly building to regen. Specks now fight to the death.

2. **Scout target priority**: scouts had a special override that forced them to target outposts over enemy bases. All unit types now use uniform target selection.

Part of epic #2327.

Closes #2338