### PR TITLE
feat(micro-land): creatures that hop, and walkers that leap to escape

### DIFF
--- a/src/app/micro-land/components/field-guide.tsx
+++ b/src/app/micro-land/components/field-guide.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import type { SpeciesRecord } from '@/app/micro-land/chronicle/types'
-import { MOVE_WORDS, canEat } from '@/app/micro-land/domain/blueprint'
+import { canEat, moveWord } from '@/app/micro-land/domain/blueprint'
 import type { CreatureBlueprint } from '@/app/micro-land/domain/types'
 import { formatDuration } from '@/app/micro-land/format'
 import { useMicroLand } from '@/app/micro-land/store'
@@ -294,7 +294,7 @@ function GuideEntry({
             lineHeight: 1.6,
           }}
         >
-          Size {bp.size} · {MOVE_WORDS[bp.move.kind] ?? bp.move.kind}
+          Size {bp.size} · {moveWord(bp)}
           {bp.body.immuneTo.length > 0 && ` · unburnable`}
           {bp.glow > 0 && ` · glows`}
           {bp.dig.through.length > 0 && ` · digs through ${bp.dig.through.join(', ')}`}

--- a/src/app/micro-land/components/inspector.tsx
+++ b/src/app/micro-land/components/inspector.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react'
 
 import { canEat } from '@/app/micro-land/domain/blueprint'
+import type { CreatureBlueprint } from '@/app/micro-land/domain/types'
 import { useMicroLand } from '@/app/micro-land/store'
 
 import { CreaturePortrait } from './creature-chip'
