### PR TITLE
feat(microland): population collapse warning — amber alert at 3 or fewer

### DIFF
--- a/src/app/micro-land/components/field-guide.tsx
+++ b/src/app/micro-land/components/field-guide.tsx
@@ -1071,10 +1071,19 @@ function GuideEntry({
               style={{
                 fontFamily: 'var(--cc-font-mono)',
                 fontSize: 10,
-                color: alive > 0 ? 'var(--cc-text-muted)' : 'var(--cc-pink)',
+                color:
+                  alive === 0
+                    ? 'var(--cc-pink)'
+                    : alive <= 3
+                    ? 'var(--cc-gold)'
+                    : 'var(--cc-text-muted)',
               }}
             >
-              {alive > 0 ? `${alive} alive` : 'none left'}
+              {alive === 0
+                ? 'none left'
+                : alive <= 3
+                ? `⚠ ${alive} left`
+                : `${alive} alive`}
             </span>
             {bp.summoned && (
               <span


### PR DESCRIPTION
## Summary
- When a species drops to ≤ 3 living members, the count in the field guide changes from muted grey to **amber gold** and reads `⚠ N left` instead of `N alive`
- At 0 members the existing pink `none left` is unchanged
- No store changes — purely a display-layer computation from the existing `alive` prop

## Test plan
- [ ] Start a world with multiple species, let one decline to ≤ 3 — verify amber `⚠ 2 left` appears in the field guide
- [ ] Confirm count returns to normal mint once the population recovers past 3
- [ ] Confirm `none left` (pink) still shows on extinction as before

Closes #3027

🤖 Generated with [Claude Code](https://claude.com/claude-code)