### PR TITLE
fix(a11y): add aria-label to InventoryPanel sort select

### DIFF
--- a/src/app/tap-tap-adventure/components/InventoryPanel.tsx
+++ b/src/app/tap-tap-adventure/components/InventoryPanel.tsx
@@ -142,6 +142,7 @@ export function InventoryPanel({ inventory }: InventoryPanelProps) {
         </h3>
         <select
           value={sortBy}
+          aria-label="Sort items"
           onChange={e => setSortBy(e.target.value as typeof sortBy)}
           className="bg-[#2a2b3f] border border-[#3a3c56] text-gray-300 text-xs rounded px-2 py-1"
         >


### PR DESCRIPTION
The `<select>` for sorting inventory items had no accessible name. Added `aria-label="Sort items"`.

Closes #2690