### PR TITLE
feat(microland): world era labels — named ages in HUD

### DIFF
--- a/src/app/micro-land/components/hud.tsx
+++ b/src/app/micro-land/components/hud.tsx
@@ -160,9 +160,10 @@ export function Hud({
   const steady = steadySeconds >= STEADY_SHOW_SECONDS ? formatDuration(steadySeconds) : null
 
   const ageLabel =
-    elapsed >= 1800 ? 'Ancient' :
-    elapsed >= 600  ? 'Established' :
-    'Young'
+    elapsed >= 3600 ? 'The Ancient Cave' :
+    elapsed >= 1200 ? 'The Great Struggle' :
+    elapsed >= 300  ? 'The Green Age' :
+    'The Young Age'
 
   const SEASON_NAMES = ['Spring', 'Summer', 'Autumn', 'Winter'] as const
   const seasonName =
@@ -345,7 +346,7 @@ export function Hud({
           {' · '}
           <span
             style={{
-              color: ageLabel === 'Young'
+              color: ageLabel === 'The Young Age'
                 ? 'var(--cc-text-muted)'
                 : 'var(--cc-gold)',
             }}


### PR DESCRIPTION
## Summary
- Replaces generic age labels ('Young', 'Established', 'Ancient') with four evocative era names shown in the HUD chip
- **The Young Age** (0–5 min), **The Green Age** (5–20 min), **The Great Struggle** (20–60 min), **The Ancient Cave** (60+ min)
- Era name also appears in the share-copy text

## Test plan
- [ ] Start a world, verify 'The Young Age' appears in the HUD chip at t=0
- [ ] Advance to 5+ min sim time, verify 'The Green Age' appears in gold
- [ ] Share button copy includes the era name

Closes #3035

🤖 Generated with [Claude Code](https://claude.com/claude-code)