### PR TITLE
feat(microland): terrain depletion — overgrazing depletes grass tiles

### DIFF
--- a/src/app/micro-land/domain/sim/world.ts
+++ b/src/app/micro-land/domain/sim/world.ts
@@ -436,6 +436,17 @@ export function erodeTile(w: WorldState, x: number, y: number): void {
   }
 }
 
+/**
+ * Restore an overgrazing-depleted tile back to grass.
+ * Only acts on dirt; all other tiles are left alone.
+ */
+export function restoreGrass(w: WorldState, x: number, y: number): void {
+  if (!inBounds(x, y)) return
+  if (w.tiles[y * WORLD_W + x] === MATERIAL_INDEX['dirt']) {
+    setTile(w, x, y, MATERIAL_INDEX['grass'])
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Spawning
 // ---------------------------------------------------------------------------

--- a/src/app/micro-land/game-instance.ts
+++ b/src/app/micro-land/game-instance.ts
@@ -57,7 +57,9 @@ import {
   paintCircle,
   paintSquare,
   registerBlueprint,
+  restoreGrass,
   seedStarters,
+  setTile,
   spawnCreature,
   spawnSomewhereSensible,
 } from './domain/sim/world'
@@ -228,6 +230,14 @@ export class GameInstance {
    */
   private erosionTraffic: Uint16Array = new Uint16Array(WORLD_W * WORLD_H)
   private erosionTickCounter = 0
+
+  // --- graze depletion ---
+  /** Per-tile count of plant-eating events; triggers grass→dirt when it overflows the threshold. */
+  private grazeTraffic: Uint16Array = new Uint16Array(WORLD_W * WORLD_H)
+  /** Marks tiles that were converted to dirt by overgrazing, so they know to recover. */
+  private grazeDepleted: Uint8Array = new Uint8Array(WORLD_W * WORLD_H)
+  /** Counts erosion ticks between graze-traffic decay steps. */
+  private grazeDecayTick = 0
 
   // --- mood history for inspector sparkline ---
   private moodHistory: string[] = []
@@ -514,6 +524,17 @@ export class GameInstance {
 
     tickCreatures(w, TICK_S, this.rng, gravity, events)
 
+    // --- graze depletion: stamp plant-eating events onto the tile they happened on ---
+    for (const event of events) {
+      if (event.kind !== 'ate') continue
+      const victimBp = w.blueprints[event.victimId ?? '']
+      if (!victimBp || victimBp.move.kind !== 'root') continue
+      const tx = Math.max(0, Math.min(WORLD_W - 1, Math.round(event.x)))
+      const ty = Math.max(0, Math.min(WORLD_H - 1, Math.round(event.y)))
+      const gi = ty * WORLD_W + tx
+      if (this.grazeTraffic[gi] < 65000) this.grazeTraffic[gi]++
+    }
+
     // --- terrain erosion (every 30 ticks ≈ every 0.5 s at 60 fps) ---
     this.erosionTickCounter++
     if (this.erosionTickCounter >= 30) {
@@ -536,6 +557,43 @@ export class GameInstance {
           this.erosionTraffic[i] = 0
         }
       }
+
+      // --- graze depletion: convert over-grazed grass to dirt and recover idle tiles ---
+      const GRAZE_THRESHOLD = 12
+      const grassVal = MATERIAL_INDEX['grass']
+      const dirtVal = MATERIAL_INDEX['dirt']
+      let grazeTilesDirty = false
+      for (let i = 0; i < this.grazeTraffic.length; i++) {
+        if (this.grazeTraffic[i] >= GRAZE_THRESHOLD) {
+          if (w.tiles[i] === grassVal) {
+            const x = i % WORLD_W
+            const y = Math.floor(i / WORLD_W)
+            setTile(w, x, y, dirtVal)
+            this.grazeDepleted[i] = 1
+            grazeTilesDirty = true
+          }
+          // Reset to just below threshold so recovery countdown starts.
+          this.grazeTraffic[i] = GRAZE_THRESHOLD - 1
+        }
+      }
+      // Decay graze traffic every 20 erosion ticks (~10 sim-seconds).
+      this.grazeDecayTick++
+      if (this.grazeDecayTick >= 20) {
+        this.grazeDecayTick = 0
+        for (let i = 0; i < this.grazeTraffic.length; i++) {
+          if (this.grazeTraffic[i] > 0) {
+            this.grazeTraffic[i]--
+          } else if (this.grazeDepleted[i]) {
+            // Traffic has fully cleared — restore grass on this depleted tile.
+            if (w.tiles[i] === dirtVal) {
+              restoreGrass(w, i % WORLD_W, Math.floor(i / WORLD_W))
+              grazeTilesDirty = true
+            }
+            this.grazeDepleted[i] = 0
+          }
+        }
+      }
+      if (grazeTilesDirty) this.renderer.markTilesDirty()
     }
 
     // --- rain ---


### PR DESCRIPTION
## Summary

- Tracks per-tile graze events via a `grazeTraffic: Uint16Array` — incremented each time a herbivore eats a rooted plant on that tile
- When a tile accumulates ≥12 graze events, grass is converted to dirt (`restoreGrass` / `setTile` via world.ts)
- Graze traffic decays 1 point every 20 erosion ticks (~10 sim-seconds), so tiles naturally recover when grazing pressure eases
- Once traffic reaches 0 on a depleted (flagged) dirt tile, it is restored to grass — no manual intervention needed
- Adds `restoreGrass()` to `world.ts` alongside the existing `erodeTile()` pattern

## Why

Closes #3038. Dense herbivore populations can now visibly overheat their food patches, turning lush grasslands brown. The ecosystem has to find balance or face starvation pressure — adds meaningful consequence to population spikes.

## Test plan

- [ ] Start a world with abundant herbivores and plants; watch for brown patches forming under grazing clusters
- [ ] Remove all herbivores; confirm grass recovers over ~2 minutes
- [ ] Verify mixed-diet creatures (omnivores eating plants) also deplete tiles
- [ ] Confirm flying/swimming creatures don't deplete tiles (only `move.kind === 'root'` victims count)

🤖 Generated with [Claude Code](https://claude.com/claude-code)