### PR TITLE
fix(chat-room): fix chat bubble text contrast

### DIFF
--- a/src/app/chat-room-of-infinity/components/molecules/ChatMessage.tsx
+++ b/src/app/chat-room-of-infinity/components/molecules/ChatMessage.tsx
@@ -24,7 +24,7 @@ export default function ChatMessage({ message }: Props) {
         sx={{
           maxWidth: '70%',
           backgroundColor: isSelf ? 'primary.main' : 'secondary.main',
-          color: isSelf ? 'white' : 'text.primary',
+          color: isSelf ? 'primary.contrastText' : 'secondary.contrastText',
           borderRadius: 2,
           p: 2,
         }}


### PR DESCRIPTION
## Problem
Both bubble variants had near-white text on bright light backgrounds:
- AI bubbles: `text.primary` (#e4e1d6) on `secondary.main` (#14d1ff) — ~1.4:1 contrast ratio
- User bubbles: `white` (#fff) on `primary.main` (#00ffc2) — ~1.3:1 contrast ratio

WCAG AA requires 4.5:1 for normal text.

## Fix
Use the contrast text values already defined in the theme:
- `primary.contrastText` (#003b2e) on teal — ~15:1 contrast
- `secondary.contrastText` (#003544) on cyan — ~11:1 contrast

🤖 Generated with [Claude Code](https://claude.ai/claude-code)