### PR TITLE
feat: obstacle avoidance for walk/crawl creatures

### DIFF
--- a/src/app/micro-land/domain/sim/creature-sim.ts
+++ b/src/app/micro-land/domain/sim/creature-sim.ts
@@ -1359,6 +1359,29 @@ function unliveableAhead(
 }
 
 /**
+ * Whether moving in the normalised direction (dx, dy) would walk into a solid
+ * tile within the next step — the obstacle detector for the steering layer.
+ *
+ * Uses a short look-ahead along the *leading edge* of the body box rather than
+ * the centre, so the check fires before the collision engine would, giving the
+ * creature time to steer clear instead of bouncing. Only called for locomotion
+ * that cares about terrain (walk/crawl); flyers and swimmers skip it.
+ */
+function solidAhead(
+  w: WorldState,
+  c: Creature,
+  body: BodyBox,
+  dx: number,
+  dy: number
+): boolean {
+  if (Math.abs(dx) < 0.01 && Math.abs(dy) < 0.01) return false
+  const lookDist = 1.5
+  const tx = c.x + body.dx + (dx > 0 ? body.w : 0) + dx * lookDist
+  const ty = c.y + body.dy + (dy > 0 ? body.h / 2 : 0)
+  return boxHitsSolid(w, tx, ty, body.w * 0.6, body.h * 0.6)
+}
+
+/**
  * Launch velocity for a creature that means to clear `move.jump` worth of
  * height — see `JUMP_TILES_PER_STRENGTH` for why `jump` stopped being a
  * velocity in the first place.
@@ -1438,6 +1461,32 @@ function steer(w: WorldState, c: Creature, bp: CreatureBlueprint, dt: number, rn
     wantX = c.drift
     wantY = bp.move.kind === 'fly' || bp.move.kind === 'swim' ? (rng() - 0.5) * 0.6 : 0
     c.targetId = null
+  }
+
+  // Obstacle avoidance: walk and crawl locomotion steer around solid walls.
+  // Flyers and swimmers are free to move through/over terrain so skip this.
+  if ((bp.move.kind === 'walk' || bp.move.kind === 'crawl') && !bp.dig.through.length) {
+    const len = Math.hypot(wantX, wantY)
+    if (len > 0.01 && solidAhead(w, c, body, wantX / len, wantY / len)) {
+      const angle = Math.atan2(wantY, wantX)
+      const tries = [Math.PI / 4, -Math.PI / 4, Math.PI / 2, -Math.PI / 2]
+      let cleared = false
+      for (const delta of tries) {
+        const a = angle + delta
+        const tx = Math.cos(a)
+        const ty = Math.sin(a)
+        if (!solidAhead(w, c, body, tx, ty)) {
+          wantX = tx
+          wantY = ty
+          cleared = true
+          break
+        }
+      }
+      if (!cleared) {
+        wantX = 0
+        wantY = 0
+      }
+    }
   }
 
   // Poison from a toxic plant halves movement speed for its duration.


### PR DESCRIPTION
## Summary
- Walk and crawl creatures now steer around solid walls instead of bunching against them
- When the intended heading leads into solid terrain, tries ±45° then ±90° alternatives; stops if all are blocked
- Uses a 1.5-tile look-ahead on the body's leading edge — fires before the collision engine so creatures turn early
- Burrowers and diggers are excluded (they intentionally move through solid tiles)
- Flyers and swimmers are excluded (they don't interact with terrain in the same way)

## Test plan
- [ ] Summon walkers near a solid wall — they should path around it instead of getting stuck
- [ ] Verify burrowing creatures still dig through rock normally
- [ ] Verify flying/swimming creatures are unaffected
- [ ] No creatures should phase through solid tiles

Closes #2828

🤖 Generated with [Claude Code](https://claude.com/claude-code)