### PR TITLE
feat(micro-land): edit a creature instead of copying it

### DIFF
--- a/src/app/api/v1/micro-land/roster/route.ts
+++ b/src/app/api/v1/micro-land/roster/route.ts
@@ -1,0 +1,92 @@
+/**
+ * Editing the shipped roster, from the game, on the machine that owns the repo.
+ *
+ * The starter creatures are global assets: every player gets them, and changing
+ * one is a change to the source, not to anybody's save file. So this route does
+ * the one thing no other route in the app does — it writes a project file — and
+ * it only exists while the dev server is running.
+ *
+ * The gate is `NODE_ENV`, which is the honest one rather than a convenient one.
+ * It is fixed at build time, so the route is dead code in the deployed bundle
+ * rather than a live endpoint behind a check; there is also no writable checkout
+ * on the host to point it at. Nothing here reads a path from the request — the
+ * body supplies a creature id used to *find* an existing declaration, and the
+ * file being written is a constant.
+ *
+ * The result still has to be committed by hand. That is the point: an edit made
+ * by dragging pixels around lands as a reviewable diff, next to the food chain
+ * that roster documents.
+ */
+import { readFile, writeFile } from 'node:fs/promises'
+import path from 'node:path'
+
+import { NextResponse } from 'next/server'
+
+import { sanitizeBlueprint } from '@/app/micro-land/domain/blueprint'
+import { ROSTER_PATH, renderCreatureLiteral, rewriteCreature } from '@/lib/micro-land/roster-source'
+
+export const runtime = 'nodejs'
+
+/** In production this route is not a forbidden endpoint — it is not an endpoint. */
+const ENABLED = process.env.NODE_ENV === 'development'
+
+export async function POST(request: Request) {
+  if (!ENABLED) return new NextResponse(null, { status: 404 })
+
+  let body: { id?: unknown; blueprint?: unknown }
+  try {
+    body = (await request.json()) as { id?: unknown; blueprint?: unknown }
+  } catch {
+    return NextResponse.json({ error: 'Expected a JSON body.' }, { status: 400 })
+  }
+
+  const id = typeof body.id === 'string' ? body.id : ''
+  // Built-in ids are slugs by construction. Insisting on that here keeps the
+  // value that goes into an `indexOf` from being able to carry regex or quote
+  // characters, whatever else changes upstream.
+  if (!/^[a-z0-9-]{1,64}$/.test(id)) {
+    return NextResponse.json({ error: 'That is not a roster creature id.' }, { status: 400 })
+  }
+
+  /**
+   * Same sanitizer as every other way into the world, for the same reason.
+   *
+   * It cannot throw, so this is not validation so much as a guarantee: what
+   * gets printed into the roster is exactly what the game would have run, with
+   * every clamp already applied. A number the builder let through but the
+   * schema does not allow is silently corrected here rather than committed and
+   * corrected on every load forever after.
+   */
+  const blueprint = sanitizeBlueprint(body.blueprint, { idPrefix: 'builtin' })
+
+  const file = path.join(process.cwd(), ROSTER_PATH)
+
+  let source: string
+  try {
+    source = await readFile(file, 'utf8')
+  } catch (error) {
+    console.error('micro-land roster read failed:', error)
+    return NextResponse.json({ error: 'Could not read the roster file.' }, { status: 500 })
+  }
+
+  try {
+    // Formatted with the project's own config rather than a guess at it, and
+    // formatted *alone* — see `renderCreatureLiteral`. The file this writes to
+    // is not prettier-clean, so running the formatter over the whole of it
+    // would bury the edited creature in reformatting of every other one.
+    const literal = await renderCreatureLiteral(blueprint, file)
+    const rewritten = rewriteCreature(source, id, literal)
+    if (rewritten === null) {
+      return NextResponse.json(
+        { error: `No creature called "${id}" in the roster to replace.` },
+        { status: 404 }
+      )
+    }
+    await writeFile(file, rewritten, 'utf8')
+  } catch (error) {
+    console.error('micro-land roster write failed:', error)
+    return NextResponse.json({ error: 'Could not write the roster file.' }, { status: 500 })
+  }
+
+  return NextResponse.json({ ok: true, id, name: blueprint.name, file: ROSTER_PATH })
+}

--- a/src/app/micro-land/MicroLandGame.tsx
+++ b/src/app/micro-land/MicroLandGame.tsx
@@ -268,6 +268,10 @@ export function MicroLandGame() {
     return gameRef.current?.introduce(raw, count) ?? null
   }, [])
 
+  const handleRevise = useCallback((blueprintId: string, raw: unknown) => {
+    return gameRef.current?.reviseSpecies(blueprintId, raw) ?? null
+  }, [])
+
   const handleNameElder = useCallback((name: string) => {
     return gameRef.current?.nameElder(name) ?? false
   }, [])
