### PR TITLE
fix(micro-land): move tools to left column when field guide is open

### DIFF
--- a/src/app/micro-land/MicroLandGame.tsx
+++ b/src/app/micro-land/MicroLandGame.tsx
@@ -53,6 +53,7 @@ export function MicroLandGame() {
   const canvasRef = useRef<HTMLCanvasElement>(null)
   const gameRef = useRef<GameInstance | null>(null)
   const notify = useMicroLand(s => s.notify)
+  const guideOpen = useMicroLand(s => s.guideOpen)
   const { user } = useAuth()
 
   /**
@@ -418,9 +419,11 @@ export function MicroLandGame() {
     <div className="micro-land-shell flex h-full w-full flex-col overflow-hidden">
       <Hud onReshuffle={handleReshuffle} onClearLife={handleClearLife} onOpenHistory={handleOpenHistory} />
 
-      {/* Canvas + Field Guide sidebar share a flex row so the sidebar pushes
-          the canvas narrower rather than overlaying it. */}
+      {/* Canvas + Field Guide (and optionally Tools) share a flex row.
+          When the guide is open the toolbar moves to the left column so the
+          layout reads [ Tools | Canvas | Guide ] instead of overlapping. */}
       <div className="flex min-h-0 flex-1 overflow-hidden">
+        {guideOpen && <Toolbar side onRemoveSpecies={handleRemoveSpecies} />}
         <div className="relative min-w-0 flex-1">
           <canvas
             ref={canvasRef}
@@ -439,7 +442,7 @@ export function MicroLandGame() {
         <FieldGuide />
       </div>
 
-      <Toolbar onRemoveSpecies={handleRemoveSpecies} />
+      {!guideOpen && <Toolbar onRemoveSpecies={handleRemoveSpecies} />}
       <SummonPanel onIntroduce={handleIntroduce} onApplyTerrain={handleApplyTerrain} />
       <WorldsPanel onKeep={handleKeepWorld} onOpen={handleOpenWorld} onForget={handleForgetWorld} />
       <ChallengesPanel />

--- a/src/app/micro-land/components/toolbar.tsx
+++ b/src/app/micro-land/components/toolbar.tsx
@@ -72,7 +72,13 @@ function Chevron({ up }: { up: boolean }) {
   )
 }
 
-export function Toolbar({ onRemoveSpecies }: { onRemoveSpecies: (blueprintId: string) => void }) {
+export function Toolbar({
+  onRemoveSpecies,
+  side = false,
+}: {
+  onRemoveSpecies: (blueprintId: string) => void
+  side?: boolean
+}) {
   const tool = useMicroLand(s => s.tool)
   const setTool = useMicroLand(s => s.setTool)
   const brush = useMicroLand(s => s.brush)
@@ -189,20 +195,32 @@ export function Toolbar({ onRemoveSpecies }: { onRemoveSpecies: (blueprintId: st
    */
   const held = heldTool(tool, blueprints)
 
+  // When the field guide is open the toolbar moves to a left column so the
+  // layout reads as [ Tools | Canvas | Guide ] rather than overlapping it.
+  const Container: React.ElementType = side ? 'aside' : 'footer'
+
   return (
-    <footer
+    <Container
       className="flex flex-col gap-1.5 px-3 pb-3 pt-2"
-      style={{
-        borderTop: '1px solid var(--cc-panel-divider)',
-        background: 'linear-gradient(0deg, var(--cc-panel-grad-from), transparent)',
-      }}
+      style={
+        side
+          ? {
+              width: 240,
+              flexShrink: 0,
+              borderRight: '1px solid var(--cc-panel-divider)',
+              background: 'linear-gradient(270deg, var(--cc-panel-grad-from), transparent)',
+              overflowY: 'auto' as const,
+            }
+          : {
+              borderTop: '1px solid var(--cc-panel-divider)',
+              background: 'linear-gradient(0deg, var(--cc-panel-grad-from), transparent)',
+            }
+      }
     >
       {/*
         The handle, and — while the drawer is open — the brush sizes beside it.
-
-        Sharing one row rather than giving the handle a strip of its own is the
-        whole point: on the phone this exists for, a row spent on a control that
-        only reveals other controls is a row taken off the world.
+        Hidden in side-column mode: the panel is always visible there, so there
+        is nothing to fold away, and the canvas row provides the visual anchor.
 
         Nothing here animates. The canvas is sized by a ResizeObserver on its
         parent and `Renderer.resize` reallocates the backing store every call, so
@@ -210,7 +228,7 @@ export function Toolbar({ onRemoveSpecies }: { onRemoveSpecies: (blueprintId: st
         length of the slide. Instant is also what `prefers-reduced-motion`
         wants, which makes the cheap answer the correct one twice over.
       */}
-      <div className="flex items-center gap-2">
+      {!side && <div className="flex items-center gap-2">
         {open && (
           <>
             <span style={label}>Ground</span>
@@ -312,9 +330,9 @@ export function Toolbar({ onRemoveSpecies }: { onRemoveSpecies: (blueprintId: st
             </>
           )}
         </button>
-      </div>
+      </div>}
 
-      {open && (
+      {(open || side) && (
         <div id="micro-land-tools" className="flex flex-col gap-1.5">
           {/* Terrain palette — collapsed first row + accordion for the rest. */}
           <div className="-mx-1 flex flex-col gap-1 px-1 pb-1">
@@ -710,7 +728,7 @@ export function Toolbar({ onRemoveSpecies }: { onRemoveSpecies: (blueprintId: st
           <div
             role="tabpanel"
             className="-mx-1 flex flex-wrap gap-1.5 overflow-y-auto px-1 pb-1"
-            style={{ maxHeight: '24vh' }}
+            style={{ maxHeight: side ? undefined : '24vh' }}
           >
             {/* Creatures still on their way hold their place at the front of the
             strip, right where the finished one lands.
@@ -846,7 +864,7 @@ export function Toolbar({ onRemoveSpecies }: { onRemoveSpecies: (blueprintId: st
           </div>
         </div>
       )}
-    </footer>
+    </Container>
   )
 }
 


### PR DESCRIPTION
## Summary

- When `guideOpen` is true, renders `<Toolbar side>` as the leftmost child of the canvas flex row instead of a bottom `<footer>`
- Layout becomes `[ Tools | Canvas | Guide ]` rather than the toolbar overlapping the guide
- When the guide is closed, toolbar reverts to the existing collapsible bottom footer

## Implementation

**`toolbar.tsx`**:
- Added `side?: boolean` prop (default `false`)
- Uses `const Container: React.ElementType = side ? 'aside' : 'footer'` to conditionally change the outer element
- Side mode: 240px fixed-width left column, `borderRight`, gradient from left, `overflow-y: auto`, always expanded
- Footer mode: existing behavior unchanged
- Handle row (fold/unfold button) is hidden in side mode — the panel is always visible
- Creature chip list has no `maxHeight` cap in side mode (the whole column scrolls)

**`MicroLandGame.tsx`**:
- Reads `guideOpen` from store
- When `guideOpen`: renders `<Toolbar side>` inside the canvas row, before the canvas div
- When `!guideOpen`: renders `<Toolbar>` after the canvas row (existing footer position)

## Test plan

- [ ] Open the field guide → toolbar appears as a left column, guide as right column, canvas in the middle
- [ ] Close the field guide → toolbar collapses back to bottom footer with fold/unfold behavior
- [ ] All tool interactions (terrain paint, creature selection, Generate/Draw) work in both positions
- [ ] Mobile layout: both columns visible, canvas still scrollable

Closes #2917

🤖 Generated with [Claude Code](https://claude.com/claude-code)