### PR TITLE
fix(trivia): add AbortController to useEffect fetch calls

### DIFF
--- a/src/app/trivia/components/InfiniteStats.tsx
+++ b/src/app/trivia/components/InfiniteStats.tsx
@@ -98,7 +98,7 @@ export function InfiniteStats() {
   const [runsLoading, setRunsLoading] = useState(true)
   const [rebuilding, setRebuilding] = useState(false)
 
-  const fetchStats = useCallback(async () => {
+  const fetchStats = useCallback(async (signal?: AbortSignal) => {
     if (!user) {
       setLoading(false)
       return
@@ -107,11 +107,13 @@ export function InfiniteStats() {
       const token = await user.getIdToken()
       const res = await fetch('/api/v1/trivia/stats/me', {
         headers: { Authorization: `Bearer ${token}` },
+        signal,
       })
       if (res.ok) {
         setStats(await res.json())
       }
-    } catch {
+    } catch (e) {
+      if (e instanceof Error && e.name === 'AbortError') return
       // silent
     } finally {
       setLoading(false)
@@ -119,10 +121,13 @@ export function InfiniteStats() {
   }, [user])
 
   useEffect(() => {
-    fetchStats()
+    const controller = new AbortController()
+    fetchStats(controller.signal)
+    return () => controller.abort()
   }, [fetchStats])
 
   useEffect(() => {
+    const controller = new AbortController()
     async function loadRuns() {
       if (!user) {
         setRunsLoading(false)
@@ -132,18 +137,21 @@ export function InfiniteStats() {
         const token = await user.getIdToken()
         const res = await fetch('/api/v1/trivia/infinite/runs?limit=20', {
           headers: { Authorization: `Bearer ${token}` },
+          signal: controller.signal,
         })
         if (res.ok) {
           const data = await res.json()
           setRuns(data.runs ?? [])
         }
-      } catch {
+      } catch (e) {
+        if (e instanceof Error && e.name === 'AbortError') return
         // silent
       } finally {
         setRunsLoading(false)
       }
     }
     loadRuns()
+    return () => controller.abort()
   }, [user])
 
   if (loading) {

--- a/src/app/trivia/components/QuestionLibrary.tsx
+++ b/src/app/trivia/components/QuestionLibrary.tsx
@@ -143,21 +143,24 @@ export function QuestionLibrary({ onBack }: QuestionLibraryProps) {
 
   // Load stats (no auth needed)
   useEffect(() => {
+    const controller = new AbortController()
     async function loadStats() {
       setStatsLoading(true)
       setStatsError(null)
       try {
-        const res = await fetch('/api/v1/trivia/questions/stats')
+        const res = await fetch('/api/v1/trivia/questions/stats', { signal: controller.signal })
         if (!res.ok) throw new Error('Failed to load stats')
         const json = await res.json()
         setStats(json)
-      } catch {
+      } catch (e) {
+        if (e instanceof Error && e.name === 'AbortError') return
         setStatsError('Failed to load stats.')
       } finally {
         setStatsLoading(false)
       }
     }
     void loadStats()
+    return () => controller.abort()
   }, [])
 
   // Load questions (requires auth token)

--- a/src/app/trivia/components/WeeklyWinnerBanner.tsx
+++ b/src/app/trivia/components/WeeklyWinnerBanner.tsx
@@ -37,7 +37,8 @@ export function WeeklyWinnerBanner() {
   const [dismissed, setDismissed] = useState<boolean | null>(null)
 
   useEffect(() => {
-    fetch('/api/v1/trivia/weekly-winner')
+    const controller = new AbortController()
+    fetch('/api/v1/trivia/weekly-winner', { signal: controller.signal })
       .then((res) => {
         if (!res.ok) throw new Error(`weekly-winner fetch failed: ${res.status}`)
         return res.json()
@@ -53,10 +54,12 @@ export function WeeklyWinnerBanner() {
         }
       })
       .catch((err) => {
+        if (err instanceof Error && err.name === 'AbortError') return
         console.error('[WeeklyWinnerBanner] Failed to load winner data:', err)
         // Hide the banner rather than showing broken state
         setDismissed(true)
       })
+    return () => controller.abort()
   }, [user?.uid])
 
   if (data === null || dismissed === null || dismissed) return null

--- a/src/app/trivia/winners/page.tsx
+++ b/src/app/trivia/winners/page.tsx
@@ -59,7 +59,8 @@ export default function WinnersPage() {
   const [loading, setLoading] = useState(true)
 
   useEffect(() => {
-    fetch('/api/v1/trivia/weekly-winners')
+    const controller = new AbortController()
+    fetch('/api/v1/trivia/weekly-winners', { signal: controller.signal })
       .then((res) => {
         if (!res.ok) throw new Error(`HTTP ${res.status}`)
         return res.json()
@@ -68,7 +69,11 @@ export default function WinnersPage() {
         setWinners(data.winners ?? [])
         setLoading(false)
       })
-      .catch(() => setLoading(false))
+      .catch((err) => {
+        if (err instanceof Error && err.name === 'AbortError') return
+        setLoading(false)
+      })
+    return () => controller.abort()
   }, [])
 
   const currentUid = user?.uid


### PR DESCRIPTION
## Summary
- Add `AbortController` to all bare `useEffect` fetch calls in the trivia module so inflight requests are cancelled on unmount
- Covers `InfiniteStats` (2 fetches), `WeeklyWinnerBanner`, `winners/page.tsx`, and `QuestionLibrary` stats fetch
- Silently swallows `AbortError` so cancelled requests don't surface as errors

Fixes #2573

## Test plan
- [ ] Navigate away from `/trivia/stats` quickly — no console errors
- [ ] Navigate away from trivia home (weekly winner banner) — no console errors
- [ ] Navigate away from `/trivia/winners` quickly — no console errors
- [ ] Open question library and close it fast — no console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)