### PR TITLE
feat: procedural ambient sound for sim events

### DIFF
--- a/src/app/micro-land/audio/sound-engine.ts
+++ b/src/app/micro-land/audio/sound-engine.ts
@@ -1,0 +1,104 @@
+/**
+ * Procedural audio for sim events.
+ *
+ * All synthesis is done via the Web Audio API — no files, no buffers.
+ * AudioContext is created lazily on the first call to `enable()`, which
+ * must happen inside a user-gesture handler (the HUD toggle).
+ *
+ * At most three OscillatorNodes play simultaneously. A fourth event while
+ * three are active is silently dropped — a brief clip is better than
+ * compounding into a wall of noise.
+ */
+let ctx: AudioContext | null = null
+let enabled = false
+let active = 0
+
+export function enableSound(): void {
+  enabled = true
+  if (!ctx) ctx = new AudioContext()
+  if (ctx.state === 'suspended') void ctx.resume()
+}
+
+export function disableSound(): void {
+  enabled = false
+}
+
+export function isSoundEnabled(): boolean {
+  return enabled
+}
+
+/**
+ * Schedule one oscillator burst.
+ *
+ * @param freq      Starting frequency in Hz
+ * @param freqEnd   End frequency (for glide); pass same as freq for steady pitch
+ * @param duration  Duration in seconds (≤ 0.3 per acceptance criteria)
+ * @param type      Oscillator waveform
+ * @param peak      Peak gain (0–1)
+ * @param startOffset  Seconds from now to start (for arpeggios)
+ */
+function tone(
+  freq: number,
+  freqEnd: number,
+  duration: number,
+  type: OscillatorType = 'sine',
+  peak: number = 0.12,
+  startOffset: number = 0
+): void {
+  if (!enabled || !ctx || active >= 3) return
+  active++
+  const now = ctx.currentTime + startOffset
+  const osc = ctx.createOscillator()
+  const gain = ctx.createGain()
+  osc.type = type
+  osc.frequency.setValueAtTime(freq, now)
+  if (freqEnd !== freq) osc.frequency.linearRampToValueAtTime(freqEnd, now + duration)
+  gain.gain.setValueAtTime(0, now)
+  gain.gain.linearRampToValueAtTime(peak, now + 0.01)
+  gain.gain.linearRampToValueAtTime(0, now + duration)
+  osc.connect(gain)
+  gain.connect(ctx.destination)
+  osc.start(now)
+  osc.stop(now + duration + 0.02)
+  osc.onended = () => { active = Math.max(0, active - 1) }
+}
+
+/**
+ * Soft ascending chime when a creature eats.
+ *
+ * Frequency is derived from the species hue so herbivores in a meadow
+ * have a different pitch from carnivores on a savanna — the world starts
+ * sounding like itself rather than playing the same clip for everything.
+ */
+export function playEat(hue: number): void {
+  const base = 440 + (hue / 360) * 440   // 440–880 Hz
+  tone(base, base * 1.15, 0.12, 'sine', 0.09)
+}
+
+/** Low descending tone for any creature death. */
+export function playDeath(): void {
+  tone(200, 110, 0.25, 'triangle', 0.1)
+}
+
+/**
+ * Harmonic pair for a birth.
+ *
+ * Two tones a major third apart, the second slightly delayed, so it
+ * reads as a brief chord rather than two unrelated clicks.
+ */
+export function playBorn(): void {
+  tone(523, 523, 0.12, 'sine', 0.09)         // C5
+  tone(659, 659, 0.10, 'sine', 0.07, 0.06)   // E5, starts 60 ms later
+}
+
+/**
+ * Slow descending arpeggio for a species going extinct.
+ *
+ * Three notes drop over ~0.3 s. Uses the 'triangle' waveform for a
+ * slightly hollow, mournful quality compared to the bright sine of a birth.
+ */
+export function playExtinction(): void {
+  tone(330, 330, 0.15, 'triangle', 0.11)
+  tone(277, 277, 0.15, 'triangle', 0.09, 0.10)
+  tone(220, 220, 0.20, 'triangle', 0.09, 0.20)
+}

--- a/src/app/micro-land/components/hud.tsx
+++ b/src/app/micro-land/components/hud.tsx
@@ -2,6 +2,7 @@
 
 import Link from 'next/link'
 
+import { disableSound, enableSound } from '@/app/micro-land/audio/sound-engine'
 import { THEMES } from '@/app/micro-land/domain/config/themes'
 import { STEADY_SHOW_SECONDS } from '@/app/micro-land/domain/constants'
 import { TUNING_DEFAULTS, type TuningKey } from '@/app/micro-land/domain/tuning'
