### PR TITLE
feat(micro-land): seasonal plant cycles — periodic boom-and-bust food (#2778)

### DIFF
--- a/src/app/micro-land/domain/sim/creature-sim.ts
+++ b/src/app/micro-land/domain/sim/creature-sim.ts
@@ -339,6 +339,17 @@ export function tickCreatures(
   w.carcasses ??= []
   w.nextCarcassId ??= 1
 
+  // Seasonal factor — a slow sine wave that modulates plant growth and seeding.
+  // 1.0 at both the start (t=0) and equinoxes; peaks in summer, troughs in winter.
+  // When `seasonAmplitude` is 0 (default), this is always exactly 1.
+  const seasonFactor =
+    TUNING.seasonAmplitude > 0
+      ? Math.max(
+          0.05,
+          1 + TUNING.seasonAmplitude * Math.sin((2 * Math.PI * w.elapsed) / TUNING.seasonPeriod)
+        )
+      : 1
+
   const creatures = w.creatures
   const dead = new Set<number>()
 
@@ -513,9 +524,12 @@ export function tickCreatures(
             // Soil fertility (0.2 on bare stone → 1.5 in waterside mud) scales
             // the cooldown inversely: richer soil means a shorter wait, so
             // plants cluster in patches rather than carpeting the map evenly.
+            // Seasons multiply the same way: summer doubles spread, winter halves it.
             c.breedCooldown =
               TUNING.plantSpreadCooldown /
-              (auraBoost(w, c, bp, bw, bh, helpers) * fertilityAt(w, c.x + bw / 2, c.y + bh / 2))
+              (auraBoost(w, c, bp, bw, bh, helpers) *
+                fertilityAt(w, c.x + bw / 2, c.y + bh / 2) *
+                seasonFactor)
           } else {
             // Both of them paid to be here, so both of them pay for it. Charging
             // only the one whose turn it happened to be would make a baby cost a
@@ -579,7 +593,7 @@ export function tickCreatures(
 
   // The only thing the world regrows on its own. Animals that die out stay
   // dead — see `seedNativePlants`.
-  seedNativePlants(w, rng)
+  seedNativePlants(w, rng, seasonFactor)
 
   // Decay carcasses and remove expired ones.
   for (const car of w.carcasses) {

--- a/src/app/micro-land/domain/sim/world.ts
+++ b/src/app/micro-land/domain/sim/world.ts
@@ -614,7 +614,7 @@ export function establishNativePlants(w: WorldState, rng: Rng): boolean {
  * creeping back over minutes reads as the land recovering, where a fast one read
  * as the game undoing what just happened.
  */
-export function seedNativePlants(w: WorldState, rng: Rng): void {
+export function seedNativePlants(w: WorldState, rng: Rng, seasonFactor = 1): void {
   if (w.elapsed < w.nextPlantSeed) return
   w.nextPlantSeed = w.elapsed + TUNING.plantSeedInterval
   if (w.dormant) return
@@ -628,7 +628,10 @@ export function seedNativePlants(w: WorldState, rng: Rng): void {
     plants++
   }
 
-  const deficit = TUNING.nativePlantTarget - plants
+  // In winter (seasonFactor < 1), the ground targets fewer plants — the seed
+  // bank is depleted. In summer (> 1) it aims higher and seeds more aggressively.
+  const scaledTarget = Math.max(0, Math.round(TUNING.nativePlantTarget * seasonFactor))
+  const deficit = scaledTarget - plants
   if (deficit <= 0) return
   if (plants >= TUNING.maxPlants || w.creatures.length >= TUNING.maxCreatures) return
 

--- a/src/app/micro-land/domain/tuning.ts
+++ b/src/app/micro-land/domain/tuning.ts
@@ -69,6 +69,16 @@ export const TUNING_DEFAULTS = {
   traitDrift: TRAIT_DRIFT,
 
   gravity: GRAVITY,
+  /**
+   * How long one seasonal cycle lasts, in sim seconds.
+   * 300 = five real-world minutes at normal speed.
+   */
+  seasonPeriod: 300,
+  /**
+   * How much seasons swing plant availability, 0..1.
+   * 0 = no seasonal effect. 0.7 = ×0.3 at trough, ×1.7 at peak.
+   */
+  seasonAmplitude: 0,
 }
 
 export type TuningKey = keyof typeof TUNING_DEFAULTS
@@ -273,6 +283,24 @@ export const KNOBS: Knob[] = [
     min: 4,
     max: 90,
     step: 1,
+  },
+  {
+    key: 'seasonAmplitude',
+    group: 'world',
+    label: 'Seasons — strength',
+    help: 'A slow cycle that swings how fast plants grow and spread. At 0 there are no seasons. At 0.7, plants thrive in summer (×1.7 rate) and barely survive winter (×0.3 rate). At 1 they go dormant entirely in the trough.',
+    min: 0,
+    max: 1,
+    step: 0.05,
+  },
+  {
+    key: 'seasonPeriod',
+    group: 'world',
+    label: 'Seasons — cycle length (sim seconds)',
+    help: 'How long one full season cycle takes in simulation time. 300 is about five real minutes at normal speed. Shorter periods make the world feel more volatile; longer ones feel geological.',
+    min: 30,
+    max: 1800,
+    step: 30,
   },
 ]
 


### PR DESCRIPTION
## Summary

Closes #2778

- Adds `seasonAmplitude` (0..1) and `seasonPeriod` (30..1800 s) tuning knobs in the **World** group — both default to non-disruptive values (amplitude 0 = no seasons, so existing worlds are unchanged until a player opts in)
- `tickCreatures` computes a sine-wave `seasonFactor` each tick using the world's elapsed time; amplitude 0 short-circuits to `1` (no cost)
- `seedNativePlants` accepts an optional `seasonFactor` parameter and scales its target count accordingly — summer boosts regrowth, winter suppresses it
- Plant spread cooldown is also divided by `seasonFactor`, so meadows fill faster in summer and nearly stop in winter
- At amplitude 0.7, plants see ×1.7 rate at peak and ×0.3 at trough; at 1.0 they go fully dormant

## Test plan

- [ ] Default world: confirm no visible change (amplitude starts at 0)
- [ ] Set amplitude to 0.5, period to 120 s: watch plant count visibly rise and fall on a ~2-minute cycle
- [ ] Set amplitude to 1.0: plants should nearly stop spreading at winter trough
- [ ] Reset tuning: sliders return to defaults, world re-stabilises

🤖 Generated with [Claude Code](https://claude.com/claude-code)