### PR TITLE
feat(micro-land): generating one creature no longer blocks the game

### DIFF
--- a/src/app/micro-land/components/summon-panel.tsx
+++ b/src/app/micro-land/components/summon-panel.tsx
@@ -32,6 +32,27 @@ const TERRAIN_IDEAS = [
   'a swamp full of little pools',
 ]
 
+/** Creatures allowed in flight at once. */
+const MAX_PENDING = 3
+
+async function requestGenerate(
+  mode: 'creature' | 'scene' | 'terrain',
+  prompt: string,
+  signal: AbortSignal
+) {
+  const response = await fetch('/api/v1/micro-land/summon', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ mode, prompt }),
+    signal,
+  })
+  if (!response.ok) {
+    const detail = (await response.json().catch(() => null)) as { error?: string } | null
+    throw new Error(detail?.error ?? 'That did not come through. Try again.')
+  }
+  return response.json()
+}
+
 type Introduce = (
   raw: unknown,
   count: number
@@ -59,16 +80,38 @@ export function SummonPanel({
   const setError = useMicroLand(s => s.setSummonError)
   const setTool = useMicroLand(s => s.setTool)
   const notify = useMicroLand(s => s.notify)
+  const pending = useMicroLand(s => s.pendingSummons)
+  const addPending = useMicroLand(s => s.addPendingSummon)
+  const removePending = useMicroLand(s => s.removePendingSummon)
 
   const [text, setText] = useState('')
   const [made, setMade] = useState<CreatureBlueprint[]>([])
   const inputRef = useRef<HTMLInputElement>(null)
-  /** Live while a generation is in flight, so the player can call it off. */
+  /** Whatever opened the panel, so closing it hands focus back. */
+  const openerRef = useRef<HTMLElement | null>(null)
+  /** Live while a world-building generation is in flight, so it can be called off. */
   const abortRef = useRef<AbortController | null>(null)
+  /**
+   * Creatures the player has walked away from. They outlive the panel being
+   * closed — that's the point — so they get their own handles, and the modal's
+   * close and Escape paths never touch them.
+   */
+  const backgroundRef = useRef<Set<AbortController>>(new Set())
 
   useEffect(() => {
     if (open && !busy) inputRef.current?.focus()
   }, [open, busy])
+
+  // A creature closes the panel out from under the player, so keyboard focus
+  // has to go back where it came from rather than to the top of the page.
+  useEffect(() => {
+    if (open) {
+      openerRef.current = document.activeElement as HTMLElement | null
+      return
+    }
+    openerRef.current?.focus()
+    openerRef.current = null
+  }, [open])
 
   useEffect(() => {
     if (!open) return
@@ -83,15 +126,77 @@ export function SummonPanel({
 
   // Nothing is left half-applied by an abort: the world is only touched after
   // the response has fully arrived.
-  useEffect(() => () => abortRef.current?.abort(), [])
+  useEffect(() => {
+    const background = backgroundRef.current
+    return () => {
+      abortRef.current?.abort()
+      for (const controller of background) controller.abort()
+    }
+  }, [])
 
   if (!open) return null
 
   const ideas = mode === 'scene' ? SCENE_IDEAS : mode === 'terrain' ? TERRAIN_IDEAS : CREATURE_IDEAS
 
+  /**
+   * One creature, made without holding the game hostage.
+   *
+   * A world or a land replaces everything the player is looking at, so those
+   * are worth waiting on. A single creature isn't: it just turns up in the
+   * strip when it's ready. So the panel gets out of the way immediately, an
+   * empty slot carries the wait, and the player keeps digging.
+   */
+  function generateInBackground(prompt: string) {
+    const pendingId = addPending(prompt)
+    const controller = new AbortController()
+    backgroundRef.current.add(controller)
+
+    // If the player has picked up a different tool while waiting, leave it in
+    // their hand. `tool` only ever changes identity through setTool, so this is
+    // an exact "have they touched it since they asked".
+    const toolAtLaunch = useMicroLand.getState().tool
+
+    void (async () => {
+      try {
+        const data = await requestGenerate('creature', prompt, controller.signal)
+        const result = data.blueprint ? onIntroduce(data.blueprint, 5) : null
+        if (!result) {
+          notify('Nothing came through. Try describing it a different way.')
+          return
+        }
+        if (useMicroLand.getState().tool === toolAtLaunch) {
+          setTool({ kind: 'creature', blueprintId: result.blueprint.id })
+        }
+        notify(`${result.blueprint.name} joins the world.`)
+      } catch (err) {
+        // Leaving the page isn't a failure worth shouting about.
+        if (err instanceof DOMException && err.name === 'AbortError') return
+        notify(err instanceof Error ? err.message : 'That did not come through. Try again.')
+      } finally {
+        backgroundRef.current.delete(controller)
+        removePending(pendingId)
+      }
+    })()
+
+    setText('')
+    setError(null)
+    setMade([])
+    setOpen(false)
+    notify(`“${prompt}” is on its way. Keep playing — it turns up in the creature bar.`)
+  }
+
   async function generate() {
     const prompt = text.trim()
     if (prompt.length < 2 || busy) return
+
+    if (mode === 'creature') {
+      if (pending.length >= MAX_PENDING) {
+        setError('There are already some on their way. Wait for one to land.')
+        return
+      }
+      generateInBackground(prompt)
+      return
+    }
 
     setBusy(true)
     setError(null)
@@ -101,18 +206,7 @@ export function SummonPanel({
     abortRef.current = controller
 
     try {
-      const response = await fetch('/api/v1/micro-land/summon', {
-        method: 'POST',
-        headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({ mode, prompt }),
-        signal: controller.signal,
-      })
-      if (!response.ok) {
-        const detail = (await response.json().catch(() => null)) as { error?: string } | null
-        throw new Error(detail?.error ?? 'That did not come through. Try again.')
-      }
-
-      const data = await response.json()
+      const data = await requestGenerate(mode, prompt, controller.signal)
       const created: CreatureBlueprint[] = []
 
       if (data.mode === 'terrain') {
@@ -147,12 +241,6 @@ export function SummonPanel({
           if (result) created.push(result.blueprint)
         }
         if (typeof data.note === 'string' && data.note) notify(data.note)
-      } else if (data.blueprint) {
-        const result = onIntroduce(data.blueprint, 5)
-        if (result) {
-          created.push(result.blueprint)
-          notify(`${result.blueprint.name} joins the world.`)
-        }
       }
 
       if (created.length === 0) {
@@ -263,7 +351,7 @@ export function SummonPanel({
 
             <p style={{ fontSize: 13, color: 'var(--cc-text-muted)', lineHeight: 1.5 }}>
               {mode === 'creature'
-                ? 'Describe something. It will be drawn, given a body, and dropped into the world.'
+                ? 'Describe something. It will be drawn, given a body, and dropped into the world. Keep playing while it is made — it turns up in the creature bar.'
                 : mode === 'terrain'
                   ? 'Describe a place. The ground, caves and water get rebuilt to match. Creatures already here are cleared out.'
                   : 'Describe a place with things living in it. You get the land AND the creatures, built to suit each other.'}
@@ -315,6 +403,14 @@ export function SummonPanel({
             {error && (
               <p style={{ fontSize: 13, color: 'var(--cc-pink)' }} role="alert">
                 {error}
+              </p>
+            )}
+
+            {pending.length > 0 && (
+              <p style={{ fontSize: 12, color: 'var(--cc-text-muted)' }}>
+                {pending.length === 1
+                  ? 'One creature is still on its way.'
+                  : `${pending.length} creatures are still on their way.`}
               </p>
             )}
 

--- a/src/app/micro-land/components/summon-sand.tsx
+++ b/src/app/micro-land/components/summon-sand.tsx
@@ -1,0 +1,191 @@
+'use client'
+
+import { useEffect, useRef } from 'react'
+
+import { SUMMON_SAND_COLORS } from '@/app/micro-land/domain/config/loader-shapes'
+
+/**
+ * The wait for one creature, shrunk to fit a slot in the creature strip.
+ *
+ * Asking for a single creature doesn't hold the game hostage any more, so the
+ * wait can't be a modal — it's an empty slot with sand pouring into it. The
+ * grains fall and pile by the same rules as the big loader and the world
+ * itself, then wash out and start over, which reads as "still coming" without
+ * ever pretending to be a finished creature.
+ *
+ * Deliberately not a copy of `SummonLoader`: at this size the assembly phase
+ * would be a smudge, and this has to be cheap enough to run several at once
+ * behind a game that is already simulating at 60fps.
+ */
+
+const GRID = 16
+/** One powder pass. Slower than the big loader — fewer grains to watch. */
+const SAND_STEP_MS = 52
+/** Half-width of the mouth the sand pours from, in cells. */
+const POUR_SPREAD = 3
+/** Grains in a full pile: enough to mound up, not enough to fill the slot. */
+const CAPACITY = 52
+const FADE_MS = 620
+
+const COLORS = SUMMON_SAND_COLORS
+
+interface Grain {
+  x: number
+  y: number
+  color: string
+}
+
+function cellIndex(x: number, y: number): number {
+  return y * GRID + x
+}
+
+export function SummonSand({ size = 34 }: { size?: number }) {
+  const canvasRef = useRef<HTMLCanvasElement>(null)
+
+  useEffect(() => {
+    const canvas = canvasRef.current
+    if (!canvas) return
+    const ctx = canvas.getContext('2d')
+    if (!ctx) return
+
+    const center = Math.floor(GRID / 2)
+    const occupied = new Int32Array(GRID * GRID)
+    let grains: Grain[] = []
+    let alpha = 1
+    let fading = false
+    let sandAcc = 0
+    let pass = 0
+
+    const draw = () => {
+      ctx.clearRect(0, 0, GRID, GRID)
+
+      // A dotted floor, so the pile lands on something rather than stopping at
+      // the edge of nothing — the same footing the big loader gives it.
+      ctx.globalAlpha = 0.5 * alpha
+      ctx.fillStyle = 'rgba(94, 234, 212, 0.35)'
+      for (let x = 0; x < GRID; x += 2) ctx.fillRect(x, GRID - 1, 1, 1)
+
+      ctx.globalAlpha = alpha
+      for (const grain of grains) {
+        ctx.fillStyle = grain.color
+        ctx.fillRect(grain.x, grain.y, 1, 1)
+      }
+      ctx.globalAlpha = 1
+    }
+
+    // Under reduced motion the wait is one settled pile, held still.
+    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+      for (let i = 0; i < CAPACITY; i++) {
+        const x = center + Math.round((i % 7) - 3)
+        const y = GRID - 1 - Math.floor(i / 7)
+        grains.push({ x, y, color: COLORS[i % COLORS.length] })
+      }
+      draw()
+      return
+    }
+
+    function pour() {
+      if (grains.length >= CAPACITY) return
+      for (let attempt = 0; attempt < 5; attempt++) {
+        const x = center + Math.round((Math.random() * 2 - 1) * POUR_SPREAD)
+        if (occupied[cellIndex(x, 0)] !== 0) continue
+        grains.push({ x, y: 0, color: COLORS[grains.length % COLORS.length] })
+        occupied[cellIndex(x, 0)] = grains.length
+        return
+      }
+    }
+
+    /** One powder pass: everything falls, piles and slides down slopes. */
+    function stepSand(): number {
+      pass++
+      const leftToRight = (pass & 1) === 0
+
+      // Bottom-up, so a grain that just fell isn't carried along by the same
+      // pass that moved it.
+      const order = grains.map((_, i) => i).sort((a, b) => grains[b].y - grains[a].y)
+
+      let moves = 0
+      for (const i of order) {
+        const grain = grains[i]
+        if (grain.y + 1 >= GRID) continue
+
+        const from = cellIndex(grain.x, grain.y)
+        const below = cellIndex(grain.x, grain.y + 1)
+        if (occupied[below] === 0) {
+          occupied[from] = 0
+          occupied[below] = i + 1
+          grain.y++
+          moves++
+          continue
+        }
+
+        const first = leftToRight ? -1 : 1
+        for (const dir of [first, -first]) {
+          const nx = grain.x + dir
+          if (nx < 0 || nx >= GRID) continue
+          const diagonal = cellIndex(nx, grain.y + 1)
+          if (occupied[diagonal] !== 0) continue
+          occupied[from] = 0
+          occupied[diagonal] = i + 1
+          grain.x = nx
+          grain.y++
+          moves++
+          break
+        }
+      }
+      return moves
+    }
+
+    function reset() {
+      occupied.fill(0)
+      grains = []
+      alpha = 1
+      fading = false
+      sandAcc = 0
+    }
+
+    let raf = 0
+    let last = performance.now()
+
+    const frame = (now: number) => {
+      // Cap the step so a backgrounded tab doesn't come back to a pile that
+      // fell through the floor in one enormous delta.
+      const dt = Math.min(now - last, 50)
+      last = now
+
+      if (fading) {
+        alpha -= dt / FADE_MS
+        if (alpha <= 0) reset()
+      } else {
+        sandAcc += dt
+        while (sandAcc >= SAND_STEP_MS) {
+          sandAcc -= SAND_STEP_MS
+          pour()
+          const moves = stepSand()
+          if (moves === 0 && grains.length >= CAPACITY) fading = true
+        }
+      }
+
+      draw()
+      raf = requestAnimationFrame(frame)
+    }
+
+    raf = requestAnimationFrame(frame)
+    return () => cancelAnimationFrame(raf)
+  }, [])
+
+  return (
+    <canvas
+      ref={canvasRef}
+      width={GRID}
+      height={GRID}
+      aria-hidden="true"
+      style={{
+        display: 'block',
+        width: size,
+        height: size,
+        imageRendering: 'pixelated',
+      }}
+    />
+  )
+}

--- a/src/app/micro-land/components/toolbar.tsx
+++ b/src/app/micro-land/components/toolbar.tsx
@@ -5,6 +5,7 @@ import { useMicroLand } from '@/app/micro-land/store'
 
 import { CreaturePortrait } from './creature-chip'
 import { SparkleIcon } from './sparkle-icon'
+import { SummonSand } from './summon-sand'
 
 const BRUSHES = [2, 4, 8, 14]
 
@@ -23,6 +24,7 @@ export function Toolbar() {
   const brush = useMicroLand((s) => s.brush)
   const setBrush = useMicroLand((s) => s.setBrush)
   const blueprints = useMicroLand((s) => s.blueprints)
+  const pending = useMicroLand((s) => s.pendingSummons)
   const setSummonOpen = useMicroLand((s) => s.setSummonOpen)
 
   const paintingSelected = tool.kind === 'material' || tool.kind === 'erase'
@@ -195,6 +197,28 @@ export function Toolbar() {
       </div>
 
       <div className="-mx-1 flex gap-1.5 overflow-x-auto px-1 pb-1">
+        {/* Creatures still on their way hold their place at the front of the
+            strip, right where the finished one lands. */}
+        {pending.map((p) => (
+          <div
+            key={p.id}
+            className="shrink-0"
+            title={`Making “${p.prompt}”`}
+            aria-label={`Making ${p.prompt}`}
+            style={{
+              ...swatchStyle(false),
+              minWidth: 62,
+              borderStyle: 'dashed',
+              borderColor: 'var(--cc-pink-border)',
+            }}
+          >
+            <span style={{ height: 34, display: 'grid', placeItems: 'center' }}>
+              <SummonSand size={34} />
+            </span>
+            <span style={{ ...swatchLabel, color: 'var(--cc-pink)' }}>Making…</span>
+          </div>
+        ))}
+
         {ordered.map((bp) => {
           const selected = tool.kind === 'creature' && tool.blueprintId === bp.id
           return (

--- a/src/app/micro-land/domain/config/loader-shapes.ts
+++ b/src/app/micro-land/domain/config/loader-shapes.ts
@@ -134,3 +134,12 @@ export const LOADER_TERRAIN_SHAPES: LoaderShape[] = [
     ],
   },
 ]
+
+/**
+ * The grains that pour into a slot while one creature is being summoned.
+ *
+ * Not a shape — the slot-sized wait never assembles into anything, it just
+ * piles up and washes out. Asset data, same as the palettes above, which is
+ * why the colors are literal.
+ */
+export const SUMMON_SAND_COLORS = ['#5eead4', '#2dd4bf', '#7dd3fc']

--- a/src/app/micro-land/store.ts
+++ b/src/app/micro-land/store.ts
@@ -61,6 +61,19 @@ export interface Notice {
   text: string
 }
 
+/**
+ * A creature that has been asked for but hasn't arrived yet.
+ *
+ * A single creature is summoned without blocking the game, so the wait has to
+ * be visible somewhere the player isn't using: an empty slot holds its place in
+ * the creature strip until the response lands. More than one can be in flight —
+ * nothing stops a player from asking for a second while the first is coming.
+ */
+export interface PendingSummon {
+  id: number
+  prompt: string
+}
+
 interface MicroLandState {
   themeId: string
   tool: Tool
@@ -80,6 +93,8 @@ interface MicroLandState {
   /** Name of the summoned land, if there is one — shown in the world picker. */
   summonedLand: string | null
   summonError: string | null
+  /** Creature summons in flight, in the order they were asked for. */
+  pendingSummons: PendingSummon[]
   guideOpen: boolean
   inspected: Inspected | null
 
@@ -97,6 +112,9 @@ interface MicroLandState {
   setSummonMode: (mode: 'creature' | 'scene' | 'terrain') => void
   setSummonedLand: (name: string | null) => void
   setSummonError: (message: string | null) => void
+  /** Opens a slot for a creature on its way; returns the id to close it with. */
+  addPendingSummon: (prompt: string) => number
+  removePendingSummon: (id: number) => void
   setGuideOpen: (open: boolean) => void
   setInspected: (snapshot: Inspected | null) => void
   notify: (text: string) => void
@@ -104,6 +122,7 @@ interface MicroLandState {
 }
 
 let noticeId = 0
+let pendingId = 0
 
 export const useMicroLand = create<MicroLandState>((set) => ({
   themeId: DEFAULT_THEME,
@@ -122,6 +141,7 @@ export const useMicroLand = create<MicroLandState>((set) => ({
   summonMode: 'creature',
   summonedLand: null,
   summonError: null,
+  pendingSummons: [],
   guideOpen: false,
   inspected: null,
 
@@ -140,6 +160,13 @@ export const useMicroLand = create<MicroLandState>((set) => ({
   setSummonMode: (summonMode) => set({ summonMode }),
   setSummonedLand: (summonedLand) => set({ summonedLand }),
   setSummonError: (summonError) => set({ summonError }),
+  addPendingSummon: (prompt) => {
+    const id = ++pendingId
+    set((s) => ({ pendingSummons: [...s.pendingSummons, { id, prompt }] }))
+    return id
+  },
+  removePendingSummon: (id) =>
+    set((s) => ({ pendingSummons: s.pendingSummons.filter((p) => p.id !== id) })),
   setGuideOpen: (guideOpen) => set({ guideOpen }),
   setInspected: (inspected) => set({ inspected }),
 


### PR DESCRIPTION
## What

Asking for **a whole world** or **just the land** replaces everything you're looking at, so those are worth waiting on — they keep the full-screen sand loader exactly as it is.

Asking for **one creature** isn't. The modal now closes the moment you hit the button, and the wait moves into an empty slot at the front of the creature strip: sand pours in and piles up under the same powder rules the world itself runs on. When the response lands, the slot is replaced by the real creature.

## Why

A creature takes the better part of a minute, and for that whole minute the game was unplayable behind a modal — for a payoff that only adds one chip to a bar. The blocking wait made sense when the result *was* the screen; it doesn't when the result is one creature.

Litmus test: **session length**. Nothing stops play while a creature is being made, and asking for one stops being a decision about whether you want to sit and wait.

## Details

- Up to **three creatures in flight** at once; past that the panel asks you to wait for one to land.
- **Your tool isn't stolen.** If you picked up dirt while waiting, the arriving creature doesn't yank it out of your hand. If you haven't touched anything, it goes straight into your hand ready to place. (Compares the store's `tool` object identity, which only changes via `setTool`.)
- **Errors surface as notices**, not in a modal you already closed.
- Closing the panel **returns keyboard focus** to whatever opened it — that path now fires on the most common flow, not just on cancel.
- **Reduced motion** gets a settled pile, held still.
- Drops the now-dead single-blueprint branch in the blocking path — the API only returns `blueprint` for creature mode.

The slot animation (`summon-sand.tsx`) is deliberately not a copy of `SummonLoader`: at 34px the assembly phase would be a smudge, and it has to be cheap enough to run several at once behind a world already simulating at 60fps. Its palette lives in `loader-shapes.ts` with the other asset colors.

## Testing

`eslint` and `tsc` clean for `src/app/micro-land`. Dev server compiles and serves `/micro-land`; the summon endpoint returns the expected creature shape.

⚠️ **Not verified visually.** No browser driver in this repo and no API key in my environment, so the endpoint answered from the offline fallback — which returns instantly and never shows the wait. The sand animation and the slot→creature handoff need a real look with a key before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)