### PR TITLE
fix(oracle): replace invalid b-2/b-4 Tailwind classes with border-2/border-4

### DIFF
--- a/src/app/oracle/components/hexagram.tsx
+++ b/src/app/oracle/components/hexagram.tsx
@@ -17,7 +17,7 @@ export const SolidLine = ({ isStatic = false }: { isStatic?: boolean }) => {
 export const EmptyLine = ({ isStatic = false }: { isStatic?: boolean }) => {
   return (
     <div
-      className={`w-44 h-4 border b-2 ${lineBorder} opacity-[0.4] hover:opacity-60 transition-all duration-200 ${isStatic ? '' : 'cursor-pointer'}`}
+      className={`w-44 h-4 border-2 ${lineBorder} opacity-[0.4] hover:opacity-60 transition-all duration-200 ${isStatic ? '' : 'cursor-pointer'}`}
     />
   )
 }
@@ -46,7 +46,7 @@ export const ChangeMarker = ({
         `w-4 h-4 rounded-full transition-all duration-200 ${isStatic ? '' : 'cursor-pointer'}`,
         hasChanges
           ? `${lineBg} opacity-[0.4]`
-          : `bg-transparent border b-4 ${lineBorder} opacity-[0.4] hover:opacity-60`
+          : `bg-transparent border-4 ${lineBorder} opacity-[0.4] hover:opacity-60`
       )}
     />
   )


### PR DESCRIPTION
Fixes invalid Tailwind CSS classes in the Oracle hexagram component.

## Changes
- `EmptyLine` (line 20): `border b-2` → `border-2`
- `ChangeMarker` (line 49): `border b-4` → `border-4`

`b-2` and `b-4` are not valid Tailwind utilities. The `border` token alone sets a 1px border but the orphaned `b-N` is silently ignored, so the intended border widths never rendered.

Closes #2657