### PR TITLE
feat(micro-land): trait evolution sparklines in field guide

### DIFF
--- a/src/app/micro-land/components/field-guide.tsx
+++ b/src/app/micro-land/components/field-guide.tsx
@@ -6,7 +6,7 @@ import type { ElderRecord, SpeciesRecord } from '@/app/micro-land/chronicle/type
 import { canEat, isPlantLike, moveWord, sanitizeBlueprint } from '@/app/micro-land/domain/blueprint'
 import { type CreatureBlueprint, type CreatureThumb, type Traits, LIFE_KINDS } from '@/app/micro-land/domain/types'
 import { formatDuration } from '@/app/micro-land/format'
-import { useMicroLand, type PopulationSnapshot } from '@/app/micro-land/store'
+import { useMicroLand, type PopulationSnapshot, type TraitHistoryEntry } from '@/app/micro-land/store'
 
 import { CreaturePortrait } from './creature-chip'
 import { SparkleIcon } from './sparkle-icon'
@@ -80,6 +80,7 @@ export function FieldGuide() {
   const requestLocateCreature = useMicroLand(s => s.requestLocateCreature)
   const compareId = useMicroLand(s => s.compareId)
   const setCompareId = useMicroLand(s => s.setCompareId)
+  const traitHistory = useMicroLand(s => s.traitHistory)
   const allBlueprintNames = Object.fromEntries(blueprints.map(b => [b.id, b.name]))
 
   const [plantsHidden, setPlantsHidden] = useState(false)
@@ -506,6 +507,7 @@ export function FieldGuide() {
               onLocateCreature={requestLocateCreature}
               onCompare={() => handleCompare(bp.id)}
               isComparePin={compareId === bp.id}
+              traitHistory={traitHistory[bp.id]}
             />
           ))}
         </ul>
