### PR TITLE
fix(tap-tap): add dependency array to CombatUI keyboard shortcut useEffect

### DIFF
--- a/src/app/tap-tap-adventure/components/AchievementToast.tsx
+++ b/src/app/tap-tap-adventure/components/AchievementToast.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { ACHIEVEMENTS } from '@/app/tap-tap-adventure/config/achievements'
 
 interface AchievementToastProps {
@@ -10,6 +10,7 @@ interface AchievementToastProps {
 
 export function AchievementToast({ achievementId, onDismiss }: AchievementToastProps) {
   const [isVisible, setIsVisible] = useState(false)
+  const dismissTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const achievement = ACHIEVEMENTS.find(a => a.id === achievementId)
 
   useEffect(() => {
@@ -18,12 +19,13 @@ export function AchievementToast({ achievementId, onDismiss }: AchievementToastP
     // Auto-dismiss after 3 seconds
     const dismissTimeout = setTimeout(() => {
       setIsVisible(false)
-      setTimeout(onDismiss, 300) // Wait for fade-out animation
+      dismissTimerRef.current = setTimeout(onDismiss, 300)
     }, 3000)
 
     return () => {
       clearTimeout(showTimeout)
       clearTimeout(dismissTimeout)
+      if (dismissTimerRef.current != null) clearTimeout(dismissTimerRef.current)
     }
   }, [onDismiss])
 

--- a/src/app/tap-tap-adventure/components/AdventureLeaderboard.tsx
+++ b/src/app/tap-tap-adventure/components/AdventureLeaderboard.tsx
@@ -233,7 +233,7 @@ export default function AdventureLeaderboard({ onBack }: AdventureLeaderboardPro
 
       {/* Name dialog */}
       {showNameDialog && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 p-4">
+        <div role="dialog" aria-modal="true" aria-label="Set player name" className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 p-4">
           <div className="w-full max-w-md bg-[#1a1b2e] border border-[#3a3c56] rounded-lg p-6 flex flex-col gap-4">
             <h3 className="text-xl font-bold text-amber-400 text-center">
               {playerName ? 'Change Player Name' : 'Set Player Name'}

--- a/src/app/tap-tap-adventure/components/CombatUI.tsx
+++ b/src/app/tap-tap-adventure/components/CombatUI.tsx
@@ -320,7 +320,7 @@ export function CombatUI({ combatState }: CombatUIProps) {
 
     window.addEventListener('keydown', handleKeyDown)
     return () => window.removeEventListener('keydown', handleKeyDown)
-  })
+  }, [status, isPending, playerState, canAttackAtDistance, handleAction, classAbility, abilityCooldown, combatState])
 
   const handleUseItem = useCallback(
     (itemId: string) => {

--- a/src/app/tap-tap-adventure/components/CraftingPanel.tsx
+++ b/src/app/tap-tap-adventure/components/CraftingPanel.tsx
@@ -1,5 +1,5 @@
 'use client'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 
 import { CRAFTING_RECIPES, CraftingRecipe } from '@/app/tap-tap-adventure/config/craftingRecipes'
 import { canCraft } from '@/app/tap-tap-adventure/lib/craftingEngine'
@@ -101,6 +101,12 @@ export function CraftingPanel() {
   const [feedbackMessage, setFeedbackMessage] = useState<string | null>(null)
   const [feedbackSuccess, setFeedbackSuccess] = useState(false)
 
+  useEffect(() => {
+    if (!feedbackMessage) return
+    const id = setTimeout(() => setFeedbackMessage(null), 3000)
+    return () => clearTimeout(id)
+  }, [feedbackMessage])
+
   const character = useGameStore(s =>
     s.gameState.characters.find(c => c.id === s.gameState.selectedCharacterId)
   )
@@ -122,7 +128,6 @@ export function CraftingPanel() {
     if (result) {
       setFeedbackSuccess(result.success)
       setFeedbackMessage(result.message)
-      setTimeout(() => setFeedbackMessage(null), 3000)
     }
   }
 

--- a/src/app/tap-tap-adventure/components/DailyRewardPopup.tsx
+++ b/src/app/tap-tap-adventure/components/DailyRewardPopup.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { Button } from '@/app/tap-tap-adventure/components/ui/button'
 import { DailyReward } from '@/app/tap-tap-adventure/config/dailyRewards'
 import { ClaimResult } from '@/app/tap-tap-adventure/lib/dailyRewardTracker'
@@ -16,6 +16,11 @@ export function DailyRewardPopup({ streak, reward, onClaim, onDismiss }: DailyRe
   const [isVisible, setIsVisible] = useState(false)
   const [claimed, setClaimed] = useState(false)
   const [claimResult, setClaimResult] = useState<ClaimResult | null>(null)
+
+  const dismissTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  useEffect(() => {
+    return () => { if (dismissTimerRef.current != null) clearTimeout(dismissTimerRef.current) }
+  }, [])
 
   useEffect(() => {
     requestAnimationFrame(() => setIsVisible(true))
@@ -43,12 +48,15 @@ export function DailyRewardPopup({ streak, reward, onClaim, onDismiss }: DailyRe
 
   return (
     <div
+      role="dialog"
+      aria-modal="true"
+      aria-label="Daily reward"
       className={`fixed inset-0 z-50 flex items-center justify-center transition-opacity duration-300 ${
         isVisible ? 'opacity-100' : 'opacity-0'
       }`}
     >
       {/* Backdrop */}
-      <div className="absolute inset-0 bg-black/60" onClick={claimed ? () => { setIsVisible(false); setTimeout(onDismiss, 300) } : undefined} />
+      <div className="absolute inset-0 bg-black/60" onClick={claimed ? () => { setIsVisible(false); dismissTimerRef.current = setTimeout(onDismiss, 300) } : undefined} />
 
       {/* Content */}
       <div

--- a/src/app/tap-tap-adventure/components/EnchantingPanel.tsx
+++ b/src/app/tap-tap-adventure/components/EnchantingPanel.tsx
@@ -1,5 +1,5 @@
 'use client'
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 
 import { useGameStore } from '@/app/tap-tap-adventure/hooks/useGameStore'
 import { getEnchantCost, getEnchantBonusStat, MAX_ENCHANT_LEVEL } from '@/app/tap-tap-adventure/config/enchanting'
@@ -97,6 +97,12 @@ export function EnchantingPanel() {
   const [feedbackMessage, setFeedbackMessage] = useState<string | null>(null)
   const [feedbackSuccess, setFeedbackSuccess] = useState(false)
 
+  useEffect(() => {
+    if (!feedbackMessage) return
+    const id = setTimeout(() => setFeedbackMessage(null), 3000)
+    return () => clearTimeout(id)
+  }, [feedbackMessage])
+
   const character = useGameStore(s =>
     s.gameState.characters.find(c => c.id === s.gameState.selectedCharacterId)
   )
@@ -118,7 +124,6 @@ export function EnchantingPanel() {
     if (result) {
       setFeedbackSuccess(result.success)
       setFeedbackMessage(result.message)
-      setTimeout(() => setFeedbackMessage(null), 3000)
     }
   }
 

--- a/src/app/tap-tap-adventure/components/EventDialog.tsx
+++ b/src/app/tap-tap-adventure/components/EventDialog.tsx
@@ -65,6 +65,9 @@ export function EventDialog({
     <div
       className="fixed inset-0 z-50 flex items-start justify-center pt-16 px-4"
       style={{ backdropFilter: 'blur(4px)', background: 'rgba(0,0,0,0.6)' }}
+      role="dialog"
+      aria-modal="true"
+      aria-label="Event"
     >
       <div
         className="bg-[#1e1f30] border border-[#3a3c56] rounded-lg max-w-md w-full p-5 shadow-xl max-h-[80vh] overflow-y-auto"
@@ -160,7 +163,7 @@ export function EventDialog({
                   </div>
                 ) : (
                   <div className="space-y-2 mt-2">
-                    {decisionPoint.options.map((option: { id: string; text: string; successEffects?: { reputation?: number }; failureEffects?: { reputation?: number }; effects?: { reputation?: number } }, index: number) => {
+                    {(decisionPoint.options ?? []).map((option: { id: string; text: string; successEffects?: { reputation?: number }; failureEffects?: { reputation?: number }; effects?: { reputation?: number } }, index: number) => {
                       if (!option) return null
 
                       // Enrich crossroads travel options with region data

--- a/src/app/tap-tap-adventure/components/ExplorationSpellsPanel.tsx
+++ b/src/app/tap-tap-adventure/components/ExplorationSpellsPanel.tsx
@@ -1,5 +1,5 @@
 'use client'
-import { useState, useCallback } from 'react'
+import { useState, useCallback, useEffect, useRef } from 'react'
 
 import { Button } from '@/app/tap-tap-adventure/components/ui/button'
 import { useGameStore } from '@/app/tap-tap-adventure/hooks/useGameStore'
@@ -32,6 +32,17 @@ export function ExplorationSpellsPanel() {
   const [schoolFilter, setSchoolFilter] = useState<string>('all')
   const [sortByMana, setSortByMana] = useState(false)
 
+  const feedbackTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  useEffect(() => {
+    return () => { if (feedbackTimerRef.current != null) clearTimeout(feedbackTimerRef.current) }
+  }, [])
+
+  useEffect(() => {
+    if (!feedbackMessage) return
+    const id = setTimeout(() => setFeedbackMessage(null), 3000)
+    return () => clearTimeout(id)
+  }, [feedbackMessage])
+
   const spellbook = character?.spellbook ?? []
   const explorationSpells = spellbook
     .filter(s => s.explorationEffect)
@@ -45,7 +56,6 @@ export function ExplorationSpellsPanel() {
     if (result) {
       setFeedbackMessage(result.message)
       setFeedbackSuccess(result.success)
-      setTimeout(() => setFeedbackMessage(null), 3000)
     }
   }, [castExplorationSpell])
 

--- a/src/app/tap-tap-adventure/components/GameUI.tsx
+++ b/src/app/tap-tap-adventure/components/GameUI.tsx
@@ -155,6 +155,7 @@ export default function GameUI({ onOpenStatus }: GameUIProps) {
   const [newlyCompletedIds, setNewlyCompletedIds] = useState<string[]>([])
   const [showDailyReward, setShowDailyReward] = useState(false)
   const [floatingResources, setFloatingResources] = useState<ResourceEvent[]>([])
+  const floatingResourcesTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const [mobileCategory, setMobileCategory] = useState<MobileCategory>(null)
   const [travelTarget, setTravelTarget] = useState<string | null>(null)
   const [gearSubTab, setGearSubTab] = useState<GearSubTab>('equipment')
@@ -351,7 +352,8 @@ export default function GameUI({ onOpenStatus }: GameUIProps) {
         }
         if (events.length > 0) {
           setFloatingResources(events)
-          setTimeout(() => setFloatingResources([]), 2000)
+          if (floatingResourcesTimerRef.current != null) clearTimeout(floatingResourcesTimerRef.current)
+          floatingResourcesTimerRef.current = setTimeout(() => setFloatingResources([]), 2000)
         }
       },
     })
@@ -473,6 +475,11 @@ export default function GameUI({ onOpenStatus }: GameUIProps) {
       clearAutoWalk()
     }
   }, [clearAutoWalk])
+
+  // Clean up floating resources timer on unmount
+  useEffect(() => {
+    return () => { if (floatingResourcesTimerRef.current != null) clearTimeout(floatingResourcesTimerRef.current) }
+  }, [])
 
   // Keyboard shortcuts
   useEffect(() => {

--- a/src/app/tap-tap-adventure/components/HudBar.tsx
+++ b/src/app/tap-tap-adventure/components/HudBar.tsx
@@ -136,6 +136,7 @@ export function HudBar({ onOpenStatus }: HudBarProps = {}) {
   interface StatDelta { id: string; key: IconType; delta: number }
   const [statDeltas, setStatDeltas] = useState<StatDelta[]>([])
   const prevStatsRef = useRef<Partial<Record<IconType, number>>>({})
+  const tooltipTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   useEffect(() => {
     const trackedKeys: IconType[] = ['heartIcon', 'sunIcon', 'waterDropIcon']
@@ -151,18 +152,25 @@ export function HudBar({ onOpenStatus }: HudBarProps = {}) {
         prevStatsRef.current[key] = current
       }
     }
+    const timerIds: ReturnType<typeof setTimeout>[] = []
     if (newDeltas.length > 0) {
       setStatDeltas(prev => {
         const combined = [...prev, ...newDeltas].slice(-5)
         return combined
       })
       newDeltas.forEach(d => {
-        setTimeout(() => {
+        const id = setTimeout(() => {
           setStatDeltas(prev => prev.filter(x => x.id !== d.id))
         }, 1200)
+        timerIds.push(id)
       })
     }
+    return () => { timerIds.forEach(clearTimeout) }
   }, [stats])
+
+  useEffect(() => {
+    return () => { if (tooltipTimerRef.current != null) clearTimeout(tooltipTimerRef.current) }
+  }, [])
 
   const [soundEnabled, setSoundEnabled] = useState(true)
 
@@ -206,8 +214,8 @@ export function HudBar({ onOpenStatus }: HudBarProps = {}) {
 
   const handleStatTap = useCallback((key: IconType) => {
     setActiveTooltip(prev => prev === key ? null : key)
-    // Auto-dismiss after 2 seconds
-    setTimeout(() => setActiveTooltip(null), 2000)
+    if (tooltipTimerRef.current != null) clearTimeout(tooltipTimerRef.current)
+    tooltipTimerRef.current = setTimeout(() => setActiveTooltip(null), 2000)
   }, [])
 
   const reputationTier = getReputationTier(character?.reputation ?? 0)

--- a/src/app/tap-tap-adventure/components/InventoryPanel.tsx
+++ b/src/app/tap-tap-adventure/components/InventoryPanel.tsx
@@ -1,5 +1,5 @@
 'use client'
-import { useCallback, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 
 import { Button } from '@/app/tap-tap-adventure/components/ui/button'
 import { List } from '@/app/tap-tap-adventure/components/ui/list'
@@ -38,6 +38,12 @@ export function InventoryPanel({ inventory }: InventoryPanelProps) {
   const [detailItem, setDetailItem] = useState<Item | null>(null)
   const longPressTimerRef = useRef<NodeJS.Timeout | null>(null)
 
+  useEffect(() => {
+    if (!feedbackMessage) return
+    const id = setTimeout(() => setFeedbackMessage(null), 3000)
+    return () => clearTimeout(id)
+  }, [feedbackMessage])
+
   const character = useGameStore(s => s.gameState.characters.find(c => c.id === s.gameState.selectedCharacterId))
   const newItemIds = useGameStore(s => s.gameState.newItemIds ?? [])
   const clearNewItemId = useGameStore(s => s.clearNewItemId)
@@ -47,7 +53,6 @@ export function InventoryPanel({ inventory }: InventoryPanelProps) {
     const result = useGameStore.getState().useItem(item.id)
     if (result) {
       setFeedbackMessage(result.message)
-      setTimeout(() => setFeedbackMessage(null), 3000)
     }
   }, [])
 
@@ -55,7 +60,6 @@ export function InventoryPanel({ inventory }: InventoryPanelProps) {
     const slot = getEquipmentSlot(item)
     useGameStore.getState().equipItem(item.id, slot)
     setFeedbackMessage(`Equipped ${item.name} in ${slot} slot`)
-    setTimeout(() => setFeedbackMessage(null), 3000)
   }, [])
 
   const handleLearnSpell = useCallback((item: Item) => {
@@ -65,7 +69,6 @@ export function InventoryPanel({ inventory }: InventoryPanelProps) {
         soundEngine.playSpellLearn()
       }
       setFeedbackMessage(result.message)
-      setTimeout(() => setFeedbackMessage(null), 3000)
     }
   }, [])
 
@@ -391,6 +394,9 @@ export function InventoryPanel({ inventory }: InventoryPanelProps) {
       </div>
       {detailItem && (
         <div
+          role="dialog"
+          aria-modal="true"
+          aria-label="Item details"
           className="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
           onClick={() => setDetailItem(null)}
         >

--- a/src/app/tap-tap-adventure/components/KeyboardHelp.tsx
+++ b/src/app/tap-tap-adventure/components/KeyboardHelp.tsx
@@ -38,7 +38,7 @@ interface KeyboardHelpProps {
 
 export function KeyboardHelp({ onClose }: KeyboardHelpProps) {
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center" onClick={onClose}>
+    <div role="dialog" aria-modal="true" aria-label="Keyboard shortcuts" className="fixed inset-0 z-50 flex items-center justify-center" onClick={onClose}>
       <div className="absolute inset-0 bg-black/60" />
       <div
         className="relative bg-[#161723] border border-[#3a3c56] rounded-xl p-5 max-w-sm w-full mx-4 shadow-2xl"

--- a/src/app/tap-tap-adventure/components/LevelUpCelebration.tsx
+++ b/src/app/tap-tap-adventure/components/LevelUpCelebration.tsx
@@ -38,6 +38,9 @@ export function LevelUpCelebration({ level, onDismiss }: LevelUpCelebrationProps
 
   return (
     <div
+      role="dialog"
+      aria-modal="true"
+      aria-label="Level up!"
       className={`fixed inset-0 z-50 flex items-center justify-center pointer-events-none transition-opacity duration-300 ${
         isVisible ? 'opacity-100' : 'opacity-0'
       }`}

--- a/src/app/tap-tap-adventure/components/MountNamingModal.tsx
+++ b/src/app/tap-tap-adventure/components/MountNamingModal.tsx
@@ -37,7 +37,7 @@ export function MountNamingModal({ mount, isOpen, onConfirm }: MountNamingModalP
   const rarityColor = MOUNT_RARITY_COLORS[mount.rarity] ?? 'border-slate-400 text-slate-300'
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center">
+    <div role="dialog" aria-modal="true" aria-label="Name your mount" className="fixed inset-0 z-50 flex items-center justify-center">
       {/* Backdrop */}
       <div className="absolute inset-0 bg-black/60" onClick={handleSkip} />
 

--- a/src/app/tap-tap-adventure/components/OnboardingHint.tsx
+++ b/src/app/tap-tap-adventure/components/OnboardingHint.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { Button } from '@/app/tap-tap-adventure/components/ui/button'
 
 interface OnboardingHintProps {
@@ -12,6 +12,11 @@ interface OnboardingHintProps {
 export function OnboardingHint({ title, body, onDismiss }: OnboardingHintProps) {
   const [isVisible, setIsVisible] = useState(false)
 
+  const dismissTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  useEffect(() => {
+    return () => { if (dismissTimerRef.current != null) clearTimeout(dismissTimerRef.current) }
+  }, [])
+
   useEffect(() => {
     requestAnimationFrame(() => setIsVisible(true))
   }, [])
@@ -20,7 +25,7 @@ export function OnboardingHint({ title, body, onDismiss }: OnboardingHintProps) 
     const handleKey = (e: KeyboardEvent) => {
       if (e.key === 'Escape' || e.key === 'Enter') {
         setIsVisible(false)
-        setTimeout(onDismiss, 300)
+        dismissTimerRef.current = setTimeout(onDismiss, 300)
       }
     }
     window.addEventListener('keydown', handleKey)
@@ -29,11 +34,14 @@ export function OnboardingHint({ title, body, onDismiss }: OnboardingHintProps) 
 
   const handleDismiss = () => {
     setIsVisible(false)
-    setTimeout(onDismiss, 300)
+    dismissTimerRef.current = setTimeout(onDismiss, 300)
   }
 
   return (
     <div
+      role="dialog"
+      aria-modal="true"
+      aria-label="Onboarding hint"
       className={`fixed inset-0 z-[60] flex items-center justify-center transition-opacity duration-300 ${
         isVisible ? 'opacity-100' : 'opacity-0'
       }`}

--- a/src/app/tap-tap-adventure/components/QuestCelebration.tsx
+++ b/src/app/tap-tap-adventure/components/QuestCelebration.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { Button } from '@/app/tap-tap-adventure/components/ui/button'
 import { soundEngine } from '@/app/tap-tap-adventure/lib/soundEngine'
 import { TimedQuest } from '@/app/tap-tap-adventure/models/quest'
@@ -13,6 +13,11 @@ interface QuestCelebrationProps {
 export function QuestCelebration({ quest, onClaim }: QuestCelebrationProps) {
   const [isVisible, setIsVisible] = useState(false)
 
+  const claimTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  useEffect(() => {
+    return () => { if (claimTimerRef.current != null) clearTimeout(claimTimerRef.current) }
+  }, [])
+
   useEffect(() => {
     soundEngine.playVictory()
     requestAnimationFrame(() => setIsVisible(true))
@@ -20,11 +25,14 @@ export function QuestCelebration({ quest, onClaim }: QuestCelebrationProps) {
 
   const handleClaim = () => {
     setIsVisible(false)
-    setTimeout(onClaim, 300)
+    claimTimerRef.current = setTimeout(onClaim, 300)
   }
 
   return (
     <div
+      role="dialog"
+      aria-modal="true"
+      aria-label="Quest complete"
       className={`fixed inset-0 z-50 flex items-center justify-center transition-opacity duration-300 ${
         isVisible ? 'opacity-100' : 'opacity-0'
       }`}

--- a/src/app/tap-tap-adventure/components/RareLootCelebration.tsx
+++ b/src/app/tap-tap-adventure/components/RareLootCelebration.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import React, { useEffect, useState } from 'react'
+import React, { useEffect, useRef, useState } from 'react'
 import { Item } from '@/app/tap-tap-adventure/models/types'
 
 const RARITY_CONFIG = {
@@ -48,6 +48,11 @@ interface RareLootCelebrationProps {
 export function RareLootCelebration({ item, onDismiss }: RareLootCelebrationProps) {
   const [isVisible, setIsVisible] = useState(false)
 
+  const dismissTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  useEffect(() => {
+    return () => { if (dismissTimerRef.current != null) clearTimeout(dismissTimerRef.current) }
+  }, [])
+
   const rarity = (item.rarity === 'legendary' || item.rarity === 'epic')
     ? item.rarity as CelebrationRarity
     : 'epic'
@@ -60,7 +65,7 @@ export function RareLootCelebration({ item, onDismiss }: RareLootCelebrationProp
 
     const timer = setTimeout(() => {
       setIsVisible(false)
-      setTimeout(onDismiss, 300)
+      dismissTimerRef.current = setTimeout(onDismiss, 300)
     }, 4000)
 
     return () => clearTimeout(timer)
@@ -68,7 +73,7 @@ export function RareLootCelebration({ item, onDismiss }: RareLootCelebrationProp
 
   const handleDismiss = () => {
     setIsVisible(false)
-    setTimeout(onDismiss, 300)
+    dismissTimerRef.current = setTimeout(onDismiss, 300)
   }
 
   const effectsSummary = item.effects
@@ -80,6 +85,9 @@ export function RareLootCelebration({ item, onDismiss }: RareLootCelebrationProp
 
   return (
     <div
+      role="dialog"
+      aria-modal="true"
+      aria-label="Rare loot drop"
       className={`fixed inset-0 z-50 flex items-center justify-center pointer-events-none transition-opacity duration-300 ${
         isVisible ? 'opacity-100' : 'opacity-0'
       }`}

--- a/src/app/trivia/components/QuestionLibrary.tsx
+++ b/src/app/trivia/components/QuestionLibrary.tsx
@@ -161,7 +161,7 @@ export function QuestionLibrary({ onBack }: QuestionLibraryProps) {
   }, [])
 
   // Load questions (requires auth token)
-  async function loadQuestions(replace: boolean) {
+  async function loadQuestions(replace: boolean, signal?: AbortSignal) {
     setBrowseLoading(true)
     setBrowseError(null)
     try {
@@ -180,6 +180,7 @@ export function QuestionLibrary({ onBack }: QuestionLibraryProps) {
 
       const res = await fetch(`/api/v1/trivia/questions?${params.toString()}`, {
         headers: token ? { Authorization: `Bearer ${token}` } : {},
+        signal,
       })
       if (!res.ok) throw new Error('Failed to load questions')
       const json: BrowseResponse = await res.json()
@@ -187,7 +188,8 @@ export function QuestionLibrary({ onBack }: QuestionLibraryProps) {
       setQuestions((prev) => (replace ? json.questions : [...prev, ...json.questions]))
       setNextCursor(json.nextCursor)
       setHasLoaded(true)
-    } catch {
+    } catch (err) {
+      if ((err as Error)?.name === 'AbortError') return
       setBrowseError('Failed to load questions.')
     } finally {
       setBrowseLoading(false)
@@ -213,7 +215,9 @@ export function QuestionLibrary({ onBack }: QuestionLibraryProps) {
     // Custom view with no resolved label hasn't picked a topic yet;
     // wait for the default-selection effect to populate it.
     if (view.kind === 'custom' && !activeCategory) return
-    void loadQuestions(true)
+    const controller = new AbortController()
+    void loadQuestions(true, controller.signal)
+    return () => controller.abort()
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [tab, sort, activeCategory, difficulty, mineLocked, view.kind])
 

--- a/src/app/trivia/components/TriviaLeaderboard.tsx
+++ b/src/app/trivia/components/TriviaLeaderboard.tsx
@@ -54,21 +54,26 @@ export function TriviaLeaderboard({ onBack }: { onBack: () => void }) {
   const authName = user ? triviaDisplayName || user.email || null : null
 
   useEffect(() => {
+    const controller = new AbortController()
     async function load() {
       setLoading(true)
       setError(null)
       try {
-        const res = await fetch(`/api/v1/trivia/leaderboard?period=${period}`)
+        const res = await fetch(`/api/v1/trivia/leaderboard?period=${period}`, {
+          signal: controller.signal,
+        })
         if (!res.ok) throw new Error('Failed to load leaderboard')
         const json = await res.json()
         setData(json)
-      } catch {
+      } catch (err) {
+        if ((err as Error)?.name === 'AbortError') return
         setError('Failed to load leaderboard.')
       } finally {
         setLoading(false)
       }
     }
     load()
+    return () => controller.abort()
   }, [period])
 
   const handleShareLeaderboard = async () => {


### PR DESCRIPTION
Without a dependency array the keyboard listener is detached and re-attached on every render, causing unnecessary DOM churn.

Adds `[status, isPending, playerState, canAttackAtDistance, handleAction, classAbility, abilityCooldown, combatState]` as the dependency array so the listener only re-registers when relevant combat state actually changes.

Closes #2507