### PR TITLE
fix(speck-wars): hide countdown while campaign level intro is showing

### DIFF
--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -993,8 +993,8 @@ export function HUD() {
         )
       })()}
 
-      {/* Cinematic countdown overlay */}
-      {countdown !== null && (
+      {/* Cinematic countdown overlay — hidden while level intro is showing */}
+      {countdown !== null && !showLevelIntro && (
         <div style={{
           position: 'absolute', inset: 0,
           display: 'flex', alignItems: 'center', justifyContent: 'center',


### PR DESCRIPTION
## Summary
- The 3-2-1 cinematic countdown and the campaign level intro overlay (flavor text) both appear at game start, causing the large countdown numbers to overlap the level name and flavor text
- Fix: suppress the countdown while `showLevelIntro` is true
- Since the intro lasts 4s and the countdown only 3s, the game is already underway when the intro disappears (or the player taps to skip)
- If the player taps to skip the intro early, the remaining countdown becomes visible as expected

## Test plan
- [ ] Start a campaign level for the first time — level name and flavor text should display cleanly without the countdown overlapping
- [ ] Tap to skip the intro early (before 3s) — countdown should resume showing
- [ ] Replay the same level (intro already seen) — countdown should show normally (intro won't appear)
- [ ] Skirmish mode unaffected (no intro, countdown shows as normal)

🤖 Generated with [Claude Code](https://claude.com/claude-code)