### PR TITLE
feat(microland): species timeline — Gantt chart of species lifespans

### DIFF
--- a/src/app/micro-land/components/field-guide.tsx
+++ b/src/app/micro-land/components/field-guide.tsx
@@ -142,6 +142,8 @@ export function FieldGuide() {
   const namedCreatures = useMicroLand(s => s.namedCreatures)
   const foodWeb = useMicroLand(s => s.foodWeb)
   const mutualismBonds = useMicroLand(s => s.mutualismBonds)
+  const speciesFirstSeen = useMicroLand(s => s.speciesFirstSeen)
+  const elapsed = useMicroLand(s => s.elapsed)
   const populationItems = useMicroLand(s => s.populationItems)
   const requestLocateCreature = useMicroLand(s => s.requestLocateCreature)
   const compareId = useMicroLand(s => s.compareId)
@@ -926,6 +928,67 @@ export function FieldGuide() {
                 </li>
               ))}
             </ul>
+          </section>
+        )}
+
+        {Object.keys(speciesFirstSeen).length > 0 && elapsed > 0 && (
+          <section className="px-4 py-3" style={{ borderTop: '1px solid var(--cc-panel-divider)' }}>
+            <h3 className="pb-2" style={sectionHeading}>Species timeline</h3>
+            <p style={{ fontSize: 11, color: 'var(--cc-text-muted)', marginBottom: 10 }}>
+              When each species appeared and how long it lasted.
+            </p>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 5 }}>
+              {Object.entries(speciesFirstSeen)
+                .sort(([, a], [, b]) => a - b)
+                .map(([bpId, firstSeen]) => {
+                  const ext = extinctions.find(e => e.blueprintId === bpId)
+                  const endTime = ext ? ext.elapsed : elapsed
+                  const isAlive = !ext
+                  const barStart = (firstSeen / elapsed) * 100
+                  const barWidth = Math.max(1, ((endTime - firstSeen) / elapsed) * 100)
+                  const name = blueprints.find(b => b.id === bpId)?.name ?? bpId
+                  // Deterministic hue from blueprint id
+                  let h = 5381
+                  for (const ch of bpId) h = (((h << 5) + h) ^ ch.charCodeAt(0)) & 0x7fffffff
+                  const hue = h % 360
+                  const color = isAlive ? `hsl(${hue}, 55%, 55%)` : `hsl(${hue}, 25%, 40%)`
+                  return (
+                    <div key={bpId} style={{ display: 'grid', gridTemplateColumns: '80px 1fr', gap: 6, alignItems: 'center' }}>
+                      <span
+                        style={{
+                          fontSize: 10,
+                          fontFamily: 'var(--cc-font-mono)',
+                          color: isAlive ? 'var(--cc-text-default)' : 'var(--cc-text-muted)',
+                          overflow: 'hidden',
+                          textOverflow: 'ellipsis',
+                          whiteSpace: 'nowrap',
+                          opacity: isAlive ? 1 : 0.6,
+                        }}
+                        title={name}
+                      >
+                        {name}
+                      </span>
+                      <div style={{ position: 'relative', height: 10, background: 'rgba(255,255,255,0.06)', borderRadius: 3 }}>
+                        <div
+                          style={{
+                            position: 'absolute',
+                            left: `${barStart}%`,
+                            width: `${barWidth}%`,
+                            height: '100%',
+                            background: color,
+                            borderRadius: 3,
+                            opacity: isAlive ? 0.85 : 0.45,
+                          }}
+                        />
+                      </div>
+                    </div>
+                  )
+                })}
+            </div>
+            <div style={{ display: 'flex', justifyContent: 'space-between', marginTop: 6, fontSize: 9, fontFamily: 'var(--cc-font-mono)', color: 'var(--cc-text-muted)', opacity: 0.5 }}>
+              <span>0</span>
+              <span>{formatDuration(elapsed)}</span>
+            </div>
           </section>
         )}
 

--- a/src/app/micro-land/game-instance.ts
+++ b/src/app/micro-land/game-instance.ts
@@ -992,6 +992,13 @@ export class GameInstance {
       useMicroLand.getState().setTraitHistory(flat)
     }
 
