### PR TITLE
feat(micro-land): carcasses — dead animals become temporary food

### DIFF
--- a/src/app/micro-land/domain/sim/creature-sim.ts
+++ b/src/app/micro-land/domain/sim/creature-sim.ts
@@ -266,6 +266,10 @@ export function tickCreatures(
 ): void {
   tickCount++
 
+  // Migration: worlds saved before carcasses were added won't have these fields.
+  w.carcasses ??= []
+  w.nextCarcassId ??= 1
+
   const creatures = w.creatures
   const dead = new Set<number>()
 
@@ -499,6 +503,14 @@ export function tickCreatures(
   // dead — see `seedNativePlants`.
   seedNativePlants(w, rng)
 
+  // Decay carcasses and remove expired ones.
+  for (const car of w.carcasses) {
+    car.decaySeconds -= dt
+  }
+  if (w.carcasses.some(car => car.decaySeconds <= 0)) {
+    w.carcasses = w.carcasses.filter(car => car.decaySeconds > 0)
+  }
+
   tickParticles(w, dt, gravityScale)
 }
 
@@ -562,6 +574,31 @@ function look(
   let preyCy = 0
   let mate: Creature | null = null
   let mateDist = Infinity
+
+  // --- Carcass eating (touch-based opportunistic scavenging) ---
+  // A hungry carnivore that stumbles over a carcass eats it immediately.
+  // No active pursuit — the creature's normal hunt/wander brings it close enough.
+  if (hungry && bp.move.kind !== 'root') {
+    for (const car of w.carcasses) {
+      const carBp = w.blueprints[car.blueprintId]
+      if (!carBp || !canEat(bp, carBp)) continue
+      const dx = car.x - cx
+      const dy = car.y - cy
+      // Gap between creature sprite edge and the carcass point.
+      const gapX = Math.max(0, Math.abs(dx) - bw / 2)
+      const gapY = Math.max(0, Math.abs(dy) - bh / 2)
+      if (gapX <= BITE_PAD && gapY <= BITE_PAD) {
+        c.hunger = Math.max(0, c.hunger - TUNING.mealValue)
+        c.starving = 0
+        c.mealsEaten++
+        c.mood = 'eat'
+        c.targetId = null
+        car.decaySeconds = 0 // mark for removal at end of tick
+        events.push({ kind: 'ate', blueprintId: bp.id, x: c.x, y: c.y })
+        return
+      }
+    }
+  }
 
   // Only the creatures whose left edge falls in the window can possibly be in
   // range; everything beyond it is skipped without being touched. Sized off the
@@ -777,6 +814,16 @@ function devour(
   if (dead.has(victim.id)) return
   dead.add(victim.id)
   const { w: vw, h: vh } = artSize(victimBp)
+  // Animals leave a carcass. Plants vanish cleanly — grazers find them alive.
+  if (victimBp.move.kind !== 'root') {
+    w.carcasses.push({
+      id: w.nextCarcassId++,
+      x: victim.x + vw / 2,
+      y: victim.y + vh / 2,
+      decaySeconds: 15,
+      blueprintId: victim.blueprintId,
+    })
+  }
   emitParticles(
     w,
     victim.x + vw / 2,
@@ -1488,6 +1535,16 @@ function kill(
   if (dead.has(c.id)) return
   dead.add(c.id)
   const { w: bw, h: bh } = artSize(bp)
+  // Animals leave a carcass on any death.
+  if (bp.move.kind !== 'root') {
+    w.carcasses.push({
+      id: w.nextCarcassId++,
+      x: c.x + bw / 2,
+      y: c.y + bh / 2,
+      decaySeconds: 15,
+      blueprintId: c.blueprintId,
+    })
+  }
   emitParticles(w, c.x + bw / 2, c.y + bh / 2, bp.death.particleColor, bp.death.particleCount)
   if (bp.death.becomes) {
     setTile(w, Math.floor(c.x + bw / 2), Math.floor(c.y + bh / 2), MATERIAL_INDEX[bp.death.becomes])

--- a/src/app/micro-land/domain/sim/world.ts
+++ b/src/app/micro-land/domain/sim/world.ts
@@ -45,6 +45,8 @@ export function createWorld(seed = 1337): WorldState {
     grain,
     creatures: [],
     particles: [],
+    carcasses: [],
+    nextCarcassId: 1,
     blueprints,
     nextCreatureId: 1,
     elapsed: 0,

--- a/src/app/micro-land/domain/types.ts
+++ b/src/app/micro-land/domain/types.ts
@@ -426,6 +426,24 @@ export interface Creature {
   huntPassCount: number
 }
 
+/**
+ * A dead animal's remains — a temporary food source for carnivores.
+ *
+ * Spawned at death (either eaten by a predator or killed by the world).
+ * Plants are excluded: grazers find them alive; a decomposing plant corpse
+ * would make root-species too easy to farm.
+ */
+export interface Carcass {
+  id: number
+  /** World-tile coordinates of the creature's centre at the moment of death. */
+  x: number
+  y: number
+  /** Seconds until this carcass vanishes. */
+  decaySeconds: number
+  /** Blueprint of the creature that died — determines who can eat it. */
+  blueprintId: string
+}
+
 export interface Particle {
   x: number
   y: number
@@ -445,6 +463,8 @@ export interface WorldState {
   grain: Uint8Array
   creatures: Creature[]
   particles: Particle[]
+  carcasses: Carcass[]
+  nextCarcassId: number
   /** Blueprints available in this world, keyed by id. */
   blueprints: Record<string, CreatureBlueprint>
   nextCreatureId: number

--- a/src/app/micro-land/rendering/renderer.ts
+++ b/src/app/micro-land/rendering/renderer.ts
@@ -487,6 +487,7 @@ export class Renderer {
 
     wctx.drawImage(this.tileCanvas, vx, 0, vw, WORLD_H, vx, 0, vw, WORLD_H)
 
+    this.drawCarcasses(w, vx, vw)
     this.drawCreatures(w, vx, vw)
     this.drawParticles(w, vx, vw)
     wctx.drawImage(this.shadowCanvas, vx, 0, vw, WORLD_H, vx, 0, vw, WORLD_H)
@@ -687,6 +688,19 @@ export class Renderer {
     const top = a + (b - a) * tx
     const bottom = c + (d - c) * tx
     return top + (bottom - top) * ty
+  }
+
+  private drawCarcasses(w: WorldState, vx: number, vw: number): void {
+    if (w.carcasses.length === 0) return
+    const ctx = this.wctx
+    ctx.fillStyle = '#5a2e10'
+    for (const car of w.carcasses) {
+      if (car.x + 1 < vx || car.x > vx + vw) continue
+      // Fade out during the last 3 seconds of decay.
+      ctx.globalAlpha = Math.min(1, car.decaySeconds / 3) * 0.8
+      ctx.fillRect(car.x - 0.75, car.y - 0.75, 1.5, 1.5)
+    }
+    ctx.globalAlpha = 1
   }
 
   private drawCreatures(w: WorldState, vx: number, vw: number): void {


### PR DESCRIPTION
Closes #2780

## What

When any animal dies it leaves behind a temporary carcass that carnivores can eat.

## How it works

- **New `Carcass` type** in `domain/types.ts`: position + 15-second decay timer + the dead creature's blueprintId.
- **`WorldState`** gains `carcasses: Carcass[]` and `nextCarcassId: number`. Old saves migrate silently via `??=` guards in `tickCreatures`.
- **`devour()` and `kill()`** both spawn a carcass for non-root animals (plants are excluded — grazers find them alive, and letting dead plants become meat would distort the food chain).
- **`look()`**: a hungry carnivore that physically overlaps a carcass (same `canEat` rule as live prey) eats it immediately. No active pursuit — the creature's normal hunt/wander brings it close enough.
- **Decay**: carcasses lose time every tick; expired ones are filtered at the end of `tickCreatures`.
- **Rendering**: `drawCarcasses()` draws a 1.5×1.5 tile dark brown mark behind creatures, fading over the last 3 seconds.

## Why

Creates a genuine scavenger niche: slow-but-opportunistic carnivores that can't catch live prey can still survive on battlefield leftovers. Population crashes become more interesting — predators have a brief food windfall as their prey collapses, which then starves them out seconds later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)