### PR TITLE
feat(micro-land): filter the roster by what a creature is

### DIFF
--- a/src/app/micro-land/components/creature-filter.tsx
+++ b/src/app/micro-land/components/creature-filter.tsx
@@ -1,0 +1,234 @@
+'use client'
+
+import { useId, useState } from 'react'
+
+import { MOVE_WORDS } from '@/app/micro-land/domain/blueprint'
+import {
+  type CreatureFilter,
+  EMPTY_FILTER,
+  type FilterOptions,
+  SIZE_BANDS,
+  type SizeBandId,
+  activeConditionCount,
+  describeFilter,
+  isFilterActive,
+} from '@/app/micro-land/domain/creature-filter'
+import type { LocomotionKind } from '@/app/micro-land/domain/types'
+
+const label: React.CSSProperties = {
+  fontFamily: 'var(--cc-font-mono)',
+  fontSize: 9,
+  letterSpacing: 1.6,
+  textTransform: 'uppercase',
+  opacity: 0.5,
+  paddingLeft: 2,
+}
+
+/** Chips match the group tabs directly below them — same pill, same selected look. */
+function chipStyle(selected: boolean): React.CSSProperties {
+  return {
+    fontFamily: 'var(--cc-font-mono)',
+    fontSize: 9,
+    letterSpacing: 1.2,
+    textTransform: 'uppercase',
+    fontWeight: selected ? 700 : 400,
+    padding: '5px 9px',
+    minHeight: 28,
+    borderRadius: 999,
+    borderWidth: 1,
+    borderStyle: 'solid',
+    borderColor: selected ? 'var(--cc-mint)' : 'var(--cc-mint-line)',
+    background: selected ? 'var(--cc-mint-soft)' : 'transparent',
+    color: selected ? 'var(--cc-mint)' : 'var(--cc-text-muted)',
+    whiteSpace: 'nowrap',
+  }
+}
+
+function toggle<T>(list: T[], value: T): T[] {
+  return list.includes(value) ? list.filter(v => v !== value) : [...list, value]
+}
+
+/**
+ * The roster filter, sitting between the creature actions and the group tabs.
+ *
+ * Collapsed by default, and that is the whole design argument: this row is above
+ * the one control the player touches most, and eleven chips permanently parked
+ * there would push the creatures themselves off a phone screen. Collapsed it
+ * costs a single button.
+ *
+ * The catch with collapsing anything is a filter that is quietly on while the
+ * panel below it looks broken, so an active filter never hides: the button goes
+ * mint and carries a count, the conditions are spelled out beside it, and Clear
+ * is one tap away without expanding anything.
+ */
+export function CreatureFilterBar({
+  filter,
+  setFilter,
+  options,
+}: {
+  filter: CreatureFilter
+  setFilter: (filter: CreatureFilter) => void
+  options: FilterOptions
+}) {
+  const [open, setOpen] = useState(false)
+  const panelId = useId()
+
+  const active = isFilterActive(filter)
+  const count = activeConditionCount(filter)
+
+  // A world can be narrow enough that there is nothing to ask about — one
+  // species of plant on an empty map has no second way of moving and no size to
+  // contrast with. Offering a filter there is a control that cannot do anything.
+  const anythingToAsk =
+    options.moves.length > 1 || options.sizes.length > 1 || options.glows || options.lavaProof
+  if (!anythingToAsk && !active) return null
+
+  const setMoves = (kind: LocomotionKind) =>
+    setFilter({ ...filter, moves: toggle(filter.moves, kind) })
+  const setSizes = (band: SizeBandId) => setFilter({ ...filter, sizes: toggle(filter.sizes, band) })
+
+  return (
+    <div className="-mx-1 flex flex-col gap-1.5 px-1">
+      <div className="flex flex-wrap items-center gap-1.5">
+        <button
+          type="button"
+          className="cc-btn shrink-0"
+          onClick={() => setOpen(v => !v)}
+          aria-expanded={open}
+          // Only while the panel exists — `aria-controls` pointing at an id
+          // that isn't in the document is a dead reference for a screen reader.
+          aria-controls={open ? panelId : undefined}
+          title="Narrow the creatures down by how they move, how big they are, and what they can take"
+          style={chipStyle(active)}
+        >
+          <span aria-hidden style={{ marginRight: 5, opacity: 0.7 }}>
+            {open ? '▾' : '▸'}
+          </span>
+          Filter
+          {active && <span style={{ opacity: 0.65, marginLeft: 5 }}>{count}</span>}
+        </button>
+
+        {active && (
+          <>
+            {/* Spelled out rather than left to the badge: the count says how
+                many conditions are on, never which, and "why is Hunters empty"
+                is a question only the words can answer. */}
+            <span
+              style={{
+                fontFamily: 'var(--cc-font-mono)',
+                fontSize: 9,
+                letterSpacing: 1,
+                color: 'var(--cc-mint)',
+                opacity: 0.8,
+                minWidth: 0,
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+                whiteSpace: 'nowrap',
+              }}
+            >
+              {describeFilter(filter)}
+            </span>
+            <button
+              type="button"
+              className="cc-btn ml-auto shrink-0"
+              onClick={() => setFilter(EMPTY_FILTER)}
+              style={chipStyle(false)}
+            >
+              Clear
+            </button>
+          </>
+        )}
+      </div>
+
+      {open && (
+        <div id={panelId} className="flex flex-col gap-1.5 pb-0.5">
+          {options.moves.length > 1 && (
+            <div
+              className="flex flex-wrap items-center gap-1"
+              role="group"
+              aria-label="How it moves"
+            >
+              <span style={{ ...label, width: 44 }}>Moves</span>
+              {options.moves.map(kind => (
+                <button
+                  key={kind}
+                  type="button"
+                  className="cc-btn shrink-0"
+                  onClick={() => setMoves(kind)}
+                  aria-pressed={filter.moves.includes(kind)}
+                  style={chipStyle(filter.moves.includes(kind))}
+                >
+                  {MOVE_WORDS[kind]}
+                </button>
+              ))}
+            </div>
+          )}
+
+          {options.sizes.length > 1 && (
+            <div
+              className="flex flex-wrap items-center gap-1"
+              role="group"
+              aria-label="How big it is"
+            >
+              <span style={{ ...label, width: 44 }}>Size</span>
+              {SIZE_BANDS.filter(b => options.sizes.includes(b.id)).map(band => (
+                <button
+                  key={band.id}
+                  type="button"
+                  className="cc-btn shrink-0"
+                  onClick={() => setSizes(band.id)}
+                  aria-pressed={filter.sizes.includes(band.id)}
+                  title={`Size ${band.min}–${band.max}`}
+                  style={chipStyle(filter.sizes.includes(band.id))}
+                >
+                  {band.label}
+                </button>
+              ))}
+            </div>
+          )}
+
+          {(options.glows || options.lavaProof) && (
+            <div
+              className="flex flex-wrap items-center gap-1"
+              role="group"
+              aria-label="What it can take"
+            >
+              <span style={{ ...label, width: 44 }}>Also</span>
+              {options.glows && (
+                <button
+                  type="button"
+                  className="cc-btn shrink-0"
+                  onClick={() => setFilter({ ...filter, glows: !filter.glows })}
+                  aria-pressed={filter.glows}
+                  style={chipStyle(filter.glows)}
+                >
+                  {/* Marks that carry meaning are paired with the word, never
+                      standing in for it — the symbol alone reaches neither a
+                      screen reader nor a five-year-old. */}
+                  <span aria-hidden style={{ marginRight: 5 }}>
+                    ✦
+                  </span>
+                  Glows in the dark
+                </button>
+              )}
+              {options.lavaProof && (
+                <button
+                  type="button"
+                  className="cc-btn shrink-0"
+                  onClick={() => setFilter({ ...filter, lavaProof: !filter.lavaProof })}
+                  aria-pressed={filter.lavaProof}
+                  style={chipStyle(filter.lavaProof)}
+                >
+                  <span aria-hidden style={{ marginRight: 5 }}>
+                    ◈
+                  </span>
+                  Lava-proof
+                </button>
+              )}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/app/micro-land/components/field-guide.tsx
+++ b/src/app/micro-land/components/field-guide.tsx
@@ -1,22 +1,13 @@
 'use client'
 
 import type { SpeciesRecord } from '@/app/micro-land/chronicle/types'
-import { canEat } from '@/app/micro-land/domain/blueprint'
+import { MOVE_WORDS, canEat } from '@/app/micro-land/domain/blueprint'
 import type { CreatureBlueprint } from '@/app/micro-land/domain/types'
 import { formatDuration } from '@/app/micro-land/format'
 import { useMicroLand } from '@/app/micro-land/store'
 
 import { CreaturePortrait } from './creature-chip'
 import { SparkleIcon } from './sparkle-icon'
-
-const KIND_WORDS: Record<string, string> = {
-  walk: 'walks',
-  fly: 'flies',
-  swim: 'swims',
-  crawl: 'climbs',
-  drift: 'floats',
-  root: 'stays put',
-}
 
 const sectionHeading: React.CSSProperties = {
   fontFamily: 'var(--cc-font-mono)',
@@ -303,7 +294,7 @@ function GuideEntry({
             lineHeight: 1.6,
           }}
         >
-          Size {bp.size} · {KIND_WORDS[bp.move.kind] ?? bp.move.kind}
+          Size {bp.size} · {MOVE_WORDS[bp.move.kind] ?? bp.move.kind}
           {bp.body.immuneTo.length > 0 && ` · unburnable`}
           {bp.glow > 0 && ` · glows`}
           {bp.dig.through.length > 0 && ` · digs through ${bp.dig.through.join(', ')}`}

--- a/src/app/micro-land/components/toolbar.tsx
+++ b/src/app/micro-land/components/toolbar.tsx
@@ -8,6 +8,14 @@ import {
   creatureGroup,
 } from '@/app/micro-land/domain/blueprint'
 import { MATERIALS, PAINTABLE, TINTS, tintedId } from '@/app/micro-land/domain/config/materials'
+import {
+  type CreatureFilter,
+  EMPTY_FILTER,
+  describeFilter,
+  filterOptions,
+  isFilterActive,
+  matchesFilter,
+} from '@/app/micro-land/domain/creature-filter'
 import type {
   CreatureBlueprint,
   MaterialId,
@@ -16,6 +24,7 @@ import type {
 import { type Tool, useMicroLand } from '@/app/micro-land/store'
 
 import { CreaturePortrait } from './creature-chip'
+import { CreatureFilterBar } from './creature-filter'
 import { SparkleIcon } from './sparkle-icon'
 import { SummonSand } from './summon-sand'
 
@@ -93,6 +102,29 @@ export function Toolbar({ onRemoveSpecies }: { onRemoveSpecies: (blueprintId: st
     return out
   }, [blueprints])
 
+  /**
+   * The roster filter, applied across every tab at once.
+   *
+   * Deliberately *not* folded into `grouped`: which tabs exist, and where a
+   * creature files, are questions about the world and must keep the same answer
+   * whatever the filter is asking. A tab strip that reshuffled itself on every
+   * chip tap would move the thing under your thumb between deciding to tap it
+   * and tapping it — so the tabs hold still and only their counts move.
+   */
+  const [filter, setFilter] = useState<CreatureFilter>(EMPTY_FILTER)
+  const filtering = isFilterActive(filter)
+  const options = useMemo(() => filterOptions(blueprints), [blueprints])
+  const filtered = useMemo(() => {
+    if (!filtering) return grouped
+    const out = new Map<CreatureGroup, typeof blueprints>()
+    for (const [key, list] of grouped)
+      out.set(
+        key,
+        list.filter(bp => matchesFilter(bp, filter))
+      )
+    return out
+  }, [grouped, filter, filtering])
+
   // A summon still in flight is enough to stand "Yours" up on its own. The
   // waiting slot lives in that tab and nowhere else, so filtering the tab out
   // while it was empty hid the loading state on the one summon that most needs
@@ -132,7 +164,7 @@ export function Toolbar({ onRemoveSpecies }: { onRemoveSpecies: (blueprintId: st
 
   // Whatever tab is showing has to exist — "Yours" disappears on a fresh world.
   const active = tabs.some(t => t.id === group) ? group : (tabs[0]?.id ?? 'plants')
-  const shown = grouped.get(active) ?? []
+  const shown = filtered.get(active) ?? []
 
   /**
    * Tidying is only ever a thing in "Yours".
@@ -500,6 +532,8 @@ export function Toolbar({ onRemoveSpecies }: { onRemoveSpecies: (blueprintId: st
             </span>
           </div>
 
+          <CreatureFilterBar filter={filter} setFilter={setFilter} options={options} />
+
           {/* The tidy toggle sits beside the tabs but outside the tablist — it is
           not a tab, and a stray child in there confuses assistive tech. */}
           <div className="-mx-1 flex items-center gap-1 px-1">
@@ -507,9 +541,16 @@ export function Toolbar({ onRemoveSpecies }: { onRemoveSpecies: (blueprintId: st
               {tabs.map(tab => {
                 const selected = tab.id === active
                 // Ones on their way count too, so the number moves the instant you ask
-                // rather than staying at zero for the length of a generation.
+                // rather than staying at zero for the length of a generation. They are
+                // counted against the filter as well: a summon has no blueprint yet, so
+                // there is nothing to match it on, and dropping it from the count would
+                // read as "nothing here" while something is visibly being made.
                 const count =
-                  (grouped.get(tab.id)?.length ?? 0) + (tab.id === 'yours' ? pending.length : 0)
+                  (filtered.get(tab.id)?.length ?? 0) + (tab.id === 'yours' ? pending.length : 0)
+                // A tab the filter has emptied is dimmed rather than removed — it is
+                // still worth knowing the category exists and that your filter is what
+                // emptied it, and it stays tappable so the empty state can explain.
+                const emptied = filtering && count === 0
                 return (
                   <button
                     key={tab.id}
@@ -543,6 +584,7 @@ export function Toolbar({ onRemoveSpecies }: { onRemoveSpecies: (blueprintId: st
                         : tab.id === 'yours'
                           ? 'var(--cc-pink)'
                           : 'var(--cc-text-muted)',
+                      opacity: emptied && !selected ? 0.4 : 1,
                       whiteSpace: 'nowrap',
                     }}
                   >
@@ -618,6 +660,42 @@ export function Toolbar({ onRemoveSpecies }: { onRemoveSpecies: (blueprintId: st
                   <span style={{ ...swatchLabel, color: 'var(--cc-pink)' }}>Making…</span>
                 </div>
               ))}
+            {/* An emptied drawer says who emptied it and hands back the way out. A
+            blank panel would read as a broken game, and the filter that did it
+            may be three taps up the screen and collapsed. */}
+            {filtering && shown.length === 0 && !(active === 'yours' && pending.length > 0) && (
+              <div className="flex flex-col gap-1.5 py-1.5" style={{ minWidth: 0 }}>
+                <span
+                  style={{
+                    fontFamily: 'var(--cc-font-mono)',
+                    fontSize: 9,
+                    letterSpacing: 1,
+                    color: 'var(--cc-text-muted)',
+                  }}
+                >
+                  Nothing in here matches — {describeFilter(filter)}.
+                </span>
+                <button
+                  type="button"
+                  className="cc-btn self-start"
+                  onClick={() => setFilter(EMPTY_FILTER)}
+                  style={{
+                    fontFamily: 'var(--cc-font-mono)',
+                    fontSize: 9,
+                    letterSpacing: 1.2,
+                    textTransform: 'uppercase',
+                    padding: '5px 9px',
+                    minHeight: 28,
+                    borderRadius: 999,
+                    border: '1px solid var(--cc-mint-line)',
+                    background: 'transparent',
+                    color: 'var(--cc-text-muted)',
+                  }}
+                >
+                  Show everything
+                </button>
+              </div>
+            )}
             {shown.map(bp => {
               const selected = tool.kind === 'creature' && tool.blueprintId === bp.id
               // Built-ins can't be removed even while tidying — they come from

--- a/src/app/micro-land/domain/__tests__/creature-filter.test.ts
+++ b/src/app/micro-land/domain/__tests__/creature-filter.test.ts
@@ -1,0 +1,171 @@
+import { describe, expect, it } from 'vitest'
+
+import { MOVE_WORDS } from '@/app/micro-land/domain/blueprint'
+import { BUILTIN_CREATURES } from '@/app/micro-land/domain/config/creatures'
+import {
+  type CreatureFilter,
+  EMPTY_FILTER,
+  MOVE_ORDER,
+  SIZE_BANDS,
+  activeConditionCount,
+  describeFilter,
+  filterOptions,
+  isFilterActive,
+  isGlowing,
+  isLavaProof,
+  matchesFilter,
+  sizeBand,
+} from '@/app/micro-land/domain/creature-filter'
+import type { CreatureBlueprint, LocomotionKind } from '@/app/micro-land/domain/types'
+
+/**
+ * A blueprint stub carrying only the fields the filter reads.
+ *
+ * Deliberately not run through `sanitizeBlueprint`: these tests are about the
+ * predicate, and building thirty full literals with valid pixel art to assert a
+ * size comparison would bury the thing being tested. The real roster is asserted
+ * against separately, below.
+ */
+function bp(over: {
+  id: string
+  size?: number
+  kind?: LocomotionKind
+  glow?: number
+  immuneTo?: string[]
+}): CreatureBlueprint {
+  return {
+    id: over.id,
+    name: over.id,
+    blurb: '',
+    size: over.size ?? 2,
+    tags: [],
+    art: { palette: {}, frames: [['.']], frameMs: 200, faceMotion: false },
+    body: {
+      mass: 1,
+      bounce: 0,
+      drag: 0.3,
+      buoyancy: 0.8,
+      immuneTo: (over.immuneTo ?? []) as CreatureBlueprint['body']['immuneTo'],
+    },
+    move: { kind: over.kind ?? 'walk', speed: 3, jump: 0, restlessness: 0.2 },
+    diet: {
+      eats: [],
+      fears: [],
+      hungerRate: 0,
+      starveSeconds: 60,
+      breedAt: 0.7,
+      lifespanSeconds: 100,
+    },
+    senses: { sight: 8 },
+    habitat: { needs: null, drowns: true },
+    dig: { through: [], speed: 1 },
+    death: { becomes: null, particleColor: '#ffffff', particleCount: 0 },
+    aura: null,
+    glow: over.glow ?? 0,
+  }
+}
+
+const filter = (over: Partial<CreatureFilter>): CreatureFilter => ({ ...EMPTY_FILTER, ...over })
+
+describe('predicates', () => {
+  it('counts any light at all as glowing', () => {
+    expect(isGlowing(bp({ id: 'a', glow: 0.05 }))).toBe(true)
+    expect(isGlowing(bp({ id: 'b', glow: 0 }))).toBe(false)
+  })
+
+  it('asks for lava by name rather than trusting a non-empty immunity list', () => {
+    expect(isLavaProof(bp({ id: 'a', immuneTo: ['lava'] }))).toBe(true)
+    expect(isLavaProof(bp({ id: 'b', immuneTo: ['lava', 'stone'] }))).toBe(true)
+    // Immune to something, but not to the thing the chip promises.
+    expect(isLavaProof(bp({ id: 'c', immuneTo: ['acid'] }))).toBe(false)
+    expect(isLavaProof(bp({ id: 'd' }))).toBe(false)
+  })
+
+  it('bands cover every size the schema allows, with no gaps or overlaps', () => {
+    for (let size = 1; size <= 6; size++) {
+      const bands = SIZE_BANDS.filter(b => size >= b.min && size <= b.max)
+      expect(bands).toHaveLength(1)
+    }
+    expect(sizeBand(bp({ id: 'a', size: 1 }))).toBe('tiny')
+    expect(sizeBand(bp({ id: 'b', size: 4 }))).toBe('medium')
+    expect(sizeBand(bp({ id: 'c', size: 6 }))).toBe('huge')
+  })
+})
+
+describe('matchesFilter', () => {
+  it('keeps everything while empty', () => {
+    expect(isFilterActive(EMPTY_FILTER)).toBe(false)
+    for (const creature of BUILTIN_CREATURES)
+      expect(matchesFilter(creature, EMPTY_FILTER)).toBe(true)
+  })
+
+  it('ORs within an axis', () => {
+    const f = filter({ moves: ['fly', 'swim'] })
+    expect(matchesFilter(bp({ id: 'a', kind: 'fly' }), f)).toBe(true)
+    expect(matchesFilter(bp({ id: 'b', kind: 'swim' }), f)).toBe(true)
+    expect(matchesFilter(bp({ id: 'c', kind: 'walk' }), f)).toBe(false)
+  })
+
+  it('ANDs across axes', () => {
+    const f = filter({ moves: ['fly'], sizes: ['huge'], glows: true, lavaProof: true })
+    const match = bp({ id: 'match', kind: 'fly', size: 6, glow: 0.5, immuneTo: ['lava'] })
+    expect(matchesFilter(match, f)).toBe(true)
+    // Failing any single axis is enough to drop it.
+    expect(matchesFilter({ ...match, move: { ...match.move, kind: 'walk' } }, f)).toBe(false)
+    expect(matchesFilter({ ...match, size: 2 }, f)).toBe(false)
+    expect(matchesFilter({ ...match, glow: 0 }, f)).toBe(false)
+    expect(matchesFilter({ ...match, body: { ...match.body, immuneTo: [] } }, f)).toBe(false)
+  })
+
+  it('counts conditions rather than axes', () => {
+    expect(activeConditionCount(EMPTY_FILTER)).toBe(0)
+    expect(activeConditionCount(filter({ moves: ['fly', 'swim'], glows: true }))).toBe(3)
+  })
+})
+
+describe('filterOptions', () => {
+  it('only offers what the roster can actually answer', () => {
+    const options = filterOptions([
+      bp({ id: 'a', kind: 'walk', size: 1 }),
+      bp({ id: 'b', kind: 'walk', size: 2 }),
+    ])
+    expect(options.moves).toEqual(['walk'])
+    expect(options.sizes).toEqual(['tiny'])
+    expect(options.glows).toBe(false)
+    expect(options.lavaProof).toBe(false)
+  })
+
+  it('offers every axis the built-in roster spans', () => {
+    const options = filterOptions([...BUILTIN_CREATURES])
+    // The roster is meant to cover all six ways of moving; if a rewrite drops
+    // one, the chip quietly disappears and this is the only thing that notices.
+    expect(options.moves).toEqual(MOVE_ORDER)
+    expect(options.sizes).toEqual(['tiny', 'medium', 'huge'])
+    expect(options.glows).toBe(true)
+    expect(options.lavaProof).toBe(true)
+  })
+
+  it('keeps chips in a stable order regardless of roster order', () => {
+    const forwards = filterOptions([bp({ id: 'a', kind: 'root' }), bp({ id: 'b', kind: 'walk' })])
+    const backwards = filterOptions([bp({ id: 'b', kind: 'walk' }), bp({ id: 'a', kind: 'root' })])
+    expect(forwards.moves).toEqual(backwards.moves)
+    expect(forwards.moves).toEqual(['walk', 'root'])
+  })
+
+  it('every option a chip can show has a word to show', () => {
+    for (const kind of MOVE_ORDER) expect(MOVE_WORDS[kind]).toBeTruthy()
+  })
+})
+
+describe('describeFilter', () => {
+  it('says what was asked for, in the words the chips used', () => {
+    expect(describeFilter(filter({ moves: ['fly'] }))).toBe('flies')
+    expect(describeFilter(filter({ moves: ['fly', 'swim'] }))).toBe('flies or swims')
+    expect(describeFilter(filter({ sizes: ['huge'], lavaProof: true }))).toBe('huge · lava-proof')
+    expect(describeFilter(EMPTY_FILTER)).toBe('')
+  })
+
+  it('lists size bands in band order, not tap order', () => {
+    expect(describeFilter(filter({ sizes: ['huge', 'tiny'] }))).toBe('tiny or huge')
+  })
+})

--- a/src/app/micro-land/domain/blueprint.ts
+++ b/src/app/micro-land/domain/blueprint.ts
@@ -16,7 +16,7 @@ import { z } from 'zod'
 import { BASE_MATERIAL_IDS, IS_LIQUID, MATERIAL_IDS, MATERIAL_INDEX } from './config/materials'
 import { TerrainSchema } from './terrain'
 
-import type { CreatureAura, CreatureBlueprint, MaterialId } from './types'
+import type { CreatureAura, CreatureBlueprint, LocomotionKind, MaterialId } from './types'
 
 export const ART_MIN = 3
 /**
@@ -599,6 +599,24 @@ export function canEat(hunter: CreatureBlueprint, prey: CreatureBlueprint): bool
 // ---------------------------------------------------------------------------
 // Grouping
 // ---------------------------------------------------------------------------
+
+/**
+ * How each way of moving is said out loud.
+ *
+ * Verbs rather than the schema's nouns — a kid reading the field guide meets
+ * "climbs", not "crawl". Lives here beside `CREATURE_GROUPS` because this file
+ * already owns the player-facing vocabulary for the roster, and because the
+ * field guide and the creature filter must never drift into calling the same
+ * locomotion two different things.
+ */
+export const MOVE_WORDS: Record<LocomotionKind, string> = {
+  walk: 'walks',
+  fly: 'flies',
+  swim: 'swims',
+  crawl: 'climbs',
+  drift: 'floats',
+  root: 'stays put',
+}
 
 export type CreatureGroup = 'yours' | 'plants' | 'grazers' | 'hunters' | 'giants' | 'helpers'
 

--- a/src/app/micro-land/domain/creature-filter.ts
+++ b/src/app/micro-land/domain/creature-filter.ts
@@ -1,0 +1,163 @@
+/**
+ * Filtering the creature roster by what a creature *is*.
+ *
+ * The roster outgrew the six group tabs a while ago — thirty-odd built-ins plus
+ * however many the player has summoned — and the tabs answer "what does it do
+ * for a living", which is the wrong question when you are looking for something
+ * that flies, or something lava can't touch. This adds the other axes.
+ *
+ * Every predicate reads the blueprint, so a creature invented thirty seconds ago
+ * files itself correctly with no list in the UI to keep up to date. That is the
+ * same reason `creatureGroup` derives its answer rather than looking it up.
+ */
+import { MOVE_WORDS } from './blueprint'
+
+import type { CreatureBlueprint, LocomotionKind } from './types'
+
+/**
+ * Size, in the three bands a person actually thinks in.
+ *
+ * The schema's 1..6 is a food-chain number, not a word — "is it bigger than me"
+ * is all the simulation ever asks of it. Six chips of bare digits would make the
+ * player do that translation themselves, so the bands carry the meaning instead.
+ * The split is where the roster naturally clusters: 1-2 is everything bug-sized,
+ * 5-6 is the handful of things that read as landmarks.
+ */
+export type SizeBandId = 'tiny' | 'medium' | 'huge'
+
+export const SIZE_BANDS: { id: SizeBandId; label: string; min: number; max: number }[] = [
+  { id: 'tiny', label: 'Tiny', min: 1, max: 2 },
+  { id: 'medium', label: 'Medium', min: 3, max: 4 },
+  { id: 'huge', label: 'Huge', min: 5, max: 6 },
+]
+
+/** Locomotion chips, in the order they appear. Ground first, then off it. */
+export const MOVE_ORDER: LocomotionKind[] = ['walk', 'crawl', 'fly', 'drift', 'swim', 'root']
+
+/**
+ * A filter is empty until the player narrows it.
+ *
+ * Each axis is ANDed with the others; within an axis the choices are ORed, so
+ * "flies or swims, and huge" is expressible and "flies and swims" — which no
+ * creature can ever satisfy, since `move.kind` is a single value — is not.
+ * An empty list on an axis means that axis isn't asking anything.
+ */
+export interface CreatureFilter {
+  moves: LocomotionKind[]
+  sizes: SizeBandId[]
+  /** Keep only creatures that cast their own light. */
+  glows: boolean
+  /** Keep only creatures lava can't hurt. */
+  lavaProof: boolean
+}
+
+export const EMPTY_FILTER: CreatureFilter = {
+  moves: [],
+  sizes: [],
+  glows: false,
+  lavaProof: false,
+}
+
+/** True if a creature casts light of its own. */
+export function isGlowing(bp: CreatureBlueprint): boolean {
+  return bp.glow > 0
+}
+
+/**
+ * True if lava can't hurt this creature.
+ *
+ * Asks for lava by name rather than trusting a non-empty `immuneTo` the way the
+ * inspector's "fireproof" line does. Immunity is a list of materials and the
+ * roster already has a creature immune to four of them; a filter that answered
+ * "lava-proof: yes" for something merely immune to acid would be a lie the
+ * player only finds out about by dropping it in a lava fall.
+ */
+export function isLavaProof(bp: CreatureBlueprint): boolean {
+  return bp.body.immuneTo.includes('lava')
+}
+
+/** Which size band a creature falls in, or null if it somehow lands outside them. */
+export function sizeBand(bp: CreatureBlueprint): SizeBandId | null {
+  return SIZE_BANDS.find(b => bp.size >= b.min && bp.size <= b.max)?.id ?? null
+}
+
+/** True if any axis is asking something. */
+export function isFilterActive(filter: CreatureFilter): boolean {
+  return filter.moves.length > 0 || filter.sizes.length > 0 || filter.glows || filter.lavaProof
+}
+
+/** How many conditions are on — the number badged on the collapsed control. */
+export function activeConditionCount(filter: CreatureFilter): number {
+  return (
+    filter.moves.length + filter.sizes.length + (filter.glows ? 1 : 0) + (filter.lavaProof ? 1 : 0)
+  )
+}
+
+export function matchesFilter(bp: CreatureBlueprint, filter: CreatureFilter): boolean {
+  if (filter.moves.length > 0 && !filter.moves.includes(bp.move.kind)) return false
+  if (filter.sizes.length > 0) {
+    const band = sizeBand(bp)
+    if (!band || !filter.sizes.includes(band)) return false
+  }
+  if (filter.glows && !isGlowing(bp)) return false
+  if (filter.lavaProof && !isLavaProof(bp)) return false
+  return true
+}
+
+/**
+ * Which chips are worth showing at all, read off the roster.
+ *
+ * A world with nothing that swims has no business offering a Swims chip whose
+ * only possible outcome is an empty panel. Computed against the *whole* roster
+ * rather than the currently-filtered one on purpose: chips that appeared and
+ * vanished as you toggled the ones beside them would move the row under a thumb
+ * mid-tap, which on a phone is how you end up filtering by something you never
+ * meant to pick.
+ */
+export interface FilterOptions {
+  moves: LocomotionKind[]
+  sizes: SizeBandId[]
+  glows: boolean
+  lavaProof: boolean
+}
+
+export function filterOptions(roster: CreatureBlueprint[]): FilterOptions {
+  const moves = new Set<LocomotionKind>()
+  const sizes = new Set<SizeBandId>()
+  let glows = false
+  let lavaProof = false
+  for (const bp of roster) {
+    moves.add(bp.move.kind)
+    const band = sizeBand(bp)
+    if (band) sizes.add(band)
+    if (isGlowing(bp)) glows = true
+    if (isLavaProof(bp)) lavaProof = true
+  }
+  return {
+    moves: MOVE_ORDER.filter(k => moves.has(k)),
+    sizes: SIZE_BANDS.filter(b => sizes.has(b.id)).map(b => b.id),
+    glows,
+    lavaProof,
+  }
+}
+
+/**
+ * The filter said as a sentence, for the collapsed summary and the empty state.
+ *
+ * Reads as a list of things the player asked for rather than a query, because
+ * the one time it is most needed is when it has emptied the panel and the
+ * question in the player's head is "what did I ask for?".
+ */
+export function describeFilter(filter: CreatureFilter): string {
+  const parts: string[] = []
+  if (filter.moves.length > 0) parts.push(filter.moves.map(k => MOVE_WORDS[k]).join(' or '))
+  if (filter.sizes.length > 0) {
+    const names = SIZE_BANDS.filter(b => filter.sizes.includes(b.id)).map(b =>
+      b.label.toLowerCase()
+    )
+    parts.push(names.join(' or '))
+  }
+  if (filter.glows) parts.push('glows in the dark')
+  if (filter.lavaProof) parts.push('lava-proof')
+  return parts.join(' · ')
+}


### PR DESCRIPTION
The creature drawer answers one question — what does this thing do for a living — and the six group tabs are the whole of it. That was the right question at fifteen creatures. It is the wrong one when you are looking for something that *flies*, or something you can drop in a lava fall: the answer is scattered across four tabs and the only way to find it is to open each one and squint at the portraits.

This adds the other axes.

## What you get

A collapsed **Filter** control between the creature actions and the group tabs, filtering across every tab at once:

| Axis | Read from |
|---|---|
| **Moves** — walks / climbs / flies / floats / swims / stays put | `move.kind` |
| **Size** — Tiny (1–2), Medium (3–4), Huge (5–6) | `size` |
| **Glows in the dark** | `glow > 0` |
| **Lava-proof** | `body.immuneTo` contains `lava` |

OR within an axis, AND across them.

## Decisions worth arguing with

**Collapsed by default.** This row sits directly above the control a thumb reaches for constantly, and eleven chips parked there permanently would push the creatures themselves off a phone screen. The catch with collapsing anything is a filter quietly on while the panel below looks broken — so an active filter never hides: the button goes mint and carries a count, the conditions are spelled out beside it (`flies · huge · lava-proof`), and Clear is one tap away without expanding.

**The tabs hold still.** Which tabs exist, and where a creature files, are questions about the world and must keep the same answer whatever the filter is asking. A tab strip that reshuffled itself on every chip tap would move the thing under your thumb between deciding to tap it and tapping it. Only the counts move; a tab the filter empties dims to 40% but stays tappable, and tapping it explains itself rather than showing a blank drawer.

**Chips are derived from the roster.** A world with nothing that swims doesn't offer a Swims chip whose only possible outcome is an empty panel. A world with nothing to ask about hides the control entirely. Same reason `creatureGroup` derives its answer — a creature summoned thirty seconds ago files itself correctly with no list in the UI to keep up to date.

**Lava-proof asks for lava by name**, rather than trusting a non-empty `immuneTo` the way the inspector's "fireproof" line does. Immunity is a list of materials and the roster already has a creature immune to four of them; a filter answering "lava-proof: yes" for something merely immune to acid is a lie the player only finds out by dropping it in a lava fall.

**Pending summons are exempt from filtering.** A summon has no blueprint yet, so there is nothing to match it on, and dropping it from the count would read as "nothing here" while something is visibly being made.

## Drive-by

`KIND_WORDS` moves out of `field-guide.tsx` into `blueprint.ts` as `MOVE_WORDS`, beside `CREATURE_GROUPS`, which already owns the player-facing vocabulary for the roster. The guide and the filter must never drift into calling the same locomotion two different things.

## Testing

- `npm run typecheck` — no micro-land errors (the trivia/tap-tap failures are pre-existing on `main`)
- `npm test` — 139 pass, including 13 new ones in `creature-filter.test.ts`. One of them asserts the built-in roster still spans all six ways of moving; if a rewrite drops one, the chip quietly disappears and nothing else would notice.
- `npm run lint` — clean
- `/micro-land` compiles and serves 200; the filter bar was render-checked headlessly in its collapsed, active-collapsed, and single-species-world states

**Not verified:** a real tap-through in a browser — there's no browser automation in this repo. The expanded chip panel in particular has not been exercised by a human. Worth a look before merging.

`npm run sim:micro-land` was skipped deliberately: this touches no simulation code, only UI and a pure predicate module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)