### PR TITLE
fix(api): add max-length and array-size guards to secret-word and voters routes

### DIFF
--- a/src/app/api/v1/secret-word/ai-response/route.ts
+++ b/src/app/api/v1/secret-word/ai-response/route.ts
@@ -35,11 +35,23 @@ export async function POST(request: NextRequest) {
       )
     }
 
+    if (playerMessage.length > 500) {
+      return NextResponse.json({ error: 'playerMessage must be 500 characters or fewer.' }, { status: 400 })
+    }
+
     if (!aiSecretWord || typeof aiSecretWord !== 'string') {
       return NextResponse.json(
         { error: 'aiSecretWord is required and must be a string' },
         { status: 400 }
       )
+    }
+
+    if (aiSecretWord.length > 100) {
+      return NextResponse.json({ error: 'aiSecretWord must be 100 characters or fewer.' }, { status: 400 })
+    }
+
+    if (Array.isArray(gameMessages) && gameMessages.length > 100) {
+      return NextResponse.json({ error: 'gameMessages must contain 100 entries or fewer.' }, { status: 400 })
     }
 
     // Build conversation context

--- a/src/app/api/v1/secret-word/score-word/route.ts
+++ b/src/app/api/v1/secret-word/score-word/route.ts
@@ -36,6 +36,10 @@ export async function POST(request: NextRequest) {
       )
     }
 
+    if (word.length > 100) {
+      return NextResponse.json({ error: 'word must be 100 characters or fewer.' }, { status: 400 })
+    }
+
     // Prompt instructing the LLM to assign a frequency band score and label
     const prompt = `You are tasked with evaluating the approximate frequency of English words in everyday usage. Use the frequency bands below to score the provided word. Output must strictly follow the provided JSON schema.
 

--- a/src/app/api/v1/voters/generate-random-voter/route.ts
+++ b/src/app/api/v1/voters/generate-random-voter/route.ts
@@ -95,6 +95,14 @@ export async function POST(request: NextRequest) {
     // Get existing voters from request body
     const { existingVoters = [] } = await request.json()
 
+    if (!Array.isArray(existingVoters)) {
+      return NextResponse.json({ error: 'existingVoters must be an array.' }, { status: 400 })
+    }
+
+    if (existingVoters.length > 50) {
+      return NextResponse.json({ error: 'existingVoters must contain 50 entries or fewer.' }, { status: 400 })
+    }
+
     // Pick a random category
     const randomCategory = VOTER_CATEGORIES[Math.floor(Math.random() * VOTER_CATEGORIES.length)]
 


### PR DESCRIPTION
Adds upper-bound validation to three API routes that embed user-controlled strings directly into LLM prompts.

## Changes

### `secret-word/score-word`
- `word` capped at 100 characters

### `secret-word/ai-response`
- `playerMessage` capped at 500 characters
- `aiSecretWord` capped at 100 characters
- `gameMessages` array capped at 100 entries

### `voters/generate-random-voter`
- `existingVoters` validated as an array and capped at 50 entries

All violations return 400. Without these guards a client could send arbitrarily large inputs that get embedded in prompts, wasting tokens.

Closes #2666