### PR TITLE
feat(speck-wars): show final base HP% on campaign victory screen

### DIFF
--- a/src/app/speck-wars/components/phase-router.tsx
+++ b/src/app/speck-wars/components/phase-router.tsx
@@ -501,6 +501,12 @@ export function PhaseRouter({ children }: { children: React.ReactNode }) {
                 <span style={{ color: 'rgba(255,255,255,0.4)' }}>{effPct}%</span>
               </>
             )}
+            {won && levelConfig && (
+              <>
+                <span style={{ opacity: 0.3 }}>·</span>
+                <span style={{ color: 'rgba(255,255,255,0.4)' }}>🏠 {Math.round(baseHpFrac * 100)}% hp</span>
+              </>
+            )}
           </div>
         </div>
 


### PR DESCRIPTION
Adds base HP% to the stats row on the victory screen when in campaign mode. Closes #2400.