### PR TITLE
feat(micro-land): population graph panel (#2820)

### DIFF
--- a/src/app/micro-land/MicroLandGame.tsx
+++ b/src/app/micro-land/MicroLandGame.tsx
@@ -10,6 +10,7 @@ import {
   onSaveState,
 } from '@/app/micro-land/chronicle/chronicle'
 import { ChallengesPanel } from '@/app/micro-land/components/challenges-panel'
+import { PopulationGraph } from '@/app/micro-land/components/population-graph'
 import { CreatureBuilder } from '@/app/micro-land/components/creature-builder'
 import { ReplayBar } from '@/app/micro-land/components/replay-bar'
 import { FieldGuide } from '@/app/micro-land/components/field-guide'
@@ -355,6 +356,7 @@ export function MicroLandGame() {
       <FieldGuide />
       <SettingsPanel />
       <ReplayBar />
+      <PopulationGraph />
     </div>
   )
 }

--- a/src/app/micro-land/components/hud.tsx
+++ b/src/app/micro-land/components/hud.tsx
@@ -59,6 +59,16 @@ function SlidersIcon() {
   )
 }
 
+function GraphIcon() {
+  return (
+    <svg width="13" height="13" viewBox="0 0 13 13" fill="currentColor" aria-hidden="true">
+      <polyline points="0,12 0,8 3,8 3,12" strokeWidth="0" />
+      <polyline points="4,12 4,4 7,4 7,12" strokeWidth="0" />
+      <polyline points="8,12 8,0 11,0 11,12" strokeWidth="0" />
+    </svg>
+  )
+}
+
 export function Hud({
   onReshuffle,
   onClearLife,
@@ -90,6 +100,8 @@ export function Hud({
   const setChallengeActive = useMicroLand(s => s.setChallengeActive)
 
   const replaySnapshots = useMicroLand(s => s.replaySnapshots)
+  const graphOpen = useMicroLand(s => s.graphOpen)
+  const setGraphOpen = useMicroLand(s => s.setGraphOpen)
 
   const { user, loading: authLoading } = useAuth()
   const isSignedIn = !authLoading && !!user && !user.isAnonymous
@@ -318,6 +330,20 @@ export function Hud({
           title={tuned ? 'The laws of this land have been changed' : 'Change the laws of this land'}
         >
           <SlidersIcon />
+        </button>
+        <button
+          type="button"
+          className="cc-btn"
+          onClick={() => setGraphOpen(!graphOpen)}
+          style={{
+            ...chipBase,
+            padding: '7px 9px',
+            ...(graphOpen ? activeChip : {}),
+          }}
+          aria-pressed={graphOpen}
+          title="Population graph — species counts over time"
+        >
+          <GraphIcon />
         </button>
         <button
           type="button"

--- a/src/app/micro-land/components/population-graph.tsx
+++ b/src/app/micro-land/components/population-graph.tsx
@@ -1,0 +1,172 @@
+'use client'
+
+import { useEffect, useRef } from 'react'
+
+import { useMicroLand } from '@/app/micro-land/store'
+
+/** Picks the first opaque color from a blueprint's art palette. */
+function firstPaletteColor(palette: Record<string, string>): string {
+  const vals = Object.values(palette)
+  return vals.length > 0 ? vals[0] : '#888888'
+}
+
+export function PopulationGraph() {
+  const graphOpen = useMicroLand(s => s.graphOpen)
+  const setGraphOpen = useMicroLand(s => s.setGraphOpen)
+  const history = useMicroLand(s => s.populationHistory)
+  const population = useMicroLand(s => s.population)
+  const blueprints = useMicroLand(s => s.blueprints)
+  const canvasRef = useRef<HTMLCanvasElement>(null)
+
+  useEffect(() => {
+    if (!graphOpen) return
+    const canvas = canvasRef.current
+    if (!canvas) return
+    const ctx = canvas.getContext('2d')
+    if (!ctx) return
+
+    const W = canvas.width
+    const H = canvas.height
+    const PAD = { top: 8, right: 10, bottom: 24, left: 34 }
+    const chartW = W - PAD.left - PAD.right
+    const chartH = H - PAD.top - PAD.bottom
+
+    ctx.clearRect(0, 0, W, H)
+
+    if (history.length < 2) {
+      ctx.fillStyle = 'rgba(255,255,255,0.25)'
+      ctx.font = '10px monospace'
+      ctx.textAlign = 'center'
+      ctx.fillText('collecting data…', W / 2, H / 2)
+      return
+    }
+
+    // Gather the blueprint ids that appear in current population or history.
+    const ids = [...new Set([
+      ...population.map(p => p.blueprintId),
+      ...history.flatMap(s => Object.keys(s.counts)),
+    ])]
+
+    const bpMap = new Map(blueprints.map(b => [b.id, b]))
+    const colorOf = (id: string) => {
+      const bp = bpMap.get(id)
+      return bp ? firstPaletteColor(bp.art.palette) : '#888888'
+    }
+
+    const elMin = history[0].elapsed
+    const elMax = history[history.length - 1].elapsed
+    const elSpan = Math.max(1, elMax - elMin)
+
+    const allCounts = history.flatMap(s => Object.values(s.counts))
+    const maxCount = Math.max(1, ...allCounts)
+
+    // Background
+    ctx.fillStyle = 'rgba(0,0,0,0.6)'
+    ctx.fillRect(0, 0, W, H)
+
+    // Grid
+    ctx.strokeStyle = 'rgba(255,255,255,0.08)'
+    ctx.lineWidth = 1
+    for (let i = 0; i <= 4; i++) {
+      const y = PAD.top + (chartH * i) / 4
+      ctx.beginPath()
+      ctx.moveTo(PAD.left, y)
+      ctx.lineTo(PAD.left + chartW, y)
+      ctx.stroke()
+    }
+
+    // Y-axis labels
+    ctx.fillStyle = 'rgba(255,255,255,0.4)'
+    ctx.font = '9px monospace'
+    ctx.textAlign = 'right'
+    for (let i = 0; i <= 4; i++) {
+      const y = PAD.top + (chartH * i) / 4
+      const val = Math.round(maxCount * (1 - i / 4))
+      ctx.fillText(String(val), PAD.left - 4, y + 3)
+    }
+
+    // X-axis label (elapsed minutes)
+    ctx.textAlign = 'center'
+    ctx.fillText(
+      `${Math.round(elSpan / 60)} min`,
+      PAD.left + chartW / 2,
+      H - 6
+    )
+
+    // Lines
+    for (const id of ids) {
+      const color = colorOf(id)
+      ctx.beginPath()
+      ctx.strokeStyle = color
+      ctx.lineWidth = 1.5
+      ctx.lineJoin = 'round'
+      let first = true
+      for (const snap of history) {
+        const count = snap.counts[id] ?? 0
+        const x = PAD.left + ((snap.elapsed - elMin) / elSpan) * chartW
+        const y = PAD.top + chartH - (count / maxCount) * chartH
+        if (first) { ctx.moveTo(x, y); first = false }
+        else ctx.lineTo(x, y)
+      }
+      ctx.stroke()
+    }
+  }, [graphOpen, history, population, blueprints])
+
+  if (!graphOpen) return null
+
+  return (
+    <div
+      style={{
+        position: 'fixed',
+        bottom: 48,
+        left: '50%',
+        transform: 'translateX(-50%)',
+        zIndex: 40,
+        borderRadius: 6,
+        overflow: 'hidden',
+        boxShadow: '0 4px 24px rgba(0,0,0,0.6)',
+        border: '1px solid rgba(255,255,255,0.12)',
+      }}
+    >
+      <div
+        style={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          padding: '4px 8px',
+          background: 'rgba(0,0,0,0.8)',
+          borderBottom: '1px solid rgba(255,255,255,0.1)',
+          fontFamily: 'var(--cc-font-mono)',
+          fontSize: 9,
+          letterSpacing: 1.2,
+          textTransform: 'uppercase',
+          color: 'rgba(255,255,255,0.5)',
+        }}
+      >
+        Population over time
+        <button
+          type="button"
+          onClick={() => setGraphOpen(false)}
+          style={{
+            background: 'none',
+            border: 'none',
+            color: 'rgba(255,255,255,0.5)',
+            cursor: 'pointer',
+            fontSize: 14,
+            lineHeight: 1,
+            padding: '0 2px',
+          }}
+          aria-label="Close population graph"
+        >
+          ×
+        </button>
+      </div>
+      <canvas
+        ref={canvasRef}
+        width={360}
+        height={160}
+        style={{ display: 'block' }}
+      />
+    </div>
+  )
+}

--- a/src/app/micro-land/store.ts
+++ b/src/app/micro-land/store.ts
@@ -207,6 +207,7 @@ interface MicroLandState {
   builderOpen: boolean
   guideOpen: boolean
   settingsOpen: boolean
+  graphOpen: boolean
   challengesOpen: boolean
   challengeActive: { name: string; goal: string } | null
   /** Incremented each time a world reshuffle is needed; watched by MicroLandGame. */
@@ -328,6 +329,7 @@ interface MicroLandState {
   setBuilderOpen: (open: boolean) => void
   setGuideOpen: (open: boolean) => void
   setSettingsOpen: (open: boolean) => void
+  setGraphOpen: (open: boolean) => void
   /** Roll the tool drawer up or down. Remembered for the next visit. */
   setToolbarOpen: (open: boolean) => void
   /** Move one knob. Takes effect on the very next tick and is remembered. */
@@ -417,6 +419,7 @@ export const useMicroLand = create<MicroLandState>(set => ({
   builderOpen: false,
   guideOpen: false,
   settingsOpen: false,
+  graphOpen: false,
   challengesOpen: false,
   challengeActive: null,
   reshuffleToken: 0,
@@ -484,6 +487,7 @@ export const useMicroLand = create<MicroLandState>(set => ({
   setBuilderOpen: builderOpen => set({ builderOpen }),
   setGuideOpen: guideOpen => set({ guideOpen }),
   setSettingsOpen: settingsOpen => set({ settingsOpen }),
+  setGraphOpen: graphOpen => set({ graphOpen }),
   setChallengesOpen: open => set({ challengesOpen: open }),
   setChallengeActive: c => set({ challengeActive: c }),
   requestReshuffle: () => set(s => ({ reshuffleToken: s.reshuffleToken + 1 })),


### PR DESCRIPTION
Closes #2820

## What this does

Adds a live canvas line chart showing species population over the last ~5 simulation minutes, toggled from a new bar-chart icon in the HUD.

### Chart details
- **One line per species** — color taken from the blueprint's first palette color, so the chart lines match the creatures on screen
- **X axis** — elapsed sim time (shows span in minutes at bottom)
- **Y axis** — creature count (0 to max seen, labeled at 4 intervals)
- **Sampling** — driven by `populationHistory` in the store, which snapshots every ~1 sim second (up to 300 points = ~5 minutes)
- **Shows "collecting data…"** before 2 snapshots are available

### UI
- Toggle button (bar-chart icon) to the left of "kinds · alive" in the HUD
- Panel floats centered at bottom, above the toolbar
- Title bar with close button

### No sim changes
Pure UI feature — reads existing `populationHistory` from the store.

🤖 Generated with [Claude Code](https://claude.com/claude-code)