### PR TITLE
feat(micro-land): creature life story log in inspector

### DIFF
--- a/src/app/micro-land/components/inspector.tsx
+++ b/src/app/micro-land/components/inspector.tsx
@@ -153,6 +153,7 @@ export function Inspector({ onName }: { onName: (name: string) => boolean }) {
    * makes it true on the same render instead of one render later.
    */
   const [pending, setPending] = useState<{ id: number; text: string } | null>(null)
+  const [lifeOpen, setLifeOpen] = useState(false)
 
   if (!inspected) return null
 
@@ -515,6 +516,56 @@ export function Inspector({ onName }: { onName: (name: string) => boolean }) {
           </strong>{' '}
           {eatenBy.length > 0 ? eatenBy.map(e => e.name).join(', ') : 'nothing here'}
         </div>
+
+        {inspected.lifeLog.length > 0 && (
+          <div>
+            <button
+              type="button"
+              className="cc-btn"
+              onClick={() => setLifeOpen(o => !o)}
+              style={{
+                fontFamily: 'var(--cc-font-mono)',
+                fontSize: 9,
+                letterSpacing: 1.2,
+                textTransform: 'uppercase',
+                color: 'var(--cc-text-muted)',
+                padding: '2px 0',
+                background: 'none',
+                border: 'none',
+                cursor: 'pointer',
+                display: 'flex',
+                alignItems: 'center',
+                gap: 4,
+              }}
+            >
+              <span style={{ opacity: 0.6 }}>{lifeOpen ? '▾' : '▸'}</span>
+              Life story
+            </button>
+            {lifeOpen && (
+              <div style={{ marginTop: 6, display: 'flex', flexDirection: 'column', gap: 3 }}>
+                {inspected.lifeLog.map((entry, i) => (
+                  <div key={i} style={{ display: 'flex', gap: 8, alignItems: 'baseline' }}>
+                    <span
+                      style={{
+                        fontFamily: 'var(--cc-font-mono)',
+                        fontSize: 9,
+                        color: 'var(--cc-text-muted)',
+                        opacity: 0.55,
+                        minWidth: 32,
+                        flexShrink: 0,
+                      }}
+                    >
+                      {Math.round(entry.elapsed)}s
+                    </span>
+                    <span style={{ fontSize: 11, color: 'var(--cc-text-muted)' }}>
+                      {entry.text}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        )}
       </div>
     </div>
   )

--- a/src/app/micro-land/domain/sim/creature-sim.ts
+++ b/src/app/micro-land/domain/sim/creature-sim.ts
@@ -190,6 +190,13 @@ export interface SimEvent {
 
 let tickCount = 0
 
+/** Append a life event to a creature's log (max 20 entries). */
+function logLife(c: Creature, elapsed: number, text: string): void {
+  if (!c.lifeLog) c.lifeLog = []
+  if (c.lifeLog.length >= 20) return
+  c.lifeLog.push({ elapsed, text })
+}
+
 /**
  * The population sorted left to right, reused between ticks.
  *
@@ -646,11 +653,15 @@ export function tickCreatures(
             hatchIn: TUNING.eggHatchSeconds,
           })
           c.children++
+          if (c.children === 1) logLife(c, w.elapsed, 'First offspring')
+          else if (c.children % 10 === 0) logLife(c, w.elapsed, `${c.children} offspring`)
           speciesCount[bp.id] = (speciesCount[bp.id] ?? 0) + 1
           c.breedCooldown = TUNING.breedCooldown
           payForChild(w, c, bp, bw, bh, helpers)
           if (mate) {
             mate.children++
+            if (mate.children === 1) logLife(mate, w.elapsed, 'First offspring')
+            else if (mate.children % 10 === 0) logLife(mate, w.elapsed, `${mate.children} offspring`)
             payForChild(w, mate, bp, bw, bh, helpers)
           }
           events.push({ kind: 'born', blueprintId: bp.id, x: ox, y: oy })
@@ -669,7 +680,10 @@ export function tickCreatures(
             // replaces them, which is what makes "born here" and "put here" two
             // genuinely different things.
             child.traits = inherit(c.traits, mate?.traits ?? null, rng)
+            child.lifeLog = [{ elapsed: w.elapsed, text: `Born (gen ${child.generation})` }]
             c.children++
+            if (c.children === 1) logLife(c, w.elapsed, 'First offspring')
+            else if (c.children % 10 === 0) logLife(c, w.elapsed, `${c.children} offspring`)
             speciesCount[bp.id] = (speciesCount[bp.id] ?? 0) + 1
             if (isPlant) {
               plantsAlive++
@@ -695,6 +709,8 @@ export function tickCreatures(
               payForChild(w, c, bp, bw, bh, helpers)
               if (mate) {
                 mate.children++
+                if (mate.children === 1) logLife(mate, w.elapsed, 'First offspring')
+                else if (mate.children % 10 === 0) logLife(mate, w.elapsed, `${mate.children} offspring`)
                 payForChild(w, mate, bp, bw, bh, helpers)
               }
             }
@@ -728,6 +744,7 @@ export function tickCreatures(
         if (hatchling) {
           hatchling.generation = egg.generation
           hatchling.traits = egg.traits
+          hatchling.lifeLog = [{ elapsed: w.elapsed, text: `Born (gen ${egg.generation})` }]
           events.push({ kind: 'born', blueprintId: ebp.id, x: egg.x, y: egg.y })
         }
       }
@@ -909,6 +926,7 @@ function look(
         c.hunger = Math.max(0, c.hunger - TUNING.mealValue)
         c.starving = 0
         c.mealsEaten++
+        if (c.mealsEaten === 1) logLife(c, w.elapsed, 'First meal')
         // Cooperative creatures signal food location to kin.
         if (((c.traits as { cooperation?: number }).cooperation ?? 0.3) > 0.5 && w.scents.length < 200) {
           w.scents.push({ x: c.x, y: c.y, blueprintId: c.blueprintId, decaySeconds: 10 })
@@ -936,6 +954,7 @@ function look(
         c.hunger = Math.max(0, c.hunger - TUNING.mealValue * 0.6) // eggs are smaller meals
         c.starving = 0
         c.mealsEaten++
+        if (c.mealsEaten === 1) logLife(c, w.elapsed, 'First meal')
         c.mood = 'eat'
         c.targetId = null
         egg.hatchIn = -1 // mark for removal by the hatching block
@@ -1016,6 +1035,7 @@ function look(
         c.hunger = Math.max(0, c.hunger - TUNING.mealValue)
         c.starving = 0
         c.mealsEaten++
+        if (c.mealsEaten === 1) logLife(c, w.elapsed, 'First meal')
         // Cooperative creatures signal food location to kin.
         if (((c.traits as { cooperation?: number }).cooperation ?? 0.3) > 0.5 && w.scents.length < 200) {
           w.scents.push({ x: c.x, y: c.y, blueprintId: c.blueprintId, decaySeconds: 10 })

--- a/src/app/micro-land/domain/types.ts
+++ b/src/app/micro-land/domain/types.ts
@@ -471,6 +471,14 @@ export interface Creature {
   /** Lifetime tally of offspring. */
   children: number
   /**
+   * Key life events in chronological order (max 20).
+   *
+   * Optional so old serialised worlds without it don't crash — always guard
+   * reads with `?? []`. Written by tickCreatures at: birth, first meal,
+   * first offspring, and every 10th offspring.
+   */
+  lifeLog?: Array<{ elapsed: number; text: string }>
+  /**
    * How far back this creature's line goes. 1 was placed or seeded by hand or by
    * the world; anything higher was born here, to a parent one lower.
    *

--- a/src/app/micro-land/game-instance.ts
+++ b/src/app/micro-land/game-instance.ts
@@ -1135,7 +1135,13 @@ export class GameInstance {
 
     const c = this.world.creatures.find(x => x.id === this.inspectedId)
     if (!c) {
-      // It died while we were watching. Let go rather than freezing a corpse.
+      // It died while we were watching. Emit a life-story notice if it logged events.
+      const was = store.inspected
+      if (was && was.lifeLog.length > 0) {
+        const label = was.name ?? (this.world.blueprints[was.blueprintId]?.name ?? 'creature')
+        const events = was.lifeLog.map(e => e.text).join(' · ')
+        store.notify(`${label}: ${events}`)
+      }
       this.inspectedId = null
       this.following = false
       store.setInspected(null)
@@ -1177,6 +1183,7 @@ export class GameInstance {
       name: c.name,
       isElder: c.id === this.elderId,
       followingScent: (c as { followingScent?: boolean }).followingScent ?? false,
+      lifeLog: c.lifeLog ?? [],
     })
   }
 

--- a/src/app/micro-land/store.ts
+++ b/src/app/micro-land/store.ts
@@ -87,6 +87,7 @@ export interface Inspected {
   isElder: boolean
   /** True while this creature is navigating toward a scent left by kin. */
   followingScent: boolean
+  lifeLog: Array<{ elapsed: number; text: string }>
 }
 
 /** One column of the guide's record book — see `KindRecord`. */


### PR DESCRIPTION
## Summary

- Adds `lifeLog?: Array<{ elapsed: number; text: string }>` to `Creature` (guarded with `?? []` throughout — old saves won't crash)
- Events logged per creature: **Born (gen N)** at birth, **First meal** on their first eat, **First offspring** / **N offspring** on breeding milestones
- Inspector shows a collapsible **▸ Life story** section listing each event with its sim-time timestamp
- When the inspected creature dies mid-watch, the life log fires as a notice: `"Zephyr: Born (gen 3) · First meal · First offspring"` — so the player sees it even if the panel is gone
- Log computation is entirely in `tickCreatures` and `pushInspected` — no React overhead when not inspecting

Closes #2871

## Test plan
- [ ] Let a creature age for a minute and verify Born/First meal/First offspring appear in the log
- [ ] Inspect a prolific creature — verify "10 offspring", "20 offspring", etc. appear
- [ ] Kill an inspected creature (via terrain paint) — verify a life-story notice fires
- [ ] Verify creatures placed by hand (gen 1) start with no lifeLog (empty section not rendered)
- [ ] Load an old save — confirm no crash from missing `lifeLog`