### PR TITLE
fix(a11y): add aria-label to auth form inputs + remove footer placeholder links

### DIFF
--- a/src/app/auth/page.tsx
+++ b/src/app/auth/page.tsx
@@ -145,6 +145,7 @@ function AuthPageInner() {
                 <Input
                   type="email"
                   required
+                  aria-label="Email"
                   placeholder="Email"
                   value={email}
                   onChange={(e) => setEmail(e.target.value)}
@@ -154,6 +155,7 @@ function AuthPageInner() {
                 <Input
                   type="password"
                   required
+                  aria-label="Password"
                   placeholder="Password"
                   value={password}
                   onChange={(e) => setPassword(e.target.value)}

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -1,5 +1,3 @@
-import Link from 'next/link'
-
 import { BrandMark } from '@/components/brand-mark'
 
 export function Footer() {
@@ -9,24 +7,9 @@ export function Footer() {
         <BrandMark size="sm" />
 
         <div className="flex gap-6">
-          <Link
-            href="#"
-            className="text-on-surface-variant hover:text-on-surface text-sm transition-colors"
-          >
-            About
-          </Link>
-          <Link
-            href="#"
-            className="text-on-surface-variant hover:text-on-surface text-sm transition-colors"
-          >
-            Privacy
-          </Link>
-          <Link
-            href="#"
-            className="text-on-surface-variant hover:text-on-surface text-sm transition-colors"
-          >
-            Contact
-          </Link>
+          <span className="text-on-surface-variant/40 text-sm">About</span>
+          <span className="text-on-surface-variant/40 text-sm">Privacy</span>
+          <span className="text-on-surface-variant/40 text-sm">Contact</span>
         </div>
 
         <div className="text-on-surface-variant/60 text-xs">


### PR DESCRIPTION
## Summary

Two small accessibility fixes to global/shared components:

**Auth page** (`src/app/auth/page.tsx`):
- Email and password inputs had `placeholder` text only — no `<label>` or `aria-label`. Placeholders disappear on focus and aren't reliably read by all screen readers. Added `aria-label="Email"` and `aria-label="Password"`.

**Footer** (`src/components/footer.tsx`):
- About, Privacy, and Contact were `href="#"` links that don't navigate anywhere. Keyboard and screen-reader users pressing Enter expect navigation. Replaced with static `<span>` text until real pages exist; cleaned up the now-unused `Link` import.

## Test plan

- [ ] Tab to email/password inputs on the auth page — screen reader should announce "Email" and "Password"
- [ ] Tab through the footer — no links that go nowhere

Closes #2651

🤖 Generated with [Claude Code](https://claude.com/claude-code)