### PR TITLE
feat(micro-land): terrain erosion from creature traffic (#2972)

### DIFF
--- a/src/app/micro-land/domain/sim/world.ts
+++ b/src/app/micro-land/domain/sim/world.ts
@@ -412,6 +412,23 @@ export function paintBiomeSquare(
   }
 }
 
+/**
+ * Degrade a tile one step due to sustained creature traffic.
+ * Grass wears to dirt; dirt wears to mud. All other materials are unchanged.
+ */
+export function erodeTile(w: WorldState, x: number, y: number): void {
+  if (!inBounds(x, y)) return
+  const current = w.tiles[y * WORLD_W + x]
+  const grassVal = MATERIAL_INDEX['grass']
+  const dirtVal = MATERIAL_INDEX['dirt']
+  const mudVal = MATERIAL_INDEX['mud']
+  if (current === grassVal) {
+    setTile(w, x, y, dirtVal)
+  } else if (current === dirtVal) {
+    setTile(w, x, y, mudVal)
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Spawning
 // ---------------------------------------------------------------------------

--- a/src/app/micro-land/game-instance.ts
+++ b/src/app/micro-land/game-instance.ts
@@ -49,6 +49,7 @@ import {
   clearCreatures,
   countByBlueprint,
   createWorld,
+  erodeTile,
   paintBiomeCircle,
   paintBiomeSquare,
   paintCircle,
@@ -206,6 +207,14 @@ export class GameInstance {
   private steadySince = 0
   /** Archive size at the last push, so the guide is only re-sent when it grows. */
   private lastArchiveSize = -1
+
+  // --- terrain erosion ---
+  /**
+   * Per-tile creature visit counter. Incremented on each erosion update;
+   * reset to 0 when the tile degrades. Uint16Array keeps it cheap.
+   */
+  private erosionTraffic: Uint16Array = new Uint16Array(WORLD_W * WORLD_H)
+  private erosionTickCounter = 0
 
   // --- heatmap ---
   private heatmap: Float32Array | null = null
@@ -457,6 +466,30 @@ export class GameInstance {
     }
 
     tickCreatures(w, TICK_S, this.rng, gravity, events)
+
+    // --- terrain erosion (every 30 ticks ≈ every 0.5 s at 60 fps) ---
+    this.erosionTickCounter++
+    if (this.erosionTickCounter >= 30) {
+      this.erosionTickCounter = 0
+      const w = this.world
+      // Stamp each creature's current tile.
+      for (const c of w.creatures) {
+        const tx = Math.max(0, Math.min(WORLD_W - 1, Math.round(c.x)))
+        const ty = Math.max(0, Math.min(WORLD_H - 1, Math.round(c.y)))
+        const i = ty * WORLD_W + tx
+        if (this.erosionTraffic[i] < 65000) this.erosionTraffic[i]++
+      }
+      // Degrade any tile that has seen enough traffic.
+      const THRESHOLD = 80
+      for (let i = 0; i < this.erosionTraffic.length; i++) {
+        if (this.erosionTraffic[i] >= THRESHOLD) {
+          const x = i % WORLD_W
+          const y = Math.floor(i / WORLD_W)
+          erodeTile(w, x, y)
+          this.erosionTraffic[i] = 0
+        }
+      }
+    }
 
     // --- heatmap update (every 5 ticks) ---
     this.heatmapTickCounter++


### PR DESCRIPTION
## Summary
- Creature positions are sampled every 30 ticks; tiles accumulate visit counts
- When a tile hits 80 cumulative visits, it degrades: grass→dirt, dirt→mud
- Counter resets after each erosion, so trails continue to deepen over time
- New `erodeTile()` function in `world.ts` handles the material transition
- No new UI or store state — purely a sim background effect

## Test plan
- [ ] Spawn many grazers on a grassy world — watch grass turn to dirt trails
- [ ] Leave the sim running 5+ minutes — some dirt paths degrade to mud
- [ ] World with no creatures: no erosion
- [ ] Player-painted tiles: erosion applies equally to any grass/dirt tile

Closes #2972

🤖 Generated with [Claude Code](https://claude.com/claude-code)