### PR TITLE
feat(micro-land): camouflage as heritable trait (#2818)

### DIFF
--- a/src/app/micro-land/domain/sim/creature-sim.ts
+++ b/src/app/micro-land/domain/sim/creature-sim.ts
@@ -97,15 +97,6 @@ const BITE_PAD = 0.5
  */
 const CAMOUFLAGE_STILL = 1.5
 
-/**
- * Fraction of food-sight at which a still animal can first be detected.
- *
- * 0.5 halves the detection radius, so a resting creature is invisible to a
- * hungry predator until it is much closer than it would otherwise need to be.
- * Plants are exempt — this only applies to animals that could plausibly freeze
- * or blend in, not to vegetation that the food chain depends on finding.
- */
-const CAMOUFLAGE_FACTOR = 0.5
 
 /**
  * How fertile the soil is at a world position — a multiplier on plant spread rate.
@@ -836,7 +827,13 @@ function look(
       const still =
         obp.move.kind !== 'root' &&
         Math.abs(other.vx) + Math.abs(other.vy) < CAMOUFLAGE_STILL
-      const efs2 = still ? foodSight2 * (CAMOUFLAGE_FACTOR * CAMOUFLAGE_FACTOR) : foodSight2
+      // Camouflage: trait scales how hard this creature is to spot.
+      // Still creatures benefit most; moving gives most of it away.
+      const camouflage = (other.traits as { camouflage?: number }).camouflage ?? 0.2
+      const detFactor = still
+        ? Math.max(0.15, 0.5 - camouflage * 0.375)  // 0.5 (camo=0) → 0.2 (camo=0.8)
+        : 1 - camouflage * 0.3                        // 1.0 (camo=0) → 0.76 (camo=0.8)
+      const efs2 = foodSight2 * detFactor * detFactor
       if (d2 <= efs2 && d2 < preyDist) {
         preyDist = d2
         prey = other

--- a/src/app/micro-land/domain/traits.ts
+++ b/src/app/micro-land/domain/traits.ts
@@ -77,6 +77,7 @@ export const NEUTRAL_TRAITS: Traits = Object.freeze({
   roam: 1,
   territorial: 0.5,
   size: 1,
+  camouflage: 0.2,
 })
 
 /** A fresh set for a creature that wasn't born here. Always a copy — it's mutable state. */
@@ -124,7 +125,7 @@ function wrapHue(h: number): number {
 export function inherit(a: Traits, b: Traits | null, rng: Rng): Traits {
   const drift = TUNING.traitDrift
   const hueDrift = drift * HUE_DRIFT_SCALE
-  const mix = (key: 'speed' | 'sight' | 'lifespan' | 'shade' | 'roam' | 'territorial' | 'size') =>
+  const mix = (key: 'speed' | 'sight' | 'lifespan' | 'shade' | 'roam' | 'territorial' | 'size' | 'camouflage') =>
     b ? (a[key] + b[key]) / 2 : a[key]
 
   return {
@@ -136,6 +137,7 @@ export function inherit(a: Traits, b: Traits | null, rng: Rng): Traits {
     roam: clamp(mix('roam') + nudge(rng, drift), TRAIT_MIN, TRAIT_MAX),
     territorial: clamp(mix('territorial') + nudge(rng, drift), 0.1, 1.4),
     size: clamp(mix('size') + nudge(rng, drift), 0.8, 1.2),
+    camouflage: clamp(mix('camouflage') + nudge(rng, drift), 0, 0.8),
   }
 }
 
@@ -260,6 +262,8 @@ export function traitPhrases(t: Traits): string[] {
   else if ((t.territorial ?? 0.5) <= 0.5 - NOTABLE) phrases.push('wandering')
   if ((t.size ?? 1) >= 1 + NOTABLE) phrases.push('larger than most')
   else if ((t.size ?? 1) <= 1 - NOTABLE) phrases.push('smaller than most')
+  if ((t.camouflage ?? 0.2) >= 0.3) phrases.push('hard to spot')
+  else if ((t.camouflage ?? 0.2) <= 0.1) phrases.push('easy to spot')
   return phrases
 }
 

--- a/src/app/micro-land/domain/types.ts
+++ b/src/app/micro-land/domain/types.ts
@@ -379,6 +379,15 @@ export interface Traits {
    * but are easier prey. Drifts each generation in [0.8, 1.2].
    */
   size: number
+  /**
+   * How well this creature blends into its background.
+   *
+   * 0 = no camouflage (full visibility), 1 = highly camouflaged (hard to spot).
+   * Still creatures benefit the most — a motionless animal with high camouflage
+   * is nearly invisible until a predator is almost on top of it. Moving gives
+   * most of it away. Heritable — a hunted line can evolve toward stillness.
+   */
+  camouflage: number
 }
 
 /** One living thing in the world. */


### PR DESCRIPTION
Closes #2818

## What this does

Replaces the hard-coded `CAMOUFLAGE_FACTOR = 0.5` with a proper heritable `camouflage` trait (range 0–0.8, neutral 0.2).

### Detection factors

| Camouflage | Still | Moving |
|---|---|---|
| 0.0 (none) | 0.50 sight | 1.00 sight |
| 0.2 (neutral) | ~0.42 sight | ~0.94 sight |
| 0.8 (max) | 0.20 sight | 0.76 sight |

A predator at full range can no longer reliably spot a motionless, well-camouflaged creature. Moving sacrifices most of the benefit.

### Heritability
Drifts each generation in [0, 0.8] via the standard `inherit()` path. A hunted population can evolve toward higher camouflage over generations.

### Old saves
Migration guard `?? 0.2` on every trait read — old creatures default to the neutral value, so behavior is nearly identical to before.

### Trait phrases
- `≥ 0.3`: "hard to spot"
- `≤ 0.1`: "easy to spot"

🤖 Generated with [Claude Code](https://claude.com/claude-code)