### PR TITLE
fix(trivia): check response.ok and log errors in WeeklyWinnerBanner

### DIFF
--- a/src/app/trivia/components/WeeklyWinnerBanner.tsx
+++ b/src/app/trivia/components/WeeklyWinnerBanner.tsx
@@ -38,7 +38,10 @@ export function WeeklyWinnerBanner() {
 
   useEffect(() => {
     fetch('/api/v1/trivia/weekly-winner')
-      .then((res) => res.json())
+      .then((res) => {
+        if (!res.ok) throw new Error(`weekly-winner fetch failed: ${res.status}`)
+        return res.json()
+      })
       .then((d: WinnerData) => {
         setData(d)
         if (d.weekKey) {
@@ -49,7 +52,9 @@ export function WeeklyWinnerBanner() {
           setDismissed(true)
         }
       })
-      .catch(() => {
+      .catch((err) => {
+        console.error('[WeeklyWinnerBanner] Failed to load winner data:', err)
+        // Hide the banner rather than showing broken state
         setDismissed(true)
       })
   }, [user?.uid])


### PR DESCRIPTION
## Summary

Closes #2487 — two bugs in the weekly winner banner fetch:

1. **No `response.ok` check**: calling `.json()` on a non-2xx response would throw a `SyntaxError` if the body isn't valid JSON (e.g., a server 500 error page), which then falls into `.catch()` anyway but with a confusing error type.

2. **Silent error swallow**: `.catch(() => setDismissed(true))` hid all errors from logs, making production failures invisible.

### Fix

```ts
.then((res) => {
  if (!res.ok) throw new Error(`weekly-winner fetch failed: ${res.status}`)
  return res.json()
})
// ...
.catch((err) => {
  console.error('[WeeklyWinnerBanner] Failed to load winner data:', err)
  setDismissed(true)
})
```

The banner still hides gracefully on failure — no broken UI shown to users. Errors are now visible in server/browser logs.

## Test plan

- [ ] Nominal: banner loads and shows winners as expected
- [ ] Force a 500 from `/api/v1/trivia/weekly-winner` — console shows the error, banner hides gracefully
- [ ] Force a network error — same behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)