### PR TITLE
feat(speck-wars): include campaign level name in share text

### DIFF
--- a/src/app/speck-wars/components/phase-router.tsx
+++ b/src/app/speck-wars/components/phase-router.tsx
@@ -422,9 +422,10 @@ export function PhaseRouter({ children }: { children: React.ReactNode }) {
     const starStr = won ? '★'.repeat(stars) + '☆'.repeat(3 - stars) : '✗✗✗'
     const today = new Date().toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
     const statsLine = `⚔ ${kills} kills · ${losses} lost · ${effPct}% eff`
+    const levelLabel = levelConfig ? `Level ${String(campaignLevel).padStart(2, '0')} · ${levelConfig.name}` : `[${layoutName}]`
     const shareText = won
-      ? `${starStr} Speck Wars ${today} [${layoutName}]\nVICTORY in ${timeStr} (${diffLabel})\n${statsLine}\nCan you do better? `
-      : `${starStr} Speck Wars ${today} [${layoutName}]\nDEFEATED in ${timeStr} (${diffLabel})\n${statsLine}\nThink you can win? `
+      ? `${starStr} Speck Wars ${today} ${levelLabel}\nVICTORY in ${timeStr} (${diffLabel})\n${statsLine}\nCan you do better? `
+      : `${starStr} Speck Wars ${today} ${levelLabel}\nDEFEATED in ${timeStr} (${diffLabel})\n${statsLine}\nThink you can win? `
 
     const handleShare = async () => {
       const url = typeof window !== 'undefined' ? window.location.href : ''


### PR DESCRIPTION
When sharing a campaign result, now includes 'Level 07 · Surge' instead of '[Canyon]', making shares level-specific and enabling direct comparison between players on the same level. Falls back to '[layoutName]' format in skirmish mode.