### PR TITLE
feat(microland): widen size trait range and make it ecologically meaningful

### DIFF
--- a/src/app/micro-land/domain/sim/creature-sim.ts
+++ b/src/app/micro-land/domain/sim/creature-sim.ts
@@ -1214,7 +1214,10 @@ function look(
       continue
     }
 
-    if (hungry && canEat(bp, obp) && sizeOf(other) / sizeOf(c) < 1.8) {
+    // Prey must not be more than 1.4× the predator's size — wide enough to let
+    // normal predation work but narrow enough that small creatures can't tackle
+    // large ones, and large creatures gain a clear dietary advantage.
+    if (hungry && canEat(bp, obp) && sizeOf(other) / sizeOf(c) < 1.4) {
       // Bodies touching? Eat now, don't bother pathing — camouflage can't save
       // something once the predator is already on top of it.
       const touching = gapX <= BITE_PAD && gapY <= BITE_PAD
@@ -1274,10 +1277,13 @@ function look(
         Math.abs(other.vx) + Math.abs(other.vy) < CAMOUFLAGE_STILL
       // Camouflage: trait scales how hard this creature is to spot.
       // Still creatures benefit most; moving gives most of it away.
+      // Small body size also reduces detectability (harder to see a tiny creature).
       const camouflage = (other.traits as { camouflage?: number }).camouflage ?? 0.2
-      const detFactor = still
+      const sizeFactor = Math.min(1, sizeOf(other))  // 0.5..1.0 — tiny creatures are half as visible
+      const detFactor = (still
         ? Math.max(0.15, 0.5 - camouflage * 0.375)  // 0.5 (camo=0) → 0.2 (camo=0.8)
         : 1 - camouflage * 0.3                        // 1.0 (camo=0) → 0.76 (camo=0.8)
+      ) * sizeFactor
       const efs2 = foodSight2 * detFactor * detFactor
       if (d2 <= efs2 && d2 < preyDist) {
         preyDist = d2

--- a/src/app/micro-land/domain/traits.ts
+++ b/src/app/micro-land/domain/traits.ts
@@ -143,7 +143,7 @@ export function inherit(a: Traits, b: Traits | null, rng: Rng): Traits {
     shade: clamp(mix('shade') + nudge(rng, drift), SHADE_MIN, SHADE_MAX),
     roam: clamp(mix('roam') + nudge(rng, drift), TRAIT_MIN, TRAIT_MAX),
     territorial: clamp(mix('territorial') + nudge(rng, drift), 0.1, 1.4),
-    size: clamp(mix('size') + nudge(rng, drift), 0.8, 1.2),
+    size: clamp(mix('size') + nudge(rng, drift * 1.5), 0.5, 1.8),
     camouflage: clamp(mix('camouflage') + nudge(rng, drift), 0, 0.8),
     toxicity: clamp(mix('toxicity') + nudge(rng, drift), 0, 1),
     cooperation: clamp(mix('cooperation') + nudge(rng, drift), 0, 1),
@@ -274,7 +274,9 @@ export function traitPhrases(t: Traits): string[] {
   else if ((t.roam ?? 1) <= 1 - NOTABLE) phrases.push('stay-close')
   if ((t.territorial ?? 0.5) >= 0.5 + NOTABLE) phrases.push('territorial')
   else if ((t.territorial ?? 0.5) <= 0.5 - NOTABLE) phrases.push('wandering')
-  if ((t.size ?? 1) >= 1 + NOTABLE) phrases.push('larger than most')
+  if ((t.size ?? 1) >= 1.5) phrases.push('giant')
+  else if ((t.size ?? 1) >= 1 + NOTABLE) phrases.push('larger than most')
+  else if ((t.size ?? 1) <= 0.7) phrases.push('tiny')
   else if ((t.size ?? 1) <= 1 - NOTABLE) phrases.push('smaller than most')
   if ((t.camouflage ?? 0.2) >= 0.3) phrases.push('hard to spot')
   else if ((t.camouflage ?? 0.2) <= 0.1) phrases.push('easy to spot')


### PR DESCRIPTION
## Summary

- **Wider size range**: 0.8..1.2 → **0.5..1.8** with 1.5× drift, so creature lines can diverge into visibly tiny vs. giant forms over generations (sprite already scales by `sizeOf(c)`)
- **Tighter prey selection**: predators can only eat prey ≤ 1.4× their own size (was 1.8×), making small creatures unable to tackle large prey while large predators retain a broad dietary range
- **Size-based detectability**: prey detectability in the `look()` sense pass now includes a `sizeFactor = min(1, sizeOf(other))`, so tiny creatures (0.5) are 50% as easy to detect as normal-sized ones
- **Inspector phrases**: added `'giant'` (≥ 1.5) and `'tiny'` (≤ 0.7) alongside existing `'larger/smaller than most'`

## Why

Closes #3037. The existing size trait existed but its narrow range (0.8..1.2) meant size differences were barely visible and had minimal ecological impact. Now size is a genuine ecological axis: giant herbivores dominate smaller predators, tiny creatures exploit niches inaccessible to larger animals.

## Test plan

- [ ] After several generations, inspect creatures for visible size diversity (some tiny/giant)
- [ ] Confirm inspector shows `tiny` / `giant` phrases for extreme sizes
- [ ] In a world with predators + prey: confirm small prey (size~0.5) are harder for predators to locate
- [ ] Confirm large herbivores (size~1.5) cannot be eaten by small predators (size~0.8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)