### PR TITLE
fix(speck-wars): keyboard dismiss for campaign level intro

### DIFF
--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -120,6 +120,14 @@ export function HUD() {
     }
   }, [phase, campaignLevel])
 
+  // Allow keyboard dismiss of level intro (desktop players expect any key to skip)
+  useEffect(() => {
+    if (!showLevelIntro) return
+    const onKey = () => setShowLevelIntro(false)
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [showLevelIntro])
+
   const BASE_MAX_HP = 100
   const playerBaseHp = hud?.players.player?.buildingHp['building-player-base']
   const hpFrac = playerBaseHp !== undefined ? playerBaseHp / BASE_MAX_HP : 1
@@ -990,7 +998,7 @@ export function HUD() {
               {lvl.flavor}
             </div>
             <div style={{ fontSize: 9, letterSpacing: 2, color: 'rgba(255,255,255,0.2)', marginTop: 8 }}>
-              TAP TO SKIP
+              {isTouchDevice ? 'TAP TO SKIP' : 'CLICK OR PRESS ANY KEY TO SKIP'}
             </div>
           </div>
         )


### PR DESCRIPTION
## Summary
- Desktop players couldn't skip the campaign level intro overlay with a keypress — only click worked
- The hint text also always said "TAP TO SKIP" regardless of device type

## Changes
- Add a `keydown` listener while `showLevelIntro` is true; any key dismisses the overlay
- Show `"CLICK OR PRESS ANY KEY TO SKIP"` on desktop, `"TAP TO SKIP"` on touch

## Test plan
- [ ] Start a campaign level for the first time (clear `speckwars-level-N-intro-seen` from localStorage)
- [ ] On desktop: verify pressing any key dismisses the intro
- [ ] On desktop: verify the skip hint reads "CLICK OR PRESS ANY KEY TO SKIP"
- [ ] On touch: verify tapping still works and hint reads "TAP TO SKIP"
- [ ] Verify the 4s auto-dismiss still fires if neither click nor keypress occurs

🤖 Generated with [Claude Code](https://claude.com/claude-code)