### PR TITLE
fix: add upper bounds to leaderboard and customCategory API inputs

### DIFF
--- a/src/app/api/v1/tap-tap-adventure/leaderboard/submit-score/route.ts
+++ b/src/app/api/v1/tap-tap-adventure/leaderboard/submit-score/route.ts
@@ -6,6 +6,9 @@ import { getTodayPST } from '@/lib/dates'
 const MAX_NAME_LENGTH = 20
 const MAX_CHAR_NAME_LENGTH = 50
 const MAX_REGIONS = 20
+const MAX_DISTANCE = 1_000_000
+const MAX_LEVEL = 500
+const MAX_GOLD = 10_000_000
 
 export async function POST(request: NextRequest) {
   try {
@@ -57,18 +60,18 @@ export async function POST(request: NextRequest) {
     }
 
     // Validate distance
-    if (typeof distance !== 'number' || distance < 0) {
-      return NextResponse.json({ error: 'distance must be a number >= 0.' }, { status: 400 })
+    if (typeof distance !== 'number' || distance < 0 || distance > MAX_DISTANCE) {
+      return NextResponse.json({ error: `distance must be a number between 0 and ${MAX_DISTANCE}.` }, { status: 400 })
     }
 
     // Validate level
-    if (typeof level !== 'number' || level < 1) {
-      return NextResponse.json({ error: 'level must be a number >= 1.' }, { status: 400 })
+    if (typeof level !== 'number' || level < 1 || level > MAX_LEVEL) {
+      return NextResponse.json({ error: `level must be a number between 1 and ${MAX_LEVEL}.` }, { status: 400 })
     }
 
     // Validate gold
-    if (typeof gold !== 'number' || gold < 0) {
-      return NextResponse.json({ error: 'gold must be a number >= 0.' }, { status: 400 })
+    if (typeof gold !== 'number' || gold < 0 || gold > MAX_GOLD) {
+      return NextResponse.json({ error: `gold must be a number between 0 and ${MAX_GOLD}.` }, { status: 400 })
     }
 
     // Validate regionsConquered

--- a/src/app/api/v1/trivia/infinite/runs/route.ts
+++ b/src/app/api/v1/trivia/infinite/runs/route.ts
@@ -52,10 +52,11 @@ export async function POST(request: NextRequest) {
     const mode = body.mode === 'practice' ? 'practice' : 'scored';
 
     // Parse and validate customCategory — mutually exclusive with preset categories.
+    const MAX_CUSTOM_CATEGORY_LENGTH = 100
     let customCategory: string | null = null
     if (typeof body.customCategory === 'string') {
       const trimmed = body.customCategory.trim().toLowerCase()
-      if (trimmed.length >= 3) {
+      if (trimmed.length >= 3 && trimmed.length <= MAX_CUSTOM_CATEGORY_LENGTH) {
         customCategory = trimmed
       }
     }


### PR DESCRIPTION
## Summary

Two API routes accepted numeric/string inputs without upper bounds, allowing bots to submit obviously invalid data.

### tap-tap-adventure leaderboard submit-score (#2631)

`distance`, `level`, and `gold` were validated for type and lower bound but had no upper limit. Added:
- `MAX_DISTANCE = 1_000_000`
- `MAX_LEVEL = 500`  
- `MAX_GOLD = 10_000_000`

### trivia infinite runs (#2632)

`customCategory` had a minimum 3-char check but no maximum length. A bot could submit a very large string. Added `MAX_CUSTOM_CATEGORY_LENGTH = 100` — inputs longer than 100 chars are silently ignored (treated as no custom category), consistent with the existing behavior for inputs shorter than 3 chars.

## Test plan

- [ ] Submit a score with normal values and confirm leaderboard shows it
- [ ] Submit a score with `distance: 9999999` and confirm 400 response
- [ ] Start an infinite run with a normal customCategory and confirm it works
- [ ] Start with a very long category string (>100 chars) and confirm it falls back to no custom category