### PR TITLE
feat: speed run mode — race to reach generation N

### DIFF
--- a/src/app/micro-land/MicroLandGame.tsx
+++ b/src/app/micro-land/MicroLandGame.tsx
@@ -10,6 +10,7 @@ import {
   onSaveState,
 } from '@/app/micro-land/chronicle/chronicle'
 import { ChallengesPanel } from '@/app/micro-land/components/challenges-panel'
+import { SpeedRunOverlay } from '@/app/micro-land/components/speed-run-overlay'
 import { PopulationGraph } from '@/app/micro-land/components/population-graph'
 import { CreatureBuilder } from '@/app/micro-land/components/creature-builder'
 import { ReplayBar } from '@/app/micro-land/components/replay-bar'
@@ -352,6 +353,7 @@ export function MicroLandGame() {
       <SummonPanel onIntroduce={handleIntroduce} onApplyTerrain={handleApplyTerrain} />
       <WorldsPanel onKeep={handleKeepWorld} onOpen={handleOpenWorld} onForget={handleForgetWorld} />
       <ChallengesPanel />
+      <SpeedRunOverlay />
       <CreatureBuilder onIntroduce={handleIntroduce} onRevise={handleRevise} />
       <FieldGuide />
       <SettingsPanel />

--- a/src/app/micro-land/components/challenges-panel.tsx
+++ b/src/app/micro-land/components/challenges-panel.tsx
@@ -1,4 +1,5 @@
 'use client'
+import { useState } from 'react'
 import { CHALLENGES } from '@/app/micro-land/domain/challenges'
 import { resetTuning, setTuning } from '@/app/micro-land/domain/tuning'
 import { useMicroLand } from '@/app/micro-land/store'
@@ -8,6 +9,12 @@ export function ChallengesPanel() {
   const setChallengesOpen = useMicroLand(s => s.setChallengesOpen)
   const setChallengeActive = useMicroLand(s => s.setChallengeActive)
   const requestReshuffle = useMicroLand(s => s.requestReshuffle)
+  const [targetGen, setTargetGen] = useState(10)
+  const timeLimitOptions = [{ label: '3 min', seconds: 180 }, { label: '5 min', seconds: 300 }, { label: '10 min', seconds: 600 }]
+  const [timeLimitIdx, setTimeLimitIdx] = useState(1)
+  const startSpeedRun = useMicroLand(s => s.startSpeedRun)
+  const elapsed = useMicroLand(s => s.elapsed)
+  const speedRun = useMicroLand(s => s.speedRun)
 
   if (!open) return null
 
@@ -98,6 +105,70 @@ export function ChallengesPanel() {
               </div>
             </button>
           ))}
