### PR TITLE
feat(microland): Cave Network theme — The Labyrinth

### DIFF
--- a/src/app/micro-land/domain/config/themes.ts
+++ b/src/app/micro-land/domain/config/themes.ts
@@ -1840,6 +1840,161 @@ const CAVE: Theme = {
   },
 }
 
+const CAVE_NETWORK: Theme = {
+  id: 'cave-network',
+  name: 'The Labyrinth',
+  blurb: 'Tunnels carved by ancient water. Chambers that breathe in the dark. Something is already here.',
+  sky: ['#070312', '#020109'],
+  gloom: 0.78,
+  gravity: 1,
+  starters: [
+    { id: 'glowvine', count: 25 },
+    { id: 'sporecap', count: 16 },
+    { id: 'loamworm', count: 10 },
+    { id: 'delver', count: 8 },
+    { id: 'finling', count: 6 },
+    { id: 'driftmole', count: 4 },
+  ],
+  build: (tiles, rng) => {
+    // Start as solid stone — every open space is carved.
+    fill(tiles, 'stone')
+
+    const edgeNoise = makeNoise2D(Math.floor(rng() * 1e9))
+    const oreNoise = makeNoise2D(Math.floor(rng() * 1e9))
+
+    // Place 5–7 chamber nodes spread across the world width, at varied depths.
+    const nodeCount = 5 + Math.round(rng() * 2 * WIDTH_SCALE)
+    const margin = 18
+    const nodes: Array<{ x: number; y: number; r: number }> = []
+    for (let i = 0; i < nodeCount; i++) {
+      const nx = margin + Math.floor((i / (nodeCount - 1)) * (WORLD_W - 2 * margin))
+      // Scatter vertically — some near the top, most in the middle, a few deep.
+      const ny = Math.floor(WORLD_H * (0.18 + rng() * 0.62))
+      const r = 6 + Math.floor(rng() * 6)   // radius 6..11
+      nodes.push({ x: nx, y: ny, r })
+    }
+
+    // Carve each chamber as a noise-deformed circle.
+    for (const { x: cx, y: cy, r } of nodes) {
+      for (let dy = -r; dy <= r; dy++) {
+        for (let dx = -r; dx <= r; dx++) {
+          const nx = cx + dx, ny = cy + dy
+          const dist = Math.sqrt(dx * dx + dy * dy)
+          const noise = edgeNoise(nx * 0.09, ny * 0.09) * 0.35
+          if (dist < r * (0.68 + noise)) set(tiles, nx, ny, 'air')
+        }
+      }
+    }
+
+    // Connect adjacent nodes with L-shaped tunnels (horizontal then vertical).
+    // Sort by x so each node connects to the next one rightward.
+    const sorted = [...nodes].sort((a, b) => a.x - b.x)
+    for (let i = 0; i + 1 < sorted.length; i++) {
+      const a = sorted[i]
+      const b = sorted[i + 1]
+      // Horizontal leg from a to b at a's depth.
+      const x0 = Math.min(a.x, b.x), x1 = Math.max(a.x, b.x)
+      for (let x = x0; x <= x1; x++) {
+        for (let dy = -2; dy <= 2; dy++) set(tiles, x, a.y + dy, 'air')
+      }
+      // Vertical leg to reach b's depth.
+      const y0 = Math.min(a.y, b.y), y1 = Math.max(a.y, b.y)
+      for (let y = y0; y <= y1; y++) {
+        for (let dx = -2; dx <= 2; dx++) set(tiles, b.x + dx, y, 'air')
+      }
+    }
+
+    // Secondary branches: random walks from random nodes, creating winding passages.
+    const branchCount = 4 + Math.round(rng() * 3 * WIDTH_SCALE)
+    for (let b = 0; b < branchCount; b++) {
+      const start = sorted[Math.floor(rng() * sorted.length)]
+      let bx = start.x + Math.floor((rng() - 0.5) * start.r * 1.5)
+      let by = start.y + Math.floor((rng() - 0.5) * start.r * 1.5)
+      const steps = 18 + Math.floor(rng() * 22)
+      const dirs = [[1, 0], [-1, 0], [0, 1], [0, -1]]
+      let lastDir = Math.floor(rng() * 4)
+      for (let s = 0; s < steps; s++) {
+        // Prefer current direction; sometimes turn.
+        if (rng() < 0.3) lastDir = (lastDir + 1 + Math.floor(rng() * 3)) % 4
+        const [ddx, ddy] = dirs[lastDir]
+        bx += ddx * 3; by += ddy * 3
+        // Carve a 2-wide passage along the step.
+        for (let dy = -1; dy <= 1; dy++) {
+          for (let dx = -1; dx <= 1; dx++) set(tiles, bx + dx, by + dy, 'air')
+        }
+        // Stay within world bounds.
+        bx = Math.max(4, Math.min(WORLD_W - 5, bx))
+        by = Math.max(4, Math.min(WORLD_H - 5, by))
+      }
+    }
+
+    // Stalactites from stone ceilings.
+    for (let x = 0; x < WORLD_W; x++) {
+      for (let y = 0; y < WORLD_H - 1; y++) {
+        if (tileAt(tiles, x, y) !== M.stone) continue
+        if (tileAt(tiles, x, y + 1) !== M.air) continue
+        if (rng() > 0.22) continue
+        const length = 2 + Math.floor(rng() * 6)
+        for (let d = 1; d <= length; d++) {
+          if (tileAt(tiles, x, y + d) !== M.air) break
+          set(tiles, x, y + d, 'stone')
+        }
+      }
+    }
+
+    // Underground pools at the bottom of lower chambers.
+    for (const { x: cx, y: cy } of nodes) {
+      if (cy < WORLD_H * 0.4 || rng() > 0.6) continue
+      const lakeW = 4 + Math.floor(rng() * 10)
+      for (let x = cx - lakeW; x <= cx + lakeW; x++) {
+        let floorY = -1
+        for (let y = cy; y < Math.min(WORLD_H, cy + 20); y++) {
+          if (tileAt(tiles, x, y) === M.stone) { floorY = y; break }
+        }
+        if (floorY < 0) continue
+        const t = 1 - Math.abs(x - cx) / (lakeW + 1)
+        const depth = Math.floor(t * 4)
+        for (let d = 1; d <= depth; d++) {
+          if (tileAt(tiles, x, floorY - d) === M.air) set(tiles, x, floorY - d, 'water')
+        }
+      }
+    }
+
+    // Acid pools — rare, tucked in narrow side passages.
+    for (let i = 0; i < across(2); i++) {
+      const nx = Math.floor(rng() * WORLD_W)
+      const ny = Math.floor(WORLD_H * (0.5 + rng() * 0.4))
+      blob(tiles, nx, ny, 2 + Math.floor(rng() * 3), 'acid', rng, ['air'])
+    }
+
+    // Crystal and gem veins in the stone walls.
+    for (let i = 0; i < across(12); i++) {
+      const nx = Math.floor(rng() * WORLD_W)
+      const ny = Math.floor(WORLD_H * (0.05 + rng() * 0.88))
+      const t = oreNoise(nx * 0.04, ny * 0.04)
+      const id: MaterialId = t < 0.45 ? 'crystal' : t < 0.8 ? 'gem' : 'gold'
+      blob(tiles, nx, ny, 2 + Math.floor(rng() * 3), id, rng, ['stone'])
+    }
+
+    // Ancient bones in the deep tunnels.
+    for (let i = 0; i < across(6); i++) {
+      const nx = Math.floor(rng() * WORLD_W)
+      const ny = Math.floor(WORLD_H * (0.3 + rng() * 0.6))
+      blob(tiles, nx, ny, 2 + Math.floor(rng() * 2), 'bone', rng, ['stone'])
+    }
+
+    // Lava pockets near the bottom.
+    for (let i = 0; i < across(2); i++) {
+      const nx = Math.floor(rng() * WORLD_W)
+      const ny = Math.floor(WORLD_H * (0.72 + rng() * 0.2))
+      blob(tiles, nx, ny, 3 + Math.floor(rng() * 4), 'lava', rng, ['stone'])
+    }
+
+    // Moss on exposed stone floors where moisture gathers.
+    mossify(tiles, rng, 0.20, ['stone'])
+  },
+}
+
 /**
  * Order is the order of the picker, and it is a reading order: nothing, then
  * the world most like ours, then the ones that bend it further and further.
@@ -1856,6 +2011,7 @@ export const THEMES: Theme[] = [
   SKYLANDS,
   VOLCANIC,
   CAVE,
+  CAVE_NETWORK,
   CASTLE,
   STATION,
   CANDY,


### PR DESCRIPTION
## Summary

New world theme `cave-network` ("The Labyrinth") that generates an interconnected tunnel network through solid stone:

- **Generation**: 5–7 chamber nodes spread across the world, connected by L-shaped corridors, plus 4–7 random-walk secondary passages for winding side tunnels
- **Features**: stalactites, underground water pools, rare acid pockets, crystal/gem/gold veins, bone deposits, lava pockets near the bottom, moss on exposed stone floors
- **Atmosphere**: `gloom: 0.78` (darker than The Deep at 0.65), near-black sky — bioluminescent and echolocating creatures are the only light sources
- **Creature set**: glowvine, sporecap, loamworm, delver, finling, driftmole — the cave's native denizens

### Difference from "The Deep" (CAVE)
| | The Deep | The Labyrinth |
|---|---|---|
| Layout | BSP chambers, Z-tunnels | Node-to-node corridors + random branches |
| Feel | Open caverns | Tight tunnels, narrow passages |
| Gloom | 0.65 | 0.78 |
| Acid pools | ✗ | ✓ |
| Driftmole | ✗ | ✓ |

## Test plan

- [ ] Switch to "The Labyrinth" theme and confirm: world is mostly stone with carved air passages
- [ ] Tunnels are narrow (2-3 tiles) with wider chambers at nodes
- [ ] Crystal/gem/bone veins visible in stone walls  
- [ ] Water pools visible in lower chambers
- [ ] Creatures navigate the tunnels successfully (spawn in air spaces)
- [ ] Theme appears in the theme picker after "The Deep"

🤖 Generated with [Claude Code](https://claude.com/claude-code)