### PR TITLE
[microland] Species population milestone notifications (#2785)

### DIFF
--- a/src/app/micro-land/game-instance.ts
+++ b/src/app/micro-land/game-instance.ts
@@ -661,6 +661,23 @@ export class GameInstance {
     // rebuilt on every stats tick.
     const archive = archivedSpecies()
 
+    // Species population milestones — fire once ever per (species × threshold).
+    //
+    // Each threshold is checked in ascending order so the first unclaimed one
+    // fires. Only one notification per species per stats push so three species
+    // all crossing 10 at the same moment don't spam the screen.
+    for (const entry of population) {
+      const bp = w.blueprints[entry.blueprintId]
+      if (!bp) continue
+      for (const threshold of [5, 10, 25, 50]) {
+        if (entry.count < threshold) break
+        if (claimMilestone(`sp:${entry.blueprintId}:${threshold}`, now)) {
+          store.notify(`${threshold} ${bp.name}s alive at once!`)
+          break
+        }
+      }
+    }
+
     this.checkMilestones(archive, {
       elapsed: w.elapsed,
       steadySeconds,


### PR DESCRIPTION
## Summary

- When a species first reaches 5, 10, 25, or 50 individuals alive simultaneously, a toast notification fires: `"10 Hoppers alive at once!"`
- Each (species × threshold) pair fires once ever, using the existing `claimMilestone` system backed by the chronicle
- One notification per species per stats push (thresholds checked ascending; breaks on first unclaimed claim)
- Zero new imports — `claimMilestone`, `store`, `population`, and `now` are already in scope inside `updateRecords()`

Closes #2785.

## Test plan

- [ ] Start a fresh world — place a few Hoppers, watch the population grow — should see "5 Hoppers alive at once!" notification when 5 are alive
- [ ] Population continues growing past 10, 25 — notifications fire in order
- [ ] After a species goes extinct and comes back, thresholds already crossed do NOT re-fire (claimed in chronicle)
- [ ] Multiple species growing simultaneously each get their own notification; no spam
- [ ] In an existing world save with 30 Hoppers: notifications already missed do not fire retroactively

🤖 Generated with [Claude Code](https://claude.com/claude-code)