### PR TITLE
fix(api): add Zod input validation to voters API routes

### DIFF
--- a/src/app/api/v1/voters/cast-vote/route.ts
+++ b/src/app/api/v1/voters/cast-vote/route.ts
@@ -3,6 +3,24 @@ import { generateObject } from 'ai'
 import { type NextRequest, NextResponse } from 'next/server'
 import { z } from 'zod'
 
+const CastVoteRequestSchema = z.object({
+  voter: z.object({
+    id: z.string(),
+    name: z.string().max(200),
+    description: z.string().max(1000),
+    modelConfig: z.object({
+      model: z.string(),
+      temperature: z.number(),
+      maxTokens: z.number(),
+    }),
+  }),
+  criteria: z.object({
+    question: z.string().max(1000),
+    options: z.array(z.string().max(500)).min(1).max(20),
+  }),
+  instance: z.number().optional(),
+})
+
 export async function POST(request: NextRequest) {
   try {
     // Get API key from environment variable or request header
@@ -20,14 +38,14 @@ export async function POST(request: NextRequest) {
       )
     }
 
-    const { voter, criteria, instance } = await request.json()
-
-    if (!criteria?.options || !Array.isArray(criteria.options) || criteria.options.length === 0) {
+    const parseResult = CastVoteRequestSchema.safeParse(await request.json())
+    if (!parseResult.success) {
       return NextResponse.json(
-        { error: 'criteria.options must be a non-empty array' },
+        { error: parseResult.error.errors[0]?.message ?? 'Invalid request' },
         { status: 400 }
       )
     }
+    const { voter, criteria, instance = 0 } = parseResult.data
 
     // Create dynamic schema based on voting criteria
     const voteSchema = z.object({

--- a/src/app/api/v1/voters/generate-criteria/route.ts
+++ b/src/app/api/v1/voters/generate-criteria/route.ts
@@ -17,6 +17,11 @@ const CriteriaSchema = z.object({
     .describe('2-4 tips for improving the question or options'),
 })
 
+const RequestSchema = z.object({
+  question: z.string().min(1, 'Question is required').max(1000),
+  existingOptions: z.array(z.string().max(500)).max(20).optional(),
+})
+
 export async function POST(request: NextRequest) {
   try {
     // Get API key from environment variable or request header
@@ -34,14 +39,14 @@ export async function POST(request: NextRequest) {
       )
     }
 
-    const { question, existingOptions = [] } = await request.json()
-
-    if (!question || typeof question !== 'string' || question.trim().length === 0) {
+    const parseResult = RequestSchema.safeParse(await request.json())
+    if (!parseResult.success) {
       return NextResponse.json(
-        { error: 'Question is required and must be a non-empty string.' },
+        { error: parseResult.error.errors[0]?.message ?? 'Invalid request' },
         { status: 400 }
       )
     }
+    const { question, existingOptions = [] } = parseResult.data
 
     const existingOptionsText =
       existingOptions.length > 0

--- a/src/app/api/v1/voters/generate-summary/route.ts
+++ b/src/app/api/v1/voters/generate-summary/route.ts
@@ -1,6 +1,22 @@
 import { createOpenAI } from '@ai-sdk/openai'
 import { generateText } from 'ai'
 import { type NextRequest, NextResponse } from 'next/server'
+import { z } from 'zod'
+
+const GenerateSummaryRequestSchema = z.object({
+  voterGroup: z.object({
+    name: z.string().max(200),
+    description: z.string().max(1000),
+  }),
+  votes: z.array(z.object({
+    choice: z.string().max(500),
+    reasoning: z.string().max(1000),
+  })).min(1).max(100),
+  criteria: z.object({
+    question: z.string().max(1000),
+    options: z.array(z.string().max(500)).max(20),
+  }),
+})
 
 export async function POST(request: NextRequest) {
   try {
@@ -19,14 +35,14 @@ export async function POST(request: NextRequest) {
       )
     }
 
-    const { voterGroup, votes, criteria } = await request.json()
-
-    if (!voterGroup || !votes || !Array.isArray(votes) || votes.length === 0) {
+    const parseResult = GenerateSummaryRequestSchema.safeParse(await request.json())
+    if (!parseResult.success) {
       return NextResponse.json(
-        { error: 'Invalid request: voterGroup and votes are required' },
+        { error: parseResult.error.errors[0]?.message ?? 'Invalid request' },
         { status: 400 }
       )
     }
+    const { voterGroup, votes, criteria } = parseResult.data
 
     // Create a summary of the voting patterns and reasoning
     const votingData = votes.map(vote => ({


### PR DESCRIPTION
## Summary
Three voters API routes passed unbounded user strings directly to OpenAI. This adds Zod schemas with `.max()` bounds on all relevant fields.

- `generate-criteria`: `question` max 1000 chars, `existingOptions` items max 500, array max 20
- `cast-vote`: voter `name` max 200, `description` max 1000, `criteria.question` max 1000, options items max 500
- `generate-summary`: `voterGroup.name` max 200, `voterGroup.description` max 1000, `criteria.question` max 1000, vote `reasoning` max 1000

## Test plan
- [ ] Normal voting flow works end-to-end
- [ ] Submitting a question > 1000 chars to generate-criteria returns 400
- [ ] Submitting a voter description > 1000 chars to cast-vote returns 400

Closes #2700

🤖 Generated with [Claude Code](https://claude.com/claude-code)