### PR TITLE
feat(micro-land): records, elders, and a field guide that remembers

### DIFF
--- a/src/app/micro-land/MicroLandGame.tsx
+++ b/src/app/micro-land/MicroLandGame.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useRef } from 'react'
 
+import { flushChronicle, initChronicle } from '@/app/micro-land/chronicle/chronicle'
 import { FieldGuide } from '@/app/micro-land/components/field-guide'
 import { Hud } from '@/app/micro-land/components/hud'
 import { Inspector } from '@/app/micro-land/components/inspector'
@@ -29,21 +30,36 @@ export function MicroLandGame() {
       useMicroLand.getState().setTheme(requested)
     }
 
-    const game = new GameInstance(canvas)
-    gameRef.current = game
-    game.start()
+    let game: GameInstance | null = null
+    let unsubscribe: (() => void) | null = null
+    let cancelled = false
 
-    // Theme changes are driven straight off the store rather than a second
-    // effect — the instance already seeded its own theme when it was built, and
-    // a dependency-driven effect would rebuild the world on every remount.
-    const unsubscribe = useMicroLand.subscribe((state, previous) => {
-      if (state.themeId !== previous.themeId) game.setTheme(state.themeId)
+    // The chronicle is read *before* the world exists. Building the instance
+    // first would let a stats tick write records into a chronicle that is about
+    // to be replaced by the stored one, quietly losing them.
+    void initChronicle().then(() => {
+      if (cancelled) return
+      game = new GameInstance(canvas)
+      gameRef.current = game
+      game.publishRecords()
+      game.start()
+
+      // Theme changes are driven straight off the store rather than a second
+      // effect — the instance already seeded its own theme when it was built,
+      // and a dependency-driven effect would rebuild the world on every remount.
+      unsubscribe = useMicroLand.subscribe((state, previous) => {
+        if (state.themeId !== previous.themeId) game?.setTheme(state.themeId)
+      })
     })
 
     return () => {
-      unsubscribe()
-      game.destroy()
+      cancelled = true
+      unsubscribe?.()
+      game?.destroy()
       gameRef.current = null
+      // Leaving for another game in the cave is a normal way to end a session,
+      // and it isn't covered by the page-hide handler.
+      void flushChronicle()
     }
   }, [])
 
