### PR TITLE
feat(micro-land): Field Guide as collapsible sidebar with population viewer

### DIFF
--- a/src/app/micro-land/MicroLandGame.tsx
+++ b/src/app/micro-land/MicroLandGame.tsx
@@ -109,6 +109,14 @@ export function MicroLandGame() {
             useMicroLand.getState().notify(`No ${name} alive right now`)
           }
         }
+        if (
+          state.locateCreatureRequest !== previous.locateCreatureRequest &&
+          state.locateCreatureRequest &&
+          game
+        ) {
+          const found = game.inspectCreature(state.locateCreatureRequest.id)
+          if (!found) useMicroLand.getState().notify('That creature is no longer with us')
+        }
         if (state.workshopSpawnRequest !== previous.workshopSpawnRequest && state.workshopSpawnRequest && game) {
           // Deferred: workshopIntroduce triggers many sequential set() calls
           // (setBlueprints, setStats, notify, clearWorkshopSpawnRequest…). Calling
@@ -343,20 +351,25 @@ export function MicroLandGame() {
     <div className="micro-land-shell flex h-full w-full flex-col overflow-hidden">
       <Hud onReshuffle={handleReshuffle} onClearLife={handleClearLife} onOpenHistory={handleOpenHistory} />
 
-      <div className="relative min-h-0 flex-1">
-        <canvas
-          ref={canvasRef}
-          // Focusable so the arrow keys reach it. The world is wider than the
-          // screen, and a keyboard has to be able to get to the rest of it.
-          tabIndex={0}
-          className="absolute inset-0 block h-full w-full touch-none focus:outline-none"
-          style={{ imageRendering: 'pixelated', cursor: 'crosshair' }}
-          aria-label="Micro Land world. Tap to place things, drag a creature to pick it up and throw it. Arrow keys scroll across the world, plus and minus move closer and further away."
-        />
-        <PanControls onHold={handleHoldPan} onNudge={handleNudgePan} />
-        <ZoomControls onZoom={handleZoom} />
-        <Notices />
-        <Inspector onName={handleName} />
+      {/* Canvas + Field Guide sidebar share a flex row so the sidebar pushes
+          the canvas narrower rather than overlaying it. */}
+      <div className="flex min-h-0 flex-1 overflow-hidden">
+        <div className="relative min-w-0 flex-1">
+          <canvas
+            ref={canvasRef}
+            // Focusable so the arrow keys reach it. The world is wider than the
+            // screen, and a keyboard has to be able to get to the rest of it.
+            tabIndex={0}
+            className="absolute inset-0 block h-full w-full touch-none focus:outline-none"
+            style={{ imageRendering: 'pixelated', cursor: 'crosshair' }}
+            aria-label="Micro Land world. Tap to place things, drag a creature to pick it up and throw it. Arrow keys scroll across the world, plus and minus move closer and further away."
+          />
+          <PanControls onHold={handleHoldPan} onNudge={handleNudgePan} />
+          <ZoomControls onZoom={handleZoom} />
+          <Notices />
+          <Inspector onName={handleName} />
+        </div>
+        <FieldGuide />
       </div>
 
       <Toolbar onRemoveSpecies={handleRemoveSpecies} />
@@ -366,7 +379,6 @@ export function MicroLandGame() {
       <BlueprintWorkshop />
       <SpeedRunOverlay />
       <CreatureBuilder onIntroduce={handleIntroduce} onRevise={handleRevise} />
-      <FieldGuide />
       <SettingsPanel />
       <HistoryPanel />
       <ReplayBar />

--- a/src/app/micro-land/components/field-guide.tsx
+++ b/src/app/micro-land/components/field-guide.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react'
 
 import type { ElderRecord, SpeciesRecord } from '@/app/micro-land/chronicle/types'
 import { canEat, isPlantLike, moveWord, sanitizeBlueprint } from '@/app/micro-land/domain/blueprint'
-import { type CreatureBlueprint, LIFE_KINDS } from '@/app/micro-land/domain/types'
+import { type CreatureBlueprint, type CreatureThumb, LIFE_KINDS } from '@/app/micro-land/domain/types'
 import { formatDuration } from '@/app/micro-land/format'
 import { useMicroLand, type PopulationSnapshot } from '@/app/micro-land/store'
 
@@ -76,6 +76,8 @@ export function FieldGuide() {
   const foodWeb = useMicroLand(s => s.foodWeb)
   const setChallengesOpen = useMicroLand(s => s.setChallengesOpen)
   const setWorkshopOpen = useMicroLand(s => s.setWorkshopOpen)
+  const populationItems = useMicroLand(s => s.populationItems)
+  const requestLocateCreature = useMicroLand(s => s.requestLocateCreature)
   const allBlueprintNames = Object.fromEntries(blueprints.map(b => [b.id, b.name]))
 
   const [plantsHidden, setPlantsHidden] = useState(false)
@@ -96,104 +98,106 @@ export function FieldGuide() {
     records.elder !== null || records.bestSteadySeconds > 0 || records.bestGenerations > 1
 
   return (
-    <div
-      className="fixed inset-0 z-50 flex items-end justify-center sm:items-center"
-      style={{ background: 'var(--cc-modal-scrim)' }}
-      onClick={() => setOpen(false)}
+    <aside
+      aria-label="Field guide"
+      style={{
+        width: 300,
+        flexShrink: 0,
+        borderLeft: '1px solid var(--cc-panel-divider)',
+        background: 'linear-gradient(180deg, var(--cc-modal-bg-from), var(--cc-modal-bg-to))',
+        display: 'flex',
+        flexDirection: 'column',
+        overflow: 'hidden',
+      }}
     >
-      <div
-        role="dialog"
-        aria-modal="true"
-        aria-label="Field guide"
-        className="w-full max-w-2xl overflow-y-auto rounded-t-xl sm:rounded-xl"
-        style={{
-          maxHeight: '88dvh',
-          background: 'linear-gradient(180deg, var(--cc-modal-bg-from), var(--cc-modal-bg-to))',
-          border: '1px solid var(--cc-modal-border)',
-        }}
-        onClick={e => e.stopPropagation()}
-      >
+      <div style={{ overflowY: 'auto', flex: 1 }}>
         <div
-          className="sticky top-0 flex items-center justify-between px-4 py-3"
+          className="sticky top-0 flex flex-col gap-1.5 px-3 py-2.5"
           style={{
             borderBottom: '1px solid var(--cc-panel-divider)',
             background: 'var(--cc-modal-bg-from)',
           }}
         >
-          <h2
-            style={{
-              fontFamily: 'var(--cc-font-mono)',
-              fontSize: 11,
-              letterSpacing: 2.5,
-              textTransform: 'uppercase',
-              color: 'var(--cc-mint)',
-            }}
-          >
-            Field Guide
-          </h2>
-          <button
-            type="button"
-            className="cc-btn"
-            onClick={() => setPlantsHidden(h => !h)}
-            style={{
-              fontFamily: 'var(--cc-font-mono)',
-              fontSize: 9,
-              letterSpacing: 1.2,
-              textTransform: 'uppercase',
-              padding: '4px 10px',
-              minHeight: 28,
-              borderRadius: 4,
-              border: plantsHidden ? '1px solid var(--cc-mint)' : '1px solid var(--cc-panel-divider)',
-              color: plantsHidden ? 'var(--cc-mint)' : 'var(--cc-text-muted)',
-            }}
-          >
-            {plantsHidden ? 'Plants hidden' : 'Hide plants'}
-          </button>
-          <button
-            type="button"
-            className="cc-btn"
-            onClick={() => { setWorkshopOpen(true) }}
-            style={{
-              fontFamily: 'var(--cc-font-mono)',
-              fontSize: 9,
-              letterSpacing: 1.2,
-              textTransform: 'uppercase',
-              padding: '4px 10px',
-              minHeight: 28,
-              borderRadius: 4,
-              border: '1px solid var(--cc-panel-divider)',
-              color: 'var(--cc-text-muted)',
-            }}
-          >
-            Workshop
-          </button>
-          <button
-            type="button"
-            className="cc-btn"
-            onClick={() => { setChallengesOpen(true) }}
-            style={{
-              fontFamily: 'var(--cc-font-mono)',
-              fontSize: 9,
-              letterSpacing: 1.2,
-              textTransform: 'uppercase',
-              padding: '4px 10px',
-              minHeight: 28,
-              borderRadius: 4,
-              border: '1px solid var(--cc-panel-divider)',
-              color: 'var(--cc-text-muted)',
-            }}
-          >
-            Challenges
-          </button>
-          <button
-            type="button"
-            className="cc-btn"
-            onClick={() => setOpen(false)}
-            aria-label="Close"
-            style={{ minWidth: 44, minHeight: 34, color: 'var(--cc-text-muted)' }}
-          >
-            ✕
-          </button>
+          {/* Title row + close */}
+          <div className="flex items-center justify-between">
+            <h2
+              style={{
+                fontFamily: 'var(--cc-font-mono)',
+                fontSize: 11,
+                letterSpacing: 2.5,
+                textTransform: 'uppercase',
+                color: 'var(--cc-mint)',
+              }}
+            >
+              Field Guide
+            </h2>
+            <button
+              type="button"
+              className="cc-btn"
+              onClick={() => setOpen(false)}
+              aria-label="Close field guide"
+              style={{ minWidth: 32, minHeight: 28, color: 'var(--cc-text-muted)' }}
+            >
+              ✕
+            </button>
+          </div>
+          {/* Action buttons row */}
+          <div className="flex flex-wrap gap-1">
+            <button
+              type="button"
+              className="cc-btn"
+              onClick={() => setPlantsHidden(h => !h)}
+              style={{
+                fontFamily: 'var(--cc-font-mono)',
+                fontSize: 9,
+                letterSpacing: 1.2,
+                textTransform: 'uppercase',
+                padding: '3px 8px',
+                minHeight: 26,
+                borderRadius: 4,
+                border: plantsHidden ? '1px solid var(--cc-mint)' : '1px solid var(--cc-panel-divider)',
+                color: plantsHidden ? 'var(--cc-mint)' : 'var(--cc-text-muted)',
+              }}
+            >
+              {plantsHidden ? 'Plants hidden' : 'Hide plants'}
+            </button>
+            <button
+              type="button"
+              className="cc-btn"
+              onClick={() => { setWorkshopOpen(true) }}
+              style={{
+                fontFamily: 'var(--cc-font-mono)',
+                fontSize: 9,
+                letterSpacing: 1.2,
+                textTransform: 'uppercase',
+                padding: '3px 8px',
+                minHeight: 26,
+                borderRadius: 4,
+                border: '1px solid var(--cc-panel-divider)',
+                color: 'var(--cc-text-muted)',
+              }}
+            >
+              Workshop
+            </button>
+            <button
+              type="button"
+              className="cc-btn"
+              onClick={() => { setChallengesOpen(true) }}
+              style={{
+                fontFamily: 'var(--cc-font-mono)',
+                fontSize: 9,
+                letterSpacing: 1.2,
+                textTransform: 'uppercase',
+                padding: '3px 8px',
+                minHeight: 26,
+                borderRadius: 4,
+                border: '1px solid var(--cc-panel-divider)',
+                color: 'var(--cc-text-muted)',
+              }}
+            >
+              Challenges
+            </button>
+          </div>
         </div>
 
         {hasRecords && (
@@ -366,6 +370,8 @@ export function FieldGuide() {
                 const code = btoa(JSON.stringify(bp))
                 navigator.clipboard.writeText(code).catch(() => {})
               }}
+              thumbs={populationItems.filter(t => t.blueprintId === bp.id)}
+              onLocateCreature={requestLocateCreature}
             />
           ))}
         </ul>
@@ -588,7 +594,7 @@ export function FieldGuide() {
 
         <ImportSection addBlueprint={addBlueprint} />
       </div>
-    </div>
+    </aside>
   )
 }
 
@@ -654,6 +660,8 @@ function GuideEntry({
   maxGeneration,
   onLocate,
   onCopyCode,
+  thumbs,
+  onLocateCreature,
 }: {
   bp: CreatureBlueprint
   alive: number
@@ -661,15 +669,53 @@ function GuideEntry({
   maxGeneration: number
   onLocate?: () => void
   onCopyCode?: () => void
+  thumbs?: CreatureThumb[]
+  onLocateCreature?: (id: number) => void
 }) {
   const eats = blueprints.filter(other => canEat(bp, other))
   const eatenBy = blueprints.filter(other => canEat(other, bp))
+  const bpColor = Object.values(bp.art.palette)[0] ?? '#888888'
 
   return (
     <li
-      className="flex gap-3 px-4 py-3"
       style={{ borderBottom: '1px solid var(--cc-panel-divider)' }}
     >
+      {thumbs && thumbs.length > 0 && onLocateCreature && (
+        <div
+          className="flex flex-wrap gap-1 px-3 pt-2"
+          role="group"
+          aria-label={`${bp.name} population — ${thumbs.length} alive`}
+        >
+          {thumbs.map(t => (
+            <button
+              key={t.id}
+              type="button"
+              className="cc-btn"
+              title={
+                t.name
+                  ? `${t.name} · ${Math.round(t.ageSeconds)}s`
+                  : `${Math.round(t.ageSeconds)}s`
+              }
+              onClick={() => onLocateCreature(t.id)}
+              style={{
+                width: 14,
+                height: 14,
+                borderRadius: '50%',
+                background: bpColor,
+                border: t.name ? '2px solid gold' : '1px solid rgba(0,0,0,0.3)',
+                padding: 0,
+                flexShrink: 0,
+              }}
+              aria-label={
+                t.name
+                  ? `${t.name}, age ${Math.round(t.ageSeconds)}s`
+                  : `${bp.name}, age ${Math.round(t.ageSeconds)}s`
+              }
+            />
+          ))}
+        </div>
+      )}
+      <div className="flex gap-3 px-4 py-3">
       <div className="shrink-0 pt-0.5">
         <CreaturePortrait blueprint={bp} size={40} />
       </div>
@@ -815,7 +861,8 @@ function GuideEntry({
           })()}
         </p>
       </div>
-    </li>
+    </div>
+  </li>
   )
 }
 

--- a/src/app/micro-land/domain/types.ts
+++ b/src/app/micro-land/domain/types.ts
@@ -727,3 +727,15 @@ export interface HistoryEntry {
   killerBlueprintId?: string
   killerSpeciesName?: string
 }
+
+/**
+ * A minimal snapshot of one living creature, used to render the population
+ * viewer circles in the Field Guide sidebar.
+ */
+export interface CreatureThumb {
+  id: number
+  blueprintId: string
+  ageSeconds: number
+  /** Player-given name, or null for unnamed individuals. */
+  name: string | null
+}

--- a/src/app/micro-land/game-instance.ts
+++ b/src/app/micro-land/game-instance.ts
@@ -58,6 +58,7 @@ import { TUNING } from './domain/tuning'
 import {
   type Creature,
   type CreatureBlueprint,
+  type CreatureThumb,
   type HistoryEntry,
   LIFE_KINDS,
   type LifeKind,
@@ -678,6 +679,17 @@ export class GameInstance {
 
     useMicroLand.getState().setStats(population, this.world.creatures.length, this.world.elapsed)
 
+    // Per-creature thumbnails for the Field Guide population viewer.
+    const thumbs: CreatureThumb[] = this.world.creatures
+      .map(c => ({
+        id: c.id,
+        blueprintId: c.blueprintId,
+        ageSeconds: c.ageSeconds,
+        name: c.name,
+      }))
+      .sort((a, b) => b.ageSeconds - a.ageSeconds)
+    useMicroLand.getState().setPopulationItems(thumbs)
+
     // Speed run win/loss detection
     const sr = useMicroLand.getState().speedRun
     if (sr.active && sr.result === 'none') {
@@ -1237,6 +1249,20 @@ export class GameInstance {
     const creature = this.world.creatures.find(c => c.blueprintId === blueprintId)
     if (!creature) return false
     this.renderer.centerOn(creature.x, creature.y)
+    return true
+  }
+
+  /**
+   * Center the camera on a specific creature by id and open the Inspector for it.
+   * Returns false if the creature is no longer alive.
+   */
+  inspectCreature(id: number): boolean {
+    const creature = this.world.creatures.find(c => c.id === id)
+    if (!creature) return false
+    this.inspectedId = id
+    this.following = true
+    this.renderer.centerOn(creature.x, creature.y)
+    this.pushInspected()
     return true
   }
 

--- a/src/app/micro-land/store.ts
+++ b/src/app/micro-land/store.ts
@@ -32,7 +32,7 @@ export interface SpeedRunState {
 
 import type { SaveState } from './chronicle/chronicle'
 import type { ElderRecord, SpeciesRecord } from './chronicle/types'
-import type { Creature, CreatureBlueprint, HistoryEntry, LifeKind, MaterialId, NamedCreatureEntry, Traits } from './domain/types'
+import type { Creature, CreatureBlueprint, CreatureThumb, HistoryEntry, LifeKind, MaterialId, NamedCreatureEntry, Traits } from './domain/types'
 import type { ShelfState } from './worlds/shelf'
 
 /** One entry in the time-lapse snapshot ring buffer. */
@@ -370,6 +370,16 @@ interface MicroLandState {
   requestLocate: (blueprintId: string) => void
 
   /**
+   * Per-creature thumbnail data for the Field Guide sidebar population viewer.
+   * Sorted longest-living → shortest. Updated by pushStats() each tick.
+   */
+  populationItems: CreatureThumb[]
+  setPopulationItems: (items: CreatureThumb[]) => void
+  /** Set when the Field Guide circle is clicked — game instance centers + inspects. */
+  locateCreatureRequest: { id: number; serial: number } | null
+  requestLocateCreature: (id: number) => void
+
+  /**
    * When set, the renderer draws each creature with a color overlay based on
    * this trait's value — blue for weak, red for strong. Null means no overlay.
    */
@@ -458,6 +468,7 @@ interface MicroLandState {
 let noticeId = 0
 let pendingId = 0
 let locateSerial = 0
+let locateCreatureSerial = 0
 let historyEntryId = 0
 
 const TOOLBAR_KEY = 'micro-land:toolbar:v1'
@@ -537,6 +548,8 @@ export const useMicroLand = create<MicroLandState>(set => ({
   shelf: { worlds: [], activeId: null, busy: false, error: null },
   worldsOpen: false,
   locateRequest: null,
+  populationItems: [],
+  locateCreatureRequest: null,
   traitOverlay: null,
   replaySnapshots: null,
   replayIndex: 0,
@@ -646,6 +659,9 @@ export const useMicroLand = create<MicroLandState>(set => ({
   setWorldsOpen: worldsOpen => set({ worldsOpen }),
   requestLocate: blueprintId =>
     set({ locateRequest: { blueprintId, serial: ++locateSerial }, guideOpen: false }),
+  setPopulationItems: items => set({ populationItems: items }),
+  requestLocateCreature: id =>
+    set({ locateCreatureRequest: { id, serial: ++locateCreatureSerial } }),
   setTraitOverlay: trait => set(s => ({ traitOverlay: s.traitOverlay === trait ? null : trait })),
   setTrailsEnabled: on => set({ trailsEnabled: on }),
   setSoundEnabled: on => set({ soundEnabled: on }),


### PR DESCRIPTION
## Summary

Converts the Field Guide from a full-screen modal overlay to a 300px collapsible sidebar that **pushes the canvas** narrower rather than overlaying it.

- `MicroLandGame.tsx`: canvas area is now a `flex-row` — the sidebar sits beside the canvas instead of over it
- `FieldGuide` renders as `<aside>` (no scrim, no fixed positioning, no `z-50`)
- Header reorganized for narrow width: title + close on top row, action buttons (Hide plants / Workshop / Challenges) on second row

## Population viewer

Each species entry now shows a row of small colored circles — one per living creature, sorted longest-living → shortest:
- Circle color comes from the blueprint's first palette color
- **Named creatures** get a gold ring border
- Hover tooltip shows age in seconds (and name if named)
- **Click** a circle → centers camera on that creature and opens the Inspector

## Data changes

| File | Change |
|------|--------|
| `types.ts` | Add `CreatureThumb { id, blueprintId, ageSeconds, name }` |
| `store.ts` | Add `populationItems: CreatureThumb[]`, `setPopulationItems`, `locateCreatureRequest`, `requestLocateCreature` |
| `game-instance.ts` | Push thumbs from `pushStats()` each tick; add `inspectCreature(id)` public method |
| `MicroLandGame.tsx` | Handle `locateCreatureRequest` in subscribe block; flex-row layout |

## Test plan
- [ ] Open Field Guide (`f` key or button) — it appears as a sidebar, canvas narrows to fill remaining width
- [ ] Close Field Guide — canvas expands back to full width
- [ ] Species with living creatures show colored circles above the entry
- [ ] Named creature circle has a gold ring
- [ ] Hover a circle — tooltip shows `Name · Ns` or just `Ns`
- [ ] Click a circle — camera centers on that creature, Inspector opens
- [ ] Click dead/gone creature (race condition) — toast says "That creature is no longer with us"

Closes #2895

🤖 Generated with [Claude Code](https://claude.com/claude-code)