### PR TITLE
feat: exclude custom runs from main leaderboard, add Custom tab (#1292)

### DIFF
--- a/src/app/api/v1/trivia/infinite/leaderboard/route.ts
+++ b/src/app/api/v1/trivia/infinite/leaderboard/route.ts
@@ -5,7 +5,12 @@ import {
   getInfiniteLeaderboardAllCategories,
   getInfiniteTopByCategory,
 } from '@/lib/trivia/categoryMedals'
-import { getInfiniteTopByScore, getInfiniteTopByStreak } from '@/lib/trivia/infiniteRuns'
+import {
+  getCustomTopByScore,
+  getCustomTopByStreak,
+  getInfiniteTopByScore,
+  getInfiniteTopByStreak,
+} from '@/lib/trivia/infiniteRuns'
 
 export async function GET(request: NextRequest) {
   const sort = request.nextUrl.searchParams.get('sort') || 'score'
@@ -40,8 +45,16 @@ export async function GET(request: NextRequest) {
       return NextResponse.json({ sort: 'allCategories', sections })
     }
 
+    if (sort === 'custom') {
+      const customSort = request.nextUrl.searchParams.get('customSort') ?? 'score'
+      const entries = customSort === 'streak'
+        ? await getCustomTopByStreak(20)
+        : await getCustomTopByScore(20)
+      return NextResponse.json({ sort: 'custom', customSort, entries })
+    }
+
     return NextResponse.json(
-      { error: 'Invalid sort. Use score, streak, category, or allCategories.' },
+      { error: 'Invalid sort. Use score, streak, category, allCategories, or custom.' },
       { status: 400 }
     )
   } catch (error: unknown) {

--- a/src/app/trivia/components/InfiniteLeaderboard.tsx
+++ b/src/app/trivia/components/InfiniteLeaderboard.tsx
@@ -13,7 +13,7 @@ import type { MedalTier } from '@/lib/trivia/medals'
 import { SignInBanner } from './SignInCTA'
 import { TriviaFooter } from './TriviaFooter'
 
-type Sort = 'score' | 'streak' | 'allCategories'
+type Sort = 'score' | 'streak' | 'allCategories' | 'custom'
 
 interface OverallEntry {
   uid: string
@@ -52,7 +52,14 @@ interface AllCategoriesResponse {
   notice?: string
 }
 
-type LeaderboardResponse = OverallResponse | AllCategoriesResponse
+interface CustomResponse {
+  sort: 'custom'
+  customSort: 'score' | 'streak'
+  entries: OverallEntry[]
+  notice?: string
+}
+
+type LeaderboardResponse = OverallResponse | AllCategoriesResponse | CustomResponse
 
 const TIER_EMOJI: Record<MedalTier, string> = {
   none: '',
@@ -74,6 +81,7 @@ export function InfiniteLeaderboard({ onBack }: { onBack: () => void }) {
   const { user } = useAuth()
   const { displayName: triviaDisplayName } = useTriviaUser()
   const [sort, setSort] = useState<Sort>('score')
+  const [customSort, setCustomSort] = useState<'score' | 'streak'>('score')
   const [loading, setLoading] = useState(true)
   const [data, setData] = useState<LeaderboardResponse | null>(null)
   const [error, setError] = useState<string | null>(null)
@@ -140,7 +148,10 @@ export function InfiniteLeaderboard({ onBack }: { onBack: () => void }) {
       setLoading(true)
       setError(null)
       try {
-        const res = await fetch(`/api/v1/trivia/infinite/leaderboard?sort=${sort}`, { signal: controller.signal })
+        const url = sort === 'custom'
+          ? `/api/v1/trivia/infinite/leaderboard?sort=${sort}&customSort=${customSort}`
+          : `/api/v1/trivia/infinite/leaderboard?sort=${sort}`
+        const res = await fetch(url, { signal: controller.signal })
         if (!res.ok) throw new Error('Failed to load leaderboard')
         const json = (await res.json()) as LeaderboardResponse
         setData(json)
@@ -153,7 +164,7 @@ export function InfiniteLeaderboard({ onBack }: { onBack: () => void }) {
     }
     load()
     return () => controller.abort()
-  }, [sort])
+  }, [sort, customSort])
 
   const renderContent = () => {
     if (!data) return null
@@ -198,6 +209,58 @@ export function InfiniteLeaderboard({ onBack }: { onBack: () => void }) {
               })}
             </div>
           ))}
