### PR TITLE
[microland] Show parent species in creature inspector (#2959)

### DIFF
--- a/src/app/micro-land/components/inspector.tsx
+++ b/src/app/micro-land/components/inspector.tsx
@@ -106,12 +106,23 @@ const meterLabel: React.CSSProperties = {
  *
  * Shown for everything — plants just have fewer facts to report.
  */
-function biography(c: Inspected, bp: CreatureBlueprint): string {
+function biography(c: Inspected, bp: CreatureBlueprint, bpMap: CreatureBlueprint[]): string {
   const parts: string[] = []
 
   if (c.generation <= 1) {
     parts.push('First of its line')
   } else {
+    const parentNames = c.parentBlueprintIds
+      ? [
+          bpMap.find(b => b.id === c.parentBlueprintIds![0])?.name ?? 'unknown',
+          c.parentBlueprintIds[1]
+            ? bpMap.find(b => b.id === c.parentBlueprintIds![1])?.name ?? 'unknown'
+            : null,
+        ].filter(Boolean).join(' × ')
+      : null
+    if (parentNames) {
+      parts.push(`Born from ${parentNames}`)
+    }
     parts.push(`Generation ${c.generation}`)
   }
 
@@ -505,7 +516,7 @@ export function Inspector({ onName }: { onName: (name: string) => boolean }) {
             opacity: 0.8,
           }}
         >
-          {biography(inspected, bp)}
+          {biography(inspected, bp, blueprints)}
         </div>
 
         <Meter

--- a/src/app/micro-land/domain/sim/creature-sim.ts
+++ b/src/app/micro-land/domain/sim/creature-sim.ts
@@ -755,6 +755,7 @@ export function tickCreatures(
             // genuinely different things.
             child.traits = inherit(c.traits, mate?.traits ?? null, rng)
             child.lifeLog = [{ elapsed: w.elapsed, text: `Born (gen ${child.generation})` }]
+            child.parentBlueprintIds = [c.blueprintId, mate?.blueprintId ?? null] as const
             c.children++
             if (c.children === 1) logLife(c, w.elapsed, 'First offspring')
             else if (c.children % 10 === 0) logLife(c, w.elapsed, `${c.children} offspring`)

--- a/src/app/micro-land/domain/types.ts
+++ b/src/app/micro-land/domain/types.ts
@@ -511,6 +511,11 @@ export interface Creature {
    */
   generation: number
   /**
+   * BlueprintIds of the two parents at live birth. Null/absent for placed creatures.
+   * The second entry is null for self-fertilisation or unknown mate.
+   */
+  parentBlueprintIds?: readonly [string, string | null]
+  /**
    * What this one inherited, as multipliers on its species.
    *
    * Neutral for anything that wasn't born here, which is what makes a species

--- a/src/app/micro-land/game-instance.ts
+++ b/src/app/micro-land/game-instance.ts
@@ -1332,6 +1332,7 @@ export class GameInstance {
       grounded: c.grounded,
       targetName: targetBp?.name ?? null,
       generation: c.generation,
+      parentBlueprintIds: (c as { parentBlueprintIds?: readonly [string, string | null] }).parentBlueprintIds ?? null,
       // Copied, like everything else here. Traits are replaced wholesale rather
       // than mutated, so the reference would in fact be safe today — but that is
       // a fact about `inherit`, and this panel shouldn't depend on it.

--- a/src/app/micro-land/store.ts
+++ b/src/app/micro-land/store.ts
@@ -82,6 +82,8 @@ export interface Inspected {
   targetName: string | null
   /** How far back its line goes; 1 means it was placed rather than born. */
   generation: number
+  /** BlueprintIds of the parents, if this creature was born here (not placed). */
+  parentBlueprintIds?: readonly [string, string | null] | null
   /** What it inherited, as multipliers on its species. Neutral at generation 1. */
   traits: Traits
   /** Player-given name, if this one earned the right to have one. */


### PR DESCRIPTION
## Summary
- Adds `parentBlueprintIds` field to `Creature` to record both parents at live birth
- Inspector biography now shows "Born from X × Y" for in-world-born creatures
- First-of-line (placed/seeded) creatures still show "First of its line"
- No store changes beyond a new optional field in `Inspected`

## Test plan
- [ ] Place two different species in the world, let them breed
- [ ] Click an offspring → inspector shows "Born from [SpeciesA] × [SpeciesB]"
- [ ] Click a placed creature → still shows "First of its line"
- [ ] Single-parent (self-fertilised) birth shows "Born from [Species]" without a second name

Closes #2959

🤖 Generated with [Claude Code](https://claude.com/claude-code)