### PR TITLE
fix: campaign UI polish — hide outpost counter on no-outpost levels, title-only cards

### DIFF
--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -825,8 +825,8 @@ export function HUD() {
         </div>
       )}
 
-      {/* Outpost ownership indicator dots */}
-      {hud && (() => {
+      {/* Outpost ownership indicator dots — hidden when no outposts exist on map */}
+      {hud && hud.minimap.buildings.some(b => b.typeId === 'outpost') && (() => {
         const OUTPOST_IDS = ['outpost-top', 'outpost-left', 'outpost-right'] as const
         const attacked = new Set(hud.attackedBuildingIds ?? [])
         const captureInfo = hud.captureInfo ?? {}

--- a/src/app/speck-wars/page.tsx
+++ b/src/app/speck-wars/page.tsx
@@ -59,7 +59,6 @@ export default function SpeckWarsCampaignPage() {
               {unlocked && level ? (
                 <>
                   <div style={{ fontSize: 13, fontWeight: 700, color: '#fff', textAlign: 'center', lineHeight: 1.3 }}>{level.name}</div>
-                  <div style={{ fontSize: 11, color: 'rgba(255,255,255,0.4)', textAlign: 'center', lineHeight: 1.4 }}>{level.flavor}</div>
                   <div style={{ fontSize: 14, letterSpacing: 2, marginTop: 4 }}>
                     {Array.from({ length: 3 }, (_, s) => (
                       <span key={s} style={{ color: s < levelStars ? '#ffd700' : 'rgba(255,255,255,0.15)' }}>&#9733;</span>


### PR DESCRIPTION
## Summary

Two small campaign UI fixes:

### #2376 — Hide outpost counter when level has no outposts
`hud.tsx`: Added `hud.minimap.buildings.some(b => b.typeId === 'outpost')` guard before rendering the outpost ownership dots. On Level 1 (First Contact) and any other level with `outpostCount: 0`, the counter was showing a meaningless "0/3 OUTPOSTS" row. Now it's hidden entirely when no outposts are in play.

### #2378 — Title-only campaign level cards
`page.tsx`: Removed the `level.flavor` tagline from level cards. Cards now show level number, name, and star rating — no flavor text. The `flavor` field stays in `LevelConfig` for future use (pre-game cutscene, etc.).

## Files changed
- `src/app/speck-wars/components/hud.tsx` — guard on outpost dots render
- `src/app/speck-wars/page.tsx` — remove flavor div from card

## Test plan
- [ ] Level 1 (no outposts): HUD shows no outpost counter during gameplay
- [ ] Level 2+ (with outposts): HUD still shows outpost dots correctly
- [ ] Campaign page: level cards show name + stars only, no flavor text
- [ ] No regressions in skirmish mode (outposts always present there)

Closes #2376 #2378

🤖 Generated with [Claude Code](https://claude.com/claude-code)