### PR TITLE
fix(a11y): add aria-label to close buttons in tap-tap-adventure panel components

### DIFF
--- a/src/app/tap-tap-adventure/components/MailboxPanel.tsx
+++ b/src/app/tap-tap-adventure/components/MailboxPanel.tsx
@@ -32,7 +32,7 @@ export function MailboxPanel({ character, onClose }: MailboxPanelProps) {
         <span className="text-sm font-bold text-amber-400">
           📬 Mailbox {unreadCount > 0 && <span className="text-[10px] bg-red-600 text-white px-1.5 py-0.5 rounded-full ml-1">{unreadCount}</span>}
         </span>
-        <button className="text-slate-400 hover:text-white text-sm" onClick={onClose}>✕</button>
+        <button className="text-slate-400 hover:text-white text-sm" onClick={onClose} aria-label="Close mailbox">✕</button>
       </div>
 
       {composing ? (

--- a/src/app/tap-tap-adventure/components/StablePanel.tsx
+++ b/src/app/tap-tap-adventure/components/StablePanel.tsx
@@ -145,7 +145,7 @@ export function StablePanel({ character, onClose }: StablePanelProps) {
     <div className="bg-[#1e1f30] border border-[#3a3c56] rounded-lg p-3 space-y-3">
       <div className="flex justify-between items-center">
         <span className="text-sm font-bold text-amber-400">Town Stable</span>
-        <button className="text-slate-400 hover:text-white text-sm" onClick={onClose}>x</button>
+        <button className="text-slate-400 hover:text-white text-sm" onClick={onClose} aria-label="Close stable">x</button>
       </div>
 
       <div className="text-[10px] text-slate-400">

--- a/src/app/tap-tap-adventure/components/WaypointPanel.tsx
+++ b/src/app/tap-tap-adventure/components/WaypointPanel.tsx
@@ -19,7 +19,7 @@ export function WaypointPanel({ character, currentTownName, onTravel, onClose }:
     <div className="bg-[#1e1f30] border border-[#3a3c56] rounded-lg p-3 space-y-3">
       <div className="flex justify-between items-center">
         <span className="text-sm font-bold text-amber-400">🗺️ Waypoints</span>
-        <button className="text-slate-400 hover:text-white text-sm" onClick={onClose}>✕</button>
+        <button className="text-slate-400 hover:text-white text-sm" onClick={onClose} aria-label="Close waypoints">✕</button>
       </div>
 
       <div className="text-[10px] text-slate-400 italic">


### PR DESCRIPTION
Adds `aria-label` to three ✕/x close buttons in tap-tap-adventure panel components.

## Changes
- `WaypointPanel.tsx`: `aria-label="Close waypoints"`
- `MailboxPanel.tsx`: `aria-label="Close mailbox"`
- `StablePanel.tsx`: `aria-label="Close stable"`

Closes #2671