### PR TITLE
feat(microland): ghost mode — haunt extinct species (#3007)

### DIFF
--- a/src/app/micro-land/components/field-guide.tsx
+++ b/src/app/micro-land/components/field-guide.tsx
@@ -138,6 +138,8 @@ export function FieldGuide() {
   const fogEnabled = useMicroLand(s => s.fogEnabled)
   const setFogEnabled = useMicroLand(s => s.setFogEnabled)
   const extinctions = useMicroLand(s => s.extinctions)
+  const ghostBlueprintId = useMicroLand(s => s.ghostBlueprintId)
+  const setGhostBlueprintId = useMicroLand(s => s.setGhostBlueprintId)
   const worldStats = useMicroLand(s => s.worldStats)
   const namedCreatures = useMicroLand(s => s.namedCreatures)
   const foodWeb = useMicroLand(s => s.foodWeb)
@@ -925,6 +927,25 @@ export function FieldGuide() {
                       ? `${formatDuration(ext.livedFor)} · reached gen ${ext.maxGeneration}`
                       : formatDuration(ext.livedFor)}
                   </span>
+                  <button
+                    onClick={() => setGhostBlueprintId(ghostBlueprintId === ext.blueprintId ? null : ext.blueprintId)}
+                    title={ghostBlueprintId === ext.blueprintId ? 'Hide ghost' : 'Show ghost'}
+                    style={{
+                      gridColumn: '1 / -1',
+                      marginTop: 3,
+                      padding: '2px 6px',
+                      fontSize: 10,
+                      fontFamily: 'var(--cc-font-mono)',
+                      background: ghostBlueprintId === ext.blueprintId ? 'rgba(147,197,253,0.2)' : 'rgba(255,255,255,0.05)',
+                      border: '1px solid rgba(147,197,253,0.3)',
+                      borderRadius: 3,
+                      color: ghostBlueprintId === ext.blueprintId ? '#93c5fd' : 'var(--cc-text-muted)',
+                      cursor: 'pointer',
+                      textAlign: 'left',
+                    }}
+                  >
+                    {ghostBlueprintId === ext.blueprintId ? '◈ haunting' : '◇ haunt'}
+                  </button>
                 </li>
               ))}
             </ul>

--- a/src/app/micro-land/game-instance.ts
+++ b/src/app/micro-land/game-instance.ts
@@ -187,6 +187,10 @@ export class GameInstance {
   private traitHistory = new Map<string, TraitHistoryEntry[]>()
   private lastTraitSample = -30
 
+  // --- ghost mode ---
+  /** Last known positions for each species, refreshed every stats tick. */
+  private lastSpeciesPositions = new Map<string, { x: number; y: number }[]>()
+
   // --- records ---
   /** Which land's records are being written to. See `landId()`. */
   private currentLand = DEFAULT_THEME
@@ -706,6 +710,11 @@ export class GameInstance {
           livedFor,
           maxGeneration,
         })
