### PR TITLE
feat(microland): tidal flooding — configurable water level cycle

### DIFF
--- a/src/app/micro-land/domain/sim/world.ts
+++ b/src/app/micro-land/domain/sim/world.ts
@@ -847,3 +847,44 @@ export function countByBlueprint(w: WorldState): Record<string, number> {
 }
 
 export { AIR }
+
+/**
+ * Applies tidal flooding — periodically raises and lowers water in the bottom
+ * tidal zone based on elapsed sim time. Only affects AIR and WATER tiles;
+ * solid terrain (stone, dirt, etc.) is never modified.
+ *
+ * Sine-wave phase: 0 s = low tide, tidalPeriod/2 = high tide.
+ * The tidal zone spans the bottom (tidalAmplitude + 2) rows, leaving the
+ * bottom 2 rows as a permanent base that is never drained.
+ */
+export function applyTide(w: WorldState): void {
+  if (TUNING.tidalPeriod <= 0) return
+
+  const WATER_IDX = MATERIAL_INDEX.water
+  const { width, height } = w
+  const amp = Math.ceil(TUNING.tidalAmplitude)
+
+  // Sinusoidal phase: low tide at start, high tide halfway through
+  const phase = (w.elapsed % TUNING.tidalPeriod) / TUNING.tidalPeriod
+  const riseRows = Math.round(((1 - Math.cos(phase * 2 * Math.PI)) / 2) * amp)
+
+  // Leave the bottom BASE rows untouched (permanent seabed/bedrock)
+  const BASE = 2
+  const zoneTop = Math.max(0, height - amp - BASE)
+  // Current tide line: rows at y >= tideLine are in the flood zone
+  const tideLine = height - BASE - riseRows
+
+  for (let x = 0; x < width; x++) {
+    for (let y = zoneTop; y < height - BASE; y++) {
+      const i = y * width + x
+      const mat = w.tiles[i]
+      if (y >= tideLine) {
+        // In the flood zone — fill air with water
+        if (mat === AIR) w.tiles[i] = WATER_IDX
+      } else if (mat === WATER_IDX) {
+        // Above the tide line in the tidal zone — drain water back to air
+        w.tiles[i] = AIR
+      }
+    }
+  }
+}

--- a/src/app/micro-land/domain/tuning.ts
+++ b/src/app/micro-land/domain/tuning.ts
@@ -126,6 +126,15 @@ export const TUNING_DEFAULTS = {
    * Probabilistic: at 1.0, one drop per tick on average (≈60/s at 60fps).
    */
   rainRate: 0,
+  /**
+   * How long one full tide cycle takes, in sim seconds. 0 = no tides.
+   * 180 = one tide every three real minutes at normal speed.
+   */
+  tidalPeriod: 0,
+  /**
+   * How many tile rows the tide rises above the permanent seabed.
+   */
+  tidalAmplitude: 8,
 }
 
 export type TuningKey = keyof typeof TUNING_DEFAULTS
@@ -464,6 +473,26 @@ export const KNOBS: Knob[] = [
     min: 0,
     max: 1,
     step: 0.05,
+  },
+  {
+    key: 'tidalPeriod',
+    group: 'world',
+    label: 'Tide cycle length',
+    help: 'How long one full tide cycle takes. 0 = no tides. 180 = one tide every three real minutes. Works best in worlds with a shoreline or open ocean near the bottom. Non-swimmers may drown at high tide.',
+    min: 0,
+    max: 600,
+    step: 30,
+    unit: 's',
+  },
+  {
+    key: 'tidalAmplitude',
+    group: 'world',
+    label: 'Tide height',
+    help: 'How many tile rows the tide rises. 8 = a gentle tide. 20 = a dramatic flood that covers the shore. Only meaningful when the tide cycle is set.',
+    min: 1,
+    max: 30,
+    step: 1,
+    unit: ' rows',
   },
 ]
 

--- a/src/app/micro-land/game-instance.ts
+++ b/src/app/micro-land/game-instance.ts
@@ -44,6 +44,7 @@ import { tickTiles } from './domain/sim/tile-sim'
 import {
   applyTheme,
   applyThemeObject,
+  applyTide,
   boxHitsSolid,
   boxLiquidFraction,
   clearCreatures,
@@ -467,6 +468,7 @@ export class GameInstance {
     if (this.tileCounter >= TILE_TICK_EVERY) {
       this.tileCounter = 0
       tickTiles(w)
+      applyTide(w)
       // Tiles moved, so the cached tile image is stale.
       this.renderer.markTilesDirty()
     }


### PR DESCRIPTION
## Summary
- Adds `tidalPeriod` and `tidalAmplitude` tuning knobs (world group, after Rain)
- `applyTide()` in `world.ts` runs each tile-tick: floods air→water below the tide line, drains water→air above it, in the bottom N rows of the world
- Wired into the `game-instance.ts` tick loop alongside `tickTiles()`

## How it works
- Sine-wave cycle: `tidalPeriod = 0` = disabled (default), `180` = one cycle per 3 real minutes
- `tidalAmplitude` = how many rows the tide rises (default 8)
- Only AIR and WATER tiles are modified — solid terrain is never touched
- Bottom 2 rows are a permanent "seabed" never drained by tide

## Test plan
- [ ] Enable tidal period (e.g. 60s) and amplitude (8) in the tuning panel
- [ ] Verify water rises and falls at the bottom of the world over the cycle
- [ ] Verify solid tiles (stone, dirt) are unaffected
- [ ] Verify 0 period = no tide (default)

Closes #2994

🤖 Generated with [Claude Code](https://claude.com/claude-code)