### PR TITLE
micro-land: split the land records by plant and animal

### DIFF
--- a/src/app/micro-land/chronicle/__tests__/chronicle.test.ts
+++ b/src/app/micro-land/chronicle/__tests__/chronicle.test.ts
@@ -23,7 +23,7 @@ import {
   emptyChronicle,
   emptyLandRecord,
 } from '@/app/micro-land/chronicle/types'
-import type { ChronicleData } from '@/app/micro-land/chronicle/types'
+import type { ChronicleData, SpeciesRecord } from '@/app/micro-land/chronicle/types'
 import { reserveSummonIds, sanitizeBlueprint } from '@/app/micro-land/domain/blueprint'
 import type { CreatureBlueprint } from '@/app/micro-land/domain/types'
 import {
@@ -560,5 +560,183 @@ describe('mergeChronicles', () => {
     const merged = mergeChronicles(a, b)
     expect(merged.lands.tidepool.steadySeconds).toBe(30)
     expect(merged.lands.volcanic.steadySeconds).toBe(70)
+  })
+
+  it('merges each column on its own, so both devices keep what they held', () => {
+    // The phone watched a hopper line get deep; the laptop grew old kelp.
+    // Neither record should knock the other out on the way in.
+    const a = emptyChronicle()
+    a.lands.tidepool = {
+      ...emptyLandRecord(),
+      byKind: { plant: kelp(400, 9), animal: hopper(0, 0) },
+    }
+    const b = emptyChronicle()
+    b.lands.tidepool = {
+      ...emptyLandRecord(),
+      byKind: { plant: kelp(20, 2), animal: hopper(90, 6) },
+    }
+
+    const merged = mergeChronicles(a, b).lands.tidepool
+    expect(merged.byKind.plant.elder?.seconds).toBe(400)
+    expect(merged.byKind.plant.generations).toBe(9)
+    expect(merged.byKind.animal.elder?.seconds).toBe(90)
+    expect(merged.byKind.animal.generations).toBe(6)
+  })
+
+  it('survives a side whose land record predates the split', () => {
+    // `mergeChronicles` is exported and is handed records that never went
+    // through `migrate` — it must not read `byKind` off a record without one.
+    const a = emptyChronicle()
+    const old = { ...emptyLandRecord(), steadySeconds: 30 }
+    delete (old as Partial<typeof old>).byKind
+    a.lands.tidepool = old
+    const b = emptyChronicle()
+    b.lands.tidepool = {
+      ...emptyLandRecord(),
+      byKind: { plant: kelp(0, 0), animal: hopper(75, 4) },
+    }
+
+    const merged = mergeChronicles(a, b).lands.tidepool
+    expect(merged.steadySeconds).toBe(30)
+    expect(merged.byKind.animal.generations).toBe(4)
+  })
+})
+
+/**
+ * Blueprint stubs that can actually be classified.
+ *
+ * `bp()` above is deliberately hollow, which is the right stub for everything
+ * that only reads a name — but `lifeKind` reaches into `move`, `diet` and
+ * `tags`, so anything testing the plant/animal split needs those present. The
+ * hollow one still earns its keep here: it stands in for a species the archive
+ * can no longer identify.
+ */
+function plantBp(id: string): CreatureBlueprint {
+  return {
+    id,
+    name: id,
+    move: { kind: 'root' },
+    diet: { eats: [] },
+    tags: [],
+  } as unknown as CreatureBlueprint
+}
+
+function animalBp(id: string): CreatureBlueprint {
+  return {
+    id,
+    name: id,
+    move: { kind: 'walk' },
+    diet: { eats: ['plant'] },
+    tags: ['meat'],
+  } as unknown as CreatureBlueprint
+}
+
+function archived(blueprint: CreatureBlueprint): SpeciesRecord {
+  return { blueprint, firstSeen: 1, lastSeen: 2, longestLife: 0 }
+}
+
+function kelp(seconds: number, generations: number) {
+  return column('kelp', 'Kelp', seconds, generations)
+}
+
+function hopper(seconds: number, generations: number) {
+  return column('hopper', 'Hopper', seconds, generations)
+}
+
+function column(id: string, name: string, seconds: number, generations: number) {
+  return {
+    elder: seconds > 0 ? { seconds, blueprintId: id, speciesName: name, name: null, at: 1 } : null,
+    generations,
+    generationsBlueprintId: generations > 0 ? id : null,
+    generationsSpeciesName: generations > 0 ? name : null,
+  }
+}
+
+/** A land record as it was written before `byKind` existed. */
+function preSplitLand(elderId: string, seconds: number, lineId: string, generations: number) {
+  const record = {
+    ...emptyLandRecord(),
+    elder: { seconds, blueprintId: elderId, speciesName: elderId, name: null, at: 1 },
+    generations,
+    generationsBlueprintId: lineId,
+    generationsSpeciesName: lineId,
+  }
+  delete (record as Partial<typeof record>).byKind
+  return record
+}
+
+describe('the plant/animal split', () => {
+  it('files a pre-split record into the column its holder belongs to', async () => {
+    // Both old records were set by kelp, which is where a returning player
+    // should still find them — not wiped, and not sitting under Animals.
+    const stored = emptyChronicle()
+    stored.species.kelp = archived(plantBp('kelp'))
+    stored.lands.tidepool = preSplitLand('kelp', 400, 'kelp', 9)
+    await loadWith(stored)
+
+    const record = landRecord('tidepool')
+    expect(record.byKind.plant.elder?.seconds).toBe(400)
+    expect(record.byKind.plant.generations).toBe(9)
+    expect(record.byKind.animal.elder).toBeNull()
+    expect(record.byKind.animal.generations).toBe(0)
+  })
+
+  it('splits a pre-split record whose two holders were different kinds', async () => {
+    const stored = emptyChronicle()
+    stored.species.kelp = archived(plantBp('kelp'))
+    stored.species.hopper = archived(animalBp('hopper'))
+    stored.lands.tidepool = preSplitLand('kelp', 400, 'hopper', 6)
+    await loadWith(stored)
+
+    const record = landRecord('tidepool')
+    expect(record.byKind.plant.elder?.seconds).toBe(400)
+    expect(record.byKind.plant.generations).toBe(0)
+    expect(record.byKind.animal.elder).toBeNull()
+    expect(record.byKind.animal.generations).toBe(6)
+  })
+
+  it('leaves both columns empty when the holder can no longer be identified', async () => {
+    // Pruned out of the archive, or deleted by the player. Guessing a column
+    // would park the record there forever, since records only move upward.
+    const stored = emptyChronicle()
+    stored.lands.tidepool = preSplitLand('ghost', 400, 'ghost', 9)
+    await loadWith(stored)
+
+    const record = landRecord('tidepool')
+    expect(record.byKind.plant.elder).toBeNull()
+    expect(record.byKind.animal.elder).toBeNull()
+    // The land-wide record it was filed from is untouched.
+    expect(record.elder?.seconds).toBe(400)
+    expect(record.generations).toBe(9)
+  })
+
+  it('does not classify off a half-written archive entry', async () => {
+    // `bp()` has no `move` and no `diet`. Reaching into those out of `migrate`
+    // would throw, and a chronicle that fails to parse must cost the player a
+    // record rather than the game.
+    const stored = emptyChronicle()
+    stored.species.kelp = archived(bp('kelp'))
+    stored.lands.tidepool = preSplitLand('kelp', 400, 'kelp', 9)
+    await loadWith(stored)
+
+    expect(landRecord('tidepool').byKind.plant.elder).toBeNull()
+    expect(landRecord('tidepool').elder?.seconds).toBe(400)
+  })
+
+  it('leaves an already-split record alone', async () => {
+    const stored = emptyChronicle()
+    stored.species.hopper = archived(animalBp('hopper'))
+    stored.lands.tidepool = {
+      ...emptyLandRecord(),
+      // The land-wide elder disagrees with both columns on purpose: a record
+      // that already has columns is the truth, not something to re-derive.
+      elder: { seconds: 400, blueprintId: 'kelp', speciesName: 'Kelp', name: null, at: 1 },
+      byKind: { plant: kelp(0, 0), animal: hopper(90, 6) },
+    }
+    await loadWith(stored)
+
+    const record = landRecord('tidepool')
+    expect(record.byKind.plant.elder).toBeNull()
+    expect(record.byKind.animal.elder?.seconds).toBe(90)
   })
 })

