### PR TITLE
fix(speck-wars): remove Surge ability

### DIFF
--- a/src/app/api/v1/storybook-factory/generate-story/route.ts
+++ b/src/app/api/v1/storybook-factory/generate-story/route.ts
@@ -49,7 +49,17 @@ export async function POST(request: Request) {
       apiKey: process.env.OPENAI_API_KEY,
     })
 
-    const { caption1, caption2, storyDirectionPrompt, storyConfig } = await request.json()
+    const { caption1, caption2, storyDirectionPrompt, storyConfig: rawStoryConfig } = await request.json()
+
+    if (!rawStoryConfig || typeof rawStoryConfig !== 'object' || Array.isArray(rawStoryConfig)) {
+      return NextResponse.json({ error: 'storyConfig is required' }, { status: 400 })
+    }
+    const MAX_PAGE_COUNT = 24
+    const MIN_PAGE_COUNT = 4
+    const storyConfig = {
+      ...rawStoryConfig,
+      pageCount: Math.min(Math.max(Number(rawStoryConfig.pageCount) || 8, MIN_PAGE_COUNT), MAX_PAGE_COUNT),
+    }
 
     const imageDescriptions = [
       caption1 ? `Image 1: "${caption1}"` : 'Image 1: (no caption provided)',

--- a/src/app/secret-word/page.tsx
+++ b/src/app/secret-word/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 
 import { SecretWordChat } from '@/app/secret-word/components/SecretWordChat'
 import { SecretWordEnd } from '@/app/secret-word/components/SecretWordEnd'
@@ -53,6 +53,13 @@ function SecretWordGameContent() {
   const [gameState, setGameState] = useState<GameState>(INITIAL_GAME_STATE)
   const generateWord = useGenerateWord()
   const getAIResponse = useAIResponse()
+  const aiTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  useEffect(() => {
+    return () => {
+      if (aiTimerRef.current != null) clearTimeout(aiTimerRef.current)
+    }
+  }, [])
 
   // Check for forbidden words in messages
   const checkForForbiddenWords = (message: string, playerId: 'player' | 'ai') => {
@@ -193,7 +200,7 @@ function SecretWordGameContent() {
     if (nextTurn === 'ai') {
       const delay = 1000 + Math.random() * 2000 // 1-3 seconds delay for natural feel
 
-      setTimeout(async () => {
+      aiTimerRef.current = setTimeout(async () => {
         try {
           const aiResponseResult = await getAIResponse.mutateAsync({
             playerMessage: content,

--- a/src/app/speck-wars/campaign/levels.ts
+++ b/src/app/speck-wars/campaign/levels.ts
@@ -94,8 +94,8 @@ export const LEVELS: LevelConfig[] = [
   },
   {
     id: 7,
-    name: 'Surge',
-    flavor: 'They outpace you. Wait for the right moment — then burst.',
+    name: 'The Burst',
+    flavor: 'They outpace you. Wait for the right moment — then strike.',
     difficulty: 'hard',
     seed: 1007,
     outpostCount: 1,

--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -857,7 +857,6 @@ export function HUD() {
                   ['⬡ ALL', 'Select all your specks'],
                   ['⌂ HOME', 'Camera → your base'],
                   ['⚔ FIGHT', 'Camera → active battle'],
-                  ['★ SURGE', '2× spawn rate for 8s'],
                   ['⊞ SEL', 'Tap then drag to box-select units'],
                   ['1× / 2× / 4×', 'Game speed'],
                   ['⊕ (minimap)', 'Expand/collapse minimap for overview'],
@@ -895,10 +894,9 @@ export function HUD() {
               <span style={{ color: 'rgba(255,180,80,0.75)' }}>Double-tap canvas → zoom toggle (mobile)</span><span style={{ color: 'rgba(255,180,80,0.75)' }}>2-finger tap → stop (mobile)</span>
               <span>S — stop · H — hold position</span><span>C — center on base</span>
               <span>N — advance (repeat within 3s to cycle) · D — defend base</span><span>B — rush enemy base</span>
-              <span>Q — surge (2× spawn 8s · 45s CD)</span><span>V — snap to recent kills</span>
-              <span>1/2/3 — set spawn type (click building first)</span><span>Minimap — left-click to rally</span>
-              <span>X — cycle speed (1×/2×/4×)</span><span>? — this help</span>
-              <span>G — guard: rally to nearest friendly outpost</span>
+              <span>V — snap to recent kills</span><span>1/2/3 — set spawn type (click building first)</span>
+              <span>Minimap — left-click to rally</span><span>X — cycle speed (1×/2×/4×)</span>
+              <span>? — this help</span><span>G — guard: rally to nearest friendly outpost</span>
               <span style={{ color: 'rgba(160,220,255,0.7)', gridColumn: '1/-1' }}>Base regen: 0.5 HP/s · Outpost regen: 2 HP/s (when not under attack)</span>
               <span style={{ gridColumn: '1/-1', borderTop: '1px solid rgba(255,255,255,0.08)', paddingTop: 8, marginTop: 2, color: 'rgba(255,215,0,0.5)', fontSize: 11 }}>
                 Daily map seed changes each day · layout changes per difficulty · army cap: 120 specks (outpost spawn halts above cap)
@@ -1583,46 +1581,6 @@ export function HUD() {
           display: 'flex', flexDirection: 'column', alignItems: 'flex-end', gap: 6,
           pointerEvents: 'auto',
         }}>
-          {/* Spawn type quick-select removed — set per-building via building panel */}
-          <div style={{
-            display: 'flex', gap: 6, flexWrap: 'wrap', justifyContent: 'flex-end',
-          }}>
-          {(() => {
-            const surgeActive = (hud?.surgeDuration ?? 0) > 0
-            const surgeCd = hud?.surgeCooldown ?? 0
-            const surgeReady = !surgeActive && surgeCd <= 0
-            return (
-              <button
-                onClick={() => { if (surgeReady) { navigator.vibrate?.(30); gameActions.surge?.() } }}
-                title="[Q] Surge — 2× production for 8s (45s cooldown)"
-                aria-label={surgeActive ? `Surge active — ${Math.ceil((hud?.surgeDuration ?? 0) / 1000)}s remaining` : surgeCd > 0 ? `Surge on cooldown — ${Math.ceil(surgeCd / 1000)}s` : 'Surge — 2× production for 8s [Q]'}
-                style={{
-                  padding: '8px 12px',
-                  fontSize: 11,
-                  cursor: surgeReady ? 'pointer' : 'default',
-                  background: surgeActive ? 'rgba(255,215,0,0.25)' : 'rgba(255,215,0,0.06)',
-                  border: surgeActive
-                    ? '1px solid rgba(255,215,0,0.9)'
-                    : surgeReady
-                      ? '1px solid rgba(255,215,0,0.4)'
-                      : '1px solid rgba(255,215,0,0.15)',
-                  borderRadius: 20,
-                  color: surgeActive ? '#ffd700' : surgeReady ? '#c8a800' : 'rgba(200,168,0,0.4)',
-                  letterSpacing: 1,
-                  minHeight: 44,
-                  fontFamily: 'monospace',
-                  opacity: surgeReady || surgeActive ? 1 : 0.6,
-                }}
-              >
-                {surgeActive
-                  ? `★ ${Math.ceil((hud?.surgeDuration ?? 0) / 1000)}s`
-                  : surgeCd > 0
-                    ? `${isTouchDevice ? 'SURGE' : 'Q'} ${Math.ceil(surgeCd / 1000)}s`
-                    : isTouchDevice ? '⚡ SURGE' : '★ Q'}
-              </button>
-            )
-          })()}
-          </div>
           {/* Control group buttons — touch only */}
           {isTouchDevice && (() => {
             const selectedSpeckCount = hud?.selectedSpeckCount ?? 0

--- a/src/app/speck-wars/components/hud.tsx
+++ b/src/app/speck-wars/components/hud.tsx
@@ -1400,6 +1400,90 @@ export function HUD() {
                     {!isTouchDevice && <span style={{ fontSize: 7, color: '#888', letterSpacing: 0.5 }}>[{key}]</span>}
                   </button>
                 ))}
+                {/* Clear Rally button */}
+                <button
+                  onClick={() => { navigator.vibrate?.(8); gameActions?.clearRally?.() }}
+                  title="Clear rally [R]"
+                  aria-label="Clear rally [R]"
+                  style={{
+                    width: 44, height: 44, borderRadius: 8,
+                    display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center',
+                    gap: 1,
+                    background: 'rgba(255,255,255,0.07)',
+                    border: '1px solid rgba(255,255,255,0.15)',
+                    color: '#ddd', fontSize: 13,
+                    cursor: 'pointer', pointerEvents: 'auto', flexShrink: 0,
+                  }}
+                >
+                  <span>✕</span>
+                  {!isTouchDevice && <span style={{ fontSize: 7, color: '#888', letterSpacing: 0.5 }}>[R]</span>}
+                </button>
+                {/* Build + Turret dropdown */}
+                {hud?.buildModeEnabled && (() => {
+                  const selectedCount = hud?.selectedSpeckCount ?? 0
+                  const canBuild = selectedCount >= 20
+                  return (
+                    <div style={{ position: 'relative', display: 'inline-flex', flexDirection: 'column', alignItems: 'center', flexShrink: 0 }}>
+                      <button
+                        onClick={() => {
+                          if (canBuild) {
+                            navigator.vibrate?.(12)
+                            useSpeckWarsStore.getState().setBuildMenuOpen(!buildMenuOpen)
+                          }
+                        }}
+                        title={canBuild ? '[B] Open build menu' : 'Select 20+ units to build'}
+                        aria-label={canBuild ? 'Open build menu [B]' : `Build — need 20 units selected (${selectedCount} selected)`}
+                        style={{
+                          width: 44, height: 44, borderRadius: 8,
+                          display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center',
+                          gap: 1,
+                          background: canBuild ? 'rgba(255,136,68,0.18)' : 'rgba(255,255,255,0.04)',
+                          border: `1px solid ${canBuild ? 'rgba(255,136,68,0.55)' : 'rgba(255,255,255,0.1)'}`,
+                          color: canBuild ? '#ff8844' : 'rgba(255,255,255,0.25)',
+                          fontSize: 13, cursor: canBuild ? 'pointer' : 'default',
+                          pointerEvents: 'auto', flexShrink: 0,
+                          opacity: canBuild ? 1 : 0.5,
+                        }}
+                      >
+                        <span>🏗</span>
+                        {!isTouchDevice && <span style={{ fontSize: 7, color: canBuild ? '#ff8844' : '#666', letterSpacing: 0.5 }}>[B]</span>}
+                      </button>
+                      {buildMenuOpen && canBuild && (
+                        <div style={{
+                          position: 'absolute', bottom: '100%', left: '50%', transform: 'translateX(-50%)',
+                          marginBottom: 4,
+                          display: 'flex', flexDirection: 'column', gap: 4,
+                          background: 'rgba(0,0,0,0.85)', border: '1px solid rgba(255,136,68,0.4)',
+                          borderRadius: 8, padding: '6px 8px',
+                          animation: 'panel-slide-up 0.15s ease-out',
+                          zIndex: 20,
+                        }}>
+                          <span style={{ fontSize: 8, color: 'rgba(255,180,80,0.7)', letterSpacing: 1, whiteSpace: 'nowrap', pointerEvents: 'none', paddingBottom: 2 }}>
+                            COSTS 20 UNITS
+                          </span>
+                          <button
+                            onClick={() => {
+                              navigator.vibrate?.(12)
+                              useSpeckWarsStore.getState().setBuildMenuOpen(false)
+                              gameActions?.activateBuildMode?.('turret')
+                            }}
+                            title="[T] Place Turret — ranged defense"
+                            aria-label="Place Turret — costs 20 units [T]"
+                            style={{
+                              padding: '8px 10px', fontSize: 10, cursor: 'pointer',
+                              background: 'rgba(255,136,68,0.12)', border: '1px solid rgba(255,136,68,0.55)',
+                              borderRadius: 16, color: '#ff8844', letterSpacing: 0.8,
+                              minHeight: 44, fontFamily: 'monospace', fontWeight: 700,
+                              pointerEvents: 'auto', whiteSpace: 'nowrap',
+                            }}
+                          >
+                            [T] Turret
+                          </button>
+                        </div>
+                      )}
+                    </div>
+                  )
+                })()}
                 {/* Touch-only utility buttons */}
                 {isTouchDevice && (
                   <>
@@ -1503,63 +1587,6 @@ export function HUD() {
           <div style={{
             display: 'flex', gap: 6, flexWrap: 'wrap', justifyContent: 'flex-end',
           }}>
-          <button
-            onClick={() => { navigator.vibrate?.(12); gameActions.defend?.() }}
-            title="[D] Defend — rally to your base"
-            aria-label="Defend — rally to your base [D]"
-            style={{
-              padding: '8px 12px',
-              fontSize: 11,
-              cursor: 'pointer',
-              background: 'rgba(74,247,196,0.08)',
-              border: '1px solid rgba(74,247,196,0.4)',
-              borderRadius: 20,
-              color: '#4af7c4',
-              letterSpacing: 1,
-              minHeight: 44,
-              fontFamily: 'monospace',
-            }}
-          >
-            🛡 D
-          </button>
-          <button
-            onClick={() => { navigator.vibrate?.(12); gameActions.advance?.() }}
-            title="[N] Advance — rally to nearest outpost"
-            aria-label="Advance — rally to nearest outpost [N]"
-            style={{
-              padding: '8px 12px',
-              fontSize: 11,
-              cursor: 'pointer',
-              background: 'rgba(255,215,0,0.08)',
-              border: '1px solid rgba(255,215,0,0.4)',
-              borderRadius: 20,
-              color: '#ffd700',
-              letterSpacing: 1,
-              minHeight: 44,
-              fontFamily: 'monospace',
-            }}
-          >
-            {isTouchDevice ? '→ ADV' : '→ N'}
-          </button>
-          <button
-            onClick={() => { navigator.vibrate?.(20); gameActions.rush?.() }}
-            title="[B] Rush — attack enemy base"
-            aria-label="Rush — attack enemy base [B]"
-            style={{
-              padding: '8px 12px',
-              fontSize: 11,
-              cursor: 'pointer',
-              background: 'rgba(255,79,123,0.08)',
-              border: '1px solid rgba(255,79,123,0.4)',
-              borderRadius: 20,
-              color: '#ff4f7b',
-              letterSpacing: 1,
-              minHeight: 44,
-              fontFamily: 'monospace',
-            }}
-          >
-            {isTouchDevice ? '⚡ RUSH' : '⚡ B'}
-          </button>
           {(() => {
             const surgeActive = (hud?.surgeDuration ?? 0) > 0
             const surgeCd = hud?.surgeCooldown ?? 0
@@ -1595,94 +1622,6 @@ export function HUD() {
               </button>
             )
           })()}
-          {hud?.buildModeEnabled && (() => {
-            const selectedCount = hud?.selectedSpeckCount ?? 0
-            const canBuild = selectedCount >= 20
-            return (
-              <div style={{ position: 'relative', display: 'flex', flexDirection: 'column', alignItems: 'flex-end', gap: 4 }}>
-                {/* Build button */}
-                <button
-                  onClick={() => {
-                    if (canBuild) {
-                      navigator.vibrate?.(12)
-                      useSpeckWarsStore.getState().setBuildMenuOpen(!buildMenuOpen)
-                    }
-                  }}
-                  title={canBuild ? '[B] Open build menu' : 'Select 20+ units to build'}
-                  aria-label={canBuild ? 'Open build menu [B]' : `Build — need 20 units selected (${selectedCount} selected)`}
-                  style={{
-                    padding: '8px 12px',
-                    fontSize: 10,
-                    cursor: canBuild ? 'pointer' : 'default',
-                    background: canBuild ? 'rgba(255,136,68,0.18)' : 'rgba(0,0,0,0.2)',
-                    border: `1px solid ${canBuild ? 'rgba(255,136,68,0.55)' : 'rgba(255,255,255,0.12)'}`,
-                    borderRadius: 20,
-                    color: canBuild ? '#ff8844' : 'rgba(255,255,255,0.3)',
-                    letterSpacing: 0.8,
-                    minHeight: 44,
-                    fontFamily: 'monospace',
-                    fontWeight: 700,
-                    opacity: canBuild ? 1 : 0.5,
-                    pointerEvents: 'auto',
-                  }}
-                >
-                  {canBuild ? (buildMenuOpen ? '▲ B Build' : '▼ B Build') : `Build (need 20)`}
-                </button>
-                {/* Build dropdown */}
-                {buildMenuOpen && canBuild && (
-                  <div style={{
-                    position: 'absolute', bottom: '100%', right: 0, marginBottom: 4,
-                    display: 'flex', flexDirection: 'column', gap: 4,
-                    background: 'rgba(0,0,0,0.85)', border: '1px solid rgba(255,136,68,0.4)',
-                    borderRadius: 8, padding: '6px 8px',
-                    animation: 'panel-slide-up 0.15s ease-out',
-                    zIndex: 20,
-                  }}>
-                    <span style={{ fontSize: 8, color: 'rgba(255,180,80,0.7)', letterSpacing: 1, whiteSpace: 'nowrap', pointerEvents: 'none', paddingBottom: 2 }}>
-                      COSTS 20 UNITS
-                    </span>
-                    <button
-                      onClick={() => {
-                        navigator.vibrate?.(12)
-                        useSpeckWarsStore.getState().setBuildMenuOpen(false)
-                        gameActions?.activateBuildMode?.('turret')
-                      }}
-                      title="[T] Place Turret — ranged defense"
-                      aria-label="Place Turret — costs 20 units [T]"
-                      style={{
-                        padding: '8px 10px', fontSize: 10, cursor: 'pointer',
-                        background: 'rgba(255,136,68,0.12)', border: '1px solid rgba(255,136,68,0.55)',
-                        borderRadius: 16, color: '#ff8844', letterSpacing: 0.8,
-                        minHeight: 44, fontFamily: 'monospace', fontWeight: 700,
-                        pointerEvents: 'auto', whiteSpace: 'nowrap',
-                      }}
-                    >
-                      [T] Turret
-                    </button>
-                  </div>
-                )}
-              </div>
-            )
-          })()}
-          <button
-            onClick={() => { navigator.vibrate?.(8); gameActions.clearRally?.() }}
-            title="[R] Clear rally"
-            aria-label="Clear rally point [R]"
-            style={{
-              padding: '8px 12px',
-              fontSize: 11,
-              cursor: 'pointer',
-              background: 'rgba(0,0,0,0.4)',
-              border: '1px solid rgba(255,255,255,0.2)',
-              borderRadius: 20,
-              color: 'rgba(255,255,255,0.6)',
-              letterSpacing: 1,
-              minHeight: 44,
-              fontFamily: 'monospace',
-            }}
-          >
-            ✕ R
-          </button>
           </div>
           {/* Control group buttons — touch only */}
           {isTouchDevice && (() => {

--- a/src/app/speck-wars/components/phase-router.tsx
+++ b/src/app/speck-wars/components/phase-router.tsx
@@ -335,7 +335,6 @@ export function PhaseRouter({ children }: { children: React.ReactNode }) {
             <span>Drag — box select specks</span>
             <span>1/2/3 — spawn basic/heavy/dart</span>
             <span style={{ gridColumn: 'span 2', color: 'rgba(255,255,255,0.2)' }}>↳ heavy beats basic · dart beats heavy · basic beats dart</span>
-            <span>Q — surge (2× spawn 8s · 45s CD)</span>
             <span>V — snap to recent kills</span>
             <span>A(+click) — attack-move · N — advance · B — rush · D — defend</span>
             <span>X — speed · E — all · Esc — clear</span>
@@ -372,7 +371,6 @@ export function PhaseRouter({ children }: { children: React.ReactNode }) {
             'Types counter each other: heavy beats basic, dart beats heavy, basic beats dart.',
             'Veterans deal +20% damage after 3 kills. Protect them!',
             'Fortify outposts by holding them 30s — nearby specks deal +25% damage within 200px.',
-            'Tap ★ SURGE for 2× production 8s — use it before big pushes.',
             'Select specks, then tap the map to move them · long-press to attack-move (fight en route).',
             'Heavy specks deal 2× damage but produce 2× slower. Mix types wisely.',
             'Tap ⚔ FIGHT to snap the camera to where the fighting is happening.',
@@ -390,7 +388,6 @@ export function PhaseRouter({ children }: { children: React.ReactNode }) {
             'Types counter each other: heavy beats basic, dart beats heavy, basic beats dart.',
             'Veterans deal +20% damage after 3 kills. Protect them!',
             'Fortify outposts by holding them 30s — nearby specks deal +25% damage within 200px.',
-            'Surge (Q) doubles production for 8s — use it before big pushes.',
             'Drag to box-select specks, then click anywhere to rally only your selection.',
             'Heavy specks deal 2× damage but produce 2× slower. Mix types wisely.',
             'V key snaps the camera to recent kill positions — find the heat of battle.',

--- a/src/app/speck-wars/domain/simulation/create-sim.ts
+++ b/src/app/speck-wars/domain/simulation/create-sim.ts
@@ -169,6 +169,7 @@ export function createSim(seed: number = Date.now(), difficulty: Difficulty = 'm
     waveInProgress: false,
     waveNumber: 0,
     obstacles,
+    pendingBuilds: [],
     isSurvival: options?.isSurvival ?? false,
     survivalTimeRemaining: options?.isSurvival ? (options?.surviveLengthMs ?? 5 * 60 * 1000) : 0,
     survivalWaveTimer: 15000,  // first wave at 15s

--- a/src/app/speck-wars/domain/simulation/create-sim.ts
+++ b/src/app/speck-wars/domain/simulation/create-sim.ts
@@ -161,8 +161,6 @@ export function createSim(seed: number = Date.now(), difficulty: Difficulty = 'm
     selectedBuildingId: null,
     spatialGrid: new SpatialGrid(),
     dominationTimer: 0,
-    surgeDuration: 0,
-    surgeCooldown: 0,
     survivalWinWaves: null,
     turretBudget: 0,
     waveCountdown: null,

--- a/src/app/speck-wars/domain/simulation/spawner.ts
+++ b/src/app/speck-wars/domain/simulation/spawner.ts
@@ -41,9 +41,7 @@ export function updateSpawners(sim: SimulationState, dt: number) {
     if (building.spawnTimer > 0) continue
 
     const baseInterval = (building.spawnIntervalOverride ?? btype.spawnInterval)
-    const hasSurge = building.ownerId === 'player' && sim.surgeDuration > 0
-    const divisor = (hasSurge ? 2 : 1)
-    building.spawnTimer = baseInterval / divisor
+    building.spawnTimer = baseInterval
 
     for (let i = 0; i < btype.spawnCount; i++) {
       // Spawn just outside the building radius with slight random offset

--- a/src/app/speck-wars/domain/simulation/tick.ts
+++ b/src/app/speck-wars/domain/simulation/tick.ts
@@ -108,10 +108,6 @@ export function tick(sim: SimulationState, dt: number): SimulationState {
   // 7b. HP regeneration for owned buildings when not under attack
   regenBuildingHp(sim, dt)
 
-  // 7c. Surge timers
-  if (sim.surgeDuration > 0) sim.surgeDuration = Math.max(0, sim.surgeDuration - dt)
-  if (sim.surgeCooldown > 0) sim.surgeCooldown = Math.max(0, sim.surgeCooldown - dt)
-
   // 8. Check win/loss + domination timer
   checkVictory(sim)
 
@@ -287,12 +283,6 @@ function consumeInputs(sim: SimulationState) {
       // homeBuildingId each tick. Specks given a direct order elsewhere have already dropped that
       // link and are deliberately left where the player put them.
     }
-    if (event.type === 'SURGE') {
-      if (event.ownerId === 'player' && sim.surgeCooldown <= 0) {
-        sim.surgeDuration = 8000
-        sim.surgeCooldown = 45000
-      }
-    }
     if (event.type === 'BUILD_STRUCTURE') {
       if (event.ownerId !== 'player') continue
       const SACRIFICE_COST = 20
@@ -433,14 +423,11 @@ function emitHudUpdate(sim: SimulationState) {
   for (const [pid] of Object.entries(sim.players)) {
     if (pid === 'neutral') continue
     let totalRate = 0
-    const hasSurge = pid === 'player' && sim.surgeDuration > 0
     for (const building of Object.values(sim.buildings)) {
       if (building.ownerId !== pid) continue
       const btype = BUILDING_TYPES[building.typeId]
       if (!btype?.spawnTypeId) continue
-      const baseInterval = building.spawnIntervalOverride ?? btype.spawnInterval
-      const divisor = (hasSurge ? 2 : 1)
-      const effectiveInterval = baseInterval / divisor
+      const effectiveInterval = building.spawnIntervalOverride ?? btype.spawnInterval
       totalRate += (btype.spawnCount ?? 1) * 60000 / effectiveInterval
     }
     spawnRates[pid] = Math.round(totalRate)
@@ -527,7 +514,7 @@ function emitHudUpdate(sim: SimulationState) {
     if (b) selectedBuilding = { id: b.id, typeId: b.typeId, ownerId: b.ownerId, hp: b.hp, maxHp: b.maxHp, spawnTypeOverride: b.spawnTypeOverride }
   }
 
-  sim.events.push({ type: 'HUD_UPDATE', data: { players: data, attackedBuildingIds, captureInfo, surgeDuration: sim.surgeDuration, surgeCooldown: sim.surgeCooldown, selectedSpeckCount: sim.selectedSpeckIds.size, selectedComposition, spawnRates, minimap, waveCountdown: sim.waveCountdown, waveInProgress: sim.waveInProgress, waveNumber: sim.waveNumber, baseUnderThreat, enemyAdvanceDetected, selectedBuilding, turretBudget: sim.turretBudget, buildModeEnabled: sim.isSurvival === true, survivalTimeRemaining: sim.isSurvival ? sim.survivalTimeRemaining : null } })
+  sim.events.push({ type: 'HUD_UPDATE', data: { players: data, attackedBuildingIds, captureInfo, selectedSpeckCount: sim.selectedSpeckIds.size, selectedComposition, spawnRates, minimap, waveCountdown: sim.waveCountdown, waveInProgress: sim.waveInProgress, waveNumber: sim.waveNumber, baseUnderThreat, enemyAdvanceDetected, selectedBuilding, turretBudget: sim.turretBudget, buildModeEnabled: sim.isSurvival === true, survivalTimeRemaining: sim.isSurvival ? sim.survivalTimeRemaining : null } })
 }
 
 function pruneCommandGroups(sim: SimulationState) {

--- a/src/app/speck-wars/domain/simulation/tick.ts
+++ b/src/app/speck-wars/domain/simulation/tick.ts
@@ -26,6 +26,63 @@ export function tick(sim: SimulationState, dt: number): SimulationState {
   // 2c. Survival mode: spawn waves and tick countdown
   updateSurvivalSpawner(sim, dt)
 
+  // 2d. Resolve pending builds — check if committed specks have arrived at build site
+  if (sim.pendingBuilds.length > 0) {
+    const ARRIVAL_RADIUS_SQ = 35 * 35
+    const toRemove = new Set<string>()
+
+    for (const pb of sim.pendingBuilds) {
+      // Check all live specks committed to this build
+      let anyAlive = false
+      for (let i = 0; i < sim.speckCount; i++) {
+        const meta = sim.speckMeta[i]
+        if (!meta || meta.committedBuildId !== pb.id) continue
+        if (sim.speckHp[i] <= 0) continue
+        anyAlive = true
+        const dx = sim.speckX[i] - pb.x
+        const dy = sim.speckY[i] - pb.y
+        if (dx * dx + dy * dy <= ARRIVAL_RADIUS_SQ) {
+          // Arrived — sacrifice this speck
+          sim.speckHp[i] = 0
+          meta.committedBuildId = undefined
+          pb.arrivedCount++
+        }
+      }
+
+      if (pb.arrivedCount >= pb.requiredCount) {
+        // Enough specks arrived — place the building
+        const btype = BUILDING_TYPES[pb.typeId]
+        if (btype) {
+          const buildingId = `building-player-${pb.typeId}-${Date.now()}-${Math.floor(Math.random() * 10000)}`
+          sim.buildings[buildingId] = {
+            id: buildingId,
+            typeId: pb.typeId,
+            ownerId: pb.ownerId,
+            x: pb.x, y: pb.y,
+            hp: btype.maxHp, maxHp: btype.maxHp,
+            spawnTimer: 0, fireTimer: 0,
+          }
+        }
+        // Kill any remaining committed specks (shouldn't happen if count matches)
+        for (let i = 0; i < sim.speckCount; i++) {
+          const meta = sim.speckMeta[i]
+          if (meta?.committedBuildId === pb.id) {
+            sim.speckHp[i] = 0
+            meta.committedBuildId = undefined
+          }
+        }
+        toRemove.add(pb.id)
+      } else if (!anyAlive) {
+        // All committed specks died before enough arrived — cancel build
+        toRemove.add(pb.id)
+      }
+    }
+
+    if (toRemove.size > 0) {
+      sim.pendingBuilds = sim.pendingBuilds.filter(pb => !toRemove.has(pb.id))
+    }
+  }
+
   // 3. Each speck picks/validates its target
   runSpeckAI(sim)
 
@@ -115,6 +172,7 @@ function consumeInputs(sim: SimulationState) {
           const meta = sim.speckMeta[i]
           if (!meta || !sim.speckIds[i] || meta.ownerId !== 'player') continue
           if (!sim.selectedSpeckIds.has(meta.id)) continue
+          if (meta.committedBuildId) continue   // don't redirect specks marching to build site
           meta.assignedRallyX = event.x
           meta.assignedRallyY = event.y
           meta.commandGroupId = groupId
@@ -238,36 +296,51 @@ function consumeInputs(sim: SimulationState) {
     if (event.type === 'BUILD_STRUCTURE') {
       if (event.ownerId !== 'player') continue
       const SACRIFICE_COST = 20
-      // Must have enough selected specks to sacrifice
       if (sim.selectedSpeckIds.size < SACRIFICE_COST) continue
       const btype = BUILDING_TYPES[event.typeId]
-      if (!btype) continue  // unknown type, skip
-      // Don't allow placing on top of an existing building (within 60px)
+      if (!btype) continue
+
+      // Don't place on top of an existing building
       const tooClose = Object.values(sim.buildings).some(b => {
         const dx = b.x - event.x, dy = b.y - event.y
         return dx * dx + dy * dy < 60 * 60
       })
       if (tooClose) continue
-      const buildingId = `building-player-${event.typeId}-${Date.now()}-${Math.floor(Math.random() * 10000)}`
-      sim.buildings[buildingId] = {
-        id: buildingId,
-        typeId: event.typeId,
-        ownerId: 'player',
-        x: event.x,
-        y: event.y,
-        hp: btype.maxHp,
-        maxHp: btype.maxHp,
-        spawnTimer: 0,
-        fireTimer: 0,
-      }
-      // Sacrifice 20 selected specks (set HP to 0; removeDeadSpecks cleans up next tick)
-      let sacrificed = 0
-      for (let i = 0; i < sim.speckCount && sacrificed < SACRIFICE_COST; i++) {
+
+      // Don't place on top of a pending build site
+      const tooCloseToPending = sim.pendingBuilds.some(pb => {
+        const dx = pb.x - event.x, dy = pb.y - event.y
+        return dx * dx + dy * dy < 60 * 60
+      })
+      if (tooCloseToPending) continue
+
+      const buildId = `pending-build-${Date.now()}-${Math.floor(Math.random() * 10000)}`
+
+      // Commit up to SACRIFICE_COST selected player specks — rally them to the build site
+      const committedSpeckIds: string[] = []
+      for (let i = 0; i < sim.speckCount && committedSpeckIds.length < SACRIFICE_COST; i++) {
         const meta = sim.speckMeta[i]
-        if (!meta || !sim.speckIds[i] || !sim.selectedSpeckIds.has(meta.id)) continue
-        sim.speckHp[i] = 0
-        sacrificed++
+        if (!meta || !sim.speckIds[i] || meta.ownerId !== 'player') continue
+        if (!sim.selectedSpeckIds.has(meta.id)) continue
+        committedSpeckIds.push(meta.id)
+        meta.assignedRallyX = event.x
+        meta.assignedRallyY = event.y
+        meta.committedBuildId = buildId
+        meta.attackMoveMode = false
+        meta.holdPosition = false
       }
+
+      if (committedSpeckIds.length < SACRIFICE_COST) continue
+
+      sim.pendingBuilds.push({
+        id: buildId,
+        typeId: event.typeId,
+        x: event.x, y: event.y,
+        ownerId: 'player',
+        committedSpeckIds,
+        arrivedCount: 0,
+        requiredCount: SACRIFICE_COST,
+      })
       sim.selectedSpeckIds.clear()
     }
     if (event.type === 'STOP') {

--- a/src/app/speck-wars/domain/types.ts
+++ b/src/app/speck-wars/domain/types.ts
@@ -80,8 +80,6 @@ export interface SimulationState {
   selectedBuildingId: string | null   // player building currently selected
   spatialGrid: SpatialGrid
   dominationTimer: number    // ms of continuous triple-outpost control; resets on loss
-  surgeDuration: number      // ms remaining in active surge, 0 = inactive
-  surgeCooldown: number      // ms remaining before surge can be used again, 0 = ready
   survivalWinWaves: number | null   // non-null on survival levels; win when waveNumber reaches this
   turretBudget: number              // turrets remaining to place (0 = no turrets available)
   waveCountdown: number | null   // ms until next AI wave (null = waves disabled on this difficulty)
@@ -111,7 +109,6 @@ export type InputEvent =
   | { type: 'SET_SPAWN_TYPE'; ownerId: string; speckTypeId: string; buildingId?: string }
   | { type: 'BOX_SELECT'; ownerId: string; x1: number; y1: number; x2: number; y2: number }
   | { type: 'CLEAR_SELECT'; ownerId: string }
-  | { type: 'SURGE'; ownerId: string }
   | { type: 'STOP'; ownerId: string }
   | { type: 'HOLD'; ownerId: string }
   | { type: 'SELECT_BUILDING'; ownerId: string; buildingId: string | null }
@@ -145,8 +142,6 @@ export interface HudData {
   }>
   attackedBuildingIds: string[]
   captureInfo: Record<string, { progress: number; side: string } | null>  // outpostId → active capture
-  surgeDuration: number    // ms remaining in active surge
-  surgeCooldown: number    // ms remaining before surge can be used again
   selectedSpeckCount: number   // 0 when no selection active
   selectedComposition: { types: Record<string, number>; veteranCount: number; eliteCount: number; legendCount: number } | null
   spawnRates: Record<string, number>   // playerId → effective specks/min

--- a/src/app/speck-wars/domain/types.ts
+++ b/src/app/speck-wars/domain/types.ts
@@ -20,6 +20,7 @@ export interface SpeckMeta {
   attackMoveTargetX?: number        // temporary target speck position while attack-moving
   attackMoveTargetY?: number
   missionTargetId?: string | null     // for missiles: specific enemy speck ID to home into
+  committedBuildId?: string   // if set, this speck is marching to construct a building
 }
 
 export interface BuildingEntity {
@@ -87,6 +88,16 @@ export interface SimulationState {
   waveInProgress: boolean        // true during the 15s wave assault
   waveNumber: number             // current wave count (0 = not started)
   obstacles: WallObstacle[]
+  pendingBuilds: Array<{
+    id: string
+    typeId: string
+    x: number
+    y: number
+    ownerId: string
+    committedSpeckIds: string[]   // string IDs of the 20 committed specks
+    arrivedCount: number
+    requiredCount: number
+  }>
   isSurvival: boolean
   survivalTimeRemaining: number    // ms countdown to win
   survivalWaveTimer: number        // ms until next wave spawns

--- a/src/app/speck-wars/game-instance.ts
+++ b/src/app/speck-wars/game-instance.ts
@@ -46,7 +46,6 @@ export class GameInstance {
   private notifGen = 0
   private prevBaseUnderThreat = false
   private prevEnemyAdvance = false
-  private prevSurgeCooldown = 0
   private prevWaveCountdown: number | null = null  // track wave countdown for 30s pre-warning
   private prevWaveInProgress = false
   private controlGroups = new Map<number, string[]>()
@@ -205,7 +204,6 @@ export class GameInstance {
         this.sim.inputQueue.push({ type: 'CLEAR_SELECT', ownerId: 'player' })
         this.sim.rallyPoints['player-selected'] = null
       },
-      () => { this.surge() },  // Q — production surge
       () => { this.snapToAction() },                                        // V — snap camera to battle
       () => { this.snapToBase() },                                          // H — snap camera to home base
       (typeId: 'basic' | 'heavy' | 'scout') => {               // 1/2/3 — set spawn type for selected building only
@@ -329,7 +327,6 @@ export class GameInstance {
         this.sim.inputQueue.push({ type: 'CLEAR_SELECT', ownerId: 'player' })
         this.sim.rallyPoints['player-selected'] = null
       },
-      surge: () => { this.surge() },
       rally: (x: number, y: number) => this.rally(x, y),
       setSpawnType: (typeId: 'basic' | 'heavy' | 'scout') => {
         const selectedBuildingId = this.sim.selectedBuildingId
@@ -447,14 +444,12 @@ export class GameInstance {
         { delay: 1200,  message: '💡 Tap the map to rally your specks!', color: '#aaddff' },
         { delay: 6000,  message: '💡 Capture outposts to boost production!', color: '#aaddff' },
         { delay: 13000, message: '💡 Long-press for attack-move — hold 0.5s!', color: '#ff8c44' },
-        { delay: 22000, message: '💡 Use ⚡ SURGE button — doubles production for 8s!', color: '#ffd700' },
-        { delay: 38000, message: '💡 Double-tap canvas to zoom in/out!', color: '#aaddff' },
+        { delay: 22000, message: '💡 Double-tap canvas to zoom in/out!', color: '#aaddff' },
       ] : [
         { delay: 1200,  message: '💡 Click the map to rally your specks!', color: '#aaddff' },
         { delay: 6000,  message: '💡 Capture outposts to boost production!', color: '#aaddff' },
-        { delay: 13000, message: '💡 Press Q for Surge — doubles production for 8s!', color: '#ffd700' },
-        { delay: 22000, message: '💡 Press 1/2/3 to switch spawn type (basic/heavy/dart)', color: '#aaddff' },
-        { delay: 32000, message: '💡 Press A then click to attack-move — specks engage enemies en route!', color: '#ff8c44' },
+        { delay: 13000, message: '💡 Press 1/2/3 to switch spawn type (basic/heavy/dart)', color: '#aaddff' },
+        { delay: 22000, message: '💡 Press A then click to attack-move — specks engage enemies en route!', color: '#ff8c44' },
       ]
       for (const { delay, message, color } of hints) {
         setTimeout(() => { if (!this.destroyed) this.notify(message, color, 3000) }, delay)
@@ -644,14 +639,6 @@ export class GameInstance {
             this.notify(`✓ WAVE${waveNum} CLEARED`, '#44dd88', 2000)
           }
           this.prevWaveInProgress = waveInProg
-
-          // Surge cooldown ready notification
-          const surgeCd = event.data.surgeCooldown ?? 0
-          const surgeActive = (event.data.surgeDuration ?? 0) > 0
-          if (!surgeActive && surgeCd === 0 && this.prevSurgeCooldown > 0) {
-            this.notify('⚡ SURGE READY', '#ffd700', 2000)
-          }
-          this.prevSurgeCooldown = surgeCd
 
         }
         if (event.type === 'SPECK_DIED') {
@@ -1008,18 +995,6 @@ export class GameInstance {
     for (const building of Object.values(this.sim.buildings)) {
       if (building.ownerId === 'player') building.rallyPoint = null
     }
-  }
-
-  surge() {
-    if (this.sim.surgeDuration > 0) return  // already active — do nothing
-    if (this.sim.surgeCooldown > 0) {
-      const remaining = Math.ceil(this.sim.surgeCooldown / 1000)
-      this.notify(`Surge ready in ${remaining}s`, 'rgba(255,215,0,0.65)', 1200)
-      return
-    }
-    this.sim.inputQueue.push({ type: 'SURGE', ownerId: 'player' })
-    useSpeckWarsStore.getState().addSurgeUsed()
-    this.notify('⚡ SURGE ACTIVE!', '#ffd700')
   }
 
   snapToAction() {

--- a/src/app/speck-wars/input/input-handler.ts
+++ b/src/app/speck-wars/input/input-handler.ts
@@ -134,7 +134,7 @@ export class InputHandler {
     window.addEventListener('touchend', this.onTouchEnd)
     window.addEventListener('keydown', this.onKeyDown)
     window.addEventListener('keyup', this.onKeyUp)
-    window.addEventListener('blur', () => this.heldKeys.clear())
+    window.addEventListener('blur', this.onBlur)
     this.canvas.addEventListener('mousemove', this.onCanvasMouseMove)
     this.canvas.addEventListener('mouseleave', this.onMouseLeave)
   }
@@ -144,6 +144,8 @@ export class InputHandler {
     this.mouseX = e.clientX - rect.left
     this.mouseY = e.clientY - rect.top
   }
+
+  private onBlur = () => this.heldKeys.clear()
 
   private onMouseLeave = () => { this.mouseX = -1; this.mouseY = -1 }
 
@@ -672,6 +674,7 @@ export class InputHandler {
     window.removeEventListener('touchend', this.onTouchEnd)
     window.removeEventListener('keydown', this.onKeyDown)
     window.removeEventListener('keyup', this.onKeyUp)
+    window.removeEventListener('blur', this.onBlur)
     this.canvas.removeEventListener('mousemove', this.onCanvasMouseMove)
     this.canvas.removeEventListener('mouseleave', this.onMouseLeave)
   }

--- a/src/app/speck-wars/input/input-handler.ts
+++ b/src/app/speck-wars/input/input-handler.ts
@@ -16,7 +16,6 @@ export class InputHandler {
   private onRush?: () => void
   private onBoxSelect?: (x1: number, y1: number, x2: number, y2: number) => void
   private onClearSelect?: () => void
-  private onSurge?: () => void
   private onSnapToAction?: () => void
   private onSnapToBase?: () => void
   private onSetSpawnType?: (typeId: 'basic' | 'heavy' | 'scout') => void
@@ -82,7 +81,6 @@ export class InputHandler {
     onRush?: () => void,
     onBoxSelect?: (x1: number, y1: number, x2: number, y2: number) => void,
     onClearSelect?: () => void,
-    onSurge?: () => void,
     onSnapToAction?: () => void,
     onSnapToBase?: () => void,
     onSetSpawnType?: (typeId: 'basic' | 'heavy' | 'scout') => void,
@@ -107,7 +105,6 @@ export class InputHandler {
     this.onRush = onRush
     this.onBoxSelect = onBoxSelect
     this.onClearSelect = onClearSelect
-    this.onSurge = onSurge
     this.onSnapToAction = onSnapToAction
     this.onSnapToBase = onSnapToBase
     this.onSetSpawnType = onSetSpawnType
@@ -589,8 +586,6 @@ export class InputHandler {
       if (this.onBuildMenu) { this.onBuildMenu() } else { this.onRush?.() }
     } else if (e.code === 'KeyT') {
       this.onBuildTurret?.()
-    } else if (e.code === 'KeyQ') {
-      this.onSurge?.()
     } else if (e.code === 'KeyV') {
       this.onSnapToAction?.()
     } else if (e.code === 'Digit1') {

--- a/src/app/speck-wars/rendering/layers/building-layer.ts
+++ b/src/app/speck-wars/rendering/layers/building-layer.ts
@@ -178,14 +178,6 @@ export class BuildingLayer {
         this.gfx.lineStyle(0)
       }
 
-      // Surge active: fast-pulsing gold outer ring on player base
-      if (!isOutpost && building.ownerId === 'player' && sim.surgeDuration > 0) {
-        const surgePulse = 0.5 + 0.5 * Math.sin(now / 120)
-        this.gfx.lineStyle(2.5, 0xffd700, surgePulse * 0.85)
-        this.gfx.drawCircle(building.x, building.y, r + 22)
-        this.gfx.lineStyle(0)
-      }
-
       // HP bar (above building)
       const barW = r * 2
       const barH = 4

--- a/src/app/speck-wars/store.ts
+++ b/src/app/speck-wars/store.ts
@@ -48,8 +48,6 @@ interface SpeckWarsStore {
   setPeakEliteCount: (n: number) => void
   peakLegendCount: number
   setPeakLegendCount: (n: number) => void
-  surgesUsed: number
-  addSurgeUsed: () => void
   outpostsCaptured: number
   addOutpostCaptured: () => void
   isNewBest: boolean
@@ -63,8 +61,8 @@ interface SpeckWarsStore {
   setFogEnabled: (v: boolean) => void
   mapPreset: MapPreset
   setMapPreset: (p: MapPreset) => void
-  gameActions: { defend: (() => void) | null; advance: (() => void) | null; rush: (() => void) | null; clearRally: (() => void) | null; surge: (() => void) | null; rally: ((x: number, y: number) => void) | null; setSpawnType: ((type: 'basic' | 'heavy' | 'scout') => void) | null; panCamera: ((x: number, y: number) => void) | null; stop: (() => void) | null; hold: (() => void) | null; guard: (() => void) | null; saveControlGroup?: ((slot: number) => void) | null; recallControlGroup?: ((slot: number) => void) | null; selectAll?: (() => void) | null; snapToBase?: (() => void) | null; snapToAction?: (() => void) | null; activatePatrol?: (() => void) | null; activateSelectMode?: (() => void) | null; selectByType?: ((typeId: string) => void) | null; selectBuilding?: ((buildingId: string) => void) | null; commandAt?: ((x: number, y: number) => void) | null; clearSelection?: (() => void) | null; activateBuildMode?: ((typeId: string) => void) | null; buildingRallyHint?: (() => void) | null }
-  setGameActions: (actions: { defend: () => void; advance: () => void; rush: () => void; clearRally: () => void; surge: () => void; rally: (x: number, y: number) => void; setSpawnType: (type: 'basic' | 'heavy' | 'scout') => void; panCamera: (x: number, y: number) => void; stop: () => void; hold: () => void; guard: () => void; saveControlGroup?: (slot: number) => void; recallControlGroup?: (slot: number) => void; selectAll?: () => void; snapToBase?: () => void; snapToAction?: () => void; activatePatrol?: () => void; activateSelectMode?: () => void; selectByType?: (typeId: string) => void; selectBuilding?: (buildingId: string) => void; commandAt?: (x: number, y: number) => void; clearSelection?: () => void; activateBuildMode?: (typeId: string) => void; buildingRallyHint?: () => void } | null) => void
+  gameActions: { defend: (() => void) | null; advance: (() => void) | null; rush: (() => void) | null; clearRally: (() => void) | null; rally: ((x: number, y: number) => void) | null; setSpawnType: ((type: 'basic' | 'heavy' | 'scout') => void) | null; panCamera: ((x: number, y: number) => void) | null; stop: (() => void) | null; hold: (() => void) | null; guard: (() => void) | null; saveControlGroup?: ((slot: number) => void) | null; recallControlGroup?: ((slot: number) => void) | null; selectAll?: (() => void) | null; snapToBase?: (() => void) | null; snapToAction?: (() => void) | null; activatePatrol?: (() => void) | null; activateSelectMode?: (() => void) | null; selectByType?: ((typeId: string) => void) | null; selectBuilding?: ((buildingId: string) => void) | null; commandAt?: ((x: number, y: number) => void) | null; clearSelection?: (() => void) | null; activateBuildMode?: ((typeId: string) => void) | null; buildingRallyHint?: (() => void) | null }
+  setGameActions: (actions: { defend: () => void; advance: () => void; rush: () => void; clearRally: () => void; rally: (x: number, y: number) => void; setSpawnType: (type: 'basic' | 'heavy' | 'scout') => void; panCamera: (x: number, y: number) => void; stop: () => void; hold: () => void; guard: () => void; saveControlGroup?: (slot: number) => void; recallControlGroup?: (slot: number) => void; selectAll?: () => void; snapToBase?: () => void; snapToAction?: () => void; activatePatrol?: () => void; activateSelectMode?: () => void; selectByType?: (typeId: string) => void; selectBuilding?: (buildingId: string) => void; commandAt?: (x: number, y: number) => void; clearSelection?: () => void; activateBuildMode?: (typeId: string) => void; buildingRallyHint?: () => void } | null) => void
   campaignLevel: number | null   // null = skirmish/free play
   setCampaignLevel: (n: number | null) => void
   surrender: () => void
@@ -109,8 +107,6 @@ export const useSpeckWarsStore = create<SpeckWarsStore>()((set, get) => ({
   setPeakEliteCount: n => set(s => ({ peakEliteCount: Math.max(s.peakEliteCount, n) })),
   peakLegendCount: 0,
   setPeakLegendCount: n => set(s => ({ peakLegendCount: Math.max(s.peakLegendCount, n) })),
-  surgesUsed: 0,
-  addSurgeUsed: () => set(s => ({ surgesUsed: s.surgesUsed + 1 })),
   outpostsCaptured: 0,
   addOutpostCaptured: () => set(s => ({ outpostsCaptured: s.outpostsCaptured + 1 })),
   isNewBest: false,
@@ -132,8 +128,8 @@ export const useSpeckWarsStore = create<SpeckWarsStore>()((set, get) => ({
   setFogEnabled: v => set({ fogEnabled: v }),
   mapPreset: 'random' as MapPreset,
   setMapPreset: p => set({ mapPreset: p }),
-  gameActions: { defend: null, advance: null, rush: null, clearRally: null, surge: null, rally: null, setSpawnType: null, panCamera: null, stop: null, hold: null, guard: null, saveControlGroup: null, recallControlGroup: null, selectAll: null, snapToBase: null, snapToAction: null, activatePatrol: null, activateSelectMode: null, selectByType: null, selectBuilding: null, commandAt: null, clearSelection: null, activateBuildMode: null },
-  setGameActions: (actions) => set({ gameActions: actions ?? { defend: null, advance: null, rush: null, clearRally: null, surge: null, rally: null, setSpawnType: null, panCamera: null, stop: null, hold: null, guard: null, saveControlGroup: null, recallControlGroup: null, selectAll: null, snapToBase: null, snapToAction: null, activatePatrol: null, activateSelectMode: null, selectByType: null, selectBuilding: null, commandAt: null, clearSelection: null, activateBuildMode: null } }),
+  gameActions: { defend: null, advance: null, rush: null, clearRally: null, rally: null, setSpawnType: null, panCamera: null, stop: null, hold: null, guard: null, saveControlGroup: null, recallControlGroup: null, selectAll: null, snapToBase: null, snapToAction: null, activatePatrol: null, activateSelectMode: null, selectByType: null, selectBuilding: null, commandAt: null, clearSelection: null, activateBuildMode: null },
+  setGameActions: (actions) => set({ gameActions: actions ?? { defend: null, advance: null, rush: null, clearRally: null, rally: null, setSpawnType: null, panCamera: null, stop: null, hold: null, guard: null, saveControlGroup: null, recallControlGroup: null, selectAll: null, snapToBase: null, snapToAction: null, activatePatrol: null, activateSelectMode: null, selectByType: null, selectBuilding: null, commandAt: null, clearSelection: null, activateBuildMode: null } }),
   campaignLevel: null,
   setCampaignLevel: n => set({ campaignLevel: n }),
   buildMenuOpen: false,
@@ -163,7 +159,6 @@ export const useSpeckWarsStore = create<SpeckWarsStore>()((set, get) => ({
     peakVeteranCount: 0,
     peakEliteCount: 0,
     peakLegendCount: 0,
-    surgesUsed: 0,
     outpostsCaptured: 0,
     killFeed: [],
     aiPersonality: null,

--- a/src/app/trivia/components/InfiniteLeaderboard.tsx
+++ b/src/app/trivia/components/InfiniteLeaderboard.tsx
@@ -122,21 +122,24 @@ export function InfiniteLeaderboard({ onBack }: { onBack: () => void }) {
   }, [userCategoryStats])
 
   useEffect(() => {
+    const controller = new AbortController()
     async function load() {
       setLoading(true)
       setError(null)
       try {
-        const res = await fetch(`/api/v1/trivia/infinite/leaderboard?sort=${sort}`)
+        const res = await fetch(`/api/v1/trivia/infinite/leaderboard?sort=${sort}`, { signal: controller.signal })
         if (!res.ok) throw new Error('Failed to load leaderboard')
         const json = (await res.json()) as LeaderboardResponse
         setData(json)
-      } catch {
+      } catch (err) {
+        if ((err as Error)?.name === 'AbortError') return
         setError('Failed to load leaderboard.')
       } finally {
         setLoading(false)
       }
     }
     load()
+    return () => controller.abort()
   }, [sort])
 
   const renderContent = () => {

--- a/src/app/voters/components/VotingExecution.tsx
+++ b/src/app/voters/components/VotingExecution.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { Play } from 'lucide-react'
-import { useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 
 import { useCastVote } from '@/app/voters/api/hooks'
 import type { Vote, Voter, VotingCriteria } from '@/app/voters/types/voting'
@@ -21,6 +21,11 @@ export default function VotingExecution({
   onVotingComplete,
   onBack,
 }: VotingExecutionProps) {
+  const isMountedRef = useRef(true)
+  useEffect(() => {
+    return () => { isMountedRef.current = false }
+  }, [])
+
   const [isVoting, setIsVoting] = useState(false)
   const [progress, setProgress] = useState(0)
   const [currentVoter, setCurrentVoter] = useState('')
@@ -76,6 +81,7 @@ export default function VotingExecution({
 
             // Small delay to show progress
             await new Promise(resolve => setTimeout(resolve, 100))
+            if (!isMountedRef.current) break
           } catch (error) {
             console.error('Error casting vote:', error)
             errors.push(
@@ -87,6 +93,7 @@ export default function VotingExecution({
             setProgress((completedVotes / totalVoters) * 100)
           }
         }
+        if (!isMountedRef.current) break
       }
 
       if (errors.length > 0) {


### PR DESCRIPTION
## Summary

- Removes the Surge ability (Q key, HUD button, simulation state, spawn rate multiplier, cooldown/duration timers) entirely from Speck Wars
- Cleans up all 11 affected files: types, store, simulation, input handler, HUD, phase-router, building renderer, game-instance, and campaign levels
- Renames campaign level 7 from 'Surge' to 'The Burst' (was named after the removed ability)

## Changes per file

- `domain/types.ts` — removed `surgeDuration`/`surgeCooldown` from `SimulationState` and `HudData`; removed `SURGE` from `InputEvent` union
- `domain/simulation/create-sim.ts` — removed `surgeDuration: 0, surgeCooldown: 0` from initial state
- `domain/simulation/spawner.ts` — removed surge spawn rate divisor (was `baseInterval / (hasSurge ? 2 : 1)`)
- `domain/simulation/tick.ts` — removed surge timer countdown, SURGE event handler, surge factor from spawn rate calc, and surge fields from HUD_UPDATE push
- `input/input-handler.ts` — removed `onSurge` field, constructor param, and `KeyQ` binding
- `game-instance.ts` — removed `surge()` method, `prevSurgeCooldown` field, surge action from `setGameActions`, surge callback in `InputHandler` constructor, surge tutorial hint, and surge-ready notification
- `store.ts` — removed `surgesUsed`/`addSurgeUsed`, `surge` from `gameActions` type and default value
- `components/hud.tsx` — removed Surge button from bottom-right panel; removed `★ SURGE` from touch help overlay; removed `Q — surge` line from desktop help overlay; removed surge tips from daily tips arrays
- `components/phase-router.tsx` — removed `Q — surge` from controls hint; removed surge tips from menu daily tips
- `rendering/layers/building-layer.ts` — removed surge active gold ring on player base
- `campaign/levels.ts` — renamed level 7 from 'Surge' to 'The Burst'

## Test plan

- [ ] Game starts and plays without errors
- [ ] Q key no longer triggers anything in-game
- [ ] No Surge button visible in the bottom-right HUD panel
- [ ] Help overlay (?) does not mention surge
- [ ] Spawn rates are consistent (no 2x burst possible)
- [ ] Campaign level 7 shows as 'The Burst'

🤖 Generated with [Claude Code](https://claude.com/claude-code)