### PR TITLE
feat: remove daily modifier system (Speck Wars #2340)

### DIFF
--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -1,7 +1,7 @@
 'use client'
 import { useState, useEffect, useRef } from 'react'
 import { useSpeckWarsStore } from '../store'
-import { PLAYER_COLOR, AI_COLOR, DAILY_MODIFIER_LABELS } from '../domain/constants'
+import { PLAYER_COLOR, AI_COLOR } from '../domain/constants'
 import { getBestTime, getWinStreak } from '../lib/personal-best'
 import { onLongPressStart, onLongPressCancel, onTapRipple } from '../input/touch-feedback'
 
@@ -280,14 +280,6 @@ export function HUD() {
             <span style={{ color: 'rgba(255,255,255,0.18)', fontSize: isTouchDevice ? 10 : 8, letterSpacing: 0.5 }}>
               DAILY MAP · {new Date().toLocaleDateString('en-US', { month: 'short', day: 'numeric' }).toUpperCase()}
             </span>
-            {hud?.dailyModifier && hud.dailyModifier !== 'standard' && (
-              <span
-                title={DAILY_MODIFIER_LABELS[hud.dailyModifier]}
-                style={{ color: '#ffd700', fontSize: isTouchDevice ? 10 : 8, letterSpacing: 0.5, opacity: 0.7, textAlign: 'right', cursor: 'help' }}
-              >
-                {hud.dailyModifier === 'bulwark' ? '⚔ BULWARK' : hud.dailyModifier === 'blitz' ? '⚡ BLITZ' : '🏰 SIEGE'}
-              </span>
-            )}
           </div>
         )
       })()}
@@ -863,7 +855,7 @@ export function HUD() {
               <span style={{ color: 'rgba(160,220,255,0.7)' }}>Friendly outposts give +35% speed to specks within 160px</span><span style={{ color: 'rgba(160,220,255,0.7)' }}>Base below 25% HP → Rally Cry: +1.5× spawn (auto)</span>
               <span style={{ color: 'rgba(160,220,255,0.7)' }}>Base regen: 0.5 HP/s · Outpost regen: 2 HP/s (when not under attack)</span><span style={{ color: 'rgba(160,220,255,0.7)' }}>Hold outpost 30s → FORTIFIED: +25% DMG to specks within 200px</span>
               <span style={{ gridColumn: '1/-1', borderTop: '1px solid rgba(255,255,255,0.08)', paddingTop: 8, marginTop: 2, color: 'rgba(255,215,0,0.5)', fontSize: 11 }}>
-                Daily map seed changes each day · modifier shown top-right (bulwark/blitz/siege) · hold all 3 outposts → +2× base production + 60s = domination win · army cap: 120 specks (outpost spawn halts above cap)
+                Daily map seed changes each day · layout changes per difficulty · hold all 3 outposts → +2× base production + 60s = domination win · army cap: 120 specks (outpost spawn halts above cap)
               </span>
             </div>
           )}

--- a/src/app/speck-wars/components/phase-router.tsx
+++ b/src/app/speck-wars/components/phase-router.tsx
@@ -3,7 +3,6 @@ import { useState, useEffect } from 'react'
 import { useSpeckWarsStore } from '../store'
 import { getBestTime, getWinStreak, getRecentResults, hasWonToday, getLifetimeStats } from '../lib/personal-best'
 import { getDailyInfo } from '../lib/daily-modifier'
-import { DAILY_MODIFIER_LABELS } from '../domain/constants'
 import type { Difficulty } from '../store'
 import { useAuth } from '@/hooks/useAuth'
 import Link from 'next/link'
@@ -123,11 +122,9 @@ export function PhaseRouter({ children }: { children: React.ReactNode }) {
             )
           })}
         </div>
