### PR TITLE
feat(micro-land): worlds you can keep, and records that follow you

### DIFF
--- a/.claude/skills/micro-land/SKILL.md
+++ b/.claude/skills/micro-land/SKILL.md
@@ -1,0 +1,235 @@
+---
+name: micro-land
+description: Working on Micro Land (src/app/micro-land) — the pixel-physics terrarium at /micro-land. Load before changing its simulation, creatures, materials, themes, renderer, summoning route, chronicle, or UI. Covers the premise a creature is data, the invariants that keep summoned creatures working, the headless ecosystem harness that is the real test, and the hazards that make a change look fine and quietly starve the world.
+---
+
+# Micro Land — Skill Document
+
+## What this covers
+
+Micro Land is a 2D falling-sand terrarium at `/micro-land`. The player paints
+terrain, drops creatures into it, watches a food chain run, and invents new
+creatures either by describing them to a model or by drawing them pixel by
+pixel. Everything lives under `src/app/micro-land`, plus one API route
+(`src/app/api/v1/micro-land/summon`), one persistence route
+(`.../micro-land/chronicle`), and one headless harness
+(`scripts/micro-land-sim.ts`).
+
+Read `references/architecture.md` for the file map, tick order and data flow.
+Read `references/extending.md` for step-by-step recipes (new material, new
+creature, new theme, new milestone, balance pass).
+
+## Whose game this is
+
+Micro Land's product direction belongs to Nick's young daughter, not to the
+codebase and not to you. She chose the empty-by-default world, the theme picker,
+the food chain as the thing that makes creatures feel alive, and summoning that
+works for one creature *or* a whole scene. She named it.
+
+When a change is a design decision rather than a repair, offer real options back
+rather than picking one: plain language, but each option must change what
+actually gets built and say what the consequence is. Toy-level choices ("bouncy
+blobs") get rejected; "cross-section of the earth vs. orbital station vs.
+tidepool" is the right altitude. Preserve the food-chain-first framing and the
+empty starting world unless she changes her mind.
+
+## The game in one paragraph
+
+A world of 672×132 tiles, each one a material from a fixed table, simulated as
+falling sand at 20 Hz while creatures move over it at 60 Hz. Every creature is a
+plain object literal — pixels, physics, appetite, lifespan — and *nothing* about
+a creature is code, which is what lets a model invent one at runtime and drop it
+into a running world. The food chain is a single rule: you can eat something if
+you list one of its tags and it isn't bigger than you. Populations rise, crash,
+and are pulled back from zero by two safety nets (the ground's plant seed bank,
+and animal seed rain). Records — longest life, deepest bloodline, longest run
+with no extinction — persist in a "chronicle" that works with no account and
+merges into one when the player signs in. A world the player wants to come back
+to can also be kept by name on a "shelf" and reopened mid-simulation.
+
+## Invariants
+
+1. **A creature is data, not code.** There is no per-species branching anywhere
+   in the simulation. Every decision reads the blueprint. Built-in creatures in
+   `domain/config/creatures.ts` are written as raw object literals and pushed
+   through the *same* `sanitizeBlueprint` a summoned one goes through — there is
+   no "built-in creature" code path. If you find yourself writing
+   `if (bp.id === 'hopper')`, the feature belongs in the blueprint schema
+   instead.
+
+2. **Sanitizers never throw.** `sanitizeBlueprint` and `sanitizeTerrain` assume
+   hostile input — wrong types, ragged pixel rows, 400 frames, colors that
+   aren't colors — and every field falls back to something playable. A failed
+   summon returns a procedural creature, never an error toast. A kid who asks
+   for a purple fire snail always gets a purple fire snail.
+
+3. **Material order is load-bearing.** The index into `MATERIAL_IDS` is what's
+   stored in the tile grid. `air` must stay at 0 (a zeroed `Uint8Array` is an
+   empty world). Appending is safe; reordering is not. Tint variants are
+   generated *after* the base list so adding a color can never shift an existing
+   index. The grid is `Uint8Array`, so the whole table is capped at 256 entries
+   (currently 26 base + 36 tints = 62).
+
+4. **The world is not in React.** `GameInstance` owns a mutable `WorldState`
+   ticked 60×/second; the Zustand store gets a small summary pushed every 300 ms
+   (`STATS_EVERY_MS`). Never put creatures, tiles or particles into store state.
+   UI reads snapshots; the game reads `useMicroLand.getState()` imperatively.
+
+5. **Counts are densities in disguise.** Anything tuned by eye against one
+   screen of land — population caps, theme starters, ponds, geodes, lava falls,
+   the plant seed bank — is multiplied by `WIDTH_SCALE` (`WORLD_W / VIEW_W`, so
+   3). A new count written as a bare number does not spread out in a
+   three-screen world, it thins out.
+
+6. **`mealValue` must stay below `breedCost`.** If one meal more than pays for
+   a child, grazers breed on every full stomach, overshoot the plants, and take
+   the entire food chain down with them. Currently 0.42 vs 0.55. Both are
+   sliders now, so this is enforced in `tuning.ts` rather than only believed —
+   `enforceInvariants` holds the meal a fixed margin under the cost whichever of
+   the two was dragged.
+
+7. **Plants have no upstream, so the ground carries their seed.** Plants only
+   come from plants, so a grazer boom that strips the last one is terminal.
+   `seedNativePlants` makes the *soil* push the plant population back toward
+   `NATIVE_PLANT_TARGET`, harder the further below it the world falls. It is
+   deliberately blind to whether anything is alive; the animal `repopulate` is
+   not, and only ever returns a species that has something to eat.
+
+8. **Empty means empty.** `world.dormant` is set when the player clears the
+   world and suppresses both safety nets. Anything generative — painting,
+   placing, summoning, changing theme — clears it again.
+
+9. **Sprite size is not collision size.** `artSize(bp)` is what the creature
+   looks like (sight, biting, drawing); `bodyBox(bp)` is what it collides with.
+   They're identical up to 12×10, above which extra drawing is only 40% solid so
+   a dragon's wingtips don't wedge it in a cave. Terrain collision, drowning and
+   spawn-fitting all use the core; anything the player can see uses the sprite.
+
+10. **The camera only ever sits on whole tiles.** The renderer draws one canvas
+    pixel per world tile into a backbuffer and blows it up with smoothing off.
+    A fractional camera would resample every tile onto a half-pixel and undo the
+    one thing the renderer exists to protect. `camX` is kept fractional so slow
+    pans accumulate, but `viewLeft()` floors it before anything is drawn.
+
+11. **Records are high-water marks.** That is why the chronicle can be sampled a
+    few times a second instead of per frame, why `mergeChronicles` needs no
+    conflict resolution, and why banking a streak early is safe. Keep any new
+    record monotonic.
+
+12. **Anonymous-first (CLAUDE.md #1).** The game starts on `localBackend` and
+    never waits for the network. Auth resolving later calls `adoptAccount`,
+    which merges rather than choosing. A player with no account and no
+    connection still gets a complete game.
+
+13. **The ecosystem numbers are read off `TUNING`, not off `constants.ts`.**
+    Plant seeding, population caps, breeding costs and gravity live in
+    `domain/tuning.ts` as a mutable object the settings panel moves while the
+    world runs; `constants.ts` holds their defaults and the reasoning for them.
+    Importing one of those constants into simulation code compiles fine and
+    silently makes that slider do nothing. Adding a knob means adding it to
+    `TUNING_DEFAULTS` *and* `KNOBS` — the test asserts those two agree.
+
+## Verifying a change
+
+Run these in order. The third one is the one that actually catches ecosystem
+regressions, and a browser cannot substitute for it.
+
+1. `npm run typecheck`
+2. `npm test` — vitest; covers `creature-kit`, `chronicle`, `wire`, `tuning` and
+   the world-save `snapshot`/`wire` pair.
+3. `npm run sim:micro-land -- --theme earth --seconds 600 --runs 5`
+   Repeat for `tidepool`, `volcanic`, `station`. This runs the real simulation
+   headless and prints population over time, causes of death, and what ate what.
+   Look for:
+   - `✓ Still alive` at the end of every theme.
+   - No species marked `EXTINCT in every run`.
+   - A low-water mark well above zero — an oscillation, not a flatline.
+   - Deaths attributed sensibly (`starved` dominating a grazer means the plants
+     lost; `burned` dominating means the terrain is hostile).
+   - `world still solid` not collapsing — diggers should tunnel, not delete.
+4. `npm run lint`
+5. In the browser at `/micro-land`: paint, place, drag-throw a creature, summon
+   one creature and one scene, pan with each input (arrows, minimap, wheel, two
+   fingers, one finger in Look mode), open the field guide.
+
+For balance work, compare the harness output *before and after* on the same
+seeds — `runOnce` seeds from `1000 + i * 7919`, so runs are comparable across
+branches. `--set knob=value` moves the same knobs the settings panel does, so a
+number found by dragging a slider can be run through the ten-minute check
+before it becomes a default:
+
+```
+npm run sim:micro-land -- --theme earth --seconds 600 --runs 3 --set plantSpeciesCap=50
+```
+
+## Known hazards
+
+- **The harness is only mostly deterministic.** `makeRng` is seeded and
+  `tile-sim` uses a coordinate hash rather than an RNG, but `emitParticles`,
+  `spawnCreature`'s animation phase, and `applyThemeObject`'s default seed all
+  call `Math.random()`. Don't write tick-exact assertions; do use `--runs N` and
+  read averages.
+
+- **Module-level simulation state.** `creature-sim.ts` keeps `tickCount` and the
+  `byX` sort buffer at module scope, and `blueprint.ts` keeps `summonCounter`
+  and `bodyBoxCache`. Two worlds in one process share all of them. Fine today
+  (one world per page, one per harness run) but it is why `bodyBox` must never
+  be asked about a blueprint whose art was mutated in place under the same id.
+
+- **Built-in creatures are silently clamped.** `builtin()` runs the literal
+  through `sanitizeBlueprint`, so a value outside the schema's clamp range in
+  `creatures.ts` does not error — it changes. If a tuning edit appears to do
+  nothing, check the clamp in `sanitizeBlueprint`.
+
+- **The `settleOnGround` arithmetic.** The tile below a box at `y` with height
+  `bh` is `floor(y + bh - 0.001) + 1`, **not** `floor(y + bh)`. The naive
+  version asks about a row the box is already standing in, which collision has
+  just proven empty, so the check silently never passes and nothing that walks
+  or roots can be placed. Never hand-roll this; call `settleOnGround`.
+
+- **Per-species caps are shared budgets.** `MAX_PLANTS` is split across every
+  plant species, so *adding a plant to the roster takes its share out of every
+  other plant*. The roster grew to seven and the grazers started starving; that
+  is what `MAX_PLANTS` 150→195 and `PLANT_SPECIES_CAP` 55→46 were fixing.
+
+- **A world can look beautiful and starve.** Terrain with no fertile material
+  (`dirt, grass, sand, ash, wood, snow, mud, moss, bone`) supports no plants, so
+  nothing eats and everything dies. `hasFertileGround` is checked on summoned
+  terrain for exactly this reason; the summon prompt derives its fertile list
+  off the material table so a new fertile material updates the prompt for free.
+
+- **`aura.converts` from `air` would let a creature wall the world in.** The
+  sanitizer rejects it, along with converting a material into itself. Keep that
+  guard if you touch `cleanAura`.
+
+- **Acid spends itself on each bite.** That is the only reason it is safe to
+  ship — a puddle can dissolve as many tiles as it has drops and then it's gone.
+  Making acid persistent would quietly erase the world while nobody watched.
+
+- **Tint variants inherit every physical property.** Painting must never change
+  how a tile behaves; `plastic-red` is `plastic` with a different color and a
+  `tintOf` back-reference. Don't give a tint its own physics.
+
+- **The summon route calls the Messages API directly on purpose.** The AI SDK's
+  `generateObject` hard-codes `temperature: 0`, which Opus 5 rejects outright.
+  Moving it back to the SDK can only work by downgrading the model.
+
+- **Chronicle persistence fails silently by design.** Every error in
+  `accountBackend` is swallowed, so a missing rules/index deploy, an expired
+  token or a dropped connection looks exactly like a working game that quietly
+  stops saving. After touching storage, confirm the write actually landed in
+  Firestore rather than trusting the absence of an error. `firestore.rules` and
+  the `microLand.blob` / `microLandWorlds.blob` index exemptions all need
+  deploying (`firebase deploy --only firestore:rules,firestore:indexes`).
+
+## House style
+
+Prettier: no semicolons, single quotes, 2-space, 100 cols, `arrowParens: avoid`.
+ESLint enforces grouped + alphabetized imports and `@/…` aliases over `../…`.
+
+Comments in this codebase explain *why*, at length, and are load-bearing
+documentation — several of them are the only record of a bug that took a day to
+find. Match that register: when you change a tuned number, update the comment
+that justifies it. Commit messages follow the same standard —
+`feat(micro-land): <lowercase phrase>` with a body that explains the reasoning,
+not the diff.

--- a/.claude/skills/micro-land/references/architecture.md
+++ b/.claude/skills/micro-land/references/architecture.md
@@ -1,0 +1,403 @@
+# Micro Land — Architecture Reference
+
+All paths relative to `src/app/micro-land/` unless noted. LOC approximate.
+
+## File map
+
+### Entry / React shell
+| File | ~LOC | Role |
+|------|------|------|
+| `page.tsx` | 28 | Route entry. Takes over the viewport (`fixed inset-0 z-40`) inside `CosmicShell`, which supplies the cave exit ✕. |
+| `layout.tsx` | 10 | Route layout |
+| `MicroLandGame.tsx` | 163 | Mounts the canvas, loads the chronicle *before* building the instance, subscribes theme changes, wires UI callbacks. A second effect calls `adoptAccount` when auth resolves — keyed on `user.uid`, not the user object, which is replaced on every token refresh |
+| `store.ts` | 300 | Zustand: tool, brush, pause/speed, population summary, records, archive, notices, panel flags, tuning mirror |
+| `format.ts` | 23 | `formatDuration` |
+
+### Core loop
+| File | ~LOC | Role |
+|------|------|------|
+| `game-instance.ts` | 1143 | Owns `WorldState`, the RAF loop, the pointer, the camera, records, and every command the UI can issue |
+
+### Simulation (`domain/sim/`)
+| File | ~LOC | Role |
+|------|------|------|
+| `world.ts` | 685 | World construction, tile access helpers, spawning, native plants, seed rain |
+| `creature-sim.ts` | 931 | Hunger, senses, steering, physics, digging, breeding, death, particles |
+| `tile-sim.ts` | 293 | Falling sand: powders, liquids, quenching, melting, corrosion |
+| `prng.ts` | 78 | Seeded RNG, value noise, fbm |
+
+### Domain
+| File | ~LOC | Role |
+|------|------|------|
+| `types.ts` | 390 | Every shared type. Read this first — the blueprint interface is the contract the whole game turns on |
+| `blueprint.ts` | 712 | Zod schema (doubles as the model's tool schema), sanitizer, `canEat`, `artSize`, `bodyBox`, creature grouping |
+| `constants.ts` | 210 | All tuning. Heavily commented; the comments are the reasoning |
+| `tuning.ts` | 310 | The ecosystem subset of those constants as a mutable `TUNING` object, plus the knob table the settings panel and `--set` both read |
+| `terrain.ts` | 327 | Promptable terrain: schema, sanitizer, ground-level fitting, map→tiles painter |
+| `creature-kit.ts` | 663 | The hand-drawing kit: `Draft`, flood fill, trim, `draftToArt`, body plans, `buildRawCreature` |
+| `procedural.ts` | 298 | Offline fallback creature/scene when the model is unavailable |
+
+### Config (`domain/config/`)
+| File | ~LOC | Role |
+|------|------|------|
+| `creatures.ts` | 1420 | The 34 built-in blueprints, as raw literals |
+| `themes.ts` | 511 | Five worlds: `empty`, `earth`, `station`, `tidepool`, `volcanic`. Default is `empty` |
+| `materials.ts` | 321 | 26 base materials + 36 tints, flag lookup tables |
+| `milestones.ts` | 105 | Eleven once-ever milestones and the context they read |
+| `loader-shapes.ts` | 145 | Pixel shapes for the summon loading animation |
+
+### Rendering
+| File | ~LOC | Role |
+|------|------|------|
+| `rendering/renderer.ts` | 726 | Backbuffer compositing, light field, shadow, camera, minimap |
+| `rendering/sprite-cache.ts` | 84 | Blueprint art → offscreen canvases, plus flipped copies |
+
+### Records (`chronicle/`)
+| File | ~LOC | Role |
+|------|------|------|
+| `chronicle.ts` | 340 | In-memory chronicle, debounced writes, land ids, species archive, `mergeChronicles`, `adoptAccount` |
+| `backend.ts` | 139 | `localBackend`, `nullBackend`, `accountBackend` behind one async interface |
+| `wire.ts` | 131 | Validate/decode/`fitChronicle` size trimming, shared by the browser and the route |
+| `types.ts` | 101 | `ChronicleData`, `LandRecord`, `SpeciesRecord`, `ElderRecord` |
+
+### Components (`components/`)
+| File | ~LOC | Role |
+|------|------|------|
+| `toolbar.tsx` | 486 | Material palette + tint strip, brush sizes, creature drawers, summon/draw entry points |
+| `hud.tsx` | 210 | Theme picker, pause, speed, population, steady streak, field guide button, settings button |
+| `summon-panel.tsx` | 484 | The describe-it flow for creature / scene / terrain |
+| `summon-loader.tsx` | 456 | The wait, made watchable |
+| `summon-sand.tsx` | 191 | Sand animation for pending summons |
+| `creature-builder.tsx` | 1070 | The pixel drawing panel |
+| `pixel-canvas.tsx` | 327 | The drawing surface itself |
+| `field-guide.tsx` | 416 | Archive, records, milestones |
+| `settings-panel.tsx` | 230 | The live tuning drawer |
+| `inspector.tsx` | 359 | Live read-out of one creature; naming the elder |
+| `creature-chip.tsx` | 78 | Sprite portrait |
+| `pan-controls.tsx` | 108 | Edge arrow buttons |
+| `notices.tsx` | 46 | Toast strip |
+| `sparkle-icon.tsx` | 24 | Marks the AI-assisted entry points |
+
+### Outside the game directory
+| Path | Role |
+|------|------|
+| `src/app/api/v1/micro-land/summon/route.ts` | Creature / scene / terrain generation |
+| `src/app/api/v1/micro-land/chronicle/route.ts` | Account-backed record storage (GET/PUT, uid from the verified token) |
+| `src/lib/micro-land/chronicle-store.ts` | Server-side chronicle persistence |
+| `firestore.rules` | `users/{uid}/microLand/{docId}` — closed to clients like everything else |
+| `firestore.indexes.json` | `fieldOverrides` entry disabling indexing on `microLand.blob` |
+| `scripts/micro-land-sim.ts` | Headless ecosystem harness (`npm run sim:micro-land`) |
+| `src/app/micro-land/domain/__tests__/creature-kit.test.ts` | Drawing kit tests |
+| `src/app/micro-land/chronicle/__tests__/chronicle.test.ts` | Record/merge/`adoptAccount` tests |
+| `src/app/micro-land/chronicle/__tests__/wire.test.ts` | Validation and size-trimming tests |
+
+---
+
+## Frame pipeline
+
+`GameInstance.frame(now)` per animation frame:
+
+1. Read store state; resolve the theme (summoned terrain wins over the registry
+   when `themeId === 'summoned'`).
+2. Clamp delta to `MAX_CATCHUP_MS` (250) — a backgrounded tab hands back a huge
+   delta and simulating all of it is a freeze.
+3. If not paused: accumulate `delta * speed`, run up to 8 fixed steps of
+   `TICK_S` (1/60 s), collecting `SimEvent[]`.
+4. `digestEvents` — turn raw events into occasional human notices.
+5. Every `STATS_EVERY_MS` (300): `pushStats` → population summary → store,
+   `updateRecords`, `pushInspected`.
+6. `updateCamera(delta/1000)` — held keys/buttons, edge-scroll while carrying a
+   creature, follow the inspected creature. Runs off wall-clock, not the sim
+   clock, so the camera answers the same whether paused or fast-forwarded.
+7. `renderer.render(world, theme, inspectedId, elderId)`.
+
+### One simulation step (`GameInstance.step`)
+
+1. `world.elapsed += TICK_S`
+2. Every `TILE_TICK_EVERY` (3) ticks: `tickTiles(world)` then
+   `renderer.markTilesDirty()`. So tiles run at 20 Hz — 60 Hz reads as frantic.
+3. `tickCreatures(world, TICK_S, rng, theme.gravity, events)`
+
+### `tickCreatures` internals
+
+Per tick, before the loop: count plants, count per species, gather aura holders,
+rebuild and sort the `byX` array (nearly-sorted every tick, which is sort's best
+case). Then per creature:
+
+1. Age, animation clock, breed cooldown
+2. Hunger → starving timer → `kill('starved')`
+3. Old age → `kill('aged')`
+4. Environment: deadly material (→ `burned` unless immune), habitat `needs`
+   unmet or drowning (→ one shared `distress` timer → `drowned` at
+   `BREATH_SECONDS`)
+5. Senses, every `SENSE_EVERY` (6) ticks, staggered by creature id. Walks only
+   the x-sorted slice within `sight + SIGHT_PAD`. Bodies overlapping → eat now
+   (`BITE_PAD`), else pick nearest threat or prey and set mood
+6. `steer` (per locomotion kind), then `integrate` (gravity, buoyancy,
+   viscosity, drag, horizontal move with step-up or dig, vertical move,
+   friction, clamp to world)
+7. `applyConversion` if the blueprint has `aura.converts`
+8. Breeding, gated on cooldown / fullness / maturity / `MAX_CREATURES` /
+   `MAX_PLANTS` / per-species cap. Plants pay no hunger cost (they
+   photosynthesise; charging them would sterilise them permanently)
+
+After the loop: filter the dead, `seedNativePlants` (plants first — everything
+is downstream of them), `repopulate`, `tickParticles`.
+
+### `tickTiles`
+
+One bottom-up pass. `moved` bitmask stops a tile falling twice in a pass. Scan
+direction alternates by `flowPhase` or liquids drift left forever. Lava moves
+every other pass; sap every eighth. Order per tile: melt check → quench (lava
+touching water → obsidian) → corrode (acid, spends itself) → powder step or
+liquid step. Liquids reach `FLOW_REACH` (4) sideways looking for a way down.
+
+---
+
+## The blueprint contract
+
+`CreatureBlueprint` is the whole entity model. Groups:
+
+| Field | What it drives |
+|-------|----------------|
+| `size` 1–6 | Food chain position — nothing eats anything bigger than itself |
+| `tags` | What it *is*. Exactly one structural tag (`plant`/`meat`/`mineral`) plus flavour |
+| `art` | `palette` (single char → hex), `frames` (rows of palette keys, `.` transparent), `frameMs`, `faceMotion` |
+| `body` | `mass`, `bounce`, `drag`, `buoyancy`, `immuneTo[]` |
+| `move` | `kind` (walk/fly/swim/crawl/drift/root), `speed`, `jump`, `restlessness` |
+| `diet` | `eats[]`, `fears[]`, `hungerRate`, `starveSeconds`, `breedAt`, `lifespanSeconds` |
+| `senses` | `sight` in tiles |
+| `habitat` | `needs[]` (hurt anywhere not touching one of these), `drowns` |
+| `dig` | `through[]` materials, `speed` tiles/sec |
+| `death` | `becomes` material, `particleColor`, `particleCount` |
+| `aura` | `radius`, `helps[]` tags, `boost`, `converts {from,to}`, `convertRate` — or null |
+| `glow` | Light cast, 0–1 |
+
+**The entire food chain** is `canEat(hunter, prey)`: not itself, prey not
+larger, and `hunter.diet.eats` intersects `prey.tags`. `fears(prey, hunter)` is
+that plus explicit `diet.fears` tags. Every relationship in the world — including
+between a built-in and something invented five seconds ago — falls out of these
+two functions.
+
+Art bounds: `ART_MIN` 3, `ART_MAX_W` 28, `ART_MAX_H` 24, `MAX_FRAMES` 4,
+`MAX_PALETTE` 12. Core-vs-sprite thresholds: `CORE_W` 12, `CORE_H` 10,
+`CORE_SLOPE` 0.4 — set above the largest pre-existing built-in (Grumblestone,
+10×7) so nothing that shipped before big creatures changed behaviour.
+
+---
+
+## Materials
+
+26 base materials, each written as a diff against a boring-rock `DEFAULTS`.
+Flags: `solid`, `liquid`, `powder`, `deadly`, `glow`, `fertile`, `viscous`,
+`breathable`, `melts`, `corrosive`, `acidProof`, `tintable`, `tintOf`.
+
+Four are tintable (`plastic`, `crystal`, `gem`, `cloud`) × 9 tints = 36
+generated variants appended after the base list. A tint is a real tile id
+(`crystal-blue`) that inherits every physical property; only the color differs.
+
+Hot-path lookups are precomputed `Uint8Array`s indexed identically to the tile
+grid: `IS_SOLID`, `IS_LIQUID`, `IS_POWDER`, `IS_DEADLY`, `IS_FERTILE`,
+`IS_DROWNING` (liquid and not breathable — sap holds you but you can breathe),
+`IS_ACID_PROOF`, `VISCOSITY` (0–255).
+
+`PAINTABLE` is palette order for the toolbar and lists only the base of each
+tintable family; colors hang off it in a tint strip.
+
+Fertile today: `dirt, grass, sand, ash, wood, snow, mud, moss, bone`.
+
+---
+
+## Themes
+
+A theme is a terrain generator plus a mood: `sky` gradient, `gloom` (0 = evenly
+lit, 1 = only glowing things visible), `gravity` multiplier, `starters[]`, and a
+`build(tiles, rng)`. Registry is `THEMES` / `THEME_BY_ID`; `DEFAULT_THEME` is
+`empty`.
+
+| id | Name | Notes |
+|----|------|-------|
+| `empty` | Empty | Default. Nothing at all — build it yourself |
+| `earth` | — | Cross-section: soil, caves, ponds |
+| `station` | — | `gravity` 0.35, high gloom |
+| `tidepool` | — | Water-heavy, kelp-led food chain |
+| `volcanic` | — | Lava seams, ember/cinder roster |
+
+`across(n)` inside `themes.ts` is the `WIDTH_SCALE` multiplier for scattered
+features. Theme starter counts get the same treatment in `seedStarters`.
+
+`SUMMONED_THEME_ID` (`'summoned'`) is a pseudo-theme: `GameInstance` holds the
+summoned `Theme` object in `summonedTheme` and `resolveTheme` prefers it.
+
+---
+
+## Summoning
+
+`POST /api/v1/micro-land/summon` with `{ mode, prompt }`, mode being
+`creature` | `scene` | `terrain`.
+
+The zod schema in `blueprint.ts` / `terrain.ts` is converted straight into the
+tool's `input_schema` via the AI SDK's `zodSchema`, so **the contract the model
+is held to and the contract the simulation reads are the same object**. The
+`.describe()` strings are the model's only instructions — they are written for
+the model, not for a human reader, and editing one edits the prompt.
+
+Calls the Messages API directly (`claude-opus-5`) rather than `generateObject`,
+which hard-codes `temperature: 0` that Opus 5 rejects. `maxDuration` 120 s with
+a 105 s internal abort so a fallback can still be returned. Max tokens: creature
+16k, terrain 16k, scene 32k.
+
+Every failure path — no API key, model error, refusal, malformed output — falls
+back to `proceduralCreature` / `proceduralScene` / `sanitizeTerrain`'s built-in
+island. The route returns `source: 'model' | 'offline'`.
+
+Client side: `GameInstance.introduce(raw, count)` sanitizes, registers (which
+also makes the species native so seed rain can bring it back), and places.
+`applyTerrain(raw, {keepCreatures})` sanitizes, wraps as a theme, repaints, and
+re-keys the records to the summoned land's name.
+
+Terrain painting (`paintTerrain`): a coarse character map, ground level fitted
+by `fitGroundLevel` (models draw the horizon two-thirds up, which plays badly —
+pad empty rows on top until the surface sits 30–50% up), then sampled with fbm
+noise jitter so cell edges come out ragged. Cells are kept **square**; a map too
+narrow to cross the world repeats mirrored rather than stretching.
+
+---
+
+## Rendering
+
+One canvas pixel per world tile into a `WORLD_W × WORLD_H` backbuffer, then one
+scaled blit with `imageSmoothingEnabled = false`. Zoom is fixed by `VIEW_W`
+(224), not by the world width, so a hopper is the same size it has always been;
+a wide display simply sees more tiles.
+
+Per frame, all clipped to visible columns:
+1. `ensureTiles` — re-bake tile colors if the view left the baked range
+   (`TILE_MARGIN` 32 columns of slack, which earns its keep while paused)
+2. `buildLight` — quarter-res light field: daylight by column depth below the
+   first solid tile (`SKY_FALLOFF` 16), glowing tiles sampled every other tile,
+   glowing creatures, three blur passes, baked into a shadow overlay scaled by
+   `theme.gloom`. Gathered `LIGHT_MARGIN` 24 columns wide because blur bleeds
+3. Sky gradient → tile layer → creatures (culled off-screen; flicker when
+   starving or distressed) → particles → **shadow** → elder halo → inspect
+   brackets. Shadow goes after sprites so creatures are dimmed by the same
+   shadows as terrain
+4. Scaled blit, then the minimap
+
+Minimap is drawn on the world canvas (not React) because it must share the pixel
+grid and updates every frame; refreshed every `MAP_REFRESH_FRAMES` (12).
+`minimapHit` must be consulted before a tap is allowed to paint.
+
+---
+
+## Input
+
+All pointer handling is in `GameInstance`, on the canvas.
+
+| Gesture | Effect |
+|---------|--------|
+| Tap/drag, paint tool | Paint a circle of `brush` radius |
+| Tap/drag, creature tool | Place (throttled `PLACE_THROTTLE_MS` 130) |
+| Drag on a creature | Pick up; release throws with trail velocity |
+| Tap in Look mode | Inspect + follow; drag in Look mode pans (nothing to paint) |
+| Two fingers | Pan, always — cancels whatever the first finger started |
+| Tap/drag on minimap | Jump/scrub the camera |
+| Wheel / trackpad | Pan sideways (vertical folded in) |
+| Arrow keys, A/D | Held pan; both held then one released keeps the other |
+| Home / End | Jump to either end |
+| Edge band while carrying | World scrolls under the carried creature |
+
+Following is cleared the moment the player pans by hand.
+
+---
+
+## Records and persistence
+
+**Chronicle** = one in-memory `ChronicleData`, written back on a 4 s debounce
+plus on `visibilitychange`/`pagehide` (not `beforeunload` — mobile kills
+backgrounded tabs without unloading).
+
+`landId(themeId, summonedLandName)` — built-ins file under their theme id; a
+summoned land files under `summoned:<slug-of-its-name>`, so re-summoning "a
+drowned cathedral" finds its own records.
+
+Per land: `elder` (seconds, species, player-given name, when taken),
+`steadySeconds` (longest run with no extinction), `generations` (deepest
+bloodline). Plus a global species archive (blueprint + first/last seen +
+longest life) and a global milestone map.
+
+- `ELDER_MIN_SECONDS` 60 — below this the record is meaningless and the halo is
+  on screen constantly.
+- `STEADY_SHOW_SECONDS` 120 — below this the streak flickers during early churn.
+- Archive pruning caps *summoned* species at `MAX_ARCHIVED_SUMMONED` 80,
+  oldest-sighting first. Built-ins are never pruned.
+- Only the elder can be named. A name is the reward for the record.
+
+Backends implement `load()/save()` async. `localBackend` wraps every access
+because `localStorage` *throws* on read in private-mode Safari.
+`accountBackend` goes through the API route (house pattern — Firestore is closed
+to clients), trims with `fitChronicle` before sending, and uses `keepalive` only
+under 60 KB because the spec rejects larger keepalive bodies outright.
+
+The game **starts on `localBackend` and never waits for the network**; when auth
+resolves, `adoptAccount` reads the account copy, `mergeChronicles` folds it into
+the live one, and the merged result is written straight back. Merging, not
+choosing — the account holds last week's phone session, the local copy holds the
+last thirty seconds, and both are real. `initChronicle` memoizes its in-flight
+promise for exactly this reason: `loaded` is only set *after* the await, so
+without the memo a local read landing after the merge would silently overwrite
+it and the account's creatures would vanish for that session.
+
+Stored at `users/{uid}/microLand/chronicle` as **one JSON string in an unindexed
+`blob` field**, not as nested maps. It is a save blob — read whole, written
+whole, never queried — and as maps Firestore would index every leaf of every
+archived creature on every write, with ids (`summon:cinder-wyrm:3`) landing in
+field paths that do not take colons. The cost is that the document is opaque in
+the console and cannot be queried across players: a public gallery would want
+creatures as their own documents, added *alongside* this rather than by
+unpicking it. `MAX_CHRONICLE_BYTES` 700 KB leaves headroom under Firestore's
+1 MiB field cap; the route refuses anything larger rather than trimming it.
+
+Anonymous players are first-class here — `useAuth` mints an anonymous uid for
+everyone, so records are kept from the first creature drawn, and signing up
+links the credential to that same uid and carries the archive across. The honest
+limit is that an anonymous uid lives in browser storage: clearing site data
+loses it, and cross-device only truly works once the player signs up.
+
+**Milestones** fire once ever, not once per land, and have no screen of their
+own — one line in the notice strip, then the back of the field guide.
+
+## Saved worlds — the shelf
+
+The chronicle is a logbook; the shelf is the save file, added alongside it. A
+player can keep up to `MAX_SAVED_WORLDS` (8) worlds by name and reopen one
+mid-simulation: same terrain, same creatures, same hungers and ages.
+
+`worlds/types.ts` (shape) · `worlds/wire.ts` (validation + size, shared with the
+route) · `worlds/snapshot.ts` (world ↔ snapshot, pure) · `worlds/backend.ts`
+(local / account) · `worlds/shelf.ts` (module state, active world, autosave) ·
+`components/worlds-panel.tsx` · `api/v1/micro-land/worlds[/[id]]` ·
+`lib/micro-land/world-store.ts`.
+
+What is stored: the RLE'd tile grid, every creature's full runtime state, the
+world scalars, `natives`, summoned blueprints **that have something alive**, the
+summoned `SanitizedTerrain` (not the `Theme` — it carries a `build` function),
+the camera column, and where the record-keeper was standing. What is not:
+`grain` (regenerated from `seed`; the visible cost is slightly different
+speckle), `particles`, and built-in blueprints.
+
+- **The material table version travels with the grid.** Tile values are indices
+  into `MATERIAL_IDS`; a save written against a *longer* table is refused rather
+  than rendered as whatever now sits at that index (invariant 3).
+- **`decodeTiles` measures before it writes.** A one-pass decoder would leave
+  half a world behind on its way to returning false, ruining the land on screen.
+- **A shelved world is released when the land is replaced** — theme change,
+  Reshape, summoned terrain — so the autosave can never overwrite a kept world
+  with the one that replaced it. Painting, placing and clearing life do not.
+- **Records survive the move.** `steadySince` and `elapsed` are saved together,
+  so a resumed streak continues rather than resetting; the outgoing world banks
+  its own on the way out. Nothing here can lower a high-water mark.
+- Stored at `users/{uid}/microLandWorlds/{saveId}`, one document per world, blob
+  unindexed like the chronicle — but with the shelf-row fields (`name`,
+  `creatures`, `elapsed`, …) alongside it so `listWorlds` can `select()` them
+  without pulling megabytes of saves.

--- a/.claude/skills/micro-land/references/extending.md
+++ b/.claude/skills/micro-land/references/extending.md
@@ -1,0 +1,255 @@
+# Micro Land — Extending
+
+Recipes for the changes that come up most. Each one lists every file that has to
+move together, because most of these have a step that is easy to miss and fails
+silently rather than loudly.
+
+---
+
+## Add a material
+
+1. `domain/types.ts` — add the id to `BaseMaterialId`.
+2. `domain/config/materials.ts` — add to `BASE_MATERIAL_IDS` **at the end**
+   (index order is stored in the tile grid) and add an entry to
+   `BASE_MATERIALS` as a diff against `DEFAULTS`. Only say what makes it
+   different from plain rock.
+3. Add it to `PAINTABLE` if the player should be able to paint it, in the place
+   in the list where it belongs by feel (soft ground first, then rock, then
+   built things, then shiny).
+4. If it should come in colors, add it to `TINTABLE` and to
+   `TintableMaterialId` in `types.ts`. That generates 9 more variants, appended
+   after everything else.
+
+Automatic once the above is done: the flag lookup arrays, the paint toolbar, the
+tint strip, the summon prompt's material list, the terrain legend enum, and the
+blueprint schema's `immuneTo` / `dig.through` / `death.becomes` enums — they all
+derive from `BASE_MATERIAL_IDS` or the material table.
+
+**Things that need a deliberate decision:**
+- `fertile` — the summon prompt's fertile list is derived, so setting this
+  changes what the model is told plants can root on. A world painted only in
+  non-fertile materials quietly starves.
+- `deadly` — kills anything without it in `immuneTo`.
+- `melts` — turns to water next to lava, handled in `tile-sim.ts`.
+- `acidProof` — there must always be enough acid-proof materials to build a
+  container out of.
+- A material with genuinely new *behaviour* (like acid corroding, or cloud being
+  passable-but-thick) needs a branch in `tile-sim.ts` or a new precomputed flag
+  array in `materials.ts`. Follow how `VISCOSITY` and `IS_DROWNING` are done —
+  a `Uint8Array` indexed the same as the grid, never a per-tile object lookup.
+
+Verify: paint it, drop something on it, run the harness on `earth` to confirm
+nothing about the food chain moved.
+
+---
+
+## Add a built-in creature
+
+Write it in `domain/config/creatures.ts` as a plain object literal — exactly the
+shape a model returns — wrapped in `builtin('<stable-id>', {...})`, then add it
+to `BUILTIN_CREATURES`.
+
+Then decide which themes it lives in: add `{ id, count }` to those themes'
+`starters` in `domain/config/themes.ts`. Counts are **per screen** and get
+multiplied by `WIDTH_SCALE` in `seedStarters` — write the number that reads as
+"a meadow" on one screen, not the total.
+
+Getting it right:
+- **`size` and art width must agree.** Size drives the food chain and the
+  summon prompt publishes the scale (`size 1` = 3–5 wide, `size 6` = 20–28).
+  A dragon drawn 9 wide is a beetle that eats everything.
+- **Exactly one structural tag** (`plant` / `meat` / `mineral`), then 1–3
+  flavour tags. The sanitizer will force one in if you forget, which may not be
+  the one you wanted.
+- **Check what it slots into.** Run `canEat` in your head against the existing
+  roster in both directions: what does it eat, and what eats it? A creature with
+  no predators and a plant diet is a population that only goes up until it hits
+  `SPECIES_SOFT_CAP`.
+- **Adding a plant costs every other plant.** `MAX_PLANTS` and
+  `PLANT_SPECIES_CAP` are a shared budget. Adding an eighth plant species to a
+  seven-species roster takes a slice out of all seven; check whether the grazers
+  still eat.
+- Values outside the sanitizer's clamp ranges are silently changed, not
+  rejected. If a tuning edit seems to do nothing, check the clamp in
+  `sanitizeBlueprint`.
+
+Verify with the harness on every theme it was added to, `--runs 5`, and confirm
+it neither goes extinct in every run nor drives something else extinct.
+
+---
+
+## Add a theme
+
+In `domain/config/themes.ts`: a `Theme` object with `id`, `name`, `blurb`, `sky`
+gradient, `gloom`, `gravity`, `starters`, and `build(tiles, rng)`. Add it to the
+`THEMES` array.
+
+Use the local helpers — `fill`, `set`, `rect`, `blob`, `mossify`, and `across(n)`
+for anything scattered (ponds, seams, rooms). `across` is the `WIDTH_SCALE`
+multiplier; a bare count doesn't spread out across three screens, it thins out.
+
+Requirements for a theme that actually lives:
+- Somewhere fertile, or nothing grows and everything starves.
+- Water deep enough to swim in if any starter swims; open air if any flies.
+- A starter list that is a working food chain: plants, then things that eat
+  plants, then usually one thing that eats those. More small things than big
+  things.
+- `mossify` after the grid is finished, not inside the generator loop — "is this
+  tile exposed" is a question about neighbours that don't exist yet mid-column.
+
+The theme picker in `components/hud.tsx` reads `THEMES`, so it needs no change.
+
+Verify: `npm run sim:micro-land -- --theme <id> --seconds 600 --runs 5`. A new
+theme that prints `✗ Everything died` is not ready regardless of how it looks.
+
+---
+
+## Add a milestone
+
+`domain/config/milestones.ts`: an entry with `id`, `text`, and
+`reached(context)`. Add fields to `MilestoneContext` only if the existing eight
+can't express it, and if you do, populate it in
+`GameInstance.updateRecords`/`checkMilestones`.
+
+Order the list by roughly when a player meets it — order only affects the field
+guide listing, and it should read as a ladder with the ones still ahead sitting
+in a stable place.
+
+Keep the voice: the world remarking on something and then getting on with it.
+No badges, no progress bars, nothing to collect on purpose. Milestones fire once
+ever, not once per land.
+
+---
+
+## Add a field to the blueprint
+
+This is the big one — it changes the contract between the model and the
+simulation, and every piece has to move at once.
+
+1. `domain/types.ts` — add to the interface, with a comment saying what it means
+   in the world.
+2. `domain/blueprint.ts` — add to `BlueprintSchema` with a `.describe()`. **That
+   string is the model's only instruction about the field**; write it for the
+   model, with concrete ranges and a worked example. Then add it to
+   `sanitizeBlueprint` with a clamp and a fallback that is playable when the
+   field is missing entirely.
+3. `domain/sim/creature-sim.ts` (or wherever it acts) — read it off the
+   blueprint. Never branch on species.
+4. `domain/config/creatures.ts` — the built-ins are literals, so they get the
+   sanitizer's fallback unless you set the field. Decide whether that fallback
+   is right for all 34 or whether some need it explicitly.
+5. `domain/creature-kit.ts` — if a hand-drawing player should be able to set it,
+   add it to `BuildOptions` and `buildRawCreature`, and a control in
+   `components/creature-builder.tsx`. If not, the plan defaults cover it.
+6. `components/field-guide.tsx` / `inspector.tsx` — if it's something a player
+   should be able to see.
+7. `domain/procedural.ts` — the offline fallback creature should set it too.
+
+If the field is optional and easy to get subtly wrong, follow `aura`'s pattern:
+collapse anything that doesn't resolve to a real effect back to `null` rather
+than shipping a half-working feature.
+
+Add a test in `domain/__tests__/` if the field has non-obvious sanitizing.
+
+---
+
+## Change the summoning prompt
+
+The system prompt lives in `src/app/api/v1/micro-land/summon/route.ts`. Its
+material list and fertile list are *derived* from the material table — keep them
+that way, so adding a material updates the prompt for free.
+
+The three user prompts (`creaturePrompt`, `terrainPrompt`, `scenePrompt`) are
+short on purpose; most instruction belongs in the shared `SYSTEM` block or in
+the schema's `.describe()` strings.
+
+Things the prompt is currently load-bearing for, learned the hard way:
+- Drawing at the scale `size` says. This is the single most common failure.
+- The head on anything size 4+: outline, an eye colour used nowhere else, a jaw
+  line, a snout that breaks the outline. Viewers find the face first.
+- Two frames with a *small* difference. Two unrelated drawings read as a glitch.
+- Facing right.
+- "Describe what the creature IS, not what it eats" — otherwise "a snail that
+  eats moss" comes back as a plant.
+- Keeping the horizon low and putting hollows in deep rock.
+- Fertile ground, or the world starves.
+
+Tone is all-ages and kid-safe; creatures hunt each other because that is nature,
+but names and descriptions stay warm.
+
+There is no automated test for prompt quality. Summon ten things across the
+range (a mite, a dragon, a plant, a fish, something absurd) and look at them.
+
+---
+
+## Balance work
+
+Everything tunable is in `domain/constants.ts`, and the comments there are the
+reasoning — update the comment when you change the number.
+
+The relationships that matter:
+- `MEAL_VALUE` (0.42) **must stay below** `BREED_COST` (0.55).
+- `MAX_PLANTS` is shared across plant species; `PLANT_SPECIES_CAP` stops one
+  species taking the lot and turning the world into a monoculture.
+- `SPECIES_SOFT_CAP` is what turns a terminal crash into an oscillation — it is
+  the environment saying "there is only so much room here".
+- `NATIVE_PLANT_TARGET` is a floor, not a quota. Above it the ground does
+  nothing; the further below, the harder it seeds. A constant trickle would pin
+  every world at `MAX_PLANTS` and produce a green carpet.
+- `PLANT_MATURITY` / `PLANT_SPREAD_COOLDOWN` are far shorter than animal
+  equivalents on purpose: a grazer empties its stomach every ~15 s.
+- Anything scaled by `WIDTH_SCALE` is a density. Keep it that way.
+
+Method: run the harness on all four populated themes at `--runs 5 --seconds 600`
+before and after, on the same seeds, and compare `peak`, `low water mark`,
+`alive at the end`, per-species averages, and the cause-of-death breakdown. A
+change that improves one theme and kills another is not done.
+
+---
+
+## Adding to the drawing kit
+
+`domain/creature-kit.ts` is the hand-drawing path. Its output is a **raw** object
+literal in the same shape the model returns, so it goes through
+`sanitizeBlueprint` on exactly the same path — a drawn creature and a summoned
+one are the same kind of thing, and that must stay true.
+
+- A `Draft` stores hex colours per pixel, not palette keys. Keys are a transport
+  detail; quantising to a real palette happens once, at the end, in
+  `draftToArt`.
+- `BODY_PLANS` numbers are lifted off the starter roster (a Walker is a Hopper,
+  a Swimmer is a Finling) so a drawn creature drops into the existing food chain
+  and behaves like it belongs. Don't invent numbers for a new plan — copy them
+  off a built-in that already works.
+- Choices exposed to the player must be answerable by a seven-year-old: how it
+  moves, what it eats, whether it glows. Anything finer belongs in the plan
+  defaults.
+- `sizeForWidth` mirrors the table in the summoning prompt so a hand-drawn and a
+  summoned creature of the same width land on the same rung. Change both or
+  neither.
+
+Tests live in `domain/__tests__/creature-kit.test.ts` and are the closest thing
+this codebase has to a spec for the kit — extend them.
+
+---
+
+## Adding UI
+
+Micro Land takes over the viewport, which interaction model 2 permits *because*
+`CosmicShell` carries the cave exit. Don't add a second exit and don't remove
+that one.
+
+- Panels are store flags (`summonOpen`, `builderOpen`, `guideOpen`), rendered
+  from `MicroLandGame`, at `z-50` (site nav is z-30, the game is z-40).
+- Read from the store with selectors, one field at a time — the store is pushed
+  to a few times a second and a whole-state selector re-renders everything.
+- Never put world data in the store. If a panel needs live creature state, push
+  a snapshot from `GameInstance` the way `pushInspected` does.
+- Style with the `--cc-*` CSS variables (`--cc-font-mono`, `--cc-mint`,
+  `--cc-mint-line`, `--cc-mint-soft`, `--cc-text-muted`) rather than raw colors;
+  the shared primary-action color is part of the cave's pact.
+- The sparkle icon marks AI-assisted entry points. AI is invisible as a *hook*
+  (CLAUDE.md #5) — the sparkle is an affordance, not a "powered by" badge.
+- Touch and mouse carry equal weight. Anything reachable by pointer needs a
+  keyboard path, and anything conveyed by color or motion needs a second
+  channel.

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -123,6 +123,16 @@
       "indexes": [
         { "order": "ASCENDING", "queryScope": "COLLECTION" }
       ]
+    },
+    {
+      "collectionGroup": "microLand",
+      "fieldPath": "blob",
+      "indexes": []
+    },
+    {
+      "collectionGroup": "microLandWorlds",
+      "fieldPath": "blob",
+      "indexes": []
     }
   ]
 }

--- a/firestore.rules
+++ b/firestore.rules
@@ -26,6 +26,16 @@ service cloud.firestore {
 
       // Comet Cards sandbox — owner-only, accessed via /api/v1/comet-cards/sandbox/*
       match /cometCardsSandbox/{docId} { allow read, write: if false; }
+
+      // Micro Land records — the species archive (including every creature the
+      // player drew or summoned), land records and milestones. Owner-only,
+      // accessed via /api/v1/micro-land/chronicle.
+      match /microLand/{docId} { allow read, write: if false; }
+
+      // Micro Land saved worlds — one document per world the player kept, each
+      // holding a whole terrarium mid-simulation. Owner-only, accessed via
+      // /api/v1/micro-land/worlds.
+      match /microLandWorlds/{docId} { allow read, write: if false; }
     }
 
     // Nicknames uniqueness index — server only

--- a/scripts/micro-land-sim.ts
+++ b/scripts/micro-land-sim.ts
@@ -11,6 +11,12 @@
  *   npx tsx scripts/micro-land-sim.ts                       # earth, 300s
  *   npx tsx scripts/micro-land-sim.ts --theme tidepool --seconds 600
  *   npx tsx scripts/micro-land-sim.ts --runs 5              # average of 5 seeds
+ *   npx tsx scripts/micro-land-sim.ts --set nativePlantTarget=60 --set maxPlants=300
+ *
+ * `--set` moves the same knobs the in-game settings panel moves, which is what
+ * makes a value found by dragging a slider testable: drag until the world looks
+ * right, then run the ten-minute ecosystem check on that number before it
+ * becomes the default.
  */
 import { THEMES, THEME_BY_ID } from '@/app/micro-land/domain/config/themes'
 import { TICK_S } from '@/app/micro-land/domain/constants'
@@ -23,6 +29,13 @@ import {
   createWorld,
   seedStarters,
 } from '@/app/micro-land/domain/sim/world'
+import {
+  TUNING,
+  TUNING_DEFAULTS,
+  type TuningKey,
+  changedKnobs,
+  setTuning,
+} from '@/app/micro-land/domain/tuning'
 
 function arg(name: string, fallback: string): string {
   const i = process.argv.indexOf(`--${name}`)
@@ -35,8 +48,29 @@ const runs = Number(arg('runs', '1'))
 const quiet = process.argv.includes('--quiet')
 
 if (!THEME_BY_ID[themeId]) {
-  console.error(`Unknown theme "${themeId}". Try: ${THEMES.map((t) => t.id).join(', ')}`)
+  console.error(`Unknown theme "${themeId}". Try: ${THEMES.map(t => t.id).join(', ')}`)
   process.exit(1)
+}
+
+for (let i = 0; i < process.argv.length; i++) {
+  if (process.argv[i] !== '--set') continue
+  const [key, raw] = (process.argv[i + 1] ?? '').split('=')
+  if (!(key in TUNING_DEFAULTS) || !Number.isFinite(Number(raw))) {
+    console.error(
+      `Bad --set "${process.argv[i + 1] ?? ''}". Knobs: ${Object.keys(TUNING_DEFAULTS).join(', ')}`
+    )
+    process.exit(1)
+  }
+  setTuning({ [key as TuningKey]: Number(raw) })
+}
+
+// Printed rather than assumed. A run whose numbers were quietly moved is worth
+// nothing as a before-and-after unless the header says what moved.
+const tuned = changedKnobs()
+if (tuned.length > 0 && !quiet) {
+  console.log(
+    `tuning: ${tuned.map(k => `${k}=${TUNING[k]} (was ${TUNING_DEFAULTS[k]})`).join(', ')}`
+  )
 }
 
 interface RunResult {
@@ -107,8 +141,7 @@ function runOnce(seed: number): RunResult {
 
     if (!quiet && sampleEvery > 0 && tick % sampleEvery === 0) {
       console.log(
-        `t=${Math.round(world.elapsed)}s`.padEnd(7) +
-          format(countByBlueprint(world), world)
+        `t=${Math.round(world.elapsed)}s`.padEnd(7) + format(countByBlueprint(world), world)
       )
     }
   }
@@ -120,7 +153,7 @@ function runOnce(seed: number): RunResult {
   const dug = world.creatures.reduce((a, c) => a + c.tilesDug, 0)
 
   const survivors = countByBlueprint(world)
-  const extinctions = [...seeded].filter((id) => !survivors[id])
+  const extinctions = [...seeded].filter(id => !survivors[id])
 
   return {
     survivors,
@@ -153,10 +186,15 @@ for (const r of results) {
 }
 
 for (const id of [...allSpecies].sort()) {
-  const counts = results.map((r) => r.survivors[id] ?? 0)
+  const counts = results.map(r => r.survivors[id] ?? 0)
   const avg = counts.reduce((a, b) => a + b, 0) / runs
-  const extinctIn = results.filter((r) => r.extinctions.includes(id)).length
-  const flag = extinctIn === runs ? '  ← EXTINCT in every run' : extinctIn > 0 ? `  ← extinct in ${extinctIn}/${runs}` : ''
+  const extinctIn = results.filter(r => r.extinctions.includes(id)).length
+  const flag =
+    extinctIn === runs
+      ? '  ← EXTINCT in every run'
+      : extinctIn > 0
+        ? `  ← extinct in ${extinctIn}/${runs}`
+        : ''
 
   // Aggregate causes of death so a collapse can be attributed, not guessed at.
   const causes: Record<string, number> = {}

--- a/src/app/api/v1/micro-land/chronicle/route.ts
+++ b/src/app/api/v1/micro-land/chronicle/route.ts
@@ -1,0 +1,68 @@
+/**
+ * A player's Micro Land records.
+ *
+ * GET reads them, PUT replaces them, and both act on the caller's own uid taken
+ * from the verified token — there is no uid in the path or the body, so one
+ * player cannot address another's document at all.
+ *
+ * Anonymous callers are first-class here, not tolerated. `useAuth` mints an
+ * anonymous uid for everyone on arrival, so a child who has never signed up
+ * still has somewhere to keep the creature they just drew, and signing up later
+ * links the credential to that same uid and carries the records with it.
+ */
+import { type NextRequest, NextResponse } from 'next/server'
+
+import {
+  MAX_CHRONICLE_BYTES,
+  chronicleBytes,
+  validateChronicle,
+} from '@/app/micro-land/chronicle/wire'
+import { verifyRequestAuth } from '@/lib/api/auth'
+import { loadChronicle, saveChronicle } from '@/lib/micro-land/chronicle-store'
+
+export async function GET(request: NextRequest) {
+  const auth = await verifyRequestAuth(request)
+  if ('error' in auth) return auth.error
+
+  try {
+    const chronicle = await loadChronicle(auth.claims.uid)
+    // A player with no stored records is the ordinary first-visit case, not a
+    // 404 — the client wants "nothing yet", which is what null already means.
+    return NextResponse.json({ chronicle })
+  } catch (error) {
+    console.error('micro-land chronicle load failed:', error)
+    return NextResponse.json({ error: 'Could not read your records.' }, { status: 500 })
+  }
+}
+
+export async function PUT(request: NextRequest) {
+  const auth = await verifyRequestAuth(request)
+  if ('error' in auth) return auth.error
+
+  let body: { chronicle?: unknown }
+  try {
+    body = (await request.json()) as { chronicle?: unknown }
+  } catch {
+    return NextResponse.json({ error: 'Expected a JSON body.' }, { status: 400 })
+  }
+
+  const chronicle = validateChronicle(body.chronicle)
+  if (!chronicle) {
+    return NextResponse.json({ error: 'That is not a chronicle.' }, { status: 400 })
+  }
+
+  // The client trims to fit before sending. Anything still over the line is not
+  // this game's client, so it is refused rather than trimmed for them.
+  const bytes = chronicleBytes(chronicle)
+  if (bytes > MAX_CHRONICLE_BYTES) {
+    return NextResponse.json({ error: 'Those records are too large to store.' }, { status: 413 })
+  }
+
+  try {
+    await saveChronicle(auth.claims.uid, chronicle)
+    return NextResponse.json({ ok: true, bytes })
+  } catch (error) {
+    console.error('micro-land chronicle save failed:', error)
+    return NextResponse.json({ error: 'Could not save your records.' }, { status: 500 })
+  }
+}

--- a/src/app/api/v1/micro-land/worlds/[id]/route.ts
+++ b/src/app/api/v1/micro-land/worlds/[id]/route.ts
@@ -1,0 +1,104 @@
+/**
+ * One saved world: read it, write it, throw it away.
+ *
+ * The id in the path is the one place a player-supplied string reaches a
+ * Firestore document id, so it is checked against `isSaveId` before it is used
+ * for anything — that rejects path separators, the reserved `__…__` form, and
+ * anything long enough to be an attempt at something.
+ *
+ * PUT is a full replace rather than a merge. The client holds the authoritative
+ * copy of a world in memory and sends all of it; merging here would splice a
+ * creature the player's own client had already buried back into the population.
+ */
+import { type NextRequest, NextResponse } from 'next/server'
+
+import {
+  MAX_SAVED_WORLDS,
+  MAX_WORLD_BYTES,
+  isSaveId,
+  validateWorldSave,
+  worldSaveBytes,
+} from '@/app/micro-land/worlds/wire'
+import { verifyRequestAuth } from '@/lib/api/auth'
+import { deleteWorld, loadWorld, saveWorld } from '@/lib/micro-land/world-store'
+
+export async function GET(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const auth = await verifyRequestAuth(request)
+  if ('error' in auth) return auth.error
+
+  const { id } = await params
+  if (!isSaveId(id)) return NextResponse.json({ error: 'No such world.' }, { status: 400 })
+
+  try {
+    const world = await loadWorld(auth.claims.uid, id)
+    // Null is the ordinary answer for a world that has been deleted on another
+    // device, which is a shelf that needs refreshing rather than an error.
+    return NextResponse.json({ world })
+  } catch (error) {
+    console.error('micro-land world load failed:', error)
+    return NextResponse.json({ error: 'Could not open that world.' }, { status: 500 })
+  }
+}
+
+export async function PUT(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const auth = await verifyRequestAuth(request)
+  if ('error' in auth) return auth.error
+
+  const { id } = await params
+  if (!isSaveId(id)) return NextResponse.json({ error: 'No such world.' }, { status: 400 })
+
+  let body: { world?: unknown }
+  try {
+    body = (await request.json()) as { world?: unknown }
+  } catch {
+    return NextResponse.json({ error: 'Expected a JSON body.' }, { status: 400 })
+  }
+
+  const world = validateWorldSave(body.world)
+  if (!world) {
+    return NextResponse.json({ error: 'That is not a world.' }, { status: 400 })
+  }
+  // The document is addressed by the path; a body claiming a different id would
+  // otherwise store a world under a name that disagrees with what is inside it.
+  if (world.id !== id) {
+    return NextResponse.json({ error: 'That world belongs somewhere else.' }, { status: 400 })
+  }
+
+  const bytes = worldSaveBytes(world)
+  if (bytes > MAX_WORLD_BYTES) {
+    return NextResponse.json({ error: 'That world is too large to keep.' }, { status: 413 })
+  }
+
+  try {
+    const stored = await saveWorld(auth.claims.uid, world)
+    if (!stored) {
+      return NextResponse.json(
+        { error: `A shelf holds ${MAX_SAVED_WORLDS} worlds. Let one go first.` },
+        { status: 409 }
+      )
+    }
+    return NextResponse.json({ ok: true, bytes })
+  } catch (error) {
+    console.error('micro-land world save failed:', error)
+    return NextResponse.json({ error: 'Could not keep that world.' }, { status: 500 })
+  }
+}
+
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const auth = await verifyRequestAuth(request)
+  if ('error' in auth) return auth.error
+
+  const { id } = await params
+  if (!isSaveId(id)) return NextResponse.json({ error: 'No such world.' }, { status: 400 })
+
+  try {
+    await deleteWorld(auth.claims.uid, id)
+    return NextResponse.json({ ok: true })
+  } catch (error) {
+    console.error('micro-land world delete failed:', error)
+    return NextResponse.json({ error: 'Could not let go of that world.' }, { status: 500 })
+  }
+}

--- a/src/app/api/v1/micro-land/worlds/route.ts
+++ b/src/app/api/v1/micro-land/worlds/route.ts
@@ -1,0 +1,29 @@
+/**
+ * A player's shelf of saved worlds.
+ *
+ * Listing only. One world is read, written and deleted through `[id]/route.ts`.
+ *
+ * Like the chronicle route, this acts on the caller's own uid taken from the
+ * verified token — there is no uid in the path or the body, so one player cannot
+ * address another's shelf at all. Anonymous callers are first-class: `useAuth`
+ * mints an anonymous uid for everyone on arrival, so a child who has never
+ * signed up can still keep the world they made, and signing up later links the
+ * credential to that same uid and brings the whole shelf with it.
+ */
+import { type NextRequest, NextResponse } from 'next/server'
+
+import { verifyRequestAuth } from '@/lib/api/auth'
+import { listWorlds } from '@/lib/micro-land/world-store'
+
+export async function GET(request: NextRequest) {
+  const auth = await verifyRequestAuth(request)
+  if ('error' in auth) return auth.error
+
+  try {
+    const worlds = await listWorlds(auth.claims.uid)
+    return NextResponse.json({ worlds })
+  } catch (error) {
+    console.error('micro-land worlds list failed:', error)
+    return NextResponse.json({ error: 'Could not read your worlds.' }, { status: 500 })
+  }
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -375,6 +375,13 @@ body {
 
   --cc-gold: #ffd166;
 
+  /* Micro Land's creature builder: the "nothing here" checkerboard behind a
+     drawing, and the grid over it. Dark and low-contrast on purpose — the
+     drawing has to be the only thing with any colour in it. */
+  --cc-checker-a: #171a22;
+  --cc-checker-b: #1e222c;
+  --cc-checker-grid: rgba(255, 255, 255, 0.07);
+
   --cc-on-mint: #031a16;
   --cc-modal-bg-from: #0a1f1c;
   --cc-modal-bg-to: #050d0e;

--- a/src/app/micro-land/MicroLandGame.tsx
+++ b/src/app/micro-land/MicroLandGame.tsx
@@ -2,27 +2,70 @@
 
 import { useCallback, useEffect, useRef } from 'react'
 
-import { flushChronicle, initChronicle } from '@/app/micro-land/chronicle/chronicle'
+import { accountBackend } from '@/app/micro-land/chronicle/backend'
+import {
+  adoptAccount,
+  flushChronicle,
+  initChronicle,
+  onSaveState,
+} from '@/app/micro-land/chronicle/chronicle'
+import { CreatureBuilder } from '@/app/micro-land/components/creature-builder'
 import { FieldGuide } from '@/app/micro-land/components/field-guide'
 import { Hud } from '@/app/micro-land/components/hud'
 import { Inspector } from '@/app/micro-land/components/inspector'
 import { Notices } from '@/app/micro-land/components/notices'
 import { PanControls } from '@/app/micro-land/components/pan-controls'
+import { SettingsPanel } from '@/app/micro-land/components/settings-panel'
 import { SummonPanel } from '@/app/micro-land/components/summon-panel'
 import { Toolbar } from '@/app/micro-land/components/toolbar'
+import { WorldsPanel } from '@/app/micro-land/components/worlds-panel'
 import { THEME_BY_ID } from '@/app/micro-land/domain/config/themes'
 import { hasFertileGround } from '@/app/micro-land/domain/terrain'
 import { GameInstance } from '@/app/micro-land/game-instance'
 import { useMicroLand } from '@/app/micro-land/store'
+import { accountWorldsBackend } from '@/app/micro-land/worlds/backend'
+import {
+  activeWorldId,
+  adoptWorldsAccount,
+  flushActiveWorld,
+  initShelf,
+  keepWorld,
+  onShelf,
+  provideSnapshot,
+  readWorld,
+  removeWorld,
+  setActiveWorld,
+} from '@/app/micro-land/worlds/shelf'
+import type { WorldSave } from '@/app/micro-land/worlds/types'
+import { newSaveId } from '@/app/micro-land/worlds/wire'
+import { useAuth } from '@/hooks/useAuth'
+
+/** Who a shelved world is, as far as the game instance is concerned. */
+type SaveIdentity = Pick<WorldSave, 'id' | 'name' | 'createdAt'>
 
 export function MicroLandGame() {
   const canvasRef = useRef<HTMLCanvasElement>(null)
   const gameRef = useRef<GameInstance | null>(null)
-  const notify = useMicroLand((s) => s.notify)
+  const notify = useMicroLand(s => s.notify)
+  const { user } = useAuth()
+
+  /**
+   * The shelf slot the world on screen belongs to.
+   *
+   * A ref rather than state: the autosave reads it from a timer that has nothing
+   * to do with a render, and nothing on screen is driven by it — the panel reads
+   * `shelf.activeId`, which the shelf module owns.
+   */
+  const identityRef = useRef<SaveIdentity | null>(null)
 
   useEffect(() => {
     const canvas = canvasRef.current
     if (!canvas) return
+
+    // Remembered settings, applied before the world is built — the ground seeds
+    // its first plants within a few seconds of the first tick, and a knob that
+    // arrived after that would look like it had done nothing.
+    useMicroLand.getState().hydrateTuning()
 
     // `?theme=tidepool` drops a visitor straight into that world. Set it before
     // the instance is built — it reads the theme from the store on construction.
@@ -53,16 +96,163 @@ export function MicroLandGame() {
       })
     })
 
+    // The shelf can write the open world back on its own — on a timer and on the
+    // way out of the page — but it has no way into the game instance, so this is
+    // how it gets one.
+    provideSnapshot(() => {
+      const identity = identityRef.current
+      if (!identity) return null
+      return gameRef.current?.toSave(identity) ?? null
+    })
+    void initShelf()
+
     return () => {
       cancelled = true
       unsubscribe?.()
+      // Before the instance goes: leaving for another game in the cave is a
+      // normal way to end a session, and it isn't covered by page-hide.
+      void flushActiveWorld()
+      provideSnapshot(null)
       game?.destroy()
       gameRef.current = null
-      // Leaving for another game in the cave is a normal way to end a session,
-      // and it isn't covered by the page-hide handler.
       void flushChronicle()
     }
   }, [])
+
+  /**
+   * Move the session's records onto the player's account once auth resolves.
+   *
+   * Deliberately a second effect that the game does not wait for. The world is
+   * already running on `localBackend` by the time this fires, which is what
+   * anonymous-first means in practice — a player with no account, or no
+   * connection, still gets a complete game, and this only ever adds to it.
+   *
+   * `useAuth` mints an anonymous uid for everyone, so this runs for a first-time
+   * visitor too: their creatures are kept from the first one they draw, and
+   * signing up later links the credential to the same uid and brings the whole
+   * archive with it.
+   *
+   * Keyed on the uid rather than the user object, which is replaced on every
+   * token refresh and would otherwise re-adopt every hour. The ref guards the
+   * remount case, where the effect re-runs with a uid already adopted.
+   */
+  // Storage state into the store, so any panel can render it like other state.
+  useEffect(() => onSaveState(useMicroLand.getState().setSaveState), [])
+  useEffect(() => onShelf(useMicroLand.getState().setShelf), [])
+
+  const adoptedRef = useRef<string | null>(null)
+  useEffect(() => {
+    const uid = user?.uid
+    if (!uid || adoptedRef.current === uid) return
+    adoptedRef.current = uid
+    // `getIdToken` refreshes on its own when the cached token has expired, so
+    // asking per request is what keeps a long session writable.
+    const getToken = () => user.getIdToken()
+    void adoptAccount(accountBackend(getToken)).then(() => {
+      // The merge may have brought in creatures made on another device; the
+      // roster was built before any of them existed.
+      gameRef.current?.refreshRoster()
+    })
+    // Independently of the chronicle: a shelf that fails to reach the account
+    // still has whatever this browser kept, which is the anonymous-first
+    // promise applied to worlds as well as to records.
+    void adoptWorldsAccount(accountWorldsBackend(getToken))
+  }, [user])
+
+  /**
+   * Remove a creature the player made, and offer to put it back.
+   *
+   * The undo holds the whole archived record rather than the id, because the id
+   * is gone the moment the species is forgotten — and the record carries the
+   * history (`firstSeen`, `longestLife`) that the blueprint alone cannot
+   * rebuild. Whatever was alive is not restored; the species goes back on the
+   * shelf, which is the same thing a reload gives you.
+   */
+  const handleRemoveSpecies = useCallback(
+    (blueprintId: string) => {
+      const game = gameRef.current
+      if (!game) return
+      const record = game.removeSpecies(blueprintId)
+      if (!record) return
+      notify(`${record.blueprint.name} is gone.`, {
+        label: 'Undo',
+        run: () => {
+          gameRef.current?.restoreSpecies(record)
+          notify(`${record.blueprint.name} is back.`)
+        },
+      })
+    },
+    [notify]
+  )
+
+  /**
+   * Put the world on screen on the shelf, or write the open one back by hand.
+   *
+   * The identity is minted here on the first save and reused forever after, so
+   * "Save now" on an already-kept world updates it rather than filling the shelf
+   * with copies. A failed write rolls the identity back — otherwise the game
+   * would believe it was autosaving into a slot that does not exist.
+   */
+  const handleKeepWorld = useCallback(
+    (name: string) => {
+      const game = gameRef.current
+      if (!game) return
+      // Only reuse the slot if the shelf still agrees this world is in it.
+      // Changing the theme, reshaping, or summoning new terrain all release the
+      // active world, and reusing the id then would overwrite a kept world with
+      // the one that replaced it.
+      const previous = activeWorldId() === identityRef.current?.id ? identityRef.current : null
+      const identity: SaveIdentity = previous
+        ? { ...previous, name }
+        : { id: newSaveId(), name, createdAt: Date.now() }
+      identityRef.current = identity
+
+      void keepWorld(game.toSave(identity))
+        .then(() => notify(`${name} is kept. It will be waiting exactly like this.`))
+        .catch(() => {
+          identityRef.current = previous
+          notify('The cave could not hold that world.')
+        })
+    },
+    [notify]
+  )
+
+  /**
+   * Leave the land on screen and pick a kept one back up.
+   *
+   * The outgoing world is written back first when it was itself shelved, so
+   * hopping between two saved worlds never loses the one you hopped off.
+   */
+  const handleOpenWorld = useCallback(
+    (id: string) => {
+      void (async () => {
+        await flushActiveWorld()
+        const save = await readWorld(id)
+        if (!save) {
+          notify('That world could not be opened.')
+          return
+        }
+        if (!gameRef.current?.adoptSave(save)) {
+          notify('That world could not be opened.')
+          return
+        }
+        identityRef.current = { id: save.id, name: save.name, createdAt: save.createdAt }
+        // After `adoptSave`, which changes the theme and so releases whatever
+        // world was active before it.
+        setActiveWorld(save.id)
+        notify(`${save.name} picks up where it left off.`)
+      })()
+    },
+    [notify]
+  )
+
+  const handleForgetWorld = useCallback(
+    (id: string) => {
+      if (identityRef.current?.id === id) identityRef.current = null
+      void removeWorld(id).then(() => notify('That world is off the shelf.'))
+    },
+    [notify]
+  )
 
   const handleReshuffle = useCallback(() => {
     gameRef.current?.reshuffle()
@@ -116,9 +306,12 @@ export function MicroLandGame() {
         <Inspector onName={handleNameElder} />
       </div>
 
-      <Toolbar />
+      <Toolbar onRemoveSpecies={handleRemoveSpecies} />
       <SummonPanel onIntroduce={handleIntroduce} onApplyTerrain={handleApplyTerrain} />
+      <WorldsPanel onKeep={handleKeepWorld} onOpen={handleOpenWorld} onForget={handleForgetWorld} />
+      <CreatureBuilder onIntroduce={handleIntroduce} />
       <FieldGuide />
+      <SettingsPanel />
     </div>
   )
 }

--- a/src/app/micro-land/chronicle/__tests__/chronicle.test.ts
+++ b/src/app/micro-land/chronicle/__tests__/chronicle.test.ts
@@ -2,9 +2,11 @@ import { beforeEach, describe, expect, it } from 'vitest'
 
 import type { ChronicleBackend } from '@/app/micro-land/chronicle/backend'
 import {
+  adoptAccount,
   archivedSpecies,
   claimMilestone,
   flushChronicle,
+  forgetSpecies,
   initChronicle,
   landId,
   landRecord,
@@ -12,6 +14,7 @@ import {
   noteSpeciesLife,
   readChronicle,
   rememberSpecies,
+  restoreSpeciesRecord,
   setBackend,
   updateChronicle,
 } from '@/app/micro-land/chronicle/chronicle'
@@ -21,6 +24,7 @@ import {
   emptyLandRecord,
 } from '@/app/micro-land/chronicle/types'
 import type { ChronicleData } from '@/app/micro-land/chronicle/types'
+import { reserveSummonIds, sanitizeBlueprint } from '@/app/micro-land/domain/blueprint'
 import type { CreatureBlueprint } from '@/app/micro-land/domain/types'
 
 /**
@@ -65,9 +69,7 @@ describe('landId', () => {
   })
 
   it('gives a summoned land its own key, so records follow the name', () => {
-    expect(landId('summoned', 'The Drowned Cathedral')).toBe(
-      'summoned:the-drowned-cathedral'
-    )
+    expect(landId('summoned', 'The Drowned Cathedral')).toBe('summoned:the-drowned-cathedral')
   })
 
   it('falls back to the theme when a name slugs down to nothing', () => {
@@ -140,11 +142,11 @@ describe('the species archive', () => {
     // One past the cap, oldest first, so the first summoned one is the victim.
     for (let i = 0; i < 81; i++) rememberSpecies(bp(`summoned-${i}`, true), 100 + i)
 
-    const ids = new Set(archivedSpecies().map((s) => s.blueprint.id))
+    const ids = new Set(archivedSpecies().map(s => s.blueprint.id))
     expect(ids.has('builtin-hopper')).toBe(true)
     expect(ids.has('summoned-0')).toBe(false)
     expect(ids.has('summoned-80')).toBe(true)
-    expect(archivedSpecies().filter((s) => s.blueprint.summoned)).toHaveLength(80)
+    expect(archivedSpecies().filter(s => s.blueprint.summoned)).toHaveLength(80)
   })
 })
 
@@ -153,6 +155,210 @@ describe('milestones', () => {
     expect(claimMilestone('first-elder', 5000)).toBe(true)
     expect(claimMilestone('first-elder', 9000)).toBe(false)
     expect(readChronicle().milestones['first-elder']).toBe(5000)
+  })
+})
+
+describe('adoptAccount', () => {
+  /** Records set locally before the account was known must survive the move. */
+  it('keeps what was played anonymously and what the account already knew', async () => {
+    await loadWith(null)
+    rememberSpecies(bp('drawn-by-hand', true), 500)
+    landRecord('tidepool').steadySeconds = 60
+
+    const stored = emptyChronicle()
+    stored.species['from-the-phone'] = {
+      blueprint: bp('from-the-phone', true),
+      firstSeen: 1,
+      lastSeen: 2,
+      longestLife: 90,
+    }
+    stored.lands.tidepool = { ...emptyLandRecord(), steadySeconds: 200 }
+
+    const account = memoryBackend(stored)
+    await adoptAccount(account.backend)
+
+    const ids = new Set(archivedSpecies().map(s => s.blueprint.id))
+    expect(ids.has('drawn-by-hand')).toBe(true)
+    expect(ids.has('from-the-phone')).toBe(true)
+    // High-water marks, so the better of the two wins with no prompt.
+    expect(landRecord('tidepool').steadySeconds).toBe(200)
+  })
+
+  it('writes the merged result straight back, so the account gains the new creature', async () => {
+    await loadWith(null)
+    rememberSpecies(bp('drawn-by-hand', true), 500)
+
+    const account = memoryBackend(emptyChronicle())
+    await adoptAccount(account.backend)
+
+    expect(Object.keys(account.state.saved?.species ?? {})).toContain('drawn-by-hand')
+  })
+
+  it('writes back even when the account has nothing stored yet', async () => {
+    await loadWith(null)
+    rememberSpecies(bp('first-ever', true), 10)
+
+    const account = memoryBackend(null)
+    await adoptAccount(account.backend)
+
+    expect(account.state.saved).not.toBeNull()
+    expect(Object.keys(account.state.saved?.species ?? {})).toContain('first-ever')
+  })
+
+  it('sends later records to the account rather than the device', async () => {
+    const local = await loadWith(null)
+    const account = memoryBackend(null)
+    await adoptAccount(account.backend)
+
+    rememberSpecies(bp('after-sign-in', true), 900)
+    await flushChronicle()
+
+    expect(Object.keys(account.state.saved?.species ?? {})).toContain('after-sign-in')
+    // The local backend was only ever written by the pre-adoption flush.
+    expect(Object.keys(local.state.saved?.species ?? {})).not.toContain('after-sign-in')
+  })
+
+  it('ignores a stored chronicle from an unknown version', async () => {
+    await loadWith(null)
+    rememberSpecies(bp('drawn-by-hand', true), 500)
+
+    const stored = { ...emptyChronicle(), version: CHRONICLE_VERSION + 99 }
+    stored.species.garbage = {
+      blueprint: bp('garbage', true),
+      firstSeen: 1,
+      lastSeen: 2,
+      longestLife: 0,
+    }
+
+    await adoptAccount(memoryBackend(stored).backend)
+
+    const ids = new Set(archivedSpecies().map(s => s.blueprint.id))
+    expect(ids.has('garbage')).toBe(false)
+    // The player's own session is not collateral damage.
+    expect(ids.has('drawn-by-hand')).toBe(true)
+  })
+
+  it('does nothing when asked to adopt the backend already in use', async () => {
+    const mem = memoryBackend(null)
+    setBackend(mem.backend)
+    await initChronicle()
+    await adoptAccount(mem.backend)
+    expect(mem.state.saved).toBeNull()
+  })
+
+  /**
+   * The race this guards: the game calls `initChronicle` on mount and auth
+   * resolves a moment later, so both can be in flight at once. If the local read
+   * lands after the merge, it overwrites the merged chronicle with its own half
+   * and the account's creatures vanish for that session.
+   */
+  it('waits for a load already in flight instead of racing it', async () => {
+    const stored = emptyChronicle()
+    stored.species['on-the-device'] = {
+      blueprint: bp('on-the-device', true),
+      firstSeen: 1,
+      lastSeen: 2,
+      longestLife: 0,
+    }
+
+    let release: () => void = () => {}
+    const gate = new Promise<void>(resolve => {
+      release = resolve
+    })
+    setBackend({
+      async load() {
+        await gate
+        return stored
+      },
+      async save() {},
+    })
+
+    const accountData = emptyChronicle()
+    accountData.species['in-the-account'] = {
+      blueprint: bp('in-the-account', true),
+      firstSeen: 1,
+      lastSeen: 2,
+      longestLife: 0,
+    }
+
+    const init = initChronicle()
+    const adopt = adoptAccount(memoryBackend(accountData).backend)
+    release()
+    await Promise.all([init, adopt])
+
+    const ids = new Set(archivedSpecies().map(s => s.blueprint.id))
+    expect(ids.has('on-the-device')).toBe(true)
+    expect(ids.has('in-the-account')).toBe(true)
+  })
+})
+
+describe('forgetting a species', () => {
+  it('removes it from the archive and hands back the record for undo', () => {
+    rememberSpecies(bp('wyrm', true), 1000)
+    noteSpeciesLife('wyrm', 42)
+
+    const record = forgetSpecies('wyrm')
+    expect(record?.blueprint.id).toBe('wyrm')
+    expect(archivedSpecies()).toHaveLength(0)
+
+    // The history is the part a blueprint alone cannot rebuild.
+    expect(record?.firstSeen).toBe(1000)
+    expect(record?.longestLife).toBe(42)
+  })
+
+  it('returns null for a species it never knew, so undo has nothing to offer', () => {
+    expect(forgetSpecies('never-existed')).toBeNull()
+  })
+
+  it('restores the record exactly, not a creature discovered just now', () => {
+    rememberSpecies(bp('wyrm', true), 1000)
+    noteSpeciesLife('wyrm', 42)
+    const record = forgetSpecies('wyrm')
+
+    restoreSpeciesRecord(record as NonNullable<typeof record>)
+    const back = archivedSpecies()[0]
+    expect(back.firstSeen).toBe(1000)
+    expect(back.longestLife).toBe(42)
+  })
+
+  it('writes the deletion through, so it does not come back on reload', async () => {
+    const mem = await loadWith(null)
+    rememberSpecies(bp('wyrm', true), 1000)
+    await flushChronicle()
+    expect(Object.keys(mem.state.saved?.species ?? {})).toContain('wyrm')
+
+    forgetSpecies('wyrm')
+    await flushChronicle()
+    expect(Object.keys(mem.state.saved?.species ?? {})).not.toContain('wyrm')
+  })
+})
+
+describe('summon id reservation', () => {
+  /**
+   * The bug: summoned ids carry a counter that resets with the page, so after a
+   * reload restored a creature as `summon:wyrm:1`, the next creature summoned
+   * was handed the same id and silently replaced it in the roster.
+   */
+  it('never reissues an id a restored creature is already using', () => {
+    const restored = sanitizeBlueprint({ name: 'Wyrm' }, { summoned: true })
+    reserveSummonIds([restored.id])
+    const fresh = sanitizeBlueprint({ name: 'Wyrm' }, { summoned: true })
+    expect(fresh.id).not.toBe(restored.id)
+  })
+
+  it('clears the whole archive, not just the highest-numbered name', () => {
+    const ids = ['summon:a:41', 'summon:b:7', 'summon:c:12']
+    reserveSummonIds(ids)
+    const fresh = sanitizeBlueprint({ name: 'D' }, { summoned: true })
+    expect(ids).not.toContain(fresh.id)
+    expect(Number(fresh.id.slice(fresh.id.lastIndexOf(':') + 1))).toBeGreaterThan(41)
+  })
+
+  it('ignores ids with no trailing counter instead of resetting', () => {
+    reserveSummonIds(['builtin-hopper', 'summon:x:nonsense'])
+    const before = sanitizeBlueprint({ name: 'E' }, { summoned: true })
+    const after = sanitizeBlueprint({ name: 'E' }, { summoned: true })
+    expect(after.id).not.toBe(before.id)
   })
 })
 

--- a/src/app/micro-land/chronicle/__tests__/wire.test.ts
+++ b/src/app/micro-land/chronicle/__tests__/wire.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it } from 'vitest'
+
+import { CHRONICLE_VERSION, emptyChronicle } from '@/app/micro-land/chronicle/types'
+import type { ChronicleData, SpeciesRecord } from '@/app/micro-land/chronicle/types'
+import {
+  MAX_CHRONICLE_BYTES,
+  chronicleBytes,
+  decodeChronicle,
+  fitChronicle,
+  validateChronicle,
+} from '@/app/micro-land/chronicle/wire'
+import type { CreatureBlueprint } from '@/app/micro-land/domain/types'
+
+/**
+ * A species record carrying `padding` bytes of pretend pixel art.
+ *
+ * Size is what every test below is about, so it is the one thing worth being
+ * able to dial precisely; the rest is cast, as in the chronicle tests.
+ */
+function species(id: string, lastSeen: number, summoned: boolean, padding = 0): SpeciesRecord {
+  return {
+    blueprint: { id, name: id, summoned, blurb: 'x'.repeat(padding) } as CreatureBlueprint,
+    firstSeen: 0,
+    lastSeen,
+    longestLife: 0,
+  }
+}
+
+describe('validateChronicle', () => {
+  it('accepts a well-formed chronicle', () => {
+    expect(validateChronicle(emptyChronicle())).toEqual(emptyChronicle())
+  })
+
+  it.each([
+    ['null', null],
+    ['an array', []],
+    ['a string', 'chronicle'],
+    ['a number', 7],
+  ])('refuses %s', (_label, value) => {
+    expect(validateChronicle(value)).toBeNull()
+  })
+
+  it('refuses a version it does not know, rather than misreading it', () => {
+    expect(validateChronicle({ ...emptyChronicle(), version: CHRONICLE_VERSION + 1 })).toBeNull()
+  })
+
+  it.each(['lands', 'species', 'milestones'])('refuses a missing %s', key => {
+    const payload: Record<string, unknown> = { ...emptyChronicle() }
+    delete payload[key]
+    expect(validateChronicle(payload)).toBeNull()
+  })
+
+  it('refuses an array where a record is expected', () => {
+    expect(validateChronicle({ ...emptyChronicle(), species: [] })).toBeNull()
+  })
+
+  it('drops unknown top-level keys instead of storing them', () => {
+    const result = validateChronicle({ ...emptyChronicle(), sneaky: 'payload' })
+    expect(result).not.toBeNull()
+    expect(Object.keys(result as ChronicleData).sort()).toEqual([
+      'lands',
+      'milestones',
+      'species',
+      'version',
+    ])
+  })
+})
+
+describe('decodeChronicle', () => {
+  it('round-trips a chronicle through a string', () => {
+    const data = emptyChronicle()
+    data.milestones['first-elder'] = 42
+    expect(decodeChronicle(JSON.stringify(data))).toEqual(data)
+  })
+
+  it('returns null for unparseable text rather than throwing', () => {
+    expect(decodeChronicle('{not json')).toBeNull()
+  })
+
+  it('returns null for a missing document field', () => {
+    expect(decodeChronicle(undefined)).toBeNull()
+  })
+
+  it('returns null for valid JSON that is not a chronicle', () => {
+    expect(decodeChronicle('{"hello":"world"}')).toBeNull()
+  })
+})
+
+describe('chronicleBytes', () => {
+  it('counts bytes rather than characters, so accents are not undercounted', () => {
+    const plain = emptyChronicle()
+    plain.milestones.aaaa = 1
+    const accented = emptyChronicle()
+    accented.milestones['ääää'] = 1
+    expect(chronicleBytes(accented)).toBeGreaterThan(chronicleBytes(plain))
+  })
+})
+
+describe('fitChronicle', () => {
+  it('leaves a chronicle that already fits completely alone', () => {
+    const data = emptyChronicle()
+    data.species.crab = species('crab', 10, true)
+    expect(fitChronicle(data)).toBe(data)
+  })
+
+  it('drops archived species until it fits', () => {
+    const data = emptyChronicle()
+    // Four creatures, each a quarter of the budget — one has to go.
+    const chunk = Math.ceil(MAX_CHRONICLE_BYTES / 4)
+    for (let i = 0; i < 4; i++) data.species[`s${i}`] = species(`s${i}`, i, true, chunk)
+
+    const fitted = fitChronicle(data)
+    expect(chronicleBytes(fitted)).toBeLessThanOrEqual(MAX_CHRONICLE_BYTES)
+    expect(Object.keys(fitted.species).length).toBeLessThan(4)
+  })
+
+  it('sheds the least recently seen creature first', () => {
+    const data = emptyChronicle()
+    const chunk = Math.ceil(MAX_CHRONICLE_BYTES / 3)
+    data.species.oldest = species('oldest', 1, true, chunk)
+    data.species.middle = species('middle', 500, true, chunk)
+    data.species.newest = species('newest', 900, true, chunk)
+
+    const kept = Object.keys(fitChronicle(data).species)
+    expect(kept).not.toContain('oldest')
+    expect(kept).toContain('newest')
+  })
+
+  it('sacrifices a built-in before a summoned creature, whatever their ages', () => {
+    const data = emptyChronicle()
+    const chunk = Math.ceil(MAX_CHRONICLE_BYTES / 2)
+    // The built-in is the more recent sighting, and still goes first: it can be
+    // recovered by playing, and the drawn one cannot.
+    data.species.builtin = species('builtin', 999, false, chunk)
+    data.species.drawn = species('drawn', 1, true, chunk)
+
+    const kept = Object.keys(fitChronicle(data).species)
+    expect(kept).toEqual(['drawn'])
+  })
+
+  it('never sheds land records or milestones to make room', () => {
+    const data = emptyChronicle()
+    data.lands.tidepool = {
+      elder: null,
+      steadySeconds: 900,
+      generations: 4,
+      generationsBlueprintId: 'crab',
+      generationsSpeciesName: 'Crab',
+    }
+    data.milestones['first-elder'] = 123
+    const chunk = Math.ceil(MAX_CHRONICLE_BYTES / 2)
+    for (let i = 0; i < 3; i++) data.species[`s${i}`] = species(`s${i}`, i, true, chunk)
+
+    const fitted = fitChronicle(data)
+    expect(fitted.lands.tidepool.steadySeconds).toBe(900)
+    expect(fitted.milestones['first-elder']).toBe(123)
+  })
+
+  it('does not mutate the chronicle it was given', () => {
+    const data = emptyChronicle()
+    const chunk = Math.ceil(MAX_CHRONICLE_BYTES / 2)
+    for (let i = 0; i < 3; i++) data.species[`s${i}`] = species(`s${i}`, i, true, chunk)
+
+    fitChronicle(data)
+    // The live in-memory chronicle must survive a flush unchanged — trimming for
+    // transport is not the same as pruning the archive.
+    expect(Object.keys(data.species)).toHaveLength(3)
+  })
+})

--- a/src/app/micro-land/chronicle/backend.ts
+++ b/src/app/micro-land/chronicle/backend.ts
@@ -1,16 +1,17 @@
 /**
  * Where the chronicle is actually kept.
  *
- * This is the seam that makes the eventual move to accounts a swap rather than a
- * rewrite. Everything above this file talks to a `ChronicleBackend` and never
- * mentions `localStorage`; when records move to Firebase, a second
- * implementation lands here and `setBackend` gets called once at startup.
+ * This is the seam that makes the move to accounts a swap rather than a rewrite.
+ * Everything above this file talks to a `ChronicleBackend` and never mentions
+ * `localStorage` or `fetch`; there are now two implementations, and which one is
+ * in use is decided once, in `MicroLandGame`.
  *
  * Both methods are async even though the local one has nothing to await. That is
- * the deliberate part — a synchronous API today would put `await` into every
- * call site on the day it moves to the network.
+ * the deliberate part — a synchronous API would have put `await` into every call
+ * site on the day this moved to the network.
  */
 import { type ChronicleData, emptyChronicle } from './types'
+import { fitChronicle, validateChronicle } from './wire'
 
 export interface ChronicleBackend {
   /** Returns null when nothing has been stored yet. */
@@ -60,27 +61,89 @@ export const nullBackend: ChronicleBackend = {
   async save() {},
 }
 
+const ENDPOINT = '/api/v1/micro-land/chronicle'
+
 /**
- * Sketch of the account-backed backend, for whoever wires it up.
+ * Records kept against a Firebase account: one document per user, any device.
  *
- * The shape below is the whole port — one document per user, read once on sign
- * in, written on the same debounce the local one uses. The interesting work is
- * not this file, it is deciding what happens to records a player set while
- * signed out (see the note on `mergeChronicles` in `chronicle.ts`).
+ * Goes through an API route rather than the Firestore client SDK, which is the
+ * house pattern — every collection in `firestore.rules` is closed to clients and
+ * reached through a route holding the admin credentials. It also means the size
+ * and shape rules live somewhere the player cannot edit.
  *
- *   export function firebaseBackend(uid: string): ChronicleBackend {
- *     const ref = doc(getFirestore(), 'microLandChronicles', uid)
- *     return {
- *       async load() {
- *         const snap = await getDoc(ref)
- *         return snap.exists() ? (snap.data() as ChronicleData) : null
- *       },
- *       async save(data) {
- *         await setDoc(ref, data)
- *       },
- *     }
- *   }
+ * `getToken` is a function rather than a token because tokens expire and a
+ * session outlasts them. It returns null when there is no signed-in user, which
+ * is not an error — the caller simply keeps whatever backend it had.
+ *
+ * Every failure here is swallowed. A player mid-game whose network drops should
+ * lose the last few seconds of records, not the game; the next flush will carry
+ * everything anyway, because the chronicle writes its whole state each time
+ * rather than a diff.
  */
+export function accountBackend(getToken: () => Promise<string | null>): ChronicleBackend {
+  async function authorized(): Promise<HeadersInit | null> {
+    const token = await getToken()
+    return token ? { authorization: `Bearer ${token}` } : null
+  }
+
+  return {
+    async load() {
+      try {
+        const headers = await authorized()
+        if (!headers) return null
+        const response = await fetch(ENDPOINT, { headers })
+        if (!response.ok) return null
+        const body = (await response.json()) as { chronicle?: unknown }
+        // The route hands back the chronicle as stored; re-validate it here so a
+        // bad document can't reach the game through a trusted-looking channel.
+        // Null is the ordinary answer for a player who has never saved.
+        return validateChronicle(body.chronicle)
+      } catch {
+        return null
+      }
+    },
+
+    /**
+     * Throws on failure, deliberately.
+     *
+     * An earlier version swallowed everything here so a network blip could never
+     * interrupt play. It still cannot — `flushChronicle` catches — but catching
+     * it *there* is what lets the game know a write failed, retry it, and tell
+     * the player. Swallowed at this level it was invisible to everything,
+     * including the code that had already marked the records as saved.
+     */
+    async save(data) {
+      const headers = await authorized()
+      // No signed-in user yet. Not a failure: the local backend still has it.
+      if (!headers) return
+
+      // Trimmed before it leaves, so an oversized archive degrades to a
+      // shorter one instead of a rejected write that records nothing.
+      const body = JSON.stringify({ chronicle: fitChronicle(data) })
+      const response = await fetch(ENDPOINT, {
+        method: 'PUT',
+        headers: { ...headers, 'content-type': 'application/json' },
+        body,
+        /**
+         * The last flush of a session fires from `pagehide`, where an ordinary
+         * fetch is cancelled as the page goes away and the records are lost.
+         *
+         * `keepalive` survives that, but the spec caps a keepalive body at
+         * 64 KiB and rejects anything larger outright — which would single out
+         * the biggest archives, the ones with the most to lose. So it is only
+         * asked for when the body is comfortably under that. Above it we rely
+         * on the `visibilitychange` flush, which runs while the page is still
+         * alive and is the one that actually fires on mobile.
+         */
+        keepalive: body.length < 60_000,
+      })
+
+      if (!response.ok) {
+        throw new Error(`chronicle save failed: ${response.status}`)
+      }
+    },
+  }
+}
 
 /** Fallback used before `load` has resolved, so readers never see undefined. */
 export const INITIAL_DATA = emptyChronicle()

--- a/src/app/micro-land/chronicle/chronicle.ts
+++ b/src/app/micro-land/chronicle/chronicle.ts
@@ -10,11 +10,7 @@
  */
 import type { CreatureBlueprint } from '@/app/micro-land/domain/types'
 
-import {
-  type ChronicleBackend,
-  INITIAL_DATA,
-  localBackend,
-} from './backend'
+import { type ChronicleBackend, INITIAL_DATA, localBackend } from './backend'
 import {
   CHRONICLE_VERSION,
   type ChronicleData,
@@ -40,8 +36,63 @@ const MAX_ARCHIVED_SUMMONED = 80
 let data: ChronicleData = INITIAL_DATA
 let backend: ChronicleBackend = localBackend
 let loaded = false
+/**
+ * The in-flight load, so concurrent callers await one read instead of racing.
+ *
+ * `loaded` alone is not enough: it is only set *after* the await, so a second
+ * caller arriving while the first is still reading storage would sail past the
+ * guard and start its own load. Both would then assign to `data`, and the slower
+ * one would win — which on the account path means a freshly merged chronicle
+ * being quietly replaced by the local-only copy it was merged from.
+ */
+let loading: Promise<ChronicleData> | null = null
 let dirty = false
 let flushTimer: ReturnType<typeof setTimeout> | null = null
+/** True once `adoptAccount` has moved writes off this device. */
+let remote = false
+
+// ---------------------------------------------------------------------------
+// Save state
+// ---------------------------------------------------------------------------
+
+/**
+ * What the storage layer is doing, for anything that wants to show it.
+ *
+ * `remote` rides along on the two settled states because "saved" means something
+ * different depending on it: saved to this device only, or saved to an account
+ * that another device can read. A player deciding whether their creatures are
+ * really safe needs to be told which one they got.
+ */
+export type SaveState =
+  | { kind: 'idle' }
+  | { kind: 'saving' }
+  | { kind: 'saved'; at: number; species: number; remote: boolean }
+  | { kind: 'failed'; at: number; remote: boolean }
+
+let saveState: SaveState = { kind: 'idle' }
+const saveListeners = new Set<(state: SaveState) => void>()
+
+/**
+ * Published rather than pushed into the store directly.
+ *
+ * This module is imported by the headless harness, which has no React and no
+ * Zustand. A listener set keeps the chronicle honest about that — the UI
+ * subscribes, the harness does not, and neither knows about the other.
+ */
+export function onSaveState(fn: (state: SaveState) => void): () => void {
+  saveListeners.add(fn)
+  fn(saveState)
+  return () => saveListeners.delete(fn)
+}
+
+export function readSaveState(): SaveState {
+  return saveState
+}
+
+function setSaveState(next: SaveState): void {
+  saveState = next
+  for (const fn of saveListeners) fn(next)
+}
 
 // ---------------------------------------------------------------------------
 // Identity
@@ -72,22 +123,71 @@ export function landId(themeId: string, summonedLandName: string | null): string
 // Lifecycle
 // ---------------------------------------------------------------------------
 
-/** Swap the storage backend. Called once at startup when accounts land. */
+/** Swap the storage backend and forget what was loaded. For tests and startup. */
 export function setBackend(next: ChronicleBackend): void {
   backend = next
   loaded = false
+  loading = null
+  remote = false
 }
 
 /**
- * Read the chronicle in. Safe to call more than once; only the first does work.
+ * Move an in-progress session onto an account, keeping both sets of records.
+ *
+ * The game starts on `localBackend` and never waits for the network, because
+ * anonymous-first (CLAUDE.md #1) means a player with no account and no
+ * connection still gets a working world. Auth resolves a moment later, and this
+ * is what happens then: read what the account already knows, fold the two
+ * together, and write the result back.
+ *
+ * Merging rather than choosing is the whole point, and it is why
+ * `mergeChronicles` was written long before there was anything to call it. Both
+ * sides are real: the account holds what this player did on their phone last
+ * week, the local copy holds what they have done in the last thirty seconds on
+ * this laptop. Every record is a high-water mark, so there is no conflict to
+ * resolve and nothing to ask the player about.
+ *
+ * The write-back is unconditional. Even when the account wins on every record,
+ * the local archive may hold a creature it has never seen, and that creature is
+ * the thing this whole path exists to save.
+ */
+export async function adoptAccount(next: ChronicleBackend): Promise<void> {
+  if (backend === next) return
+
+  // Never merge into a chronicle that hasn't finished loading — the local read
+  // would land afterwards and overwrite the merged result with its own half.
+  await initChronicle()
+
+  const stored = await next.load()
+  backend = next
+  remote = true
+  if (stored) data = mergeChronicles(migrate(stored), data)
+
+  touch()
+  await flushChronicle()
+}
+
+/**
+ * Read the chronicle in. Safe to call more than once, and safe to call
+ * concurrently; only the first does work and the rest await it.
  */
 export async function initChronicle(): Promise<ChronicleData> {
   if (loaded) return data
-  const stored = await backend.load()
-  data = migrate(stored)
-  loaded = true
-  attachFlushOnHide()
-  return data
+  if (loading) return loading
+
+  loading = (async () => {
+    const stored = await backend.load()
+    data = migrate(stored)
+    loaded = true
+    attachFlushOnHide()
+    return data
+  })()
+
+  try {
+    return await loading
+  } finally {
+    loading = null
+  }
 }
 
 /**
@@ -137,6 +237,22 @@ function touch(): void {
   }
 }
 
+/**
+ * Write the chronicle out, and say what happened.
+ *
+ * The failure handling is the load-bearing part. `dirty` is cleared *before* the
+ * write so that records changed while it is in flight are not lost — but if the
+ * write then fails, clearing it would mark the chronicle clean when nothing was
+ * stored, and those records would never be retried. A dropped connection would
+ * silently cost the player everything since the last successful flush. So a
+ * failure puts the flag back and re-arms the debounce.
+ *
+ * Failures are caught rather than thrown, because every caller is a page-hide
+ * handler or a fire-and-forget timer and none of them can do anything useful
+ * with an exception. Swallowing them *here* rather than inside the backend is
+ * the difference between unobservable and merely non-fatal: the state goes to
+ * `failed`, the UI can say so, and the next flush tries again.
+ */
 export async function flushChronicle(): Promise<void> {
   if (!dirty) return
   dirty = false
@@ -144,7 +260,24 @@ export async function flushChronicle(): Promise<void> {
     clearTimeout(flushTimer)
     flushTimer = null
   }
-  await backend.save(data)
+
+  setSaveState({ kind: 'saving' })
+  try {
+    await backend.save(data)
+    setSaveState({
+      kind: 'saved',
+      at: Date.now(),
+      species: Object.keys(data.species).length,
+      remote,
+    })
+  } catch (error) {
+    console.warn('micro-land: could not save records —', error)
+    // Put it back in the queue. `touch` re-arms the debounce, so a transient
+    // failure costs a few seconds rather than the session.
+    dirty = true
+    touch()
+    setSaveState({ kind: 'failed', at: Date.now(), remote })
+  }
 }
 
 /**
@@ -211,6 +344,28 @@ export function noteSpeciesLife(blueprintId: string, seconds: number): boolean {
   return true
 }
 
+/**
+ * Drop a species from the archive, returning what was removed.
+ *
+ * The returned record is the whole undo: it carries `firstSeen` and
+ * `longestLife`, which cannot be reconstructed from the blueprint, so putting it
+ * back with `restoreSpeciesRecord` restores the history rather than a creature
+ * that claims to have been discovered just now.
+ */
+export function forgetSpecies(id: string): SpeciesRecord | null {
+  const record = data.species[id]
+  if (!record) return null
+  delete data.species[id]
+  touch()
+  return record
+}
+
+/** Put a forgotten species back exactly as it was. The other half of undo. */
+export function restoreSpeciesRecord(record: SpeciesRecord): void {
+  data.species[record.blueprint.id] = record
+  touch()
+}
+
 /** Every archived species, newest sighting first. */
 export function archivedSpecies(): SpeciesRecord[] {
   return Object.values(data.species).sort((a, b) => b.lastSeen - a.lastSeen)
@@ -225,7 +380,7 @@ export function claimMilestone(id: string, now: number): boolean {
 }
 
 function pruneArchive(): void {
-  const summoned = Object.values(data.species).filter((s) => s.blueprint.summoned)
+  const summoned = Object.values(data.species).filter(s => s.blueprint.summoned)
   if (summoned.length <= MAX_ARCHIVED_SUMMONED) return
   summoned.sort((a, b) => a.lastSeen - b.lastSeen)
   const excess = summoned.length - MAX_ARCHIVED_SUMMONED
@@ -253,10 +408,7 @@ export function mergeChronicles(a: ChronicleData, b: ChronicleData): ChronicleDa
     const right = b.lands[id] ?? emptyLandRecord()
     const deeper = right.generations > left.generations ? right : left
     merged.lands[id] = {
-      elder:
-        (right.elder?.seconds ?? 0) > (left.elder?.seconds ?? 0)
-          ? right.elder
-          : left.elder,
+      elder: (right.elder?.seconds ?? 0) > (left.elder?.seconds ?? 0) ? right.elder : left.elder,
       steadySeconds: Math.max(left.steadySeconds, right.steadySeconds),
       generations: deeper.generations,
       generationsBlueprintId: deeper.generationsBlueprintId,

--- a/src/app/micro-land/chronicle/wire.ts
+++ b/src/app/micro-land/chronicle/wire.ts
@@ -1,0 +1,131 @@
+/**
+ * The chronicle on the wire.
+ *
+ * One definition of "what a chronicle looks like when it isn't in memory",
+ * shared by the client backend that sends it and the route that stores it. The
+ * server has to treat every byte as hostile — the payload is arbitrary JSON from
+ * a browser — and the client has to keep itself under the size the server will
+ * accept, so both ends need the same rules and neither should own them alone.
+ *
+ * Nothing here reaches into Firestore or `fetch`. It is pure enough to test,
+ * which is the point: the interesting failures are all shape and size, and both
+ * are much easier to get wrong than the transport around them.
+ */
+import { CHRONICLE_VERSION, type ChronicleData, emptyChronicle } from './types'
+
+/**
+ * The most a stored chronicle is allowed to weigh, in bytes of JSON.
+ *
+ * A Firestore field value caps at 1 MiB minus change. The headroom below that
+ * is deliberate and generous: the same document carries a few small scalar
+ * fields, and a chronicle that fails to write is one that silently stops
+ * recording, which the player would only discover much later.
+ *
+ * For scale — the archive holds at most 80 summoned species (see
+ * `MAX_ARCHIVED_SUMMONED`), and a big one runs a few kilobytes of pixel art. A
+ * full archive lands around a third of this.
+ */
+export const MAX_CHRONICLE_BYTES = 700_000
+
+/**
+ * JSON byte length, which is what the limit is actually about.
+ *
+ * `TextEncoder` rather than `Buffer.byteLength`, because this module is imported
+ * by the browser backend as well as the route and `Buffer` is not a thing there.
+ * Length in characters would not do either — a creature named with an emoji, or
+ * any of the accented names this game happily accepts, counts for more bytes
+ * than characters, and the limit being defended is a byte limit.
+ */
+const encoder = new TextEncoder()
+
+export function chronicleBytes(data: ChronicleData): number {
+  return encoder.encode(JSON.stringify(data)).length
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+/**
+ * Coerce untrusted input into a chronicle, or refuse it.
+ *
+ * Returns null rather than throwing, and rather than repairing: a payload this
+ * far off shape is a bug or an attack, not a chronicle to be salvaged, and the
+ * caller's fallback — "this player has no records yet" — is already correct for
+ * both. Note the deliberate asymmetry with `migrate` in `chronicle.ts`, which
+ * *does* repair: that one is reading our own storage, this one is reading a POST
+ * body.
+ *
+ * The three collections are checked for shape but not for content. Their values
+ * are game records that the player's own client wrote and only that player will
+ * ever read back, so validating every field would be a large amount of code
+ * defending a document against its only reader.
+ */
+export function validateChronicle(value: unknown): ChronicleData | null {
+  if (!isPlainObject(value)) return null
+  if (value.version !== CHRONICLE_VERSION) return null
+
+  const { lands, species, milestones } = value
+  if (!isPlainObject(lands) || !isPlainObject(species) || !isPlainObject(milestones)) {
+    return null
+  }
+
+  return {
+    version: CHRONICLE_VERSION,
+    lands: lands as ChronicleData['lands'],
+    species: species as ChronicleData['species'],
+    milestones: milestones as ChronicleData['milestones'],
+  }
+}
+
+/** Parse and validate in one step, for reading a stored JSON string back. */
+export function decodeChronicle(raw: unknown): ChronicleData | null {
+  if (typeof raw !== 'string') return null
+  try {
+    return validateChronicle(JSON.parse(raw))
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Shed archived species until the chronicle fits, oldest sighting first.
+ *
+ * The archive is already capped at 80 summoned species, so this should never
+ * fire — it exists because "should never" and "cannot" are different, and the
+ * failure it guards against is a write the server rejects, which stops the
+ * chronicle recording anything at all. Losing the least recently seen creature
+ * is a far better outcome than losing every future record.
+ *
+ * Built-in species are dropped only once no summoned one is left, since a
+ * built-in can always be recovered by playing whereas a summoned one cannot.
+ * Land records and milestones are never touched: they are small, and they are
+ * the part of the chronicle the player actually earned.
+ */
+export function fitChronicle(data: ChronicleData): ChronicleData {
+  if (chronicleBytes(data) <= MAX_CHRONICLE_BYTES) return data
+
+  const trimmed: ChronicleData = {
+    version: data.version,
+    lands: data.lands,
+    species: { ...data.species },
+    milestones: data.milestones,
+  }
+
+  const order = Object.values(trimmed.species).sort((a, b) => {
+    // Summoned creatures are the ones worth keeping, so they leave last.
+    if (a.blueprint.summoned !== b.blueprint.summoned) {
+      return a.blueprint.summoned ? 1 : -1
+    }
+    return a.lastSeen - b.lastSeen
+  })
+
+  for (const record of order) {
+    if (chronicleBytes(trimmed) <= MAX_CHRONICLE_BYTES) break
+    delete trimmed.species[record.blueprint.id]
+  }
+
+  // Even an empty archive can overflow if `lands` has been tampered with. The
+  // caller gets something storable rather than something rejected.
+  return chronicleBytes(trimmed) <= MAX_CHRONICLE_BYTES ? trimmed : emptyChronicle()
+}

--- a/src/app/micro-land/components/creature-builder.tsx
+++ b/src/app/micro-land/components/creature-builder.tsx
@@ -1,0 +1,1080 @@
+'use client'
+
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+import { sanitizeBlueprint } from '@/app/micro-land/domain/blueprint'
+import {
+  BODY_PLANS,
+  CANVAS_SIZES,
+  DEFAULT_INKS,
+  DIET_CHOICES,
+  type DietId,
+  type Draft,
+  FRAME_SPEEDS,
+  INK_NAMES,
+  MAX_DRAFT_FRAMES,
+  type PlanId,
+  SIZE_WORDS,
+  blankDraft,
+  buildRawCreature,
+  dietOf,
+  draftFromBlueprint,
+  floodFill,
+  inkBounds,
+  planOf,
+  resizeDraft,
+  sizeForWidth,
+  trimDraft,
+} from '@/app/micro-land/domain/creature-kit'
+import type { CreatureBlueprint } from '@/app/micro-land/domain/types'
+import { useMicroLand } from '@/app/micro-land/store'
+
+import { CreaturePortrait } from './creature-chip'
+import { PixelCanvas } from './pixel-canvas'
+import { SparkleIcon } from './sparkle-icon'
+import { SummonLoader } from './summon-loader'
+
+/**
+ * The creature builder.
+ *
+ * Summoning hands you a finished creature. This hands you the pencil — and,
+ * because a blank grid is the least inviting thing in the world, it will draw a
+ * first attempt from a description so there is always something to change
+ * rather than something to start.
+ *
+ * Only the pixels are drawn here. Everything else a creature needs comes from
+ * four choices — how it moves, what it eats, whether it glows, whether fire
+ * hurts it — and one number read straight off the drawing: how big it is. The
+ * rest of the blueprint is inherited from whatever the drawing started from, so
+ * recolouring a summoned creature keeps the parts of it that no canvas can
+ * express.
+ */
+
+const IDEAS = [
+  'a tiny glowing snail',
+  'a fat orange fish',
+  'a paper bird',
+  'a mushroom with a face',
+  'a spiky purple beetle',
+]
+
+/** How many to drop into the world the moment it is finished. */
+const PLACE_COUNT = 4
+
+type PaintTool = 'draw' | 'fill' | 'erase' | 'pick'
+
+const TOOLS: { id: PaintTool; label: string; glyph: string }[] = [
+  { id: 'draw', label: 'Draw', glyph: '✎' },
+  { id: 'fill', label: 'Fill', glyph: '▨' },
+  { id: 'erase', label: 'Rub out', glyph: '⌫' },
+  { id: 'pick', label: 'Copy colour', glyph: '⊙' },
+]
+
+/** Undo depth. Deep enough to walk back a bad idea, shallow enough to be free. */
+const MAX_HISTORY = 40
+
+const REDUCED_MOTION = '(prefers-reduced-motion: reduce)'
+
+function inkName(hex: string): string {
+  return INK_NAMES[hex] ?? hex
+}
+
+/** The palette to open with: the drawing's own colours first, then the basics. */
+function inksFor(draft: Draft): string[] {
+  const used: string[] = []
+  for (const cells of draft.frames) {
+    for (const hex of cells) {
+      if (hex && !used.includes(hex)) used.push(hex)
+    }
+  }
+  return [...used, ...DEFAULT_INKS.filter(hex => !used.includes(hex))].slice(0, 18)
+}
+
+export function CreatureBuilder({
+  onIntroduce,
+}: {
+  onIntroduce: (
+    raw: unknown,
+    count: number
+  ) => { blueprint: CreatureBlueprint; placed: number } | null
+}) {
+  const open = useMicroLand(s => s.builderOpen)
+  const setOpen = useMicroLand(s => s.setBuilderOpen)
+  const blueprints = useMicroLand(s => s.blueprints)
+  const setTool = useMicroLand(s => s.setTool)
+  const notify = useMicroLand(s => s.notify)
+
+  const [draft, setDraft] = useState<Draft | null>(null)
+  const [seed, setSeed] = useState<CreatureBlueprint | null>(null)
+  const [name, setName] = useState('')
+  const [frame, setFrame] = useState(0)
+  const [tool, setPaintTool] = useState<PaintTool>('draw')
+  const [inks, setInks] = useState<string[]>(DEFAULT_INKS)
+  const [color, setColor] = useState(DEFAULT_INKS[6])
+  const [onion, setOnion] = useState(true)
+  const [planId, setPlanId] = useState<PlanId>('walk')
+  const [dietId, setDietId] = useState<DietId>('plant')
+  const [glows, setGlows] = useState(false)
+  const [fireproof, setFireproof] = useState(false)
+
+  const [past, setPast] = useState<Draft[]>([])
+  const [future, setFuture] = useState<Draft[]>([])
+
+  const [prompt, setPrompt] = useState('')
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const abortRef = useRef<AbortController | null>(null)
+  const openerRef = useRef<HTMLElement | null>(null)
+
+  // The panel closes out from under whatever opened it, so focus has to go back
+  // rather than to the top of the page.
+  useEffect(() => {
+    if (open) {
+      openerRef.current = document.activeElement as HTMLElement | null
+      return
+    }
+    openerRef.current?.focus()
+    openerRef.current = null
+  }, [open])
+
+  useEffect(() => {
+    if (!open) return
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key !== 'Escape') return
+      abortRef.current?.abort()
+      setOpen(false)
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [open, setOpen])
+
+  useEffect(() => () => abortRef.current?.abort(), [])
+
+  /** Adopt a drawing and everything that came with it. */
+  const adopt = useCallback((next: Draft, from: CreatureBlueprint | null) => {
+    setDraft(next)
+    setSeed(from)
+    setPast([])
+    setFuture([])
+    setFrame(0)
+    const palette = inksFor(next)
+    setInks(palette)
+    setColor(palette[0] ?? DEFAULT_INKS[6])
+    if (from) {
+      setName(from.name)
+      setPlanId(planOf(from))
+      setDietId(dietOf(from))
+      setGlows(from.glow > 0)
+      setFireproof(from.body.immuneTo.includes('lava'))
+    } else {
+      setName('')
+      setPlanId('walk')
+      setDietId('plant')
+      setGlows(false)
+      setFireproof(false)
+    }
+  }, [])
+
+  /**
+   * Snapshot for undo.
+   *
+   * Reads `draft` out of the closure rather than out of a state updater: every
+   * caller is an event handler, so the closure is already current, and React
+   * is free to run an updater more than once — which would push the same
+   * snapshot twice and make undo take two presses.
+   */
+  const pushHistory = useCallback(() => {
+    if (!draft) return
+    setPast(p => [...p, draft].slice(-MAX_HISTORY))
+    setFuture([])
+  }, [draft])
+
+  const paint = useCallback(
+    (index: number, first: boolean) => {
+      if (tool === 'pick') {
+        const hex = first ? draft?.frames[frame][index] : null
+        if (hex) {
+          setColor(hex)
+          setInks(list => (list.includes(hex) ? list : appendInk(list, hex)))
+        }
+        return
+      }
+
+      if (first) pushHistory()
+      const value = tool === 'erase' ? null : color
+
+      setDraft(prev => {
+        if (!prev) return prev
+        const cells = prev.frames[frame]
+        let next: (string | null)[]
+
+        if (tool === 'fill') {
+          next = floodFill(cells, prev.w, prev.h, index, value)
+        } else {
+          if (cells[index] === value) return prev
+          next = cells.slice()
+          next[index] = value
+        }
+
+        if (next === cells) return prev
+        const frames = prev.frames.slice()
+        frames[frame] = next
+        return { ...prev, frames }
+      })
+    },
+    [tool, color, frame, draft, pushHistory]
+  )
+
+  const undo = useCallback(() => {
+    if (past.length === 0 || !draft) return
+    setFuture(f => [draft, ...f].slice(0, MAX_HISTORY))
+    setDraft(past[past.length - 1])
+    setPast(p => p.slice(0, -1))
+  }, [past, draft])
+
+  const redo = useCallback(() => {
+    if (future.length === 0 || !draft) return
+    setPast(p => [...p, draft].slice(-MAX_HISTORY))
+    setDraft(future[0])
+    setFuture(f => f.slice(1))
+  }, [future, draft])
+
+  /** Ask for a first attempt. Same route, same model, same sanitizer as summoning. */
+  async function drawFromPrompt() {
+    const description = prompt.trim()
+    if (description.length < 2 || busy) return
+
+    setBusy(true)
+    setError(null)
+    const controller = new AbortController()
+    abortRef.current = controller
+
+    try {
+      const response = await fetch('/api/v1/micro-land/summon', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ mode: 'creature', prompt: description }),
+        signal: controller.signal,
+      })
+      if (!response.ok) throw new Error('That did not come through. Try again.')
+      const data = (await response.json()) as { blueprint?: unknown }
+      const blueprint = sanitizeBlueprint(data.blueprint, { summoned: true })
+      adopt(draftFromBlueprint(blueprint), blueprint)
+    } catch (err) {
+      if (err instanceof DOMException && err.name === 'AbortError') return
+      setError('Nothing came through. Try describing it a different way.')
+    } finally {
+      abortRef.current = null
+      setBusy(false)
+    }
+  }
+
+  function bringToLife() {
+    if (!draft || empty) return
+    const raw = buildRawCreature({ name, draft, planId, dietId, glows, fireproof, seed })
+    const result = onIntroduce(raw, PLACE_COUNT)
+    if (!result) {
+      setError('It would not hold together. Try again.')
+      return
+    }
+    setTool({ kind: 'creature', blueprintId: result.blueprint.id })
+    notify(`${result.blueprint.name} steps out of the drawing.`)
+    setOpen(false)
+  }
+
+  // Both walk every pixel of every frame. `draft` is replaced rather than
+  // mutated, so the compiler's own memoization keys off it exactly and neither
+  // re-runs on the cells of a drag that didn't change it.
+  const empty = draft === null || inkBounds(draft) === null
+  const trimmed = draft ? trimDraft(draft) : null
+  const size = trimmed && !empty ? sizeForWidth(trimmed.w) : 0
+
+  const describe = useCallback(
+    (index: number) => {
+      if (!draft) return ''
+      const x = (index % draft.w) + 1
+      const y = ((index / draft.w) | 0) + 1
+      const hex = draft.frames[frame][index]
+      return `Row ${y}, column ${x}, ${hex ? inkName(hex) : 'empty'}`
+    },
+    [draft, frame]
+  )
+
+  if (!open) return null
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-end justify-center sm:items-center"
+      style={{ background: 'var(--cc-modal-scrim)' }}
+      onClick={() => !busy && setOpen(false)}
+    >
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label="Creature builder"
+        className="w-full max-w-md overflow-y-auto rounded-t-xl md:max-w-3xl md:rounded-xl"
+        style={{
+          maxHeight: '92dvh',
+          background: 'linear-gradient(180deg, var(--cc-modal-bg-from), var(--cc-modal-bg-to))',
+          border: '1px solid var(--cc-modal-border)',
+        }}
+        onClick={e => e.stopPropagation()}
+      >
+        <div
+          className="flex items-center justify-between px-4 py-3"
+          style={{ borderBottom: '1px solid var(--cc-panel-divider)' }}
+        >
+          <h2 style={heading}>✎ Creature Builder</h2>
+          <button
+            type="button"
+            className="cc-btn"
+            onClick={() => {
+              abortRef.current?.abort()
+              setOpen(false)
+            }}
+            aria-label="Close"
+            style={{ minWidth: 44, minHeight: 34, color: 'var(--cc-text-muted)' }}
+          >
+            ✕
+          </button>
+        </div>
+
+        {busy ? (
+          // The same wait the summon panel shows. Drawing a first attempt is the
+          // same model call taking the same minute, so it gets the same sand —
+          // two different loaders for one wait read as two different features.
+          <div className="flex flex-col items-center">
+            <SummonLoader
+              mode="creature"
+              prompt={prompt.trim()}
+              onCancel={() => abortRef.current?.abort()}
+            />
+            <p
+              style={{
+                fontSize: 13,
+                color: 'var(--cc-text-muted)',
+                textAlign: 'center',
+                padding: '0 16px 16px',
+              }}
+            >
+              You can change every pixel of it afterwards.
+            </p>
+          </div>
+        ) : !draft ? (
+          <StartStep
+            prompt={prompt}
+            setPrompt={setPrompt}
+            onDraw={() => void drawFromPrompt()}
+            onBlank={(w, h) => adopt(blankDraft(w, h), null)}
+            onCopy={bp => adopt(draftFromBlueprint(bp), bp)}
+            blueprints={blueprints}
+            error={error}
+          />
+        ) : (
+          <div className="flex flex-col gap-4 p-4 md:flex-row md:items-start">
+            {/* ---- the drawing ---- */}
+            <div className="flex min-w-0 flex-1 flex-col gap-3">
+              <PixelCanvas
+                w={draft.w}
+                h={draft.h}
+                cells={draft.frames[frame]}
+                ghost={
+                  onion && draft.frames.length > 1
+                    ? draft.frames[(frame + 1) % draft.frames.length]
+                    : null
+                }
+                onPaint={paint}
+                describe={describe}
+                label={`Drawing of ${name || 'a new creature'}, ${draft.w} squares across and ${draft.h} down.`}
+              />
+
+              <div
+                className="flex flex-wrap items-center gap-1.5"
+                role="group"
+                aria-label="Drawing tools"
+              >
+                {TOOLS.map(t => (
+                  <button
+                    key={t.id}
+                    type="button"
+                    className="cc-btn"
+                    onClick={() => setPaintTool(t.id)}
+                    aria-pressed={tool === t.id}
+                    style={chipStyle(tool === t.id)}
+                  >
+                    <span aria-hidden style={{ marginRight: 5 }}>
+                      {t.glyph}
+                    </span>
+                    {t.label}
+                  </button>
+                ))}
+                <span className="flex-1" />
+                <button
+                  type="button"
+                  className="cc-btn"
+                  onClick={undo}
+                  disabled={past.length === 0}
+                  aria-label="Undo"
+                  style={{ ...chipStyle(false), opacity: past.length === 0 ? 0.35 : 1 }}
+                >
+                  ↶
+                </button>
+                <button
+                  type="button"
+                  className="cc-btn"
+                  onClick={redo}
+                  disabled={future.length === 0}
+                  aria-label="Redo"
+                  style={{ ...chipStyle(false), opacity: future.length === 0 ? 0.35 : 1 }}
+                >
+                  ↷
+                </button>
+              </div>
+
+              <div>
+                <span style={label}>Colours</span>
+                <div className="mt-1.5 flex flex-wrap items-center gap-1.5">
+                  {inks.map(hex => {
+                    const selected = hex === color && tool !== 'erase'
+                    return (
+                      <button
+                        key={hex}
+                        type="button"
+                        className="cc-btn"
+                        onClick={() => {
+                          setColor(hex)
+                          if (tool === 'erase' || tool === 'pick') setPaintTool('draw')
+                        }}
+                        aria-pressed={selected}
+                        aria-label={inkName(hex)}
+                        title={inkName(hex)}
+                        style={{
+                          width: 32,
+                          height: 32,
+                          display: 'grid',
+                          placeItems: 'center',
+                          borderRadius: 999,
+                          border: `2px solid ${selected ? 'var(--cc-mint)' : 'transparent'}`,
+                          background: 'transparent',
+                        }}
+                      >
+                        <span
+                          aria-hidden
+                          style={{
+                            display: 'block',
+                            width: 21,
+                            height: 21,
+                            borderRadius: 999,
+                            background: hex,
+                            boxShadow: 'inset 0 0 0 1px rgba(0,0,0,0.4)',
+                          }}
+                        />
+                      </button>
+                    )
+                  })}
+                  <label
+                    title="Mix your own colour"
+                    style={{
+                      width: 32,
+                      height: 32,
+                      display: 'grid',
+                      placeItems: 'center',
+                      borderRadius: 999,
+                      border: '1px dashed var(--cc-mint-line)',
+                      cursor: 'pointer',
+                    }}
+                  >
+                    <span aria-hidden style={{ fontSize: 13, color: 'var(--cc-text-muted)' }}>
+                      +
+                    </span>
+                    <input
+                      type="color"
+                      value={color}
+                      aria-label="Mix your own colour"
+                      onChange={e => {
+                        const hex = e.target.value.toLowerCase()
+                        setColor(hex)
+                        setInks(list => (list.includes(hex) ? list : appendInk(list, hex)))
+                        if (tool === 'erase' || tool === 'pick') setPaintTool('draw')
+                      }}
+                      style={{ position: 'absolute', width: 1, height: 1, opacity: 0 }}
+                    />
+                  </label>
+                </div>
+              </div>
+
+              <div>
+                <span style={label}>Frames</span>
+                <div className="mt-1.5 flex flex-wrap items-center gap-1.5">
+                  {draft.frames.map((_, i) => (
+                    <button
+                      key={i}
+                      type="button"
+                      className="cc-btn"
+                      onClick={() => setFrame(i)}
+                      aria-pressed={frame === i}
+                      style={chipStyle(frame === i)}
+                    >
+                      {i + 1}
+                    </button>
+                  ))}
+                  {draft.frames.length < MAX_DRAFT_FRAMES && (
+                    <button
+                      type="button"
+                      className="cc-btn"
+                      title="Add a frame — a copy of this one, so you can nudge it"
+                      onClick={() => {
+                        pushHistory()
+                        setDraft(prev =>
+                          prev
+                            ? { ...prev, frames: [...prev.frames, prev.frames[frame].slice()] }
+                            : prev
+                        )
+                        setFrame(draft.frames.length)
+                      }}
+                      style={chipStyle(false)}
+                    >
+                      + Frame
+                    </button>
+                  )}
+                  {draft.frames.length > 1 && (
+                    <button
+                      type="button"
+                      className="cc-btn"
+                      onClick={() => {
+                        pushHistory()
+                        setDraft(prev =>
+                          prev
+                            ? { ...prev, frames: prev.frames.filter((_, i) => i !== frame) }
+                            : prev
+                        )
+                        setFrame(f => Math.max(0, f - 1))
+                      }}
+                      style={chipStyle(false)}
+                    >
+                      − Frame
+                    </button>
+                  )}
+                  <button
+                    type="button"
+                    className="cc-btn"
+                    onClick={() => setOnion(v => !v)}
+                    aria-pressed={onion}
+                    title="Show the next frame faintly underneath"
+                    style={chipStyle(onion)}
+                  >
+                    Ghost
+                  </button>
+                </div>
+                <p style={{ ...note, marginTop: 6 }}>
+                  {draft.frames.length > 1
+                    ? 'Make each frame a small change from the last — a step, a blink, a wing beat.'
+                    : 'Add a second frame to make it move.'}
+                </p>
+              </div>
+
+              <div className="flex flex-wrap items-center gap-1.5">
+                <span style={label}>Speed</span>
+                {FRAME_SPEEDS.map(speed => (
+                  <button
+                    key={speed.id}
+                    type="button"
+                    className="cc-btn"
+                    onClick={() => setDraft(prev => (prev ? { ...prev, frameMs: speed.ms } : prev))}
+                    aria-pressed={draft.frameMs === speed.ms}
+                    style={chipStyle(draft.frameMs === speed.ms)}
+                  >
+                    {speed.label}
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            {/* ---- what it is ---- */}
+            <div className="flex w-full flex-col gap-3 md:w-[250px] md:shrink-0">
+              <div
+                className="flex items-center gap-3 rounded-lg p-3"
+                style={{ background: 'rgba(94,234,212,0.06)' }}
+              >
+                <DraftPreview art={trimmed as Draft} />
+                <div className="min-w-0">
+                  <input
+                    value={name}
+                    onChange={e => setName(e.target.value)}
+                    maxLength={32}
+                    placeholder="Name it"
+                    aria-label="Creature name"
+                    style={{
+                      width: '100%',
+                      padding: '6px 8px',
+                      borderRadius: 4,
+                      fontFamily: 'var(--cc-font-mono)',
+                      fontSize: 12,
+                      letterSpacing: 1,
+                      textTransform: 'uppercase',
+                      background: 'rgba(0,0,0,0.35)',
+                      border: '1px solid var(--cc-mint-line)',
+                      color: 'var(--cc-mint)',
+                    }}
+                  />
+                  <div style={{ ...note, marginTop: 5 }}>
+                    {empty ? 'Nothing drawn yet' : `Size ${size} — ${SIZE_WORDS[size]}`}
+                  </div>
+                </div>
+              </div>
+
+              <div>
+                <span style={label}>Canvas</span>
+                <div className="mt-1.5 flex flex-wrap gap-1.5">
+                  {CANVAS_SIZES.map(option => {
+                    const selected = draft.w === option.w && draft.h === option.h
+                    return (
+                      <button
+                        key={option.id}
+                        type="button"
+                        className="cc-btn"
+                        onClick={() => {
+                          if (selected) return
+                          pushHistory()
+                          setDraft(prev => (prev ? resizeDraft(prev, option.w, option.h) : prev))
+                        }}
+                        aria-pressed={selected}
+                        style={chipStyle(selected)}
+                      >
+                        {option.label}
+                      </button>
+                    )
+                  })}
+                </div>
+                <p style={{ ...note, marginTop: 6 }}>
+                  How much of the canvas you fill decides how big it is in the world.
+                </p>
+              </div>
+
+              <div>
+                <span style={label}>How it moves</span>
+                <div className="mt-1.5 flex flex-wrap gap-1.5">
+                  {BODY_PLANS.map(plan => (
+                    <button
+                      key={plan.id}
+                      type="button"
+                      className="cc-btn"
+                      onClick={() => setPlanId(plan.id)}
+                      aria-pressed={planId === plan.id}
+                      title={plan.hint}
+                      style={chipStyle(planId === plan.id)}
+                    >
+                      {plan.label}
+                    </button>
+                  ))}
+                </div>
+                <p style={{ ...note, marginTop: 6 }}>
+                  {BODY_PLANS.find(p => p.id === planId)?.hint}
+                </p>
+              </div>
+
+              {planId !== 'root' && (
+                <div>
+                  <span style={label}>What it eats</span>
+                  <div className="mt-1.5 flex flex-wrap gap-1.5">
+                    {DIET_CHOICES.map(choice => (
+                      <button
+                        key={choice.id}
+                        type="button"
+                        className="cc-btn"
+                        onClick={() => setDietId(choice.id)}
+                        aria-pressed={dietId === choice.id}
+                        title={choice.hint}
+                        style={chipStyle(dietId === choice.id)}
+                      >
+                        {choice.label}
+                      </button>
+                    ))}
+                  </div>
+                  <p style={{ ...note, marginTop: 6 }}>
+                    {DIET_CHOICES.find(c => c.id === dietId)?.hint}
+                  </p>
+                </div>
+              )}
+
+              <div className="flex flex-wrap gap-1.5">
+                <button
+                  type="button"
+                  className="cc-btn"
+                  onClick={() => setGlows(v => !v)}
+                  aria-pressed={glows}
+                  style={chipStyle(glows)}
+                >
+                  ✦ Glows in the dark
+                </button>
+                <button
+                  type="button"
+                  className="cc-btn"
+                  onClick={() => setFireproof(v => !v)}
+                  aria-pressed={fireproof}
+                  style={chipStyle(fireproof)}
+                >
+                  ▲ Lava can’t hurt it
+                </button>
+              </div>
+
+              {error && (
+                <p style={{ fontSize: 13, color: 'var(--cc-pink)' }} role="alert">
+                  {error}
+                </p>
+              )}
+
+              <button
+                type="button"
+                className="cc-btn"
+                onClick={bringToLife}
+                disabled={empty}
+                style={{
+                  display: 'inline-flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  gap: 8,
+                  fontFamily: 'var(--cc-font-mono)',
+                  fontSize: 11,
+                  fontWeight: 700,
+                  letterSpacing: 2,
+                  textTransform: 'uppercase',
+                  padding: '13px 22px',
+                  minHeight: 48,
+                  borderRadius: 5,
+                  background: 'linear-gradient(180deg, var(--cc-mint), var(--cc-mint-hi))',
+                  border: '1px solid var(--cc-mint)',
+                  color: 'var(--cc-on-mint)',
+                  boxShadow: 'var(--cc-mint-glow)',
+                  opacity: empty ? 0.4 : 1,
+                }}
+              >
+                <SparkleIcon size={13} />
+                Bring it to life
+              </button>
+
+              <button
+                type="button"
+                className="cc-btn"
+                onClick={() => {
+                  setDraft(null)
+                  setSeed(null)
+                  setPast([])
+                  setFuture([])
+                  setError(null)
+                }}
+                style={{ ...ghostButton, minHeight: 36 }}
+              >
+                ← Start again
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Start
+// ---------------------------------------------------------------------------
+
+function StartStep({
+  prompt,
+  setPrompt,
+  onDraw,
+  onBlank,
+  onCopy,
+  blueprints,
+  error,
+}: {
+  prompt: string
+  setPrompt: (value: string) => void
+  onDraw: () => void
+  onBlank: (w: number, h: number) => void
+  onCopy: (bp: CreatureBlueprint) => void
+  blueprints: CreatureBlueprint[]
+  error: string | null
+}) {
+  const inputRef = useRef<HTMLInputElement>(null)
+  useEffect(() => inputRef.current?.focus(), [])
+
+  return (
+    <div className="flex flex-col gap-3 p-4">
+      <p style={{ fontSize: 13, color: 'var(--cc-text-muted)', lineHeight: 1.5 }}>
+        Colour it in yourself, one square at a time. Start from nothing, or describe something and
+        get a first sketch you can change every pixel of.
+      </p>
+
+      <div className="flex gap-1.5">
+        <input
+          ref={inputRef}
+          value={prompt}
+          onChange={e => setPrompt(e.target.value)}
+          onKeyDown={e => {
+            if (e.key === 'Enter') onDraw()
+          }}
+          maxLength={300}
+          placeholder={IDEAS[0]}
+          aria-label="Describe something to sketch"
+          style={{
+            flex: 1,
+            minWidth: 0,
+            padding: '12px 14px',
+            minHeight: 46,
+            borderRadius: 5,
+            fontSize: 15,
+            background: 'rgba(0,0,0,0.35)',
+            border: '1px solid var(--cc-mint-line)',
+            color: 'var(--cc-text-default)',
+          }}
+        />
+        <button
+          type="button"
+          className="cc-btn"
+          onClick={onDraw}
+          disabled={prompt.trim().length < 2}
+          style={{
+            display: 'inline-flex',
+            alignItems: 'center',
+            gap: 6,
+            fontFamily: 'var(--cc-font-mono)',
+            fontSize: 10,
+            fontWeight: 700,
+            letterSpacing: 1.4,
+            textTransform: 'uppercase',
+            padding: '0 14px',
+            minHeight: 46,
+            borderRadius: 5,
+            background: 'linear-gradient(180deg, var(--cc-mint), var(--cc-mint-hi))',
+            border: '1px solid var(--cc-mint)',
+            color: 'var(--cc-on-mint)',
+            boxShadow: 'var(--cc-mint-glow)',
+            opacity: prompt.trim().length < 2 ? 0.4 : 1,
+            whiteSpace: 'nowrap',
+          }}
+        >
+          <SparkleIcon size={12} />
+          Sketch it
+        </button>
+      </div>
+
+      <div className="flex flex-wrap gap-1.5">
+        {IDEAS.map(idea => (
+          <button
+            key={idea}
+            type="button"
+            className="cc-btn"
+            onClick={() => setPrompt(idea)}
+            style={{
+              fontSize: 11,
+              padding: '6px 10px',
+              minHeight: 32,
+              borderRadius: 999,
+              border: '1px solid var(--cc-mint-line)',
+              color: 'var(--cc-text-muted)',
+            }}
+          >
+            {idea}
+          </button>
+        ))}
+      </div>
+
+      {error && (
+        <p style={{ fontSize: 13, color: 'var(--cc-pink)' }} role="alert">
+          {error}
+        </p>
+      )}
+
+      <div style={rule} />
+
+      <div>
+        <span style={label}>Or start from an empty canvas</span>
+        <div className="mt-1.5 flex flex-wrap gap-1.5">
+          {CANVAS_SIZES.map(option => (
+            <button
+              key={option.id}
+              type="button"
+              className="cc-btn"
+              onClick={() => onBlank(option.w, option.h)}
+              style={chipStyle(false)}
+            >
+              {option.label}
+              <span style={{ opacity: 0.5, marginLeft: 6 }}>
+                {option.w}×{option.h}
+              </span>
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {blueprints.length > 0 && (
+        <>
+          <div style={rule} />
+          <div>
+            <span style={label}>Or change one that already exists</span>
+            <div
+              className="-mx-1 mt-1.5 flex flex-wrap gap-1.5 overflow-y-auto px-1"
+              style={{ maxHeight: '22vh' }}
+            >
+              {blueprints.map(bp => (
+                <button
+                  key={bp.id}
+                  type="button"
+                  className="cc-btn shrink-0"
+                  onClick={() => onCopy(bp)}
+                  title={bp.blurb}
+                  style={{
+                    display: 'flex',
+                    flexDirection: 'column',
+                    alignItems: 'center',
+                    gap: 4,
+                    padding: '6px 8px',
+                    minWidth: 62,
+                    minHeight: 44,
+                    borderRadius: 5,
+                    border: `1px solid ${bp.summoned ? 'var(--cc-pink-border)' : 'var(--cc-mint-line)'}`,
+                    background: 'rgba(255,255,255,0.02)',
+                  }}
+                >
+                  <span style={{ height: 34, display: 'grid', placeItems: 'center' }}>
+                    <CreaturePortrait blueprint={bp} size={34} />
+                  </span>
+                  <span
+                    style={{
+                      fontFamily: 'var(--cc-font-mono)',
+                      fontSize: 8,
+                      letterSpacing: 0.8,
+                      textTransform: 'uppercase',
+                      whiteSpace: 'nowrap',
+                      opacity: 0.75,
+                    }}
+                  >
+                    {bp.name}
+                  </span>
+                </button>
+              ))}
+            </div>
+          </div>
+        </>
+      )}
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Preview
+// ---------------------------------------------------------------------------
+
+/**
+ * The drawing, animating, at the size it will actually be seen.
+ *
+ * Shows the trimmed art rather than the canvas, because the blank margin is not
+ * part of the creature and seeing it padded is misleading about the size.
+ */
+function DraftPreview({ art }: { art: Draft }) {
+  const [step, setStep] = useState(0)
+  const [still, setStill] = useState(
+    () => typeof window !== 'undefined' && window.matchMedia(REDUCED_MOTION).matches
+  )
+
+  useEffect(() => {
+    const query = window.matchMedia(REDUCED_MOTION)
+    const sync = () => setStill(query.matches)
+    query.addEventListener('change', sync)
+    return () => query.removeEventListener('change', sync)
+  }, [])
+
+  const count = art.frames.length
+
+  useEffect(() => {
+    if (still || count < 2) return
+    const timer = window.setInterval(() => setStep(s => s + 1), Math.max(60, art.frameMs))
+    return () => window.clearInterval(timer)
+  }, [still, count, art.frameMs])
+
+  const cells = art.frames[step % count]
+  const scale = Math.min(52 / art.w, 52 / art.h)
+
+  return (
+    <svg
+      viewBox={`0 0 ${art.w} ${art.h}`}
+      width={art.w * scale}
+      height={art.h * scale}
+      shapeRendering="crispEdges"
+      aria-hidden
+      focusable="false"
+      style={{ display: 'block', flexShrink: 0 }}
+    >
+      {cells.map((hex, i) =>
+        hex ? (
+          <rect key={i} x={i % art.w} y={(i / art.w) | 0} width={1} height={1} fill={hex} />
+        ) : null
+      )}
+    </svg>
+  )
+}
+
+// ---------------------------------------------------------------------------
+
+function appendInk(list: string[], hex: string): string[] {
+  // Grow the palette rather than shuffling it — a swatch that moves out from
+  // under a finger mid-drawing is worse than one that never appears.
+  if (list.length < 18) return [...list, hex]
+  return [...list.slice(0, -1), hex]
+}
+
+const heading: React.CSSProperties = {
+  fontFamily: 'var(--cc-font-mono)',
+  fontSize: 11,
+  letterSpacing: 2.5,
+  textTransform: 'uppercase',
+  color: 'var(--cc-mint)',
+}
+
+const label: React.CSSProperties = {
+  fontFamily: 'var(--cc-font-mono)',
+  fontSize: 9,
+  letterSpacing: 1.6,
+  textTransform: 'uppercase',
+  opacity: 0.5,
+}
+
+const note: React.CSSProperties = {
+  fontSize: 11,
+  color: 'var(--cc-text-muted)',
+  lineHeight: 1.45,
+}
+
+const rule: React.CSSProperties = {
+  height: 1,
+  background: 'var(--cc-panel-divider)',
+}
+
+const ghostButton: React.CSSProperties = {
+  fontFamily: 'var(--cc-font-mono)',
+  fontSize: 10,
+  letterSpacing: 1.4,
+  textTransform: 'uppercase',
+  padding: '8px 14px',
+  borderRadius: 4,
+  border: '1px solid var(--cc-mint-line)',
+  color: 'var(--cc-text-muted)',
+  background: 'transparent',
+}
+
+function chipStyle(selected: boolean): React.CSSProperties {
+  return {
+    fontFamily: 'var(--cc-font-mono)',
+    fontSize: 10,
+    letterSpacing: 1.1,
+    textTransform: 'uppercase',
+    padding: '7px 11px',
+    minHeight: 34,
+    borderRadius: 4,
+    border: `1px solid ${selected ? 'var(--cc-mint)' : 'var(--cc-mint-line)'}`,
+    background: selected ? 'var(--cc-mint-soft)' : 'transparent',
+    color: selected ? 'var(--cc-mint)' : 'var(--cc-text-muted)',
+  }
+}

--- a/src/app/micro-land/components/creature-chip.tsx
+++ b/src/app/micro-land/components/creature-chip.tsx
@@ -63,7 +63,7 @@ export function CreaturePortrait({
       focusable="false"
       style={{ display: 'block', overflow: 'visible' }}
     >
-      {toRuns(blueprint).map((run) => (
+      {toRuns(blueprint).map(run => (
         <rect
           key={`${run.y}-${run.x}`}
           x={run.x}

--- a/src/app/micro-land/components/field-guide.tsx
+++ b/src/app/micro-land/components/field-guide.tsx
@@ -9,7 +9,6 @@ import { useMicroLand } from '@/app/micro-land/store'
 import { CreaturePortrait } from './creature-chip'
 import { SparkleIcon } from './sparkle-icon'
 
-
 const KIND_WORDS: Record<string, string> = {
   walk: 'walks',
   fly: 'flies',
@@ -48,30 +47,26 @@ const recordLabel: React.CSSProperties = {
  * whoever wants it.
  */
 export function FieldGuide() {
-  const open = useMicroLand((s) => s.guideOpen)
-  const setOpen = useMicroLand((s) => s.setGuideOpen)
-  const blueprints = useMicroLand((s) => s.blueprints)
-  const population = useMicroLand((s) => s.population)
-  const records = useMicroLand((s) => s.records)
-  const archive = useMicroLand((s) => s.archive)
-  const milestones = useMicroLand((s) => s.milestones)
+  const open = useMicroLand(s => s.guideOpen)
+  const setOpen = useMicroLand(s => s.setGuideOpen)
+  const blueprints = useMicroLand(s => s.blueprints)
+  const population = useMicroLand(s => s.population)
+  const records = useMicroLand(s => s.records)
+  const archive = useMicroLand(s => s.archive)
+  const milestones = useMicroLand(s => s.milestones)
 
   if (!open) return null
 
-  const counts = new Map(population.map((p) => [p.blueprintId, p.count]))
-  const ordered = [...blueprints].sort(
-    (a, b) => (counts.get(b.id) ?? 0) - (counts.get(a.id) ?? 0)
-  )
+  const counts = new Map(population.map(p => [p.blueprintId, p.count]))
+  const ordered = [...blueprints].sort((a, b) => (counts.get(b.id) ?? 0) - (counts.get(a.id) ?? 0))
 
   // Species the player has met before that aren't in this world — the reason a
   // summoned creature no longer dies with the tab it was invented in.
-  const here = new Set(blueprints.map((b) => b.id))
-  const remembered = archive.filter((s) => !here.has(s.blueprint.id))
+  const here = new Set(blueprints.map(b => b.id))
+  const remembered = archive.filter(s => !here.has(s.blueprint.id))
 
   const hasRecords =
-    records.elder !== null ||
-    records.bestSteadySeconds > 0 ||
-    records.bestGenerations > 1
+    records.elder !== null || records.bestSteadySeconds > 0 || records.bestGenerations > 1
 
   return (
     <div
@@ -89,7 +84,7 @@ export function FieldGuide() {
           background: 'linear-gradient(180deg, var(--cc-modal-bg-from), var(--cc-modal-bg-to))',
           border: '1px solid var(--cc-modal-border)',
         }}
-        onClick={(e) => e.stopPropagation()}
+        onClick={e => e.stopPropagation()}
       >
         <div
           className="sticky top-0 flex items-center justify-between px-4 py-3"
@@ -173,7 +168,7 @@ export function FieldGuide() {
         )}
 
         <ul className="flex flex-col">
-          {ordered.map((bp) => (
+          {ordered.map(bp => (
             <GuideEntry
               key={bp.id}
               bp={bp}
@@ -195,7 +190,7 @@ export function FieldGuide() {
               Kinds you have met before. None of them are in this land.
             </p>
             <ul className="flex flex-col">
-              {remembered.map((record) => (
+              {remembered.map(record => (
                 <RememberedEntry key={record.blueprint.id} record={record} />
               ))}
             </ul>
@@ -203,15 +198,12 @@ export function FieldGuide() {
         )}
 
         {milestones.length > 0 && (
-          <section
-            className="px-4 py-3"
-            style={{ borderTop: '1px solid var(--cc-panel-divider)' }}
-          >
+          <section className="px-4 py-3" style={{ borderTop: '1px solid var(--cc-panel-divider)' }}>
             <h3 className="pb-2" style={sectionHeading}>
               Things that have happened
             </h3>
             <ul className="flex flex-col gap-1.5">
-              {milestones.map((m) => (
+              {milestones.map(m => (
                 <li
                   key={m.id}
                   className="flex items-baseline justify-between gap-3"
@@ -247,8 +239,8 @@ function GuideEntry({
   alive: number
   blueprints: CreatureBlueprint[]
 }) {
-  const eats = blueprints.filter((other) => canEat(bp, other))
-  const eatenBy = blueprints.filter((other) => canEat(other, bp))
+  const eats = blueprints.filter(other => canEat(bp, other))
+  const eatenBy = blueprints.filter(other => canEat(other, bp))
 
   return (
     <li
@@ -300,9 +292,7 @@ function GuideEntry({
           )}
         </div>
 
-        <p style={{ fontSize: 13, color: 'var(--cc-text-muted)', marginTop: 2 }}>
-          {bp.blurb}
-        </p>
+        <p style={{ fontSize: 13, color: 'var(--cc-text-muted)', marginTop: 2 }}>{bp.blurb}</p>
 
         <p
           style={{
@@ -325,8 +315,7 @@ function GuideEntry({
                 bp.aura.helps.length > 0 &&
                   bp.aura.boost > 1 &&
                   `${bp.aura.helps.join(' and ')} nearby grow back faster`,
-                bp.aura.converts &&
-                  `turns ${bp.aura.converts.from} into ${bp.aura.converts.to}`,
+                bp.aura.converts && `turns ${bp.aura.converts.from} into ${bp.aura.converts.to}`,
               ]
                 .filter(Boolean)
                 .join(' · ')}
@@ -335,13 +324,13 @@ function GuideEntry({
           <br />
           <strong style={{ fontWeight: 600 }}>Eats:</strong>{' '}
           {eats.length > 0
-            ? eats.map((e) => e.name).join(', ')
+            ? eats.map(e => e.name).join(', ')
             : bp.move.kind === 'root'
               ? 'sunlight'
               : 'nothing here'}
           <br />
           <strong style={{ fontWeight: 600 }}>Eaten by:</strong>{' '}
-          {eatenBy.length > 0 ? eatenBy.map((e) => e.name).join(', ') : 'nothing here'}
+          {eatenBy.length > 0 ? eatenBy.map(e => e.name).join(', ') : 'nothing here'}
         </p>
       </div>
     </li>
@@ -395,9 +384,7 @@ function RememberedEntry({ record }: { record: SpeciesRecord }) {
             </span>
           )}
         </div>
-        <p style={{ fontSize: 12, color: 'var(--cc-text-muted)', marginTop: 1 }}>
-          {bp.blurb}
-        </p>
+        <p style={{ fontSize: 12, color: 'var(--cc-text-muted)', marginTop: 1 }}>{bp.blurb}</p>
         <p
           style={{
             fontFamily: 'var(--cc-font-mono)',

--- a/src/app/micro-land/components/hud.tsx
+++ b/src/app/micro-land/components/hud.tsx
@@ -2,6 +2,7 @@
 
 import { THEMES } from '@/app/micro-land/domain/config/themes'
 import { STEADY_SHOW_SECONDS } from '@/app/micro-land/domain/constants'
+import { TUNING_DEFAULTS, type TuningKey } from '@/app/micro-land/domain/tuning'
 import { formatDuration } from '@/app/micro-land/format'
 import { SUMMONED_THEME_ID, useMicroLand } from '@/app/micro-land/store'
 
@@ -30,6 +31,26 @@ const activeChip: React.CSSProperties = {
   color: 'var(--cc-mint)',
 }
 
+/**
+ * Three sliders, drawn on the same grid as everything else in the world.
+ *
+ * A gear would be the obvious icon and the wrong one: a gear means "app
+ * settings", and this opens the numbers the ecosystem runs on. Sliders say what
+ * is behind it.
+ */
+function SlidersIcon() {
+  return (
+    <svg width="13" height="13" viewBox="0 0 13 13" fill="currentColor" aria-hidden="true">
+      <rect x="0" y="2" width="13" height="1" />
+      <rect x="3" y="0" width="3" height="5" />
+      <rect x="0" y="6" width="13" height="1" />
+      <rect x="8" y="4" width="3" height="5" />
+      <rect x="0" y="10" width="13" height="1" />
+      <rect x="1" y="8" width="3" height="5" />
+    </svg>
+  )
+}
+
 export function Hud({
   onReshuffle,
   onClearLife,
@@ -37,17 +58,29 @@ export function Hud({
   onReshuffle: () => void
   onClearLife: () => void
 }) {
-  const themeId = useMicroLand((s) => s.themeId)
-  const setTheme = useMicroLand((s) => s.setTheme)
-  const paused = useMicroLand((s) => s.paused)
-  const togglePaused = useMicroLand((s) => s.togglePaused)
-  const speed = useMicroLand((s) => s.speed)
-  const setSpeed = useMicroLand((s) => s.setSpeed)
-  const total = useMicroLand((s) => s.totalCreatures)
-  const population = useMicroLand((s) => s.population)
-  const setGuideOpen = useMicroLand((s) => s.setGuideOpen)
-  const summonedLand = useMicroLand((s) => s.summonedLand)
-  const steadySeconds = useMicroLand((s) => s.records.steadySeconds)
+  const themeId = useMicroLand(s => s.themeId)
+  const setTheme = useMicroLand(s => s.setTheme)
+  const paused = useMicroLand(s => s.paused)
+  const togglePaused = useMicroLand(s => s.togglePaused)
+  const speed = useMicroLand(s => s.speed)
+  const setSpeed = useMicroLand(s => s.setSpeed)
+  const total = useMicroLand(s => s.totalCreatures)
+  const population = useMicroLand(s => s.population)
+  const setGuideOpen = useMicroLand(s => s.setGuideOpen)
+  const summonedLand = useMicroLand(s => s.summonedLand)
+  const steadySeconds = useMicroLand(s => s.records.steadySeconds)
+  const setWorldsOpen = useMicroLand(s => s.setWorldsOpen)
+  const activeWorldId = useMicroLand(s => s.shelf.activeId)
+  const settingsOpen = useMicroLand(s => s.settingsOpen)
+  const setSettingsOpen = useMicroLand(s => s.setSettingsOpen)
+  const tuning = useMicroLand(s => s.tuning)
+
+  // A world running on numbers other than the shipped ones is worth saying out
+  // loud — otherwise a land that behaves strangely months from now is a mystery
+  // rather than a slider someone left pushed over.
+  const tuned = (Object.keys(TUNING_DEFAULTS) as TuningKey[]).some(
+    key => tuning[key] !== TUNING_DEFAULTS[key]
+  )
 
   const species = population.length
   // Below the threshold this would flicker on and off through the early churn,
@@ -81,21 +114,19 @@ export function Hud({
       <select
         id="micro-land-theme"
         value={themeId}
-        onChange={(e) => setTheme(e.target.value)}
+        onChange={e => setTheme(e.target.value)}
         style={{
           ...chipBase,
           color: 'var(--cc-text-default)',
           background: 'var(--cc-panel-grad-to)',
         }}
       >
-        {THEMES.map((theme) => (
+        {THEMES.map(theme => (
           <option key={theme.id} value={theme.id}>
             {theme.name}
           </option>
         ))}
-        {summonedLand && (
-          <option value={SUMMONED_THEME_ID}>✦ {summonedLand}</option>
-        )}
+        {summonedLand && <option value={SUMMONED_THEME_ID}>✦ {summonedLand}</option>}
       </select>
 
       <button
@@ -108,6 +139,25 @@ export function Hud({
         Reshape
       </button>
 
+      {/*
+        Next to the world picker rather than off with the settings, because it is
+        part of the same question: which land am I in? The picker chooses a kind
+        of world; this chooses one you have already made.
+      */}
+      <button
+        type="button"
+        className="cc-btn"
+        onClick={() => setWorldsOpen(true)}
+        style={{ ...chipBase, ...(activeWorldId ? activeChip : {}) }}
+        title={
+          activeWorldId
+            ? 'This world is kept — everything you do here is saved'
+            : 'Keep this world, or open one you kept'
+        }
+      >
+        {activeWorldId ? 'Kept' : 'Keep'}
+      </button>
+
       <div className="flex items-center gap-1" role="group" aria-label="Speed">
         <button
           type="button"
@@ -118,7 +168,7 @@ export function Hud({
         >
           {paused ? 'Paused' : 'Pause'}
         </button>
-        {SPEEDS.map((option) => (
+        {SPEEDS.map(option => (
           <button
             key={option.value}
             type="button"
@@ -141,13 +191,27 @@ export function Hud({
         <button
           type="button"
           className="cc-btn"
+          onClick={() => setSettingsOpen(!settingsOpen)}
+          style={{
+            ...chipBase,
+            padding: '7px 9px',
+            ...(settingsOpen ? activeChip : {}),
+            ...(tuned && !settingsOpen
+              ? { borderColor: 'var(--cc-gold)', color: 'var(--cc-gold)' }
+              : {}),
+          }}
+          aria-pressed={settingsOpen}
+          aria-label="World settings"
+          title={tuned ? 'The laws of this land have been changed' : 'Change the laws of this land'}
+        >
+          <SlidersIcon />
+        </button>
+        <button
+          type="button"
+          className="cc-btn"
           onClick={() => setGuideOpen(true)}
           style={chipBase}
-          title={
-            steady
-              ? 'How long this land has gone without losing a species'
-              : undefined
-          }
+          title={steady ? 'How long this land has gone without losing a species' : undefined}
         >
           {species} kinds · {total} alive
           {steady && (

--- a/src/app/micro-land/components/inspector.tsx
+++ b/src/app/micro-land/components/inspector.tsx
@@ -82,9 +82,9 @@ const meterLabel: React.CSSProperties = {
  * including who eats it, which is derived from `canEat` rather than authored.
  */
 export function Inspector({ onName }: { onName: (name: string) => boolean }) {
-  const inspected = useMicroLand((s) => s.inspected)
-  const blueprints = useMicroLand((s) => s.blueprints)
-  const setTool = useMicroLand((s) => s.setTool)
+  const inspected = useMicroLand(s => s.inspected)
+  const blueprints = useMicroLand(s => s.blueprints)
+  const setTool = useMicroLand(s => s.setTool)
 
   /**
    * The half-typed name, tagged with who it is for.
@@ -100,17 +100,14 @@ export function Inspector({ onName }: { onName: (name: string) => boolean }) {
   const naming = pending?.id === inspected.id
   const draft = naming ? pending.text : ''
 
-  const bp = blueprints.find((b) => b.id === inspected.blueprintId)
+  const bp = blueprints.find(b => b.id === inspected.blueprintId)
   if (!bp) return null
 
-  const eats = blueprints.filter((other) => canEat(bp, other))
-  const eatenBy = blueprints.filter((other) => canEat(other, bp))
+  const eats = blueprints.filter(other => canEat(bp, other))
+  const eatenBy = blueprints.filter(other => canEat(other, bp))
 
   const fullness = 1 - inspected.hunger
-  const lifeLeft = Math.max(
-    0,
-    1 - inspected.ageSeconds / Math.max(1, inspected.lifespanSeconds)
-  )
+  const lifeLeft = Math.max(0, 1 - inspected.ageSeconds / Math.max(1, inspected.lifespanSeconds))
 
   const trouble =
     inspected.starving > 0
@@ -159,7 +156,7 @@ export function Inspector({ onName }: { onName: (name: string) => boolean }) {
           onClick={() => setTool({ kind: 'inspect' })}
           aria-label="Stop inspecting"
           style={{ minWidth: 28, minHeight: 28, color: 'var(--cc-text-muted)', fontSize: 12 }}
-          onPointerDown={(e) => e.stopPropagation()}
+          onPointerDown={e => e.stopPropagation()}
         >
           ✕
         </button>
@@ -194,7 +191,7 @@ export function Inspector({ onName }: { onName: (name: string) => boolean }) {
             {inspected.name ? null : naming ? (
               <form
                 className="flex gap-1.5"
-                onSubmit={(e) => {
+                onSubmit={e => {
                   e.preventDefault()
                   if (onName(draft)) setPending(null)
                 }}
@@ -206,7 +203,7 @@ export function Inspector({ onName }: { onName: (name: string) => boolean }) {
                   id="micro-land-elder-name"
                   autoFocus
                   value={draft}
-                  onChange={(e) => setPending({ id: inspected.id, text: e.target.value })}
+                  onChange={e => setPending({ id: inspected.id, text: e.target.value })}
                   maxLength={24}
                   placeholder="Call it something"
                   className="min-w-0 flex-1 rounded px-2 py-1"
@@ -218,7 +215,7 @@ export function Inspector({ onName }: { onName: (name: string) => boolean }) {
                   }}
                   // The canvas grabs creatures on pointerdown; without this,
                   // tapping the field throws whatever is underneath it.
-                  onPointerDown={(e) => e.stopPropagation()}
+                  onPointerDown={e => e.stopPropagation()}
                 />
                 <button
                   type="submit"
@@ -234,7 +231,7 @@ export function Inspector({ onName }: { onName: (name: string) => boolean }) {
                     border: '1px solid rgba(252, 211, 77, 0.35)',
                     opacity: draft.trim().length === 0 ? 0.4 : 1,
                   }}
-                  onPointerDown={(e) => e.stopPropagation()}
+                  onPointerDown={e => e.stopPropagation()}
                 >
                   Name
                 </button>
@@ -253,7 +250,7 @@ export function Inspector({ onName }: { onName: (name: string) => boolean }) {
                   color: 'var(--cc-gold)',
                   border: '1px solid rgba(252, 211, 77, 0.35)',
                 }}
-                onPointerDown={(e) => e.stopPropagation()}
+                onPointerDown={e => e.stopPropagation()}
               >
                 Give it a name
               </button>
@@ -322,11 +319,9 @@ export function Inspector({ onName }: { onName: (name: string) => boolean }) {
         </div>
 
         <div style={{ fontSize: 11, color: 'var(--cc-text-muted)', lineHeight: 1.55 }}>
-          <strong style={{ fontWeight: 600, color: 'var(--cc-text-default)' }}>
-            Eats:
-          </strong>{' '}
+          <strong style={{ fontWeight: 600, color: 'var(--cc-text-default)' }}>Eats:</strong>{' '}
           {eats.length > 0
-            ? eats.map((e) => e.name).join(', ')
+            ? eats.map(e => e.name).join(', ')
             : bp.move.kind === 'root'
               ? 'sunlight'
               : 'nothing here'}
@@ -334,7 +329,7 @@ export function Inspector({ onName }: { onName: (name: string) => boolean }) {
           <strong style={{ fontWeight: 600, color: 'var(--cc-text-default)' }}>
             Eaten by:
           </strong>{' '}
-          {eatenBy.length > 0 ? eatenBy.map((e) => e.name).join(', ') : 'nothing here'}
+          {eatenBy.length > 0 ? eatenBy.map(e => e.name).join(', ') : 'nothing here'}
         </div>
       </div>
     </div>

--- a/src/app/micro-land/components/notices.tsx
+++ b/src/app/micro-land/components/notices.tsx
@@ -8,14 +8,12 @@ const LIFETIME_MS = 4200
 
 /** Small, quiet messages about what just happened in the world. */
 export function Notices() {
-  const notices = useMicroLand((s) => s.notices)
-  const dismiss = useMicroLand((s) => s.dismissNotice)
+  const notices = useMicroLand(s => s.notices)
+  const dismiss = useMicroLand(s => s.dismissNotice)
 
   useEffect(() => {
     if (notices.length === 0) return
-    const timers = notices.map((notice) =>
-      setTimeout(() => dismiss(notice.id), LIFETIME_MS)
-    )
+    const timers = notices.map(notice => setTimeout(() => dismiss(notice.id), LIFETIME_MS))
     return () => timers.forEach(clearTimeout)
   }, [notices, dismiss])
 
@@ -26,10 +24,14 @@ export function Notices() {
       className="pointer-events-none absolute left-1/2 top-3 flex -translate-x-1/2 flex-col items-center gap-1.5 px-3"
       aria-live="polite"
     >
-      {notices.map((notice) => (
+      {notices.map(notice => (
         <div
           key={notice.id}
-          className="rounded-full px-3.5 py-1.5 text-center backdrop-blur-sm"
+          // Notices are a pass-through layer over the canvas, so the strip
+          // itself must not take pointer events — only an actual button may.
+          className={`flex items-center gap-2 rounded-full py-1.5 pl-3.5 text-center backdrop-blur-sm ${
+            notice.action ? 'pointer-events-auto pr-1.5' : 'pr-3.5'
+          }`}
           style={{
             fontSize: 12,
             color: 'var(--cc-text-default)',
@@ -38,7 +40,31 @@ export function Notices() {
             maxWidth: '92vw',
           }}
         >
-          {notice.text}
+          <span>{notice.text}</span>
+          {notice.action && (
+            <button
+              type="button"
+              className="cc-btn shrink-0"
+              onClick={() => {
+                notice.action?.run()
+                dismiss(notice.id)
+              }}
+              style={{
+                fontFamily: 'var(--cc-font-mono)',
+                fontSize: 10,
+                letterSpacing: 1.2,
+                textTransform: 'uppercase',
+                padding: '4px 10px',
+                minHeight: 28,
+                borderRadius: 999,
+                border: '1px solid var(--cc-mint)',
+                background: 'var(--cc-mint-soft)',
+                color: 'var(--cc-mint)',
+              }}
+            >
+              {notice.action.label}
+            </button>
+          )}
         </div>
       ))}
     </div>

--- a/src/app/micro-land/components/pan-controls.tsx
+++ b/src/app/micro-land/components/pan-controls.tsx
@@ -25,7 +25,7 @@ export function PanControls({
   onHold: (direction: -1 | 0 | 1) => void
   onNudge: (direction: -1 | 1) => void
 }) {
-  const canPan = useMicroLand((s) => s.canPan)
+  const canPan = useMicroLand(s => s.canPan)
   const pressedAt = useRef(0)
 
   const stop = useCallback(() => {
@@ -59,12 +59,12 @@ export function PanControls({
         opacity: 0.62,
         touchAction: 'none',
       }}
-      onPointerDown={(e) => {
+      onPointerDown={e => {
         e.preventDefault()
         pressedAt.current = e.timeStamp
         onHold(direction)
       }}
-      onPointerUp={(e) => {
+      onPointerUp={e => {
         // Let go quickly and the hold barely moved anything; give it one clean
         // step so a tap always does something you can see.
         if (pressedAt.current > 0 && e.timeStamp - pressedAt.current < TAP_MS) {
@@ -75,7 +75,7 @@ export function PanControls({
       onPointerLeave={stop}
       // Enter and Space fire a click with no pointer event behind it, and that
       // is the only case this needs to catch — `detail` is 0 for exactly those.
-      onClick={(e) => {
+      onClick={e => {
         if (e.detail === 0) onNudge(direction)
       }}
     >

--- a/src/app/micro-land/components/pixel-canvas.tsx
+++ b/src/app/micro-land/components/pixel-canvas.tsx
@@ -1,0 +1,331 @@
+'use client'
+
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+/**
+ * The drawing surface.
+ *
+ * Canvas rather than a grid of elements: 28x24 across four frames is 672 nodes
+ * per redraw, and dragging across a div grid means `elementFromPoint` on every
+ * pointer move. One canvas draws in a few hundred fill calls and the geometry
+ * is arithmetic.
+ *
+ * The backing store is sized to the *displayed* box rather than being scaled up
+ * with `image-rendering: pixelated`. Pixelated upscaling is only crisp at whole
+ * multiples, and the canvas here is fluid — at 17.3 display pixels per cell the
+ * grid lines would shimmer and some cells would come out a pixel wider than
+ * their neighbours.
+ */
+
+/**
+ * Canvas 2D takes colour strings, not CSS variables, so the tokens have to be
+ * resolved by hand. Read once per mount and cached: `getComputedStyle` forces
+ * style resolution, and this runs on every cell of every drag.
+ */
+interface Tokens {
+  checkerA: string
+  checkerB: string
+  grid: string
+  cursorInner: string
+  cursorOuter: string
+}
+
+function readTokens(el: Element): Tokens {
+  const style = getComputedStyle(el)
+  const token = (name: string, fallback: string) => style.getPropertyValue(name).trim() || fallback
+  // The fallbacks only matter if this ever renders outside the cosmic shell.
+  // An empty string is a silent no-op on `fillStyle`, which would leave the
+  // checkerboard invisible rather than wrong — worth four strings to avoid.
+  return {
+    checkerA: token('--cc-checker-a', 'rgb(23 26 34)'),
+    checkerB: token('--cc-checker-b', 'rgb(30 34 44)'),
+    grid: token('--cc-checker-grid', 'rgb(255 255 255 / 7%)'),
+    cursorInner: token('--cc-mint', 'rgb(94 234 212)'),
+    cursorOuter: token('--cc-bg-deep', 'rgb(2 8 10)'),
+  }
+}
+
+interface Props {
+  w: number
+  h: number
+  cells: (string | null)[]
+  /** The neighbouring frame, drawn faintly underneath. Null to hide it. */
+  ghost: (string | null)[] | null
+  /**
+   * One cell of a stroke. `first` marks the pointer-down (or key press) that
+   * began it — the parent uses it to snapshot undo state exactly once.
+   */
+  onPaint: (index: number, first: boolean) => void
+  /** Read back so the keyboard cursor can announce what it is sitting on. */
+  describe: (index: number) => string
+  label: string
+}
+
+export function PixelCanvas({ w, h, cells, ghost, onPaint, describe, label }: Props) {
+  const wrapRef = useRef<HTMLDivElement>(null)
+  const canvasRef = useRef<HTMLCanvasElement>(null)
+  const [box, setBox] = useState({ w: 0, h: 0 })
+
+  /**
+   * Where the keyboard is pointing. Null until the canvas is focused.
+   *
+   * Clamped on read rather than corrected in an effect, because shrinking the
+   * canvas can strand it past the end of the grid and a render that briefly
+   * draws the marker out of bounds is worse than a derived value.
+   */
+  const [rawCursor, setCursor] = useState<number | null>(null)
+  const cursor = rawCursor === null ? null : Math.min(rawCursor, w * h - 1)
+
+  const tokensRef = useRef<Tokens | null>(null)
+  const drawing = useRef(false)
+  const last = useRef<number | null>(null)
+
+  useEffect(() => {
+    const el = wrapRef.current
+    if (!el) return
+    const observer = new ResizeObserver(([entry]) => {
+      const rect = entry.contentRect
+      setBox({ w: rect.width, h: rect.height })
+    })
+    observer.observe(el)
+    return () => observer.disconnect()
+  }, [])
+
+  useEffect(() => {
+    const canvas = canvasRef.current
+    if (!canvas || box.w === 0) return
+    const ctx = canvas.getContext('2d')
+    if (!ctx) return
+
+    if (!tokensRef.current) tokensRef.current = readTokens(canvas)
+    const tokens = tokensRef.current
+
+    const dpr = Math.min(window.devicePixelRatio || 1, 2)
+    const pxW = Math.round(box.w * dpr)
+    const pxH = Math.round(box.h * dpr)
+    if (canvas.width !== pxW || canvas.height !== pxH) {
+      canvas.width = pxW
+      canvas.height = pxH
+    }
+
+    const cw = pxW / w
+    const ch = pxH / h
+    // Snap every edge to a whole device pixel, sharing the rounding error out
+    // across the grid instead of letting it pile up as a seam on the last cell.
+    const left = (x: number) => Math.round(x * cw)
+    const top = (y: number) => Math.round(y * ch)
+
+    ctx.clearRect(0, 0, pxW, pxH)
+
+    for (let y = 0; y < h; y++) {
+      for (let x = 0; x < w; x++) {
+        ctx.fillStyle = (x + y) % 2 === 0 ? tokens.checkerA : tokens.checkerB
+        ctx.fillRect(left(x), top(y), left(x + 1) - left(x), top(y + 1) - top(y))
+      }
+    }
+
+    if (ghost) {
+      ctx.globalAlpha = 0.22
+      for (let i = 0; i < ghost.length; i++) {
+        const hex = ghost[i]
+        if (!hex) continue
+        const x = i % w
+        const y = (i / w) | 0
+        ctx.fillStyle = hex
+        ctx.fillRect(left(x), top(y), left(x + 1) - left(x), top(y + 1) - top(y))
+      }
+      ctx.globalAlpha = 1
+    }
+
+    for (let i = 0; i < cells.length; i++) {
+      const hex = cells[i]
+      if (!hex) continue
+      const x = i % w
+      const y = (i / w) | 0
+      ctx.fillStyle = hex
+      ctx.fillRect(left(x), top(y), left(x + 1) - left(x), top(y + 1) - top(y))
+    }
+
+    ctx.strokeStyle = tokens.grid
+    ctx.lineWidth = 1
+    ctx.beginPath()
+    for (let x = 1; x < w; x++) {
+      ctx.moveTo(left(x) + 0.5, 0)
+      ctx.lineTo(left(x) + 0.5, pxH)
+    }
+    for (let y = 1; y < h; y++) {
+      ctx.moveTo(0, top(y) + 0.5)
+      ctx.lineTo(pxW, top(y) + 0.5)
+    }
+    ctx.stroke()
+
+    if (cursor !== null) {
+      const x = cursor % w
+      const y = (cursor / w) | 0
+      // Two rings so the marker survives landing on a light pixel or a dark one.
+      ctx.lineWidth = Math.max(2, dpr * 1.5)
+      ctx.strokeStyle = tokens.cursorOuter
+      ctx.strokeRect(left(x) + 1, top(y) + 1, left(x + 1) - left(x) - 2, top(y + 1) - top(y) - 2)
+      ctx.strokeStyle = tokens.cursorInner
+      ctx.strokeRect(
+        left(x) + 2.5,
+        top(y) + 2.5,
+        left(x + 1) - left(x) - 5,
+        top(y + 1) - top(y) - 5
+      )
+    }
+  }, [box, w, h, cells, ghost, cursor])
+
+  const cellAt = useCallback(
+    (clientX: number, clientY: number): number | null => {
+      const canvas = canvasRef.current
+      if (!canvas) return null
+      const rect = canvas.getBoundingClientRect()
+      const x = Math.floor(((clientX - rect.left) / rect.width) * w)
+      const y = Math.floor(((clientY - rect.top) / rect.height) * h)
+      if (x < 0 || y < 0 || x >= w || y >= h) return null
+      return y * w + x
+    },
+    [w, h]
+  )
+
+  /**
+   * Fill the gap between two cells.
+   *
+   * A fast drag reports a handful of positions several cells apart, and without
+   * this a quick diagonal stroke comes out as dots.
+   */
+  const paintLine = useCallback(
+    (from: number, to: number) => {
+      let x0 = from % w
+      let y0 = (from / w) | 0
+      const x1 = to % w
+      const y1 = (to / w) | 0
+      const dx = Math.abs(x1 - x0)
+      const dy = -Math.abs(y1 - y0)
+      const sx = x0 < x1 ? 1 : -1
+      const sy = y0 < y1 ? 1 : -1
+      let err = dx + dy
+
+      for (;;) {
+        if (x0 === x1 && y0 === y1) break
+        const e2 = 2 * err
+        if (e2 >= dy) {
+          err += dy
+          x0 += sx
+        }
+        if (e2 <= dx) {
+          err += dx
+          y0 += sy
+        }
+        onPaint(y0 * w + x0, false)
+      }
+    },
+    [w, onPaint]
+  )
+
+  return (
+    <div
+      ref={wrapRef}
+      style={{
+        position: 'relative',
+        width: '100%',
+        // Cap the zoom so an 8x8 canvas doesn't balloon into a chessboard.
+        maxWidth: Math.min(w * 30, 560),
+        aspectRatio: `${w} / ${h}`,
+        margin: '0 auto',
+        borderRadius: 6,
+        overflow: 'hidden',
+        border: '1px solid var(--cc-mint-line)',
+        touchAction: 'none',
+      }}
+    >
+      <canvas
+        ref={canvasRef}
+        tabIndex={0}
+        role="application"
+        aria-label={`${label} Use the arrow keys to move around the drawing and Enter to colour in a square.`}
+        style={{
+          display: 'block',
+          width: '100%',
+          height: '100%',
+          cursor: 'crosshair',
+          outline: 'none',
+        }}
+        onPointerDown={e => {
+          e.currentTarget.setPointerCapture(e.pointerId)
+          e.currentTarget.focus()
+          drawing.current = true
+          const index = cellAt(e.clientX, e.clientY)
+          if (index === null) return
+          setCursor(index)
+          onPaint(index, true)
+          last.current = index
+        }}
+        onPointerMove={e => {
+          if (!drawing.current) return
+          const index = cellAt(e.clientX, e.clientY)
+          if (index === null || index === last.current) return
+          if (last.current === null) onPaint(index, false)
+          else paintLine(last.current, index)
+          last.current = index
+          setCursor(index)
+        }}
+        onPointerUp={() => {
+          drawing.current = false
+          last.current = null
+        }}
+        onPointerCancel={() => {
+          drawing.current = false
+          last.current = null
+        }}
+        onFocus={() => {
+          if (cursor === null) setCursor(Math.floor(h / 2) * w + Math.floor(w / 2))
+        }}
+        onKeyDown={e => {
+          const step =
+            e.key === 'ArrowLeft'
+              ? -1
+              : e.key === 'ArrowRight'
+                ? 1
+                : e.key === 'ArrowUp'
+                  ? -w
+                  : e.key === 'ArrowDown'
+                    ? w
+                    : 0
+
+          if (step !== 0) {
+            e.preventDefault()
+            const from = cursor ?? 0
+            // Left and right must not wrap onto the row above or below.
+            if (Math.abs(step) === 1 && ((from % w) + step < 0 || (from % w) + step >= w)) {
+              return
+            }
+            const next = from + step
+            if (next >= 0 && next < w * h) setCursor(next)
+            return
+          }
+
+          if ((e.key === 'Enter' || e.key === ' ') && cursor !== null) {
+            e.preventDefault()
+            onPaint(cursor, true)
+          }
+        }}
+      />
+      <span
+        aria-live="polite"
+        className="sr-only"
+        style={{
+          position: 'absolute',
+          width: 1,
+          height: 1,
+          overflow: 'hidden',
+          clip: 'rect(0 0 0 0)',
+          whiteSpace: 'nowrap',
+        }}
+      >
+        {cursor === null ? '' : describe(cursor)}
+      </span>
+    </div>
+  )
+}

--- a/src/app/micro-land/components/settings-panel.tsx
+++ b/src/app/micro-land/components/settings-panel.tsx
@@ -1,0 +1,235 @@
+'use client'
+
+import { useEffect } from 'react'
+
+import {
+  KNOBS,
+  KNOB_GROUPS,
+  type Knob,
+  TUNING_DEFAULTS,
+  type TuningKey,
+} from '@/app/micro-land/domain/tuning'
+import { useMicroLand } from '@/app/micro-land/store'
+
+const heading: React.CSSProperties = {
+  fontFamily: 'var(--cc-font-mono)',
+  fontSize: 10,
+  letterSpacing: 2,
+  textTransform: 'uppercase',
+  color: 'var(--cc-text-muted)',
+}
+
+const knobLabel: React.CSSProperties = {
+  fontSize: 12,
+  color: 'var(--cc-text-default)',
+}
+
+const knobValue: React.CSSProperties = {
+  fontFamily: 'var(--cc-font-mono)',
+  fontSize: 11,
+  color: 'var(--cc-mint)',
+  whiteSpace: 'nowrap',
+}
+
+/** Fractions read as fractions; everything else is a whole number of things. */
+function show(knob: Knob, value: number): string {
+  const text = knob.step < 1 ? value.toFixed(2) : String(Math.round(value))
+  return knob.unit ? `${text}${knob.unit === 's' ? 's' : ` ${knob.unit}`}` : text
+}
+
+/**
+ * The knobs, out of the way.
+ *
+ * A drawer down the side rather than a modal over the middle, and with no scrim
+ * behind it, because the whole reason to open it is to watch the world while you
+ * drag. A dialog that dims what you are trying to look at would make every
+ * setting a guess followed by a close-and-check.
+ *
+ * Every change lands on the next tick — there is no Apply. Ecosystem numbers are
+ * not the kind of thing anyone can pick correctly in the abstract; you find the
+ * right one by moving it until the meadow looks the way you meant.
+ */
+export function SettingsPanel() {
+  const open = useMicroLand(s => s.settingsOpen)
+  const setOpen = useMicroLand(s => s.setSettingsOpen)
+  const tuning = useMicroLand(s => s.tuning)
+  const setKnob = useMicroLand(s => s.setTuningKnob)
+  const reset = useMicroLand(s => s.resetTuningKnobs)
+
+  // Escape closes, wherever focus happens to be — the panel deliberately does
+  // not take focus away from the world, so it can't rely on catching the key
+  // itself.
+  useEffect(() => {
+    if (!open) return
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setOpen(false)
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [open, setOpen])
+
+  if (!open) return null
+
+  const changed = (Object.keys(TUNING_DEFAULTS) as TuningKey[]).filter(
+    key => tuning[key] !== TUNING_DEFAULTS[key]
+  ).length
+
+  return (
+    <div
+      role="dialog"
+      aria-label="World settings"
+      // Bottom sheet on a phone, drawer down the right on anything wider. The
+      // height cap has to come off on desktop or `inset-y-0` would pin a
+      // three-quarter-height panel to the top edge and leave a gap under it.
+      className="fixed inset-x-0 bottom-0 z-50 flex max-h-[72dvh] flex-col rounded-t-xl sm:inset-y-0 sm:left-auto sm:right-0 sm:w-[350px] sm:max-h-none sm:rounded-none"
+      style={{
+        background: 'linear-gradient(180deg, var(--cc-modal-bg-from), var(--cc-modal-bg-to))',
+        borderTop: '1px solid var(--cc-modal-border)',
+        borderLeft: '1px solid var(--cc-modal-border)',
+      }}
+    >
+      <div
+        className="flex shrink-0 items-center justify-between gap-2 px-4 py-3"
+        style={{
+          borderBottom: '1px solid var(--cc-panel-divider)',
+          background: 'var(--cc-modal-bg-from)',
+        }}
+      >
+        <h2
+          style={{
+            fontFamily: 'var(--cc-font-mono)',
+            fontSize: 11,
+            letterSpacing: 2.5,
+            textTransform: 'uppercase',
+            color: 'var(--cc-mint)',
+          }}
+        >
+          Laws of the land
+        </h2>
+        <div className="flex items-center gap-1">
+          <button
+            type="button"
+            className="cc-btn"
+            onClick={reset}
+            disabled={changed === 0}
+            style={{
+              fontFamily: 'var(--cc-font-mono)',
+              fontSize: 10,
+              letterSpacing: 1.2,
+              textTransform: 'uppercase',
+              padding: '6px 8px',
+              minHeight: 32,
+              borderRadius: 4,
+              border: '1px solid var(--cc-mint-line)',
+              color: changed === 0 ? 'var(--cc-text-muted)' : 'var(--cc-gold)',
+              opacity: changed === 0 ? 0.4 : 1,
+            }}
+            title="Put every setting back to the way the game shipped"
+          >
+            Reset{changed > 0 ? ` (${changed})` : ''}
+          </button>
+          <button
+            type="button"
+            className="cc-btn"
+            onClick={() => setOpen(false)}
+            aria-label="Close settings"
+            style={{ minWidth: 40, minHeight: 32, color: 'var(--cc-text-muted)' }}
+          >
+            ✕
+          </button>
+        </div>
+      </div>
+
+      <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain">
+        <p
+          className="px-4 pt-3"
+          style={{ fontSize: 12, color: 'var(--cc-text-muted)', lineHeight: 1.5 }}
+        >
+          Everything here changes the world while you watch. Nothing is saved into your records, and
+          the land itself is left alone.
+        </p>
+
+        {KNOB_GROUPS.map(group => (
+          <section
+            key={group.id}
+            className="px-4 py-3"
+            style={{ borderTop: '1px solid var(--cc-panel-divider)', marginTop: 12 }}
+          >
+            <h3 style={heading}>{group.title}</h3>
+            <p
+              className="pb-1 pt-1"
+              style={{ fontSize: 11, color: 'var(--cc-text-muted)', opacity: 0.8, lineHeight: 1.5 }}
+            >
+              {group.blurb}
+            </p>
+
+            <div className="flex flex-col gap-4 pt-2">
+              {KNOBS.filter(knob => knob.group === group.id).map(knob => (
+                <KnobRow
+                  key={knob.key}
+                  knob={knob}
+                  value={tuning[knob.key]}
+                  onChange={value => setKnob(knob.key, value)}
+                />
+              ))}
+            </div>
+          </section>
+        ))}
+
+        <div className="h-4" />
+      </div>
+    </div>
+  )
+}
+
+function KnobRow({
+  knob,
+  value,
+  onChange,
+}: {
+  knob: Knob
+  value: number
+  onChange: (value: number) => void
+}) {
+  const id = `micro-land-knob-${knob.key}`
+  const isDefault = value === TUNING_DEFAULTS[knob.key]
+
+  return (
+    <div className="flex flex-col gap-1">
+      <div className="flex items-baseline justify-between gap-3">
+        <label htmlFor={id} style={knobLabel}>
+          {knob.label}
+        </label>
+        <span style={knobValue}>
+          {show(knob, value)}
+          {!isDefault && (
+            // The shipped value stays on screen next to the changed one, so
+            // "how far have I pushed this" never needs a reset to answer.
+            <span style={{ color: 'var(--cc-text-muted)', opacity: 0.6 }}>
+              {' / '}
+              {show(knob, TUNING_DEFAULTS[knob.key])}
+            </span>
+          )}
+        </span>
+      </div>
+      <input
+        id={id}
+        type="range"
+        min={knob.min}
+        max={knob.max}
+        step={knob.step}
+        value={value}
+        onChange={e => onChange(Number(e.target.value))}
+        className="w-full"
+        style={{ accentColor: isDefault ? 'var(--cc-mint)' : 'var(--cc-gold)', minHeight: 24 }}
+        aria-describedby={`${id}-help`}
+      />
+      <p
+        id={`${id}-help`}
+        style={{ fontSize: 11, color: 'var(--cc-text-muted)', opacity: 0.75, lineHeight: 1.45 }}
+      >
+        {knob.help}
+      </p>
+    </div>
+  )
+}

--- a/src/app/micro-land/components/toolbar.tsx
+++ b/src/app/micro-land/components/toolbar.tsx
@@ -7,12 +7,7 @@ import {
   type CreatureGroup,
   creatureGroup,
 } from '@/app/micro-land/domain/blueprint'
-import {
-  MATERIALS,
-  PAINTABLE,
-  TINTS,
-  tintedId,
-} from '@/app/micro-land/domain/config/materials'
+import { MATERIALS, PAINTABLE, TINTS, tintedId } from '@/app/micro-land/domain/config/materials'
 import type { MaterialId, TintableMaterialId } from '@/app/micro-land/domain/types'
 import { useMicroLand } from '@/app/micro-land/store'
 
@@ -45,14 +40,15 @@ const label: React.CSSProperties = {
   paddingLeft: 2,
 }
 
-export function Toolbar() {
-  const tool = useMicroLand((s) => s.tool)
-  const setTool = useMicroLand((s) => s.setTool)
-  const brush = useMicroLand((s) => s.brush)
-  const setBrush = useMicroLand((s) => s.setBrush)
-  const blueprints = useMicroLand((s) => s.blueprints)
-  const pending = useMicroLand((s) => s.pendingSummons)
-  const setSummonOpen = useMicroLand((s) => s.setSummonOpen)
+export function Toolbar({ onRemoveSpecies }: { onRemoveSpecies: (blueprintId: string) => void }) {
+  const tool = useMicroLand(s => s.tool)
+  const setTool = useMicroLand(s => s.setTool)
+  const brush = useMicroLand(s => s.brush)
+  const setBrush = useMicroLand(s => s.setBrush)
+  const blueprints = useMicroLand(s => s.blueprints)
+  const pending = useMicroLand(s => s.pendingSummons)
+  const setSummonOpen = useMicroLand(s => s.setSummonOpen)
+  const setBuilderOpen = useMicroLand(s => s.setBuilderOpen)
 
   const paintingSelected = tool.kind === 'material' || tool.kind === 'erase'
   const family = tool.kind === 'material' ? tintFamily(tool.material) : null
@@ -72,21 +68,58 @@ export function Toolbar() {
     return out
   }, [blueprints])
 
-  const tabs = CREATURE_GROUPS.filter((g) => (grouped.get(g.id)?.length ?? 0) > 0)
+  // A summon still in flight is enough to stand "Yours" up on its own. The
+  // waiting slot lives in that tab and nowhere else, so filtering the tab out
+  // while it was empty hid the loading state on the one summon that most needs
+  // it — the very first, when there is nothing else in "Yours" to keep it open.
+  const tabs = CREATURE_GROUPS.filter(
+    g => (grouped.get(g.id)?.length ?? 0) > 0 || (g.id === 'yours' && pending.length > 0)
+  )
   const [group, setGroup] = useState<CreatureGroup>('plants')
+  /**
+   * Tidy mode: while it is on, tapping a creature in "Yours" removes it.
+   *
+   * A mode rather than a permanent ✕ on every chip. This row is what a thumb
+   * reaches for constantly during play, and a delete control living there full
+   * time would be hit by accident — expensive, since a drawn creature can be
+   * half an hour of somebody's afternoon. It also keeps the chip a single
+   * button: a ✕ nested inside the chip button would be invalid HTML and a tap
+   * target far too small for the hands this is built for.
+   */
+  const [tidying, setTidying] = useState(false)
 
-  // Jump to "Yours" the moment a summon lands, so the thing you just invented
+  // Jump to "Yours" the moment a summon is asked for, and again when it lands,
+  // so the thing you just invented — and the slot holding its place until then —
   // is under your thumb instead of behind a tab you have to go and find.
-  const summonedCount = blueprints.filter((bp) => bp.summoned).length
+  const summonedCount = blueprints.filter(bp => bp.summoned).length
+  const pendingCount = pending.length
   const lastSummoned = useRef(summonedCount)
+  const lastPending = useRef(pendingCount)
   useEffect(() => {
-    if (summonedCount > lastSummoned.current) setGroup('yours')
+    if (summonedCount > lastSummoned.current || pendingCount > lastPending.current) {
+      setGroup('yours')
+      // Arriving here because something new was made must never arrive armed.
+      setTidying(false)
+    }
     lastSummoned.current = summonedCount
-  }, [summonedCount])
+    lastPending.current = pendingCount
+  }, [summonedCount, pendingCount])
 
   // Whatever tab is showing has to exist — "Yours" disappears on a fresh world.
-  const active = tabs.some((t) => t.id === group) ? group : (tabs[0]?.id ?? 'plants')
+  const active = tabs.some(t => t.id === group) ? group : (tabs[0]?.id ?? 'plants')
   const shown = grouped.get(active) ?? []
+
+  /**
+   * Tidying is only ever a thing in "Yours".
+   *
+   * Derived rather than cleaned up in an effect, so the armed state can never
+   * outlive the conditions for it even for one render: switching tab, emptying
+   * the drawer, or a summon landing all disarm it on the spot. It is also reset
+   * on the way out of the tab, so coming back later never finds a row that
+   * silently deletes on tap.
+   */
+  const canTidy = active === 'yours' && shown.length > 0
+  const tidyOn = tidying && canTidy
 
   return (
     <footer
@@ -100,7 +133,7 @@ export function Toolbar() {
       <div className="flex items-center gap-2">
         <span style={label}>Ground</span>
         <div className="flex items-center gap-1">
-          {BRUSHES.map((size) => (
+          {BRUSHES.map(size => (
             <button
               key={size}
               type="button"
@@ -152,14 +185,12 @@ export function Toolbar() {
           <span style={swatchLabel}>Erase</span>
         </button>
 
-        {PAINTABLE.map((id) => {
+        {PAINTABLE.map(id => {
           // A tintable swatch shows whichever color of itself is in hand, so
           // the palette reflects what the brush will actually paint.
-          const inHand =
-            family === id && tool.kind === 'material' ? tool.material : id
+          const inHand = family === id && tool.kind === 'material' ? tool.material : id
           const material = MATERIALS[inHand]
-          const selected =
-            tool.kind === 'material' && (tool.material === id || family === id)
+          const selected = tool.kind === 'material' && (tool.material === id || family === id)
           return (
             <button
               key={id}
@@ -179,7 +210,9 @@ export function Toolbar() {
                   borderRadius: 3,
                   background: material.color,
                   boxShadow:
-                    material.glow > 0 ? `0 0 10px ${material.color}` : 'inset 0 0 0 1px rgba(0,0,0,0.35)',
+                    material.glow > 0
+                      ? `0 0 10px ${material.color}`
+                      : 'inset 0 0 0 1px rgba(0,0,0,0.35)',
                 }}
               >
                 {MATERIALS[id].tintable && (
@@ -212,7 +245,7 @@ export function Toolbar() {
           <span style={{ ...label, paddingLeft: 4 }}>Colour</span>
           {[
             { id: family as MaterialId, name: MATERIALS[family].name },
-            ...TINTS.map((t) => ({
+            ...TINTS.map(t => ({
               id: tintedId(family, t.id),
               name: t.name,
             })),
@@ -255,7 +288,8 @@ export function Toolbar() {
       )}
 
       {/* --- creatures --- */}
-      <div className="flex items-center gap-2">
+      {/* Wraps: Generate, Draw and Inspect together overflow a 360px phone. */}
+      <div className="flex flex-wrap items-center gap-2">
         <span style={label}>Creatures</span>
         <button
           type="button"
@@ -282,11 +316,35 @@ export function Toolbar() {
           <SparkleIcon size={12} />
           Generate
         </button>
+        {/* Secondary to Generate on purpose: one primary-action colour per
+            screen, and drawing is the slower, more deliberate of the two. */}
+        <button
+          type="button"
+          className="cc-btn"
+          onClick={() => setBuilderOpen(true)}
+          title="Colour in a creature yourself, square by square"
+          style={{
+            fontFamily: 'var(--cc-font-mono)',
+            fontSize: 10,
+            letterSpacing: 1.6,
+            textTransform: 'uppercase',
+            padding: '6px 12px',
+            minHeight: 32,
+            borderRadius: 4,
+            border: '1px solid var(--cc-mint-line)',
+            background: 'transparent',
+            color: 'var(--cc-text-muted)',
+          }}
+        >
+          ✎ Draw
+        </button>
         <button
           type="button"
           className="cc-btn"
           onClick={() =>
-            setTool(tool.kind === 'inspect' ? { kind: 'material', material: 'dirt' } : { kind: 'inspect' })
+            setTool(
+              tool.kind === 'inspect' ? { kind: 'material', material: 'dirt' } : { kind: 'inspect' }
+            )
           }
           aria-pressed={tool.kind === 'inspect'}
           title="Tap a creature to see how it is doing"
@@ -322,55 +380,87 @@ export function Toolbar() {
         </span>
       </div>
 
-{/* Creatures still on their way hold their place at the front of the
-            strip, right where the finished one lands. */}
-        
-      <div
-        className="-mx-1 flex gap-1 overflow-x-auto px-1"
-        role="tablist"
-        aria-label="Creature kinds"
-      >
-        {tabs.map((tab) => {
-          const selected = tab.id === active
-          const count = grouped.get(tab.id)?.length ?? 0
-          return (
-            <button
-              key={tab.id}
-              type="button"
-              role="tab"
-              className="cc-btn shrink-0"
-              aria-selected={selected}
-              onClick={() => setGroup(tab.id)}
-              style={{
-                fontFamily: 'var(--cc-font-mono)',
-                fontSize: 9,
-                letterSpacing: 1.2,
-                textTransform: 'uppercase',
-                fontWeight: selected ? 700 : 400,
-                padding: '5px 9px',
-                minHeight: 28,
-                borderRadius: 999,
-                border: `1px solid ${
-                  selected
+      {/* The tidy toggle sits beside the tabs but outside the tablist — it is
+          not a tab, and a stray child in there confuses assistive tech. */}
+      <div className="-mx-1 flex items-center gap-1 px-1">
+        <div className="flex gap-1 overflow-x-auto" role="tablist" aria-label="Creature kinds">
+          {tabs.map(tab => {
+            const selected = tab.id === active
+            // Ones on their way count too, so the number moves the instant you ask
+            // rather than staying at zero for the length of a generation.
+            const count =
+              (grouped.get(tab.id)?.length ?? 0) + (tab.id === 'yours' ? pending.length : 0)
+            return (
+              <button
+                key={tab.id}
+                type="button"
+                role="tab"
+                className="cc-btn shrink-0"
+                aria-selected={selected}
+                onClick={() => {
+                  setGroup(tab.id)
+                  setTidying(false)
+                }}
+                style={{
+                  fontFamily: 'var(--cc-font-mono)',
+                  fontSize: 9,
+                  letterSpacing: 1.2,
+                  textTransform: 'uppercase',
+                  fontWeight: selected ? 700 : 400,
+                  padding: '5px 9px',
+                  minHeight: 28,
+                  borderRadius: 999,
+                  border: `1px solid ${
+                    selected
+                      ? 'var(--cc-mint)'
+                      : tab.id === 'yours'
+                        ? 'var(--cc-pink-border)'
+                        : 'var(--cc-mint-line)'
+                  }`,
+                  background: selected ? 'var(--cc-mint-soft)' : 'transparent',
+                  color: selected
                     ? 'var(--cc-mint)'
                     : tab.id === 'yours'
-                      ? 'var(--cc-pink-border)'
-                      : 'var(--cc-mint-line)'
-                }`,
-                background: selected ? 'var(--cc-mint-soft)' : 'transparent',
-                color: selected
-                  ? 'var(--cc-mint)'
-                  : tab.id === 'yours'
-                    ? 'var(--cc-pink)'
-                    : 'var(--cc-text-muted)',
-                whiteSpace: 'nowrap',
-              }}
-            >
-              {tab.label}
-              <span style={{ opacity: 0.55, marginLeft: 5 }}>{count}</span>
-            </button>
-          )
-        })}
+                      ? 'var(--cc-pink)'
+                      : 'var(--cc-text-muted)',
+                  whiteSpace: 'nowrap',
+                }}
+              >
+                {tab.label}
+                <span style={{ opacity: 0.55, marginLeft: 5 }}>{count}</span>
+              </button>
+            )
+          })}
+        </div>
+
+        {canTidy && (
+          <button
+            type="button"
+            className="cc-btn ml-auto shrink-0"
+            onClick={() => setTidying(v => !v)}
+            aria-pressed={tidyOn}
+            title={
+              tidyOn
+                ? 'Done tidying — tapping a creature places it again'
+                : 'Tidy up — tap a creature to remove it'
+            }
+            style={{
+              fontFamily: 'var(--cc-font-mono)',
+              fontSize: 9,
+              letterSpacing: 1.2,
+              textTransform: 'uppercase',
+              padding: '5px 9px',
+              minHeight: 28,
+              borderRadius: 999,
+              border: `1px solid ${tidyOn ? 'var(--cc-pink)' : 'var(--cc-mint-line)'}`,
+              background: tidyOn ? 'var(--cc-pink-soft, rgba(255,122,184,0.14))' : 'transparent',
+              color: tidyOn ? 'var(--cc-pink)' : 'var(--cc-text-muted)',
+              whiteSpace: 'nowrap',
+            }}
+          >
+            {tidyOn ? 'Done' : 'Tidy'}
+          </button>
+        )}
       </div>
 
       {/* Wrapped, not a scrolling row — a whole group is visible at once. The
@@ -380,43 +470,64 @@ export function Toolbar() {
         className="-mx-1 flex flex-wrap gap-1.5 overflow-y-auto px-1 pb-1"
         style={{ maxHeight: '24vh' }}
       >
-        { group === 'yours' && pending.map((p) => (
-          <div
-            key={p.id}
-            className="shrink-0"
-            title={`Making “${p.prompt}”`}
-            aria-label={`Making ${p.prompt}`}
-            style={{
-              ...swatchStyle(false),
-              minWidth: 62,
-              borderStyle: 'dashed',
-              borderColor: 'var(--cc-pink-border)',
-            }}
-          >
-            <span style={{ height: 34, display: 'grid', placeItems: 'center' }}>
-              <SummonSand size={34} />
-            </span>
-            <span style={{ ...swatchLabel, color: 'var(--cc-pink)' }}>Making…</span>
-          </div>
-        ))}
-        {shown.map((bp) => {
+        {/* Creatures still on their way hold their place at the front of the
+            strip, right where the finished one lands.
+
+            Keyed off `active`, not `group`: the two diverge whenever the
+            remembered tab doesn't exist, and testing the remembered one put the
+            waiting slots under whichever group the fallback had landed on. */}
+        {active === 'yours' &&
+          pending.map(p => (
+            <div
+              key={p.id}
+              className="shrink-0"
+              title={`Making “${p.prompt}”`}
+              aria-label={`Making ${p.prompt}`}
+              style={{
+                ...swatchStyle(false),
+                minWidth: 62,
+                borderStyle: 'dashed',
+                borderColor: 'var(--cc-pink-border)',
+              }}
+            >
+              <span style={{ height: 34, display: 'grid', placeItems: 'center' }}>
+                <SummonSand size={34} />
+              </span>
+              <span style={{ ...swatchLabel, color: 'var(--cc-pink)' }}>Making…</span>
+            </div>
+          ))}
+        {shown.map(bp => {
           const selected = tool.kind === 'creature' && tool.blueprintId === bp.id
+          // Built-ins can't be removed even while tidying — they come from
+          // config, so deleting one would just bring it back on reload.
+          const removable = tidyOn && bp.summoned
           return (
             <button
               key={bp.id}
               type="button"
               className="cc-btn shrink-0"
-              onClick={() => setTool({ kind: 'creature', blueprintId: bp.id })}
-              aria-pressed={selected}
-              title={bp.blurb}
+              onClick={() =>
+                removable
+                  ? onRemoveSpecies(bp.id)
+                  : setTool({ kind: 'creature', blueprintId: bp.id })
+              }
+              aria-pressed={removable ? undefined : selected}
+              aria-label={removable ? `Remove ${bp.name}` : undefined}
+              title={removable ? `Remove ${bp.name}` : bp.blurb}
               style={{
-                ...swatchStyle(selected),
+                ...swatchStyle(selected && !tidyOn),
                 minWidth: 62,
-                borderColor: selected
-                  ? 'var(--cc-mint)'
-                  : bp.summoned
-                    ? 'var(--cc-pink-border)'
-                    : 'var(--cc-mint-line)',
+                position: 'relative',
+                borderColor: removable
+                  ? 'var(--cc-pink)'
+                  : selected && !tidyOn
+                    ? 'var(--cc-mint)'
+                    : bp.summoned
+                      ? 'var(--cc-pink-border)'
+                      : 'var(--cc-mint-line)',
+                // A built-in during tidy mode is inert; say so rather than
+                // letting it look tappable and do nothing.
+                opacity: tidyOn && !bp.summoned ? 0.35 : 1,
               }}
             >
               <span
@@ -429,6 +540,28 @@ export function Toolbar() {
                 <CreaturePortrait blueprint={bp} size={34} />
               </span>
               <span style={swatchLabel}>{bp.name}</span>
+              {removable && (
+                <span
+                  aria-hidden
+                  style={{
+                    position: 'absolute',
+                    top: -6,
+                    right: -6,
+                    width: 20,
+                    height: 20,
+                    display: 'grid',
+                    placeItems: 'center',
+                    borderRadius: 999,
+                    fontSize: 11,
+                    lineHeight: 1,
+                    background: 'var(--cc-pink)',
+                    color: 'var(--cc-on-pink, #1b1b26)',
+                    boxShadow: '0 0 0 2px rgba(2,8,10,0.85)',
+                  }}
+                >
+                  ✕
+                </span>
+              )}
             </button>
           )
         })}

--- a/src/app/micro-land/components/worlds-panel.tsx
+++ b/src/app/micro-land/components/worlds-panel.tsx
@@ -1,0 +1,309 @@
+'use client'
+
+import { useState } from 'react'
+
+import { THEME_BY_ID } from '@/app/micro-land/domain/config/themes'
+import { formatDuration } from '@/app/micro-land/format'
+import { useMicroLand } from '@/app/micro-land/store'
+import { MAX_SAVED_WORLDS, cleanWorldName } from '@/app/micro-land/worlds/wire'
+
+const heading: React.CSSProperties = {
+  fontFamily: 'var(--cc-font-mono)',
+  fontSize: 10,
+  letterSpacing: 2,
+  textTransform: 'uppercase',
+  color: 'var(--cc-text-muted)',
+}
+
+const buttonBase: React.CSSProperties = {
+  fontFamily: 'var(--cc-font-mono)',
+  fontSize: 10,
+  letterSpacing: 1.2,
+  textTransform: 'uppercase',
+  padding: '7px 12px',
+  minHeight: 34,
+  borderRadius: 4,
+  border: '1px solid var(--cc-mint-line)',
+  background: 'transparent',
+  color: 'var(--cc-text-muted)',
+}
+
+const primaryButton: React.CSSProperties = {
+  ...buttonBase,
+  border: '1px solid var(--cc-mint)',
+  background: 'var(--cc-mint-soft)',
+  color: 'var(--cc-mint)',
+}
+
+/** "3 minutes ago" beats a timestamp for a shelf you visit a few times a week. */
+function since(at: number): string {
+  const seconds = Math.max(0, (Date.now() - at) / 1000)
+  if (seconds < 90) return 'just now'
+  if (seconds < 3600) return `${Math.round(seconds / 60)} min ago`
+  if (seconds < 86_400) return `${Math.round(seconds / 3600)} hr ago`
+  const days = Math.round(seconds / 86_400)
+  return days === 1 ? 'yesterday' : `${days} days ago`
+}
+
+/**
+ * The shelf — worlds the player has kept, and the way back into them.
+ *
+ * Two things this panel is careful about, both because the person using it is a
+ * child mid-play:
+ *
+ * - Letting go of a world asks first, in place, on the row itself. A modal on
+ *   top of a modal is a wall; a row that turns into "Really?" is a question.
+ * - Opening a world says out loud that the one on screen is not being kept,
+ *   *before* the tap rather than after it. The alternative is a child losing a
+ *   land they had been building for twenty minutes and learning that the shelf
+ *   is dangerous.
+ */
+export function WorldsPanel({
+  onKeep,
+  onOpen,
+  onForget,
+}: {
+  onKeep: (name: string) => void
+  onOpen: (id: string) => void
+  onForget: (id: string) => void
+}) {
+  const open = useMicroLand(s => s.worldsOpen)
+  const setOpen = useMicroLand(s => s.setWorldsOpen)
+  const shelf = useMicroLand(s => s.shelf)
+  const themeId = useMicroLand(s => s.themeId)
+  const summonedLand = useMicroLand(s => s.summonedLand)
+  const total = useMicroLand(s => s.totalCreatures)
+
+  const [name, setName] = useState('')
+  const [confirming, setConfirming] = useState<string | null>(null)
+
+  if (!open) return null
+
+  const active = shelf.worlds.find(w => w.id === shelf.activeId) ?? null
+  const full = shelf.worlds.length >= MAX_SAVED_WORLDS && !active
+  const here = summonedLand ?? THEME_BY_ID[themeId]?.name ?? 'This land'
+
+  // Through the same cleaner the server would apply, so a world is called the
+  // same thing whether it was kept on this device or on the account.
+  const keep = () => {
+    onKeep(cleanWorldName(name, active ? active.name : here))
+    setName('')
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-end justify-center sm:items-center"
+      style={{ background: 'var(--cc-modal-scrim)' }}
+      onClick={() => setOpen(false)}
+    >
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label="Saved worlds"
+        className="w-full max-w-lg overflow-y-auto rounded-t-xl sm:rounded-xl"
+        style={{
+          maxHeight: '88dvh',
+          background: 'linear-gradient(180deg, var(--cc-modal-bg-from), var(--cc-modal-bg-to))',
+          border: '1px solid var(--cc-modal-border)',
+        }}
+        onClick={e => e.stopPropagation()}
+      >
+        <div
+          className="sticky top-0 flex items-center justify-between px-4 py-3"
+          style={{
+            borderBottom: '1px solid var(--cc-panel-divider)',
+            background: 'var(--cc-modal-bg-from)',
+          }}
+        >
+          <h2
+            style={{
+              fontFamily: 'var(--cc-font-mono)',
+              fontSize: 11,
+              letterSpacing: 2.5,
+              textTransform: 'uppercase',
+              color: 'var(--cc-mint)',
+            }}
+          >
+            Your worlds
+          </h2>
+          <button
+            type="button"
+            className="cc-btn"
+            onClick={() => setOpen(false)}
+            aria-label="Close"
+            style={{ minWidth: 44, minHeight: 34, color: 'var(--cc-text-muted)' }}
+          >
+            ✕
+          </button>
+        </div>
+
+        <section
+          className="flex flex-col gap-2 px-4 py-3"
+          style={{ borderBottom: '1px solid var(--cc-panel-divider)' }}
+        >
+          <h3 style={heading}>{active ? 'Kept as' : 'Keep this one'}</h3>
+          <p style={{ fontSize: 12, color: 'var(--cc-text-muted)' }}>
+            {active
+              ? `${active.name} — everything you do here is written back on its own.`
+              : `${here}, ${total} alive. Give it a name and it will be waiting exactly like this.`}
+          </p>
+          <div className="flex items-center gap-2">
+            <label className="sr-only" htmlFor="micro-land-world-name">
+              Name this world
+            </label>
+            <input
+              id="micro-land-world-name"
+              value={name}
+              onChange={e => setName(e.target.value)}
+              onKeyDown={e => {
+                if (e.key === 'Enter') keep()
+              }}
+              maxLength={40}
+              placeholder={active ? active.name : here}
+              className="min-w-0 flex-1"
+              style={{
+                fontSize: 13,
+                padding: '8px 10px',
+                minHeight: 38,
+                borderRadius: 4,
+                border: '1px solid var(--cc-mint-line)',
+                background: 'var(--cc-panel-grad-to)',
+                color: 'var(--cc-text-default)',
+              }}
+            />
+            <button
+              type="button"
+              className="cc-btn shrink-0"
+              onClick={keep}
+              disabled={shelf.busy || full}
+              style={{ ...primaryButton, opacity: shelf.busy || full ? 0.45 : 1 }}
+            >
+              {active ? 'Save now' : 'Keep it'}
+            </button>
+          </div>
+          {full && (
+            <p style={{ fontSize: 11, color: 'var(--cc-gold)' }}>
+              The shelf holds {MAX_SAVED_WORLDS}. Let one go to make room.
+            </p>
+          )}
+          {shelf.error && (
+            <p style={{ fontSize: 11, color: 'var(--cc-gold)' }}>The cave says: {shelf.error}</p>
+          )}
+        </section>
+
+        <section className="flex flex-col gap-2 px-4 py-3">
+          <h3 style={heading}>
+            On the shelf · {shelf.worlds.length}/{MAX_SAVED_WORLDS}
+          </h3>
+
+          {shelf.worlds.length === 0 && (
+            <p style={{ fontSize: 12, color: 'var(--cc-text-muted)' }}>
+              Nothing kept yet. A world you keep comes back exactly as you left it — same ground,
+              same creatures, same hungers.
+            </p>
+          )}
+
+          <ul className="flex flex-col gap-2">
+            {shelf.worlds.map(world => {
+              const isActive = world.id === shelf.activeId
+              return (
+                <li
+                  key={world.id}
+                  className="flex items-center gap-3 rounded px-3 py-2"
+                  style={{
+                    border: `1px solid ${isActive ? 'var(--cc-mint)' : 'var(--cc-mint-line)'}`,
+                    background: isActive ? 'var(--cc-mint-soft)' : 'transparent',
+                  }}
+                >
+                  <div className="min-w-0 flex-1">
+                    <p
+                      className="truncate"
+                      style={{ fontSize: 13, color: 'var(--cc-text-default)' }}
+                    >
+                      {world.name}
+                      {isActive && (
+                        <span style={{ color: 'var(--cc-mint)', fontSize: 11 }}> · open now</span>
+                      )}
+                    </p>
+                    <p
+                      style={{
+                        fontFamily: 'var(--cc-font-mono)',
+                        fontSize: 10,
+                        color: 'var(--cc-text-muted)',
+                      }}
+                    >
+                      {world.landName ?? THEME_BY_ID[world.themeId]?.name ?? world.themeId} ·{' '}
+                      {world.creatures} alive · {formatDuration(world.elapsed)} old ·{' '}
+                      {since(world.updatedAt)}
+                    </p>
+                  </div>
+
+                  {confirming === world.id ? (
+                    <div className="flex shrink-0 items-center gap-1.5">
+                      <button
+                        type="button"
+                        className="cc-btn"
+                        onClick={() => {
+                          onForget(world.id)
+                          setConfirming(null)
+                        }}
+                        style={{
+                          ...buttonBase,
+                          borderColor: 'var(--cc-pink-border)',
+                          background: 'var(--cc-pink-soft)',
+                          color: 'var(--cc-pink)',
+                        }}
+                      >
+                        Really
+                      </button>
+                      <button
+                        type="button"
+                        className="cc-btn"
+                        onClick={() => setConfirming(null)}
+                        style={buttonBase}
+                      >
+                        No
+                      </button>
+                    </div>
+                  ) : (
+                    <div className="flex shrink-0 items-center gap-1.5">
+                      {!isActive && (
+                        <button
+                          type="button"
+                          className="cc-btn"
+                          onClick={() => {
+                            onOpen(world.id)
+                            setOpen(false)
+                          }}
+                          disabled={shelf.busy}
+                          style={{ ...primaryButton, opacity: shelf.busy ? 0.45 : 1 }}
+                        >
+                          Open
+                        </button>
+                      )}
+                      <button
+                        type="button"
+                        className="cc-btn"
+                        onClick={() => setConfirming(world.id)}
+                        aria-label={`Let go of ${world.name}`}
+                        style={buttonBase}
+                      >
+                        Let go
+                      </button>
+                    </div>
+                  )}
+                </li>
+              )
+            })}
+          </ul>
+
+          {!active && shelf.worlds.length > 0 && (
+            <p style={{ fontSize: 11, color: 'var(--cc-text-muted)' }}>
+              The land you are in now is not on the shelf. Opening one of these leaves it behind.
+            </p>
+          )}
+        </section>
+      </div>
+    </div>
+  )
+}

--- a/src/app/micro-land/domain/__tests__/creature-kit.test.ts
+++ b/src/app/micro-land/domain/__tests__/creature-kit.test.ts
@@ -1,0 +1,211 @@
+import { describe, expect, it } from 'vitest'
+
+import { MAX_PALETTE, sanitizeBlueprint } from '@/app/micro-land/domain/blueprint'
+import {
+  type Draft,
+  blankDraft,
+  buildRawCreature,
+  draftFromBlueprint,
+  draftToArt,
+  floodFill,
+  inkBounds,
+  resizeDraft,
+  sizeForWidth,
+  trimDraft,
+} from '@/app/micro-land/domain/creature-kit'
+import type { CreatureBlueprint } from '@/app/micro-land/domain/types'
+
+/** Colour in a rectangle on every frame of a draft. */
+function fillRect(
+  draft: Draft,
+  x0: number,
+  y0: number,
+  x1: number,
+  y1: number,
+  hex: string
+): Draft {
+  const frames = draft.frames.map(cells => {
+    const out = cells.slice()
+    for (let y = y0; y <= y1; y++) {
+      for (let x = x0; x <= x1; x++) out[y * draft.w + x] = hex
+    }
+    return out
+  })
+  return { ...draft, frames }
+}
+
+describe('drafts', () => {
+  it('starts empty', () => {
+    const draft = blankDraft(8, 8)
+    expect(draft.frames).toHaveLength(2)
+    expect(inkBounds(draft)).toBeNull()
+  })
+
+  it('keeps the drawing centred when the canvas changes', () => {
+    const drawn = fillRect(blankDraft(8, 8), 3, 3, 4, 4, '#ff0000')
+    const grown = resizeDraft(drawn, 14, 12)
+
+    // 3 columns and 2 rows of new margin on the near side.
+    expect(inkBounds(grown)).toEqual({ x0: 6, y0: 5, x1: 7, y1: 6 })
+    expect(resizeDraft(grown, 8, 8)).toEqual(drawn)
+  })
+
+  it('crops the blank margin away, since sprite size is collision size', () => {
+    const drawn = fillRect(blankDraft(28, 24), 10, 8, 15, 13, '#ff0000')
+    const trimmed = trimDraft(drawn)
+    expect([trimmed.w, trimmed.h]).toEqual([6, 6])
+  })
+
+  it('never crops below the minimum the blueprint contract allows', () => {
+    const dot = fillRect(blankDraft(14, 12), 6, 6, 6, 6, '#ff0000')
+    const trimmed = trimDraft(dot)
+    expect(trimmed.w).toBeGreaterThanOrEqual(3)
+    expect(trimmed.h).toBeGreaterThanOrEqual(3)
+  })
+
+  it('fills a region without leaking through diagonal gaps', () => {
+    // A 3x3 ring of wall with a hollow centre, drawn on a 5x5 canvas.
+    let draft = fillRect(blankDraft(5, 5), 1, 1, 3, 3, '#000000')
+    draft = fillRect(draft, 2, 2, 2, 2, '#ffffff')
+    const filled = floodFill(draft.frames[0], 5, 5, 2 * 5 + 2, '#ff0000')
+
+    expect(filled[2 * 5 + 2]).toBe('#ff0000')
+    // The outside is still untouched.
+    expect(filled[0]).toBeNull()
+  })
+})
+
+describe('draftToArt', () => {
+  it('writes the most-used colour into the first palette slot', () => {
+    let draft = fillRect(blankDraft(6, 6), 0, 0, 5, 5, '#112233')
+    draft = fillRect(draft, 0, 0, 0, 0, '#445566')
+    const art = draftToArt(draft, true)
+
+    expect(art.palette.a).toBe('#112233')
+    expect(Object.values(art.palette)).toContain('#445566')
+    expect(art.frames[0][0][0]).toBe(art.frames[0][0][0].toLowerCase())
+  })
+
+  it('folds a thirteenth colour into its nearest neighbour instead of dropping it', () => {
+    let draft = blankDraft(20, 4, 1)
+    // Twelve well-used colours, then one rare near-black in the last column.
+    for (let i = 0; i < MAX_PALETTE; i++) {
+      const hex = `#${(i * 20).toString(16).padStart(2, '0').repeat(3)}`
+      draft = fillRect(draft, i, 0, i, 3, hex)
+    }
+    draft = fillRect(draft, 15, 0, 15, 0, '#010101')
+
+    const art = draftToArt(draft, true)
+    expect(Object.keys(art.palette)).toHaveLength(MAX_PALETTE)
+    // Folded, not punched out — the rare colour still renders as *something*.
+    expect(art.frames[0][0][15]).not.toBe('.')
+    expect(art.palette[art.frames[0][0][15]]).toBe('#000000')
+  })
+
+  it('round-trips through a blueprint', () => {
+    let draft = fillRect(blankDraft(7, 5), 1, 1, 5, 3, '#33dd88')
+    draft = fillRect(draft, 5, 1, 5, 1, '#ffffff')
+
+    const bp = sanitizeBlueprint({ name: 'Round Trip', art: draftToArt(draft, true) })
+    expect(draftFromBlueprint(bp)).toEqual({ ...draft, frameMs: bp.art.frameMs })
+  })
+})
+
+describe('sizeForWidth', () => {
+  it('follows the same scale the summoning prompt gives the model', () => {
+    expect(sizeForWidth(4)).toBe(1)
+    expect(sizeForWidth(8)).toBe(2)
+    expect(sizeForWidth(10)).toBe(3)
+    expect(sizeForWidth(14)).toBe(4)
+    expect(sizeForWidth(20)).toBe(5)
+    expect(sizeForWidth(28)).toBe(6)
+  })
+})
+
+describe('buildRawCreature', () => {
+  const drawn = fillRect(blankDraft(28, 24), 4, 4, 13, 13, '#33dd88')
+
+  function build(overrides: Partial<Parameters<typeof buildRawCreature>[0]> = {}) {
+    return sanitizeBlueprint(
+      buildRawCreature({
+        name: 'Test Thing',
+        draft: drawn,
+        planId: 'walk',
+        dietId: 'plant',
+        glows: false,
+        fireproof: false,
+        seed: null,
+        ...overrides,
+      })
+    )
+  }
+
+  it('reads size off the trimmed drawing, not the canvas', () => {
+    // Ten columns of ink on the biggest canvas is a cat, not a leviathan.
+    expect(build().size).toBe(3)
+  })
+
+  it('gives a plant exactly one structural tag and nothing to eat', () => {
+    const plant = build({ planId: 'root', dietId: 'meat' })
+    expect(plant.tags.filter(t => ['plant', 'meat', 'mineral'].includes(t))).toEqual(['plant'])
+    expect(plant.diet.eats).toEqual([])
+    expect(plant.move.kind).toBe('root')
+  })
+
+  it('turns the toggles into real world behaviour', () => {
+    const creature = build({ glows: true, fireproof: true })
+    expect(creature.glow).toBeGreaterThan(0)
+    expect(creature.tags).toContain('glow')
+    expect(creature.body.immuneTo).toContain('lava')
+  })
+
+  it('keeps a seed creature tuned as it was when only the pixels changed', () => {
+    const seed = sanitizeBlueprint({
+      name: 'Cinder Wyrm',
+      blurb: 'It swims through lava.',
+      size: 5,
+      tags: ['meat', 'beast'],
+      move: { kind: 'walk', speed: 9.5, jump: 3, restlessness: 0.11 },
+      diet: { eats: ['plant'], lifespanSeconds: 777 },
+      body: { immuneTo: ['lava'] },
+      dig: { through: ['stone'], speed: 2 },
+    }) as CreatureBlueprint
+
+    const same = build({ seed, name: 'Cinder Wyrm' })
+    expect(same.move.speed).toBe(9.5)
+    expect(same.diet.lifespanSeconds).toBe(777)
+    expect(same.blurb).toBe('It swims through lava.')
+    // Things no canvas can express come along for the ride.
+    expect(same.dig.through).toEqual(['stone'])
+    // ...but the drawing still decides how big it is.
+    expect(same.size).toBe(3)
+  })
+
+  it('drops the seed tuning once the player changes how it moves', () => {
+    const seed = sanitizeBlueprint({
+      name: 'Cinder Wyrm',
+      move: { kind: 'walk', speed: 9.5, jump: 3, restlessness: 0.11 },
+      tags: ['meat', 'beast'],
+      diet: { eats: ['plant'] },
+    }) as CreatureBlueprint
+
+    const swimmer = build({ seed, planId: 'swim' })
+    expect(swimmer.move.kind).toBe('swim')
+    expect(swimmer.move.speed).not.toBe(9.5)
+    expect(swimmer.habitat.needs).toEqual(['water'])
+  })
+
+  it('never leaves a plant seed carrying a plant tag once it becomes an animal', () => {
+    const seed = sanitizeBlueprint({
+      name: 'Sunleaf',
+      tags: ['plant'],
+      move: { kind: 'root' },
+      diet: { eats: [] },
+    }) as CreatureBlueprint
+
+    const animal = build({ seed, planId: 'walk', dietId: 'meat' })
+    expect(animal.tags).toContain('meat')
+    expect(animal.tags).not.toContain('plant')
+    expect(animal.diet.eats).toEqual(['meat'])
+  })
+})

--- a/src/app/micro-land/domain/__tests__/tuning.test.ts
+++ b/src/app/micro-land/domain/__tests__/tuning.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, describe, expect, it } from 'vitest'
+
+import {
+  KNOBS,
+  TUNING,
+  TUNING_DEFAULTS,
+  type TuningKey,
+  changedKnobs,
+  resetTuning,
+  setTuning,
+} from '@/app/micro-land/domain/tuning'
+
+afterEach(() => {
+  // `TUNING` is module state shared by every test in this process, exactly as it
+  // is shared by everything in the running game.
+  resetTuning()
+})
+
+describe('knob table', () => {
+  it('covers every tunable value exactly once', () => {
+    const keys = KNOBS.map(k => k.key).sort()
+    expect(keys).toEqual((Object.keys(TUNING_DEFAULTS) as TuningKey[]).sort())
+    expect(new Set(keys).size).toBe(keys.length)
+  })
+
+  it('gives every default a range that contains it', () => {
+    for (const knob of KNOBS) {
+      const value = TUNING_DEFAULTS[knob.key]
+      expect(value, knob.key).toBeGreaterThanOrEqual(knob.min)
+      expect(value, knob.key).toBeLessThanOrEqual(knob.max)
+    }
+  })
+})
+
+describe('setTuning', () => {
+  it('clamps rather than rejecting, so a bad value is never a broken world', () => {
+    setTuning({ nativePlantTarget: 99999 })
+    expect(TUNING.nativePlantTarget).toBe(400)
+
+    setTuning({ maxPlants: -50 })
+    expect(TUNING.maxPlants).toBe(10)
+  })
+
+  it('falls back to the default for values that are not numbers', () => {
+    setTuning({ plantSeedBatch: Number.NaN })
+    expect(TUNING.plantSeedBatch).toBe(TUNING_DEFAULTS.plantSeedBatch)
+  })
+
+  it('rounds knobs that count things', () => {
+    setTuning({ plantSeedInterval: 4.7 })
+    expect(TUNING.plantSeedInterval).toBe(5)
+  })
+
+  it('keeps fractions for the knobs that are fractions', () => {
+    setTuning({ breedCost: 0.73 })
+    expect(TUNING.breedCost).toBeCloseTo(0.73)
+  })
+
+  it('ignores keys that are not knobs', () => {
+    setTuning({ worldWidth: 10 } as unknown as Partial<typeof TUNING>)
+    expect(changedKnobs()).toEqual([])
+  })
+
+  /**
+   * The one relationship the panel is not allowed to break: if a meal more than
+   * pays for a child, grazers breed on every full stomach and strip the world.
+   */
+  it('never lets a meal pay for a baby', () => {
+    setTuning({ mealValue: 0.95, breedCost: 0.5 })
+    expect(TUNING.mealValue).toBeLessThan(TUNING.breedCost)
+
+    // Pulling the cost down has to drag the meal down with it, not leave the
+    // pair inverted.
+    setTuning({ breedCost: 0.2 })
+    expect(TUNING.mealValue).toBeLessThan(TUNING.breedCost)
+  })
+})
+
+describe('changedKnobs', () => {
+  it('is empty on a fresh world and names only what moved', () => {
+    expect(changedKnobs()).toEqual([])
+    setTuning({ nativePlantTarget: 60 })
+    expect(changedKnobs()).toEqual(['nativePlantTarget'])
+    resetTuning()
+    expect(changedKnobs()).toEqual([])
+  })
+})

--- a/src/app/micro-land/domain/blueprint.ts
+++ b/src/app/micro-land/domain/blueprint.ts
@@ -63,19 +63,13 @@ const CORE_SLOPE = 0.4
  */
 const materialEnum = z.enum([...BASE_MATERIAL_IDS] as [MaterialId, ...MaterialId[]])
 
-const hexColor = z
-  .string()
-  .regex(/^#[0-9a-fA-F]{6}$/, 'Must be a hex color like #ff8800')
+const hexColor = z.string().regex(/^#[0-9a-fA-F]{6}$/, 'Must be a hex color like #ff8800')
 
 export const BlueprintSchema = z.object({
-  name: z
-    .string()
-    .describe('Short display name, 1-3 words. Title Case. No emoji.'),
+  name: z.string().describe('Short display name, 1-3 words. Title Case. No emoji.'),
   blurb: z
     .string()
-    .describe(
-      'One short sentence describing the creature, written for a curious kid. No emoji.'
-    ),
+    .describe('One short sentence describing the creature, written for a curious kid. No emoji.'),
   size: z
     .number()
     .describe(
@@ -98,9 +92,7 @@ export const BlueprintSchema = z.object({
         .describe(
           'Animation frames. Each frame is an array of equal-length row strings; each character is a palette key or "." for transparent. At least 3 wide and tall, at most 28 wide and 24 tall. SCALE THE DRAWING TO THE "size" FIELD: size 1 is 3-5 wide, size 3 about 9, size 6 is 20-28 wide. A size 6 dragon drawn 9 wide looks like an insect. Give 2 frames so it animates — make frame 2 a small change (a step, a blink, a wing beat), not a completely different drawing. Draw the creature FACING RIGHT.'
         ),
-      frameMs: z
-        .number()
-        .describe('Milliseconds each frame is shown. 90-400. Faster = twitchier.'),
+      frameMs: z.number().describe('Milliseconds each frame is shown. 90-400. Faster = twitchier.'),
       faceMotion: z
         .boolean()
         .describe(
@@ -110,16 +102,10 @@ export const BlueprintSchema = z.object({
     .describe('How the creature looks and animates, as pixel art.'),
   body: z
     .object({
-      mass: z
-        .number()
-        .describe('Gravity multiplier. 0.2 = feather, 1 = normal, 3 = boulder.'),
+      mass: z.number().describe('Gravity multiplier. 0.2 = feather, 1 = normal, 3 = boulder.'),
       bounce: z.number().describe('Bounciness on impact, 0 = thud, 0.8 = rubber ball.'),
-      drag: z
-        .number()
-        .describe('Fraction of speed kept each second, 0.05-0.99. Low = sluggish.'),
-      buoyancy: z
-        .number()
-        .describe('Above 1 floats in water, below 1 sinks. 1 = neutral.'),
+      drag: z.number().describe('Fraction of speed kept each second, 0.05-0.99. Low = sluggish.'),
+      buoyancy: z.number().describe('Above 1 floats in water, below 1 sinks. 1 = neutral.'),
       immuneTo: z
         .array(materialEnum)
         .describe(
@@ -156,22 +142,16 @@ export const BlueprintSchema = z.object({
       hungerRate: z
         .number()
         .describe('How fast it gets hungry, 0-0.2 per second. 0.03 is typical.'),
-      starveSeconds: z
-        .number()
-        .describe('How long it survives once starving, 5-120 seconds.'),
+      starveSeconds: z.number().describe('How long it survives once starving, 5-120 seconds.'),
       breedAt: z
         .number()
         .describe('How full it must be to reproduce, 0-1. Around 0.75 is typical.'),
-      lifespanSeconds: z
-        .number()
-        .describe('Dies of old age after this long, 20-900 seconds.'),
+      lifespanSeconds: z.number().describe('Dies of old age after this long, 20-900 seconds.'),
     })
     .describe('Hunger, hunting and reproduction — this is what drives the food chain.'),
   senses: z
     .object({
-      sight: z
-        .number()
-        .describe('How far it spots food and danger, in tiles. 4-50.'),
+      sight: z.number().describe('How far it spots food and danger, in tiles. 4-50.'),
     })
     .describe('Perception.'),
   habitat: z
@@ -218,9 +198,7 @@ export const BlueprintSchema = z.object({
         .describe(
           'Tags of creatures that breed faster near this one. ["plant"] makes a pollinator. Use [] for no effect.'
         ),
-      boost: z
-        .number()
-        .describe('How much faster they breed, 1 to 4. 1 means no help.'),
+      boost: z.number().describe('How much faster they breed, 1 to 4. 1 means no help.'),
       converts: z
         .object({
           from: materialEnum.describe('The material it changes.'),
@@ -230,17 +208,13 @@ export const BlueprintSchema = z.object({
         .describe(
           'Ground it slowly improves as it goes, e.g. {"from":"stone","to":"dirt"} for a worm that makes soil. Null for almost everything.'
         ),
-      convertRate: z
-        .number()
-        .describe('Tiles changed per second, 0.05-1. Keep it slow.'),
+      convertRate: z.number().describe('Tiles changed per second, 0.05-1. Keep it slow.'),
     })
     .nullable()
     .describe(
       'A special ability that changes the world around it — pollinating, or turning one material into another. Use null unless the description specifically calls for a helper creature; ordinary animals have no aura.'
     ),
-  glow: z
-    .number()
-    .describe('Light it casts into dark places, 0-1. 0 for most creatures.'),
+  glow: z.number().describe('Light it casts into dark places, 0-1. 0 for most creatures.'),
 })
 
 export type RawBlueprint = z.infer<typeof BlueprintSchema>
@@ -258,9 +232,7 @@ export const SceneSchema = z.object({
   creatures: z
     .array(
       BlueprintSchema.extend({
-        count: z
-          .number()
-          .describe('How many of this creature to place in the world, 1-40.'),
+        count: z.number().describe('How many of this creature to place in the world, 1-40.'),
       })
     )
     .describe(
@@ -287,8 +259,13 @@ function cleanTags(input: unknown, fallback: string[]): string[] {
   if (!Array.isArray(input)) return fallback
   const out = input
     .filter((t): t is string => typeof t === 'string')
-    .map((t) => t.trim().toLowerCase().replace(/[^a-z-]/g, ''))
-    .filter((t) => t.length > 0 && t.length <= 16)
+    .map(t =>
+      t
+        .trim()
+        .toLowerCase()
+        .replace(/[^a-z-]/g, '')
+    )
+    .filter(t => t.length > 0 && t.length <= 16)
   return Array.from(new Set(out)).slice(0, 6)
 }
 
@@ -302,9 +279,7 @@ function cleanMaterials(input: unknown): MaterialId[] {
 
 function cleanMaterial(input: unknown): MaterialId | null {
   if (typeof input !== 'string') return null
-  return (MATERIAL_IDS as readonly string[]).includes(input)
-    ? (input as MaterialId)
-    : null
+  return (MATERIAL_IDS as readonly string[]).includes(input) ? (input as MaterialId) : null
 }
 
 /**
@@ -417,7 +392,7 @@ function sanitizeArt(raw: unknown, fallbackColor: string): CreatureBlueprint['ar
    * Only runs when the art is over the cap, so anything already in range keeps
    * its padding — and therefore its collision box — exactly as drawn.
    */
-  const rawWidth = Math.max(...frames.map((f) => Math.max(...f.map((r) => r.length))))
+  const rawWidth = Math.max(...frames.map(f => Math.max(...f.map(r => r.length))))
   if (rawWidth > ART_MAX_W) {
     let first = Infinity
     let last = -1
@@ -433,29 +408,21 @@ function sanitizeArt(raw: unknown, fallbackColor: string): CreatureBlueprint['ar
     if (last >= first) {
       const inkWidth = last - first + 1
       // Centre the window on the ink when even the trimmed drawing overflows.
-      const start =
-        inkWidth <= ART_MAX_W
-          ? first
-          : first + Math.floor((inkWidth - ART_MAX_W) / 2)
-      frames = frames.map((rows) => rows.map((row) => row.slice(start, start + ART_MAX_W)))
+      const start = inkWidth <= ART_MAX_W ? first : first + Math.floor((inkWidth - ART_MAX_W) / 2)
+      frames = frames.map(rows => rows.map(row => row.slice(start, start + ART_MAX_W)))
     }
   }
 
   // Every frame must share one width and height, or animation would jitter.
   const width = clamp(
-    Math.max(...frames.map((f) => Math.max(...f.map((r) => r.length)))),
+    Math.max(...frames.map(f => Math.max(...f.map(r => r.length)))),
     ART_MIN,
     ART_MAX_W,
     4
   )
-  const height = clamp(
-    Math.max(...frames.map((f) => f.length)),
-    ART_MIN,
-    ART_MAX_H,
-    4
-  )
+  const height = clamp(Math.max(...frames.map(f => f.length)), ART_MIN, ART_MAX_H, 4)
 
-  const normalized = frames.map((rows) => {
+  const normalized = frames.map(rows => {
     const out: string[] = []
     for (let y = 0; y < height; y++) {
       const row = rows[y] ?? ''
@@ -470,7 +437,7 @@ function sanitizeArt(raw: unknown, fallbackColor: string): CreatureBlueprint['ar
   })
 
   // An all-transparent sprite is an invisible creature — give it a body.
-  const anyOpaque = normalized.some((f) => f.some((r) => /[^.]/.test(r)))
+  const anyOpaque = normalized.some(f => f.some(r => /[^.]/.test(r)))
   if (!anyOpaque) {
     const key = Object.keys(palette)[0]
     const mid = Math.floor(height / 2)
@@ -486,6 +453,27 @@ function sanitizeArt(raw: unknown, fallbackColor: string): CreatureBlueprint['ar
 }
 
 let summonCounter = 0
+
+/**
+ * Move the id counter past ids that already exist.
+ *
+ * Ids look like `summon:cinder-wyrm:3`, and the counter is module state that
+ * resets with the page. That was harmless while summoned creatures evaporated
+ * on refresh, but restoring them from the chronicle brings old ids back into a
+ * world whose counter has restarted at zero — so the next creature summoned
+ * would be handed `summon:cinder-wyrm:1` again and quietly replace the restored
+ * one in `world.blueprints`, taking its art and its place in the food chain
+ * with it.
+ *
+ * Only the trailing counter matters; the slug does not, because the counter is
+ * global rather than per-name.
+ */
+export function reserveSummonIds(ids: string[]): void {
+  for (const id of ids) {
+    const n = Number(id.slice(id.lastIndexOf(':') + 1))
+    if (Number.isFinite(n) && n > summonCounter) summonCounter = n
+  }
+}
 
 /**
  * Turn arbitrary model output into a blueprint the world can run.
@@ -505,12 +493,13 @@ export function sanitizeBlueprint(
   const dig = (b.dig ?? {}) as Record<string, unknown>
 
   const name =
-    typeof b.name === 'string' && b.name.trim().length > 0
-      ? b.name.trim().slice(0, 32)
-      : 'Whatsit'
+    typeof b.name === 'string' && b.name.trim().length > 0 ? b.name.trim().slice(0, 32) : 'Whatsit'
 
   const prefix = opts.idPrefix ?? 'summon'
-  const slug = name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '')
+  const slug = name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-|-$/g, '')
   const id = `${prefix}:${slug || 'creature'}:${++summonCounter}`
 
   const kindRaw = typeof move.kind === 'string' ? move.kind : 'walk'
@@ -525,7 +514,7 @@ export function sanitizeBlueprint(
 
   // Keep exactly one "what am I made of" tag so the food chain always resolves.
   let tags = cleanTags(b.tags, ['meat'])
-  if (!tags.some((t) => t === 'plant' || t === 'meat' || t === 'mineral')) {
+  if (!tags.some(t => t === 'plant' || t === 'meat' || t === 'mineral')) {
     tags = [kind === 'root' ? 'plant' : 'meat', ...tags].slice(0, 6)
   }
 
@@ -573,7 +562,7 @@ export function sanitizeBlueprint(
     dig: {
       // Liquids aren't walls — letting them be "dug" would delete oceans.
       through: cleanMaterials(dig.through).filter(
-        (m) => m !== 'air' && IS_LIQUID[MATERIAL_INDEX[m]] !== 1
+        m => m !== 'air' && IS_LIQUID[MATERIAL_INDEX[m]] !== 1
       ),
       speed: clamp(dig.speed, 0.05, 8, 1),
     },
@@ -604,20 +593,14 @@ export function sanitizeBlueprint(
 export function canEat(hunter: CreatureBlueprint, prey: CreatureBlueprint): boolean {
   if (hunter.id === prey.id) return false
   if (prey.size > hunter.size) return false
-  return hunter.diet.eats.some((tag) => prey.tags.includes(tag))
+  return hunter.diet.eats.some(tag => prey.tags.includes(tag))
 }
 
 // ---------------------------------------------------------------------------
 // Grouping
 // ---------------------------------------------------------------------------
 
-export type CreatureGroup =
-  | 'yours'
-  | 'plants'
-  | 'grazers'
-  | 'hunters'
-  | 'giants'
-  | 'helpers'
+export type CreatureGroup = 'yours' | 'plants' | 'grazers' | 'hunters' | 'giants' | 'helpers'
 
 /** Tab order, and the labels the player sees. Plain words, not taxonomy. */
 export const CREATURE_GROUPS: { id: CreatureGroup; label: string }[] = [
@@ -647,21 +630,18 @@ function isPlantLike(bp: CreatureBlueprint): boolean {
  * `roster` is every creature in the world; a hunter is defined as something
  * that can actually eat one of them, which is the same rule the simulation uses.
  */
-export function creatureGroup(
-  bp: CreatureBlueprint,
-  roster: CreatureBlueprint[]
-): CreatureGroup {
+export function creatureGroup(bp: CreatureBlueprint, roster: CreatureBlueprint[]): CreatureGroup {
   if (bp.summoned) return 'yours'
   if (isPlantLike(bp)) return 'plants'
   if (bp.size >= 5) return 'giants'
   if (bp.aura) return 'helpers'
-  if (roster.some((other) => canEat(bp, other) && !isPlantLike(other))) return 'hunters'
+  if (roster.some(other => canEat(bp, other) && !isPlantLike(other))) return 'hunters'
   return 'grazers'
 }
 
 /** True if `prey` should run from `hunter`. */
 export function fears(prey: CreatureBlueprint, hunter: CreatureBlueprint): boolean {
-  if (prey.diet.fears.some((tag) => hunter.tags.includes(tag))) return true
+  if (prey.diet.fears.some(tag => hunter.tags.includes(tag))) return true
   return canEat(hunter, prey)
 }
 

--- a/src/app/micro-land/domain/config/creatures.ts
+++ b/src/app/micro-land/domain/config/creatures.ts
@@ -492,7 +492,6 @@ const RUSTBOT = builtin('rustbot', {
   glow: 0.2,
 })
 
-
 const DELVER = builtin('delver', {
   name: 'Delver',
   blurb: 'A blind digger that chews its own tunnels through soil and stone.',
@@ -1078,11 +1077,22 @@ const CRYSTAL_SNAIL = builtin('crystal-snail', {
 
 const DRAGON = builtin('dragon', {
   name: 'Emberwing Elder',
-  blurb: 'An ancient dragon with wings as wide as a barn, whose scales still glow with the fire inside it.',
+  blurb:
+    'An ancient dragon with wings as wide as a barn, whose scales still glow with the fire inside it.',
   size: 6,
   tags: ['meat', 'dragon', 'fire'],
   art: {
-    palette: { 'k': '#180806', 'd': '#7d1f14', 'r': '#c0392b', 'o': '#e8792f', 'y': '#ffc247', 'e': '#fff3c0', 'w': '#ffeccc', 'm': '#9c3320', 'v': '#5e1a10' },
+    palette: {
+      k: '#180806',
+      d: '#7d1f14',
+      r: '#c0392b',
+      o: '#e8792f',
+      y: '#ffc247',
+      e: '#fff3c0',
+      w: '#ffeccc',
+      m: '#9c3320',
+      v: '#5e1a10',
+    },
     frames: [
       [
         '..kk......................',
@@ -1132,7 +1142,13 @@ const DRAGON = builtin('dragon', {
     frameMs: 300,
     faceMotion: true,
   },
-  body: { mass: 3, bounce: 0.05, drag: 0.82, buoyancy: 0.7, immuneTo: ['lava', 'ash', 'obsidian', 'stone'] },
+  body: {
+    mass: 3,
+    bounce: 0.05,
+    drag: 0.82,
+    buoyancy: 0.7,
+    immuneTo: ['lava', 'ash', 'obsidian', 'stone'],
+  },
   move: { kind: 'fly', speed: 4.5, jump: 0, restlessness: 0.12 },
   diet: {
     eats: ['meat'],
@@ -1146,7 +1162,13 @@ const DRAGON = builtin('dragon', {
   habitat: { needs: null, drowns: true },
   dig: { through: ['ash', 'obsidian', 'stone'], speed: 0.6 },
   death: { becomes: 'ash', particleColor: '#ff8a1e', particleCount: 30 },
-  aura: {"radius":10,"helps":[],"boost":1,"converts":{"from":"ice","to":"water"},"convertRate":0.3},
+  aura: {
+    radius: 10,
+    helps: [],
+    boost: 1,
+    converts: { from: 'ice', to: 'water' },
+    convertRate: 0.3,
+  },
   glow: 0.6,
 })
 
@@ -1156,7 +1178,15 @@ const TREX = builtin('trex', {
   size: 6,
   tags: ['meat', 'dinosaur', 'beast'],
   art: {
-    palette: { 'k': '#14200f', 'd': '#2c4620', 'g': '#4e7a35', 'l': '#7aa84c', 'e': '#ffd23f', 'w': '#f2f0e4', 'r': '#8e3b3b' },
+    palette: {
+      k: '#14200f',
+      d: '#2c4620',
+      g: '#4e7a35',
+      l: '#7aa84c',
+      e: '#ffd23f',
+      w: '#f2f0e4',
+      r: '#8e3b3b',
+    },
     frames: [
       [
         '................kkkkkk..',
@@ -1222,11 +1252,21 @@ const TREX = builtin('trex', {
 
 const TOWER_FOLK = builtin('tower-folk', {
   name: 'Tall Tim Twosome',
-  blurb: 'Two friends who travel everywhere as one very tall person, with the top one keeping watch far ahead.',
+  blurb:
+    'Two friends who travel everywhere as one very tall person, with the top one keeping watch far ahead.',
   size: 5,
   tags: ['meat', 'walker'],
   art: {
-    palette: { 's': '#f0c39a', 'k': '#d69a70', 'c': '#3f6fbf', 'b': '#2b4c8c', 'r': '#c8443c', 'h': '#4a3327', 'e': '#20242c', 'y': '#ffe9a8' },
+    palette: {
+      s: '#f0c39a',
+      k: '#d69a70',
+      c: '#3f6fbf',
+      b: '#2b4c8c',
+      r: '#c8443c',
+      h: '#4a3327',
+      e: '#20242c',
+      y: '#ffe9a8',
+    },
     frames: [
       [
         '......yyy.....',
@@ -1304,11 +1344,21 @@ const TOWER_FOLK = builtin('tower-folk', {
 
 const UNICYCLE_CLOWN = builtin('unicycle-clown', {
   name: 'Wobble Clown',
-  blurb: 'A cheerful circus clown who balances on a squeaky one-wheeled cycle and never quite stops wobbling.',
+  blurb:
+    'A cheerful circus clown who balances on a squeaky one-wheeled cycle and never quite stops wobbling.',
   size: 4,
   tags: ['meat', 'clown', 'rider'],
   art: {
-    palette: { 'r': '#e83b3b', 'w': '#fff4f0', 'y': '#ffd23f', 'b': '#3b6ee8', 's': '#f6c6a8', 'k': '#2a2438', 'g': '#8a8fa8', 'o': '#ff8a3d' },
+    palette: {
+      r: '#e83b3b',
+      w: '#fff4f0',
+      y: '#ffd23f',
+      b: '#3b6ee8',
+      s: '#f6c6a8',
+      k: '#2a2438',
+      g: '#8a8fa8',
+      o: '#ff8a3d',
+    },
     frames: [
       [
         '......rrr.......',
@@ -1416,5 +1466,5 @@ export const BUILTIN_CREATURES: CreatureBlueprint[] = [
 ]
 
 export const BUILTIN_BY_ID: Record<string, CreatureBlueprint> = Object.fromEntries(
-  BUILTIN_CREATURES.map((c) => [c.id, c])
+  BUILTIN_CREATURES.map(c => [c.id, c])
 )

--- a/src/app/micro-land/domain/config/materials.ts
+++ b/src/app/micro-land/domain/config/materials.ts
@@ -204,8 +204,8 @@ export function tintedId(base: TintableMaterialId, tint: TintId): MaterialId {
   return `${base}-${tint}`
 }
 
-const TINT_MATERIALS: Material[] = TINTABLE.flatMap((base) =>
-  TINTS.map((tint) => {
+const TINT_MATERIALS: Material[] = TINTABLE.flatMap(base =>
+  TINTS.map(tint => {
     const source = BASE_MATERIALS[base]
     const id = tintedId(base, tint.id)
     return {
@@ -225,25 +225,22 @@ const TINT_MATERIALS: Material[] = TINTABLE.flatMap((base) =>
 function mix(a: string, b: string, t: number): string {
   const pa = parseInt(a.slice(1), 16)
   const pb = parseInt(b.slice(1), 16)
-  const out = [16, 8, 0].map((shift) => {
+  const out = [16, 8, 0].map(shift => {
     const ca = (pa >> shift) & 255
     const cb = (pb >> shift) & 255
     return Math.round(ca + (cb - ca) * t)
   })
-  return `#${out.map((c) => c.toString(16).padStart(2, '0')).join('')}`
+  return `#${out.map(c => c.toString(16).padStart(2, '0')).join('')}`
 }
 
 // ---------------------------------------------------------------------------
 
 /** Every material in the world, base colors first, then every tint. */
-export const MATERIAL_IDS: MaterialId[] = [
-  ...BASE_MATERIAL_IDS,
-  ...TINT_MATERIALS.map((m) => m.id),
-]
+export const MATERIAL_IDS: MaterialId[] = [...BASE_MATERIAL_IDS, ...TINT_MATERIALS.map(m => m.id)]
 
 export const MATERIALS: Record<MaterialId, Material> = {
   ...BASE_MATERIALS,
-  ...Object.fromEntries(TINT_MATERIALS.map((m) => [m.id, m])),
+  ...Object.fromEntries(TINT_MATERIALS.map(m => [m.id, m])),
 } as Record<MaterialId, Material>
 
 /** Numeric index of each material, for the tile grid. */
@@ -255,7 +252,7 @@ export const MATERIAL_INDEX: Record<MaterialId, number> = MATERIAL_IDS.reduce(
   {} as Record<MaterialId, number>
 )
 
-export const MATERIAL_BY_INDEX: Material[] = MATERIAL_IDS.map((id) => MATERIALS[id])
+export const MATERIAL_BY_INDEX: Material[] = MATERIAL_IDS.map(id => MATERIALS[id])
 
 export const AIR = MATERIAL_INDEX.air
 
@@ -293,29 +290,21 @@ export const PAINTABLE: BaseMaterialId[] = [
 ]
 
 /** Precomputed flags, indexed the same way as the tile grid (hot path). */
-export const IS_SOLID: Uint8Array = new Uint8Array(
-  MATERIAL_BY_INDEX.map((m) => (m.solid ? 1 : 0))
-)
-export const IS_LIQUID: Uint8Array = new Uint8Array(
-  MATERIAL_BY_INDEX.map((m) => (m.liquid ? 1 : 0))
-)
-export const IS_POWDER: Uint8Array = new Uint8Array(
-  MATERIAL_BY_INDEX.map((m) => (m.powder ? 1 : 0))
-)
-export const IS_DEADLY: Uint8Array = new Uint8Array(
-  MATERIAL_BY_INDEX.map((m) => (m.deadly ? 1 : 0))
-)
+export const IS_SOLID: Uint8Array = new Uint8Array(MATERIAL_BY_INDEX.map(m => (m.solid ? 1 : 0)))
+export const IS_LIQUID: Uint8Array = new Uint8Array(MATERIAL_BY_INDEX.map(m => (m.liquid ? 1 : 0)))
+export const IS_POWDER: Uint8Array = new Uint8Array(MATERIAL_BY_INDEX.map(m => (m.powder ? 1 : 0)))
+export const IS_DEADLY: Uint8Array = new Uint8Array(MATERIAL_BY_INDEX.map(m => (m.deadly ? 1 : 0)))
 export const IS_FERTILE: Uint8Array = new Uint8Array(
-  MATERIAL_BY_INDEX.map((m) => (m.fertile ? 1 : 0))
+  MATERIAL_BY_INDEX.map(m => (m.fertile ? 1 : 0))
 )
 /** Liquids you can actually drown in — sap is thick, but you can breathe in it. */
 export const IS_DROWNING: Uint8Array = new Uint8Array(
-  MATERIAL_BY_INDEX.map((m) => (m.liquid && !m.breathable ? 1 : 0))
+  MATERIAL_BY_INDEX.map(m => (m.liquid && !m.breathable ? 1 : 0))
 )
 export const IS_ACID_PROOF: Uint8Array = new Uint8Array(
-  MATERIAL_BY_INDEX.map((m) => (m.acidProof ? 1 : 0))
+  MATERIAL_BY_INDEX.map(m => (m.acidProof ? 1 : 0))
 )
 /** How much each material slows things moving through it, 0..255. */
 export const VISCOSITY: Uint8Array = new Uint8Array(
-  MATERIAL_BY_INDEX.map((m) => Math.round(m.viscous * 255))
+  MATERIAL_BY_INDEX.map(m => Math.round(m.viscous * 255))
 )

--- a/src/app/micro-land/domain/config/milestones.ts
+++ b/src/app/micro-land/domain/config/milestones.ts
@@ -46,60 +46,60 @@ export const MILESTONES: Milestone[] = [
   {
     id: 'first-elder',
     text: 'Something here has grown old.',
-    reached: (c) => c.oldestSeconds >= 60,
+    reached: c => c.oldestSeconds >= 60,
   },
   {
     id: 'many-kinds',
     text: 'Eight kinds sharing one land.',
-    reached: (c) => c.speciesAlive >= 8,
+    reached: c => c.speciesAlive >= 8,
   },
   {
     id: 'steady-3m',
     text: 'Three minutes, and nothing has died out.',
-    reached: (c) => c.steadySeconds >= 180,
+    reached: c => c.steadySeconds >= 180,
   },
   {
     id: 'gen-5',
     text: 'A family line five deep.',
-    reached: (c) => c.generations >= 5,
+    reached: c => c.generations >= 5,
   },
   {
     id: 'guide-12',
     text: 'Twelve kinds recorded in the field guide.',
-    reached: (c) => c.archived >= 12,
+    reached: c => c.archived >= 12,
   },
   {
     id: 'elder-5m',
     text: 'One creature has lived five whole minutes.',
-    reached: (c) => c.oldestSeconds >= 300,
+    reached: c => c.oldestSeconds >= 300,
   },
   {
     id: 'summoned-5',
     text: 'Five creatures of your own invention, remembered.',
-    reached: (c) => c.summonedArchived >= 5,
+    reached: c => c.summonedArchived >= 5,
   },
   {
     id: 'crowded',
     text: 'Two hundred and fifty living things at once.',
-    reached: (c) => c.total >= 250,
+    reached: c => c.total >= 250,
   },
   {
     id: 'steady-10m',
     text: 'Ten minutes steady. This web holds.',
-    reached: (c) => c.steadySeconds >= 600,
+    reached: c => c.steadySeconds >= 600,
   },
   {
     id: 'gen-12',
     text: 'Twelve generations. None of the first are left.',
-    reached: (c) => c.generations >= 12,
+    reached: c => c.generations >= 12,
   },
   {
     id: 'guide-30',
     text: 'Thirty kinds. The field guide is getting heavy.',
-    reached: (c) => c.archived >= 30,
+    reached: c => c.archived >= 30,
   },
 ]
 
 export const MILESTONE_BY_ID: Record<string, Milestone> = Object.fromEntries(
-  MILESTONES.map((m) => [m.id, m])
+  MILESTONES.map(m => [m.id, m])
 )

--- a/src/app/micro-land/domain/config/themes.ts
+++ b/src/app/micro-land/domain/config/themes.ts
@@ -50,14 +50,7 @@ function set(tiles: Uint8Array, x: number, y: number, id: MaterialId) {
   tiles[y * WORLD_W + x] = M[id]
 }
 
-function rect(
-  tiles: Uint8Array,
-  x0: number,
-  y0: number,
-  x1: number,
-  y1: number,
-  id: MaterialId
-) {
+function rect(tiles: Uint8Array, x0: number, y0: number, x1: number, y1: number, id: MaterialId) {
   for (let y = Math.max(0, y0); y <= Math.min(WORLD_H - 1, y1); y++) {
     for (let x = Math.max(0, x0); x <= Math.min(WORLD_W - 1, x1); x++) {
       tiles[y * WORLD_W + x] = M[id]
@@ -78,7 +71,7 @@ function tileAt(tiles: Uint8Array, x: number, y: number): number {
  * exist yet while the column is still being written.
  */
 function mossify(tiles: Uint8Array, rng: Rng, chance: number, on: MaterialId[]) {
-  const allowed = new Set(on.map((id) => M[id]))
+  const allowed = new Set(on.map(id => M[id]))
   for (let y = 1; y < WORLD_H; y++) {
     for (let x = 0; x < WORLD_W; x++) {
       const here = tileAt(tiles, x, y)
@@ -99,7 +92,7 @@ function blob(
   rng: Rng,
   into: MaterialId[]
 ) {
-  const allowed = new Set(into.map((m) => M[m]))
+  const allowed = new Set(into.map(m => M[m]))
   for (let y = cy - radius; y <= cy + radius; y++) {
     for (let x = cx - radius; x <= cx + radius; x++) {
       const d = Math.hypot(x - cx, y - cy)
@@ -120,7 +113,7 @@ const EMPTY: Theme = {
   gloom: 0.1,
   gravity: 1,
   starters: [],
-  build: (tiles) => fill(tiles, 'air'),
+  build: tiles => fill(tiles, 'air'),
 }
 
 const EARTH: Theme = {
@@ -287,10 +280,7 @@ const STATION: Theme = {
     }
 
     const margin = 12
-    split(
-      { x0: margin, y0: 10, x1: WORLD_W - margin, y1: WORLD_H - 10 },
-      0
-    )
+    split({ x0: margin, y0: 10, x1: WORLD_W - margin, y1: WORLD_H - 10 }, 0)
 
     for (const room of rooms) {
       // Skip a few rooms entirely — a station with holes in it reads as broken.
@@ -298,8 +288,7 @@ const STATION: Theme = {
       // Different decks were built by different people. Rusted iron reads as
       // the old part of the station, marble as the part somebody cared about.
       const shellRoll = rng()
-      const shell: MaterialId =
-        shellRoll < 0.18 ? 'iron' : shellRoll < 0.26 ? 'marble' : 'metal'
+      const shell: MaterialId = shellRoll < 0.18 ? 'iron' : shellRoll < 0.26 ? 'marble' : 'metal'
       rect(tiles, room.x0, room.y0, room.x1, room.y1, shell)
       rect(tiles, room.x0 + 2, room.y0 + 2, room.x1 - 2, room.y1 - 2, 'air')
 
@@ -504,8 +493,6 @@ const VOLCANIC: Theme = {
 
 export const THEMES: Theme[] = [EMPTY, EARTH, STATION, TIDEPOOL, VOLCANIC]
 
-export const THEME_BY_ID: Record<string, Theme> = Object.fromEntries(
-  THEMES.map((t) => [t.id, t])
-)
+export const THEME_BY_ID: Record<string, Theme> = Object.fromEntries(THEMES.map(t => [t.id, t]))
 
 export const DEFAULT_THEME = 'empty'

--- a/src/app/micro-land/domain/constants.ts
+++ b/src/app/micro-land/domain/constants.ts
@@ -1,4 +1,17 @@
-/** World tuning. One place to change the feel of everything. */
+/**
+ * World tuning. One place to change the feel of everything.
+ *
+ * Some of these are *defaults* rather than values: the ecosystem numbers — plant
+ * seeding, population caps, breeding, gravity — are re-exported through
+ * `tuning.ts` as a mutable `TUNING` object that the options panel can move while
+ * the world runs, and the simulation reads that object rather than the constant.
+ * The comments here are still the reasoning for where each one starts; if you
+ * change one, change it here, and check whether `tuning.ts` gives it a slider
+ * range that still contains the new value.
+ *
+ * If you add a use of one of those constants directly in simulation code, the
+ * panel will silently stop working for it. Read it off `TUNING` instead.
+ */
 
 /**
  * World size in tiles. Everything is drawn at 1 pixel per tile, then scaled up.

--- a/src/app/micro-land/domain/creature-kit.ts
+++ b/src/app/micro-land/domain/creature-kit.ts
@@ -1,0 +1,662 @@
+/**
+ * The hand-drawing kit.
+ *
+ * Summoning asks a model for a whole creature at once. This is the other door
+ * into the same room: the player colours the pixels themselves, and everything
+ * that isn't pixels comes from a handful of choices a seven-year-old can make —
+ * how it moves, what it eats, whether it glows.
+ *
+ * The output is deliberately a *raw* object literal, the same shape the model
+ * returns, so it goes through `sanitizeBlueprint` on exactly the same path. A
+ * drawn creature and a summoned one are the same kind of thing, which is the
+ * whole premise of this world.
+ *
+ * A `Draft` stores hex colours per pixel rather than palette keys. Keys are a
+ * transport detail — they force a rename every time a colour is swapped, and
+ * they cap you at twelve while you're still deciding. Quantising down to a real
+ * palette happens once, at the end, in `draftToArt`.
+ */
+import { ART_MAX_H, ART_MAX_W, ART_MIN, MAX_PALETTE } from './blueprint'
+
+import type { CreatureArt, CreatureBlueprint, LocomotionKind, MaterialId } from './types'
+
+/** Matches `MAX_FRAMES` in the blueprint contract. */
+export const MAX_DRAFT_FRAMES = 4
+
+/** Palette keys, assigned in order of how much a colour is used. */
+const PALETTE_KEYS = 'abcdefghijkl'.slice(0, MAX_PALETTE)
+
+/**
+ * A drawing in progress.
+ *
+ * `frames[f][y * w + x]` is a `#rrggbb` string, or null for transparent. Every
+ * frame shares one size — animation that changes shape mid-loop reads as a
+ * glitch, and the blueprint contract requires it anyway.
+ */
+export interface Draft {
+  w: number
+  h: number
+  frames: (string | null)[][]
+  frameMs: number
+}
+
+// ---------------------------------------------------------------------------
+// Canvas
+// ---------------------------------------------------------------------------
+
+export interface CanvasSize {
+  id: string
+  label: string
+  w: number
+  h: number
+}
+
+/**
+ * Canvas presets, in the language of the thing being drawn rather than pixels.
+ *
+ * The top end is exactly the sprite cap, so a hand-drawn creature can be as big
+ * as a summoned one — the point is that both doors lead to the same world.
+ */
+export const CANVAS_SIZES: CanvasSize[] = [
+  { id: 'small', label: 'Small', w: 8, h: 8 },
+  { id: 'medium', label: 'Medium', w: 14, h: 12 },
+  { id: 'big', label: 'Big', w: 20, h: 18 },
+  { id: 'huge', label: 'Huge', w: ART_MAX_W, h: ART_MAX_H },
+]
+
+/**
+ * The starting ink pots.
+ *
+ * Two neutrals and white for outlines, shading and eyes — the three things that
+ * make a sprite read at this scale — then a spread of hues wide enough that no
+ * two sit next to each other. Any of them can be replaced with a custom colour.
+ */
+export const DEFAULT_INKS = [
+  '#1b1b26',
+  '#6b7280',
+  '#ffffff',
+  '#e04b4b',
+  '#ff8f3f',
+  '#ffd166',
+  '#7ede4f',
+  '#2e8b6b',
+  '#5eead4',
+  '#4a9df0',
+  '#a06bff',
+  '#ff7ab8',
+]
+
+/** Spoken names for the starting inks — swatches are unreadable without them. */
+export const INK_NAMES: Record<string, string> = {
+  '#1b1b26': 'shadow',
+  '#6b7280': 'stone',
+  '#ffffff': 'white',
+  '#e04b4b': 'red',
+  '#ff8f3f': 'orange',
+  '#ffd166': 'yellow',
+  '#7ede4f': 'leaf green',
+  '#2e8b6b': 'deep green',
+  '#5eead4': 'mint',
+  '#4a9df0': 'blue',
+  '#a06bff': 'purple',
+  '#ff7ab8': 'pink',
+}
+
+/** Frame speeds, named for how the creature ends up feeling. */
+export const FRAME_SPEEDS = [
+  { id: 'calm', label: 'Calm', ms: 420 },
+  { id: 'steady', label: 'Steady', ms: 200 },
+  { id: 'quick', label: 'Quick', ms: 110 },
+]
+
+export function blankDraft(w: number, h: number, frames = 2): Draft {
+  const size = w * h
+  return {
+    w,
+    h,
+    frames: Array.from({ length: frames }, () => new Array<string | null>(size).fill(null)),
+    frameMs: 200,
+  }
+}
+
+/** Open an existing creature — summoned, built-in or drawn — for editing. */
+export function draftFromBlueprint(bp: CreatureBlueprint): Draft {
+  const h = bp.art.frames[0].length
+  const w = bp.art.frames[0][0].length
+
+  return {
+    w,
+    h,
+    frames: bp.art.frames.map(rows => {
+      const cells = new Array<string | null>(w * h).fill(null)
+      for (let y = 0; y < h; y++) {
+        for (let x = 0; x < w; x++) {
+          const key = rows[y]?.[x]
+          const hex = key && key !== '.' ? bp.art.palette[key] : undefined
+          if (hex) cells[y * w + x] = hex
+        }
+      }
+      return cells
+    }),
+    frameMs: bp.art.frameMs,
+  }
+}
+
+/**
+ * Change the canvas without losing the drawing.
+ *
+ * The art stays centred, so growing the canvas adds room on every side and
+ * shrinking it eats the margins first. Anchoring top-left would be one line
+ * shorter and would drag the creature into the corner every time.
+ */
+export function resizeDraft(draft: Draft, w: number, h: number): Draft {
+  if (w === draft.w && h === draft.h) return draft
+  const dx = Math.round((w - draft.w) / 2)
+  const dy = Math.round((h - draft.h) / 2)
+
+  return {
+    ...draft,
+    w,
+    h,
+    frames: draft.frames.map(cells => {
+      const out = new Array<string | null>(w * h).fill(null)
+      for (let y = 0; y < draft.h; y++) {
+        const ny = y + dy
+        if (ny < 0 || ny >= h) continue
+        for (let x = 0; x < draft.w; x++) {
+          const nx = x + dx
+          if (nx < 0 || nx >= w) continue
+          out[ny * w + nx] = cells[y * draft.w + x]
+        }
+      }
+      return out
+    }),
+  }
+}
+
+export interface InkBounds {
+  x0: number
+  y0: number
+  x1: number
+  y1: number
+}
+
+/** The box the drawing actually occupies, across every frame. Null if empty. */
+export function inkBounds(draft: Draft): InkBounds | null {
+  let x0 = Infinity
+  let y0 = Infinity
+  let x1 = -1
+  let y1 = -1
+
+  for (const cells of draft.frames) {
+    for (let i = 0; i < cells.length; i++) {
+      if (!cells[i]) continue
+      const x = i % draft.w
+      const y = (i / draft.w) | 0
+      if (x < x0) x0 = x
+      if (x > x1) x1 = x
+      if (y < y0) y0 = y
+      if (y > y1) y1 = y
+    }
+  }
+
+  return x1 < 0 ? null : { x0, y0, x1, y1 }
+}
+
+export function isDraftEmpty(draft: Draft): boolean {
+  return inkBounds(draft) === null
+}
+
+/**
+ * Crop the blank margin away before the creature enters the world.
+ *
+ * A sprite's dimensions *are* its collision box, so a six-pixel bug drawn in
+ * the middle of the biggest canvas would otherwise barge around the world
+ * inside an invisible 28-tile crate. The player never sees this happen — the
+ * canvas they drew on keeps its full size.
+ */
+export function trimDraft(draft: Draft): Draft {
+  const bounds = inkBounds(draft)
+  if (!bounds) return draft
+
+  // Grow the crop back out symmetrically if the drawing is under the floor the
+  // blueprint contract sets, clamped so it can never run off the canvas.
+  let { x0, y0, x1, y1 } = bounds
+  while (x1 - x0 + 1 < ART_MIN && (x0 > 0 || x1 < draft.w - 1)) {
+    if (x0 > 0) x0--
+    else x1++
+  }
+  while (y1 - y0 + 1 < ART_MIN && (y0 > 0 || y1 < draft.h - 1)) {
+    if (y0 > 0) y0--
+    else y1++
+  }
+
+  const w = x1 - x0 + 1
+  const h = y1 - y0 + 1
+  if (w === draft.w && h === draft.h) return draft
+
+  return {
+    ...draft,
+    w,
+    h,
+    frames: draft.frames.map(cells => {
+      const out = new Array<string | null>(w * h).fill(null)
+      for (let y = 0; y < h; y++) {
+        for (let x = 0; x < w; x++) {
+          out[y * w + x] = cells[(y + y0) * draft.w + (x + x0)]
+        }
+      }
+      return out
+    }),
+  }
+}
+
+/** Paint bucket. Returns the same array when nothing changed. */
+export function floodFill(
+  cells: (string | null)[],
+  w: number,
+  h: number,
+  start: number,
+  color: string | null
+): (string | null)[] {
+  const target = cells[start]
+  if (target === color) return cells
+
+  const out = cells.slice()
+  const stack = [start]
+  out[start] = color
+
+  while (stack.length > 0) {
+    const i = stack.pop() as number
+    const x = i % w
+    const y = (i / w) | 0
+    // Four-way only. Diagonal fill leaks through the single-pixel gaps that
+    // pixel art is made of, which reads as the tool being broken.
+    if (x > 0 && cells[i - 1] === target && out[i - 1] !== color) {
+      out[i - 1] = color
+      stack.push(i - 1)
+    }
+    if (x < w - 1 && cells[i + 1] === target && out[i + 1] !== color) {
+      out[i + 1] = color
+      stack.push(i + 1)
+    }
+    if (y > 0 && cells[i - w] === target && out[i - w] !== color) {
+      out[i - w] = color
+      stack.push(i - w)
+    }
+    if (y < h - 1 && cells[i + w] === target && out[i + w] !== color) {
+      out[i + w] = color
+      stack.push(i + w)
+    }
+  }
+
+  return out
+}
+
+// ---------------------------------------------------------------------------
+// Drawing → art
+// ---------------------------------------------------------------------------
+
+function rgb(hex: string): [number, number, number] {
+  return [
+    parseInt(hex.slice(1, 3), 16),
+    parseInt(hex.slice(3, 5), 16),
+    parseInt(hex.slice(5, 7), 16),
+  ]
+}
+
+function nearest(hex: string, options: string[]): string {
+  const [r, g, b] = rgb(hex)
+  let best = options[0]
+  let bestDistance = Infinity
+  for (const option of options) {
+    const [r2, g2, b2] = rgb(option)
+    const distance = (r - r2) ** 2 + (g - g2) ** 2 + (b - b2) ** 2
+    if (distance < bestDistance) {
+      bestDistance = distance
+      best = option
+    }
+  }
+  return best
+}
+
+/**
+ * Turn a drawing into the palette-and-rows form the world renders.
+ *
+ * The palette caps at twelve, and nothing in the editor stops a player from
+ * reaching for a thirteenth colour — so the rarest colours are folded into
+ * their nearest neighbour rather than dropped. Losing a colour is a smudge;
+ * dropping it would punch transparent holes in the creature.
+ */
+export function draftToArt(draft: Draft, faceMotion: boolean): CreatureArt {
+  const counts = new Map<string, number>()
+  for (const cells of draft.frames) {
+    for (const hex of cells) {
+      if (hex) counts.set(hex, (counts.get(hex) ?? 0) + 1)
+    }
+  }
+
+  const ordered = [...counts.entries()].sort((a, b) => b[1] - a[1]).map(([hex]) => hex)
+  const kept = ordered.slice(0, MAX_PALETTE)
+
+  const palette: Record<string, string> = {}
+  const keyOf = new Map<string, string>()
+  kept.forEach((hex, i) => {
+    palette[PALETTE_KEYS[i]] = hex
+    keyOf.set(hex, PALETTE_KEYS[i])
+  })
+  for (const hex of ordered.slice(MAX_PALETTE)) {
+    keyOf.set(hex, keyOf.get(nearest(hex, kept)) as string)
+  }
+  // An empty drawing never reaches here from the UI, but the sanitizer wants a
+  // palette with something in it either way.
+  if (kept.length === 0) palette[PALETTE_KEYS[0]] = '#ffffff'
+
+  const frames = draft.frames.map(cells => {
+    const rows: string[] = []
+    for (let y = 0; y < draft.h; y++) {
+      let row = ''
+      for (let x = 0; x < draft.w; x++) {
+        const hex = cells[y * draft.w + x]
+        row += hex ? (keyOf.get(hex) ?? '.') : '.'
+      }
+      rows.push(row)
+    }
+    return rows
+  })
+
+  return { palette, frames, frameMs: draft.frameMs, faceMotion }
+}
+
+// ---------------------------------------------------------------------------
+// Size
+// ---------------------------------------------------------------------------
+
+/**
+ * Size, read off the drawing rather than asked for.
+ *
+ * Size is the one number that decides a creature's place in the food chain, and
+ * it is also the one thing a drawing already tells you. The thresholds are the
+ * same table the summoning prompt gives the model, so a hand-drawn creature and
+ * a summoned one of the same width land on the same rung.
+ */
+export function sizeForWidth(width: number): number {
+  if (width <= 5) return 1
+  if (width <= 8) return 2
+  if (width <= 11) return 3
+  if (width <= 16) return 4
+  if (width <= 22) return 5
+  return 6
+}
+
+/** Plain-language sizes, for showing the player what their drawing means. */
+export const SIZE_WORDS: Record<number, string> = {
+  1: 'speck-sized',
+  2: 'bug-sized',
+  3: 'cat-sized',
+  4: 'wolf-sized',
+  5: 'bear-sized',
+  6: 'enormous',
+}
+
+// ---------------------------------------------------------------------------
+// Body plans
+// ---------------------------------------------------------------------------
+
+export type PlanId = LocomotionKind
+
+interface BodyPlan {
+  id: PlanId
+  label: string
+  hint: string
+  /** Flavour tags used when there's no seed creature to inherit them from. */
+  flavour: string[]
+  move: CreatureBlueprint['move']
+  body: Omit<CreatureBlueprint['body'], 'immuneTo'>
+  habitat: CreatureBlueprint['habitat']
+  hungerRate: number
+  starveSeconds: number
+  breedAt: number
+  lifespanSeconds: number
+  faceMotion: boolean
+}
+
+/**
+ * The six ways of being alive here.
+ *
+ * Numbers are lifted off the starter roster rather than invented — a Walker is
+ * a Hopper, a Swimmer is a Finling — so a drawn creature drops into an existing
+ * food chain and behaves like it belongs there.
+ */
+export const BODY_PLANS: BodyPlan[] = [
+  {
+    id: 'walk',
+    label: 'Walker',
+    hint: 'Runs along the ground and jumps.',
+    flavour: ['beast'],
+    move: { kind: 'walk', speed: 5, jump: 10, restlessness: 0.3 },
+    body: { mass: 1, bounce: 0.15, drag: 0.4, buoyancy: 0.85 },
+    habitat: { needs: null, drowns: true },
+    hungerRate: 0.027,
+    starveSeconds: 30,
+    breedAt: 0.78,
+    lifespanSeconds: 240,
+    faceMotion: true,
+  },
+  {
+    id: 'fly',
+    label: 'Flyer',
+    hint: 'Goes anywhere in the air.',
+    flavour: ['bug'],
+    move: { kind: 'fly', speed: 4.5, jump: 0, restlessness: 0.55 },
+    body: { mass: 0.12, bounce: 0.1, drag: 0.5, buoyancy: 1.4 },
+    habitat: { needs: null, drowns: true },
+    hungerRate: 0.03,
+    starveSeconds: 26,
+    breedAt: 0.75,
+    lifespanSeconds: 190,
+    faceMotion: true,
+  },
+  {
+    id: 'swim',
+    label: 'Swimmer',
+    hint: 'Needs water. Gasps on dry land.',
+    flavour: ['fish'],
+    move: { kind: 'swim', speed: 5, jump: 0, restlessness: 0.4 },
+    body: { mass: 0.4, bounce: 0.1, drag: 0.45, buoyancy: 1 },
+    habitat: { needs: ['water'], drowns: false },
+    hungerRate: 0.03,
+    starveSeconds: 30,
+    breedAt: 0.72,
+    lifespanSeconds: 220,
+    faceMotion: true,
+  },
+  {
+    id: 'crawl',
+    label: 'Crawler',
+    hint: 'Sticks to walls and ceilings.',
+    flavour: ['bug'],
+    move: { kind: 'crawl', speed: 3, jump: 0, restlessness: 0.35 },
+    body: { mass: 1, bounce: 0.05, drag: 0.35, buoyancy: 0.8 },
+    habitat: { needs: null, drowns: true },
+    hungerRate: 0.028,
+    starveSeconds: 32,
+    breedAt: 0.75,
+    lifespanSeconds: 220,
+    faceMotion: true,
+  },
+  {
+    id: 'drift',
+    label: 'Floater',
+    hint: 'Bobs about wherever it likes.',
+    flavour: [],
+    // Buoyancy a hair over 1 keeps it at the waterline instead of climbing out
+    // of the sea and sailing off the top of the world.
+    move: { kind: 'drift', speed: 1.8, jump: 0, restlessness: 0.5 },
+    body: { mass: 0.15, bounce: 0.3, drag: 0.55, buoyancy: 1.03 },
+    habitat: { needs: null, drowns: false },
+    hungerRate: 0.02,
+    starveSeconds: 55,
+    breedAt: 0.85,
+    lifespanSeconds: 300,
+    faceMotion: false,
+  },
+  {
+    id: 'root',
+    label: 'Plant',
+    hint: 'Never moves. Feeds everything else.',
+    flavour: [],
+    move: { kind: 'root', speed: 0, jump: 0, restlessness: 0 },
+    body: { mass: 1, bounce: 0, drag: 0.2, buoyancy: 0.6 },
+    habitat: { needs: null, drowns: false },
+    hungerRate: 0,
+    starveSeconds: 999,
+    breedAt: 0.2,
+    lifespanSeconds: 280,
+    faceMotion: false,
+  },
+]
+
+const PLAN_BY_ID = new Map(BODY_PLANS.map(plan => [plan.id, plan]))
+
+export function planById(id: PlanId): BodyPlan {
+  return PLAN_BY_ID.get(id) ?? BODY_PLANS[0]
+}
+
+export type DietId = 'plant' | 'meat' | 'none'
+
+export const DIET_CHOICES: { id: DietId; label: string; hint: string }[] = [
+  { id: 'plant', label: 'Plants', hint: 'Grazes on anything rooted.' },
+  { id: 'meat', label: 'Creatures', hint: 'Hunts anything its own size or smaller.' },
+  { id: 'none', label: 'Nothing', hint: 'Never gets hungry.' },
+]
+
+/** Which chip should be lit when an existing creature is opened for editing. */
+export function planOf(bp: CreatureBlueprint): PlanId {
+  return PLAN_BY_ID.has(bp.move.kind) ? bp.move.kind : 'walk'
+}
+
+export function dietOf(bp: CreatureBlueprint): DietId {
+  if (bp.diet.eats.length === 0) return 'none'
+  return bp.diet.eats.includes('plant') ? 'plant' : 'meat'
+}
+
+// ---------------------------------------------------------------------------
+// Drawing → creature
+// ---------------------------------------------------------------------------
+
+/** Tags that answer "what am I made of". Exactly one belongs on a creature. */
+const STRUCTURAL = new Set(['plant', 'meat', 'mineral'])
+
+export interface BuildOptions {
+  name: string
+  draft: Draft
+  planId: PlanId
+  dietId: DietId
+  glows: boolean
+  fireproof: boolean
+  /**
+   * The creature this drawing started from, if any.
+   *
+   * Anything that makes a creature *itself* rather than a category — its
+   * description, what it can tunnel through, what it leaves behind, its aura —
+   * is carried across, because none of it is expressible on this canvas and
+   * throwing it away would punish the player for opening a summoned dragon and
+   * changing two pixels.
+   */
+  seed: CreatureBlueprint | null
+}
+
+/**
+ * Assemble the raw blueprint literal.
+ *
+ * Deliberately returns loose data rather than a `CreatureBlueprint`: the caller
+ * hands it to `introduce`, which runs it through `sanitizeBlueprint` like any
+ * other untrusted input. There is no privileged path into the world.
+ */
+export function buildRawCreature(options: BuildOptions): Record<string, unknown> {
+  const { draft, planId, dietId, glows, fireproof, seed } = options
+
+  const plan = planById(planId)
+  // A plant that hunts is a contradiction the food chain can't resolve.
+  const diet = planId === 'root' ? 'none' : dietId
+
+  const trimmed = trimDraft(draft)
+  const art = draftToArt(trimmed, plan.faceMotion)
+  const size = sizeForWidth(trimmed.w)
+
+  /**
+   * A seed whose plan and diet are untouched keeps its own tuning.
+   *
+   * The presets are a good generic Walker; a summoned creature's numbers were
+   * chosen *for that creature*. Recolouring a Cinder Wyrm shouldn't quietly
+   * turn it into a stock quadruped, but switching it to a Swimmer should.
+   */
+  const keepSeedTuning = seed !== null && planOf(seed) === planId && dietOf(seed) === diet
+
+  const structural = planId === 'root' ? 'plant' : 'meat'
+  const flavour = seed
+    ? seed.tags.filter(tag => !STRUCTURAL.has(tag) && tag !== 'glow').slice(0, 3)
+    : plan.flavour
+  const tags = [structural, ...flavour, ...(glows ? ['glow'] : [])]
+
+  const eats = diet === 'none' ? [] : diet === 'meat' ? ['meat'] : ['plant']
+
+  const immuneTo = new Set<MaterialId>(seed?.body.immuneTo ?? [])
+  if (fireproof) immuneTo.add('lava')
+  else immuneTo.delete('lava')
+
+  // The colour it bursts into should be the colour it mostly is.
+  const dominant = Object.values(art.palette)[0] ?? '#ffd166'
+
+  const name = options.name.trim().slice(0, 32) || seed?.name || 'My Creature'
+  const blurb = seed && seed.name === name ? seed.blurb : 'Drawn by hand, one pixel at a time.'
+
+  return {
+    name,
+    blurb,
+    size,
+    tags,
+    art,
+    body: {
+      ...(keepSeedTuning
+        ? {
+            mass: seed.body.mass,
+            bounce: seed.body.bounce,
+            drag: seed.body.drag,
+            buoyancy: seed.body.buoyancy,
+          }
+        : plan.body),
+      immuneTo: [...immuneTo],
+    },
+    move: keepSeedTuning ? seed.move : plan.move,
+    diet: {
+      eats,
+      fears: seed?.diet.fears ?? [],
+      ...(keepSeedTuning
+        ? {
+            hungerRate: seed.diet.hungerRate,
+            starveSeconds: seed.diet.starveSeconds,
+            breedAt: seed.diet.breedAt,
+            lifespanSeconds: seed.diet.lifespanSeconds,
+          }
+        : {
+            hungerRate: diet === 'none' ? 0 : plan.hungerRate,
+            starveSeconds: diet === 'none' ? 999 : plan.starveSeconds,
+            breedAt: diet === 'none' ? 0.2 : plan.breedAt,
+            lifespanSeconds: plan.lifespanSeconds,
+          }),
+    },
+    // Hunters need to see further than the things they are chasing.
+    senses: { sight: keepSeedTuning ? seed.senses.sight : diet === 'meat' ? 32 : 20 },
+    habitat: keepSeedTuning ? seed.habitat : plan.habitat,
+    dig: seed?.dig ?? { through: [], speed: 1 },
+    death: {
+      becomes: seed?.death.becomes ?? null,
+      particleColor: dominant,
+      particleCount: Math.min(14, 4 + size * 2),
+    },
+    aura: seed?.aura ?? null,
+    glow: glows ? 0.7 : 0,
+  }
+}

--- a/src/app/micro-land/domain/procedural.ts
+++ b/src/app/micro-land/domain/procedural.ts
@@ -58,48 +58,48 @@ type Shape = (b: string, d: string, e: string) => string[][]
 
 const SHAPES: Record<string, Shape> = {
   blob: (b, d, e) => [
-    ['.bbbb.', 'bbbbbb', `bbb${e}bb`, 'bbbbbb', '.dddd.'].map((r) => r.replace(/b/g, b).replace(/d/g, d)),
-    ['.bbbb.', 'bbbbbb', `bbb${e}bb`, 'bbbbbb', '.d..d.'].map((r) => r.replace(/b/g, b).replace(/d/g, d)),
-  ],
-  bug: (b, d, e) => [
-    ['.bbbb.', `bbbbb${e}`, 'bbbbbb', 'd.dd.d'].map((r) => r.replace(/b/g, b).replace(/d/g, d)),
-    ['.bbbb.', `bbbbb${e}`, 'bbbbbb', '.dd.d.'].map((r) => r.replace(/b/g, b).replace(/d/g, d)),
-  ],
-  fish: (b, d, e) => [
-    ['d.bbbb.', `dbbbbb${e}`, 'dbbbbbb', 'd.bbbb.'].map((r) => r.replace(/b/g, b).replace(/d/g, d)),
-    ['..bbbb.', `.bbbbb${e}`, 'dbbbbbb', 'd.bbbb.'].map((r) => r.replace(/b/g, b).replace(/d/g, d)),
-  ],
-  winged: (b, d, e) => [
-    ['b.....b', 'bb...bb', '.bbbbb.', `..bb${e}..`, '..ddd..'].map((r) =>
+    ['.bbbb.', 'bbbbbb', `bbb${e}bb`, 'bbbbbb', '.dddd.'].map(r =>
       r.replace(/b/g, b).replace(/d/g, d)
     ),
-    ['.......', '.b...b.', 'bbbbbbb', `b.bb${e}.b`, '..ddd..'].map((r) =>
+    ['.bbbb.', 'bbbbbb', `bbb${e}bb`, 'bbbbbb', '.d..d.'].map(r =>
+      r.replace(/b/g, b).replace(/d/g, d)
+    ),
+  ],
+  bug: (b, d, e) => [
+    ['.bbbb.', `bbbbb${e}`, 'bbbbbb', 'd.dd.d'].map(r => r.replace(/b/g, b).replace(/d/g, d)),
+    ['.bbbb.', `bbbbb${e}`, 'bbbbbb', '.dd.d.'].map(r => r.replace(/b/g, b).replace(/d/g, d)),
+  ],
+  fish: (b, d, e) => [
+    ['d.bbbb.', `dbbbbb${e}`, 'dbbbbbb', 'd.bbbb.'].map(r => r.replace(/b/g, b).replace(/d/g, d)),
+    ['..bbbb.', `.bbbbb${e}`, 'dbbbbbb', 'd.bbbb.'].map(r => r.replace(/b/g, b).replace(/d/g, d)),
+  ],
+  winged: (b, d, e) => [
+    ['b.....b', 'bb...bb', '.bbbbb.', `..bb${e}..`, '..ddd..'].map(r =>
+      r.replace(/b/g, b).replace(/d/g, d)
+    ),
+    ['.......', '.b...b.', 'bbbbbbb', `b.bb${e}.b`, '..ddd..'].map(r =>
       r.replace(/b/g, b).replace(/d/g, d)
     ),
   ],
   beast: (b, d, e) => [
-    ['..bbbb..', `.bbbbbb${e}`, 'bbbbbbbb', '.dd..dd.', '.d....d.', '.d....d.'].map((r) =>
+    ['..bbbb..', `.bbbbbb${e}`, 'bbbbbbbb', '.dd..dd.', '.d....d.', '.d....d.'].map(r =>
       r.replace(/b/g, b).replace(/d/g, d)
     ),
-    ['..bbbb..', `.bbbbbb${e}`, 'bbbbbbbb', '.dd..dd.', '.d....d.', '..d..d..'].map((r) =>
+    ['..bbbb..', `.bbbbbb${e}`, 'bbbbbbbb', '.dd..dd.', '.d....d.', '..d..d..'].map(r =>
       r.replace(/b/g, b).replace(/d/g, d)
     ),
   ],
   plant: (b, d, e) => [
-    ['..b..', `.b${e}b.`, '..d..', '.bd..', '..d..', '..d..'].map((r) =>
+    ['..b..', `.b${e}b.`, '..d..', '.bd..', '..d..', '..d..'].map(r =>
       r.replace(/b/g, b).replace(/d/g, d)
     ),
-    ['..b..', `.b${e}b.`, '..d..', '..db.', '..d..', '..d..'].map((r) =>
+    ['..b..', `.b${e}b.`, '..d..', '..db.', '..d..', '..d..'].map(r =>
       r.replace(/b/g, b).replace(/d/g, d)
     ),
   ],
   orb: (b, d, e) => [
-    ['.bbb.', `bb${e}bb`, 'bbbbb', 'bbbbb', '.bbb.'].map((r) =>
-      r.replace(/b/g, b).replace(/d/g, d)
-    ),
-    ['.ddd.', `db${e}bd`, 'dbbbd', 'dbbbd', '.ddd.'].map((r) =>
-      r.replace(/b/g, b).replace(/d/g, d)
-    ),
+    ['.bbb.', `bb${e}bb`, 'bbbbb', 'bbbbb', '.bbb.'].map(r => r.replace(/b/g, b).replace(/d/g, d)),
+    ['.ddd.', `db${e}bd`, 'dbbbd', 'dbbbd', '.ddd.'].map(r => r.replace(/b/g, b).replace(/d/g, d)),
   ],
 }
 
@@ -127,8 +127,8 @@ function readPrompt(prompt: string): Read {
   const t = eatsMatch ? lower.slice(0, eatsMatch.index) : lower
   const food = eatsMatch ? lower.slice((eatsMatch.index ?? 0) + eatsMatch[0].length) : ''
 
-  const has = (...words: string[]) => words.some((word) => t.includes(word))
-  const foodHas = (...words: string[]) => words.some((word) => food.includes(word))
+  const has = (...words: string[]) => words.some(word => t.includes(word))
+  const foodHas = (...words: string[]) => words.some(word => food.includes(word))
 
   let kind: LocomotionKind = 'walk'
   let shape: keyof typeof SHAPES = 'blob'
@@ -159,13 +159,37 @@ function readPrompt(prompt: string): Read {
   // Diet. An explicit "eats ..." clause wins; otherwise anything that sounds
   // toothy eats meat and the rest graze.
   const eatsMeat = foodHas('meat', 'bug', 'fish', 'bird', 'animal', 'creature', 'flesh')
-  const eatsPlant = foodHas('plant', 'moss', 'leaf', 'leaves', 'grass', 'fungus', 'mushroom', 'algae', 'kelp', 'seed', 'fruit')
+  const eatsPlant = foodHas(
+    'plant',
+    'moss',
+    'leaf',
+    'leaves',
+    'grass',
+    'fungus',
+    'mushroom',
+    'algae',
+    'kelp',
+    'seed',
+    'fruit'
+  )
   const predator =
     eatsMeat ||
     (!eatsPlant &&
       has(
-        'predator', 'hunt', 'carnivore', 'fangs', 'teeth', 'claws', 'fierce',
-        'shark', 'wolf', 'lion', 'tiger', 'monster', 'dragon', 'spider'
+        'predator',
+        'hunt',
+        'carnivore',
+        'fangs',
+        'teeth',
+        'claws',
+        'fierce',
+        'shark',
+        'wolf',
+        'lion',
+        'tiger',
+        'monster',
+        'dragon',
+        'spider'
       ))
   const eats = kind === 'root' ? [] : predator ? ['meat'] : ['plant']
 
@@ -174,8 +198,7 @@ function readPrompt(prompt: string): Read {
   if (has('big', 'large', 'giant', 'huge', 'massive', 'enormous', 'king')) size = 5
 
   const fireproof = has('fire', 'flame', 'lava', 'magma', 'ember', 'cinder', 'molten', 'volcano')
-  const glow =
-    has('glow', 'light', 'lumin', 'shine', 'star', 'neon', 'spark', 'ghost') ? 0.7 : 0
+  const glow = has('glow', 'light', 'lumin', 'shine', 'star', 'neon', 'spark', 'ghost') ? 0.7 : 0
 
   let hue: number | null = null
   for (const [word, h] of Object.entries(COLOR_WORDS)) {
@@ -211,7 +234,7 @@ function titleCase(input: string): string {
     .split(/\s+/)
     .filter(Boolean)
     .slice(0, 3)
-    .map((word) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
+    .map(word => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
     .join(' ')
 }
 
@@ -227,8 +250,7 @@ export function proceduralCreature(prompt: string): CreatureBlueprint {
 
   const frames = SHAPES[read.shape]('b', 'd', 'e')
 
-  const name =
-    titleCase(prompt.replace(/[^a-zA-Z ]/g, '').trim()) || 'Mystery Thing'
+  const name = titleCase(prompt.replace(/[^a-zA-Z ]/g, '').trim()) || 'Mystery Thing'
 
   return sanitizeBlueprint(
     {

--- a/src/app/micro-land/domain/sim/creature-sim.ts
+++ b/src/app/micro-land/domain/sim/creature-sim.ts
@@ -13,22 +13,13 @@ import type { BodyBox } from '@/app/micro-land/domain/blueprint'
 import { MATERIAL_INDEX } from '@/app/micro-land/domain/config/materials'
 import {
   BREATH_SECONDS,
-  BREED_COOLDOWN,
-  BREED_COST,
-  GRAVITY,
-  MAX_CREATURES,
   MAX_FALL,
   MAX_PARTICLES,
-  MAX_PLANTS,
-  MEAL_VALUE,
   PARTICLE_LIFE,
-  PLANT_MATURITY,
-  PLANT_SPECIES_CAP,
-  PLANT_SPREAD_COOLDOWN,
-  SPECIES_SOFT_CAP,
   WORLD_H,
   WORLD_W,
 } from '@/app/micro-land/domain/constants'
+import { TUNING } from '@/app/micro-land/domain/tuning'
 import type { Creature, CreatureBlueprint, WorldState } from '@/app/micro-land/domain/types'
 
 import {
@@ -206,7 +197,7 @@ export function tickCreatures(
     const wet = boxLiquidFraction(w, px, py, body.w, body.h)
     const deadlyMat = boxDeadlyMaterial(w, px, py, body.w, body.h)
     if (deadlyMat !== null) {
-      const immune = bp.body.immuneTo.some((m) => MATERIAL_INDEX[m] === deadlyMat)
+      const immune = bp.body.immuneTo.some(m => MATERIAL_INDEX[m] === deadlyMat)
       if (!immune) {
         kill(w, c, bp, dead, events, 'burned')
         continue
@@ -256,14 +247,14 @@ export function tickCreatures(
     // usual hunger cost would sterilise them permanently — their hungerRate is
     // 0, so the debt could never be paid back and each plant would breed twice
     // in its entire life.
-    const maturity = isPlant ? PLANT_MATURITY : bp.diet.lifespanSeconds * 0.2
+    const maturity = isPlant ? TUNING.plantMaturity : bp.diet.lifespanSeconds * 0.2
     if (
       c.breedCooldown <= 0 &&
       fullness >= bp.diet.breedAt &&
       c.ageSeconds > maturity &&
-      creatures.length < MAX_CREATURES &&
-      !(isPlant && plantsAlive >= MAX_PLANTS) &&
-      (speciesCount[bp.id] ?? 0) < (isPlant ? PLANT_SPECIES_CAP : SPECIES_SOFT_CAP)
+      creatures.length < TUNING.maxCreatures &&
+      !(isPlant && plantsAlive >= TUNING.maxPlants) &&
+      (speciesCount[bp.id] ?? 0) < (isPlant ? TUNING.plantSpeciesCap : TUNING.speciesSoftCap)
     ) {
       const child = reproduce(w, c, bp, bw, bh, rng)
       if (child) {
@@ -272,11 +263,11 @@ export function tickCreatures(
         child.generation = c.generation + 1
         c.children++
         if (isPlant) plantsAlive++
-        else c.hunger = Math.min(1, c.hunger + BREED_COST)
+        else c.hunger = Math.min(1, c.hunger + TUNING.breedCost)
         speciesCount[bp.id] = (speciesCount[bp.id] ?? 0) + 1
         // A pollinator nearby shortens the wait before the next one.
         const help = auraBoost(w, c, bp, bw, bh, helpers)
-        c.breedCooldown = (isPlant ? PLANT_SPREAD_COOLDOWN : BREED_COOLDOWN) / help
+        c.breedCooldown = (isPlant ? TUNING.plantSpreadCooldown : TUNING.breedCooldown) / help
         events.push({ kind: 'born', blueprintId: bp.id, x: child.x, y: child.y })
       } else {
         // Nowhere to put it — wait a bit before trying again.
@@ -286,7 +277,7 @@ export function tickCreatures(
   }
 
   if (dead.size > 0) {
-    w.creatures = creatures.filter((c) => !dead.has(c.id))
+    w.creatures = creatures.filter(c => !dead.has(c.id))
   }
 
   // Plants first — everything else in the world is downstream of them.
@@ -347,11 +338,10 @@ function look(
     if (hungry && canEat(bp, obp)) {
       // Bodies touching? Eat now, don't bother pathing.
       const touching =
-        Math.abs(dx) <= (bw + ow) / 2 + BITE_PAD &&
-        Math.abs(dy) <= (bh + oh) / 2 + BITE_PAD
+        Math.abs(dx) <= (bw + ow) / 2 + BITE_PAD && Math.abs(dy) <= (bh + oh) / 2 + BITE_PAD
       if (touching) {
         devour(w, other, obp, dead, events)
-        c.hunger = Math.max(0, c.hunger - MEAL_VALUE)
+        c.hunger = Math.max(0, c.hunger - TUNING.mealValue)
         c.starving = 0
         c.mealsEaten++
         c.mood = 'eat'
@@ -437,7 +427,7 @@ function auraBoost(
     if (helper.id === c.id) continue
     const aura = w.blueprints[helper.blueprintId]?.aura
     if (!aura || aura.helps.length === 0) continue
-    if (!aura.helps.some((tag) => bp.tags.includes(tag))) continue
+    if (!aura.helps.some(tag => bp.tags.includes(tag))) continue
 
     const hbp = w.blueprints[helper.blueprintId]
     if (!hbp) continue
@@ -493,13 +483,7 @@ function applyConversion(
 // Steering
 // ---------------------------------------------------------------------------
 
-function steer(
-  w: WorldState,
-  c: Creature,
-  bp: CreatureBlueprint,
-  dt: number,
-  rng: Rng
-): void {
+function steer(w: WorldState, c: Creature, bp: CreatureBlueprint, dt: number, rng: Rng): void {
   const { w: bw, h: bh } = artSize(bp)
   const body = bodyBox(bp)
   const cx = c.x + bw / 2
@@ -650,7 +634,7 @@ function integrate(
   const inGoo = goo > 0.05
 
   if (!weightless) {
-    let g = GRAVITY * bp.body.mass * gravityScale
+    let g = TUNING.gravity * bp.body.mass * gravityScale
     if (inLiquid) {
       // Buoyancy above 1 pushes up harder than gravity pulls down.
       g *= 1 - bp.body.buoyancy
@@ -705,8 +689,7 @@ function integrate(
     c.vx *= 0.2
   } else {
     const bx = nx + ox
-    c.x =
-      (c.vx > 0 ? Math.floor(bx + body.w - 0.001) - body.w : Math.floor(bx) + 1) - ox
+    c.x = (c.vx > 0 ? Math.floor(bx + body.w - 0.001) - body.w : Math.floor(bx) + 1) - ox
     c.vx = -c.vx * bp.body.bounce
     c.drift = -c.drift
     c.facing = (c.facing === 1 ? -1 : 1) as 1 | -1
@@ -760,7 +743,7 @@ function chewThrough(
   bh: number,
   dt: number
 ): boolean {
-  const diggable = new Set(bp.dig.through.map((m) => MATERIAL_INDEX[m]))
+  const diggable = new Set(bp.dig.through.map(m => MATERIAL_INDEX[m]))
 
   // Collect the blocking tiles this move would run into.
   const x0 = Math.floor(x)
@@ -866,20 +849,9 @@ function kill(
   if (dead.has(c.id)) return
   dead.add(c.id)
   const { w: bw, h: bh } = artSize(bp)
-  emitParticles(
-    w,
-    c.x + bw / 2,
-    c.y + bh / 2,
-    bp.death.particleColor,
-    bp.death.particleCount
-  )
+  emitParticles(w, c.x + bw / 2, c.y + bh / 2, bp.death.particleColor, bp.death.particleCount)
   if (bp.death.becomes) {
-    setTile(
-      w,
-      Math.floor(c.x + bw / 2),
-      Math.floor(c.y + bh / 2),
-      MATERIAL_INDEX[bp.death.becomes]
-    )
+    setTile(w, Math.floor(c.x + bw / 2), Math.floor(c.y + bh / 2), MATERIAL_INDEX[bp.death.becomes])
   }
   events.push({ kind: cause, blueprintId: bp.id, x: c.x, y: c.y })
 }
@@ -916,7 +888,7 @@ function tickParticles(w: WorldState, dt: number, gravityScale: number): void {
   for (const p of w.particles) {
     p.life -= dt
     if (p.life <= 0) continue
-    p.vy += GRAVITY * 0.35 * gravityScale * dt
+    p.vy += TUNING.gravity * 0.35 * gravityScale * dt
     p.x += p.vx * dt
     p.y += p.vy * dt
     if (p.x < 0 || p.y < 0 || p.x >= WORLD_W || p.y >= WORLD_H) continue

--- a/src/app/micro-land/domain/sim/tile-sim.ts
+++ b/src/app/micro-land/domain/sim/tile-sim.ts
@@ -30,9 +30,7 @@ const ACID = MATERIAL_INDEX.acid
 const SAP = MATERIAL_INDEX.sap
 
 /** Anything that turns to water next to lava — ice, snow. */
-const MELTS: Uint8Array = new Uint8Array(
-  MATERIAL_BY_INDEX.map((m) => (m.melts ? 1 : 0))
-)
+const MELTS: Uint8Array = new Uint8Array(MATERIAL_BY_INDEX.map(m => (m.melts ? 1 : 0)))
 
 /**
  * Chance an acid tile eats its neighbour on a pass it is allowed to act, 0..1.
@@ -248,13 +246,7 @@ function quench(tiles: Uint8Array, x: number, y: number, at: number): boolean {
  *
  * Returns true if the tile was used up.
  */
-function corrode(
-  tiles: Uint8Array,
-  x: number,
-  y: number,
-  at: number,
-  phase: number
-): boolean {
+function corrode(tiles: Uint8Array, x: number, y: number, at: number, phase: number): boolean {
   if (hash3(x, y, phase) > ACID_BITE) return false
 
   // Below first, then the sides, then up — acid works downward like it should.

--- a/src/app/micro-land/domain/sim/world.ts
+++ b/src/app/micro-land/domain/sim/world.ts
@@ -13,20 +13,18 @@ import {
 } from '@/app/micro-land/domain/config/materials'
 import { DEFAULT_THEME, THEME_BY_ID, type Theme } from '@/app/micro-land/domain/config/themes'
 import {
-  MAX_CREATURES,
-  MAX_PLANTS,
-  NATIVE_PLANT_SPECIES,
-  NATIVE_PLANT_TARGET,
-  PLANT_SEED_BATCH,
-  PLANT_SEED_INTERVAL,
-  PLANT_SPECIES_CAP,
-  SEED_RAIN_INTERVAL,
   SURFACE_SEEDING_BIAS,
   WIDTH_SCALE,
   WORLD_H,
   WORLD_W,
 } from '@/app/micro-land/domain/constants'
-import type { Creature, CreatureBlueprint, MaterialId, WorldState } from '@/app/micro-land/domain/types'
+import { TUNING } from '@/app/micro-land/domain/tuning'
+import type {
+  Creature,
+  CreatureBlueprint,
+  MaterialId,
+  WorldState,
+} from '@/app/micro-land/domain/types'
 
 import { type Rng, makeRng } from './prng'
 
@@ -106,13 +104,7 @@ export function setTile(w: WorldState, x: number, y: number, mat: number): void 
  * Does a box of tiles overlap anything solid?
  * Used for both movement collision and finding somewhere to put a creature.
  */
-export function boxHitsSolid(
-  w: WorldState,
-  x: number,
-  y: number,
-  bw: number,
-  bh: number
-): boolean {
+export function boxHitsSolid(w: WorldState, x: number, y: number, bw: number, bh: number): boolean {
   const x0 = Math.floor(x)
   const y0 = Math.floor(y)
   const x1 = Math.floor(x + bw - 0.001)
@@ -249,13 +241,7 @@ export function boxDrownFraction(
  * The thickest tile wins rather than the average: one foot in the sap should
  * hold you, not be diluted by the nine tiles of clear air around it.
  */
-export function boxViscosity(
-  w: WorldState,
-  x: number,
-  y: number,
-  bw: number,
-  bh: number
-): number {
+export function boxViscosity(w: WorldState, x: number, y: number, bw: number, bh: number): number {
   const x0 = Math.floor(x)
   const y0 = Math.floor(y)
   const x1 = Math.floor(x + bw - 0.001)
@@ -354,7 +340,7 @@ export function spawnCreature(
   x: number,
   y: number
 ): Creature | null {
-  if (w.creatures.length >= MAX_CREATURES) return null
+  if (w.creatures.length >= TUNING.maxCreatures) return null
   if (!w.blueprints[bp.id]) w.blueprints[bp.id] = bp
 
   const creature: Creature = {
@@ -411,8 +397,7 @@ export function findSpawnSpot(
   // Somewhere to stand is judged on the solid core, not the drawing. A dragon
   // that needed a clear 28-tile box to exist would almost never find one, and
   // every summon would silently fall back to "drop it wherever".
-  const fits = (x: number, y: number) =>
-    !boxHitsSolid(w, x + body.dx, y + body.dy, body.w, body.h)
+  const fits = (x: number, y: number) => !boxHitsSolid(w, x + body.dx, y + body.dy, body.w, body.h)
 
   for (let attempt = 0; attempt < 120; attempt++) {
     let x: number
@@ -551,7 +536,7 @@ function isPlant(bp: CreatureBlueprint | undefined): boolean {
 
 /** Native species that are plants. Empty until the ground has decided. */
 function nativePlantIds(w: WorldState): string[] {
-  return w.natives.filter((id) => isPlant(w.blueprints[id]))
+  return w.natives.filter(id => isPlant(w.blueprints[id]))
 }
 
 /** Is there anywhere in this world a plant could put roots down? */
@@ -595,7 +580,7 @@ export function establishNativePlants(w: WorldState, rng: Rng): boolean {
     const j = Math.floor(rng() * (i + 1))
     ;[viable[i], viable[j]] = [viable[j], viable[i]]
   }
-  for (const id of viable.slice(0, NATIVE_PLANT_SPECIES)) w.natives.push(id)
+  for (const id of viable.slice(0, TUNING.nativePlantSpecies)) w.natives.push(id)
   return true
 }
 
@@ -614,7 +599,7 @@ export function establishNativePlants(w: WorldState, rng: Rng): boolean {
  */
 export function seedNativePlants(w: WorldState, rng: Rng): void {
   if (w.elapsed < w.nextPlantSeed) return
-  w.nextPlantSeed = w.elapsed + PLANT_SEED_INTERVAL
+  w.nextPlantSeed = w.elapsed + TUNING.plantSeedInterval
   if (w.dormant) return
   if (!establishNativePlants(w, rng)) return
 
@@ -626,22 +611,22 @@ export function seedNativePlants(w: WorldState, rng: Rng): void {
     plants++
   }
 
-  const deficit = NATIVE_PLANT_TARGET - plants
+  const deficit = TUNING.nativePlantTarget - plants
   if (deficit <= 0) return
-  if (plants >= MAX_PLANTS || w.creatures.length >= MAX_CREATURES) return
+  if (plants >= TUNING.maxPlants || w.creatures.length >= TUNING.maxCreatures) return
 
   // Scale the seeding to how bare the world is: a nearly-full meadow gets one
   // sprout, a stripped one gets the full batch. Recovery from a crash is fast
   // without the ground quietly out-growing the grazers the rest of the time.
   const batch = Math.min(
-    PLANT_SEED_BATCH,
-    Math.max(1, Math.ceil((deficit / NATIVE_PLANT_TARGET) * PLANT_SEED_BATCH))
+    TUNING.plantSeedBatch,
+    Math.max(1, Math.ceil((deficit / TUNING.nativePlantTarget) * TUNING.plantSeedBatch))
   )
 
   // Rarest first, so the ground refills the species the grazers actually
   // emptied instead of piling more onto whichever one is already winning.
   const pool = nativePlantIds(w)
-    .filter((id) => (counts[id] ?? 0) < PLANT_SPECIES_CAP)
+    .filter(id => (counts[id] ?? 0) < TUNING.plantSpeciesCap)
     .sort((a, b) => (counts[a] ?? 0) - (counts[b] ?? 0))
   if (pool.length === 0) return
 
@@ -671,7 +656,7 @@ export function seedNativePlants(w: WorldState, rng: Rng): void {
  */
 export function repopulate(w: WorldState, rng: Rng): void {
   if (w.elapsed < w.nextSeedRain) return
-  w.nextSeedRain = w.elapsed + SEED_RAIN_INTERVAL
+  w.nextSeedRain = w.elapsed + TUNING.seedRainInterval
   if (w.dormant || w.creatures.length === 0 || w.natives.length === 0) return
 
   const counts: Record<string, number> = {}
@@ -683,12 +668,12 @@ export function repopulate(w: WorldState, rng: Rng): void {
   // Plants count here too: one plant species thriving is not a reason for the
   // others to stay extinct, and a grazer too small to eat the survivor depends
   // on the little ones coming back.
-  const candidates = w.natives.filter((id) => {
+  const candidates = w.natives.filter(id => {
     if (counts[id]) return false
     const bp = w.blueprints[id]
     if (!bp) return false
     if (bp.move.kind === 'root' || bp.diet.eats.length === 0) return true
-    return w.creatures.some((c) => {
+    return w.creatures.some(c => {
       const other = w.blueprints[c.blueprintId]
       return other ? canEat(bp, other) : false
     })

--- a/src/app/micro-land/domain/terrain.ts
+++ b/src/app/micro-land/domain/terrain.ts
@@ -71,9 +71,7 @@ export const TerrainSchema = z.object({
       top: hexColor.describe('Color at the very top of the background.'),
       bottom: hexColor.describe('Color at the very bottom of the background.'),
     })
-    .describe(
-      'The empty background behind the world, seen wherever there are no tiles.'
-    ),
+    .describe('The empty background behind the world, seen wherever there are no tiles.'),
   gloom: z
     .number()
     .describe(
@@ -157,12 +155,9 @@ export function sanitizeTerrain(raw: unknown): SanitizedTerrain {
       ...Array(11).fill('ssssssssssssssssssssssssssssssssssssssss'),
     ]
   } else {
-    const width = Math.min(
-      MAP_MAX_COLS,
-      Math.max(MAP_MIN, Math.max(...rawMap.map((r) => r.length)))
-    )
+    const width = Math.min(MAP_MAX_COLS, Math.max(MAP_MIN, Math.max(...rawMap.map(r => r.length))))
     const known = new Set(Object.keys(legend))
-    map = rawMap.map((row) => {
+    map = rawMap.map(row => {
       let line = ''
       for (let x = 0; x < width; x++) {
         const ch = row[x] ?? '.'
@@ -323,5 +318,5 @@ export function terrainToTheme(
 export function hasFertileGround(terrain: SanitizedTerrain): boolean {
   // Read off the materials themselves rather than a copy of the list, so a new
   // fertile material is never fertile for plants but invisible to this check.
-  return Object.values(terrain.legend).some((m) => MATERIALS[m]?.fertile)
+  return Object.values(terrain.legend).some(m => MATERIALS[m]?.fertile)
 }

--- a/src/app/micro-land/domain/tuning.ts
+++ b/src/app/micro-land/domain/tuning.ts
@@ -1,0 +1,365 @@
+/**
+ * The knobs, and the fact that they turn.
+ *
+ * `constants.ts` is the record of what every number should be and why. This is
+ * the small subset of those numbers the simulation reads through a *mutable*
+ * object, so they can be moved while the world is running.
+ *
+ * Every default here is imported from `constants.ts` rather than restated. The
+ * reasoning stays in one place, and a shipped default can never quietly drift
+ * away from the one the panel resets to.
+ *
+ * The simulation reads `TUNING.x`, never the constant it came from. That costs
+ * one property lookup on a hot path, which is nothing; what it buys is a world
+ * you can rebalance by watching it. "The native plants grow too fast" is not a
+ * complaint you can reason your way to a replacement number for — it is a thing
+ * you drag a slider on until the meadow looks right.
+ *
+ * Not everything in `constants.ts` belongs here. A knob earns its place by
+ * being something worth *watching* change: how much green the ground pushes
+ * for, how often, how crowded one species is allowed to get. World size, tick
+ * rate and the record thresholds are not knobs — they are the shape of the
+ * game, and a slider that can break the renderer is not an option, it's a trap.
+ */
+import {
+  BREED_COOLDOWN,
+  BREED_COST,
+  GRAVITY,
+  MAX_CREATURES,
+  MAX_PLANTS,
+  MEAL_VALUE,
+  NATIVE_PLANT_SPECIES,
+  NATIVE_PLANT_TARGET,
+  PLANT_MATURITY,
+  PLANT_SEED_BATCH,
+  PLANT_SEED_INTERVAL,
+  PLANT_SPECIES_CAP,
+  PLANT_SPREAD_COOLDOWN,
+  SEED_RAIN_INTERVAL,
+  SPECIES_SOFT_CAP,
+} from '@/app/micro-land/domain/constants'
+
+/**
+ * Defaults, in the order the panel shows them.
+ *
+ * Counts that `constants.ts` scales by `WIDTH_SCALE` arrive here already
+ * scaled, so a slider labelled "most plants at once" says how many plants there
+ * will actually be in the three-screen world rather than in a screen that no
+ * longer exists.
+ */
+export const TUNING_DEFAULTS = {
+  nativePlantTarget: NATIVE_PLANT_TARGET,
+  plantSeedInterval: PLANT_SEED_INTERVAL,
+  plantSeedBatch: PLANT_SEED_BATCH,
+  plantMaturity: PLANT_MATURITY,
+  plantSpreadCooldown: PLANT_SPREAD_COOLDOWN,
+  maxPlants: MAX_PLANTS,
+  plantSpeciesCap: PLANT_SPECIES_CAP,
+  nativePlantSpecies: NATIVE_PLANT_SPECIES,
+
+  maxCreatures: MAX_CREATURES,
+  speciesSoftCap: SPECIES_SOFT_CAP,
+  breedCooldown: BREED_COOLDOWN,
+  mealValue: MEAL_VALUE,
+  breedCost: BREED_COST,
+  seedRainInterval: SEED_RAIN_INTERVAL,
+
+  gravity: GRAVITY,
+}
+
+export type TuningKey = keyof typeof TUNING_DEFAULTS
+export type Tuning = Record<TuningKey, number>
+
+export type KnobGroup = 'plants' | 'creatures' | 'world'
+
+export interface Knob {
+  key: TuningKey
+  group: KnobGroup
+  /** What the slider is called. Plain language — this panel is for a player. */
+  label: string
+  /** One line under it, saying what turning it up actually does. */
+  help: string
+  min: number
+  max: number
+  step: number
+  /** Appended to the number, for the ones where a bare integer means nothing. */
+  unit?: string
+}
+
+export const KNOB_GROUPS: { id: KnobGroup; title: string; blurb: string }[] = [
+  {
+    id: 'plants',
+    title: 'Green things',
+    blurb:
+      'Plants are the bottom of the food chain, so these move everything above them too. Turn them down and the world gets hungrier.',
+  },
+  {
+    id: 'creatures',
+    title: 'Living things',
+    blurb: 'How crowded the land gets, and how quickly anything makes more of itself.',
+  },
+  { id: 'world', title: 'The world itself', blurb: 'Rules that apply to everything at once.' },
+]
+
+/**
+ * Ranges are wide on purpose.
+ *
+ * The point of the panel is to find out what a world feels like at a number
+ * nobody would have written down, so the ends are set where the simulation
+ * stops *working* rather than where it stops being balanced. A slider that only
+ * offers sensible values can't tell you anything you didn't already know.
+ */
+export const KNOBS: Knob[] = [
+  {
+    key: 'nativePlantTarget',
+    group: 'plants',
+    label: 'Green the ground pushes for',
+    help: 'The soil keeps sprouting until there are roughly this many, then stops and lets plants spread on their own. So this sets how fast a stripped world greens over, not how green it ends up.',
+    min: 0,
+    max: 400,
+    step: 5,
+    unit: 'plants',
+  },
+  {
+    key: 'plantSeedInterval',
+    group: 'plants',
+    label: 'Wait between sproutings',
+    help: 'How long the ground pauses before it seeds again. Longer means green comes back more slowly after a crash.',
+    min: 1,
+    max: 60,
+    step: 1,
+    unit: 's',
+  },
+  {
+    key: 'plantSeedBatch',
+    group: 'plants',
+    label: 'Sprouts at a time',
+    help: 'Most plants one seeding can place, when the world is completely bare.',
+    min: 1,
+    max: 30,
+    step: 1,
+  },
+  {
+    key: 'plantMaturity',
+    group: 'plants',
+    label: 'Age before a plant can spread',
+    help: 'How long a new plant has to stand there before it is allowed to make another.',
+    min: 1,
+    max: 120,
+    step: 1,
+    unit: 's',
+  },
+  {
+    key: 'plantSpreadCooldown',
+    group: 'plants',
+    label: 'Wait between spreads',
+    help: 'How long a grown plant rests after spreading. This is how fast a meadow fills in on its own.',
+    min: 1,
+    max: 180,
+    step: 1,
+    unit: 's',
+  },
+  {
+    key: 'maxPlants',
+    group: 'plants',
+    label: 'Most plants at once',
+    help: 'A hard ceiling. Nothing green is born past this, no matter what else is set.',
+    min: 10,
+    max: 1000,
+    step: 5,
+  },
+  {
+    key: 'plantSpeciesCap',
+    group: 'plants',
+    label: 'Most of any one plant',
+    help: 'Every plant species settles right about here, so this is really how green a grown-in world looks. Turn it down to thin the meadow out — the grazers get hungrier, and there end up being more of them.',
+    min: 5,
+    max: 600,
+    step: 5,
+  },
+  {
+    key: 'nativePlantSpecies',
+    group: 'plants',
+    label: 'Kinds of plant the ground picks',
+    help: 'How many species the soil settles on the first time it decides. Takes effect in the next land you make.',
+    min: 1,
+    max: 8,
+    step: 1,
+  },
+
+  {
+    key: 'maxCreatures',
+    group: 'creatures',
+    label: 'Most creatures at once',
+    help: 'A hard ceiling on everything alive, plants included. Placing and summoning still work past it.',
+    min: 20,
+    max: 2000,
+    step: 10,
+  },
+  {
+    key: 'speciesSoftCap',
+    group: 'creatures',
+    label: 'Most of any one animal',
+    help: 'The land saying there is only so much room here. This is what turns a population crash into a rise and fall.',
+    min: 5,
+    max: 800,
+    step: 5,
+  },
+  {
+    key: 'breedCooldown',
+    group: 'creatures',
+    label: 'Rest between babies',
+    help: 'How long an animal waits after having one before it can have another.',
+    min: 1,
+    max: 120,
+    step: 1,
+    unit: 's',
+  },
+  {
+    key: 'mealValue',
+    group: 'creatures',
+    label: 'How filling a meal is',
+    help: 'How much of an empty stomach one bite fills. A meal is always kept a little short of a baby — otherwise everything breeds on every mouthful and eats the world.',
+    min: 0.05,
+    max: 0.95,
+    step: 0.01,
+  },
+  {
+    key: 'breedCost',
+    group: 'creatures',
+    label: 'What a baby costs a parent',
+    help: 'How much of a full stomach having one uses up.',
+    min: 0.1,
+    max: 1,
+    step: 0.01,
+  },
+  {
+    key: 'seedRainInterval',
+    group: 'creatures',
+    label: 'Wait between comebacks',
+    help: 'How often a kind that has died out is allowed to wander back in — and only ever when there is something alive for it to eat.',
+    min: 1,
+    max: 120,
+    step: 1,
+    unit: 's',
+  },
+
+  {
+    key: 'gravity',
+    group: 'world',
+    label: 'Pull downwards',
+    help: 'How hard everything falls. Each world scales this again on its own, so the station stays floaty.',
+    min: 4,
+    max: 90,
+    step: 1,
+  },
+]
+
+const KNOB_BY_KEY: Record<TuningKey, Knob> = Object.fromEntries(
+  KNOBS.map(k => [k.key, k])
+) as Record<TuningKey, Knob>
+
+/**
+ * The live values. This object is read by the simulation every tick.
+ *
+ * Mutated in place rather than replaced, so the modules that closed over it at
+ * import time see every change without anyone having to re-wire them.
+ */
+export const TUNING: Tuning = { ...TUNING_DEFAULTS }
+
+/**
+ * The one relationship between two knobs that isn't allowed to break.
+ *
+ * If a meal more than pays for a child, grazers breed on every full stomach,
+ * overshoot the plants, and take the entire food chain down with them — a
+ * failure that looks like a thriving world for about ninety seconds. The panel
+ * says so in the help text; this makes sure it stays true regardless.
+ */
+const MEAL_HEADROOM = 0.05
+
+function clampKnob(key: TuningKey, value: number): number {
+  const knob = KNOB_BY_KEY[key]
+  if (!knob || !Number.isFinite(value)) return TUNING_DEFAULTS[key]
+  const clamped = Math.max(knob.min, Math.min(knob.max, value))
+  // Integer steps mean integer values: a batch of 2.6 sprouts is a rounding
+  // decision made somewhere further down, where nobody can see it.
+  return knob.step >= 1 ? Math.round(clamped) : clamped
+}
+
+function enforceInvariants(t: Tuning): void {
+  t.mealValue = Math.min(t.mealValue, t.breedCost - MEAL_HEADROOM)
+  t.mealValue = Math.max(KNOB_BY_KEY.mealValue.min, t.mealValue)
+}
+
+/** Move one or more knobs. Values outside a knob's range are clamped, not rejected. */
+export function setTuning(patch: Partial<Tuning>): void {
+  for (const [key, value] of Object.entries(patch)) {
+    if (!(key in TUNING_DEFAULTS)) continue
+    TUNING[key as TuningKey] = clampKnob(key as TuningKey, value as number)
+  }
+  enforceInvariants(TUNING)
+}
+
+export function resetTuning(): void {
+  Object.assign(TUNING, TUNING_DEFAULTS)
+}
+
+/** Which knobs are currently away from their shipped value. */
+export function changedKnobs(t: Tuning = TUNING): TuningKey[] {
+  return (Object.keys(TUNING_DEFAULTS) as TuningKey[]).filter(
+    key => t[key] !== TUNING_DEFAULTS[key]
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Remembering the settings
+// ---------------------------------------------------------------------------
+
+const STORAGE_KEY = 'micro-land:tuning:v1'
+
+/**
+ * Only the differences are stored, never the whole set.
+ *
+ * A player who never touched a knob keeps getting whatever the game ships with,
+ * including next month's rebalance. Writing all fifteen values would freeze the
+ * defaults of the day they first opened the panel into their browser forever.
+ */
+export function saveTuning(): void {
+  const diff: Partial<Tuning> = {}
+  for (const key of changedKnobs()) diff[key] = TUNING[key]
+  try {
+    if (Object.keys(diff).length === 0) localStorage.removeItem(STORAGE_KEY)
+    else localStorage.setItem(STORAGE_KEY, JSON.stringify(diff))
+  } catch {
+    // Private-mode Safari throws on write. Losing the settings is survivable;
+    // taking the game down with it is not.
+  }
+}
+
+/** Read stored knobs and apply them. Safe to call before anything else exists. */
+export function loadTuning(): void {
+  let raw: string | null = null
+  try {
+    // `localStorage` *throws on read* in private-mode Safari, so even looking
+    // has to be wrapped.
+    raw = localStorage.getItem(STORAGE_KEY)
+  } catch {
+    return
+  }
+  if (!raw) return
+  try {
+    const parsed: unknown = JSON.parse(raw)
+    if (parsed && typeof parsed === 'object') setTuning(parsed as Partial<Tuning>)
+  } catch {
+    // Someone edited it by hand, or a past version wrote something else. The
+    // defaults are a perfectly good answer.
+  }
+}
+
+export function clearStoredTuning(): void {
+  try {
+    localStorage.removeItem(STORAGE_KEY)
+  } catch {
+    // See saveTuning.
+  }
+}

--- a/src/app/micro-land/domain/types.ts
+++ b/src/app/micro-land/domain/types.ts
@@ -48,15 +48,7 @@ export type BaseMaterialId =
 
 /** The colors a tintable material can be painted in. */
 export type TintId =
-  | 'red'
-  | 'orange'
-  | 'yellow'
-  | 'green'
-  | 'blue'
-  | 'purple'
-  | 'pink'
-  | 'white'
-  | 'black'
+  'red' | 'orange' | 'yellow' | 'green' | 'blue' | 'purple' | 'pink' | 'white' | 'black'
 
 /** Materials that come in colors. */
 export type TintableMaterialId = 'plastic' | 'crystal' | 'gem' | 'cloud'

--- a/src/app/micro-land/game-instance.ts
+++ b/src/app/micro-land/game-instance.ts
@@ -15,23 +15,21 @@ import { SUMMONED_THEME_ID } from '@/app/micro-land/store'
 import {
   archivedSpecies,
   claimMilestone,
+  flushChronicle,
+  forgetSpecies,
   landId,
   landRecord,
   noteSpeciesLife,
   readChronicle,
   rememberSpecies,
+  restoreSpeciesRecord,
   updateChronicle,
 } from './chronicle/chronicle'
-import { artSize, bodyBox, sanitizeBlueprint } from './domain/blueprint'
+import { artSize, bodyBox, reserveSummonIds, sanitizeBlueprint } from './domain/blueprint'
 import { MILESTONES, type MilestoneContext } from './domain/config/milestones'
 import { DEFAULT_THEME, THEME_BY_ID, type Theme } from './domain/config/themes'
-import {
-  ELDER_MIN_SECONDS,
-  MAX_CREATURES,
-  TICK_S,
-  TILE_TICK_EVERY,
-} from './domain/constants'
-import { type SimEvent, tickCreatures } from './domain/sim/creature-sim'
+import { ELDER_MIN_SECONDS, TICK_S, TILE_TICK_EVERY } from './domain/constants'
+import { type SimEvent, emitParticles, tickCreatures } from './domain/sim/creature-sim'
 import { makeRng } from './domain/sim/prng'
 import { tickTiles } from './domain/sim/tile-sim'
 import {
@@ -48,13 +46,13 @@ import {
   spawnCreature,
   spawnSomewhereSensible,
 } from './domain/sim/world'
+import { TUNING } from './domain/tuning'
 import { formatDuration } from './format'
 import { Renderer } from './rendering/renderer'
-import {
-  type EarnedMilestone,
-  type PopulationEntry,
-  useMicroLand,
-} from './store'
+import { type EarnedMilestone, type PopulationEntry, useMicroLand } from './store'
+import { releaseActiveWorld, touchActiveWorld } from './worlds/shelf'
+import { restoreSnapshot, snapshotWorld } from './worlds/snapshot'
+import { WORLD_SAVE_VERSION, type WorldSave } from './worlds/types'
 
 import type { SpeciesRecord } from './chronicle/types'
 import type { Creature, CreatureBlueprint, WorldState } from './domain/types'
@@ -79,7 +77,7 @@ const MAX_CATCHUP_MS = 250
  */
 function readMilestones(): EarnedMilestone[] {
   const earned = readChronicle().milestones
-  return MILESTONES.filter((m) => earned[m.id]).map((m) => ({
+  return MILESTONES.filter(m => earned[m.id]).map(m => ({
     id: m.id,
     text: m.text,
     at: earned[m.id],
@@ -137,8 +135,7 @@ export class GameInstance {
    * has already been filtered out of the world, so there is nothing left to read
    * its age or its name off by then.
    */
-  private elderSnapshot: { name: string | null; species: string; seconds: number } | null =
-    null
+  private elderSnapshot: { name: string | null; species: string; seconds: number } | null = null
   /** World-clock time the current no-extinction streak began. */
   private steadySince = 0
   /** Archive size at the last push, so the guide is only re-sent when it grows. */
@@ -151,6 +148,14 @@ export class GameInstance {
   private inspectedId: number | null = null
   /** Terrain the player summoned, standing in for a built-in theme. */
   private summonedTheme: Theme | null = null
+  /**
+   * The terrain that theme was built from.
+   *
+   * Kept alongside it because a `Theme` carries a `build` function and functions
+   * do not survive JSON — this is the half of a summoned land that can be
+   * shelved, and `terrainToTheme` rebuilds the rest of it on the way back in.
+   */
+  private summonedTerrain: SanitizedTerrain | null = null
   private grabTrail: { x: number; y: number; t: number }[] = []
   private lastPlaceAt = 0
   private resizeObserver: ResizeObserver | null = null
@@ -184,6 +189,7 @@ export class GameInstance {
     this.renderer = new Renderer(canvas)
     this.world = createWorld(Date.now() & 0xffff)
 
+    this.restoreArchivedCreatures()
     this.syncBlueprintsToStore()
     this.setTheme(useMicroLand.getState().themeId || DEFAULT_THEME)
     this.attachInput()
@@ -307,7 +313,7 @@ export class GameInstance {
     }
 
     if (this.following && this.inspectedId !== null) {
-      const c = this.world.creatures.find((x) => x.id === this.inspectedId)
+      const c = this.world.creatures.find(x => x.id === this.inspectedId)
       if (c) {
         this.renderer.keepInView(c.x, this.renderer.viewWidth * 0.22, FOLLOW_SPEED * dt)
       }
@@ -354,16 +360,14 @@ export class GameInstance {
       if (!bp) continue
       // Was that the last one? Only interesting for species we'd seen alive.
       if (!this.knownSpecies.has(bp.id)) continue
-      const stillAlive = this.world.creatures.some((c) => c.blueprintId === bp.id)
+      const stillAlive = this.world.creatures.some(c => c.blueprintId === bp.id)
       if (stillAlive) continue
       this.knownSpecies.delete(bp.id)
       // An extinction is exactly what the steady streak measures the absence of
       // — it is the moment the world has to bail the player out via seed rain.
       this.breakSteadyStreak()
       notify(
-        event.kind === 'starved'
-          ? `The last ${bp.name} starved.`
-          : `The last ${bp.name} was eaten.`
+        event.kind === 'starved' ? `The last ${bp.name} starved.` : `The last ${bp.name} was eaten.`
       )
     }
   }
@@ -396,12 +400,15 @@ export class GameInstance {
 
     for (const entry of population) this.knownSpecies.add(entry.blueprintId)
 
-    useMicroLand
-      .getState()
-      .setStats(population, this.world.creatures.length, this.world.elapsed)
+    useMicroLand.getState().setStats(population, this.world.creatures.length, this.world.elapsed)
 
     this.updateRecords(population)
     this.pushInspected()
+
+    // A running world is different every tick, so there is no cheaper signal
+    // than "time passed" to hang the autosave on. The shelf debounces it hard
+    // and does nothing at all when no shelved world is open.
+    touchActiveWorld()
   }
 
   // -------------------------------------------------------------------------
@@ -422,7 +429,7 @@ export class GameInstance {
 
     // The elder is gone if it isn't in the world any more. Checked before the
     // new elder is chosen so the eulogy names the right creature.
-    if (this.elderId !== null && !w.creatures.some((c) => c.id === this.elderId)) {
+    if (this.elderId !== null && !w.creatures.some(c => c.id === this.elderId)) {
       this.mourn()
     }
 
@@ -457,11 +464,7 @@ export class GameInstance {
     updateChronicle(() => {
       // --- longevity ---------------------------------------------------
       const best = record.elder?.seconds ?? 0
-      if (
-        oldest &&
-        oldest.ageSeconds >= ELDER_MIN_SECONDS &&
-        oldest.ageSeconds > best
-      ) {
+      if (oldest && oldest.ageSeconds >= ELDER_MIN_SECONDS && oldest.ageSeconds > best) {
         const bp = w.blueprints[oldest.blueprintId]
         if (bp) {
           const crowning = this.elderId !== oldest.id
@@ -491,7 +494,7 @@ export class GameInstance {
       // --- bloodline ----------------------------------------------------
       if (deepest > record.generations) {
         record.generations = deepest
-        const line = w.creatures.find((c) => c.generation === deepest)
+        const line = w.creatures.find(c => c.generation === deepest)
         const bp = line ? w.blueprints[line.blueprintId] : undefined
         record.generationsBlueprintId = bp?.id ?? null
         record.generationsSpeciesName = bp?.name ?? null
@@ -553,7 +556,7 @@ export class GameInstance {
   nameElder(name: string): boolean {
     const trimmed = name.trim().slice(0, 24)
     if (!trimmed || this.elderId === null) return false
-    const c = this.world.creatures.find((x) => x.id === this.elderId)
+    const c = this.world.creatures.find(x => x.id === this.elderId)
     if (!c) return false
     c.name = trimmed
     if (this.elderSnapshot) this.elderSnapshot.name = trimmed
@@ -573,7 +576,7 @@ export class GameInstance {
     const full = {
       ...context,
       archived: archive.length,
-      summonedArchived: archive.filter((s) => s.blueprint.summoned).length,
+      summonedArchived: archive.filter(s => s.blueprint.summoned).length,
     }
     const now = Date.now()
     const store = useMicroLand.getState()
@@ -617,10 +620,7 @@ export class GameInstance {
    */
   private beginLand(): void {
     this.breakSteadyStreak()
-    this.currentLand = landId(
-      useMicroLand.getState().themeId,
-      useMicroLand.getState().summonedLand
-    )
+    this.currentLand = landId(useMicroLand.getState().themeId, useMicroLand.getState().summonedLand)
     this.steadySince = this.world.elapsed
     // A cleared world has no elder; do this quietly rather than eulogizing a
     // creature the player deliberately removed.
@@ -637,11 +637,11 @@ export class GameInstance {
       return
     }
 
-    const c = this.world.creatures.find((x) => x.id === this.inspectedId)
+    const c = this.world.creatures.find(x => x.id === this.inspectedId)
     if (!c) {
       // It died while we were watching. Let go rather than freezing a corpse.
       this.inspectedId = null
-    this.following = false
+      this.following = false
       store.setInspected(null)
       return
     }
@@ -650,9 +650,8 @@ export class GameInstance {
     if (!bp) return
     const { w: bw, h: bh } = artSize(bp)
 
-    const target = c.targetId !== null
-      ? this.world.creatures.find((x) => x.id === c.targetId)
-      : undefined
+    const target =
+      c.targetId !== null ? this.world.creatures.find(x => x.id === c.targetId) : undefined
     const targetBp = target ? this.world.blueprints[target.blueprintId] : undefined
 
     store.setInspected({
@@ -681,6 +680,116 @@ export class GameInstance {
     useMicroLand.getState().setBlueprints(Object.values(this.world.blueprints))
   }
 
+  /**
+   * Put previously summoned creatures back on the shelf.
+   *
+   * The chronicle has archived their blueprints in full since it was written —
+   * that is the stated point of `SpeciesRecord.blueprint` — but nothing ever
+   * read them back into the roster, so `createWorld` seeded only the built-ins
+   * and a creature invented yesterday was missing from the toolbar today. It
+   * still appeared in the field guide, which made the loss look like a display
+   * bug rather than a missing restore.
+   *
+   * Only the roster is restored, never the population. The land is deliberately
+   * forgetful — "you are not keeping a save file, you are keeping a logbook" —
+   * and spawning yesterday's creatures into today's world would break both that
+   * and the empty-by-default start. What comes back is the *ability* to place
+   * them.
+   *
+   * Safe to call before `initChronicle` resolves, in which case the archive is
+   * simply empty; `MicroLandGame` already sequences the load first.
+   */
+  /**
+   * Re-read the archive into the roster after it has changed underneath us.
+   *
+   * Signing in merges an account's chronicle into the live one *after* the world
+   * was built, so a player opening Micro Land on a new device would see their
+   * creatures land in the field guide but not in the toolbar until they
+   * reloaded. Cheap enough to just re-run: `registerBlueprint` overwrites by id.
+   */
+  refreshRoster(): void {
+    this.restoreArchivedCreatures()
+    this.syncBlueprintsToStore()
+  }
+
+  /**
+   * Remove a summoned species from the world and from the records.
+   *
+   * Everything alive bursts in its own death colour rather than blinking out —
+   * the particle burst is the one already used when a creature dies, so "gone"
+   * looks like something that happened rather than a rendering glitch.
+   *
+   * Returns the archived record, which is the entire undo. Null means there was
+   * nothing to remove, or the caller aimed at a built-in: those are config, not
+   * records, and would simply reappear on the next load.
+   */
+  removeSpecies(blueprintId: string): SpeciesRecord | null {
+    const bp = this.world.blueprints[blueprintId]
+    if (!bp?.summoned) return null
+
+    const w = this.world
+    for (const c of w.creatures) {
+      if (c.blueprintId !== blueprintId) continue
+      const { w: aw, h: ah } = artSize(bp)
+      emitParticles(w, c.x + aw / 2, c.y + ah / 2, bp.death.particleColor, bp.death.particleCount)
+    }
+    w.creatures = w.creatures.filter(c => c.blueprintId !== blueprintId)
+
+    delete w.blueprints[blueprintId]
+    /**
+     * `natives` must lose it too.
+     *
+     * `registerBlueprint` pushes every species onto that list, and both safety
+     * nets read `w.blueprints[id]` straight off it — `nativePlants` to decide
+     * what the soil can re-seed, `repopulate` to pick who comes back. Leaving a
+     * dangling id there hands `undefined` to `isPlant` and breaks the two
+     * mechanisms that stop the world flatlining, which would look nothing like
+     * a deletion bug when it eventually surfaced.
+     */
+    w.natives = w.natives.filter(id => id !== blueprintId)
+
+    // The player may have had it selected, or been watching one of them.
+    const state = useMicroLand.getState()
+    if (state.tool.kind === 'creature' && state.tool.blueprintId === blueprintId) {
+      state.setTool({ kind: 'inspect' })
+    }
+    if (!w.creatures.some(c => c.id === this.inspectedId)) {
+      this.inspectedId = null
+      this.following = false
+      state.setInspected(null)
+    }
+
+    const record = forgetSpecies(blueprintId)
+    this.syncBlueprintsToStore()
+    this.pushStats()
+    // Straight to storage rather than on the debounce: a deletion the player
+    // then closes the tab on must not come back.
+    void flushChronicle()
+
+    return record ?? { blueprint: bp, firstSeen: Date.now(), lastSeen: Date.now(), longestLife: 0 }
+  }
+
+  /** Put a removed species back on the shelf. Undo for `removeSpecies`. */
+  restoreSpecies(record: SpeciesRecord): void {
+    restoreSpeciesRecord(record)
+    registerBlueprint(this.world, record.blueprint)
+    this.syncBlueprintsToStore()
+    void flushChronicle()
+  }
+
+  private restoreArchivedCreatures(): void {
+    const restored = archivedSpecies()
+      .filter(record => record.blueprint.summoned)
+      .map(record => record.blueprint)
+
+    for (const bp of restored) registerBlueprint(this.world, bp)
+
+    // Ids carry a counter that resets with the page. Without this, the first
+    // creature summoned after a reload would be handed an id a restored one is
+    // already using, and would silently overwrite it in the roster.
+    reserveSummonIds(restored.map(bp => bp.id))
+  }
+
   // -------------------------------------------------------------------------
   // World commands (called from the UI)
   // -------------------------------------------------------------------------
@@ -696,14 +805,19 @@ export class GameInstance {
    * Living creatures are kept — the ground changes underneath them.
    */
   applyTerrain(raw: unknown, opts: { keepCreatures?: boolean } = {}): SanitizedTerrain {
+    // The land is about to be something else, so this is no longer the world the
+    // player shelved. Let go of it rather than letting the next autosave
+    // overwrite a saved world with the one that replaced it.
+    releaseActiveWorld()
     const terrain = sanitizeTerrain(raw)
+    this.summonedTerrain = terrain
     this.summonedTheme = terrainToTheme(terrain, MATERIAL_INDEX)
     applyThemeObject(this.world, this.summonedTheme)
     if (!opts.keepCreatures) {
       clearCreatures(this.world)
       this.knownSpecies.clear()
       this.inspectedId = null
-    this.following = false
+      this.following = false
     }
     this.renderer.markTilesDirty()
     useMicroLand.getState().setSummonedLand(terrain.name)
@@ -716,12 +830,15 @@ export class GameInstance {
   }
 
   setTheme(themeId: string): void {
+    // Same reasoning as `applyTerrain`: a new theme is a new land, not a change
+    // to the shelved one. `adoptSave` re-claims it immediately afterwards.
+    releaseActiveWorld()
     if (themeId === SUMMONED_THEME_ID && this.summonedTheme) {
       applyThemeObject(this.world, this.summonedTheme)
       clearCreatures(this.world)
       this.knownSpecies.clear()
       this.inspectedId = null
-    this.following = false
+      this.following = false
       this.renderer.markTilesDirty()
       this.beginLand()
       this.pushStats()
@@ -742,13 +859,16 @@ export class GameInstance {
 
   /** Rebuild the terrain with a new seed, keeping the theme. */
   reshuffle(): void {
+    // Reshape rebuilds the terrain from a new seed — the shelved world is gone
+    // from the screen, and must not be gone from the shelf as well.
+    releaseActiveWorld()
     const themeId = useMicroLand.getState().themeId
     if (themeId === SUMMONED_THEME_ID && this.summonedTheme) {
       applyThemeObject(this.world, this.summonedTheme)
       clearCreatures(this.world)
       this.knownSpecies.clear()
       this.inspectedId = null
-    this.following = false
+      this.following = false
       this.renderer.markTilesDirty()
       this.beginLand()
       this.pushStats()
@@ -792,7 +912,7 @@ export class GameInstance {
 
     let placed = 0
     for (let i = 0; i < count; i++) {
-      if (this.world.creatures.length >= MAX_CREATURES) break
+      if (this.world.creatures.length >= TUNING.maxCreatures) break
       if (spawnSomewhereSensible(this.world, bp, this.rng)) placed++
     }
     this.pushStats()
@@ -801,6 +921,116 @@ export class GameInstance {
 
   getWorld(): WorldState {
     return this.world
+  }
+
+  // -------------------------------------------------------------------------
+  // The shelf
+  // -------------------------------------------------------------------------
+
+  /**
+   * Freeze the world as it stands, under a given identity.
+   *
+   * The identity comes from the caller rather than from here because the game
+   * instance has no opinion about which shelf slot it is: a first save mints an
+   * id and takes the name the player typed, and every autosave afterwards passes
+   * the same three back in. Everything else — the land, its inhabitants, where
+   * the record-keeper was standing, where the camera was pointing — is read off
+   * the running world.
+   */
+  toSave(identity: { id: string; name: string; createdAt: number }): WorldSave {
+    return {
+      version: WORLD_SAVE_VERSION,
+      id: identity.id,
+      name: identity.name,
+      createdAt: identity.createdAt,
+      updatedAt: Date.now(),
+      themeId: useMicroLand.getState().themeId,
+      terrain: this.summonedTerrain,
+      camX: Math.round(this.renderer.cameraX),
+      land: {
+        landId: this.currentLand,
+        steadySince: this.steadySince,
+        elderId: this.elderId,
+      },
+      world: snapshotWorld(this.world),
+    }
+  }
+
+  /**
+   * Drop the player into a shelved world, mid-breath.
+   *
+   * The order here is load-bearing. The store's theme is set *first*, which the
+   * subscription in `MicroLandGame` turns into a `setTheme` call and a freshly
+   * generated land — wasted work that is nonetheless the simplest correct thing,
+   * because it leaves every piece of theme state (sky, gloom, gravity, the world
+   * picker) consistent before the saved tiles are written over the top of it.
+   * The alternative was a re-entrancy flag threaded through the store, to save
+   * about ten milliseconds once per world opened.
+   *
+   * Records survive the move intact: the outgoing world banks its streak on the
+   * way out, and the saved one restores the streak it was in the middle of, so
+   * neither is lost and neither is inflated. Nothing here can lower a
+   * high-water mark (invariant 11) — `steadySince` is a live clock, not a record.
+   *
+   * Returns false if the save could not be decoded, having changed nothing the
+   * player can see except the theme they asked for.
+   */
+  adoptSave(save: WorldSave): boolean {
+    const store = useMicroLand.getState()
+
+    if (save.terrain) {
+      this.summonedTerrain = save.terrain
+      this.summonedTheme = terrainToTheme(save.terrain, MATERIAL_INDEX)
+      store.setSummonedLand(save.terrain.name)
+      store.setTheme(SUMMONED_THEME_ID)
+    } else {
+      // The previous summoned land is deliberately left in place. It is still
+      // an entry in the world picker, and `summonedTheme` and `summonedTerrain`
+      // have to stay in step — clearing only one of them would leave a land the
+      // player can still select but that can no longer be shelved.
+      store.setTheme(save.themeId)
+    }
+    // `setTheme` above may not have fired the subscription — the theme can
+    // already be the right one — so bank the outgoing streak here rather than
+    // relying on the rebuild to have done it.
+    this.breakSteadyStreak()
+
+    if (!restoreSnapshot(this.world, save.world)) return false
+
+    this.currentLand = save.land.landId
+    // Clamped because `steadySince` is a point on the world clock and a save
+    // claiming one in this world's future would report a negative streak.
+    this.steadySince = Math.min(save.land.steadySince, this.world.elapsed)
+
+    // The elder's halo comes back only if the creature wearing it did. The
+    // eulogy needs its own copy of the details, because by the time it is spoken
+    // the creature has already been filtered out of the world.
+    const elder =
+      save.land.elderId === null
+        ? undefined
+        : this.world.creatures.find(c => c.id === save.land.elderId)
+    this.elderId = elder?.id ?? null
+    this.elderSnapshot = elder
+      ? {
+          name: elder.name,
+          species: this.world.blueprints[elder.blueprintId]?.name ?? 'creature',
+          seconds: elder.ageSeconds,
+        }
+      : null
+
+    // Seeded from what is actually alive, so opening a world does not announce
+    // the extinction of everything that was in the land it replaced.
+    this.knownSpecies = new Set(this.world.creatures.map(c => c.blueprintId))
+    this.inspectedId = null
+    this.following = false
+    store.setInspected(null)
+
+    this.renderer.panToLeft(save.camX)
+    this.renderer.markTilesDirty()
+    this.syncBlueprintsToStore()
+    this.publishRecords()
+    this.pushStats()
+    return true
   }
 
   // -------------------------------------------------------------------------
@@ -912,9 +1142,7 @@ export class GameInstance {
       const dx = from - this.panAnchorX
       // A tap that has turned into a drag is no longer a tap.
       if (this.pendingInspect && Math.abs(dx) > TAP_SLOP) this.pendingInspect = null
-      this.renderer.panToLeft(
-        this.panAnchorCam - dx * this.renderer.tilesPerClientPixel()
-      )
+      this.renderer.panToLeft(this.panAnchorCam - dx * this.renderer.tilesPerClientPixel())
       return
     }
 
@@ -933,14 +1161,8 @@ export class GameInstance {
       const bp = this.world.blueprints[this.grabbed.blueprintId]
       if (bp) {
         const { w, h } = artSize(bp)
-        this.grabbed.x = Math.max(
-          0,
-          Math.min(this.world.width - w, p.x - w / 2)
-        )
-        this.grabbed.y = Math.max(
-          0,
-          Math.min(this.world.height - h, p.y - h / 2)
-        )
+        this.grabbed.x = Math.max(0, Math.min(this.world.width - w, p.x - w / 2))
+        this.grabbed.y = Math.max(0, Math.min(this.world.height - h, p.y - h / 2))
         this.grabbed.vx = 0
         this.grabbed.vy = 0
       }
@@ -1001,7 +1223,7 @@ export class GameInstance {
       const bp = this.world.blueprints[tool.blueprintId]
       if (!bp) return
       this.world.dormant = false
-      if (this.world.creatures.length >= MAX_CREATURES) {
+      if (this.world.creatures.length >= TUNING.maxCreatures) {
         state.notify('The world is full. Something has to go.')
         return
       }
@@ -1039,12 +1261,7 @@ export class GameInstance {
       const { w, h } = artSize(bp)
       // A little slack so small creatures are still grabbable on a phone.
       const pad = Math.max(0, 3 - Math.min(w, h) / 2)
-      if (
-        x >= c.x - pad &&
-        x <= c.x + w + pad &&
-        y >= c.y - pad &&
-        y <= c.y + h + pad
-      ) {
+      if (x >= c.x - pad && x <= c.x + w + pad && y >= c.y - pad && y <= c.y + h + pad) {
         return c
       }
     }

--- a/src/app/micro-land/rendering/renderer.ts
+++ b/src/app/micro-land/rendering/renderer.ts
@@ -157,7 +157,7 @@ export class Renderer {
     this.mapCtx = this.mapCanvas.getContext('2d')!
     this.mapImage = this.mapCtx.createImageData(MW, MH)
 
-    this.materialRgb = MATERIAL_BY_INDEX.map((m) => hexToRgb(m.color))
+    this.materialRgb = MATERIAL_BY_INDEX.map(m => hexToRgb(m.color))
   }
 
   /** Call whenever tiles change — painting, theme swap, lava setting solid. */
@@ -522,14 +522,9 @@ export class Renderer {
       // many things happen to be alive.
       if (c.x + sprites.width < vx || c.x > vx + vw) continue
       const frameCount = sprites.frames.length
-      const frame =
-        frameCount === 1
-          ? 0
-          : Math.floor(c.animMs / sprites.frameMs) % frameCount
+      const frame = frameCount === 1 ? 0 : Math.floor(c.animMs / sprites.frameMs) % frameCount
       const source =
-        c.facing === -1 && bp.art.faceMotion
-          ? sprites.flipped[frame]
-          : sprites.frames[frame]
+        c.facing === -1 && bp.art.faceMotion ? sprites.flipped[frame] : sprites.frames[frame]
 
       const x = Math.round(c.x)
       const y = Math.round(c.y)
@@ -554,7 +549,7 @@ export class Renderer {
    * it knows lives behind a tap.
    */
   private drawElder(w: WorldState, id: number): void {
-    const c = w.creatures.find((x) => x.id === id)
+    const c = w.creatures.find(x => x.id === id)
     if (!c) return
     const bp = w.blueprints[c.blueprintId]
     if (!bp) return
@@ -580,19 +575,14 @@ export class Renderer {
     const steps = Math.max(12, Math.round(rx * 6))
     for (let i = 0; i < steps; i++) {
       const t = (i / steps) * Math.PI * 2
-      ctx.fillRect(
-        Math.round(cx + Math.cos(t) * rx),
-        Math.round(cy + Math.sin(t) * ry),
-        1,
-        1
-      )
+      ctx.fillRect(Math.round(cx + Math.cos(t) * rx), Math.round(cy + Math.sin(t) * ry), 1, 1)
     }
     ctx.globalAlpha = 1
   }
 
   /** Ring around the creature the inspector is watching. */
   private drawHighlight(w: WorldState, id: number): void {
-    const c = w.creatures.find((x) => x.id === id)
+    const c = w.creatures.find(x => x.id === id)
     if (!c) return
     const bp = w.blueprints[c.blueprintId]
     if (!bp) return

--- a/src/app/micro-land/rendering/sprite-cache.ts
+++ b/src/app/micro-land/rendering/sprite-cache.ts
@@ -67,7 +67,7 @@ export function getSprites(bp: CreatureBlueprint): SpriteSet {
   const existing = cache.get(bp.id)
   if (existing) return existing
 
-  const frames = bp.art.frames.map((rows) => rasterize(bp, rows))
+  const frames = bp.art.frames.map(rows => rasterize(bp, rows))
   const set: SpriteSet = {
     width: frames[0].width,
     height: frames[0].height,

--- a/src/app/micro-land/store.ts
+++ b/src/app/micro-land/store.ts
@@ -10,9 +10,21 @@
 import { create } from 'zustand'
 
 import { DEFAULT_THEME } from './domain/config/themes'
+import {
+  TUNING,
+  type Tuning,
+  type TuningKey,
+  clearStoredTuning,
+  loadTuning,
+  resetTuning,
+  saveTuning,
+  setTuning,
+} from './domain/tuning'
 
+import type { SaveState } from './chronicle/chronicle'
 import type { ElderRecord, SpeciesRecord } from './chronicle/types'
 import type { CreatureBlueprint, MaterialId } from './domain/types'
+import type { ShelfState } from './worlds/shelf'
 
 /** Theme id standing for "the land the player summoned". */
 export const SUMMONED_THEME_ID = 'summoned'
@@ -100,6 +112,15 @@ export interface PopulationEntry {
 export interface Notice {
   id: number
   text: string
+  /**
+   * An optional one-tap follow-up, used for undo.
+   *
+   * Lives on the notice rather than in a dialog because the audience is a child
+   * mid-play: a strip that says what happened and offers to take it back costs
+   * no reading and no dismissal, and a wrong tap costs exactly one more tap.
+   * Running it dismisses the notice.
+   */
+  action?: { label: string; run: () => void }
 }
 
 /**
@@ -136,7 +157,25 @@ interface MicroLandState {
   summonError: string | null
   /** Creature summons in flight, in the order they were asked for. */
   pendingSummons: PendingSummon[]
+  /**
+   * The hand-drawing panel.
+   *
+   * Its own flag rather than a fourth `summonMode`: drawing is a session the
+   * player comes back to, not a one-shot request, and it has to survive the
+   * summon panel being opened and closed around it.
+   */
+  builderOpen: boolean
   guideOpen: boolean
+  settingsOpen: boolean
+  /**
+   * A copy of the live tuning knobs, kept only so React can draw the sliders.
+   *
+   * The simulation reads the mutable `TUNING` object directly and never looks at
+   * this. Two representations of the same thing is normally a smell; here it is
+   * the same trade the world itself makes — the thing that runs sixty times a
+   * second stays out of React, and React gets a snapshot it can render.
+   */
+  tuning: Tuning
   inspected: Inspected | null
 
   /** Records for the land on screen. */
@@ -160,6 +199,27 @@ interface MicroLandState {
 
   notices: Notice[]
 
+  /**
+   * What the chronicle's storage layer is doing.
+   *
+   * Mirrored into the store rather than read through a hook so the field guide
+   * can render it like any other piece of state. Kept deliberately factual —
+   * whether records are safe, and where — because a player who cannot tell the
+   * difference between "kept forever" and "kept until you clear your browser"
+   * cannot make a sensible decision about signing up.
+   */
+  saveState: SaveState
+
+  /**
+   * The shelf of saved worlds, mirrored out of `worlds/shelf.ts`.
+   *
+   * Same arrangement as `saveState`: the module owns it because it outlives any
+   * React tree and the game instance reads it imperatively, and the store gets a
+   * copy so panels can render it like any other state.
+   */
+  shelf: ShelfState
+  worldsOpen: boolean
+
   setTheme: (id: string) => void
   setTool: (tool: Tool) => void
   setBrush: (n: number) => void
@@ -175,20 +235,38 @@ interface MicroLandState {
   /** Opens a slot for a creature on its way; returns the id to close it with. */
   addPendingSummon: (prompt: string) => number
   removePendingSummon: (id: number) => void
+  setBuilderOpen: (open: boolean) => void
   setGuideOpen: (open: boolean) => void
+  setSettingsOpen: (open: boolean) => void
+  /** Move one knob. Takes effect on the very next tick and is remembered. */
+  setTuningKnob: (key: TuningKey, value: number) => void
+  /** Put every knob back to what the game shipped with. */
+  resetTuningKnobs: () => void
+  /**
+   * Pull remembered knobs out of storage.
+   *
+   * Called once from the client rather than done when this module loads: the
+   * store is built during the server render too, and reading `localStorage`
+   * there gives a different answer than the browser will, which is a hydration
+   * mismatch waiting to happen.
+   */
+  hydrateTuning: () => void
   setInspected: (snapshot: Inspected | null) => void
   setRecords: (records: RecordsView) => void
   setArchive: (archive: SpeciesRecord[]) => void
   setMilestones: (milestones: EarnedMilestone[]) => void
   setCanPan: (canPan: boolean) => void
-  notify: (text: string) => void
+  setSaveState: (state: SaveState) => void
+  setShelf: (shelf: ShelfState) => void
+  setWorldsOpen: (open: boolean) => void
+  notify: (text: string, action?: Notice['action']) => void
   dismissNotice: (id: number) => void
 }
 
 let noticeId = 0
 let pendingId = 0
 
-export const useMicroLand = create<MicroLandState>((set) => ({
+export const useMicroLand = create<MicroLandState>(set => ({
   themeId: DEFAULT_THEME,
   tool: { kind: 'material', material: 'dirt' },
   brush: 4,
@@ -206,7 +284,10 @@ export const useMicroLand = create<MicroLandState>((set) => ({
   summonedLand: null,
   summonError: null,
   pendingSummons: [],
+  builderOpen: false,
   guideOpen: false,
+  settingsOpen: false,
+  tuning: { ...TUNING },
   inspected: null,
   canPan: true,
 
@@ -215,39 +296,64 @@ export const useMicroLand = create<MicroLandState>((set) => ({
   milestones: [],
 
   notices: [],
+  saveState: { kind: 'idle' },
+  shelf: { worlds: [], activeId: null, busy: false, error: null },
+  worldsOpen: false,
 
-  setTheme: (themeId) => set({ themeId }),
-  setTool: (tool) => set({ tool }),
-  setBrush: (brush) => set({ brush }),
-  togglePaused: () => set((s) => ({ paused: !s.paused })),
-  setSpeed: (speed) => set({ speed }),
-  setBlueprints: (blueprints) => set({ blueprints }),
-  setStats: (population, totalCreatures, elapsed) =>
-    set({ population, totalCreatures, elapsed }),
-  setSummonOpen: (summonOpen) => set({ summonOpen }),
-  setSummonBusy: (summonBusy) => set({ summonBusy }),
-  setSummonMode: (summonMode) => set({ summonMode }),
-  setSummonedLand: (summonedLand) => set({ summonedLand }),
-  setSummonError: (summonError) => set({ summonError }),
-  addPendingSummon: (prompt) => {
+  setTheme: themeId => set({ themeId }),
+  setTool: tool => set({ tool }),
+  setBrush: brush => set({ brush }),
+  togglePaused: () => set(s => ({ paused: !s.paused })),
+  setSpeed: speed => set({ speed }),
+  setBlueprints: blueprints => set({ blueprints }),
+  setStats: (population, totalCreatures, elapsed) => set({ population, totalCreatures, elapsed }),
+  setSummonOpen: summonOpen => set({ summonOpen }),
+  setSummonBusy: summonBusy => set({ summonBusy }),
+  setSummonMode: summonMode => set({ summonMode }),
+  setSummonedLand: summonedLand => set({ summonedLand }),
+  setSummonError: summonError => set({ summonError }),
+  addPendingSummon: prompt => {
     const id = ++pendingId
-    set((s) => ({ pendingSummons: [...s.pendingSummons, { id, prompt }] }))
+    set(s => ({ pendingSummons: [...s.pendingSummons, { id, prompt }] }))
     return id
   },
-  removePendingSummon: (id) =>
-    set((s) => ({ pendingSummons: s.pendingSummons.filter((p) => p.id !== id) })),
-  setGuideOpen: (guideOpen) => set({ guideOpen }),
-  setInspected: (inspected) => set({ inspected }),
-  setRecords: (records) => set({ records }),
-  setArchive: (archive) => set({ archive }),
-  setMilestones: (milestones) => set({ milestones }),
-  setCanPan: (canPan) => set({ canPan }),
+  removePendingSummon: id =>
+    set(s => ({ pendingSummons: s.pendingSummons.filter(p => p.id !== id) })),
+  setBuilderOpen: builderOpen => set({ builderOpen }),
+  setGuideOpen: guideOpen => set({ guideOpen }),
+  setSettingsOpen: settingsOpen => set({ settingsOpen }),
 
-  notify: (text) =>
-    set((s) => ({
+  // Every one of these writes the mutable object first and mirrors it after,
+  // never the other way round: `setTuning` clamps and can hold one knob against
+  // another, so the snapshot has to be taken of what actually landed.
+  setTuningKnob: (key, value) => {
+    setTuning({ [key]: value })
+    saveTuning()
+    set({ tuning: { ...TUNING } })
+  },
+  resetTuningKnobs: () => {
+    resetTuning()
+    clearStoredTuning()
+    set({ tuning: { ...TUNING } })
+  },
+  hydrateTuning: () => {
+    loadTuning()
+    set({ tuning: { ...TUNING } })
+  },
+  setInspected: inspected => set({ inspected }),
+  setRecords: records => set({ records }),
+  setArchive: archive => set({ archive }),
+  setMilestones: milestones => set({ milestones }),
+  setCanPan: canPan => set({ canPan }),
+
+  setSaveState: saveState => set({ saveState }),
+  setShelf: shelf => set({ shelf }),
+  setWorldsOpen: worldsOpen => set({ worldsOpen }),
+
+  notify: (text, action) =>
+    set(s => ({
       // Keep the last few — a population crash can fire several at once.
-      notices: [...s.notices, { id: ++noticeId, text }].slice(-3),
+      notices: [...s.notices, { id: ++noticeId, text, action }].slice(-3),
     })),
-  dismissNotice: (id) =>
-    set((s) => ({ notices: s.notices.filter((n) => n.id !== id) })),
+  dismissNotice: id => set(s => ({ notices: s.notices.filter(n => n.id !== id) })),
 }))

--- a/src/app/micro-land/worlds/__tests__/snapshot.test.ts
+++ b/src/app/micro-land/worlds/__tests__/snapshot.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, it } from 'vitest'
+
+import { sanitizeBlueprint } from '@/app/micro-land/domain/blueprint'
+import { MATERIAL_IDS, MATERIAL_INDEX } from '@/app/micro-land/domain/config/materials'
+import { WORLD_H, WORLD_W } from '@/app/micro-land/domain/constants'
+import { createWorld, registerBlueprint, spawnCreature } from '@/app/micro-land/domain/sim/world'
+import {
+  decodeTiles,
+  encodeTiles,
+  restoreSnapshot,
+  snapshotWorld,
+} from '@/app/micro-land/worlds/snapshot'
+
+/** A world with some ground, a summoned species, and a few of them alive in it. */
+function populatedWorld() {
+  const w = createWorld(4242)
+  for (let y = WORLD_H - 20; y < WORLD_H; y++) {
+    for (let x = 0; x < WORLD_W; x++) w.tiles[y * WORLD_W + x] = MATERIAL_INDEX.dirt
+  }
+
+  const bp = sanitizeBlueprint(
+    {
+      name: 'Test Grazer',
+      body: { pixels: ['ab', 'ba'], palette: { a: '#ff0000', b: '#00ff00' } },
+      move: { kind: 'walk' },
+      diet: { eats: ['plant'], lifespanSeconds: 120 },
+    },
+    { summoned: true }
+  )
+  registerBlueprint(w, bp)
+
+  for (let i = 0; i < 5; i++) spawnCreature(w, bp, 10 + i * 4, WORLD_H - 22)
+  return { w, bp }
+}
+
+describe('run-length encoding the tile grid', () => {
+  it('collapses a uniform world to a single run', () => {
+    const tiles = new Uint8Array(1000)
+    expect(encodeTiles(tiles)).toEqual([0, 1000])
+  })
+
+  it('round-trips an arbitrary grid', () => {
+    const tiles = new Uint8Array(500)
+    for (let i = 0; i < tiles.length; i++) tiles[i] = ((i / 7) | 0) % MATERIAL_IDS.length
+    const back = new Uint8Array(500)
+    expect(decodeTiles(encodeTiles(tiles), back)).toBe(true)
+    expect(Array.from(back)).toEqual(Array.from(tiles))
+  })
+
+  it('reads a material this build does not have as air, not as whatever is there', () => {
+    const into = new Uint8Array(4)
+    expect(decodeTiles([MATERIAL_IDS.length + 3, 4], into)).toBe(true)
+    expect(Array.from(into)).toEqual([0, 0, 0, 0])
+  })
+
+  it('round-trips a grid that alternates every tile', () => {
+    const tiles = new Uint8Array(64)
+    for (let i = 0; i < tiles.length; i++) tiles[i] = i % 2
+    const runs = encodeTiles(tiles)
+    expect(runs).toHaveLength(128)
+    const back = new Uint8Array(64)
+    expect(decodeTiles(runs, back)).toBe(true)
+    expect(Array.from(back)).toEqual(Array.from(tiles))
+  })
+
+  it('refuses runs that do not cover the grid', () => {
+    const into = new Uint8Array(100)
+    expect(decodeTiles([1, 40], into)).toBe(false)
+  })
+
+  it('refuses runs that overflow the grid rather than writing past the end', () => {
+    const into = new Uint8Array(100)
+    expect(decodeTiles([1, 90, 2, 90], into)).toBe(false)
+  })
+
+  it('refuses a zero-length run, which a naive decoder would loop on', () => {
+    const into = new Uint8Array(10)
+    expect(decodeTiles([1, 0, 1, 10], into)).toBe(false)
+  })
+})
+
+describe('freezing and thawing a world', () => {
+  it('brings back the terrain tile for tile', () => {
+    const { w } = populatedWorld()
+    const snap = snapshotWorld(w)
+
+    const fresh = createWorld(1)
+    expect(restoreSnapshot(fresh, snap)).toBe(true)
+    expect(Array.from(fresh.tiles)).toEqual(Array.from(w.tiles))
+  })
+
+  it('brings back every creature mid-life, not reset', () => {
+    const { w } = populatedWorld()
+    w.creatures[0].hunger = 0.77
+    w.creatures[0].ageSeconds = 91.5
+    w.creatures[0].mealsEaten = 12
+    w.creatures[0].generation = 4
+    w.creatures[0].name = 'Bramble'
+    w.elapsed = 300.25
+
+    const fresh = createWorld(1)
+    restoreSnapshot(fresh, snapshotWorld(w))
+
+    expect(fresh.creatures).toHaveLength(5)
+    expect(fresh.elapsed).toBeCloseTo(300.25, 2)
+    const first = fresh.creatures[0]
+    expect(first.hunger).toBeCloseTo(0.77, 2)
+    expect(first.ageSeconds).toBeCloseTo(91.5, 2)
+    expect(first.mealsEaten).toBe(12)
+    expect(first.generation).toBe(4)
+    expect(first.name).toBe('Bramble')
+  })
+
+  it('carries the summoned species so the world can be opened anywhere', () => {
+    const { w, bp } = populatedWorld()
+    const snap = snapshotWorld(w)
+    expect(snap.blueprints.map(b => b.id)).toEqual([bp.id])
+
+    // A world that has never heard of this species.
+    const fresh = createWorld(1)
+    expect(fresh.blueprints[bp.id]).toBeUndefined()
+    restoreSnapshot(fresh, snap)
+    expect(fresh.blueprints[bp.id]?.name).toBe('Test Grazer')
+  })
+
+  it('leaves behind creatures whose species did not survive the trip', () => {
+    const { w, bp } = populatedWorld()
+    const snap = snapshotWorld(w)
+    // As if the blueprint had been pruned from the save.
+    snap.blueprints = []
+
+    const fresh = createWorld(1)
+    restoreSnapshot(fresh, snap)
+    expect(fresh.creatures.filter(c => c.blueprintId === bp.id)).toHaveLength(0)
+  })
+
+  it('never lets natives point at a species that is not there', () => {
+    const { w } = populatedWorld()
+    const snap = snapshotWorld(w)
+    snap.natives = [...snap.natives, 'summon:ghost:999']
+
+    const fresh = createWorld(1)
+    restoreSnapshot(fresh, snap)
+    expect(fresh.natives).not.toContain('summon:ghost:999')
+    for (const id of fresh.natives) expect(fresh.blueprints[id]).toBeDefined()
+  })
+
+  it('hands out ids above everything already alive', () => {
+    const { w } = populatedWorld()
+    const snap = snapshotWorld(w)
+    // A save whose counter has fallen behind its own population.
+    snap.nextCreatureId = 1
+
+    const fresh = createWorld(1)
+    restoreSnapshot(fresh, snap)
+    const highest = Math.max(...fresh.creatures.map(c => c.id))
+    expect(fresh.nextCreatureId).toBeGreaterThan(highest)
+  })
+
+  it('drops particles rather than thawing a frozen puff of sparks', () => {
+    const { w } = populatedWorld()
+    const fresh = createWorld(1)
+    fresh.particles.push({ x: 1, y: 1, vx: 0, vy: 0, life: 1, maxLife: 1, color: '#fff' })
+    restoreSnapshot(fresh, snapshotWorld(w))
+    expect(fresh.particles).toHaveLength(0)
+  })
+
+  it('leaves the world alone when the tiles cannot be decoded', () => {
+    const { w } = populatedWorld()
+    const snap = snapshotWorld(w)
+    snap.tiles = [1, 10]
+
+    const fresh = createWorld(1)
+    const before = Array.from(fresh.tiles)
+    expect(restoreSnapshot(fresh, snap)).toBe(false)
+    expect(Array.from(fresh.tiles)).toEqual(before)
+  })
+})

--- a/src/app/micro-land/worlds/__tests__/wire.test.ts
+++ b/src/app/micro-land/worlds/__tests__/wire.test.ts
@@ -1,0 +1,182 @@
+import { describe, expect, it } from 'vitest'
+
+import { MATERIAL_IDS, MATERIAL_INDEX } from '@/app/micro-land/domain/config/materials'
+import { WORLD_H, WORLD_W } from '@/app/micro-land/domain/constants'
+import { createWorld } from '@/app/micro-land/domain/sim/world'
+import { snapshotWorld } from '@/app/micro-land/worlds/snapshot'
+import { WORLD_SAVE_VERSION, type WorldSave } from '@/app/micro-land/worlds/types'
+import {
+  cleanWorldName,
+  isSaveId,
+  newSaveId,
+  summarize,
+  validateWorldSave,
+  worldSaveBytes,
+} from '@/app/micro-land/worlds/wire'
+
+function aSave(): WorldSave {
+  const w = createWorld(99)
+  for (let x = 0; x < WORLD_W; x++) w.tiles[(WORLD_H - 1) * WORLD_W + x] = MATERIAL_INDEX.stone
+  return {
+    version: WORLD_SAVE_VERSION,
+    id: 'w-abcdef123456',
+    name: 'The Long Shallows',
+    createdAt: 1_700_000_000_000,
+    updatedAt: 1_700_000_100_000,
+    themeId: 'tidepool',
+    terrain: null,
+    camX: 120,
+    land: { landId: 'tidepool', steadySince: 0, elderId: null },
+    world: snapshotWorld(w),
+  }
+}
+
+describe('save ids', () => {
+  it('mints ids it will accept back', () => {
+    for (let i = 0; i < 20; i++) expect(isSaveId(newSaveId())).toBe(true)
+  })
+
+  it('rejects anything that could escape a document path', () => {
+    expect(isSaveId('../other')).toBe(false)
+    expect(isSaveId('a/b')).toBe(false)
+    expect(isSaveId('__proto__')).toBe(false)
+    expect(isSaveId('short')).toBe(false)
+    expect(isSaveId('w-' + 'a'.repeat(60))).toBe(false)
+  })
+})
+
+describe('naming a world', () => {
+  it('takes what the player typed, tidied', () => {
+    expect(cleanWorldName('  the   drowned  cathedral ')).toBe('the drowned cathedral')
+  })
+
+  it('falls back rather than refusing an empty name', () => {
+    expect(cleanWorldName('   ')).toBe('A world')
+    expect(cleanWorldName(undefined, 'Tidepool')).toBe('Tidepool')
+  })
+
+  it('caps a name that would not fit on a shelf row', () => {
+    expect(cleanWorldName('x'.repeat(200))).toHaveLength(40)
+  })
+})
+
+describe('validating a save off the wire', () => {
+  it('accepts one this game wrote', () => {
+    const save = validateWorldSave(aSave())
+    expect(save).not.toBeNull()
+    expect(save?.name).toBe('The Long Shallows')
+    expect(save?.world.creatures).toEqual([])
+  })
+
+  it('survives a JSON round trip unchanged where it matters', () => {
+    const original = aSave()
+    const back = validateWorldSave(JSON.parse(JSON.stringify(original)))
+    expect(back?.world.tiles).toEqual(original.world.tiles)
+    expect(back?.camX).toBe(120)
+  })
+
+  it('refuses a version it does not know', () => {
+    expect(validateWorldSave({ ...aSave(), version: 99 })).toBeNull()
+  })
+
+  it('refuses an id it would not have minted', () => {
+    expect(validateWorldSave({ ...aSave(), id: '../elsewhere' })).toBeNull()
+  })
+
+  it('refuses a grid from a world of a different size', () => {
+    const save = aSave()
+    save.world.width = 100
+    expect(validateWorldSave(save)).toBeNull()
+  })
+
+  it('refuses runs that do not add up to exactly one world', () => {
+    const save = aSave()
+    save.world.tiles = [0, 10]
+    expect(validateWorldSave(save)).toBeNull()
+  })
+
+  it('refuses a material index this build has no material for', () => {
+    const save = aSave()
+    save.world.tiles = [MATERIAL_IDS.length + 5, WORLD_W * WORLD_H]
+    expect(validateWorldSave(save)).toBeNull()
+  })
+
+  it('refuses a grid written against a longer material table', () => {
+    const save = aSave()
+    save.world.materials = MATERIAL_IDS.length + 1
+    expect(validateWorldSave(save)).toBeNull()
+  })
+
+  it('accepts a grid written against a shorter one, since the table only grows', () => {
+    const save = aSave()
+    save.world.materials = 4
+    expect(validateWorldSave(save)).not.toBeNull()
+  })
+
+  it('coerces a creature with nonsense in it rather than dropping the world', () => {
+    const save = aSave()
+    save.world.creatures = [
+      {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        ...({ blueprintId: 'hopper', hunger: 'very', x: -50, generation: 0 } as any),
+      },
+    ]
+    const back = validateWorldSave(save)
+    expect(back?.world.creatures).toHaveLength(1)
+    expect(back?.world.creatures[0].hunger).toBe(0.2)
+    expect(back?.world.creatures[0].x).toBe(0)
+    expect(back?.world.creatures[0].generation).toBe(1)
+  })
+
+  it('drops a creature with no species to point at', () => {
+    const save = aSave()
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    save.world.creatures = [{ x: 1, y: 1 } as any]
+    expect(validateWorldSave(save)?.world.creatures).toEqual([])
+  })
+
+  it('never lets a streak claim to have started in the future', () => {
+    const save = aSave()
+    save.world.elapsed = 60
+    save.land.steadySince = 5000
+    expect(validateWorldSave(save)?.land.steadySince).toBe(60)
+  })
+
+  it('refuses something that is not an object at all', () => {
+    expect(validateWorldSave(null)).toBeNull()
+    expect(validateWorldSave('a world')).toBeNull()
+    expect(validateWorldSave([])).toBeNull()
+  })
+})
+
+describe('the shelf row', () => {
+  it('is derived from the save, so it cannot drift', () => {
+    const save = aSave()
+    save.world.elapsed = 42
+    expect(summarize(save)).toEqual({
+      id: 'w-abcdef123456',
+      name: 'The Long Shallows',
+      createdAt: 1_700_000_000_000,
+      updatedAt: 1_700_000_100_000,
+      themeId: 'tidepool',
+      landName: null,
+      creatures: 0,
+      elapsed: 42,
+    })
+  })
+})
+
+describe('measuring a save', () => {
+  it('counts bytes rather than characters', () => {
+    const save = aSave()
+    // One character, two bytes — the limit being defended is a byte limit.
+    save.name = 'ñ'
+    expect(worldSaveBytes(save)).toBe(worldSaveBytes({ ...save, name: 'n' }) + 1)
+  })
+
+  it('keeps an empty world well under the storage ceiling', () => {
+    // Three screens of terrain run-length encode to almost nothing when empty;
+    // this is the floor the real numbers are measured against.
+    expect(worldSaveBytes(aSave())).toBeLessThan(5_000)
+  })
+})

--- a/src/app/micro-land/worlds/backend.ts
+++ b/src/app/micro-land/worlds/backend.ts
@@ -1,0 +1,191 @@
+/**
+ * Where shelved worlds are actually kept.
+ *
+ * Same seam as `chronicle/backend.ts`, and for the same reason: nothing above
+ * this file mentions `localStorage` or `fetch`. There are two implementations
+ * and which one is in use is decided once, in `MicroLandGame`.
+ *
+ * The one real difference from the chronicle's backend is what a failed write
+ * means. A dropped chronicle flush costs a few seconds of records and the next
+ * flush carries them anyway, so it can be quiet. Saving a world is something the
+ * player *asked for*, once, by name — if it doesn't happen they have to be told,
+ * so `save` and `remove` throw and the shelf reports it.
+ */
+import {
+  MAX_WORLD_BYTES,
+  decodeWorldSave,
+  summarize,
+  validateWorldSave,
+  worldSaveBytes,
+} from './wire'
+
+import type { WorldSave, WorldSummary } from './types'
+
+export interface WorldsBackend {
+  list(): Promise<WorldSummary[]>
+  /** Null when there is no such world, or what's stored is unreadable. */
+  load(id: string): Promise<WorldSave | null>
+  save(save: WorldSave): Promise<void>
+  remove(id: string): Promise<void>
+}
+
+const INDEX_KEY = 'micro-land:worlds'
+const SAVE_PREFIX = 'micro-land:world:'
+
+/**
+ * Worlds on this device only: no account, no network.
+ *
+ * The index is kept as its own small key rather than derived by walking
+ * `localStorage`, so listing the shelf never has to parse a megabyte of saves to
+ * draw eight rows.
+ *
+ * Every access is wrapped, because `localStorage` is not merely empty in
+ * private-mode Safari and locked-down embeds — *reading it throws*. Reads
+ * degrade to an empty shelf. Writes are the exception: a quota error on a save
+ * the player explicitly asked for is reported, not swallowed.
+ */
+export const localWorldsBackend: WorldsBackend = {
+  async list() {
+    if (typeof window === 'undefined') return []
+    try {
+      const raw = window.localStorage.getItem(INDEX_KEY)
+      if (!raw) return []
+      const parsed: unknown = JSON.parse(raw)
+      return Array.isArray(parsed) ? (parsed as WorldSummary[]) : []
+    } catch {
+      return []
+    }
+  },
+
+  async load(id) {
+    if (typeof window === 'undefined') return null
+    try {
+      return decodeWorldSave(window.localStorage.getItem(SAVE_PREFIX + id))
+    } catch {
+      return null
+    }
+  },
+
+  async save(save) {
+    if (typeof window === 'undefined') return
+    const index = await localWorldsBackend.list()
+    const next = [summarize(save), ...index.filter(w => w.id !== save.id)]
+    try {
+      window.localStorage.setItem(SAVE_PREFIX + save.id, JSON.stringify(save))
+      window.localStorage.setItem(INDEX_KEY, JSON.stringify(next))
+    } catch {
+      // Almost always the 5 MB quota. Roll the index back so the shelf never
+      // lists a world whose save isn't there — an entry that fails to open is a
+      // worse outcome than a save that plainly didn't happen.
+      try {
+        window.localStorage.removeItem(SAVE_PREFIX + save.id)
+        window.localStorage.setItem(INDEX_KEY, JSON.stringify(index))
+      } catch {
+        // Storage is refusing everything. Nothing left to tidy.
+      }
+      throw new Error('this browser has no room to keep another world')
+    }
+  },
+
+  async remove(id) {
+    if (typeof window === 'undefined') return
+    const index = await localWorldsBackend.list()
+    try {
+      window.localStorage.removeItem(SAVE_PREFIX + id)
+      window.localStorage.setItem(INDEX_KEY, JSON.stringify(index.filter(w => w.id !== id)))
+    } catch {
+      throw new Error('this browser would not let go of that world')
+    }
+  },
+}
+
+/** A shelf that remembers nothing, for tests and for server rendering. */
+export const nullWorldsBackend: WorldsBackend = {
+  async list() {
+    return []
+  },
+  async load() {
+    return null
+  },
+  async save() {},
+  async remove() {},
+}
+
+const ENDPOINT = '/api/v1/micro-land/worlds'
+
+/**
+ * Worlds kept against a Firebase account: one document per world, any device.
+ *
+ * Goes through an API route rather than the Firestore client SDK, which is the
+ * house pattern — every collection in `firestore.rules` is closed to clients and
+ * reached through a route holding the admin credentials.
+ *
+ * `getToken` is a function rather than a token because tokens expire and a
+ * session outlasts them. `useAuth` mints an anonymous uid for everyone on
+ * arrival, so this is the ordinary path for a player who has never signed up,
+ * not a signed-in-only feature.
+ */
+export function accountWorldsBackend(getToken: () => Promise<string | null>): WorldsBackend {
+  async function authorized(): Promise<HeadersInit | null> {
+    const token = await getToken()
+    return token ? { authorization: `Bearer ${token}` } : null
+  }
+
+  return {
+    async list() {
+      try {
+        const headers = await authorized()
+        if (!headers) return []
+        const response = await fetch(ENDPOINT, { headers })
+        if (!response.ok) return []
+        const body = (await response.json()) as { worlds?: unknown }
+        return Array.isArray(body.worlds) ? (body.worlds as WorldSummary[]) : []
+      } catch {
+        return []
+      }
+    },
+
+    async load(id) {
+      try {
+        const headers = await authorized()
+        if (!headers) return null
+        const response = await fetch(`${ENDPOINT}/${encodeURIComponent(id)}`, { headers })
+        if (!response.ok) return null
+        const body = (await response.json()) as { world?: unknown }
+        // The route hands back the save as stored; re-validate here so a bad
+        // document cannot reach the simulation through a trusted-looking channel.
+        return validateWorldSave(body.world)
+      } catch {
+        return null
+      }
+    },
+
+    async save(save) {
+      const headers = await authorized()
+      if (!headers) throw new Error('not signed in yet')
+
+      // Checked before it leaves so an oversized world fails with something the
+      // player can act on, rather than as a 413 from a route they can't see.
+      if (worldSaveBytes(save) > MAX_WORLD_BYTES) {
+        throw new Error('that world is too big to keep')
+      }
+
+      const response = await fetch(`${ENDPOINT}/${encodeURIComponent(save.id)}`, {
+        method: 'PUT',
+        headers: { ...headers, 'content-type': 'application/json' },
+        body: JSON.stringify({ world: save }),
+      })
+      if (!response.ok) throw new Error(`world save failed: ${response.status}`)
+    },
+
+    async remove(id) {
+      const headers = await authorized()
+      if (!headers) throw new Error('not signed in yet')
+      const response = await fetch(`${ENDPOINT}/${encodeURIComponent(id)}`, {
+        method: 'DELETE',
+        headers,
+      })
+      if (!response.ok) throw new Error(`world delete failed: ${response.status}`)
+    },
+  }
+}

--- a/src/app/micro-land/worlds/shelf.ts
+++ b/src/app/micro-land/worlds/shelf.ts
@@ -1,0 +1,296 @@
+/**
+ * The shelf — one place that knows which worlds exist and which one is open.
+ *
+ * Module state rather than store state, exactly as the chronicle is, and for the
+ * same reason: this outlives any React tree, has to work before one has mounted,
+ * and is read by the game instance imperatively. The store gets a snapshot
+ * pushed at it through `onShelf` so panels can render it like anything else.
+ *
+ * The one rule worth holding on to: **a shelved world is the one you are
+ * playing, until you change the land.** Painting, placing, summoning creatures
+ * and clearing life all happen *inside* a world and keep updating it. Choosing a
+ * different theme, reshaping, or summoning new terrain makes a new unsaved world
+ * and lets go of the shelved one. Without that, "Reshape" would quietly destroy
+ * the world the player had asked the game to keep.
+ */
+import { type WorldsBackend, localWorldsBackend } from './backend'
+import { MAX_SAVED_WORLDS, summarize } from './wire'
+
+import type { WorldSave, WorldSummary } from './types'
+
+/** How long after a change the open world is written back. */
+const AUTOSAVE_MS = 20_000
+
+export interface ShelfState {
+  worlds: WorldSummary[]
+  /** The shelved world currently being played, if any. */
+  activeId: string | null
+  /** A list, open, save or delete is in flight. */
+  busy: boolean
+  /** Something the player should be told about the last operation. */
+  error: string | null
+}
+
+let backend: WorldsBackend = localWorldsBackend
+let state: ShelfState = { worlds: [], activeId: null, busy: false, error: null }
+let listeners = new Set<(state: ShelfState) => void>()
+let listed = false
+let listing: Promise<void> | null = null
+
+/** Set by the game so the shelf can write the open world back on its own. */
+let takeSnapshot: (() => WorldSave | null) | null = null
+let autosaveTimer: ReturnType<typeof setTimeout> | null = null
+let dirty = false
+let hideHooked = false
+
+export function onShelf(fn: (state: ShelfState) => void): () => void {
+  listeners.add(fn)
+  fn(state)
+  return () => {
+    listeners.delete(fn)
+  }
+}
+
+export function readShelf(): ShelfState {
+  return state
+}
+
+function publish(patch: Partial<ShelfState>): void {
+  state = { ...state, ...patch }
+  for (const fn of listeners) fn(state)
+}
+
+/** Newest first — the shelf reads as "what I was just playing", not an archive. */
+function order(worlds: WorldSummary[]): WorldSummary[] {
+  return [...worlds].sort((a, b) => b.updatedAt - a.updatedAt)
+}
+
+function withSummary(worlds: WorldSummary[], summary: WorldSummary): WorldSummary[] {
+  return order([summary, ...worlds.filter(w => w.id !== summary.id)])
+}
+
+/**
+ * Read the shelf once.
+ *
+ * Memoized on the in-flight promise rather than on `listed`, which is only set
+ * after the await: two panels mounting in the same frame would otherwise both
+ * see "not listed yet" and both hit the network.
+ */
+export async function initShelf(): Promise<void> {
+  if (listed) return
+  if (listing) return listing
+
+  listing = (async () => {
+    publish({ busy: true })
+    const worlds = await backend.list()
+    listed = true
+    publish({ worlds: order(worlds), busy: false })
+  })()
+
+  try {
+    await listing
+  } finally {
+    listing = null
+  }
+}
+
+/**
+ * Move this device's shelf onto the player's account.
+ *
+ * Union by id, newest `updatedAt` wins, and anything local that the account has
+ * not seen is uploaded. No conflict resolution beyond that and none is needed:
+ * ids are minted randomly per save (see `newSaveId`), so the same id on two
+ * devices means the same world, and the later write is the one the player made
+ * later.
+ *
+ * Failures here are swallowed on purpose. This runs unprompted when auth
+ * resolves; a player who is offline keeps the local shelf they already had, and
+ * the next save will try again.
+ */
+export async function adoptWorldsAccount(next: WorldsBackend): Promise<void> {
+  if (backend === next) return
+  await initShelf()
+
+  const local = state.worlds
+  const remote = await next.list()
+  const remoteById = new Map(remote.map(w => [w.id, w]))
+
+  backend = next
+  publish({ busy: true })
+
+  for (const summary of local) {
+    const known = remoteById.get(summary.id)
+    if (known && known.updatedAt >= summary.updatedAt) continue
+    try {
+      const save = await localWorldsBackend.load(summary.id)
+      if (save) await next.save(save)
+      remoteById.set(summary.id, summary)
+    } catch {
+      // Offline, or the account shelf is full. Keep going: one world that
+      // refuses to upload must not cost the player the rest of them.
+    }
+  }
+
+  publish({ worlds: order([...remoteById.values()]).slice(0, MAX_SAVED_WORLDS), busy: false })
+}
+
+export function setBackend(next: WorldsBackend): void {
+  backend = next
+  listed = false
+  listing = null
+  publish({ worlds: [], activeId: null, busy: false, error: null })
+}
+
+export function isShelfFull(): boolean {
+  return state.worlds.length >= MAX_SAVED_WORLDS
+}
+
+/**
+ * Register how to freeze the world that's on screen.
+ *
+ * The shelf writes the open world back on its own — on a slow debounce and when
+ * the page goes away — and it cannot reach into the game instance to do it, so
+ * the game hands it a way. Called with null on teardown.
+ */
+export function provideSnapshot(fn: (() => WorldSave | null) | null): void {
+  takeSnapshot = fn
+}
+
+/** Put a world on the shelf, or write the open one back. Throws on failure. */
+export async function keepWorld(save: WorldSave): Promise<void> {
+  publish({ busy: true, error: null })
+  try {
+    await backend.save(save)
+    publish({
+      worlds: withSummary(state.worlds, summarize(save)),
+      activeId: save.id,
+      busy: false,
+    })
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'that world would not keep'
+    publish({ busy: false, error: message })
+    throw error
+  }
+}
+
+export async function readWorld(id: string): Promise<WorldSave | null> {
+  publish({ busy: true, error: null })
+  try {
+    const save = await backend.load(id)
+    publish({ busy: false, error: save ? null : 'that world could not be opened' })
+    return save
+  } catch {
+    publish({ busy: false, error: 'that world could not be opened' })
+    return null
+  }
+}
+
+export async function removeWorld(id: string): Promise<void> {
+  publish({ busy: true, error: null })
+  try {
+    await backend.remove(id)
+    // Deleting the world you are standing in leaves you standing in it — it is
+    // simply no longer kept. The pending autosave has to go with it, or it would
+    // write the world straight back a few seconds later.
+    if (state.activeId === id) releaseActiveWorld()
+    publish({ worlds: state.worlds.filter(w => w.id !== id), busy: false })
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'that world would not let go'
+    publish({ busy: false, error: message })
+  }
+}
+
+/** Which shelved world is on screen, if any. */
+export function activeWorldId(): string | null {
+  return state.activeId
+}
+
+/**
+ * Let go of the shelved world without deleting it.
+ *
+ * Called when the land is replaced — a new theme, a reshape, summoned terrain.
+ * The player is now somewhere else, and the next autosave must not overwrite the
+ * world they asked the game to keep with the one that replaced it.
+ */
+export function releaseActiveWorld(): void {
+  dirty = false
+  if (autosaveTimer !== null) {
+    clearTimeout(autosaveTimer)
+    autosaveTimer = null
+  }
+  if (state.activeId !== null) publish({ activeId: null })
+}
+
+export function setActiveWorld(id: string | null): void {
+  publish({ activeId: id })
+}
+
+/**
+ * Note that the open world has moved on, and arrange to write it back.
+ *
+ * Debounced hard — twenty seconds — because this is a simulation and *every*
+ * tick changes it. A save is a few hundred kilobytes; writing one per second
+ * would be a fine way to spend a player's data plan on a terrarium.
+ */
+export function touchActiveWorld(): void {
+  if (state.activeId === null) return
+  dirty = true
+  attachFlushOnHide()
+  if (autosaveTimer !== null) return
+  autosaveTimer = setTimeout(() => {
+    autosaveTimer = null
+    void flushActiveWorld()
+  }, AUTOSAVE_MS)
+}
+
+/**
+ * Write the open world back now.
+ *
+ * Quiet on failure, unlike `keepWorld`: this one fires on a timer and on the way
+ * out of the page, where there is nobody to tell and nothing useful to say. The
+ * world stays dirty so the next attempt carries it.
+ */
+export async function flushActiveWorld(): Promise<void> {
+  if (!dirty || state.activeId === null || !takeSnapshot) return
+  const save = takeSnapshot()
+  if (!save || save.id !== state.activeId) return
+
+  dirty = false
+  try {
+    await backend.save(save)
+    publish({ worlds: withSummary(state.worlds, summarize(save)) })
+  } catch {
+    dirty = true
+  }
+}
+
+/**
+ * Flush when the page goes away.
+ *
+ * `visibilitychange` rather than `beforeunload`, which mobile browsers do not
+ * reliably fire — a phone backgrounding the tab is the ordinary way a session
+ * ends, and it is exactly the case where "pick up where you left off" is being
+ * promised. `pagehide` covers the desktop close.
+ */
+function attachFlushOnHide(): void {
+  if (hideHooked || typeof document === 'undefined') return
+  hideHooked = true
+  const flush = () => {
+    if (document.visibilityState === 'hidden') void flushActiveWorld()
+  }
+  document.addEventListener('visibilitychange', flush)
+  window.addEventListener('pagehide', () => void flushActiveWorld())
+}
+
+/** Test seam: put the module back to how it loaded. */
+export function resetShelf(): void {
+  backend = localWorldsBackend
+  state = { worlds: [], activeId: null, busy: false, error: null }
+  listeners = new Set()
+  listed = false
+  listing = null
+  takeSnapshot = null
+  dirty = false
+  if (autosaveTimer !== null) clearTimeout(autosaveTimer)
+  autosaveTimer = null
+}

--- a/src/app/micro-land/worlds/snapshot.ts
+++ b/src/app/micro-land/worlds/snapshot.ts
@@ -1,0 +1,242 @@
+/**
+ * Freezing a world and thawing it again.
+ *
+ * The two functions here are inverses and are tested as such. Everything they
+ * touch is either stored or *deliberately* not, and the "not" list is the
+ * interesting half:
+ *
+ * - `grain` is per-tile colour jitter, one random byte per tile. Storing it
+ *   would roughly triple the size of a save for something nobody can name, and
+ *   random bytes are exactly the data run-length encoding cannot help with. It
+ *   is regenerated from `seed` instead. The consequence is honest and small: a
+ *   reopened world has the same terrain with slightly different speckle.
+ * - `particles` are sparks that live under a second. Storing a world mid-burst
+ *   and thawing it an hour later to a frozen puff would look like a bug.
+ * - Built-in blueprints are config, not world state. `createWorld` has them.
+ *
+ * Neither function ever throws. `restoreSnapshot` in particular is handed data
+ * that has been through `validateWorldSave`, but it still drops anything it
+ * cannot resolve rather than trusting it — a creature whose species is missing
+ * is left behind, not spawned as a hole in the simulation.
+ */
+import { reserveSummonIds } from '@/app/micro-land/domain/blueprint'
+import { MATERIAL_IDS } from '@/app/micro-land/domain/config/materials'
+import { makeRng } from '@/app/micro-land/domain/sim/prng'
+import { registerBlueprint } from '@/app/micro-land/domain/sim/world'
+import type { Creature, CreatureMood, WorldState } from '@/app/micro-land/domain/types'
+
+import type { SavedCreature, WorldSnapshot } from './types'
+
+const MOODS: CreatureMood[] = ['wander', 'hunt', 'flee', 'eat', 'rest']
+
+/** Two decimals is a hundredth of a tile — far finer than a pixel can show. */
+function round(n: number): number {
+  return Math.round(n * 100) / 100
+}
+
+/**
+ * Run-length encode the tile grid.
+ *
+ * Terrain is made of long contiguous runs — a row of sky, a seam of stone — so
+ * this is worth an order of magnitude on a real world and never costs more than
+ * two entries per tile in the pathological case. Row-major order is kept as-is
+ * because runs mostly *are* horizontal; encoding by column would break every one
+ * of them.
+ */
+export function encodeTiles(tiles: Uint8Array): number[] {
+  const runs: number[] = []
+  if (tiles.length === 0) return runs
+
+  let material = tiles[0]
+  let length = 1
+  for (let i = 1; i < tiles.length; i++) {
+    if (tiles[i] === material) {
+      length++
+      continue
+    }
+    runs.push(material, length)
+    material = tiles[i]
+    length = 1
+  }
+  runs.push(material, length)
+  return runs
+}
+
+/**
+ * Write a run-length encoded grid back into an existing `Uint8Array`.
+ *
+ * In place rather than allocating, because the game instance already owns a
+ * world and replacing its `tiles` reference would leave the renderer's cached
+ * tile image pointing at the old one.
+ *
+ * Returns false if the runs don't cover the grid exactly. `validateWorldSave`
+ * has already checked that, so this is the second lock on the same door — but it
+ * is the door where getting it wrong means writing past the end of the world.
+ *
+ * Measured in full before a single tile is written, which is what lets the
+ * caller promise that a save it cannot read costs the player nothing: a
+ * one-pass decoder would leave half a world behind on the way to returning
+ * false, and the land on screen would already be ruined.
+ */
+export function decodeTiles(runs: number[], into: Uint8Array): boolean {
+  if (runs.length % 2 !== 0) return false
+
+  let total = 0
+  for (let i = 1; i < runs.length; i += 2) {
+    const length = runs[i]
+    if (!Number.isInteger(length) || length < 1) return false
+    total += length
+    if (total > into.length) return false
+  }
+  if (total !== into.length) return false
+
+  let cursor = 0
+  for (let i = 0; i < runs.length; i += 2) {
+    const material = runs[i]
+    const length = runs[i + 1]
+    // Anything outside the table would render as a material this build cannot
+    // name; air is the one value that is always safe and always means "nothing".
+    const value =
+      Number.isInteger(material) && material >= 0 && material < MATERIAL_IDS.length ? material : 0
+    into.fill(value, cursor, cursor + length)
+    cursor += length
+  }
+
+  return true
+}
+
+/**
+ * Everything about this world that isn't the chronicle's business.
+ *
+ * Only summoned species with something alive are carried. The rest of the roster
+ * comes back the way it always does, out of the chronicle's archive — embedding
+ * all of it would put eighty creatures' pixel art into every save of every world
+ * for the sake of a shelf the player can already see. What must be embedded is
+ * the species standing in *this* land, because the archive prunes by last
+ * sighting and a world left alone for a month would otherwise reopen half empty.
+ */
+export function snapshotWorld(w: WorldState): WorldSnapshot {
+  const living = new Set(w.creatures.map(c => c.blueprintId))
+  const blueprints = Object.values(w.blueprints).filter(bp => bp.summoned && living.has(bp.id))
+
+  return {
+    materials: MATERIAL_IDS.length,
+    width: w.width,
+    height: w.height,
+    seed: w.seed,
+    elapsed: round(w.elapsed),
+    flowPhase: w.flowPhase,
+    dormant: w.dormant,
+    nextCreatureId: w.nextCreatureId,
+    nextSeedRain: round(w.nextSeedRain),
+    nextPlantSeed: round(w.nextPlantSeed),
+    natives: [...w.natives],
+    tiles: encodeTiles(w.tiles),
+    creatures: w.creatures.map(c => ({
+      id: c.id,
+      blueprintId: c.blueprintId,
+      x: round(c.x),
+      y: round(c.y),
+      vx: round(c.vx),
+      vy: round(c.vy),
+      facing: c.facing,
+      hunger: round(c.hunger),
+      starving: round(c.starving),
+      ageSeconds: round(c.ageSeconds),
+      distress: round(c.distress),
+      mood: c.mood,
+      targetId: c.targetId,
+      drift: round(c.drift),
+      animMs: Math.round(c.animMs),
+      grounded: c.grounded,
+      breedCooldown: round(c.breedCooldown),
+      mealsEaten: c.mealsEaten,
+      children: c.children,
+      digProgress: round(c.digProgress),
+      tilesDug: c.tilesDug,
+      generation: c.generation,
+      name: c.name,
+    })),
+    blueprints,
+  }
+}
+
+function thaw(saved: SavedCreature): Creature {
+  return {
+    id: saved.id,
+    blueprintId: saved.blueprintId,
+    x: saved.x,
+    y: saved.y,
+    vx: saved.vx,
+    vy: saved.vy,
+    facing: saved.facing,
+    hunger: saved.hunger,
+    starving: saved.starving,
+    ageSeconds: saved.ageSeconds,
+    distress: saved.distress,
+    mood: (MOODS as string[]).includes(saved.mood) ? (saved.mood as CreatureMood) : 'wander',
+    // Deliberately cleared rather than restored. A target is a *reference* to
+    // another creature, and the one it pointed at may have been dropped for a
+    // missing species — leaving the id would have a hunter chasing nothing until
+    // the next re-target. They all re-acquire within a tick anyway.
+    targetId: null,
+    drift: saved.drift,
+    animMs: saved.animMs,
+    grounded: saved.grounded,
+    breedCooldown: saved.breedCooldown,
+    mealsEaten: saved.mealsEaten,
+    children: saved.children,
+    digProgress: saved.digProgress,
+    tilesDug: saved.tilesDug,
+    generation: saved.generation,
+    name: saved.name,
+  }
+}
+
+/**
+ * Thaw a snapshot into an existing world, replacing everything in it.
+ *
+ * Mutates `w` rather than returning a new world, because the game instance holds
+ * one for its whole life and the renderer caches against its arrays.
+ *
+ * Returns false only when the tile grid could not be decoded, which leaves the
+ * world untouched — the caller keeps playing the land it already had rather than
+ * being dropped into a half-written one.
+ */
+export function restoreSnapshot(w: WorldState, snap: WorldSnapshot): boolean {
+  if (!decodeTiles(snap.tiles, w.tiles)) return false
+
+  // Same sequence `createWorld` uses, so a world restored from a given seed
+  // speckles the same way a fresh one from that seed would.
+  const rng = makeRng(snap.seed)
+  for (let i = 0; i < w.grain.length; i++) w.grain[i] = Math.floor(rng() * 256)
+
+  for (const bp of snap.blueprints) registerBlueprint(w, bp)
+  // Ids carry a counter that resets with the page. Without this, the next
+  // creature summoned after opening a saved world could be handed an id one of
+  // its inhabitants is already using and silently overwrite it in the roster.
+  reserveSummonIds(snap.blueprints.map(bp => bp.id))
+
+  w.creatures = snap.creatures.filter(c => w.blueprints[c.blueprintId]).map(thaw)
+  w.particles.length = 0
+
+  // A dangling id here would hand `undefined` to `isPlant` and break both
+  // safety nets — the soil's seed bank and animal seed rain — which is how a
+  // restored world would quietly stop being able to recover from a crash.
+  w.natives = snap.natives.filter(id => w.blueprints[id])
+
+  w.seed = snap.seed
+  w.elapsed = snap.elapsed
+  w.flowPhase = snap.flowPhase
+  w.dormant = snap.dormant
+  w.nextSeedRain = snap.nextSeedRain
+  w.nextPlantSeed = snap.nextPlantSeed
+  // Never below anything already alive: ids are handed out by increment, and a
+  // counter that starts underneath the population would issue duplicates, which
+  // every `targetId` lookup and the inspector all resolve by id.
+  let nextId = snap.nextCreatureId
+  for (const c of w.creatures) if (c.id >= nextId) nextId = c.id + 1
+  w.nextCreatureId = nextId
+
+  return true
+}

--- a/src/app/micro-land/worlds/types.ts
+++ b/src/app/micro-land/worlds/types.ts
@@ -1,0 +1,170 @@
+/**
+ * Saved worlds — the shelf.
+ *
+ * The chronicle deliberately keeps a logbook and not a save file: close the tab
+ * and the land is gone, and what survives is the *record* of it. That is still
+ * true of the land you happen to be standing in. This is the other half — a
+ * player can take a world they care about, give it a name, and put it on a
+ * shelf, and opening it later drops them back into it mid-breath: same terrain,
+ * same creatures, same hungers, same ages.
+ *
+ * Two things follow from that split and are worth stating up front:
+ *
+ * - A shelved world is a *copy*, not a link. Reopening one does not disturb the
+ *   record of any other, and the world you were in when you opened it is simply
+ *   left behind (its streak banked, like any other world change).
+ * - The chronicle still owns species, records and milestones. A save carries
+ *   only what a world is, never what the player has achieved — so deleting a
+ *   world can never cost someone a record they earned in it.
+ *
+ * Everything here is plain JSON for the same reason the chronicle is: no `Map`,
+ * no `Set`, no typed array, `null` rather than `undefined`. `Uint8Array` in
+ * particular round-trips through `JSON.stringify` as an *object* keyed by index
+ * — 88,704 keys — which is why the tile grid is run-length encoded on the way
+ * out rather than handed over as-is.
+ */
+import type { SanitizedTerrain } from '@/app/micro-land/domain/terrain'
+import type { CreatureBlueprint } from '@/app/micro-land/domain/types'
+
+/**
+ * Bump when an old save would be *misread* rather than merely come up short.
+ *
+ * Unlike the chronicle there is no migration path here and there deliberately
+ * isn't one: a save whose version we don't know is refused, and the player keeps
+ * every other world on the shelf. Records, which are the part they earned, live
+ * in the chronicle and are unaffected either way.
+ */
+export const WORLD_SAVE_VERSION = 1
+
+/**
+ * One creature, frozen.
+ *
+ * The whole runtime state, not a summary — hunger, age, breeding cooldown and
+ * distress are what make a reopened world feel like it was paused rather than
+ * restarted. `mood`, `targetId` and `animMs` are cosmetic and cost almost
+ * nothing, and dropping them would make the first frame after a load look like
+ * every creature had just been dropped in from nowhere.
+ */
+export interface SavedCreature {
+  id: number
+  blueprintId: string
+  x: number
+  y: number
+  vx: number
+  vy: number
+  facing: 1 | -1
+  hunger: number
+  starving: number
+  ageSeconds: number
+  distress: number
+  mood: string
+  targetId: number | null
+  drift: number
+  animMs: number
+  grounded: boolean
+  breedCooldown: number
+  mealsEaten: number
+  children: number
+  digProgress: number
+  tilesDug: number
+  generation: number
+  name: string | null
+}
+
+export interface WorldSnapshot {
+  /**
+   * How many materials existed when this grid was written.
+   *
+   * Tile values are indices into `MATERIAL_IDS`, and that order is load-bearing
+   * (invariant 3): appending is safe, reordering is not. A save written against
+   * a *longer* table may hold indices this build has no material for, so it is
+   * refused rather than rendered as whatever now sits at that index. A shorter
+   * one is fine, which is what makes adding a material a non-event for saves.
+   */
+  materials: number
+  width: number
+  height: number
+  /** Regenerates `grain`; the tile grid itself is stored, not rebuilt from this. */
+  seed: number
+  elapsed: number
+  flowPhase: number
+  dormant: boolean
+  nextCreatureId: number
+  nextSeedRain: number
+  nextPlantSeed: number
+  natives: string[]
+  /** Run-length encoded: material, length, material, length, … See `snapshot.ts`. */
+  tiles: number[]
+  creatures: SavedCreature[]
+  /**
+   * Summoned blueprints referenced by this world, embedded whole.
+   *
+   * Redundant with the chronicle's archive on the device that made the save, and
+   * not redundant at all anywhere else: the archive is capped and prunes by last
+   * sighting, so a world left on the shelf for a month could otherwise reopen
+   * with half its inhabitants missing. Built-ins are never stored — they are
+   * config, and `createWorld` already has them.
+   */
+  blueprints: CreatureBlueprint[]
+}
+
+/**
+ * Where the record-keeper was standing when the world was put away.
+ *
+ * Without this, reopening a world would bank its no-extinction streak and start
+ * counting from zero — which would make the shelf a way to *lose* progress. The
+ * streak's length is `elapsed - steadySince` and both travel together, so it
+ * simply carries on. Records themselves stay monotonic high-water marks
+ * (invariant 11); nothing here can lower one.
+ */
+export interface SavedLand {
+  /** Record key, from `landId()`. */
+  landId: string
+  /** World-clock time the current no-extinction streak began. */
+  steadySince: number
+  /** Creature holding the longevity record, if it was still alive. */
+  elderId: number | null
+}
+
+export interface WorldSave {
+  version: number
+  id: string
+  name: string
+  /** Epoch ms. */
+  createdAt: number
+  updatedAt: number
+  themeId: string
+  /**
+   * The terrain the player summoned, if this land was one.
+   *
+   * The sanitized terrain rather than the `Theme` built from it, because a Theme
+   * carries a `build` function and functions do not survive JSON. `terrainToTheme`
+   * rebuilds it on load, which also means a summoned land can still be Reshaped
+   * after it comes back off the shelf.
+   */
+  terrain: SanitizedTerrain | null
+  /** Left edge of the view, in world tiles — reopen looking where you left off. */
+  camX: number
+  land: SavedLand
+  world: WorldSnapshot
+}
+
+/**
+ * What the shelf can show without reading a whole save.
+ *
+ * A save is a few hundred kilobytes; a shelf of eight is megabytes. Listing them
+ * pulls only this, which is why the account backend keeps these as their own
+ * fields alongside the blob rather than parsing it out on every list.
+ */
+export interface WorldSummary {
+  id: string
+  name: string
+  createdAt: number
+  updatedAt: number
+  themeId: string
+  /** Name of the summoned land, when the theme is one. */
+  landName: string | null
+  creatures: number
+  /** World-seconds this land has been running. */
+  elapsed: number
+}

--- a/src/app/micro-land/worlds/wire.ts
+++ b/src/app/micro-land/worlds/wire.ts
@@ -1,0 +1,301 @@
+/**
+ * A saved world on the wire.
+ *
+ * The same job `chronicle/wire.ts` does for records, and for the same reason:
+ * the browser has to keep itself under the size the server will accept, the
+ * server has to treat every byte as hostile, and neither end should own the
+ * rules alone.
+ *
+ * This one validates harder than the chronicle's does, and the asymmetry is
+ * deliberate. A chronicle is a bag of records that only its author ever reads
+ * back, so its fields are checked for shape and trusted for content. A world
+ * save is *fed to the simulation* — the tile runs drive an allocation loop, the
+ * creature list is spliced straight into the tick, and every coordinate is
+ * indexed into a grid. So the run lengths are checked to sum to exactly one
+ * grid, and every creature is coerced field by field before it can exist.
+ *
+ * Nothing here reaches into Firestore, `fetch` or `localStorage`. It is pure so
+ * it can be tested, which is where the interesting failures are.
+ */
+import { MATERIAL_IDS } from '@/app/micro-land/domain/config/materials'
+import { WORLD_H, WORLD_W } from '@/app/micro-land/domain/constants'
+import { sanitizeTerrain } from '@/app/micro-land/domain/terrain'
+import type { CreatureBlueprint } from '@/app/micro-land/domain/types'
+
+import {
+  type SavedCreature,
+  WORLD_SAVE_VERSION,
+  type WorldSave,
+  type WorldSnapshot,
+  type WorldSummary,
+} from './types'
+
+/**
+ * The most one stored world is allowed to weigh, in bytes of JSON.
+ *
+ * A Firestore field value caps just under 1 MiB. Measured against a full world —
+ * three screens of dense terrain, the population cap reached, a roster of
+ * summoned species carrying their pixel art — a save lands around 250 KB, so
+ * this is roughly three times the worst case seen and still clear of the ceiling.
+ *
+ * A save that will not fit is refused rather than trimmed. There is no honest
+ * way to shrink a world: dropping creatures or flattening terrain hands the
+ * player back something that is not the place they saved.
+ */
+export const MAX_WORLD_BYTES = 800_000
+
+/**
+ * How many worlds one player may shelve.
+ *
+ * Small on purpose. The shelf is meant to hold the handful of worlds someone
+ * actually cares about — a place you go back to, not an archive — and a list
+ * long enough to need scrolling and searching is a different, worse feature. It
+ * is also what keeps the browser-local copy inside a `localStorage` quota.
+ */
+export const MAX_SAVED_WORLDS = 8
+
+const encoder = new TextEncoder()
+
+export function worldSaveBytes(save: WorldSave): number {
+  return encoder.encode(JSON.stringify(save)).length
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function num(value: unknown, fallback: number): number {
+  return typeof value === 'number' && Number.isFinite(value) ? value : fallback
+}
+
+function clamp(value: unknown, lo: number, hi: number, fallback: number): number {
+  return Math.min(hi, Math.max(lo, num(value, fallback)))
+}
+
+function str(value: unknown, fallback: string, max: number): string {
+  return typeof value === 'string' ? value.slice(0, max) : fallback
+}
+
+/** Ids are ours, and they end up as Firestore document ids and storage keys. */
+export function isSaveId(value: unknown): value is string {
+  return typeof value === 'string' && /^[a-z0-9-]{6,48}$/.test(value)
+}
+
+/**
+ * A world's name, as the player typed it.
+ *
+ * Trimmed and capped, never rejected: this is a text box a child types into, and
+ * "that is not a valid name" is not an answer a game should ever give. An empty
+ * one falls back rather than blocking the save.
+ */
+export function cleanWorldName(value: unknown, fallback = 'A world'): string {
+  const name = typeof value === 'string' ? value.trim().replace(/\s+/g, ' ').slice(0, 40) : ''
+  return name.length > 0 ? name : fallback
+}
+
+/**
+ * Check the run-length encoded grid covers exactly one world, and nothing more.
+ *
+ * Every part of this matters. A run length of zero would loop forever in a naive
+ * decoder; a negative or fractional one would corrupt the write cursor; a total
+ * under the grid leaves the tail as whatever the array was initialised to; a
+ * total over it writes past the end. And a material index the table doesn't have
+ * would render as garbage rather than fail, which is the worst of the four
+ * because nobody would notice.
+ */
+function validRuns(runs: unknown, tileCount: number): number[] | null {
+  if (!Array.isArray(runs)) return null
+  if (runs.length % 2 !== 0) return null
+  // Two entries per run, and a run can't be shorter than one tile.
+  if (runs.length > tileCount * 2) return null
+
+  let total = 0
+  for (let i = 0; i < runs.length; i += 2) {
+    const material = runs[i]
+    const length = runs[i + 1]
+    if (!Number.isInteger(material) || material < 0 || material >= MATERIAL_IDS.length) return null
+    if (!Number.isInteger(length) || length < 1) return null
+    total += length as number
+    if (total > tileCount) return null
+  }
+
+  return total === tileCount ? (runs as number[]) : null
+}
+
+/**
+ * Coerce one stored creature into something the simulation can hold.
+ *
+ * Never throws and never refuses — every field falls back, in the same spirit as
+ * `sanitizeBlueprint`. A creature with a nonsense hunger becomes a hungry
+ * creature; one whose species has gone is dropped later, by the restore, which
+ * is the only reason a creature is ever discarded.
+ */
+function cleanCreature(raw: unknown, index: number): SavedCreature | null {
+  if (!isPlainObject(raw)) return null
+  if (typeof raw.blueprintId !== 'string' || raw.blueprintId.length === 0) return null
+
+  return {
+    id: Math.max(1, Math.floor(num(raw.id, index + 1))),
+    blueprintId: raw.blueprintId.slice(0, 120),
+    x: clamp(raw.x, 0, WORLD_W, 0),
+    y: clamp(raw.y, 0, WORLD_H, 0),
+    vx: clamp(raw.vx, -200, 200, 0),
+    vy: clamp(raw.vy, -200, 200, 0),
+    facing: raw.facing === -1 ? -1 : 1,
+    hunger: clamp(raw.hunger, 0, 1, 0.2),
+    starving: clamp(raw.starving, 0, 1e6, 0),
+    ageSeconds: clamp(raw.ageSeconds, 0, 1e7, 0),
+    distress: clamp(raw.distress, 0, 1e6, 0),
+    mood: str(raw.mood, 'wander', 16),
+    targetId:
+      typeof raw.targetId === 'number' && Number.isFinite(raw.targetId) ? raw.targetId : null,
+    drift: clamp(raw.drift, -1, 1, 0),
+    animMs: clamp(raw.animMs, 0, 1e9, 0),
+    grounded: raw.grounded === true,
+    breedCooldown: clamp(raw.breedCooldown, 0, 1e6, 0),
+    mealsEaten: Math.floor(clamp(raw.mealsEaten, 0, 1e9, 0)),
+    children: Math.floor(clamp(raw.children, 0, 1e9, 0)),
+    digProgress: clamp(raw.digProgress, 0, 1, 0),
+    tilesDug: Math.floor(clamp(raw.tilesDug, 0, 1e9, 0)),
+    generation: Math.floor(clamp(raw.generation, 1, 1e6, 1)),
+    name: typeof raw.name === 'string' ? raw.name.slice(0, 32) : null,
+  }
+}
+
+function validSnapshot(value: unknown): WorldSnapshot | null {
+  if (!isPlainObject(value)) return null
+
+  // The grid is a fixed size, and a save from a build with different dimensions
+  // cannot be stretched to fit — the terrain would mean something else.
+  if (value.width !== WORLD_W || value.height !== WORLD_H) return null
+
+  const materials = num(value.materials, -1)
+  // Written against a table longer than ours: it may hold indices we cannot
+  // name. Shorter is fine — the list is only ever appended to (invariant 3).
+  if (!Number.isInteger(materials) || materials < 1 || materials > MATERIAL_IDS.length) return null
+
+  const tiles = validRuns(value.tiles, WORLD_W * WORLD_H)
+  if (!tiles) return null
+
+  if (!Array.isArray(value.creatures)) return null
+  if (!Array.isArray(value.natives)) return null
+  if (!Array.isArray(value.blueprints)) return null
+
+  const creatures: SavedCreature[] = []
+  for (let i = 0; i < value.creatures.length; i++) {
+    const creature = cleanCreature(value.creatures[i], i)
+    if (creature) creatures.push(creature)
+  }
+
+  const natives = value.natives.filter((id): id is string => typeof id === 'string')
+  // Blueprints are passed through as stored, exactly as the chronicle's archived
+  // ones are: they went through `sanitizeBlueprint` when the species was
+  // invented, and re-sanitizing would mint a fresh id and orphan every creature
+  // pointing at the old one. Shape is checked; content is the author's own.
+  const blueprints = value.blueprints.filter(
+    (bp): bp is CreatureBlueprint =>
+      isPlainObject(bp) && typeof bp.id === 'string' && isPlainObject(bp.body)
+  )
+
+  return {
+    materials,
+    width: WORLD_W,
+    height: WORLD_H,
+    seed: Math.floor(clamp(value.seed, 0, 0xffffffff, 1337)),
+    elapsed: clamp(value.elapsed, 0, 1e9, 0),
+    flowPhase: num(value.flowPhase, 0),
+    dormant: value.dormant === true,
+    nextCreatureId: Math.max(1, Math.floor(num(value.nextCreatureId, 1))),
+    nextSeedRain: clamp(value.nextSeedRain, 0, 1e9, 0),
+    nextPlantSeed: clamp(value.nextPlantSeed, 0, 1e9, 0),
+    natives,
+    tiles,
+    creatures,
+    blueprints,
+  }
+}
+
+/**
+ * Coerce untrusted input into a world save, or refuse it.
+ *
+ * Returns null rather than throwing. A payload this far off shape is a bug or an
+ * attack, not a world to be salvaged, and the caller's fallback — "that save is
+ * unreadable, here are your others" — is already right for both.
+ */
+export function validateWorldSave(value: unknown): WorldSave | null {
+  if (!isPlainObject(value)) return null
+  if (value.version !== WORLD_SAVE_VERSION) return null
+  if (!isSaveId(value.id)) return null
+
+  const world = validSnapshot(value.world)
+  if (!world) return null
+
+  const land = isPlainObject(value.land) ? value.land : {}
+  // Run back through the same sanitizer that produced it. It is deterministic
+  // and idempotent, it never throws, and it is the guarantee `terrainToTheme`
+  // relies on — a legend of real materials and a rectangular map. Trusting the
+  // stored shape here would put a ragged map into the terrain painter.
+  const terrain = isPlainObject(value.terrain) ? sanitizeTerrain(value.terrain) : null
+
+  const now = num(value.updatedAt, 0)
+  const themeId = str(value.themeId, 'earth', 48) || 'earth'
+  return {
+    version: WORLD_SAVE_VERSION,
+    id: value.id,
+    name: cleanWorldName(value.name),
+    createdAt: Math.max(0, Math.floor(num(value.createdAt, now))),
+    updatedAt: Math.max(0, Math.floor(now)),
+    themeId,
+    terrain,
+    camX: clamp(value.camX, 0, WORLD_W, 0),
+    land: {
+      landId: str(land.landId, themeId, 120) || themeId,
+      steadySince: clamp(land.steadySince, 0, world.elapsed, 0),
+      elderId:
+        typeof land.elderId === 'number' && Number.isFinite(land.elderId)
+          ? Math.floor(land.elderId)
+          : null,
+    },
+    world,
+  }
+}
+
+/** Parse and validate in one step, for reading a stored JSON string back. */
+export function decodeWorldSave(raw: unknown): WorldSave | null {
+  if (typeof raw !== 'string') return null
+  try {
+    return validateWorldSave(JSON.parse(raw))
+  } catch {
+    return null
+  }
+}
+
+/** The row the shelf shows. Derived rather than stored, so it cannot drift. */
+export function summarize(save: WorldSave): WorldSummary {
+  return {
+    id: save.id,
+    name: save.name,
+    createdAt: save.createdAt,
+    updatedAt: save.updatedAt,
+    themeId: save.themeId,
+    landName: save.terrain?.name ?? null,
+    creatures: save.world.creatures.length,
+    elapsed: save.world.elapsed,
+  }
+}
+
+/**
+ * A fresh id for a world about to be shelved.
+ *
+ * Random rather than sequential because ids are minted on two backends that
+ * cannot see each other — a world saved on a phone while signed out and one
+ * saved on a laptop must not collide when the account merges them. The alphabet
+ * is deliberately the one `isSaveId` accepts, which is also what Firestore is
+ * happy to use as a document id.
+ */
+export function newSaveId(): string {
+  let id = 'w-'
+  for (let i = 0; i < 12; i++)
+    id += 'abcdefghijklmnopqrstuvwxyz0123456789'[(Math.random() * 36) | 0]
+  return id
+}

--- a/src/lib/micro-land/chronicle-store.ts
+++ b/src/lib/micro-land/chronicle-store.ts
@@ -1,0 +1,60 @@
+/**
+ * The chronicle in Firestore: one document per player.
+ *
+ * Stored as a single JSON string rather than as nested maps, which is the one
+ * decision in this file worth explaining. A chronicle is a save blob — it is
+ * read whole, written whole, and never queried. As nested maps, Firestore would
+ * index every leaf of every archived creature on every write: a few hundred
+ * species times forty-odd fields of pixel art, none of which anything will ever
+ * filter or sort on. It would also put the ids straight into field paths, and
+ * those ids contain colons (`summon:cinder-wyrm:3`, `summoned:the-drowned-
+ * cathedral`), which field paths do not take kindly to.
+ *
+ * As one unindexed string it is a single cheap write, and the shape of the game
+ * data stops being Firestore's business — see the `fieldOverrides` entry for
+ * `microLand.blob` in `firestore.indexes.json`, which is what keeps it unindexed
+ * and therefore clear of the 7.5 KiB index-entry ceiling.
+ *
+ * The trade is that the document is opaque in the console and cannot be queried
+ * across players. That is the right trade while these records are private; a
+ * public gallery would want creatures as their own documents, and should add
+ * that alongside rather than unpicking this.
+ */
+import { FieldValue } from 'firebase-admin/firestore'
+
+import { CHRONICLE_VERSION, type ChronicleData } from '@/app/micro-land/chronicle/types'
+import { chronicleBytes, decodeChronicle } from '@/app/micro-land/chronicle/wire'
+import { getFirestoreDb } from '@/lib/firebase/server'
+
+function chronicleRef(uid: string) {
+  return getFirestoreDb().doc(`users/${uid}/microLand/chronicle`)
+}
+
+/** Null when this player has never saved, or when what they saved is unreadable. */
+export async function loadChronicle(uid: string): Promise<ChronicleData | null> {
+  const snap = await chronicleRef(uid).get()
+  if (!snap.exists) return null
+  return decodeChronicle(snap.data()?.blob)
+}
+
+/**
+ * Overwrite this player's chronicle.
+ *
+ * A full replace rather than a merge: the client holds the authoritative copy in
+ * memory, having already merged the stored one into it on sign-in, and it sends
+ * its whole state on every flush. Merging here as well would resurrect species
+ * the player's own client had pruned.
+ *
+ * The scalars alongside the blob are there to be readable without parsing it —
+ * enough to answer "when did this player last play, and how big is their
+ * archive" from the console or a script.
+ */
+export async function saveChronicle(uid: string, data: ChronicleData): Promise<void> {
+  await chronicleRef(uid).set({
+    blob: JSON.stringify(data),
+    version: CHRONICLE_VERSION,
+    bytes: chronicleBytes(data),
+    speciesCount: Object.keys(data.species).length,
+    updatedAt: FieldValue.serverTimestamp(),
+  })
+}

--- a/src/lib/micro-land/world-store.ts
+++ b/src/lib/micro-land/world-store.ts
@@ -1,0 +1,101 @@
+/**
+ * Shelved worlds in Firestore: one document per saved world.
+ *
+ * A world is a save blob for the same reasons the chronicle is — read whole,
+ * written whole, never queried by its contents — and stored the same way, as one
+ * unindexed JSON string. See the note in `chronicle-store.ts`; everything it
+ * says about indexing every leaf of every creature applies here with more force,
+ * because a world carries three hundred of them.
+ *
+ * Where this one differs is the *listing*. The shelf has to draw eight rows
+ * without pulling eight save blobs across the network, so the handful of things
+ * a row shows are kept as their own fields alongside the blob and read with a
+ * projection. They are denormalized copies of what is inside the blob, written
+ * in the same operation, and the blob remains the truth: if the two ever
+ * disagree, the row is cosmetic and the world is not.
+ */
+import { FieldValue } from 'firebase-admin/firestore'
+
+import {
+  WORLD_SAVE_VERSION,
+  type WorldSave,
+  type WorldSummary,
+} from '@/app/micro-land/worlds/types'
+import { MAX_SAVED_WORLDS, decodeWorldSave, worldSaveBytes } from '@/app/micro-land/worlds/wire'
+import { getFirestoreDb } from '@/lib/firebase/server'
+
+function worldsRef(uid: string) {
+  return getFirestoreDb().collection(`users/${uid}/microLandWorlds`)
+}
+
+/**
+ * Every world on this player's shelf, without reading a single save.
+ *
+ * `select()` is what makes this cheap: Firestore bills and transfers only the
+ * named fields, so the blob — the entire point of the document — never leaves
+ * the database.
+ */
+export async function listWorlds(uid: string): Promise<WorldSummary[]> {
+  const snap = await worldsRef(uid)
+    .select('name', 'themeId', 'landName', 'creatures', 'elapsed', 'createdAt', 'updatedAt')
+    .get()
+
+  return snap.docs.map(doc => {
+    const data = doc.data()
+    return {
+      id: doc.id,
+      name: typeof data.name === 'string' ? data.name : 'A world',
+      createdAt: typeof data.createdAt === 'number' ? data.createdAt : 0,
+      updatedAt: typeof data.updatedAt === 'number' ? data.updatedAt : 0,
+      themeId: typeof data.themeId === 'string' ? data.themeId : 'earth',
+      landName: typeof data.landName === 'string' ? data.landName : null,
+      creatures: typeof data.creatures === 'number' ? data.creatures : 0,
+      elapsed: typeof data.elapsed === 'number' ? data.elapsed : 0,
+    }
+  })
+}
+
+/** Null when there's no such world, or what's stored is unreadable. */
+export async function loadWorld(uid: string, id: string): Promise<WorldSave | null> {
+  const snap = await worldsRef(uid).doc(id).get()
+  if (!snap.exists) return null
+  return decodeWorldSave(snap.data()?.blob)
+}
+
+/**
+ * Write one world, creating it if it's new.
+ *
+ * The cap is enforced here as well as in the client, and the check is
+ * deliberately "how many *other* worlds are there" rather than a plain count —
+ * writing back a world already on the shelf must keep working when the shelf is
+ * full, which is the ordinary case for every autosave once a player has filled
+ * it. Returns false when the shelf has no room for a genuinely new world.
+ */
+export async function saveWorld(uid: string, save: WorldSave): Promise<boolean> {
+  const collection = worldsRef(uid)
+  const existing = await collection.select().get()
+  const isNew = !existing.docs.some(doc => doc.id === save.id)
+  if (isNew && existing.size >= MAX_SAVED_WORLDS) return false
+
+  await collection.doc(save.id).set({
+    blob: JSON.stringify(save),
+    version: WORLD_SAVE_VERSION,
+    bytes: worldSaveBytes(save),
+    // The projection the shelf lists on. Kept in step with the blob by being
+    // written in the same call and never on their own.
+    name: save.name,
+    themeId: save.themeId,
+    landName: save.terrain?.name ?? null,
+    creatures: save.world.creatures.length,
+    elapsed: save.world.elapsed,
+    createdAt: save.createdAt,
+    updatedAt: save.updatedAt,
+    storedAt: FieldValue.serverTimestamp(),
+  })
+
+  return true
+}
+
+export async function deleteWorld(uid: string, id: string): Promise<void> {
+  await worldsRef(uid).doc(id).delete()
+}


### PR DESCRIPTION
Micro Land kept a logbook and not a save file: close the tab and the land was gone, and only the record of it survived. That was the right default and it stays the default — but a world someone spent an afternoon building deserves to be somewhere they can go back to. This adds the other half, plus the storage layer both halves needed.

It is a larger PR than one feature because the work landed as one pile: `game-instance.ts`, `store.ts`, `MicroLandGame.tsx` and `hud.tsx` each carry several of these threads, so splitting by file would have produced intermediate states that do not build.

## Worlds you can keep

Up to eight, by name, reopened mid-simulation — same terrain, same creatures, same hungers and ages.

- The tile grid is run-length encoded. Terrain is long contiguous runs, so a full 240-creature world with real structure lands around **80 KB**.
- `grain` is regenerated from the seed rather than stored — it is one random byte per tile, exactly the data RLE cannot help with. The honest cost is slightly different speckle on reopen.
- Particles are dropped. A frozen puff of sparks thawed an hour later would look like a bug.
- A save records the **length of the material table it was written against** and is refused if that table has since grown. Tile values are indices into `MATERIAL_IDS`; appending is safe, reordering is not (invariant 3).
- `decodeTiles` measures the whole grid before writing a single tile, so a save that cannot be read costs the player nothing — a one-pass decoder would leave half a world behind on its way to returning false.

**Changing the land releases the shelved world** — a new theme, Reshape, summoned terrain — rather than overwriting it. Painting, placing and clearing life happen *inside* a world and keep updating it. Without that rule, "Reshape" would quietly destroy the world the player had asked the game to keep.

**Records survive the move.** `steadySince` and `elapsed` travel together so a resumed no-extinction streak continues rather than resetting; the world being left banks its own on the way out. Nothing here can lower a high-water mark (invariant 11).

## The chronicle moves to an account

Records, land history and the species archive were browser-local. They now round-trip through `users/{uid}/microLand/chronicle` behind an API route, as one unindexed JSON blob — a save blob is read whole, written whole and never queried, and as nested maps Firestore would index every leaf of every archived creature on every write, with ids like `summon:cinder-wyrm:3` landing in field paths that do not take colons.

The game still starts on `localBackend` and never waits for the network; `adoptAccount` merges rather than chooses when auth resolves. Anonymous uids are first-class (CLAUDE.md #1), so a child who has never signed up keeps the creature they just drew, and signing up later links the credential to the same uid.

Two bugs fell out of writing it:

- Archived blueprints were stored in full but **nothing ever read them back into the roster**, so a creature invented yesterday was missing from the toolbar today while still appearing in the field guide — which made a missing restore look like a display bug.
- `flushChronicle` cleared its dirty flag **before** a write that could fail, so a dropped connection marked the records saved with nothing stored, and never retried.

## Species can be deleted

A tidy mode on the creature strip, a burst in the species' own death colour rather than a blink, and undo in the notice strip holding the whole archived record — the id is gone the moment the species is forgotten, and the record carries history the blueprint alone cannot rebuild.

Removing a blueprint prunes `natives` too: both population safety nets index `w.blueprints[id]` straight off that list, and a dangling id there breaks the two mechanisms that stop the world flatlining.

## Also in here

The hand-drawing creature builder and its shared kit, the tuning panel behind the sliders icon, and a skill document for the game.

## Verification

- **113 unit tests** across chronicle, world-save snapshot/wire, creature-kit and tuning
- **End-to-end Firestore round-trip** of a 240-creature world with structured terrain: stored, listed via the `select()` projection, read back, thawed tile-for-tile identical with a named creature's age and hunger intact; confirmed the shelf refuses a ninth world while still allowing an existing one to be rewritten
- **Routes are auth-gated**: 401 without a token, 400 on a path-traversal id
- **Headless ecosystem harness**, 5×600s per theme:

  | theme | low water | peak | at end | |
  |---|---|---|---|---|
  | earth | 548 | 849 | 697 | ✓ Still alive |
  | tidepool | 318 | 521 | 458 | ✓ Still alive |
  | volcanic | 264 | 345 | 300 | ✓ Still alive |
  | station | 197 | 277 | 224 | ✓ Still alive |

  No species extinct in every run.

## Note on the branch

This is cut from `main` rather than from `feat/micro-land`, which has already been merged. The two share no history for micro-land — everything landed on `main` as squash merges, so the merge base predates the game entirely and `git merge` produces add/add conflicts on nineteen files. The work was cherry-picked onto `main` instead. One real conflict, in `domain/sim/world.ts`: this branch moves the ecosystem numbers out of `constants.ts` into `TUNING`, while #2708 added `SURFACE_SEEDING_BIAS` to `constants.ts`. Both are kept — `SURFACE_SEEDING_BIAS` stays where #2708 put it, and the sky-drop block is intact inside the new `findSpawnSpot`.

## Deploy

`firestore.rules` and the `microLand.blob` / `microLandWorlds.blob` index exemptions both need `firebase deploy --only firestore:rules,firestore:indexes`. Chronicle and world writes fail silently by design, so a missing deploy looks exactly like a working game that quietly stops saving.

## Open questions for the owner

Micro Land's direction belongs to Nick's daughter, and two numbers here are my defaults rather than her decision:

- the shelf holds **8** worlds
- the open world **autosaves every 20 seconds**, rather than only when you tap Save

🤖 Generated with [Claude Code](https://claude.com/claude-code)
