### PR TITLE
feat(micro-land): conventional names for the standard controls

### DIFF
--- a/src/app/micro-land/components/creature-builder.tsx
+++ b/src/app/micro-land/components/creature-builder.tsx
@@ -85,8 +85,8 @@ type PaintTool = 'draw' | 'fill' | 'erase' | 'pick'
 const TOOLS: { id: PaintTool; label: string; glyph: string }[] = [
   { id: 'draw', label: 'Draw', glyph: '✎' },
   { id: 'fill', label: 'Fill', glyph: '▨' },
-  { id: 'erase', label: 'Rub out', glyph: '⌫' },
-  { id: 'pick', label: 'Copy colour', glyph: '⊙' },
+  { id: 'erase', label: 'Erase', glyph: '⌫' },
+  { id: 'pick', label: 'Pick colour', glyph: '⊙' },
 ]
 
 /** Undo depth. Deep enough to walk back a bad idea, shallow enough to be free. */
@@ -872,7 +872,7 @@ export function CreatureBuilder({
                   style={primaryButton(empty || saving)}
                 >
                   <SparkleIcon size={13} />
-                  {saving ? 'Writing…' : 'Save to roster'}
+                  {saving ? 'Saving…' : 'Save to roster'}
                 </button>
               ) : (
                 <button
@@ -919,7 +919,7 @@ export function CreatureBuilder({
                 }}
                 style={{ ...ghostButton, minHeight: 36 }}
               >
-                ← Start again
+                ← Back
               </button>
             </div>
           </div>

--- a/src/app/micro-land/components/hud.tsx
+++ b/src/app/micro-land/components/hud.tsx
@@ -237,7 +237,7 @@ export function Hud({
           }}
           title="Remove every living thing"
         >
-          Empty
+          Clear all
         </button>
       </div>
     </header>

--- a/src/app/micro-land/components/inspector.tsx
+++ b/src/app/micro-land/components/inspector.tsx
@@ -240,7 +240,7 @@ export function Inspector({ onName }: { onName: (name: string) => boolean }) {
                   }}
                   onPointerDown={e => e.stopPropagation()}
                 >
-                  Name
+                  Save
                 </button>
               </form>
             ) : (
@@ -259,7 +259,7 @@ export function Inspector({ onName }: { onName: (name: string) => boolean }) {
                 }}
                 onPointerDown={e => e.stopPropagation()}
               >
-                Give it a name
+                Add name
               </button>
             )}
           </div>

--- a/src/app/micro-land/components/summon-loader.tsx
+++ b/src/app/micro-land/components/summon-loader.tsx
@@ -449,7 +449,7 @@ export function SummonLoader({
           color: 'var(--cc-text-muted)',
         }}
       >
-        Never mind
+        Cancel
       </button>
     </div>
   )

