### PR TITLE
fix(a11y): toast close button aria-label + star-field prefers-reduced-motion

### DIFF
--- a/src/components/star-field.tsx
+++ b/src/components/star-field.tsx
@@ -48,6 +48,21 @@ export function StarField() {
       })
     }
 
+    const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches
+
+    if (prefersReducedMotion) {
+      // Draw static stars — no animation loop
+      stars.forEach(star => {
+        ctx.beginPath()
+        ctx.arc(star.x, star.y, star.radius, 0, Math.PI * 2)
+        ctx.fillStyle = `rgba(255, 255, 240, ${star.opacity})`
+        ctx.fill()
+      })
+      return () => {
+        window.removeEventListener('resize', resizeCanvas)
+      }
+    }
+
     // Animation loop
     let animationFrameId: number
     const animate = () => {

--- a/src/components/ui/toast.tsx
+++ b/src/components/ui/toast.tsx
@@ -80,6 +80,7 @@ const ToastClose = React.forwardRef<
       className
     )}
     toast-close=""
+    aria-label="Close"
     {...props}
   >
     <X className="h-4 w-4" />


### PR DESCRIPTION
## Summary

### Toast close button (#2623)

ToastClose rendered only an X icon inside the Radix Toast.Close button with no accessible label. Screen readers announced it as an unlabelled button. Added aria-label="Close".

### Star-field prefers-reduced-motion (#2624)

The StarField component ran a continuous requestAnimationFrame twinkling loop unconditionally, violating CLAUDE.md principle #8 ("assume reduced-motion as the baseline"). Users with prefers-reduced-motion: reduce saw continuous background animation.

Now checks window.matchMedia('(prefers-reduced-motion: reduce)') on mount — if set, draws static stars once without an animation loop.

## Test plan

- [ ] With prefers-reduced-motion: reduce set in OS/browser, confirm the home page star field is static (no twinkling)
- [ ] Without the setting, confirm stars still twinkle normally
- [ ] Tab to a dismissable toast and confirm screen reader announces "Close"