### PR TITLE
[microland] Migration corridor brush (#2970)

### DIFF
--- a/src/app/micro-land/components/toolbar.tsx
+++ b/src/app/micro-land/components/toolbar.tsx
@@ -480,6 +480,35 @@ export function Toolbar({
             })}
           </div>
 
+          {/* Migration corridor brush */}
+          <div className="-mx-1 flex flex-wrap items-center gap-1.5 px-1 pb-1">
+            <span style={label}>Corridors</span>
+            <button
+              type="button"
+              className="cc-btn shrink-0"
+              onClick={() => setTool({ kind: 'corridor' })}
+              aria-pressed={tool.kind === 'corridor'}
+              title="Paint migration corridors — hungry creatures follow these paths"
+              style={swatchStyle(tool.kind === 'corridor')}
+            >
+              <span
+                aria-hidden
+                style={{
+                  width: 22,
+                  height: 22,
+                  borderRadius: 3,
+                  background: '#ffe066',
+                  boxShadow: 'inset 0 0 0 1px rgba(0,0,0,0.35)',
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  fontSize: 14,
+                }}
+              >→</span>
+              <span style={swatchLabel}>Path</span>
+            </button>
+          </div>
+
           {family && (
             <div
               className="-mx-1 flex flex-wrap items-center gap-1.5 px-1 pb-1"
@@ -895,6 +924,10 @@ function heldTool(
 
   if (tool.kind === 'inspect') {
     return { name: 'Inspect', swatch: <span style={{ fontSize: 13 }}>⌕</span> }
+  }
+
+  if (tool.kind === 'corridor') {
+    return { name: 'Corridor path', swatch: null }
   }
 
   if (tool.kind === 'biome') {

--- a/src/app/micro-land/domain/sim/creature-sim.ts
+++ b/src/app/micro-land/domain/sim/creature-sim.ts
@@ -1832,19 +1832,33 @@ function steer(w: WorldState, c: Creature, bp: CreatureBlueprint, dt: number, rn
     // Rate-limited via rng() so the tile scan fires ~once per second
     // rather than every tick — about 0.017 per tick at 60 Hz.
     if (c.migrateTimer > TUNING.migrationThreshold && bp.move.kind !== 'root' && rng() < 0.017) {
-      const grassIdx = MATERIAL_INDEX.grass
-      const mossIdx = MATERIAL_INDEX.moss
-      let leftScore = 0
-      let rightScore = 0
       const baseX = Math.round(c.x)
       const baseY = Math.round(c.y)
-      for (let dy = -20; dy <= 20; dy += 10) {
-        const sy = Math.max(0, Math.min(WORLD_H - 1, baseY + dy))
-        for (let dx = 12; dx <= 160; dx += 12) {
-          const lMat = tileAt(w, Math.max(0, baseX - dx), sy)
-          const rMat = tileAt(w, Math.min(WORLD_W - 1, baseX + dx), sy)
-          if (lMat === grassIdx || lMat === mossIdx) leftScore++
-          if (rMat === grassIdx || rMat === mossIdx) rightScore++
+      let leftScore = 0
+      let rightScore = 0
+      // If the player has painted corridor paths, prefer those over terrain scan.
+      const corr = w.corridors
+      if (corr) {
+        for (let dy = -15; dy <= 15; dy += 5) {
+          const sy = Math.max(0, Math.min(WORLD_H - 1, baseY + dy))
+          for (let dx = 12; dx <= 200; dx += 20) {
+            if (corr[sy * WORLD_W + Math.max(0, baseX - dx)]) leftScore++
+            if (corr[sy * WORLD_W + Math.min(WORLD_W - 1, baseX + dx)]) rightScore++
+          }
+        }
+      }
+      // Fall back to grass/moss scan if no corridor preference found.
+      if (leftScore === rightScore) {
+        const grassIdx = MATERIAL_INDEX.grass
+        const mossIdx = MATERIAL_INDEX.moss
+        for (let dy = -20; dy <= 20; dy += 10) {
+          const sy = Math.max(0, Math.min(WORLD_H - 1, baseY + dy))
+          for (let dx = 12; dx <= 160; dx += 12) {
+            const lMat = tileAt(w, Math.max(0, baseX - dx), sy)
+            const rMat = tileAt(w, Math.min(WORLD_W - 1, baseX + dx), sy)
+            if (lMat === grassIdx || lMat === mossIdx) leftScore++
+            if (rMat === grassIdx || rMat === mossIdx) rightScore++
+          }
         }
       }
       if (leftScore !== rightScore) {

--- a/src/app/micro-land/domain/sim/world.ts
+++ b/src/app/micro-land/domain/sim/world.ts
@@ -64,6 +64,7 @@ export function createWorld(seed = 1337): WorldState {
     natives: [],
     nextPlantSeed: 0,
     dormant: false,
+    corridors: new Uint8Array(WORLD_W * WORLD_H),
   }
 }
 

--- a/src/app/micro-land/domain/types.ts
+++ b/src/app/micro-land/domain/types.ts
@@ -776,6 +776,12 @@ export interface WorldState {
    * generative — painting, placing, summoning, changing theme — wakes it again.
    */
   dormant: boolean
+  /**
+   * Per-tile corridor markers, painted by the player. Migrating creatures
+   * prefer moving toward marked tiles over bare terrain scanning.
+   * Optional so old serialised worlds without it don't crash.
+   */
+  corridors?: Uint8Array
 }
 
 // ---------------------------------------------------------------------------

--- a/src/app/micro-land/game-instance.ts
+++ b/src/app/micro-land/game-instance.ts
@@ -2205,6 +2205,23 @@ export class GameInstance {
     // Inspecting is resolved on pointerdown; it never paints.
     if (tool.kind === 'inspect') return
 
+    if (tool.kind === 'corridor') {
+      if (!this.world.corridors) this.world.corridors = new Uint8Array(WORLD_W * WORLD_H)
+      const r = state.brush
+      const x0 = Math.max(0, Math.round(x) - r)
+      const x1 = Math.min(WORLD_W - 1, Math.round(x) + r)
+      const y0 = Math.max(0, Math.round(y) - r)
+      const y1 = Math.min(WORLD_H - 1, Math.round(y) + r)
+      for (let cy = y0; cy <= y1; cy++) {
+        for (let cx = x0; cx <= x1; cx++) {
+          const dx = cx - x, dy = cy - y
+          if (state.brushShape !== 'square' && dx * dx + dy * dy > r * r) continue
+          this.world.corridors[cy * WORLD_W + cx] = 1
+        }
+      }
+      return
+    }
+
     if (tool.kind === 'biome') {
       const biome = BIOME_BY_ID[tool.biomeId]
       if (biome) {

--- a/src/app/micro-land/rendering/renderer.ts
+++ b/src/app/micro-land/rendering/renderer.ts
@@ -498,6 +498,7 @@ export class Renderer {
     this.drawNests(w, vx, vw)
     this.drawTombstones(w, vx, vw)
     if (heatmap) this.drawHeatmap(heatmap, vx, vw)
+    if (w.corridors) this.drawCorridors(w.corridors, vx, vw)
     this.drawEggs(w, vx, vw)
     this.drawCreatures(w, vx, vw)
     this.drawStatusDots(w, vx, vw)
@@ -733,6 +734,19 @@ export class Renderer {
         if (v < 0.5) continue
         ctx.globalAlpha = Math.min(0.5, v / peak)
         ctx.fillStyle = '#ff3200'
+        ctx.fillRect(x, y, 1, 1)
+      }
+    }
+    ctx.globalAlpha = 1
+  }
+
+  private drawCorridors(corridors: Uint8Array, vx: number, vw: number): void {
+    const ctx = this.wctx
+    for (let x = vx; x < vx + vw; x++) {
+      for (let y = 0; y < WORLD_H; y++) {
+        if (!corridors[y * WORLD_W + x]) continue
+        ctx.globalAlpha = 0.38
+        ctx.fillStyle = '#ffe066'
         ctx.fillRect(x, y, 1, 1)
       }
     }

--- a/src/app/micro-land/store.ts
+++ b/src/app/micro-land/store.ts
@@ -48,6 +48,7 @@ export type Tool =
   | { kind: 'material'; material: MaterialId }
   | { kind: 'erase' }
   | { kind: 'biome'; biomeId: string }
+  | { kind: 'corridor' }
   | { kind: 'creature'; blueprintId: string }
   | { kind: 'inspect' }
 


### PR DESCRIPTION
## Summary
- New "Corridor path" brush in the terrain toolbar (yellow arrow swatch)
- Corridor tiles are stored as a `Uint8Array` overlay in `WorldState` — no physics interaction
- Migrating creatures (hunger-driven, migrateTimer > threshold) scan for corridor tiles first and steer toward them; fall back to grass/moss terrain scan if no corridors are nearby
- Corridors render as semi-transparent yellow highlights on the canvas

## How to test
- [ ] Start a world, paint some corridors with the new Path brush
- [ ] Yellow highlights appear where corridors are painted
- [ ] Add hungry animals — let them run out of food
- [ ] After ~30s of hunger, they should migrate toward the corridor path
- [ ] Worlds without corridors painted behave exactly as before (fall-back scan)

Closes #2970

🤖 Generated with [Claude Code](https://claude.com/claude-code)