### PR TITLE
fix: NoticeBoard close button aria-label + replace weak combatId with crypto.randomUUID

### DIFF
--- a/src/app/api/v1/tap-tap-adventure/combat/start/route.ts
+++ b/src/app/api/v1/tap-tap-adventure/combat/start/route.ts
@@ -81,7 +81,7 @@ export async function POST(req: NextRequest) {
     const finalEnemy: CombatEnemy = isBossEncounter ? scaleBossForParty(enemy, partySize) : enemy
 
     // Generate a stable combat ID first so we can use it for seeding
-    const combatId = `combat-${Date.now()}-${Math.floor(Math.random() * 10000)}`
+    const combatId = crypto.randomUUID()
 
     // Generate additional enemies for non-boss fights with party members
     let additionalEnemies: CombatEnemy[] | undefined

--- a/src/app/tap-tap-adventure/components/NoticeBoard.tsx
+++ b/src/app/tap-tap-adventure/components/NoticeBoard.tsx
@@ -95,7 +95,7 @@ export function NoticeBoard({ character, activeQuest, onAcceptQuest, onClose }: 
       {/* Header */}
       <div className="flex justify-between items-center">
         <span className="text-sm font-bold text-amber-400">📋 Notice Board</span>
-        <button className="text-slate-400 hover:text-white text-sm" onClick={onClose}>✕</button>
+        <button className="text-slate-400 hover:text-white text-sm" onClick={onClose} aria-label="Close notice board">✕</button>
       </div>
 
       {/* Section 1: Quests & Bounties */}


### PR DESCRIPTION
Bundles two small fixes.

## Accessibility
`NoticeBoard.tsx` line 98: add `aria-label="Close notice board"` to the ✕ close button.

## ID generation
`combat/start/route.ts` line 84: replace `` `combat-${Date.now()}-${Math.floor(Math.random() * 10000)}` `` with `crypto.randomUUID()`. The old pattern had only 10,000 possible random values — collisions were possible if multiple combats started within the same millisecond.

Closes #2679