### PR TITLE
feat(microland): echolocation trait — sound-based navigation with sonar pulses

### DIFF
--- a/src/app/micro-land/domain/sim/creature-sim.ts
+++ b/src/app/micro-land/domain/sim/creature-sim.ts
@@ -1047,7 +1047,11 @@ function look(
     : 0
   const diurnalPenalty = Math.max(0, diurnal > 0 ? diurnal * nightFactor : -diurnal * (1 - nightFactor)) * 0.5
   const inPhaseBonus = Math.max(0, (diurnal > 0 ? diurnal * (1 - nightFactor * 2) : -diurnal * (nightFactor * 2 - 1)) * 0.5)
-  const sight = sightOf(c, bp) * (1 - diurnalPenalty) * (1 + inPhaseBonus)
+  // Echolocation bypasses light-dependent penalties and adds a sight bonus.
+  const echo = (c.traits as { echolocation?: number }).echolocation ?? 0
+  const echoPenaltyBypass = echo >= 0.5 ? diurnalPenalty : 0
+  const echoBonus = Math.max(0, echo - 0.3) * 1.5
+  const sight = sightOf(c, bp) * (1 - diurnalPenalty + echoPenaltyBypass) * (1 + inPhaseBonus + echoBonus)
   const sight2 = sight * sight
 
   /**

--- a/src/app/micro-land/domain/traits.ts
+++ b/src/app/micro-land/domain/traits.ts
@@ -85,6 +85,7 @@ export const NEUTRAL_TRAITS: Traits = Object.freeze({
   reproductionCooldown: 1,
   thermophily: 0,
   clutchSize: 1,
+  echolocation: 0,
 })
 
 /** A fresh set for a creature that wasn't born here. Always a copy — it's mutable state. */
@@ -132,7 +133,7 @@ function wrapHue(h: number): number {
 export function inherit(a: Traits, b: Traits | null, rng: Rng): Traits {
   const drift = TUNING.traitDrift
   const hueDrift = drift * HUE_DRIFT_SCALE
-  const mix = (key: 'speed' | 'sight' | 'lifespan' | 'shade' | 'roam' | 'territorial' | 'size' | 'camouflage' | 'toxicity' | 'cooperation' | 'diurnal' | 'immunity' | 'reproductionCooldown' | 'thermophily' | 'clutchSize') =>
+  const mix = (key: 'speed' | 'sight' | 'lifespan' | 'shade' | 'roam' | 'territorial' | 'size' | 'camouflage' | 'toxicity' | 'cooperation' | 'diurnal' | 'immunity' | 'reproductionCooldown' | 'thermophily' | 'clutchSize' | 'echolocation') =>
     b ? (a[key] + b[key]) / 2 : a[key]
 
   return {
@@ -152,6 +153,7 @@ export function inherit(a: Traits, b: Traits | null, rng: Rng): Traits {
     reproductionCooldown: clamp(mix('reproductionCooldown') + nudge(rng, drift), TRAIT_MIN, TRAIT_MAX),
     thermophily: clamp(mix('thermophily') + nudge(rng, drift), -1, 1),
     clutchSize: clamp(mix('clutchSize') + nudge(rng, drift * 0.5), 1, 4),
+    echolocation: clamp(mix('echolocation') + nudge(rng, drift * 0.5), 0, 1),
   }
 }
 
@@ -289,6 +291,7 @@ export function traitPhrases(t: Traits): string[] {
   else if ((t.immunity ?? 0.2) <= 0.05) phrases.push('susceptible')
   if ((t.reproductionCooldown ?? 1) <= 1 - NOTABLE) phrases.push('breeds quickly')
   else if ((t.reproductionCooldown ?? 1) >= 1 + NOTABLE) phrases.push('breeds slowly')
+  if ((t.echolocation ?? 0) >= 0.6) phrases.push('navigates by sound')
   return phrases
 }
 

--- a/src/app/micro-land/domain/types.ts
+++ b/src/app/micro-land/domain/types.ts
@@ -463,6 +463,14 @@ export interface Traits {
    * Ignored for live-bearing species.
    */
   clutchSize: number
+  /**
+   * Ability to navigate by emitting sound pulses (0..1).
+   *
+   * Range 0..1. When ≥ 0.5, this creature bypasses light-dependent vision
+   * penalties (diurnal darkness, cave fog) and gains a proportional sight
+   * bonus — echolocation is not affected by the time of day or ambient light.
+   */
+  echolocation: number
 }
 
 /** One living thing in the world. */

--- a/src/app/micro-land/rendering/renderer.ts
+++ b/src/app/micro-land/rendering/renderer.ts
@@ -528,6 +528,7 @@ export class Renderer {
     this.drawStatusDots(w, vx, vw)
     this.drawPollinatorAuras(w, vx, vw)
     this.drawGlowAuras(w, vx, vw)
+    this.drawEcholocationPulses(w, vx, vw)
     if (useMicroLand.getState().scentsEnabled) this.drawScentBeacons(w, vx, vw)
     this.drawParticles(w, vx, vw)
     wctx.drawImage(this.shadowCanvas, vx, 0, vw, WORLD_H, vx, 0, vw, WORLD_H)
@@ -1038,6 +1039,49 @@ export class Renderer {
       }
     }
     ctx.globalAlpha = 1
+  }
+
+  /**
+   * Expanding sonar-ring pulses for creatures with high echolocation trait.
+   *
+   * Each pulse is a thin ring that expands outward from the creature and fades.
+   * Multiple offset pulses per creature simulate the periodic ping of real sonar.
+   * Drawn on the world canvas in amber so it reads as "sound" vs. the cyan of bioluminescence.
+   */
+  private drawEcholocationPulses(w: WorldState, vx: number, vw: number): void {
+    const ctx = this.wctx
+    const PULSE_PERIOD = 2.5   // seconds between pings
+    const MAX_RADIUS = 10       // max ring radius in tiles
+    ctx.strokeStyle = '#f59e0b' // amber-400 — warm sonar colour
+
+    for (const c of w.creatures) {
+      const echo = (c.traits as { echolocation?: number }).echolocation ?? 0
+      if (echo < 0.4) continue
+      const bp = w.blueprints[c.blueprintId]
+      if (!bp) continue
+      const rows = bp.art.frames[0]
+      const bw = rows[0].length
+      const bh = rows.length
+      if (c.x + bw < vx || c.x > vx + vw) continue
+
+      const cx = c.x + bw / 2
+      const cy = c.y + bh / 2
+      const phase = (w.elapsed % PULSE_PERIOD) / PULSE_PERIOD
+      // Draw two staggered rings per creature so there is always one in motion.
+      for (const offset of [0, 0.5]) {
+        const t = (phase + offset) % 1  // 0..1, 0 = just emitted, 1 = fully expanded
+        const r = t * MAX_RADIUS * echo
+        const alpha = (1 - t) * echo * 0.6
+        if (r < 0.5 || alpha < 0.02) continue
+        ctx.globalAlpha = alpha
+        ctx.lineWidth = 0.6
+        ctx.beginPath()
+        ctx.arc(cx, cy, r, 0, Math.PI * 2)
+        ctx.stroke()
+      }
+    }
+    ctx.globalAlpha = 1
+    ctx.lineWidth = 1
   }
 
   private drawScentBeacons(w: WorldState, vx: number, vw: number): void {


### PR DESCRIPTION
## Summary

- Adds heritable `echolocation: number` trait (0..1) to `Traits`, `NEUTRAL_TRAITS`, and `inherit()`
- When echolocation ≥ 0.5: diurnal darkness penalty is bypassed entirely (creature navigates by sound, not light)
- Echolocation ≥ 0.3 adds a proportional sight bonus (up to +1.05× at value 1.0)
- `traitPhrases()` reports `'navigates by sound'` for echolocation ≥ 0.6
- Renders amber (#f59e0b) sonar rings: two staggered expanding circles per echolocating creature, fading as they expand — drawn on the world canvas so they're visible under the shadow overlay

## Why

Closes #3041. Creates a meaningful niche for cave-adapted creatures: high echolocation lines thrive where diurnal creatures are penalized by darkness, providing selective pressure and visible differentiation.

## Test plan

- [ ] Enable day/night cycle (`dayLengthSeconds > 0`) and observe that highly echolocating creatures maintain full sight range in darkness
- [ ] In normal play (no day/night), echolocation provides mild sight bonus but no penalty bypass
- [ ] Inspector shows `navigates by sound` phrase for echolocation ≥ 0.6
- [ ] Sonar rings are visible around echolocating creatures on screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)