### PR TITLE
feat(micro-land): a tool drawer you can fold away

### DIFF
--- a/src/app/micro-land/MicroLandGame.tsx
+++ b/src/app/micro-land/MicroLandGame.tsx
@@ -136,6 +136,11 @@ export function MicroLandGame() {
    * token refresh and would otherwise re-adopt every hour. The ref guards the
    * remount case, where the effect re-runs with a uid already adopted.
    */
+  // Whether the tool drawer was left folded away. Its own effect rather than a
+  // line in the one above: it is a preference about the screen, not about the
+  // world, and it has nothing to do with getting the first tick out on time.
+  useEffect(() => useMicroLand.getState().hydrateToolbar(), [])
+
   // Storage state into the store, so any panel can render it like other state.
   useEffect(() => onSaveState(useMicroLand.getState().setSaveState), [])
   useEffect(() => onShelf(useMicroLand.getState().setShelf), [])

--- a/src/app/micro-land/components/toolbar.tsx
+++ b/src/app/micro-land/components/toolbar.tsx
@@ -8,8 +8,12 @@ import {
   creatureGroup,
 } from '@/app/micro-land/domain/blueprint'
 import { MATERIALS, PAINTABLE, TINTS, tintedId } from '@/app/micro-land/domain/config/materials'
-import type { MaterialId, TintableMaterialId } from '@/app/micro-land/domain/types'
-import { useMicroLand } from '@/app/micro-land/store'
+import type {
+  CreatureBlueprint,
+  MaterialId,
+  TintableMaterialId,
+} from '@/app/micro-land/domain/types'
+import { type Tool, useMicroLand } from '@/app/micro-land/store'
 
 import { CreaturePortrait } from './creature-chip'
 import { SparkleIcon } from './sparkle-icon'
@@ -40,6 +44,25 @@ const label: React.CSSProperties = {
   paddingLeft: 2,
 }
 
+/** The chevron on the drawer handle — down to fold it away, up to unroll it. */
+function Chevron({ up }: { up: boolean }) {
+  return (
+    <svg
+      width="10"
+      height="10"
+      viewBox="0 0 10 10"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.6"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      {up ? <polyline points="2,6.5 5,3.5 8,6.5" /> : <polyline points="2,3.5 5,6.5 8,3.5" />}
+    </svg>
+  )
+}
+
 export function Toolbar({ onRemoveSpecies }: { onRemoveSpecies: (blueprintId: string) => void }) {
   const tool = useMicroLand(s => s.tool)
   const setTool = useMicroLand(s => s.setTool)
@@ -49,6 +72,8 @@ export function Toolbar({ onRemoveSpecies }: { onRemoveSpecies: (blueprintId: st
   const pending = useMicroLand(s => s.pendingSummons)
   const setSummonOpen = useMicroLand(s => s.setSummonOpen)
   const setBuilderOpen = useMicroLand(s => s.setBuilderOpen)
+  const open = useMicroLand(s => s.toolbarOpen)
+  const setOpen = useMicroLand(s => s.setToolbarOpen)
 
   const paintingSelected = tool.kind === 'material' || tool.kind === 'erase'
   const family = tool.kind === 'material' ? tintFamily(tool.material) : null
@@ -121,6 +146,16 @@ export function Toolbar({ onRemoveSpecies }: { onRemoveSpecies: (blueprintId: st
   const canTidy = active === 'yours' && shown.length > 0
   const tidyOn = tidying && canTidy
 
+  /**
+   * What the folded drawer still says is in your hand.
+   *
+   * Folding the drawer away does not disarm the tool — you can go on tapping to
+   * place dirt or drop hoppers with the whole screen given over to the world.
+   * That only works if the handle says what a tap is going to do, because the
+   * picker that used to answer that question is the thing you just hid.
+   */
+  const held = heldTool(tool, blueprints)
+
   return (
     <footer
       className="flex flex-col gap-1.5 px-3 pb-3 pt-2"
@@ -129,445 +164,591 @@ export function Toolbar({ onRemoveSpecies }: { onRemoveSpecies: (blueprintId: st
         background: 'linear-gradient(0deg, var(--cc-panel-grad-from), transparent)',
       }}
     >
-      {/* --- ground --- */}
+      {/*
+        The handle, and — while the drawer is open — the brush sizes beside it.
+
+        Sharing one row rather than giving the handle a strip of its own is the
+        whole point: on the phone this exists for, a row spent on a control that
+        only reveals other controls is a row taken off the world.
+
+        Nothing here animates. The canvas is sized by a ResizeObserver on its
+        parent and `Renderer.resize` reallocates the backing store every call, so
+        a height transition would rebuild the canvas once per frame for the
+        length of the slide. Instant is also what `prefers-reduced-motion`
+        wants, which makes the cheap answer the correct one twice over.
+      */}
       <div className="flex items-center gap-2">
-        <span style={label}>Ground</span>
-        <div className="flex items-center gap-1">
-          {BRUSHES.map(size => (
-            <button
-              key={size}
-              type="button"
-              className="cc-btn"
-              onClick={() => setBrush(size)}
-              aria-label={`Brush size ${size}`}
-              aria-pressed={brush === size}
-              style={{
-                width: 26,
-                height: 26,
-                display: 'grid',
-                placeItems: 'center',
-                borderRadius: 4,
-                border: `1px solid ${brush === size ? 'var(--cc-mint)' : 'var(--cc-mint-line)'}`,
-                background: brush === size ? 'var(--cc-mint-soft)' : 'transparent',
-              }}
-            >
-              <span
-                style={{
-                  display: 'block',
-                  width: Math.min(14, 3 + size),
-                  height: Math.min(14, 3 + size),
-                  borderRadius: '50%',
-                  background: brush === size ? 'var(--cc-mint)' : 'var(--cc-text-muted)',
-                }}
-              />
-            </button>
-          ))}
-        </div>
-      </div>
-
-      <div className="-mx-1 flex gap-1.5 overflow-x-auto px-1 pb-1">
-        <button
-          type="button"
-          className="cc-btn shrink-0"
-          onClick={() => setTool({ kind: 'erase' })}
-          aria-pressed={tool.kind === 'erase'}
-          style={swatchStyle(tool.kind === 'erase')}
-        >
-          <span
-            aria-hidden
-            style={{
-              width: 22,
-              height: 22,
-              borderRadius: 3,
-              border: '1px dashed var(--cc-text-muted)',
-            }}
-          />
-          <span style={swatchLabel}>Erase</span>
-        </button>
-
-        {PAINTABLE.map(id => {
-          // A tintable swatch shows whichever color of itself is in hand, so
-          // the palette reflects what the brush will actually paint.
-          const inHand = family === id && tool.kind === 'material' ? tool.material : id
-          const material = MATERIALS[inHand]
-          const selected = tool.kind === 'material' && (tool.material === id || family === id)
-          return (
-            <button
-              key={id}
-              type="button"
-              className="cc-btn shrink-0"
-              onClick={() => setTool({ kind: 'material', material: inHand })}
-              aria-pressed={selected}
-              style={swatchStyle(selected)}
-            >
-              <span
-                aria-hidden
-                style={{
-                  position: 'relative',
-                  display: 'block',
-                  width: 22,
-                  height: 22,
-                  borderRadius: 3,
-                  background: material.color,
-                  boxShadow:
-                    material.glow > 0
-                      ? `0 0 10px ${material.color}`
-                      : 'inset 0 0 0 1px rgba(0,0,0,0.35)',
-                }}
-              >
-                {MATERIALS[id].tintable && (
-                  // A corner notch marks the ones that come in colors.
+        {open && (
+          <>
+            <span style={label}>Ground</span>
+            <div className="flex items-center gap-1">
+              {BRUSHES.map(size => (
+                <button
+                  key={size}
+                  type="button"
+                  className="cc-btn"
+                  onClick={() => setBrush(size)}
+                  aria-label={`Brush size ${size}`}
+                  aria-pressed={brush === size}
+                  style={{
+                    width: 26,
+                    height: 26,
+                    display: 'grid',
+                    placeItems: 'center',
+                    borderRadius: 4,
+                    border: `1px solid ${brush === size ? 'var(--cc-mint)' : 'var(--cc-mint-line)'}`,
+                    background: brush === size ? 'var(--cc-mint-soft)' : 'transparent',
+                  }}
+                >
                   <span
                     style={{
-                      position: 'absolute',
-                      right: 1,
-                      bottom: 1,
-                      width: 0,
-                      height: 0,
-                      borderLeft: '6px solid transparent',
-                      borderBottom: '6px solid rgba(255,255,255,0.75)',
+                      display: 'block',
+                      width: Math.min(14, 3 + size),
+                      height: Math.min(14, 3 + size),
+                      borderRadius: '50%',
+                      background: brush === size ? 'var(--cc-mint)' : 'var(--cc-text-muted)',
                     }}
                   />
-                )}
-              </span>
-              <span style={swatchLabel}>{MATERIALS[id].name}</span>
-            </button>
-          )
-        })}
-      </div>
+                </button>
+              ))}
+            </div>
+          </>
+        )}
 
-      {family && (
-        <div
-          className="-mx-1 flex items-center gap-1.5 overflow-x-auto px-1 pb-1"
-          role="group"
-          aria-label={`${MATERIALS[family].name} colour`}
-        >
-          <span style={{ ...label, paddingLeft: 4 }}>Colour</span>
-          {[
-            { id: family as MaterialId, name: MATERIALS[family].name },
-            ...TINTS.map(t => ({
-              id: tintedId(family, t.id),
-              name: t.name,
-            })),
-          ].map(({ id, name }) => {
-            const selected = tool.kind === 'material' && tool.material === id
-            return (
-              <button
-                key={id}
-                type="button"
-                className="cc-btn shrink-0"
-                onClick={() => setTool({ kind: 'material', material: id })}
-                aria-pressed={selected}
-                aria-label={name}
-                title={name}
-                style={{
-                  width: 30,
-                  height: 30,
-                  display: 'grid',
-                  placeItems: 'center',
-                  borderRadius: 999,
-                  border: `2px solid ${selected ? 'var(--cc-mint)' : 'transparent'}`,
-                  background: 'transparent',
-                }}
-              >
-                <span
-                  aria-hidden
-                  style={{
-                    display: 'block',
-                    width: 20,
-                    height: 20,
-                    borderRadius: 999,
-                    background: MATERIALS[id].color,
-                    boxShadow: 'inset 0 0 0 1px rgba(0,0,0,0.35)',
-                  }}
-                />
-              </button>
-            )
-          })}
-        </div>
-      )}
-
-      {/* --- creatures --- */}
-      {/* Wraps: Generate, Draw and Inspect together overflow a 360px phone. */}
-      <div className="flex flex-wrap items-center gap-2">
-        <span style={label}>Creatures</span>
+        {/* Folded, the handle takes the whole row: it is the only control left
+            down here, and a thumb should not have to aim for it. Open, it
+            shrinks to a chip in the corner and gets out of the way. */}
         <button
           type="button"
-          className="cc-btn"
-          onClick={() => setSummonOpen(true)}
+          className={open ? 'cc-btn ml-auto shrink-0' : 'cc-btn w-full'}
+          onClick={() => setOpen(!open)}
+          // `aria-expanded` and no `aria-controls`: the drawer is unmounted
+          // while folded, and pointing at an id that isn't in the document is a
+          // broken reference rather than a helpful one. The button says what
+          // state it is in, which is the part that matters.
+          aria-expanded={open}
+          aria-label={open ? 'Hide the tools' : `Show the tools. Holding ${held.name}.`}
+          title={open ? 'Hide the tools and watch the world' : 'Bring the tools back'}
           style={{
-            fontFamily: 'var(--cc-font-mono)',
-            fontSize: 10,
-            letterSpacing: 1.6,
-            textTransform: 'uppercase',
-            fontWeight: 700,
-            padding: '6px 14px',
-            minHeight: 32,
-            borderRadius: 4,
-            background: 'linear-gradient(180deg, var(--cc-mint), var(--cc-mint-hi))',
-            border: '1px solid var(--cc-mint)',
-            color: 'var(--cc-on-mint)',
-            boxShadow: 'var(--cc-mint-glow)',
-            display: 'inline-flex',
+            display: 'flex',
             alignItems: 'center',
-            gap: 6,
-          }}
-        >
-          <SparkleIcon size={12} />
-          Generate
-        </button>
-        {/* Secondary to Generate on purpose: one primary-action colour per
-            screen, and drawing is the slower, more deliberate of the two. */}
-        <button
-          type="button"
-          className="cc-btn"
-          onClick={() => setBuilderOpen(true)}
-          title="Colour in a creature yourself, square by square"
-          style={{
-            fontFamily: 'var(--cc-font-mono)',
-            fontSize: 10,
-            letterSpacing: 1.6,
-            textTransform: 'uppercase',
-            padding: '6px 12px',
-            minHeight: 32,
+            gap: 8,
+            minHeight: open ? 26 : 34,
+            padding: open ? '5px 9px' : '6px 10px',
             borderRadius: 4,
             border: '1px solid var(--cc-mint-line)',
             background: 'transparent',
             color: 'var(--cc-text-muted)',
-          }}
-        >
-          ✎ Draw
-        </button>
-        <button
-          type="button"
-          className="cc-btn"
-          onClick={() =>
-            setTool(
-              tool.kind === 'inspect' ? { kind: 'material', material: 'dirt' } : { kind: 'inspect' }
-            )
-          }
-          aria-pressed={tool.kind === 'inspect'}
-          title="Tap a creature to see how it is doing"
-          style={{
-            fontFamily: 'var(--cc-font-mono)',
-            fontSize: 10,
-            letterSpacing: 1.6,
-            textTransform: 'uppercase',
-            padding: '6px 12px',
-            minHeight: 32,
-            borderRadius: 4,
-            border: `1px solid ${tool.kind === 'inspect' ? 'var(--cc-mint)' : 'var(--cc-mint-line)'}`,
-            background: tool.kind === 'inspect' ? 'var(--cc-mint-soft)' : 'transparent',
-            color: tool.kind === 'inspect' ? 'var(--cc-mint)' : 'var(--cc-text-muted)',
-          }}
-        >
-          ⌕ Inspect
-        </button>
-        <span
-          style={{
             fontFamily: 'var(--cc-font-mono)',
             fontSize: 9,
-            opacity: 0.45,
-            letterSpacing: 1,
+            letterSpacing: 1.2,
+            textTransform: 'uppercase',
+            whiteSpace: 'nowrap',
           }}
-          className="hidden sm:inline"
         >
-          {tool.kind === 'inspect'
-            ? 'tap a creature to watch it'
-            : paintingSelected
-              ? 'drag a creature to throw it'
-              : 'tap to place · drag a creature to throw it'}
-        </span>
+          <Chevron up={!open} />
+          {open ? (
+            'Hide'
+          ) : (
+            <>
+              Tools
+              <span aria-hidden style={{ opacity: 0.3 }}>
+                |
+              </span>
+              {/* The held tool, drawn the same way the picker draws it, so the
+                  handle reads as the one swatch you left selected. */}
+              <span
+                aria-hidden
+                className="flex min-w-0 items-center gap-1.5"
+                style={{ color: 'var(--cc-mint)' }}
+              >
+                {held.swatch}
+                {/* `min-w-0` so a long summoned name shrinks to an ellipsis
+                    instead of shoving the handle wider than the phone. */}
+                <span className="min-w-0" style={{ overflow: 'hidden', textOverflow: 'ellipsis' }}>
+                  {held.name}
+                </span>
+              </span>
+              <span
+                aria-hidden
+                className="ml-auto hidden sm:inline"
+                style={{ opacity: 0.4, letterSpacing: 1 }}
+              >
+                tap the world to place it
+              </span>
+            </>
+          )}
+        </button>
       </div>
 
-      {/* The tidy toggle sits beside the tabs but outside the tablist — it is
-          not a tab, and a stray child in there confuses assistive tech. */}
-      <div className="-mx-1 flex items-center gap-1 px-1">
-        <div className="flex gap-1 overflow-x-auto" role="tablist" aria-label="Creature kinds">
-          {tabs.map(tab => {
-            const selected = tab.id === active
-            // Ones on their way count too, so the number moves the instant you ask
-            // rather than staying at zero for the length of a generation.
-            const count =
-              (grouped.get(tab.id)?.length ?? 0) + (tab.id === 'yours' ? pending.length : 0)
-            return (
-              <button
-                key={tab.id}
-                type="button"
-                role="tab"
-                className="cc-btn shrink-0"
-                aria-selected={selected}
-                onClick={() => {
-                  setGroup(tab.id)
-                  setTidying(false)
+      {open && (
+        <div id="micro-land-tools" className="flex flex-col gap-1.5">
+          <div className="-mx-1 flex gap-1.5 overflow-x-auto px-1 pb-1">
+            <button
+              type="button"
+              className="cc-btn shrink-0"
+              onClick={() => setTool({ kind: 'erase' })}
+              aria-pressed={tool.kind === 'erase'}
+              style={swatchStyle(tool.kind === 'erase')}
+            >
+              <span
+                aria-hidden
+                style={{
+                  width: 22,
+                  height: 22,
+                  borderRadius: 3,
+                  border: '1px dashed var(--cc-text-muted)',
                 }}
+              />
+              <span style={swatchLabel}>Erase</span>
+            </button>
+
+            {PAINTABLE.map(id => {
+              // A tintable swatch shows whichever color of itself is in hand, so
+              // the palette reflects what the brush will actually paint.
+              const inHand = family === id && tool.kind === 'material' ? tool.material : id
+              const material = MATERIALS[inHand]
+              const selected = tool.kind === 'material' && (tool.material === id || family === id)
+              return (
+                <button
+                  key={id}
+                  type="button"
+                  className="cc-btn shrink-0"
+                  onClick={() => setTool({ kind: 'material', material: inHand })}
+                  aria-pressed={selected}
+                  style={swatchStyle(selected)}
+                >
+                  <span
+                    aria-hidden
+                    style={{
+                      position: 'relative',
+                      display: 'block',
+                      width: 22,
+                      height: 22,
+                      borderRadius: 3,
+                      background: material.color,
+                      boxShadow:
+                        material.glow > 0
+                          ? `0 0 10px ${material.color}`
+                          : 'inset 0 0 0 1px rgba(0,0,0,0.35)',
+                    }}
+                  >
+                    {MATERIALS[id].tintable && (
+                      // A corner notch marks the ones that come in colors.
+                      <span
+                        style={{
+                          position: 'absolute',
+                          right: 1,
+                          bottom: 1,
+                          width: 0,
+                          height: 0,
+                          borderLeft: '6px solid transparent',
+                          borderBottom: '6px solid rgba(255,255,255,0.75)',
+                        }}
+                      />
+                    )}
+                  </span>
+                  <span style={swatchLabel}>{MATERIALS[id].name}</span>
+                </button>
+              )
+            })}
+          </div>
+
+          {family && (
+            <div
+              className="-mx-1 flex items-center gap-1.5 overflow-x-auto px-1 pb-1"
+              role="group"
+              aria-label={`${MATERIALS[family].name} colour`}
+            >
+              <span style={{ ...label, paddingLeft: 4 }}>Colour</span>
+              {[
+                { id: family as MaterialId, name: MATERIALS[family].name },
+                ...TINTS.map(t => ({
+                  id: tintedId(family, t.id),
+                  name: t.name,
+                })),
+              ].map(({ id, name }) => {
+                const selected = tool.kind === 'material' && tool.material === id
+                return (
+                  <button
+                    key={id}
+                    type="button"
+                    className="cc-btn shrink-0"
+                    onClick={() => setTool({ kind: 'material', material: id })}
+                    aria-pressed={selected}
+                    aria-label={name}
+                    title={name}
+                    style={{
+                      width: 30,
+                      height: 30,
+                      display: 'grid',
+                      placeItems: 'center',
+                      borderRadius: 999,
+                      border: `2px solid ${selected ? 'var(--cc-mint)' : 'transparent'}`,
+                      background: 'transparent',
+                    }}
+                  >
+                    <span
+                      aria-hidden
+                      style={{
+                        display: 'block',
+                        width: 20,
+                        height: 20,
+                        borderRadius: 999,
+                        background: MATERIALS[id].color,
+                        boxShadow: 'inset 0 0 0 1px rgba(0,0,0,0.35)',
+                      }}
+                    />
+                  </button>
+                )
+              })}
+            </div>
+          )}
+
+          {/* --- creatures --- */}
+          {/* Wraps: Generate, Draw and Inspect together overflow a 360px phone. */}
+          <div className="flex flex-wrap items-center gap-2">
+            <span style={label}>Creatures</span>
+            <button
+              type="button"
+              className="cc-btn"
+              onClick={() => setSummonOpen(true)}
+              style={{
+                fontFamily: 'var(--cc-font-mono)',
+                fontSize: 10,
+                letterSpacing: 1.6,
+                textTransform: 'uppercase',
+                fontWeight: 700,
+                padding: '6px 14px',
+                minHeight: 32,
+                borderRadius: 4,
+                background: 'linear-gradient(180deg, var(--cc-mint), var(--cc-mint-hi))',
+                border: '1px solid var(--cc-mint)',
+                color: 'var(--cc-on-mint)',
+                boxShadow: 'var(--cc-mint-glow)',
+                display: 'inline-flex',
+                alignItems: 'center',
+                gap: 6,
+              }}
+            >
+              <SparkleIcon size={12} />
+              Generate
+            </button>
+            {/* Secondary to Generate on purpose: one primary-action colour per
+            screen, and drawing is the slower, more deliberate of the two. */}
+            <button
+              type="button"
+              className="cc-btn"
+              onClick={() => setBuilderOpen(true)}
+              title="Colour in a creature yourself, square by square"
+              style={{
+                fontFamily: 'var(--cc-font-mono)',
+                fontSize: 10,
+                letterSpacing: 1.6,
+                textTransform: 'uppercase',
+                padding: '6px 12px',
+                minHeight: 32,
+                borderRadius: 4,
+                border: '1px solid var(--cc-mint-line)',
+                background: 'transparent',
+                color: 'var(--cc-text-muted)',
+              }}
+            >
+              ✎ Draw
+            </button>
+            <button
+              type="button"
+              className="cc-btn"
+              onClick={() =>
+                setTool(
+                  tool.kind === 'inspect'
+                    ? { kind: 'material', material: 'dirt' }
+                    : { kind: 'inspect' }
+                )
+              }
+              aria-pressed={tool.kind === 'inspect'}
+              title="Tap a creature to see how it is doing"
+              style={{
+                fontFamily: 'var(--cc-font-mono)',
+                fontSize: 10,
+                letterSpacing: 1.6,
+                textTransform: 'uppercase',
+                padding: '6px 12px',
+                minHeight: 32,
+                borderRadius: 4,
+                border: `1px solid ${tool.kind === 'inspect' ? 'var(--cc-mint)' : 'var(--cc-mint-line)'}`,
+                background: tool.kind === 'inspect' ? 'var(--cc-mint-soft)' : 'transparent',
+                color: tool.kind === 'inspect' ? 'var(--cc-mint)' : 'var(--cc-text-muted)',
+              }}
+            >
+              ⌕ Inspect
+            </button>
+            <span
+              style={{
+                fontFamily: 'var(--cc-font-mono)',
+                fontSize: 9,
+                opacity: 0.45,
+                letterSpacing: 1,
+              }}
+              className="hidden sm:inline"
+            >
+              {tool.kind === 'inspect'
+                ? 'tap a creature to watch it'
+                : paintingSelected
+                  ? 'drag a creature to throw it'
+                  : 'tap to place · drag a creature to throw it'}
+            </span>
+          </div>
+
+          {/* The tidy toggle sits beside the tabs but outside the tablist — it is
+          not a tab, and a stray child in there confuses assistive tech. */}
+          <div className="-mx-1 flex items-center gap-1 px-1">
+            <div className="flex gap-1 overflow-x-auto" role="tablist" aria-label="Creature kinds">
+              {tabs.map(tab => {
+                const selected = tab.id === active
+                // Ones on their way count too, so the number moves the instant you ask
+                // rather than staying at zero for the length of a generation.
+                const count =
+                  (grouped.get(tab.id)?.length ?? 0) + (tab.id === 'yours' ? pending.length : 0)
+                return (
+                  <button
+                    key={tab.id}
+                    type="button"
+                    role="tab"
+                    className="cc-btn shrink-0"
+                    aria-selected={selected}
+                    onClick={() => {
+                      setGroup(tab.id)
+                      setTidying(false)
+                    }}
+                    style={{
+                      fontFamily: 'var(--cc-font-mono)',
+                      fontSize: 9,
+                      letterSpacing: 1.2,
+                      textTransform: 'uppercase',
+                      fontWeight: selected ? 700 : 400,
+                      padding: '5px 9px',
+                      minHeight: 28,
+                      borderRadius: 999,
+                      border: `1px solid ${
+                        selected
+                          ? 'var(--cc-mint)'
+                          : tab.id === 'yours'
+                            ? 'var(--cc-pink-border)'
+                            : 'var(--cc-mint-line)'
+                      }`,
+                      background: selected ? 'var(--cc-mint-soft)' : 'transparent',
+                      color: selected
+                        ? 'var(--cc-mint)'
+                        : tab.id === 'yours'
+                          ? 'var(--cc-pink)'
+                          : 'var(--cc-text-muted)',
+                      whiteSpace: 'nowrap',
+                    }}
+                  >
+                    {tab.label}
+                    <span style={{ opacity: 0.55, marginLeft: 5 }}>{count}</span>
+                  </button>
+                )
+              })}
+            </div>
+
+            {canTidy && (
+              <button
+                type="button"
+                className="cc-btn ml-auto shrink-0"
+                onClick={() => setTidying(v => !v)}
+                aria-pressed={tidyOn}
+                title={
+                  tidyOn
+                    ? 'Done tidying — tapping a creature places it again'
+                    : 'Tidy up — tap a creature to remove it'
+                }
                 style={{
                   fontFamily: 'var(--cc-font-mono)',
                   fontSize: 9,
                   letterSpacing: 1.2,
                   textTransform: 'uppercase',
-                  fontWeight: selected ? 700 : 400,
                   padding: '5px 9px',
                   minHeight: 28,
                   borderRadius: 999,
-                  border: `1px solid ${
-                    selected
-                      ? 'var(--cc-mint)'
-                      : tab.id === 'yours'
-                        ? 'var(--cc-pink-border)'
-                        : 'var(--cc-mint-line)'
-                  }`,
-                  background: selected ? 'var(--cc-mint-soft)' : 'transparent',
-                  color: selected
-                    ? 'var(--cc-mint)'
-                    : tab.id === 'yours'
-                      ? 'var(--cc-pink)'
-                      : 'var(--cc-text-muted)',
+                  border: `1px solid ${tidyOn ? 'var(--cc-pink)' : 'var(--cc-mint-line)'}`,
+                  background: tidyOn
+                    ? 'var(--cc-pink-soft, rgba(255,122,184,0.14))'
+                    : 'transparent',
+                  color: tidyOn ? 'var(--cc-pink)' : 'var(--cc-text-muted)',
                   whiteSpace: 'nowrap',
                 }}
               >
-                {tab.label}
-                <span style={{ opacity: 0.55, marginLeft: 5 }}>{count}</span>
+                {tidyOn ? 'Done' : 'Tidy'}
               </button>
-            )
-          })}
-        </div>
+            )}
+          </div>
 
-        {canTidy && (
-          <button
-            type="button"
-            className="cc-btn ml-auto shrink-0"
-            onClick={() => setTidying(v => !v)}
-            aria-pressed={tidyOn}
-            title={
-              tidyOn
-                ? 'Done tidying — tapping a creature places it again'
-                : 'Tidy up — tap a creature to remove it'
-            }
-            style={{
-              fontFamily: 'var(--cc-font-mono)',
-              fontSize: 9,
-              letterSpacing: 1.2,
-              textTransform: 'uppercase',
-              padding: '5px 9px',
-              minHeight: 28,
-              borderRadius: 999,
-              border: `1px solid ${tidyOn ? 'var(--cc-pink)' : 'var(--cc-mint-line)'}`,
-              background: tidyOn ? 'var(--cc-pink-soft, rgba(255,122,184,0.14))' : 'transparent',
-              color: tidyOn ? 'var(--cc-pink)' : 'var(--cc-text-muted)',
-              whiteSpace: 'nowrap',
-            }}
-          >
-            {tidyOn ? 'Done' : 'Tidy'}
-          </button>
-        )}
-      </div>
-
-      {/* Wrapped, not a scrolling row — a whole group is visible at once. The
+          {/* Wrapped, not a scrolling row — a whole group is visible at once. The
           cap only bites on "Yours" after a long session of summoning. */}
-      <div
-        role="tabpanel"
-        className="-mx-1 flex flex-wrap gap-1.5 overflow-y-auto px-1 pb-1"
-        style={{ maxHeight: '24vh' }}
-      >
-        {/* Creatures still on their way hold their place at the front of the
+          <div
+            role="tabpanel"
+            className="-mx-1 flex flex-wrap gap-1.5 overflow-y-auto px-1 pb-1"
+            style={{ maxHeight: '24vh' }}
+          >
+            {/* Creatures still on their way hold their place at the front of the
             strip, right where the finished one lands.
 
             Keyed off `active`, not `group`: the two diverge whenever the
             remembered tab doesn't exist, and testing the remembered one put the
             waiting slots under whichever group the fallback had landed on. */}
-        {active === 'yours' &&
-          pending.map(p => (
-            <div
-              key={p.id}
-              className="shrink-0"
-              title={`Making “${p.prompt}”`}
-              aria-label={`Making ${p.prompt}`}
-              style={{
-                ...swatchStyle(false),
-                minWidth: 62,
-                borderStyle: 'dashed',
-                borderColor: 'var(--cc-pink-border)',
-              }}
-            >
-              <span style={{ height: 34, display: 'grid', placeItems: 'center' }}>
-                <SummonSand size={34} />
-              </span>
-              <span style={{ ...swatchLabel, color: 'var(--cc-pink)' }}>Making…</span>
-            </div>
-          ))}
-        {shown.map(bp => {
-          const selected = tool.kind === 'creature' && tool.blueprintId === bp.id
-          // Built-ins can't be removed even while tidying — they come from
-          // config, so deleting one would just bring it back on reload.
-          const removable = tidyOn && bp.summoned
-          return (
-            <button
-              key={bp.id}
-              type="button"
-              className="cc-btn shrink-0"
-              onClick={() =>
-                removable
-                  ? onRemoveSpecies(bp.id)
-                  : setTool({ kind: 'creature', blueprintId: bp.id })
-              }
-              aria-pressed={removable ? undefined : selected}
-              aria-label={removable ? `Remove ${bp.name}` : undefined}
-              title={removable ? `Remove ${bp.name}` : bp.blurb}
-              style={{
-                ...swatchStyle(selected && !tidyOn),
-                minWidth: 62,
-                position: 'relative',
-                borderColor: removable
-                  ? 'var(--cc-pink)'
-                  : selected && !tidyOn
-                    ? 'var(--cc-mint)'
-                    : bp.summoned
-                      ? 'var(--cc-pink-border)'
-                      : 'var(--cc-mint-line)',
-                // A built-in during tidy mode is inert; say so rather than
-                // letting it look tappable and do nothing.
-                opacity: tidyOn && !bp.summoned ? 0.35 : 1,
-              }}
-            >
-              <span
-                style={{
-                  height: 34,
-                  display: 'grid',
-                  placeItems: 'center',
-                }}
-              >
-                <CreaturePortrait blueprint={bp} size={34} />
-              </span>
-              <span style={swatchLabel}>{bp.name}</span>
-              {removable && (
-                <span
-                  aria-hidden
+            {active === 'yours' &&
+              pending.map(p => (
+                <div
+                  key={p.id}
+                  className="shrink-0"
+                  title={`Making “${p.prompt}”`}
+                  aria-label={`Making ${p.prompt}`}
                   style={{
-                    position: 'absolute',
-                    top: -6,
-                    right: -6,
-                    width: 20,
-                    height: 20,
-                    display: 'grid',
-                    placeItems: 'center',
-                    borderRadius: 999,
-                    fontSize: 11,
-                    lineHeight: 1,
-                    background: 'var(--cc-pink)',
-                    color: 'var(--cc-on-pink, #1b1b26)',
-                    boxShadow: '0 0 0 2px rgba(2,8,10,0.85)',
+                    ...swatchStyle(false),
+                    minWidth: 62,
+                    borderStyle: 'dashed',
+                    borderColor: 'var(--cc-pink-border)',
                   }}
                 >
-                  ✕
-                </span>
-              )}
-            </button>
-          )
-        })}
-      </div>
+                  <span style={{ height: 34, display: 'grid', placeItems: 'center' }}>
+                    <SummonSand size={34} />
+                  </span>
+                  <span style={{ ...swatchLabel, color: 'var(--cc-pink)' }}>Making…</span>
+                </div>
+              ))}
+            {shown.map(bp => {
+              const selected = tool.kind === 'creature' && tool.blueprintId === bp.id
+              // Built-ins can't be removed even while tidying — they come from
+              // config, so deleting one would just bring it back on reload.
+              const removable = tidyOn && bp.summoned
+              return (
+                <button
+                  key={bp.id}
+                  type="button"
+                  className="cc-btn shrink-0"
+                  onClick={() =>
+                    removable
+                      ? onRemoveSpecies(bp.id)
+                      : setTool({ kind: 'creature', blueprintId: bp.id })
+                  }
+                  aria-pressed={removable ? undefined : selected}
+                  aria-label={removable ? `Remove ${bp.name}` : undefined}
+                  title={removable ? `Remove ${bp.name}` : bp.blurb}
+                  style={{
+                    ...swatchStyle(selected && !tidyOn),
+                    minWidth: 62,
+                    position: 'relative',
+                    borderColor: removable
+                      ? 'var(--cc-pink)'
+                      : selected && !tidyOn
+                        ? 'var(--cc-mint)'
+                        : bp.summoned
+                          ? 'var(--cc-pink-border)'
+                          : 'var(--cc-mint-line)',
+                    // A built-in during tidy mode is inert; say so rather than
+                    // letting it look tappable and do nothing.
+                    opacity: tidyOn && !bp.summoned ? 0.35 : 1,
+                  }}
+                >
+                  <span
+                    style={{
+                      height: 34,
+                      display: 'grid',
+                      placeItems: 'center',
+                    }}
+                  >
+                    <CreaturePortrait blueprint={bp} size={34} />
+                  </span>
+                  <span style={swatchLabel}>{bp.name}</span>
+                  {removable && (
+                    <span
+                      aria-hidden
+                      style={{
+                        position: 'absolute',
+                        top: -6,
+                        right: -6,
+                        width: 20,
+                        height: 20,
+                        display: 'grid',
+                        placeItems: 'center',
+                        borderRadius: 999,
+                        fontSize: 11,
+                        lineHeight: 1,
+                        background: 'var(--cc-pink)',
+                        color: 'var(--cc-on-pink, #1b1b26)',
+                        boxShadow: '0 0 0 2px rgba(2,8,10,0.85)',
+                      }}
+                    >
+                      ✕
+                    </span>
+                  )}
+                </button>
+              )
+            })}
+          </div>
+        </div>
+      )}
     </footer>
   )
+}
+
+/**
+ * The tool in hand, as a name and a swatch the folded handle can wear.
+ *
+ * Drawn from the same sources the picker draws from — the material table and
+ * the live roster — rather than a second description kept in step by hand, so a
+ * newly summoned creature or a tint added to the table needs nothing here.
+ */
+function heldTool(
+  tool: Tool,
+  blueprints: CreatureBlueprint[]
+): { name: string; swatch: React.ReactNode } {
+  if (tool.kind === 'erase') {
+    return {
+      name: 'Erase',
+      swatch: (
+        <span
+          style={{
+            width: 16,
+            height: 16,
+            borderRadius: 3,
+            border: '1px dashed var(--cc-text-muted)',
+          }}
+        />
+      ),
+    }
+  }
+
+  if (tool.kind === 'inspect') {
+    return { name: 'Inspect', swatch: <span style={{ fontSize: 13 }}>⌕</span> }
+  }
+
+  if (tool.kind === 'creature') {
+    const bp = blueprints.find(b => b.id === tool.blueprintId)
+    // The roster is empty for the first frames of a session, and a creature the
+    // player removed leaves the tool pointing at nothing until they pick again.
+    if (!bp) return { name: 'Creature', swatch: null }
+    return { name: bp.name, swatch: <CreaturePortrait blueprint={bp} size={18} /> }
+  }
+
+  const material = MATERIALS[tool.material]
+  return {
+    name: material.name,
+    swatch: (
+      <span
+        style={{
+          width: 16,
+          height: 16,
+          borderRadius: 3,
+          background: material.color,
+          boxShadow:
+            material.glow > 0 ? `0 0 8px ${material.color}` : 'inset 0 0 0 1px rgba(0,0,0,0.35)',
+        }}
+      />
+    ),
+  }
 }
 
 function swatchStyle(selected: boolean): React.CSSProperties {

--- a/src/app/micro-land/store.ts
+++ b/src/app/micro-land/store.ts
@@ -168,6 +168,15 @@ interface MicroLandState {
   guideOpen: boolean
   settingsOpen: boolean
   /**
+   * Whether the tool drawer along the bottom is unrolled.
+   *
+   * On a phone the drawer is most of the screen, and the world it is there to
+   * change is the part you came to watch. Folding it away leaves the tool
+   * already in hand still armed, so tapping to place goes on working — you lose
+   * the picker, not the game.
+   */
+  toolbarOpen: boolean
+  /**
    * A copy of the live tuning knobs, kept only so React can draw the sliders.
    *
    * The simulation reads the mutable `TUNING` object directly and never looks at
@@ -238,6 +247,8 @@ interface MicroLandState {
   setBuilderOpen: (open: boolean) => void
   setGuideOpen: (open: boolean) => void
   setSettingsOpen: (open: boolean) => void
+  /** Roll the tool drawer up or down. Remembered for the next visit. */
+  setToolbarOpen: (open: boolean) => void
   /** Move one knob. Takes effect on the very next tick and is remembered. */
   setTuningKnob: (key: TuningKey, value: number) => void
   /** Put every knob back to what the game shipped with. */
@@ -251,6 +262,15 @@ interface MicroLandState {
    * mismatch waiting to happen.
    */
   hydrateTuning: () => void
+  /**
+   * Pull the remembered drawer state out of storage.
+   *
+   * Separate from the initial value for the same reason as `hydrateTuning`: this
+   * store is built during the server render too, and a `localStorage` read there
+   * answers differently than the browser will. The drawer starts unrolled on
+   * both sides and folds itself on the client if that is how it was left.
+   */
+  hydrateToolbar: () => void
   setInspected: (snapshot: Inspected | null) => void
   setRecords: (records: RecordsView) => void
   setArchive: (archive: SpeciesRecord[]) => void
@@ -265,6 +285,32 @@ interface MicroLandState {
 
 let noticeId = 0
 let pendingId = 0
+
+const TOOLBAR_KEY = 'micro-land:toolbar:v1'
+
+/**
+ * Remember whether the drawer was left folded away.
+ *
+ * Both halves swallow everything: `localStorage` *throws on read as well as on
+ * write* in private-mode Safari, and a drawer that cannot remember its state is
+ * a far smaller loss than a game that will not start.
+ */
+function storeToolbarOpen(open: boolean): void {
+  try {
+    if (open) localStorage.removeItem(TOOLBAR_KEY)
+    else localStorage.setItem(TOOLBAR_KEY, 'closed')
+  } catch {
+    // Nothing to do; the drawer just starts unrolled next time.
+  }
+}
+
+function readToolbarOpen(): boolean {
+  try {
+    return localStorage.getItem(TOOLBAR_KEY) !== 'closed'
+  } catch {
+    return true
+  }
+}
 
 export const useMicroLand = create<MicroLandState>(set => ({
   themeId: DEFAULT_THEME,
@@ -287,6 +333,7 @@ export const useMicroLand = create<MicroLandState>(set => ({
   builderOpen: false,
   guideOpen: false,
   settingsOpen: false,
+  toolbarOpen: true,
   tuning: { ...TUNING },
   inspected: null,
   canPan: true,
@@ -322,6 +369,11 @@ export const useMicroLand = create<MicroLandState>(set => ({
   setBuilderOpen: builderOpen => set({ builderOpen }),
   setGuideOpen: guideOpen => set({ guideOpen }),
   setSettingsOpen: settingsOpen => set({ settingsOpen }),
+  setToolbarOpen: toolbarOpen => {
+    storeToolbarOpen(toolbarOpen)
+    set({ toolbarOpen })
+  },
+  hydrateToolbar: () => set({ toolbarOpen: readToolbarOpen() }),
 
   // Every one of these writes the mutable object first and mirrors it after,
   // never the other way round: `setTuning` clamps and can hold one knob against


### PR DESCRIPTION
The panel along the bottom of Micro Land is now hideable. On a phone that gives roughly 40% more screen back to the world.

### What it does

**Open** — the top row reads `Ground [brush sizes] ……… [▾ Hide]`. The handle shares the row the brushes were already on, so the affordance costs no extra height.

**Folded** — everything below unmounts and the handle becomes a full-width button reading `▴ Tools | ◼ Dirt`.

The decision that matters: **folding does not disarm the tool.** You can go on tapping to place dirt or drop hoppers with the whole screen given to the world — you lose the picker, not the game. That only works if the handle says what a tap will do, which is why the folded handle wears the held tool's own swatch (or creature portrait), pulled from the material table and the live roster rather than a second description kept in step by hand.

### Notes for review

- **Read the toolbar diff with `git diff -w`.** It is +186/−5 ignoring whitespace; the rest is re-indentation from wrapping the collapsible body in a container.
- **No animation, deliberately.** The canvas is sized by a `ResizeObserver` on its parent and `Renderer.resize` reallocates the backing store on every call, so a height transition would rebuild the canvas once per frame for the length of the slide. Instant is also what `prefers-reduced-motion` wants — the cheap answer is the correct one twice over.
- **The state persists** (`micro-land:toolbar:v1`), hydrated client-side via `hydrateToolbar()` in its own effect, mirroring the existing `hydrateTuning` pattern — reading `localStorage` during the server render is a hydration mismatch waiting to happen. Both read and write swallow exceptions, since `localStorage` throws on *read* in private-mode Safari.
- `aria-expanded` with no `aria-controls`, because the panel is unmounted while folded and pointing at an absent id is a broken reference rather than a helpful one.

Touches `components/toolbar.tsx`, `store.ts`, `MicroLandGame.tsx`. No simulation code.

### Verification

- `npm run typecheck` — no micro-land errors
- `npx eslint src/app/micro-land/` — clean
- `npm test -- src/app/micro-land` — 113 passed
- Prettier clean; dev server serves `/micro-land` at 200 with the handle in the SSR output

**Not verified in a real browser** — no browser automation on this machine. The layout at 360px, the tap targets, and how a long summoned creature name ellipsizes in the folded handle are reasoned about but not seen. Worth a minute on a phone before merging.

`npm run sim:micro-land` was skipped; this touches no simulation code.

The repo has pre-existing failures unrelated to this branch: 71 test failures in `comet-cards`/`trivia`, and typecheck errors in `src/lib/trivia/generateQuestion.ts` from AI SDK version drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)