### PR TITLE
feat(micro-land): only the ground grows back, and slowly

### DIFF
--- a/.claude/skills/micro-land/SKILL.md
+++ b/.claude/skills/micro-land/SKILL.md
@@ -40,9 +40,10 @@ falling sand at 20 Hz while creatures move over it at 60 Hz. Every creature is a
 plain object literal — pixels, physics, appetite, lifespan — and *nothing* about
 a creature is code, which is what lets a model invent one at runtime and drop it
 into a running world. The food chain is a single rule: you can eat something if
-you list one of its tags and it isn't bigger than you. Populations rise, crash,
-and are pulled back from zero by two safety nets (the ground's plant seed bank,
-and animal seed rain). Records — longest life, deepest bloodline, longest run
+you list one of its tags and it isn't bigger than you. Populations rise and
+crash, and the only thing pulled back from zero is the flora — the ground's
+plant seed bank, running slowly. An animal that dies out is gone until the
+player puts one back. Records — longest life, deepest bloodline, longest run
 with no extinction — persist in a "chronicle" that works with no account and
 merges into one when the player signs in. A world the player wants to come back
 to can also be kept by name on a "shelf" and reopened mid-simulation.
@@ -88,16 +89,22 @@ to can also be kept by name on a "shelf" and reopened mid-simulation.
    `enforceInvariants` holds the meal a fixed margin under the cost whichever of
    the two was dragged.
 
-7. **Plants have no upstream, so the ground carries their seed.** Plants only
-   come from plants, so a grazer boom that strips the last one is terminal.
-   `seedNativePlants` makes the *soil* push the plant population back toward
-   `NATIVE_PLANT_TARGET`, harder the further below it the world falls. It is
-   deliberately blind to whether anything is alive; the animal `repopulate` is
-   not, and only ever returns a species that has something to eat.
+7. **Native plants are the only thing that regrows.** Plants only come from
+   plants, so a grazer boom that strips the last one is terminal for everything
+   above it — the ground carries their seed instead. `seedNativePlants` makes
+   the *soil* push the plant population back toward `NATIVE_PLANT_TARGET`,
+   harder the further below it the world falls, and it is deliberately blind to
+   whether anything is alive. It is also deliberately slow (a batch every 30s,
+   3 sprouts at total bareness): it exists to get a stripped world off zero and
+   then let plants spread on their own, not to keep the meadow topped up.
+   Animals have no equivalent. There *was* an animal seed rain (`repopulate`);
+   it was removed because a species coming back four seconds after it died out
+   made extinction meaningless. An animal that dies out stays out until the
+   player places one.
 
 8. **Empty means empty.** `world.dormant` is set when the player clears the
-   world and suppresses both safety nets. Anything generative — painting,
-   placing, summoning, changing theme — clears it again.
+   world and suppresses the seed bank. Anything generative — painting, placing,
+   summoning, changing theme — clears it again.
 
 9. **Sprite size is not collision size.** `artSize(bp)` is what the creature
    looks like (sight, biting, drawing); `bodyBox(bp)` is what it collides with.
@@ -142,8 +149,15 @@ regressions, and a browser cannot substitute for it.
    headless and prints population over time, causes of death, and what ate what.
    Look for:
    - `✓ Still alive` at the end of every theme.
-   - No species marked `EXTINCT in every run`.
    - A low-water mark well above zero — an oscillation, not a flatline.
+   - **Known-failing since the animal seed rain was removed:** every animal is
+     currently marked `EXTINCT in every run` on all four themes, within 3–8
+     minutes, leaving a plant-only world. The seed rain had been restocking them
+     every four seconds, which hid the fact that no animal population is
+     self-sustaining at the current tuning — grazers starve with the meadow
+     pinned at its species caps, so the problem is reach and distribution rather
+     than a shortage of food. Until that is fixed, read this line as "no *new*
+     species went extinct", not as a pass.
    - Deaths attributed sensibly (`starved` dominating a grazer means the plants
      lost; `burned` dominating means the terrain is hostile).
    - `world still solid` not collapsing — diggers should tunnel, not delete.

--- a/.claude/skills/micro-land/references/architecture.md
+++ b/.claude/skills/micro-land/references/architecture.md
@@ -141,8 +141,8 @@ case). Then per creature:
    `MAX_PLANTS` / per-species cap. Plants pay no hunger cost (they
    photosynthesise; charging them would sterilise them permanently)
 
