### PR TITLE
fix(speck-wars): remove blur listener in InputHandler.destroy() to prevent memory leak

### DIFF
--- a/src/app/speck-wars/input/input-handler.ts
+++ b/src/app/speck-wars/input/input-handler.ts
@@ -134,7 +134,7 @@ export class InputHandler {
     window.addEventListener('touchend', this.onTouchEnd)
     window.addEventListener('keydown', this.onKeyDown)
     window.addEventListener('keyup', this.onKeyUp)
-    window.addEventListener('blur', () => this.heldKeys.clear())
+    window.addEventListener('blur', this.onBlur)
     this.canvas.addEventListener('mousemove', this.onCanvasMouseMove)
     this.canvas.addEventListener('mouseleave', this.onMouseLeave)
   }
@@ -144,6 +144,8 @@ export class InputHandler {
     this.mouseX = e.clientX - rect.left
     this.mouseY = e.clientY - rect.top
   }
+
+  private onBlur = () => this.heldKeys.clear()
 
   private onMouseLeave = () => { this.mouseX = -1; this.mouseY = -1 }
 
@@ -672,6 +674,7 @@ export class InputHandler {
     window.removeEventListener('touchend', this.onTouchEnd)
     window.removeEventListener('keydown', this.onKeyDown)
     window.removeEventListener('keyup', this.onKeyUp)
+    window.removeEventListener('blur', this.onBlur)
     this.canvas.removeEventListener('mousemove', this.onCanvasMouseMove)
     this.canvas.removeEventListener('mouseleave', this.onMouseLeave)
   }


### PR DESCRIPTION
## Summary
- Added `private onBlur = () => this.heldKeys.clear()` as a named class method
- Registered it by reference in `attach()` (replacing anonymous arrow function)
- Removed it by reference in `destroy()`

## Why
The anonymous blur listener in `attach()` had no stored reference, so `destroy()` could not remove it. Every `GameInstance` lifecycle (navigate away + back, React StrictMode double-mount) accumulated an orphaned `window` listener that kept the `InputHandler` alive in memory.

Closes #2539

🤖 Generated with [Claude Code](https://claude.com/claude-code)