### PR TITLE
feat(micro-land): mud slows walkers 50%, quicksand progressively traps them (#2791)

### DIFF
--- a/src/app/micro-land/domain/config/materials.ts
+++ b/src/app/micro-land/domain/config/materials.ts
@@ -67,6 +67,7 @@ export const BASE_MATERIAL_IDS = [
   'wood',
   'snow',
   'mud',
+  'quicksand',
   'moss',
   'crystal',
   'gem',
@@ -119,6 +120,7 @@ const BASE_MATERIALS: Record<BaseMaterialId, Material> = {
     melts: true,
   }),
   mud: material('mud', 'Mud', '#4d3a26', { grain: 0.22, powder: true, fertile: true }),
+  quicksand: material('quicksand', 'Quicksand', '#c4a060', { grain: 0.18, powder: true }),
   moss: material('moss', 'Moss', '#5f8a3e', { grain: 0.24, fertile: true, glow: 0.04 }),
 
   // --- shiny --------------------------------------------------------------
@@ -267,6 +269,7 @@ export const PAINTABLE: BaseMaterialId[] = [
   'grass',
   'moss',
   'mud',
+  'quicksand',
   'stone',
   'sand',
   'snow',

--- a/src/app/micro-land/domain/sim/creature-sim.ts
+++ b/src/app/micro-land/domain/sim/creature-sim.ts
@@ -390,7 +390,23 @@ export function tickCreatures(
     if (c.breedCooldown > 0) c.breedCooldown -= dt
     // Migration: creatures saved before toxicity was added won't have poisoned.
     if (c.poisoned === undefined) c.poisoned = 0
+    if ((c as { sinking?: number }).sinking === undefined) c.sinking = 0
     if (c.poisoned > 0) c.poisoned = Math.max(0, c.poisoned - dt)
+
+    // Quicksand: walkers progressively slow and die after 12 s if they can't escape.
+    if (bp.body.locomotion === 'walk') {
+      const qs_fx = Math.floor(c.x + body.dx + body.w / 2)
+      const qs_fy = Math.floor(c.y + body.dy + body.h)
+      if (MATERIAL_BY_INDEX[tileAt(w, qs_fx, qs_fy)]?.id === 'quicksand') {
+        c.sinking += dt
+        if (c.sinking > 12) {
+          kill(w, c, bp, dead, events, 'drowned')
+          continue
+        }
+      } else {
+        c.sinking = Math.max(0, c.sinking - dt * 2)
+      }
+    }
 
     // --- hunger ---------------------------------------------------------
     // Resting creatures aren't running or hunting, so they burn energy more slowly.
@@ -1213,8 +1229,16 @@ function steer(w: WorldState, c: Creature, bp: CreatureBlueprint, dt: number, rn
 
   switch (bp.move.kind) {
     case 'walk': {
+      // Mud slows walkers to 50%; quicksand slows progressively toward 0.
+      const footX = Math.floor(c.x + body.dx + body.w / 2)
+      const footY = Math.floor(c.y + body.dy + body.h)
+      const groundId = MATERIAL_BY_INDEX[tileAt(w, footX, footY)]?.id
+      const groundMult =
+        groundId === 'mud' ? 0.5
+        : groundId === 'quicksand' ? Math.max(0.05, 1 - c.sinking / 8)
+        : 1
       c.vx += wantX * accel * dt
-      c.vx = clampMag(c.vx, speed)
+      c.vx = clampMag(c.vx, speed * groundMult)
 
       /**
        * A burrower goes to ground when it is fed, and comes back up when it is

--- a/src/app/micro-land/domain/sim/world.ts
+++ b/src/app/micro-land/domain/sim/world.ts
@@ -379,6 +379,7 @@ export function spawnCreature(
     name: null,
     huntPassCount: 0,
     poisoned: 0,
+    sinking: 0,
   }
   w.creatures.push(creature)
   return creature

--- a/src/app/micro-land/domain/types.ts
+++ b/src/app/micro-land/domain/types.ts
@@ -34,6 +34,7 @@ export type BaseMaterialId =
   | 'wood'
   | 'snow'
   | 'mud'
+  | 'quicksand'
   | 'moss'
   | 'crystal'
   | 'gem'
@@ -439,6 +440,14 @@ export interface Creature {
    * each tick and returns to 0 on its own — no antidote needed.
    */
   poisoned: number
+  /**
+   * Seconds spent standing on quicksand.
+   *
+   * Walkers slow progressively as this rises (fully stopped at 8 s) and die
+   * if trapped for more than 12 s. Decays at 2× speed when off quicksand.
+   * Only tracked for 'walk' locomotion; other locomotion kinds ignore it.
+   */
+  sinking: number
 }
 
 /**


### PR DESCRIPTION
## Summary

Closes #2791

- **Mud** is already paintable; walkers now move at 50% speed on it. Crawlers, swimmers, and flyers are unaffected — only 'walk' locomotion sees the penalty.
- **Quicksand** is a new material (sandy gold, powder, `#c4a060`) added to the palette after mud. Walkers progressively slow as they sink — fully stopped after 8 s, dead after 12 s if they don't escape. Speed decays back at 2× rate once they're off it, so a creature that scrambles out quickly recovers fast.
- Migration guards handle saves that pre-date the `sinking` field.
- No new Creature fields visible in the inspector — sinking is internal bookkeeping only.

## Test plan

- [ ] Paint a mud patch; drop a walker on it — confirm it moves at half speed (swimmers/flyers unaffected)
- [ ] Paint a quicksand patch; drop a walker — confirm it slows progressively and dies after ~12 s if left there
- [ ] Drop a walker on quicksand, let it sink partway, then watch it escape — confirm speed recovers
- [ ] Drop a crawler on quicksand — confirm no effect
- [ ] Quicksand appears in the material palette after mud

🤖 Generated with [Claude Code](https://claude.com/claude-code)