### PR TITLE
fix(speck-wars): use level-specific star thresholds in campaign share text

### DIFF
--- a/src/app/speck-wars/components/phase-router.tsx
+++ b/src/app/speck-wars/components/phase-router.tsx
@@ -419,7 +419,7 @@ export function PhaseRouter({ children }: { children: React.ReactNode }) {
 
     const { layoutName } = getDailyInfo(difficulty)
     const effPct = kills + losses > 0 ? Math.round((kills / (kills + losses)) * 100) : 0
-    const starStr = won ? '★'.repeat(stars) + '☆'.repeat(3 - stars) : '✗✗✗'
+    const starStr = won ? '★'.repeat(displayStars) + '☆'.repeat(3 - displayStars) : '✗✗✗'
     const today = new Date().toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
     const statsLine = `⚔ ${kills} kills · ${losses} lost · ${effPct}% eff`
     const shareText = won


### PR DESCRIPTION
The victory/defeat share text used hardcoded star thresholds (0.75 for 3 stars, 0.5 for 2 stars) via the general `stars` variable. Campaign levels have level-specific thresholds via `displayStars`. The UI correctly showed `displayStars` but the shareable text showed the wrong count.

Fix: use `displayStars` in `starStr`.