### PR TITLE
feat(speck-wars): turret sacrifice + Level 11 time-based survival redesign

### DIFF
--- a/src/app/speck-wars/campaign/levels.ts
+++ b/src/app/speck-wars/campaign/levels.ts
@@ -19,6 +19,10 @@ export interface LevelConfig {
   allowTurrets?: boolean        // enables turret placement UI this level
   turretBudget?: number         // starting turret placement budget (default 0)
   survivalWaves?: number        // win when waveNumber reaches this (null = no survival win)
+  isSurvival?: boolean
+  surviveLengthMs?: number      // total survival time in ms
+  noAiBase?: boolean            // skip AI base creation
+  playerBaseCenter?: boolean    // place player base at world center (1500,1500)
 }
 
 export const LEVELS: LevelConfig[] = [
@@ -135,16 +139,18 @@ export const LEVELS: LevelConfig[] = [
   {
     id: 11,
     name: 'Last Stand',
-    flavor: 'No reinforcements. Build your line. Survive what comes.',
+    flavor: 'Hold the center. Survive the onslaught.',
     difficulty: 'very-hard',
     seed: 1111,
     outpostCount: 0,
     mapPreset: 'pillars',
-    preSpawn: { player: 20, ai: 0 },
+    preSpawn: { player: 30, ai: 0 },
     starThresholds: { three: 0.65, two: 0.30 },
     allowTurrets: true,
-    turretBudget: 4,
-    survivalWaves: 10,
+    isSurvival: true,
+    surviveLengthMs: 5 * 60 * 1000,
+    noAiBase: true,
+    playerBaseCenter: true,
   },
 ]
 

--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -17,6 +17,13 @@ function formatTime(ms: number): string {
   return `${m.toString().padStart(2, '0')}:${s.toString().padStart(2, '0')}`
 }
 
+function formatSurvivalTime(ms: number): string {
+  const s = Math.ceil(ms / 1000)
+  const m = Math.floor(s / 60)
+  const sec = s % 60
+  return `${m}:${sec.toString().padStart(2, '0')}`
+}
+
 export function HUD() {
   const [showHelp, setShowHelp] = useState(false)
   const [winStreak, setWinStreak] = useState(0)
@@ -99,6 +106,7 @@ export function HUD() {
   const surrender = useSpeckWarsStore(s => s.surrender)
   const gameActions = useSpeckWarsStore(s => s.gameActions)
   const campaignLevel = useSpeckWarsStore(s => s.campaignLevel)
+  const buildMenuOpen = useSpeckWarsStore(s => s.buildMenuOpen)
 
   // Auto-collapse building drawer when building is deselected
   useEffect(() => {
@@ -214,6 +222,20 @@ export function HUD() {
             border: 'none', fontFamily: 'monospace',
           }}
         >⚠ BASE UNDER ATTACK ↑</button>
+      )}
+      {hud?.survivalTimeRemaining != null && phase === 'playing' && (
+        <div style={{
+          position: 'absolute', top: 12, left: '50%', transform: 'translateX(-50%)',
+          fontFamily: 'monospace', fontSize: 16, letterSpacing: 2,
+          color: hud.survivalTimeRemaining < 30000 ? '#ff4f7b' : hud.survivalTimeRemaining < 60000 ? '#ffaa44' : '#4af7c4',
+          textShadow: '0 0 12px currentColor',
+          pointerEvents: 'none', zIndex: 12,
+        }}>
+          {hud.waveInProgress
+            ? `WAVE ${hud.waveNumber} — HOLD!`
+            : `SURVIVE ${formatSurvivalTime(hud.survivalTimeRemaining)}`
+          }
+        </div>
       )}
       {(() => {
         const myCount = hud?.players?.player?.speckCount ?? 0
@@ -331,8 +353,8 @@ export function HUD() {
         )
       })()}
 
-      {/* Wave countdown — only shows when wave is imminent or in progress */}
-      {hud && (hud.waveCountdown !== null || hud.waveInProgress) && (() => {
+      {/* Wave countdown — only shows when wave is imminent or in progress (not on survival levels which use their own timer) */}
+      {hud && hud.survivalTimeRemaining == null && (hud.waveCountdown !== null || hud.waveInProgress) && (() => {
         const countdown = hud.waveCountdown ?? 0
         const inProgress = hud.waveInProgress
         if (!inProgress && countdown > 30000) return null  // only show when < 30s
@@ -1571,46 +1593,75 @@ export function HUD() {
               </button>
             )
           })()}
-          {hud?.buildModeEnabled && (
-            <>
-              <span style={{ fontSize: 9, color: 'rgba(255,180,80,0.7)', fontFamily: 'monospace', letterSpacing: 0.5, whiteSpace: 'nowrap', pointerEvents: 'none' }}>
-                Builds: {hud?.turretBudget ?? 0}
-              </span>
-              {([
-                { typeId: 'turret',     label: '⬡ Turret',     bg: 'rgba(255,136,68,0.12)',  border: 'rgba(255,136,68,0.55)',  color: '#ff8844', title: 'Place Turret — ranged defense' },
-                { typeId: 'scoutPost',  label: '⟩ Scout Post', bg: 'rgba(80,200,255,0.10)',  border: 'rgba(80,200,255,0.50)',  color: '#50c8ff', title: 'Place Scout Post — spawns fast scouts' },
-                { typeId: 'heavyForge', label: '▣ Heavy Forge', bg: 'rgba(255,80,60,0.10)',  border: 'rgba(255,100,60,0.50)',  color: '#ff6644', title: 'Place Heavy Forge — spawns tanky heavies' },
-              ] as const).map(({ typeId, label, bg, border, color, title }) => {
-                const disabled = (hud?.turretBudget ?? 0) <= 0
-                return (
-                  <button
-                    key={typeId}
-                    onClick={() => { if (!disabled) { navigator.vibrate?.(12); gameActions?.activateBuildMode?.(typeId) } }}
-                    title={title}
-                    aria-label={`${title} — ${hud?.turretBudget ?? 0} placement${(hud?.turretBudget ?? 0) !== 1 ? 's' : ''} remaining`}
-                    disabled={disabled}
-                    style={{
-                      padding: '8px 10px',
-                      fontSize: 10,
-                      cursor: disabled ? 'not-allowed' : 'pointer',
-                      background: disabled ? 'rgba(0,0,0,0.2)' : bg,
-                      border: `1px solid ${disabled ? 'rgba(255,255,255,0.12)' : border}`,
-                      borderRadius: 20,
-                      color: disabled ? 'rgba(255,255,255,0.3)' : color,
-                      letterSpacing: 0.8,
-                      minHeight: 44,
-                      fontFamily: 'monospace',
-                      fontWeight: 700,
-                      opacity: disabled ? 0.5 : 1,
-                      pointerEvents: 'auto',
-                    }}
-                  >
-                    {label}
-                  </button>
-                )
-              })}
-            </>
-          )}
+          {hud?.buildModeEnabled && (() => {
+            const selectedCount = hud?.selectedSpeckCount ?? 0
+            const canBuild = selectedCount >= 20
+            return (
+              <div style={{ position: 'relative', display: 'flex', flexDirection: 'column', alignItems: 'flex-end', gap: 4 }}>
+                {/* Build button */}
+                <button
+                  onClick={() => {
+                    if (canBuild) {
+                      navigator.vibrate?.(12)
+                      useSpeckWarsStore.getState().setBuildMenuOpen(!buildMenuOpen)
+                    }
+                  }}
+                  title={canBuild ? '[B] Open build menu' : 'Select 20+ units to build'}
+                  aria-label={canBuild ? 'Open build menu [B]' : `Build — need 20 units selected (${selectedCount} selected)`}
+                  style={{
+                    padding: '8px 12px',
+                    fontSize: 10,
+                    cursor: canBuild ? 'pointer' : 'default',
+                    background: canBuild ? 'rgba(255,136,68,0.18)' : 'rgba(0,0,0,0.2)',
+                    border: `1px solid ${canBuild ? 'rgba(255,136,68,0.55)' : 'rgba(255,255,255,0.12)'}`,
+                    borderRadius: 20,
+                    color: canBuild ? '#ff8844' : 'rgba(255,255,255,0.3)',
+                    letterSpacing: 0.8,
+                    minHeight: 44,
+                    fontFamily: 'monospace',
+                    fontWeight: 700,
+                    opacity: canBuild ? 1 : 0.5,
+                    pointerEvents: 'auto',
+                  }}
+                >
+                  {canBuild ? (buildMenuOpen ? '▲ B Build' : '▼ B Build') : `Build (need 20)`}
+                </button>
+                {/* Build dropdown */}
+                {buildMenuOpen && canBuild && (
+                  <div style={{
+                    position: 'absolute', bottom: '100%', right: 0, marginBottom: 4,
+                    display: 'flex', flexDirection: 'column', gap: 4,
+                    background: 'rgba(0,0,0,0.85)', border: '1px solid rgba(255,136,68,0.4)',
+                    borderRadius: 8, padding: '6px 8px',
+                    animation: 'panel-slide-up 0.15s ease-out',
+                    zIndex: 20,
+                  }}>
+                    <span style={{ fontSize: 8, color: 'rgba(255,180,80,0.7)', letterSpacing: 1, whiteSpace: 'nowrap', pointerEvents: 'none', paddingBottom: 2 }}>
+                      COSTS 20 UNITS
+                    </span>
+                    <button
+                      onClick={() => {
+                        navigator.vibrate?.(12)
+                        useSpeckWarsStore.getState().setBuildMenuOpen(false)
+                        gameActions?.activateBuildMode?.('turret')
+                      }}
+                      title="[T] Place Turret — ranged defense"
+                      aria-label="Place Turret — costs 20 units [T]"
+                      style={{
+                        padding: '8px 10px', fontSize: 10, cursor: 'pointer',
+                        background: 'rgba(255,136,68,0.12)', border: '1px solid rgba(255,136,68,0.55)',
+                        borderRadius: 16, color: '#ff8844', letterSpacing: 0.8,
+                        minHeight: 44, fontFamily: 'monospace', fontWeight: 700,
+                        pointerEvents: 'auto', whiteSpace: 'nowrap',
+                      }}
+                    >
+                      [T] Turret
+                    </button>
+                  </div>
+                )}
+              </div>
+            )
+          })()}
           <button
             onClick={() => { navigator.vibrate?.(8); gameActions.clearRally?.() }}
             title="[R] Clear rally"

--- a/src/app/speck-wars/domain/ai/ai-controller.ts
+++ b/src/app/speck-wars/domain/ai/ai-controller.ts
@@ -24,7 +24,8 @@ export class AIController {
   }
 
   update(sim: SimulationState, dt: number = 16) {
-    if (this.waveEnabled) {
+    // Survival mode manages its own wave spawning via survival-spawner.ts
+    if (this.waveEnabled && !sim.isSurvival) {
       this.waveTimer -= dt
       if (this.waveRemainingMs > 0) {
         this.waveRemainingMs = Math.max(0, this.waveRemainingMs - dt)
@@ -45,6 +46,8 @@ export class AIController {
     this.lastDecisionTick = sim.tick
 
     if (sim.players[this.playerId]?.isDefeated) return
+    // In survival mode the AI has no base — specks are managed by survival-spawner.ts
+    if (sim.isSurvival) return
 
     // Compute AI swarm centroid (or fall back to own base)
     let cx = 0, cy = 0, count = 0

--- a/src/app/speck-wars/domain/simulation/create-sim.ts
+++ b/src/app/speck-wars/domain/simulation/create-sim.ts
@@ -68,12 +68,14 @@ const playerSpawnInterval: Record<Difficulty, number | undefined> = {
   'very-hard': undefined,  // same as hard — no advantage
 }
 
-export function createSim(seed: number = Date.now(), difficulty: Difficulty = 'medium', mapPreset: MapPreset = 'random', outpostCount: number = 3): SimulationState {
+export function createSim(seed: number = Date.now(), difficulty: Difficulty = 'medium', mapPreset: MapPreset = 'random', outpostCount: number = 3, options?: { playerBaseCenter?: boolean; noAiBase?: boolean; isSurvival?: boolean; surviveLengthMs?: number }): SimulationState {
+  const playerBaseX = options?.playerBaseCenter ? 1500 : PLAYER_BASE_X
+  const playerBaseY = options?.playerBaseCenter ? 1500 : PLAYER_BASE_Y
   const playerBase: BuildingEntity = {
     id: 'building-player-base',
     typeId: 'base',
     ownerId: 'player',
-    x: PLAYER_BASE_X, y: PLAYER_BASE_Y,
+    x: playerBaseX, y: playerBaseY,
     hp: BASE_HP, maxHp: BASE_HP,
     spawnTimer: 0,
     spawnIntervalOverride: playerSpawnInterval[difficulty],
@@ -132,10 +134,15 @@ export function createSim(seed: number = Date.now(), difficulty: Difficulty = 'm
   // seed-pinned regression tests; balance must be measured as an average over many games.
   // Making the run reproducible means routing those calls through a seeded PRNG — a real
   // project, not a drive-by fix.
+  const initialBuildings: Record<string, BuildingEntity> = { 'building-player-base': playerBase, ...outpostBuildings }
+  if (!options?.noAiBase) {
+    initialBuildings['building-ai-base'] = aiBase
+  }
+
   const sim: SimulationState = {
     tick: 0,
     players: { player, ai, neutral },
-    buildings: { 'building-player-base': playerBase, 'building-ai-base': aiBase, ...outpostBuildings },
+    buildings: initialBuildings,
     speckIds: new Array(MAX_SPECKS).fill(''),
     speckX: new Float32Array(MAX_SPECKS),
     speckY: new Float32Array(MAX_SPECKS),
@@ -162,6 +169,11 @@ export function createSim(seed: number = Date.now(), difficulty: Difficulty = 'm
     waveInProgress: false,
     waveNumber: 0,
     obstacles,
+    isSurvival: options?.isSurvival ?? false,
+    survivalTimeRemaining: options?.isSurvival ? (options?.surviveLengthMs ?? 5 * 60 * 1000) : 0,
+    survivalWaveTimer: 15000,  // first wave at 15s
+    survivalWaveRemainingMs: 0,
+    survivalWaveNumber: 0,
   }
 
   return sim

--- a/src/app/speck-wars/domain/simulation/survival-spawner.ts
+++ b/src/app/speck-wars/domain/simulation/survival-spawner.ts
@@ -1,0 +1,88 @@
+import type { SimulationState, SpeckMeta } from '../types'
+import { SPECK_TYPES } from '../config/speck-types'
+import { MAX_SPECKS } from '../constants'
+
+const WORLD_SIZE = 3000
+const SPAWN_MARGIN = 50
+
+function randomEdgePosition(): { x: number; y: number } {
+  const edge = Math.floor(Math.random() * 4)
+  switch (edge) {
+    case 0: return { x: Math.random() * WORLD_SIZE, y: SPAWN_MARGIN }              // top
+    case 1: return { x: Math.random() * WORLD_SIZE, y: WORLD_SIZE - SPAWN_MARGIN } // bottom
+    case 2: return { x: SPAWN_MARGIN, y: Math.random() * WORLD_SIZE }              // left
+    default: return { x: WORLD_SIZE - SPAWN_MARGIN, y: Math.random() * WORLD_SIZE } // right
+  }
+}
+
+let survivalSpeckCounter = 0
+
+function spawnEnemyWave(sim: SimulationState) {
+  const playerBase = Object.values(sim.buildings).find(b => b.ownerId === 'player' && b.typeId === 'base')
+  if (!playerBase) return
+  // Wave size scales: 8 + waveNumber*4
+  const waveSize = 8 + sim.survivalWaveNumber * 4
+  const speckTypeId = sim.survivalWaveNumber > 5 ? 'heavy' : 'basic'
+  const stype = SPECK_TYPES[speckTypeId]
+  for (let i = 0; i < waveSize; i++) {
+    const { x, y } = randomEdgePosition()
+    const meta: SpeckMeta = {
+      id: `sv-${++survivalSpeckCounter}`,
+      typeId: speckTypeId,
+      ownerId: 'ai',
+      state: 'moving',
+      targetId: null,
+      attackCooldown: 0,
+      kills: 0,
+      assignedRallyX: playerBase.x,
+      assignedRallyY: playerBase.y,
+    }
+    let slot: number
+    if (sim.freeSlots.length > 0) {
+      slot = sim.freeSlots.pop()!
+    } else if (sim.speckCount < MAX_SPECKS) {
+      slot = sim.speckCount++
+    } else {
+      break
+    }
+    sim.speckX[slot] = x
+    sim.speckY[slot] = y
+    sim.speckVx[slot] = 0
+    sim.speckVy[slot] = 0
+    sim.speckHp[slot] = stype.hp
+    sim.speckIds[slot] = meta.id
+    sim.speckMeta[slot] = meta
+  }
+}
+
+export function updateSurvivalSpawner(sim: SimulationState, dt: number) {
+  if (!sim.isSurvival) return
+
+  // Tick survival countdown
+  if (sim.survivalTimeRemaining > 0) {
+    sim.survivalTimeRemaining = Math.max(0, sim.survivalTimeRemaining - dt)
+  }
+
+  // Tick wave remaining timer
+  if (sim.survivalWaveRemainingMs > 0) {
+    sim.survivalWaveRemainingMs = Math.max(0, sim.survivalWaveRemainingMs - dt)
+  }
+
+  sim.waveInProgress = sim.survivalWaveRemainingMs > 0
+
+  if (sim.survivalWaveRemainingMs === 0) {
+    sim.survivalWaveTimer -= dt
+    if (sim.survivalWaveTimer <= 0) {
+      sim.survivalWaveNumber++
+      sim.waveNumber = sim.survivalWaveNumber
+      spawnEnemyWave(sim)
+      sim.survivalWaveRemainingMs = 20000     // wave lasts 20s
+      sim.survivalWaveTimer = 25000           // break before next wave
+      sim.waveInProgress = true
+      sim.events.push({ type: 'AI_WAVE_START', waveNumber: sim.survivalWaveNumber })
+      sim.waveCountdown = 25000
+    } else {
+      sim.waveCountdown = sim.survivalWaveTimer
+    }
+  }
+}

--- a/src/app/speck-wars/domain/simulation/tick.ts
+++ b/src/app/speck-wars/domain/simulation/tick.ts
@@ -9,6 +9,7 @@ import { updateCapture } from './capture'
 import { BUILDING_TYPES } from '../config/building-types'
 import { HUD_UPDATE_INTERVAL, DOMINATION_TIME } from '../constants'
 import { updateTurrets } from './turret'
+import { updateSurvivalSpawner } from './survival-spawner'
 
 export function tick(sim: SimulationState, dt: number): SimulationState {
   sim.events = []  // clear outbound events from previous tick
@@ -21,6 +22,9 @@ export function tick(sim: SimulationState, dt: number): SimulationState {
 
   // 2b. Turrets: fire missiles at nearby enemies
   updateTurrets(sim, dt)
+
+  // 2c. Survival mode: spawn waves and tick countdown
+  updateSurvivalSpawner(sim, dt)
 
   // 3. Each speck picks/validates its target
   runSpeckAI(sim)
@@ -70,13 +74,6 @@ export function tick(sim: SimulationState, dt: number): SimulationState {
     }
   } else {
     sim.dominationTimer = 0
-  }
-
-  // Survival win: on survival levels, winning enough waves beats the level
-  if (sim.survivalWinWaves !== null &&
-      sim.waveNumber >= sim.survivalWinWaves &&
-      !sim.waveInProgress) {
-    sim.events.push({ type: 'GAME_OVER', winnerId: 'player', victoryType: 'survival' })
   }
 
   // 9. Emit HUD update every N ticks
@@ -240,7 +237,9 @@ function consumeInputs(sim: SimulationState) {
     }
     if (event.type === 'BUILD_STRUCTURE') {
       if (event.ownerId !== 'player') continue
-      if (sim.turretBudget <= 0) continue
+      const SACRIFICE_COST = 20
+      // Must have enough selected specks to sacrifice
+      if (sim.selectedSpeckIds.size < SACRIFICE_COST) continue
       const btype = BUILDING_TYPES[event.typeId]
       if (!btype) continue  // unknown type, skip
       // Don't allow placing on top of an existing building (within 60px)
@@ -261,7 +260,15 @@ function consumeInputs(sim: SimulationState) {
         spawnTimer: 0,
         fireTimer: 0,
       }
-      sim.turretBudget--
+      // Sacrifice 20 selected specks (set HP to 0; removeDeadSpecks cleans up next tick)
+      let sacrificed = 0
+      for (let i = 0; i < sim.speckCount && sacrificed < SACRIFICE_COST; i++) {
+        const meta = sim.speckMeta[i]
+        if (!meta || !sim.speckIds[i] || !sim.selectedSpeckIds.has(meta.id)) continue
+        sim.speckHp[i] = 0
+        sacrificed++
+      }
+      sim.selectedSpeckIds.clear()
     }
     if (event.type === 'STOP') {
       if (event.ownerId === 'player' && sim.selectedSpeckIds.size === 0) continue
@@ -447,7 +454,7 @@ function emitHudUpdate(sim: SimulationState) {
     if (b) selectedBuilding = { id: b.id, typeId: b.typeId, ownerId: b.ownerId, hp: b.hp, maxHp: b.maxHp, spawnTypeOverride: b.spawnTypeOverride }
   }
 
-  sim.events.push({ type: 'HUD_UPDATE', data: { players: data, attackedBuildingIds, captureInfo, surgeDuration: sim.surgeDuration, surgeCooldown: sim.surgeCooldown, selectedSpeckCount: sim.selectedSpeckIds.size, selectedComposition, spawnRates, minimap, waveCountdown: sim.waveCountdown, waveInProgress: sim.waveInProgress, waveNumber: sim.waveNumber, baseUnderThreat, enemyAdvanceDetected, selectedBuilding, turretBudget: sim.turretBudget, buildModeEnabled: sim.turretBudget >= 0 && sim.survivalWinWaves !== null } })
+  sim.events.push({ type: 'HUD_UPDATE', data: { players: data, attackedBuildingIds, captureInfo, surgeDuration: sim.surgeDuration, surgeCooldown: sim.surgeCooldown, selectedSpeckCount: sim.selectedSpeckIds.size, selectedComposition, spawnRates, minimap, waveCountdown: sim.waveCountdown, waveInProgress: sim.waveInProgress, waveNumber: sim.waveNumber, baseUnderThreat, enemyAdvanceDetected, selectedBuilding, turretBudget: sim.turretBudget, buildModeEnabled: sim.isSurvival === true, survivalTimeRemaining: sim.isSurvival ? sim.survivalTimeRemaining : null } })
 }
 
 function pruneCommandGroups(sim: SimulationState) {

--- a/src/app/speck-wars/domain/simulation/victory.ts
+++ b/src/app/speck-wars/domain/simulation/victory.ts
@@ -1,6 +1,22 @@
 import type { SimulationState } from '../types'
 
 export function checkVictory(sim: SimulationState) {
+  // Survival mode: AI can't be defeated (no base), player wins by outlasting timer
+  if (sim.isSurvival) {
+    if (sim.survivalTimeRemaining <= 0 && !sim.waveInProgress) {
+      sim.events.push({ type: 'GAME_OVER', winnerId: 'player', victoryType: 'survival' })
+    }
+    // Check player defeat: player base destroyed
+    const playerAlive = Object.values(sim.buildings).some(b => b.ownerId === 'player')
+    if (!playerAlive) {
+      const player = sim.players['player']
+      if (player) player.isDefeated = true
+      sim.events.push({ type: 'GAME_OVER', winnerId: 'ai', victoryType: 'destruction' })
+    }
+    return
+  }
+
+  // Normal mode (original logic)
   for (const [pid, player] of Object.entries(sim.players)) {
     if (player.isDefeated) continue
     if (pid === 'neutral') continue  // neutral is never defeated and never wins

--- a/src/app/speck-wars/domain/types.ts
+++ b/src/app/speck-wars/domain/types.ts
@@ -87,6 +87,11 @@ export interface SimulationState {
   waveInProgress: boolean        // true during the 15s wave assault
   waveNumber: number             // current wave count (0 = not started)
   obstacles: WallObstacle[]
+  isSurvival: boolean
+  survivalTimeRemaining: number    // ms countdown to win
+  survivalWaveTimer: number        // ms until next wave spawns
+  survivalWaveRemainingMs: number  // ms left in current wave
+  survivalWaveNumber: number       // current wave count
 }
 
 export type InputEvent =
@@ -149,4 +154,5 @@ export interface HudData {
     aiRallyPoint: { x: number; y: number } | null
   }
   cameraViewport?: { x: number; y: number; w: number; h: number }  // world-space viewport rect
+  survivalTimeRemaining: number | null
 }

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -82,9 +82,16 @@ export class GameInstance {
       if (levelConfig) {
         difficulty = levelConfig.difficulty
         this.levelConfig = levelConfig
-        sim = createSim(levelConfig.seed, levelConfig.difficulty, levelConfig.mapPreset ?? 'open', levelConfig.outpostCount)
+        sim = createSim(levelConfig.seed, levelConfig.difficulty, levelConfig.mapPreset ?? 'open', levelConfig.outpostCount, {
+          playerBaseCenter: levelConfig.playerBaseCenter,
+          noAiBase: levelConfig.noAiBase,
+          isSurvival: levelConfig.isSurvival,
+          surviveLengthMs: levelConfig.surviveLengthMs,
+        })
         preSpawnUnits(sim, 'player', levelConfig.preSpawn.player)
-        preSpawnUnits(sim, 'ai', levelConfig.preSpawn.ai)
+        if (!levelConfig.isSurvival) {
+          preSpawnUnits(sim, 'ai', levelConfig.preSpawn.ai)
+        }
         if (levelConfig.survivalWaves) {
           sim.survivalWinWaves = levelConfig.survivalWaves
         }
@@ -148,6 +155,13 @@ export class GameInstance {
       this.canvas,
       this.camera,
       (wx, wy) => {
+        // Right-click in build mode: cancel build
+        if (this.buildModeTypeId) {
+          this.buildModeTypeId = null
+          if (this.canvas) this.canvas.style.cursor = 'default'
+          this.notify('Build cancelled', 'rgba(255,255,255,0.4)', 600)
+          return
+        }
         // Check if click hit a player building — select it instead of rallying
         // Touch devices get a larger buffer to ensure 44px+ screen hit area at default zoom
         const isTouchDevice = typeof navigator !== 'undefined' && navigator.maxTouchPoints > 0
@@ -181,20 +195,9 @@ export class GameInstance {
       (x1, y1, x2, y2) => {                                           // drag — box-select specks
         this.sim.inputQueue.push({ type: 'BOX_SELECT', ownerId: 'player', x1, y1, x2, y2 })
       },
-      () => {                                                          // Escape/left-click — clear selection or place structure
-        if (this.buildModeTypeId) {
-          // In build mode, left-click places a structure at the mouse world position
-          const mousePos = this.inputHandler.getMouseScreenPos()
-          if (mousePos) {
-            const { x: wx, y: wy } = screenToWorld(mousePos.x, mousePos.y, this.camera)
-            this.sim.inputQueue.push({ type: 'BUILD_STRUCTURE', ownerId: 'player', typeId: this.buildModeTypeId, x: wx, y: wy })
-          }
-          this.buildModeTypeId = null
-          if (this.canvas) this.canvas.style.cursor = 'default'
-        } else {
-          this.sim.inputQueue.push({ type: 'CLEAR_SELECT', ownerId: 'player' })
-          this.sim.rallyPoints['player-selected'] = null
-        }
+      () => {                                                          // Escape — clear selection
+        this.sim.inputQueue.push({ type: 'CLEAR_SELECT', ownerId: 'player' })
+        this.sim.rallyPoints['player-selected'] = null
       },
       () => { this.surge() },  // Q — production surge
       () => { this.snapToAction() },                                        // V — snap camera to battle
@@ -253,6 +256,13 @@ export class GameInstance {
     )
     this.inputHandler.onGuard = () => { this.guard(); this.notify('🛡 GUARD', '#4af7c4', 1000) }
     this.inputHandler.onTap = (wx, wy) => {
+      // Build mode: left-click places the structure
+      if (this.buildModeTypeId) {
+        this.sim.inputQueue.push({ type: 'BUILD_STRUCTURE', ownerId: 'player', typeId: this.buildModeTypeId, x: wx, y: wy })
+        this.buildModeTypeId = null
+        if (this.canvas) this.canvas.style.cursor = 'default'
+        return
+      }
       // Left-click: select a player building if tapped, otherwise deselect
       const isTouchDevice = typeof navigator !== 'undefined' && navigator.maxTouchPoints > 0
       const hitBuffer = isTouchDevice ? 30 : 20
@@ -288,6 +298,21 @@ export class GameInstance {
         if (aliveIds.has(id)) this.sim.selectedSpeckIds.add(id)
       }
       this.sim.rallyPoints['player-selected'] = this.sim.rallyPoints['player']
+    }
+    this.inputHandler.onBuildMenu = () => {
+      if (this.sim.isSurvival && this.sim.selectedSpeckIds.size >= 20) {
+        const current = useSpeckWarsStore.getState().buildMenuOpen
+        useSpeckWarsStore.getState().setBuildMenuOpen(!current)
+      } else {
+        // Fall through to rush if not in survival mode or not enough units
+        this.rush(); this.notify('⚡ RUSH!', '#ff4f7b')
+      }
+    }
+    this.inputHandler.onBuildTurret = () => {
+      if (this.sim.isSurvival && this.sim.selectedSpeckIds.size >= 20) {
+        useSpeckWarsStore.getState().setBuildMenuOpen(false)
+        useSpeckWarsStore.getState().gameActions?.activateBuildMode?.('turret')
+      }
     }
     useSpeckWarsStore.getState().setGameActions({
       defend: () => { this.defend(); this.notify('🛡 DEFEND', '#4af7c4') },
@@ -334,13 +359,12 @@ export class GameInstance {
       activatePatrol: () => this.inputHandler.activateTouchPatrol(),
       activateSelectMode: () => this.inputHandler.activateTouchSelectMode(),
       activateBuildMode: (typeId: string) => {
-        if (this.sim.turretBudget <= 0) return
         this.buildModeTypeId = typeId
         if (this.canvas) this.canvas.style.cursor = 'crosshair'
         const labels: Record<string, string> = {
-          turret: 'Click to place Turret',
-          scoutPost: 'Click to place Scout Post',
-          heavyForge: 'Click to place Heavy Forge',
+          turret: 'Click to place Turret (costs 20 units)',
+          scoutPost: 'Click to place Scout Post (costs 20 units)',
+          heavyForge: 'Click to place Heavy Forge (costs 20 units)',
         }
         this.notify(labels[typeId] ?? 'Click to place', '#ff8844', 1500)
       },
@@ -787,13 +811,6 @@ export class GameInstance {
           const waveColors = ['#ff4f7b', '#ff6b35', '#cc00ff']
           const color = waveColors[(event.waveNumber - 1) % waveColors.length]
           this.notify(`⚠ WAVE ${event.waveNumber} ASSAULT!`, color, 3000)
-          if (this.levelConfig?.allowTurrets) {
-            // Reward: earn one more turret to place after each wave starts
-            if (this.sim.turretBudget < 8) {  // cap at 8 total
-              this.sim.turretBudget++
-              this.notify('⬡ Turret ready (+1)', '#ff8844', 1800)
-            }
-          }
         }
         if (event.type === 'AI_SPAWN_SWITCH' && event.speckTypeId === 'heavy') {
           this.notify('⚠ ENEMY SWITCHING TO HEAVY', '#ff8844')

--- a/src/app/speck-wars/input/input-handler.ts
+++ b/src/app/speck-wars/input/input-handler.ts
@@ -33,6 +33,8 @@ export class InputHandler {
   private onAttackMove?: (worldX: number, worldY: number) => void
   public onGuard?: () => void
   public onTap?: (worldX: number, worldY: number) => void
+  public onBuildMenu?: () => void
+  public onBuildTurret?: () => void
   private heldKeys = new Set<string>()
   private isDragging = false
   private lastX = 0
@@ -578,7 +580,9 @@ export class InputHandler {
     } else if (e.code === 'KeyN') {
       this.onAdvanceOutpost?.()
     } else if (e.code === 'KeyB') {
-      this.onRush?.()
+      if (this.onBuildMenu) { this.onBuildMenu() } else { this.onRush?.() }
+    } else if (e.code === 'KeyT') {
+      this.onBuildTurret?.()
     } else if (e.code === 'KeyQ') {
       this.onSurge?.()
     } else if (e.code === 'KeyV') {

--- a/src/app/speck-wars/store.ts
+++ b/src/app/speck-wars/store.ts
@@ -69,6 +69,8 @@ interface SpeckWarsStore {
   setCampaignLevel: (n: number | null) => void
   surrender: () => void
   resetGame: () => void
+  buildMenuOpen: boolean
+  setBuildMenuOpen: (open: boolean) => void
 }
 
 export const useSpeckWarsStore = create<SpeckWarsStore>()((set, get) => ({
@@ -134,6 +136,8 @@ export const useSpeckWarsStore = create<SpeckWarsStore>()((set, get) => ({
   setGameActions: (actions) => set({ gameActions: actions ?? { defend: null, advance: null, rush: null, clearRally: null, surge: null, rally: null, setSpawnType: null, panCamera: null, stop: null, hold: null, guard: null, saveControlGroup: null, recallControlGroup: null, selectAll: null, snapToBase: null, snapToAction: null, activatePatrol: null, activateSelectMode: null, selectByType: null, selectBuilding: null, commandAt: null, clearSelection: null, activateBuildMode: null } }),
   campaignLevel: null,
   setCampaignLevel: n => set({ campaignLevel: n }),
+  buildMenuOpen: false,
+  setBuildMenuOpen: (open) => set({ buildMenuOpen: open }),
   surrender: () => {
     const s = get()
     resetWinStreak()
@@ -165,5 +169,6 @@ export const useSpeckWarsStore = create<SpeckWarsStore>()((set, get) => ({
     aiPersonality: null,
     difficulty: s.difficulty,
     campaignLevel: null,
+    buildMenuOpen: false,
   })),
 }))


### PR DESCRIPTION
## Turret changes

**Placement fixed**: left-click now places (via `onTap`), right-click cancels build mode. The previous code had placement in `onClearSelect` (Escape key) which was unreachable after the #2468 input model change.

**Sacrifice mechanic**: building a turret requires 20 selected specks. On placement, 20 are killed and selection is cleared. No more `turretBudget` counter — the unit cost is the gate.

**Build flow**: Select 20+ units → press **B** (or tap Build button) to open build menu → press **T** (or tap Turret) to enter ghost-cursor mode → left-click to place, right-click to cancel.

## Level 11 redesign

| Before | After |
|--------|-------|
| Enemy base on right side | No enemy base |
| Player base on left side | Player base at world center (1500, 1500) |
| Win by surviving 10 waves | Win by surviving 5 minutes |
| AI spawns from base | Enemies spawn from random map edges each wave |

**Survival spawner** (`survival-spawner.ts`): new file. Manages countdown timer, wave intervals, edge-spawn logic. Wave size scales: `8 + waveNumber×4`. Waves 1–5 use basic specks; wave 6+ uses heavies.

**HUD**: survival countdown shown at top center, color-coded (green → orange → red as time runs low). Shows "⚠ WAVE N — HOLD!" during active waves.

## Test plan
- [ ] Start Level 11 — player base at center, no AI base, 30 player specks
- [ ] First wave spawns at ~15s from random edges, heads for center
- [ ] Countdown timer visible at top, ticks down from 5:00
- [ ] Select 20+ specks → B opens build menu → T enters turret ghost mode
- [ ] Left-click places turret, 20 specks die, selection clears
- [ ] Right-click cancels build mode
- [ ] Survive 5:00 → survival victory
- [ ] Base destroyed → defeat
- [ ] B key on non-survival levels still = Rush