### PR TITLE
feat(speck-wars): track and display best completion time per campaign level

### DIFF
--- a/src/app/speck-wars/campaign/levels.ts
+++ b/src/app/speck-wars/campaign/levels.ts
@@ -145,6 +145,25 @@ export function saveLevelStars(levelId: number, stars: number): void {
   } catch {}
 }
 
+export function getLevelBestTime(levelId: number): number | null {
+  try {
+    const raw = localStorage.getItem(`speckwars-level-${levelId}-time`)
+    const n = raw ? parseInt(raw, 10) : NaN
+    return isNaN(n) ? null : n
+  } catch { return null }
+}
+
+export function saveLevelBestTime(levelId: number, ms: number): boolean {
+  try {
+    const prev = getLevelBestTime(levelId)
+    if (prev === null || ms < prev) {
+      localStorage.setItem(`speckwars-level-${levelId}-time`, String(ms))
+      return true
+    }
+    return false
+  } catch { return false }
+}
+
 // Level 1 is always unlocked. Level N requires at least 1 star on level N-1.
 export function isLevelUnlocked(levelId: number): boolean {
   if (levelId <= 1) return true

--- a/src/app/speck-wars/components/phase-router.tsx
+++ b/src/app/speck-wars/components/phase-router.tsx
@@ -7,7 +7,7 @@ import { getDailyInfo } from '../lib/daily-modifier'
 import type { Difficulty } from '../store'
 import { useAuth } from '@/hooks/useAuth'
 import Link from 'next/link'
-import { LEVELS, saveLevelStars } from '../campaign/levels'
+import { LEVELS, saveLevelStars, getLevelBestTime, saveLevelBestTime } from '../campaign/levels'
 
 export function PhaseRouter({ children }: { children: React.ReactNode }) {
   const { phase, winnerId, setPhase, difficulty, setDifficulty, elapsedMs, resetGame, kills, losses, isNewBest, hud, fogEnabled, setFogEnabled, mapPreset, setMapPreset, campaignLevel, setCampaignLevel } = useSpeckWarsStore()
@@ -81,7 +81,8 @@ export function PhaseRouter({ children }: { children: React.ReactNode }) {
         : baseHpFrac >= levelCfg.starThresholds.two ? 2 : 1)
       : 0
     saveLevelStars(campaignLevel, starsEarned)
-  }, [phase, campaignLevel, winnerId, hud])
+    if (won) saveLevelBestTime(campaignLevel, elapsedMs)
+  }, [phase, campaignLevel, winnerId, hud, elapsedMs])
 
   const difficulties: Array<{ key: 'easy' | 'medium' | 'hard' | 'very-hard'; label: string; color: string; desc: string }> = [
     { key: 'easy', label: 'Easy', color: '#44ff88', desc: 'slow AI · player spawn bonus' },
@@ -522,6 +523,18 @@ export function PhaseRouter({ children }: { children: React.ReactNode }) {
               </>
             )}
           </div>
+          {levelConfig && (() => {
+            const bestMs = getLevelBestTime(campaignLevel!)
+            if (!bestMs) return null
+            const bSec = Math.floor(bestMs / 1000)
+            const bMM = String(Math.floor(bSec / 60)).padStart(2, '0')
+            const bSS = String(bSec % 60).padStart(2, '0')
+            return (
+              <div style={{ fontSize: 11, color: 'rgba(255,255,255,0.3)', letterSpacing: 1 }}>
+                level best: {bMM}:{bSS}
+              </div>
+            )
+          })()}
         </div>
 
         {/* Tier 3: Primary actions */}


### PR DESCRIPTION
## Summary

- Adds `getLevelBestTime` and `saveLevelBestTime` helpers to `levels.ts`, storing per-level best time in localStorage under `speckwars-level-{id}-time`
- On campaign victory, saves the elapsed time via `saveLevelBestTime` in the existing stars useEffect
- Victory screen shows a `level best: MM:SS` line in the Tier 2 stats section when in campaign mode

## Test plan

- [ ] Play and win a campaign level — verify `speckwars-level-{id}-time` appears in localStorage with the correct ms value
- [ ] Play the same level faster — verify the value updates
- [ ] Play the same level slower — verify the value does not update
- [ ] Defeat on a campaign level — verify no time is saved
- [ ] Open the victory screen in campaign mode — verify "level best: MM:SS" appears below the kills/losses row
- [ ] Open the victory screen in non-campaign (freeplay) mode — verify no level best line appears

Closes #2408

🤖 Generated with [Claude Code](https://claude.com/claude-code)