### PR TITLE
fix(speck-wars): star threshold boundary, campaign nav label, give-up aria

### DIFF
--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -1214,6 +1214,7 @@ export function HUD() {
           })()}
           <button
             onClick={(e) => { e.stopPropagation(); surrender() }}
+            aria-label="Give up — end the game and go to defeat screen"
             style={{
               pointerEvents: 'auto',
               padding: '8px 24px',

--- a/src/app/speck-wars/components/phase-router.tsx
+++ b/src/app/speck-wars/components/phase-router.tsx
@@ -433,7 +433,7 @@ export function PhaseRouter({ children }: { children: React.ReactNode }) {
     const playerBaseHp = hud?.players?.player?.buildingHp?.['building-player-base'] ?? 0
     const baseHpFrac = playerBaseHp / 100
     const stars = won
-      ? baseHpFrac > 0.75 ? 3 : baseHpFrac > 0.5 ? 2 : 1
+      ? baseHpFrac >= 0.75 ? 3 : baseHpFrac >= 0.5 ? 2 : 1
       : 0
 
     // Campaign mode: level config and star tracking
@@ -646,7 +646,7 @@ export function PhaseRouter({ children }: { children: React.ReactNode }) {
                   borderRadius: 6, color: 'rgba(255,255,255,0.55)', minHeight: 44,
                 }}
               >
-                Campaign
+                ← Campaign
               </button>
             )}
             <button


### PR DESCRIPTION
Three small organic polish fixes found during code review.

## Changes

**Star threshold bug** (`phase-router.tsx:436`): Skirmish mode used strict `>` comparisons (`> 0.75`, `> 0.5`) while campaign mode correctly used `>=`. This meant a player finishing with exactly 75% HP got 2 stars instead of 3. Now both modes use `>=` at the thresholds.

**Campaign nav button** (`phase-router.tsx:649`): Post-game "Campaign" button renamed to "← Campaign" to make it clear this navigates back to the campaign select screen, not some in-place action.

**Give Up aria-label** (`hud.tsx:1215`): Added `aria-label="Give up — end the game and go to defeat screen"` so screen readers convey the destructive intent of the surrender button in the pause overlay.

## Files changed
- `src/app/speck-wars/components/phase-router.tsx` — 2 lines
- `src/app/speck-wars/components/hud.tsx` — 1 line

🤖 Generated with [Claude Code](https://claude.com/claude-code)