### PR TITLE
feat(speck-wars): campaign entry screen + Level 1 (First Contact)

### DIFF
--- a/src/app/speck-wars/campaign/levels.ts
+++ b/src/app/speck-wars/campaign/levels.ts
@@ -1,0 +1,45 @@
+import type { Difficulty } from '../store'
+
+export interface LevelConfig {
+  id: number
+  name: string
+  flavor: string          // 1-2 line cosmic narrator intro shown before the level
+  difficulty: Difficulty
+  seed: number            // fixed seed for consistent layout
+  outpostCount: number    // 0 = no outposts
+  preSpawn: {
+    player: number        // basic units pre-spawned for player
+    ai: number            // basic units pre-spawned for AI
+  }
+  starThresholds: {       // player base HP% required for each star count
+    three: number         // e.g. 0.75 = 75% HP remaining
+    two: number
+  }
+}
+
+export const LEVELS: LevelConfig[] = [
+  {
+    id: 1,
+    name: 'First Contact',
+    flavor: 'One base. No tricks. Just you and them.',
+    difficulty: 'easy',
+    seed: 1001,
+    outpostCount: 0,
+    preSpawn: { player: 15, ai: 5 },
+    starThresholds: { three: 0.75, two: 0.40 },
+  },
+]
+
+export function getLevelStars(levelId: number): number {
+  try {
+    const raw = localStorage.getItem(`speckwars-level-${levelId}-stars`)
+    return raw ? parseInt(raw, 10) : 0
+  } catch { return 0 }
+}
+
+export function saveLevelStars(levelId: number, stars: number): void {
+  try {
+    const existing = getLevelStars(levelId)
+    if (stars > existing) localStorage.setItem(`speckwars-level-${levelId}-stars`, String(stars))
+  } catch {}
+}

--- a/src/app/speck-wars/components/phase-router.tsx
+++ b/src/app/speck-wars/components/phase-router.tsx
@@ -1,20 +1,30 @@
 'use client'
 import { useState, useEffect } from 'react'
+import { useRouter } from 'next/navigation'
 import { useSpeckWarsStore } from '../store'
 import { getBestTime, getWinStreak, getRecentResults, hasWonToday, getLifetimeStats } from '../lib/personal-best'
 import { getDailyInfo } from '../lib/daily-modifier'
 import type { Difficulty } from '../store'
 import { useAuth } from '@/hooks/useAuth'
 import Link from 'next/link'
