### PR TITLE
fix(api): remove error details from 4 tap-tap-adventure 500 responses

### DIFF
--- a/src/app/api/v1/tap-tap-adventure/combat/start/route.ts
+++ b/src/app/api/v1/tap-tap-adventure/combat/start/route.ts
@@ -122,7 +122,7 @@ export async function POST(req: NextRequest) {
   } catch (err) {
     console.error('Error starting combat', err)
     return NextResponse.json(
-      { error: 'Failed to start combat', details: (err as Error).message },
+      { error: 'Failed to start combat' },
       { status: 500 }
     )
   }

--- a/src/app/api/v1/tap-tap-adventure/shop/generate/route.ts
+++ b/src/app/api/v1/tap-tap-adventure/shop/generate/route.ts
@@ -15,7 +15,7 @@ export async function POST(req: NextRequest) {
   } catch (err) {
     console.error('Error generating shop', err)
     return NextResponse.json(
-      { error: 'Failed to generate shop', details: (err as Error).message },
+      { error: 'Failed to generate shop' },
       { status: 500 }
     )
   }

--- a/src/app/api/v1/tap-tap-adventure/shop/purchase/route.ts
+++ b/src/app/api/v1/tap-tap-adventure/shop/purchase/route.ts
@@ -35,7 +35,7 @@ export async function POST(req: NextRequest) {
   } catch (err) {
     console.error('Error purchasing item', err)
     return NextResponse.json(
-      { error: 'Failed to purchase item', details: (err as Error).message },
+      { error: 'Failed to purchase item' },
       { status: 500 }
     )
   }

--- a/src/app/api/v1/tap-tap-adventure/shop/sell/route.ts
+++ b/src/app/api/v1/tap-tap-adventure/shop/sell/route.ts
@@ -41,7 +41,7 @@ export async function POST(req: NextRequest) {
   } catch (err) {
     console.error('Error selling item', err)
     return NextResponse.json(
-      { error: 'Failed to sell item', details: (err as Error).message },
+      { error: 'Failed to sell item' },
       { status: 500 }
     )
   }


### PR DESCRIPTION
Same pattern as #2660 (combat/action). Removes `details: (err as Error).message` from four more tap-tap API routes.

## Routes fixed
- `combat/start/route.ts`
- `shop/purchase/route.ts`
- `shop/sell/route.ts`
- `shop/generate/route.ts`

Errors are already logged server-side via `console.error`.

Closes #2670