+        </div>
+      )
+    }
+
+    if (data.sort === 'custom') {
+      return (
+        <div className="flex flex-col gap-3">
+          <div className="flex gap-2">
+            {(['score', 'streak'] as const).map((s) => (
+              <button
+                key={s}
+                onClick={() => setCustomSort(s)}
+                className={`text-xs px-3 py-1 rounded-full border transition-colors ${
+                  customSort === s
+                    ? 'bg-ds-tertiary text-on-tertiary border-ds-tertiary'
+                    : 'bg-transparent text-on-surface/60 border-outline-variant hover:border-outline'
+                }`}
+              >
+                {s === 'score' ? 'Score' : 'Streak'}
+              </button>
+            ))}
+          </div>
+          {data.entries.length === 0 ? (
+            <div className="text-center text-on-surface/50 py-8 px-4">
+              {data.notice ?? 'No custom runs yet. Be the first!'}
+            </div>
+          ) : (
+            <div className="flex flex-col gap-1.5">
+              {data.entries.map((entry, i) => {
+                const primary = customSort === 'score'
+                  ? `${entry.score.toLocaleString()} pts`
+                  : `${entry.longestStreak} streak`
+                const secondary = entry.customCategory
+                  ? customSort === 'score'
+                    ? `${entry.longestStreak} streak · ${entry.questionsAnswered} Qs · ${entry.customCategory}`
+                    : `${entry.score.toLocaleString()} pts · ${entry.questionsAnswered} Qs · ${entry.customCategory}`
+                  : customSort === 'score'
+                    ? `${entry.longestStreak} streak · ${entry.questionsAnswered} Qs`
+                    : `${entry.score.toLocaleString()} pts · ${entry.questionsAnswered} Qs`
+                return (
+                  <LeaderboardRow
+                    key={`${entry.uid}-${i}`}
+                    rank={i + 1}
+                    name={entry.displayName || 'Unknown'}
+                    primary={primary}
+                    secondary={secondary}
+                    isCurrentUser={!!currentUid && entry.uid === currentUid}
+                  />
+                )
+              })}
+            </div>
+          )}
         </div>
       )
     }
@@ -254,14 +317,14 @@ export function InfiniteLeaderboard({ onBack }: { onBack: () => void }) {
       )}
 
       {/* Sort tabs */}
-      <div className="grid grid-cols-3 gap-2">
-        {(['score', 'streak', 'allCategories'] as Sort[]).map((s) => (
+      <div className="grid grid-cols-4 gap-2">
+        {(['score', 'streak', 'allCategories', 'custom'] as Sort[]).map((s) => (
           <ChunkyButton
             key={s}
             variant={sort === s ? 'primary' : 'secondary'}
             onClick={() => setSort(s)}
           >
-            {s === 'score' ? 'Top Score' : s === 'streak' ? 'Top Streak' : 'By Category'}
+            {s === 'score' ? 'Top Score' : s === 'streak' ? 'Top Streak' : s === 'allCategories' ? 'By Category' : 'Custom'}
           </ChunkyButton>
         ))}
       </div>

--- a/src/lib/trivia/infiniteRuns.ts
+++ b/src/lib/trivia/infiniteRuns.ts
@@ -376,6 +376,10 @@ async function hydrateNicknames(uids: string[]): Promise<Map<string, string>> {
   return map
 }
 
+function isCustomRun(run: RunDoc): boolean {
+  return typeof run.customCategory === 'string' && run.customCategory.length > 0
+}
+
 // Keeps only the first entry per uid. Inputs must already be sorted so that
 // each player's best run appears before their lesser ones.
 function dedupeByUid<T extends { uid: string }>(entries: T[]): T[] {
@@ -416,7 +420,7 @@ export async function getInfiniteTopByScore(limit = 20): Promise<InfiniteLeaderb
       categoryFilters: run.categoryFilters ?? [],
       customCategory: run.customCategory ?? null,
     }
-  })
+  }).filter(e => !e.customCategory)
   const nicknames = await hydrateNicknames(entries.map((e) => e.uid))
   return dedupeByUid(entries.filter((e) => !!nicknames.get(e.uid)))
     .slice(0, limit)
