### PR TITLE
fix(a11y): add aria-hidden to decorative Material Icons on home page

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -36,7 +36,7 @@ export default function Home() {
             AI Dream Arcade — explore an infinite galaxy of games, challenges, and cosmic adventures.
           </p>
           <Link href={ROUTE_CONSTANTS.TRIVIA}>
-            <ChunkyButton variant="primary" size="hero" iconEnd={<span className="material-symbols-outlined">play_circle</span>}>
+            <ChunkyButton variant="primary" size="hero" iconEnd={<span className="material-symbols-outlined" aria-hidden="true">play_circle</span>}>
               START QUESTING
             </ChunkyButton>
           </Link>
@@ -46,7 +46,7 @@ export default function Home() {
       {/* Arcade Floor */}
       <section>
         <h2 className="font-headline text-headline-md text-on-surface mb-6 flex items-center gap-3">
-          <span className="material-symbols-outlined text-ds-tertiary text-[32px]" style={{ fontVariationSettings: "'FILL' 1" }}>
+          <span className="material-symbols-outlined text-ds-tertiary text-[32px]" style={{ fontVariationSettings: "'FILL' 1" }} aria-hidden="true">
             sports_esports
           </span>
           Arcade Floor
@@ -57,7 +57,7 @@ export default function Home() {
               <ChunkyCard variant="surface-variant" interactive cornerGlow="primary" className="h-full">
                 <ChunkyCardContent className="pt-6 pb-6 flex flex-col items-center text-center gap-3">
                   <div className="flex items-center justify-center w-16 h-16 rounded-full bg-ds-surface border-2 border-outline-variant">
-                    <span className="material-symbols-outlined text-[32px] text-ds-primary" style={{ fontVariationSettings: "'FILL' 1" }}>
+                    <span className="material-symbols-outlined text-[32px] text-ds-primary" style={{ fontVariationSettings: "'FILL' 1" }} aria-hidden="true">
                       {game.icon}
                     </span>
                   </div>


### PR DESCRIPTION
Adds `aria-hidden="true"` to three decorative icon spans on the home page.

## Changes (`src/app/page.tsx`)
- `play_circle` icon in the START QUESTING button `iconEnd` slot
- `sports_esports` icon in the "Arcade Floor" section heading
- `{game.icon}` in each game card tile

All three have adjacent visible text that carries the meaning; the icon names themselves are noise for screen reader users.

Closes #2668