### PR TITLE
feat(micro-land): remove Find and Copy code buttons from Field Guide

### DIFF
--- a/src/app/micro-land/components/field-guide.tsx
+++ b/src/app/micro-land/components/field-guide.tsx
@@ -66,7 +66,6 @@ export function FieldGuide() {
   const archive = useMicroLand(s => s.archive)
   const milestones = useMicroLand(s => s.milestones)
   const populationHistory = useMicroLand(s => s.populationHistory)
-  const requestLocate = useMicroLand(s => s.requestLocate)
   const traitOverlay = useMicroLand(s => s.traitOverlay)
   const setTraitOverlay = useMicroLand(s => s.setTraitOverlay)
   const addBlueprint = useMicroLand(s => s.addBlueprint)
@@ -529,11 +528,6 @@ export function FieldGuide() {
               alive={counts.get(bp.id) ?? 0}
               maxGeneration={genByBp.get(bp.id) ?? 1}
               blueprints={blueprints}
-              onLocate={(counts.get(bp.id) ?? 0) > 0 ? () => requestLocate(bp.id) : undefined}
-              onCopyCode={() => {
-                const code = btoa(JSON.stringify(bp))
-                navigator.clipboard.writeText(code).catch(() => {})
-              }}
               thumbs={populationItems.filter(t => t.blueprintId === bp.id)}
               onLocateCreature={requestLocateCreature}
               onCompare={() => handleCompare(bp.id)}
@@ -828,8 +822,6 @@ function GuideEntry({
   alive,
   blueprints,
   maxGeneration,
-  onLocate,
-  onCopyCode,
   thumbs,
   onLocateCreature,
   onCompare,
@@ -841,8 +833,6 @@ function GuideEntry({
   alive: number
   blueprints: CreatureBlueprint[]
   maxGeneration: number
-  onLocate?: () => void
-  onCopyCode?: () => void
   thumbs?: CreatureThumb[]
   onLocateCreature?: (id: number) => void
   onCompare?: () => void
@@ -941,7 +931,7 @@ function GuideEntry({
               </span>
             )}
           </div>
-          {(onLocate || onCopyCode || onCompare) && (
+          {onCompare && (
             <div className="flex shrink-0 items-center gap-1">
               {onCompare && (
                 <button
@@ -963,48 +953,6 @@ function GuideEntry({
                   }}
                 >
                   ⇄
-                </button>
-              )}
-              {onCopyCode && (
-                <button
-                  type="button"
-                  className="cc-btn"
-                  onClick={onCopyCode}
-                  title="Copy blueprint code to share"
-                  style={{
-                    fontFamily: 'var(--cc-font-mono)',
-                    fontSize: 9,
-                    letterSpacing: 1,
-                    textTransform: 'uppercase',
-                    padding: '3px 8px',
-                    border: '1px solid var(--cc-mint-line)',
-                    color: 'var(--cc-text-muted)',
-                  }}
-                >
-                  Copy code
-                </button>
-              )}
-              {onLocate && (
-                <button
-                  type="button"
-                  className="cc-btn"
-                  onClick={onLocate}
-                  aria-label={`Pan camera to ${bp.name}`}
-                  title="Pan to this creature in the world"
-                  style={{
-                    fontFamily: 'var(--cc-font-mono)',
-                    fontSize: 9,
-                    letterSpacing: 1,
-                    textTransform: 'uppercase',
-                    padding: '3px 7px',
-                    minHeight: 24,
-                    borderRadius: 4,
-                    border: '1px solid var(--cc-mint-line)',
-                    color: 'var(--cc-mint)',
-                    opacity: 0.8,
-                  }}
-                >
-                  Find
                 </button>
               )}
             </div>


### PR DESCRIPTION
Closes #2890
Closes #2891

Removes the "Find" (pan camera to species) and "Copy code" (clipboard export) buttons from the Field Guide species list. Individual creature dot-thumbnails that navigate to specific creatures are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)