### PR TITLE
fix(a11y): add aria-pressed to comet-cards SortPill and ItemRow

### DIFF
--- a/src/app/comet-cards/components/cosmic/buttons.tsx
+++ b/src/app/comet-cards/components/cosmic/buttons.tsx
@@ -106,6 +106,7 @@ export function SortPill({
       type="button"
       className="cc-btn"
       onClick={onClick}
+      aria-pressed={active ?? false}
       style={{
         background: 'transparent',
         border: 'none',

--- a/src/app/comet-cards/components/cosmic/item-row.tsx
+++ b/src/app/comet-cards/components/cosmic/item-row.tsx
@@ -18,6 +18,7 @@ export function ItemRow({
       type="button"
       onClick={onClick}
       aria-label={`${name}: ${description}`}
+      aria-pressed={selected}
       className="cc-btn flex w-full items-start gap-3 rounded-md p-2.5 text-left transition-colors"
       style={{
         background: selected


### PR DESCRIPTION
## Summary
- `SortPill`: adds `aria-pressed={active ?? false}` so screen readers announce which sort mode is active
- `ItemRow`: adds `aria-pressed={selected}` so screen readers announce when a consumable is selected

Both components were using visual-only indicators (color/border) to show state, with no semantic ARIA signal.

Partial progress on #1519

## Test plan
- [ ] Screen reader announces "pressed" / "not pressed" on SortPill (Value / Suit)
- [ ] Screen reader announces selection state on consumable ItemRow

Generated with Claude Code