### PR TITLE
fix: response.ok check in rewardExtractor + defer trivia rating localStorage write

### DIFF
--- a/src/app/tap-tap-adventure/lib/parsers/rewardExtractor.ts
+++ b/src/app/tap-tap-adventure/lib/parsers/rewardExtractor.ts
@@ -29,6 +29,10 @@ export default async function extractRewardItemsFromText(text: string): Promise<
         response_format: { type: 'json_object' },
       }),
     })
+    if (!response.ok) {
+      console.error('[rewardExtractor] OpenAI API error:', response.status, response.statusText)
+      throw new Error(`OpenAI API error: ${response.status}`)
+    }
     const data = await response.json()
     const content = data.choices?.[0]?.message?.content?.trim()
     if (!content) return []

--- a/src/app/trivia/components/TriviaGame.tsx
+++ b/src/app/trivia/components/TriviaGame.tsx
@@ -180,10 +180,9 @@ export function TriviaGame({ onFinish, onFlee, date: dateProp }: { onFinish: (re
     const storageKey = `trivia-rated-${q.id}`
     if (localStorage.getItem(storageKey)) return
 
-    localStorage.setItem(storageKey, rating)
+    // Optimistic UI update
     setQuestionRating(rating)
 
-    // Fire-and-forget — don't await
     fetch('/api/v1/trivia/rate-question', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -198,7 +197,11 @@ export function TriviaGame({ onFinish, onFlee, date: dateProp }: { onFinish: (re
         difficulty: q.difficulty,
         category: q.category,
       }),
-    }).catch(() => {}) // swallow errors — best effort
+    })
+      .then((res) => {
+        if (res.ok) localStorage.setItem(storageKey, rating)
+      })
+      .catch(() => {}) // best effort — if server fails, user can retry
   }
 
   const nextQuestion = useCallback(() => {


### PR DESCRIPTION
## Summary

- **tap-tap-adventure rewardExtractor** (#2491): `response.json()` was called without checking `response.ok` first. On a non-2xx response (401, 429, 500) the error body would be parsed as if it were successful data, silently producing `[]`. Now throws immediately so the outer `catch` can fall back to regex extraction.

- **trivia rating** (#2492): `localStorage.setItem` was written before the server call completed. If the fetch failed, the dedup guard would be permanently set and the user could never retry the rating. Now only written after `res.ok`.

## Test plan
- [ ] With an invalid `OPENAI_API_KEY`, tap-tap-adventure reward extraction falls back to regex without silent failure
- [ ] Trivia rating: if the `/api/v1/trivia/rate-question` call fails, the thumbs remain clickable for retry
- [ ] Trivia rating: on success, rating cannot be submitted twice (localStorage guard still works)

🤖 Generated with [Claude Code](https://claude.com/claude-code)