### PR TITLE
feat(micro-land): rain weather effect (#2955)

### DIFF
--- a/src/app/micro-land/domain/tuning.ts
+++ b/src/app/micro-land/domain/tuning.ts
@@ -121,6 +121,11 @@ export const TUNING_DEFAULTS = {
   pollinationOnly: POLLINATION_ONLY,
   plantCrowdingStrength: PLANT_CROWDING_STRENGTH,
   plantSpreadMin: PLANT_SPREAD_MIN,
+  /**
+   * How many water drops fall per tick, 0 = dry.
+   * Probabilistic: at 1.0, one drop per tick on average (≈60/s at 60fps).
+   */
+  rainRate: 0,
 }
 
 export type TuningKey = keyof typeof TUNING_DEFAULTS
@@ -450,6 +455,15 @@ export const KNOBS: Knob[] = [
     min: 0,
     max: 600,
     step: 30,
+  },
+  {
+    key: 'rainRate',
+    group: 'world',
+    label: 'Rain',
+    help: 'Water drops that fall from the sky. 0 = dry. 0.3 = light rain. 1.0 = downpour. Water pools and flows naturally using the world physics. Pairs well with water-adapted creatures and muddy terrain.',
+    min: 0,
+    max: 1,
+    step: 0.05,
   },
 ]
 

--- a/src/app/micro-land/game-instance.ts
+++ b/src/app/micro-land/game-instance.ts
@@ -462,6 +462,12 @@ export class GameInstance {
 
     tickCreatures(w, TICK_S, this.rng, gravity, events)
 
+    // --- rain ---
+    if (TUNING.rainRate > 0 && this.rng() < TUNING.rainRate) {
+      const rx = Math.floor(this.rng() * WORLD_W)
+      paintCircle(this.world, rx, 0, 1, 'water')
+    }
+
     // --- heatmap update (every 5 ticks) ---
     this.heatmapTickCounter++
     if (this.heatmapTickCounter >= 5) {


### PR DESCRIPTION
## Summary
- Adds a "Rain" slider to Settings (World group)
- Each tick, with probability = rainRate, drops a water tile at a random x at y=0
- World physics (falling-sand) handles the rest: water falls, pools, and flows
- 0 = dry (default), 0.3 = light rain, 1.0 = downpour
- Pairs naturally with the day/night cycle and seasonal erosion features

## Test plan
- [ ] Open Settings (··· → Settings) → see "Rain" slider in World group
- [ ] Set to 0.3 — water drops appear falling from sky
- [ ] Water pools at the surface and flows into holes
- [ ] Set to 0 — rain stops immediately
- [ ] Heavy rain (1.0) floods the world

Closes #2955