### PR TITLE
fix(speck-wars): role=application + aria-hidden on game canvas

### DIFF
--- a/src/app/speck-wars/SpeckWarsGame.tsx
+++ b/src/app/speck-wars/SpeckWarsGame.tsx
@@ -118,6 +118,7 @@ function GameCanvas() {
     // canvas. React StrictMode mounts, tears down and remounts this effect in
     // development, so that path is hit on every dev page load.
     const canvas = document.createElement('canvas')
+    canvas.setAttribute('aria-hidden', 'true')  // purely visual — HUD handles screen-reader interaction
     canvas.style.display = 'block'
     canvas.style.width = '100%'
     canvas.style.height = '100%'
@@ -170,7 +171,7 @@ export function SpeckWarsGame() {
   }, [])
 
   return (
-    <div style={{ position: 'relative', width: '100%', height: '100%' }}>
+    <div role="application" aria-label="Speck Wars" style={{ position: 'relative', width: '100%', height: '100%' }}>
       <PhaseRouter>
         {(phase === 'playing' || phase === 'paused') && <GameCanvas />}
       </PhaseRouter>


### PR DESCRIPTION
## Summary
- Adds `role="application"` to the Speck Wars root wrapper so screen readers switch to application mode, allowing game keyboard shortcuts (D/N/B/Q/Space etc.) to pass through instead of being intercepted for virtual cursor navigation
- Marks the raw WebGL canvas `aria-hidden="true"` — the canvas is purely visual; all accessible labels and live regions are already on the HUD overlay

Per UX Principle #8 (accessible on every device).

## Test plan
- [ ] Screen reader in application mode allows Space/D/N/B/Q keypresses to reach the game
- [ ] No duplicate announcements from the raw canvas element

🤖 Generated with [Claude Code](https://claude.com/claude-code)