### PR TITLE
fix(voters): prevent infinite retry loop in summary generation on API error

### DIFF
--- a/src/app/voters/components/VotingResults.tsx
+++ b/src/app/voters/components/VotingResults.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import {
   Bar,
   BarChart,
@@ -29,6 +29,7 @@ interface VotingResultsProps {
 export default function VotingResults({ votes, voters, criteria, onRestart }: VotingResultsProps) {
   const [groupSummaries, setGroupSummaries] = useState<Record<string, string>>({})
   const [loadingSummaries, setLoadingSummaries] = useState<string[]>([])
+  const failedSummariesRef = useRef(new Set<string>())
 
   const generateSummaryMutation = useGenerateSummary()
 
@@ -76,7 +77,10 @@ export default function VotingResults({ votes, voters, criteria, onRestart }: Vo
 
       const groupsNeedingSummary = Object.entries(results.groupResults).filter(
         ([groupName, groupData]) =>
-          groupData.total > 5 && !groupSummaries[groupName] && !loadingSummaries.includes(groupName)
+          groupData.total > 5 &&
+          !groupSummaries[groupName] &&
+          !loadingSummaries.includes(groupName) &&
+          !failedSummariesRef.current.has(groupName)
       )
 
       if (groupsNeedingSummary.length === 0) return
@@ -97,6 +101,8 @@ export default function VotingResults({ votes, voters, criteria, onRestart }: Vo
             },
             onError: error => {
               console.error(`Error generating summary for ${groupName}:`, error)
+              // Track as failed so the effect doesn't retry infinitely
+              failedSummariesRef.current.add(groupName)
               setLoadingSummaries(prev => prev.filter(name => name !== groupName))
             },
           }
@@ -105,7 +111,8 @@ export default function VotingResults({ votes, voters, criteria, onRestart }: Vo
     }
 
     generateSummariesForLargeGroups()
-  }, [results.groupResults, criteria, groupSummaries, loadingSummaries, generateSummaryMutation])
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [results.groupResults, criteria, groupSummaries])
 
   const chartData = Object.entries(results.distribution).map(([option, count]) => ({
     option,


### PR DESCRIPTION
## Problem

When `generateSummaryMutation` failed, `onError` removed the group from `loadingSummaries`. Since `loadingSummaries` was in the `useEffect` dep array, this triggered a re-run. On re-run, the group was no longer in `loadingSummaries` or `groupSummaries`, so the mutation was retried — creating an infinite loop that hammered the API on persistent errors (invalid key, rate limit, network down).

## Fix

- Add `failedSummariesRef = useRef(new Set<string>())` to track groups that errored
- In `onError`, add the group to `failedSummariesRef` before removing from `loadingSummaries`
- Add `!failedSummariesRef.current.has(groupName)` to the filter condition
- Remove `loadingSummaries` and `generateSummaryMutation` from the dep array — both were causing unnecessary re-runs (mutation object is stable by react-query contract; `loadingSummaries` should be read by ref, not trigger the effect)

## Test plan

- [ ] Vote with large groups (>5 voters per group) — summaries still generate on success
- [ ] Simulate API error — summary generation should attempt once and stop, not loop
- [ ] Network tab shows no repeated calls to the summary endpoint after an error

Closes #2649

🤖 Generated with [Claude Code](https://claude.com/claude-code)