### PR TITLE
fix(api): remove error message details from combat action 500 response

### DIFF
--- a/src/app/api/v1/tap-tap-adventure/combat/action/route.ts
+++ b/src/app/api/v1/tap-tap-adventure/combat/action/route.ts
@@ -103,7 +103,7 @@ export async function POST(req: NextRequest) {
   } catch (err) {
     console.error('Error processing combat action', err)
     return NextResponse.json(
-      { error: 'Failed to process combat action', details: (err as Error).message },
+      { error: 'Failed to process combat action' },
       { status: 500 }
     )
   }


### PR DESCRIPTION
Removes raw error message from the 500 response in the combat action API route.

## Changes
`src/app/api/v1/tap-tap-adventure/combat/action/route.ts`: strip `details: (err as Error).message` from the error JSON.

The error is already logged server-side via `console.error`; clients don't need internal stack trace / library message details.

Closes #2658