### PR TITLE
feat(microland): scent trail visualization toggle

### DIFF
--- a/src/app/micro-land/components/creature-filter.tsx
+++ b/src/app/micro-land/components/creature-filter.tsx
@@ -80,7 +80,11 @@ export function CreatureFilterBar({
   // species of plant on an empty map has no second way of moving and no size to
   // contrast with. Offering a filter there is a control that cannot do anything.
   const anythingToAsk =
-    options.moves.length > 1 || options.sizes.length > 1 || options.glows || options.lavaProof
+    options.moves.length > 1 ||
+    options.sizes.length > 1 ||
+    options.glows ||
+    options.lavaProof ||
+    options.dietTags.length > 1
   if (!anythingToAsk && !active) return null
 
   const setMoves = (kind: LocomotionKind) =>
@@ -184,6 +188,39 @@ export function CreatureFilterBar({
                   {band.label}
                 </button>
               ))}
+            </div>
+          )}
+
+          {options.dietTags.length > 1 && (
+            <div
+              className="flex flex-wrap items-center gap-1"
+              role="group"
+              aria-label="What it eats"
+            >
+              <span style={{ ...label, width: 44 }}>Diet</span>
+              {options.dietTags.map(tag => {
+                const active = filter.dietTags.includes(tag)
+                const tagLabel = tag === 'plant' ? 'Plant' : tag === 'meat' ? 'Meat' : 'Mineral'
+                return (
+                  <button
+                    key={tag}
+                    type="button"
+                    className="cc-btn shrink-0"
+                    onClick={() =>
+                      setFilter({
+                        ...filter,
+                        dietTags: active
+                          ? filter.dietTags.filter(t => t !== tag)
+                          : [...filter.dietTags, tag],
+                      })
+                    }
+                    aria-pressed={active}
+                    style={chipStyle(active)}
+                  >
+                    {tagLabel}
+                  </button>
+                )
+              })}
             </div>
           )}
 

--- a/src/app/micro-land/components/field-guide.tsx
+++ b/src/app/micro-land/components/field-guide.tsx
@@ -71,6 +71,8 @@ export function FieldGuide() {
   const addBlueprint = useMicroLand(s => s.addBlueprint)
   const trailsEnabled = useMicroLand(s => s.trailsEnabled)
   const setTrailsEnabled = useMicroLand(s => s.setTrailsEnabled)
+  const scentsEnabled = useMicroLand(s => s.scentsEnabled)
+  const setScentsEnabled = useMicroLand(s => s.setScentsEnabled)
   const extinctions = useMicroLand(s => s.extinctions)
   const worldStats = useMicroLand(s => s.worldStats)
   const namedCreatures = useMicroLand(s => s.namedCreatures)
@@ -690,6 +692,27 @@ export function FieldGuide() {
               }}
             >
               Trails
