### PR TITLE
feat(speck-wars): CAMPAIGN COMPLETE badge on final level victory

### DIFF
--- a/src/app/speck-wars/components/phase-router.tsx
+++ b/src/app/speck-wars/components/phase-router.tsx
@@ -487,6 +487,11 @@ export function PhaseRouter({ children }: { children: React.ReactNode }) {
               }
             </div>
           )}
+          {won && levelConfig && !nextCampaignLevel && (
+            <div style={{ fontSize: 10, letterSpacing: 3, color: 'rgba(255,215,0,0.65)', marginTop: 2 }}>
+              ✦ CAMPAIGN COMPLETE ✦
+            </div>
+          )}
         </div>
 
         {/* Achievement chips */}


### PR DESCRIPTION
## Summary
- When the player wins the last campaign level (Level 10), the victory screen now shows `✦ CAMPAIGN COMPLETE ✦` beneath the stars
- Previously there was no special moment acknowledging the campaign was finished — the screen looked identical to any other level win

## Test plan
- [ ] Win Level 10 — `✦ CAMPAIGN COMPLETE ✦` should appear below the star row
- [ ] Win any earlier level (e.g. Level 7) — badge should NOT appear
- [ ] Verify skirmish mode is unaffected (no badge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)