### PR TITLE
feat: day/night cycle with heritable diurnal trait

### DIFF
--- a/src/app/micro-land/domain/sim/creature-sim.ts
+++ b/src/app/micro-land/domain/sim/creature-sim.ts
@@ -667,7 +667,12 @@ function look(
 
   // This creature's sight, not its species' — everything downstream, including
   // the foraging reach and the window the loop below walks, is measured off it.
-  const sight = sightOf(c, bp)
+  const diurnal = (c.traits as { diurnal?: number }).diurnal ?? 0
+  const nightFactor = TUNING.dayLengthSeconds > 0
+    ? (1 - Math.cos(2 * Math.PI * w.elapsed / TUNING.dayLengthSeconds)) / 2
+    : 0
+  const diurnalPenalty = Math.max(0, diurnal > 0 ? diurnal * nightFactor : -diurnal * (1 - nightFactor)) * 0.5
+  const sight = sightOf(c, bp) * (1 - diurnalPenalty)
   const sight2 = sight * sight
 
   /**
@@ -1377,7 +1382,12 @@ function steer(w: WorldState, c: Creature, bp: CreatureBlueprint, dt: number, rn
 
   // Poison from a toxic plant halves movement speed for its duration.
   // Larger creatures are slower: size is a denominator, not a multiplier.
-  const speed = speedOf(c, bp) * (c.poisoned > 0 ? 0.5 : 1) * (c.packTimer > 0 ? 1.2 : 1) * (c.stunTimer > 0 ? 0.2 : 1) / sizeOf(c)
+  const diurnal = (c.traits as { diurnal?: number }).diurnal ?? 0
+  const nightFactor = TUNING.dayLengthSeconds > 0
+    ? (1 - Math.cos(2 * Math.PI * w.elapsed / TUNING.dayLengthSeconds)) / 2
+    : 0
+  const diurnalPenalty = Math.max(0, diurnal > 0 ? diurnal * nightFactor : -diurnal * (1 - nightFactor)) * 0.5
+  const speed = speedOf(c, bp) * (c.poisoned > 0 ? 0.5 : 1) * (c.packTimer > 0 ? 1.2 : 1) * (c.stunTimer > 0 ? 0.2 : 1) / sizeOf(c) * (1 - diurnalPenalty)
   const accel = speed * 6
   const digger = bp.dig.through.length > 0
 

--- a/src/app/micro-land/domain/traits.ts
+++ b/src/app/micro-land/domain/traits.ts
@@ -80,6 +80,7 @@ export const NEUTRAL_TRAITS: Traits = Object.freeze({
   camouflage: 0.2,
   toxicity: 0,
   cooperation: 0.3,
+  diurnal: 0,
 })
 
 /** A fresh set for a creature that wasn't born here. Always a copy — it's mutable state. */
@@ -127,7 +128,7 @@ function wrapHue(h: number): number {
 export function inherit(a: Traits, b: Traits | null, rng: Rng): Traits {
   const drift = TUNING.traitDrift
   const hueDrift = drift * HUE_DRIFT_SCALE
-  const mix = (key: 'speed' | 'sight' | 'lifespan' | 'shade' | 'roam' | 'territorial' | 'size' | 'camouflage' | 'toxicity' | 'cooperation') =>
+  const mix = (key: 'speed' | 'sight' | 'lifespan' | 'shade' | 'roam' | 'territorial' | 'size' | 'camouflage' | 'toxicity' | 'cooperation' | 'diurnal') =>
     b ? (a[key] + b[key]) / 2 : a[key]
 
   return {
@@ -142,6 +143,7 @@ export function inherit(a: Traits, b: Traits | null, rng: Rng): Traits {
     camouflage: clamp(mix('camouflage') + nudge(rng, drift), 0, 0.8),
     toxicity: clamp(mix('toxicity') + nudge(rng, drift), 0, 1),
     cooperation: clamp(mix('cooperation') + nudge(rng, drift), 0, 1),
+    diurnal: clamp(mix('diurnal') + nudge(rng, drift), -1, 1),
   }
 }
 
@@ -271,6 +273,8 @@ export function traitPhrases(t: Traits): string[] {
   if ((t.toxicity ?? 0) >= 0.4) phrases.push('venomous')
   if ((t.cooperation ?? 0.3) >= 0.5 + NOTABLE) phrases.push('shares food with kin')
   else if ((t.cooperation ?? 0.3) <= 0.3 - NOTABLE) phrases.push('solitary')
+  if ((t.diurnal ?? 0) >= 0.5) phrases.push('diurnal')
+  else if ((t.diurnal ?? 0) <= -0.5) phrases.push('nocturnal')
   return phrases
 }
 

--- a/src/app/micro-land/domain/traits.ts
+++ b/src/app/micro-land/domain/traits.ts
@@ -129,7 +129,6 @@ function wrapHue(h: number): number {
 export function inherit(a: Traits, b: Traits | null, rng: Rng): Traits {
   const drift = TUNING.traitDrift
   const hueDrift = drift * HUE_DRIFT_SCALE
-<<<<<<< HEAD
   const mix = (key: 'speed' | 'sight' | 'lifespan' | 'shade' | 'roam' | 'territorial' | 'size' | 'camouflage' | 'toxicity' | 'cooperation' | 'diurnal' | 'immunity') =>
     b ? (a[key] + b[key]) / 2 : a[key]
 

--- a/src/app/micro-land/domain/tuning.ts
+++ b/src/app/micro-land/domain/tuning.ts
@@ -83,6 +83,11 @@ export const TUNING_DEFAULTS = {
    * 0 = no seasonal effect. 0.7 = ×0.3 at trough, ×1.7 at peak.
    */
   seasonAmplitude: 0,
+  /**
+   * How long one day/night cycle lasts, in sim seconds.
+   * 0 = no day/night cycle (default). 120 = one cycle every two real-world minutes at normal speed.
+   */
+  dayLengthSeconds: 0,
 }
 
 export type TuningKey = keyof typeof TUNING_DEFAULTS

--- a/src/app/micro-land/domain/types.ts
+++ b/src/app/micro-land/domain/types.ts
@@ -405,6 +405,14 @@ export interface Traits {
    * below neither emit nor follow. Creates a fork: loners vs. clusters.
    */
   cooperation: number
+  /**
+   * Activity preference: -1 = fully nocturnal, 0 = crepuscular, +1 = fully diurnal.
+   *
+   * During the creature's inactive phase (day for nocturnal, night for diurnal)
+   * speed and sight are reduced by up to 50%. Neutral at 0 — no preference.
+   * Heritable — a line that survives better at night drifts toward nocturnal.
+   */
+  diurnal: number
 }
 
 /** One living thing in the world. */

--- a/src/app/micro-land/rendering/renderer.ts
+++ b/src/app/micro-land/rendering/renderer.ts
@@ -29,6 +29,7 @@ import { MATERIAL_BY_INDEX } from '@/app/micro-land/domain/config/materials'
 import type { Theme } from '@/app/micro-land/domain/config/themes'
 import { VIEW_W, WORLD_H, WORLD_W } from '@/app/micro-land/domain/constants'
 import { lifespanOf, sizeOf, tintKey } from '@/app/micro-land/domain/traits'
+import { TUNING } from '@/app/micro-land/domain/tuning'
 import type { WorldState } from '@/app/micro-land/domain/types'
 import { useMicroLand } from '@/app/micro-land/store'
 
@@ -500,6 +501,17 @@ export class Renderer {
     // goes first so the selection brackets sit on top when you inspect an elder.
     if (elderId !== null) this.drawElder(w, elderId)
     if (highlightId !== null) this.drawHighlight(w, highlightId)
+
+    // Day/night cycle: gradually darkens during the night phase.
+    if (TUNING.dayLengthSeconds > 0) {
+      const nightFactor = (1 - Math.cos(2 * Math.PI * w.elapsed / TUNING.dayLengthSeconds)) / 2
+      if (nightFactor > 0.05) {
+        wctx.globalAlpha = Math.min(0.5, nightFactor * 0.55)
+        wctx.fillStyle = '#000a1f'
+        wctx.fillRect(vx, 0, vw, WORLD_H)
+        wctx.globalAlpha = 1
+      }
+    }
 
     // One scaled blit. Nearest-neighbour keeps the pixels crisp.
     const ctx = this.ctx


### PR DESCRIPTION
## Summary
- Adds a day/night cycle to Micro Land: configurable via TUNING `dayLengthSeconds` (default 0 = off)
- Adds heritable `diurnal` trait: -1=nocturnal, 0=crepuscular (neutral), +1=diurnal
- During a creature's inactive phase, speed and sight are reduced by up to 50%
- World renders with a gradually darkening dark-blue overlay at night
- "diurnal"/"nocturnal" trait phrases appear in the inspector
- Feature is off by default — existing worlds unchanged until player turns on the day cycle in settings

## Test plan
- [ ] Set `dayLengthSeconds` to 60 in settings — world should visibly darken and lighten
- [ ] Nocturnal creatures should be sluggish at noon, active at midnight
- [ ] Diurnal creatures should be sluggish at midnight, active at noon
- [ ] Crepuscular (diurnal=0) creatures are unaffected regardless of time
- [ ] With dayLengthSeconds=0 (default), no overlay and no penalties

Closes #2834

🤖 Generated with [Claude Code](https://claude.com/claude-code)