### PR TITLE
feat(micro-land): a line of creatures that stops being its species

### DIFF
--- a/scripts/micro-land-sim.ts
+++ b/scripts/micro-land-sim.ts
@@ -86,6 +86,21 @@ interface RunResult {
   solidFraction: number
   /** Tiles tunnelled through by creatures still alive at the end. */
   dug: number
+  /**
+   * blueprintId → what its survivors inherited, averaged.
+   *
+   * The only way to tell whether mutation is doing anything. Traits start at
+   * exactly 1.0 for everything the world places, so any species whose average
+   * has moved off 1.0 has been *selected* — the drift itself is symmetric and
+   * cancels out. A grazer under real predation should come out above 1 on speed;
+   * one that comes out at 1.00 after twenty generations means the pressure isn't
+   * reaching it, and the whole mechanic is decoration.
+   *
+   * `gen` is the check on the rest of the row: two generations of drift can't
+   * show anything, so a trait average is only worth reading next to how many
+   * generations produced it.
+   */
+  drift: Record<string, { speed: number; sight: number; lifespan: number; gen: number }>
 }
 
 function runOnce(seed: number): RunResult {
@@ -155,6 +170,25 @@ function runOnce(seed: number): RunResult {
   const survivors = countByBlueprint(world)
   const extinctions = [...seeded].filter(id => !survivors[id])
 
+  // Averaged over the survivors, which is the population selection actually
+  // produced — averaging over everything that ever lived would fold in exactly
+  // the individuals the world rejected and pull the answer back toward 1.
+  const drift: RunResult['drift'] = {}
+  for (const c of world.creatures) {
+    const d = (drift[c.blueprintId] ??= { speed: 0, sight: 0, lifespan: 0, gen: 0 })
+    d.speed += c.traits.speed
+    d.sight += c.traits.sight
+    d.lifespan += c.traits.lifespan
+    d.gen += c.generation
+  }
+  for (const [id, d] of Object.entries(drift)) {
+    const n = survivors[id] || 1
+    d.speed /= n
+    d.sight /= n
+    d.lifespan /= n
+    d.gen /= n
+  }
+
   return {
     survivors,
     extinctions,
@@ -164,6 +198,7 @@ function runOnce(seed: number): RunResult {
     meals,
     solidFraction: solidLeft / world.tiles.length,
     dug,
+    drift,
   }
 }
 
@@ -220,6 +255,22 @@ for (const id of [...allSpecies].sort()) {
     console.log(
       `  ${''.padEnd(16)} ate: ${Math.round(plants / runs)} plants, ` +
         `${Math.round(animals / runs)} animals`
+    )
+  }
+
+  // Only runs that still had one of these at the end have anything to say about
+  // what it inherited, so the average is over those rather than over `runs` —
+  // otherwise a species that thrived in two runs and died in three reads as
+  // having drifted 40% less than it did.
+  const drifted = results.map(r => r.drift[id]).filter(Boolean)
+  if (drifted.length > 0) {
+    const mean = (pick: (d: NonNullable<(typeof drifted)[number]>) => number) =>
+      drifted.reduce((a, d) => a + pick(d), 0) / drifted.length
+    console.log(
+      `  ${''.padEnd(16)} drift: speed ${mean(d => d.speed).toFixed(2)}  ` +
+        `sight ${mean(d => d.sight).toFixed(2)}  ` +
+        `life ${mean(d => d.lifespan).toFixed(2)}  ` +
+        `(gen ${mean(d => d.gen).toFixed(1)})`
     )
   }
 }

--- a/src/app/micro-land/components/inspector.tsx
+++ b/src/app/micro-land/components/inspector.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react'
 
 import { canEat } from '@/app/micro-land/domain/blueprint'
+import { notableTraits, traitPhrases } from '@/app/micro-land/domain/traits'
 import type { CreatureBlueprint } from '@/app/micro-land/domain/types'
 import { useMicroLand } from '@/app/micro-land/store'
 
@@ -34,6 +35,20 @@ const KIND_TEXT: Record<string, string> = {
   crawl: 'Climbs walls and ceilings',
   drift: 'Floats along',
   root: 'Rooted to the spot',
+}
+
+/**
+ * Join phrases the way a person would: "quick, sharp-eyed and long-lived".
+ *
+ * Capitalised at the front because it stands on its own line as a sentence
+ * rather than following anything.
+ */
+function sentence(parts: string[]): string {
+  const joined =
+    parts.length <= 1
+      ? parts.join('')
+      : `${parts.slice(0, -1).join(', ')} and ${parts[parts.length - 1]}`
+  return joined.charAt(0).toUpperCase() + joined.slice(1)
 }
 
 /** A springy walker is a hopper first — it is the thing you notice about it. */
@@ -116,6 +131,18 @@ export function Inspector({ onName }: { onName: (name: string) => boolean }) {
 
   const fullness = 1 - inspected.hunger
   const lifeLeft = Math.max(0, 1 - inspected.ageSeconds / Math.max(1, inspected.lifespanSeconds))
+
+  /**
+   * What this one inherited, said twice.
+   *
+   * The sentence is the point and the numbers are the footnote — a player should
+   * be able to learn that their hoppers are getting faster without ever reading
+   * a multiplier. Both are empty for anything placed by hand, which is every
+   * creature at generation 1, so a fresh world's panel looks exactly as it
+   * always did.
+   */
+  const phrases = traitPhrases(inspected.traits)
+  const traits = notableTraits(inspected.traits)
 
   const trouble =
     inspected.starving > 0
@@ -283,6 +310,23 @@ export function Inspector({ onName }: { onName: (name: string) => boolean }) {
           )}
         </div>
 
+        {/*
+          Sits directly under the mood, above the meters, because it is the one
+          line on this panel that is about *this* creature rather than about its
+          kind — everything below is true of every hopper alive.
+        */}
+        {phrases.length > 0 && (
+          <div
+            style={{
+              fontSize: 12,
+              lineHeight: 1.5,
+              color: 'var(--cc-gold)',
+            }}
+          >
+            {sentence(phrases)}
+          </div>
+        )}
+
         <Meter
           label="Full"
           value={fullness}
@@ -308,6 +352,15 @@ export function Inspector({ onName }: { onName: (name: string) => boolean }) {
           {inspected.generation > 1 && (
             <Stat label="Generation" value={String(inspected.generation)} />
           )}
+          {/*
+            The evidence under the sentence above. Only the traits that earned a
+            phrase are listed, and only as a ratio against the species — "1.24×"
+            says what "quicker than most" means without the panel having to
+            explain what a hopper's speed is in tiles per second.
+          */}
+          {traits.map(t => (
+            <Stat key={t.label} label={t.label} value={`${t.value.toFixed(2)}×`} />
+          ))}
           {bp.dig.through.length > 0 && (
             <Stat label="Tiles dug" value={String(inspected.tilesDug)} />
           )}

--- a/src/app/micro-land/domain/__tests__/traits.test.ts
+++ b/src/app/micro-land/domain/__tests__/traits.test.ts
@@ -1,0 +1,146 @@
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { makeRng } from '@/app/micro-land/domain/sim/prng'
+import {
+  NEUTRAL_TINT,
+  SHADE_MAX,
+  SHADE_MIN,
+  TRAIT_MAX,
+  TRAIT_MIN,
+  inherit,
+  neutralTraits,
+  notableTraits,
+  tintFromKey,
+  tintKey,
+  traitPhrases,
+} from '@/app/micro-land/domain/traits'
+import { resetTuning, setTuning } from '@/app/micro-land/domain/tuning'
+import type { Traits } from '@/app/micro-land/domain/types'
+
+afterEach(resetTuning)
+
+const rng = makeRng(4242)
+
+function traits(patch: Partial<Traits>): Traits {
+  return { ...neutralTraits(), ...patch }
+}
+
+describe('inherit', () => {
+  it('keeps a child near the midpoint of its two parents', () => {
+    const fast = traits({ speed: 1.4 })
+    const slow = traits({ speed: 1.0 })
+    for (let i = 0; i < 200; i++) {
+      const child = inherit(fast, slow, rng)
+      // Midpoint 1.2, plus at most one drift step either way.
+      expect(child.speed).toBeGreaterThanOrEqual(1.2 - 0.12 - 1e-9)
+      expect(child.speed).toBeLessThanOrEqual(1.2 + 0.12 + 1e-9)
+    }
+  })
+
+  it('drifts from the single parent when there is no partner', () => {
+    const parent = traits({ sight: 1.3 })
+    for (let i = 0; i < 200; i++) {
+      const child = inherit(parent, null, rng)
+      expect(child.sight).toBeGreaterThanOrEqual(1.3 - 0.12 - 1e-9)
+      expect(child.sight).toBeLessThanOrEqual(1.3 + 0.12 + 1e-9)
+    }
+  })
+
+  /**
+   * The reason the clamp exists. A line under relentless selection would
+   * otherwise walk to whatever number a long enough session produces, and both
+   * speed and sight feed systems tuned against the blueprint's value.
+   */
+  it('never escapes the clamp, however long the line runs', () => {
+    let line = traits({ speed: TRAIT_MAX, sight: TRAIT_MIN, lifespan: TRAIT_MAX })
+    for (let i = 0; i < 2000; i++) {
+      line = inherit(line, line, rng)
+      expect(line.speed).toBeLessThanOrEqual(TRAIT_MAX)
+      expect(line.speed).toBeGreaterThanOrEqual(TRAIT_MIN)
+      expect(line.sight).toBeGreaterThanOrEqual(TRAIT_MIN)
+      expect(line.lifespan).toBeLessThanOrEqual(TRAIT_MAX)
+      expect(line.shade).toBeGreaterThanOrEqual(SHADE_MIN)
+      expect(line.shade).toBeLessThanOrEqual(SHADE_MAX)
+    }
+  })
+
+  /**
+   * Two parents that look the same colour must produce a child that looks the
+   * same colour. A naive average puts 350° and 10° at 180° — the opposite side
+   * of the wheel — so a pair of red creatures would have a cyan baby.
+   */
+  it('averages hue the short way around the circle', () => {
+    const a = traits({ hue: 350 })
+    const b = traits({ hue: 10 })
+    for (let i = 0; i < 100; i++) {
+      const child = inherit(a, b, rng)
+      const fromZero = Math.min(child.hue, 360 - child.hue)
+      expect(fromZero).toBeLessThan(30)
+    }
+  })
+
+  it('keeps hue on the circle', () => {
+    let line = traits({ hue: 355 })
+    for (let i = 0; i < 500; i++) {
+      line = inherit(line, null, rng)
+      expect(line.hue).toBeGreaterThanOrEqual(0)
+      expect(line.hue).toBeLessThan(360)
+    }
+  })
+
+  it('stops entirely when the drift knob is at zero', () => {
+    setTuning({ traitDrift: 0 })
+    let line = neutralTraits()
+    for (let i = 0; i < 50; i++) line = inherit(line, line, rng)
+    expect(line).toEqual(neutralTraits())
+  })
+})
+
+describe('tint buckets', () => {
+  it('puts a neutral creature in the neutral bucket, which recolors nothing', () => {
+    expect(tintKey(neutralTraits())).toBe(NEUTRAL_TINT)
+    const { hue, shade } = tintFromKey(NEUTRAL_TINT)
+    expect(hue).toBe(0)
+    expect(shade).toBeCloseTo(1)
+  })
+
+  it('separates hues far enough apart to see', () => {
+    expect(tintKey(traits({ hue: 10 }))).not.toBe(tintKey(traits({ hue: 190 })))
+  })
+
+  it('collapses hues too close together to see, so the cache stays a cache', () => {
+    expect(tintKey(traits({ hue: 1 }))).toBe(tintKey(traits({ hue: 9 })))
+  })
+
+  it('survives a hue at either end of the circle', () => {
+    for (const hue of [0, 359.999, 360, -0.001]) {
+      const key = tintKey(traits({ hue }))
+      expect(Number.isFinite(key)).toBe(true)
+      expect(key).toBeGreaterThanOrEqual(0)
+    }
+  })
+})
+
+describe('what the panel says', () => {
+  it('says nothing at all about a creature that was placed rather than born', () => {
+    expect(traitPhrases(neutralTraits())).toEqual([])
+    expect(notableTraits(neutralTraits())).toEqual([])
+  })
+
+  it('agrees with itself about what is worth mentioning', () => {
+    // A phrase with no number under it, or a number with no phrase, reads as a
+    // broken panel — the two share one threshold precisely to prevent that.
+    for (const speed of [0.6, 0.85, 0.91, 1, 1.09, 1.15, 1.6]) {
+      const t = traits({ speed })
+      const hasPhrase = traitPhrases(t).length > 0
+      const hasNumber = notableTraits(t).length > 0
+      expect(hasPhrase, `speed ${speed}`).toBe(hasNumber)
+    }
+  })
+
+  it('names the direction, not just the difference', () => {
+    expect(traitPhrases(traits({ speed: 1.4 }))).toContain('quicker than most')
+    expect(traitPhrases(traits({ speed: 0.7 }))).toContain('slower than most')
+    expect(traitPhrases(traits({ lifespan: 1.4 }))).toContain('long-lived')
+  })
+})

--- a/src/app/micro-land/domain/constants.ts
+++ b/src/app/micro-land/domain/constants.ts
@@ -174,6 +174,36 @@ export const BREED_COOLDOWN = 12
 export const MATE_RADIUS = 6
 
 /**
+ * How far a child's heritable traits may fall from its parents'.
+ *
+ * Every creature carries a handful of numbers of its own — how fast it is, how
+ * far it sees, how long it lives, what colour it is — as multipliers on its
+ * species' blueprint. A child takes the midpoint of its two parents and then
+ * moves by up to this much in either direction. That is the entire mutation
+ * mechanic; the world's existing pressures (predators, starvation, drowning) do
+ * the selecting for free.
+ *
+ * This number carries *all* of the variation, which is why it is as large as it
+ * is. Founders are deliberately identical — every creature placed by hand, and
+ * every plant the ground seeds, is exactly 1.0 on everything — so a new world
+ * starts with no variance at all and every difference you ever see was
+ * manufactured here, one birth at a time.
+ *
+ * Blending halves the spread each generation while this puts some back, so a
+ * population settles at a standard deviation of about `drift * sqrt(2/3)` —
+ * 0.10 at 0.12. That is the number to reason with: it is roughly how far apart
+ * two siblings are, and therefore how much raw material selection has to work
+ * on in any one generation. At 0.04 the drift is real but takes a hundred
+ * generations to see, which is longer than any world survives. At 0.12 a line
+ * under steady pressure visibly separates from its founders in about ten.
+ *
+ * Zero is a legitimate setting and turns inheritance off entirely: every
+ * creature is then exactly its blueprint, which is how the game behaved before
+ * any of this existed.
+ */
+export const TRAIT_DRIFT = 0.12
+
+/**
  * Plants play by different rules, and they have to.
  *
  * A grazer empties its stomach every ~15s, so a dozen of them strip the map far

--- a/src/app/micro-land/domain/sim/creature-sim.ts
+++ b/src/app/micro-land/domain/sim/creature-sim.ts
@@ -30,6 +30,7 @@ import {
   WORLD_H,
   WORLD_W,
 } from '@/app/micro-land/domain/constants'
+import { inherit, lifespanOf, sightOf, speedOf } from '@/app/micro-land/domain/traits'
 import { TUNING } from '@/app/micro-land/domain/tuning'
 import type { Creature, CreatureBlueprint, WorldState } from '@/app/micro-land/domain/types'
 
@@ -127,9 +128,13 @@ function compareX(a: Creature, b: Creature): number {
  * Plants get a flat few seconds; everything else gets a fifth of its own
  * lifespan, so a mayfly and a dragon are both "grown" at the same point in
  * their own story rather than at the same wall-clock moment.
+ *
+ * A fifth of *this creature's* lifespan, not its species' — a short-lived line
+ * that matured on the species clock would die before it was ever allowed to
+ * breed. See `lifespanOf`.
  */
-function breedingAge(bp: CreatureBlueprint): number {
-  return bp.move.kind === 'root' ? TUNING.plantMaturity : bp.diet.lifespanSeconds * 0.2
+function breedingAge(c: Creature, bp: CreatureBlueprint): number {
+  return bp.move.kind === 'root' ? TUNING.plantMaturity : lifespanOf(c, bp) * 0.2
 }
 
 /**
@@ -166,7 +171,9 @@ function needsPartner(bp: CreatureBlueprint): boolean {
  * about the population rather than about this animal.
  */
 function readyToBreed(c: Creature, bp: CreatureBlueprint): boolean {
-  return c.breedCooldown <= 0 && 1 - c.hunger >= bp.diet.breedAt && c.ageSeconds > breedingAge(bp)
+  return (
+    c.breedCooldown <= 0 && 1 - c.hunger >= bp.diet.breedAt && c.ageSeconds > breedingAge(c, bp)
+  )
 }
 
 /**
@@ -283,7 +290,7 @@ export function tickCreatures(
     }
 
     // --- old age --------------------------------------------------------
-    if (c.ageSeconds >= bp.diet.lifespanSeconds) {
+    if (c.ageSeconds >= lifespanOf(c, bp)) {
       kill(w, c, bp, dead, events, 'aged')
       continue
     }
@@ -371,6 +378,12 @@ export function tickCreatures(
           // counts ancestry, so a bloodline shouldn't get shallower by marrying
           // into a newer one.
           child.generation = Math.max(c.generation, mate?.generation ?? 0) + 1
+          // Set here for the same reason as the generation above, and from the
+          // same two parents. `spawnCreature` gave the child its species'
+          // neutral values; this is the only place in the game that ever
+          // replaces them, which is what makes "born here" and "put here" two
+          // genuinely different things.
+          child.traits = inherit(c.traits, mate?.traits ?? null, rng)
           c.children++
           speciesCount[bp.id] = (speciesCount[bp.id] ?? 0) + 1
           if (isPlant) {
@@ -431,7 +444,9 @@ function look(
   const cy = c.y + bh / 2
   const hungry = c.hunger > 0.3
 
-  const sight = bp.senses.sight
+  // This creature's sight, not its species' — everything downstream, including
+  // the foraging reach and the window the loop below walks, is measured off it.
+  const sight = sightOf(c, bp)
   const sight2 = sight * sight
 
   /**
@@ -936,7 +951,7 @@ function steer(w: WorldState, c: Creature, bp: CreatureBlueprint, dt: number, rn
     c.targetId = null
   }
 
-  const speed = bp.move.speed
+  const speed = speedOf(c, bp)
   const accel = speed * 6
   const digger = bp.dig.through.length > 0
 

--- a/src/app/micro-land/domain/sim/world.ts
+++ b/src/app/micro-land/domain/sim/world.ts
@@ -18,6 +18,7 @@ import {
   WORLD_H,
   WORLD_W,
 } from '@/app/micro-land/domain/constants'
+import { neutralTraits } from '@/app/micro-land/domain/traits'
 import { TUNING } from '@/app/micro-land/domain/tuning'
 import type {
   Creature,
@@ -364,8 +365,15 @@ export function spawnCreature(
     children: 0,
     digProgress: 0,
     tilesDug: 0,
-    // Founder of its line until `reproduce` says otherwise.
+    // Founder of its line until `reproduce` says otherwise — and, being a
+    // founder, exactly its species. Every creature this function makes is one
+    // the world put there rather than one that was born: placed by hand, seeded
+    // by the ground, dropped in by a theme. Inheritance is applied by the
+    // breeding block afterwards, so this is also what makes a species that died
+    // out and was placed again start over from the blueprint rather than from
+    // wherever its last line had drifted to.
     generation: 1,
+    traits: neutralTraits(),
     name: null,
   }
   w.creatures.push(creature)

--- a/src/app/micro-land/domain/traits.ts
+++ b/src/app/micro-land/domain/traits.ts
@@ -1,0 +1,253 @@
+/**
+ * Heritable variation — where a line of creatures stops being its species.
+ *
+ * A blueprint is shared by every creature that has it, so a mutation cannot go
+ * there without every hopper alive mutating at once. Instead each creature
+ * carries a `Traits` object (see `types.ts`) of multipliers applied on top of
+ * its species, and a child takes the midpoint of its two parents plus a small
+ * random nudge. That is the whole mechanic. There is no fitness function and
+ * nothing scores anything: the world already kills the slow, the short-sighted
+ * and the unlucky, so pointing inheritance at numbers the world already tests is
+ * enough to make selection happen on its own.
+ *
+ * Two consequences worth knowing before touching anything here.
+ *
+ * **Founders are identical.** Everything placed by hand, seeded by the ground or
+ * dropped in by a theme is exactly neutral — 1.0 on every multiplier, 0 hue.
+ * Every difference in a world was therefore made by `inherit`, one birth at a
+ * time. That is a deliberate choice rather than an oversight: it is what makes
+ * "this species died out and I placed another" mean the line genuinely started
+ * over, and it is why `TRAIT_DRIFT` has to be big enough to carry the entire
+ * spread by itself.
+ *
+ * **Blending loses variance.** Averaging two parents halves the population's
+ * spread every generation, so without the nudge a species would converge on its
+ * founders and stay there forever. The two settle at a standard deviation of
+ * about `drift * sqrt(2/3)`; see `TRAIT_DRIFT` for what that buys.
+ */
+// Drift is read off `TUNING`, never off the constant it defaults to — the
+// settings panel can move it while the world runs, and reading the constant here
+// is exactly the mistake `constants.ts` warns about at the top of the file.
+import { TUNING } from '@/app/micro-land/domain/tuning'
+import type { Creature, CreatureBlueprint, Traits } from '@/app/micro-land/domain/types'
+
+import type { Rng } from './sim/prng'
+
+/**
+ * How far the scaling traits may drift from the blueprint, in either direction.
+ *
+ * Wide enough that a line under real pressure can become visibly different, and
+ * hard enough that it can't become absurd. The ceiling is the load-bearing end:
+ * speed feeds `clampMag` on velocity and sight feeds the sense pass's search
+ * window, and both were tuned against a world where the blueprint's number was
+ * the final answer. A creature at four times its species' speed would cross a
+ * tile faster than collision samples one; one at four times its sight would drag
+ * the O(n²) neighbour walk back to the whole population it was rewritten to
+ * avoid. 1.6 is a big animal, not a broken one.
+ *
+ * The floor matters less but still exists — a line drifting toward zero speed
+ * stops being able to reach food, which is a slow death the player can't read as
+ * anything but the game breaking.
+ */
+export const TRAIT_MIN = 0.6
+export const TRAIT_MAX = 1.6
+
+/** Lightness gets a much shorter leash — see `Traits.shade`. */
+export const SHADE_MIN = 0.82
+export const SHADE_MAX = 1.18
+
+/**
+ * How far hue may move in one birth, in degrees, relative to `TRAIT_DRIFT`.
+ *
+ * Scaled off the same knob so that turning drift off turns *all* of it off, and
+ * so the panel has one honest control rather than one that stops half the
+ * mechanic. 120° per unit of drift means the shipped 0.12 moves a child about
+ * 14° from its parents — a step you can't see, in a walk you can: colour is the
+ * one trait nothing selects on, so it wanders freely and a small population's
+ * average can travel right around the wheel over a long session.
+ */
+const HUE_DRIFT_SCALE = 120
+
+export const NEUTRAL_TRAITS: Traits = Object.freeze({
+  speed: 1,
+  sight: 1,
+  lifespan: 1,
+  hue: 0,
+  shade: 1,
+})
+
+/** A fresh set for a creature that wasn't born here. Always a copy — it's mutable state. */
+export function neutralTraits(): Traits {
+  return { ...NEUTRAL_TRAITS }
+}
+
+function clamp(v: number, lo: number, hi: number): number {
+  return v < lo ? lo : v > hi ? hi : v
+}
+
+/** Uniform in [-amount, +amount]. */
+function nudge(rng: Rng, amount: number): number {
+  return (rng() * 2 - 1) * amount
+}
+
+/**
+ * Average two hues the short way around the circle.
+ *
+ * Hue is the one trait that wraps, and a naive `(a + b) / 2` gets it exactly
+ * backwards at the seam: two parents at 350° and 10° are the same colour to look
+ * at, and their midpoint is 180° — the opposite one. A pair of nearly identical
+ * red creatures would produce a cyan child, which reads as the mutation system
+ * being random rather than heritable, and only near red, which makes it look
+ * like a rendering bug rather than a maths one.
+ */
+function blendHue(a: number, b: number): number {
+  const delta = ((b - a + 540) % 360) - 180
+  return wrapHue(a + delta / 2)
+}
+
+function wrapHue(h: number): number {
+  return ((h % 360) + 360) % 360
+}
+
+/**
+ * What a child inherits.
+ *
+ * `b` is null for anything that reproduces alone — which today means plants,
+ * and means them for a reason (see the breeding block in `creature-sim.ts`).
+ * A single parent passes on its own values rather than a blend, so a plant line
+ * drifts as a pure random walk while an animal line is pulled toward whatever
+ * its population's average happens to be.
+ */
+export function inherit(a: Traits, b: Traits | null, rng: Rng): Traits {
+  const drift = TUNING.traitDrift
+  const hueDrift = drift * HUE_DRIFT_SCALE
+  const mix = (key: 'speed' | 'sight' | 'lifespan' | 'shade') =>
+    b ? (a[key] + b[key]) / 2 : a[key]
+
+  return {
+    speed: clamp(mix('speed') + nudge(rng, drift), TRAIT_MIN, TRAIT_MAX),
+    sight: clamp(mix('sight') + nudge(rng, drift), TRAIT_MIN, TRAIT_MAX),
+    lifespan: clamp(mix('lifespan') + nudge(rng, drift), TRAIT_MIN, TRAIT_MAX),
+    hue: wrapHue((b ? blendHue(a.hue, b.hue) : a.hue) + nudge(rng, hueDrift)),
+    shade: clamp(mix('shade') + nudge(rng, drift), SHADE_MIN, SHADE_MAX),
+  }
+}
+
+// ---------------------------------------------------------------------------
+// What the simulation reads
+// ---------------------------------------------------------------------------
+//
+// Three accessors rather than three multiplications scattered through the sim.
+// The point is that there is exactly one place per trait where the blueprint's
+// number turns into this creature's number, so a fourth read site added later
+// can't quietly go on using the species value.
+
+export function speedOf(c: Creature, bp: CreatureBlueprint): number {
+  return bp.move.speed * c.traits.speed
+}
+
+export function sightOf(c: Creature, bp: CreatureBlueprint): number {
+  return bp.senses.sight * c.traits.sight
+}
+
+/**
+ * How long this one gets.
+ *
+ * Breeding age is a fifth of the lifespan, and it reads this rather than the
+ * blueprint for a reason that took a while to see coming: if death scaled and
+ * maturity didn't, a creature at the bottom of the lifespan range would reach a
+ * maturity set by its species *after* it had already died of old age. Short life
+ * would be perfectly heritable and perfectly sterile, so selection would delete
+ * it in one generation — not because short-lived creatures do badly in the
+ * world, but because they were never allowed to breed at all.
+ */
+export function lifespanOf(c: Creature, bp: CreatureBlueprint): number {
+  return bp.diet.lifespanSeconds * c.traits.lifespan
+}
+
+// ---------------------------------------------------------------------------
+// Colour, as the sprite cache wants it
+// ---------------------------------------------------------------------------
+
+/**
+ * Hue and shade are quantized before they reach the renderer.
+ *
+ * Sprites are rasterized once per blueprint and kept, because they are the same
+ * handful of pixels every frame. A continuous per-creature colour would mean
+ * either re-rasterizing a sprite every time anything moved or filtering a canvas
+ * per draw, and both give back exactly the cost the cache exists to avoid.
+ *
+ * Bucketing keeps it a cache. Twelve hues by three shades is 36 possible
+ * variants per species, most worlds touch a handful, and two hoppers thirty
+ * degrees apart are still visibly different colours — which is all this has to
+ * be, because nothing here is trying to render a gradient.
+ */
+export const HUE_BUCKETS = 12
+export const SHADE_BUCKETS = 3
+
+/** The bucket a neutral creature lands in. Anything else means a recolor. */
+export const NEUTRAL_TINT = tintKey(NEUTRAL_TRAITS)
+
+export function tintKey(t: Traits): number {
+  const hue = Math.floor(wrapHue(t.hue) / (360 / HUE_BUCKETS)) % HUE_BUCKETS
+  const span = (SHADE_MAX - SHADE_MIN) / SHADE_BUCKETS
+  const shade = Math.min(SHADE_BUCKETS - 1, Math.max(0, Math.floor((t.shade - SHADE_MIN) / span)))
+  return hue * SHADE_BUCKETS + shade
+}
+
+/** The colour a bucket stands for: the middle of the range it covers. */
+export function tintFromKey(key: number): { hue: number; shade: number } {
+  const hueStep = 360 / HUE_BUCKETS
+  const shadeStep = (SHADE_MAX - SHADE_MIN) / SHADE_BUCKETS
+  return {
+    hue: Math.floor(key / SHADE_BUCKETS) * hueStep,
+    shade: SHADE_MIN + ((key % SHADE_BUCKETS) + 0.5) * shadeStep,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Saying it out loud
+// ---------------------------------------------------------------------------
+
+/**
+ * How far from its species a trait has to be before it's worth mentioning.
+ *
+ * Set at roughly the population's own standard deviation, so a phrase means
+ * "unusual for its kind" rather than "not exactly average". Below this every
+ * creature born would carry a label and the labels would stop meaning anything.
+ */
+const NOTABLE = 0.1
+
+/**
+ * What makes this one different, in words a child can read.
+ *
+ * The inspector shows these above the numbers rather than instead of them —
+ * "quicker than most" is what the trait *is*, and 1.24 is the evidence. Colour
+ * is left out on purpose: it's already on screen.
+ */
+export function traitPhrases(t: Traits): string[] {
+  const phrases: string[] = []
+  if (t.speed >= 1 + NOTABLE) phrases.push('quicker than most')
+  else if (t.speed <= 1 - NOTABLE) phrases.push('slower than most')
+  if (t.sight >= 1 + NOTABLE) phrases.push('sharp-eyed')
+  else if (t.sight <= 1 - NOTABLE) phrases.push('short-sighted')
+  if (t.lifespan >= 1 + NOTABLE) phrases.push('long-lived')
+  else if (t.lifespan <= 1 - NOTABLE) phrases.push('short-lived')
+  return phrases
+}
+
+/**
+ * The same traits as numbers, for the panel to print under the phrases.
+ *
+ * Shares `NOTABLE` with `traitPhrases` rather than restating it, so the two can
+ * never disagree about which traits are worth mentioning — a creature described
+ * as quicker than most and then shown no speed to back it up reads as the panel
+ * being broken.
+ */
+export function notableTraits(t: Traits): { label: string; value: number }[] {
+  return [
+    { label: 'Own speed', value: t.speed },
+    { label: 'Own sight', value: t.sight },
+    { label: 'Own lifespan', value: t.lifespan },
+  ].filter(entry => Math.abs(entry.value - 1) >= NOTABLE)
+}

--- a/src/app/micro-land/domain/tuning.ts
+++ b/src/app/micro-land/domain/tuning.ts
@@ -37,6 +37,7 @@ import {
   PLANT_SPECIES_CAP,
   PLANT_SPREAD_COOLDOWN,
   SPECIES_SOFT_CAP,
+  TRAIT_DRIFT,
 } from '@/app/micro-land/domain/constants'
 
 /**
@@ -63,6 +64,7 @@ export const TUNING_DEFAULTS = {
   mateRadius: MATE_RADIUS,
   mealValue: MEAL_VALUE,
   breedCost: BREED_COST,
+  traitDrift: TRAIT_DRIFT,
 
   gravity: GRAVITY,
 }
@@ -241,6 +243,15 @@ export const KNOBS: Knob[] = [
     help: 'How much of a full stomach having one uses up.',
     min: 0.1,
     max: 1,
+    step: 0.01,
+  },
+  {
+    key: 'traitDrift',
+    group: 'creatures',
+    label: 'How much a baby takes after its parents',
+    help: 'Every animal is a little faster or slower, sharper-eyed or blinder, longer or shorter lived than the two it came from, and a little different in colour. This is how big that step is. Turn it up and a family changes in front of you; set it to nothing and every creature is exactly its own kind forever. Nothing you place is ever affected — only things born here.',
+    min: 0,
+    max: 0.4,
     step: 0.01,
   },
   {

--- a/src/app/micro-land/domain/types.ts
+++ b/src/app/micro-land/domain/types.ts
@@ -307,6 +307,45 @@ export const LIFE_KINDS: LifeKind[] = ['plant', 'animal']
 
 export type CreatureMood = 'wander' | 'hunt' | 'flee' | 'eat' | 'rest' | 'mate'
 
+/**
+ * The small part of a creature that is its own rather than its species'.
+ *
+ * A blueprint is shared by every creature that has it — one object, in
+ * `WorldState.blueprints`, read by all of them. That is the premise the whole
+ * game rests on and it is not up for negotiation, so heritable variation cannot
+ * live in the blueprint. It lives here instead: per-creature numbers applied
+ * *on top of* the species, passed from parents to children with a nudge.
+ *
+ * Everything here is deliberately a modifier rather than a value. A hopper's
+ * speed is still the hopper's speed; this says whether this particular hopper is
+ * a little quicker than its parents were. It also means a trait can never make a
+ * creature into something the blueprint didn't describe — the food chain (size
+ * and tags) and the economics of eating (`hungerRate`, `breedAt`) are not in
+ * here on purpose, because those are what the ecosystem was balanced against.
+ *
+ * See `domain/traits.ts` for how these are inherited and what reads them.
+ */
+export interface Traits {
+  /** Multiplier on `move.speed`. */
+  speed: number
+  /** Multiplier on `senses.sight`. */
+  sight: number
+  /** Multiplier on `diet.lifespanSeconds` — and so on breeding age with it. */
+  lifespan: number
+  /** Hue rotation applied to the whole palette, in degrees. Wraps. */
+  hue: number
+  /**
+   * Multiplier on the palette's lightness.
+   *
+   * Carried alongside `hue` because hue rotation does nothing whatsoever to a
+   * grey: a species drawn in white and charcoal would drift for a thousand
+   * generations and never once look different. Clamped far tighter than the
+   * others — a line that drifted to twice its lightness would be a white smear
+   * against the sky, and one at half would vanish into the dark.
+   */
+  shade: number
+}
+
 /** One living thing in the world. */
 export interface Creature {
   id: number
@@ -355,6 +394,13 @@ export interface Creature {
    * can dwindle to a single individual and its line keeps its depth.
    */
   generation: number
+  /**
+   * What this one inherited, as multipliers on its species.
+   *
+   * Neutral for anything that wasn't born here, which is what makes a species
+   * that dies out and is placed again genuinely start over rather than resume.
+   */
+  traits: Traits
   /**
    * What the player called it.
    *

--- a/src/app/micro-land/game-instance.ts
+++ b/src/app/micro-land/game-instance.ts
@@ -53,6 +53,7 @@ import {
   spawnCreature,
   spawnSomewhereSensible,
 } from './domain/sim/world'
+import { lifespanOf } from './domain/traits'
 import { TUNING } from './domain/tuning'
 import {
   type Creature,
@@ -812,7 +813,10 @@ export class GameInstance {
       mood: c.mood,
       hunger: c.hunger,
       ageSeconds: c.ageSeconds,
-      lifespanSeconds: bp.diet.lifespanSeconds,
+      // This one's lifespan, not its species' — a long-lived creature showing a
+      // "life left" meter drawn against the blueprint would sit at empty for the
+      // whole of the extra life its line earned it.
+      lifespanSeconds: lifespanOf(c, bp),
       mealsEaten: c.mealsEaten,
       children: c.children,
       tilesDug: c.tilesDug,
@@ -823,6 +827,10 @@ export class GameInstance {
       grounded: c.grounded,
       targetName: targetBp?.name ?? null,
       generation: c.generation,
+      // Copied, like everything else here. Traits are replaced wholesale rather
+      // than mutated, so the reference would in fact be safe today — but that is
+      // a fact about `inherit`, and this panel shouldn't depend on it.
+      traits: { ...c.traits },
       name: c.name,
       isElder: c.id === this.elderId,
     })

--- a/src/app/micro-land/rendering/renderer.ts
+++ b/src/app/micro-land/rendering/renderer.ts
@@ -28,6 +28,7 @@
 import { MATERIAL_BY_INDEX } from '@/app/micro-land/domain/config/materials'
 import type { Theme } from '@/app/micro-land/domain/config/themes'
 import { VIEW_W, WORLD_H, WORLD_W } from '@/app/micro-land/domain/constants'
+import { tintKey } from '@/app/micro-land/domain/traits'
 import type { WorldState } from '@/app/micro-land/domain/types'
 
 import { getSprites } from './sprite-cache'
@@ -692,7 +693,9 @@ export class Renderer {
     for (const c of w.creatures) {
       const bp = w.blueprints[c.blueprintId]
       if (!bp) continue
-      const sprites = getSprites(bp)
+      // Its own colour, not its species'. `tintKey` quantizes, so a whole
+      // population that has drifted together shares one cached set.
+      const sprites = getSprites(bp, tintKey(c.traits))
       // Most of the population is off screen in a world this wide. Culling here
       // is what keeps the draw cost tied to what you can see rather than to how
       // many things happen to be alive.

--- a/src/app/micro-land/rendering/sprite-cache.ts
+++ b/src/app/micro-land/rendering/sprite-cache.ts
@@ -5,7 +5,15 @@
  *
  * Sprites are one canvas pixel per world tile. All the scaling happens once, at
  * the very end of the render, so everything stays on the same pixel grid.
+ *
+ * Since creatures inherit a colour of their own, a blueprint no longer names one
+ * drawing but up to `HUE_BUCKETS * SHADE_BUCKETS` of them. Recolouring is done to
+ * the *palette* — a dozen hex strings — before rasterizing, rather than to the
+ * pixels afterwards: the art is a few hundred pixels and the palette is twelve
+ * entries, so working on the palette is the cheaper end by an order of magnitude
+ * and it keeps every pixel exactly on the grid.
  */
+import { NEUTRAL_TINT, tintFromKey } from '@/app/micro-land/domain/traits'
 import type { CreatureBlueprint } from '@/app/micro-land/domain/types'
 
 export interface SpriteSet {
@@ -16,9 +24,91 @@ export interface SpriteSet {
   frameMs: number
 }
 
-const cache = new Map<string, SpriteSet>()
+/**
+ * Two caches, because the two have completely different lifetimes.
+ *
+ * Every creature that has never bred is neutral, so the neutral set is what the
+ * overwhelming majority of draws ask for and it is never worth evicting. Tinted
+ * variants are the long tail: a species can touch up to 36 of them over a long
+ * session, most of them for a handful of creatures, and a world with thirty
+ * summoned species could otherwise sit on a thousand canvases it will never draw
+ * again.
+ */
+const neutral = new Map<string, SpriteSet>()
+const tinted = new Map<string, SpriteSet>()
 
-function rasterize(bp: CreatureBlueprint, rows: string[]): HTMLCanvasElement {
+/**
+ * How many tinted sets to keep before dropping the least recently drawn.
+ *
+ * Generous enough that everything visible at once stays cached — the cap is on
+ * *variants*, and no single screen contains anywhere near this many distinct
+ * species-and-colour pairs — and small enough to bound the memory at a few
+ * megabytes of very small canvases. A miss only costs one rasterize of a sprite
+ * no bigger than 28×24.
+ */
+const MAX_TINTED = 240
+
+function hexToRgb(hex: string): [number, number, number] {
+  const n = parseInt(hex.slice(1), 16)
+  return [(n >> 16) & 255, (n >> 8) & 255, n & 255]
+}
+
+/**
+ * Rotate a colour's hue and scale its lightness.
+ *
+ * Goes through HSL rather than doing anything clever to the channels directly,
+ * because hue is an angle and the whole mechanic is a walk around that circle;
+ * per-channel arithmetic can lighten and desaturate but it cannot *rotate*, so a
+ * green creature could never become a blue one.
+ */
+function shiftColor(hex: string, hueShift: number, shade: number): string {
+  const [r255, g255, b255] = hexToRgb(hex)
+  const r = r255 / 255
+  const g = g255 / 255
+  const b = b255 / 255
+  const max = Math.max(r, g, b)
+  const min = Math.min(r, g, b)
+  const l = (max + min) / 2
+  const d = max - min
+
+  let h = 0
+  let s = 0
+  if (d !== 0) {
+    s = l > 0.5 ? d / (2 - max - min) : d / (max + min)
+    if (max === r) h = ((g - b) / d + (g < b ? 6 : 0)) / 6
+    else if (max === g) h = ((b - r) / d + 2) / 6
+    else h = ((r - g) / d + 4) / 6
+  }
+
+  h = (((h + hueShift / 360) % 1) + 1) % 1
+  // Clamped rather than wrapped: a highlight pushed past white should stop at
+  // white, not come back round as black.
+  const l2 = Math.max(0, Math.min(1, l * shade))
+
+  const q = l2 < 0.5 ? l2 * (1 + s) : l2 + s - l2 * s
+  const p = 2 * l2 - q
+  const channel = (t: number) => {
+    let v = t
+    if (v < 0) v += 1
+    if (v > 1) v -= 1
+    if (v < 1 / 6) return p + (q - p) * 6 * v
+    if (v < 1 / 2) return q
+    if (v < 2 / 3) return p + (q - p) * (2 / 3 - v) * 6
+    return p
+  }
+
+  const out = (v: number) =>
+    Math.round(Math.max(0, Math.min(1, v)) * 255)
+      .toString(16)
+      .padStart(2, '0')
+  return `#${out(channel(h + 1 / 3))}${out(channel(h))}${out(channel(h - 1 / 3))}`
+}
+
+function rasterize(
+  bp: CreatureBlueprint,
+  rows: string[],
+  palette: Record<string, string>
+): HTMLCanvasElement {
   const height = rows.length
   const width = rows[0].length
   const canvas = document.createElement('canvas')
@@ -35,7 +125,7 @@ function rasterize(bp: CreatureBlueprint, rows: string[]): HTMLCanvasElement {
     for (let x = 0; x < width; x++) {
       const ch = row[x]
       if (ch === '.' || ch === undefined) continue
-      const hex = bp.art.palette[ch]
+      const hex = palette[ch]
       if (!hex) continue
       const n = parseInt(hex.slice(1), 16)
       const o = (y * width + x) * 4
@@ -63,19 +153,58 @@ function mirror(source: HTMLCanvasElement): HTMLCanvasElement {
   return canvas
 }
 
-export function getSprites(bp: CreatureBlueprint): SpriteSet {
-  const existing = cache.get(bp.id)
-  if (existing) return existing
+function build(bp: CreatureBlueprint, tint: number): SpriteSet {
+  let palette = bp.art.palette
+  if (tint !== NEUTRAL_TINT) {
+    const { hue, shade } = tintFromKey(tint)
+    palette = {}
+    for (const [key, hex] of Object.entries(bp.art.palette)) {
+      palette[key] = shiftColor(hex, hue, shade)
+    }
+  }
 
-  const frames = bp.art.frames.map(rows => rasterize(bp, rows))
-  const set: SpriteSet = {
+  const frames = bp.art.frames.map(rows => rasterize(bp, rows, palette))
+  return {
     width: frames[0].width,
     height: frames[0].height,
     frames,
     flipped: bp.art.faceMotion ? frames.map(mirror) : frames,
     frameMs: bp.art.frameMs,
   }
-  cache.set(bp.id, set)
+}
+
+/**
+ * The sprites for one creature, in its own colour.
+ *
+ * `tint` comes from `tintKey(creature.traits)`; passing the neutral bucket gets
+ * the blueprint exactly as it was drawn, which is both the common case and the
+ * fast path.
+ */
+export function getSprites(bp: CreatureBlueprint, tint: number = NEUTRAL_TINT): SpriteSet {
+  if (tint === NEUTRAL_TINT) {
+    const existing = neutral.get(bp.id)
+    if (existing) return existing
+    const set = build(bp, tint)
+    neutral.set(bp.id, set)
+    return set
+  }
+
+  const key = `${bp.id}|${tint}`
+  const existing = tinted.get(key)
+  if (existing) {
+    // Re-insert to move it to the back of the Map's insertion order, which is
+    // the whole of the LRU: the eviction below always takes the front.
+    tinted.delete(key)
+    tinted.set(key, existing)
+    return existing
+  }
+
+  const set = build(bp, tint)
+  tinted.set(key, set)
+  if (tinted.size > MAX_TINTED) {
+    const oldest = tinted.keys().next()
+    if (!oldest.done) tinted.delete(oldest.value)
+  }
   return set
 }
 
@@ -86,11 +215,21 @@ export function getSprites(bp: CreatureBlueprint): SpriteSet {
  * only way to change a creature was to invent a new one. Editing in place
  * breaks that: without this, a repainted Hopper keeps showing its old colours
  * for the rest of the session, and the edit looks like it never saved.
+ *
+ * Every tint has to go with it. An id no longer names one entry, and dropping
+ * only the neutral one would leave a repainted creature showing its old drawing
+ * for as long as its line stayed off-neutral — which is to say, for exactly the
+ * creatures whose colour the player is most likely to be watching.
  */
 export function forgetSprites(id: string): void {
-  cache.delete(id)
+  neutral.delete(id)
+  const prefix = `${id}|`
+  for (const key of tinted.keys()) {
+    if (key.startsWith(prefix)) tinted.delete(key)
+  }
 }
 
 export function clearSpriteCache(): void {
-  cache.clear()
+  neutral.clear()
+  tinted.clear()
 }

--- a/src/app/micro-land/store.ts
+++ b/src/app/micro-land/store.ts
@@ -23,7 +23,7 @@ import {
 
 import type { SaveState } from './chronicle/chronicle'
 import type { ElderRecord, SpeciesRecord } from './chronicle/types'
-import type { CreatureBlueprint, LifeKind, MaterialId } from './domain/types'
+import type { CreatureBlueprint, LifeKind, MaterialId, Traits } from './domain/types'
 import type { ShelfState } from './worlds/shelf'
 
 /** Theme id standing for "the land the player summoned". */
@@ -63,6 +63,8 @@ export interface Inspected {
   targetName: string | null
   /** How far back its line goes; 1 means it was placed rather than born. */
   generation: number
+  /** What it inherited, as multipliers on its species. Neutral at generation 1. */
+  traits: Traits
   /** Player-given name, if this one earned the right to have one. */
   name: string | null
   /** True while this creature holds the land's longevity record. */

--- a/src/app/micro-land/worlds/__tests__/snapshot.test.ts
+++ b/src/app/micro-land/worlds/__tests__/snapshot.test.ts
@@ -111,6 +111,46 @@ describe('freezing and thawing a world', () => {
     expect(first.name).toBe('Bramble')
   })
 
+  /**
+   * The failure this guards against is invisible: a reopened world would have
+   * all of its creatures, in the right places, at the right ages — and every
+   * line the player had grown would silently be back to its blueprint.
+   */
+  it('brings back what each creature inherited', () => {
+    const { w } = populatedWorld()
+    w.creatures[0].traits = { speed: 1.37, sight: 0.72, lifespan: 1.15, hue: 214, shade: 0.9 }
+
+    const fresh = createWorld(1)
+    restoreSnapshot(fresh, snapshotWorld(w))
+
+    const first = fresh.creatures[0]
+    expect(first.traits.speed).toBeCloseTo(1.37, 2)
+    expect(first.traits.sight).toBeCloseTo(0.72, 2)
+    expect(first.traits.lifespan).toBeCloseTo(1.15, 2)
+    expect(first.traits.hue).toBeCloseTo(214, 0)
+    expect(first.traits.shade).toBeCloseTo(0.9, 2)
+    // Untouched creatures stay exactly their species, which is what makes a
+    // placed creature and a born one different things.
+    expect(fresh.creatures[1].traits).toEqual({
+      speed: 1,
+      sight: 1,
+      lifespan: 1,
+      hue: 0,
+      shade: 1,
+    })
+  })
+
+  it('thaws a world saved before creatures inherited anything into neutral ones', () => {
+    const { w } = populatedWorld()
+    const snap = snapshotWorld(w)
+    for (const c of snap.creatures) delete c.traits
+
+    const fresh = createWorld(1)
+    expect(restoreSnapshot(fresh, snap)).toBe(true)
+    expect(fresh.creatures[0].traits.speed).toBe(1)
+    expect(fresh.creatures[0].traits.hue).toBe(0)
+  })
+
   it('carries the summoned species so the world can be opened anywhere', () => {
     const { w, bp } = populatedWorld()
     const snap = snapshotWorld(w)

--- a/src/app/micro-land/worlds/snapshot.ts
+++ b/src/app/micro-land/worlds/snapshot.ts
@@ -23,6 +23,7 @@ import { reserveSummonIds } from '@/app/micro-land/domain/blueprint'
 import { MATERIAL_IDS } from '@/app/micro-land/domain/config/materials'
 import { makeRng } from '@/app/micro-land/domain/sim/prng'
 import { registerBlueprint } from '@/app/micro-land/domain/sim/world'
+import { neutralTraits } from '@/app/micro-land/domain/traits'
 import type { Creature, CreatureMood, WorldState } from '@/app/micro-land/domain/types'
 
 import type { SavedCreature, WorldSnapshot } from './types'
@@ -154,6 +155,17 @@ export function snapshotWorld(w: WorldState): WorldSnapshot {
       digProgress: round(c.digProgress),
       tilesDug: c.tilesDug,
       generation: c.generation,
+      // Stored, and it has to be. A reopened world whose creatures came back as
+      // their blueprints would quietly delete every line the player had grown —
+      // and it would look like nothing had happened, because the animals would
+      // all still be there.
+      traits: {
+        speed: round(c.traits.speed),
+        sight: round(c.traits.sight),
+        lifespan: round(c.traits.lifespan),
+        hue: Math.round(c.traits.hue),
+        shade: round(c.traits.shade),
+      },
       name: c.name,
     })),
     blueprints,
@@ -188,6 +200,7 @@ function thaw(saved: SavedCreature): Creature {
     digProgress: saved.digProgress,
     tilesDug: saved.tilesDug,
     generation: saved.generation,
+    traits: saved.traits ? { ...saved.traits } : neutralTraits(),
     name: saved.name,
   }
 }

--- a/src/app/micro-land/worlds/types.ts
+++ b/src/app/micro-land/worlds/types.ts
@@ -68,6 +68,16 @@ export interface SavedCreature {
   digProgress: number
   tilesDug: number
   generation: number
+  /**
+   * What this one inherited, or absent for a world saved before creatures
+   * inherited anything.
+   *
+   * Optional rather than required because an old save must thaw into neutral
+   * creatures, which is exactly what the sanitizer does with a missing value —
+   * and neutral is the right answer, not a lossy one: a world written before the
+   * mechanic existed genuinely had no drift in it.
+   */
+  traits?: { speed: number; sight: number; lifespan: number; hue: number; shade: number }
   name: string | null
 }
 

--- a/src/app/micro-land/worlds/wire.ts
+++ b/src/app/micro-land/worlds/wire.ts
@@ -20,6 +20,7 @@
 import { MATERIAL_IDS } from '@/app/micro-land/domain/config/materials'
 import { WORLD_H, WORLD_W } from '@/app/micro-land/domain/constants'
 import { sanitizeTerrain } from '@/app/micro-land/domain/terrain'
+import { SHADE_MAX, SHADE_MIN, TRAIT_MAX, TRAIT_MIN } from '@/app/micro-land/domain/traits'
 import type { CreatureBlueprint } from '@/app/micro-land/domain/types'
 
 import {
@@ -130,6 +131,28 @@ function validRuns(runs: unknown, tileCount: number): number[] | null {
  * creature; one whose species has gone is dropped later, by the restore, which
  * is the only reason a creature is ever discarded.
  */
+/**
+ * Coerce stored inheritance back into the range the simulation was built for.
+ *
+ * Clamped to the same bounds `inherit` enforces rather than merely to something
+ * finite, because these numbers multiply the blueprint on hot paths that were
+ * tuned against it: a hand-edited save claiming a hopper is forty times its
+ * species' speed would move it across a tile faster than collision samples one.
+ * A save with no traits at all is a save written before any of this existed, and
+ * neutral is the honest answer for it.
+ */
+function cleanTraits(raw: unknown): SavedCreature['traits'] {
+  if (!isPlainObject(raw)) return undefined
+  return {
+    speed: clamp(raw.speed, TRAIT_MIN, TRAIT_MAX, 1),
+    sight: clamp(raw.sight, TRAIT_MIN, TRAIT_MAX, 1),
+    lifespan: clamp(raw.lifespan, TRAIT_MIN, TRAIT_MAX, 1),
+    // Wrapped rather than clamped — hue is an angle, and 370° is 10°, not 360°.
+    hue: ((clamp(raw.hue, -1e6, 1e6, 0) % 360) + 360) % 360,
+    shade: clamp(raw.shade, SHADE_MIN, SHADE_MAX, 1),
+  }
+}
+
 function cleanCreature(raw: unknown, index: number): SavedCreature | null {
   if (!isPlainObject(raw)) return null
   if (typeof raw.blueprintId !== 'string' || raw.blueprintId.length === 0) return null
@@ -158,6 +181,7 @@ function cleanCreature(raw: unknown, index: number): SavedCreature | null {
     digProgress: clamp(raw.digProgress, 0, 1, 0),
     tilesDug: Math.floor(clamp(raw.tilesDug, 0, 1e9, 0)),
     generation: Math.floor(clamp(raw.generation, 1, 1e6, 1)),
+    traits: cleanTraits(raw.traits),
     name: typeof raw.name === 'string' ? raw.name.slice(0, 32) : null,
   }
 }


### PR DESCRIPTION
Creatures now inherit. A child takes the midpoint of its two parents' traits
plus a small random nudge, and the world's existing pressures do the selecting.

## Where a mutation can live

A blueprint is shared by every creature that has it, so a mutation cannot go
there without every hopper alive mutating at once. Each creature carries its own
`Traits` instead — multipliers applied on top of its species:

| trait | what it scales |
|---|---|
| `speed` | `move.speed`, in `steer` |
| `sight` | `senses.sight`, and the foraging reach derived from it |
| `lifespan` | `diet.lifespanSeconds`, **and breeding age with it** |
| `hue` / `shade` | the palette, at draw time |

There is no fitness function and nothing scores anything. The world already
kills the slow, the short-sighted and the unlucky, so pointing inheritance at
numbers the world already tests is enough for selection to happen on its own.

## Founders are identical, on purpose

Everything placed by hand, seeded by the ground or dropped in by a theme is
exactly 1.0. A new world starts with no variance at all, and every difference in
it was manufactured one birth at a time.

That is what makes "this species died out and I placed another" mean the line
genuinely started over rather than resumed. It is also why the drift is as large
as it is: blending halves the population's variance every generation while the
nudge puts some back, and the two settle around `drift * sqrt(2/3)`.

## What is deliberately not heritable

- **Size and tags** — the food chain is `canEat`, and a world balanced around it
  cannot be allowed to drift out from under itself.
- **`hungerRate` and `breedAt`** — a line free to drift its own breeding cost
  below its meal value is exactly the runaway `MEAL_VALUE < BREED_COST` exists
  to prevent.

Lifespan scales breeding age with it, or a short-lived line would reach maturity
after it had already died of old age — selection would delete short life for a
reason having nothing to do with the world.

## Colour

Twelve hue by three shade buckets through the sprite cache, recolouring the
twelve-entry palette rather than the pixels, with the neutral bucket as a fast
path that rasterizes exactly what was drawn. Shade rides along with hue because
hue rotation does nothing whatsoever to a grey.

`forgetSprites` now sweeps the whole `id|` prefix. An id no longer names one
drawing, and dropping only the neutral entry would leave a repainted creature
showing its old art for precisely the lines whose colour the player is watching.

## Persistence and the panel

Traits are stored in world saves and clamped on the way back in to the same
bounds `inherit` enforces; a pre-feature save thaws to neutral, which is what it
honestly held. `traitDrift` is a knob in the settings panel, and 0 turns the
mechanic off entirely.

The inspector says it in words first — "quicker than most and long-lived" — with
the multipliers underneath as evidence. Both are empty at generation 1, so a
fresh world's panel looks exactly as it always did.

## Verification

`npm run typecheck`, `npx eslint` over the changed files, and all 176 micro-land
tests pass. The harness now prints per-species trait means next to generation
depth, which is the only way to tell selection from decoration.

On plants it is already visible, and the control is clean:

| species | eaten | generations | lifespan drift |
|---|---|---|---|
| sunleaf | 189 | 4.6 | **1.21** |
| bramble | 149 | 4.1 | 1.15 |
| glowvine | 127 | 4.1 | 1.13 |
| skybloom | 4 | **12.0** | **1.00** |

Skybloom has three times the generations of anything else and almost no
predation, and has not drifted at all; sunleaf has the fewest generations and
the most predation and drifted the most. Speed and sight sit at ~1.00 for
everything rooted, which is right — a rooted plant's survival can test neither.
Pressure moves the number, not time.

Population curves are unchanged with the feature on: drift is symmetric and
starts neutral, and running with `TRAIT_DRIFT` at 0 gives peak 733 vs 732 and a
low water mark of 523 vs 523 on the same seeds.

## Known gap

**The same claim is unverified on animals**, because no animal population on
`main` currently survives long enough to breed — every animal species is extinct
in every run, in all four themes. That is true with this feature switched off
and is not caused by it; the identical drift-0 numbers above are the check. It
closes by itself once animals breed again, since the harness now reports drift
on every run.

Not covered: a browser pass. The colour rendering is the part most deserving of
a human eye.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
