### PR TITLE
feat(micro-land): food web visualization in field guide (#2824)

### DIFF
--- a/src/app/micro-land/components/field-guide.tsx
+++ b/src/app/micro-land/components/field-guide.tsx
@@ -71,6 +71,10 @@ export function FieldGuide() {
   const trailsEnabled = useMicroLand(s => s.trailsEnabled)
   const setTrailsEnabled = useMicroLand(s => s.setTrailsEnabled)
   const extinctions = useMicroLand(s => s.extinctions)
+  const foodWeb = useMicroLand(s => s.foodWeb)
+  const allBlueprintNames = useMicroLand(s =>
+    Object.fromEntries(s.blueprints.map(b => [b.id, b.name]))
+  )
 
   const [hiddenPlantIds, setHiddenPlantIds] = useState<ReadonlySet<string>>(new Set())
 
@@ -420,6 +424,38 @@ export function FieldGuide() {
                   <span>🦴 {ext.name}</span>
                   <span style={{ color: 'var(--cc-text-muted)', fontSize: 10 }}>
                     gen {ext.maxGeneration} · {Math.round(ext.livedFor / 60)} min
+                  </span>
+                </li>
+              ))}
+            </ul>
+          </section>
+        )}
+
+        {Object.keys(foodWeb).length > 0 && (
+          <section className="px-4 py-3" style={{ borderTop: '1px solid var(--cc-panel-divider)' }}>
+            <h3 className="pb-2" style={sectionHeading}>
+              Food web
+            </h3>
+            <p style={{ fontSize: 11, color: 'var(--cc-text-muted)', marginBottom: 8 }}>
+              Who ate whom — observed in this world so far.
+            </p>
+            <ul style={{ listStyle: 'none', padding: 0, margin: 0 }}>
+              {Object.entries(foodWeb).map(([eaterId, preyIds]) => (
+                <li
+                  key={eaterId}
+                  style={{
+                    fontSize: 11,
+                    fontFamily: 'var(--cc-font-mono)',
+                    padding: '3px 0',
+                    lineHeight: 1.6,
+                  }}
+                >
+                  <span style={{ color: 'var(--cc-text-default)' }}>
+                    {allBlueprintNames[eaterId] ?? eaterId}
+                  </span>
+                  <span style={{ color: 'var(--cc-text-muted)' }}>{' → '}</span>
+                  <span style={{ color: 'var(--cc-text-muted)' }}>
+                    {preyIds.map(id => allBlueprintNames[id] ?? id).join(', ')}
                   </span>
                 </li>
               ))}

--- a/src/app/micro-land/domain/sim/creature-sim.ts
+++ b/src/app/micro-land/domain/sim/creature-sim.ts
@@ -737,7 +737,7 @@ function look(
         c.mood = 'eat'
         c.targetId = null
         car.decaySeconds = 0 // mark for removal at end of tick
-        events.push({ kind: 'ate', blueprintId: bp.id, x: c.x, y: c.y })
+        events.push({ kind: 'ate', blueprintId: bp.id, victimId: car.blueprintId, x: c.x, y: c.y })
         return
       }
     }

--- a/src/app/micro-land/game-instance.ts
+++ b/src/app/micro-land/game-instance.ts
@@ -440,14 +440,17 @@ export class GameInstance {
 
   /** Turn raw sim events into the occasional human-readable notice. */
   private digestEvents(events: SimEvent[]): void {
-    const notify = useMicroLand.getState().notify
+    const { notify, logEat } = useMicroLand.getState()
 
     for (const event of events) {
+      if (event.kind !== 'ate' || !event.victimId) continue
+      // Log to food web — every eat, including carcasses (victimId now set for both).
+      logEat(event.blueprintId, event.victimId)
+
       // Announce predation on animals — a kill is instant and the victim just
       // vanishes, so without this the food chain runs invisibly and looks like
       // it isn't happening at all. Plants are eaten constantly; saying so every
       // time would drown out everything else.
-      if (event.kind !== 'ate' || !event.victimId) continue
       const victim = this.world.blueprints[event.victimId]
       if (!victim || victim.move.kind === 'root') continue
       if (this.world.elapsed - this.lastHuntNotice < HUNT_NOTICE_GAP) continue
@@ -1408,6 +1411,7 @@ export class GameInstance {
     this.following = false
     store.setInspected(null)
     store.clearExtinctions()
+    store.clearFoodWeb()
 
     this.renderer.panToLeft(save.camX)
     this.renderer.markTilesDirty()

--- a/src/app/micro-land/store.ts
+++ b/src/app/micro-land/store.ts
@@ -201,6 +201,13 @@ interface MicroLandState {
   populationHistory: PopulationSnapshot[]
   /** Species that went extinct in this session, newest last. */
   extinctions: ExtinctionRecord[]
+  /**
+   * Observed predator → prey relationships in this world.
+   *
+   * Key = eater blueprintId, value = array of eaten blueprintIds (unique).
+   * Updated on every eat event (live prey and carcasses).
+   */
+  foodWeb: Record<string, string[]>
 
   summonOpen: boolean
   summonBusy: boolean
@@ -333,6 +340,8 @@ interface MicroLandState {
   setStats: (population: PopulationEntry[], total: number, elapsed: number) => void
   addExtinction: (record: ExtinctionRecord) => void
   clearExtinctions: () => void
+  logEat: (eaterId: string, preyId: string) => void
+  clearFoodWeb: () => void
   setSummonOpen: (open: boolean) => void
   setSummonBusy: (busy: boolean) => void
   setSummonMode: (mode: 'creature' | 'scene' | 'terrain') => void
@@ -425,6 +434,7 @@ export const useMicroLand = create<MicroLandState>(set => ({
   elapsed: 0,
   populationHistory: [],
   extinctions: [],
+  foodWeb: {},
 
   summonOpen: false,
   summonBusy: false,
@@ -465,7 +475,7 @@ export const useMicroLand = create<MicroLandState>(set => ({
   setBrush: brush => set({ brush }),
   togglePaused: () => set(s => ({ paused: !s.paused })),
   setSpeed: speed => set({ speed }),
-  setBlueprints: blueprints => set({ blueprints, populationHistory: [], extinctions: [] }),
+  setBlueprints: blueprints => set({ blueprints, populationHistory: [], extinctions: [], foodWeb: {} }),
   addBlueprint: bp =>
     set(s => ({
       blueprints: s.blueprints.some(b => b.id === bp.id)
@@ -490,6 +500,12 @@ export const useMicroLand = create<MicroLandState>(set => ({
     }),
   addExtinction: record => set(s => ({ extinctions: [...s.extinctions, record] })),
   clearExtinctions: () => set({ extinctions: [] }),
+  logEat: (eaterId, preyId) => set(s => {
+    const existing = s.foodWeb[eaterId] ?? []
+    if (existing.includes(preyId)) return {}
+    return { foodWeb: { ...s.foodWeb, [eaterId]: [...existing, preyId] } }
+  }),
+  clearFoodWeb: () => set({ foodWeb: {} }),
   setSummonOpen: summonOpen => set({ summonOpen }),
   setSummonBusy: summonBusy => set({ summonBusy }),
   setSummonMode: summonMode => set({ summonMode }),


### PR DESCRIPTION
Closes #2824

## What this does

Tracks and displays every observed predator→prey relationship in the current world, shown in the field guide under a "Food web" section.

### Data flow
1. `creature-sim.ts` — carcass eat events now carry `victimId` (previously missing for dead-body consumption, only live kills had it)
2. `game-instance.ts` — `digestEvents` calls `logEat(eaterId, preyId)` for every `ate` event that has a `victimId`
3. `store.ts` — `foodWeb: Record<string, string[]>` stores unique eater→prey pairs; `logEat` is a no-op if the pair already exists
4. `field-guide.tsx` — "Food web" section lists each predator with its observed prey

### Display
```
Stalker → Hopper, Jumper
Hopper  → Green Fern
```

Uses blueprint names from the store; shows only observed relationships (not what the blueprint *can* eat). Appears only when at least one eat event has occurred.

### Cleanup
`foodWeb` clears on `adoptSave` (new world load) alongside extinctions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)