### PR TITLE
fix(speck-wars): load campaign stars synchronously to avoid flash

### DIFF
--- a/src/app/speck-wars/page.tsx
+++ b/src/app/speck-wars/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 import { useRouter } from 'next/navigation'
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 import { useSpeckWarsStore } from './store'
 import { LEVELS, getLevelStars, getLevelBestTime, isLevelUnlocked } from './campaign/levels'
 
@@ -12,15 +12,14 @@ const DIFF_LABELS: Record<string, string> = { easy: 'Easy', medium: 'Medium', ha
 export default function SpeckWarsCampaignPage() {
   const router = useRouter()
   const { setCampaignLevel, resetGame } = useSpeckWarsStore()
-  const [stars, setStars] = useState<Record<number, number>>({})
-  const [copied, setCopied] = useState(false)
-  const [hoveredLevel, setHoveredLevel] = useState<number | null>(null)
-
-  useEffect(() => {
+  const [stars, setStars] = useState<Record<number, number>>(() => {
+    if (typeof localStorage === 'undefined') return {}
     const s: Record<number, number> = {}
     for (const l of LEVELS) s[l.id] = getLevelStars(l.id)
-    setStars(s)
-  }, [])
+    return s
+  })
+  const [copied, setCopied] = useState(false)
+  const [hoveredLevel, setHoveredLevel] = useState<number | null>(null)
 
   const handlePlay = (levelId: number) => {
     resetGame()


### PR DESCRIPTION
## Summary
- Campaign level select briefly showed ☆☆☆ on all levels for one render frame while `useEffect` asynchronously loaded star counts from localStorage
- Replaced with a lazy `useState` initializer that reads localStorage synchronously on the first client render, so stars are correct immediately
- Removed now-unused `useEffect` import

## Test plan
- [ ] Open the campaign page — stars should show immediately without a flash to ☆☆☆ first
- [ ] Verify this works on first load and on return from a level
- [ ] Locked/unlocked state should be unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)