### PR TITLE
fix(comet-cards): log HTTP errors from sandbox validation persist PUT

### DIFF
--- a/src/app/comet-cards/sandbox/useValidations.ts
+++ b/src/app/comet-cards/sandbox/useValidations.ts
@@ -119,7 +119,7 @@ export function useValidations() {
       try {
         const token = await user.getIdToken()
         if (cancelled) return
-        await fetch(ENDPOINT, {
+        const res = await fetch(ENDPOINT, {
           method: 'PUT',
           headers: {
             'Content-Type': 'application/json',
@@ -127,6 +127,9 @@ export function useValidations() {
           },
           body: JSON.stringify({ state }),
         })
+        if (!res.ok) {
+          console.error('[sandbox] failed to persist validations: HTTP', res.status)
+        }
       } catch (err) {
         console.error('[sandbox] failed to persist validations:', err)
       }


### PR DESCRIPTION
## Summary

`useValidations.ts` line 122: `await fetch(ENDPOINT, { method: 'PUT', ... })` had no `res.ok` check. `fetch()` doesn't throw on non-2xx responses — so a 4xx or 5xx from the persist endpoint was silently swallowed. The `catch` block only catches network errors, not HTTP errors.

Now stores the response and logs when `!res.ok`, making server-side persist failures visible to developers.

Closes #2503

## Test plan
- [ ] With the persist endpoint returning 500, browser console shows `[sandbox] failed to persist validations: HTTP 500`
- [ ] On success, no change in behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)