### PR TITLE
feat(micro-land): scent trails — hungry creatures follow species pheromones toward food (#2781)

### DIFF
--- a/src/app/micro-land/domain/sim/creature-sim.ts
+++ b/src/app/micro-land/domain/sim/creature-sim.ts
@@ -32,7 +32,7 @@ import {
 } from '@/app/micro-land/domain/constants'
 import { inherit, lifespanOf, roamOf, sightOf, speedOf } from '@/app/micro-land/domain/traits'
 import { TUNING } from '@/app/micro-land/domain/tuning'
-import type { Creature, CreatureBlueprint, WorldState } from '@/app/micro-land/domain/types'
+import type { Creature, CreatureBlueprint, Scent, WorldState } from '@/app/micro-land/domain/types'
 
 import {
   boxDeadlyMaterial,
@@ -338,6 +338,7 @@ export function tickCreatures(
   // Migration: worlds saved before carcasses were added won't have these fields.
   w.carcasses ??= []
   w.nextCarcassId ??= 1
+  w.scents ??= []
 
   const creatures = w.creatures
   const dead = new Set<number>()
@@ -589,6 +590,10 @@ export function tickCreatures(
     w.carcasses = w.carcasses.filter(car => car.decaySeconds > 0)
   }
 
+  // Scent decay
+  for (const s of w.scents) s.decaySeconds -= dt
+  w.scents = w.scents.filter(s => s.decaySeconds > 0)
+
   tickParticles(w, dt, gravityScale)
 }
 
@@ -669,6 +674,10 @@ function look(
         c.hunger = Math.max(0, c.hunger - TUNING.mealValue)
         c.starving = 0
         c.mealsEaten++
+        // Leave a scent so hungry packmates can follow toward food.
+        if (w.scents.length < 200) {
+          w.scents.push({ x: c.x, y: c.y, blueprintId: c.blueprintId, decaySeconds: 15 })
+        }
         c.mood = 'eat'
         c.targetId = null
         car.decaySeconds = 0 // mark for removal at end of tick
@@ -739,6 +748,10 @@ function look(
         c.hunger = Math.max(0, c.hunger - TUNING.mealValue)
         c.starving = 0
         c.mealsEaten++
+        // Leave a scent so hungry packmates can follow toward food.
+        if (w.scents.length < 200) {
+          w.scents.push({ x: c.x, y: c.y, blueprintId: c.blueprintId, decaySeconds: 15 })
+        }
         c.mood = 'eat'
         c.targetId = null
         // Toxic plants slow the eater — the meal lands, but at a cost.
@@ -768,6 +781,30 @@ function look(
         preyCx = other.x + ow / 2
         preyCy = other.y + oh / 2
       }
+    }
+  }
+
+  // Scent following: a hungry animal with nothing in sight drifts toward
+  // a same-species scent trail if one is nearby. Cap the search radius at
+  // 2× plain sight so the behavior doesn't fire from across the world.
+  if (hungry && !prey && !threat && w.scents.length > 0) {
+    const scentReach2 = sight * sight * 4
+    const midX = cx
+    const midY = c.y + bh / 2
+    let nearestD2 = Infinity
+    let nearestScent: Scent | null = null
+    for (const s of w.scents) {
+      if (s.blueprintId !== c.blueprintId) continue
+      const sdx = s.x - midX
+      const sdy = s.y - midY
+      const d2 = sdx * sdx + sdy * sdy
+      if (d2 < nearestD2 && d2 < scentReach2) {
+        nearestD2 = d2
+        nearestScent = s
+      }
+    }
+    if (nearestScent) {
+      c.drift = nearestScent.x > midX ? 1 : -1
     }
   }
 

--- a/src/app/micro-land/domain/sim/world.ts
+++ b/src/app/micro-land/domain/sim/world.ts
@@ -47,6 +47,7 @@ export function createWorld(seed = 1337): WorldState {
     particles: [],
     carcasses: [],
     nextCarcassId: 1,
+    scents: [],
     blueprints,
     nextCreatureId: 1,
     elapsed: 0,

--- a/src/app/micro-land/domain/types.ts
+++ b/src/app/micro-land/domain/types.ts
@@ -459,6 +459,22 @@ export interface Carcass {
   blueprintId: string
 }
 
+/**
+ * A chemical marker left when a creature eats.
+ *
+ * Same-species animals that are hungry and have nothing in sight drift toward
+ * nearby scents, creating social foraging without any explicit communication.
+ * Decays over 15 seconds and vanishes. Capped at 200 world-wide.
+ */
+export interface Scent {
+  x: number
+  y: number
+  /** Which species left this marker. Only that species follows it. */
+  blueprintId: string
+  /** Seconds until this marker vanishes. */
+  decaySeconds: number
+}
+
 export interface Particle {
   x: number
   y: number
@@ -480,6 +496,7 @@ export interface WorldState {
   particles: Particle[]
   carcasses: Carcass[]
   nextCarcassId: number
+  scents: Scent[]
   /** Blueprints available in this world, keyed by id. */
   blueprints: Record<string, CreatureBlueprint>
   nextCreatureId: number


### PR DESCRIPTION
## Summary

Closes #2781

- When a creature eats, it leaves a `Scent` marker at its position (decays over 15 s, world-wide cap of 200)
- Hungry animals of the same species that have no prey in sight and no threat scan within 2× their plain-sight radius for scents — if found, they drift toward the nearest one
- Works for both predators (eating live prey) and grazers (eating plants or carcasses)
- The cap and 15s decay mean a well-fed world accumulates scents fast enough to guide hungry neighbours, but they don't persist so long they mislead when the food is gone
- Migration guards handle old saves without `scents` in WorldState

## Why this works

A predator eating in one corner leaves a trail; its species-mates, wandering hungry, pick up the direction and move that way — not because they were told to, but because they're following the last-seen-food signal. This concentrates populations around active feeding zones without any explicit coordination logic.

## Test plan

- [ ] Observe hungry creatures drifting toward areas where their species recently ate
- [ ] Clear all food — confirm scents expire within ~15 s and creatures stop following them
- [ ] Place a species with no food anywhere — confirm no infinite drift loop (no scents = no following)

🤖 Generated with [Claude Code](https://claude.com/claude-code)