### PR TITLE
feat(micro-land): expose day/night cycle in settings (#2954)

### DIFF
--- a/src/app/micro-land/domain/tuning.ts
+++ b/src/app/micro-land/domain/tuning.ts
@@ -442,6 +442,15 @@ export const KNOBS: Knob[] = [
     max: 1800,
     step: 30,
   },
+  {
+    key: 'dayLengthSeconds',
+    group: 'world',
+    label: 'Day/night cycle (sim seconds)',
+    help: 'How long one full day/night cycle takes. 0 means no cycle. 120 is two real minutes at normal speed; the world darkens at night and creatures with diurnal traits lose sight in the wrong light. Shorter days feel dramatic; longer days feel subtle.',
+    min: 0,
+    max: 600,
+    step: 30,
+  },
 ]
 
 const KNOB_BY_KEY: Record<TuningKey, Knob> = Object.fromEntries(


### PR DESCRIPTION
## Summary
- Exposes the `dayLengthSeconds` tuning knob in the Settings panel under the "World" group
- The renderer (`renderer.ts`) and diurnal creature behavior (`creature-sim.ts`) were already implemented — this is purely a UI exposure
- Default 0 = disabled; set to e.g. 120 for a 2-minute day/night cycle
- The world darkens with a cosine overlay at night; diurnal/nocturnal creatures lose sight in the wrong phase

## Test plan
- [ ] Open Settings (··· → Settings) — see "Day/night cycle" slider in the World group
- [ ] Drag slider to 120 — world visibly darkens and brightens on a 2-minute cycle
- [ ] Drag back to 0 — constant daytime restored
- [ ] Settings gold star (tuned) appears when cycle is active

Closes #2954

🤖 Generated with [Claude Code](https://claude.com/claude-code)