### PR TITLE
fix(speck-wars): show campaign level difficulty in HUD badge

### DIFF
--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -3,7 +3,7 @@ import { useState, useEffect, useRef } from 'react'
 import { useSpeckWarsStore } from '../store'
 import { PLAYER_COLOR, AI_COLOR } from '../domain/constants'
 import { getBestTime, getWinStreak } from '../lib/personal-best'
-import { LEVELS } from '../campaign/levels'
+import { LEVELS, getLevelBestTime } from '../campaign/levels'
 import { onLongPressStart, onLongPressCancel, onTapRipple } from '../input/touch-feedback'
 
 function colorHex(n: number) {
@@ -618,7 +618,7 @@ export function HUD() {
         <span style={{ fontSize: 15, letterSpacing: 2, opacity: 0.9, display: 'flex', alignItems: 'center', gap: 6 }}>
           {formatTime(elapsedMs)}
           {(() => {
-            const pb = getBestTime(difficulty)
+            const pb = campaignLevel !== null ? getLevelBestTime(campaignLevel) : getBestTime(difficulty)
             if (!pb) return null
             const ahead = pb - elapsedMs
             return (

--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -298,14 +298,16 @@ export function HUD() {
       {/* Difficulty badge — top right */}
       {(() => {
         const diffColors: Record<string, string> = { easy: '#44ff88', medium: '#ffcc44', hard: '#ff4f7b', 'very-hard': '#cc00ff' }
-        const color = diffColors[difficulty] ?? '#ffffff'
+        const lvl = campaignLevel !== null ? LEVELS.find(l => l.id === campaignLevel) : null
+        const effectiveDiff = lvl?.difficulty ?? difficulty
+        const color = diffColors[effectiveDiff] ?? '#ffffff'
         return (
           <div style={{ position: 'absolute', top: 12, right: 16, fontSize: 10, letterSpacing: 1, display: 'flex', flexDirection: 'column', alignItems: 'flex-end', gap: 3 }}>
             <span style={{ color, opacity: 0.5, border: `1px solid ${color}`, borderRadius: 3, padding: '2px 6px' }}>
-              {difficulty.toUpperCase()}
+              {effectiveDiff.toUpperCase()}
             </span>
             <span style={{ color: 'rgba(255,255,255,0.18)', fontSize: isTouchDevice ? 10 : 8, letterSpacing: 0.5 }}>
-              DAILY MAP · {new Date().toLocaleDateString('en-US', { month: 'short', day: 'numeric' }).toUpperCase()}
+              {lvl ? 'CAMPAIGN' : `DAILY MAP · ${new Date().toLocaleDateString('en-US', { month: 'short', day: 'numeric' }).toUpperCase()}`}
             </span>
           </div>
         )


### PR DESCRIPTION
## Summary
Two HUD fixes for campaign mode:

1. **Difficulty badge shows wrong info**: was showing skirmish preference (e.g. `MEDIUM`) instead of the campaign level's actual difficulty (e.g. `HARD`), and `DAILY MAP · Date` instead of `CAMPAIGN`
2. **PB timer compares against wrong baseline**: the live `+/−` timer was comparing against the skirmish difficulty best time instead of the campaign level's best time

## Test plan
- [ ] Start a campaign level (e.g. Level 7 "Surge" which is `hard`) — badge should show `HARD` and `CAMPAIGN`
- [ ] Play skirmish — badge should show the selected difficulty and `DAILY MAP · <date>`
- [ ] Beat a campaign level, then replay it — the `+/−` timer should compare against *that level's* best time, not a skirmish time
- [ ] Verify PB timer is absent on first play of a level (no stored best time yet)

🤖 Generated with [Claude Code](https://claude.com/claude-code)