### PR TITLE
fix(a11y+api): CombatUI progress bar ARIA + storybook-factory input length validation

### DIFF
--- a/src/app/api/v1/storybook-factory/generate-illustration/route.ts
+++ b/src/app/api/v1/storybook-factory/generate-illustration/route.ts
@@ -25,6 +25,12 @@ export async function POST(request: Request) {
     if (!prompt) {
       return NextResponse.json({ error: 'prompt is required' }, { status: 400 })
     }
+    if (prompt.length > 1000) {
+      return NextResponse.json({ error: 'prompt must be 1000 characters or fewer.' }, { status: 400 })
+    }
+    if (storyContext && storyContext.length > 2000) {
+      return NextResponse.json({ error: 'storyContext must be 2000 characters or fewer.' }, { status: 400 })
+    }
 
     const genAI = new GoogleGenerativeAI(process.env.GEMINI_API_KEY!)
 

--- a/src/app/api/v1/storybook-factory/generate-story/route.ts
+++ b/src/app/api/v1/storybook-factory/generate-story/route.ts
@@ -51,6 +51,16 @@ export async function POST(request: Request) {
 
     const { caption1, caption2, storyDirectionPrompt, storyConfig: rawStoryConfig } = await request.json()
 
+    if (caption1 && caption1.length > 500) {
+      return NextResponse.json({ error: 'caption1 must be 500 characters or fewer.' }, { status: 400 })
+    }
+    if (caption2 && caption2.length > 500) {
+      return NextResponse.json({ error: 'caption2 must be 500 characters or fewer.' }, { status: 400 })
+    }
+    if (storyDirectionPrompt && storyDirectionPrompt.length > 1000) {
+      return NextResponse.json({ error: 'storyDirectionPrompt must be 1000 characters or fewer.' }, { status: 400 })
+    }
+
     if (!rawStoryConfig || typeof rawStoryConfig !== 'object' || Array.isArray(rawStoryConfig)) {
       return NextResponse.json({ error: 'storyConfig is required' }, { status: 400 })
     }

--- a/src/app/api/v1/storybook-factory/revise-story/route.ts
+++ b/src/app/api/v1/storybook-factory/revise-story/route.ts
@@ -51,6 +51,10 @@ export async function POST(request: Request) {
 
     const { revisionPrompt, currentLayout, storyConfig } = await request.json()
 
+    if (revisionPrompt && revisionPrompt.length > 1000) {
+      return NextResponse.json({ error: 'revisionPrompt must be 1000 characters or fewer.' }, { status: 400 })
+    }
+
     if (!revisionPrompt || !currentLayout) {
       return NextResponse.json(
         { error: 'revisionPrompt and currentLayout are required' },

--- a/src/app/api/v1/storybook-factory/suggest-configuration/route.ts
+++ b/src/app/api/v1/storybook-factory/suggest-configuration/route.ts
@@ -21,6 +21,16 @@ export async function POST(request: Request) {
 
     const { caption1, caption2, storyDirectionPrompt } = await request.json()
 
+    if (caption1 && caption1.length > 500) {
+      return NextResponse.json({ error: 'caption1 must be 500 characters or fewer.' }, { status: 400 })
+    }
+    if (caption2 && caption2.length > 500) {
+      return NextResponse.json({ error: 'caption2 must be 500 characters or fewer.' }, { status: 400 })
+    }
+    if (storyDirectionPrompt && storyDirectionPrompt.length > 1000) {
+      return NextResponse.json({ error: 'storyDirectionPrompt must be 1000 characters or fewer.' }, { status: 400 })
+    }
+
     const imageDescriptions = [
       caption1 ? `Image 1: "${caption1}"` : 'Image 1: (no caption provided)',
       caption2 ? `Image 2: "${caption2}"` : 'Image 2: (no caption provided)',

--- a/src/app/tap-tap-adventure/components/CombatUI.tsx
+++ b/src/app/tap-tap-adventure/components/CombatUI.tsx
@@ -34,7 +34,7 @@ function HpBar({ current, max, label, color }: { current: number; max: number; l
         <span className="text-slate-300">{label}</span>
         <span className={color}>{current}/{max} HP</span>
       </div>
-      <div className="h-2 bg-slate-700 rounded-full overflow-hidden">
+      <div className="h-2 bg-slate-700 rounded-full overflow-hidden" role="progressbar" aria-valuenow={current} aria-valuemin={0} aria-valuemax={max} aria-label={label}>
         <div
           className={`h-full ${barColor} rounded-full transition-all duration-300`}
           style={{ width: `${pct}%` }}
@@ -53,7 +53,7 @@ function ManaBar({ current, max }: { current: number; max: number }) {
         <span className="text-slate-300">MP</span>
         <span className="text-blue-400">{current}/{max} MP</span>
       </div>
-      <div className="h-2 bg-slate-700 rounded-full overflow-hidden">
+      <div className="h-2 bg-slate-700 rounded-full overflow-hidden" role="progressbar" aria-valuenow={current} aria-valuemin={0} aria-valuemax={max} aria-label="Mana">
         <div
           className="h-full bg-blue-500 rounded-full transition-all duration-300"
           style={{ width: `${pct}%` }}


### PR DESCRIPTION
Bundles two related fixes.

## CombatUI ARIA (`src/app/tap-tap-adventure/components/CombatUI.tsx`)
`HpBar` and `ManaBar` outer track divs now carry `role="progressbar"`, `aria-valuenow`, `aria-valuemin`, `aria-valuemax`, and `aria-label`. Screen readers can now convey HP/MP values.

## Storybook-factory input length validation
Four routes that inject user strings into AI prompts now validate input lengths:
- `generate-story`: `caption1`/`caption2` ≤ 500, `storyDirectionPrompt` ≤ 1000
- `revise-story`: `revisionPrompt` ≤ 1000
- `suggest-configuration`: same as generate-story
- `generate-illustration`: `prompt` ≤ 1000, `storyContext` ≤ 2000

Closes #2687, closes #2688