### PR TITLE
fix(api): add input length validation to whowouldwininator character generation routes

### DIFF
--- a/src/app/api/v1/whowouldwininator/generate-character-description/route.ts
+++ b/src/app/api/v1/whowouldwininator/generate-character-description/route.ts
@@ -11,6 +11,9 @@ export async function POST(request: Request) {
     if (!name || name.trim() === '') {
       return NextResponse.json({ error: 'Character name is required' }, { status: 400 })
     }
+    if (name.length > 200) {
+      return NextResponse.json({ error: 'name must be 200 characters or fewer.' }, { status: 400 })
+    }
 
     const openaiClient = createOpenAI({
       apiKey: process.env.OPENAI_API_KEY,

--- a/src/app/api/v1/whowouldwininator/generate-character-details/backstory/route.ts
+++ b/src/app/api/v1/whowouldwininator/generate-character-details/backstory/route.ts
@@ -8,6 +8,16 @@ export async function POST(request: Request) {
   try {
     const { name, description } = await request.json()
 
+    if (!name || typeof name !== 'string') {
+      return NextResponse.json({ error: 'name is required.' }, { status: 400 })
+    }
+    if (name.length > 200) {
+      return NextResponse.json({ error: 'name must be 200 characters or fewer.' }, { status: 400 })
+    }
+    if (description && description.length > 1000) {
+      return NextResponse.json({ error: 'description must be 1000 characters or fewer.' }, { status: 400 })
+    }
+
     const openaiClient = createOpenAI({
       apiKey: process.env.OPENAI_API_KEY,
     })

--- a/src/app/api/v1/whowouldwininator/generate-character-details/feats/route.ts
+++ b/src/app/api/v1/whowouldwininator/generate-character-details/feats/route.ts
@@ -9,6 +9,16 @@ export async function POST(request: Request) {
   try {
     const { name, description } = await request.json()
 
+    if (!name || typeof name !== 'string') {
+      return NextResponse.json({ error: 'name is required.' }, { status: 400 })
+    }
+    if (name.length > 200) {
+      return NextResponse.json({ error: 'name must be 200 characters or fewer.' }, { status: 400 })
+    }
+    if (description && description.length > 1000) {
+      return NextResponse.json({ error: 'description must be 1000 characters or fewer.' }, { status: 400 })
+    }
+
     const openaiClient = createOpenAI({
       apiKey: process.env.OPENAI_API_KEY,
     })

--- a/src/app/api/v1/whowouldwininator/generate-character-details/portrait/route.ts
+++ b/src/app/api/v1/whowouldwininator/generate-character-details/portrait/route.ts
@@ -17,6 +17,16 @@ export async function POST(request: Request) {
     }
     const { name, description } = await request.json()
 
+    if (!name || typeof name !== 'string') {
+      return NextResponse.json({ error: 'name is required.' }, { status: 400 })
+    }
+    if (name.length > 200) {
+      return NextResponse.json({ error: 'name must be 200 characters or fewer.' }, { status: 400 })
+    }
+    if (description && description.length > 1000) {
+      return NextResponse.json({ error: 'description must be 1000 characters or fewer.' }, { status: 400 })
+    }
+
     const openaiClient = createOpenAI({
       apiKey: process.env.OPENAI_API_KEY,
     })

--- a/src/app/api/v1/whowouldwininator/generate-character-details/powers/route.ts
+++ b/src/app/api/v1/whowouldwininator/generate-character-details/powers/route.ts
@@ -8,6 +8,16 @@ export async function POST(request: Request) {
   try {
     const { name, description } = await request.json()
 
+    if (!name || typeof name !== 'string') {
+      return NextResponse.json({ error: 'name is required.' }, { status: 400 })
+    }
+    if (name.length > 200) {
+      return NextResponse.json({ error: 'name must be 200 characters or fewer.' }, { status: 400 })
+    }
+    if (description && description.length > 1000) {
+      return NextResponse.json({ error: 'description must be 1000 characters or fewer.' }, { status: 400 })
+    }
+
     const openaiClient = createOpenAI({
       apiKey: process.env.OPENAI_API_KEY,
     })

--- a/src/app/api/v1/whowouldwininator/generate-character-details/stats/route.ts
+++ b/src/app/api/v1/whowouldwininator/generate-character-details/stats/route.ts
@@ -8,6 +8,16 @@ export async function POST(request: Request) {
   try {
     const { name, description } = await request.json()
 
+    if (!name || typeof name !== 'string') {
+      return NextResponse.json({ error: 'name is required.' }, { status: 400 })
+    }
+    if (name.length > 200) {
+      return NextResponse.json({ error: 'name must be 200 characters or fewer.' }, { status: 400 })
+    }
+    if (description && description.length > 1000) {
+      return NextResponse.json({ error: 'description must be 1000 characters or fewer.' }, { status: 400 })
+    }
+
     const openaiClient = createOpenAI({
       apiKey: process.env.OPENAI_API_KEY,
     })


### PR DESCRIPTION
Adds max-length guards to 6 whowouldwininator routes that inject user-controlled strings into AI prompts. Same pattern as PR #2667 (secret-word/voters).

## Routes fixed
- `generate-character-description`: `name` ≤ 200 chars
- `generate-character-details/backstory`: `name` required + ≤ 200, `description` ≤ 1000
- `generate-character-details/feats`: same
- `generate-character-details/portrait`: same
- `generate-character-details/powers`: same
- `generate-character-details/stats`: same

All violations return 400.

Closes #2681