### PR TITLE
feat(micro-land): wire roam trait into wander distance and inspector

### DIFF
--- a/src/app/micro-land/components/creature-builder.tsx
+++ b/src/app/micro-land/components/creature-builder.tsx
@@ -147,6 +147,7 @@ export function CreatureBuilder({
   const [onion, setOnion] = useState(true)
   const [planId, setPlanId] = useState<PlanId>('walk')
   const [hop, setHop] = useState(0)
+  const [roam, setRoam] = useState(1)
   const [dietId, setDietId] = useState<DietId>('plant')
   const [glows, setGlows] = useState(false)
   const [fireproof, setFireproof] = useState(false)
@@ -206,6 +207,7 @@ export function CreatureBuilder({
       setName(from.name)
       setPlanId(planOf(from))
       setHop(from.move.hop)
+      setRoam(from.traitDefaults?.roam ?? 1)
       setDietId(dietOf(from))
       setGlows(from.glow > 0)
       setFireproof(from.body.immuneTo.includes('lava'))
@@ -213,6 +215,7 @@ export function CreatureBuilder({
       setName('')
       setPlanId('walk')
       setHop(0)
+      setRoam(1)
       setDietId('plant')
       setGlows(false)
       setFireproof(false)
@@ -323,6 +326,8 @@ export function CreatureBuilder({
     if ((planId === 'walk' || planId === 'hop') && raw.move && typeof raw.move === 'object') {
       ;(raw.move as Record<string, unknown>).hop = hop
     }
+    // Propagate the roam slider into spawned creatures via traitDefaults.
+    raw.traitDefaults = { roam }
     return raw
   }
 
@@ -856,6 +861,58 @@ export function CreatureBuilder({
                           : hop < 0.7
                             ? 'Moves in bounds — part walker, part frog.'
                             : 'Travels entirely in leaps. Always airborne between steps.'}
+                    </p>
+                  </div>
+                )}
+                {planId !== 'root' && (
+                  <div className="mt-3">
+                    <div className="flex items-baseline justify-between gap-2">
+                      <label
+                        htmlFor="creature-builder-roam"
+                        style={{ ...note, color: 'var(--cc-text-default)' }}
+                      >
+                        Roam
+                      </label>
+                      <span
+                        style={{
+                          fontFamily: 'var(--cc-font-mono)',
+                          fontSize: 11,
+                          color: roam !== 1 ? 'var(--cc-mint)' : 'var(--cc-text-muted)',
+                          whiteSpace: 'nowrap',
+                        }}
+                      >
+                        {roam < 0.6
+                          ? 'Homebody'
+                          : roam < 0.9
+                            ? 'Stays close'
+                            : roam < 1.1
+                              ? 'Typical'
+                              : roam < 1.5
+                                ? 'Wide-ranging'
+                                : 'Nomad'}
+                      </span>
+                    </div>
+                    <input
+                      id="creature-builder-roam"
+                      type="range"
+                      min={0.25}
+                      max={2}
+                      step={0.05}
+                      value={roam}
+                      onChange={e => setRoam(Number(e.target.value))}
+                      className="mt-1 w-full"
+                      style={{ accentColor: roam !== 1 ? 'var(--cc-mint)' : undefined, minHeight: 24 }}
+                    />
+                    <p style={{ ...note, marginTop: 2 }}>
+                      {roam < 0.6
+                        ? 'Barely leaves home. Stays very close to where it spawned.'
+                        : roam < 0.9
+                          ? 'Tends to stay nearby. Wanders only a little.'
+                          : roam < 1.1
+                            ? 'Default ranging. Moves about as far as any creature would.'
+                            : roam < 1.5
+                              ? 'Ranges farther than most before turning back home.'
+                              : 'Barely tethered. Will roam very far from its starting point.'}
                     </p>
                   </div>
                 )}

--- a/src/app/micro-land/components/inspector.tsx
+++ b/src/app/micro-land/components/inspector.tsx
@@ -479,13 +479,14 @@ export function Inspector({ onName }: { onName: (name: string) => boolean }) {
         <div className="grid grid-cols-2 gap-x-3 gap-y-1 pt-0.5">
           <Stat label="Size" value={String(bp.size)} />
           <Stat label="Speed" value={inspected.speed.toFixed(1)} />
+          <Stat label="Roam" value={`${(inspected.traits.roam ?? 1).toFixed(2)}×`} />
           {/*
             The evidence under the sentence above. Only the traits that earned a
             phrase are listed, and only as a ratio against the species — "1.24×"
             says what "quicker than most" means without the panel having to
             explain what a hopper's speed is in tiles per second.
           */}
-          {traits.map(t => (
+          {traits.filter(t => t.label !== 'Own roam').map(t => (
             <Stat key={t.label} label={t.label} value={`${t.value.toFixed(2)}×`} />
           ))}
         </div>

--- a/src/app/micro-land/domain/blueprint.ts
+++ b/src/app/micro-land/domain/blueprint.ts
@@ -583,6 +583,14 @@ export function sanitizeBlueprint(
     aura: cleanAura(b.aura),
     glow: clamp(b.glow, 0, 1, 0),
     summoned: opts.summoned ?? false,
+    traitDefaults:
+      b.traitDefaults && typeof b.traitDefaults === 'object'
+        ? {
+            ...((b.traitDefaults as Record<string, unknown>).roam !== undefined && {
+              roam: Number((b.traitDefaults as Record<string, unknown>).roam),
+            }),
+          }
+        : undefined,
   }
 }
 

--- a/src/app/micro-land/domain/sim/creature-sim.ts
+++ b/src/app/micro-land/domain/sim/creature-sim.ts
@@ -1584,8 +1584,9 @@ function steer(w: WorldState, c: Creature, bp: CreatureBlueprint, dt: number, rn
     if (c.drift !== 0 && unliveableAhead(w, c, bp, body, c.drift > 0 ? 1 : -1)) {
       c.drift = -c.drift
     }
-    // Pull toward home when far away.
-    if ((c.traits.territorial ?? 0.5) > 0.2 && Math.abs(c.homeX - c.x) > 15) {
+    // Pull toward home when far away. Roam multiplies the leash distance so
+    // wide-ranging creatures drift further before snapping back.
+    if ((c.traits.territorial ?? 0.5) > 0.2 && Math.abs(c.homeX - c.x) > 15 * (c.traits.roam ?? 1)) {
       c.drift = c.homeX > c.x ? 1 : -1
     }
     wantX = c.drift

--- a/src/app/micro-land/domain/sim/world.ts
+++ b/src/app/micro-land/domain/sim/world.ts
@@ -379,7 +379,9 @@ export function spawnCreature(
     // out and was placed again start over from the blueprint rather than from
     // wherever its last line had drifted to.
     generation: 1,
-    traits: neutralTraits(),
+    traits: bp.traitDefaults
+      ? { ...((bp.move.kind === 'fly' || bp.move.kind === 'swim') ? { ...neutralTraits(), roam: 1.3 } : neutralTraits()), ...bp.traitDefaults }
+      : (bp.move.kind === 'fly' || bp.move.kind === 'swim') ? { ...neutralTraits(), roam: 1.3 } : neutralTraits(),
     name: null,
     huntPassCount: 0,
     poisoned: 0,

--- a/src/app/micro-land/domain/types.ts
+++ b/src/app/micro-land/domain/types.ts
@@ -298,6 +298,12 @@ export interface CreatureBlueprint {
    * for the buff to apply to both.
    */
   symbiosisPartnerId?: string | null
+  /**
+   * Optional trait overrides applied when each instance of this species is first
+   * spawned. The builder uses this to propagate the roam slider into the world
+   * without widening the spawning path.
+   */
+  traitDefaults?: Partial<Traits>
 }
 
 /**


### PR DESCRIPTION
## Summary
- Roam trait now multiplies the home-pull leash in `creature-sim.ts` (base 15 tiles × roam), so wide-ranging creatures actually wander wider before snapping back
- Fly/swim creatures spawn with roam 1.3 instead of neutral 1.0 — they feel naturally more nomadic by default
- Inspector always shows a Roam stat (was only visible when the trait was notable); 'Own roam' is filtered from the notable-traits list to prevent duplication
- CreatureBuilder gains a roam slider for all non-root body plans, wired through `traitDefaults.roam` → `sanitizeBlueprint` → `spawnCreature`

Two supporting type changes: `CreatureBlueprint.traitDefaults?: Partial<Traits>` added to `types.ts`, and `sanitizeBlueprint` passes `traitDefaults.roam` through in `blueprint.ts`.

Closes #2882

## Test plan
- [ ] Spawn a walker with roam maxed (slider far right) — it should drift further from its starting tile before turning back
- [ ] Spawn a flyer — check inspector shows Roam ≈ 1.30 on first creature
- [ ] Open CreatureBuilder, confirm roam slider appears for walk/hop/fly/swim/crawl plans and is absent for root
- [ ] Inspector: create a neutral creature, confirm Roam shows as 1.00× always; roam-notable creature shows value without a second "Own roam" entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)