### PR TITLE
fix(trivia): guard answer.trim() with typeof string check in infinite run answer route

### DIFF
--- a/src/app/api/v1/trivia/infinite/runs/[runId]/answer/route.ts
+++ b/src/app/api/v1/trivia/infinite/runs/[runId]/answer/route.ts
@@ -23,7 +23,7 @@ export async function POST(
     }
 
     // Empty answer (timeout) is treated as incorrect — skip the judge
-    const isTimeout = !answer || answer.trim() === ''
+    const isTimeout = !answer || typeof answer !== 'string' || answer.trim() === ''
 
     // Load question
     const db = getFirestoreDb();


### PR DESCRIPTION
## Summary

`src/app/api/v1/trivia/infinite/runs/[runId]/answer/route.ts` line 26 called `answer.trim()` without verifying `answer` is a string. A malformed client sending `answer` as a number/object/array would cause a `TypeError`, returning a misleading 500 instead of treating the non-answer as a timeout.

Fixed by adding `typeof answer !== 'string'` to the isTimeout check.

Closes #2513

🤖 Generated with [Claude Code](https://claude.com/claude-code)