### PR TITLE
fix(chat-room): remove duplicate ChatState interface + replace weak random IDs

### DIFF
--- a/src/app/chat-room-of-infinity/store.ts
+++ b/src/app/chat-room-of-infinity/store.ts
@@ -20,6 +20,7 @@ interface ChatState {
   isTyping: boolean
   charactersRespondToEachOther: boolean
   remainingCharacterMessages: number
+  consecutiveCharacterResponses: number
 }
 
 export interface Store {
@@ -55,16 +56,6 @@ export interface Store {
   toggleCustomCharacterForm: () => void
   updateCustomCharacterForm: (updates: Partial<CustomCharacterFormState>) => void
   saveCustomCharacter: () => void
-}
-
-interface ChatState {
-  messages: ChatMessage[]
-  characters: Character[]
-  typingCharacters: Character[]
-  isTyping: boolean
-  charactersRespondToEachOther: boolean
-  remainingCharacterMessages: number
-  consecutiveCharacterResponses: number
 }
 
 export const useStore = create<Store>()(
@@ -156,7 +147,7 @@ export const useStore = create<Store>()(
             messages: [
               ...(state.chat.messages || []),
               {
-                id: Math.random().toString(36).substring(7),
+                id: crypto.randomUUID(),
                 character: {
                   id: 'user',
                   name: 'You',
@@ -178,7 +169,7 @@ export const useStore = create<Store>()(
             messages: [
               ...(state.chat.messages || []),
               {
-                id: Math.random().toString(36).substring(7),
+                id: crypto.randomUUID(),
                 character,
                 message,
                 timestamp: Date.now(),
@@ -284,7 +275,7 @@ export const useStore = create<Store>()(
       saveCustomCharacter: () =>
         set(state => {
           const character: Character = {
-            id: Math.random().toString(36).substring(7),
+            id: crypto.randomUUID(),
             name: state.customCharacterForm.name,
             description: state.customCharacterForm.description,
           }


### PR DESCRIPTION
## Summary

- **Duplicate interface removed**: `store.ts` declared `ChatState` twice (lines 16–23 and 60–68) with different fields. TypeScript silently merges declarations, so it compiled — but the split made the type hard to read and hid the `consecutiveCharacterResponses` field from the first definition. Merged into one complete declaration.
- **Stronger IDs**: All three `Math.random().toString(36).substring(7)` calls replaced with `crypto.randomUUID()`. The old IDs were ~5 base-36 chars (~60M unique values) — low but non-zero collision probability over a long session, which would cause React key reconciliation to silently misbehave.

## Test plan

- [ ] Sending messages still works — messages appear with valid IDs
- [ ] Adding custom characters still works
- [ ] No TypeScript errors (duplicate interface removed)

Closes #2640

🤖 Generated with [Claude Code](https://claude.com/claude-code)