### PR TITLE
feat: disease spread mechanic with heritable immunity trait

### DIFF
--- a/src/app/micro-land/domain/sim/creature-sim.ts
+++ b/src/app/micro-land/domain/sim/creature-sim.ts
@@ -402,6 +402,18 @@ export function tickCreatures(
     if (c.packTimer > 0) c.packTimer = Math.max(0, c.packTimer - dt)
     if ((c as { stunTimer?: number }).stunTimer === undefined) c.stunTimer = 0
     if (c.stunTimer > 0) c.stunTimer = Math.max(0, c.stunTimer - dt)
+    if ((c as { sick?: number }).sick === undefined) c.sick = 0
+    if (c.sick > 0) {
+      c.sick -= dt
+      if (c.sick <= 0) {
+        c.sick = 0
+        const immunity = (c.traits as { immunity?: number }).immunity ?? 0.2
+        if (rng() >= immunity * 0.8 + 0.2) {
+          kill(w, c, bp, dead, events, 'starved')
+          continue
+        }
+      }
+    }
     // Migrate timer: counts seconds hungry with no food found.
     if (c.hunger > FORAGE_HUNGER && c.targetId === null) {
       c.migrateTimer += dt
@@ -644,6 +656,20 @@ export function tickCreatures(
   // Scent decay
   for (const s of w.scents) s.decaySeconds -= dt
   w.scents = w.scents.filter(s => s.decaySeconds > 0)
+
+  // Disease outbreak: roughly every 3 sim-minutes, infect one random non-plant.
+  if (Math.floor(w.elapsed / 180) > Math.floor((w.elapsed - dt) / 180)) {
+    const animals = w.creatures.filter(
+      c => !dead.has(c.id) && w.blueprints[c.blueprintId]?.move.kind !== 'root'
+    )
+    if (animals.length > 0) {
+      const victim = animals[Math.floor(rng() * animals.length)]
+      const immunity = (victim.traits as { immunity?: number }).immunity ?? 0.2
+      if (rng() > immunity) {
+        victim.sick = 20
+      }
+    }
+  }
 
   tickParticles(w, dt, gravityScale)
 }
@@ -922,6 +948,28 @@ function look(
     }
   } else if (c.mood !== 'hunt') {
     c.huntPassCount = 0
+  }
+
+  // Disease spread: an infected creature spreads to non-plant neighbours within 4 tiles.
+  if (c.sick > 0 && bp.move.kind !== 'root') {
+    const spreadReach = 4
+    const last2 = cx + spreadReach + bw / 2 + SIGHT_PAD_RIGHT
+    for (let i = lowerBound(byX, cx - spreadReach - SIGHT_PAD_LEFT); i < byX.length; i++) {
+      const other = byX[i]
+      if (other.x > last2) break
+      if (other.id === c.id || dead.has(other.id)) continue
+      if ((other as { sick?: number }).sick) continue // already sick
+      const obp = w.blueprints[other.blueprintId]
+      if (!obp || obp.move.kind === 'root') continue
+      const { w: ow, h: oh } = artSize(obp)
+      const gdx = Math.max(0, Math.abs(other.x + ow / 2 - cx) - (bw + ow) / 2)
+      const gdy = Math.max(0, Math.abs(other.y + oh / 2 - (c.y + bh / 2)) - (bh + oh) / 2)
+      if (gdx * gdx + gdy * gdy > spreadReach * spreadReach) continue
+      const otherImmunity = (other.traits as { immunity?: number }).immunity ?? 0.2
+      if (rng() < 0.05 * (1 - otherImmunity)) {
+        other.sick = 20
+      }
+    }
   }
 
   // Pack hunting: scan for a same-species neighbour targeting the same prey.
@@ -1377,7 +1425,7 @@ function steer(w: WorldState, c: Creature, bp: CreatureBlueprint, dt: number, rn
 
   // Poison from a toxic plant halves movement speed for its duration.
   // Larger creatures are slower: size is a denominator, not a multiplier.
-  const speed = speedOf(c, bp) * (c.poisoned > 0 ? 0.5 : 1) * (c.packTimer > 0 ? 1.2 : 1) * (c.stunTimer > 0 ? 0.2 : 1) / sizeOf(c)
+  const speed = speedOf(c, bp) * (c.poisoned > 0 ? 0.5 : 1) * (c.packTimer > 0 ? 1.2 : 1) * (c.stunTimer > 0 ? 0.2 : 1) * (c.sick > 0 ? 0.7 : 1) / sizeOf(c)
   const accel = speed * 6
   const digger = bp.dig.through.length > 0
 

--- a/src/app/micro-land/domain/sim/world.ts
+++ b/src/app/micro-land/domain/sim/world.ts
@@ -387,6 +387,7 @@ export function spawnCreature(
     packTimer: 0,
     sinking: 0,
     stunTimer: 0,
+    sick: 0,
   }
   w.creatures.push(creature)
   return creature

--- a/src/app/micro-land/domain/traits.ts
+++ b/src/app/micro-land/domain/traits.ts
@@ -80,6 +80,7 @@ export const NEUTRAL_TRAITS: Traits = Object.freeze({
   camouflage: 0.2,
   toxicity: 0,
   cooperation: 0.3,
+  immunity: 0.2,
 })
 
 /** A fresh set for a creature that wasn't born here. Always a copy — it's mutable state. */
@@ -127,7 +128,7 @@ function wrapHue(h: number): number {
 export function inherit(a: Traits, b: Traits | null, rng: Rng): Traits {
   const drift = TUNING.traitDrift
   const hueDrift = drift * HUE_DRIFT_SCALE
-  const mix = (key: 'speed' | 'sight' | 'lifespan' | 'shade' | 'roam' | 'territorial' | 'size' | 'camouflage' | 'toxicity' | 'cooperation') =>
+  const mix = (key: 'speed' | 'sight' | 'lifespan' | 'shade' | 'roam' | 'territorial' | 'size' | 'camouflage' | 'toxicity' | 'cooperation' | 'immunity') =>
     b ? (a[key] + b[key]) / 2 : a[key]
 
   return {
@@ -142,6 +143,7 @@ export function inherit(a: Traits, b: Traits | null, rng: Rng): Traits {
     camouflage: clamp(mix('camouflage') + nudge(rng, drift), 0, 0.8),
     toxicity: clamp(mix('toxicity') + nudge(rng, drift), 0, 1),
     cooperation: clamp(mix('cooperation') + nudge(rng, drift), 0, 1),
+    immunity: clamp(mix('immunity') + nudge(rng, drift), 0, 1),
   }
 }
 
@@ -271,6 +273,8 @@ export function traitPhrases(t: Traits): string[] {
   if ((t.toxicity ?? 0) >= 0.4) phrases.push('venomous')
   if ((t.cooperation ?? 0.3) >= 0.5 + NOTABLE) phrases.push('shares food with kin')
   else if ((t.cooperation ?? 0.3) <= 0.3 - NOTABLE) phrases.push('solitary')
+  if ((t.immunity ?? 0.2) >= 0.6) phrases.push('disease-resistant')
+  else if ((t.immunity ?? 0.2) <= 0.05) phrases.push('susceptible')
   return phrases
 }
 

--- a/src/app/micro-land/domain/types.ts
+++ b/src/app/micro-land/domain/types.ts
@@ -405,6 +405,15 @@ export interface Traits {
    * below neither emit nor follow. Creates a fork: loners vs. clusters.
    */
   cooperation: number
+  /**
+   * Resistance to disease.
+   *
+   * 0 = fully susceptible, 1 = immune. Higher immunity means a sick creature
+   * is more likely to survive the disease and less likely to catch it from a
+   * neighbour. Heritable — a population under disease pressure can evolve
+   * resistance over generations. Neutral at 0.2.
+   */
+  immunity: number
 }
 
 /** One living thing in the world. */
@@ -518,6 +527,15 @@ export interface Creature {
    * the creature moves at 0.2× speed. Counts down each tick.
    */
   stunTimer: number
+  /**
+   * Seconds of disease remaining.
+   *
+   * Set to 20 when infected. Counts down each tick. When it reaches 0 the
+   * creature either recovers (rng < immunity * 0.8 + 0.2) or dies. While
+   * positive the creature moves at 0.7× speed and can spread disease to
+   * nearby animals within 4 tiles.
+   */
+  sick: number
 }
 
 /**

--- a/src/app/micro-land/rendering/renderer.ts
+++ b/src/app/micro-land/rendering/renderer.ts
@@ -797,6 +797,15 @@ export class Renderer {
         }
       }
 
+      // Disease indicator: semi-transparent green-yellow wash that pulses.
+      if ((c as { sick?: number }).sick) {
+        const sickPulse = Math.sin(w.elapsed * 6) * 0.25 + 0.55
+        ctx.globalAlpha = sickPulse
+        ctx.fillStyle = '#7fff00'
+        ctx.fillRect(x, y, sw, sh)
+        ctx.globalAlpha = 1
+      }
+
       if (traitKey) {
         const delta = ((c.traits as Record<string, number>)[traitKey] ?? 1) - 1.0
         if (Math.abs(delta) >= 0.08) {


### PR DESCRIPTION
## Summary
- Adds a disease mechanic to Micro Land: every ~3 sim-minutes, one random animal is infected
- Sick creatures (20s timer) spread disease to nearby animals within 4 tiles, with a 5% chance per tick modulated by the target's immunity
- Adds heritable `immunity` trait (neutral 0.2): high-immunity lineages survive and resist better, creating real selection pressure
- Sick creatures move at 0.7× speed and are rendered with a pulsing chartreuse overlay
- When the 20s sick timer expires: creature recovers (`rng < immunity * 0.8 + 0.2`) or dies
- `immunity` phrase appears in the inspector for high (≥0.6 → "disease-resistant") and low (≤0.05 → "susceptible") values

## Test plan
- [ ] Launch a world and wait ~3 sim-minutes — a creature should flash green
- [ ] Verify sick creatures move noticeably slower
- [ ] Verify disease can spread to nearby animals (start a small world and watch the outbreak)
- [ ] Inspect creatures after generations — immunity trait should drift and vary
- [ ] Verify old saves load without error (migration guard fires for `sick` and `immunity`)

Closes #2821

🤖 Generated with [Claude Code](https://claude.com/claude-code)