### PR TITLE
feat(microland): creature memory trail — fading position history for inspected creature

### DIFF
--- a/src/app/micro-land/game-instance.ts
+++ b/src/app/micro-land/game-instance.ts
@@ -222,6 +222,9 @@ export class GameInstance {
   // --- mood history for inspector sparkline ---
   private moodHistory: string[] = []
   private moodHistoryCreatureId: number | null = null
+  /** Position samples for the memory trail; reset when inspectedId changes. */
+  private inspectedTrail: { x: number; y: number }[] = []
+  private trailLastSample = -999
 
   // --- heatmap ---
   private heatmap: Float32Array | null = null
@@ -1305,6 +1308,8 @@ export class GameInstance {
     const store = useMicroLand.getState()
     if (this.inspectedId === null) {
       if (store.inspected !== null) store.setInspected(null)
+      this.inspectedTrail = []
+      this.trailLastSample = -999
       return
     }
 
@@ -1329,9 +1334,17 @@ export class GameInstance {
     if (c.id !== this.moodHistoryCreatureId) {
       this.moodHistory = [c.mood]
       this.moodHistoryCreatureId = c.id
+      this.inspectedTrail = []
+      this.trailLastSample = -999
     } else {
       this.moodHistory.push(c.mood)
       if (this.moodHistory.length > 40) this.moodHistory.shift()
+    }
+    // Sample position every sim-second for the memory trail.
+    if (this.world.elapsed - this.trailLastSample >= 1) {
+      this.trailLastSample = this.world.elapsed
+      this.inspectedTrail.push({ x: c.x, y: c.y })
+      if (this.inspectedTrail.length > 30) this.inspectedTrail.shift()
     }
     const { w: bw, h: bh } = artSize(bp)
 
@@ -1379,6 +1392,7 @@ export class GameInstance {
       moodHistory: [...this.moodHistory],
       lastMealX: c.lastMealX,
       lastMealY: c.lastMealY,
+      trail: [...this.inspectedTrail],
     })
   }
 

--- a/src/app/micro-land/rendering/renderer.ts
+++ b/src/app/micro-land/rendering/renderer.ts
@@ -530,7 +530,10 @@ export class Renderer {
     // Both drawn after the shadow so they stay legible in a dark cave. The halo
     // goes first so the selection brackets sit on top when you inspect an elder.
     if (elderId !== null) this.drawElder(w, elderId)
-    if (highlightId !== null) this.drawHighlight(w, highlightId)
+    if (highlightId !== null) {
+      this.drawMemoryTrail(vx)
+      this.drawHighlight(w, highlightId)
+    }
 
     // Day/night cycle: gradually darkens during the night phase.
     if (TUNING.dayLengthSeconds > 0) {
@@ -1204,6 +1207,26 @@ export class Renderer {
     for (let i = 0; i < steps; i++) {
       const t = (i / steps) * Math.PI * 2
       ctx.fillRect(Math.round(cx + Math.cos(t) * rx), Math.round(cy + Math.sin(t) * ry), 1, 1)
+    }
+    ctx.globalAlpha = 1
+  }
+
+  /**
+   * Fading dot trail showing where the inspected creature has been.
+   * Oldest dots are most transparent; newest are brightest.
+   */
+  private drawMemoryTrail(vx: number): void {
+    const trail = useMicroLand.getState().inspected?.trail
+    if (!trail || trail.length < 2) return
+    const ctx = this.wctx
+    for (let i = 0; i < trail.length; i++) {
+      const pt = trail[i]
+      const t = (i + 1) / trail.length  // 0 = oldest, 1 = newest
+      ctx.globalAlpha = t * 0.55
+      ctx.fillStyle = '#5eead4'
+      const px = Math.round(pt.x) - vx
+      const py = Math.round(pt.y)
+      ctx.fillRect(px, py, 1, 1)
     }
     ctx.globalAlpha = 1
   }

--- a/src/app/micro-land/store.ts
+++ b/src/app/micro-land/store.ts
@@ -104,6 +104,8 @@ export interface Inspected {
   lastMealX: number | null
   /** Tile Y where the creature last ate successfully. null = never eaten. */
   lastMealY: number | null
+  /** Position history — up to 30 samples taken every sim-second. Oldest first. */
+  trail: { x: number; y: number }[]
 }
 
 /** One column of the guide's record book — see `KindRecord`. */


### PR DESCRIPTION
## Summary
- Adds `trail: { x, y }[]` to the `Inspected` store interface (up to 30 samples)
- `game-instance` samples the inspected creature's position every sim-second, accumulating up to 30 entries; resets when a different creature is selected
- Renderer draws fading teal dots behind the creature (oldest ≈ 10% alpha, newest ≈ 55%) whenever a creature is highlighted

## Test plan
- [ ] Inspect a creature, wait several seconds — verify a trail of fading dots appears behind it as it moves
- [ ] Click a different creature or deselect — verify trail resets/disappears
- [ ] Verify no trail appears when nothing is inspected

Closes #3043

🤖 Generated with [Claude Code](https://claude.com/claude-code)