### PR TITLE
fix(micro-land): a deletion the account knows about stays deleted

### DIFF
--- a/src/app/micro-land/MicroLandGame.tsx
+++ b/src/app/micro-land/MicroLandGame.tsx
@@ -148,7 +148,10 @@ export function MicroLandGame() {
     // `getIdToken` refreshes on its own when the cached token has expired, so
     // asking per request is what keeps a long session writable.
     const getToken = () => user.getIdToken()
-    void adoptAccount(accountBackend(getToken)).then(() => {
+    // The uid goes along so both stores can tell "this device holds work the
+    // account has never seen" from "this device is a stale copy of it" — the
+    // difference between merging and honouring a deletion. See `sync-mark.ts`.
+    void adoptAccount(accountBackend(getToken), uid).then(() => {
       // The merge may have brought in creatures made on another device; the
       // roster was built before any of them existed.
       gameRef.current?.refreshRoster()
@@ -156,7 +159,7 @@ export function MicroLandGame() {
     // Independently of the chronicle: a shelf that fails to reach the account
     // still has whatever this browser kept, which is the anonymous-first
     // promise applied to worlds as well as to records.
-    void adoptWorldsAccount(accountWorldsBackend(getToken))
+    void adoptWorldsAccount(accountWorldsBackend(getToken), uid)
   }, [user])
 
   /**

--- a/src/app/micro-land/chronicle/__tests__/chronicle.test.ts
+++ b/src/app/micro-land/chronicle/__tests__/chronicle.test.ts
@@ -26,6 +26,12 @@ import {
 import type { ChronicleData } from '@/app/micro-land/chronicle/types'
 import { reserveSummonIds, sanitizeBlueprint } from '@/app/micro-land/domain/blueprint'
 import type { CreatureBlueprint } from '@/app/micro-land/domain/types'
+import {
+  CHRONICLE_SYNC_KEY,
+  readSyncMark,
+  setSyncStore,
+  writeSyncMark,
+} from '@/app/micro-land/sync-mark'
 
 /**
  * A blueprint stub.
@@ -59,7 +65,18 @@ async function loadWith(stored: ChronicleData | null) {
   return mem
 }
 
+/** Stands in for `localStorage`, which the sync marks live in. */
+function memoryStore() {
+  const entries = new Map<string, string>()
+  return {
+    getItem: (key: string) => entries.get(key) ?? null,
+    setItem: (key: string, value: string) => void entries.set(key, value),
+    removeItem: (key: string) => void entries.delete(key),
+  }
+}
+
 beforeEach(async () => {
+  setSyncStore(memoryStore())
   await loadWith(null)
 })
 
@@ -175,7 +192,7 @@ describe('adoptAccount', () => {
     stored.lands.tidepool = { ...emptyLandRecord(), steadySeconds: 200 }
 
     const account = memoryBackend(stored)
-    await adoptAccount(account.backend)
+    await adoptAccount(account.backend, 'uid-1')
 
     const ids = new Set(archivedSpecies().map(s => s.blueprint.id))
     expect(ids.has('drawn-by-hand')).toBe(true)
@@ -189,7 +206,7 @@ describe('adoptAccount', () => {
     rememberSpecies(bp('drawn-by-hand', true), 500)
 
     const account = memoryBackend(emptyChronicle())
-    await adoptAccount(account.backend)
+    await adoptAccount(account.backend, 'uid-1')
 
     expect(Object.keys(account.state.saved?.species ?? {})).toContain('drawn-by-hand')
   })
@@ -199,23 +216,107 @@ describe('adoptAccount', () => {
     rememberSpecies(bp('first-ever', true), 10)
 
     const account = memoryBackend(null)
-    await adoptAccount(account.backend)
+    await adoptAccount(account.backend, 'uid-1')
 
     expect(account.state.saved).not.toBeNull()
     expect(Object.keys(account.state.saved?.species ?? {})).toContain('first-ever')
   })
 
-  it('sends later records to the account rather than the device', async () => {
+  /**
+   * The device copy has to keep moving after sign-in, or it freezes at that
+   * moment and spends every later load arguing for putting back what has been
+   * deleted since. That is the bug this whole mirror exists to close.
+   */
+  it('keeps the device copy in step behind the account', async () => {
     const local = await loadWith(null)
     const account = memoryBackend(null)
-    await adoptAccount(account.backend)
+    await adoptAccount(account.backend, 'uid-1')
 
     rememberSpecies(bp('after-sign-in', true), 900)
     await flushChronicle()
 
     expect(Object.keys(account.state.saved?.species ?? {})).toContain('after-sign-in')
-    // The local backend was only ever written by the pre-adoption flush.
-    expect(Object.keys(local.state.saved?.species ?? {})).not.toContain('after-sign-in')
+    expect(Object.keys(local.state.saved?.species ?? {})).toContain('after-sign-in')
+  })
+
+  it('marks the device as in step only once the account write has landed', async () => {
+    await loadWith(null)
+    const local = memoryBackend(null)
+    setBackend(local.backend)
+    await initChronicle()
+
+    rememberSpecies(bp('made-offline', true), 900)
+    await adoptAccount(
+      {
+        async load() {
+          return null
+        },
+        async save() {
+          throw new Error('offline')
+        },
+      },
+      'uid-1'
+    )
+
+    // Nothing reached the account, so the device must not claim it did — the
+    // next load has to merge, which is what carries this creature up.
+    expect(readSyncMark(CHRONICLE_SYNC_KEY)).toBeNull()
+  })
+
+  /**
+   * The reported bug, reduced: a creature deleted in the last session is gone
+   * from the account and still sitting in this device's copy, because the
+   * deletion was written to the account the device was mirroring.
+   */
+  it('lets the account drop a species the device copy still remembers', async () => {
+    const stale = emptyChronicle()
+    stale.species.wyrm = {
+      blueprint: bp('wyrm', true),
+      firstSeen: 1,
+      lastSeen: 2,
+      longestLife: 30,
+    }
+    await loadWith(stale)
+    writeSyncMark(CHRONICLE_SYNC_KEY, 'uid-1')
+
+    await adoptAccount(memoryBackend(emptyChronicle()).backend, 'uid-1')
+
+    expect(archivedSpecies()).toHaveLength(0)
+  })
+
+  it('still merges when the device was last in step with a different account', async () => {
+    const stale = emptyChronicle()
+    stale.species.wyrm = {
+      blueprint: bp('wyrm', true),
+      firstSeen: 1,
+      lastSeen: 2,
+      longestLife: 30,
+    }
+    await loadWith(stale)
+    writeSyncMark(CHRONICLE_SYNC_KEY, 'someone-else')
+
+    await adoptAccount(memoryBackend(emptyChronicle()).backend, 'uid-1')
+
+    // Nothing here says this account has ever seen the wyrm, so it is a
+    // creature to carry up rather than one to let go of.
+    expect(archivedSpecies()).toHaveLength(1)
+  })
+
+  it('keeps the device copy when the account cannot be read at all', async () => {
+    const stale = emptyChronicle()
+    stale.species.wyrm = {
+      blueprint: bp('wyrm', true),
+      firstSeen: 1,
+      lastSeen: 2,
+      longestLife: 30,
+    }
+    await loadWith(stale)
+    writeSyncMark(CHRONICLE_SYNC_KEY, 'uid-1')
+
+    // A dropped connection and a player who has never saved both read as null.
+    await adoptAccount(memoryBackend(null).backend, 'uid-1')
+
+    expect(archivedSpecies()).toHaveLength(1)
   })
 
   it('ignores a stored chronicle from an unknown version', async () => {
@@ -230,7 +331,7 @@ describe('adoptAccount', () => {
       longestLife: 0,
     }
 
-    await adoptAccount(memoryBackend(stored).backend)
+    await adoptAccount(memoryBackend(stored).backend, 'uid-1')
 
     const ids = new Set(archivedSpecies().map(s => s.blueprint.id))
     expect(ids.has('garbage')).toBe(false)
@@ -242,7 +343,7 @@ describe('adoptAccount', () => {
     const mem = memoryBackend(null)
     setBackend(mem.backend)
     await initChronicle()
-    await adoptAccount(mem.backend)
+    await adoptAccount(mem.backend, 'uid-1')
     expect(mem.state.saved).toBeNull()
   })
 
@@ -282,7 +383,7 @@ describe('adoptAccount', () => {
     }
 
     const init = initChronicle()
-    const adopt = adoptAccount(memoryBackend(accountData).backend)
+    const adopt = adoptAccount(memoryBackend(accountData).backend, 'uid-1')
     release()
     await Promise.all([init, adopt])
 

--- a/src/app/micro-land/chronicle/chronicle.ts
+++ b/src/app/micro-land/chronicle/chronicle.ts
@@ -9,6 +9,7 @@
  * is an acceptable trade; janking the frame loop is not.
  */
 import type { CreatureBlueprint } from '@/app/micro-land/domain/types'
+import { CHRONICLE_SYNC_KEY, readSyncMark, writeSyncMark } from '@/app/micro-land/sync-mark'
 
 import { type ChronicleBackend, INITIAL_DATA, localBackend } from './backend'
 import {
@@ -50,6 +51,19 @@ let dirty = false
 let flushTimer: ReturnType<typeof setTimeout> | null = null
 /** True once `adoptAccount` has moved writes off this device. */
 let remote = false
+/**
+ * The device copy, once the account has taken over the writes.
+ *
+ * The account is where the chronicle lives after `adoptAccount`, but the local
+ * copy is not abandoned — it is kept in step *behind* it, so a player whose
+ * account is unreachable next session still opens a game with their records in
+ * it. A mirror that stopped being written would be worse than no mirror at all:
+ * it freezes at the moment of sign-in and then argues, on every load, for
+ * putting back everything deleted since. See `sync-mark.ts`.
+ */
+let mirror: ChronicleBackend | null = null
+/** Whose account `backend` is writing to, so the mark can name it. */
+let accountId: string | null = null
 
 // ---------------------------------------------------------------------------
 // Save state
@@ -129,6 +143,8 @@ export function setBackend(next: ChronicleBackend): void {
   loaded = false
   loading = null
   remote = false
+  mirror = null
+  accountId = null
 }
 
 /**
@@ -150,8 +166,19 @@ export function setBackend(next: ChronicleBackend): void {
  * The write-back is unconditional. Even when the account wins on every record,
  * the local archive may hold a creature it has never seen, and that creature is
  * the thing this whole path exists to save.
+ *
+ * The merge is skipped in exactly one case: when this device's copy is already
+ * known to be in step with *this* account (see `sync-mark.ts`). Then the account
+ * holds everything the local copy does, plus every deletion made since, so
+ * unioning the two would resurrect every creature the player has thrown away —
+ * which is what "deleting does not work, it comes back on refresh" was. In that
+ * case the account is simply the truth.
+ *
+ * `stored` being null is deliberately *not* treated as "the account is empty".
+ * A dropped connection reads the same way, and the safe answer to both is to
+ * keep what this device has and hand it up.
  */
-export async function adoptAccount(next: ChronicleBackend): Promise<void> {
+export async function adoptAccount(next: ChronicleBackend, account: string): Promise<void> {
   if (backend === next) return
 
   // Never merge into a chronicle that hasn't finished loading — the local read
@@ -159,9 +186,18 @@ export async function adoptAccount(next: ChronicleBackend): Promise<void> {
   await initChronicle()
 
   const stored = await next.load()
+  const mirrored = readSyncMark(CHRONICLE_SYNC_KEY) === account
+
+  // Whatever was being written before the account took over becomes the mirror —
+  // `localBackend` in the game, and whatever a test installed in a test. Adopting
+  // a *second* account (a sign-out and back in under another uid) leaves it
+  // alone: the device is still the thing to mirror, the account being left
+  // behind is not.
+  if (!remote) mirror = backend
   backend = next
+  accountId = account
   remote = true
-  if (stored) data = mergeChronicles(migrate(stored), data)
+  if (stored) data = mirrored ? migrate(stored) : mergeChronicles(migrate(stored), data)
 
   touch()
   await flushChronicle()
@@ -264,6 +300,24 @@ export async function flushChronicle(): Promise<void> {
   setSaveState({ kind: 'saving' })
   try {
     await backend.save(data)
+    /**
+     * The device copy trails the account, and only ever on success.
+     *
+     * Written *after* the account rather than alongside it, so the mark can only
+     * ever claim something true: everything on this device is also up there.
+     * Mirroring a failed account save would put the device ahead instead, and
+     * the next load would merge it back up — which for a deletion means undoing
+     * it, the exact bug this is here to close.
+     *
+     * So a flush that cannot reach the account leaves the device holding the
+     * last state that did reach it. The in-memory chronicle keeps the newer one
+     * and `dirty` keeps retrying; nothing is lost that was not already lost
+     * before this mirror existed.
+     */
+    if (mirror) {
+      await mirror.save(data)
+      writeSyncMark(CHRONICLE_SYNC_KEY, accountId)
+    }
     setSaveState({
       kind: 'saved',
       at: Date.now(),

--- a/src/app/micro-land/sync-mark.ts
+++ b/src/app/micro-land/sync-mark.ts
@@ -1,0 +1,83 @@
+/**
+ * A note, per account, saying "everything this device kept locally is up there".
+ *
+ * The chronicle and the shelf each keep a copy on this device and a copy in the
+ * player's account, and each folds the two together when auth resolves. That
+ * fold is a union, and for everything the player *adds* a union is exactly
+ * right: every record is a high-water mark, so there is no conflict to resolve
+ * and nothing to ask about.
+ *
+ * It is exactly wrong for everything the player *removes*. A deletion is not a
+ * record, it is the absence of one, and a union cannot tell "this device has a
+ * creature the account has never seen" from "the account no longer has a
+ * creature this device still remembers". Both look like one side holding
+ * something the other does not, and the union puts it back.
+ *
+ * That was the whole of the "deleting does not work — it all comes back on
+ * refresh" bug. Adopting an account moved the writes off the device and stopped
+ * writing the local copy, freezing it at the moment of sign-in. Every deletion
+ * afterwards reached the account and left that frozen copy alone, and the next
+ * load merged it straight back in.
+ *
+ * This is the missing fact. When the mark names the account being adopted, the
+ * account holds everything this device does *plus* whatever was deleted since,
+ * so it is the whole truth and anything missing from it is missing on purpose.
+ * When it does not — a first sign-in, a session that never managed to write, a
+ * different account on the same device — the union is still correct and still
+ * runs.
+ *
+ * A device with no usable storage simply never has a mark, which falls back to
+ * the union. That is the older behaviour, not a broken one.
+ */
+
+/** The slice of `Storage` this needs. An interface so a test can hand one over. */
+export interface SyncStore {
+  getItem(key: string): string | null
+  setItem(key: string, value: string): void
+  removeItem(key: string): void
+}
+
+/** Kept together so it is obvious the two share a namespace. */
+export const CHRONICLE_SYNC_KEY = 'micro-land:chronicle-synced'
+export const WORLDS_SYNC_KEY = 'micro-land:worlds-synced'
+
+/** `undefined` means "not looked for yet"; `null` means "there isn't one". */
+let store: SyncStore | null | undefined
+
+function resolve(): SyncStore | null {
+  if (store !== undefined) return store
+  try {
+    // Merely *reading* `localStorage` throws in private-mode Safari and in
+    // locked-down embeds, which is why this is wrapped rather than checked.
+    store = typeof window === 'undefined' ? null : window.localStorage
+  } catch {
+    store = null
+  }
+  return store
+}
+
+export function readSyncMark(key: string): string | null {
+  try {
+    return resolve()?.getItem(key) ?? null
+  } catch {
+    return null
+  }
+}
+
+/** Null clears the mark, which is how a caller says "no longer in step". */
+export function writeSyncMark(key: string, accountId: string | null): void {
+  try {
+    const target = resolve()
+    if (!target) return
+    if (accountId === null) target.removeItem(key)
+    else target.setItem(key, accountId)
+  } catch {
+    // Storage is full or refusing. Losing the mark costs a merge, which is the
+    // behaviour this whole file replaced; it is never worth interrupting play.
+  }
+}
+
+/** Test seam: put the marks somewhere a test can read and write them. */
+export function setSyncStore(next: SyncStore | null): void {
+  store = next
+}

--- a/src/app/micro-land/worlds/__tests__/shelf.test.ts
+++ b/src/app/micro-land/worlds/__tests__/shelf.test.ts
@@ -1,0 +1,235 @@
+/**
+ * The shelf's storage behaviour, and mostly one question: does letting go of a
+ * world stick?
+ *
+ * It did not. Deleting removed the world from whichever backend was in use — the
+ * account, once auth had resolved, which is every player — and left this
+ * device's copy alone. The next visit read that copy, found a world the account
+ * had never heard of, and helpfully uploaded it again. Every test below that
+ * mentions a mark is about telling those two situations apart.
+ */
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import {
+  WORLDS_SYNC_KEY,
+  readSyncMark,
+  setSyncStore,
+  writeSyncMark,
+} from '@/app/micro-land/sync-mark'
+import type { WorldsBackend } from '@/app/micro-land/worlds/backend'
+import {
+  adoptWorldsAccount,
+  initShelf,
+  keepWorld,
+  readShelf,
+  removeWorld,
+  resetShelf,
+  setBackend,
+} from '@/app/micro-land/worlds/shelf'
+import type { WorldSave } from '@/app/micro-land/worlds/types'
+
+/**
+ * A save with nothing in it but its identity.
+ *
+ * The shelf never looks inside one — it stores the blob and reads `summarize`'s
+ * eight fields off the top — so filling in a tile grid would only obscure what
+ * these tests are about. `snapshot.test.ts` is where a real world is exercised.
+ */
+function save(id: string, updatedAt = 1000): WorldSave {
+  return {
+    version: 1,
+    id,
+    name: id,
+    createdAt: 1,
+    updatedAt,
+    themeId: 'earth',
+    terrain: null,
+    camX: 0,
+    land: { landId: 'earth', steadySince: 0, elderId: null },
+    world: { creatures: [], elapsed: 0 },
+  } as unknown as WorldSave
+}
+
+/** A backend that keeps saves in a Map, standing in for a device or an account. */
+function memoryBackend(initial: WorldSave[] = []) {
+  const saves = new Map(initial.map(s => [s.id, s]))
+  const backend: WorldsBackend = {
+    async list() {
+      return [...saves.values()].map(s => ({
+        id: s.id,
+        name: s.name,
+        createdAt: s.createdAt,
+        updatedAt: s.updatedAt,
+        themeId: s.themeId,
+        landName: null,
+        creatures: 0,
+        elapsed: 0,
+      }))
+    },
+    async load(id) {
+      return saves.get(id) ?? null
+    },
+    async save(next) {
+      saves.set(next.id, next)
+    },
+    async remove(id) {
+      saves.delete(id)
+    },
+  }
+  return { backend, saves }
+}
+
+/** Stands in for `localStorage`, which the sync marks live in. */
+function memoryStore() {
+  const entries = new Map<string, string>()
+  return {
+    getItem: (key: string) => entries.get(key) ?? null,
+    setItem: (key: string, value: string) => void entries.set(key, value),
+    removeItem: (key: string) => void entries.delete(key),
+  }
+}
+
+/** Open the shelf on a device that already has these worlds on it. */
+async function deviceWith(worlds: WorldSave[]) {
+  const device = memoryBackend(worlds)
+  setBackend(device.backend)
+  await initShelf()
+  return device
+}
+
+beforeEach(() => {
+  resetShelf()
+  setSyncStore(memoryStore())
+})
+
+describe('adopting an account', () => {
+  it('hands up a world kept before there was an account to keep it in', async () => {
+    await deviceWith([save('made-anon')])
+    const account = memoryBackend()
+
+    await adoptWorldsAccount(account.backend, 'uid-1')
+
+    expect(account.saves.has('made-anon')).toBe(true)
+    expect(readShelf().worlds.map(w => w.id)).toEqual(['made-anon'])
+    // Everything this device had is up there now, which is what lets the next
+    // adoption trust the account's list.
+    expect(readSyncMark(WORLDS_SYNC_KEY)).toBe('uid-1')
+  })
+
+  it('brings down a world kept on another device', async () => {
+    await deviceWith([])
+    const account = memoryBackend([save('from-the-phone')])
+
+    await adoptWorldsAccount(account.backend, 'uid-1')
+
+    expect(readShelf().worlds.map(w => w.id)).toEqual(['from-the-phone'])
+  })
+
+  /** The reported bug: forgetting a world, then finding it back after a refresh. */
+  it('does not upload a world this device kept but the account has let go of', async () => {
+    const device = await deviceWith([save('forgotten')])
+    writeSyncMark(WORLDS_SYNC_KEY, 'uid-1')
+    const account = memoryBackend()
+
+    await adoptWorldsAccount(account.backend, 'uid-1')
+
+    expect(account.saves.has('forgotten')).toBe(false)
+    expect(readShelf().worlds).toHaveLength(0)
+    // And the copy left behind goes, so it cannot argue again next time.
+    expect(device.saves.has('forgotten')).toBe(false)
+  })
+
+  it('still uploads when the device was last in step with a different account', async () => {
+    await deviceWith([save('mine')])
+    writeSyncMark(WORLDS_SYNC_KEY, 'someone-else')
+    const account = memoryBackend()
+
+    await adoptWorldsAccount(account.backend, 'uid-1')
+
+    expect(account.saves.has('mine')).toBe(true)
+  })
+
+  it('changes nothing when the account shelf cannot be read', async () => {
+    const device = await deviceWith([save('kept')])
+    writeSyncMark(WORLDS_SYNC_KEY, 'uid-1')
+
+    await adoptWorldsAccount(
+      {
+        async list() {
+          throw new Error('offline')
+        },
+        async load() {
+          return null
+        },
+        async save() {},
+        async remove() {},
+      },
+      'uid-1'
+    )
+
+    // An unreachable account lists nothing, and nothing is exactly what a shelf
+    // whose every world was deleted elsewhere would list too.
+    expect(device.saves.has('kept')).toBe(true)
+    expect(readShelf().worlds.map(w => w.id)).toEqual(['kept'])
+  })
+
+  it('does not claim to be in step when a world would not upload', async () => {
+    await deviceWith([save('too-big')])
+    const account = memoryBackend()
+    const refuses: WorldsBackend = {
+      ...account.backend,
+      async save() {
+        throw new Error('that world is too big to keep')
+      },
+    }
+
+    await adoptWorldsAccount(refuses, 'uid-1')
+
+    // Claiming otherwise would delete this world on the next visit, having never
+    // put it anywhere.
+    expect(readSyncMark(WORLDS_SYNC_KEY)).toBeNull()
+  })
+})
+
+describe('once the account has taken over', () => {
+  /** Set up a device and an account that have already met. */
+  async function signedIn(worlds: WorldSave[] = []) {
+    const device = await deviceWith(worlds)
+    const account = memoryBackend()
+    await adoptWorldsAccount(account.backend, 'uid-1')
+    return { device, account }
+  }
+
+  it('writes a kept world to both the account and this device', async () => {
+    const { device, account } = await signedIn()
+
+    await keepWorld(save('new-one'))
+
+    expect(account.saves.has('new-one')).toBe(true)
+    expect(device.saves.has('new-one')).toBe(true)
+  })
+
+  it('takes a forgotten world off both, so nothing is left to re-upload', async () => {
+    const { device, account } = await signedIn([save('doomed')])
+
+    await removeWorld('doomed')
+
+    expect(account.saves.has('doomed')).toBe(false)
+    expect(device.saves.has('doomed')).toBe(false)
+    expect(readShelf().worlds).toHaveLength(0)
+  })
+
+  it('survives a reload without putting the forgotten world back', async () => {
+    const { device, account } = await signedIn([save('doomed')])
+    await removeWorld('doomed')
+
+    // The page comes back: the device shelf is read first, then the account is
+    // adopted a moment later, exactly as `MicroLandGame` sequences it.
+    resetShelf()
+    setBackend(device.backend)
+    await initShelf()
+    await adoptWorldsAccount(account.backend, 'uid-1')
+
+    expect(readShelf().worlds).toHaveLength(0)
+  })
+})

--- a/src/app/micro-land/worlds/backend.ts
+++ b/src/app/micro-land/worlds/backend.ts
@@ -132,17 +132,23 @@ export function accountWorldsBackend(getToken: () => Promise<string | null>): Wo
   }
 
   return {
+    /**
+     * Throws when the account cannot be reached, deliberately.
+     *
+     * An empty shelf and an unreadable one are identical to a caller handed `[]`
+     * for both, and they call for opposite responses. `adoptWorldsAccount`
+     * reconciles this device's shelf against what the account lists — treating a
+     * dropped connection as "the account lists nothing" would read as "every
+     * world you kept was deleted on another device" and take the local copies
+     * with it.
+     */
     async list() {
-      try {
-        const headers = await authorized()
-        if (!headers) return []
-        const response = await fetch(ENDPOINT, { headers })
-        if (!response.ok) return []
-        const body = (await response.json()) as { worlds?: unknown }
-        return Array.isArray(body.worlds) ? (body.worlds as WorldSummary[]) : []
-      } catch {
-        return []
-      }
+      const headers = await authorized()
+      if (!headers) throw new Error('not signed in yet')
+      const response = await fetch(ENDPOINT, { headers })
+      if (!response.ok) throw new Error(`world list failed: ${response.status}`)
+      const body = (await response.json()) as { worlds?: unknown }
+      return Array.isArray(body.worlds) ? (body.worlds as WorldSummary[]) : []
     },
 
     async load(id) {

--- a/src/app/micro-land/worlds/shelf.ts
+++ b/src/app/micro-land/worlds/shelf.ts
@@ -13,6 +13,8 @@
  * and lets go of the shelved one. Without that, "Reshape" would quietly destroy
  * the world the player had asked the game to keep.
  */
+import { WORLDS_SYNC_KEY, readSyncMark, writeSyncMark } from '@/app/micro-land/sync-mark'
+
 import { type WorldsBackend, localWorldsBackend } from './backend'
 import { MAX_SAVED_WORLDS, summarize } from './wire'
 
@@ -32,6 +34,15 @@ export interface ShelfState {
 }
 
 let backend: WorldsBackend = localWorldsBackend
+/**
+ * The device shelf, once the account has taken over the writes.
+ *
+ * Same reasoning as the chronicle's mirror: a local copy that stops being
+ * written freezes at the moment of sign-in, and every load afterwards argues for
+ * re-uploading the worlds the player has since thrown away. Saves and deletions
+ * both go through to it, so it never drifts from the account on this device.
+ */
+let mirror: WorldsBackend | null = null
 let state: ShelfState = { worlds: [], activeId: null, busy: false, error: null }
 let listeners = new Set<(state: ShelfState) => void>()
 let listed = false
@@ -82,7 +93,14 @@ export async function initShelf(): Promise<void> {
 
   listing = (async () => {
     publish({ busy: true })
-    const worlds = await backend.list()
+    let worlds: WorldSummary[] = []
+    try {
+      worlds = await backend.list()
+    } catch {
+      // A shelf that cannot be read shows as empty rather than as an error. This
+      // runs on mount against this device's own storage, where the only way to
+      // fail is a browser refusing storage outright.
+    }
     listed = true
     publish({ worlds: order(worlds), busy: false })
   })()
@@ -106,39 +124,110 @@ export async function initShelf(): Promise<void> {
  * Failures here are swallowed on purpose. This runs unprompted when auth
  * resolves; a player who is offline keeps the local shelf they already had, and
  * the next save will try again.
+ *
+ * The upload only happens while this device still holds something the account
+ * has never seen. Once the mark says otherwise (`sync-mark.ts`), the account's
+ * list is the whole truth: a world it does not name was *deleted*, not
+ * undiscovered, and uploading it again is precisely how a forgotten world came
+ * back on the next refresh. Then the local copies go instead.
  */
-export async function adoptWorldsAccount(next: WorldsBackend): Promise<void> {
+export async function adoptWorldsAccount(next: WorldsBackend, account: string): Promise<void> {
   if (backend === next) return
   await initShelf()
 
   const local = state.worlds
-  const remote = await next.list()
+  // Whatever was being written before the account took over becomes the mirror —
+  // `localWorldsBackend` in the game, and whatever a test installed in a test.
+  // Adopting a *second* account (a sign-out and back in under another uid) keeps
+  // the one already found: the device is still the thing to mirror.
+  const device = mirror ?? backend
+
+  let remote: WorldSummary[]
+  try {
+    remote = await next.list()
+  } catch {
+    // The account could not be read. Take it over for writes — a save the player
+    // asks for should go to the account and can report its own failure — but
+    // reconcile nothing: every world would look deleted.
+    backend = next
+    mirror = device
+    return
+  }
+
+  const mirrored = readSyncMark(WORLDS_SYNC_KEY) === account
   const remoteById = new Map(remote.map(w => [w.id, w]))
 
   backend = next
+  mirror = device
   publish({ busy: true })
 
+  // Cleared by any world that would not go up, so the mark never claims more
+  // than actually happened — a lie here deletes that world on the next visit.
+  let allPushed = true
+
   for (const summary of local) {
+    if (mirrored) {
+      // Deleted elsewhere, or deleted here in a session whose local removal did
+      // not land. Either way the account has already settled it.
+      if (remoteById.has(summary.id)) continue
+      try {
+        await device.remove(summary.id)
+      } catch {
+        // Storage is refusing. The entry is not published either way, so the
+        // player does not see the world; the blob is tidied on a later visit.
+      }
+      continue
+    }
+
     const known = remoteById.get(summary.id)
     if (known && known.updatedAt >= summary.updatedAt) continue
     try {
-      const save = await localWorldsBackend.load(summary.id)
+      const save = await device.load(summary.id)
       if (save) await next.save(save)
       remoteById.set(summary.id, summary)
     } catch {
       // Offline, or the account shelf is full. Keep going: one world that
       // refuses to upload must not cost the player the rest of them.
+      allPushed = false
     }
   }
 
+  writeSyncMark(WORLDS_SYNC_KEY, allPushed ? account : null)
   publish({ worlds: order([...remoteById.values()]).slice(0, MAX_SAVED_WORLDS), busy: false })
 }
 
 export function setBackend(next: WorldsBackend): void {
   backend = next
+  mirror = null
   listed = false
   listing = null
   publish({ worlds: [], activeId: null, busy: false, error: null })
+}
+
+/**
+ * Keep the device copy in step behind the account's.
+ *
+ * Best-effort and quiet, both ways round: this is a cache, not the record. A
+ * local quota error on a world that is safely in the account is not worth
+ * interrupting the player with, and a local removal that fails is cleaned up by
+ * the reconcile on the next visit.
+ */
+async function mirrorSave(save: WorldSave): Promise<void> {
+  if (!mirror) return
+  try {
+    await mirror.save(save)
+  } catch {
+    // See above — the account has it, which is what the player was promised.
+  }
+}
+
+async function mirrorRemove(id: string): Promise<void> {
+  if (!mirror) return
+  try {
+    await mirror.remove(id)
+  } catch {
+    // See above — it is gone from the account, which is what the player asked.
+  }
 }
 
 export function isShelfFull(): boolean {
@@ -161,6 +250,7 @@ export async function keepWorld(save: WorldSave): Promise<void> {
   publish({ busy: true, error: null })
   try {
     await backend.save(save)
+    await mirrorSave(save)
     publish({
       worlds: withSummary(state.worlds, summarize(save)),
       activeId: save.id,
@@ -189,6 +279,9 @@ export async function removeWorld(id: string): Promise<void> {
   publish({ busy: true, error: null })
   try {
     await backend.remove(id)
+    // Through to this device as well, or the copy left behind is uploaded again
+    // the next time the account is adopted and the world reappears on the shelf.
+    await mirrorRemove(id)
     // Deleting the world you are standing in leaves you standing in it — it is
     // simply no longer kept. The pending autosave has to go with it, or it would
     // write the world straight back a few seconds later.
@@ -258,6 +351,7 @@ export async function flushActiveWorld(): Promise<void> {
   dirty = false
   try {
     await backend.save(save)
+    await mirrorSave(save)
     publish({ worlds: withSummary(state.worlds, summarize(save)) })
   } catch {
     dirty = true
@@ -285,6 +379,7 @@ function attachFlushOnHide(): void {
 /** Test seam: put the module back to how it loaded. */
 export function resetShelf(): void {
   backend = localWorldsBackend
+  mirror = null
   state = { worlds: [], activeId: null, busy: false, error: null }
   listeners = new Set()
   listed = false


### PR DESCRIPTION
## The bug

Deleting worked. The sync put it back. Delete a creature from the toolbar or a world from the shelf, refresh, and everything is back on the shelf.

`useAuth` mints an anonymous uid for **everyone**, so every player goes through `adoptAccount` / `adoptWorldsAccount` a moment after the page loads. Both fold this device's copy together with the account's as a **union** — right for records, which are all high-water marks, and exactly wrong for deletions, because a union cannot tell "this device has a creature the account has never seen" from "the account no longer has a creature this device still remembers."

What made it fire every time is that adopting an account moved the writes off the device and then *stopped writing the local copy*, freezing it at the moment of sign-in:

1. Sign-in: local copy frozen, writes go to the account.
2. Delete → gone from the account. The frozen local copy still has it.
3. Refresh → `initChronicle` reads the frozen copy, adoption unions it back up. It's back, permanently.

The shelf had the same shape and a stronger version of it: `removeWorld` deleted from the account only, and `adoptWorldsAccount` then re-*uploaded* the leftover local save.

## The fix

`src/app/micro-land/sync-mark.ts` (new) records the one missing fact, per account: *everything this device kept locally has already reached that account.*

- **The device copy keeps moving.** The chronicle and the shelf both write through to local *behind* the account, and only after the account write lands — so the mark can never claim something untrue. `removeWorld` removes from both.
- **Adoption trusts the account when the mark names it.** Then a species or world missing from the account was deleted on purpose, not undiscovered. With no mark — a first sign-in, a session that never managed to write, a different uid — the union runs exactly as before.
- **`accountWorldsBackend.list()` throws** instead of answering `[]` when the account is unreachable. An empty shelf and an unreadable one were identical to a caller handed `[]` for both, and they want opposite responses: reconciling against a failed read would have deleted every local copy.

## Verification

- `npx vitest run src/app/micro-land` — 126 pass, including a new `worlds/__tests__/shelf.test.ts` and four new `adoptAccount` cases. Confirmed the new tests **fail when the fix is disabled** (4 fail), so they reproduce the bug rather than restate the code.
- `npm run typecheck` clean for micro-land; eslint and prettier clean. The trivia / comet-cards / tap-tap failures in the full suite are pre-existing on `main`.
- `npm run sim:micro-land -- --theme earth --seconds 300 --runs 2` still `✓ Still alive`, low-water 546 — this is a storage-layer change and does not touch the simulation.

## One-time cost

No mark exists on any device yet, so the first load after this ships resurrects whatever was deleted before it. Deleting once more sticks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)