### PR TITLE
fix(micro-land): unclip the HUD overflow menu

### DIFF
--- a/src/app/micro-land/components/hud.tsx
+++ b/src/app/micro-land/components/hud.tsx
@@ -164,17 +164,38 @@ export function Hud({
 
   const [overflowOpen, setOverflowOpen] = useState(false)
   const overflowRef = useRef<HTMLDivElement>(null)
+  const overflowBtnRef = useRef<HTMLButtonElement>(null)
 
-  // Close the overflow menu when clicking outside it.
+  // The header clips its own overflow so a crowded chip row can never push the
+  // page sideways on a phone. That clipping also swallowed this dropdown whole:
+  // it hangs *below* the header, so an absolutely positioned menu opened, sat
+  // outside the header's box, and was painted nowhere — the button looked dead.
+  // CSS can't clip one axis and spill the other (a visible axis paired with a
+  // hidden one computes to auto), so the menu is positioned fixed instead and
+  // anchored to the button's measured rect. Nothing above it is transformed, so
+  // fixed genuinely escapes the clip.
+  const [menuPos, setMenuPos] = useState<{ top: number; right: number } | null>(null)
+
   useEffect(() => {
     if (!overflowOpen) return
+
+    const place = () => {
+      const rect = overflowBtnRef.current?.getBoundingClientRect()
+      if (rect) setMenuPos({ top: rect.bottom + 4, right: window.innerWidth - rect.right })
+    }
+    place()
+
     const onDown = (e: MouseEvent) => {
       if (overflowRef.current && !overflowRef.current.contains(e.target as Node)) {
         setOverflowOpen(false)
       }
     }
     document.addEventListener('mousedown', onDown)
-    return () => document.removeEventListener('mousedown', onDown)
+    window.addEventListener('resize', place)
+    return () => {
+      document.removeEventListener('mousedown', onDown)
+      window.removeEventListener('resize', place)
+    }
   }, [overflowOpen])
 
   // Shared style for items inside the overflow dropdown.
@@ -382,6 +403,7 @@ export function Hud({
         {/* Overflow menu — secondary actions */}
         <div ref={overflowRef} style={{ position: 'relative' }}>
           <button
+            ref={overflowBtnRef}
             type="button"
             className="cc-btn"
             onClick={() => setOverflowOpen(v => !v)}
@@ -401,13 +423,18 @@ export function Hud({
             ···
           </button>
 
-          {overflowOpen && (
+          {overflowOpen && menuPos && (
             <div
               style={{
-                position: 'absolute',
-                right: 0,
-                top: 'calc(100% + 4px)',
+                position: 'fixed',
+                right: menuPos.right,
+                top: menuPos.top,
                 minWidth: 200,
+                // Micro Land is played landscape, so on a short phone the full
+                // list is taller than what's left below the header — scroll it
+                // rather than run the last items off the bottom of the screen.
+                maxHeight: `calc(100vh - ${menuPos.top + 8}px)`,
+                overflowY: 'auto',
                 background: 'var(--cc-modal-bg-to, #1b1b2e)',
                 border: '1px solid var(--cc-panel-divider)',
                 borderRadius: 6,


### PR DESCRIPTION
## The bug

The `···` menu at the top right of Micro Land does nothing visible.

`hud.tsx` sets `overflow: 'hidden'` on the `<header>` — that stops a crowded chip row from pushing the page sideways on a phone. The dropdown was `position: absolute; top: calc(100% + 4px)`, hanging entirely *below* the header's box, so the clip swallowed it whole.

The button itself was working the whole time: it toggled state and even switched to its active chip style. That's why it reads as a dead button rather than a layout problem.

Both the clip and the menu arrived in the same commit (6e08a06f, "reorganise HUD — core actions one-click, rest in overflow menu"), so there's no regression to point at — the menu has never been visible.

## The fix

CSS can't clip one axis and spill the other (a `visible` axis paired with a `hidden` one computes to `auto`), so the header keeps its clip and the menu is positioned `fixed` against the button's measured `getBoundingClientRect()` instead. Nothing above it is transformed, so `fixed` genuinely escapes the clipping ancestor. The rect is re-measured on window resize while the menu is open.

Also caps the panel's height and lets it scroll — Micro Land is played landscape, and nine items is taller than what's left below the header on a short phone.

Outside-click dismissal is unchanged: the fixed panel is still a DOM descendant of `overflowRef`, so the `contains()` check still matches.

## Verification

- Page compiles and serves.
- `npm run typecheck` and `eslint` both report errors, but **all are pre-existing on `main`** and none are on touched lines (trait-schema drift in `blueprint-workshop`/`snapshot`/`wire`, hex literals in the health palette, import ordering).
- **Not clicked in a browser** — no browser automation in the authoring environment. Worth a manual check that the panel lands where it should at desktop and phone widths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)