### PR TITLE
feat(micro-land): season name in HUD when seasons are active (#2956)

### DIFF
--- a/src/app/micro-land/components/hud.tsx
+++ b/src/app/micro-land/components/hud.tsx
@@ -163,6 +163,12 @@ export function Hud({
     elapsed >= 600  ? 'Established' :
     'Young'
 
+  const SEASON_NAMES = ['Spring', 'Summer', 'Autumn', 'Winter'] as const
+  const seasonName =
+    tuning.seasonAmplitude > 0 && tuning.seasonPeriod > 0
+      ? SEASON_NAMES[Math.floor(((elapsed % tuning.seasonPeriod) / tuning.seasonPeriod) * 4) % 4]
+      : null
+
   const [overflowOpen, setOverflowOpen] = useState(false)
   const [copied, setCopied] = useState(false)
   const overflowRef = useRef<HTMLDivElement>(null)
@@ -342,6 +348,12 @@ export function Hud({
           >
             {ageLabel}
           </span>
+          {seasonName && (
+            <>
+              {' · '}
+              <span style={{ color: 'var(--cc-text-muted)' }}>{seasonName}</span>
+            </>
+          )}
         </button>
 
         {/* Ecosystem health — informational */}


### PR DESCRIPTION
## Summary
- Shows Spring/Summer/Autumn/Winter in the species/population chip when the season amplitude tuning knob is > 0
- Season is derived from `elapsed % seasonPeriod`, divided into 4 equal quarters
- Only visible when seasons are enabled (amplitude > 0), so it doesn't clutter the default HUD
- Ecological effects (plant growth rate swing) were already implemented via `seasonAmplitude`/`seasonPeriod` tuning knobs

## Test plan
- [ ] By default (seasonAmplitude = 0): no season name shown
- [ ] Set seasonAmplitude > 0 in Settings → "Spring" / "Summer" / "Autumn" / "Winter" appears in the chip
- [ ] Label changes as sim time advances through the cycle
- [ ] Works at all speed settings (3× etc.)

Closes #2956

🤖 Generated with [Claude Code](https://claude.com/claude-code)