### PR TITLE
fix(trivia): add role/aria-selected to leaderboard sub-tabs + aria-label to answer input

### DIFF
--- a/src/app/trivia/components/InfiniteQuestionCard.tsx
+++ b/src/app/trivia/components/InfiniteQuestionCard.tsx
@@ -82,6 +82,7 @@ export function InfiniteQuestionCard({
             autoComplete="off"
             autoCorrect="off"
             spellCheck={false}
+            aria-label="Your answer"
           />
           {!isAnswered && (
             <div className="flex gap-2">

--- a/src/app/trivia/components/TriviaLeaderboard.tsx
+++ b/src/app/trivia/components/TriviaLeaderboard.tsx
@@ -241,6 +241,8 @@ export function TriviaLeaderboard({ onBack }: { onBack: () => void }) {
             <button
               key={key}
               type="button"
+              role="tab"
+              aria-selected={period === key}
               onClick={() => setPeriod(key)}
               className={`text-sm py-1.5 rounded transition-colors ${
                 period === key


### PR DESCRIPTION
Fixes two accessibility issues in the Trivia game.

## Changes

### TriviaLeaderboard
- Add `role="tab"` and `aria-selected={period === key}` to the Crowns / Points / Accuracy buttons — previously active state was conveyed only through visual styling

### InfiniteQuestionCard
- Add `aria-label="Your answer"` to the free-text answer input — placeholder text is not a reliable accessible name

Closes #2663