### PR TITLE
feat(micro-land): speed run leaderboard — persist and display best times

### DIFF
--- a/src/app/micro-land/components/challenges-panel.tsx
+++ b/src/app/micro-land/components/challenges-panel.tsx
@@ -1,8 +1,10 @@
 'use client'
-import { useState } from 'react'
+import { useState, useMemo } from 'react'
 import { CHALLENGES } from '@/app/micro-land/domain/challenges'
+import { loadSpeedRunRecords } from '@/app/micro-land/domain/speed-run-records'
 import { resetTuning, setTuning } from '@/app/micro-land/domain/tuning'
 import { useMicroLand } from '@/app/micro-land/store'
+import { formatDuration } from '@/app/micro-land/format'
 
 /**
  * The challenges content — usable both inside the field guide sidebar
@@ -18,6 +20,8 @@ export function ChallengesPane({ onClose }: { onClose: () => void }) {
   const startSpeedRun = useMicroLand(s => s.startSpeedRun)
   const elapsed = useMicroLand(s => s.elapsed)
   const speedRun = useMicroLand(s => s.speedRun)
+  const [recordsEpoch, setRecordsEpoch] = useState(0)
+  const records = useMemo(() => loadSpeedRunRecords(targetGen), [targetGen, recordsEpoch])
 
   function startChallenge(preset: (typeof CHALLENGES)[number]) {
     resetTuning()
@@ -136,6 +140,7 @@ export function ChallengesPane({ onClose }: { onClose: () => void }) {
           className="cc-btn"
           onClick={() => {
             startSpeedRun(targetGen, timeLimitOptions[timeLimitIdx].seconds, elapsed)
+            setRecordsEpoch(e => e + 1)
             onClose()
           }}
           style={{
@@ -148,6 +153,32 @@ export function ChallengesPane({ onClose }: { onClose: () => void }) {
         >
           {speedRun.active ? 'Restart Speed Run' : 'Start Speed Run'}
         </button>
+        {records.length > 0 && (
+          <div style={{ marginTop: 14 }}>
+            <div style={{
+              fontFamily: 'var(--cc-font-mono)', fontSize: 9, letterSpacing: 1.2,
+              textTransform: 'uppercase', color: 'var(--cc-text-muted)',
+              opacity: 0.7, marginBottom: 6,
+            }}>
+              Best times — gen {targetGen}
+            </div>
+            <ol style={{ listStyle: 'none', padding: 0, margin: 0, display: 'flex', flexDirection: 'column', gap: 3 }}>
+              {records.slice(0, 5).map((r, i) => (
+                <li
+                  key={i}
+                  style={{
+                    display: 'flex', justifyContent: 'space-between', alignItems: 'baseline',
+                    fontFamily: 'var(--cc-font-mono)', fontSize: 11,
+                    color: i === 0 ? 'var(--cc-gold)' : 'var(--cc-text-muted)',
+                  }}
+                >
+                  <span>{i + 1}. {formatDuration(r.seconds)}</span>
+                  <span style={{ fontSize: 9, opacity: 0.6 }}>{r.theme} · {r.date}</span>
+                </li>
+              ))}
+            </ol>
+          </div>
+        )}
       </div>
       <button
         type="button"

--- a/src/app/micro-land/domain/speed-run-records.ts
+++ b/src/app/micro-land/domain/speed-run-records.ts
@@ -1,0 +1,38 @@
+export interface SpeedRunRecord {
+  theme: string
+  targetGen: number
+  seconds: number
+  date: string
+}
+
+const KEY = 'micro-land:speed-run:records:v1'
+const MAX_PER_TARGET = 10
+
+function loadAll(): Record<string, SpeedRunRecord[]> {
+  try {
+    const raw = localStorage.getItem(KEY)
+    if (!raw) return {}
+    return JSON.parse(raw) as Record<string, SpeedRunRecord[]>
+  } catch {
+    return {}
+  }
+}
+
+export function loadSpeedRunRecords(targetGen: number): SpeedRunRecord[] {
+  return loadAll()[String(targetGen)] ?? []
+}
+
+export function saveSpeedRunRecord(record: SpeedRunRecord): void {
+  try {
+    const all = loadAll()
+    const key = String(record.targetGen)
+    const existing = all[key] ?? []
+    const updated = [...existing, record]
+      .sort((a, b) => a.seconds - b.seconds)
+      .slice(0, MAX_PER_TARGET)
+    all[key] = updated
+    localStorage.setItem(KEY, JSON.stringify(all))
+  } catch {
+    // Private-mode Safari or storage full — silently skip
+  }
+}

--- a/src/app/micro-land/game-instance.ts
+++ b/src/app/micro-land/game-instance.ts
@@ -11,6 +11,7 @@ import {
   terrainToTheme,
 } from '@/app/micro-land/domain/terrain'
 import { SUMMONED_THEME_ID } from '@/app/micro-land/store'
+import { saveSpeedRunRecord } from '@/app/micro-land/domain/speed-run-records'
 
 import {
   archivedSpecies,
@@ -703,6 +704,12 @@ export class GameInstance {
       const timeUsed = this.world.elapsed - sr.startElapsed
       if (deepestGen >= sr.targetGeneration) {
         useMicroLand.getState().endSpeedRun('won')
+        saveSpeedRunRecord({
+          theme: useMicroLand.getState().themeId,
+          targetGen: sr.targetGeneration,
+          seconds: Math.round(timeUsed),
+          date: new Date().toLocaleDateString(),
+        })
       } else if (timeUsed >= sr.timeLimitSeconds || this.world.creatures.length === 0) {
         useMicroLand.getState().endSpeedRun('lost')
       }


### PR DESCRIPTION
Closes #2867

## What changed

**New `domain/speed-run-records.ts`**
- `SpeedRunRecord`: `{ theme, targetGen, seconds, date }`
- `saveSpeedRunRecord(r)`: appends to localStorage key `micro-land:speed-run:records:v1`, keeps top 10 per targetGen, sorted ascending by time
- `loadSpeedRunRecords(targetGen)`: returns stored records for a target generation

**`game-instance.ts`**
- On speed run win: calls `saveSpeedRunRecord` with current theme, targetGen, elapsed time (rounded to seconds), and today's date

**`challenges-panel.tsx`**
- Imports `loadSpeedRunRecords` and `formatDuration`
- Shows "Best times — gen N" below the Start button when records exist
- Top 5 per targetGen; #1 in gold; each entry shows time, theme, date
- `recordsEpoch` state forces a re-read after starting a new run

## Test plan
- [ ] Win a speed run → check localStorage for the record
- [ ] Reopen Challenges panel → best times appear under the target gen
- [ ] Change target gen → list updates to that gen's records
- [ ] Reload page → records persist

🤖 Generated with [Claude Code](https://claude.com/claude-code)