### PR TITLE
feat: terrain moisture — water-adjacent tiles fertilise plant growth

### DIFF
--- a/src/app/micro-land/domain/sim/creature-sim.ts
+++ b/src/app/micro-land/domain/sim/creature-sim.ts
@@ -47,6 +47,7 @@ import {
   settleOnGround,
   solidAt,
   spawnCreature,
+  tickMoisture,
   tileAt,
 } from './world'
 
@@ -335,6 +336,8 @@ export function tickCreatures(
   w.nextCarcassId ??= 1
   w.burrows ??= []
   w.scents ??= []
+  w.moisture ??= new Float32Array(WORLD_W * WORLD_H)
+  tickMoisture(w, tickCount, dt, rng)
   w.eggs ??= []
   w.nextEggId ??= 1
 

--- a/src/app/micro-land/domain/sim/world.ts
+++ b/src/app/micro-land/domain/sim/world.ts
@@ -49,6 +49,7 @@ export function createWorld(seed = 1337): WorldState {
     burrows: [],
     nextCarcassId: 1,
     scents: [],
+    moisture: new Float32Array(WORLD_W * WORLD_H),
     eggs: [],
     nextEggId: 1,
     blueprints,
@@ -664,7 +665,67 @@ export function seedNativePlants(w: WorldState, rng: Rng, seasonFactor = 1): voi
 
   for (let i = 0; i < batch; i++) {
     const bp = w.blueprints[pool[i % pool.length]]
-    if (bp) spawnSomewhereSensible(w, bp, rng)
+    if (!bp) continue
+    // Try a couple of spots and prefer the more moist one — moisture fertilises.
+    const spot1 = findSpawnSpot(w, bp, rng)
+    const spot2 = findSpawnSpot(w, bp, rng)
+    let bestSpot = spot1
+    if (spot1 && spot2 && w.moisture) {
+      const m1 = w.moisture[Math.floor(spot1.y) * WORLD_W + Math.floor(spot1.x)] ?? 0
+      const m2 = w.moisture[Math.floor(spot2.y) * WORLD_W + Math.floor(spot2.x)] ?? 0
+      bestSpot = m2 > m1 ? spot2 : spot1
+    } else {
+      bestSpot = spot1 ?? spot2
+    }
+    if (bestSpot) {
+      spawnCreature(w, bp, bestSpot.x, bestSpot.y)
+    }
+  }
+}
+
+/**
+ * Update the moisture field — called once per sim step.
+ *
+ * Runs at a reduced cadence (every 30 ticks ≈ twice a second) to keep the
+ * O(width×height) scan from dominating the frame budget. Water-adjacent tiles
+ * gain moisture; everything dries at a baseline rate; a periodic rainfall zone
+ * adds a burst of moisture somewhere in the world.
+ */
+export function tickMoisture(w: WorldState, tickCount: number, dt: number, rng: Rng): void {
+  if (tickCount % 30 !== 0) return
+  w.moisture ??= new Float32Array(WORLD_W * WORLD_H)
+  const timePassed = 30 / 60 // seconds per update window
+  const waterIdx = MATERIAL_INDEX.water
+  for (let y = 0; y < WORLD_H; y++) {
+    for (let x = 0; x < WORLD_W; x++) {
+      const i = y * WORLD_W + x
+      w.moisture[i] = Math.max(0, w.moisture[i] - 0.005 * timePassed)
+      const hasWater =
+        w.tiles[i] === waterIdx ||
+        (x > 0 && w.tiles[i - 1] === waterIdx) ||
+        (x < WORLD_W - 1 && w.tiles[i + 1] === waterIdx) ||
+        (y > 0 && w.tiles[i - WORLD_W] === waterIdx) ||
+        (y < WORLD_H - 1 && w.tiles[i + WORLD_W] === waterIdx)
+      if (hasWater) {
+        w.moisture[i] = Math.min(1, w.moisture[i] + 0.01 * timePassed)
+      }
+    }
+  }
+  // Rainfall: once per sim-minute, soak a random zone.
+  if (Math.floor(w.elapsed / 60) > Math.floor((w.elapsed - timePassed) / 60)) {
+    const rx = Math.floor(rng() * WORLD_W)
+    const ry = Math.floor(rng() * WORLD_H)
+    const radius = 15 + Math.floor(rng() * 25)
+    for (let dy2 = -radius; dy2 <= radius; dy2++) {
+      for (let dx2 = -radius; dx2 <= radius; dx2++) {
+        const tx = rx + dx2
+        const ty = ry + dy2
+        if (tx < 0 || tx >= WORLD_W || ty < 0 || ty >= WORLD_H) continue
+        if (dx2 * dx2 + dy2 * dy2 > radius * radius) continue
+        const mi = ty * WORLD_W + tx
+        w.moisture[mi] = Math.min(1, (w.moisture[mi] || 0) + 0.25)
+      }
+    }
   }
 }
 

--- a/src/app/micro-land/domain/types.ts
+++ b/src/app/micro-land/domain/types.ts
@@ -659,6 +659,11 @@ export interface WorldState {
   burrows: Burrow[]
   nextCarcassId: number
   scents: Scent[]
+  /**
+   * Per-tile moisture level, [0,1]. Tiles near water gain moisture; all tiles
+   * slowly dry out. Plants seed more readily in moist soil.
+   */
+  moisture: Float32Array
   eggs: Egg[]
   nextEggId: number
   /** Blueprints available in this world, keyed by id. */


### PR DESCRIPTION
## Summary
- Adds a `moisture: Float32Array` to WorldState tracking per-tile moisture (0–1)
- Water-adjacent tiles gain +0.01/s moisture; all tiles decay at -0.005/s
- Periodic rainfall events (once per sim-minute) soak a random zone with +0.25 moisture
- Plant seeding now compares two random candidate spots and picks the more moist one, creating emergent fertile zones near rivers and lakes
- Migration-safe: `w.moisture ??= new Float32Array(...)` guard for old saves

## Test plan
- [ ] Fill a world with water in one area and run for a few minutes — plants should cluster near it
- [ ] Observe that areas with no water stay drier and have fewer spontaneous plant spawns
- [ ] Old saves load without error
- [ ] No visible performance degradation (moisture updates every 30 ticks ≈ 2×/second)

Closes #2827

🤖 Generated with [Claude Code](https://claude.com/claude-code)