### PR TITLE
fix(micro-land): stop a pan from selecting the page

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -612,6 +612,46 @@ body {
   }
 }
 
+/* ───────────────────────────────────────────────────────────────────
+   Micro Land — a canvas you drag your finger across, not a document
+   ─────────────────────────────────────────────────────────────────── */
+
+/*
+  The world is three screens wide, so swiping back and forth across it is the
+  main way you move — and a phone reads a slow horizontal drag over a page as
+  "start selecting text". The result was the whole game flashing blue mid-pan,
+  and a long press bringing up the copy/paste callout over a terrarium. The
+  canvas already had `touch-action: none`, which only stops scrolling; nothing
+  stopped selection, because selection is a document behaviour and this is a
+  game.
+
+  Set on the shell rather than the canvas because a selection that *starts* on
+  an unselectable canvas will happily still rope in the HUD and toolbar text
+  beside it. Both properties inherit, so one declaration covers the modals too.
+*/
+.micro-land-shell {
+  -webkit-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+}
+
+/* Typing a world's name still needs a cursor, a caret and a double-tap. */
+.micro-land-shell input,
+.micro-land-shell textarea {
+  -webkit-user-select: text;
+  user-select: text;
+  -webkit-touch-callout: default;
+}
+
+/*
+  Only the canvas. The toolbar chips have no hover state on a phone, so the tap
+  flash is the sole feedback that a tool was chosen — worth keeping there. On
+  the world it is just a grey rectangle over the land every time you pan.
+*/
+.micro-land-shell canvas {
+  -webkit-tap-highlight-color: transparent;
+}
+
 @layer base {
   :root {
     --background: 0 0% 100%;

--- a/src/app/micro-land/MicroLandGame.tsx
+++ b/src/app/micro-land/MicroLandGame.tsx
@@ -305,7 +305,7 @@ export function MicroLandGame() {
   }, [])
 
   return (
-    <div className="flex h-full w-full flex-col overflow-hidden">
+    <div className="micro-land-shell flex h-full w-full flex-col overflow-hidden">
       <Hud onReshuffle={handleReshuffle} onClearLife={handleClearLife} />
 
       <div className="relative min-h-0 flex-1">


### PR DESCRIPTION
On mobile, swiping back and forth across the world often made the page "select" — the canvas and surrounding chrome flashing blue mid-pan, and a long press raising the copy/paste callout over the terrarium.

The world is 672 tiles wide (three screens), so horizontal swiping is *the* way to get around it. That makes this something you hit constantly rather than an edge case, and it undercuts CLAUDE.md #7 (**hand-crafted, not templated**) — a game that highlights like a document is the loudest possible tell that it's a website with a canvas on it.

## Cause

The canvas carries `touch-none` (`touch-action: none`), which only suppresses **scrolling**. Text selection and the iOS long-press callout are separate document behaviours with separate properties, and nothing in the game set either — `grep -r user-select src/app/micro-land/` returned nothing.

## Fix

A `.micro-land-shell` block in `globals.css`, plus that one class on the game's root div.

- **On the shell, not the canvas.** A selection that *starts* on an unselectable canvas will still rope in the HUD and toolbar text beside it. Both properties inherit, so the single declaration also covers every modal (`WorldsPanel`, `SummonPanel`, `CreatureBuilder`, `FieldGuide`, `SettingsPanel`) and the new `ZoomControls`.
- **Inputs opt back in.** Safari's `-webkit-user-select: none` inherits *into* form fields and kills the caret and double-tap-to-select. Naming `input, textarea` rather than each field means new panels get it for free — all seven current fields are plain `<input>`, no `contentEditable` anywhere.
- **Tap highlight cleared on the canvas only.** The toolbar chips have no hover state on a phone, so that grey flash is their sole feedback that a tool was chosen; worth keeping there, worth losing over the land.

No simulation, tuning, or blueprint code is touched, so no ecosystem invariants are in play and the headless harness isn't relevant here.

## Verification

- `typecheck` — the 2 remaining errors are pre-existing on `main` in an unrelated trivia test (confirmed identical with this patch stashed)
- `lint` — exit 0
- `npm test -- src/app/micro-land` — 161/161 pass
- **Not yet verified on a real device.** Desktop device-emulation does not reproduce iOS selection behaviour, so this needs a phone: swipe the world (no blue flash), long-press it (no callout), then open **Worlds** and confirm the name field still takes a caret and double-tap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)