### PR TITLE
feat: blueprint workshop + biome world (Three Lands theme)

### DIFF
--- a/src/app/micro-land/MicroLandGame.tsx
+++ b/src/app/micro-land/MicroLandGame.tsx
@@ -9,6 +9,7 @@ import {
   initChronicle,
   onSaveState,
 } from '@/app/micro-land/chronicle/chronicle'
+import { BlueprintWorkshop } from '@/app/micro-land/components/blueprint-workshop'
 import { ChallengesPanel } from '@/app/micro-land/components/challenges-panel'
 import { PopulationGraph } from '@/app/micro-land/components/population-graph'
 import { CreatureBuilder } from '@/app/micro-land/components/creature-builder'
@@ -106,6 +107,9 @@ export function MicroLandGame() {
               state.locateRequest.blueprintId
             useMicroLand.getState().notify(`No ${name} alive right now`)
           }
+        }
+        if (state.workshopSpawnRequest !== previous.workshopSpawnRequest && state.workshopSpawnRequest && game) {
+          game.workshopIntroduce(state.workshopSpawnRequest.blueprint, state.workshopSpawnRequest.traits)
         }
       })
     })
@@ -352,6 +356,7 @@ export function MicroLandGame() {
       <SummonPanel onIntroduce={handleIntroduce} onApplyTerrain={handleApplyTerrain} />
       <WorldsPanel onKeep={handleKeepWorld} onOpen={handleOpenWorld} onForget={handleForgetWorld} />
       <ChallengesPanel />
+      <BlueprintWorkshop />
       <CreatureBuilder onIntroduce={handleIntroduce} onRevise={handleRevise} />
       <FieldGuide />
       <SettingsPanel />

--- a/src/app/micro-land/components/blueprint-workshop.tsx
+++ b/src/app/micro-land/components/blueprint-workshop.tsx
@@ -1,0 +1,412 @@
+'use client'
+
+import { useState } from 'react'
+import { useMicroLand } from '@/app/micro-land/store'
+import type { CreatureBlueprint, Traits } from '@/app/micro-land/domain/types'
+
+const TRAIT_DEFS: Array<{ key: keyof Traits; label: string; min: number; max: number; step: number; neutral: number }> = [
+  { key: 'speed',       label: 'Speed',        min: 0.6, max: 1.6, step: 0.01, neutral: 1 },
+  { key: 'sight',       label: 'Sight',        min: 0.6, max: 1.6, step: 0.01, neutral: 1 },
+  { key: 'lifespan',    label: 'Lifespan',     min: 0.6, max: 1.6, step: 0.01, neutral: 1 },
+  { key: 'size',        label: 'Size',         min: 0.8, max: 1.2, step: 0.01, neutral: 1 },
+  { key: 'roam',        label: 'Roam',         min: 0.6, max: 1.6, step: 0.01, neutral: 1 },
+  { key: 'territorial', label: 'Territorial',  min: 0.1, max: 1.4, step: 0.01, neutral: 0.5 },
+  { key: 'camouflage',  label: 'Camouflage',   min: 0,   max: 0.8, step: 0.01, neutral: 0.2 },
+  { key: 'toxicity',    label: 'Toxicity',     min: 0,   max: 1,   step: 0.01, neutral: 0 },
+  { key: 'cooperation', label: 'Cooperation',  min: 0,   max: 1,   step: 0.01, neutral: 0.3 },
+  { key: 'immunity',    label: 'Immunity',     min: 0,   max: 1,   step: 0.01, neutral: 0.2 },
+]
+
+const LOCO_KINDS = ['walk', 'fly', 'swim', 'crawl', 'drift', 'root'] as const
+const DIET_OPTIONS: Array<{ label: string; eats: string[] }> = [
+  { label: 'Herbivore', eats: ['plant'] },
+  { label: 'Carnivore', eats: ['meat'] },
+  { label: 'Omnivore',  eats: ['plant', 'meat'] },
+  { label: 'Fungivore', eats: ['plant', 'fungus'] },
+]
+
+/** Convert trait hue (0–360) and shade (0.82–1.18) to a preview color. */
+function traitColor(hue: number, shade: number): string {
+  const lightness = Math.round(30 + shade * 30) // 55–65 range
+  return `hsl(${Math.round(hue)}, 60%, ${lightness}%)`
+}
+
+function defaultTraits(): Traits {
+  return {
+    speed: 1, sight: 1, lifespan: 1, hue: 0, shade: 1,
+    roam: 1, territorial: 0.5, size: 1, camouflage: 0.2,
+    toxicity: 0, cooperation: 0.3, immunity: 0.2,
+  }
+}
+
+export function BlueprintWorkshop() {
+  const open = useMicroLand(s => s.workshopOpen)
+  const setWorkshopOpen = useMicroLand(s => s.setWorkshopOpen)
+  const blueprints = useMicroLand(s => s.blueprints)
+  const requestWorkshopSpawn = useMicroLand(s => s.requestWorkshopSpawn)
+
+  const [step, setStep] = useState<'pick' | 'configure'>('pick')
+  const [base, setBase] = useState<CreatureBlueprint | null>(null)
+  const [name, setName] = useState('')
+  const [nameError, setNameError] = useState(false)
+  const [locoKind, setLocoKind] = useState<typeof LOCO_KINDS[number]>('walk')
+  const [dietIdx, setDietIdx] = useState(0)
+  const [traits, setTraits] = useState<Traits>(defaultTraits)
+  const [hue, setHue] = useState(0)
+  const [shade, setShade] = useState(1)
+
+  if (!open) return null
+
+  const animals = blueprints.filter(bp => bp.move.kind !== 'root')
+  const displayList = animals.length > 0 ? animals : blueprints
+
+  function pickBase(bp: CreatureBlueprint) {
+    setBase(bp)
+    setName(bp.name + ' (variant)')
+    setLocoKind(bp.move.kind === 'root' ? 'walk' : bp.move.kind)
+    // Pick nearest diet option
+    const hasPlant = bp.diet.eats.includes('plant')
+    const hasMeat = bp.diet.eats.includes('meat')
+    if (hasPlant && hasMeat) setDietIdx(2)
+    else if (hasMeat) setDietIdx(1)
+    else setDietIdx(0)
+    setTraits(defaultTraits())
+    setHue(0)
+    setShade(1)
+    setNameError(false)
+    setStep('configure')
+  }
+
+  function setTrait(key: keyof Traits, value: number) {
+    setTraits(t => ({ ...t, [key]: value }))
+  }
+
+  function handleSpawn() {
+    if (!base) return
+    if (!name.trim()) { setNameError(true); return }
+    setNameError(false)
+
+    const finalBlueprint: CreatureBlueprint = {
+      ...base,
+      name: name.trim(),
+      move: { ...base.move, kind: locoKind },
+      diet: { ...base.diet, eats: DIET_OPTIONS[dietIdx].eats },
+    }
+    const finalTraits: Traits = { ...traits, hue, shade }
+    requestWorkshopSpawn(finalBlueprint, finalTraits)
+    setWorkshopOpen(false)
+    setStep('pick')
+  }
+
+  function close() {
+    setWorkshopOpen(false)
+    setStep('pick')
+  }
+
+  const chipBase = {
+    fontFamily: 'var(--cc-font-mono)',
+    fontSize: 10,
+    letterSpacing: 1,
+    textTransform: 'uppercase' as const,
+    padding: '3px 10px',
+    borderRadius: 4,
+    background: 'transparent',
+    cursor: 'pointer',
+  }
+
+  return (
+    <div
+      style={{
+        position: 'fixed', inset: 0, zIndex: 50,
+        background: 'rgba(0,0,0,0.7)',
+        display: 'flex', alignItems: 'center', justifyContent: 'center',
+        overflowY: 'auto',
+      }}
+      onClick={close}
+    >
+      <div
+        style={{
+          background: 'var(--cc-panel-bg)',
+          border: '1px solid var(--cc-panel-divider)',
+          borderRadius: 8,
+          padding: '20px 24px',
+          maxWidth: 460,
+          width: '90vw',
+          maxHeight: '85vh',
+          overflowY: 'auto',
+        }}
+        onClick={e => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 16 }}>
+          <h2 style={{
+            fontFamily: 'var(--cc-font-mono)', fontSize: 11,
+            letterSpacing: 1.6, textTransform: 'uppercase',
+            color: 'var(--cc-text-muted)', margin: 0,
+          }}>
+            {step === 'pick' ? 'Blueprint Workshop — Pick a Base' : 'Blueprint Workshop — Configure'}
+          </h2>
+          {step === 'configure' && (
+            <button
+              type="button"
+              className="cc-btn"
+              onClick={() => setStep('pick')}
+              style={{ ...chipBase, border: '1px solid var(--cc-panel-divider)', color: 'var(--cc-text-muted)' }}
+            >
+              ← Back
+            </button>
+          )}
+        </div>
+
+        {step === 'pick' && (
+          <>
+            <p style={{ fontSize: 12, color: 'var(--cc-text-muted)', marginBottom: 12 }}>
+              Pick a species as your starting point. You&apos;ll be able to rename it and adjust all of its traits.
+            </p>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+              {displayList.map(bp => (
+                <button
+                  key={bp.id}
+                  type="button"
+                  className="cc-btn"
+                  onClick={() => pickBase(bp)}
+                  style={{
+                    display: 'block', textAlign: 'left',
+                    padding: '8px 12px',
+                    border: '1px solid var(--cc-mint-line)',
+                    borderRadius: 6, background: 'transparent', cursor: 'pointer',
+                  }}
+                >
+                  <div style={{
+                    fontFamily: 'var(--cc-font-mono)', fontSize: 11,
+                    letterSpacing: 1.2, textTransform: 'uppercase',
+                    color: 'var(--cc-mint)', marginBottom: 2,
+                  }}>
+                    {bp.name}
+                  </div>
+                  <div style={{ fontSize: 11, color: 'var(--cc-text-muted)' }}>
+                    {bp.move.kind} · {bp.diet.eats.join('/')}
+                  </div>
+                </button>
+              ))}
+              {displayList.length === 0 && (
+                <p style={{ fontSize: 12, color: 'var(--cc-text-muted)' }}>
+                  No species in the world yet. Place some creatures first.
+                </p>
+              )}
+            </div>
+          </>
+        )}
+
+        {step === 'configure' && base && (
+          <>
+            {/* Name */}
+            <div style={{ marginBottom: 14 }}>
+              <label style={{
+                display: 'block',
+                fontFamily: 'var(--cc-font-mono)', fontSize: 10,
+                letterSpacing: 1.2, textTransform: 'uppercase',
+                color: 'var(--cc-text-muted)', marginBottom: 4,
+              }}>
+                Name *
+              </label>
+              <input
+                type="text"
+                value={name}
+                onChange={e => { setName(e.target.value); setNameError(false) }}
+                maxLength={32}
+                style={{
+                  width: '100%',
+                  background: 'rgba(255,255,255,0.05)',
+                  border: `1px solid ${nameError ? '#ef4444' : 'var(--cc-panel-divider)'}`,
+                  borderRadius: 4, color: 'var(--cc-text-main)',
+                  fontFamily: 'var(--cc-font-mono)', fontSize: 12,
+                  padding: '6px 10px', outline: 'none', boxSizing: 'border-box',
+                }}
+                placeholder="Name your creature"
+              />
+              {nameError && <div style={{ fontSize: 11, color: '#ef4444', marginTop: 4 }}>Name cannot be empty</div>}
+            </div>
+
+            {/* Locomotion kind */}
+            <div style={{ marginBottom: 12 }}>
+              <div style={{
+                fontFamily: 'var(--cc-font-mono)', fontSize: 10,
+                letterSpacing: 1.2, textTransform: 'uppercase',
+                color: 'var(--cc-text-muted)', marginBottom: 6,
+              }}>
+                Locomotion
+              </div>
+              <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6 }}>
+                {LOCO_KINDS.map(k => (
+                  <button
+                    key={k}
+                    type="button"
+                    className="cc-btn"
+                    onClick={() => setLocoKind(k)}
+                    style={{
+                      ...chipBase,
+                      border: `1px solid ${locoKind === k ? 'var(--cc-mint)' : 'var(--cc-panel-divider)'}`,
+                      color: locoKind === k ? 'var(--cc-mint)' : 'var(--cc-text-muted)',
+                    }}
+                  >
+                    {k}
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            {/* Diet */}
+            <div style={{ marginBottom: 12 }}>
+              <div style={{
+                fontFamily: 'var(--cc-font-mono)', fontSize: 10,
+                letterSpacing: 1.2, textTransform: 'uppercase',
+                color: 'var(--cc-text-muted)', marginBottom: 6,
+              }}>
+                Diet
+              </div>
+              <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6 }}>
+                {DIET_OPTIONS.map((opt, i) => (
+                  <button
+                    key={opt.label}
+                    type="button"
+                    className="cc-btn"
+                    onClick={() => setDietIdx(i)}
+                    style={{
+                      ...chipBase,
+                      border: `1px solid ${dietIdx === i ? 'var(--cc-mint)' : 'var(--cc-panel-divider)'}`,
+                      color: dietIdx === i ? 'var(--cc-mint)' : 'var(--cc-text-muted)',
+                    }}
+                  >
+                    {opt.label}
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            {/* Hue + Shade + Color preview */}
+            <div style={{ marginBottom: 14 }}>
+              <div style={{
+                fontFamily: 'var(--cc-font-mono)', fontSize: 10,
+                letterSpacing: 1.2, textTransform: 'uppercase',
+                color: 'var(--cc-text-muted)', marginBottom: 6,
+              }}>
+                Color
+              </div>
+              <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+                <div
+                  style={{
+                    width: 28, height: 28, borderRadius: 4,
+                    background: traitColor(hue, shade),
+                    border: '1px solid rgba(255,255,255,0.15)',
+                    flexShrink: 0,
+                  }}
+                />
+                <div style={{ flex: 1 }}>
+                  <div style={{ fontSize: 10, color: 'var(--cc-text-muted)', marginBottom: 2 }}>Hue</div>
+                  <input
+                    type="range" min={0} max={359} step={1} value={hue}
+                    onChange={e => setHue(Number(e.target.value))}
+                    style={{ width: '100%' }}
+                  />
+                </div>
+                <div style={{ flex: 1 }}>
+                  <div style={{ fontSize: 10, color: 'var(--cc-text-muted)', marginBottom: 2 }}>Shade</div>
+                  <input
+                    type="range" min={0.82} max={1.18} step={0.01} value={shade}
+                    onChange={e => setShade(Number(e.target.value))}
+                    style={{ width: '100%' }}
+                  />
+                </div>
+              </div>
+            </div>
+
+            {/* Trait sliders */}
+            <div style={{ marginBottom: 14 }}>
+              <div style={{
+                fontFamily: 'var(--cc-font-mono)', fontSize: 10,
+                letterSpacing: 1.2, textTransform: 'uppercase',
+                color: 'var(--cc-text-muted)', marginBottom: 8,
+              }}>
+                Traits
+              </div>
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+                {TRAIT_DEFS.map(def => (
+                  <div key={def.key} style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                    <div style={{
+                      width: 88, fontSize: 11, color: 'var(--cc-text-muted)',
+                      fontFamily: 'var(--cc-font-mono)', flexShrink: 0,
+                    }}>
+                      {def.label}
+                    </div>
+                    <input
+                      type="range"
+                      min={def.min}
+                      max={def.max}
+                      step={def.step}
+                      value={(traits[def.key] as number) ?? def.neutral}
+                      onChange={e => setTrait(def.key, Number(e.target.value))}
+                      style={{ flex: 1 }}
+                    />
+                    <div style={{
+                      width: 36, textAlign: 'right',
+                      fontSize: 11, color: 'var(--cc-text-muted)',
+                      fontFamily: 'var(--cc-font-mono)', flexShrink: 0,
+                    }}>
+                      {((traits[def.key] as number) ?? def.neutral).toFixed(2)}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            {/* Spawn button */}
+            <div style={{ display: 'flex', gap: 10, justifyContent: 'flex-end' }}>
+              <button
+                type="button"
+                className="cc-btn"
+                onClick={close}
+                style={{
+                  ...chipBase,
+                  border: '1px solid var(--cc-panel-divider)',
+                  color: 'var(--cc-text-muted)',
+                }}
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                className="cc-btn"
+                onClick={handleSpawn}
+                style={{
+                  ...chipBase,
+                  border: '1px solid var(--cc-mint)',
+                  color: 'var(--cc-mint)',
+                  padding: '6px 16px',
+                }}
+              >
+                Create & Spawn 5
+              </button>
+            </div>
+          </>
+        )}
+
+        {step === 'pick' && (
+          <button
+            type="button"
+            className="cc-btn"
+            onClick={close}
+            style={{
+              marginTop: 14,
+              ...chipBase,
+              border: '1px solid var(--cc-panel-divider)',
+              color: 'var(--cc-text-muted)',
+            }}
+          >
+            Close
+          </button>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/app/micro-land/components/hud.tsx
+++ b/src/app/micro-land/components/hud.tsx
@@ -137,6 +137,8 @@ export function Hud({
   const setChallengesOpen = useMicroLand(s => s.setChallengesOpen)
   const challengeActive = useMicroLand(s => s.challengeActive)
   const setChallengeActive = useMicroLand(s => s.setChallengeActive)
+  const workshopOpen = useMicroLand(s => s.workshopOpen)
+  const setWorkshopOpen = useMicroLand(s => s.setWorkshopOpen)
 
   const replaySnapshots = useMicroLand(s => s.replaySnapshots)
   const graphOpen = useMicroLand(s => s.graphOpen)
@@ -235,6 +237,22 @@ export function Hud({
         }
       >
         Worlds
+      </button>
+
+      <button
+        type="button"
+        className="cc-btn"
+        onClick={() => setWorkshopOpen(!workshopOpen)}
+        style={{
+          ...chipBase,
+          ...(workshopOpen
+            ? { borderColor: 'var(--cc-mint)', color: 'var(--cc-mint)', background: 'rgba(100,220,200,0.08)' }
+            : {}),
+        }}
+        aria-pressed={workshopOpen}
+        title="Blueprint Workshop — design a creature"
+      >
+        Workshop
       </button>
 
       <button

--- a/src/app/micro-land/domain/config/themes.ts
+++ b/src/app/micro-land/domain/config/themes.ts
@@ -1403,6 +1403,157 @@ const CANDY: Theme = {
   },
 }
 
+const BIOME_WORLD: Theme = {
+  id: 'biome-world',
+  name: 'Three Lands',
+  blurb: 'Forest, open plains, and desert — three biomes side by side.',
+  sky: ['#8ecf9a', '#2a5c3a'],
+  gloom: 0.18,
+  gravity: 1,
+  starters: [
+    { id: 'sunleaf', count: 20 },
+    { id: 'glowvine', count: 8 },
+    { id: 'bramble', count: 10 },
+    { id: 'skybloom', count: 8 },
+    { id: 'sporecap', count: 6 },
+    { id: 'mite', count: 10 },
+    { id: 'mote', count: 8 },
+    { id: 'hopper', count: 6 },
+    { id: 'dustbee', count: 6 },
+    { id: 'loamworm', count: 4 },
+    { id: 'glimmer-moth', count: 4 },
+    { id: 'woolly', count: 4 },
+    { id: 'delver', count: 3 },
+    { id: 'ember-grub', count: 4 },
+    { id: 'stalker', count: 2 },
+    { id: 'sunhawk', count: 2 },
+  ],
+  build: (tiles, rng) => {
+    fill(tiles, 'air')
+    const surfaceNoise = makeNoise2D(Math.floor(rng() * 1e9))
+    const featureNoise = makeNoise2D(Math.floor(rng() * 1e9))
+
+    const THIRD = Math.floor(WORLD_W / 3)
+    const skyDepth = Math.floor(WORLD_H * 0.30)
+    const BLEND = 18  // border blend width in tiles
+
+    for (let x = 0; x < WORLD_W; x++) {
+      // Smooth biome blend factor at borders: 0 = first biome, 1 = second biome
+      const leftBorder = THIRD
+      const rightBorder = THIRD * 2
+
+      // blendFP: 0 = pure forest, 1 = pure plains (active in transition zone)
+      const blendFP = x < leftBorder - BLEND ? 0
+        : x > leftBorder ? 1
+        : (x - (leftBorder - BLEND)) / BLEND
+
+      // blendPD: 0 = pure plains, 1 = pure desert
+      const blendPD = x < rightBorder - BLEND ? 0
+        : x > rightBorder ? 1
+        : (x - (rightBorder - BLEND)) / BLEND
+
+      // Terrain height per biome
+      const forestH = fbm(surfaceNoise, x * 0.030, 0.5, 3)
+      const forestSurf = skyDepth + (forestH - 0.5) * 22
+
+      const plainsH = fbm(surfaceNoise, x * 0.014 + 100, 0.5, 2)
+      const plainsSurf = skyDepth + (plainsH - 0.5) * 8 + 4
+
+      const desertH = fbm(surfaceNoise, x * 0.020 + 300, 0.5, 2)
+      const desertSurf = skyDepth + (desertH - 0.5) * 16 + 6
+
+      // Blend surface heights at borders
+      let rawSurf: number
+      if (x < leftBorder) {
+        rawSurf = forestSurf * (1 - blendFP) + plainsSurf * blendFP
+      } else if (x < rightBorder) {
+        rawSurf = plainsSurf * (1 - blendPD) + desertSurf * blendPD
+      } else {
+        rawSurf = desertSurf
+      }
+      const surface = Math.floor(rawSurf)
+
+      for (let y = surface; y < WORLD_H; y++) {
+        const depth = (y - surface) / (WORLD_H - surface)
+        let mat: MaterialId
+
+        if (x < leftBorder) {
+          // Forest: grass crust, dirt, stone, deep lava
+          if (depth < 0.02) mat = 'grass'
+          else if (depth < 0.16) mat = 'dirt'
+          else if (depth < 0.85) mat = 'stone'
+          else mat = 'lava'
+        } else if (x < rightBorder) {
+          // Plains: thicker grass layer, dirt, stone
+          if (depth < 0.04) mat = 'grass'
+          else if (depth < 0.20) mat = 'dirt'
+          else if (depth < 0.85) mat = 'stone'
+          else mat = 'lava'
+        } else {
+          // Desert: deep sand over stone
+          if (depth < 0.28) mat = 'sand'
+          else if (depth < 0.85) mat = 'stone'
+          else mat = 'lava'
+        }
+
+        set(tiles, x, y, mat)
+      }
+    }
+
+    // Forest trees: wood columns above ground with moss canopy
+    for (let x = 4; x < THIRD - 4; x++) {
+      if (featureNoise(x * 0.18, 0.2) > 0.52) {
+        const sy = surfaceY(tiles, x)
+        const height = 4 + Math.floor(rng() * 5)
+        for (let dy = 1; dy <= height; dy++) {
+          set(tiles, x, sy - dy, 'wood')
+        }
+        for (let dx = -2; dx <= 2; dx++) {
+          for (let dy = height - 1; dy <= height + 2; dy++) {
+            if (rng() > 0.35) set(tiles, x + dx, sy - dy, 'moss')
+          }
+        }
+      }
+    }
+
+    // Forest: water springs (3–4 pools)
+    const springCount = 3 + Math.floor(rng() * 2)
+    for (let i = 0; i < springCount; i++) {
+      const sx = 20 + Math.floor(rng() * (THIRD - 40))
+      const sy = surfaceY(tiles, sx)
+      blob(tiles, sx, sy + 3 + Math.floor(rng() * 4), 3, 'water', rng, ['dirt', 'stone'])
+    }
+
+    // Plains: scattered water pools
+    for (let i = 0; i < 3; i++) {
+      const px = THIRD + 20 + Math.floor(rng() * (THIRD - 40))
+      const sy = surfaceY(tiles, px)
+      blob(tiles, px, sy + 2, 4, 'water', rng, ['dirt', 'stone', 'grass'])
+    }
+
+    // Desert: stone rock formations
+    for (let rx = THIRD * 2 + 25; rx < WORLD_W - 20; rx += 30 + Math.floor(rng() * 25)) {
+      const sy = surfaceY(tiles, rx)
+      const height = 3 + Math.floor(rng() * 6)
+      for (let dy = 0; dy < height; dy++) {
+        set(tiles, rx, sy - dy, 'stone')
+        if (rng() > 0.4) set(tiles, rx + 1, sy - dy, 'stone')
+      }
+    }
+
+    // Desert: buried aquifer (water at depth ~78%)
+    const waterTable = Math.floor(WORLD_H * 0.78)
+    for (let x = THIRD * 2; x < WORLD_W; x++) {
+      for (let dy = 0; dy < 3; dy++) {
+        const y = waterTable + dy
+        if (y < WORLD_H && tileAt(tiles, x, y) !== M.air) {
+          set(tiles, x, y, 'water')
+        }
+      }
+    }
+  },
+}
+
 /**
  * Order is the order of the picker, and it is a reading order: nothing, then
  * the world most like ours, then the ones that bend it further and further.
@@ -1410,6 +1561,7 @@ const CANDY: Theme = {
 export const THEMES: Theme[] = [
   EMPTY,
   EARTH,
+  BIOME_WORLD,
   PEAKS,
   WINTER,
   DUNES,

--- a/src/app/micro-land/game-instance.ts
+++ b/src/app/micro-land/game-instance.ts
@@ -60,6 +60,7 @@ import {
   type CreatureBlueprint,
   LIFE_KINDS,
   type LifeKind,
+  type Traits,
   type WorldState,
 } from './domain/types'
 import { formatDuration } from './format'
@@ -1236,6 +1237,35 @@ export class GameInstance {
     }
     this.pushStats()
     return { blueprint: bp, placed }
+  }
+
+  /**
+   * Create a new species from the workshop and spawn 5 of them.
+   *
+   * The blueprint is sanitized (so it gets a fresh id) and registered; then
+   * 5 creatures are placed and their traits are overwritten with the player's
+   * chosen values before the stats are pushed.
+   */
+  workshopIntroduce(blueprint: CreatureBlueprint, traits: Traits): void {
+    const bp = sanitizeBlueprint(blueprint as unknown, { summoned: true, idPrefix: 'workshop' })
+    this.world.dormant = false
+    registerBlueprint(this.world, bp)
+    this.syncBlueprintsToStore()
+
+    let placed = 0
+    for (let i = 0; i < 5; i++) {
+      if (this.world.creatures.length >= TUNING.maxCreatures) break
+      const creature = spawnSomewhereSensible(this.world, bp, this.rng)
+      if (creature) {
+        creature.traits = { ...traits }
+        placed++
+      }
+    }
+    this.pushStats()
+    if (placed > 0) {
+      useMicroLand.getState().notify(`${bp.name} × ${placed} placed in the world`)
+    }
+    useMicroLand.getState().clearWorkshopSpawnRequest()
   }
 
   /**

--- a/src/app/micro-land/store.ts
+++ b/src/app/micro-land/store.ts
@@ -208,6 +208,15 @@ export interface PendingSummon {
   prompt: string
 }
 
+export interface WorkshopSpawnRequest {
+  /** The blueprint to introduce (will be sanitized in game-instance). */
+  blueprint: CreatureBlueprint
+  /** Initial traits for all spawned creatures. */
+  traits: Traits
+  /** Incremented to trigger the subscribe handler even for the same blueprint. */
+  serial: number
+}
+
 interface MicroLandState {
   themeId: string
   tool: Tool
@@ -254,10 +263,15 @@ interface MicroLandState {
   graphOpen: boolean
   challengesOpen: boolean
   challengeActive: { name: string; goal: string } | null
+  workshopOpen: boolean
+  workshopSpawnRequest: WorkshopSpawnRequest | null
   /** Incremented each time a world reshuffle is needed; watched by MicroLandGame. */
   reshuffleToken: number
   setChallengesOpen: (open: boolean) => void
   setChallengeActive: (c: { name: string; goal: string } | null) => void
+  setWorkshopOpen: (open: boolean) => void
+  requestWorkshopSpawn: (blueprint: CreatureBlueprint, traits: Traits) => void
+  clearWorkshopSpawnRequest: () => void
   requestReshuffle: () => void
   /**
    * Whether the tool drawer along the bottom is unrolled.
@@ -475,6 +489,8 @@ export const useMicroLand = create<MicroLandState>(set => ({
   graphOpen: false,
   challengesOpen: false,
   challengeActive: null,
+  workshopOpen: false,
+  workshopSpawnRequest: null,
   reshuffleToken: 0,
   toolbarOpen: true,
   tuning: { ...TUNING },
@@ -553,6 +569,10 @@ export const useMicroLand = create<MicroLandState>(set => ({
   setGraphOpen: graphOpen => set({ graphOpen }),
   setChallengesOpen: open => set({ challengesOpen: open }),
   setChallengeActive: c => set({ challengeActive: c }),
+  setWorkshopOpen: open => set({ workshopOpen: open }),
+  requestWorkshopSpawn: (blueprint, traits) =>
+    set(s => ({ workshopSpawnRequest: { blueprint, traits, serial: (s.workshopSpawnRequest?.serial ?? 0) + 1 } })),
+  clearWorkshopSpawnRequest: () => set({ workshopSpawnRequest: null }),
   requestReshuffle: () => set(s => ({ reshuffleToken: s.reshuffleToken + 1 })),
   setToolbarOpen: toolbarOpen => {
     storeToolbarOpen(toolbarOpen)


### PR DESCRIPTION
## Summary

### Blueprint Workshop (closes #2822)
- New "Workshop" HUD button opens a two-step modal
- Step 1: pick an existing species as the base
- Step 2: configure name, locomotion kind, diet, hue/shade (live color preview), and sliders for all 10 heritable traits
- "Create & Spawn 5" mints a new blueprint and places 5 creatures with custom starting traits

### Three Lands Biome World (closes #2755)
- New world theme (`id: 'biome-world'`, name: "Three Lands")  
- Left third: Forest — rolling hills, grass/dirt/stone, wood trees with moss canopy, embedded water springs
- Middle third: Plains — flat terrain, thick grass layer, scattered water pools
- Right third: Desert — sand dunes over stone, rock formations, buried aquifer at depth ~78%
- 18-tile smooth transition zones at biome borders via fbm-blended terrain heights
- Mixed starters spanning all three biomes; habitat filtering distributes to viable terrain

## Test plan
- [ ] Workshop: open → pick base → configure → Spawn 5 → creatures appear with custom traits
- [ ] Workshop: empty name shows validation error; hue/shade preview updates live
- [ ] Biome World: select "Three Lands" theme → 3 distinct terrain regions
- [ ] Forest has trees and grass; plains is flat; desert has sand and stone outcrops
- [ ] Biome borders smooth (no hard terrain cliff)

Closes #2822, #2755

🤖 Generated with [Claude Code](https://claude.com/claude-code)