### PR TITLE
fix(a11y): add aria-label to role=button divs in oracle hexagram components

### DIFF
--- a/src/app/oracle/components/hexagram.tsx
+++ b/src/app/oracle/components/hexagram.tsx
@@ -96,6 +96,7 @@ export const LineControl = ({
       <div
         onClick={isStatic ? undefined : () => toggleLine()}
         role={isStatic ? undefined : 'button'}
+        aria-label={isStatic ? undefined : 'Toggle line — solid or broken'}
         tabIndex={isStatic ? undefined : 0}
         onKeyDown={isStatic ? undefined : e => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); toggleLine() } }}
       >
@@ -104,6 +105,7 @@ export const LineControl = ({
       <div
         onClick={isStatic ? undefined : () => toggleHasChanges()}
         role={isStatic ? undefined : 'button'}
+        aria-label={isStatic ? undefined : 'Toggle changing line'}
         tabIndex={isStatic ? undefined : 0}
         onKeyDown={isStatic ? undefined : e => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); toggleHasChanges() } }}
       >

--- a/src/app/oracle/components/interative-hexagram.tsx
+++ b/src/app/oracle/components/interative-hexagram.tsx
@@ -81,6 +81,7 @@ export const LineControl = ({
     <div className="flex gap-2">
       <div
         role="button"
+        aria-label="Toggle line — solid or broken"
         tabIndex={0}
         onClick={() => toggleLine()}
         onKeyDown={e => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); toggleLine() } }}
@@ -89,6 +90,7 @@ export const LineControl = ({
       </div>
       <div
         role="button"
+        aria-label="Toggle changing line"
         tabIndex={0}
         onClick={() => toggleHasChanges()}
         onKeyDown={e => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); toggleHasChanges() } }}


### PR DESCRIPTION
## What

Closes #2575.

Two `div[role=button]` elements in the Oracle hexagram controls were missing `aria-label`. Screen readers announced them as "button" with no description of what they do.

## Changes

- `hexagram.tsx` — both interactive divs (when `!isStatic`) get `aria-label={isStatic ? undefined : '...'}`
- `interative-hexagram.tsx` — same fix, both always-interactive divs

## Labels used

| Control | aria-label |
|---------|------------|
| Line type toggle (solid ↔ broken) | `"Toggle line — solid or broken"` |
| Changing-line marker | `"Toggle changing line"` |