### PR TITLE
fix(tap-tap): replace Math.random ID generation with crypto.randomUUID in combat hooks

### DIFF
--- a/src/app/tap-tap-adventure/hooks/useCombatActionMutation.ts
+++ b/src/app/tap-tap-adventure/hooks/useCombatActionMutation.ts
@@ -241,7 +241,7 @@ export function useCombatActionMutation(options?: { onMountDrop?: (mount: Mount)
                 heirloom: null,
               })
               recordRun({
-                id: `${Date.now()}-${Math.random().toString(36).slice(2, 9)}`,
+                id: crypto.randomUUID(),
                 characterName: victoryChar.name,
                 characterClass: victoryChar.class,
                 level: victoryChar.level,
@@ -340,7 +340,7 @@ export function useCombatActionMutation(options?: { onMountDrop?: (mount: Mount)
             })
 
             recordRun({
-              id: `${Date.now()}-${Math.random().toString(36).slice(2, 9)}`,
+              id: crypto.randomUUID(),
               characterName: character.name,
               characterClass: character.class,
               level: character.level,
@@ -400,7 +400,7 @@ export function useCombatActionMutation(options?: { onMountDrop?: (mount: Mount)
             })
 
             recordRun({
-              id: `${Date.now()}-${Math.random().toString(36).slice(2, 9)}`,
+              id: crypto.randomUUID(),
               characterName: character.name,
               characterClass: character.class,
               level: character.level,

--- a/src/app/tap-tap-adventure/hooks/useGameStore.ts
+++ b/src/app/tap-tap-adventure/hooks/useGameStore.ts
@@ -1412,7 +1412,7 @@ export const useGameStore = create<GameStore>()(
 
             // Record run history for retirement
             const retirementEntry: RunHistoryEntry = {
-              id: `${Date.now()}-${Math.random().toString(36).slice(2, 9)}`,
+              id: crypto.randomUUID(),
               characterName: characterSnapshot.name,
               characterClass: characterSnapshot.class,
               level: characterSnapshot.level,


### PR DESCRIPTION
Replaces four uses of `` `${Date.now()}-${Math.random().toString(36).slice(2, 9)}` `` with `crypto.randomUUID()`.

## Locations
- `useCombatActionMutation.ts` lines 244, 343, 403 (victory/permadeath/death record runs)
- `useGameStore.ts` line 1415 (retirement entry)

`crypto.randomUUID()` is available in all modern browsers and the Next.js runtime. No import needed.

Closes #2674