@@ -59,6 +75,10 @@ export function MicroLandGame() {
 
   const handleIntroduce = useCallback((raw: unknown, count: number) => {
     return gameRef.current?.introduce(raw, count) ?? null
+  }, [])
+
+  const handleNameElder = useCallback((name: string) => {
+    return gameRef.current?.nameElder(name) ?? false
   }, [])
 
   const handleApplyTerrain = useCallback((raw: unknown, keepCreatures: boolean) => {
@@ -80,7 +100,7 @@ export function MicroLandGame() {
           aria-label="Micro Land world. Tap to place things, drag a creature to pick it up and throw it."
         />
         <Notices />
-        <Inspector />
+        <Inspector onName={handleNameElder} />
       </div>
 
       <Toolbar />

--- a/src/app/micro-land/chronicle/__tests__/chronicle.test.ts
+++ b/src/app/micro-land/chronicle/__tests__/chronicle.test.ts
@@ -1,0 +1,257 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import type { ChronicleBackend } from '@/app/micro-land/chronicle/backend'
+import {
+  archivedSpecies,
+  claimMilestone,
+  flushChronicle,
+  initChronicle,
+  landId,
+  landRecord,
+  mergeChronicles,
+  noteSpeciesLife,
+  readChronicle,
+  rememberSpecies,
+  setBackend,
+  updateChronicle,
+} from '@/app/micro-land/chronicle/chronicle'
+import {
+  CHRONICLE_VERSION,
+  emptyChronicle,
+  emptyLandRecord,
+} from '@/app/micro-land/chronicle/types'
+import type { ChronicleData } from '@/app/micro-land/chronicle/types'
+import type { CreatureBlueprint } from '@/app/micro-land/domain/types'
+
+/**
+ * A blueprint stub.
+ *
+ * Cast rather than filled in: the chronicle only ever reads `id`, `name` and
+ * `summoned`, and spelling out forty fields of pixel art would obscure what each
+ * test is actually about.
+ */
+function bp(id: string, summoned = false): CreatureBlueprint {
+  return { id, name: id, summoned } as CreatureBlueprint
+}
+
+function memoryBackend(initial: ChronicleData | null = null) {
+  const state = { saved: initial }
+  const backend: ChronicleBackend = {
+    async load() {
+      return state.saved
+    },
+    async save(data) {
+      state.saved = JSON.parse(JSON.stringify(data)) as ChronicleData
+    },
+  }
+  return { backend, state }
+}
+
+/** Point the module singleton at a fresh backend and read it in. */
+async function loadWith(stored: ChronicleData | null) {
+  const mem = memoryBackend(stored)
+  setBackend(mem.backend)
+  await initChronicle()
+  return mem
+}
+
+beforeEach(async () => {
+  await loadWith(null)
+})
+
+describe('landId', () => {
+  it('files a built-in theme under its own id', () => {
+    expect(landId('tidepool', null)).toBe('tidepool')
+  })
+
+  it('gives a summoned land its own key, so records follow the name', () => {
+    expect(landId('summoned', 'The Drowned Cathedral')).toBe(
+      'summoned:the-drowned-cathedral'
+    )
+  })
+
+  it('falls back to the theme when a name slugs down to nothing', () => {
+    expect(landId('summoned', '!!!')).toBe('summoned')
+  })
+})
+
+describe('loading', () => {
+  it('restores stored records', async () => {
+    const stored = emptyChronicle()
+    stored.lands.tidepool = { ...emptyLandRecord(), steadySeconds: 420 }
+    await loadWith(stored)
+    expect(landRecord('tidepool').steadySeconds).toBe(420)
+  })
+
+  it('starts fresh rather than misreading an unknown version', async () => {
+    const stored = { ...emptyChronicle(), version: CHRONICLE_VERSION + 99 }
+    stored.lands.tidepool = { ...emptyLandRecord(), steadySeconds: 420 }
+    await loadWith(stored)
+    expect(readChronicle().lands).toEqual({})
+  })
+
+  it('survives a corrupt payload without throwing', async () => {
+    await loadWith({ version: CHRONICLE_VERSION } as ChronicleData)
+    expect(readChronicle().species).toEqual({})
+  })
+})
+
+describe('writing', () => {
+  it('flushes pending changes through to the backend', async () => {
+    const mem = await loadWith(null)
+    updateChronicle(() => {
+      landRecord('volcanic').steadySeconds = 99
+    })
+    await flushChronicle()
+    expect(mem.state.saved?.lands.volcanic.steadySeconds).toBe(99)
+  })
+
+  it('does not write when nothing changed', async () => {
+    const mem = await loadWith(null)
+    await flushChronicle()
+    expect(mem.state.saved).toBeNull()
+  })
+})
+
+describe('the species archive', () => {
+  it('keeps the most recent version of a blueprint that comes back', () => {
+    rememberSpecies(bp('drifter'), 1000)
+    const improved = { ...bp('drifter'), name: 'Drifter, redrawn' } as CreatureBlueprint
+    rememberSpecies(improved, 2000)
+    expect(archivedSpecies()).toHaveLength(1)
+    expect(archivedSpecies()[0].blueprint.name).toBe('Drifter, redrawn')
+    expect(archivedSpecies()[0].firstSeen).toBe(1000)
+    expect(archivedSpecies()[0].lastSeen).toBe(2000)
+  })
+
+  it('only records a lifespan that beats the species best', () => {
+    rememberSpecies(bp('hopper'), 1000)
+    expect(noteSpeciesLife('hopper', 30)).toBe(true)
+    expect(noteSpeciesLife('hopper', 12)).toBe(false)
+    expect(archivedSpecies()[0].longestLife).toBe(30)
+  })
+
+  it('ignores a lifespan for a species it has never seen', () => {
+    expect(noteSpeciesLife('ghost', 500)).toBe(false)
+  })
+
+  it('prunes the oldest summoned species but never a built-in', () => {
+    rememberSpecies(bp('builtin-hopper'), 1)
+    // One past the cap, oldest first, so the first summoned one is the victim.
+    for (let i = 0; i < 81; i++) rememberSpecies(bp(`summoned-${i}`, true), 100 + i)
+
+    const ids = new Set(archivedSpecies().map((s) => s.blueprint.id))
+    expect(ids.has('builtin-hopper')).toBe(true)
+    expect(ids.has('summoned-0')).toBe(false)
+    expect(ids.has('summoned-80')).toBe(true)
+    expect(archivedSpecies().filter((s) => s.blueprint.summoned)).toHaveLength(80)
+  })
+})
+
+describe('milestones', () => {
+  it('fires once and never again', () => {
+    expect(claimMilestone('first-elder', 5000)).toBe(true)
+    expect(claimMilestone('first-elder', 9000)).toBe(false)
+    expect(readChronicle().milestones['first-elder']).toBe(5000)
+  })
+})
+
+describe('mergeChronicles', () => {
+  it('keeps the longer life, whichever side it came from', () => {
+    const a = emptyChronicle()
+    a.lands.tidepool = {
+      ...emptyLandRecord(),
+      elder: {
+        seconds: 100,
+        blueprintId: 'crab',
+        speciesName: 'Crab',
+        name: null,
+        at: 1,
+      },
+    }
+    const b = emptyChronicle()
+    b.lands.tidepool = {
+      ...emptyLandRecord(),
+      elder: {
+        seconds: 300,
+        blueprintId: 'crab',
+        speciesName: 'Crab',
+        name: 'Steve',
+        at: 2,
+      },
+    }
+    expect(mergeChronicles(a, b).lands.tidepool.elder?.name).toBe('Steve')
+    // Order must not matter — sign-in can merge either direction.
+    expect(mergeChronicles(b, a).lands.tidepool.elder?.name).toBe('Steve')
+  })
+
+  it('takes the high-water mark of each record independently', () => {
+    const a = emptyChronicle()
+    a.lands.tidepool = {
+      ...emptyLandRecord(),
+      steadySeconds: 900,
+      generations: 3,
+      generationsBlueprintId: 'crab',
+      generationsSpeciesName: 'Crab',
+    }
+    const b = emptyChronicle()
+    b.lands.tidepool = {
+      ...emptyLandRecord(),
+      steadySeconds: 120,
+      generations: 11,
+      generationsBlueprintId: 'kelp',
+      generationsSpeciesName: 'Kelp',
+    }
+
+    const merged = mergeChronicles(a, b).lands.tidepool
+    expect(merged.steadySeconds).toBe(900)
+    expect(merged.generations).toBe(11)
+    // The species has to travel with the number it belongs to.
+    expect(merged.generationsSpeciesName).toBe('Kelp')
+  })
+
+  it('unions the archive and keeps the earliest milestone', () => {
+    const a = emptyChronicle()
+    a.species.crab = {
+      blueprint: bp('crab'),
+      firstSeen: 50,
+      lastSeen: 60,
+      longestLife: 10,
+    }
+    a.milestones['first-elder'] = 900
+
+    const b = emptyChronicle()
+    b.species.kelp = {
+      blueprint: bp('kelp'),
+      firstSeen: 10,
+      lastSeen: 20,
+      longestLife: 5,
+    }
+    b.species.crab = {
+      blueprint: bp('crab'),
+      firstSeen: 5,
+      lastSeen: 400,
+      longestLife: 7,
+    }
+    b.milestones['first-elder'] = 100
+
+    const merged = mergeChronicles(a, b)
+    expect(Object.keys(merged.species).sort()).toEqual(['crab', 'kelp'])
+    expect(merged.species.crab.firstSeen).toBe(5)
+    expect(merged.species.crab.lastSeen).toBe(400)
+    expect(merged.species.crab.longestLife).toBe(10)
+    // A first is a first — the earlier timestamp wins.
+    expect(merged.milestones['first-elder']).toBe(100)
+  })
+
+  it('carries over a land only one side has ever visited', () => {
+    const a = emptyChronicle()
+    a.lands.tidepool = { ...emptyLandRecord(), steadySeconds: 30 }
+    const b = emptyChronicle()
+    b.lands.volcanic = { ...emptyLandRecord(), steadySeconds: 70 }
+
+    const merged = mergeChronicles(a, b)
+    expect(merged.lands.tidepool.steadySeconds).toBe(30)
+    expect(merged.lands.volcanic.steadySeconds).toBe(70)
+  })
+})

--- a/src/app/micro-land/chronicle/backend.ts
+++ b/src/app/micro-land/chronicle/backend.ts
@@ -1,0 +1,86 @@
+/**
+ * Where the chronicle is actually kept.
+ *
+ * This is the seam that makes the eventual move to accounts a swap rather than a
+ * rewrite. Everything above this file talks to a `ChronicleBackend` and never
+ * mentions `localStorage`; when records move to Firebase, a second
+ * implementation lands here and `setBackend` gets called once at startup.
+ *
+ * Both methods are async even though the local one has nothing to await. That is
+ * the deliberate part — a synchronous API today would put `await` into every
+ * call site on the day it moves to the network.
+ */
+import { type ChronicleData, emptyChronicle } from './types'
+
+export interface ChronicleBackend {
+  /** Returns null when nothing has been stored yet. */
+  load(): Promise<ChronicleData | null>
+  save(data: ChronicleData): Promise<void>
+}
+
+const STORAGE_KEY = 'micro-land:chronicle'
+
+/**
+ * Browser-local records: no account, no network, this device only.
+ *
+ * Every access is wrapped, because `localStorage` is not merely empty in
+ * private-mode Safari and locked-down embeds — *reading it throws*. A player
+ * whose browser refuses storage should still get a working game that simply
+ * doesn't remember anything, so failure here is always silent and always
+ * degrades to "no records yet".
+ */
+export const localBackend: ChronicleBackend = {
+  async load() {
+    if (typeof window === 'undefined') return null
+    try {
+      const raw = window.localStorage.getItem(STORAGE_KEY)
+      if (!raw) return null
+      return JSON.parse(raw) as ChronicleData
+    } catch {
+      return null
+    }
+  },
+
+  async save(data) {
+    if (typeof window === 'undefined') return
+    try {
+      window.localStorage.setItem(STORAGE_KEY, JSON.stringify(data))
+    } catch {
+      // Quota exceeded or storage disabled. Records stop persisting; the game
+      // carries on. Nothing here is worth interrupting play over.
+    }
+  },
+}
+
+/** A backend that remembers nothing, for tests and for server rendering. */
+export const nullBackend: ChronicleBackend = {
+  async load() {
+    return null
+  },
+  async save() {},
+}
+
+/**
+ * Sketch of the account-backed backend, for whoever wires it up.
+ *
+ * The shape below is the whole port — one document per user, read once on sign
+ * in, written on the same debounce the local one uses. The interesting work is
+ * not this file, it is deciding what happens to records a player set while
+ * signed out (see the note on `mergeChronicles` in `chronicle.ts`).
+ *
+ *   export function firebaseBackend(uid: string): ChronicleBackend {
+ *     const ref = doc(getFirestore(), 'microLandChronicles', uid)
+ *     return {
+ *       async load() {
+ *         const snap = await getDoc(ref)
+ *         return snap.exists() ? (snap.data() as ChronicleData) : null
+ *       },
+ *       async save(data) {
+ *         await setDoc(ref, data)
+ *       },
+ *     }
+ *   }
+ */
+
+/** Fallback used before `load` has resolved, so readers never see undefined. */
+export const INITIAL_DATA = emptyChronicle()

--- a/src/app/micro-land/chronicle/chronicle.ts
+++ b/src/app/micro-land/chronicle/chronicle.ts
@@ -1,0 +1,290 @@
+/**
+ * The live chronicle: one in-memory copy, written back on a debounce.
+ *
+ * The simulation touches records several times a second — every stats push asks
+ * "is this the oldest thing that has ever lived here?". Serializing to storage
+ * at that rate would be pointless work, so reads and writes hit an in-memory
+ * object and the backend only sees it every few seconds, plus once more when the
+ * page goes away. Losing the last couple of seconds of a record on a hard crash
+ * is an acceptable trade; janking the frame loop is not.
+ */
+import type { CreatureBlueprint } from '@/app/micro-land/domain/types'
+
+import {
+  type ChronicleBackend,
+  INITIAL_DATA,
+  localBackend,
+} from './backend'
+import {
+  CHRONICLE_VERSION,
+  type ChronicleData,
+  type LandRecord,
+  type SpeciesRecord,
+  emptyChronicle,
+  emptyLandRecord,
+} from './types'
+
+/** How long writes are allowed to pile up before they reach the backend. */
+const FLUSH_DEBOUNCE_MS = 4000
+
+/**
+ * Cap on archived *summoned* species.
+ *
+ * Built-ins are bounded by the config and never pruned. Summoned ones are not
+ * bounded by anything — a player could invent hundreds — and each carries its
+ * own pixel art, so the archive is trimmed oldest-sighting-first to keep a
+ * chronicle comfortably inside a `localStorage` quota.
+ */
+const MAX_ARCHIVED_SUMMONED = 80
+
+let data: ChronicleData = INITIAL_DATA
+let backend: ChronicleBackend = localBackend
+let loaded = false
+let dirty = false
+let flushTimer: ReturnType<typeof setTimeout> | null = null
+
+// ---------------------------------------------------------------------------
+// Identity
+// ---------------------------------------------------------------------------
+
+/**
+ * The key a land's records are filed under.
+ *
+ * Built-in themes use their own id, so the tidepool always has one set of
+ * records however many times it is reshaped. A summoned land is keyed by its
+ * *name* rather than the generic `summoned` theme id — the player who described
+ * "a drowned cathedral" should find that land's records again next time they
+ * summon it, not a pile shared with every other invention.
+ */
+export function landId(themeId: string, summonedLandName: string | null): string {
+  if (summonedLandName) {
+    const slug = summonedLandName
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-|-$/g, '')
+      .slice(0, 48)
+    if (slug) return `summoned:${slug}`
+  }
+  return themeId
+}
+
+// ---------------------------------------------------------------------------
+// Lifecycle
+// ---------------------------------------------------------------------------
+
+/** Swap the storage backend. Called once at startup when accounts land. */
+export function setBackend(next: ChronicleBackend): void {
+  backend = next
+  loaded = false
+}
+
+/**
+ * Read the chronicle in. Safe to call more than once; only the first does work.
+ */
+export async function initChronicle(): Promise<ChronicleData> {
+  if (loaded) return data
+  const stored = await backend.load()
+  data = migrate(stored)
+  loaded = true
+  attachFlushOnHide()
+  return data
+}
+
+/**
+ * Bring an old chronicle forward, or start a fresh one.
+ *
+ * There is only one version so far, so anything unrecognized is discarded
+ * rather than guessed at. When version 2 arrives this is where the field-by-
+ * field upgrade goes — and note it must never throw, because a chronicle that
+ * fails to parse should cost the player their records, not their game.
+ */
+function migrate(stored: ChronicleData | null): ChronicleData {
+  if (!stored || typeof stored !== 'object') return emptyChronicle()
+  if (stored.version !== CHRONICLE_VERSION) return emptyChronicle()
+  return {
+    version: CHRONICLE_VERSION,
+    lands: stored.lands ?? {},
+    species: stored.species ?? {},
+    milestones: stored.milestones ?? {},
+  }
+}
+
+export function readChronicle(): ChronicleData {
+  return data
+}
+
+/** Mutate the chronicle in place and schedule a write. */
+export function updateChronicle(mutate: (draft: ChronicleData) => void): void {
+  mutate(data)
+  touch()
+}
+
+/**
+ * Mark the chronicle as needing a write and start the debounce.
+ *
+ * Every mutating helper below calls this itself rather than relying on being
+ * wrapped in `updateChronicle`. An unwritten record is invisible until the
+ * player closes the tab and finds it missing, which is the worst possible time
+ * to discover the invariant was broken.
+ */
+function touch(): void {
+  dirty = true
+  if (flushTimer === null) {
+    flushTimer = setTimeout(() => {
+      flushTimer = null
+      void flushChronicle()
+    }, FLUSH_DEBOUNCE_MS)
+  }
+}
+
+export async function flushChronicle(): Promise<void> {
+  if (!dirty) return
+  dirty = false
+  if (flushTimer !== null) {
+    clearTimeout(flushTimer)
+    flushTimer = null
+  }
+  await backend.save(data)
+}
+
+/**
+ * Write on the way out.
+ *
+ * `visibilitychange` rather than `beforeunload`: on mobile a tab is very often
+ * backgrounded and then killed without ever firing an unload, which is exactly
+ * the case where an unwritten record would be lost.
+ */
+let hideHooked = false
+function attachFlushOnHide(): void {
+  if (hideHooked || typeof document === 'undefined') return
+  hideHooked = true
+  document.addEventListener('visibilitychange', () => {
+    if (document.visibilityState === 'hidden') void flushChronicle()
+  })
+  window.addEventListener('pagehide', () => void flushChronicle())
+}
+
+// ---------------------------------------------------------------------------
+// Accessors
+// ---------------------------------------------------------------------------
+
+/** The record for a land, created on first access. */
+export function landRecord(id: string): LandRecord {
+  const existing = data.lands[id]
+  if (existing) return existing
+  const fresh = emptyLandRecord()
+  data.lands[id] = fresh
+  return fresh
+}
+
+/**
+ * Note that a species was seen alive, archiving its blueprint the first time.
+ *
+ * The blueprint is re-copied on every sighting rather than only on the first:
+ * summoning is non-deterministic, so the same id can come back with better art
+ * or a fixed diet, and the archive should hold the most recent version.
+ */
+export function rememberSpecies(bp: CreatureBlueprint, now: number): void {
+  const existing = data.species[bp.id]
+  if (existing) {
+    existing.lastSeen = now
+    existing.blueprint = bp
+    touch()
+    return
+  }
+  data.species[bp.id] = {
+    blueprint: bp,
+    firstSeen: now,
+    lastSeen: now,
+    longestLife: 0,
+  }
+  pruneArchive()
+  touch()
+}
+
+/** Record a lifespan against a species, if it beats what that species has done. */
+export function noteSpeciesLife(blueprintId: string, seconds: number): boolean {
+  const record = data.species[blueprintId]
+  if (!record || seconds <= record.longestLife) return false
+  record.longestLife = seconds
+  touch()
+  return true
+}
+
+/** Every archived species, newest sighting first. */
+export function archivedSpecies(): SpeciesRecord[] {
+  return Object.values(data.species).sort((a, b) => b.lastSeen - a.lastSeen)
+}
+
+/** True if this milestone has never fired before; marks it fired if so. */
+export function claimMilestone(id: string, now: number): boolean {
+  if (data.milestones[id]) return false
+  data.milestones[id] = now
+  touch()
+  return true
+}
+
+function pruneArchive(): void {
+  const summoned = Object.values(data.species).filter((s) => s.blueprint.summoned)
+  if (summoned.length <= MAX_ARCHIVED_SUMMONED) return
+  summoned.sort((a, b) => a.lastSeen - b.lastSeen)
+  const excess = summoned.length - MAX_ARCHIVED_SUMMONED
+  for (let i = 0; i < excess; i++) delete data.species[summoned[i].blueprint.id]
+}
+
+// ---------------------------------------------------------------------------
+// For the account-backed future
+// ---------------------------------------------------------------------------
+
+/**
+ * Combine two chronicles, keeping the better of each record.
+ *
+ * Unused today, and written now because it is the one genuinely hard part of
+ * moving to accounts: a player will arrive at sign-in holding records they set
+ * anonymously, and throwing those away is the wrong answer. Records are all
+ * high-water marks, so "keep the larger" merges cleanly — no conflict, no
+ * prompt. Milestones keep the earlier timestamp; a first is a first.
+ */
+export function mergeChronicles(a: ChronicleData, b: ChronicleData): ChronicleData {
+  const merged = emptyChronicle()
+
+  for (const id of new Set([...Object.keys(a.lands), ...Object.keys(b.lands)])) {
+    const left = a.lands[id] ?? emptyLandRecord()
+    const right = b.lands[id] ?? emptyLandRecord()
+    const deeper = right.generations > left.generations ? right : left
+    merged.lands[id] = {
+      elder:
+        (right.elder?.seconds ?? 0) > (left.elder?.seconds ?? 0)
+          ? right.elder
+          : left.elder,
+      steadySeconds: Math.max(left.steadySeconds, right.steadySeconds),
+      generations: deeper.generations,
+      generationsBlueprintId: deeper.generationsBlueprintId,
+      generationsSpeciesName: deeper.generationsSpeciesName,
+    }
+  }
+
+  for (const id of new Set([...Object.keys(a.species), ...Object.keys(b.species)])) {
+    const left = a.species[id]
+    const right = b.species[id]
+    if (!left || !right) {
+      merged.species[id] = (left ?? right) as SpeciesRecord
+      continue
+    }
+    merged.species[id] = {
+      // The more recently seen copy is the more current art.
+      blueprint: right.lastSeen > left.lastSeen ? right.blueprint : left.blueprint,
+      firstSeen: Math.min(left.firstSeen, right.firstSeen),
+      lastSeen: Math.max(left.lastSeen, right.lastSeen),
+      longestLife: Math.max(left.longestLife, right.longestLife),
+    }
+  }
+
+  for (const id of new Set([...Object.keys(a.milestones), ...Object.keys(b.milestones)])) {
+    const left = a.milestones[id] ?? Infinity
+    const right = b.milestones[id] ?? Infinity
+    merged.milestones[id] = Math.min(left, right)
+  }
+
+  return merged
+}

--- a/src/app/micro-land/chronicle/types.ts
+++ b/src/app/micro-land/chronicle/types.ts
@@ -1,0 +1,101 @@
+/**
+ * The chronicle — everything Micro Land remembers between visits.
+ *
+ * The world itself stays deliberately forgetful: close the tab and the land is
+ * gone. What survives is the *record* of it — who lived longest, how long a food
+ * web held together, every species you ever saw. That split is the whole design.
+ * You are not keeping a save file, you are keeping a logbook.
+ *
+ * Every type here is plain JSON on purpose: no `Map`, no `Set`, no class, and
+ * `null` rather than `undefined` anywhere a field can be absent. Today this
+ * round-trips through `localStorage`; the plan is for it to round-trip through a
+ * Firebase document keyed by user id instead, and when that happens the only
+ * thing that should have to change is the backend (see `backend.ts`). Anything
+ * that isn't serializable breaks that promise.
+ */
+import type { CreatureBlueprint } from '@/app/micro-land/domain/types'
+
+/**
+ * Bump only when a shape change would make an old chronicle *misread* rather
+ * than merely come up short. Adding an optional field is not a version bump;
+ * changing what an existing field means is. See `migrate` in `chronicle.ts`.
+ */
+export const CHRONICLE_VERSION = 1
+
+/** The single longest life a land has ever held. */
+export interface ElderRecord {
+  /** Age reached, in world-seconds. */
+  seconds: number
+  blueprintId: string
+  /**
+   * Species name copied at the time of the record.
+   *
+   * Denormalized on purpose: a summoned species can fall out of the archive
+   * (see `MAX_ARCHIVED` in `chronicle.ts`) and a record that renders as
+   * "unknown creature" is worse than one that carries its own name.
+   */
+  speciesName: string
+  /** What the player called it, if they named it. */
+  name: string | null
+  /** Epoch ms the record was set. */
+  at: number
+}
+
+/**
+ * What one land remembers.
+ *
+ * Kept per land rather than globally because these numbers only mean something
+ * relative to their world — six minutes alive in a tidepool and six minutes in a
+ * volcanic field are not the same achievement.
+ */
+export interface LandRecord {
+  elder: ElderRecord | null
+  /** Longest stretch, in world-seconds, that passed without an extinction. */
+  steadySeconds: number
+  /** Deepest unbroken family line ever reached here, in generations. */
+  generations: number
+  generationsBlueprintId: string | null
+  generationsSpeciesName: string | null
+}
+
+/**
+ * A species the player has seen alive at least once, in any land.
+ *
+ * The blueprint is archived *in full*, which is the entire point: a summoned
+ * creature currently evaporates on refresh, and this is where it stops doing
+ * that. Blueprints are small — a palette and a few rows of characters — so
+ * carrying them costs little.
+ */
+export interface SpeciesRecord {
+  blueprint: CreatureBlueprint
+  /** Epoch ms of the first sighting. */
+  firstSeen: number
+  /** Epoch ms of the most recent sighting. Drives archive pruning. */
+  lastSeen: number
+  /** Longest one of these has ever lived, in world-seconds. */
+  longestLife: number
+}
+
+export interface ChronicleData {
+  version: number
+  /** Land id → what that land remembers. Ids come from `landId()`. */
+  lands: Record<string, LandRecord>
+  /** Blueprint id → the archived species. */
+  species: Record<string, SpeciesRecord>
+  /** Milestone id → epoch ms first reached. Milestones fire once, ever. */
+  milestones: Record<string, number>
+}
+
+export function emptyChronicle(): ChronicleData {
+  return { version: CHRONICLE_VERSION, lands: {}, species: {}, milestones: {} }
+}
+
+export function emptyLandRecord(): LandRecord {
+  return {
+    elder: null,
+    steadySeconds: 0,
+    generations: 0,
+    generationsBlueprintId: null,
+    generationsSpeciesName: null,
+  }
+}

--- a/src/app/micro-land/components/field-guide.tsx
+++ b/src/app/micro-land/components/field-guide.tsx
@@ -1,9 +1,13 @@
 'use client'
 
+import type { SpeciesRecord } from '@/app/micro-land/chronicle/types'
 import { canEat } from '@/app/micro-land/domain/blueprint'
+import type { CreatureBlueprint } from '@/app/micro-land/domain/types'
+import { formatDuration } from '@/app/micro-land/format'
 import { useMicroLand } from '@/app/micro-land/store'
 
 import { CreaturePortrait } from './creature-chip'
+
 
 const KIND_WORDS: Record<string, string> = {
   walk: 'walks',
@@ -14,18 +18,42 @@ const KIND_WORDS: Record<string, string> = {
   root: 'stays put',
 }
 
+const sectionHeading: React.CSSProperties = {
+  fontFamily: 'var(--cc-font-mono)',
+  fontSize: 10,
+  letterSpacing: 2,
+  textTransform: 'uppercase',
+  color: 'var(--cc-text-muted)',
+}
+
+const recordLabel: React.CSSProperties = {
+  fontFamily: 'var(--cc-font-mono)',
+  fontSize: 9,
+  letterSpacing: 1.2,
+  textTransform: 'uppercase',
+  color: 'var(--cc-text-muted)',
+}
+
 /**
- * The field guide.
+ * The field guide — and, behind the same tap, the logbook.
  *
  * Every relationship shown here is derived from the same `canEat` rule the
  * simulation uses, so a creature summoned thirty seconds ago is described as
  * accurately as one that shipped with the game.
+ *
+ * The records, the remembered species and the milestones all live in here
+ * rather than anywhere on the main screen. That is deliberate: the world stays a
+ * world, and everything the game has been quietly counting is one tap away for
+ * whoever wants it.
  */
 export function FieldGuide() {
   const open = useMicroLand((s) => s.guideOpen)
   const setOpen = useMicroLand((s) => s.setGuideOpen)
   const blueprints = useMicroLand((s) => s.blueprints)
   const population = useMicroLand((s) => s.population)
+  const records = useMicroLand((s) => s.records)
+  const archive = useMicroLand((s) => s.archive)
+  const milestones = useMicroLand((s) => s.milestones)
 
   if (!open) return null
 
@@ -33,6 +61,16 @@ export function FieldGuide() {
   const ordered = [...blueprints].sort(
     (a, b) => (counts.get(b.id) ?? 0) - (counts.get(a.id) ?? 0)
   )
+
+  // Species the player has met before that aren't in this world — the reason a
+  // summoned creature no longer dies with the tab it was invented in.
+  const here = new Set(blueprints.map((b) => b.id))
+  const remembered = archive.filter((s) => !here.has(s.blueprint.id))
+
+  const hasRecords =
+    records.elder !== null ||
+    records.bestSteadySeconds > 0 ||
+    records.bestGenerations > 1
 
   return (
     <div
@@ -81,96 +119,280 @@ export function FieldGuide() {
           </button>
         </div>
 
-        <ul className="flex flex-col">
-          {ordered.map((bp) => {
-            const eats = blueprints.filter((other) => canEat(bp, other))
-            const eatenBy = blueprints.filter((other) => canEat(other, bp))
-            const alive = counts.get(bp.id) ?? 0
+        {hasRecords && (
+          <section
+            className="flex flex-col gap-2.5 px-4 py-3"
+            style={{ borderBottom: '1px solid var(--cc-panel-divider)' }}
+          >
+            <h3 style={sectionHeading}>This land&rsquo;s records</h3>
 
-            return (
-              <li
-                key={bp.id}
-                className="flex gap-3 px-4 py-3"
-                style={{ borderBottom: '1px solid var(--cc-panel-divider)' }}
-              >
-                <div className="shrink-0 pt-0.5">
-                  <CreaturePortrait blueprint={bp} size={40} />
-                </div>
-                <div className="min-w-0 flex-1">
-                  <div className="flex flex-wrap items-baseline gap-x-2 gap-y-1">
-                    <span
-                      style={{
-                        fontFamily: 'var(--cc-font-mono)',
-                        fontSize: 12,
-                        letterSpacing: 1.4,
-                        textTransform: 'uppercase',
-                        color: alive > 0 ? 'var(--cc-mint)' : 'var(--cc-text-muted)',
-                      }}
-                    >
-                      {bp.name}
-                    </span>
-                    <span
-                      style={{
-                        fontFamily: 'var(--cc-font-mono)',
-                        fontSize: 10,
-                        color: alive > 0 ? 'var(--cc-text-muted)' : 'var(--cc-pink)',
-                      }}
-                    >
-                      {alive > 0 ? `${alive} alive` : 'none left'}
-                    </span>
-                    {bp.summoned && (
-                      <span
-                        style={{
-                          fontFamily: 'var(--cc-font-mono)',
-                          fontSize: 9,
-                          letterSpacing: 1.2,
-                          textTransform: 'uppercase',
-                          padding: '2px 6px',
-                          borderRadius: 999,
-                          color: 'var(--cc-pink)',
-                          border: '1px solid var(--cc-pink-border)',
-                        }}
-                      >
-                        Summoned
-                      </span>
+            {records.elder && (
+              <div className="flex flex-col gap-0.5">
+                <span style={recordLabel}>Longest life</span>
+                <span style={{ fontSize: 13, color: 'var(--cc-gold)' }}>
+                  {formatDuration(records.elder.seconds)}
+                  <span style={{ color: 'var(--cc-text-muted)' }}>
+                    {' — '}
+                    {records.elder.name
+                      ? `${records.elder.name}, a ${records.elder.speciesName}`
+                      : records.elder.speciesName}
+                  </span>
+                </span>
+              </div>
+            )}
+
+            {records.bestSteadySeconds > 0 && (
+              <div className="flex flex-col gap-0.5">
+                <span style={recordLabel}>Longest without losing a kind</span>
+                <span style={{ fontSize: 13, color: 'var(--cc-text-default)' }}>
+                  {formatDuration(records.bestSteadySeconds)}
+                  {records.steadySeconds >= records.bestSteadySeconds &&
+                    records.steadySeconds > 0 && (
+                      <span style={{ color: 'var(--cc-gold)' }}> — going now</span>
                     )}
-                  </div>
+                </span>
+              </div>
+            )}
 
-                  <p style={{ fontSize: 13, color: 'var(--cc-text-muted)', marginTop: 2 }}>
-                    {bp.blurb}
-                  </p>
+            {records.bestGenerations > 1 && (
+              <div className="flex flex-col gap-0.5">
+                <span style={recordLabel}>Deepest family line</span>
+                <span style={{ fontSize: 13, color: 'var(--cc-text-default)' }}>
+                  {records.bestGenerations} generations
+                  {records.bestGenerationsSpeciesName && (
+                    <span style={{ color: 'var(--cc-text-muted)' }}>
+                      {' — '}
+                      {records.bestGenerationsSpeciesName}
+                    </span>
+                  )}
+                </span>
+              </div>
+            )}
+          </section>
+        )}
 
-                  <p
+        <ul className="flex flex-col">
+          {ordered.map((bp) => (
+            <GuideEntry
+              key={bp.id}
+              bp={bp}
+              alive={counts.get(bp.id) ?? 0}
+              blueprints={blueprints}
+            />
+          ))}
+        </ul>
+
+        {remembered.length > 0 && (
+          <section style={{ borderTop: '1px solid var(--cc-panel-divider)' }}>
+            <h3 className="px-4 pb-1 pt-3" style={sectionHeading}>
+              Remembered · {remembered.length}
+            </h3>
+            <p
+              className="px-4 pb-2"
+              style={{ fontSize: 12, color: 'var(--cc-text-muted)', opacity: 0.8 }}
+            >
+              Kinds you have met before. None of them are in this land.
+            </p>
+            <ul className="flex flex-col">
+              {remembered.map((record) => (
+                <RememberedEntry key={record.blueprint.id} record={record} />
+              ))}
+            </ul>
+          </section>
+        )}
+
+        {milestones.length > 0 && (
+          <section
+            className="px-4 py-3"
+            style={{ borderTop: '1px solid var(--cc-panel-divider)' }}
+          >
+            <h3 className="pb-2" style={sectionHeading}>
+              Things that have happened
+            </h3>
+            <ul className="flex flex-col gap-1.5">
+              {milestones.map((m) => (
+                <li
+                  key={m.id}
+                  className="flex items-baseline justify-between gap-3"
+                  style={{ fontSize: 12, color: 'var(--cc-text-muted)' }}
+                >
+                  <span>{m.text}</span>
+                  <span
                     style={{
-                      fontSize: 12,
-                      color: 'var(--cc-text-muted)',
-                      opacity: 0.85,
-                      marginTop: 6,
-                      lineHeight: 1.6,
+                      fontFamily: 'var(--cc-font-mono)',
+                      fontSize: 10,
+                      opacity: 0.6,
+                      whiteSpace: 'nowrap',
                     }}
                   >
-                    Size {bp.size} · {KIND_WORDS[bp.move.kind] ?? bp.move.kind}
-                    {bp.body.immuneTo.length > 0 && ` · unburnable`}
-                    {bp.glow > 0 && ` · glows`}
-                    {bp.dig.through.length > 0 &&
-                      ` · digs through ${bp.dig.through.join(', ')}`}
-                    <br />
-                    <strong style={{ fontWeight: 600 }}>Eats:</strong>{' '}
-                    {eats.length > 0
-                      ? eats.map((e) => e.name).join(', ')
-                      : bp.move.kind === 'root'
-                        ? 'sunlight'
-                        : 'nothing here'}
-                    <br />
-                    <strong style={{ fontWeight: 600 }}>Eaten by:</strong>{' '}
-                    {eatenBy.length > 0 ? eatenBy.map((e) => e.name).join(', ') : 'nothing here'}
-                  </p>
-                </div>
-              </li>
-            )
-          })}
-        </ul>
+                    {new Date(m.at).toLocaleDateString()}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          </section>
+        )}
       </div>
     </div>
+  )
+}
+
+function GuideEntry({
+  bp,
+  alive,
+  blueprints,
+}: {
+  bp: CreatureBlueprint
+  alive: number
+  blueprints: CreatureBlueprint[]
+}) {
+  const eats = blueprints.filter((other) => canEat(bp, other))
+  const eatenBy = blueprints.filter((other) => canEat(other, bp))
+
+  return (
+    <li
+      className="flex gap-3 px-4 py-3"
+      style={{ borderBottom: '1px solid var(--cc-panel-divider)' }}
+    >
+      <div className="shrink-0 pt-0.5">
+        <CreaturePortrait blueprint={bp} size={40} />
+      </div>
+      <div className="min-w-0 flex-1">
+        <div className="flex flex-wrap items-baseline gap-x-2 gap-y-1">
+          <span
+            style={{
+              fontFamily: 'var(--cc-font-mono)',
+              fontSize: 12,
+              letterSpacing: 1.4,
+              textTransform: 'uppercase',
+              color: alive > 0 ? 'var(--cc-mint)' : 'var(--cc-text-muted)',
+            }}
+          >
+            {bp.name}
+          </span>
+          <span
+            style={{
+              fontFamily: 'var(--cc-font-mono)',
+              fontSize: 10,
+              color: alive > 0 ? 'var(--cc-text-muted)' : 'var(--cc-pink)',
+            }}
+          >
+            {alive > 0 ? `${alive} alive` : 'none left'}
+          </span>
+          {bp.summoned && (
+            <span
+              style={{
+                fontFamily: 'var(--cc-font-mono)',
+                fontSize: 9,
+                letterSpacing: 1.2,
+                textTransform: 'uppercase',
+                padding: '2px 6px',
+                borderRadius: 999,
+                color: 'var(--cc-pink)',
+                border: '1px solid var(--cc-pink-border)',
+              }}
+            >
+              Summoned
+            </span>
+          )}
+        </div>
+
+        <p style={{ fontSize: 13, color: 'var(--cc-text-muted)', marginTop: 2 }}>
+          {bp.blurb}
+        </p>
+
+        <p
+          style={{
+            fontSize: 12,
+            color: 'var(--cc-text-muted)',
+            opacity: 0.85,
+            marginTop: 6,
+            lineHeight: 1.6,
+          }}
+        >
+          Size {bp.size} · {KIND_WORDS[bp.move.kind] ?? bp.move.kind}
+          {bp.body.immuneTo.length > 0 && ` · unburnable`}
+          {bp.glow > 0 && ` · glows`}
+          {bp.dig.through.length > 0 && ` · digs through ${bp.dig.through.join(', ')}`}
+          <br />
+          <strong style={{ fontWeight: 600 }}>Eats:</strong>{' '}
+          {eats.length > 0
+            ? eats.map((e) => e.name).join(', ')
+            : bp.move.kind === 'root'
+              ? 'sunlight'
+              : 'nothing here'}
+          <br />
+          <strong style={{ fontWeight: 600 }}>Eaten by:</strong>{' '}
+          {eatenBy.length > 0 ? eatenBy.map((e) => e.name).join(', ') : 'nothing here'}
+        </p>
+      </div>
+    </li>
+  )
+}
+
+/**
+ * A species from a past visit.
+ *
+ * Says less than a live entry on purpose: who eats whom is a fact about *this*
+ * world, and repeating it for a creature that isn't here would be describing a
+ * food chain that doesn't exist.
+ */
+function RememberedEntry({ record }: { record: SpeciesRecord }) {
+  const bp = record.blueprint
+  return (
+    <li
+      className="flex gap-3 px-4 py-2.5"
+      style={{ borderBottom: '1px solid var(--cc-panel-divider)', opacity: 0.62 }}
+    >
+      <div className="shrink-0 pt-0.5">
+        <CreaturePortrait blueprint={bp} size={30} />
+      </div>
+      <div className="min-w-0 flex-1">
+        <div className="flex flex-wrap items-baseline gap-x-2 gap-y-1">
+          <span
+            style={{
+              fontFamily: 'var(--cc-font-mono)',
+              fontSize: 11,
+              letterSpacing: 1.4,
+              textTransform: 'uppercase',
+              color: 'var(--cc-text-muted)',
+            }}
+          >
+            {bp.name}
+          </span>
+          {bp.summoned && (
+            <span
+              style={{
+                fontFamily: 'var(--cc-font-mono)',
+                fontSize: 9,
+                letterSpacing: 1.2,
+                textTransform: 'uppercase',
+                padding: '1px 5px',
+                borderRadius: 999,
+                color: 'var(--cc-pink)',
+                border: '1px solid var(--cc-pink-border)',
+              }}
+            >
+              Summoned
+            </span>
+          )}
+        </div>
+        <p style={{ fontSize: 12, color: 'var(--cc-text-muted)', marginTop: 1 }}>
+          {bp.blurb}
+        </p>
+        <p
+          style={{
+            fontFamily: 'var(--cc-font-mono)',
+            fontSize: 10,
+            color: 'var(--cc-text-muted)',
+            opacity: 0.75,
+            marginTop: 4,
+          }}
+        >
+          First seen {new Date(record.firstSeen).toLocaleDateString()}
+          {record.longestLife > 0 && ` · lived ${formatDuration(record.longestLife)}`}
+        </p>
+      </div>
+    </li>
   )
 }

--- a/src/app/micro-land/components/hud.tsx
+++ b/src/app/micro-land/components/hud.tsx
@@ -1,6 +1,8 @@
 'use client'
 
 import { THEMES } from '@/app/micro-land/domain/config/themes'
+import { STEADY_SHOW_SECONDS } from '@/app/micro-land/domain/constants'
+import { formatDuration } from '@/app/micro-land/format'
 import { SUMMONED_THEME_ID, useMicroLand } from '@/app/micro-land/store'
 
 const SPEEDS = [
@@ -45,8 +47,12 @@ export function Hud({
   const population = useMicroLand((s) => s.population)
   const setGuideOpen = useMicroLand((s) => s.setGuideOpen)
   const summonedLand = useMicroLand((s) => s.summonedLand)
+  const steadySeconds = useMicroLand((s) => s.records.steadySeconds)
 
   const species = population.length
+  // Below the threshold this would flicker on and off through the early churn,
+  // which reads as a broken counter rather than as a streak.
+  const steady = steadySeconds >= STEADY_SHOW_SECONDS ? formatDuration(steadySeconds) : null
 
   return (
     <header
@@ -137,8 +143,19 @@ export function Hud({
           className="cc-btn"
           onClick={() => setGuideOpen(true)}
           style={chipBase}
+          title={
+            steady
+              ? 'How long this land has gone without losing a species'
+              : undefined
+          }
         >
           {species} kinds · {total} alive
+          {steady && (
+            <>
+              {' · '}
+              <span style={{ color: 'var(--cc-gold)' }}>{steady} steady</span>
+            </>
+          )}
         </button>
         <button
           type="button"

--- a/src/app/micro-land/components/inspector.tsx
+++ b/src/app/micro-land/components/inspector.tsx
@@ -1,5 +1,7 @@
 'use client'
 
+import { useState } from 'react'
+
 import { canEat } from '@/app/micro-land/domain/blueprint'
 import { useMicroLand } from '@/app/micro-land/store'
 
@@ -79,12 +81,24 @@ const meterLabel: React.CSSProperties = {
  * creature summoned a moment ago reports exactly as completely as a built-in —
  * including who eats it, which is derived from `canEat` rather than authored.
  */
-export function Inspector() {
+export function Inspector({ onName }: { onName: (name: string) => boolean }) {
   const inspected = useMicroLand((s) => s.inspected)
   const blueprints = useMicroLand((s) => s.blueprints)
   const setTool = useMicroLand((s) => s.setTool)
 
+  /**
+   * The half-typed name, tagged with who it is for.
+   *
+   * Keyed by creature id rather than reset in an effect: tapping a second
+   * creature mid-type has to abandon the name, and deriving that from the id
+   * makes it true on the same render instead of one render later.
+   */
+  const [pending, setPending] = useState<{ id: number; text: string } | null>(null)
+
   if (!inspected) return null
+
+  const naming = pending?.id === inspected.id
+  const draft = naming ? pending.text : ''
 
   const bp = blueprints.find((b) => b.id === inspected.blueprintId)
   if (!bp) return null
@@ -133,10 +147,10 @@ export function Inspector() {
               color: 'var(--cc-mint)',
             }}
           >
-            {bp.name}
+            {inspected.name ?? bp.name}
           </div>
           <div style={{ fontSize: 11, color: 'var(--cc-text-muted)', lineHeight: 1.4 }}>
-            {bp.blurb}
+            {inspected.name ? bp.name : bp.blurb}
           </div>
         </div>
         <button
@@ -152,6 +166,101 @@ export function Inspector() {
       </div>
 
       <div className="flex flex-col gap-2.5 p-3">
+        {/*
+          The elder band is the only thing in this panel that isn't a fact about
+          the creature — it's the game acknowledging one. It appears for exactly
+          one creature at a time and nowhere else in the UI.
+        */}
+        {inspected.isElder && (
+          <div
+            className="flex flex-col gap-1.5 rounded px-2.5 py-2"
+            style={{
+              background: 'rgba(252, 211, 77, 0.08)',
+              border: '1px solid rgba(252, 211, 77, 0.35)',
+            }}
+          >
+            <div
+              style={{
+                fontFamily: 'var(--cc-font-mono)',
+                fontSize: 9,
+                letterSpacing: 1.2,
+                textTransform: 'uppercase',
+                color: 'var(--cc-gold)',
+              }}
+            >
+              ✦ Oldest this land remembers
+            </div>
+
+            {inspected.name ? null : naming ? (
+              <form
+                className="flex gap-1.5"
+                onSubmit={(e) => {
+                  e.preventDefault()
+                  if (onName(draft)) setPending(null)
+                }}
+              >
+                <label className="sr-only" htmlFor="micro-land-elder-name">
+                  Name this creature
+                </label>
+                <input
+                  id="micro-land-elder-name"
+                  autoFocus
+                  value={draft}
+                  onChange={(e) => setPending({ id: inspected.id, text: e.target.value })}
+                  maxLength={24}
+                  placeholder="Call it something"
+                  className="min-w-0 flex-1 rounded px-2 py-1"
+                  style={{
+                    fontSize: 12,
+                    color: 'var(--cc-text-default)',
+                    background: 'rgba(0,0,0,0.4)',
+                    border: '1px solid var(--cc-mint-line)',
+                  }}
+                  // The canvas grabs creatures on pointerdown; without this,
+                  // tapping the field throws whatever is underneath it.
+                  onPointerDown={(e) => e.stopPropagation()}
+                />
+                <button
+                  type="submit"
+                  className="cc-btn"
+                  disabled={draft.trim().length === 0}
+                  style={{
+                    fontFamily: 'var(--cc-font-mono)',
+                    fontSize: 10,
+                    letterSpacing: 1,
+                    textTransform: 'uppercase',
+                    padding: '4px 8px',
+                    color: 'var(--cc-gold)',
+                    border: '1px solid rgba(252, 211, 77, 0.35)',
+                    opacity: draft.trim().length === 0 ? 0.4 : 1,
+                  }}
+                  onPointerDown={(e) => e.stopPropagation()}
+                >
+                  Name
+                </button>
+              </form>
+            ) : (
+              <button
+                type="button"
+                className="cc-btn self-start"
+                onClick={() => setPending({ id: inspected.id, text: '' })}
+                style={{
+                  fontFamily: 'var(--cc-font-mono)',
+                  fontSize: 10,
+                  letterSpacing: 1,
+                  textTransform: 'uppercase',
+                  padding: '4px 8px',
+                  color: 'var(--cc-gold)',
+                  border: '1px solid rgba(252, 211, 77, 0.35)',
+                }}
+                onPointerDown={(e) => e.stopPropagation()}
+              >
+                Give it a name
+              </button>
+            )}
+          </div>
+        )}
+
         <div
           style={{
             fontFamily: 'var(--cc-font-mono)',
@@ -186,6 +295,14 @@ export function Inspector() {
           <Stat label="Babies" value={String(inspected.children)} />
           <Stat label="Size" value={String(bp.size)} />
           <Stat label="Speed" value={inspected.speed.toFixed(1)} />
+          {/*
+            Hidden at generation 1, which is every creature you place by hand.
+            It appears the first time you're looking at something that was *born*
+            here, which is the only point at which the number means anything.
+          */}
+          {inspected.generation > 1 && (
+            <Stat label="Generation" value={String(inspected.generation)} />
+          )}
           {bp.dig.through.length > 0 && (
             <Stat label="Tiles dug" value={String(inspected.tilesDug)} />
           )}

--- a/src/app/micro-land/domain/config/milestones.ts
+++ b/src/app/micro-land/domain/config/milestones.ts
@@ -1,0 +1,105 @@
+/**
+ * Milestones — the game noticing you, once.
+ *
+ * These deliberately have no screen of their own. A milestone arrives as one
+ * line in the same notice strip that already reports hunts and extinctions, and
+ * afterwards it lives in the back of the field guide. There is no badge, no
+ * progress bar, and nothing to collect on purpose: the whole mechanism is the
+ * world remarking on something you did and then getting on with it.
+ *
+ * They fire once ever, not once per land. Seeing "a family line five deep" in
+ * every world you open would turn a discovery into a chore.
+ */
+
+/** Everything a milestone is allowed to look at. All counts are current. */
+export interface MilestoneContext {
+  /** World-seconds this land has been running. */
+  elapsed: number
+  /** World-seconds since the last extinction here. */
+  steadySeconds: number
+  /** Age of the oldest thing currently alive. */
+  oldestSeconds: number
+  /** Deepest generation currently alive. */
+  generations: number
+  /** Distinct species currently alive. */
+  speciesAlive: number
+  /** Living things right now. */
+  total: number
+  /** Species in the field guide archive. */
+  archived: number
+  /** How many of those the player summoned. */
+  summonedArchived: number
+}
+
+export interface Milestone {
+  id: string
+  /** Shown as a notice when it fires, and in the field guide from then on. */
+  text: string
+  reached: (c: MilestoneContext) => boolean
+}
+
+/**
+ * Ordered loosely by when a player is likely to meet them. Order only affects
+ * the field guide listing — the checks are independent.
+ */
+export const MILESTONES: Milestone[] = [
+  {
+    id: 'first-elder',
+    text: 'Something here has grown old.',
+    reached: (c) => c.oldestSeconds >= 60,
+  },
+  {
+    id: 'many-kinds',
+    text: 'Eight kinds sharing one land.',
+    reached: (c) => c.speciesAlive >= 8,
+  },
+  {
+    id: 'steady-3m',
+    text: 'Three minutes, and nothing has died out.',
+    reached: (c) => c.steadySeconds >= 180,
+  },
+  {
+    id: 'gen-5',
+    text: 'A family line five deep.',
+    reached: (c) => c.generations >= 5,
+  },
+  {
+    id: 'guide-12',
+    text: 'Twelve kinds recorded in the field guide.',
+    reached: (c) => c.archived >= 12,
+  },
+  {
+    id: 'elder-5m',
+    text: 'One creature has lived five whole minutes.',
+    reached: (c) => c.oldestSeconds >= 300,
+  },
+  {
+    id: 'summoned-5',
+    text: 'Five creatures of your own invention, remembered.',
+    reached: (c) => c.summonedArchived >= 5,
+  },
+  {
+    id: 'crowded',
+    text: 'Two hundred and fifty living things at once.',
+    reached: (c) => c.total >= 250,
+  },
+  {
+    id: 'steady-10m',
+    text: 'Ten minutes steady. This web holds.',
+    reached: (c) => c.steadySeconds >= 600,
+  },
+  {
+    id: 'gen-12',
+    text: 'Twelve generations. None of the first are left.',
+    reached: (c) => c.generations >= 12,
+  },
+  {
+    id: 'guide-30',
+    text: 'Thirty kinds. The field guide is getting heavy.',
+    reached: (c) => c.archived >= 30,
+  },
+]
+
+export const MILESTONE_BY_ID: Record<string, Milestone> = Object.fromEntries(
+  MILESTONES.map((m) => [m.id, m])
+)

--- a/src/app/micro-land/domain/constants.ts
+++ b/src/app/micro-land/domain/constants.ts
@@ -98,3 +98,27 @@ export const PLANT_SPECIES_CAP = 55
 export const PARTICLE_LIFE = 0.9
 
 export const MAX_PARTICLES = 400
+
+// ---------------------------------------------------------------------------
+// Records
+// ---------------------------------------------------------------------------
+
+/**
+ * How old something has to get before it can hold the longevity record.
+ *
+ * Without a floor the very first creature in a fresh land takes the record at
+ * one hundredth of a second and wears its halo immediately, which makes the mark
+ * meaningless and puts it on screen constantly — the opposite of the intent.
+ * Sixty seconds is long enough that most things are eaten first, so an elder is
+ * genuinely something that survived rather than something that merely spawned.
+ */
+export const ELDER_MIN_SECONDS = 60
+
+/**
+ * How long a land must hold together before its steady streak is worth showing.
+ *
+ * Below this the number would flicker on and off during the early churn while
+ * populations find their level, which reads as noise. Two minutes in, a streak
+ * means the food web actually settled.
+ */
+export const STEADY_SHOW_SECONDS = 120

--- a/src/app/micro-land/domain/sim/creature-sim.ts
+++ b/src/app/micro-land/domain/sim/creature-sim.ts
@@ -195,6 +195,9 @@ export function tickCreatures(
     ) {
       const child = reproduce(w, c, bp, bw, bh, rng)
       if (child) {
+        // Set here rather than inside `reproduce`, which returns through two
+        // different paths and would need the parent threaded into both.
+        child.generation = c.generation + 1
         c.children++
         if (isPlant) plantsAlive++
         else c.hunger = Math.min(1, c.hunger + BREED_COST)

--- a/src/app/micro-land/domain/sim/world.ts
+++ b/src/app/micro-land/domain/sim/world.ts
@@ -285,6 +285,9 @@ export function spawnCreature(
     children: 0,
     digProgress: 0,
     tilesDug: 0,
+    // Founder of its line until `reproduce` says otherwise.
+    generation: 1,
+    name: null,
   }
   w.creatures.push(creature)
   return creature

--- a/src/app/micro-land/domain/types.ts
+++ b/src/app/micro-land/domain/types.ts
@@ -244,6 +244,22 @@ export interface Creature {
   digProgress: number
   /** Lifetime tally of tiles tunnelled through. */
   tilesDug: number
+  /**
+   * How far back this creature's line goes. 1 was placed or seeded by hand or by
+   * the world; anything higher was born here, to a parent one lower.
+   *
+   * Counts ancestry rather than population, so it survives a crash: a species
+   * can dwindle to a single individual and its line keeps its depth.
+   */
+  generation: number
+  /**
+   * What the player called it.
+   *
+   * Only ever offered for a creature holding the longevity record — naming is
+   * the moment a creature stops being one of the hoppers and becomes *yours*,
+   * and it is worth more if it has to be earned.
+   */
+  name: string | null
 }
 
 export interface Particle {

--- a/src/app/micro-land/format.ts
+++ b/src/app/micro-land/format.ts
@@ -1,0 +1,23 @@
+/**
+ * Shared formatting for record read-outs.
+ *
+ * Lives outside the components because the same duration is spoken three times
+ * — in a notice, in the inspector, in the field guide — and they have to agree.
+ */
+
+/**
+ * Durations as a person would say them: "48s", "3m 12s", "1h 04m".
+ *
+ * Seconds are dropped above an hour, kept everywhere below it. A creature that
+ * lived four minutes and two seconds beat one that lived four minutes flat, and
+ * rounding that away would hide the thing the record is about.
+ */
+export function formatDuration(seconds: number): string {
+  const total = Math.max(0, Math.floor(seconds))
+  if (total < 60) return `${total}s`
+  const minutes = Math.floor(total / 60)
+  const rest = total % 60
+  if (minutes < 60) return `${minutes}m ${String(rest).padStart(2, '0')}s`
+  const hours = Math.floor(minutes / 60)
+  return `${hours}h ${String(minutes % 60).padStart(2, '0')}m`
+}

--- a/src/app/micro-land/game-instance.ts
+++ b/src/app/micro-land/game-instance.ts
@@ -12,9 +12,25 @@ import {
 } from '@/app/micro-land/domain/terrain'
 import { SUMMONED_THEME_ID } from '@/app/micro-land/store'
 
+import {
+  archivedSpecies,
+  claimMilestone,
+  landId,
+  landRecord,
+  noteSpeciesLife,
+  readChronicle,
+  rememberSpecies,
+  updateChronicle,
+} from './chronicle/chronicle'
 import { artSize, sanitizeBlueprint } from './domain/blueprint'
+import { MILESTONES, type MilestoneContext } from './domain/config/milestones'
 import { DEFAULT_THEME, THEME_BY_ID, type Theme } from './domain/config/themes'
-import { MAX_CREATURES, TICK_S, TILE_TICK_EVERY } from './domain/constants'
+import {
+  ELDER_MIN_SECONDS,
+  MAX_CREATURES,
+  TICK_S,
+  TILE_TICK_EVERY,
+} from './domain/constants'
 import { type SimEvent, tickCreatures } from './domain/sim/creature-sim'
 import { makeRng } from './domain/sim/prng'
 import { tickTiles } from './domain/sim/tile-sim'
@@ -32,9 +48,15 @@ import {
   spawnCreature,
   spawnSomewhereSensible,
 } from './domain/sim/world'
+import { formatDuration } from './format'
 import { Renderer } from './rendering/renderer'
-import { type PopulationEntry, useMicroLand } from './store'
+import {
+  type EarnedMilestone,
+  type PopulationEntry,
+  useMicroLand,
+} from './store'
 
+import type { SpeciesRecord } from './chronicle/types'
 import type { Creature, CreatureBlueprint, WorldState } from './domain/types'
 
 /** How often the UI gets a fresh population summary. */
@@ -48,6 +70,21 @@ const HUNT_NOTICE_GAP = 7
 
 /** Simulation can't catch up on more than this much time at once. */
 const MAX_CATCHUP_MS = 250
+
+/**
+ * Milestones already earned, in the order the config lists them.
+ *
+ * Ordered by the config rather than by when they were reached so the field
+ * guide reads as a ladder — the ones still ahead of you sit in a stable place.
+ */
+function readMilestones(): EarnedMilestone[] {
+  const earned = readChronicle().milestones
+  return MILESTONES.filter((m) => earned[m.id]).map((m) => ({
+    id: m.id,
+    text: m.text,
+    at: earned[m.id],
+  }))
+}
 
 export class GameInstance {
   private canvas: HTMLCanvasElement
@@ -66,6 +103,25 @@ export class GameInstance {
   private knownSpecies = new Set<string>()
   /** World-clock time of the last hunt notice, so kills don't spam the screen. */
   private lastHuntNotice = -HUNT_NOTICE_GAP
+
+  // --- records ---
+  /** Which land's records are being written to. See `landId()`. */
+  private currentLand = DEFAULT_THEME
+  /** The creature currently holding the longevity record, if one is alive. */
+  private elderId: number | null = null
+  /**
+   * Enough of the elder to eulogize it.
+   *
+   * Kept alongside the id because the announcement happens *after* the creature
+   * has already been filtered out of the world, so there is nothing left to read
+   * its age or its name off by then.
+   */
+  private elderSnapshot: { name: string | null; species: string; seconds: number } | null =
+    null
+  /** World-clock time the current no-extinction streak began. */
+  private steadySince = 0
+  /** Archive size at the last push, so the guide is only re-sent when it grows. */
+  private lastArchiveSize = -1
 
   // --- pointer state ---
   private pointerDown = false
@@ -162,7 +218,7 @@ export class GameInstance {
     // Keep the grabbed creature glued to the finger even while paused.
     if (this.grabbed) this.grabbed.vx = this.grabbed.vy = 0
 
-    this.renderer.render(this.world, theme, this.inspectedId)
+    this.renderer.render(this.world, theme, this.inspectedId, this.elderId)
   }
 
   private step(gravity: number, events: SimEvent[]): void {
@@ -208,12 +264,31 @@ export class GameInstance {
       const stillAlive = this.world.creatures.some((c) => c.blueprintId === bp.id)
       if (stillAlive) continue
       this.knownSpecies.delete(bp.id)
+      // An extinction is exactly what the steady streak measures the absence of
+      // — it is the moment the world has to bail the player out via seed rain.
+      this.breakSteadyStreak()
       notify(
         event.kind === 'starved'
           ? `The last ${bp.name} starved.`
           : `The last ${bp.name} was eaten.`
       )
     }
+  }
+
+  /**
+   * End the current no-extinction streak, banking it if it was the best.
+   *
+   * Banked before the reset rather than only at the end of a session, because
+   * most sessions end with the tab closing rather than with anything tidy.
+   */
+  private breakSteadyStreak(): void {
+    const run = this.world.elapsed - this.steadySince
+    this.steadySince = this.world.elapsed
+    if (run <= 0) return
+    updateChronicle(() => {
+      const record = landRecord(this.currentLand)
+      if (run > record.steadySeconds) record.steadySeconds = run
+    })
   }
 
   private pushStats(): void {
@@ -232,7 +307,233 @@ export class GameInstance {
       .getState()
       .setStats(population, this.world.creatures.length, this.world.elapsed)
 
+    this.updateRecords(population)
     this.pushInspected()
+  }
+
+  // -------------------------------------------------------------------------
+  // Records
+  // -------------------------------------------------------------------------
+
+  /**
+   * Keep the chronicle up to date and push a read-out to the UI.
+   *
+   * Runs on the stats tick — a few times a second, not per frame. Records are
+   * high-water marks, so sampling is fine: a creature cannot get younger between
+   * ticks, and the worst case is a record set a fraction of a second late.
+   */
+  private updateRecords(population: PopulationEntry[]): void {
+    const w = this.world
+    const now = Date.now()
+    const store = useMicroLand.getState()
+
+    // The elder is gone if it isn't in the world any more. Checked before the
+    // new elder is chosen so the eulogy names the right creature.
+    if (this.elderId !== null && !w.creatures.some((c) => c.id === this.elderId)) {
+      this.mourn()
+    }
+
+    let oldest: Creature | null = null
+    let deepest = 0
+    // Oldest *per species*, not just overall: the guide reports a longest life
+    // for every kind, and only ever noting the single oldest creature would
+    // leave every species but one permanently blank.
+    const eldestOf = new Map<string, number>()
+    for (const c of w.creatures) {
+      if (!oldest || c.ageSeconds > oldest.ageSeconds) oldest = c
+      if (c.generation > deepest) deepest = c.generation
+      const best = eldestOf.get(c.blueprintId)
+      if (best === undefined || c.ageSeconds > best) {
+        eldestOf.set(c.blueprintId, c.ageSeconds)
+      }
+    }
+
+    // Every species on screen goes into the guide, and takes its blueprint with
+    // it — this is what stops a summoned creature dying with the tab.
+    for (const entry of population) {
+      const bp = w.blueprints[entry.blueprintId]
+      if (bp) rememberSpecies(bp, now)
+    }
+    for (const [blueprintId, seconds] of eldestOf) {
+      noteSpeciesLife(blueprintId, seconds)
+    }
+
+    const record = landRecord(this.currentLand)
+    const steadySeconds = w.elapsed - this.steadySince
+
+    updateChronicle(() => {
+      // --- longevity ---------------------------------------------------
+      const best = record.elder?.seconds ?? 0
+      if (
+        oldest &&
+        oldest.ageSeconds >= ELDER_MIN_SECONDS &&
+        oldest.ageSeconds > best
+      ) {
+        const bp = w.blueprints[oldest.blueprintId]
+        if (bp) {
+          const crowning = this.elderId !== oldest.id
+          this.elderId = oldest.id
+          // Rewritten every tick while the elder lives, so the record tracks it
+          // upward and freezes at whatever age it finally reached. `at` is the
+          // exception — it marks when the record was *taken*, so it survives the
+          // rewrites rather than creeping forward with them.
+          record.elder = {
+            seconds: oldest.ageSeconds,
+            blueprintId: bp.id,
+            speciesName: bp.name,
+            name: oldest.name,
+            at: crowning ? now : (record.elder?.at ?? now),
+          }
+          this.elderSnapshot = {
+            name: oldest.name,
+            species: bp.name,
+            seconds: oldest.ageSeconds,
+          }
+          if (crowning) {
+            store.notify(`A ${bp.name} has outlived everything this land remembers.`)
+          }
+        }
+      }
+
+      // --- bloodline ----------------------------------------------------
+      if (deepest > record.generations) {
+        record.generations = deepest
+        const line = w.creatures.find((c) => c.generation === deepest)
+        const bp = line ? w.blueprints[line.blueprintId] : undefined
+        record.generationsBlueprintId = bp?.id ?? null
+        record.generationsSpeciesName = bp?.name ?? null
+      }
+
+      // --- stability ----------------------------------------------------
+      // Banked live rather than only when the streak breaks, so a session that
+      // ends by closing the tab still keeps the run it was in the middle of.
+      if (steadySeconds > record.steadySeconds) record.steadySeconds = steadySeconds
+    })
+
+    store.setRecords({
+      elder: record.elder,
+      bestSteadySeconds: record.steadySeconds,
+      bestGenerations: record.generations,
+      bestGenerationsSpeciesName: record.generationsSpeciesName,
+      steadySeconds,
+      deepestGeneration: deepest,
+    })
+
+    // Sorted once and shared: both of these want the same list, and it is
+    // rebuilt on every stats tick.
+    const archive = archivedSpecies()
+
+    this.checkMilestones(archive, {
+      elapsed: w.elapsed,
+      steadySeconds,
+      oldestSeconds: oldest?.ageSeconds ?? 0,
+      generations: deepest,
+      speciesAlive: population.length,
+      total: w.creatures.length,
+    })
+
+    this.syncArchive(archive)
+  }
+
+  /** Announce the elder's death, then stand down the halo. */
+  private mourn(): void {
+    const gone = this.elderSnapshot
+    this.elderId = null
+    this.elderSnapshot = null
+    if (!gone) return
+    const age = formatDuration(gone.seconds)
+    useMicroLand
+      .getState()
+      .notify(
+        gone.name
+          ? `${gone.name} died at ${age}. Nothing here has lived longer.`
+          : `The oldest ${gone.species} died at ${age}.`
+      )
+  }
+
+  /**
+   * Give the record-holder a name.
+   *
+   * Only the elder can be named, which is the point — a name is the reward for
+   * the record, not a labelling tool. Returns false if the moment has passed.
+   */
+  nameElder(name: string): boolean {
+    const trimmed = name.trim().slice(0, 24)
+    if (!trimmed || this.elderId === null) return false
+    const c = this.world.creatures.find((x) => x.id === this.elderId)
+    if (!c) return false
+    c.name = trimmed
+    if (this.elderSnapshot) this.elderSnapshot.name = trimmed
+    updateChronicle(() => {
+      const record = landRecord(this.currentLand)
+      if (record.elder) record.elder.name = trimmed
+    })
+    this.pushStats()
+    return true
+  }
+
+  /** Fire any milestone that just became true. Each one fires once, ever. */
+  private checkMilestones(
+    archive: SpeciesRecord[],
+    context: Omit<MilestoneContext, 'archived' | 'summonedArchived'>
+  ): void {
+    const full = {
+      ...context,
+      archived: archive.length,
+      summonedArchived: archive.filter((s) => s.blueprint.summoned).length,
+    }
+    const now = Date.now()
+    const store = useMicroLand.getState()
+    let fired = false
+    for (const milestone of MILESTONES) {
+      if (!milestone.reached(full)) continue
+      if (!claimMilestone(milestone.id, now)) continue
+      store.notify(milestone.text)
+      fired = true
+    }
+    if (fired) this.pushMilestones()
+  }
+
+  /**
+   * Push everything the chronicle already knew into the UI.
+   *
+   * Called once after the chronicle loads, so a returning player's field guide
+   * is populated before the first creature has drawn breath in this session.
+   */
+  publishRecords(): void {
+    this.lastArchiveSize = -1
+    this.syncArchive(archivedSpecies())
+    this.pushMilestones()
+  }
+
+  /** Re-send the guide's archive, but only when it has actually changed. */
+  private syncArchive(archive: SpeciesRecord[]): void {
+    if (archive.length === this.lastArchiveSize) return
+    this.lastArchiveSize = archive.length
+    useMicroLand.getState().setArchive(archive)
+  }
+
+  private pushMilestones(): void {
+    const earned = readMilestones()
+    useMicroLand.getState().setMilestones(earned)
+  }
+
+  /**
+   * Point the recorder at whichever land is now on screen, banking the run that
+   * was in progress. Called whenever the world is replaced under the player.
+   */
+  private beginLand(): void {
+    this.breakSteadyStreak()
+    this.currentLand = landId(
+      useMicroLand.getState().themeId,
+      useMicroLand.getState().summonedLand
+    )
+    this.steadySince = this.world.elapsed
+    // A cleared world has no elder; do this quietly rather than eulogizing a
+    // creature the player deliberately removed.
+    this.elderId = null
+    this.elderSnapshot = null
+    this.lastArchiveSize = -1
   }
 
   /** Copy the watched creature's live state out for the inspector panel. */
@@ -276,6 +577,9 @@ export class GameInstance {
       inWater: boxLiquidFraction(this.world, c.x, c.y, bw, bh) > 0.3,
       grounded: c.grounded,
       targetName: targetBp?.name ?? null,
+      generation: c.generation,
+      name: c.name,
+      isElder: c.id === this.elderId,
     })
   }
 
@@ -309,6 +613,9 @@ export class GameInstance {
     this.renderer.markTilesDirty()
     useMicroLand.getState().setSummonedLand(terrain.name)
     useMicroLand.getState().setTheme(SUMMONED_THEME_ID)
+    // After the store knows the land's name — `beginLand` derives the record key
+    // from it, and a summoned land files its records under its own name.
+    this.beginLand()
     this.pushStats()
     return terrain
   }
@@ -320,6 +627,7 @@ export class GameInstance {
       this.knownSpecies.clear()
       this.inspectedId = null
       this.renderer.markTilesDirty()
+      this.beginLand()
       this.pushStats()
       return
     }
@@ -331,6 +639,7 @@ export class GameInstance {
     this.inspectedId = null
     seedStarters(this.world, themeId, this.rng)
     this.renderer.markTilesDirty()
+    this.beginLand()
     this.pushStats()
   }
 
@@ -343,6 +652,7 @@ export class GameInstance {
       this.knownSpecies.clear()
       this.inspectedId = null
       this.renderer.markTilesDirty()
+      this.beginLand()
       this.pushStats()
       return
     }
@@ -352,6 +662,7 @@ export class GameInstance {
     this.inspectedId = null
     seedStarters(this.world, themeId, this.rng)
     this.renderer.markTilesDirty()
+    this.beginLand()
     this.pushStats()
   }
 
@@ -359,6 +670,9 @@ export class GameInstance {
     clearCreatures(this.world)
     this.knownSpecies.clear()
     this.inspectedId = null
+    // Emptying the world is an extinction of everything, so the streak goes with
+    // it — but silently, since the player did it on purpose.
+    this.beginLand()
     this.pushStats()
   }
 

--- a/src/app/micro-land/rendering/renderer.ts
+++ b/src/app/micro-land/rendering/renderer.ts
@@ -124,7 +124,12 @@ export class Renderer {
     }
   }
 
-  render(w: WorldState, theme: Theme, highlightId: number | null = null): void {
+  render(
+    w: WorldState,
+    theme: Theme,
+    highlightId: number | null = null,
+    elderId: number | null = null
+  ): void {
     if (this.tilesDirty) {
       this.buildTiles(w)
       this.tilesDirty = false
@@ -146,7 +151,9 @@ export class Renderer {
     this.drawCreatures(w)
     this.drawParticles(w)
     wctx.drawImage(this.shadowCanvas, 0, 0)
-    // Drawn after the shadow so the selection stays legible in a dark cave.
+    // Both drawn after the shadow so they stay legible in a dark cave. The halo
+    // goes first so the selection brackets sit on top when you inspect an elder.
+    if (elderId !== null) this.drawElder(w, elderId)
     if (highlightId !== null) this.drawHighlight(w, highlightId)
 
     // One scaled blit. Nearest-neighbour keeps the pixels crisp.
@@ -337,6 +344,52 @@ export class Renderer {
       ctx.drawImage(source, x, y)
       ctx.globalAlpha = 1
     }
+  }
+
+  /**
+   * Halo over the oldest thing that has ever lived here.
+   *
+   * A ring rather than a crown: at six pixels wide a crown is three pixels of
+   * mush sitting on the creature's head, while an ellipse floating clear of the
+   * sprite reads as a halo at any size and never hides the animal wearing it.
+   * This is the only mark the record system puts on the world — everything else
+   * it knows lives behind a tap.
+   */
+  private drawElder(w: WorldState, id: number): void {
+    const c = w.creatures.find((x) => x.id === id)
+    if (!c) return
+    const bp = w.blueprints[c.blueprintId]
+    if (!bp) return
+    const rows = bp.art.frames[0]
+    const bw = rows[0].length
+
+    const ctx = this.wctx
+    const cx = Math.round(c.x) + bw / 2
+    // Two pixels of clear air above the sprite, so it reads as floating rather
+    // than as part of the creature.
+    const cy = Math.round(c.y) - 3
+    const rx = Math.max(2, Math.min(6, bw / 2))
+    const ry = Math.max(1, rx * 0.42)
+
+    // Slower than the selection pulse — this is meant to be noticed, not to
+    // demand attention while you're doing something else.
+    ctx.fillStyle = '#fcd34d'
+    ctx.globalAlpha = 0.62 + 0.28 * Math.sin(w.elapsed * 2.6)
+
+    // Plotted point by point instead of ctx.ellipse: a stroked path at this
+    // scale antialiases into a grey smudge, and the whole world is nearest
+    // neighbour. Step is tied to the radius so small halos don't come out dotted.
+    const steps = Math.max(12, Math.round(rx * 6))
+    for (let i = 0; i < steps; i++) {
+      const t = (i / steps) * Math.PI * 2
+      ctx.fillRect(
+        Math.round(cx + Math.cos(t) * rx),
+        Math.round(cy + Math.sin(t) * ry),
+        1,
+        1
+      )
+    }
+    ctx.globalAlpha = 1
   }
 
   /** Ring around the creature the inspector is watching. */

--- a/src/app/micro-land/store.ts
+++ b/src/app/micro-land/store.ts
@@ -11,6 +11,7 @@ import { create } from 'zustand'
 
 import { DEFAULT_THEME } from './domain/config/themes'
 
+import type { ElderRecord, SpeciesRecord } from './chronicle/types'
 import type { CreatureBlueprint, MaterialId } from './domain/types'
 
 /** Theme id standing for "the land the player summoned". */
@@ -48,6 +49,46 @@ export interface Inspected {
   grounded: boolean
   /** What it's chasing or running from right now. */
   targetName: string | null
+  /** How far back its line goes; 1 means it was placed rather than born. */
+  generation: number
+  /** Player-given name, if this one earned the right to have one. */
+  name: string | null
+  /** True while this creature holds the land's longevity record. */
+  isElder: boolean
+}
+
+/**
+ * Records for the land currently on screen, as the UI wants them.
+ *
+ * Flattened out of the chronicle rather than exposing it directly: the panels
+ * want "best ever here" and "how it's going right now" side by side, and those
+ * come from two different places.
+ */
+export interface RecordsView {
+  /** Best ever in this land. */
+  elder: ElderRecord | null
+  bestSteadySeconds: number
+  bestGenerations: number
+  bestGenerationsSpeciesName: string | null
+  /** How this run is going. */
+  steadySeconds: number
+  deepestGeneration: number
+}
+
+export interface EarnedMilestone {
+  id: string
+  text: string
+  /** Epoch ms it was first reached. */
+  at: number
+}
+
+const EMPTY_RECORDS: RecordsView = {
+  elder: null,
+  bestSteadySeconds: 0,
+  bestGenerations: 0,
+  bestGenerationsSpeciesName: null,
+  steadySeconds: 0,
+  deepestGeneration: 0,
 }
 
 export interface PopulationEntry {
@@ -83,6 +124,18 @@ interface MicroLandState {
   guideOpen: boolean
   inspected: Inspected | null
 
+  /** Records for the land on screen. */
+  records: RecordsView
+  /**
+   * Every species ever seen alive, including summoned ones from past visits.
+   *
+   * Pushed only when it actually changes rather than on every stats tick — it
+   * turns over rarely and re-rendering the guide three times a second for a list
+   * that hasn't moved is wasted work.
+   */
+  archive: SpeciesRecord[]
+  milestones: EarnedMilestone[]
+
   notices: Notice[]
 
   setTheme: (id: string) => void
@@ -99,6 +152,9 @@ interface MicroLandState {
   setSummonError: (message: string | null) => void
   setGuideOpen: (open: boolean) => void
   setInspected: (snapshot: Inspected | null) => void
+  setRecords: (records: RecordsView) => void
+  setArchive: (archive: SpeciesRecord[]) => void
+  setMilestones: (milestones: EarnedMilestone[]) => void
   notify: (text: string) => void
   dismissNotice: (id: number) => void
 }
@@ -125,6 +181,10 @@ export const useMicroLand = create<MicroLandState>((set) => ({
   guideOpen: false,
   inspected: null,
 
+  records: EMPTY_RECORDS,
+  archive: [],
+  milestones: [],
+
   notices: [],
 
   setTheme: (themeId) => set({ themeId }),
@@ -142,6 +202,9 @@ export const useMicroLand = create<MicroLandState>((set) => ({
   setSummonError: (summonError) => set({ summonError }),
   setGuideOpen: (guideOpen) => set({ guideOpen }),
   setInspected: (inspected) => set({ inspected }),
+  setRecords: (records) => set({ records }),
+  setArchive: (archive) => set({ archive }),
+  setMilestones: (milestones) => set({ milestones }),
 
   notify: (text) =>
     set((s) => ({

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -18,6 +18,7 @@ export default defineConfig({
       'src/app/comet-cards/**/*.test.tsx',
       'src/lib/trivia/**/*.test.ts',
       'src/app/trivia/**/*.test.ts',
+      'src/app/micro-land/**/*.test.ts',
     ],
     coverage: {
       reporter: ['text', 'json', 'html'],


### PR DESCRIPTION
Stacked on #2570 — base is `feat/micro-land`, so this diff is only the records layer.

Micro Land forgets everything when the tab closes. This keeps the *logbook* rather than the world: who lived longest, how long a food web held together, and every species you ever saw — including the ones you invented.

## The constraint

Five features, **one new pixel on screen**. Every record either draws a mark on a creature, adds a line to a panel that's already behind a tap, or speaks through the notice strip that already exists. Nothing here earns a new surface.

| | Where it shows |
|---|---|
| **Elders** | A halo on the record-holding creature; naming appears in the inspector for that creature only |
| **Steady streaks** | One extra segment in the existing `N kinds · N alive` chip, hidden below 2 minutes |
| **Field guide remembers** | New "Remembered" section — archives the full blueprint |
| **Bloodlines** | `Generation N` in the inspector, hidden at generation 1 |
| **Milestones** | Fire into the notice strip, then settle into the back of the guide |

## Elders, and why this is a pet game

The longest life a land has held wears a halo. Passing the record earns the right to *name* that creature — the moment it stops being one of the hoppers and becomes yours. Keeping an elder alive means keeping its prey breeding, which means keeping the prey's food alive. The husbandry loop is the food chain with a face on it, and it needed no new verb: you feed an elder by placing its prey, which the toolbar already does.

Two calls worth flagging:

- **Halo, not crown.** At six pixels wide a crown is three pixels of mush on the creature's head. An ellipse floating clear of the sprite reads at any size and never hides the animal wearing it.
- **A 60s floor before anything can be an elder.** Without it the first creature in a fresh land takes the record instantly and wears the halo constantly, which makes the mark meaningless.

## Steady streaks

The real challenge in a food-chain game isn't keeping one creature alive, it's building a web that doesn't collapse. The world already bails you out via seed rain when a species dies out — so extinction is the natural definition of failure, and the streak measures its absence. It resets visibly.

## Built for the move to accounts

Records are browser-local for now. Storage sits behind a `ChronicleBackend` with `load()`/`save()`, both **async today even though localStorage needs no await** — a sync API now would put `await` into every call site on porting day. `localBackend` is the current implementation; there's a commented Firestore sketch beside it.

The genuinely hard part of that port isn't storage, it's that a player arrives at sign-in already holding anonymous records. `mergeChronicles()` is written and tested now: every record is a high-water mark, so "keep the larger" merges with no conflict and no prompt. Milestones keep the *earlier* timestamp — a first is a first.

## Testing

- 17 new unit tests covering merge, version migration, archive pruning, land keys, and milestone once-only firing. Adds the first test glob for micro-land to `vitest.config.ts`.
- Types and lint clean across `src/app/micro-land`; `/micro-land` serves 200 with no compile errors.
- The suite's 70 pre-existing failures are unchanged — verified identical on an untouched checkout.

**Not verified:** no browser automation in this repo, so the halo, the naming flow and the steady counter have not been seen rendering in a live session. Worth a look before merge — run dev, set speed to 3×, wait ~20s for the first elder.

## Open question

A summoned land currently files records under its own name, so re-summoning "the drowned cathedral" finds its old records. If all summoned lands should share one shelf instead, that's a one-line change in `landId()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)