### PR TITLE
feat(speck-wars): command groups + mutual-exclusion selection model

### DIFF
--- a/src/app/speck-wars/components/minimap.tsx
+++ b/src/app/speck-wars/components/minimap.tsx
@@ -94,18 +94,26 @@ export function Minimap({ gameRef }: MinimapProps) {
         }
       }
 
-      // Draw rally point
-      const rp = sim.rallyPoints['player']
-      if (rp) {
-        const rx = rp.x * SCALE_X
-        const ry = rp.y * SCALE_Y
-        ctx.strokeStyle = playerColor
+      // Draw command group rally markers (numbered crosshairs)
+      if (sim.commandGroupRallies.size > 0) {
         ctx.lineWidth = 1.5
-        ctx.globalAlpha = 0.7
-        ctx.beginPath()
-        ctx.moveTo(rx - 4, ry); ctx.lineTo(rx + 4, ry)
-        ctx.moveTo(rx, ry - 4); ctx.lineTo(rx, ry + 4)
-        ctx.stroke()
+        for (const [groupId, rally] of sim.commandGroupRallies) {
+          const rx = rally.x * SCALE_X
+          const ry = rally.y * SCALE_Y
+          ctx.strokeStyle = playerColor
+          ctx.globalAlpha = 0.8
+          ctx.beginPath()
+          ctx.moveTo(rx - 4, ry); ctx.lineTo(rx + 4, ry)
+          ctx.moveTo(rx, ry - 4); ctx.lineTo(rx, ry + 4)
+          ctx.stroke()
+          // Number badge
+          ctx.globalAlpha = 0.9
+          ctx.fillStyle = playerColor
+          ctx.font = 'bold 7px monospace'
+          ctx.textAlign = 'left'
+          ctx.textBaseline = 'top'
+          ctx.fillText(String(groupId), rx + 4, ry - 8)
+        }
         ctx.globalAlpha = 1
       }
 

--- a/src/app/speck-wars/domain/simulation/create-sim.ts
+++ b/src/app/speck-wars/domain/simulation/create-sim.ts
@@ -148,6 +148,8 @@ export function createSim(seed: number = Date.now(), difficulty: Difficulty = 'm
     inputQueue: [],
     events: [],
     rallyPoints: { player: null, ai: null, 'player-selected': null },
+    nextCommandGroupId: 0,
+    commandGroupRallies: new Map(),
     selectedSpeckIds: new Set<string>(),
     selectedBuildingId: null,
     spatialGrid: new SpatialGrid(),

--- a/src/app/speck-wars/domain/simulation/tick.ts
+++ b/src/app/speck-wars/domain/simulation/tick.ts
@@ -38,6 +38,7 @@ export function tick(sim: SimulationState, dt: number): SimulationState {
 
   // 6. Remove dead specks (compact arrays)
   removeDeadSpecks(sim)
+  pruneCommandGroups(sim)
 
   // 7. Update outpost capture progress
   updateCapture(sim, dt)
@@ -99,26 +100,28 @@ function consumeInputs(sim: SimulationState) {
   for (const event of sim.inputQueue) {
     if (event.type === 'RALLY') {
       if (event.ownerId === 'player') {
-        // With a selection this moves that group; with none it is an army-wide order from the
-        // Defend / Advance / Rush / Guard verbs. A bare map click never gets here — game-instance
-        // drops it when nothing is selected, so specks are never moved by accident.
-        const useSelection = sim.selectedSpeckIds.size > 0
-        sim.rallyPoints['player-selected'] = useSelection ? { x: event.x, y: event.y } : null
+        // Require an explicit selection — bare map click has already been converted to CLEAR_SELECT
+        // by the input layer, and Defend/Advance/Rush/Guard only issue RALLY when something is selected.
+        if (sim.selectedSpeckIds.size === 0) continue
+        sim.nextCommandGroupId++
+        const groupId = sim.nextCommandGroupId
+        sim.commandGroupRallies.set(groupId, { x: event.x, y: event.y })
+        sim.rallyPoints['player-selected'] = { x: event.x, y: event.y }
         for (let i = 0; i < sim.speckCount; i++) {
           const meta = sim.speckMeta[i]
           if (!meta || !sim.speckIds[i] || meta.ownerId !== 'player') continue
-          if (useSelection && !sim.selectedSpeckIds.has(meta.id)) continue
+          if (!sim.selectedSpeckIds.has(meta.id)) continue
           meta.assignedRallyX = event.x
           meta.assignedRallyY = event.y
-          meta.homeBuildingId = undefined  // a direct order outranks the spawn building's rally
-          meta.holdPosition = false  // clear hold when a new rally is issued
-          meta.attackMoveMode = false  // normal move cancels attack-move
+          meta.commandGroupId = groupId
+          meta.homeBuildingId = undefined
+          meta.holdPosition = false
+          meta.attackMoveMode = false
         }
       } else {
         // AI (and any non-player owner): keep global rally logic
         sim.rallyPoints[event.ownerId] = { x: event.x, y: event.y }
       }
-      // Player with no selection: do nothing — player rally is per-building only (SET_BUILDING_RALLY)
     }
     if (event.type === 'ATTACK_MOVE') {
       const hasSelection = event.ownerId === 'player' && sim.selectedSpeckIds.size > 0
@@ -180,6 +183,8 @@ function consumeInputs(sim: SimulationState) {
       }
       // Selected specks initially use the same rally as unselected
       sim.rallyPoints['player-selected'] = sim.rallyPoints['player']
+      // Mutual exclusion: selecting specks always clears any building selection
+      sim.selectedBuildingId = null
     }
     if (event.type === 'CLEAR_SELECT') {
       sim.selectedSpeckIds.clear()
@@ -212,6 +217,7 @@ function consumeInputs(sim: SimulationState) {
       }
     }
     if (event.type === 'STOP') {
+      if (event.ownerId === 'player' && sim.selectedSpeckIds.size === 0) continue
       // Stop selected specks: clear their assigned rally and targeting, enter idle
       for (let i = 0; i < sim.speckCount; i++) {
         const meta = sim.speckMeta[i]
@@ -231,6 +237,7 @@ function consumeInputs(sim: SimulationState) {
       }
     }
     if (event.type === 'HOLD') {
+      if (event.ownerId === 'player' && sim.selectedSpeckIds.size === 0) continue
       // Hold position: selected specks stop and don't attack
       for (let i = 0; i < sim.speckCount; i++) {
         const meta = sim.speckMeta[i]
@@ -394,4 +401,16 @@ function emitHudUpdate(sim: SimulationState) {
   }
 
   sim.events.push({ type: 'HUD_UPDATE', data: { players: data, attackedBuildingIds, captureInfo, surgeDuration: sim.surgeDuration, surgeCooldown: sim.surgeCooldown, selectedSpeckCount: sim.selectedSpeckIds.size, selectedComposition, spawnRates, minimap, waveCountdown: sim.waveCountdown, waveInProgress: sim.waveInProgress, waveNumber: sim.waveNumber, baseUnderThreat, enemyAdvanceDetected, selectedBuilding } })
+}
+
+function pruneCommandGroups(sim: SimulationState) {
+  if (sim.commandGroupRallies.size === 0) return
+  const liveGroups = new Set<number>()
+  for (let i = 0; i < sim.speckCount; i++) {
+    const meta = sim.speckMeta[i]
+    if (meta?.commandGroupId !== undefined) liveGroups.add(meta.commandGroupId)
+  }
+  for (const gid of sim.commandGroupRallies.keys()) {
+    if (!liveGroups.has(gid)) sim.commandGroupRallies.delete(gid)
+  }
 }

--- a/src/app/speck-wars/domain/types.ts
+++ b/src/app/speck-wars/domain/types.ts
@@ -10,6 +10,7 @@ export interface SpeckMeta {
   kills: number            // enemies killed; 3+ = veteran (gold ring, +20% damage)
   assignedRallyX?: number  // individual sub-group rally — persists after deselection
   assignedRallyY?: number
+  commandGroupId?: number     // which move order this speck belongs to; set each time it receives a RALLY command
   homeBuildingId?: string  // building that produced this speck. While set the speck is under
                            // "standing orders": it musters at that building's rally point (or at
                            // the building itself) and never picks its own objective. Cleared by
@@ -72,6 +73,8 @@ export interface SimulationState {
   inputQueue: InputEvent[]
   events: SimEvent[]
   rallyPoints: Record<string, { x: number; y: number } | null>
+  nextCommandGroupId: number          // monotonic counter; incremented each time a new RALLY is issued to a selection
+  commandGroupRallies: Map<number, { x: number; y: number }>  // groupId → world-space destination
   selectedSpeckIds: Set<string>  // IDs of player specks currently in selection
   selectedBuildingId: string | null   // player building currently selected
   spatialGrid: SpatialGrid

--- a/src/app/speck-wars/input/input-handler.ts
+++ b/src/app/speck-wars/input/input-handler.ts
@@ -230,8 +230,8 @@ export class InputHandler {
           this.pendingModifier = 'none'
           if (this.canvas) this.canvas.style.cursor = 'default'
         } else {
-          // Default: move/rally command (selects building if clicked on one, otherwise sets rally)
-          this.onRally?.(world.x, world.y)
+          // Left-click on canvas = deselect (right-click is the command/move action)
+          this.onClearSelect?.()
         }
       }
       return

--- a/src/app/speck-wars/rendering/renderer.ts
+++ b/src/app/speck-wars/rendering/renderer.ts
@@ -1,4 +1,4 @@
-import { Application, Container, Graphics } from 'pixi.js'
+import { Application, Container, Graphics, Text } from 'pixi.js'
 import { SpeckLayer } from './layers/speck-layer'
 import { BuildingLayer } from './layers/building-layer'
 import { GridLayer } from './layers/grid-layer'
@@ -39,6 +39,7 @@ export class Renderer {
   private fogLayer!: FogLayer
   private fogFrameCounter = 0
   private rallyGfx!: Graphics
+  private commandGroupLabels: Map<number, Text> = new Map()
   private selectionGfx!: Graphics
   private vignetteGfx!: Graphics
   private ready = false        // layers built — everything below is safe to touch
@@ -177,6 +178,41 @@ export class Renderer {
       }
     }
 
+    // Command group rally markers — one numbered crosshair per active move order
+    const groupPulse = 0.5 + 0.5 * Math.sin(Date.now() / 400)
+    const groupAlpha = 0.4 + 0.5 * groupPulse
+    // Remove labels for groups that no longer exist
+    for (const [gid, label] of this.commandGroupLabels) {
+      if (!sim.commandGroupRallies.has(gid)) {
+        this.world.removeChild(label)
+        this.commandGroupLabels.delete(gid)
+      }
+    }
+
+    // Add/update markers for current groups
+    for (const [groupId, rally] of sim.commandGroupRallies) {
+      const { x: gx, y: gy } = rally
+      const s = 8
+      this.rallyGfx.lineStyle(1.5, PLAYER_COLOR, groupAlpha)
+      this.rallyGfx.moveTo(gx - s, gy); this.rallyGfx.lineTo(gx + s, gy)
+      this.rallyGfx.moveTo(gx, gy - s); this.rallyGfx.lineTo(gx, gy + s)
+      this.rallyGfx.lineStyle(1, PLAYER_COLOR, groupAlpha * 0.5)
+      this.rallyGfx.drawCircle(gx, gy, 11)
+      this.rallyGfx.lineStyle(0)
+
+      // Number label
+      let label = this.commandGroupLabels.get(groupId)
+      if (!label) {
+        label = new Text(String(groupId), { fontSize: 9, fill: PLAYER_COLOR, fontWeight: '700' })
+        this.world.addChild(label)
+        this.commandGroupLabels.set(groupId, label)
+      } else {
+        label.text = String(groupId)
+      }
+      label.position.set(gx + 12, gy - 16)
+      label.alpha = groupAlpha
+    }
+
     // Draw drag-selection box (screen space)
     this.selectionGfx.clear()
     if (dragRect) {
@@ -242,6 +278,10 @@ export class Renderer {
     this.rallyGfx.destroy()
     this.selectionGfx.destroy()
     this.vignetteGfx.destroy()
+    for (const label of this.commandGroupLabels.values()) {
+      this.world.removeChild(label)
+    }
+    this.commandGroupLabels.clear()
     this.app.destroy()
   }
 }


### PR DESCRIPTION
## Summary
- **Selection mutual exclusion**: selecting specks (box-drag) now always clears building selection; selecting a building already cleared speck selection — so units and buildings can never both be selected simultaneously
- **Left-click = deselect, right-click = command**: left-click tap on the canvas now clears all selection (empty-space deselect); right-click remains the move/rally action
- **Numbered command groups**: each right-click with a selection creates a numbered group — those specks move independently; re-commanding units from an old group transfers them to the new one; dead specks are pruned from groups each tick
- **No-op with empty selection**: STOP, HOLD, RALLY are all no-ops when nothing is selected
- **Visual markers**: numbered crosshair markers render in the PixiJS canvas and minimap per active group

## How to test
1. Box-drag to select a group of specks → right-click somewhere → crosshair labeled `1` appears
2. Box-drag a different group → right-click elsewhere → crosshair labeled `2` appears; group 1 marker remains
3. Include some group-1 specks in a group-2 selection → right-click → those specks leave `1` and join `2`; marker `1` disappears if it empties
4. Click empty canvas space → selection clears
5. Click a building (via HUD overlay) → building selected, no speck selection
6. Box-drag over area containing both specks and a building → only specks selected
7. With nothing selected: right-click, press S, press H → nothing happens

Closes #2377 (right-click move), addresses the selection ambiguity raised in review.