@@ -32,6 +33,12 @@ const KIND_TEXT: Record<string, string> = {
   crawl: 'Climbs walls and ceilings',
   drift: 'Floats along',
   root: 'Rooted to the spot',
+}
+
+/** A springy walker is a hopper first — it is the thing you notice about it. */
+function moveText(bp: CreatureBlueprint): string {
+  if (bp.move.kind === 'walk' && bp.move.hop >= 0.25) return 'Hops along the ground'
+  return KIND_TEXT[bp.move.kind] ?? bp.move.kind
 }
 
 function Meter({
@@ -306,7 +313,7 @@ export function Inspector({ onName }: { onName: (name: string) => boolean }) {
         </div>
 
         <div style={{ fontSize: 11, color: 'var(--cc-text-muted)', lineHeight: 1.55 }}>
-          {KIND_TEXT[bp.move.kind] ?? bp.move.kind}
+          {moveText(bp)}
           {bp.body.immuneTo.length > 0 && ' · fireproof'}
           {bp.glow > 0 && ' · glows'}
           {inspected.inWater && ' · in water'}

--- a/src/app/micro-land/domain/__tests__/creature-filter.test.ts
+++ b/src/app/micro-land/domain/__tests__/creature-filter.test.ts
@@ -47,7 +47,7 @@ function bp(over: {
       buoyancy: 0.8,
       immuneTo: (over.immuneTo ?? []) as CreatureBlueprint['body']['immuneTo'],
     },
-    move: { kind: over.kind ?? 'walk', speed: 3, jump: 0, restlessness: 0.2 },
+    move: { kind: over.kind ?? 'walk', speed: 3, jump: 0, hop: 0, restlessness: 0.2 },
     diet: {
       eats: [],
       fears: [],

--- a/src/app/micro-land/domain/__tests__/creature-kit.test.ts
+++ b/src/app/micro-land/domain/__tests__/creature-kit.test.ts
@@ -9,6 +9,7 @@ import {
   draftToArt,
   floodFill,
   inkBounds,
+  planOf,
   resizeDraft,
   sizeForWidth,
   trimDraft,
@@ -207,5 +208,40 @@ describe('buildRawCreature', () => {
     expect(animal.tags).toContain('meat')
     expect(animal.tags).not.toContain('plant')
     expect(animal.diet.eats).toEqual(['meat'])
+  })
+
+  it('makes the Hopper chip a walker that bounces, and Walker one that does not', () => {
+    const hopper = build({ planId: 'hop' }) as { move: CreatureBlueprint['move'] }
+    expect(hopper.move.kind).toBe('walk')
+    expect(hopper.move.hop).toBeGreaterThan(0)
+
+    const walker = build({ planId: 'walk' }) as { move: CreatureBlueprint['move'] }
+    expect(walker.move.hop).toBe(0)
+  })
+})
+
+describe('planOf', () => {
+  it('lights the Hopper chip for a springy walker and Walker for the rest', () => {
+    const springy = sanitizeBlueprint({
+      name: 'Frog',
+      move: { kind: 'walk', hop: 1 },
+    }) as CreatureBlueprint
+    expect(planOf(springy)).toBe('hop')
+
+    const plodding = sanitizeBlueprint({
+      name: 'Ox',
+      move: { kind: 'walk' },
+    }) as CreatureBlueprint
+    expect(planOf(plodding)).toBe('walk')
+  })
+
+  it('treats a blueprint written before hopping existed as a plain walker', () => {
+    // Worlds and chronicles keep summoned blueprints exactly as they were
+    // stored, so one saved before `hop` was a field arrives without it.
+    const old = {
+      ...(sanitizeBlueprint({ name: 'Old', move: { kind: 'walk' } }) as CreatureBlueprint),
+    }
+    old.move = { kind: 'walk', speed: 4, jump: 8, restlessness: 0.3 } as CreatureBlueprint['move']
+    expect(planOf(old)).toBe('walk')
   })
 })

--- a/src/app/micro-land/domain/blueprint.ts
+++ b/src/app/micro-land/domain/blueprint.ts
@@ -122,6 +122,11 @@ export const BlueprintSchema = z.object({
         ),
       speed: z.number().describe('Top speed in tiles per second, 0.5-14.'),
       jump: z.number().describe('Jump strength for walkers, 0-20. Ignored otherwise.'),
+      hop: z
+        .number()
+        .describe(
+          'How much of a walking creature travels by jumping, 0-1. 0 = runs along the ground, 0.3 = a frog that pauses between leaps, 1 = a grasshopper that bounces constantly. Use it for anything springy — frogs, fleas, rabbits, kangaroos, bouncing blobs. Ignored by everything that is not a walker.'
+        ),
       restlessness: z
         .number()
         .describe('Chance per second of changing idle direction, 0-1. 0.2 is calm.'),
@@ -548,6 +553,9 @@ export function sanitizeBlueprint(
       kind,
       speed: clamp(move.speed, 0, 16, 3),
       jump: clamp(move.jump, 0, 24, 8),
+      // Defaults to 0 — running is the ordinary way to be a walker, and every
+      // blueprint written before hopping existed means to run.
+      hop: clamp(move.hop, 0, 1, 0),
       restlessness: clamp(move.restlessness, 0, 1, 0.25),
     },
     diet: {
@@ -616,6 +624,19 @@ export const MOVE_WORDS: Record<LocomotionKind, string> = {
   crawl: 'climbs',
   drift: 'floats',
   root: 'stays put',
+}
+
+/**
+ * What one particular creature is doing, rather than what its kind is called.
+ *
+ * A springy walker is a hopper first — bouncing is the thing you notice about
+ * it long before you notice it has legs. The filter still files it under
+ * "walks" with every other ground animal, which is right: hopping is a way of
+ * walking, not a seventh way of being alive.
+ */
+export function moveWord(bp: CreatureBlueprint): string {
+  if (bp.move.kind === 'walk' && bp.move.hop >= 0.25) return 'hops'
+  return MOVE_WORDS[bp.move.kind] ?? bp.move.kind
 }
 
 export type CreatureGroup = 'yours' | 'plants' | 'grazers' | 'hunters' | 'giants' | 'helpers'

--- a/src/app/micro-land/domain/config/creatures.ts
+++ b/src/app/micro-land/domain/config/creatures.ts
@@ -210,7 +210,10 @@ const HOPPER = builtin('hopper', {
     faceMotion: true,
   },
   body: { mass: 1, bounce: 0.2, drag: 0.4, buoyancy: 0.85, immuneTo: [] },
-  move: { kind: 'walk', speed: 5, jump: 12, restlessness: 0.35 },
+  // The one the blurb has always promised. It bounds rather than runs, which is
+  // also its whole defence: a Stalker is faster over the ground and would catch
+  // it every time otherwise.
+  move: { kind: 'walk', speed: 5, jump: 12, hop: 1, restlessness: 0.35 },
   diet: {
     eats: ['plant'],
     fears: [],
@@ -1455,7 +1458,9 @@ const UNICYCLE_CLOWN = builtin('unicycle-clown', {
     faceMotion: true,
   },
   body: { mass: 1, bounce: 0.35, drag: 0.82, buoyancy: 0.95, immuneTo: [] },
-  move: { kind: 'walk', speed: 6, jump: 7, restlessness: 0.6 },
+  // Hopping on one wheel, because a clown on a unicycle that simply walked
+  // about would be the least funny thing in the world.
+  move: { kind: 'walk', speed: 6, jump: 7, hop: 0.55, restlessness: 0.6 },
   diet: {
     eats: ['plant'],
     fears: [],

--- a/src/app/micro-land/domain/creature-kit.ts
+++ b/src/app/micro-land/domain/creature-kit.ts
@@ -403,7 +403,16 @@ export const SIZE_WORDS: Record<number, string> = {
 // Body plans
 // ---------------------------------------------------------------------------
 
-export type PlanId = LocomotionKind
+/**
+ * The chips on the drawing panel.
+ *
+ * Mostly the locomotion kinds, plus `hop` — which is not a seventh way of
+ * moving but a walker with `move.hop` turned up. It gets its own chip because
+ * "it bounces" is the difference a child sees, and asking them to pick Walker
+ * and then find a slider would be asking them to know how the simulation is
+ * put together.
+ */
+export type PlanId = LocomotionKind | 'hop'
 
 interface BodyPlan {
   id: PlanId
@@ -432,9 +441,9 @@ export const BODY_PLANS: BodyPlan[] = [
   {
     id: 'walk',
     label: 'Walker',
-    hint: 'Runs along the ground and jumps.',
+    hint: 'Runs along the ground. Jumps when it has to.',
     flavour: ['beast'],
-    move: { kind: 'walk', speed: 5, jump: 10, restlessness: 0.3 },
+    move: { kind: 'walk', speed: 5, jump: 10, hop: 0, restlessness: 0.3 },
     body: { mass: 1, bounce: 0.15, drag: 0.4, buoyancy: 0.85 },
     habitat: { needs: null, drowns: true },
     hungerRate: 0.027,
@@ -444,11 +453,28 @@ export const BODY_PLANS: BodyPlan[] = [
     faceMotion: true,
   },
   {
+    // A Walker with its speed moved into the leap — same numbers off the same
+    // starter (the Hopper), so a drawn hopper drops into the food chain in the
+    // place the built-in one already holds.
+    id: 'hop',
+    label: 'Hopper',
+    hint: 'Bounces along in leaps.',
+    flavour: ['beast'],
+    move: { kind: 'walk', speed: 5, jump: 12, hop: 1, restlessness: 0.35 },
+    body: { mass: 1, bounce: 0.2, drag: 0.4, buoyancy: 0.85 },
+    habitat: { needs: null, drowns: true },
+    hungerRate: 0.026,
+    starveSeconds: 28,
+    breedAt: 0.8,
+    lifespanSeconds: 200,
+    faceMotion: true,
+  },
+  {
     id: 'fly',
     label: 'Flyer',
     hint: 'Goes anywhere in the air.',
     flavour: ['bug'],
-    move: { kind: 'fly', speed: 4.5, jump: 0, restlessness: 0.55 },
+    move: { kind: 'fly', speed: 4.5, jump: 0, hop: 0, restlessness: 0.55 },
     body: { mass: 0.12, bounce: 0.1, drag: 0.5, buoyancy: 1.4 },
     habitat: { needs: null, drowns: true },
     hungerRate: 0.03,
@@ -462,7 +488,7 @@ export const BODY_PLANS: BodyPlan[] = [
     label: 'Swimmer',
     hint: 'Needs water. Gasps on dry land.',
     flavour: ['fish'],
-    move: { kind: 'swim', speed: 5, jump: 0, restlessness: 0.4 },
+    move: { kind: 'swim', speed: 5, jump: 0, hop: 0, restlessness: 0.4 },
     body: { mass: 0.4, bounce: 0.1, drag: 0.45, buoyancy: 1 },
     habitat: { needs: ['water'], drowns: false },
     hungerRate: 0.03,
@@ -476,7 +502,7 @@ export const BODY_PLANS: BodyPlan[] = [
     label: 'Crawler',
     hint: 'Sticks to walls and ceilings.',
     flavour: ['bug'],
-    move: { kind: 'crawl', speed: 3, jump: 0, restlessness: 0.35 },
+    move: { kind: 'crawl', speed: 3, jump: 0, hop: 0, restlessness: 0.35 },
     body: { mass: 1, bounce: 0.05, drag: 0.35, buoyancy: 0.8 },
     habitat: { needs: null, drowns: true },
     hungerRate: 0.028,
@@ -492,7 +518,7 @@ export const BODY_PLANS: BodyPlan[] = [
     flavour: [],
     // Buoyancy a hair over 1 keeps it at the waterline instead of climbing out
     // of the sea and sailing off the top of the world.
-    move: { kind: 'drift', speed: 1.8, jump: 0, restlessness: 0.5 },
+    move: { kind: 'drift', speed: 1.8, jump: 0, hop: 0, restlessness: 0.5 },
     body: { mass: 0.15, bounce: 0.3, drag: 0.55, buoyancy: 1.03 },
     habitat: { needs: null, drowns: false },
     hungerRate: 0.02,
@@ -506,7 +532,7 @@ export const BODY_PLANS: BodyPlan[] = [
     label: 'Plant',
     hint: 'Never moves. Feeds everything else.',
     flavour: [],
-    move: { kind: 'root', speed: 0, jump: 0, restlessness: 0 },
+    move: { kind: 'root', speed: 0, jump: 0, hop: 0, restlessness: 0 },
     body: { mass: 1, bounce: 0, drag: 0.2, buoyancy: 0.6 },
     habitat: { needs: null, drowns: false },
     hungerRate: 0,
@@ -531,8 +557,17 @@ export const DIET_CHOICES: { id: DietId; label: string; hint: string }[] = [
   { id: 'none', label: 'Nothing', hint: 'Never gets hungry.' },
 ]
 
-/** Which chip should be lit when an existing creature is opened for editing. */
+/**
+ * Which chip should be lit when an existing creature is opened for editing.
+ *
+ * A walker that spends a fair share of its travel airborne is a Hopper as far
+ * as the panel is concerned, so opening a summoned frog lights the chip that
+ * describes what the player can see it doing. The threshold is deliberately low:
+ * anything with a real bounce reads as a hopper, and only a token amount of
+ * jumping comes back as a plain Walker.
+ */
 export function planOf(bp: CreatureBlueprint): PlanId {
+  if (bp.move.kind === 'walk' && bp.move.hop >= 0.25) return 'hop'
   return PLAN_BY_ID.has(bp.move.kind) ? bp.move.kind : 'walk'
 }
 

--- a/src/app/micro-land/domain/procedural.ts
+++ b/src/app/micro-land/domain/procedural.ts
@@ -108,6 +108,8 @@ const SHAPES: Record<string, Shape> = {
 interface Read {
   kind: LocomotionKind
   shape: keyof typeof SHAPES
+  /** Springiness for walkers — see `CreatureMove.hop`. */
+  hop: number
   eats: string[]
   tags: string[]
   size: number
@@ -155,6 +157,18 @@ function readPrompt(prompt: string): Read {
     kind = 'walk'
     shape = 'bug'
   }
+
+  // Springiness rides on top of the body plan rather than replacing it, so a
+  // "hopping mushroom" is still rooted and a frog is still a walker. This is the
+  // fallback creature — the one a child gets when the summon fails — and asking
+  // for a frog and being handed something that plods is the moment they notice
+  // nobody was really listening. Matching on 'hop' as a substring picks up
+  // grasshopper and hopper along the way, which is the intent.
+  const hop = has('frog', 'toad', 'rabbit', 'bunny', 'hare', 'kangaroo', 'flea', 'hop', 'bounce')
+    ? 1
+    : has('cricket', 'locust', 'spring', 'jump', 'leap')
+      ? 0.6
+      : 0
 
   // Diet. An explicit "eats ..." clause wins; otherwise anything that sounds
   // toothy eats meat and the rest graze.
@@ -219,6 +233,7 @@ function readPrompt(prompt: string): Read {
   return {
     kind,
     shape,
+    hop,
     eats,
     tags,
     size,
@@ -275,6 +290,7 @@ export function proceduralCreature(prompt: string): CreatureBlueprint {
         kind: read.kind,
         speed: read.kind === 'root' ? 0 : 3 + (seed % 5),
         jump: 9,
+        hop: read.hop,
         restlessness: 0.3,
       },
       diet: {

--- a/src/app/micro-land/domain/sim/creature-sim.ts
+++ b/src/app/micro-land/domain/sim/creature-sim.ts
@@ -537,7 +537,35 @@ function steer(w: WorldState, c: Creature, bp: CreatureBlueprint, dt: number, rn
         Math.floor(c.y + body.dy + body.h / 2)
       )
       const wantsUp = wantY < -0.4
-      if (c.grounded && (blocked || (wantsUp && rng() < 0.08))) {
+
+      /**
+       * How badly it wants to be off the ground, in launches per second.
+       *
+       * Fleeing is the case that earns this. A walker that only ever runs
+       * sideways is caught by anything faster than it, so every chase had the
+       * same ending; going *over* the thing chasing you is the one answer a
+       * pursuer can't match by simply being quicker. Reaching for prey overhead
+       * is the same move from the other side. An unbothered walker still stays
+       * on the ground, which is what keeps a leap worth watching.
+       *
+       * The reaching term is the old per-tick 0.08 restated per second, so a
+       * hunter still climbs after prey exactly as eagerly as it used to; the
+       * fleeing term is new, and adds to it when a cornered creature is both
+       * running away and looking up.
+       */
+      const urgency = (wantsUp ? 4.8 : 0) + (c.mood === 'flee' ? 3 : 0)
+
+      // A hopper doesn't run, it launches: its whole speed is spent at take-off
+      // rather than built up by its legs, so it covers roughly the ground a
+      // walker does but in arcs, with a beat on landing. That beat is the trade
+      // — it can still steer in the air, but it cannot turn round on the spot
+      // the way something running can.
+      const going = Math.abs(wantX) > 0.15
+      if (c.grounded && bp.move.hop > 0 && going && rng() < bp.move.hop * 6 * dt) {
+        c.vx = Math.sign(wantX) * speed
+        c.vy = -bp.move.jump
+        c.grounded = false
+      } else if (c.grounded && (blocked || rng() < urgency * dt)) {
         c.vy = -bp.move.jump
         c.grounded = false
       }

--- a/src/app/micro-land/domain/types.ts
+++ b/src/app/micro-land/domain/types.ts
@@ -157,6 +157,16 @@ export interface CreatureMove {
   speed: number
   /** Jump impulse in tiles/second. Only used by `walk`. */
   jump: number
+  /**
+   * How much of its travelling is done in the air, 0..1. Only used by `walk`.
+   *
+   * At 0 it runs, and only leaves the ground when something is in its way or
+   * it is trying to escape. Above 0 it *hops*: the whole of its speed goes into
+   * the leap rather than into its legs, so it covers roughly the ground a
+   * walker does but in bursts, with a beat on landing. 0.3 is a frog that sits
+   * between jumps; 1 is a grasshopper that is barely ever down.
+   */
+  hop: number
   /** Chance per second of picking a new idle direction, 0..1. */
   restlessness: number
 }


### PR DESCRIPTION
The Hopper's blurb has always promised *a springy grazer that bounds away from anything with teeth*, and it has never once left the ground on purpose. Walkers only jumped when a wall was in front of them or prey was directly overhead, so the one creature named after the move never made it.

The kids asked for creatures that can jump. This is both halves of that: hopping as a way of getting around, and leaping as something a creature does when it matters.

## Hopping is data, not behaviour

`move.hop` is a new blueprint field — how much of a walker's travelling is done in the air, 0 to 1. Above zero it launches instead of running: its whole speed is spent at take-off rather than built up by its legs, so it covers roughly the ground a walker does but in arcs, with a beat on landing. That beat is the trade — it can steer in the air but cannot turn round on the spot the way something running can.

Nothing branches on species. A summoned frog bounces for the same reason the Hopper does.

| creature | hop | why |
|---|---|---|
| Hopper | 1 | the whole animal |
| Wobble Clown | 0.55 | a clown on a unicycle that plods is the least funny thing in the world |

## Leaping when it matters

Walkers now leave the ground while **fleeing**, not only when cornered. A creature that can only run sideways is caught by anything faster than it, which gave every chase the same ending; going *over* the thing chasing you is the one answer a pursuer can't match by simply being quicker. The reaching-for-prey term is the old per-tick `0.08` restated per second, so hunters climb after food exactly as eagerly as they did before.

## Where it shows up

- **Drawing panel** gets a seventh chip, **Hopper** — "it bounces" is the difference a child sees, and asking them to pick Walker and then find a slider would be asking them to know how the simulation is put together. It's a walker with `hop` turned up, not a seventh way of being alive, which is why the roster filter still files it under *walks*.
- **Field guide / inspector** say "hops" for anything springy, via a shared `moveWord` next to `MOVE_WORDS` so the two surfaces can't drift apart.
- **Offline fallback** reads frog, rabbit, kangaroo, flea and grasshopper out of the prompt, so a summon that fails still hops.

## Balance

#2715 left every animal going extinct on every theme within three to eight minutes and said so, so a ten-minute harness run on this branch compares two plant-only worlds and proves nothing. Measured instead inside the window where animals still exist — **earth, three 240s runs on the same seeds**:

| species | main | this branch |
|---|---|---|
| hopper | avg 1.0 | avg 4.0 |
| stalker | extinct in every run | avg 3.0 |
| mite | avg 35.0 | avg 1.0 |

Bouncing prey did not starve the things that hunt it. Mites swing hard between seeds in both directions. Nothing here fixes the balance pass that is still owed, and nothing here makes it worse.

Jump strength stays at 12: at 14 a hopper is airborne 73% of the time and the landing beat vanishes.

## Verification

- `npm run typecheck` — clean for micro-land
- `npm test` — 142 pass, 3 new (Hopper chip round-trips, `planOf` lights it, a blueprint saved before `hop` existed still reads as a plain walker)
- `npm run sim:micro-land` on all four themes — every one ends `✓ Still alive`, no change to the plant-only end state main already has
- `npm run lint` + prettier — clean on touched files
- Headless path check: a Hopper is airborne 52% of the time in a 2-tile arc; a Mite stays down at 1%
- `/micro-land` renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)