### PR TITLE
fix(micro-land): toolbar stays in world column when field guide is open

### DIFF
--- a/src/app/micro-land/MicroLandGame.tsx
+++ b/src/app/micro-land/MicroLandGame.tsx
@@ -419,30 +419,34 @@ export function MicroLandGame() {
     <div className="micro-land-shell flex h-full w-full flex-col overflow-hidden">
       <Hud onReshuffle={handleReshuffle} onClearLife={handleClearLife} onOpenHistory={handleOpenHistory} />
 
-      {/* Canvas + Field Guide (and optionally Tools) share a flex row.
-          When the guide is open the toolbar moves to the left column so the
-          layout reads [ Tools | Canvas | Guide ] instead of overlapping. */}
-      <div className="flex min-h-0 flex-1 overflow-hidden" style={{ position: 'relative' }}>
-        {guideOpen && <Toolbar side onRemoveSpecies={handleRemoveSpecies} />}
-        <div className="relative min-w-0 flex-1">
-          <canvas
-            ref={canvasRef}
-            // Focusable so the arrow keys reach it. The world is wider than the
-            // screen, and a keyboard has to be able to get to the rest of it.
-            tabIndex={0}
-            className="absolute inset-0 block h-full w-full touch-none focus:outline-none"
-            style={{ imageRendering: 'pixelated', cursor: 'crosshair' }}
-            aria-label="Micro Land world. Tap to place things, drag a creature to pick it up and throw it. Arrow keys scroll across the world, plus and minus move closer and further away."
-          />
-          <PanControls onHold={handleHoldPan} onNudge={handleNudgePan} />
-          <ZoomControls onZoom={handleZoom} />
-          <Notices />
-          <Inspector onName={handleName} />
+      {/* Two-column layout: world column (canvas + toolbar) | field guide column.
+          The toolbar stays anchored at the bottom of the world column whether
+          the guide is open or closed. The divider between columns is draggable
+          (handled by FieldGuide's internal resize logic). */}
+      <div className="flex min-h-0 flex-1 overflow-hidden">
+        {/* World column: canvas fills remaining space, toolbar always at bottom */}
+        <div className="flex min-w-0 flex-1 flex-col overflow-hidden">
+          <div className="relative min-h-0 flex-1">
+            <canvas
+              ref={canvasRef}
+              // Focusable so the arrow keys reach it. The world is wider than the
+              // screen, and a keyboard has to be able to get to the rest of it.
+              tabIndex={0}
+              className="absolute inset-0 block h-full w-full touch-none focus:outline-none"
+              style={{ imageRendering: 'pixelated', cursor: 'crosshair' }}
+              aria-label="Micro Land world. Tap to place things, drag a creature to pick it up and throw it. Arrow keys scroll across the world, plus and minus move closer and further away."
+            />
+            <PanControls onHold={handleHoldPan} onNudge={handleNudgePan} />
+            <ZoomControls onZoom={handleZoom} />
+            <Notices />
+            <Inspector onName={handleName} />
+          </div>
+          <Toolbar onRemoveSpecies={handleRemoveSpecies} />
         </div>
+        {/* Field guide column — renders null when closed */}
         <FieldGuide />
       </div>
 
-      {!guideOpen && <Toolbar onRemoveSpecies={handleRemoveSpecies} />}
       <SummonPanel onIntroduce={handleIntroduce} onApplyTerrain={handleApplyTerrain} />
       <WorldsPanel onKeep={handleKeepWorld} onOpen={handleOpenWorld} onForget={handleForgetWorld} />
       <ChallengesPanel />

--- a/src/app/micro-land/components/field-guide.tsx
+++ b/src/app/micro-land/components/field-guide.tsx
@@ -93,7 +93,6 @@ export function FieldGuide() {
   })
   const isDragging = useRef(false)
 
-  const OVERLAP_THRESHOLD = 330
   const MIN_WIDTH = 240
   const MAX_WIDTH = 600
 
@@ -120,7 +119,6 @@ export function FieldGuide() {
     document.addEventListener('mouseup', onUp)
   }, [])
 
-  const isOverlap = guideWidth > OVERLAP_THRESHOLD
   const [view, setView] = useState<'guide' | 'workshop' | 'challenges'>('guide')
   const [compareTarget, setCompareTarget] = useState<string | null>(null)
 
