### PR TITLE
fix: viewport height clipping — bottom of page no longer cut off

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3,7 +3,8 @@
 @tailwind utilities;
 
 html {
-  overflow-y: scroll;
+  overflow-y: auto;
+  overflow-x: clip;
 }
 
 body {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -56,7 +56,7 @@ export default function RootLayout({
           />
         </head>
         <body className={`${plusJakartaSans.variable} ${beVietnamPro.variable} ${lexend.variable} ${beVietnamPro.className}`}>
-          <div id="site-wrapper" className="min-h-screen flex flex-col bg-surface-dim text-on-surface relative overflow-hidden">
+          <div id="site-wrapper" className="min-h-dvh flex flex-col bg-surface-dim text-on-surface relative overflow-x-hidden">
             <AmbientOrbs palette={['primary', 'secondary', 'tertiary']} intensity="medium" />
             <LayoutShell nav={<TopNavBar />} footer={<Footer />}>
               {children}


### PR DESCRIPTION
## Problem

The bottom 25–50px of the app were being clipped and required scrolling to see. Two causes:

1. `overflow-hidden` on `#site-wrapper` clipped content at the viewport edge
2. `min-h-screen` (`100vh`) doesn't account for mobile browser chrome (address bar, bottom nav bar)

## Fix

- `overflow-hidden` → `overflow-x-hidden` — vertical content can now grow and scroll normally; only horizontal overflow (ambient orbs) is clipped
- `min-h-screen` → `min-h-dvh` — uses dynamic viewport height which correctly excludes mobile browser UI
- `html { overflow-y: scroll }` → `overflow-y: auto; overflow-x: clip` — removes the forced scrollbar on pages that don't need it, while still preventing horizontal shift from the orbs

🤖 Generated with [Claude Code](https://claude.com/claude-code)