### PR TITLE
fix: response.ok checks and failure surfacing across trivia, tap-tap-adventure, and storybook-factory

### DIFF
--- a/src/app/api/v1/trivia/daily/route.ts
+++ b/src/app/api/v1/trivia/daily/route.ts
@@ -89,6 +89,7 @@ async function fetchOpenTDBQuestions(dateStr: string): Promise<TriviaQuestionWit
     try {
       const url = `https://opentdb.com/api.php?amount=${count}&category=${categoryId}&difficulty=${difficulty}&type=multiple`
       const res = await fetch(url)
+      if (!res.ok) throw new Error(`OpenTDB API error: ${res.status}`)
       const data: OpenTDBResponse = await res.json()
 
       if (data.response_code === 0 && data.results.length > 0) {

--- a/src/app/storybook-factory/components/useStorybookFactoryState.tsx
+++ b/src/app/storybook-factory/components/useStorybookFactoryState.tsx
@@ -372,9 +372,13 @@ export function useStorybookFactoryState(): StorybookFactoryState {
       if (response.ok) {
         const data = await response.json()
         setIllustrationUrls(prev => ({ ...prev, [key]: data.imageUrl }))
+      } else {
+        console.error(`Failed to regenerate illustration for ${key}: HTTP ${response.status}`)
+        setIllustrationError('Failed to regenerate illustration. Please try again.')
       }
     } catch (err) {
       console.error(`Failed to regenerate illustration for ${key}:`, err)
+      setIllustrationError('Failed to regenerate illustration. Please try again.')
     }
   }
 

--- a/src/app/tap-tap-adventure/hooks/useResolveDecisionMutation.ts
+++ b/src/app/tap-tap-adventure/hooks/useResolveDecisionMutation.ts
@@ -207,6 +207,8 @@ export function useResolveDecisionMutation() {
             if (combatData.updatedCharacter) {
               updateSelectedCharacter(combatData.updatedCharacter)
             }
+          } else {
+            console.error('[useResolveDecisionMutation] combat/start failed:', combatRes.status)
           }
           addStoryEvent({
             id: `result-${Date.now()}`,
@@ -352,6 +354,8 @@ export function useResolveDecisionMutation() {
         if (shopRes.ok) {
           const shopData = await shopRes.json()
           setShopState({ items: shopData.shopItems, isOpen: true, shopMount: shopData.shopMount ?? null })
+        } else {
+          console.error('[useResolveDecisionMutation] shop/generate failed:', shopRes.status)
         }
       }
 
@@ -402,6 +406,8 @@ export function useResolveDecisionMutation() {
           if (combatData.updatedCharacter) {
             updateSelectedCharacter(combatData.updatedCharacter)
           }
+        } else {
+          console.error('[useResolveDecisionMutation] combat/start failed:', combatRes.status)
         }
       }
 

--- a/src/app/trivia/winners/page.tsx
+++ b/src/app/trivia/winners/page.tsx
@@ -60,7 +60,10 @@ export default function WinnersPage() {
 
   useEffect(() => {
     fetch('/api/v1/trivia/weekly-winners')
-      .then((res) => res.json())
+      .then((res) => {
+        if (!res.ok) throw new Error(`HTTP ${res.status}`)
+        return res.json()
+      })
       .then((data) => {
         setWinners(data.winners ?? [])
         setLoading(false)


### PR DESCRIPTION
## Summary

Four related fetch-error-handling fixes across three features:

- **trivia daily route** (#2498): `res.ok` check before `.json()` on OpenTDB response — without it, a 5xx error page was parsed as JSON and threw `SyntaxError`, crashing the daily endpoint.
- **trivia winners page** (#2499): `res.ok` check before `.json()` — on HTTP error, the page was stuck in permanent loading state with no error message.
- **tap-tap-adventure combat/shop** (#2500): Added `console.error` when `combat/start` and `shop/generate` return non-2xx, so silent failures are now visible to developers.
- **storybook-factory regenerateIllustration** (#2501): HTTP errors and exceptions now call `setIllustrationError(...)`, giving users actionable feedback instead of a silent no-op.

## Test plan
- [ ] trivia daily: with OpenTDB returning an error, request returns gracefully (no 500)
- [ ] trivia winners: with API down, page shows no loading spinner after failure
- [ ] tap-tap-adventure: combat/shop failures appear in browser console
- [ ] storybook-factory: failed single-panel regenerate shows error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)