### PR TITLE
fix: remove typescript.ignoreBuildErrors from next.config.ts

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,11 +1,6 @@
 import type { NextConfig } from 'next'
 
 const nextConfig: NextConfig = {
-  // TODO: Remove once all TypeScript strict-mode errors are resolved.
-  // See issue #2719 for tracking.
-  typescript: {
-    ignoreBuildErrors: true,
-  },
   images: {
     remotePatterns: [
       {

--- a/src/app/api/v1/agent/character/route.ts
+++ b/src/app/api/v1/agent/character/route.ts
@@ -74,7 +74,7 @@ export async function POST(request: Request) {
         const aiService = AIServiceFactory.create('openai', config)
 
         // Generate character response using OpenAI
-        const rawResponse = await aiService.generateCharacterResponse(character, aiMessages)
+        const rawResponse = await aiService.generateCharacterResponse({ ...character, description: character.description ?? '' }, aiMessages)
 
         // Post-process to remove any character name prefixes
         // Check for common patterns like "Character Name:" or "Character Name -"

--- a/src/app/tap-tap-adventure/lib/useDialogFocus.ts
+++ b/src/app/tap-tap-adventure/lib/useDialogFocus.ts
@@ -6,15 +6,16 @@ import { type RefObject, useEffect } from 'react'
  *   (or the container itself if nothing else is focusable)
  * - On unmount: returns focus to whatever element was focused before the dialog opened
  */
-export function useDialogFocus(containerRef: RefObject<HTMLElement | null>) {
+export function useDialogFocus<T extends HTMLElement | null>(containerRef: RefObject<T>) {
   useEffect(() => {
     const previousFocus = document.activeElement as HTMLElement | null
+    const container = containerRef.current as HTMLElement | null
 
-    const focusable = containerRef.current?.querySelector<HTMLElement>(
+    const focusable = container?.querySelector<HTMLElement>(
       'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), ' +
         'textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
     )
-    const target = focusable ?? containerRef.current
+    const target = focusable ?? container
     target?.focus()
 
     return () => {


### PR DESCRIPTION
## Summary
- Removes `typescript.ignoreBuildErrors: true` from `next.config.ts` to re-enable strict TypeScript checking during Next.js builds
- Fixes underlying TypeScript errors that were hidden by the flag:
  - **`useDialogFocus` generic type fix**: Made the hook generic (`<T extends HTMLElement | null>`) to work correctly with React 19's mutable `RefObject` in all 14 tap-tap-adventure dialog components
  - **`agent/character` route**: Normalized `description` field from `string | undefined` (Zod optional) to `string` (required by `Character` type) at the `generateCharacterResponse` call site

Closes #2720

## Test plan
- [ ] Vercel CI passes with TypeScript strict checking enabled
- [ ] All 14 tap-tap-adventure dialog components compile without errors
- [ ] agent/character API route compiles without errors
- [ ] No regression in existing functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)