### PR TITLE
feat(microland): biome diversity score HUD counter

### DIFF
--- a/src/app/micro-land/components/hud.tsx
+++ b/src/app/micro-land/components/hud.tsx
@@ -139,6 +139,7 @@ export function Hud({
   const tool = useMicroLand(s => s.tool)
   const setTool = useMicroLand(s => s.setTool)
   const notify = useMicroLand(s => s.notify)
+  const activeMaterials = useMicroLand(s => s.activeMaterials)
 
   const { user, loading: authLoading } = useAuth()
   const isSignedIn = !authLoading && !!user && !user.isAnonymous
@@ -359,6 +360,12 @@ export function Hud({
           )}
           {' · '}
           <span style={{ color: 'var(--cc-text-muted)' }}>Day {dayNumber}</span>
+          {activeMaterials > 0 && (
+            <>
+              {' · '}
+              <span style={{ color: 'var(--cc-text-muted)' }}>{activeMaterials} biomes</span>
+            </>
+          )}
         </button>
 
         {/* Ecosystem health — informational */}

--- a/src/app/micro-land/game-instance.ts
+++ b/src/app/micro-land/game-instance.ts
@@ -4,7 +4,7 @@
  * Deliberately outside React: the world mutates 60 times a second and React
  * only hears about it through a small summary pushed a few times a second.
  */
-import { MATERIAL_INDEX } from '@/app/micro-land/domain/config/materials'
+import { AIR, MATERIAL_INDEX } from '@/app/micro-land/domain/config/materials'
 import {
   type SanitizedTerrain,
   sanitizeTerrain,
@@ -812,6 +812,14 @@ export class GameInstance {
     this.pendingBirths = {}
     this.pendingDeaths = {}
     useMicroLand.getState().setStats(population, this.world.creatures.length, this.world.elapsed, births, deaths)
+
+    // Count distinct non-air tile materials for biome diversity score.
+    const seenMaterials = new Set<number>()
+    for (let i = 0; i < this.world.tiles.length; i++) {
+      const m = this.world.tiles[i]
+      if (m !== AIR) seenMaterials.add(m)
+    }
+    useMicroLand.getState().setActiveMaterials(seenMaterials.size)
 
     // Per-creature thumbnails for the Field Guide population viewer.
     const thumbs: CreatureThumb[] = this.world.creatures

--- a/src/app/micro-land/store.ts
+++ b/src/app/micro-land/store.ts
@@ -276,6 +276,8 @@ interface MicroLandState {
   blueprints: CreatureBlueprint[]
   population: PopulationEntry[]
   totalCreatures: number
+  /** Number of distinct non-air material types currently present in the world tiles. */
+  activeMaterials: number
   elapsed: number
   /** Rolling history for the population graph. Cleared on world load. */
   populationHistory: PopulationSnapshot[]
@@ -477,6 +479,7 @@ interface MicroLandState {
   /** Add a single blueprint without resetting population history. */
   addBlueprint: (bp: CreatureBlueprint) => void
   setStats: (population: PopulationEntry[], total: number, elapsed: number, births?: Record<string, number>, deaths?: Record<string, number>) => void
+  setActiveMaterials: (n: number) => void
   addExtinction: (record: ExtinctionRecord) => void
   clearExtinctions: () => void
   updateWorldStats: (patch: Partial<WorldStats>) => void
@@ -578,6 +581,7 @@ export const useMicroLand = create<MicroLandState>(set => ({
   blueprints: [],
   population: [],
   totalCreatures: 0,
+  activeMaterials: 0,
   elapsed: 0,
   populationHistory: [],
   extinctions: [],
@@ -748,6 +752,7 @@ export const useMicroLand = create<MicroLandState>(set => ({
   requestLocate: blueprintId =>
     set({ locateRequest: { blueprintId, serial: ++locateSerial }, guideOpen: false }),
   setPopulationItems: items => set({ populationItems: items }),
+  setActiveMaterials: n => set({ activeMaterials: n }),
   requestLocateCreature: id =>
     set({ locateCreatureRequest: { id, serial: ++locateCreatureSerial } }),
   setTraitOverlay: trait => set(s => ({ traitOverlay: s.traitOverlay === trait ? null : trait })),


### PR DESCRIPTION
Closes #3006. Counts distinct non-air material types in the world tile grid each stats tick and shows the count in the HUD chip as 'N biomes'.

## What changed

- `store.ts` — added `activeMaterials: number` field, `setActiveMaterials` action interface entry, initial value `0`, and implementation.
- `game-instance.ts` — imported `AIR` from materials, added biome diversity scan in `pushStats()` using a `Set<number>` to count unique non-air tile material indices, calls `setActiveMaterials` with the count.
- `hud.tsx` — reads `activeMaterials` from store, renders `{N} biomes` in the main stat chip after `Day {dayNumber}`, conditionally shown only when count > 0.