### PR TITLE
feat: symbiosis — mutualistic species pairs with shared buffs

### DIFF
--- a/src/app/micro-land/components/field-guide.tsx
+++ b/src/app/micro-land/components/field-guide.tsx
@@ -734,6 +734,17 @@ function GuideEntry({
           <br />
           <strong style={{ fontWeight: 600 }}>Eaten by:</strong>{' '}
           {eatenBy.length > 0 ? eatenBy.map(e => e.name).join(', ') : 'nothing here'}
+          {bp.symbiosisPartnerId && (() => {
+            const partner = blueprints.find(b => b.id === bp.symbiosisPartnerId)
+            return partner ? (
+              <>
+                <br />
+                <span style={{ color: 'var(--cc-text-muted)', fontSize: 10 }}>
+                  Partners with: {partner.name}
+                </span>
+              </>
+            ) : null
+          })()}
         </p>
       </div>
     </li>

--- a/src/app/micro-land/domain/sim/creature-sim.ts
+++ b/src/app/micro-land/domain/sim/creature-sim.ts
@@ -406,6 +406,8 @@ export function tickCreatures(
     if (c.packTimer > 0) c.packTimer = Math.max(0, c.packTimer - dt)
     if ((c as { stunTimer?: number }).stunTimer === undefined) c.stunTimer = 0
     if (c.stunTimer > 0) c.stunTimer = Math.max(0, c.stunTimer - dt)
+    if ((c as { symbiosisTimer?: number }).symbiosisTimer === undefined) c.symbiosisTimer = 0
+    if (c.symbiosisTimer > 0) c.symbiosisTimer = Math.max(0, c.symbiosisTimer - dt)
     if ((c as { sick?: number }).sick === undefined) c.sick = 0
     if (c.sick > 0) {
       c.sick -= dt
@@ -460,7 +462,8 @@ export function tickCreatures(
       }
     }
 
-    c.hunger = Math.min(1, c.hunger + bp.diet.hungerRate * TUNING.hungerRateScale * restSlowdown * dt)
+    const symbiosisFed = c.symbiosisTimer > 0 ? 0.8 : 1
+    c.hunger = Math.min(1, c.hunger + bp.diet.hungerRate * TUNING.hungerRateScale * restSlowdown * symbiosisFed * dt)
     if (c.hunger >= 1) {
       c.starving += dt
       if (c.starving >= bp.diet.starveSeconds) {
@@ -821,6 +824,16 @@ function look(
       if (seeking && d2 <= sight2 && readyToBreed(other, obp) && d2 < mateDist) {
         mateDist = d2
         mate = other
+      }
+      continue
+    }
+
+    // Symbiosis: skip attack against declared partner species.
+    const isPartner = bp.symbiosisPartnerId && obp.id === bp.symbiosisPartnerId
+    if (isPartner) {
+      // Partner is near — grant bonus and skip attack.
+      if (d2 <= sight2) {
+        c.symbiosisTimer = Math.max(c.symbiosisTimer, (SENSE_EVERY / 60) * 2.5)
       }
       continue
     }
@@ -1429,7 +1442,7 @@ function steer(w: WorldState, c: Creature, bp: CreatureBlueprint, dt: number, rn
 
   // Poison from a toxic plant halves movement speed for its duration.
   // Larger creatures are slower: size is a denominator, not a multiplier.
-  const speed = speedOf(c, bp) * (c.poisoned > 0 ? 0.5 : 1) * (c.packTimer > 0 ? 1.2 : 1) * (c.stunTimer > 0 ? 0.2 : 1) * (c.sick > 0 ? 0.7 : 1) / sizeOf(c)
+  const speed = speedOf(c, bp) * (c.poisoned > 0 ? 0.5 : 1) * (c.packTimer > 0 ? 1.2 : 1) * (c.stunTimer > 0 ? 0.2 : 1) * (c.sick > 0 ? 0.7 : 1) * (c.symbiosisTimer > 0 ? 1.15 : 1) / sizeOf(c)
   const accel = speed * 6
   const digger = bp.dig.through.length > 0
 

--- a/src/app/micro-land/domain/sim/world.ts
+++ b/src/app/micro-land/domain/sim/world.ts
@@ -387,6 +387,7 @@ export function spawnCreature(
     packTimer: 0,
     sinking: 0,
     stunTimer: 0,
+    symbiosisTimer: 0,
     sick: 0,
   }
   w.creatures.push(creature)

--- a/src/app/micro-land/domain/types.ts
+++ b/src/app/micro-land/domain/types.ts
@@ -294,6 +294,17 @@ export interface CreatureBlueprint {
   toxicity?: number
   /** True for anything the player summoned, so we can badge it in the UI. */
   summoned?: boolean
+  /**
+   * Optional symbiosis partner.
+   *
+   * When set to another species' blueprintId, this creature treats that species
+   * as a mutualistic partner: it won't attack them even if its diet says it
+   * could, and when near them it gets a 15% speed boost and 20% slower hunger
+   * drain. The bond is declared here rather than negotiated at runtime, so it
+   * is stable but one-sided by default — both partners have to name each other
+   * for the buff to apply to both.
+   */
+  symbiosisPartnerId?: string | null
 }
 
 /**
@@ -527,6 +538,14 @@ export interface Creature {
    * the creature moves at 0.2× speed. Counts down each tick.
    */
   stunTimer: number
+  /**
+   * Seconds of symbiosis bonus remaining.
+   *
+   * Set by the sense pass when a symbiosis partner is within 5 tiles. Grants
+   * 15% speed boost and 20% slower hunger drain while above zero. Decays each
+   * tick. Only one sense-interval worth of time is granted at a time.
+   */
+  symbiosisTimer: number
   /**
    * Seconds of disease remaining.
    *


### PR DESCRIPTION
## Summary
- Blueprints can now declare `symbiosisPartnerId` to name a mutualistic partner species
- When near their partner (within sight range), creatures skip attacks and gain: 15% speed boost, 20% slower hunger drain
- Migration-safe: old saves get `symbiosisTimer: 0` on load
- Field guide shows "Partners with: [Name]" for any species that has a declared partner
- No UI to configure — set via blueprint JSON / import; built-in creatures can be configured in creature definitions

## Test plan
- [ ] Add `symbiosisPartnerId` to two complementary creatures in a custom save and verify they don't attack each other
- [ ] Verify the speed boost and slower hunger are visible when the pair is near each other
- [ ] Verify field guide shows the partner name
- [ ] Old saves load without error

Closes #2836

🤖 Generated with [Claude Code](https://claude.com/claude-code)