### PR TITLE
feat(micro-land): biome brush — paint terrain themes (#2957)

### DIFF
--- a/src/app/micro-land/components/toolbar.tsx
+++ b/src/app/micro-land/components/toolbar.tsx
@@ -7,6 +7,7 @@ import {
   type CreatureGroup,
   creatureGroup,
 } from '@/app/micro-land/domain/blueprint'
+import { BIOMES } from '@/app/micro-land/domain/config/biomes'
 import { MATERIALS, PAINTABLE, TINTS, tintedId } from '@/app/micro-land/domain/config/materials'
 import {
   type CreatureFilter,
@@ -448,6 +449,37 @@ export function Toolbar({
             </button>
           </div>
 
+          {/* Biome brushes — paint mixed terrain themes in one stroke */}
+          <div className="-mx-1 flex flex-wrap items-center gap-1.5 px-1 pb-1">
+            <span style={label}>Biomes</span>
+            {BIOMES.map(biome => {
+              const selected = tool.kind === 'biome' && tool.biomeId === biome.id
+              return (
+                <button
+                  key={biome.id}
+                  type="button"
+                  className="cc-btn shrink-0"
+                  onClick={() => setTool({ kind: 'biome', biomeId: biome.id })}
+                  aria-pressed={selected}
+                  title={`Paint ${biome.label.toLowerCase()} terrain mix`}
+                  style={swatchStyle(selected)}
+                >
+                  <span
+                    aria-hidden
+                    style={{
+                      width: 22,
+                      height: 22,
+                      borderRadius: 3,
+                      background: biome.color,
+                      boxShadow: 'inset 0 0 0 1px rgba(0,0,0,0.35)',
+                    }}
+                  />
+                  <span style={swatchLabel}>{biome.label}</span>
+                </button>
+              )
+            })}
+          </div>
+
           {family && (
             <div
               className="-mx-1 flex flex-wrap items-center gap-1.5 px-1 pb-1"
@@ -863,6 +895,25 @@ function heldTool(
 
   if (tool.kind === 'inspect') {
     return { name: 'Inspect', swatch: <span style={{ fontSize: 13 }}>⌕</span> }
+  }
+
+  if (tool.kind === 'biome') {
+    const biome = BIOMES.find(b => b.id === tool.biomeId)
+    if (!biome) return { name: 'Biome', swatch: null }
+    return {
+      name: biome.label,
+      swatch: (
+        <span
+          style={{
+            width: 16,
+            height: 16,
+            borderRadius: 3,
+            background: biome.color,
+            boxShadow: 'inset 0 0 0 1px rgba(0,0,0,0.35)',
+          }}
+        />
+      ),
+    }
   }
 
   if (tool.kind === 'creature') {

--- a/src/app/micro-land/domain/config/biomes.ts
+++ b/src/app/micro-land/domain/config/biomes.ts
@@ -1,0 +1,63 @@
+import type { MaterialId } from '../types'
+
+export interface BiomeEntry {
+  material: MaterialId
+  weight: number
+}
+
+export interface Biome {
+  id: string
+  label: string
+  /** Representative CSS color for the toolbar swatch. */
+  color: string
+  /** Each painted tile picks a material by weighted random selection. */
+  palette: BiomeEntry[]
+}
+
+export const BIOMES: Biome[] = [
+  {
+    id: 'forest',
+    label: 'Forest',
+    color: '#4a7c59',
+    palette: [
+      { material: 'grass', weight: 4 },
+      { material: 'dirt', weight: 3 },
+      { material: 'wood', weight: 2 },
+      { material: 'moss', weight: 1 },
+    ],
+  },
+  {
+    id: 'desert',
+    label: 'Desert',
+    color: '#c8a84b',
+    palette: [
+      { material: 'sand', weight: 8 },
+      { material: 'stone', weight: 2 },
+      { material: 'glass', weight: 1 },
+    ],
+  },
+  {
+    id: 'wetland',
+    label: 'Wetland',
+    color: '#2d6a8f',
+    palette: [
+      { material: 'mud', weight: 5 },
+      { material: 'water', weight: 3 },
+      { material: 'grass', weight: 2 },
+    ],
+  },
+  {
+    id: 'savanna',
+    label: 'Savanna',
+    color: '#8ab86b',
+    palette: [
+      { material: 'grass', weight: 6 },
+      { material: 'sand', weight: 2 },
+      { material: 'stone', weight: 1 },
+    ],
+  },
+]
+
+export const BIOME_BY_ID: Record<string, Biome> = Object.fromEntries(
+  BIOMES.map(b => [b.id, b])
+)

--- a/src/app/micro-land/domain/sim/world.ts
+++ b/src/app/micro-land/domain/sim/world.ts
@@ -11,6 +11,7 @@ import {
   MATERIAL_INDEX,
   VISCOSITY,
 } from '@/app/micro-land/domain/config/materials'
+import type { Biome } from '../config/biomes'
 import { DEFAULT_THEME, THEME_BY_ID, type Theme } from '@/app/micro-land/domain/config/themes'
 import {
   SURFACE_SEEDING_BIAS,
@@ -350,6 +351,63 @@ export function paintSquare(
   for (let y = y0; y <= y1; y++) {
     for (let x = x0; x <= x1; x++) {
       setTile(w, x, y, value)
+    }
+  }
+}
+
+/** Pick one material from a biome palette by weighted random selection. */
+function pickBiomeMat(rng: Rng, palette: Biome['palette']): number {
+  let total = 0
+  for (const e of palette) total += e.weight
+  let roll = rng() * total
+  for (const e of palette) {
+    roll -= e.weight
+    if (roll < 0) return MATERIAL_INDEX[e.material]
+  }
+  return MATERIAL_INDEX[palette[palette.length - 1].material]
+}
+
+/** Paint a filled circle where each tile is drawn from a biome's weighted material palette. */
+export function paintBiomeCircle(
+  w: WorldState,
+  cx: number,
+  cy: number,
+  radius: number,
+  biome: Biome,
+  rng: Rng
+): void {
+  w.dormant = false
+  const r2 = radius * radius
+  const x0 = Math.floor(cx - radius)
+  const x1 = Math.ceil(cx + radius)
+  const y0 = Math.floor(cy - radius)
+  const y1 = Math.ceil(cy + radius)
+  for (let y = y0; y <= y1; y++) {
+    for (let x = x0; x <= x1; x++) {
+      const dx = x - cx
+      const dy = y - cy
+      if (dx * dx + dy * dy <= r2) setTile(w, x, y, pickBiomeMat(rng, biome.palette))
+    }
+  }
+}
+
+/** Paint a filled square where each tile is drawn from a biome's weighted material palette. */
+export function paintBiomeSquare(
+  w: WorldState,
+  cx: number,
+  cy: number,
+  half: number,
+  biome: Biome,
+  rng: Rng
+): void {
+  w.dormant = false
+  const x0 = Math.floor(cx - half)
+  const x1 = Math.ceil(cx + half)
+  const y0 = Math.floor(cy - half)
+  const y1 = Math.ceil(cy + half)
+  for (let y = y0; y <= y1; y++) {
+    for (let x = x0; x <= x1; x++) {
+      setTile(w, x, y, pickBiomeMat(rng, biome.palette))
     }
   }
 }

--- a/src/app/micro-land/game-instance.ts
+++ b/src/app/micro-land/game-instance.ts
@@ -34,6 +34,7 @@ import {
   reserveSummonIds,
   sanitizeBlueprint,
 } from './domain/blueprint'
+import { BIOME_BY_ID } from './domain/config/biomes'
 import { MILESTONES, type MilestoneContext } from './domain/config/milestones'
 import { DEFAULT_THEME, THEME_BY_ID, type Theme } from './domain/config/themes'
 import { ELDER_MIN_SECONDS, TICK_S, TILE_TICK_EVERY, WORLD_H, WORLD_W } from './domain/constants'
@@ -48,6 +49,8 @@ import {
   clearCreatures,
   countByBlueprint,
   createWorld,
+  paintBiomeCircle,
+  paintBiomeSquare,
   paintCircle,
   paintSquare,
   registerBlueprint,
@@ -2114,6 +2117,19 @@ export class GameInstance {
 
     // Inspecting is resolved on pointerdown; it never paints.
     if (tool.kind === 'inspect') return
+
+    if (tool.kind === 'biome') {
+      const biome = BIOME_BY_ID[tool.biomeId]
+      if (biome) {
+        if (state.brushShape === 'square') {
+          paintBiomeSquare(this.world, x, y, state.brush, biome, this.rng)
+        } else {
+          paintBiomeCircle(this.world, x, y, state.brush, biome, this.rng)
+        }
+        this.renderer.markTilesDirty()
+      }
+      return
+    }
 
     const material = tool.kind === 'erase' ? 'air' : tool.material
     if (state.brushShape === 'square') {

--- a/src/app/micro-land/store.ts
+++ b/src/app/micro-land/store.ts
@@ -47,6 +47,7 @@ export const SUMMONED_THEME_ID = 'summoned'
 export type Tool =
   | { kind: 'material'; material: MaterialId }
   | { kind: 'erase' }
+  | { kind: 'biome'; biomeId: string }
   | { kind: 'creature'; blueprintId: string }
   | { kind: 'inspect' }
 


### PR DESCRIPTION
## Summary
- Adds 4 biome presets to the terrain toolbar: Forest, Desert, Wetland, Savanna
- Each biome brush stroke paints a weighted random mix of materials, creating natural-looking terrain variation in one gesture
- New `paintBiomeCircle()` / `paintBiomeSquare()` functions in `world.ts` do per-tile weighted random material selection
- Biome configs live in `domain/config/biomes.ts` (easy to extend with more biomes)
- Biome section appears below the terrain palette when the toolbar is open

## Test plan
- [ ] Open toolbar → see "Biomes" row with 4 buttons (Forest, Desert, Wetland, Savanna)
- [ ] Select Forest biome and paint — canvas shows mixed grass/dirt/wood/moss tiles
- [ ] Select Desert biome and paint — mostly sand with some stone/glass
- [ ] Toolbar handle shows biome name (e.g., "Forest") when biome tool is active
- [ ] Shape (circle/square) and size controls still work with biome brush
- [ ] Switching to a material resets tool; biome selection is preserved across sessions

Closes #2957

🤖 Generated with [Claude Code](https://claude.com/claude-code)