-After the loop: filter the dead, `seedNativePlants` (plants first — everything
-is downstream of them), `repopulate`, `tickParticles`.
+After the loop: filter the dead, `seedNativePlants` (the only regrowth there is
+— animals that die out stay dead), `tickParticles`.
 
 ### `tickTiles`
 

--- a/src/app/micro-land/domain/constants.ts
+++ b/src/app/micro-land/domain/constants.ts
@@ -114,16 +114,14 @@ export const MEAL_VALUE = 0.42
 export const BREED_COST = 0.55
 
 /**
- * Seed rain — animals.
+ * Native plants — the ground's own seed bank, and the only regrowth there is.
  *
- * A native that has died out comes back once there is something alive for it to
- * eat again. It only fires while something is still alive, so pressing Empty
- * leaves the world empty.
- */
-export const SEED_RAIN_INTERVAL = 4
-
-/**
- * Native plants — the ground's own seed bank.
+ * Animals had a seed bank too once: any native that had died out wandered back
+ * in every four seconds as long as something was alive for it to eat. It kept
+ * every world populated and it made extinction meaningless — a kind you had
+ * watched starve was back before the notice finished scrolling, and the world
+ * read as a stocked aquarium rather than somewhere things happen. It is gone.
+ * Animals that die out stay out until the player places one.
  *
  * Plants are the only thing in the world with no upstream: a grazer boom strips
  * the last one and then nothing can ever bring it back, because plants only come
@@ -142,16 +140,29 @@ export const SEED_RAIN_INTERVAL = 4
  * trickle would just pin every world at MAX_PLANTS and turn it into a carpet.
  */
 export const NATIVE_PLANT_TARGET = Math.round(45 * WIDTH_SCALE)
-export const PLANT_SEED_INTERVAL = 3
+/**
+ * How long the ground waits between seedings.
+ *
+ * Slow on purpose — 30s, up from 3s. At three seconds the soil was doing the
+ * work the plants are supposed to do: a grazed patch filled back in while you
+ * were still watching it be grazed, so nothing the animals did to the meadow
+ * ever showed. Thirty seconds makes the seed bank a floor under a crash rather
+ * than a groundskeeper. Recovery still happens, because plants that exist
+ * spread on their own (PLANT_MATURITY + PLANT_SPREAD_COOLDOWN, ~15s per
+ * doubling) — all the ground has to do is get the count off zero and then stay
+ * out of the way.
+ */
+export const PLANT_SEED_INTERVAL = 30
 /**
  * Most plants a single seeding may place, when the world is at zero.
  *
- * Scaled along with the target, not left alone. The interval is a wall-clock
- * rate, so a batch that doesn't grow with the world turns "a meadow can come
- * back" into "a meadow comes back three times slower" — long enough that the
- * grazers waiting on it starve again before it arrives.
+ * One per screen of land, scaled up here rather than left as a bare number, so
+ * a three-screen world gets three sprouts spread across it instead of three
+ * screens sharing one. Small on purpose: the ground is starting a meadow, not
+ * planting one. Anywhere near the target this rounds down to a single sprout
+ * every thirty seconds, which is what the trickle is meant to feel like.
  */
-export const PLANT_SEED_BATCH = Math.round(3 * WIDTH_SCALE)
+export const PLANT_SEED_BATCH = Math.round(1 * WIDTH_SCALE)
 /**
  * How many species the ground picks when it establishes its natives.
  *

--- a/src/app/micro-land/domain/sim/creature-sim.ts
+++ b/src/app/micro-land/domain/sim/creature-sim.ts
@@ -29,7 +29,6 @@ import {
   boxLiquidFraction,
   boxViscosity,
   inBounds,
-  repopulate,
   seedNativePlants,
   setTile,
   settleOnGround,
@@ -280,9 +279,9 @@ export function tickCreatures(
     w.creatures = creatures.filter(c => !dead.has(c.id))
   }
 
-  // Plants first — everything else in the world is downstream of them.
+  // The only thing the world regrows on its own. Animals that die out stay
+  // dead — see `seedNativePlants`.
   seedNativePlants(w, rng)
-  repopulate(w, rng)
 
   tickParticles(w, dt, gravityScale)
 }

--- a/src/app/micro-land/domain/sim/world.ts
+++ b/src/app/micro-land/domain/sim/world.ts
@@ -1,5 +1,5 @@
 /** World construction, tile access, and spawning. */