+import { LEVELS, getLevelStars, saveLevelStars } from '../campaign/levels'
 
 export function PhaseRouter({ children }: { children: React.ReactNode }) {
-  const { phase, winnerId, setPhase, difficulty, setDifficulty, elapsedMs, resetGame, kills, losses, isNewBest, victoryType, hud, peakArmySize, outpostsCaptured, aiPersonality, peakVeteranCount, peakEliteCount, peakLegendCount, surgesUsed, fogEnabled, setFogEnabled, mapPreset, setMapPreset } = useSpeckWarsStore()
+  const { phase, winnerId, setPhase, difficulty, setDifficulty, elapsedMs, resetGame, kills, losses, isNewBest, victoryType, hud, peakArmySize, outpostsCaptured, aiPersonality, peakVeteranCount, peakEliteCount, peakLegendCount, surgesUsed, fogEnabled, setFogEnabled, mapPreset, setMapPreset, campaignLevel, setCampaignLevel } = useSpeckWarsStore()
   const [copied, setCopied] = useState(false)
   const [bestTimes, setBestTimes] = useState<Partial<Record<Difficulty, number>>>({})
   const [winStreak, setWinStreak] = useState(0)
   const [lifetimeStats, setLifetimeStats] = useState({ gamesPlayed: 0, totalKills: 0, bestStreak: 0 })
   const { user } = useAuth()
   const isTouchDevice = typeof navigator !== 'undefined' && navigator.maxTouchPoints > 0
+  const router = useRouter()
+
+  // Auto-start when launched from campaign
+  useEffect(() => {
+    if (phase === 'menu' && campaignLevel !== null) {
+      setPhase('playing')
+    }
+  }, [phase, campaignLevel, setPhase])
 
   useEffect(() => {
     if (phase === 'menu') {
@@ -57,6 +67,21 @@ export function PhaseRouter({ children }: { children: React.ReactNode }) {
       navigator.vibrate?.([200, 60, 80])  // heavy thud then short pulse: loss
     }
   }, [phase])
+
+  // Save campaign stars when victory/defeat reached
+  useEffect(() => {
+    if ((phase !== 'victory' && phase !== 'defeat') || campaignLevel === null) return
+    const won = winnerId === 'player'
+    const playerBaseHp = hud?.players?.player?.buildingHp?.['building-player-base'] ?? 0
+    const baseHpFrac = playerBaseHp / 100
+    const levelCfg = LEVELS.find(l => l.id === campaignLevel)
+    if (!levelCfg) return
+    const starsEarned = won
+      ? (baseHpFrac >= levelCfg.starThresholds.three ? 3
+        : baseHpFrac >= levelCfg.starThresholds.two ? 2 : 1)
+      : 0
+    saveLevelStars(campaignLevel, starsEarned)
+  }, [phase, campaignLevel, winnerId, hud])
 
   const difficulties: Array<{ key: 'easy' | 'medium' | 'hard' | 'very-hard'; label: string; color: string; desc: string }> = [
     { key: 'easy', label: 'Easy', color: '#44ff88', desc: 'slow AI · player spawn bonus' },
@@ -382,6 +407,13 @@ export function PhaseRouter({ children }: { children: React.ReactNode }) {
       ? baseHpFrac > 0.75 ? 3 : baseHpFrac > 0.5 ? 2 : 1
       : 0
 
+    // Campaign mode: level config and star tracking
+    const levelConfig = campaignLevel ? LEVELS.find(l => l.id === campaignLevel) ?? null : null
+    const campaignStarsEarned = won && levelConfig
+      ? (baseHpFrac >= levelConfig.starThresholds.three ? 3
+        : baseHpFrac >= levelConfig.starThresholds.two ? 2 : 1)
+      : 0
+
     const nextDifficulty: Partial<Record<string, { key: Difficulty; label: string; color: string }>> = {
       easy:   { key: 'medium',    label: 'Medium', color: '#ffcc44' },
       medium: { key: 'hard',      label: 'Hard',   color: '#ff4f7b' },
@@ -424,6 +456,11 @@ export function PhaseRouter({ children }: { children: React.ReactNode }) {
         <h1 style={{ color: accentColor, fontSize: isTouchDevice ? 44 : 64, margin: 0, letterSpacing: 4 }}>
           {won ? 'VICTORY' : 'DEFEATED'}
         </h1>
+        {levelConfig && (
+          <div style={{ fontSize: 13, letterSpacing: 2, color: 'rgba(255,255,255,0.5)', marginTop: 4 }}>
+            Level {campaignLevel} — {levelConfig.name}
+          </div>
+        )}
         {victoryType && (
           <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 4 }}>
             <div style={{
@@ -446,13 +483,19 @@ export function PhaseRouter({ children }: { children: React.ReactNode }) {
           </div>
         )}
         {won && (
-          <div title={stars === 3 ? '3 stars: base HP > 75%' : stars === 2 ? '2 stars: base HP > 50%' : '1 star: base HP ≤ 50%'} style={{ fontSize: 28, letterSpacing: 4, color: '#ffd700', textShadow: stars === 3 ? '0 0 20px #ffd700' : 'none' }}>
-            {'★'.repeat(stars)}{'☆'.repeat(3 - stars)}
+          <div title={
+            levelConfig
+              ? (campaignStarsEarned === 3 ? `3 stars: base HP > ${Math.round(levelConfig.starThresholds.three * 100)}%` : campaignStarsEarned === 2 ? `2 stars: base HP > ${Math.round(levelConfig.starThresholds.two * 100)}%` : '1 star')
+              : (stars === 3 ? '3 stars: base HP > 75%' : stars === 2 ? '2 stars: base HP > 50%' : '1 star: base HP ≤ 50%')
+          } style={{ fontSize: 28, letterSpacing: 4, color: '#ffd700', textShadow: (levelConfig ? campaignStarsEarned : stars) === 3 ? '0 0 20px #ffd700' : 'none' }}>
+            {'★'.repeat(levelConfig ? campaignStarsEarned : stars)}{'☆'.repeat(3 - (levelConfig ? campaignStarsEarned : stars))}
           </div>
         )}
-        {won && stars < 3 && (
+        {won && (levelConfig ? campaignStarsEarned : stars) < 3 && (
           <div style={{ fontSize: 9, letterSpacing: 1, color: 'rgba(255,215,0,0.4)', marginTop: -6 }}>
-            {stars === 2 ? 'finish >75% HP for ★★★' : 'finish >50% HP for ★★'}
+            {(levelConfig ? campaignStarsEarned : stars) === 2
+              ? `finish >${Math.round((levelConfig?.starThresholds.three ?? 0.75) * 100)}% HP for ★★★`
+              : `finish >${Math.round((levelConfig?.starThresholds.two ?? 0.50) * 100)}% HP for ★★`}
           </div>
         )}
         {won && isNewBest && (
@@ -645,6 +688,22 @@ export function PhaseRouter({ children }: { children: React.ReactNode }) {
           >
             Play Again
           </button>
+          {campaignLevel !== null && (
+            <button
+              onClick={() => {
+                resetGame()
+                setCampaignLevel(null)
+                router.push('/speck-wars')
+              }}
+              style={{
+                padding: '12px 28px', fontSize: 16, cursor: 'pointer',
+                background: 'transparent', border: `2px solid ${accentColor}`,
+                borderRadius: 8, color: accentColor, minHeight: 52,
+              }}
+            >
+              Back to Campaign
+            </button>
+          )}
           <button
             onClick={handleShare}
             style={{

--- a/src/app/speck-wars/domain/simulation/create-sim.ts
+++ b/src/app/speck-wars/domain/simulation/create-sim.ts
@@ -3,6 +3,7 @@ import { PLAYER_BASE_X, PLAYER_BASE_Y, AI_BASE_X, AI_BASE_Y, PLAYER_COLOR, AI_CO
 import { SpatialGrid } from './spatial-grid'
 import { mulberry32 } from './prng'
 import type { Difficulty, MapPreset } from '../../store'
+import { SPECK_TYPES } from '../config/speck-types'
 
 // Preset obstacle layouts — world is 3000×3000, player base at (600,1500), AI base at (2400,1500)
 const MAP_PRESET_OBSTACLES: Partial<Record<MapPreset, WallObstacle[]>> = {
@@ -67,7 +68,7 @@ const playerSpawnInterval: Record<Difficulty, number | undefined> = {
   'very-hard': undefined,  // same as hard — no advantage
 }
 
-export function createSim(seed: number = Date.now(), difficulty: Difficulty = 'medium', mapPreset: MapPreset = 'random'): SimulationState {
+export function createSim(seed: number = Date.now(), difficulty: Difficulty = 'medium', mapPreset: MapPreset = 'random', outpostCount: number = 3): SimulationState {
   const playerBase: BuildingEntity = {
     id: 'building-player-base',
     typeId: 'base',
@@ -106,7 +107,8 @@ export function createSim(seed: number = Date.now(), difficulty: Difficulty = 'm
   const layoutIndex = Math.floor(rng() * MAP_LAYOUTS.length)
   const outpostPositions = MAP_LAYOUTS[layoutIndex]
   const outpostBuildings: Record<string, BuildingEntity> = {}
-  for (const pos of outpostPositions) {
+  const limitedOutpostPositions = outpostCount > 0 ? outpostPositions.slice(0, outpostCount) : []
+  for (const pos of limitedOutpostPositions) {
     const jx = (rng() * 2 - 1) * JITTER
     const jy = (rng() * 2 - 1) * JITTER
     outpostBuildings[pos.id] = {
@@ -159,4 +161,58 @@ export function createSim(seed: number = Date.now(), difficulty: Difficulty = 'm
   }
 
   return sim
+}
+
+export function preSpawnUnits(
+  sim: SimulationState,
+  ownerId: string,
+  count: number,
+  typeId: 'basic' | 'heavy' | 'scout' = 'basic'
+): void {
+  // Find the owner's base building
+  const base = Object.values(sim.buildings).find(
+    b => b.ownerId === ownerId && b.typeId === 'base'
+  )
+  if (!base) return
+
+  const stype = SPECK_TYPES[typeId]
+
+  for (let i = 0; i < count; i++) {
+    // Scatter units in a radius around the base
+    const angle = (i / count) * Math.PI * 2
+    const radius = 40 + Math.random() * 20
+    const x = base.x + Math.cos(angle) * radius
+    const y = base.y + Math.sin(angle) * radius
+
+    // Find a free slot in the SoA arrays (prefer recycled free slots)
+    let slot: number
+    if (sim.freeSlots.length > 0) {
+      slot = sim.freeSlots.pop()!
+    } else if (sim.speckCount < MAX_SPECKS) {
+      slot = sim.speckCount
+      sim.speckCount++
+    } else {
+      break  // at capacity
+    }
+
+    const id = `pre-${ownerId}-${i}-${Date.now()}`
+    sim.speckIds[slot] = id
+    sim.speckX[slot] = x
+    sim.speckY[slot] = y
+    sim.speckVx[slot] = 0
+    sim.speckVy[slot] = 0
+    sim.speckHp[slot] = stype?.hp ?? 1
+
+    sim.speckMeta[slot] = {
+      id,
+      ownerId,
+      typeId,
+      state: 'idle',
+      targetId: null,
+      attackCooldown: 0,
+      kills: 0,
+      assignedRallyX: base.x,
+      assignedRallyY: base.y,
+    }
+  }
 }

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -1,4 +1,4 @@
-import { createSim } from './domain/simulation/create-sim'
+import { createSim, preSpawnUnits } from './domain/simulation/create-sim'
 import { tick } from './domain/simulation/tick'
 import type { SimulationState } from './domain/types'
 import { useSpeckWarsStore } from './store'
@@ -9,6 +9,7 @@ import type { Camera } from './rendering/camera'
 import { AIController, type AIPersonality } from './domain/ai/ai-controller'
 import { recordBestTime, incrementWinStreak, resetWinStreak, isFirstGame, markFirstGameDone, recordGameResult, markWonToday, updateLifetimeStats, getWinStreak, hasSeenVeteranTip, markVeteranTipSeen } from './lib/personal-best'
 import { BUILDING_TYPES } from './domain/config/building-types'
+import { LEVELS } from './campaign/levels'
 
 export class GameInstance {
   private canvas: HTMLCanvasElement
@@ -65,14 +66,41 @@ export class GameInstance {
 
   constructor(canvas: HTMLCanvasElement) {
     this.canvas = canvas
-    const difficulty = useSpeckWarsStore.getState().difficulty
-    const mapPreset = useSpeckWarsStore.getState().mapPreset
+    const storeState = useSpeckWarsStore.getState()
+    const campaignLevel = storeState.campaignLevel
     const aiTickInterval: Record<string, number> = { easy: 60, medium: 30, hard: 15, 'very-hard': 6 }
-    const now = new Date()
-    const dateKey = now.getFullYear() * 10000 + (now.getMonth() + 1) * 100 + now.getDate()
-    const diffHash = [...difficulty].reduce((acc, ch) => acc + ch.charCodeAt(0), 0)
-    const dailySeed = dateKey * 1000 + diffHash
-    this.sim = createSim(dailySeed, difficulty, mapPreset)
+
+    let difficulty = storeState.difficulty
+    let sim: SimulationState
+
+    if (campaignLevel !== null) {
+      // Campaign mode: use level config
+      const levelConfig = LEVELS.find(l => l.id === campaignLevel)
+      if (levelConfig) {
+        difficulty = levelConfig.difficulty
+        sim = createSim(levelConfig.seed, levelConfig.difficulty, 'open', levelConfig.outpostCount)
+        preSpawnUnits(sim, 'player', levelConfig.preSpawn.player)
+        preSpawnUnits(sim, 'ai', levelConfig.preSpawn.ai)
+      } else {
+        // Fallback: treat as skirmish
+        const mapPreset = storeState.mapPreset
+        const now = new Date()
+        const dateKey = now.getFullYear() * 10000 + (now.getMonth() + 1) * 100 + now.getDate()
+        const diffHash = [...difficulty].reduce((acc, ch) => acc + ch.charCodeAt(0), 0)
+        const dailySeed = dateKey * 1000 + diffHash
+        sim = createSim(dailySeed, difficulty, mapPreset)
+      }
+    } else {
+      // Skirmish/free play mode
+      const mapPreset = storeState.mapPreset
+      const now = new Date()
+      const dateKey = now.getFullYear() * 10000 + (now.getMonth() + 1) * 100 + now.getDate()
+      const diffHash = [...difficulty].reduce((acc, ch) => acc + ch.charCodeAt(0), 0)
+      const dailySeed = dateKey * 1000 + diffHash
+      sim = createSim(dailySeed, difficulty, mapPreset)
+    }
+
+    this.sim = sim
     this.renderer = new Renderer()
     this.camera = createCamera(canvas.clientWidth, canvas.clientHeight)
     const aiPersonality = (): AIPersonality => {

--- a/src/app/speck-wars/page.tsx
+++ b/src/app/speck-wars/page.tsx
@@ -1,14 +1,82 @@
 'use client'
+import { useRouter } from 'next/navigation'
+import { useEffect, useState } from 'react'
+import { useSpeckWarsStore } from './store'
+import { LEVELS, getLevelStars } from './campaign/levels'
 
-import { CosmicShell } from '../comet-cards/components/cosmic/shell'
-import { SpeckWarsGame } from './SpeckWarsGame'
+// Show 8 level slots total (1 real + 7 locked placeholders)
+const TOTAL_SLOTS = 8
 
-export default function SpeckWarsPage() {
+export default function SpeckWarsCampaignPage() {
+  const router = useRouter()
+  const { setCampaignLevel, resetGame } = useSpeckWarsStore()
+  const [stars, setStars] = useState<number[]>([])
+
+  useEffect(() => {
+    setStars(LEVELS.map(l => getLevelStars(l.id)))
+  }, [])
+
+  const handlePlay = (levelId: number) => {
+    resetGame()
+    setCampaignLevel(levelId)
+    router.push('/speck-wars/play')
+  }
+
   return (
-    <CosmicShell>
-      <div style={{ position: 'relative', width: '100%', height: '100%' }}>
-        <SpeckWarsGame />
+    <div style={{ minHeight: '100dvh', background: '#080810', display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', gap: 32, padding: 24 }}>
+      <div style={{ textAlign: 'center' }}>
+        <h1 style={{ fontSize: 48, fontWeight: 800, color: '#fff', margin: 0, letterSpacing: 2 }}>SPECK WARS</h1>
+        <div style={{ fontSize: 14, letterSpacing: 4, color: 'rgba(255,255,255,0.4)', marginTop: 6 }}>CAMPAIGN</div>
       </div>
-    </CosmicShell>
+
+      <div style={{ display: 'flex', flexWrap: 'wrap', gap: 12, justifyContent: 'center', maxWidth: 600 }}>
+        {Array.from({ length: TOTAL_SLOTS }, (_, i) => {
+          const levelNum = i + 1
+          const level = LEVELS.find(l => l.id === levelNum)
+          const levelStars = level ? (stars[i] ?? 0) : 0
+          const unlocked = !!level
+
+          return (
+            <button
+              key={levelNum}
+              type="button"
+              disabled={!unlocked}
+              onClick={() => unlocked && handlePlay(levelNum)}
+              style={{
+                width: 120, height: 140,
+                display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', gap: 6,
+                background: unlocked ? 'rgba(0,255,194,0.06)' : 'rgba(255,255,255,0.02)',
+                border: `1px solid ${unlocked ? 'rgba(0,255,194,0.3)' : 'rgba(255,255,255,0.06)'}`,
+                borderRadius: 12,
+                cursor: unlocked ? 'pointer' : 'default',
+                padding: 12,
+                transition: 'all 0.15s',
+              }}
+            >
+              <div style={{ fontSize: 11, letterSpacing: 2, color: unlocked ? '#00ffc2' : 'rgba(255,255,255,0.2)' }}>
+                {String(levelNum).padStart(2, '0')}
+              </div>
+              {unlocked && level ? (
+                <>
+                  <div style={{ fontSize: 13, fontWeight: 700, color: '#fff', textAlign: 'center', lineHeight: 1.3 }}>{level.name}</div>
+                  <div style={{ fontSize: 11, color: 'rgba(255,255,255,0.4)', textAlign: 'center', lineHeight: 1.4 }}>{level.flavor}</div>
+                  <div style={{ fontSize: 14, letterSpacing: 2, marginTop: 4 }}>
+                    {Array.from({ length: 3 }, (_, s) => (
+                      <span key={s} style={{ color: s < levelStars ? '#ffd700' : 'rgba(255,255,255,0.15)' }}>&#9733;</span>
+                    ))}
+                  </div>
+                </>
+              ) : (
+                <div style={{ fontSize: 20, opacity: 0.2 }}>&#128274;</div>
+              )}
+            </button>
+          )
+        })}
+      </div>
+
+      <a href="/speck-wars/skirmish" style={{ fontSize: 11, color: 'rgba(255,255,255,0.2)', letterSpacing: 1, textDecoration: 'none', marginTop: 16 }}>
+        Sandbox &rarr;
+      </a>
+    </div>
   )
 }

--- a/src/app/speck-wars/play/page.tsx
+++ b/src/app/speck-wars/play/page.tsx
@@ -1,0 +1,14 @@
+'use client'
+
+import { CosmicShell } from '../../comet-cards/components/cosmic/shell'
+import { SpeckWarsGame } from '../SpeckWarsGame'
+
+export default function SpeckWarsPlayPage() {
+  return (
+    <CosmicShell>
+      <div style={{ position: 'relative', width: '100%', height: '100%' }}>
+        <SpeckWarsGame />
+      </div>
+    </CosmicShell>
+  )
+}

--- a/src/app/speck-wars/skirmish/page.tsx
+++ b/src/app/speck-wars/skirmish/page.tsx
@@ -1,0 +1,14 @@
+'use client'
+
+import { CosmicShell } from '../../comet-cards/components/cosmic/shell'
+import { SpeckWarsGame } from '../SpeckWarsGame'
+
+export default function SpeckWarsSkirmishPage() {
+  return (
+    <CosmicShell>
+      <div style={{ position: 'relative', width: '100%', height: '100%' }}>
+        <SpeckWarsGame />
+      </div>
+    </CosmicShell>
+  )
+}

--- a/src/app/speck-wars/store.ts
+++ b/src/app/speck-wars/store.ts
@@ -65,6 +65,8 @@ interface SpeckWarsStore {
   setMapPreset: (p: MapPreset) => void
   gameActions: { defend: (() => void) | null; advance: (() => void) | null; rush: (() => void) | null; clearRally: (() => void) | null; surge: (() => void) | null; rally: ((x: number, y: number) => void) | null; setSpawnType: ((type: 'basic' | 'heavy' | 'scout') => void) | null; panCamera: ((x: number, y: number) => void) | null; stop: (() => void) | null; hold: (() => void) | null; guard: (() => void) | null; saveControlGroup?: ((slot: number) => void) | null; recallControlGroup?: ((slot: number) => void) | null; selectAll?: (() => void) | null; snapToBase?: (() => void) | null; snapToAction?: (() => void) | null; activatePatrol?: (() => void) | null; activateSelectMode?: (() => void) | null; selectByType?: ((typeId: string) => void) | null; selectBuilding?: ((buildingId: string) => void) | null; commandAt?: ((x: number, y: number) => void) | null; clearSelection?: (() => void) | null }
   setGameActions: (actions: { defend: () => void; advance: () => void; rush: () => void; clearRally: () => void; surge: () => void; rally: (x: number, y: number) => void; setSpawnType: (type: 'basic' | 'heavy' | 'scout') => void; panCamera: (x: number, y: number) => void; stop: () => void; hold: () => void; guard: () => void; saveControlGroup?: (slot: number) => void; recallControlGroup?: (slot: number) => void; selectAll?: () => void; snapToBase?: () => void; snapToAction?: () => void; activatePatrol?: () => void; activateSelectMode?: () => void; selectByType?: (typeId: string) => void; selectBuilding?: (buildingId: string) => void; commandAt?: (x: number, y: number) => void; clearSelection?: () => void } | null) => void
+  campaignLevel: number | null   // null = skirmish/free play
+  setCampaignLevel: (n: number | null) => void
   surrender: () => void
   resetGame: () => void
 }
@@ -130,6 +132,8 @@ export const useSpeckWarsStore = create<SpeckWarsStore>()((set, get) => ({
   setMapPreset: p => set({ mapPreset: p }),
   gameActions: { defend: null, advance: null, rush: null, clearRally: null, surge: null, rally: null, setSpawnType: null, panCamera: null, stop: null, hold: null, guard: null, saveControlGroup: null, recallControlGroup: null, selectAll: null, snapToBase: null, snapToAction: null, activatePatrol: null, activateSelectMode: null, selectByType: null, selectBuilding: null, commandAt: null, clearSelection: null },
   setGameActions: (actions) => set({ gameActions: actions ?? { defend: null, advance: null, rush: null, clearRally: null, surge: null, rally: null, setSpawnType: null, panCamera: null, stop: null, hold: null, guard: null, saveControlGroup: null, recallControlGroup: null, selectAll: null, snapToBase: null, snapToAction: null, activatePatrol: null, activateSelectMode: null, selectByType: null, selectBuilding: null, commandAt: null, clearSelection: null } }),
+  campaignLevel: null,
+  setCampaignLevel: n => set({ campaignLevel: n }),
   surrender: () => {
     const s = get()
     resetWinStreak()
@@ -156,5 +160,6 @@ export const useSpeckWarsStore = create<SpeckWarsStore>()((set, get) => ({
     killFeed: [],
     aiPersonality: null,
     difficulty: s.difficulty,
+    campaignLevel: null,
   })),
 }))


### PR DESCRIPTION
## Summary
- `/speck-wars` is now a campaign map with Level 1 unlocked (levels 2-8 locked)
- `/speck-wars/play` runs the game in campaign mode (auto-starts, no menu, uses level config)
- `/speck-wars/skirmish` preserves the existing sandbox game as the development playground
- Level 1 "First Contact": no outposts, easy AI, fixed seed, 15 player / 5 AI pre-spawned units
- Stars (1-3) earned by base HP% at victory, persisted to localStorage

Closes #2362 (partial — epic for campaign mode)

Rebased from integration branch onto main after the simplification work (removed supply, hero, garrison, turret, stance systems from the integration branch's version).

## Test plan
- [ ] `/speck-wars` shows campaign entry screen with Level 1 unlocked, levels 2-8 locked
- [ ] Clicking Level 1 starts the game with pre-spawned units and no outposts
- [ ] Victory shows star rating based on base HP %
- [ ] Stars persist to localStorage across page reloads
- [ ] "Back to Campaign" returns to `/speck-wars`
- [ ] `/speck-wars/skirmish` still works as the full sandbox game
- [ ] `/speck-wars/play` works as the campaign game runner

🤖 Generated with [Claude Code](https://claude.com/claude-code)