### PR TITLE
[microland] Still animals blend in — predators detect them at half range (#2779)

### DIFF
--- a/src/app/micro-land/domain/sim/creature-sim.ts
+++ b/src/app/micro-land/domain/sim/creature-sim.ts
@@ -88,6 +88,25 @@ const STUCK_COOLDOWN_PASSES = 6
  */
 const BITE_PAD = 0.5
 
+/**
+ * Speed (|vx| + |vy|) below which a non-root animal counts as still.
+ *
+ * Still animals are harder to spot — camouflage. A creature pressed against a
+ * wall or resting between hops reads as effectively motionless even though it
+ * isn't at literal zero, so the threshold is a small positive rather than zero.
+ */
+const CAMOUFLAGE_STILL = 1.5
+
+/**
+ * Fraction of food-sight at which a still animal can first be detected.
+ *
+ * 0.5 halves the detection radius, so a resting creature is invisible to a
+ * hungry predator until it is much closer than it would otherwise need to be.
+ * Plants are exempt — this only applies to animals that could plausibly freeze
+ * or blend in, not to vegetation that the food chain depends on finding.
+ */
+const CAMOUFLAGE_FACTOR = 0.5
+
 export interface SimEvent {
   /**
    * `eaten` is from the victim's side (this species lost one); `ate` is from the
@@ -594,8 +613,9 @@ function look(
       continue
     }
 
-    if (hungry && d2 <= foodSight2 && canEat(bp, obp)) {
-      // Bodies touching? Eat now, don't bother pathing.
+    if (hungry && canEat(bp, obp)) {
+      // Bodies touching? Eat now, don't bother pathing — camouflage can't save
+      // something once the predator is already on top of it.
       const touching = gapX <= BITE_PAD && gapY <= BITE_PAD
       if (touching) {
         devour(w, other, obp, dead, events)
@@ -613,7 +633,14 @@ function look(
         })
         return
       }
-      if (d2 < preyDist) {
+      // A still non-root animal blends in — detected at a shorter range.
+      // Plants are exempt: the whole food chain depends on grazers finding them,
+      // and roots never move anyway so they'd always benefit without this guard.
+      const still =
+        obp.move.kind !== 'root' &&
+        Math.abs(other.vx) + Math.abs(other.vy) < CAMOUFLAGE_STILL
+      const efs2 = still ? foodSight2 * (CAMOUFLAGE_FACTOR * CAMOUFLAGE_FACTOR) : foodSight2
+      if (d2 <= efs2 && d2 < preyDist) {
         preyDist = d2
         prey = other
         preyDir = dx >= 0 ? 1 : -1


### PR DESCRIPTION
## Summary

- Non-root animals moving slower than 1.5 tiles/s are **camouflaged**: predators can only detect them at 50% of their normal food-sight radius
- Once a predator is already touching its prey, camouflage offers no protection — the bite happens regardless, keeping the touching-eats path simple
- Plants (`move.kind === 'root'`) are explicitly excluded so that grazer food-finding is completely unaffected
- Two module constants: `CAMOUFLAGE_STILL = 1.5` (speed threshold) and `CAMOUFLAGE_FACTOR = 0.5` (radius multiplier)

**Effect on play**: resting animals or those briefly grounded by physics are harder to hunt. A predator needs to stumble upon them closely or spot them while they're moving. Creates a low-key stealth mechanic with no new UI.

Closes #2779.

## Test plan

- [ ] Place a few prey animals (e.g. Hoppers) and a predator — verify predator still hunts successfully when prey is moving
- [ ] Watch a resting/grounded Hopper — predator should get much closer before noticing it vs. a moving one
- [ ] Verify plants (grass, kelp, etc.) are still found and eaten normally — camouflage must not affect plant-finding
- [ ] Edge case: predator touching still prey → still gets eaten (touching check is camouflage-exempt)

🤖 Generated with [Claude Code](https://claude.com/claude-code)