### PR TITLE
[microland] Login link / logged-in username in header

### DIFF
--- a/src/app/micro-land/components/hud.tsx
+++ b/src/app/micro-land/components/hud.tsx
@@ -1,10 +1,13 @@
 'use client'
 
+import Link from 'next/link'
+
 import { THEMES } from '@/app/micro-land/domain/config/themes'
 import { STEADY_SHOW_SECONDS } from '@/app/micro-land/domain/constants'
 import { TUNING_DEFAULTS, type TuningKey } from '@/app/micro-land/domain/tuning'
 import { formatDuration } from '@/app/micro-land/format'
 import { SUMMONED_THEME_ID, useMicroLand } from '@/app/micro-land/store'
+import { useAuth } from '@/hooks/useAuth'
 
 const SPEEDS = [
   { value: 0.5, label: '½×' },
@@ -79,6 +82,12 @@ export function Hud({
   const settingsOpen = useMicroLand(s => s.settingsOpen)
   const setSettingsOpen = useMicroLand(s => s.setSettingsOpen)
   const tuning = useMicroLand(s => s.tuning)
+
+  const { user, loading: authLoading } = useAuth()
+  const isSignedIn = !authLoading && !!user && !user.isAnonymous
+  const authLabel = isSignedIn
+    ? (user?.displayName || user?.email?.split('@')[0] || 'Account')
+    : 'Log in'
 
   // A world running on numbers other than the shipped ones is worth saying out
   // loud — otherwise a land that behaves strangely months from now is a mystery
@@ -199,6 +208,21 @@ export function Hud({
       </div>
 
       <div className="ml-auto flex items-center gap-2">
+        {!authLoading && (
+          <Link
+            href="/auth"
+            style={{
+              ...chipBase,
+              padding: '7px 10px',
+              ...(isSignedIn
+                ? { color: 'var(--cc-text-default)' }
+                : { color: 'var(--cc-mint)', borderColor: 'var(--cc-mint)' }),
+            }}
+            title={isSignedIn ? 'Account settings' : 'Sign in to save your progress across devices'}
+          >
+            {authLabel}
+          </Link>
+        )}
         <button
           type="button"
           className="cc-btn"


### PR DESCRIPTION
Closes #2760

## What

Adds an auth state chip to the right side of the Micro Land HUD header.

**Anonymous / logged-out:** Shows "Log in" in mint — a gentle invite, not a gate. Links to `/auth`.

**Signed in:** Shows the user's display name (or email prefix if no display name, or "Account" as final fallback) in default text color. Also links to `/auth` for account settings.

Renders nothing during the brief auth-loading phase to avoid a flash of the wrong state.

## Pattern

Follows the same logic as the existing `top-nav-bar.tsx`:
- `user && !user.isAnonymous` = real account
- Otherwise anonymous/guest

## UX alignment

- **Anonymous-first**: anonymous play is fully functional; "Log in" is a path, not a gate
- **Consistent location**: right-side header, matching the global nav pattern
- **The cave is light**: minimal chip styled exactly like the other HUD controls

🤖 Generated with [Claude Code](https://claude.com/claude-code)