### PR TITLE
feat(micro-land): a world three screens wide, and a camera to cross it

### DIFF
--- a/src/app/api/v1/micro-land/summon/route.ts
+++ b/src/app/api/v1/micro-land/summon/route.ts
@@ -97,7 +97,8 @@ DRAWING
 - A very large creature collides with its middle rather than its whole outline, so wings, tails and long necks can hang over the edges. Draw the shape you want; you do not have to keep it compact.
 
 DRAWING THE LAND
-- The world is a grid 224 tiles wide and 132 tall. You draw it as a small map — about 40 characters across and 24 rows down — which is scaled up and roughened, so draw big shapes and let the detail happen.
+- The world is a grid 672 tiles wide and 132 tall — a long, wide stretch of land that the player scrolls across. You draw it as a map about 120 characters across and 24 rows down, which is scaled up and roughened, so draw big shapes and let the detail happen.
+- Because it is wide, give it a JOURNEY: different country at each end and something to find in between. A shoreline that becomes cliffs that become a cave system beats the same hill drawn 120 times.
 - The top row is the top of the sky; the bottom row is the very bottom of the world. "." is empty air.
 - KEEP THE GROUND LOW. The surface — the first row that is mostly solid — should sit about 30-50% of the way up from the bottom, so at least half the map is open air. A horizon two-thirds up the page looks right on paper and plays badly: everything worth watching happens above the ground, and a world that is mostly dirt leaves the creatures nowhere to live. On a 24-row map that means roughly 13-16 rows of sky before the land starts.
 - Depth below the surface is only interesting where it is hollow. A solid slab of stone ten rows thick is wasted world — put caves, pockets, water or a lava seam in it, or make it thinner.

--- a/src/app/micro-land/MicroLandGame.tsx
+++ b/src/app/micro-land/MicroLandGame.tsx
@@ -7,6 +7,7 @@ import { FieldGuide } from '@/app/micro-land/components/field-guide'
 import { Hud } from '@/app/micro-land/components/hud'
 import { Inspector } from '@/app/micro-land/components/inspector'
 import { Notices } from '@/app/micro-land/components/notices'
+import { PanControls } from '@/app/micro-land/components/pan-controls'
 import { SummonPanel } from '@/app/micro-land/components/summon-panel'
 import { Toolbar } from '@/app/micro-land/components/toolbar'
 import { THEME_BY_ID } from '@/app/micro-land/domain/config/themes'
@@ -81,6 +82,14 @@ export function MicroLandGame() {
     return gameRef.current?.nameElder(name) ?? false
   }, [])
 
