### PR TITLE
fix(speck-wars): add ← Cave link to campaign select page

### DIFF
--- a/src/app/speck-wars/page.tsx
+++ b/src/app/speck-wars/page.tsx
@@ -197,9 +197,14 @@ export default function SpeckWarsCampaignPage() {
         })}
       </div>
 
-      <a href="/speck-wars/skirmish" style={{ fontSize: 11, color: 'rgba(255,255,255,0.2)', letterSpacing: 1, textDecoration: 'none', marginTop: 16 }}>
-        Sandbox &rarr;
-      </a>
+      <div style={{ display: 'flex', gap: 20, alignItems: 'center', marginTop: 16 }}>
+        <a href="/" style={{ fontSize: 11, color: 'rgba(255,255,255,0.15)', letterSpacing: 1, textDecoration: 'none' }}>
+          &larr; Cave
+        </a>
+        <a href="/speck-wars/skirmish" style={{ fontSize: 11, color: 'rgba(255,255,255,0.2)', letterSpacing: 1, textDecoration: 'none' }}>
+          Sandbox &rarr;
+        </a>
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
The campaign select page (`/speck-wars`) had no way to navigate back to the cave home — violating CLAUDE.md **Principle 6: The shared pact** ("Persistent exit back to the cave").

Added a `← Cave` link alongside the existing `Sandbox →` link at the bottom of the page.

## Why this matters
Every game surface must provide a persistent exit back to the cave. The play/skirmish pages get this automatically via `CosmicShell`, but the campaign select is a standalone page that had no home link at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)