### PR TITLE
feat(micro-land): show 'yours' creatures in species tabs, not a separate filter

### DIFF
--- a/src/app/micro-land/components/toolbar.tsx
+++ b/src/app/micro-land/components/toolbar.tsx
@@ -150,22 +150,18 @@ export function Toolbar({
   const [editing, setEditing] = useState(false)
   const [terrainExpanded, setTerrainExpanded] = useState(false)
 
-  // Jump to "Yours" the moment a summon is asked for, and again when it lands,
-  // so the thing you just invented — and the slot holding its place until then —
-  // is under your thumb instead of behind a tab you have to go and find.
-  const summonedCount = blueprints.filter(bp => bp.summoned).length
+  // Jump to "Yours" the moment a summon is asked for, so the loading slot is
+  // under your thumb. Once the creature lands it moves to its species tab —
+  // no need to redirect there, the user is already watching.
   const pendingCount = pending.length
-  const lastSummoned = useRef(summonedCount)
   const lastPending = useRef(pendingCount)
   useEffect(() => {
-    if (summonedCount > lastSummoned.current || pendingCount > lastPending.current) {
+    if (pendingCount > lastPending.current) {
       setGroup('yours')
-      // Arriving here because something new was made must never arrive armed.
       setEditing(false)
     }
-    lastSummoned.current = summonedCount
     lastPending.current = pendingCount
-  }, [summonedCount, pendingCount])
+  }, [pendingCount])
 
   // Whatever tab is showing has to exist — "Yours" disappears on a fresh world.
   const active = tabs.some(t => t.id === group) ? group : (tabs[0]?.id ?? 'plants')
@@ -180,7 +176,7 @@ export function Toolbar({
    * on the way out of the tab, so coming back later never finds a row that
    * silently deletes on tap.
    */
-  const canEdit = active === 'yours' && shown.length > 0
+  const canEdit = shown.some(bp => bp.summoned)
   const editOn = editing && canEdit
 
   /**

--- a/src/app/micro-land/domain/blueprint.ts
+++ b/src/app/micro-land/domain/blueprint.ts
@@ -679,15 +679,14 @@ export function lifeKind(bp: CreatureBlueprint): LifeKind {
  * Worked out from the blueprint rather than a hand-kept list, for the same
  * reason the field guide derives its "eats / eaten by": a creature summoned
  * thirty seconds ago has to file itself correctly, and a list in the UI would
- * silently drop every one of them into "other". The one exception is `yours`,
- * which wins over everything — after you summon a dragon you want to find the
- * dragon, not go hunting for which category it landed in.
+ * silently drop every one of them into "other". Summoned creatures land in
+ * their natural species tab; the pink border on the chip is how you tell
+ * them apart from the world's own natives.
  *
  * `roster` is every creature in the world; a hunter is defined as something
  * that can actually eat one of them, which is the same rule the simulation uses.
  */
 export function creatureGroup(bp: CreatureBlueprint, roster: CreatureBlueprint[]): CreatureGroup {
-  if (bp.summoned) return 'yours'
   if (isPlantLike(bp)) return 'plants'
   if (bp.size >= 5) return 'giants'
   if (bp.aura) return 'helpers'


### PR DESCRIPTION
## Summary
- Summoned creatures now appear **inline in their natural species tab** (Plants, Grazers, Hunters, etc.) alongside world natives
- The existing **pink border** on the creature chip is the visual indicator that it was summoned by you
- The **'Yours' tab** now only appears while a summon is actively in flight (showing the loading placeholder slot) — it disappears once the creature has landed

## How it works
- `creatureGroup()` in `blueprint.ts`: removed the early `return 'yours'` for summoned blueprints, so they fall through to their natural classification (plant, giant, helper, hunter, or grazer)
- The 'Yours' tab naturally disappears when `pending.length === 0` (existing tab-filter logic already handled this)
- `canEdit` in `toolbar.tsx`: the Edit button now enables in any tab containing summoned creatures, not just the 'Yours' tab
- Auto-jump to 'Yours': still fires when a new summon starts so the loading slot is visible; removed the redundant jump when the summon completes

Closes #2942

## Test plan
- [ ] Summon a creature — 'Yours' tab appears showing the loading slot
- [ ] Once creature lands — it moves to its natural species tab (e.g. a plant → Plants tab), pink border intact
- [ ] 'Yours' tab disappears when no pending summons
- [ ] Edit button appears in species tabs that contain summoned creatures; clicking Edit + tapping a pink-bordered creature removes it

🤖 Generated with [Claude Code](https://claude.com/claude-code)