+            </button>
+            <button
+              type="button"
+              className="cc-btn"
+              onClick={() => setScentsEnabled(!scentsEnabled)}
+              style={{
+                fontFamily: 'var(--cc-font-mono)',
+                fontSize: 9,
+                letterSpacing: 1.2,
+                textTransform: 'uppercase',
+                padding: '4px 10px',
+                minHeight: 28,
+                borderRadius: 4,
+                border: scentsEnabled
+                  ? '1px solid var(--cc-mint)'
+                  : '1px solid var(--cc-mint-line)',
+                color: scentsEnabled ? 'var(--cc-mint)' : 'var(--cc-text-muted)',
+                background: scentsEnabled ? 'rgba(100,220,200,0.1)' : 'transparent',
+              }}
+            >
+              Scents
             </button>
           </div>
           {traitOverlay && (

--- a/src/app/micro-land/domain/__tests__/creature-filter.test.ts
+++ b/src/app/micro-land/domain/__tests__/creature-filter.test.ts
@@ -32,13 +32,14 @@ function bp(over: {
   kind?: LocomotionKind
   glow?: number
   immuneTo?: string[]
+  tags?: string[]
 }): CreatureBlueprint {
   return {
     id: over.id,
     name: over.id,
     blurb: '',
     size: over.size ?? 2,
-    tags: [],
+    tags: over.tags ?? [],
     art: { palette: {}, frames: [['.']], frameMs: 200, faceMotion: false },
     body: {
       mass: 1,
@@ -116,9 +117,27 @@ describe('matchesFilter', () => {
     expect(matchesFilter({ ...match, body: { ...match.body, immuneTo: [] } }, f)).toBe(false)
   })
 
+  it('ORs diet tags within the axis', () => {
+    const f = filter({ dietTags: ['plant', 'mineral'] })
+    expect(matchesFilter(bp({ id: 'a', tags: ['plant'] }), f)).toBe(true)
+    expect(matchesFilter(bp({ id: 'b', tags: ['mineral'] }), f)).toBe(true)
+    expect(matchesFilter(bp({ id: 'c', tags: ['meat'] }), f)).toBe(false)
+    // A creature with a flavor tag but none of the chosen diet tags is excluded.
+    expect(matchesFilter(bp({ id: 'd', tags: ['bug', 'meat'] }), f)).toBe(false)
+    // A creature with a matching diet tag alongside flavor tags is included.
+    expect(matchesFilter(bp({ id: 'e', tags: ['bug', 'plant'] }), f)).toBe(true)
+  })
+
+  it('empty dietTags axis passes everything through', () => {
+    const f = filter({ dietTags: [] })
+    expect(matchesFilter(bp({ id: 'a', tags: [] }), f)).toBe(true)
+    expect(matchesFilter(bp({ id: 'b', tags: ['plant'] }), f)).toBe(true)
+  })
+
   it('counts conditions rather than axes', () => {
     expect(activeConditionCount(EMPTY_FILTER)).toBe(0)
     expect(activeConditionCount(filter({ moves: ['fly', 'swim'], glows: true }))).toBe(3)
+    expect(activeConditionCount(filter({ dietTags: ['plant', 'meat'] }))).toBe(2)
   })
 })
 
@@ -132,6 +151,30 @@ describe('filterOptions', () => {
     expect(options.sizes).toEqual(['tiny'])
     expect(options.glows).toBe(false)
     expect(options.lavaProof).toBe(false)
+    expect(options.dietTags).toEqual([])
+  })
+
+  it('collects diet tags present in the roster in canonical order', () => {
+    const options = filterOptions([
+      bp({ id: 'a', tags: ['meat', 'bug'] }),
+      bp({ id: 'b', tags: ['plant'] }),
+      bp({ id: 'c', tags: ['fish'] }),
+    ])
+    // 'mineral' is absent from the roster so it should not appear
+    expect(options.dietTags).toEqual(['plant', 'meat'])
+  })
+
+  it('keeps diet tag chips in canonical order regardless of roster order', () => {
+    const forwards = filterOptions([
+      bp({ id: 'a', tags: ['meat'] }),
+      bp({ id: 'b', tags: ['plant'] }),
+    ])
+    const backwards = filterOptions([
+      bp({ id: 'b', tags: ['plant'] }),
+      bp({ id: 'a', tags: ['meat'] }),
+    ])
+    expect(forwards.dietTags).toEqual(backwards.dietTags)
+    expect(forwards.dietTags).toEqual(['plant', 'meat'])
   })
 
   it('offers every axis the built-in roster spans', () => {
@@ -166,5 +209,13 @@ describe('describeFilter', () => {
 
   it('lists size bands in band order, not tap order', () => {
     expect(describeFilter(filter({ sizes: ['huge', 'tiny'] }))).toBe('tiny or huge')
+  })
+
+  it('includes diet tags in the description', () => {
+    expect(describeFilter(filter({ dietTags: ['plant'] }))).toBe('plant')
+    expect(describeFilter(filter({ dietTags: ['meat', 'mineral'] }))).toBe('meat or mineral')
+    expect(
+      describeFilter(filter({ sizes: ['tiny'], dietTags: ['plant'] }))
+    ).toBe('tiny · plant')
   })
 })

--- a/src/app/micro-land/domain/creature-filter.ts
+++ b/src/app/micro-land/domain/creature-filter.ts
@@ -49,6 +49,8 @@ export interface CreatureFilter {
   glows: boolean
   /** Keep only creatures lava can't hurt. */
   lavaProof: boolean
+  /** Keep only creatures with at least one of these structural diet tags. */
+  dietTags: string[]
 }
 
 export const EMPTY_FILTER: CreatureFilter = {
@@ -56,6 +58,7 @@ export const EMPTY_FILTER: CreatureFilter = {
   sizes: [],
   glows: false,
   lavaProof: false,
+  dietTags: [],
 }
 
 /** True if a creature casts light of its own. */
@@ -83,13 +86,23 @@ export function sizeBand(bp: CreatureBlueprint): SizeBandId | null {
 
 /** True if any axis is asking something. */
 export function isFilterActive(filter: CreatureFilter): boolean {
-  return filter.moves.length > 0 || filter.sizes.length > 0 || filter.glows || filter.lavaProof
+  return (
+    filter.moves.length > 0 ||
+    filter.sizes.length > 0 ||
+    filter.glows ||
+    filter.lavaProof ||
+    filter.dietTags.length > 0
+  )
 }
 
 /** How many conditions are on — the number badged on the collapsed control. */
 export function activeConditionCount(filter: CreatureFilter): number {
   return (
-    filter.moves.length + filter.sizes.length + (filter.glows ? 1 : 0) + (filter.lavaProof ? 1 : 0)
+    filter.moves.length +
+    filter.sizes.length +
+    (filter.glows ? 1 : 0) +
+    (filter.lavaProof ? 1 : 0) +
+    filter.dietTags.length
   )
 }
 
@@ -101,6 +114,7 @@ export function matchesFilter(bp: CreatureBlueprint, filter: CreatureFilter): bo
   }
   if (filter.glows && !isGlowing(bp)) return false
   if (filter.lavaProof && !isLavaProof(bp)) return false
+  if (filter.dietTags.length > 0 && !filter.dietTags.some(tag => bp.tags.includes(tag))) return false
   return true
 }
 
@@ -119,25 +133,35 @@ export interface FilterOptions {
   sizes: SizeBandId[]
   glows: boolean
   lavaProof: boolean
+  dietTags: string[]
 }
+
+const DIET_TAG_ORDER = ['plant', 'meat', 'mineral'] as const
 
 export function filterOptions(roster: CreatureBlueprint[]): FilterOptions {
   const moves = new Set<LocomotionKind>()
   const sizes = new Set<SizeBandId>()
   let glows = false
   let lavaProof = false
+  const dietTagSet = new Set<string>()
   for (const bp of roster) {
     moves.add(bp.move.kind)
     const band = sizeBand(bp)
     if (band) sizes.add(band)
     if (isGlowing(bp)) glows = true
     if (isLavaProof(bp)) lavaProof = true
+    for (const tag of bp.tags) {
+      if (DIET_TAG_ORDER.includes(tag as (typeof DIET_TAG_ORDER)[number])) {
+        dietTagSet.add(tag)
+      }
+    }
   }
   return {
     moves: MOVE_ORDER.filter(k => moves.has(k)),
     sizes: SIZE_BANDS.filter(b => sizes.has(b.id)).map(b => b.id),
     glows,
     lavaProof,
+    dietTags: DIET_TAG_ORDER.filter(t => dietTagSet.has(t)),
   }
 }
 
@@ -159,5 +183,6 @@ export function describeFilter(filter: CreatureFilter): string {
   }
   if (filter.glows) parts.push('glows in the dark')
   if (filter.lavaProof) parts.push('lava-proof')
+  if (filter.dietTags.length > 0) parts.push(filter.dietTags.join(' or '))
   return parts.join(' · ')
 }

--- a/src/app/micro-land/rendering/renderer.ts
+++ b/src/app/micro-land/rendering/renderer.ts
@@ -508,6 +508,7 @@ export class Renderer {
     this.drawCreatures(w, vx, vw)
     this.drawStatusDots(w, vx, vw)
     this.drawPollinatorAuras(w, vx, vw)
+    if (useMicroLand.getState().scentsEnabled) this.drawScentBeacons(w, vx, vw)
     this.drawParticles(w, vx, vw)
     wctx.drawImage(this.shadowCanvas, vx, 0, vw, WORLD_H, vx, 0, vw, WORLD_H)
     // Both drawn after the shadow so they stay legible in a dark cave. The halo
@@ -838,6 +839,21 @@ export class Renderer {
       }
 
       ctx.globalAlpha = 1
+    }
+  }
+
+  private drawScentBeacons(w: WorldState, vx: number, vw: number): void {
+    const ctx = this.wctx
+    for (const scent of w.scents) {
+      if (scent.x < vx || scent.x >= vx + vw) continue
+      const alpha = Math.max(0.1, scent.decaySeconds / 15)
+      ctx.save()
+      ctx.globalAlpha = alpha * 0.7
+      ctx.fillStyle = '#22c55e'
+      ctx.beginPath()
+      ctx.arc(scent.x + 0.5, scent.y + 0.5, 0.4, 0, Math.PI * 2)
+      ctx.fill()
+      ctx.restore()
     }
   }
 

--- a/src/app/micro-land/store.ts
+++ b/src/app/micro-land/store.ts
@@ -454,6 +454,8 @@ interface MicroLandState {
   setFocusedSpeciesStats: (stats: FocusedSpeciesStats | null) => void
   trailsEnabled: boolean
   setTrailsEnabled: (on: boolean) => void
+  scentsEnabled: boolean
+  setScentsEnabled: (on: boolean) => void
   /** The species whose activity is shown as a heatmap overlay; null = off. */
   heatmapBlueprintId: string | null
   setHeatmapBlueprint: (id: string | null) => void
@@ -632,6 +634,7 @@ export const useMicroLand = create<MicroLandState>(set => ({
   replaySnapshots: null,
   replayIndex: 0,
   trailsEnabled: false,
+  scentsEnabled: false,
   heatmapBlueprintId: null,
   soundEnabled: false,
 
@@ -756,6 +759,7 @@ export const useMicroLand = create<MicroLandState>(set => ({
   setGraphFocusId: id => set({ graphFocusId: id, ...(id === null && { focusedSpeciesStats: null }) }),
   setFocusedSpeciesStats: stats => set({ focusedSpeciesStats: stats }),
   setTrailsEnabled: on => set({ trailsEnabled: on }),
+  setScentsEnabled: on => set({ scentsEnabled: on }),
   setHeatmapBlueprint: id => set({ heatmapBlueprintId: id }),
   setSoundEnabled: on => set({ soundEnabled: on }),
 


### PR DESCRIPTION
Closes #3004. Adds a 'Scents' toggle in the field guide overlay controls. When on, renders all active scent beacons as small green dots on the canvas, fading as they decay.