### PR TITLE
feat(micro-land): name the worlds button for what it opens

### DIFF
--- a/src/app/micro-land/components/hud.tsx
+++ b/src/app/micro-land/components/hud.tsx
@@ -154,13 +154,19 @@ export function Hud({
         className="cc-btn"
         onClick={() => setWorldsOpen(true)}
         style={{ ...chipBase, ...(activeWorldId ? activeChip : {}) }}
+        // The chip highlight says 'saved' visually; the label stopped saying it
+        // when this became a noun, so the state has to reach a screen reader
+        // some other way than the colour.
+        aria-label={
+          activeWorldId ? 'Worlds — this world is saved' : 'Worlds — this world is not saved'
+        }
         title={
           activeWorldId
-            ? 'This world is kept — everything you do here is saved'
-            : 'Keep this world, or open one you kept'
+            ? 'This world is saved — everything you do here is written back on its own'
+            : 'Save this world, or open one you saved'
         }
       >
-        {activeWorldId ? 'Kept' : 'Keep'}
+        Worlds
       </button>
 
       <div className="flex items-center gap-1" role="group" aria-label="Speed">

--- a/src/app/micro-land/components/worlds-panel.tsx
+++ b/src/app/micro-land/components/worlds-panel.tsx
@@ -141,7 +141,7 @@ export function WorldsPanel({
           className="flex flex-col gap-2 px-4 py-3"
           style={{ borderBottom: '1px solid var(--cc-panel-divider)' }}
         >
-          <h3 style={heading}>{active ? 'Kept as' : 'Keep this one'}</h3>
+          <h3 style={heading}>{active ? 'Saved as' : 'Save this world'}</h3>
           <p style={{ fontSize: 12, color: 'var(--cc-text-muted)' }}>
             {active
               ? `${active.name} — everything you do here is written back on its own.`
@@ -178,12 +178,12 @@ export function WorldsPanel({
               disabled={shelf.busy || full}
               style={{ ...primaryButton, opacity: shelf.busy || full ? 0.45 : 1 }}
             >
-              {active ? 'Save now' : 'Keep it'}
+              Save
             </button>
           </div>
           {full && (
             <p style={{ fontSize: 11, color: 'var(--cc-gold)' }}>
-              The shelf holds {MAX_SAVED_WORLDS}. Delete one to make room.
+              You can save {MAX_SAVED_WORLDS} worlds. Delete one to make room.
             </p>
           )}
           {shelf.error && (
@@ -193,12 +193,12 @@ export function WorldsPanel({
 
         <section className="flex flex-col gap-2 px-4 py-3">
           <h3 style={heading}>
-            On the shelf · {shelf.worlds.length}/{MAX_SAVED_WORLDS}
+            Saved worlds · {shelf.worlds.length}/{MAX_SAVED_WORLDS}
           </h3>
 
           {shelf.worlds.length === 0 && (
             <p style={{ fontSize: 12, color: 'var(--cc-text-muted)' }}>
-              Nothing kept yet. A world you keep comes back exactly as you left it — same ground,
+              No saved worlds yet. A world you save comes back exactly as you left it — same ground,
               same creatures, same hungers.
             </p>
           )}
@@ -299,7 +299,7 @@ export function WorldsPanel({
 
           {!active && shelf.worlds.length > 0 && (
             <p style={{ fontSize: 11, color: 'var(--cc-text-muted)' }}>
-              The land you are in now is not on the shelf. Opening one of these leaves it behind.
+              The land you are in now is not saved. Opening one of these leaves it behind.
             </p>
           )}
         </section>


### PR DESCRIPTION
Follow-up to #2719. `Keep` / `Kept` was left alone in that pass as voice; on a second look it's an affordance problem, not a voice one.

## Why not Save / Load

`Keep` is a verb on a button that keeps nothing — it opens a panel where you name and save this world, open another, or delete one.

Save/Load is the obvious replacement and the wrong model. A saved world here **writes itself back continuously** ("everything you do here is written back on its own"), so there is no snapshot to load and no progress lost by loading one. That's the document model — Google Docs, not a console save screen. The panel's own heading, `Your worlds`, had already landed on the right noun.

Naming the button for what it opens also covers **saving and loading in one word**, instead of a verb that has to pick a side.

| | Was | Now |
|---|---|---|
| HUD | `Keep` / `Kept` | **`Worlds`** |
| Panel | Keep this one | **Save this world** |
| Panel | Kept as | **Saved as** |
| Panel | Keep it / Save now | **Save** |
| Panel | On the shelf · 2/6 | **Saved worlds · 2/6** |
| Panel | Nothing kept yet… | **No saved worlds yet…** |
| Panel | The shelf holds 6. | **You can save 6 worlds.** |
| Panel | …is not on the shelf. | **…is not saved.** |
| Panel | `Your worlds`, `Open`, `Delete` | unchanged |

## One thing the rename cost, and how it's paid back

`Kept` vs `Keep` was doing a second job: telling you at a glance whether this world was being saved. A noun can't carry that, which leaves the chip highlight — **colour alone**, exactly what CLAUDE.md #8 says not to lean on.

The state moved into the button's accessible name (`Worlds — this world is saved` / `…is not saved`) rather than being quietly dropped. The visible cue is still the highlight, which is the same active-chip language `Pause` and the settings button already use in this HUD.

**Worth a second opinion:** if you'd rather the saved state stay visible in text, a small marker on the chip would do it. I didn't add one unasked — it's a design call, and this is her game.

## On "the shelf"

`On the shelf` is a lovely phrase that nobody would think to look under for their saved games. It's gone from the UI; the `shelf` store slice and `MAX_SAVED_WORLDS` keep the name internally, since that's the domain model and renaming it buys the player nothing.

## Testing

- `tsc --noEmit` — 0 errors.
- `npx vitest run src/app/micro-land` — **9 files, 154 tests, all pass**.
- `eslint` + `prettier` clean on both changed files.
- No simulation change, so the ecosystem harness was not run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)