### PR TITLE
fix(speck-wars): reset countdown to null in resetGame

### DIFF
--- a/src/app/speck-wars/store.ts
+++ b/src/app/speck-wars/store.ts
@@ -148,6 +148,7 @@ export const useSpeckWarsStore = create<SpeckWarsStore>()((set, get) => ({
     winnerId: null,
     victoryType: null,
     hud: null,
+    countdown: null,
     elapsedMs: 0,
     speed: 1 as 1 | 2 | 4,
     notification: null,


### PR DESCRIPTION
## Problem

`resetGame()` in `store.ts` clears all game state except `countdown`. The cinematic 3-2-1 countdown is normally cleared by a `setTimeout` at `game-instance.ts:352`, but if a player navigates away (back to menu, next level, etc.) before that 3-second window completes, the stale countdown value remains in Zustand state. On the next game's menu render, the HUD countdown overlay (`hud.tsx:1029`) would briefly display the leftover number.

## Fix

Added `countdown: null` to the `resetGame()` state slice (`store.ts:148`). One-line change — safe, no side effects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)