### PR TITLE
feat(micro-land): time-lapse replay — 30-min creature history with scrub timeline (#2792)

### DIFF
--- a/src/app/micro-land/MicroLandGame.tsx
+++ b/src/app/micro-land/MicroLandGame.tsx
@@ -10,6 +10,7 @@ import {
   onSaveState,
 } from '@/app/micro-land/chronicle/chronicle'
 import { CreatureBuilder } from '@/app/micro-land/components/creature-builder'
+import { ReplayBar } from '@/app/micro-land/components/replay-bar'
 import { FieldGuide } from '@/app/micro-land/components/field-guide'
 import { Hud } from '@/app/micro-land/components/hud'
 import { Inspector } from '@/app/micro-land/components/inspector'
@@ -272,6 +273,15 @@ export function MicroLandGame() {
     [notify]
   )
 
+  const handleOpenHistory = useCallback(() => {
+    const snapshots = gameRef.current?.getSnapshotHistory() ?? []
+    if (snapshots.length === 0) {
+      useMicroLand.getState().notify('No history yet — the world needs to run for at least 30 seconds.')
+      return
+    }
+    useMicroLand.getState().enterReplay(snapshots)
+  }, [])
+
   const handleReshuffle = useCallback(() => {
     gameRef.current?.reshuffle()
     notify('The ground shifts and settles somewhere new.')
@@ -317,7 +327,7 @@ export function MicroLandGame() {
 
   return (
     <div className="micro-land-shell flex h-full w-full flex-col overflow-hidden">
-      <Hud onReshuffle={handleReshuffle} onClearLife={handleClearLife} />
+      <Hud onReshuffle={handleReshuffle} onClearLife={handleClearLife} onOpenHistory={handleOpenHistory} />
 
       <div className="relative min-h-0 flex-1">
         <canvas
@@ -341,6 +351,7 @@ export function MicroLandGame() {
       <CreatureBuilder onIntroduce={handleIntroduce} onRevise={handleRevise} />
       <FieldGuide />
       <SettingsPanel />
+      <ReplayBar />
     </div>
   )
 }

--- a/src/app/micro-land/components/hud.tsx
+++ b/src/app/micro-land/components/hud.tsx
@@ -62,9 +62,11 @@ function SlidersIcon() {
 export function Hud({
   onReshuffle,
   onClearLife,
+  onOpenHistory,
 }: {
   onReshuffle: () => void
   onClearLife: () => void
+  onOpenHistory: () => void
 }) {
   const themeId = useMicroLand(s => s.themeId)
   const setTheme = useMicroLand(s => s.setTheme)
@@ -82,6 +84,8 @@ export function Hud({
   const settingsOpen = useMicroLand(s => s.settingsOpen)
   const setSettingsOpen = useMicroLand(s => s.setSettingsOpen)
   const tuning = useMicroLand(s => s.tuning)
+
+  const replaySnapshots = useMicroLand(s => s.replaySnapshots)
 
   const { user, loading: authLoading } = useAuth()
   const isSignedIn = !authLoading && !!user && !user.isAnonymous
@@ -206,6 +210,25 @@ export function Hud({
           </button>
         ))}
       </div>
+
+      <button
+        type="button"
+        className="cc-btn"
+        onClick={onOpenHistory}
+        disabled={!!replaySnapshots}
+        style={{
+          fontFamily: 'var(--cc-font-mono)',
+          fontSize: 9,
+          letterSpacing: 1.2,
+          textTransform: 'uppercase',
+          padding: '3px 8px',
+          border: '1px solid var(--cc-mint-line)',
+          color: 'var(--cc-text-muted)',
+        }}
+        title="View ecosystem history"
+      >
+        History
+      </button>
 
       <div className="ml-auto flex items-center gap-2">
         {!authLoading && (

--- a/src/app/micro-land/components/replay-bar.tsx
+++ b/src/app/micro-land/components/replay-bar.tsx
@@ -1,0 +1,146 @@
+'use client'
+import { useMicroLand } from '@/app/micro-land/store'
+
+export function ReplayBar() {
+  const replaySnapshots = useMicroLand(s => s.replaySnapshots)
+  const replayIndex = useMicroLand(s => s.replayIndex)
+  const setReplayIndex = useMicroLand(s => s.setReplayIndex)
+  const exitReplay = useMicroLand(s => s.exitReplay)
+
+  if (!replaySnapshots || replaySnapshots.length === 0) return null
+
+  const current = replaySnapshots[replayIndex]
+  const totalElapsed = replaySnapshots[replaySnapshots.length - 1].elapsed
+
+  function formatTime(s: number) {
+    const m = Math.floor(s / 60)
+    return `${m}m ${Math.floor(s % 60)}s`
+  }
+
+  return (
+    <div
+      style={{
+        position: 'fixed',
+        bottom: 0,
+        left: 0,
+        right: 0,
+        zIndex: 40,
+        background: 'rgba(10,10,18,0.92)',
+        borderTop: '1px solid var(--cc-panel-divider)',
+        padding: '8px 16px',
+        display: 'flex',
+        alignItems: 'center',
+        gap: 12,
+      }}
+    >
+      <span
+        style={{
+          fontFamily: 'var(--cc-font-mono)',
+          fontSize: 10,
+          letterSpacing: 1.2,
+          textTransform: 'uppercase',
+          color: 'var(--cc-mint)',
+          whiteSpace: 'nowrap',
+        }}
+      >
+        History
+      </span>
+
+      {/* Scrub bar */}
+      <div style={{ flex: 1, position: 'relative', height: 32, cursor: 'pointer' }}>
+        {/* Background track */}
+        <div
+          style={{
+            position: 'absolute',
+            top: '50%',
+            left: 0,
+            right: 0,
+            height: 2,
+            background: 'var(--cc-panel-divider)',
+            transform: 'translateY(-50%)',
+          }}
+        />
+        {/* Tick marks at each snapshot */}
+        {replaySnapshots.map((snap, i) => {
+          const pct = totalElapsed > 0 ? (snap.elapsed / totalElapsed) * 100 : 0
+          const isActive = i === replayIndex
+          return (
+            <button
+              key={i}
+              type="button"
+              onClick={() => setReplayIndex(i)}
+              style={{
+                position: 'absolute',
+                top: '50%',
+                left: `${pct}%`,
+                transform: 'translate(-50%, -50%)',
+                width: isActive ? 10 : 6,
+                height: isActive ? 10 : 6,
+                borderRadius: '50%',
+                background: isActive ? 'var(--cc-mint)' : 'var(--cc-text-muted)',
+                border: 'none',
+                padding: 0,
+                cursor: 'pointer',
+                transition: 'all 0.1s',
+              }}
+              title={formatTime(snap.elapsed)}
+            />
+          )
+        })}
+      </div>
+
+      {/* Current time */}
+      <span
+        style={{
+          fontFamily: 'var(--cc-font-mono)',
+          fontSize: 10,
+          color: 'var(--cc-text-muted)',
+          whiteSpace: 'nowrap',
+          minWidth: 60,
+          textAlign: 'right',
+        }}
+      >
+        {current ? formatTime(current.elapsed) : '—'}
+      </span>
+
+      {/* Prev / Next */}
+      <button
+        type="button"
+        className="cc-btn"
+        onClick={() => setReplayIndex(Math.max(0, replayIndex - 1))}
+        disabled={replayIndex <= 0}
+        style={{ fontFamily: 'var(--cc-font-mono)', fontSize: 11, padding: '3px 8px', border: '1px solid var(--cc-mint-line)', color: 'var(--cc-text-muted)' }}
+      >
+        ‹
+      </button>
+      <button
+        type="button"
+        className="cc-btn"
+        onClick={() => setReplayIndex(Math.min(replaySnapshots.length - 1, replayIndex + 1))}
+        disabled={replayIndex >= replaySnapshots.length - 1}
+        style={{ fontFamily: 'var(--cc-font-mono)', fontSize: 11, padding: '3px 8px', border: '1px solid var(--cc-mint-line)', color: 'var(--cc-text-muted)' }}
+      >
+        ›
+      </button>
+
+      {/* Exit */}
+      <button
+        type="button"
+        className="cc-btn"
+        onClick={exitReplay}
+        style={{
+          fontFamily: 'var(--cc-font-mono)',
+          fontSize: 9,
+          letterSpacing: 1,
+          textTransform: 'uppercase',
+          padding: '4px 10px',
+          border: '1px solid var(--cc-pink-border)',
+          color: 'var(--cc-pink)',
+          whiteSpace: 'nowrap',
+        }}
+      >
+        Exit
+      </button>
+    </div>
+  )
+}

--- a/src/app/micro-land/game-instance.ts
+++ b/src/app/micro-land/game-instance.ts
@@ -156,6 +156,10 @@ export class GameInstance {
   /** World-clock time of the last hunt notice, so kills don't spam the screen. */
   private lastHuntNotice = -HUNT_NOTICE_GAP
 
+  // --- time-lapse ---
+  private snapshotHistory: Array<{ elapsed: number; creatures: Creature[] }> = []
+  private lastSnapshotElapsed = -30
+
   // --- records ---
   /** Which land's records are being written to. See `landId()`. */
   private currentLand = DEFAULT_THEME
@@ -336,7 +340,15 @@ export class GameInstance {
     // answers at the same speed whether the world is paused or on fast-forward.
     this.updateCamera(delta / 1000)
 
-    this.renderer.render(this.world, theme, this.inspectedId, this.elderId)
+    // In replay mode, render the historical snapshot instead of live creatures.
+    const { replaySnapshots, replayIndex } = useMicroLand.getState()
+    if (replaySnapshots && replaySnapshots.length > 0) {
+      const snap = replaySnapshots[replayIndex] ?? replaySnapshots[replaySnapshots.length - 1]
+      const replayWorld = { ...this.world, creatures: snap.creatures }
+      this.renderer.render(replayWorld, theme, undefined, undefined)
+    } else {
+      this.renderer.render(this.world, theme, this.inspectedId, this.elderId)
+    }
   }
 
   /**
@@ -400,6 +412,17 @@ export class GameInstance {
   private step(gravity: number, events: SimEvent[]): void {
     const w = this.world
     w.elapsed += TICK_S
+
+    // Time-lapse: take a creature snapshot every 30 sim-seconds.
+    if (w.elapsed - this.lastSnapshotElapsed >= 30) {
+      this.lastSnapshotElapsed = w.elapsed
+      this.snapshotHistory.push({
+        elapsed: w.elapsed,
+        creatures: w.creatures.map(c => ({ ...c, traits: { ...c.traits } })),
+      })
+      // Keep last 60 snapshots (30 min at 30s intervals)
+      if (this.snapshotHistory.length > 60) this.snapshotHistory.shift()
+    }
 
     this.tileCounter++
     if (this.tileCounter >= TILE_TICK_EVERY) {
@@ -1059,6 +1082,8 @@ export class GameInstance {
       this.knownSpecies.clear()
       this.inspectedId = null
       this.following = false
+      this.snapshotHistory = []
+      this.lastSnapshotElapsed = -30
       this.renderer.markTilesDirty()
       this.beginLand()
       this.pushStats()
@@ -1071,6 +1096,8 @@ export class GameInstance {
     this.knownSpecies.clear()
     this.inspectedId = null
     this.following = false
+    this.snapshotHistory = []
+    this.lastSnapshotElapsed = -30
     seedStarters(this.world, themeId, this.rng)
     this.renderer.markTilesDirty()
     this.beginLand()
@@ -1089,6 +1116,8 @@ export class GameInstance {
       this.knownSpecies.clear()
       this.inspectedId = null
       this.following = false
+      this.snapshotHistory = []
+      this.lastSnapshotElapsed = -30
       this.renderer.markTilesDirty()
       this.beginLand()
       this.pushStats()
@@ -1099,6 +1128,8 @@ export class GameInstance {
     this.knownSpecies.clear()
     this.inspectedId = null
     this.following = false
+    this.snapshotHistory = []
+    this.lastSnapshotElapsed = -30
     seedStarters(this.world, themeId, this.rng)
     this.renderer.markTilesDirty()
     this.beginLand()
@@ -1231,6 +1262,11 @@ export class GameInstance {
 
   getWorld(): WorldState {
     return this.world
+  }
+
+  /** Returns a copy of the snapshot ring buffer for the replay UI. */
+  getSnapshotHistory(): Array<{ elapsed: number; creatures: Creature[] }> {
+    return [...this.snapshotHistory]
   }
 
   // -------------------------------------------------------------------------

--- a/src/app/micro-land/store.ts
+++ b/src/app/micro-land/store.ts
@@ -23,8 +23,14 @@ import {
 
 import type { SaveState } from './chronicle/chronicle'
 import type { ElderRecord, SpeciesRecord } from './chronicle/types'
-import type { CreatureBlueprint, LifeKind, MaterialId, Traits } from './domain/types'
+import type { Creature, CreatureBlueprint, LifeKind, MaterialId, Traits } from './domain/types'
 import type { ShelfState } from './worlds/shelf'
+
+/** One entry in the time-lapse snapshot ring buffer. */
+export interface CreatureSnapshot {
+  elapsed: number
+  creatures: Creature[]
+}
 
 /** Theme id standing for "the land the player summoned". */
 export const SUMMONED_THEME_ID = 'summoned'
@@ -284,6 +290,13 @@ interface MicroLandState {
   /** Toggle the trait overlay. Passing the current trait turns it off. */
   setTraitOverlay: (trait: string | null) => void
 
+  /** Creature snapshots for time-lapse. Null = not in replay mode. */
+  replaySnapshots: CreatureSnapshot[] | null
+  replayIndex: number
+  enterReplay: (snapshots: CreatureSnapshot[]) => void
+  setReplayIndex: (i: number) => void
+  exitReplay: () => void
+
   setTheme: (id: string) => void
   setTool: (tool: Tool) => void
   setBrush: (n: number) => void
@@ -408,6 +421,8 @@ export const useMicroLand = create<MicroLandState>(set => ({
   worldsOpen: false,
   locateRequest: null,
   traitOverlay: null,
+  replaySnapshots: null,
+  replayIndex: 0,
 
   setTheme: themeId => set({ themeId }),
   setTool: tool => set({ tool }),
@@ -482,6 +497,11 @@ export const useMicroLand = create<MicroLandState>(set => ({
   requestLocate: blueprintId =>
     set({ locateRequest: { blueprintId, serial: ++locateSerial }, guideOpen: false }),
   setTraitOverlay: trait => set(s => ({ traitOverlay: s.traitOverlay === trait ? null : trait })),
+
+  enterReplay: snapshots =>
+    set({ replaySnapshots: snapshots, replayIndex: snapshots.length - 1, paused: true }),
+  setReplayIndex: i => set({ replayIndex: i }),
+  exitReplay: () => set({ replaySnapshots: null, replayIndex: 0, paused: false }),
 
   notify: (text, action) =>
     set(s => ({


### PR DESCRIPTION
## Summary
- Captures a rolling 30-minute creature history (max 60 snapshots at 30s intervals) in `game-instance.ts`
- Adds a fixed-bottom `ReplayBar` component with a scrub timeline (click any dot to jump, prev/next buttons, time display, Exit)
- Replay mode renders historical creatures over the live tile map; exiting resumes live simulation
- History button added to HUD (disabled while already in replay)
- Snapshot buffer resets on theme change or world reshuffle

## How it works
1. Every 30 sim-seconds, `game-instance.ts` pushes a shallow clone of all creatures into a ring buffer (max 60)
2. "History" HUD button calls `enterReplay(snapshots)` → pauses sim, stores snapshots in store
3. `frame()` detects replay mode and renders `{ ...this.world, creatures: snap.creatures }` — live tiles, historical creatures
4. `ReplayBar` scrub UI lets you jump to any point; Exit resumes live play

Closes #2792

🤖 Generated with [Claude Code](https://claude.com/claude-code)