### PR TITLE
feat(microland): day counter badge in HUD

### DIFF
--- a/src/app/micro-land/components/hud.tsx
+++ b/src/app/micro-land/components/hud.tsx
@@ -169,6 +169,9 @@ export function Hud({
       ? SEASON_NAMES[Math.floor(((elapsed % tuning.seasonPeriod) / tuning.seasonPeriod) * 4) % 4]
       : null
 
+  /** One in-world day = 60 sim seconds. Day 1 starts at t=0. */
+  const dayNumber = Math.floor(elapsed / 60) + 1
+
   const [overflowOpen, setOverflowOpen] = useState(false)
   const [copied, setCopied] = useState(false)
   const overflowRef = useRef<HTMLDivElement>(null)
@@ -354,6 +357,8 @@ export function Hud({
               <span style={{ color: 'var(--cc-text-muted)' }}>{seasonName}</span>
             </>
           )}
+          {' · '}
+          <span style={{ color: 'var(--cc-text-muted)' }}>Day {dayNumber}</span>
         </button>
 
         {/* Ecosystem health — informational */}


### PR DESCRIPTION
## Summary
- Adds a `dayNumber` counter (1-indexed) to the stat chip in the micro-land HUD
- One in-world day = 60 sim seconds, independent of the seasonal tuning knob
- Renders as `· Day N` after the season name in the existing chip button

Closes #3009

## Test plan
- [ ] Load micro-land; chip shows `· Day 1` at start
- [ ] After ~60 seconds of elapsed sim time, chip shows `· Day 2`
- [ ] Season and day labels coexist correctly in the chip

🤖 Generated with [Claude Code](https://claude.com/claude-code)