### PR TITLE
fix: replace Math.random() with crypto.randomUUID() in comet-cards

### DIFF
--- a/src/app/comet-cards/domain/randomness/index.ts
+++ b/src/app/comet-cards/domain/randomness/index.ts
@@ -23,9 +23,7 @@ export function mulberry32(seed: number) {
 }
 
 export function uuid() {
-  return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}-${Math.random()
-    .toString(36)
-    .slice(2, 10)}`
+  return crypto.randomUUID()
 }
 
 export function deterministicUuid(seed: string) {


### PR DESCRIPTION
## Summary
- Replaces the custom `Math.random()`-based `uuid()` with `crypto.randomUUID()` in the comet-cards domain randomness module
- `crypto.randomUUID()` is cryptographically secure and available in all modern browsers and Node.js 15+
- All other seeded RNG functions are unchanged (they use deterministic randomness by design)

Closes #2705

## Test plan
- [ ] Card IDs are generated as valid UUIDs in the comet-cards game
- [ ] Game state with generated card IDs still functions correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)