### PR TITLE
feat(micro-land): wire camouflage trait into sim and renderer

### DIFF
--- a/src/app/micro-land/domain/sim/creature-sim.ts
+++ b/src/app/micro-land/domain/sim/creature-sim.ts
@@ -1124,7 +1124,9 @@ function look(
       obp.move.kind !== 'root'  // not a plant
     ) {
       const territoryR = (c.traits.territorial ?? 0.5) * 10
-      if (d2 < territoryR * territoryR && d2 < preyDist) {
+      const intruderCamo = (other.traits as { camouflage?: number }).camouflage ?? 0.2
+      const effectiveTerritoryR = territoryR * (1 - intruderCamo * 0.5)
+      if (d2 < effectiveTerritoryR * effectiveTerritoryR && d2 < preyDist) {
         preyDist = d2
         prey = other
         preyDir = dx >= 0 ? 1 : -1

--- a/src/app/micro-land/domain/traits.ts
+++ b/src/app/micro-land/domain/traits.ts
@@ -291,11 +291,15 @@ export function traitPhrases(t: Traits): string[] {
  * being broken.
  */
 export function notableTraits(t: Traits): { label: string; value: number }[] {
-  return [
+  const base = [
     { label: 'Own speed', value: t.speed },
     { label: 'Own sight', value: t.sight },
     { label: 'Own lifespan', value: t.lifespan },
     { label: 'Own roam', value: t.roam ?? 1 },
     { label: 'Own size', value: t.size ?? 1 },
   ].filter(entry => Math.abs(entry.value - 1) >= NOTABLE)
+  // Camouflage uses a custom threshold: notable when it meaningfully affects
+  // detection (>0.4), not when it deviates from 1 (neutral is 0.2, not 1).
+  if ((t.camouflage ?? 0.2) > 0.4) base.push({ label: 'Own camouflage', value: t.camouflage ?? 0.2 })
+  return base
 }

--- a/src/app/micro-land/rendering/renderer.ts
+++ b/src/app/micro-land/rendering/renderer.ts
@@ -920,6 +920,10 @@ export class Renderer {
         const pulse = Math.sin(w.elapsed * 12) * 0.5 + 0.5
         ctx.globalAlpha = 0.45 + pulse * 0.55
       }
+      // Highly camouflaged creatures (>0.6) render slightly transparent —
+      // the visual hint that they're harder to spot.
+      const camo = (c.traits as { camouflage?: number }).camouflage ?? 0.2
+      if (camo > 0.6) ctx.globalAlpha *= 1 - (camo - 0.6) * 0.6
       ctx.drawImage(source, x, y, sw, sh)
       ctx.globalAlpha = 1
 


### PR DESCRIPTION
Closes #2878

## What changed

Three small additions across 3 files:

### `creature-sim.ts` — territorial detection respects camouflage
```typescript
const intruderCamo = (other.traits as { camouflage?: number }).camouflage ?? 0.2
const effectiveTerritoryR = territoryR * (1 - intruderCamo * 0.5)
```
A max-camouflage (0.8) intruder can approach within half the normal territory radius without triggering a chase.

### `traits.ts` — `notableTraits()` surfaces camouflage when it matters
Camouflage > 0.4 now shows in the inspector panel as "Own camouflage". Uses a custom threshold (not the standard ±NOTABLE-from-1 check) because camouflage's neutral value is 0.2, not 1.

### `renderer.ts` — subtle transparency for high-camouflage creatures
```typescript
const camo = (c.traits as { camouflage?: number }).camouflage ?? 0.2
if (camo > 0.6) ctx.globalAlpha *= 1 - (camo - 0.6) * 0.6
```
At max camouflage 0.8: `globalAlpha *= 0.88` — a 12% reduction, a visual hint that blends with the existing flicker effect for starving/drowning creatures.

## What was already there
Food detection already applied camouflage via `detFactor`: still creatures are detected at down to 20% of normal sight range, moving creatures at 76%. No change needed to that path.

## Test plan
- [ ] Spawn two territorial species; add one creature with high camouflage — verify it gets chased later/not at all vs a neutral creature
- [ ] Breed a high-camouflage line; verify "Own camouflage" appears in inspector when value > 0.4
- [ ] Verify high-camouflage creatures look slightly faded compared to neutral ones

🤖 Generated with [Claude Code](https://claude.com/claude-code)