### PR TITLE
feat(micro-land): toxicity/immunity arms race

### DIFF
--- a/src/app/micro-land/domain/config/milestones.ts
+++ b/src/app/micro-land/domain/config/milestones.ts
@@ -29,6 +29,10 @@ export interface MilestoneContext {
   archived: number
   /** How many of those the player summoned. */
   summonedArchived: number
+  /** Highest toxicity trait value among all living creatures. */
+  maxToxicity: number
+  /** Highest immunity trait value among living meat-eaters. */
+  maxPredatorImmunity: number
 }
 
 export interface Milestone {
@@ -97,6 +101,11 @@ export const MILESTONES: Milestone[] = [
     id: 'guide-30',
     text: 'Thirty kinds. The field guide is getting heavy.',
     reached: c => c.archived >= 30,
+  },
+  {
+    id: 'toxicity-arms-race',
+    text: 'A venomous lineage and an immune one, locked in step.',
+    reached: c => c.maxToxicity >= 0.7 && c.maxPredatorImmunity >= 0.5,
   },
 ]
 

--- a/src/app/micro-land/domain/sim/creature-sim.ts
+++ b/src/app/micro-land/domain/sim/creature-sim.ts
@@ -1027,10 +1027,14 @@ function look(
           c.poisoned = Math.max(c.poisoned, obp.toxicity * 5)
         }
         // Trait-level toxicity: venomous prey stuns the predator and cuts the meal.
+        // High immunity in the predator reduces both effects — this is the arms-race
+        // mechanic: toxic lineages and immune lineages co-evolve under mutual pressure.
         const preyToxicity = (other.traits as { toxicity?: number }).toxicity ?? 0
         if (preyToxicity > 0.5) {
-          c.hunger = Math.min(1, c.hunger + TUNING.mealValue * preyToxicity * 0.5)
-          c.stunTimer = Math.max((c as { stunTimer?: number }).stunTimer ?? 0, 1.5)
+          const eatImmunity = (c.traits as { immunity?: number }).immunity ?? 0.2
+          const toxMod = Math.max(0, 1 - eatImmunity * 0.7)
+          c.hunger = Math.min(1, c.hunger + TUNING.mealValue * preyToxicity * 0.5 * toxMod)
+          c.stunTimer = Math.max((c as { stunTimer?: number }).stunTimer ?? 0, 1.5 * toxMod)
         }
         events.push({
           kind: 'ate',

--- a/src/app/micro-land/game-instance.ts
+++ b/src/app/micro-land/game-instance.ts
@@ -929,6 +929,14 @@ export class GameInstance {
       }
     }
 
+    const maxToxicity = w.creatures.reduce(
+      (m, cr) => Math.max(m, (cr.traits as Traits).toxicity ?? 0),
+      0
+    )
+    const maxPredatorImmunity = w.creatures
+      .filter(cr => w.blueprints[cr.blueprintId]?.diet.eats.includes('meat'))
+      .reduce((m, cr) => Math.max(m, (cr.traits as Traits).immunity ?? 0), 0)
+
     this.checkMilestones(archive, {
       elapsed: w.elapsed,
       steadySeconds,
@@ -936,6 +944,8 @@ export class GameInstance {
       generations: deepest,
       speciesAlive: population.length,
       total: w.creatures.length,
+      maxToxicity,
+      maxPredatorImmunity,
     })
 
     this.syncArchive(archive)


### PR DESCRIPTION
## Summary

- Predator immunity now scales down the stun and meal-penalty from eating venomous prey (`toxMod = 1 - immunity × 0.7`), so a high-immunity lineage shrugs off toxins that would paralyze an unresistant predator
- Adds `maxToxicity` and `maxPredatorImmunity` to `MilestoneContext` so milestones can observe the arms race
- New milestone **"A venomous lineage and an immune one, locked in step"** fires when a 0.7+ toxicity creature and a 0.5+ immunity predator coexist — the world noticing that two lineages are shaping each other

Closes #2880

## Test plan
- [ ] Spawn a venomous creature (toxicity > 0.5) and a meat-eater — verify stun still fires
- [ ] Over several generations, check inspector shows immunity drift upward in predator lines under toxic pressure
- [ ] Let world run until milestone fires; verify notice appears in strip and is listed in field guide