@@ -141,6 +142,8 @@ export function Hud({
   const replaySnapshots = useMicroLand(s => s.replaySnapshots)
   const graphOpen = useMicroLand(s => s.graphOpen)
   const setGraphOpen = useMicroLand(s => s.setGraphOpen)
+  const soundEnabled = useMicroLand(s => s.soundEnabled)
+  const setSoundEnabled = useMicroLand(s => s.setSoundEnabled)
 
   const { user, loading: authLoading } = useAuth()
   const isSignedIn = !authLoading && !!user && !user.isAnonymous
@@ -299,6 +302,27 @@ export function Hud({
         title="View ecosystem history"
       >
         History
+      </button>
+
+      <button
+        type="button"
+        className="cc-btn"
+        onClick={() => {
+          const next = !soundEnabled
+          if (next) enableSound()
+          else disableSound()
+          setSoundEnabled(next)
+        }}
+        style={{
+          ...chipBase,
+          ...(soundEnabled
+            ? { borderColor: 'var(--cc-mint)', color: 'var(--cc-mint)', background: 'rgba(100,220,200,0.08)' }
+            : {}),
+        }}
+        aria-pressed={soundEnabled}
+        title="Toggle ambient sound"
+      >
+        {soundEnabled ? 'Sound on' : 'Sound off'}
       </button>
 
       <div className="ml-auto flex items-center gap-2">

--- a/src/app/micro-land/game-instance.ts
+++ b/src/app/micro-land/game-instance.ts
@@ -62,6 +62,7 @@ import {
   type LifeKind,
   type WorldState,
 } from './domain/types'
+import { playBorn, playDeath, playEat, playExtinction, isSoundEnabled } from './audio/sound-engine'
 import { formatDuration } from './format'
 import { Renderer } from './rendering/renderer'
 import { forgetSprites } from './rendering/sprite-cache'
@@ -446,6 +447,12 @@ export class GameInstance {
       if (event.kind !== 'ate' || !event.victimId) continue
       // Log to food web — every eat, including carcasses (victimId now set for both).
       logEat(event.blueprintId, event.victimId)
+      if (isSoundEnabled()) {
+        // Hash blueprint id to a hue-like number (0–360) for pitch variety
+        let h = 0
+        for (const ch of event.blueprintId) h = (h * 31 + ch.charCodeAt(0)) & 0xffff
+        playEat((h % 360))
+      }
 
       // Announce predation on animals — a kill is instant and the victim just
       // vanishes, so without this the food chain runs invisibly and looks like
@@ -489,6 +496,7 @@ export class GameInstance {
       notify(
         event.kind === 'starved' ? `The last ${bp.name} starved.` : `The last ${bp.name} was eaten.`
       )
+      if (isSoundEnabled()) playExtinction()
     }
 
     // Accumulate lifetime stats.
@@ -518,6 +526,17 @@ export class GameInstance {
         mostProlificName,
         mostProlificChildren,
       })
+    }
+
+    // Play sounds for aggregate events this tick
+    if (isSoundEnabled()) {
+      let hadBirth = false, hadDeath = false
+      for (const ev of events) {
+        if (ev.kind === 'born' && !hadBirth) { playBorn(); hadBirth = true }
+        if ((ev.kind === 'aged' || ev.kind === 'starved' || ev.kind === 'drowned' || ev.kind === 'burned') && !hadDeath) {
+          playDeath(); hadDeath = true
+        }
+      }
     }
   }
 

--- a/src/app/micro-land/store.ts
+++ b/src/app/micro-land/store.ts
@@ -358,6 +358,8 @@ interface MicroLandState {
   setTraitOverlay: (trait: string | null) => void
   trailsEnabled: boolean
   setTrailsEnabled: (on: boolean) => void
+  soundEnabled: boolean
+  setSoundEnabled: (on: boolean) => void
 
   /** Creature snapshots for time-lapse. Null = not in replay mode. */
   replaySnapshots: CreatureSnapshot[] | null
@@ -510,6 +512,7 @@ export const useMicroLand = create<MicroLandState>(set => ({
   replaySnapshots: null,
   replayIndex: 0,
   trailsEnabled: false,
+  soundEnabled: false,
 
   setTheme: themeId => set({ themeId }),
   setTool: tool => set({ tool }),
@@ -611,6 +614,7 @@ export const useMicroLand = create<MicroLandState>(set => ({
     set({ locateRequest: { blueprintId, serial: ++locateSerial }, guideOpen: false }),
   setTraitOverlay: trait => set(s => ({ traitOverlay: s.traitOverlay === trait ? null : trait })),
   setTrailsEnabled: on => set({ trailsEnabled: on }),
+  setSoundEnabled: on => set({ soundEnabled: on }),
 
   enterReplay: snapshots =>
     set({ replaySnapshots: snapshots, replayIndex: snapshots.length - 1, paused: true }),


### PR DESCRIPTION
## Summary
- Adds Web Audio API synthesis for four sim events — no audio files, synthesized only
- Off by default; "Sound on/off" toggle button in the HUD
- Eat: ascending sine chime, pitch varies by species (blueprint id hash → 0–360 hue proxy), so different creatures have different pitches
- Death: low triangle tone descending 200→110 Hz over 0.25s
- Birth: harmonic C5+E5 pair (major third), staggered 60ms
- Extinction: slow descending arpeggio (330→277→220 Hz, triangle, over 0.3s)

## Technical
- `AudioContext` created lazily inside `enableSound()`, which is only called from the HUD button click (satisfies browser autoplay policy)
- Max 3 simultaneous `OscillatorNode`s — a 4th event while 3 are active is silently dropped
- Eat sounds trigger once per eat event (throttled by the existing 3-cap); birth/death sounds trigger at most once per sim tick via `digestEvents()` aggregation
- No SSR issues — module-level variables are `null` until `enableSound()` runs client-side

## Test plan
- [ ] Load the game — no audio plays, no errors
- [ ] Click "Sound off" → "Sound on" (button turns mint)
- [ ] Watch creatures eat → subtle ascending chimes
- [ ] Let a creature die → low descending tone
- [ ] Breed creatures → brief harmonic chord
- [ ] Kill off a whole species → descending arpeggio
- [ ] Click "Sound on" → "Sound off" → silence returns
- [ ] Rapid events don't stack beyond 3 simultaneous oscillators

Closes #2835

🤖 Generated with [Claude Code](https://claude.com/claude-code)