### PR TITLE
feat(micro-land): zoom the camera in and out

### DIFF
--- a/src/app/micro-land/MicroLandGame.tsx
+++ b/src/app/micro-land/MicroLandGame.tsx
@@ -19,6 +19,7 @@ import { SettingsPanel } from '@/app/micro-land/components/settings-panel'
 import { SummonPanel } from '@/app/micro-land/components/summon-panel'
 import { Toolbar } from '@/app/micro-land/components/toolbar'
 import { WorldsPanel } from '@/app/micro-land/components/worlds-panel'
+import { ZoomControls } from '@/app/micro-land/components/zoom-controls'
 import { THEME_BY_ID } from '@/app/micro-land/domain/config/themes'
 import { hasFertileGround } from '@/app/micro-land/domain/terrain'
 import { GameInstance } from '@/app/micro-land/game-instance'
@@ -292,6 +293,10 @@ export function MicroLandGame() {
     gameRef.current?.nudgePan(direction)
   }, [])
 
+  const handleZoom = useCallback((direction: 1 | -1) => {
+    gameRef.current?.zoomByStep(direction)
+  }, [])
+
   const handleApplyTerrain = useCallback((raw: unknown, keepCreatures: boolean) => {
     const game = gameRef.current
     if (!game) return null
@@ -311,9 +316,10 @@ export function MicroLandGame() {
           tabIndex={0}
           className="absolute inset-0 block h-full w-full touch-none focus:outline-none"
           style={{ imageRendering: 'pixelated', cursor: 'crosshair' }}
-          aria-label="Micro Land world. Tap to place things, drag a creature to pick it up and throw it. Arrow keys scroll across the world."
+          aria-label="Micro Land world. Tap to place things, drag a creature to pick it up and throw it. Arrow keys scroll across the world, plus and minus move closer and further away."
         />
         <PanControls onHold={handleHoldPan} onNudge={handleNudgePan} />
+        <ZoomControls onZoom={handleZoom} />
         <Notices />
         <Inspector onName={handleNameElder} />
       </div>

--- a/src/app/micro-land/chronicle/__tests__/chronicle.test.ts
+++ b/src/app/micro-land/chronicle/__tests__/chronicle.test.ts
@@ -23,7 +23,7 @@ import {
   emptyChronicle,
   emptyLandRecord,
 } from '@/app/micro-land/chronicle/types'
-import type { ChronicleData } from '@/app/micro-land/chronicle/types'
+import type { ChronicleData, SpeciesRecord } from '@/app/micro-land/chronicle/types'
 import { reserveSummonIds, sanitizeBlueprint } from '@/app/micro-land/domain/blueprint'
 import type { CreatureBlueprint } from '@/app/micro-land/domain/types'
 import {
@@ -560,5 +560,183 @@ describe('mergeChronicles', () => {
     const merged = mergeChronicles(a, b)
     expect(merged.lands.tidepool.steadySeconds).toBe(30)
     expect(merged.lands.volcanic.steadySeconds).toBe(70)
+  })
+
+  it('merges each column on its own, so both devices keep what they held', () => {
+    // The phone watched a hopper line get deep; the laptop grew old kelp.
+    // Neither record should knock the other out on the way in.
+    const a = emptyChronicle()
+    a.lands.tidepool = {
+      ...emptyLandRecord(),
+      byKind: { plant: kelp(400, 9), animal: hopper(0, 0) },
+    }
+    const b = emptyChronicle()
+    b.lands.tidepool = {
+      ...emptyLandRecord(),
+      byKind: { plant: kelp(20, 2), animal: hopper(90, 6) },
+    }
+
+    const merged = mergeChronicles(a, b).lands.tidepool
+    expect(merged.byKind.plant.elder?.seconds).toBe(400)
+    expect(merged.byKind.plant.generations).toBe(9)
+    expect(merged.byKind.animal.elder?.seconds).toBe(90)
+    expect(merged.byKind.animal.generations).toBe(6)
+  })
+
+  it('survives a side whose land record predates the split', () => {
+    // `mergeChronicles` is exported and is handed records that never went
+    // through `migrate` — it must not read `byKind` off a record without one.
+    const a = emptyChronicle()
+    const old = { ...emptyLandRecord(), steadySeconds: 30 }
+    delete (old as Partial<typeof old>).byKind
+    a.lands.tidepool = old
+    const b = emptyChronicle()
+    b.lands.tidepool = {
+      ...emptyLandRecord(),
+      byKind: { plant: kelp(0, 0), animal: hopper(75, 4) },
+    }
+
+    const merged = mergeChronicles(a, b).lands.tidepool
+    expect(merged.steadySeconds).toBe(30)
+    expect(merged.byKind.animal.generations).toBe(4)
+  })
+})
+
+/**
+ * Blueprint stubs that can actually be classified.
+ *
+ * `bp()` above is deliberately hollow, which is the right stub for everything
+ * that only reads a name — but `lifeKind` reaches into `move`, `diet` and
+ * `tags`, so anything testing the plant/animal split needs those present. The
+ * hollow one still earns its keep here: it stands in for a species the archive
+ * can no longer identify.
+ */
+function plantBp(id: string): CreatureBlueprint {
+  return {
+    id,
+    name: id,
+    move: { kind: 'root' },
+    diet: { eats: [] },
+    tags: [],
+  } as unknown as CreatureBlueprint
+}
+
+function animalBp(id: string): CreatureBlueprint {
+  return {
+    id,
+    name: id,
+    move: { kind: 'walk' },
+    diet: { eats: ['plant'] },
+    tags: ['meat'],
+  } as unknown as CreatureBlueprint
+}
+
+function archived(blueprint: CreatureBlueprint): SpeciesRecord {
+  return { blueprint, firstSeen: 1, lastSeen: 2, longestLife: 0 }
+}
+
+function kelp(seconds: number, generations: number) {
+  return column('kelp', 'Kelp', seconds, generations)
+}
+
+function hopper(seconds: number, generations: number) {
+  return column('hopper', 'Hopper', seconds, generations)
+}
+
+function column(id: string, name: string, seconds: number, generations: number) {
+  return {
+    elder: seconds > 0 ? { seconds, blueprintId: id, speciesName: name, name: null, at: 1 } : null,
+    generations,
+    generationsBlueprintId: generations > 0 ? id : null,
+    generationsSpeciesName: generations > 0 ? name : null,
+  }
+}
+
+/** A land record as it was written before `byKind` existed. */
+function preSplitLand(elderId: string, seconds: number, lineId: string, generations: number) {
+  const record = {
+    ...emptyLandRecord(),
+    elder: { seconds, blueprintId: elderId, speciesName: elderId, name: null, at: 1 },
+    generations,
+    generationsBlueprintId: lineId,
+    generationsSpeciesName: lineId,
+  }
+  delete (record as Partial<typeof record>).byKind
+  return record
+}
+
+describe('the plant/animal split', () => {
+  it('files a pre-split record into the column its holder belongs to', async () => {
+    // Both old records were set by kelp, which is where a returning player
+    // should still find them — not wiped, and not sitting under Animals.
+    const stored = emptyChronicle()
+    stored.species.kelp = archived(plantBp('kelp'))
+    stored.lands.tidepool = preSplitLand('kelp', 400, 'kelp', 9)
+    await loadWith(stored)
+
+    const record = landRecord('tidepool')
+    expect(record.byKind.plant.elder?.seconds).toBe(400)
+    expect(record.byKind.plant.generations).toBe(9)
+    expect(record.byKind.animal.elder).toBeNull()
+    expect(record.byKind.animal.generations).toBe(0)
+  })
+
+  it('splits a pre-split record whose two holders were different kinds', async () => {
+    const stored = emptyChronicle()
+    stored.species.kelp = archived(plantBp('kelp'))
+    stored.species.hopper = archived(animalBp('hopper'))
+    stored.lands.tidepool = preSplitLand('kelp', 400, 'hopper', 6)
+    await loadWith(stored)
+
+    const record = landRecord('tidepool')
+    expect(record.byKind.plant.elder?.seconds).toBe(400)
+    expect(record.byKind.plant.generations).toBe(0)
+    expect(record.byKind.animal.elder).toBeNull()
+    expect(record.byKind.animal.generations).toBe(6)
+  })
+
+  it('leaves both columns empty when the holder can no longer be identified', async () => {
+    // Pruned out of the archive, or deleted by the player. Guessing a column
+    // would park the record there forever, since records only move upward.
+    const stored = emptyChronicle()
+    stored.lands.tidepool = preSplitLand('ghost', 400, 'ghost', 9)
+    await loadWith(stored)
+
+    const record = landRecord('tidepool')
+    expect(record.byKind.plant.elder).toBeNull()
+    expect(record.byKind.animal.elder).toBeNull()
+    // The land-wide record it was filed from is untouched.
+    expect(record.elder?.seconds).toBe(400)
+    expect(record.generations).toBe(9)
+  })
+
+  it('does not classify off a half-written archive entry', async () => {
+    // `bp()` has no `move` and no `diet`. Reaching into those out of `migrate`
+    // would throw, and a chronicle that fails to parse must cost the player a
+    // record rather than the game.
+    const stored = emptyChronicle()
+    stored.species.kelp = archived(bp('kelp'))
+    stored.lands.tidepool = preSplitLand('kelp', 400, 'kelp', 9)
+    await loadWith(stored)
+
+    expect(landRecord('tidepool').byKind.plant.elder).toBeNull()
+    expect(landRecord('tidepool').elder?.seconds).toBe(400)
+  })
+
+  it('leaves an already-split record alone', async () => {
+    const stored = emptyChronicle()
+    stored.species.hopper = archived(animalBp('hopper'))
+    stored.lands.tidepool = {
+      ...emptyLandRecord(),
+      // The land-wide elder disagrees with both columns on purpose: a record
+      // that already has columns is the truth, not something to re-derive.
+      elder: { seconds: 400, blueprintId: 'kelp', speciesName: 'Kelp', name: null, at: 1 },
+      byKind: { plant: kelp(0, 0), animal: hopper(90, 6) },
+    }
+    await loadWith(stored)
+
+    const record = landRecord('tidepool')
+    expect(record.byKind.plant.elder).toBeNull()
+    expect(record.byKind.animal.elder?.seconds).toBe(90)
   })
 })

--- a/src/app/micro-land/chronicle/__tests__/wire.test.ts
+++ b/src/app/micro-land/chronicle/__tests__/wire.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest'
 
-import { CHRONICLE_VERSION, emptyChronicle } from '@/app/micro-land/chronicle/types'
+import {
+  CHRONICLE_VERSION,
+  emptyChronicle,
+  emptyLandRecord,
+} from '@/app/micro-land/chronicle/types'
 import type { ChronicleData, SpeciesRecord } from '@/app/micro-land/chronicle/types'
 import {
   MAX_CHRONICLE_BYTES,
@@ -141,7 +145,7 @@ describe('fitChronicle', () => {
   it('never sheds land records or milestones to make room', () => {
     const data = emptyChronicle()
     data.lands.tidepool = {
-      elder: null,
+      ...emptyLandRecord(),
       steadySeconds: 900,
       generations: 4,
       generationsBlueprintId: 'crab',

--- a/src/app/micro-land/chronicle/chronicle.ts
+++ b/src/app/micro-land/chronicle/chronicle.ts
@@ -8,16 +8,19 @@
  * page goes away. Losing the last couple of seconds of a record on a hard crash
  * is an acceptable trade; janking the frame loop is not.
  */
-import type { CreatureBlueprint } from '@/app/micro-land/domain/types'
+import { lifeKind } from '@/app/micro-land/domain/blueprint'
+import { type CreatureBlueprint, LIFE_KINDS, type LifeKind } from '@/app/micro-land/domain/types'
 import { CHRONICLE_SYNC_KEY, readSyncMark, writeSyncMark } from '@/app/micro-land/sync-mark'
 
 import { type ChronicleBackend, INITIAL_DATA, localBackend } from './backend'
 import {
   CHRONICLE_VERSION,
   type ChronicleData,
+  type KindRecord,
   type LandRecord,
   type SpeciesRecord,
   emptyChronicle,
+  emptyKindRecord,
   emptyLandRecord,
 } from './types'
 
@@ -237,12 +240,74 @@ export async function initChronicle(): Promise<ChronicleData> {
 function migrate(stored: ChronicleData | null): ChronicleData {
   if (!stored || typeof stored !== 'object') return emptyChronicle()
   if (stored.version !== CHRONICLE_VERSION) return emptyChronicle()
+  const species = stored.species ?? {}
+  const lands: Record<string, LandRecord> = {}
+  for (const [id, record] of Object.entries(stored.lands ?? {})) {
+    if (record && typeof record === 'object') lands[id] = normalizeLandRecord(record, species)
+  }
   return {
     version: CHRONICLE_VERSION,
-    lands: stored.lands ?? {},
-    species: stored.species ?? {},
+    lands,
+    species,
     milestones: stored.milestones ?? {},
   }
+}
+
+/**
+ * Which side of the food web an archived species was on, if we can still tell.
+ *
+ * The blueprint here came out of storage, so it is only a `CreatureBlueprint` by
+ * assertion — `isPlantLike` reaches into `move`, `diet` and `tags`, and a
+ * half-written archive entry would throw out of `migrate`, which is the one
+ * thing `migrate` may never do. Anything that doesn't look like a blueprint is
+ * simply unclassifiable.
+ */
+function kindOfArchived(
+  blueprintId: string | null | undefined,
+  species: Record<string, SpeciesRecord>
+): LifeKind | null {
+  if (!blueprintId) return null
+  const bp = species[blueprintId]?.blueprint
+  if (!bp || typeof bp !== 'object') return null
+  if (!bp.move || !bp.diet || !Array.isArray(bp.diet.eats) || !Array.isArray(bp.tags)) return null
+  return lifeKind(bp)
+}
+
+/**
+ * Grow a stored land record into the current shape.
+ *
+ * `byKind` arrived after version 1 shipped, so every record written before it
+ * has to be given one. Filing the old land-wide records into a column rather
+ * than starting both columns empty is the point: a player returning to a
+ * fourteen-generation line they set last week should find it under Plants, not
+ * find it apparently wiped.
+ *
+ * A holder that can no longer be classified — pruned out of the archive, or
+ * deleted by the player — leaves the split empty instead of being guessed into a
+ * column. An empty column refills within a minute of play; a plant record parked
+ * under Animals is a lie that never expires, because records only ever move
+ * upward and nothing would beat it.
+ */
+function normalizeLandRecord(
+  record: LandRecord,
+  species: Record<string, SpeciesRecord>
+): LandRecord {
+  const filled: LandRecord = { ...emptyLandRecord(), ...record }
+  if (record.byKind?.plant && record.byKind?.animal) return filled
+
+  const byKind = { plant: emptyKindRecord(), animal: emptyKindRecord() }
+
+  const elderKind = kindOfArchived(record.elder?.blueprintId, species)
+  if (record.elder && elderKind) byKind[elderKind].elder = record.elder
+
+  const lineKind = kindOfArchived(record.generationsBlueprintId, species)
+  if (record.generations > 0 && lineKind) {
+    byKind[lineKind].generations = record.generations
+    byKind[lineKind].generationsBlueprintId = record.generationsBlueprintId
+    byKind[lineKind].generationsSpeciesName = record.generationsSpeciesName
+  }
+
+  return { ...filled, byKind }
 }
 
 export function readChronicle(): ChronicleData {
@@ -454,6 +519,17 @@ function pruneArchive(): void {
  * high-water marks, so "keep the larger" merges cleanly — no conflict, no
  * prompt. Milestones keep the earlier timestamp; a first is a first.
  */
+/** Keep the better of each record in one column. Same high-water-mark rule. */
+function mergeKindRecords(left: KindRecord, right: KindRecord): KindRecord {
+  const deeper = right.generations > left.generations ? right : left
+  return {
+    elder: (right.elder?.seconds ?? 0) > (left.elder?.seconds ?? 0) ? right.elder : left.elder,
+    generations: deeper.generations,
+    generationsBlueprintId: deeper.generationsBlueprintId,
+    generationsSpeciesName: deeper.generationsSpeciesName,
+  }
+}
+
 export function mergeChronicles(a: ChronicleData, b: ChronicleData): ChronicleData {
   const merged = emptyChronicle()
 
@@ -461,12 +537,24 @@ export function mergeChronicles(a: ChronicleData, b: ChronicleData): ChronicleDa
     const left = a.lands[id] ?? emptyLandRecord()
     const right = b.lands[id] ?? emptyLandRecord()
     const deeper = right.generations > left.generations ? right : left
+    // Each column merges on its own, so a phone that holds the animal record and
+    // a laptop that holds the plant one end up with both. `byKind` is defaulted
+    // per side rather than assumed present: `mergeChronicles` is exported and
+    // gets handed records that never went through `migrate`.
+    const byKind = {} as Record<LifeKind, KindRecord>
+    for (const kind of LIFE_KINDS) {
+      byKind[kind] = mergeKindRecords(
+        left.byKind?.[kind] ?? emptyKindRecord(),
+        right.byKind?.[kind] ?? emptyKindRecord()
+      )
+    }
     merged.lands[id] = {
       elder: (right.elder?.seconds ?? 0) > (left.elder?.seconds ?? 0) ? right.elder : left.elder,
       steadySeconds: Math.max(left.steadySeconds, right.steadySeconds),
       generations: deeper.generations,
       generationsBlueprintId: deeper.generationsBlueprintId,
       generationsSpeciesName: deeper.generationsSpeciesName,
+      byKind,
     }
   }
 

--- a/src/app/micro-land/chronicle/types.ts
+++ b/src/app/micro-land/chronicle/types.ts
@@ -13,7 +13,7 @@
  * thing that should have to change is the backend (see `backend.ts`). Anything
  * that isn't serializable breaks that promise.
  */
-import type { CreatureBlueprint } from '@/app/micro-land/domain/types'
+import type { CreatureBlueprint, LifeKind } from '@/app/micro-land/domain/types'
 
 /**
  * Bump only when a shape change would make an old chronicle *misread* rather
@@ -42,6 +42,25 @@ export interface ElderRecord {
 }
 
 /**
+ * The records one kind of life holds in one land.
+ *
+ * Split out because a single set of them is a plant leaderboard wearing a
+ * neutral label. A rooted thing is never chased, never has to find its next
+ * meal, and is restocked by the soil itself, so it outlives and out-breeds every
+ * animal in the world by an order of magnitude — "longest life" and "deepest
+ * family line" were being won by moss on every land, every session, and the
+ * animals the player actually watches could not compete for either. Two columns
+ * gives each half of the food web a record it can plausibly take.
+ */
+export interface KindRecord {
+  elder: ElderRecord | null
+  /** Deepest unbroken family line this kind has reached here, in generations. */
+  generations: number
+  generationsBlueprintId: string | null
+  generationsSpeciesName: string | null
+}
+
+/**
  * What one land remembers.
  *
  * Kept per land rather than globally because these numbers only mean something
@@ -49,6 +68,14 @@ export interface ElderRecord {
  * volcanic field are not the same achievement.
  */
 export interface LandRecord {
+  /**
+   * The single oldest thing this land has ever held, of any kind.
+   *
+   * Kept alongside `byKind` rather than replaced by it because this one is not
+   * only a statistic: it is what the crown is drawn on and what `nameElder`
+   * writes into, and there is one crown. The panel shows the split; the world
+   * shows this.
+   */
   elder: ElderRecord | null
   /** Longest stretch, in world-seconds, that passed without an extinction. */
   steadySeconds: number
@@ -56,6 +83,14 @@ export interface LandRecord {
   generations: number
   generationsBlueprintId: string | null
   generationsSpeciesName: string | null
+  /**
+   * The same records again, kept apart for plants and for animals.
+   *
+   * Added after version 1 shipped, which is why `normalizeLandRecord` exists —
+   * an old chronicle has no `byKind` at all, and every path that can produce a
+   * `LandRecord` runs it through there so nothing downstream has to ask.
+   */
+  byKind: Record<LifeKind, KindRecord>
 }
 
 /**
@@ -90,6 +125,15 @@ export function emptyChronicle(): ChronicleData {
   return { version: CHRONICLE_VERSION, lands: {}, species: {}, milestones: {} }
 }
 
+export function emptyKindRecord(): KindRecord {
+  return {
+    elder: null,
+    generations: 0,
+    generationsBlueprintId: null,
+    generationsSpeciesName: null,
+  }
+}
+
 export function emptyLandRecord(): LandRecord {
   return {
     elder: null,
@@ -97,5 +141,6 @@ export function emptyLandRecord(): LandRecord {
     generations: 0,
     generationsBlueprintId: null,
     generationsSpeciesName: null,
+    byKind: { plant: emptyKindRecord(), animal: emptyKindRecord() },
   }
 }

--- a/src/app/micro-land/components/field-guide.tsx
+++ b/src/app/micro-land/components/field-guide.tsx
@@ -1,8 +1,8 @@
 'use client'
 
-import type { SpeciesRecord } from '@/app/micro-land/chronicle/types'
+import type { ElderRecord, SpeciesRecord } from '@/app/micro-land/chronicle/types'
 import { canEat, moveWord } from '@/app/micro-land/domain/blueprint'
-import type { CreatureBlueprint } from '@/app/micro-land/domain/types'
+import { type CreatureBlueprint, LIFE_KINDS } from '@/app/micro-land/domain/types'
 import { formatDuration } from '@/app/micro-land/format'
 import { useMicroLand } from '@/app/micro-land/store'
 
@@ -23,6 +23,22 @@ const recordLabel: React.CSSProperties = {
   letterSpacing: 1.2,
   textTransform: 'uppercase',
   color: 'var(--cc-text-muted)',
+}
+
+/** The two column headings. Same treatment as a row label, but centred over its column. */
+const columnHeading: React.CSSProperties = {
+  ...recordLabel,
+  textAlign: 'left',
+  paddingBottom: 4,
+}
+
+const recordCell: React.CSSProperties = {
+  fontSize: 13,
+  verticalAlign: 'top',
+  paddingBottom: 8,
+  // The two columns are read against each other, so they get equal width
+  // regardless of which one happens to hold the longer species name.
+  width: '38%',
 }
 
 /**
@@ -113,20 +129,55 @@ export function FieldGuide() {
           >
             <h3 style={sectionHeading}>This land&rsquo;s records</h3>
 
-            {records.elder && (
-              <div className="flex flex-col gap-0.5">
-                <span style={recordLabel}>Longest life</span>
-                <span style={{ fontSize: 13, color: 'var(--cc-gold)' }}>
-                  {formatDuration(records.elder.seconds)}
-                  <span style={{ color: 'var(--cc-text-muted)' }}>
-                    {' — '}
-                    {records.elder.name
-                      ? `${records.elder.name}, a ${records.elder.speciesName}`
-                      : records.elder.speciesName}
-                  </span>
-                </span>
-              </div>
-            )}
+            {/*
+              Two columns rather than one list, because one list is a plant
+              leaderboard. Nothing rooted is ever chased or ever has to find a
+              meal, so moss out-lives and out-breeds every animal in the world by
+              an order of magnitude and took both records on every land, every
+              session — leaving the creatures the player actually watches move
+              with nothing to win. Both columns show at all times, empty ones
+              included: an Animals column that only appeared once an animal had
+              earned something would hide the very thing worth chasing.
+            */}
+            <table style={{ width: '100%', borderCollapse: 'collapse', tableLayout: 'fixed' }}>
+              <thead>
+                <tr>
+                  {/* Empty corner cell — the row labels below are the row headers. */}
+                  <td />
+                  <th scope="col" style={columnHeading}>
+                    Plants
+                  </th>
+                  <th scope="col" style={columnHeading}>
+                    Animals
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <th scope="row" style={{ ...recordLabel, textAlign: 'left', paddingRight: 8 }}>
+                    Longest life
+                  </th>
+                  {LIFE_KINDS.map(kind => (
+                    <td key={kind} style={recordCell}>
+                      <ElderCell elder={records.byKind[kind].elder} />
+                    </td>
+                  ))}
+                </tr>
+                <tr>
+                  <th scope="row" style={{ ...recordLabel, textAlign: 'left', paddingRight: 8 }}>
+                    Deepest family line
+                  </th>
+                  {LIFE_KINDS.map(kind => (
+                    <td key={kind} style={recordCell}>
+                      <LineCell
+                        generations={records.byKind[kind].bestGenerations}
+                        speciesName={records.byKind[kind].bestGenerationsSpeciesName}
+                      />
+                    </td>
+                  ))}
+                </tr>
+              </tbody>
+            </table>
 
             {records.bestSteadySeconds > 0 && (
               <div className="flex flex-col gap-0.5">
@@ -137,21 +188,6 @@ export function FieldGuide() {
                     records.steadySeconds > 0 && (
                       <span style={{ color: 'var(--cc-gold)' }}> — going now</span>
                     )}
-                </span>
-              </div>
-            )}
-
-            {records.bestGenerations > 1 && (
-              <div className="flex flex-col gap-0.5">
-                <span style={recordLabel}>Deepest family line</span>
-                <span style={{ fontSize: 13, color: 'var(--cc-text-default)' }}>
-                  {records.bestGenerations} generations
-                  {records.bestGenerationsSpeciesName && (
-                    <span style={{ color: 'var(--cc-text-muted)' }}>
-                      {' — '}
-                      {records.bestGenerationsSpeciesName}
-                    </span>
-                  )}
                 </span>
               </div>
             )}
@@ -218,6 +254,61 @@ export function FieldGuide() {
         )}
       </div>
     </div>
+  )
+}
+
+/**
+ * A column that has nothing in it yet.
+ *
+ * A dash rather than a blank cell, and rather than nothing at all: an empty cell
+ * reads as a rendering fault, whereas a dash reads as a record still going
+ * spare. It is also the only thing marking the state — never colour alone.
+ */
+function NoRecord() {
+  return (
+    <span style={{ color: 'var(--cc-text-muted)', opacity: 0.55 }}>
+      <span aria-hidden>—</span>
+      <span className="sr-only">none yet</span>
+    </span>
+  )
+}
+
+function ElderCell({ elder }: { elder: ElderRecord | null }) {
+  if (!elder) return <NoRecord />
+  return (
+    <>
+      <span style={{ color: 'var(--cc-gold)' }}>{formatDuration(elder.seconds)}</span>
+      {/* The holder on its own line: two columns of "4m 12s — a sky moss" on a
+          phone wraps into something unreadable, and the number is what is being
+          compared across the columns. */}
+      <br />
+      <span style={{ color: 'var(--cc-text-muted)', fontSize: 12 }}>
+        {elder.name ? `${elder.name}, a ${elder.speciesName}` : elder.speciesName}
+      </span>
+    </>
+  )
+}
+
+function LineCell({
+  generations,
+  speciesName,
+}: {
+  generations: number
+  speciesName: string | null
+}) {
+  // One generation is everything the player put there by hand, so it is not a
+  // family line yet and saying "1 generations" would suggest otherwise.
+  if (generations <= 1) return <NoRecord />
+  return (
+    <>
+      <span style={{ color: 'var(--cc-text-default)' }}>{generations} generations</span>
+      {speciesName && (
+        <>
+          <br />
+          <span style={{ color: 'var(--cc-text-muted)', fontSize: 12 }}>{speciesName}</span>
+        </>
+      )}
+    </>
   )
 }
 

--- a/src/app/micro-land/components/zoom-controls.tsx
+++ b/src/app/micro-land/components/zoom-controls.tsx
@@ -1,0 +1,68 @@
+'use client'
+
+import { useMicroLand } from '@/app/micro-land/store'
+
+/**
+ * The two buttons that change how close you are standing.
+ *
+ * Every other way of zooming is a gesture you have to already know — a pinch, a
+ * ctrl-wheel, a key — and the terrarium is for people who have never used any of
+ * them. These are the version a small child can find and a screen reader can
+ * announce, which is the only reason they are on screen at all.
+ *
+ * A tap each, no hold: unlike panning, where you often want to travel a long way
+ * and holding is the natural thing, there are only five or six steps from end to
+ * end of the range and a held button would blow through all of them.
+ *
+ * They live at the bottom-right rather than beside the pan arrows, which sit at
+ * the vertical middle of each edge: stacking four controls down one side turns
+ * the edge of the world into a toolbar, and the pan arrows are the ones that
+ * have to stay in the same place they have always been.
+ */
+export function ZoomControls({ onZoom }: { onZoom: (direction: 1 | -1) => void }) {
+  const canZoomIn = useMicroLand(s => s.canZoomIn)
+  const canZoomOut = useMicroLand(s => s.canZoomOut)
+
+  const button = (direction: 1 | -1, enabled: boolean) => (
+    <button
+      type="button"
+      // In the cave's voice rather than "zoom in" — the chrome narrates, it
+      // doesn't label a control panel.
+      aria-label={direction === 1 ? 'Look closer' : 'Look further out'}
+      disabled={!enabled}
+      className="pointer-events-auto flex h-11 w-9 items-center justify-center rounded-lg backdrop-blur-sm transition-opacity hover:opacity-100 focus-visible:opacity-100 disabled:cursor-default disabled:hover:opacity-25"
+      style={{
+        color: 'var(--cc-text-default)',
+        background: 'rgba(2, 8, 10, 0.6)',
+        border: '1px solid var(--cc-mint-line)',
+        // Faded rather than hidden at the end of the range: a button that
+        // vanishes takes the other one with it on the way past your thumb.
+        opacity: enabled ? 0.62 : 0.25,
+        touchAction: 'none',
+      }}
+      onPointerDown={e => e.preventDefault()}
+      onClick={() => onZoom(direction)}
+    >
+      <svg
+        width="14"
+        height="14"
+        viewBox="0 0 14 14"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        aria-hidden="true"
+      >
+        <line x1="2" y1="7" x2="12" y2="7" />
+        {direction === 1 && <line x1="7" y1="2" x2="7" y2="12" />}
+      </svg>
+    </button>
+  )
+
+  return (
+    <div className="pointer-events-none absolute bottom-2 right-2 flex flex-col gap-1.5">
+      {button(1, canZoomIn)}
+      {button(-1, canZoomOut)}
+    </div>
+  )
+}

--- a/src/app/micro-land/domain/blueprint.ts
+++ b/src/app/micro-land/domain/blueprint.ts
@@ -16,7 +16,7 @@ import { z } from 'zod'
 import { BASE_MATERIAL_IDS, IS_LIQUID, MATERIAL_IDS, MATERIAL_INDEX } from './config/materials'
 import { TerrainSchema } from './terrain'
 
-import type { CreatureAura, CreatureBlueprint, LocomotionKind, MaterialId } from './types'
+import type { CreatureAura, CreatureBlueprint, LifeKind, LocomotionKind, MaterialId } from './types'
 
 export const ART_MIN = 3
 /**
@@ -669,6 +669,18 @@ export const CREATURE_GROUPS: { id: CreatureGroup; label: string }[] = [
 /** Anything that photosynthesises rather than hunts — moss, coral, a sky flower. */
 export function isPlantLike(bp: CreatureBlueprint): boolean {
   return bp.move.kind === 'root' || (bp.diet.eats.length === 0 && bp.tags.includes('plant'))
+}
+
+/**
+ * Which side of the record book a creature keeps its numbers in.
+ *
+ * The same `isPlantLike` the creature menu files by, said as the two-way split
+ * the chronicle uses, so a species can never be a plant in one place and an
+ * animal in the other. Derived rather than stored for the usual reason: a
+ * creature invented thirty seconds ago has to file itself.
+ */
+export function lifeKind(bp: CreatureBlueprint): LifeKind {
+  return isPlantLike(bp) ? 'plant' : 'animal'
 }
 
 /**

--- a/src/app/micro-land/domain/types.ts
+++ b/src/app/micro-land/domain/types.ts
@@ -48,7 +48,15 @@ export type BaseMaterialId =
 
 /** The colors a tintable material can be painted in. */
 export type TintId =
-  'red' | 'orange' | 'yellow' | 'green' | 'blue' | 'purple' | 'pink' | 'white' | 'black'
+  | 'red'
+  | 'orange'
+  | 'yellow'
+  | 'green'
+  | 'blue'
+  | 'purple'
+  | 'pink'
+  | 'white'
+  | 'black'
 
 /** Materials that come in colors. */
 export type TintableMaterialId = 'plastic' | 'crystal' | 'gem' | 'cloud'
@@ -278,6 +286,20 @@ export interface CreatureBlueprint {
   /** True for anything the player summoned, so we can badge it in the UI. */
   summoned?: boolean
 }
+
+/**
+ * Which half of the food web something belongs to.
+ *
+ * Two buckets rather than the six `CREATURE_GROUPS`, and the reason is that a
+ * record is only worth holding if something is competing for it. Split six ways,
+ * a land with one hunter in it hands that hunter every hunter record forever and
+ * they stop meaning anything. Plant against animal is the one split where both
+ * sides are always crowded.
+ */
+export type LifeKind = 'plant' | 'animal'
+
+/** Display order wherever the two are shown side by side. Plants first. */
+export const LIFE_KINDS: LifeKind[] = ['plant', 'animal']
 
 // ---------------------------------------------------------------------------
 // Live world state

--- a/src/app/micro-land/game-instance.ts
+++ b/src/app/micro-land/game-instance.ts
@@ -127,6 +127,16 @@ const FOLLOW_SPEED = 90
 /** Drag further than this and a tap was really a pan. CSS pixels. */
 const TAP_SLOP = 6
 
+/**
+ * How much zoom one notch of a ctrl-wheel is worth.
+ *
+ * A trackpad pinch on macOS arrives as a wheel event with `ctrlKey` set and a
+ * delta of a few pixels per frame, so this has to be gentle enough that a pinch
+ * is smooth; a mouse wheel sends one large delta per notch and gets a whole step
+ * out of the same number.
+ */
+const WHEEL_ZOOM_RATE = 0.0125
+
 export class GameInstance {
   private canvas: HTMLCanvasElement
   private renderer: Renderer
@@ -193,14 +203,33 @@ export class GameInstance {
   private resizeObserver: ResizeObserver | null = null
 
   // --- camera state ---
-  /** Every pointer currently down, so a second finger can be noticed. */
-  private pointers = new Map<number, number>()
-  /** Client X where a drag-pan started, and the camera position it started at. */
+  /**
+   * Every pointer currently down, so a second finger can be noticed.
+   *
+   * Both coordinates, not just the column: a pinch needs the distance between
+   * two fingers, and zoomed in there is somewhere to pan vertically to.
+   */
+  private pointers = new Map<number, { x: number; y: number }>()
+  /** Where a drag-pan started, and the camera position it started at. */
   private panAnchorX = 0
+  private panAnchorY = 0
   private panAnchorCam = 0
+  private panAnchorCamY = 0
   private panning = false
+  /**
+   * The two-finger gesture in progress, if there is one.
+   *
+   * Pinching is tracked as a change since the *last* move rather than since the
+   * gesture began, unlike the one-finger drag: a pinch is a zoom and a pan at
+   * once, and an absolute anchor for each would have them fighting over the same
+   * camera every frame. Incremental, they compose — zoom about the midpoint,
+   * then slide by however far the midpoint itself travelled.
+   */
+  private pinch: { dist: number; x: number; y: number } | null = null
   /** -1, 0 or 1 — an arrow key or arrow button being held down. */
   private panHeld = 0
+  /** The same, vertically. Only reachable by keyboard, and only when zoomed in. */
+  private panHeldY = 0
   /** Direction keys currently held, so releasing one of two doesn't stop both. */
   private keysDown = new Set<string>()
   /** A look-mode tap waiting to see whether it turns into a pan. */
@@ -258,7 +287,7 @@ export class GameInstance {
     const apply = () => {
       const rect = parent.getBoundingClientRect()
       this.renderer.resize(rect.width, rect.height)
-      useMicroLand.getState().setCanPan(!this.renderer.fitsOnScreen)
+      this.pushCamera()
     }
     apply()
     this.resizeObserver = new ResizeObserver(apply)
@@ -317,9 +346,9 @@ export class GameInstance {
    * the pointer handler; everything here is per-second and belongs on a clock.
    */
   private updateCamera(dt: number): void {
-    if (this.panHeld !== 0) {
+    if (this.panHeld !== 0 || this.panHeldY !== 0) {
       this.following = false
-      this.renderer.panBy(this.panHeld * PAN_SPEED * dt)
+      this.renderer.panBy(this.panHeld * PAN_SPEED * dt, this.panHeldY * PAN_SPEED * dt)
     }
 
     // Carry a creature to the edge and the world comes with it — otherwise
@@ -332,15 +361,29 @@ export class GameInstance {
       if (held < cam + view * EDGE_BAND) dir = -1
       else if (held > cam + view * (1 - EDGE_BAND)) dir = 1
 
-      if (dir !== 0) {
-        this.renderer.panBy(dir * EDGE_SPEED * dt)
+      // The same band top and bottom, but only once zoom has put world off
+      // screen that way — otherwise dragging something down to the floor, which
+      // is a completely normal thing to do, would try to scroll after it.
+      const rows = this.renderer.viewHeight
+      const camY = this.renderer.cameraY
+      const heldY = this.grabbed.y
+      let dirY = 0
+      if (this.renderer.canPanVertically) {
+        if (heldY < camY + rows * EDGE_BAND) dirY = -1
+        else if (heldY > camY + rows * (1 - EDGE_BAND)) dirY = 1
+      }
+
+      if (dir !== 0 || dirY !== 0) {
+        this.renderer.panBy(dir * EDGE_SPEED * dt, dirY * EDGE_SPEED * dt)
         // The creature is positioned from the pointer, and the pointer isn't
         // moving — so without dragging it along by the same amount it would slip
         // out of the edge band on the first frame and the scroll would stop dead.
         const moved = this.renderer.cameraX - cam
+        const movedY = this.renderer.cameraY - camY
         const bp = this.world.blueprints[this.grabbed.blueprintId]
-        const bw = bp ? artSize(bp).w : 0
-        this.grabbed.x = Math.max(0, Math.min(this.world.width - bw, held + moved))
+        const art = bp ? artSize(bp) : { w: 0, h: 0 }
+        this.grabbed.x = Math.max(0, Math.min(this.world.width - art.w, held + moved))
+        this.grabbed.y = Math.max(0, Math.min(this.world.height - art.h, heldY + movedY))
       }
     }
 
@@ -348,6 +391,7 @@ export class GameInstance {
       const c = this.world.creatures.find(x => x.id === this.inspectedId)
       if (c) {
         this.renderer.keepInView(c.x, this.renderer.viewWidth * 0.22, FOLLOW_SPEED * dt)
+        this.renderer.keepInViewY(c.y, this.renderer.viewHeight * 0.22, FOLLOW_SPEED * dt)
       }
     }
   }
@@ -1253,20 +1297,74 @@ export class GameInstance {
     this.renderer.panBy(direction * PAN_STEP)
   }
 
+  /** One press of the on-screen + or −, or of the + / − keys. */
+  zoomByStep(direction: 1 | -1): void {
+    if (this.renderer.zoomByStep(direction)) this.pushCamera()
+  }
+
+  /** Back to the framing the world opens at. */
+  resetZoom(): void {
+    if (this.renderer.resetZoom()) this.pushCamera()
+  }
+
+  /**
+   * Tell the UI what the camera can currently do.
+   *
+   * Only on change rather than every frame: these drive whether buttons are on
+   * screen and whether they look pressable, and none of them move on their own.
+   */
+  private pushCamera(): void {
+    const store = useMicroLand.getState()
+    const canPan = !this.renderer.fitsOnScreen
+    const canZoomIn = this.renderer.canZoomIn
+    const canZoomOut = this.renderer.canZoomOut
+    // Guarded rather than set unconditionally: a pinch calls this on every
+    // pointermove, and each `set` walks every subscriber in the tree to tell
+    // them nothing changed.
+    if (canPan !== store.canPan) store.setCanPan(canPan)
+    if (canZoomIn !== store.canZoomIn || canZoomOut !== store.canZoomOut) {
+      store.setZoomState(canZoomIn, canZoomOut)
+    }
+  }
+
   // --- pointer --------------------------------------------------------------
 
-  private beginPan(clientX: number): void {
+  private beginPan(clientX: number, clientY: number): void {
     this.panning = true
     this.following = false
     this.panAnchorX = clientX
+    this.panAnchorY = clientY
     this.panAnchorCam = this.renderer.cameraX
+    this.panAnchorCamY = this.renderer.cameraY
   }
 
   /** Midpoint of every finger down, so a two-finger pan doesn't pivot. */
-  private pointerCenterX(): number {
-    let sum = 0
-    for (const x of this.pointers.values()) sum += x
-    return this.pointers.size > 0 ? sum / this.pointers.size : 0
+  private pointerCenter(): { x: number; y: number } {
+    let sumX = 0
+    let sumY = 0
+    for (const p of this.pointers.values()) {
+      sumX += p.x
+      sumY += p.y
+    }
+    const n = Math.max(1, this.pointers.size)
+    return { x: sumX / n, y: sumY / n }
+  }
+
+  /** How far apart the two fingers of a pinch are. Zero if there aren't two. */
+  private pinchDistance(): number {
+    const points = [...this.pointers.values()]
+    if (points.length < 2) return 0
+    const dx = points[0].x - points[1].x
+    const dy = points[0].y - points[1].y
+    return Math.hypot(dx, dy)
+  }
+
+  /** Take a fresh reading of the pinch, so adding a finger doesn't jump. */
+  private beginPinch(): void {
+    this.panning = false
+    this.following = false
+    const center = this.pointerCenter()
+    this.pinch = { dist: this.pinchDistance(), x: center.x, y: center.y }
   }
 
   /** Let go of whatever the first finger had started, without acting on it. */
@@ -1281,18 +1379,18 @@ export class GameInstance {
   }
 
   private onPointerDown = (e: PointerEvent) => {
-    this.pointers.set(e.pointerId, e.clientX)
+    this.pointers.set(e.pointerId, { x: e.clientX, y: e.clientY })
 
     // A second finger always means "move the world", whatever the first one had
-    // started doing. Two fingers on a canvas is a pan everywhere else on a
-    // phone, and the alternative — painting from both — is nobody's intent.
+    // started doing. Two fingers on a canvas is a pinch-and-pan everywhere else
+    // on a phone, and the alternative — painting from both — is nobody's intent.
     if (this.pointers.size === 2) {
       this.cancelPointerAction()
-      this.beginPan(this.pointerCenterX())
+      this.beginPinch()
       return
     }
     if (this.pointers.size > 2) {
-      this.reanchorPan()
+      this.beginPinch()
       return
     }
     if (!e.isPrimary) return
@@ -1309,7 +1407,7 @@ export class GameInstance {
     if (jump !== null) {
       this.scrubbingMap = true
       this.following = false
-      this.renderer.centerOn(jump)
+      this.renderer.centerOn(jump.x, jump.y)
       return
     }
 
@@ -1321,7 +1419,7 @@ export class GameInstance {
       // one place a single finger can move the world without ambiguity. The
       // selection is resolved on release, so a pan doesn't also deselect.
       this.pendingInspect = { id: hit ? hit.id : null }
-      this.beginPan(e.clientX)
+      this.beginPan(e.clientX, e.clientY)
       return
     }
 
@@ -1337,14 +1435,43 @@ export class GameInstance {
   }
 
   private onPointerMove = (e: PointerEvent) => {
-    if (this.pointers.has(e.pointerId)) this.pointers.set(e.pointerId, e.clientX)
+    if (this.pointers.has(e.pointerId))
+      this.pointers.set(e.pointerId, { x: e.clientX, y: e.clientY })
+
+    // Two fingers: zoom about the point between them, then slide by however far
+    // that point moved. Both are read against the previous move rather than the
+    // start of the gesture — see `pinch`.
+    if (this.pinch && this.pointers.size >= 2) {
+      const dist = this.pinchDistance()
+      const center = this.pointerCenter()
+      if (dist > 0 && this.pinch.dist > 0) {
+        const ratio = dist / this.pinch.dist
+        // A fraction of a pixel of finger tremor is not a zoom, and feeding it
+        // back into the camera every frame reads as the world breathing.
+        if (Math.abs(ratio - 1) > 0.002) {
+          this.renderer.setZoom(this.renderer.zoomLevel * ratio, {
+            clientX: center.x,
+            clientY: center.y,
+          })
+          this.pushCamera()
+        }
+      }
+      const perPixel = this.renderer.tilesPerClientPixel()
+      this.renderer.panBy(
+        -(center.x - this.pinch.x) * perPixel,
+        -(center.y - this.pinch.y) * perPixel
+      )
+      this.pinch = { dist, x: center.x, y: center.y }
+      return
+    }
 
     if (this.panning) {
-      const from = this.pointers.size >= 2 ? this.pointerCenterX() : e.clientX
-      const dx = from - this.panAnchorX
+      const dx = e.clientX - this.panAnchorX
+      const dy = e.clientY - this.panAnchorY
       // A tap that has turned into a drag is no longer a tap.
-      if (this.pendingInspect && Math.abs(dx) > TAP_SLOP) this.pendingInspect = null
-      this.renderer.panToLeft(this.panAnchorCam - dx * this.renderer.tilesPerClientPixel())
+      if (this.pendingInspect && Math.hypot(dx, dy) > TAP_SLOP) this.pendingInspect = null
+      const perPixel = this.renderer.tilesPerClientPixel()
+      this.renderer.panTo(this.panAnchorCam - dx * perPixel, this.panAnchorCamY - dy * perPixel)
       return
     }
 
@@ -1353,7 +1480,7 @@ export class GameInstance {
     // Drag along the map and the world follows — the fastest way to cross it.
     if (this.scrubbingMap) {
       const jump = this.renderer.minimapHit(e.clientX, e.clientY)
-      if (jump !== null) this.renderer.centerOn(jump)
+      if (jump !== null) this.renderer.centerOn(jump.x, jump.y)
       return
     }
 
@@ -1378,8 +1505,24 @@ export class GameInstance {
 
   private onPointerUp = (e: PointerEvent) => {
     this.pointers.delete(e.pointerId)
-    if (this.panning && this.pointers.size === 0) this.panning = false
-    else this.reanchorPan()
+
+    if (this.pinch) {
+      if (this.pointers.size >= 2) {
+        // Still a pinch, one finger lighter. Re-read it or the next move counts
+        // the jump in the midpoint as a pan.
+        this.beginPinch()
+      } else {
+        this.pinch = null
+        // One finger left over from a two-finger gesture keeps moving the world
+        // rather than suddenly starting to paint with it.
+        const last = [...this.pointers.values()][0]
+        if (last) this.beginPan(last.x, last.y)
+      }
+    } else if (this.panning && this.pointers.size === 0) {
+      this.panning = false
+    } else {
+      this.reanchorPan()
+    }
 
     if (!e.isPrimary) return
     this.pointerDown = false
@@ -1473,26 +1616,62 @@ export class GameInstance {
   /** Fingers came or went mid-pan — take a fresh reading so it doesn't jump. */
   private reanchorPan(): void {
     if (!this.panning || this.pointers.size === 0) return
-    this.panAnchorX = this.pointerCenterX()
+    const center = this.pointerCenter()
+    this.panAnchorX = center.x
+    this.panAnchorY = center.y
     this.panAnchorCam = this.renderer.cameraX
+    this.panAnchorCamY = this.renderer.cameraY
   }
 
   /**
-   * A wheel or trackpad scrolls the world sideways.
+   * A wheel or trackpad moves the world; held with ctrl or ⌘, it zooms it.
    *
-   * Vertical scroll is folded in as well as horizontal: there is nothing above
-   * or below to scroll to, and a mouse with one wheel is still the most common
-   * way anyone will touch this.
+   * The ctrl half is not a keyboard shortcut anyone has to know — a trackpad
+   * pinch on macOS *is* a ctrl-wheel, so this is how a laptop pinches. Plain
+   * scrolling stays a pan, which is the thing you do far more often.
+   *
+   * Panning folds vertical scroll into horizontal while the world fits top to
+   * bottom, because a mouse with one wheel is still the most common way anyone
+   * will touch this and there would otherwise be nowhere for it to go. Zoomed in
+   * far enough that there *is* somewhere, the two axes separate.
    */
   private onWheel = (e: WheelEvent) => {
-    const raw = Math.abs(e.deltaX) > Math.abs(e.deltaY) ? e.deltaX : e.deltaY
-    if (raw === 0) return
-    e.preventDefault()
-    this.following = false
     // deltaMode: 0 pixels, 1 lines, 2 pages.
     const unit = e.deltaMode === 1 ? 16 : e.deltaMode === 2 ? 400 : 1
-    const tiles = raw * unit * 0.25
-    this.renderer.panBy(Math.max(-PAN_STEP, Math.min(PAN_STEP, tiles)))
+
+    if (e.ctrlKey || e.metaKey) {
+      if (e.deltaY === 0) return
+      e.preventDefault()
+      this.following = false
+      // Exponential so a notch is worth the same proportion of the zoom at
+      // either end of the range — linear steps crawl when close in and lurch
+      // when far out.
+      const factor = Math.exp(-e.deltaY * unit * WHEEL_ZOOM_RATE)
+      this.renderer.setZoom(this.renderer.zoomLevel * factor, {
+        clientX: e.clientX,
+        clientY: e.clientY,
+      })
+      this.pushCamera()
+      return
+    }
+
+    // Shift-wheel is the web's horizontal scroll. Most platforms hand it over
+    // already turned into `deltaX`; the ones that don't are why this is here,
+    // and it is the only way a mouse with a single wheel can cross a world nine
+    // screens wide once zoom has claimed the vertical axis.
+    const sideways = e.shiftKey && e.deltaX === 0
+    const splitAxes = this.renderer.canPanVertically && !sideways
+    const rawX = splitAxes
+      ? e.deltaX
+      : Math.abs(e.deltaX) > Math.abs(e.deltaY)
+        ? e.deltaX
+        : e.deltaY
+    const rawY = splitAxes ? e.deltaY : 0
+    if (rawX === 0 && rawY === 0) return
+    e.preventDefault()
+    this.following = false
+    const step = (raw: number) => Math.max(-PAN_STEP, Math.min(PAN_STEP, raw * unit * 0.25))
+    this.renderer.panBy(step(rawX), step(rawY))
   }
 
   /** Which way, if any, does this key point? */
@@ -1502,8 +1681,32 @@ export class GameInstance {
     return 0
   }
 
+  /** The same, up and down. Only reaches anything once zoom has made room. */
+  private static keyDirectionY(key: string): -1 | 0 | 1 {
+    if (key === 'ArrowUp' || key === 'w' || key === 'W') return -1
+    if (key === 'ArrowDown' || key === 's' || key === 'S') return 1
+    return 0
+  }
+
   private onKeyDown = (e: KeyboardEvent) => {
     if (e.metaKey || e.ctrlKey || e.altKey) return
+
+    // `=` is the unshifted key `+` lives on, and nobody holds shift to zoom in.
+    if (e.key === '+' || e.key === '=') {
+      e.preventDefault()
+      this.zoomByStep(1)
+      return
+    }
+    if (e.key === '-' || e.key === '_') {
+      e.preventDefault()
+      this.zoomByStep(-1)
+      return
+    }
+    if (e.key === '0') {
+      e.preventDefault()
+      this.resetZoom()
+      return
+    }
 
     if (e.key === 'Home' || e.key === 'End') {
       e.preventDefault()
@@ -1513,10 +1716,15 @@ export class GameInstance {
     }
 
     const dir = GameInstance.keyDirection(e.key)
-    if (dir === 0) return
+    // Ignored outright rather than held at zero while the world fits top to
+    // bottom: a key that silently stops the camera following something, and
+    // then moves nothing, is worse than a key that does nothing at all.
+    const dirY = this.renderer.canPanVertically ? GameInstance.keyDirectionY(e.key) : 0
+    if (dir === 0 && dirY === 0) return
     e.preventDefault()
     this.keysDown.add(e.key)
-    this.panHeld = dir
+    if (dir !== 0) this.panHeld = dir
+    if (dirY !== 0) this.panHeldY = dirY
     this.following = false
   }
 
@@ -1525,17 +1733,22 @@ export class GameInstance {
     // Holding both arrows and releasing one should leave you moving the other
     // way, not stop dead.
     let dir: -1 | 0 | 1 = 0
+    let dirY: -1 | 0 | 1 = 0
     for (const key of this.keysDown) {
       const d = GameInstance.keyDirection(key)
       if (d !== 0) dir = d
+      const dy = GameInstance.keyDirectionY(key)
+      if (dy !== 0) dirY = dy
     }
     this.panHeld = dir
+    this.panHeldY = dirY
   }
 
   /** A canvas that lost focus can't hear a keyup, so it must not stay stuck. */
   private onBlur = () => {
     this.keysDown.clear()
     this.panHeld = 0
+    this.panHeldY = 0
   }
 
   private attachInput(): void {

--- a/src/app/micro-land/game-instance.ts
+++ b/src/app/micro-land/game-instance.ts
@@ -29,6 +29,7 @@ import {
   artSize,
   bodyBox,
   forgetBodyBox,
+  lifeKind,
   reserveSummonIds,
   sanitizeBlueprint,
 } from './domain/blueprint'
@@ -53,16 +54,27 @@ import {
   spawnSomewhereSensible,
 } from './domain/sim/world'
 import { TUNING } from './domain/tuning'
+import {
+  type Creature,
+  type CreatureBlueprint,
+  LIFE_KINDS,
+  type LifeKind,
+  type WorldState,
+} from './domain/types'
 import { formatDuration } from './format'
 import { Renderer } from './rendering/renderer'
 import { forgetSprites } from './rendering/sprite-cache'
-import { type EarnedMilestone, type PopulationEntry, useMicroLand } from './store'
+import {
+  type EarnedMilestone,
+  type KindRecordsView,
+  type PopulationEntry,
+  useMicroLand,
+} from './store'
 import { releaseActiveWorld, touchActiveWorld } from './worlds/shelf'
 import { restoreSnapshot, snapshotWorld } from './worlds/snapshot'
 import { WORLD_SAVE_VERSION, type WorldSave } from './worlds/types'
 
 import type { SpeciesRecord } from './chronicle/types'
-import type { Creature, CreatureBlueprint, WorldState } from './domain/types'
 
 /** How often the UI gets a fresh population summary. */
 const STATS_EVERY_MS = 300
@@ -146,6 +158,16 @@ export class GameInstance {
    * its age or its name off by then.
    */
   private elderSnapshot: { name: string | null; species: string; seconds: number } | null = null
+  /**
+   * Who currently holds each column's longevity record.
+   *
+   * Only used to date the record: `at` marks when a record was *taken*, and the
+   * column is rewritten on every stats tick while its holder keeps ageing, so
+   * without knowing whether the holder changed the date would creep forward
+   * forever and no record would ever look old. Not a second crown — the halo,
+   * the eulogy and naming all still follow `elderId`, of which there is one.
+   */
+  private kindElderIds = new Map<LifeKind, number>()
   /** World-clock time the current no-extinction streak began. */
   private steadySince = 0
   /** Archive size at the last push, so the guide is only re-sent when it grows. */
@@ -449,6 +471,12 @@ export class GameInstance {
     // for every kind, and only ever noting the single oldest creature would
     // leave every species but one permanently blank.
     const eldestOf = new Map<string, number>()
+    // And the same two figures per *column*, which is what stops the record
+    // book being a plant leaderboard — see `KindRecord`. Held as creatures
+    // rather than numbers because the record wants the holder's name and
+    // species too.
+    const oldestOfKind = new Map<LifeKind, Creature>()
+    const deepestOfKind = new Map<LifeKind, Creature>()
     for (const c of w.creatures) {
       if (!oldest || c.ageSeconds > oldest.ageSeconds) oldest = c
       if (c.generation > deepest) deepest = c.generation
@@ -456,6 +484,17 @@ export class GameInstance {
       if (best === undefined || c.ageSeconds > best) {
         eldestOf.set(c.blueprintId, c.ageSeconds)
       }
+
+      const bp = w.blueprints[c.blueprintId]
+      // A creature whose blueprint has gone is unclassifiable and unnameable, so
+      // it cannot hold a record either. It still counts toward the land-wide
+      // figures above, which need neither.
+      if (!bp) continue
+      const kind = lifeKind(bp)
+      const kindOldest = oldestOfKind.get(kind)
+      if (!kindOldest || c.ageSeconds > kindOldest.ageSeconds) oldestOfKind.set(kind, c)
+      const kindDeepest = deepestOfKind.get(kind)
+      if (!kindDeepest || c.generation > kindDeepest.generation) deepestOfKind.set(kind, c)
     }
 
     // Every species on screen goes into the guide, and takes its blueprint with
@@ -510,11 +549,58 @@ export class GameInstance {
         record.generationsSpeciesName = bp?.name ?? null
       }
 
+      // --- the same two, per column -------------------------------------
+      // No notice fires from in here. The land-wide record above already
+      // announces itself, and a second line every time an animal beats a
+      // record only animals are competing for would be constant early on,
+      // when generation 2 beats generation 1 and so does 3.
+      for (const kind of LIFE_KINDS) {
+        const column = record.byKind[kind]
+
+        const eldest = oldestOfKind.get(kind)
+        const bestHere = column.elder?.seconds ?? 0
+        if (eldest && eldest.ageSeconds >= ELDER_MIN_SECONDS && eldest.ageSeconds > bestHere) {
+          const bp = w.blueprints[eldest.blueprintId]
+          if (bp) {
+            const taking = this.kindElderIds.get(kind) !== eldest.id
+            this.kindElderIds.set(kind, eldest.id)
+            column.elder = {
+              seconds: eldest.ageSeconds,
+              blueprintId: bp.id,
+              speciesName: bp.name,
+              name: eldest.name,
+              at: taking ? now : (column.elder?.at ?? now),
+            }
+          }
+        }
+
+        const line = deepestOfKind.get(kind)
+        if (line && line.generation > column.generations) {
+          const bp = w.blueprints[line.blueprintId]
+          column.generations = line.generation
+          column.generationsBlueprintId = bp?.id ?? null
+          column.generationsSpeciesName = bp?.name ?? null
+        }
+      }
+
       // --- stability ----------------------------------------------------
       // Banked live rather than only when the streak breaks, so a session that
       // ends by closing the tab still keeps the run it was in the middle of.
       if (steadySeconds > record.steadySeconds) record.steadySeconds = steadySeconds
     })
+
+    // Copied out rather than handed over: `record` is the live chronicle object
+    // and the next stats tick mutates it in place, so passing it into the store
+    // would give React a value that changes without ever being re-set.
+    const byKind = {} as Record<LifeKind, KindRecordsView>
+    for (const kind of LIFE_KINDS) {
+      const column = record.byKind[kind]
+      byKind[kind] = {
+        elder: column.elder,
+        bestGenerations: column.generations,
+        bestGenerationsSpeciesName: column.generationsSpeciesName,
+      }
+    }
 
     store.setRecords({
       elder: record.elder,
@@ -523,6 +609,7 @@ export class GameInstance {
       bestGenerationsSpeciesName: record.generationsSpeciesName,
       steadySeconds,
       deepestGeneration: deepest,
+      byKind,
     })
 
     // Sorted once and shared: both of these want the same list, and it is
@@ -573,6 +660,14 @@ export class GameInstance {
     updateChronicle(() => {
       const record = landRecord(this.currentLand)
       if (record.elder) record.elder.name = trimmed
+      // The crowned creature is also holding its own column's record, near
+      // enough always. Written across so the guide doesn't show the name beside
+      // the land-wide line and the bare species name beside the split one.
+      for (const kind of LIFE_KINDS) {
+        if (this.kindElderIds.get(kind) !== c.id) continue
+        const column = record.byKind[kind]
+        if (column.elder) column.elder.name = trimmed
+      }
     })
     this.pushStats()
     return true
@@ -636,6 +731,9 @@ export class GameInstance {
     // creature the player deliberately removed.
     this.elderId = null
     this.elderSnapshot = null
+    // Creature ids are per-world, so holders carried across a land change would
+    // eventually collide with an unrelated creature and freeze a record's date.
+    this.kindElderIds.clear()
     this.lastArchiveSize = -1
   }
 
@@ -1116,6 +1214,11 @@ export class GameInstance {
           seconds: elder.ageSeconds,
         }
       : null
+    // Not saved, and doesn't need to be: it only decides whether a column's `at`
+    // date refreshes. Left empty, the first stats tick re-dates a record whose
+    // holder survived the reload, which is off by however long the world sat
+    // closed and self-corrects the moment anything beats it.
+    this.kindElderIds.clear()
 
     // Seeded from what is actually alive, so opening a world does not announce
     // the extinction of everything that was in the land it replaced.

--- a/src/app/micro-land/rendering/renderer.ts
+++ b/src/app/micro-land/rendering/renderer.ts
@@ -11,12 +11,19 @@
  * creatures), blurred and composited as a darkness layer *after* sprites, so
  * creatures are dimmed by the same shadows as the terrain.
  *
- * The world is wider than the screen, so there is a camera. It only moves
- * horizontally and it only ever sits on whole tiles: a camera at x = 12.4 would
- * resample every tile in the world onto a half-pixel and undo the one thing this
- * renderer exists to protect. Every per-frame pass below — tiles, light, shadow,
- * sprites — is clipped to the visible column range, which is what keeps a world
- * three times the size costing about what one screen used to.
+ * The world is wider than the screen, so there is a camera, and it only ever
+ * sits on whole tiles: a camera at x = 12.4 would resample every tile in the
+ * world onto a half-pixel and undo the one thing this renderer exists to
+ * protect. Every per-frame pass below — tiles, light, shadow, sprites — is
+ * clipped to the visible column range, which is what keeps a world three times
+ * the size costing about what one screen used to.
+ *
+ * Zoom moves the size of a tile, never the size of the backbuffer: the world is
+ * always composed at one pixel per tile and the zoom lives entirely in the final
+ * blit, so pushing in costs nothing and pulling out to the whole world costs
+ * only the wider column range. Pushed in far enough the world no longer fits
+ * top to bottom, which is the only reason there is a vertical camera at all —
+ * it is pinned to 0 and does nothing until the rows stop fitting.
  */
 import { MATERIAL_BY_INDEX } from '@/app/micro-land/domain/config/materials'
 import type { Theme } from '@/app/micro-land/domain/config/themes'
@@ -60,6 +67,23 @@ const MH = Math.ceil(WORLD_H / MAP_SCALE)
 
 /** Frames between minimap refreshes. It's a thumbnail; 5Hz is more than enough. */
 const MAP_REFRESH_FRAMES = 12
+
+/**
+ * How far in the camera can push, as a multiple of the default framing.
+ *
+ * 3× puts roughly 75 tiles across a phone, which is about a dozen body lengths
+ * of a mid-sized creature — close enough to watch one eat without losing the
+ * ground it is standing on. Past that the pixels are large enough that the art
+ * stops reading as a creature and starts reading as squares.
+ */
+const ZOOM_MAX = 3
+
+/** One press of + or −. Five or six presses cross the whole range. */
+export const ZOOM_STEP = 1.5
+
+function clamp(value: number, low: number, high: number): number {
+  return Math.max(low, Math.min(high, value))
+}
 
 interface Rgb {
   r: number
@@ -121,12 +145,28 @@ export class Renderer {
   private offsetY = 0
 
   /**
+   * Display pixels per tile at zoom 1 — the default framing, VIEW_W across.
+   *
+   * Zoom is expressed as a multiple of this rather than as an absolute tile size
+   * so that 1× means the same thing on every display: exactly the framing the
+   * game has always had, whatever the screen happens to be.
+   */
+  private baseScale = 1
+  private zoom = 1
+  /** Pulled back far enough to see the whole world. Depends on the display. */
+  private minZoom = 1
+
+  /**
    * Left edge of the view in world tiles. Kept fractional so a slow pan can
    * accumulate, but always floored before anything is drawn from it.
    */
   private camX = 0
+  /** Top edge, same rules. Stays 0 unless zoom has made the world too tall. */
+  private camY = 0
   /** How many world tiles the display is wide at the current scale. */
   private viewTiles = VIEW_W
+  /** How many world rows the display is tall at the current scale. */
+  private viewRows = WORLD_H
 
   constructor(display: HTMLCanvasElement) {
     this.display = display
@@ -172,14 +212,29 @@ export class Renderer {
     this.display.style.width = `${cssWidth}px`
     this.display.style.height = `${cssHeight}px`
 
-    // Zoom is fixed by VIEW_W, not by the whole world: a tile is sized so that
-    // one screen's worth spans the canvas, exactly as it did when the world was
-    // one screen wide. Whatever extra height allows, you simply get to see.
-    const fit = Math.min(this.display.width / VIEW_W, this.display.height / WORLD_H)
-    this.scale = fit
-    this.viewTiles = Math.min(WORLD_W, this.display.width / fit)
-    this.offsetX = Math.floor((this.display.width - this.viewTiles * fit) / 2)
-    this.offsetY = Math.floor((this.display.height - WORLD_H * fit) / 2)
+    // The resting zoom is fixed by VIEW_W, not by the whole world: a tile is
+    // sized so that one screen's worth spans the canvas, exactly as it did when
+    // the world was one screen wide. Whatever extra height allows, you simply
+    // get to see.
+    this.baseScale = Math.min(this.display.width / VIEW_W, this.display.height / WORLD_H)
+    // Far enough out to hold all 672 columns, and never past 1× — on a display
+    // wide enough to show the whole world already there is nothing to pull back
+    // to, and a zoom-out button that magnified would be a lie.
+    this.minZoom = Math.min(1, this.display.width / WORLD_W / this.baseScale)
+    this.applyZoom()
+  }
+
+  /** Re-derive everything that depends on the zoom. Always ends clamped. */
+  private applyZoom(): void {
+    this.zoom = clamp(this.zoom, this.minZoom, ZOOM_MAX)
+    const scale = this.baseScale * this.zoom
+    this.scale = scale
+    // Capped at the world: pulled all the way out there is letterboxing rather
+    // than a view that claims to extend past the edge of everything there is.
+    this.viewTiles = Math.min(WORLD_W, this.display.width / scale)
+    this.viewRows = Math.min(WORLD_H, this.display.height / scale)
+    this.offsetX = Math.floor((this.display.width - this.viewTiles * scale) / 2)
+    this.offsetY = Math.floor((this.display.height - this.viewRows * scale) / 2)
     this.clampCam()
   }
 
@@ -192,18 +247,46 @@ export class Renderer {
     return this.camX
   }
 
+  /** Top edge of the view, in world rows. */
+  get cameraY(): number {
+    return this.camY
+  }
+
   /** How much world is on screen right now, in tiles. */
   get viewWidth(): number {
     return this.viewTiles
   }
 
-  /** True when the whole world already fits — nothing to scroll to. */
-  get fitsOnScreen(): boolean {
-    return this.viewTiles >= WORLD_W
+  /** How much world is on screen right now, in rows. */
+  get viewHeight(): number {
+    return this.viewRows
   }
 
-  panBy(tiles: number): void {
+  /** True when the whole world already fits — nothing to scroll to. */
+  get fitsOnScreen(): boolean {
+    return this.viewTiles >= WORLD_W && this.viewRows >= WORLD_H
+  }
+
+  /** Whether there is any world above or below to scroll to. */
+  get canPanVertically(): boolean {
+    return this.viewRows < WORLD_H
+  }
+
+  get zoomLevel(): number {
+    return this.zoom
+  }
+
+  get canZoomIn(): boolean {
+    return this.zoom < ZOOM_MAX - 1e-6
+  }
+
+  get canZoomOut(): boolean {
+    return this.zoom > this.minZoom + 1e-6
+  }
+
+  panBy(tiles: number, rows = 0): void {
     this.camX += tiles
+    this.camY += rows
     this.clampCam()
   }
 
@@ -213,10 +296,79 @@ export class Renderer {
     this.clampCam()
   }
 
-  /** Put this world column in the middle of the view. */
-  centerOn(worldX: number): void {
-    this.camX = worldX - this.viewTiles / 2
+  /** Put this world point at the top-left corner. Absolute, for drag-panning. */
+  panTo(tile: number, row: number): void {
+    this.camX = tile
+    this.camY = row
     this.clampCam()
+  }
+
+  /** Put this world column — and optionally this row — in the middle of the view. */
+  centerOn(worldX: number, worldY?: number): void {
+    this.camX = worldX - this.viewTiles / 2
+    if (worldY !== undefined) this.camY = worldY - this.viewRows / 2
+    this.clampCam()
+  }
+
+  // -------------------------------------------------------------------------
+  // Zoom
+  // -------------------------------------------------------------------------
+
+  /**
+   * Change the zoom, holding one point of the world still under the screen.
+   *
+   * Without an anchor the middle of the view is what stays put, which is what a
+   * button press wants. With one — the pointer, or the midpoint between two
+   * fingers — the tile you started the gesture on is the tile you end it on,
+   * which is the whole difference between pinching a map and fighting one.
+   *
+   * Returns whether the zoom actually moved, so a caller can tell a press that
+   * did something from one that hit the end of the range.
+   */
+  setZoom(next: number, anchor?: { clientX: number; clientY: number }): boolean {
+    const target = clamp(next, this.minZoom, ZOOM_MAX)
+    if (Math.abs(target - this.zoom) < 1e-6) return false
+
+    if (!anchor) {
+      const midX = this.camX + this.viewTiles / 2
+      const midY = this.camY + this.viewRows / 2
+      this.zoom = target
+      this.applyZoom()
+      this.centerOn(midX, midY)
+      return true
+    }
+
+    // Measured off the fractional camera rather than `screenToWorld`, which
+    // floors: a pinch is a stream of tiny changes, and quantising the anchor to
+    // whole tiles at every step is what makes a zoom gesture crawl sideways.
+    const rect = this.display.getBoundingClientRect()
+    const dpr = rect.width === 0 ? 1 : this.display.width / rect.width
+    const px = (anchor.clientX - rect.left) * dpr
+    const py = (anchor.clientY - rect.top) * dpr
+    const worldX = this.camX + (px - this.offsetX) / this.scale
+    const worldY = this.camY + (py - this.offsetY) / this.scale
+
+    this.zoom = target
+    this.applyZoom()
+
+    this.camX = worldX - (px - this.offsetX) / this.scale
+    this.camY = worldY - (py - this.offsetY) / this.scale
+    this.clampCam()
+    return true
+  }
+
+  /** One notch of the +/− ladder. */
+  zoomByStep(direction: 1 | -1, anchor?: { clientX: number; clientY: number }): boolean {
+    const next = direction === 1 ? this.zoom * ZOOM_STEP : this.zoom / ZOOM_STEP
+    // 1× is the framing the game was built around, so a ladder that steps over
+    // it can never be landed on again without a lucky screen width. Anything
+    // that crosses it stops there first.
+    const snapped = (this.zoom - 1) * (next - 1) < 0 ? 1 : next
+    return this.setZoom(snapped, anchor)
+  }
+
+  resetZoom(): boolean {
+    return this.setZoom(1)
   }
 
   /**
@@ -232,12 +384,26 @@ export class Renderer {
     else if (worldX > right) this.panBy(Math.min(maxTiles, worldX - right))
   }
 
+  /** The same, up and down. A no-op while the world still fits vertically. */
+  keepInViewY(worldY: number, margin: number, maxRows: number): void {
+    if (!this.canPanVertically) return
+    const top = this.camY + margin
+    const bottom = this.camY + this.viewRows - margin
+    if (worldY < top) this.panBy(0, Math.max(-maxRows, worldY - top))
+    else if (worldY > bottom) this.panBy(0, Math.min(maxRows, worldY - bottom))
+  }
+
   private clampCam(): void {
-    this.camX = Math.max(0, Math.min(WORLD_W - this.viewTiles, this.camX))
+    // `max(0, …)` on the limit as well as the value: pulled out far enough that
+    // the world is letterboxed, `WORLD_W - viewTiles` is negative and the naive
+    // clamp would pin the camera to a negative column.
+    this.camX = clamp(this.camX, 0, Math.max(0, WORLD_W - this.viewTiles))
+    this.camY = clamp(this.camY, 0, Math.max(0, WORLD_H - this.viewRows))
   }
 
   /**
-   * How many world tiles one CSS pixel of horizontal drag is worth.
+   * How many world tiles one CSS pixel of drag is worth. Same either axis —
+   * tiles are square and the scale is uniform.
    *
    * Drag-panning can't be built out of `screenToWorld` differences: that already
    * has the camera folded into it, so moving the camera moves the answer and the
@@ -254,6 +420,11 @@ export class Renderer {
     return Math.floor(this.camX)
   }
 
+  /** Whole-tile top edge. Same reason as `viewLeft`. */
+  private viewTop(): number {
+    return Math.floor(this.camY)
+  }
+
   /** Display pixel → world tile. Used by every pointer interaction. */
   screenToWorld(clientX: number, clientY: number): { x: number; y: number } {
     const rect = this.display.getBoundingClientRect()
@@ -262,18 +433,23 @@ export class Renderer {
     const py = (clientY - rect.top) * dpr
     return {
       x: this.viewLeft() + (px - this.offsetX) / this.scale,
-      y: (py - this.offsetY) / this.scale,
+      y: this.viewTop() + (py - this.offsetY) / this.scale,
     }
   }
 
   /**
    * Was this tap on the minimap, and if so where in the world does it point?
    *
-   * Returns the world column to centre on, or null if the tap missed. The
+   * Returns the world point to centre on, or null if the tap missed. The
    * minimap is the only part of the world canvas that isn't the world, so it
    * has to be asked about before a tap is allowed to paint anything.
+   *
+   * The row comes back as well as the column because zoomed in there is a
+   * vertical camera to aim, and the thumbnail shows the whole height — tapping
+   * a cave near the bottom of it and arriving at the surface would be a map
+   * that answers a question you didn't ask.
    */
-  minimapHit(clientX: number, clientY: number): number | null {
+  minimapHit(clientX: number, clientY: number): { x: number; y: number } | null {
     const m = this.mapRect
     if (m.w <= 0) return null
     const rect = this.display.getBoundingClientRect()
@@ -281,7 +457,7 @@ export class Renderer {
     const px = (clientX - rect.left) * dpr
     const py = (clientY - rect.top) * dpr
     if (px < m.x || px > m.x + m.w || py < m.y || py > m.y + m.h) return null
-    return ((px - m.x) / m.w) * WORLD_W
+    return { x: ((px - m.x) / m.w) * WORLD_W, y: ((py - m.y) / m.h) * WORLD_H }
   }
 
   // -------------------------------------------------------------------------
@@ -326,13 +502,13 @@ export class Renderer {
     ctx.drawImage(
       this.world,
       vx,
-      0,
+      this.viewTop(),
       this.viewTiles,
-      WORLD_H,
+      this.viewRows,
       this.offsetX,
       this.offsetY,
       this.viewTiles * this.scale,
-      WORLD_H * this.scale
+      this.viewRows * this.scale
     )
 
     this.drawMinimap(w, theme, vx)
@@ -673,17 +849,19 @@ export class Renderer {
     ctx.drawImage(this.mapCanvas, 0, 0, MW, MH, x, y, width, height)
     ctx.globalAlpha = 1
 
-    // The view, marked. Kept at least a couple of pixels wide so it can't
-    // vanish on a narrow screen.
+    // The view, marked. Kept at least a couple of pixels each way so it can't
+    // vanish on a narrow screen — or, zoomed right in, collapse to a line.
     const vxPx = x + Math.round((vx / WORLD_W) * width)
     const vwPx = Math.max(3, Math.round((this.viewTiles / WORLD_W) * width))
+    const vyPx = y + Math.round((this.viewTop() / WORLD_H) * height)
+    const vhPx = Math.max(3, Math.round((this.viewRows / WORLD_H) * height))
     ctx.strokeStyle = '#5eead4'
     ctx.lineWidth = Math.max(1, Math.round(width / 220))
     ctx.strokeRect(
       vxPx + ctx.lineWidth / 2,
-      y + ctx.lineWidth / 2,
+      vyPx + ctx.lineWidth / 2,
       Math.min(vwPx, width - (vxPx - x)) - ctx.lineWidth,
-      height - ctx.lineWidth
+      Math.min(vhPx, height - (vyPx - y)) - ctx.lineWidth
     )
 
     ctx.strokeStyle = 'rgba(94, 234, 212, 0.35)'

--- a/src/app/micro-land/store.ts
+++ b/src/app/micro-land/store.ts
@@ -23,7 +23,7 @@ import {
 
 import type { SaveState } from './chronicle/chronicle'
 import type { ElderRecord, SpeciesRecord } from './chronicle/types'
-import type { CreatureBlueprint, MaterialId } from './domain/types'
+import type { CreatureBlueprint, LifeKind, MaterialId } from './domain/types'
 import type { ShelfState } from './worlds/shelf'
 
 /** Theme id standing for "the land the player summoned". */
@@ -69,6 +69,13 @@ export interface Inspected {
   isElder: boolean
 }
 
+/** One column of the guide's record book — see `KindRecord`. */
+export interface KindRecordsView {
+  elder: ElderRecord | null
+  bestGenerations: number
+  bestGenerationsSpeciesName: string | null
+}
+
 /**
  * Records for the land currently on screen, as the UI wants them.
  *
@@ -77,7 +84,7 @@ export interface Inspected {
  * come from two different places.
  */
 export interface RecordsView {
-  /** Best ever in this land. */
+  /** Best ever in this land, of any kind. Backs the crown, not the panel. */
   elder: ElderRecord | null
   bestSteadySeconds: number
   bestGenerations: number
@@ -85,6 +92,18 @@ export interface RecordsView {
   /** How this run is going. */
   steadySeconds: number
   deepestGeneration: number
+  /**
+   * The two records again, split plant against animal — what the guide shows.
+   *
+   * Flat copies rather than the chronicle's own objects: those are mutated in
+   * place several times a second, and a store value that changes without being
+   * re-set is one React will never re-render for.
+   */
+  byKind: Record<LifeKind, KindRecordsView>
+}
+
+function emptyKindRecords(): KindRecordsView {
+  return { elder: null, bestGenerations: 0, bestGenerationsSpeciesName: null }
 }
 
 export interface EarnedMilestone {
@@ -101,6 +120,7 @@ const EMPTY_RECORDS: RecordsView = {
   bestGenerationsSpeciesName: null,
   steadySeconds: 0,
   deepestGeneration: 0,
+  byKind: { plant: emptyKindRecords(), animal: emptyKindRecords() },
 }
 
 export interface PopulationEntry {

--- a/src/app/micro-land/store.ts
+++ b/src/app/micro-land/store.ts
@@ -219,12 +219,22 @@ interface MicroLandState {
   archive: SpeciesRecord[]
   milestones: EarnedMilestone[]
   /**
-   * Whether the world is wider than the view.
+   * Whether there is any world off screen to scroll to.
    *
    * Almost always true, but an ultrawide display can fit all 672 tiles at once,
-   * and scroll buttons that visibly do nothing are worse than no buttons.
+   * and so can any display once the player has zoomed all the way out. Scroll
+   * buttons that visibly do nothing are worse than no buttons.
    */
   canPan: boolean
+  /**
+   * Whether the zoom has anywhere left to go in each direction.
+   *
+   * Both ends are reachable — a couple of presses of − on a wide monitor is the
+   * whole world — so the buttons have to be able to say so rather than going
+   * quietly dead under a finger.
+   */
+  canZoomIn: boolean
+  canZoomOut: boolean
 
   notices: Notice[]
 
@@ -296,6 +306,7 @@ interface MicroLandState {
   setArchive: (archive: SpeciesRecord[]) => void
   setMilestones: (milestones: EarnedMilestone[]) => void
   setCanPan: (canPan: boolean) => void
+  setZoomState: (canZoomIn: boolean, canZoomOut: boolean) => void
   setSaveState: (state: SaveState) => void
   setShelf: (shelf: ShelfState) => void
   setWorldsOpen: (open: boolean) => void
@@ -357,6 +368,8 @@ export const useMicroLand = create<MicroLandState>(set => ({
   tuning: { ...TUNING },
   inspected: null,
   canPan: true,
+  canZoomIn: true,
+  canZoomOut: true,
 
   records: EMPTY_RECORDS,
   archive: [],
@@ -417,6 +430,7 @@ export const useMicroLand = create<MicroLandState>(set => ({
   setArchive: archive => set({ archive }),
   setMilestones: milestones => set({ milestones }),
   setCanPan: canPan => set({ canPan }),
+  setZoomState: (canZoomIn, canZoomOut) => set({ canZoomIn, canZoomOut }),
 
   setSaveState: saveState => set({ saveState }),
   setShelf: shelf => set({ shelf }),


### PR DESCRIPTION
Zoom for Micro Land, running both ways from the framing the game already had. `1×` stays the resting point; `−` pulls back to all 672 columns at once, `+` pushes in to 3× (roughly 75 tiles across a phone).

## How it works

Zoom lives entirely in the final blit. The world is still composed at one canvas pixel per tile into the same backbuffer, so pushing in costs nothing and pulling out costs only the wider column range every pass was already clipped to.

Pushed in far enough the world stops fitting top to bottom, and that is the only reason there is now a **vertical camera**. It's pinned to 0 and inert until the rows stop fitting — which is why the existing gestures grew a second axis rather than gaining a new mode. Drag, follow, edge-scroll-while-carrying and the minimap all aim a row now, and the minimap draws its view box in both directions.

Both cameras still floor to whole tiles before anything is drawn. A fractional camera resamples every tile onto a half-pixel and undoes the one thing the renderer exists to protect — that argument was never about the x axis.

**Anchored zoom** is what makes a pinch feel like a map rather than a fight: `setZoom` holds one world point still under the screen, measured off the fractional camera rather than `screenToWorld`, which floors. Two fingers are tracked incrementally rather than against the start of the gesture, unlike the one-finger drag — a pinch is a zoom and a pan at once, and an absolute anchor for each has them fighting over the same camera every frame.

## Controls

Four ways in, on purpose. Pinch and ctrl/⌘-wheel are what people already do (a trackpad pinch on macOS *is* a ctrl-wheel) but both are invisible, and this game's audience has never used either. The buttons are the version a child can find and a screen reader can announce.

| | |
|---|---|
| touch | pinch |
| trackpad / mouse | ctrl/⌘ + wheel |
| on screen | `+` / `−`, bottom-right |
| keys | `+` / `−`, `0` to reset |

Plain wheel still pans. Zoomed in it splits into two axes, with shift-wheel left as the way a single-wheel mouse crosses a world nine screens wide.

## Verified

Driven in a real browser at both ends of the range, desktop and a phone viewport:

- The anchored point holds to a colour distance of **0.0** under a ctrl-wheel zoom, where a centred button zoom moves it by **60**.
- Two-finger translation pans without disturbing the zoom; pinch reaches both ends of the range.
- Vertical camera reached by key and by drag; look-mode drag pans both axes.
- Pulled all the way out, the minimap and pan arrows take themselves off screen — there is nothing left to scroll to, and the view *is* the map.
- No console errors. `typecheck` clean, 161 micro-land tests pass, `sim:micro-land` still alive. The one `eslint` error in the game (`toolbar.tsx`) is pre-existing on main.

## Notes

- At full zoom-out on a phone a creature is about 2px. That end of the range is an overview, not a place to play — a deliberate trade.
- Zoom is a view preference, not world state: it resets to 1× on reload, and reopening a shelved world restores the saved column but not the zoom. Easy to persist if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)