### PR TITLE
feat(speck-wars): add page metadata (title + description)

### DIFF
--- a/src/app/speck-wars/layout.tsx
+++ b/src/app/speck-wars/layout.tsx
@@ -1,8 +1,13 @@
-import type { Viewport } from 'next'
+import type { Metadata, Viewport } from 'next'
 import type React from 'react'
 
 export const viewport: Viewport = {
   viewportFit: 'cover',
+}
+
+export const metadata: Metadata = {
+  title: 'Speck Wars | CometCave',
+  description: 'A real-time strategy micro-game. Command your specks, capture outposts, and destroy the enemy base. Play the 10-level campaign or go free-play in skirmish mode.',
 }
 
 export default function SpeckWarsLayout({ children }: { children: React.ReactNode }) {


### PR DESCRIPTION
## Summary
- All Speck Wars routes (`/speck-wars`, `/speck-wars/play`, `/speck-wars/skirmish`) were falling back to the generic CometCave root metadata
- Added `metadata` export to `SpeckWarsLayout` so browser tabs, bookmarks, and search previews show "Speck Wars | CometCave"

## Changes
- `src/app/speck-wars/layout.tsx`: export `metadata` with title + description alongside existing `viewport` export

## Test plan
- [ ] Visit `/speck-wars` — browser tab should read "Speck Wars | CometCave"
- [ ] Visit `/speck-wars/play` — same title
- [ ] Visit `/speck-wars/skirmish` — same title
- [ ] Root `/` still reads "CometCave - AI Galaxy Arcade" (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)