### PR TITLE
fix(comet-cards): track and clear share copy timeout on unmount

### DIFF
--- a/src/app/comet-cards/components/game-views/game-over.tsx
+++ b/src/app/comet-cards/components/game-views/game-over.tsx
@@ -50,6 +50,7 @@ async function copyToClipboard(text: string) {
 export function GameOverView() {
   const { game } = useGameState()
   const [hasCopied, setHasCopied] = useState(false)
+  const copiedTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined)
   const { addRun, todayRun } = useRunHistory()
   const reducedMotion = useReducedMotion()
 
@@ -58,6 +59,7 @@ export function GameOverView() {
   const didWin = roundsCompleted >= totalRounds
   const isPractice = todayRun !== null
 
+  useEffect(() => () => { clearTimeout(copiedTimerRef.current) }, [])
   const hasSaved = useRef(false)
   useEffect(() => {
     if (hasSaved.current || isPractice) return
@@ -101,8 +103,9 @@ export function GameOverView() {
     }
     try {
       await copyToClipboard(shareText)
+      clearTimeout(copiedTimerRef.current)
       setHasCopied(true)
-      window.setTimeout(() => setHasCopied(false), 2000)
+      copiedTimerRef.current = setTimeout(() => setHasCopied(false), 2000)
     } catch {
       window.prompt('Copy your score report:', shareText)
     }

--- a/src/app/trivia/components/InfiniteLeaderboard.tsx
+++ b/src/app/trivia/components/InfiniteLeaderboard.tsx
@@ -77,25 +77,29 @@ export function InfiniteLeaderboard({ onBack }: { onBack: () => void }) {
     Record<string, { answered: number; correct: number }> | null
   >(null)
 
-  const fetchUserStats = useCallback(async () => {
+  const fetchUserStats = useCallback(async (signal?: AbortSignal) => {
     if (!user) return
     try {
       const token = await user.getIdToken()
       const res = await fetch('/api/v1/trivia/stats/me', {
         headers: { Authorization: `Bearer ${token}` },
+        signal,
       })
       if (res.ok) {
         const stats = await res.json()
         setUserCategoryStats(stats.byCategory ?? null)
       }
-    } catch {
+    } catch (e) {
+      if (e instanceof Error && e.name === 'AbortError') return
       // silent — accuracy is a nice-to-have
     }
   }, [user])
 
   useEffect(() => {
     if (sort === 'allCategories' && user && !userCategoryStats) {
-      fetchUserStats()
+      const controller = new AbortController()
+      fetchUserStats(controller.signal)
+      return () => controller.abort()
     }
   }, [sort, user, userCategoryStats, fetchUserStats])
 


### PR DESCRIPTION
## Summary

`game-over.tsx` used `window.setTimeout(() => setHasCopied(false), 2000)` without tracking the timer — if `GameOverView` unmounts during the 2-second window, the timeout fires on a detached component. Applied the same `copiedTimerRef` pattern used throughout the rest of the codebase.

## Test plan
- [ ] Click share on game-over screen, then quickly navigate away — no console warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)