### PR TITLE
feat(microland): weather events — storms strip vegetation and cause flash floods

### DIFF
--- a/src/app/micro-land/domain/sim/world.ts
+++ b/src/app/micro-land/domain/sim/world.ts
@@ -936,3 +936,56 @@ export function applyMassExtinction(
 
   return { cx, cy, radius }
 }
+
+/**
+ * Apply a storm event at a random horizontal position.
+ *
+ * A storm has two effects on terrain:
+ *   1. Strips vegetation — grass and moss tiles near the surface become dirt,
+ *      simulating heavy rain tearing off leaf cover.
+ *   2. Flash flood — adds a thin sheet of water above the surface across the
+ *      storm's width; gravity and normal tile physics carry it downhill.
+ *
+ * Returns the X range of the storm so the caller can render rain particles.
+ */
+export function applyStorm(
+  w: WorldState,
+  rng: Rng
+): { x0: number; x1: number } {
+  const halfW = Math.max(5, Math.round(TUNING.stormWidth / 2))
+  const cx = halfW + Math.floor(rng() * (WORLD_W - 2 * halfW))
+  const x0 = Math.max(0, cx - halfW)
+  const x1 = Math.min(WORLD_W - 1, cx + halfW)
+
+  const grassIdx = MATERIAL_INDEX['grass']
+  const mossIdx = MATERIAL_INDEX['moss']
+  const dirtIdx = MATERIAL_INDEX['dirt']
+  const airIdx = MATERIAL_INDEX['air']
+  const waterIdx = MATERIAL_INDEX['water']
+
+  for (let x = x0; x <= x1; x++) {
+    // Strip vegetation in the top 60% of the column above the first solid tile.
+    let hitSurface = false
+    for (let y = 0; y < WORLD_H; y++) {
+      const mat = w.tiles[y * WORLD_W + x]
+      if (mat === airIdx) continue
+      // First solid tile — strip it if grass/moss.
+      hitSurface = true
+      if (mat === grassIdx || mat === mossIdx) {
+        w.tiles[y * WORLD_W + x] = dirtIdx
+      }
+      break
+    }
+    // Flash flood: drop water at the very top of the column if it's open air.
+    if (hitSurface) {
+      const depth = 1 + Math.floor(rng() * 2)
+      for (let d = 0; d < depth; d++) {
+        if (w.tiles[d * WORLD_W + x] === airIdx) {
+          w.tiles[d * WORLD_W + x] = waterIdx
+        }
+      }
+    }
+  }
+
+  return { x0, x1 }
+}

--- a/src/app/micro-land/domain/tuning.ts
+++ b/src/app/micro-land/domain/tuning.ts
@@ -151,6 +151,16 @@ export const TUNING_DEFAULTS = {
    * Radius of the destruction zone for each mass extinction event, in tiles.
    */
   massExtinctionRadius: 20,
+  /**
+   * How often a storm strikes, in sim seconds. 0 = never.
+   * Each storm strips vegetation from the surface and dumps rain in the area,
+   * creating a brief flash flood.
+   */
+  stormInterval: 0,
+  /**
+   * Horizontal width (in tiles) of the storm's ground effect.
+   */
+  stormWidth: 40,
 }
 
 export type TuningKey = keyof typeof TUNING_DEFAULTS
@@ -537,6 +547,26 @@ export const KNOBS: Knob[] = [
     min: 5,
     max: 50,
     step: 5,
+    unit: ' tiles',
+  },
+  {
+    key: 'stormInterval',
+    group: 'world',
+    label: 'Storm interval',
+    help: 'How often a storm rolls in, stripping vegetation and flooding the surface. 0 = never. 120 = every 2 minutes.',
+    min: 0,
+    max: 1200,
+    step: 30,
+    unit: 's',
+  },
+  {
+    key: 'stormWidth',
+    group: 'world',
+    label: 'Storm width',
+    help: 'How wide a swath the storm covers. Only meaningful when storm interval is set.',
+    min: 10,
+    max: 120,
+    step: 10,
     unit: ' tiles',
   },
 ]

--- a/src/app/micro-land/game-instance.ts
+++ b/src/app/micro-land/game-instance.ts
@@ -43,6 +43,7 @@ import { makeRng } from './domain/sim/prng'
 import { tickTiles } from './domain/sim/tile-sim'
 import {
   applyMassExtinction,
+  applyStorm,
   applyTheme,
   applyThemeObject,
   applyTide,
@@ -220,6 +221,8 @@ export class GameInstance {
   private lastArchiveSize = -1
   /** World-time of the last mass extinction cataclysm. */
   private lastMassExtinction = -Infinity
+  /** World-time of the last storm. */
+  private lastStorm = -Infinity
 
   // --- terrain erosion ---
   /**
@@ -510,6 +513,32 @@ export class GameInstance {
       }
       useMicroLand.getState().notify('A cataclysm strikes. The land remembers nothing.')
       this.breakSteadyStreak()
+    }
+
+    // --- storm event ---
+    if (
+      TUNING.stormInterval > 0 &&
+      w.elapsed - this.lastStorm >= TUNING.stormInterval
+    ) {
+      this.lastStorm = w.elapsed
+      const { x0, x1 } = applyStorm(w, this.rng)
+      this.renderer.markTilesDirty()
+      // Scatter blue-grey rain particles across the storm column.
+      const stormW = x1 - x0
+      for (let i = 0; i < Math.min(30, stormW); i++) {
+        const rx = x0 + Math.floor(this.rng() * stormW)
+        const ry = this.rng() * 8
+        w.particles.push({
+          x: rx,
+          y: ry,
+          vx: (this.rng() - 0.5) * 0.3,
+          vy: 1.5 + this.rng() * 2,
+          life: 1.5 + this.rng() * 1.5,
+          maxLife: 3,
+          color: this.rng() < 0.6 ? '#93c5fd' : '#60a5fa',
+        })
+      }
+      useMicroLand.getState().notify('A storm sweeps through, stripping the land and flooding the banks.')
     }
 
     tickCreatures(w, TICK_S, this.rng, gravity, events)


### PR DESCRIPTION
## Summary

Adds a configurable storm event system to microland:

- **New tuning knobs** (world group):
  - `stormInterval` (0 = never, seconds between storms; default 0)
  - `stormWidth` (tile-width of the storm's ground effect; default 40)
- **`applyStorm(w, rng)`** in `world.ts`: at the surface level, converts grass/moss to dirt (leaf stripping) and drops 1-2 water tiles at the top of each column in the storm zone
- **Flash flood**: the dropped water tiles flow naturally via existing tile physics — puddles form, fill low areas, and drain over time
- **Visual**: 30 blue rain particles scatter above the storm zone on each event
- **Notification**: "A storm sweeps through, stripping the land and flooding the banks."

## Why

Closes #3001. Storms create an ecological pulse — vegetation is temporarily stripped, flooding clears up on its own, and creatures that prefer wet habitats see short-term boosts. Off by default so existing worlds aren't affected.

## Test plan

- [ ] Set `stormInterval = 60` in tuning panel; observe storm within ~1 min
- [ ] Confirm grass tiles near storm center convert to dirt
- [ ] Confirm blue rain particles appear during storm
- [ ] Water tiles appear at top of columns in storm zone and flow downhill
- [ ] With no storm interval set (0), no storms ever fire

🤖 Generated with [Claude Code](https://claude.com/claude-code)