### PR TITLE
feat(micro-land): trait evolution overlay in field guide

### DIFF
--- a/src/app/micro-land/components/field-guide.tsx
+++ b/src/app/micro-land/components/field-guide.tsx
@@ -65,6 +65,8 @@ export function FieldGuide() {
   const milestones = useMicroLand(s => s.milestones)
   const populationHistory = useMicroLand(s => s.populationHistory)
   const requestLocate = useMicroLand(s => s.requestLocate)
+  const traitOverlay = useMicroLand(s => s.traitOverlay)
+  const setTraitOverlay = useMicroLand(s => s.setTraitOverlay)
 
   const [hiddenPlantIds, setHiddenPlantIds] = useState<ReadonlySet<string>>(new Set())
 
@@ -307,6 +309,60 @@ export function FieldGuide() {
           </section>
         )}
         <PopulationGraph history={populationHistory} blueprints={blueprints} />
+
+        <section className="px-4 py-3" style={{ borderTop: '1px solid var(--cc-panel-divider)' }}>
+          <h3 className="pb-2" style={sectionHeading}>
+            Evolution view
+          </h3>
+          <p style={{ fontSize: 11, color: 'var(--cc-text-muted)', lineHeight: 1.5, marginBottom: 8, opacity: 0.8 }}>
+            Color creatures by trait — blue is below average, red is above.
+          </p>
+          <div className="flex flex-wrap gap-1.5">
+            {(['speed', 'sight', 'lifespan', 'roam'] as const).map(trait => (
+              <button
+                key={trait}
+                type="button"
+                className="cc-btn"
+                onClick={() => setTraitOverlay(trait)}
+                style={{
+                  fontFamily: 'var(--cc-font-mono)',
+                  fontSize: 9,
+                  letterSpacing: 1.2,
+                  textTransform: 'uppercase',
+                  padding: '4px 10px',
+                  minHeight: 28,
+                  borderRadius: 4,
+                  border: traitOverlay === trait
+                    ? '1px solid var(--cc-mint)'
+                    : '1px solid var(--cc-mint-line)',
+                  color: traitOverlay === trait ? 'var(--cc-mint)' : 'var(--cc-text-muted)',
+                  background: traitOverlay === trait ? 'rgba(100,220,200,0.1)' : 'transparent',
+                }}
+              >
+                {trait === 'lifespan' ? 'Life' : trait.charAt(0).toUpperCase() + trait.slice(1)}
+              </button>
+            ))}
+          </div>
+          {traitOverlay && (
+            <button
+              type="button"
+              className="cc-btn"
+              onClick={() => setTraitOverlay(null)}
+              style={{
+                marginTop: 8,
+                fontFamily: 'var(--cc-font-mono)',
+                fontSize: 9,
+                letterSpacing: 1,
+                textTransform: 'uppercase',
+                padding: '3px 8px',
+                color: 'var(--cc-text-muted)',
+                border: '1px solid var(--cc-panel-divider)',
+              }}
+            >
+              Clear
+            </button>
+          )}
+        </section>
       </div>
     </div>
   )

--- a/src/app/micro-land/rendering/renderer.ts
+++ b/src/app/micro-land/rendering/renderer.ts
@@ -30,6 +30,7 @@ import type { Theme } from '@/app/micro-land/domain/config/themes'
 import { VIEW_W, WORLD_H, WORLD_W } from '@/app/micro-land/domain/constants'
 import { tintKey } from '@/app/micro-land/domain/traits'
 import type { WorldState } from '@/app/micro-land/domain/types'
+import { useMicroLand } from '@/app/micro-land/store'
 
 import { getSprites } from './sprite-cache'
 
@@ -705,6 +706,7 @@ export class Renderer {
 
   private drawCreatures(w: WorldState, vx: number, vw: number): void {
     const ctx = this.wctx
+    const traitKey = useMicroLand.getState().traitOverlay
     for (const c of w.creatures) {
       const bp = w.blueprints[c.blueprintId]
       if (!bp) continue
@@ -730,6 +732,17 @@ export class Renderer {
       }
       ctx.drawImage(source, x, y)
       ctx.globalAlpha = 1
+
+      if (traitKey) {
+        const delta = ((c.traits as Record<string, number>)[traitKey] ?? 1) - 1.0
+        if (Math.abs(delta) >= 0.08) {
+          const alpha = Math.min(0.6, Math.abs(delta) * 1.2).toFixed(2)
+          ctx.globalAlpha = parseFloat(alpha)
+          ctx.fillStyle = delta < 0 ? '#1e64ff' : '#ff3c00'
+          ctx.fillRect(x, y, sprites.width, sprites.height)
+          ctx.globalAlpha = 1
+        }
+      }
     }
   }
 

--- a/src/app/micro-land/store.ts
+++ b/src/app/micro-land/store.ts
@@ -276,6 +276,14 @@ interface MicroLandState {
   /** Close the guide and emit a locate request for the game instance to handle. */
   requestLocate: (blueprintId: string) => void
 
+  /**
+   * When set, the renderer draws each creature with a color overlay based on
+   * this trait's value — blue for weak, red for strong. Null means no overlay.
+   */
+  traitOverlay: string | null
+  /** Toggle the trait overlay. Passing the current trait turns it off. */
+  setTraitOverlay: (trait: string | null) => void
+
   setTheme: (id: string) => void
   setTool: (tool: Tool) => void
   setBrush: (n: number) => void
@@ -399,6 +407,7 @@ export const useMicroLand = create<MicroLandState>(set => ({
   shelf: { worlds: [], activeId: null, busy: false, error: null },
   worldsOpen: false,
   locateRequest: null,
+  traitOverlay: null,
 
   setTheme: themeId => set({ themeId }),
   setTool: tool => set({ tool }),
@@ -472,6 +481,7 @@ export const useMicroLand = create<MicroLandState>(set => ({
   setWorldsOpen: worldsOpen => set({ worldsOpen }),
   requestLocate: blueprintId =>
     set({ locateRequest: { blueprintId, serial: ++locateSerial }, guideOpen: false }),
+  setTraitOverlay: trait => set(s => ({ traitOverlay: s.traitOverlay === trait ? null : trait })),
 
   notify: (text, action) =>
     set(s => ({


### PR DESCRIPTION
Closes #2790

## What

Adds an "Evolution view" section to the field guide. Select a trait (Speed, Sight, Life, Roam) and every creature in the world is tinted — blue for below-average, red for above-average — making population-level evolution visible at a glance.

## How it works

- **Store**: `traitOverlay: string | null` — the active trait key, or null when off. `setTraitOverlay` toggles: passing the same trait turns it off.
- **Renderer**: `drawCreatures()` reads `useMicroLand.getState().traitOverlay` once per frame (non-reactive, correct for 60Hz). For each creature, if the trait delta from neutral (1.0) is ≥ 0.08, draws a `fillRect` over the sprite with `ctx.globalAlpha` set to `min(0.6, |delta| * 1.2)`. Below neutral → `#1e64ff` (blue), above → `#ff3c00` (red).
- **Field guide**: Four toggle buttons at the bottom of the guide with active-state styling. A "Clear" button appears when any overlay is active.

## Why it works

After a predator wipe-out, the survivors that were fastest get to breed. The next generation shifts red. A player watching this happen can now see the whole population drift warm after a drought — without needing to read per-creature stats.

🤖 Generated with [Claude Code](https://claude.com/claude-code)