### PR TITLE
feat(micro-land): the ground remembers its plants

### DIFF
--- a/src/app/micro-land/domain/constants.ts
+++ b/src/app/micro-land/domain/constants.ts
@@ -60,19 +60,44 @@ export const MEAL_VALUE = 0.42
 export const BREED_COST = 0.55
 
 /**
- * Seed rain.
+ * Seed rain — animals.
  *
- * Left alone, a grazer boom strips the last plant and then starves — and a
- * world at zero plants can never come back, because plants only come from other
- * plants. Real meadows recover because seed blows in from outside the meadow;
- * this is that, and it is the difference between a world that breathes and a
- * world you have to restart.
- *
- * It only fires while something is still alive, so pressing Empty leaves the
- * world empty.
+ * A native that has died out comes back once there is something alive for it to
+ * eat again. It only fires while something is still alive, so pressing Empty
+ * leaves the world empty.
  */
-export const PLANT_FLOOR = 6
 export const SEED_RAIN_INTERVAL = 4
+
+/**
+ * Native plants — the ground's own seed bank.
+ *
+ * Plants are the only thing in the world with no upstream: a grazer boom strips
+ * the last one and then nothing can ever bring it back, because plants only come
+ * from plants. Everything downstream starves and the world is a restart.
+ *
+ * So the *ground* holds the seed instead of the plants. The first time a world
+ * has soil in it, whichever species could live on that soil become its natives
+ * (see `establishNativePlants`), and from then on that soil keeps pushing the
+ * plant population back toward `NATIVE_PLANT_TARGET`. A meadow can be grazed
+ * flat and still come back, which is what makes a population renewable rather
+ * than merely long-lived.
+ *
+ * The target is a floor, not a quota. Well above it the ground does nothing at
+ * all and plants spread the ordinary way; the further below it the world falls,
+ * the harder the seed comes in. That asymmetry is deliberate — a constant
+ * trickle would just pin every world at MAX_PLANTS and turn it into a carpet.
+ */
+export const NATIVE_PLANT_TARGET = 45
+export const PLANT_SEED_INTERVAL = 3
+/** Most plants a single seeding may place, when the world is at zero. */
+export const PLANT_SEED_BATCH = 3
+/**
+ * How many species the ground picks when it establishes its natives.
+ *
+ * Fewer than are viable, on purpose: two worlds painted with the same soil
+ * should not grow the same flora.
+ */
+export const NATIVE_PLANT_SPECIES = 3
 
 /**
  * Carrying capacity for a single animal species.

--- a/src/app/micro-land/domain/sim/creature-sim.ts
+++ b/src/app/micro-land/domain/sim/creature-sim.ts
@@ -36,6 +36,7 @@ import {
   boxLiquidFraction,
   inBounds,
   repopulate,
+  seedNativePlants,
   setTile,
   settleOnGround,
   solidAt,
@@ -212,6 +213,8 @@ export function tickCreatures(
     w.creatures = creatures.filter((c) => !dead.has(c.id))
   }
 
+  // Plants first — everything else in the world is downstream of them.
+  seedNativePlants(w, rng)
   repopulate(w, rng)
 
   tickParticles(w, dt, gravityScale)

--- a/src/app/micro-land/domain/sim/world.ts
+++ b/src/app/micro-land/domain/sim/world.ts
@@ -12,7 +12,12 @@ import {
 import { DEFAULT_THEME, THEME_BY_ID, type Theme } from '@/app/micro-land/domain/config/themes'
 import {
   MAX_CREATURES,
-  PLANT_FLOOR,
+  MAX_PLANTS,
+  NATIVE_PLANT_SPECIES,
+  NATIVE_PLANT_TARGET,
+  PLANT_SEED_BATCH,
+  PLANT_SEED_INTERVAL,
+  PLANT_SPECIES_CAP,
   SEED_RAIN_INTERVAL,
   WORLD_H,
   WORLD_W,
@@ -44,6 +49,8 @@ export function createWorld(seed = 1337): WorldState {
     flowPhase: 0,
     natives: [],
     nextSeedRain: 0,
+    nextPlantSeed: 0,
+    dormant: false,
   }
 }
 
@@ -218,6 +225,7 @@ export function applyThemeObject(w: WorldState, theme: Theme, seed?: number): vo
   theme.build(w.tiles, rng)
   for (let i = 0; i < w.grain.length; i++) w.grain[i] = Math.floor(rng() * 256)
   w.particles.length = 0
+  w.dormant = false
 }
 
 /** Paint a filled circle of material. This is the player's brush. */
