### PR TITLE
[microland] Blueprint gallery — share creature designs with a link (#2964)

### DIFF
--- a/src/app/api/v1/micro-land/blueprints/[id]/route.ts
+++ b/src/app/api/v1/micro-land/blueprints/[id]/route.ts
@@ -1,0 +1,15 @@
+import { type NextRequest, NextResponse } from 'next/server'
+import { getSharedBlueprint } from '@/lib/micro-land/blueprint-store'
+
+export async function GET(_request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params
+  if (!id) return NextResponse.json({ error: 'id required.' }, { status: 400 })
+  try {
+    const shared = await getSharedBlueprint(id)
+    if (!shared) return NextResponse.json({ error: 'Not found.' }, { status: 404 })
+    return NextResponse.json({ shared })
+  } catch (error) {
+    console.error('blueprint fetch failed:', error)
+    return NextResponse.json({ error: 'Could not fetch blueprint.' }, { status: 500 })
+  }
+}

--- a/src/app/api/v1/micro-land/blueprints/route.ts
+++ b/src/app/api/v1/micro-land/blueprints/route.ts
@@ -1,0 +1,42 @@
+import { type NextRequest, NextResponse } from 'next/server'
+import { verifyRequestAuth } from '@/lib/api/auth'
+import { getOrCreateProfile } from '@/lib/users/profile'
+import { listRecentBlueprints, saveSharedBlueprint } from '@/lib/micro-land/blueprint-store'
+import type { CreatureBlueprint } from '@/app/micro-land/domain/types'
+
+export async function GET() {
+  try {
+    const blueprints = await listRecentBlueprints(20)
+    return NextResponse.json({ blueprints: blueprints.map(b => ({ ...b, blueprintJson: undefined })) })
+  } catch (error) {
+    console.error('blueprint list failed:', error)
+    return NextResponse.json({ error: 'Could not list blueprints.' }, { status: 500 })
+  }
+}
+
+export async function POST(request: NextRequest) {
+  const auth = await verifyRequestAuth(request)
+  if ('error' in auth) return auth.error
+
+  let body: unknown
+  try { body = await request.json() } catch {
+    return NextResponse.json({ error: 'Invalid JSON.' }, { status: 400 })
+  }
+  if (typeof body !== 'object' || body === null) {
+    return NextResponse.json({ error: 'Invalid body.' }, { status: 400 })
+  }
+  const { blueprint } = body as Record<string, unknown>
+  if (typeof blueprint !== 'object' || blueprint === null || typeof (blueprint as Record<string, unknown>).name !== 'string') {
+    return NextResponse.json({ error: 'blueprint object with name is required.' }, { status: 400 })
+  }
+
+  try {
+    const profile = await getOrCreateProfile(auth.claims)
+    const nickname = profile.nickname || 'Explorer'
+    const id = await saveSharedBlueprint(blueprint as CreatureBlueprint, nickname)
+    return NextResponse.json({ id })
+  } catch (error) {
+    console.error('blueprint save failed:', error)
+    return NextResponse.json({ error: 'Could not save blueprint.' }, { status: 500 })
+  }
+}

--- a/src/app/micro-land/MicroLandGame.tsx
+++ b/src/app/micro-land/MicroLandGame.tsx
@@ -179,6 +179,31 @@ export function MicroLandGame() {
   useEffect(() => onSaveState(useMicroLand.getState().setSaveState), [])
   useEffect(() => onShelf(useMicroLand.getState().setShelf), [])
 
+  // Load a blueprint from URL param and spawn it when the game is ready
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search)
+    const blueprintId = params.get('blueprint')
+    if (!blueprintId) return
+    // Wait for game to be ready, then spawn
+    const trySpawn = async () => {
+      for (let i = 0; i < 20; i++) {
+        if (gameRef.current) break
+        await new Promise(r => setTimeout(r, 300))
+      }
+      if (!gameRef.current) return
+      try {
+        const res = await fetch(`/api/v1/micro-land/blueprints/${blueprintId}`)
+        if (!res.ok) return
+        const { shared } = await res.json() as { shared: { blueprintJson: string; name: string; creatorNickname: string } }
+        const blueprint = JSON.parse(shared.blueprintJson) as import('./domain/types').CreatureBlueprint
+        useMicroLand.getState().requestWorkshopSpawn(blueprint, blueprint.traitDefaults ?? {})
+        useMicroLand.getState().notify(`Spawning "${shared.name}" by ${shared.creatorNickname}`)
+      } catch { /* best effort */ }
+    }
+    void trySpawn()
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
   const adoptedRef = useRef<string | null>(null)
   useEffect(() => {
     const uid = user?.uid

--- a/src/app/micro-land/components/blueprint-workshop.tsx
+++ b/src/app/micro-land/components/blueprint-workshop.tsx
@@ -54,6 +54,9 @@ export function WorkshopPane({ onClose }: { onClose: () => void }) {
   const [traits, setTraits] = useState<Traits>(defaultTraits)
   const [hue, setHue] = useState(0)
   const [shade, setShade] = useState(1)
+  const [sharing, setSharing] = useState(false)
+  const [shareMsg, setShareMsg] = useState<string | null>(null)
+  const notify = useMicroLand(s => s.notify)
 
   const animals = blueprints.filter(bp => bp.move.kind !== 'root')
   const displayList = animals.length > 0 ? animals : blueprints
@@ -94,6 +97,49 @@ export function WorkshopPane({ onClose }: { onClose: () => void }) {
     requestWorkshopSpawn(finalBlueprint, finalTraits)
     onClose()
     setStep('pick')
+  }
+
+  async function handleShare() {
+    if (!base) return
+    if (!name.trim()) { setNameError(true); return }
+    setNameError(false)
+    setSharing(true)
+    setShareMsg(null)
+    const finalBlueprint: CreatureBlueprint = {
+      ...base,
+      name: name.trim(),
+      move: { ...base.move, kind: locoKind },
+      diet: { ...base.diet, eats: DIET_OPTIONS[dietIdx].eats },
+    }
+    try {
+      // Get auth token if available
+      const headers: Record<string, string> = { 'Content-Type': 'application/json' }
+      try {
+        const { getAuth } = await import('firebase/auth')
+        const { getApp } = await import('firebase/app')
+        const user = getAuth(getApp()).currentUser
+        if (user) {
+          const token = await user.getIdToken()
+          headers['Authorization'] = `Bearer ${token}`
+        }
+      } catch { /* no auth token, still try */ }
+
+      const res = await fetch('/api/v1/micro-land/blueprints', {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({ blueprint: finalBlueprint }),
+      })
+      if (!res.ok) throw new Error('Save failed')
+      const { id } = await res.json() as { id: string }
+      const url = `${window.location.origin}/micro-land?blueprint=${id}`
+      await navigator.clipboard.writeText(url)
+      notify('Blueprint link copied to clipboard!')
+      setShareMsg('Link copied!')
+    } catch {
+      notify('Could not share blueprint — try again.')
+      setShareMsg('Failed')
+    }
+    setSharing(false)
   }
 
   const chipBase = {
@@ -370,6 +416,21 @@ export function WorkshopPane({ onClose }: { onClose: () => void }) {
               }}
             >
               Cancel
+            </button>
+            <button
+              type="button"
+              className="cc-btn"
+              onClick={() => void handleShare()}
+              disabled={sharing}
+              title="Share this design — copies a link to clipboard"
+              style={{
+                ...chipBase,
+                border: '1px solid var(--cc-panel-divider)',
+                color: shareMsg === 'Link copied!' ? 'var(--cc-mint)' : 'var(--cc-text-muted)',
+                opacity: sharing ? 0.5 : 1,
+              }}
+            >
+              {sharing ? 'Sharing…' : shareMsg ?? 'Share link'}
             </button>
             <button
               type="button"

--- a/src/lib/micro-land/blueprint-store.ts
+++ b/src/lib/micro-land/blueprint-store.ts
@@ -1,0 +1,58 @@
+import { FieldValue, Timestamp } from 'firebase-admin/firestore'
+import { getFirestoreDb } from '@/lib/firebase/server'
+import type { CreatureBlueprint } from '@/app/micro-land/domain/types'
+
+export interface SharedBlueprint {
+  id: string
+  name: string
+  creatorNickname: string
+  blueprintJson: string  // JSON.stringify(blueprint)
+  createdAt: number      // ms epoch
+}
+
+function blueprintsRef() {
+  return getFirestoreDb().collection('microLandBlueprints')
+}
+
+export async function saveSharedBlueprint(
+  blueprint: CreatureBlueprint,
+  creatorNickname: string
+): Promise<string> {
+  const doc = await blueprintsRef().add({
+    name: blueprint.name,
+    creatorNickname,
+    blueprintJson: JSON.stringify(blueprint),
+    createdAt: FieldValue.serverTimestamp(),
+  })
+  return doc.id
+}
+
+export async function getSharedBlueprint(id: string): Promise<SharedBlueprint | null> {
+  const snap = await blueprintsRef().doc(id).get()
+  if (!snap.exists) return null
+  const d = snap.data()!
+  return {
+    id: snap.id,
+    name: typeof d.name === 'string' ? d.name : 'Unknown',
+    creatorNickname: typeof d.creatorNickname === 'string' ? d.creatorNickname : 'Explorer',
+    blueprintJson: typeof d.blueprintJson === 'string' ? d.blueprintJson : '{}',
+    createdAt: (d.createdAt as Timestamp)?.toMillis?.() ?? Date.now(),
+  }
+}
+
+export async function listRecentBlueprints(limit = 20): Promise<SharedBlueprint[]> {
+  const snap = await blueprintsRef()
+    .orderBy('createdAt', 'desc')
+    .limit(limit)
+    .get()
+  return snap.docs.map(doc => {
+    const d = doc.data()
+    return {
+      id: doc.id,
+      name: typeof d.name === 'string' ? d.name : 'Unknown',
+      creatorNickname: typeof d.creatorNickname === 'string' ? d.creatorNickname : 'Explorer',
+      blueprintJson: typeof d.blueprintJson === 'string' ? d.blueprintJson : '{}',
+      createdAt: (d.createdAt as Timestamp)?.toMillis?.() ?? Date.now(),
+    }
+  })
+}


### PR DESCRIPTION
## Summary
- New Firestore collection `microLandBlueprints` stores shared creature designs
- "Share link" button in the Blueprint Workshop → saves to Firestore → copies `/micro-land?blueprint={id}` to clipboard
- Visiting a share link automatically spawns the creature into the world and shows a notification: "Spawning 'Name' by Creator"
- Public GET endpoints for listing recent blueprints and fetching by ID
- Works for both anonymous and signed-in users

## API routes added
- `GET /api/v1/micro-land/blueprints` — list 20 most recent shared designs
- `POST /api/v1/micro-land/blueprints` — save a design (auth required)
- `GET /api/v1/micro-land/blueprints/[id]` — fetch one by ID (public)

## Test plan
- [ ] Open Blueprint Workshop → configure a creature → click "Share link" → "Blueprint link copied to clipboard!" notification
- [ ] Paste the copied link in a new tab → the creature spawns into the world
- [ ] Share notification: "Spawning 'Creature Name' by YourName"
- [ ] Works for both anonymous and signed-in users

Closes #2964

🤖 Generated with [Claude Code](https://claude.com/claude-code)