### PR TITLE
feat(micro-land): complete territorial behavior feature

### DIFF
--- a/src/app/micro-land/components/creature-builder.tsx
+++ b/src/app/micro-land/components/creature-builder.tsx
@@ -148,6 +148,7 @@ export function CreatureBuilder({
   const [planId, setPlanId] = useState<PlanId>('walk')
   const [hop, setHop] = useState(0)
   const [roam, setRoam] = useState(1)
+  const [territorial, setTerritorial] = useState(0.5)
   const [dietId, setDietId] = useState<DietId>('plant')
   const [glows, setGlows] = useState(false)
   const [fireproof, setFireproof] = useState(false)
@@ -208,6 +209,7 @@ export function CreatureBuilder({
       setPlanId(planOf(from))
       setHop(from.move.hop)
       setRoam(from.traitDefaults?.roam ?? 1)
+      setTerritorial(from.traitDefaults?.territorial ?? 0.5)
       setDietId(dietOf(from))
       setGlows(from.glow > 0)
       setFireproof(from.body.immuneTo.includes('lava'))
@@ -216,6 +218,7 @@ export function CreatureBuilder({
       setPlanId('walk')
       setHop(0)
       setRoam(1)
+      setTerritorial(0.5)
       setDietId('plant')
       setGlows(false)
       setFireproof(false)
@@ -326,8 +329,8 @@ export function CreatureBuilder({
     if ((planId === 'walk' || planId === 'hop') && raw.move && typeof raw.move === 'object') {
       ;(raw.move as Record<string, unknown>).hop = hop
     }
-    // Propagate the roam slider into spawned creatures via traitDefaults.
-    raw.traitDefaults = { roam }
+    // Propagate the roam and territorial sliders into spawned creatures via traitDefaults.
+    raw.traitDefaults = { roam, territorial }
     return raw
   }
 
@@ -913,6 +916,58 @@ export function CreatureBuilder({
                             : roam < 1.5
                               ? 'Ranges farther than most before turning back home.'
                               : 'Barely tethered. Will roam very far from its starting point.'}
+                    </p>
+                  </div>
+                )}
+                {planId !== 'root' && (
+                  <div className="mt-3">
+                    <div className="flex items-baseline justify-between gap-2">
+                      <label
+                        htmlFor="creature-builder-territorial"
+                        style={{ ...note, color: 'var(--cc-text-default)' }}
+                      >
+                        Territorial
+                      </label>
+                      <span
+                        style={{
+                          fontFamily: 'var(--cc-font-mono)',
+                          fontSize: 11,
+                          color: Math.abs(territorial - 0.5) > 0.1 ? 'var(--cc-mint)' : 'var(--cc-text-muted)',
+                          whiteSpace: 'nowrap',
+                        }}
+                      >
+                        {territorial < 0.25
+                          ? 'Drifter'
+                          : territorial < 0.4
+                            ? 'Loose'
+                            : territorial < 0.6
+                              ? 'Typical'
+                              : territorial < 0.85
+                                ? 'Territorial'
+                                : 'Fiercely territorial'}
+                      </span>
+                    </div>
+                    <input
+                      id="creature-builder-territorial"
+                      type="range"
+                      min={0.1}
+                      max={1.4}
+                      step={0.05}
+                      value={territorial}
+                      onChange={e => setTerritorial(Number(e.target.value))}
+                      className="mt-1 w-full"
+                      style={{ accentColor: Math.abs(territorial - 0.5) > 0.1 ? 'var(--cc-mint)' : undefined, minHeight: 24 }}
+                    />
+                    <p style={{ ...note, marginTop: 2 }}>
+                      {territorial < 0.25
+                        ? 'Roams freely, no attachment to any spot.'
+                        : territorial < 0.4
+                          ? 'Wanders widely with only a loose sense of home.'
+                          : territorial < 0.6
+                            ? 'Returns to a general area but doesn\'t defend it.'
+                            : territorial < 0.85
+                              ? 'Defends a territory and chases rivals away.'
+                              : 'Fiercely guards its patch. Will pursue rivals very aggressively.'}
                     </p>
                   </div>
                 )}

--- a/src/app/micro-land/components/inspector.tsx
+++ b/src/app/micro-land/components/inspector.tsx
@@ -483,6 +483,7 @@ export function Inspector({ onName }: { onName: (name: string) => boolean }) {
           <Stat label="Size" value={String(bp.size)} />
           <Stat label="Speed" value={inspected.speed.toFixed(1)} />
           <Stat label="Roam" value={`${(inspected.traits.roam ?? 1).toFixed(2)}×`} />
+          <Stat label="Territorial" value={`${(inspected.traits.territorial ?? 0.5).toFixed(2)}×`} />
           {/*
             The evidence under the sentence above. Only the traits that earned a
             phrase are listed, and only as a ratio against the species — "1.24×"

--- a/src/app/micro-land/domain/sim/creature-sim.ts
+++ b/src/app/micro-land/domain/sim/creature-sim.ts
@@ -415,6 +415,19 @@ export function tickCreatures(
     if ((c as { migrateTimer?: number }).migrateTimer === undefined) c.migrateTimer = 0
     if ((c as { packTimer?: number }).packTimer === undefined) c.packTimer = 0
     if (c.packTimer > 0) c.packTimer = Math.max(0, c.packTimer - dt)
+    // Home drift: territory gradually shifts toward wherever the creature
+    // has been thriving. A hungry creature stays anchored; a well-fed one
+    // slowly claims the area it's actually living in.
+    const hdt = c as { homeDriftTimer?: number }
+    if (hdt.homeDriftTimer === undefined) hdt.homeDriftTimer = 30
+    hdt.homeDriftTimer = Math.max(0, hdt.homeDriftTimer - dt)
+    if (hdt.homeDriftTimer <= 0) {
+      const wellFed = Math.max(0, 0.5 - c.hunger)  // 0 when hungry, up to 0.5 when stuffed
+      const pull = wellFed * 0.3                    // at most 15% shift per 30s tick
+      c.homeX += (c.x - c.homeX) * pull
+      c.homeY += (c.y - c.homeY) * pull
+      hdt.homeDriftTimer = 30
+    }
     if ((c as { stunTimer?: number }).stunTimer === undefined) c.stunTimer = 0
     if (c.stunTimer > 0) c.stunTimer = Math.max(0, c.stunTimer - dt)
     if ((c as { symbiosisTimer?: number }).symbiosisTimer === undefined) c.symbiosisTimer = 0
@@ -1592,9 +1605,11 @@ function steer(w: WorldState, c: Creature, bp: CreatureBlueprint, dt: number, rn
     if (c.drift !== 0 && unliveableAhead(w, c, bp, body, c.drift > 0 ? 1 : -1)) {
       c.drift = -c.drift
     }
-    // Pull toward home when far away. Roam multiplies the leash distance so
-    // wide-ranging creatures drift further before snapping back.
-    if ((c.traits.territorial ?? 0.5) > 0.2 && Math.abs(c.homeX - c.x) > 15 * (c.traits.roam ?? 1)) {
+    // Pull toward home when far away — but not when starving. A creature that
+    // has exhausted its local food must be free to range until it finds more.
+    // Roam multiplies the leash so wide-ranging creatures drift further.
+    if ((c.traits.territorial ?? 0.5) > 0.2 && c.hunger <= 0.6 &&
+        Math.abs(c.homeX - c.x) > 15 * (c.traits.roam ?? 1)) {
       c.drift = c.homeX > c.x ? 1 : -1
     }
     wantX = c.drift

--- a/src/app/micro-land/domain/sim/world.ts
+++ b/src/app/micro-land/domain/sim/world.ts
@@ -351,6 +351,14 @@ export function spawnCreature(
   if (w.creatures.length >= TUNING.maxCreatures) return null
   if (!w.blueprints[bp.id]) w.blueprints[bp.id] = bp
 
+  // Species-specific trait baselines: fly/swim range naturally farther;
+  // meat-eaters are naturally more territorial about their hunting grounds.
+  const spawnBaseTraits = {
+    ...neutralTraits(),
+    ...(bp.move.kind === 'fly' || bp.move.kind === 'swim' ? { roam: 1.3 } : {}),
+    ...(bp.diet.eats.includes('meat') ? { territorial: 0.7 } : {}),
+  }
+
   const creature: Creature = {
     id: w.nextCreatureId++,
     blueprintId: bp.id,
@@ -379,9 +387,7 @@ export function spawnCreature(
     // out and was placed again start over from the blueprint rather than from
     // wherever its last line had drifted to.
     generation: 1,
-    traits: bp.traitDefaults
-      ? { ...((bp.move.kind === 'fly' || bp.move.kind === 'swim') ? { ...neutralTraits(), roam: 1.3 } : neutralTraits()), ...bp.traitDefaults }
-      : (bp.move.kind === 'fly' || bp.move.kind === 'swim') ? { ...neutralTraits(), roam: 1.3 } : neutralTraits(),
+    traits: bp.traitDefaults ? { ...spawnBaseTraits, ...bp.traitDefaults } : spawnBaseTraits,
     name: null,
     huntPassCount: 0,
     poisoned: 0,


### PR DESCRIPTION
## Summary
Five connected improvements to the territorial trait:

- **Hunger releases territory:** Home-pull is now suppressed when `c.hunger > 0.6` — a starving creature is free to roam beyond its patch until it finds food, at which point it re-anchors naturally
- **Territory drifts over lifetime:** `homeDriftTimer` fires every 30s and nudges `homeX`/`homeY` toward the creature's current position, weighted by how well-fed it is (up to 15% shift per tick when stuffed). A thriving creature in a new area gradually claims it
- **Meat-eaters spawn at territorial 0.7:** `spawnBaseTraits` now sets `territorial: 0.7` for any species whose diet includes `'meat'`, so predators are naturally more defensive of their hunting grounds without manual tuning
- **Inspector always shows Territorial:** Added as a fixed stat after Roam (value × format, fallback 0.5 for old saves)
- **CreatureBuilder gains territorial slider:** All non-root plans show the slider (range 0.1–1.4); wired through `traitDefaults` like roam

Closes #2883

## Test plan
- [ ] Starving creature (hunger > 0.6) should drift past its 15-tile home leash without snapping back
- [ ] Well-fed creature in a new area: after ~30s the territory should have shifted toward it (debug with inspector homeX display if available, or observe patrol range)
- [ ] Spawn a carnivore — inspector should show Territorial ≈ 0.70 on first creature
- [ ] Inspector: territorial always visible regardless of whether trait is notable
- [ ] CreatureBuilder: territorial slider shows for walk/hop/fly/swim/crawl, absent for root

🤖 Generated with [Claude Code](https://claude.com/claude-code)