### PR TITLE
feat(microland): fossil record — extinct species leave permanent markers in terrain

### DIFF
--- a/src/app/micro-land/domain/sim/world.ts
+++ b/src/app/micro-land/domain/sim/world.ts
@@ -49,6 +49,8 @@ export function createWorld(seed = 1337): WorldState {
     carcasses: [],
     tombstones: [],
     nextTombstoneId: 1,
+    fossils: [],
+    nextFossilId: 1,
     nextCarcassId: 1,
     scents: [],
     moisture: new Float32Array(WORLD_W * WORLD_H),

--- a/src/app/micro-land/domain/types.ts
+++ b/src/app/micro-land/domain/types.ts
@@ -656,6 +656,29 @@ export interface Tombstone {
   children: number
 }
 
+/**
+ * A permanent fossil marker left where the last creature of a species died.
+ * Records the extinction position and final stats. Never decays — the cave
+ * keeps a record of every extinction.
+ */
+export interface Fossil {
+  id: number
+  /** World-tile x coordinate where the last individual died. */
+  x: number
+  /** World-tile y coordinate where the last individual died. */
+  y: number
+  /** Blueprint id of the extinct species. */
+  blueprintId: string
+  /** Species name, cached here so the renderer needs no blueprint lookup. */
+  name: string
+  /** How long this species survived (sim-seconds). */
+  livedFor: number
+  /** Highest generation reached by this species. */
+  maxGeneration: number
+  /** World elapsed time when extinction happened. */
+  elapsed: number
+}
+
 /** A named creature — may be alive or dead. */
 export interface NamedCreatureEntry {
   name: string
@@ -748,6 +771,8 @@ export interface WorldState {
   carcasses: Carcass[]
   tombstones: Tombstone[]
   nextTombstoneId: number
+  fossils: Fossil[]
+  nextFossilId: number
   nextCarcassId: number
   scents: Scent[]
   /**

--- a/src/app/micro-land/game-instance.ts
+++ b/src/app/micro-land/game-instance.ts
@@ -578,15 +578,28 @@ export class GameInstance {
       // Record extinction in store for the field guide memorial.
       {
         const firstSeen = this.speciesFirstSeen.get(bp.id) ?? this.world.elapsed
+        const livedFor = this.world.elapsed - firstSeen
+        const maxGeneration = this.world.creatures.reduce(
+          (max, c) => c.blueprintId === bp.id ? Math.max(max, c.generation) : max,
+          1
+        )
         useMicroLand.getState().addExtinction({
           blueprintId: bp.id,
           name: bp.name,
           elapsed: this.world.elapsed,
-          livedFor: this.world.elapsed - firstSeen,
-          maxGeneration: this.world.creatures.reduce(
-            (max, c) => c.blueprintId === bp.id ? Math.max(max, c.generation) : max,
-            1
-          ),
+          livedFor,
+          maxGeneration,
+        })
+        // Drop a fossil where the last creature of this species died.
+        this.world.fossils.push({
+          id: this.world.nextFossilId++,
+          x: event.x,
+          y: event.y,
+          blueprintId: bp.id,
+          name: bp.name,
+          livedFor,
+          maxGeneration,
+          elapsed: this.world.elapsed,
         })
       }
       // An extinction is exactly what the steady streak measures the absence of

--- a/src/app/micro-land/rendering/renderer.ts
+++ b/src/app/micro-land/rendering/renderer.ts
@@ -518,6 +518,7 @@ export class Renderer {
     this.drawCarcasses(w, vx, vw)
     this.drawNests(w, vx, vw)
     this.drawTombstones(w, vx, vw)
+    this.drawFossils(w, vx, vw)
     if (heatmap) this.drawHeatmap(heatmap, vx, vw)
     if (w.corridors) this.drawCorridors(w.corridors, vx, vw)
     this.drawEggs(w, vx, vw)
@@ -601,6 +602,7 @@ export class Renderer {
     this.drawMinimap(w, theme, vx)
     this.drawNameLabels(w, vx, vw, elderId)
     this.drawTombstoneLabels(w, vx, vw)
+    this.drawFossilLabels(w, vx, vw)
   }
 
   // -------------------------------------------------------------------------
@@ -940,6 +942,29 @@ export class Renderer {
   }
 
   /**
+   * Tiny bone-colored cross markers where species went extinct.
+   * Drawn on the world canvas so they scale with zoom like terrain features.
+   */
+  private drawFossils(w: WorldState, vx: number, vw: number): void {
+    if (!w.fossils || w.fossils.length === 0) return
+    const ctx = this.wctx
+    ctx.fillStyle = '#c8b89a'
+    ctx.globalAlpha = 0.7
+
+    for (const fossil of w.fossils) {
+      const fx = Math.round(fossil.x)
+      const fy = Math.round(fossil.y)
+      if (fx + 3 < vx || fx - 3 > vx + vw) continue
+
+      // Cross / × marker: horizontal bar + vertical bar, 3×1 and 1×3.
+      ctx.fillRect(fx - 1, fy,     3, 1)  // horizontal
+      ctx.fillRect(fx,     fy - 1, 1, 3)  // vertical
+    }
+
+    ctx.globalAlpha = 1
+  }
+
+  /**
    * Pixel-art headstones where named creatures died.
    *
    * Drawn on the world canvas so they sit in the world at tile scale and get
@@ -967,6 +992,41 @@ export class Renderer {
     }
 
     ctx.globalAlpha = 1
+  }
+
+  /**
+   * Species name above each fossil, drawn on the display canvas so text stays
+   * legible at any zoom — same approach as drawTombstoneLabels.
+   */
+  private drawFossilLabels(w: WorldState, vx: number, vw: number): void {
+    if (!w.fossils || w.fossils.length === 0) return
+
+    const ctx = this.ctx
+    const scale = this.scale
+    const offsetX = this.offsetX
+    const offsetY = this.offsetY
+    const viewTop = this.viewTop()
+
+    ctx.font = '8px monospace'
+    ctx.textAlign = 'center'
+    ctx.textBaseline = 'bottom'
+
+    for (const fossil of w.fossils) {
+      if (fossil.x + 3 < vx || fossil.x - 3 > vx + vw) continue
+
+      const dx = (fossil.x - vx) * scale + offsetX
+      const dy = (fossil.y - 3 - viewTop) * scale + offsetY
+
+      ctx.globalAlpha = 0.5
+      ctx.fillStyle = 'rgba(0,0,0,0.4)'
+      ctx.fillText(`✦ ${fossil.name}`, dx + 1, dy + 1)
+      ctx.fillStyle = '#c8b89a'
+      ctx.fillText(`✦ ${fossil.name}`, dx, dy)
+    }
+
+    ctx.globalAlpha = 1
+    ctx.textAlign = 'left'
+    ctx.textBaseline = 'alphabetic'
   }
 
   /**


### PR DESCRIPTION
## Summary
- When the last creature of a species dies, a permanent fossil marker drops at that exact position in the world
- Fossils render as bone-colored cross (`+`) markers on the world canvas, scaling with zoom
- Each fossil shows the species name as a `✦ name` label on the display canvas (same pattern as tombstone labels)
- Fossils never decay — the cave remembers every extinction

## Technical
- Added `Fossil` interface to `domain/types.ts` with `id, x, y, blueprintId, name, livedFor, maxGeneration, elapsed`
- Added `fossils: Fossil[]` and `nextFossilId: number` to `WorldState`
- `createWorld` initializes both fields
- `game-instance.ts` drops a fossil at `event.x, event.y` when extinction is detected (position comes from the `SimEvent` which already carries the dying creature's coordinates)
- `renderer.ts` adds `drawFossils` (world canvas, bone-colored `#c8b89a` cross at 0.7 alpha) and `drawFossilLabels` (display canvas, 8px monospace at 0.5 alpha)

Closes #3026

🤖 Generated with [Claude Code](https://claude.com/claude-code)