+  const handleHoldPan = useCallback((direction: -1 | 0 | 1) => {
+    gameRef.current?.holdPan(direction)
+  }, [])
+
+  const handleNudgePan = useCallback((direction: -1 | 1) => {
+    gameRef.current?.nudgePan(direction)
+  }, [])
+
   const handleApplyTerrain = useCallback((raw: unknown, keepCreatures: boolean) => {
     const game = gameRef.current
     if (!game) return null
@@ -95,10 +104,14 @@ export function MicroLandGame() {
       <div className="relative min-h-0 flex-1">
         <canvas
           ref={canvasRef}
-          className="absolute inset-0 block h-full w-full touch-none"
+          // Focusable so the arrow keys reach it. The world is wider than the
+          // screen, and a keyboard has to be able to get to the rest of it.
+          tabIndex={0}
+          className="absolute inset-0 block h-full w-full touch-none focus:outline-none"
           style={{ imageRendering: 'pixelated', cursor: 'crosshair' }}
-          aria-label="Micro Land world. Tap to place things, drag a creature to pick it up and throw it."
+          aria-label="Micro Land world. Tap to place things, drag a creature to pick it up and throw it. Arrow keys scroll across the world."
         />
+        <PanControls onHold={handleHoldPan} onNudge={handleNudgePan} />
         <Notices />
         <Inspector onName={handleNameElder} />
       </div>

--- a/src/app/micro-land/components/pan-controls.tsx
+++ b/src/app/micro-land/components/pan-controls.tsx
@@ -1,0 +1,108 @@
+'use client'
+
+import { useCallback, useEffect, useRef } from 'react'
+
+import { useMicroLand } from '@/app/micro-land/store'
+
+/** A press shorter than this was a click, not a hold. */
+const TAP_MS = 200
+
+/**
+ * The two arrows that walk you along the world.
+ *
+ * The world is three screens wide, and every other way of moving it is a gesture
+ * you have to already know: two fingers, a trackpad swipe, an arrow key, a tap
+ * on the map. These are the one control that is simply *visible*, which makes
+ * them the ones that matter on a phone and the ones a screen reader can find.
+ *
+ * Press and hold to keep going; a quick press steps once. Both are wired,
+ * because a small child holds the button down and an adult clicks it.
+ */
+export function PanControls({
+  onHold,
+  onNudge,
+}: {
+  onHold: (direction: -1 | 0 | 1) => void
+  onNudge: (direction: -1 | 1) => void
+}) {
+  const canPan = useMicroLand((s) => s.canPan)
+  const pressedAt = useRef(0)
+
+  const stop = useCallback(() => {
+    pressedAt.current = 0
+    onHold(0)
+  }, [onHold])
+
+  // A pointer released outside the button never sends pointerup *to* the
+  // button, and a camera that scrolls forever after is the worst bug this could
+  // have. The window always hears about it.
+  useEffect(() => {
+    window.addEventListener('pointerup', stop)
+    window.addEventListener('pointercancel', stop)
+    return () => {
+      window.removeEventListener('pointerup', stop)
+      window.removeEventListener('pointercancel', stop)
+    }
+  }, [stop])
+
+  if (!canPan) return null
+
+  const button = (direction: -1 | 1) => (
+    <button
+      type="button"
+      aria-label={direction === -1 ? 'Look further west' : 'Look further east'}
+      className="pointer-events-auto flex h-11 w-9 items-center justify-center rounded-lg backdrop-blur-sm transition-opacity hover:opacity-100 focus-visible:opacity-100"
+      style={{
+        color: 'var(--cc-text-default)',
+        background: 'rgba(2, 8, 10, 0.6)',
+        border: '1px solid var(--cc-mint-line)',
+        opacity: 0.62,
+        touchAction: 'none',
+      }}
+      onPointerDown={(e) => {
+        e.preventDefault()
+        pressedAt.current = e.timeStamp
+        onHold(direction)
+      }}
+      onPointerUp={(e) => {
+        // Let go quickly and the hold barely moved anything; give it one clean
+        // step so a tap always does something you can see.
+        if (pressedAt.current > 0 && e.timeStamp - pressedAt.current < TAP_MS) {
+          onNudge(direction)
+        }
+        stop()
+      }}
+      onPointerLeave={stop}
+      // Enter and Space fire a click with no pointer event behind it, and that
+      // is the only case this needs to catch — `detail` is 0 for exactly those.
+      onClick={(e) => {
+        if (e.detail === 0) onNudge(direction)
+      }}
+    >
+      <svg
+        width="14"
+        height="14"
+        viewBox="0 0 14 14"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        aria-hidden="true"
+      >
+        {direction === -1 ? (
+          <polyline points="9,2 3,7 9,12" />
+        ) : (
+          <polyline points="5,2 11,7 5,12" />
+        )}
+      </svg>
+    </button>
+  )
+
+  return (
+    <div className="pointer-events-none absolute inset-0 flex items-center justify-between px-2">
+      {button(-1)}
+      {button(1)}
+    </div>
+  )
+}

--- a/src/app/micro-land/domain/config/themes.ts
+++ b/src/app/micro-land/domain/config/themes.ts
@@ -6,7 +6,7 @@
  * up already living there. Switching themes rebuilds the tile grid; summoned
  * creatures survive the change.
  */
-import { WORLD_H, WORLD_W } from '@/app/micro-land/domain/constants'
+import { WIDTH_SCALE, WORLD_H, WORLD_W } from '@/app/micro-land/domain/constants'
 import { type Rng, fbm, makeNoise2D } from '@/app/micro-land/domain/sim/prng'
 import type { MaterialId } from '@/app/micro-land/domain/types'
 
@@ -28,6 +28,18 @@ export interface Theme {
 }
 
 const M = MATERIAL_INDEX
+
+/**
+ * "This many per screen" → "this many across the whole world".
+ *
+ * Every scattered feature below — ponds, geodes, lava falls — was a count
+ * chosen by eye against one screen of land. Left alone in a world three screens
+ * wide they don't spread out, they thin out: two ponds in a world this long
+ * means most of it has no fresh water at all.
+ */
+function across(n: number): number {
+  return Math.round(n * WIDTH_SCALE)
+}
 
 function fill(tiles: Uint8Array, id: MaterialId) {
   tiles.fill(M[id])
@@ -195,7 +207,7 @@ const EARTH: Theme = {
 
     // A shallow pond or two on the surface, with mud round the rim — the one
     // place on the map where the ground is both wet and fertile.
-    const ponds = 2 + Math.floor(rng() * 2)
+    const ponds = across(2) + Math.floor(rng() * across(2))
     for (let p = 0; p < ponds; p++) {
       const cx = Math.floor(rng() * WORLD_W)
       const w = 8 + Math.floor(rng() * 14)
@@ -249,10 +261,16 @@ const STATION: Theme = {
     }
     const rooms: Box[] = []
 
+    // Each level of recursion doubles the room count, so widening the station
+    // needs *more depth*, not a bigger number — at the old limit of 4 the same
+    // sixteen rooms would simply have been stretched to three times the size,
+    // and a station made of enormous empty halls stops reading as a station.
+    const maxDepth = 4 + Math.round(Math.log2(WIDTH_SCALE))
+
     function split(box: Box, depth: number) {
       const w = box.x1 - box.x0
       const h = box.y1 - box.y0
-      if (depth > 4 || (w < 26 && h < 20) || rooms.length > 24) {
+      if (depth > maxDepth || (w < 26 && h < 20) || rooms.length > across(24)) {
         rooms.push(box)
         return
       }
@@ -373,7 +391,7 @@ const TIDEPOOL: Theme = {
     }
 
     // Scattered tidepools sitting on top of the shelves.
-    for (let i = 0; i < 14; i++) {
+    for (let i = 0; i < across(14); i++) {
       const cx = Math.floor(rng() * WORLD_W)
       let y = 0
       while (y < WORLD_H && tiles[y * WORLD_W + cx] === M.air) y++
@@ -386,7 +404,7 @@ const TIDEPOOL: Theme = {
     }
 
     // Shells and old bones worked into the sand, and a few gems in the bedrock.
-    for (let i = 0; i < 10; i++) {
+    for (let i = 0; i < across(10); i++) {
       const cx = Math.floor(rng() * WORLD_W)
       const cy = Math.floor(WORLD_H * (0.7 + rng() * 0.28))
       blob(tiles, cx, cy, 2 + Math.floor(rng() * 3), rng() < 0.6 ? 'bone' : 'gem', rng, [
@@ -449,7 +467,7 @@ const VOLCANIC: Theme = {
     }
 
     // Lava falls spilling down from the surface.
-    for (let i = 0; i < 4; i++) {
+    for (let i = 0; i < across(4); i++) {
       const cx = 12 + Math.floor(rng() * (WORLD_W - 24))
       let y = 0
       while (y < WORLD_H && tiles[y * WORLD_W + cx] === M.air) y++
@@ -461,7 +479,7 @@ const VOLCANIC: Theme = {
 
     // Crystal geodes and gem seams growing in the cooled rock, plus the bones
     // of whatever didn't get out in time.
-    for (let i = 0; i < 16; i++) {
+    for (let i = 0; i < across(16); i++) {
       const cx = Math.floor(rng() * WORLD_W)
       const cy = Math.floor(WORLD_H * (0.4 + rng() * 0.45))
       const roll = rng()
@@ -471,7 +489,7 @@ const VOLCANIC: Theme = {
 
     // A couple of acid pools sitting in the ash. They eat their way down and
     // then they're gone, which is exactly what makes them safe to leave here.
-    for (let i = 0; i < 2; i++) {
+    for (let i = 0; i < across(2); i++) {
       const cx = Math.floor(rng() * WORLD_W)
       let y = 0
       while (y < WORLD_H && tiles[y * WORLD_W + cx] === M.air) y++

--- a/src/app/micro-land/domain/constants.ts
+++ b/src/app/micro-land/domain/constants.ts
@@ -1,8 +1,37 @@
 /** World tuning. One place to change the feel of everything. */
 
-/** World size in tiles. Everything is drawn at 1 pixel per tile, then scaled up. */
-export const WORLD_W = 224
+/**
+ * World size in tiles. Everything is drawn at 1 pixel per tile, then scaled up.
+ *
+ * The world is three screens wide and one screen tall. It used to be exactly one
+ * screen of each, and the old width lives on as VIEW_W below — that is the part
+ * that matters, because the terrarium is only legible at a certain number of
+ * tiles across. A creature is 4-28 tiles; fit 672 of them into a phone and the
+ * whole world is smaller than the sprite you are trying to look at.
+ */
+export const WORLD_W = 672
 export const WORLD_H = 132
+
+/**
+ * How much world the camera shows at once, in tiles.
+ *
+ * This is the *zoom*, not a viewport size: the renderer sizes a tile so that
+ * VIEW_W of them span the canvas, which is exactly the scale the world had back
+ * when it was 224 wide and fully visible. A wide display gets to see more than
+ * VIEW_W tiles (height runs out first), a phone sees exactly this many. Either
+ * way a hopper is the same size it has always been.
+ */
+export const VIEW_W = 224
+
+/**
+ * How many times wider than one screen the world is.
+ *
+ * Counts tuned for a single screen — how many ponds, how many starting hoppers,
+ * how many of a species the land can carry — are all densities wearing an
+ * absolute number's clothing. Multiplying them by this is what stops a world
+ * three times the size from feeling three times as empty.
+ */
+export const WIDTH_SCALE = WORLD_W / VIEW_W
 
 /** Fixed simulation step. */
 export const TICK_MS = 1000 / 60
@@ -17,8 +46,15 @@ export const GRAVITY = 34
 /** Terminal fall speed, tiles/second. Stops tunnelling through thin floors. */
 export const MAX_FALL = 46
 
-/** Hard population ceiling. Past this, nothing new is born (summoning still works). */
-export const MAX_CREATURES = 340
+/**
+ * Hard population ceiling. Past this, nothing new is born (summoning still works).
+ *
+ * Scaled with the world rather than left alone, because this ceiling binds well
+ * before the per-species caps do — leaving it at a single screen's worth would
+ * have made a three-screen world one third as densely populated, which is the
+ * opposite of what a bigger world is for.
+ */
+export const MAX_CREATURES = Math.round(340 * WIDTH_SCALE)
 
 /**
  * Hard ceiling on plants, so they can't blanket the world.
@@ -34,7 +70,7 @@ export const MAX_CREATURES = 340
  * else's, and a crowded world was starving its grazers rather than feeding more
  * of them.
  */
-export const MAX_PLANTS = 195
+export const MAX_PLANTS = Math.round(195 * WIDTH_SCALE)
 
 /** Seconds a drowning creature survives underwater. */
 export const BREATH_SECONDS = 9
@@ -92,10 +128,17 @@ export const SEED_RAIN_INTERVAL = 4
  * the harder the seed comes in. That asymmetry is deliberate — a constant
  * trickle would just pin every world at MAX_PLANTS and turn it into a carpet.
  */
-export const NATIVE_PLANT_TARGET = 45
+export const NATIVE_PLANT_TARGET = Math.round(45 * WIDTH_SCALE)
 export const PLANT_SEED_INTERVAL = 3
-/** Most plants a single seeding may place, when the world is at zero. */
-export const PLANT_SEED_BATCH = 3
+/**
+ * Most plants a single seeding may place, when the world is at zero.
+ *
+ * Scaled along with the target, not left alone. The interval is a wall-clock
+ * rate, so a batch that doesn't grow with the world turns "a meadow can come
+ * back" into "a meadow comes back three times slower" — long enough that the
+ * grazers waiting on it starve again before it arrives.
+ */
+export const PLANT_SEED_BATCH = Math.round(3 * WIDTH_SCALE)
 /**
  * How many species the ground picks when it establishes its natives.
  *
@@ -112,7 +155,7 @@ export const NATIVE_PLANT_SPECIES = 3
  * species starves at once. This is the environment saying "there is only so much
  * room here" and is what turns a terminal crash into an oscillation.
  */
-export const SPECIES_SOFT_CAP = 70
+export const SPECIES_SOFT_CAP = Math.round(70 * WIDTH_SCALE)
 
 /**
  * Carrying capacity for a single *plant* species.
@@ -122,12 +165,12 @@ export const SPECIES_SOFT_CAP = 70
  * a monoculture — which then starves out every grazer too small to eat it.
  * Keeping this well under MAX_PLANTS is what leaves room for a mixed meadow.
  */
-export const PLANT_SPECIES_CAP = 46
+export const PLANT_SPECIES_CAP = Math.round(46 * WIDTH_SCALE)
 
 /** Particle lifetime range, seconds. */
 export const PARTICLE_LIFE = 0.9
 
-export const MAX_PARTICLES = 400
+export const MAX_PARTICLES = Math.round(400 * WIDTH_SCALE)
 
 // ---------------------------------------------------------------------------
 // Records

--- a/src/app/micro-land/domain/sim/creature-sim.ts
+++ b/src/app/micro-land/domain/sim/creature-sim.ts
@@ -81,6 +81,48 @@ export interface SimEvent {
 
 let tickCount = 0
 
+/**
+ * The population sorted left to right, reused between ticks.
+ *
+ * `look` used to walk the entire population to find the handful of things within
+ * an 18-tile line of sight. That was tolerable when the world was one screen
+ * wide, and stops being tolerable at three: the population cap scales with the
+ * area, so the all-pairs cost scales with its *square* while the number of
+ * creatures actually near you doesn't change at all.
+ *
+ * Sorting by x and walking only the slice within reach makes the cost track the
+ * local crowd instead of the headcount. The array is nearly sorted every tick —
+ * nothing moves far in 1/60th of a second — which is the case sort is fastest
+ * at, and it is kept around rather than rebuilt so a busy world isn't handing
+ * the collector a thousand-element array sixty times a second.
+ */
+const byX: Creature[] = []
+
+/**
+ * Slack either side of the sight window, in tiles.
+ *
+ * Sorting is on the sprite's left edge but sight is measured from its centre,
+ * so a wide creature's edge can sit well outside the window its centre falls in.
+ * Covers the widest sprite plus a tick's worth of drift since the sort.
+ */
+const SIGHT_PAD = 20
+
+function compareX(a: Creature, b: Creature): number {
+  return a.x - b.x
+}
+
+/** First index whose x is not less than `x`. The array must be sorted. */
+function lowerBound(list: Creature[], x: number): number {
+  let lo = 0
+  let hi = list.length
+  while (lo < hi) {
+    const mid = (lo + hi) >> 1
+    if (list[mid].x < x) lo = mid + 1
+    else hi = mid
+  }
+  return lo
+}
+
 export function tickCreatures(
   w: WorldState,
   dt: number,
@@ -116,6 +158,11 @@ export function tickCreatures(
   for (const c of creatures) {
     if (w.blueprints[c.blueprintId]?.aura) helpers.push(c)
   }
+
+  // Rebuilt in place, then sorted, once for every creature that looks this tick.
+  byX.length = creatures.length
+  for (let i = 0; i < creatures.length; i++) byX[i] = creatures[i]
+  byX.sort(compareX)
 
   for (const c of creatures) {
     if (dead.has(c.id)) continue
@@ -272,7 +319,13 @@ function look(
   let prey: Creature | null = null
   let preyDist = Infinity
 
-  for (const other of w.creatures) {
+  // Only the creatures whose left edge falls in the sight window can possibly
+  // be in range; everything beyond the window is skipped without being touched.
+  const reach = bp.senses.sight + SIGHT_PAD
+  const last = cx + reach
+  for (let i = lowerBound(byX, cx - reach); i < byX.length; i++) {
+    const other = byX[i]
+    if (other.x > last) break
     if (other.id === c.id || dead.has(other.id)) continue
     const obp = w.blueprints[other.blueprintId]
     if (!obp) continue

--- a/src/app/micro-land/domain/sim/world.ts
+++ b/src/app/micro-land/domain/sim/world.ts
@@ -21,6 +21,7 @@ import {
   PLANT_SEED_INTERVAL,
   PLANT_SPECIES_CAP,
   SEED_RAIN_INTERVAL,
+  WIDTH_SCALE,
   WORLD_H,
   WORLD_W,
 } from '@/app/micro-land/domain/constants'
@@ -488,7 +489,14 @@ export function spawnSomewhereSensible(
   return spawnCreature(w, bp, spot.x, spot.y)
 }
 
-/** Seed a theme's resident population. */
+/**
+ * Seed a theme's resident population.
+ *
+ * Starter counts are written per screen of land, and scaled up here rather than
+ * in each theme so the numbers stay readable as what they are: 34 sunleaf is a
+ * meadow, and it should still be a meadow in a world three times the size
+ * instead of a thin scattering the player has to go looking for.
+ */
 export function seedStarters(w: WorldState, themeId: string, rng: Rng): void {
   const theme = THEME_BY_ID[themeId]
   if (!theme) return
@@ -497,7 +505,8 @@ export function seedStarters(w: WorldState, themeId: string, rng: Rng): void {
     const bp = w.blueprints[entry.id]
     if (!bp) continue
     if (!w.natives.includes(bp.id)) w.natives.push(bp.id)
-    for (let i = 0; i < entry.count; i++) spawnSomewhereSensible(w, bp, rng)
+    const count = Math.round(entry.count * WIDTH_SCALE)
+    for (let i = 0; i < count; i++) spawnSomewhereSensible(w, bp, rng)
   }
 }
 

--- a/src/app/micro-land/domain/terrain.ts
+++ b/src/app/micro-land/domain/terrain.ts
@@ -22,7 +22,14 @@ import type { Theme } from './config/themes'
 import type { MaterialId } from './types'
 
 const MAP_MIN = 6
-const MAP_MAX_COLS = 96
+/**
+ * Wide enough for a model to draw the whole world at once.
+ *
+ * A world 672 tiles across wants roughly 120 map columns to keep its cells
+ * square. This sits well above that so a model that draws generously gets its
+ * detail scaled down rather than chopped off at the right-hand edge.
+ */
+const MAP_MAX_COLS = 200
 const MAP_MAX_ROWS = 48
 const MAX_LEGEND = 14
 
@@ -90,7 +97,7 @@ export const TerrainSchema = z.object({
   map: z
     .array(z.string())
     .describe(
-      'The world drawn as rows of characters, top row = sky, bottom row = the very bottom of the world. Aim for about 40 characters wide and 24 rows tall; every row must be the same length. Use "." for empty air. This gets scaled up and roughened, so draw the big shapes — hills, caves, a shoreline, a lava layer — and let the detail happen on its own.'
+      'The world drawn as rows of characters, top row = sky, bottom row = the very bottom of the world. The world is WIDE — aim for about 120 characters across and 24 rows tall; every row must be the same length. Use "." for empty air. This gets scaled up and roughened, so draw the big shapes — hills, caves, a shoreline, a lava layer — and let the detail happen on its own. Vary it from one end to the other: it is a long stretch of land, not one scene repeated.'
     ),
 })
 
@@ -240,6 +247,14 @@ export function fitGroundLevel(map: string[], rng: Rng): string[] {
  * The sample point is nudged by a little fbm noise before it's floored, which
  * is what turns the map's straight cell edges into ragged, natural-looking
  * boundaries. Without it a 40x24 map upscaled 5x reads as obvious blocks.
+ *
+ * Horizontal scale is *not* simply "stretch the map to fit". The world is five
+ * times wider than it is tall, so stretching a 40-column map across it makes
+ * every cell three times wider than it is deep — hills become plateaus, caves
+ * become tunnels, and the whole thing reads as a smear. Instead a cell is kept
+ * square, and a map too narrow to reach the far edge is repeated, mirrored, so
+ * the seams line up and the land simply carries on. A model that draws the full
+ * ~120 columns never repeats at all.
  */
 export function paintTerrain(
   tiles: Uint8Array,
@@ -252,17 +267,31 @@ export function paintTerrain(
   const cols = map[0].length
   const noise = makeNoise2D(Math.floor(rng() * 1e9))
 
-  const scaleX = cols / WORLD_W
   const scaleY = rows / WORLD_H
+  // How many columns a map would need to cross the world with square cells.
+  const squareCols = WORLD_W * scaleY
+  const repeats = cols < squareCols - 0.5
+  // A map drawn *wider* than that is squeezed to fit instead of repeated. There
+  // is no third option — the rows have to span the world's full height, which
+  // fixes the vertical scale — and squeezing is much the gentler failure: it
+  // makes hills steeper, where the old stretch made them into plateaus.
+  const scaleX = repeats ? scaleY : cols / WORLD_W
+  // Out and back again, so the joins are reflections rather than hard cuts.
+  const period = cols * 2
+
   // Roughen by about half a map cell, in world tiles.
-  const wobble = Math.max(1, Math.min(WORLD_W / cols, WORLD_H / rows) * 0.65)
+  const wobble = Math.max(1, Math.min(1 / scaleX, 1 / scaleY) * 0.65)
 
   for (let y = 0; y < WORLD_H; y++) {
     for (let x = 0; x < WORLD_W; x++) {
       const nx = (fbm(noise, x * 0.09, y * 0.09, 2) - 0.5) * 2 * wobble
       const ny = (fbm(noise, x * 0.09 + 31.7, y * 0.09 - 12.3, 2) - 0.5) * 2 * wobble
 
-      const cx = Math.floor((x + nx) * scaleX)
+      let cx = Math.floor((x + nx) * scaleX)
+      if (repeats) {
+        const p = ((cx % period) + period) % period
+        cx = p < cols ? p : period - 1 - p
+      }
       const cy = Math.floor((y + ny) * scaleY)
       const row = map[Math.max(0, Math.min(rows - 1, cy))]
       const ch = row[Math.max(0, Math.min(cols - 1, cx))] ?? '.'

--- a/src/app/micro-land/game-instance.ts
+++ b/src/app/micro-land/game-instance.ts
@@ -22,8 +22,8 @@ import {
   rememberSpecies,
   updateChronicle,
 } from './chronicle/chronicle'
-import { MILESTONES, type MilestoneContext } from './domain/config/milestones'
 import { artSize, bodyBox, sanitizeBlueprint } from './domain/blueprint'
+import { MILESTONES, type MilestoneContext } from './domain/config/milestones'
 import { DEFAULT_THEME, THEME_BY_ID, type Theme } from './domain/config/themes'
 import {
   ELDER_MIN_SECONDS,
@@ -86,6 +86,27 @@ function readMilestones(): EarnedMilestone[] {
   }))
 }
 
+/** Held-key and held-button pan speed, world tiles per second. */
+const PAN_SPEED = 115
+
+/** One wheel notch or one arrow-button tap, in world tiles. */
+const PAN_STEP = 34
+
+/**
+ * How close to the edge you can drag something before the world starts sliding.
+ *
+ * Expressed as a fraction of the view rather than a tile count so it behaves the
+ * same on a phone showing 224 tiles and a monitor showing 400.
+ */
+const EDGE_BAND = 0.12
+const EDGE_SPEED = 90
+
+/** How hard the camera chases the creature the inspector is watching. */
+const FOLLOW_SPEED = 90
+
+/** Drag further than this and a tap was really a pan. CSS pixels. */
+const TAP_SLOP = 6
+
 export class GameInstance {
   private canvas: HTMLCanvasElement
   private renderer: Renderer
@@ -134,6 +155,30 @@ export class GameInstance {
   private lastPlaceAt = 0
   private resizeObserver: ResizeObserver | null = null
 
+  // --- camera state ---
+  /** Every pointer currently down, so a second finger can be noticed. */
+  private pointers = new Map<number, number>()
+  /** Client X where a drag-pan started, and the camera position it started at. */
+  private panAnchorX = 0
+  private panAnchorCam = 0
+  private panning = false
+  /** -1, 0 or 1 — an arrow key or arrow button being held down. */
+  private panHeld = 0
+  /** Direction keys currently held, so releasing one of two doesn't stop both. */
+  private keysDown = new Set<string>()
+  /** A look-mode tap waiting to see whether it turns into a pan. */
+  private pendingInspect: { id: number | null } | null = null
+  /** The pointer went down on the minimap, so it belongs to the minimap. */
+  private scrubbingMap = false
+  /**
+   * Whether the camera is still chasing the inspected creature.
+   *
+   * Cleared the moment the player pans by hand: following is a convenience, and
+   * a camera that drags itself back after you deliberately looked somewhere else
+   * is not a convenience.
+   */
+  private following = false
+
   constructor(canvas: HTMLCanvasElement) {
     this.canvas = canvas
     this.renderer = new Renderer(canvas)
@@ -175,6 +220,7 @@ export class GameInstance {
     const apply = () => {
       const rect = parent.getBoundingClientRect()
       this.renderer.resize(rect.width, rect.height)
+      useMicroLand.getState().setCanPan(!this.renderer.fitsOnScreen)
     }
     apply()
     this.resizeObserver = new ResizeObserver(apply)
@@ -218,7 +264,54 @@ export class GameInstance {
     // Keep the grabbed creature glued to the finger even while paused.
     if (this.grabbed) this.grabbed.vx = this.grabbed.vy = 0
 
+    // Panning runs off wall-clock rather than the sim clock, so the camera
+    // answers at the same speed whether the world is paused or on fast-forward.
+    this.updateCamera(delta / 1000)
+
     this.renderer.render(this.world, theme, this.inspectedId, this.elderId)
+  }
+
+  /**
+   * Move the camera for anything that isn't a direct drag.
+   *
+   * Held keys and held buttons, carrying a creature past the edge, and chasing
+   * whatever the inspector is watching. Drag-panning is absolute and lives in
+   * the pointer handler; everything here is per-second and belongs on a clock.
+   */
+  private updateCamera(dt: number): void {
+    if (this.panHeld !== 0) {
+      this.following = false
+      this.renderer.panBy(this.panHeld * PAN_SPEED * dt)
+    }
+
+    // Carry a creature to the edge and the world comes with it — otherwise
+    // there is no way to move something from one end of the world to the other.
+    if (this.grabbed && this.pointerDown && !this.panning) {
+      const view = this.renderer.viewWidth
+      const cam = this.renderer.cameraX
+      const held = this.grabbed.x
+      let dir = 0
+      if (held < cam + view * EDGE_BAND) dir = -1
+      else if (held > cam + view * (1 - EDGE_BAND)) dir = 1
+
+      if (dir !== 0) {
+        this.renderer.panBy(dir * EDGE_SPEED * dt)
+        // The creature is positioned from the pointer, and the pointer isn't
+        // moving — so without dragging it along by the same amount it would slip
+        // out of the edge band on the first frame and the scroll would stop dead.
+        const moved = this.renderer.cameraX - cam
+        const bp = this.world.blueprints[this.grabbed.blueprintId]
+        const bw = bp ? artSize(bp).w : 0
+        this.grabbed.x = Math.max(0, Math.min(this.world.width - bw, held + moved))
+      }
+    }
+
+    if (this.following && this.inspectedId !== null) {
+      const c = this.world.creatures.find((x) => x.id === this.inspectedId)
+      if (c) {
+        this.renderer.keepInView(c.x, this.renderer.viewWidth * 0.22, FOLLOW_SPEED * dt)
+      }
+    }
   }
 
   private step(gravity: number, events: SimEvent[]): void {
@@ -548,6 +641,7 @@ export class GameInstance {
     if (!c) {
       // It died while we were watching. Let go rather than freezing a corpse.
       this.inspectedId = null
+    this.following = false
       store.setInspected(null)
       return
     }
@@ -609,6 +703,7 @@ export class GameInstance {
       clearCreatures(this.world)
       this.knownSpecies.clear()
       this.inspectedId = null
+    this.following = false
     }
     this.renderer.markTilesDirty()
     useMicroLand.getState().setSummonedLand(terrain.name)
@@ -626,6 +721,7 @@ export class GameInstance {
       clearCreatures(this.world)
       this.knownSpecies.clear()
       this.inspectedId = null
+    this.following = false
       this.renderer.markTilesDirty()
       this.beginLand()
       this.pushStats()
@@ -637,6 +733,7 @@ export class GameInstance {
     clearCreatures(this.world)
     this.knownSpecies.clear()
     this.inspectedId = null
+    this.following = false
     seedStarters(this.world, themeId, this.rng)
     this.renderer.markTilesDirty()
     this.beginLand()
@@ -651,6 +748,7 @@ export class GameInstance {
       clearCreatures(this.world)
       this.knownSpecies.clear()
       this.inspectedId = null
+    this.following = false
       this.renderer.markTilesDirty()
       this.beginLand()
       this.pushStats()
@@ -660,6 +758,7 @@ export class GameInstance {
     clearCreatures(this.world)
     this.knownSpecies.clear()
     this.inspectedId = null
+    this.following = false
     seedStarters(this.world, themeId, this.rng)
     this.renderer.markTilesDirty()
     this.beginLand()
@@ -674,6 +773,7 @@ export class GameInstance {
     this.world.dormant = true
     this.knownSpecies.clear()
     this.inspectedId = null
+    this.following = false
     // Emptying the world is an extinction of everything, so the streak goes with
     // it — but silently, since the player did it on purpose.
     this.beginLand()
@@ -707,18 +807,89 @@ export class GameInstance {
   // Input
   // -------------------------------------------------------------------------
 
+  // --- camera, driven from the UI ------------------------------------------
+
+  /** Start or stop a held pan. Used by the on-screen arrows. */
+  holdPan(direction: -1 | 0 | 1): void {
+    this.panHeld = direction
+    if (direction !== 0) this.following = false
+  }
+
+  /** One tap's worth of pan, for a click that never becomes a hold. */
+  nudgePan(direction: -1 | 1): void {
+    this.following = false
+    this.renderer.panBy(direction * PAN_STEP)
+  }
+
+  // --- pointer --------------------------------------------------------------
+
+  private beginPan(clientX: number): void {
+    this.panning = true
+    this.following = false
+    this.panAnchorX = clientX
+    this.panAnchorCam = this.renderer.cameraX
+  }
+
+  /** Midpoint of every finger down, so a two-finger pan doesn't pivot. */
+  private pointerCenterX(): number {
+    let sum = 0
+    for (const x of this.pointers.values()) sum += x
+    return this.pointers.size > 0 ? sum / this.pointers.size : 0
+  }
+
+  /** Let go of whatever the first finger had started, without acting on it. */
+  private cancelPointerAction(): void {
+    if (this.grabbed) {
+      this.grabbed.vx = 0
+      this.grabbed.vy = 0
+      this.grabbed = null
+      this.grabTrail = []
+    }
+    this.pendingInspect = null
+  }
+
   private onPointerDown = (e: PointerEvent) => {
+    this.pointers.set(e.pointerId, e.clientX)
+
+    // A second finger always means "move the world", whatever the first one had
+    // started doing. Two fingers on a canvas is a pan everywhere else on a
+    // phone, and the alternative — painting from both — is nobody's intent.
+    if (this.pointers.size === 2) {
+      this.cancelPointerAction()
+      this.beginPan(this.pointerCenterX())
+      return
+    }
+    if (this.pointers.size > 2) {
+      this.reanchorPan()
+      return
+    }
     if (!e.isPrimary) return
+
     this.canvas.setPointerCapture(e.pointerId)
+    this.canvas.focus({ preventScroll: true })
     this.pointerDown = true
+
+    // The minimap is painted on the world canvas, so it has to be given the
+    // chance to claim a tap before the tap is allowed to dig a hole. The flag
+    // has to outlive the tap, too: without it the next pointermove would fall
+    // straight through to the paint tool and carve a trench under the map.
+    const jump = this.renderer.minimapHit(e.clientX, e.clientY)
+    if (jump !== null) {
+      this.scrubbingMap = true
+      this.following = false
+      this.renderer.centerOn(jump)
+      return
+    }
 
     const p = this.renderer.screenToWorld(e.clientX, e.clientY)
     const hit = this.creatureAt(p.x, p.y)
 
     if (useMicroLand.getState().tool.kind === 'inspect') {
-      // Tapping nothing clears the selection, which is how you close the panel.
-      this.inspectedId = hit ? hit.id : null
-      this.pushInspected()
+      // Look mode has nothing to paint, so a drag is free to mean "pan" — the
+      // one place a single finger can move the world without ambiguity. The
+      // selection is resolved on release, so a pan doesn't also deselect.
+      this.pendingInspect = { id: hit ? hit.id : null }
+      this.beginPan(e.clientX)
       return
     }
 
@@ -734,7 +905,28 @@ export class GameInstance {
   }
 
   private onPointerMove = (e: PointerEvent) => {
+    if (this.pointers.has(e.pointerId)) this.pointers.set(e.pointerId, e.clientX)
+
+    if (this.panning) {
+      const from = this.pointers.size >= 2 ? this.pointerCenterX() : e.clientX
+      const dx = from - this.panAnchorX
+      // A tap that has turned into a drag is no longer a tap.
+      if (this.pendingInspect && Math.abs(dx) > TAP_SLOP) this.pendingInspect = null
+      this.renderer.panToLeft(
+        this.panAnchorCam - dx * this.renderer.tilesPerClientPixel()
+      )
+      return
+    }
+
     if (!this.pointerDown || !e.isPrimary) return
+
+    // Drag along the map and the world follows — the fastest way to cross it.
+    if (this.scrubbingMap) {
+      const jump = this.renderer.minimapHit(e.clientX, e.clientY)
+      if (jump !== null) this.renderer.centerOn(jump)
+      return
+    }
+
     const p = this.renderer.screenToWorld(e.clientX, e.clientY)
 
     if (this.grabbed) {
@@ -761,8 +953,23 @@ export class GameInstance {
   }
 
   private onPointerUp = (e: PointerEvent) => {
+    this.pointers.delete(e.pointerId)
+    if (this.panning && this.pointers.size === 0) this.panning = false
+    else this.reanchorPan()
+
     if (!e.isPrimary) return
     this.pointerDown = false
+    this.scrubbingMap = false
+
+    // A look-mode tap that never travelled far enough to be a pan.
+    if (this.pendingInspect) {
+      this.inspectedId = this.pendingInspect.id
+      // Following a creature you deliberately picked out is the point of
+      // watching one; following "nothing" would just freeze the camera.
+      this.following = this.pendingInspect.id !== null
+      this.pendingInspect = null
+      this.pushInspected()
+    }
 
     if (this.grabbed) {
       // Throw: velocity from how fast the pointer was moving as it let go.
@@ -844,11 +1051,83 @@ export class GameInstance {
     return null
   }
 
+  /** Fingers came or went mid-pan — take a fresh reading so it doesn't jump. */
+  private reanchorPan(): void {
+    if (!this.panning || this.pointers.size === 0) return
+    this.panAnchorX = this.pointerCenterX()
+    this.panAnchorCam = this.renderer.cameraX
+  }
+
+  /**
+   * A wheel or trackpad scrolls the world sideways.
+   *
+   * Vertical scroll is folded in as well as horizontal: there is nothing above
+   * or below to scroll to, and a mouse with one wheel is still the most common
+   * way anyone will touch this.
+   */
+  private onWheel = (e: WheelEvent) => {
+    const raw = Math.abs(e.deltaX) > Math.abs(e.deltaY) ? e.deltaX : e.deltaY
+    if (raw === 0) return
+    e.preventDefault()
+    this.following = false
+    // deltaMode: 0 pixels, 1 lines, 2 pages.
+    const unit = e.deltaMode === 1 ? 16 : e.deltaMode === 2 ? 400 : 1
+    const tiles = raw * unit * 0.25
+    this.renderer.panBy(Math.max(-PAN_STEP, Math.min(PAN_STEP, tiles)))
+  }
+
+  /** Which way, if any, does this key point? */
+  private static keyDirection(key: string): -1 | 0 | 1 {
+    if (key === 'ArrowLeft' || key === 'a' || key === 'A') return -1
+    if (key === 'ArrowRight' || key === 'd' || key === 'D') return 1
+    return 0
+  }
+
+  private onKeyDown = (e: KeyboardEvent) => {
+    if (e.metaKey || e.ctrlKey || e.altKey) return
+
+    if (e.key === 'Home' || e.key === 'End') {
+      e.preventDefault()
+      this.following = false
+      this.renderer.panToLeft(e.key === 'Home' ? 0 : this.world.width)
+      return
+    }
+
+    const dir = GameInstance.keyDirection(e.key)
+    if (dir === 0) return
+    e.preventDefault()
+    this.keysDown.add(e.key)
+    this.panHeld = dir
+    this.following = false
+  }
+
+  private onKeyUp = (e: KeyboardEvent) => {
+    this.keysDown.delete(e.key)
+    // Holding both arrows and releasing one should leave you moving the other
+    // way, not stop dead.
+    let dir: -1 | 0 | 1 = 0
+    for (const key of this.keysDown) {
+      const d = GameInstance.keyDirection(key)
+      if (d !== 0) dir = d
+    }
+    this.panHeld = dir
+  }
+
+  /** A canvas that lost focus can't hear a keyup, so it must not stay stuck. */
+  private onBlur = () => {
+    this.keysDown.clear()
+    this.panHeld = 0
+  }
+
   private attachInput(): void {
     this.canvas.addEventListener('pointerdown', this.onPointerDown)
     this.canvas.addEventListener('pointermove', this.onPointerMove)
     this.canvas.addEventListener('pointerup', this.onPointerUp)
     this.canvas.addEventListener('pointercancel', this.onPointerUp)
+    this.canvas.addEventListener('wheel', this.onWheel, { passive: false })
+    this.canvas.addEventListener('keydown', this.onKeyDown)
+    this.canvas.addEventListener('keyup', this.onKeyUp)
+    this.canvas.addEventListener('blur', this.onBlur)
   }
 
   private detachInput(): void {
@@ -856,5 +1135,9 @@ export class GameInstance {
     this.canvas.removeEventListener('pointermove', this.onPointerMove)
     this.canvas.removeEventListener('pointerup', this.onPointerUp)
     this.canvas.removeEventListener('pointercancel', this.onPointerUp)
+    this.canvas.removeEventListener('wheel', this.onWheel)
+    this.canvas.removeEventListener('keydown', this.onKeyDown)
+    this.canvas.removeEventListener('keyup', this.onKeyUp)
+    this.canvas.removeEventListener('blur', this.onBlur)
   }
 }

--- a/src/app/micro-land/rendering/renderer.ts
+++ b/src/app/micro-land/rendering/renderer.ts
@@ -10,10 +10,17 @@
  * Light is a quarter-resolution field (sky from above, plus glowing tiles and
  * creatures), blurred and composited as a darkness layer *after* sprites, so
  * creatures are dimmed by the same shadows as the terrain.
+ *
+ * The world is wider than the screen, so there is a camera. It only moves
+ * horizontally and it only ever sits on whole tiles: a camera at x = 12.4 would
+ * resample every tile in the world onto a half-pixel and undo the one thing this
+ * renderer exists to protect. Every per-frame pass below — tiles, light, shadow,
+ * sprites — is clipped to the visible column range, which is what keeps a world
+ * three times the size costing about what one screen used to.
  */
 import { MATERIAL_BY_INDEX } from '@/app/micro-land/domain/config/materials'
 import type { Theme } from '@/app/micro-land/domain/config/themes'
-import { WORLD_H, WORLD_W } from '@/app/micro-land/domain/constants'
+import { VIEW_W, WORLD_H, WORLD_W } from '@/app/micro-land/domain/constants'
 import type { WorldState } from '@/app/micro-land/domain/types'
 
 import { getSprites } from './sprite-cache'
@@ -26,6 +33,34 @@ const LH = Math.ceil(WORLD_H / LIGHT_SCALE)
 /** How far daylight reaches below the first solid tile in a column, in tiles. */
 const SKY_FALLOFF = 16
 
+/**
+ * Columns of slack baked either side of the view.
+ *
+ * Tiles are re-baked whenever the sand moves, which is 20 times a second, so
+ * this margin mostly buys nothing while the world is running. It earns its keep
+ * while paused, where panning would otherwise re-bake on every single frame.
+ */
+const TILE_MARGIN = 32
+
+/**
+ * Light bleeds sideways through the blur, so it's gathered a little wider.
+ *
+ * Has to cover more than the blur reaches. Each of the three passes pulls in one
+ * coarse cell from outside the gathered range — which is stale, because nothing
+ * out there was computed — so the outermost three cells of the margin are wrong
+ * by the end. At 4 tiles per cell this leaves three clean cells of slack beyond
+ * that before the visible edge starts.
+ */
+const LIGHT_MARGIN = 24
+
+/** The minimap is a whole-world thumbnail at this many tiles per pixel. */
+const MAP_SCALE = 4
+const MW = Math.ceil(WORLD_W / MAP_SCALE)
+const MH = Math.ceil(WORLD_H / MAP_SCALE)
+
+/** Frames between minimap refreshes. It's a thumbnail; 5Hz is more than enough. */
+const MAP_REFRESH_FRAMES = 12
+
 interface Rgb {
   r: number
   g: number
@@ -35,6 +70,14 @@ interface Rgb {
 function hexToRgb(hex: string): Rgb {
   const n = parseInt(hex.slice(1), 16)
   return { r: (n >> 16) & 255, g: (n >> 8) & 255, b: n & 255 }
+}
+
+/** Where the minimap ended up on the display, in device pixels. */
+export interface MapRect {
+  x: number
+  y: number
+  w: number
+  h: number
 }
 
 export class Renderer {
@@ -50,6 +93,9 @@ export class Renderer {
   private tileCanvas: HTMLCanvasElement
   private tileCtx: CanvasRenderingContext2D
   private tilesDirty = true
+  /** Column range currently baked into `tileCanvas`; outside it is stale. */
+  private builtX0 = 0
+  private builtX1 = 0
 
   /** Darkness overlay, world resolution. */
   private shadowImage: ImageData
@@ -60,12 +106,27 @@ export class Renderer {
   private lightScratch = new Float32Array(LW * LH)
   private skyDepth = new Int16Array(WORLD_W)
 
+  /** Whole-world thumbnail behind the minimap. */
+  private mapImage: ImageData
+  private mapCanvas: HTMLCanvasElement
+  private mapCtx: CanvasRenderingContext2D
+  private mapAge = MAP_REFRESH_FRAMES
+  private mapRect: MapRect = { x: 0, y: 0, w: 0, h: 0 }
+
   private materialRgb: Rgb[]
 
   /** Placement of the world inside the display canvas. */
   private scale = 1
   private offsetX = 0
   private offsetY = 0
+
+  /**
+   * Left edge of the view in world tiles. Kept fractional so a slow pan can
+   * accumulate, but always floored before anything is drawn from it.
+   */
+  private camX = 0
+  /** How many world tiles the display is wide at the current scale. */
+  private viewTiles = VIEW_W
 
   constructor(display: HTMLCanvasElement) {
     this.display = display
@@ -90,6 +151,12 @@ export class Renderer {
     this.shadowCtx = this.shadowCanvas.getContext('2d')!
     this.shadowImage = this.shadowCtx.createImageData(WORLD_W, WORLD_H)
 
+    this.mapCanvas = document.createElement('canvas')
+    this.mapCanvas.width = MW
+    this.mapCanvas.height = MH
+    this.mapCtx = this.mapCanvas.getContext('2d')!
+    this.mapImage = this.mapCtx.createImageData(MW, MH)
+
     this.materialRgb = MATERIAL_BY_INDEX.map((m) => hexToRgb(m.color))
   }
 
@@ -105,11 +172,86 @@ export class Renderer {
     this.display.style.width = `${cssWidth}px`
     this.display.style.height = `${cssHeight}px`
 
-    // Fit the whole world in view — it's a terrarium, you should see all of it.
-    const fit = Math.min(this.display.width / WORLD_W, this.display.height / WORLD_H)
+    // Zoom is fixed by VIEW_W, not by the whole world: a tile is sized so that
+    // one screen's worth spans the canvas, exactly as it did when the world was
+    // one screen wide. Whatever extra height allows, you simply get to see.
+    const fit = Math.min(this.display.width / VIEW_W, this.display.height / WORLD_H)
     this.scale = fit
-    this.offsetX = Math.floor((this.display.width - WORLD_W * fit) / 2)
+    this.viewTiles = Math.min(WORLD_W, this.display.width / fit)
+    this.offsetX = Math.floor((this.display.width - this.viewTiles * fit) / 2)
     this.offsetY = Math.floor((this.display.height - WORLD_H * fit) / 2)
+    this.clampCam()
+  }
+
+  // -------------------------------------------------------------------------
+  // Camera
+  // -------------------------------------------------------------------------
+
+  /** Left edge of the view, in world tiles. */
+  get cameraX(): number {
+    return this.camX
+  }
+
+  /** How much world is on screen right now, in tiles. */
+  get viewWidth(): number {
+    return this.viewTiles
+  }
+
+  /** True when the whole world already fits — nothing to scroll to. */
+  get fitsOnScreen(): boolean {
+    return this.viewTiles >= WORLD_W
+  }
+
+  panBy(tiles: number): void {
+    this.camX += tiles
+    this.clampCam()
+  }
+
+  /** Put this world column at the left edge of the view. */
+  panToLeft(tile: number): void {
+    this.camX = tile
+    this.clampCam()
+  }
+
+  /** Put this world column in the middle of the view. */
+  centerOn(worldX: number): void {
+    this.camX = worldX - this.viewTiles / 2
+    this.clampCam()
+  }
+
+  /**
+   * Slide just far enough to bring a point back on screen.
+   *
+   * Used to keep a creature you're carrying — or watching — from walking off
+   * the edge of the view and leaving you looking at nothing.
+   */
+  keepInView(worldX: number, margin: number, maxTiles: number): void {
+    const left = this.camX + margin
+    const right = this.camX + this.viewTiles - margin
+    if (worldX < left) this.panBy(Math.max(-maxTiles, worldX - left))
+    else if (worldX > right) this.panBy(Math.min(maxTiles, worldX - right))
+  }
+
+  private clampCam(): void {
+    this.camX = Math.max(0, Math.min(WORLD_W - this.viewTiles, this.camX))
+  }
+
+  /**
+   * How many world tiles one CSS pixel of horizontal drag is worth.
+   *
+   * Drag-panning can't be built out of `screenToWorld` differences: that already
+   * has the camera folded into it, so moving the camera moves the answer and the
+   * two cancel out to a world that won't budge.
+   */
+  tilesPerClientPixel(): number {
+    const rect = this.display.getBoundingClientRect()
+    if (rect.width === 0) return 0
+    return this.display.width / rect.width / this.scale
+  }
+
+  /** Whole-tile left edge. Everything drawn this frame is measured from here. */
+  private viewLeft(): number {
+    return Math.floor(this.camX)
   }
 
   /** Display pixel → world tile. Used by every pointer interaction. */
@@ -119,10 +261,30 @@ export class Renderer {
     const px = (clientX - rect.left) * dpr
     const py = (clientY - rect.top) * dpr
     return {
-      x: (px - this.offsetX) / this.scale,
+      x: this.viewLeft() + (px - this.offsetX) / this.scale,
       y: (py - this.offsetY) / this.scale,
     }
   }
+
+  /**
+   * Was this tap on the minimap, and if so where in the world does it point?
+   *
+   * Returns the world column to centre on, or null if the tap missed. The
+   * minimap is the only part of the world canvas that isn't the world, so it
+   * has to be asked about before a tap is allowed to paint anything.
+   */
+  minimapHit(clientX: number, clientY: number): number | null {
+    const m = this.mapRect
+    if (m.w <= 0) return null
+    const rect = this.display.getBoundingClientRect()
+    const dpr = this.display.width / rect.width
+    const px = (clientX - rect.left) * dpr
+    const py = (clientY - rect.top) * dpr
+    if (px < m.x || px > m.x + m.w || py < m.y || py > m.y + m.h) return null
+    return ((px - m.x) / m.w) * WORLD_W
+  }
+
+  // -------------------------------------------------------------------------
 
   render(
     w: WorldState,
@@ -130,11 +292,11 @@ export class Renderer {
     highlightId: number | null = null,
     elderId: number | null = null
   ): void {
-    if (this.tilesDirty) {
-      this.buildTiles(w)
-      this.tilesDirty = false
-    }
-    this.buildLight(w, theme)
+    const vx = this.viewLeft()
+    const vw = Math.min(WORLD_W - vx, Math.ceil(this.viewTiles))
+
+    this.ensureTiles(w, vx, vw)
+    this.buildLight(w, theme, vx, vw)
 
     const wctx = this.wctx
     wctx.imageSmoothingEnabled = false
@@ -144,13 +306,13 @@ export class Renderer {
     sky.addColorStop(0, theme.sky[0])
     sky.addColorStop(1, theme.sky[1])
     wctx.fillStyle = sky
-    wctx.fillRect(0, 0, WORLD_W, WORLD_H)
+    wctx.fillRect(vx, 0, vw, WORLD_H)
 
-    wctx.drawImage(this.tileCanvas, 0, 0)
+    wctx.drawImage(this.tileCanvas, vx, 0, vw, WORLD_H, vx, 0, vw, WORLD_H)
 
-    this.drawCreatures(w)
-    this.drawParticles(w)
-    wctx.drawImage(this.shadowCanvas, 0, 0)
+    this.drawCreatures(w, vx, vw)
+    this.drawParticles(w, vx, vw)
+    wctx.drawImage(this.shadowCanvas, vx, 0, vw, WORLD_H, vx, 0, vw, WORLD_H)
     // Both drawn after the shadow so they stay legible in a dark cave. The halo
     // goes first so the selection brackets sit on top when you inspect an elder.
     if (elderId !== null) this.drawElder(w, elderId)
@@ -163,54 +325,81 @@ export class Renderer {
     ctx.fillRect(0, 0, this.display.width, this.display.height)
     ctx.drawImage(
       this.world,
+      vx,
       0,
-      0,
-      WORLD_W,
+      this.viewTiles,
       WORLD_H,
       this.offsetX,
       this.offsetY,
-      WORLD_W * this.scale,
+      this.viewTiles * this.scale,
       WORLD_H * this.scale
     )
+
+    this.drawMinimap(w, theme, vx)
   }
 
   // -------------------------------------------------------------------------
 
-  private buildTiles(w: WorldState): void {
+  /** Re-bake the tile colours if the view has left the range we baked last. */
+  private ensureTiles(w: WorldState, vx: number, vw: number): void {
+    const covered = !this.tilesDirty && vx >= this.builtX0 && vx + vw <= this.builtX1
+    if (covered) return
+
+    const x0 = Math.max(0, vx - TILE_MARGIN)
+    const x1 = Math.min(WORLD_W, vx + vw + TILE_MARGIN)
+    this.buildTiles(w, x0, x1)
+    this.builtX0 = x0
+    this.builtX1 = x1
+    this.tilesDirty = false
+  }
+
+  private buildTiles(w: WorldState, x0: number, x1: number): void {
     const data = this.tileImage.data
     const tiles = w.tiles
     const grain = w.grain
     const rgb = this.materialRgb
     const materials = MATERIAL_BY_INDEX
 
-    for (let i = 0; i < tiles.length; i++) {
-      const mat = tiles[i]
-      const o = i * 4
-      if (mat === 0) {
-        // Air — leave it transparent so the sky gradient shows through.
-        data[o + 3] = 0
-        continue
+    for (let y = 0; y < WORLD_H; y++) {
+      const row = y * WORLD_W
+      for (let x = x0; x < x1; x++) {
+        const i = row + x
+        const mat = tiles[i]
+        const o = i * 4
+        if (mat === 0) {
+          // Air — leave it transparent so the sky gradient shows through.
+          data[o + 3] = 0
+          continue
+        }
+        const base = rgb[mat]
+        // Per-tile jitter stops large fills from looking like flat blocks.
+        const jitter = ((grain[i] / 255) * 2 - 1) * materials[mat].grain
+        const k = 1 + jitter
+        data[o] = Math.max(0, Math.min(255, base.r * k))
+        data[o + 1] = Math.max(0, Math.min(255, base.g * k))
+        data[o + 2] = Math.max(0, Math.min(255, base.b * k))
+        data[o + 3] = 255
       }
-      const base = rgb[mat]
-      // Per-tile jitter stops large fills from looking like flat blocks.
-      const jitter = ((grain[i] / 255) * 2 - 1) * materials[mat].grain
-      const k = 1 + jitter
-      data[o] = Math.max(0, Math.min(255, base.r * k))
-      data[o + 1] = Math.max(0, Math.min(255, base.g * k))
-      data[o + 2] = Math.max(0, Math.min(255, base.b * k))
-      data[o + 3] = 255
     }
 
-    this.tileCtx.putImageData(this.tileImage, 0, 0)
+    this.tileCtx.putImageData(this.tileImage, 0, 0, x0, 0, x1 - x0, WORLD_H)
   }
 
-  private buildLight(w: WorldState, theme: Theme): void {
+  private buildLight(w: WorldState, theme: Theme, vx: number, vw: number): void {
+    // Light spreads sideways as it blurs, so it is gathered a little beyond the
+    // view — otherwise the lava just off screen stops lighting the cave mouth
+    // you can see, and the edge of the screen visibly darkens as you pan.
+    const gx0 = Math.max(0, vx - LIGHT_MARGIN)
+    const gx1 = Math.min(WORLD_W, vx + vw + LIGHT_MARGIN)
+    const lx0 = Math.floor(gx0 / LIGHT_SCALE)
+    const lx1 = Math.min(LW, Math.ceil(gx1 / LIGHT_SCALE))
+
     const light = this.light
-    light.fill(0)
+    for (let ly = 0; ly < LH; ly++) light.fill(0, ly * LW + lx0, ly * LW + lx1)
 
     // --- daylight: how far below the first solid tile is each column? ---
     const tiles = w.tiles
-    for (let x = 0; x < WORLD_W; x++) {
+    for (let x = gx0; x < gx1; x++) {
       let y = 0
       while (y < WORLD_H && MATERIAL_BY_INDEX[tiles[y * WORLD_W + x]].solid === false) {
         y++
@@ -220,7 +409,7 @@ export class Renderer {
 
     for (let ly = 0; ly < LH; ly++) {
       const wy = ly * LIGHT_SCALE + LIGHT_SCALE / 2
-      for (let lx = 0; lx < LW; lx++) {
+      for (let lx = lx0; lx < lx1; lx++) {
         const wx = Math.min(WORLD_W - 1, lx * LIGHT_SCALE + (LIGHT_SCALE >> 1))
         const surface = this.skyDepth[wx]
         const below = wy - surface
@@ -234,7 +423,7 @@ export class Renderer {
     // --- emitters: glowing tiles ---
     // Sampled every other tile; the blur smooths over the gaps.
     for (let y = 0; y < WORLD_H; y += 2) {
-      for (let x = 0; x < WORLD_W; x += 2) {
+      for (let x = gx0; x < gx1; x += 2) {
         const mat = MATERIAL_BY_INDEX[tiles[y * WORLD_W + x]]
         if (mat.glow <= 0) continue
         const li = Math.floor(y / LIGHT_SCALE) * LW + Math.floor(x / LIGHT_SCALE)
@@ -248,37 +437,38 @@ export class Renderer {
       if (!bp || bp.glow <= 0) continue
       const lx = Math.floor(c.x / LIGHT_SCALE)
       const ly = Math.floor(c.y / LIGHT_SCALE)
-      if (lx < 0 || ly < 0 || lx >= LW || ly >= LH) continue
+      if (lx < lx0 || ly < 0 || lx >= lx1 || ly >= LH) continue
       const li = ly * LW + lx
       light[li] = Math.min(1.8, light[li] + bp.glow * 1.4)
     }
 
     // --- blur, so light pools instead of forming squares ---
-    for (let pass = 0; pass < 3; pass++) this.blurLight()
+    for (let pass = 0; pass < 3; pass++) this.blurLight(lx0, lx1)
 
     // --- bake into the shadow overlay ---
     const gloom = theme.gloom
     const data = this.shadowImage.data
     for (let y = 0; y < WORLD_H; y++) {
       const ly = y / LIGHT_SCALE
-      for (let x = 0; x < WORLD_W; x++) {
+      const row = y * WORLD_W
+      for (let x = vx; x < vx + vw; x++) {
         const value = this.sampleLight(x / LIGHT_SCALE, ly)
         const alpha = Math.max(0, Math.min(1, 1 - value)) * gloom
-        const o = (y * WORLD_W + x) * 4
+        const o = (row + x) * 4
         data[o] = 4
         data[o + 1] = 3
         data[o + 2] = 12
         data[o + 3] = Math.round(alpha * 255)
       }
     }
-    this.shadowCtx.putImageData(this.shadowImage, 0, 0)
+    this.shadowCtx.putImageData(this.shadowImage, 0, 0, vx, 0, vw, WORLD_H)
   }
 
-  private blurLight(): void {
+  private blurLight(lx0: number, lx1: number): void {
     const src = this.light
     const dst = this.lightScratch
     for (let y = 0; y < LH; y++) {
-      for (let x = 0; x < LW; x++) {
+      for (let x = lx0; x < lx1; x++) {
         let sum = 0
         let count = 0
         for (let dy = -1; dy <= 1; dy++) {
@@ -294,7 +484,11 @@ export class Renderer {
         dst[y * LW + x] = sum / count
       }
     }
-    this.light.set(dst)
+    for (let y = 0; y < LH; y++) {
+      const a = y * LW + lx0
+      const b = y * LW + lx1
+      src.set(dst.subarray(a, b), a)
+    }
   }
 
   /** Bilinear sample of the coarse light field. */
@@ -317,12 +511,16 @@ export class Renderer {
     return top + (bottom - top) * ty
   }
 
-  private drawCreatures(w: WorldState): void {
+  private drawCreatures(w: WorldState, vx: number, vw: number): void {
     const ctx = this.wctx
     for (const c of w.creatures) {
       const bp = w.blueprints[c.blueprintId]
       if (!bp) continue
       const sprites = getSprites(bp)
+      // Most of the population is off screen in a world this wide. Culling here
+      // is what keeps the draw cost tied to what you can see rather than to how
+      // many things happen to be alive.
+      if (c.x + sprites.width < vx || c.x > vx + vw) continue
       const frameCount = sprites.frames.length
       const frame =
         frameCount === 1
@@ -428,13 +626,101 @@ export class Renderer {
     ctx.globalAlpha = 1
   }
 
-  private drawParticles(w: WorldState): void {
+  private drawParticles(w: WorldState, vx: number, vw: number): void {
     const ctx = this.wctx
     for (const p of w.particles) {
+      if (p.x < vx || p.x > vx + vw) continue
       ctx.globalAlpha = Math.max(0, Math.min(1, p.life / p.maxLife))
       ctx.fillStyle = p.color
       ctx.fillRect(Math.round(p.x), Math.round(p.y), 1, 1)
     }
     ctx.globalAlpha = 1
+  }
+
+  // -------------------------------------------------------------------------
+  // Minimap
+  // -------------------------------------------------------------------------
+
+  /**
+   * A thumbnail of the whole world with the view marked on it.
+   *
+   * Drawn on the canvas rather than in React because it has to stay on the same
+   * pixel grid as the world and it changes every frame — a DOM element updated
+   * at 60Hz would be the most expensive thing on the page. The buttons beside it
+   * are the real controls; this is the map that tells you where you are.
+   */
+  private drawMinimap(w: WorldState, theme: Theme, vx: number): void {
+    if (this.fitsOnScreen) {
+      this.mapRect.w = 0
+      return
+    }
+
+    this.mapAge++
+    if (this.mapAge >= MAP_REFRESH_FRAMES) {
+      this.mapAge = 0
+      this.buildMapImage(w, theme)
+    }
+
+    const dw = this.display.width
+    const dh = this.display.height
+    const width = Math.round(Math.max(140, Math.min(dw * 0.32, 520)))
+    const height = Math.round((width * MH) / MW)
+    const pad = Math.max(6, Math.round(dh * 0.025))
+    const x = Math.round((dw - width) / 2)
+    const y = dh - height - pad
+
+    this.mapRect = { x, y, w: width, h: height }
+
+    const ctx = this.ctx
+    ctx.save()
+    ctx.imageSmoothingEnabled = false
+
+    const border = Math.max(1, Math.round(width / 200))
+    ctx.fillStyle = 'rgba(5, 4, 12, 0.72)'
+    ctx.fillRect(x - border, y - border, width + border * 2, height + border * 2)
+
+    ctx.globalAlpha = 0.9
+    ctx.drawImage(this.mapCanvas, 0, 0, MW, MH, x, y, width, height)
+    ctx.globalAlpha = 1
+
+    // The view, marked. Kept at least a couple of pixels wide so it can't
+    // vanish on a narrow screen.
+    const vxPx = x + Math.round((vx / WORLD_W) * width)
+    const vwPx = Math.max(3, Math.round((this.viewTiles / WORLD_W) * width))
+    ctx.strokeStyle = '#5eead4'
+    ctx.lineWidth = Math.max(1, Math.round(width / 220))
+    ctx.strokeRect(
+      vxPx + ctx.lineWidth / 2,
+      y + ctx.lineWidth / 2,
+      Math.min(vwPx, width - (vxPx - x)) - ctx.lineWidth,
+      height - ctx.lineWidth
+    )
+
+    ctx.strokeStyle = 'rgba(94, 234, 212, 0.35)'
+    ctx.lineWidth = border
+    ctx.strokeRect(x - border / 2, y - border / 2, width + border, height + border)
+    ctx.restore()
+  }
+
+  private buildMapImage(w: WorldState, theme: Theme): void {
+    const data = this.mapImage.data
+    const tiles = w.tiles
+    const rgb = this.materialRgb
+    const sky = hexToRgb(theme.sky[1])
+
+    for (let my = 0; my < MH; my++) {
+      const wy = Math.min(WORLD_H - 1, my * MAP_SCALE)
+      for (let mx = 0; mx < MW; mx++) {
+        const wx = Math.min(WORLD_W - 1, mx * MAP_SCALE)
+        const mat = tiles[wy * WORLD_W + wx]
+        const o = (my * MW + mx) * 4
+        const c = mat === 0 ? sky : rgb[mat]
+        data[o] = c.r
+        data[o + 1] = c.g
+        data[o + 2] = c.b
+        data[o + 3] = 255
+      }
+    }
+    this.mapCtx.putImageData(this.mapImage, 0, 0)
   }
 }

--- a/src/app/micro-land/store.ts
+++ b/src/app/micro-land/store.ts
@@ -150,6 +150,13 @@ interface MicroLandState {
    */
   archive: SpeciesRecord[]
   milestones: EarnedMilestone[]
+  /**
+   * Whether the world is wider than the view.
+   *
+   * Almost always true, but an ultrawide display can fit all 672 tiles at once,
+   * and scroll buttons that visibly do nothing are worse than no buttons.
+   */
+  canPan: boolean
 
   notices: Notice[]
 
@@ -173,6 +180,7 @@ interface MicroLandState {
   setRecords: (records: RecordsView) => void
   setArchive: (archive: SpeciesRecord[]) => void
   setMilestones: (milestones: EarnedMilestone[]) => void
+  setCanPan: (canPan: boolean) => void
   notify: (text: string) => void
   dismissNotice: (id: number) => void
 }
@@ -200,6 +208,7 @@ export const useMicroLand = create<MicroLandState>((set) => ({
   pendingSummons: [],
   guideOpen: false,
   inspected: null,
+  canPan: true,
 
   records: EMPTY_RECORDS,
   archive: [],
@@ -232,6 +241,7 @@ export const useMicroLand = create<MicroLandState>((set) => ({
   setRecords: (records) => set({ records }),
   setArchive: (archive) => set({ archive }),
   setMilestones: (milestones) => set({ milestones }),
+  setCanPan: (canPan) => set({ canPan }),
 
   notify: (text) =>
     set((s) => ({


### PR DESCRIPTION
The world is **672 × 132 tiles** instead of 224 × 132 — three times as wide.

Zoom is unchanged. `VIEW_W` now holds the old width and fixes how large a tile is drawn, so a hopper is exactly the size it always was on every device. Fitting all 672 tiles on screen instead would have shrunk everything to a third, which on a phone works out to less than one pixel per tile.

## Getting around

No single gesture suits both a phone and a mouse, so there are several:

- **Arrow buttons** at the screen edges — hold to run, tap to step. The only *visible* control, and the one a screen reader finds.
- **Minimap** at the bottom of the canvas — the whole world as a thumbnail with the view marked. Tap or drag along it to jump.
- **Arrow keys / A / D**, plus Home and End. The canvas is focusable now.
- **Wheel or trackpad**, horizontal or vertical.
- **Two fingers** anywhere, or **one finger in Look mode** — Look has nothing to paint, so a drag there is free to mean pan.

Plus: carry a creature to the edge and the world scrolls under it, and the camera follows whatever the inspector is watching until you pan by hand.

## Density, not just size

Population caps, starter counts, ponds, geodes, lava falls, station rooms and the plant seed bank all scale off a single `WIDTH_SCALE`. Counts tuned against one screen are densities wearing an absolute number's clothing — left alone they don't spread out across a bigger world, they thin out.

## Summoned land

The old code stretched the model's map to fit. At 5:1 that made every cell three times wider than deep, so hills became plateaus and caves became tunnels. Cells are now kept square, and a map too narrow to reach the far edge repeats mirrored so the joins are reflections rather than cuts. The prompt asks for ~120 columns and for a journey from one end to the other; a test summon came back as coast → chalk cliffs → crystal cavern, all distinct.

## Performance

Tiles, lighting, shadow, sprites and particles are clipped to the visible columns. `look()` walks an x-sorted slice instead of the whole population — that cost was scaling with the *square* of a cap that itself scales with area.

## Testing

Driven in headless Chrome on desktop (1440×820) and mobile (390×780), across Cross-Section, Tidepool and a summoned world. Confirmed working: keyboard pan, wheel, inspect-drag, two-finger pan, minimap tap and scrub, carry-to-edge scroll — and that painting still paints without panning. No console errors. Frame times median 8.2 ms, max 15.1 ms with ~330 creatures alive (headless Chrome on an M-series Mac, so a signal rather than a number to quote).

The terrain scale/mirror arithmetic was also checked directly across map sizes from 6×24 to 200×24: every sample lands in range, adjacent world tiles never jump more than one map cell, and cells stay square except for over-wide maps, which are squeezed — the gentler failure, since the rows have to span the world's full height.

🤖 Generated with [Claude Code](https://claude.com/claude-code)