### PR TITLE
fix(speck-wars): show campaign map preset name on victory screen

### DIFF
--- a/src/app/speck-wars/components/phase-router.tsx
+++ b/src/app/speck-wars/components/phase-router.tsx
@@ -417,7 +417,9 @@ export function PhaseRouter({ children }: { children: React.ReactNode }) {
     const displayStars = levelConfig ? campaignStarsEarned : stars
     const nextCampaignLevel = campaignLevel !== null ? LEVELS.find(l => l.id === campaignLevel + 1) ?? null : null
 
-    const { layoutName } = getDailyInfo(difficulty)
+    const { layoutName: skirmishLayoutName } = getDailyInfo(difficulty)
+    const campaignPresetNames: Record<string, string> = { open: 'Open Field', canyon: 'Canyon', pillars: 'Pillars', river: 'River', walls: 'Walls', random: 'Random' }
+    const layoutName = levelConfig?.mapPreset ? (campaignPresetNames[levelConfig.mapPreset] ?? levelConfig.mapPreset) : skirmishLayoutName
     const effPct = kills + losses > 0 ? Math.round((kills / (kills + losses)) * 100) : 0
     const starStr = won ? '★'.repeat(stars) + '☆'.repeat(3 - stars) : '✗✗✗'
     const today = new Date().toLocaleDateString('en-US', { month: 'short', day: 'numeric' })


### PR DESCRIPTION
The victory screen showed the daily skirmish layout name ('Triangle', 'Corridor', 'Wings') even during campaign games, where the map is fixed by levelConfig.mapPreset. Now shows 'Canyon', 'River', 'Open Field', etc. for campaign levels. Falls back to daily layout name in skirmish mode.

Closes the issue created in this PR.