### PR TITLE
feat(micro-land): add square brush shape alongside circle

### DIFF
--- a/src/app/micro-land/components/toolbar.tsx
+++ b/src/app/micro-land/components/toolbar.tsx
@@ -81,6 +81,8 @@ export function Toolbar({
   const setTool = useMicroLand(s => s.setTool)
   const brush = useMicroLand(s => s.brush)
   const setBrush = useMicroLand(s => s.setBrush)
+  const brushShape = useMicroLand(s => s.brushShape)
+  const setBrushShape = useMicroLand(s => s.setBrushShape)
   const blueprints = useMicroLand(s => s.blueprints)
   const pending = useMicroLand(s => s.pendingSummons)
   const setSummonOpen = useMicroLand(s => s.setSummonOpen)
@@ -210,7 +212,44 @@ export function Toolbar({
         {open && (
           <>
             <span style={label}>Ground</span>
-            <div className="flex items-center gap-1">
+            {/* Brush shape: circle or square */}
+            <div className="flex items-center gap-1" role="group" aria-label="Brush shape">
+              {(['circle', 'square'] as const).map(shape => {
+                const selected = brushShape === shape
+                return (
+                  <button
+                    key={shape}
+                    type="button"
+                    className="cc-btn"
+                    onClick={() => setBrushShape(shape)}
+                    aria-label={`${shape} brush`}
+                    aria-pressed={selected}
+                    title={shape === 'circle' ? 'Circle brush' : 'Square brush'}
+                    style={{
+                      width: 26,
+                      height: 26,
+                      display: 'grid',
+                      placeItems: 'center',
+                      borderRadius: 4,
+                      border: `1px solid ${selected ? 'var(--cc-mint)' : 'var(--cc-mint-line)'}`,
+                      background: selected ? 'var(--cc-mint-soft)' : 'transparent',
+                    }}
+                  >
+                    <span
+                      style={{
+                        display: 'block',
+                        width: 10,
+                        height: 10,
+                        borderRadius: shape === 'circle' ? '50%' : 2,
+                        background: selected ? 'var(--cc-mint)' : 'var(--cc-text-muted)',
+                      }}
+                    />
+                  </button>
+                )
+              })}
+            </div>
+            {/* Brush size */}
+            <div className="flex items-center gap-1" role="group" aria-label="Brush size">
               {BRUSHES.map(size => (
                 <button
                   key={size}
@@ -234,7 +273,7 @@ export function Toolbar({
                       display: 'block',
                       width: Math.min(14, 3 + size),
                       height: Math.min(14, 3 + size),
-                      borderRadius: '50%',
+                      borderRadius: brushShape === 'square' ? 2 : '50%',
                       background: brush === size ? 'var(--cc-mint)' : 'var(--cc-text-muted)',
                     }}
                   />

--- a/src/app/micro-land/domain/sim/world.ts
+++ b/src/app/micro-land/domain/sim/world.ts
@@ -333,6 +333,27 @@ export function paintCircle(
   }
 }
 
+/** Paint a filled square (axis-aligned) of material. */
+export function paintSquare(
+  w: WorldState,
+  cx: number,
+  cy: number,
+  half: number,
+  mat: MaterialId
+): void {
+  const value = MATERIAL_INDEX[mat]
+  w.dormant = false
+  const x0 = Math.floor(cx - half)
+  const x1 = Math.ceil(cx + half)
+  const y0 = Math.floor(cy - half)
+  const y1 = Math.ceil(cy + half)
+  for (let y = y0; y <= y1; y++) {
+    for (let x = x0; x <= x1; x++) {
+      setTile(w, x, y, value)
+    }
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Spawning
 // ---------------------------------------------------------------------------

--- a/src/app/micro-land/game-instance.ts
+++ b/src/app/micro-land/game-instance.ts
@@ -49,6 +49,7 @@ import {
   countByBlueprint,
   createWorld,
   paintCircle,
+  paintSquare,
   registerBlueprint,
   seedStarters,
   spawnCreature,
@@ -2115,7 +2116,11 @@ export class GameInstance {
     if (tool.kind === 'inspect') return
 
     const material = tool.kind === 'erase' ? 'air' : tool.material
-    paintCircle(this.world, x, y, state.brush, material)
+    if (state.brushShape === 'square') {
+      paintSquare(this.world, x, y, state.brush, material)
+    } else {
+      paintCircle(this.world, x, y, state.brush, material)
+    }
     this.renderer.markTilesDirty()
   }
 

--- a/src/app/micro-land/store.ts
+++ b/src/app/micro-land/store.ts
@@ -256,6 +256,7 @@ interface MicroLandState {
   themeId: string
   tool: Tool
   brush: number
+  brushShape: 'circle' | 'square'
   paused: boolean
   speed: number
 
@@ -446,6 +447,7 @@ interface MicroLandState {
   setTheme: (id: string) => void
   setTool: (tool: Tool) => void
   setBrush: (n: number) => void
+  setBrushShape: (shape: 'circle' | 'square') => void
   togglePaused: () => void
   setSpeed: (n: number) => void
   setBlueprints: (list: CreatureBlueprint[]) => void
@@ -546,6 +548,7 @@ export const useMicroLand = create<MicroLandState>(set => ({
   themeId: DEFAULT_THEME,
   tool: { kind: 'material', material: 'dirt' },
   brush: 4,
+  brushShape: 'circle',
   paused: false,
   speed: 1,
 
@@ -609,6 +612,7 @@ export const useMicroLand = create<MicroLandState>(set => ({
   setTheme: themeId => set({ themeId }),
   setTool: tool => set({ tool }),
   setBrush: brush => set({ brush }),
+  setBrushShape: brushShape => set({ brushShape }),
   togglePaused: () => set(s => ({ paused: !s.paused })),
   setSpeed: speed => set({ speed }),
   setBlueprints: blueprints => set({ blueprints, populationHistory: [], extinctions: [], worldStats: { ...EMPTY_STATS }, foodWeb: {}, historyLog: [] }),


### PR DESCRIPTION
## Summary
- Adds a **circle / square brush shape toggle** to the terrain tool UI, alongside the existing brush size controls
- The brush size preview dots update to reflect the active shape (rounded for circle, squared for square)
- Square brush fills an axis-aligned rectangle of tiles at the same "radius" (half-width) as the circle brush

## Changes
- `world.ts`: new `paintSquare(w, cx, cy, half, mat)` — fills tiles in `[cx±half, cy±half]` bounds
- `store.ts`: `brushShape: 'circle' | 'square'` (default `'circle'`) with `setBrushShape` setter
- `game-instance.ts`: dispatches to `paintSquare` or `paintCircle` based on `state.brushShape`
- `toolbar.tsx`: two shape buttons appear in the Ground controls row when the drawer is open

Closes #2944

## Test plan
- [ ] Open terrain drawer, select a material, drag on canvas — circle brush by default
- [ ] Click the square shape button — drag now paints square patches
- [ ] Switch back to circle — circle painting resumes
- [ ] Brush size buttons work with both shapes; preview dots reflect active shape
- [ ] Erase tool also respects the selected shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)