### PR TITLE
fix(tap-tap): remove nested dialog role in DailyRewardPopup + Escape handler in TravelConfirmDialog

### DIFF
--- a/src/app/tap-tap-adventure/components/DailyRewardPopup.tsx
+++ b/src/app/tap-tap-adventure/components/DailyRewardPopup.tsx
@@ -18,6 +18,8 @@ export function DailyRewardPopup({ streak, reward, onClaim, onDismiss }: DailyRe
   const [claimResult, setClaimResult] = useState<ClaimResult | null>(null)
 
   const dismissTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const dialogRef = useRef<HTMLDivElement>(null)
+
   useEffect(() => {
     return () => { if (dismissTimerRef.current != null) clearTimeout(dismissTimerRef.current) }
   }, [])
@@ -25,6 +27,21 @@ export function DailyRewardPopup({ streak, reward, onClaim, onDismiss }: DailyRe
   useEffect(() => {
     requestAnimationFrame(() => setIsVisible(true))
   }, [])
+
+  useEffect(() => {
+    dialogRef.current?.focus()
+  }, [])
+
+  useEffect(() => {
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        setIsVisible(false)
+        dismissTimerRef.current = setTimeout(onDismiss, 300)
+      }
+    }
+    window.addEventListener('keydown', handleKey)
+    return () => window.removeEventListener('keydown', handleKey)
+  }, [onDismiss])
 
   // Auto-dismiss after claiming
   useEffect(() => {
@@ -48,9 +65,6 @@ export function DailyRewardPopup({ streak, reward, onClaim, onDismiss }: DailyRe
 
   return (
     <div
-      role="dialog"
-      aria-modal="true"
-      aria-label="Daily reward"
       className={`fixed inset-0 z-50 flex items-center justify-center transition-opacity duration-300 ${
         isVisible ? 'opacity-100' : 'opacity-0'
       }`}
@@ -65,10 +79,12 @@ export function DailyRewardPopup({ streak, reward, onClaim, onDismiss }: DailyRe
         }`}
       >
         <div
+          ref={dialogRef}
           role="dialog"
           aria-modal="true"
           aria-label="Daily Reward"
-          className="bg-gradient-to-b from-[#1e1f30] to-[#161723] border-2 border-amber-500/50 rounded-2xl px-8 py-6 text-center shadow-2xl shadow-amber-500/20 max-w-sm mx-4"
+          tabIndex={-1}
+          className="bg-gradient-to-b from-[#1e1f30] to-[#161723] border-2 border-amber-500/50 rounded-2xl px-8 py-6 text-center shadow-2xl shadow-amber-500/20 max-w-sm mx-4 outline-none"
         >
           {!claimed ? (
             <>

--- a/src/app/tap-tap-adventure/components/TravelConfirmDialog.tsx
+++ b/src/app/tap-tap-adventure/components/TravelConfirmDialog.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { useEffect } from 'react'
 import { Region } from '@/app/tap-tap-adventure/config/regions'
 
 interface TravelConfirmDialogProps {
@@ -28,6 +29,14 @@ const ELEMENT_BADGE: Record<string, { label: string; classes: string }> = {
 export function TravelConfirmDialog({ region, onConfirm, onCancel }: TravelConfirmDialogProps) {
   const difficulty = DIFFICULTY_BADGE[region.difficulty] ?? DIFFICULTY_BADGE.easy
   const element = ELEMENT_BADGE[region.element] ?? ELEMENT_BADGE.none
+
+  useEffect(() => {
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onCancel()
+    }
+    window.addEventListener('keydown', handleKey)
+    return () => window.removeEventListener('keydown', handleKey)
+  }, [onCancel])
 
   return (
     <div
@@ -85,6 +94,7 @@ export function TravelConfirmDialog({ region, onConfirm, onCancel }: TravelConfi
             Travel
           </button>
           <button
+            autoFocus
             onClick={onCancel}
             className="flex-1 py-2.5 rounded-lg bg-slate-700 hover:bg-slate-600 text-slate-200 text-sm font-medium transition-colors"
           >


### PR DESCRIPTION
## Summary

**DailyRewardPopup:**
- Remove `role="dialog"` from the outer backdrop wrapper (was nested — ARIA spec requires exactly one role per modal)
- Add ref + tabIndex={-1} to the inner content div and focus it on mount
- Add Escape key handler: closes the popup with the same 300ms animation as backdrop click

**TravelConfirmDialog:**
- Add Escape key handler: calls onCancel() (same as clicking Cancel or the backdrop)
- Add autoFocus to the Cancel button — safe default for a destructive-action confirmation

## Test plan

- [ ] Daily reward popup: press Escape after it appears — should dismiss
- [ ] Daily reward popup: screen reader should announce only one "Daily Reward" dialog (not two)
- [ ] Travel confirm dialog: press Escape — should cancel
- [ ] Travel confirm dialog: focus lands on Cancel button when dialog opens

Closes #2644

🤖 Generated with [Claude Code](https://claude.com/claude-code)