### PR TITLE
feat(micro-land): species activity heatmap overlay

### DIFF
--- a/src/app/micro-land/components/field-guide.tsx
+++ b/src/app/micro-land/components/field-guide.tsx
@@ -81,6 +81,8 @@ export function FieldGuide() {
   const compareId = useMicroLand(s => s.compareId)
   const setCompareId = useMicroLand(s => s.setCompareId)
   const traitHistory = useMicroLand(s => s.traitHistory)
+  const heatmapBlueprintId = useMicroLand(s => s.heatmapBlueprintId)
+  const setHeatmapBlueprint = useMicroLand(s => s.setHeatmapBlueprint)
   const allBlueprintNames = Object.fromEntries(blueprints.map(b => [b.id, b.name]))
 
   const [plantsHidden, setPlantsHidden] = useState(false)
@@ -540,6 +542,8 @@ export function FieldGuide() {
               isComparePin={compareId === bp.id}
               traitHistory={traitHistory[bp.id]}
               compact={compact}
+              isHeatmap={heatmapBlueprintId === bp.id}
+              onHeatmap={() => setHeatmapBlueprint(heatmapBlueprintId === bp.id ? null : bp.id)}
             />
           ))}
         </ul>
@@ -836,6 +840,8 @@ function GuideEntry({
   isComparePin,
   traitHistory,
   compact,
+  isHeatmap,
+  onHeatmap,
 }: {
   bp: CreatureBlueprint
   alive: number
@@ -849,6 +855,8 @@ function GuideEntry({
   isComparePin?: boolean
   traitHistory?: TraitHistoryEntry[]
   compact?: boolean
+  isHeatmap?: boolean
+  onHeatmap?: () => void
 }) {
   const eats = blueprints.filter(other => canEat(bp, other))
   const eatenBy = blueprints.filter(other => canEat(other, bp))
@@ -941,8 +949,30 @@ function GuideEntry({
               </span>
             )}
           </div>
-          {(onLocate || onCopyCode || onCompare) && (
+          {(onLocate || onCopyCode || onCompare || onHeatmap) && (
             <div className="flex shrink-0 items-center gap-1">
+              {onHeatmap && (
+                <button
+                  type="button"
+                  className="cc-btn"
+                  onClick={onHeatmap}
+                  aria-pressed={isHeatmap}
+                  title={isHeatmap ? 'Turn off heatmap' : 'Show activity heatmap'}
+                  style={{
+                    fontFamily: 'var(--cc-font-mono)',
+                    fontSize: 9,
+                    letterSpacing: 1,
+                    textTransform: 'uppercase',
+                    padding: '3px 7px',
+                    minHeight: 24,
+                    borderRadius: 4,
+                    border: isHeatmap ? '1px solid var(--cc-pink)' : '1px solid var(--cc-mint-line)',
+                    color: isHeatmap ? 'var(--cc-pink)' : 'var(--cc-text-muted)',
+                  }}
+                >
+                  ⬤
+                </button>
+              )}
               {onCompare && (
                 <button
                   type="button"

--- a/src/app/micro-land/game-instance.ts
+++ b/src/app/micro-land/game-instance.ts
@@ -35,7 +35,7 @@ import {
 } from './domain/blueprint'
 import { MILESTONES, type MilestoneContext } from './domain/config/milestones'
 import { DEFAULT_THEME, THEME_BY_ID, type Theme } from './domain/config/themes'
-import { ELDER_MIN_SECONDS, TICK_S, TILE_TICK_EVERY } from './domain/constants'
+import { ELDER_MIN_SECONDS, TICK_S, TILE_TICK_EVERY, WORLD_H, WORLD_W } from './domain/constants'
 import { type SimEvent, emitParticles, tickCreatures } from './domain/sim/creature-sim'
 import { makeRng } from './domain/sim/prng'
 import { tickTiles } from './domain/sim/tile-sim'
@@ -202,6 +202,11 @@ export class GameInstance {
   /** Archive size at the last push, so the guide is only re-sent when it grows. */
   private lastArchiveSize = -1
 
+  // --- heatmap ---
+  private heatmap: Float32Array | null = null
+  private heatmapCurrentBpId: string | null = null
+  private heatmapTickCounter = 0
+
   // --- pointer state ---
   private pointerDown = false
   private grabbed: Creature | null = null
@@ -359,9 +364,9 @@ export class GameInstance {
     if (replaySnapshots && replaySnapshots.length > 0) {
       const snap = replaySnapshots[replayIndex] ?? replaySnapshots[replaySnapshots.length - 1]
       const replayWorld = { ...this.world, creatures: snap.creatures }
-      this.renderer.render(replayWorld, theme, undefined, undefined)
+      this.renderer.render(replayWorld, theme, undefined, undefined, null)
     } else {
-      this.renderer.render(this.world, theme, this.inspectedId, this.elderId)
+      this.renderer.render(this.world, theme, this.inspectedId, this.elderId, this.heatmap)
     }
   }
 
@@ -447,6 +452,28 @@ export class GameInstance {
     }
 
     tickCreatures(w, TICK_S, this.rng, gravity, events)
+
+    // --- heatmap update (every 5 ticks) ---
+    this.heatmapTickCounter++
+    if (this.heatmapTickCounter >= 5) {
+      this.heatmapTickCounter = 0
+      const bpId = useMicroLand.getState().heatmapBlueprintId
+      if (bpId !== this.heatmapCurrentBpId) {
+        this.heatmapCurrentBpId = bpId
+        this.heatmap = bpId ? new Float32Array(WORLD_W * WORLD_H) : null
+      }
+      if (this.heatmap && bpId) {
+        // Decay existing values.
+        for (let i = 0; i < this.heatmap.length; i++) this.heatmap[i] *= 0.995
+        // Stamp each creature of the tracked species.
+        for (const c of w.creatures) {
+          if (c.blueprintId !== bpId) continue
+          const tx = Math.max(0, Math.min(WORLD_W - 1, Math.round(c.x)))
+          const ty = Math.max(0, Math.min(WORLD_H - 1, Math.round(c.y)))
+          this.heatmap[ty * WORLD_W + tx] += 1
+        }
+      }
+    }
   }
 
   /** Turn raw sim events into the occasional human-readable notice. */

--- a/src/app/micro-land/rendering/renderer.ts
+++ b/src/app/micro-land/rendering/renderer.ts
@@ -473,7 +473,8 @@ export class Renderer {
     w: WorldState,
     theme: Theme,
     highlightId: number | null = null,
-    elderId: number | null = null
+    elderId: number | null = null,
+    heatmap: Float32Array | null = null
   ): void {
     const vx = this.viewLeft()
     const vw = Math.min(WORLD_W - vx, Math.ceil(this.viewTiles))
@@ -495,6 +496,7 @@ export class Renderer {
 
     this.drawCarcasses(w, vx, vw)
     this.drawTombstones(w, vx, vw)
+    if (heatmap) this.drawHeatmap(heatmap, vx, vw)
     this.drawEggs(w, vx, vw)
     this.drawCreatures(w, vx, vw)
     this.drawStatusDots(w, vx, vw)
@@ -710,6 +712,30 @@ export class Renderer {
     const top = a + (b - a) * tx
     const bottom = c + (d - c) * tx
     return top + (bottom - top) * ty
+  }
+
+  private drawHeatmap(heatmap: Float32Array, vx: number, vw: number): void {
+    // Find the peak value over visible tiles for normalization.
+    let peak = 0
+    for (let x = vx; x < vx + vw; x++) {
+      for (let y = 0; y < WORLD_H; y++) {
+        const v = heatmap[y * WORLD_W + x]
+        if (v > peak) peak = v
+      }
+    }
+    if (peak < 0.5) return
+
+    const ctx = this.wctx
+    for (let x = vx; x < vx + vw; x++) {
+      for (let y = 0; y < WORLD_H; y++) {
+        const v = heatmap[y * WORLD_W + x]
+        if (v < 0.5) continue
+        ctx.globalAlpha = Math.min(0.5, v / peak)
+        ctx.fillStyle = '#ff3200'
+        ctx.fillRect(x, y, 1, 1)
+      }
+    }
+    ctx.globalAlpha = 1
   }
 
   private drawCarcasses(w: WorldState, vx: number, vw: number): void {

--- a/src/app/micro-land/store.ts
+++ b/src/app/micro-land/store.ts
@@ -430,6 +430,9 @@ interface MicroLandState {
   setFocusedSpeciesStats: (stats: FocusedSpeciesStats | null) => void
   trailsEnabled: boolean
   setTrailsEnabled: (on: boolean) => void
+  /** The species whose activity is shown as a heatmap overlay; null = off. */
+  heatmapBlueprintId: string | null
+  setHeatmapBlueprint: (id: string | null) => void
   soundEnabled: boolean
   setSoundEnabled: (on: boolean) => void
 
@@ -600,6 +603,7 @@ export const useMicroLand = create<MicroLandState>(set => ({
   replaySnapshots: null,
   replayIndex: 0,
   trailsEnabled: false,
+  heatmapBlueprintId: null,
   soundEnabled: false,
 
   setTheme: themeId => set({ themeId }),
@@ -714,6 +718,7 @@ export const useMicroLand = create<MicroLandState>(set => ({
   setGraphFocusId: id => set({ graphFocusId: id, ...(id === null && { focusedSpeciesStats: null }) }),
   setFocusedSpeciesStats: stats => set({ focusedSpeciesStats: stats }),
   setTrailsEnabled: on => set({ trailsEnabled: on }),
+  setHeatmapBlueprint: id => set({ heatmapBlueprintId: id }),
   setSoundEnabled: on => set({ soundEnabled: on }),
 
   enterReplay: snapshots =>


### PR DESCRIPTION
Closes #2879

Replaces PR #2929 (rebased to resolve merge conflict with #2923 compact view).

## What changed

4 files:

### `store.ts`
- `heatmapBlueprintId: string | null` — which species is being tracked
- `setHeatmapBlueprint(id)` — action to toggle on/off (same id = off)

### `game-instance.ts`
- Private `heatmap: Float32Array | null`, `heatmapCurrentBpId`, `heatmapTickCounter`
- Every 5 ticks: reads `heatmapBlueprintId` from store; reallocates `Float32Array(WORLD_W * WORLD_H)` when species changes; decays all values × 0.995; stamps each creature of tracked species at their tile position
- Passes `heatmap` to `renderer.render()`

### `renderer.ts`
- New 5th param `heatmap: Float32Array | null = null` on `render()`
- `private drawHeatmap(heatmap, vx, vw)`: finds peak over visible tiles, skips values < 0.5, draws `rgba(255,50,0, min(0.5, v/peak))` per tile
- Called after tiles/carcasses, before eggs/creatures

### `field-guide.tsx`
- `heatmapBlueprintId` + `setHeatmapBlueprint` store selectors in `FieldGuide`
- Passes `isHeatmap` + `onHeatmap` to each `GuideEntry`
- New ⬤ toggle button in the action row: pink border when active, muted when off
- Clicking active species button turns off the heatmap (toggle behavior)
- Rebased on top of compact view changes from #2923: `compact` prop and `isHeatmap`/`onHeatmap` props coexist

## Test plan
- [ ] Open Field Guide, click ⬤ on a species — red heatmap appears on canvas tracking that species' positions
- [ ] Watch the heatmap accumulate and decay over ~30s
- [ ] Click ⬤ again — heatmap turns off
- [ ] Click ⬤ on a different species — previous heatmap clears, new one starts
- [ ] Verify performance: no noticeable frame drop with a large population

🤖 Generated with [Claude Code](https://claude.com/claude-code)