### PR TITLE
feat(micro-land): complete scent trail navigation with inspector signal

### DIFF
--- a/src/app/micro-land/components/inspector.tsx
+++ b/src/app/micro-land/components/inspector.tsx
@@ -434,6 +434,9 @@ export function Inspector({ onName }: { onName: (name: string) => boolean }) {
               {inspected.targetName}
             </span>
           )}
+          {inspected.followingScent && !trouble && !inspected.targetName && (
+            <span style={{ opacity: 0.65 }}> · following a scent</span>
+          )}
         </div>
 
         {/*

--- a/src/app/micro-land/domain/sim/creature-sim.ts
+++ b/src/app/micro-land/domain/sim/creature-sim.ts
@@ -1071,9 +1071,12 @@ function look(
   }
 
   // Scent following: cooperative creatures follow food beacons left by kin.
-  // Only creatures with cooperation > 0.5 participate — loners ignore signals.
-  if (hungry && !prey && !threat && w.scents.length > 0 &&
-      ((c.traits as { cooperation?: number }).cooperation ?? 0.3) > 0.5) {
+  // Only when wandering and hungry — not while actively fleeing or hunting a
+  // visible target. High cooperation → stronger pull (weight = cooperation × 0.3).
+  const cooperationVal = ((c.traits as { cooperation?: number }).cooperation ?? 0.3)
+  ;(c as { followingScent?: boolean }).followingScent = false
+  if (hungry && !prey && !threat && c.mood === 'wander' && w.scents.length > 0 &&
+      cooperationVal > 0.5) {
     const scentReach2 = sight * sight * 4
     const midX = cx
     const midY = c.y + bh / 2
@@ -1090,7 +1093,12 @@ function look(
       }
     }
     if (nearestScent) {
-      c.drift = nearestScent.x > midX ? 1 : -1
+      // Softer than direct food following: a gentle bias rather than full
+      // commitment. Cooperation scales the strength — a barely-cooperative
+      // creature barely follows, a highly cooperative one follows reliably.
+      const weight = cooperationVal * 0.3
+      c.drift = nearestScent.x > midX ? weight : -weight
+      ;(c as { followingScent?: boolean }).followingScent = true
     }
   }
 

--- a/src/app/micro-land/game-instance.ts
+++ b/src/app/micro-land/game-instance.ts
@@ -1143,6 +1143,7 @@ export class GameInstance {
       traits: { ...c.traits },
       name: c.name,
       isElder: c.id === this.elderId,
+      followingScent: (c as { followingScent?: boolean }).followingScent ?? false,
     })
   }
 

--- a/src/app/micro-land/store.ts
+++ b/src/app/micro-land/store.ts
@@ -85,6 +85,8 @@ export interface Inspected {
   name: string | null
   /** True while this creature holds the land's longevity record. */
   isElder: boolean
+  /** True while this creature is navigating toward a scent left by kin. */
+  followingScent: boolean
 }
 
 /** One column of the guide's record book — see `KindRecord`. */


### PR DESCRIPTION
## Summary
Scent trails were partially wired — cooperative creatures already emitted scents when eating, and `look()` already pointed wanderers toward them. This PR completes the three missing pieces:

- **Mood gating:** Scent following now requires `c.mood === 'wander'` (from the previous tick). Creatures that are fleeing, hunting a visible target, or eating don't get their drift biased by nearby scents.
- **Cooperation as pull weight:** Instead of a binary ±1 drift, the pull is now `cooperation × 0.3`. A barely-cooperative creature (0.51) barely follows (drift 0.15); a highly cooperative one (1.0) follows with drift 0.3. This keeps scent following softer than direct prey tracking.
- **Inspector "following a scent":** When the creature is wander-mood and scent-directed, the inspector shows `· following a scent` alongside the mood text. Clears immediately if the creature switches mood or the scent expires.

Closes #2877

## Test plan
- [ ] Spawn a species with cooperation > 0.5 and watch them eat — open Field Guide → Evolution view → confirm cooperation is above midline
- [ ] In inspector, tap a cooperative wandering creature — when it's near a scent trail, mood line should read "Wandering about · following a scent"
- [ ] Tap a creature with cooperation < 0.5 — it should never show "following a scent"
- [ ] While fleeing, the "following a scent" text should not appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)