### PR TITLE
feat(microland): temperature gradient — thermophily trait with warm-bottom / cold-top pressure

### DIFF
--- a/src/app/micro-land/domain/sim/creature-sim.ts
+++ b/src/app/micro-land/domain/sim/creature-sim.ts
@@ -176,7 +176,7 @@ export interface SimEvent {
    * hunter's side and carries who it caught. Both fire for a single kill — the
    * UI wants the hunter's framing, the extinction check wants the victim's.
    */
-  kind: 'born' | 'eaten' | 'ate' | 'starved' | 'drowned' | 'burned' | 'aged' | 'diseased' | 'sick'
+  kind: 'born' | 'eaten' | 'ate' | 'starved' | 'drowned' | 'burned' | 'aged' | 'diseased' | 'sick' | 'frosted' | 'overheated'
   blueprintId: string
   /** Only set on `ate`: the blueprint id of what was caught. */
   victimId?: string
@@ -552,6 +552,24 @@ export function tickCreatures(
       }
     } else {
       c.distress = Math.max(0, c.distress - dt * 1.5)
+    }
+
+    // Temperature stress: creatures with strong thermophily out of their zone
+    // take slow health damage. Only active when temperatureGradient > 0.
+    if (TUNING.temperatureGradient > 0 && Math.abs(c.traits.thermophily ?? 0) > 0.3) {
+      const worldTemp = c.y / WORLD_H   // 0 at top (cold), 1 at bottom (hot)
+      const pref = ((c.traits.thermophily ?? 0) + 1) / 2  // map [-1,1] to [0,1]
+      const mismatch = Math.abs(worldTemp - pref)
+      if (mismatch > 0.3) {
+        const stress = (mismatch - 0.3) * TUNING.temperatureGradient * dt * 0.003
+        c.hunger = Math.min(1, c.hunger + stress)
+        c.starving += stress
+        if (c.starving >= bp.diet.starveSeconds) {
+          const cause = (c.traits.thermophily ?? 0) > 0 ? 'frosted' : 'overheated'
+          kill(w, c, bp, dead, events, cause)
+          continue
+        }
+      }
     }
 
     // --- senses ---------------------------------------------------------

--- a/src/app/micro-land/domain/traits.ts
+++ b/src/app/micro-land/domain/traits.ts
@@ -83,6 +83,7 @@ export const NEUTRAL_TRAITS: Traits = Object.freeze({
   diurnal: 0,
   immunity: 0.2,
   reproductionCooldown: 1,
+  thermophily: 0,
 })
 
 /** A fresh set for a creature that wasn't born here. Always a copy — it's mutable state. */
