### PR TITLE
[microland] Field guide: click creature entry to locate it in the world

### DIFF
--- a/src/app/micro-land/MicroLandGame.tsx
+++ b/src/app/micro-land/MicroLandGame.tsx
@@ -94,6 +94,15 @@ export function MicroLandGame() {
       // and a dependency-driven effect would rebuild the world on every remount.
       unsubscribe = useMicroLand.subscribe((state, previous) => {
         if (state.themeId !== previous.themeId) game?.setTheme(state.themeId)
+        if (state.locateRequest !== previous.locateRequest && state.locateRequest && game) {
+          const found = game.locateSpecies(state.locateRequest.blueprintId)
+          if (!found) {
+            const name =
+              game.getWorld().blueprints[state.locateRequest.blueprintId]?.name ??
+              state.locateRequest.blueprintId
+            useMicroLand.getState().notify(`No ${name} alive right now`)
+          }
+        }
       })
     })
 

--- a/src/app/micro-land/components/field-guide.tsx
+++ b/src/app/micro-land/components/field-guide.tsx
@@ -61,6 +61,7 @@ export function FieldGuide() {
   const records = useMicroLand(s => s.records)
   const archive = useMicroLand(s => s.archive)
   const milestones = useMicroLand(s => s.milestones)
+  const requestLocate = useMicroLand(s => s.requestLocate)
 
   if (!open) return null
 
@@ -201,6 +202,7 @@ export function FieldGuide() {
               bp={bp}
               alive={counts.get(bp.id) ?? 0}
               blueprints={blueprints}
+              onLocate={(counts.get(bp.id) ?? 0) > 0 ? () => requestLocate(bp.id) : undefined}
             />
           ))}
         </ul>
