### PR TITLE
fix: footer always cut off — three root causes

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -56,7 +56,7 @@ export default function RootLayout({
           />
         </head>
         <body className={`${plusJakartaSans.variable} ${beVietnamPro.variable} ${lexend.variable} ${beVietnamPro.className}`}>
-          <div id="site-wrapper" className="min-h-dvh flex flex-col bg-surface-dim text-on-surface relative overflow-x-hidden">
+          <div id="site-wrapper" className="min-h-dvh flex flex-col bg-surface-dim text-on-surface relative overflow-x-clip">
             <AmbientOrbs palette={['primary', 'secondary', 'tertiary']} intensity="medium" />
             <LayoutShell nav={<TopNavBar />} footer={<Footer />}>
               {children}

--- a/src/app/speck-wars/page.tsx
+++ b/src/app/speck-wars/page.tsx
@@ -50,7 +50,7 @@ export default function SpeckWarsCampaignPage() {
   }
 
   return (
-    <div style={{ minHeight: '100dvh', background: '#080810', display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', gap: 32, padding: 24 }}>
+    <div style={{ flex: 1, background: '#080810', display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', gap: 32, padding: 24 }}>
       <div style={{ textAlign: 'center' }}>
         <h1 style={{ fontSize: 48, fontWeight: 800, color: '#fff', margin: 0, letterSpacing: 2 }}>SPECK WARS</h1>
         <div style={{ fontSize: 14, letterSpacing: 4, color: 'rgba(255,255,255,0.4)', marginTop: 6 }}>CAMPAIGN</div>

--- a/src/components/layout-shell.tsx
+++ b/src/components/layout-shell.tsx
@@ -4,7 +4,11 @@ import { usePathname } from 'next/navigation'
 import { ROUTE_CONSTANTS } from '@/app/route-constants'
 import type { ReactNode } from 'react'
 
-const IMMERSIVE_ROUTES = [ROUTE_CONSTANTS.COMET_CARDS]
+const IMMERSIVE_ROUTES = [
+  ROUTE_CONSTANTS.COMET_CARDS,
+  `${ROUTE_CONSTANTS.SPECK_WARS}/play`,
+  `${ROUTE_CONSTANTS.SPECK_WARS}/skirmish`,
+]
 
 export function LayoutShell({
   children,


### PR DESCRIPTION
Three separate things were conspiring to cut off the app footer:

**1. `overflow-x-hidden` → implicit `overflow-y: auto` (CSS spec gotcha)**
Per spec: when `overflow-x` is `hidden` and `overflow-y` would be `visible`, the browser computes `overflow-y` as `auto`. This made `#site-wrapper` a scroll container, hiding the footer inside an internal scroll. Fixed by switching to `overflow-x-clip`, which clips without creating a BFC or affecting overflow-y.

**2. Game pages included nav+footer despite using a full-viewport shell**
`/speck-wars/play` and `/speck-wars/skirmish` render inside `CosmicShell` (`height: 100dvh`), but the app shell was still wrapping them with `TopNavBar` + `Footer`. Result: nav + game (100dvh) + footer = page taller than viewport. Added both routes to `IMMERSIVE_ROUTES` so nav/footer are skipped during gameplay.

**3. Campaign map page had its own `minHeight: 100dvh`**
`/speck-wars/page.tsx` set `minHeight: 100dvh` on its root container, fighting the shell's flex layout and pushing the footer off-screen. Changed to `flex: 1`.

Closes #2379

🤖 Generated with [Claude Code](https://claude.com/claude-code)