### PR TITLE
feat(micro-land): pack hunting — 1.2× speed when two predators target the same prey (#2776)

### DIFF
--- a/src/app/micro-land/domain/sim/creature-sim.ts
+++ b/src/app/micro-land/domain/sim/creature-sim.ts
@@ -391,6 +391,8 @@ export function tickCreatures(
     // Migration: creatures saved before toxicity was added won't have poisoned.
     if (c.poisoned === undefined) c.poisoned = 0
     if (c.poisoned > 0) c.poisoned = Math.max(0, c.poisoned - dt)
+    if ((c as { packTimer?: number }).packTimer === undefined) c.packTimer = 0
+    if (c.packTimer > 0) c.packTimer = Math.max(0, c.packTimer - dt)
 
     // --- hunger ---------------------------------------------------------
     // Resting creatures aren't running or hunting, so they burn energy more slowly.
@@ -800,6 +802,29 @@ function look(
     c.huntPassCount = 0
   }
 
+  // Pack hunting: scan for a same-species neighbour targeting the same prey.
+  // When found, both creatures share a brief speed bonus — coordinated attacks
+  // close faster and are harder to flee from.
+  if (prey !== null) {
+    const packReach = sight + bw / 2
+    const packLast = cx + packReach + SIGHT_PAD_RIGHT
+    let coordinating = false
+    for (let pi = lowerBound(byX, cx - packReach - SIGHT_PAD_LEFT); pi < byX.length; pi++) {
+      const pk = byX[pi]
+      if (pk.x > packLast) break
+      if (pk.id === c.id) continue
+      if (pk.blueprintId === c.blueprintId && pk.targetId === prey.id) {
+        coordinating = true
+        break
+      }
+    }
+    // Grant one sense-interval of bonus (plus a little buffer) so it persists
+    // until the next pass rather than dropping between ticks.
+    c.packTimer = coordinating ? (SENSE_EVERY / 60) * 2.5 : 0
+  } else {
+    c.packTimer = 0
+  }
+
   if (threat) {
     c.mood = 'flee'
     c.targetId = threat.id
@@ -1207,7 +1232,7 @@ function steer(w: WorldState, c: Creature, bp: CreatureBlueprint, dt: number, rn
   }
 
   // Poison from a toxic plant halves movement speed for its duration.
-  const speed = speedOf(c, bp) * (c.poisoned > 0 ? 0.5 : 1)
+  const speed = speedOf(c, bp) * (c.poisoned > 0 ? 0.5 : 1) * (c.packTimer > 0 ? 1.2 : 1)
   const accel = speed * 6
   const digger = bp.dig.through.length > 0
 

--- a/src/app/micro-land/domain/sim/world.ts
+++ b/src/app/micro-land/domain/sim/world.ts
@@ -379,6 +379,7 @@ export function spawnCreature(
     name: null,
     huntPassCount: 0,
     poisoned: 0,
+    packTimer: 0,
   }
   w.creatures.push(creature)
   return creature

--- a/src/app/micro-land/domain/types.ts
+++ b/src/app/micro-land/domain/types.ts
@@ -439,6 +439,15 @@ export interface Creature {
    * each tick and returns to 0 on its own — no antidote needed.
    */
   poisoned: number
+  /**
+   * Seconds of pack-hunting speed bonus remaining.
+   *
+   * Set by the sense pass when a same-species neighbour is also targeting the
+   * same prey. Grants a 1.2× speed multiplier while above zero; decays each
+   * tick. Only one sense-interval worth of time is granted at a time, so the
+   * bonus only persists as long as coordination continues.
+   */
+  packTimer: number
 }
 
 /**


### PR DESCRIPTION
## Summary

Closes #2776

- Each sense pass, after a predator identifies prey, scans same-species neighbours within sight for any creature already targeting the same prey ID
- When a packmate is found, `packTimer` is set to ~2.5 sense-intervals worth of seconds (long enough to survive the gap between passes without flickering)
- While `packTimer > 0`, the `1.2×` speed multiplier applies in `steer()` — both the initiator and the packmate benefit independently as long as they're both targeting the same thing
- `packTimer` decays every tick; drops to 0 if coordination breaks (prey escapes, one of them eats, one changes target)
- No persistent squad state — purely emergent from the sense-pass geometry

## How it feels

Two hoppers that separately lock onto the same creature will close on it ~20% faster while they're both focused, making them harder to outrun than a lone predator. The pack dissolves the moment either of them finds a different target.

## Test plan

- [ ] Place two predators of the same species near prey — observe they close visibly faster when both locked on the same target vs. one hunting alone
- [ ] Place three predators; confirm all three benefit when any two share a target
- [ ] Grazers and swimmers: confirm no unintended interactions (pack check only fires when `prey !== null`, which for grazers means sharing a plant target — minor, benign)

🤖 Generated with [Claude Code](https://claude.com/claude-code)