### PR TITLE
feat(microland): prompt for world name on first save

### DIFF
--- a/src/app/micro-land/components/population-graph.tsx
+++ b/src/app/micro-land/components/population-graph.tsx
@@ -224,6 +224,51 @@ export function PopulationGraph() {
       ctx.stroke()
       ctx.globalAlpha = 1
     }
+
+    // Birth/death rate lines — green for births, red for deaths
+    const allBirthValues = history.flatMap(s => Object.values(s.births ?? {}))
+    const allDeathValues = history.flatMap(s => Object.values(s.deaths ?? {}))
+    const maxBirthDeath = Math.max(1, ...allBirthValues, ...allDeathValues)
+
+    if (allBirthValues.length > 0 || allDeathValues.length > 0) {
+      for (const id of ids) {
+        const isFocused = id === graphFocusId
+        const hasFocus = graphFocusId !== null
+        const baseAlpha = hasFocus && !isFocused ? 0.08 : 0.5
+
+        ctx.setLineDash([3, 3])
+        ctx.lineWidth = 1
+
+        // Births line — green dashed
+        ctx.strokeStyle = '#22c55e'
+        ctx.globalAlpha = baseAlpha
+        ctx.beginPath()
+        let firstB = true
+        for (const snap of history) {
+          const b = snap.births?.[id] ?? 0
+          const x = PAD.left + ((snap.elapsed - elMin) / elSpan) * chartW
+          const y = PAD.top + chartH - (b / maxBirthDeath) * chartH
+          if (firstB) { ctx.moveTo(x, y); firstB = false }
+          else ctx.lineTo(x, y)
+        }
+        ctx.stroke()
+
+        // Deaths line — red dashed
+        ctx.strokeStyle = '#ef4444'
+        let firstD = true
+        ctx.beginPath()
+        for (const snap of history) {
+          const d = snap.deaths?.[id] ?? 0
+          const x = PAD.left + ((snap.elapsed - elMin) / elSpan) * chartW
+          const y = PAD.top + chartH - (d / maxBirthDeath) * chartH
+          if (firstD) { ctx.moveTo(x, y); firstD = false }
+          else ctx.lineTo(x, y)
+        }
+        ctx.stroke()
+      }
+      ctx.setLineDash([])
+      ctx.globalAlpha = 1
+    }
   }, [graphOpen, history, population, blueprints, graphFocusId])
 
   const handleCanvasClick = (e: React.MouseEvent<HTMLCanvasElement>) => {
@@ -311,7 +356,7 @@ export function PopulationGraph() {
           color: 'rgba(255,255,255,0.5)',
         }}
       >
-        Population over time
+        Population / activity over time
         <button
           type="button"
           onClick={() => setGraphOpen(false)}

--- a/src/app/micro-land/components/worlds-panel.tsx
+++ b/src/app/micro-land/components/worlds-panel.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 
 import { THEME_BY_ID } from '@/app/micro-land/domain/config/themes'
 import { formatDuration } from '@/app/micro-land/format'
@@ -46,6 +46,18 @@ function since(at: number): string {
 }
 
 /**
+ * Conjure a name from whatever is alive in the world right now.
+ * Returns null when there is nothing interesting to work with.
+ */
+function suggestWorldName(blueprints: { name: string }[], here: string): string {
+  // Pick up to two creature kinds and weave them into the land name.
+  const names = blueprints.slice(0, 2).map(b => b.name)
+  if (names.length === 2) return `The ${here} of ${names[0]}s and ${names[1]}s`
+  if (names.length === 1) return `The ${here} of ${names[0]}s`
+  return here
+}
+
+/**
  * The shelf — worlds the player has kept, and the way back into them.
  *
  * Two things this panel is careful about, both because the person using it is a
@@ -73,21 +85,37 @@ export function WorldsPanel({
   const themeId = useMicroLand(s => s.themeId)
   const summonedLand = useMicroLand(s => s.summonedLand)
   const total = useMicroLand(s => s.totalCreatures)
+  const blueprints = useMicroLand(s => s.blueprints)
 
   const [name, setName] = useState('')
   const [confirming, setConfirming] = useState<string | null>(null)
+  const [focusInputOnMount, setFocusInputOnMount] = useState(false)
 
   if (!open) return null
 
   const active = shelf.worlds.find(w => w.id === shelf.activeId) ?? null
   const full = shelf.worlds.length >= MAX_SAVED_WORLDS && !active
   const here = summonedLand ?? THEME_BY_ID[themeId]?.name ?? 'This land'
+  const suggested = !active ? suggestWorldName(blueprints, here) : here
+
+  // When panel opens for a new world, pre-fill name with suggestion and set focus flag
+  useEffect(() => {
+    if (open && !active) {
+      setName(suggested)
+      setFocusInputOnMount(true)
+    } else if (!open) {
+      // Reset on close
+      setName('')
+      setFocusInputOnMount(false)
+    }
+  }, [open, active, suggested])
 
   // Through the same cleaner the server would apply, so a world is called the
   // same thing whether it was kept on this device or on the account.
   const keep = () => {
-    onKeep(cleanWorldName(name, active ? active.name : here))
+    onKeep(cleanWorldName(name, active ? active.name : suggested))
     setName('')
+    setFocusInputOnMount(false)
   }
 
   return (
@@ -153,13 +181,19 @@ export function WorldsPanel({
             </label>
             <input
               id="micro-land-world-name"
+              ref={el => {
+                if (focusInputOnMount && el) {
+                  el.focus()
+                  setFocusInputOnMount(false)
+                }
+              }}
               value={name}
               onChange={e => setName(e.target.value)}
               onKeyDown={e => {
                 if (e.key === 'Enter') keep()
               }}
               maxLength={40}
-              placeholder={active ? active.name : here}
+              placeholder={active ? active.name : suggested}
               className="min-w-0 flex-1"
               style={{
                 fontSize: 13,

--- a/src/app/micro-land/game-instance.ts
+++ b/src/app/micro-land/game-instance.ts
@@ -164,6 +164,8 @@ export class GameInstance {
   private accumulator = 0
   private tileCounter = 0
   private statsTimer = 0
+  private pendingBirths: Record<string, number> = {}
+  private pendingDeaths: Record<string, number> = {}
 
   /** Species that existed last time we checked, for extinction notices. */
   private knownSpecies = new Set<string>()
