### PR TITLE
feat(micro-land): creature fatigue — rest after sustained sprinting

### DIFF
--- a/src/app/micro-land/components/inspector.tsx
+++ b/src/app/micro-land/components/inspector.tsx
@@ -479,6 +479,13 @@ export function Inspector({ onName }: { onName: (name: string) => boolean }) {
           value={fullness}
           tone={fullness < 0.25 ? 'var(--cc-pink)' : 'var(--cc-mint)'}
         />
+        {inspected.fatigue > 0.1 && (
+          <Meter
+            label="Fatigue"
+            value={inspected.fatigue}
+            tone={inspected.fatigue > 0.8 ? 'var(--cc-pink)' : 'var(--cc-gold)'}
+          />
+        )}
         <Meter
           label="Life left"
           value={lifeLeft}

--- a/src/app/micro-land/domain/sim/creature-sim.ts
+++ b/src/app/micro-land/domain/sim/creature-sim.ts
@@ -561,6 +561,29 @@ export function tickCreatures(
       integrate(w, c, bp, bw, bh, dt, wet, gravityScale)
     }
 
+    // --- fatigue --------------------------------------------------------
+    if (bp.move.kind !== 'root') {
+      const fatigue = c.fatigue ?? 0
+      const isExerting = c.mood === 'hunt' || c.mood === 'flee'
+      const isResting = c.mood === 'rest' || c.mood === 'eat'
+      // Larger creatures have more stamina — high size trait slows fatigue build.
+      const stamina = c.traits.size ?? 1
+      if (isExerting) {
+        c.fatigue = Math.min(1, fatigue + dt * 0.15 / stamina)
+      } else if (isResting) {
+        c.fatigue = Math.max(0, fatigue - dt * 0.2)
+      } else {
+        c.fatigue = Math.max(0, fatigue - dt * 0.1)
+      }
+      // Enter rest when exhausted; exit when sufficiently recovered.
+      if ((c.fatigue ?? 0) >= 0.9 && c.mood !== 'rest') {
+        c.mood = 'rest'
+        c.targetId = null
+      } else if (c.mood === 'rest' && (c.fatigue ?? 0) < 0.2) {
+        c.mood = 'wander'
+      }
+    }
+
     // --- pollination: seed carrying ----------------------------------------
     //
     // Pollinators (aura.helps contains 'plant') pick up a seed when they
@@ -1749,7 +1772,7 @@ function steer(w: WorldState, c: Creature, bp: CreatureBlueprint, dt: number, rn
     ? (1 - Math.cos(2 * Math.PI * w.elapsed / TUNING.dayLengthSeconds)) / 2
     : 0
   const diurnalPenalty = Math.max(0, diurnal > 0 ? diurnal * nightFactor : -diurnal * (1 - nightFactor)) * 0.5
-  const speed = speedOf(c, bp) * (c.poisoned > 0 ? 0.5 : 1) * (c.packTimer > 0 ? 1.2 : 1) * (c.stunTimer > 0 ? 0.2 : 1) * (c.sick > 0 ? 0.7 : 1) * (c.symbiosisTimer > 0 ? 1.15 : 1) / sizeOf(c) * (1 - diurnalPenalty)
+  const speed = speedOf(c, bp) * (c.poisoned > 0 ? 0.5 : 1) * (c.packTimer > 0 ? 1.2 : 1) * (c.stunTimer > 0 ? 0.2 : 1) * (c.sick > 0 ? 0.7 : 1) * (c.symbiosisTimer > 0 ? 1.15 : 1) * (1 - Math.max(0, (c.fatigue ?? 0) - 0.5)) / sizeOf(c) * (1 - diurnalPenalty)
   const accel = speed * 6
 
   switch (bp.move.kind) {

--- a/src/app/micro-land/domain/sim/world.ts
+++ b/src/app/micro-land/domain/sim/world.ts
@@ -399,6 +399,7 @@ export function spawnCreature(
     stunTimer: 0,
     symbiosisTimer: 0,
     sick: 0,
+    fatigue: 0,
     carryingSeed: null,
     seedTimer: 0,
   }

--- a/src/app/micro-land/domain/types.ts
+++ b/src/app/micro-land/domain/types.ts
@@ -591,6 +591,13 @@ export interface Creature {
    * nearby animals within 4 tiles.
    */
   sick: number
+  /**
+   * Sprint fatigue, 0–1. Accumulates while chasing or fleeing; drains while
+   * resting or eating. Above 0.5 it reduces effective speed; at 0.9 the
+   * creature enters 'rest' mood until it recovers. Optional so old saves with
+   * no fatigue data default to 0.
+   */
+  fatigue?: number
 }
 
 /**

--- a/src/app/micro-land/game-instance.ts
+++ b/src/app/micro-land/game-instance.ts
@@ -1202,6 +1202,7 @@ export class GameInstance {
       distress: c.distress,
       starving: c.starving,
       sick: (c as { sick?: number }).sick ?? 0,
+      fatigue: (c as { fatigue?: number }).fatigue ?? 0,
       speed: Math.hypot(c.vx, c.vy),
       inWater: boxLiquidFraction(this.world, c.x, c.y, bw, bh) > 0.3,
       grounded: c.grounded,

--- a/src/app/micro-land/store.ts
+++ b/src/app/micro-land/store.ts
@@ -72,6 +72,8 @@ export interface Inspected {
   starving: number
   /** Seconds of disease remaining; 0 when healthy. */
   sick: number
+  /** Sprint fatigue 0–1; 0 when rested. */
+  fatigue: number
   speed: number
   inWater: boolean
   grounded: boolean


### PR DESCRIPTION
Closes #2866

## What changed

6 files:

### `types.ts` — new `fatigue?: number` on Creature
Optional (defaults to 0) so old saves don't crash.

### `world.ts` — initialize `fatigue: 0` in spawnCreature

### `creature-sim.ts` — two changes
**Fatigue tick block** (added after movement):
- Accumulates +0.15/s while `mood === 'hunt' | 'flee'`
- Drains -0.2/s while `mood === 'rest' | 'eat'`, -0.1/s otherwise
- Rate divided by `size` trait — bigger creatures have more stamina
- At fatigue ≥ 0.9: enters `'rest'` mood (creature stops, fatigue drains 2× faster)
- At fatigue < 0.2 while resting: returns to `'wander'`

**Speed formula** (in steer):
```typescript
* (1 - Math.max(0, (c.fatigue ?? 0) - 0.5))
```
No penalty below 0.5; linear reduction to 50% at full fatigue.

### `store.ts` — `fatigue: number` in Inspected interface

### `game-instance.ts` — maps `creature.fatigue` into inspector snapshot

### `inspector.tsx` — fatigue meter
```tsx
{inspected.fatigue > 0.1 && (
  <Meter label="Fatigue" value={inspected.fatigue}
    tone={inspected.fatigue > 0.8 ? 'var(--cc-pink)' : 'var(--cc-gold)'} />
)}
```
Gold when moderate, pink when exhausted.

## Test plan
- [ ] Spawn predator + prey, let them chase — predator eventually slows and stops to rest
- [ ] Open inspector on a sprinting creature — fatigue meter appears and fills
- [ ] Verify inspector meter turns pink when creature enters rest mood
- [ ] Verify large-size-trait creatures accumulate fatigue more slowly than small ones
- [ ] Load an old saved world — no crash, fatigue starts at 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)