### PR TITLE
fix: track and clear share-button copy timeouts on unmount (5 files)

### DIFF
--- a/src/app/speck-wars/components/phase-router.tsx
+++ b/src/app/speck-wars/components/phase-router.tsx
@@ -12,6 +12,7 @@ import { LEVELS, saveLevelStars, getLevelStars, getLevelBestTime, saveLevelBestT
 export function PhaseRouter({ children }: { children: React.ReactNode }) {
   const { phase, winnerId, setPhase, difficulty, setDifficulty, elapsedMs, resetGame, kills, losses, isNewBest, hud, fogEnabled, setFogEnabled, mapPreset, setMapPreset, campaignLevel, setCampaignLevel } = useSpeckWarsStore()
   const [copied, setCopied] = useState(false)
+  const copiedTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined)
   const [bestTimes, setBestTimes] = useState<Partial<Record<Difficulty, number>>>({})
   const [winStreak, setWinStreak] = useState(0)
   const [lifetimeStats, setLifetimeStats] = useState({ gamesPlayed: 0, totalKills: 0, bestStreak: 0 })
@@ -19,6 +20,8 @@ export function PhaseRouter({ children }: { children: React.ReactNode }) {
   const [isNewLevelBest, setIsNewLevelBest] = useState(false)
   const resultHeadingRef = useRef<HTMLHeadingElement>(null)
   const { user } = useAuth()
+
+  useEffect(() => () => { clearTimeout(copiedTimerRef.current) }, [])
   const isTouchDevice = typeof navigator !== 'undefined' && navigator.maxTouchPoints > 0
   const router = useRouter()
 
@@ -469,8 +472,9 @@ export function PhaseRouter({ children }: { children: React.ReactNode }) {
       } else {
         await navigator.clipboard.writeText(`${shareText} ${url}`)
         navigator.vibrate?.(12)
+        clearTimeout(copiedTimerRef.current)
         setCopied(true)
-        setTimeout(() => setCopied(false), 2000)
+        copiedTimerRef.current = setTimeout(() => setCopied(false), 2000)
       }
     }
 

--- a/src/app/speck-wars/page.tsx
+++ b/src/app/speck-wars/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 import { useRouter } from 'next/navigation'
-import { useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { useSpeckWarsStore } from './store'
 import { LEVELS, getLevelStars, getLevelBestTime, isLevelUnlocked } from './campaign/levels'
 
@@ -19,6 +19,9 @@ export default function SpeckWarsCampaignPage() {
     return s
   })
   const [copied, setCopied] = useState(false)
+  const copiedTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined)
+
+  useEffect(() => () => { clearTimeout(copiedTimerRef.current) }, [])
   const [hoveredLevel, setHoveredLevel] = useState<number | null>(null)
   const [focusedLevel, setFocusedLevel] = useState<number | null>(null)
 
@@ -44,8 +47,9 @@ export default function SpeckWarsCampaignPage() {
       try { await navigator.share({ title: 'Speck Wars', text, url }) } catch { /* cancelled */ }
     } else {
       await navigator.clipboard.writeText(`${text} ${url}`)
+      clearTimeout(copiedTimerRef.current)
       setCopied(true)
-      setTimeout(() => setCopied(false), 2000)
+      copiedTimerRef.current = setTimeout(() => setCopied(false), 2000)
     }
   }
 

--- a/src/app/trivia/components/InfiniteRunSummary.tsx
+++ b/src/app/trivia/components/InfiniteRunSummary.tsx
@@ -1,5 +1,5 @@
 'use client'
