### PR TITLE
feat(micro-land): mutualism tracker in field guide (#2968)

### DIFF
--- a/src/app/micro-land/components/field-guide.tsx
+++ b/src/app/micro-land/components/field-guide.tsx
@@ -786,6 +786,50 @@ export function FieldGuide() {
           </section>
         )}
 
+        {/* Mutualism — derived from which alive blueprints have auras that help other alive species */}
+        {(() => {
+          const aliveIds = new Set(population.map(p => p.blueprintId))
+          const grouped: Record<string, string[]> = {}
+          for (const helper of blueprints) {
+            if (!helper.aura?.helps?.length || !aliveIds.has(helper.id)) continue
+            for (const helpee of blueprints) {
+              if (helpee.id === helper.id || !aliveIds.has(helpee.id)) continue
+              if (helper.aura.helps.some(tag => helpee.tags.includes(tag))) {
+                grouped[helper.name] = [...(grouped[helper.name] ?? []), helpee.name]
+              }
+            }
+          }
+          const entries = Object.entries(grouped)
+          if (!entries.length) return null
+          return (
+            <section className="px-4 py-3" style={{ borderTop: '1px solid var(--cc-panel-divider)' }}>
+              <h3 className="pb-2" style={sectionHeading}>
+                Mutualism
+              </h3>
+              <p style={{ fontSize: 11, color: 'var(--cc-text-muted)', marginBottom: 8 }}>
+                Helpers and the species they support right now.
+              </p>
+              <ul style={{ listStyle: 'none', padding: 0, margin: 0 }}>
+                {entries.map(([helperName, helpeeNames]) => (
+                  <li
+                    key={helperName}
+                    style={{
+                      fontSize: 11,
+                      fontFamily: 'var(--cc-font-mono)',
+                      padding: '3px 0',
+                      lineHeight: 1.6,
+                    }}
+                  >
+                    <span style={{ color: 'var(--cc-mint)' }}>{helperName}</span>
+                    <span style={{ color: 'var(--cc-text-muted)' }}>{' ↔ '}</span>
+                    <span style={{ color: 'var(--cc-text-muted)' }}>{helpeeNames.join(', ')}</span>
+                  </li>
+                ))}
+              </ul>
+            </section>
+          )
+        })()}
+
         {/* World Statistics */}
         <section className="px-4 py-3" style={{ borderTop: '1px solid var(--cc-panel-divider)' }}>
           <h3 className="pb-2" style={sectionHeading}>


### PR DESCRIPTION
## Summary
- Adds a "Mutualism" section to the Field Guide below the food web
- Shows helper species (e.g., Honeybee) paired with the species they support (e.g., plants they help breed)
- Purely derived from `blueprints` + `population` — no store changes, no sim changes
- Only appears when helper species with aura effects are currently alive alongside their target species

## Test plan
- [ ] Summon a Honeybee into a world with plants — "Mutualism" section appears
- [ ] Section shows "Honeybee ↔ [plant species names]"
- [ ] When the Honeybee goes extinct, the section disappears
- [ ] No "Mutualism" section when only non-helper species are present

Closes #2968

🤖 Generated with [Claude Code](https://claude.com/claude-code)