### PR TITLE
feat(micro-land): extinction memorial in field guide (#2826)

### DIFF
--- a/src/app/micro-land/components/field-guide.tsx
+++ b/src/app/micro-land/components/field-guide.tsx
@@ -70,6 +70,7 @@ export function FieldGuide() {
   const addBlueprint = useMicroLand(s => s.addBlueprint)
   const trailsEnabled = useMicroLand(s => s.trailsEnabled)
   const setTrailsEnabled = useMicroLand(s => s.setTrailsEnabled)
+  const extinctions = useMicroLand(s => s.extinctions)
 
   const [hiddenPlantIds, setHiddenPlantIds] = useState<ReadonlySet<string>>(new Set())
 
@@ -393,6 +394,38 @@ export function FieldGuide() {
             </button>
           )}
         </section>
+
+        {extinctions.length > 0 && (
+          <section className="px-4 py-3" style={{ borderTop: '1px solid var(--cc-panel-divider)' }}>
+            <h3 className="pb-2" style={sectionHeading}>
+              Extinctions
+            </h3>
+            <p style={{ fontSize: 11, color: 'var(--cc-text-muted)', marginBottom: 8 }}>
+              Species that lived and died in this land.
+            </p>
+            <ul style={{ listStyle: 'none', padding: 0, margin: 0 }}>
+              {[...extinctions].reverse().map(ext => (
+                <li
+                  key={ext.blueprintId + ext.elapsed}
+                  style={{
+                    display: 'flex',
+                    justifyContent: 'space-between',
+                    alignItems: 'baseline',
+                    padding: '3px 0',
+                    opacity: 0.6,
+                    fontSize: 11,
+                    fontFamily: 'var(--cc-font-mono)',
+                  }}
+                >
+                  <span>🦴 {ext.name}</span>
+                  <span style={{ color: 'var(--cc-text-muted)', fontSize: 10 }}>
+                    gen {ext.maxGeneration} · {Math.round(ext.livedFor / 60)} min
+                  </span>
+                </li>
+              ))}
+            </ul>
+          </section>
+        )}
 
         <ImportSection addBlueprint={addBlueprint} />
       </div>

--- a/src/app/micro-land/game-instance.ts
+++ b/src/app/micro-land/game-instance.ts
@@ -67,6 +67,7 @@ import { Renderer } from './rendering/renderer'
 import { forgetSprites } from './rendering/sprite-cache'
 import {
   type EarnedMilestone,
+  type ExtinctionRecord,
   type KindRecordsView,
   type PopulationEntry,
   useMicroLand,
@@ -153,6 +154,8 @@ export class GameInstance {
 
   /** Species that existed last time we checked, for extinction notices. */
   private knownSpecies = new Set<string>()
+  /** World-clock time when each species was first observed alive in this world. */
+  private speciesFirstSeen = new Map<string, number>()
   /** World-clock time of the last hunt notice, so kills don't spam the screen. */
   private lastHuntNotice = -HUNT_NOTICE_GAP
 
@@ -463,6 +466,20 @@ export class GameInstance {
       const stillAlive = this.world.creatures.some(c => c.blueprintId === bp.id)
       if (stillAlive) continue
       this.knownSpecies.delete(bp.id)
+      // Record extinction in store for the field guide memorial.
+      {
+        const firstSeen = this.speciesFirstSeen.get(bp.id) ?? this.world.elapsed
+        useMicroLand.getState().addExtinction({
+          blueprintId: bp.id,
+          name: bp.name,
+          elapsed: this.world.elapsed,
+          livedFor: this.world.elapsed - firstSeen,
+          maxGeneration: this.world.creatures.reduce(
+            (max, c) => c.blueprintId === bp.id ? Math.max(max, c.generation) : max,
+            1
+          ),
+        })
+      }
       // An extinction is exactly what the steady streak measures the absence of
       // — it is the moment the world has to bail the player out via seed rain.
       this.breakSteadyStreak()
@@ -501,7 +518,12 @@ export class GameInstance {
       })
       .sort((a, b) => b.count - a.count)
 
-    for (const entry of population) this.knownSpecies.add(entry.blueprintId)
+    for (const entry of population) {
+      this.knownSpecies.add(entry.blueprintId)
+      if (!this.speciesFirstSeen.has(entry.blueprintId)) {
+        this.speciesFirstSeen.set(entry.blueprintId, this.world.elapsed)
+      }
+    }
 
     useMicroLand.getState().setStats(population, this.world.creatures.length, this.world.elapsed)
 
@@ -1062,6 +1084,7 @@ export class GameInstance {
     if (!opts.keepCreatures) {
       clearCreatures(this.world)
       this.knownSpecies.clear()
+      this.speciesFirstSeen.clear()
       this.inspectedId = null
       this.following = false
     }
@@ -1083,6 +1106,7 @@ export class GameInstance {
       applyThemeObject(this.world, this.summonedTheme)
       clearCreatures(this.world)
       this.knownSpecies.clear()
+      this.speciesFirstSeen.clear()
       this.inspectedId = null
       this.following = false
       this.snapshotHistory = []
@@ -1097,6 +1121,7 @@ export class GameInstance {
     applyTheme(this.world, themeId)
     clearCreatures(this.world)
     this.knownSpecies.clear()
+    this.speciesFirstSeen.clear()
     this.inspectedId = null
     this.following = false
     this.snapshotHistory = []
@@ -1117,6 +1142,7 @@ export class GameInstance {
       applyThemeObject(this.world, this.summonedTheme)
       clearCreatures(this.world)
       this.knownSpecies.clear()
+      this.speciesFirstSeen.clear()
       this.inspectedId = null
       this.following = false
       this.snapshotHistory = []
@@ -1129,6 +1155,7 @@ export class GameInstance {
     applyTheme(this.world, themeId)
     clearCreatures(this.world)
     this.knownSpecies.clear()
+    this.speciesFirstSeen.clear()
     this.inspectedId = null
     this.following = false
     this.snapshotHistory = []
@@ -1146,6 +1173,7 @@ export class GameInstance {
     // the player does next — painting, placing, summoning — wakes it back up.
     this.world.dormant = true
     this.knownSpecies.clear()
+    this.speciesFirstSeen.clear()
     this.inspectedId = null
     this.following = false
     // Emptying the world is an extinction of everything, so the streak goes with
@@ -1375,9 +1403,11 @@ export class GameInstance {
     // Seeded from what is actually alive, so opening a world does not announce
     // the extinction of everything that was in the land it replaced.
     this.knownSpecies = new Set(this.world.creatures.map(c => c.blueprintId))
+    this.speciesFirstSeen.clear()
     this.inspectedId = null
     this.following = false
     store.setInspected(null)
+    store.clearExtinctions()
 
     this.renderer.panToLeft(save.camX)
     this.renderer.markTilesDirty()

--- a/src/app/micro-land/store.ts
+++ b/src/app/micro-land/store.ts
@@ -139,6 +139,17 @@ export interface PopulationEntry {
   maxGeneration: number
 }
 
+export interface ExtinctionRecord {
+  blueprintId: string
+  name: string
+  /** Sim time when the last one died, seconds. */
+  elapsed: number
+  /** How many sim seconds it was alive in this world. */
+  livedFor: number
+  /** Highest generation reached. */
+  maxGeneration: number
+}
+
 /** One time-series data point for the population graph. */
 export interface PopulationSnapshot {
   /** Sim time in seconds when this snapshot was taken. */
@@ -188,6 +199,8 @@ interface MicroLandState {
   elapsed: number
   /** Rolling history for the population graph. Cleared on world load. */
   populationHistory: PopulationSnapshot[]
+  /** Species that went extinct in this session, newest last. */
+  extinctions: ExtinctionRecord[]
 
   summonOpen: boolean
   summonBusy: boolean
@@ -317,6 +330,8 @@ interface MicroLandState {
   /** Add a single blueprint without resetting population history. */
   addBlueprint: (bp: CreatureBlueprint) => void
   setStats: (population: PopulationEntry[], total: number, elapsed: number) => void
+  addExtinction: (record: ExtinctionRecord) => void
+  clearExtinctions: () => void
   setSummonOpen: (open: boolean) => void
   setSummonBusy: (busy: boolean) => void
   setSummonMode: (mode: 'creature' | 'scene' | 'terrain') => void
@@ -407,6 +422,7 @@ export const useMicroLand = create<MicroLandState>(set => ({
   totalCreatures: 0,
   elapsed: 0,
   populationHistory: [],
+  extinctions: [],
 
   summonOpen: false,
   summonBusy: false,
@@ -446,7 +462,7 @@ export const useMicroLand = create<MicroLandState>(set => ({
   setBrush: brush => set({ brush }),
   togglePaused: () => set(s => ({ paused: !s.paused })),
   setSpeed: speed => set({ speed }),
-  setBlueprints: blueprints => set({ blueprints, populationHistory: [] }),
+  setBlueprints: blueprints => set({ blueprints, populationHistory: [], extinctions: [] }),
   addBlueprint: bp =>
     set(s => ({
       blueprints: s.blueprints.some(b => b.id === bp.id)
@@ -469,6 +485,8 @@ export const useMicroLand = create<MicroLandState>(set => ({
         }),
       }
     }),
+  addExtinction: record => set(s => ({ extinctions: [...s.extinctions, record] })),
+  clearExtinctions: () => set({ extinctions: [] }),
   setSummonOpen: summonOpen => set({ summonOpen }),
   setSummonBusy: summonBusy => set({ summonBusy }),
   setSummonMode: summonMode => set({ summonMode }),


### PR DESCRIPTION
Closes #2826

## What this does

Records every species extinction for the current land and shows them in the field guide under an "Extinctions" section.

### Detection
The existing `digestEvents` loop in `game-instance.ts` already fires when the last creature of a species dies. Now it also:
1. Looks up when the species was first seen (`speciesFirstSeen` map, populated in `pushStats`)
2. Calls `store.addExtinction({ blueprintId, name, elapsed, livedFor, maxGeneration })`

### Store
- `ExtinctionRecord` interface: `{ blueprintId, name, elapsed, livedFor, maxGeneration }`
- `extinctions: ExtinctionRecord[]` array in store state
- `addExtinction` / `clearExtinctions` actions
- Extinctions clear on: new land load, clear-all, `adoptSave`

### Field guide
A new "Extinctions" section appears at the bottom of the field guide when any species has gone extinct. Each entry shows:
- 🦴 Species name
- Highest generation reached
- Minutes it was alive in this land

Entries are shown newest-first (most recent extinction at top).

### Toast
The existing `notify()` call already shows a 3-second toast when extinction happens — no change needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)