### PR TITLE
fix(speck-wars): Enter/Space on end screen replays campaign level

### DIFF
--- a/src/app/speck-wars/components/phase-router.tsx
+++ b/src/app/speck-wars/components/phase-router.tsx
@@ -53,13 +53,21 @@ export function PhaseRouter({ children }: { children: React.ReactNode }) {
     const onKey = (e: KeyboardEvent) => {
       if (e.code === 'Enter' || e.code === 'Space') {
         e.preventDefault()
+        // Capture campaign level before resetGame() clears it
+        const lvl = useSpeckWarsStore.getState().campaignLevel
         resetGame()
-        setPhase('playing')
+        if (lvl !== null) {
+          // Campaign mode: restore level and let auto-start effect handle it
+          setCampaignLevel(lvl)
+        } else {
+          // Skirmish mode: start directly
+          setPhase('playing')
+        }
       }
     }
     window.addEventListener('keydown', onKey)
     return () => window.removeEventListener('keydown', onKey)
-  }, [phase, resetGame, setPhase])
+  }, [phase, resetGame, setPhase, setCampaignLevel])
 
   useEffect(() => {
     if (phase === 'victory') {


### PR DESCRIPTION
## Summary
- **Bug**: pressing Enter or Space on the victory/defeat screen while in campaign mode started a new **skirmish** game instead of replaying the current level
- **Root cause**: the keyboard handler called `resetGame()` (which clears `campaignLevel`) followed by `setPhase('playing')`, bypassing the campaign context
- **Fix**: capture `campaignLevel` from the store before `resetGame()`, then restore it and let the existing auto-start effect handle the transition

## Test plan
- [ ] Start a campaign level → win or lose → press Enter or Space → game should replay the **same** campaign level (not a skirmish)
- [ ] In skirmish mode, press Enter or Space on end screen → should restart skirmish as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)