-        {/* Daily info row — map layout + modifier badge */}
+        {/* Daily info row — map layout */}
         {(() => {
-          const { modifier, layoutName } = getDailyInfo(difficulty)
-          const color = modifier === 'bulwark' ? '#44aaff' : modifier === 'blitz' ? '#ffd700' : modifier === 'siege' ? '#ff8844' : 'rgba(255,255,255,0.25)'
-          const label = modifier !== 'standard' ? DAILY_MODIFIER_LABELS[modifier] : null
+          const { layoutName } = getDailyInfo(difficulty)
           return (
             <div style={{ display: 'flex', gap: 8, alignItems: 'center', marginBottom: 2 }}>
               <div style={{
@@ -138,16 +135,6 @@ export function PhaseRouter({ children }: { children: React.ReactNode }) {
               }}>
                 ⬡ {layoutName}
               </div>
-              {label && (
-                <div style={{
-                  fontSize: 10, letterSpacing: 1,
-                  color,
-                  border: `1px solid ${color}44`,
-                  padding: '3px 8px', borderRadius: 4,
-                }}>
-                  {label}
-                </div>
-              )}
             </div>
           )
         })()}
@@ -404,13 +391,12 @@ export function PhaseRouter({ children }: { children: React.ReactNode }) {
 
     const today = new Date().toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
     const starStr = won ? '★'.repeat(stars) + '☆'.repeat(3 - stars) : '✗✗✗'
-    const modifier = hud?.dailyModifier && hud.dailyModifier !== 'standard' ? ` [${hud.dailyModifier.toUpperCase()}]` : ''
     const { layoutName } = getDailyInfo(difficulty)
     const effPct = kills + losses > 0 ? Math.round((kills / (kills + losses)) * 100) : 0
     const statsLine = `⚔ ${kills} kills · ${losses} lost · ${effPct}% eff${peakArmySize > 0 ? ` · peak ${peakArmySize}` : ''}`
     const shareText = won
-      ? `${starStr} Speck Wars ${today} [${layoutName}]${modifier}\nVICTORY in ${timeStr} (${diffLabel})\n${statsLine}\nCan you do better? `
-      : `${starStr} Speck Wars ${today} [${layoutName}]${modifier}\nDEFEATED in ${timeStr} (${diffLabel})\n${statsLine}\nThink you can win? `
+      ? `${starStr} Speck Wars ${today} [${layoutName}]\nVICTORY in ${timeStr} (${diffLabel})\n${statsLine}\nCan you do better? `
+      : `${starStr} Speck Wars ${today} [${layoutName}]\nDEFEATED in ${timeStr} (${diffLabel})\n${statsLine}\nThink you can win? `
 
     const handleShare = async () => {
       const url = typeof window !== 'undefined' ? window.location.href : ''
@@ -493,18 +479,6 @@ export function PhaseRouter({ children }: { children: React.ReactNode }) {
           }}>
             ⬡ {layoutName}
           </span>
-          {hud?.dailyModifier && hud.dailyModifier !== 'standard' && (
-            <span style={{
-              fontSize: 11, letterSpacing: 1.5,
-              color: hud.dailyModifier === 'bulwark' ? '#44aaff'
-                : hud.dailyModifier === 'blitz' ? '#ffd700'
-                : '#ff8844',
-              border: `1px solid ${hud.dailyModifier === 'bulwark' ? '#44aaff44' : hud.dailyModifier === 'blitz' ? '#ffd70044' : '#ff884444'}`,
-              padding: '2px 8px', borderRadius: 4,
-            }}>
-              {hud.dailyModifier.toUpperCase()}
-            </span>
-          )}
         </div>
 
         {aiPersonality && aiPersonality !== 'balanced' && (difficulty === 'hard' || difficulty === 'very-hard') && (
@@ -583,7 +557,6 @@ export function PhaseRouter({ children }: { children: React.ReactNode }) {
         {/* Contextual tactical tip */}
         {(() => {
           const eff = kills + losses > 0 ? kills / (kills + losses) : 0
-          const modifier = hud?.dailyModifier ?? 'standard'
           let tip: string | null = null
 
           if (won && elapsedMs < 180000) {
@@ -602,8 +575,6 @@ export function PhaseRouter({ children }: { children: React.ReactNode }) {
             tip = isTouchDevice
               ? 'Tip: Tap ★ SURGE for 2× production 8s. Use it when you\'re behind!'
               : 'Tip: Press Q for Surge — doubles production for 8s. Use it when you\'re behind!'
-          } else if (won && modifier === 'siege') {
-            tip = '⬡ Siege modifier won — outposts were twice as hard to capture. Nice patience!'
           }
 
           if (!tip) return null

--- a/src/app/speck-wars/domain/constants.ts
+++ b/src/app/speck-wars/domain/constants.ts
@@ -52,16 +52,3 @@ export const FOG_VISION_SPECK = 150     // px vision radius per speck (coarse ce
 export const FOG_VISION_BASE = 300      // px vision radius around player base
 export const FOG_VISION_BUILDING = 180  // px vision radius around owned outposts/buildings
 
-export type DailyModifier = 'standard' | 'bulwark' | 'blitz' | 'siege'
-
-// Weighted array: standard appears 2× more often than others
-export const DAILY_MODIFIER_POOL: DailyModifier[] = [
-  'standard', 'standard', 'bulwark', 'blitz', 'siege'
-]
-
-export const DAILY_MODIFIER_LABELS: Record<DailyModifier, string> = {
-  standard: '',
-  bulwark:  '⚔ BULWARK — bases have 2× HP',
-  blitz:    '⚡ BLITZ — 1.5× production speed',
-  siege:    '🏰 SIEGE — outposts take 2× longer to capture',
-}

--- a/src/app/speck-wars/domain/simulation/capture.ts
+++ b/src/app/speck-wars/domain/simulation/capture.ts
@@ -31,7 +31,7 @@ export function updateCapture(sim: SimulationState, dt: number) {
         const hasEnemyProgress = (building.captureProgress ?? 0) > 0 &&
           building.captureSide && building.captureSide !== topOwner
         if (hasEnemyProgress) {
-          const captureTimeMs = sim.dailyModifier === 'siege' ? CAPTURE_TIME * 2 : CAPTURE_TIME
+          const captureTimeMs = CAPTURE_TIME
           building.captureProgress = Math.max(0, (building.captureProgress ?? 0) - (dt / captureTimeMs) * 0.5)
           if ((building.captureProgress ?? 0) <= 0) building.captureSide = null
         }
@@ -49,7 +49,7 @@ export function updateCapture(sim: SimulationState, dt: number) {
     }
 
     // Flat timer: any presence captures at constant rate
-    const captureTimeMs = sim.dailyModifier === 'siege' ? CAPTURE_TIME * 2 : CAPTURE_TIME
+    const captureTimeMs = CAPTURE_TIME
     building.captureProgress = (building.captureProgress ?? 0) + (dt / captureTimeMs)
     if ((building.captureProgress ?? 0) >= 1) {
       const previousOwner = building.ownerId

--- a/src/app/speck-wars/domain/simulation/create-sim.ts
+++ b/src/app/speck-wars/domain/simulation/create-sim.ts
@@ -1,6 +1,5 @@
 import type { SimulationState, Player, BuildingEntity, WallObstacle } from '../types'
-import { PLAYER_BASE_X, PLAYER_BASE_Y, AI_BASE_X, AI_BASE_Y, PLAYER_COLOR, AI_COLOR, BASE_HP, MAX_SPECKS, NEUTRAL_COLOR, MAP_LAYOUTS, DAILY_MODIFIER_POOL } from '../constants'
-import type { DailyModifier } from '../constants'
+import { PLAYER_BASE_X, PLAYER_BASE_Y, AI_BASE_X, AI_BASE_Y, PLAYER_COLOR, AI_COLOR, BASE_HP, MAX_SPECKS, NEUTRAL_COLOR, MAP_LAYOUTS } from '../constants'
 import { SpatialGrid } from './spatial-grid'
 import { mulberry32 } from './prng'
 import type { Difficulty, MapPreset } from '../../store'
@@ -123,27 +122,10 @@ export function createSim(seed: number = Date.now(), difficulty: Difficulty = 'm
     }
   }
 
-  // Pick daily modifier — after layout and jitter RNG calls
-  const modifierIndex = Math.floor(rng() * DAILY_MODIFIER_POOL.length)
-  const dailyModifier: DailyModifier = DAILY_MODIFIER_POOL[modifierIndex]
-
-  // Generate obstacles AFTER modifier pick to avoid shifting existing RNG sequence
+  // Generate obstacles after layout and jitter RNG calls
   const obstacles = mapPreset === 'random'
     ? generateObstacles(rng)
     : (MAP_PRESET_OBSTACLES[mapPreset] ?? [])
-
-  // Apply static modifier effects
-  if (dailyModifier === 'bulwark') {
-    playerBase.hp = BASE_HP * 2
-    playerBase.maxHp = BASE_HP * 2
-    aiBase.hp = BASE_HP * 2
-    aiBase.maxHp = BASE_HP * 2
-  }
-  if (dailyModifier === 'blitz') {
-    const DEFAULT_BASE_INTERVAL = 800  // BUILDING_TYPES.base.spawnInterval
-    playerBase.spawnIntervalOverride = (playerBase.spawnIntervalOverride ?? DEFAULT_BASE_INTERVAL) * 0.65
-    aiBase.spawnIntervalOverride = (aiBase.spawnIntervalOverride ?? DEFAULT_BASE_INTERVAL) * 0.65
-  }
 
   // NOTE: `seed` governs setup only — map layout, outpost jitter, daily modifier, obstacles.
   // Everything after createSim (spawner.ts, tick.ts, ai-controller.ts) calls raw Math.random(),
@@ -173,7 +155,6 @@ export function createSim(seed: number = Date.now(), difficulty: Difficulty = 'm
     dominationTimer: 0,
     surgeDuration: 0,
     surgeCooldown: 0,
-    dailyModifier,
     waveCountdown: null,
     waveInProgress: false,
     waveNumber: 0,

--- a/src/app/speck-wars/domain/simulation/tick.ts
+++ b/src/app/speck-wars/domain/simulation/tick.ts
@@ -448,5 +448,5 @@ function emitHudUpdate(sim: SimulationState) {
     if (b) selectedBuilding = { id: b.id, typeId: b.typeId, ownerId: b.ownerId, hp: b.hp, maxHp: b.maxHp, spawnTypeOverride: b.spawnTypeOverride }
   }
 
-  sim.events.push({ type: 'HUD_UPDATE', data: { players: data, attackedBuildingIds, captureInfo, surgeDuration: sim.surgeDuration, surgeCooldown: sim.surgeCooldown, selectedSpeckCount: sim.selectedSpeckIds.size, selectedComposition, spawnRates, minimap, dailyModifier: sim.dailyModifier, waveCountdown: sim.waveCountdown, waveInProgress: sim.waveInProgress, waveNumber: sim.waveNumber, baseUnderThreat, enemyAdvanceDetected, selectedBuilding } })
+  sim.events.push({ type: 'HUD_UPDATE', data: { players: data, attackedBuildingIds, captureInfo, surgeDuration: sim.surgeDuration, surgeCooldown: sim.surgeCooldown, selectedSpeckCount: sim.selectedSpeckIds.size, selectedComposition, spawnRates, minimap, waveCountdown: sim.waveCountdown, waveInProgress: sim.waveInProgress, waveNumber: sim.waveNumber, baseUnderThreat, enemyAdvanceDetected, selectedBuilding } })
 }

--- a/src/app/speck-wars/domain/types.ts
+++ b/src/app/speck-wars/domain/types.ts
@@ -79,7 +79,6 @@ export interface SimulationState {
   dominationTimer: number    // ms of continuous triple-outpost control; resets on loss
   surgeDuration: number      // ms remaining in active surge, 0 = inactive
   surgeCooldown: number      // ms remaining before surge can be used again, 0 = ready
-  dailyModifier: 'standard' | 'bulwark' | 'blitz' | 'siege'
   waveCountdown: number | null   // ms until next AI wave (null = waves disabled on this difficulty)
   waveInProgress: boolean        // true during the 15s wave assault
   waveNumber: number             // current wave count (0 = not started)
@@ -132,7 +131,6 @@ export interface HudData {
   selectedSpeckCount: number   // 0 when no selection active
   selectedComposition: { types: Record<string, number>; veteranCount: number; eliteCount: number; legendCount: number } | null
   spawnRates: Record<string, number>   // playerId → effective specks/min
-  dailyModifier: 'standard' | 'bulwark' | 'blitz' | 'siege'
   waveCountdown: number | null
   waveInProgress: boolean
   waveNumber: number

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -9,7 +9,6 @@ import type { Camera } from './rendering/camera'
 import { AIController, type AIPersonality } from './domain/ai/ai-controller'
 import { recordBestTime, incrementWinStreak, resetWinStreak, isFirstGame, markFirstGameDone, recordGameResult, markWonToday, updateLifetimeStats, getWinStreak, hasSeenVeteranTip, markVeteranTipSeen } from './lib/personal-best'
 import { BUILDING_TYPES } from './domain/config/building-types'
-import { DAILY_MODIFIER_LABELS } from './domain/constants'
 
 export class GameInstance {
   private canvas: HTMLCanvasElement
@@ -332,13 +331,6 @@ export class GameInstance {
       this.notify('⚔ FIGHT!', '#4af7c4', 800)
       navigator.vibrate?.([50, 30, 50, 30, 100])
     }, 3000)
-
-    // Announce daily modifier so players know the active rule change
-    if (this.sim.dailyModifier !== 'standard') {
-      const modColor = this.sim.dailyModifier === 'bulwark' ? '#44aaff'
-        : this.sim.dailyModifier === 'blitz' ? '#ffd700' : '#ff8844'
-      setTimeout(() => this.notify(`📅 ${DAILY_MODIFIER_LABELS[this.sim.dailyModifier]}`, modColor, 4000), 3600)
-    }
 
     // Show tutorial hints for first-time players
     if (isFirstGame()) {

--- a/src/app/speck-wars/lib/daily-modifier.ts
+++ b/src/app/speck-wars/lib/daily-modifier.ts
@@ -1,17 +1,16 @@
 import { mulberry32 } from '../domain/simulation/prng'
-import { DAILY_MODIFIER_POOL, MAP_LAYOUTS, MAP_LAYOUT_NAMES } from '../domain/constants'
-import type { DailyModifier } from '../domain/constants'
+import { MAP_LAYOUTS, MAP_LAYOUT_NAMES } from '../domain/constants'
 import type { Difficulty } from '../store'
 
 /**
- * Returns today's map layout name and daily modifier for the given difficulty
+ * Returns today's map layout name for the given difficulty
  * without running a full simulation. Replicates the exact RNG call sequence
  * from createSim so the results always match the in-game values.
  */
 export function getDailyInfo(
   difficulty: Difficulty,
   date: Date = new Date()
-): { modifier: DailyModifier; layoutName: string } {
+): { layoutName: string } {
   const dateKey = date.getFullYear() * 10000 + (date.getMonth() + 1) * 100 + date.getDate()
   const diffHash = [...difficulty].reduce((acc, ch) => acc + ch.charCodeAt(0), 0)
   const seed = dateKey * 1000 + diffHash
@@ -19,21 +18,8 @@ export function getDailyInfo(
   const rng = mulberry32(seed)
   // Call 1: layout index
   const layoutIndex = Math.floor(rng() * MAP_LAYOUTS.length)
-  // Calls 2–7: jitter (2 per outpost, 3 outposts in every layout)
-  const outpostCount = MAP_LAYOUTS[layoutIndex].length
-  for (let i = 0; i < outpostCount; i++) {
-    rng(); rng()
-  }
-  // Call 8: modifier
-  const modifierIndex = Math.floor(rng() * DAILY_MODIFIER_POOL.length)
 
   return {
-    modifier: DAILY_MODIFIER_POOL[modifierIndex],
     layoutName: MAP_LAYOUT_NAMES[layoutIndex],
   }
-}
-
-/** Convenience wrapper — returns only the modifier. */
-export function getDailyModifier(difficulty: Difficulty, date?: Date): DailyModifier {
-  return getDailyInfo(difficulty, date).modifier
 }


### PR DESCRIPTION
Removes the system where each day has a different game modifier (bulwark/blitz/siege). All games now use standard rules: base HP 100, normal spawn rate, flat 5s capture time. Part of epic #2327.

## Changes

- `domain/constants.ts` — removed `DailyModifier` type, `DAILY_MODIFIER_POOL`, `DAILY_MODIFIER_LABELS`
- `domain/types.ts` — removed `dailyModifier` field from `SimulationState` and `HudData`
- `domain/simulation/create-sim.ts` — removed modifier computation, bulwark HP doubling, blitz spawn interval override, and `dailyModifier` field in returned state
- `domain/simulation/capture.ts` — simplified both capture time expressions from `siege ? CAPTURE_TIME * 2 : CAPTURE_TIME` to `CAPTURE_TIME`
- `domain/simulation/tick.ts` — removed `dailyModifier` from HUD_UPDATE emission
- `game-instance.ts` — removed `DAILY_MODIFIER_LABELS` import and the daily modifier announcement notification
- `components/hud.tsx` — removed `DAILY_MODIFIER_LABELS` import and the bulwark/blitz/siege badge in the top-right HUD
- `components/phase-router.tsx` — removed modifier badge in the menu difficulty area, modifier badge in victory/defeat screen, modifier in share text, and the siege victory tip
- `lib/daily-modifier.ts` — stripped down to return only `layoutName` (still used by `phase-router.tsx`)

Closes #2340