### PR TITLE
feat(micro-land): a tiny living world — terrain, creatures, and AI summoning

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -78,6 +78,12 @@ const eslintConfig = [
     ignores: [
       'src/app/globals.css',
       'src/app/ring-toss/**',
+      // Micro Land's creature palettes, tile materials and terrain themes are
+      // pixel-art asset data, not themeable chrome — a creature's colors are
+      // part of the creature, and summoned ones carry their own palette from
+      // the model. Its React components are NOT exempt and use tokens.
+      'src/app/micro-land/domain/**',
+      'src/app/micro-land/rendering/**',
       'src/**/*.test.*',
       'src/**/*.spec.*',
       'src/**/*.stories.*',

--- a/package-lock.json
+++ b/package-lock.json
@@ -82,6 +82,7 @@
         "tailwindcss-animate": "^1.0.7",
         "vaul": "^0.9.6",
         "zod": "^3.24.3",
+        "zod-to-json-schema": "^3.24.5",
         "zustand": "^5.0.3"
       },
       "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -82,7 +82,6 @@
         "tailwindcss-animate": "^1.0.7",
         "vaul": "^0.9.6",
         "zod": "^3.24.3",
-        "zod-to-json-schema": "^3.24.5",
         "zustand": "^5.0.3"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -99,7 +99,6 @@
     "tailwindcss-animate": "^1.0.7",
     "vaul": "^0.9.6",
     "zod": "^3.24.3",
-    "zod-to-json-schema": "^3.24.5",
     "zustand": "^5.0.3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "eval:trivia": "tsx --env-file=.env.local scripts/eval-trivia.ts",
     "eval:trivia:smoke": "tsx --env-file=.env.local scripts/eval-trivia.ts --smoke",
     "seed-ai-questions": "tsx --env-file=.env.local scripts/seed-ai-questions.ts",
+    "sim:micro-land": "tsx scripts/micro-land-sim.ts",
     "migrate:daily-trivia": "tsx --env-file=.env.local scripts/migrate-daily-trivia-to-firestore.ts"
   },
   "dependencies": {
@@ -98,6 +99,7 @@
     "tailwindcss-animate": "^1.0.7",
     "vaul": "^0.9.6",
     "zod": "^3.24.3",
+    "zod-to-json-schema": "^3.24.5",
     "zustand": "^5.0.3"
   },
   "devDependencies": {

--- a/scripts/micro-land-sim.ts
+++ b/scripts/micro-land-sim.ts
@@ -1,0 +1,208 @@
+/**
+ * Headless Micro Land harness.
+ *
+ * The world is only interesting if populations rise and fall instead of
+ * flatlining at zero, and you cannot see that in a screenshot — a browser tells
+ * you what one instant looks like, not whether the ecosystem survives ten
+ * minutes. This runs the real simulation with no canvas and prints the
+ * population over time.
+ *
+ * Usage:
+ *   npx tsx scripts/micro-land-sim.ts                       # earth, 300s
+ *   npx tsx scripts/micro-land-sim.ts --theme tidepool --seconds 600
+ *   npx tsx scripts/micro-land-sim.ts --runs 5              # average of 5 seeds
+ */
+import { THEMES, THEME_BY_ID } from '@/app/micro-land/domain/config/themes'
+import { TICK_S } from '@/app/micro-land/domain/constants'
+import { type SimEvent, tickCreatures } from '@/app/micro-land/domain/sim/creature-sim'
+import { makeRng } from '@/app/micro-land/domain/sim/prng'
+import { tickTiles } from '@/app/micro-land/domain/sim/tile-sim'
+import {
+  applyTheme,
+  countByBlueprint,
+  createWorld,
+  seedStarters,
+} from '@/app/micro-land/domain/sim/world'
+
+function arg(name: string, fallback: string): string {
+  const i = process.argv.indexOf(`--${name}`)
+  return i >= 0 && process.argv[i + 1] ? process.argv[i + 1] : fallback
+}
+
+const themeId = arg('theme', 'earth')
+const seconds = Number(arg('seconds', '300'))
+const runs = Number(arg('runs', '1'))
+const quiet = process.argv.includes('--quiet')
+
+if (!THEME_BY_ID[themeId]) {
+  console.error(`Unknown theme "${themeId}". Try: ${THEMES.map((t) => t.id).join(', ')}`)
+  process.exit(1)
+}
+
+interface RunResult {
+  survivors: Record<string, number>
+  extinctions: string[]
+  peak: number
+  minAfterSettle: number
+  /** blueprintId → cause → count. The only way to tell starvation from lava. */
+  deaths: Record<string, Record<string, number>>
+  /** blueprintId → { plants, animals } eaten. Predation you can actually see. */
+  meals: Record<string, { plants: number; animals: number }>
+  /** Share of the world still made of something, 0..1. */
+  solidFraction: number
+  /** Tiles tunnelled through by creatures still alive at the end. */
+  dug: number
+}
+
+function runOnce(seed: number): RunResult {
+  const world = createWorld(seed)
+  const rng = makeRng(seed ^ 0x9e3779b9)
+  applyTheme(world, themeId, seed)
+  seedStarters(world, themeId, rng)
+
+  const theme = THEME_BY_ID[themeId]
+  const seeded = new Set(Object.keys(countByBlueprint(world)))
+
+  const totalTicks = Math.floor(seconds / TICK_S)
+  const sampleEvery = Math.floor(totalTicks / 10)
+  let tileCounter = 0
+  let peak = world.creatures.length
+  let minAfterSettle = Infinity
+  const deaths: Record<string, Record<string, number>> = {}
+  const meals: Record<string, { plants: number; animals: number }> = {}
+
+  if (!quiet) {
+    console.log(`\n── ${theme.name} · seed ${seed} ─────────────────────────`)
+    console.log(`t=0s   ${format(countByBlueprint(world), world)}`)
+  }
+
+  for (let tick = 1; tick <= totalTicks; tick++) {
+    const events: SimEvent[] = []
+    world.elapsed += TICK_S
+    if (++tileCounter >= 3) {
+      tileCounter = 0
+      tickTiles(world)
+    }
+    tickCreatures(world, TICK_S, rng, theme.gravity, events)
+
+    for (const e of events) {
+      if (e.kind === 'born') continue
+      if (e.kind === 'ate') {
+        // A meal is not a death — it's the hunter's side of someone else's.
+        meals[e.blueprintId] ??= { plants: 0, animals: 0 }
+        const victim = e.victimId ? world.blueprints[e.victimId] : undefined
+        if (victim?.move.kind === 'root') meals[e.blueprintId].plants++
+        else meals[e.blueprintId].animals++
+        continue
+      }
+      deaths[e.blueprintId] ??= {}
+      deaths[e.blueprintId][e.kind] = (deaths[e.blueprintId][e.kind] ?? 0) + 1
+    }
+
+    peak = Math.max(peak, world.creatures.length)
+    // Ignore the first 20s — the opening scramble is not the steady state.
+    if (world.elapsed > 20) {
+      minAfterSettle = Math.min(minAfterSettle, world.creatures.length)
+    }
+
+    if (!quiet && sampleEvery > 0 && tick % sampleEvery === 0) {
+      console.log(
+        `t=${Math.round(world.elapsed)}s`.padEnd(7) +
+          format(countByBlueprint(world), world)
+      )
+    }
+  }
+
+  // How much of the map got eaten by diggers? A tunnel network is the point;
+  // a world with no walls left is a bug.
+  let solidLeft = 0
+  for (let i = 0; i < world.tiles.length; i++) if (world.tiles[i] !== 0) solidLeft++
+  const dug = world.creatures.reduce((a, c) => a + c.tilesDug, 0)
+
+  const survivors = countByBlueprint(world)
+  const extinctions = [...seeded].filter((id) => !survivors[id])
+
+  return {
+    survivors,
+    extinctions,
+    peak,
+    minAfterSettle: minAfterSettle === Infinity ? 0 : minAfterSettle,
+    deaths,
+    meals,
+    solidFraction: solidLeft / world.tiles.length,
+    dug,
+  }
+}
+
+function format(counts: Record<string, number>, world: ReturnType<typeof createWorld>) {
+  const parts = Object.entries(counts)
+    .sort((a, b) => b[1] - a[1])
+    .map(([id, n]) => `${world.blueprints[id]?.name ?? id}:${n}`)
+  return `total=${world.creatures.length.toString().padEnd(4)} ${parts.join('  ') || '(empty)'}`
+}
+
+const results: RunResult[] = []
+for (let i = 0; i < runs; i++) results.push(runOnce(1000 + i * 7919))
+
+console.log(`\n══ Summary over ${runs} run(s), ${seconds}s each ══════════`)
+
+const allSpecies = new Set<string>()
+for (const r of results) {
+  for (const id of Object.keys(r.survivors)) allSpecies.add(id)
+  for (const id of r.extinctions) allSpecies.add(id)
+}
+
+for (const id of [...allSpecies].sort()) {
+  const counts = results.map((r) => r.survivors[id] ?? 0)
+  const avg = counts.reduce((a, b) => a + b, 0) / runs
+  const extinctIn = results.filter((r) => r.extinctions.includes(id)).length
+  const flag = extinctIn === runs ? '  ← EXTINCT in every run' : extinctIn > 0 ? `  ← extinct in ${extinctIn}/${runs}` : ''
+
+  // Aggregate causes of death so a collapse can be attributed, not guessed at.
+  const causes: Record<string, number> = {}
+  for (const r of results) {
+    for (const [cause, n] of Object.entries(r.deaths[id] ?? {})) {
+      causes[cause] = (causes[cause] ?? 0) + n
+    }
+  }
+  const causeText = Object.entries(causes)
+    .sort((a, b) => b[1] - a[1])
+    .map(([cause, n]) => `${cause} ${Math.round(n / runs)}`)
+    .join(', ')
+  let plants = 0
+  let animals = 0
+  for (const r of results) {
+    plants += r.meals[id]?.plants ?? 0
+    animals += r.meals[id]?.animals ?? 0
+  }
+
+  console.log(`  ${id.padEnd(16)} avg ${avg.toFixed(1).padStart(6)}${flag}`)
+  if (causeText) console.log(`  ${''.padEnd(16)} died: ${causeText}`)
+  if (plants + animals > 0) {
+    console.log(
+      `  ${''.padEnd(16)} ate: ${Math.round(plants / runs)} plants, ` +
+        `${Math.round(animals / runs)} animals`
+    )
+  }
+}
+
+const avgPeak = results.reduce((a, r) => a + r.peak, 0) / runs
+const avgMin = results.reduce((a, r) => a + r.minAfterSettle, 0) / runs
+const totalAlive = results.reduce(
+  (a, r) => a + Object.values(r.survivors).reduce((x, y) => x + y, 0),
+  0
+)
+console.log(`\n  peak population   ${avgPeak.toFixed(0)}`)
+console.log(`  low water mark    ${avgMin.toFixed(0)}`)
+console.log(`  alive at the end  ${(totalAlive / runs).toFixed(0)}`)
+console.log(
+  `  world still solid ${((results.reduce((a, r) => a + r.solidFraction, 0) / runs) * 100).toFixed(0)}%`
+)
+console.log(
+  `  tunnelled (live)  ${(results.reduce((a, r) => a + r.dug, 0) / runs).toFixed(0)} tiles`
+)
+console.log(
+  totalAlive === 0
+    ? '\n  ✗ Everything died. The world is not self-sustaining.\n'
+    : '\n  ✓ Still alive.\n'
+)

--- a/src/app/api/v1/micro-land/summon/route.ts
+++ b/src/app/api/v1/micro-land/summon/route.ts
@@ -188,7 +188,7 @@ export async function POST(request: NextRequest) {
     typeof body.prompt === 'string' ? body.prompt.trim().slice(0, MAX_PROMPT) : ''
 
   if (description.length < 2) {
-    return NextResponse.json({ error: 'Tell me what to summon first.' }, { status: 400 })
+    return NextResponse.json({ error: 'Tell me what to generate first.' }, { status: 400 })
   }
 
   const apiKey = process.env.ANTHROPIC_API_KEY

--- a/src/app/api/v1/micro-land/summon/route.ts
+++ b/src/app/api/v1/micro-land/summon/route.ts
@@ -1,0 +1,275 @@
+/**
+ * Summoning.
+ *
+ * A player describes something; the model fills in the blueprint object literal
+ * and this route hands it back. The zod schema in `blueprint.ts` is converted
+ * straight into the tool's `input_schema`, so the contract the model is held to
+ * and the contract the simulation reads are the same object — there is no
+ * translation layer to drift.
+ *
+ * Three modes:
+ *   creature — one fully specified creature
+ *   terrain  — the land itself, drawn as a coarse character map
+ *   scene    — a land *and* the creatures that live in it, designed together
+ *
+ * This calls the Messages API directly rather than going through the AI SDK's
+ * `generateObject`, which hard-codes `temperature: 0` (ai@4 —
+ * `temperature != null ? temperature : 0`, no way to omit it). Claude Opus 5
+ * removed the sampling parameters and rejects the request outright, so the SDK
+ * path can only reach this model by downgrading it.
+ *
+ * If anything goes wrong — no key, model error, refusal, malformed art — this
+ * falls back to a procedural creature instead of an error. A kid asking for a
+ * purple fire snail should always get a purple fire snail.
+ */
+import { type NextRequest, NextResponse } from 'next/server'
+import { z } from 'zod'
+import { zodToJsonSchema } from 'zod-to-json-schema'
+
+import { BlueprintSchema, SceneSchema } from '@/app/micro-land/domain/blueprint'
+import { MATERIAL_IDS } from '@/app/micro-land/domain/config/materials'
+import {
+  proceduralCreature,
+  proceduralScene,
+} from '@/app/micro-land/domain/procedural'
+import { TerrainSchema } from '@/app/micro-land/domain/terrain'
+
+const MODEL = 'claude-opus-5'
+const API_URL = 'https://api.anthropic.com/v1/messages'
+const MAX_PROMPT = 300
+
+/** A scene is several blueprints in one response, so it needs more room. */
+const MAX_TOKENS = { creature: 16000, scene: 32000, terrain: 16000 }
+
+type Mode = 'creature' | 'scene' | 'terrain'
+
+/** Scenes can take a while — give the platform room before it cuts us off. */
+export const maxDuration = 120
+
+const SYSTEM = `You design creatures for Micro Land, a 2D pixel-art physics sandbox played by children and families.
+
+You are given a short description and you fill in a complete creature blueprint. The blueprint is pure data — pixels, animation, physics, appetite — and the running world reads it directly, so every field matters.
+
+HOW THE WORLD WORKS
+- The world is a grid of tiles: ${MATERIAL_IDS.join(', ')}. Solid tiles block movement, water and lava flow, lava kills anything not immune to it.
+- Gravity pulls things down. Walkers need ground; fliers do not; swimmers only move inside water and suffocate on land; rooted things never move at all.
+- The food chain is one rule: a creature can eat another if it lists one of the target's tags in "eats", AND the target is not larger than it. That single rule produces the whole ecosystem, so choose "size", "tags" and "eats" deliberately.
+- Creatures get hungry, hunt, flee from anything that hunts them, breed when well fed, and die of hunger, drowning, lava or old age. Populations rise and crash on their own.
+
+READING THE DESCRIPTION
+- Describe what the creature IS, not what it eats. "A snail that eats moss" is a snail — a crawling animal whose "eats" list is ["plant"]. It is not a plant.
+- Only use the rooted plant type for something that genuinely is a plant, fungus, coral or seed.
+
+DRAWING
+- Pixel art only, between 3x3 and 14x14. Small and readable beats big and mushy — most creatures look best between 5 and 9 pixels wide.
+- Use a handful of colors: a body color, a darker shade for legs and underside, and usually one bright pixel for an eye. Silhouette is what makes a creature recognisable at this size, not detail.
+- Draw the creature FACING RIGHT.
+- Always give two frames, and make the second a SMALL change from the first — a leg swapping position, a wing beating, a blink. Two unrelated drawings read as a glitch, not an animation.
+
+DRAWING THE LAND
+- The world is a grid 224 tiles wide and 132 tall. You draw it as a small map — about 40 characters across and 24 rows down — which is scaled up and roughened, so draw big shapes and let the detail happen.
+- The top row is the top of the sky; the bottom row is the very bottom of the world. "." is empty air.
+- Plants can only root on dirt, grass, sand, ash or wood. A world built only from stone, metal and glass looks fine and then quietly starves, because nothing can grow and so nothing can eat. Always put some fertile ground where you want life.
+- Match the land to the creatures: water deep enough to swim in if anything swims, open air if anything flies, and somewhere safe to stand if anything walks.
+
+TONE
+- All ages. Nothing gory, frightening, or cruel. Creatures can hunt each other — that is nature — but keep names and descriptions warm and curious.
+- Interpret imaginative requests generously and literally. "A cat made of lava" should be lava-colored, cat-shaped, and immune to lava.`
+
+function creaturePrompt(description: string): string {
+  return `Design one creature: "${description}"
+
+Fill in every field. Make its numbers match its description — a heavy creature should have high mass and low speed, a fragile one should have a short lifespan.`
+}
+
+function terrainPrompt(description: string): string {
+  return `Draw the land for: "${description}"
+
+Make somewhere worth exploring — height, depth, and at least one surprise (a cave, an overhang, a pool, a lava seam). Remember the fertile ground.`
+}
+
+function scenePrompt(description: string): string {
+  return `Design a small scene: "${description}"
+
+First build the land it happens in, then the creatures that live there.
+
+Give 2-4 creatures and how many of each to place. They must form a food chain that can actually run on its own:
+- Include at least one rooted plant creature with "eats": [] — nothing else has anything to eat without it.
+- Include at least one creature that eats "plant".
+- Usually include one larger creature that eats "meat".
+- Place more of the small things than the big things. A world with eight predators and two plants dies in seconds.`
+}
+
+interface ToolUseBlock {
+  type: string
+  name?: string
+  input?: unknown
+}
+
+/**
+ * Ask Claude to fill in `schema` and return the tool input verbatim.
+ * Sanitizing happens on the client, against the same schema's rules.
+ */
+async function askClaude(
+  apiKey: string,
+  schema: z.ZodTypeAny,
+  toolName: string,
+  userPrompt: string,
+  maxTokens: number,
+  signal: AbortSignal
+): Promise<unknown> {
+  const inputSchema = zodToJsonSchema(schema, {
+    $refStrategy: 'none',
+    target: 'jsonSchema7',
+  }) as Record<string, unknown>
+  // Anthropic rejects the $schema meta-key on a tool input schema.
+  delete inputSchema.$schema
+
+  const response = await fetch(API_URL, {
+    method: 'POST',
+    signal,
+    headers: {
+      'x-api-key': apiKey,
+      'anthropic-version': '2023-06-01',
+      'content-type': 'application/json',
+    },
+    body: JSON.stringify({
+      model: MODEL,
+      max_tokens: maxTokens,
+      system: SYSTEM,
+      tools: [
+        {
+          name: toolName,
+          description: 'Return the finished blueprint.',
+          input_schema: inputSchema,
+        },
+      ],
+      tool_choice: { type: 'tool', name: toolName },
+      messages: [{ role: 'user', content: userPrompt }],
+    }),
+  })
+
+  if (!response.ok) {
+    const detail = await response.text()
+    throw new Error(`anthropic ${response.status}: ${detail.slice(0, 300)}`)
+  }
+
+  const data = (await response.json()) as {
+    stop_reason?: string
+    content?: ToolUseBlock[]
+  }
+
+  // Safety classifiers can decline; treat it as a failed summon, not a crash.
+  if (data.stop_reason === 'refusal') {
+    throw new Error('refused')
+  }
+
+  const tool = data.content?.find((b) => b.type === 'tool_use' && b.name === toolName)
+  if (!tool?.input) throw new Error('no tool_use block in response')
+  return tool.input
+}
+
+interface SummonRequest {
+  mode?: unknown
+  prompt?: unknown
+}
+
+export async function POST(request: NextRequest) {
+  let body: SummonRequest
+  try {
+    body = (await request.json()) as SummonRequest
+  } catch {
+    return NextResponse.json({ error: 'Expected a JSON body.' }, { status: 400 })
+  }
+
+  const mode: Mode =
+    body.mode === 'scene' ? 'scene' : body.mode === 'terrain' ? 'terrain' : 'creature'
+  const description =
+    typeof body.prompt === 'string' ? body.prompt.trim().slice(0, MAX_PROMPT) : ''
+
+  if (description.length < 2) {
+    return NextResponse.json({ error: 'Tell me what to summon first.' }, { status: 400 })
+  }
+
+  const apiKey = process.env.ANTHROPIC_API_KEY
+  if (!apiKey) return NextResponse.json(fallback(mode, description))
+
+  // Give up before the platform does, so we can still return a creature.
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), 105_000)
+
+  try {
+    if (mode === 'terrain') {
+      const terrain = await askClaude(
+        apiKey,
+        TerrainSchema,
+        'design_terrain',
+        terrainPrompt(description),
+        MAX_TOKENS.terrain,
+        controller.signal
+      )
+      return NextResponse.json({ mode: 'terrain', source: 'model', terrain })
+    }
+
+    if (mode === 'scene') {
+      const scene = (await askClaude(
+        apiKey,
+        SceneSchema,
+        'design_scene',
+        scenePrompt(description),
+        MAX_TOKENS.scene,
+        controller.signal
+      )) as {
+        title?: string
+        note?: string
+        creatures?: unknown[]
+        terrain?: unknown
+      }
+
+      if (!Array.isArray(scene.creatures) || scene.creatures.length === 0) {
+        throw new Error('scene had no creatures')
+      }
+
+      return NextResponse.json({
+        mode: 'scene',
+        source: 'model',
+        title: scene.title ?? 'A Small World',
+        note: scene.note ?? '',
+        terrain: scene.terrain ?? null,
+        creatures: scene.creatures,
+      })
+    }
+
+    const blueprint = await askClaude(
+      apiKey,
+      BlueprintSchema,
+      'design_creature',
+      creaturePrompt(description),
+      MAX_TOKENS.creature,
+      controller.signal
+    )
+    return NextResponse.json({ mode: 'creature', source: 'model', blueprint })
+  } catch (error) {
+    // A failed summon should still produce a creature — falling back is a much
+    // better experience than an error toast, especially for this audience.
+    console.error('micro-land summon failed:', error)
+    return NextResponse.json(fallback(mode, description))
+  } finally {
+    clearTimeout(timeout)
+  }
+}
+
+function fallback(mode: Mode, description: string) {
+  if (mode === 'terrain') {
+    // No model: sanitizeTerrain's own fallback map is a perfectly good island.
+    return { mode: 'terrain' as const, source: 'offline' as const, terrain: null }
+  }
+  if (mode === 'scene') {
+    return { mode: 'scene' as const, source: 'offline' as const, ...proceduralScene(description) }
+  }
+  return {
+    mode: 'creature' as const,
+    source: 'offline' as const,
+    blueprint: proceduralCreature(description),
+  }
+}

--- a/src/app/api/v1/micro-land/summon/route.ts
+++ b/src/app/api/v1/micro-land/summon/route.ts
@@ -18,16 +18,20 @@
  * removed the sampling parameters and rejects the request outright, so the SDK
  * path can only reach this model by downgrading it.
  *
+ * We do borrow the SDK's `zodSchema` for the conversion, though — it delegates
+ * to the same `zod-to-json-schema` the lockfile already pins at a version this
+ * app's zod satisfies, which a direct dependency on that package does not.
+ *
  * If anything goes wrong — no key, model error, refusal, malformed art — this
  * falls back to a procedural creature instead of an error. A kid asking for a
  * purple fire snail should always get a purple fire snail.
  */
+import { zodSchema } from 'ai'
 import { type NextRequest, NextResponse } from 'next/server'
 import { z } from 'zod'
-import { zodToJsonSchema } from 'zod-to-json-schema'
 
 import { BlueprintSchema, SceneSchema } from '@/app/micro-land/domain/blueprint'
-import { MATERIAL_IDS } from '@/app/micro-land/domain/config/materials'
+import { BASE_MATERIAL_IDS, MATERIALS } from '@/app/micro-land/domain/config/materials'
 import {
   proceduralCreature,
   proceduralScene,
@@ -46,12 +50,22 @@ type Mode = 'creature' | 'scene' | 'terrain'
 /** Scenes can take a while — give the platform room before it cuts us off. */
 export const maxDuration = 120
 
+/**
+ * The list of fertile materials is derived, not typed out.
+ *
+ * The model is told where plants can root, and getting that wrong produces a
+ * beautiful world that quietly starves. Reading it off the material table means
+ * adding a fertile material updates the prompt for free.
+ */
+const FERTILE = BASE_MATERIAL_IDS.filter((id) => MATERIALS[id].fertile).join(', ')
+
 const SYSTEM = `You design creatures for Micro Land, a 2D pixel-art physics sandbox played by children and families.
 
 You are given a short description and you fill in a complete creature blueprint. The blueprint is pure data — pixels, animation, physics, appetite — and the running world reads it directly, so every field matters.
 
 HOW THE WORLD WORKS
-- The world is a grid of tiles: ${MATERIAL_IDS.join(', ')}. Solid tiles block movement, water and lava flow, lava kills anything not immune to it.
+- The world is a grid of tiles: ${BASE_MATERIAL_IDS.join(', ')}. Solid tiles block movement, water and lava flow, lava kills anything not immune to it.
+- Some tiles have their own habits: acid burns like lava and eats through soft rock, sap is thick and holds things fast without drowning them, cloud is soft enough to sink slowly through, snow and ice melt near heat.
 - Gravity pulls things down. Walkers need ground; fliers do not; swimmers only move inside water and suffocate on land; rooted things never move at all.
 - The food chain is one rule: a creature can eat another if it lists one of the target's tags in "eats", AND the target is not larger than it. That single rule produces the whole ecosystem, so choose "size", "tags" and "eats" deliberately.
 - Creatures get hungry, hunt, flee from anything that hunts them, breed when well fed, and die of hunger, drowning, lava or old age. Populations rise and crash on their own.
@@ -61,15 +75,33 @@ READING THE DESCRIPTION
 - Only use the rooted plant type for something that genuinely is a plant, fungus, coral or seed.
 
 DRAWING
-- Pixel art only, between 3x3 and 14x14. Small and readable beats big and mushy — most creatures look best between 5 and 9 pixels wide.
-- Use a handful of colors: a body color, a darker shade for legs and underside, and usually one bright pixel for an eye. Silhouette is what makes a creature recognisable at this size, not detail.
+- Pixel art only, from 3x3 up to 28 wide and 24 tall.
+- DRAW IT AT THE SCALE ITS SIZE SAYS. This is the single most common mistake: a dragon drawn 9 pixels wide is a bug that happens to eat everything. Match the size number:
+    size 1 (mite, seed)      3-5 wide
+    size 2 (bug, fish)       5-8 wide
+    size 3 (cat)             7-11 wide
+    size 4 (wolf, big bird)  11-16 wide
+    size 5 (bear, horse)     15-22 wide
+    size 6 (dragon, whale)   20-28 wide
+- Big creatures are worth the pixels. If something is described as huge, ancient, giant, monstrous or a dragon, it should be size 6 and drawn near the full 28 — that is the difference between a monster and a beetle. Use the height too: a long wyrm can be wide and short, a tyrannosaur tall and narrow.
+- Use the extra room on a big creature for structure, not noise: a readable head, a distinct limb, a tail that tapers. Detail that doesn't change the silhouette is wasted at this scale.
+- THE HEAD IS THE HARDEST PART AND THE PART THAT DECIDES WHETHER IT WORKS. A head drawn in the body's own colour is a blob on a neck, and that is the single most common way a big creature fails. On anything size 4 or larger, give the head all four of these:
+    · a dark outline running along the jaw and over the skull, so the head separates from both the neck and the sky behind it
+    · an eye of one or two pixels in a colour used NOWHERE else on the creature, with a dark pixel touching it for contrast
+    · a jaw line — a row of dark or transparent pixels cutting between the upper and lower jaw. An open mouth with a gap inside it reads far better than a closed one
+    · a snout or muzzle that breaks the outline and pokes forward past the neck, rather than a bump on the shoulders
+- Spend your contrast on the head. The rest of a creature can be nearly flat and it will still read, as long as the head is crisp — a viewer finds the face first and decides there.
+- Use a body color, a darker shade for legs and underside, and usually one bright pixel for an eye. Small creatures need 3-4 colors; a size 5 or 6 can carry 6-10.
 - Draw the creature FACING RIGHT.
 - Always give two frames, and make the second a SMALL change from the first — a leg swapping position, a wing beating, a blink. Two unrelated drawings read as a glitch, not an animation.
+- A very large creature collides with its middle rather than its whole outline, so wings, tails and long necks can hang over the edges. Draw the shape you want; you do not have to keep it compact.
 
 DRAWING THE LAND
 - The world is a grid 224 tiles wide and 132 tall. You draw it as a small map — about 40 characters across and 24 rows down — which is scaled up and roughened, so draw big shapes and let the detail happen.
 - The top row is the top of the sky; the bottom row is the very bottom of the world. "." is empty air.
-- Plants can only root on dirt, grass, sand, ash or wood. A world built only from stone, metal and glass looks fine and then quietly starves, because nothing can grow and so nothing can eat. Always put some fertile ground where you want life.
+- KEEP THE GROUND LOW. The surface — the first row that is mostly solid — should sit about 30-50% of the way up from the bottom, so at least half the map is open air. A horizon two-thirds up the page looks right on paper and plays badly: everything worth watching happens above the ground, and a world that is mostly dirt leaves the creatures nowhere to live. On a 24-row map that means roughly 13-16 rows of sky before the land starts.
+- Depth below the surface is only interesting where it is hollow. A solid slab of stone ten rows thick is wasted world — put caves, pockets, water or a lava seam in it, or make it thinner.
+- Plants can only root on ${FERTILE}. A world built only from stone, metal and glass looks fine and then quietly starves, because nothing can grow and so nothing can eat. Always put some fertile ground where you want life.
 - Match the land to the creatures: water deep enough to swim in if anything swims, open air if anything flies, and somewhere safe to stand if anything walks.
 
 TONE
@@ -118,12 +150,12 @@ async function askClaude(
   maxTokens: number,
   signal: AbortSignal
 ): Promise<unknown> {
-  const inputSchema = zodToJsonSchema(schema, {
-    $refStrategy: 'none',
-    target: 'jsonSchema7',
-  }) as Record<string, unknown>
-  // Anthropic rejects the $schema meta-key on a tool input schema.
-  delete inputSchema.$schema
+  // Refs come out inlined, which is what a tool input_schema wants.
+  const { $schema, ...inputSchema } = zodSchema(schema).jsonSchema as Record<
+    string,
+    unknown
+  >
+  void $schema // Anthropic rejects the $schema meta-key on a tool input schema.
 
   const response = await fetch(API_URL, {
     method: 'POST',

--- a/src/app/api/v1/micro-land/summon/route.ts
+++ b/src/app/api/v1/micro-land/summon/route.ts
@@ -97,7 +97,8 @@ DRAWING
 - A very large creature collides with its middle rather than its whole outline, so wings, tails and long necks can hang over the edges. Draw the shape you want; you do not have to keep it compact.
 
 DRAWING THE LAND
-- The world is a grid 224 tiles wide and 132 tall. You draw it as a small map — about 40 characters across and 24 rows down — which is scaled up and roughened, so draw big shapes and let the detail happen.
+- The world is a grid 672 tiles wide and 132 tall — a long, wide stretch of land that the player scrolls across. You draw it as a map about 120 characters across and 24 rows down, which is scaled up and roughened, so draw big shapes and let the detail happen.
+- Because it is wide, give it a JOURNEY: different country at each end and something to find in between. A shoreline that becomes cliffs that become a cave system beats the same hill drawn 120 times.
 - The top row is the top of the sky; the bottom row is the very bottom of the world. "." is empty air.
 - KEEP THE GROUND LOW. The surface — the first row that is mostly solid — should sit about 30-50% of the way up from the bottom, so at least half the map is open air. A horizon two-thirds up the page looks right on paper and plays badly: everything worth watching happens above the ground, and a world that is mostly dirt leaves the creatures nowhere to live. On a 24-row map that means roughly 13-16 rows of sky before the land starts.
 - Depth below the surface is only interesting where it is hollow. A solid slab of stone ten rows thick is wasted world — put caves, pockets, water or a lava seam in it, or make it thinner.

--- a/src/app/micro-land/MicroLandGame.tsx
+++ b/src/app/micro-land/MicroLandGame.tsx
@@ -1,0 +1,91 @@
+'use client'
+
+import { useCallback, useEffect, useRef } from 'react'
+
+import { FieldGuide } from '@/app/micro-land/components/field-guide'
+import { Hud } from '@/app/micro-land/components/hud'
+import { Inspector } from '@/app/micro-land/components/inspector'
+import { Notices } from '@/app/micro-land/components/notices'
+import { SummonPanel } from '@/app/micro-land/components/summon-panel'
+import { Toolbar } from '@/app/micro-land/components/toolbar'
+import { THEME_BY_ID } from '@/app/micro-land/domain/config/themes'
+import { hasFertileGround } from '@/app/micro-land/domain/terrain'
+import { GameInstance } from '@/app/micro-land/game-instance'
+import { useMicroLand } from '@/app/micro-land/store'
+
+export function MicroLandGame() {
+  const canvasRef = useRef<HTMLCanvasElement>(null)
+  const gameRef = useRef<GameInstance | null>(null)
+  const notify = useMicroLand((s) => s.notify)
+
+  useEffect(() => {
+    const canvas = canvasRef.current
+    if (!canvas) return
+
+    // `?theme=tidepool` drops a visitor straight into that world. Set it before
+    // the instance is built — it reads the theme from the store on construction.
+    const requested = new URLSearchParams(window.location.search).get('theme')
+    if (requested && THEME_BY_ID[requested]) {
+      useMicroLand.getState().setTheme(requested)
+    }
+
+    const game = new GameInstance(canvas)
+    gameRef.current = game
+    game.start()
+
+    // Theme changes are driven straight off the store rather than a second
+    // effect — the instance already seeded its own theme when it was built, and
+    // a dependency-driven effect would rebuild the world on every remount.
+    const unsubscribe = useMicroLand.subscribe((state, previous) => {
+      if (state.themeId !== previous.themeId) game.setTheme(state.themeId)
+    })
+
+    return () => {
+      unsubscribe()
+      game.destroy()
+      gameRef.current = null
+    }
+  }, [])
+
+  const handleReshuffle = useCallback(() => {
+    gameRef.current?.reshuffle()
+    notify('The ground shifts and settles somewhere new.')
+  }, [notify])
+
+  const handleClearLife = useCallback(() => {
+    gameRef.current?.clearLife()
+    notify('Everything living is gone. The land waits.')
+  }, [notify])
+
+  const handleIntroduce = useCallback((raw: unknown, count: number) => {
+    return gameRef.current?.introduce(raw, count) ?? null
+  }, [])
+
+  const handleApplyTerrain = useCallback((raw: unknown, keepCreatures: boolean) => {
+    const game = gameRef.current
+    if (!game) return null
+    const terrain = game.applyTerrain(raw, { keepCreatures })
+    return { name: terrain.name, fertile: hasFertileGround(terrain) }
+  }, [])
+
+  return (
+    <div className="flex h-full w-full flex-col overflow-hidden">
+      <Hud onReshuffle={handleReshuffle} onClearLife={handleClearLife} />
+
+      <div className="relative min-h-0 flex-1">
+        <canvas
+          ref={canvasRef}
+          className="absolute inset-0 block h-full w-full touch-none"
+          style={{ imageRendering: 'pixelated', cursor: 'crosshair' }}
+          aria-label="Micro Land world. Tap to place things, drag a creature to pick it up and throw it."
+        />
+        <Notices />
+        <Inspector />
+      </div>
+
+      <Toolbar />
+      <SummonPanel onIntroduce={handleIntroduce} onApplyTerrain={handleApplyTerrain} />
+      <FieldGuide />
+    </div>
+  )
+}

--- a/src/app/micro-land/MicroLandGame.tsx
+++ b/src/app/micro-land/MicroLandGame.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useRef } from 'react'
 
+import { flushChronicle, initChronicle } from '@/app/micro-land/chronicle/chronicle'
 import { FieldGuide } from '@/app/micro-land/components/field-guide'
 import { Hud } from '@/app/micro-land/components/hud'
 import { Inspector } from '@/app/micro-land/components/inspector'
@@ -29,21 +30,36 @@ export function MicroLandGame() {
       useMicroLand.getState().setTheme(requested)
     }
 
-    const game = new GameInstance(canvas)
-    gameRef.current = game
-    game.start()
+    let game: GameInstance | null = null
+    let unsubscribe: (() => void) | null = null
+    let cancelled = false
 
-    // Theme changes are driven straight off the store rather than a second
-    // effect — the instance already seeded its own theme when it was built, and
-    // a dependency-driven effect would rebuild the world on every remount.
-    const unsubscribe = useMicroLand.subscribe((state, previous) => {
-      if (state.themeId !== previous.themeId) game.setTheme(state.themeId)
+    // The chronicle is read *before* the world exists. Building the instance
+    // first would let a stats tick write records into a chronicle that is about
+    // to be replaced by the stored one, quietly losing them.
+    void initChronicle().then(() => {
+      if (cancelled) return
+      game = new GameInstance(canvas)
+      gameRef.current = game
+      game.publishRecords()
+      game.start()
+
+      // Theme changes are driven straight off the store rather than a second
+      // effect — the instance already seeded its own theme when it was built,
+      // and a dependency-driven effect would rebuild the world on every remount.
+      unsubscribe = useMicroLand.subscribe((state, previous) => {
+        if (state.themeId !== previous.themeId) game?.setTheme(state.themeId)
+      })
     })
 
     return () => {
-      unsubscribe()
-      game.destroy()
+      cancelled = true
+      unsubscribe?.()
+      game?.destroy()
       gameRef.current = null
+      // Leaving for another game in the cave is a normal way to end a session,
+      // and it isn't covered by the page-hide handler.
+      void flushChronicle()
     }
   }, [])
 
@@ -59,6 +75,10 @@ export function MicroLandGame() {
 
   const handleIntroduce = useCallback((raw: unknown, count: number) => {
     return gameRef.current?.introduce(raw, count) ?? null
+  }, [])
+
+  const handleNameElder = useCallback((name: string) => {
+    return gameRef.current?.nameElder(name) ?? false
   }, [])
 
   const handleApplyTerrain = useCallback((raw: unknown, keepCreatures: boolean) => {
@@ -80,7 +100,7 @@ export function MicroLandGame() {
           aria-label="Micro Land world. Tap to place things, drag a creature to pick it up and throw it."
         />
         <Notices />
-        <Inspector />
+        <Inspector onName={handleNameElder} />
       </div>
 
       <Toolbar />

--- a/src/app/micro-land/MicroLandGame.tsx
+++ b/src/app/micro-land/MicroLandGame.tsx
@@ -7,6 +7,7 @@ import { FieldGuide } from '@/app/micro-land/components/field-guide'
 import { Hud } from '@/app/micro-land/components/hud'
 import { Inspector } from '@/app/micro-land/components/inspector'
 import { Notices } from '@/app/micro-land/components/notices'
+import { PanControls } from '@/app/micro-land/components/pan-controls'
 import { SummonPanel } from '@/app/micro-land/components/summon-panel'
 import { Toolbar } from '@/app/micro-land/components/toolbar'
 import { THEME_BY_ID } from '@/app/micro-land/domain/config/themes'
@@ -81,6 +82,14 @@ export function MicroLandGame() {
     return gameRef.current?.nameElder(name) ?? false
   }, [])
 
+  const handleHoldPan = useCallback((direction: -1 | 0 | 1) => {
+    gameRef.current?.holdPan(direction)
+  }, [])
+
+  const handleNudgePan = useCallback((direction: -1 | 1) => {
+    gameRef.current?.nudgePan(direction)
+  }, [])
+
   const handleApplyTerrain = useCallback((raw: unknown, keepCreatures: boolean) => {
     const game = gameRef.current
     if (!game) return null
@@ -95,10 +104,14 @@ export function MicroLandGame() {
       <div className="relative min-h-0 flex-1">
         <canvas
           ref={canvasRef}
-          className="absolute inset-0 block h-full w-full touch-none"
+          // Focusable so the arrow keys reach it. The world is wider than the
+          // screen, and a keyboard has to be able to get to the rest of it.
+          tabIndex={0}
+          className="absolute inset-0 block h-full w-full touch-none focus:outline-none"
           style={{ imageRendering: 'pixelated', cursor: 'crosshair' }}
-          aria-label="Micro Land world. Tap to place things, drag a creature to pick it up and throw it."
+          aria-label="Micro Land world. Tap to place things, drag a creature to pick it up and throw it. Arrow keys scroll across the world."
         />
+        <PanControls onHold={handleHoldPan} onNudge={handleNudgePan} />
         <Notices />
         <Inspector onName={handleNameElder} />
       </div>

--- a/src/app/micro-land/chronicle/__tests__/chronicle.test.ts
+++ b/src/app/micro-land/chronicle/__tests__/chronicle.test.ts
@@ -1,0 +1,257 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import type { ChronicleBackend } from '@/app/micro-land/chronicle/backend'
+import {
+  archivedSpecies,
+  claimMilestone,
+  flushChronicle,
+  initChronicle,
+  landId,
+  landRecord,
+  mergeChronicles,
+  noteSpeciesLife,
+  readChronicle,
+  rememberSpecies,
+  setBackend,
+  updateChronicle,
+} from '@/app/micro-land/chronicle/chronicle'
+import {
+  CHRONICLE_VERSION,
+  emptyChronicle,
+  emptyLandRecord,
+} from '@/app/micro-land/chronicle/types'
+import type { ChronicleData } from '@/app/micro-land/chronicle/types'
+import type { CreatureBlueprint } from '@/app/micro-land/domain/types'
+
+/**
+ * A blueprint stub.
+ *
+ * Cast rather than filled in: the chronicle only ever reads `id`, `name` and
+ * `summoned`, and spelling out forty fields of pixel art would obscure what each
+ * test is actually about.
+ */
+function bp(id: string, summoned = false): CreatureBlueprint {
+  return { id, name: id, summoned } as CreatureBlueprint
+}
+
+function memoryBackend(initial: ChronicleData | null = null) {
+  const state = { saved: initial }
+  const backend: ChronicleBackend = {
+    async load() {
+      return state.saved
+    },
+    async save(data) {
+      state.saved = JSON.parse(JSON.stringify(data)) as ChronicleData
+    },
+  }
+  return { backend, state }
+}
+
+/** Point the module singleton at a fresh backend and read it in. */
+async function loadWith(stored: ChronicleData | null) {
+  const mem = memoryBackend(stored)
+  setBackend(mem.backend)
+  await initChronicle()
+  return mem
+}
+
+beforeEach(async () => {
+  await loadWith(null)
+})
+
+describe('landId', () => {
+  it('files a built-in theme under its own id', () => {
+    expect(landId('tidepool', null)).toBe('tidepool')
+  })
+
+  it('gives a summoned land its own key, so records follow the name', () => {
+    expect(landId('summoned', 'The Drowned Cathedral')).toBe(
+      'summoned:the-drowned-cathedral'
+    )
+  })
+
+  it('falls back to the theme when a name slugs down to nothing', () => {
+    expect(landId('summoned', '!!!')).toBe('summoned')
+  })
+})
+
+describe('loading', () => {
+  it('restores stored records', async () => {
+    const stored = emptyChronicle()
+    stored.lands.tidepool = { ...emptyLandRecord(), steadySeconds: 420 }
+    await loadWith(stored)
+    expect(landRecord('tidepool').steadySeconds).toBe(420)
+  })
+
+  it('starts fresh rather than misreading an unknown version', async () => {
+    const stored = { ...emptyChronicle(), version: CHRONICLE_VERSION + 99 }
+    stored.lands.tidepool = { ...emptyLandRecord(), steadySeconds: 420 }
+    await loadWith(stored)
+    expect(readChronicle().lands).toEqual({})
+  })
+
+  it('survives a corrupt payload without throwing', async () => {
+    await loadWith({ version: CHRONICLE_VERSION } as ChronicleData)
+    expect(readChronicle().species).toEqual({})
+  })
+})
+
+describe('writing', () => {
+  it('flushes pending changes through to the backend', async () => {
+    const mem = await loadWith(null)
+    updateChronicle(() => {
+      landRecord('volcanic').steadySeconds = 99
+    })
+    await flushChronicle()
+    expect(mem.state.saved?.lands.volcanic.steadySeconds).toBe(99)
+  })
+
+  it('does not write when nothing changed', async () => {
+    const mem = await loadWith(null)
+    await flushChronicle()
+    expect(mem.state.saved).toBeNull()
+  })
+})
+
+describe('the species archive', () => {
+  it('keeps the most recent version of a blueprint that comes back', () => {
+    rememberSpecies(bp('drifter'), 1000)
+    const improved = { ...bp('drifter'), name: 'Drifter, redrawn' } as CreatureBlueprint
+    rememberSpecies(improved, 2000)
+    expect(archivedSpecies()).toHaveLength(1)
+    expect(archivedSpecies()[0].blueprint.name).toBe('Drifter, redrawn')
+    expect(archivedSpecies()[0].firstSeen).toBe(1000)
+    expect(archivedSpecies()[0].lastSeen).toBe(2000)
+  })
+
+  it('only records a lifespan that beats the species best', () => {
+    rememberSpecies(bp('hopper'), 1000)
+    expect(noteSpeciesLife('hopper', 30)).toBe(true)
+    expect(noteSpeciesLife('hopper', 12)).toBe(false)
+    expect(archivedSpecies()[0].longestLife).toBe(30)
+  })
+
+  it('ignores a lifespan for a species it has never seen', () => {
+    expect(noteSpeciesLife('ghost', 500)).toBe(false)
+  })
+
+  it('prunes the oldest summoned species but never a built-in', () => {
+    rememberSpecies(bp('builtin-hopper'), 1)
+    // One past the cap, oldest first, so the first summoned one is the victim.
+    for (let i = 0; i < 81; i++) rememberSpecies(bp(`summoned-${i}`, true), 100 + i)
+
+    const ids = new Set(archivedSpecies().map((s) => s.blueprint.id))
+    expect(ids.has('builtin-hopper')).toBe(true)
+    expect(ids.has('summoned-0')).toBe(false)
+    expect(ids.has('summoned-80')).toBe(true)
+    expect(archivedSpecies().filter((s) => s.blueprint.summoned)).toHaveLength(80)
+  })
+})
+
+describe('milestones', () => {
+  it('fires once and never again', () => {
+    expect(claimMilestone('first-elder', 5000)).toBe(true)
+    expect(claimMilestone('first-elder', 9000)).toBe(false)
+    expect(readChronicle().milestones['first-elder']).toBe(5000)
+  })
+})
+
+describe('mergeChronicles', () => {
+  it('keeps the longer life, whichever side it came from', () => {
+    const a = emptyChronicle()
+    a.lands.tidepool = {
+      ...emptyLandRecord(),
+      elder: {
+        seconds: 100,
+        blueprintId: 'crab',
+        speciesName: 'Crab',
+        name: null,
+        at: 1,
+      },
+    }
+    const b = emptyChronicle()
+    b.lands.tidepool = {
+      ...emptyLandRecord(),
+      elder: {
+        seconds: 300,
+        blueprintId: 'crab',
+        speciesName: 'Crab',
+        name: 'Steve',
+        at: 2,
+      },
+    }
+    expect(mergeChronicles(a, b).lands.tidepool.elder?.name).toBe('Steve')
+    // Order must not matter — sign-in can merge either direction.
+    expect(mergeChronicles(b, a).lands.tidepool.elder?.name).toBe('Steve')
+  })
+
+  it('takes the high-water mark of each record independently', () => {
+    const a = emptyChronicle()
+    a.lands.tidepool = {
+      ...emptyLandRecord(),
+      steadySeconds: 900,
+      generations: 3,
+      generationsBlueprintId: 'crab',
+      generationsSpeciesName: 'Crab',
+    }
+    const b = emptyChronicle()
+    b.lands.tidepool = {
+      ...emptyLandRecord(),
+      steadySeconds: 120,
+      generations: 11,
+      generationsBlueprintId: 'kelp',
+      generationsSpeciesName: 'Kelp',
+    }
+
+    const merged = mergeChronicles(a, b).lands.tidepool
+    expect(merged.steadySeconds).toBe(900)
+    expect(merged.generations).toBe(11)
+    // The species has to travel with the number it belongs to.
+    expect(merged.generationsSpeciesName).toBe('Kelp')
+  })
+
+  it('unions the archive and keeps the earliest milestone', () => {
+    const a = emptyChronicle()
+    a.species.crab = {
+      blueprint: bp('crab'),
+      firstSeen: 50,
+      lastSeen: 60,
+      longestLife: 10,
+    }
+    a.milestones['first-elder'] = 900
+
+    const b = emptyChronicle()
+    b.species.kelp = {
+      blueprint: bp('kelp'),
+      firstSeen: 10,
+      lastSeen: 20,
+      longestLife: 5,
+    }
+    b.species.crab = {
+      blueprint: bp('crab'),
+      firstSeen: 5,
+      lastSeen: 400,
+      longestLife: 7,
+    }
+    b.milestones['first-elder'] = 100
+
+    const merged = mergeChronicles(a, b)
+    expect(Object.keys(merged.species).sort()).toEqual(['crab', 'kelp'])
+    expect(merged.species.crab.firstSeen).toBe(5)
+    expect(merged.species.crab.lastSeen).toBe(400)
+    expect(merged.species.crab.longestLife).toBe(10)
+    // A first is a first — the earlier timestamp wins.
+    expect(merged.milestones['first-elder']).toBe(100)
+  })
+
+  it('carries over a land only one side has ever visited', () => {
+    const a = emptyChronicle()
+    a.lands.tidepool = { ...emptyLandRecord(), steadySeconds: 30 }
+    const b = emptyChronicle()
+    b.lands.volcanic = { ...emptyLandRecord(), steadySeconds: 70 }
+
+    const merged = mergeChronicles(a, b)
+    expect(merged.lands.tidepool.steadySeconds).toBe(30)
+    expect(merged.lands.volcanic.steadySeconds).toBe(70)
+  })
+})

--- a/src/app/micro-land/chronicle/backend.ts
+++ b/src/app/micro-land/chronicle/backend.ts
@@ -1,0 +1,86 @@
+/**
+ * Where the chronicle is actually kept.
+ *
+ * This is the seam that makes the eventual move to accounts a swap rather than a
+ * rewrite. Everything above this file talks to a `ChronicleBackend` and never
+ * mentions `localStorage`; when records move to Firebase, a second
+ * implementation lands here and `setBackend` gets called once at startup.
+ *
+ * Both methods are async even though the local one has nothing to await. That is
+ * the deliberate part — a synchronous API today would put `await` into every
+ * call site on the day it moves to the network.
+ */
+import { type ChronicleData, emptyChronicle } from './types'
+
+export interface ChronicleBackend {
+  /** Returns null when nothing has been stored yet. */
+  load(): Promise<ChronicleData | null>
+  save(data: ChronicleData): Promise<void>
+}
+
+const STORAGE_KEY = 'micro-land:chronicle'
+
+/**
+ * Browser-local records: no account, no network, this device only.
+ *
+ * Every access is wrapped, because `localStorage` is not merely empty in
+ * private-mode Safari and locked-down embeds — *reading it throws*. A player
+ * whose browser refuses storage should still get a working game that simply
+ * doesn't remember anything, so failure here is always silent and always
+ * degrades to "no records yet".
+ */
+export const localBackend: ChronicleBackend = {
+  async load() {
+    if (typeof window === 'undefined') return null
+    try {
+      const raw = window.localStorage.getItem(STORAGE_KEY)
+      if (!raw) return null
+      return JSON.parse(raw) as ChronicleData
+    } catch {
+      return null
+    }
+  },
+
+  async save(data) {
+    if (typeof window === 'undefined') return
+    try {
+      window.localStorage.setItem(STORAGE_KEY, JSON.stringify(data))
+    } catch {
+      // Quota exceeded or storage disabled. Records stop persisting; the game
+      // carries on. Nothing here is worth interrupting play over.
+    }
+  },
+}
+
+/** A backend that remembers nothing, for tests and for server rendering. */
+export const nullBackend: ChronicleBackend = {
+  async load() {
+    return null
+  },
+  async save() {},
+}
+
+/**
+ * Sketch of the account-backed backend, for whoever wires it up.
+ *
+ * The shape below is the whole port — one document per user, read once on sign
+ * in, written on the same debounce the local one uses. The interesting work is
+ * not this file, it is deciding what happens to records a player set while
+ * signed out (see the note on `mergeChronicles` in `chronicle.ts`).
+ *
+ *   export function firebaseBackend(uid: string): ChronicleBackend {
+ *     const ref = doc(getFirestore(), 'microLandChronicles', uid)
+ *     return {
+ *       async load() {
+ *         const snap = await getDoc(ref)
+ *         return snap.exists() ? (snap.data() as ChronicleData) : null
+ *       },
+ *       async save(data) {
+ *         await setDoc(ref, data)
+ *       },
+ *     }
+ *   }
+ */
+
+/** Fallback used before `load` has resolved, so readers never see undefined. */
+export const INITIAL_DATA = emptyChronicle()

--- a/src/app/micro-land/chronicle/chronicle.ts
+++ b/src/app/micro-land/chronicle/chronicle.ts
@@ -1,0 +1,290 @@
+/**
+ * The live chronicle: one in-memory copy, written back on a debounce.
+ *
+ * The simulation touches records several times a second — every stats push asks
+ * "is this the oldest thing that has ever lived here?". Serializing to storage
+ * at that rate would be pointless work, so reads and writes hit an in-memory
+ * object and the backend only sees it every few seconds, plus once more when the
+ * page goes away. Losing the last couple of seconds of a record on a hard crash
+ * is an acceptable trade; janking the frame loop is not.
+ */
+import type { CreatureBlueprint } from '@/app/micro-land/domain/types'
+
+import {
+  type ChronicleBackend,
+  INITIAL_DATA,
+  localBackend,
+} from './backend'
+import {
+  CHRONICLE_VERSION,
+  type ChronicleData,
+  type LandRecord,
+  type SpeciesRecord,
+  emptyChronicle,
+  emptyLandRecord,
+} from './types'
+
+/** How long writes are allowed to pile up before they reach the backend. */
+const FLUSH_DEBOUNCE_MS = 4000
+
+/**
+ * Cap on archived *summoned* species.
+ *
+ * Built-ins are bounded by the config and never pruned. Summoned ones are not
+ * bounded by anything — a player could invent hundreds — and each carries its
+ * own pixel art, so the archive is trimmed oldest-sighting-first to keep a
+ * chronicle comfortably inside a `localStorage` quota.
+ */
+const MAX_ARCHIVED_SUMMONED = 80
+
+let data: ChronicleData = INITIAL_DATA
+let backend: ChronicleBackend = localBackend
+let loaded = false
+let dirty = false
+let flushTimer: ReturnType<typeof setTimeout> | null = null
+
+// ---------------------------------------------------------------------------
+// Identity
+// ---------------------------------------------------------------------------
+
+/**
+ * The key a land's records are filed under.
+ *
+ * Built-in themes use their own id, so the tidepool always has one set of
+ * records however many times it is reshaped. A summoned land is keyed by its
+ * *name* rather than the generic `summoned` theme id — the player who described
+ * "a drowned cathedral" should find that land's records again next time they
+ * summon it, not a pile shared with every other invention.
+ */
+export function landId(themeId: string, summonedLandName: string | null): string {
+  if (summonedLandName) {
+    const slug = summonedLandName
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-|-$/g, '')
+      .slice(0, 48)
+    if (slug) return `summoned:${slug}`
+  }
+  return themeId
+}
+
+// ---------------------------------------------------------------------------
+// Lifecycle
+// ---------------------------------------------------------------------------
+
+/** Swap the storage backend. Called once at startup when accounts land. */
+export function setBackend(next: ChronicleBackend): void {
+  backend = next
+  loaded = false
+}
+
+/**
+ * Read the chronicle in. Safe to call more than once; only the first does work.
+ */
+export async function initChronicle(): Promise<ChronicleData> {
+  if (loaded) return data
+  const stored = await backend.load()
+  data = migrate(stored)
+  loaded = true
+  attachFlushOnHide()
+  return data
+}
+
+/**
+ * Bring an old chronicle forward, or start a fresh one.
+ *
+ * There is only one version so far, so anything unrecognized is discarded
+ * rather than guessed at. When version 2 arrives this is where the field-by-
+ * field upgrade goes — and note it must never throw, because a chronicle that
+ * fails to parse should cost the player their records, not their game.
+ */
+function migrate(stored: ChronicleData | null): ChronicleData {
+  if (!stored || typeof stored !== 'object') return emptyChronicle()
+  if (stored.version !== CHRONICLE_VERSION) return emptyChronicle()
+  return {
+    version: CHRONICLE_VERSION,
+    lands: stored.lands ?? {},
+    species: stored.species ?? {},
+    milestones: stored.milestones ?? {},
+  }
+}
+
+export function readChronicle(): ChronicleData {
+  return data
+}
+
+/** Mutate the chronicle in place and schedule a write. */
+export function updateChronicle(mutate: (draft: ChronicleData) => void): void {
+  mutate(data)
+  touch()
+}
+
+/**
+ * Mark the chronicle as needing a write and start the debounce.
+ *
+ * Every mutating helper below calls this itself rather than relying on being
+ * wrapped in `updateChronicle`. An unwritten record is invisible until the
+ * player closes the tab and finds it missing, which is the worst possible time
+ * to discover the invariant was broken.
+ */
+function touch(): void {
+  dirty = true
+  if (flushTimer === null) {
+    flushTimer = setTimeout(() => {
+      flushTimer = null
+      void flushChronicle()
+    }, FLUSH_DEBOUNCE_MS)
+  }
+}
+
+export async function flushChronicle(): Promise<void> {
+  if (!dirty) return
+  dirty = false
+  if (flushTimer !== null) {
+    clearTimeout(flushTimer)
+    flushTimer = null
+  }
+  await backend.save(data)
+}
+
+/**
+ * Write on the way out.
+ *
+ * `visibilitychange` rather than `beforeunload`: on mobile a tab is very often
+ * backgrounded and then killed without ever firing an unload, which is exactly
+ * the case where an unwritten record would be lost.
+ */
+let hideHooked = false
+function attachFlushOnHide(): void {
+  if (hideHooked || typeof document === 'undefined') return
+  hideHooked = true
+  document.addEventListener('visibilitychange', () => {
+    if (document.visibilityState === 'hidden') void flushChronicle()
+  })
+  window.addEventListener('pagehide', () => void flushChronicle())
+}
+
+// ---------------------------------------------------------------------------
+// Accessors
+// ---------------------------------------------------------------------------
+
+/** The record for a land, created on first access. */
+export function landRecord(id: string): LandRecord {
+  const existing = data.lands[id]
+  if (existing) return existing
+  const fresh = emptyLandRecord()
+  data.lands[id] = fresh
+  return fresh
+}
+
+/**
+ * Note that a species was seen alive, archiving its blueprint the first time.
+ *
+ * The blueprint is re-copied on every sighting rather than only on the first:
+ * summoning is non-deterministic, so the same id can come back with better art
+ * or a fixed diet, and the archive should hold the most recent version.
+ */
+export function rememberSpecies(bp: CreatureBlueprint, now: number): void {
+  const existing = data.species[bp.id]
+  if (existing) {
+    existing.lastSeen = now
+    existing.blueprint = bp
+    touch()
+    return
+  }
+  data.species[bp.id] = {
+    blueprint: bp,
+    firstSeen: now,
+    lastSeen: now,
+    longestLife: 0,
+  }
+  pruneArchive()
+  touch()
+}
+
+/** Record a lifespan against a species, if it beats what that species has done. */
+export function noteSpeciesLife(blueprintId: string, seconds: number): boolean {
+  const record = data.species[blueprintId]
+  if (!record || seconds <= record.longestLife) return false
+  record.longestLife = seconds
+  touch()
+  return true
+}
+
+/** Every archived species, newest sighting first. */
+export function archivedSpecies(): SpeciesRecord[] {
+  return Object.values(data.species).sort((a, b) => b.lastSeen - a.lastSeen)
+}
+
+/** True if this milestone has never fired before; marks it fired if so. */
+export function claimMilestone(id: string, now: number): boolean {
+  if (data.milestones[id]) return false
+  data.milestones[id] = now
+  touch()
+  return true
+}
+
+function pruneArchive(): void {
+  const summoned = Object.values(data.species).filter((s) => s.blueprint.summoned)
+  if (summoned.length <= MAX_ARCHIVED_SUMMONED) return
+  summoned.sort((a, b) => a.lastSeen - b.lastSeen)
+  const excess = summoned.length - MAX_ARCHIVED_SUMMONED
+  for (let i = 0; i < excess; i++) delete data.species[summoned[i].blueprint.id]
+}
+
+// ---------------------------------------------------------------------------
+// For the account-backed future
+// ---------------------------------------------------------------------------
+
+/**
+ * Combine two chronicles, keeping the better of each record.
+ *
+ * Unused today, and written now because it is the one genuinely hard part of
+ * moving to accounts: a player will arrive at sign-in holding records they set
+ * anonymously, and throwing those away is the wrong answer. Records are all
+ * high-water marks, so "keep the larger" merges cleanly — no conflict, no
+ * prompt. Milestones keep the earlier timestamp; a first is a first.
+ */
+export function mergeChronicles(a: ChronicleData, b: ChronicleData): ChronicleData {
+  const merged = emptyChronicle()
+
+  for (const id of new Set([...Object.keys(a.lands), ...Object.keys(b.lands)])) {
+    const left = a.lands[id] ?? emptyLandRecord()
+    const right = b.lands[id] ?? emptyLandRecord()
+    const deeper = right.generations > left.generations ? right : left
+    merged.lands[id] = {
+      elder:
+        (right.elder?.seconds ?? 0) > (left.elder?.seconds ?? 0)
+          ? right.elder
+          : left.elder,
+      steadySeconds: Math.max(left.steadySeconds, right.steadySeconds),
+      generations: deeper.generations,
+      generationsBlueprintId: deeper.generationsBlueprintId,
+      generationsSpeciesName: deeper.generationsSpeciesName,
+    }
+  }
+
+  for (const id of new Set([...Object.keys(a.species), ...Object.keys(b.species)])) {
+    const left = a.species[id]
+    const right = b.species[id]
+    if (!left || !right) {
+      merged.species[id] = (left ?? right) as SpeciesRecord
+      continue
+    }
+    merged.species[id] = {
+      // The more recently seen copy is the more current art.
+      blueprint: right.lastSeen > left.lastSeen ? right.blueprint : left.blueprint,
+      firstSeen: Math.min(left.firstSeen, right.firstSeen),
+      lastSeen: Math.max(left.lastSeen, right.lastSeen),
+      longestLife: Math.max(left.longestLife, right.longestLife),
+    }
+  }
+
+  for (const id of new Set([...Object.keys(a.milestones), ...Object.keys(b.milestones)])) {
+    const left = a.milestones[id] ?? Infinity
+    const right = b.milestones[id] ?? Infinity
+    merged.milestones[id] = Math.min(left, right)
+  }
+
+  return merged
+}

--- a/src/app/micro-land/chronicle/types.ts
+++ b/src/app/micro-land/chronicle/types.ts
@@ -1,0 +1,101 @@
+/**
+ * The chronicle — everything Micro Land remembers between visits.
+ *
+ * The world itself stays deliberately forgetful: close the tab and the land is
+ * gone. What survives is the *record* of it — who lived longest, how long a food
+ * web held together, every species you ever saw. That split is the whole design.
+ * You are not keeping a save file, you are keeping a logbook.
+ *
+ * Every type here is plain JSON on purpose: no `Map`, no `Set`, no class, and
+ * `null` rather than `undefined` anywhere a field can be absent. Today this
+ * round-trips through `localStorage`; the plan is for it to round-trip through a
+ * Firebase document keyed by user id instead, and when that happens the only
+ * thing that should have to change is the backend (see `backend.ts`). Anything
+ * that isn't serializable breaks that promise.
+ */
+import type { CreatureBlueprint } from '@/app/micro-land/domain/types'
+
+/**
+ * Bump only when a shape change would make an old chronicle *misread* rather
+ * than merely come up short. Adding an optional field is not a version bump;
+ * changing what an existing field means is. See `migrate` in `chronicle.ts`.
+ */
+export const CHRONICLE_VERSION = 1
+
+/** The single longest life a land has ever held. */
+export interface ElderRecord {
+  /** Age reached, in world-seconds. */
+  seconds: number
+  blueprintId: string
+  /**
+   * Species name copied at the time of the record.
+   *
+   * Denormalized on purpose: a summoned species can fall out of the archive
+   * (see `MAX_ARCHIVED` in `chronicle.ts`) and a record that renders as
+   * "unknown creature" is worse than one that carries its own name.
+   */
+  speciesName: string
+  /** What the player called it, if they named it. */
+  name: string | null
+  /** Epoch ms the record was set. */
+  at: number
+}
+
+/**
+ * What one land remembers.
+ *
+ * Kept per land rather than globally because these numbers only mean something
+ * relative to their world — six minutes alive in a tidepool and six minutes in a
+ * volcanic field are not the same achievement.
+ */
+export interface LandRecord {
+  elder: ElderRecord | null
+  /** Longest stretch, in world-seconds, that passed without an extinction. */
+  steadySeconds: number
+  /** Deepest unbroken family line ever reached here, in generations. */
+  generations: number
+  generationsBlueprintId: string | null
+  generationsSpeciesName: string | null
+}
+
+/**
+ * A species the player has seen alive at least once, in any land.
+ *
+ * The blueprint is archived *in full*, which is the entire point: a summoned
+ * creature currently evaporates on refresh, and this is where it stops doing
+ * that. Blueprints are small — a palette and a few rows of characters — so
+ * carrying them costs little.
+ */
+export interface SpeciesRecord {
+  blueprint: CreatureBlueprint
+  /** Epoch ms of the first sighting. */
+  firstSeen: number
+  /** Epoch ms of the most recent sighting. Drives archive pruning. */
+  lastSeen: number
+  /** Longest one of these has ever lived, in world-seconds. */
+  longestLife: number
+}
+
+export interface ChronicleData {
+  version: number
+  /** Land id → what that land remembers. Ids come from `landId()`. */
+  lands: Record<string, LandRecord>
+  /** Blueprint id → the archived species. */
+  species: Record<string, SpeciesRecord>
+  /** Milestone id → epoch ms first reached. Milestones fire once, ever. */
+  milestones: Record<string, number>
+}
+
+export function emptyChronicle(): ChronicleData {
+  return { version: CHRONICLE_VERSION, lands: {}, species: {}, milestones: {} }
+}
+
+export function emptyLandRecord(): LandRecord {
+  return {
+    elder: null,
+    steadySeconds: 0,
+    generations: 0,
+    generationsBlueprintId: null,
+    generationsSpeciesName: null,
+  }
+}

--- a/src/app/micro-land/components/creature-chip.tsx
+++ b/src/app/micro-land/components/creature-chip.tsx
@@ -14,8 +14,8 @@ interface Run {
  *
  * SVG rather than a canvas so portraits need no DOM APIs and no post-mount
  * effect — they render on the server and in the first paint. Horizontal runs of
- * the same color collapse into one rect, which keeps a 14-wide sprite at a
- * dozen or so nodes instead of two hundred.
+ * the same color collapse into one rect, which matters more now that a sprite
+ * can be 28x24: a dragon is a few dozen nodes this way and 672 without.
  */
 function toRuns(blueprint: CreatureBlueprint): Run[] {
   const rows = blueprint.art.frames[0]

--- a/src/app/micro-land/components/creature-chip.tsx
+++ b/src/app/micro-land/components/creature-chip.tsx
@@ -1,0 +1,78 @@
+'use client'
+
+import type { CreatureBlueprint } from '@/app/micro-land/domain/types'
+
+interface Run {
+  x: number
+  y: number
+  width: number
+  fill: string
+}
+
+/**
+ * A creature's own pixels, drawn as SVG.
+ *
+ * SVG rather than a canvas so portraits need no DOM APIs and no post-mount
+ * effect — they render on the server and in the first paint. Horizontal runs of
+ * the same color collapse into one rect, which keeps a 14-wide sprite at a
+ * dozen or so nodes instead of two hundred.
+ */
+function toRuns(blueprint: CreatureBlueprint): Run[] {
+  const rows = blueprint.art.frames[0]
+  const palette = blueprint.art.palette
+  const runs: Run[] = []
+
+  for (let y = 0; y < rows.length; y++) {
+    const row = rows[y]
+    let x = 0
+    while (x < row.length) {
+      const ch = row[x]
+      const fill = ch === '.' ? undefined : palette[ch]
+      if (!fill) {
+        x++
+        continue
+      }
+      let width = 1
+      while (x + width < row.length && row[x + width] === ch) width++
+      runs.push({ x, y, width, fill })
+      x += width
+    }
+  }
+  return runs
+}
+
+export function CreaturePortrait({
+  blueprint,
+  size = 40,
+}: {
+  blueprint: CreatureBlueprint
+  size?: number
+}) {
+  const rows = blueprint.art.frames[0]
+  const w = rows[0].length
+  const h = rows.length
+  const ratio = w / h
+
+  return (
+    <svg
+      viewBox={`0 0 ${w} ${h}`}
+      width={ratio >= 1 ? size : size * ratio}
+      height={ratio >= 1 ? size / ratio : size}
+      shapeRendering="crispEdges"
+      aria-hidden
+      focusable="false"
+      style={{ display: 'block', overflow: 'visible' }}
+    >
+      {toRuns(blueprint).map((run) => (
+        <rect
+          key={`${run.y}-${run.x}`}
+          x={run.x}
+          y={run.y}
+          width={run.width}
+          height={1}
+          fill={run.fill}
+        />
+      ))}
+    </svg>
+  )
+}

--- a/src/app/micro-land/components/field-guide.tsx
+++ b/src/app/micro-land/components/field-guide.tsx
@@ -1,0 +1,176 @@
+'use client'
+
+import { canEat } from '@/app/micro-land/domain/blueprint'
+import { useMicroLand } from '@/app/micro-land/store'
+
+import { CreaturePortrait } from './creature-chip'
+
+const KIND_WORDS: Record<string, string> = {
+  walk: 'walks',
+  fly: 'flies',
+  swim: 'swims',
+  crawl: 'climbs',
+  drift: 'floats',
+  root: 'stays put',
+}
+
+/**
+ * The field guide.
+ *
+ * Every relationship shown here is derived from the same `canEat` rule the
+ * simulation uses, so a creature summoned thirty seconds ago is described as
+ * accurately as one that shipped with the game.
+ */
+export function FieldGuide() {
+  const open = useMicroLand((s) => s.guideOpen)
+  const setOpen = useMicroLand((s) => s.setGuideOpen)
+  const blueprints = useMicroLand((s) => s.blueprints)
+  const population = useMicroLand((s) => s.population)
+
+  if (!open) return null
+
+  const counts = new Map(population.map((p) => [p.blueprintId, p.count]))
+  const ordered = [...blueprints].sort(
+    (a, b) => (counts.get(b.id) ?? 0) - (counts.get(a.id) ?? 0)
+  )
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-end justify-center sm:items-center"
+      style={{ background: 'var(--cc-modal-scrim)' }}
+      onClick={() => setOpen(false)}
+    >
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label="Field guide"
+        className="w-full max-w-2xl overflow-y-auto rounded-t-xl sm:rounded-xl"
+        style={{
+          maxHeight: '88dvh',
+          background: 'linear-gradient(180deg, var(--cc-modal-bg-from), var(--cc-modal-bg-to))',
+          border: '1px solid var(--cc-modal-border)',
+        }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div
+          className="sticky top-0 flex items-center justify-between px-4 py-3"
+          style={{
+            borderBottom: '1px solid var(--cc-panel-divider)',
+            background: 'var(--cc-modal-bg-from)',
+          }}
+        >
+          <h2
+            style={{
+              fontFamily: 'var(--cc-font-mono)',
+              fontSize: 11,
+              letterSpacing: 2.5,
+              textTransform: 'uppercase',
+              color: 'var(--cc-mint)',
+            }}
+          >
+            Field Guide
+          </h2>
+          <button
+            type="button"
+            className="cc-btn"
+            onClick={() => setOpen(false)}
+            aria-label="Close"
+            style={{ minWidth: 44, minHeight: 34, color: 'var(--cc-text-muted)' }}
+          >
+            ✕
+          </button>
+        </div>
+
+        <ul className="flex flex-col">
+          {ordered.map((bp) => {
+            const eats = blueprints.filter((other) => canEat(bp, other))
+            const eatenBy = blueprints.filter((other) => canEat(other, bp))
+            const alive = counts.get(bp.id) ?? 0
+
+            return (
+              <li
+                key={bp.id}
+                className="flex gap-3 px-4 py-3"
+                style={{ borderBottom: '1px solid var(--cc-panel-divider)' }}
+              >
+                <div className="shrink-0 pt-0.5">
+                  <CreaturePortrait blueprint={bp} size={40} />
+                </div>
+                <div className="min-w-0 flex-1">
+                  <div className="flex flex-wrap items-baseline gap-x-2 gap-y-1">
+                    <span
+                      style={{
+                        fontFamily: 'var(--cc-font-mono)',
+                        fontSize: 12,
+                        letterSpacing: 1.4,
+                        textTransform: 'uppercase',
+                        color: alive > 0 ? 'var(--cc-mint)' : 'var(--cc-text-muted)',
+                      }}
+                    >
+                      {bp.name}
+                    </span>
+                    <span
+                      style={{
+                        fontFamily: 'var(--cc-font-mono)',
+                        fontSize: 10,
+                        color: alive > 0 ? 'var(--cc-text-muted)' : 'var(--cc-pink)',
+                      }}
+                    >
+                      {alive > 0 ? `${alive} alive` : 'none left'}
+                    </span>
+                    {bp.summoned && (
+                      <span
+                        style={{
+                          fontFamily: 'var(--cc-font-mono)',
+                          fontSize: 9,
+                          letterSpacing: 1.2,
+                          textTransform: 'uppercase',
+                          padding: '2px 6px',
+                          borderRadius: 999,
+                          color: 'var(--cc-pink)',
+                          border: '1px solid var(--cc-pink-border)',
+                        }}
+                      >
+                        Summoned
+                      </span>
+                    )}
+                  </div>
+
+                  <p style={{ fontSize: 13, color: 'var(--cc-text-muted)', marginTop: 2 }}>
+                    {bp.blurb}
+                  </p>
+
+                  <p
+                    style={{
+                      fontSize: 12,
+                      color: 'var(--cc-text-muted)',
+                      opacity: 0.85,
+                      marginTop: 6,
+                      lineHeight: 1.6,
+                    }}
+                  >
+                    Size {bp.size} · {KIND_WORDS[bp.move.kind] ?? bp.move.kind}
+                    {bp.body.immuneTo.length > 0 && ` · unburnable`}
+                    {bp.glow > 0 && ` · glows`}
+                    {bp.dig.through.length > 0 &&
+                      ` · digs through ${bp.dig.through.join(', ')}`}
+                    <br />
+                    <strong style={{ fontWeight: 600 }}>Eats:</strong>{' '}
+                    {eats.length > 0
+                      ? eats.map((e) => e.name).join(', ')
+                      : bp.move.kind === 'root'
+                        ? 'sunlight'
+                        : 'nothing here'}
+                    <br />
+                    <strong style={{ fontWeight: 600 }}>Eaten by:</strong>{' '}
+                    {eatenBy.length > 0 ? eatenBy.map((e) => e.name).join(', ') : 'nothing here'}
+                  </p>
+                </div>
+              </li>
+            )
+          })}
+        </ul>
+      </div>
+    </div>
+  )
+}

--- a/src/app/micro-land/components/field-guide.tsx
+++ b/src/app/micro-land/components/field-guide.tsx
@@ -173,63 +173,7 @@ export function FieldGuide() {
         )}
 
         <ul className="flex flex-col">
-          {ordered.map((bp) => {
-            const eats = blueprints.filter((other) => canEat(bp, other))
-            const eatenBy = blueprints.filter((other) => canEat(other, bp))
-            const alive = counts.get(bp.id) ?? 0
-
-            return (
-              <li
-                key={bp.id}
-                className="flex gap-3 px-4 py-3"
-                style={{ borderBottom: '1px solid var(--cc-panel-divider)' }}
-              >
-                <div className="shrink-0 pt-0.5">
-                  <CreaturePortrait blueprint={bp} size={40} />
-                </div>
-                <div className="min-w-0 flex-1">
-                  <div className="flex flex-wrap items-baseline gap-x-2 gap-y-1">
-                    <span
-                      style={{
-                        fontFamily: 'var(--cc-font-mono)',
-                        fontSize: 12,
-                        letterSpacing: 1.4,
-                        textTransform: 'uppercase',
-                        color: alive > 0 ? 'var(--cc-mint)' : 'var(--cc-text-muted)',
-                      }}
-                    >
-                      {bp.name}
-                    </span>
-                    <span
-                      style={{
-                        fontFamily: 'var(--cc-font-mono)',
-                        fontSize: 10,
-                        color: alive > 0 ? 'var(--cc-text-muted)' : 'var(--cc-pink)',
-                      }}
-                    >
-                      {alive > 0 ? `${alive} alive` : 'none left'}
-                    </span>
-                    {bp.summoned && (
-                      <span
-                        className="inline-flex items-center gap-1"
-                        style={{
-                          fontFamily: 'var(--cc-font-mono)',
-                          fontSize: 9,
-                          letterSpacing: 1.2,
-                          textTransform: 'uppercase',
-                          padding: '2px 6px',
-                          borderRadius: 999,
-                          color: 'var(--cc-pink)',
-                          border: '1px solid var(--cc-pink-border)',
-                        }}
-                      >
-                        <SparkleIcon size={9} />
-                        Generated
-                      </span>
-                    )}
-                  </div>
-                </div>
-                    
+          {ordered.map((bp) => (
             <GuideEntry
               key={bp.id}
               bp={bp}
@@ -338,6 +282,7 @@ function GuideEntry({
           </span>
           {bp.summoned && (
             <span
+              className="inline-flex items-center gap-1"
               style={{
                 fontFamily: 'var(--cc-font-mono)',
                 fontSize: 9,
@@ -349,7 +294,8 @@ function GuideEntry({
                 border: '1px solid var(--cc-pink-border)',
               }}
             >
-              Summoned
+              <SparkleIcon size={9} />
+              Generated
             </span>
           )}
         </div>
@@ -371,6 +317,21 @@ function GuideEntry({
           {bp.body.immuneTo.length > 0 && ` · unburnable`}
           {bp.glow > 0 && ` · glows`}
           {bp.dig.through.length > 0 && ` · digs through ${bp.dig.through.join(', ')}`}
+          {bp.aura && (
+            <>
+              <br />
+              <strong style={{ fontWeight: 600 }}>Helps:</strong>{' '}
+              {[
+                bp.aura.helps.length > 0 &&
+                  bp.aura.boost > 1 &&
+                  `${bp.aura.helps.join(' and ')} nearby grow back faster`,
+                bp.aura.converts &&
+                  `turns ${bp.aura.converts.from} into ${bp.aura.converts.to}`,
+              ]
+                .filter(Boolean)
+                .join(' · ')}
+            </>
+          )}
           <br />
           <strong style={{ fontWeight: 600 }}>Eats:</strong>{' '}
           {eats.length > 0

--- a/src/app/micro-land/components/field-guide.tsx
+++ b/src/app/micro-land/components/field-guide.tsx
@@ -1,10 +1,14 @@
 'use client'
 
+import type { SpeciesRecord } from '@/app/micro-land/chronicle/types'
 import { canEat } from '@/app/micro-land/domain/blueprint'
+import type { CreatureBlueprint } from '@/app/micro-land/domain/types'
+import { formatDuration } from '@/app/micro-land/format'
 import { useMicroLand } from '@/app/micro-land/store'
 
 import { CreaturePortrait } from './creature-chip'
 import { SparkleIcon } from './sparkle-icon'
+
 
 const KIND_WORDS: Record<string, string> = {
   walk: 'walks',
@@ -15,18 +19,42 @@ const KIND_WORDS: Record<string, string> = {
   root: 'stays put',
 }
 
+const sectionHeading: React.CSSProperties = {
+  fontFamily: 'var(--cc-font-mono)',
+  fontSize: 10,
+  letterSpacing: 2,
+  textTransform: 'uppercase',
+  color: 'var(--cc-text-muted)',
+}
+
+const recordLabel: React.CSSProperties = {
+  fontFamily: 'var(--cc-font-mono)',
+  fontSize: 9,
+  letterSpacing: 1.2,
+  textTransform: 'uppercase',
+  color: 'var(--cc-text-muted)',
+}
+
 /**
- * The field guide.
+ * The field guide — and, behind the same tap, the logbook.
  *
  * Every relationship shown here is derived from the same `canEat` rule the
  * simulation uses, so a creature summoned thirty seconds ago is described as
  * accurately as one that shipped with the game.
+ *
+ * The records, the remembered species and the milestones all live in here
+ * rather than anywhere on the main screen. That is deliberate: the world stays a
+ * world, and everything the game has been quietly counting is one tap away for
+ * whoever wants it.
  */
 export function FieldGuide() {
   const open = useMicroLand((s) => s.guideOpen)
   const setOpen = useMicroLand((s) => s.setGuideOpen)
   const blueprints = useMicroLand((s) => s.blueprints)
   const population = useMicroLand((s) => s.population)
+  const records = useMicroLand((s) => s.records)
+  const archive = useMicroLand((s) => s.archive)
+  const milestones = useMicroLand((s) => s.milestones)
 
   if (!open) return null
 
@@ -34,6 +62,16 @@ export function FieldGuide() {
   const ordered = [...blueprints].sort(
     (a, b) => (counts.get(b.id) ?? 0) - (counts.get(a.id) ?? 0)
   )
+
+  // Species the player has met before that aren't in this world — the reason a
+  // summoned creature no longer dies with the tab it was invented in.
+  const here = new Set(blueprints.map((b) => b.id))
+  const remembered = archive.filter((s) => !here.has(s.blueprint.id))
+
+  const hasRecords =
+    records.elder !== null ||
+    records.bestSteadySeconds > 0 ||
+    records.bestGenerations > 1
 
   return (
     <div
@@ -81,6 +119,58 @@ export function FieldGuide() {
             ✕
           </button>
         </div>
+
+        {hasRecords && (
+          <section
+            className="flex flex-col gap-2.5 px-4 py-3"
+            style={{ borderBottom: '1px solid var(--cc-panel-divider)' }}
+          >
+            <h3 style={sectionHeading}>This land&rsquo;s records</h3>
+
+            {records.elder && (
+              <div className="flex flex-col gap-0.5">
+                <span style={recordLabel}>Longest life</span>
+                <span style={{ fontSize: 13, color: 'var(--cc-gold)' }}>
+                  {formatDuration(records.elder.seconds)}
+                  <span style={{ color: 'var(--cc-text-muted)' }}>
+                    {' — '}
+                    {records.elder.name
+                      ? `${records.elder.name}, a ${records.elder.speciesName}`
+                      : records.elder.speciesName}
+                  </span>
+                </span>
+              </div>
+            )}
+
+            {records.bestSteadySeconds > 0 && (
+              <div className="flex flex-col gap-0.5">
+                <span style={recordLabel}>Longest without losing a kind</span>
+                <span style={{ fontSize: 13, color: 'var(--cc-text-default)' }}>
+                  {formatDuration(records.bestSteadySeconds)}
+                  {records.steadySeconds >= records.bestSteadySeconds &&
+                    records.steadySeconds > 0 && (
+                      <span style={{ color: 'var(--cc-gold)' }}> — going now</span>
+                    )}
+                </span>
+              </div>
+            )}
+
+            {records.bestGenerations > 1 && (
+              <div className="flex flex-col gap-0.5">
+                <span style={recordLabel}>Deepest family line</span>
+                <span style={{ fontSize: 13, color: 'var(--cc-text-default)' }}>
+                  {records.bestGenerations} generations
+                  {records.bestGenerationsSpeciesName && (
+                    <span style={{ color: 'var(--cc-text-muted)' }}>
+                      {' — '}
+                      {records.bestGenerationsSpeciesName}
+                    </span>
+                  )}
+                </span>
+              </div>
+            )}
+          </section>
+        )}
 
         <ul className="flex flex-col">
           {ordered.map((bp) => {
@@ -138,42 +228,228 @@ export function FieldGuide() {
                       </span>
                     )}
                   </div>
+                </div>
+                    
+            <GuideEntry
+              key={bp.id}
+              bp={bp}
+              alive={counts.get(bp.id) ?? 0}
+              blueprints={blueprints}
+            />
+          ))}
+        </ul>
 
-                  <p style={{ fontSize: 13, color: 'var(--cc-text-muted)', marginTop: 2 }}>
-                    {bp.blurb}
-                  </p>
+        {remembered.length > 0 && (
+          <section style={{ borderTop: '1px solid var(--cc-panel-divider)' }}>
+            <h3 className="px-4 pb-1 pt-3" style={sectionHeading}>
+              Remembered · {remembered.length}
+            </h3>
+            <p
+              className="px-4 pb-2"
+              style={{ fontSize: 12, color: 'var(--cc-text-muted)', opacity: 0.8 }}
+            >
+              Kinds you have met before. None of them are in this land.
+            </p>
+            <ul className="flex flex-col">
+              {remembered.map((record) => (
+                <RememberedEntry key={record.blueprint.id} record={record} />
+              ))}
+            </ul>
+          </section>
+        )}
 
-                  <p
+        {milestones.length > 0 && (
+          <section
+            className="px-4 py-3"
+            style={{ borderTop: '1px solid var(--cc-panel-divider)' }}
+          >
+            <h3 className="pb-2" style={sectionHeading}>
+              Things that have happened
+            </h3>
+            <ul className="flex flex-col gap-1.5">
+              {milestones.map((m) => (
+                <li
+                  key={m.id}
+                  className="flex items-baseline justify-between gap-3"
+                  style={{ fontSize: 12, color: 'var(--cc-text-muted)' }}
+                >
+                  <span>{m.text}</span>
+                  <span
                     style={{
-                      fontSize: 12,
-                      color: 'var(--cc-text-muted)',
-                      opacity: 0.85,
-                      marginTop: 6,
-                      lineHeight: 1.6,
+                      fontFamily: 'var(--cc-font-mono)',
+                      fontSize: 10,
+                      opacity: 0.6,
+                      whiteSpace: 'nowrap',
                     }}
                   >
-                    Size {bp.size} · {KIND_WORDS[bp.move.kind] ?? bp.move.kind}
-                    {bp.body.immuneTo.length > 0 && ` · unburnable`}
-                    {bp.glow > 0 && ` · glows`}
-                    {bp.dig.through.length > 0 &&
-                      ` · digs through ${bp.dig.through.join(', ')}`}
-                    <br />
-                    <strong style={{ fontWeight: 600 }}>Eats:</strong>{' '}
-                    {eats.length > 0
-                      ? eats.map((e) => e.name).join(', ')
-                      : bp.move.kind === 'root'
-                        ? 'sunlight'
-                        : 'nothing here'}
-                    <br />
-                    <strong style={{ fontWeight: 600 }}>Eaten by:</strong>{' '}
-                    {eatenBy.length > 0 ? eatenBy.map((e) => e.name).join(', ') : 'nothing here'}
-                  </p>
-                </div>
-              </li>
-            )
-          })}
-        </ul>
+                    {new Date(m.at).toLocaleDateString()}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          </section>
+        )}
       </div>
     </div>
+  )
+}
+
+function GuideEntry({
+  bp,
+  alive,
+  blueprints,
+}: {
+  bp: CreatureBlueprint
+  alive: number
+  blueprints: CreatureBlueprint[]
+}) {
+  const eats = blueprints.filter((other) => canEat(bp, other))
+  const eatenBy = blueprints.filter((other) => canEat(other, bp))
+
+  return (
+    <li
+      className="flex gap-3 px-4 py-3"
+      style={{ borderBottom: '1px solid var(--cc-panel-divider)' }}
+    >
+      <div className="shrink-0 pt-0.5">
+        <CreaturePortrait blueprint={bp} size={40} />
+      </div>
+      <div className="min-w-0 flex-1">
+        <div className="flex flex-wrap items-baseline gap-x-2 gap-y-1">
+          <span
+            style={{
+              fontFamily: 'var(--cc-font-mono)',
+              fontSize: 12,
+              letterSpacing: 1.4,
+              textTransform: 'uppercase',
+              color: alive > 0 ? 'var(--cc-mint)' : 'var(--cc-text-muted)',
+            }}
+          >
+            {bp.name}
+          </span>
+          <span
+            style={{
+              fontFamily: 'var(--cc-font-mono)',
+              fontSize: 10,
+              color: alive > 0 ? 'var(--cc-text-muted)' : 'var(--cc-pink)',
+            }}
+          >
+            {alive > 0 ? `${alive} alive` : 'none left'}
+          </span>
+          {bp.summoned && (
+            <span
+              style={{
+                fontFamily: 'var(--cc-font-mono)',
+                fontSize: 9,
+                letterSpacing: 1.2,
+                textTransform: 'uppercase',
+                padding: '2px 6px',
+                borderRadius: 999,
+                color: 'var(--cc-pink)',
+                border: '1px solid var(--cc-pink-border)',
+              }}
+            >
+              Summoned
+            </span>
+          )}
+        </div>
+
+        <p style={{ fontSize: 13, color: 'var(--cc-text-muted)', marginTop: 2 }}>
+          {bp.blurb}
+        </p>
+
+        <p
+          style={{
+            fontSize: 12,
+            color: 'var(--cc-text-muted)',
+            opacity: 0.85,
+            marginTop: 6,
+            lineHeight: 1.6,
+          }}
+        >
+          Size {bp.size} · {KIND_WORDS[bp.move.kind] ?? bp.move.kind}
+          {bp.body.immuneTo.length > 0 && ` · unburnable`}
+          {bp.glow > 0 && ` · glows`}
+          {bp.dig.through.length > 0 && ` · digs through ${bp.dig.through.join(', ')}`}
+          <br />
+          <strong style={{ fontWeight: 600 }}>Eats:</strong>{' '}
+          {eats.length > 0
+            ? eats.map((e) => e.name).join(', ')
+            : bp.move.kind === 'root'
+              ? 'sunlight'
+              : 'nothing here'}
+          <br />
+          <strong style={{ fontWeight: 600 }}>Eaten by:</strong>{' '}
+          {eatenBy.length > 0 ? eatenBy.map((e) => e.name).join(', ') : 'nothing here'}
+        </p>
+      </div>
+    </li>
+  )
+}
+
+/**
+ * A species from a past visit.
+ *
+ * Says less than a live entry on purpose: who eats whom is a fact about *this*
+ * world, and repeating it for a creature that isn't here would be describing a
+ * food chain that doesn't exist.
+ */
+function RememberedEntry({ record }: { record: SpeciesRecord }) {
+  const bp = record.blueprint
+  return (
+    <li
+      className="flex gap-3 px-4 py-2.5"
+      style={{ borderBottom: '1px solid var(--cc-panel-divider)', opacity: 0.62 }}
+    >
+      <div className="shrink-0 pt-0.5">
+        <CreaturePortrait blueprint={bp} size={30} />
+      </div>
+      <div className="min-w-0 flex-1">
+        <div className="flex flex-wrap items-baseline gap-x-2 gap-y-1">
+          <span
+            style={{
+              fontFamily: 'var(--cc-font-mono)',
+              fontSize: 11,
+              letterSpacing: 1.4,
+              textTransform: 'uppercase',
+              color: 'var(--cc-text-muted)',
+            }}
+          >
+            {bp.name}
+          </span>
+          {bp.summoned && (
+            <span
+              style={{
+                fontFamily: 'var(--cc-font-mono)',
+                fontSize: 9,
+                letterSpacing: 1.2,
+                textTransform: 'uppercase',
+                padding: '1px 5px',
+                borderRadius: 999,
+                color: 'var(--cc-pink)',
+                border: '1px solid var(--cc-pink-border)',
+              }}
+            >
+              Summoned
+            </span>
+          )}
+        </div>
+        <p style={{ fontSize: 12, color: 'var(--cc-text-muted)', marginTop: 1 }}>
+          {bp.blurb}
+        </p>
+        <p
+          style={{
+            fontFamily: 'var(--cc-font-mono)',
+            fontSize: 10,
+            color: 'var(--cc-text-muted)',
+            opacity: 0.75,
+            marginTop: 4,
+          }}
+        >
+          First seen {new Date(record.firstSeen).toLocaleDateString()}
+          {record.longestLife > 0 && ` · lived ${formatDuration(record.longestLife)}`}
+        </p>
+      </div>
+    </li>
   )
 }

--- a/src/app/micro-land/components/field-guide.tsx
+++ b/src/app/micro-land/components/field-guide.tsx
@@ -4,6 +4,7 @@ import { canEat } from '@/app/micro-land/domain/blueprint'
 import { useMicroLand } from '@/app/micro-land/store'
 
 import { CreaturePortrait } from './creature-chip'
+import { SparkleIcon } from './sparkle-icon'
 
 const KIND_WORDS: Record<string, string> = {
   walk: 'walks',
@@ -120,6 +121,7 @@ export function FieldGuide() {
                     </span>
                     {bp.summoned && (
                       <span
+                        className="inline-flex items-center gap-1"
                         style={{
                           fontFamily: 'var(--cc-font-mono)',
                           fontSize: 9,
@@ -131,7 +133,8 @@ export function FieldGuide() {
                           border: '1px solid var(--cc-pink-border)',
                         }}
                       >
-                        Summoned
+                        <SparkleIcon size={9} />
+                        Generated
                       </span>
                     )}
                   </div>

--- a/src/app/micro-land/components/hud.tsx
+++ b/src/app/micro-land/components/hud.tsx
@@ -1,6 +1,8 @@
 'use client'
 
 import { THEMES } from '@/app/micro-land/domain/config/themes'
+import { STEADY_SHOW_SECONDS } from '@/app/micro-land/domain/constants'
+import { formatDuration } from '@/app/micro-land/format'
 import { SUMMONED_THEME_ID, useMicroLand } from '@/app/micro-land/store'
 
 const SPEEDS = [
@@ -45,8 +47,12 @@ export function Hud({
   const population = useMicroLand((s) => s.population)
   const setGuideOpen = useMicroLand((s) => s.setGuideOpen)
   const summonedLand = useMicroLand((s) => s.summonedLand)
+  const steadySeconds = useMicroLand((s) => s.records.steadySeconds)
 
   const species = population.length
+  // Below the threshold this would flicker on and off through the early churn,
+  // which reads as a broken counter rather than as a streak.
+  const steady = steadySeconds >= STEADY_SHOW_SECONDS ? formatDuration(steadySeconds) : null
 
   return (
     <header
@@ -137,8 +143,19 @@ export function Hud({
           className="cc-btn"
           onClick={() => setGuideOpen(true)}
           style={chipBase}
+          title={
+            steady
+              ? 'How long this land has gone without losing a species'
+              : undefined
+          }
         >
           {species} kinds · {total} alive
+          {steady && (
+            <>
+              {' · '}
+              <span style={{ color: 'var(--cc-gold)' }}>{steady} steady</span>
+            </>
+          )}
         </button>
         <button
           type="button"

--- a/src/app/micro-land/components/hud.tsx
+++ b/src/app/micro-land/components/hud.tsx
@@ -1,0 +1,159 @@
+'use client'
+
+import { THEMES } from '@/app/micro-land/domain/config/themes'
+import { SUMMONED_THEME_ID, useMicroLand } from '@/app/micro-land/store'
+
+const SPEEDS = [
+  { value: 0.5, label: '½×' },
+  { value: 1, label: '1×' },
+  { value: 3, label: '3×' },
+]
+
+const chipBase: React.CSSProperties = {
+  fontFamily: 'var(--cc-font-mono)',
+  fontSize: 10,
+  letterSpacing: 1.4,
+  textTransform: 'uppercase',
+  borderRadius: 4,
+  padding: '7px 10px',
+  minHeight: 34,
+  border: '1px solid var(--cc-mint-line)',
+  background: 'transparent',
+  color: 'var(--cc-text-muted)',
+}
+
+const activeChip: React.CSSProperties = {
+  background: 'var(--cc-mint-soft)',
+  borderColor: 'var(--cc-mint)',
+  color: 'var(--cc-mint)',
+}
+
+export function Hud({
+  onReshuffle,
+  onClearLife,
+}: {
+  onReshuffle: () => void
+  onClearLife: () => void
+}) {
+  const themeId = useMicroLand((s) => s.themeId)
+  const setTheme = useMicroLand((s) => s.setTheme)
+  const paused = useMicroLand((s) => s.paused)
+  const togglePaused = useMicroLand((s) => s.togglePaused)
+  const speed = useMicroLand((s) => s.speed)
+  const setSpeed = useMicroLand((s) => s.setSpeed)
+  const total = useMicroLand((s) => s.totalCreatures)
+  const population = useMicroLand((s) => s.population)
+  const setGuideOpen = useMicroLand((s) => s.setGuideOpen)
+  const summonedLand = useMicroLand((s) => s.summonedLand)
+
+  const species = population.length
+
+  return (
+    <header
+      className="flex flex-wrap items-center gap-2 px-3 py-2 pl-14"
+      style={{
+        borderBottom: '1px solid var(--cc-panel-divider)',
+        background: 'linear-gradient(180deg, var(--cc-panel-grad-from), transparent)',
+      }}
+    >
+      <h1
+        className="hidden sm:block"
+        style={{
+          fontFamily: 'var(--cc-font-mono)',
+          fontSize: 12,
+          letterSpacing: 3,
+          textTransform: 'uppercase',
+          color: 'var(--cc-mint)',
+        }}
+      >
+        Micro&nbsp;Land
+      </h1>
+
+      <label className="sr-only" htmlFor="micro-land-theme">
+        Choose a world
+      </label>
+      <select
+        id="micro-land-theme"
+        value={themeId}
+        onChange={(e) => setTheme(e.target.value)}
+        style={{
+          ...chipBase,
+          color: 'var(--cc-text-default)',
+          background: 'var(--cc-panel-grad-to)',
+        }}
+      >
+        {THEMES.map((theme) => (
+          <option key={theme.id} value={theme.id}>
+            {theme.name}
+          </option>
+        ))}
+        {summonedLand && (
+          <option value={SUMMONED_THEME_ID}>✦ {summonedLand}</option>
+        )}
+      </select>
+
+      <button
+        type="button"
+        className="cc-btn"
+        onClick={onReshuffle}
+        style={chipBase}
+        title="Build this world again, differently"
+      >
+        Reshape
+      </button>
+
+      <div className="flex items-center gap-1" role="group" aria-label="Speed">
+        <button
+          type="button"
+          className="cc-btn"
+          onClick={togglePaused}
+          style={{ ...chipBase, ...(paused ? activeChip : {}) }}
+          aria-pressed={paused}
+        >
+          {paused ? 'Paused' : 'Pause'}
+        </button>
+        {SPEEDS.map((option) => (
+          <button
+            key={option.value}
+            type="button"
+            className="cc-btn"
+            onClick={() => setSpeed(option.value)}
+            style={{
+              ...chipBase,
+              padding: '7px 9px',
+              ...(speed === option.value ? activeChip : {}),
+            }}
+            aria-pressed={speed === option.value}
+            aria-label={`Speed ${option.label}`}
+          >
+            {option.label}
+          </button>
+        ))}
+      </div>
+
+      <div className="ml-auto flex items-center gap-2">
+        <button
+          type="button"
+          className="cc-btn"
+          onClick={() => setGuideOpen(true)}
+          style={chipBase}
+        >
+          {species} kinds · {total} alive
+        </button>
+        <button
+          type="button"
+          className="cc-btn"
+          onClick={onClearLife}
+          style={{
+            ...chipBase,
+            borderColor: 'var(--cc-pink-border)',
+            color: 'var(--cc-pink)',
+          }}
+          title="Remove every living thing"
+        >
+          Empty
+        </button>
+      </div>
+    </header>
+  )
+}

--- a/src/app/micro-land/components/inspector.tsx
+++ b/src/app/micro-land/components/inspector.tsx
@@ -1,0 +1,242 @@
+'use client'
+
+import { canEat } from '@/app/micro-land/domain/blueprint'
+import { useMicroLand } from '@/app/micro-land/store'
+
+import { CreaturePortrait } from './creature-chip'
+
+/** Plain-language version of the mood the simulation is actually in. */
+const MOOD_TEXT: Record<string, string> = {
+  wander: 'Wandering about',
+  hunt: 'Looking for food',
+  flee: 'Running away!',
+  eat: 'Eating',
+  rest: 'Resting',
+}
+
+/**
+ * Rooted things share the same moods internally but can't act on them, so
+ * "Wandering about" for a mushroom reads as a bug rather than flavour.
+ */
+function moodText(mood: string, kind: string): string {
+  if (kind === 'root') return 'Growing quietly'
+  return MOOD_TEXT[mood] ?? mood
+}
+
+const KIND_TEXT: Record<string, string> = {
+  walk: 'Walks on the ground',
+  fly: 'Flies',
+  swim: 'Swims — drowns in air',
+  crawl: 'Climbs walls and ceilings',
+  drift: 'Floats along',
+  root: 'Rooted to the spot',
+}
+
+function Meter({
+  label,
+  value,
+  tone,
+  right,
+}: {
+  label: string
+  value: number
+  tone: string
+  right?: string
+}) {
+  const pct = Math.round(Math.max(0, Math.min(1, value)) * 100)
+  return (
+    <div className="flex flex-col gap-1">
+      <div className="flex items-baseline justify-between">
+        <span style={meterLabel}>{label}</span>
+        <span style={{ ...meterLabel, opacity: 0.55 }}>{right ?? `${pct}%`}</span>
+      </div>
+      <div
+        style={{
+          height: 6,
+          borderRadius: 3,
+          background: 'rgba(0,0,0,0.45)',
+          overflow: 'hidden',
+        }}
+      >
+        <div style={{ width: `${pct}%`, height: '100%', background: tone }} />
+      </div>
+    </div>
+  )
+}
+
+const meterLabel: React.CSSProperties = {
+  fontFamily: 'var(--cc-font-mono)',
+  fontSize: 9,
+  letterSpacing: 1.2,
+  textTransform: 'uppercase',
+  opacity: 0.75,
+}
+
+/**
+ * Live read-out for one creature.
+ *
+ * Everything here comes from the same blueprint the simulation runs on, so a
+ * creature summoned a moment ago reports exactly as completely as a built-in —
+ * including who eats it, which is derived from `canEat` rather than authored.
+ */
+export function Inspector() {
+  const inspected = useMicroLand((s) => s.inspected)
+  const blueprints = useMicroLand((s) => s.blueprints)
+  const setTool = useMicroLand((s) => s.setTool)
+
+  if (!inspected) return null
+
+  const bp = blueprints.find((b) => b.id === inspected.blueprintId)
+  if (!bp) return null
+
+  const eats = blueprints.filter((other) => canEat(bp, other))
+  const eatenBy = blueprints.filter((other) => canEat(other, bp))
+
+  const fullness = 1 - inspected.hunger
+  const lifeLeft = Math.max(
+    0,
+    1 - inspected.ageSeconds / Math.max(1, inspected.lifespanSeconds)
+  )
+
+  const trouble =
+    inspected.starving > 0
+      ? 'Starving!'
+      : inspected.distress > 1
+        ? inspected.inWater
+          ? 'Drowning!'
+          : 'Out of water!'
+        : null
+
+  return (
+    <div
+      className="pointer-events-auto absolute right-2 top-2 w-[248px] max-w-[calc(100%-1rem)] overflow-y-auto rounded-lg backdrop-blur-sm"
+      style={{
+        maxHeight: 'calc(100% - 1rem)',
+        background: 'rgba(4, 14, 16, 0.88)',
+        border: '1px solid var(--cc-mint-line)',
+      }}
+      role="status"
+      aria-live="polite"
+    >
+      <div
+        className="flex items-start gap-2.5 p-3"
+        style={{ borderBottom: '1px solid var(--cc-panel-divider)' }}
+      >
+        <CreaturePortrait blueprint={bp} size={38} />
+        <div className="min-w-0 flex-1">
+          <div
+            style={{
+              fontFamily: 'var(--cc-font-mono)',
+              fontSize: 11,
+              letterSpacing: 1.4,
+              textTransform: 'uppercase',
+              color: 'var(--cc-mint)',
+            }}
+          >
+            {bp.name}
+          </div>
+          <div style={{ fontSize: 11, color: 'var(--cc-text-muted)', lineHeight: 1.4 }}>
+            {bp.blurb}
+          </div>
+        </div>
+        <button
+          type="button"
+          className="cc-btn"
+          onClick={() => setTool({ kind: 'inspect' })}
+          aria-label="Stop inspecting"
+          style={{ minWidth: 28, minHeight: 28, color: 'var(--cc-text-muted)', fontSize: 12 }}
+          onPointerDown={(e) => e.stopPropagation()}
+        >
+          ✕
+        </button>
+      </div>
+
+      <div className="flex flex-col gap-2.5 p-3">
+        <div
+          style={{
+            fontFamily: 'var(--cc-font-mono)',
+            fontSize: 10,
+            letterSpacing: 1,
+            color: trouble ? 'var(--cc-pink)' : 'var(--cc-text-default)',
+          }}
+        >
+          {trouble ?? moodText(inspected.mood, bp.move.kind)}
+          {inspected.targetName && !trouble && bp.move.kind !== 'root' && (
+            <span style={{ opacity: 0.7 }}>
+              {inspected.mood === 'flee' ? ' from ' : ' → '}
+              {inspected.targetName}
+            </span>
+          )}
+        </div>
+
+        <Meter
+          label="Full"
+          value={fullness}
+          tone={fullness < 0.25 ? 'var(--cc-pink)' : 'var(--cc-mint)'}
+        />
+        <Meter
+          label="Life left"
+          value={lifeLeft}
+          tone="var(--cc-gold)"
+          right={`${Math.round(inspected.ageSeconds)}s old`}
+        />
+
+        <div className="grid grid-cols-2 gap-x-3 gap-y-1 pt-0.5">
+          <Stat label="Meals eaten" value={String(inspected.mealsEaten)} />
+          <Stat label="Babies" value={String(inspected.children)} />
+          <Stat label="Size" value={String(bp.size)} />
+          <Stat label="Speed" value={inspected.speed.toFixed(1)} />
+          {bp.dig.through.length > 0 && (
+            <Stat label="Tiles dug" value={String(inspected.tilesDug)} />
+          )}
+        </div>
+
+        <div style={{ fontSize: 11, color: 'var(--cc-text-muted)', lineHeight: 1.55 }}>
+          {KIND_TEXT[bp.move.kind] ?? bp.move.kind}
+          {bp.body.immuneTo.length > 0 && ' · fireproof'}
+          {bp.glow > 0 && ' · glows'}
+          {inspected.inWater && ' · in water'}
+          {bp.dig.through.length > 0 && (
+            <>
+              <br />
+              Digs through {bp.dig.through.join(', ')}
+            </>
+          )}
+        </div>
+
+        <div style={{ fontSize: 11, color: 'var(--cc-text-muted)', lineHeight: 1.55 }}>
+          <strong style={{ fontWeight: 600, color: 'var(--cc-text-default)' }}>
+            Eats:
+          </strong>{' '}
+          {eats.length > 0
+            ? eats.map((e) => e.name).join(', ')
+            : bp.move.kind === 'root'
+              ? 'sunlight'
+              : 'nothing here'}
+          <br />
+          <strong style={{ fontWeight: 600, color: 'var(--cc-text-default)' }}>
+            Eaten by:
+          </strong>{' '}
+          {eatenBy.length > 0 ? eatenBy.map((e) => e.name).join(', ') : 'nothing here'}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function Stat({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex items-baseline justify-between gap-2">
+      <span style={meterLabel}>{label}</span>
+      <span
+        style={{
+          fontFamily: 'var(--cc-font-mono)',
+          fontSize: 12,
+          color: 'var(--cc-text-default)',
+        }}
+      >
+        {value}
+      </span>
+    </div>
+  )
+}

--- a/src/app/micro-land/components/inspector.tsx
+++ b/src/app/micro-land/components/inspector.tsx
@@ -1,5 +1,7 @@
 'use client'
 
+import { useState } from 'react'
+
 import { canEat } from '@/app/micro-land/domain/blueprint'
 import { useMicroLand } from '@/app/micro-land/store'
 
@@ -79,12 +81,24 @@ const meterLabel: React.CSSProperties = {
  * creature summoned a moment ago reports exactly as completely as a built-in —
  * including who eats it, which is derived from `canEat` rather than authored.
  */
-export function Inspector() {
+export function Inspector({ onName }: { onName: (name: string) => boolean }) {
   const inspected = useMicroLand((s) => s.inspected)
   const blueprints = useMicroLand((s) => s.blueprints)
   const setTool = useMicroLand((s) => s.setTool)
 
+  /**
+   * The half-typed name, tagged with who it is for.
+   *
+   * Keyed by creature id rather than reset in an effect: tapping a second
+   * creature mid-type has to abandon the name, and deriving that from the id
+   * makes it true on the same render instead of one render later.
+   */
+  const [pending, setPending] = useState<{ id: number; text: string } | null>(null)
+
   if (!inspected) return null
+
+  const naming = pending?.id === inspected.id
+  const draft = naming ? pending.text : ''
 
   const bp = blueprints.find((b) => b.id === inspected.blueprintId)
   if (!bp) return null
@@ -133,10 +147,10 @@ export function Inspector() {
               color: 'var(--cc-mint)',
             }}
           >
-            {bp.name}
+            {inspected.name ?? bp.name}
           </div>
           <div style={{ fontSize: 11, color: 'var(--cc-text-muted)', lineHeight: 1.4 }}>
-            {bp.blurb}
+            {inspected.name ? bp.name : bp.blurb}
           </div>
         </div>
         <button
@@ -152,6 +166,101 @@ export function Inspector() {
       </div>
 
       <div className="flex flex-col gap-2.5 p-3">
+        {/*
+          The elder band is the only thing in this panel that isn't a fact about
+          the creature — it's the game acknowledging one. It appears for exactly
+          one creature at a time and nowhere else in the UI.
+        */}
+        {inspected.isElder && (
+          <div
+            className="flex flex-col gap-1.5 rounded px-2.5 py-2"
+            style={{
+              background: 'rgba(252, 211, 77, 0.08)',
+              border: '1px solid rgba(252, 211, 77, 0.35)',
+            }}
+          >
+            <div
+              style={{
+                fontFamily: 'var(--cc-font-mono)',
+                fontSize: 9,
+                letterSpacing: 1.2,
+                textTransform: 'uppercase',
+                color: 'var(--cc-gold)',
+              }}
+            >
+              ✦ Oldest this land remembers
+            </div>
+
+            {inspected.name ? null : naming ? (
+              <form
+                className="flex gap-1.5"
+                onSubmit={(e) => {
+                  e.preventDefault()
+                  if (onName(draft)) setPending(null)
+                }}
+              >
+                <label className="sr-only" htmlFor="micro-land-elder-name">
+                  Name this creature
+                </label>
+                <input
+                  id="micro-land-elder-name"
+                  autoFocus
+                  value={draft}
+                  onChange={(e) => setPending({ id: inspected.id, text: e.target.value })}
+                  maxLength={24}
+                  placeholder="Call it something"
+                  className="min-w-0 flex-1 rounded px-2 py-1"
+                  style={{
+                    fontSize: 12,
+                    color: 'var(--cc-text-default)',
+                    background: 'rgba(0,0,0,0.4)',
+                    border: '1px solid var(--cc-mint-line)',
+                  }}
+                  // The canvas grabs creatures on pointerdown; without this,
+                  // tapping the field throws whatever is underneath it.
+                  onPointerDown={(e) => e.stopPropagation()}
+                />
+                <button
+                  type="submit"
+                  className="cc-btn"
+                  disabled={draft.trim().length === 0}
+                  style={{
+                    fontFamily: 'var(--cc-font-mono)',
+                    fontSize: 10,
+                    letterSpacing: 1,
+                    textTransform: 'uppercase',
+                    padding: '4px 8px',
+                    color: 'var(--cc-gold)',
+                    border: '1px solid rgba(252, 211, 77, 0.35)',
+                    opacity: draft.trim().length === 0 ? 0.4 : 1,
+                  }}
+                  onPointerDown={(e) => e.stopPropagation()}
+                >
+                  Name
+                </button>
+              </form>
+            ) : (
+              <button
+                type="button"
+                className="cc-btn self-start"
+                onClick={() => setPending({ id: inspected.id, text: '' })}
+                style={{
+                  fontFamily: 'var(--cc-font-mono)',
+                  fontSize: 10,
+                  letterSpacing: 1,
+                  textTransform: 'uppercase',
+                  padding: '4px 8px',
+                  color: 'var(--cc-gold)',
+                  border: '1px solid rgba(252, 211, 77, 0.35)',
+                }}
+                onPointerDown={(e) => e.stopPropagation()}
+              >
+                Give it a name
+              </button>
+            )}
+          </div>
+        )}
+
         <div
           style={{
             fontFamily: 'var(--cc-font-mono)',
@@ -186,6 +295,14 @@ export function Inspector() {
           <Stat label="Babies" value={String(inspected.children)} />
           <Stat label="Size" value={String(bp.size)} />
           <Stat label="Speed" value={inspected.speed.toFixed(1)} />
+          {/*
+            Hidden at generation 1, which is every creature you place by hand.
+            It appears the first time you're looking at something that was *born*
+            here, which is the only point at which the number means anything.
+          */}
+          {inspected.generation > 1 && (
+            <Stat label="Generation" value={String(inspected.generation)} />
+          )}
           {bp.dig.through.length > 0 && (
             <Stat label="Tiles dug" value={String(inspected.tilesDug)} />
           )}

--- a/src/app/micro-land/components/notices.tsx
+++ b/src/app/micro-land/components/notices.tsx
@@ -1,0 +1,46 @@
+'use client'
+
+import { useEffect } from 'react'
+
+import { useMicroLand } from '@/app/micro-land/store'
+
+const LIFETIME_MS = 4200
+
+/** Small, quiet messages about what just happened in the world. */
+export function Notices() {
+  const notices = useMicroLand((s) => s.notices)
+  const dismiss = useMicroLand((s) => s.dismissNotice)
+
+  useEffect(() => {
+    if (notices.length === 0) return
+    const timers = notices.map((notice) =>
+      setTimeout(() => dismiss(notice.id), LIFETIME_MS)
+    )
+    return () => timers.forEach(clearTimeout)
+  }, [notices, dismiss])
+
+  if (notices.length === 0) return null
+
+  return (
+    <div
+      className="pointer-events-none absolute left-1/2 top-3 flex -translate-x-1/2 flex-col items-center gap-1.5 px-3"
+      aria-live="polite"
+    >
+      {notices.map((notice) => (
+        <div
+          key={notice.id}
+          className="rounded-full px-3.5 py-1.5 text-center backdrop-blur-sm"
+          style={{
+            fontSize: 12,
+            color: 'var(--cc-text-default)',
+            background: 'rgba(2, 8, 10, 0.72)',
+            border: '1px solid var(--cc-mint-line)',
+            maxWidth: '92vw',
+          }}
+        >
+          {notice.text}
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/src/app/micro-land/components/pan-controls.tsx
+++ b/src/app/micro-land/components/pan-controls.tsx
@@ -1,0 +1,108 @@
+'use client'
+
+import { useCallback, useEffect, useRef } from 'react'
+
+import { useMicroLand } from '@/app/micro-land/store'
+
+/** A press shorter than this was a click, not a hold. */
+const TAP_MS = 200
+
+/**
+ * The two arrows that walk you along the world.
+ *
+ * The world is three screens wide, and every other way of moving it is a gesture
+ * you have to already know: two fingers, a trackpad swipe, an arrow key, a tap
+ * on the map. These are the one control that is simply *visible*, which makes
+ * them the ones that matter on a phone and the ones a screen reader can find.
+ *
+ * Press and hold to keep going; a quick press steps once. Both are wired,
+ * because a small child holds the button down and an adult clicks it.
+ */
+export function PanControls({
+  onHold,
+  onNudge,
+}: {
+  onHold: (direction: -1 | 0 | 1) => void
+  onNudge: (direction: -1 | 1) => void
+}) {
+  const canPan = useMicroLand((s) => s.canPan)
+  const pressedAt = useRef(0)
+
+  const stop = useCallback(() => {
+    pressedAt.current = 0
+    onHold(0)
+  }, [onHold])
+
+  // A pointer released outside the button never sends pointerup *to* the
+  // button, and a camera that scrolls forever after is the worst bug this could
+  // have. The window always hears about it.
+  useEffect(() => {
+    window.addEventListener('pointerup', stop)
+    window.addEventListener('pointercancel', stop)
+    return () => {
+      window.removeEventListener('pointerup', stop)
+      window.removeEventListener('pointercancel', stop)
+    }
+  }, [stop])
+
+  if (!canPan) return null
+
+  const button = (direction: -1 | 1) => (
+    <button
+      type="button"
+      aria-label={direction === -1 ? 'Look further west' : 'Look further east'}
+      className="pointer-events-auto flex h-11 w-9 items-center justify-center rounded-lg backdrop-blur-sm transition-opacity hover:opacity-100 focus-visible:opacity-100"
+      style={{
+        color: 'var(--cc-text-default)',
+        background: 'rgba(2, 8, 10, 0.6)',
+        border: '1px solid var(--cc-mint-line)',
+        opacity: 0.62,
+        touchAction: 'none',
+      }}
+      onPointerDown={(e) => {
+        e.preventDefault()
+        pressedAt.current = e.timeStamp
+        onHold(direction)
+      }}
+      onPointerUp={(e) => {
+        // Let go quickly and the hold barely moved anything; give it one clean
+        // step so a tap always does something you can see.
+        if (pressedAt.current > 0 && e.timeStamp - pressedAt.current < TAP_MS) {
+          onNudge(direction)
+        }
+        stop()
+      }}
+      onPointerLeave={stop}
+      // Enter and Space fire a click with no pointer event behind it, and that
+      // is the only case this needs to catch — `detail` is 0 for exactly those.
+      onClick={(e) => {
+        if (e.detail === 0) onNudge(direction)
+      }}
+    >
+      <svg
+        width="14"
+        height="14"
+        viewBox="0 0 14 14"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        aria-hidden="true"
+      >
+        {direction === -1 ? (
+          <polyline points="9,2 3,7 9,12" />
+        ) : (
+          <polyline points="5,2 11,7 5,12" />
+        )}
+      </svg>
+    </button>
+  )
+
+  return (
+    <div className="pointer-events-none absolute inset-0 flex items-center justify-between px-2">
+      {button(-1)}
+      {button(1)}
+    </div>
+  )
+}

--- a/src/app/micro-land/components/sparkle-icon.tsx
+++ b/src/app/micro-land/components/sparkle-icon.tsx
@@ -1,0 +1,24 @@
+/**
+ * The four-point sparkle that marks the parts of Micro Land a machine makes.
+ *
+ * Two stars rather than one: the small trailing star is what reads as "sparkle"
+ * at 12px instead of as an asterisk. Drawn in `currentColor` so it takes the
+ * tint of whatever button or badge it sits in, and sized in `em` so it scales
+ * with the label beside it.
+ */
+export function SparkleIcon({ size = '1em' }: { size?: number | string }) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      width={size}
+      height={size}
+      fill="currentColor"
+      aria-hidden="true"
+      focusable="false"
+      style={{ display: 'inline-block', verticalAlign: '-0.12em', flex: 'none' }}
+    >
+      <path d="M9 2 10.4 7.6 16 9 10.4 10.4 9 16 7.6 10.4 2 9 7.6 7.6Z" />
+      <path d="M17.5 13.5 18.4 17.1 22 18l-3.6.9-.9 3.6-.9-3.6L13 18l3.6-.9Z" />
+    </svg>
+  )
+}

--- a/src/app/micro-land/components/summon-loader.tsx
+++ b/src/app/micro-land/components/summon-loader.tsx
@@ -433,7 +433,7 @@ export function SummonLoader({
       </p>
 
       <span className="sr-only" role="status">
-        Summoning. This can take a minute.
+        Generating. This can take a minute.
       </span>
 
       <button

--- a/src/app/micro-land/components/summon-loader.tsx
+++ b/src/app/micro-land/components/summon-loader.tsx
@@ -1,0 +1,456 @@
+'use client'
+
+import { useEffect, useRef, useState } from 'react'
+
+import {
+  LOADER_CREATURE_SHAPES,
+  LOADER_TERRAIN_SHAPES,
+  type LoaderShape,
+} from '@/app/micro-land/domain/config/loader-shapes'
+
+/**
+ * The wait, as a piece of the world.
+ *
+ * A summon can take the better part of a minute. A greyed-out form for that
+ * long reads as a broken game — especially to a player who just described a
+ * lava cat and is waiting to meet it. So the wait shows the work: sand pours
+ * into the panel and piles up under the same falling-powder rules the world
+ * runs on, then lifts off the floor and assembles into a creature, which
+ * breathes for a moment before collapsing back into sand and starting over.
+ *
+ * The physics here is a small self-contained copy rather than `tickTiles`:
+ * the real world is still simulating behind the modal and tickTiles keeps a
+ * module-level scratch buffer, and the assembly phase needs free-floating
+ * grains at fractional positions, which a tile grid can't express.
+ *
+ * Drawn one canvas pixel per grain and blown up by CSS, the same way the world
+ * renderer works — so the loader sits on the same pixel grid as the game.
+ */
+
+const GRID_W = 64
+const GRID_H = 36
+
+/** One powder pass. Slow enough that you can watch grains land. */
+const SAND_STEP_MS = 28
+const GRAINS_PER_STEP = 2
+/** Half-width of the mouth the sand pours from, in cells. */
+const POUR_SPREAD = 8
+
+const RAIN_MAX_MS = 4600
+const GATHER_MS = 1000
+const HOLD_MS = 2400
+const SCATTER_MS = 900
+
+type Phase = 'rain' | 'gather' | 'hold' | 'scatter'
+
+interface Grain {
+  x: number
+  y: number
+  vx: number
+  vy: number
+  /** Where this grain belongs once the body comes together. */
+  tx: number
+  ty: number
+  color: string
+  eye: boolean
+  alpha: number
+  /** Fixed per grain, so the shimmer in the hold phase isn't in lockstep. */
+  seed: number
+}
+
+const CREATURE_LINES = [
+  'Finding its shape…',
+  'Choosing its colors…',
+  'Giving it a body…',
+  'Working out how it moves…',
+  'Deciding what it eats…',
+  'Waking it up…',
+]
+
+const SCENE_LINES = [
+  'Picking a place…',
+  'Piling up the ground…',
+  'Pouring in the water…',
+  'Growing something for everyone to eat…',
+  'Working out who eats who…',
+  'Letting them all in…',
+]
+
+const TERRAIN_LINES = [
+  'Picking a place…',
+  'Piling up the ground…',
+  'Digging out the caves…',
+  'Pouring in the water…',
+  'Planting things on top…',
+  'Letting it settle…',
+]
+
+const LINE_MS = 3200
+
+function cellIndex(x: number, y: number): number {
+  return y * GRID_W + x
+}
+
+function buildGrains(shape: LoaderShape): Grain[] {
+  const h = shape.rows.length
+  const w = shape.rows[0].length
+  const ox = Math.floor((GRID_W - w) / 2)
+  const oy = Math.floor(GRID_H * 0.42 - h / 2)
+
+  const grains: Grain[] = []
+  for (let y = 0; y < h; y++) {
+    for (let x = 0; x < w; x++) {
+      const ch = shape.rows[y][x]
+      const color = ch === '.' ? undefined : shape.palette[ch]
+      if (!color) continue
+      grains.push({
+        x: 0,
+        y: 0,
+        vx: 0,
+        vy: 0,
+        tx: ox + x,
+        ty: oy + y,
+        color,
+        eye: ch === 'e',
+        alpha: 1,
+        seed: Math.random() * Math.PI * 2,
+      })
+    }
+  }
+
+  // Rain them in mixed up, so the pile is speckled rather than sorted by color.
+  for (let i = grains.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1))
+    ;[grains[i], grains[j]] = [grains[j], grains[i]]
+  }
+  return grains
+}
+
+/**
+ * Hand every grain the target nearest its own column, within its own color.
+ * Grains are built one-per-pixel so the counts always match exactly; matching
+ * on x keeps the assembly from crossing itself into a knot.
+ */
+function assignTargets(grains: Grain[]): void {
+  const groups = new Map<string, number[]>()
+  grains.forEach((grain, i) => {
+    const group = groups.get(grain.color)
+    if (group) group.push(i)
+    else groups.set(grain.color, [i])
+  })
+
+  for (const indices of groups.values()) {
+    const targets = indices.map(i => ({ tx: grains[i].tx, ty: grains[i].ty }))
+    indices.sort((a, b) => grains[a].x - grains[b].x || grains[a].y - grains[b].y)
+    targets.sort((a, b) => a.tx - b.tx || a.ty - b.ty)
+    indices.forEach((grainIndex, slot) => {
+      grains[grainIndex].tx = targets[slot].tx
+      grains[grainIndex].ty = targets[slot].ty
+    })
+  }
+}
+
+export function SummonLoader({
+  mode,
+  prompt,
+  onCancel,
+}: {
+  mode: 'creature' | 'scene' | 'terrain'
+  prompt: string
+  onCancel: () => void
+}) {
+  const canvasRef = useRef<HTMLCanvasElement>(null)
+  const [lineIndex, setLineIndex] = useState(0)
+
+  const lines = mode === 'scene' ? SCENE_LINES : mode === 'terrain' ? TERRAIN_LINES : CREATURE_LINES
+
+  // Walk the lines once and stay on the last one. Looping back to "finding its
+  // shape" after a minute would read as the summon having restarted.
+  useEffect(() => {
+    const id = window.setInterval(() => {
+      setLineIndex(i => Math.min(i + 1, lines.length - 1))
+    }, LINE_MS)
+    return () => window.clearInterval(id)
+  }, [lines.length])
+
+  useEffect(() => {
+    const canvas = canvasRef.current
+    if (!canvas) return
+    const ctx = canvas.getContext('2d')
+    if (!ctx) return
+
+    const centerX = Math.floor(GRID_W / 2)
+    const occupied = new Int32Array(GRID_W * GRID_H)
+
+    // Asking for land shows land being built; asking for creatures shows
+    // creatures. The wait should look like the thing being waited on.
+    const shapes = mode === 'terrain' ? LOADER_TERRAIN_SHAPES : LOADER_CREATURE_SHAPES
+
+    let shapeIndex = Math.floor(Math.random() * shapes.length)
+    let grains = buildGrains(shapes[shapeIndex])
+    let blinkColor = shapes[shapeIndex].blink
+    let live = 0
+    let phase: Phase = 'rain'
+    let phaseMs = 0
+    let sandAcc = 0
+    let pass = 0
+
+    // An arrow rather than a declaration: a hoisted function would lose the
+    // narrowing from the null check above and need an assertion on every call.
+    const draw = (now: number) => {
+      ctx.clearRect(0, 0, GRID_W, GRID_H)
+
+      // A dotted floor, so the pile has something to land on rather than
+      // stopping at the edge of nothing.
+      ctx.globalAlpha = 1
+      ctx.fillStyle = 'rgba(94, 234, 212, 0.14)'
+      for (let x = 0; x < GRID_W; x += 2) ctx.fillRect(x, GRID_H - 1, 1, 1)
+
+      const holding = phase === 'hold'
+      const bob = holding ? Math.round(Math.sin(now * 0.0024) * 0.9) : 0
+      const blinking = holding && (now * 0.001) % 2.4 < 0.13
+
+      for (let i = 0; i < live; i++) {
+        const grain = grains[i]
+        let x = grain.x
+        let y = grain.y
+        if (holding) {
+          // A sparse one-pixel shimmer on top of the whole-body bob — the two
+          // together read as breathing rather than as a static sprite.
+          x += Math.sin(now * 0.004 + grain.seed) * 0.45
+          y += bob + Math.cos(now * 0.003 + grain.seed * 1.7) * 0.35
+        }
+        ctx.globalAlpha = grain.alpha
+        ctx.fillStyle = blinking && grain.eye ? blinkColor : grain.color
+        ctx.fillRect(Math.round(x), Math.round(y), 1, 1)
+      }
+      ctx.globalAlpha = 1
+    }
+
+    // Under reduced motion the wait is a single assembled creature, held still.
+    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+      for (const grain of grains) {
+        grain.x = grain.tx
+        grain.y = grain.ty
+      }
+      live = grains.length
+      phase = 'gather'
+      draw(0)
+      return
+    }
+
+    /** One powder pass: everything falls, piles and slides down slopes. */
+    function stepSand(): number {
+      pass++
+      const leftToRight = (pass & 1) === 0
+
+      for (let n = 0; n < GRAINS_PER_STEP && live < grains.length; n++) {
+        for (let attempt = 0; attempt < 6; attempt++) {
+          const x = centerX + Math.floor((Math.random() * 2 - 1) * POUR_SPREAD)
+          if (occupied[cellIndex(x, 0)] !== 0) continue
+          const grain = grains[live]
+          grain.x = x
+          grain.y = 0
+          occupied[cellIndex(x, 0)] = live + 1
+          live++
+          break
+        }
+      }
+
+      // Bottom-up, so a grain that just fell isn't carried along by the pass
+      // that moved it — same reason the world's tile step scans upward.
+      const order: number[] = []
+      for (let i = 0; i < live; i++) order.push(i)
+      order.sort((a, b) => grains[b].y - grains[a].y)
+
+      let moves = 0
+      for (const i of order) {
+        const grain = grains[i]
+        if (grain.y + 1 >= GRID_H) continue
+
+        const from = cellIndex(grain.x, grain.y)
+        const below = cellIndex(grain.x, grain.y + 1)
+        if (occupied[below] === 0) {
+          occupied[from] = 0
+          occupied[below] = i + 1
+          grain.y++
+          moves++
+          continue
+        }
+
+        const first = leftToRight ? -1 : 1
+        for (const dir of [first, -first]) {
+          const nx = grain.x + dir
+          if (nx < 0 || nx >= GRID_W) continue
+          const diagonal = cellIndex(nx, grain.y + 1)
+          if (occupied[diagonal] !== 0) continue
+          occupied[from] = 0
+          occupied[diagonal] = i + 1
+          grain.x = nx
+          grain.y++
+          moves++
+          break
+        }
+      }
+      return moves
+    }
+
+    function enterGather() {
+      // Anything still queued when the pile settles joins from the top, so the
+      // body is never assembled out of a partial set of grains.
+      while (live < grains.length) {
+        const grain = grains[live]
+        grain.x = centerX + Math.floor((Math.random() * 2 - 1) * POUR_SPREAD)
+        grain.y = -Math.floor(Math.random() * 6)
+        live++
+      }
+      assignTargets(grains)
+      for (const grain of grains) {
+        grain.vx = 0
+        grain.vy = 0
+      }
+      phase = 'gather'
+      phaseMs = 0
+    }
+
+    function enterScatter() {
+      for (const grain of grains) {
+        grain.vx = (grain.x - centerX) * 1.1 + (Math.random() * 6 - 3)
+        grain.vy = -(3 + Math.random() * 7)
+      }
+      phase = 'scatter'
+      phaseMs = 0
+    }
+
+    function nextShape() {
+      shapeIndex = (shapeIndex + 1) % shapes.length
+      grains = buildGrains(shapes[shapeIndex])
+      blinkColor = shapes[shapeIndex].blink
+      occupied.fill(0)
+      live = 0
+      phase = 'rain'
+      phaseMs = 0
+      sandAcc = 0
+    }
+
+    let raf = 0
+    let last = performance.now()
+
+    const frame = (now: number) => {
+      // Cap the step so a backgrounded tab doesn't come back to grains
+      // launched out of the canvas by one enormous delta.
+      const dt = Math.min((now - last) / 1000, 0.05)
+      last = now
+      phaseMs += dt * 1000
+
+      if (phase === 'rain') {
+        sandAcc += dt * 1000
+        let settled = false
+        while (sandAcc >= SAND_STEP_MS) {
+          sandAcc -= SAND_STEP_MS
+          if (stepSand() === 0 && live === grains.length) settled = true
+        }
+        if (settled || phaseMs > RAIN_MAX_MS) enterGather()
+      } else if (phase === 'gather') {
+        // Underdamped spring: the grains overshoot their slot by a hair and
+        // snap back, which is what makes it look like they were pulled.
+        for (const grain of grains) {
+          grain.vx += (grain.tx - grain.x) * 90 * dt - grain.vx * 12 * dt
+          grain.vy += (grain.ty - grain.y) * 90 * dt - grain.vy * 12 * dt
+          grain.x += grain.vx * dt
+          grain.y += grain.vy * dt
+        }
+        if (phaseMs >= GATHER_MS) {
+          for (const grain of grains) {
+            grain.x = grain.tx
+            grain.y = grain.ty
+          }
+          phase = 'hold'
+          phaseMs = 0
+        }
+      } else if (phase === 'hold') {
+        if (phaseMs >= HOLD_MS) enterScatter()
+      } else {
+        for (const grain of grains) {
+          grain.vy += 34 * dt
+          grain.x += grain.vx * dt
+          grain.y += grain.vy * dt
+          grain.alpha = Math.max(0, 1 - phaseMs / SCATTER_MS)
+        }
+        if (phaseMs >= SCATTER_MS) nextShape()
+      }
+
+      draw(now)
+      raf = requestAnimationFrame(frame)
+    }
+
+    raf = requestAnimationFrame(frame)
+    return () => cancelAnimationFrame(raf)
+  }, [mode])
+
+  return (
+    <div className="flex flex-col items-center gap-3 p-4">
+      <div
+        className="w-full overflow-hidden rounded-lg"
+        style={{
+          background: 'linear-gradient(180deg, rgba(2,8,10,0.9), rgba(10,31,28,0.55))',
+          border: '1px solid var(--cc-mint-line)',
+        }}
+      >
+        <canvas
+          ref={canvasRef}
+          width={GRID_W}
+          height={GRID_H}
+          aria-hidden="true"
+          style={{ display: 'block', width: '100%', imageRendering: 'pixelated' }}
+        />
+      </div>
+
+      <p
+        aria-hidden="true"
+        style={{
+          fontFamily: 'var(--cc-font-mono)',
+          fontSize: 11,
+          letterSpacing: 1.8,
+          textTransform: 'uppercase',
+          color: 'var(--cc-mint)',
+          textAlign: 'center',
+          minHeight: 16,
+        }}
+      >
+        {lines[lineIndex]}
+      </p>
+
+      <p
+        style={{
+          fontSize: 13,
+          color: 'var(--cc-text-muted)',
+          textAlign: 'center',
+          lineHeight: 1.5,
+        }}
+      >
+        “{prompt}”
+      </p>
+
+      <span className="sr-only" role="status">
+        Summoning. This can take a minute.
+      </span>
+
+      <button
+        type="button"
+        className="cc-btn"
+        onClick={onCancel}
+        style={{
+          fontSize: 12,
+          padding: '8px 16px',
+          minHeight: 36,
+          borderRadius: 999,
+          border: '1px solid var(--cc-mint-line)',
+          color: 'var(--cc-text-muted)',
+        }}
+      >
+        Never mind
+      </button>
+    </div>
+  )
+}

--- a/src/app/micro-land/components/summon-panel.tsx
+++ b/src/app/micro-land/components/summon-panel.tsx
@@ -32,6 +32,27 @@ const TERRAIN_IDEAS = [
   'a swamp full of little pools',
 ]
 
+/** Creatures allowed in flight at once. */
+const MAX_PENDING = 3
+
+async function requestGenerate(
+  mode: 'creature' | 'scene' | 'terrain',
+  prompt: string,
+  signal: AbortSignal
+) {
+  const response = await fetch('/api/v1/micro-land/summon', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ mode, prompt }),
+    signal,
+  })
+  if (!response.ok) {
+    const detail = (await response.json().catch(() => null)) as { error?: string } | null
+    throw new Error(detail?.error ?? 'That did not come through. Try again.')
+  }
+  return response.json()
+}
+
 type Introduce = (
   raw: unknown,
   count: number
@@ -59,16 +80,38 @@ export function SummonPanel({
   const setError = useMicroLand(s => s.setSummonError)
   const setTool = useMicroLand(s => s.setTool)
   const notify = useMicroLand(s => s.notify)
+  const pending = useMicroLand(s => s.pendingSummons)
+  const addPending = useMicroLand(s => s.addPendingSummon)
+  const removePending = useMicroLand(s => s.removePendingSummon)
 
   const [text, setText] = useState('')
   const [made, setMade] = useState<CreatureBlueprint[]>([])
   const inputRef = useRef<HTMLInputElement>(null)
-  /** Live while a generation is in flight, so the player can call it off. */
+  /** Whatever opened the panel, so closing it hands focus back. */
+  const openerRef = useRef<HTMLElement | null>(null)
+  /** Live while a world-building generation is in flight, so it can be called off. */
   const abortRef = useRef<AbortController | null>(null)
+  /**
+   * Creatures the player has walked away from. They outlive the panel being
+   * closed — that's the point — so they get their own handles, and the modal's
+   * close and Escape paths never touch them.
+   */
+  const backgroundRef = useRef<Set<AbortController>>(new Set())
 
   useEffect(() => {
     if (open && !busy) inputRef.current?.focus()
   }, [open, busy])
+
+  // A creature closes the panel out from under the player, so keyboard focus
+  // has to go back where it came from rather than to the top of the page.
+  useEffect(() => {
+    if (open) {
+      openerRef.current = document.activeElement as HTMLElement | null
+      return
+    }
+    openerRef.current?.focus()
+    openerRef.current = null
+  }, [open])
 
   useEffect(() => {
     if (!open) return
@@ -83,15 +126,77 @@ export function SummonPanel({
 
   // Nothing is left half-applied by an abort: the world is only touched after
   // the response has fully arrived.
-  useEffect(() => () => abortRef.current?.abort(), [])
+  useEffect(() => {
+    const background = backgroundRef.current
+    return () => {
+      abortRef.current?.abort()
+      for (const controller of background) controller.abort()
+    }
+  }, [])
 
   if (!open) return null
 
   const ideas = mode === 'scene' ? SCENE_IDEAS : mode === 'terrain' ? TERRAIN_IDEAS : CREATURE_IDEAS
 
+  /**
+   * One creature, made without holding the game hostage.
+   *
+   * A world or a land replaces everything the player is looking at, so those
+   * are worth waiting on. A single creature isn't: it just turns up in the
+   * strip when it's ready. So the panel gets out of the way immediately, an
+   * empty slot carries the wait, and the player keeps digging.
+   */
+  function generateInBackground(prompt: string) {
+    const pendingId = addPending(prompt)
+    const controller = new AbortController()
+    backgroundRef.current.add(controller)
+
+    // If the player has picked up a different tool while waiting, leave it in
+    // their hand. `tool` only ever changes identity through setTool, so this is
+    // an exact "have they touched it since they asked".
+    const toolAtLaunch = useMicroLand.getState().tool
+
+    void (async () => {
+      try {
+        const data = await requestGenerate('creature', prompt, controller.signal)
+        const result = data.blueprint ? onIntroduce(data.blueprint, 5) : null
+        if (!result) {
+          notify('Nothing came through. Try describing it a different way.')
+          return
+        }
+        if (useMicroLand.getState().tool === toolAtLaunch) {
+          setTool({ kind: 'creature', blueprintId: result.blueprint.id })
+        }
+        notify(`${result.blueprint.name} joins the world.`)
+      } catch (err) {
+        // Leaving the page isn't a failure worth shouting about.
+        if (err instanceof DOMException && err.name === 'AbortError') return
+        notify(err instanceof Error ? err.message : 'That did not come through. Try again.')
+      } finally {
+        backgroundRef.current.delete(controller)
+        removePending(pendingId)
+      }
+    })()
+
+    setText('')
+    setError(null)
+    setMade([])
+    setOpen(false)
+    notify(`“${prompt}” is on its way. Keep playing — it turns up in the creature bar.`)
+  }
+
   async function generate() {
     const prompt = text.trim()
     if (prompt.length < 2 || busy) return
+
+    if (mode === 'creature') {
+      if (pending.length >= MAX_PENDING) {
+        setError('There are already some on their way. Wait for one to land.')
+        return
+      }
+      generateInBackground(prompt)
+      return
+    }
 
     setBusy(true)
     setError(null)
@@ -101,18 +206,7 @@ export function SummonPanel({
     abortRef.current = controller
 
     try {
-      const response = await fetch('/api/v1/micro-land/summon', {
-        method: 'POST',
-        headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({ mode, prompt }),
-        signal: controller.signal,
-      })
-      if (!response.ok) {
-        const detail = (await response.json().catch(() => null)) as { error?: string } | null
-        throw new Error(detail?.error ?? 'That did not come through. Try again.')
-      }
-
-      const data = await response.json()
+      const data = await requestGenerate(mode, prompt, controller.signal)
       const created: CreatureBlueprint[] = []
 
       if (data.mode === 'terrain') {
@@ -147,12 +241,6 @@ export function SummonPanel({
           if (result) created.push(result.blueprint)
         }
         if (typeof data.note === 'string' && data.note) notify(data.note)
-      } else if (data.blueprint) {
-        const result = onIntroduce(data.blueprint, 5)
-        if (result) {
-          created.push(result.blueprint)
-          notify(`${result.blueprint.name} joins the world.`)
-        }
       }
 
       if (created.length === 0) {
@@ -263,7 +351,7 @@ export function SummonPanel({
 
             <p style={{ fontSize: 13, color: 'var(--cc-text-muted)', lineHeight: 1.5 }}>
               {mode === 'creature'
-                ? 'Describe something. It will be drawn, given a body, and dropped into the world.'
+                ? 'Describe something. It will be drawn, given a body, and dropped into the world. Keep playing while it is made — it turns up in the creature bar.'
                 : mode === 'terrain'
                   ? 'Describe a place. The ground, caves and water get rebuilt to match. Creatures already here are cleared out.'
                   : 'Describe a place with things living in it. You get the land AND the creatures, built to suit each other.'}
@@ -315,6 +403,14 @@ export function SummonPanel({
             {error && (
               <p style={{ fontSize: 13, color: 'var(--cc-pink)' }} role="alert">
                 {error}
+              </p>
+            )}
+
+            {pending.length > 0 && (
+              <p style={{ fontSize: 12, color: 'var(--cc-text-muted)' }}>
+                {pending.length === 1
+                  ? 'One creature is still on its way.'
+                  : `${pending.length} creatures are still on their way.`}
               </p>
             )}
 

--- a/src/app/micro-land/components/summon-panel.tsx
+++ b/src/app/micro-land/components/summon-panel.tsx
@@ -1,0 +1,380 @@
+'use client'
+
+import { useEffect, useRef, useState } from 'react'
+
+import type { CreatureBlueprint } from '@/app/micro-land/domain/types'
+import { useMicroLand } from '@/app/micro-land/store'
+
+import { CreaturePortrait } from './creature-chip'
+import { SummonLoader } from './summon-loader'
+
+const CREATURE_IDEAS = [
+  'a tiny glowing snail that eats moss',
+  'a cat made of lava',
+  'a paper bird that folds itself',
+  'a fat blue fish with whiskers',
+  'a spider that walks on the ceiling',
+  'a mushroom that grows in the dark',
+]
+
+const SCENE_IDEAS = [
+  'a swarm of little things chased by something big and slow',
+  'a rockpool full of crabs and seaweed',
+  'a cave where everything glows',
+  'a jungle with tiny dragons in it',
+]
+
+const TERRAIN_IDEAS = [
+  'a floating island with a waterfall',
+  'a deep cave with a lava lake at the bottom',
+  'a snowy mountain with a warm cave inside',
+  'a swamp full of little pools',
+]
+
+type Introduce = (
+  raw: unknown,
+  count: number
+) => { blueprint: CreatureBlueprint; placed: number } | null
+
+type ApplyTerrain = (
+  raw: unknown,
+  keepCreatures: boolean
+) => { name: string; fertile: boolean } | null
+
+export function SummonPanel({
+  onIntroduce,
+  onApplyTerrain,
+}: {
+  onIntroduce: Introduce
+  onApplyTerrain: ApplyTerrain
+}) {
+  const open = useMicroLand(s => s.summonOpen)
+  const setOpen = useMicroLand(s => s.setSummonOpen)
+  const busy = useMicroLand(s => s.summonBusy)
+  const setBusy = useMicroLand(s => s.setSummonBusy)
+  const mode = useMicroLand(s => s.summonMode)
+  const setMode = useMicroLand(s => s.setSummonMode)
+  const error = useMicroLand(s => s.summonError)
+  const setError = useMicroLand(s => s.setSummonError)
+  const setTool = useMicroLand(s => s.setTool)
+  const notify = useMicroLand(s => s.notify)
+
+  const [text, setText] = useState('')
+  const [made, setMade] = useState<CreatureBlueprint[]>([])
+  const inputRef = useRef<HTMLInputElement>(null)
+  /** Live while a summon is in flight, so the player can call it off. */
+  const abortRef = useRef<AbortController | null>(null)
+
+  useEffect(() => {
+    if (open && !busy) inputRef.current?.focus()
+  }, [open, busy])
+
+  useEffect(() => {
+    if (!open) return
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key !== 'Escape') return
+      abortRef.current?.abort()
+      setOpen(false)
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [open, setOpen])
+
+  // Nothing is left half-applied by an abort: the world is only touched after
+  // the response has fully arrived.
+  useEffect(() => () => abortRef.current?.abort(), [])
+
+  if (!open) return null
+
+  const ideas = mode === 'scene' ? SCENE_IDEAS : mode === 'terrain' ? TERRAIN_IDEAS : CREATURE_IDEAS
+
+  async function summon() {
+    const prompt = text.trim()
+    if (prompt.length < 2 || busy) return
+
+    setBusy(true)
+    setError(null)
+    setMade([])
+
+    const controller = new AbortController()
+    abortRef.current = controller
+
+    try {
+      const response = await fetch('/api/v1/micro-land/summon', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ mode, prompt }),
+        signal: controller.signal,
+      })
+      if (!response.ok) {
+        const detail = (await response.json().catch(() => null)) as { error?: string } | null
+        throw new Error(detail?.error ?? 'The summoning fizzled.')
+      }
+
+      const data = await response.json()
+      const created: CreatureBlueprint[] = []
+
+      if (data.mode === 'terrain') {
+        // `null` terrain still builds — sanitizeTerrain falls back to an island.
+        const land = onApplyTerrain(data.terrain, false)
+        if (land) {
+          notify(
+            land.fertile
+              ? `${land.name} rises out of nothing.`
+              : `${land.name} rises — but nothing can take root here. Try adding dirt or sand.`
+          )
+          setText('')
+          // Get out of the way: the whole point was to look at the land.
+          setOpen(false)
+        } else {
+          setError('The land would not hold together. Try describing it again.')
+        }
+        return
+      }
+
+      if (data.mode === 'scene' && Array.isArray(data.creatures)) {
+        // Land first: creatures are placed into it, so it has to exist already.
+        if (data.terrain) {
+          const land = onApplyTerrain(data.terrain, false)
+          if (land && !land.fertile) {
+            notify(`${land.name} has no soil — plants will struggle here.`)
+          }
+        }
+        for (const entry of data.creatures) {
+          const count = Math.max(1, Math.min(40, Number(entry?.count) || 4))
+          const result = onIntroduce(entry, count)
+          if (result) created.push(result.blueprint)
+        }
+        if (typeof data.note === 'string' && data.note) notify(data.note)
+      } else if (data.blueprint) {
+        const result = onIntroduce(data.blueprint, 5)
+        if (result) {
+          created.push(result.blueprint)
+          notify(`${result.blueprint.name} joins the world.`)
+        }
+      }
+
+      if (created.length === 0) {
+        setError('Nothing came through. Try describing it a different way.')
+      } else {
+        setMade(created)
+        // Select the new creature so the next tap places another one.
+        setTool({ kind: 'creature', blueprintId: created[0].id })
+        setText('')
+      }
+    } catch (err) {
+      // Calling it off isn't a failure — the player already knows what happened.
+      if (!(err instanceof DOMException && err.name === 'AbortError')) {
+        setError(err instanceof Error ? err.message : 'The summoning fizzled.')
+      }
+    } finally {
+      abortRef.current = null
+      setBusy(false)
+    }
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-end justify-center sm:items-center"
+      style={{ background: 'var(--cc-modal-scrim)' }}
+      onClick={() => !busy && setOpen(false)}
+    >
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label="Summon a creature"
+        className="w-full max-w-lg overflow-y-auto rounded-t-xl sm:rounded-xl"
+        style={{
+          maxHeight: '88dvh',
+          background: 'linear-gradient(180deg, var(--cc-modal-bg-from), var(--cc-modal-bg-to))',
+          border: '1px solid var(--cc-modal-border)',
+        }}
+        onClick={e => e.stopPropagation()}
+      >
+        <div
+          className="flex items-center justify-between px-4 py-3"
+          style={{ borderBottom: '1px solid var(--cc-panel-divider)' }}
+        >
+          <h2
+            style={{
+              fontFamily: 'var(--cc-font-mono)',
+              fontSize: 11,
+              letterSpacing: 2.5,
+              textTransform: 'uppercase',
+              color: 'var(--cc-mint)',
+            }}
+          >
+            Summon
+          </h2>
+          <button
+            type="button"
+            className="cc-btn"
+            onClick={() => {
+              abortRef.current?.abort()
+              setOpen(false)
+            }}
+            aria-label="Close"
+            style={{ minWidth: 44, minHeight: 34, color: 'var(--cc-text-muted)' }}
+          >
+            ✕
+          </button>
+        </div>
+
+        {busy ? (
+          <SummonLoader
+            mode={mode}
+            prompt={text.trim()}
+            onCancel={() => abortRef.current?.abort()}
+          />
+        ) : (
+          <div className="flex flex-col gap-3 p-4">
+            <div className="flex gap-1.5" role="group" aria-label="What to summon">
+              {(['creature', 'terrain', 'scene'] as const).map(option => (
+                <button
+                  key={option}
+                  type="button"
+                  className="cc-btn flex-1"
+                  onClick={() => setMode(option)}
+                  aria-pressed={mode === option}
+                  style={{
+                    fontFamily: 'var(--cc-font-mono)',
+                    fontSize: 10,
+                    letterSpacing: 1.2,
+                    textTransform: 'uppercase',
+                    padding: '9px 10px',
+                    minHeight: 40,
+                    borderRadius: 4,
+                    border: `1px solid ${mode === option ? 'var(--cc-mint)' : 'var(--cc-mint-line)'}`,
+                    background: mode === option ? 'var(--cc-mint-soft)' : 'transparent',
+                    color: mode === option ? 'var(--cc-mint)' : 'var(--cc-text-muted)',
+                  }}
+                >
+                  {option === 'creature'
+                    ? 'One creature'
+                    : option === 'terrain'
+                      ? 'Just the land'
+                      : 'A whole world'}
+                </button>
+              ))}
+            </div>
+
+            <p style={{ fontSize: 13, color: 'var(--cc-text-muted)', lineHeight: 1.5 }}>
+              {mode === 'creature'
+                ? 'Describe something. It will be drawn, given a body, and dropped into the world.'
+                : mode === 'terrain'
+                  ? 'Describe a place. The ground, caves and water get rebuilt to match. Creatures already here are cleared out.'
+                  : 'Describe a place with things living in it. You get the land AND the creatures, built to suit each other.'}
+            </p>
+
+            <input
+              ref={inputRef}
+              value={text}
+              onChange={e => setText(e.target.value)}
+              onKeyDown={e => {
+                if (e.key === 'Enter') void summon()
+              }}
+              maxLength={300}
+              placeholder={ideas[0]}
+              aria-label="Describe what to summon"
+              style={{
+                width: '100%',
+                padding: '12px 14px',
+                minHeight: 46,
+                borderRadius: 5,
+                fontSize: 15,
+                background: 'rgba(0,0,0,0.35)',
+                border: '1px solid var(--cc-mint-line)',
+                color: 'var(--cc-text-default)',
+              }}
+            />
+
+            <div className="flex flex-wrap gap-1.5">
+              {ideas.map(idea => (
+                <button
+                  key={idea}
+                  type="button"
+                  className="cc-btn"
+                  onClick={() => setText(idea)}
+                  style={{
+                    fontSize: 11,
+                    padding: '6px 10px',
+                    minHeight: 32,
+                    borderRadius: 999,
+                    border: '1px solid var(--cc-mint-line)',
+                    color: 'var(--cc-text-muted)',
+                  }}
+                >
+                  {idea}
+                </button>
+              ))}
+            </div>
+
+            {error && (
+              <p style={{ fontSize: 13, color: 'var(--cc-pink)' }} role="alert">
+                {error}
+              </p>
+            )}
+
+            {made.length > 0 && (
+              <div
+                className="flex flex-col gap-2 rounded-lg p-3"
+                style={{ background: 'rgba(94,234,212,0.06)' }}
+              >
+                {made.map(bp => (
+                  <div key={bp.id} className="flex items-center gap-3">
+                    <CreaturePortrait blueprint={bp} size={38} />
+                    <div className="min-w-0">
+                      <div
+                        style={{
+                          fontFamily: 'var(--cc-font-mono)',
+                          fontSize: 11,
+                          letterSpacing: 1.4,
+                          textTransform: 'uppercase',
+                          color: 'var(--cc-mint)',
+                        }}
+                      >
+                        {bp.name}
+                      </div>
+                      <div style={{ fontSize: 12, color: 'var(--cc-text-muted)' }}>{bp.blurb}</div>
+                    </div>
+                  </div>
+                ))}
+                <p style={{ fontSize: 11, color: 'var(--cc-text-muted)', opacity: 0.8 }}>
+                  Tap the world to place more.
+                </p>
+              </div>
+            )}
+
+            <button
+              type="button"
+              className="cc-btn"
+              onClick={() => void summon()}
+              disabled={text.trim().length < 2}
+              style={{
+                fontFamily: 'var(--cc-font-mono)',
+                fontSize: 11,
+                fontWeight: 700,
+                letterSpacing: 2,
+                textTransform: 'uppercase',
+                padding: '13px 22px',
+                minHeight: 48,
+                borderRadius: 5,
+                background: 'linear-gradient(180deg, var(--cc-mint), var(--cc-mint-hi))',
+                border: '1px solid var(--cc-mint)',
+                color: 'var(--cc-on-mint)',
+                boxShadow: 'var(--cc-mint-glow)',
+                opacity: text.trim().length < 2 ? 0.4 : 1,
+              }}
+            >
+              {mode === 'creature'
+                ? 'Summon it'
+                : mode === 'terrain'
+                  ? 'Build the land'
+                  : 'Summon it all'}
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/app/micro-land/components/summon-panel.tsx
+++ b/src/app/micro-land/components/summon-panel.tsx
@@ -6,6 +6,7 @@ import type { CreatureBlueprint } from '@/app/micro-land/domain/types'
 import { useMicroLand } from '@/app/micro-land/store'
 
 import { CreaturePortrait } from './creature-chip'
+import { SparkleIcon } from './sparkle-icon'
 import { SummonLoader } from './summon-loader'
 
 const CREATURE_IDEAS = [
@@ -62,7 +63,7 @@ export function SummonPanel({
   const [text, setText] = useState('')
   const [made, setMade] = useState<CreatureBlueprint[]>([])
   const inputRef = useRef<HTMLInputElement>(null)
-  /** Live while a summon is in flight, so the player can call it off. */
+  /** Live while a generation is in flight, so the player can call it off. */
   const abortRef = useRef<AbortController | null>(null)
 
   useEffect(() => {
@@ -88,7 +89,7 @@ export function SummonPanel({
 
   const ideas = mode === 'scene' ? SCENE_IDEAS : mode === 'terrain' ? TERRAIN_IDEAS : CREATURE_IDEAS
 
-  async function summon() {
+  async function generate() {
     const prompt = text.trim()
     if (prompt.length < 2 || busy) return
 
@@ -108,7 +109,7 @@ export function SummonPanel({
       })
       if (!response.ok) {
         const detail = (await response.json().catch(() => null)) as { error?: string } | null
-        throw new Error(detail?.error ?? 'The summoning fizzled.')
+        throw new Error(detail?.error ?? 'That did not come through. Try again.')
       }
 
       const data = await response.json()
@@ -165,7 +166,7 @@ export function SummonPanel({
     } catch (err) {
       // Calling it off isn't a failure — the player already knows what happened.
       if (!(err instanceof DOMException && err.name === 'AbortError')) {
-        setError(err instanceof Error ? err.message : 'The summoning fizzled.')
+        setError(err instanceof Error ? err.message : 'That did not come through. Try again.')
       }
     } finally {
       abortRef.current = null
@@ -182,7 +183,7 @@ export function SummonPanel({
       <div
         role="dialog"
         aria-modal="true"
-        aria-label="Summon a creature"
+        aria-label="Generate a creature"
         className="w-full max-w-lg overflow-y-auto rounded-t-xl sm:rounded-xl"
         style={{
           maxHeight: '88dvh',
@@ -196,6 +197,7 @@ export function SummonPanel({
           style={{ borderBottom: '1px solid var(--cc-panel-divider)' }}
         >
           <h2
+            className="flex items-center gap-2"
             style={{
               fontFamily: 'var(--cc-font-mono)',
               fontSize: 11,
@@ -204,7 +206,8 @@ export function SummonPanel({
               color: 'var(--cc-mint)',
             }}
           >
-            Summon
+            <SparkleIcon size={13} />
+            Generate
           </h2>
           <button
             type="button"
@@ -228,7 +231,7 @@ export function SummonPanel({
           />
         ) : (
           <div className="flex flex-col gap-3 p-4">
-            <div className="flex gap-1.5" role="group" aria-label="What to summon">
+            <div className="flex gap-1.5" role="group" aria-label="What to generate">
               {(['creature', 'terrain', 'scene'] as const).map(option => (
                 <button
                   key={option}
@@ -271,11 +274,11 @@ export function SummonPanel({
               value={text}
               onChange={e => setText(e.target.value)}
               onKeyDown={e => {
-                if (e.key === 'Enter') void summon()
+                if (e.key === 'Enter') void generate()
               }}
               maxLength={300}
               placeholder={ideas[0]}
-              aria-label="Describe what to summon"
+              aria-label="Describe what to generate"
               style={{
                 width: '100%',
                 padding: '12px 14px',
@@ -348,9 +351,13 @@ export function SummonPanel({
             <button
               type="button"
               className="cc-btn"
-              onClick={() => void summon()}
+              onClick={() => void generate()}
               disabled={text.trim().length < 2}
               style={{
+                display: 'inline-flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                gap: 8,
                 fontFamily: 'var(--cc-font-mono)',
                 fontSize: 11,
                 fontWeight: 700,
@@ -366,11 +373,12 @@ export function SummonPanel({
                 opacity: text.trim().length < 2 ? 0.4 : 1,
               }}
             >
+              <SparkleIcon size={13} />
               {mode === 'creature'
-                ? 'Summon it'
+                ? 'Generate it'
                 : mode === 'terrain'
-                  ? 'Build the land'
-                  : 'Summon it all'}
+                  ? 'Generate the land'
+                  : 'Generate it all'}
             </button>
           </div>
         )}

--- a/src/app/micro-land/components/summon-sand.tsx
+++ b/src/app/micro-land/components/summon-sand.tsx
@@ -1,0 +1,191 @@
+'use client'
+
+import { useEffect, useRef } from 'react'
+
+import { SUMMON_SAND_COLORS } from '@/app/micro-land/domain/config/loader-shapes'
+
+/**
+ * The wait for one creature, shrunk to fit a slot in the creature strip.
+ *
+ * Asking for a single creature doesn't hold the game hostage any more, so the
+ * wait can't be a modal — it's an empty slot with sand pouring into it. The
+ * grains fall and pile by the same rules as the big loader and the world
+ * itself, then wash out and start over, which reads as "still coming" without
+ * ever pretending to be a finished creature.
+ *
+ * Deliberately not a copy of `SummonLoader`: at this size the assembly phase
+ * would be a smudge, and this has to be cheap enough to run several at once
+ * behind a game that is already simulating at 60fps.
+ */
+
+const GRID = 16
+/** One powder pass. Slower than the big loader — fewer grains to watch. */
+const SAND_STEP_MS = 52
+/** Half-width of the mouth the sand pours from, in cells. */
+const POUR_SPREAD = 3
+/** Grains in a full pile: enough to mound up, not enough to fill the slot. */
+const CAPACITY = 52
+const FADE_MS = 620
+
+const COLORS = SUMMON_SAND_COLORS
+
+interface Grain {
+  x: number
+  y: number
+  color: string
+}
+
+function cellIndex(x: number, y: number): number {
+  return y * GRID + x
+}
+
+export function SummonSand({ size = 34 }: { size?: number }) {
+  const canvasRef = useRef<HTMLCanvasElement>(null)
+
+  useEffect(() => {
+    const canvas = canvasRef.current
+    if (!canvas) return
+    const ctx = canvas.getContext('2d')
+    if (!ctx) return
+
+    const center = Math.floor(GRID / 2)
+    const occupied = new Int32Array(GRID * GRID)
+    let grains: Grain[] = []
+    let alpha = 1
+    let fading = false
+    let sandAcc = 0
+    let pass = 0
+
+    const draw = () => {
+      ctx.clearRect(0, 0, GRID, GRID)
+
+      // A dotted floor, so the pile lands on something rather than stopping at
+      // the edge of nothing — the same footing the big loader gives it.
+      ctx.globalAlpha = 0.5 * alpha
+      ctx.fillStyle = 'rgba(94, 234, 212, 0.35)'
+      for (let x = 0; x < GRID; x += 2) ctx.fillRect(x, GRID - 1, 1, 1)
+
+      ctx.globalAlpha = alpha
+      for (const grain of grains) {
+        ctx.fillStyle = grain.color
+        ctx.fillRect(grain.x, grain.y, 1, 1)
+      }
+      ctx.globalAlpha = 1
+    }
+
+    // Under reduced motion the wait is one settled pile, held still.
+    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+      for (let i = 0; i < CAPACITY; i++) {
+        const x = center + Math.round((i % 7) - 3)
+        const y = GRID - 1 - Math.floor(i / 7)
+        grains.push({ x, y, color: COLORS[i % COLORS.length] })
+      }
+      draw()
+      return
+    }
+
+    function pour() {
+      if (grains.length >= CAPACITY) return
+      for (let attempt = 0; attempt < 5; attempt++) {
+        const x = center + Math.round((Math.random() * 2 - 1) * POUR_SPREAD)
+        if (occupied[cellIndex(x, 0)] !== 0) continue
+        grains.push({ x, y: 0, color: COLORS[grains.length % COLORS.length] })
+        occupied[cellIndex(x, 0)] = grains.length
+        return
+      }
+    }
+
+    /** One powder pass: everything falls, piles and slides down slopes. */
+    function stepSand(): number {
+      pass++
+      const leftToRight = (pass & 1) === 0
+
+      // Bottom-up, so a grain that just fell isn't carried along by the same
+      // pass that moved it.
+      const order = grains.map((_, i) => i).sort((a, b) => grains[b].y - grains[a].y)
+
+      let moves = 0
+      for (const i of order) {
+        const grain = grains[i]
+        if (grain.y + 1 >= GRID) continue
+
+        const from = cellIndex(grain.x, grain.y)
+        const below = cellIndex(grain.x, grain.y + 1)
+        if (occupied[below] === 0) {
+          occupied[from] = 0
+          occupied[below] = i + 1
+          grain.y++
+          moves++
+          continue
+        }
+
+        const first = leftToRight ? -1 : 1
+        for (const dir of [first, -first]) {
+          const nx = grain.x + dir
+          if (nx < 0 || nx >= GRID) continue
+          const diagonal = cellIndex(nx, grain.y + 1)
+          if (occupied[diagonal] !== 0) continue
+          occupied[from] = 0
+          occupied[diagonal] = i + 1
+          grain.x = nx
+          grain.y++
+          moves++
+          break
+        }
+      }
+      return moves
+    }
+
+    function reset() {
+      occupied.fill(0)
+      grains = []
+      alpha = 1
+      fading = false
+      sandAcc = 0
+    }
+
+    let raf = 0
+    let last = performance.now()
+
+    const frame = (now: number) => {
+      // Cap the step so a backgrounded tab doesn't come back to a pile that
+      // fell through the floor in one enormous delta.
+      const dt = Math.min(now - last, 50)
+      last = now
+
+      if (fading) {
+        alpha -= dt / FADE_MS
+        if (alpha <= 0) reset()
+      } else {
+        sandAcc += dt
+        while (sandAcc >= SAND_STEP_MS) {
+          sandAcc -= SAND_STEP_MS
+          pour()
+          const moves = stepSand()
+          if (moves === 0 && grains.length >= CAPACITY) fading = true
+        }
+      }
+
+      draw()
+      raf = requestAnimationFrame(frame)
+    }
+
+    raf = requestAnimationFrame(frame)
+    return () => cancelAnimationFrame(raf)
+  }, [])
+
+  return (
+    <canvas
+      ref={canvasRef}
+      width={GRID}
+      height={GRID}
+      aria-hidden="true"
+      style={{
+        display: 'block',
+        width: size,
+        height: size,
+        imageRendering: 'pixelated',
+      }}
+    />
+  )
+}

--- a/src/app/micro-land/components/toolbar.tsx
+++ b/src/app/micro-land/components/toolbar.tsx
@@ -5,6 +5,7 @@ import { useMicroLand } from '@/app/micro-land/store'
 
 import { CreaturePortrait } from './creature-chip'
 import { SparkleIcon } from './sparkle-icon'
+import { SummonSand } from './summon-sand'
 
 const BRUSHES = [2, 4, 8, 14]
 
@@ -23,6 +24,7 @@ export function Toolbar() {
   const brush = useMicroLand((s) => s.brush)
   const setBrush = useMicroLand((s) => s.setBrush)
   const blueprints = useMicroLand((s) => s.blueprints)
+  const pending = useMicroLand((s) => s.pendingSummons)
   const setSummonOpen = useMicroLand((s) => s.setSummonOpen)
 
   const paintingSelected = tool.kind === 'material' || tool.kind === 'erase'
@@ -195,6 +197,28 @@ export function Toolbar() {
       </div>
 
       <div className="-mx-1 flex gap-1.5 overflow-x-auto px-1 pb-1">
+        {/* Creatures still on their way hold their place at the front of the
+            strip, right where the finished one lands. */}
+        {pending.map((p) => (
+          <div
+            key={p.id}
+            className="shrink-0"
+            title={`Making “${p.prompt}”`}
+            aria-label={`Making ${p.prompt}`}
+            style={{
+              ...swatchStyle(false),
+              minWidth: 62,
+              borderStyle: 'dashed',
+              borderColor: 'var(--cc-pink-border)',
+            }}
+          >
+            <span style={{ height: 34, display: 'grid', placeItems: 'center' }}>
+              <SummonSand size={34} />
+            </span>
+            <span style={{ ...swatchLabel, color: 'var(--cc-pink)' }}>Making…</span>
+          </div>
+        ))}
+
         {ordered.map((bp) => {
           const selected = tool.kind === 'creature' && tool.blueprintId === bp.id
           return (

--- a/src/app/micro-land/components/toolbar.tsx
+++ b/src/app/micro-land/components/toolbar.tsx
@@ -4,6 +4,7 @@ import { MATERIALS, PAINTABLE } from '@/app/micro-land/domain/config/materials'
 import { useMicroLand } from '@/app/micro-land/store'
 
 import { CreaturePortrait } from './creature-chip'
+import { SparkleIcon } from './sparkle-icon'
 
 const BRUSHES = [2, 4, 8, 14]
 
@@ -145,9 +146,13 @@ export function Toolbar() {
             border: '1px solid var(--cc-mint)',
             color: 'var(--cc-on-mint)',
             boxShadow: 'var(--cc-mint-glow)',
+            display: 'inline-flex',
+            alignItems: 'center',
+            gap: 6,
           }}
         >
-          ✦ Summon
+          <SparkleIcon size={12} />
+          Generate
         </button>
         <button
           type="button"

--- a/src/app/micro-land/components/toolbar.tsx
+++ b/src/app/micro-land/components/toolbar.tsx
@@ -1,6 +1,19 @@
 'use client'
 
-import { MATERIALS, PAINTABLE } from '@/app/micro-land/domain/config/materials'
+import { useEffect, useMemo, useRef, useState } from 'react'
+
+import {
+  CREATURE_GROUPS,
+  type CreatureGroup,
+  creatureGroup,
+} from '@/app/micro-land/domain/blueprint'
+import {
+  MATERIALS,
+  PAINTABLE,
+  TINTS,
+  tintedId,
+} from '@/app/micro-land/domain/config/materials'
+import type { MaterialId, TintableMaterialId } from '@/app/micro-land/domain/types'
 import { useMicroLand } from '@/app/micro-land/store'
 
 import { CreaturePortrait } from './creature-chip'
@@ -8,6 +21,20 @@ import { SparkleIcon } from './sparkle-icon'
 import { SummonSand } from './summon-sand'
 
 const BRUSHES = [2, 4, 8, 14]
+
+/**
+ * Which tintable family, if any, the current material belongs to.
+ *
+ * Covers both the plain material ('crystal') and one of its colors
+ * ('crystal-blue'), so picking a color keeps the color strip open on the
+ * family you're painting with instead of collapsing it out from under you.
+ */
+function tintFamily(id: MaterialId): TintableMaterialId | null {
+  const material = MATERIALS[id]
+  if (!material) return null
+  if (material.tintable) return id as TintableMaterialId
+  return material.tintOf
+}
 
 const label: React.CSSProperties = {
   fontFamily: 'var(--cc-font-mono)',
@@ -28,12 +55,38 @@ export function Toolbar() {
   const setSummonOpen = useMicroLand((s) => s.setSummonOpen)
 
   const paintingSelected = tool.kind === 'material' || tool.kind === 'erase'
+  const family = tool.kind === 'material' ? tintFamily(tool.material) : null
 
-  // Summoned creatures first — you just made them, you want to place them.
-  const ordered = [...blueprints].sort((a, b) => {
-    if (!!a.summoned === !!b.summoned) return a.name.localeCompare(b.name)
-    return a.summoned ? -1 : 1
-  })
+  // One flat scrolling row stopped working somewhere around fifteen creatures
+  // and there are more than thirty now. Grouped and wrapped instead: you see a
+  // whole category at once rather than swiping past everything you don't want.
+  const grouped = useMemo(() => {
+    const out = new Map<CreatureGroup, typeof blueprints>()
+    for (const bp of blueprints) {
+      const key = creatureGroup(bp, blueprints)
+      const list = out.get(key)
+      if (list) list.push(bp)
+      else out.set(key, [bp])
+    }
+    for (const list of out.values()) list.sort((a, b) => a.name.localeCompare(b.name))
+    return out
+  }, [blueprints])
+
+  const tabs = CREATURE_GROUPS.filter((g) => (grouped.get(g.id)?.length ?? 0) > 0)
+  const [group, setGroup] = useState<CreatureGroup>('plants')
+
+  // Jump to "Yours" the moment a summon lands, so the thing you just invented
+  // is under your thumb instead of behind a tab you have to go and find.
+  const summonedCount = blueprints.filter((bp) => bp.summoned).length
+  const lastSummoned = useRef(summonedCount)
+  useEffect(() => {
+    if (summonedCount > lastSummoned.current) setGroup('yours')
+    lastSummoned.current = summonedCount
+  }, [summonedCount])
+
+  // Whatever tab is showing has to exist — "Yours" disappears on a fresh world.
+  const active = tabs.some((t) => t.id === group) ? group : (tabs[0]?.id ?? 'plants')
+  const shown = grouped.get(active) ?? []
 
   return (
     <footer
@@ -100,20 +153,27 @@ export function Toolbar() {
         </button>
 
         {PAINTABLE.map((id) => {
-          const material = MATERIALS[id]
-          const selected = tool.kind === 'material' && tool.material === id
+          // A tintable swatch shows whichever color of itself is in hand, so
+          // the palette reflects what the brush will actually paint.
+          const inHand =
+            family === id && tool.kind === 'material' ? tool.material : id
+          const material = MATERIALS[inHand]
+          const selected =
+            tool.kind === 'material' && (tool.material === id || family === id)
           return (
             <button
               key={id}
               type="button"
               className="cc-btn shrink-0"
-              onClick={() => setTool({ kind: 'material', material: id })}
+              onClick={() => setTool({ kind: 'material', material: inHand })}
               aria-pressed={selected}
               style={swatchStyle(selected)}
             >
               <span
                 aria-hidden
                 style={{
+                  position: 'relative',
+                  display: 'block',
                   width: 22,
                   height: 22,
                   borderRadius: 3,
@@ -121,12 +181,78 @@ export function Toolbar() {
                   boxShadow:
                     material.glow > 0 ? `0 0 10px ${material.color}` : 'inset 0 0 0 1px rgba(0,0,0,0.35)',
                 }}
-              />
-              <span style={swatchLabel}>{material.name}</span>
+              >
+                {MATERIALS[id].tintable && (
+                  // A corner notch marks the ones that come in colors.
+                  <span
+                    style={{
+                      position: 'absolute',
+                      right: 1,
+                      bottom: 1,
+                      width: 0,
+                      height: 0,
+                      borderLeft: '6px solid transparent',
+                      borderBottom: '6px solid rgba(255,255,255,0.75)',
+                    }}
+                  />
+                )}
+              </span>
+              <span style={swatchLabel}>{MATERIALS[id].name}</span>
             </button>
           )
         })}
       </div>
+
+      {family && (
+        <div
+          className="-mx-1 flex items-center gap-1.5 overflow-x-auto px-1 pb-1"
+          role="group"
+          aria-label={`${MATERIALS[family].name} colour`}
+        >
+          <span style={{ ...label, paddingLeft: 4 }}>Colour</span>
+          {[
+            { id: family as MaterialId, name: MATERIALS[family].name },
+            ...TINTS.map((t) => ({
+              id: tintedId(family, t.id),
+              name: t.name,
+            })),
+          ].map(({ id, name }) => {
+            const selected = tool.kind === 'material' && tool.material === id
+            return (
+              <button
+                key={id}
+                type="button"
+                className="cc-btn shrink-0"
+                onClick={() => setTool({ kind: 'material', material: id })}
+                aria-pressed={selected}
+                aria-label={name}
+                title={name}
+                style={{
+                  width: 30,
+                  height: 30,
+                  display: 'grid',
+                  placeItems: 'center',
+                  borderRadius: 999,
+                  border: `2px solid ${selected ? 'var(--cc-mint)' : 'transparent'}`,
+                  background: 'transparent',
+                }}
+              >
+                <span
+                  aria-hidden
+                  style={{
+                    display: 'block',
+                    width: 20,
+                    height: 20,
+                    borderRadius: 999,
+                    background: MATERIALS[id].color,
+                    boxShadow: 'inset 0 0 0 1px rgba(0,0,0,0.35)',
+                  }}
+                />
+              </button>
+            )
+          })}
+        </div>
+      )}
 
       {/* --- creatures --- */}
       <div className="flex items-center gap-2">
@@ -196,10 +322,65 @@ export function Toolbar() {
         </span>
       </div>
 
-      <div className="-mx-1 flex gap-1.5 overflow-x-auto px-1 pb-1">
-        {/* Creatures still on their way hold their place at the front of the
+{/* Creatures still on their way hold their place at the front of the
             strip, right where the finished one lands. */}
-        {pending.map((p) => (
+        
+      <div
+        className="-mx-1 flex gap-1 overflow-x-auto px-1"
+        role="tablist"
+        aria-label="Creature kinds"
+      >
+        {tabs.map((tab) => {
+          const selected = tab.id === active
+          const count = grouped.get(tab.id)?.length ?? 0
+          return (
+            <button
+              key={tab.id}
+              type="button"
+              role="tab"
+              className="cc-btn shrink-0"
+              aria-selected={selected}
+              onClick={() => setGroup(tab.id)}
+              style={{
+                fontFamily: 'var(--cc-font-mono)',
+                fontSize: 9,
+                letterSpacing: 1.2,
+                textTransform: 'uppercase',
+                fontWeight: selected ? 700 : 400,
+                padding: '5px 9px',
+                minHeight: 28,
+                borderRadius: 999,
+                border: `1px solid ${
+                  selected
+                    ? 'var(--cc-mint)'
+                    : tab.id === 'yours'
+                      ? 'var(--cc-pink-border)'
+                      : 'var(--cc-mint-line)'
+                }`,
+                background: selected ? 'var(--cc-mint-soft)' : 'transparent',
+                color: selected
+                  ? 'var(--cc-mint)'
+                  : tab.id === 'yours'
+                    ? 'var(--cc-pink)'
+                    : 'var(--cc-text-muted)',
+                whiteSpace: 'nowrap',
+              }}
+            >
+              {tab.label}
+              <span style={{ opacity: 0.55, marginLeft: 5 }}>{count}</span>
+            </button>
+          )
+        })}
+      </div>
+
+      {/* Wrapped, not a scrolling row — a whole group is visible at once. The
+          cap only bites on "Yours" after a long session of summoning. */}
+      <div
+        role="tabpanel"
+        className="-mx-1 flex flex-wrap gap-1.5 overflow-y-auto px-1 pb-1"
+        style={{ maxHeight: '24vh' }}
+      >
+        { group === 'yours' && pending.map((p) => (
           <div
             key={p.id}
             className="shrink-0"
@@ -218,8 +399,7 @@ export function Toolbar() {
             <span style={{ ...swatchLabel, color: 'var(--cc-pink)' }}>Making…</span>
           </div>
         ))}
-
-        {ordered.map((bp) => {
+        {shown.map((bp) => {
           const selected = tool.kind === 'creature' && tool.blueprintId === bp.id
           return (
             <button

--- a/src/app/micro-land/components/toolbar.tsx
+++ b/src/app/micro-land/components/toolbar.tsx
@@ -1,0 +1,253 @@
+'use client'
+
+import { MATERIALS, PAINTABLE } from '@/app/micro-land/domain/config/materials'
+import { useMicroLand } from '@/app/micro-land/store'
+
+import { CreaturePortrait } from './creature-chip'
+
+const BRUSHES = [2, 4, 8, 14]
+
+const label: React.CSSProperties = {
+  fontFamily: 'var(--cc-font-mono)',
+  fontSize: 9,
+  letterSpacing: 1.6,
+  textTransform: 'uppercase',
+  opacity: 0.5,
+  paddingLeft: 2,
+}
+
+export function Toolbar() {
+  const tool = useMicroLand((s) => s.tool)
+  const setTool = useMicroLand((s) => s.setTool)
+  const brush = useMicroLand((s) => s.brush)
+  const setBrush = useMicroLand((s) => s.setBrush)
+  const blueprints = useMicroLand((s) => s.blueprints)
+  const setSummonOpen = useMicroLand((s) => s.setSummonOpen)
+
+  const paintingSelected = tool.kind === 'material' || tool.kind === 'erase'
+
+  // Summoned creatures first — you just made them, you want to place them.
+  const ordered = [...blueprints].sort((a, b) => {
+    if (!!a.summoned === !!b.summoned) return a.name.localeCompare(b.name)
+    return a.summoned ? -1 : 1
+  })
+
+  return (
+    <footer
+      className="flex flex-col gap-1.5 px-3 pb-3 pt-2"
+      style={{
+        borderTop: '1px solid var(--cc-panel-divider)',
+        background: 'linear-gradient(0deg, var(--cc-panel-grad-from), transparent)',
+      }}
+    >
+      {/* --- ground --- */}
+      <div className="flex items-center gap-2">
+        <span style={label}>Ground</span>
+        <div className="flex items-center gap-1">
+          {BRUSHES.map((size) => (
+            <button
+              key={size}
+              type="button"
+              className="cc-btn"
+              onClick={() => setBrush(size)}
+              aria-label={`Brush size ${size}`}
+              aria-pressed={brush === size}
+              style={{
+                width: 26,
+                height: 26,
+                display: 'grid',
+                placeItems: 'center',
+                borderRadius: 4,
+                border: `1px solid ${brush === size ? 'var(--cc-mint)' : 'var(--cc-mint-line)'}`,
+                background: brush === size ? 'var(--cc-mint-soft)' : 'transparent',
+              }}
+            >
+              <span
+                style={{
+                  display: 'block',
+                  width: Math.min(14, 3 + size),
+                  height: Math.min(14, 3 + size),
+                  borderRadius: '50%',
+                  background: brush === size ? 'var(--cc-mint)' : 'var(--cc-text-muted)',
+                }}
+              />
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div className="-mx-1 flex gap-1.5 overflow-x-auto px-1 pb-1">
+        <button
+          type="button"
+          className="cc-btn shrink-0"
+          onClick={() => setTool({ kind: 'erase' })}
+          aria-pressed={tool.kind === 'erase'}
+          style={swatchStyle(tool.kind === 'erase')}
+        >
+          <span
+            aria-hidden
+            style={{
+              width: 22,
+              height: 22,
+              borderRadius: 3,
+              border: '1px dashed var(--cc-text-muted)',
+            }}
+          />
+          <span style={swatchLabel}>Erase</span>
+        </button>
+
+        {PAINTABLE.map((id) => {
+          const material = MATERIALS[id]
+          const selected = tool.kind === 'material' && tool.material === id
+          return (
+            <button
+              key={id}
+              type="button"
+              className="cc-btn shrink-0"
+              onClick={() => setTool({ kind: 'material', material: id })}
+              aria-pressed={selected}
+              style={swatchStyle(selected)}
+            >
+              <span
+                aria-hidden
+                style={{
+                  width: 22,
+                  height: 22,
+                  borderRadius: 3,
+                  background: material.color,
+                  boxShadow:
+                    material.glow > 0 ? `0 0 10px ${material.color}` : 'inset 0 0 0 1px rgba(0,0,0,0.35)',
+                }}
+              />
+              <span style={swatchLabel}>{material.name}</span>
+            </button>
+          )
+        })}
+      </div>
+
+      {/* --- creatures --- */}
+      <div className="flex items-center gap-2">
+        <span style={label}>Creatures</span>
+        <button
+          type="button"
+          className="cc-btn"
+          onClick={() => setSummonOpen(true)}
+          style={{
+            fontFamily: 'var(--cc-font-mono)',
+            fontSize: 10,
+            letterSpacing: 1.6,
+            textTransform: 'uppercase',
+            fontWeight: 700,
+            padding: '6px 14px',
+            minHeight: 32,
+            borderRadius: 4,
+            background: 'linear-gradient(180deg, var(--cc-mint), var(--cc-mint-hi))',
+            border: '1px solid var(--cc-mint)',
+            color: 'var(--cc-on-mint)',
+            boxShadow: 'var(--cc-mint-glow)',
+          }}
+        >
+          ✦ Summon
+        </button>
+        <button
+          type="button"
+          className="cc-btn"
+          onClick={() =>
+            setTool(tool.kind === 'inspect' ? { kind: 'material', material: 'dirt' } : { kind: 'inspect' })
+          }
+          aria-pressed={tool.kind === 'inspect'}
+          title="Tap a creature to see how it is doing"
+          style={{
+            fontFamily: 'var(--cc-font-mono)',
+            fontSize: 10,
+            letterSpacing: 1.6,
+            textTransform: 'uppercase',
+            padding: '6px 12px',
+            minHeight: 32,
+            borderRadius: 4,
+            border: `1px solid ${tool.kind === 'inspect' ? 'var(--cc-mint)' : 'var(--cc-mint-line)'}`,
+            background: tool.kind === 'inspect' ? 'var(--cc-mint-soft)' : 'transparent',
+            color: tool.kind === 'inspect' ? 'var(--cc-mint)' : 'var(--cc-text-muted)',
+          }}
+        >
+          ⌕ Inspect
+        </button>
+        <span
+          style={{
+            fontFamily: 'var(--cc-font-mono)',
+            fontSize: 9,
+            opacity: 0.45,
+            letterSpacing: 1,
+          }}
+          className="hidden sm:inline"
+        >
+          {tool.kind === 'inspect'
+            ? 'tap a creature to watch it'
+            : paintingSelected
+              ? 'drag a creature to throw it'
+              : 'tap to place · drag a creature to throw it'}
+        </span>
+      </div>
+
+      <div className="-mx-1 flex gap-1.5 overflow-x-auto px-1 pb-1">
+        {ordered.map((bp) => {
+          const selected = tool.kind === 'creature' && tool.blueprintId === bp.id
+          return (
+            <button
+              key={bp.id}
+              type="button"
+              className="cc-btn shrink-0"
+              onClick={() => setTool({ kind: 'creature', blueprintId: bp.id })}
+              aria-pressed={selected}
+              title={bp.blurb}
+              style={{
+                ...swatchStyle(selected),
+                minWidth: 62,
+                borderColor: selected
+                  ? 'var(--cc-mint)'
+                  : bp.summoned
+                    ? 'var(--cc-pink-border)'
+                    : 'var(--cc-mint-line)',
+              }}
+            >
+              <span
+                style={{
+                  height: 34,
+                  display: 'grid',
+                  placeItems: 'center',
+                }}
+              >
+                <CreaturePortrait blueprint={bp} size={34} />
+              </span>
+              <span style={swatchLabel}>{bp.name}</span>
+            </button>
+          )
+        })}
+      </div>
+    </footer>
+  )
+}
+
+function swatchStyle(selected: boolean): React.CSSProperties {
+  return {
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    gap: 4,
+    padding: '6px 8px',
+    minWidth: 54,
+    minHeight: 44,
+    borderRadius: 5,
+    border: `1px solid ${selected ? 'var(--cc-mint)' : 'var(--cc-mint-line)'}`,
+    background: selected ? 'var(--cc-mint-soft)' : 'rgba(255,255,255,0.02)',
+  }
+}
+
+const swatchLabel: React.CSSProperties = {
+  fontFamily: 'var(--cc-font-mono)',
+  fontSize: 8,
+  letterSpacing: 0.8,
+  textTransform: 'uppercase',
+  whiteSpace: 'nowrap',
+  opacity: 0.75,
+}

--- a/src/app/micro-land/domain/blueprint.ts
+++ b/src/app/micro-land/domain/blueprint.ts
@@ -1,0 +1,455 @@
+/**
+ * The blueprint contract.
+ *
+ * This file is the seam between "an LLM invented a creature" and "the world can
+ * safely run it". The zod schema doubles as the tool-call schema handed to the
+ * model — the `.describe()` calls are the model's only instructions about what
+ * each field means, so they're written for the model to read.
+ *
+ * Everything that comes back gets pushed through `sanitizeBlueprint`, which
+ * assumes the input is hostile: wrong types, absurd numbers, ragged pixel rows,
+ * colors that aren't colors, 400 animation frames. The world only ever sees the
+ * sanitized result.
+ */
+import { z } from 'zod'
+
+import { MATERIAL_IDS } from './config/materials'
+import { TerrainSchema } from './terrain'
+
+import type { CreatureBlueprint, MaterialId } from './types'
+
+export const ART_MIN = 3
+export const ART_MAX = 14
+export const MAX_FRAMES = 4
+export const MAX_PALETTE = 10
+
+// z.enum wants a mutable tuple; MATERIAL_IDS is `as const`.
+const materialEnum = z.enum([...MATERIAL_IDS] as [MaterialId, ...MaterialId[]])
+
+const hexColor = z
+  .string()
+  .regex(/^#[0-9a-fA-F]{6}$/, 'Must be a hex color like #ff8800')
+
+export const BlueprintSchema = z.object({
+  name: z
+    .string()
+    .describe('Short display name, 1-3 words. Title Case. No emoji.'),
+  blurb: z
+    .string()
+    .describe(
+      'One short sentence describing the creature, written for a curious kid. No emoji.'
+    ),
+  size: z
+    .number()
+    .describe(
+      'Relative size from 1 to 6. 1 = mite or seed, 2 = bug, 3 = cat-sized, 4 = wolf-sized, 5 = bear-sized, 6 = leviathan. Nothing can eat something LARGER than itself, so size is what sets its place in the food chain.'
+    ),
+  tags: z
+    .array(z.string())
+    .describe(
+      'What this creature IS — other creatures hunt it by matching these. Always include exactly one of "plant", "meat", or "mineral". Then add 1-3 flavour tags like "bug", "fish", "bird", "glow", "fungus", "metal". Lowercase single words.'
+    ),
+  art: z
+    .object({
+      palette: z
+        .record(z.string(), hexColor)
+        .describe(
+          'Map of SINGLE characters to hex colors, e.g. {"b":"#33dd88","e":"#ffffff"}. Max 10 entries. Never define "." — it is always transparent.'
+        ),
+      frames: z
+        .array(z.array(z.string()))
+        .describe(
+          'Animation frames. Each frame is an array of equal-length row strings; each character is a palette key or "." for transparent. Between 3 and 14 characters wide and tall. Give 2 frames so it animates — make frame 2 a small change (a step, a blink, a wing beat), not a completely different drawing. Draw the creature FACING RIGHT.'
+        ),
+      frameMs: z
+        .number()
+        .describe('Milliseconds each frame is shown. 90-400. Faster = twitchier.'),
+      faceMotion: z
+        .boolean()
+        .describe(
+          'True if the sprite should flip horizontally when moving left. True for anything with a clear front (animals). False for blobs, orbs and plants.'
+        ),
+    })
+    .describe('How the creature looks and animates, as pixel art.'),
+  body: z
+    .object({
+      mass: z
+        .number()
+        .describe('Gravity multiplier. 0.2 = feather, 1 = normal, 3 = boulder.'),
+      bounce: z.number().describe('Bounciness on impact, 0 = thud, 0.8 = rubber ball.'),
+      drag: z
+        .number()
+        .describe('Fraction of speed kept each second, 0.05-0.99. Low = sluggish.'),
+      buoyancy: z
+        .number()
+        .describe('Above 1 floats in water, below 1 sinks. 1 = neutral.'),
+      immuneTo: z
+        .array(materialEnum)
+        .describe(
+          'Materials that cannot hurt it. Use ["lava"] for fire creatures, [] for most things.'
+        ),
+    })
+    .describe('Physical properties.'),
+  move: z
+    .object({
+      kind: z
+        .enum(['walk', 'fly', 'swim', 'crawl', 'drift', 'root'])
+        .describe(
+          'walk = ground animal that can jump. fly = free movement through air. swim = only moves in water, helpless on land. crawl = clings to walls and ceilings. drift = floats and bobs. root = never moves (plants, coral, eggs, mushrooms).'
+        ),
+      speed: z.number().describe('Top speed in tiles per second, 0.5-14.'),
+      jump: z.number().describe('Jump strength for walkers, 0-20. Ignored otherwise.'),
+      restlessness: z
+        .number()
+        .describe('Chance per second of changing idle direction, 0-1. 0.2 is calm.'),
+    })
+    .describe('How it moves.'),
+  diet: z
+    .object({
+      eats: z
+        .array(z.string())
+        .describe(
+          'Tags it can eat. ["plant"] = herbivore, ["meat"] = predator, ["plant","meat"] = omnivore, [] = eats nothing and never gets hungry (use for plants and minerals). It can only eat creatures its own size or smaller.'
+        ),
+      fears: z
+        .array(z.string())
+        .describe(
+          'Extra tags to run away from, beyond the creatures that naturally hunt it. Usually [].'
+        ),
+      hungerRate: z
+        .number()
+        .describe('How fast it gets hungry, 0-0.2 per second. 0.03 is typical.'),
+      starveSeconds: z
+        .number()
+        .describe('How long it survives once starving, 5-120 seconds.'),
+      breedAt: z
+        .number()
+        .describe('How full it must be to reproduce, 0-1. Around 0.75 is typical.'),
+      lifespanSeconds: z
+        .number()
+        .describe('Dies of old age after this long, 20-900 seconds.'),
+    })
+    .describe('Hunger, hunting and reproduction — this is what drives the food chain.'),
+  senses: z
+    .object({
+      sight: z
+        .number()
+        .describe('How far it spots food and danger, in tiles. 4-50.'),
+    })
+    .describe('Perception.'),
+  habitat: z
+    .object({
+      needs: z
+        .array(materialEnum)
+        .nullable()
+        .describe(
+          'If set, it is hurt anywhere it is NOT touching one of these. Use ["water"] for a fish. Use null for creatures that live anywhere.'
+        ),
+      drowns: z
+        .boolean()
+        .describe('True if being underwater kills it. False for fish and amphibians.'),
+    })
+    .describe('Where it can survive.'),
+  dig: z
+    .object({
+      through: z
+        .array(materialEnum)
+        .describe(
+          'Materials this creature can tunnel through, leaving a real tunnel behind it. [] for almost everything — digging is a special ability, not a default. A mole might use ["dirt","sand","grass"]; a rock-borer ["stone","obsidian"]; a scrap-eating machine ["metal","glass"]. Never include water or lava; those are liquids, not walls.'
+        ),
+      speed: z
+        .number()
+        .describe(
+          'Tiles chewed through per second, 0.2 to 6. Slow digging through hard rock looks like effort; fast digging through loose sand looks right.'
+        ),
+    })
+    .describe('Tunnelling ability. Most creatures cannot dig.'),
+  death: z
+    .object({
+      becomes: materialEnum
+        .nullable()
+        .describe('Material left behind where it died, or null for nothing.'),
+      particleColor: hexColor.describe('Color of the burst it leaves behind.'),
+      particleCount: z.number().describe('How many particles, 0-30.'),
+    })
+    .describe('What happens when it dies.'),
+  glow: z
+    .number()
+    .describe('Light it casts into dark places, 0-1. 0 for most creatures.'),
+})
+
+export type RawBlueprint = z.infer<typeof BlueprintSchema>
+
+export const SceneSchema = z.object({
+  title: z.string().describe('A short evocative name for this scene, 2-5 words.'),
+  terrain: TerrainSchema.describe(
+    'The land this scene lives in. Build somewhere these particular creatures can actually survive: water if anything swims, open air if anything flies, and fertile ground (dirt, grass, sand, ash or wood) wherever plants need to root.'
+  ),
+  note: z
+    .string()
+    .describe(
+      'One friendly sentence telling the player what to watch for, e.g. "The glimmer-moths keep the vines down — until the stalkers arrive."'
+    ),
+  creatures: z
+    .array(
+      BlueprintSchema.extend({
+        count: z
+          .number()
+          .describe('How many of this creature to place in the world, 1-40.'),
+      })
+    )
+    .describe(
+      'The creatures in this scene, 2-5 of them. Build a working food chain: include something that eats plants and something that eats the plant-eater, so the population can rise and fall on its own.'
+    ),
+})
+
+export type RawScene = z.infer<typeof SceneSchema>
+
+// ---------------------------------------------------------------------------
+// Sanitizing
+// ---------------------------------------------------------------------------
+
+function clamp(n: unknown, lo: number, hi: number, fallback: number): number {
+  const v = typeof n === 'number' && Number.isFinite(n) ? n : fallback
+  return Math.min(hi, Math.max(lo, v))
+}
+
+function cleanColor(c: unknown, fallback: string): string {
+  return typeof c === 'string' && /^#[0-9a-fA-F]{6}$/.test(c) ? c.toLowerCase() : fallback
+}
+
+function cleanTags(input: unknown, fallback: string[]): string[] {
+  if (!Array.isArray(input)) return fallback
+  const out = input
+    .filter((t): t is string => typeof t === 'string')
+    .map((t) => t.trim().toLowerCase().replace(/[^a-z-]/g, ''))
+    .filter((t) => t.length > 0 && t.length <= 16)
+  return Array.from(new Set(out)).slice(0, 6)
+}
+
+function cleanMaterials(input: unknown): MaterialId[] {
+  if (!Array.isArray(input)) return []
+  const valid = new Set<string>(MATERIAL_IDS)
+  return Array.from(
+    new Set(input.filter((m): m is MaterialId => typeof m === 'string' && valid.has(m)))
+  )
+}
+
+/**
+ * Coerce whatever the model drew into a rectangular, in-bounds sprite.
+ *
+ * Ragged rows are the single most common malformed output, so rows are padded
+ * or cropped to a common width rather than rejected — a slightly-wrong creature
+ * is much better than an error message. If nothing usable survives, the caller
+ * gets a visible fallback blob instead of an invisible creature.
+ */
+function sanitizeArt(raw: unknown, fallbackColor: string): CreatureBlueprint['art'] {
+  const art = (raw ?? {}) as Record<string, unknown>
+
+  // Palette: single-char keys → hex colors. '.' is reserved for transparent.
+  const palette: Record<string, string> = {}
+  const rawPalette = (art.palette ?? {}) as Record<string, unknown>
+  if (rawPalette && typeof rawPalette === 'object') {
+    for (const [key, value] of Object.entries(rawPalette)) {
+      if (key.length !== 1 || key === '.') continue
+      if (typeof value !== 'string' || !/^#[0-9a-fA-F]{6}$/.test(value)) continue
+      palette[key] = value.toLowerCase()
+      if (Object.keys(palette).length >= MAX_PALETTE) break
+    }
+  }
+  if (Object.keys(palette).length === 0) palette.o = fallbackColor
+
+  const known = new Set(Object.keys(palette))
+
+  // Frames: drop anything non-string, normalize each row to the modal width.
+  const rawFrames = Array.isArray(art.frames) ? art.frames : []
+  let frames: string[][] = []
+  for (const frame of rawFrames.slice(0, MAX_FRAMES)) {
+    if (!Array.isArray(frame)) continue
+    const rows = frame.filter((r): r is string => typeof r === 'string').slice(0, ART_MAX)
+    if (rows.length === 0) continue
+    frames.push(rows)
+  }
+
+  if (frames.length === 0) {
+    // Nothing usable — a small blob so the creature is at least visible.
+    const key = Object.keys(palette)[0]
+    frames = [[`.${key}${key}.`, `${key}${key}${key}${key}`, `.${key}${key}.`]]
+  }
+
+  // Every frame must share one width and height, or animation would jitter.
+  const width = clamp(
+    Math.max(...frames.map((f) => Math.max(...f.map((r) => r.length)))),
+    ART_MIN,
+    ART_MAX,
+    4
+  )
+  const height = clamp(
+    Math.max(...frames.map((f) => f.length)),
+    ART_MIN,
+    ART_MAX,
+    4
+  )
+
+  const normalized = frames.map((rows) => {
+    const out: string[] = []
+    for (let y = 0; y < height; y++) {
+      const row = rows[y] ?? ''
+      let line = ''
+      for (let x = 0; x < width; x++) {
+        const ch = row[x] ?? '.'
+        line += known.has(ch) ? ch : '.'
+      }
+      out.push(line)
+    }
+    return out
+  })
+
+  // An all-transparent sprite is an invisible creature — give it a body.
+  const anyOpaque = normalized.some((f) => f.some((r) => /[^.]/.test(r)))
+  if (!anyOpaque) {
+    const key = Object.keys(palette)[0]
+    const mid = Math.floor(height / 2)
+    normalized[0][mid] = key.repeat(width)
+  }
+
+  return {
+    palette,
+    frames: normalized,
+    frameMs: clamp(art.frameMs, 60, 1200, 200),
+    faceMotion: art.faceMotion !== false,
+  }
+}
+
+let summonCounter = 0
+
+/**
+ * Turn arbitrary model output into a blueprint the world can run.
+ * Never throws — every field falls back to something playable.
+ */
+export function sanitizeBlueprint(
+  raw: unknown,
+  opts: { idPrefix?: string; summoned?: boolean } = {}
+): CreatureBlueprint {
+  const b = (raw ?? {}) as Record<string, unknown>
+  const body = (b.body ?? {}) as Record<string, unknown>
+  const move = (b.move ?? {}) as Record<string, unknown>
+  const diet = (b.diet ?? {}) as Record<string, unknown>
+  const senses = (b.senses ?? {}) as Record<string, unknown>
+  const habitat = (b.habitat ?? {}) as Record<string, unknown>
+  const death = (b.death ?? {}) as Record<string, unknown>
+  const dig = (b.dig ?? {}) as Record<string, unknown>
+
+  const name =
+    typeof b.name === 'string' && b.name.trim().length > 0
+      ? b.name.trim().slice(0, 32)
+      : 'Whatsit'
+
+  const prefix = opts.idPrefix ?? 'summon'
+  const slug = name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '')
+  const id = `${prefix}:${slug || 'creature'}:${++summonCounter}`
+
+  const kindRaw = typeof move.kind === 'string' ? move.kind : 'walk'
+  const kind = (['walk', 'fly', 'swim', 'crawl', 'drift', 'root'] as const).includes(
+    kindRaw as never
+  )
+    ? (kindRaw as CreatureBlueprint['move']['kind'])
+    : 'walk'
+
+  const particleColor = cleanColor(death.particleColor, '#ffd166')
+  const art = sanitizeArt(b.art, particleColor)
+
+  // Keep exactly one "what am I made of" tag so the food chain always resolves.
+  let tags = cleanTags(b.tags, ['meat'])
+  if (!tags.some((t) => t === 'plant' || t === 'meat' || t === 'mineral')) {
+    tags = [kind === 'root' ? 'plant' : 'meat', ...tags].slice(0, 6)
+  }
+
+  const becomes = typeof death.becomes === 'string' ? death.becomes : null
+  const validBecomes =
+    becomes && (MATERIAL_IDS as readonly string[]).includes(becomes)
+      ? (becomes as MaterialId)
+      : null
+
+  const needsRaw = habitat.needs
+  const needs = needsRaw === null || needsRaw === undefined ? null : cleanMaterials(needsRaw)
+
+  return {
+    id,
+    name,
+    blurb:
+      typeof b.blurb === 'string' && b.blurb.trim().length > 0
+        ? b.blurb.trim().slice(0, 160)
+        : 'Nobody has written this one up yet.',
+    size: Math.round(clamp(b.size, 1, 6, 2)),
+    tags,
+    art,
+    body: {
+      mass: clamp(body.mass, 0, 6, 1),
+      bounce: clamp(body.bounce, 0, 0.95, 0.1),
+      drag: clamp(body.drag, 0.01, 0.99, 0.4),
+      buoyancy: clamp(body.buoyancy, 0, 3, 0.9),
+      immuneTo: cleanMaterials(body.immuneTo),
+    },
+    move: {
+      kind,
+      speed: clamp(move.speed, 0, 16, 3),
+      jump: clamp(move.jump, 0, 24, 8),
+      restlessness: clamp(move.restlessness, 0, 1, 0.25),
+    },
+    diet: {
+      eats: cleanTags(diet.eats, []),
+      fears: cleanTags(diet.fears, []),
+      hungerRate: clamp(diet.hungerRate, 0, 0.3, 0.03),
+      starveSeconds: clamp(diet.starveSeconds, 3, 300, 30),
+      breedAt: clamp(diet.breedAt, 0.1, 1, 0.75),
+      lifespanSeconds: clamp(diet.lifespanSeconds, 10, 1800, 240),
+    },
+    senses: { sight: clamp(senses.sight, 1, 60, 14) },
+    dig: {
+      // Liquids aren't walls — letting them be "dug" would delete oceans.
+      through: cleanMaterials(dig.through).filter(
+        (m) => m !== 'water' && m !== 'lava' && m !== 'air'
+      ),
+      speed: clamp(dig.speed, 0.05, 8, 1),
+    },
+    habitat: {
+      needs: needs && needs.length > 0 ? needs : null,
+      drowns: habitat.drowns !== false,
+    },
+    death: {
+      becomes: validBecomes,
+      particleColor,
+      particleCount: Math.round(clamp(death.particleCount, 0, 30, 6)),
+    },
+    glow: clamp(b.glow, 0, 1, 0),
+    summoned: opts.summoned ?? false,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Food chain
+// ---------------------------------------------------------------------------
+
+/**
+ * The entire predator/prey rule: you can eat it if you eat one of its tags and
+ * it isn't bigger than you. Every relationship in the world falls out of this,
+ * including ones between a built-in creature and one invented five seconds ago.
+ */
+export function canEat(hunter: CreatureBlueprint, prey: CreatureBlueprint): boolean {
+  if (hunter.id === prey.id) return false
+  if (prey.size > hunter.size) return false
+  return hunter.diet.eats.some((tag) => prey.tags.includes(tag))
+}
+
+/** True if `prey` should run from `hunter`. */
+export function fears(prey: CreatureBlueprint, hunter: CreatureBlueprint): boolean {
+  if (prey.diet.fears.some((tag) => hunter.tags.includes(tag))) return true
+  return canEat(hunter, prey)
+}
+
+/** Sprite dimensions in tiles. */
+export function artSize(bp: CreatureBlueprint): { w: number; h: number } {
+  const frame = bp.art.frames[0]
+  return { w: frame[0].length, h: frame.length }
+}

--- a/src/app/micro-land/domain/blueprint.ts
+++ b/src/app/micro-land/domain/blueprint.ts
@@ -13,18 +13,55 @@
  */
 import { z } from 'zod'
 
-import { MATERIAL_IDS } from './config/materials'
+import { BASE_MATERIAL_IDS, IS_LIQUID, MATERIAL_IDS, MATERIAL_INDEX } from './config/materials'
 import { TerrainSchema } from './terrain'
 
-import type { CreatureBlueprint, MaterialId } from './types'
+import type { CreatureAura, CreatureBlueprint, MaterialId } from './types'
 
 export const ART_MIN = 3
-export const ART_MAX = 14
+/**
+ * Sprite bounds, in world tiles.
+ *
+ * Wider than tall, because the things that want to be big are long: dragons,
+ * wyrms, whales, a tyrannosaur's tail. 28 is an eighth of the world's width,
+ * which is the point at which a creature reads as a landmark rather than an
+ * animal — go much past that and it can only exist in open sky.
+ *
+ * These were one shared 14 for a long time, and 14 is small enough that the
+ * model would draw a leviathan at exactly the same scale as a beetle.
+ */
+export const ART_MAX_W = 28
+export const ART_MAX_H = 24
 export const MAX_FRAMES = 4
-export const MAX_PALETTE = 10
+/** A 28x24 monster has room for shading a 6x6 bug never did. */
+export const MAX_PALETTE = 12
 
-// z.enum wants a mutable tuple; MATERIAL_IDS is `as const`.
-const materialEnum = z.enum([...MATERIAL_IDS] as [MaterialId, ...MaterialId[]])
+/**
+ * Size of a creature's *solid core*, beyond which the sprite stops counting as
+ * a wall.
+ *
+ * A creature collides with its whole drawing, which is correct right up until
+ * the drawing is mostly wings. A 28-wide dragon would need a 28-wide gap to
+ * walk through and would wedge in the first cave it tried to enter — so past
+ * this threshold, extra sprite is only 40% solid. Wingtips, tails and long
+ * necks pass through rock; the body itself still doesn't.
+ *
+ * Set deliberately above the largest built-in creature (Grumblestone, 10x7) so
+ * every creature that existed before this rule behaves exactly as it did.
+ */
+const CORE_W = 12
+const CORE_H = 10
+const CORE_SLOPE = 0.4
+
+/**
+ * Only the base materials are offered to the model.
+ *
+ * The tints ('plastic-red', 'crystal-blue' …) are a painting affordance, not
+ * vocabulary — putting all of them in the enum would quadruple the schema and
+ * invite a creature that digs through mauve plastic but not blue. Tints are
+ * still *accepted* by the sanitizer, since they're perfectly valid materials.
+ */
+const materialEnum = z.enum([...BASE_MATERIAL_IDS] as [MaterialId, ...MaterialId[]])
 
 const hexColor = z
   .string()
@@ -59,7 +96,7 @@ export const BlueprintSchema = z.object({
       frames: z
         .array(z.array(z.string()))
         .describe(
-          'Animation frames. Each frame is an array of equal-length row strings; each character is a palette key or "." for transparent. Between 3 and 14 characters wide and tall. Give 2 frames so it animates — make frame 2 a small change (a step, a blink, a wing beat), not a completely different drawing. Draw the creature FACING RIGHT.'
+          'Animation frames. Each frame is an array of equal-length row strings; each character is a palette key or "." for transparent. At least 3 wide and tall, at most 28 wide and 24 tall. SCALE THE DRAWING TO THE "size" FIELD: size 1 is 3-5 wide, size 3 about 9, size 6 is 20-28 wide. A size 6 dragon drawn 9 wide looks like an insect. Give 2 frames so it animates — make frame 2 a small change (a step, a blink, a wing beat), not a completely different drawing. Draw the creature FACING RIGHT.'
         ),
       frameMs: z
         .number()
@@ -173,6 +210,34 @@ export const BlueprintSchema = z.object({
       particleCount: z.number().describe('How many particles, 0-30.'),
     })
     .describe('What happens when it dies.'),
+  aura: z
+    .object({
+      radius: z.number().describe('How far the effect reaches, in tiles. 5-30.'),
+      helps: z
+        .array(z.string())
+        .describe(
+          'Tags of creatures that breed faster near this one. ["plant"] makes a pollinator. Use [] for no effect.'
+        ),
+      boost: z
+        .number()
+        .describe('How much faster they breed, 1 to 4. 1 means no help.'),
+      converts: z
+        .object({
+          from: materialEnum.describe('The material it changes.'),
+          to: materialEnum.describe('What that material becomes.'),
+        })
+        .nullable()
+        .describe(
+          'Ground it slowly improves as it goes, e.g. {"from":"stone","to":"dirt"} for a worm that makes soil. Null for almost everything.'
+        ),
+      convertRate: z
+        .number()
+        .describe('Tiles changed per second, 0.05-1. Keep it slow.'),
+    })
+    .nullable()
+    .describe(
+      'A special ability that changes the world around it — pollinating, or turning one material into another. Use null unless the description specifically calls for a helper creature; ordinary animals have no aura.'
+    ),
   glow: z
     .number()
     .describe('Light it casts into dark places, 0-1. 0 for most creatures.'),
@@ -235,6 +300,47 @@ function cleanMaterials(input: unknown): MaterialId[] {
   )
 }
 
+function cleanMaterial(input: unknown): MaterialId | null {
+  if (typeof input !== 'string') return null
+  return (MATERIAL_IDS as readonly string[]).includes(input)
+    ? (input as MaterialId)
+    : null
+}
+
+/**
+ * An aura is optional and easy to get subtly wrong, so anything that doesn't
+ * resolve to a real effect collapses back to null — a creature with a broken
+ * aura is just a creature.
+ */
+function cleanAura(raw: unknown): CreatureAura | null {
+  if (!raw || typeof raw !== 'object') return null
+  const a = raw as Record<string, unknown>
+
+  const helps = cleanTags(a.helps, [])
+  const boost = clamp(a.boost, 1, 4, 1)
+
+  let converts: CreatureAura['converts'] = null
+  const rawConverts = a.converts
+  if (rawConverts && typeof rawConverts === 'object') {
+    const from = cleanMaterial((rawConverts as Record<string, unknown>).from)
+    const to = cleanMaterial((rawConverts as Record<string, unknown>).to)
+    // Converting air into rock would let a creature wall the world in, and
+    // converting something into itself is a no-op that still costs a tile scan.
+    if (from && to && from !== to && from !== 'air') converts = { from, to }
+  }
+
+  const doesSomething = (helps.length > 0 && boost > 1) || converts !== null
+  if (!doesSomething) return null
+
+  return {
+    radius: clamp(a.radius, 2, 40, 12),
+    helps,
+    boost,
+    converts,
+    convertRate: clamp(a.convertRate, 0.01, 2, 0.2),
+  }
+}
+
 /**
  * Coerce whatever the model drew into a rectangular, in-bounds sprite.
  *
@@ -243,12 +349,31 @@ function cleanMaterials(input: unknown): MaterialId[] {
  * is much better than an error message. If nothing usable survives, the caller
  * gets a visible fallback blob instead of an invisible creature.
  */
+/**
+ * Unwrap a value the model handed back as a JSON string instead of an object.
+ *
+ * It does this occasionally on the deeply nested fields — `art` comes through as
+ * `"{\"palette\":...}"` — and the difference is invisible until the creature
+ * arrives as a featureless blob, because every field inside reads as missing and
+ * quietly falls back. One `JSON.parse` is the whole fix.
+ */
+function unwrapJson(value: unknown): unknown {
+  if (typeof value !== 'string') return value
+  const text = value.trim()
+  if (!text.startsWith('{') && !text.startsWith('[')) return value
+  try {
+    return JSON.parse(text)
+  } catch {
+    return value
+  }
+}
+
 function sanitizeArt(raw: unknown, fallbackColor: string): CreatureBlueprint['art'] {
-  const art = (raw ?? {}) as Record<string, unknown>
+  const art = (unwrapJson(raw) ?? {}) as Record<string, unknown>
 
   // Palette: single-char keys → hex colors. '.' is reserved for transparent.
   const palette: Record<string, string> = {}
-  const rawPalette = (art.palette ?? {}) as Record<string, unknown>
+  const rawPalette = (unwrapJson(art.palette) ?? {}) as Record<string, unknown>
   if (rawPalette && typeof rawPalette === 'object') {
     for (const [key, value] of Object.entries(rawPalette)) {
       if (key.length !== 1 || key === '.') continue
@@ -262,11 +387,13 @@ function sanitizeArt(raw: unknown, fallbackColor: string): CreatureBlueprint['ar
   const known = new Set(Object.keys(palette))
 
   // Frames: drop anything non-string, normalize each row to the modal width.
-  const rawFrames = Array.isArray(art.frames) ? art.frames : []
+  const unwrappedFrames = unwrapJson(art.frames)
+  const rawFrames = Array.isArray(unwrappedFrames) ? unwrappedFrames : []
   let frames: string[][] = []
-  for (const frame of rawFrames.slice(0, MAX_FRAMES)) {
+  for (const raw of rawFrames.slice(0, MAX_FRAMES)) {
+    const frame = unwrapJson(raw)
     if (!Array.isArray(frame)) continue
-    const rows = frame.filter((r): r is string => typeof r === 'string').slice(0, ART_MAX)
+    const rows = frame.filter((r): r is string => typeof r === 'string').slice(0, ART_MAX_H)
     if (rows.length === 0) continue
     frames.push(rows)
   }
@@ -277,17 +404,54 @@ function sanitizeArt(raw: unknown, fallbackColor: string): CreatureBlueprint['ar
     frames = [[`.${key}${key}.`, `${key}${key}${key}${key}`, `.${key}${key}.`]]
   }
 
+  /**
+   * Oversize art: slide the window onto where the drawing actually is.
+   *
+   * Rows wider than the cap used to be truncated with `row.slice(0, MAX)`,
+   * keeping the leftmost columns. Creatures are drawn facing right, so on a
+   * 44-wide dragon that throws away the head and keeps the tail — the one crop
+   * guaranteed to destroy it. Trimming blank columns first usually gets it
+   * under the cap on its own, since overshoot is mostly empty margin; if it is
+   * still too wide the window centres on the ink instead of the origin.
+   *
+   * Only runs when the art is over the cap, so anything already in range keeps
+   * its padding — and therefore its collision box — exactly as drawn.
+   */
+  const rawWidth = Math.max(...frames.map((f) => Math.max(...f.map((r) => r.length))))
+  if (rawWidth > ART_MAX_W) {
+    let first = Infinity
+    let last = -1
+    for (const rows of frames) {
+      for (const row of rows) {
+        for (let x = 0; x < row.length; x++) {
+          if (row[x] === '.' || !known.has(row[x])) continue
+          if (x < first) first = x
+          if (x > last) last = x
+        }
+      }
+    }
+    if (last >= first) {
+      const inkWidth = last - first + 1
+      // Centre the window on the ink when even the trimmed drawing overflows.
+      const start =
+        inkWidth <= ART_MAX_W
+          ? first
+          : first + Math.floor((inkWidth - ART_MAX_W) / 2)
+      frames = frames.map((rows) => rows.map((row) => row.slice(start, start + ART_MAX_W)))
+    }
+  }
+
   // Every frame must share one width and height, or animation would jitter.
   const width = clamp(
     Math.max(...frames.map((f) => Math.max(...f.map((r) => r.length)))),
     ART_MIN,
-    ART_MAX,
+    ART_MAX_W,
     4
   )
   const height = clamp(
     Math.max(...frames.map((f) => f.length)),
     ART_MIN,
-    ART_MAX,
+    ART_MAX_H,
     4
   )
 
@@ -409,7 +573,7 @@ export function sanitizeBlueprint(
     dig: {
       // Liquids aren't walls — letting them be "dug" would delete oceans.
       through: cleanMaterials(dig.through).filter(
-        (m) => m !== 'water' && m !== 'lava' && m !== 'air'
+        (m) => m !== 'air' && IS_LIQUID[MATERIAL_INDEX[m]] !== 1
       ),
       speed: clamp(dig.speed, 0.05, 8, 1),
     },
@@ -422,6 +586,7 @@ export function sanitizeBlueprint(
       particleColor,
       particleCount: Math.round(clamp(death.particleCount, 0, 30, 6)),
     },
+    aura: cleanAura(b.aura),
     glow: clamp(b.glow, 0, 1, 0),
     summoned: opts.summoned ?? false,
   }
@@ -442,6 +607,58 @@ export function canEat(hunter: CreatureBlueprint, prey: CreatureBlueprint): bool
   return hunter.diet.eats.some((tag) => prey.tags.includes(tag))
 }
 
+// ---------------------------------------------------------------------------
+// Grouping
+// ---------------------------------------------------------------------------
+
+export type CreatureGroup =
+  | 'yours'
+  | 'plants'
+  | 'grazers'
+  | 'hunters'
+  | 'giants'
+  | 'helpers'
+
+/** Tab order, and the labels the player sees. Plain words, not taxonomy. */
+export const CREATURE_GROUPS: { id: CreatureGroup; label: string }[] = [
+  { id: 'yours', label: 'Yours' },
+  { id: 'plants', label: 'Plants' },
+  { id: 'grazers', label: 'Plant Eaters' },
+  { id: 'hunters', label: 'Hunters' },
+  { id: 'giants', label: 'Giants' },
+  { id: 'helpers', label: 'Helpers' },
+]
+
+/** Anything that photosynthesises rather than hunts — moss, coral, a sky flower. */
+function isPlantLike(bp: CreatureBlueprint): boolean {
+  return bp.move.kind === 'root' || (bp.diet.eats.length === 0 && bp.tags.includes('plant'))
+}
+
+/**
+ * Which drawer of the creature menu this belongs in.
+ *
+ * Worked out from the blueprint rather than a hand-kept list, for the same
+ * reason the field guide derives its "eats / eaten by": a creature summoned
+ * thirty seconds ago has to file itself correctly, and a list in the UI would
+ * silently drop every one of them into "other". The one exception is `yours`,
+ * which wins over everything — after you summon a dragon you want to find the
+ * dragon, not go hunting for which category it landed in.
+ *
+ * `roster` is every creature in the world; a hunter is defined as something
+ * that can actually eat one of them, which is the same rule the simulation uses.
+ */
+export function creatureGroup(
+  bp: CreatureBlueprint,
+  roster: CreatureBlueprint[]
+): CreatureGroup {
+  if (bp.summoned) return 'yours'
+  if (isPlantLike(bp)) return 'plants'
+  if (bp.size >= 5) return 'giants'
+  if (bp.aura) return 'helpers'
+  if (roster.some((other) => canEat(bp, other) && !isPlantLike(other))) return 'hunters'
+  return 'grazers'
+}
+
 /** True if `prey` should run from `hunter`. */
 export function fears(prey: CreatureBlueprint, hunter: CreatureBlueprint): boolean {
   if (prey.diet.fears.some((tag) => hunter.tags.includes(tag))) return true
@@ -452,4 +669,44 @@ export function fears(prey: CreatureBlueprint, hunter: CreatureBlueprint): boole
 export function artSize(bp: CreatureBlueprint): { w: number; h: number } {
   const frame = bp.art.frames[0]
   return { w: frame[0].length, h: frame.length }
+}
+
+/** The part of a sprite that actually collides, offset from its top-left. */
+export interface BodyBox {
+  dx: number
+  dy: number
+  w: number
+  h: number
+}
+
+const bodyBoxCache = new Map<string, BodyBox>()
+
+/**
+ * The solid core of a creature — what terrain collision and drowning use.
+ *
+ * For anything up to CORE_W x CORE_H this is just the sprite, so every creature
+ * that shipped before big monsters existed is untouched. Past that, each extra
+ * tile of drawing only counts 40% solid.
+ *
+ * The core sits centred horizontally and flush with the *bottom* of the sprite.
+ * Bottom-aligned matters: the inset has to come off the top, where the wings,
+ * horns and long neck are, or a walker's drawn feet would sink into the floor
+ * while its actual box rested a few tiles higher.
+ */
+export function bodyBox(bp: CreatureBlueprint): BodyBox {
+  const cached = bodyBoxCache.get(bp.id)
+  if (cached) return cached
+
+  const { w, h } = artSize(bp)
+  const cw = w <= CORE_W ? w : CORE_W + (w - CORE_W) * CORE_SLOPE
+  const ch = h <= CORE_H ? h : CORE_H + (h - CORE_H) * CORE_SLOPE
+
+  const box: BodyBox = {
+    dx: (w - cw) / 2,
+    dy: h - ch,
+    w: cw,
+    h: ch,
+  }
+  bodyBoxCache.set(bp.id, box)
+  return box
 }

--- a/src/app/micro-land/domain/config/creatures.ts
+++ b/src/app/micro-land/domain/config/creatures.ts
@@ -1,0 +1,526 @@
+/**
+ * The starter roster.
+ *
+ * These are written in exactly the format the LLM produces — plain object
+ * literals, pushed through the same sanitizer. There is no "built-in creature"
+ * code path; a summoned creature and a Sunleaf are the same kind of thing.
+ *
+ * The roster is a deliberate food chain. Plants feed grazers, grazers feed
+ * hunters, and every population is capable of crashing:
+ *
+ *   sunleaf / bramble / kelp / sporecap   (plant)
+ *     └─ mite, hopper, glimmer moth, finling, ember grub   (eat plant)
+ *          └─ stalker, gulper, cinder wyrm, drifter jelly  (eat meat)
+ */
+import { sanitizeBlueprint } from '@/app/micro-land/domain/blueprint'
+import type { CreatureBlueprint } from '@/app/micro-land/domain/types'
+
+/** Same pipeline as a summoned creature, but with a stable id. */
+function builtin(id: string, raw: unknown): CreatureBlueprint {
+  return { ...sanitizeBlueprint(raw, { idPrefix: 'builtin' }), id, summoned: false }
+}
+
+// ---------------------------------------------------------------------------
+// Plants — the bottom of every food chain. They spread instead of breeding.
+// ---------------------------------------------------------------------------
+
+const SUNLEAF = builtin('sunleaf', {
+  name: 'Sunleaf',
+  blurb: 'A little green sprout. Almost everything eats these.',
+  size: 1,
+  tags: ['plant'],
+  art: {
+    palette: { s: '#3f7d2a', l: '#7ede4f' },
+    frames: [
+      ['..l..', '.lsl.', '..s..', '.ls..', '..s..'],
+      ['..l..', '.lsl.', '..s..', '..sl.', '..s..'],
+    ],
+    frameMs: 620,
+    faceMotion: false,
+  },
+  body: { mass: 1, bounce: 0, drag: 0.2, buoyancy: 0.6, immuneTo: [] },
+  move: { kind: 'root', speed: 0, jump: 0, restlessness: 0 },
+  diet: {
+    eats: [],
+    fears: [],
+    hungerRate: 0,
+    starveSeconds: 999,
+    breedAt: 0.2,
+    lifespanSeconds: 260,
+  },
+  senses: { sight: 1 },
+  habitat: { needs: null, drowns: false },
+  dig: { through: [], speed: 1 },
+  death: { becomes: null, particleColor: '#7ede4f', particleCount: 4 },
+  glow: 0,
+})
+
+const BRAMBLE = builtin('bramble', {
+  name: 'Bramble',
+  blurb: 'A tangled berry bush. Bigger meals for bigger mouths.',
+  size: 2,
+  tags: ['plant'],
+  art: {
+    palette: { s: '#2f6b3a', l: '#57b04a', b: '#d1466f' },
+    frames: [
+      ['.l.b.l.', '.lslsl.', '..lsl..', '...s...', '..l.l..', '...s...'],
+      ['.b.l.l.', '.lslsl.', '..lsl..', '...s...', '..l.l..', '...s...'],
+    ],
+    frameMs: 700,
+    faceMotion: false,
+  },
+  body: { mass: 1, bounce: 0, drag: 0.2, buoyancy: 0.6, immuneTo: [] },
+  move: { kind: 'root', speed: 0, jump: 0, restlessness: 0 },
+  diet: {
+    eats: [],
+    fears: [],
+    hungerRate: 0,
+    starveSeconds: 999,
+    breedAt: 0.2,
+    lifespanSeconds: 340,
+  },
+  senses: { sight: 1 },
+  habitat: { needs: null, drowns: false },
+  dig: { through: [], speed: 1 },
+  death: { becomes: null, particleColor: '#57b04a', particleCount: 5 },
+  glow: 0,
+})
+
+const KELP = builtin('kelp', {
+  name: 'Kelp',
+  blurb: 'Slow ribbons of green that only grow underwater.',
+  size: 1,
+  tags: ['plant'],
+  art: {
+    palette: { k: '#2e8b6b', t: '#5fd6a8' },
+    frames: [
+      ['.t.', 'kt.', '.k.', '.kt', '.k.', 'tk.'],
+      ['.t.', '.tk', '.k.', 'tk.', '.k.', '.kt'],
+    ],
+    frameMs: 520,
+    faceMotion: false,
+  },
+  body: { mass: 1, bounce: 0, drag: 0.2, buoyancy: 0.6, immuneTo: [] },
+  move: { kind: 'root', speed: 0, jump: 0, restlessness: 0 },
+  diet: {
+    eats: [],
+    fears: [],
+    hungerRate: 0,
+    starveSeconds: 999,
+    breedAt: 0.2,
+    lifespanSeconds: 300,
+  },
+  senses: { sight: 1 },
+  habitat: { needs: ['water'], drowns: false },
+  dig: { through: [], speed: 1 },
+  death: { becomes: null, particleColor: '#5fd6a8', particleCount: 4 },
+  glow: 0,
+})
+
+const SPORECAP = builtin('sporecap', {
+  name: 'Sporecap',
+  blurb: 'A pale mushroom that glows faintly in the dark.',
+  size: 1,
+  tags: ['plant', 'fungus', 'glow'],
+  art: {
+    palette: { c: '#b9a6ff', s: '#efe7ff', d: '#6f5bb5' },
+    frames: [
+      ['.ccc.', 'ccccc', 'dcccd', '..s..', '..s..'],
+      ['.ccc.', 'ccccc', 'dcccd', '..s..', '.ss..'],
+    ],
+    frameMs: 900,
+    faceMotion: false,
+  },
+  body: { mass: 1, bounce: 0, drag: 0.2, buoyancy: 0.6, immuneTo: ['lava'] },
+  move: { kind: 'root', speed: 0, jump: 0, restlessness: 0 },
+  diet: {
+    eats: [],
+    fears: [],
+    hungerRate: 0,
+    starveSeconds: 999,
+    breedAt: 0.2,
+    lifespanSeconds: 400,
+  },
+  senses: { sight: 1 },
+  habitat: { needs: null, drowns: false },
+  dig: { through: [], speed: 1 },
+  death: { becomes: null, particleColor: '#b9a6ff', particleCount: 6 },
+  glow: 0.55,
+})
+
+// ---------------------------------------------------------------------------
+// Grazers — eat plants, get eaten
+// ---------------------------------------------------------------------------
+
+const MITE = builtin('mite', {
+  name: 'Mite',
+  blurb: 'A speck with legs. Eats leaves, breeds fast, dies faster.',
+  size: 1,
+  tags: ['meat', 'bug'],
+  art: {
+    palette: { b: '#d2762b', e: '#ffe9c4' },
+    frames: [
+      ['.bb.', 'bbeb', 'b..b'],
+      ['.bb.', 'bbeb', '.bb.'],
+    ],
+    frameMs: 130,
+    faceMotion: true,
+  },
+  body: { mass: 1, bounce: 0.15, drag: 0.35, buoyancy: 0.8, immuneTo: [] },
+  move: { kind: 'walk', speed: 4.5, jump: 6, restlessness: 0.5 },
+  diet: {
+    eats: ['plant'],
+    fears: [],
+    hungerRate: 0.034,
+    starveSeconds: 18,
+    breedAt: 0.7,
+    lifespanSeconds: 110,
+  },
+  senses: { sight: 14 },
+  habitat: { needs: null, drowns: true },
+  dig: { through: [], speed: 1 },
+  death: { becomes: null, particleColor: '#d2762b', particleCount: 4 },
+  glow: 0,
+})
+
+const HOPPER = builtin('hopper', {
+  name: 'Hopper',
+  blurb: 'A springy grazer that bounds away from anything with teeth.',
+  size: 2,
+  tags: ['meat', 'bug'],
+  art: {
+    palette: { b: '#63c15a', d: '#2f7a34', e: '#ffffff' },
+    frames: [
+      ['..bb..', '.bbbbe', 'bbbbbb', '.d..d.', 'd....d'],
+      ['..bb..', '.bbbbe', 'bbbbbb', '.dd.d.', '..d..d'],
+    ],
+    frameMs: 150,
+    faceMotion: true,
+  },
+  body: { mass: 1, bounce: 0.2, drag: 0.4, buoyancy: 0.85, immuneTo: [] },
+  move: { kind: 'walk', speed: 5, jump: 12, restlessness: 0.35 },
+  diet: {
+    eats: ['plant'],
+    fears: [],
+    hungerRate: 0.026,
+    starveSeconds: 28,
+    breedAt: 0.8,
+    lifespanSeconds: 200,
+  },
+  senses: { sight: 20 },
+  habitat: { needs: null, drowns: true },
+  dig: { through: [], speed: 1 },
+  death: { becomes: null, particleColor: '#63c15a', particleCount: 6 },
+  glow: 0,
+})
+
+const GLIMMER_MOTH = builtin('glimmer-moth', {
+  name: 'Glimmer Moth',
+  blurb: 'Drifts through the air on soft wings, carrying its own little light.',
+  size: 1,
+  tags: ['meat', 'bug', 'glow'],
+  art: {
+    palette: { w: '#e6c9ff', b: '#7a5fb0', g: '#fff2a8' },
+    frames: [
+      ['w....w', 'ww..ww', '.wbbw.', '..bg..', '..bb..'],
+      ['......', '.w..w.', 'wwbbww', 'w.bg.w', '..bb..'],
+    ],
+    frameMs: 110,
+    faceMotion: true,
+  },
+  body: { mass: 0.1, bounce: 0.1, drag: 0.5, buoyancy: 1.4, immuneTo: [] },
+  move: { kind: 'fly', speed: 4, jump: 0, restlessness: 0.6 },
+  diet: {
+    eats: ['plant'],
+    fears: [],
+    hungerRate: 0.03,
+    starveSeconds: 26,
+    breedAt: 0.75,
+    lifespanSeconds: 170,
+  },
+  senses: { sight: 24 },
+  habitat: { needs: null, drowns: true },
+  dig: { through: [], speed: 1 },
+  death: { becomes: null, particleColor: '#fff2a8', particleCount: 10 },
+  glow: 0.7,
+})
+
+const FINLING = builtin('finling', {
+  name: 'Finling',
+  blurb: 'A small bright fish. Out of water it flops and gasps.',
+  size: 2,
+  tags: ['meat', 'fish'],
+  art: {
+    palette: { f: '#ffa62b', d: '#c4621a', e: '#ffffff' },
+    frames: [
+      ['d.ffff', 'dffffe', 'dfffff', 'd.ffff'],
+      ['..ffff', '.ffffe', 'dfffff', 'd.ffff'],
+    ],
+    frameMs: 160,
+    faceMotion: true,
+  },
+  body: { mass: 0.4, bounce: 0.1, drag: 0.45, buoyancy: 1, immuneTo: [] },
+  move: { kind: 'swim', speed: 5, jump: 0, restlessness: 0.4 },
+  diet: {
+    eats: ['plant'],
+    fears: [],
+    hungerRate: 0.03,
+    starveSeconds: 30,
+    breedAt: 0.72,
+    lifespanSeconds: 220,
+  },
+  senses: { sight: 20 },
+  habitat: { needs: ['water'], drowns: false },
+  dig: { through: [], speed: 1 },
+  death: { becomes: null, particleColor: '#ffa62b', particleCount: 6 },
+  glow: 0,
+})
+
+const EMBER_GRUB = builtin('ember-grub', {
+  name: 'Ember Grub',
+  blurb: 'Crawls over anything, even lava. Nothing burns it.',
+  size: 2,
+  tags: ['meat', 'bug'],
+  art: {
+    palette: { r: '#ff7a2f', d: '#8c2a10', y: '#ffd36b' },
+    frames: [
+      ['.rrrr.', 'rryyrr', 'rrrrry', '.d.d.d'],
+      ['.rrrr.', 'rryyrr', 'rrrrry', 'd.d.d.'],
+    ],
+    frameMs: 170,
+    faceMotion: true,
+  },
+  body: { mass: 1.2, bounce: 0, drag: 0.3, buoyancy: 0.5, immuneTo: ['lava'] },
+  move: { kind: 'crawl', speed: 2.6, jump: 0, restlessness: 0.3 },
+  diet: {
+    eats: ['plant'],
+    fears: [],
+    hungerRate: 0.025,
+    starveSeconds: 40,
+    breedAt: 0.78,
+    lifespanSeconds: 260,
+  },
+  senses: { sight: 16 },
+  habitat: { needs: null, drowns: true },
+  dig: { through: ['ash', 'sand', 'dirt'], speed: 1.6 },
+  death: { becomes: 'ash', particleColor: '#ff7a2f', particleCount: 8 },
+  glow: 0.35,
+})
+
+// ---------------------------------------------------------------------------
+// Hunters — eat the grazers
+// ---------------------------------------------------------------------------
+
+const STALKER = builtin('stalker', {
+  name: 'Stalker',
+  blurb: 'Patient, hungry, and faster than it looks.',
+  size: 3,
+  tags: ['meat', 'beast'],
+  art: {
+    palette: { b: '#8c4459', d: '#40202c', e: '#ffd166' },
+    frames: [
+      ['..bbbb..', '.bbbbbbe', 'bbbbbbbb', '.dd..dd.', '.d....d.', '.d....d.'],
+      ['..bbbb..', '.bbbbbbe', 'bbbbbbbb', '.dd..dd.', '.d....d.', '..d..d..'],
+    ],
+    frameMs: 170,
+    faceMotion: true,
+  },
+  body: { mass: 1.4, bounce: 0.1, drag: 0.4, buoyancy: 0.8, immuneTo: [] },
+  move: { kind: 'walk', speed: 6, jump: 10, restlessness: 0.2 },
+  diet: {
+    eats: ['meat'],
+    fears: [],
+    hungerRate: 0.022,
+    starveSeconds: 50,
+    breedAt: 0.85,
+    lifespanSeconds: 340,
+  },
+  senses: { sight: 34 },
+  habitat: { needs: null, drowns: true },
+  dig: { through: [], speed: 1 },
+  death: { becomes: null, particleColor: '#8c4459', particleCount: 10 },
+  glow: 0,
+})
+
+const DRIFTER_JELLY = builtin('drifter-jelly', {
+  name: 'Drifter Jelly',
+  blurb: 'Floats wherever it likes and eats whatever bumps into it.',
+  size: 2,
+  tags: ['meat'],
+  art: {
+    palette: { j: '#8fd7ff', c: '#ffffff', t: '#5fa9d6' },
+    frames: [
+      ['.jjjj.', 'jjccjj', 'jjjjjj', '.tttt.', '.t.t.t', 't..t..'],
+      ['.jjjj.', 'jjccjj', 'jjjjjj', '.tttt.', 't.t..t', '.t..t.'],
+    ],
+    frameMs: 260,
+    faceMotion: false,
+  },
+  // Buoyancy just over 1 so it hangs at the waterline instead of bobbing up
+  // out of the sea and drifting off into open sky.
+  body: { mass: 0.15, bounce: 0.3, drag: 0.55, buoyancy: 1.03, immuneTo: [] },
+  move: { kind: 'drift', speed: 1.8, jump: 0, restlessness: 0.5 },
+  diet: {
+    eats: ['bug'],
+    fears: [],
+    hungerRate: 0.02,
+    starveSeconds: 55,
+    breedAt: 0.85,
+    lifespanSeconds: 300,
+  },
+  senses: { sight: 16 },
+  habitat: { needs: null, drowns: false },
+  dig: { through: [], speed: 1 },
+  death: { becomes: null, particleColor: '#8fd7ff', particleCount: 12 },
+  glow: 0.25,
+})
+
+const GULPER = builtin('gulper', {
+  name: 'Gulper',
+  blurb: 'The biggest thing in the water, and it knows it.',
+  size: 4,
+  tags: ['meat', 'fish'],
+  art: {
+    palette: { g: '#3f5f8a', d: '#22314a', e: '#ffe066' },
+    frames: [
+      ['..gggggg.', '.ggggggge', 'dggggggdd', 'dgggggggg', '.gggggggg', '..gggggg.'],
+      ['..gggggg.', '.ggggggge', 'dgggggggg', 'dggggggdd', '.gggggggg', '..gggggg.'],
+    ],
+    frameMs: 240,
+    faceMotion: true,
+  },
+  body: { mass: 0.6, bounce: 0.05, drag: 0.4, buoyancy: 1, immuneTo: [] },
+  move: { kind: 'swim', speed: 4, jump: 0, restlessness: 0.25 },
+  diet: {
+    eats: ['fish', 'bug'],
+    fears: [],
+    hungerRate: 0.018,
+    starveSeconds: 70,
+    breedAt: 0.88,
+    lifespanSeconds: 420,
+  },
+  senses: { sight: 30 },
+  habitat: { needs: ['water'], drowns: false },
+  dig: { through: [], speed: 1 },
+  death: { becomes: null, particleColor: '#3f5f8a', particleCount: 12 },
+  glow: 0,
+})
+
+const CINDER_WYRM = builtin('cinder-wyrm', {
+  name: 'Cinder Wyrm',
+  blurb: 'Swims through lava the way a fish swims through water.',
+  size: 4,
+  tags: ['meat', 'beast'],
+  art: {
+    palette: { r: '#e2551d', y: '#ffc247', d: '#5c1a08' },
+    frames: [
+      ['...rrrr..', '..rrrrrry', '.rrrrrrrr', 'drrrrrrd.', '.dd..dd..'],
+      ['...rrrr..', '..rrrrrry', '.rrrrrrrr', '.drrrrrrd', '..dd..dd.'],
+    ],
+    frameMs: 190,
+    faceMotion: true,
+  },
+  body: { mass: 1.6, bounce: 0.05, drag: 0.4, buoyancy: 0.9, immuneTo: ['lava'] },
+  move: { kind: 'walk', speed: 4.5, jump: 9, restlessness: 0.2 },
+  diet: {
+    eats: ['meat'],
+    fears: [],
+    hungerRate: 0.02,
+    starveSeconds: 60,
+    breedAt: 0.9,
+    lifespanSeconds: 380,
+  },
+  senses: { sight: 30 },
+  habitat: { needs: null, drowns: true },
+  dig: { through: ['stone', 'obsidian', 'ash', 'dirt', 'sand'], speed: 0.9 },
+  death: { becomes: 'obsidian', particleColor: '#e2551d', particleCount: 14 },
+  glow: 0.8,
+})
+
+const RUSTBOT = builtin('rustbot', {
+  name: 'Rustbot',
+  blurb: 'Somebody left it running. It eats scrap and keeps going.',
+  size: 3,
+  tags: ['mineral', 'metal'],
+  art: {
+    palette: { m: '#8a93a3', d: '#3d4553', e: '#66ffcc' },
+    frames: [
+      ['.mmmm.', 'mdeedm', 'mmmmmm', '.mmmm.', 'd.mm.d', 'd....d'],
+      ['.mmmm.', 'mdeedm', 'mmmmmm', '.mmmm.', 'd.mm.d', '.d..d.'],
+    ],
+    frameMs: 200,
+    faceMotion: true,
+  },
+  body: { mass: 2.2, bounce: 0, drag: 0.3, buoyancy: 0.2, immuneTo: [] },
+  move: { kind: 'walk', speed: 2.4, jump: 6, restlessness: 0.15 },
+  diet: {
+    // Grinds up the fungus growing on its own hull. It used to eat "mineral",
+    // a tag nothing but a Rustbot carries — and since nothing can eat its own
+    // species, that quietly meant it could never eat anything at all.
+    eats: ['fungus'],
+    fears: [],
+    hungerRate: 0.012,
+    starveSeconds: 90,
+    breedAt: 0.9,
+    lifespanSeconds: 600,
+  },
+  senses: { sight: 26 },
+  habitat: { needs: null, drowns: false },
+  dig: { through: ['metal', 'glass', 'ice'], speed: 0.5 },
+  death: { becomes: 'metal', particleColor: '#8a93a3', particleCount: 10 },
+  glow: 0.2,
+})
+
+
+const DELVER = builtin('delver', {
+  name: 'Delver',
+  blurb: 'A blind digger that chews its own tunnels through soil and stone.',
+  size: 2,
+  tags: ['meat', 'beast'],
+  art: {
+    palette: { b: '#9a7b5f', d: '#5c4433', n: '#ffb4a8', c: '#e8e0d4' },
+    frames: [
+      ['.bbbbb.', 'cbbbbbn', 'cbbbbbb', '.ddd.d.'],
+      ['.bbbbb.', 'cbbbbbn', 'cbbbbbb', '.d.ddd.'],
+    ],
+    frameMs: 160,
+    faceMotion: true,
+  },
+  body: { mass: 1.3, bounce: 0, drag: 0.35, buoyancy: 0.6, immuneTo: [] },
+  move: { kind: 'walk', speed: 3.2, jump: 5, restlessness: 0.4 },
+  diet: {
+    eats: ['plant'],
+    fears: [],
+    hungerRate: 0.028,
+    starveSeconds: 34,
+    breedAt: 0.8,
+    lifespanSeconds: 240,
+  },
+  senses: { sight: 16 },
+  habitat: { needs: null, drowns: true },
+  dig: { through: ['dirt', 'grass', 'sand', 'ash'], speed: 2.2 },
+  death: { becomes: null, particleColor: '#9a7b5f', particleCount: 6 },
+  glow: 0,
+})
+
+export const BUILTIN_CREATURES: CreatureBlueprint[] = [
+  SUNLEAF,
+  BRAMBLE,
+  KELP,
+  SPORECAP,
+  MITE,
+  HOPPER,
+  GLIMMER_MOTH,
+  FINLING,
+  EMBER_GRUB,
+  DELVER,
+  STALKER,
+  DRIFTER_JELLY,
+  GULPER,
+  CINDER_WYRM,
+  RUSTBOT,
+]
+
+export const BUILTIN_BY_ID: Record<string, CreatureBlueprint> = Object.fromEntries(
+  BUILTIN_CREATURES.map((c) => [c.id, c])
+)

--- a/src/app/micro-land/domain/config/creatures.ts
+++ b/src/app/micro-land/domain/config/creatures.ts
@@ -8,9 +8,16 @@
  * The roster is a deliberate food chain. Plants feed grazers, grazers feed
  * hunters, and every population is capable of crashing:
  *
- *   sunleaf / bramble / kelp / sporecap   (plant)
- *     └─ mite, hopper, glimmer moth, finling, ember grub   (eat plant)
- *          └─ stalker, gulper, cinder wyrm, drifter jelly  (eat meat)
+ *   sunleaf / bramble / kelp / sporecap / frostcap / glowvine / skybloom
+ *     └─ mite, hopper, glimmer moth, finling, ember grub, delver, mote,
+ *        palecrawler, driftmole, woolly, dustbee, loamworm, crystal snail
+ *          └─ stalker, gulper, cinder wyrm, drifter jelly, rimeclaw,
+ *             sunhawk, gloomweaver, wisp, grumblestone
+ *
+ * Two of them are *helpers*: a Dustbee makes nearby plants spread faster and a
+ * Loamworm turns bare stone into soil. They are the only creatures here that
+ * change the world rather than just live in it, and they do it through the same
+ * plain `aura` data any summoned creature can carry.
  */
 import { sanitizeBlueprint } from '@/app/micro-land/domain/blueprint'
 import type { CreatureBlueprint } from '@/app/micro-land/domain/types'
@@ -52,6 +59,7 @@ const SUNLEAF = builtin('sunleaf', {
   habitat: { needs: null, drowns: false },
   dig: { through: [], speed: 1 },
   death: { becomes: null, particleColor: '#7ede4f', particleCount: 4 },
+  aura: null,
   glow: 0,
 })
 
@@ -83,6 +91,7 @@ const BRAMBLE = builtin('bramble', {
   habitat: { needs: null, drowns: false },
   dig: { through: [], speed: 1 },
   death: { becomes: null, particleColor: '#57b04a', particleCount: 5 },
+  aura: null,
   glow: 0,
 })
 
@@ -114,6 +123,7 @@ const KELP = builtin('kelp', {
   habitat: { needs: ['water'], drowns: false },
   dig: { through: [], speed: 1 },
   death: { becomes: null, particleColor: '#5fd6a8', particleCount: 4 },
+  aura: null,
   glow: 0,
 })
 
@@ -145,6 +155,7 @@ const SPORECAP = builtin('sporecap', {
   habitat: { needs: null, drowns: false },
   dig: { through: [], speed: 1 },
   death: { becomes: null, particleColor: '#b9a6ff', particleCount: 6 },
+  aura: null,
   glow: 0.55,
 })
 
@@ -180,6 +191,7 @@ const MITE = builtin('mite', {
   habitat: { needs: null, drowns: true },
   dig: { through: [], speed: 1 },
   death: { becomes: null, particleColor: '#d2762b', particleCount: 4 },
+  aura: null,
   glow: 0,
 })
 
@@ -211,6 +223,7 @@ const HOPPER = builtin('hopper', {
   habitat: { needs: null, drowns: true },
   dig: { through: [], speed: 1 },
   death: { becomes: null, particleColor: '#63c15a', particleCount: 6 },
+  aura: null,
   glow: 0,
 })
 
@@ -242,6 +255,7 @@ const GLIMMER_MOTH = builtin('glimmer-moth', {
   habitat: { needs: null, drowns: true },
   dig: { through: [], speed: 1 },
   death: { becomes: null, particleColor: '#fff2a8', particleCount: 10 },
+  aura: null,
   glow: 0.7,
 })
 
@@ -273,6 +287,7 @@ const FINLING = builtin('finling', {
   habitat: { needs: ['water'], drowns: false },
   dig: { through: [], speed: 1 },
   death: { becomes: null, particleColor: '#ffa62b', particleCount: 6 },
+  aura: null,
   glow: 0,
 })
 
@@ -304,6 +319,7 @@ const EMBER_GRUB = builtin('ember-grub', {
   habitat: { needs: null, drowns: true },
   dig: { through: ['ash', 'sand', 'dirt'], speed: 1.6 },
   death: { becomes: 'ash', particleColor: '#ff7a2f', particleCount: 8 },
+  aura: null,
   glow: 0.35,
 })
 
@@ -339,6 +355,7 @@ const STALKER = builtin('stalker', {
   habitat: { needs: null, drowns: true },
   dig: { through: [], speed: 1 },
   death: { becomes: null, particleColor: '#8c4459', particleCount: 10 },
+  aura: null,
   glow: 0,
 })
 
@@ -372,6 +389,7 @@ const DRIFTER_JELLY = builtin('drifter-jelly', {
   habitat: { needs: null, drowns: false },
   dig: { through: [], speed: 1 },
   death: { becomes: null, particleColor: '#8fd7ff', particleCount: 12 },
+  aura: null,
   glow: 0.25,
 })
 
@@ -403,6 +421,7 @@ const GULPER = builtin('gulper', {
   habitat: { needs: ['water'], drowns: false },
   dig: { through: [], speed: 1 },
   death: { becomes: null, particleColor: '#3f5f8a', particleCount: 12 },
+  aura: null,
   glow: 0,
 })
 
@@ -434,6 +453,7 @@ const CINDER_WYRM = builtin('cinder-wyrm', {
   habitat: { needs: null, drowns: true },
   dig: { through: ['stone', 'obsidian', 'ash', 'dirt', 'sand'], speed: 0.9 },
   death: { becomes: 'obsidian', particleColor: '#e2551d', particleCount: 14 },
+  aura: null,
   glow: 0.8,
 })
 
@@ -468,6 +488,7 @@ const RUSTBOT = builtin('rustbot', {
   habitat: { needs: null, drowns: false },
   dig: { through: ['metal', 'glass', 'ice'], speed: 0.5 },
   death: { becomes: 'metal', particleColor: '#8a93a3', particleCount: 10 },
+  aura: null,
   glow: 0.2,
 })
 
@@ -500,6 +521,860 @@ const DELVER = builtin('delver', {
   habitat: { needs: null, drowns: true },
   dig: { through: ['dirt', 'grass', 'sand', 'ash'], speed: 2.2 },
   death: { becomes: null, particleColor: '#9a7b5f', particleCount: 6 },
+  aura: null,
+  glow: 0,
+})
+
+// ---------------------------------------------------------------------------
+// The cold set — a food chain that works on snow
+// ---------------------------------------------------------------------------
+
+const FROSTCAP = builtin('frostcap', {
+  name: 'Frostcap',
+  blurb: 'A stiff little shrub that only bothers growing where it is cold.',
+  size: 1,
+  tags: ['plant'],
+  art: {
+    palette: { i: '#bfe6f7', w: '#ffffff', s: '#7fb8d4' },
+    frames: [
+      ['..w..', '.iwi.', 'iisii', '..s..', '..s..'],
+      ['..w..', '.iwi.', 'isiii', '..s..', '..s..'],
+    ],
+    frameMs: 780,
+    faceMotion: false,
+  },
+  body: { mass: 1, bounce: 0, drag: 0.2, buoyancy: 0.6, immuneTo: [] },
+  move: { kind: 'root', speed: 0, jump: 0, restlessness: 0 },
+  diet: {
+    eats: [],
+    fears: [],
+    hungerRate: 0,
+    starveSeconds: 999,
+    breedAt: 0.2,
+    lifespanSeconds: 320,
+  },
+  senses: { sight: 1 },
+  habitat: { needs: null, drowns: false },
+  dig: { through: [], speed: 1 },
+  death: { becomes: null, particleColor: '#bfe6f7', particleCount: 4 },
+  aura: null,
+  glow: 0.05,
+})
+
+const WOOLLY = builtin('woolly', {
+  name: 'Woolly',
+  blurb: 'A round, patient grazer wearing far too many coats.',
+  size: 3,
+  tags: ['meat', 'beast'],
+  art: {
+    palette: { w: '#f2ece0', d: '#9c8b76', e: '#3b3229' },
+    frames: [
+      ['.wwwww..', 'wwwwwwwe', 'wwwwwwww', '.wwwwww.', '.d.d.dd.', '.d.d.d..'],
+      ['.wwwww..', 'wwwwwwwe', 'wwwwwwww', '.wwwwww.', '.dd.d.d.', '..d.d.d.'],
+    ],
+    frameMs: 240,
+    faceMotion: true,
+  },
+  body: { mass: 1.6, bounce: 0.05, drag: 0.35, buoyancy: 0.9, immuneTo: [] },
+  move: { kind: 'walk', speed: 3, jump: 6, restlessness: 0.2 },
+  diet: {
+    eats: ['plant'],
+    fears: [],
+    hungerRate: 0.02,
+    starveSeconds: 45,
+    breedAt: 0.82,
+    lifespanSeconds: 300,
+  },
+  senses: { sight: 18 },
+  habitat: { needs: null, drowns: true },
+  dig: { through: ['snow'], speed: 1.4 },
+  death: { becomes: null, particleColor: '#f2ece0', particleCount: 8 },
+  aura: null,
+  glow: 0,
+})
+
+const DRIFTMOLE = builtin('driftmole', {
+  name: 'Driftmole',
+  blurb: 'Tunnels under the snow and pops up somewhere else entirely.',
+  size: 2,
+  tags: ['meat', 'beast'],
+  art: {
+    palette: { b: '#8ea3b8', d: '#4f5f70', n: '#ffc0cb', c: '#e8eef5' },
+    frames: [
+      ['.bbbbb.', 'cbbbbbn', 'cbbbbbb', '.dd.dd.'],
+      ['.bbbbb.', 'cbbbbbn', 'cbbbbbb', '.d.ddd.'],
+    ],
+    frameMs: 150,
+    faceMotion: true,
+  },
+  body: { mass: 1.2, bounce: 0, drag: 0.35, buoyancy: 0.6, immuneTo: [] },
+  move: { kind: 'walk', speed: 3.4, jump: 5, restlessness: 0.4 },
+  diet: {
+    eats: ['plant'],
+    fears: [],
+    hungerRate: 0.028,
+    starveSeconds: 34,
+    breedAt: 0.8,
+    lifespanSeconds: 230,
+  },
+  senses: { sight: 16 },
+  habitat: { needs: null, drowns: true },
+  dig: { through: ['snow', 'ice', 'dirt', 'mud'], speed: 2.4 },
+  death: { becomes: null, particleColor: '#8ea3b8', particleCount: 6 },
+  aura: null,
+  glow: 0,
+})
+
+const RIMECLAW = builtin('rimeclaw', {
+  name: 'Rimeclaw',
+  blurb: 'Quiet on the snow, and it knows exactly how quiet it is.',
+  size: 4,
+  tags: ['meat', 'beast'],
+  art: {
+    palette: { b: '#9fc6dd', d: '#3f5f78', e: '#ffe9a8', w: '#e8f5ff' },
+    frames: [
+      ['..bbbbb..', '.bbbbbbbe', 'bwbbbbbbb', '.dd...dd.', '.d.....d.', '.d.....d.'],
+      ['..bbbbb..', '.bbbbbbbe', 'bwbbbbbbb', '.dd...dd.', '.d.....d.', '..d...d..'],
+    ],
+    frameMs: 180,
+    faceMotion: true,
+  },
+  body: { mass: 1.5, bounce: 0.1, drag: 0.4, buoyancy: 0.8, immuneTo: [] },
+  move: { kind: 'walk', speed: 5.6, jump: 10, restlessness: 0.2 },
+  diet: {
+    eats: ['meat'],
+    fears: [],
+    hungerRate: 0.02,
+    starveSeconds: 55,
+    breedAt: 0.88,
+    lifespanSeconds: 360,
+  },
+  senses: { sight: 32 },
+  habitat: { needs: null, drowns: true },
+  dig: { through: ['snow'], speed: 1.8 },
+  death: { becomes: null, particleColor: '#9fc6dd', particleCount: 10 },
+  aura: null,
+  glow: 0,
+})
+
+// ---------------------------------------------------------------------------
+// The sky set — the open air was the emptiest part of the world
+// ---------------------------------------------------------------------------
+
+/**
+ * A plant that flies.
+ *
+ * `root` would be the honest locomotion for a plant, but a rooted thing has to
+ * settle onto fertile ground to exist at all — which is exactly what this one
+ * hasn't got. Flying instead, with a hunger rate of zero, gets a plant that
+ * lives in open air: it never starves, and because breeding costs fullness it
+ * can never pay back, each Skybloom seeds roughly once and then just drifts.
+ */
+const SKYBLOOM = builtin('skybloom', {
+  name: 'Skybloom',
+  blurb: 'A flower that never landed. It just keeps floating.',
+  size: 2,
+  tags: ['plant', 'sky'],
+  art: {
+    palette: { p: '#ffd7ef', s: '#a8e6cf', g: '#ffffff' },
+    frames: [
+      ['.pppp.', 'pppggp', 'pppppp', '.pppp.', '..ss..', '.s..s.'],
+      ['.pppp.', 'pgppgp', 'pppppp', '.pppp.', '..ss..', '..s.s.'],
+    ],
+    frameMs: 640,
+    faceMotion: false,
+  },
+  body: { mass: 0.05, bounce: 0.2, drag: 0.5, buoyancy: 1.2, immuneTo: [] },
+  move: { kind: 'fly', speed: 0.9, jump: 0, restlessness: 0.12 },
+  diet: {
+    eats: [],
+    fears: [],
+    hungerRate: 0,
+    starveSeconds: 999,
+    breedAt: 0.6,
+    lifespanSeconds: 340,
+  },
+  senses: { sight: 2 },
+  habitat: { needs: null, drowns: true },
+  dig: { through: [], speed: 1 },
+  death: { becomes: null, particleColor: '#ffd7ef', particleCount: 8 },
+  aura: null,
+  glow: 0.1,
+})
+
+const MOTE = builtin('mote', {
+  name: 'Mote',
+  blurb: 'A crumb of light with wings. Never seems to be alone.',
+  size: 1,
+  tags: ['meat', 'bug'],
+  art: {
+    palette: { y: '#fff2a8', o: '#e6b93f' },
+    frames: [
+      ['.yy.', 'yoyy', '.yy.'],
+      ['.yy.', 'yyoy', 'y..y'],
+    ],
+    frameMs: 100,
+    faceMotion: true,
+  },
+  body: { mass: 0.08, bounce: 0.1, drag: 0.5, buoyancy: 1.3, immuneTo: [] },
+  move: { kind: 'fly', speed: 5, jump: 0, restlessness: 0.75 },
+  diet: {
+    eats: ['plant'],
+    fears: [],
+    hungerRate: 0.034,
+    starveSeconds: 20,
+    breedAt: 0.7,
+    lifespanSeconds: 120,
+  },
+  senses: { sight: 22 },
+  habitat: { needs: null, drowns: true },
+  dig: { through: [], speed: 1 },
+  death: { becomes: null, particleColor: '#fff2a8', particleCount: 5 },
+  aura: null,
+  glow: 0.3,
+})
+
+const SUNHAWK = builtin('sunhawk', {
+  name: 'Sunhawk',
+  blurb: 'Rides the high air all day and drops on whatever it spots.',
+  size: 4,
+  tags: ['meat', 'bird'],
+  art: {
+    palette: { b: '#c9762f', d: '#6b3a12', e: '#fff0b8', w: '#f0b45f' },
+    frames: [
+      ['ww.....ww', '.wwbbbww.', '..bbbbbe.', '...bbb...', '...d.d...'],
+      ['.........', 'ww.bbb.ww', '.wbbbbbe.', '..wbbbw..', '...d.d...'],
+    ],
+    frameMs: 130,
+    faceMotion: true,
+  },
+  body: { mass: 0.5, bounce: 0.1, drag: 0.45, buoyancy: 1.1, immuneTo: [] },
+  move: { kind: 'fly', speed: 7, jump: 0, restlessness: 0.3 },
+  diet: {
+    eats: ['bug', 'meat'],
+    fears: [],
+    hungerRate: 0.019,
+    starveSeconds: 60,
+    breedAt: 0.88,
+    lifespanSeconds: 380,
+  },
+  // Sight is what makes a flier fearsome: nothing else in the world can cross
+  // the map unobstructed. At 40 tiles it could see a third of the world at once
+  // and cleared out every grazer in it, so it hunts by patrolling instead.
+  senses: { sight: 26 },
+  habitat: { needs: null, drowns: true },
+  dig: { through: [], speed: 1 },
+  death: { becomes: null, particleColor: '#c9762f', particleCount: 12 },
+  aura: null,
+  glow: 0,
+})
+
+// ---------------------------------------------------------------------------
+// The cave set — makes the dark worth going into
+// ---------------------------------------------------------------------------
+
+const GLOWVINE = builtin('glowvine', {
+  name: 'Glowvine',
+  blurb: 'Hangs in the dark and lights its own little room.',
+  size: 1,
+  tags: ['plant', 'glow'],
+  art: {
+    palette: { v: '#3f8f6f', l: '#8ffcd0', d: '#276b52' },
+    frames: [
+      ['..l..', '.lvl.', '..v..', '.lv..', '..v..', '..d..'],
+      ['..l..', '.lvl.', '..v..', '..vl.', '..v..', '..d..'],
+    ],
+    frameMs: 700,
+    faceMotion: false,
+  },
+  body: { mass: 1, bounce: 0, drag: 0.2, buoyancy: 0.6, immuneTo: [] },
+  move: { kind: 'root', speed: 0, jump: 0, restlessness: 0 },
+  diet: {
+    eats: [],
+    fears: [],
+    hungerRate: 0,
+    starveSeconds: 999,
+    breedAt: 0.2,
+    lifespanSeconds: 380,
+  },
+  senses: { sight: 1 },
+  habitat: { needs: null, drowns: false },
+  dig: { through: [], speed: 1 },
+  death: { becomes: null, particleColor: '#8ffcd0', particleCount: 6 },
+  aura: null,
+  glow: 0.62,
+})
+
+const PALECRAWLER = builtin('palecrawler', {
+  name: 'Palecrawler',
+  blurb: 'Walks upside down along cave ceilings and never looks down.',
+  size: 2,
+  tags: ['meat', 'bug'],
+  art: {
+    palette: { p: '#ded3c4', d: '#8c8072', e: '#ff9c9c' },
+    frames: [
+      ['.ppppp.', 'ppppppe', 'ppppppp', 'd.d.d.d'],
+      ['.ppppp.', 'ppppppe', 'ppppppp', '.d.d.d.'],
+    ],
+    frameMs: 160,
+    faceMotion: true,
+  },
+  body: { mass: 0.9, bounce: 0.1, drag: 0.35, buoyancy: 0.8, immuneTo: [] },
+  move: { kind: 'crawl', speed: 3.4, jump: 0, restlessness: 0.35 },
+  diet: {
+    eats: ['plant', 'fungus'],
+    fears: [],
+    hungerRate: 0.026,
+    starveSeconds: 32,
+    breedAt: 0.78,
+    lifespanSeconds: 220,
+  },
+  senses: { sight: 16 },
+  habitat: { needs: null, drowns: true },
+  dig: { through: [], speed: 1 },
+  death: { becomes: null, particleColor: '#ded3c4', particleCount: 6 },
+  aura: null,
+  glow: 0,
+})
+
+const GLOOMWEAVER = builtin('gloomweaver', {
+  name: 'Gloomweaver',
+  blurb: 'Waits on the ceiling. Patient about it, too.',
+  size: 3,
+  tags: ['meat', 'bug'],
+  art: {
+    palette: { b: '#4b3b5a', d: '#221a2e', e: '#ff5f8f' },
+    frames: [
+      ['d......d', '.dbbbbd.', 'dbbeebbd', '.dbbbbd.', 'd..dd..d'],
+      ['.d....d.', 'd.bbbb.d', 'dbbeebbd', 'd.bbbb.d', '.d.dd.d.'],
+    ],
+    frameMs: 210,
+    faceMotion: true,
+  },
+  body: { mass: 1, bounce: 0.05, drag: 0.4, buoyancy: 0.8, immuneTo: [] },
+  move: { kind: 'crawl', speed: 4.4, jump: 0, restlessness: 0.15 },
+  diet: {
+    eats: ['bug'],
+    fears: [],
+    hungerRate: 0.021,
+    starveSeconds: 55,
+    breedAt: 0.86,
+    lifespanSeconds: 330,
+  },
+  senses: { sight: 30 },
+  habitat: { needs: null, drowns: true },
+  dig: { through: [], speed: 1 },
+  death: { becomes: null, particleColor: '#4b3b5a', particleCount: 10 },
+  aura: null,
+  glow: 0,
+})
+
+// ---------------------------------------------------------------------------
+// Helpers — the only creatures that change the world instead of just eating it
+// ---------------------------------------------------------------------------
+
+const DUSTBEE = builtin('dustbee', {
+  name: 'Dustbee',
+  blurb: 'Carries flower dust from plant to plant. Everything grows faster near it.',
+  size: 1,
+  tags: ['meat', 'bug'],
+  art: {
+    palette: { y: '#ffd94a', d: '#3a2f10', w: '#fffbe8' },
+    frames: [
+      ['.ww..', '.yyy.', 'ydydy', '..d..'],
+      ['..ww.', '.yyy.', 'ydydy', '.d...'],
+    ],
+    frameMs: 90,
+    faceMotion: true,
+  },
+  body: { mass: 0.1, bounce: 0.1, drag: 0.5, buoyancy: 1.2, immuneTo: [] },
+  move: { kind: 'fly', speed: 5.5, jump: 0, restlessness: 0.65 },
+  diet: {
+    eats: ['plant'],
+    fears: [],
+    hungerRate: 0.028,
+    starveSeconds: 26,
+    breedAt: 0.72,
+    lifespanSeconds: 190,
+  },
+  senses: { sight: 26 },
+  habitat: { needs: null, drowns: true },
+  dig: { through: [], speed: 1 },
+  death: { becomes: null, particleColor: '#ffd94a', particleCount: 6 },
+  aura: { radius: 20, helps: ['plant'], boost: 2.4, converts: null, convertRate: 0 },
+  glow: 0,
+})
+
+const LOAMWORM = builtin('loamworm', {
+  name: 'Loamworm',
+  blurb: 'Chews bare rock and leaves good soil behind it.',
+  size: 2,
+  tags: ['meat', 'bug'],
+  art: {
+    palette: { p: '#d99a8a', d: '#a86b5c', e: '#5c3a30' },
+    frames: [
+      ['.ppppp.', 'pppppde', '.ppppp.'],
+      ['..pppp.', 'pppppde', '..pppp.'],
+    ],
+    frameMs: 200,
+    faceMotion: true,
+  },
+  body: { mass: 1.1, bounce: 0, drag: 0.3, buoyancy: 0.7, immuneTo: [] },
+  move: { kind: 'walk', speed: 2.2, jump: 3, restlessness: 0.35 },
+  diet: {
+    eats: ['plant'],
+    fears: [],
+    hungerRate: 0.022,
+    starveSeconds: 40,
+    breedAt: 0.82,
+    lifespanSeconds: 280,
+  },
+  senses: { sight: 12 },
+  habitat: { needs: null, drowns: true },
+  dig: { through: ['dirt', 'sand', 'ash', 'stone', 'mud'], speed: 1.6 },
+  death: { becomes: 'mud', particleColor: '#d99a8a', particleCount: 6 },
+  aura: {
+    radius: 7,
+    helps: [],
+    boost: 1,
+    converts: { from: 'stone', to: 'dirt' },
+    convertRate: 0.35,
+  },
+  glow: 0,
+})
+
+// ---------------------------------------------------------------------------
+// The fantasy set
+// ---------------------------------------------------------------------------
+
+const WISP = builtin('wisp', {
+  name: 'Wisp',
+  blurb: 'A wandering light. Nobody is sure it is really an animal.',
+  size: 1,
+  tags: ['meat', 'spirit', 'glow'],
+  art: {
+    palette: { c: '#cfefff', w: '#ffffff', b: '#7fb6ff' },
+    frames: [
+      ['..w..', '.wcw.', 'wcccw', '.bcb.', '..b..'],
+      ['..w..', '.wcw.', 'wcccw', '.bcb.', '.b.b.'],
+    ],
+    frameMs: 300,
+    faceMotion: false,
+  },
+  body: { mass: 0.05, bounce: 0.3, drag: 0.55, buoyancy: 1.3, immuneTo: ['lava'] },
+  move: { kind: 'drift', speed: 2.4, jump: 0, restlessness: 0.55 },
+  diet: {
+    eats: ['bug'],
+    fears: [],
+    hungerRate: 0.014,
+    starveSeconds: 70,
+    breedAt: 0.86,
+    lifespanSeconds: 400,
+  },
+  senses: { sight: 26 },
+  habitat: { needs: null, drowns: false },
+  dig: { through: [], speed: 1 },
+  death: { becomes: null, particleColor: '#cfefff', particleCount: 14 },
+  aura: null,
+  glow: 1,
+})
+
+const GRUMBLESTONE = builtin('grumblestone', {
+  name: 'Grumblestone',
+  blurb: 'A boulder that got up. Slow, heavy, and takes a lot of feeding.',
+  size: 5,
+  tags: ['meat', 'beast', 'mineral'],
+  art: {
+    palette: { s: '#6b7280', d: '#3d434d', m: '#8a929e', e: '#ffd166' },
+    frames: [
+      [
+        '..ssssss..',
+        '.smmmmmms.',
+        'smmmmeems.',
+        '.smmmmmms.',
+        '..ssssss..',
+        '.dd....dd.',
+        '.d......d.',
+      ],
+      [
+        '..ssssss..',
+        '.smmmmmms.',
+        'smmmmeems.',
+        '.smmmmmms.',
+        '..ssssss..',
+        '.dd....dd.',
+        '..d....d..',
+      ],
+    ],
+    frameMs: 320,
+    faceMotion: true,
+  },
+  body: { mass: 3, bounce: 0, drag: 0.25, buoyancy: 0.2, immuneTo: ['lava'] },
+  move: { kind: 'walk', speed: 2, jump: 5, restlessness: 0.1 },
+  diet: {
+    eats: ['meat'],
+    fears: [],
+    hungerRate: 0.011,
+    starveSeconds: 100,
+    breedAt: 0.92,
+    lifespanSeconds: 620,
+  },
+  senses: { sight: 24 },
+  habitat: { needs: null, drowns: false },
+  dig: { through: ['stone', 'dirt', 'ash', 'mud', 'obsidian'], speed: 0.7 },
+  death: { becomes: 'stone', particleColor: '#6b7280', particleCount: 14 },
+  aura: null,
+  glow: 0,
+})
+
+const CRYSTAL_SNAIL = builtin('crystal-snail', {
+  name: 'Crystal Snail',
+  blurb: 'Grazes on cave fuzz and grows a shell you can see the light through.',
+  size: 2,
+  tags: ['mineral', 'crystal', 'glow'],
+  art: {
+    palette: { c: '#8fe9ff', d: '#3f8fa8', b: '#d7c4a8', e: '#2a2a3a' },
+    frames: [
+      ['..cccc..', '.cccccc.', 'cccddccc', 'bbbbbbb.', '.bbbbbbe'],
+      ['..cccc..', '.cccccc.', 'cccddccc', '.bbbbbb.', 'bbbbbbbe'],
+    ],
+    frameMs: 340,
+    faceMotion: true,
+  },
+  body: { mass: 1.3, bounce: 0, drag: 0.3, buoyancy: 0.5, immuneTo: [] },
+  move: { kind: 'crawl', speed: 1.4, jump: 0, restlessness: 0.2 },
+  diet: {
+    eats: ['plant', 'fungus'],
+    fears: [],
+    hungerRate: 0.014,
+    starveSeconds: 80,
+    breedAt: 0.88,
+    lifespanSeconds: 480,
+  },
+  senses: { sight: 14 },
+  // Amphibious, like a real snail. It lives in caves and in tidepools, and the
+  // tidepool is half underwater — a snail that drowns in a rockpool is a snail
+  // that dies on the first tide.
+  habitat: { needs: null, drowns: false },
+  dig: { through: ['crystal', 'gem', 'stone'], speed: 0.6 },
+  death: { becomes: 'crystal', particleColor: '#8fe9ff', particleCount: 10 },
+  aura: null,
+  glow: 0.4,
+})
+
+// ---------------------------------------------------------------------------
+// The big ones
+//
+// Every one of these was authored by the model through the ordinary summon
+// route and pasted in verbatim — no hand-editing. They are here because they
+// prove the claim this file opens with: a creature is data, and there is no
+// size at which that stops being true. The Emberwing Elder is 28x24, about
+// twelve times the area of a Stalker, and the simulation needed nothing new to
+// run it.
+//
+// Anything past 12x10 collides with its middle only (see `bodyBox`), which is
+// what lets that wingspan follow a rider down a cave mouth half its width.
+// ---------------------------------------------------------------------------
+
+const DRAGON = builtin('dragon', {
+  name: 'Emberwing Elder',
+  blurb: 'An ancient dragon with wings as wide as a barn, whose scales still glow with the fire inside it.',
+  size: 6,
+  tags: ['meat', 'dragon', 'fire'],
+  art: {
+    palette: { 'k': '#180806', 'd': '#7d1f14', 'r': '#c0392b', 'o': '#e8792f', 'y': '#ffc247', 'e': '#fff3c0', 'w': '#ffeccc', 'm': '#9c3320', 'v': '#5e1a10' },
+    frames: [
+      [
+        '..kk......................',
+        '.kmmk.....................',
+        '.kmvmk....................',
+        '.kmvmmk...............kk..',
+        '.kmvmmmk............kkrrk.',
+        '.kmvmmvmk.........kkrrrrk.',
+        '.kmvmmvmmk.......kkrrrrrrk',
+        '.kmvmmvmmvk.....kkrrerrrrk',
+        '.kmvmmvmmvmkk...krrrwwwwwk',
+        '.kkmkkmkkmkmmkkkrrrrwwwkk.',
+        '....kkkkkkkkrrrrrrrrrkkk..',
+        '.......kkkkrrrrrrrrrrkk...',
+        '..kkkkkkrrrrroooorrrrkk...',
+        'kkddddrrrrroooooooorrrk...',
+        '.kkddrrrrrrooooooorrrrk...',
+        '..kkkddrrrrrrrrrrrrrrk....',
+        '.....kkkrrkkkkrrkkkkkk....',
+        '........krrk..krrk........',
+        '.......kkddk.kkddk........',
+        '.......kkkk...kkkk........',
+      ],
+      [
+        '..........................',
+        '..kk......................',
+        '.kmmk.................kk..',
+        '.kmvmk..............kkrrk.',
+        '.kmvmmk...........kkrrrrk.',
+        '.kmvmmvk.........kkrrrrrrk',
+        '.kmvmmvmk.......kkrrerrrrk',
+        '.kmvmmvmmk......krrrwwwwwk',
+        '.kmvmmvmmvkk...krrrrwwwkk.',
+        '.kkmkkmkkmkmkkkrrrrrrrkkk.',
+        '....kkkkkkkkrrrrrrrrrkk...',
+        '.......kkkkrrrrrrrrrrkk...',
+        '..kkkkkkrrrrroooorrrrkk...',
+        'kkddddrrrrroooooooorrrk...',
+        '.kkddrrrrrrooooooorrrrk...',
+        '..kkkddrrrrrrrrrrrrrrk....',
+        '.....kkkrrkkkkrrkkkkkk....',
+        '.......kkrrk..krrkk.......',
+        '.......kkddk.kkddkk.......',
+        '......kkkk.....kkkk.......',
+      ],
+    ],
+    frameMs: 300,
+    faceMotion: true,
+  },
+  body: { mass: 3, bounce: 0.05, drag: 0.82, buoyancy: 0.7, immuneTo: ['lava', 'ash', 'obsidian', 'stone'] },
+  move: { kind: 'fly', speed: 4.5, jump: 0, restlessness: 0.12 },
+  diet: {
+    eats: ['meat'],
+    fears: [],
+    hungerRate: 0.014,
+    starveSeconds: 110,
+    breedAt: 0.85,
+    lifespanSeconds: 900,
+  },
+  senses: { sight: 46 },
+  habitat: { needs: null, drowns: true },
+  dig: { through: ['ash', 'obsidian', 'stone'], speed: 0.6 },
+  death: { becomes: 'ash', particleColor: '#ff8a1e', particleCount: 30 },
+  aura: {"radius":10,"helps":[],"boost":1,"converts":{"from":"ice","to":"water"},"convertRate":0.3},
+  glow: 0.6,
+})
+
+const TREX = builtin('trex', {
+  name: 'Tyrannosaurus Rex',
+  blurb: 'A huge two-legged dinosaur with tiny arms and a jaw big enough to swallow a log.',
+  size: 6,
+  tags: ['meat', 'dinosaur', 'beast'],
+  art: {
+    palette: { 'k': '#14200f', 'd': '#2c4620', 'g': '#4e7a35', 'l': '#7aa84c', 'e': '#ffd23f', 'w': '#f2f0e4', 'r': '#8e3b3b' },
+    frames: [
+      [
+        '................kkkkkk..',
+        '...............kllllllk.',
+        '...............klgeglllk',
+        '..............kglgggllk.',
+        '..............kgwwwwwwk.',
+        '............kkkgrrrrrk..',
+        '.........kkkkgggwwwwk...',
+        '......kkkkgggggggkkkk...',
+        '.....kkgggllllgggggk....',
+        '..kkkgggglllllllgggggk..',
+        'kkggggllllllllllggggggk.',
+        '.kkkgggllllllllgggggk...',
+        '....kkkggggggggggggk....',
+        '......kgggk..kggggk.....',
+        '......kggk....kgggk.....',
+        '.....kkdgk....kdggk.....',
+        '....kkddk......kdgk.....',
+        '...kkddkk.....kkddkk....',
+      ],
+      [
+        '................kkkkkk..',
+        '...............kllllllk.',
+        '...............klgeglllk',
+        '..............kglgggllk.',
+        '..............kgwwwwwwk.',
+        '............kkkgrrrrrk..',
+        '.........kkkkgggwwwwk...',
+        '......kkkkgggggggkkkk...',
+        '....kkkgggllllgggggk....',
+        '.kkkkgggglllllllgggggk..',
+        'kgggggllllllllllggggggk.',
+        '.kkkgggllllllllgggggk...',
+        '....kkkggggggggggggk....',
+        '.....kggggk...kgggk.....',
+        '.....kgggk....kggggk....',
+        '.....kdggk....kdgggk....',
+        '....kkdgk......kddgk....',
+        '...kkddkk.....kkkddkk...',
+      ],
+    ],
+    frameMs: 260,
+    faceMotion: true,
+  },
+  body: { mass: 3, bounce: 0.05, drag: 0.6, buoyancy: 0.85, immuneTo: [] },
+  move: { kind: 'walk', speed: 5, jump: 6, restlessness: 0.15 },
+  diet: {
+    eats: ['meat'],
+    fears: [],
+    hungerRate: 0.02,
+    starveSeconds: 90,
+    breedAt: 0.8,
+    lifespanSeconds: 800,
+  },
+  senses: { sight: 40 },
+  habitat: { needs: null, drowns: true },
+  dig: { through: [], speed: 0.2 },
+  death: { becomes: 'bone', particleColor: '#8fae52', particleCount: 24 },
+  aura: null,
+  glow: 0,
+})
+
+const TOWER_FOLK = builtin('tower-folk', {
+  name: 'Tall Tim Twosome',
+  blurb: 'Two friends who travel everywhere as one very tall person, with the top one keeping watch far ahead.',
+  size: 5,
+  tags: ['meat', 'walker'],
+  art: {
+    palette: { 's': '#f0c39a', 'k': '#d69a70', 'c': '#3f6fbf', 'b': '#2b4c8c', 'r': '#c8443c', 'h': '#4a3327', 'e': '#20242c', 'y': '#ffe9a8' },
+    frames: [
+      [
+        '......yyy.....',
+        '.....yhhhy....',
+        '.....hsssh....',
+        '.....sseses...',
+        '......sss.....',
+        '....rrrrrrr...',
+        '...r.rrrrr.r..',
+        '...s.rrrrr.s..',
+        '...s..rrr..s..',
+        '......bbb.....',
+        '.....bb.bb....',
+        '.....k....k...',
+        '.....k....k...',
+        '......hhh.....',
+        '.....hhhhh....',
+        '.....hsssh....',
+        '......sses....',
+        '....ccccccc...',
+        '...c.ccccc.c..',
+        '...s.ccccc.s..',
+        '...s..ccc..s..',
+        '......bbb.....',
+        '.....bb.bb....',
+        '....kk....kk..',
+      ],
+      [
+        '......yyy.....',
+        '.....yhhhy....',
+        '.....hsssh....',
+        '.....sse.es...',
+        '......sss.....',
+        '....rrrrrrr...',
+        '..sr.rrrrr.rs.',
+        '...s.rrrrr.s..',
+        '......rrr.....',
+        '......bbb.....',
+        '.....bb.bb....',
+        '.....k....k...',
+        '.....k....k...',
+        '......hhh.....',
+        '.....hhhhh....',
+        '.....hsssh....',
+        '......sses....',
+        '....ccccccc...',
+        '..sc.ccccc.cs.',
+        '...s.ccccc.s..',
+        '......ccc.....',
+        '......bbb.....',
+        '.....bb.bb....',
+        '...kk......kk.',
+      ],
+    ],
+    frameMs: 220,
+    faceMotion: true,
+  },
+  body: { mass: 1.6, bounce: 0.05, drag: 0.75, buoyancy: 0.9, immuneTo: [] },
+  move: { kind: 'walk', speed: 3.5, jump: 5, restlessness: 0.25 },
+  diet: {
+    eats: ['plant', 'meat'],
+    fears: [],
+    hungerRate: 0.03,
+    starveSeconds: 50,
+    breedAt: 0.78,
+    lifespanSeconds: 420,
+  },
+  senses: { sight: 34 },
+  habitat: { needs: null, drowns: true },
+  dig: { through: [], speed: 0.2 },
+  death: { becomes: null, particleColor: '#c8443c', particleCount: 10 },
+  aura: null,
+  glow: 0,
+})
+
+const UNICYCLE_CLOWN = builtin('unicycle-clown', {
+  name: 'Wobble Clown',
+  blurb: 'A cheerful circus clown who balances on a squeaky one-wheeled cycle and never quite stops wobbling.',
+  size: 4,
+  tags: ['meat', 'clown', 'rider'],
+  art: {
+    palette: { 'r': '#e83b3b', 'w': '#fff4f0', 'y': '#ffd23f', 'b': '#3b6ee8', 's': '#f6c6a8', 'k': '#2a2438', 'g': '#8a8fa8', 'o': '#ff8a3d' },
+    frames: [
+      [
+        '......rrr.......',
+        '....rrrrrrr.....',
+        '.....rwwwwr.....',
+        '....rwsssswr....',
+        '....ws.k.k.sw...',
+        '....ws..r..sw...',
+        '....ws.www.sw...',
+        '.....wsssssw....',
+        '......bbbbb.....',
+        '....yybbbbbyy...',
+        '...y.bbbbbbb.y..',
+        '......bbbbb.....',
+        '.....b.....b....',
+        '....k.......k...',
+        '......kkk.......',
+        '.....k.g.k......',
+        '....k..g..k.....',
+        '....k.ggg..k....',
+        '....k..g...k....',
+        '.....k...k......',
+        '......kkk.......',
+      ],
+      [
+        '......rrr.......',
+        '....rrrrrrr.....',
+        '.....rwwwwr.....',
+        '....rwsssswr....',
+        '....ws.-.-.sw...',
+        '....ws..r..sw...',
+        '....ws.www.sw...',
+        '.....wsssssw....',
+        '......bbbbb.....',
+        '...yybbbbbbyy...',
+        '..y..bbbbbbb..y.',
+        '......bbbbb.....',
+        '.....b.....b....',
+        '......k...k.....',
+        '......kkk.......',
+        '.....k...k......',
+        '....k..g..k.....',
+        '....k.ggg..k....',
+        '....k..g..k.....',
+        '.....k.g.k......',
+        '......kkk.......',
+      ],
+    ],
+    frameMs: 150,
+    faceMotion: true,
+  },
+  body: { mass: 1, bounce: 0.35, drag: 0.82, buoyancy: 0.95, immuneTo: [] },
+  move: { kind: 'walk', speed: 6, jump: 7, restlessness: 0.6 },
+  diet: {
+    eats: ['plant'],
+    fears: [],
+    hungerRate: 0.03,
+    starveSeconds: 40,
+    breedAt: 0.75,
+    lifespanSeconds: 300,
+  },
+  senses: { sight: 18 },
+  habitat: { needs: null, drowns: true },
+  dig: { through: [], speed: 0.2 },
+  death: { becomes: null, particleColor: '#ffd23f', particleCount: 16 },
+  aura: null,
   glow: 0,
 })
 
@@ -508,17 +1383,36 @@ export const BUILTIN_CREATURES: CreatureBlueprint[] = [
   BRAMBLE,
   KELP,
   SPORECAP,
+  FROSTCAP,
+  GLOWVINE,
+  SKYBLOOM,
   MITE,
   HOPPER,
   GLIMMER_MOTH,
   FINLING,
   EMBER_GRUB,
   DELVER,
+  MOTE,
+  PALECRAWLER,
+  DRIFTMOLE,
+  WOOLLY,
+  DUSTBEE,
+  LOAMWORM,
+  CRYSTAL_SNAIL,
   STALKER,
   DRIFTER_JELLY,
   GULPER,
   CINDER_WYRM,
   RUSTBOT,
+  UNICYCLE_CLOWN,
+  TOWER_FOLK,
+  RIMECLAW,
+  SUNHAWK,
+  GLOOMWEAVER,
+  WISP,
+  GRUMBLESTONE,
+  TREX,
+  DRAGON,
 ]
 
 export const BUILTIN_BY_ID: Record<string, CreatureBlueprint> = Object.fromEntries(

--- a/src/app/micro-land/domain/config/loader-shapes.ts
+++ b/src/app/micro-land/domain/config/loader-shapes.ts
@@ -134,3 +134,12 @@ export const LOADER_TERRAIN_SHAPES: LoaderShape[] = [
     ],
   },
 ]
+
+/**
+ * The grains that pour into a slot while one creature is being summoned.
+ *
+ * Not a shape — the slot-sized wait never assembles into anything, it just
+ * piles up and washes out. Asset data, same as the palettes above, which is
+ * why the colors are literal.
+ */
+export const SUMMON_SAND_COLORS = ['#5eead4', '#2dd4bf', '#7dd3fc']

--- a/src/app/micro-land/domain/config/loader-shapes.ts
+++ b/src/app/micro-land/domain/config/loader-shapes.ts
@@ -1,0 +1,136 @@
+/**
+ * Pixel art for the summon loader.
+ *
+ * Hand-drawn stand-ins shown while the model is drawing the real thing —
+ * creatures in the size range the real ones come back in, and land built from
+ * the world's own material colors. Asset data, like the creature and material
+ * palettes next door, which is why the colors are literal.
+ *
+ * Eyes are bright rather than dark: the loader assembles these out of falling
+ * grains, and a dark pixel disappears against the panel on the way down.
+ */
+import { MATERIALS } from '@/app/micro-land/domain/config/materials'
+
+export interface LoaderShape {
+  /** Maps a character in `rows` to a color. `.` is empty. */
+  palette: Record<string, string>
+  /** What the eye takes on while blinking — the body color around it. */
+  blink: string
+  /** All rows must be the same length. */
+  rows: string[]
+}
+
+export const LOADER_CREATURE_SHAPES: LoaderShape[] = [
+  // Snail — shell behind, foot along the ground.
+  {
+    palette: { d: '#e0a83c', s: '#ffd166', b: '#5eead4', e: '#e6fff7' },
+    blink: '#5eead4',
+    rows: [
+      '...ddd....',
+      '..dsssd..b',
+      '..ds.sd.b.',
+      '..dsssd.bb',
+      '...ddd.beb',
+      '.bbbbbbbbb',
+      '..bbbbbbb.',
+    ],
+  },
+  // Moth — wings out, fat little body.
+  {
+    palette: { w: '#c084fc', v: '#8b5cf6', b: '#ffd166', e: '#e6fff7' },
+    blink: '#ffd166',
+    rows: [
+      '.v.....v.',
+      'vwwv.vwwv',
+      'wwwwbwwww',
+      '.wwwbwww.',
+      '..wwbww..',
+      '...beb...',
+      '...b.b...',
+    ],
+  },
+  // Fish — tail on the left, facing right like everything else here.
+  {
+    palette: { f: '#5eead4', t: '#2dd4bf', e: '#e6fff7' },
+    blink: '#5eead4',
+    rows: [
+      't....fff..',
+      'tt..ffffff',
+      'tttfffefff',
+      'ttffffffff',
+      'tttfffffff',
+      'tt..ffffff',
+      't....fff..',
+    ],
+  },
+  // Beetle — round back, legs splayed.
+  {
+    palette: { h: '#ff6b9d', l: '#b23a63', e: '#e6fff7' },
+    blink: '#ff6b9d',
+    // Short enough that prettier would fold it onto one line, which stops the
+    // drawing from being a drawing.
+    // prettier-ignore
+    rows: [
+      '..hhhhh..',
+      '.hhhhhhh.',
+      'hhhhhhheh',
+      '.hhhhhhh.',
+      '.l.l.l.l.',
+      'l.......l',
+    ],
+  },
+]
+
+/** Land in the world's own colors, so the grains fall as real dirt and water. */
+const TERRAIN_PALETTE = {
+  g: MATERIALS.grass.color,
+  d: MATERIALS.dirt.color,
+  s: MATERIALS.stone.color,
+  w: MATERIALS.water.color,
+}
+
+export const LOADER_TERRAIN_SHAPES: LoaderShape[] = [
+  // Floating island, trailing a waterfall.
+  {
+    palette: TERRAIN_PALETTE,
+    blink: TERRAIN_PALETTE.g,
+    rows: [
+      '......gggggggg......',
+      '.....dddddddddd.....',
+      '.....ssssssssss.....',
+      '......ssssssss......',
+      '.......ssssss.......',
+      '........ssss........',
+      '.........ss.........',
+      '.........w..........',
+      '..........w.........',
+    ],
+  },
+  // A mountain with a cave hollowed out of it.
+  {
+    palette: TERRAIN_PALETTE,
+    blink: TERRAIN_PALETTE.s,
+    rows: [
+      '.........gg.........',
+      '........gddg........',
+      '.......gddddg.......',
+      '......gddddddg......',
+      '.....gdd....ddg.....',
+      '....gdd......ddg....',
+      '..gddddddddddddddg..',
+      '.ssssssssssssssssss.',
+    ],
+  },
+  // Low ground with two pools in it.
+  {
+    palette: TERRAIN_PALETTE,
+    blink: TERRAIN_PALETTE.d,
+    rows: [
+      '..gggg...gggg...ggg.',
+      '.dddddwwwddddwwwdddd',
+      '.dddddwwwddddwwwdddd',
+      '.dddddddddddddddddd.',
+      '..ssssssssssssssss..',
+    ],
+  },
+]

--- a/src/app/micro-land/domain/config/materials.ts
+++ b/src/app/micro-land/domain/config/materials.ts
@@ -3,11 +3,55 @@
  *
  * Order matters: the index into MATERIAL_IDS is what's stored in the tile grid,
  * so `air` must stay at 0 (a zeroed Uint8Array is an empty world). Appending is
- * safe; reordering is not.
+ * safe; reordering is not. Tint variants are generated *after* the base list for
+ * exactly that reason — adding a new color can never shift an existing index.
+ *
+ * Every material is written as a short override of `DEFAULTS`, so each entry
+ * says only what makes it different from plain rock.
  */
-import type { Material, MaterialId } from '@/app/micro-land/domain/types'
+import type {
+  BaseMaterialId,
+  Material,
+  MaterialId,
+  TintId,
+  TintableMaterialId,
+} from '@/app/micro-land/domain/types'
 
-export const MATERIAL_IDS = [
+/** Boring rock. Every material below is a diff against this. */
+const DEFAULTS: Omit<Material, 'id' | 'name' | 'color'> = {
+  grain: 0.14,
+  solid: true,
+  liquid: false,
+  powder: false,
+  deadly: false,
+  glow: 0,
+  fertile: false,
+  viscous: 0,
+  breathable: false,
+  melts: false,
+  corrosive: false,
+  acidProof: false,
+  tintable: false,
+  tintOf: null,
+}
+
+function material(
+  id: MaterialId,
+  name: string,
+  color: string,
+  overrides: Partial<Material> = {}
+): Material {
+  return { ...DEFAULTS, id, name, color, ...overrides }
+}
+
+/**
+ * The vocabulary — the materials a person names.
+ *
+ * This is also the list handed to the summoning model, which is why the tints
+ * are kept out of it: "plastic" is a thing you can ask for, "plastic-mauve" is a
+ * thing you point at in the paint box.
+ */
+export const BASE_MATERIAL_IDS = [
   'air',
   'dirt',
   'grass',
@@ -21,166 +65,186 @@ export const MATERIAL_IDS = [
   'ash',
   'obsidian',
   'wood',
-] as const
+  'snow',
+  'mud',
+  'moss',
+  'crystal',
+  'gem',
+  'gold',
+  'bone',
+  'iron',
+  'marble',
+  'plastic',
+  'cloud',
+  'sap',
+  'acid',
+] as const satisfies readonly BaseMaterialId[]
 
-export const MATERIALS: Record<MaterialId, Material> = {
-  air: {
-    id: 'air',
-    name: 'Air',
-    color: '#000000',
-    grain: 0,
-    solid: false,
-    liquid: false,
-    powder: false,
-    deadly: false,
-    glow: 0,
-    fertile: false,
-  },
-  dirt: {
-    id: 'dirt',
-    name: 'Dirt',
-    color: '#6b4a2f',
-    grain: 0.16,
-    solid: true,
-    liquid: false,
-    powder: false,
-    deadly: false,
-    glow: 0,
-    fertile: true,
-  },
-  grass: {
-    id: 'grass',
-    name: 'Grass',
-    color: '#4f9d3a',
-    grain: 0.18,
-    solid: true,
-    liquid: false,
-    powder: false,
-    deadly: false,
-    glow: 0,
-    fertile: true,
-  },
-  stone: {
-    id: 'stone',
-    name: 'Stone',
-    color: '#5c6470',
-    grain: 0.14,
-    solid: true,
-    liquid: false,
-    powder: false,
-    deadly: false,
-    glow: 0,
-    fertile: false,
-  },
-  sand: {
-    id: 'sand',
-    name: 'Sand',
-    color: '#d9c08a',
-    grain: 0.12,
-    solid: true,
-    liquid: false,
-    powder: true,
-    deadly: false,
-    glow: 0,
-    fertile: true,
-  },
-  water: {
-    id: 'water',
-    name: 'Water',
-    color: '#2f7fd4',
+const BASE_MATERIALS: Record<BaseMaterialId, Material> = {
+  air: material('air', 'Air', '#000000', { grain: 0, solid: false }),
+  dirt: material('dirt', 'Dirt', '#6b4a2f', { grain: 0.16, fertile: true }),
+  grass: material('grass', 'Grass', '#4f9d3a', { grain: 0.18, fertile: true }),
+  stone: material('stone', 'Stone', '#5c6470'),
+  sand: material('sand', 'Sand', '#d9c08a', { grain: 0.12, powder: true, fertile: true }),
+  water: material('water', 'Water', '#2f7fd4', {
     grain: 0.1,
     solid: false,
     liquid: true,
-    powder: false,
-    deadly: false,
     glow: 0.05,
-    fertile: false,
-  },
-  lava: {
-    id: 'lava',
-    name: 'Lava',
-    color: '#e2551d',
+  }),
+  lava: material('lava', 'Lava', '#e2551d', {
     grain: 0.2,
     solid: false,
     liquid: true,
-    powder: false,
     deadly: true,
     glow: 1,
-    fertile: false,
-  },
-  ice: {
-    id: 'ice',
-    name: 'Ice',
-    color: '#a8d8ea',
-    grain: 0.1,
-    solid: true,
-    liquid: false,
-    powder: false,
-    deadly: false,
-    glow: 0.1,
-    fertile: false,
-  },
-  metal: {
-    id: 'metal',
-    name: 'Metal',
-    color: '#8a93a3',
-    grain: 0.08,
-    solid: true,
-    liquid: false,
-    powder: false,
-    deadly: false,
-    glow: 0,
-    fertile: false,
-  },
-  glass: {
-    id: 'glass',
-    name: 'Glass',
-    color: '#9fd4d8',
-    grain: 0.06,
-    solid: true,
-    liquid: false,
-    powder: false,
-    deadly: false,
-    glow: 0.15,
-    fertile: false,
-  },
-  ash: {
-    id: 'ash',
-    name: 'Ash',
-    color: '#4a4550',
-    grain: 0.18,
-    solid: true,
-    liquid: false,
+    acidProof: true,
+  }),
+  ice: material('ice', 'Ice', '#a8d8ea', { grain: 0.1, glow: 0.1, melts: true }),
+  metal: material('metal', 'Metal', '#8a93a3', { grain: 0.08 }),
+  glass: material('glass', 'Glass', '#9fd4d8', { grain: 0.06, glow: 0.15, acidProof: true }),
+  ash: material('ash', 'Ash', '#4a4550', { grain: 0.18, powder: true, fertile: true }),
+  obsidian: material('obsidian', 'Obsidian', '#241f2e', { grain: 0.12, acidProof: true }),
+  wood: material('wood', 'Wood', '#7a5230', { fertile: true }),
+
+  // --- cold ---------------------------------------------------------------
+  // Snow is fertile on purpose: a snowfield made only of snow would have
+  // nowhere for a frostcap to root, and a cold world where nothing grows is a
+  // cold world where nothing lives.
+  snow: material('snow', 'Snow', '#eaf2fb', {
+    grain: 0.07,
     powder: true,
-    deadly: false,
-    glow: 0,
     fertile: true,
-  },
-  obsidian: {
-    id: 'obsidian',
-    name: 'Obsidian',
-    color: '#241f2e',
-    grain: 0.12,
-    solid: true,
-    liquid: false,
-    powder: false,
-    deadly: false,
-    glow: 0,
-    fertile: false,
-  },
-  wood: {
-    id: 'wood',
-    name: 'Wood',
-    color: '#7a5230',
-    grain: 0.14,
-    solid: true,
-    liquid: false,
-    powder: false,
-    deadly: false,
-    glow: 0,
-    fertile: true,
-  },
+    glow: 0.08,
+    melts: true,
+  }),
+  mud: material('mud', 'Mud', '#4d3a26', { grain: 0.22, powder: true, fertile: true }),
+  moss: material('moss', 'Moss', '#5f8a3e', { grain: 0.24, fertile: true, glow: 0.04 }),
+
+  // --- shiny --------------------------------------------------------------
+  crystal: material('crystal', 'Crystal', '#8fe9ff', {
+    grain: 0.09,
+    glow: 0.5,
+    acidProof: true,
+    tintable: true,
+  }),
+  gem: material('gem', 'Gem', '#ff6fa8', {
+    grain: 0.07,
+    glow: 0.32,
+    acidProof: true,
+    tintable: true,
+  }),
+  gold: material('gold', 'Gold', '#e8b73a', { grain: 0.1, glow: 0.12, acidProof: true }),
+  bone: material('bone', 'Bone', '#e4ddc6', { grain: 0.15, fertile: true }),
+
+  // --- built --------------------------------------------------------------
+  iron: material('iron', 'Iron', '#6e5648', { grain: 0.17 }),
+  marble: material('marble', 'Marble', '#e6e8ef', { grain: 0.05, acidProof: true }),
+  plastic: material('plastic', 'Plastic', '#d8dce4', {
+    grain: 0.03,
+    acidProof: true,
+    tintable: true,
+  }),
+
+  // --- soft and mean ------------------------------------------------------
+  // Cloud is the odd one out: not solid, so you fall through it, but thick
+  // enough that you fall *slowly*. It doesn't flow, so it stays where painted.
+  cloud: material('cloud', 'Cloud', '#f2f6ff', {
+    grain: 0.05,
+    solid: false,
+    glow: 0.18,
+    viscous: 0.78,
+    tintable: true,
+  }),
+  sap: material('sap', 'Sap', '#c98a1e', {
+    grain: 0.13,
+    solid: false,
+    liquid: true,
+    breathable: true,
+    viscous: 0.92,
+    glow: 0.06,
+  }),
+  acid: material('acid', 'Acid', '#8ee02a', {
+    grain: 0.16,
+    solid: false,
+    liquid: true,
+    deadly: true,
+    corrosive: true,
+    glow: 0.4,
+    acidProof: true,
+  }),
 }
+
+// ---------------------------------------------------------------------------
+// Tints
+// ---------------------------------------------------------------------------
+
+export interface Tint {
+  id: TintId
+  name: string
+  color: string
+}
+
+export const TINTS: Tint[] = [
+  { id: 'red', name: 'Red', color: '#e0483f' },
+  { id: 'orange', name: 'Orange', color: '#ef8c3a' },
+  { id: 'yellow', name: 'Yellow', color: '#f2d04b' },
+  { id: 'green', name: 'Green', color: '#4fb861' },
+  { id: 'blue', name: 'Blue', color: '#3f86e0' },
+  { id: 'purple', name: 'Purple', color: '#9b5fd0' },
+  { id: 'pink', name: 'Pink', color: '#ef79b0' },
+  { id: 'white', name: 'White', color: '#eef1f6' },
+  { id: 'black', name: 'Black', color: '#2a2b34' },
+]
+
+const TINTABLE: TintableMaterialId[] = ['plastic', 'crystal', 'gem', 'cloud']
+
+/** `'plastic' + 'red'` → `'plastic-red'`, in one place so nothing hand-builds it. */
+export function tintedId(base: TintableMaterialId, tint: TintId): MaterialId {
+  return `${base}-${tint}`
+}
+
+const TINT_MATERIALS: Material[] = TINTABLE.flatMap((base) =>
+  TINTS.map((tint) => {
+    const source = BASE_MATERIALS[base]
+    const id = tintedId(base, tint.id)
+    return {
+      ...source,
+      id,
+      name: `${tint.name} ${source.name}`,
+      // A tinted crystal should still read as crystal, so the tint is pulled
+      // part-way toward the material's own color rather than replacing it.
+      color: mix(tint.color, source.color, base === 'plastic' ? 0.1 : 0.34),
+      tintable: false,
+      tintOf: base,
+    }
+  })
+)
+
+/** Blend two hex colors. `t` is how much of `b` to take. */
+function mix(a: string, b: string, t: number): string {
+  const pa = parseInt(a.slice(1), 16)
+  const pb = parseInt(b.slice(1), 16)
+  const out = [16, 8, 0].map((shift) => {
+    const ca = (pa >> shift) & 255
+    const cb = (pb >> shift) & 255
+    return Math.round(ca + (cb - ca) * t)
+  })
+  return `#${out.map((c) => c.toString(16).padStart(2, '0')).join('')}`
+}
+
+// ---------------------------------------------------------------------------
+
+/** Every material in the world, base colors first, then every tint. */
+export const MATERIAL_IDS: MaterialId[] = [
+  ...BASE_MATERIAL_IDS,
+  ...TINT_MATERIALS.map((m) => m.id),
+]
+
+export const MATERIALS: Record<MaterialId, Material> = {
+  ...BASE_MATERIALS,
+  ...Object.fromEntries(TINT_MATERIALS.map((m) => [m.id, m])),
+} as Record<MaterialId, Material>
 
 /** Numeric index of each material, for the tile grid. */
 export const MATERIAL_INDEX: Record<MaterialId, number> = MATERIAL_IDS.reduce(
@@ -195,19 +259,37 @@ export const MATERIAL_BY_INDEX: Material[] = MATERIAL_IDS.map((id) => MATERIALS[
 
 export const AIR = MATERIAL_INDEX.air
 
-/** Materials the player can paint with, in palette order. */
-export const PAINTABLE: MaterialId[] = [
+/**
+ * Materials the player can paint with, in palette order.
+ *
+ * Only the base of each tintable family appears here — the colors hang off it
+ * in the toolbar's tint strip instead of turning one palette into fifty.
+ */
+export const PAINTABLE: BaseMaterialId[] = [
   'dirt',
   'grass',
+  'moss',
+  'mud',
   'stone',
   'sand',
+  'snow',
   'water',
   'lava',
+  'acid',
+  'sap',
   'ice',
+  'cloud',
   'wood',
+  'bone',
   'metal',
+  'iron',
+  'marble',
   'glass',
+  'plastic',
   'obsidian',
+  'crystal',
+  'gem',
+  'gold',
 ]
 
 /** Precomputed flags, indexed the same way as the tile grid (hot path). */
@@ -225,4 +307,15 @@ export const IS_DEADLY: Uint8Array = new Uint8Array(
 )
 export const IS_FERTILE: Uint8Array = new Uint8Array(
   MATERIAL_BY_INDEX.map((m) => (m.fertile ? 1 : 0))
+)
+/** Liquids you can actually drown in — sap is thick, but you can breathe in it. */
+export const IS_DROWNING: Uint8Array = new Uint8Array(
+  MATERIAL_BY_INDEX.map((m) => (m.liquid && !m.breathable ? 1 : 0))
+)
+export const IS_ACID_PROOF: Uint8Array = new Uint8Array(
+  MATERIAL_BY_INDEX.map((m) => (m.acidProof ? 1 : 0))
+)
+/** How much each material slows things moving through it, 0..255. */
+export const VISCOSITY: Uint8Array = new Uint8Array(
+  MATERIAL_BY_INDEX.map((m) => Math.round(m.viscous * 255))
 )

--- a/src/app/micro-land/domain/config/materials.ts
+++ b/src/app/micro-land/domain/config/materials.ts
@@ -1,0 +1,228 @@
+/**
+ * The stuff the world is made of.
+ *
+ * Order matters: the index into MATERIAL_IDS is what's stored in the tile grid,
+ * so `air` must stay at 0 (a zeroed Uint8Array is an empty world). Appending is
+ * safe; reordering is not.
+ */
+import type { Material, MaterialId } from '@/app/micro-land/domain/types'
+
+export const MATERIAL_IDS = [
+  'air',
+  'dirt',
+  'grass',
+  'stone',
+  'sand',
+  'water',
+  'lava',
+  'ice',
+  'metal',
+  'glass',
+  'ash',
+  'obsidian',
+  'wood',
+] as const
+
+export const MATERIALS: Record<MaterialId, Material> = {
+  air: {
+    id: 'air',
+    name: 'Air',
+    color: '#000000',
+    grain: 0,
+    solid: false,
+    liquid: false,
+    powder: false,
+    deadly: false,
+    glow: 0,
+    fertile: false,
+  },
+  dirt: {
+    id: 'dirt',
+    name: 'Dirt',
+    color: '#6b4a2f',
+    grain: 0.16,
+    solid: true,
+    liquid: false,
+    powder: false,
+    deadly: false,
+    glow: 0,
+    fertile: true,
+  },
+  grass: {
+    id: 'grass',
+    name: 'Grass',
+    color: '#4f9d3a',
+    grain: 0.18,
+    solid: true,
+    liquid: false,
+    powder: false,
+    deadly: false,
+    glow: 0,
+    fertile: true,
+  },
+  stone: {
+    id: 'stone',
+    name: 'Stone',
+    color: '#5c6470',
+    grain: 0.14,
+    solid: true,
+    liquid: false,
+    powder: false,
+    deadly: false,
+    glow: 0,
+    fertile: false,
+  },
+  sand: {
+    id: 'sand',
+    name: 'Sand',
+    color: '#d9c08a',
+    grain: 0.12,
+    solid: true,
+    liquid: false,
+    powder: true,
+    deadly: false,
+    glow: 0,
+    fertile: true,
+  },
+  water: {
+    id: 'water',
+    name: 'Water',
+    color: '#2f7fd4',
+    grain: 0.1,
+    solid: false,
+    liquid: true,
+    powder: false,
+    deadly: false,
+    glow: 0.05,
+    fertile: false,
+  },
+  lava: {
+    id: 'lava',
+    name: 'Lava',
+    color: '#e2551d',
+    grain: 0.2,
+    solid: false,
+    liquid: true,
+    powder: false,
+    deadly: true,
+    glow: 1,
+    fertile: false,
+  },
+  ice: {
+    id: 'ice',
+    name: 'Ice',
+    color: '#a8d8ea',
+    grain: 0.1,
+    solid: true,
+    liquid: false,
+    powder: false,
+    deadly: false,
+    glow: 0.1,
+    fertile: false,
+  },
+  metal: {
+    id: 'metal',
+    name: 'Metal',
+    color: '#8a93a3',
+    grain: 0.08,
+    solid: true,
+    liquid: false,
+    powder: false,
+    deadly: false,
+    glow: 0,
+    fertile: false,
+  },
+  glass: {
+    id: 'glass',
+    name: 'Glass',
+    color: '#9fd4d8',
+    grain: 0.06,
+    solid: true,
+    liquid: false,
+    powder: false,
+    deadly: false,
+    glow: 0.15,
+    fertile: false,
+  },
+  ash: {
+    id: 'ash',
+    name: 'Ash',
+    color: '#4a4550',
+    grain: 0.18,
+    solid: true,
+    liquid: false,
+    powder: true,
+    deadly: false,
+    glow: 0,
+    fertile: true,
+  },
+  obsidian: {
+    id: 'obsidian',
+    name: 'Obsidian',
+    color: '#241f2e',
+    grain: 0.12,
+    solid: true,
+    liquid: false,
+    powder: false,
+    deadly: false,
+    glow: 0,
+    fertile: false,
+  },
+  wood: {
+    id: 'wood',
+    name: 'Wood',
+    color: '#7a5230',
+    grain: 0.14,
+    solid: true,
+    liquid: false,
+    powder: false,
+    deadly: false,
+    glow: 0,
+    fertile: true,
+  },
+}
+
+/** Numeric index of each material, for the tile grid. */
+export const MATERIAL_INDEX: Record<MaterialId, number> = MATERIAL_IDS.reduce(
+  (acc, id, i) => {
+    acc[id] = i
+    return acc
+  },
+  {} as Record<MaterialId, number>
+)
+
+export const MATERIAL_BY_INDEX: Material[] = MATERIAL_IDS.map((id) => MATERIALS[id])
+
+export const AIR = MATERIAL_INDEX.air
+
+/** Materials the player can paint with, in palette order. */
+export const PAINTABLE: MaterialId[] = [
+  'dirt',
+  'grass',
+  'stone',
+  'sand',
+  'water',
+  'lava',
+  'ice',
+  'wood',
+  'metal',
+  'glass',
+  'obsidian',
+]
+
+/** Precomputed flags, indexed the same way as the tile grid (hot path). */
+export const IS_SOLID: Uint8Array = new Uint8Array(
+  MATERIAL_BY_INDEX.map((m) => (m.solid ? 1 : 0))
+)
+export const IS_LIQUID: Uint8Array = new Uint8Array(
+  MATERIAL_BY_INDEX.map((m) => (m.liquid ? 1 : 0))
+)
+export const IS_POWDER: Uint8Array = new Uint8Array(
+  MATERIAL_BY_INDEX.map((m) => (m.powder ? 1 : 0))
+)
+export const IS_DEADLY: Uint8Array = new Uint8Array(
+  MATERIAL_BY_INDEX.map((m) => (m.deadly ? 1 : 0))
+)
+export const IS_FERTILE: Uint8Array = new Uint8Array(
+  MATERIAL_BY_INDEX.map((m) => (m.fertile ? 1 : 0))
+)

--- a/src/app/micro-land/domain/config/milestones.ts
+++ b/src/app/micro-land/domain/config/milestones.ts
@@ -1,0 +1,105 @@
+/**
+ * Milestones — the game noticing you, once.
+ *
+ * These deliberately have no screen of their own. A milestone arrives as one
+ * line in the same notice strip that already reports hunts and extinctions, and
+ * afterwards it lives in the back of the field guide. There is no badge, no
+ * progress bar, and nothing to collect on purpose: the whole mechanism is the
+ * world remarking on something you did and then getting on with it.
+ *
+ * They fire once ever, not once per land. Seeing "a family line five deep" in
+ * every world you open would turn a discovery into a chore.
+ */
+
+/** Everything a milestone is allowed to look at. All counts are current. */
+export interface MilestoneContext {
+  /** World-seconds this land has been running. */
+  elapsed: number
+  /** World-seconds since the last extinction here. */
+  steadySeconds: number
+  /** Age of the oldest thing currently alive. */
+  oldestSeconds: number
+  /** Deepest generation currently alive. */
+  generations: number
+  /** Distinct species currently alive. */
+  speciesAlive: number
+  /** Living things right now. */
+  total: number
+  /** Species in the field guide archive. */
+  archived: number
+  /** How many of those the player summoned. */
+  summonedArchived: number
+}
+
+export interface Milestone {
+  id: string
+  /** Shown as a notice when it fires, and in the field guide from then on. */
+  text: string
+  reached: (c: MilestoneContext) => boolean
+}
+
+/**
+ * Ordered loosely by when a player is likely to meet them. Order only affects
+ * the field guide listing — the checks are independent.
+ */
+export const MILESTONES: Milestone[] = [
+  {
+    id: 'first-elder',
+    text: 'Something here has grown old.',
+    reached: (c) => c.oldestSeconds >= 60,
+  },
+  {
+    id: 'many-kinds',
+    text: 'Eight kinds sharing one land.',
+    reached: (c) => c.speciesAlive >= 8,
+  },
+  {
+    id: 'steady-3m',
+    text: 'Three minutes, and nothing has died out.',
+    reached: (c) => c.steadySeconds >= 180,
+  },
+  {
+    id: 'gen-5',
+    text: 'A family line five deep.',
+    reached: (c) => c.generations >= 5,
+  },
+  {
+    id: 'guide-12',
+    text: 'Twelve kinds recorded in the field guide.',
+    reached: (c) => c.archived >= 12,
+  },
+  {
+    id: 'elder-5m',
+    text: 'One creature has lived five whole minutes.',
+    reached: (c) => c.oldestSeconds >= 300,
+  },
+  {
+    id: 'summoned-5',
+    text: 'Five creatures of your own invention, remembered.',
+    reached: (c) => c.summonedArchived >= 5,
+  },
+  {
+    id: 'crowded',
+    text: 'Two hundred and fifty living things at once.',
+    reached: (c) => c.total >= 250,
+  },
+  {
+    id: 'steady-10m',
+    text: 'Ten minutes steady. This web holds.',
+    reached: (c) => c.steadySeconds >= 600,
+  },
+  {
+    id: 'gen-12',
+    text: 'Twelve generations. None of the first are left.',
+    reached: (c) => c.generations >= 12,
+  },
+  {
+    id: 'guide-30',
+    text: 'Thirty kinds. The field guide is getting heavy.',
+    reached: (c) => c.archived >= 30,
+  },
+]
+
+export const MILESTONE_BY_ID: Record<string, Milestone> = Object.fromEntries(
+  MILESTONES.map((m) => [m.id, m])
+)

--- a/src/app/micro-land/domain/config/themes.ts
+++ b/src/app/micro-land/domain/config/themes.ts
@@ -1,0 +1,347 @@
+/**
+ * Themes — the worlds you can switch between.
+ *
+ * A theme is a terrain generator plus a mood: what the void behind the world
+ * looks like, how dark it is, how hard gravity pulls, and which creatures show
+ * up already living there. Switching themes rebuilds the tile grid; summoned
+ * creatures survive the change.
+ */
+import { WORLD_H, WORLD_W } from '@/app/micro-land/domain/constants'
+import { type Rng, fbm, makeNoise2D } from '@/app/micro-land/domain/sim/prng'
+import type { MaterialId } from '@/app/micro-land/domain/types'
+
+import { MATERIAL_INDEX } from './materials'
+
+export interface Theme {
+  id: string
+  name: string
+  blurb: string
+  /** Two-stop gradient behind the world, top to bottom. */
+  sky: [string, string]
+  /** 0 = evenly lit, 1 = only glowing things are visible. */
+  gloom: number
+  /** Gravity multiplier. The station is 0.35; everywhere else is 1. */
+  gravity: number
+  /** Who already lives here. */
+  starters: { id: string; count: number }[]
+  build: (tiles: Uint8Array, rng: Rng) => void
+}
+
+const M = MATERIAL_INDEX
+
+function fill(tiles: Uint8Array, id: MaterialId) {
+  tiles.fill(M[id])
+}
+
+function set(tiles: Uint8Array, x: number, y: number, id: MaterialId) {
+  if (x < 0 || y < 0 || x >= WORLD_W || y >= WORLD_H) return
+  tiles[y * WORLD_W + x] = M[id]
+}
+
+function rect(
+  tiles: Uint8Array,
+  x0: number,
+  y0: number,
+  x1: number,
+  y1: number,
+  id: MaterialId
+) {
+  for (let y = Math.max(0, y0); y <= Math.min(WORLD_H - 1, y1); y++) {
+    for (let x = Math.max(0, x0); x <= Math.min(WORLD_W - 1, x1); x++) {
+      tiles[y * WORLD_W + x] = M[id]
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+
+const EMPTY: Theme = {
+  id: 'empty',
+  name: 'Empty',
+  blurb: 'Nothing at all. Build it yourself.',
+  sky: ['#141026', '#090713'],
+  gloom: 0.1,
+  gravity: 1,
+  starters: [],
+  build: (tiles) => fill(tiles, 'air'),
+}
+
+const EARTH: Theme = {
+  id: 'earth',
+  name: 'Cross-Section',
+  blurb: 'Sky, grass, dirt, caves, and molten rock at the bottom.',
+  sky: ['#7fc4e8', '#2a3a5c'],
+  gloom: 0.34,
+  gravity: 1,
+  starters: [
+    { id: 'sunleaf', count: 44 },
+    { id: 'bramble', count: 14 },
+    { id: 'mite', count: 10 },
+    { id: 'hopper', count: 6 },
+    { id: 'glimmer-moth', count: 6 },
+    { id: 'stalker', count: 2 },
+    { id: 'delver', count: 4 },
+    { id: 'sporecap', count: 5 },
+  ],
+  build: (tiles, rng) => {
+    fill(tiles, 'air')
+    const surfaceNoise = makeNoise2D(Math.floor(rng() * 1e9))
+    const caveNoise = makeNoise2D(Math.floor(rng() * 1e9))
+    const oreNoise = makeNoise2D(Math.floor(rng() * 1e9))
+
+    const skyDepth = Math.floor(WORLD_H * 0.3)
+
+    for (let x = 0; x < WORLD_W; x++) {
+      // Rolling hills: a couple of octaves is enough at this width.
+      const h = fbm(surfaceNoise, x * 0.035, 0.5, 3)
+      const surface = Math.floor(skyDepth + (h - 0.5) * 18)
+
+      for (let y = surface; y < WORLD_H; y++) {
+        const depth = (y - surface) / (WORLD_H - surface)
+        let mat: MaterialId
+        if (y === surface) mat = 'grass'
+        else if (depth < 0.22) mat = 'dirt'
+        else if (depth > 0.9) mat = 'lava'
+        else mat = 'stone'
+
+        // Carve caves out of the rock, but never out of the top crust.
+        if (mat === 'stone' && depth < 0.88) {
+          const c = fbm(caveNoise, x * 0.06, y * 0.09, 3)
+          if (c > 0.62) mat = 'air'
+        }
+        // Occasional water pockets and sand seams.
+        if (mat === 'stone' && depth > 0.35 && depth < 0.7) {
+          const o = oreNoise(x * 0.12, y * 0.12)
+          if (o > 0.88) mat = 'water'
+          else if (o < 0.08) mat = 'sand'
+        }
+        set(tiles, x, y, mat)
+      }
+    }
+
+    // A shallow pond or two on the surface.
+    const ponds = 2 + Math.floor(rng() * 2)
+    for (let p = 0; p < ponds; p++) {
+      const cx = Math.floor(rng() * WORLD_W)
+      const w = 8 + Math.floor(rng() * 14)
+      for (let x = cx - w; x <= cx + w; x++) {
+        if (x < 0 || x >= WORLD_W) continue
+        // Find the surface at this column, then scoop a bowl into it.
+        let surface = 0
+        while (surface < WORLD_H && tiles[surface * WORLD_W + x] === M.air) surface++
+        const t = 1 - Math.abs(x - cx) / (w + 1)
+        const depth = Math.floor(t * 5)
+        for (let d = 0; d < depth; d++) set(tiles, x, surface + d, 'water')
+      }
+    }
+  },
+}
+
+const STATION: Theme = {
+  id: 'station',
+  name: 'Broken Station',
+  blurb: 'Metal rooms adrift in orbit. Everything falls slowly here.',
+  sky: ['#060812', '#01030a'],
+  gloom: 0.62,
+  gravity: 0.35,
+  starters: [
+    { id: 'rustbot', count: 5 },
+    { id: 'sporecap', count: 18 },
+    { id: 'drifter-jelly', count: 5 },
+    { id: 'glimmer-moth', count: 7 },
+    { id: 'mite', count: 8 },
+  ],
+  build: (tiles, rng) => {
+    fill(tiles, 'air')
+
+    // Chop the interior into rooms by recursively splitting a box, then hollow
+    // each one out and knock a doorway through — cheap, and it always connects.
+    interface Box {
+      x0: number
+      y0: number
+      x1: number
+      y1: number
+    }
+    const rooms: Box[] = []
+
+    function split(box: Box, depth: number) {
+      const w = box.x1 - box.x0
+      const h = box.y1 - box.y0
+      if (depth > 4 || (w < 26 && h < 20) || rooms.length > 24) {
+        rooms.push(box)
+        return
+      }
+      const horizontal = w > h * 1.4 ? true : h > w * 1.4 ? false : rng() > 0.5
+      if (horizontal) {
+        const cut = box.x0 + Math.floor(w * (0.35 + rng() * 0.3))
+        split({ ...box, x1: cut }, depth + 1)
+        split({ ...box, x0: cut }, depth + 1)
+      } else {
+        const cut = box.y0 + Math.floor(h * (0.35 + rng() * 0.3))
+        split({ ...box, y1: cut }, depth + 1)
+        split({ ...box, y0: cut }, depth + 1)
+      }
+    }
+
+    const margin = 12
+    split(
+      { x0: margin, y0: 10, x1: WORLD_W - margin, y1: WORLD_H - 10 },
+      0
+    )
+
+    for (const room of rooms) {
+      // Skip a few rooms entirely — a station with holes in it reads as broken.
+      if (rng() < 0.18) continue
+      rect(tiles, room.x0, room.y0, room.x1, room.y1, 'metal')
+      rect(tiles, room.x0 + 2, room.y0 + 2, room.x1 - 2, room.y1 - 2, 'air')
+
+      // Viewports.
+      if (rng() < 0.5) {
+        const gy = room.y0 + 2 + Math.floor(rng() * Math.max(1, room.y1 - room.y0 - 4))
+        rect(tiles, room.x0, gy, room.x0 + 1, gy + 1, 'glass')
+      }
+      // Doorway to the room on the right.
+      const dy = room.y1 - 3
+      rect(tiles, room.x1 - 2, dy - 2, room.x1 + 2, dy, 'air')
+
+      // Leftover cargo: water tanks, scrap piles, and — critically — soil.
+      //
+      // Metal and glass are not fertile, so a station built only from those has
+      // nowhere for a plant to root. Nothing grows, nothing eats, and the whole
+      // station starves within a couple of minutes. These are the overgrown
+      // hydroponics beds, and they are what make the place survivable.
+      const roll = rng()
+      if (roll < 0.2) {
+        rect(tiles, room.x0 + 3, room.y1 - 6, room.x0 + 10, room.y1 - 3, 'water')
+      } else if (roll < 0.32) {
+        rect(tiles, room.x0 + 4, room.y1 - 4, room.x0 + 9, room.y1 - 3, 'metal')
+      }
+      if (rng() < 0.65) {
+        const bedX = room.x0 + 3
+        const bedW = Math.max(4, Math.floor((room.x1 - room.x0) * 0.5))
+        rect(tiles, bedX, room.y1 - 3, bedX + bedW, room.y1 - 3, 'dirt')
+      }
+    }
+  },
+}
+
+const TIDEPOOL: Theme = {
+  id: 'tidepool',
+  name: 'Tidepool',
+  blurb: 'Shallow water over rock shelves and sand.',
+  sky: ['#bfe6f5', '#4a89a8'],
+  gloom: 0.22,
+  gravity: 1,
+  starters: [
+    { id: 'kelp', count: 34 },
+    { id: 'sunleaf', count: 8 },
+    { id: 'finling', count: 10 },
+    { id: 'mite', count: 6 },
+    { id: 'gulper', count: 2 },
+    { id: 'drifter-jelly', count: 4 },
+  ],
+  build: (tiles, rng) => {
+    fill(tiles, 'air')
+    const floorNoise = makeNoise2D(Math.floor(rng() * 1e9))
+    const shelfNoise = makeNoise2D(Math.floor(rng() * 1e9))
+
+    const waterLine = Math.floor(WORLD_H * 0.34)
+
+    for (let x = 0; x < WORLD_W; x++) {
+      const f = fbm(floorNoise, x * 0.045, 2.5, 3)
+      const floor = Math.floor(WORLD_H * 0.66 + (f - 0.5) * 26)
+
+      for (let y = waterLine; y < floor; y++) set(tiles, x, y, 'water')
+      for (let y = floor; y < WORLD_H; y++) {
+        const depth = y - floor
+        set(tiles, x, y, depth < 3 ? 'sand' : 'stone')
+      }
+
+      // Rock shelves that break the surface — the tide leaves these dry.
+      const s = fbm(shelfNoise, x * 0.03, 8.5, 2)
+      if (s > 0.66) {
+        const top = waterLine - Math.floor((s - 0.66) * 34)
+        for (let y = top; y < floor; y++) {
+          set(tiles, x, y, y < waterLine + 1 ? 'stone' : 'stone')
+        }
+        set(tiles, x, top, 'stone')
+      }
+    }
+
+    // Scattered tidepools sitting on top of the shelves.
+    for (let i = 0; i < 14; i++) {
+      const cx = Math.floor(rng() * WORLD_W)
+      let y = 0
+      while (y < WORLD_H && tiles[y * WORLD_W + cx] === M.air) y++
+      if (y >= waterLine || y >= WORLD_H - 2) continue
+      const w = 2 + Math.floor(rng() * 5)
+      for (let x = cx - w; x <= cx + w; x++) {
+        const t = 1 - Math.abs(x - cx) / (w + 1)
+        for (let d = 0; d < Math.floor(t * 4); d++) set(tiles, x, y + d, 'water')
+      }
+    }
+  },
+}
+
+const VOLCANIC: Theme = {
+  id: 'volcanic',
+  name: 'Volcanic',
+  blurb: 'Ash, black rock and rivers of lava. Only tough things last.',
+  sky: ['#3a1512', '#120608'],
+  gloom: 0.5,
+  gravity: 1,
+  starters: [
+    { id: 'sporecap', count: 20 },
+    { id: 'ember-grub', count: 7 },
+    { id: 'cinder-wyrm', count: 3 },
+    { id: 'mite', count: 6 },
+    { id: 'delver', count: 3 },
+    { id: 'rustbot', count: 2 },
+  ],
+  build: (tiles, rng) => {
+    fill(tiles, 'air')
+    const surfaceNoise = makeNoise2D(Math.floor(rng() * 1e9))
+    const caveNoise = makeNoise2D(Math.floor(rng() * 1e9))
+
+    const skyDepth = Math.floor(WORLD_H * 0.28)
+
+    for (let x = 0; x < WORLD_W; x++) {
+      const h = fbm(surfaceNoise, x * 0.05, 1.5, 4)
+      const surface = Math.floor(skyDepth + (h - 0.5) * 30)
+
+      for (let y = surface; y < WORLD_H; y++) {
+        const depth = (y - surface) / (WORLD_H - surface)
+        let mat: MaterialId
+        if (depth < 0.06) mat = 'ash'
+        else if (depth > 0.86) mat = 'lava'
+        else mat = depth > 0.55 ? 'obsidian' : 'stone'
+
+        if ((mat === 'stone' || mat === 'obsidian') && depth < 0.82) {
+          const c = fbm(caveNoise, x * 0.07, y * 0.1, 3)
+          if (c > 0.6) mat = 'air'
+          else if (c < 0.16 && depth > 0.4) mat = 'lava'
+        }
+        set(tiles, x, y, mat)
+      }
+    }
+
+    // Lava falls spilling down from the surface.
+    for (let i = 0; i < 4; i++) {
+      const cx = 12 + Math.floor(rng() * (WORLD_W - 24))
+      let y = 0
+      while (y < WORLD_H && tiles[y * WORLD_W + cx] === M.air) y++
+      const w = 1 + Math.floor(rng() * 2)
+      for (let d = 0; d < 18; d++) {
+        for (let x = cx - w; x <= cx + w; x++) set(tiles, x, y + d, 'lava')
+      }
+    }
+  },
+}
+
+export const THEMES: Theme[] = [EMPTY, EARTH, STATION, TIDEPOOL, VOLCANIC]
+
+export const THEME_BY_ID: Record<string, Theme> = Object.fromEntries(
+  THEMES.map((t) => [t.id, t])
+)
+
+export const DEFAULT_THEME = 'empty'

--- a/src/app/micro-land/domain/config/themes.ts
+++ b/src/app/micro-land/domain/config/themes.ts
@@ -6,7 +6,7 @@
  * up already living there. Switching themes rebuilds the tile grid; summoned
  * creatures survive the change.
  */
-import { WORLD_H, WORLD_W } from '@/app/micro-land/domain/constants'
+import { WIDTH_SCALE, WORLD_H, WORLD_W } from '@/app/micro-land/domain/constants'
 import { type Rng, fbm, makeNoise2D } from '@/app/micro-land/domain/sim/prng'
 import type { MaterialId } from '@/app/micro-land/domain/types'
 
@@ -28,6 +28,18 @@ export interface Theme {
 }
 
 const M = MATERIAL_INDEX
+
+/**
+ * "This many per screen" → "this many across the whole world".
+ *
+ * Every scattered feature below — ponds, geodes, lava falls — was a count
+ * chosen by eye against one screen of land. Left alone in a world three screens
+ * wide they don't spread out, they thin out: two ponds in a world this long
+ * means most of it has no fresh water at all.
+ */
+function across(n: number): number {
+  return Math.round(n * WIDTH_SCALE)
+}
 
 function fill(tiles: Uint8Array, id: MaterialId) {
   tiles.fill(M[id])
@@ -195,7 +207,7 @@ const EARTH: Theme = {
 
     // A shallow pond or two on the surface, with mud round the rim — the one
     // place on the map where the ground is both wet and fertile.
-    const ponds = 2 + Math.floor(rng() * 2)
+    const ponds = across(2) + Math.floor(rng() * across(2))
     for (let p = 0; p < ponds; p++) {
       const cx = Math.floor(rng() * WORLD_W)
       const w = 8 + Math.floor(rng() * 14)
@@ -249,10 +261,16 @@ const STATION: Theme = {
     }
     const rooms: Box[] = []
 
+    // Each level of recursion doubles the room count, so widening the station
+    // needs *more depth*, not a bigger number — at the old limit of 4 the same
+    // sixteen rooms would simply have been stretched to three times the size,
+    // and a station made of enormous empty halls stops reading as a station.
+    const maxDepth = 4 + Math.round(Math.log2(WIDTH_SCALE))
+
     function split(box: Box, depth: number) {
       const w = box.x1 - box.x0
       const h = box.y1 - box.y0
-      if (depth > 4 || (w < 26 && h < 20) || rooms.length > 24) {
+      if (depth > maxDepth || (w < 26 && h < 20) || rooms.length > across(24)) {
         rooms.push(box)
         return
       }
@@ -373,7 +391,7 @@ const TIDEPOOL: Theme = {
     }
 
     // Scattered tidepools sitting on top of the shelves.
-    for (let i = 0; i < 14; i++) {
+    for (let i = 0; i < across(14); i++) {
       const cx = Math.floor(rng() * WORLD_W)
       let y = 0
       while (y < WORLD_H && tiles[y * WORLD_W + cx] === M.air) y++
@@ -386,7 +404,7 @@ const TIDEPOOL: Theme = {
     }
 
     // Shells and old bones worked into the sand, and a few gems in the bedrock.
-    for (let i = 0; i < 10; i++) {
+    for (let i = 0; i < across(10); i++) {
       const cx = Math.floor(rng() * WORLD_W)
       const cy = Math.floor(WORLD_H * (0.7 + rng() * 0.28))
       blob(tiles, cx, cy, 2 + Math.floor(rng() * 3), rng() < 0.6 ? 'bone' : 'gem', rng, [
@@ -449,7 +467,7 @@ const VOLCANIC: Theme = {
     }
 
     // Lava falls spilling down from the surface.
-    for (let i = 0; i < 4; i++) {
+    for (let i = 0; i < across(4); i++) {
       const cx = 12 + Math.floor(rng() * (WORLD_W - 24))
       let y = 0
       while (y < WORLD_H && tiles[y * WORLD_W + cx] === M.air) y++
@@ -461,7 +479,7 @@ const VOLCANIC: Theme = {
 
     // Crystal geodes and gem seams growing in the cooled rock, plus the bones
     // of whatever didn't get out in time.
-    for (let i = 0; i < 16; i++) {
+    for (let i = 0; i < across(16); i++) {
       const cx = Math.floor(rng() * WORLD_W)
       const cy = Math.floor(WORLD_H * (0.4 + rng() * 0.45))
       const roll = rng()
@@ -471,7 +489,7 @@ const VOLCANIC: Theme = {
 
     // A couple of acid pools sitting in the ash. They eat their way down and
     // then they're gone, which is exactly what makes them safe to leave here.
-    for (let i = 0; i < 2; i++) {
+    for (let i = 0; i < across(2); i++) {
       const cx = Math.floor(rng() * WORLD_W)
       let y = 0
       while (y < WORLD_H && tiles[y * WORLD_W + cx] === M.air) y++

--- a/src/app/micro-land/domain/config/themes.ts
+++ b/src/app/micro-land/domain/config/themes.ts
@@ -53,6 +53,51 @@ function rect(
   }
 }
 
+function tileAt(tiles: Uint8Array, x: number, y: number): number {
+  if (x < 0 || y < 0 || x >= WORLD_W || y >= WORLD_H) return -1
+  return tiles[y * WORLD_W + x]
+}
+
+/**
+ * Creep moss over any bare rock with open space above it.
+ *
+ * Run as a pass over the finished grid rather than inside the generator loop,
+ * because "is this tile exposed" is a question about neighbours that don't
+ * exist yet while the column is still being written.
+ */
+function mossify(tiles: Uint8Array, rng: Rng, chance: number, on: MaterialId[]) {
+  const allowed = new Set(on.map((id) => M[id]))
+  for (let y = 1; y < WORLD_H; y++) {
+    for (let x = 0; x < WORLD_W; x++) {
+      const here = tileAt(tiles, x, y)
+      if (!allowed.has(here)) continue
+      if (tileAt(tiles, x, y - 1) !== M.air) continue
+      if (rng() < chance) set(tiles, x, y, 'moss')
+    }
+  }
+}
+
+/** Drop a rough blob of material centred on a tile. Used for ore and pools. */
+function blob(
+  tiles: Uint8Array,
+  cx: number,
+  cy: number,
+  radius: number,
+  id: MaterialId,
+  rng: Rng,
+  into: MaterialId[]
+) {
+  const allowed = new Set(into.map((m) => M[m]))
+  for (let y = cy - radius; y <= cy + radius; y++) {
+    for (let x = cx - radius; x <= cx + radius; x++) {
+      const d = Math.hypot(x - cx, y - cy)
+      if (d > radius * (0.6 + rng() * 0.5)) continue
+      if (!allowed.has(tileAt(tiles, x, y))) continue
+      set(tiles, x, y, id)
+    }
+  }
+}
+
 // ---------------------------------------------------------------------------
 
 const EMPTY: Theme = {
@@ -69,37 +114,56 @@ const EMPTY: Theme = {
 const EARTH: Theme = {
   id: 'earth',
   name: 'Cross-Section',
-  blurb: 'Sky, grass, dirt, caves, and molten rock at the bottom.',
+  blurb: 'Snowy tops, grass, dirt, caves, and molten rock at the bottom.',
   sky: ['#7fc4e8', '#2a3a5c'],
   gloom: 0.34,
   gravity: 1,
   starters: [
-    { id: 'sunleaf', count: 44 },
-    { id: 'bramble', count: 14 },
-    { id: 'mite', count: 10 },
+    { id: 'sunleaf', count: 34 },
+    { id: 'bramble', count: 12 },
+    { id: 'glowvine', count: 8 },
+    { id: 'frostcap', count: 8 },
+    { id: 'sporecap', count: 4 },
+    { id: 'skybloom', count: 6 },
+    { id: 'mite', count: 8 },
+    { id: 'mote', count: 8 },
     { id: 'hopper', count: 6 },
-    { id: 'glimmer-moth', count: 6 },
+    { id: 'glimmer-moth', count: 5 },
+    { id: 'dustbee', count: 5 },
+    { id: 'loamworm', count: 4 },
+    { id: 'delver', count: 3 },
+    { id: 'woolly', count: 4 },
+    { id: 'driftmole', count: 3 },
     { id: 'stalker', count: 2 },
-    { id: 'delver', count: 4 },
-    { id: 'sporecap', count: 5 },
+    { id: 'sunhawk', count: 1 },
+    { id: 'rimeclaw', count: 1 },
   ],
   build: (tiles, rng) => {
     fill(tiles, 'air')
     const surfaceNoise = makeNoise2D(Math.floor(rng() * 1e9))
     const caveNoise = makeNoise2D(Math.floor(rng() * 1e9))
     const oreNoise = makeNoise2D(Math.floor(rng() * 1e9))
+    const treasureNoise = makeNoise2D(Math.floor(rng() * 1e9))
 
     const skyDepth = Math.floor(WORLD_H * 0.3)
+    // Anything this far above the average hilltop keeps its snow.
+    const snowLine = skyDepth - 4
 
     for (let x = 0; x < WORLD_W; x++) {
       // Rolling hills: a couple of octaves is enough at this width.
       const h = fbm(surfaceNoise, x * 0.035, 0.5, 3)
       const surface = Math.floor(skyDepth + (h - 0.5) * 18)
+      const snowy = surface < snowLine
+      const snowDepth = snowy ? 3 + Math.floor((snowLine - surface) / 3) : 0
 
       for (let y = surface; y < WORLD_H; y++) {
         const depth = (y - surface) / (WORLD_H - surface)
         let mat: MaterialId
-        if (y === surface) mat = 'grass'
+        // Loose snow on top of packed ice. Snow is a powder, so the top layer
+        // slides off the steep faces and drifts into the valleys the moment the
+        // world starts — the ice underneath is what keeps the peak white.
+        if (snowy && y - surface < snowDepth) mat = y - surface < 2 ? 'snow' : 'ice'
+        else if (y === surface) mat = 'grass'
         else if (depth < 0.22) mat = 'dirt'
         else if (depth > 0.9) mat = 'lava'
         else mat = 'stone'
@@ -115,11 +179,22 @@ const EARTH: Theme = {
           if (o > 0.88) mat = 'water'
           else if (o < 0.08) mat = 'sand'
         }
+        // Things worth digging for. Deeper is better, which is the point:
+        // gold and crystal sit below the lava-adjacent rock, so getting there
+        // costs something.
+        if (mat === 'stone') {
+          const t = treasureNoise(x * 0.19, y * 0.19)
+          if (depth > 0.6 && t > 0.93) mat = 'gold'
+          else if (depth > 0.7 && t < 0.05) mat = 'crystal'
+          else if (depth > 0.45 && t > 0.895 && t <= 0.93) mat = 'gem'
+          else if (depth > 0.2 && depth < 0.45 && t < 0.06) mat = 'bone'
+        }
         set(tiles, x, y, mat)
       }
     }
 
-    // A shallow pond or two on the surface.
+    // A shallow pond or two on the surface, with mud round the rim — the one
+    // place on the map where the ground is both wet and fertile.
     const ponds = 2 + Math.floor(rng() * 2)
     for (let p = 0; p < ponds; p++) {
       const cx = Math.floor(rng() * WORLD_W)
@@ -132,8 +207,13 @@ const EARTH: Theme = {
         const t = 1 - Math.abs(x - cx) / (w + 1)
         const depth = Math.floor(t * 5)
         for (let d = 0; d < depth; d++) set(tiles, x, surface + d, 'water')
+        for (let d = depth; d < depth + 2; d++) {
+          if (tileAt(tiles, x, surface + d) === M.dirt) set(tiles, x, surface + d, 'mud')
+        }
       }
     }
+
+    mossify(tiles, rng, 0.4, ['stone', 'dirt'])
   },
 }
 
@@ -146,10 +226,15 @@ const STATION: Theme = {
   gravity: 0.35,
   starters: [
     { id: 'rustbot', count: 5 },
-    { id: 'sporecap', count: 18 },
+    { id: 'sporecap', count: 16 },
+    { id: 'skybloom', count: 5 },
     { id: 'drifter-jelly', count: 5 },
     { id: 'glimmer-moth', count: 7 },
     { id: 'mite', count: 8 },
+    { id: 'mote', count: 6 },
+    { id: 'dustbee', count: 3 },
+    { id: 'palecrawler', count: 4 },
+    { id: 'wisp', count: 4 },
   ],
   build: (tiles, rng) => {
     fill(tiles, 'air')
@@ -192,7 +277,12 @@ const STATION: Theme = {
     for (const room of rooms) {
       // Skip a few rooms entirely — a station with holes in it reads as broken.
       if (rng() < 0.18) continue
-      rect(tiles, room.x0, room.y0, room.x1, room.y1, 'metal')
+      // Different decks were built by different people. Rusted iron reads as
+      // the old part of the station, marble as the part somebody cared about.
+      const shellRoll = rng()
+      const shell: MaterialId =
+        shellRoll < 0.18 ? 'iron' : shellRoll < 0.26 ? 'marble' : 'metal'
+      rect(tiles, room.x0, room.y0, room.x1, room.y1, shell)
       rect(tiles, room.x0 + 2, room.y0 + 2, room.x1 - 2, room.y1 - 2, 'air')
 
       // Viewports.
@@ -214,14 +304,23 @@ const STATION: Theme = {
       if (roll < 0.2) {
         rect(tiles, room.x0 + 3, room.y1 - 6, room.x0 + 10, room.y1 - 3, 'water')
       } else if (roll < 0.32) {
-        rect(tiles, room.x0 + 4, room.y1 - 4, room.x0 + 9, room.y1 - 3, 'metal')
+        rect(tiles, room.x0 + 4, room.y1 - 4, room.x0 + 9, room.y1 - 3, 'iron')
+      } else if (roll < 0.44) {
+        // Stacked supply crates.
+        rect(tiles, room.x0 + 4, room.y1 - 5, room.x0 + 7, room.y1 - 3, 'plastic')
       }
       if (rng() < 0.65) {
         const bedX = room.x0 + 3
         const bedW = Math.max(4, Math.floor((room.x1 - room.x0) * 0.5))
         rect(tiles, bedX, room.y1 - 3, bedX + bedW, room.y1 - 3, 'dirt')
+        // Long-abandoned beds have gone over to mud and moss.
+        if (rng() < 0.5) {
+          rect(tiles, bedX, room.y1 - 3, bedX + Math.floor(bedW / 2), room.y1 - 3, 'mud')
+        }
       }
     }
+
+    mossify(tiles, rng, 0.12, ['dirt', 'mud'])
   },
 }
 
@@ -233,10 +332,14 @@ const TIDEPOOL: Theme = {
   gloom: 0.22,
   gravity: 1,
   starters: [
-    { id: 'kelp', count: 34 },
+    { id: 'kelp', count: 30 },
     { id: 'sunleaf', count: 8 },
+    { id: 'skybloom', count: 4 },
     { id: 'finling', count: 10 },
     { id: 'mite', count: 6 },
+    { id: 'mote', count: 6 },
+    { id: 'dustbee', count: 4 },
+    { id: 'crystal-snail', count: 4 },
     { id: 'gulper', count: 2 },
     { id: 'drifter-jelly', count: 4 },
   ],
@@ -254,7 +357,8 @@ const TIDEPOOL: Theme = {
       for (let y = waterLine; y < floor; y++) set(tiles, x, y, 'water')
       for (let y = floor; y < WORLD_H; y++) {
         const depth = y - floor
-        set(tiles, x, y, depth < 3 ? 'sand' : 'stone')
+        // Sand on top, then the silt that collects under it, then bedrock.
+        set(tiles, x, y, depth < 3 ? 'sand' : depth < 6 ? 'mud' : 'stone')
       }
 
       // Rock shelves that break the surface — the tide leaves these dry.
@@ -280,6 +384,20 @@ const TIDEPOOL: Theme = {
         for (let d = 0; d < Math.floor(t * 4); d++) set(tiles, x, y + d, 'water')
       }
     }
+
+    // Shells and old bones worked into the sand, and a few gems in the bedrock.
+    for (let i = 0; i < 10; i++) {
+      const cx = Math.floor(rng() * WORLD_W)
+      const cy = Math.floor(WORLD_H * (0.7 + rng() * 0.28))
+      blob(tiles, cx, cy, 2 + Math.floor(rng() * 3), rng() < 0.6 ? 'bone' : 'gem', rng, [
+        'stone',
+        'sand',
+        'mud',
+      ])
+    }
+
+    // The wet rock above the tideline is where everything green gets a hold.
+    mossify(tiles, rng, 0.5, ['stone'])
   },
 }
 
@@ -292,11 +410,16 @@ const VOLCANIC: Theme = {
   gravity: 1,
   starters: [
     { id: 'sporecap', count: 20 },
+    { id: 'glowvine', count: 8 },
     { id: 'ember-grub', count: 7 },
     { id: 'cinder-wyrm', count: 3 },
     { id: 'mite', count: 6 },
     { id: 'delver', count: 3 },
+    { id: 'loamworm', count: 3 },
+    { id: 'crystal-snail', count: 4 },
     { id: 'rustbot', count: 2 },
+    { id: 'wisp', count: 4 },
+    { id: 'grumblestone', count: 2 },
   ],
   build: (tiles, rng) => {
     fill(tiles, 'air')
@@ -333,6 +456,29 @@ const VOLCANIC: Theme = {
       const w = 1 + Math.floor(rng() * 2)
       for (let d = 0; d < 18; d++) {
         for (let x = cx - w; x <= cx + w; x++) set(tiles, x, y + d, 'lava')
+      }
+    }
+
+    // Crystal geodes and gem seams growing in the cooled rock, plus the bones
+    // of whatever didn't get out in time.
+    for (let i = 0; i < 16; i++) {
+      const cx = Math.floor(rng() * WORLD_W)
+      const cy = Math.floor(WORLD_H * (0.4 + rng() * 0.45))
+      const roll = rng()
+      const id: MaterialId = roll < 0.45 ? 'crystal' : roll < 0.75 ? 'gem' : 'bone'
+      blob(tiles, cx, cy, 2 + Math.floor(rng() * 3), id, rng, ['stone', 'obsidian', 'ash'])
+    }
+
+    // A couple of acid pools sitting in the ash. They eat their way down and
+    // then they're gone, which is exactly what makes them safe to leave here.
+    for (let i = 0; i < 2; i++) {
+      const cx = Math.floor(rng() * WORLD_W)
+      let y = 0
+      while (y < WORLD_H && tiles[y * WORLD_W + cx] === M.air) y++
+      const w = 2 + Math.floor(rng() * 3)
+      for (let x = cx - w; x <= cx + w; x++) {
+        const t = 1 - Math.abs(x - cx) / (w + 1)
+        for (let d = 0; d < Math.floor(t * 3); d++) set(tiles, x, y + d, 'acid')
       }
     }
   },

--- a/src/app/micro-land/domain/constants.ts
+++ b/src/app/micro-land/domain/constants.ts
@@ -1,0 +1,100 @@
+/** World tuning. One place to change the feel of everything. */
+
+/** World size in tiles. Everything is drawn at 1 pixel per tile, then scaled up. */
+export const WORLD_W = 224
+export const WORLD_H = 132
+
+/** Fixed simulation step. */
+export const TICK_MS = 1000 / 60
+export const TICK_S = TICK_MS / 1000
+
+/** Tile physics runs every N sim ticks — 20Hz reads as liquid, 60Hz as frantic. */
+export const TILE_TICK_EVERY = 3
+
+/** Base downward acceleration, tiles/second². */
+export const GRAVITY = 34
+
+/** Terminal fall speed, tiles/second. Stops tunnelling through thin floors. */
+export const MAX_FALL = 46
+
+/** Hard population ceiling. Past this, nothing new is born (summoning still works). */
+export const MAX_CREATURES = 340
+
+/**
+ * Hard ceiling on plants, so they can't blanket the world.
+ *
+ * This is an absolute count, not a share of the population, and that matters in
+ * both directions. As a share it is self-defeating: a theme that starts with
+ * more plants than grazers is over the cap on frame one and can never spread,
+ * so the meadow only ever shrinks — and after a crash, a world of nothing but
+ * plants is permanently at 100% and can never regrow either.
+ */
+export const MAX_PLANTS = 150
+
+/** Seconds a drowning creature survives underwater. */
+export const BREATH_SECONDS = 9
+
+/** Cooldown after breeding, seconds. */
+export const BREED_COOLDOWN = 12
+
+/**
+ * Plants play by different rules, and they have to.
+ *
+ * A grazer empties its stomach every ~15s, so a dozen of them strip the map far
+ * faster than anything gated on a fraction of a 260-second lifespan can grow
+ * back — the plants vanish, then everything that eats plants starves, then
+ * everything that eats *those* starves. Plants mature in seconds and spread
+ * often, and MAX_PLANT_SHARE is what stops that from becoming a green carpet.
+ */
+export const PLANT_MATURITY = 6
+export const PLANT_SPREAD_COOLDOWN = 9
+
+/**
+ * How much fullness a meal restores, and what breeding costs.
+ *
+ * Keep the cost above the meal: if one meal more than pays for a child, grazers
+ * breed on every full stomach, overshoot the plants, and take the whole food
+ * chain down with them.
+ */
+export const MEAL_VALUE = 0.42
+export const BREED_COST = 0.55
+
+/**
+ * Seed rain.
+ *
+ * Left alone, a grazer boom strips the last plant and then starves — and a
+ * world at zero plants can never come back, because plants only come from other
+ * plants. Real meadows recover because seed blows in from outside the meadow;
+ * this is that, and it is the difference between a world that breathes and a
+ * world you have to restart.
+ *
+ * It only fires while something is still alive, so pressing Empty leaves the
+ * world empty.
+ */
+export const PLANT_FLOOR = 6
+export const SEED_RAIN_INTERVAL = 4
+
+/**
+ * Carrying capacity for a single animal species.
+ *
+ * Without predator pressure a grazer grows until it hits the global population
+ * ceiling — 234 hoppers on a map that can feed maybe 60 — and then the entire
+ * species starves at once. This is the environment saying "there is only so much
+ * room here" and is what turns a terminal crash into an oscillation.
+ */
+export const SPECIES_SOFT_CAP = 70
+
+/**
+ * Carrying capacity for a single *plant* species.
+ *
+ * Plants share the MAX_PLANTS budget, so without a per-species limit whichever
+ * one happens to spread fastest takes the entire allowance and the world becomes
+ * a monoculture — which then starves out every grazer too small to eat it.
+ * Keeping this well under MAX_PLANTS is what leaves room for a mixed meadow.
+ */
+export const PLANT_SPECIES_CAP = 55
+
+/** Particle lifetime range, seconds. */
+export const PARTICLE_LIFE = 0.9
+
+export const MAX_PARTICLES = 400

--- a/src/app/micro-land/domain/constants.ts
+++ b/src/app/micro-land/domain/constants.ts
@@ -60,19 +60,44 @@ export const MEAL_VALUE = 0.42
 export const BREED_COST = 0.55
 
 /**
- * Seed rain.
+ * Seed rain — animals.
  *
- * Left alone, a grazer boom strips the last plant and then starves — and a
- * world at zero plants can never come back, because plants only come from other
- * plants. Real meadows recover because seed blows in from outside the meadow;
- * this is that, and it is the difference between a world that breathes and a
- * world you have to restart.
- *
- * It only fires while something is still alive, so pressing Empty leaves the
- * world empty.
+ * A native that has died out comes back once there is something alive for it to
+ * eat again. It only fires while something is still alive, so pressing Empty
+ * leaves the world empty.
  */
-export const PLANT_FLOOR = 6
 export const SEED_RAIN_INTERVAL = 4
+
+/**
+ * Native plants — the ground's own seed bank.
+ *
+ * Plants are the only thing in the world with no upstream: a grazer boom strips
+ * the last one and then nothing can ever bring it back, because plants only come
+ * from plants. Everything downstream starves and the world is a restart.
+ *
+ * So the *ground* holds the seed instead of the plants. The first time a world
+ * has soil in it, whichever species could live on that soil become its natives
+ * (see `establishNativePlants`), and from then on that soil keeps pushing the
+ * plant population back toward `NATIVE_PLANT_TARGET`. A meadow can be grazed
+ * flat and still come back, which is what makes a population renewable rather
+ * than merely long-lived.
+ *
+ * The target is a floor, not a quota. Well above it the ground does nothing at
+ * all and plants spread the ordinary way; the further below it the world falls,
+ * the harder the seed comes in. That asymmetry is deliberate — a constant
+ * trickle would just pin every world at MAX_PLANTS and turn it into a carpet.
+ */
+export const NATIVE_PLANT_TARGET = 45
+export const PLANT_SEED_INTERVAL = 3
+/** Most plants a single seeding may place, when the world is at zero. */
+export const PLANT_SEED_BATCH = 3
+/**
+ * How many species the ground picks when it establishes its natives.
+ *
+ * Fewer than are viable, on purpose: two worlds painted with the same soil
+ * should not grow the same flora.
+ */
+export const NATIVE_PLANT_SPECIES = 3
 
 /**
  * Carrying capacity for a single animal species.

--- a/src/app/micro-land/domain/constants.ts
+++ b/src/app/micro-land/domain/constants.ts
@@ -28,8 +28,13 @@ export const MAX_CREATURES = 340
  * more plants than grazers is over the cap on frame one and can never spread,
  * so the meadow only ever shrinks — and after a crash, a world of nothing but
  * plants is permanently at 100% and can never regrow either.
+ *
+ * Raised from 150 when the roster grew to seven plant species: the ceiling is
+ * shared, so every species added to a world takes its share out of everything
+ * else's, and a crowded world was starving its grazers rather than feeding more
+ * of them.
  */
-export const MAX_PLANTS = 150
+export const MAX_PLANTS = 195
 
 /** Seconds a drowning creature survives underwater. */
 export const BREATH_SECONDS = 9
@@ -117,7 +122,7 @@ export const SPECIES_SOFT_CAP = 70
  * a monoculture — which then starves out every grazer too small to eat it.
  * Keeping this well under MAX_PLANTS is what leaves room for a mixed meadow.
  */
-export const PLANT_SPECIES_CAP = 55
+export const PLANT_SPECIES_CAP = 46
 
 /** Particle lifetime range, seconds. */
 export const PARTICLE_LIFE = 0.9

--- a/src/app/micro-land/domain/constants.ts
+++ b/src/app/micro-land/domain/constants.ts
@@ -123,3 +123,27 @@ export const PLANT_SPECIES_CAP = 55
 export const PARTICLE_LIFE = 0.9
 
 export const MAX_PARTICLES = 400
+
+// ---------------------------------------------------------------------------
+// Records
+// ---------------------------------------------------------------------------
+
+/**
+ * How old something has to get before it can hold the longevity record.
+ *
+ * Without a floor the very first creature in a fresh land takes the record at
+ * one hundredth of a second and wears its halo immediately, which makes the mark
+ * meaningless and puts it on screen constantly — the opposite of the intent.
+ * Sixty seconds is long enough that most things are eaten first, so an elder is
+ * genuinely something that survived rather than something that merely spawned.
+ */
+export const ELDER_MIN_SECONDS = 60
+
+/**
+ * How long a land must hold together before its steady streak is worth showing.
+ *
+ * Below this the number would flicker on and off during the early churn while
+ * populations find their level, which reads as noise. Two minutes in, a streak
+ * means the food web actually settled.
+ */
+export const STEADY_SHOW_SECONDS = 120

--- a/src/app/micro-land/domain/constants.ts
+++ b/src/app/micro-land/domain/constants.ts
@@ -1,8 +1,37 @@
 /** World tuning. One place to change the feel of everything. */
 
-/** World size in tiles. Everything is drawn at 1 pixel per tile, then scaled up. */
-export const WORLD_W = 224
+/**
+ * World size in tiles. Everything is drawn at 1 pixel per tile, then scaled up.
+ *
+ * The world is three screens wide and one screen tall. It used to be exactly one
+ * screen of each, and the old width lives on as VIEW_W below — that is the part
+ * that matters, because the terrarium is only legible at a certain number of
+ * tiles across. A creature is 4-28 tiles; fit 672 of them into a phone and the
+ * whole world is smaller than the sprite you are trying to look at.
+ */
+export const WORLD_W = 672
 export const WORLD_H = 132
+
+/**
+ * How much world the camera shows at once, in tiles.
+ *
+ * This is the *zoom*, not a viewport size: the renderer sizes a tile so that
+ * VIEW_W of them span the canvas, which is exactly the scale the world had back
+ * when it was 224 wide and fully visible. A wide display gets to see more than
+ * VIEW_W tiles (height runs out first), a phone sees exactly this many. Either
+ * way a hopper is the same size it has always been.
+ */
+export const VIEW_W = 224
+
+/**
+ * How many times wider than one screen the world is.
+ *
+ * Counts tuned for a single screen — how many ponds, how many starting hoppers,
+ * how many of a species the land can carry — are all densities wearing an
+ * absolute number's clothing. Multiplying them by this is what stops a world
+ * three times the size from feeling three times as empty.
+ */
+export const WIDTH_SCALE = WORLD_W / VIEW_W
 
 /** Fixed simulation step. */
 export const TICK_MS = 1000 / 60
@@ -17,8 +46,15 @@ export const GRAVITY = 34
 /** Terminal fall speed, tiles/second. Stops tunnelling through thin floors. */
 export const MAX_FALL = 46
 
-/** Hard population ceiling. Past this, nothing new is born (summoning still works). */
-export const MAX_CREATURES = 340
+/**
+ * Hard population ceiling. Past this, nothing new is born (summoning still works).
+ *
+ * Scaled with the world rather than left alone, because this ceiling binds well
+ * before the per-species caps do — leaving it at a single screen's worth would
+ * have made a three-screen world one third as densely populated, which is the
+ * opposite of what a bigger world is for.
+ */
+export const MAX_CREATURES = Math.round(340 * WIDTH_SCALE)
 
 /**
  * Hard ceiling on plants, so they can't blanket the world.
@@ -34,7 +70,7 @@ export const MAX_CREATURES = 340
  * else's, and a crowded world was starving its grazers rather than feeding more
  * of them.
  */
-export const MAX_PLANTS = 195
+export const MAX_PLANTS = Math.round(195 * WIDTH_SCALE)
 
 /** Seconds a drowning creature survives underwater. */
 export const BREATH_SECONDS = 9
@@ -92,10 +128,17 @@ export const SEED_RAIN_INTERVAL = 4
  * the harder the seed comes in. That asymmetry is deliberate — a constant
  * trickle would just pin every world at MAX_PLANTS and turn it into a carpet.
  */
-export const NATIVE_PLANT_TARGET = 45
+export const NATIVE_PLANT_TARGET = Math.round(45 * WIDTH_SCALE)
 export const PLANT_SEED_INTERVAL = 3
-/** Most plants a single seeding may place, when the world is at zero. */
-export const PLANT_SEED_BATCH = 3
+/**
+ * Most plants a single seeding may place, when the world is at zero.
+ *
+ * Scaled along with the target, not left alone. The interval is a wall-clock
+ * rate, so a batch that doesn't grow with the world turns "a meadow can come
+ * back" into "a meadow comes back three times slower" — long enough that the
+ * grazers waiting on it starve again before it arrives.
+ */
+export const PLANT_SEED_BATCH = Math.round(3 * WIDTH_SCALE)
 /**
  * How many species the ground picks when it establishes its natives.
  *
@@ -112,7 +155,7 @@ export const NATIVE_PLANT_SPECIES = 3
  * species starves at once. This is the environment saying "there is only so much
  * room here" and is what turns a terminal crash into an oscillation.
  */
-export const SPECIES_SOFT_CAP = 70
+export const SPECIES_SOFT_CAP = Math.round(70 * WIDTH_SCALE)
 
 /**
  * Carrying capacity for a single *plant* species.
@@ -122,12 +165,12 @@ export const SPECIES_SOFT_CAP = 70
  * a monoculture — which then starves out every grazer too small to eat it.
  * Keeping this well under MAX_PLANTS is what leaves room for a mixed meadow.
  */
-export const PLANT_SPECIES_CAP = 46
+export const PLANT_SPECIES_CAP = Math.round(46 * WIDTH_SCALE)
 
 /** Particle lifetime range, seconds. */
 export const PARTICLE_LIFE = 0.9
 
-export const MAX_PARTICLES = 400
+export const MAX_PARTICLES = Math.round(400 * WIDTH_SCALE)
 
 // ---------------------------------------------------------------------------
 // Records

--- a/src/app/micro-land/domain/procedural.ts
+++ b/src/app/micro-land/domain/procedural.ts
@@ -1,0 +1,298 @@
+/**
+ * Offline creature generator.
+ *
+ * Two jobs. It's the fallback when there's no API key or the model call fails,
+ * and it's the reason summoning never dead-ends: a kid typing "a purple fire
+ * snail" always gets *something* purple and fire-proof back, even on a plane.
+ *
+ * It reads keywords out of the prompt, picks a body plan, and emits exactly the
+ * same object literal shape the model would.
+ */
+import { sanitizeBlueprint } from './blueprint'
+
+import type { CreatureBlueprint, LocomotionKind, MaterialId } from './types'
+
+function hashString(input: string): number {
+  let h = 2166136261
+  for (let i = 0; i < input.length; i++) {
+    h ^= input.charCodeAt(i)
+    h = Math.imul(h, 16777619)
+  }
+  return h >>> 0
+}
+
+function hsl(h: number, s: number, l: number): string {
+  const a = s * Math.min(l, 1 - l)
+  const f = (n: number) => {
+    const k = (n + h / 30) % 12
+    const c = l - a * Math.max(-1, Math.min(k - 3, Math.min(9 - k, 1)))
+    return Math.round(255 * c)
+      .toString(16)
+      .padStart(2, '0')
+  }
+  return `#${f(0)}${f(8)}${f(4)}`
+}
+
+const COLOR_WORDS: Record<string, number> = {
+  red: 0,
+  orange: 28,
+  amber: 40,
+  gold: 45,
+  yellow: 52,
+  lime: 85,
+  green: 130,
+  teal: 168,
+  cyan: 185,
+  blue: 215,
+  indigo: 245,
+  purple: 275,
+  violet: 282,
+  magenta: 305,
+  pink: 335,
+  rose: 345,
+}
+
+// --- body plans -------------------------------------------------------------
+
+type Shape = (b: string, d: string, e: string) => string[][]
+
+const SHAPES: Record<string, Shape> = {
+  blob: (b, d, e) => [
+    ['.bbbb.', 'bbbbbb', `bbb${e}bb`, 'bbbbbb', '.dddd.'].map((r) => r.replace(/b/g, b).replace(/d/g, d)),
+    ['.bbbb.', 'bbbbbb', `bbb${e}bb`, 'bbbbbb', '.d..d.'].map((r) => r.replace(/b/g, b).replace(/d/g, d)),
+  ],
+  bug: (b, d, e) => [
+    ['.bbbb.', `bbbbb${e}`, 'bbbbbb', 'd.dd.d'].map((r) => r.replace(/b/g, b).replace(/d/g, d)),
+    ['.bbbb.', `bbbbb${e}`, 'bbbbbb', '.dd.d.'].map((r) => r.replace(/b/g, b).replace(/d/g, d)),
+  ],
+  fish: (b, d, e) => [
+    ['d.bbbb.', `dbbbbb${e}`, 'dbbbbbb', 'd.bbbb.'].map((r) => r.replace(/b/g, b).replace(/d/g, d)),
+    ['..bbbb.', `.bbbbb${e}`, 'dbbbbbb', 'd.bbbb.'].map((r) => r.replace(/b/g, b).replace(/d/g, d)),
+  ],
+  winged: (b, d, e) => [
+    ['b.....b', 'bb...bb', '.bbbbb.', `..bb${e}..`, '..ddd..'].map((r) =>
+      r.replace(/b/g, b).replace(/d/g, d)
+    ),
+    ['.......', '.b...b.', 'bbbbbbb', `b.bb${e}.b`, '..ddd..'].map((r) =>
+      r.replace(/b/g, b).replace(/d/g, d)
+    ),
+  ],
+  beast: (b, d, e) => [
+    ['..bbbb..', `.bbbbbb${e}`, 'bbbbbbbb', '.dd..dd.', '.d....d.', '.d....d.'].map((r) =>
+      r.replace(/b/g, b).replace(/d/g, d)
+    ),
+    ['..bbbb..', `.bbbbbb${e}`, 'bbbbbbbb', '.dd..dd.', '.d....d.', '..d..d..'].map((r) =>
+      r.replace(/b/g, b).replace(/d/g, d)
+    ),
+  ],
+  plant: (b, d, e) => [
+    ['..b..', `.b${e}b.`, '..d..', '.bd..', '..d..', '..d..'].map((r) =>
+      r.replace(/b/g, b).replace(/d/g, d)
+    ),
+    ['..b..', `.b${e}b.`, '..d..', '..db.', '..d..', '..d..'].map((r) =>
+      r.replace(/b/g, b).replace(/d/g, d)
+    ),
+  ],
+  orb: (b, d, e) => [
+    ['.bbb.', `bb${e}bb`, 'bbbbb', 'bbbbb', '.bbb.'].map((r) =>
+      r.replace(/b/g, b).replace(/d/g, d)
+    ),
+    ['.ddd.', `db${e}bd`, 'dbbbd', 'dbbbd', '.ddd.'].map((r) =>
+      r.replace(/b/g, b).replace(/d/g, d)
+    ),
+  ],
+}
+
+// --- keyword reading --------------------------------------------------------
+
+interface Read {
+  kind: LocomotionKind
+  shape: keyof typeof SHAPES
+  eats: string[]
+  tags: string[]
+  size: number
+  immuneTo: MaterialId[]
+  needs: MaterialId[] | null
+  glow: number
+  hue: number | null
+}
+
+function readPrompt(prompt: string): Read {
+  const lower = ` ${prompt.toLowerCase()} `
+
+  // Split "a snail that eats moss" into what it IS and what it EATS. Without
+  // this the body-plan keywords match on the food — "moss" makes the snail a
+  // plant — and you get a rooted shrub instead of an animal.
+  const eatsMatch = lower.match(/\b(?:that\s+)?(?:eats|eating|feeds\s+on|munches)\b/)
+  const t = eatsMatch ? lower.slice(0, eatsMatch.index) : lower
+  const food = eatsMatch ? lower.slice((eatsMatch.index ?? 0) + eatsMatch[0].length) : ''
+
+  const has = (...words: string[]) => words.some((word) => t.includes(word))
+  const foodHas = (...words: string[]) => words.some((word) => food.includes(word))
+
+  let kind: LocomotionKind = 'walk'
+  let shape: keyof typeof SHAPES = 'blob'
+
+  if (has('plant', 'tree', 'flower', 'vine', 'moss', 'mushroom', 'fungus', 'coral', 'seed')) {
+    kind = 'root'
+    shape = 'plant'
+  } else if (has('fish', 'shark', 'eel', 'squid', 'octopus', 'whale', 'seahorse')) {
+    kind = 'swim'
+    shape = 'fish'
+  } else if (has('bird', 'moth', 'butterfly', 'bat', 'fairy', 'dragon', 'wasp', 'bee', 'fly')) {
+    kind = 'fly'
+    shape = 'winged'
+  } else if (has('snail', 'slug', 'spider', 'worm', 'grub', 'crawl', 'centipede')) {
+    kind = 'crawl'
+    shape = 'bug'
+  } else if (has('jelly', 'balloon', 'cloud', 'ghost', 'spirit', 'float', 'drift', 'bubble')) {
+    kind = 'drift'
+    shape = 'orb'
+  } else if (has('wolf', 'cat', 'dog', 'bear', 'lion', 'tiger', 'beast', 'monster', 'hound')) {
+    kind = 'walk'
+    shape = 'beast'
+  } else if (has('bug', 'beetle', 'ant', 'mite', 'roach', 'cricket')) {
+    kind = 'walk'
+    shape = 'bug'
+  }
+
+  // Diet. An explicit "eats ..." clause wins; otherwise anything that sounds
+  // toothy eats meat and the rest graze.
+  const eatsMeat = foodHas('meat', 'bug', 'fish', 'bird', 'animal', 'creature', 'flesh')
+  const eatsPlant = foodHas('plant', 'moss', 'leaf', 'leaves', 'grass', 'fungus', 'mushroom', 'algae', 'kelp', 'seed', 'fruit')
+  const predator =
+    eatsMeat ||
+    (!eatsPlant &&
+      has(
+        'predator', 'hunt', 'carnivore', 'fangs', 'teeth', 'claws', 'fierce',
+        'shark', 'wolf', 'lion', 'tiger', 'monster', 'dragon', 'spider'
+      ))
+  const eats = kind === 'root' ? [] : predator ? ['meat'] : ['plant']
+
+  let size = kind === 'root' ? 1 : predator ? 3 : 2
+  if (has('tiny', 'small', 'little', 'mini', 'micro', 'baby')) size = 1
+  if (has('big', 'large', 'giant', 'huge', 'massive', 'enormous', 'king')) size = 5
+
+  const fireproof = has('fire', 'flame', 'lava', 'magma', 'ember', 'cinder', 'molten', 'volcano')
+  const glow =
+    has('glow', 'light', 'lumin', 'shine', 'star', 'neon', 'spark', 'ghost') ? 0.7 : 0
+
+  let hue: number | null = null
+  for (const [word, h] of Object.entries(COLOR_WORDS)) {
+    if (t.includes(word)) {
+      hue = h
+      break
+    }
+  }
+  if (hue === null && fireproof) hue = 18
+
+  const tags = [kind === 'root' ? 'plant' : 'meat']
+  if (shape === 'bug') tags.push('bug')
+  if (shape === 'fish') tags.push('fish')
+  if (shape === 'winged') tags.push('bug')
+  if (shape === 'beast') tags.push('beast')
+  if (glow > 0) tags.push('glow')
+
+  return {
+    kind,
+    shape,
+    eats,
+    tags,
+    size,
+    immuneTo: fireproof ? ['lava'] : [],
+    needs: kind === 'swim' ? ['water'] : null,
+    glow,
+    hue,
+  }
+}
+
+function titleCase(input: string): string {
+  return input
+    .split(/\s+/)
+    .filter(Boolean)
+    .slice(0, 3)
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
+    .join(' ')
+}
+
+/** Build a complete blueprint from a description, with no model involved. */
+export function proceduralCreature(prompt: string): CreatureBlueprint {
+  const seed = hashString(prompt)
+  const read = readPrompt(prompt)
+
+  const hue = read.hue ?? seed % 360
+  const body = hsl(hue, 0.62, 0.55)
+  const shade = hsl(hue, 0.55, 0.32)
+  const eye = read.glow > 0 ? hsl((hue + 40) % 360, 1, 0.85) : '#ffffff'
+
+  const frames = SHAPES[read.shape]('b', 'd', 'e')
+
+  const name =
+    titleCase(prompt.replace(/[^a-zA-Z ]/g, '').trim()) || 'Mystery Thing'
+
+  return sanitizeBlueprint(
+    {
+      name,
+      blurb: `Summoned from the words "${prompt.trim().slice(0, 60)}".`,
+      size: read.size,
+      tags: read.tags,
+      art: {
+        palette: { b: body, d: shade, e: eye },
+        frames,
+        frameMs: read.kind === 'fly' ? 120 : 200,
+        faceMotion: read.kind !== 'root' && read.shape !== 'orb',
+      },
+      body: {
+        mass: read.kind === 'fly' ? 0.2 : read.kind === 'drift' ? 0.15 : 1,
+        bounce: read.kind === 'drift' ? 0.35 : 0.12,
+        drag: 0.4,
+        buoyancy: read.kind === 'drift' ? 1.25 : 0.9,
+        immuneTo: read.immuneTo,
+      },
+      move: {
+        kind: read.kind,
+        speed: read.kind === 'root' ? 0 : 3 + (seed % 5),
+        jump: 9,
+        restlessness: 0.3,
+      },
+      diet: {
+        eats: read.eats,
+        fears: [],
+        hungerRate: read.kind === 'root' ? 0 : 0.03,
+        starveSeconds: read.kind === 'root' ? 999 : 30,
+        breedAt: read.kind === 'root' ? 0.25 : 0.75,
+        lifespanSeconds: 220 + (seed % 160),
+      },
+      senses: { sight: 18 },
+      habitat: { needs: read.needs, drowns: read.kind !== 'swim' },
+      death: {
+        becomes: null,
+        particleColor: body,
+        particleCount: 7,
+      },
+      glow: read.glow,
+    },
+    { summoned: true }
+  )
+}
+
+/** A small self-contained food chain, for scene mode without a model. */
+export function proceduralScene(prompt: string): {
+  title: string
+  note: string
+  creatures: (CreatureBlueprint & { count: number })[]
+} {
+  const base = proceduralCreature(prompt)
+  const grazer = proceduralCreature(`${prompt} tiny grazer`)
+  const grower = proceduralCreature(`${prompt} glowing moss plant`)
+
+  return {
+    title: titleCase(prompt) || 'A Small World',
+    note: 'Made without the summoning circle — the plants feed the grazers, and the big one eats both.',
+    creatures: [
+      { ...grower, count: 16 },
+      { ...grazer, count: 10 },
+      { ...base, count: 3 },
+    ],
+  }
+}

--- a/src/app/micro-land/domain/sim/creature-sim.ts
+++ b/src/app/micro-land/domain/sim/creature-sim.ts
@@ -81,6 +81,48 @@ export interface SimEvent {
 
 let tickCount = 0
 
+/**
+ * The population sorted left to right, reused between ticks.
+ *
+ * `look` used to walk the entire population to find the handful of things within
+ * an 18-tile line of sight. That was tolerable when the world was one screen
+ * wide, and stops being tolerable at three: the population cap scales with the
+ * area, so the all-pairs cost scales with its *square* while the number of
+ * creatures actually near you doesn't change at all.
+ *
+ * Sorting by x and walking only the slice within reach makes the cost track the
+ * local crowd instead of the headcount. The array is nearly sorted every tick —
+ * nothing moves far in 1/60th of a second — which is the case sort is fastest
+ * at, and it is kept around rather than rebuilt so a busy world isn't handing
+ * the collector a thousand-element array sixty times a second.
+ */
+const byX: Creature[] = []
+
+/**
+ * Slack either side of the sight window, in tiles.
+ *
+ * Sorting is on the sprite's left edge but sight is measured from its centre,
+ * so a wide creature's edge can sit well outside the window its centre falls in.
+ * Covers the widest sprite plus a tick's worth of drift since the sort.
+ */
+const SIGHT_PAD = 20
+
+function compareX(a: Creature, b: Creature): number {
+  return a.x - b.x
+}
+
+/** First index whose x is not less than `x`. The array must be sorted. */
+function lowerBound(list: Creature[], x: number): number {
+  let lo = 0
+  let hi = list.length
+  while (lo < hi) {
+    const mid = (lo + hi) >> 1
+    if (list[mid].x < x) lo = mid + 1
+    else hi = mid
+  }
+  return lo
+}
+
 export function tickCreatures(
   w: WorldState,
   dt: number,
@@ -116,6 +158,11 @@ export function tickCreatures(
   for (const c of creatures) {
     if (w.blueprints[c.blueprintId]?.aura) helpers.push(c)
   }
+
+  // Rebuilt in place, then sorted, once for every creature that looks this tick.
+  byX.length = creatures.length
+  for (let i = 0; i < creatures.length; i++) byX[i] = creatures[i]
+  byX.sort(compareX)
 
   for (const c of creatures) {
     if (dead.has(c.id)) continue
@@ -272,7 +319,13 @@ function look(
   let prey: Creature | null = null
   let preyDist = Infinity
 
-  for (const other of w.creatures) {
+  // Only the creatures whose left edge falls in the sight window can possibly
+  // be in range; everything beyond the window is skipped without being touched.
+  const reach = bp.senses.sight + SIGHT_PAD
+  const last = cx + reach
+  for (let i = lowerBound(byX, cx - reach); i < byX.length; i++) {
+    const other = byX[i]
+    if (other.x > last) break
     if (other.id === c.id || dead.has(other.id)) continue
     const obp = w.blueprints[other.blueprintId]
     if (!obp) continue

--- a/src/app/micro-land/domain/sim/creature-sim.ts
+++ b/src/app/micro-land/domain/sim/creature-sim.ts
@@ -1,0 +1,723 @@
+/**
+ * Creature behavior — hunger, hunting, fleeing, breeding, dying.
+ *
+ * Nothing in here knows about any specific creature. Every decision reads the
+ * blueprint, which is why a creature invented at runtime behaves as completely
+ * as one that shipped with the game.
+ *
+ * The sense pass (who can I eat, who is about to eat me) is O(n²), so it runs
+ * at 10Hz with creatures staggered across ticks rather than every frame.
+ */
+import { artSize, canEat, fears } from '@/app/micro-land/domain/blueprint'
+import { MATERIAL_INDEX } from '@/app/micro-land/domain/config/materials'
+import {
+  BREATH_SECONDS,
+  BREED_COOLDOWN,
+  BREED_COST,
+  GRAVITY,
+  MAX_CREATURES,
+  MAX_FALL,
+  MAX_PARTICLES,
+  MAX_PLANTS,
+  MEAL_VALUE,
+  PARTICLE_LIFE,
+  PLANT_MATURITY,
+  PLANT_SPECIES_CAP,
+  PLANT_SPREAD_COOLDOWN,
+  SPECIES_SOFT_CAP,
+  WORLD_H,
+  WORLD_W,
+} from '@/app/micro-land/domain/constants'
+import type { Creature, CreatureBlueprint, WorldState } from '@/app/micro-land/domain/types'
+
+import {
+  boxDeadlyMaterial,
+  boxHitsSolid,
+  boxLiquidFraction,
+  inBounds,
+  repopulate,
+  setTile,
+  settleOnGround,
+  solidAt,
+  spawnCreature,
+  tileAt,
+} from './world'
+
+import type { Rng } from './prng'
+
+/** How often each creature looks around, in sim ticks. */
+const SENSE_EVERY = 6
+
+/**
+ * How much the two bodies have to overlap to count as a bite, in tiles.
+ *
+ * This is deliberately a box-overlap test rather than a distance between
+ * centres. Centre-to-centre punishes big creatures for being big: a Stalker is
+ * 8x6, so its own centre sits ~4 tiles behind its nose, and a fixed radius small
+ * enough to look like "touching" for a Mite meant a Stalker had to be almost
+ * perfectly superimposed on its prey to land a bite. Stationary plants still got
+ * eaten — grazers walk onto them and linger — so the food chain looked like it
+ * worked while predation on anything that moved almost never fired.
+ */
+const BITE_PAD = 0.5
+
+export interface SimEvent {
+  /**
+   * `eaten` is from the victim's side (this species lost one); `ate` is from the
+   * hunter's side and carries who it caught. Both fire for a single kill — the
+   * UI wants the hunter's framing, the extinction check wants the victim's.
+   */
+  kind: 'born' | 'eaten' | 'ate' | 'starved' | 'drowned' | 'burned' | 'aged'
+  blueprintId: string
+  /** Only set on `ate`: the blueprint id of what was caught. */
+  victimId?: string
+  x: number
+  y: number
+}
+
+let tickCount = 0
+
+export function tickCreatures(
+  w: WorldState,
+  dt: number,
+  rng: Rng,
+  gravityScale: number,
+  events: SimEvent[]
+): void {
+  tickCount++
+
+  const creatures = w.creatures
+  const dead = new Set<number>()
+
+  // Plants are capped as a share of the population so they can't carpet the map.
+  let plantCount = 0
+  for (const c of creatures) {
+    if (w.blueprints[c.blueprintId]?.move.kind === 'root') plantCount++
+  }
+  // Tracked live rather than snapshotted: every eligible plant breeds in the
+  // same tick, so a snapshot taken up here lets 150 plants become 300 before
+  // the cap is ever re-read.
+  let plantsAlive = plantCount
+
+  // Per-species headcount, so no single animal can eat the world on its own.
+  const speciesCount: Record<string, number> = {}
+  for (const c of creatures) {
+    speciesCount[c.blueprintId] = (speciesCount[c.blueprintId] ?? 0) + 1
+  }
+
+  for (const c of creatures) {
+    if (dead.has(c.id)) continue
+    const bp = w.blueprints[c.blueprintId]
+    if (!bp) {
+      dead.add(c.id)
+      continue
+    }
+
+    const { w: bw, h: bh } = artSize(bp)
+
+    c.ageSeconds += dt
+    c.animMs += dt * 1000
+    if (c.breedCooldown > 0) c.breedCooldown -= dt
+
+    // --- hunger ---------------------------------------------------------
+    c.hunger = Math.min(1, c.hunger + bp.diet.hungerRate * dt)
+    if (c.hunger >= 1) {
+      c.starving += dt
+      if (c.starving >= bp.diet.starveSeconds) {
+        kill(w, c, bp, dead, events, 'starved')
+        continue
+      }
+    } else {
+      c.starving = Math.max(0, c.starving - dt * 2)
+    }
+
+    // --- old age --------------------------------------------------------
+    if (c.ageSeconds >= bp.diet.lifespanSeconds) {
+      kill(w, c, bp, dead, events, 'aged')
+      continue
+    }
+
+    // --- environment ----------------------------------------------------
+    const wet = boxLiquidFraction(w, c.x, c.y, bw, bh)
+    const deadlyMat = boxDeadlyMaterial(w, c.x, c.y, bw, bh)
+    if (deadlyMat !== null) {
+      const immune = bp.body.immuneTo.some((m) => MATERIAL_INDEX[m] === deadlyMat)
+      if (!immune) {
+        kill(w, c, bp, dead, events, 'burned')
+        continue
+      }
+    }
+
+    // One timer, two ways to be in the wrong place.
+    let inTrouble = false
+    if (bp.habitat.needs && bp.habitat.needs.length > 0) {
+      const needsWater = bp.habitat.needs.includes('water')
+      if (needsWater && wet < 0.25) inTrouble = true
+    }
+    if (bp.habitat.drowns && wet > 0.7) inTrouble = true
+
+    if (inTrouble) {
+      c.distress += dt
+      if (c.distress >= BREATH_SECONDS) {
+        kill(w, c, bp, dead, events, 'drowned')
+        continue
+      }
+    } else {
+      c.distress = Math.max(0, c.distress - dt * 1.5)
+    }
+
+    // --- senses ---------------------------------------------------------
+    if ((tickCount + c.id) % SENSE_EVERY === 0) {
+      look(w, c, bp, bw, bh, dead, events)
+    }
+
+    // --- movement -------------------------------------------------------
+    if (bp.move.kind !== 'root') {
+      steer(w, c, bp, dt, rng)
+      integrate(w, c, bp, bw, bh, dt, wet, gravityScale)
+    }
+
+    // --- breeding -------------------------------------------------------
+    const fullness = 1 - c.hunger
+    const isPlant = bp.move.kind === 'root'
+    // Plants photosynthesise: spreading costs them nothing. Charging them the
+    // usual hunger cost would sterilise them permanently — their hungerRate is
+    // 0, so the debt could never be paid back and each plant would breed twice
+    // in its entire life.
+    const maturity = isPlant ? PLANT_MATURITY : bp.diet.lifespanSeconds * 0.2
+    if (
+      c.breedCooldown <= 0 &&
+      fullness >= bp.diet.breedAt &&
+      c.ageSeconds > maturity &&
+      creatures.length < MAX_CREATURES &&
+      !(isPlant && plantsAlive >= MAX_PLANTS) &&
+      (speciesCount[bp.id] ?? 0) < (isPlant ? PLANT_SPECIES_CAP : SPECIES_SOFT_CAP)
+    ) {
+      const child = reproduce(w, c, bp, bw, bh, rng)
+      if (child) {
+        c.children++
+        if (isPlant) plantsAlive++
+        else c.hunger = Math.min(1, c.hunger + BREED_COST)
+        speciesCount[bp.id] = (speciesCount[bp.id] ?? 0) + 1
+        c.breedCooldown = isPlant ? PLANT_SPREAD_COOLDOWN : BREED_COOLDOWN
+        events.push({ kind: 'born', blueprintId: bp.id, x: child.x, y: child.y })
+      } else {
+        // Nowhere to put it — wait a bit before trying again.
+        c.breedCooldown = 3
+      }
+    }
+  }
+
+  if (dead.size > 0) {
+    w.creatures = creatures.filter((c) => !dead.has(c.id))
+  }
+
+  repopulate(w, rng)
+
+  tickParticles(w, dt, gravityScale)
+}
+
+// ---------------------------------------------------------------------------
+// Senses
+// ---------------------------------------------------------------------------
+
+function look(
+  w: WorldState,
+  c: Creature,
+  bp: CreatureBlueprint,
+  bw: number,
+  bh: number,
+  dead: Set<number>,
+  events: SimEvent[]
+): void {
+  const sight2 = bp.senses.sight * bp.senses.sight
+  const cx = c.x + bw / 2
+  const cy = c.y + bh / 2
+  const hungry = c.hunger > 0.3
+
+  let threat: Creature | null = null
+  let threatDist = Infinity
+  let prey: Creature | null = null
+  let preyDist = Infinity
+
+  for (const other of w.creatures) {
+    if (other.id === c.id || dead.has(other.id)) continue
+    const obp = w.blueprints[other.blueprintId]
+    if (!obp) continue
+
+    const { w: ow, h: oh } = artSize(obp)
+    const dx = other.x + ow / 2 - cx
+    const dy = other.y + oh / 2 - cy
+    const d2 = dx * dx + dy * dy
+    if (d2 > sight2) continue
+
+    if (fears(bp, obp)) {
+      if (d2 < threatDist) {
+        threatDist = d2
+        threat = other
+      }
+      continue
+    }
+
+    if (hungry && canEat(bp, obp)) {
+      // Bodies touching? Eat now, don't bother pathing.
+      const touching =
+        Math.abs(dx) <= (bw + ow) / 2 + BITE_PAD &&
+        Math.abs(dy) <= (bh + oh) / 2 + BITE_PAD
+      if (touching) {
+        devour(w, other, obp, dead, events)
+        c.hunger = Math.max(0, c.hunger - MEAL_VALUE)
+        c.starving = 0
+        c.mealsEaten++
+        c.mood = 'eat'
+        c.targetId = null
+        events.push({
+          kind: 'ate',
+          blueprintId: bp.id,
+          victimId: obp.id,
+          x: c.x,
+          y: c.y,
+        })
+        return
+      }
+      if (d2 < preyDist) {
+        preyDist = d2
+        prey = other
+      }
+    }
+  }
+
+  if (threat) {
+    c.mood = 'flee'
+    c.targetId = threat.id
+  } else if (prey) {
+    c.mood = 'hunt'
+    c.targetId = prey.id
+  } else {
+    c.mood = c.hunger > 0.75 ? 'hunt' : 'wander'
+    c.targetId = null
+  }
+}
+
+function devour(
+  w: WorldState,
+  victim: Creature,
+  victimBp: CreatureBlueprint,
+  dead: Set<number>,
+  events: SimEvent[]
+): void {
+  if (dead.has(victim.id)) return
+  dead.add(victim.id)
+  const { w: vw, h: vh } = artSize(victimBp)
+  emitParticles(
+    w,
+    victim.x + vw / 2,
+    victim.y + vh / 2,
+    victimBp.death.particleColor,
+    victimBp.death.particleCount
+  )
+  events.push({
+    kind: 'eaten',
+    blueprintId: victimBp.id,
+    x: victim.x,
+    y: victim.y,
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Steering
+// ---------------------------------------------------------------------------
+
+function steer(
+  w: WorldState,
+  c: Creature,
+  bp: CreatureBlueprint,
+  dt: number,
+  rng: Rng
+): void {
+  const { w: bw, h: bh } = artSize(bp)
+  const cx = c.x + bw / 2
+  const cy = c.y + bh / 2
+
+  let wantX = 0
+  let wantY = 0
+
+  const target = c.targetId !== null ? findCreature(w, c.targetId) : null
+  if (target) {
+    const tbp = w.blueprints[target.blueprintId]
+    const size = tbp ? artSize(tbp) : { w: 1, h: 1 }
+    const dx = target.x + size.w / 2 - cx
+    const dy = target.y + size.h / 2 - cy
+    const len = Math.hypot(dx, dy) || 1
+    const sign = c.mood === 'flee' ? -1 : 1
+    wantX = (dx / len) * sign
+    wantY = (dy / len) * sign
+  } else {
+    // Idle wander. `restlessness` is how often it changes its mind.
+    if (rng() < bp.move.restlessness * dt * 4) {
+      c.drift = rng() * 2 - 1
+    }
+    wantX = c.drift
+    wantY = bp.move.kind === 'fly' || bp.move.kind === 'swim' ? (rng() - 0.5) * 0.6 : 0
+    c.targetId = null
+  }
+
+  const speed = bp.move.speed
+  const accel = speed * 6
+  const digger = bp.dig.through.length > 0
+
+  switch (bp.move.kind) {
+    case 'walk': {
+      c.vx += wantX * accel * dt
+      c.vx = clampMag(c.vx, speed)
+      // A burrower doesn't only dig when cornered — a well-fed one goes to
+      // ground and makes a warren. Only when well fed, or it would tunnel away
+      // from the food it needs and starve in the dark. How deep it gets is
+      // bounded by its own dig list: a Delver chews soil but not stone, so it
+      // hollows out the topsoil and stops there instead of reaching the lava.
+      if (digger && c.grounded && c.hunger < 0.4 && rng() < 0.6 * dt) {
+        c.vy = 6
+      }
+      // Jump when there's a wall in the way, or the target is overhead.
+      const ahead = Math.sign(c.vx) || c.facing
+      const blocked = solidAt(w, Math.floor(cx + ahead * (bw / 2 + 1)), Math.floor(cy))
+      const wantsUp = wantY < -0.4
+      if (c.grounded && (blocked || (wantsUp && rng() < 0.08))) {
+        c.vy = -bp.move.jump
+        c.grounded = false
+      }
+      break
+    }
+    case 'fly': {
+      c.vx += wantX * accel * dt
+      c.vy += wantY * accel * dt
+      c.vx = clampMag(c.vx, speed)
+      c.vy = clampMag(c.vy, speed)
+      break
+    }
+    case 'swim': {
+      const wet = boxLiquidFraction(w, c.x, c.y, bw, bh)
+      if (wet > 0.3) {
+        c.vx += wantX * accel * dt
+        c.vy += wantY * accel * dt
+        c.vx = clampMag(c.vx, speed)
+        c.vy = clampMag(c.vy, speed)
+      } else {
+        // Beached — flop uselessly and hope for the best.
+        if (c.grounded && rng() < 6 * dt) {
+          c.vy = -6
+          c.vx = (rng() - 0.5) * 6
+        }
+      }
+      break
+    }
+    case 'crawl': {
+      // Sticks to any surface, so it moves in 2D but only along walls.
+      const touching = touchesSurface(w, c, bw, bh)
+      if (touching) {
+        c.vx += wantX * accel * dt
+        c.vy += wantY * accel * dt
+        c.vx = clampMag(c.vx, speed)
+        c.vy = clampMag(c.vy, speed)
+      } else {
+        c.vx += wantX * accel * dt * 0.3
+      }
+      break
+    }
+    case 'drift': {
+      c.vx += wantX * accel * dt * 0.4
+      c.vy += wantY * accel * dt * 0.4
+      c.vx = clampMag(c.vx, speed)
+      c.vy = clampMag(c.vy, speed * 0.8)
+      break
+    }
+  }
+
+  if (bp.art.faceMotion && Math.abs(c.vx) > 0.2) {
+    c.facing = c.vx > 0 ? 1 : -1
+  }
+}
+
+function touchesSurface(w: WorldState, c: Creature, bw: number, bh: number): boolean {
+  const x0 = Math.floor(c.x) - 1
+  const x1 = Math.floor(c.x + bw - 0.001) + 1
+  const y0 = Math.floor(c.y) - 1
+  const y1 = Math.floor(c.y + bh - 0.001) + 1
+  for (let x = x0; x <= x1; x++) {
+    if (solidAt(w, x, y0) || solidAt(w, x, y1)) return true
+  }
+  for (let y = y0; y <= y1; y++) {
+    if (solidAt(w, x0, y) || solidAt(w, x1, y)) return true
+  }
+  return false
+}
+
+// ---------------------------------------------------------------------------
+// Physics
+// ---------------------------------------------------------------------------
+
+function integrate(
+  w: WorldState,
+  c: Creature,
+  bp: CreatureBlueprint,
+  bw: number,
+  bh: number,
+  dt: number,
+  wet: number,
+  gravityScale: number
+): void {
+  const kind = bp.move.kind
+  const inLiquid = wet > 0.3
+  const weightless = kind === 'fly' || (kind === 'crawl' && touchesSurface(w, c, bw, bh))
+
+  if (!weightless) {
+    let g = GRAVITY * bp.body.mass * gravityScale
+    if (inLiquid) {
+      // Buoyancy above 1 pushes up harder than gravity pulls down.
+      g *= 1 - bp.body.buoyancy
+    }
+    if (kind === 'drift') g *= 0.35
+    c.vy += g * dt
+  }
+
+  // Drag. `body.drag` is the fraction of speed kept per second.
+  const dragBase = inLiquid ? bp.body.drag * 0.45 : bp.body.drag
+  const keep = Math.pow(Math.max(0.001, dragBase), dt)
+  c.vx *= keep
+  if (weightless || inLiquid || kind === 'drift') c.vy *= keep
+
+  c.vy = Math.max(-MAX_FALL, Math.min(MAX_FALL, c.vy))
+  c.vx = Math.max(-MAX_FALL, Math.min(MAX_FALL, c.vx))
+
+  const canStepUp = kind === 'walk'
+  const digger = bp.dig.through.length > 0
+
+  // --- horizontal ---
+  const nx = c.x + c.vx * dt
+  if (!boxHitsSolid(w, nx, c.y, bw, bh)) {
+    c.x = nx
+  } else if (canStepUp && !boxHitsSolid(w, nx, c.y - 1, bw, bh)) {
+    // Walk up a single-tile ledge without needing to jump.
+    c.x = nx
+    c.y -= 1
+  } else if (digger && chewThrough(w, c, bp, nx, c.y, bw, bh, dt)) {
+    // Held against the rock while it works. The tunnel opens next tick.
+    c.vx *= 0.2
+  } else {
+    c.x = c.vx > 0 ? Math.floor(nx + bw - 0.001) - bw : Math.floor(nx) + 1
+    c.vx = -c.vx * bp.body.bounce
+    c.drift = -c.drift
+    c.facing = (c.facing === 1 ? -1 : 1) as 1 | -1
+  }
+
+  // --- vertical ---
+  c.grounded = false
+  const ny = c.y + c.vy * dt
+  if (!boxHitsSolid(w, c.x, ny, bw, bh)) {
+    c.y = ny
+  } else if (digger && chewThrough(w, c, bp, c.x, ny, bw, bh, dt)) {
+    c.vy *= 0.2
+    // A digger resting on rock it is actively burrowing into still counts as
+    // standing on something, or a walker would never get the jump to push down.
+    if (c.vy > 0) c.grounded = true
+  } else {
+    if (c.vy > 0) {
+      c.y = Math.floor(ny + bh - 0.001) - bh
+      c.grounded = true
+    } else {
+      c.y = Math.floor(ny) + 1
+    }
+    c.vy = Math.abs(c.vy) > 4 ? -c.vy * bp.body.bounce : 0
+  }
+
+  // Ground friction, so walkers don't skate.
+  if (c.grounded && kind === 'walk') c.vx *= Math.pow(0.02, dt)
+
+  // Belt and braces: never let anything escape the box.
+  c.x = Math.max(0, Math.min(WORLD_W - bw, c.x))
+  c.y = Math.max(0, Math.min(WORLD_H - bh, c.y))
+}
+
+/**
+ * Try to tunnel into whatever is blocking a move.
+ *
+ * Returns true when the creature is *able* to dig here — including while it is
+ * still part-way through a tile — so the caller stalls it against the rock
+ * instead of bouncing it off. Only one tile is removed per completed unit of
+ * progress, which is what makes a slow digger read as effort rather than a
+ * creature that phases through walls.
+ */
+function chewThrough(
+  w: WorldState,
+  c: Creature,
+  bp: CreatureBlueprint,
+  x: number,
+  y: number,
+  bw: number,
+  bh: number,
+  dt: number
+): boolean {
+  const diggable = new Set(bp.dig.through.map((m) => MATERIAL_INDEX[m]))
+
+  // Collect the blocking tiles this move would run into.
+  const x0 = Math.floor(x)
+  const y0 = Math.floor(y)
+  const x1 = Math.floor(x + bw - 0.001)
+  const y1 = Math.floor(y + bh - 0.001)
+
+  let targetX = -1
+  let targetY = -1
+  for (let ty = y0; ty <= y1 && targetX < 0; ty++) {
+    for (let tx = x0; tx <= x1; tx++) {
+      if (!solidAt(w, tx, ty)) continue
+      // Out of bounds reads as solid but isn't a real tile — never dig the walls
+      // of the world, or creatures escape the box entirely.
+      if (!inBounds(tx, ty)) return false
+      if (!diggable.has(tileAt(w, tx, ty))) return false
+      targetX = tx
+      targetY = ty
+      break
+    }
+  }
+  if (targetX < 0) return false
+
+  c.digProgress += bp.dig.speed * dt
+  if (c.digProgress >= 1) {
+    c.digProgress -= 1
+    setTile(w, targetX, targetY, MATERIAL_INDEX.air)
+    c.tilesDug++
+  }
+  return true
+}
+
+function clampMag(v: number, max: number): number {
+  return Math.max(-max, Math.min(max, v))
+}
+
+function findCreature(w: WorldState, id: number): Creature | null {
+  for (const c of w.creatures) if (c.id === id) return c
+  return null
+}
+
+// ---------------------------------------------------------------------------
+// Reproduction and death
+// ---------------------------------------------------------------------------
+
+function reproduce(
+  w: WorldState,
+  parent: Creature,
+  bp: CreatureBlueprint,
+  bw: number,
+  bh: number,
+  rng: Rng
+): Creature | null {
+  const isPlant = bp.move.kind === 'root'
+  const spread = isPlant ? 14 : 5
+
+  for (let attempt = 0; attempt < 12; attempt++) {
+    const x = parent.x + (rng() * 2 - 1) * spread
+    const y = parent.y + (rng() * 2 - 1) * (isPlant ? 6 : spread)
+    const cx = Math.max(0, Math.min(WORLD_W - bw, x))
+    const cy = Math.max(0, Math.min(WORLD_H - bh, y))
+
+    if (boxHitsSolid(w, cx, cy, bw, bh)) continue
+    if (boxDeadlyMaterial(w, cx, cy, bw, bh) !== null && bp.body.immuneTo.length === 0) {
+      continue
+    }
+
+    if (isPlant) {
+      // A seedling settles onto the first fertile ground below the spot we
+      // picked. Same trap as spawning: the tile under a box is
+      // `floor(y + bh - 0.001) + 1`, so `settleOnGround` owns that arithmetic.
+      const settled = settleOnGround(w, cx, cy, bw, bh, {
+        requireFertile: true,
+        maxDrop: 10,
+      })
+      if (settled === null) continue
+      return spawnCreature(w, bp, cx, settled)
+    }
+
+    const wet = boxLiquidFraction(w, cx, cy, bw, bh)
+    const needsWater = bp.move.kind === 'swim' || !!bp.habitat.needs?.includes('water')
+    if (needsWater && wet < 0.5) continue
+    if (!needsWater && bp.habitat.drowns && wet > 0.5) continue
+
+    return spawnCreature(w, bp, cx, cy)
+  }
+  return null
+}
+
+function kill(
+  w: WorldState,
+  c: Creature,
+  bp: CreatureBlueprint,
+  dead: Set<number>,
+  events: SimEvent[],
+  cause: SimEvent['kind']
+): void {
+  if (dead.has(c.id)) return
+  dead.add(c.id)
+  const { w: bw, h: bh } = artSize(bp)
+  emitParticles(
+    w,
+    c.x + bw / 2,
+    c.y + bh / 2,
+    bp.death.particleColor,
+    bp.death.particleCount
+  )
+  if (bp.death.becomes) {
+    setTile(
+      w,
+      Math.floor(c.x + bw / 2),
+      Math.floor(c.y + bh / 2),
+      MATERIAL_INDEX[bp.death.becomes]
+    )
+  }
+  events.push({ kind: cause, blueprintId: bp.id, x: c.x, y: c.y })
+}
+
+// ---------------------------------------------------------------------------
+// Particles
+// ---------------------------------------------------------------------------
+
+export function emitParticles(
+  w: WorldState,
+  x: number,
+  y: number,
+  color: string,
+  count: number
+): void {
+  for (let i = 0; i < count; i++) {
+    if (w.particles.length >= MAX_PARTICLES) return
+    const a = Math.random() * Math.PI * 2
+    const speed = 2 + Math.random() * 8
+    w.particles.push({
+      x,
+      y,
+      vx: Math.cos(a) * speed,
+      vy: Math.sin(a) * speed - 3,
+      life: PARTICLE_LIFE * (0.6 + Math.random() * 0.8),
+      maxLife: PARTICLE_LIFE,
+      color,
+    })
+  }
+}
+
+function tickParticles(w: WorldState, dt: number, gravityScale: number): void {
+  const out: typeof w.particles = []
+  for (const p of w.particles) {
+    p.life -= dt
+    if (p.life <= 0) continue
+    p.vy += GRAVITY * 0.35 * gravityScale * dt
+    p.x += p.vx * dt
+    p.y += p.vy * dt
+    if (p.x < 0 || p.y < 0 || p.x >= WORLD_W || p.y >= WORLD_H) continue
+    if (solidAt(w, Math.floor(p.x), Math.floor(p.y))) {
+      p.vx *= 0.4
+      p.vy = -p.vy * 0.2
+      p.y -= 0.6
+    }
+    out.push(p)
+  }
+  w.particles = out
+}

--- a/src/app/micro-land/domain/sim/creature-sim.ts
+++ b/src/app/micro-land/domain/sim/creature-sim.ts
@@ -196,6 +196,9 @@ export function tickCreatures(
     ) {
       const child = reproduce(w, c, bp, bw, bh, rng)
       if (child) {
+        // Set here rather than inside `reproduce`, which returns through two
+        // different paths and would need the parent threaded into both.
+        child.generation = c.generation + 1
         c.children++
         if (isPlant) plantsAlive++
         else c.hunger = Math.min(1, c.hunger + BREED_COST)

--- a/src/app/micro-land/domain/sim/creature-sim.ts
+++ b/src/app/micro-land/domain/sim/creature-sim.ts
@@ -36,6 +36,7 @@ import {
   boxLiquidFraction,
   inBounds,
   repopulate,
+  seedNativePlants,
   setTile,
   settleOnGround,
   solidAt,
@@ -212,6 +213,8 @@ export function tickCreatures(
     w.creatures = creatures.filter((c) => !dead.has(c.id))
   }
 
+  // Plants first — everything else in the world is downstream of them.
+  seedNativePlants(w, rng)
   repopulate(w, rng)
 
   tickParticles(w, dt, gravityScale)

--- a/src/app/micro-land/domain/sim/creature-sim.ts
+++ b/src/app/micro-land/domain/sim/creature-sim.ts
@@ -8,7 +8,8 @@
  * The sense pass (who can I eat, who is about to eat me) is O(n²), so it runs
  * at 10Hz with creatures staggered across ticks rather than every frame.
  */
-import { artSize, canEat, fears } from '@/app/micro-land/domain/blueprint'
+import { artSize, bodyBox, canEat, fears } from '@/app/micro-land/domain/blueprint'
+import type { BodyBox } from '@/app/micro-land/domain/blueprint'
 import { MATERIAL_INDEX } from '@/app/micro-land/domain/config/materials'
 import {
   BREATH_SECONDS,
@@ -32,8 +33,10 @@ import type { Creature, CreatureBlueprint, WorldState } from '@/app/micro-land/d
 
 import {
   boxDeadlyMaterial,
+  boxDrownFraction,
   boxHitsSolid,
   boxLiquidFraction,
+  boxViscosity,
   inBounds,
   repopulate,
   seedNativePlants,
@@ -106,6 +109,14 @@ export function tickCreatures(
     speciesCount[c.blueprintId] = (speciesCount[c.blueprintId] ?? 0) + 1
   }
 
+  // Helpers — bees, worms, anything with an aura. Gathered once per tick
+  // because the breeding check below asks "is one of these near me", and there
+  // are normally none at all.
+  const helpers: Creature[] = []
+  for (const c of creatures) {
+    if (w.blueprints[c.blueprintId]?.aura) helpers.push(c)
+  }
+
   for (const c of creatures) {
     if (dead.has(c.id)) continue
     const bp = w.blueprints[c.blueprintId]
@@ -114,7 +125,11 @@ export function tickCreatures(
       continue
     }
 
+    // `bw`/`bh` are what the creature *looks* like — used for sight, biting and
+    // anything the player can see. `body` is what it collides with. For all but
+    // the largest creatures the two are identical.
     const { w: bw, h: bh } = artSize(bp)
+    const body = bodyBox(bp)
 
     c.ageSeconds += dt
     c.animMs += dt * 1000
@@ -139,8 +154,10 @@ export function tickCreatures(
     }
 
     // --- environment ----------------------------------------------------
-    const wet = boxLiquidFraction(w, c.x, c.y, bw, bh)
-    const deadlyMat = boxDeadlyMaterial(w, c.x, c.y, bw, bh)
+    const px = c.x + body.dx
+    const py = c.y + body.dy
+    const wet = boxLiquidFraction(w, px, py, body.w, body.h)
+    const deadlyMat = boxDeadlyMaterial(w, px, py, body.w, body.h)
     if (deadlyMat !== null) {
       const immune = bp.body.immuneTo.some((m) => MATERIAL_INDEX[m] === deadlyMat)
       if (!immune) {
@@ -155,7 +172,11 @@ export function tickCreatures(
       const needsWater = bp.habitat.needs.includes('water')
       if (needsWater && wet < 0.25) inTrouble = true
     }
-    if (bp.habitat.drowns && wet > 0.7) inTrouble = true
+    // Drowning asks specifically about water, not "any liquid" — sap holds you
+    // fast but you can still breathe in it.
+    if (bp.habitat.drowns && boxDrownFraction(w, px, py, body.w, body.h) > 0.7) {
+      inTrouble = true
+    }
 
     if (inTrouble) {
       c.distress += dt
@@ -177,6 +198,9 @@ export function tickCreatures(
       steer(w, c, bp, dt, rng)
       integrate(w, c, bp, bw, bh, dt, wet, gravityScale)
     }
+
+    // --- what it does to the world around it -----------------------------
+    if (bp.aura?.converts) applyConversion(w, c, bp, bw, bh, dt, rng)
 
     // --- breeding -------------------------------------------------------
     const fullness = 1 - c.hunger
@@ -203,7 +227,9 @@ export function tickCreatures(
         if (isPlant) plantsAlive++
         else c.hunger = Math.min(1, c.hunger + BREED_COST)
         speciesCount[bp.id] = (speciesCount[bp.id] ?? 0) + 1
-        c.breedCooldown = isPlant ? PLANT_SPREAD_COOLDOWN : BREED_COOLDOWN
+        // A pollinator nearby shortens the wait before the next one.
+        const help = auraBoost(w, c, bp, bw, bh, helpers)
+        c.breedCooldown = (isPlant ? PLANT_SPREAD_COOLDOWN : BREED_COOLDOWN) / help
         events.push({ kind: 'born', blueprintId: bp.id, x: child.x, y: child.y })
       } else {
         // Nowhere to put it — wait a bit before trying again.
@@ -331,6 +357,86 @@ function devour(
 }
 
 // ---------------------------------------------------------------------------
+// Auras — creatures that change the world instead of only living in it
+// ---------------------------------------------------------------------------
+
+/**
+ * How much faster this creature breeds thanks to helpers standing nearby.
+ *
+ * Returns 1 when nothing is helping, which is the overwhelmingly common case —
+ * hence the early exit on an empty helper list, so a world with no bees in it
+ * pays nothing for the feature.
+ */
+function auraBoost(
+  w: WorldState,
+  c: Creature,
+  bp: CreatureBlueprint,
+  bw: number,
+  bh: number,
+  helpers: Creature[]
+): number {
+  if (helpers.length === 0) return 1
+  const cx = c.x + bw / 2
+  const cy = c.y + bh / 2
+
+  let best = 1
+  for (const helper of helpers) {
+    if (helper.id === c.id) continue
+    const aura = w.blueprints[helper.blueprintId]?.aura
+    if (!aura || aura.helps.length === 0) continue
+    if (!aura.helps.some((tag) => bp.tags.includes(tag))) continue
+
+    const hbp = w.blueprints[helper.blueprintId]
+    if (!hbp) continue
+    const { w: hw, h: hh } = artSize(hbp)
+    const dx = helper.x + hw / 2 - cx
+    const dy = helper.y + hh / 2 - cy
+    if (dx * dx + dy * dy > aura.radius * aura.radius) continue
+    // Best helper wins rather than stacking — twenty bees in one flowerbed
+    // shouldn't make it breed twenty times as fast.
+    if (aura.boost > best) best = aura.boost
+  }
+  return best
+}
+
+/**
+ * Slowly turn the ground into something else — a worm making soil out of rock.
+ *
+ * Only one tile at a time, and only tiles that already match `from`, so this
+ * enriches a world rather than rewriting it. A single loamworm takes minutes to
+ * make a visible patch, which is the point: you notice it after you stop
+ * watching it.
+ */
+function applyConversion(
+  w: WorldState,
+  c: Creature,
+  bp: CreatureBlueprint,
+  bw: number,
+  bh: number,
+  dt: number,
+  rng: Rng
+): void {
+  const aura = bp.aura
+  if (!aura?.converts) return
+  if (rng() > aura.convertRate * dt) return
+
+  const from = MATERIAL_INDEX[aura.converts.from]
+  const to = MATERIAL_INDEX[aura.converts.to]
+  if (from === undefined || to === undefined) return
+
+  const cx = c.x + bw / 2
+  const cy = c.y + bh / 2
+  for (let attempt = 0; attempt < 6; attempt++) {
+    const tx = Math.floor(cx + (rng() * 2 - 1) * aura.radius)
+    const ty = Math.floor(cy + (rng() * 2 - 1) * aura.radius)
+    if (!inBounds(tx, ty)) continue
+    if (tileAt(w, tx, ty) !== from) continue
+    setTile(w, tx, ty, to)
+    return
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Steering
 // ---------------------------------------------------------------------------
 
@@ -342,6 +448,7 @@ function steer(
   rng: Rng
 ): void {
   const { w: bw, h: bh } = artSize(bp)
+  const body = bodyBox(bp)
   const cx = c.x + bw / 2
   const cy = c.y + bh / 2
 
@@ -384,9 +491,15 @@ function steer(
       if (digger && c.grounded && c.hunger < 0.4 && rng() < 0.6 * dt) {
         c.vy = 6
       }
-      // Jump when there's a wall in the way, or the target is overhead.
+      // Jump when there's a wall in the way, or the target is overhead. Probed
+      // from the solid core, not the wingtip — a dragon shouldn't try to hop
+      // over a pebble its wing is drawn across.
       const ahead = Math.sign(c.vx) || c.facing
-      const blocked = solidAt(w, Math.floor(cx + ahead * (bw / 2 + 1)), Math.floor(cy))
+      const blocked = solidAt(
+        w,
+        Math.floor(c.x + body.dx + body.w / 2 + ahead * (body.w / 2 + 1)),
+        Math.floor(c.y + body.dy + body.h / 2)
+      )
       const wantsUp = wantY < -0.4
       if (c.grounded && (blocked || (wantsUp && rng() < 0.08))) {
         c.vy = -bp.move.jump
@@ -419,7 +532,7 @@ function steer(
     }
     case 'crawl': {
       // Sticks to any surface, so it moves in 2D but only along walls.
-      const touching = touchesSurface(w, c, bw, bh)
+      const touching = touchesSurface(w, c, body)
       if (touching) {
         c.vx += wantX * accel * dt
         c.vy += wantY * accel * dt
@@ -444,11 +557,11 @@ function steer(
   }
 }
 
-function touchesSurface(w: WorldState, c: Creature, bw: number, bh: number): boolean {
-  const x0 = Math.floor(c.x) - 1
-  const x1 = Math.floor(c.x + bw - 0.001) + 1
-  const y0 = Math.floor(c.y) - 1
-  const y1 = Math.floor(c.y + bh - 0.001) + 1
+function touchesSurface(w: WorldState, c: Creature, body: BodyBox): boolean {
+  const x0 = Math.floor(c.x + body.dx) - 1
+  const x1 = Math.floor(c.x + body.dx + body.w - 0.001) + 1
+  const y0 = Math.floor(c.y + body.dy) - 1
+  const y1 = Math.floor(c.y + body.dy + body.h - 0.001) + 1
   for (let x = x0; x <= x1; x++) {
     if (solidAt(w, x, y0) || solidAt(w, x, y1)) return true
   }
@@ -473,8 +586,15 @@ function integrate(
   gravityScale: number
 ): void {
   const kind = bp.move.kind
+  const body = bodyBox(bp)
   const inLiquid = wet > 0.3
-  const weightless = kind === 'fly' || (kind === 'crawl' && touchesSurface(w, c, bw, bh))
+  const weightless = kind === 'fly' || (kind === 'crawl' && touchesSurface(w, c, body))
+
+  // Cloud and sap: not walls, but not nothing either. A high viscosity holds
+  // you up against gravity and bleeds off whatever speed you arrived with, so
+  // you sink through a cloud instead of dropping through it.
+  const goo = boxViscosity(w, c.x + body.dx, c.y + body.dy, body.w, body.h)
+  const inGoo = goo > 0.05
 
   if (!weightless) {
     let g = GRAVITY * bp.body.mass * gravityScale
@@ -483,14 +603,16 @@ function integrate(
       g *= 1 - bp.body.buoyancy
     }
     if (kind === 'drift') g *= 0.35
+    if (inGoo) g *= 1 - goo * 0.85
     c.vy += g * dt
   }
 
   // Drag. `body.drag` is the fraction of speed kept per second.
-  const dragBase = inLiquid ? bp.body.drag * 0.45 : bp.body.drag
+  let dragBase = inLiquid ? bp.body.drag * 0.45 : bp.body.drag
+  if (inGoo) dragBase *= 1 - goo * 0.75
   const keep = Math.pow(Math.max(0.001, dragBase), dt)
   c.vx *= keep
-  if (weightless || inLiquid || kind === 'drift') c.vy *= keep
+  if (weightless || inLiquid || inGoo || kind === 'drift') c.vy *= keep
 
   c.vy = Math.max(-MAX_FALL, Math.min(MAX_FALL, c.vy))
   c.vx = Math.max(-MAX_FALL, Math.min(MAX_FALL, c.vx))
@@ -498,19 +620,40 @@ function integrate(
   const canStepUp = kind === 'walk'
   const digger = bp.dig.through.length > 0
 
+  // Everything below works in *core* coordinates and converts back at the end.
+  // `c.x`/`c.y` are the sprite's top-left; the core sits at `+ body.dx/dy`, so
+  // snapping the sprite against a tile directly would wedge a big creature by
+  // however far its wings stick out.
+  const ox = body.dx
+  const oy = body.dy
+
   // --- horizontal ---
   const nx = c.x + c.vx * dt
-  if (!boxHitsSolid(w, nx, c.y, bw, bh)) {
+
+  // Walk up a ledge without needing to jump. How high a ledge depends on how
+  // long your legs are: one tile per five of body height. Everything that
+  // existed before big creatures did is under ten tiles tall, so they all still
+  // get exactly the one tile they always had — but a tyrannosaur steps over a
+  // boulder instead of wedging against it, which is what it was doing.
+  const maxStep = canStepUp ? Math.max(1, Math.floor(body.h / 5)) : 0
+  let step = -1
+  for (let s = 0; s <= maxStep; s++) {
+    if (!boxHitsSolid(w, nx + ox, c.y + oy - s, body.w, body.h)) {
+      step = s
+      break
+    }
+  }
+
+  if (step >= 0) {
     c.x = nx
-  } else if (canStepUp && !boxHitsSolid(w, nx, c.y - 1, bw, bh)) {
-    // Walk up a single-tile ledge without needing to jump.
-    c.x = nx
-    c.y -= 1
-  } else if (digger && chewThrough(w, c, bp, nx, c.y, bw, bh, dt)) {
+    c.y -= step
+  } else if (digger && chewThrough(w, c, bp, nx + ox, c.y + oy, body.w, body.h, dt)) {
     // Held against the rock while it works. The tunnel opens next tick.
     c.vx *= 0.2
   } else {
-    c.x = c.vx > 0 ? Math.floor(nx + bw - 0.001) - bw : Math.floor(nx) + 1
+    const bx = nx + ox
+    c.x =
+      (c.vx > 0 ? Math.floor(bx + body.w - 0.001) - body.w : Math.floor(bx) + 1) - ox
     c.vx = -c.vx * bp.body.bounce
     c.drift = -c.drift
     c.facing = (c.facing === 1 ? -1 : 1) as 1 | -1
@@ -519,19 +662,20 @@ function integrate(
   // --- vertical ---
   c.grounded = false
   const ny = c.y + c.vy * dt
-  if (!boxHitsSolid(w, c.x, ny, bw, bh)) {
+  if (!boxHitsSolid(w, c.x + ox, ny + oy, body.w, body.h)) {
     c.y = ny
-  } else if (digger && chewThrough(w, c, bp, c.x, ny, bw, bh, dt)) {
+  } else if (digger && chewThrough(w, c, bp, c.x + ox, ny + oy, body.w, body.h, dt)) {
     c.vy *= 0.2
     // A digger resting on rock it is actively burrowing into still counts as
     // standing on something, or a walker would never get the jump to push down.
     if (c.vy > 0) c.grounded = true
   } else {
+    const by = ny + oy
     if (c.vy > 0) {
-      c.y = Math.floor(ny + bh - 0.001) - bh
+      c.y = Math.floor(by + body.h - 0.001) - body.h - oy
       c.grounded = true
     } else {
-      c.y = Math.floor(ny) + 1
+      c.y = Math.floor(by) + 1 - oy
     }
     c.vy = Math.abs(c.vy) > 4 ? -c.vy * bp.body.bounce : 0
   }
@@ -619,6 +763,7 @@ function reproduce(
 ): Creature | null {
   const isPlant = bp.move.kind === 'root'
   const spread = isPlant ? 14 : 5
+  const body = bodyBox(bp)
 
   for (let attempt = 0; attempt < 12; attempt++) {
     const x = parent.x + (rng() * 2 - 1) * spread
@@ -626,8 +771,11 @@ function reproduce(
     const cx = Math.max(0, Math.min(WORLD_W - bw, x))
     const cy = Math.max(0, Math.min(WORLD_H - bh, y))
 
-    if (boxHitsSolid(w, cx, cy, bw, bh)) continue
-    if (boxDeadlyMaterial(w, cx, cy, bw, bh) !== null && bp.body.immuneTo.length === 0) {
+    if (boxHitsSolid(w, cx + body.dx, cy + body.dy, body.w, body.h)) continue
+    if (
+      boxDeadlyMaterial(w, cx + body.dx, cy + body.dy, body.w, body.h) !== null &&
+      bp.body.immuneTo.length === 0
+    ) {
       continue
     }
 
@@ -635,15 +783,16 @@ function reproduce(
       // A seedling settles onto the first fertile ground below the spot we
       // picked. Same trap as spawning: the tile under a box is
       // `floor(y + bh - 0.001) + 1`, so `settleOnGround` owns that arithmetic.
-      const settled = settleOnGround(w, cx, cy, bw, bh, {
+      const settled = settleOnGround(w, cx + body.dx, cy + body.dy, body.w, body.h, {
         requireFertile: true,
         maxDrop: 10,
       })
       if (settled === null) continue
-      return spawnCreature(w, bp, cx, settled)
+      // `settled` is where the core came to rest; the sprite sits above it.
+      return spawnCreature(w, bp, cx, settled - body.dy)
     }
 
-    const wet = boxLiquidFraction(w, cx, cy, bw, bh)
+    const wet = boxLiquidFraction(w, cx + body.dx, cy + body.dy, body.w, body.h)
     const needsWater = bp.move.kind === 'swim' || !!bp.habitat.needs?.includes('water')
     if (needsWater && wet < 0.5) continue
     if (!needsWater && bp.habitat.drowns && wet > 0.5) continue

--- a/src/app/micro-land/domain/sim/prng.ts
+++ b/src/app/micro-land/domain/sim/prng.ts
@@ -1,0 +1,78 @@
+/** Deterministic RNG + value noise. Same seed, same world, every time. */
+
+/** mulberry32 — small, fast, good enough for terrain and wandering. */
+export function makeRng(seed: number): () => number {
+  let a = seed >>> 0
+  return function rng() {
+    a = (a + 0x6d2b79f5) >>> 0
+    let t = a
+    t = Math.imul(t ^ (t >>> 15), t | 1)
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61)
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296
+  }
+}
+
+export type Rng = () => number
+
+export function randRange(rng: Rng, lo: number, hi: number): number {
+  return lo + rng() * (hi - lo)
+}
+
+export function randInt(rng: Rng, lo: number, hi: number): number {
+  return Math.floor(randRange(rng, lo, hi + 1))
+}
+
+export function pick<T>(rng: Rng, list: readonly T[]): T {
+  return list[Math.min(list.length - 1, Math.floor(rng() * list.length))]
+}
+
+/**
+ * 2D value noise with a hashed lattice. Cheaper than Perlin and plenty for
+ * cave blobs and hill lines at this resolution.
+ */
+export function makeNoise2D(seed: number): (x: number, y: number) => number {
+  const s = seed >>> 0
+
+  function hash(ix: number, iy: number): number {
+    let h = (ix * 374761393 + iy * 668265263 + s * 1274126177) | 0
+    h = (h ^ (h >>> 13)) | 0
+    h = Math.imul(h, 1274126177)
+    return ((h ^ (h >>> 16)) >>> 0) / 4294967296
+  }
+
+  const smooth = (t: number) => t * t * (3 - 2 * t)
+
+  return function noise(x: number, y: number): number {
+    const x0 = Math.floor(x)
+    const y0 = Math.floor(y)
+    const fx = smooth(x - x0)
+    const fy = smooth(y - y0)
+    const n00 = hash(x0, y0)
+    const n10 = hash(x0 + 1, y0)
+    const n01 = hash(x0, y0 + 1)
+    const n11 = hash(x0 + 1, y0 + 1)
+    const a = n00 + (n10 - n00) * fx
+    const b = n01 + (n11 - n01) * fx
+    return a + (b - a) * fy
+  }
+}
+
+/** Layered noise — a few octaves of `makeNoise2D` summed. */
+export function fbm(
+  noise: (x: number, y: number) => number,
+  x: number,
+  y: number,
+  octaves = 4
+): number {
+  let value = 0
+  let amp = 0.5
+  let freq = 1
+  let total = 0
+  for (let i = 0; i < octaves; i++) {
+    value += noise(x * freq, y * freq) * amp
+    total += amp
+    amp *= 0.5
+    freq *= 2
+  }
+  return value / total
+}

--- a/src/app/micro-land/domain/sim/tile-sim.ts
+++ b/src/app/micro-land/domain/sim/tile-sim.ts
@@ -1,0 +1,200 @@
+/**
+ * Falling-sand tile physics.
+ *
+ * One bottom-up pass per step: powders pile, liquids flow and level out, lava
+ * quenches into obsidian where it meets water, ice melts near heat. A `moved`
+ * bitmask stops a tile that just fell from being processed again in the same
+ * pass (which would make everything drop at light speed).
+ *
+ * Scan direction alternates each pass — without that, liquids visibly drift
+ * left forever.
+ */
+import { IS_LIQUID, IS_POWDER, MATERIAL_INDEX } from '@/app/micro-land/domain/config/materials'
+import { WORLD_H, WORLD_W } from '@/app/micro-land/domain/constants'
+import type { WorldState } from '@/app/micro-land/domain/types'
+
+const AIR = MATERIAL_INDEX.air
+const WATER = MATERIAL_INDEX.water
+const LAVA = MATERIAL_INDEX.lava
+const STONE = MATERIAL_INDEX.stone
+const OBSIDIAN = MATERIAL_INDEX.obsidian
+const ICE = MATERIAL_INDEX.ice
+
+/** Reused across passes — the grid never changes size. */
+const moved = new Uint8Array(WORLD_W * WORLD_H)
+
+/** How far a liquid can slide sideways in one pass looking for a way down. */
+const FLOW_REACH = 4
+
+export function tickTiles(w: WorldState): void {
+  moved.fill(0)
+  const tiles = w.tiles
+  w.flowPhase++
+  const leftToRight = (w.flowPhase & 1) === 0
+  // Lava is viscous: it only gets to move on every other pass.
+  const lavaMoves = (w.flowPhase & 1) === 0
+
+  for (let y = WORLD_H - 1; y >= 0; y--) {
+    const rowStart = y * WORLD_W
+    for (let i = 0; i < WORLD_W; i++) {
+      const x = leftToRight ? i : WORLD_W - 1 - i
+      const at = rowStart + x
+      if (moved[at]) continue
+
+      const mat = tiles[at]
+      if (mat === AIR) continue
+
+      if (mat === ICE) {
+        if (touchesHeat(tiles, x, y)) tiles[at] = WATER
+        continue
+      }
+
+      const isPowder = IS_POWDER[mat] === 1
+      const isLiquid = IS_LIQUID[mat] === 1
+      if (!isPowder && !isLiquid) continue
+
+      if (mat === LAVA) {
+        // Quenching wins over movement — a lava tile touching water sets solid.
+        if (quench(tiles, x, y, at)) continue
+        if (!lavaMoves) continue
+      }
+
+      if (isPowder) {
+        stepPowder(tiles, x, y, at, leftToRight)
+      } else {
+        stepLiquid(tiles, x, y, at, mat, leftToRight)
+      }
+    }
+  }
+}
+
+function cell(x: number, y: number): number {
+  return y * WORLD_W + x
+}
+
+function passableForPowder(mat: number): boolean {
+  // Powders sink through air and liquid alike.
+  return mat === AIR || IS_LIQUID[mat] === 1
+}
+
+function swap(tiles: Uint8Array, a: number, b: number): void {
+  const tmp = tiles[a]
+  tiles[a] = tiles[b]
+  tiles[b] = tmp
+  moved[a] = 1
+  moved[b] = 1
+}
+
+function stepPowder(
+  tiles: Uint8Array,
+  x: number,
+  y: number,
+  at: number,
+  leftToRight: boolean
+): void {
+  if (y + 1 >= WORLD_H) return
+
+  const below = cell(x, y + 1)
+  if (passableForPowder(tiles[below])) {
+    swap(tiles, at, below)
+    return
+  }
+
+  // Blocked straight down — try the diagonals so it forms a slope.
+  const first = leftToRight ? -1 : 1
+  for (const dir of [first, -first]) {
+    const nx = x + dir
+    if (nx < 0 || nx >= WORLD_W) continue
+    const diag = cell(nx, y + 1)
+    if (passableForPowder(tiles[diag])) {
+      swap(tiles, at, diag)
+      return
+    }
+  }
+}
+
+function stepLiquid(
+  tiles: Uint8Array,
+  x: number,
+  y: number,
+  at: number,
+  mat: number,
+  leftToRight: boolean
+): void {
+  if (y + 1 < WORLD_H) {
+    const below = cell(x, y + 1)
+    if (tiles[below] === AIR) {
+      swap(tiles, at, below)
+      return
+    }
+    // Lava is denser than water: it sinks through it.
+    if (mat === LAVA && tiles[below] === WATER) {
+      swap(tiles, at, below)
+      return
+    }
+  }
+
+  const first = leftToRight ? -1 : 1
+  for (const dir of [first, -first]) {
+    const nx = x + dir
+    if (nx < 0 || nx >= WORLD_W || y + 1 >= WORLD_H) continue
+    const diag = cell(nx, y + 1)
+    if (tiles[diag] === AIR) {
+      swap(tiles, at, diag)
+      return
+    }
+  }
+
+  // Can't go down anywhere — spread sideways so the surface levels out. Reach
+  // further than one tile per pass or puddles take forever to settle.
+  for (const dir of [first, -first]) {
+    for (let step = 1; step <= FLOW_REACH; step++) {
+      const nx = x + dir * step
+      if (nx < 0 || nx >= WORLD_W) break
+      const side = cell(nx, y)
+      if (tiles[side] !== AIR) break
+      // Prefer a spot that has somewhere to fall from.
+      const under = y + 1 < WORLD_H ? tiles[cell(nx, y + 1)] : STONE
+      if (under === AIR || step === FLOW_REACH) {
+        swap(tiles, at, side)
+        return
+      }
+    }
+  }
+}
+
+/** Lava touching water: lava sets to obsidian, the water boils away. */
+function quench(tiles: Uint8Array, x: number, y: number, at: number): boolean {
+  let found = false
+  for (let dy = -1; dy <= 1; dy++) {
+    for (let dx = -1; dx <= 1; dx++) {
+      if (dx === 0 && dy === 0) continue
+      const nx = x + dx
+      const ny = y + dy
+      if (nx < 0 || ny < 0 || nx >= WORLD_W || ny >= WORLD_H) continue
+      const n = cell(nx, ny)
+      if (tiles[n] === WATER) {
+        tiles[n] = AIR
+        found = true
+      }
+    }
+  }
+  if (found) {
+    tiles[at] = OBSIDIAN
+    moved[at] = 1
+  }
+  return found
+}
+
+function touchesHeat(tiles: Uint8Array, x: number, y: number): boolean {
+  for (let dy = -1; dy <= 1; dy++) {
+    for (let dx = -1; dx <= 1; dx++) {
+      if (dx === 0 && dy === 0) continue
+      const nx = x + dx
+      const ny = y + dy
+      if (nx < 0 || ny < 0 || nx >= WORLD_W || ny >= WORLD_H) continue
+      if (tiles[cell(nx, ny)] === LAVA) return true
+    }
+  }
+  return false
+}

--- a/src/app/micro-land/domain/sim/tile-sim.ts
+++ b/src/app/micro-land/domain/sim/tile-sim.ts
@@ -2,14 +2,22 @@
  * Falling-sand tile physics.
  *
  * One bottom-up pass per step: powders pile, liquids flow and level out, lava
- * quenches into obsidian where it meets water, ice melts near heat. A `moved`
- * bitmask stops a tile that just fell from being processed again in the same
- * pass (which would make everything drop at light speed).
+ * quenches into obsidian where it meets water, ice and snow melt near heat,
+ * acid eats through whatever it is sitting on. A `moved` bitmask stops a tile
+ * that just fell from being processed again in the same pass (which would make
+ * everything drop at light speed).
  *
  * Scan direction alternates each pass — without that, liquids visibly drift
  * left forever.
  */
-import { IS_LIQUID, IS_POWDER, MATERIAL_INDEX } from '@/app/micro-land/domain/config/materials'
+import {
+  IS_ACID_PROOF,
+  IS_LIQUID,
+  IS_POWDER,
+  IS_SOLID,
+  MATERIAL_BY_INDEX,
+  MATERIAL_INDEX,
+} from '@/app/micro-land/domain/config/materials'
 import { WORLD_H, WORLD_W } from '@/app/micro-land/domain/constants'
 import type { WorldState } from '@/app/micro-land/domain/types'
 
@@ -18,7 +26,21 @@ const WATER = MATERIAL_INDEX.water
 const LAVA = MATERIAL_INDEX.lava
 const STONE = MATERIAL_INDEX.stone
 const OBSIDIAN = MATERIAL_INDEX.obsidian
-const ICE = MATERIAL_INDEX.ice
+const ACID = MATERIAL_INDEX.acid
+const SAP = MATERIAL_INDEX.sap
+
+/** Anything that turns to water next to lava — ice, snow. */
+const MELTS: Uint8Array = new Uint8Array(
+  MATERIAL_BY_INDEX.map((m) => (m.melts ? 1 : 0))
+)
+
+/**
+ * Chance an acid tile eats its neighbour on a pass it is allowed to act, 0..1.
+ *
+ * Low on purpose. Acid that dissolves instantly just deletes terrain; acid that
+ * takes a few seconds to chew through a wall is something you watch.
+ */
+const ACID_BITE = 0.22
 
 /** Reused across passes — the grid never changes size. */
 const moved = new Uint8Array(WORLD_W * WORLD_H)
@@ -30,9 +52,12 @@ export function tickTiles(w: WorldState): void {
   moved.fill(0)
   const tiles = w.tiles
   w.flowPhase++
-  const leftToRight = (w.flowPhase & 1) === 0
+  const phase = w.flowPhase
+  const leftToRight = (phase & 1) === 0
   // Lava is viscous: it only gets to move on every other pass.
-  const lavaMoves = (w.flowPhase & 1) === 0
+  const lavaMoves = (phase & 1) === 0
+  // Sap is far thicker than lava — it creeps.
+  const sapMoves = (phase & 7) === 0
 
   for (let y = WORLD_H - 1; y >= 0; y--) {
     const rowStart = y * WORLD_W
@@ -44,9 +69,15 @@ export function tickTiles(w: WorldState): void {
       const mat = tiles[at]
       if (mat === AIR) continue
 
-      if (mat === ICE) {
-        if (touchesHeat(tiles, x, y)) tiles[at] = WATER
-        continue
+      if (MELTS[mat] === 1) {
+        if (touchesHeat(tiles, x, y)) {
+          tiles[at] = WATER
+          continue
+        }
+        // Ice is a wall and has nothing else to do this pass. Snow is a powder,
+        // so it still has to fall — this used to `continue` for both, and snow
+        // hung in mid-air wherever it was painted.
+        if (IS_POWDER[mat] !== 1) continue
       }
 
       const isPowder = IS_POWDER[mat] === 1
@@ -59,6 +90,13 @@ export function tickTiles(w: WorldState): void {
         if (!lavaMoves) continue
       }
 
+      if (mat === ACID) {
+        // Eating a wall uses the acid up, so there's nothing left to move.
+        if (corrode(tiles, x, y, at, phase)) continue
+      }
+
+      if (mat === SAP && !sapMoves) continue
+
       if (isPowder) {
         stepPowder(tiles, x, y, at, leftToRight)
       } else {
@@ -68,13 +106,26 @@ export function tickTiles(w: WorldState): void {
   }
 }
 
+/**
+ * Cheap deterministic noise from a tile and the pass number.
+ *
+ * The tile sim has no RNG of its own and shouldn't gain one — it has to give
+ * the same result for the same world on every machine, including the headless
+ * harness. Hashing the coordinates gets randomness without any state.
+ */
+function hash3(x: number, y: number, z: number): number {
+  let h = (x * 374761393 + y * 668265263 + z * 2147483647) | 0
+  h = (h ^ (h >>> 13)) * 1274126177
+  return ((h ^ (h >>> 16)) >>> 0) / 4294967296
+}
+
 function cell(x: number, y: number): number {
   return y * WORLD_W + x
 }
 
 function passableForPowder(mat: number): boolean {
-  // Powders sink through air and liquid alike.
-  return mat === AIR || IS_LIQUID[mat] === 1
+  // Powders sink through anything that isn't a wall — air, liquid, cloud alike.
+  return IS_SOLID[mat] !== 1
 }
 
 function swap(tiles: Uint8Array, a: number, b: number): void {
@@ -184,6 +235,48 @@ function quench(tiles: Uint8Array, x: number, y: number, at: number): boolean {
     moved[at] = 1
   }
   return found
+}
+
+/**
+ * Acid eating whatever it's resting against.
+ *
+ * The acid tile is spent by the bite, which is the whole reason this is safe to
+ * ship: a puddle can only dissolve as many tiles as it has drops, so acid digs a
+ * hole and then it's gone. Without that it would quietly erase the world while
+ * nobody was looking. Glass, obsidian, marble, plastic, gold, crystal, gem and
+ * lava shrug it off, so there is always something to build a container out of.
+ *
+ * Returns true if the tile was used up.
+ */
+function corrode(
+  tiles: Uint8Array,
+  x: number,
+  y: number,
+  at: number,
+  phase: number
+): boolean {
+  if (hash3(x, y, phase) > ACID_BITE) return false
+
+  // Below first, then the sides, then up — acid works downward like it should.
+  for (const [dx, dy] of [
+    [0, 1],
+    [-1, 0],
+    [1, 0],
+    [0, -1],
+  ]) {
+    const nx = x + dx
+    const ny = y + dy
+    if (nx < 0 || ny < 0 || nx >= WORLD_W || ny >= WORLD_H) continue
+    const n = cell(nx, ny)
+    const target = tiles[n]
+    if (IS_SOLID[target] !== 1 || IS_ACID_PROOF[target] === 1) continue
+    tiles[n] = AIR
+    tiles[at] = AIR
+    moved[n] = 1
+    moved[at] = 1
+    return true
+  }
+  return false
 }
 
 function touchesHeat(tiles: Uint8Array, x: number, y: number): boolean {

--- a/src/app/micro-land/domain/sim/world.ts
+++ b/src/app/micro-land/domain/sim/world.ts
@@ -21,6 +21,7 @@ import {
   PLANT_SEED_INTERVAL,
   PLANT_SPECIES_CAP,
   SEED_RAIN_INTERVAL,
+  WIDTH_SCALE,
   WORLD_H,
   WORLD_W,
 } from '@/app/micro-land/domain/constants'
@@ -488,7 +489,14 @@ export function spawnSomewhereSensible(
   return spawnCreature(w, bp, spot.x, spot.y)
 }
 
-/** Seed a theme's resident population. */
+/**
+ * Seed a theme's resident population.
+ *
+ * Starter counts are written per screen of land, and scaled up here rather than
+ * in each theme so the numbers stay readable as what they are: 34 sunleaf is a
+ * meadow, and it should still be a meadow in a world three times the size
+ * instead of a thin scattering the player has to go looking for.
+ */
 export function seedStarters(w: WorldState, themeId: string, rng: Rng): void {
   const theme = THEME_BY_ID[themeId]
   if (!theme) return
@@ -497,7 +505,8 @@ export function seedStarters(w: WorldState, themeId: string, rng: Rng): void {
     const bp = w.blueprints[entry.id]
     if (!bp) continue
     if (!w.natives.includes(bp.id)) w.natives.push(bp.id)
-    for (let i = 0; i < entry.count; i++) spawnSomewhereSensible(w, bp, rng)
+    const count = Math.round(entry.count * WIDTH_SCALE)
+    for (let i = 0; i < count; i++) spawnSomewhereSensible(w, bp, rng)
   }
 }
 

--- a/src/app/micro-land/domain/sim/world.ts
+++ b/src/app/micro-land/domain/sim/world.ts
@@ -1,0 +1,445 @@
+/** World construction, tile access, and spawning. */
+import { artSize, canEat } from '@/app/micro-land/domain/blueprint'
+import { BUILTIN_CREATURES } from '@/app/micro-land/domain/config/creatures'
+import {
+  AIR,
+  IS_DEADLY,
+  IS_FERTILE,
+  IS_LIQUID,
+  IS_SOLID,
+  MATERIAL_INDEX,
+} from '@/app/micro-land/domain/config/materials'
+import { DEFAULT_THEME, THEME_BY_ID, type Theme } from '@/app/micro-land/domain/config/themes'
+import {
+  MAX_CREATURES,
+  PLANT_FLOOR,
+  SEED_RAIN_INTERVAL,
+  WORLD_H,
+  WORLD_W,
+} from '@/app/micro-land/domain/constants'
+import type { Creature, CreatureBlueprint, MaterialId, WorldState } from '@/app/micro-land/domain/types'
+
+import { type Rng, makeRng } from './prng'
+
+export function createWorld(seed = 1337): WorldState {
+  const tiles = new Uint8Array(WORLD_W * WORLD_H)
+  const grain = new Uint8Array(WORLD_W * WORLD_H)
+  const rng = makeRng(seed)
+  for (let i = 0; i < grain.length; i++) grain[i] = Math.floor(rng() * 256)
+
+  const blueprints: Record<string, CreatureBlueprint> = {}
+  for (const bp of BUILTIN_CREATURES) blueprints[bp.id] = bp
+
+  return {
+    width: WORLD_W,
+    height: WORLD_H,
+    tiles,
+    grain,
+    creatures: [],
+    particles: [],
+    blueprints,
+    nextCreatureId: 1,
+    elapsed: 0,
+    seed,
+    flowPhase: 0,
+    natives: [],
+    nextSeedRain: 0,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tile access
+// ---------------------------------------------------------------------------
+
+export function idx(x: number, y: number): number {
+  return y * WORLD_W + x
+}
+
+export function inBounds(x: number, y: number): boolean {
+  return x >= 0 && y >= 0 && x < WORLD_W && y < WORLD_H
+}
+
+/** Material index at a tile. Out of bounds reads as stone — the world is a box. */
+export function tileAt(w: WorldState, x: number, y: number): number {
+  if (!inBounds(x, y)) return MATERIAL_INDEX.stone
+  return w.tiles[y * WORLD_W + x]
+}
+
+/** Out of bounds counts as solid, so nothing can wander out of the world. */
+export function solidAt(w: WorldState, x: number, y: number): boolean {
+  if (!inBounds(x, y)) return true
+  return IS_SOLID[w.tiles[y * WORLD_W + x]] === 1
+}
+
+export function liquidAt(w: WorldState, x: number, y: number): boolean {
+  if (!inBounds(x, y)) return false
+  return IS_LIQUID[w.tiles[y * WORLD_W + x]] === 1
+}
+
+export function deadlyAt(w: WorldState, x: number, y: number): boolean {
+  if (!inBounds(x, y)) return false
+  return IS_DEADLY[w.tiles[y * WORLD_W + x]] === 1
+}
+
+export function fertileAt(w: WorldState, x: number, y: number): boolean {
+  if (!inBounds(x, y)) return false
+  return IS_FERTILE[w.tiles[y * WORLD_W + x]] === 1
+}
+
+export function setTile(w: WorldState, x: number, y: number, mat: number): void {
+  if (!inBounds(x, y)) return
+  w.tiles[y * WORLD_W + x] = mat
+}
+
+/**
+ * Does a box of tiles overlap anything solid?
+ * Used for both movement collision and finding somewhere to put a creature.
+ */
+export function boxHitsSolid(
+  w: WorldState,
+  x: number,
+  y: number,
+  bw: number,
+  bh: number
+): boolean {
+  const x0 = Math.floor(x)
+  const y0 = Math.floor(y)
+  const x1 = Math.floor(x + bw - 0.001)
+  const y1 = Math.floor(y + bh - 0.001)
+  for (let ty = y0; ty <= y1; ty++) {
+    for (let tx = x0; tx <= x1; tx++) {
+      if (solidAt(w, tx, ty)) return true
+    }
+  }
+  return false
+}
+
+/**
+ * Drop a box straight down from `y` until it rests on solid ground, and return
+ * the resting top edge (or null if there's no floor within `maxDrop`, or the
+ * box would be buried where it lands).
+ *
+ * This exists because "is there ground under me" is deceptively easy to get
+ * wrong. A box at y with height bh occupies rows `floor(y)` through
+ * `floor(y + bh - 0.001)` — so the tile *below* it is `floor(y + bh - 0.001) + 1`,
+ * NOT `floor(y + bh)`. Those two differ for every non-integer y, and the naive
+ * version asks about a row the box is already standing in — which collision has
+ * necessarily just proven to be empty. The check silently never passes, and
+ * nothing that walks or grows can ever be placed.
+ */
+export function settleOnGround(
+  w: WorldState,
+  x: number,
+  y: number,
+  bw: number,
+  bh: number,
+  opts: { maxDrop?: number; requireFertile?: boolean } = {}
+): number | null {
+  const maxDrop = opts.maxDrop ?? 64
+  const x0 = Math.floor(x)
+  const x1 = Math.floor(x + bw - 0.001)
+
+  for (let top = Math.floor(y); top <= Math.floor(y) + maxDrop; top++) {
+    if (top + bh > WORLD_H) return null
+    const groundRow = top + bh
+
+    let footing = false
+    for (let tx = x0; tx <= x1; tx++) {
+      if (!solidAt(w, tx, groundRow)) continue
+      footing = opts.requireFertile ? fertileAt(w, tx, groundRow) : true
+      if (footing) break
+    }
+    if (!footing) continue
+
+    // Found a floor. It only counts if the body itself fits above it.
+    if (boxHitsSolid(w, x, top, bw, bh)) return null
+    return top
+  }
+  return null
+}
+
+/** Fraction of a creature's box that's sitting in liquid, 0..1. */
+export function boxLiquidFraction(
+  w: WorldState,
+  x: number,
+  y: number,
+  bw: number,
+  bh: number
+): number {
+  const x0 = Math.floor(x)
+  const y0 = Math.floor(y)
+  const x1 = Math.floor(x + bw - 0.001)
+  const y1 = Math.floor(y + bh - 0.001)
+  let wet = 0
+  let total = 0
+  for (let ty = y0; ty <= y1; ty++) {
+    for (let tx = x0; tx <= x1; tx++) {
+      total++
+      if (liquidAt(w, tx, ty)) wet++
+    }
+  }
+  return total === 0 ? 0 : wet / total
+}
+
+/** The first deadly material the creature's box is touching, if any. */
+export function boxDeadlyMaterial(
+  w: WorldState,
+  x: number,
+  y: number,
+  bw: number,
+  bh: number
+): number | null {
+  const x0 = Math.floor(x)
+  const y0 = Math.floor(y)
+  const x1 = Math.floor(x + bw - 0.001)
+  const y1 = Math.floor(y + bh - 0.001)
+  for (let ty = y0; ty <= y1; ty++) {
+    for (let tx = x0; tx <= x1; tx++) {
+      if (deadlyAt(w, tx, ty)) return tileAt(w, tx, ty)
+    }
+  }
+  return null
+}
+
+// ---------------------------------------------------------------------------
+// Terrain
+// ---------------------------------------------------------------------------
+
+/** Rebuild the tile grid from a theme. Creatures are left alone. */
+export function applyTheme(w: WorldState, themeId: string, seed?: number): void {
+  applyThemeObject(w, THEME_BY_ID[themeId] ?? THEME_BY_ID[DEFAULT_THEME], seed)
+}
+
+/** Same, for a theme that isn't in the registry — i.e. summoned terrain. */
+export function applyThemeObject(w: WorldState, theme: Theme, seed?: number): void {
+  const s = seed ?? Math.floor(Math.random() * 1e9)
+  w.seed = s
+  const rng = makeRng(s)
+  theme.build(w.tiles, rng)
+  for (let i = 0; i < w.grain.length; i++) w.grain[i] = Math.floor(rng() * 256)
+  w.particles.length = 0
+}
+
+/** Paint a filled circle of material. This is the player's brush. */
+export function paintCircle(
+  w: WorldState,
+  cx: number,
+  cy: number,
+  radius: number,
+  mat: MaterialId
+): void {
+  const value = MATERIAL_INDEX[mat]
+  const r2 = radius * radius
+  const x0 = Math.floor(cx - radius)
+  const x1 = Math.ceil(cx + radius)
+  const y0 = Math.floor(cy - radius)
+  const y1 = Math.ceil(cy + radius)
+  for (let y = y0; y <= y1; y++) {
+    for (let x = x0; x <= x1; x++) {
+      const dx = x - cx
+      const dy = y - cy
+      if (dx * dx + dy * dy <= r2) setTile(w, x, y, value)
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Spawning
+// ---------------------------------------------------------------------------
+
+export function registerBlueprint(w: WorldState, bp: CreatureBlueprint): void {
+  w.blueprints[bp.id] = bp
+  // Summoned creatures become native too, so the world can bring them back.
+  if (!w.natives.includes(bp.id)) w.natives.push(bp.id)
+}
+
+/** Make a creature at an exact spot, no questions asked. */
+export function spawnCreature(
+  w: WorldState,
+  bp: CreatureBlueprint,
+  x: number,
+  y: number
+): Creature | null {
+  if (w.creatures.length >= MAX_CREATURES) return null
+  if (!w.blueprints[bp.id]) w.blueprints[bp.id] = bp
+
+  const creature: Creature = {
+    id: w.nextCreatureId++,
+    blueprintId: bp.id,
+    x,
+    y,
+    vx: 0,
+    vy: 0,
+    facing: 1,
+    hunger: 0.2,
+    starving: 0,
+    ageSeconds: 0,
+    distress: 0,
+    mood: 'wander',
+    targetId: null,
+    drift: 0,
+    animMs: Math.random() * bp.art.frameMs * bp.art.frames.length,
+    grounded: false,
+    breedCooldown: 0,
+    mealsEaten: 0,
+    children: 0,
+    digProgress: 0,
+    tilesDug: 0,
+  }
+  w.creatures.push(creature)
+  return creature
+}
+
+/**
+ * Find somewhere this creature could actually survive and put it there.
+ *
+ * Plants want fertile ground under them, fish want water, walkers want a floor.
+ * Tries random spots and falls back to the requested position so a summon never
+ * silently does nothing.
+ */
+export function spawnSomewhereSensible(
+  w: WorldState,
+  bp: CreatureBlueprint,
+  rng: Rng,
+  near?: { x: number; y: number; radius: number }
+): Creature | null {
+  const { w: bw, h: bh } = artSize(bp)
+  const wantsLiquid = bp.move.kind === 'swim' || bp.habitat.needs?.includes('water')
+  const isPlant = bp.move.kind === 'root'
+
+  for (let attempt = 0; attempt < 120; attempt++) {
+    let x: number
+    let y: number
+    if (near) {
+      const a = rng() * Math.PI * 2
+      const r = rng() * near.radius
+      x = near.x + Math.cos(a) * r
+      y = near.y + Math.sin(a) * r
+    } else {
+      x = rng() * (WORLD_W - bw)
+      y = rng() * (WORLD_H - bh)
+    }
+    x = Math.max(0, Math.min(WORLD_W - bw, x))
+    y = Math.max(0, Math.min(WORLD_H - bh, y))
+
+    if (boxHitsSolid(w, x, y, bw, bh)) continue
+
+    const wet = boxLiquidFraction(w, x, y, bw, bh)
+    if (wantsLiquid && wet < 0.6) continue
+    if (!wantsLiquid && bp.habitat.drowns && wet > 0.3) continue
+    if (boxDeadlyMaterial(w, x, y, bw, bh) !== null) {
+      const immune = bp.body.immuneTo.length > 0
+      if (!immune) continue
+    }
+
+    if (isPlant || bp.move.kind === 'walk') {
+      // Fall from wherever we landed onto the first floor beneath it. Scanning
+      // down rather than demanding a floor at exactly this height is what makes
+      // a random point in open sky a usable spawn instead of a wasted attempt.
+      const settled = settleOnGround(w, x, y, bw, bh, { requireFertile: isPlant })
+      if (settled === null) continue
+      y = settled
+      // Re-check the surroundings at the resting spot, not where we aimed.
+      if (bp.habitat.drowns && boxLiquidFraction(w, x, y, bw, bh) > 0.3) continue
+      if (
+        boxDeadlyMaterial(w, x, y, bw, bh) !== null &&
+        bp.body.immuneTo.length === 0
+      ) {
+        continue
+      }
+    }
+
+    return spawnCreature(w, bp, x, y)
+  }
+
+  // Nowhere ideal. Drop it wherever the player asked and let physics sort it out.
+  if (near && !boxHitsSolid(w, near.x, near.y, bw, bh)) {
+    return spawnCreature(w, bp, near.x - bw / 2, near.y - bh / 2)
+  }
+  return null
+}
+
+/** Seed a theme's resident population. */
+export function seedStarters(w: WorldState, themeId: string, rng: Rng): void {
+  const theme = THEME_BY_ID[themeId]
+  if (!theme) return
+  for (const entry of theme.starters) {
+    const bp = w.blueprints[entry.id]
+    if (!bp) continue
+    if (!w.natives.includes(bp.id)) w.natives.push(bp.id)
+    for (let i = 0; i < entry.count; i++) spawnSomewhereSensible(w, bp, rng)
+  }
+}
+
+export function clearCreatures(w: WorldState): void {
+  w.creatures.length = 0
+  w.particles.length = 0
+}
+
+/**
+ * Let the world heal itself.
+ *
+ * Populations here are small enough that an oscillation eventually touches zero,
+ * and zero is absorbing: plants only come from plants, hoppers only from
+ * hoppers. Without this, every world converges on the same dead end — a field of
+ * whatever happened to be last standing — and the only cure is a restart.
+ *
+ * Real habitats recover because the frame we're watching isn't the whole world:
+ * seed blows in, animals wander over the hill. This is that edge, and it obeys
+ * two rules that keep it honest:
+ *   - Nothing returns to an empty world. Pressing Empty means empty.
+ *   - A predator only returns when there is something alive for it to eat, so
+ *     this can never conjure a species straight back into starving to death.
+ */
+export function repopulate(w: WorldState, rng: Rng): void {
+  if (w.elapsed < w.nextSeedRain) return
+  w.nextSeedRain = w.elapsed + SEED_RAIN_INTERVAL
+  if (w.creatures.length === 0 || w.natives.length === 0) return
+
+  const counts: Record<string, number> = {}
+  let plants = 0
+  for (const c of w.creatures) {
+    counts[c.blueprintId] = (counts[c.blueprintId] ?? 0) + 1
+    if (w.blueprints[c.blueprintId]?.move.kind === 'root') plants++
+  }
+
+  // Plants first — everything else is downstream of them.
+  if (plants < PLANT_FLOOR) {
+    const plantIds = w.natives.filter((id) => w.blueprints[id]?.move.kind === 'root')
+    if (plantIds.length > 0) {
+      const bp = w.blueprints[plantIds[Math.floor(rng() * plantIds.length)]]
+      if (bp) spawnSomewhereSensible(w, bp, rng)
+      return
+    }
+  }
+
+  // Then any native that has died out and now has something to eat again.
+  // Plants count here too: one plant species thriving is not a reason for the
+  // others to stay extinct, and a grazer too small to eat the survivor depends
+  // on the little ones coming back.
+  const candidates = w.natives.filter((id) => {
+    if (counts[id]) return false
+    const bp = w.blueprints[id]
+    if (!bp) return false
+    if (bp.move.kind === 'root' || bp.diet.eats.length === 0) return true
+    return w.creatures.some((c) => {
+      const other = w.blueprints[c.blueprintId]
+      return other ? canEat(bp, other) : false
+    })
+  })
+  if (candidates.length === 0) return
+
+  const bp = w.blueprints[candidates[Math.floor(rng() * candidates.length)]]
+  if (bp) {
+    spawnSomewhereSensible(w, bp, rng)
+    spawnSomewhereSensible(w, bp, rng)
+  }
+}
+
+export function countByBlueprint(w: WorldState): Record<string, number> {
+  const counts: Record<string, number> = {}
+  for (const c of w.creatures) counts[c.blueprintId] = (counts[c.blueprintId] ?? 0) + 1
+  return counts
+}
+
+export { AIR }

--- a/src/app/micro-land/domain/sim/world.ts
+++ b/src/app/micro-land/domain/sim/world.ts
@@ -1,13 +1,15 @@
 /** World construction, tile access, and spawning. */
-import { artSize, canEat } from '@/app/micro-land/domain/blueprint'
+import { artSize, bodyBox, canEat } from '@/app/micro-land/domain/blueprint'
 import { BUILTIN_CREATURES } from '@/app/micro-land/domain/config/creatures'
 import {
   AIR,
   IS_DEADLY,
+  IS_DROWNING,
   IS_FERTILE,
   IS_LIQUID,
   IS_SOLID,
   MATERIAL_INDEX,
+  VISCOSITY,
 } from '@/app/micro-land/domain/config/materials'
 import { DEFAULT_THEME, THEME_BY_ID, type Theme } from '@/app/micro-land/domain/config/themes'
 import {
@@ -145,24 +147,45 @@ export function settleOnGround(
   const maxDrop = opts.maxDrop ?? 64
   const x0 = Math.floor(x)
   const x1 = Math.floor(x + bw - 0.001)
+  const startTop = Math.floor(y)
+  const limit = Math.min(WORLD_H - 1, startTop + maxDrop + Math.ceil(bh))
 
-  for (let top = Math.floor(y); top <= Math.floor(y) + maxDrop; top++) {
-    if (top + bh > WORLD_H) return null
-    const groundRow = top + bh
-
-    let footing = false
-    for (let tx = x0; tx <= x1; tx++) {
-      if (!solidAt(w, tx, groundRow)) continue
-      footing = opts.requireFertile ? fertileAt(w, tx, groundRow) : true
-      if (footing) break
+  /**
+   * The *highest* solid tile anywhere under the footprint.
+   *
+   * This used to take the first footing found in any column, walking the box
+   * down until some column had ground beneath it. For a 4-wide bug that is the
+   * same answer. For an 18-wide dinosaur on a hillside it lands the box at the
+   * height of the lowest column, which buries its uphill half in the slope —
+   * the fit check then fails and nothing that big could ever be placed at all.
+   * Resting on the highest ground under the footprint is what "standing on a
+   * hill" actually means.
+   */
+  let ground = Infinity
+  let fertileGround = false
+  for (let tx = x0; tx <= x1; tx++) {
+    for (let ty = startTop; ty <= limit; ty++) {
+      if (!solidAt(w, tx, ty)) continue
+      if (ty < ground) {
+        ground = ty
+        fertileGround = fertileAt(w, tx, ty)
+      } else if (ty === ground && fertileAt(w, tx, ty)) {
+        fertileGround = true
+      }
+      break
     }
-    if (!footing) continue
-
-    // Found a floor. It only counts if the body itself fits above it.
-    if (boxHitsSolid(w, x, top, bw, bh)) return null
-    return top
   }
-  return null
+  if (ground === Infinity) return null
+  if (opts.requireFertile && !fertileGround) return null
+
+  // The tile *below* a box at `top` is `floor(top + bh - 0.001) + 1`, not
+  // `floor(top + bh)` — those differ for every non-integer top, and the naive
+  // version asks about a row the box is already standing in. Sitting the box
+  // exactly `bh` above the ground row is what makes that arithmetic come out.
+  const top = ground - bh
+  if (top < 0) return null
+  if (boxHitsSolid(w, x, top, bw, bh)) return null
+  return top
 }
 
 /** Fraction of a creature's box that's sitting in liquid, 0..1. */
@@ -186,6 +209,64 @@ export function boxLiquidFraction(
     }
   }
   return total === 0 ? 0 : wet / total
+}
+
+/**
+ * Fraction of the box sitting in something it could drown in, 0..1.
+ *
+ * Deliberately not the same as `boxLiquidFraction`. Sap is a liquid for every
+ * physical purpose — it's buoyant, it drags, things sink into it — but it isn't
+ * water, and a creature stuck in tree sap is stuck, not drowning.
+ */
+export function boxDrownFraction(
+  w: WorldState,
+  x: number,
+  y: number,
+  bw: number,
+  bh: number
+): number {
+  const x0 = Math.floor(x)
+  const y0 = Math.floor(y)
+  const x1 = Math.floor(x + bw - 0.001)
+  const y1 = Math.floor(y + bh - 0.001)
+  let submerged = 0
+  let total = 0
+  for (let ty = y0; ty <= y1; ty++) {
+    for (let tx = x0; tx <= x1; tx++) {
+      total++
+      if (!inBounds(tx, ty)) continue
+      if (IS_DROWNING[w.tiles[ty * WORLD_W + tx]] === 1) submerged++
+    }
+  }
+  return total === 0 ? 0 : submerged / total
+}
+
+/**
+ * How gummed-up the creature's box is, 0..1.
+ *
+ * The thickest tile wins rather than the average: one foot in the sap should
+ * hold you, not be diluted by the nine tiles of clear air around it.
+ */
+export function boxViscosity(
+  w: WorldState,
+  x: number,
+  y: number,
+  bw: number,
+  bh: number
+): number {
+  const x0 = Math.floor(x)
+  const y0 = Math.floor(y)
+  const x1 = Math.floor(x + bw - 0.001)
+  const y1 = Math.floor(y + bh - 0.001)
+  let worst = 0
+  for (let ty = y0; ty <= y1; ty++) {
+    for (let tx = x0; tx <= x1; tx++) {
+      if (!inBounds(tx, ty)) continue
+      const v = VISCOSITY[w.tiles[ty * WORLD_W + tx]]
+      if (v > worst) worst = v
+    }
+  }
+  return worst / 255
 }
 
 /** The first deadly material the creature's box is touching, if any. */
@@ -321,8 +402,15 @@ export function findSpawnSpot(
   near?: { x: number; y: number; radius: number }
 ): { x: number; y: number } | null {
   const { w: bw, h: bh } = artSize(bp)
+  const body = bodyBox(bp)
   const wantsLiquid = bp.move.kind === 'swim' || bp.habitat.needs?.includes('water')
   const isPlant = bp.move.kind === 'root'
+
+  // Somewhere to stand is judged on the solid core, not the drawing. A dragon
+  // that needed a clear 28-tile box to exist would almost never find one, and
+  // every summon would silently fall back to "drop it wherever".
+  const fits = (x: number, y: number) =>
+    !boxHitsSolid(w, x + body.dx, y + body.dy, body.w, body.h)
 
   for (let attempt = 0; attempt < 120; attempt++) {
     let x: number
@@ -339,12 +427,12 @@ export function findSpawnSpot(
     x = Math.max(0, Math.min(WORLD_W - bw, x))
     y = Math.max(0, Math.min(WORLD_H - bh, y))
 
-    if (boxHitsSolid(w, x, y, bw, bh)) continue
+    if (!fits(x, y)) continue
 
-    const wet = boxLiquidFraction(w, x, y, bw, bh)
+    const wet = boxLiquidFraction(w, x + body.dx, y + body.dy, body.w, body.h)
     if (wantsLiquid && wet < 0.6) continue
     if (!wantsLiquid && bp.habitat.drowns && wet > 0.3) continue
-    if (boxDeadlyMaterial(w, x, y, bw, bh) !== null) {
+    if (boxDeadlyMaterial(w, x + body.dx, y + body.dy, body.w, body.h) !== null) {
       const immune = bp.body.immuneTo.length > 0
       if (!immune) continue
     }
@@ -353,13 +441,21 @@ export function findSpawnSpot(
       // Fall from wherever we landed onto the first floor beneath it. Scanning
       // down rather than demanding a floor at exactly this height is what makes
       // a random point in open sky a usable spawn instead of a wasted attempt.
-      const settled = settleOnGround(w, x, y, bw, bh, { requireFertile: isPlant })
+      const settled = settleOnGround(w, x + body.dx, y + body.dy, body.w, body.h, {
+        requireFertile: isPlant,
+      })
       if (settled === null) continue
-      y = settled
+      // `settled` is the core's resting top edge; the sprite hangs above it.
+      y = settled - body.dy
       // Re-check the surroundings at the resting spot, not where we aimed.
-      if (bp.habitat.drowns && boxLiquidFraction(w, x, y, bw, bh) > 0.3) continue
       if (
-        boxDeadlyMaterial(w, x, y, bw, bh) !== null &&
+        bp.habitat.drowns &&
+        boxLiquidFraction(w, x + body.dx, y + body.dy, body.w, body.h) > 0.3
+      ) {
+        continue
+      }
+      if (
+        boxDeadlyMaterial(w, x + body.dx, y + body.dy, body.w, body.h) !== null &&
         bp.body.immuneTo.length === 0
       ) {
         continue
@@ -370,7 +466,11 @@ export function findSpawnSpot(
   }
 
   // Nowhere ideal. Drop it wherever the player asked and let physics sort it out.
-  if (near && !boxHitsSolid(w, near.x, near.y, bw, bh)) {
+  // Resolved from a stash conflict: keep this function returning a spot (the
+  // caller does the spawning now), but test the fit against the solid core
+  // rather than the whole sprite — a dragon's wingtips overlapping a hill must
+  // not be the reason a summon lands nowhere.
+  if (near && fits(near.x - bw / 2, near.y - bh / 2)) {
     return { x: near.x - bw / 2, y: near.y - bh / 2 }
   }
   return null

--- a/src/app/micro-land/domain/sim/world.ts
+++ b/src/app/micro-land/domain/sim/world.ts
@@ -12,7 +12,12 @@ import {
 import { DEFAULT_THEME, THEME_BY_ID, type Theme } from '@/app/micro-land/domain/config/themes'
 import {
   MAX_CREATURES,
-  PLANT_FLOOR,
+  MAX_PLANTS,
+  NATIVE_PLANT_SPECIES,
+  NATIVE_PLANT_TARGET,
+  PLANT_SEED_BATCH,
+  PLANT_SEED_INTERVAL,
+  PLANT_SPECIES_CAP,
   SEED_RAIN_INTERVAL,
   WORLD_H,
   WORLD_W,
@@ -44,6 +49,8 @@ export function createWorld(seed = 1337): WorldState {
     flowPhase: 0,
     natives: [],
     nextSeedRain: 0,
+    nextPlantSeed: 0,
+    dormant: false,
   }
 }
 
@@ -218,6 +225,7 @@ export function applyThemeObject(w: WorldState, theme: Theme, seed?: number): vo
   theme.build(w.tiles, rng)
   for (let i = 0; i < w.grain.length; i++) w.grain[i] = Math.floor(rng() * 256)
   w.particles.length = 0
+  w.dormant = false
 }
 
 /** Paint a filled circle of material. This is the player's brush. */
@@ -229,6 +237,9 @@ export function paintCircle(
   mat: MaterialId
 ): void {
   const value = MATERIAL_INDEX[mat]
+  // Painting is the player building something, which is the opposite of asking
+  // for an empty world — so the ground is allowed to grow again.
+  w.dormant = false
   const r2 = radius * radius
   const x0 = Math.floor(cx - radius)
   const x1 = Math.ceil(cx + radius)
@@ -291,18 +302,21 @@ export function spawnCreature(
 }
 
 /**
- * Find somewhere this creature could actually survive and put it there.
+ * Find somewhere this creature could actually survive.
  *
  * Plants want fertile ground under them, fish want water, walkers want a floor.
- * Tries random spots and falls back to the requested position so a summon never
- * silently does nothing.
+ * Returns the sprite's top-left corner, or null if nowhere in this world suits.
+ *
+ * Split out from `spawnSomewhereSensible` so the same search can answer "could
+ * this species live here at all?" without actually creating anything — which is
+ * how the ground decides which plants are native to it.
  */
-export function spawnSomewhereSensible(
+export function findSpawnSpot(
   w: WorldState,
   bp: CreatureBlueprint,
   rng: Rng,
   near?: { x: number; y: number; radius: number }
-): Creature | null {
+): { x: number; y: number } | null {
   const { w: bw, h: bh } = artSize(bp)
   const wantsLiquid = bp.move.kind === 'swim' || bp.habitat.needs?.includes('water')
   const isPlant = bp.move.kind === 'root'
@@ -349,20 +363,33 @@ export function spawnSomewhereSensible(
       }
     }
 
-    return spawnCreature(w, bp, x, y)
+    return { x, y }
   }
 
   // Nowhere ideal. Drop it wherever the player asked and let physics sort it out.
   if (near && !boxHitsSolid(w, near.x, near.y, bw, bh)) {
-    return spawnCreature(w, bp, near.x - bw / 2, near.y - bh / 2)
+    return { x: near.x - bw / 2, y: near.y - bh / 2 }
   }
   return null
+}
+
+/** Find somewhere this creature could survive and put it there. */
+export function spawnSomewhereSensible(
+  w: WorldState,
+  bp: CreatureBlueprint,
+  rng: Rng,
+  near?: { x: number; y: number; radius: number }
+): Creature | null {
+  const spot = findSpawnSpot(w, bp, rng, near)
+  if (!spot) return null
+  return spawnCreature(w, bp, spot.x, spot.y)
 }
 
 /** Seed a theme's resident population. */
 export function seedStarters(w: WorldState, themeId: string, rng: Rng): void {
   const theme = THEME_BY_ID[themeId]
   if (!theme) return
+  w.dormant = false
   for (const entry of theme.starters) {
     const bp = w.blueprints[entry.id]
     if (!bp) continue
@@ -376,44 +403,145 @@ export function clearCreatures(w: WorldState): void {
   w.particles.length = 0
 }
 
+// ---------------------------------------------------------------------------
+// Native plants — the ground's seed bank
+// ---------------------------------------------------------------------------
+
+function isPlant(bp: CreatureBlueprint | undefined): boolean {
+  return bp?.move.kind === 'root'
+}
+
+/** Native species that are plants. Empty until the ground has decided. */
+function nativePlantIds(w: WorldState): string[] {
+  return w.natives.filter((id) => isPlant(w.blueprints[id]))
+}
+
+/** Is there anywhere in this world a plant could put roots down? */
+function hasFertileGround(w: WorldState): boolean {
+  for (let i = 0; i < w.tiles.length; i++) {
+    if (IS_FERTILE[w.tiles[i]] === 1) return true
+  }
+  return false
+}
+
 /**
- * Let the world heal itself.
+ * Decide which plants belong to this world, once, the first time it has soil.
  *
- * Populations here are small enough that an oscillation eventually touches zero,
- * and zero is absorbing: plants only come from plants, hoppers only from
- * hoppers. Without this, every world converges on the same dead end — a field of
- * whatever happened to be last standing — and the only cure is a restart.
+ * A theme hands its flora over through `starters`, so this is really for the
+ * worlds nobody wrote: an Empty canvas the player paints grass onto, terrain
+ * that came back from a summon, stone a Loamworm has been patiently turning
+ * into dirt. Those worlds have ground and no reason for anything to grow on it.
  *
- * Real habitats recover because the frame we're watching isn't the whole world:
- * seed blows in, animals wander over the hill. This is that edge, and it obeys
- * two rules that keep it honest:
- *   - Nothing returns to an empty world. Pressing Empty means empty.
- *   - A predator only returns when there is something alive for it to eat, so
- *     this can never conjure a species straight back into starving to death.
+ * Which species is settled by asking the world rather than by a lookup table —
+ * a candidate is native if `findSpawnSpot` can actually place it. Kelp rules
+ * itself out of a world with no water without anyone having to say so, and a
+ * summoned material nobody has thought about yet still gets an honest answer.
+ *
+ * Picks a few of the viable species rather than all of them, so a pond and a
+ * meadow don't grow the same flora.
  */
-export function repopulate(w: WorldState, rng: Rng): void {
-  if (w.elapsed < w.nextSeedRain) return
-  w.nextSeedRain = w.elapsed + SEED_RAIN_INTERVAL
-  if (w.creatures.length === 0 || w.natives.length === 0) return
+export function establishNativePlants(w: WorldState, rng: Rng): boolean {
+  if (nativePlantIds(w).length > 0) return true
+  if (!hasFertileGround(w)) return false
+
+  const viable: string[] = []
+  for (const bp of Object.values(w.blueprints)) {
+    if (!isPlant(bp)) continue
+    if (findSpawnSpot(w, bp, rng)) viable.push(bp.id)
+  }
+  if (viable.length === 0) return false
+
+  // Fisher–Yates over a copy, so the pick is drawn from the world's own RNG and
+  // stays reproducible for the headless harness.
+  for (let i = viable.length - 1; i > 0; i--) {
+    const j = Math.floor(rng() * (i + 1))
+    ;[viable[i], viable[j]] = [viable[j], viable[i]]
+  }
+  for (const id of viable.slice(0, NATIVE_PLANT_SPECIES)) w.natives.push(id)
+  return true
+}
+
+/**
+ * The ground pushing its plant population back toward a living level.
+ *
+ * Runs on its own clock, separate from the animal seed rain, because the two
+ * answer different questions. Seed rain asks "has a species died out and is
+ * there food for it again"; this asks "is there less green here than this soil
+ * can support" — and it keeps asking, which is the whole point. A meadow that
+ * gets grazed to nothing is a meadow that grows back.
+ *
+ * Deliberately blind to whether anything is alive. Plants having no upstream is
+ * exactly the problem being solved; requiring a survivor would leave a stripped
+ * world just as dead as before.
+ */
+export function seedNativePlants(w: WorldState, rng: Rng): void {
+  if (w.elapsed < w.nextPlantSeed) return
+  w.nextPlantSeed = w.elapsed + PLANT_SEED_INTERVAL
+  if (w.dormant) return
+  if (!establishNativePlants(w, rng)) return
 
   const counts: Record<string, number> = {}
   let plants = 0
   for (const c of w.creatures) {
+    if (!isPlant(w.blueprints[c.blueprintId])) continue
     counts[c.blueprintId] = (counts[c.blueprintId] ?? 0) + 1
-    if (w.blueprints[c.blueprintId]?.move.kind === 'root') plants++
+    plants++
   }
 
-  // Plants first — everything else is downstream of them.
-  if (plants < PLANT_FLOOR) {
-    const plantIds = w.natives.filter((id) => w.blueprints[id]?.move.kind === 'root')
-    if (plantIds.length > 0) {
-      const bp = w.blueprints[plantIds[Math.floor(rng() * plantIds.length)]]
-      if (bp) spawnSomewhereSensible(w, bp, rng)
-      return
-    }
+  const deficit = NATIVE_PLANT_TARGET - plants
+  if (deficit <= 0) return
+  if (plants >= MAX_PLANTS || w.creatures.length >= MAX_CREATURES) return
+
+  // Scale the seeding to how bare the world is: a nearly-full meadow gets one
+  // sprout, a stripped one gets the full batch. Recovery from a crash is fast
+  // without the ground quietly out-growing the grazers the rest of the time.
+  const batch = Math.min(
+    PLANT_SEED_BATCH,
+    Math.max(1, Math.ceil((deficit / NATIVE_PLANT_TARGET) * PLANT_SEED_BATCH))
+  )
+
+  // Rarest first, so the ground refills the species the grazers actually
+  // emptied instead of piling more onto whichever one is already winning.
+  const pool = nativePlantIds(w)
+    .filter((id) => (counts[id] ?? 0) < PLANT_SPECIES_CAP)
+    .sort((a, b) => (counts[a] ?? 0) - (counts[b] ?? 0))
+  if (pool.length === 0) return
+
+  for (let i = 0; i < batch; i++) {
+    const bp = w.blueprints[pool[i % pool.length]]
+    if (bp) spawnSomewhereSensible(w, bp, rng)
+  }
+}
+
+/**
+ * Let the world heal itself — the animal half.
+ *
+ * Populations here are small enough that an oscillation eventually touches zero,
+ * and zero is absorbing: hoppers only come from hoppers. Without this, every
+ * world converges on the same dead end — a field of whatever happened to be last
+ * standing — and the only cure is a restart.
+ *
+ * Real habitats recover because the frame we're watching isn't the whole world:
+ * animals wander over the hill. This is that edge, and it obeys two rules that
+ * keep it honest:
+ *   - Nothing returns to an empty world. Pressing Empty means empty.
+ *   - A predator only returns when there is something alive for it to eat, so
+ *     this can never conjure a species straight back into starving to death.
+ *
+ * Plants are not handled here. They have no upstream at all, so the ground
+ * carries their seed instead — see `seedNativePlants`.
+ */
+export function repopulate(w: WorldState, rng: Rng): void {
+  if (w.elapsed < w.nextSeedRain) return
+  w.nextSeedRain = w.elapsed + SEED_RAIN_INTERVAL
+  if (w.dormant || w.creatures.length === 0 || w.natives.length === 0) return
+
+  const counts: Record<string, number> = {}
+  for (const c of w.creatures) {
+    counts[c.blueprintId] = (counts[c.blueprintId] ?? 0) + 1
   }
 
-  // Then any native that has died out and now has something to eat again.
+  // Any native that has died out and now has something to eat again.
   // Plants count here too: one plant species thriving is not a reason for the
   // others to stay extinct, and a grazer too small to eat the survivor depends
   // on the little ones coming back.

--- a/src/app/micro-land/domain/sim/world.ts
+++ b/src/app/micro-land/domain/sim/world.ts
@@ -296,6 +296,9 @@ export function spawnCreature(
     children: 0,
     digProgress: 0,
     tilesDug: 0,
+    // Founder of its line until `reproduce` says otherwise.
+    generation: 1,
+    name: null,
   }
   w.creatures.push(creature)
   return creature

--- a/src/app/micro-land/domain/terrain.ts
+++ b/src/app/micro-land/domain/terrain.ts
@@ -1,0 +1,211 @@
+/**
+ * Promptable terrain.
+ *
+ * The model already draws creatures as a grid of characters plus a legend, and
+ * it turns out that is also the right way to let it draw a *world*. A coarse map
+ * — roughly 40x24 — is small enough to author reliably and, scaled up with a
+ * noise-jittered sample, produces organic caves and shorelines rather than
+ * visible rectangles.
+ *
+ * The alternative (a parameterised list of layers and features) would have been
+ * more compact but far less expressive: you can't ask for "an island with a
+ * flooded cave under it" in a band list, and you can draw it in about four
+ * lines of text.
+ */
+import { z } from 'zod'
+
+import { MATERIAL_IDS } from './config/materials'
+import { WORLD_H, WORLD_W } from './constants'
+import { type Rng, fbm, makeNoise2D } from './sim/prng'
+
+import type { Theme } from './config/themes'
+import type { MaterialId } from './types'
+
+const MAP_MIN = 6
+const MAP_MAX_COLS = 96
+const MAP_MAX_ROWS = 48
+const MAX_LEGEND = 14
+
+const materialEnum = z.enum([...MATERIAL_IDS] as [MaterialId, ...MaterialId[]])
+
+const hexColor = z.string().describe('A hex color like #7fc4e8.')
+
+export const TerrainSchema = z.object({
+  name: z.string().describe('Short name for this land, 1-3 words. Title Case.'),
+  sky: z
+    .object({
+      top: hexColor.describe('Color at the very top of the background.'),
+      bottom: hexColor.describe('Color at the very bottom of the background.'),
+    })
+    .describe(
+      'The empty background behind the world, seen wherever there are no tiles.'
+    ),
+  gloom: z
+    .number()
+    .describe(
+      'How dark the unlit parts are, 0 to 1. 0.2 for a bright outdoor place, 0.6 for a deep cave or deep space. Light comes from open sky above and from lava and glowing creatures.'
+    ),
+  gravity: z
+    .number()
+    .describe(
+      'Gravity multiplier, 0.2 to 1.5. Use 1 for anywhere on the ground. Use about 0.35 for orbit or space, so things drift instead of dropping.'
+    ),
+  legend: z
+    .array(
+      z.object({
+        key: z.string().describe('A SINGLE character used in the map rows.'),
+        material: materialEnum.describe('Which material that character means.'),
+      })
+    )
+    .describe(
+      'What each character in the map means. Max 14 entries. Never define "." — it is always empty air.'
+    ),
+  map: z
+    .array(z.string())
+    .describe(
+      'The world drawn as rows of characters, top row = sky, bottom row = the very bottom of the world. Aim for about 40 characters wide and 24 rows tall; every row must be the same length. Use "." for empty air. This gets scaled up and roughened, so draw the big shapes — hills, caves, a shoreline, a lava layer — and let the detail happen on its own.'
+    ),
+})
+
+export type RawTerrain = z.infer<typeof TerrainSchema>
+
+export interface SanitizedTerrain {
+  name: string
+  sky: [string, string]
+  gloom: number
+  gravity: number
+  legend: Record<string, MaterialId>
+  map: string[]
+}
+
+function clamp(n: unknown, lo: number, hi: number, fallback: number): number {
+  const v = typeof n === 'number' && Number.isFinite(n) ? n : fallback
+  return Math.min(hi, Math.max(lo, v))
+}
+
+function cleanColor(c: unknown, fallback: string): string {
+  return typeof c === 'string' && /^#[0-9a-fA-F]{6}$/.test(c) ? c.toLowerCase() : fallback
+}
+
+/** Never throws — a half-drawn map still becomes a playable world. */
+export function sanitizeTerrain(raw: unknown): SanitizedTerrain {
+  const t = (raw ?? {}) as Record<string, unknown>
+  const sky = (t.sky ?? {}) as Record<string, unknown>
+
+  const valid = new Set<string>(MATERIAL_IDS)
+  const legend: Record<string, MaterialId> = {}
+  if (Array.isArray(t.legend)) {
+    for (const entry of t.legend) {
+      const e = (entry ?? {}) as Record<string, unknown>
+      const key = typeof e.key === 'string' ? e.key.slice(0, 1) : ''
+      const material = typeof e.material === 'string' ? e.material : ''
+      if (!key || key === '.' || !valid.has(material)) continue
+      legend[key] = material as MaterialId
+      if (Object.keys(legend).length >= MAX_LEGEND) break
+    }
+  }
+
+  const rawMap = Array.isArray(t.map)
+    ? t.map.filter((r): r is string => typeof r === 'string').slice(0, MAP_MAX_ROWS)
+    : []
+
+  let map: string[]
+  if (rawMap.length < MAP_MIN || Object.keys(legend).length === 0) {
+    // Nothing usable. A flat island beats an empty void the player can't stand on.
+    legend.g = 'grass'
+    legend.d = 'dirt'
+    legend.s = 'stone'
+    map = [
+      ...Array(10).fill('.'.repeat(40)),
+      'gggggggggggggggggggggggggggggggggggggggg',
+      'dddddddddddddddddddddddddddddddddddddddd',
+      'dddddddddddddddddddddddddddddddddddddddd',
+      ...Array(11).fill('ssssssssssssssssssssssssssssssssssssssss'),
+    ]
+  } else {
+    const width = Math.min(
+      MAP_MAX_COLS,
+      Math.max(MAP_MIN, Math.max(...rawMap.map((r) => r.length)))
+    )
+    const known = new Set(Object.keys(legend))
+    map = rawMap.map((row) => {
+      let line = ''
+      for (let x = 0; x < width; x++) {
+        const ch = row[x] ?? '.'
+        line += known.has(ch) ? ch : '.'
+      }
+      return line
+    })
+  }
+
+  return {
+    name:
+      typeof t.name === 'string' && t.name.trim() ? t.name.trim().slice(0, 32) : 'Summoned Land',
+    sky: [cleanColor(sky.top, '#243b55'), cleanColor(sky.bottom, '#0b1020')],
+    gloom: clamp(t.gloom, 0, 0.85, 0.3),
+    gravity: clamp(t.gravity, 0.15, 2, 1),
+    legend,
+    map,
+  }
+}
+
+/**
+ * Paint the coarse map into the tile grid.
+ *
+ * The sample point is nudged by a little fbm noise before it's floored, which
+ * is what turns the map's straight cell edges into ragged, natural-looking
+ * boundaries. Without it a 40x24 map upscaled 5x reads as obvious blocks.
+ */
+export function paintTerrain(
+  tiles: Uint8Array,
+  terrain: SanitizedTerrain,
+  rng: Rng,
+  materialIndex: Record<MaterialId, number>
+): void {
+  const rows = terrain.map.length
+  const cols = terrain.map[0].length
+  const noise = makeNoise2D(Math.floor(rng() * 1e9))
+
+  const scaleX = cols / WORLD_W
+  const scaleY = rows / WORLD_H
+  // Roughen by about half a map cell, in world tiles.
+  const wobble = Math.max(1, Math.min(WORLD_W / cols, WORLD_H / rows) * 0.65)
+
+  for (let y = 0; y < WORLD_H; y++) {
+    for (let x = 0; x < WORLD_W; x++) {
+      const nx = (fbm(noise, x * 0.09, y * 0.09, 2) - 0.5) * 2 * wobble
+      const ny = (fbm(noise, x * 0.09 + 31.7, y * 0.09 - 12.3, 2) - 0.5) * 2 * wobble
+
+      const cx = Math.floor((x + nx) * scaleX)
+      const cy = Math.floor((y + ny) * scaleY)
+      const row = terrain.map[Math.max(0, Math.min(rows - 1, cy))]
+      const ch = row[Math.max(0, Math.min(cols - 1, cx))] ?? '.'
+      const material = terrain.legend[ch]
+      tiles[y * WORLD_W + x] = material ? materialIndex[material] : 0
+    }
+  }
+}
+
+/** Wrap summoned terrain so it behaves exactly like a built-in theme. */
+export function terrainToTheme(
+  terrain: SanitizedTerrain,
+  materialIndex: Record<MaterialId, number>
+): Theme {
+  return {
+    id: 'summoned',
+    name: terrain.name,
+    blurb: 'A land you asked for.',
+    sky: terrain.sky,
+    gloom: terrain.gloom,
+    gravity: terrain.gravity,
+    // Creatures arrive from the scene that summoned it, not from a starter list.
+    starters: [],
+    build: (tiles, rng) => paintTerrain(tiles, terrain, rng, materialIndex),
+  }
+}
+
+/** True if anything can take root here — no fertile tile means no food chain. */
+export function hasFertileGround(terrain: SanitizedTerrain): boolean {
+  const fertile = new Set<MaterialId>(['dirt', 'grass', 'sand', 'ash', 'wood'])
+  return Object.values(terrain.legend).some((m) => fertile.has(m))
+}

--- a/src/app/micro-land/domain/terrain.ts
+++ b/src/app/micro-land/domain/terrain.ts
@@ -22,7 +22,14 @@ import type { Theme } from './config/themes'
 import type { MaterialId } from './types'
 
 const MAP_MIN = 6
-const MAP_MAX_COLS = 96
+/**
+ * Wide enough for a model to draw the whole world at once.
+ *
+ * A world 672 tiles across wants roughly 120 map columns to keep its cells
+ * square. This sits well above that so a model that draws generously gets its
+ * detail scaled down rather than chopped off at the right-hand edge.
+ */
+const MAP_MAX_COLS = 200
 const MAP_MAX_ROWS = 48
 const MAX_LEGEND = 14
 
@@ -90,7 +97,7 @@ export const TerrainSchema = z.object({
   map: z
     .array(z.string())
     .describe(
-      'The world drawn as rows of characters, top row = sky, bottom row = the very bottom of the world. Aim for about 40 characters wide and 24 rows tall; every row must be the same length. Use "." for empty air. This gets scaled up and roughened, so draw the big shapes — hills, caves, a shoreline, a lava layer — and let the detail happen on its own.'
+      'The world drawn as rows of characters, top row = sky, bottom row = the very bottom of the world. The world is WIDE — aim for about 120 characters across and 24 rows tall; every row must be the same length. Use "." for empty air. This gets scaled up and roughened, so draw the big shapes — hills, caves, a shoreline, a lava layer — and let the detail happen on its own. Vary it from one end to the other: it is a long stretch of land, not one scene repeated.'
     ),
 })
 
@@ -240,6 +247,14 @@ export function fitGroundLevel(map: string[], rng: Rng): string[] {
  * The sample point is nudged by a little fbm noise before it's floored, which
  * is what turns the map's straight cell edges into ragged, natural-looking
  * boundaries. Without it a 40x24 map upscaled 5x reads as obvious blocks.
+ *
+ * Horizontal scale is *not* simply "stretch the map to fit". The world is five
+ * times wider than it is tall, so stretching a 40-column map across it makes
+ * every cell three times wider than it is deep — hills become plateaus, caves
+ * become tunnels, and the whole thing reads as a smear. Instead a cell is kept
+ * square, and a map too narrow to reach the far edge is repeated, mirrored, so
+ * the seams line up and the land simply carries on. A model that draws the full
+ * ~120 columns never repeats at all.
  */
 export function paintTerrain(
   tiles: Uint8Array,
@@ -252,17 +267,31 @@ export function paintTerrain(
   const cols = map[0].length
   const noise = makeNoise2D(Math.floor(rng() * 1e9))
 
-  const scaleX = cols / WORLD_W
   const scaleY = rows / WORLD_H
+  // How many columns a map would need to cross the world with square cells.
+  const squareCols = WORLD_W * scaleY
+  const repeats = cols < squareCols - 0.5
+  // A map drawn *wider* than that is squeezed to fit instead of repeated. There
+  // is no third option — the rows have to span the world's full height, which
+  // fixes the vertical scale — and squeezing is much the gentler failure: it
+  // makes hills steeper, where the old stretch made them into plateaus.
+  const scaleX = repeats ? scaleY : cols / WORLD_W
+  // Out and back again, so the joins are reflections rather than hard cuts.
+  const period = cols * 2
+
   // Roughen by about half a map cell, in world tiles.
-  const wobble = Math.max(1, Math.min(WORLD_W / cols, WORLD_H / rows) * 0.65)
+  const wobble = Math.max(1, Math.min(1 / scaleX, 1 / scaleY) * 0.65)
 
   for (let y = 0; y < WORLD_H; y++) {
     for (let x = 0; x < WORLD_W; x++) {
       const nx = (fbm(noise, x * 0.09, y * 0.09, 2) - 0.5) * 2 * wobble
       const ny = (fbm(noise, x * 0.09 + 31.7, y * 0.09 - 12.3, 2) - 0.5) * 2 * wobble
 
-      const cx = Math.floor((x + nx) * scaleX)
+      let cx = Math.floor((x + nx) * scaleX)
+      if (repeats) {
+        const p = ((cx % period) + period) % period
+        cx = p < cols ? p : period - 1 - p
+      }
       const cy = Math.floor((y + ny) * scaleY)
       const row = map[Math.max(0, Math.min(rows - 1, cy))]
       const ch = row[Math.max(0, Math.min(cols - 1, cx))] ?? '.'

--- a/src/app/micro-land/domain/terrain.ts
+++ b/src/app/micro-land/domain/terrain.ts
@@ -14,7 +14,7 @@
  */
 import { z } from 'zod'
 
-import { MATERIAL_IDS } from './config/materials'
+import { BASE_MATERIAL_IDS, MATERIALS, MATERIAL_IDS } from './config/materials'
 import { WORLD_H, WORLD_W } from './constants'
 import { type Rng, fbm, makeNoise2D } from './sim/prng'
 
@@ -26,7 +26,34 @@ const MAP_MAX_COLS = 96
 const MAP_MAX_ROWS = 48
 const MAX_LEGEND = 14
 
-const materialEnum = z.enum([...MATERIAL_IDS] as [MaterialId, ...MaterialId[]])
+/**
+ * Where the ground should sit, as a share of the world's height.
+ *
+ * Models draw a horizon the way you would on paper — two thirds of the way up,
+ * with a strip of sky above it — and the result is a world that is mostly dirt.
+ * But almost everything a player comes to watch happens *above* the surface:
+ * things walking, flying, hunting, falling. Earth below the surface is only
+ * interesting where it's hollow. So the surface belongs low, and the air above
+ * it is the part worth spending the world's height on.
+ *
+ * Around 0.4, spread so it usually lands between 0.3 and 0.5 and sometimes
+ * doesn't — a world that always has its horizon in the same place stops reading
+ * as a place and starts reading as a template.
+ */
+const GROUND_TARGET = 0.4
+const GROUND_SPREAD = 0.52
+const GROUND_MIN = 0.18
+const GROUND_MAX = 0.62
+
+/** A row counts as ground once this much of it is solid. */
+const GROUND_ROW_FILL = 0.5
+
+/** Ceiling on rows after padding, so an extreme roll can't squash the land flat. */
+const MAX_PADDED_ROWS = 100
+
+// Base materials only — tints are something the player paints, not vocabulary
+// the model needs. See the same note in `blueprint.ts`.
+const materialEnum = z.enum([...BASE_MATERIAL_IDS] as [MaterialId, ...MaterialId[]])
 
 const hexColor = z.string().describe('A hex color like #7fc4e8.')
 
@@ -150,6 +177,64 @@ export function sanitizeTerrain(raw: unknown): SanitizedTerrain {
 }
 
 /**
+ * The first row that is mostly solid — the top of the land.
+ *
+ * Deliberately not "the highest non-air tile in each column": that finds the tip
+ * of a lone mountain, a cloud, or a floating island and calls it the ground,
+ * which would shove a perfectly good world into the basement. A row only counts
+ * once it is half earth, which is the row a creature would actually walk on.
+ *
+ * Returns -1 when nothing qualifies — a world of floating islands has no ground
+ * level to speak of, and the honest answer there is to leave it alone.
+ */
+function groundRow(map: string[]): number {
+  const cols = map[0].length
+  const needed = cols * GROUND_ROW_FILL
+  for (let y = 0; y < map.length; y++) {
+    let solid = 0
+    for (let x = 0; x < cols; x++) if (map[y][x] !== '.') solid++
+    if (solid >= needed) return y
+  }
+  return -1
+}
+
+/**
+ * Slide the ground down (or up) until the surface sits at a sensible height.
+ *
+ * The map is stretched to the world's height whatever its row count, so adding
+ * empty rows on top is all it takes: the land keeps every cave, seam and pool
+ * the model drew and simply occupies less of the world. Trimming works the same
+ * way in reverse, and only ever removes rows that are entirely air, so nothing
+ * drawn is ever cut off.
+ */
+export function fitGroundLevel(map: string[], rng: Rng): string[] {
+  const top = groundRow(map)
+  if (top < 0) return map
+
+  const rows = map.length
+  // Three rolls averaged: a hump around GROUND_TARGET rather than a flat band,
+  // so the usual world is ordinary and the occasional one is a canyon or a plain.
+  const roll = (rng() + rng() + rng()) / 3
+  const target = Math.min(
+    GROUND_MAX,
+    Math.max(GROUND_MIN, GROUND_TARGET + (roll - 0.5) * GROUND_SPREAD)
+  )
+
+  const depth = rows - top
+  const wanted = Math.min(MAX_PADDED_ROWS, Math.round(depth / target))
+  const sky = '.'.repeat(map[0].length)
+
+  if (wanted > rows) return [...Array<string>(wanted - rows).fill(sky), ...map]
+
+  // Raising the ground means eating into the sky, and only into empty sky —
+  // a mountain peak or a floating island sits above `top` and must survive.
+  let empty = 0
+  while (empty < top && /^\.*$/.test(map[empty])) empty++
+  const trim = Math.min(rows - wanted, empty)
+  return trim > 0 ? map.slice(trim) : map
+}
+
+/**
  * Paint the coarse map into the tile grid.
  *
  * The sample point is nudged by a little fbm noise before it's floored, which
@@ -162,8 +247,9 @@ export function paintTerrain(
   rng: Rng,
   materialIndex: Record<MaterialId, number>
 ): void {
-  const rows = terrain.map.length
-  const cols = terrain.map[0].length
+  const map = fitGroundLevel(terrain.map, rng)
+  const rows = map.length
+  const cols = map[0].length
   const noise = makeNoise2D(Math.floor(rng() * 1e9))
 
   const scaleX = cols / WORLD_W
@@ -178,7 +264,7 @@ export function paintTerrain(
 
       const cx = Math.floor((x + nx) * scaleX)
       const cy = Math.floor((y + ny) * scaleY)
-      const row = terrain.map[Math.max(0, Math.min(rows - 1, cy))]
+      const row = map[Math.max(0, Math.min(rows - 1, cy))]
       const ch = row[Math.max(0, Math.min(cols - 1, cx))] ?? '.'
       const material = terrain.legend[ch]
       tiles[y * WORLD_W + x] = material ? materialIndex[material] : 0
@@ -206,6 +292,7 @@ export function terrainToTheme(
 
 /** True if anything can take root here — no fertile tile means no food chain. */
 export function hasFertileGround(terrain: SanitizedTerrain): boolean {
-  const fertile = new Set<MaterialId>(['dirt', 'grass', 'sand', 'ash', 'wood'])
-  return Object.values(terrain.legend).some((m) => fertile.has(m))
+  // Read off the materials themselves rather than a copy of the list, so a new
+  // fertile material is never fertile for plants but invisible to this check.
+  return Object.values(terrain.legend).some((m) => MATERIALS[m]?.fertile)
 }

--- a/src/app/micro-land/domain/types.ts
+++ b/src/app/micro-land/domain/types.ts
@@ -244,6 +244,22 @@ export interface Creature {
   digProgress: number
   /** Lifetime tally of tiles tunnelled through. */
   tilesDug: number
+  /**
+   * How far back this creature's line goes. 1 was placed or seeded by hand or by
+   * the world; anything higher was born here, to a parent one lower.
+   *
+   * Counts ancestry rather than population, so it survives a crash: a species
+   * can dwindle to a single individual and its line keeps its depth.
+   */
+  generation: number
+  /**
+   * What the player called it.
+   *
+   * Only ever offered for a creature holding the longevity record — naming is
+   * the moment a creature stops being one of the hoppers and becomes *yours*,
+   * and it is worth more if it has to be earned.
+   */
+  name: string | null
 }
 
 export interface Particle {

--- a/src/app/micro-land/domain/types.ts
+++ b/src/app/micro-land/domain/types.ts
@@ -9,8 +9,16 @@
  * into a running world with no new rendering or behavior code.
  */
 
-/** Tile materials. The world is a grid of these. */
-export type MaterialId =
+/**
+ * Tile materials. The world is a grid of these.
+ *
+ * `BaseMaterialId` is the vocabulary — the list a person (or the summoning
+ * model) thinks in. A handful of those are *tintable*: the player can paint them
+ * in any of `TintId`'s colors, and each color is its own entry in the tile grid
+ * (`'plastic-red'`, `'crystal-blue'`). Tints are pure recolors — they inherit
+ * every physical property from the material they came from.
+ */
+export type BaseMaterialId =
   | 'air'
   | 'dirt'
   | 'grass'
@@ -24,6 +32,36 @@ export type MaterialId =
   | 'ash'
   | 'obsidian'
   | 'wood'
+  | 'snow'
+  | 'mud'
+  | 'moss'
+  | 'crystal'
+  | 'gem'
+  | 'gold'
+  | 'bone'
+  | 'iron'
+  | 'marble'
+  | 'plastic'
+  | 'cloud'
+  | 'sap'
+  | 'acid'
+
+/** The colors a tintable material can be painted in. */
+export type TintId =
+  | 'red'
+  | 'orange'
+  | 'yellow'
+  | 'green'
+  | 'blue'
+  | 'purple'
+  | 'pink'
+  | 'white'
+  | 'black'
+
+/** Materials that come in colors. */
+export type TintableMaterialId = 'plastic' | 'crystal' | 'gem' | 'cloud'
+
+export type MaterialId = BaseMaterialId | `${TintableMaterialId}-${TintId}`
 
 export interface Material {
   id: MaterialId
@@ -44,6 +82,25 @@ export interface Material {
   glow: number
   /** Plants can only root on these. */
   fertile: boolean
+  /**
+   * How much this gums up anything moving through it, 0..1.
+   *
+   * Only means anything for stuff you can be *inside* — cloud and sap. 0 is
+   * open air; 0.9 is wading through treacle.
+   */
+  viscous: number
+  /** A liquid you can still breathe in, so it never drowns anything. */
+  breathable: boolean
+  /** Turns to water next to lava. */
+  melts: boolean
+  /** Eats through neighbouring solids, using itself up as it goes. */
+  corrosive: boolean
+  /** Corrosive materials can't touch this. */
+  acidProof: boolean
+  /** The player can paint this in any tint. Set on the base material only. */
+  tintable: boolean
+  /** For a tint variant, the material it is a recolor of. */
+  tintOf: TintableMaterialId | null
 }
 
 // ---------------------------------------------------------------------------
@@ -157,6 +214,26 @@ export interface CreatureDig {
   speed: number
 }
 
+/**
+ * A creature that changes the world around it rather than just living in it.
+ *
+ * This is how a bee is different from a moth. Both fly and eat plants; only one
+ * of them makes the meadow grow faster. Kept as data like everything else, so a
+ * summoned creature can be a helper too.
+ */
+export interface CreatureAura {
+  /** How far the effect reaches, in tiles. */
+  radius: number
+  /** Creatures carrying any of these tags breed faster nearby. */
+  helps: string[]
+  /** How much faster. 1 = no help, 3 = three times as fast. */
+  boost: number
+  /** Ground it slowly changes as it goes, e.g. stone into dirt. */
+  converts: { from: MaterialId; to: MaterialId } | null
+  /** Conversions per second, at most. Low reads as patient work. */
+  convertRate: number
+}
+
 export interface CreatureDeath {
   /** Leaves this material behind on the tile where it died. */
   becomes: MaterialId | null
@@ -192,6 +269,8 @@ export interface CreatureBlueprint {
   habitat: CreatureHabitat
   dig: CreatureDig
   death: CreatureDeath
+  /** What it does to its surroundings, or null for the vast majority. */
+  aura: CreatureAura | null
   /** Light it casts into dark areas, 0..1. */
   glow: number
   /** True for anything the player summoned, so we can badge it in the UI. */

--- a/src/app/micro-land/domain/types.ts
+++ b/src/app/micro-land/domain/types.ts
@@ -282,4 +282,14 @@ export interface WorldState {
   natives: string[]
   /** Next world-clock time at which repopulation may fire. */
   nextSeedRain: number
+  /** Next world-clock time at which the ground may seed native plants. */
+  nextPlantSeed: number
+  /**
+   * True while the player has deliberately emptied the world.
+   *
+   * Native plants otherwise grow back out of the soil forever, which would make
+   * Empty impossible to hold on any world that has ground in it. Anything
+   * generative — painting, placing, summoning, changing theme — wakes it again.
+   */
+  dormant: boolean
 }

--- a/src/app/micro-land/domain/types.ts
+++ b/src/app/micro-land/domain/types.ts
@@ -1,0 +1,285 @@
+/**
+ * Micro Land — core types.
+ *
+ * The whole point of this world is that a creature is *data*. Everything a
+ * creature is — its pixels, its animation, how it falls, what it eats, what it
+ * runs from, what it leaves behind when it dies — lives in a single plain
+ * object literal. Nothing about a creature is code. That's what lets an LLM
+ * invent one at runtime (see `blueprint.ts` + the summon route) and drop it
+ * into a running world with no new rendering or behavior code.
+ */
+
+/** Tile materials. The world is a grid of these. */
+export type MaterialId =
+  | 'air'
+  | 'dirt'
+  | 'grass'
+  | 'stone'
+  | 'sand'
+  | 'water'
+  | 'lava'
+  | 'ice'
+  | 'metal'
+  | 'glass'
+  | 'ash'
+  | 'obsidian'
+  | 'wood'
+
+export interface Material {
+  id: MaterialId
+  name: string
+  /** Base color, #rrggbb. Per-tile jitter is applied at render time. */
+  color: string
+  /** How much the renderer varies each tile's color, 0..1. Gives texture. */
+  grain: number
+  /** Solid tiles block movement and stop falling powders. */
+  solid: boolean
+  /** Liquids flow sideways and creatures can swim/drown in them. */
+  liquid: boolean
+  /** Powders fall and pile into slopes. */
+  powder: boolean
+  /** Touching this kills anything not immune to it. */
+  deadly: boolean
+  /** Emits light into the dark. 0 = none. */
+  glow: number
+  /** Plants can only root on these. */
+  fertile: boolean
+}
+
+// ---------------------------------------------------------------------------
+// Creature blueprints — the promptable entity model
+// ---------------------------------------------------------------------------
+
+/**
+ * Pixel art for a creature.
+ *
+ * `frames` is an array of animation frames; each frame is an array of row
+ * strings; each character in a row is a key into `palette`. `.` is always
+ * transparent. Every row in every frame must be the same length.
+ *
+ *   palette: { b: '#33dd88', e: '#ffffff' }
+ *   frames: [
+ *     ['.bbb.',
+ *      'bebeb',
+ *      '.bbb.'],
+ *   ]
+ */
+export interface CreatureArt {
+  /** Single-character key → `#rrggbb`. `.` is reserved for transparent. */
+  palette: Record<string, string>
+  /** 1–4 frames of equal dimensions. */
+  frames: string[][]
+  /** Milliseconds per animation frame. */
+  frameMs: number
+  /** Mirror the sprite horizontally when moving left. */
+  faceMotion: boolean
+}
+
+export type LocomotionKind =
+  /** Affected by gravity, walks on solid ground, can jump. */
+  | 'walk'
+  /** Ignores gravity, moves freely through air. */
+  | 'fly'
+  /** Only moves inside liquid; flops helplessly on land. */
+  | 'swim'
+  /** Sticks to any surface — walls and ceilings included. */
+  | 'crawl'
+  /** Gravity applies but weakly; bobs and drifts. */
+  | 'drift'
+  /** Never moves. Plants, eggs, coral, mushrooms. */
+  | 'root'
+
+export interface CreatureBody {
+  /** Gravity multiplier. 0 = weightless, 1 = normal, 3 = boulder. */
+  mass: number
+  /** How much velocity is kept on impact, 0..1. */
+  bounce: number
+  /** Velocity retained per second in air, 0..1. Low = sluggish. */
+  drag: number
+  /** > 1 floats up in liquid, < 1 sinks. */
+  buoyancy: number
+  /** Materials that can't hurt this creature (e.g. `['lava']`). */
+  immuneTo: MaterialId[]
+}
+
+export interface CreatureMove {
+  kind: LocomotionKind
+  /** Tiles per second at full tilt. */
+  speed: number
+  /** Jump impulse in tiles/second. Only used by `walk`. */
+  jump: number
+  /** Chance per second of picking a new idle direction, 0..1. */
+  restlessness: number
+}
+
+export interface CreatureDiet {
+  /**
+   * Tags this creature can eat. A creature can eat another if any of these
+   * tags appears in the target's `tags` *and* the target isn't bigger than it.
+   * This one rule is the entire food chain.
+   */
+  eats: string[]
+  /** Extra tags to flee from beyond its natural predators. */
+  fears: string[]
+  /** Hunger gained per second, 0..1 scale. At 1 it starts starving. */
+  hungerRate: number
+  /** How long it survives at full hunger before dying. */
+  starveSeconds: number
+  /** Fullness (0..1) needed before it will reproduce. */
+  breedAt: number
+  /** Dies of old age after this long. */
+  lifespanSeconds: number
+}
+
+export interface CreatureSenses {
+  /** How far it can spot food or danger, in tiles. */
+  sight: number
+}
+
+export interface CreatureHabitat {
+  /** If set, it takes damage anywhere that isn't one of these materials. */
+  needs: MaterialId[] | null
+  /** Non-swimmers drown; set false for amphibians. */
+  drowns: boolean
+}
+
+/**
+ * What this creature can tunnel through.
+ *
+ * Kept separate from locomotion on purpose: digging is orthogonal to how you
+ * move, so a walker, a swimmer and a floater can each be a digger, and each can
+ * be limited to different rock.
+ */
+export interface CreatureDig {
+  /** Materials it can chew through. Empty means it cannot dig at all. */
+  through: MaterialId[]
+  /** Tiles per second it gets through. Low values read as effort. */
+  speed: number
+}
+
+export interface CreatureDeath {
+  /** Leaves this material behind on the tile where it died. */
+  becomes: MaterialId | null
+  /** Color of the burst of particles it leaves, `#rrggbb`. */
+  particleColor: string
+  /** How many particles. 0 for a quiet death. */
+  particleCount: number
+}
+
+/**
+ * A complete creature, as a plain object literal.
+ *
+ * Everything here is data an LLM can author. Nothing is a function, a class,
+ * or a reference to code. Add one of these to the world and it lives.
+ */
+export interface CreatureBlueprint {
+  id: string
+  name: string
+  /** One-line description, shown in the palette and the field guide. */
+  blurb: string
+  /**
+   * Relative size, 1 (mite) to 6 (leviathan). Drives the food chain: nothing
+   * can eat something bigger than itself.
+   */
+  size: number
+  /** What this creature *is*. Others hunt it by matching these. */
+  tags: string[]
+  art: CreatureArt
+  body: CreatureBody
+  move: CreatureMove
+  diet: CreatureDiet
+  senses: CreatureSenses
+  habitat: CreatureHabitat
+  dig: CreatureDig
+  death: CreatureDeath
+  /** Light it casts into dark areas, 0..1. */
+  glow: number
+  /** True for anything the player summoned, so we can badge it in the UI. */
+  summoned?: boolean
+}
+
+// ---------------------------------------------------------------------------
+// Live world state
+// ---------------------------------------------------------------------------
+
+export type CreatureMood = 'wander' | 'hunt' | 'flee' | 'eat' | 'rest'
+
+/** One living thing in the world. */
+export interface Creature {
+  id: number
+  blueprintId: string
+  /** World-tile coordinates of the sprite's top-left corner. */
+  x: number
+  y: number
+  vx: number
+  vy: number
+  /** Facing: 1 = right, -1 = left. */
+  facing: 1 | -1
+  /** 0 = stuffed, 1 = starving. */
+  hunger: number
+  /** Seconds spent at hunger >= 1. */
+  starving: number
+  ageSeconds: number
+  /**
+   * Seconds spent somewhere this creature can't survive — underwater for a
+   * lander, out of water for a fish. One timer covers both.
+   */
+  distress: number
+  mood: CreatureMood
+  /** Creature id this one is chasing or fleeing, if any. */
+  targetId: number | null
+  /** Idle wander direction, -1..1. */
+  drift: number
+  /** Animation clock, ms. */
+  animMs: number
+  /** True once it's on the ground (walkers only). */
+  grounded: boolean
+  /** Cooldown before it can breed again, seconds. */
+  breedCooldown: number
+  /** Lifetime tally of meals eaten — the inspector's evidence that it hunts. */
+  mealsEaten: number
+  /** Lifetime tally of offspring. */
+  children: number
+  /** Progress into the tile currently being chewed through, 0..1. */
+  digProgress: number
+  /** Lifetime tally of tiles tunnelled through. */
+  tilesDug: number
+}
+
+export interface Particle {
+  x: number
+  y: number
+  vx: number
+  vy: number
+  life: number
+  maxLife: number
+  color: string
+}
+
+export interface WorldState {
+  width: number
+  height: number
+  /** Row-major grid of materials, length `width * height`. */
+  tiles: Uint8Array
+  /** Per-tile color jitter, so the terrain doesn't look flat. */
+  grain: Uint8Array
+  creatures: Creature[]
+  particles: Particle[]
+  /** Blueprints available in this world, keyed by id. */
+  blueprints: Record<string, CreatureBlueprint>
+  nextCreatureId: number
+  /** Seconds since the world started. */
+  elapsed: number
+  /** Deterministic RNG state. */
+  seed: number
+  /** Tile-simulation phase, alternated so liquids don't drift one way. */
+  flowPhase: number
+  /**
+   * Species that belong to this world — theme starters plus anything the player
+   * summoned. Repopulation only ever draws from this list, so a desert never
+   * spontaneously sprouts kelp.
+   */
+  natives: string[]
+  /** Next world-clock time at which repopulation may fire. */
+  nextSeedRain: number
+}

--- a/src/app/micro-land/format.ts
+++ b/src/app/micro-land/format.ts
@@ -1,0 +1,23 @@
+/**
+ * Shared formatting for record read-outs.
+ *
+ * Lives outside the components because the same duration is spoken three times
+ * — in a notice, in the inspector, in the field guide — and they have to agree.
+ */
+
+/**
+ * Durations as a person would say them: "48s", "3m 12s", "1h 04m".
+ *
+ * Seconds are dropped above an hour, kept everywhere below it. A creature that
+ * lived four minutes and two seconds beat one that lived four minutes flat, and
+ * rounding that away would hide the thing the record is about.
+ */
+export function formatDuration(seconds: number): string {
+  const total = Math.max(0, Math.floor(seconds))
+  if (total < 60) return `${total}s`
+  const minutes = Math.floor(total / 60)
+  const rest = total % 60
+  if (minutes < 60) return `${minutes}m ${String(rest).padStart(2, '0')}s`
+  const hours = Math.floor(minutes / 60)
+  return `${hours}h ${String(minutes % 60).padStart(2, '0')}m`
+}

--- a/src/app/micro-land/game-instance.ts
+++ b/src/app/micro-land/game-instance.ts
@@ -1,0 +1,537 @@
+/**
+ * Owns the world, the loop, and the pointer.
+ *
+ * Deliberately outside React: the world mutates 60 times a second and React
+ * only hears about it through a small summary pushed a few times a second.
+ */
+import { MATERIAL_INDEX } from '@/app/micro-land/domain/config/materials'
+import {
+  type SanitizedTerrain,
+  sanitizeTerrain,
+  terrainToTheme,
+} from '@/app/micro-land/domain/terrain'
+import { SUMMONED_THEME_ID } from '@/app/micro-land/store'
+
+import { artSize, sanitizeBlueprint } from './domain/blueprint'
+import { DEFAULT_THEME, THEME_BY_ID, type Theme } from './domain/config/themes'
+import { MAX_CREATURES, TICK_S, TILE_TICK_EVERY } from './domain/constants'
+import { type SimEvent, tickCreatures } from './domain/sim/creature-sim'
+import { makeRng } from './domain/sim/prng'
+import { tickTiles } from './domain/sim/tile-sim'
+import {
+  applyTheme,
+  applyThemeObject,
+  boxHitsSolid,
+  boxLiquidFraction,
+  clearCreatures,
+  countByBlueprint,
+  createWorld,
+  paintCircle,
+  registerBlueprint,
+  seedStarters,
+  spawnCreature,
+  spawnSomewhereSensible,
+} from './domain/sim/world'
+import { Renderer } from './rendering/renderer'
+import { type PopulationEntry, useMicroLand } from './store'
+
+import type { Creature, CreatureBlueprint, WorldState } from './domain/types'
+
+/** How often the UI gets a fresh population summary. */
+const STATS_EVERY_MS = 300
+
+/** Placing creatures by dragging shouldn't fire once per frame. */
+const PLACE_THROTTLE_MS = 130
+
+/** Minimum world-seconds between "X caught a Y" notices. */
+const HUNT_NOTICE_GAP = 7
+
+/** Simulation can't catch up on more than this much time at once. */
+const MAX_CATCHUP_MS = 250
+
+export class GameInstance {
+  private canvas: HTMLCanvasElement
+  private renderer: Renderer
+  private world: WorldState
+  private rng = makeRng(0xc0ffee)
+
+  private rafId: number | null = null
+  private destroyed = false
+  private lastFrame = 0
+  private accumulator = 0
+  private tileCounter = 0
+  private statsTimer = 0
+
+  /** Species that existed last time we checked, for extinction notices. */
+  private knownSpecies = new Set<string>()
+  /** World-clock time of the last hunt notice, so kills don't spam the screen. */
+  private lastHuntNotice = -HUNT_NOTICE_GAP
+
+  // --- pointer state ---
+  private pointerDown = false
+  private grabbed: Creature | null = null
+  /** Creature the inspector is watching, if any. */
+  private inspectedId: number | null = null
+  /** Terrain the player summoned, standing in for a built-in theme. */
+  private summonedTheme: Theme | null = null
+  private grabTrail: { x: number; y: number; t: number }[] = []
+  private lastPlaceAt = 0
+  private resizeObserver: ResizeObserver | null = null
+
+  constructor(canvas: HTMLCanvasElement) {
+    this.canvas = canvas
+    this.renderer = new Renderer(canvas)
+    this.world = createWorld(Date.now() & 0xffff)
+
+    this.syncBlueprintsToStore()
+    this.setTheme(useMicroLand.getState().themeId || DEFAULT_THEME)
+    this.attachInput()
+    this.observeResize()
+  }
+
+  // -------------------------------------------------------------------------
+  // Lifecycle
+  // -------------------------------------------------------------------------
+
+  start(): void {
+    if (this.rafId !== null) return
+    this.lastFrame = performance.now()
+    const loop = (now: number) => {
+      if (this.destroyed) return
+      this.frame(now)
+      this.rafId = requestAnimationFrame(loop)
+    }
+    this.rafId = requestAnimationFrame(loop)
+  }
+
+  destroy(): void {
+    this.destroyed = true
+    if (this.rafId !== null) cancelAnimationFrame(this.rafId)
+    this.rafId = null
+    this.detachInput()
+    this.resizeObserver?.disconnect()
+    this.resizeObserver = null
+  }
+
+  private observeResize(): void {
+    const parent = this.canvas.parentElement
+    if (!parent) return
+    const apply = () => {
+      const rect = parent.getBoundingClientRect()
+      this.renderer.resize(rect.width, rect.height)
+    }
+    apply()
+    this.resizeObserver = new ResizeObserver(apply)
+    this.resizeObserver.observe(parent)
+  }
+
+  // -------------------------------------------------------------------------
+  // Loop
+  // -------------------------------------------------------------------------
+
+  private frame(now: number): void {
+    const state = useMicroLand.getState()
+    const theme = this.resolveTheme(state.themeId)
+
+    let delta = now - this.lastFrame
+    this.lastFrame = now
+    // A backgrounded tab hands back a huge delta; don't try to simulate it all.
+    if (delta > MAX_CATCHUP_MS) delta = MAX_CATCHUP_MS
+
+    if (!state.paused) {
+      this.accumulator += delta * state.speed
+      const step = TICK_S * 1000
+      let steps = 0
+      const events: SimEvent[] = []
+      while (this.accumulator >= step && steps < 8) {
+        this.accumulator -= step
+        steps++
+        this.step(theme.gravity, events)
+      }
+      if (steps > 0 && events.length > 0) this.digestEvents(events)
+    } else {
+      this.accumulator = 0
+    }
+
+    this.statsTimer += delta
+    if (this.statsTimer >= STATS_EVERY_MS) {
+      this.statsTimer = 0
+      this.pushStats()
+    }
+
+    // Keep the grabbed creature glued to the finger even while paused.
+    if (this.grabbed) this.grabbed.vx = this.grabbed.vy = 0
+
+    this.renderer.render(this.world, theme, this.inspectedId)
+  }
+
+  private step(gravity: number, events: SimEvent[]): void {
+    const w = this.world
+    w.elapsed += TICK_S
+
+    this.tileCounter++
+    if (this.tileCounter >= TILE_TICK_EVERY) {
+      this.tileCounter = 0
+      tickTiles(w)
+      // Tiles moved, so the cached tile image is stale.
+      this.renderer.markTilesDirty()
+    }
+
+    tickCreatures(w, TICK_S, this.rng, gravity, events)
+  }
+
+  /** Turn raw sim events into the occasional human-readable notice. */
+  private digestEvents(events: SimEvent[]): void {
+    const notify = useMicroLand.getState().notify
+
+    for (const event of events) {
+      // Announce predation on animals — a kill is instant and the victim just
+      // vanishes, so without this the food chain runs invisibly and looks like
+      // it isn't happening at all. Plants are eaten constantly; saying so every
+      // time would drown out everything else.
+      if (event.kind !== 'ate' || !event.victimId) continue
+      const victim = this.world.blueprints[event.victimId]
+      if (!victim || victim.move.kind === 'root') continue
+      if (this.world.elapsed - this.lastHuntNotice < HUNT_NOTICE_GAP) continue
+      const hunter = this.world.blueprints[event.blueprintId]
+      if (!hunter) continue
+      this.lastHuntNotice = this.world.elapsed
+      notify(`A ${hunter.name} caught a ${victim.name}.`)
+    }
+
+    for (const event of events) {
+      if (event.kind !== 'eaten' && event.kind !== 'starved') continue
+      const bp = this.world.blueprints[event.blueprintId]
+      if (!bp) continue
+      // Was that the last one? Only interesting for species we'd seen alive.
+      if (!this.knownSpecies.has(bp.id)) continue
+      const stillAlive = this.world.creatures.some((c) => c.blueprintId === bp.id)
+      if (stillAlive) continue
+      this.knownSpecies.delete(bp.id)
+      notify(
+        event.kind === 'starved'
+          ? `The last ${bp.name} starved.`
+          : `The last ${bp.name} was eaten.`
+      )
+    }
+  }
+
+  private pushStats(): void {
+    const counts = countByBlueprint(this.world)
+    const population: PopulationEntry[] = Object.entries(counts)
+      .map(([blueprintId, count]) => ({
+        blueprintId,
+        name: this.world.blueprints[blueprintId]?.name ?? blueprintId,
+        count,
+      }))
+      .sort((a, b) => b.count - a.count)
+
+    for (const entry of population) this.knownSpecies.add(entry.blueprintId)
+
+    useMicroLand
+      .getState()
+      .setStats(population, this.world.creatures.length, this.world.elapsed)
+
+    this.pushInspected()
+  }
+
+  /** Copy the watched creature's live state out for the inspector panel. */
+  private pushInspected(): void {
+    const store = useMicroLand.getState()
+    if (this.inspectedId === null) {
+      if (store.inspected !== null) store.setInspected(null)
+      return
+    }
+
+    const c = this.world.creatures.find((x) => x.id === this.inspectedId)
+    if (!c) {
+      // It died while we were watching. Let go rather than freezing a corpse.
+      this.inspectedId = null
+      store.setInspected(null)
+      return
+    }
+
+    const bp = this.world.blueprints[c.blueprintId]
+    if (!bp) return
+    const { w: bw, h: bh } = artSize(bp)
+
+    const target = c.targetId !== null
+      ? this.world.creatures.find((x) => x.id === c.targetId)
+      : undefined
+    const targetBp = target ? this.world.blueprints[target.blueprintId] : undefined
+
+    store.setInspected({
+      id: c.id,
+      blueprintId: c.blueprintId,
+      mood: c.mood,
+      hunger: c.hunger,
+      ageSeconds: c.ageSeconds,
+      lifespanSeconds: bp.diet.lifespanSeconds,
+      mealsEaten: c.mealsEaten,
+      children: c.children,
+      tilesDug: c.tilesDug,
+      distress: c.distress,
+      starving: c.starving,
+      speed: Math.hypot(c.vx, c.vy),
+      inWater: boxLiquidFraction(this.world, c.x, c.y, bw, bh) > 0.3,
+      grounded: c.grounded,
+      targetName: targetBp?.name ?? null,
+    })
+  }
+
+  private syncBlueprintsToStore(): void {
+    useMicroLand.getState().setBlueprints(Object.values(this.world.blueprints))
+  }
+
+  // -------------------------------------------------------------------------
+  // World commands (called from the UI)
+  // -------------------------------------------------------------------------
+
+  /** Summoned terrain wins over the registry when it's the selected world. */
+  private resolveTheme(themeId: string): Theme {
+    if (themeId === SUMMONED_THEME_ID && this.summonedTheme) return this.summonedTheme
+    return THEME_BY_ID[themeId] ?? THEME_BY_ID[DEFAULT_THEME]
+  }
+
+  /**
+   * Replace the land with terrain the player described.
+   * Living creatures are kept — the ground changes underneath them.
+   */
+  applyTerrain(raw: unknown, opts: { keepCreatures?: boolean } = {}): SanitizedTerrain {
+    const terrain = sanitizeTerrain(raw)
+    this.summonedTheme = terrainToTheme(terrain, MATERIAL_INDEX)
+    applyThemeObject(this.world, this.summonedTheme)
+    if (!opts.keepCreatures) {
+      clearCreatures(this.world)
+      this.knownSpecies.clear()
+      this.inspectedId = null
+    }
+    this.renderer.markTilesDirty()
+    useMicroLand.getState().setSummonedLand(terrain.name)
+    useMicroLand.getState().setTheme(SUMMONED_THEME_ID)
+    this.pushStats()
+    return terrain
+  }
+
+  setTheme(themeId: string): void {
+    if (themeId === SUMMONED_THEME_ID && this.summonedTheme) {
+      applyThemeObject(this.world, this.summonedTheme)
+      clearCreatures(this.world)
+      this.knownSpecies.clear()
+      this.inspectedId = null
+      this.renderer.markTilesDirty()
+      this.pushStats()
+      return
+    }
+    const theme = THEME_BY_ID[themeId]
+    if (!theme) return
+    applyTheme(this.world, themeId)
+    clearCreatures(this.world)
+    this.knownSpecies.clear()
+    this.inspectedId = null
+    seedStarters(this.world, themeId, this.rng)
+    this.renderer.markTilesDirty()
+    this.pushStats()
+  }
+
+  /** Rebuild the terrain with a new seed, keeping the theme. */
+  reshuffle(): void {
+    const themeId = useMicroLand.getState().themeId
+    if (themeId === SUMMONED_THEME_ID && this.summonedTheme) {
+      applyThemeObject(this.world, this.summonedTheme)
+      clearCreatures(this.world)
+      this.knownSpecies.clear()
+      this.inspectedId = null
+      this.renderer.markTilesDirty()
+      this.pushStats()
+      return
+    }
+    applyTheme(this.world, themeId)
+    clearCreatures(this.world)
+    this.knownSpecies.clear()
+    this.inspectedId = null
+    seedStarters(this.world, themeId, this.rng)
+    this.renderer.markTilesDirty()
+    this.pushStats()
+  }
+
+  clearLife(): void {
+    clearCreatures(this.world)
+    this.knownSpecies.clear()
+    this.inspectedId = null
+    this.pushStats()
+  }
+
+  /**
+   * Register a summoned blueprint and drop some into the world.
+   * Returns how many actually found somewhere to live.
+   */
+  introduce(raw: unknown, count: number): { blueprint: CreatureBlueprint; placed: number } {
+    const bp = sanitizeBlueprint(raw, { summoned: true })
+    registerBlueprint(this.world, bp)
+    this.syncBlueprintsToStore()
+
+    let placed = 0
+    for (let i = 0; i < count; i++) {
+      if (this.world.creatures.length >= MAX_CREATURES) break
+      if (spawnSomewhereSensible(this.world, bp, this.rng)) placed++
+    }
+    this.pushStats()
+    return { blueprint: bp, placed }
+  }
+
+  getWorld(): WorldState {
+    return this.world
+  }
+
+  // -------------------------------------------------------------------------
+  // Input
+  // -------------------------------------------------------------------------
+
+  private onPointerDown = (e: PointerEvent) => {
+    if (!e.isPrimary) return
+    this.canvas.setPointerCapture(e.pointerId)
+    this.pointerDown = true
+
+    const p = this.renderer.screenToWorld(e.clientX, e.clientY)
+    const hit = this.creatureAt(p.x, p.y)
+
+    if (useMicroLand.getState().tool.kind === 'inspect') {
+      // Tapping nothing clears the selection, which is how you close the panel.
+      this.inspectedId = hit ? hit.id : null
+      this.pushInspected()
+      return
+    }
+
+    if (hit) {
+      // Pick it up. This wins over placing — grabbing is the more specific intent.
+      this.grabbed = hit
+      this.grabTrail = [{ x: p.x, y: p.y, t: performance.now() }]
+      return
+    }
+
+    this.lastPlaceAt = 0
+    this.applyTool(p.x, p.y)
+  }
+
+  private onPointerMove = (e: PointerEvent) => {
+    if (!this.pointerDown || !e.isPrimary) return
+    const p = this.renderer.screenToWorld(e.clientX, e.clientY)
+
+    if (this.grabbed) {
+      const bp = this.world.blueprints[this.grabbed.blueprintId]
+      if (bp) {
+        const { w, h } = artSize(bp)
+        this.grabbed.x = Math.max(
+          0,
+          Math.min(this.world.width - w, p.x - w / 2)
+        )
+        this.grabbed.y = Math.max(
+          0,
+          Math.min(this.world.height - h, p.y - h / 2)
+        )
+        this.grabbed.vx = 0
+        this.grabbed.vy = 0
+      }
+      this.grabTrail.push({ x: p.x, y: p.y, t: performance.now() })
+      if (this.grabTrail.length > 6) this.grabTrail.shift()
+      return
+    }
+
+    this.applyTool(p.x, p.y)
+  }
+
+  private onPointerUp = (e: PointerEvent) => {
+    if (!e.isPrimary) return
+    this.pointerDown = false
+
+    if (this.grabbed) {
+      // Throw: velocity from how fast the pointer was moving as it let go.
+      const trail = this.grabTrail
+      if (trail.length >= 2) {
+        const first = trail[0]
+        const last = trail[trail.length - 1]
+        const dt = Math.max(0.016, (last.t - first.t) / 1000)
+        this.grabbed.vx = Math.max(-40, Math.min(40, (last.x - first.x) / dt))
+        this.grabbed.vy = Math.max(-40, Math.min(40, (last.y - first.y) / dt))
+      }
+      this.grabbed = null
+      this.grabTrail = []
+    }
+
+    if (this.canvas.hasPointerCapture(e.pointerId)) {
+      this.canvas.releasePointerCapture(e.pointerId)
+    }
+  }
+
+  private applyTool(x: number, y: number): void {
+    const state = useMicroLand.getState()
+    const tool = state.tool
+
+    if (tool.kind === 'creature') {
+      const now = performance.now()
+      if (now - this.lastPlaceAt < PLACE_THROTTLE_MS) return
+      this.lastPlaceAt = now
+      const bp = this.world.blueprints[tool.blueprintId]
+      if (!bp) return
+      if (this.world.creatures.length >= MAX_CREATURES) {
+        state.notify('The world is full. Something has to go.')
+        return
+      }
+      const { w, h } = artSize(bp)
+      const px = Math.max(0, Math.min(this.world.width - w, x - w / 2))
+      const py = Math.max(0, Math.min(this.world.height - h, y - h / 2))
+      if (boxHitsSolid(this.world, px, py, w, h)) {
+        // Tapped inside rock — find the nearest breathing room instead.
+        spawnSomewhereSensible(this.world, bp, this.rng, { x, y, radius: 10 })
+      } else {
+        spawnCreature(this.world, bp, px, py)
+      }
+      this.pushStats()
+      return
+    }
+
+    // Inspecting is resolved on pointerdown; it never paints.
+    if (tool.kind === 'inspect') return
+
+    const material = tool.kind === 'erase' ? 'air' : tool.material
+    paintCircle(this.world, x, y, state.brush, material)
+    this.renderer.markTilesDirty()
+  }
+
+  /** Topmost creature whose sprite box contains this point. */
+  private creatureAt(x: number, y: number): Creature | null {
+    const creatures = this.world.creatures
+    for (let i = creatures.length - 1; i >= 0; i--) {
+      const c = creatures[i]
+      const bp = this.world.blueprints[c.blueprintId]
+      if (!bp) continue
+      const { w, h } = artSize(bp)
+      // A little slack so small creatures are still grabbable on a phone.
+      const pad = Math.max(0, 3 - Math.min(w, h) / 2)
+      if (
+        x >= c.x - pad &&
+        x <= c.x + w + pad &&
+        y >= c.y - pad &&
+        y <= c.y + h + pad
+      ) {
+        return c
+      }
+    }
+    return null
+  }
+
+  private attachInput(): void {
+    this.canvas.addEventListener('pointerdown', this.onPointerDown)
+    this.canvas.addEventListener('pointermove', this.onPointerMove)
+    this.canvas.addEventListener('pointerup', this.onPointerUp)
+    this.canvas.addEventListener('pointercancel', this.onPointerUp)
+  }
+
+  private detachInput(): void {
+    this.canvas.removeEventListener('pointerdown', this.onPointerDown)
+    this.canvas.removeEventListener('pointermove', this.onPointerMove)
+    this.canvas.removeEventListener('pointerup', this.onPointerUp)
+    this.canvas.removeEventListener('pointercancel', this.onPointerUp)
+  }
+}

--- a/src/app/micro-land/game-instance.ts
+++ b/src/app/micro-land/game-instance.ts
@@ -22,8 +22,8 @@ import {
   rememberSpecies,
   updateChronicle,
 } from './chronicle/chronicle'
-import { artSize, sanitizeBlueprint } from './domain/blueprint'
 import { MILESTONES, type MilestoneContext } from './domain/config/milestones'
+import { artSize, bodyBox, sanitizeBlueprint } from './domain/blueprint'
 import { DEFAULT_THEME, THEME_BY_ID, type Theme } from './domain/config/themes'
 import {
   ELDER_MIN_SECONDS,
@@ -799,9 +799,12 @@ export class GameInstance {
         return
       }
       const { w, h } = artSize(bp)
+      const body = bodyBox(bp)
       const px = Math.max(0, Math.min(this.world.width - w, x - w / 2))
       const py = Math.max(0, Math.min(this.world.height - h, y - h / 2))
-      if (boxHitsSolid(this.world, px, py, w, h)) {
+      // Only the solid core has to be clear — tapping a spot where a dragon's
+      // wingtip overlaps a hill should still place the dragon.
+      if (boxHitsSolid(this.world, px + body.dx, py + body.dy, body.w, body.h)) {
         // Tapped inside rock — find the nearest breathing room instead.
         spawnSomewhereSensible(this.world, bp, this.rng, { x, y, radius: 10 })
       } else {

--- a/src/app/micro-land/game-instance.ts
+++ b/src/app/micro-land/game-instance.ts
@@ -12,9 +12,25 @@ import {
 } from '@/app/micro-land/domain/terrain'
 import { SUMMONED_THEME_ID } from '@/app/micro-land/store'
 
+import {
+  archivedSpecies,
+  claimMilestone,
+  landId,
+  landRecord,
+  noteSpeciesLife,
+  readChronicle,
+  rememberSpecies,
+  updateChronicle,
+} from './chronicle/chronicle'
 import { artSize, sanitizeBlueprint } from './domain/blueprint'
+import { MILESTONES, type MilestoneContext } from './domain/config/milestones'
 import { DEFAULT_THEME, THEME_BY_ID, type Theme } from './domain/config/themes'
-import { MAX_CREATURES, TICK_S, TILE_TICK_EVERY } from './domain/constants'
+import {
+  ELDER_MIN_SECONDS,
+  MAX_CREATURES,
+  TICK_S,
+  TILE_TICK_EVERY,
+} from './domain/constants'
 import { type SimEvent, tickCreatures } from './domain/sim/creature-sim'
 import { makeRng } from './domain/sim/prng'
 import { tickTiles } from './domain/sim/tile-sim'
@@ -32,9 +48,15 @@ import {
   spawnCreature,
   spawnSomewhereSensible,
 } from './domain/sim/world'
+import { formatDuration } from './format'
 import { Renderer } from './rendering/renderer'
-import { type PopulationEntry, useMicroLand } from './store'
+import {
+  type EarnedMilestone,
+  type PopulationEntry,
+  useMicroLand,
+} from './store'
 
+import type { SpeciesRecord } from './chronicle/types'
 import type { Creature, CreatureBlueprint, WorldState } from './domain/types'
 
 /** How often the UI gets a fresh population summary. */
@@ -48,6 +70,21 @@ const HUNT_NOTICE_GAP = 7
 
 /** Simulation can't catch up on more than this much time at once. */
 const MAX_CATCHUP_MS = 250
+
+/**
+ * Milestones already earned, in the order the config lists them.
+ *
+ * Ordered by the config rather than by when they were reached so the field
+ * guide reads as a ladder — the ones still ahead of you sit in a stable place.
+ */
+function readMilestones(): EarnedMilestone[] {
+  const earned = readChronicle().milestones
+  return MILESTONES.filter((m) => earned[m.id]).map((m) => ({
+    id: m.id,
+    text: m.text,
+    at: earned[m.id],
+  }))
+}
 
 export class GameInstance {
   private canvas: HTMLCanvasElement
@@ -66,6 +103,25 @@ export class GameInstance {
   private knownSpecies = new Set<string>()
   /** World-clock time of the last hunt notice, so kills don't spam the screen. */
   private lastHuntNotice = -HUNT_NOTICE_GAP
+
+  // --- records ---
+  /** Which land's records are being written to. See `landId()`. */
+  private currentLand = DEFAULT_THEME
+  /** The creature currently holding the longevity record, if one is alive. */
+  private elderId: number | null = null
+  /**
+   * Enough of the elder to eulogize it.
+   *
+   * Kept alongside the id because the announcement happens *after* the creature
+   * has already been filtered out of the world, so there is nothing left to read
+   * its age or its name off by then.
+   */
+  private elderSnapshot: { name: string | null; species: string; seconds: number } | null =
+    null
+  /** World-clock time the current no-extinction streak began. */
+  private steadySince = 0
+  /** Archive size at the last push, so the guide is only re-sent when it grows. */
+  private lastArchiveSize = -1
 
   // --- pointer state ---
   private pointerDown = false
@@ -162,7 +218,7 @@ export class GameInstance {
     // Keep the grabbed creature glued to the finger even while paused.
     if (this.grabbed) this.grabbed.vx = this.grabbed.vy = 0
 
-    this.renderer.render(this.world, theme, this.inspectedId)
+    this.renderer.render(this.world, theme, this.inspectedId, this.elderId)
   }
 
   private step(gravity: number, events: SimEvent[]): void {
@@ -208,12 +264,31 @@ export class GameInstance {
       const stillAlive = this.world.creatures.some((c) => c.blueprintId === bp.id)
       if (stillAlive) continue
       this.knownSpecies.delete(bp.id)
+      // An extinction is exactly what the steady streak measures the absence of
+      // — it is the moment the world has to bail the player out via seed rain.
+      this.breakSteadyStreak()
       notify(
         event.kind === 'starved'
           ? `The last ${bp.name} starved.`
           : `The last ${bp.name} was eaten.`
       )
     }
+  }
+
+  /**
+   * End the current no-extinction streak, banking it if it was the best.
+   *
+   * Banked before the reset rather than only at the end of a session, because
+   * most sessions end with the tab closing rather than with anything tidy.
+   */
+  private breakSteadyStreak(): void {
+    const run = this.world.elapsed - this.steadySince
+    this.steadySince = this.world.elapsed
+    if (run <= 0) return
+    updateChronicle(() => {
+      const record = landRecord(this.currentLand)
+      if (run > record.steadySeconds) record.steadySeconds = run
+    })
   }
 
   private pushStats(): void {
@@ -232,7 +307,233 @@ export class GameInstance {
       .getState()
       .setStats(population, this.world.creatures.length, this.world.elapsed)
 
+    this.updateRecords(population)
     this.pushInspected()
+  }
+
+  // -------------------------------------------------------------------------
+  // Records
+  // -------------------------------------------------------------------------
+
+  /**
+   * Keep the chronicle up to date and push a read-out to the UI.
+   *
+   * Runs on the stats tick — a few times a second, not per frame. Records are
+   * high-water marks, so sampling is fine: a creature cannot get younger between
+   * ticks, and the worst case is a record set a fraction of a second late.
+   */
+  private updateRecords(population: PopulationEntry[]): void {
+    const w = this.world
+    const now = Date.now()
+    const store = useMicroLand.getState()
+
+    // The elder is gone if it isn't in the world any more. Checked before the
+    // new elder is chosen so the eulogy names the right creature.
+    if (this.elderId !== null && !w.creatures.some((c) => c.id === this.elderId)) {
+      this.mourn()
+    }
+
+    let oldest: Creature | null = null
+    let deepest = 0
+    // Oldest *per species*, not just overall: the guide reports a longest life
+    // for every kind, and only ever noting the single oldest creature would
+    // leave every species but one permanently blank.
+    const eldestOf = new Map<string, number>()
+    for (const c of w.creatures) {
+      if (!oldest || c.ageSeconds > oldest.ageSeconds) oldest = c
+      if (c.generation > deepest) deepest = c.generation
+      const best = eldestOf.get(c.blueprintId)
+      if (best === undefined || c.ageSeconds > best) {
+        eldestOf.set(c.blueprintId, c.ageSeconds)
+      }
+    }
+
+    // Every species on screen goes into the guide, and takes its blueprint with
+    // it — this is what stops a summoned creature dying with the tab.
+    for (const entry of population) {
+      const bp = w.blueprints[entry.blueprintId]
+      if (bp) rememberSpecies(bp, now)
+    }
+    for (const [blueprintId, seconds] of eldestOf) {
+      noteSpeciesLife(blueprintId, seconds)
+    }
+
+    const record = landRecord(this.currentLand)
+    const steadySeconds = w.elapsed - this.steadySince
+
+    updateChronicle(() => {
+      // --- longevity ---------------------------------------------------
+      const best = record.elder?.seconds ?? 0
+      if (
+        oldest &&
+        oldest.ageSeconds >= ELDER_MIN_SECONDS &&
+        oldest.ageSeconds > best
+      ) {
+        const bp = w.blueprints[oldest.blueprintId]
+        if (bp) {
+          const crowning = this.elderId !== oldest.id
+          this.elderId = oldest.id
+          // Rewritten every tick while the elder lives, so the record tracks it
+          // upward and freezes at whatever age it finally reached. `at` is the
+          // exception — it marks when the record was *taken*, so it survives the
+          // rewrites rather than creeping forward with them.
+          record.elder = {
+            seconds: oldest.ageSeconds,
+            blueprintId: bp.id,
+            speciesName: bp.name,
+            name: oldest.name,
+            at: crowning ? now : (record.elder?.at ?? now),
+          }
+          this.elderSnapshot = {
+            name: oldest.name,
+            species: bp.name,
+            seconds: oldest.ageSeconds,
+          }
+          if (crowning) {
+            store.notify(`A ${bp.name} has outlived everything this land remembers.`)
+          }
+        }
+      }
+
+      // --- bloodline ----------------------------------------------------
+      if (deepest > record.generations) {
+        record.generations = deepest
+        const line = w.creatures.find((c) => c.generation === deepest)
+        const bp = line ? w.blueprints[line.blueprintId] : undefined
+        record.generationsBlueprintId = bp?.id ?? null
+        record.generationsSpeciesName = bp?.name ?? null
+      }
+
+      // --- stability ----------------------------------------------------
+      // Banked live rather than only when the streak breaks, so a session that
+      // ends by closing the tab still keeps the run it was in the middle of.
+      if (steadySeconds > record.steadySeconds) record.steadySeconds = steadySeconds
+    })
+
+    store.setRecords({
+      elder: record.elder,
+      bestSteadySeconds: record.steadySeconds,
+      bestGenerations: record.generations,
+      bestGenerationsSpeciesName: record.generationsSpeciesName,
+      steadySeconds,
+      deepestGeneration: deepest,
+    })
+
+    // Sorted once and shared: both of these want the same list, and it is
+    // rebuilt on every stats tick.
+    const archive = archivedSpecies()
+
+    this.checkMilestones(archive, {
+      elapsed: w.elapsed,
+      steadySeconds,
+      oldestSeconds: oldest?.ageSeconds ?? 0,
+      generations: deepest,
+      speciesAlive: population.length,
+      total: w.creatures.length,
+    })
+
+    this.syncArchive(archive)
+  }
+
+  /** Announce the elder's death, then stand down the halo. */
+  private mourn(): void {
+    const gone = this.elderSnapshot
+    this.elderId = null
+    this.elderSnapshot = null
+    if (!gone) return
+    const age = formatDuration(gone.seconds)
+    useMicroLand
+      .getState()
+      .notify(
+        gone.name
+          ? `${gone.name} died at ${age}. Nothing here has lived longer.`
+          : `The oldest ${gone.species} died at ${age}.`
+      )
+  }
+
+  /**
+   * Give the record-holder a name.
+   *
+   * Only the elder can be named, which is the point — a name is the reward for
+   * the record, not a labelling tool. Returns false if the moment has passed.
+   */
+  nameElder(name: string): boolean {
+    const trimmed = name.trim().slice(0, 24)
+    if (!trimmed || this.elderId === null) return false
+    const c = this.world.creatures.find((x) => x.id === this.elderId)
+    if (!c) return false
+    c.name = trimmed
+    if (this.elderSnapshot) this.elderSnapshot.name = trimmed
+    updateChronicle(() => {
+      const record = landRecord(this.currentLand)
+      if (record.elder) record.elder.name = trimmed
+    })
+    this.pushStats()
+    return true
+  }
+
+  /** Fire any milestone that just became true. Each one fires once, ever. */
+  private checkMilestones(
+    archive: SpeciesRecord[],
+    context: Omit<MilestoneContext, 'archived' | 'summonedArchived'>
+  ): void {
+    const full = {
+      ...context,
+      archived: archive.length,
+      summonedArchived: archive.filter((s) => s.blueprint.summoned).length,
+    }
+    const now = Date.now()
+    const store = useMicroLand.getState()
+    let fired = false
+    for (const milestone of MILESTONES) {
+      if (!milestone.reached(full)) continue
+      if (!claimMilestone(milestone.id, now)) continue
+      store.notify(milestone.text)
+      fired = true
+    }
+    if (fired) this.pushMilestones()
+  }
+
+  /**
+   * Push everything the chronicle already knew into the UI.
+   *
+   * Called once after the chronicle loads, so a returning player's field guide
+   * is populated before the first creature has drawn breath in this session.
+   */
+  publishRecords(): void {
+    this.lastArchiveSize = -1
+    this.syncArchive(archivedSpecies())
+    this.pushMilestones()
+  }
+
+  /** Re-send the guide's archive, but only when it has actually changed. */
+  private syncArchive(archive: SpeciesRecord[]): void {
+    if (archive.length === this.lastArchiveSize) return
+    this.lastArchiveSize = archive.length
+    useMicroLand.getState().setArchive(archive)
+  }
+
+  private pushMilestones(): void {
+    const earned = readMilestones()
+    useMicroLand.getState().setMilestones(earned)
+  }
+
+  /**
+   * Point the recorder at whichever land is now on screen, banking the run that
+   * was in progress. Called whenever the world is replaced under the player.
+   */
+  private beginLand(): void {
+    this.breakSteadyStreak()
+    this.currentLand = landId(
+      useMicroLand.getState().themeId,
+      useMicroLand.getState().summonedLand
+    )
+    this.steadySince = this.world.elapsed
+    // A cleared world has no elder; do this quietly rather than eulogizing a
+    // creature the player deliberately removed.
+    this.elderId = null
+    this.elderSnapshot = null
+    this.lastArchiveSize = -1
   }
 
   /** Copy the watched creature's live state out for the inspector panel. */
@@ -276,6 +577,9 @@ export class GameInstance {
       inWater: boxLiquidFraction(this.world, c.x, c.y, bw, bh) > 0.3,
       grounded: c.grounded,
       targetName: targetBp?.name ?? null,
+      generation: c.generation,
+      name: c.name,
+      isElder: c.id === this.elderId,
     })
   }
 
@@ -309,6 +613,9 @@ export class GameInstance {
     this.renderer.markTilesDirty()
     useMicroLand.getState().setSummonedLand(terrain.name)
     useMicroLand.getState().setTheme(SUMMONED_THEME_ID)
+    // After the store knows the land's name — `beginLand` derives the record key
+    // from it, and a summoned land files its records under its own name.
+    this.beginLand()
     this.pushStats()
     return terrain
   }
@@ -320,6 +627,7 @@ export class GameInstance {
       this.knownSpecies.clear()
       this.inspectedId = null
       this.renderer.markTilesDirty()
+      this.beginLand()
       this.pushStats()
       return
     }
@@ -331,6 +639,7 @@ export class GameInstance {
     this.inspectedId = null
     seedStarters(this.world, themeId, this.rng)
     this.renderer.markTilesDirty()
+    this.beginLand()
     this.pushStats()
   }
 
@@ -343,6 +652,7 @@ export class GameInstance {
       this.knownSpecies.clear()
       this.inspectedId = null
       this.renderer.markTilesDirty()
+      this.beginLand()
       this.pushStats()
       return
     }
@@ -352,6 +662,7 @@ export class GameInstance {
     this.inspectedId = null
     seedStarters(this.world, themeId, this.rng)
     this.renderer.markTilesDirty()
+    this.beginLand()
     this.pushStats()
   }
 
@@ -363,6 +674,9 @@ export class GameInstance {
     this.world.dormant = true
     this.knownSpecies.clear()
     this.inspectedId = null
+    // Emptying the world is an extinction of everything, so the streak goes with
+    // it — but silently, since the player did it on purpose.
+    this.beginLand()
     this.pushStats()
   }
 

--- a/src/app/micro-land/game-instance.ts
+++ b/src/app/micro-land/game-instance.ts
@@ -357,6 +357,10 @@ export class GameInstance {
 
   clearLife(): void {
     clearCreatures(this.world)
+    // Native plants grow back out of the soil on their own, so on any world with
+    // ground in it "empty" would last about three seconds without this. Anything
+    // the player does next — painting, placing, summoning — wakes it back up.
+    this.world.dormant = true
     this.knownSpecies.clear()
     this.inspectedId = null
     this.pushStats()
@@ -368,6 +372,7 @@ export class GameInstance {
    */
   introduce(raw: unknown, count: number): { blueprint: CreatureBlueprint; placed: number } {
     const bp = sanitizeBlueprint(raw, { summoned: true })
+    this.world.dormant = false
     registerBlueprint(this.world, bp)
     this.syncBlueprintsToStore()
 
@@ -474,6 +479,7 @@ export class GameInstance {
       this.lastPlaceAt = now
       const bp = this.world.blueprints[tool.blueprintId]
       if (!bp) return
+      this.world.dormant = false
       if (this.world.creatures.length >= MAX_CREATURES) {
         state.notify('The world is full. Something has to go.')
         return

--- a/src/app/micro-land/game-instance.ts
+++ b/src/app/micro-land/game-instance.ts
@@ -22,8 +22,8 @@ import {
   rememberSpecies,
   updateChronicle,
 } from './chronicle/chronicle'
-import { MILESTONES, type MilestoneContext } from './domain/config/milestones'
 import { artSize, bodyBox, sanitizeBlueprint } from './domain/blueprint'
+import { MILESTONES, type MilestoneContext } from './domain/config/milestones'
 import { DEFAULT_THEME, THEME_BY_ID, type Theme } from './domain/config/themes'
 import {
   ELDER_MIN_SECONDS,
@@ -86,6 +86,27 @@ function readMilestones(): EarnedMilestone[] {
   }))
 }
 
+/** Held-key and held-button pan speed, world tiles per second. */
+const PAN_SPEED = 115
+
+/** One wheel notch or one arrow-button tap, in world tiles. */
+const PAN_STEP = 34
+
+/**
+ * How close to the edge you can drag something before the world starts sliding.
+ *
+ * Expressed as a fraction of the view rather than a tile count so it behaves the
+ * same on a phone showing 224 tiles and a monitor showing 400.
+ */
+const EDGE_BAND = 0.12
+const EDGE_SPEED = 90
+
+/** How hard the camera chases the creature the inspector is watching. */
+const FOLLOW_SPEED = 90
+
+/** Drag further than this and a tap was really a pan. CSS pixels. */
+const TAP_SLOP = 6
+
 export class GameInstance {
   private canvas: HTMLCanvasElement
   private renderer: Renderer
@@ -134,6 +155,30 @@ export class GameInstance {
   private lastPlaceAt = 0
   private resizeObserver: ResizeObserver | null = null
 
+  // --- camera state ---
+  /** Every pointer currently down, so a second finger can be noticed. */
+  private pointers = new Map<number, number>()
+  /** Client X where a drag-pan started, and the camera position it started at. */
+  private panAnchorX = 0
+  private panAnchorCam = 0
+  private panning = false
+  /** -1, 0 or 1 — an arrow key or arrow button being held down. */
+  private panHeld = 0
+  /** Direction keys currently held, so releasing one of two doesn't stop both. */
+  private keysDown = new Set<string>()
+  /** A look-mode tap waiting to see whether it turns into a pan. */
+  private pendingInspect: { id: number | null } | null = null
+  /** The pointer went down on the minimap, so it belongs to the minimap. */
+  private scrubbingMap = false
+  /**
+   * Whether the camera is still chasing the inspected creature.
+   *
+   * Cleared the moment the player pans by hand: following is a convenience, and
+   * a camera that drags itself back after you deliberately looked somewhere else
+   * is not a convenience.
+   */
+  private following = false
+
   constructor(canvas: HTMLCanvasElement) {
     this.canvas = canvas
     this.renderer = new Renderer(canvas)
@@ -175,6 +220,7 @@ export class GameInstance {
     const apply = () => {
       const rect = parent.getBoundingClientRect()
       this.renderer.resize(rect.width, rect.height)
+      useMicroLand.getState().setCanPan(!this.renderer.fitsOnScreen)
     }
     apply()
     this.resizeObserver = new ResizeObserver(apply)
@@ -218,7 +264,54 @@ export class GameInstance {
     // Keep the grabbed creature glued to the finger even while paused.
     if (this.grabbed) this.grabbed.vx = this.grabbed.vy = 0
 
+    // Panning runs off wall-clock rather than the sim clock, so the camera
+    // answers at the same speed whether the world is paused or on fast-forward.
+    this.updateCamera(delta / 1000)
+
     this.renderer.render(this.world, theme, this.inspectedId, this.elderId)
+  }
+
+  /**
+   * Move the camera for anything that isn't a direct drag.
+   *
+   * Held keys and held buttons, carrying a creature past the edge, and chasing
+   * whatever the inspector is watching. Drag-panning is absolute and lives in
+   * the pointer handler; everything here is per-second and belongs on a clock.
+   */
+  private updateCamera(dt: number): void {
+    if (this.panHeld !== 0) {
+      this.following = false
+      this.renderer.panBy(this.panHeld * PAN_SPEED * dt)
+    }
+
+    // Carry a creature to the edge and the world comes with it — otherwise
+    // there is no way to move something from one end of the world to the other.
+    if (this.grabbed && this.pointerDown && !this.panning) {
+      const view = this.renderer.viewWidth
+      const cam = this.renderer.cameraX
+      const held = this.grabbed.x
+      let dir = 0
+      if (held < cam + view * EDGE_BAND) dir = -1
+      else if (held > cam + view * (1 - EDGE_BAND)) dir = 1
+
+      if (dir !== 0) {
+        this.renderer.panBy(dir * EDGE_SPEED * dt)
+        // The creature is positioned from the pointer, and the pointer isn't
+        // moving — so without dragging it along by the same amount it would slip
+        // out of the edge band on the first frame and the scroll would stop dead.
+        const moved = this.renderer.cameraX - cam
+        const bp = this.world.blueprints[this.grabbed.blueprintId]
+        const bw = bp ? artSize(bp).w : 0
+        this.grabbed.x = Math.max(0, Math.min(this.world.width - bw, held + moved))
+      }
+    }
+
+    if (this.following && this.inspectedId !== null) {
+      const c = this.world.creatures.find((x) => x.id === this.inspectedId)
+      if (c) {
+        this.renderer.keepInView(c.x, this.renderer.viewWidth * 0.22, FOLLOW_SPEED * dt)
+      }
+    }
   }
 
   private step(gravity: number, events: SimEvent[]): void {
@@ -548,6 +641,7 @@ export class GameInstance {
     if (!c) {
       // It died while we were watching. Let go rather than freezing a corpse.
       this.inspectedId = null
+    this.following = false
       store.setInspected(null)
       return
     }
@@ -609,6 +703,7 @@ export class GameInstance {
       clearCreatures(this.world)
       this.knownSpecies.clear()
       this.inspectedId = null
+    this.following = false
     }
     this.renderer.markTilesDirty()
     useMicroLand.getState().setSummonedLand(terrain.name)
@@ -626,6 +721,7 @@ export class GameInstance {
       clearCreatures(this.world)
       this.knownSpecies.clear()
       this.inspectedId = null
+    this.following = false
       this.renderer.markTilesDirty()
       this.beginLand()
       this.pushStats()
@@ -637,6 +733,7 @@ export class GameInstance {
     clearCreatures(this.world)
     this.knownSpecies.clear()
     this.inspectedId = null
+    this.following = false
     seedStarters(this.world, themeId, this.rng)
     this.renderer.markTilesDirty()
     this.beginLand()
@@ -651,6 +748,7 @@ export class GameInstance {
       clearCreatures(this.world)
       this.knownSpecies.clear()
       this.inspectedId = null
+    this.following = false
       this.renderer.markTilesDirty()
       this.beginLand()
       this.pushStats()
@@ -660,6 +758,7 @@ export class GameInstance {
     clearCreatures(this.world)
     this.knownSpecies.clear()
     this.inspectedId = null
+    this.following = false
     seedStarters(this.world, themeId, this.rng)
     this.renderer.markTilesDirty()
     this.beginLand()
@@ -674,6 +773,7 @@ export class GameInstance {
     this.world.dormant = true
     this.knownSpecies.clear()
     this.inspectedId = null
+    this.following = false
     // Emptying the world is an extinction of everything, so the streak goes with
     // it — but silently, since the player did it on purpose.
     this.beginLand()
@@ -707,18 +807,89 @@ export class GameInstance {
   // Input
   // -------------------------------------------------------------------------
 
+  // --- camera, driven from the UI ------------------------------------------
+
+  /** Start or stop a held pan. Used by the on-screen arrows. */
+  holdPan(direction: -1 | 0 | 1): void {
+    this.panHeld = direction
+    if (direction !== 0) this.following = false
+  }
+
+  /** One tap's worth of pan, for a click that never becomes a hold. */
+  nudgePan(direction: -1 | 1): void {
+    this.following = false
+    this.renderer.panBy(direction * PAN_STEP)
+  }
+
+  // --- pointer --------------------------------------------------------------
+
+  private beginPan(clientX: number): void {
+    this.panning = true
+    this.following = false
+    this.panAnchorX = clientX
+    this.panAnchorCam = this.renderer.cameraX
+  }
+
+  /** Midpoint of every finger down, so a two-finger pan doesn't pivot. */
+  private pointerCenterX(): number {
+    let sum = 0
+    for (const x of this.pointers.values()) sum += x
+    return this.pointers.size > 0 ? sum / this.pointers.size : 0
+  }
+
+  /** Let go of whatever the first finger had started, without acting on it. */
+  private cancelPointerAction(): void {
+    if (this.grabbed) {
+      this.grabbed.vx = 0
+      this.grabbed.vy = 0
+      this.grabbed = null
+      this.grabTrail = []
+    }
+    this.pendingInspect = null
+  }
+
   private onPointerDown = (e: PointerEvent) => {
+    this.pointers.set(e.pointerId, e.clientX)
+
+    // A second finger always means "move the world", whatever the first one had
+    // started doing. Two fingers on a canvas is a pan everywhere else on a
+    // phone, and the alternative — painting from both — is nobody's intent.
+    if (this.pointers.size === 2) {
+      this.cancelPointerAction()
+      this.beginPan(this.pointerCenterX())
+      return
+    }
+    if (this.pointers.size > 2) {
+      this.reanchorPan()
+      return
+    }
     if (!e.isPrimary) return
+
     this.canvas.setPointerCapture(e.pointerId)
+    this.canvas.focus({ preventScroll: true })
     this.pointerDown = true
+
+    // The minimap is painted on the world canvas, so it has to be given the
+    // chance to claim a tap before the tap is allowed to dig a hole. The flag
+    // has to outlive the tap, too: without it the next pointermove would fall
+    // straight through to the paint tool and carve a trench under the map.
+    const jump = this.renderer.minimapHit(e.clientX, e.clientY)
+    if (jump !== null) {
+      this.scrubbingMap = true
+      this.following = false
+      this.renderer.centerOn(jump)
+      return
+    }
 
     const p = this.renderer.screenToWorld(e.clientX, e.clientY)
     const hit = this.creatureAt(p.x, p.y)
 
     if (useMicroLand.getState().tool.kind === 'inspect') {
-      // Tapping nothing clears the selection, which is how you close the panel.
-      this.inspectedId = hit ? hit.id : null
-      this.pushInspected()
+      // Look mode has nothing to paint, so a drag is free to mean "pan" — the
+      // one place a single finger can move the world without ambiguity. The
+      // selection is resolved on release, so a pan doesn't also deselect.
+      this.pendingInspect = { id: hit ? hit.id : null }
+      this.beginPan(e.clientX)
       return
     }
 
@@ -734,7 +905,28 @@ export class GameInstance {
   }
 
   private onPointerMove = (e: PointerEvent) => {
+    if (this.pointers.has(e.pointerId)) this.pointers.set(e.pointerId, e.clientX)
+
+    if (this.panning) {
+      const from = this.pointers.size >= 2 ? this.pointerCenterX() : e.clientX
+      const dx = from - this.panAnchorX
+      // A tap that has turned into a drag is no longer a tap.
+      if (this.pendingInspect && Math.abs(dx) > TAP_SLOP) this.pendingInspect = null
+      this.renderer.panToLeft(
+        this.panAnchorCam - dx * this.renderer.tilesPerClientPixel()
+      )
+      return
+    }
+
     if (!this.pointerDown || !e.isPrimary) return
+
+    // Drag along the map and the world follows — the fastest way to cross it.
+    if (this.scrubbingMap) {
+      const jump = this.renderer.minimapHit(e.clientX, e.clientY)
+      if (jump !== null) this.renderer.centerOn(jump)
+      return
+    }
+
     const p = this.renderer.screenToWorld(e.clientX, e.clientY)
 
     if (this.grabbed) {
@@ -761,8 +953,23 @@ export class GameInstance {
   }
 
   private onPointerUp = (e: PointerEvent) => {
+    this.pointers.delete(e.pointerId)
+    if (this.panning && this.pointers.size === 0) this.panning = false
+    else this.reanchorPan()
+
     if (!e.isPrimary) return
     this.pointerDown = false
+    this.scrubbingMap = false
+
+    // A look-mode tap that never travelled far enough to be a pan.
+    if (this.pendingInspect) {
+      this.inspectedId = this.pendingInspect.id
+      // Following a creature you deliberately picked out is the point of
+      // watching one; following "nothing" would just freeze the camera.
+      this.following = this.pendingInspect.id !== null
+      this.pendingInspect = null
+      this.pushInspected()
+    }
 
     if (this.grabbed) {
       // Throw: velocity from how fast the pointer was moving as it let go.
@@ -844,11 +1051,83 @@ export class GameInstance {
     return null
   }
 
+  /** Fingers came or went mid-pan — take a fresh reading so it doesn't jump. */
+  private reanchorPan(): void {
+    if (!this.panning || this.pointers.size === 0) return
+    this.panAnchorX = this.pointerCenterX()
+    this.panAnchorCam = this.renderer.cameraX
+  }
+
+  /**
+   * A wheel or trackpad scrolls the world sideways.
+   *
+   * Vertical scroll is folded in as well as horizontal: there is nothing above
+   * or below to scroll to, and a mouse with one wheel is still the most common
+   * way anyone will touch this.
+   */
+  private onWheel = (e: WheelEvent) => {
+    const raw = Math.abs(e.deltaX) > Math.abs(e.deltaY) ? e.deltaX : e.deltaY
+    if (raw === 0) return
+    e.preventDefault()
+    this.following = false
+    // deltaMode: 0 pixels, 1 lines, 2 pages.
+    const unit = e.deltaMode === 1 ? 16 : e.deltaMode === 2 ? 400 : 1
+    const tiles = raw * unit * 0.25
+    this.renderer.panBy(Math.max(-PAN_STEP, Math.min(PAN_STEP, tiles)))
+  }
+
+  /** Which way, if any, does this key point? */
+  private static keyDirection(key: string): -1 | 0 | 1 {
+    if (key === 'ArrowLeft' || key === 'a' || key === 'A') return -1
+    if (key === 'ArrowRight' || key === 'd' || key === 'D') return 1
+    return 0
+  }
+
+  private onKeyDown = (e: KeyboardEvent) => {
+    if (e.metaKey || e.ctrlKey || e.altKey) return
+
+    if (e.key === 'Home' || e.key === 'End') {
+      e.preventDefault()
+      this.following = false
+      this.renderer.panToLeft(e.key === 'Home' ? 0 : this.world.width)
+      return
+    }
+
+    const dir = GameInstance.keyDirection(e.key)
+    if (dir === 0) return
+    e.preventDefault()
+    this.keysDown.add(e.key)
+    this.panHeld = dir
+    this.following = false
+  }
+
+  private onKeyUp = (e: KeyboardEvent) => {
+    this.keysDown.delete(e.key)
+    // Holding both arrows and releasing one should leave you moving the other
+    // way, not stop dead.
+    let dir: -1 | 0 | 1 = 0
+    for (const key of this.keysDown) {
+      const d = GameInstance.keyDirection(key)
+      if (d !== 0) dir = d
+    }
+    this.panHeld = dir
+  }
+
+  /** A canvas that lost focus can't hear a keyup, so it must not stay stuck. */
+  private onBlur = () => {
+    this.keysDown.clear()
+    this.panHeld = 0
+  }
+
   private attachInput(): void {
     this.canvas.addEventListener('pointerdown', this.onPointerDown)
     this.canvas.addEventListener('pointermove', this.onPointerMove)
     this.canvas.addEventListener('pointerup', this.onPointerUp)
     this.canvas.addEventListener('pointercancel', this.onPointerUp)
+    this.canvas.addEventListener('wheel', this.onWheel, { passive: false })
+    this.canvas.addEventListener('keydown', this.onKeyDown)
+    this.canvas.addEventListener('keyup', this.onKeyUp)
+    this.canvas.addEventListener('blur', this.onBlur)
   }
 
   private detachInput(): void {
@@ -856,5 +1135,9 @@ export class GameInstance {
     this.canvas.removeEventListener('pointermove', this.onPointerMove)
     this.canvas.removeEventListener('pointerup', this.onPointerUp)
     this.canvas.removeEventListener('pointercancel', this.onPointerUp)
+    this.canvas.removeEventListener('wheel', this.onWheel)
+    this.canvas.removeEventListener('keydown', this.onKeyDown)
+    this.canvas.removeEventListener('keyup', this.onKeyUp)
+    this.canvas.removeEventListener('blur', this.onBlur)
   }
 }

--- a/src/app/micro-land/layout.tsx
+++ b/src/app/micro-land/layout.tsx
@@ -1,0 +1,10 @@
+import type { Viewport } from 'next'
+import type React from 'react'
+
+export const viewport: Viewport = {
+  viewportFit: 'cover',
+}
+
+export default function MicroLandLayout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>
+}

--- a/src/app/micro-land/page.tsx
+++ b/src/app/micro-land/page.tsx
@@ -1,0 +1,28 @@
+'use client'
+
+import { CosmicShell } from '@/app/comet-cards/components/cosmic/shell'
+
+import { MicroLandGame } from './MicroLandGame'
+
+/**
+ * Micro Land takes over the viewport.
+ *
+ * A canvas world with a fixed tool dock can't share vertical space with the
+ * site header — the controls end up below the fold and the world gets a
+ * letterbox it doesn't need. Interaction model 2 covers this case: a game may
+ * take over the viewport as long as it carries its own cave exit, which is the
+ * ✕ CosmicShell already puts top-left.
+ *
+ * z-40 sits above the site nav (z-30) and below this game's own modals (z-50).
+ */
+export default function MicroLandPage() {
+  return (
+    <div className="fixed inset-0 z-40">
+      <CosmicShell>
+        <div style={{ position: 'relative', width: '100%', height: '100%' }}>
+          <MicroLandGame />
+        </div>
+      </CosmicShell>
+    </div>
+  )
+}

--- a/src/app/micro-land/rendering/renderer.ts
+++ b/src/app/micro-land/rendering/renderer.ts
@@ -124,7 +124,12 @@ export class Renderer {
     }
   }
 
-  render(w: WorldState, theme: Theme, highlightId: number | null = null): void {
+  render(
+    w: WorldState,
+    theme: Theme,
+    highlightId: number | null = null,
+    elderId: number | null = null
+  ): void {
     if (this.tilesDirty) {
       this.buildTiles(w)
       this.tilesDirty = false
@@ -146,7 +151,9 @@ export class Renderer {
     this.drawCreatures(w)
     this.drawParticles(w)
     wctx.drawImage(this.shadowCanvas, 0, 0)
-    // Drawn after the shadow so the selection stays legible in a dark cave.
+    // Both drawn after the shadow so they stay legible in a dark cave. The halo
+    // goes first so the selection brackets sit on top when you inspect an elder.
+    if (elderId !== null) this.drawElder(w, elderId)
     if (highlightId !== null) this.drawHighlight(w, highlightId)
 
     // One scaled blit. Nearest-neighbour keeps the pixels crisp.
@@ -337,6 +344,52 @@ export class Renderer {
       ctx.drawImage(source, x, y)
       ctx.globalAlpha = 1
     }
+  }
+
+  /**
+   * Halo over the oldest thing that has ever lived here.
+   *
+   * A ring rather than a crown: at six pixels wide a crown is three pixels of
+   * mush sitting on the creature's head, while an ellipse floating clear of the
+   * sprite reads as a halo at any size and never hides the animal wearing it.
+   * This is the only mark the record system puts on the world — everything else
+   * it knows lives behind a tap.
+   */
+  private drawElder(w: WorldState, id: number): void {
+    const c = w.creatures.find((x) => x.id === id)
+    if (!c) return
+    const bp = w.blueprints[c.blueprintId]
+    if (!bp) return
+    const rows = bp.art.frames[0]
+    const bw = rows[0].length
+
+    const ctx = this.wctx
+    const cx = Math.round(c.x) + bw / 2
+    // Two pixels of clear air above the sprite, so it reads as floating rather
+    // than as part of the creature.
+    const cy = Math.round(c.y) - 3
+    const rx = Math.max(2, Math.min(6, bw / 2))
+    const ry = Math.max(1, rx * 0.42)
+
+    // Slower than the selection pulse — this is meant to be noticed, not to
+    // demand attention while you're doing something else.
+    ctx.fillStyle = '#fcd34d'
+    ctx.globalAlpha = 0.62 + 0.28 * Math.sin(w.elapsed * 2.6)
+
+    // Plotted point by point instead of ctx.ellipse: a stroked path at this
+    // scale antialiases into a grey smudge, and the whole world is nearest
+    // neighbour. Step is tied to the radius so small halos don't come out dotted.
+    const steps = Math.max(12, Math.round(rx * 6))
+    for (let i = 0; i < steps; i++) {
+      const t = (i / steps) * Math.PI * 2
+      ctx.fillRect(
+        Math.round(cx + Math.cos(t) * rx),
+        Math.round(cy + Math.sin(t) * ry),
+        1,
+        1
+      )
+    }
+    ctx.globalAlpha = 1
   }
 
   /** Ring around the creature the inspector is watching. */

--- a/src/app/micro-land/rendering/renderer.ts
+++ b/src/app/micro-land/rendering/renderer.ts
@@ -10,10 +10,17 @@
  * Light is a quarter-resolution field (sky from above, plus glowing tiles and
  * creatures), blurred and composited as a darkness layer *after* sprites, so
  * creatures are dimmed by the same shadows as the terrain.
+ *
+ * The world is wider than the screen, so there is a camera. It only moves
+ * horizontally and it only ever sits on whole tiles: a camera at x = 12.4 would
+ * resample every tile in the world onto a half-pixel and undo the one thing this
+ * renderer exists to protect. Every per-frame pass below — tiles, light, shadow,
+ * sprites — is clipped to the visible column range, which is what keeps a world
+ * three times the size costing about what one screen used to.
  */
 import { MATERIAL_BY_INDEX } from '@/app/micro-land/domain/config/materials'
 import type { Theme } from '@/app/micro-land/domain/config/themes'
-import { WORLD_H, WORLD_W } from '@/app/micro-land/domain/constants'
+import { VIEW_W, WORLD_H, WORLD_W } from '@/app/micro-land/domain/constants'
 import type { WorldState } from '@/app/micro-land/domain/types'
 
 import { getSprites } from './sprite-cache'
@@ -26,6 +33,34 @@ const LH = Math.ceil(WORLD_H / LIGHT_SCALE)
 /** How far daylight reaches below the first solid tile in a column, in tiles. */
 const SKY_FALLOFF = 16
 
+/**
+ * Columns of slack baked either side of the view.
+ *
+ * Tiles are re-baked whenever the sand moves, which is 20 times a second, so
+ * this margin mostly buys nothing while the world is running. It earns its keep
+ * while paused, where panning would otherwise re-bake on every single frame.
+ */
+const TILE_MARGIN = 32
+
+/**
+ * Light bleeds sideways through the blur, so it's gathered a little wider.
+ *
+ * Has to cover more than the blur reaches. Each of the three passes pulls in one
+ * coarse cell from outside the gathered range — which is stale, because nothing
+ * out there was computed — so the outermost three cells of the margin are wrong
+ * by the end. At 4 tiles per cell this leaves three clean cells of slack beyond
+ * that before the visible edge starts.
+ */
+const LIGHT_MARGIN = 24
+
+/** The minimap is a whole-world thumbnail at this many tiles per pixel. */
+const MAP_SCALE = 4
+const MW = Math.ceil(WORLD_W / MAP_SCALE)
+const MH = Math.ceil(WORLD_H / MAP_SCALE)
+
+/** Frames between minimap refreshes. It's a thumbnail; 5Hz is more than enough. */
+const MAP_REFRESH_FRAMES = 12
+
 interface Rgb {
   r: number
   g: number
@@ -35,6 +70,14 @@ interface Rgb {
 function hexToRgb(hex: string): Rgb {
   const n = parseInt(hex.slice(1), 16)
   return { r: (n >> 16) & 255, g: (n >> 8) & 255, b: n & 255 }
+}
+
+/** Where the minimap ended up on the display, in device pixels. */
+export interface MapRect {
+  x: number
+  y: number
+  w: number
+  h: number
 }
 
 export class Renderer {
@@ -50,6 +93,9 @@ export class Renderer {
   private tileCanvas: HTMLCanvasElement
   private tileCtx: CanvasRenderingContext2D
   private tilesDirty = true
+  /** Column range currently baked into `tileCanvas`; outside it is stale. */
+  private builtX0 = 0
+  private builtX1 = 0
 
   /** Darkness overlay, world resolution. */
   private shadowImage: ImageData
@@ -60,12 +106,27 @@ export class Renderer {
   private lightScratch = new Float32Array(LW * LH)
   private skyDepth = new Int16Array(WORLD_W)
 
+  /** Whole-world thumbnail behind the minimap. */
+  private mapImage: ImageData
+  private mapCanvas: HTMLCanvasElement
+  private mapCtx: CanvasRenderingContext2D
+  private mapAge = MAP_REFRESH_FRAMES
+  private mapRect: MapRect = { x: 0, y: 0, w: 0, h: 0 }
+
   private materialRgb: Rgb[]
 
   /** Placement of the world inside the display canvas. */
   private scale = 1
   private offsetX = 0
   private offsetY = 0
+
+  /**
+   * Left edge of the view in world tiles. Kept fractional so a slow pan can
+   * accumulate, but always floored before anything is drawn from it.
+   */
+  private camX = 0
+  /** How many world tiles the display is wide at the current scale. */
+  private viewTiles = VIEW_W
 
   constructor(display: HTMLCanvasElement) {
     this.display = display
@@ -90,6 +151,12 @@ export class Renderer {
     this.shadowCtx = this.shadowCanvas.getContext('2d')!
     this.shadowImage = this.shadowCtx.createImageData(WORLD_W, WORLD_H)
 
+    this.mapCanvas = document.createElement('canvas')
+    this.mapCanvas.width = MW
+    this.mapCanvas.height = MH
+    this.mapCtx = this.mapCanvas.getContext('2d')!
+    this.mapImage = this.mapCtx.createImageData(MW, MH)
+
     this.materialRgb = MATERIAL_BY_INDEX.map((m) => hexToRgb(m.color))
   }
 
@@ -105,11 +172,86 @@ export class Renderer {
     this.display.style.width = `${cssWidth}px`
     this.display.style.height = `${cssHeight}px`
 
-    // Fit the whole world in view — it's a terrarium, you should see all of it.
-    const fit = Math.min(this.display.width / WORLD_W, this.display.height / WORLD_H)
+    // Zoom is fixed by VIEW_W, not by the whole world: a tile is sized so that
+    // one screen's worth spans the canvas, exactly as it did when the world was
+    // one screen wide. Whatever extra height allows, you simply get to see.
+    const fit = Math.min(this.display.width / VIEW_W, this.display.height / WORLD_H)
     this.scale = fit
-    this.offsetX = Math.floor((this.display.width - WORLD_W * fit) / 2)
+    this.viewTiles = Math.min(WORLD_W, this.display.width / fit)
+    this.offsetX = Math.floor((this.display.width - this.viewTiles * fit) / 2)
     this.offsetY = Math.floor((this.display.height - WORLD_H * fit) / 2)
+    this.clampCam()
+  }
+
+  // -------------------------------------------------------------------------
+  // Camera
+  // -------------------------------------------------------------------------
+
+  /** Left edge of the view, in world tiles. */
+  get cameraX(): number {
+    return this.camX
+  }
+
+  /** How much world is on screen right now, in tiles. */
+  get viewWidth(): number {
+    return this.viewTiles
+  }
+
+  /** True when the whole world already fits — nothing to scroll to. */
+  get fitsOnScreen(): boolean {
+    return this.viewTiles >= WORLD_W
+  }
+
+  panBy(tiles: number): void {
+    this.camX += tiles
+    this.clampCam()
+  }
+
+  /** Put this world column at the left edge of the view. */
+  panToLeft(tile: number): void {
+    this.camX = tile
+    this.clampCam()
+  }
+
+  /** Put this world column in the middle of the view. */
+  centerOn(worldX: number): void {
+    this.camX = worldX - this.viewTiles / 2
+    this.clampCam()
+  }
+
+  /**
+   * Slide just far enough to bring a point back on screen.
+   *
+   * Used to keep a creature you're carrying — or watching — from walking off
+   * the edge of the view and leaving you looking at nothing.
+   */
+  keepInView(worldX: number, margin: number, maxTiles: number): void {
+    const left = this.camX + margin
+    const right = this.camX + this.viewTiles - margin
+    if (worldX < left) this.panBy(Math.max(-maxTiles, worldX - left))
+    else if (worldX > right) this.panBy(Math.min(maxTiles, worldX - right))
+  }
+
+  private clampCam(): void {
+    this.camX = Math.max(0, Math.min(WORLD_W - this.viewTiles, this.camX))
+  }
+
+  /**
+   * How many world tiles one CSS pixel of horizontal drag is worth.
+   *
+   * Drag-panning can't be built out of `screenToWorld` differences: that already
+   * has the camera folded into it, so moving the camera moves the answer and the
+   * two cancel out to a world that won't budge.
+   */
+  tilesPerClientPixel(): number {
+    const rect = this.display.getBoundingClientRect()
+    if (rect.width === 0) return 0
+    return this.display.width / rect.width / this.scale
+  }
+
+  /** Whole-tile left edge. Everything drawn this frame is measured from here. */
+  private viewLeft(): number {
+    return Math.floor(this.camX)
   }
 
   /** Display pixel → world tile. Used by every pointer interaction. */
@@ -119,10 +261,30 @@ export class Renderer {
     const px = (clientX - rect.left) * dpr
     const py = (clientY - rect.top) * dpr
     return {
-      x: (px - this.offsetX) / this.scale,
+      x: this.viewLeft() + (px - this.offsetX) / this.scale,
       y: (py - this.offsetY) / this.scale,
     }
   }
+
+  /**
+   * Was this tap on the minimap, and if so where in the world does it point?
+   *
+   * Returns the world column to centre on, or null if the tap missed. The
+   * minimap is the only part of the world canvas that isn't the world, so it
+   * has to be asked about before a tap is allowed to paint anything.
+   */
+  minimapHit(clientX: number, clientY: number): number | null {
+    const m = this.mapRect
+    if (m.w <= 0) return null
+    const rect = this.display.getBoundingClientRect()
+    const dpr = this.display.width / rect.width
+    const px = (clientX - rect.left) * dpr
+    const py = (clientY - rect.top) * dpr
+    if (px < m.x || px > m.x + m.w || py < m.y || py > m.y + m.h) return null
+    return ((px - m.x) / m.w) * WORLD_W
+  }
+
+  // -------------------------------------------------------------------------
 
   render(
     w: WorldState,
@@ -130,11 +292,11 @@ export class Renderer {
     highlightId: number | null = null,
     elderId: number | null = null
   ): void {
-    if (this.tilesDirty) {
-      this.buildTiles(w)
-      this.tilesDirty = false
-    }
-    this.buildLight(w, theme)
+    const vx = this.viewLeft()
+    const vw = Math.min(WORLD_W - vx, Math.ceil(this.viewTiles))
+
+    this.ensureTiles(w, vx, vw)
+    this.buildLight(w, theme, vx, vw)
 
     const wctx = this.wctx
     wctx.imageSmoothingEnabled = false
@@ -144,13 +306,13 @@ export class Renderer {
     sky.addColorStop(0, theme.sky[0])
     sky.addColorStop(1, theme.sky[1])
     wctx.fillStyle = sky
-    wctx.fillRect(0, 0, WORLD_W, WORLD_H)
+    wctx.fillRect(vx, 0, vw, WORLD_H)
 
-    wctx.drawImage(this.tileCanvas, 0, 0)
+    wctx.drawImage(this.tileCanvas, vx, 0, vw, WORLD_H, vx, 0, vw, WORLD_H)
 
-    this.drawCreatures(w)
-    this.drawParticles(w)
-    wctx.drawImage(this.shadowCanvas, 0, 0)
+    this.drawCreatures(w, vx, vw)
+    this.drawParticles(w, vx, vw)
+    wctx.drawImage(this.shadowCanvas, vx, 0, vw, WORLD_H, vx, 0, vw, WORLD_H)
     // Both drawn after the shadow so they stay legible in a dark cave. The halo
     // goes first so the selection brackets sit on top when you inspect an elder.
     if (elderId !== null) this.drawElder(w, elderId)
@@ -163,54 +325,81 @@ export class Renderer {
     ctx.fillRect(0, 0, this.display.width, this.display.height)
     ctx.drawImage(
       this.world,
+      vx,
       0,
-      0,
-      WORLD_W,
+      this.viewTiles,
       WORLD_H,
       this.offsetX,
       this.offsetY,
-      WORLD_W * this.scale,
+      this.viewTiles * this.scale,
       WORLD_H * this.scale
     )
+
+    this.drawMinimap(w, theme, vx)
   }
 
   // -------------------------------------------------------------------------
 
-  private buildTiles(w: WorldState): void {
+  /** Re-bake the tile colours if the view has left the range we baked last. */
+  private ensureTiles(w: WorldState, vx: number, vw: number): void {
+    const covered = !this.tilesDirty && vx >= this.builtX0 && vx + vw <= this.builtX1
+    if (covered) return
+
+    const x0 = Math.max(0, vx - TILE_MARGIN)
+    const x1 = Math.min(WORLD_W, vx + vw + TILE_MARGIN)
+    this.buildTiles(w, x0, x1)
+    this.builtX0 = x0
+    this.builtX1 = x1
+    this.tilesDirty = false
+  }
+
+  private buildTiles(w: WorldState, x0: number, x1: number): void {
     const data = this.tileImage.data
     const tiles = w.tiles
     const grain = w.grain
     const rgb = this.materialRgb
     const materials = MATERIAL_BY_INDEX
 
-    for (let i = 0; i < tiles.length; i++) {
-      const mat = tiles[i]
-      const o = i * 4
-      if (mat === 0) {
-        // Air — leave it transparent so the sky gradient shows through.
-        data[o + 3] = 0
-        continue
+    for (let y = 0; y < WORLD_H; y++) {
+      const row = y * WORLD_W
+      for (let x = x0; x < x1; x++) {
+        const i = row + x
+        const mat = tiles[i]
+        const o = i * 4
+        if (mat === 0) {
+          // Air — leave it transparent so the sky gradient shows through.
+          data[o + 3] = 0
+          continue
+        }
+        const base = rgb[mat]
+        // Per-tile jitter stops large fills from looking like flat blocks.
+        const jitter = ((grain[i] / 255) * 2 - 1) * materials[mat].grain
+        const k = 1 + jitter
+        data[o] = Math.max(0, Math.min(255, base.r * k))
+        data[o + 1] = Math.max(0, Math.min(255, base.g * k))
+        data[o + 2] = Math.max(0, Math.min(255, base.b * k))
+        data[o + 3] = 255
       }
-      const base = rgb[mat]
-      // Per-tile jitter stops large fills from looking like flat blocks.
-      const jitter = ((grain[i] / 255) * 2 - 1) * materials[mat].grain
-      const k = 1 + jitter
-      data[o] = Math.max(0, Math.min(255, base.r * k))
-      data[o + 1] = Math.max(0, Math.min(255, base.g * k))
-      data[o + 2] = Math.max(0, Math.min(255, base.b * k))
-      data[o + 3] = 255
     }
 
-    this.tileCtx.putImageData(this.tileImage, 0, 0)
+    this.tileCtx.putImageData(this.tileImage, 0, 0, x0, 0, x1 - x0, WORLD_H)
   }
 
-  private buildLight(w: WorldState, theme: Theme): void {
+  private buildLight(w: WorldState, theme: Theme, vx: number, vw: number): void {
+    // Light spreads sideways as it blurs, so it is gathered a little beyond the
+    // view — otherwise the lava just off screen stops lighting the cave mouth
+    // you can see, and the edge of the screen visibly darkens as you pan.
+    const gx0 = Math.max(0, vx - LIGHT_MARGIN)
+    const gx1 = Math.min(WORLD_W, vx + vw + LIGHT_MARGIN)
+    const lx0 = Math.floor(gx0 / LIGHT_SCALE)
+    const lx1 = Math.min(LW, Math.ceil(gx1 / LIGHT_SCALE))
+
     const light = this.light
-    light.fill(0)
+    for (let ly = 0; ly < LH; ly++) light.fill(0, ly * LW + lx0, ly * LW + lx1)
 
     // --- daylight: how far below the first solid tile is each column? ---
     const tiles = w.tiles
-    for (let x = 0; x < WORLD_W; x++) {
+    for (let x = gx0; x < gx1; x++) {
       let y = 0
       while (y < WORLD_H && MATERIAL_BY_INDEX[tiles[y * WORLD_W + x]].solid === false) {
         y++
@@ -220,7 +409,7 @@ export class Renderer {
 
     for (let ly = 0; ly < LH; ly++) {
       const wy = ly * LIGHT_SCALE + LIGHT_SCALE / 2
-      for (let lx = 0; lx < LW; lx++) {
+      for (let lx = lx0; lx < lx1; lx++) {
         const wx = Math.min(WORLD_W - 1, lx * LIGHT_SCALE + (LIGHT_SCALE >> 1))
         const surface = this.skyDepth[wx]
         const below = wy - surface
@@ -234,7 +423,7 @@ export class Renderer {
     // --- emitters: glowing tiles ---
     // Sampled every other tile; the blur smooths over the gaps.
     for (let y = 0; y < WORLD_H; y += 2) {
-      for (let x = 0; x < WORLD_W; x += 2) {
+      for (let x = gx0; x < gx1; x += 2) {
         const mat = MATERIAL_BY_INDEX[tiles[y * WORLD_W + x]]
         if (mat.glow <= 0) continue
         const li = Math.floor(y / LIGHT_SCALE) * LW + Math.floor(x / LIGHT_SCALE)
@@ -248,37 +437,38 @@ export class Renderer {
       if (!bp || bp.glow <= 0) continue
       const lx = Math.floor(c.x / LIGHT_SCALE)
       const ly = Math.floor(c.y / LIGHT_SCALE)
-      if (lx < 0 || ly < 0 || lx >= LW || ly >= LH) continue
+      if (lx < lx0 || ly < 0 || lx >= lx1 || ly >= LH) continue
       const li = ly * LW + lx
       light[li] = Math.min(1.8, light[li] + bp.glow * 1.4)
     }
 
     // --- blur, so light pools instead of forming squares ---
-    for (let pass = 0; pass < 3; pass++) this.blurLight()
+    for (let pass = 0; pass < 3; pass++) this.blurLight(lx0, lx1)
 
     // --- bake into the shadow overlay ---
     const gloom = theme.gloom
     const data = this.shadowImage.data
     for (let y = 0; y < WORLD_H; y++) {
       const ly = y / LIGHT_SCALE
-      for (let x = 0; x < WORLD_W; x++) {
+      const row = y * WORLD_W
+      for (let x = vx; x < vx + vw; x++) {
         const value = this.sampleLight(x / LIGHT_SCALE, ly)
         const alpha = Math.max(0, Math.min(1, 1 - value)) * gloom
-        const o = (y * WORLD_W + x) * 4
+        const o = (row + x) * 4
         data[o] = 4
         data[o + 1] = 3
         data[o + 2] = 12
         data[o + 3] = Math.round(alpha * 255)
       }
     }
-    this.shadowCtx.putImageData(this.shadowImage, 0, 0)
+    this.shadowCtx.putImageData(this.shadowImage, 0, 0, vx, 0, vw, WORLD_H)
   }
 
-  private blurLight(): void {
+  private blurLight(lx0: number, lx1: number): void {
     const src = this.light
     const dst = this.lightScratch
     for (let y = 0; y < LH; y++) {
-      for (let x = 0; x < LW; x++) {
+      for (let x = lx0; x < lx1; x++) {
         let sum = 0
         let count = 0
         for (let dy = -1; dy <= 1; dy++) {
@@ -294,7 +484,11 @@ export class Renderer {
         dst[y * LW + x] = sum / count
       }
     }
-    this.light.set(dst)
+    for (let y = 0; y < LH; y++) {
+      const a = y * LW + lx0
+      const b = y * LW + lx1
+      src.set(dst.subarray(a, b), a)
+    }
   }
 
   /** Bilinear sample of the coarse light field. */
@@ -317,12 +511,16 @@ export class Renderer {
     return top + (bottom - top) * ty
   }
 
-  private drawCreatures(w: WorldState): void {
+  private drawCreatures(w: WorldState, vx: number, vw: number): void {
     const ctx = this.wctx
     for (const c of w.creatures) {
       const bp = w.blueprints[c.blueprintId]
       if (!bp) continue
       const sprites = getSprites(bp)
+      // Most of the population is off screen in a world this wide. Culling here
+      // is what keeps the draw cost tied to what you can see rather than to how
+      // many things happen to be alive.
+      if (c.x + sprites.width < vx || c.x > vx + vw) continue
       const frameCount = sprites.frames.length
       const frame =
         frameCount === 1
@@ -428,13 +626,101 @@ export class Renderer {
     ctx.globalAlpha = 1
   }
 
-  private drawParticles(w: WorldState): void {
+  private drawParticles(w: WorldState, vx: number, vw: number): void {
     const ctx = this.wctx
     for (const p of w.particles) {
+      if (p.x < vx || p.x > vx + vw) continue
       ctx.globalAlpha = Math.max(0, Math.min(1, p.life / p.maxLife))
       ctx.fillStyle = p.color
       ctx.fillRect(Math.round(p.x), Math.round(p.y), 1, 1)
     }
     ctx.globalAlpha = 1
+  }
+
+  // -------------------------------------------------------------------------
+  // Minimap
+  // -------------------------------------------------------------------------
+
+  /**
+   * A thumbnail of the whole world with the view marked on it.
+   *
+   * Drawn on the canvas rather than in React because it has to stay on the same
+   * pixel grid as the world and it changes every frame — a DOM element updated
+   * at 60Hz would be the most expensive thing on the page. The buttons beside it
+   * are the real controls; this is the map that tells you where you are.
+   */
+  private drawMinimap(w: WorldState, theme: Theme, vx: number): void {
+    if (this.fitsOnScreen) {
+      this.mapRect.w = 0
+      return
+    }
+
+    this.mapAge++
+    if (this.mapAge >= MAP_REFRESH_FRAMES) {
+      this.mapAge = 0
+      this.buildMapImage(w, theme)
+    }
+
+    const dw = this.display.width
+    const dh = this.display.height
+    const width = Math.round(Math.max(140, Math.min(dw * 0.32, 520)))
+    const height = Math.round((width * MH) / MW)
+    const pad = Math.max(6, Math.round(dh * 0.025))
+    const x = Math.round((dw - width) / 2)
+    const y = dh - height - pad
+
+    this.mapRect = { x, y, w: width, h: height }
+
+    const ctx = this.ctx
+    ctx.save()
+    ctx.imageSmoothingEnabled = false
+
+    const border = Math.max(1, Math.round(width / 200))
+    ctx.fillStyle = 'rgba(5, 4, 12, 0.72)'
+    ctx.fillRect(x - border, y - border, width + border * 2, height + border * 2)
+
+    ctx.globalAlpha = 0.9
+    ctx.drawImage(this.mapCanvas, 0, 0, MW, MH, x, y, width, height)
+    ctx.globalAlpha = 1
+
+    // The view, marked. Kept at least a couple of pixels wide so it can't
+    // vanish on a narrow screen.
+    const vxPx = x + Math.round((vx / WORLD_W) * width)
+    const vwPx = Math.max(3, Math.round((this.viewTiles / WORLD_W) * width))
+    ctx.strokeStyle = '#5eead4'
+    ctx.lineWidth = Math.max(1, Math.round(width / 220))
+    ctx.strokeRect(
+      vxPx + ctx.lineWidth / 2,
+      y + ctx.lineWidth / 2,
+      Math.min(vwPx, width - (vxPx - x)) - ctx.lineWidth,
+      height - ctx.lineWidth
+    )
+
+    ctx.strokeStyle = 'rgba(94, 234, 212, 0.35)'
+    ctx.lineWidth = border
+    ctx.strokeRect(x - border / 2, y - border / 2, width + border, height + border)
+    ctx.restore()
+  }
+
+  private buildMapImage(w: WorldState, theme: Theme): void {
+    const data = this.mapImage.data
+    const tiles = w.tiles
+    const rgb = this.materialRgb
+    const sky = hexToRgb(theme.sky[1])
+
+    for (let my = 0; my < MH; my++) {
+      const wy = Math.min(WORLD_H - 1, my * MAP_SCALE)
+      for (let mx = 0; mx < MW; mx++) {
+        const wx = Math.min(WORLD_W - 1, mx * MAP_SCALE)
+        const mat = tiles[wy * WORLD_W + wx]
+        const o = (my * MW + mx) * 4
+        const c = mat === 0 ? sky : rgb[mat]
+        data[o] = c.r
+        data[o + 1] = c.g
+        data[o + 2] = c.b
+        data[o + 3] = 255
+      }
+    }
+    this.mapCtx.putImageData(this.mapImage, 0, 0)
   }
 }

--- a/src/app/micro-land/rendering/renderer.ts
+++ b/src/app/micro-land/rendering/renderer.ts
@@ -1,0 +1,387 @@
+/**
+ * Renderer.
+ *
+ * Everything is drawn at exactly one canvas pixel per world tile into a small
+ * backbuffer, then blown up to the display with smoothing off. That's what
+ * keeps tiles, creatures and particles on a single shared pixel grid — nothing
+ * lands on a half-pixel, so the whole thing reads as one piece of pixel art
+ * rather than sprites floating over a background.
+ *
+ * Light is a quarter-resolution field (sky from above, plus glowing tiles and
+ * creatures), blurred and composited as a darkness layer *after* sprites, so
+ * creatures are dimmed by the same shadows as the terrain.
+ */
+import { MATERIAL_BY_INDEX } from '@/app/micro-land/domain/config/materials'
+import type { Theme } from '@/app/micro-land/domain/config/themes'
+import { WORLD_H, WORLD_W } from '@/app/micro-land/domain/constants'
+import type { WorldState } from '@/app/micro-land/domain/types'
+
+import { getSprites } from './sprite-cache'
+
+/** Light is computed on a coarse grid and blurred — no need for per-pixel. */
+const LIGHT_SCALE = 4
+const LW = Math.ceil(WORLD_W / LIGHT_SCALE)
+const LH = Math.ceil(WORLD_H / LIGHT_SCALE)
+
+/** How far daylight reaches below the first solid tile in a column, in tiles. */
+const SKY_FALLOFF = 16
+
+interface Rgb {
+  r: number
+  g: number
+  b: number
+}
+
+function hexToRgb(hex: string): Rgb {
+  const n = parseInt(hex.slice(1), 16)
+  return { r: (n >> 16) & 255, g: (n >> 8) & 255, b: n & 255 }
+}
+
+export class Renderer {
+  private display: HTMLCanvasElement
+  private ctx: CanvasRenderingContext2D
+
+  /** Backbuffer at world resolution. Everything is composed here first. */
+  private world: HTMLCanvasElement
+  private wctx: CanvasRenderingContext2D
+
+  /** Tile colors. Rebuilt only when the grid actually changes. */
+  private tileImage: ImageData
+  private tileCanvas: HTMLCanvasElement
+  private tileCtx: CanvasRenderingContext2D
+  private tilesDirty = true
+
+  /** Darkness overlay, world resolution. */
+  private shadowImage: ImageData
+  private shadowCanvas: HTMLCanvasElement
+  private shadowCtx: CanvasRenderingContext2D
+
+  private light = new Float32Array(LW * LH)
+  private lightScratch = new Float32Array(LW * LH)
+  private skyDepth = new Int16Array(WORLD_W)
+
+  private materialRgb: Rgb[]
+
+  /** Placement of the world inside the display canvas. */
+  private scale = 1
+  private offsetX = 0
+  private offsetY = 0
+
+  constructor(display: HTMLCanvasElement) {
+    this.display = display
+    const ctx = display.getContext('2d')
+    if (!ctx) throw new Error('micro-land: 2d canvas context unavailable')
+    this.ctx = ctx
+
+    this.world = document.createElement('canvas')
+    this.world.width = WORLD_W
+    this.world.height = WORLD_H
+    this.wctx = this.world.getContext('2d')!
+
+    this.tileCanvas = document.createElement('canvas')
+    this.tileCanvas.width = WORLD_W
+    this.tileCanvas.height = WORLD_H
+    this.tileCtx = this.tileCanvas.getContext('2d')!
+    this.tileImage = this.tileCtx.createImageData(WORLD_W, WORLD_H)
+
+    this.shadowCanvas = document.createElement('canvas')
+    this.shadowCanvas.width = WORLD_W
+    this.shadowCanvas.height = WORLD_H
+    this.shadowCtx = this.shadowCanvas.getContext('2d')!
+    this.shadowImage = this.shadowCtx.createImageData(WORLD_W, WORLD_H)
+
+    this.materialRgb = MATERIAL_BY_INDEX.map((m) => hexToRgb(m.color))
+  }
+
+  /** Call whenever tiles change — painting, theme swap, lava setting solid. */
+  markTilesDirty(): void {
+    this.tilesDirty = true
+  }
+
+  resize(cssWidth: number, cssHeight: number): void {
+    const dpr = Math.min(window.devicePixelRatio || 1, 2)
+    this.display.width = Math.max(1, Math.floor(cssWidth * dpr))
+    this.display.height = Math.max(1, Math.floor(cssHeight * dpr))
+    this.display.style.width = `${cssWidth}px`
+    this.display.style.height = `${cssHeight}px`
+
+    // Fit the whole world in view — it's a terrarium, you should see all of it.
+    const fit = Math.min(this.display.width / WORLD_W, this.display.height / WORLD_H)
+    this.scale = fit
+    this.offsetX = Math.floor((this.display.width - WORLD_W * fit) / 2)
+    this.offsetY = Math.floor((this.display.height - WORLD_H * fit) / 2)
+  }
+
+  /** Display pixel → world tile. Used by every pointer interaction. */
+  screenToWorld(clientX: number, clientY: number): { x: number; y: number } {
+    const rect = this.display.getBoundingClientRect()
+    const dpr = this.display.width / rect.width
+    const px = (clientX - rect.left) * dpr
+    const py = (clientY - rect.top) * dpr
+    return {
+      x: (px - this.offsetX) / this.scale,
+      y: (py - this.offsetY) / this.scale,
+    }
+  }
+
+  render(w: WorldState, theme: Theme, highlightId: number | null = null): void {
+    if (this.tilesDirty) {
+      this.buildTiles(w)
+      this.tilesDirty = false
+    }
+    this.buildLight(w, theme)
+
+    const wctx = this.wctx
+    wctx.imageSmoothingEnabled = false
+
+    // Sky behind everything (air tiles are transparent in the tile layer).
+    const sky = wctx.createLinearGradient(0, 0, 0, WORLD_H)
+    sky.addColorStop(0, theme.sky[0])
+    sky.addColorStop(1, theme.sky[1])
+    wctx.fillStyle = sky
+    wctx.fillRect(0, 0, WORLD_W, WORLD_H)
+
+    wctx.drawImage(this.tileCanvas, 0, 0)
+
+    this.drawCreatures(w)
+    this.drawParticles(w)
+    wctx.drawImage(this.shadowCanvas, 0, 0)
+    // Drawn after the shadow so the selection stays legible in a dark cave.
+    if (highlightId !== null) this.drawHighlight(w, highlightId)
+
+    // One scaled blit. Nearest-neighbour keeps the pixels crisp.
+    const ctx = this.ctx
+    ctx.imageSmoothingEnabled = false
+    ctx.fillStyle = '#05040c'
+    ctx.fillRect(0, 0, this.display.width, this.display.height)
+    ctx.drawImage(
+      this.world,
+      0,
+      0,
+      WORLD_W,
+      WORLD_H,
+      this.offsetX,
+      this.offsetY,
+      WORLD_W * this.scale,
+      WORLD_H * this.scale
+    )
+  }
+
+  // -------------------------------------------------------------------------
+
+  private buildTiles(w: WorldState): void {
+    const data = this.tileImage.data
+    const tiles = w.tiles
+    const grain = w.grain
+    const rgb = this.materialRgb
+    const materials = MATERIAL_BY_INDEX
+
+    for (let i = 0; i < tiles.length; i++) {
+      const mat = tiles[i]
+      const o = i * 4
+      if (mat === 0) {
+        // Air — leave it transparent so the sky gradient shows through.
+        data[o + 3] = 0
+        continue
+      }
+      const base = rgb[mat]
+      // Per-tile jitter stops large fills from looking like flat blocks.
+      const jitter = ((grain[i] / 255) * 2 - 1) * materials[mat].grain
+      const k = 1 + jitter
+      data[o] = Math.max(0, Math.min(255, base.r * k))
+      data[o + 1] = Math.max(0, Math.min(255, base.g * k))
+      data[o + 2] = Math.max(0, Math.min(255, base.b * k))
+      data[o + 3] = 255
+    }
+
+    this.tileCtx.putImageData(this.tileImage, 0, 0)
+  }
+
+  private buildLight(w: WorldState, theme: Theme): void {
+    const light = this.light
+    light.fill(0)
+
+    // --- daylight: how far below the first solid tile is each column? ---
+    const tiles = w.tiles
+    for (let x = 0; x < WORLD_W; x++) {
+      let y = 0
+      while (y < WORLD_H && MATERIAL_BY_INDEX[tiles[y * WORLD_W + x]].solid === false) {
+        y++
+      }
+      this.skyDepth[x] = y
+    }
+
+    for (let ly = 0; ly < LH; ly++) {
+      const wy = ly * LIGHT_SCALE + LIGHT_SCALE / 2
+      for (let lx = 0; lx < LW; lx++) {
+        const wx = Math.min(WORLD_W - 1, lx * LIGHT_SCALE + (LIGHT_SCALE >> 1))
+        const surface = this.skyDepth[wx]
+        const below = wy - surface
+        let value: number
+        if (below <= 0) value = 1
+        else value = Math.max(0, 1 - below / SKY_FALLOFF)
+        light[ly * LW + lx] = value
+      }
+    }
+
+    // --- emitters: glowing tiles ---
+    // Sampled every other tile; the blur smooths over the gaps.
+    for (let y = 0; y < WORLD_H; y += 2) {
+      for (let x = 0; x < WORLD_W; x += 2) {
+        const mat = MATERIAL_BY_INDEX[tiles[y * WORLD_W + x]]
+        if (mat.glow <= 0) continue
+        const li = Math.floor(y / LIGHT_SCALE) * LW + Math.floor(x / LIGHT_SCALE)
+        light[li] = Math.min(1.6, light[li] + mat.glow * 0.5)
+      }
+    }
+
+    // --- emitters: glowing creatures ---
+    for (const c of w.creatures) {
+      const bp = w.blueprints[c.blueprintId]
+      if (!bp || bp.glow <= 0) continue
+      const lx = Math.floor(c.x / LIGHT_SCALE)
+      const ly = Math.floor(c.y / LIGHT_SCALE)
+      if (lx < 0 || ly < 0 || lx >= LW || ly >= LH) continue
+      const li = ly * LW + lx
+      light[li] = Math.min(1.8, light[li] + bp.glow * 1.4)
+    }
+
+    // --- blur, so light pools instead of forming squares ---
+    for (let pass = 0; pass < 3; pass++) this.blurLight()
+
+    // --- bake into the shadow overlay ---
+    const gloom = theme.gloom
+    const data = this.shadowImage.data
+    for (let y = 0; y < WORLD_H; y++) {
+      const ly = y / LIGHT_SCALE
+      for (let x = 0; x < WORLD_W; x++) {
+        const value = this.sampleLight(x / LIGHT_SCALE, ly)
+        const alpha = Math.max(0, Math.min(1, 1 - value)) * gloom
+        const o = (y * WORLD_W + x) * 4
+        data[o] = 4
+        data[o + 1] = 3
+        data[o + 2] = 12
+        data[o + 3] = Math.round(alpha * 255)
+      }
+    }
+    this.shadowCtx.putImageData(this.shadowImage, 0, 0)
+  }
+
+  private blurLight(): void {
+    const src = this.light
+    const dst = this.lightScratch
+    for (let y = 0; y < LH; y++) {
+      for (let x = 0; x < LW; x++) {
+        let sum = 0
+        let count = 0
+        for (let dy = -1; dy <= 1; dy++) {
+          const ny = y + dy
+          if (ny < 0 || ny >= LH) continue
+          for (let dx = -1; dx <= 1; dx++) {
+            const nx = x + dx
+            if (nx < 0 || nx >= LW) continue
+            sum += src[ny * LW + nx]
+            count++
+          }
+        }
+        dst[y * LW + x] = sum / count
+      }
+    }
+    this.light.set(dst)
+  }
+
+  /** Bilinear sample of the coarse light field. */
+  private sampleLight(fx: number, fy: number): number {
+    const x0 = Math.floor(fx)
+    const y0 = Math.floor(fy)
+    const tx = fx - x0
+    const ty = fy - y0
+    const cx0 = Math.max(0, Math.min(LW - 1, x0))
+    const cy0 = Math.max(0, Math.min(LH - 1, y0))
+    const cx1 = Math.min(LW - 1, cx0 + 1)
+    const cy1 = Math.min(LH - 1, cy0 + 1)
+    const l = this.light
+    const a = l[cy0 * LW + cx0]
+    const b = l[cy0 * LW + cx1]
+    const c = l[cy1 * LW + cx0]
+    const d = l[cy1 * LW + cx1]
+    const top = a + (b - a) * tx
+    const bottom = c + (d - c) * tx
+    return top + (bottom - top) * ty
+  }
+
+  private drawCreatures(w: WorldState): void {
+    const ctx = this.wctx
+    for (const c of w.creatures) {
+      const bp = w.blueprints[c.blueprintId]
+      if (!bp) continue
+      const sprites = getSprites(bp)
+      const frameCount = sprites.frames.length
+      const frame =
+        frameCount === 1
+          ? 0
+          : Math.floor(c.animMs / sprites.frameMs) % frameCount
+      const source =
+        c.facing === -1 && bp.art.faceMotion
+          ? sprites.flipped[frame]
+          : sprites.frames[frame]
+
+      const x = Math.round(c.x)
+      const y = Math.round(c.y)
+
+      // A creature about to starve or drown flickers, so you can spot it.
+      if (c.starving > 0 || c.distress > 2) {
+        const pulse = Math.sin(w.elapsed * 12) * 0.5 + 0.5
+        ctx.globalAlpha = 0.45 + pulse * 0.55
+      }
+      ctx.drawImage(source, x, y)
+      ctx.globalAlpha = 1
+    }
+  }
+
+  /** Ring around the creature the inspector is watching. */
+  private drawHighlight(w: WorldState, id: number): void {
+    const c = w.creatures.find((x) => x.id === id)
+    if (!c) return
+    const bp = w.blueprints[c.blueprintId]
+    if (!bp) return
+    const rows = bp.art.frames[0]
+    const bw = rows[0].length
+    const bh = rows.length
+
+    const ctx = this.wctx
+    const x = Math.round(c.x) - 2
+    const y = Math.round(c.y) - 2
+    const width = bw + 4
+    const height = bh + 4
+
+    // Corner brackets rather than a full box — a solid outline on a 6px sprite
+    // hides more of the creature than it frames.
+    const arm = Math.max(2, Math.floor(Math.min(width, height) / 3))
+    ctx.fillStyle = '#5eead4'
+    const pulse = 0.55 + 0.45 * Math.sin(w.elapsed * 6)
+    ctx.globalAlpha = pulse
+    for (const [cx, cy, sx, sy] of [
+      [x, y, 1, 1],
+      [x + width - 1, y, -1, 1],
+      [x, y + height - 1, 1, -1],
+      [x + width - 1, y + height - 1, -1, -1],
+    ]) {
+      for (let i = 0; i < arm; i++) {
+        ctx.fillRect(cx + sx * i, cy, 1, 1)
+        ctx.fillRect(cx, cy + sy * i, 1, 1)
+      }
+    }
+    ctx.globalAlpha = 1
+  }
+
+  private drawParticles(w: WorldState): void {
+    const ctx = this.wctx
+    for (const p of w.particles) {
+      ctx.globalAlpha = Math.max(0, Math.min(1, p.life / p.maxLife))
+      ctx.fillStyle = p.color
+      ctx.fillRect(Math.round(p.x), Math.round(p.y), 1, 1)
+    }
+    ctx.globalAlpha = 1
+  }
+}

--- a/src/app/micro-land/rendering/sprite-cache.ts
+++ b/src/app/micro-land/rendering/sprite-cache.ts
@@ -1,0 +1,84 @@
+/**
+ * Rasterizes a blueprint's `art` (palette + rows of characters) into tiny
+ * canvases — one per frame, plus a mirrored copy for creatures that turn to
+ * face where they're going.
+ *
+ * Sprites are one canvas pixel per world tile. All the scaling happens once, at
+ * the very end of the render, so everything stays on the same pixel grid.
+ */
+import type { CreatureBlueprint } from '@/app/micro-land/domain/types'
+
+export interface SpriteSet {
+  width: number
+  height: number
+  frames: HTMLCanvasElement[]
+  flipped: HTMLCanvasElement[]
+  frameMs: number
+}
+
+const cache = new Map<string, SpriteSet>()
+
+function rasterize(bp: CreatureBlueprint, rows: string[]): HTMLCanvasElement {
+  const height = rows.length
+  const width = rows[0].length
+  const canvas = document.createElement('canvas')
+  canvas.width = width
+  canvas.height = height
+  const ctx = canvas.getContext('2d')
+  if (!ctx) return canvas
+
+  const image = ctx.createImageData(width, height)
+  const data = image.data
+
+  for (let y = 0; y < height; y++) {
+    const row = rows[y]
+    for (let x = 0; x < width; x++) {
+      const ch = row[x]
+      if (ch === '.' || ch === undefined) continue
+      const hex = bp.art.palette[ch]
+      if (!hex) continue
+      const n = parseInt(hex.slice(1), 16)
+      const o = (y * width + x) * 4
+      data[o] = (n >> 16) & 255
+      data[o + 1] = (n >> 8) & 255
+      data[o + 2] = n & 255
+      data[o + 3] = 255
+    }
+  }
+
+  ctx.putImageData(image, 0, 0)
+  return canvas
+}
+
+function mirror(source: HTMLCanvasElement): HTMLCanvasElement {
+  const canvas = document.createElement('canvas')
+  canvas.width = source.width
+  canvas.height = source.height
+  const ctx = canvas.getContext('2d')
+  if (!ctx) return canvas
+  ctx.imageSmoothingEnabled = false
+  ctx.translate(source.width, 0)
+  ctx.scale(-1, 1)
+  ctx.drawImage(source, 0, 0)
+  return canvas
+}
+
+export function getSprites(bp: CreatureBlueprint): SpriteSet {
+  const existing = cache.get(bp.id)
+  if (existing) return existing
+
+  const frames = bp.art.frames.map((rows) => rasterize(bp, rows))
+  const set: SpriteSet = {
+    width: frames[0].width,
+    height: frames[0].height,
+    frames,
+    flipped: bp.art.faceMotion ? frames.map(mirror) : frames,
+    frameMs: bp.art.frameMs,
+  }
+  cache.set(bp.id, set)
+  return set
+}
+
+export function clearSpriteCache(): void {
+  cache.clear()
+}

--- a/src/app/micro-land/store.ts
+++ b/src/app/micro-land/store.ts
@@ -1,0 +1,153 @@
+/**
+ * UI state.
+ *
+ * The world itself is *not* in here — it's a mutable object owned by the game
+ * instance, ticked 60 times a second. Putting 300 creatures into React state
+ * would re-render the tree every frame for no reason. The game pushes a small
+ * summary (population, clock, notices) into this store a few times a second,
+ * and that's all the UI ever needs.
+ */
+import { create } from 'zustand'
+
+import { DEFAULT_THEME } from './domain/config/themes'
+
+import type { CreatureBlueprint, MaterialId } from './domain/types'
+
+/** Theme id standing for "the land the player summoned". */
+export const SUMMONED_THEME_ID = 'summoned'
+
+export type Tool =
+  | { kind: 'material'; material: MaterialId }
+  | { kind: 'erase' }
+  | { kind: 'creature'; blueprintId: string }
+  | { kind: 'inspect' }
+
+/**
+ * A live read-out of one creature.
+ *
+ * Snapshotted out of the simulation a few times a second rather than exposing
+ * the mutable Creature object, so the panel can re-render without dragging the
+ * whole world into React state.
+ */
+export interface Inspected {
+  id: number
+  blueprintId: string
+  mood: string
+  /** 0 = stuffed, 1 = starving. */
+  hunger: number
+  ageSeconds: number
+  lifespanSeconds: number
+  mealsEaten: number
+  children: number
+  tilesDug: number
+  /** Seconds spent somewhere it can't survive; 0 when it's fine. */
+  distress: number
+  starving: number
+  speed: number
+  inWater: boolean
+  grounded: boolean
+  /** What it's chasing or running from right now. */
+  targetName: string | null
+}
+
+export interface PopulationEntry {
+  blueprintId: string
+  name: string
+  count: number
+}
+
+export interface Notice {
+  id: number
+  text: string
+}
+
+interface MicroLandState {
+  themeId: string
+  tool: Tool
+  brush: number
+  paused: boolean
+  speed: number
+
+  /** Every creature that exists in this world, built-in and summoned. */
+  blueprints: CreatureBlueprint[]
+  population: PopulationEntry[]
+  totalCreatures: number
+  elapsed: number
+
+  summonOpen: boolean
+  summonBusy: boolean
+  summonMode: 'creature' | 'scene' | 'terrain'
+  /** Name of the summoned land, if there is one — shown in the world picker. */
+  summonedLand: string | null
+  summonError: string | null
+  guideOpen: boolean
+  inspected: Inspected | null
+
+  notices: Notice[]
+
+  setTheme: (id: string) => void
+  setTool: (tool: Tool) => void
+  setBrush: (n: number) => void
+  togglePaused: () => void
+  setSpeed: (n: number) => void
+  setBlueprints: (list: CreatureBlueprint[]) => void
+  setStats: (population: PopulationEntry[], total: number, elapsed: number) => void
+  setSummonOpen: (open: boolean) => void
+  setSummonBusy: (busy: boolean) => void
+  setSummonMode: (mode: 'creature' | 'scene' | 'terrain') => void
+  setSummonedLand: (name: string | null) => void
+  setSummonError: (message: string | null) => void
+  setGuideOpen: (open: boolean) => void
+  setInspected: (snapshot: Inspected | null) => void
+  notify: (text: string) => void
+  dismissNotice: (id: number) => void
+}
+
+let noticeId = 0
+
+export const useMicroLand = create<MicroLandState>((set) => ({
+  themeId: DEFAULT_THEME,
+  tool: { kind: 'material', material: 'dirt' },
+  brush: 4,
+  paused: false,
+  speed: 1,
+
+  blueprints: [],
+  population: [],
+  totalCreatures: 0,
+  elapsed: 0,
+
+  summonOpen: false,
+  summonBusy: false,
+  summonMode: 'creature',
+  summonedLand: null,
+  summonError: null,
+  guideOpen: false,
+  inspected: null,
+
+  notices: [],
+
+  setTheme: (themeId) => set({ themeId }),
+  setTool: (tool) => set({ tool }),
+  setBrush: (brush) => set({ brush }),
+  togglePaused: () => set((s) => ({ paused: !s.paused })),
+  setSpeed: (speed) => set({ speed }),
+  setBlueprints: (blueprints) => set({ blueprints }),
+  setStats: (population, totalCreatures, elapsed) =>
+    set({ population, totalCreatures, elapsed }),
+  setSummonOpen: (summonOpen) => set({ summonOpen }),
+  setSummonBusy: (summonBusy) => set({ summonBusy }),
+  setSummonMode: (summonMode) => set({ summonMode }),
+  setSummonedLand: (summonedLand) => set({ summonedLand }),
+  setSummonError: (summonError) => set({ summonError }),
+  setGuideOpen: (guideOpen) => set({ guideOpen }),
+  setInspected: (inspected) => set({ inspected }),
+
+  notify: (text) =>
+    set((s) => ({
+      // Keep the last few — a population crash can fire several at once.
+      notices: [...s.notices, { id: ++noticeId, text }].slice(-3),
+    })),
+  dismissNotice: (id) =>
+    set((s) => ({ notices: s.notices.filter((n) => n.id !== id) })),
+}))

--- a/src/app/micro-land/store.ts
+++ b/src/app/micro-land/store.ts
@@ -150,6 +150,13 @@ interface MicroLandState {
    */
   archive: SpeciesRecord[]
   milestones: EarnedMilestone[]
+  /**
+   * Whether the world is wider than the view.
+   *
+   * Almost always true, but an ultrawide display can fit all 672 tiles at once,
+   * and scroll buttons that visibly do nothing are worse than no buttons.
+   */
+  canPan: boolean
 
   notices: Notice[]
 
@@ -173,6 +180,7 @@ interface MicroLandState {
   setRecords: (records: RecordsView) => void
   setArchive: (archive: SpeciesRecord[]) => void
   setMilestones: (milestones: EarnedMilestone[]) => void
+  setCanPan: (canPan: boolean) => void
   notify: (text: string) => void
   dismissNotice: (id: number) => void
 }
@@ -200,6 +208,7 @@ export const useMicroLand = create<MicroLandState>((set) => ({
   pendingSummons: [],
   guideOpen: false,
   inspected: null,
+  canPan: true,
 
   records: EMPTY_RECORDS,
   archive: [],
@@ -232,6 +241,7 @@ export const useMicroLand = create<MicroLandState>((set) => ({
   setRecords: (records) => set({ records }),
   setArchive: (archive) => set({ archive }),
   setMilestones: (milestones) => set({ milestones }),
+  setCanPan: (canPan) => set({ canPan }),
 
   notify: (text) =>
     set((s) => ({

--- a/src/app/micro-land/store.ts
+++ b/src/app/micro-land/store.ts
@@ -61,6 +61,19 @@ export interface Notice {
   text: string
 }
 
+/**
+ * A creature that has been asked for but hasn't arrived yet.
+ *
+ * A single creature is summoned without blocking the game, so the wait has to
+ * be visible somewhere the player isn't using: an empty slot holds its place in
+ * the creature strip until the response lands. More than one can be in flight —
+ * nothing stops a player from asking for a second while the first is coming.
+ */
+export interface PendingSummon {
+  id: number
+  prompt: string
+}
+
 interface MicroLandState {
   themeId: string
   tool: Tool
@@ -80,6 +93,8 @@ interface MicroLandState {
   /** Name of the summoned land, if there is one — shown in the world picker. */
   summonedLand: string | null
   summonError: string | null
+  /** Creature summons in flight, in the order they were asked for. */
+  pendingSummons: PendingSummon[]
   guideOpen: boolean
   inspected: Inspected | null
 
@@ -97,6 +112,9 @@ interface MicroLandState {
   setSummonMode: (mode: 'creature' | 'scene' | 'terrain') => void
   setSummonedLand: (name: string | null) => void
   setSummonError: (message: string | null) => void
+  /** Opens a slot for a creature on its way; returns the id to close it with. */
+  addPendingSummon: (prompt: string) => number
+  removePendingSummon: (id: number) => void
   setGuideOpen: (open: boolean) => void
   setInspected: (snapshot: Inspected | null) => void
   notify: (text: string) => void
@@ -104,6 +122,7 @@ interface MicroLandState {
 }
 
 let noticeId = 0
+let pendingId = 0
 
 export const useMicroLand = create<MicroLandState>((set) => ({
   themeId: DEFAULT_THEME,
@@ -122,6 +141,7 @@ export const useMicroLand = create<MicroLandState>((set) => ({
   summonMode: 'creature',
   summonedLand: null,
   summonError: null,
+  pendingSummons: [],
   guideOpen: false,
   inspected: null,
 
@@ -140,6 +160,13 @@ export const useMicroLand = create<MicroLandState>((set) => ({
   setSummonMode: (summonMode) => set({ summonMode }),
   setSummonedLand: (summonedLand) => set({ summonedLand }),
   setSummonError: (summonError) => set({ summonError }),
+  addPendingSummon: (prompt) => {
+    const id = ++pendingId
+    set((s) => ({ pendingSummons: [...s.pendingSummons, { id, prompt }] }))
+    return id
+  },
+  removePendingSummon: (id) =>
+    set((s) => ({ pendingSummons: s.pendingSummons.filter((p) => p.id !== id) })),
   setGuideOpen: (guideOpen) => set({ guideOpen }),
   setInspected: (inspected) => set({ inspected }),
 

--- a/src/app/micro-land/store.ts
+++ b/src/app/micro-land/store.ts
@@ -11,6 +11,7 @@ import { create } from 'zustand'
 
 import { DEFAULT_THEME } from './domain/config/themes'
 
+import type { ElderRecord, SpeciesRecord } from './chronicle/types'
 import type { CreatureBlueprint, MaterialId } from './domain/types'
 
 /** Theme id standing for "the land the player summoned". */
@@ -48,6 +49,46 @@ export interface Inspected {
   grounded: boolean
   /** What it's chasing or running from right now. */
   targetName: string | null
+  /** How far back its line goes; 1 means it was placed rather than born. */
+  generation: number
+  /** Player-given name, if this one earned the right to have one. */
+  name: string | null
+  /** True while this creature holds the land's longevity record. */
+  isElder: boolean
+}
+
+/**
+ * Records for the land currently on screen, as the UI wants them.
+ *
+ * Flattened out of the chronicle rather than exposing it directly: the panels
+ * want "best ever here" and "how it's going right now" side by side, and those
+ * come from two different places.
+ */
+export interface RecordsView {
+  /** Best ever in this land. */
+  elder: ElderRecord | null
+  bestSteadySeconds: number
+  bestGenerations: number
+  bestGenerationsSpeciesName: string | null
+  /** How this run is going. */
+  steadySeconds: number
+  deepestGeneration: number
+}
+
+export interface EarnedMilestone {
+  id: string
+  text: string
+  /** Epoch ms it was first reached. */
+  at: number
+}
+
+const EMPTY_RECORDS: RecordsView = {
+  elder: null,
+  bestSteadySeconds: 0,
+  bestGenerations: 0,
+  bestGenerationsSpeciesName: null,
+  steadySeconds: 0,
+  deepestGeneration: 0,
 }
 
 export interface PopulationEntry {
@@ -98,6 +139,18 @@ interface MicroLandState {
   guideOpen: boolean
   inspected: Inspected | null
 
+  /** Records for the land on screen. */
+  records: RecordsView
+  /**
+   * Every species ever seen alive, including summoned ones from past visits.
+   *
+   * Pushed only when it actually changes rather than on every stats tick — it
+   * turns over rarely and re-rendering the guide three times a second for a list
+   * that hasn't moved is wasted work.
+   */
+  archive: SpeciesRecord[]
+  milestones: EarnedMilestone[]
+
   notices: Notice[]
 
   setTheme: (id: string) => void
@@ -117,6 +170,9 @@ interface MicroLandState {
   removePendingSummon: (id: number) => void
   setGuideOpen: (open: boolean) => void
   setInspected: (snapshot: Inspected | null) => void
+  setRecords: (records: RecordsView) => void
+  setArchive: (archive: SpeciesRecord[]) => void
+  setMilestones: (milestones: EarnedMilestone[]) => void
   notify: (text: string) => void
   dismissNotice: (id: number) => void
 }
@@ -145,6 +201,10 @@ export const useMicroLand = create<MicroLandState>((set) => ({
   guideOpen: false,
   inspected: null,
 
+  records: EMPTY_RECORDS,
+  archive: [],
+  milestones: [],
+
   notices: [],
 
   setTheme: (themeId) => set({ themeId }),
@@ -169,6 +229,9 @@ export const useMicroLand = create<MicroLandState>((set) => ({
     set((s) => ({ pendingSummons: s.pendingSummons.filter((p) => p.id !== id) })),
   setGuideOpen: (guideOpen) => set({ guideOpen }),
   setInspected: (inspected) => set({ inspected }),
+  setRecords: (records) => set({ records }),
+  setArchive: (archive) => set({ archive }),
+  setMilestones: (milestones) => set({ milestones }),
 
   notify: (text) =>
     set((s) => ({

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -20,6 +20,7 @@ const games: readonly { title: string; icon: string; href: string; description: 
   { title: 'Storybook Factory', icon: 'auto_stories', href: ROUTE_CONSTANTS.STORYBOOK_FACTORY, description: 'Create illustrated comic books and storybooks from your pictures' },
   { title: 'Speck Wars', icon: 'bug_report', href: ROUTE_CONSTANTS.SPECK_WARS, description: 'Command your specks to capture enemy bases in this real-time strategy micro-battle' },
   { title: 'Disneyland Hunt', icon: 'search', href: ROUTE_CONSTANTS.DISNEYLAND_HUNT, description: 'Scavenger hunt checklist for your Disneyland visit — track finds, earn bonus stars' },
+  { title: 'Micro Land', icon: 'pest_control', href: ROUTE_CONSTANTS.MICRO_LAND, description: 'A tiny living world — build the ground, summon creatures, and watch them eat each other' },
 ]
 
 export default function Home() {

--- a/src/app/route-constants.ts
+++ b/src/app/route-constants.ts
@@ -14,4 +14,5 @@ export const ROUTE_CONSTANTS = {
   STORYBOOK_FACTORY: '/storybook-factory',
   SPECK_WARS: '/speck-wars',
   DISNEYLAND_HUNT: '/disneyland-hunt',
+  MICRO_LAND: '/micro-land',
 }

--- a/src/components/layout-shell.tsx
+++ b/src/components/layout-shell.tsx
@@ -6,6 +6,7 @@ import type { ReactNode } from 'react'
 
 const IMMERSIVE_ROUTES = [
   ROUTE_CONSTANTS.COMET_CARDS,
+  ROUTE_CONSTANTS.MICRO_LAND,
   `${ROUTE_CONSTANTS.SPECK_WARS}/play`,
   `${ROUTE_CONSTANTS.SPECK_WARS}/skirmish`,
 ]

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -18,6 +18,7 @@ export default defineConfig({
       'src/app/comet-cards/**/*.test.tsx',
       'src/lib/trivia/**/*.test.ts',
       'src/app/trivia/**/*.test.ts',
+      'src/app/micro-land/**/*.test.ts',
     ],
     coverage: {
       reporter: ['text', 'json', 'html'],

--- a/yarn.lock
+++ b/yarn.lock
@@ -580,15 +580,15 @@
   resolved "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.4.0.tgz"
   integrity sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg==
 
-"@esbuild/linux-x64@0.25.3":
+"@esbuild/darwin-arm64@0.25.3":
   version "0.25.3"
-  resolved "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.3.tgz"
-  integrity sha512-nQHDz4pXjSDC6UfOE1Fw9Q8d6GCAd9KdvMZpfVGWSJztYCarRgSDfOVBY5xwhQXseiyxapkiSJi/5/ja8mRFFA==
+  resolved "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.3.tgz"
+  integrity sha512-eESK5yfPNTqpAmDfFWNsOhmIOaQA59tAcF/EfYvo5/QWQCzXn5iUSOnqt3ra3UdzBv073ykTtmeLJZGt3HhA+w==
 
-"@esbuild/linux-x64@0.27.7":
+"@esbuild/darwin-arm64@0.27.7":
   version "0.27.7"
-  resolved "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz"
-  integrity sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==
+  resolved "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz"
+  integrity sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==
 
 "@eslint-community/eslint-utils@^4.2.0", "@eslint-community/eslint-utils@^4.7.0":
   version "4.9.0"
@@ -1222,29 +1222,17 @@
   resolved "https://registry.npmjs.org/@img/colour/-/colour-1.0.0.tgz"
   integrity sha512-A5P/LfWGFSl6nsckYtjw9da+19jB8hkJ6ACTGcDfEJ0aE+l2n2El7dsVM7UVHZQ9s2lmYMWlrS21YLy2IR1LUw==
 
-"@img/sharp-libvips-linux-x64@1.2.4":
-  version "1.2.4"
-  resolved "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz"
-  integrity sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==
-
-"@img/sharp-libvips-linuxmusl-x64@1.2.4":
-  version "1.2.4"
-  resolved "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz"
-  integrity sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==
-
-"@img/sharp-linux-x64@0.34.5":
+"@img/sharp-darwin-arm64@0.34.5":
   version "0.34.5"
-  resolved "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz"
-  integrity sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==
+  resolved "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz"
+  integrity sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==
   optionalDependencies:
-    "@img/sharp-libvips-linux-x64" "1.2.4"
+    "@img/sharp-libvips-darwin-arm64" "1.2.4"
 
-"@img/sharp-linuxmusl-x64@0.34.5":
-  version "0.34.5"
-  resolved "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz"
-  integrity sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==
-  optionalDependencies:
-    "@img/sharp-libvips-linuxmusl-x64" "1.2.4"
+"@img/sharp-libvips-darwin-arm64@1.2.4":
+  version "1.2.4"
+  resolved "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz"
+  integrity sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==
 
 "@isaacs/cliui@^8.0.2":
   version "8.0.2"
@@ -1599,15 +1587,10 @@
   dependencies:
     fast-glob "3.3.1"
 
-"@next/swc-linux-x64-gnu@16.1.1":
+"@next/swc-darwin-arm64@16.1.1":
   version "16.1.1"
-  resolved "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.1.1.tgz"
-  integrity sha512-20bYDfgOQAPUkkKBnyP9PTuHiJGM7HzNBbuqmD0jiFVZ0aOldz+VnJhbxzjcSabYsnNjMPsE0cyzEudpYxsrUQ==
-
-"@next/swc-linux-x64-musl@16.1.1":
-  version "16.1.1"
-  resolved "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.1.1.tgz"
-  integrity sha512-9pRbK3M4asAHQRkwaXwu601oPZHghuSC8IXNENgbBSyImHv/zY4K5udBusgdHkvJ/Tcr96jJwQYOll0qU8+fPA==
+  resolved "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.1.1.tgz"
+  integrity sha512-JS3m42ifsVSJjSTzh27nW+Igfha3NdBOFScr9C80hHGrWx55pTrVL23RJbqir7k7/15SKlrLHhh/MQzqBBYrQA==
 
 "@nodable/entities@^2.1.0":
   version "2.1.0"
@@ -2311,15 +2294,10 @@
   resolved "https://registry.npmjs.org/@radix-ui/rect/-/rect-1.1.0.tgz"
   integrity sha512-A9+lCBZoaMJlVKcRBz2YByCG+Cp2t6nAnMnNba+XiWxnj6r4JUFqfsgwocMBZU9LPtdxC6wB56ySYpc7LQIoJg==
 
-"@rollup/rollup-linux-x64-gnu@4.40.0":
+"@rollup/rollup-darwin-arm64@4.40.0":
   version "4.40.0"
-  resolved "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.40.0.tgz"
-  integrity sha512-RcDGMtqF9EFN8i2RYN2W+64CdHruJ5rPqrlYw+cgM3uOVPSsnAQps7cpjXe9be/yDp8UC7VLoCoKC8J3Kn2FkQ==
-
-"@rollup/rollup-linux-x64-musl@4.40.0":
-  version "4.40.0"
-  resolved "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.40.0.tgz"
-  integrity sha512-HZvjpiUmSNx5zFgwtQAV1GaGazT2RWvqeDi0hV+AtC8unqqDSsaFjPxfsO6qPtKRRg25SisACWnJ37Yio8ttaw==
+  resolved "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.40.0.tgz"
+  integrity sha512-GwYOcOakYHdfnjjKwqpTGgn5a6cUX7+Ra2HeNj/GdXvO2VJOOXCiYYlRFU4CubFM67EhbmzLOmACKEfvp3J1kQ==
 
 "@rtsao/scc@^1.1.0":
   version "1.1.0"
@@ -2772,15 +2750,10 @@
     "@typescript-eslint/types" "8.50.1"
     eslint-visitor-keys "^4.2.1"
 
-"@unrs/resolver-binding-linux-x64-gnu@1.4.1":
+"@unrs/resolver-binding-darwin-arm64@1.4.1":
   version "1.4.1"
-  resolved "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.4.1.tgz"
-  integrity sha512-XpU9uzIkD86+19NjCXxlVPISMUrVXsXo5htxtuG+uJ59p5JauSRZsIxQxzzfKzkxEjdvANPM/lS1HFoX6A6QeA==
-
-"@unrs/resolver-binding-linux-x64-musl@1.4.1":
-  version "1.4.1"
-  resolved "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-musl/-/resolver-binding-linux-x64-musl-1.4.1.tgz"
-  integrity sha512-3CDjG/spbTKCSHl66QP2ekHSD+H34i7utuDIM5gzoNBcZ1gTO0Op09Wx5cikXnhORRf9+HyDWzm37vU1PLSM1A==
+  resolved "https://registry.npmjs.org/@unrs/resolver-binding-darwin-arm64/-/resolver-binding-darwin-arm64-1.4.1.tgz"
+  integrity sha512-8Tv+Bsd0BjGwfEedIyor4inw8atppRxM5BdUnIt+3mAm/QXUm7Dw74CHnXpfZKXkp07EXJGiA8hStqCINAWhdw==
 
 "@vitest/expect@3.1.2":
   version "3.1.2"
@@ -4733,6 +4706,11 @@ fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
   integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
+
+fsevents@^2.3.2, fsevents@~2.3.2, fsevents@~2.3.3:
+  version "2.3.3"
+  resolved "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz"
+  integrity sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
 
 function-bind@^1.1.2:
   version "1.1.2"
@@ -8629,7 +8607,7 @@ yocto-queue@^0.1.0:
   resolved "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
 
-zod-to-json-schema@^3.24.1:
+zod-to-json-schema@^3.24.1, zod-to-json-schema@^3.24.5:
   version "3.24.5"
   resolved "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.24.5.tgz"
   integrity sha512-/AuWwMP+YqiPbsJx5D6TfgRTc4kTLjsh5SOcd4bLsfUg2RcEXrFMJl1DGgdHy2aCfsIA/cr/1JM0xcB2GZji8g==


### PR DESCRIPTION
## What this is

Micro Land is a 2D pixel-art physics sandbox at `/micro-land`. You paint the ground, generate creatures, and watch an ecosystem run itself.

Designed by my daughter — she owns the direction on this one.

## The simulation

A 224×132 tile world stepped at a fixed 60Hz, deliberately **outside React** — the world mutates 60 times a second and React only hears about it through a small population summary pushed a few times a second.

- **Tiles** — gravity, flowing water and lava, solid/liquid materials. Tile physics runs at 20Hz (every 3rd sim tick); 60Hz reads as frantic.
- **Creatures** — walk, fly, swim, or stay rooted. They get hungry, hunt, flee from whatever hunts them, breed when well fed, and die of hunger, drowning, lava, or old age.
- **The food chain is one rule**: a creature can eat another if it lists one of the target's tags in `eats`, **and** the target is not larger than it. That single rule produces the whole ecosystem — populations rise and crash on their own.

## Materials, and the tints you paint them in

The palette is 26 base materials — dirt, stone, water, lava and the rest, plus snow, mud, moss, crystal, gem, gold, bone, iron, marble, plastic, cloud, sap and acid. Each one is declared as a **diff against a boring-rock default**, so adding a material is a line rather than a block, and forgetting a property is impossible.

Four of them are tintable. A tint is its own entry in the tile grid (`crystal-blue`, `plastic-red`) that **inherits every physical property from the material it recolors** — painting can change how a tile looks and never how it behaves.

Materials also grew habits to go with the vocabulary:

- **viscous** — sap and cloud hold things fast without drowning them
- **breathable** — a liquid you can be inside and still breathe
- **melts** — snow and ice turn to water near lava
- **corrosive / acidProof** — acid eats through neighbouring solids and spends itself doing it

## Creatures that change the world

Creatures can now carry an **aura**: a radius, a set of tags it makes breed faster nearby, and ground it slowly converts (stone into dirt, say) at a deliberately patient rate.

This is the difference between a bee and a moth. Both fly and eat plants; only one of them makes the meadow grow. It's plain blueprint data like everything else, so a *generated* creature can be a helper too.

Alongside that: art up to 28×24 with a 12-color palette so a dragon can look like one instead of a beetle, and creature groups behind tabs in the field guide.

## Generation

`POST /api/v1/micro-land/summon` — three modes: `creature`, `terrain`, and `scene` (a land *and* the creatures designed to live in it).

The zod blueprint schema in `domain/blueprint.ts` is converted straight into the model's tool `input_schema`, so the contract the model is held to and the contract the simulation reads are **the same object** — there's no translation layer to drift.

Two implementation notes worth flagging for review:

- It calls the Messages API directly rather than going through the AI SDK's `generateObject`, which hard-codes `temperature: 0` with no way to omit it. Opus 5 removed the sampling parameters and rejects the request outright, so the SDK path could only reach this model by downgrading it.
- **Every** failure path — no API key, model error, safety refusal, malformed art — falls back to a procedural creature instead of an error. A kid asking for a purple fire snail should always get a purple fire snail.

### Generated worlds keep the ground low

Models draw a horizon two thirds of the way up the page. That looks right on paper and plays badly: everything worth watching happens *above* the surface, and a world that is mostly dirt leaves the creatures nowhere to live.

`fitGroundLevel` finds the first row that is at least half solid — not the highest non-air cell, so a lone peak or a floating island isn't mistaken for the ground — and pads empty rows on top until the surface sits around **30–50% of the way up**, with enough spread that some worlds come out a canyon and some a plain. Since the map is stretched to the world's height whatever its row count, this costs nothing the model drew: every cave, pool and lava seam survives, in less world. The prompt asks for the same proportion up front, so the correction usually has little to do.

## Balance pass

`MAX_PLANTS` 150 → 195 and `PLANT_SPECIES_CAP` 55 → 46. The plant budget is a shared absolute count, so a seven-species roster was splitting a fixed allowance seven ways and starving the grazers rather than feeding more of them.

## Headless harness

`npm run sim:micro-land` runs the real simulation with no canvas and prints populations over time. A browser tells you what one instant looks like, not whether the ecosystem survives ten minutes.

```
npm run sim:micro-land                              # earth, 300s
npm run sim:micro-land -- --theme tidepool --seconds 600
npm run sim:micro-land -- --runs 5                  # average of 5 seeds
```

## Against the UX principles

- **Anonymous-first** — fully playable, no account, no sign-up prompt anywhere.
- **The cave is light, the worlds are loud** — all the juice is inside the game; nothing was added to the shell.
- **Hand-crafted** — the generation loader is its own little animated piece rather than a spinner.
- **The shared pact** — takes over the viewport under interaction model 2, carrying its own cave exit (the ✕ that `CosmicShell` puts top-left). `z-40` sits above the site nav (`z-30`) and below this game's own modals (`z-50`).

On **AI is invisible**: this PR deliberately does *not* hide the mechanism. #2582 renamed "summon" to "generate" and put a sparkle on it, because a player had no way to tell that button from the ones that paint dirt — the wait and the occasional odd result read as a bug otherwise. Flagging it as a knowing exception rather than an oversight.

## Notable diff details

- `eslint.config.mjs` exempts **only** `micro-land/domain/**` and `rendering/**` from the hex-color rule. Creature palettes, tile materials, and terrain themes are pixel-art asset data, not themeable chrome — a creature's colors are part of the creature, and generated ones carry their own palette from the model. **The React components are not exempt and use design tokens.**
- **Drops `zod-to-json-schema` as a direct dependency** (this reverses an earlier note in this PR). The route borrows the AI SDK's `zodSchema` for the conversion instead, which delegates to the copy the lockfile already pins at a version this app's zod satisfies — a direct dependency resolves to one it doesn't.
- The field guide's `GuideEntry` extraction had left the old inline `<li>` markup behind, unclosed, so the file didn't parse; the duplicate is gone. Its badge had also regressed to "Summoned" without the sparkle — restored to the "✦ Generated" that #2582 established.

## Verification

- `npx eslint` on all Micro Land paths — **clean**
- `tsc --noEmit` — **no Micro Land errors**
- `next build` — **compiles successfully.** The TypeScript step still fails on `scripts/classify-seed-difficulty.ts` (AI SDK version mismatch) — a file this branch does not touch, pre-existing on `main`.
- `npm run sim:micro-land -- --seconds 60` — ecosystem survives: peak 257, low-water 222, 252 alive at the end, no extinctions.

**Micro Land ships with no unit tests of its own** — the headless harness is the current safety net for sim behavior. Worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
