### PR TITLE
fix(tap-tap): remove error leak in resolve-decision + aria-label on 3 panel close buttons

### DIFF
--- a/src/app/api/v1/tap-tap-adventure/resolve-decision/route.ts
+++ b/src/app/api/v1/tap-tap-adventure/resolve-decision/route.ts
@@ -1247,7 +1247,7 @@ export async function POST(req: NextRequest) {
     return NextResponse.json(response)
   } catch (err) {
     return NextResponse.json(
-      { error: 'Invalid request', details: (err as Error).message },
+      { error: 'Invalid request' },
       { status: 400 }
     )
   }

--- a/src/app/tap-tap-adventure/components/MercenaryPanel.tsx
+++ b/src/app/tap-tap-adventure/components/MercenaryPanel.tsx
@@ -232,6 +232,7 @@ export function MercenaryPanel({ character }: MercenaryPanelProps) {
                       <button
                         className="text-[10px] px-1.5 py-0.5 bg-red-900/30 text-red-400 rounded hover:bg-red-800/40 transition-colors"
                         onClick={() => setDismissConfirm(`roster-${merc.id}`)}
+                        aria-label="Close mercenary panel"
                       >
                         ✕
                       </button>

--- a/src/app/tap-tap-adventure/components/PartyDialoguePanel.tsx
+++ b/src/app/tap-tap-adventure/components/PartyDialoguePanel.tsx
@@ -96,7 +96,7 @@ export function PartyDialoguePanel({
             {tier.label}
           </span>
         </div>
-        <button className="text-slate-400 hover:text-white text-sm" onClick={onClose}>&#x2715;</button>
+        <button className="text-slate-400 hover:text-white text-sm" onClick={onClose} aria-label="Close dialogue">&#x2715;</button>
       </div>
 
       {/* Disposition bar */}

--- a/src/app/tap-tap-adventure/components/TavernPanel.tsx
+++ b/src/app/tap-tap-adventure/components/TavernPanel.tsx
@@ -90,7 +90,7 @@ export function TavernPanel({ character, townName, onRest, isResting, onClose }:
       {/* Header */}
       <div className="flex justify-between items-center">
         <span className="text-sm font-bold text-amber-400">🍺 Tavern &amp; Inn</span>
-        <button className="text-slate-400 hover:text-white text-sm" onClick={onClose}>✕</button>
+        <button className="text-slate-400 hover:text-white text-sm" onClick={onClose} aria-label="Close tavern">✕</button>
       </div>
 
       {/* Atmosphere */}


### PR DESCRIPTION
Bundles two fix categories into one PR.

## Error leak fix
`src/app/api/v1/tap-tap-adventure/resolve-decision/route.ts` line 1250: removed `details: (err as Error).message` from 500 response. Same pattern as #2672.

## Accessibility fixes (close buttons)
- `TavernPanel.tsx`: `aria-label="Close tavern"`
- `PartyDialoguePanel.tsx`: `aria-label="Close dialogue"`
- `MercenaryPanel.tsx`: `aria-label="Close mercenary panel"`

Closes #2675, closes #2676