### PR TITLE
fix(api): add Zod validation to whowouldwininator generate-character-description

### DIFF
--- a/src/app/api/v1/whowouldwininator/generate-character-description/route.ts
+++ b/src/app/api/v1/whowouldwininator/generate-character-description/route.ts
@@ -1,16 +1,23 @@
 import { createOpenAI } from '@ai-sdk/openai'
 import { generateText } from 'ai'
 import { NextResponse } from 'next/server'
+import { z } from 'zod'
 
 import { READING_LEVEL } from '@/app/api/v1/whowouldwininator/constants'
 
+const RequestSchema = z.object({
+  name: z.string().min(1, 'Character name is required').max(200),
+})
+
 export async function POST(request: Request) {
   try {
-    const { name } = await request.json()
-
-    if (!name || name.trim() === '') {
-      return NextResponse.json({ error: 'Character name is required' }, { status: 400 })
+    const body = await request.json()
+    const parseResult = RequestSchema.safeParse(body)
+    if (!parseResult.success) {
+      return NextResponse.json({ error: parseResult.error.errors[0]?.message ?? 'Invalid request' }, { status: 400 })
     }
+
+    const { name } = parseResult.data
 
     const openaiClient = createOpenAI({
       apiKey: process.env.OPENAI_API_KEY,


### PR DESCRIPTION
## Summary
- Added `z.string().min(1).max(200)` Zod schema to `generate-character-description/route.ts`
- Replaces loose manual `if (!name || name.trim() === '')` check with proper `safeParse` returning 400 on failure
- Other whowouldwininator routes were fixed in PR #2682 — this one was missed

## Test plan
- [ ] POST with valid name → description generated as before
- [ ] POST with empty name → 400 "Character name is required"
- [ ] POST with name > 200 chars → 400 error

Closes #2699

🤖 Generated with [Claude Code](https://claude.com/claude-code)