### PR TITLE
feat(microland): births and deaths lines in population graph

### DIFF
--- a/src/app/micro-land/components/population-graph.tsx
+++ b/src/app/micro-land/components/population-graph.tsx
@@ -224,6 +224,51 @@ export function PopulationGraph() {
       ctx.stroke()
       ctx.globalAlpha = 1
     }
+
+    // Birth/death rate lines — green for births, red for deaths
+    const allBirthValues = history.flatMap(s => Object.values(s.births ?? {}))
+    const allDeathValues = history.flatMap(s => Object.values(s.deaths ?? {}))
+    const maxBirthDeath = Math.max(1, ...allBirthValues, ...allDeathValues)
+
+    if (allBirthValues.length > 0 || allDeathValues.length > 0) {
+      for (const id of ids) {
+        const isFocused = id === graphFocusId
+        const hasFocus = graphFocusId !== null
+        const baseAlpha = hasFocus && !isFocused ? 0.08 : 0.5
+
+        ctx.setLineDash([3, 3])
+        ctx.lineWidth = 1
+
+        // Births line — green dashed
+        ctx.strokeStyle = '#22c55e'
+        ctx.globalAlpha = baseAlpha
+        ctx.beginPath()
+        let firstB = true
+        for (const snap of history) {
+          const b = snap.births?.[id] ?? 0
+          const x = PAD.left + ((snap.elapsed - elMin) / elSpan) * chartW
+          const y = PAD.top + chartH - (b / maxBirthDeath) * chartH
+          if (firstB) { ctx.moveTo(x, y); firstB = false }
+          else ctx.lineTo(x, y)
+        }
+        ctx.stroke()
+
+        // Deaths line — red dashed
+        ctx.strokeStyle = '#ef4444'
+        let firstD = true
+        ctx.beginPath()
+        for (const snap of history) {
+          const d = snap.deaths?.[id] ?? 0
+          const x = PAD.left + ((snap.elapsed - elMin) / elSpan) * chartW
+          const y = PAD.top + chartH - (d / maxBirthDeath) * chartH
+          if (firstD) { ctx.moveTo(x, y); firstD = false }
+          else ctx.lineTo(x, y)
+        }
+        ctx.stroke()
+      }
+      ctx.setLineDash([])
+      ctx.globalAlpha = 1
+    }
   }, [graphOpen, history, population, blueprints, graphFocusId])
 
   const handleCanvasClick = (e: React.MouseEvent<HTMLCanvasElement>) => {
@@ -311,7 +356,7 @@ export function PopulationGraph() {
           color: 'rgba(255,255,255,0.5)',
         }}
       >
-        Population over time
+        Population / activity over time
         <button
           type="button"
           onClick={() => setGraphOpen(false)}

--- a/src/app/micro-land/game-instance.ts
+++ b/src/app/micro-land/game-instance.ts
@@ -164,6 +164,8 @@ export class GameInstance {
   private accumulator = 0
   private tileCounter = 0
   private statsTimer = 0
+  private pendingBirths: Record<string, number> = {}
+  private pendingDeaths: Record<string, number> = {}
 
   /** Species that existed last time we checked, for extinction notices. */
   private knownSpecies = new Set<string>()
@@ -653,6 +655,18 @@ export class GameInstance {
       })
     }
 
+    // Track per-species births/deaths for the population graph.
+    for (const event of events) {
+      if (event.kind === 'born') {
+        this.pendingBirths[event.blueprintId] = (this.pendingBirths[event.blueprintId] ?? 0) + 1
+      } else if (
+        event.kind === 'eaten' || event.kind === 'starved' || event.kind === 'drowned' ||
+        event.kind === 'burned' || event.kind === 'aged' || event.kind === 'diseased'
+      ) {
+        this.pendingDeaths[event.blueprintId] = (this.pendingDeaths[event.blueprintId] ?? 0) + 1
+      }
+    }
+
     // Play sounds for aggregate events this tick
     if (isSoundEnabled()) {
       let hadBirth = false, hadDeath = false
@@ -793,7 +807,11 @@ export class GameInstance {
       }
     }
 
