### PR TITLE
fix(chat-room-of-infinity): add aria-labels to all icon-only buttons

### DIFF
--- a/src/app/chat-room-of-infinity/components/organisims/Chat.tsx
+++ b/src/app/chat-room-of-infinity/components/organisims/Chat.tsx
@@ -95,7 +95,7 @@ export default function Chat() {
           top: '12px',
         }}
       >
-        <IconButton onClick={handleMenuOpen} size="small">
+        <IconButton onClick={handleMenuOpen} size="small" aria-label="Open chat menu">
           <MoreVert />
         </IconButton>
         <Menu anchorEl={menuAnchor} open={Boolean(menuAnchor)} onClose={handleMenuClose}>
@@ -187,6 +187,7 @@ export default function Chat() {
       <Fade in={showScrollButton}>
         <IconButton
           onClick={scrollToBottom}
+          aria-label="Scroll to bottom"
           sx={{
             position: 'absolute',
             bottom: 100,
@@ -242,7 +243,7 @@ export default function Chat() {
               },
             }}
           />
-          <IconButton onClick={handleSend} color="primary" disabled={isSubmitting}>
+          <IconButton onClick={handleSend} color="primary" disabled={isSubmitting} aria-label="Send message">
             <Send />
           </IconButton>
         </Box>

--- a/src/app/chat-room-of-infinity/components/organisims/UserList.tsx
+++ b/src/app/chat-room-of-infinity/components/organisims/UserList.tsx
@@ -79,7 +79,7 @@ export default function UserList() {
   return (
     <Box sx={sx.container}>
       <Box sx={sx.drawerToggle(isCollapsed)}>
-        <IconButton onClick={toggleUserList}>
+        <IconButton onClick={toggleUserList} aria-label={isCollapsed ? 'Expand user list' : 'Collapse user list'}>
           {isCollapsed ? <ExpandMore /> : <ExpandLess />}
         </IconButton>
       </Box>
@@ -92,6 +92,7 @@ export default function UserList() {
                 <IconButton
                   onClick={toggleUserSelector}
                   color={isSelectorOpen ? 'primary' : 'default'}
+                  aria-label={isSelectorOpen ? 'Close character selector' : 'Add new character'}
                   sx={sx.iconButton(isSelectorOpen)}
                 >
                   {isSelectorOpen ? <Close /> : <PersonAdd />}


### PR DESCRIPTION
## Summary

Closes #2486 — all `IconButton` components in the chat UI now have descriptive `aria-label` attributes, making them accessible to screen reader users.

| Component | Button | Label added |
|---|---|---|
| `Chat.tsx` | Chat menu (⋮) | `"Open chat menu"` |
| `Chat.tsx` | Scroll to bottom (↓) | `"Scroll to bottom"` |
| `Chat.tsx` | Send message (→) | `"Send message"` |
| `UserList.tsx` | Collapse/expand drawer | `"Expand user list"` / `"Collapse user list"` (dynamic) |
| `UserList.tsx` | Add/close character selector | Mirrors existing Tooltip text |

## Test plan

- [ ] Run a screen reader (VoiceOver / NVDA) and tab through the chat — all buttons should announce their purpose
- [ ] Verify the collapse toggle announces the correct state on each press
- [ ] No visual changes — aria attributes are invisible to sighted users

Fixes WCAG 2.1 SC 4.1.2 (Name, Role, Value).

🤖 Generated with [Claude Code](https://claude.com/claude-code)