### PR TITLE
feat(micro-land): pack hunting cooperation gating and pack size

### DIFF
--- a/src/app/micro-land/components/inspector.tsx
+++ b/src/app/micro-land/components/inspector.tsx
@@ -438,6 +438,9 @@ export function Inspector({ onName }: { onName: (name: string) => boolean }) {
           {inspected.followingScent && !trouble && !inspected.targetName && (
             <span style={{ opacity: 0.65 }}> · following a scent</span>
           )}
+          {inspected.packSize > 1 && inspected.mood === 'hunt' && !trouble && (
+            <span style={{ opacity: 0.65 }}> · pack of {inspected.packSize}</span>
+          )}
         </div>
 
         {/*

--- a/src/app/micro-land/domain/sim/creature-sim.ts
+++ b/src/app/micro-land/domain/sim/creature-sim.ts
@@ -1193,27 +1193,38 @@ function look(
     }
   }
 
-  // Pack hunting: scan for a same-species neighbour targeting the same prey.
-  // When found, both creatures share a brief speed bonus — coordinated attacks
-  // close faster and are harder to flee from.
-  if (prey !== null) {
+  // Pack hunting: scan for same-species neighbours targeting the same prey.
+  //
+  // Cooperation gates participation: creatures with cooperation < 0.2 are
+  // loners and never join. For the rest, count how many pack members share
+  // this target and redirect idle kin with high cooperation toward it.
+  const packCooperation = (c.traits as { cooperation?: number }).cooperation ?? 0.3
+  if (prey !== null && packCooperation >= 0.2) {
     const packReach = sight + bw / 2
     const packLast = cx + packReach + SIGHT_PAD_RIGHT
-    let coordinating = false
+    let packCount = 0
     for (let pi = lowerBound(byX, cx - packReach - SIGHT_PAD_LEFT); pi < byX.length; pi++) {
       const pk = byX[pi]
       if (pk.x > packLast) break
       if (pk.id === c.id) continue
-      if (pk.blueprintId === c.blueprintId && pk.targetId === prey.id) {
-        coordinating = true
-        break
+      if (pk.blueprintId !== c.blueprintId) continue
+      const pkCoop = (pk.traits as { cooperation?: number }).cooperation ?? 0.3
+      if (pk.targetId === prey.id) {
+        packCount++
+      } else if (pkCoop >= 0.4 && pk.targetId === null && pk.mood === 'wander' && packCount > 0) {
+        // Recruit idle, cooperative kin to the pack's target.
+        pk.targetId = prey.id
+        pk.mood = 'hunt'
       }
     }
     // Grant one sense-interval of bonus (plus a little buffer) so it persists
     // until the next pass rather than dropping between ticks.
-    c.packTimer = coordinating ? (SENSE_EVERY / 60) * 2.5 : 0
+    const inPack = packCount > 0
+    c.packTimer = inPack ? (SENSE_EVERY / 60) * 2.5 : 0
+    c.packSize = inPack ? packCount + 1 : 0
   } else {
     c.packTimer = 0
+    c.packSize = 0
   }
 
   if (threat) {

--- a/src/app/micro-land/domain/types.ts
+++ b/src/app/micro-land/domain/types.ts
@@ -539,6 +539,13 @@ export interface Creature {
    */
   packTimer: number
   /**
+   * How many creatures are currently hunting the same prey in this creature's pack.
+   *
+   * 0 = not in a pack. Updated every sense tick alongside packTimer.
+   * Pushed to the inspector so the panel can say "hunting in a pack of 3".
+   */
+  packSize?: number
+  /**
    * Seconds spent standing on quicksand.
    *
    * Walkers slow progressively as this rises (fully stopped at 8 s) and die

--- a/src/app/micro-land/game-instance.ts
+++ b/src/app/micro-land/game-instance.ts
@@ -1184,6 +1184,7 @@ export class GameInstance {
       isElder: c.id === this.elderId,
       followingScent: (c as { followingScent?: boolean }).followingScent ?? false,
       lifeLog: c.lifeLog ?? [],
+      packSize: c.packSize ?? 0,
     })
   }
 

--- a/src/app/micro-land/store.ts
+++ b/src/app/micro-land/store.ts
@@ -88,6 +88,7 @@ export interface Inspected {
   /** True while this creature is navigating toward a scent left by kin. */
   followingScent: boolean
   lifeLog: Array<{ elapsed: number; text: string }>
+  packSize: number
 }
 
 /** One column of the guide's record book — see `KindRecord`. */


### PR DESCRIPTION
## Summary

The foundational pack hunting mechanic (speed bonus when same-species predators share a target) was already in place. This PR completes it:

- **Cooperation gating**: creatures with `cooperation < 0.2` are loners — they never join a pack; those ≥ 0.2 participate normally. This means the cooperation trait now actively shapes hunting behavior.
- **Target sharing**: idle, cooperative (≥ 0.4) kin within the pack leader's sight range are redirected to join the hunt, making packs grow organically.
- **Pack size tracking**: `packSize` is updated each sense tick and pushed to the inspector.
- **Inspector label**: shows `· pack of 3` (or N) on the mood line when the creature is actively hunting in a coordinated group.

Closes #2862

## Test plan
- [ ] Summon multiple carnivores of the same species with high cooperation — verify they coordinate and the inspector shows "pack of N"
- [ ] Summon the same species with cooperation set very low (<0.2) — verify they hunt independently and no pack label appears
- [ ] Watch a pack expand: one creature locks on prey, nearby idle kin redirect and join
- [ ] Verify speed boost still fires when in a pack (existing behavior preserved)