### PR TITLE
feat(micro-land): rename "summon" to "generate" and mark it with a sparkle

### DIFF
--- a/src/app/api/v1/micro-land/summon/route.ts
+++ b/src/app/api/v1/micro-land/summon/route.ts
@@ -188,7 +188,7 @@ export async function POST(request: NextRequest) {
     typeof body.prompt === 'string' ? body.prompt.trim().slice(0, MAX_PROMPT) : ''
 
   if (description.length < 2) {
-    return NextResponse.json({ error: 'Tell me what to summon first.' }, { status: 400 })
+    return NextResponse.json({ error: 'Tell me what to generate first.' }, { status: 400 })
   }
 
   const apiKey = process.env.ANTHROPIC_API_KEY

--- a/src/app/micro-land/components/field-guide.tsx
+++ b/src/app/micro-land/components/field-guide.tsx
@@ -4,6 +4,7 @@ import { canEat } from '@/app/micro-land/domain/blueprint'
 import { useMicroLand } from '@/app/micro-land/store'
 
 import { CreaturePortrait } from './creature-chip'
+import { SparkleIcon } from './sparkle-icon'
 
 const KIND_WORDS: Record<string, string> = {
   walk: 'walks',
@@ -120,6 +121,7 @@ export function FieldGuide() {
                     </span>
                     {bp.summoned && (
                       <span
+                        className="inline-flex items-center gap-1"
                         style={{
                           fontFamily: 'var(--cc-font-mono)',
                           fontSize: 9,
@@ -131,7 +133,8 @@ export function FieldGuide() {
                           border: '1px solid var(--cc-pink-border)',
                         }}
                       >
-                        Summoned
+                        <SparkleIcon size={9} />
+                        Generated
                       </span>
                     )}
                   </div>

--- a/src/app/micro-land/components/sparkle-icon.tsx
+++ b/src/app/micro-land/components/sparkle-icon.tsx
@@ -1,0 +1,24 @@
+/**
+ * The four-point sparkle that marks the parts of Micro Land a machine makes.
+ *
+ * Two stars rather than one: the small trailing star is what reads as "sparkle"
+ * at 12px instead of as an asterisk. Drawn in `currentColor` so it takes the
+ * tint of whatever button or badge it sits in, and sized in `em` so it scales
+ * with the label beside it.
+ */
+export function SparkleIcon({ size = '1em' }: { size?: number | string }) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      width={size}
+      height={size}
+      fill="currentColor"
+      aria-hidden="true"
+      focusable="false"
+      style={{ display: 'inline-block', verticalAlign: '-0.12em', flex: 'none' }}
+    >
+      <path d="M9 2 10.4 7.6 16 9 10.4 10.4 9 16 7.6 10.4 2 9 7.6 7.6Z" />
+      <path d="M17.5 13.5 18.4 17.1 22 18l-3.6.9-.9 3.6-.9-3.6L13 18l3.6-.9Z" />
+    </svg>
+  )
+}

--- a/src/app/micro-land/components/summon-loader.tsx
+++ b/src/app/micro-land/components/summon-loader.tsx
@@ -433,7 +433,7 @@ export function SummonLoader({
       </p>
 
       <span className="sr-only" role="status">
-        Summoning. This can take a minute.
+        Generating. This can take a minute.
       </span>
 
       <button

--- a/src/app/micro-land/components/summon-panel.tsx
+++ b/src/app/micro-land/components/summon-panel.tsx
@@ -6,6 +6,7 @@ import type { CreatureBlueprint } from '@/app/micro-land/domain/types'
 import { useMicroLand } from '@/app/micro-land/store'
 
 import { CreaturePortrait } from './creature-chip'
+import { SparkleIcon } from './sparkle-icon'
 import { SummonLoader } from './summon-loader'
 
 const CREATURE_IDEAS = [
@@ -62,7 +63,7 @@ export function SummonPanel({
   const [text, setText] = useState('')
   const [made, setMade] = useState<CreatureBlueprint[]>([])
   const inputRef = useRef<HTMLInputElement>(null)
-  /** Live while a summon is in flight, so the player can call it off. */
+  /** Live while a generation is in flight, so the player can call it off. */
   const abortRef = useRef<AbortController | null>(null)
 
   useEffect(() => {
@@ -88,7 +89,7 @@ export function SummonPanel({
 
   const ideas = mode === 'scene' ? SCENE_IDEAS : mode === 'terrain' ? TERRAIN_IDEAS : CREATURE_IDEAS
 
-  async function summon() {
+  async function generate() {
     const prompt = text.trim()
     if (prompt.length < 2 || busy) return
 
@@ -108,7 +109,7 @@ export function SummonPanel({
       })
       if (!response.ok) {
         const detail = (await response.json().catch(() => null)) as { error?: string } | null
-        throw new Error(detail?.error ?? 'The summoning fizzled.')
+        throw new Error(detail?.error ?? 'That did not come through. Try again.')
       }
 
       const data = await response.json()
@@ -165,7 +166,7 @@ export function SummonPanel({
     } catch (err) {
       // Calling it off isn't a failure — the player already knows what happened.
       if (!(err instanceof DOMException && err.name === 'AbortError')) {
-        setError(err instanceof Error ? err.message : 'The summoning fizzled.')
+        setError(err instanceof Error ? err.message : 'That did not come through. Try again.')
       }
     } finally {
       abortRef.current = null
@@ -182,7 +183,7 @@ export function SummonPanel({
       <div
         role="dialog"
         aria-modal="true"
-        aria-label="Summon a creature"
+        aria-label="Generate a creature"
         className="w-full max-w-lg overflow-y-auto rounded-t-xl sm:rounded-xl"
         style={{
           maxHeight: '88dvh',
@@ -196,6 +197,7 @@ export function SummonPanel({
           style={{ borderBottom: '1px solid var(--cc-panel-divider)' }}
         >
           <h2
+            className="flex items-center gap-2"
             style={{
               fontFamily: 'var(--cc-font-mono)',
               fontSize: 11,
@@ -204,7 +206,8 @@ export function SummonPanel({
               color: 'var(--cc-mint)',
             }}
           >
-            Summon
+            <SparkleIcon size={13} />
+            Generate
           </h2>
           <button
             type="button"
@@ -228,7 +231,7 @@ export function SummonPanel({
           />
         ) : (
           <div className="flex flex-col gap-3 p-4">
-            <div className="flex gap-1.5" role="group" aria-label="What to summon">
+            <div className="flex gap-1.5" role="group" aria-label="What to generate">
               {(['creature', 'terrain', 'scene'] as const).map(option => (
                 <button
                   key={option}
@@ -271,11 +274,11 @@ export function SummonPanel({
               value={text}
               onChange={e => setText(e.target.value)}
               onKeyDown={e => {
-                if (e.key === 'Enter') void summon()
+                if (e.key === 'Enter') void generate()
               }}
               maxLength={300}
               placeholder={ideas[0]}
-              aria-label="Describe what to summon"
+              aria-label="Describe what to generate"
               style={{
                 width: '100%',
                 padding: '12px 14px',
@@ -348,9 +351,13 @@ export function SummonPanel({
             <button
               type="button"
               className="cc-btn"
-              onClick={() => void summon()}
+              onClick={() => void generate()}
               disabled={text.trim().length < 2}
               style={{
+                display: 'inline-flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                gap: 8,
                 fontFamily: 'var(--cc-font-mono)',
                 fontSize: 11,
                 fontWeight: 700,
@@ -366,11 +373,12 @@ export function SummonPanel({
                 opacity: text.trim().length < 2 ? 0.4 : 1,
               }}
             >
+              <SparkleIcon size={13} />
               {mode === 'creature'
-                ? 'Summon it'
+                ? 'Generate it'
                 : mode === 'terrain'
-                  ? 'Build the land'
-                  : 'Summon it all'}
+                  ? 'Generate the land'
+                  : 'Generate it all'}
             </button>
           </div>
         )}

--- a/src/app/micro-land/components/toolbar.tsx
+++ b/src/app/micro-land/components/toolbar.tsx
@@ -4,6 +4,7 @@ import { MATERIALS, PAINTABLE } from '@/app/micro-land/domain/config/materials'
 import { useMicroLand } from '@/app/micro-land/store'
 
 import { CreaturePortrait } from './creature-chip'
+import { SparkleIcon } from './sparkle-icon'
 
 const BRUSHES = [2, 4, 8, 14]
 
@@ -145,9 +146,13 @@ export function Toolbar() {
             border: '1px solid var(--cc-mint)',
             color: 'var(--cc-on-mint)',
             boxShadow: 'var(--cc-mint-glow)',
+            display: 'inline-flex',
+            alignItems: 'center',
+            gap: 6,
           }}
         >
-          ✦ Summon
+          <SparkleIcon size={12} />
+          Generate
         </button>
         <button
           type="button"


### PR DESCRIPTION
Stacked on #2570 — base is `feat/micro-land`, so this diff is copy and one new icon component only.

## What

The panel builds creatures, land, and whole scenes with a model, but "summon" read as pure fantasy flavor — a player had no way to tell that button from the ones that paint dirt. It's now **Generate**, prefixed with a sparkle, borrowing the convention players already know from elsewhere. The wait and the occasional odd result become expected rather than a bug.

- **Toolbar** — `✦ Summon` → sparkle + `Generate`
- **Panel** — header and CTA → `Generate it` / `Generate the land` / `Generate it all`; dialog, mode-group, and input `aria-label`s follow
- **Field guide** — the `Summoned` badge on model-made creatures → sparkle + `Generated`
- **Loader** — screen-reader status `Summoning.` → `Generating.`
- **API** — `Tell me what to summon first.` → `…generate first.`
- Failure copy `The summoning fizzled.` → `That did not come through. Try again.`

New `sparkle-icon.tsx`: a two-star SVG in `currentColor`, sized in `em`, `aria-hidden` so it never doubles up on the label beside it.

## Judgment calls

- The terrain CTA moves from `Build the land` to `Generate the land` even though it never said "summon" — all three modes now share one verb under one icon. Easy to revert if you'd rather keep it.
- The home-page card still says "summon creatures." That's cave chrome, and **AI is invisible** says AI stays out of marketing surfaces — the sparkle belongs inside the game, not on the shelf.
- Internal names (`summonOpen`, `SUMMONED_THEME_ID`, `/api/v1/micro-land/summon`, filenames) are untouched. This is a copy change; renaming the route and store would be a large diff for zero player benefit.

## Verification

- `eslint` clean on `src/app/micro-land` and `src/app/api/v1/micro-land`
- `tsc --noEmit` reports no micro-land errors (repo has pre-existing unrelated failures in `src/lib/trivia`)
- Prettier flags `toolbar.tsx`, `field-guide.tsx`, `route.ts` — those warnings already exist at the base commit, so formatting was left alone rather than burying the diff
- **Not yet checked in a browser** — the 9px sparkle in the field-guide badge in particular deserves a look

🤖 Generated with [Claude Code](https://claude.com/claude-code)