### PR TITLE
feat(speck-wars): right-click tap to move/rally

### DIFF
--- a/src/app/speck-wars/input/input-handler.ts
+++ b/src/app/speck-wars/input/input-handler.ts
@@ -239,6 +239,14 @@ export class InputHandler {
 
     if (e.button === 2) {
       this.isRightDragging = false
+      // Right-click tap (not a pan-drag): issue move/rally command
+      if (dist < 10) {
+        const rect = this.canvas.getBoundingClientRect()
+        const sx = e.clientX - rect.left
+        const sy = e.clientY - rect.top
+        const world = screenToWorld(sx, sy, this.camera)
+        this.onRally?.(world.x, world.y)
+      }
     }
 
     this.isDragging = false


### PR DESCRIPTION
## Summary
- Right-clicking on the canvas now issues a move/rally command when units or a building are selected
- Right-drag (camera pan) is unaffected — the command only fires when drag distance is < 10px
- Leverages the existing `onRally` → `commandAt()` routing, so building selection and unit movement both work correctly

## Test plan
- [ ] Select units via left-click drag-select, then right-click an empty area — units should move there
- [ ] Right-drag to pan — should pan camera, no move command
- [ ] Right-click with nothing selected — should do nothing (commandAt handles this)
- [ ] Right-click on a building — should select it (same as left-click)

Closes #2377

🤖 Generated with [Claude Code](https://claude.com/claude-code)