### PR TITLE
feat: campaign sequential level progression and Next Level button

### DIFF
--- a/src/app/speck-wars/campaign/levels.ts
+++ b/src/app/speck-wars/campaign/levels.ts
@@ -43,3 +43,9 @@ export function saveLevelStars(levelId: number, stars: number): void {
     if (stars > existing) localStorage.setItem(`speckwars-level-${levelId}-stars`, String(stars))
   } catch {}
 }
+
+// Level 1 is always unlocked. Level N requires at least 1 star on level N-1.
+export function isLevelUnlocked(levelId: number): boolean {
+  if (levelId <= 1) return true
+  return getLevelStars(levelId - 1) >= 1
+}

--- a/src/app/speck-wars/components/phase-router.tsx
+++ b/src/app/speck-wars/components/phase-router.tsx
@@ -688,6 +688,27 @@ export function PhaseRouter({ children }: { children: React.ReactNode }) {
           >
             Play Again
           </button>
+          {campaignLevel !== null && won && (() => {
+            const nextLevel = LEVELS.find(l => l.id === campaignLevel + 1)
+            if (!nextLevel) return null
+            // Winning the current level always unlocks the next one
+            return (
+              <button
+                onClick={() => {
+                  resetGame()
+                  setCampaignLevel(nextLevel.id)
+                  setPhase('playing')
+                }}
+                style={{
+                  padding: '12px 28px', fontSize: 16, cursor: 'pointer',
+                  background: accentColor, border: `2px solid ${accentColor}`,
+                  borderRadius: 8, color: '#000', fontWeight: 'bold', minHeight: 52,
+                }}
+              >
+                Level {nextLevel.id} →
+              </button>
+            )
+          })()}
           {campaignLevel !== null && (
             <button
               onClick={() => {

--- a/src/app/speck-wars/page.tsx
+++ b/src/app/speck-wars/page.tsx
@@ -2,18 +2,20 @@
 import { useRouter } from 'next/navigation'
 import { useEffect, useState } from 'react'
 import { useSpeckWarsStore } from './store'
-import { LEVELS, getLevelStars } from './campaign/levels'
+import { LEVELS, getLevelStars, isLevelUnlocked } from './campaign/levels'
 
-// Show 8 level slots total (1 real + 7 locked placeholders)
-const TOTAL_SLOTS = 8
+// Show as many slots as there are defined levels
+const TOTAL_SLOTS = LEVELS.length
 
 export default function SpeckWarsCampaignPage() {
   const router = useRouter()
   const { setCampaignLevel, resetGame } = useSpeckWarsStore()
-  const [stars, setStars] = useState<number[]>([])
+  const [stars, setStars] = useState<Record<number, number>>({})
 
   useEffect(() => {
-    setStars(LEVELS.map(l => getLevelStars(l.id)))
+    const s: Record<number, number> = {}
+    for (const l of LEVELS) s[l.id] = getLevelStars(l.id)
+    setStars(s)
   }, [])
 
   const handlePlay = (levelId: number) => {
@@ -33,8 +35,8 @@ export default function SpeckWarsCampaignPage() {
         {Array.from({ length: TOTAL_SLOTS }, (_, i) => {
           const levelNum = i + 1
           const level = LEVELS.find(l => l.id === levelNum)
-          const levelStars = level ? (stars[i] ?? 0) : 0
-          const unlocked = !!level
+          const levelStars = stars[levelNum] ?? 0
+          const unlocked = !!level && isLevelUnlocked(levelNum)
 
           return (
             <button
@@ -65,6 +67,12 @@ export default function SpeckWarsCampaignPage() {
                       <span key={s} style={{ color: s < levelStars ? '#ffd700' : 'rgba(255,255,255,0.15)' }}>&#9733;</span>
                     ))}
                   </div>
+                </>
+              ) : level ? (
+                <>
+                  <div style={{ fontSize: 20, opacity: 0.2 }}>&#128274;</div>
+                  <div style={{ fontSize: 12, fontWeight: 600, color: 'rgba(255,255,255,0.2)', textAlign: 'center', lineHeight: 1.3 }}>{level.name}</div>
+                  <div style={{ fontSize: 9, color: 'rgba(255,255,255,0.12)', letterSpacing: 0.5 }}>beat {levelNum - 1} first</div>
                 </>
               ) : (
                 <div style={{ fontSize: 20, opacity: 0.2 }}>&#128274;</div>


### PR DESCRIPTION
## Summary

- Sequential unlocking: level N is locked until the player earns ≥1 star on level N-1
- Locked levels show their name dimly with "beat N first" hint instead of a blank lock icon
- `TOTAL_SLOTS` now derives from `LEVELS.length` (no hardcoded magic number)
- Victory screen adds a **"Level N →"** primary CTA when in campaign mode and a next level exists
- Stars lookup refactored from array index to a per-level ID map (avoids off-by-one issues)

## How it works

- `isLevelUnlocked(levelId)` in `levels.ts`: level 1 always open; level N ≥ 2 requires `getLevelStars(N-1) >= 1`
- Campaign page imports and calls this to gate the Play button and style locked slots
- Victory screen checks for a `LEVELS.find(l => l.id === campaignLevel + 1)` and shows the CTA when found and player won

## Expected metrics impact

**Session length**: Players flow directly into the next level rather than navigating back.
**Daily return rate**: Visible locked levels with names create forward momentum to return.

## Note

This PR is independent of #2375 (which adds levels 2-10). When #2375 merges, the progression logic automatically governs all 10 levels — this PR adds the infrastructure today.

## Test plan
- [ ] Level 1 playable on fresh install
- [ ] After beating level 1, level 2 unlocks on campaign page (once #2375 is merged)
- [ ] Locked levels show name dimly + "beat N first" hint
- [ ] Victory screen shows "Level N →" button after a win
- [ ] Defeat screen does NOT show "Level N →" button

🤖 Generated with [Claude Code](https://claude.com/claude-code)