### PR TITLE
fix(a11y): oracle step02 keyboard support + hexagram line aria-labels + chat remove button label

### DIFF
--- a/src/app/chat-room-of-infinity/components/molecules/CharacterUserItem.tsx
+++ b/src/app/chat-room-of-infinity/components/molecules/CharacterUserItem.tsx
@@ -18,7 +18,7 @@ export default function CharacterUserItem({ character }: Props) {
   return (
     <UserListItem
       secondaryAction={
-        <IconButton edge="end" onClick={() => removeCharacter(character.id)}>
+        <IconButton edge="end" aria-label={`Remove ${character.name}`} onClick={() => removeCharacter(character.id)}>
           <Close />
         </IconButton>
       }

--- a/src/app/oracle/components/hexagram.tsx
+++ b/src/app/oracle/components/hexagram.tsx
@@ -98,6 +98,7 @@ export const LineControl = ({
         role={isStatic ? undefined : 'button'}
         tabIndex={isStatic ? undefined : 0}
         onKeyDown={isStatic ? undefined : e => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); toggleLine() } }}
+        aria-label={isStatic ? undefined : 'Toggle line type'}
       >
         <Line type={lineData?.type} isStatic={isStatic} />
       </div>
@@ -106,6 +107,7 @@ export const LineControl = ({
         role={isStatic ? undefined : 'button'}
         tabIndex={isStatic ? undefined : 0}
         onKeyDown={isStatic ? undefined : e => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); toggleHasChanges() } }}
+        aria-label={isStatic ? undefined : 'Toggle changing line'}
       >
         <ChangeMarker hasChanges={Boolean(lineData?.hasChanges)} isStatic={isStatic} />
       </div>

--- a/src/app/oracle/components/workflow/step02-select-generation-method.tsx
+++ b/src/app/oracle/components/workflow/step02-select-generation-method.tsx
@@ -63,7 +63,11 @@ export const Step02SelectGenerationMethod = ({
               <div className="grid md:grid-cols-2 gap-6">
                 <ChunkyCard
                   className="cursor-pointer hover:border-surface-variant hover:shadow-lg transition-all duration-200 group relative overflow-hidden"
+                  role="button"
+                  tabIndex={0}
                   onClick={() => handleSelectGenerationMethod('generate')}
+                  onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); handleSelectGenerationMethod('generate') } }}
+                  aria-label="Generate with Divination"
                 >
                   <div className="absolute top-4 right-4">
                     <SparkleIcon />
@@ -95,7 +99,11 @@ export const Step02SelectGenerationMethod = ({
 
                 <ChunkyCard
                   className="cursor-pointer hover:border-surface-variant hover:shadow-lg transition-all duration-200 group relative overflow-hidden"
+                  role="button"
+                  tabIndex={0}
                   onClick={() => handleSelectGenerationMethod('build')}
+                  onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); handleSelectGenerationMethod('build') } }}
+                  aria-label="Enter Hexagram Manually"
                 >
                   <div className="absolute top-4 right-4">
                     <HexagramIcon />


### PR DESCRIPTION
Three small accessibility fixes across oracle and chat-room-of-infinity.

## Oracle step02 method selection cards
`step02-select-generation-method.tsx`: the two ChunkyCard selection cards had `onClick` but no keyboard support. Added `role="button"`, `tabIndex={0}`, `onKeyDown`, and `aria-label` to each.

## Hexagram LineControl buttons
`hexagram.tsx`: the two interactive divs (toggle line type, toggle changing line) already had `role="button"` and keyboard handling, but were missing `aria-label`. Added `"Toggle line type"` and `"Toggle changing line"`.

## Chat room character remove button
`CharacterUserItem.tsx`: MUI `<IconButton>` with `<Close />` icon lacked an accessible label. Added `aria-label={\`Remove \${character.name}\`}`.

Closes #2685