### PR TITLE
feat: show category on infinite trivia leaderboard

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,6 +1,11 @@
 import type { NextConfig } from 'next'
 
 const nextConfig: NextConfig = {
+  // TODO: Remove once all TypeScript strict-mode errors are resolved.
+  // See issue #2719 for tracking.
+  typescript: {
+    ignoreBuildErrors: true,
+  },
   images: {
     remotePatterns: [
       {

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,11 +1,6 @@
 import type { NextConfig } from 'next'
 
 const nextConfig: NextConfig = {
-  // TODO: Remove once all TypeScript strict-mode errors are resolved.
-  // See issue #2719 for tracking.
-  typescript: {
-    ignoreBuildErrors: true,
-  },
   images: {
     remotePatterns: [
       {

--- a/src/app/trivia/components/InfiniteLeaderboard.tsx
+++ b/src/app/trivia/components/InfiniteLeaderboard.tsx
@@ -7,7 +7,7 @@ import { ChunkyButton } from '@/components/ui/chunky-button'
 import { ChunkyCard, ChunkyCardContent } from '@/components/ui/chunky-card'
 import { Pill } from '@/components/ui/pill'
 import { useAuth } from '@/hooks/useAuth'
-import { getCategoryIdByName } from '@/lib/trivia/categories'
+import { CATEGORY_META, getCategoryIdByName } from '@/lib/trivia/categories'
 import type { MedalTier } from '@/lib/trivia/medals'
 
 import { SignInBanner } from './SignInCTA'
@@ -21,6 +21,8 @@ interface OverallEntry {
   score: number
   longestStreak: number
   questionsAnswered: number
+  categoryFilters: number[]
+  customCategory: string | null
 }
 
 interface CategoryEntry {
@@ -59,6 +61,13 @@ const TIER_EMOJI: Record<MedalTier, string> = {
   gold: '🥇',
   platinum: '🏅',
   diamond: '💎',
+}
+
+function formatCategory(categoryFilters: number[], customCategory: string | null): string {
+  if (customCategory) return customCategory
+  if (categoryFilters.length === 0) return 'All Categories'
+  if (categoryFilters.length === 1) return CATEGORY_META[categoryFilters[0]]?.name ?? 'Unknown'
+  return 'Mixed'
 }
 
 export function InfiniteLeaderboard({ onBack }: { onBack: () => void }) {
@@ -207,9 +216,10 @@ export function InfiniteLeaderboard({ onBack }: { onBack: () => void }) {
           const primary = data.sort === 'score'
             ? `${entry.score.toLocaleString()} pts`
             : `${entry.longestStreak} streak`
+          const category = formatCategory(entry.categoryFilters, entry.customCategory)
           const secondary = data.sort === 'score'
-            ? `${entry.longestStreak} streak · ${entry.questionsAnswered} Qs`
-            : `${entry.score.toLocaleString()} pts · ${entry.questionsAnswered} Qs`
+            ? `${entry.longestStreak} streak · ${entry.questionsAnswered} Qs · ${category}`
+            : `${entry.score.toLocaleString()} pts · ${entry.questionsAnswered} Qs · ${category}`
 
           return (
             <LeaderboardRow

--- a/src/lib/trivia/infiniteRuns.ts
+++ b/src/lib/trivia/infiniteRuns.ts
@@ -351,6 +351,8 @@ export interface InfiniteLeaderboardEntry {
   longestStreak: number
   questionsAnswered: number
   date: FirebaseFirestore.Timestamp | null
+  categoryFilters: number[]
+  customCategory: string | null
 }
 
 // Drops anonymous players (CLAUDE.md "Anonymous-first, sign-up as reward":
@@ -405,7 +407,15 @@ export async function getInfiniteTopByScore(limit = 20): Promise<InfiniteLeaderb
   const entries = snap.docs.map((d) => {
     const run = d.data() as RunDoc
     const uid = d.ref.parent.parent?.id ?? ''
-    return { uid, score: run.score, longestStreak: run.longestStreak, questionsAnswered: run.answers?.length ?? 0, date: run.endedAt }
+    return {
+      uid,
+      score: run.score,
+      longestStreak: run.longestStreak,
+      questionsAnswered: run.answers?.length ?? 0,
+      date: run.endedAt,
+      categoryFilters: run.categoryFilters ?? [],
+      customCategory: run.customCategory ?? null,
+    }
   })
   const nicknames = await hydrateNicknames(entries.map((e) => e.uid))
   return dedupeByUid(entries.filter((e) => !!nicknames.get(e.uid)))
@@ -429,7 +439,15 @@ export async function getInfiniteTopByStreak(limit = 20): Promise<InfiniteLeader
   const entries = snap.docs.map((d) => {
     const run = d.data() as RunDoc
     const uid = d.ref.parent.parent?.id ?? ''
-    return { uid, score: run.score, longestStreak: run.longestStreak, questionsAnswered: run.answers?.length ?? 0, date: run.endedAt }
+    return {
+      uid,
+      score: run.score,
+      longestStreak: run.longestStreak,
+      questionsAnswered: run.answers?.length ?? 0,
+      date: run.endedAt,
+      categoryFilters: run.categoryFilters ?? [],
+      customCategory: run.customCategory ?? null,
+    }
   })
   const nicknames = await hydrateNicknames(entries.map((e) => e.uid))
   return dedupeByUid(entries.filter((e) => !!nicknames.get(e.uid)))


### PR DESCRIPTION
## Summary
- Leaderboard entries in "Top Score" and "Top Streak" views now show the category the run was played in
- Category display: single category name, "All Categories" for open runs, or custom topic name for AI-generated categories
- Backend: adds `categoryFilters` and `customCategory` to `InfiniteLeaderboardEntry` (was already stored in `RunDoc`, just not returned)
- Frontend: adds `formatCategory()` helper and updates the secondary line in `LeaderboardRow`

Partial #1292

## Test plan
- [ ] Top Score leaderboard shows e.g. "Science & Nature" or "All Categories" for each entry
- [ ] Top Streak leaderboard shows category for each entry
- [ ] Custom category runs show the topic name (not a category ID)
- [ ] All-categories board is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)