### PR TITLE
fix(speck-wars): campaign grid alignment + outpost label legibility

### DIFF
--- a/src/app/speck-wars/page.tsx
+++ b/src/app/speck-wars/page.tsx
@@ -125,7 +125,7 @@ export default function SpeckWarsCampaignPage() {
         </div>
       )}
 
-      <div style={{ display: 'flex', flexWrap: 'wrap', gap: 12, justifyContent: 'center', maxWidth: 600 }}>
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(120px, 1fr))', gap: 12, width: '100%', maxWidth: 660 }}>
         {Array.from({ length: TOTAL_SLOTS }, (_, i) => {
           const levelNum = i + 1
           const level = LEVELS.find(l => l.id === levelNum)
@@ -147,7 +147,7 @@ export default function SpeckWarsCampaignPage() {
                 ? `Play level ${levelNum}: ${level.name} — ${DIFF_LABELS[level.difficulty]}${level.outpostCount > 0 ? ` — ${level.outpostCount} outpost${level.outpostCount > 1 ? 's' : ''}` : ''}${levelStars > 0 ? ` — ${levelStars} of 3 stars` : ''}`
                 : `Level ${levelNum} locked — beat level ${levelNum - 1} first`) : `Level ${levelNum}`}
               style={{
-                width: 120, height: 140,
+                width: '100%', height: 140,
                 display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', gap: 6,
                 background: isNext ? 'rgba(0,255,194,0.12)' : isHovered && unlocked ? 'rgba(0,255,194,0.09)' : unlocked ? 'rgba(0,255,194,0.06)' : 'rgba(255,255,255,0.02)',
                 border: `1px solid ${isNext ? 'rgba(0,255,194,0.8)' : isHovered && unlocked ? 'rgba(0,255,194,0.55)' : unlocked ? 'rgba(0,255,194,0.3)' : 'rgba(255,255,255,0.06)'}`,
@@ -163,7 +163,7 @@ export default function SpeckWarsCampaignPage() {
               {unlocked && level ? (
                 <>
                   <div style={{ fontSize: 13, fontWeight: 700, color: '#fff', textAlign: 'center', lineHeight: 1.3 }}>{level.name}</div>
-                  {level.outpostCount > 0 && <div style={{ fontSize: 9, color: 'rgba(255,255,255,0.3)', letterSpacing: 0.5 }}>⬡ {level.outpostCount}</div>}
+                  {level.outpostCount > 0 && <div style={{ fontSize: 9, color: 'rgba(255,255,255,0.3)', letterSpacing: 0.5 }}>{level.outpostCount} outpost{level.outpostCount !== 1 ? 's' : ''}</div>}
                   <div style={{
                     fontSize: 8, letterSpacing: 1, textTransform: 'uppercase',
                     color: DIFF_COLORS[level.difficulty],


### PR DESCRIPTION
Closes #2437

## Changes

**Grid alignment** (`page.tsx:128`): Switched from `display: flex; flex-wrap: wrap; justify-content: center` to CSS Grid with `repeat(auto-fill, minmax(120px, 1fr))`. Eliminates the orphaned-last-row centering artifact. `max-width` widened from 600 to 660 to allow exactly 5 columns (2 even rows of 5) at desktop. Cards use `width: 100%` to fill their grid column.

**Outpost label** (`page.tsx:166`): Replaced `⬡ 1` (9px hexagon + bare number) with plain-English `1 outpost` / `N outposts`.

## Acceptance criteria
- [x] Grid fills rows evenly — no orphaned center-floated rows
- [x] Outpost count is readable without prior knowledge
- [x] Card heights remain consistent (140px fixed on all cards)

🤖 Generated with [Claude Code](https://claude.com/claude-code)