@@ -800,6 +802,7 @@ function GuideEntry({
   onLocateCreature,
   onCompare,
   isComparePin,
+  traitHistory,
 }: {
   bp: CreatureBlueprint
   alive: number
@@ -811,6 +814,7 @@ function GuideEntry({
   onLocateCreature?: (id: number) => void
   onCompare?: () => void
   isComparePin?: boolean
+  traitHistory?: TraitHistoryEntry[]
 }) {
   const eats = blueprints.filter(other => canEat(bp, other))
   const eatenBy = blueprints.filter(other => canEat(other, bp))
@@ -1022,6 +1026,14 @@ function GuideEntry({
             ) : null
           })()}
         </p>
+
+        {traitHistory && traitHistory.length >= 3 && (
+          <div style={{ marginTop: 8, display: 'flex', gap: 12, alignItems: 'flex-end' }}>
+            <Sparkline data={traitHistory.map(e => e.speed)} label="speed" />
+            <Sparkline data={traitHistory.map(e => e.sight)} label="sight" />
+            <Sparkline data={traitHistory.map(e => e.size)} label="size" />
+          </div>
+        )}
       </div>
     </div>
   </li>
@@ -1253,6 +1265,56 @@ function PopulationGraph({
  * world, and repeating it for a creature that isn't here would be describing a
  * food chain that doesn't exist.
  */
+/**
+ * A tiny inline SVG line graph showing a trait's drift over the last N samples.
+ *
+ * Lines are mint when the trait has drifted > 0.15 from its first recorded value,
+ * dimmed otherwise — the point is to surface meaningful evolution, not noise.
+ */
+function Sparkline({
+  data,
+  label,
+}: {
+  data: number[]
+  label: string
+}) {
+  if (data.length < 3) return null
+  const min = Math.min(...data)
+  const max = Math.max(...data)
+  const range = max - min || 0.001
+  const W = 56
+  const H = 16
+  const points = data
+    .map((v, i) => `${(i / (data.length - 1)) * W},${H - ((v - min) / range) * (H - 2) - 1}`)
+    .join(' ')
+  const drifted = Math.abs(data[data.length - 1] - data[0]) > 0.15
+  const color = drifted ? 'var(--cc-mint)' : 'rgba(255,255,255,0.3)'
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 2 }}>
+      <svg
+        width={W}
+        height={H}
+        style={{ overflow: 'visible' }}
+        aria-label={`${label} trend`}
+      >
+        <polyline points={points} fill="none" stroke={color} strokeWidth={1.5} strokeLinejoin="round" />
+      </svg>
+      <span
+        style={{
+          fontFamily: 'var(--cc-font-mono)',
+          fontSize: 8,
+          letterSpacing: 0.8,
+          textTransform: 'uppercase',
+          color: drifted ? 'var(--cc-mint)' : 'rgba(255,255,255,0.35)',
+        }}
+      >
+        {label}
+      </span>
+    </div>
+  )
+}
+
 function RememberedEntry({ record }: { record: SpeciesRecord }) {
   const bp = record.blueprint
   return (

--- a/src/app/micro-land/game-instance.ts
+++ b/src/app/micro-land/game-instance.ts
@@ -76,6 +76,7 @@ import {
   type FocusedSpeciesStats,
   type KindRecordsView,
   type PopulationEntry,
+  type TraitHistoryEntry,
   useMicroLand,
 } from './store'
 import { releaseActiveWorld, touchActiveWorld } from './worlds/shelf'
@@ -168,6 +169,10 @@ export class GameInstance {
   // --- time-lapse ---
   private snapshotHistory: Array<{ elapsed: number; creatures: Creature[] }> = []
   private lastSnapshotElapsed = -30
+
+  // --- trait evolution history ---
+  private traitHistory = new Map<string, TraitHistoryEntry[]>()
+  private lastTraitSample = -30
 
   // --- records ---
   /** Which land's records are being written to. See `landId()`. */
@@ -756,6 +761,29 @@ export class GameInstance {
     }))
     useMicroLand.getState().setNamedCreatures([...livingNamed, ...deadNamed])
 
+    // Trait evolution history — sample mean traits for each living species every 30s.
+    if (this.world.elapsed - this.lastTraitSample >= 30) {
+      this.lastTraitSample = this.world.elapsed
+      const liveIds = new Set(population.map(p => p.blueprintId))
+      for (const bpId of liveIds) {
+        const members = this.world.creatures.filter(c => c.blueprintId === bpId)
+        if (members.length === 0) continue
+        const avg = (f: (c: Creature) => number) =>
+          members.reduce((s, c) => s + f(c), 0) / members.length
+        const entry: TraitHistoryEntry = {
+          elapsed: this.world.elapsed,
+          speed: avg(c => (c.traits as Traits).speed ?? 1),
+          sight: avg(c => (c.traits as Traits).sight ?? 1),
+          size: avg(c => (c.traits as Traits).size ?? 1),
+        }
+        const prev = this.traitHistory.get(bpId) ?? []
+        this.traitHistory.set(bpId, [...prev.slice(-59), entry])
+      }
+      const flat: Record<string, TraitHistoryEntry[]> = {}
+      for (const [id, hist] of this.traitHistory) flat[id] = hist
+      useMicroLand.getState().setTraitHistory(flat)
+    }
+
     // A running world is different every tick, so there is no cheaper signal
     // than "time passed" to hang the autosave on. The shelf debounces it hard
     // and does nothing at all when no shelved world is open.
@@ -1123,6 +1151,9 @@ export class GameInstance {
     // eventually collide with an unrelated creature and freeze a record's date.
     this.kindElderIds.clear()
     this.lastArchiveSize = -1
+    this.traitHistory.clear()
+    this.lastTraitSample = -30
+    useMicroLand.getState().setTraitHistory({})
   }
 
   /** Copy the watched creature's live state out for the inspector panel. */

--- a/src/app/micro-land/store.ts
+++ b/src/app/micro-land/store.ts
@@ -195,6 +195,14 @@ export interface PopulationSnapshot {
   counts: Record<string, number>
 }
 
+/** One sample in the trait evolution history for a species. */
+export interface TraitHistoryEntry {
+  elapsed: number
+  speed: number
+  sight: number
+  size: number
+}
+
 /** Average trait values for the species the player has focused in the graph. */
 export interface FocusedSpeciesStats {
   blueprintId: string
@@ -403,6 +411,14 @@ interface MicroLandState {
   /** Species pinned for comparison (first selection). */
   compareId: string | null
   setCompareId: (id: string | null) => void
+  /**
+   * Mean trait values sampled every 30s for each living species.
+   *
+   * Ring buffer — at most 60 entries per species. Pushed by game-instance.
+   * Sparse — species that went extinct no longer receive new samples.
+   */
+  traitHistory: Record<string, TraitHistoryEntry[]>
+  setTraitHistory: (h: Record<string, TraitHistoryEntry[]>) => void
   /** Blueprint id of the species clicked in the population graph — drives the detail panel. */
   graphFocusId: string | null
   setGraphFocusId: (id: string | null) => void
@@ -575,6 +591,7 @@ export const useMicroLand = create<MicroLandState>(set => ({
   locateCreatureRequest: null,
   traitOverlay: null,
   compareId: null,
+  traitHistory: {},
   graphFocusId: null,
   focusedSpeciesStats: null,
   replaySnapshots: null,
@@ -690,6 +707,7 @@ export const useMicroLand = create<MicroLandState>(set => ({
     set({ locateCreatureRequest: { id, serial: ++locateCreatureSerial } }),
   setTraitOverlay: trait => set(s => ({ traitOverlay: s.traitOverlay === trait ? null : trait })),
   setCompareId: id => set({ compareId: id }),
+  setTraitHistory: h => set({ traitHistory: h }),
   setGraphFocusId: id => set({ graphFocusId: id, ...(id === null && { focusedSpeciesStats: null }) }),
   setFocusedSpeciesStats: stats => set({ focusedSpeciesStats: stats }),
   setTrailsEnabled: on => set({ trailsEnabled: on }),


### PR DESCRIPTION
## Summary

- Every 30 sim-seconds, game-instance samples mean **speed**, **sight**, and **size** across all living members of each species into a 60-entry ring buffer (`traitHistory` map, never stored in React state directly)
- Field guide species panels show three tiny sparklines once ≥ 3 samples exist
- Lines render **mint** when a trait has drifted > 0.15 from its founding value; **dimmed** otherwise — shows meaningful evolution without noise
- History clears on world change; extinct species stop receiving new samples

Closes #2859

## Test plan
- [ ] Let a world run for ~90s — verify sparklines appear in field guide species entries
- [ ] Let predators outcompete grazers over several minutes — verify speed/sight sparklines trend up in predator lineages
- [ ] Start a new world — verify all sparklines disappear (history reset)
- [ ] Verify extinct species no longer show new samples (their last snapshot stays visible)