### PR TITLE
[microland] Creature hover tooltip — mood and hunger bar (#2991)

### DIFF
--- a/src/app/micro-land/MicroLandGame.tsx
+++ b/src/app/micro-land/MicroLandGame.tsx
@@ -16,6 +16,7 @@ import { CreatureBuilder } from '@/app/micro-land/components/creature-builder'
 import { ReplayBar } from '@/app/micro-land/components/replay-bar'
 import { FieldGuide } from '@/app/micro-land/components/field-guide'
 import { Hud } from '@/app/micro-land/components/hud'
+import { CreatureTooltip } from '@/app/micro-land/components/creature-tooltip'
 import { Inspector } from '@/app/micro-land/components/inspector'
 import { Notices } from '@/app/micro-land/components/notices'
 import { PanControls } from '@/app/micro-land/components/pan-controls'
@@ -466,6 +467,7 @@ export function MicroLandGame() {
             <ZoomControls onZoom={handleZoom} />
             <Notices />
             <Inspector onName={handleName} />
+            <CreatureTooltip />
           </div>
           <Toolbar onRemoveSpecies={handleRemoveSpecies} />
         </div>

--- a/src/app/micro-land/components/creature-tooltip.tsx
+++ b/src/app/micro-land/components/creature-tooltip.tsx
@@ -1,0 +1,73 @@
+'use client'
+
+import { useMicroLand } from '@/app/micro-land/store'
+
+const MOOD_EMOJI: Record<string, string> = {
+  eat: '🌿',
+  hunt: '⚔',
+  flee: '→',
+  mate: '♡',
+  rest: '~',
+  wander: '·',
+}
+
+const MOOD_COLOR: Record<string, string> = {
+  eat: '#22c55e',
+  hunt: '#ef4444',
+  flee: '#f97316',
+  mate: '#c084fc',
+  rest: '#60a5fa',
+  wander: '#94a3b8',
+}
+
+export function CreatureTooltip() {
+  const hovered = useMicroLand(s => s.hoveredCreature)
+  if (!hovered) return null
+
+  const fullness = 1 - hovered.hunger
+  const color = MOOD_COLOR[hovered.mood] ?? '#94a3b8'
+  const emoji = MOOD_EMOJI[hovered.mood] ?? '·'
+
+  return (
+    <div
+      style={{
+        position: 'fixed',
+        left: hovered.screenX + 14,
+        top: hovered.screenY - 58,
+        pointerEvents: 'none',
+        zIndex: 45,
+        background: 'rgba(2, 8, 10, 0.9)',
+        border: `1px solid ${color}55`,
+        borderRadius: 6,
+        padding: '5px 9px',
+        minWidth: 120,
+        fontFamily: 'var(--cc-font-mono)',
+        fontSize: 11,
+        color: 'var(--cc-text-default)',
+        backdropFilter: 'blur(4px)',
+        userSelect: 'none',
+      }}
+    >
+      <div style={{ display: 'flex', alignItems: 'center', gap: 5, marginBottom: 4 }}>
+        <span style={{ fontSize: 12, width: 14, textAlign: 'center' }}>{emoji}</span>
+        <span style={{ color, fontWeight: 500, flex: 1 }}>{hovered.mood}</span>
+        <span style={{ color: 'var(--cc-text-muted)', fontSize: 10, maxWidth: 72, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+          {hovered.name}
+        </span>
+      </div>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 5 }}>
+        <span style={{ fontSize: 10, color: 'var(--cc-text-muted)', width: 38 }}>hunger</span>
+        <div style={{ flex: 1, height: 3, background: 'rgba(255,255,255,0.12)', borderRadius: 2, overflow: 'hidden' }}>
+          <div
+            style={{
+              height: '100%',
+              width: `${fullness * 100}%`,
+              background: fullness > 0.5 ? '#22c55e' : fullness > 0.25 ? '#f59e0b' : '#ef4444',
+              borderRadius: 2,
+            }}
+          />
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/app/micro-land/game-instance.ts
+++ b/src/app/micro-land/game-instance.ts
@@ -1989,6 +1989,10 @@ export class GameInstance {
     this.pendingInspect = null
   }
 
+  private onPointerLeave = () => {
+    useMicroLand.getState().setHoveredCreature(null)
+  }
+
   private onPointerDown = (e: PointerEvent) => {
     this.pointers.set(e.pointerId, { x: e.clientX, y: e.clientY })
 
@@ -2084,6 +2088,42 @@ export class GameInstance {
       const perPixel = this.renderer.tilesPerClientPixel()
       this.renderer.panTo(this.panAnchorCam - dx * perPixel, this.panAnchorCamY - dy * perPixel)
       return
+    }
+
+    // Hover tooltip: track which creature is under the cursor when not painting or panning.
+    if (e.isPrimary && !this.pointerDown && !this.panning && this.pointers.size <= 1) {
+      const hp = this.renderer.screenToWorld(e.clientX, e.clientY)
+      const hovered = this.creatureAt(hp.x, hp.y)
+      const hState = useMicroLand.getState()
+      const currentId = hState.hoveredCreature?.id ?? null
+      const newId = hovered?.id ?? null
+      if (newId !== currentId) {
+        if (hovered) {
+          const bp = this.world.blueprints[hovered.blueprintId]
+          hState.setHoveredCreature({
+            id: hovered.id,
+            mood: hovered.mood,
+            hunger: hovered.hunger,
+            name: bp?.name ?? hovered.blueprintId,
+            screenX: e.clientX,
+            screenY: e.clientY,
+          })
+        } else {
+          hState.setHoveredCreature(null)
+        }
+      } else if (hovered && hState.hoveredCreature) {
+        // Keep position and stats fresh even without id change.
+        const cur = hState.hoveredCreature
+        if (Math.abs(e.clientX - cur.screenX) > 4 || Math.abs(e.clientY - cur.screenY) > 4 ||
+            cur.mood !== hovered.mood || Math.abs(cur.hunger - hovered.hunger) > 0.05) {
+          const bp = this.world.blueprints[hovered.blueprintId]
+          hState.setHoveredCreature({
+            id: hovered.id, mood: hovered.mood, hunger: hovered.hunger,
+            name: bp?.name ?? hovered.blueprintId,
+            screenX: e.clientX, screenY: e.clientY,
+          })
+        }
+      }
     }
 
     if (!this.pointerDown || !e.isPrimary) return
@@ -2413,6 +2453,7 @@ export class GameInstance {
     this.canvas.addEventListener('pointermove', this.onPointerMove)
     this.canvas.addEventListener('pointerup', this.onPointerUp)
     this.canvas.addEventListener('pointercancel', this.onPointerUp)
+    this.canvas.addEventListener('pointerleave', this.onPointerLeave)
     this.canvas.addEventListener('wheel', this.onWheel, { passive: false })
     this.canvas.addEventListener('keydown', this.onKeyDown)
     this.canvas.addEventListener('keyup', this.onKeyUp)
@@ -2424,6 +2465,7 @@ export class GameInstance {
     this.canvas.removeEventListener('pointermove', this.onPointerMove)
     this.canvas.removeEventListener('pointerup', this.onPointerUp)
     this.canvas.removeEventListener('pointercancel', this.onPointerUp)
+    this.canvas.removeEventListener('pointerleave', this.onPointerLeave)
     this.canvas.removeEventListener('wheel', this.onWheel)
     this.canvas.removeEventListener('keydown', this.onKeyDown)
     this.canvas.removeEventListener('keyup', this.onKeyUp)

--- a/src/app/micro-land/store.ts
+++ b/src/app/micro-land/store.ts
@@ -372,6 +372,10 @@ interface MicroLandState {
   viewScale: 'wide' | 'standard' | 'close'
   setViewScale: (scale: 'wide' | 'standard' | 'close') => void
 
+  /** Creature under the cursor when not actively interacting. */
+  hoveredCreature: { id: number; mood: string; hunger: number; name: string; screenX: number; screenY: number } | null
+  setHoveredCreature: (c: { id: number; mood: string; hunger: number; name: string; screenX: number; screenY: number } | null) => void
+
   notices: Notice[]
 
   /** Event history log, newest first, capped at 500 entries. */
@@ -594,6 +598,7 @@ export const useMicroLand = create<MicroLandState>(set => ({
   canZoomIn: true,
   canZoomOut: true,
   viewScale: 'standard',
+  hoveredCreature: null,
 
   records: EMPTY_RECORDS,
   archive: [],
@@ -718,6 +723,7 @@ export const useMicroLand = create<MicroLandState>(set => ({
   setCanPan: canPan => set({ canPan }),
   setZoomState: (canZoomIn, canZoomOut) => set({ canZoomIn, canZoomOut }),
   setViewScale: viewScale => set({ viewScale }),
+  setHoveredCreature: c => set({ hoveredCreature: c }),
 
   setSaveState: saveState => set({ saveState }),
   setShelf: shelf => set({ shelf }),


### PR DESCRIPTION
## Summary
- Hover over any creature on the canvas (without clicking) to see a tooltip
- Shows: mood symbol + label (color-coded by state), species name, and a hunger bar
- Hunger bar is green when full, amber when hungry, red when starving
- Tooltip follows the cursor; disappears when cursor leaves the canvas or moves off the creature

## Test plan
- [ ] Hover over a wandering creature → tooltip shows "· wander" in grey, full green hunger bar
- [ ] Hover over a hunting carnivore → "⚔ hunt" in red
- [ ] Hover over a starving creature → hunger bar is red and nearly empty
- [ ] Move cursor off → tooltip disappears
- [ ] Click to inspect still works normally alongside hover

Closes #2991

🤖 Generated with [Claude Code](https://claude.com/claude-code)