### PR TITLE
fix(speck-wars): show correct difficulty on campaign victory screen

### DIFF
--- a/src/app/speck-wars/components/phase-router.tsx
+++ b/src/app/speck-wars/components/phase-router.tsx
@@ -400,8 +400,6 @@ export function PhaseRouter({ children }: { children: React.ReactNode }) {
     const timeStr = `${mm}:${ss}`
 
     const difficultyColors: Record<string, string> = { easy: '#44ff88', medium: '#ffcc44', hard: '#ff4f7b', 'very-hard': '#cc00ff' }
-    const diffLabel = difficulty === 'very-hard' ? 'Brutal' : difficulty.charAt(0).toUpperCase() + difficulty.slice(1)
-    const diffColor = difficultyColors[difficulty]
     const playerBaseHp = hud?.players?.player?.buildingHp?.['building-player-base'] ?? 0
     const baseHpFrac = playerBaseHp / 100
     const stars = won
@@ -410,6 +408,9 @@ export function PhaseRouter({ children }: { children: React.ReactNode }) {
 
     // Campaign mode: level config and star tracking
     const levelConfig = campaignLevel ? LEVELS.find(l => l.id === campaignLevel) ?? null : null
+    const effectiveDifficulty = levelConfig?.difficulty ?? difficulty
+    const diffLabel = effectiveDifficulty === 'very-hard' ? 'Brutal' : effectiveDifficulty.charAt(0).toUpperCase() + effectiveDifficulty.slice(1)
+    const diffColor = difficultyColors[effectiveDifficulty]
     const campaignStarsEarned = won && levelConfig
       ? (baseHpFrac >= levelConfig.starThresholds.three ? 3
         : baseHpFrac >= levelConfig.starThresholds.two ? 2 : 1)


### PR DESCRIPTION
## Bug
The victory screen showed the store's `difficulty` (skirmish preference) instead of the campaign level's actual difficulty. A player with skirmish set to 'Medium' who plays campaign level 7 ('Hard') would see 'Medium' on the victory screen.

## Fix
Compute `effectiveDifficulty = levelConfig?.difficulty ?? difficulty` and use it for `diffLabel` and `diffColor`. Falls back to the store value in skirmish mode (where levelConfig is null).

Closes #2420.