### PR TITLE
fix(a11y): add aria-label to 6 unlabeled inputs in tap-tap-adventure components

### DIFF
--- a/src/app/tap-tap-adventure/components/AdventureLeaderboard.tsx
+++ b/src/app/tap-tap-adventure/components/AdventureLeaderboard.tsx
@@ -250,6 +250,7 @@ export default function AdventureLeaderboard({ onBack }: AdventureLeaderboardPro
               value={nameInput}
               onChange={e => setNameInput(e.target.value.slice(0, 20))}
               placeholder="Your player name"
+              aria-label="Your player name"
               className="w-full px-3 py-2 rounded bg-[#161723] border border-[#3a3c56] text-slate-200 placeholder-slate-500 focus:outline-none focus:border-indigo-500"
               onKeyDown={e => { if (e.key === 'Enter') handleSaveName() }}
               autoFocus

--- a/src/app/tap-tap-adventure/components/BestiaryPanel.tsx
+++ b/src/app/tap-tap-adventure/components/BestiaryPanel.tsx
@@ -106,6 +106,7 @@ export function BestiaryPanel({ bestiary }: { bestiary: BestiaryEntry[] }) {
         <input
           type="text"
           placeholder="Search enemies..."
+          aria-label="Search enemies"
           value={searchQuery}
           onChange={e => setSearchQuery(e.target.value)}
           className="w-full bg-[#161723] border border-[#2a2b3f] rounded px-2 py-1.5 text-xs text-slate-200 placeholder:text-slate-500 focus:outline-none focus:border-indigo-600"

--- a/src/app/tap-tap-adventure/components/NPCDialoguePanel.tsx
+++ b/src/app/tap-tap-adventure/components/NPCDialoguePanel.tsx
@@ -239,6 +239,7 @@ export function NPCDialoguePanel({
             type="text"
             className="flex-1 bg-[#161723] border border-[#2a2b3f] rounded px-3 py-2 text-sm text-slate-200 placeholder-slate-500 focus:outline-none focus:border-indigo-600 disabled:opacity-50"
             placeholder="Type your response..."
+            aria-label="Type your response"
             value={playerInput}
             onChange={e => setPlayerInput(e.target.value)}
             onKeyDown={handleKeyDown}

--- a/src/app/tap-tap-adventure/components/PartyDialoguePanel.tsx
+++ b/src/app/tap-tap-adventure/components/PartyDialoguePanel.tsx
@@ -136,6 +136,7 @@ export function PartyDialoguePanel({
           type="text"
           className="flex-1 bg-[#252638] border border-[#3a3c56] rounded px-2 py-1 text-xs text-slate-200 placeholder:text-slate-500 focus:outline-none focus:border-indigo-500"
           placeholder={conversationComplete ? 'Conversation ended' : 'Say something...'}
+          aria-label="Dialogue input"
           value={inputText}
           onChange={e => setInputText(e.target.value)}
           onKeyDown={e => e.key === 'Enter' && handleSend()}

--- a/src/app/tap-tap-adventure/components/RunSummary.tsx
+++ b/src/app/tap-tap-adventure/components/RunSummary.tsx
@@ -250,6 +250,7 @@ export default function RunSummary({
               value={nameInput}
               onChange={e => setNameInput(e.target.value.slice(0, 20))}
               placeholder="Enter your player name"
+              aria-label="Player name"
               className="flex-1 px-3 py-2 rounded bg-[#161723] border border-[#3a3c56] text-slate-200 placeholder-slate-500 focus:outline-none focus:border-indigo-500 text-sm"
               onKeyDown={e => { if (e.key === 'Enter') handleSaveName() }}
             />

--- a/src/app/tap-tap-adventure/components/StoryFeed.tsx
+++ b/src/app/tap-tap-adventure/components/StoryFeed.tsx
@@ -225,6 +225,7 @@ export function StoryFeed({
         <input
           type="text"
           placeholder="Search..."
+          aria-label="Search events"
           value={searchQuery}
           onChange={e => setSearchQuery(e.target.value)}
           className="flex-1 min-w-[80px] bg-slate-800 border border-slate-700 rounded px-1.5 py-0.5 text-[10px] text-slate-200 placeholder:text-slate-500 focus:outline-none focus:border-indigo-600"


### PR DESCRIPTION
Adds `aria-label` to six form inputs that had none.

## Changes
- `BestiaryPanel.tsx`: `aria-label="Search enemies"` on search input
- `NPCDialoguePanel.tsx`: `aria-label="Type your response"` on dialogue input
- `RunSummary.tsx`: `aria-label="Player name"` on leaderboard name input
- `AdventureLeaderboard.tsx`: `aria-label="Your player name"` on name dialog input
- `PartyDialoguePanel.tsx`: `aria-label="Dialogue input"` on party dialogue input
- `StoryFeed.tsx`: `aria-label="Search events"` on event search input

Closes #2694