### PR TITLE
feat(micro-land): creature trail visualization — fading path overlay (#2772)

### DIFF
--- a/src/app/micro-land/components/field-guide.tsx
+++ b/src/app/micro-land/components/field-guide.tsx
@@ -67,6 +67,8 @@ export function FieldGuide() {
   const requestLocate = useMicroLand(s => s.requestLocate)
   const traitOverlay = useMicroLand(s => s.traitOverlay)
   const setTraitOverlay = useMicroLand(s => s.setTraitOverlay)
+  const trailsEnabled = useMicroLand(s => s.trailsEnabled)
+  const setTrailsEnabled = useMicroLand(s => s.setTrailsEnabled)
 
   const [hiddenPlantIds, setHiddenPlantIds] = useState<ReadonlySet<string>>(new Set())
 
@@ -342,6 +344,27 @@ export function FieldGuide() {
                 {trait === 'lifespan' ? 'Life' : trait.charAt(0).toUpperCase() + trait.slice(1)}
               </button>
             ))}
+            <button
+              type="button"
+              className="cc-btn"
+              onClick={() => setTrailsEnabled(!trailsEnabled)}
+              style={{
+                fontFamily: 'var(--cc-font-mono)',
+                fontSize: 9,
+                letterSpacing: 1.2,
+                textTransform: 'uppercase',
+                padding: '4px 10px',
+                minHeight: 28,
+                borderRadius: 4,
+                border: trailsEnabled
+                  ? '1px solid var(--cc-mint)'
+                  : '1px solid var(--cc-mint-line)',
+                color: trailsEnabled ? 'var(--cc-mint)' : 'var(--cc-text-muted)',
+                background: trailsEnabled ? 'rgba(100,220,200,0.1)' : 'transparent',
+              }}
+            >
+              Trails
+            </button>
           </div>
           {traitOverlay && (
             <button

--- a/src/app/micro-land/rendering/renderer.ts
+++ b/src/app/micro-land/rendering/renderer.ts
@@ -106,6 +106,10 @@ export interface MapRect {
   h: number
 }
 
+interface TrailPoint { x: number; y: number; elapsed: number }
+/** Creature id → recent positions. Updated and drawn by drawCreatures(). */
+const trailMap = new Map<number, TrailPoint[]>()
+
 export class Renderer {
   private display: HTMLCanvasElement
   private ctx: CanvasRenderingContext2D
@@ -707,6 +711,48 @@ export class Renderer {
   private drawCreatures(w: WorldState, vx: number, vw: number): void {
     const ctx = this.wctx
     const traitKey = useMicroLand.getState().traitOverlay
+    const trailsEnabled = useMicroLand.getState().trailsEnabled
+
+    // --- trails: record positions, then draw before sprites ---
+    if (trailsEnabled) {
+      const now = w.elapsed
+      // Build a fast id→creature lookup for pruning dead trails
+      const alive = new Set(w.creatures.map(c => c.id))
+      for (const id of trailMap.keys()) {
+        if (!alive.has(id)) trailMap.delete(id)
+      }
+      // Sample & prune each creature
+      for (const c of w.creatures) {
+        let trail = trailMap.get(c.id)
+        if (!trail) { trail = []; trailMap.set(c.id, trail) }
+        // Sample at ~10 Hz (every 0.1 s of elapsed time)
+        const last = trail[trail.length - 1]
+        if (!last || now - last.elapsed > 0.1) {
+          trail.push({ x: c.x, y: c.y, elapsed: now })
+        }
+        // Drop points older than 5 s
+        while (trail.length > 0 && now - trail[0].elapsed > 5) trail.shift()
+      }
+      // Draw all trails (under sprites)
+      for (const c of w.creatures) {
+        const trail = trailMap.get(c.id)
+        if (!trail || trail.length < 2) continue
+        if (c.x + 4 < vx || c.x > vx + vw) continue  // rough cull
+        const hue = c.traits.hue ?? 0
+        ctx.fillStyle = `hsl(${hue}, 55%, 68%)`
+        for (const pt of trail) {
+          const age = w.elapsed - pt.elapsed
+          if (age > 5) continue
+          ctx.globalAlpha = (1 - age / 5) * 0.45
+          ctx.fillRect(Math.round(pt.x), Math.round(pt.y), 1, 1)
+        }
+      }
+      ctx.globalAlpha = 1
+    } else {
+      // Clear stale data when trails are off, so re-enabling starts fresh.
+      if (trailMap.size > 0) trailMap.clear()
+    }
+
     for (const c of w.creatures) {
       const bp = w.blueprints[c.blueprintId]
       if (!bp) continue

--- a/src/app/micro-land/store.ts
+++ b/src/app/micro-land/store.ts
@@ -283,6 +283,8 @@ interface MicroLandState {
   traitOverlay: string | null
   /** Toggle the trait overlay. Passing the current trait turns it off. */
   setTraitOverlay: (trait: string | null) => void
+  trailsEnabled: boolean
+  setTrailsEnabled: (on: boolean) => void
 
   setTheme: (id: string) => void
   setTool: (tool: Tool) => void
@@ -408,6 +410,7 @@ export const useMicroLand = create<MicroLandState>(set => ({
   worldsOpen: false,
   locateRequest: null,
   traitOverlay: null,
+  trailsEnabled: false,
 
   setTheme: themeId => set({ themeId }),
   setTool: tool => set({ tool }),
@@ -482,6 +485,7 @@ export const useMicroLand = create<MicroLandState>(set => ({
   requestLocate: blueprintId =>
     set({ locateRequest: { blueprintId, serial: ++locateSerial }, guideOpen: false }),
   setTraitOverlay: trait => set(s => ({ traitOverlay: s.traitOverlay === trait ? null : trait })),
+  setTrailsEnabled: on => set({ trailsEnabled: on }),
 
   notify: (text, action) =>
     set(s => ({


### PR DESCRIPTION
## Summary

Closes #2772

- "Trails" toggle button added to the Evolution view section in the field guide, matching the existing trait-button style
- When enabled, each creature records its position at ~10 Hz; points older than 5 s are dropped
- Trail dots are drawn before sprites (so they appear under creatures), fading from 45% alpha at fresh → 0% at 5 s old
- Color is `hsl(hue, 55%, 68%)` — matches the creature's hue drift, giving each species a distinct color without needing to decode sprites
- Trails clear automatically when toggled off; dead creature trails are pruned each frame
- Off by default — zero overhead when disabled (trail map is cleared on disable)

## Test plan

- [ ] Open field guide → Evolution view → click Trails — confirm faint colored dots appear behind moving creatures
- [ ] Let creatures wander — confirm trails fade and disappear after ~5 s
- [ ] Toggle Trails off — trails disappear immediately; toggle back on — fresh trails form
- [ ] Different species show different hue-colored trails when their trait.hue has drifted

🤖 Generated with [Claude Code](https://claude.com/claude-code)