### PR TITLE
fix(api): remove Zod error details from 400 responses + guard JSON parse in try-catch

### DIFF
--- a/src/app/api/v1/tap-tap-adventure/move-forward/route.ts
+++ b/src/app/api/v1/tap-tap-adventure/move-forward/route.ts
@@ -9,7 +9,7 @@ export async function POST(req: NextRequest) {
     const parseResult = MoveForwardRequestSchema.safeParse(body)
     if (!parseResult.success) {
       return NextResponse.json(
-        { error: 'Invalid request', details: parseResult.error },
+        { error: 'Invalid request' },
         { status: 400 }
       ) // error object, not MoveForwardResponse
     }

--- a/src/app/api/v1/tap-tap-adventure/npc/dialogue/route.ts
+++ b/src/app/api/v1/tap-tap-adventure/npc/dialogue/route.ts
@@ -34,7 +34,7 @@ export async function POST(req: NextRequest) {
     const parseResult = DialogueRequestSchema.safeParse(body)
     if (!parseResult.success) {
       return NextResponse.json(
-        { error: 'Invalid request', details: parseResult.error },
+        { error: 'Invalid request' },
         { status: 400 }
       )
     }

--- a/src/app/api/v1/tap-tap-adventure/party/dialogue/route.ts
+++ b/src/app/api/v1/tap-tap-adventure/party/dialogue/route.ts
@@ -39,7 +39,7 @@ export async function POST(req: NextRequest) {
     const body = await req.json()
     const parseResult = DialogueRequestSchema.safeParse(body)
     if (!parseResult.success) {
-      return NextResponse.json({ error: 'Invalid request', details: parseResult.error }, { status: 400 })
+      return NextResponse.json({ error: 'Invalid request' }, { status: 400 })
     }
 
     const {

--- a/src/app/api/v1/whowouldwininator/generate-random-scenario/route.ts
+++ b/src/app/api/v1/whowouldwininator/generate-random-scenario/route.ts
@@ -228,10 +228,9 @@ const SCENARIO_CATEGORIES = [
 ]
 
 export async function POST(request: Request) {
-  const { character1Name, character2Name, character1Description, character2Description } =
-    await request.json()
-
   try {
+    const { character1Name, character2Name, character1Description, character2Description } =
+      await request.json()
     const openaiClient = createOpenAI({
       apiKey: process.env.OPENAI_API_KEY,
     })


### PR DESCRIPTION
## Summary

Two related API error-handling improvements:

**1. Zod error details removed from 400 responses** (3 routes)
- `tap-tap-adventure/party/dialogue` — `details: parseResult.error` removed
- `tap-tap-adventure/move-forward` — `details: parseResult.error` removed
- `tap-tap-adventure/npc/dialogue` — `details: parseResult.error` removed

Raw Zod error objects include field paths, constraint metadata, and schema structure. Clients only need the generic "Invalid request" message.

**2. JSON parsing moved inside try-catch** (1 route)
- `whowouldwininator/generate-random-scenario` — `await request.json()` was called before the `try` block. Malformed JSON throws a SyntaxError that the catch block never sees, resulting in an unhandled rejection.

## Test plan

- [ ] Send malformed JSON to `/api/v1/whowouldwininator/generate-random-scenario` — should return 500 JSON, not crash
- [ ] Send invalid body to dialogue routes — should return `{ error: "Invalid request" }` without schema details

Closes #2642

🤖 Generated with [Claude Code](https://claude.com/claude-code)