### PR TITLE
fix(speck-wars): left-click + drag-box select player buildings (#2464 follow-up)

### DIFF
--- a/src/app/speck-wars/domain/simulation/tick.ts
+++ b/src/app/speck-wars/domain/simulation/tick.ts
@@ -183,8 +183,23 @@ function consumeInputs(sim: SimulationState) {
       }
       // Selected specks initially use the same rally as unselected
       sim.rallyPoints['player-selected'] = sim.rallyPoints['player']
-      // Mutual exclusion: selecting specks always clears any building selection
-      sim.selectedBuildingId = null
+      if (sim.selectedSpeckIds.size > 0) {
+        // Mutual exclusion: selecting specks always clears any building selection
+        sim.selectedBuildingId = null
+      } else {
+        // No specks in box — fall back to selecting an overlapping player building
+        const cx = (minX + maxX) / 2
+        const cy = (minY + maxY) / 2
+        for (const b of Object.values(sim.buildings)) {
+          if (b.ownerId !== event.ownerId) continue
+          const btype = BUILDING_TYPES[b.typeId]
+          const r = (btype?.size ?? 20) + 40
+          if (Math.hypot(cx - b.x, cy - b.y) <= r) {
+            sim.selectedBuildingId = b.id
+            break
+          }
+        }
+      }
     }
     if (event.type === 'CLEAR_SELECT') {
       sim.selectedSpeckIds.clear()

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -231,6 +231,23 @@ export class GameInstance {
       },
     )
     this.inputHandler.onGuard = () => { this.guard(); this.notify('🛡 GUARD', '#4af7c4', 1000) }
+    this.inputHandler.onTap = (wx, wy) => {
+      // Left-click: select a player building if tapped, otherwise deselect
+      const isTouchDevice = typeof navigator !== 'undefined' && navigator.maxTouchPoints > 0
+      const hitBuffer = isTouchDevice ? 30 : 20
+      for (const building of Object.values(this.sim.buildings)) {
+        if (building.ownerId !== 'player') continue
+        const btype = BUILDING_TYPES[building.typeId]
+        const r = (btype?.size ?? 20) + hitBuffer
+        if (Math.hypot(wx - building.x, wy - building.y) <= r) {
+          navigator.vibrate?.(10)
+          this.sim.inputQueue.push({ type: 'SELECT_BUILDING', ownerId: 'player', buildingId: building.id })
+          return
+        }
+      }
+      this.sim.inputQueue.push({ type: 'CLEAR_SELECT', ownerId: 'player' })
+      this.sim.rallyPoints['player-selected'] = null
+    }
     this.inputHandler.onSaveControlGroup = (slot: number) => {
       const saved = [...this.sim.selectedSpeckIds]
       this.controlGroups.set(slot, saved)

--- a/src/app/speck-wars/input/input-handler.ts
+++ b/src/app/speck-wars/input/input-handler.ts
@@ -32,6 +32,7 @@ export class InputHandler {
   private onHold?: () => void
   private onAttackMove?: (worldX: number, worldY: number) => void
   public onGuard?: () => void
+  public onTap?: (worldX: number, worldY: number) => void
   private heldKeys = new Set<string>()
   private isDragging = false
   private lastX = 0
@@ -230,8 +231,8 @@ export class InputHandler {
           this.pendingModifier = 'none'
           if (this.canvas) this.canvas.style.cursor = 'default'
         } else {
-          // Left-click on canvas = deselect (right-click is the command/move action)
-          this.onClearSelect?.()
+          // Left-click on canvas: onTap handles building hit-test + deselect
+          this.onTap?.(world.x, world.y)
         }
       }
       return


### PR DESCRIPTION
## Problem
PR #2464 changed left-click to call onClearSelect() (deselect) and right-click to onRally() (move). The building-selection fix — clicking a base/outpost should select it — was not included in the merge.

Two symptoms:
- Left-clicking a building deselects everything instead of selecting the building
- Drag-box over an area with only your base selects nothing

## Changes

**input-handler.ts** — add onTap public property
Left-click tap now calls onTap(worldX, worldY) instead of onClearSelect() so the caller receives coordinates for hit-testing. Escape still calls onClearSelect() — the two remain separate.

**game-instance.ts** — wire onTap to building hit-test
Left-click on a player building → SELECT_BUILDING. Left-click on empty canvas → CLEAR_SELECT. Same touch hit-buffer as the right-click building test.

**tick.ts** — BOX_SELECT building fallback
When drag-box captures 0 specks, check if a player building center is within the box (size + 40px radius). If so, select it; otherwise clear building selection as before.

## Test plan
- [ ] Left-click player base → base panel opens
- [ ] Left-click player outpost → outpost panel opens
- [ ] Left-click empty canvas → selection cleared
- [ ] Escape → selection cleared (no building hit-test)
- [ ] Drag-box over base with no specks → base selected
- [ ] Drag-box over specks → specks selected, building selection cleared