@@ -229,6 +237,9 @@ export function paintCircle(
   mat: MaterialId
 ): void {
   const value = MATERIAL_INDEX[mat]
+  // Painting is the player building something, which is the opposite of asking
+  // for an empty world — so the ground is allowed to grow again.
+  w.dormant = false
   const r2 = radius * radius
   const x0 = Math.floor(cx - radius)
   const x1 = Math.ceil(cx + radius)
@@ -291,18 +302,21 @@ export function spawnCreature(
 }
 
 /**
- * Find somewhere this creature could actually survive and put it there.
+ * Find somewhere this creature could actually survive.
  *
  * Plants want fertile ground under them, fish want water, walkers want a floor.
- * Tries random spots and falls back to the requested position so a summon never
- * silently does nothing.
+ * Returns the sprite's top-left corner, or null if nowhere in this world suits.
+ *
+ * Split out from `spawnSomewhereSensible` so the same search can answer "could
+ * this species live here at all?" without actually creating anything — which is
+ * how the ground decides which plants are native to it.
  */
-export function spawnSomewhereSensible(
+export function findSpawnSpot(
   w: WorldState,
   bp: CreatureBlueprint,
   rng: Rng,
   near?: { x: number; y: number; radius: number }
-): Creature | null {
+): { x: number; y: number } | null {
   const { w: bw, h: bh } = artSize(bp)
   const wantsLiquid = bp.move.kind === 'swim' || bp.habitat.needs?.includes('water')
   const isPlant = bp.move.kind === 'root'
@@ -349,20 +363,33 @@ export function spawnSomewhereSensible(
       }
     }
 
-    return spawnCreature(w, bp, x, y)
+    return { x, y }
   }
 
   // Nowhere ideal. Drop it wherever the player asked and let physics sort it out.
   if (near && !boxHitsSolid(w, near.x, near.y, bw, bh)) {
-    return spawnCreature(w, bp, near.x - bw / 2, near.y - bh / 2)
+    return { x: near.x - bw / 2, y: near.y - bh / 2 }
   }
   return null
+}
+
+/** Find somewhere this creature could survive and put it there. */
+export function spawnSomewhereSensible(
+  w: WorldState,
+  bp: CreatureBlueprint,
+  rng: Rng,
+  near?: { x: number; y: number; radius: number }
+): Creature | null {
+  const spot = findSpawnSpot(w, bp, rng, near)
+  if (!spot) return null
+  return spawnCreature(w, bp, spot.x, spot.y)
 }
 
 /** Seed a theme's resident population. */
 export function seedStarters(w: WorldState, themeId: string, rng: Rng): void {
   const theme = THEME_BY_ID[themeId]
   if (!theme) return
+  w.dormant = false
   for (const entry of theme.starters) {
     const bp = w.blueprints[entry.id]
     if (!bp) continue
@@ -376,44 +403,145 @@ export function clearCreatures(w: WorldState): void {
   w.particles.length = 0
 }
 
+// ---------------------------------------------------------------------------
+// Native plants — the ground's seed bank
+// ---------------------------------------------------------------------------
+
+function isPlant(bp: CreatureBlueprint | undefined): boolean {
+  return bp?.move.kind === 'root'
+}
+
+/** Native species that are plants. Empty until the ground has decided. */
+function nativePlantIds(w: WorldState): string[] {
+  return w.natives.filter((id) => isPlant(w.blueprints[id]))
+}
+
+/** Is there anywhere in this world a plant could put roots down? */
+function hasFertileGround(w: WorldState): boolean {
+  for (let i = 0; i < w.tiles.length; i++) {
+    if (IS_FERTILE[w.tiles[i]] === 1) return true
+  }
+  return false
+}
+
 /**
- * Let the world heal itself.
+ * Decide which plants belong to this world, once, the first time it has soil.
  *
- * Populations here are small enough that an oscillation eventually touches zero,
- * and zero is absorbing: plants only come from plants, hoppers only from
- * hoppers. Without this, every world converges on the same dead end — a field of
- * whatever happened to be last standing — and the only cure is a restart.
+ * A theme hands its flora over through `starters`, so this is really for the
+ * worlds nobody wrote: an Empty canvas the player paints grass onto, terrain
+ * that came back from a summon, stone a Loamworm has been patiently turning
+ * into dirt. Those worlds have ground and no reason for anything to grow on it.
  *
- * Real habitats recover because the frame we're watching isn't the whole world:
- * seed blows in, animals wander over the hill. This is that edge, and it obeys
- * two rules that keep it honest:
- *   - Nothing returns to an empty world. Pressing Empty means empty.
- *   - A predator only returns when there is something alive for it to eat, so
- *     this can never conjure a species straight back into starving to death.
+ * Which species is settled by asking the world rather than by a lookup table —
+ * a candidate is native if `findSpawnSpot` can actually place it. Kelp rules
+ * itself out of a world with no water without anyone having to say so, and a
+ * summoned material nobody has thought about yet still gets an honest answer.
+ *
+ * Picks a few of the viable species rather than all of them, so a pond and a
+ * meadow don't grow the same flora.
  */
-export function repopulate(w: WorldState, rng: Rng): void {
-  if (w.elapsed < w.nextSeedRain) return
-  w.nextSeedRain = w.elapsed + SEED_RAIN_INTERVAL
-  if (w.creatures.length === 0 || w.natives.length === 0) return
+export function establishNativePlants(w: WorldState, rng: Rng): boolean {
+  if (nativePlantIds(w).length > 0) return true
+  if (!hasFertileGround(w)) return false
+
+  const viable: string[] = []
+  for (const bp of Object.values(w.blueprints)) {
+    if (!isPlant(bp)) continue
+    if (findSpawnSpot(w, bp, rng)) viable.push(bp.id)
+  }
+  if (viable.length === 0) return false
+
+  // Fisher–Yates over a copy, so the pick is drawn from the world's own RNG and
+  // stays reproducible for the headless harness.
+  for (let i = viable.length - 1; i > 0; i--) {
+    const j = Math.floor(rng() * (i + 1))
+    ;[viable[i], viable[j]] = [viable[j], viable[i]]
+  }
+  for (const id of viable.slice(0, NATIVE_PLANT_SPECIES)) w.natives.push(id)
+  return true
+}
+
+/**
+ * The ground pushing its plant population back toward a living level.
+ *
+ * Runs on its own clock, separate from the animal seed rain, because the two
+ * answer different questions. Seed rain asks "has a species died out and is
+ * there food for it again"; this asks "is there less green here than this soil
+ * can support" — and it keeps asking, which is the whole point. A meadow that
+ * gets grazed to nothing is a meadow that grows back.
+ *
+ * Deliberately blind to whether anything is alive. Plants having no upstream is
+ * exactly the problem being solved; requiring a survivor would leave a stripped
+ * world just as dead as before.
+ */
+export function seedNativePlants(w: WorldState, rng: Rng): void {
+  if (w.elapsed < w.nextPlantSeed) return
+  w.nextPlantSeed = w.elapsed + PLANT_SEED_INTERVAL
+  if (w.dormant) return
+  if (!establishNativePlants(w, rng)) return
 
   const counts: Record<string, number> = {}
   let plants = 0
   for (const c of w.creatures) {
+    if (!isPlant(w.blueprints[c.blueprintId])) continue
     counts[c.blueprintId] = (counts[c.blueprintId] ?? 0) + 1
-    if (w.blueprints[c.blueprintId]?.move.kind === 'root') plants++
+    plants++
   }
 
-  // Plants first — everything else is downstream of them.
-  if (plants < PLANT_FLOOR) {
-    const plantIds = w.natives.filter((id) => w.blueprints[id]?.move.kind === 'root')
-    if (plantIds.length > 0) {
-      const bp = w.blueprints[plantIds[Math.floor(rng() * plantIds.length)]]
-      if (bp) spawnSomewhereSensible(w, bp, rng)
-      return
-    }
+  const deficit = NATIVE_PLANT_TARGET - plants
+  if (deficit <= 0) return
+  if (plants >= MAX_PLANTS || w.creatures.length >= MAX_CREATURES) return
+
+  // Scale the seeding to how bare the world is: a nearly-full meadow gets one
+  // sprout, a stripped one gets the full batch. Recovery from a crash is fast
+  // without the ground quietly out-growing the grazers the rest of the time.
+  const batch = Math.min(
+    PLANT_SEED_BATCH,
+    Math.max(1, Math.ceil((deficit / NATIVE_PLANT_TARGET) * PLANT_SEED_BATCH))
+  )
+
+  // Rarest first, so the ground refills the species the grazers actually
+  // emptied instead of piling more onto whichever one is already winning.
+  const pool = nativePlantIds(w)
+    .filter((id) => (counts[id] ?? 0) < PLANT_SPECIES_CAP)
+    .sort((a, b) => (counts[a] ?? 0) - (counts[b] ?? 0))
+  if (pool.length === 0) return
+
+  for (let i = 0; i < batch; i++) {
+    const bp = w.blueprints[pool[i % pool.length]]
+    if (bp) spawnSomewhereSensible(w, bp, rng)
+  }
+}
+
+/**
+ * Let the world heal itself — the animal half.
+ *
+ * Populations here are small enough that an oscillation eventually touches zero,
+ * and zero is absorbing: hoppers only come from hoppers. Without this, every
+ * world converges on the same dead end — a field of whatever happened to be last
+ * standing — and the only cure is a restart.
+ *
+ * Real habitats recover because the frame we're watching isn't the whole world:
+ * animals wander over the hill. This is that edge, and it obeys two rules that
+ * keep it honest:
+ *   - Nothing returns to an empty world. Pressing Empty means empty.
+ *   - A predator only returns when there is something alive for it to eat, so
+ *     this can never conjure a species straight back into starving to death.
+ *
+ * Plants are not handled here. They have no upstream at all, so the ground
+ * carries their seed instead — see `seedNativePlants`.
+ */
+export function repopulate(w: WorldState, rng: Rng): void {
+  if (w.elapsed < w.nextSeedRain) return
+  w.nextSeedRain = w.elapsed + SEED_RAIN_INTERVAL
+  if (w.dormant || w.creatures.length === 0 || w.natives.length === 0) return
+
+  const counts: Record<string, number> = {}
+  for (const c of w.creatures) {
+    counts[c.blueprintId] = (counts[c.blueprintId] ?? 0) + 1
   }
 
-  // Then any native that has died out and now has something to eat again.
+  // Any native that has died out and now has something to eat again.
   // Plants count here too: one plant species thriving is not a reason for the
   // others to stay extinct, and a grazer too small to eat the survivor depends
   // on the little ones coming back.

--- a/src/app/micro-land/domain/types.ts
+++ b/src/app/micro-land/domain/types.ts
@@ -282,4 +282,14 @@ export interface WorldState {
   natives: string[]
   /** Next world-clock time at which repopulation may fire. */
   nextSeedRain: number
+  /** Next world-clock time at which the ground may seed native plants. */
+  nextPlantSeed: number
+  /**
+   * True while the player has deliberately emptied the world.
+   *
+   * Native plants otherwise grow back out of the soil forever, which would make
+   * Empty impossible to hold on any world that has ground in it. Anything
+   * generative — painting, placing, summoning, changing theme — wakes it again.
+   */
+  dormant: boolean
 }

--- a/src/app/micro-land/game-instance.ts
+++ b/src/app/micro-land/game-instance.ts
@@ -357,6 +357,10 @@ export class GameInstance {
 
   clearLife(): void {
     clearCreatures(this.world)
+    // Native plants grow back out of the soil on their own, so on any world with
+    // ground in it "empty" would last about three seconds without this. Anything
+    // the player does next — painting, placing, summoning — wakes it back up.
+    this.world.dormant = true
     this.knownSpecies.clear()
     this.inspectedId = null
     this.pushStats()
@@ -368,6 +372,7 @@ export class GameInstance {
    */
   introduce(raw: unknown, count: number): { blueprint: CreatureBlueprint; placed: number } {
     const bp = sanitizeBlueprint(raw, { summoned: true })
+    this.world.dormant = false
     registerBlueprint(this.world, bp)
     this.syncBlueprintsToStore()
 
@@ -474,6 +479,7 @@ export class GameInstance {
       this.lastPlaceAt = now
       const bp = this.world.blueprints[tool.blueprintId]
       if (!bp) return
+      this.world.dormant = false
       if (this.world.creatures.length >= MAX_CREATURES) {
         state.notify('The world is full. Something has to go.')
         return


### PR DESCRIPTION
## The problem

Plants are the only thing in Micro Land with no upstream. A grazer boom strips the last one and nothing can ever bring it back, because plants only come from plants — everything downstream starves and the world is a restart.

Seed rain already covered the animal half of that. The plant half was one sprout every four seconds below a floor of six, which is slower than a single hopper eats.

## The idea

Put the seed in the **ground** instead of in the plants.

**`establishNativePlants`** — the first time a world has soil in it, it decides which species belong to that world, once. Which species is settled by asking the world rather than by a lookup table: a candidate is native if `findSpawnSpot` can actually place it. Kelp rules itself out of a world with no water without anyone having to say so, and a generated material nobody has thought about yet still gets an honest answer. It takes three of the viable species rather than all of them, so a pond and a meadow don't grow the same flora.

**`seedNativePlants`** — from then on, every three world-seconds, the ground pushes the plant count back toward `NATIVE_PLANT_TARGET` (45), rarest species first so the meadow stays mixed. It's deficit-scaled: a stripped world gets the full batch of 3, a nearly-full one gets a single sprout, and above the target the ground does nothing at all. A constant trickle would just pin every world at `MAX_PLANTS` and turn it into a green carpet — the asymmetry is what makes this a floor rather than a quota. It's also deliberately blind to whether anything is alive, since requiring a survivor is exactly the trap being escaped.

This mostly matters for the worlds nobody wrote: an Empty canvas the player paints grass onto, terrain that came back from a generate, stone a Loamworm has been patiently turning into dirt. Themed worlds already sit well above the target, so they're untouched.

## The one judgment call

Plants growing back out of the soil would make **Empty impossible to hold** — on any world with ground in it, "empty" would last about three seconds. A `dormant` flag keeps that pact: `clearLife()` sets it, and anything generative — painting, placing, generating, changing theme — clears it. Verified in scenario 4 below.

## Also in here

- `repopulate` is animals-only now; the old `PLANT_FLOOR` branch is gone so the two mechanisms can't fight.
- `findSpawnSpot` split out of `spawnSomewhereSensible`, so viability can be probed without creating anything.

## Verification

Scenarios run through the real sim headlessly:

| Scenario | Result |
| --- | --- |
| Empty theme, bare air, 10s | 0 plants, no natives — nothing spawns from nothing |
| Paint a grass shelf | natives set to `[bramble, sporecap, sunleaf]`, 105 plants at +30s |
| Paint a sand basin + water | picks kelp, unprompted |
| Earth, **every plant wiped** at t=60s | 0 → 68 plants in 30s → 150 at +120s, world survives |
| Earth, cleared by hand | still 0 after 120s; painting grass wakes it |

Theme regression check, 3 seeds × 300s, all still self-sustaining:

| Theme | low-water mark | alive at end |
| --- | --- | --- |
| earth | 147 → 147 | 184 → 184 (bit-identical) |
| station | 61 → 62 | 64 → 69 |
| tidepool | 103 → **113** | 115 → 124 |
| volcanic | 55 → **60** | 83 → 62 |

Earth is bit-identical because its plants never fall below the target, so the ground never fires and consumes no RNG. Volcanic is worth a note: over 6 seeds its peak drops (83 → 75) while its low-water mark rises (57 → 60) — a narrower oscillation, which is what a stabilizer should do, though part of that delta is simply a different RNG trajectory once seeding starts drawing from the stream.

Typecheck clean for micro-land; eslint clean on all touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)