### PR TITLE
fix(speck-wars): accessible star display on victory/defeat screen

### DIFF
--- a/src/app/speck-wars/components/phase-router.tsx
+++ b/src/app/speck-wars/components/phase-router.tsx
@@ -501,7 +501,11 @@ export function PhaseRouter({ children }: { children: React.ReactNode }) {
           {!won && levelConfig && (
             <div style={{ fontSize: 10, letterSpacing: 1, color: 'rgba(255,255,255,0.25)', textAlign: 'center', lineHeight: 1.8 }}>
               <div>next time: win at...</div>
-              <div>★ any hp &nbsp;·&nbsp; ★★ {Math.round(levelConfig.starThresholds.two * 100)}%+ &nbsp;·&nbsp; ★★★ {Math.round(levelConfig.starThresholds.three * 100)}%+</div>
+              <div>
+                <span aria-hidden="true">★</span><span className="sr-only">1 star</span>{' any hp \u00a0·\u00a0 '}
+                <span aria-hidden="true">★★</span><span className="sr-only">2 stars</span>{` ${Math.round(levelConfig.starThresholds.two * 100)}%+ \u00a0·\u00a0 `}
+                <span aria-hidden="true">★★★</span><span className="sr-only">3 stars</span>{` ${Math.round(levelConfig.starThresholds.three * 100)}%+`}
+              </div>
             </div>
           )}
           {won && (

--- a/src/app/speck-wars/components/phase-router.tsx
+++ b/src/app/speck-wars/components/phase-router.tsx
@@ -505,15 +505,18 @@ export function PhaseRouter({ children }: { children: React.ReactNode }) {
             </div>
           )}
           {won && (
-            <div style={{ fontSize: 44, letterSpacing: 6, color: '#ffd700', textShadow: displayStars === 3 ? '0 0 28px #ffd700' : 'none', marginTop: 4 }}>
-              {'★'.repeat(displayStars)}{'☆'.repeat(3 - displayStars)}
+            <div
+              aria-label={`${displayStars} of 3 stars`}
+              style={{ fontSize: 44, letterSpacing: 6, color: '#ffd700', textShadow: displayStars === 3 ? '0 0 28px #ffd700' : 'none', marginTop: 4 }}
+            >
+              <span aria-hidden="true">{'★'.repeat(displayStars)}{'☆'.repeat(3 - displayStars)}</span>
             </div>
           )}
           {won && levelConfig && displayStars < 3 && (
             <div style={{ fontSize: 10, letterSpacing: 1, color: 'rgba(255,255,255,0.3)', marginTop: 2, textAlign: 'center' }}>
               {displayStars === 2
-                ? `for ★★★: survive at ${Math.round(levelConfig.starThresholds.three * 100)}%+ hp`
-                : `for ★★: ${Math.round(levelConfig.starThresholds.two * 100)}%+ hp · for ★★★: ${Math.round(levelConfig.starThresholds.three * 100)}%+ hp`
+                ? <><span aria-hidden="true">★★★</span><span className="sr-only">3 stars</span>{`: survive at ${Math.round(levelConfig.starThresholds.three * 100)}%+ hp`}</>
+                : <><span aria-hidden="true">★★</span><span className="sr-only">2 stars</span>{`: ${Math.round(levelConfig.starThresholds.two * 100)}%+ hp · `}<span aria-hidden="true">★★★</span><span className="sr-only">3 stars</span>{`: ${Math.round(levelConfig.starThresholds.three * 100)}%+ hp`}</>
               }
             </div>
           )}

--- a/src/app/speck-wars/components/phase-router.tsx
+++ b/src/app/speck-wars/components/phase-router.tsx
@@ -541,8 +541,11 @@ export function PhaseRouter({ children }: { children: React.ReactNode }) {
               </span>
             )}
             {starImprovedFrom !== null && levelConfig && (
-              <span style={{ fontSize: 10, letterSpacing: 2, color: '#ffd700', border: '1px solid rgba(255,215,0,0.5)', padding: '3px 10px', borderRadius: 20 }}>
-                {'★'.repeat(starImprovedFrom)}{'☆'.repeat(3 - starImprovedFrom)} → {'★'.repeat(displayStars)}
+              <span
+                aria-label={`Star rating improved: ${starImprovedFrom} to ${displayStars} stars`}
+                style={{ fontSize: 10, letterSpacing: 2, color: '#ffd700', border: '1px solid rgba(255,215,0,0.5)', padding: '3px 10px', borderRadius: 20 }}
+              >
+                <span aria-hidden="true">{'★'.repeat(starImprovedFrom)}{'☆'.repeat(3 - starImprovedFrom)} → {'★'.repeat(displayStars)}</span>
               </span>
             )}
           </div>


### PR DESCRIPTION
## Summary
The raw ★/☆ characters on the end-screen were read ambiguously by screen readers (e.g., "black star black star empty star"). 

- Wraps the star display `div` with `aria-label="N of 3 stars"` and marks inner characters `aria-hidden="true"`
- Replaces inline star symbols in the threshold hint text with `aria-hidden` decorative spans + `sr-only` text equivalents

## Test plan
- [ ] Screen reader announces "2 of 3 stars" on a 2-star win
- [ ] Threshold hint reads "2 stars: 40%+ hp · 3 stars: 65%+ hp" without raw star characters

🤖 Generated with [Claude Code](https://claude.com/claude-code)