### PR TITLE
feat(speck-wars): rally placement mode — click [R] to set building rally point

### DIFF
--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -180,9 +180,9 @@ export class GameInstance {
         this.commandAt(wx, wy)
       },
       () => useSpeckWarsStore.getState().togglePause(),   // Space
-      () => {                                              // R — rally hint if building selected, else clear rally
+      () => {                                              // R — rally placement mode if building selected, else clear rally
         if (this.sim.selectedBuildingId) {
-          this.notify('Right-click to set rally point', 'rgba(255,255,255,0.5)', 1200)
+          this.activateBuildingRallyMode()
         } else {
           this.clearRally()
         }
@@ -351,7 +351,7 @@ export class GameInstance {
       stop: () => this.sim.inputQueue.push({ type: 'STOP', ownerId: 'player' }),
       hold: () => this.sim.inputQueue.push({ type: 'HOLD', ownerId: 'player' }),
       guard: () => this.guard(),
-      buildingRallyHint: () => this.notify('Right-click to set rally point', 'rgba(255,255,255,0.5)', 1200),
+      buildingRallyHint: () => this.activateBuildingRallyMode(),
       saveControlGroup: (slot: number) => {
         this.inputHandler.onSaveControlGroup?.(slot)
       },
@@ -1037,6 +1037,12 @@ export class GameInstance {
     this.camera.y = h / 2 - cy * this.camera.zoom
     clampCamera(this.camera, w, h)
     this.notify('⚔ Battle', '#ff8844', 700)
+  }
+
+  private activateBuildingRallyMode() {
+    this.inputHandler.pendingModifier = 'rally'
+    if (this.canvas) this.canvas.style.cursor = 'crosshair'
+    this.notify('Left-click to set rally point', 'rgba(100,200,255,0.7)', 1500)
   }
 
   private snapToBase() {

--- a/src/app/speck-wars/input/input-handler.ts
+++ b/src/app/speck-wars/input/input-handler.ts
@@ -24,7 +24,7 @@ export class InputHandler {
   private onSelectAll?: () => void
   public onSaveControlGroup?: (slot: number) => void
   public onRecallControlGroup?: (slot: number) => void
-  private pendingModifier: 'none' | 'attack' = 'none'
+  public pendingModifier: 'none' | 'attack' | 'rally' = 'none'
   private isPanDragging = false   // middle-mouse only
   private isRightDragging = false
   private pendingBuildActive = false
@@ -230,6 +230,10 @@ export class InputHandler {
         const world = screenToWorld(sx, sy, this.camera)
         if (this.pendingModifier === 'attack') {
           this.onAttackMove?.(world.x, world.y)
+          this.pendingModifier = 'none'
+          if (this.canvas) this.canvas.style.cursor = 'default'
+        } else if (this.pendingModifier === 'rally') {
+          this.onRally?.(world.x, world.y)
           this.pendingModifier = 'none'
           if (this.canvas) this.canvas.style.cursor = 'default'
         } else {


### PR DESCRIPTION
## Summary
- Pressing R or clicking the Rally button (⚑) with a building selected activates a **left-click placement mode** — cursor changes to crosshair and a toast prompts "Left-click to set rally point"
- Left-clicking while in rally mode sets the building rally point (calls `SET_BUILDING_RALLY`) — no longer requires right-click exclusively
- Escape cancels rally placement mode (same key that cancels attack-move)
- Right-click still works as before for quick rally setting

## Implementation
Same `pendingModifier` pattern already used for attack-move:
- `input-handler.ts`: `pendingModifier` extended to `'none' | 'attack' | 'rally'`; left-click `'rally'` branch calls `onRally`
- `game-instance.ts`: `activateBuildingRallyMode()` helper sets modifier + crosshair cursor + toast; R key and `buildingRallyHint` action both use it

🤖 Generated with [Claude Code](https://claude.ai/claude-code)