### PR TITLE
feat: world statistics panel — session totals in field guide

### DIFF
--- a/src/app/micro-land/components/field-guide.tsx
+++ b/src/app/micro-land/components/field-guide.tsx
@@ -71,6 +71,7 @@ export function FieldGuide() {
   const trailsEnabled = useMicroLand(s => s.trailsEnabled)
   const setTrailsEnabled = useMicroLand(s => s.setTrailsEnabled)
   const extinctions = useMicroLand(s => s.extinctions)
+  const worldStats = useMicroLand(s => s.worldStats)
   const foodWeb = useMicroLand(s => s.foodWeb)
   const allBlueprintNames = useMicroLand(s =>
     Object.fromEntries(s.blueprints.map(b => [b.id, b.name]))
@@ -462,6 +463,34 @@ export function FieldGuide() {
             </ul>
           </section>
         )}
+
+        {/* World Statistics */}
+        <section className="px-4 py-3" style={{ borderTop: '1px solid var(--cc-panel-divider)' }}>
+          <h3 className="pb-2" style={sectionHeading}>
+            This session
+          </h3>
+          <table style={{ width: '100%', fontSize: 11, fontFamily: 'var(--cc-font-mono)', borderCollapse: 'collapse' }}>
+            <tbody>
+              {(
+                [
+                  ['Born', worldStats.totalBorn],
+                  ['Died', worldStats.totalDeaths],
+                  ['Predation events', worldStats.totalEats],
+                  ['Peak population', worldStats.peakPopulation],
+                  ['Longest life', worldStats.longestLived > 0 ? `${Math.round(worldStats.longestLived)}s` : '—'],
+                  ['Most prolific', worldStats.mostProlificName
+                    ? `${worldStats.mostProlificName} (${worldStats.mostProlificChildren} offspring)`
+                    : '—'],
+                ] as [string, string | number][]
+              ).map(([label, value]) => (
+                <tr key={label} style={{ borderBottom: '1px solid var(--cc-panel-divider)' }}>
+                  <td style={{ padding: '4px 0', color: 'var(--cc-text-muted)', width: '55%' }}>{label}</td>
+                  <td style={{ padding: '4px 0', textAlign: 'right' }}>{value}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </section>
 
         <ImportSection addBlueprint={addBlueprint} />
       </div>

--- a/src/app/micro-land/domain/sim/creature-sim.ts
+++ b/src/app/micro-land/domain/sim/creature-sim.ts
@@ -179,6 +179,10 @@ export interface SimEvent {
   victimId?: string
   x: number
   y: number
+  /** Only set on death events: how long the creature lived. */
+  ageSeconds?: number
+  /** Only set on death events: how many children the creature had. */
+  children?: number
 }
 
 let tickCount = 0
@@ -1817,7 +1821,7 @@ function kill(
   if (bp.death.becomes) {
     setTile(w, Math.floor(c.x + bw / 2), Math.floor(c.y + bh / 2), MATERIAL_INDEX[bp.death.becomes])
   }
-  events.push({ kind: cause, blueprintId: bp.id, x: c.x, y: c.y })
+  events.push({ kind: cause, blueprintId: bp.id, x: c.x, y: c.y, ageSeconds: c.ageSeconds, children: c.children })
 }
 
 // ---------------------------------------------------------------------------

--- a/src/app/micro-land/game-instance.ts
+++ b/src/app/micro-land/game-instance.ts
@@ -440,7 +440,7 @@ export class GameInstance {
 
   /** Turn raw sim events into the occasional human-readable notice. */
   private digestEvents(events: SimEvent[]): void {
-    const { notify, logEat } = useMicroLand.getState()
+    const { notify, logEat, updateWorldStats, worldStats } = useMicroLand.getState()
 
     for (const event of events) {
       if (event.kind !== 'ate' || !event.victimId) continue
@@ -490,6 +490,35 @@ export class GameInstance {
         event.kind === 'starved' ? `The last ${bp.name} starved.` : `The last ${bp.name} was eaten.`
       )
     }
+
+    // Accumulate lifetime stats.
+    let totalBorn = 0, totalDeaths = 0, totalEats = 0
+    let longestLived = worldStats.longestLived
+    let mostProlificName = worldStats.mostProlificName
+    let mostProlificChildren = worldStats.mostProlificChildren
+    for (const event of events) {
+      if (event.kind === 'born') { totalBorn++ }
+      else if (event.kind === 'eaten' || event.kind === 'starved' || event.kind === 'drowned' || event.kind === 'burned' || event.kind === 'aged') {
+        totalDeaths++
+        if ((event.ageSeconds ?? 0) > longestLived) longestLived = event.ageSeconds ?? 0
+        if ((event.children ?? 0) > mostProlificChildren) {
+          mostProlificChildren = event.children ?? 0
+          mostProlificName = this.world.blueprints[event.blueprintId]?.name ?? null
+        }
+      } else if (event.kind === 'ate' && event.victimId) {
+        totalEats++
+      }
+    }
+    if (totalBorn > 0 || totalDeaths > 0 || totalEats > 0 || longestLived !== worldStats.longestLived) {
+      updateWorldStats({
+        totalBorn: worldStats.totalBorn + totalBorn,
+        totalDeaths: worldStats.totalDeaths + totalDeaths,
+        totalEats: worldStats.totalEats + totalEats,
+        longestLived,
+        mostProlificName,
+        mostProlificChildren,
+      })
+    }
   }
 
   /**
@@ -529,6 +558,11 @@ export class GameInstance {
     }
 
     useMicroLand.getState().setStats(population, this.world.creatures.length, this.world.elapsed)
+
+    const currentStats = useMicroLand.getState().worldStats
+    if (this.world.creatures.length > currentStats.peakPopulation) {
+      useMicroLand.getState().updateWorldStats({ peakPopulation: this.world.creatures.length })
+    }
 
     this.updateRecords(population)
     this.pushInspected()

--- a/src/app/micro-land/store.ts
+++ b/src/app/micro-land/store.ts
@@ -150,6 +150,29 @@ export interface ExtinctionRecord {
   maxGeneration: number
 }
 
+/** Session-level lifetime statistics. */
+export interface WorldStats {
+  totalBorn: number
+  totalDeaths: number
+  totalEats: number
+  peakPopulation: number
+  /** Age in seconds of the longest-lived creature that died this session. */
+  longestLived: number
+  /** Name of the most prolific species (most children from one creature). */
+  mostProlificName: string | null
+  mostProlificChildren: number
+}
+
+const EMPTY_STATS: WorldStats = {
+  totalBorn: 0,
+  totalDeaths: 0,
+  totalEats: 0,
+  peakPopulation: 0,
+  longestLived: 0,
+  mostProlificName: null,
+  mostProlificChildren: 0,
+}
+
 /** One time-series data point for the population graph. */
 export interface PopulationSnapshot {
   /** Sim time in seconds when this snapshot was taken. */
@@ -208,6 +231,7 @@ interface MicroLandState {
    * Updated on every eat event (live prey and carcasses).
    */
   foodWeb: Record<string, string[]>
+  worldStats: WorldStats
 
   summonOpen: boolean
   summonBusy: boolean
@@ -340,6 +364,8 @@ interface MicroLandState {
   setStats: (population: PopulationEntry[], total: number, elapsed: number) => void
   addExtinction: (record: ExtinctionRecord) => void
   clearExtinctions: () => void
+  updateWorldStats: (patch: Partial<WorldStats>) => void
+  resetWorldStats: () => void
   logEat: (eaterId: string, preyId: string) => void
   clearFoodWeb: () => void
   setSummonOpen: (open: boolean) => void
@@ -435,6 +461,7 @@ export const useMicroLand = create<MicroLandState>(set => ({
   populationHistory: [],
   extinctions: [],
   foodWeb: {},
+  worldStats: { ...EMPTY_STATS },
 
   summonOpen: false,
   summonBusy: false,
@@ -475,7 +502,7 @@ export const useMicroLand = create<MicroLandState>(set => ({
   setBrush: brush => set({ brush }),
   togglePaused: () => set(s => ({ paused: !s.paused })),
   setSpeed: speed => set({ speed }),
-  setBlueprints: blueprints => set({ blueprints, populationHistory: [], extinctions: [], foodWeb: {} }),
+  setBlueprints: blueprints => set({ blueprints, populationHistory: [], extinctions: [], worldStats: { ...EMPTY_STATS }, foodWeb: {} }),
   addBlueprint: bp =>
     set(s => ({
       blueprints: s.blueprints.some(b => b.id === bp.id)
@@ -500,6 +527,8 @@ export const useMicroLand = create<MicroLandState>(set => ({
     }),
   addExtinction: record => set(s => ({ extinctions: [...s.extinctions, record] })),
   clearExtinctions: () => set({ extinctions: [] }),
+  updateWorldStats: patch => set(s => ({ worldStats: { ...s.worldStats, ...patch } })),
+  resetWorldStats: () => set({ worldStats: { ...EMPTY_STATS } }),
   logEat: (eaterId, preyId) => set(s => {
     const existing = s.foodWeb[eaterId] ?? []
     if (existing.includes(preyId)) return {}


### PR DESCRIPTION
## Summary
- Adds session-level lifetime statistics accumulated via sim events
- Tracks: total born, total deaths, total predation events, peak population, longest-lived creature age, most prolific species
- `WorldStats` interface in store — reset on reshuffle/setBlueprints
- `SimEvent` now carries `ageSeconds` and `children` on death events so `digestEvents` can update longest-lived/most-prolific without querying the (already-removed) creature
- "This session" table displayed in the field guide, just before the import section

## Test plan
- [ ] Launch a world and watch the stats populate over time
- [ ] Verify "Born" increments on each birth notification
- [ ] Verify "Peak population" tracks the max seen
- [ ] Reshuffle — stats should reset to 0
- [ ] Old saves load correctly (ageSeconds/children on SimEvent are optional, won't affect old code)

Closes #2837

🤖 Generated with [Claude Code](https://claude.com/claude-code)