### PR TITLE
feat(microland): mutualism bond tracking — long-running symbiosis pairs in field guide

### DIFF
--- a/src/app/micro-land/components/field-guide.tsx
+++ b/src/app/micro-land/components/field-guide.tsx
@@ -141,6 +141,7 @@ export function FieldGuide() {
   const worldStats = useMicroLand(s => s.worldStats)
   const namedCreatures = useMicroLand(s => s.namedCreatures)
   const foodWeb = useMicroLand(s => s.foodWeb)
+  const mutualismBonds = useMicroLand(s => s.mutualismBonds)
   const populationItems = useMicroLand(s => s.populationItems)
   const requestLocateCreature = useMicroLand(s => s.requestLocateCreature)
   const compareId = useMicroLand(s => s.compareId)
@@ -935,6 +936,43 @@ export function FieldGuide() {
             aliveIds={new Set(population.map(p => p.blueprintId))}
             foodWeb={foodWeb}
           />
+          {(() => {
+            const significantBonds = Object.entries(mutualismBonds)
+              .filter(([, seconds]) => seconds >= 30)
+              .sort(([, a], [, b]) => b - a)
+            if (significantBonds.length === 0) return null
+            return (
+              <div style={{ marginTop: 10 }}>
+                <p style={{ fontSize: 10, fontFamily: 'var(--cc-font-mono)', letterSpacing: 1, textTransform: 'uppercase', color: 'var(--cc-text-muted)', marginBottom: 6 }}>
+                  Long-running bonds
+                </p>
+                <ul style={{ listStyle: 'none', padding: 0, margin: 0 }}>
+                  {significantBonds.map(([key, seconds]) => {
+                    const [aId, bId] = key.split(':')
+                    const aName = blueprints.find(bp => bp.id === aId)?.name ?? aId
+                    const bName = blueprints.find(bp => bp.id === bId)?.name ?? bId
+                    return (
+                      <li
+                        key={key}
+                        style={{
+                          display: 'flex',
+                          justifyContent: 'space-between',
+                          fontSize: 11,
+                          fontFamily: 'var(--cc-font-mono)',
+                          padding: '3px 0',
+                          color: 'var(--cc-text-muted)',
+                          borderBottom: '1px solid rgba(255,255,255,0.04)',
+                        }}
+                      >
+                        <span style={{ color: '#4ade80' }}>{aName} ↔ {bName}</span>
+                        <span>{formatDuration(Math.round(seconds))}</span>
+                      </li>
+                    )
+                  })}
+                </ul>
+              </div>
+            )
+          })()}
         </section>
 
         {Object.keys(foodWeb).length > 0 && (

--- a/src/app/micro-land/game-instance.ts
+++ b/src/app/micro-land/game-instance.ts
@@ -992,6 +992,16 @@ export class GameInstance {
       useMicroLand.getState().setTraitHistory(flat)
     }
 
+    // Accumulate mutualism bond time for species pairs in active symbiosis.
+    const STATS_DT = STATS_EVERY_MS / 1000
+    for (const c of this.world.creatures) {
+      if (c.symbiosisTimer <= 0) continue
+      const bp = this.world.blueprints[c.blueprintId]
+      if (!bp?.symbiosisPartnerId) continue
+      const [a, b] = [c.blueprintId, bp.symbiosisPartnerId].sort()
+      useMicroLand.getState().recordMutualismTime(`${a}:${b}`, STATS_DT)
+    }
+
     // A running world is different every tick, so there is no cheaper signal
     // than "time passed" to hang the autosave on. The shelf debounces it hard
     // and does nothing at all when no shelved world is open.

--- a/src/app/micro-land/store.ts
+++ b/src/app/micro-land/store.ts
@@ -296,6 +296,13 @@ interface MicroLandState {
    * Updated on every eat event (live prey and carcasses).
    */
   foodWeb: Record<string, string[]>
+  /**
+   * Cumulative seconds each symbiosis pair has spent in active proximity.
+   *
+   * Key = `"${bpA}:${bpB}"` where bpA < bpB alphabetically.
+   * Value = total sim-seconds of active symbiosis between that pair.
+   */
+  mutualismBonds: Record<string, number>
   worldStats: WorldStats
   namedCreatures: NamedCreatureEntry[]
 
@@ -503,6 +510,8 @@ interface MicroLandState {
   resetWorldStats: () => void
   logEat: (eaterId: string, preyId: string) => void
   clearFoodWeb: () => void
+  recordMutualismTime: (pairKey: string, seconds: number) => void
+  clearMutualismBonds: () => void
   setNamedCreatures: (entries: NamedCreatureEntry[]) => void
   setSummonOpen: (open: boolean) => void
   setSummonBusy: (busy: boolean) => void
@@ -603,6 +612,7 @@ export const useMicroLand = create<MicroLandState>(set => ({
   populationHistory: [],
   extinctions: [],
   foodWeb: {},
+  mutualismBonds: {},
   worldStats: { ...EMPTY_STATS },
   namedCreatures: [],
 
@@ -664,7 +674,7 @@ export const useMicroLand = create<MicroLandState>(set => ({
   setBrushShape: brushShape => set({ brushShape }),
   togglePaused: () => set(s => ({ paused: !s.paused })),
   setSpeed: speed => set({ speed }),
-  setBlueprints: blueprints => set({ blueprints, populationHistory: [], extinctions: [], worldStats: { ...EMPTY_STATS }, foodWeb: {}, historyLog: [] }),
+  setBlueprints: blueprints => set({ blueprints, populationHistory: [], extinctions: [], worldStats: { ...EMPTY_STATS }, foodWeb: {}, mutualismBonds: {}, historyLog: [] }),
   addBlueprint: bp =>
     set(s => ({
       blueprints: s.blueprints.some(b => b.id === bp.id)
@@ -702,6 +712,10 @@ export const useMicroLand = create<MicroLandState>(set => ({
     return { foodWeb: { ...s.foodWeb, [eaterId]: [...existing, preyId] } }
   }),
   clearFoodWeb: () => set({ foodWeb: {} }),
+  recordMutualismTime: (pairKey, seconds) => set(s => ({
+    mutualismBonds: { ...s.mutualismBonds, [pairKey]: (s.mutualismBonds[pairKey] ?? 0) + seconds },
+  })),
+  clearMutualismBonds: () => set({ mutualismBonds: {} }),
   setNamedCreatures: entries => set({ namedCreatures: entries }),
   setSummonOpen: summonOpen => set({ summonOpen }),
   setSummonBusy: summonBusy => set({ summonBusy }),


### PR DESCRIPTION
## Summary
- Tracks cumulative seconds each declared symbiosis pair spends in active proximity (`symbiosisTimer > 0`)
- Field guide Symbiosis web section now shows a "Long-running bonds" list once any pair hits 30s of cumulative bond time
- Pairs are sorted by total bonded time (highest first), shown as `Species A ↔ Species B · duration`

## Technical
- `mutualismBonds: Record<string, number>` added to store (key = `"bpA:bpB"` sorted alphabetically, value = cumulative seconds)
- `recordMutualismTime` action increments bond time; `clearMutualismBonds` resets on world load
- `pushStats()` in `game-instance.ts` loops all creatures with `symbiosisTimer > 0`, finds their `bp.symbiosisPartnerId`, and accumulates 0.3s (stats interval) per tick
- Field guide reads `mutualismBonds` from store, filters pairs ≥30s, shows them under symbiosis web section

Closes #3033

🤖 Generated with [Claude Code](https://claude.com/claude-code)