+        </div>
+        <div style={{ marginTop: 18, borderTop: '1px solid var(--cc-panel-divider)', paddingTop: 14 }}>
+          <div style={{
+            fontFamily: 'var(--cc-font-mono)', fontSize: 10, letterSpacing: 1.6,
+            textTransform: 'uppercase', color: 'var(--cc-text-muted)', marginBottom: 10,
+          }}>
+            Speed Run
+          </div>
+          <div style={{ fontSize: 12, color: 'var(--cc-text-muted)', marginBottom: 10 }}>
+            Race to keep a lineage alive to generation {targetGen} within the time limit.
+          </div>
+          <div style={{ display: 'flex', gap: 8, marginBottom: 8, flexWrap: 'wrap' }}>
+            {[10, 20, 30].map(g => (
+              <button
+                key={g}
+                type="button"
+                className="cc-btn"
+                onClick={() => setTargetGen(g)}
+                style={{
+                  fontFamily: 'var(--cc-font-mono)', fontSize: 10, letterSpacing: 1,
+                  textTransform: 'uppercase', padding: '3px 10px',
+                  border: `1px solid ${targetGen === g ? 'var(--cc-mint)' : 'var(--cc-panel-divider)'}`,
+                  color: targetGen === g ? 'var(--cc-mint)' : 'var(--cc-text-muted)',
+                }}
+              >
+                gen {g}
+              </button>
+            ))}
+          </div>
+          <div style={{ display: 'flex', gap: 8, marginBottom: 12, flexWrap: 'wrap' }}>
+            {timeLimitOptions.map((opt, i) => (
+              <button
+                key={opt.label}
+                type="button"
+                className="cc-btn"
+                onClick={() => setTimeLimitIdx(i)}
+                style={{
+                  fontFamily: 'var(--cc-font-mono)', fontSize: 10, letterSpacing: 1,
+                  textTransform: 'uppercase', padding: '3px 10px',
+                  border: `1px solid ${timeLimitIdx === i ? 'var(--cc-mint)' : 'var(--cc-panel-divider)'}`,
+                  color: timeLimitIdx === i ? 'var(--cc-mint)' : 'var(--cc-text-muted)',
+                }}
+              >
+                {opt.label}
+              </button>
+            ))}
+          </div>
+          <button
+            type="button"
+            className="cc-btn"
+            onClick={() => {
+              startSpeedRun(targetGen, timeLimitOptions[timeLimitIdx].seconds, elapsed)
+              setChallengesOpen(false)
+            }}
+            style={{
+              fontFamily: 'var(--cc-font-mono)', fontSize: 10, letterSpacing: 1.2,
+              textTransform: 'uppercase', padding: '5px 14px',
+              border: '1px solid var(--cc-mint)',
+              color: 'var(--cc-mint)',
+              display: 'block',
+            }}
+          >
+            {speedRun.active ? 'Restart Speed Run' : 'Start Speed Run'}
+          </button>
         </div>
         <button
           type="button"

