### PR TITLE
fix(a11y): add skip-to-main-content link to layout shell

### DIFF
--- a/src/components/layout-shell.tsx
+++ b/src/components/layout-shell.tsx
@@ -23,13 +23,19 @@ export function LayoutShell({
   const isImmersive = IMMERSIVE_ROUTES.some(r => pathname.startsWith(r))
 
   if (isImmersive) {
-    return <main className="flex-1 z-20 relative">{children}</main>
+    return <main id="main-content" className="flex-1 z-20 relative">{children}</main>
   }
 
   return (
     <>
+      <a
+        href="#main-content"
+        className="sr-only focus:not-sr-only focus:fixed focus:top-4 focus:left-4 focus:z-[200] focus:px-4 focus:py-2 focus:bg-surface-container focus:text-on-surface focus:rounded-lg focus:outline-none focus:ring-2 focus:ring-ds-primary"
+      >
+        Skip to main content
+      </a>
       {nav}
-      <main className="flex-1 container mx-auto p-4 z-20 relative">{children}</main>
+      <main id="main-content" className="flex-1 container mx-auto p-4 z-20 relative">{children}</main>
       {footer}
     </>
   )


### PR DESCRIPTION
## Summary

Without a skip link, keyboard users had to tab through the entire top navigation on every page load to reach the main content — a WCAG 2.1 Level A violation (SC 2.4.1 Bypass Blocks).

- Added a visually hidden but focusable "Skip to main content" `<a>` link as the **first** focusable element in the normal layout. It becomes visible when focused via `focus:not-sr-only`.
- Added `id="main-content"` to the `<main>` element in both the normal and immersive layout paths.

## Test plan

- [ ] Tab from any page — first focusable element is the skip link
- [ ] Press Enter on the skip link — focus jumps to `#main-content`
- [ ] Skip link is invisible in normal browsing (visually hidden)
- [ ] Immersive game routes (comet-cards, speck-wars) still work normally

Closes #2653

🤖 Generated with [Claude Code](https://claude.com/claude-code)