### PR TITLE
feat(micro-land): lineage summary in field guide — generations born per species (#2773)

### DIFF
--- a/src/app/micro-land/components/field-guide.tsx
+++ b/src/app/micro-land/components/field-guide.tsx
@@ -81,6 +81,7 @@ export function FieldGuide() {
   if (!open) return null
 
   const counts = new Map(population.map(p => [p.blueprintId, p.count]))
+  const genByBp = new Map(population.map(p => [p.blueprintId, p.maxGeneration]))
   const allOrdered = [...blueprints].sort((a, b) => (counts.get(b.id) ?? 0) - (counts.get(a.id) ?? 0))
   const hiddenCount = [...allOrdered].filter(bp => hiddenPlantIds.has(bp.id)).length
   const ordered = allOrdered.filter(bp => !hiddenPlantIds.has(bp.id))
@@ -254,6 +255,7 @@ export function FieldGuide() {
               key={bp.id}
               bp={bp}
               alive={counts.get(bp.id) ?? 0}
+              maxGeneration={genByBp.get(bp.id) ?? 1}
               blueprints={blueprints}
               onLocate={(counts.get(bp.id) ?? 0) > 0 ? () => requestLocate(bp.id) : undefined}
               onHide={isPlantLike(bp) ? () => hideSpecies(bp.id) : undefined}
@@ -427,12 +429,14 @@ function GuideEntry({
   bp,
   alive,
   blueprints,
+  maxGeneration,
   onHide,
   onLocate,
 }: {
   bp: CreatureBlueprint
   alive: number
   blueprints: CreatureBlueprint[]
+  maxGeneration: number
   onHide?: () => void
   onLocate?: () => void
 }) {
@@ -553,6 +557,7 @@ function GuideEntry({
           }}
         >
           Size {bp.size} · {moveWord(bp)}
+          {maxGeneration > 1 && ` · ${maxGeneration} generations born here`}
           {bp.body.immuneTo.length > 0 && ` · unburnable`}
           {bp.glow > 0 && ` · glows`}
           {bp.dig.through.length > 0 && ` · digs through ${bp.dig.through.join(', ')}`}

--- a/src/app/micro-land/game-instance.ts
+++ b/src/app/micro-land/game-instance.ts
@@ -468,11 +468,14 @@ export class GameInstance {
   private pushStats(): void {
     const counts = countByBlueprint(this.world)
     const population: PopulationEntry[] = Object.entries(counts)
-      .map(([blueprintId, count]) => ({
-        blueprintId,
-        name: this.world.blueprints[blueprintId]?.name ?? blueprintId,
-        count,
-      }))
+      .map(([blueprintId, count]) => {
+        const name = this.world.blueprints[blueprintId]?.name ?? blueprintId
+        const maxGeneration = this.world.creatures.reduce(
+          (max, c) => c.blueprintId === blueprintId ? Math.max(max, c.generation) : max,
+          1
+        )
+        return { blueprintId, name, count, maxGeneration }
+      })
       .sort((a, b) => b.count - a.count)
 
     for (const entry of population) this.knownSpecies.add(entry.blueprintId)

--- a/src/app/micro-land/store.ts
+++ b/src/app/micro-land/store.ts
@@ -129,6 +129,8 @@ export interface PopulationEntry {
   blueprintId: string
   name: string
   count: number
+  /** Highest generation number among living creatures of this species. */
+  maxGeneration: number
 }
 
 /** One time-series data point for the population graph. */


### PR DESCRIPTION
## Summary

Closes #2773

- `PopulationEntry` gains a `maxGeneration: number` field — the highest generation number among living creatures of that species
- Computed in `pushStats()` via a single `reduce` over `this.world.creatures` — O(n) per species, runs a few times/second, negligible cost
- Field guide's `GuideEntry` displays `· N generations born here` when `maxGeneration > 1`; generation 1 (all placed by hand) shows nothing — no spurious "1 generations born" on a freshly painted world
- "Born here" language distinguishes placed founders from true offspring

## What it looks like

```
HOPPLING  · 14 alive
A small browsing creature...
Size 1 · walks · 7 generations born here
Eats: Sungrass, Greenpatch
Eaten by: Finling
```

## Test plan

- [ ] Fresh world: place a species — confirm no generation line appears
- [ ] Let creatures breed — confirm the number increments as generations pass
- [ ] Species at generation 14: field guide shows "14 generations born here"

🤖 Generated with [Claude Code](https://claude.com/claude-code)