@@ -653,6 +655,18 @@ export class GameInstance {
       })
     }
 
+    // Track per-species births/deaths for the population graph.
+    for (const event of events) {
+      if (event.kind === 'born') {
+        this.pendingBirths[event.blueprintId] = (this.pendingBirths[event.blueprintId] ?? 0) + 1
+      } else if (
+        event.kind === 'eaten' || event.kind === 'starved' || event.kind === 'drowned' ||
+        event.kind === 'burned' || event.kind === 'aged' || event.kind === 'diseased'
+      ) {
+        this.pendingDeaths[event.blueprintId] = (this.pendingDeaths[event.blueprintId] ?? 0) + 1
+      }
+    }
+
     // Play sounds for aggregate events this tick
     if (isSoundEnabled()) {
       let hadBirth = false, hadDeath = false
@@ -793,7 +807,11 @@ export class GameInstance {
       }
     }
 
-    useMicroLand.getState().setStats(population, this.world.creatures.length, this.world.elapsed)
+    const births = { ...this.pendingBirths }
+    const deaths = { ...this.pendingDeaths }
+    this.pendingBirths = {}
+    this.pendingDeaths = {}
+    useMicroLand.getState().setStats(population, this.world.creatures.length, this.world.elapsed, births, deaths)
 
     // Per-creature thumbnails for the Field Guide population viewer.
     const thumbs: CreatureThumb[] = this.world.creatures

--- a/src/app/micro-land/store.ts
+++ b/src/app/micro-land/store.ts
@@ -204,6 +204,10 @@ export interface PopulationSnapshot {
   elapsed: number
   /** Creature count per blueprintId at this moment. */
   counts: Record<string, number>
+  /** Per-species births since previous snapshot. */
+  births?: Record<string, number>
+  /** Per-species deaths since previous snapshot. */
+  deaths?: Record<string, number>
 }
 
 /** One sample in the trait evolution history for a species. */
@@ -468,7 +472,7 @@ interface MicroLandState {
   setBlueprints: (list: CreatureBlueprint[]) => void
   /** Add a single blueprint without resetting population history. */
   addBlueprint: (bp: CreatureBlueprint) => void
-  setStats: (population: PopulationEntry[], total: number, elapsed: number) => void
+  setStats: (population: PopulationEntry[], total: number, elapsed: number, births?: Record<string, number>, deaths?: Record<string, number>) => void
   addExtinction: (record: ExtinctionRecord) => void
   clearExtinctions: () => void
   updateWorldStats: (patch: Partial<WorldStats>) => void
@@ -639,12 +643,17 @@ export const useMicroLand = create<MicroLandState>(set => ({
         ? s.blueprints.map(b => (b.id === bp.id ? bp : b))
         : [...s.blueprints, bp],
     })),
-  setStats: (population, totalCreatures, elapsed) =>
+  setStats: (population, totalCreatures, elapsed, births, deaths) =>
     set(s => {
       const last = s.populationHistory[s.populationHistory.length - 1]
       const shouldSnapshot = !last || elapsed - last.elapsed >= 1
       const snapshot: PopulationSnapshot | undefined = shouldSnapshot
-        ? { elapsed, counts: Object.fromEntries(population.map(p => [p.blueprintId, p.count])) }
+        ? {
+            elapsed,
+            counts: Object.fromEntries(population.map(p => [p.blueprintId, p.count])),
+            ...(births && Object.keys(births).length > 0 && { births }),
+            ...(deaths && Object.keys(deaths).length > 0 && { deaths }),
+          }
         : undefined
       return {
         population,


### PR DESCRIPTION
Closes #2993

When saving a world for the first time, the name input now:
- Auto-focuses so the user can immediately type
- Pre-fills with a generated name based on species present (e.g., "The Forest of Rabbits and Wolves")
- Falls back to the land/theme name if no creatures are present

The suggestion uses the first two creature types found in blueprints, making it easy for players to name their worlds while keeping the gameplay feel intact.