### PR TITLE
fix(speck-wars): enrich campaign level card aria-label

### DIFF
--- a/src/app/speck-wars/page.tsx
+++ b/src/app/speck-wars/page.tsx
@@ -143,7 +143,9 @@ export default function SpeckWarsCampaignPage() {
               onMouseEnter={() => setHoveredLevel(levelNum)}
               onMouseLeave={() => setHoveredLevel(null)}
               title={level && unlocked ? `${level.name} — ${level.flavor}` : undefined}
-              aria-label={level ? (unlocked ? `Play level ${levelNum}: ${level.name}` : `Level ${levelNum} locked — beat level ${levelNum - 1} first`) : `Level ${levelNum}`}
+              aria-label={level ? (unlocked
+                ? `Play level ${levelNum}: ${level.name} — ${DIFF_LABELS[level.difficulty]}${level.outpostCount > 0 ? ` — ${level.outpostCount} outpost${level.outpostCount > 1 ? 's' : ''}` : ''}${levelStars > 0 ? ` — ${levelStars} of 3 stars` : ''}`
+                : `Level ${levelNum} locked — beat level ${levelNum - 1} first`) : `Level ${levelNum}`}
               style={{
                 width: 120, height: 140,
                 display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', gap: 6,


### PR DESCRIPTION
## Summary
Level cards on the campaign select page previously only announced "Play level N: Name" to screen readers. Updated to include difficulty, outpost count, and current star rating so the full level context is available without seeing the visual card.

Example: "Play level 5: Two Fronts — Medium — 2 outposts — 1 of 3 stars"

## Test plan
- [ ] Screen reader announces difficulty, outpost count, and star rating when focusing a level card
- [ ] Locked cards still announce lock state and required level

🤖 Generated with [Claude Code](https://claude.com/claude-code)