### PR TITLE
feat(micro-land): add reproductionCooldown as heritable evolutionary trait

### DIFF
--- a/src/app/micro-land/domain/sim/creature-sim.ts
+++ b/src/app/micro-land/domain/sim/creature-sim.ts
@@ -672,7 +672,7 @@ export function tickCreatures(
           if (c.children === 1) logLife(c, w.elapsed, 'First offspring')
           else if (c.children % 10 === 0) logLife(c, w.elapsed, `${c.children} offspring`)
           speciesCount[bp.id] = (speciesCount[bp.id] ?? 0) + 1
-          c.breedCooldown = TUNING.breedCooldown
+          c.breedCooldown = TUNING.breedCooldown * ((c.traits as { reproductionCooldown?: number }).reproductionCooldown ?? 1)
           payForChild(w, c, bp, bw, bh, helpers)
           if (mate) {
             mate.children++
@@ -1421,7 +1421,7 @@ function payForChild(
   helpers: Creature[]
 ): void {
   parent.hunger = Math.min(1, parent.hunger + TUNING.breedCost)
-  parent.breedCooldown = TUNING.breedCooldown / auraBoost(w, parent, bp, bw, bh, helpers)
+  parent.breedCooldown = TUNING.breedCooldown * ((parent.traits as { reproductionCooldown?: number }).reproductionCooldown ?? 1) / auraBoost(w, parent, bp, bw, bh, helpers)
   if (parent.mood === 'mate') {
     parent.mood = 'wander'
     parent.targetId = null

--- a/src/app/micro-land/domain/traits.ts
+++ b/src/app/micro-land/domain/traits.ts
@@ -82,6 +82,7 @@ export const NEUTRAL_TRAITS: Traits = Object.freeze({
   cooperation: 0.3,
   diurnal: 0,
   immunity: 0.2,
+  reproductionCooldown: 1,
 })
 
 /** A fresh set for a creature that wasn't born here. Always a copy — it's mutable state. */
@@ -129,7 +130,7 @@ function wrapHue(h: number): number {
 export function inherit(a: Traits, b: Traits | null, rng: Rng): Traits {
   const drift = TUNING.traitDrift
   const hueDrift = drift * HUE_DRIFT_SCALE
-  const mix = (key: 'speed' | 'sight' | 'lifespan' | 'shade' | 'roam' | 'territorial' | 'size' | 'camouflage' | 'toxicity' | 'cooperation' | 'diurnal' | 'immunity') =>
+  const mix = (key: 'speed' | 'sight' | 'lifespan' | 'shade' | 'roam' | 'territorial' | 'size' | 'camouflage' | 'toxicity' | 'cooperation' | 'diurnal' | 'immunity' | 'reproductionCooldown') =>
     b ? (a[key] + b[key]) / 2 : a[key]
 
   return {
@@ -146,6 +147,7 @@ export function inherit(a: Traits, b: Traits | null, rng: Rng): Traits {
     cooperation: clamp(mix('cooperation') + nudge(rng, drift), 0, 1),
     diurnal: clamp(mix('diurnal') + nudge(rng, drift), -1, 1),
     immunity: clamp(mix('immunity') + nudge(rng, drift), 0, 1),
+    reproductionCooldown: clamp(mix('reproductionCooldown') + nudge(rng, drift), TRAIT_MIN, TRAIT_MAX),
   }
 }
 
@@ -279,6 +281,8 @@ export function traitPhrases(t: Traits): string[] {
   else if ((t.diurnal ?? 0) <= -0.5) phrases.push('nocturnal')
   if ((t.immunity ?? 0.2) >= 0.6) phrases.push('disease-resistant')
   else if ((t.immunity ?? 0.2) <= 0.05) phrases.push('susceptible')
+  if ((t.reproductionCooldown ?? 1) <= 1 - NOTABLE) phrases.push('breeds quickly')
+  else if ((t.reproductionCooldown ?? 1) >= 1 + NOTABLE) phrases.push('breeds slowly')
   return phrases
 }
 
@@ -297,5 +301,6 @@ export function notableTraits(t: Traits): { label: string; value: number }[] {
     { label: 'Own lifespan', value: t.lifespan },
     { label: 'Own roam', value: t.roam ?? 1 },
     { label: 'Own size', value: t.size ?? 1 },
+    { label: 'Own breed cooldown', value: t.reproductionCooldown ?? 1 },
   ].filter(entry => Math.abs(entry.value - 1) >= NOTABLE)
 }

--- a/src/app/micro-land/domain/types.ts
+++ b/src/app/micro-land/domain/types.ts
@@ -438,6 +438,16 @@ export interface Traits {
    * resistance over generations. Neutral at 0.2.
    */
   immunity: number
+  /**
+   * Multiplier on the time this creature waits between births.
+   *
+   * Below 1 means a shorter cooldown — fast breeders that swamp food-rich
+   * environments. Above 1 means longer waits — slow breeders that trade
+   * quantity for whatever makes each offspring more likely to survive.
+   * `effectiveCooldown = TUNING.breedCooldown * reproductionCooldown`.
+   * Neutral at 1. Range [TRAIT_MIN, TRAIT_MAX].
+   */
+  reproductionCooldown: number
 }
 
 /** One living thing in the world. */


### PR DESCRIPTION
Closes #2901

## What changed

- **`types.ts`** — Added `reproductionCooldown: number` to the `Traits` interface. Below 1 = faster breeder, above 1 = slower. Neutral at 1.
- **`traits.ts`** — Wired into the full trait pipeline:
  - `NEUTRAL_TRAITS`: starts at 1
  - `inherit()`: blended + nudged each birth, clamped to `[TRAIT_MIN, TRAIT_MAX]`
  - `traitPhrases()`: "breeds quickly" / "breeds slowly" at ±0.1 from neutral
  - `notableTraits()`: "Own breed cooldown" shown in inspector panel when notable
- **`creature-sim.ts`** — Applied at both cooldown-reset sites:
  - Egg-path reset (line 675): `TUNING.breedCooldown × trait`
  - `payForChild()` reset (line 1424): `TUNING.breedCooldown × trait / auraBoost`

## Why

Breeding rate is one of the most ecologically meaningful variables a species can evolve. r/K selection (fast-breeding opportunists vs slow-breeding stable types) is a real dynamic that should emerge from the sim. Previously `breedCooldown` was fixed per-species with no heritable variation — every creature of a species waited exactly the same time.

## Test plan
- [ ] Spawn a world, run for a few minutes — verify inspector shows "breeds quickly"/"breeds slowly" on evolved creatures
- [ ] Confirm the trait drifts visibly in the trait panel over generations
- [ ] Verify old saves still load (trait defaults to 1 via `?? 1` guards)

🤖 Generated with [Claude Code](https://claude.com/claude-code)