+        // Save last-known positions so ghost mode can haunt this species.
+        useMicroLand.getState().setGhostPositions(
+          bp.id,
+          this.lastSpeciesPositions.get(bp.id) ?? [{ x: event.x, y: event.y }],
+        )
         // Drop a fossil where the last creature of this species died.
         this.world.fossils.push({
           id: this.world.nextFossilId++,
@@ -1084,6 +1093,15 @@ export class GameInstance {
       const flat: Record<string, number> = {}
       for (const [id, t] of this.speciesFirstSeen) flat[id] = t
       useMicroLand.getState().setSpeciesFirstSeen(flat)
+    }
+
+    // Track last-known positions for ghost mode — snapshot where each species is
+    // right now so we have something to draw if it goes extinct.
+    for (const entry of population) {
+      const positions = this.world.creatures
+        .filter(c => c.blueprintId === entry.blueprintId)
+        .map(c => ({ x: c.x, y: c.y }))
+      this.lastSpeciesPositions.set(entry.blueprintId, positions)
     }
 
     // Accumulate mutualism bond time for species pairs in active symbiosis.

--- a/src/app/micro-land/rendering/renderer.ts
+++ b/src/app/micro-land/rendering/renderer.ts
@@ -28,7 +28,7 @@
 import { MATERIAL_BY_INDEX } from '@/app/micro-land/domain/config/materials'
 import type { Theme } from '@/app/micro-land/domain/config/themes'
 import { VIEW_W, WORLD_H, WORLD_W } from '@/app/micro-land/domain/constants'
-import { lifespanOf, sizeOf, tintKey } from '@/app/micro-land/domain/traits'
+import { NEUTRAL_TINT, lifespanOf, sizeOf, tintKey } from '@/app/micro-land/domain/traits'
 import { TUNING } from '@/app/micro-land/domain/tuning'
 import type { WorldState } from '@/app/micro-land/domain/types'
 import { useMicroLand } from '@/app/micro-land/store'
@@ -529,6 +529,7 @@ export class Renderer {
     this.drawPollinatorAuras(w, vx, vw)
     this.drawGlowAuras(w, vx, vw)
     this.drawEcholocationPulses(w, vx, vw)
+    this.drawGhosts(w, vx, vw)
     if (useMicroLand.getState().scentsEnabled) this.drawScentBeacons(w, vx, vw)
     this.drawParticles(w, vx, vw)
     wctx.drawImage(this.shadowCanvas, vx, 0, vw, WORLD_H, vx, 0, vw, WORLD_H)
@@ -1082,6 +1083,29 @@ export class Renderer {
     }
     ctx.globalAlpha = 1
     ctx.lineWidth = 1
+  }
+
+  /** Ghost mode: draw extinct species' last positions as translucent spirits. */
+  private drawGhosts(w: WorldState, vx: number, vw: number): void {
+    const { ghostBlueprintId, ghostPositions } = useMicroLand.getState()
+    if (!ghostBlueprintId) return
+    const positions = ghostPositions[ghostBlueprintId]
+    if (!positions || positions.length === 0) return
+    const bp = w.blueprints[ghostBlueprintId]
+    if (!bp) return
+
+    const ctx = this.wctx
+    const sprites = getSprites(bp, NEUTRAL_TINT)
+    // Gentle drift: ghosts pulse in and out of visibility
+    const pulse = 0.15 + Math.sin(w.elapsed * 1.5) * 0.08
+    ctx.globalAlpha = pulse
+
+    for (const pos of positions) {
+      if (pos.x + sprites.width < vx || pos.x > vx + vw) continue
+      const frame = sprites.frames[0]
+      ctx.drawImage(frame, Math.round(pos.x), Math.round(pos.y), sprites.width, sprites.height)
+    }
+    ctx.globalAlpha = 1
   }
 
   private drawScentBeacons(w: WorldState, vx: number, vw: number): void {

--- a/src/app/micro-land/store.ts
+++ b/src/app/micro-land/store.ts
@@ -498,6 +498,19 @@ interface MicroLandState {
   setReplayIndex: (i: number) => void
   exitReplay: () => void
 
+  /**
+   * Ghost mode: which extinct species to show as a translucent overlay.
+   * Null = no ghost active.
+   */
+  ghostBlueprintId: string | null
+  /**
+   * Last-known positions for each species at the moment it went extinct.
+   * Key = blueprintId. Written when the last creature of a species dies.
+   */
+  ghostPositions: Record<string, { x: number; y: number }[]>
+  setGhostBlueprintId: (id: string | null) => void
+  setGhostPositions: (blueprintId: string, positions: { x: number; y: number }[]) => void
+
   setTheme: (id: string) => void
   setTool: (tool: Tool) => void
   setBrush: (n: number) => void
@@ -674,6 +687,8 @@ export const useMicroLand = create<MicroLandState>(set => ({
   fogEnabled: true,
   heatmapBlueprintId: null,
   soundEnabled: false,
+  ghostBlueprintId: null,
+  ghostPositions: {},
 
   setTheme: themeId => set({ themeId }),
   setTool: tool => set({ tool }),
@@ -681,7 +696,7 @@ export const useMicroLand = create<MicroLandState>(set => ({
   setBrushShape: brushShape => set({ brushShape }),
   togglePaused: () => set(s => ({ paused: !s.paused })),
   setSpeed: speed => set({ speed }),
-  setBlueprints: blueprints => set({ blueprints, populationHistory: [], extinctions: [], worldStats: { ...EMPTY_STATS }, foodWeb: {}, mutualismBonds: {}, speciesFirstSeen: {}, historyLog: [] }),
+  setBlueprints: blueprints => set({ blueprints, populationHistory: [], extinctions: [], worldStats: { ...EMPTY_STATS }, foodWeb: {}, mutualismBonds: {}, speciesFirstSeen: {}, historyLog: [], ghostBlueprintId: null, ghostPositions: {} }),
   addBlueprint: bp =>
     set(s => ({
       blueprints: s.blueprints.some(b => b.id === bp.id)
@@ -811,6 +826,10 @@ export const useMicroLand = create<MicroLandState>(set => ({
     set({ replaySnapshots: snapshots, replayIndex: snapshots.length - 1, paused: true }),
   setReplayIndex: i => set({ replayIndex: i }),
   exitReplay: () => set({ replaySnapshots: null, replayIndex: 0, paused: false }),
+
+  setGhostBlueprintId: id => set({ ghostBlueprintId: id }),
+  setGhostPositions: (blueprintId, positions) =>
+    set(s => ({ ghostPositions: { ...s.ghostPositions, [blueprintId]: positions } })),
 
   notify: (text, action) =>
     set(s => ({


### PR DESCRIPTION
## Summary
- Track each species' last-known positions in GameInstance (updated every stats tick)
- On extinction, push those positions to the store via `setGhostPositions`
- Renderer draws ghosts as pulsing translucent sprites (α ≈ 0.15–0.23) using the species' neutral art
- Field Guide Memorial section adds a **◇ haunt** toggle button per extinct species; active ghost shows **◈ haunting** in blue

## Test plan
- [ ] Let a species go extinct, open the Field Guide → Memorial → click "haunt"
- [ ] Verify ghost sprites appear at the species' last known positions, pulsing faintly
- [ ] Click "haunting" to toggle off; verify ghosts disappear
- [ ] Activating a different extinct species replaces the previous ghost

🤖 Generated with [Claude Code](https://claude.com/claude-code)