### PR TITLE
[microland] Canvas view preset — Wide / Standard / Close (#2962)

### DIFF
--- a/src/app/micro-land/MicroLandGame.tsx
+++ b/src/app/micro-land/MicroLandGame.tsx
@@ -101,6 +101,7 @@ export function MicroLandGame() {
       unsubscribe = useMicroLand.subscribe((state, previous) => {
         if (state.themeId !== previous.themeId) game?.setTheme(state.themeId)
         if (state.reshuffleToken !== previous.reshuffleToken) game?.reshuffle()
+        if (state.viewScale !== previous.viewScale) game?.setViewScale(state.viewScale)
         if (state.locateRequest !== previous.locateRequest && state.locateRequest && game) {
           const found = game.locateSpecies(state.locateRequest.blueprintId)
           if (!found) {

--- a/src/app/micro-land/components/settings-panel.tsx
+++ b/src/app/micro-land/components/settings-panel.tsx
@@ -37,6 +37,44 @@ function show(knob: Knob, value: number): string {
   return knob.unit ? `${text}${knob.unit === 's' ? 's' : ` ${knob.unit}`}` : text
 }
 
+function ViewScaleButtons() {
+  const viewScale = useMicroLand(s => s.viewScale)
+  const setViewScale = useMicroLand(s => s.setViewScale)
+  const options: Array<{ key: 'wide' | 'standard' | 'close'; label: string }> = [
+    { key: 'wide', label: 'Wide' },
+    { key: 'standard', label: 'Standard' },
+    { key: 'close', label: 'Close' },
+  ]
+  return (
+    <div style={{ display: 'flex', gap: 8 }}>
+      {options.map(({ key, label }) => (
+        <button
+          key={key}
+          type="button"
+          className="cc-btn"
+          onClick={() => setViewScale(key)}
+          aria-pressed={viewScale === key}
+          style={{
+            flex: 1,
+            padding: '6px 4px',
+            minHeight: 32,
+            borderRadius: 6,
+            border: `1px solid ${viewScale === key ? 'var(--cc-mint)' : 'var(--cc-mint-line)'}`,
+            background: viewScale === key ? 'rgba(100,220,180,0.12)' : 'transparent',
+            color: viewScale === key ? 'var(--cc-mint)' : 'var(--cc-text-muted)',
+            fontFamily: 'var(--cc-font-mono)',
+            fontSize: 11,
+            letterSpacing: 1,
+            textTransform: 'uppercase' as const,
+          }}
+        >
+          {label}
+        </button>
+      ))}
+    </div>
+  )
+}
+
 /**
  * The knobs, out of the way.
  *
@@ -251,6 +289,21 @@ export function SettingsPanel() {
             </div>
           </section>
         ))}
+
+        <section
+          className="px-4 py-3"
+          style={{ borderTop: '1px solid var(--cc-panel-divider)', marginTop: 12 }}
+        >
+          <h3 style={heading}>Canvas view</h3>
+          <p
+            className="pb-2 pt-1"
+            style={{ fontSize: 11, color: 'var(--cc-text-muted)', opacity: 0.8, lineHeight: 1.5 }}
+          >
+            How much of the world is visible at once. Wide shows the whole land; Close shows fine
+            detail.
+          </p>
+          <ViewScaleButtons />
+        </section>
 
         <div className="h-4" />
       </div>

--- a/src/app/micro-land/game-instance.ts
+++ b/src/app/micro-land/game-instance.ts
@@ -1909,6 +1909,14 @@ export class GameInstance {
     if (this.renderer.resetZoom()) this.pushCamera()
   }
 
+  setViewScale(preset: 'wide' | 'standard' | 'close'): void {
+    const target =
+      preset === 'wide' ? this.renderer.minZoomLevel :
+      preset === 'close' ? 2 :
+      1
+    if (this.renderer.setZoom(target)) this.pushCamera()
+  }
+
   /**
    * Tell the UI what the camera can currently do.
    *

--- a/src/app/micro-land/rendering/renderer.ts
+++ b/src/app/micro-land/rendering/renderer.ts
@@ -378,6 +378,11 @@ export class Renderer {
     return this.setZoom(1)
   }
 
+  /** The minimum zoom — shows the full world width. */
+  get minZoomLevel(): number {
+    return this.minZoom
+  }
+
   /**
    * Slide just far enough to bring a point back on screen.
    *

--- a/src/app/micro-land/store.ts
+++ b/src/app/micro-land/store.ts
@@ -365,6 +365,9 @@ interface MicroLandState {
    */
   canZoomIn: boolean
   canZoomOut: boolean
+  /** Player's preferred zoom preset. Controls the canvas zoom level. */
+  viewScale: 'wide' | 'standard' | 'close'
+  setViewScale: (scale: 'wide' | 'standard' | 'close') => void
 
   notices: Notice[]
 
@@ -587,6 +590,7 @@ export const useMicroLand = create<MicroLandState>(set => ({
   canPan: true,
   canZoomIn: true,
   canZoomOut: true,
+  viewScale: 'standard',
 
   records: EMPTY_RECORDS,
   archive: [],
@@ -710,6 +714,7 @@ export const useMicroLand = create<MicroLandState>(set => ({
   setMilestones: milestones => set({ milestones }),
   setCanPan: canPan => set({ canPan }),
   setZoomState: (canZoomIn, canZoomOut) => set({ canZoomIn, canZoomOut }),
+  setViewScale: viewScale => set({ viewScale }),
 
   setSaveState: saveState => set({ saveState }),
   setShelf: shelf => set({ shelf }),


### PR DESCRIPTION
## Summary
- New "Canvas view" section in the Settings panel with three zoom presets
- **Wide** — zooms out to show the full world width (3 screens)
- **Standard** — default 1-screen framing (existing behavior)
- **Close** — zooms in 2× for fine pixel-art detail
- Active preset is highlighted in mint; stored in Zustand and applied immediately to the renderer

## Test plan
- [ ] Open Settings → scroll to bottom → see "Canvas view" with 3 buttons
- [ ] Click Wide → world zooms out to full width
- [ ] Click Standard → returns to default 1-screen view
- [ ] Click Close → zooms in 2×
- [ ] Switching between them is smooth (no page reload)

Closes #2962

🤖 Generated with [Claude Code](https://claude.com/claude-code)