@@ -448,7 +452,73 @@ export async function getInfiniteTopByStreak(limit = 20): Promise<InfiniteLeader
       categoryFilters: run.categoryFilters ?? [],
       customCategory: run.customCategory ?? null,
     }
-  })
+  }).filter(e => !e.customCategory)
+  const nicknames = await hydrateNicknames(entries.map((e) => e.uid))
+  return dedupeByUid(entries.filter((e) => !!nicknames.get(e.uid)))
+    .slice(0, limit)
+    .map((e) => ({
+      ...e,
+      displayName: nicknames.get(e.uid) as string,
+    }))
+}
+
+export async function getCustomTopByScore(limit = 20): Promise<InfiniteLeaderboardEntry[]> {
+  const db = getFirestoreDb()
+  const snap = await db
+    .collectionGroup('triviaInfinite')
+    .where('mode', '==', 'scored')
+    .where('endedAt', '!=', null)
+    .orderBy('score', 'desc')
+    .limit(limit * 20)  // overfetch more since custom runs are sparse
+    .get()
+
+  const entries = snap.docs.map((d) => {
+    const run = d.data() as RunDoc
+    const uid = d.ref.parent.parent?.id ?? ''
+    return {
+      uid,
+      score: run.score,
+      longestStreak: run.longestStreak,
+      questionsAnswered: run.answers?.length ?? 0,
+      date: run.endedAt,
+      categoryFilters: run.categoryFilters ?? [],
+      customCategory: run.customCategory ?? null,
+    }
+  }).filter(e => e.customCategory)  // only custom runs
+
+  const nicknames = await hydrateNicknames(entries.map((e) => e.uid))
+  return dedupeByUid(entries.filter((e) => !!nicknames.get(e.uid)))
+    .slice(0, limit)
+    .map((e) => ({
+      ...e,
+      displayName: nicknames.get(e.uid) as string,
+    }))
+}
+
+export async function getCustomTopByStreak(limit = 20): Promise<InfiniteLeaderboardEntry[]> {
+  const db = getFirestoreDb()
+  const snap = await db
+    .collectionGroup('triviaInfinite')
+    .where('mode', '==', 'scored')
+    .where('endedAt', '!=', null)
+    .orderBy('longestStreak', 'desc')
+    .limit(limit * 20)
+    .get()
+
+  const entries = snap.docs.map((d) => {
+    const run = d.data() as RunDoc
+    const uid = d.ref.parent.parent?.id ?? ''
+    return {
+      uid,
+      score: run.score,
+      longestStreak: run.longestStreak,
+      questionsAnswered: run.answers?.length ?? 0,
+      date: run.endedAt,
+      categoryFilters: run.categoryFilters ?? [],
+      customCategory: run.customCategory ?? null,
+    }
+  }).filter(e => e.customCategory)  // only custom runs
+
   const nicknames = await hydrateNicknames(entries.map((e) => e.uid))
   return dedupeByUid(entries.filter((e) => !!nicknames.get(e.uid)))
     .slice(0, limit)


### PR DESCRIPTION
## Summary
Completes issue #1292 parts 2 and 3 (part 1 is in the base PR #2731):

- **Excludes custom category runs from the main Score and Streak leaderboards** — custom topic runs (where `customCategory` is set) are now post-filtered out after the Firestore query, so a "Pokemon Gen 1" run doesn't compete against "Science & Nature" runs on the global board. Legacy docs without the field are correctly treated as standard runs.
- **New "Custom" tab** on the infinite leaderboard — shows top custom-category runs by score or streak, with a Score/Streak sub-tab. Each entry shows the custom category name. Empty state shown when no custom runs exist yet.
- No new Firestore indexes needed — the filtering is done in application code to avoid the missing-field semantics of `where('customCategory', '==', null)` on legacy documents.

Depends on #2731 (base branch) for the category display helpers.

Partial #1292

## Test plan
- [ ] Standard leaderboard (Score/Streak tabs) no longer shows custom category runs
- [ ] Legacy runs (no `customCategory` field) still appear on main leaderboard
- [ ] Custom tab shows only custom category runs with their topic name
- [ ] Score/Streak sub-tabs on Custom tab re-order the list
- [ ] Empty state shows correctly when no custom runs exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)