### PR TITLE
feat(micro-land): burrowing homes — diggers create persistent dens (#2754)

### DIFF
--- a/src/app/micro-land/domain/sim/creature-sim.ts
+++ b/src/app/micro-land/domain/sim/creature-sim.ts
@@ -32,7 +32,7 @@ import {
 } from '@/app/micro-land/domain/constants'
 import { inherit, lifespanOf, roamOf, sightOf, speedOf } from '@/app/micro-land/domain/traits'
 import { TUNING } from '@/app/micro-land/domain/tuning'
-import type { Creature, CreatureBlueprint, WorldState } from '@/app/micro-land/domain/types'
+import type { Burrow, Creature, CreatureBlueprint, WorldState } from '@/app/micro-land/domain/types'
 
 import {
   boxDeadlyMaterial,
@@ -338,6 +338,7 @@ export function tickCreatures(
   // Migration: worlds saved before carcasses were added won't have these fields.
   w.carcasses ??= []
   w.nextCarcassId ??= 1
+  w.burrows ??= []
 
   const creatures = w.creatures
   const dead = new Set<number>()
@@ -395,6 +396,23 @@ export function tickCreatures(
     // --- hunger ---------------------------------------------------------
     // Resting creatures aren't running or hunting, so they burn energy more slowly.
     const restSlowdown = c.mood === 'rest' ? 0.5 : 1
+
+    // Burrowing: a well-rested digger stakes this spot as a den if none is nearby.
+    if (
+      c.mood === 'rest' &&
+      bp.dig.through.length > 0 &&
+      w.burrows.length < 50
+    ) {
+      const bx = Math.round(c.x)
+      const by = Math.round(c.y)
+      const nearbyBurrow = w.burrows.some(
+        b => b.blueprintId === c.blueprintId && Math.abs(b.x - bx) + Math.abs(b.y - by) < 8
+      )
+      if (!nearbyBurrow) {
+        w.burrows.push({ x: bx, y: by, blueprintId: c.blueprintId })
+      }
+    }
+
     c.hunger = Math.min(1, c.hunger + bp.diet.hungerRate * TUNING.hungerRateScale * restSlowdown * dt)
     if (c.hunger >= 1) {
       c.starving += dt
@@ -803,6 +821,24 @@ function look(
   if (threat) {
     c.mood = 'flee'
     c.targetId = threat.id
+    // Diggers: flee toward a known burrow rather than just away from threat.
+    if (bp.dig.through.length > 0 && w.burrows.length > 0) {
+      let nearestBurrow: Burrow | null = null
+      let nearestBurrowD2 = Infinity
+      for (const b of w.burrows) {
+        if (b.blueprintId !== c.blueprintId) continue
+        const bdx = b.x - cx
+        const bdy = b.y - (c.y + bh / 2)
+        const bd2 = bdx * bdx + bdy * bdy
+        if (bd2 < nearestBurrowD2 && bd2 < sight * sight * 9) {
+          nearestBurrowD2 = bd2
+          nearestBurrow = b
+        }
+      }
+      if (nearestBurrow) {
+        c.drift = nearestBurrow.x > cx ? 1 : -1
+      }
+    }
   } else if (prey && (preyDist <= sight2 || clearRun(w, bp, cx, cy, preyCx, preyCy))) {
     c.mood = 'hunt'
     c.targetId = prey.id

--- a/src/app/micro-land/domain/sim/world.ts
+++ b/src/app/micro-land/domain/sim/world.ts
@@ -46,6 +46,7 @@ export function createWorld(seed = 1337): WorldState {
     creatures: [],
     particles: [],
     carcasses: [],
+    burrows: [],
     nextCarcassId: 1,
     blueprints,
     nextCreatureId: 1,

--- a/src/app/micro-land/domain/types.ts
+++ b/src/app/micro-land/domain/types.ts
@@ -459,6 +459,21 @@ export interface Carcass {
   blueprintId: string
 }
 
+/**
+ * A persistent den created by a burrowing creature.
+ *
+ * A creature with dig capability that rests long enough at a spot stakes that
+ * spot as a burrow for its species. Same-species diggers flee toward the nearest
+ * burrow when threatened, and the burrow persists after the creator dies — ready
+ * for another to claim.
+ */
+export interface Burrow {
+  x: number
+  y: number
+  /** The species that made (and can use) this burrow. */
+  blueprintId: string
+}
+
 export interface Particle {
   x: number
   y: number
@@ -479,6 +494,7 @@ export interface WorldState {
   creatures: Creature[]
   particles: Particle[]
   carcasses: Carcass[]
+  burrows: Burrow[]
   nextCarcassId: number
   /** Blueprints available in this world, keyed by id. */
   blueprints: Record<string, CreatureBlueprint>


### PR DESCRIPTION
## Summary

Closes #2754

- **Burrow creation**: any creature with dig capability (`bp.dig.through.length > 0`) that rests at a spot creates a `Burrow` there if no same-species burrow exists within 8 Manhattan-distance tiles. Capped at 50 burrows world-wide.
- **Persistence**: burrows are stored in `WorldState.burrows[]` — they survive creature death and are available for any same-species digger to use
- **Flee behavior**: when a digger is threatened, it scans for the nearest same-species burrow within 3× plain-sight radius and steers toward it — the burrow acts as a refuge
- Migration guards handle old saves without `burrows` in WorldState

## Design answers (re: issue open questions)

- **Multiple creatures**: yes — any same-species digger can recognize and flee to any burrow of its kind
- **Burrow cost**: no explicit energy cost — creation happens during rest (when the creature is idle anyway)
- **Terrain**: the burrow is a metadata marker only, no tile modification needed for MVP

## Test plan

- [ ] Place a species with dig capability; observe it rest and establish a burrow (no visual yet — check via inspector/console)
- [ ] When threatened, the digger should move toward a nearby burrow rather than fleeing at random
- [ ] Kill the burrow creator — confirm another of the same species uses the burrow location

🤖 Generated with [Claude Code](https://claude.com/claude-code)