### PR TITLE
fix(avatar-maker): revoke blob URLs in convertToPng and handleGenerate

### DIFF
--- a/src/app/avatar-maker/page.tsx
+++ b/src/app/avatar-maker/page.tsx
@@ -228,7 +228,9 @@ export default function AvatarMakerPage() {
   const convertToPng = (file: File): Promise<File> => {
     return new Promise((resolve, reject) => {
       const img = new window.Image()
+      const objectUrl = URL.createObjectURL(file)
       img.onload = () => {
+        URL.revokeObjectURL(objectUrl)
         const canvas = document.createElement('canvas')
         canvas.width = img.width
         canvas.height = img.height
@@ -249,8 +251,11 @@ export default function AvatarMakerPage() {
           resolve(pngFile)
         }, 'image/png')
       }
-      img.onerror = () => reject(new Error('Failed to load image'))
-      img.src = URL.createObjectURL(file)
+      img.onerror = () => {
+        URL.revokeObjectURL(objectUrl)
+        reject(new Error('Failed to load image'))
+      }
+      img.src = objectUrl
     })
   }
 
@@ -277,8 +282,10 @@ export default function AvatarMakerPage() {
 
       // Create a fully transparent mask of same dimensions
       const img = new window.Image()
-      img.src = URL.createObjectURL(uploadFile)
+      const maskObjectUrl = URL.createObjectURL(uploadFile)
+      img.src = maskObjectUrl
       await new Promise(resolve => (img.onload = resolve))
+      URL.revokeObjectURL(maskObjectUrl)
       const maskFile = createTransparentMask(img.width, img.height)
 
       const formData = new FormData()


### PR DESCRIPTION
## Summary

Two functions in `avatar-maker/page.tsx` created object URLs but never revoked them, leaking memory every time the user generates an avatar:

- `convertToPng`: captures the URL before setting `img.src`, revokes it in both `img.onload` and `img.onerror`
- `handleGenerate`: captures the URL before setting `img.src`, revokes it after the `img.onload` promise resolves

The per-upload preview URL was already fixed in #2518. This closes the two remaining leaks.

## Test plan

- [ ] Upload a non-PNG image and generate — no memory leak (DevTools memory snapshot)
- [ ] Upload a PNG image and generate — no memory leak
- [ ] Both paths still generate correctly

Closes #2637

🤖 Generated with [Claude Code](https://claude.com/claude-code)