-    useMicroLand.getState().setStats(population, this.world.creatures.length, this.world.elapsed)
+    const births = { ...this.pendingBirths }
+    const deaths = { ...this.pendingDeaths }
+    this.pendingBirths = {}
+    this.pendingDeaths = {}
+    useMicroLand.getState().setStats(population, this.world.creatures.length, this.world.elapsed, births, deaths)
 
     // Per-creature thumbnails for the Field Guide population viewer.
     const thumbs: CreatureThumb[] = this.world.creatures

--- a/src/app/micro-land/store.ts
+++ b/src/app/micro-land/store.ts
@@ -204,6 +204,10 @@ export interface PopulationSnapshot {
   elapsed: number
   /** Creature count per blueprintId at this moment. */
   counts: Record<string, number>
+  /** Per-species births since previous snapshot. */
+  births?: Record<string, number>
+  /** Per-species deaths since previous snapshot. */
+  deaths?: Record<string, number>
 }
 
 /** One sample in the trait evolution history for a species. */
@@ -468,7 +472,7 @@ interface MicroLandState {
   setBlueprints: (list: CreatureBlueprint[]) => void
   /** Add a single blueprint without resetting population history. */
   addBlueprint: (bp: CreatureBlueprint) => void
-  setStats: (population: PopulationEntry[], total: number, elapsed: number) => void
+  setStats: (population: PopulationEntry[], total: number, elapsed: number, births?: Record<string, number>, deaths?: Record<string, number>) => void
   addExtinction: (record: ExtinctionRecord) => void
   clearExtinctions: () => void
   updateWorldStats: (patch: Partial<WorldStats>) => void
@@ -639,12 +643,17 @@ export const useMicroLand = create<MicroLandState>(set => ({
         ? s.blueprints.map(b => (b.id === bp.id ? bp : b))
         : [...s.blueprints, bp],
     })),
-  setStats: (population, totalCreatures, elapsed) =>
+  setStats: (population, totalCreatures, elapsed, births, deaths) =>
     set(s => {
       const last = s.populationHistory[s.populationHistory.length - 1]
       const shouldSnapshot = !last || elapsed - last.elapsed >= 1
       const snapshot: PopulationSnapshot | undefined = shouldSnapshot
-        ? { elapsed, counts: Object.fromEntries(population.map(p => [p.blueprintId, p.count])) }
+        ? {
+            elapsed,
+            counts: Object.fromEntries(population.map(p => [p.blueprintId, p.count])),
+            ...(births && Object.keys(births).length > 0 && { births }),
+            ...(deaths && Object.keys(deaths).length > 0 && { deaths }),
+          }
         : undefined
       return {
         population,


### PR DESCRIPTION
## Summary

Closes #2992.

- Extends `PopulationSnapshot` in `store.ts` with optional `births` and `deaths` fields (`Record<string, number>`) tracking per-species event counts between snapshots.
- Updates `setStats` signature and implementation to accept and persist birth/death counts into the history, only if non-empty.
- Adds `pendingBirths` / `pendingDeaths` accumulators in `GameInstance`; incremented in `digestEvents` for every `born` / `eaten|starved|drowned|burned|aged|diseased` event, then snapshotted and reset in `pushStats`.
- Draws dashed green (`#22c55e`) birth lines and dashed red (`#ef4444`) death lines as overlays in the population graph canvas, scaled independently to their own `maxBirthDeath` axis so they don't crowd out the population curves.
- Renames the graph header from "Population over time" to "Population / activity over time".

## Test plan

- [ ] Start a micro-land simulation, open the population graph, and verify dashed green/red lines appear after a few seconds.
- [ ] Focus a species by clicking a line — confirm birth/death lines dim for unfocused species (alpha 0.08) and remain visible for the focused one.
- [ ] Verify no regression: population curves still render, species panel still opens on click.
- [ ] Confirm TypeScript compiles cleanly (CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)