+    // Push species first-seen times to the store for the lineage timeline.
+    {
+      const flat: Record<string, number> = {}
+      for (const [id, t] of this.speciesFirstSeen) flat[id] = t
+      useMicroLand.getState().setSpeciesFirstSeen(flat)
+    }
+
     // Accumulate mutualism bond time for species pairs in active symbiosis.
     const STATS_DT = STATS_EVERY_MS / 1000
     for (const c of this.world.creatures) {

--- a/src/app/micro-land/store.ts
+++ b/src/app/micro-land/store.ts
@@ -303,6 +303,11 @@ interface MicroLandState {
    * Value = total sim-seconds of active symbiosis between that pair.
    */
   mutualismBonds: Record<string, number>
+  /**
+   * World-time (elapsed seconds) when each species was first observed alive.
+   * Key = blueprintId.
+   */
+  speciesFirstSeen: Record<string, number>
   worldStats: WorldStats
   namedCreatures: NamedCreatureEntry[]
 
@@ -512,6 +517,7 @@ interface MicroLandState {
   clearFoodWeb: () => void
   recordMutualismTime: (pairKey: string, seconds: number) => void
   clearMutualismBonds: () => void
+  setSpeciesFirstSeen: (firstSeen: Record<string, number>) => void
   setNamedCreatures: (entries: NamedCreatureEntry[]) => void
   setSummonOpen: (open: boolean) => void
   setSummonBusy: (busy: boolean) => void
@@ -613,6 +619,7 @@ export const useMicroLand = create<MicroLandState>(set => ({
   extinctions: [],
   foodWeb: {},
   mutualismBonds: {},
+  speciesFirstSeen: {},
   worldStats: { ...EMPTY_STATS },
   namedCreatures: [],
 
@@ -674,7 +681,7 @@ export const useMicroLand = create<MicroLandState>(set => ({
   setBrushShape: brushShape => set({ brushShape }),
   togglePaused: () => set(s => ({ paused: !s.paused })),
   setSpeed: speed => set({ speed }),
-  setBlueprints: blueprints => set({ blueprints, populationHistory: [], extinctions: [], worldStats: { ...EMPTY_STATS }, foodWeb: {}, mutualismBonds: {}, historyLog: [] }),
+  setBlueprints: blueprints => set({ blueprints, populationHistory: [], extinctions: [], worldStats: { ...EMPTY_STATS }, foodWeb: {}, mutualismBonds: {}, speciesFirstSeen: {}, historyLog: [] }),
   addBlueprint: bp =>
     set(s => ({
       blueprints: s.blueprints.some(b => b.id === bp.id)
@@ -716,6 +723,7 @@ export const useMicroLand = create<MicroLandState>(set => ({
     mutualismBonds: { ...s.mutualismBonds, [pairKey]: (s.mutualismBonds[pairKey] ?? 0) + seconds },
   })),
   clearMutualismBonds: () => set({ mutualismBonds: {} }),
+  setSpeciesFirstSeen: firstSeen => set({ speciesFirstSeen: firstSeen }),
   setNamedCreatures: entries => set({ namedCreatures: entries }),
   setSummonOpen: summonOpen => set({ summonOpen }),
   setSummonBusy: summonBusy => set({ summonBusy }),


### PR DESCRIPTION
## Summary

- Adds `speciesFirstSeen: Record<string, number>` to the store, tracking when each species was first observed alive (world elapsed seconds)
- Pushes this map from `GameInstance.pushStats()` every stats tick alongside existing trait history
- Adds a **Species timeline** section in the field guide showing each species as a horizontal bar on a common time axis
  - Bars are colored by a deterministic hue derived from the blueprint ID
  - Living species appear bright; extinct species appear dimmed
  - Sorted by appearance order so the world's ecological succession is readable at a glance
  - Axis labels show 0 and current elapsed time

## Why

Closes #3036. The timeline makes the world's evolutionary history tangible — you can see when species arrived, how long they overlapped, and which ones were around at the start vs. latecomers.

## Test plan

- [ ] Start a world; after a few seconds, open field guide — "Species timeline" section appears with bars for each living species
- [ ] Let a species go extinct; its bar should shorten to its extinction time and dim
- [ ] Confirm bars are sorted by appearance order (earliest first)
- [ ] Reset the world; timeline should clear

🤖 Generated with [Claude Code](https://claude.com/claude-code)