### PR TITLE
feat: campaign levels 2-10 with mapPreset terrain support

### DIFF
--- a/src/app/speck-wars/campaign/levels.ts
+++ b/src/app/speck-wars/campaign/levels.ts
@@ -1,4 +1,4 @@
-import type { Difficulty } from '../store'
+import type { Difficulty, MapPreset } from '../store'
 
 export interface LevelConfig {
   id: number
@@ -7,6 +7,7 @@ export interface LevelConfig {
   difficulty: Difficulty
   seed: number            // fixed seed for consistent layout
   outpostCount: number    // 0 = no outposts
+  mapPreset?: MapPreset   // terrain preset; defaults to 'open' if omitted
   preSpawn: {
     player: number        // basic units pre-spawned for player
     ai: number            // basic units pre-spawned for AI
@@ -25,8 +26,108 @@ export const LEVELS: LevelConfig[] = [
     difficulty: 'easy',
     seed: 1001,
     outpostCount: 0,
+    mapPreset: 'open',
     preSpawn: { player: 15, ai: 5 },
     starThresholds: { three: 0.75, two: 0.40 },
+  },
+  {
+    id: 2,
+    name: 'Middle Ground',
+    flavor: 'One outpost between you. Whoever holds it wins.',
+    difficulty: 'easy',
+    seed: 1002,
+    outpostCount: 1,
+    mapPreset: 'open',
+    preSpawn: { player: 12, ai: 5 },
+    starThresholds: { three: 0.70, two: 0.35 },
+  },
+  {
+    id: 3,
+    name: 'The Chokepoint',
+    flavor: 'One narrow pass. Patience wins the canyon.',
+    difficulty: 'medium',
+    seed: 1003,
+    outpostCount: 0,
+    mapPreset: 'canyon',
+    preSpawn: { player: 10, ai: 10 },
+    starThresholds: { three: 0.65, two: 0.30 },
+  },
+  {
+    id: 4,
+    name: 'Forward Command',
+    flavor: 'Push your rally past the midline. Make them play your game.',
+    difficulty: 'medium',
+    seed: 1004,
+    outpostCount: 1,
+    mapPreset: 'pillars',
+    preSpawn: { player: 8, ai: 8 },
+    starThresholds: { three: 0.60, two: 0.28 },
+  },
+  {
+    id: 5,
+    name: 'Two Fronts',
+    flavor: 'Two outposts. One army. Choose which fights are worth having.',
+    difficulty: 'medium',
+    seed: 1005,
+    outpostCount: 2,
+    mapPreset: 'open',
+    preSpawn: { player: 6, ai: 6 },
+    starThresholds: { three: 0.60, two: 0.25 },
+  },
+  {
+    id: 6,
+    name: 'The Crossing',
+    flavor: 'One gap in the river wall. Control the crossing, control the game.',
+    difficulty: 'hard',
+    seed: 1006,
+    outpostCount: 0,
+    mapPreset: 'river',
+    preSpawn: { player: 8, ai: 8 },
+    starThresholds: { three: 0.55, two: 0.25 },
+  },
+  {
+    id: 7,
+    name: 'Surge',
+    flavor: 'They outpace you. Wait for the right moment — then burst.',
+    difficulty: 'hard',
+    seed: 1007,
+    outpostCount: 1,
+    mapPreset: 'walls',
+    preSpawn: { player: 5, ai: 10 },
+    starThresholds: { three: 0.55, two: 0.22 },
+  },
+  {
+    id: 8,
+    name: 'Full Board',
+    flavor: 'Three prizes. The board is full. Everything is contested.',
+    difficulty: 'hard',
+    seed: 1008,
+    outpostCount: 3,
+    mapPreset: 'walls',
+    preSpawn: { player: 5, ai: 5 },
+    starThresholds: { three: 0.50, two: 0.20 },
+  },
+  {
+    id: 9,
+    name: 'Outnumbered',
+    flavor: 'They start with more. Work smarter, not harder.',
+    difficulty: 'hard',
+    seed: 1009,
+    outpostCount: 3,
+    mapPreset: 'pillars',
+    preSpawn: { player: 3, ai: 18 },
+    starThresholds: { three: 0.45, two: 0.18 },
+  },
+  {
+    id: 10,
+    name: 'Endgame',
+    flavor: 'No favors. No head start. Just you against the apex threat.',
+    difficulty: 'very-hard',
+    seed: 1010,
+    outpostCount: 3,
+    mapPreset: 'random',
+    preSpawn: { player: 0, ai: 0 },
+    starThresholds: { three: 0.40, two: 0.15 },
   },
 ]
 

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -78,7 +78,7 @@ export class GameInstance {
       const levelConfig = LEVELS.find(l => l.id === campaignLevel)
       if (levelConfig) {
         difficulty = levelConfig.difficulty
-        sim = createSim(levelConfig.seed, levelConfig.difficulty, 'open', levelConfig.outpostCount)
+        sim = createSim(levelConfig.seed, levelConfig.difficulty, levelConfig.mapPreset ?? 'open', levelConfig.outpostCount)
         preSpawnUnits(sim, 'player', levelConfig.preSpawn.player)
         preSpawnUnits(sim, 'ai', levelConfig.preSpawn.ai)
       } else {

--- a/src/app/speck-wars/page.tsx
+++ b/src/app/speck-wars/page.tsx
@@ -4,8 +4,8 @@ import { useEffect, useState } from 'react'
 import { useSpeckWarsStore } from './store'
 import { LEVELS, getLevelStars } from './campaign/levels'
 
-// Show 8 level slots total (1 real + 7 locked placeholders)
-const TOTAL_SLOTS = 8
+// Show 10 level slots total
+const TOTAL_SLOTS = 10
 
 export default function SpeckWarsCampaignPage() {
   const router = useRouter()


### PR DESCRIPTION
## Summary

- Adds `mapPreset` field to `LevelConfig` so levels can specify terrain (closes #2374)
- Implements campaign levels 2-10, closing all 9 open level issues
- Updates campaign page from 8 to 10 level slots

## Level progression

| # | Name | Difficulty | Terrain | Outposts | Notes |
|---|------|-----------|---------|----------|-------|
| 2 | Middle Ground | easy | open | 1 | Introduce outpost capture |
| 3 | The Chokepoint | medium | canyon | 0 | Defensive patience through narrow pass |
| 4 | Forward Command | medium | pillars | 1 | Rally points as force multipliers |
| 5 | Two Fronts | medium | open | 2 | Multi-outpost attention management |
| 6 | The Crossing | hard | river | 0 | River map, single chokepoint |
| 7 | Surge | hard | walls | 1 | Player deficit, teaches burst ability |
| 8 | Full Board | hard | walls | 3 | All outposts contested |
| 9 | Outnumbered | hard | pillars | 3 | 3 vs 18 pre-spawn deficit |
| 10 | Endgame | very-hard | random | 3 | No pre-spawn advantage, apex AI |

## Files changed

- `src/app/speck-wars/campaign/levels.ts` — `mapPreset` field + 9 new level configs
- `src/app/speck-wars/game-instance.ts` — use `levelConfig.mapPreset ?? 'open'`
- `src/app/speck-wars/page.tsx` — expand `TOTAL_SLOTS` from 8 to 10

## Test plan
- [ ] Campaign page shows all 10 slots, levels 1-10 all playable
- [ ] Each level loads with correct terrain preset (verify canyon, river, walls, pillars on levels 3/6/7-9/4)
- [ ] Level 10 uses random terrain (different each run)
- [ ] Stars persist correctly across all 10 levels
- [ ] Level 2 has 1 outpost, level 5 has 2, levels 8-10 have 3

Closes #2365 #2366 #2367 #2368 #2369 #2370 #2371 #2372 #2373 #2374

🤖 Generated with [Claude Code](https://claude.com/claude-code)