### PR TITLE
feat(micro-land): unified creature creator — tab navigation between Configure and Draw

### DIFF
--- a/src/app/micro-land/components/blueprint-workshop.tsx
+++ b/src/app/micro-land/components/blueprint-workshop.tsx
@@ -43,6 +43,7 @@ function defaultTraits(): Traits {
 export function WorkshopPane({ onClose }: { onClose: () => void }) {
   const blueprints = useMicroLand(s => s.blueprints)
   const requestWorkshopSpawn = useMicroLand(s => s.requestWorkshopSpawn)
+  const setBuilderOpen = useMicroLand(s => s.setBuilderOpen)
 
   const [step, setStep] = useState<'pick' | 'configure'>('pick')
   const [base, setBase] = useState<CreatureBlueprint | null>(null)
@@ -108,25 +109,50 @@ export function WorkshopPane({ onClose }: { onClose: () => void }) {
 
   return (
     <div style={{ padding: '16px 16px 20px' }}>
-      {/* Header */}
-      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 16 }}>
-        <h2 style={{
-          fontFamily: 'var(--cc-font-mono)', fontSize: 11,
-          letterSpacing: 1.6, textTransform: 'uppercase',
-          color: 'var(--cc-text-muted)', margin: 0,
-        }}>
-          {step === 'pick' ? 'Blueprint Workshop — Pick a Base' : 'Blueprint Workshop — Configure'}
-        </h2>
-        {step === 'configure' && (
+      {/* Tab row + header */}
+      <div style={{ marginBottom: 16 }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 4, marginBottom: 12 }}>
+          <span style={{
+            fontFamily: 'var(--cc-font-mono)', fontSize: 10, letterSpacing: 1.2,
+            textTransform: 'uppercase', padding: '3px 10px', borderRadius: 4,
+            border: '1px solid var(--cc-mint)', color: 'var(--cc-mint)',
+            background: 'rgba(100,220,200,0.08)',
+          }}>
+            Configure
+          </span>
           <button
             type="button"
             className="cc-btn"
-            onClick={() => setStep('pick')}
-            style={{ ...chipBase, border: '1px solid var(--cc-panel-divider)', color: 'var(--cc-text-muted)' }}
+            onClick={() => { setBuilderOpen(true); onClose() }}
+            style={{
+              ...chipBase,
+              border: '1px solid var(--cc-panel-divider)',
+              color: 'var(--cc-text-muted)',
+            }}
+            title="Switch to the pixel drawing tool"
           >
-            ← Back
+            ✎ Draw
           </button>
-        )}
+        </div>
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+          <h2 style={{
+            fontFamily: 'var(--cc-font-mono)', fontSize: 11,
+            letterSpacing: 1.6, textTransform: 'uppercase',
+            color: 'var(--cc-text-muted)', margin: 0,
+          }}>
+            {step === 'pick' ? 'Pick a base species' : 'Configure variant'}
+          </h2>
+          {step === 'configure' && (
+            <button
+              type="button"
+              className="cc-btn"
+              onClick={() => setStep('pick')}
+              style={{ ...chipBase, border: '1px solid var(--cc-panel-divider)', color: 'var(--cc-text-muted)' }}
+            >
+              ← Back
+            </button>
+          )}
+        </div>
       </div>
 
       {step === 'pick' && (

--- a/src/app/micro-land/components/creature-builder.tsx
+++ b/src/app/micro-land/components/creature-builder.tsx
@@ -127,6 +127,7 @@ export function CreatureBuilder({
   const blueprints = useMicroLand(s => s.blueprints)
   const setTool = useMicroLand(s => s.setTool)
   const notify = useMicroLand(s => s.notify)
+  const setWorkshopOpen = useMicroLand(s => s.setWorkshopOpen)
 
   const [draft, setDraft] = useState<Draft | null>(null)
   const [seed, setSeed] = useState<CreatureBlueprint | null>(null)
@@ -464,7 +465,27 @@ export function CreatureBuilder({
           className="flex items-center justify-between px-4 py-3"
           style={{ borderBottom: '1px solid var(--cc-panel-divider)' }}
         >
-          <h2 style={heading}>✎ Creature Builder</h2>
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              className="cc-btn"
+              onClick={() => {
+                abortRef.current?.abort()
+                setWorkshopOpen(true)
+                setOpen(false)
+              }}
+              style={{
+                fontFamily: 'var(--cc-font-mono)', fontSize: 10, letterSpacing: 1.2,
+                textTransform: 'uppercase', padding: '3px 10px', borderRadius: 4,
+                border: '1px solid var(--cc-panel-divider)', color: 'var(--cc-text-muted)',
+                background: 'transparent',
+              }}
+              title="Switch to the stat-based configure tool"
+            >
+              Configure
+            </button>
+            <span style={heading}>✎ Draw</span>
+          </div>
           <button
             type="button"
             className="cc-btn"


### PR DESCRIPTION
Closes #2931

## What changed

**`blueprint-workshop.tsx` (WorkshopPane)**
- Added tab row at the top: "Configure" (active, mint-highlighted) and "✎ Draw" (inactive)
- Clicking "✎ Draw" opens the CreatureBuilder and closes the Workshop
- Title text simplified: "Pick a base species" / "Configure variant"

**`creature-builder.tsx` (CreatureBuilder)**
- Modal header now has "Configure" tab button + "✎ Draw" active label
- Clicking "Configure" closes the builder and opens the Blueprint Workshop

Both tools retain all existing functionality. No internal refactoring.

## Why this approach

Both panels are already full-screen modals with complex internal state. Rather than merging them into one large component (which would require extracting ~1400 lines of pixel-editor logic), this adds navigation so players can switch without returning to the toolbar. The experience is: one entry point, two tabs, no hunting for the right tool.

## Test plan
- [ ] Open Workshop from Field Guide or Toolbar → see "Configure / ✎ Draw" tabs at top
- [ ] Click "✎ Draw" → Workshop closes, Builder opens
- [ ] Click "Configure" in Builder header → Builder closes, Workshop opens
- [ ] Verify both tools still function as before after switching back

🤖 Generated with [Claude Code](https://claude.com/claude-code)