### PR TITLE
fix(speck-wars): remove debug console.logs and add speed button aria-label

### DIFF
--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -664,6 +664,7 @@ export function HUD() {
         </button>
         <button
           onClick={cycleSpeed}
+          aria-label={`Game speed ${speed}× — click to cycle`}
           style={{
             pointerEvents: 'auto',
             padding: '8px 14px',

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -125,7 +125,6 @@ export class GameInstance {
   }
 
   async start() {
-    console.log('GameInstance started')
     document.addEventListener('visibilitychange', this.onVisibilityChange)
     this.onResize = () => { clampCamera(this.camera, this.canvas.clientWidth, this.canvas.clientHeight) }
     window.addEventListener('resize', this.onResize)
@@ -803,7 +802,6 @@ export class GameInstance {
     this.renderer.destroy()
     this.inputHandler?.destroy()
     useSpeckWarsStore.getState().setGameActions(null)
-    console.log('GameInstance destroyed')
   }
 
   rally(x: number, y: number) {


### PR DESCRIPTION
## Summary
Two small code quality fixes:

1. **Remove production console.logs** — `console.log('GameInstance started')` and `console.log('GameInstance destroyed')` were leftover debug statements polluting the browser console in production
2. **Add aria-label to speed cycle button** — the `1×/2×/4×` speed button in the HUD had no accessible label (CLAUDE.md Principle 8: accessible on every device)

## Test plan
- [ ] Open browser DevTools console during a game — no "GameInstance started/destroyed" logs
- [ ] Screen reader / accessibility audit — speed button should announce "Game speed 1× — click to cycle"

🤖 Generated with [Claude Code](https://claude.com/claude-code)