@@ -130,7 +131,7 @@ function wrapHue(h: number): number {
 export function inherit(a: Traits, b: Traits | null, rng: Rng): Traits {
   const drift = TUNING.traitDrift
   const hueDrift = drift * HUE_DRIFT_SCALE
-  const mix = (key: 'speed' | 'sight' | 'lifespan' | 'shade' | 'roam' | 'territorial' | 'size' | 'camouflage' | 'toxicity' | 'cooperation' | 'diurnal' | 'immunity' | 'reproductionCooldown') =>
+  const mix = (key: 'speed' | 'sight' | 'lifespan' | 'shade' | 'roam' | 'territorial' | 'size' | 'camouflage' | 'toxicity' | 'cooperation' | 'diurnal' | 'immunity' | 'reproductionCooldown' | 'thermophily') =>
     b ? (a[key] + b[key]) / 2 : a[key]
 
   return {
@@ -148,6 +149,7 @@ export function inherit(a: Traits, b: Traits | null, rng: Rng): Traits {
     diurnal: clamp(mix('diurnal') + nudge(rng, drift), -1, 1),
     immunity: clamp(mix('immunity') + nudge(rng, drift), 0, 1),
     reproductionCooldown: clamp(mix('reproductionCooldown') + nudge(rng, drift), TRAIT_MIN, TRAIT_MAX),
+    thermophily: clamp(mix('thermophily') + nudge(rng, drift), -1, 1),
   }
 }
 
@@ -279,6 +281,8 @@ export function traitPhrases(t: Traits): string[] {
   else if ((t.cooperation ?? 0.3) <= 0.3 - NOTABLE) phrases.push('solitary')
   if ((t.diurnal ?? 0) >= 0.5) phrases.push('diurnal')
   else if ((t.diurnal ?? 0) <= -0.5) phrases.push('nocturnal')
+  if ((t.thermophily ?? 0) >= 0.5) phrases.push('heat-loving')
+  else if ((t.thermophily ?? 0) <= -0.5) phrases.push('cold-loving')
   if ((t.immunity ?? 0.2) >= 0.6) phrases.push('disease-resistant')
   else if ((t.immunity ?? 0.2) <= 0.05) phrases.push('susceptible')
   if ((t.reproductionCooldown ?? 1) <= 1 - NOTABLE) phrases.push('breeds quickly')

--- a/src/app/micro-land/domain/tuning.ts
+++ b/src/app/micro-land/domain/tuning.ts
@@ -135,6 +135,12 @@ export const TUNING_DEFAULTS = {
    * How many tile rows the tide rises above the permanent seabed.
    */
   tidalAmplitude: 8,
+  /**
+   * Strength of the temperature gradient, 0..1.
+   * 0 = no gradient (default). 1 = full warm-bottom / cold-top effect.
+   * Affects both the visual tint and how strongly thermophily trait matters.
+   */
+  temperatureGradient: 0,
 }
 
 export type TuningKey = keyof typeof TUNING_DEFAULTS
@@ -493,6 +499,15 @@ export const KNOBS: Knob[] = [
     max: 30,
     step: 1,
     unit: ' rows',
+  },
+  {
+    key: 'temperatureGradient',
+    group: 'world',
+    label: 'Temperature gradient',
+    help: 'Warmer at the bottom, cooler at the top. Heat-loving creatures thrive near the floor; cold-lovers do better in the heights. 0 = off.',
+    min: 0,
+    max: 1,
+    step: 0.1,
   },
 ]
 

--- a/src/app/micro-land/domain/types.ts
+++ b/src/app/micro-land/domain/types.ts
@@ -448,6 +448,12 @@ export interface Traits {
    * Neutral at 1. Range [TRAIT_MIN, TRAIT_MAX].
    */
   reproductionCooldown: number
+  /**
+   * Thermal preference: -1 = craves cold (top rows), +1 = craves heat (bottom
+   * rows), 0 = indifferent. Heritable — a line consistently exposed to harsh
+   * temperatures drifts toward tolerance over generations.
+   */
+  thermophily: number
 }
 
 /** One living thing in the world. */

--- a/src/app/micro-land/game-instance.ts
+++ b/src/app/micro-land/game-instance.ts
@@ -567,7 +567,7 @@ export class GameInstance {
     }
 
     for (const event of events) {
-      if (event.kind !== 'eaten' && event.kind !== 'starved' && event.kind !== 'drowned' && event.kind !== 'burned' && event.kind !== 'aged' && event.kind !== 'diseased') continue
+      if (event.kind !== 'eaten' && event.kind !== 'starved' && event.kind !== 'drowned' && event.kind !== 'burned' && event.kind !== 'aged' && event.kind !== 'diseased' && event.kind !== 'frosted' && event.kind !== 'overheated') continue
       const bp = this.world.blueprints[event.blueprintId]
       if (!bp) continue
       // Was that the last one? Only interesting for species we'd seen alive.
@@ -611,6 +611,8 @@ export class GameInstance {
         : event.kind === 'drowned' ? `The last ${bp.name} drowned.`
         : event.kind === 'burned' ? `The last ${bp.name} burned.`
         : event.kind === 'aged' ? `The last ${bp.name} lived to old age.`
+        : event.kind === 'frosted' ? `The last ${bp.name} froze.`
+        : event.kind === 'overheated' ? `The last ${bp.name} overheated.`
         : `The last ${bp.name} was eaten.`
       )
       // Trophic cascade: note the food web ripple from this extinction.

--- a/src/app/micro-land/rendering/renderer.ts
+++ b/src/app/micro-land/rendering/renderer.ts
@@ -521,6 +521,7 @@ export class Renderer {
     this.drawFossils(w, vx, vw)
     if (heatmap) this.drawHeatmap(heatmap, vx, vw)
     if (w.corridors) this.drawCorridors(w.corridors, vx, vw)
+    if (TUNING.temperatureGradient > 0) this.drawTemperatureGradient(vx, vw)
     this.drawTerritorialStains(w, vx, vw)
     this.drawEggs(w, vx, vw)
     this.drawCreatures(w, vx, vw)
@@ -841,6 +842,33 @@ export class Renderer {
           ctx.fillRect(x, y, 1, 1)
         }
       }
+    }
+    ctx.globalAlpha = 1
+  }
+
+  /**
+   * Subtle warm-to-cool tint across the world height.
+   * Bottom rows get a red-orange wash; top rows get a blue wash.
+   * Only called when temperatureGradient > 0.
+   */
+  private drawTemperatureGradient(vx: number, vw: number): void {
+    const ctx = this.wctx
+    const strength = TUNING.temperatureGradient
+    // Hot bottom: warm orange-red rows.
+    const hotRows = Math.round(WORLD_H * 0.25)
+    for (let y = WORLD_H - hotRows; y < WORLD_H; y++) {
+      const t = (y - (WORLD_H - hotRows)) / hotRows  // 0 at zone top, 1 at bottom
+      ctx.globalAlpha = t * strength * 0.12
+      ctx.fillStyle = '#f97316'  // orange-500
+      ctx.fillRect(vx, y, vw, 1)
+    }
+    // Cold top: blue rows.
+    const coldRows = Math.round(WORLD_H * 0.25)
+    for (let y = 0; y < coldRows; y++) {
+      const t = 1 - y / coldRows  // 1 at very top, 0 at zone bottom
+      ctx.globalAlpha = t * strength * 0.10
+      ctx.fillStyle = '#60a5fa'  // blue-400
+      ctx.fillRect(vx, y, vw, 1)
     }
     ctx.globalAlpha = 1
   }


### PR DESCRIPTION
## Summary
- New `thermophily` trait on creatures: -1 = cold-lover (thrives at top), +1 = heat-lover (thrives at bottom), 0 = indifferent
- When the `temperatureGradient` knob is > 0, creatures in their thermal wrong-zone accumulate extra hunger stress and eventually die (`frosted` or `overheated`)
- Visual: subtle blue wash at top rows, warm orange wash at bottom rows (only visible when gradient knob is on)
- Trait is fully heritable — lines exposed to thermal pressure drift toward tolerance over generations

## Technical
- `thermophily` added to `Traits` interface, `NEUTRAL_TRAITS` (default 0), and `inherit()` function (range -1..1)
- Trait phrase labels: "heat-loving" / "cold-loving" in trait descriptions
- `TUNING.temperatureGradient` knob (world group, 0..1) — off by default
- Temperature stress in `creature-sim.ts`: mirrors hunger/starving mechanic; `frosted`/`overheated` added as new `SimEvent` kinds
- Extinction notices for both new causes wired in `game-instance.ts`
- `drawTemperatureGradient` in `renderer.ts` — paints per-row orange/blue wash at bottom/top 25% of world height

Closes #3032

🤖 Generated with [Claude Code](https://claude.com/claude-code)