### PR TITLE
fix: make useDialogFocus generic to fix React 19 RefObject type error

### DIFF
--- a/src/app/tap-tap-adventure/lib/useDialogFocus.ts
+++ b/src/app/tap-tap-adventure/lib/useDialogFocus.ts
@@ -6,15 +6,16 @@ import { type RefObject, useEffect } from 'react'
  *   (or the container itself if nothing else is focusable)
  * - On unmount: returns focus to whatever element was focused before the dialog opened
  */
-export function useDialogFocus(containerRef: RefObject<HTMLElement | null>) {
+export function useDialogFocus<T extends HTMLElement | null>(containerRef: RefObject<T>) {
   useEffect(() => {
     const previousFocus = document.activeElement as HTMLElement | null
+    const container = containerRef.current as HTMLElement | null
 
-    const focusable = containerRef.current?.querySelector<HTMLElement>(
+    const focusable = container?.querySelector<HTMLElement>(
       'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), ' +
         'textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
     )
-    const target = focusable ?? containerRef.current
+    const target = focusable ?? container
     target?.focus()
 
     return () => {


### PR DESCRIPTION
## Summary
In React 19, `useRef<HTMLDivElement>(null)` returns `RefObject<HTMLDivElement | null>` where `.current` is mutable. TypeScript treats mutable generic containers as invariant, so `RefObject<HTMLDivElement | null>` is not assignable to `RefObject<HTMLElement | null>` in strict mode.

Making `useDialogFocus<T extends HTMLElement | null>(containerRef: RefObject<T>)` generic fixes this — each call site infers `T` from the passed ref's concrete type.

Discovered when PR #2730 (removing `typescript.ignoreBuildErrors`) exposed this strict-mode error.

## Test plan
- [ ] Vercel build succeeds with TypeScript checking enabled (i.e. PR #2730 can now merge)
- [ ] All tap-tap-adventure dialogs still manage focus correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)