### PR TITLE
feat(micro-land): plant toxicity — toxic plants slow the eater

### DIFF
--- a/src/app/micro-land/domain/sim/creature-sim.ts
+++ b/src/app/micro-land/domain/sim/creature-sim.ts
@@ -319,6 +319,9 @@ export function tickCreatures(
     c.ageSeconds += dt
     c.animMs += dt * 1000
     if (c.breedCooldown > 0) c.breedCooldown -= dt
+    // Migration: creatures saved before toxicity was added won't have poisoned.
+    if (c.poisoned === undefined) c.poisoned = 0
+    if (c.poisoned > 0) c.poisoned = Math.max(0, c.poisoned - dt)
 
     // --- hunger ---------------------------------------------------------
     // Resting creatures aren't running or hunting, so they burn energy more slowly.
@@ -663,6 +666,10 @@ function look(
         c.mealsEaten++
         c.mood = 'eat'
         c.targetId = null
+        // Toxic plants slow the eater — the meal lands, but at a cost.
+        if (obp.toxicity) {
+          c.poisoned = Math.max(c.poisoned, obp.toxicity * 5)
+        }
         events.push({
           kind: 'ate',
           blueprintId: bp.id,
@@ -1124,7 +1131,8 @@ function steer(w: WorldState, c: Creature, bp: CreatureBlueprint, dt: number, rn
     c.targetId = null
   }
 
-  const speed = speedOf(c, bp)
+  // Poison from a toxic plant halves movement speed for its duration.
+  const speed = speedOf(c, bp) * (c.poisoned > 0 ? 0.5 : 1)
   const accel = speed * 6
   const digger = bp.dig.through.length > 0
 

--- a/src/app/micro-land/domain/sim/world.ts
+++ b/src/app/micro-land/domain/sim/world.ts
@@ -378,6 +378,7 @@ export function spawnCreature(
     traits: neutralTraits(),
     name: null,
     huntPassCount: 0,
+    poisoned: 0,
   }
   w.creatures.push(creature)
   return creature

--- a/src/app/micro-land/domain/types.ts
+++ b/src/app/micro-land/domain/types.ts
@@ -283,6 +283,14 @@ export interface CreatureBlueprint {
   aura: CreatureAura | null
   /** Light it casts into dark areas, 0..1. */
   glow: number
+  /**
+   * How harmful this creature is to eat, 0..1.
+   *
+   * Typically nonzero only for plants. When an animal consumes a toxic plant it
+   * keeps the meal but moves at half-speed for `toxicity * 5` seconds — a
+   * deterrent rather than a kill, creating selection pressure for resistance.
+   */
+  toxicity?: number
   /** True for anything the player summoned, so we can badge it in the UI. */
   summoned?: boolean
 }
@@ -424,6 +432,13 @@ export interface Creature {
    * Resets when the target changes or a meal is eaten. Used for stuck detection.
    */
   huntPassCount: number
+  /**
+   * Seconds of poison remaining after eating a toxic plant.
+   *
+   * While above zero the creature moves at half its normal speed. Counts down
+   * each tick and returns to 0 on its own — no antidote needed.
+   */
+  poisoned: number
 }
 
 /**


### PR DESCRIPTION
Closes #2787

## What

Adds a `toxicity` field (0–1) to creature blueprints. When an animal eats a toxic plant, it keeps the meal but is poisoned — moving at half speed for `toxicity × 5` seconds.

## Details

- **`CreatureBlueprint.toxicity?: number`** (optional, defaults to 0 when absent)
- **`Creature.poisoned: number`** — seconds of poison remaining; counts down each tick via `Math.max(0, c.poisoned - dt)`
- Speed penalty applied in `steer()`: `speedOf(c, bp) * (c.poisoned > 0 ? 0.5 : 1)`
- Toxicity applied on eat (the `touching` devour path in `look()`): `c.poisoned = Math.max(c.poisoned, obp.toxicity * 5)` — taking `max` so multiple toxic plants don't reset each other
- Old saved creatures migrate silently: `if (c.poisoned === undefined) c.poisoned = 0` in the per-creature tick loop

## Note

No built-in creatures have `toxicity` set yet — the field is available for AI-summoned or hand-designed creatures to use. The arms race dynamic (plants evolving toxicity, animals evolving resistance) emerges once summoned creatures start using it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)