@@ -309,7 +313,7 @@ export function MicroLandGame() {
       <Toolbar onRemoveSpecies={handleRemoveSpecies} />
       <SummonPanel onIntroduce={handleIntroduce} onApplyTerrain={handleApplyTerrain} />
       <WorldsPanel onKeep={handleKeepWorld} onOpen={handleOpenWorld} onForget={handleForgetWorld} />
-      <CreatureBuilder onIntroduce={handleIntroduce} />
+      <CreatureBuilder onIntroduce={handleIntroduce} onRevise={handleRevise} />
       <FieldGuide />
       <SettingsPanel />
     </div>

--- a/src/app/micro-land/components/creature-builder.tsx
+++ b/src/app/micro-land/components/creature-builder.tsx
@@ -48,6 +48,14 @@ import { SummonLoader } from './summon-loader'
  * rest of the blueprint is inherited from whatever the drawing started from, so
  * recolouring a summoned creature keeps the parts of it that no canvas can
  * express.
+ *
+ * Opening a creature that already exists can mean two different things, and the
+ * panel used to assume the wrong one: saving always minted a new species, so
+ * fixing four pixels on your own dragon left you with two dragons. Editing and
+ * branching are now separate buttons, and which of them you get depends on what
+ * was opened — your own creature can be changed in place, the shipped roster
+ * can only be branched from, and the one machine with the repo checked out can
+ * write to the roster itself.
  */
 
 const IDEAS = [
@@ -60,6 +68,17 @@ const IDEAS = [
 
 /** How many to drop into the world the moment it is finished. */
 const PLACE_COUNT = 4
+
+/**
+ * Whether the roster can be written to from here.
+ *
+ * The starter creatures are global assets — everybody's, not the player's — so
+ * changing one is a change to the repository. Inlined at build time by Next, so
+ * in a deployed build this is `false` at the point the bundle is written and
+ * the button does not exist rather than being hidden; the route that would
+ * serve it is a 404 in production for the same reason.
+ */
+const CAN_EDIT_ROSTER = process.env.NODE_ENV === 'development'
 
 type PaintTool = 'draw' | 'fill' | 'erase' | 'pick'
 
@@ -92,11 +111,16 @@ function inksFor(draft: Draft): string[] {
 
 export function CreatureBuilder({
   onIntroduce,
+  onRevise,
 }: {
   onIntroduce: (
     raw: unknown,
     count: number
   ) => { blueprint: CreatureBlueprint; placed: number } | null
+  onRevise: (
+    blueprintId: string,
+    raw: unknown
+  ) => { blueprint: CreatureBlueprint; living: number } | null
 }) {
   const open = useMicroLand(s => s.builderOpen)
   const setOpen = useMicroLand(s => s.setBuilderOpen)
@@ -106,6 +130,15 @@ export function CreatureBuilder({
 
   const [draft, setDraft] = useState<Draft | null>(null)
   const [seed, setSeed] = useState<CreatureBlueprint | null>(null)
+  /**
+   * The species this drawing *is*, as opposed to the one it started from.
+   *
+   * Only set when a creature was opened off the shelf. A sketch the model just
+   * drew is also a whole blueprint and makes a perfectly good seed, but it has
+   * never been registered in the world — offering to save changes to it would
+   * mean offering to edit something that does not exist yet.
+   */
+  const [editingId, setEditingId] = useState<string | null>(null)
   const [name, setName] = useState('')
   const [frame, setFrame] = useState(0)
   const [tool, setPaintTool] = useState<PaintTool>('draw')
@@ -122,6 +155,7 @@ export function CreatureBuilder({
 
   const [prompt, setPrompt] = useState('')
   const [busy, setBusy] = useState(false)
+  const [saving, setSaving] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
   const abortRef = useRef<AbortController | null>(null)
@@ -151,10 +185,16 @@ export function CreatureBuilder({
 
   useEffect(() => () => abortRef.current?.abort(), [])
 
-  /** Adopt a drawing and everything that came with it. */
-  const adopt = useCallback((next: Draft, from: CreatureBlueprint | null) => {
+  /**
+   * Adopt a drawing and everything that came with it.
+   *
+   * `existing` says whether `from` is a creature already in the world, which is
+   * the difference between "change this one" and "start from this one".
+   */
+  const adopt = useCallback((next: Draft, from: CreatureBlueprint | null, existing = false) => {
     setDraft(next)
     setSeed(from)
+    setEditingId(existing && from ? from.id : null)
     setPast([])
     setFuture([])
     setFrame(0)
@@ -270,9 +310,16 @@ export function CreatureBuilder({
     }
   }
 
+  /** The literal the drawing describes. Same shape the model returns. */
+  function compose(): Record<string, unknown> | null {
+    if (!draft || empty) return null
+    return buildRawCreature({ name, draft, planId, dietId, glows, fireproof, seed })
+  }
+
+  /** Make a new species out of the drawing, leaving whatever it came from alone. */
   function bringToLife() {
-    if (!draft || empty) return
-    const raw = buildRawCreature({ name, draft, planId, dietId, glows, fireproof, seed })
+    const raw = compose()
+    if (!raw) return
     const result = onIntroduce(raw, PLACE_COUNT)
     if (!result) {
       setError('It would not hold together. Try again.')
@@ -283,12 +330,86 @@ export function CreatureBuilder({
     setOpen(false)
   }
 
+  /** Change the creature this drawing *is*. Everything alive follows along. */
+  function saveChanges() {
+    const raw = compose()
+    if (!raw || !editingId) return
+    const result = onRevise(editingId, raw)
+    if (!result) {
+      setError('That one is not here any more. You can still save it as a new creature.')
+      return
+    }
+    setTool({ kind: 'creature', blueprintId: result.blueprint.id })
+    notify(
+      result.living > 0
+        ? `Every ${result.blueprint.name} changes at once.`
+        : `${result.blueprint.name} is redrawn. Tap the world to place some.`
+    )
+    setOpen(false)
+  }
+
+  /**
+   * Write a starter creature back into the game's own source. Local only.
+   *
+   * The world is updated first and independently of the file. The two can
+   * disagree — a checkout can be read-only, the file can have moved — and when
+   * they do, the drawing you are looking at is still the one that matters right
+   * now, so it is applied either way and only the *permanence* is reported as
+   * having failed.
+   */
+  async function saveToRoster() {
+    const raw = compose()
+    if (!raw || !editingId || saving) return
+
+    setSaving(true)
+    setError(null)
+
+    const applied = onRevise(editingId, raw)
+    if (!applied) {
+      setError('That one is not here any more. You can still save it as a new creature.')
+      setSaving(false)
+      return
+    }
+
+    try {
+      const response = await fetch('/api/v1/micro-land/roster', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ id: editingId, blueprint: raw }),
+      })
+      const data = (await response.json().catch(() => ({}))) as { error?: string }
+      if (!response.ok) throw new Error(data.error ?? 'The roster would not take it.')
+    } catch (err) {
+      setError(
+        `${err instanceof Error ? err.message : 'Could not write it.'} The change is live here but is not saved to the file.`
+      )
+      setSaving(false)
+      return
+    }
+
+    setSaving(false)
+    notify(`${applied.blueprint.name} is written into the roster. Commit it to keep it.`)
+    setOpen(false)
+  }
+
   // Both walk every pixel of every frame. `draft` is replaced rather than
   // mutated, so the compiler's own memoization keys off it exactly and neither
   // re-runs on the cells of a drag that didn't change it.
   const empty = draft === null || inkBounds(draft) === null
   const trimmed = draft ? trimDraft(draft) : null
   const size = trimmed && !empty ? sizeForWidth(trimmed.w) : 0
+
+  /**
+   * What saving is allowed to mean here.
+   *
+   * A creature the player made is theirs to change. A starter creature is
+   * everybody's — on a deployed build it can only ever be branched from, since
+   * an edit to it would live in one browser and quietly disagree with the game
+   * every other player is running. On the machine holding the repo it can be
+   * edited properly, by writing the source.
+   */
+  const editingOwn = editingId !== null && seed?.summoned === true
+  const editingRoster = editingId !== null && seed !== null && !seed.summoned && CAN_EDIT_ROSTER
 
   const describe = useCallback(
     (index: number) => {
@@ -367,7 +488,7 @@ export function CreatureBuilder({
             setPrompt={setPrompt}
             onDraw={() => void drawFromPrompt()}
             onBlank={(w, h) => adopt(blankDraft(w, h), null)}
-            onCopy={bp => adopt(draftFromBlueprint(bp), bp)}
+            onCopy={bp => adopt(draftFromBlueprint(bp), bp, true)}
             blueprints={blueprints}
             error={error}
           />
@@ -725,34 +846,65 @@ export function CreatureBuilder({
                 </p>
               )}
 
-              <button
-                type="button"
-                className="cc-btn"
-                onClick={bringToLife}
-                disabled={empty}
-                style={{
-                  display: 'inline-flex',
-                  alignItems: 'center',
-                  justifyContent: 'center',
-                  gap: 8,
-                  fontFamily: 'var(--cc-font-mono)',
-                  fontSize: 11,
-                  fontWeight: 700,
-                  letterSpacing: 2,
-                  textTransform: 'uppercase',
-                  padding: '13px 22px',
-                  minHeight: 48,
-                  borderRadius: 5,
-                  background: 'linear-gradient(180deg, var(--cc-mint), var(--cc-mint-hi))',
-                  border: '1px solid var(--cc-mint)',
-                  color: 'var(--cc-on-mint)',
-                  boxShadow: 'var(--cc-mint-glow)',
-                  opacity: empty ? 0.4 : 1,
-                }}
-              >
-                <SparkleIcon size={13} />
-                Bring it to life
-              </button>
+              {/*
+                One primary button, whatever it happens to mean here. Showing
+                "save" and "save as new" as equals would make the player decide
+                which is the ordinary one every single time; the ordinary one is
+                whichever matches how the drawing was opened.
+              */}
+              {editingOwn ? (
+                <button
+                  type="button"
+                  className="cc-btn"
+                  onClick={saveChanges}
+                  disabled={empty}
+                  style={primaryButton(empty)}
+                >
+                  <SparkleIcon size={13} />
+                  Save changes
+                </button>
+              ) : editingRoster ? (
+                <button
+                  type="button"
+                  className="cc-btn"
+                  onClick={() => void saveToRoster()}
+                  disabled={empty || saving}
+                  style={primaryButton(empty || saving)}
+                >
+                  <SparkleIcon size={13} />
+                  {saving ? 'Writing…' : 'Save to roster'}
+                </button>
+              ) : (
+                <button
+                  type="button"
+                  className="cc-btn"
+                  onClick={bringToLife}
+                  disabled={empty}
+                  style={primaryButton(empty)}
+                >
+                  <SparkleIcon size={13} />
+                  Bring it to life
+                </button>
+              )}
+
+              {(editingOwn || editingRoster) && (
+                <button
+                  type="button"
+                  className="cc-btn"
+                  onClick={bringToLife}
+                  disabled={empty || saving}
+                  style={{ ...ghostButton, minHeight: 40, opacity: empty || saving ? 0.4 : 1 }}
+                >
+                  Save as a new creature
+                </button>
+              )}
+
+              {editingRoster && (
+                <p style={note}>
+                  Writes over {seed?.name} in the game’s own files. Only you can do this, and only
+                  while the game is running on this computer.
+                </p>
+              )}
 
               <button
                 type="button"
@@ -760,6 +912,7 @@ export function CreatureBuilder({
                 onClick={() => {
                   setDraft(null)
                   setSeed(null)
+                  setEditingId(null)
                   setPast([])
                   setFuture([])
                   setError(null)
@@ -1050,6 +1203,28 @@ const note: React.CSSProperties = {
 const rule: React.CSSProperties = {
   height: 1,
   background: 'var(--cc-panel-divider)',
+}
+
+function primaryButton(dimmed: boolean): React.CSSProperties {
+  return {
+    display: 'inline-flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 8,
+    fontFamily: 'var(--cc-font-mono)',
+    fontSize: 11,
+    fontWeight: 700,
+    letterSpacing: 2,
+    textTransform: 'uppercase',
+    padding: '13px 22px',
+    minHeight: 48,
+    borderRadius: 5,
+    background: 'linear-gradient(180deg, var(--cc-mint), var(--cc-mint-hi))',
+    border: '1px solid var(--cc-mint)',
+    color: 'var(--cc-on-mint)',
+    boxShadow: 'var(--cc-mint-glow)',
+    opacity: dimmed ? 0.4 : 1,
+  }
 }
 
 const ghostButton: React.CSSProperties = {

--- a/src/app/micro-land/domain/blueprint.ts
+++ b/src/app/micro-land/domain/blueprint.ts
@@ -690,3 +690,16 @@ export function bodyBox(bp: CreatureBlueprint): BodyBox {
   bodyBoxCache.set(bp.id, box)
   return box
 }
+
+/**
+ * Forget one creature's collision box, because its art changed under its id.
+ *
+ * Same broken assumption as the sprite cache, with worse consequences. A stale
+ * sprite is a creature that looks wrong; a stale body box is a creature that is
+ * *drawn* at its new size while terrain collision, drowning and spawn-fitting
+ * all still answer for the old one — so a hand-drawn wing gets to overlap solid
+ * rock, and shrinking a creature leaves it wedged in a hole it no longer fills.
+ */
+export function forgetBodyBox(id: string): void {
+  bodyBoxCache.delete(id)
+}

--- a/src/app/micro-land/game-instance.ts
+++ b/src/app/micro-land/game-instance.ts
@@ -25,7 +25,13 @@ import {
   restoreSpeciesRecord,
   updateChronicle,
 } from './chronicle/chronicle'
-import { artSize, bodyBox, reserveSummonIds, sanitizeBlueprint } from './domain/blueprint'
+import {
+  artSize,
+  bodyBox,
+  forgetBodyBox,
+  reserveSummonIds,
+  sanitizeBlueprint,
+} from './domain/blueprint'
 import { MILESTONES, type MilestoneContext } from './domain/config/milestones'
 import { DEFAULT_THEME, THEME_BY_ID, type Theme } from './domain/config/themes'
 import { ELDER_MIN_SECONDS, TICK_S, TILE_TICK_EVERY } from './domain/constants'
@@ -49,6 +55,7 @@ import {
 import { TUNING } from './domain/tuning'
 import { formatDuration } from './format'
 import { Renderer } from './rendering/renderer'
+import { forgetSprites } from './rendering/sprite-cache'
 import { type EarnedMilestone, type PopulationEntry, useMicroLand } from './store'
 import { releaseActiveWorld, touchActiveWorld } from './worlds/shelf'
 import { restoreSnapshot, snapshotWorld } from './worlds/snapshot'
@@ -59,6 +66,9 @@ import type { Creature, CreatureBlueprint, WorldState } from './domain/types'
 
 /** How often the UI gets a fresh population summary. */
 const STATS_EVERY_MS = 300
+
+/** How many to put out when an edited species has nobody left alive to change. */
+const REVISE_PLACE_COUNT = 4
 
 /** Placing creatures by dragging shouldn't fire once per frame. */
 const PLACE_THROTTLE_MS = 130
@@ -917,6 +927,96 @@ export class GameInstance {
     }
     this.pushStats()
     return { blueprint: bp, placed }
+  }
+
+  /**
+   * Change a species that already exists, rather than inventing another one.
+   *
+   * `introduce` was the only door into the roster, and it always mints a fresh
+   * id — so opening a Hopper in the builder, moving four pixels and saving gave
+   * you a *second* Hopper standing next to the first. That is right when the
+   * player wants a variation and wrong when they meant to fix their own
+   * creature, so the two are now separate verbs.
+   *
+   * Keeping the id is the whole point: every creature already alive belongs to
+   * this species, the chronicle's records are filed under it, and the food
+   * chain resolves through it. They all follow the edit for free, because
+   * nothing in the simulation holds a blueprint — it holds an id and looks it
+   * up. What is *not* free is the two caches that assumed art never changes
+   * under an id; both are dropped here, and forgetting either one is invisible
+   * until something is drawn at one size and collides at another.
+   *
+   * Anything alive whose body just grew may find itself overlapping rock. That
+   * needs no repair: `integrate` snaps a downward-moving box out of the tile it
+   * is inside, so gravity walks it back out over the next few ticks, which
+   * reads as the creature shrugging itself loose.
+   *
+   * Returns null if the species is gone — the player can have deleted it from
+   * the toolbar while the builder was open — and otherwise how many individuals
+   * the edit caught, so the caller can tell "every Hopper just changed" from
+   * "there were no Hoppers to change".
+   */
+  reviseSpecies(
+    blueprintId: string,
+    raw: unknown
+  ): { blueprint: CreatureBlueprint; living: number } | null {
+    const existing = this.world.blueprints[blueprintId]
+    if (!existing) return null
+
+    /**
+     * The sanitizer mints an id and we throw it away, exactly as `builtin()`
+     * does. Harmless — the summon counter only ever climbs, so no id it hands
+     * out later can collide with one already in use.
+     *
+     * `summoned` is carried over rather than re-derived. It decides whether the
+     * chronicle archives this creature at all, and a built-in that started
+     * claiming to be summoned would get written into the player's records and
+     * restored on top of the real roster entry on the next load.
+     */
+    const next: CreatureBlueprint = {
+      ...sanitizeBlueprint(raw, { summoned: existing.summoned }),
+      id: blueprintId,
+      summoned: existing.summoned,
+    }
+
+    forgetBodyBox(blueprintId)
+    forgetSprites(blueprintId)
+
+    this.world.dormant = false
+    registerBlueprint(this.world, next)
+
+    // Built-ins are config and are rebuilt from source on every load; writing
+    // one into the archive would shadow it forever with a stale copy.
+    if (next.summoned) rememberSpecies(next, Date.now())
+
+    /**
+     * Put a few out if the edit had nothing to land on.
+     *
+     * Saving is meant to be the moment the change becomes real, and a species
+     * with no individuals alive gives back an empty screen — which reads as the
+     * save having failed rather than as there being nothing to update. The
+     * player can already place them by hand; this only spares them having to
+     * work out that they need to.
+     */
+    let living = this.world.creatures.reduce(
+      (n, c) => (c.blueprintId === blueprintId ? n + 1 : n),
+      0
+    )
+    if (living === 0) {
+      for (let i = 0; i < REVISE_PLACE_COUNT; i++) {
+        if (this.world.creatures.length >= TUNING.maxCreatures) break
+        if (spawnSomewhereSensible(this.world, next, this.rng)) living++
+      }
+    }
+
+    this.syncBlueprintsToStore()
+    this.pushStats()
+    // Straight to storage rather than on the debounce, for the same reason a
+    // deletion is: an edit the player then closes the tab on must not come back
+    // as the drawing they replaced.
+    void flushChronicle()
+
+    return { blueprint: next, living }
   }
 
   getWorld(): WorldState {

--- a/src/app/micro-land/rendering/sprite-cache.ts
+++ b/src/app/micro-land/rendering/sprite-cache.ts
@@ -79,6 +79,18 @@ export function getSprites(bp: CreatureBlueprint): SpriteSet {
   return set
 }
 
+/**
+ * Drop one blueprint's sprites, because its art changed underneath its id.
+ *
+ * The cache assumes an id names a fixed drawing, which held for as long as the
+ * only way to change a creature was to invent a new one. Editing in place
+ * breaks that: without this, a repainted Hopper keeps showing its old colours
+ * for the rest of the session, and the edit looks like it never saved.
+ */
+export function forgetSprites(id: string): void {
+  cache.delete(id)
+}
+
 export function clearSpriteCache(): void {
   cache.clear()
 }

--- a/src/lib/micro-land/__tests__/roster-source.test.ts
+++ b/src/lib/micro-land/__tests__/roster-source.test.ts
@@ -1,0 +1,227 @@
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+
+import { describe, expect, it } from 'vitest'
+
+import { sanitizeBlueprint } from '@/app/micro-land/domain/blueprint'
+import type { CreatureBlueprint } from '@/app/micro-land/domain/types'
+import {
+  ROSTER_PATH,
+  creatureLiteral,
+  printCreatureLiteral,
+  renderCreatureLiteral,
+  rewriteCreature,
+} from '@/lib/micro-land/roster-source'
+
+function blueprint(overrides: Record<string, unknown> = {}): CreatureBlueprint {
+  return sanitizeBlueprint({
+    name: 'Test Beast',
+    blurb: 'A creature for a test.',
+    size: 2,
+    tags: ['meat', 'beast'],
+    art: {
+      palette: { a: '#112233', b: '#445566' },
+      frames: [['.a.', 'aba', '.a.']],
+      frameMs: 200,
+      faceMotion: true,
+    },
+    body: { mass: 1, bounce: 0.1, drag: 0.4, buoyancy: 0.9, immuneTo: [] },
+    move: { kind: 'walk', speed: 5, jump: 10, restlessness: 0.3 },
+    diet: {
+      eats: ['plant'],
+      fears: [],
+      hungerRate: 0.027,
+      starveSeconds: 30,
+      breedAt: 0.78,
+      lifespanSeconds: 240,
+    },
+    senses: { sight: 20 },
+    habitat: { needs: null, drowns: true },
+    dig: { through: [], speed: 1 },
+    death: { becomes: null, particleColor: '#ffd166', particleCount: 6 },
+    aura: null,
+    glow: 0,
+    ...overrides,
+  })
+}
+
+/** The shape of the real file, small enough to read. */
+function source(body: string): string {
+  return [
+    "import { sanitizeBlueprint } from '@/app/micro-land/domain/blueprint'",
+    '',
+    '// A comment above, which must survive.',
+    body,
+    '',
+    'export const BUILTIN_CREATURES = [SUNLEAF, HOPPER]',
+    '',
+  ].join('\n')
+}
+
+describe('creatureLiteral', () => {
+  it('leaves out the fields builtin() supplies', () => {
+    const literal = creatureLiteral(blueprint())
+    expect(literal).not.toHaveProperty('id')
+    expect(literal).not.toHaveProperty('summoned')
+  })
+
+  it('keeps the file’s field order rather than the sanitizer’s', () => {
+    expect(Object.keys(creatureLiteral(blueprint()))).toEqual([
+      'name',
+      'blurb',
+      'size',
+      'tags',
+      'art',
+      'body',
+      'move',
+      'diet',
+      'senses',
+      'habitat',
+      'dig',
+      'death',
+      'aura',
+      'glow',
+    ])
+  })
+
+  it('rounds float noise rather than committing it', () => {
+    const bp = blueprint({
+      body: { mass: 0.1 + 0.2, bounce: 0.1, drag: 0.4, buoyancy: 0.9, immuneTo: [] },
+    })
+    const rewritten = rewriteCreature(
+      source("const HOPPER = builtin('hopper', {})"),
+      'hopper',
+      printCreatureLiteral(bp)
+    )
+    expect(rewritten).toContain('"mass":0.3')
+    expect(rewritten).not.toContain('0.30000000000000004')
+  })
+})
+
+describe('rewriteCreature', () => {
+  it('replaces the literal and leaves the file around it alone', () => {
+    const before = source("const HOPPER = builtin('hopper', { name: 'Hopper' })")
+    const after = rewriteCreature(
+      before,
+      'hopper',
+      printCreatureLiteral(blueprint({ name: 'Bouncer' }))
+    ) as string
+
+    expect(after).toContain('// A comment above, which must survive.')
+    expect(after).toContain('import { sanitizeBlueprint }')
+    expect(after).toContain('export const BUILTIN_CREATURES = [SUNLEAF, HOPPER]')
+    expect(after).toContain("const HOPPER = builtin('hopper', {")
+    expect(after).toContain('"name":"Bouncer"')
+    expect(after).not.toContain("'Hopper'")
+  })
+
+  it('finds the end of a literal containing nested objects', () => {
+    const before = source(
+      "const HOPPER = builtin('hopper', { art: { palette: { a: '#fff' } }, aura: { radius: 3 } })\nconst NEXT = 1"
+    )
+    const after = rewriteCreature(before, 'hopper', printCreatureLiteral(blueprint())) as string
+    expect(after).toContain('const NEXT = 1')
+    expect(after).not.toContain('radius: 3')
+  })
+
+  it('is not fooled by a brace inside a string', () => {
+    const before = source(
+      "const HOPPER = builtin('hopper', { blurb: 'it eats { and } for breakfast' })\nconst NEXT = 1"
+    )
+    const after = rewriteCreature(before, 'hopper', printCreatureLiteral(blueprint())) as string
+    expect(after).toContain('const NEXT = 1')
+    expect(after).not.toContain('for breakfast')
+  })
+
+  it('is not fooled by a brace inside a comment', () => {
+    const before = source(
+      "const HOPPER = builtin('hopper', {\n  // an unmatched } in a note\n  size: 2,\n})\nconst NEXT = 1"
+    )
+    const after = rewriteCreature(before, 'hopper', printCreatureLiteral(blueprint())) as string
+    expect(after).toContain('const NEXT = 1')
+    expect(after).not.toContain('an unmatched')
+  })
+
+  it('refuses a creature that is not in the roster rather than appending one', () => {
+    const before = source("const HOPPER = builtin('hopper', {})")
+    expect(rewriteCreature(before, 'nonesuch', printCreatureLiteral(blueprint()))).toBeNull()
+  })
+
+  it('refuses a literal whose braces never close', () => {
+    const before = "const HOPPER = builtin('hopper', { size: 2"
+    expect(rewriteCreature(before, 'hopper', printCreatureLiteral(blueprint()))).toBeNull()
+  })
+
+  it('locates by id, not by the constant name above it', () => {
+    const before = source("const SOMETHING_ELSE = builtin('hopper', { size: 2 })")
+    const after = rewriteCreature(before, 'hopper', printCreatureLiteral(blueprint())) as string
+    expect(after).toContain("const SOMETHING_ELSE = builtin('hopper', {")
+  })
+})
+
+describe('against the real roster', () => {
+  const file = path.join(process.cwd(), ROSTER_PATH)
+  const real = readFileSync(file, 'utf8')
+
+  /**
+   * The scanner has to survive the file it exists for. The last three carry
+   * hand-written comments *inside* their literal, which is both the hardest
+   * case for brace matching and the thing the rewrite is documented to wipe.
+   */
+  it.each(['sunleaf', 'hopper', 'crystal-snail', 'sunhawk', 'drifter-jelly'])(
+    'rewrites %s without disturbing the rest of the file',
+    id => {
+      const after = rewriteCreature(
+        real,
+        id,
+        printCreatureLiteral(blueprint({ name: 'Rewritten' }))
+      )
+      expect(after).not.toBeNull()
+
+      const text = after as string
+      expect(text).toContain('"name":"Rewritten"')
+      // The roster's own scaffolding is untouched.
+      expect(text).toContain('function builtin(id: string, raw: unknown)')
+      expect(text).toContain('export const BUILTIN_CREATURES')
+      expect(text).toContain('export const BUILTIN_BY_ID')
+      // Every other creature is still declared exactly once.
+      const declarations = text.match(/= builtin\(/g) ?? []
+      expect(declarations).toHaveLength((real.match(/= builtin\(/g) ?? []).length)
+    }
+  )
+
+  it('formats the literal in house style', async () => {
+    const literal = await renderCreatureLiteral(blueprint({ name: 'Rewritten' }), file)
+
+    expect(literal.startsWith('{')).toBe(true)
+    expect(literal.endsWith('}')).toBe(true)
+    // Single quotes, unquoted keys, and indented for where it is going: two
+    // spaces for its own fields, four for a nested object's.
+    expect(literal).toContain("\n  name: 'Rewritten',")
+    expect(literal).toContain('\n  art: {')
+    expect(literal).toContain('\n    frameMs: 200,')
+    expect(literal).not.toContain('"name"')
+  })
+
+  /**
+   * The reason the literal is formatted alone rather than the file after it.
+   *
+   * `creatures.ts` is not prettier-clean — creatures added by hand have drifted
+   * — so running the formatter over the whole file would rewrite creatures
+   * nobody touched and bury the edit. This asserts against the exact drift that
+   * caught it: the Emberwing Elder's palette is one long line prettier would
+   * split, and it has to survive an edit to a different creature untouched.
+   */
+  it('leaves every other creature byte-identical', async () => {
+    const literal = await renderCreatureLiteral(blueprint({ name: 'Rewritten' }), file)
+    const after = rewriteCreature(real, 'sunleaf', literal) as string
+
+    // Everything before the edited literal and after it is the original file.
+    const head = real.indexOf("builtin('sunleaf',")
+    expect(after.slice(0, head)).toBe(real.slice(0, head))
+
+    const tail = real.indexOf("const BRAMBLE = builtin('bramble',")
+    expect(tail).toBeGreaterThan(0)
+    expect(after.slice(after.indexOf("const BRAMBLE = builtin('bramble',"))).toBe(real.slice(tail))
+  })
+})

--- a/src/lib/micro-land/roster-source.ts
+++ b/src/lib/micro-land/roster-source.ts
@@ -1,0 +1,229 @@
+/**
+ * Writing a creature back into the roster's source.
+ *
+ * The starter roster in `domain/config/creatures.ts` is thirty-four object
+ * literals, and the only way to change one has been to hand-edit a wall of
+ * five-character strings and guess at the colours. This turns the drawing tool
+ * into the editor for them: the builder produces exactly the shape those
+ * literals are written in, so an edited creature can be printed straight back
+ * over the one it came from.
+ *
+ * Regenerating the literal wholesale is a deliberate trade. It means every
+ * field the builder can reach — pixels, size, diet, how it moves — lands in the
+ * file, at the cost of wiping any comment written *inside* the literal being
+ * replaced. Three of the thirty-four carry one (the Drifter Jelly's buoyancy
+ * note, the Sunhawk's sight note, the Crystal Snail's amphibian note) and they
+ * are worth re-adding by hand, which the diff makes impossible to miss.
+ *
+ * Everything here is pure string work on source text and is deliberately
+ * separate from the route that calls it, because the fragile part — finding
+ * where one literal ends — is the part worth testing directly.
+ */
+import prettier from 'prettier'
+
+import type { CreatureBlueprint } from '@/app/micro-land/domain/types'
+
+/** The roster file, relative to the repository root. */
+export const ROSTER_PATH = 'src/app/micro-land/domain/config/creatures.ts'
+
+/**
+ * The blueprint as the roster writes it.
+ *
+ * Key order is the file's order rather than the sanitizer's — the two differ
+ * around `senses`/`habitat`/`dig`, and the file's order is the one a human
+ * reads in a diff.
+ *
+ * `id` and `summoned` are deliberately absent. Both are `builtin()`'s to
+ * supply, and printing an id inside the literal would create a second place
+ * where a creature's identity is written down.
+ */
+export function creatureLiteral(bp: CreatureBlueprint): Record<string, unknown> {
+  return {
+    name: bp.name,
+    blurb: bp.blurb,
+    size: bp.size,
+    tags: bp.tags,
+    art: {
+      palette: bp.art.palette,
+      frames: bp.art.frames,
+      frameMs: bp.art.frameMs,
+      faceMotion: bp.art.faceMotion,
+    },
+    body: {
+      mass: bp.body.mass,
+      bounce: bp.body.bounce,
+      drag: bp.body.drag,
+      buoyancy: bp.body.buoyancy,
+      immuneTo: bp.body.immuneTo,
+    },
+    move: {
+      kind: bp.move.kind,
+      speed: bp.move.speed,
+      jump: bp.move.jump,
+      restlessness: bp.move.restlessness,
+    },
+    diet: {
+      eats: bp.diet.eats,
+      fears: bp.diet.fears,
+      hungerRate: bp.diet.hungerRate,
+      starveSeconds: bp.diet.starveSeconds,
+      breedAt: bp.diet.breedAt,
+      lifespanSeconds: bp.diet.lifespanSeconds,
+    },
+    senses: { sight: bp.senses.sight },
+    habitat: { needs: bp.habitat.needs, drowns: bp.habitat.drowns },
+    dig: { through: bp.dig.through, speed: bp.dig.speed },
+    death: {
+      becomes: bp.death.becomes,
+      particleColor: bp.death.particleColor,
+      particleCount: bp.death.particleCount,
+    },
+    aura: bp.aura,
+    glow: bp.glow,
+  }
+}
+
+/**
+ * Print the literal as source.
+ *
+ * JSON is a subset of the object syntax TypeScript wants here, so the output
+ * only needs to be *valid* — prettier turns it into house style afterwards,
+ * unquoting the keys and swapping the quotes using the project's own config.
+ * Hand-rolling the formatting instead would mean maintaining a second opinion
+ * about how this repo indents.
+ *
+ * Floats are rounded on the way out. Every number the builder produces has come
+ * through a clamp and arithmetic, and a `0.30000000000000004` committed to the
+ * roster is noise that survives forever.
+ */
+export function printCreatureLiteral(bp: CreatureBlueprint): string {
+  return JSON.stringify(creatureLiteral(bp), (_key, value) =>
+    typeof value === 'number' && !Number.isInteger(value)
+      ? Number(value.toFixed(5))
+      : (value as unknown)
+  )
+}
+
+/**
+ * The literal as house-style source, formatted on its own.
+ *
+ * Formatting the whole file after splicing would be one line shorter and was
+ * wrong: `creatures.ts` is not prettier-clean today — creatures added by hand
+ * have drifted — so every save would sweep unrelated reformatting of other
+ * creatures into the diff, and the one thing this tool has to be is a diff you
+ * can read.
+ *
+ * The trick is the wrapper. Prettier needs a whole statement to parse, and
+ * `builtin(...)` at the top level is exactly where the literal is going to sit,
+ * so what comes back is already indented for its destination. Formatting the
+ * bare object instead would produce a correct literal indented for column zero.
+ */
+export async function renderCreatureLiteral(
+  bp: CreatureBlueprint,
+  configPath: string
+): Promise<string> {
+  const options = await prettier.resolveConfig(configPath)
+  const wrapped = await prettier.format(`const _ = builtin('x', ${printCreatureLiteral(bp)})`, {
+    ...options,
+    filepath: configPath,
+    parser: 'typescript',
+  })
+
+  const open = wrapped.indexOf('{')
+  const close = matchBrace(wrapped, open)
+  // Prettier just produced this, so both are always found. Falling back to the
+  // unformatted literal is still better than writing a truncated one.
+  if (open < 0 || close < 0) return printCreatureLiteral(bp)
+  return wrapped.slice(open, close + 1)
+}
+
+/**
+ * Walk forward to the `}` that closes the `{` at `open`.
+ *
+ * A plain brace counter is wrong here and would stay wrong quietly: a blurb is
+ * free-text and a frame row is arbitrary characters, so a single `{` inside a
+ * string would throw the count off and the splice would eat the rest of the
+ * file. Strings and comments are skipped rather than counted.
+ *
+ * Returns -1 if the brace never closes, which means the file is not what we
+ * think it is and nothing should be written.
+ */
+function matchBrace(source: string, open: number): number {
+  let depth = 0
+
+  for (let i = open; i < source.length; i++) {
+    const ch = source[i]
+
+    if (ch === "'" || ch === '"' || ch === '`') {
+      i = skipString(source, i)
+      if (i < 0) return -1
+      continue
+    }
+
+    if (ch === '/' && source[i + 1] === '/') {
+      const end = source.indexOf('\n', i)
+      if (end < 0) return -1
+      i = end
+      continue
+    }
+
+    if (ch === '/' && source[i + 1] === '*') {
+      const end = source.indexOf('*/', i + 2)
+      if (end < 0) return -1
+      i = end + 1
+      continue
+    }
+
+    if (ch === '{') depth++
+    else if (ch === '}' && --depth === 0) return i
+  }
+
+  return -1
+}
+
+/** Index of the quote that closes the string opening at `start`. -1 if unterminated. */
+function skipString(source: string, start: number): number {
+  const quote = source[start]
+  for (let i = start + 1; i < source.length; i++) {
+    if (source[i] === '\\') {
+      i++
+      continue
+    }
+    if (source[i] === quote) return i
+    // Only template literals are allowed to span lines; anything else running
+    // past the end of its line means the scan has lost its place.
+    if (source[i] === '\n' && quote !== '`') return -1
+  }
+  return -1
+}
+
+/**
+ * Replace one creature's literal in the roster source, leaving the file alone.
+ *
+ * Located by its `builtin('<id>', {` call rather than by the constant's name,
+ * because the id is the thing the game actually knows a creature by — the
+ * `const SUNLEAF` above it is just a local handle, and renaming a creature is
+ * expected to leave both of them untouched.
+ *
+ * Returns null when there is no such creature, which the caller should treat as
+ * a refusal rather than as permission to append one. This tool edits the roster
+ * and does not grow it: a new species also needs a place in the documented food
+ * chain at the top of that file and a share of the per-species population caps,
+ * neither of which can be inferred from a drawing.
+ *
+ * Takes the literal as text, already formatted, rather than a blueprint — so
+ * that the only edit made to the file is this splice.
+ */
+export function rewriteCreature(source: string, id: string, literal: string): string | null {
+  const call = `builtin('${id}',`
+  const at = source.indexOf(call)
+  if (at < 0) return null
+
+  const open = source.indexOf('{', at + call.length)
+  if (open < 0) return null
+
+  const close = matchBrace(source, open)
+  if (close < 0) return null
+
+  return source.slice(0, open) + literal + source.slice(close + 1)
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -19,6 +19,7 @@ export default defineConfig({
       'src/lib/trivia/**/*.test.ts',
       'src/app/trivia/**/*.test.ts',
       'src/app/micro-land/**/*.test.ts',
+      'src/lib/micro-land/**/*.test.ts',
     ],
     coverage: {
       reporter: ['text', 'json', 'html'],


### PR DESCRIPTION
One commit on top of main, nine files. `feat/micro-land` and #2711 landed while this was in progress, so everything this depends on is already on main.

## The problem

The drawing panel could already open any creature, but saving always minted a new species. Open your own dragon, move four pixels, save — now you have two dragons.

## What changed

`GameInstance.reviseSpecies` keeps the blueprint id. That's the whole trick: everything already alive belongs to the species *by id*, the chronicle files its records under it, and the food chain resolves through it — so they all follow the edit for free. Nothing in the simulation holds a blueprint; it holds an id and looks it up.

What does **not** follow for free is the two caches that assumed art never changes under an id. Both are dropped on edit. Forgetting the sprite cache gives a creature that keeps its old colours. Forgetting `bodyBoxCache` is worse and quieter — the creature is drawn at its new size while terrain collision, drowning and spawn-fitting still answer for the old one.

Who may edit what follows from whose creature it is:

| Opened creature | Deployed build | Local dev |
|---|---|---|
| Yours (drawn or generated) | **Save changes** + Save as new | same |
| A starter creature | Save as new only | **Save to roster** + Save as new |

A creature the player made is theirs — edited in place, written to their archive immediately rather than on the 4s debounce, because an edit they then close the tab on must not come back as the old drawing.

A starter creature is everybody's. On a deployed build it can only be branched from; an edit would live in one browser and disagree with the game every other player is running.

## The dev-only roster route

On the machine holding the repo, a starter creature is edited properly — by rewriting `domain/config/creatures.ts`.

Gated on `NODE_ENV`, which is fixed at build time, so it's dead code in the deployed bundle rather than a live endpoint behind a check (and there's no writable checkout on the host anyway). It rewrites one `builtin('<id>', {...})` literal in place and **refuses an id it can't find rather than appending one** — a new species also needs a place in that file's documented food chain and a share of the per-species population caps, and neither can be inferred from a drawing.

The literal is formatted *alone*, wrapped in a throwaway `builtin()` call so prettier indents it for its destination. Formatting the whole file after splicing was the first attempt and was wrong: `creatures.ts` isn't prettier-clean, so every save reformatted unrelated creatures and buried the edit in a 66-line diff. A test asserts the file is byte-identical either side of the splice.

Editing Sunleaf's top pixel and its drag produces exactly this:

```diff
-    palette: { s: '#3f7d2a', l: '#7ede4f' },
+    palette: { s: '#3f7d2a', l: '#7ede4f', f: '#ffd166' },
-      ['..l..', '.lsl.', '..s..', '.ls..', '..s..'],
+      ['..f..', '.lsl.', '..s..', '.ls..', '..s..'],
-  body: { mass: 1, bounce: 0, drag: 0.2, buoyancy: 0.6, immuneTo: [] },
+  body: { mass: 1, bounce: 0, drag: 0.3, buoyancy: 0.6, immuneTo: [] },
-    starveSeconds: 999,
+    starveSeconds: 300,
```

## Two things worth knowing

**Saving a built-in normalizes it.** That last hunk is untouched by the edit — `starveSeconds: 999` becomes `300` because that's the clamp the game has always applied at load. The source said something the game never ran; now it says the truth. Expect a few of these the first time each creature is saved.

**Regenerating the whole literal wipes any comment written inside it.** Three of the thirty-four carry one (Drifter Jelly's buoyancy note, Sunhawk's sight note, Crystal Snail's amphibian note). The diff makes that impossible to miss, and they're worth re-adding by hand.

## Verified

- 130 micro-land tests pass, 17 new — brace-matching against braces inside strings and comments, and against the real roster file
- Typecheck and lint clean for micro-land
- `npm run sim:micro-land --theme earth --seconds 600 --runs 3` — `✓ Still alive`, low-water 554, nothing extinct in every run
- End-to-end against a dev server on this exact tree: POST → file rewritten to the diff above → still compiles → `/micro-land` returns 200

**Not verified:** I didn't click through the UI in a browser. The builder's button logic is covered by typecheck and reading only — worth a manual pass on opening your own creature vs. a starter, and the "Save as a new creature" secondary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)