### PR TITLE
fix(a11y): dialog roles for tap-tap modals + keyboard access for speck-wars overlays

### DIFF
--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -819,7 +819,11 @@ export function HUD() {
       {/* Help overlay */}
       {showHelp && (
         <div
+          role="button"
+          tabIndex={0}
+          aria-label="Close help"
           onClick={() => setShowHelp(false)}
+          onKeyDown={(e) => { if (e.key === 'Escape' || e.key === 'Enter' || e.key === ' ') setShowHelp(false) }}
           style={{
             position: 'absolute', inset: 0,
             background: 'rgba(0,0,0,0.7)',
@@ -1167,12 +1171,18 @@ export function HUD() {
 
       {/* Paused overlay */}
       {phase === 'paused' && (
-        <div onClick={togglePause} style={{
-          position: 'absolute', inset: 0,
-          background: 'rgba(0,0,0,0.55)',
-          display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', gap: 20,
-          cursor: 'pointer',
-        }}>
+        <div
+          role="button"
+          tabIndex={0}
+          aria-label="Resume game"
+          onClick={togglePause}
+          onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ' || e.key === 'Escape') togglePause() }}
+          style={{
+            position: 'absolute', inset: 0,
+            background: 'rgba(0,0,0,0.55)',
+            display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', gap: 20,
+            cursor: 'pointer',
+          }}>
           <span style={{ fontSize: 36, fontWeight: 'bold', letterSpacing: 4, opacity: 0.9 }}>
             PAUSED
           </span>

--- a/src/app/tap-tap-adventure/components/EventDialog.tsx
+++ b/src/app/tap-tap-adventure/components/EventDialog.tsx
@@ -68,6 +68,9 @@ export function EventDialog({
     >
       <div
         className="bg-[#1e1f30] border border-[#3a3c56] rounded-lg max-w-md w-full p-5 shadow-xl max-h-[80vh] overflow-y-auto"
+        role="dialog"
+        aria-modal="true"
+        aria-label="Event"
         onClick={e => e.stopPropagation()}
       >
         {/* Results step */}

--- a/src/app/tap-tap-adventure/components/MountNamingModal.tsx
+++ b/src/app/tap-tap-adventure/components/MountNamingModal.tsx
@@ -42,7 +42,12 @@ export function MountNamingModal({ mount, isOpen, onConfirm }: MountNamingModalP
       <div className="absolute inset-0 bg-black/60" onClick={handleSkip} />
 
       {/* Content */}
-      <div className="relative z-10 bg-gradient-to-b from-[#1e1f30] to-[#161723] border-2 border-amber-500/50 rounded-2xl px-8 py-6 text-center shadow-2xl shadow-amber-500/20 max-w-sm mx-4 w-full">
+      <div
+        className="relative z-10 bg-gradient-to-b from-[#1e1f30] to-[#161723] border-2 border-amber-500/50 rounded-2xl px-8 py-6 text-center shadow-2xl shadow-amber-500/20 max-w-sm mx-4 w-full"
+        role="dialog"
+        aria-modal="true"
+        aria-label="New Mount"
+      >
         <h2 className="text-2xl font-bold text-amber-400 mb-1">New Mount!</h2>
         <p className="text-slate-400 text-sm mb-5">Would you like to give it a name?</p>
 

--- a/src/app/tap-tap-adventure/components/TravelConfirmDialog.tsx
+++ b/src/app/tap-tap-adventure/components/TravelConfirmDialog.tsx
@@ -37,6 +37,9 @@ export function TravelConfirmDialog({ region, onConfirm, onCancel }: TravelConfi
     >
       <div
         className="bg-[#1e1f30] border border-[#3a3c56] rounded-lg max-w-sm w-full p-5 space-y-4 shadow-xl"
+        role="dialog"
+        aria-modal="true"
+        aria-label={`Travel to ${region.name}`}
         onClick={e => e.stopPropagation()}
       >
         {/* Header */}


### PR DESCRIPTION
## Summary

- **tap-tap-adventure modals** (#2510): `EventDialog`, `MountNamingModal`, and `TravelConfirmDialog` were missing `role="dialog"` and `aria-modal="true"`. Screen readers had no way to identify them as modals. Added both attributes plus `aria-label` to each inner content container.

- **speck-wars overlays** (#2511): The help overlay and paused overlay were `<div onClick={...}>` with no keyboard support. Keyboard-only users couldn't close the help screen or resume from pause. Added `role="button"`, `tabIndex={0}`, and `onKeyDown` handlers for Enter/Space/Escape.

## Test plan
- [ ] Screen reader (VoiceOver/NVDA) announces modal role when EventDialog opens
- [ ] Escape/Enter/Space closes the help overlay in speck-wars
- [ ] Escape/Enter/Space resumes from the pause overlay in speck-wars
- [ ] No visual changes to any of these surfaces

🤖 Generated with [Claude Code](https://claude.com/claude-code)