-import { useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 
 import type { InfiniteMode, InfiniteRunState } from '@/app/trivia/hooks/useInfiniteRun'
 import { ChunkyButton } from '@/components/ui/chunky-button'
@@ -47,8 +47,11 @@ type AnswerEntry = InfiniteRunState['answers'][number]
 export function InfiniteRunSummary({ state, onPlayAgain, onBack, onViewStats, onViewLeaderboard, mode = 'scored', runId, onFlagged, ratings }: Props) {
   const { user } = useAuth()
   const [copied, setCopied] = useState(false)
+  const copiedTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined)
   const [showAllAnswers, setShowAllAnswers] = useState(false)
   const [detailFor, setDetailFor] = useState<AnswerEntry | null>(null)
+
+  useEffect(() => () => { clearTimeout(copiedTimerRef.current) }, [])
 
   const questionsCorrect = state.answers.filter(a => a.correct).length
 
@@ -63,8 +66,9 @@ export function InfiniteRunSummary({ state, onPlayAgain, onBack, onViewStats, on
 
     try {
       await navigator.clipboard.writeText(lines)
+      clearTimeout(copiedTimerRef.current)
       setCopied(true)
-      setTimeout(() => setCopied(false), 2000)
+      copiedTimerRef.current = setTimeout(() => setCopied(false), 2000)
     } catch {
       // Silent fail
     }

--- a/src/app/trivia/components/TriviaLeaderboard.tsx
+++ b/src/app/trivia/components/TriviaLeaderboard.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 
 import { useTriviaUser } from '@/app/trivia/hooks/useTriviaUser'
 import { ChunkyButton } from '@/components/ui/chunky-button'
@@ -49,6 +49,9 @@ export function TriviaLeaderboard({ onBack }: { onBack: () => void }) {
   const [data, setData] = useState<LeaderboardResponse | null>(null)
   const [error, setError] = useState<string | null>(null)
   const [copied, setCopied] = useState(false)
+  const copiedTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined)
+
+  useEffect(() => () => { clearTimeout(copiedTimerRef.current) }, [])
 
   const currentUid = user?.uid ?? null
   const authName = user ? triviaDisplayName || user.email || null : null
@@ -101,8 +104,9 @@ export function TriviaLeaderboard({ onBack }: { onBack: () => void }) {
 
     try {
       await navigator.clipboard.writeText(shareText)
+      clearTimeout(copiedTimerRef.current)
       setCopied(true)
-      setTimeout(() => setCopied(false), 2000)
+      copiedTimerRef.current = setTimeout(() => setCopied(false), 2000)
     } catch {
       // fallback
     }

--- a/src/app/trivia/components/TriviaResults.tsx
+++ b/src/app/trivia/components/TriviaResults.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 
 import { useTriviaUser } from '@/app/trivia/hooks/useTriviaUser'
 import type { TriviaGameResult } from '@/app/trivia/models/trivia'
@@ -103,10 +103,13 @@ interface TriviaResultsProps {
 
 export function TriviaResults({ result, onBack, onViewStats, onViewLeaderboard, onStartInfinite, onNextDay, onPreviousDay, isRetroactive }: TriviaResultsProps) {
   const [copied, setCopied] = useState(false)
+  const copiedTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined)
   const { user } = useAuth()
   const { stats, displayName } = useTriviaUser()
   const currentStreak = stats.currentStreak
   const countdown = useCountdown()
+
+  useEffect(() => () => { clearTimeout(copiedTimerRef.current) }, [])
 
   // Treat anonymous Firebase users as "not signed in" for share-text and CTAs.
   const isNamedUser = !!user && !user.isAnonymous
@@ -129,8 +132,9 @@ export function TriviaResults({ result, onBack, onViewStats, onViewLeaderboard, 
     }
     try {
       await navigator.clipboard.writeText(text)
+      clearTimeout(copiedTimerRef.current)
       setCopied(true)
-      setTimeout(() => setCopied(false), 2000)
+      copiedTimerRef.current = setTimeout(() => setCopied(false), 2000)
     } catch {
       // Fallback for older browsers
       const textarea = document.createElement('textarea')
@@ -139,8 +143,9 @@ export function TriviaResults({ result, onBack, onViewStats, onViewLeaderboard, 
       textarea.select()
       document.execCommand('copy')
       document.body.removeChild(textarea)
+      clearTimeout(copiedTimerRef.current)
       setCopied(true)
-      setTimeout(() => setCopied(false), 2000)
+      copiedTimerRef.current = setTimeout(() => setCopied(false), 2000)
     }
   }
 


### PR DESCRIPTION
## Summary

Five components use an untracked `setTimeout(() => setCopied(false), 2000)` after clipboard copy — if the component unmounts during those 2 seconds, the timer fires on a detached component. Applied the same `copiedTimerRef` pattern used in InfiniteGame.tsx (PR #2579):

- `speck-wars/components/phase-router.tsx` — post-game share button
- `speck-wars/page.tsx` — campaign page share button
- `trivia/components/InfiniteRunSummary.tsx` — infinite run share
- `trivia/components/TriviaLeaderboard.tsx` — leaderboard share
- `trivia/components/TriviaResults.tsx` — results share (two call sites in try/catch)

Fixes #2593

## Test plan
- [ ] Click share on any of the above screens, then quickly navigate away — no console warnings about state updates on unmounted components

🤖 Generated with [Claude Code](https://claude.com/claude-code)