### PR TITLE
[microland] Add heritable roam trait (wander distance score)

### DIFF
--- a/src/app/micro-land/domain/sim/creature-sim.ts
+++ b/src/app/micro-land/domain/sim/creature-sim.ts
@@ -30,7 +30,7 @@ import {
   WORLD_H,
   WORLD_W,
 } from '@/app/micro-land/domain/constants'
-import { inherit, lifespanOf, sightOf, speedOf } from '@/app/micro-land/domain/traits'
+import { inherit, lifespanOf, roamOf, sightOf, speedOf } from '@/app/micro-land/domain/traits'
 import { TUNING } from '@/app/micro-land/domain/tuning'
 import type { Creature, CreatureBlueprint, WorldState } from '@/app/micro-land/domain/types'
 
@@ -461,13 +461,15 @@ function look(
    * How far it can find something to eat, which is not how far it can see.
    *
    * Ramps from plain sight at the moment it starts feeling hungry up to
-   * `1 + HUNGER_REACH` times that by the time it is nearly starving. Food only:
+   * `1 + HUNGER_REACH * roam` times that by the time it is nearly starving.
+   * The `roam` trait multiplies the extension, so a wide-ranging line smells
+   * food further out and a stay-close line hunts at shorter range. Food only:
    * `sight2` above still decides what counts as a threat, so getting hungry
    * makes an animal bolder and further-ranging without also making it better at
    * noticing what is stalking it.
    */
   const desperation = Math.max(0, Math.min(1, (c.hunger - 0.3) / 0.6))
-  const foodSight = sight * (1 + HUNGER_REACH * desperation)
+  const foodSight = sight * (1 + HUNGER_REACH * desperation * roamOf(c))
   const foodSight2 = foodSight * foodSight
 
   /**

--- a/src/app/micro-land/domain/traits.ts
+++ b/src/app/micro-land/domain/traits.ts
@@ -74,6 +74,7 @@ export const NEUTRAL_TRAITS: Traits = Object.freeze({
   lifespan: 1,
   hue: 0,
   shade: 1,
+  roam: 1,
 })
 
 /** A fresh set for a creature that wasn't born here. Always a copy — it's mutable state. */
@@ -121,7 +122,7 @@ function wrapHue(h: number): number {
 export function inherit(a: Traits, b: Traits | null, rng: Rng): Traits {
   const drift = TUNING.traitDrift
   const hueDrift = drift * HUE_DRIFT_SCALE
-  const mix = (key: 'speed' | 'sight' | 'lifespan' | 'shade') =>
+  const mix = (key: 'speed' | 'sight' | 'lifespan' | 'shade' | 'roam') =>
     b ? (a[key] + b[key]) / 2 : a[key]
 
   return {
@@ -130,6 +131,7 @@ export function inherit(a: Traits, b: Traits | null, rng: Rng): Traits {
     lifespan: clamp(mix('lifespan') + nudge(rng, drift), TRAIT_MIN, TRAIT_MAX),
     hue: wrapHue((b ? blendHue(a.hue, b.hue) : a.hue) + nudge(rng, hueDrift)),
     shade: clamp(mix('shade') + nudge(rng, drift), SHADE_MIN, SHADE_MAX),
+    roam: clamp(mix('roam') + nudge(rng, drift), TRAIT_MIN, TRAIT_MAX),
   }
 }
 
@@ -163,6 +165,16 @@ export function sightOf(c: Creature, bp: CreatureBlueprint): number {
  */
 export function lifespanOf(c: Creature, bp: CreatureBlueprint): number {
   return bp.diet.lifespanSeconds * c.traits.lifespan
+}
+
+/**
+ * How far beyond its plain sight radius this creature will smell food.
+ *
+ * Old saves that predate the roam trait have `undefined` here; defaulting to 1
+ * keeps them identical to freshly spawned creatures at the neutral value.
+ */
+export function roamOf(c: Creature): number {
+  return c.traits.roam ?? 1
 }
 
 // ---------------------------------------------------------------------------
@@ -233,6 +245,8 @@ export function traitPhrases(t: Traits): string[] {
   else if (t.sight <= 1 - NOTABLE) phrases.push('short-sighted')
   if (t.lifespan >= 1 + NOTABLE) phrases.push('long-lived')
   else if (t.lifespan <= 1 - NOTABLE) phrases.push('short-lived')
+  if ((t.roam ?? 1) >= 1 + NOTABLE) phrases.push('wide-ranging')
+  else if ((t.roam ?? 1) <= 1 - NOTABLE) phrases.push('stay-close')
   return phrases
 }
 
@@ -249,5 +263,6 @@ export function notableTraits(t: Traits): { label: string; value: number }[] {
     { label: 'Own speed', value: t.speed },
     { label: 'Own sight', value: t.sight },
     { label: 'Own lifespan', value: t.lifespan },
+    { label: 'Own roam', value: t.roam ?? 1 },
   ].filter(entry => Math.abs(entry.value - 1) >= NOTABLE)
 }

--- a/src/app/micro-land/domain/types.ts
+++ b/src/app/micro-land/domain/types.ts
@@ -344,6 +344,16 @@ export interface Traits {
    * against the sky, and one at half would vanish into the dark.
    */
   shade: number
+  /**
+   * Multiplier on the hunger-reach bonus — how much further than plain sight a
+   * hungry creature will sense food.
+   *
+   * A wide-ranging line drifts above 1 and picks up food earlier in a search,
+   * which pays off when food is spread thin. A stay-close line drifts below 1
+   * and hunts at shorter range, which matters less when prey is dense.
+   * Neither is universally better; which wins depends on the world.
+   */
+  roam: number
 }
 
 /** One living thing in the world. */

--- a/src/app/micro-land/worlds/wire.ts
+++ b/src/app/micro-land/worlds/wire.ts
@@ -150,6 +150,8 @@ function cleanTraits(raw: unknown): SavedCreature['traits'] {
     // Wrapped rather than clamped — hue is an angle, and 370° is 10°, not 360°.
     hue: ((clamp(raw.hue, -1e6, 1e6, 0) % 360) + 360) % 360,
     shade: clamp(raw.shade, SHADE_MIN, SHADE_MAX, 1),
+    // roam was added after the first save format; absent in old saves → defaults to 1.
+    roam: clamp(raw.roam, TRAIT_MIN, TRAIT_MAX, 1),
   }
 }
 


### PR DESCRIPTION
## Summary

Closes #2748

Adds a `roam` multiplier trait to the heritable trait system (alongside speed, sight, lifespan). The trait controls how far a hungry creature senses food beyond its normal sight radius.

**Effect on behavior:**
- At roam=1.6 (wide-ranging): smells food at ~60% farther than a neutral creature when desperate
- At roam=0.6 (stay-close): hunts at roughly 40% shorter reach
- At roam=1.0 (neutral): identical to current behavior

**Selection pressure**: when food is spread thin, wide-ranging lines find meals stay-close ones can't reach. When food is dense, stay-close lines are competitive. Neither extreme dominates unconditionally.

**All founders start at 1.0** (neutral), with the trait drifting via the existing `TUNING.traitDrift` knob across generations. Old world saves load cleanly — `cleanTraits()` defaults absent `roam` fields to 1.

**Visible in creature inspector**: "wide-ranging" / "stay-close" labels appear alongside the other trait phrases; "Own roam" shows in the notable traits number list.

## Implementation

- `types.ts`: `roam: number` added to `Traits` interface
- `traits.ts`: `NEUTRAL_TRAITS`, `inherit()`, `roamOf()` accessor, `traitPhrases()`, `notableTraits()`
- `worlds/wire.ts`: `cleanTraits()` loads roam with fallback 1 for old saves
- `creature-sim.ts`: imports `roamOf`, applies to `foodSight = sight * (1 + HUNGER_REACH * desperation * roamOf(c))`

## Test plan

- [ ] Long-lived world: some creatures acquire "wide-ranging" or "stay-close" labels in the inspector
- [ ] Old world save still loads; creatures with no stored roam value behave as before
- [ ] Turn TUNING.traitDrift to 0 → roam stays at 1.0 for all newborns
- [ ] Turn traitDrift to max → roam spreads quickly, wide-ranging creatures appear within minutes

🤖 Generated with [Claude Code](https://claude.com/claude-code)