### PR TITLE
feat(micro-land): parasitism infrastructure

### DIFF
--- a/src/app/micro-land/components/inspector.tsx
+++ b/src/app/micro-land/components/inspector.tsx
@@ -441,6 +441,9 @@ export function Inspector({ onName }: { onName: (name: string) => boolean }) {
           {inspected.packSize > 1 && inspected.mood === 'hunt' && !trouble && (
             <span style={{ opacity: 0.65 }}> · pack of {inspected.packSize}</span>
           )}
+          {inspected.hostName && !trouble && (
+            <span style={{ opacity: 0.65 }}> · riding {inspected.hostName}</span>
+          )}
         </div>
 
         {/*

--- a/src/app/micro-land/components/inspector.tsx
+++ b/src/app/micro-land/components/inspector.tsx
@@ -438,6 +438,9 @@ export function Inspector({ onName }: { onName: (name: string) => boolean }) {
           {inspected.followingScent && !trouble && !inspected.targetName && (
             <span style={{ opacity: 0.65 }}> · following a scent</span>
           )}
+          {inspected.packSize > 1 && inspected.mood === 'hunt' && !trouble && (
+            <span style={{ opacity: 0.65 }}> · pack of {inspected.packSize}</span>
+          )}
         </div>
 
         {/*

--- a/src/app/micro-land/domain/sim/creature-sim.ts
+++ b/src/app/micro-land/domain/sim/creature-sim.ts
@@ -1193,27 +1193,38 @@ function look(
     }
   }
 
-  // Pack hunting: scan for a same-species neighbour targeting the same prey.
-  // When found, both creatures share a brief speed bonus — coordinated attacks
-  // close faster and are harder to flee from.
-  if (prey !== null) {
+  // Pack hunting: scan for same-species neighbours targeting the same prey.
+  //
+  // Cooperation gates participation: creatures with cooperation < 0.2 are
+  // loners and never join. For the rest, count how many pack members share
+  // this target and redirect idle kin with high cooperation toward it.
+  const packCooperation = (c.traits as { cooperation?: number }).cooperation ?? 0.3
+  if (prey !== null && packCooperation >= 0.2) {
     const packReach = sight + bw / 2
     const packLast = cx + packReach + SIGHT_PAD_RIGHT
-    let coordinating = false
+    let packCount = 0
     for (let pi = lowerBound(byX, cx - packReach - SIGHT_PAD_LEFT); pi < byX.length; pi++) {
       const pk = byX[pi]
       if (pk.x > packLast) break
       if (pk.id === c.id) continue
-      if (pk.blueprintId === c.blueprintId && pk.targetId === prey.id) {
-        coordinating = true
-        break
+      if (pk.blueprintId !== c.blueprintId) continue
+      const pkCoop = (pk.traits as { cooperation?: number }).cooperation ?? 0.3
+      if (pk.targetId === prey.id) {
+        packCount++
+      } else if (pkCoop >= 0.4 && pk.targetId === null && pk.mood === 'wander' && packCount > 0) {
+        // Recruit idle, cooperative kin to the pack's target.
+        pk.targetId = prey.id
+        pk.mood = 'hunt'
       }
     }
     // Grant one sense-interval of bonus (plus a little buffer) so it persists
     // until the next pass rather than dropping between ticks.
-    c.packTimer = coordinating ? (SENSE_EVERY / 60) * 2.5 : 0
+    const inPack = packCount > 0
+    c.packTimer = inPack ? (SENSE_EVERY / 60) * 2.5 : 0
+    c.packSize = inPack ? packCount + 1 : 0
   } else {
     c.packTimer = 0
+    c.packSize = 0
   }
 
   if (threat) {

--- a/src/app/micro-land/domain/sim/creature-sim.ts
+++ b/src/app/micro-land/domain/sim/creature-sim.ts
@@ -493,6 +493,22 @@ export function tickCreatures(
       c.starving = Math.max(0, c.starving - dt * 2)
     }
 
+    // --- parasitism: drain host, stay fed, detach when host dies ----------
+    if (c.hostId != null) {
+      const host = findCreature(w, c.hostId)
+      if (!host || dead.has(host.id)) {
+        c.hostId = null // host is dead, detach
+      } else {
+        host.hunger = Math.min(1, host.hunger + 0.018 * dt)
+        if (host.mood === 'wander' || host.mood === 'rest') {
+          host.mood = 'flee'
+          host.targetId = c.id
+        }
+        c.hunger = Math.max(0, c.hunger - 0.015 * dt)
+        c.starving = 0
+      }
+    }
+
     // --- old age --------------------------------------------------------
     if (c.ageSeconds >= lifespanOf(c, bp)) {
       kill(w, c, bp, dead, events, 'aged')
@@ -1030,6 +1046,17 @@ function look(
       // Bodies touching? Eat now, don't bother pathing — camouflage can't save
       // something once the predator is already on top of it.
       const touching = gapX <= BITE_PAD && gapY <= BITE_PAD
+      if (touching && bp.parasite) {
+        // Parasites attach rather than kill — drain the host over time.
+        c.hostId = other.id
+        c.mood = 'eat'
+        c.targetId = null
+        if (other.mood === 'wander' || other.mood === 'rest') {
+          other.mood = 'flee'
+          other.targetId = c.id
+        }
+        return
+      }
       if (touching) {
         devour(w, other, obp, dead, events)
         c.hunger = Math.max(0, c.hunger - TUNING.mealValue)
@@ -1589,6 +1616,19 @@ function steer(w: WorldState, c: Creature, bp: CreatureBlueprint, dt: number, rn
   const body = bodyBox(bp)
   const cx = c.x + bw / 2
   const cy = c.y + bh / 2
+
+  // Attached parasite: snap to host position and return — no other steering.
+  if (c.hostId != null) {
+    const host = findCreature(w, c.hostId)
+    if (host) {
+      c.x = host.x + 0.5  // small offset so they're not perfectly overlapping
+      c.y = host.y - 0.3
+      c.vx = 0
+      c.vy = 0
+      return
+    }
+    c.hostId = null // host gone, detach
+  }
 
   let wantX = 0
   let wantY = 0

--- a/src/app/micro-land/domain/types.ts
+++ b/src/app/micro-land/domain/types.ts
@@ -304,6 +304,12 @@ export interface CreatureBlueprint {
    * without widening the spawning path.
    */
   traitDefaults?: Partial<Traits>
+  /**
+   * When true, this species is parasitic: instead of killing prey on contact,
+   * it attaches and drains the host's energy over time without immediately
+   * killing it. The host's `diet.eats` categories still determine valid hosts.
+   */
+  parasite?: boolean
 }
 
 /**
@@ -470,6 +476,14 @@ export interface Creature {
   mealsEaten: number
   /** Lifetime tally of offspring. */
   children: number
+  /**
+   * The creature the parasite is currently riding.
+   *
+   * Null for non-parasites and unattached parasites. Set by `look()` when the
+   * parasite first contacts a valid host; cleared when the host dies. While set,
+   * the parasite's position is locked near the host and the host's hunger drains.
+   */
+  hostId?: number | null
   /**
    * Key life events in chronological order (max 20).
    *

--- a/src/app/micro-land/domain/types.ts
+++ b/src/app/micro-land/domain/types.ts
@@ -539,6 +539,13 @@ export interface Creature {
    */
   packTimer: number
   /**
+   * How many creatures are currently hunting the same prey in this creature's pack.
+   *
+   * 0 = not in a pack. Updated every sense tick alongside packTimer.
+   * Pushed to the inspector so the panel can say "hunting in a pack of 3".
+   */
+  packSize?: number
+  /**
    * Seconds spent standing on quicksand.
    *
    * Walkers slow progressively as this rises (fully stopped at 8 s) and die

--- a/src/app/micro-land/game-instance.ts
+++ b/src/app/micro-land/game-instance.ts
@@ -1184,6 +1184,7 @@ export class GameInstance {
       isElder: c.id === this.elderId,
       followingScent: (c as { followingScent?: boolean }).followingScent ?? false,
       lifeLog: c.lifeLog ?? [],
+      packSize: c.packSize ?? 0,
     })
   }
 

--- a/src/app/micro-land/game-instance.ts
+++ b/src/app/micro-land/game-instance.ts
@@ -1185,6 +1185,12 @@ export class GameInstance {
       followingScent: (c as { followingScent?: boolean }).followingScent ?? false,
       lifeLog: c.lifeLog ?? [],
       packSize: c.packSize ?? 0,
+      hostName: (() => {
+        const hid = c.hostId
+        if (hid == null) return null
+        const host = this.world.creatures.find(x => x.id === hid)
+        return host ? (this.world.blueprints[host.blueprintId]?.name ?? null) : null
+      })(),
     })
   }
 

--- a/src/app/micro-land/store.ts
+++ b/src/app/micro-land/store.ts
@@ -89,6 +89,7 @@ export interface Inspected {
   followingScent: boolean
   lifeLog: Array<{ elapsed: number; text: string }>
   packSize: number
+  hostName: string | null
 }
 
 /** One column of the guide's record book — see `KindRecord`. */

--- a/src/app/micro-land/store.ts
+++ b/src/app/micro-land/store.ts
@@ -88,6 +88,7 @@ export interface Inspected {
   /** True while this creature is navigating toward a scent left by kin. */
   followingScent: boolean
   lifeLog: Array<{ elapsed: number; text: string }>
+  packSize: number
 }
 
 /** One column of the guide's record book — see `KindRecord`. */


### PR DESCRIPTION
## Summary

Ships the mechanics for parasitic creatures. No blueprint included — players can use the blueprint workshop to create parasitic species.

- **`parasite?: boolean`** on `CreatureBlueprint` — marks a species as parasitic
- **`hostId?: number | null`** on `Creature` — tracks the attached host
- **Attachment** (`look()`): when a parasite touches a valid host, it attaches instead of killing — sets `hostId`, warns the host (mood → flee)
- **Drain** (per-creature tick): while attached, drains host hunger (+0.018/s) and keeps the parasite fed (-0.015/s); detaches automatically when the host dies
- **Position lock** (`steer()`): attached parasite snaps to host position at a small offset; all other movement skipped
- **Inspector**: shows `· riding [species]` when a parasite is attached

Closes #2864

## Test plan
- [ ] Summon a creature with `parasite: true` and a suitable prey species — verify attachment happens on contact
- [ ] While attached, watch the host's hunger meter rise; verify parasite hunger slowly recovers
- [ ] Kill the host (terrain paint, etc.) — verify parasite detaches and resumes normal behavior
- [ ] Inspect an attached parasite — verify "· riding [species]" label appears
- [ ] Verify non-parasite carnivores are unaffected