### PR TITLE
feat(shell): add global error.tsx for branded error recovery

### DIFF
--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,0 +1,31 @@
+'use client'
+
+import { useEffect } from 'react'
+import { ChunkyButton } from '@/components/ui/chunky-button'
+
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string }
+  reset: () => void
+}) {
+  useEffect(() => {
+    console.error(error)
+  }, [error])
+
+  return (
+    <div className="flex flex-col items-center justify-center min-h-[60vh] px-6 text-center">
+      <div className="text-8xl font-bold text-on-surface/10 select-none mb-2">!</div>
+      <h1 className="text-2xl font-bold text-on-surface mb-3">
+        The cave is sleeping…
+      </h1>
+      <p className="text-on-surface/50 text-sm max-w-sm mb-8">
+        Something stirred in the dark and the lights went out. It may wake on its own — or you can try calling it back.
+      </p>
+      <ChunkyButton variant="secondary" size="md" onClick={reset}>
+        Try again
+      </ChunkyButton>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

There was no `src/app/error.tsx` file. Unhandled render errors (failed RSC fetches, null dereferences, etc.) fell through to Next.js's default unstyled error page — breaking the cave's visual identity.

The new page:
- Follows the cosmic-narrator voice ("The cave is sleeping…")
- Provides a `reset()` button to retry the failed render tree
- Matches the visual style of the existing `not-found.tsx` page
- Logs the error to the console for debugging

## Test plan

- [ ] Trigger a render error (e.g., throw in a page component) — should show the branded error page
- [ ] Click "Try again" — should attempt to re-render the tree

Closes #2655

🤖 Generated with [Claude Code](https://claude.com/claude-code)