### PR TITLE
[microland] Global speed-run leaderboard (#2963)

### DIFF
--- a/src/app/api/v1/micro-land/speed-runs/route.ts
+++ b/src/app/api/v1/micro-land/speed-runs/route.ts
@@ -1,0 +1,47 @@
+import { type NextRequest, NextResponse } from 'next/server'
+import { verifyRequestAuth } from '@/lib/api/auth'
+import { getOrCreateProfile } from '@/lib/users/profile'
+import { getLeaderboard, saveGlobalSpeedRun } from '@/lib/micro-land/speed-run-store'
+
+export async function GET(request: NextRequest) {
+  const targetGen = Number(request.nextUrl.searchParams.get('targetGen'))
+  const limit = Math.min(20, Math.max(1, Number(request.nextUrl.searchParams.get('limit') ?? '10')))
+  if (!Number.isFinite(targetGen) || targetGen <= 0) {
+    return NextResponse.json({ error: 'targetGen is required.' }, { status: 400 })
+  }
+  try {
+    const entries = await getLeaderboard(targetGen, limit)
+    return NextResponse.json({ targetGen, entries })
+  } catch (error: unknown) {
+    const msg = error instanceof Error ? error.message : String(error)
+    if (msg.includes('FAILED_PRECONDITION') || msg.includes('requires an index')) {
+      return NextResponse.json({ targetGen, entries: [], notice: 'Leaderboard index is building.' })
+    }
+    console.error('speed-run leaderboard failed:', error)
+    return NextResponse.json({ error: 'Could not fetch leaderboard.' }, { status: 500 })
+  }
+}
+
+export async function POST(request: NextRequest) {
+  const auth = await verifyRequestAuth(request)
+  if ('error' in auth) return auth.error
+  if (auth.claims.isAnonymous) {
+    return NextResponse.json({ error: 'Sign in to appear on the leaderboard.' }, { status: 403 })
+  }
+  let body: unknown
+  try { body = await request.json() } catch { return NextResponse.json({ error: 'Invalid JSON.' }, { status: 400 }) }
+  if (typeof body !== 'object' || body === null) return NextResponse.json({ error: 'Invalid body.' }, { status: 400 })
+  const { targetGen, theme, seconds } = body as Record<string, unknown>
+  if (typeof targetGen !== 'number' || typeof theme !== 'string' || typeof seconds !== 'number') {
+    return NextResponse.json({ error: 'targetGen, theme, seconds required.' }, { status: 400 })
+  }
+  try {
+    const profile = await getOrCreateProfile(auth.claims)
+    const displayName = profile.nickname || 'Explorer'
+    await saveGlobalSpeedRun({ uid: auth.claims.uid, displayName, theme, targetGen, seconds })
+    return NextResponse.json({ ok: true })
+  } catch (error) {
+    console.error('speed-run save failed:', error)
+    return NextResponse.json({ error: 'Could not save run.' }, { status: 500 })
+  }
+}

--- a/src/app/micro-land/components/speed-run-overlay.tsx
+++ b/src/app/micro-land/components/speed-run-overlay.tsx
@@ -1,5 +1,7 @@
 'use client'
+import { useEffect, useState } from 'react'
 import { useMicroLand } from '@/app/micro-land/store'
+import { getFirebaseAuth } from '@/lib/firebase/client'
 
 function formatTime(seconds: number): string {
   const s = Math.max(0, Math.floor(seconds))
@@ -13,6 +15,55 @@ export function SpeedRunOverlay() {
   const deepestGeneration = useMicroLand(s => s.records.deepestGeneration)
   const cancelSpeedRun = useMicroLand(s => s.cancelSpeedRun)
   const requestReshuffle = useMicroLand(s => s.requestReshuffle)
+  const themeId = useMicroLand(s => s.themeId)
+  const leaderboard = useMicroLand(s => s.speedRunLeaderboard)
+  const setLeaderboard = useMicroLand(s => s.setSpeedRunLeaderboard)
+  const [submitting, setSubmitting] = useState(false)
+  const [submitted, setSubmitted] = useState(false)
+
+  useEffect(() => {
+    if (speedRun.result !== 'won' || submitted) return
+    const wonSeconds = speedRun.wonSeconds
+    if (wonSeconds == null) return
+
+    async function submitAndFetch() {
+      setSubmitting(true)
+      // Submit if signed in and not anonymous
+      try {
+        const auth = getFirebaseAuth()
+        const user = auth.currentUser
+        if (user && !user.isAnonymous) {
+          const token = await user.getIdToken()
+          await fetch('/api/v1/micro-land/speed-runs', {
+            method: 'POST',
+            headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+            body: JSON.stringify({ targetGen: speedRun.targetGeneration, theme: themeId, seconds: wonSeconds }),
+          })
+        }
+      } catch { /* best effort */ }
+
+      // Always fetch leaderboard
+      try {
+        const res = await fetch(`/api/v1/micro-land/speed-runs?targetGen=${speedRun.targetGeneration}&limit=10`)
+        if (res.ok) {
+          const data = await res.json() as { entries: Array<{ displayName: string; theme: string; seconds: number; completedAt: number }> }
+          setLeaderboard(data.entries)
+        }
+      } catch { /* best effort */ }
+
+      setSubmitting(false)
+      setSubmitted(true)
+    }
+    void submitAndFetch()
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [speedRun.result])
+
+  useEffect(() => {
+    if (speedRun.result === 'none') {
+      setLeaderboard(null)
+      setSubmitted(false)
+    }
+  }, [speedRun.result, setLeaderboard])
 
   if (!speedRun.active && speedRun.result === 'none') return null
 
@@ -78,6 +129,25 @@ export function SpeedRunOverlay() {
               Keep watching
             </button>
           </div>
+          {leaderboard && leaderboard.length > 0 && (
+            <div style={{ marginTop: 20, textAlign: 'left' }}>
+              <div style={{ fontFamily: 'var(--cc-font-mono)', fontSize: 9, letterSpacing: 1.6, textTransform: 'uppercase', color: 'var(--cc-text-muted)', marginBottom: 8 }}>
+                Gen {speedRun.targetGeneration} leaderboard
+              </div>
+              {leaderboard.map((entry, i) => (
+                <div key={i} style={{ display: 'flex', justifyContent: 'space-between', gap: 8, padding: '3px 0', fontSize: 12, color: i === 0 ? 'var(--cc-mint)' : 'var(--cc-text-default)' }}>
+                  <span style={{ fontFamily: 'var(--cc-font-mono)', minWidth: 16 }}>{i + 1}.</span>
+                  <span style={{ flex: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{entry.displayName}</span>
+                  <span style={{ fontFamily: 'var(--cc-font-mono)', color: 'var(--cc-mint)', opacity: i === 0 ? 1 : 0.7 }}>{formatTime(entry.seconds)}</span>
+                </div>
+              ))}
+            </div>
+          )}
+          {submitting && (
+            <div style={{ marginTop: 12, fontSize: 11, color: 'var(--cc-text-muted)', fontFamily: 'var(--cc-font-mono)', letterSpacing: 0.5 }}>
+              Submitting to leaderboard…
+            </div>
+          )}
         </div>
       </div>
     )

--- a/src/app/micro-land/game-instance.ts
+++ b/src/app/micro-land/game-instance.ts
@@ -812,7 +812,7 @@ export class GameInstance {
       const deepestGen = population.reduce((max, p) => Math.max(max, p.maxGeneration), 0)
       const timeUsed = this.world.elapsed - sr.startElapsed
       if (deepestGen >= sr.targetGeneration) {
-        useMicroLand.getState().endSpeedRun('won')
+        useMicroLand.getState().endSpeedRun('won', Math.round(timeUsed))
         saveSpeedRunRecord({
           theme: useMicroLand.getState().themeId,
           targetGen: sr.targetGeneration,

--- a/src/app/micro-land/store.ts
+++ b/src/app/micro-land/store.ts
@@ -28,6 +28,8 @@ export interface SpeedRunState {
   /** World elapsed time (seconds) when the run started — so countdown = timeLimit - (elapsed - startElapsed). */
   startElapsed: number
   result: 'none' | 'won' | 'lost'
+  /** Seconds taken when result is 'won'. Null otherwise. */
+  wonSeconds: number | null
 }
 
 import type { SaveState } from './chronicle/chronicle'
@@ -314,7 +316,7 @@ interface MicroLandState {
   requestWorkshopSpawn: (blueprint: CreatureBlueprint, traits: Traits) => void
   clearWorkshopSpawnRequest: () => void
   startSpeedRun: (targetGeneration: number, timeLimitSeconds: number, currentElapsed: number) => void
-  endSpeedRun: (result: 'won' | 'lost') => void
+  endSpeedRun: (result: 'won' | 'lost', wonSeconds?: number) => void
   cancelSpeedRun: () => void
   requestReshuffle: () => void
   /**
@@ -365,6 +367,10 @@ interface MicroLandState {
    */
   canZoomIn: boolean
   canZoomOut: boolean
+
+  /** Global leaderboard fetched after a speed run win. Null = not yet fetched. */
+  speedRunLeaderboard: Array<{ displayName: string; theme: string; seconds: number; completedAt: number }> | null
+  setSpeedRunLeaderboard: (entries: Array<{ displayName: string; theme: string; seconds: number; completedAt: number }> | null) => void
 
   notices: Notice[]
 
@@ -579,7 +585,7 @@ export const useMicroLand = create<MicroLandState>(set => ({
   challengeActive: null,
   workshopOpen: false,
   workshopSpawnRequest: null,
-  speedRun: { active: false, targetGeneration: 10, timeLimitSeconds: 300, startElapsed: 0, result: 'none' },
+  speedRun: { active: false, targetGeneration: 10, timeLimitSeconds: 300, startElapsed: 0, result: 'none', wonSeconds: null },
   reshuffleToken: 0,
   toolbarOpen: true,
   tuning: { ...TUNING },
@@ -587,6 +593,7 @@ export const useMicroLand = create<MicroLandState>(set => ({
   canPan: true,
   canZoomIn: true,
   canZoomOut: true,
+  speedRunLeaderboard: null,
 
   records: EMPTY_RECORDS,
   archive: [],
@@ -675,9 +682,9 @@ export const useMicroLand = create<MicroLandState>(set => ({
     set(s => ({ workshopSpawnRequest: { blueprint, traits, serial: (s.workshopSpawnRequest?.serial ?? 0) + 1 } })),
   clearWorkshopSpawnRequest: () => set({ workshopSpawnRequest: null }),
   startSpeedRun: (targetGeneration, timeLimitSeconds, currentElapsed) =>
-    set({ speedRun: { active: true, targetGeneration, timeLimitSeconds, startElapsed: currentElapsed, result: 'none' } }),
-  endSpeedRun: result =>
-    set(s => ({ speedRun: { ...s.speedRun, active: false, result } })),
+    set({ speedRun: { active: true, targetGeneration, timeLimitSeconds, startElapsed: currentElapsed, result: 'none', wonSeconds: null } }),
+  endSpeedRun: (result, wonSeconds) =>
+    set(s => ({ speedRun: { ...s.speedRun, active: false, result, wonSeconds: wonSeconds ?? null } })),
   cancelSpeedRun: () =>
     set(s => ({ speedRun: { ...s.speedRun, active: false, result: 'none' } })),
   requestReshuffle: () => set(s => ({ reshuffleToken: s.reshuffleToken + 1 })),
@@ -710,6 +717,7 @@ export const useMicroLand = create<MicroLandState>(set => ({
   setMilestones: milestones => set({ milestones }),
   setCanPan: canPan => set({ canPan }),
   setZoomState: (canZoomIn, canZoomOut) => set({ canZoomIn, canZoomOut }),
+  setSpeedRunLeaderboard: entries => set({ speedRunLeaderboard: entries }),
 
   setSaveState: saveState => set({ saveState }),
   setShelf: shelf => set({ shelf }),

--- a/src/lib/micro-land/speed-run-store.ts
+++ b/src/lib/micro-land/speed-run-store.ts
@@ -1,0 +1,47 @@
+import { FieldValue, Timestamp } from 'firebase-admin/firestore'
+import { getFirestoreDb } from '@/lib/firebase/server'
+
+export interface GlobalSpeedRunRecord {
+  uid: string
+  displayName: string
+  theme: string
+  targetGen: number
+  seconds: number
+  completedAt: Timestamp | FieldValue
+}
+
+export interface LeaderboardEntry {
+  displayName: string
+  theme: string
+  seconds: number
+  completedAt: number  // ms epoch
+}
+
+function speedRunsRef() {
+  return getFirestoreDb().collection('microLandSpeedRuns')
+}
+
+export async function saveGlobalSpeedRun(record: Omit<GlobalSpeedRunRecord, 'completedAt'>): Promise<void> {
+  await speedRunsRef().add({
+    ...record,
+    completedAt: FieldValue.serverTimestamp(),
+  })
+}
+
+export async function getLeaderboard(targetGen: number, limit = 10): Promise<LeaderboardEntry[]> {
+  const snap = await speedRunsRef()
+    .where('targetGen', '==', targetGen)
+    .orderBy('seconds', 'asc')
+    .limit(limit)
+    .get()
+
+  return snap.docs.map(doc => {
+    const d = doc.data() as GlobalSpeedRunRecord
+    return {
+      displayName: d.displayName,
+      theme: d.theme,
+      seconds: d.seconds,
+      completedAt: (d.completedAt as Timestamp)?.toMillis?.() ?? Date.now(),
+    }
+  })
+}


### PR DESCRIPTION
## Summary
- New `microLandSpeedRuns` Firestore collection — one doc per completed run
- `GET /api/v1/micro-land/speed-runs?targetGen=N` — public leaderboard endpoint
- `POST /api/v1/micro-land/speed-runs` — authenticated submission (non-anonymous only)
- Win modal now shows the top 10 times for the same generation goal
- Leaderboard is fetched client-side after each win; submission is fire-and-forget
- Degrades gracefully while the Firestore composite index (`targetGen + seconds`) builds

## Firestore index needed
First call will fail with FAILED_PRECONDITION and log a URL to create the composite index. The GET handler returns `{ entries: [], notice: '...' }` in the meantime. Create the index at the URL in the server logs.

## Test plan
- [ ] Win a speed run → win modal shows "Submitting to leaderboard…" then clears
- [ ] Leaderboard appears below the buttons with rank, name, and time
- [ ] Anonymous users see the leaderboard but don't appear on it
- [ ] Signed-in users appear with their nickname
- [ ] "Try again" resets the leaderboard for the next attempt

Closes #2963

🤖 Generated with [Claude Code](https://claude.com/claude-code)