### PR TITLE
feat(speck-wars): star threshold tick marks on HP bar in campaign mode

### DIFF
--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -270,6 +270,16 @@ export function HUD() {
               background: hpFrac > 0.5 ? '#4af7c4' : hpFrac > 0.25 ? '#ffcc44' : '#ff4f7b',
               transition: 'width 0.3s ease, background 0.5s ease',
             }} />
+            {campaignLevel !== null && (() => {
+              const lvl = LEVELS.find(l => l.id === campaignLevel)
+              if (!lvl) return null
+              return (
+                <>
+                  <div style={{ position: 'absolute', top: 0, bottom: 0, left: `${lvl.starThresholds.three * 100}%`, width: 1, background: 'rgba(255,215,0,0.85)', zIndex: 2 }} />
+                  <div style={{ position: 'absolute', top: 0, bottom: 0, left: `${lvl.starThresholds.two * 100}%`, width: 1, background: 'rgba(255,255,255,0.35)', zIndex: 2 }} />
+                </>
+              )
+            })()}
           </div>
           {/* 1px gap in center */}
           <div style={{ width: 2, background: 'rgba(0,0,0,0.8)' }} />


### PR DESCRIPTION
Adds subtle vertical tick marks on the player HP bar (top edge) during campaign levels:
- Gold tick at the 3-star HP threshold position
- Faint white tick at the 2-star HP threshold position

Gives players real-time feedback on which star tier their base HP is tracking toward. The marks are absolute-positioned inside the player bar container, independent of the fill bar.

Closes #2418.