### PR TITLE
feat(micro-land): plants seed where the light is

### DIFF
--- a/src/app/micro-land/domain/constants.ts
+++ b/src/app/micro-land/domain/constants.ts
@@ -148,6 +148,28 @@ export const PLANT_SEED_BATCH = Math.round(3 * WIDTH_SCALE)
 export const NATIVE_PLANT_SPECIES = 3
 
 /**
+ * How often a seed is dropped from the sky rather than from a random height.
+ *
+ * Not a taste setting — this is the difference between a meadow and a world
+ * that looks bare while its plant counter reads full. Every fertile surface in
+ * a cross-section world is a candidate for a seed, and the overwhelming
+ * majority of them are cave floors: the sky holds nothing, the outdoor surface
+ * is one row per column, and the rock below it is a honeycomb. Sampling a point
+ * in that volume uniformly put 95% of the flora underground. Measured on earth
+ * over ten minutes: 554 of 585 plants buried, one sunleaf left on the surface
+ * of the entire world, grazers starving at more than twice the rate they were
+ * being hunted, and the ground's own seed bank switched off the whole time
+ * because the *global* plant count was sitting on its ceiling.
+ *
+ * Short of 1 on purpose. Caves keeping some flora is what makes a glowvine
+ * worth finding down there, and it is the only way anything grows in a world
+ * with no outdoor surface at all — a sealed station, a cavern the player
+ * painted shut. One seed in six is enough to green a cave system slowly
+ * without taking the meadow's share of MAX_PLANTS back off it.
+ */
+export const SURFACE_SEEDING_BIAS = 0.84
+
+/**
  * Carrying capacity for a single animal species.
  *
  * Without predator pressure a grazer grows until it hits the global population

--- a/src/app/micro-land/domain/sim/world.ts
+++ b/src/app/micro-land/domain/sim/world.ts
@@ -21,6 +21,7 @@ import {
   PLANT_SEED_INTERVAL,
   PLANT_SPECIES_CAP,
   SEED_RAIN_INTERVAL,
+  SURFACE_SEEDING_BIAS,
   WIDTH_SCALE,
   WORLD_H,
   WORLD_W,
@@ -416,11 +417,32 @@ export function findSpawnSpot(
   for (let attempt = 0; attempt < 120; attempt++) {
     let x: number
     let y: number
+    /**
+     * Dropped from the sky rather than from a random height, so the seed lands
+     * on the *outdoor* surface of its column instead of the first cave floor it
+     * happens to fall past.
+     *
+     * A random point in the world volume is overwhelmingly a point underground:
+     * the sky is empty, the surface is one row, and everything below it is a
+     * honeycomb of caves whose floors are all fertile. Sampling y uniformly and
+     * settling from there put 554 of 585 plants in caves nobody can see, left
+     * one sunleaf on the entire surface of the world, and starved every grazer
+     * standing on it — while the headline plant count read as a world at its
+     * ceiling. See SURFACE_SEEDING_BIAS for why some seeds still fall short.
+     */
+    let fromSky = false
     if (near) {
       const a = rng() * Math.PI * 2
       const r = rng() * near.radius
       x = near.x + Math.cos(a) * r
       y = near.y + Math.sin(a) * r
+    } else if (isPlant && !wantsLiquid && rng() < SURFACE_SEEDING_BIAS) {
+      // Water plants are excluded because the checks below judge the spot
+      // *before* it settles: kelp asked about an empty sky reads as beached and
+      // rejects all 120 attempts, which would quietly wipe kelp out of tidepool.
+      x = rng() * (WORLD_W - bw)
+      y = 0
+      fromSky = true
     } else {
       x = rng() * (WORLD_W - bw)
       y = rng() * (WORLD_H - bh)
@@ -444,6 +466,10 @@ export function findSpawnSpot(
       // a random point in open sky a usable spawn instead of a wasted attempt.
       const settled = settleOnGround(w, x + body.dx, y + body.dy, body.w, body.h, {
         requireFertile: isPlant,
+        // A seed let go at the top of the sky has the whole world to fall
+        // through. The default 64 stops half way down and would leave every
+        // deep valley barren for no reason the player could ever work out.
+        maxDrop: fromSky ? WORLD_H : undefined,
       })
       if (settled === null) continue
       // `settled` is the core's resting top edge; the sprite hangs above it.


### PR DESCRIPTION
## The plants were not being ignored. They were underground.

The symptom was that grazers never seemed to eat, and it looked like predation — the plant eaters were getting hunted before they could graze. The harness says otherwise.

`findSpawnSpot` picks a uniform random point in the world **volume** and drops it onto the first fertile ground beneath. In a cross-section world that is almost always a cave floor: the sky holds nothing, the outdoor surface is one row per column, and everything below it is a honeycomb whose floors are all fertile.

Measured on earth over ten minutes: **532 of 583 plants buried, 51 left on the surface of the entire world.**

So grazers standing on the grass starved while the plant counter read full. Starvation killed them at nearly twice the rate predators did — 377 starved against 225 eaten — which from the outside reads as "the hunters are too strong" and is really "there is nothing up here to eat."

Two things kept it that way:

- The plant count sits pinned at `MAX_PLANTS`, so `seedNativePlants` compares it against `NATIVE_PLANT_TARGET`, sees a large surplus, and **never fires at all**. The ground's seed bank — which exists precisely so a grazed meadow grows back — is switched off in every earth run.
- The global ceiling binds before the per-species caps do, so no plant can breed except into a slot just freed by a death. The cave species win that race on sheer number of parents, and sunleaf's population was the arithmetic remainder of it rather than an equilibrium.

## The change

Seeds now fall from the top of the sky and settle on their column's outdoor surface. Two files, 48 lines added, nothing removed.

Short of always, deliberately — one seed in six still starts at a random height. That is what keeps a glowvine worth finding underground, and what lets anything grow at all in a world with no outdoor surface: a sealed station, a cavern the player painted shut.

## Numbers

Matched pair, earth, 600s × 3 runs, same seeds. The control keeps the `rng()` draw so the random streams stay aligned — a control that skips the call shifts every subsequent draw and is not comparable.

| | before | after |
|---|---|---|
| plants eaten | 1675 | **2101** (+25%) |
| plants on the surface | 51 | **264** |
| plants buried | 532 | 320 |
| grazers eaten | 225 | 199 |

All four themes end `✓ Still alive`, low-water marks unchanged. Tidepool gains most — its finling herd goes from 13 to 68 — while volcanic and station are flat by design: volcanic's surface is ash and obsidian, the station is sealed, so their flora is genuinely cave flora and the 16% fallback leaves them alone.

## Worth knowing for review

- **Water plants are excluded from the sky drop.** The wetness checks in `findSpawnSpot` judge a spot *before* it settles, so a kelp seed released into empty sky reads as beached and would fail all 120 attempts — silently emptying tidepool of kelp. This exclusion is load-bearing, not defensive.
- **`maxDrop` is raised for sky-dropped seeds only.** The default 64 stops half way down a 132-tall world and would leave deep valleys barren for no visible reason.
- Verified: `npm run typecheck` (no micro-land errors), `npx vitest run src/app/micro-land` 17/17, `npx eslint` clean on both files, and the ten-minute harness on all four themes.

## Not included

Pulling hunters back is a real further lever — deleting every hunter triples grazing to ~4450 plants eaten — but how dangerous the world should feel is a design call for Micro Land's owner, not a balance number to quietly tune. Left untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
