### PR TITLE
feat(speck-wars): show campaign level intro only on first play

### DIFF
--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -105,10 +105,14 @@ export function HUD() {
     if (!hud?.selectedBuilding) setBuildingPanelExpanded(false)
   }, [hud?.selectedBuilding])
 
-  // Show level intro when a campaign level starts playing
+  // Show level intro when a campaign level starts playing (only on first play of each level)
   useEffect(() => {
     if (phase === 'playing' && campaignLevel !== null) {
+      const seenKey = `speckwars-level-${campaignLevel}-intro-seen`
+      const alreadySeen = typeof localStorage !== 'undefined' && localStorage.getItem(seenKey)
+      if (alreadySeen) return
       setShowLevelIntro(true)
+      try { localStorage.setItem(seenKey, '1') } catch {}
       const t = setTimeout(() => setShowLevelIntro(false), 4000)
       return () => clearTimeout(t)
     } else {


### PR DESCRIPTION
Tracks which campaign level intros have been seen via localStorage ('speckwars-level-{id}-intro-seen'). On first play of a level, shows the 4-second intro normally. On replays, skips it immediately so returning players aren't blocked by a re-seen overlay.

The TAP TO SKIP affordance remains for first-play dismissal.

Closes #2412.