--- a/src/app/micro-land/chronicle/__tests__/wire.test.ts
+++ b/src/app/micro-land/chronicle/__tests__/wire.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest'
 
-import { CHRONICLE_VERSION, emptyChronicle } from '@/app/micro-land/chronicle/types'
+import {
+  CHRONICLE_VERSION,
+  emptyChronicle,
+  emptyLandRecord,
+} from '@/app/micro-land/chronicle/types'
 import type { ChronicleData, SpeciesRecord } from '@/app/micro-land/chronicle/types'
 import {
   MAX_CHRONICLE_BYTES,
@@ -141,7 +145,7 @@ describe('fitChronicle', () => {
   it('never sheds land records or milestones to make room', () => {
     const data = emptyChronicle()
     data.lands.tidepool = {
-      elder: null,
+      ...emptyLandRecord(),
       steadySeconds: 900,
       generations: 4,
       generationsBlueprintId: 'crab',

--- a/src/app/micro-land/chronicle/chronicle.ts
+++ b/src/app/micro-land/chronicle/chronicle.ts
@@ -8,16 +8,19 @@
  * page goes away. Losing the last couple of seconds of a record on a hard crash
  * is an acceptable trade; janking the frame loop is not.
  */
-import type { CreatureBlueprint } from '@/app/micro-land/domain/types'
+import { lifeKind } from '@/app/micro-land/domain/blueprint'
+import { type CreatureBlueprint, LIFE_KINDS, type LifeKind } from '@/app/micro-land/domain/types'
 import { CHRONICLE_SYNC_KEY, readSyncMark, writeSyncMark } from '@/app/micro-land/sync-mark'
 
 import { type ChronicleBackend, INITIAL_DATA, localBackend } from './backend'
 import {
   CHRONICLE_VERSION,
   type ChronicleData,
+  type KindRecord,
   type LandRecord,
   type SpeciesRecord,
   emptyChronicle,
+  emptyKindRecord,
   emptyLandRecord,
 } from './types'
 
@@ -237,12 +240,74 @@ export async function initChronicle(): Promise<ChronicleData> {
 function migrate(stored: ChronicleData | null): ChronicleData {
   if (!stored || typeof stored !== 'object') return emptyChronicle()
   if (stored.version !== CHRONICLE_VERSION) return emptyChronicle()
+  const species = stored.species ?? {}
+  const lands: Record<string, LandRecord> = {}
+  for (const [id, record] of Object.entries(stored.lands ?? {})) {
+    if (record && typeof record === 'object') lands[id] = normalizeLandRecord(record, species)
+  }
   return {
     version: CHRONICLE_VERSION,
-    lands: stored.lands ?? {},
-    species: stored.species ?? {},
+    lands,
+    species,
     milestones: stored.milestones ?? {},
   }
+}
+
+/**
+ * Which side of the food web an archived species was on, if we can still tell.
+ *
+ * The blueprint here came out of storage, so it is only a `CreatureBlueprint` by
+ * assertion — `isPlantLike` reaches into `move`, `diet` and `tags`, and a
+ * half-written archive entry would throw out of `migrate`, which is the one
+ * thing `migrate` may never do. Anything that doesn't look like a blueprint is
+ * simply unclassifiable.
+ */
+function kindOfArchived(
+  blueprintId: string | null | undefined,
+  species: Record<string, SpeciesRecord>
+): LifeKind | null {
+  if (!blueprintId) return null
+  const bp = species[blueprintId]?.blueprint
+  if (!bp || typeof bp !== 'object') return null
+  if (!bp.move || !bp.diet || !Array.isArray(bp.diet.eats) || !Array.isArray(bp.tags)) return null
+  return lifeKind(bp)
+}
+
+/**
+ * Grow a stored land record into the current shape.
+ *
+ * `byKind` arrived after version 1 shipped, so every record written before it
+ * has to be given one. Filing the old land-wide records into a column rather
+ * than starting both columns empty is the point: a player returning to a
+ * fourteen-generation line they set last week should find it under Plants, not
+ * find it apparently wiped.
+ *
+ * A holder that can no longer be classified — pruned out of the archive, or
+ * deleted by the player — leaves the split empty instead of being guessed into a
+ * column. An empty column refills within a minute of play; a plant record parked
+ * under Animals is a lie that never expires, because records only ever move
+ * upward and nothing would beat it.
+ */
+function normalizeLandRecord(
+  record: LandRecord,
+  species: Record<string, SpeciesRecord>
+): LandRecord {
+  const filled: LandRecord = { ...emptyLandRecord(), ...record }
+  if (record.byKind?.plant && record.byKind?.animal) return filled
+
+  const byKind = { plant: emptyKindRecord(), animal: emptyKindRecord() }
+
+  const elderKind = kindOfArchived(record.elder?.blueprintId, species)
+  if (record.elder && elderKind) byKind[elderKind].elder = record.elder
+
+  const lineKind = kindOfArchived(record.generationsBlueprintId, species)
+  if (record.generations > 0 && lineKind) {
+    byKind[lineKind].generations = record.generations
+    byKind[lineKind].generationsBlueprintId = record.generationsBlueprintId
+    byKind[lineKind].generationsSpeciesName = record.generationsSpeciesName
+  }
+
+  return { ...filled, byKind }
 }
 
 export function readChronicle(): ChronicleData {
@@ -454,6 +519,17 @@ function pruneArchive(): void {
  * high-water marks, so "keep the larger" merges cleanly — no conflict, no
  * prompt. Milestones keep the earlier timestamp; a first is a first.
  */
+/** Keep the better of each record in one column. Same high-water-mark rule. */
+function mergeKindRecords(left: KindRecord, right: KindRecord): KindRecord {
+  const deeper = right.generations > left.generations ? right : left
+  return {
+    elder: (right.elder?.seconds ?? 0) > (left.elder?.seconds ?? 0) ? right.elder : left.elder,
+    generations: deeper.generations,
+    generationsBlueprintId: deeper.generationsBlueprintId,
+    generationsSpeciesName: deeper.generationsSpeciesName,
+  }
+}
+
 export function mergeChronicles(a: ChronicleData, b: ChronicleData): ChronicleData {
   const merged = emptyChronicle()
 
@@ -461,12 +537,24 @@ export function mergeChronicles(a: ChronicleData, b: ChronicleData): ChronicleDa
     const left = a.lands[id] ?? emptyLandRecord()
     const right = b.lands[id] ?? emptyLandRecord()
     const deeper = right.generations > left.generations ? right : left
+    // Each column merges on its own, so a phone that holds the animal record and
+    // a laptop that holds the plant one end up with both. `byKind` is defaulted
+    // per side rather than assumed present: `mergeChronicles` is exported and
+    // gets handed records that never went through `migrate`.
+    const byKind = {} as Record<LifeKind, KindRecord>
+    for (const kind of LIFE_KINDS) {
+      byKind[kind] = mergeKindRecords(
+        left.byKind?.[kind] ?? emptyKindRecord(),
+        right.byKind?.[kind] ?? emptyKindRecord()
+      )
+    }
     merged.lands[id] = {
       elder: (right.elder?.seconds ?? 0) > (left.elder?.seconds ?? 0) ? right.elder : left.elder,
       steadySeconds: Math.max(left.steadySeconds, right.steadySeconds),
       generations: deeper.generations,
       generationsBlueprintId: deeper.generationsBlueprintId,
       generationsSpeciesName: deeper.generationsSpeciesName,
+      byKind,
     }
   }
 

--- a/src/app/micro-land/chronicle/types.ts
+++ b/src/app/micro-land/chronicle/types.ts
@@ -13,7 +13,7 @@
  * thing that should have to change is the backend (see `backend.ts`). Anything
  * that isn't serializable breaks that promise.
  */
-import type { CreatureBlueprint } from '@/app/micro-land/domain/types'
+import type { CreatureBlueprint, LifeKind } from '@/app/micro-land/domain/types'
 
 /**
  * Bump only when a shape change would make an old chronicle *misread* rather
@@ -42,6 +42,25 @@ export interface ElderRecord {
 }
 
 /**
+ * The records one kind of life holds in one land.
+ *
+ * Split out because a single set of them is a plant leaderboard wearing a
+ * neutral label. A rooted thing is never chased, never has to find its next
+ * meal, and is restocked by the soil itself, so it outlives and out-breeds every
+ * animal in the world by an order of magnitude — "longest life" and "deepest
+ * family line" were being won by moss on every land, every session, and the
+ * animals the player actually watches could not compete for either. Two columns
+ * gives each half of the food web a record it can plausibly take.
+ */
+export interface KindRecord {
+  elder: ElderRecord | null
+  /** Deepest unbroken family line this kind has reached here, in generations. */
+  generations: number
+  generationsBlueprintId: string | null
+  generationsSpeciesName: string | null
+}
+
+/**
  * What one land remembers.
  *
  * Kept per land rather than globally because these numbers only mean something
@@ -49,6 +68,14 @@ export interface ElderRecord {
  * volcanic field are not the same achievement.
  */
 export interface LandRecord {
+  /**
+   * The single oldest thing this land has ever held, of any kind.
+   *
+   * Kept alongside `byKind` rather than replaced by it because this one is not
+   * only a statistic: it is what the crown is drawn on and what `nameElder`
+   * writes into, and there is one crown. The panel shows the split; the world
+   * shows this.
+   */
   elder: ElderRecord | null
   /** Longest stretch, in world-seconds, that passed without an extinction. */
   steadySeconds: number
@@ -56,6 +83,14 @@ export interface LandRecord {
   generations: number
   generationsBlueprintId: string | null
   generationsSpeciesName: string | null
+  /**
+   * The same records again, kept apart for plants and for animals.
+   *
+   * Added after version 1 shipped, which is why `normalizeLandRecord` exists —
+   * an old chronicle has no `byKind` at all, and every path that can produce a
+   * `LandRecord` runs it through there so nothing downstream has to ask.
+   */
+  byKind: Record<LifeKind, KindRecord>
 }
 
 /**
@@ -90,6 +125,15 @@ export function emptyChronicle(): ChronicleData {
   return { version: CHRONICLE_VERSION, lands: {}, species: {}, milestones: {} }
 }
 
+export function emptyKindRecord(): KindRecord {
+  return {
+    elder: null,
+    generations: 0,
+    generationsBlueprintId: null,
+    generationsSpeciesName: null,
+  }
+}
+
 export function emptyLandRecord(): LandRecord {
   return {
     elder: null,
@@ -97,5 +141,6 @@ export function emptyLandRecord(): LandRecord {
     generations: 0,
     generationsBlueprintId: null,
     generationsSpeciesName: null,
+    byKind: { plant: emptyKindRecord(), animal: emptyKindRecord() },
   }
 }

--- a/src/app/micro-land/components/field-guide.tsx
+++ b/src/app/micro-land/components/field-guide.tsx
@@ -1,8 +1,8 @@
 'use client'
 
-import type { SpeciesRecord } from '@/app/micro-land/chronicle/types'
+import type { ElderRecord, SpeciesRecord } from '@/app/micro-land/chronicle/types'
 import { canEat, moveWord } from '@/app/micro-land/domain/blueprint'
-import type { CreatureBlueprint } from '@/app/micro-land/domain/types'
+import { type CreatureBlueprint, LIFE_KINDS } from '@/app/micro-land/domain/types'
 import { formatDuration } from '@/app/micro-land/format'
 import { useMicroLand } from '@/app/micro-land/store'
 
@@ -23,6 +23,22 @@ const recordLabel: React.CSSProperties = {
   letterSpacing: 1.2,
   textTransform: 'uppercase',
   color: 'var(--cc-text-muted)',
+}
+
+/** The two column headings. Same treatment as a row label, but centred over its column. */
+const columnHeading: React.CSSProperties = {
+  ...recordLabel,
+  textAlign: 'left',
+  paddingBottom: 4,
+}
+
+const recordCell: React.CSSProperties = {
+  fontSize: 13,
+  verticalAlign: 'top',
+  paddingBottom: 8,
+  // The two columns are read against each other, so they get equal width
+  // regardless of which one happens to hold the longer species name.
+  width: '38%',
 }
 
 /**
@@ -113,20 +129,55 @@ export function FieldGuide() {
           >
             <h3 style={sectionHeading}>This land&rsquo;s records</h3>
 
-            {records.elder && (
-              <div className="flex flex-col gap-0.5">
-                <span style={recordLabel}>Longest life</span>
-                <span style={{ fontSize: 13, color: 'var(--cc-gold)' }}>
-                  {formatDuration(records.elder.seconds)}
-                  <span style={{ color: 'var(--cc-text-muted)' }}>
-                    {' — '}
-                    {records.elder.name
-                      ? `${records.elder.name}, a ${records.elder.speciesName}`
-                      : records.elder.speciesName}
-                  </span>
-                </span>
-              </div>
-            )}
+            {/*
+              Two columns rather than one list, because one list is a plant
+              leaderboard. Nothing rooted is ever chased or ever has to find a
+              meal, so moss out-lives and out-breeds every animal in the world by
+              an order of magnitude and took both records on every land, every
+              session — leaving the creatures the player actually watches move
+              with nothing to win. Both columns show at all times, empty ones
+              included: an Animals column that only appeared once an animal had
+              earned something would hide the very thing worth chasing.
+            */}
+            <table style={{ width: '100%', borderCollapse: 'collapse', tableLayout: 'fixed' }}>
+              <thead>
+                <tr>
+                  {/* Empty corner cell — the row labels below are the row headers. */}
+                  <td />
+                  <th scope="col" style={columnHeading}>
+                    Plants
+                  </th>
+                  <th scope="col" style={columnHeading}>
+                    Animals
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <th scope="row" style={{ ...recordLabel, textAlign: 'left', paddingRight: 8 }}>
+                    Longest life
+                  </th>
+                  {LIFE_KINDS.map(kind => (
+                    <td key={kind} style={recordCell}>
+                      <ElderCell elder={records.byKind[kind].elder} />
+                    </td>
+                  ))}
+                </tr>
+                <tr>
+                  <th scope="row" style={{ ...recordLabel, textAlign: 'left', paddingRight: 8 }}>
+                    Deepest family line
+                  </th>
+                  {LIFE_KINDS.map(kind => (
+                    <td key={kind} style={recordCell}>
+                      <LineCell
+                        generations={records.byKind[kind].bestGenerations}
+                        speciesName={records.byKind[kind].bestGenerationsSpeciesName}
+                      />
+                    </td>
+                  ))}
+                </tr>
+              </tbody>
+            </table>
 
             {records.bestSteadySeconds > 0 && (
               <div className="flex flex-col gap-0.5">
@@ -137,21 +188,6 @@ export function FieldGuide() {
                     records.steadySeconds > 0 && (
                       <span style={{ color: 'var(--cc-gold)' }}> — going now</span>
                     )}
-                </span>
-              </div>
-            )}
-
-            {records.bestGenerations > 1 && (
-              <div className="flex flex-col gap-0.5">
-                <span style={recordLabel}>Deepest family line</span>
-                <span style={{ fontSize: 13, color: 'var(--cc-text-default)' }}>
-                  {records.bestGenerations} generations
-                  {records.bestGenerationsSpeciesName && (
-                    <span style={{ color: 'var(--cc-text-muted)' }}>
-                      {' — '}
-                      {records.bestGenerationsSpeciesName}
-                    </span>
-                  )}
                 </span>
               </div>
             )}
@@ -218,6 +254,61 @@ export function FieldGuide() {
         )}
       </div>
     </div>
+  )
+}
+
+/**
+ * A column that has nothing in it yet.
+ *
+ * A dash rather than a blank cell, and rather than nothing at all: an empty cell
+ * reads as a rendering fault, whereas a dash reads as a record still going
+ * spare. It is also the only thing marking the state — never colour alone.
+ */
+function NoRecord() {
+  return (
+    <span style={{ color: 'var(--cc-text-muted)', opacity: 0.55 }}>
+      <span aria-hidden>—</span>
+      <span className="sr-only">none yet</span>
+    </span>
+  )
+}
+
+function ElderCell({ elder }: { elder: ElderRecord | null }) {
+  if (!elder) return <NoRecord />
+  return (
+    <>
+      <span style={{ color: 'var(--cc-gold)' }}>{formatDuration(elder.seconds)}</span>
+      {/* The holder on its own line: two columns of "4m 12s — a sky moss" on a
+          phone wraps into something unreadable, and the number is what is being
+          compared across the columns. */}
+      <br />
+      <span style={{ color: 'var(--cc-text-muted)', fontSize: 12 }}>
+        {elder.name ? `${elder.name}, a ${elder.speciesName}` : elder.speciesName}
+      </span>
+    </>
+  )
+}
+
+function LineCell({
+  generations,
+  speciesName,
+}: {
+  generations: number
+  speciesName: string | null
+}) {
+  // One generation is everything the player put there by hand, so it is not a
+  // family line yet and saying "1 generations" would suggest otherwise.
+  if (generations <= 1) return <NoRecord />
+  return (
+    <>
+      <span style={{ color: 'var(--cc-text-default)' }}>{generations} generations</span>
+      {speciesName && (
+        <>
+          <br />
+          <span style={{ color: 'var(--cc-text-muted)', fontSize: 12 }}>{speciesName}</span>
+        </>
+      )}
+    </>
   )
 }
 

--- a/src/app/micro-land/domain/blueprint.ts
+++ b/src/app/micro-land/domain/blueprint.ts
@@ -16,7 +16,7 @@ import { z } from 'zod'
 import { BASE_MATERIAL_IDS, IS_LIQUID, MATERIAL_IDS, MATERIAL_INDEX } from './config/materials'
 import { TerrainSchema } from './terrain'
 
-import type { CreatureAura, CreatureBlueprint, LocomotionKind, MaterialId } from './types'
+import type { CreatureAura, CreatureBlueprint, LifeKind, LocomotionKind, MaterialId } from './types'
 
 export const ART_MIN = 3
 /**
@@ -669,6 +669,18 @@ export const CREATURE_GROUPS: { id: CreatureGroup; label: string }[] = [
 /** Anything that photosynthesises rather than hunts — moss, coral, a sky flower. */
 export function isPlantLike(bp: CreatureBlueprint): boolean {
   return bp.move.kind === 'root' || (bp.diet.eats.length === 0 && bp.tags.includes('plant'))
+}
+
+/**
+ * Which side of the record book a creature keeps its numbers in.
+ *
+ * The same `isPlantLike` the creature menu files by, said as the two-way split
+ * the chronicle uses, so a species can never be a plant in one place and an
+ * animal in the other. Derived rather than stored for the usual reason: a
+ * creature invented thirty seconds ago has to file itself.
+ */
+export function lifeKind(bp: CreatureBlueprint): LifeKind {
+  return isPlantLike(bp) ? 'plant' : 'animal'
 }
 
 /**

--- a/src/app/micro-land/domain/types.ts
+++ b/src/app/micro-land/domain/types.ts
@@ -48,7 +48,15 @@ export type BaseMaterialId =
 
 /** The colors a tintable material can be painted in. */
 export type TintId =
-  'red' | 'orange' | 'yellow' | 'green' | 'blue' | 'purple' | 'pink' | 'white' | 'black'
+  | 'red'
+  | 'orange'
+  | 'yellow'
+  | 'green'
+  | 'blue'
+  | 'purple'
+  | 'pink'
+  | 'white'
+  | 'black'
 
 /** Materials that come in colors. */
 export type TintableMaterialId = 'plastic' | 'crystal' | 'gem' | 'cloud'
@@ -278,6 +286,20 @@ export interface CreatureBlueprint {
   /** True for anything the player summoned, so we can badge it in the UI. */
   summoned?: boolean
 }
+
+/**
+ * Which half of the food web something belongs to.
+ *
+ * Two buckets rather than the six `CREATURE_GROUPS`, and the reason is that a
+ * record is only worth holding if something is competing for it. Split six ways,
+ * a land with one hunter in it hands that hunter every hunter record forever and
+ * they stop meaning anything. Plant against animal is the one split where both
+ * sides are always crowded.
+ */
+export type LifeKind = 'plant' | 'animal'
+
+/** Display order wherever the two are shown side by side. Plants first. */
+export const LIFE_KINDS: LifeKind[] = ['plant', 'animal']
 
 // ---------------------------------------------------------------------------
 // Live world state

--- a/src/app/micro-land/game-instance.ts
+++ b/src/app/micro-land/game-instance.ts
@@ -29,6 +29,7 @@ import {
   artSize,
   bodyBox,
   forgetBodyBox,
+  lifeKind,
   reserveSummonIds,
   sanitizeBlueprint,
 } from './domain/blueprint'
@@ -53,16 +54,27 @@ import {
   spawnSomewhereSensible,
 } from './domain/sim/world'
 import { TUNING } from './domain/tuning'
+import {
+  type Creature,
+  type CreatureBlueprint,
+  LIFE_KINDS,
+  type LifeKind,
+  type WorldState,
+} from './domain/types'
 import { formatDuration } from './format'
 import { Renderer } from './rendering/renderer'
 import { forgetSprites } from './rendering/sprite-cache'
-import { type EarnedMilestone, type PopulationEntry, useMicroLand } from './store'
+import {
+  type EarnedMilestone,
+  type KindRecordsView,
+  type PopulationEntry,
+  useMicroLand,
+} from './store'
 import { releaseActiveWorld, touchActiveWorld } from './worlds/shelf'
 import { restoreSnapshot, snapshotWorld } from './worlds/snapshot'
 import { WORLD_SAVE_VERSION, type WorldSave } from './worlds/types'
 
 import type { SpeciesRecord } from './chronicle/types'
-import type { Creature, CreatureBlueprint, WorldState } from './domain/types'
 
 /** How often the UI gets a fresh population summary. */
 const STATS_EVERY_MS = 300
@@ -146,6 +158,16 @@ export class GameInstance {
    * its age or its name off by then.
    */
   private elderSnapshot: { name: string | null; species: string; seconds: number } | null = null
+  /**
+   * Who currently holds each column's longevity record.
+   *
+   * Only used to date the record: `at` marks when a record was *taken*, and the
+   * column is rewritten on every stats tick while its holder keeps ageing, so
+   * without knowing whether the holder changed the date would creep forward
+   * forever and no record would ever look old. Not a second crown — the halo,
+   * the eulogy and naming all still follow `elderId`, of which there is one.
+   */
+  private kindElderIds = new Map<LifeKind, number>()
   /** World-clock time the current no-extinction streak began. */
   private steadySince = 0
   /** Archive size at the last push, so the guide is only re-sent when it grows. */
@@ -449,6 +471,12 @@ export class GameInstance {
     // for every kind, and only ever noting the single oldest creature would
     // leave every species but one permanently blank.
     const eldestOf = new Map<string, number>()
+    // And the same two figures per *column*, which is what stops the record
+    // book being a plant leaderboard — see `KindRecord`. Held as creatures
+    // rather than numbers because the record wants the holder's name and
+    // species too.
+    const oldestOfKind = new Map<LifeKind, Creature>()
+    const deepestOfKind = new Map<LifeKind, Creature>()
     for (const c of w.creatures) {
       if (!oldest || c.ageSeconds > oldest.ageSeconds) oldest = c
       if (c.generation > deepest) deepest = c.generation
@@ -456,6 +484,17 @@ export class GameInstance {
       if (best === undefined || c.ageSeconds > best) {
         eldestOf.set(c.blueprintId, c.ageSeconds)
       }
+
+      const bp = w.blueprints[c.blueprintId]
+      // A creature whose blueprint has gone is unclassifiable and unnameable, so
+      // it cannot hold a record either. It still counts toward the land-wide
+      // figures above, which need neither.
+      if (!bp) continue
+      const kind = lifeKind(bp)
+      const kindOldest = oldestOfKind.get(kind)
+      if (!kindOldest || c.ageSeconds > kindOldest.ageSeconds) oldestOfKind.set(kind, c)
+      const kindDeepest = deepestOfKind.get(kind)
+      if (!kindDeepest || c.generation > kindDeepest.generation) deepestOfKind.set(kind, c)
     }
 
     // Every species on screen goes into the guide, and takes its blueprint with
@@ -510,11 +549,58 @@ export class GameInstance {
         record.generationsSpeciesName = bp?.name ?? null
       }
 
+      // --- the same two, per column -------------------------------------
+      // No notice fires from in here. The land-wide record above already
+      // announces itself, and a second line every time an animal beats a
+      // record only animals are competing for would be constant early on,
+      // when generation 2 beats generation 1 and so does 3.
+      for (const kind of LIFE_KINDS) {
+        const column = record.byKind[kind]
+
+        const eldest = oldestOfKind.get(kind)
+        const bestHere = column.elder?.seconds ?? 0
+        if (eldest && eldest.ageSeconds >= ELDER_MIN_SECONDS && eldest.ageSeconds > bestHere) {
+          const bp = w.blueprints[eldest.blueprintId]
+          if (bp) {
+            const taking = this.kindElderIds.get(kind) !== eldest.id
+            this.kindElderIds.set(kind, eldest.id)
+            column.elder = {
+              seconds: eldest.ageSeconds,
+              blueprintId: bp.id,
+              speciesName: bp.name,
+              name: eldest.name,
+              at: taking ? now : (column.elder?.at ?? now),
+            }
+          }
+        }
+
+        const line = deepestOfKind.get(kind)
+        if (line && line.generation > column.generations) {
+          const bp = w.blueprints[line.blueprintId]
+          column.generations = line.generation
+          column.generationsBlueprintId = bp?.id ?? null
+          column.generationsSpeciesName = bp?.name ?? null
+        }
+      }
+
       // --- stability ----------------------------------------------------
       // Banked live rather than only when the streak breaks, so a session that
       // ends by closing the tab still keeps the run it was in the middle of.
       if (steadySeconds > record.steadySeconds) record.steadySeconds = steadySeconds
     })
+
+    // Copied out rather than handed over: `record` is the live chronicle object
+    // and the next stats tick mutates it in place, so passing it into the store
+    // would give React a value that changes without ever being re-set.
+    const byKind = {} as Record<LifeKind, KindRecordsView>
+    for (const kind of LIFE_KINDS) {
+      const column = record.byKind[kind]
+      byKind[kind] = {
+        elder: column.elder,
+        bestGenerations: column.generations,
+        bestGenerationsSpeciesName: column.generationsSpeciesName,
+      }
+    }
 
     store.setRecords({
       elder: record.elder,
@@ -523,6 +609,7 @@ export class GameInstance {
       bestGenerationsSpeciesName: record.generationsSpeciesName,
       steadySeconds,
       deepestGeneration: deepest,
+      byKind,
     })
 
     // Sorted once and shared: both of these want the same list, and it is
@@ -573,6 +660,14 @@ export class GameInstance {
     updateChronicle(() => {
       const record = landRecord(this.currentLand)
       if (record.elder) record.elder.name = trimmed
+      // The crowned creature is also holding its own column's record, near
+      // enough always. Written across so the guide doesn't show the name beside
+      // the land-wide line and the bare species name beside the split one.
+      for (const kind of LIFE_KINDS) {
+        if (this.kindElderIds.get(kind) !== c.id) continue
+        const column = record.byKind[kind]
+        if (column.elder) column.elder.name = trimmed
+      }
     })
     this.pushStats()
     return true
@@ -636,6 +731,9 @@ export class GameInstance {
     // creature the player deliberately removed.
     this.elderId = null
     this.elderSnapshot = null
+    // Creature ids are per-world, so holders carried across a land change would
+    // eventually collide with an unrelated creature and freeze a record's date.
+    this.kindElderIds.clear()
     this.lastArchiveSize = -1
   }
 
@@ -1116,6 +1214,11 @@ export class GameInstance {
           seconds: elder.ageSeconds,
         }
       : null
+    // Not saved, and doesn't need to be: it only decides whether a column's `at`
+    // date refreshes. Left empty, the first stats tick re-dates a record whose
+    // holder survived the reload, which is off by however long the world sat
+    // closed and self-corrects the moment anything beats it.
+    this.kindElderIds.clear()
 
     // Seeded from what is actually alive, so opening a world does not announce
     // the extinction of everything that was in the land it replaced.

--- a/src/app/micro-land/store.ts
+++ b/src/app/micro-land/store.ts
@@ -23,7 +23,7 @@ import {
 
 import type { SaveState } from './chronicle/chronicle'
 import type { ElderRecord, SpeciesRecord } from './chronicle/types'
-import type { CreatureBlueprint, MaterialId } from './domain/types'
+import type { CreatureBlueprint, LifeKind, MaterialId } from './domain/types'
 import type { ShelfState } from './worlds/shelf'
 
 /** Theme id standing for "the land the player summoned". */
@@ -69,6 +69,13 @@ export interface Inspected {
   isElder: boolean
 }
 
+/** One column of the guide's record book — see `KindRecord`. */
+export interface KindRecordsView {
+  elder: ElderRecord | null
+  bestGenerations: number
+  bestGenerationsSpeciesName: string | null
+}
+
 /**
  * Records for the land currently on screen, as the UI wants them.
  *
@@ -77,7 +84,7 @@ export interface Inspected {
  * come from two different places.
  */
 export interface RecordsView {
-  /** Best ever in this land. */
+  /** Best ever in this land, of any kind. Backs the crown, not the panel. */
   elder: ElderRecord | null
   bestSteadySeconds: number
   bestGenerations: number
@@ -85,6 +92,18 @@ export interface RecordsView {
   /** How this run is going. */
   steadySeconds: number
   deepestGeneration: number
+  /**
+   * The two records again, split plant against animal — what the guide shows.
+   *
+   * Flat copies rather than the chronicle's own objects: those are mutated in
+   * place several times a second, and a store value that changes without being
+   * re-set is one React will never re-render for.
+   */
+  byKind: Record<LifeKind, KindRecordsView>
+}
+
+function emptyKindRecords(): KindRecordsView {
+  return { elder: null, bestGenerations: 0, bestGenerationsSpeciesName: null }
 }
 
 export interface EarnedMilestone {
@@ -101,6 +120,7 @@ const EMPTY_RECORDS: RecordsView = {
   bestGenerationsSpeciesName: null,
   steadySeconds: 0,
   deepestGeneration: 0,
+  byKind: { plant: emptyKindRecords(), animal: emptyKindRecords() },
 }
 
 export interface PopulationEntry {


### PR DESCRIPTION
## The problem

One list of records is a plant leaderboard.

Nothing rooted is ever chased, ever has to find its next meal, or has to survive being found — and the seed bank restocks it besides. So moss out-lives and out-breeds every animal in the world by an order of magnitude, and **"Longest life" and "Deepest family line" were won by a plant on every land, in every session.** The creatures the player actually watches move had nothing they could take.

## The change

Every record now exists twice — once for plants, once for animals — and both columns are on screen at all times.

```
THIS LAND'S RECORDS
                     PLANTS          ANIMALS
Longest life         6m 12s          1m 48s
                     sky moss        hopper

Deepest family line  14 generations  4 generations
                     sky moss        hopper

Longest without losing a kind
6m 30s — going now
```

An Animals column that only appeared once an animal had earned something would hide the very thing worth chasing, so an empty one shows a dash. "Longest without losing a kind" stays full-width: an extinction of *any* kind breaks that streak, so it does not split.

## Notes for review

**The split is derived, not declared.** `lifeKind` is the two-way reading of the `isPlantLike` the creature menu already files by, so a creature invented thirty seconds ago sorts itself and no list in the UI has to keep up — invariant 1, a creature is data. Using the same rule in both places also means a species can never be a plant in the menu and an animal in the record book.

**No chronicle version bump.** The land-wide `elder` stays alongside the new columns rather than being replaced, because it is not only a statistic — it is what the halo is drawn on and what `nameElder` writes into, and there is one halo. That keeps this an added field rather than a changed one, so an old chronicle comes up short rather than misreading.

**Old records are filed, not dropped.** Coming up short would still have cost a returning player the fourteen-generation line they set last week, so `migrate` files a pre-split record into a column by looking its holder up in the species archive. A holder that can no longer be identified (pruned from the archive, or deleted by the player) leaves both columns empty rather than being guessed into one — records only ever move upward, so a plant record parked under Animals is a lie nothing could beat, whereas an empty column refills within a minute of play.

**Accessibility.** The panel is a real `<table>` with `scope="col"`/`scope="row"` headers rather than a grid of spans, since this is genuinely two-dimensional data. The holder's name sits *under* the number rather than beside it — two columns of "4m 12s — a sky moss" wraps into mush on a phone, and the number is the thing being compared. The empty state is a dash plus an `sr-only` "none yet", never colour alone.

## Verification

- `tsc` clean; `eslint` and `prettier` clean on every file touched (the pre-existing `toolbar.tsx` `set-state-in-effect` error is untouched and unrelated)
- 161 tests pass, including 7 new ones covering the migration backfill (classified, unclassifiable, half-written archive entry, already-split) and the per-column merge
- `npm run sim:micro-land -- --theme earth --seconds 120` finishes `✓ Still alive` — **the simulation is untouched by this change**

**Not verified: the browser pass.** There is no Playwright/Puppeteer in the repo and micro-land has no component tests (vitest runs `node` and only globs `.test.ts`), so the two-column table's actual layout — particularly on a narrow phone, where three columns of small mono text is the tight case — has not been looked at in a real browser. Worth a look at `/micro-land` before merging.

## Deliberately left alone

- **The crown is still single, and it will still be a plant.** The halo, the eulogy and the right to be named all follow the one oldest creature in the land. Splitting that means two haloes, which touches the renderer and the world-save format.
- **Milestones are unsplit.** `gen-12` and `elder-5m` still fire off whatever gets there first, which is moss. Animal-specific milestones would be new content.

Both are design calls rather than repairs, so they are not in scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)