### PR TITLE
fix(avatar-maker, whowouldwininator): object URL leak, dropzone a11y, stale step closure

### DIFF
--- a/src/app/api/v1/trivia/infinite/runs/[runId]/answer/route.ts
+++ b/src/app/api/v1/trivia/infinite/runs/[runId]/answer/route.ts
@@ -23,7 +23,7 @@ export async function POST(
     }
 
     // Empty answer (timeout) is treated as incorrect — skip the judge
-    const isTimeout = !answer || answer.trim() === ''
+    const isTimeout = !answer || typeof answer !== 'string' || answer.trim() === ''
 
     // Load question
     const db = getFirestoreDb();

--- a/src/app/avatar-maker/page.tsx
+++ b/src/app/avatar-maker/page.tsx
@@ -174,6 +174,7 @@ const ALL_STYLES: string[] = Array.from(
 
 export default function AvatarMakerPage() {
   const [imageFile, setImageFile] = useState<File | null>(null)
+  const [imagePreviewUrl, setImagePreviewUrl] = useState<string | null>(null)
   const [prompt, setPrompt] = useState<string>('')
   const [generatedImages, setGeneratedImages] = useState<string[]>([])
   const [loading, setLoading] = useState(false)
@@ -193,6 +194,17 @@ export default function AvatarMakerPage() {
     isImageGenerationAllowedClient().then(setImageGenerationAllowed)
     getImageGenerationDisableReasonClient().then(setDisableReason)
   }, [])
+
+  // Manage object URL lifecycle — revoke previous URL when imageFile changes
+  useEffect(() => {
+    if (!imageFile) {
+      setImagePreviewUrl(null)
+      return
+    }
+    const url = URL.createObjectURL(imageFile)
+    setImagePreviewUrl(url)
+    return () => URL.revokeObjectURL(url)
+  }, [imageFile])
 
   // Style list becomes dependent on selected medium
   const styleOptions = medium && mediumStyles[medium] ? mediumStyles[medium].styles : ALL_STYLES
@@ -371,7 +383,11 @@ export default function AvatarMakerPage() {
 
               {/* Dropzone */}
               <div
+                role="button"
+                tabIndex={0}
+                aria-label="Upload image"
                 onClick={() => fileInputRef.current?.click()}
+                onKeyDown={e => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); fileInputRef.current?.click() } }}
                 onDragOver={e => e.preventDefault()}
                 onDrop={e => {
                   e.preventDefault()
@@ -388,9 +404,9 @@ export default function AvatarMakerPage() {
                   imageFile ? 'border-surface-variant' : 'border-outline-variant hover:border-ds-primary'
                 )}
               >
-                {imageFile ? (
+                {imagePreviewUrl ? (
                   <Image
-                    src={URL.createObjectURL(imageFile)}
+                    src={imagePreviewUrl}
                     alt="Uploaded preview"
                     className="rounded max-h-80 object-contain w-full"
                     width={320}

--- a/src/app/whowouldwininator/components/useWorkflow.tsx
+++ b/src/app/whowouldwininator/components/useWorkflow.tsx
@@ -4,11 +4,11 @@ export function useWorkflow() {
   const [currentStep, setCurrentStep] = useState(0)
 
   const nextStep = () => {
-    setCurrentStep(currentStep + 1)
+    setCurrentStep(prev => prev + 1)
   }
 
   const previousStep = () => {
-    setCurrentStep(currentStep - 1)
+    setCurrentStep(prev => prev - 1)
   }
 
   return {


### PR DESCRIPTION
## Summary
- **avatar-maker**: `URL.createObjectURL(imageFile)` was called in JSX on every render, leaking blob URLs forever. Now managed via `useEffect` so the previous URL is revoked whenever `imageFile` changes. Closes #2515
- **avatar-maker**: Upload dropzone `<div>` lacked `role="button"`, `tabIndex`, and `onKeyDown` — keyboard users couldn't trigger file selection. Fixed. Closes #2516
- **whowouldwininator**: `useWorkflow` `nextStep`/`previousStep` used stale closure (`currentStep + 1`). Switched to functional updater form (`prev => prev + 1`). Closes #2517

## Test plan
- [ ] Upload an image in avatar-maker — preview should appear and no new blob URLs should accumulate on re-render
- [ ] Tab to the upload dropzone and press Enter or Space — file picker should open
- [ ] Navigate through whowouldwininator steps — double-tapping Next/Previous should not skip steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)