### PR TITLE
feat(micro-land): challenge presets — 4 named world configurations with goals (#2784)

### DIFF
--- a/src/app/micro-land/MicroLandGame.tsx
+++ b/src/app/micro-land/MicroLandGame.tsx
@@ -9,6 +9,7 @@ import {
   initChronicle,
   onSaveState,
 } from '@/app/micro-land/chronicle/chronicle'
+import { ChallengesPanel } from '@/app/micro-land/components/challenges-panel'
 import { CreatureBuilder } from '@/app/micro-land/components/creature-builder'
 import { FieldGuide } from '@/app/micro-land/components/field-guide'
 import { Hud } from '@/app/micro-land/components/hud'
@@ -94,6 +95,7 @@ export function MicroLandGame() {
       // and a dependency-driven effect would rebuild the world on every remount.
       unsubscribe = useMicroLand.subscribe((state, previous) => {
         if (state.themeId !== previous.themeId) game?.setTheme(state.themeId)
+        if (state.reshuffleToken !== previous.reshuffleToken) game?.reshuffle()
         if (state.locateRequest !== previous.locateRequest && state.locateRequest && game) {
           const found = game.locateSpecies(state.locateRequest.blueprintId)
           if (!found) {
@@ -338,6 +340,7 @@ export function MicroLandGame() {
       <Toolbar onRemoveSpecies={handleRemoveSpecies} />
       <SummonPanel onIntroduce={handleIntroduce} onApplyTerrain={handleApplyTerrain} />
       <WorldsPanel onKeep={handleKeepWorld} onOpen={handleOpenWorld} onForget={handleForgetWorld} />
+      <ChallengesPanel />
       <CreatureBuilder onIntroduce={handleIntroduce} onRevise={handleRevise} />
       <FieldGuide />
       <SettingsPanel />

--- a/src/app/micro-land/components/challenges-panel.tsx
+++ b/src/app/micro-land/components/challenges-panel.tsx
@@ -1,0 +1,122 @@
+'use client'
+import { CHALLENGES } from '@/app/micro-land/domain/challenges'
+import { resetTuning, setTuning } from '@/app/micro-land/domain/tuning'
+import { useMicroLand } from '@/app/micro-land/store'
+
+export function ChallengesPanel() {
+  const open = useMicroLand(s => s.challengesOpen)
+  const setChallengesOpen = useMicroLand(s => s.setChallengesOpen)
+  const setChallengeActive = useMicroLand(s => s.setChallengeActive)
+  const requestReshuffle = useMicroLand(s => s.requestReshuffle)
+
+  if (!open) return null
+
+  function startChallenge(preset: (typeof CHALLENGES)[number]) {
+    resetTuning()
+    setTuning(preset.tuning)
+    setChallengeActive({ name: preset.name, goal: preset.goal })
+    requestReshuffle()
+    setChallengesOpen(false)
+  }
+
+  return (
+    <div
+      style={{
+        position: 'fixed',
+        inset: 0,
+        zIndex: 50,
+        background: 'rgba(0,0,0,0.7)',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+      }}
+      onClick={() => setChallengesOpen(false)}
+    >
+      <div
+        style={{
+          background: 'var(--cc-panel-bg)',
+          border: '1px solid var(--cc-panel-divider)',
+          borderRadius: 8,
+          padding: '20px 24px',
+          maxWidth: 420,
+          width: '90vw',
+        }}
+        onClick={e => e.stopPropagation()}
+      >
+        <h2
+          style={{
+            fontFamily: 'var(--cc-font-mono)',
+            fontSize: 11,
+            letterSpacing: 1.6,
+            textTransform: 'uppercase',
+            color: 'var(--cc-text-muted)',
+            marginBottom: 16,
+          }}
+        >
+          Challenges
+        </h2>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+          {CHALLENGES.map(c => (
+            <button
+              key={c.id}
+              type="button"
+              className="cc-btn"
+              onClick={() => startChallenge(c)}
+              style={{
+                display: 'block',
+                textAlign: 'left',
+                padding: '10px 14px',
+                border: '1px solid var(--cc-mint-line)',
+                borderRadius: 6,
+                background: 'transparent',
+              }}
+            >
+              <div
+                style={{
+                  fontFamily: 'var(--cc-font-mono)',
+                  fontSize: 11,
+                  letterSpacing: 1.2,
+                  textTransform: 'uppercase',
+                  color: 'var(--cc-mint)',
+                  marginBottom: 3,
+                }}
+              >
+                {c.name}
+              </div>
+              <div style={{ fontSize: 12, color: 'var(--cc-text-muted)', marginBottom: 4 }}>
+                {c.blurb}
+              </div>
+              <div
+                style={{
+                  fontSize: 10,
+                  fontFamily: 'var(--cc-font-mono)',
+                  color: 'var(--cc-text-muted)',
+                  opacity: 0.7,
+                }}
+              >
+                Goal: {c.goal}
+              </div>
+            </button>
+          ))}
+        </div>
+        <button
+          type="button"
+          className="cc-btn"
+          onClick={() => setChallengesOpen(false)}
+          style={{
+            marginTop: 14,
+            fontFamily: 'var(--cc-font-mono)',
+            fontSize: 9,
+            letterSpacing: 1,
+            textTransform: 'uppercase',
+            padding: '4px 10px',
+            border: '1px solid var(--cc-panel-divider)',
+            color: 'var(--cc-text-muted)',
+          }}
+        >
+          Close
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/src/app/micro-land/components/hud.tsx
+++ b/src/app/micro-land/components/hud.tsx
@@ -82,6 +82,10 @@ export function Hud({
   const settingsOpen = useMicroLand(s => s.settingsOpen)
   const setSettingsOpen = useMicroLand(s => s.setSettingsOpen)
   const tuning = useMicroLand(s => s.tuning)
+  const challengesOpen = useMicroLand(s => s.challengesOpen)
+  const setChallengesOpen = useMicroLand(s => s.setChallengesOpen)
+  const challengeActive = useMicroLand(s => s.challengeActive)
+  const setChallengeActive = useMicroLand(s => s.setChallengeActive)
 
   const { user, loading: authLoading } = useAuth()
   const isSignedIn = !authLoading && !!user && !user.isAnonymous
@@ -178,6 +182,22 @@ export function Hud({
         Worlds
       </button>
 
+      <button
+        type="button"
+        className="cc-btn"
+        onClick={() => setChallengesOpen(!challengesOpen)}
+        style={{
+          ...chipBase,
+          ...(challengeActive
+            ? { borderColor: 'var(--cc-mint)', color: 'var(--cc-mint)', background: 'rgba(100,220,200,0.08)' }
+            : {}),
+        }}
+        aria-pressed={challengesOpen}
+        title="Choose a challenge"
+      >
+        Challenges
+      </button>
+
       <div className="flex items-center gap-1" role="group" aria-label="Speed">
         <button
           type="button"
@@ -208,6 +228,41 @@ export function Hud({
       </div>
 
       <div className="ml-auto flex items-center gap-2">
+        {challengeActive && (
+          <span
+            style={{
+              fontFamily: 'var(--cc-font-mono)',
+              fontSize: 9,
+              letterSpacing: 1,
+              color: 'var(--cc-mint)',
+              opacity: 0.85,
+              maxWidth: 240,
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
+            }}
+            title={challengeActive.goal}
+          >
+            {challengeActive.name}: {challengeActive.goal}
+          </span>
+        )}
+        {challengeActive && (
+          <button
+            type="button"
+            className="cc-btn"
+            onClick={() => setChallengeActive(null)}
+            title="End challenge"
+            style={{
+              fontFamily: 'var(--cc-font-mono)',
+              fontSize: 9,
+              padding: '2px 6px',
+              border: '1px solid var(--cc-mint-line)',
+              color: 'var(--cc-text-muted)',
+            }}
+          >
+            ×
+          </button>
+        )}
         {!authLoading && (
           <Link
             href="/auth"

--- a/src/app/micro-land/domain/challenges.ts
+++ b/src/app/micro-land/domain/challenges.ts
@@ -1,0 +1,40 @@
+import type { Tuning } from '@/app/micro-land/domain/tuning'
+
+export interface ChallengePreset {
+  id: string
+  name: string
+  blurb: string
+  goal: string
+  tuning: Partial<Tuning>
+}
+
+export const CHALLENGES: ChallengePreset[] = [
+  {
+    id: 'empty-table',
+    name: 'Empty Table',
+    blurb: 'The soil grows nothing. Everything alive comes from your hands.',
+    goal: 'Keep at least one species alive for 5 minutes.',
+    tuning: { nativePlantTarget: 0, plantSeedBatch: 1, plantSeedInterval: 60 },
+  },
+  {
+    id: 'extreme-gravity',
+    name: 'Extreme Gravity',
+    blurb: 'Three times the pull. The surface is everything.',
+    goal: 'Keep two species alive for 3 minutes.',
+    tuning: { gravity: 75 },
+  },
+  {
+    id: 'last-generation',
+    name: 'Last Generation',
+    blurb: 'Nothing here can have children. The world winds down.',
+    goal: 'Keep any creature alive for 5 minutes.',
+    tuning: { breedCooldown: 120, hungerRateScale: 0.5 },
+  },
+  {
+    id: 'winter',
+    name: 'Permanent Winter',
+    blurb: 'Plants barely grow. Everything competes for the little that does.',
+    goal: 'Build a stable food chain of two or more species.',
+    tuning: { nativePlantTarget: 15, plantSpeciesCap: 12, plantSpreadCooldown: 120 },
+  },
+]

--- a/src/app/micro-land/store.ts
+++ b/src/app/micro-land/store.ts
@@ -199,6 +199,13 @@ interface MicroLandState {
   builderOpen: boolean
   guideOpen: boolean
   settingsOpen: boolean
+  challengesOpen: boolean
+  challengeActive: { name: string; goal: string } | null
+  /** Incremented each time a world reshuffle is needed; watched by MicroLandGame. */
+  reshuffleToken: number
+  setChallengesOpen: (open: boolean) => void
+  setChallengeActive: (c: { name: string; goal: string } | null) => void
+  requestReshuffle: () => void
   /**
    * Whether the tool drawer along the bottom is unrolled.
    *
@@ -391,6 +398,9 @@ export const useMicroLand = create<MicroLandState>(set => ({
   builderOpen: false,
   guideOpen: false,
   settingsOpen: false,
+  challengesOpen: false,
+  challengeActive: null,
+  reshuffleToken: 0,
   toolbarOpen: true,
   tuning: { ...TUNING },
   inspected: null,
@@ -446,6 +456,9 @@ export const useMicroLand = create<MicroLandState>(set => ({
   setBuilderOpen: builderOpen => set({ builderOpen }),
   setGuideOpen: guideOpen => set({ guideOpen }),
   setSettingsOpen: settingsOpen => set({ settingsOpen }),
+  setChallengesOpen: open => set({ challengesOpen: open }),
+  setChallengeActive: c => set({ challengeActive: c }),
+  requestReshuffle: () => set(s => ({ reshuffleToken: s.reshuffleToken + 1 })),
   setToolbarOpen: toolbarOpen => {
     storeToolbarOpen(toolbarOpen)
     set({ toolbarOpen })


### PR DESCRIPTION
## Summary

Closes #2784

- Four challenge presets: **Empty Table** (soil grows nothing), **Extreme Gravity** (75 gravity), **Last Generation** (120s breed cooldown), **Permanent Winter** (sparse slow-growing plants)
- "Challenges" button in the HUD opens a modal card list; each card shows name, flavour text, and goal
- Clicking a preset: resets tuning → applies preset tuning → reshuffles the world → records active challenge
- Active challenge name + goal displayed inline in the HUD; × button dismisses it
- `reshuffleToken` in the store (increment-to-trigger pattern) lets the challenges panel trigger a world reset via the existing `game.reshuffle()` path without needing a prop-drill

## Test plan

- [ ] Click Challenges in HUD → 4 presets appear with names, blurbs, and goals
- [ ] Start "Empty Table" → world reshuffles, ground grows no plants, HUD shows challenge banner
- [ ] Start "Extreme Gravity" → creatures fall very fast
- [ ] Dismiss challenge via × → banner clears, tuning is not automatically reset (player keeps custom world)
- [ ] Start a second challenge while one is active → old tuning replaced by new preset

🤖 Generated with [Claude Code](https://claude.com/claude-code)