@@ -316,10 +318,14 @@ function GuideEntry({
   bp,
   alive,
   blueprints,
+  onHide,
+  onLocate,
 }: {
   bp: CreatureBlueprint
   alive: number
   blueprints: CreatureBlueprint[]
+  onHide?: () => void
+  onLocate?: () => void
 }) {
   const eats = blueprints.filter(other => canEat(bp, other))
   const eatenBy = blueprints.filter(other => canEat(other, bp))
@@ -333,44 +339,96 @@ function GuideEntry({
         <CreaturePortrait blueprint={bp} size={40} />
       </div>
       <div className="min-w-0 flex-1">
-        <div className="flex flex-wrap items-baseline gap-x-2 gap-y-1">
-          <span
-            style={{
-              fontFamily: 'var(--cc-font-mono)',
-              fontSize: 12,
-              letterSpacing: 1.4,
-              textTransform: 'uppercase',
-              color: alive > 0 ? 'var(--cc-mint)' : 'var(--cc-text-muted)',
-            }}
-          >
-            {bp.name}
-          </span>
-          <span
-            style={{
-              fontFamily: 'var(--cc-font-mono)',
-              fontSize: 10,
-              color: alive > 0 ? 'var(--cc-text-muted)' : 'var(--cc-pink)',
-            }}
-          >
-            {alive > 0 ? `${alive} alive` : 'none left'}
-          </span>
-          {bp.summoned && (
+        <div className="flex items-start justify-between gap-2">
+          <div className="flex flex-wrap items-baseline gap-x-2 gap-y-1">
             <span
-              className="inline-flex items-center gap-1"
               style={{
                 fontFamily: 'var(--cc-font-mono)',
-                fontSize: 9,
-                letterSpacing: 1.2,
+                fontSize: 12,
+                letterSpacing: 1.4,
                 textTransform: 'uppercase',
-                padding: '2px 6px',
-                borderRadius: 999,
-                color: 'var(--cc-pink)',
-                border: '1px solid var(--cc-pink-border)',
+                color: alive > 0 ? 'var(--cc-mint)' : 'var(--cc-text-muted)',
               }}
             >
-              <SparkleIcon size={9} />
-              Generated
+              {bp.name}
             </span>
+            <span
+              style={{
+                fontFamily: 'var(--cc-font-mono)',
+                fontSize: 10,
+                color: alive > 0 ? 'var(--cc-text-muted)' : 'var(--cc-pink)',
+              }}
+            >
+              {alive > 0 ? `${alive} alive` : 'none left'}
+            </span>
+            {bp.summoned && (
+              <span
+                className="inline-flex items-center gap-1"
+                style={{
+                  fontFamily: 'var(--cc-font-mono)',
+                  fontSize: 9,
+                  letterSpacing: 1.2,
+                  textTransform: 'uppercase',
+                  padding: '2px 6px',
+                  borderRadius: 999,
+                  color: 'var(--cc-pink)',
+                  border: '1px solid var(--cc-pink-border)',
+                }}
+              >
+                <SparkleIcon size={9} />
+                Generated
+              </span>
+            )}
+          </div>
+          {(onLocate || onHide) && (
+            <div className="flex shrink-0 items-center gap-1">
+              {onLocate && (
+                <button
+                  type="button"
+                  className="cc-btn"
+                  onClick={onLocate}
+                  aria-label={`Pan camera to ${bp.name}`}
+                  title="Pan to this creature in the world"
+                  style={{
+                    fontFamily: 'var(--cc-font-mono)',
+                    fontSize: 9,
+                    letterSpacing: 1,
+                    textTransform: 'uppercase',
+                    padding: '3px 7px',
+                    minHeight: 24,
+                    borderRadius: 4,
+                    border: '1px solid var(--cc-mint-line)',
+                    color: 'var(--cc-mint)',
+                    opacity: 0.8,
+                  }}
+                >
+                  Find
+                </button>
+              )}
+              {onHide && (
+                <button
+                  type="button"
+                  className="cc-btn shrink-0"
+                  onClick={onHide}
+                  aria-label={`Hide ${bp.name} from field guide`}
+                  title="Hide from field guide (plant still lives in the world)"
+                  style={{
+                    fontFamily: 'var(--cc-font-mono)',
+                    fontSize: 9,
+                    letterSpacing: 1,
+                    textTransform: 'uppercase',
+                    padding: '3px 7px',
+                    minHeight: 24,
+                    borderRadius: 4,
+                    border: '1px solid var(--cc-mint-line)',
+                    color: 'var(--cc-text-muted)',
+                    opacity: 0.65,
+                  }}
+                >
+                  Hide
+                </button>
+              )}
+            </div>
           )}
         </div>
 

--- a/src/app/micro-land/game-instance.ts
+++ b/src/app/micro-land/game-instance.ts
@@ -928,6 +928,20 @@ export class GameInstance {
     return record ?? { blueprint: bp, firstSeen: Date.now(), lastSeen: Date.now(), longestLife: 0 }
   }
 
+  /**
+   * Centre the camera on the first living creature of this species.
+   *
+   * Returns true when one was found; false when the species has no living
+   * members (so the caller can tell the player rather than quietly doing
+   * nothing).
+   */
+  locateSpecies(blueprintId: string): boolean {
+    const creature = this.world.creatures.find(c => c.blueprintId === blueprintId)
+    if (!creature) return false
+    this.renderer.centerOn(creature.x, creature.y)
+    return true
+  }
+
   /** Put a removed species back on the shelf. Undo for `removeSpecies`. */
   restoreSpecies(record: SpeciesRecord): void {
     restoreSpeciesRecord(record)

--- a/src/app/micro-land/store.ts
+++ b/src/app/micro-land/store.ts
@@ -261,6 +261,11 @@ interface MicroLandState {
   shelf: ShelfState
   worldsOpen: boolean
 
+  /** Set when the field guide asks to find a species in the world. */
+  locateRequest: { blueprintId: string; serial: number } | null
+  /** Close the guide and emit a locate request for the game instance to handle. */
+  requestLocate: (blueprintId: string) => void
+
   setTheme: (id: string) => void
   setTool: (tool: Tool) => void
   setBrush: (n: number) => void
@@ -318,6 +323,7 @@ interface MicroLandState {
 
 let noticeId = 0
 let pendingId = 0
+let locateSerial = 0
 
 const TOOLBAR_KEY = 'micro-land:toolbar:v1'
 
@@ -381,6 +387,7 @@ export const useMicroLand = create<MicroLandState>(set => ({
   saveState: { kind: 'idle' },
   shelf: { worlds: [], activeId: null, busy: false, error: null },
   worldsOpen: false,
+  locateRequest: null,
 
   setTheme: themeId => set({ themeId }),
   setTool: tool => set({ tool }),
@@ -437,6 +444,8 @@ export const useMicroLand = create<MicroLandState>(set => ({
   setSaveState: saveState => set({ saveState }),
   setShelf: shelf => set({ shelf }),
   setWorldsOpen: worldsOpen => set({ worldsOpen }),
+  requestLocate: blueprintId =>
+    set({ locateRequest: { blueprintId, serial: ++locateSerial }, guideOpen: false }),
 
   notify: (text, action) =>
     set(s => ({


### PR DESCRIPTION
Closes #2758

## What

Adds a **Find** button to each live creature entry in the field guide. Clicking it:

1. Closes the field guide
2. Centres the camera on a living creature of that species

If no creature of that species is alive (race condition between guide update and click), a toast says "No `<name>` alive right now".

## How

**Store** — `requestLocate(blueprintId)` closes the guide and sets `locateRequest: { blueprintId, serial }`. The serial is a monotonically increasing counter so two clicks on the same species both trigger the subscription, even though `blueprintId` didn't change.

**GameInstance** — new `locateSpecies(blueprintId): boolean` finds the first creature in `world.creatures` with that blueprint id and calls `renderer.centerOn(x, y)`. Returns `false` if the species has no living members.

**MicroLandGame** — extends the existing `useMicroLand.subscribe` callback: on a new `locateRequest`, delegates to `locateSpecies` and emits a notice if nothing was found.

**FieldGuide** — "Find" button appears on entries where `alive > 0`. It sits next to the existing "Hide" button for plant entries, so plant entries can show both.

## Behaviour

- **Only shown when alive** — an extinct entry has no "Find" button (the request would always fail)
- **Closes the guide** — the camera move is invisible behind an open modal, so closing first makes the effect legible
- **Single creature** — pans to the first found; no cycling in this iteration (the issue listed cycling as optional)

🤖 Generated with [Claude Code](https://claude.com/claude-code)