@@ -161,19 +159,12 @@ export function FieldGuide() {
       style={{
         width: guideWidth,
         flexShrink: 0,
-        borderLeft: isOverlap ? 'none' : '1px solid var(--cc-panel-divider)',
+        borderLeft: '1px solid var(--cc-panel-divider)',
         background: 'linear-gradient(180deg, var(--cc-modal-bg-from), var(--cc-modal-bg-to))',
         display: 'flex',
         flexDirection: 'column',
         overflow: 'hidden',
-        ...(isOverlap ? {
-          position: 'absolute' as const,
-          right: 0,
-          top: 0,
-          bottom: 0,
-          zIndex: 10,
-          boxShadow: '-4px 0 20px rgba(0,0,0,0.4)',
-        } : {}),
+        position: 'relative',
       }}
     >
       {/* Drag handle — left edge of the guide */}

--- a/src/app/micro-land/components/toolbar.tsx
+++ b/src/app/micro-land/components/toolbar.tsx
@@ -74,10 +74,8 @@ function Chevron({ up }: { up: boolean }) {
 
 export function Toolbar({
   onRemoveSpecies,
-  side = false,
 }: {
   onRemoveSpecies: (blueprintId: string) => void
-  side?: boolean
 }) {
   const tool = useMicroLand(s => s.tool)
   const setTool = useMicroLand(s => s.setTool)
@@ -195,32 +193,16 @@ export function Toolbar({
    */
   const held = heldTool(tool, blueprints)
 
-  // When the field guide is open the toolbar moves to a left column so the
-  // layout reads as [ Tools | Canvas | Guide ] rather than overlapping it.
-  const Container: React.ElementType = side ? 'aside' : 'footer'
-
   return (
-    <Container
+    <footer
       className="flex flex-col gap-1.5 px-3 pb-3 pt-2"
-      style={
-        side
-          ? {
-              width: 240,
-              flexShrink: 0,
-              borderRight: '1px solid var(--cc-panel-divider)',
-              background: 'linear-gradient(270deg, var(--cc-panel-grad-from), transparent)',
-              overflowY: 'auto' as const,
-            }
-          : {
-              borderTop: '1px solid var(--cc-panel-divider)',
-              background: 'linear-gradient(0deg, var(--cc-panel-grad-from), transparent)',
-            }
-      }
+      style={{
+        borderTop: '1px solid var(--cc-panel-divider)',
+        background: 'linear-gradient(0deg, var(--cc-panel-grad-from), transparent)',
+      }}
     >
       {/*
         The handle, and — while the drawer is open — the brush sizes beside it.
-        Hidden in side-column mode: the panel is always visible there, so there
-        is nothing to fold away, and the canvas row provides the visual anchor.
 
         Nothing here animates. The canvas is sized by a ResizeObserver on its
         parent and `Renderer.resize` reallocates the backing store every call, so
@@ -228,7 +210,7 @@ export function Toolbar({
         length of the slide. Instant is also what `prefers-reduced-motion`
         wants, which makes the cheap answer the correct one twice over.
       */}
-      {!side && <div className="flex items-center gap-2">
+      <div className="flex items-center gap-2">
         {open && (
           <>
             <span style={label}>Ground</span>
@@ -330,9 +312,9 @@ export function Toolbar({
             </>
           )}
         </button>
-      </div>}
+      </div>
 
-      {(open || side) && (
+      {open && (
         <div id="micro-land-tools" className="flex flex-col gap-1.5">
           {/* Terrain palette — fills full width, clips to one row when collapsed */}
           <div className="-mx-1 flex flex-col gap-1 px-1 pb-1">
@@ -677,7 +659,7 @@ export function Toolbar({
           <div
             role="tabpanel"
             className="-mx-1 flex flex-wrap gap-1.5 overflow-y-auto px-1 pb-1"
-            style={{ maxHeight: side ? undefined : '24vh' }}
+            style={{ maxHeight: '24vh' }}
           >
             {/* Creatures still on their way hold their place at the front of the
             strip, right where the finished one lands.
@@ -813,7 +795,7 @@ export function Toolbar({
           </div>
         </div>
       )}
-    </Container>
+    </footer>
   )
 }
 


### PR DESCRIPTION
## Summary
- Restructures the layout into a proper two-column flexbox: **world column** (canvas + toolbar) | **field guide column**
- The toolbar is now always anchored at the bottom of the world column, whether the guide is open or closed — it no longer shifts to a sidebar
- Removes the field guide's absolute-positioning "overlap" mode (≥330px) — the guide is now always a proper flex column with a draggable left-edge divider

## Before / After

**Before:** `[ Tools (sidebar) | Canvas | Guide ]` — toolbar moved between sidebar and footer depending on guide state

**After:**
```
[ HUD — full width                     ]
[ Canvas (flex-1)  | Field Guide       ]
[ Toolbar          |                   ]
```

## Changes
- `MicroLandGame.tsx`: removed conditional `{guideOpen && <Toolbar side>}` and `{!guideOpen && <Toolbar>}`, replaced with always-rendered `<Toolbar>` inside a world column `flex-col` div
- `toolbar.tsx`: removed `side` prop and its sidebar-rendering branch; always renders as `<footer>`
- `field-guide.tsx`: removed `isOverlap` / `OVERLAP_THRESHOLD` and the `position: absolute` overlay mode

Closes #2946

## Test plan
- [ ] Open micro-land, open field guide — toolbar stays at bottom of world view, not in a sidebar
- [ ] Close field guide — toolbar remains at bottom, same position
- [ ] Drag the field guide left-edge handle to resize — world column + toolbar resize correctly
- [ ] Verify on mobile — toolbar still accessible at bottom

🤖 Generated with [Claude Code](https://claude.com/claude-code)