### PR TITLE
feat(microland): fog of war — unvisited tiles stay dark until a creature passes through

### DIFF
--- a/src/app/micro-land/components/field-guide.tsx
+++ b/src/app/micro-land/components/field-guide.tsx
@@ -73,6 +73,8 @@ export function FieldGuide() {
   const setTrailsEnabled = useMicroLand(s => s.setTrailsEnabled)
   const scentsEnabled = useMicroLand(s => s.scentsEnabled)
   const setScentsEnabled = useMicroLand(s => s.setScentsEnabled)
+  const fogEnabled = useMicroLand(s => s.fogEnabled)
+  const setFogEnabled = useMicroLand(s => s.setFogEnabled)
   const extinctions = useMicroLand(s => s.extinctions)
   const worldStats = useMicroLand(s => s.worldStats)
   const namedCreatures = useMicroLand(s => s.namedCreatures)
@@ -713,6 +715,27 @@ export function FieldGuide() {
               }}
             >
               Scents
+            </button>
+            <button
+              type="button"
+              className="cc-btn"
+              onClick={() => setFogEnabled(!fogEnabled)}
+              style={{
+                fontFamily: 'var(--cc-font-mono)',
+                fontSize: 9,
+                letterSpacing: 1.2,
+                textTransform: 'uppercase',
+                padding: '4px 10px',
+                minHeight: 28,
+                borderRadius: 4,
+                border: fogEnabled
+                  ? '1px solid var(--cc-mint)'
+                  : '1px solid var(--cc-mint-line)',
+                color: fogEnabled ? 'var(--cc-mint)' : 'var(--cc-text-muted)',
+                background: fogEnabled ? 'rgba(100,220,200,0.1)' : 'transparent',
+              }}
+            >
+              Fog
             </button>
           </div>
           {traitOverlay && (

--- a/src/app/micro-land/domain/sim/creature-sim.ts
+++ b/src/app/micro-land/domain/sim/creature-sim.ts
@@ -355,6 +355,8 @@ export function tickCreatures(
   tickMoisture(w, tickCount, dt, rng)
   w.eggs ??= []
   w.nextEggId ??= 1
+  // Migration: worlds loaded from a save before fog-of-war shipped won't have visited.
+  w.visited ??= new Uint8Array(WORLD_W * WORLD_H)
 
   // Seasonal factor — a slow sine wave that modulates plant growth and seeding.
   // 1.0 at both the start (t=0) and equinoxes; peaks in summer, troughs in winter.
@@ -561,6 +563,28 @@ export function tickCreatures(
     if (bp.move.kind !== 'root') {
       steer(w, c, bp, dt, rng)
       integrate(w, c, bp, bw, bh, dt, wet, gravityScale)
+    }
+
+    // --- fog of war: reveal tiles near this creature --------------------
+    //
+    // Runs once per creature per tick (not per physics sub-step), so a busy
+    // world pays the scan 60 times a second per creature rather than once per
+    // integration step. The visited array is optional so old saves still work.
+    if (w.visited) {
+      const visRadius = 3
+      const vcx = Math.floor(c.x + bw / 2)
+      const vcy = Math.floor(c.y + bh / 2)
+      for (let dy = -visRadius; dy <= visRadius; dy++) {
+        const row = vcy + dy
+        if (row < 0 || row >= WORLD_H) continue
+        for (let dx = -visRadius; dx <= visRadius; dx++) {
+          const col = vcx + dx
+          if (col < 0 || col >= WORLD_W) continue
+          if (dx * dx + dy * dy <= visRadius * visRadius) {
+            w.visited[row * WORLD_W + col] = 1
+          }
+        }
+      }
     }
 
     // --- fatigue --------------------------------------------------------

--- a/src/app/micro-land/domain/sim/world.ts
+++ b/src/app/micro-land/domain/sim/world.ts
@@ -65,6 +65,7 @@ export function createWorld(seed = 1337): WorldState {
     nextPlantSeed: 0,
     dormant: false,
     corridors: new Uint8Array(WORLD_W * WORLD_H),
+    visited: new Uint8Array(WORLD_W * WORLD_H),
   }
 }
 
@@ -307,6 +308,9 @@ export function applyThemeObject(w: WorldState, theme: Theme, seed?: number): vo
   for (let i = 0; i < w.grain.length; i++) w.grain[i] = Math.floor(rng() * 256)
   w.particles.length = 0
   w.dormant = false
+  // New terrain means a new exploration slate — all fog reset.
+  if (w.visited) w.visited.fill(0)
+  else w.visited = new Uint8Array(WORLD_W * WORLD_H)
 }
 
 /** Paint a filled circle of material. This is the player's brush. */

--- a/src/app/micro-land/domain/types.ts
+++ b/src/app/micro-land/domain/types.ts
@@ -791,6 +791,14 @@ export interface WorldState {
    * Optional so old serialised worlds without it don't crash.
    */
   corridors?: Uint8Array
+  /**
+   * Which tiles have been seen by at least one living creature this session.
+   *
+   * A 1 means visited; 0 means fog. Length = width × height. Transient — not
+   * persisted in WorldSave. Optional so worlds loaded from a save still work
+   * before the first tick initialises it.
+   */
+  visited?: Uint8Array
 }
 
 // ---------------------------------------------------------------------------

--- a/src/app/micro-land/rendering/renderer.ts
+++ b/src/app/micro-land/rendering/renderer.ts
@@ -133,6 +133,16 @@ export class Renderer {
   private shadowCanvas: HTMLCanvasElement
   private shadowCtx: CanvasRenderingContext2D
 
+  /**
+   * Fog-of-war overlay, world resolution.
+   *
+   * Tiles not yet visited by any creature are painted black with partial
+   * opacity. The canvas is full world width so we only blit the visible slice.
+   */
+  private fogCanvas: HTMLCanvasElement
+  private fogCtx: CanvasRenderingContext2D
+  private fogImage: ImageData
+
   private light = new Float32Array(LW * LH)
   private lightScratch = new Float32Array(LW * LH)
   private skyDepth = new Int16Array(WORLD_W)
@@ -197,6 +207,12 @@ export class Renderer {
     this.shadowCanvas.height = WORLD_H
     this.shadowCtx = this.shadowCanvas.getContext('2d')!
     this.shadowImage = this.shadowCtx.createImageData(WORLD_W, WORLD_H)
+
+    this.fogCanvas = document.createElement('canvas')
+    this.fogCanvas.width = WORLD_W
+    this.fogCanvas.height = WORLD_H
+    this.fogCtx = this.fogCanvas.getContext('2d')!
+    this.fogImage = this.fogCtx.createImageData(WORLD_W, WORLD_H)
 
     this.mapCanvas = document.createElement('canvas')
     this.mapCanvas.width = MW
@@ -527,6 +543,14 @@ export class Renderer {
       }
     }
 
+    // Fog of war: paint darkness over tiles no creature has ever visited.
+    // Read the store directly — the renderer already reads TUNING and
+    // trailsEnabled this same way rather than threading them as props.
+    if (w.visited && useMicroLand.getState().fogEnabled) {
+      this.updateFog(w.visited, vx, vw)
+      wctx.drawImage(this.fogCanvas, vx, 0, vw, WORLD_H, vx, 0, vw, WORLD_H)
+    }
+
     // One scaled blit. Nearest-neighbour keeps the pixels crisp.
     const ctx = this.ctx
     ctx.imageSmoothingEnabled = false
@@ -757,6 +781,34 @@ export class Renderer {
       }
     }
     ctx.globalAlpha = 1
+  }
+
+  /**
+   * Paint fog-of-war over unvisited tiles.
+   *
+   * Writes only the vx..vx+vw column slice of the ImageData so the scan is
+   * proportional to viewport width rather than the full world width. Visited
+   * tiles are transparent; everything else gets a dark overlay.
+   */
+  private updateFog(visited: Uint8Array, vx: number, vw: number): void {
+    const data = this.fogImage.data
+    for (let y = 0; y < WORLD_H; y++) {
+      const rowBase = y * WORLD_W
+      for (let x = vx; x < vx + vw; x++) {
+        const o = (rowBase + x) * 4
+        if (visited[rowBase + x]) {
+          // Visited — transparent so the world shows through.
+          data[o + 3] = 0
+        } else {
+          // Unvisited — nearly-opaque dark fill.
+          data[o] = 0
+          data[o + 1] = 0
+          data[o + 2] = 0
+          data[o + 3] = 210
+        }
+      }
+    }
+    this.fogCtx.putImageData(this.fogImage, 0, 0, vx, 0, vw, WORLD_H)
   }
 
   /**

--- a/src/app/micro-land/store.ts
+++ b/src/app/micro-land/store.ts
@@ -462,6 +462,15 @@ interface MicroLandState {
   setTrailsEnabled: (on: boolean) => void
   scentsEnabled: boolean
   setScentsEnabled: (on: boolean) => void
+  /**
+   * Whether the fog-of-war overlay is on.
+   *
+   * When enabled, tiles that no creature has ever visited are covered by a dark
+   * overlay. Players who find it distracting can toggle it off in the field
+   * guide. Defaults to true so new sessions start in fog.
+   */
+  fogEnabled: boolean
+  setFogEnabled: (on: boolean) => void
   /** The species whose activity is shown as a heatmap overlay; null = off. */
   heatmapBlueprintId: string | null
   setHeatmapBlueprint: (id: string | null) => void
@@ -643,6 +652,7 @@ export const useMicroLand = create<MicroLandState>(set => ({
   replayIndex: 0,
   trailsEnabled: false,
   scentsEnabled: false,
+  fogEnabled: true,
   heatmapBlueprintId: null,
   soundEnabled: false,
 
@@ -769,6 +779,7 @@ export const useMicroLand = create<MicroLandState>(set => ({
   setFocusedSpeciesStats: stats => set({ focusedSpeciesStats: stats }),
   setTrailsEnabled: on => set({ trailsEnabled: on }),
   setScentsEnabled: on => set({ scentsEnabled: on }),
+  setFogEnabled: on => set({ fogEnabled: on }),
   setHeatmapBlueprint: id => set({ heatmapBlueprintId: id }),
   setSoundEnabled: on => set({ soundEnabled: on }),
 


### PR DESCRIPTION
## Summary

- Unvisited tiles are covered by a near-opaque dark overlay until a living creature moves through them, revealing the terrain beneath
- Creatures reveal a 3-tile circular radius around their centre each tick (once per tick, not per physics sub-step — cost proportional to creature count, not integration rate)
- Fog resets to all-dark whenever the player changes terrain or loads a new theme, so each land starts as a fresh mystery
- A **Fog** toggle button sits next to Trails and Scents in the Field Guide for players who prefer to see the whole world from the start

## Technical notes

- `WorldState.visited` is a `Uint8Array` (1 = visited, 0 = fog), optional and transient — not persisted in `WorldSave`. Old saves initialise it on their first tick.
- `applyThemeObject` resets `visited` to all-zero on every terrain change.
- `updateFog()` in the renderer only writes the visible column slice per frame so performance scales with viewport width, not `WORLD_W`.
- `fogEnabled` in the store defaults to `true`; the Field Guide toggle lets players disable it without a page reload.

## Test plan

- [ ] Load Micro Land — world starts fully dark
- [ ] Place a creature and watch it reveal tiles as it moves
- [ ] Change theme / reshuffle — fog resets to all-dark
- [ ] Open Field Guide → toggle Fog off → world reveals fully → toggle back on → fog returns
- [ ] Pan the camera while fog is on — revealed tiles stay revealed, unrevealed tiles stay dark
- [ ] Zooming in and out — fog overlay scales correctly with the pixel-art renderer
- [ ] All existing vitest tests pass (pre-existing failures in breeding.test.ts and tuning.test.ts are unrelated to this PR)

Closes #3000

🤖 Generated with [Claude Code](https://claude.com/claude-code)