### PR TITLE
docs(speck-wars): add skill docs for post-simplification game (#2343)

### DIFF
--- a/.claude/skills/speck-wars/SKILL.md
+++ b/.claude/skills/speck-wars/SKILL.md
@@ -1,0 +1,37 @@
+# Speck Wars — Skill Document
+
+## What this skill covers
+Speck Wars is a real-time strategy browser game in which a player captures outposts and defeats the AI by destroying its base. This skill covers the post-simplification game (after epic #2327): mechanics not documented here have been removed.
+
+## The game in one paragraph
+Two bases face each other across a 3000×1500 px world. Each base and capturable outpost automatically spawns units ("specks") at a steady rate. The player commands specks with rally points, attack-move orders, and spawn-type switches. The AI responds based on its personality (aggressive / macro / balanced). Victory goes to whoever destroys the enemy base first, or to whichever side holds all three outposts for 60 consecutive seconds (domination win).
+
+## Invariants
+
+1. **SOA structure, fixed arrays.** All speck data lives in parallel typed arrays (`speckX`, `speckY`, `speckHp`, …) allocated once at max capacity (`MAX_SPECKS = 15000`). Dead slots are recycled via `freeSlots`. No new arrays are ever allocated per tick. `speckCount` is a high-water mark, not a live count.
+
+2. **Seeded setup, non-deterministic run.** Map layout (outpost positions, starting orientation) is seeded from the daily date + difficulty, so the same day/difficulty always produces the same map. The simulation itself is non-deterministic: `Math.random()` is used during spawning and AI decisions. Replay and lockstep are not supported.
+
+3. **No global mutable state outside SimulationState.** The entire game world is `SimulationState`. Rendering reads it; inputs enter via `inputQueue`; events leave via `events`. The `game-instance.ts` wrapper owns the RAF loop and wires UI ↔ sim.
+
+4. **Player specks never choose their own objective.** Once a player speck reaches its assigned rally point it waits there, attacking enemies that come within `GUARD_ENGAGE_RANGE` (130 px). Only AI specks autonomously seek the nearest enemy building.
+
+5. **Capture is flat.** A single speck captures an outpost at the same speed as a hundred; the only thing that matters is *presence* inside `CAPTURE_RADIUS` (100 px). Contested reversal is also flat (0.5 speed).
+
+6. **Veteran progression is real.** Specks accumulate kills and gain permanent stat bonuses at 3 (Veteran, +20% dmg), 6 (Elite, +35%), and 12 (Legend, +50% + AoE splash). Kill counts survive until the speck dies; they are not reset by rallying or holding.
+
+## Baseline balance
+A player who issues no orders after the opening wins approximately 4 out of 5 games on easy. On medium the passive win rate drops to roughly 1 in 2. On hard and very-hard the AI's faster decision ticks and wave assault mechanic mean a passive player loses reliably. Re-measure after any change to spawn intervals, capture time, or AI tick rates.
+
+## Verifying a change
+1. Run `npx tsc --noEmit` in `cometcave/` — no type errors.
+2. Start a game at each difficulty and observe for at least 90 s.
+3. Check that the HUD surge button, minimap, and speck composition panel update correctly.
+4. On hard, let the AI reach wave 1 and confirm the WAVE indicator appears.
+5. Capture all three outposts and hold them — confirm domination countdown and win screen.
+
+## Known hazards
+- **Non-determinism in spawning.** `Math.random()` is called inside `updateSpawners` and `runSpeckAI`. Tests that assert exact unit positions or kill counts across ticks will be fragile.
+- **SOA index invalidation.** `freeSlots.pop()` recycles indices. Code that caches a speck index across ticks (rather than looking up by ID) will read stale data for a recycled slot.
+- `speckCount` is a high-water mark, not a live count. Iterating `0..speckCount` visits dead slots; always check `speckIds[i]` before reading a slot.
+- `dominationTimer` in `SimulationState` is reset to 0 whenever the player loses an outpost. A near-win can silently reset. Watch this field in the HUD if domination wins stop triggering.

--- a/.claude/skills/speck-wars/references/architecture.md
+++ b/.claude/skills/speck-wars/references/architecture.md
@@ -1,0 +1,214 @@
+# Speck Wars — Architecture Reference
+
+## File map
+
+All paths relative to `src/app/speck-wars/`. Approximate LOC after epic #2327 simplification.
+
+### Entry / React shell
+| File | ~LOC | Role |
+|------|------|------|
+| `page.tsx` | 14 | Next.js route entry |
+| `layout.tsx` | 10 | Route layout |
+| `SpeckWarsGame.tsx` | 178 | React root; mounts canvas, wires store |
+| `components/phase-router.tsx` | 696 | Renders correct UI per game phase |
+| `components/hud.tsx` | 1730 | In-game HUD (stats, surge button, help overlay) |
+| `components/minimap.tsx` | 184 | Minimap overlay |
+| `store.ts` | 160 | Zustand store: phase, HUD data, game actions |
+
+### Core game loop
+| File | ~LOC | Role |
+|------|------|------|
+| `game-instance.ts` | 928 | RAF loop, sim↔UI bridge, key bindings |
+| `input/input-handler.ts` | 685 | Mouse/touch/keyboard → InputEvents |
+| `input/touch-feedback.ts` | 20 | Touch ripple visuals |
+
+### Simulation (`domain/simulation/`)
+| File | ~LOC | Role |
+|------|------|------|
+| `tick.ts` | 397 | Master tick: calls all subsystems in order |
+| `create-sim.ts` | 162 | Build initial `SimulationState` for a new game |
+| `spawner.ts` | 87 | Spawn specks from buildings each tick |
+| `speck-ai.ts` | 198 | Per-speck target selection and state machine |
+| `movement.ts` | 229 | Velocity, steering, separation, guard bubble |
+| `combat.ts` | 150 | Damage resolution, veteran promotion, building damage |
+| `capture.ts` | 74 | Outpost capture progress |
+| `turret.ts` | 71 | Turret fire logic (missile spawning) |
+| `victory.ts` | 17 | Win/loss condition checks |
+| `muster.ts` | 26 | Muster radius helpers for rally arrival |
+| `spatial-grid.ts` | 37 | Spatial hash for O(1) neighbor queries |
+| `prng.ts` | 9 | Seeded PRNG (map layout only) |
+
+### AI (`domain/ai/`)
+| File | ~LOC | Role |
+|------|------|------|
+| `ai-controller.ts` | 197 | High-level AI: personality, wave timing, decision loop |
+
+### Config / types (`domain/`)
+| File | ~LOC | Role |
+|------|------|------|
+| `types.ts` | 144 | All shared TypeScript interfaces |
+| `constants.ts` | 54 | Numeric game constants |
+| `config/building-types.ts` | 27 | Building type definitions |
+| `config/speck-types.ts` | 53 | Unit type definitions |
+
+### Rendering (`rendering/`)
+| File | ~LOC | Role |
+|------|------|------|
+| `renderer.ts` | 247 | Pixi.js app setup, layer orchestration |
+| `camera.ts` | 54 | Viewport transform |
+| `textures.ts` | 12 | Texture cache |
+| `layers/building-layer.ts` | 327 | Draw buildings, capture bars, HP rings |
+| `layers/speck-layer.ts` | 172 | Draw specks, veteran rings, selection halos |
+| `layers/effects-layer.ts` | 159 | Death particles, explosions |
+| `layers/fog-layer.ts` | 179 | Fog-of-war mask |
+| `layers/starfield-layer.ts` | 44 | Parallax background |
+| `layers/grid-layer.ts` | 40 | Debug grid overlay |
+
+### Persistence / lib
+| File | ~LOC | Role |
+|------|------|------|
+| `lib/personal-best.ts` | 131 | Local-storage personal best tracking |
+| `lib/daily-modifier.ts` | 25 | Returns layout name from daily seed (modifier logic removed) |
+
+**Deleted files** (epic #2327):
+- `domain/simulation/garrison.ts`
+- `domain/simulation/construction.ts`
+- `domain/simulation/unit-abilities.ts`
+
+---
+
+## Tick pipeline (execution order)
+
+Each animation frame calls `tick(sim, dt)` in `tick.ts`:
+
+1. `consumeInputs()` — drain `sim.inputQueue`; apply RALLY, ATTACK_MOVE, SURGE, HOLD, STOP, BOX_SELECT, CLEAR_SELECT, SELECT_BUILDING, SET_BUILDING_RALLY, SET_SPAWN_TYPE
+2. `updateSpawners()` — decrement `spawnTimer`; emit `SPECK_SPAWNED`
+3. `updateTurrets()` — fire missiles at nearby enemies
+4. `runSpeckAI()` — each speck picks or validates its target
+5. `moveSpecks()` — update positions, apply separation forces
+6. `resolveCombat()` — deal damage; emit SPECK_DIED, BUILDING_DAMAGED, BUILDING_DESTROYED
+7. Auto-clear `selectedBuildingId` if building was destroyed this tick
+8. `removeDeadSpecks()` — compact `speckMeta`; push freed indices to `freeSlots`
+9. `updateCapture()` — advance capture progress; emit OUTPOST_CAPTURED
+10. `regenBuildingHp()` — restore HP (5 s no-damage cooldown required)
+11. Surge timers — decrement `surgeDuration` / `surgeCooldown`
+12. `checkVictory()` — emit GAME_OVER if win condition met
+13. Domination check — if `dominationTimer >= DOMINATION_TIME` emit GAME_OVER (domination)
+14. `emitHudUpdate()` — emit HUD_UPDATE every 10 ticks
+
+---
+
+## InputEvent catalog
+
+| Type | Key fields | Effect |
+|------|-----------|--------|
+| RALLY | ownerId, x, y | Move selected specks to (x, y) |
+| ATTACK_MOVE | ownerId, x, y | Attack-move to (x, y) |
+| SET_SPAWN_TYPE | ownerId, speckTypeId, buildingId? | Change production type for a building (or all) |
+| BOX_SELECT | ownerId, x1, y1, x2, y2 | Select specks inside bounding box |
+| CLEAR_SELECT | ownerId | Deselect all |
+| SURGE | ownerId | Activate surge (2x spawn, 8 s, 45 s CD) |
+| STOP | ownerId | Idle selected specks |
+| HOLD | ownerId | Hold-position selected specks |
+| SELECT_BUILDING | ownerId, buildingId | Focus a building for inspection |
+| SET_BUILDING_RALLY | ownerId, buildingId, x, y | Set per-building rally point |
+
+---
+
+## SimEvent catalog
+
+| Type | Key fields | Consumer |
+|------|-----------|----------|
+| SPECK_DIED | speckId, x, y, killedOwnerId, killerOwnerId | Effects layer, kill feed |
+| BUILDING_DAMAGED | buildingId, hp | Building layer (HP ring) |
+| BUILDING_DESTROYED | buildingId, ownerId, x, y | Explosion effect, victory check |
+| SPECK_SPAWNED | speckId, buildingId | (informational) |
+| GAME_OVER | winnerId, victoryType | phase-router → results screen |
+| HUD_UPDATE | data: HudData | store → HUD component |
+| OUTPOST_CAPTURED | outpostId, newOwner, previousOwner | Notification toast |
+| SPECK_VETERAN | speckId, ownerId | Speck layer (gold ring) |
+| SPECK_ELITE | speckId, ownerId | Speck layer (purple ring) |
+| SPECK_LEGEND | speckId, ownerId | Speck layer (AoE ring) |
+| AI_WAVE_START | waveNumber | HUD wave indicator |
+| VETERAN_FALLEN | speckId, ownerId, kills, x, y | Kill-feed toast |
+| AI_SPAWN_SWITCH | speckTypeId | (informational) |
+
+---
+
+## Keybinding table
+
+| Key | Action |
+|-----|--------|
+| Space | Pause / resume |
+| Escape | Cancel modifier or clear selection |
+| R | Clear all rally points |
+| H | Hold position (selected specks) |
+| S | Stop (selected specks) |
+| C | Re-center camera on player base |
+| D | Defend — rally to player base |
+| N | Advance — rally to nearest uncaptured outpost (cycles on repeat) |
+| B | Rush — rally to enemy base |
+| Q | Surge (2x spawn, 8 s, 45 s cooldown) |
+| V | Snap camera to recent combat |
+| A | Arm attack-move mode (click to execute) |
+| G | Guard — rally to nearest friendly outpost |
+| E / Ctrl+A | Select all player specks |
+| 1 / 2 / 3 | Set spawn type: basic / heavy / scout (select building first) |
+| X | Cycle playback speed (1x / 2x) |
+| 4-9 | Recall control group |
+| Ctrl+4-9 | Save control group |
+| ? | Toggle help overlay |
+| Arrow keys | Pan camera |
+
+Removed keys (epic #2327): Z (stance), Y (commander ability), F (sacrifice), T (build turret).
+
+---
+
+## Unit and building config
+
+### Building types (`domain/config/building-types.ts`)
+
+| typeId | Name | Max HP | Size | Spawn type | Spawn interval | Regen |
+|--------|------|--------|------|------------|----------------|-------|
+| base | Base | 100 | 40 px | basic | 1800 ms | 0.5 HP/s |
+| outpost | Outpost | 50 | 20 px | heavy | 2700 ms | 2.0 HP/s |
+
+Regen only when not damaged for 5 s.
+
+### Speck types (`domain/config/speck-types.ts`)
+
+| typeId | Name | HP | Damage | Speed | Attack range | Attack CD | Size |
+|--------|------|----|----|-------|------------|-----------|------|
+| basic | Speck | 1 | 1.0 | 64 px/s | 6 px | 500 ms | 3 px |
+| heavy | Tank | 5 | 2.0 | 48 px/s | 8 px | 700 ms | 6 px |
+| scout | Dart | 1 | 0.5 | 120 px/s | 4 px | 600 ms | 2 px |
+| missile | Missile | 1 | 1.0 | 220 px/s | 6 px | — | 2 px |
+
+Type advantage: Heavy→Basic x1.3, Scout→Heavy x1.35, Basic→Scout x1.25.
+Missile is turret-only; the player cannot produce or command missiles.
+
+---
+
+## Key numeric constants (`domain/constants.ts`)
+
+| Constant | Value | Meaning |
+|----------|-------|---------|
+| MAX_SPECKS | 15 000 | Hard array capacity |
+| WORLD_WIDTH / HEIGHT | 3000 / 1500 px | Play area |
+| CAPTURE_RADIUS | 100 px | Proximity to count toward capture |
+| CAPTURE_TIME | 5 000 ms | Full capture duration |
+| DOMINATION_TIME | 60 000 ms | Hold all 3 outposts to win |
+| FOG_VISION_SPECK | 150 px | Per-speck vision radius |
+| FOG_VISION_BASE | 300 px | Vision around player base |
+| FOG_VISION_BUILDING | 180 px | Vision around owned buildings |
+| HUD_UPDATE_INTERVAL | 10 ticks | HUD sync frequency (~160 ms at 60 FPS) |
+
+---
+
+## Known hazards
+
+- **Non-determinism.** `Math.random()` is called during spawning and AI decisions. Map layout is seeded; the runtime is not. Do not write tick-level deterministic tests.
+- **SOA slot reuse.** `freeSlots` recycles dead indices. Never cache a slot index across ticks; always look up by speck ID.
+- **`speckCount` is a high-water mark.** Dead slots may exist between 0 and `speckCount`. Guard reads with `if (!speckIds[i]) continue`.
+- **`dominationTimer` resets on outpost loss.** If the player loses one outpost for even one tick, the 60 s clock restarts. Intentional but non-obvious when debugging win-condition edge cases.
+- **`rngState` removed, non-determinism remains.** There is no longer a seeded RNG state for the runtime; do not attempt to add one expecting replay fidelity without a deeper architectural change.

--- a/.claude/skills/speck-wars/references/feature-map.md
+++ b/.claude/skills/speck-wars/references/feature-map.md
@@ -1,0 +1,71 @@
+# Speck Wars — Feature Map
+
+Last updated after epic #2327 simplification (all stat-modifier sprawl removed).
+
+## Core systems (all active)
+
+### Production
+- Each building spawns units at a fixed interval; `spawnTimer` counts down each tick.
+- Surge (`SURGE` input): doubles spawn rate for 8 s, 45 s cooldown. Player only.
+- Spawn type per building: player switches between basic / heavy / scout via keys 1/2/3.
+- Capturing an outpost grants a new production building; owning all three doubles total output.
+
+### Movement and orders
+- `RALLY` — move selection to world position; updates `assignedRallyX/Y` on each speck.
+- `ATTACK_MOVE` — move and engage enemies en route.
+- `STOP` — set state to `idle`.
+- `HOLD` — set `holdPosition = true`; speck stays put, attacks only adjacent enemies.
+- `SET_BUILDING_RALLY` — per-building rally; specks spawned from that building march there immediately.
+- Guard bubble: player specks at their rally engage enemy buildings within 130 px (`GUARD_ENGAGE_RANGE`).
+- AI specks attack-move to the nearest enemy building autonomously.
+
+### Combat
+- Melee range: 6–8 px depending on unit type.
+- Rock-paper-scissors type advantage: Heavy > Basic (×1.3), Scout > Heavy (×1.35), Basic > Scout (×1.25).
+- Veteran kills bonuses: 3 kills = +20% dmg, 6 kills = +35%, 12 kills = +50% + AoE splash.
+- Buildings lose HP from adjacent enemy specks; regen when not attacked for 5 s.
+- Base regen: 0.5 HP/s. Outpost regen: 2 HP/s.
+
+### Capture
+- Specks within 100 px of a neutral/enemy outpost advance capture at rate 1.0 (flat — no unit-count scaling).
+- Contested: opponent presence reverses capture at rate 0.5.
+- Full capture takes 5 000 ms (`CAPTURE_TIME`).
+
+### Victory
+- Destroy enemy base → destruction victory.
+- Hold all 3 outposts for 60 s → domination victory (`DOMINATION_TIME`).
+- AI base HP ≤ 20% → AI may surrender (difficulty-dependent).
+
+### Fog of war
+- Vision: 150 px per speck, 300 px around player base, 180 px around owned buildings.
+- Fog alpha: 0.85. Implemented in `rendering/layers/fog-layer.ts`.
+
+### AI
+- Three personalities: `aggressive`, `macro`, `balanced`.
+- Hard/very-hard: coordinated wave assaults every 90 s, 15 s duration.
+- AI counter-spawns to exploit type advantage.
+- No rubber-banding; no adaptive difficulty.
+
+### Minimap
+- Downsampled live speck positions + building positions.
+- Left-click on minimap → rally player specks to that world position.
+
+## Removed systems (epic #2327)
+Do not reference these in new code or tests:
+
+- Garrison / recall garrison (`garrison.ts` deleted)
+- Research / upgrade tiers
+- Fortification (outpost fortify timer, +25% dmg aura)
+- Creep camps and camp boost
+- Daily modifier (spawn multiplier, damage modifier pool)
+- Commander / hero unit
+- Sacrifice mechanic
+- Player build-turret action (turrets still fire as building fixtures; player cannot place them)
+- Player stance system (aggressive / defensive / balanced)
+- Adaptive AI difficulty / rubber-banding (`dominanceTimer`, `lastStandTriggered`)
+- Construction system (`construction.ts` deleted, `underConstruction` flag)
+- Supply cap
+- Rally cry (HP-threshold global buff)
+- Triple-outpost +2× production bonus
+- AI last-stand forced rally override
+- Unit abilities (`unit-abilities.ts` deleted)

--- a/.gitignore
+++ b/.gitignore
@@ -40,5 +40,7 @@ yarn-error.log*
 *.tsbuildinfo
 next-env.d.ts
 # Claude Code local state (settings, scheduled tasks, worktrees)
-/.claude/
+/.claude/worktrees/
+/.claude/settings.json
+/.claude/settings.local.json
 .claude-scratch/


### PR DESCRIPTION
## Summary
- Adds `.claude/skills/speck-wars/SKILL.md`: game overview, invariants, balance baseline, verification steps, known hazards
- Adds `.claude/skills/speck-wars/references/feature-map.md`: all active systems + explicit inventory of every removed mechanic (epic #2327)
- Adds `.claude/skills/speck-wars/references/architecture.md`: file map with LOC, full tick pipeline, InputEvent/SimEvent catalogs, keybinding table, unit/building config, numeric constants
- Updates `.gitignore` to track `.claude/skills/` (was previously ignoring all of `.claude/`)

These docs replace the pre-simplification skill docs (which did not exist in the repo — they were only in session memory) with accurate, committed references for future agents and developers.

Closes #2343. Part of epic #2327.

## Test plan
- [ ] All file paths named in architecture.md exist in the repo
- [ ] Deleted files listed (garrison.ts, construction.ts, unit-abilities.ts) are confirmed absent
- [ ] Keybinding table matches what's in `input/input-handler.ts` and `game-instance.ts`
- [ ] CI passes (TypeScript compile only; no runtime change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)