### PR TITLE
feat(microland): egg clutch size trait — egg-layers can evolve 1–4 eggs per breeding event

### DIFF
--- a/src/app/micro-land/domain/sim/creature-sim.ts
+++ b/src/app/micro-land/domain/sim/creature-sim.ts
@@ -753,28 +753,33 @@ export function tickCreatures(
         const ox = mate ? (c.x + mate.x) / 2 : c.x
         const oy = mate ? (c.y + mate.y) / 2 : c.y
         if (bp.egglayer && !isPlant) {
-          // Egg-layer: drop an egg with inherited traits rather than spawning live.
-          const childTraits = inherit(c.traits, mate?.traits ?? null, rng)
+          // Egg-layer: drop a clutch of inherited eggs rather than spawning live.
           const generation = Math.max(c.generation, mate?.generation ?? 0) + 1
-          w.eggs.push({
-            id: w.nextEggId++,
-            x: ox,
-            y: oy,
-            blueprintId: bp.id,
-            traits: childTraits,
-            generation,
-            hatchIn: TUNING.eggHatchSeconds,
-          })
-          c.children++
-          if (c.children === 1) logLife(c, w.elapsed, 'First offspring')
-          else if (c.children % 10 === 0) logLife(c, w.elapsed, `${c.children} offspring`)
-          speciesCount[bp.id] = (speciesCount[bp.id] ?? 0) + 1
+          const clutch = Math.max(1, Math.round((c.traits as { clutchSize?: number }).clutchSize ?? 1))
+          for (let egg = 0; egg < clutch; egg++) {
+            const childTraits = inherit(c.traits, mate?.traits ?? null, rng)
+            // Scatter eggs slightly so they don't all pile on the same tile.
+            const scatter = clutch > 1 ? (rng() * 2 - 1) * 2 : 0
+            w.eggs.push({
+              id: w.nextEggId++,
+              x: ox + scatter,
+              y: oy,
+              blueprintId: bp.id,
+              traits: childTraits,
+              generation,
+              hatchIn: TUNING.eggHatchSeconds,
+            })
+          }
+          c.children += clutch
+          if (c.children === clutch) logLife(c, w.elapsed, 'First offspring')
+          else if (Math.floor(c.children / 10) > Math.floor((c.children - clutch) / 10)) logLife(c, w.elapsed, `${c.children} offspring`)
+          speciesCount[bp.id] = (speciesCount[bp.id] ?? 0) + clutch
           c.breedCooldown = TUNING.breedCooldown * ((c.traits as { reproductionCooldown?: number }).reproductionCooldown ?? 1)
           payForChild(w, c, bp, bw, bh, helpers)
           if (mate) {
-            mate.children++
-            if (mate.children === 1) logLife(mate, w.elapsed, 'First offspring')
-            else if (mate.children % 10 === 0) logLife(mate, w.elapsed, `${mate.children} offspring`)
+            mate.children += clutch
+            if (mate.children === clutch) logLife(mate, w.elapsed, 'First offspring')
+            else if (Math.floor(mate.children / 10) > Math.floor((mate.children - clutch) / 10)) logLife(mate, w.elapsed, `${mate.children} offspring`)
             payForChild(w, mate, bp, bw, bh, helpers)
           }
           events.push({ kind: 'born', blueprintId: bp.id, x: ox, y: oy })

--- a/src/app/micro-land/domain/traits.ts
+++ b/src/app/micro-land/domain/traits.ts
@@ -83,6 +83,7 @@ export const NEUTRAL_TRAITS: Traits = Object.freeze({
   diurnal: 0,
   immunity: 0.2,
   reproductionCooldown: 1,
+  clutchSize: 1,
 })
 
 /** A fresh set for a creature that wasn't born here. Always a copy — it's mutable state. */
@@ -130,7 +131,7 @@ function wrapHue(h: number): number {
 export function inherit(a: Traits, b: Traits | null, rng: Rng): Traits {
   const drift = TUNING.traitDrift
   const hueDrift = drift * HUE_DRIFT_SCALE
-  const mix = (key: 'speed' | 'sight' | 'lifespan' | 'shade' | 'roam' | 'territorial' | 'size' | 'camouflage' | 'toxicity' | 'cooperation' | 'diurnal' | 'immunity' | 'reproductionCooldown') =>
+  const mix = (key: 'speed' | 'sight' | 'lifespan' | 'shade' | 'roam' | 'territorial' | 'size' | 'camouflage' | 'toxicity' | 'cooperation' | 'diurnal' | 'immunity' | 'reproductionCooldown' | 'clutchSize') =>
     b ? (a[key] + b[key]) / 2 : a[key]
 
   return {
@@ -148,6 +149,7 @@ export function inherit(a: Traits, b: Traits | null, rng: Rng): Traits {
     diurnal: clamp(mix('diurnal') + nudge(rng, drift), -1, 1),
     immunity: clamp(mix('immunity') + nudge(rng, drift), 0, 1),
     reproductionCooldown: clamp(mix('reproductionCooldown') + nudge(rng, drift), TRAIT_MIN, TRAIT_MAX),
+    clutchSize: clamp(mix('clutchSize') + nudge(rng, drift * 0.5), 1, 4),
   }
 }
 

--- a/src/app/micro-land/domain/types.ts
+++ b/src/app/micro-land/domain/types.ts
@@ -448,6 +448,15 @@ export interface Traits {
    * Neutral at 1. Range [TRAIT_MIN, TRAIT_MAX].
    */
   reproductionCooldown: number
+  /**
+   * How many eggs this creature lays per breeding event (egg-layers only).
+   *
+   * Range 1..4; heritable. A line in a food-rich patch with few predators can
+   * drift toward larger clutches over generations; one under heavy predation may
+   * not gain enough from multiple eggs to outweigh the breeding cost.
+   * Ignored for live-bearing species.
+   */
+  clutchSize: number
 }
 
 /** One living thing in the world. */


### PR DESCRIPTION
## Summary
- New `clutchSize` trait on creatures: range 1..4, default 1. Heritable with a gentle drift (half normal drift rate to keep initial worlds feeling familiar)
- Egg-laying species now drop a full clutch each breeding event instead of always one egg
- Eggs in a clutch of >1 are scattered ±2 tiles horizontally so they don't stack
- `children` counter on both parents increments by the full clutch size

## Technical
- `clutchSize` added to `Traits` interface, `NEUTRAL_TRAITS` (default 1), and `inherit()` function
- Breeding loop in `creature-sim.ts`: `const clutch = Math.round(c.traits.clutchSize ?? 1)`, then iterates pushing that many eggs with freshly-inherited traits each time
- Each egg gets independent trait inheritance so siblings vary naturally
- `speciesCount` adjusted by `clutch` to keep soft-cap math correct
- Backward-compatible: non-egg-layers ignore the trait

Closes #3039

🤖 Generated with [Claude Code](https://claude.com/claude-code)