### PR TITLE
fix(speck-wars): guard setTimeout callbacks against post-destroy firing

### DIFF
--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -346,9 +346,10 @@ export class GameInstance {
     // Freeze the sim for the countdown duration
     this.cinematicMs = 3000  // 3 seconds total
     useSpeckWarsStore.getState().setCountdown(3)
-    setTimeout(() => useSpeckWarsStore.getState().setCountdown(2), 1000)
-    setTimeout(() => useSpeckWarsStore.getState().setCountdown(1), 2000)
+    setTimeout(() => { if (!this.destroyed) useSpeckWarsStore.getState().setCountdown(2) }, 1000)
+    setTimeout(() => { if (!this.destroyed) useSpeckWarsStore.getState().setCountdown(1) }, 2000)
     setTimeout(() => {
+      if (this.destroyed) return
       useSpeckWarsStore.getState().setCountdown(null)
       this.cinematicMs = 0
       this.notify('⚔ FIGHT!', '#4af7c4', 800)
@@ -373,7 +374,7 @@ export class GameInstance {
         { delay: 32000, message: '💡 Press A then click to attack-move — specks engage enemies en route!', color: '#ff8c44' },
       ]
       for (const { delay, message, color } of hints) {
-        setTimeout(() => this.notify(message, color, 3000), delay)
+        setTimeout(() => { if (!this.destroyed) this.notify(message, color, 3000) }, delay)
       }
     }
   }
@@ -440,6 +441,7 @@ export class GameInstance {
           })
           const elapsedAtEnd = this.elapsedMs
           setTimeout(() => {
+            if (this.destroyed) return
             const s = useSpeckWarsStore.getState()
             const isCampaign = s.campaignLevel !== null
             if (won) {
@@ -944,7 +946,7 @@ export class GameInstance {
     const gen = ++this.notifGen
     useSpeckWarsStore.getState().setNotification({ message, color })
     setTimeout(() => {
-      if (this.notifGen === gen) useSpeckWarsStore.getState().setNotification(null)
+      if (!this.destroyed && this.notifGen === gen) useSpeckWarsStore.getState().setNotification(null)
     }, durationMs)
   }
 


### PR DESCRIPTION
## Problem

`GameInstance.destroy()` cancels the RAF and removes DOM event listeners but does **not** cancel pending `setTimeout` callbacks. Several callbacks can outlive the instance:

| Timer | Delay | Effect if stale |
|---|---|---|
| Countdown 2→1→null | 1s / 2s / 3s | Mutates `setCountdown` on destroyed instance |
| Tutorial hints | 1.2s – 38s | Shows hints in a new game |
| Game-end phase transition | 1.4s | Calls `s.setPhase('victory'/'defeat')` — **forces UI into end-screen on a freshly reset game** |
| Notify auto-clear | variable | Nulls a notification from the new game |

The game-end timer is the most dangerous: if a user clicks "← Campaign" or "Play Again" within 1.4 seconds of game over, the old timer fires and sends the new game to victory/defeat screen.

## Fix

Added `if (this.destroyed) return` / `if (!this.destroyed)` guards to all four affected callback sites. Uses the existing `private destroyed` flag — no new infrastructure.

## Files changed
- `src/app/speck-wars/game-instance.ts` — 6 lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)