### PR TITLE
fix(speck-wars): don't pollute skirmish stats with campaign game results

### DIFF
--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -442,18 +442,26 @@ export class GameInstance {
           const elapsedAtEnd = this.elapsedMs
           setTimeout(() => {
             const s = useSpeckWarsStore.getState()
+            const isCampaign = s.campaignLevel !== null
             if (won) {
-              const isNew = recordBestTime(s.difficulty, elapsedAtEnd)
               incrementWinStreak()
-              recordGameResult(s.difficulty, true, elapsedAtEnd, s.kills)
               updateLifetimeStats(s.kills, getWinStreak())
-              markWonToday(s.difficulty)
-              s.setIsNewBest(isNew)
+              if (!isCampaign) {
+                // Skirmish only: record against difficulty PB and mark day as won
+                const isNew = recordBestTime(s.difficulty, elapsedAtEnd)
+                recordGameResult(s.difficulty, true, elapsedAtEnd, s.kills)
+                markWonToday(s.difficulty)
+                s.setIsNewBest(isNew)
+              } else {
+                s.setIsNewBest(false)
+              }
               s.setPhase('victory')
             } else {
               resetWinStreak()
-              recordGameResult(s.difficulty, false, elapsedAtEnd, s.kills)
               updateLifetimeStats(s.kills, getWinStreak())
+              if (!isCampaign) {
+                recordGameResult(s.difficulty, false, elapsedAtEnd, s.kills)
+              }
               s.setIsNewBest(false)
               s.setPhase('defeat')
             }


### PR DESCRIPTION
## Summary
- Campaign wins were calling `recordBestTime`, `recordGameResult`, and `markWonToday` with `s.difficulty` — the player's **skirmish preference**, not the campaign level's difficulty
- This meant: playing Level 7 (Hard) while your skirmish is set to Medium would overwrite your Medium-difficulty personal best, mark today's Medium game as "won", and appear in Medium game history — all incorrect
- Campaign games should only track: win streak and lifetime kill/game counts
- Per-level best times are tracked separately via `saveLevelBestTime` in phase-router

## What changes
- `recordBestTime`, `recordGameResult`, `markWonToday` are now **skipped** for campaign games
- `isNewBest` is always set to `false` in campaign mode (per-level chip comes from `isNewLevelBest` in PR #2428)
- `incrementWinStreak` / `resetWinStreak` / `updateLifetimeStats` still run for campaign games

## Test plan
- [ ] Play a campaign level → win → check skirmish personal best for your difficulty setting — it should **not** be updated
- [ ] Win a campaign level on a fresh day → "Today's Daily" / skirmish "won today" flag should remain unset
- [ ] Win streak should still increment on campaign win, reset on loss
- [ ] Skirmish games should behave exactly as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)