--- a/src/app/micro-land/components/toolbar.tsx
+++ b/src/app/micro-land/components/toolbar.tsx
@@ -134,7 +134,7 @@ export function Toolbar({ onRemoveSpecies }: { onRemoveSpecies: (blueprintId: st
   )
   const [group, setGroup] = useState<CreatureGroup>('plants')
   /**
-   * Tidy mode: while it is on, tapping a creature in "Yours" removes it.
+   * Edit mode: while it is on, tapping a creature in "Yours" removes it.
    *
    * A mode rather than a permanent ✕ on every chip. This row is what a thumb
    * reaches for constantly during play, and a delete control living there full
@@ -143,7 +143,7 @@ export function Toolbar({ onRemoveSpecies }: { onRemoveSpecies: (blueprintId: st
    * button: a ✕ nested inside the chip button would be invalid HTML and a tap
    * target far too small for the hands this is built for.
    */
-  const [tidying, setTidying] = useState(false)
+  const [editing, setEditing] = useState(false)
 
   // Jump to "Yours" the moment a summon is asked for, and again when it lands,
   // so the thing you just invented — and the slot holding its place until then —
@@ -156,7 +156,7 @@ export function Toolbar({ onRemoveSpecies }: { onRemoveSpecies: (blueprintId: st
     if (summonedCount > lastSummoned.current || pendingCount > lastPending.current) {
       setGroup('yours')
       // Arriving here because something new was made must never arrive armed.
-      setTidying(false)
+      setEditing(false)
     }
     lastSummoned.current = summonedCount
     lastPending.current = pendingCount
@@ -167,7 +167,7 @@ export function Toolbar({ onRemoveSpecies }: { onRemoveSpecies: (blueprintId: st
   const shown = filtered.get(active) ?? []
 
   /**
-   * Tidying is only ever a thing in "Yours".
+   * Edit mode is only ever a thing in "Yours".
    *
    * Derived rather than cleaned up in an effect, so the armed state can never
    * outlive the conditions for it even for one render: switching tab, emptying
@@ -175,8 +175,8 @@ export function Toolbar({ onRemoveSpecies }: { onRemoveSpecies: (blueprintId: st
    * on the way out of the tab, so coming back later never finds a row that
    * silently deletes on tap.
    */
-  const canTidy = active === 'yours' && shown.length > 0
-  const tidyOn = tidying && canTidy
+  const canEdit = active === 'yours' && shown.length > 0
+  const editOn = editing && canEdit
 
   /**
    * What the folded drawer still says is in your hand.
@@ -534,7 +534,7 @@ export function Toolbar({ onRemoveSpecies }: { onRemoveSpecies: (blueprintId: st
 
           <CreatureFilterBar filter={filter} setFilter={setFilter} options={options} />
 
-          {/* The tidy toggle sits beside the tabs but outside the tablist — it is
+          {/* The edit toggle sits beside the tabs but outside the tablist — it is
           not a tab, and a stray child in there confuses assistive tech. */}
           <div className="-mx-1 flex items-center gap-1 px-1">
             <div className="flex gap-1 overflow-x-auto" role="tablist" aria-label="Creature kinds">
@@ -560,7 +560,7 @@ export function Toolbar({ onRemoveSpecies }: { onRemoveSpecies: (blueprintId: st
                     aria-selected={selected}
                     onClick={() => {
                       setGroup(tab.id)
-                      setTidying(false)
+                      setEditing(false)
                     }}
                     style={{
                       fontFamily: 'var(--cc-font-mono)',
@@ -595,16 +595,16 @@ export function Toolbar({ onRemoveSpecies }: { onRemoveSpecies: (blueprintId: st
               })}
             </div>
 
-            {canTidy && (
+            {canEdit && (
               <button
                 type="button"
                 className="cc-btn ml-auto shrink-0"
-                onClick={() => setTidying(v => !v)}
-                aria-pressed={tidyOn}
+                onClick={() => setEditing(v => !v)}
+                aria-pressed={editOn}
                 title={
-                  tidyOn
-                    ? 'Done tidying — tapping a creature places it again'
-                    : 'Tidy up — tap a creature to remove it'
+                  editOn
+                    ? 'Done — tapping a creature places it again'
+                    : 'Edit — tap a creature to remove it'
                 }
                 style={{
                   fontFamily: 'var(--cc-font-mono)',
@@ -614,15 +614,15 @@ export function Toolbar({ onRemoveSpecies }: { onRemoveSpecies: (blueprintId: st
                   padding: '5px 9px',
                   minHeight: 28,
                   borderRadius: 999,
-                  border: `1px solid ${tidyOn ? 'var(--cc-pink)' : 'var(--cc-mint-line)'}`,
-                  background: tidyOn
+                  border: `1px solid ${editOn ? 'var(--cc-pink)' : 'var(--cc-mint-line)'}`,
+                  background: editOn
                     ? 'var(--cc-pink-soft, rgba(255,122,184,0.14))'
                     : 'transparent',
-                  color: tidyOn ? 'var(--cc-pink)' : 'var(--cc-text-muted)',
+                  color: editOn ? 'var(--cc-pink)' : 'var(--cc-text-muted)',
                   whiteSpace: 'nowrap',
                 }}
               >
-                {tidyOn ? 'Done' : 'Tidy'}
+                {editOn ? 'Done' : 'Edit'}
               </button>
             )}
           </div>
@@ -698,9 +698,9 @@ export function Toolbar({ onRemoveSpecies }: { onRemoveSpecies: (blueprintId: st
             )}
             {shown.map(bp => {
               const selected = tool.kind === 'creature' && tool.blueprintId === bp.id
-              // Built-ins can't be removed even while tidying — they come from
+              // Built-ins can't be removed even in edit mode — they come from
               // config, so deleting one would just bring it back on reload.
-              const removable = tidyOn && bp.summoned
+              const removable = editOn && bp.summoned
               return (
                 <button
                   key={bp.id}
@@ -715,19 +715,19 @@ export function Toolbar({ onRemoveSpecies }: { onRemoveSpecies: (blueprintId: st
                   aria-label={removable ? `Remove ${bp.name}` : undefined}
                   title={removable ? `Remove ${bp.name}` : bp.blurb}
                   style={{
-                    ...swatchStyle(selected && !tidyOn),
+                    ...swatchStyle(selected && !editOn),
                     minWidth: 62,
                     position: 'relative',
                     borderColor: removable
                       ? 'var(--cc-pink)'
-                      : selected && !tidyOn
+                      : selected && !editOn
                         ? 'var(--cc-mint)'
                         : bp.summoned
                           ? 'var(--cc-pink-border)'
                           : 'var(--cc-mint-line)',
-                    // A built-in during tidy mode is inert; say so rather than
+                    // A built-in during edit mode is inert; say so rather than
                     // letting it look tappable and do nothing.
-                    opacity: tidyOn && !bp.summoned ? 0.35 : 1,
+                    opacity: editOn && !bp.summoned ? 0.35 : 1,
                   }}
                 >
                   <span

--- a/src/app/micro-land/components/worlds-panel.tsx
+++ b/src/app/micro-land/components/worlds-panel.tsx
@@ -183,7 +183,7 @@ export function WorldsPanel({
           </div>
           {full && (
             <p style={{ fontSize: 11, color: 'var(--cc-gold)' }}>
-              The shelf holds {MAX_SAVED_WORLDS}. Let one go to make room.
+              The shelf holds {MAX_SAVED_WORLDS}. Delete one to make room.
             </p>
           )}
           {shelf.error && (
@@ -254,7 +254,7 @@ export function WorldsPanel({
                           color: 'var(--cc-pink)',
                         }}
                       >
-                        Really
+                        Delete
                       </button>
                       <button
                         type="button"
@@ -262,7 +262,7 @@ export function WorldsPanel({
                         onClick={() => setConfirming(null)}
                         style={buttonBase}
                       >
-                        No
+                        Cancel
                       </button>
                     </div>
                   ) : (
@@ -285,10 +285,10 @@ export function WorldsPanel({
                         type="button"
                         className="cc-btn"
                         onClick={() => setConfirming(world.id)}
-                        aria-label={`Let go of ${world.name}`}
+                        aria-label={`Delete ${world.name}`}
                         style={buttonBase}
                       >
-                        Let go
+                        Delete
                       </button>
                     </div>
                   )}


### PR DESCRIPTION
Micro Land's standard controls were using invented names, so a player had to learn this game's word for something they already knew how to do. This renames the affordances and leaves the voice alone.

| Where | Was | Now |
|---|---|---|
| `toolbar.tsx` | Tidy / Done | **Edit** / Done |
| `creature-builder.tsx` | Rub out | **Erase** |
| `creature-builder.tsx` | Copy colour | **Pick colour** |
| `creature-builder.tsx` | ← Start again | **← Back** |
| `creature-builder.tsx` | Writing… | **Saving…** |
| `worlds-panel.tsx` | Let go | **Delete** |
| `worlds-panel.tsx` | Really / No | **Delete** / **Cancel** |
| `summon-loader.tsx` | Never mind | **Cancel** |
| `hud.tsx` | Empty | **Clear all** |
| `inspector.tsx` | Give it a name → Name | **Add name** → **Save** |

## Two that aren't the obvious rename

- **"Clear all", not "Clear"**, in the HUD. The creature filter bar already has a `Clear`, and one screen with two buttons where one drops a filter and the other kills every living thing is worth an extra word to separate. It also matches the button's own tooltip, "Remove every living thing".
- **"Add name", not "Rename"**, in the inspector. That button only renders for a creature with *no* name — there is no rename path in the code — so `Rename` would describe something the button cannot do. The submit went `Name` → `Save` so the trigger and the confirm aren't the same word.

## What deliberately did not change

The game's voice: *Bring it to life*, *Keep / Kept*, *Reshape*, *Laws of the land*, *Field Guide*, *Things that have happened*, and the tooltip prose. The line drawn here is affordance vs. character — the label telling you what a button does should be boring; everything around it can sing. This keeps CLAUDE.md #4 (game voice inside the game) intact.

One line of prose moved past that line: *"The shelf holds 6. Let one go to make room."* → *"Delete one to make room."* It was pointing at a button that no longer says "let go".

`toolbar.tsx` carries the largest diff because the mode's internals were renamed with it (`tidying`/`canTidy`/`tidyOn` → `editing`/`canEdit`/`editOn`) plus the comments explaining them, so the code doesn't drift from the label.

## Testing

- `npm run typecheck` — 0 errors in micro-land. (The repo has pre-existing `src/lib/trivia` AI-SDK type errors on `main`, untouched here.)
- `npm test` — all 9 micro-land suites pass. The unrelated jokers/tarot failures predate this branch.
- Prettier clean.
- No simulation change, so the ecosystem harness was not run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)