### PR TITLE
fix: Fisher-Yates shuffle in chat-room + storybook-factory abort cleanup on unmount

### DIFF
--- a/src/app/chat-room-of-infinity/services/ai/openai.ts
+++ b/src/app/chat-room-of-infinity/services/ai/openai.ts
@@ -4,6 +4,15 @@ import { Character } from '@/app/chat-room-of-infinity/types'
 
 import { AIService, AIServiceConfig, Message, SafetyCheckResponse } from './types'
 
+function shuffled<T>(arr: T[]): T[] {
+  const a = [...arr]
+  for (let i = a.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1))
+    ;[a[i], a[j]] = [a[j], a[i]]
+  }
+  return a
+}
+
 export class OpenAIService implements AIService {
   private client: OpenAI
   private config: AIServiceConfig
@@ -164,8 +173,7 @@ You will receive a list of available characters with their descriptions and the 
 
       if (!toolCalls || toolCalls.length === 0) {
         const numToSelect = Math.floor(Math.random() * 3) + 1
-        const shuffled = [...characters].sort(() => 0.5 - Math.random())
-        return shuffled.slice(0, Math.min(numToSelect, characters.length))
+        return shuffled(characters).slice(0, Math.min(numToSelect, characters.length))
       }
 
       // Get the function call arguments
@@ -181,15 +189,13 @@ You will receive a list of available characters with their descriptions and the 
           selectedIds = args.character_ids
         } else {
           const numToSelect = Math.floor(Math.random() * 3) + 1
-          const shuffled = [...characters].sort(() => 0.5 - Math.random())
-          return shuffled.slice(0, Math.min(numToSelect, characters.length))
+          return shuffled(characters).slice(0, Math.min(numToSelect, characters.length))
         }
       } catch (error) {
         console.error('Error parsing character selection response:', error)
         // Fall back to random selection
         const numToSelect = Math.floor(Math.random() * 3) + 1
-        const shuffled = [...characters].sort(() => 0.5 - Math.random())
-        return shuffled.slice(0, Math.min(numToSelect, characters.length))
+        return shuffled(characters).slice(0, Math.min(numToSelect, characters.length))
       }
 
       // Find the characters with the selected IDs
@@ -198,8 +204,7 @@ You will receive a list of available characters with their descriptions and the 
       // If no characters were selected or something went wrong, fall back to random selection
       if (selectedCharacters?.length === 0) {
         const numToSelect = Math.floor(Math.random() * 3) + 1
-        const shuffled = [...characters].sort(() => 0.5 - Math.random())
-        return shuffled.slice(0, Math.min(numToSelect, characters.length))
+        return shuffled(characters).slice(0, Math.min(numToSelect, characters.length))
       }
 
       return selectedCharacters
@@ -207,8 +212,7 @@ You will receive a list of available characters with their descriptions and the 
       console.error('Error selecting responding characters:', error)
       // Fall back to random selection
       const numToSelect = Math.floor(Math.random() * 3) + 1
-      const shuffled = [...characters].sort(() => 0.5 - Math.random())
-      return shuffled.slice(0, Math.min(numToSelect, characters.length))
+      return shuffled(characters).slice(0, Math.min(numToSelect, characters.length))
     }
   }
 }

--- a/src/app/storybook-factory/components/useStorybookFactoryState.tsx
+++ b/src/app/storybook-factory/components/useStorybookFactoryState.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useRef, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import type { GeneratedStory } from '../types'
 
 export interface StoryConfiguration {
@@ -121,6 +121,9 @@ export function useStorybookFactoryState(): StorybookFactoryState {
   const [illustrationProgress, setIllustrationProgress] = useState({ completed: 0, total: 0 })
   const [illustrationError, setIllustrationError] = useState<string | null>(null)
   const illustrationAbortRef = useRef<AbortController | null>(null)
+
+  // Cancel any in-flight illustration generation on unmount
+  useEffect(() => () => { illustrationAbortRef.current?.abort() }, [])
 
   // Inline editing & revision state
   const [editingPanel, setEditingPanel] = useState<{ pageIndex: number; panelIndex: number } | null>(null)


### PR DESCRIPTION
## Summary

- **chat-room-of-infinity**: All 5 uses of \`.sort(() => 0.5 - Math.random())\` in \`openai.ts\` replaced with a proper Fisher-Yates shuffle helper. The sort-based approach produces biased results because V8's TimSort depends on consistent comparisons — certain characters were systematically over-represented in random selection. Fixes #2589
- **storybook-factory**: \`useStorybookFactoryState\` now aborts any in-flight illustration generation when the component unmounts, preventing state updates on detached components and leaked fetch requests. Fixes #2586

## Test plan
- [ ] Chat room: start a conversation with several characters — all characters should appear to respond with roughly equal frequency over many messages
- [ ] Storybook factory: navigate away mid-illustration-generation — no console errors about state updates on unmounted components

🤖 Generated with [Claude Code](https://claude.com/claude-code)