### PR TITLE
fix(tap-tap-adventure): add dep array to CombatUI keyboard effect + log shop failure

### DIFF
--- a/src/app/tap-tap-adventure/components/CombatUI.tsx
+++ b/src/app/tap-tap-adventure/components/CombatUI.tsx
@@ -320,7 +320,7 @@ export function CombatUI({ combatState }: CombatUIProps) {
 
     window.addEventListener('keydown', handleKeyDown)
     return () => window.removeEventListener('keydown', handleKeyDown)
-  })
+  }, [status, isPending, playerState, combatState, canAttackAtDistance, classAbility, abilityCooldown, handleAction])
 
   const handleUseItem = useCallback(
     (itemId: string) => {

--- a/src/app/tap-tap-adventure/hooks/useMoveForwardMutation.ts
+++ b/src/app/tap-tap-adventure/hooks/useMoveForwardMutation.ts
@@ -96,6 +96,8 @@ export function useMoveForwardMutation() {
           setGenericMessage(null)
           setDecisionPoint(null)
           setShopState({ items: shopData.shopItems, isOpen: true, shopMount: shopData.shopMount ?? null })
+        } else {
+          console.error('[useMoveForwardMutation] shop/generate failed:', shopRes.status)
         }
       } else if (data.decisionPoint) {
         if (data.decisionPoint.isLegendary) {


### PR DESCRIPTION
## Summary

- **CombatUI keyboard useEffect** (#2507): The `useEffect` for keyboard shortcuts had no dependency array — it re-registered the `window.addEventListener` on every render, causing unnecessary DOM churn. Added a proper dep array covering all closed-over values: `[status, isPending, playerState, combatState, canAttackAtDistance, classAbility, abilityCooldown, handleAction]`.

- **useMoveForwardMutation shop failure** (#2508): When `shop/generate` returns non-2xx after a step milestone triggers a shop event, the failure was silently swallowed. Now logs `console.error`. Same pattern as the fix in #2502.

## Test plan
- [ ] Combat keyboard shortcuts (A/H/D/F/Q/E/Z/5) still work correctly during combat
- [ ] No excessive listener registration in React DevTools event listeners panel
- [ ] With shop API returning 500, browser console shows the error

🤖 Generated with [Claude Code](https://claude.com/claude-code)