### PR TITLE
feat(field-guide): open Challenges inline instead of a separate modal

### DIFF
--- a/src/app/micro-land/components/challenges-panel.tsx
+++ b/src/app/micro-land/components/challenges-panel.tsx
@@ -4,9 +4,12 @@ import { CHALLENGES } from '@/app/micro-land/domain/challenges'
 import { resetTuning, setTuning } from '@/app/micro-land/domain/tuning'
 import { useMicroLand } from '@/app/micro-land/store'
 
-export function ChallengesPanel() {
-  const open = useMicroLand(s => s.challengesOpen)
-  const setChallengesOpen = useMicroLand(s => s.setChallengesOpen)
+/**
+ * The challenges content — usable both inside the field guide sidebar
+ * (where `onClose` returns to the guide view) and inside the standalone
+ * modal (`ChallengesPanel`).
+ */
+export function ChallengesPane({ onClose }: { onClose: () => void }) {
   const setChallengeActive = useMicroLand(s => s.setChallengeActive)
   const requestReshuffle = useMicroLand(s => s.requestReshuffle)
   const [targetGen, setTargetGen] = useState(10)
@@ -16,15 +19,163 @@ export function ChallengesPanel() {
   const elapsed = useMicroLand(s => s.elapsed)
   const speedRun = useMicroLand(s => s.speedRun)
 
-  if (!open) return null
-
   function startChallenge(preset: (typeof CHALLENGES)[number]) {
     resetTuning()
     setTuning(preset.tuning)
     setChallengeActive({ name: preset.name, goal: preset.goal })
     requestReshuffle()
-    setChallengesOpen(false)
+    onClose()
   }
+
+  return (
+    <div style={{ padding: '16px 16px 20px' }}>
+      <h2
+        style={{
+          fontFamily: 'var(--cc-font-mono)',
+          fontSize: 11,
+          letterSpacing: 1.6,
+          textTransform: 'uppercase',
+          color: 'var(--cc-text-muted)',
+          marginBottom: 16,
+        }}
+      >
+        Challenges
+      </h2>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+        {CHALLENGES.map(c => (
+          <button
+            key={c.id}
+            type="button"
+            className="cc-btn"
+            onClick={() => startChallenge(c)}
+            style={{
+              display: 'block',
+              textAlign: 'left',
+              padding: '10px 14px',
+              border: '1px solid var(--cc-mint-line)',
+              borderRadius: 6,
+              background: 'transparent',
+            }}
+          >
+            <div
+              style={{
+                fontFamily: 'var(--cc-font-mono)',
+                fontSize: 11,
+                letterSpacing: 1.2,
+                textTransform: 'uppercase',
+                color: 'var(--cc-mint)',
+                marginBottom: 3,
+              }}
+            >
+              {c.name}
+            </div>
+            <div style={{ fontSize: 12, color: 'var(--cc-text-muted)', marginBottom: 4 }}>
+              {c.blurb}
+            </div>
+            <div
+              style={{
+                fontSize: 10,
+                fontFamily: 'var(--cc-font-mono)',
+                color: 'var(--cc-text-muted)',
+                opacity: 0.7,
+              }}
+            >
+              Goal: {c.goal}
+            </div>
+          </button>
+        ))}
+      </div>
+      <div style={{ marginTop: 18, borderTop: '1px solid var(--cc-panel-divider)', paddingTop: 14 }}>
+        <div style={{
+          fontFamily: 'var(--cc-font-mono)', fontSize: 10, letterSpacing: 1.6,
+          textTransform: 'uppercase', color: 'var(--cc-text-muted)', marginBottom: 10,
+        }}>
+          Speed Run
+        </div>
+        <div style={{ fontSize: 12, color: 'var(--cc-text-muted)', marginBottom: 10 }}>
+          Race to keep a lineage alive to generation {targetGen} within the time limit.
+        </div>
+        <div style={{ display: 'flex', gap: 8, marginBottom: 8, flexWrap: 'wrap' }}>
+          {[10, 20, 30].map(g => (
+            <button
+              key={g}
+              type="button"
+              className="cc-btn"
+              onClick={() => setTargetGen(g)}
+              style={{
+                fontFamily: 'var(--cc-font-mono)', fontSize: 10, letterSpacing: 1,
+                textTransform: 'uppercase', padding: '3px 10px',
+                border: `1px solid ${targetGen === g ? 'var(--cc-mint)' : 'var(--cc-panel-divider)'}`,
+                color: targetGen === g ? 'var(--cc-mint)' : 'var(--cc-text-muted)',
+              }}
+            >
+              gen {g}
+            </button>
+          ))}
+        </div>
+        <div style={{ display: 'flex', gap: 8, marginBottom: 12, flexWrap: 'wrap' }}>
+          {timeLimitOptions.map((opt, i) => (
+            <button
+              key={opt.label}
+              type="button"
+              className="cc-btn"
+              onClick={() => setTimeLimitIdx(i)}
+              style={{
+                fontFamily: 'var(--cc-font-mono)', fontSize: 10, letterSpacing: 1,
+                textTransform: 'uppercase', padding: '3px 10px',
+                border: `1px solid ${timeLimitIdx === i ? 'var(--cc-mint)' : 'var(--cc-panel-divider)'}`,
+                color: timeLimitIdx === i ? 'var(--cc-mint)' : 'var(--cc-text-muted)',
+              }}
+            >
+              {opt.label}
+            </button>
+          ))}
+        </div>
+        <button
+          type="button"
+          className="cc-btn"
+          onClick={() => {
+            startSpeedRun(targetGen, timeLimitOptions[timeLimitIdx].seconds, elapsed)
+            onClose()
+          }}
+          style={{
+            fontFamily: 'var(--cc-font-mono)', fontSize: 10, letterSpacing: 1.2,
+            textTransform: 'uppercase', padding: '5px 14px',
+            border: '1px solid var(--cc-mint)',
+            color: 'var(--cc-mint)',
+            display: 'block',
+          }}
+        >
+          {speedRun.active ? 'Restart Speed Run' : 'Start Speed Run'}
+        </button>
+      </div>
+      <button
+        type="button"
+        className="cc-btn"
+        onClick={onClose}
+        style={{
+          marginTop: 14,
+          fontFamily: 'var(--cc-font-mono)',
+          fontSize: 9,
+          letterSpacing: 1,
+          textTransform: 'uppercase',
+          padding: '4px 10px',
+          border: '1px solid var(--cc-panel-divider)',
+          color: 'var(--cc-text-muted)',
+        }}
+      >
+        Close
+      </button>
+    </div>
+  )
+}
+
+/** Standalone modal — opens from the Challenges keyboard shortcut or the toolbar. */
+export function ChallengesPanel() {
+  const open = useMicroLand(s => s.challengesOpen)
+  const setChallengesOpen = useMicroLand(s => s.setChallengesOpen)
+
+  if (!open) return null
 
   return (
     <div
@@ -44,149 +195,14 @@ export function ChallengesPanel() {
           background: 'var(--cc-panel-bg)',
           border: '1px solid var(--cc-panel-divider)',
           borderRadius: 8,
-          padding: '20px 24px',
           maxWidth: 420,
           width: '90vw',
+          overflowY: 'auto',
+          maxHeight: '90vh',
         }}
         onClick={e => e.stopPropagation()}
       >
-        <h2
-          style={{
-            fontFamily: 'var(--cc-font-mono)',
-            fontSize: 11,
-            letterSpacing: 1.6,
-            textTransform: 'uppercase',
-            color: 'var(--cc-text-muted)',
-            marginBottom: 16,
-          }}
-        >
-          Challenges
-        </h2>
-        <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
-          {CHALLENGES.map(c => (
-            <button
-              key={c.id}
-              type="button"
-              className="cc-btn"
-              onClick={() => startChallenge(c)}
-              style={{
-                display: 'block',
-                textAlign: 'left',
-                padding: '10px 14px',
-                border: '1px solid var(--cc-mint-line)',
-                borderRadius: 6,
-                background: 'transparent',
-              }}
-            >
-              <div
-                style={{
-                  fontFamily: 'var(--cc-font-mono)',
-                  fontSize: 11,
-                  letterSpacing: 1.2,
-                  textTransform: 'uppercase',
-                  color: 'var(--cc-mint)',
-                  marginBottom: 3,
-                }}
-              >
-                {c.name}
-              </div>
-              <div style={{ fontSize: 12, color: 'var(--cc-text-muted)', marginBottom: 4 }}>
-                {c.blurb}
-              </div>
-              <div
-                style={{
-                  fontSize: 10,
-                  fontFamily: 'var(--cc-font-mono)',
-                  color: 'var(--cc-text-muted)',
-                  opacity: 0.7,
-                }}
-              >
-                Goal: {c.goal}
-              </div>
-            </button>
-          ))}
-        </div>
-        <div style={{ marginTop: 18, borderTop: '1px solid var(--cc-panel-divider)', paddingTop: 14 }}>
-          <div style={{
-            fontFamily: 'var(--cc-font-mono)', fontSize: 10, letterSpacing: 1.6,
-            textTransform: 'uppercase', color: 'var(--cc-text-muted)', marginBottom: 10,
-          }}>
-            Speed Run
-          </div>
-          <div style={{ fontSize: 12, color: 'var(--cc-text-muted)', marginBottom: 10 }}>
-            Race to keep a lineage alive to generation {targetGen} within the time limit.
-          </div>
-          <div style={{ display: 'flex', gap: 8, marginBottom: 8, flexWrap: 'wrap' }}>
-            {[10, 20, 30].map(g => (
-              <button
-                key={g}
-                type="button"
-                className="cc-btn"
-                onClick={() => setTargetGen(g)}
-                style={{
-                  fontFamily: 'var(--cc-font-mono)', fontSize: 10, letterSpacing: 1,
-                  textTransform: 'uppercase', padding: '3px 10px',
-                  border: `1px solid ${targetGen === g ? 'var(--cc-mint)' : 'var(--cc-panel-divider)'}`,
-                  color: targetGen === g ? 'var(--cc-mint)' : 'var(--cc-text-muted)',
-                }}
-              >
-                gen {g}
-              </button>
-            ))}
-          </div>
-          <div style={{ display: 'flex', gap: 8, marginBottom: 12, flexWrap: 'wrap' }}>
-            {timeLimitOptions.map((opt, i) => (
-              <button
-                key={opt.label}
-                type="button"
-                className="cc-btn"
-                onClick={() => setTimeLimitIdx(i)}
-                style={{
-                  fontFamily: 'var(--cc-font-mono)', fontSize: 10, letterSpacing: 1,
-                  textTransform: 'uppercase', padding: '3px 10px',
-                  border: `1px solid ${timeLimitIdx === i ? 'var(--cc-mint)' : 'var(--cc-panel-divider)'}`,
-                  color: timeLimitIdx === i ? 'var(--cc-mint)' : 'var(--cc-text-muted)',
-                }}
-              >
-                {opt.label}
-              </button>
-            ))}
-          </div>
-          <button
-            type="button"
-            className="cc-btn"
-            onClick={() => {
-              startSpeedRun(targetGen, timeLimitOptions[timeLimitIdx].seconds, elapsed)
-              setChallengesOpen(false)
-            }}
-            style={{
-              fontFamily: 'var(--cc-font-mono)', fontSize: 10, letterSpacing: 1.2,
-              textTransform: 'uppercase', padding: '5px 14px',
-              border: '1px solid var(--cc-mint)',
-              color: 'var(--cc-mint)',
-              display: 'block',
-            }}
-          >
-            {speedRun.active ? 'Restart Speed Run' : 'Start Speed Run'}
-          </button>
-        </div>
-        <button
-          type="button"
-          className="cc-btn"
-          onClick={() => setChallengesOpen(false)}
-          style={{
-            marginTop: 14,
-            fontFamily: 'var(--cc-font-mono)',
-            fontSize: 9,
-            letterSpacing: 1,
-            textTransform: 'uppercase',
-            padding: '4px 10px',
-            border: '1px solid var(--cc-panel-divider)',
-            color: 'var(--cc-text-muted)',
-          }}
-        >
-          Close
-        </button>
+        <ChallengesPane onClose={() => setChallengesOpen(false)} />
       </div>
     </div>
   )

--- a/src/app/micro-land/components/field-guide.tsx
+++ b/src/app/micro-land/components/field-guide.tsx
@@ -11,6 +11,7 @@ import { useMicroLand, type PopulationSnapshot } from '@/app/micro-land/store'
 import { CreaturePortrait } from './creature-chip'
 import { SparkleIcon } from './sparkle-icon'
 import { WorkshopPane } from './blueprint-workshop'
+import { ChallengesPane } from './challenges-panel'
 
 const sectionHeading: React.CSSProperties = {
   fontFamily: 'var(--cc-font-mono)',
@@ -75,13 +76,12 @@ export function FieldGuide() {
   const worldStats = useMicroLand(s => s.worldStats)
   const namedCreatures = useMicroLand(s => s.namedCreatures)
   const foodWeb = useMicroLand(s => s.foodWeb)
-  const setChallengesOpen = useMicroLand(s => s.setChallengesOpen)
   const populationItems = useMicroLand(s => s.populationItems)
   const requestLocateCreature = useMicroLand(s => s.requestLocateCreature)
   const allBlueprintNames = Object.fromEntries(blueprints.map(b => [b.id, b.name]))
 
   const [plantsHidden, setPlantsHidden] = useState(false)
-  const [view, setView] = useState<'guide' | 'workshop'>('guide')
+  const [view, setView] = useState<'guide' | 'workshop' | 'challenges'>('guide')
 
   if (!open) return null
 
@@ -165,7 +165,7 @@ export function FieldGuide() {
             <button
               type="button"
               className="cc-btn"
-              onClick={() => { setChallengesOpen(true) }}
+              onClick={() => setView('challenges')}
               style={{
                 fontFamily: 'var(--cc-font-mono)',
                 fontSize: 9,
@@ -185,6 +185,10 @@ export function FieldGuide() {
 
         {view === 'workshop' && (
           <WorkshopPane onClose={() => setView('guide')} />
+        )}
+
+        {view === 'challenges' && (
+          <ChallengesPane onClose={() => setView('guide')} />
         )}
 
         {view === 'guide' && hasRecords && (


### PR DESCRIPTION
## Summary
Consistent with the Workshop inline change: the Challenges button in the Field Guide sidebar now replaces the guide content with the challenges list inline. The keyboard shortcut (`c`) still opens the standalone modal.

Extracted `ChallengesPane` from `ChallengesPanel` — thin wrapper pattern identical to `WorkshopPane`/`BlueprintWorkshop`.

Closes #2889

## Test plan
- [ ] Click Challenges in Field Guide sidebar — challenges list appears inline, same sidebar
- [ ] Starting a challenge closes the view and returns to guide
- [ ] Starting a Speed Run closes the view and returns to guide
- [ ] Close button returns to guide view
- [ ] `c` keyboard shortcut still opens the standalone modal
- [ ] Workshop inline still works (not broken by view-type extension)

🤖 Generated with [Claude Code](https://claude.com/claude-code)