### PR TITLE
fix(speck-wars): Play Again in campaign mode restores campaign level

### DIFF
--- a/src/app/speck-wars/components/phase-router.tsx
+++ b/src/app/speck-wars/components/phase-router.tsx
@@ -532,7 +532,7 @@ export function PhaseRouter({ children }: { children: React.ReactNode }) {
           {/* Primary row */}
           <div style={{ display: 'flex', gap: 10, flexWrap: 'wrap', justifyContent: 'center' }}>
             <button
-              onClick={resetGame}
+              onClick={() => { const lvl = campaignLevel; resetGame(); if (lvl !== null) setCampaignLevel(lvl) }}
               style={{
                 padding: '12px 28px', fontSize: 16, cursor: 'pointer',
                 background: accentColor, border: 'none', borderRadius: 8,


### PR DESCRIPTION
## Bug
'Play Again' on the campaign victory/defeat screen called resetGame(), which sets campaignLevel: null, silently dropping the player into skirmish mode instead of retrying the same campaign level.

## Fix
Capture campaignLevel before calling resetGame(), then restore it so the player replays the same campaign level.

Closes #2406.