--- a/src/app/micro-land/components/speed-run-overlay.tsx
+++ b/src/app/micro-land/components/speed-run-overlay.tsx
@@ -1,0 +1,124 @@
+'use client'
+import { useMicroLand } from '@/app/micro-land/store'
+
+function formatTime(seconds: number): string {
+  const s = Math.max(0, Math.floor(seconds))
+  const m = Math.floor(s / 60)
+  return `${m}:${String(s % 60).padStart(2, '0')}`
+}
+
+export function SpeedRunOverlay() {
+  const speedRun = useMicroLand(s => s.speedRun)
+  const elapsed = useMicroLand(s => s.elapsed)
+  const deepestGeneration = useMicroLand(s => s.records.deepestGeneration)
+  const cancelSpeedRun = useMicroLand(s => s.cancelSpeedRun)
+  const requestReshuffle = useMicroLand(s => s.requestReshuffle)
+
+  if (!speedRun.active && speedRun.result === 'none') return null
+
+  const timeRemaining = speedRun.timeLimitSeconds - (elapsed - speedRun.startElapsed)
+  const isLow = timeRemaining < 30 && speedRun.result === 'none'
+  const progress = Math.min(1, deepestGeneration / speedRun.targetGeneration)
+
+  if (speedRun.result !== 'none') {
+    const won = speedRun.result === 'won'
+    return (
+      <div style={{
+        position: 'fixed', inset: 0, zIndex: 60,
+        background: 'rgba(0,0,0,0.75)',
+        display: 'flex', alignItems: 'center', justifyContent: 'center',
+      }}>
+        <div style={{
+          background: 'var(--cc-panel-bg)',
+          border: `1px solid ${won ? 'var(--cc-mint)' : 'var(--cc-panel-divider)'}`,
+          borderRadius: 8, padding: '28px 32px', maxWidth: 340, width: '90vw',
+          textAlign: 'center',
+        }}>
+          <div style={{
+            fontFamily: 'var(--cc-font-mono)', fontSize: 11,
+            letterSpacing: 1.6, textTransform: 'uppercase',
+            color: won ? 'var(--cc-mint)' : 'var(--cc-text-muted)',
+            marginBottom: 12,
+          }}>
+            {won ? 'Speed Run Complete' : 'Speed Run Failed'}
+          </div>
+          <div style={{ fontSize: 28, marginBottom: 8 }}>{won ? '🏆' : '💀'}</div>
+          <div style={{ fontSize: 14, color: 'var(--cc-text-muted)', marginBottom: 20 }}>
+            {won
+              ? `Reached generation ${speedRun.targetGeneration} — the line endures.`
+              : `Generation ${deepestGeneration} of ${speedRun.targetGeneration} before time ran out.`}
+          </div>
+          <div style={{ display: 'flex', gap: 10, justifyContent: 'center' }}>
+            <button
+              type="button"
+              className="cc-btn"
+              onClick={() => { cancelSpeedRun(); requestReshuffle() }}
+              style={{
+                fontFamily: 'var(--cc-font-mono)', fontSize: 10,
+                letterSpacing: 1, textTransform: 'uppercase',
+                padding: '6px 14px',
+                border: '1px solid var(--cc-mint-line)',
+                color: 'var(--cc-mint)',
+              }}
+            >
+              Try again
+            </button>
+            <button
+              type="button"
+              className="cc-btn"
+              onClick={cancelSpeedRun}
+              style={{
+                fontFamily: 'var(--cc-font-mono)', fontSize: 10,
+                letterSpacing: 1, textTransform: 'uppercase',
+                padding: '6px 14px',
+                border: '1px solid var(--cc-panel-divider)',
+                color: 'var(--cc-text-muted)',
+              }}
+            >
+              Keep watching
+            </button>
+          </div>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div style={{
+      position: 'fixed', top: 12, left: '50%', transform: 'translateX(-50%)',
+      zIndex: 40,
+      background: 'rgba(0,0,0,0.7)',
+      border: `1px solid ${isLow ? '#ff6b6b' : 'var(--cc-panel-divider)'}`,
+      borderRadius: 6, padding: '7px 14px',
+      display: 'flex', alignItems: 'center', gap: 14,
+      fontFamily: 'var(--cc-font-mono)', fontSize: 11,
+      pointerEvents: 'auto',
+    }}>
+      <span style={{ color: isLow ? '#ff6b6b' : 'var(--cc-text-muted)', letterSpacing: 1.2 }}>
+        {formatTime(timeRemaining)}
+      </span>
+      <div style={{ width: 80, height: 4, background: 'rgba(255,255,255,0.1)', borderRadius: 2 }}>
+        <div style={{
+          width: `${progress * 100}%`, height: '100%',
+          background: 'var(--cc-mint)', borderRadius: 2,
+          transition: 'width 0.3s',
+        }} />
+      </div>
+      <span style={{ color: 'var(--cc-text-muted)', letterSpacing: 1 }}>
+        gen {deepestGeneration}/{speedRun.targetGeneration}
+      </span>
+      <button
+        type="button"
+        onClick={cancelSpeedRun}
+        style={{
+          background: 'none', border: 'none', cursor: 'pointer',
+          color: 'var(--cc-text-muted)', fontSize: 11, padding: 0,
+          lineHeight: 1,
+        }}
+        title="Cancel speed run"
+      >
+        ×
+      </button>
+    </div>
+  )
+}

--- a/src/app/micro-land/game-instance.ts
+++ b/src/app/micro-land/game-instance.ts
@@ -559,6 +559,18 @@ export class GameInstance {
 
     useMicroLand.getState().setStats(population, this.world.creatures.length, this.world.elapsed)
 
+    // Speed run win/loss detection
+    const sr = useMicroLand.getState().speedRun
+    if (sr.active && sr.result === 'none') {
+      const deepestGen = population.reduce((max, p) => Math.max(max, p.maxGeneration), 0)
+      const timeUsed = this.world.elapsed - sr.startElapsed
+      if (deepestGen >= sr.targetGeneration) {
+        useMicroLand.getState().endSpeedRun('won')
+      } else if (timeUsed >= sr.timeLimitSeconds || this.world.creatures.length === 0) {
+        useMicroLand.getState().endSpeedRun('lost')
+      }
+    }
+
     const currentStats = useMicroLand.getState().worldStats
     if (this.world.creatures.length > currentStats.peakPopulation) {
       useMicroLand.getState().updateWorldStats({ peakPopulation: this.world.creatures.length })

--- a/src/app/micro-land/store.ts
+++ b/src/app/micro-land/store.ts
@@ -21,6 +21,15 @@ import {
   setTuning,
 } from './domain/tuning'
 
+export interface SpeedRunState {
+  active: boolean
+  targetGeneration: number
+  timeLimitSeconds: number
+  /** World elapsed time (seconds) when the run started — so countdown = timeLimit - (elapsed - startElapsed). */
+  startElapsed: number
+  result: 'none' | 'won' | 'lost'
+}
+
 import type { SaveState } from './chronicle/chronicle'
 import type { ElderRecord, SpeciesRecord } from './chronicle/types'
 import type { Creature, CreatureBlueprint, LifeKind, MaterialId, Traits } from './domain/types'
@@ -254,10 +263,14 @@ interface MicroLandState {
   graphOpen: boolean
   challengesOpen: boolean
   challengeActive: { name: string; goal: string } | null
+  speedRun: SpeedRunState
   /** Incremented each time a world reshuffle is needed; watched by MicroLandGame. */
   reshuffleToken: number
   setChallengesOpen: (open: boolean) => void
   setChallengeActive: (c: { name: string; goal: string } | null) => void
+  startSpeedRun: (targetGeneration: number, timeLimitSeconds: number, currentElapsed: number) => void
+  endSpeedRun: (result: 'won' | 'lost') => void
+  cancelSpeedRun: () => void
   requestReshuffle: () => void
   /**
    * Whether the tool drawer along the bottom is unrolled.
@@ -475,6 +488,7 @@ export const useMicroLand = create<MicroLandState>(set => ({
   graphOpen: false,
   challengesOpen: false,
   challengeActive: null,
+  speedRun: { active: false, targetGeneration: 10, timeLimitSeconds: 300, startElapsed: 0, result: 'none' },
   reshuffleToken: 0,
   toolbarOpen: true,
   tuning: { ...TUNING },
@@ -553,6 +567,12 @@ export const useMicroLand = create<MicroLandState>(set => ({
   setGraphOpen: graphOpen => set({ graphOpen }),
   setChallengesOpen: open => set({ challengesOpen: open }),
   setChallengeActive: c => set({ challengeActive: c }),
+  startSpeedRun: (targetGeneration, timeLimitSeconds, currentElapsed) =>
+    set({ speedRun: { active: true, targetGeneration, timeLimitSeconds, startElapsed: currentElapsed, result: 'none' } }),
+  endSpeedRun: result =>
+    set(s => ({ speedRun: { ...s.speedRun, active: false, result } })),
+  cancelSpeedRun: () =>
+    set(s => ({ speedRun: { ...s.speedRun, active: false, result: 'none' } })),
   requestReshuffle: () => set(s => ({ reshuffleToken: s.reshuffleToken + 1 })),
   setToolbarOpen: toolbarOpen => {
     storeToolbarOpen(toolbarOpen)


### PR DESCRIPTION
## Summary
- Adds a timed challenge mode accessible from the Challenges panel
- Player picks a generation target (10/20/30) and a time limit (3/5/10 min)
- Win condition: any lineage reaches the target generation; lose condition: time runs out or all creatures die
- Live HUD strip shows countdown timer + generation progress bar while active
- Result modal (won/lost) with "Try again" and "Keep watching" options

## Implementation
- `SpeedRunState` in store with `startSpeedRun`/`endSpeedRun`/`cancelSpeedRun` actions
- Win/loss detection runs in `pushStats()` (the existing ~3×/sec stats tick) — no extra tick overhead
- `SpeedRunOverlay` component handles both the HUD strip and the result modal
- Speed Run section added to the existing Challenges panel below existing challenge presets

## Test plan
- [ ] Open Challenges panel → Speed Run section appears below existing challenges
- [ ] Select gen 10 / 3 min → "Start Speed Run" → HUD strip appears at top-center
- [ ] Let timer expire → "Speed Run Failed" modal appears
- [ ] Click "Try again" → world reshuffles, new run starts
- [ ] Breed creatures to gen 10 → "Speed Run Complete" modal appears
- [ ] "Keep watching" dismisses modal, world keeps running
- [ ] "×" button in HUD strip cancels the run silently

Closes #2833

🤖 Generated with [Claude Code](https://claude.com/claude-code)