### PR TITLE
feat(micro-land): mood history sparkline in inspector (#2973)

### DIFF
--- a/src/app/micro-land/components/inspector.tsx
+++ b/src/app/micro-land/components/inspector.tsx
@@ -446,6 +446,40 @@ export function Inspector({ onName }: { onName: (name: string) => boolean }) {
           )}
         </div>
 
+        {/* Mood history — color-coded timeline of recent states */}
+        {inspected.moodHistory.length > 1 && (
+          <div
+            style={{
+              display: 'flex',
+              gap: 2,
+              flexWrap: 'wrap',
+              marginTop: 4,
+            }}
+            title="Mood history — oldest to newest"
+          >
+            {inspected.moodHistory.map((m, i) => (
+              <span
+                key={i}
+                style={{
+                  display: 'block',
+                  width: 5,
+                  height: 10,
+                  borderRadius: 1,
+                  flexShrink: 0,
+                  background:
+                    m === 'eat'    ? '#22c55e' :
+                    m === 'mate'   ? '#c084fc' :
+                    m === 'hunt'   ? '#ef4444' :
+                    m === 'flee'   ? '#f97316' :
+                    m === 'rest'   ? '#60a5fa' :
+                    /* wander */     '#94a3b8',
+                  opacity: 0.5 + 0.5 * (i / inspected.moodHistory.length),
+                }}
+              />
+            ))}
+          </div>
+        )}
+
         {/*
           Sits directly under the mood, above the meters, because it is the one
           line on this panel that is about *this* creature rather than about its

--- a/src/app/micro-land/game-instance.ts
+++ b/src/app/micro-land/game-instance.ts
@@ -207,6 +207,10 @@ export class GameInstance {
   /** Archive size at the last push, so the guide is only re-sent when it grows. */
   private lastArchiveSize = -1
 
+  // --- mood history for inspector sparkline ---
+  private moodHistory: string[] = []
+  private moodHistoryCreatureId: number | null = null
+
   // --- heatmap ---
   private heatmap: Float32Array | null = null
   private heatmapCurrentBpId: string | null = null
@@ -1254,6 +1258,14 @@ export class GameInstance {
 
     const bp = this.world.blueprints[c.blueprintId]
     if (!bp) return
+    // Accumulate mood history for the sparkline.
+    if (c.id !== this.moodHistoryCreatureId) {
+      this.moodHistory = [c.mood]
+      this.moodHistoryCreatureId = c.id
+    } else {
+      this.moodHistory.push(c.mood)
+      if (this.moodHistory.length > 40) this.moodHistory.shift()
+    }
     const { w: bw, h: bh } = artSize(bp)
 
     const target =
@@ -1296,6 +1308,7 @@ export class GameInstance {
         const host = this.world.creatures.find(x => x.id === hid)
         return host ? (this.world.blueprints[host.blueprintId]?.name ?? null) : null
       })(),
+      moodHistory: [...this.moodHistory],
     })
   }
 

--- a/src/app/micro-land/store.ts
+++ b/src/app/micro-land/store.ts
@@ -93,6 +93,8 @@ export interface Inspected {
   lifeLog: Array<{ elapsed: number; text: string }>
   packSize: number
   hostName: string | null
+  /** Rolling history of recent mood states, oldest first, max 40 entries. */
+  moodHistory: string[]
 }
 
 /** One column of the guide's record book — see `KindRecord`. */


### PR DESCRIPTION
## Summary
- Adds a compact colour-coded bar chart below the creature's current mood in the inspector
- Green=eating, purple=mating, red=hunting, orange=fleeing, blue=resting, grey=wandering
- Bars fade from dim (oldest) to bright (newest), showing up to 40 recent mood samples
- History accumulates in \`GameInstance\` while a creature is being watched; resets on switching creatures
- Only appears after the creature has been watched long enough to accumulate ≥2 snapshots

## Test plan
- [ ] Click a creature — inspector opens
- [ ] After a few seconds, a row of colored bars appears below the mood text
- [ ] Bars reflect visible behavior (creature eating → green bars, fleeing → orange, etc.)
- [ ] Bars fade older to newer (left=dim, right=bright)
- [ ] Clicking a different creature resets the sparkline

Closes #2973

🤖 Generated with [Claude Code](https://claude.com/claude-code)