-import { artSize, bodyBox, canEat } from '@/app/micro-land/domain/blueprint'
+import { artSize, bodyBox } from '@/app/micro-land/domain/blueprint'
 import { BUILTIN_CREATURES } from '@/app/micro-land/domain/config/creatures'
 import {
   AIR,
@@ -50,7 +50,6 @@ export function createWorld(seed = 1337): WorldState {
     seed,
     flowPhase: 0,
     natives: [],
-    nextSeedRain: 0,
     nextPlantSeed: 0,
     dormant: false,
   }
@@ -587,15 +586,21 @@ export function establishNativePlants(w: WorldState, rng: Rng): boolean {
 /**
  * The ground pushing its plant population back toward a living level.
  *
- * Runs on its own clock, separate from the animal seed rain, because the two
- * answer different questions. Seed rain asks "has a species died out and is
- * there food for it again"; this asks "is there less green here than this soil
- * can support" — and it keeps asking, which is the whole point. A meadow that
- * gets grazed to nothing is a meadow that grows back.
+ * This is the *only* thing in the game that brings a species back. Animals used
+ * to wander back in too, on a four-second clock, and it made the world feel like
+ * it was being restocked rather than lived in: a kind you had watched go extinct
+ * was back before you had finished reading the notice. Nothing does that now.
+ * Lose a creature and it is gone until you place another one.
  *
- * Deliberately blind to whether anything is alive. Plants having no upstream is
- * exactly the problem being solved; requiring a survivor would leave a stripped
- * world just as dead as before.
+ * Plants keep their seed bank because they are the one thing with no upstream —
+ * plants only come from plants, so a grazer boom that strips the last one is
+ * terminal for everything above it. The soil holding the seed is what makes a
+ * meadow renewable instead of merely long-lived.
+ *
+ * Deliberately blind to whether anything is alive, and deliberately slow. The
+ * rate is a trickle rather than a refill (see PLANT_SEED_INTERVAL): green
+ * creeping back over minutes reads as the land recovering, where a fast one read
+ * as the game undoing what just happened.
  */
 export function seedNativePlants(w: WorldState, rng: Rng): void {
   if (w.elapsed < w.nextPlantSeed) return
@@ -633,57 +638,6 @@ export function seedNativePlants(w: WorldState, rng: Rng): void {
   for (let i = 0; i < batch; i++) {
     const bp = w.blueprints[pool[i % pool.length]]
     if (bp) spawnSomewhereSensible(w, bp, rng)
-  }
-}
-
-/**
- * Let the world heal itself — the animal half.
- *
- * Populations here are small enough that an oscillation eventually touches zero,
- * and zero is absorbing: hoppers only come from hoppers. Without this, every
- * world converges on the same dead end — a field of whatever happened to be last
- * standing — and the only cure is a restart.
- *
- * Real habitats recover because the frame we're watching isn't the whole world:
- * animals wander over the hill. This is that edge, and it obeys two rules that
- * keep it honest:
- *   - Nothing returns to an empty world. Pressing Empty means empty.
- *   - A predator only returns when there is something alive for it to eat, so
- *     this can never conjure a species straight back into starving to death.
- *
- * Plants are not handled here. They have no upstream at all, so the ground
- * carries their seed instead — see `seedNativePlants`.
- */
-export function repopulate(w: WorldState, rng: Rng): void {
-  if (w.elapsed < w.nextSeedRain) return
-  w.nextSeedRain = w.elapsed + TUNING.seedRainInterval
-  if (w.dormant || w.creatures.length === 0 || w.natives.length === 0) return
-
-  const counts: Record<string, number> = {}
-  for (const c of w.creatures) {
-    counts[c.blueprintId] = (counts[c.blueprintId] ?? 0) + 1
-  }
-
-  // Any native that has died out and now has something to eat again.
-  // Plants count here too: one plant species thriving is not a reason for the
-  // others to stay extinct, and a grazer too small to eat the survivor depends
-  // on the little ones coming back.
-  const candidates = w.natives.filter(id => {
-    if (counts[id]) return false
-    const bp = w.blueprints[id]
-    if (!bp) return false
-    if (bp.move.kind === 'root' || bp.diet.eats.length === 0) return true
-    return w.creatures.some(c => {
-      const other = w.blueprints[c.blueprintId]
-      return other ? canEat(bp, other) : false
-    })
-  })
-  if (candidates.length === 0) return
-
-  const bp = w.blueprints[candidates[Math.floor(rng() * candidates.length)]]
-  if (bp) {
-    spawnSomewhereSensible(w, bp, rng)
-    spawnSomewhereSensible(w, bp, rng)
   }
 }
 

--- a/src/app/micro-land/domain/tuning.ts
+++ b/src/app/micro-land/domain/tuning.ts
@@ -35,7 +35,6 @@ import {
   PLANT_SEED_INTERVAL,
   PLANT_SPECIES_CAP,
   PLANT_SPREAD_COOLDOWN,
-  SEED_RAIN_INTERVAL,
   SPECIES_SOFT_CAP,
 } from '@/app/micro-land/domain/constants'
 
@@ -62,7 +61,6 @@ export const TUNING_DEFAULTS = {
   breedCooldown: BREED_COOLDOWN,
   mealValue: MEAL_VALUE,
   breedCost: BREED_COST,
-  seedRainInterval: SEED_RAIN_INTERVAL,
 
   gravity: GRAVITY,
 }
@@ -234,17 +232,6 @@ export const KNOBS: Knob[] = [
     step: 0.01,
   },
   {
-    key: 'seedRainInterval',
-    group: 'creatures',
-    label: 'Wait between comebacks',
-    help: 'How often a kind that has died out is allowed to wander back in — and only ever when there is something alive for it to eat.',
-    min: 1,
-    max: 120,
-    step: 1,
-    unit: 's',
-  },
-
-  {
     key: 'gravity',
     group: 'world',
     label: 'Pull downwards',
@@ -321,7 +308,7 @@ const STORAGE_KEY = 'micro-land:tuning:v1'
  * Only the differences are stored, never the whole set.
  *
  * A player who never touched a knob keeps getting whatever the game ships with,
- * including next month's rebalance. Writing all fifteen values would freeze the
+ * including next month's rebalance. Writing the whole set would freeze the
  * defaults of the day they first opened the panel into their browser forever.
  */
 export function saveTuning(): void {

--- a/src/app/micro-land/domain/types.ts
+++ b/src/app/micro-land/domain/types.ts
@@ -363,12 +363,10 @@ export interface WorldState {
   flowPhase: number
   /**
    * Species that belong to this world — theme starters plus anything the player
-   * summoned. Repopulation only ever draws from this list, so a desert never
-   * spontaneously sprouts kelp.
+   * summoned. The ground's seed bank only ever draws from this list, so a desert
+   * never spontaneously sprouts kelp.
    */
   natives: string[]
-  /** Next world-clock time at which repopulation may fire. */
-  nextSeedRain: number
   /** Next world-clock time at which the ground may seed native plants. */
   nextPlantSeed: number
   /**

--- a/src/app/micro-land/game-instance.ts
+++ b/src/app/micro-land/game-instance.ts
@@ -749,12 +749,11 @@ export class GameInstance {
     /**
      * `natives` must lose it too.
      *
-     * `registerBlueprint` pushes every species onto that list, and both safety
-     * nets read `w.blueprints[id]` straight off it — `nativePlants` to decide
-     * what the soil can re-seed, `repopulate` to pick who comes back. Leaving a
-     * dangling id there hands `undefined` to `isPlant` and breaks the two
-     * mechanisms that stop the world flatlining, which would look nothing like
-     * a deletion bug when it eventually surfaced.
+     * `registerBlueprint` pushes every species onto that list, and the soil's
+     * seed bank reads `w.blueprints[id]` straight off it to decide what it can
+     * re-seed. Leaving a dangling id there hands `undefined` to `isPlant` and
+     * breaks the one mechanism that stops the world flatlining, which would look
+     * nothing like a deletion bug when it eventually surfaced.
      */
     w.natives = w.natives.filter(id => id !== blueprintId)
 

--- a/src/app/micro-land/worlds/snapshot.ts
+++ b/src/app/micro-land/worlds/snapshot.ts
@@ -128,7 +128,6 @@ export function snapshotWorld(w: WorldState): WorldSnapshot {
     flowPhase: w.flowPhase,
     dormant: w.dormant,
     nextCreatureId: w.nextCreatureId,
-    nextSeedRain: round(w.nextSeedRain),
     nextPlantSeed: round(w.nextPlantSeed),
     natives: [...w.natives],
     tiles: encodeTiles(w.tiles),
@@ -220,16 +219,15 @@ export function restoreSnapshot(w: WorldState, snap: WorldSnapshot): boolean {
   w.creatures = snap.creatures.filter(c => w.blueprints[c.blueprintId]).map(thaw)
   w.particles.length = 0
 
-  // A dangling id here would hand `undefined` to `isPlant` and break both
-  // safety nets — the soil's seed bank and animal seed rain — which is how a
-  // restored world would quietly stop being able to recover from a crash.
+  // A dangling id here would hand `undefined` to `isPlant` and break the soil's
+  // seed bank, which is how a restored world would quietly stop being able to
+  // grow its plants back.
   w.natives = snap.natives.filter(id => w.blueprints[id])
 
   w.seed = snap.seed
   w.elapsed = snap.elapsed
   w.flowPhase = snap.flowPhase
   w.dormant = snap.dormant
-  w.nextSeedRain = snap.nextSeedRain
   w.nextPlantSeed = snap.nextPlantSeed
   // Never below anything already alive: ids are handed out by increment, and a
   // counter that starts underneath the population would issue duplicates, which

--- a/src/app/micro-land/worlds/types.ts
+++ b/src/app/micro-land/worlds/types.ts
@@ -90,7 +90,6 @@ export interface WorldSnapshot {
   flowPhase: number
   dormant: boolean
   nextCreatureId: number
-  nextSeedRain: number
   nextPlantSeed: number
   natives: string[]
   /** Run-length encoded: material, length, material, length, … See `snapshot.ts`. */

--- a/src/app/micro-land/worlds/wire.ts
+++ b/src/app/micro-land/worlds/wire.ts
@@ -206,7 +206,9 @@ function validSnapshot(value: unknown): WorldSnapshot | null {
     flowPhase: num(value.flowPhase, 0),
     dormant: value.dormant === true,
     nextCreatureId: Math.max(1, Math.floor(num(value.nextCreatureId, 1))),
-    nextSeedRain: clamp(value.nextSeedRain, 0, 1e9, 0),
+    // `nextSeedRain` used to live here, back when animals wandered back into a
+    // world they had died out of. Worlds saved before that was removed still
+    // carry the field; dropping it on the way in is all the migration needed.
     nextPlantSeed: clamp(value.nextPlantSeed, 0, 1e9, 0),
     natives,
     tiles,


### PR DESCRIPTION
Wildlife regeneration was doing too much of the world's work. This narrows it to native plants only, and slows that down a lot.

## What changed

**Animals no longer come back.** `repopulate` — the seed rain that respawned any extinct native every 4 seconds as long as something was alive for it to eat — is removed, along with its "Wait between comebacks" knob, `SEED_RAIN_INTERVAL`, and the `nextSeedRain` world field. Saved worlds carrying that field drop it on load; no migration needed. An animal that dies out stays out until the player places one.

**Native plants regenerate ~30× slower.** `PLANT_SEED_INTERVAL` 3s → 30s, `PLANT_SEED_BATCH` 9 → 3 (one per screen of land, scaled). The soil is a floor under a crash now, not a groundskeeper — it gets a stripped world off zero and lets plants spread on their own from there.

## Two findings from the harness

**1. The plant seed bank was never the visible thing.** Running with the old plant numbers and the new ones produces *byte-identical* output at every timestep. In a healthy world the seed bank never fires, because plants sit pinned at their species caps from their own spreading. So the plant half of this change only shows up after a crash. If the fast green fill-in is what needs slowing, the levers are `plantMaturity`, `plantSpreadCooldown` and `plantSpeciesCap` — that's a separate pass.

**2. Removing the seed rain kills every animal, on every theme.** This is the honest result of the change, not a defect in it:

| theme | animals gone by | world at 10 min |
|---|---|---|
| earth | ~5 min | 655 plants, 0 animals, static |
| tidepool | ~5 min (snails survive 1 of 3 runs) | plants, sometimes snails |
| volcanic | ~5 min | 276 plants, 0 animals |
| station | ~3 min | 208 plants, 0 animals |

The 4-second seed rain had been continuously restocking animals, which hid the fact that **no animal population is self-sustaining at the current tuning**. Grazers starve while the meadow is at full species cap, so this is reach and distribution, not a shortage of food. Fixing it is a balance pass and a separate PR. `SKILL.md`'s verification checklist now records this as known-failing rather than leaving the next reader to find it as a mystery regression.

## Verification

- `npm run typecheck` — no micro-land errors
- `npx vitest run src/app/micro-land` — 113/113 pass
- `npm run lint` — nothing in the touched files
- `npm run sim:micro-land` at 600s × 3 runs on all four themes — `✓ Still alive` everywhere, with the animal extinctions above
- Repo-wide test/lint failures in `comet-cards`, `trivia` and `theme.ts` are pre-existing and untouched by this branch
- Not yet exercised in the browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)