### PR TITLE
feat(micro-land): the world loops around

### DIFF
--- a/.claude/skills/micro-land/SKILL.md
+++ b/.claude/skills/micro-land/SKILL.md
@@ -118,17 +118,40 @@ to can also be kept by name on a "shelf" and reopened mid-simulation.
     one thing the renderer exists to protect. `camX` is kept fractional so slow
     pans accumulate, but `viewLeft()` floors it before anything is drawn.
 
-11. **Records are high-water marks.** That is why the chronicle can be sampled a
+11. **The world is a cylinder, and every stored x is wrapped.** Walk off the
+    right edge and you come back on the left; top and bottom are still walls,
+    because a wrapped ceiling in falling sand rains powder out of the sky
+    forever. `domain/wrap.ts` owns the whole idea. Two consequences bite
+    constantly:
+
+    - **`b - a` is not a distance.** Use `deltaX` (signed, and its sign is a
+      direction) or `distX`. A plain subtraction compiles, looks right, and
+      produces a creature that can *see* across the seam but walks the long way
+      round to get there — which reads as bad AI, not as a wrap bug. The same
+      trap catches any *midpoint*: half of `a + b` is the far side of the world
+      from both parents when they meet across the seam.
+    - **Terrain has to meet itself.** Generators sample noise around a *ring*
+      (`ringXY`, plus `makeNoise3D`/`fbm3` when depth is involved), never along a
+      line from x=0 to x=671, which has no reason to arrive back where it
+      started. `world-wrap.test.ts` measures the surface jump at column zero
+      against each theme's own roughness — that test is the only thing standing
+      between you and a visible cliff down the seam.
+
+    Culling and drawing are the renderer's version of the same problem:
+    `overlapsView` decides visibility on a circle, and anything overlapping
+    column zero is drawn twice, once at each end.
+
+12. **Records are high-water marks.** That is why the chronicle can be sampled a
     few times a second instead of per frame, why `mergeChronicles` needs no
     conflict resolution, and why banking a streak early is safe. Keep any new
     record monotonic.
 
-12. **Anonymous-first (CLAUDE.md #1).** The game starts on `localBackend` and
+13. **Anonymous-first (CLAUDE.md #1).** The game starts on `localBackend` and
     never waits for the network. Auth resolving later calls `adoptAccount`,
     which merges rather than choosing. A player with no account and no
     connection still gets a complete game.
 
-13. **The ecosystem numbers are read off `TUNING`, not off `constants.ts`.**
+14. **The ecosystem numbers are read off `TUNING`, not off `constants.ts`.**
     Plant seeding, population caps, breeding costs and gravity live in
     `domain/tuning.ts` as a mutable object the settings panel moves while the
     world runs; `constants.ts` holds their defaults and the reasoning for them.

--- a/.claude/skills/micro-land/references/architecture.md
+++ b/.claude/skills/micro-land/references/architecture.md
@@ -22,9 +22,10 @@ All paths relative to `src/app/micro-land/` unless noted. LOC approximate.
 | File | ~LOC | Role |
 |------|------|------|
 | `world.ts` | 685 | World construction, tile access helpers, spawning, native plants, seed rain |
+| `wrap.ts` (in `domain/`) | 130 | The world is a cylinder. `wrapX`/`wrapCol` normalise a column, `deltaX`/`distX` measure the short way round, `overlapsView` culls on a circle, `ringXY` maps a column onto the noise ring |
 | `creature-sim.ts` | 931 | Hunger, senses, steering, physics, digging, breeding, death, particles |
 | `tile-sim.ts` | 293 | Falling sand: powders, liquids, quenching, melting, corrosion |
-| `prng.ts` | 78 | Seeded RNG, value noise, fbm |
+| `prng.ts` | 142 | Seeded RNG, value noise, fbm — plus the 3D lattice (`makeNoise3D`/`fbm3`) the ring sampling needs when depth is also in play |
 
 ### Domain
 | File | ~LOC | Role |
@@ -226,6 +227,16 @@ lit, 1 = only glowing things visible), `gravity` multiplier, `starters[]`, and a
 `across(n)` inside `themes.ts` is the `WIDTH_SCALE` multiplier for scattered
 features. Theme starter counts get the same treatment in `seedStarters`.
 
+**Every generator samples noise around a ring, not along a line.** `ring1` for a
+surface height, `ring2` for a field that also varies with depth, `ring2Raw` for a
+single unlayered sample — all built on `ringXY` + `fbm3`. A circle closes on
+itself, so a continuous field read along one is periodic by construction: no
+blending band, and no requirement that the noise lattice divide evenly into the
+world width. Writing `fbm(noise, x * 0.03, …)` again is what puts the cliff back.
+One trap worth knowing: on a ring an **x-offset is only a rotation of the same
+circle**, so the old trick of decorrelating two curves with `x * f + 100` does
+nothing — offset the *layer* instead.
+
 `SUMMONED_THEME_ID` (`'summoned'`) is a pseudo-theme: `GameInstance` holds the
 summoned `Theme` object in `summonedTheme` and `resolveTheme` prefers it.
 
@@ -259,25 +270,45 @@ re-keys the records to the summoned land's name.
 Terrain painting (`paintTerrain`): a coarse character map, ground level fitted
 by `fitGroundLevel` (models draw the horizon two-thirds up, which plays badly —
 pad empty rows on top until the surface sits 30–50% up), then sampled with fbm
-noise jitter so cell edges come out ragged. Cells are kept **square**; a map too
-narrow to cross the world repeats mirrored rather than stretching.
+noise jitter so cell edges come out ragged. The map is walked **mirrored, out and
+back**, and the world now always spans a **whole number of those round trips** —
+a fractional one met itself part-way through and put a hard vertical cut down the
+seam, in the very place the reflection was there to avoid one. Rounding to the
+nearest whole trip is what keeps cells near-square. The jitter is ring-sampled
+for the same reason as the themes.
 
 ---
 
 ## Rendering
 
-One canvas pixel per world tile into a `WORLD_W × WORLD_H` backbuffer, then one
-scaled blit with `imageSmoothingEnabled = false`. Zoom is fixed by `VIEW_W`
+One canvas pixel per world tile into a backbuffer, then one scaled blit with
+`imageSmoothingEnabled = false`.
+
+The backbuffer is **`WORLD_W + WORLD_W` wide**. The camera wraps, so the visible
+range can run off the end of the world; rather than splitting the frame into two
+of everything, the head of the world is copied into that overhang once per frame
+(only as many columns as actually hang over) and the blit stays a single
+contiguous read. Content is drawn twice, at offset `0` and `-WORLD_W`, so a
+sprite hanging over the seam lands in column zero as well — `overlapsView`
+rejects the second copy for anything that does not reach the seam, which is
+nearly everything. Zoom is fixed by `VIEW_W`
 (224), not by the world width, so a hopper is the same size it has always been;
 a wide display simply sees more tiles.
 
 Per frame, all clipped to visible columns:
 1. `ensureTiles` — re-bake tile colors if the view left the baked range
-   (`TILE_MARGIN` 32 columns of slack, which earns its keep while paused)
-2. `buildLight` — quarter-res light field: daylight by column depth below the
-   first solid tile (`SKY_FALLOFF` 16), glowing tiles sampled every other tile,
-   glowing creatures, three blur passes, baked into a shadow overlay scaled by
-   `theme.gloom`. Gathered `LIGHT_MARGIN` 24 columns wide because blur bleeds
+   (`TILE_MARGIN` 32 columns of slack, which earns its keep while paused). A view
+   straddling the seam bakes the whole world instead: one baked range cannot
+   describe two ends of the grid, and the state lasts only as long as it takes to
+   pan past column zero
+2. `buildLight` — quarter-res light field, computed for the **whole world**:
+   daylight by column depth below the first solid tile (`SKY_FALLOFF` 16),
+   glowing tiles sampled every other tile, glowing creatures, three blur passes
+   that wrap sideways. A windowed version would have needed a two-range variant
+   of the gather, the blur and the bilinear sample, to save a field of 168×33
+   cells. The **shadow bake** it feeds is still clipped to the visible span
+   (`forEachSpan`), because that one is a pixel per visible tile per frame and is
+   the only part that ever showed up in a frame budget
 3. Sky gradient → tile layer → creatures (culled off-screen; flicker when
    starving or distressed) → particles → **shadow** → elder halo → inspect
    brackets. Shadow goes after sprites so creatures are dimmed by the same

--- a/src/app/micro-land/domain/__tests__/world-wrap.test.ts
+++ b/src/app/micro-land/domain/__tests__/world-wrap.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest'
+
+import { MATERIAL_INDEX } from '@/app/micro-land/domain/config/materials'
+import { THEMES } from '@/app/micro-land/domain/config/themes'
+import { WORLD_H, WORLD_W } from '@/app/micro-land/domain/constants'
+import { makeRng } from '@/app/micro-land/domain/sim/prng'
+import { createWorld, setTile, solidAt, tileAt } from '@/app/micro-land/domain/sim/world'
+
+describe('tile access wraps sideways', () => {
+  it('reads a column past the right edge as one near the left', () => {
+    const w = createWorld(1)
+    setTile(w, 5, 10, MATERIAL_INDEX.stone)
+    expect(tileAt(w, WORLD_W + 5, 10)).toBe(MATERIAL_INDEX.stone)
+    expect(tileAt(w, 5 - WORLD_W, 10)).toBe(MATERIAL_INDEX.stone)
+  })
+
+  it('writes through the seam too', () => {
+    const w = createWorld(1)
+    setTile(w, -1, 10, MATERIAL_INDEX.dirt)
+    expect(tileAt(w, WORLD_W - 1, 10)).toBe(MATERIAL_INDEX.dirt)
+  })
+
+  /**
+   * The old contract was "out of bounds counts as solid, so nothing can wander
+   * out of the world". Sideways that wall is exactly what has been removed, and
+   * a stray `true` here would read to every walker as a cliff face at column
+   * zero that it turns around at forever.
+   */
+  it('no longer reports a wall at either side', () => {
+    const w = createWorld(1)
+    expect(solidAt(w, -1, 10)).toBe(false)
+    expect(solidAt(w, WORLD_W, 10)).toBe(false)
+  })
+
+  it('still reports a wall above and below', () => {
+    const w = createWorld(1)
+    expect(solidAt(w, 10, -1)).toBe(true)
+    expect(solidAt(w, 10, WORLD_H)).toBe(true)
+  })
+})
+
+/**
+ * Terrain has to meet itself at the seam.
+ *
+ * A world that wraps but whose hills do not is worse than one that does not wrap
+ * at all: the cliff at column zero is the single thing that gives the loop away.
+ * Every generator samples its noise around a ring for this reason, and the way
+ * that silently regresses is someone writing `fbm(noise, x * 0.03, ...)` again
+ * because it is the obvious thing to write.
+ *
+ * Measured against the terrain's own roughness rather than an absolute, because
+ * a theme with genuine cliffs in it is allowed a big step — just not a bigger
+ * one at the seam than it takes anywhere else.
+ */
+describe('every theme is continuous across the seam', () => {
+  function surfaceRow(tiles: Uint8Array, x: number): number {
+    let y = 0
+    while (y < WORLD_H && tiles[y * WORLD_W + x] === 0) y++
+    return y
+  }
+
+  for (const theme of THEMES) {
+    it(`${theme.id} has no cliff at column zero`, () => {
+      const tiles = new Uint8Array(WORLD_W * WORLD_H)
+      theme.build(tiles, makeRng(4242))
+
+      const seamStep = Math.abs(surfaceRow(tiles, WORLD_W - 1) - surfaceRow(tiles, 0))
+      let worstStep = 0
+      for (let x = 1; x < WORLD_W; x++) {
+        const step = Math.abs(surfaceRow(tiles, x) - surfaceRow(tiles, x - 1))
+        if (step > worstStep) worstStep = step
+      }
+
+      expect(seamStep).toBeLessThanOrEqual(Math.max(3, worstStep))
+    })
+  }
+})

--- a/src/app/micro-land/domain/__tests__/wrap.test.ts
+++ b/src/app/micro-land/domain/__tests__/wrap.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from 'vitest'
+
+import { WORLD_W } from '@/app/micro-land/domain/constants'
+import { deltaX, distX, overlapsView, wrapCol, wrapX } from '@/app/micro-land/domain/wrap'
+
+describe('wrapX', () => {
+  it('leaves an in-range column alone', () => {
+    expect(wrapX(0)).toBe(0)
+    expect(wrapX(12.5)).toBe(12.5)
+    expect(wrapX(WORLD_W - 1)).toBe(WORLD_W - 1)
+  })
+
+  it('brings a column off the right edge back on the left', () => {
+    expect(wrapX(WORLD_W)).toBe(0)
+    expect(wrapX(WORLD_W + 4)).toBe(4)
+  })
+
+  /**
+   * The bug this function exists to prevent. `%` keeps the sign of the dividend
+   * in JavaScript, so the obvious one-liner returns -1 here — which then indexes
+   * the last tile of the row *above*, and nothing looks wrong until something
+   * walks left.
+   */
+  it('brings a column off the left edge back on the right', () => {
+    expect(wrapX(-1)).toBe(WORLD_W - 1)
+    expect(wrapX(-0.5)).toBe(WORLD_W - 0.5)
+    expect(wrapX(-WORLD_W - 3)).toBe(WORLD_W - 3)
+  })
+
+  it('always lands in [0, WORLD_W)', () => {
+    for (let i = -3 * WORLD_W; i < 3 * WORLD_W; i += 7) {
+      const v = wrapX(i)
+      expect(v).toBeGreaterThanOrEqual(0)
+      expect(v).toBeLessThan(WORLD_W)
+    }
+  })
+})
+
+describe('wrapCol', () => {
+  it('agrees with wrapX on whole columns', () => {
+    for (let i = -2 * WORLD_W; i < 2 * WORLD_W; i += 13) {
+      expect(wrapCol(i)).toBe(wrapX(i))
+    }
+  })
+})
+
+describe('deltaX', () => {
+  it('is plain subtraction away from the seam', () => {
+    expect(deltaX(100, 140)).toBe(40)
+    expect(deltaX(140, 100)).toBe(-40)
+  })
+
+  /**
+   * The whole point. Two creatures either side of column zero are neighbours,
+   * and the sign has to say "step right", not "walk six hundred tiles left".
+   */
+  it('takes the short way across the seam', () => {
+    expect(deltaX(WORLD_W - 2, 3)).toBe(5)
+    expect(deltaX(3, WORLD_W - 2)).toBe(-5)
+  })
+
+  it('never reports more than half a world', () => {
+    for (let a = 0; a < WORLD_W; a += 31) {
+      for (let b = 0; b < WORLD_W; b += 29) {
+        expect(Math.abs(deltaX(a, b))).toBeLessThanOrEqual(WORLD_W / 2)
+      }
+    }
+  })
+
+  it('is antisymmetric', () => {
+    for (let a = 0; a < WORLD_W; a += 37) {
+      for (let b = 0; b < WORLD_W; b += 41) {
+        // The exact half-world case is the one point where both directions are
+        // equally short, so it is allowed to pick a side and the pair sums to a
+        // world rather than to zero.
+        const d = deltaX(a, b)
+        if (Math.abs(d) === WORLD_W / 2) continue
+        // Numeric rather than `toBe`, which is Object.is and so separates -0
+        // from 0 — a distinction with no meaning for a distance.
+        expect(deltaX(b, a)).toBeCloseTo(-d, 9)
+      }
+    }
+  })
+
+  it('lands you on the target when added to the origin', () => {
+    for (let a = 0; a < WORLD_W; a += 53) {
+      for (let b = 0; b < WORLD_W; b += 47) {
+        expect(wrapX(a + deltaX(a, b))).toBeCloseTo(b, 9)
+      }
+    }
+  })
+})
+
+describe('distX', () => {
+  it('matches the magnitude of deltaX', () => {
+    for (let a = 0; a < WORLD_W; a += 43) {
+      for (let b = 0; b < WORLD_W; b += 39) {
+        expect(distX(a, b)).toBeCloseTo(Math.abs(deltaX(a, b)), 9)
+      }
+    }
+  })
+
+  it('is symmetric', () => {
+    expect(distX(WORLD_W - 2, 3)).toBe(distX(3, WORLD_W - 2))
+  })
+})
+
+describe('overlapsView', () => {
+  const VIEW = 224
+
+  it('accepts something inside the view and rejects something behind it', () => {
+    expect(overlapsView(100, 4, 50, VIEW)).toBe(true)
+    expect(overlapsView(400, 4, 50, VIEW)).toBe(false)
+  })
+
+  it('accepts something straddling the left edge of the view', () => {
+    // Two tiles of a four-wide sprite are showing.
+    expect(overlapsView(48, 4, 50, VIEW)).toBe(true)
+  })
+
+  /**
+   * The case the seam adds. A creature sitting on column 670 has its tail in
+   * column 2, so a view that starts at column 0 has to draw it even though its
+   * left edge is most of a world away to the left.
+   */
+  it('accepts something whose tail wraps into the start of the view', () => {
+    expect(overlapsView(WORLD_W - 2, 8, 0, VIEW)).toBe(true)
+  })
+
+  it('accepts something the wrapped view has come round to', () => {
+    // View starts near the end of the world and runs past column zero.
+    expect(overlapsView(10, 4, WORLD_W - 40, VIEW)).toBe(true)
+  })
+
+  it('still rejects the far side of the world from a wrapped view', () => {
+    expect(overlapsView(WORLD_W / 2, 4, WORLD_W - 40, VIEW)).toBe(false)
+  })
+
+  it('accepts everything when the view is the whole world', () => {
+    for (let x = 0; x < WORLD_W; x += 37) {
+      expect(overlapsView(x, 1, 300, WORLD_W)).toBe(true)
+    }
+  })
+})

--- a/src/app/micro-land/domain/config/themes.ts
+++ b/src/app/micro-land/domain/config/themes.ts
@@ -7,8 +7,9 @@
  * creatures survive the change.
  */
 import { WIDTH_SCALE, WORLD_H, WORLD_W } from '@/app/micro-land/domain/constants'
-import { type Rng, fbm, makeNoise2D } from '@/app/micro-land/domain/sim/prng'
+import { type Rng, fbm3, makeNoise3D } from '@/app/micro-land/domain/sim/prng'
 import type { MaterialId } from '@/app/micro-land/domain/types'
+import { ringXY, wrapCol } from '@/app/micro-land/domain/wrap'
 
 import { MATERIAL_INDEX } from './materials'
 
@@ -41,26 +42,84 @@ function across(n: number): number {
   return Math.round(n * WIDTH_SCALE)
 }
 
+/**
+ * A surface height that meets itself at the seam.
+ *
+ * Drop-in for `fbm(noise, x * freq, layer, octaves)`. `layer` keeps its old
+ * meaning — a fixed offset picking out one slice of the field, which is how the
+ * themes get several unrelated-looking curves out of a single noise object.
+ */
+function ring1(
+  noise: (x: number, y: number, z: number) => number,
+  x: number,
+  freq: number,
+  layer: number,
+  octaves = 3
+): number {
+  const { u, v } = ringXY(x, freq)
+  return fbm3(noise, u, v, layer, octaves)
+}
+
+/**
+ * A 2-D field — caves, ore, cloud banks — periodic in x and free in y.
+ *
+ * The circle uses up two dimensions, so depth gets the third. That is the whole
+ * reason `makeNoise3D` exists.
+ */
+function ring2(
+  noise: (x: number, y: number, z: number) => number,
+  x: number,
+  freq: number,
+  y: number,
+  yFreq: number,
+  octaves = 3
+): number {
+  const { u, v } = ringXY(x, freq)
+  return fbm3(noise, u, v, y * yFreq, octaves)
+}
+
+/** `ring2` without the octave stack, for the single-sample call sites. */
+function ring2Raw(
+  noise: (x: number, y: number, z: number) => number,
+  x: number,
+  freq: number,
+  y: number,
+  yFreq: number
+): number {
+  const { u, v } = ringXY(x, freq)
+  return noise(u, v, y * yFreq)
+}
+
 function fill(tiles: Uint8Array, id: MaterialId) {
   tiles.fill(M[id])
 }
 
+/**
+ * Write one tile. Columns wrap; rows do not.
+ *
+ * Every scattered feature in every theme goes through here, so wrapping at this
+ * one point is what lets a lava fall, a tree or a geode straddle column zero and
+ * come out whole. Clipping them instead would leave a strip down the seam where
+ * nothing generated — subtler than a cliff, and still a tell.
+ */
 function set(tiles: Uint8Array, x: number, y: number, id: MaterialId) {
-  if (x < 0 || y < 0 || x >= WORLD_W || y >= WORLD_H) return
-  tiles[y * WORLD_W + x] = M[id]
+  if (y < 0 || y >= WORLD_H) return
+  tiles[y * WORLD_W + wrapCol(x)] = M[id]
 }
 
+/** Filled block. `x0 > x1` is not a thing; a rect that runs off the right edge
+ *  simply carries on from the left. */
 function rect(tiles: Uint8Array, x0: number, y0: number, x1: number, y1: number, id: MaterialId) {
   for (let y = Math.max(0, y0); y <= Math.min(WORLD_H - 1, y1); y++) {
-    for (let x = Math.max(0, x0); x <= Math.min(WORLD_W - 1, x1); x++) {
-      tiles[y * WORLD_W + x] = M[id]
+    for (let x = x0; x <= x1; x++) {
+      tiles[y * WORLD_W + wrapCol(x)] = M[id]
     }
   }
 }
 
 function tileAt(tiles: Uint8Array, x: number, y: number): number {
-  if (x < 0 || y < 0 || x >= WORLD_W || y >= WORLD_H) return -1
-  return tiles[y * WORLD_W + x]
+  if (y < 0 || y >= WORLD_H) return -1
+  return tiles[y * WORLD_W + wrapCol(x)]
 }
 
 /**
@@ -73,8 +132,9 @@ function tileAt(tiles: Uint8Array, x: number, y: number): number {
  * floor of the hole.
  */
 function surfaceY(tiles: Uint8Array, x: number): number {
+  const col = wrapCol(x)
   let y = 0
-  while (y < WORLD_H && tiles[y * WORLD_W + x] === M.air) y++
+  while (y < WORLD_H && tiles[y * WORLD_W + col] === M.air) y++
   return y
 }
 
@@ -176,10 +236,10 @@ const EARTH: Theme = {
   ],
   build: (tiles, rng) => {
     fill(tiles, 'air')
-    const surfaceNoise = makeNoise2D(Math.floor(rng() * 1e9))
-    const caveNoise = makeNoise2D(Math.floor(rng() * 1e9))
-    const oreNoise = makeNoise2D(Math.floor(rng() * 1e9))
-    const treasureNoise = makeNoise2D(Math.floor(rng() * 1e9))
+    const surfaceNoise = makeNoise3D(Math.floor(rng() * 1e9))
+    const caveNoise = makeNoise3D(Math.floor(rng() * 1e9))
+    const oreNoise = makeNoise3D(Math.floor(rng() * 1e9))
+    const treasureNoise = makeNoise3D(Math.floor(rng() * 1e9))
 
     const skyDepth = Math.floor(WORLD_H * 0.3)
     // Anything this far above the average hilltop keeps its snow.
@@ -187,7 +247,7 @@ const EARTH: Theme = {
 
     for (let x = 0; x < WORLD_W; x++) {
       // Rolling hills: a couple of octaves is enough at this width.
-      const h = fbm(surfaceNoise, x * 0.035, 0.5, 3)
+      const h = ring1(surfaceNoise, x, 0.035, 0.5, 3)
       const surface = Math.floor(skyDepth + (h - 0.5) * 18)
       const snowy = surface < snowLine
       const snowDepth = snowy ? 3 + Math.floor((snowLine - surface) / 3) : 0
@@ -206,12 +266,12 @@ const EARTH: Theme = {
 
         // Carve caves out of the rock, but never out of the top crust.
         if (mat === 'stone' && depth < 0.88) {
-          const c = fbm(caveNoise, x * 0.06, y * 0.09, 3)
+          const c = ring2(caveNoise, x, 0.06, y, 0.09, 3)
           if (c > 0.62) mat = 'air'
         }
         // Occasional water pockets and sand seams.
         if (mat === 'stone' && depth > 0.35 && depth < 0.7) {
-          const o = oreNoise(x * 0.12, y * 0.12)
+          const o = ring2Raw(oreNoise, x, 0.12, y, 0.12)
           if (o > 0.88) mat = 'water'
           else if (o < 0.08) mat = 'sand'
         }
@@ -219,7 +279,7 @@ const EARTH: Theme = {
         // gold and crystal sit below the lava-adjacent rock, so getting there
         // costs something.
         if (mat === 'stone') {
-          const t = treasureNoise(x * 0.19, y * 0.19)
+          const t = ring2Raw(treasureNoise, x, 0.19, y, 0.19)
           if (depth > 0.6 && t > 0.93) mat = 'gold'
           else if (depth > 0.7 && t < 0.05) mat = 'crystal'
           else if (depth > 0.45 && t > 0.895 && t <= 0.93) mat = 'gem'
@@ -236,7 +296,6 @@ const EARTH: Theme = {
       const cx = Math.floor(rng() * WORLD_W)
       const w = 8 + Math.floor(rng() * 14)
       for (let x = cx - w; x <= cx + w; x++) {
-        if (x < 0 || x >= WORLD_W) continue
         // Find the surface at this column, then scoop a bowl into it.
         const surface = surfaceY(tiles, x)
         const t = 1 - Math.abs(x - cx) / (w + 1)
@@ -386,13 +445,13 @@ const TIDEPOOL: Theme = {
   ],
   build: (tiles, rng) => {
     fill(tiles, 'air')
-    const floorNoise = makeNoise2D(Math.floor(rng() * 1e9))
-    const shelfNoise = makeNoise2D(Math.floor(rng() * 1e9))
+    const floorNoise = makeNoise3D(Math.floor(rng() * 1e9))
+    const shelfNoise = makeNoise3D(Math.floor(rng() * 1e9))
 
     const waterLine = Math.floor(WORLD_H * 0.34)
 
     for (let x = 0; x < WORLD_W; x++) {
-      const f = fbm(floorNoise, x * 0.045, 2.5, 3)
+      const f = ring1(floorNoise, x, 0.045, 2.5, 3)
       const floor = Math.floor(WORLD_H * 0.66 + (f - 0.5) * 26)
 
       for (let y = waterLine; y < floor; y++) set(tiles, x, y, 'water')
@@ -403,7 +462,7 @@ const TIDEPOOL: Theme = {
       }
 
       // Rock shelves that break the surface — the tide leaves these dry.
-      const s = fbm(shelfNoise, x * 0.03, 8.5, 2)
+      const s = ring1(shelfNoise, x, 0.03, 8.5, 2)
       if (s > 0.66) {
         const top = waterLine - Math.floor((s - 0.66) * 34)
         for (let y = top; y < floor; y++) {
@@ -463,13 +522,13 @@ const VOLCANIC: Theme = {
   ],
   build: (tiles, rng) => {
     fill(tiles, 'air')
-    const surfaceNoise = makeNoise2D(Math.floor(rng() * 1e9))
-    const caveNoise = makeNoise2D(Math.floor(rng() * 1e9))
+    const surfaceNoise = makeNoise3D(Math.floor(rng() * 1e9))
+    const caveNoise = makeNoise3D(Math.floor(rng() * 1e9))
 
     const skyDepth = Math.floor(WORLD_H * 0.28)
 
     for (let x = 0; x < WORLD_W; x++) {
-      const h = fbm(surfaceNoise, x * 0.05, 1.5, 4)
+      const h = ring1(surfaceNoise, x, 0.05, 1.5, 4)
       const surface = Math.floor(skyDepth + (h - 0.5) * 30)
 
       for (let y = surface; y < WORLD_H; y++) {
@@ -480,7 +539,7 @@ const VOLCANIC: Theme = {
         else mat = depth > 0.55 ? 'obsidian' : 'stone'
 
         if ((mat === 'stone' || mat === 'obsidian') && depth < 0.82) {
-          const c = fbm(caveNoise, x * 0.07, y * 0.1, 3)
+          const c = ring2(caveNoise, x, 0.07, y, 0.1, 3)
           if (c > 0.6) mat = 'air'
           else if (c < 0.16 && depth > 0.4) mat = 'lava'
         }
@@ -552,8 +611,8 @@ const SKYLANDS: Theme = {
   ],
   build: (tiles, rng) => {
     fill(tiles, 'air')
-    const groundNoise = makeNoise2D(Math.floor(rng() * 1e9))
-    const cloudNoise = makeNoise2D(Math.floor(rng() * 1e9))
+    const groundNoise = makeNoise3D(Math.floor(rng() * 1e9))
+    const cloudNoise = makeNoise3D(Math.floor(rng() * 1e9))
 
     /**
      * The floor of the world, and it has to be a living one.
@@ -566,7 +625,7 @@ const SKYLANDS: Theme = {
      */
     const underTop = Math.floor(WORLD_H * 0.84)
     for (let x = 0; x < WORLD_W; x++) {
-      const h = fbm(groundNoise, x * 0.03, 4.5, 3)
+      const h = ring1(groundNoise, x, 0.03, 4.5, 3)
       const surface = underTop + Math.floor((h - 0.5) * 10)
       for (let y = surface; y < WORLD_H; y++) {
         const depth = y - surface
@@ -634,7 +693,7 @@ const SKYLANDS: Theme = {
       const density = 0.4 + Math.sin(t * Math.PI) * 0.32
       for (let x = 0; x < WORLD_W; x++) {
         if (tileAt(tiles, x, y) !== M.air) continue
-        if (fbm(cloudNoise, x * 0.05, y * 0.11, 2) < density) set(tiles, x, y, 'cloud')
+        if (ring2(cloudNoise, x, 0.05, y, 0.11, 2) < density) set(tiles, x, y, 'cloud')
       }
     }
 
@@ -672,9 +731,9 @@ const DUNES: Theme = {
   ],
   build: (tiles, rng) => {
     fill(tiles, 'air')
-    const surfaceNoise = makeNoise2D(Math.floor(rng() * 1e9))
-    const seamNoise = makeNoise2D(Math.floor(rng() * 1e9))
-    const tableNoise = makeNoise2D(Math.floor(rng() * 1e9))
+    const surfaceNoise = makeNoise3D(Math.floor(rng() * 1e9))
+    const seamNoise = makeNoise3D(Math.floor(rng() * 1e9))
+    const tableNoise = makeNoise3D(Math.floor(rng() * 1e9))
 
     const skyDepth = Math.floor(WORLD_H * 0.36)
     // Where the rock stops being dry. Everything interesting in this world is
@@ -691,7 +750,7 @@ const DUNES: Theme = {
        * gentle is what makes the settling look like weather instead of like
        * the world falling over.
        */
-      const h = fbm(surfaceNoise, x * 0.018, 7.5, 3)
+      const h = ring1(surfaceNoise, x, 0.018, 7.5, 3)
       const surface = Math.floor(skyDepth + (h - 0.5) * 16)
 
       for (let y = surface; y < WORLD_H; y++) {
@@ -710,10 +769,10 @@ const DUNES: Theme = {
         let mat: MaterialId = depth < 0.62 ? 'sand' : 'stone'
         // Rock shelves the sand has drifted up against, so the sea has
         // something in it besides sand.
-        if (mat === 'sand' && d > 6 && seamNoise(x * 0.05, y * 0.085) > 0.8) mat = 'stone'
+        if (mat === 'sand' && d > 6 && ring2Raw(seamNoise, x, 0.05, y, 0.085) > 0.8) mat = 'stone'
         // The water table: porous rock down here, and the pockets join up into
         // something a well can reach.
-        if (y > waterTable && tableNoise(x * 0.06, y * 0.14) > 0.42) mat = 'water'
+        if (y > waterTable && ring2Raw(tableNoise, x, 0.06, y, 0.14) > 0.42) mat = 'water'
         set(tiles, x, y, mat)
       }
     }
@@ -790,13 +849,11 @@ const DUNES: Theme = {
       // loudest thing on the screen, and bone is fertile, so the shore it makes
       // is somewhere a root can take hold.
       for (let x = cx - w - 4; x <= cx + w + 4; x++) {
-        if (x < 0 || x >= WORLD_W) continue
         const t = 1 - Math.abs(x - cx) / (w + 5)
         const top = surfaceY(tiles, x)
         for (let d = 0; d < Math.floor(t * 14); d++) set(tiles, x, top + d, 'bone')
       }
       for (let x = cx - w; x <= cx + w; x++) {
-        if (x < 0 || x >= WORLD_W) continue
         const t = 1 - Math.abs(x - cx) / (w + 1)
         const depth = Math.floor(t * 9)
         const top = surfaceY(tiles, x)
@@ -858,20 +915,20 @@ const WINTER: Theme = {
   ],
   build: (tiles, rng) => {
     fill(tiles, 'air')
-    const surfaceNoise = makeNoise2D(Math.floor(rng() * 1e9))
-    const caveNoise = makeNoise2D(Math.floor(rng() * 1e9))
-    const veinNoise = makeNoise2D(Math.floor(rng() * 1e9))
+    const surfaceNoise = makeNoise3D(Math.floor(rng() * 1e9))
+    const caveNoise = makeNoise3D(Math.floor(rng() * 1e9))
+    const veinNoise = makeNoise3D(Math.floor(rng() * 1e9))
 
     const skyDepth = Math.floor(WORLD_H * 0.34)
 
     for (let x = 0; x < WORLD_W; x++) {
       // `fbm` only spans about 0.2–0.72, so the multiplier buys roughly half
       // its face value in tiles: this is an eighteen-tile range, not thirty.
-      const h = fbm(surfaceNoise, x * 0.03, 2.5, 3)
+      const h = ring1(surfaceNoise, x, 0.03, 2.5, 3)
       const surface = Math.floor(skyDepth + (h - 0.5) * 34)
       // Where the glacier gives out and rock begins. A constant would draw a
       // ruler-straight seam from one end of the world to the other.
-      const iceFloor = 0.42 + fbm(surfaceNoise, x * 0.012, 30.5, 2) * 0.2
+      const iceFloor = 0.42 + ring1(surfaceNoise, x, 0.012, 30.5, 2) * 0.2
 
       for (let y = surface; y < WORLD_H; y++) {
         const d = y - surface
@@ -890,13 +947,13 @@ const WINTER: Theme = {
         // Caves, cut through the ice as much as the rock — glacier caves, so
         // they show blue rather than black.
         if (depth < 0.86 && d > 6) {
-          const c = fbm(caveNoise, x * 0.065, y * 0.095, 3)
+          const c = ring2(caveNoise, x, 0.065, y, 0.095, 3)
           if (c > 0.63) mat = 'air'
         }
         // Sparingly. At the thresholds this started on, the rock came out
         // flecked pink and cyan from end to end and read as static.
         if (mat === 'stone') {
-          const v = veinNoise(x * 0.17, y * 0.17)
+          const v = ring2Raw(veinNoise, x, 0.17, y, 0.17)
           if (depth > 0.6 && v > 0.95) mat = 'crystal'
           else if (depth > 0.5 && v < 0.035) mat = 'bone'
           else if (depth > 0.55 && v > 0.93 && v <= 0.95) mat = 'gem'
@@ -916,7 +973,6 @@ const WINTER: Theme = {
       const cx = Math.floor(rng() * WORLD_W)
       const w = 7 + Math.floor(rng() * 12)
       for (let x = cx - w; x <= cx + w; x++) {
-        if (x < 0 || x >= WORLD_W) continue
         const surface = surfaceY(tiles, x)
         const t = 1 - Math.abs(x - cx) / (w + 1)
         const depth = Math.floor(t * 8)
@@ -985,8 +1041,8 @@ const PEAKS: Theme = {
   ],
   build: (tiles, rng) => {
     fill(tiles, 'air')
-    const floorNoise = makeNoise2D(Math.floor(rng() * 1e9))
-    const cloudNoise = makeNoise2D(Math.floor(rng() * 1e9))
+    const floorNoise = makeNoise3D(Math.floor(rng() * 1e9))
+    const cloudNoise = makeNoise3D(Math.floor(rng() * 1e9))
 
     const valley = Math.floor(WORLD_H * 0.84)
     // Above this, rock goes white. It sits above both cloud bands, so the snow
@@ -994,7 +1050,7 @@ const PEAKS: Theme = {
     const snowLine = Math.floor(WORLD_H * 0.28)
 
     for (let x = 0; x < WORLD_W; x++) {
-      const h = fbm(floorNoise, x * 0.04, 1.5, 3)
+      const h = ring1(floorNoise, x, 0.04, 1.5, 3)
       const surface = valley + Math.floor((h - 0.5) * 8)
       for (let y = surface; y < WORLD_H; y++) {
         const d = y - surface
@@ -1069,7 +1125,11 @@ const PEAKS: Theme = {
         const t = 1 - Math.abs(y - cy) / 6
         for (let x = 0; x < WORLD_W; x++) {
           if (tileAt(tiles, x, y) !== M.air) continue
-          if (fbm(cloudNoise, x * 0.04, y * 0.13 + band * 10, 2) < 0.32 + t * 0.3) {
+          // Not `ring2`: the depth coordinate carries a per-band offset as well,
+          // which is what stops the two cloud decks coming out as copies of each
+          // other. Built by hand rather than widening `ring2` for one caller.
+          const { u, v } = ringXY(x, 0.04)
+          if (fbm3(cloudNoise, u, v, y * 0.13 + band * 10, 2) < 0.32 + t * 0.3) {
             set(tiles, x, y, 'cloud')
           }
         }
@@ -1120,14 +1180,14 @@ const CASTLE: Theme = {
   ],
   build: (tiles, rng) => {
     fill(tiles, 'air')
-    const groundNoise = makeNoise2D(Math.floor(rng() * 1e9))
-    const oreNoise = makeNoise2D(Math.floor(rng() * 1e9))
+    const groundNoise = makeNoise3D(Math.floor(rng() * 1e9))
+    const oreNoise = makeNoise3D(Math.floor(rng() * 1e9))
 
     // Flatter than any other land here, on purpose: people build on the level,
     // and rolling hills would leave every house half-buried on one side.
     const groundLine = Math.floor(WORLD_H * 0.52)
     for (let x = 0; x < WORLD_W; x++) {
-      const h = fbm(groundNoise, x * 0.02, 3.5, 2)
+      const h = ring1(groundNoise, x, 0.02, 3.5, 2)
       const surface = groundLine + Math.floor((h - 0.5) * 6)
       for (let y = surface; y < WORLD_H; y++) {
         const d = y - surface
@@ -1137,7 +1197,7 @@ const CASTLE: Theme = {
         // confettied from end to end and the treasure stopped reading as
         // treasure.
         if (mat === 'stone') {
-          const o = oreNoise(x * 0.15, y * 0.15)
+          const o = ring2Raw(oreNoise, x, 0.15, y, 0.15)
           if (depth > 0.6 && o > 0.965) mat = 'gold'
           else if (depth > 0.45 && o < 0.03) mat = 'bone'
           else if (depth > 0.5 && o > 0.945 && o <= 0.965) mat = 'gem'
@@ -1210,7 +1270,6 @@ const CASTLE: Theme = {
       const mx = mid + side * (keepHalf + 24)
       const half = 14
       for (let x = mx - half; x <= mx + half; x++) {
-        if (x < 0 || x >= WORLD_W) continue
         const top = surfaceY(tiles, x)
         if (top >= WORLD_H - 4) continue
         const t = 1 - Math.abs(x - mx) / (half + 1)
@@ -1325,9 +1384,9 @@ const CANDY: Theme = {
   ],
   build: (tiles, rng) => {
     fill(tiles, 'air')
-    const surfaceNoise = makeNoise2D(Math.floor(rng() * 1e9))
-    const seamNoise = makeNoise2D(Math.floor(rng() * 1e9))
-    const flossNoise = makeNoise2D(Math.floor(rng() * 1e9))
+    const surfaceNoise = makeNoise3D(Math.floor(rng() * 1e9))
+    const seamNoise = makeNoise3D(Math.floor(rng() * 1e9))
+    const flossNoise = makeNoise3D(Math.floor(rng() * 1e9))
 
     const skyDepth = Math.floor(WORLD_H * 0.36)
     const STRIPES: MaterialId[] = [
@@ -1338,7 +1397,7 @@ const CANDY: Theme = {
     ]
 
     for (let x = 0; x < WORLD_W; x++) {
-      const h = fbm(surfaceNoise, x * 0.028, 6.5, 3)
+      const h = ring1(surfaceNoise, x, 0.028, 6.5, 3)
       const surface = Math.floor(skyDepth + (h - 0.5) * 20)
 
       for (let y = surface; y < WORLD_H; y++) {
@@ -1359,8 +1418,8 @@ const CANDY: Theme = {
         else if (d < 6) mat = 'wood'
         else mat = STRIPES[Math.floor((d - 6) / 5) % STRIPES.length]
 
-        if (d >= 6 && seamNoise(x * 0.1, y * 0.1) > 0.85) mat = 'sand'
-        if (d >= 12 && seamNoise(x * 0.24, y * 0.24) < 0.055) {
+        if (d >= 6 && ring2Raw(seamNoise, x, 0.1, y, 0.1) > 0.85) mat = 'sand'
+        if (d >= 12 && ring2Raw(seamNoise, x, 0.24, y, 0.24) < 0.055) {
           mat = rng() < 0.5 ? 'gem-green' : 'gem-purple'
         }
         set(tiles, x, y, mat)
@@ -1374,7 +1433,6 @@ const CANDY: Theme = {
       const cx = 14 + Math.floor(rng() * (WORLD_W - 28))
       const w = 4 + Math.floor(rng() * 5)
       for (let x = cx - w; x <= cx + w; x++) {
-        if (x < 0 || x >= WORLD_W) continue
         const top = surfaceY(tiles, x)
         const t = 1 - Math.abs(x - cx) / (w + 1)
         const depth = Math.floor(t * 8)
@@ -1413,8 +1471,8 @@ const CANDY: Theme = {
     for (let y = 3; y < skyDepth - 8; y++) {
       for (let x = 0; x < WORLD_W; x++) {
         if (tileAt(tiles, x, y) !== M.air) continue
-        if (fbm(flossNoise, x * 0.022, y * 0.07, 2) > 0.6) {
-          set(tiles, x, y, fbm(flossNoise, x * 0.008, 40.5, 1) > 0.5 ? 'cloud-pink' : 'cloud-white')
+        if (ring2(flossNoise, x, 0.022, y, 0.07, 2) > 0.6) {
+          set(tiles, x, y, ring1(flossNoise, x, 0.008, 40.5, 1) > 0.5 ? 'cloud-pink' : 'cloud-white')
         }
       }
     }
@@ -1450,8 +1508,8 @@ const BIOME_WORLD: Theme = {
   ],
   build: (tiles, rng) => {
     fill(tiles, 'air')
-    const surfaceNoise = makeNoise2D(Math.floor(rng() * 1e9))
-    const featureNoise = makeNoise2D(Math.floor(rng() * 1e9))
+    const surfaceNoise = makeNoise3D(Math.floor(rng() * 1e9))
+    const featureNoise = makeNoise3D(Math.floor(rng() * 1e9))
 
     const THIRD = Math.floor(WORLD_W / 3)
     const skyDepth = Math.floor(WORLD_H * 0.30)
@@ -1473,13 +1531,13 @@ const BIOME_WORLD: Theme = {
         : (x - (rightBorder - BLEND)) / BLEND
 
       // Terrain height per biome
-      const forestH = fbm(surfaceNoise, x * 0.030, 0.5, 3)
+      const forestH = ring1(surfaceNoise, x, 0.030, 0.5, 3)
       const forestSurf = skyDepth + (forestH - 0.5) * 22
 
-      const plainsH = fbm(surfaceNoise, x * 0.014 + 100, 0.5, 2)
+      const plainsH = ring1(surfaceNoise, x, 0.014, 100.5, 2)
       const plainsSurf = skyDepth + (plainsH - 0.5) * 8 + 4
 
-      const desertH = fbm(surfaceNoise, x * 0.020 + 300, 0.5, 2)
+      const desertH = ring1(surfaceNoise, x, 0.020, 300.5, 2)
       const desertSurf = skyDepth + (desertH - 0.5) * 16 + 6
 
       // Blend surface heights at borders
@@ -1522,7 +1580,7 @@ const BIOME_WORLD: Theme = {
 
     // Forest trees: wood columns above ground with moss canopy
     for (let x = 4; x < THIRD - 4; x++) {
-      if (featureNoise(x * 0.18, 0.2) > 0.52) {
+      if (ring1(featureNoise, x, 0.18, 0.2, 1) > 0.52) {
         const sy = surfaceY(tiles, x)
         const height = 4 + Math.floor(rng() * 5)
         for (let dy = 1; dy <= height; dy++) {
@@ -1591,14 +1649,14 @@ const MUSHROOM_FOREST: Theme = {
   ],
   build: (tiles, rng) => {
     fill(tiles, 'air')
-    const groundNoise = makeNoise2D(Math.floor(rng() * 1e9))
-    const treeNoise = makeNoise2D(Math.floor(rng() * 1e9))
+    const groundNoise = makeNoise3D(Math.floor(rng() * 1e9))
+    const treeNoise = makeNoise3D(Math.floor(rng() * 1e9))
 
     const skyDepth = Math.floor(WORLD_H * 0.44)
 
     // Muddy ground: shallow surface layer is mud, then dirt, then stone.
     for (let x = 0; x < WORLD_W; x++) {
-      const h = fbm(groundNoise, x * 0.022, 4.5, 2)
+      const h = ring1(groundNoise, x, 0.022, 4.5, 2)
       const surface = Math.floor(skyDepth + (h - 0.5) * 12)
       for (let y = surface; y < WORLD_H; y++) {
         const d = y - surface
@@ -1612,7 +1670,7 @@ const MUSHROOM_FOREST: Theme = {
     for (let pass = 0; pass < 2; pass++) {
       for (let x = 2; x < WORLD_W - 2; x++) {
         const thresh = pass === 0 ? 0.52 : 0.40
-        if (treeNoise(x * 0.13 + pass * 50, 0.7 + pass * 0.3) < thresh) continue
+        if (ring1(treeNoise, x, 0.13, 0.7 + pass * 50, 1) < thresh) continue
         const sy = surfaceY(tiles, x)
         if (sy >= WORLD_H - 4) continue
         const height = pass === 0
@@ -1702,8 +1760,8 @@ const CAVE: Theme = {
     // The whole world is stone to start; everything is carved out of it.
     fill(tiles, 'stone')
 
-    const edgeNoise = makeNoise2D(Math.floor(rng() * 1e9))
-    const oreNoise = makeNoise2D(Math.floor(rng() * 1e9))
+    const edgeNoise = makeNoise3D(Math.floor(rng() * 1e9))
+    const oreNoise = makeNoise3D(Math.floor(rng() * 1e9))
 
     // BSP carves connected cave chambers — same trick as STATION but organic.
     interface CaveBox { x0: number; y0: number; x1: number; y1: number }
@@ -1749,7 +1807,7 @@ const CAVE: Theme = {
           const ny = (y - cy) / (ry + 1)
           const dist = Math.sqrt(nx * nx + ny * ny)
           // Edge noise makes the boundary rough rather than a perfect ellipse.
-          const noise = edgeNoise(x * 0.07, y * 0.07) * 0.38
+          const noise = ring2Raw(edgeNoise, x, 0.07, y, 0.07) * 0.38
           if (dist < 0.64 + noise) set(tiles, x, y, 'air')
         }
       }
@@ -1823,7 +1881,7 @@ const CAVE: Theme = {
     for (let i = 0; i < across(14); i++) {
       const cx = Math.floor(rng() * WORLD_W)
       const cy = Math.floor(WORLD_H * (0.08 + rng() * 0.84))
-      const t = oreNoise(cx * 0.05, cy * 0.05)
+      const t = ring2Raw(oreNoise, cx, 0.05, cy, 0.05)
       const id: MaterialId = t < 0.4 ? 'crystal' : t < 0.75 ? 'gem' : 'gold'
       blob(tiles, cx, cy, 2 + Math.floor(rng() * 3), id, rng, ['stone'])
     }

--- a/src/app/micro-land/domain/sim/creature-sim.ts
+++ b/src/app/micro-land/domain/sim/creature-sim.ts
@@ -35,6 +35,7 @@ import {
 import { inherit, lifespanOf, roamOf, sightOf, sizeOf, speedOf } from '@/app/micro-land/domain/traits'
 import { TUNING } from '@/app/micro-land/domain/tuning'
 import type { Creature, CreatureBlueprint, Scent, WorldState } from '@/app/micro-land/domain/types'
+import { deltaX, distX, wrapCol, wrapX } from '@/app/micro-land/domain/wrap'
 
 import {
   boxDeadlyMaterial,
@@ -319,7 +320,7 @@ function findMate(
   // there is no need to ask `artSize` about either of them.
   if (other.blueprintId !== c.blueprintId) return null
   if (!readyToBreed(other, bp)) return null
-  const dx = other.x - c.x
+  const dx = deltaX(c.x, other.x)
   const dy = other.y - c.y
   return dx * dx + dy * dy <= TUNING.mateRadius * TUNING.mateRadius ? other : null
 }
@@ -334,6 +335,61 @@ function lowerBound(list: Creature[], x: number): number {
     else hi = mid
   }
   return lo
+}
+
+/**
+ * Neighbours found by the last `gather`. Module scope for the same reason `byX`
+ * is: this is refilled several times per creature per sense pass and handing the
+ * collector a fresh array each time would cost more than the search does.
+ */
+const found: Creature[] = []
+
+/**
+ * Everything whose left edge lies within `reach` of column `cx`, the short way
+ * round, left in `found`. Returns how many.
+ *
+ * A sight window used to be one contiguous slice of the x-sorted population, and
+ * on a cylinder it is two: a creature standing at 670 with eighteen tiles of
+ * sight can see something at 5, and the slice it needs runs off the end of the
+ * array and continues at the start. Hence the buffer — the four scans in `look`
+ * have quite different bodies, one of which returns out of `look` mid-loop, and
+ * a two-range iteration open-coded four times is four chances to get the second
+ * range subtly wrong.
+ *
+ * The seam case is rare by construction: only creatures within roughly a sight
+ * radius of column zero straddle it at all, so the overwhelming majority of the
+ * population still takes one binary search and one walk, exactly as before.
+ *
+ * **One buffer, so callers must be done before gathering again.** The scans in
+ * `look` run strictly one after another today. Nesting one inside another would
+ * corrupt the outer loop's view of the world without any error being raised.
+ */
+function gather(cx: number, reach: number): number {
+  found.length = 0
+  const span = reach + SIGHT_PAD_LEFT + SIGHT_PAD_RIGHT
+
+  /**
+   * A window wider than the world sees everything, and asking for it as two
+   * ranges would double-count the overlap. A starving migrator on four times
+   * its normal sight is the realistic way to get here.
+   */
+  if (span >= WORLD_W) {
+    for (let i = 0; i < byX.length; i++) found.push(byX[i])
+    return found.length
+  }
+
+  const lo = wrapX(cx - reach - SIGHT_PAD_LEFT)
+  const hi = wrapX(cx + reach + SIGHT_PAD_RIGHT)
+
+  if (lo <= hi) {
+    for (let i = lowerBound(byX, lo); i < byX.length && byX[i].x <= hi; i++) found.push(byX[i])
+  } else {
+    // Straddling the seam: [lo, WORLD_W) then [0, hi]. Disjoint because the
+    // whole-world case above has already been dealt with.
+    for (let i = lowerBound(byX, lo); i < byX.length; i++) found.push(byX[i])
+    for (let i = 0; i < byX.length && byX[i].x <= hi; i++) found.push(byX[i])
+  }
+  return found.length
 }
 
 export function tickCreatures(
@@ -433,7 +489,11 @@ export function tickCreatures(
     if (hdt.homeDriftTimer <= 0) {
       const wellFed = Math.max(0, 0.5 - c.hunger)  // 0 when hungry, up to 0.5 when stuffed
       const pull = wellFed * 0.3                    // at most 15% shift per 30s tick
-      c.homeX += (c.x - c.homeX) * pull
+      // Drift toward where it has actually been living, the short way round — an
+      // animal that crossed the seam has not moved six hundred tiles from home,
+      // and a plain subtraction here would haul its territory back across the
+      // entire world one 15% step at a time.
+      c.homeX = wrapX(c.homeX + deltaX(c.homeX, c.x) * pull)
       c.homeY += (c.y - c.homeY) * pull
       hdt.homeDriftTimer = 30
     }
@@ -561,6 +621,23 @@ export function tickCreatures(
     if (bp.move.kind !== 'root') {
       steer(w, c, bp, dt, rng)
       integrate(w, c, bp, bw, bh, dt, wet, gravityScale)
+    } else if (!hasFooting(w, c, body)) {
+      /**
+       * A plant whose ground went away falls to the next one down.
+       *
+       * Rooting is permanent — `settleOnGround` places a seedling on fertile
+       * ground and nothing ever looks at that ground again — but the ground
+       * itself is not: lava drains, ash and sand settle, ice melts, acid eats
+       * through. On the volcanic theme a fifth of the flora ended up hanging in
+       * mid-air within the first minute, which reads as green pixels stuck to
+       * the sky. Everything else in the world falls when it has nothing under
+       * it, so a stranded plant falls too — through `integrate`, which is the
+       * one piece of code that knows how to land a body on a tile. `steer` is
+       * still skipped, and a rooted creature has no `vx`, so this is a straight
+       * drop rather than the plant learning to walk.
+       */
+      c.vy = Math.max(0, c.vy)
+      integrate(w, c, bp, bw, bh, dt, wet, gravityScale)
     }
 
     // --- fatigue --------------------------------------------------------
@@ -603,7 +680,7 @@ export function tickCreatures(
         nest = {
           id: w.nextNestId++,
           creatureId: c.id,
-          x: Math.round(c.homeX),
+          x: wrapCol(Math.round(c.homeX)),
           y: Math.round(c.homeY),
           progress: 0,
           decaySeconds: NEST_DECAY_SECONDS,
@@ -613,7 +690,7 @@ export function tickCreatures(
       // Advance build progress; a completed nest stays at 1.
       if (nest.progress < 1) nest.progress = Math.min(1, nest.progress + dt / NEST_BUILD_TIME)
       // Track the creature's current home (it drifts slightly over time).
-      nest.x = Math.round(c.homeX)
+      nest.x = wrapCol(Math.round(c.homeX))
       nest.y = Math.round(c.homeY)
       // Refresh decay: the owner is here, so the burrow doesn't collapse.
       nest.decaySeconds = NEST_DECAY_SECONDS
@@ -671,7 +748,7 @@ export function tickCreatures(
             const obp = w.blueprints[other.blueprintId]
             if (!obp || obp.move.kind !== 'root') continue
             const { w: ow, h: oh } = artSize(obp)
-            const dx = cx - (other.x + ow / 2)
+            const dx = deltaX(other.x + ow / 2, cx)
             const dy = cy - (other.y + oh / 2)
             if (dx * dx + dy * dy < 9) { // within ~3 tiles
               c.carryingSeed = other.blueprintId
@@ -711,7 +788,13 @@ export function tickCreatures(
       if (!wantsMate || mate) {
         // Born between the two of them, which is the whole point of having made
         // them walk to each other.
-        const ox = mate ? (c.x + mate.x) / 2 : c.x
+        //
+        // Half the *wrapped* gap, not half the sum. A pair that met across the
+        // seam — one at 5, one at 670 — averages to 337, which is the far side
+        // of the world from either parent: the child would be born alone in the
+        // middle of nowhere, and `reproduce` would spend all twelve of its
+        // attempts failing to find ground there.
+        const ox = mate ? wrapX(c.x + deltaX(c.x, mate.x) / 2) : c.x
         const oy = mate ? (c.y + mate.y) / 2 : c.y
         if (bp.egglayer && !isPlant) {
           // Egg-layer: drop an egg with inherited traits rather than spawning live.
@@ -779,7 +862,7 @@ export function tickCreatures(
               let crowdCount = 0
               for (const other of w.creatures) {
                 if (other === c || other.blueprintId !== bp.id) continue
-                const cdx = other.x - c.x
+                const cdx = deltaX(c.x, other.x)
                 const cdy = other.y - c.y
                 if (cdx * cdx + cdy * cdy < crowdRadius * crowdRadius) crowdCount++
               }
@@ -1019,7 +1102,7 @@ function look(
     for (const car of w.carcasses) {
       const carBp = w.blueprints[car.blueprintId]
       if (!carBp || !canEat(bp, carBp)) continue
-      const dx = car.x - cx
+      const dx = deltaX(cx, car.x)
       const dy = car.y - cy
       // Gap between creature sprite edge and the carcass point.
       const gapX = Math.max(0, Math.abs(dx) - bw / 2)
@@ -1048,7 +1131,7 @@ function look(
       if (egg.hatchIn <= 0) continue // already eaten or hatched
       const eggBp = w.blueprints[egg.blueprintId]
       if (!eggBp || !canEat(bp, eggBp)) continue
-      const dx = egg.x - cx
+      const dx = deltaX(cx, egg.x)
       const dy = egg.y - cy
       const gapX = Math.max(0, Math.abs(dx) - bw / 2)
       const gapY = Math.max(0, Math.abs(dy) - bh / 2)
@@ -1071,16 +1154,18 @@ function look(
   // *food* reach, which is the larger of the two whenever the creature is hungry
   // enough for it to matter — so a fed animal pays exactly what it always did.
   const reach = Math.max(sight, foodSight) + bw / 2
-  const last = cx + reach + SIGHT_PAD_RIGHT
-  for (let i = lowerBound(byX, cx - reach - SIGHT_PAD_LEFT); i < byX.length; i++) {
-    const other = byX[i]
-    if (other.x > last) break
+  const nearby = gather(cx, reach)
+  for (let i = 0; i < nearby; i++) {
+    const other = found[i]
     if (other.id === c.id || dead.has(other.id)) continue
     const obp = w.blueprints[other.blueprintId]
     if (!obp) continue
 
     const { w: ow, h: oh } = artSize(obp)
-    const dx = other.x + ow / 2 - cx
+    // The short way round, so a creature by the seam hunts across it rather than
+    // reading its neighbour as six hundred tiles away and ignoring it. The sign
+    // is also the direction `preyDir` sets off in below.
+    const dx = deltaX(cx, other.x + ow / 2)
     const dy = other.y + oh / 2 - cy
 
     /**
@@ -1236,7 +1321,7 @@ function look(
     let nearestScent: Scent | null = null
     for (const s of w.scents) {
       if (s.blueprintId !== c.blueprintId) continue
-      const sdx = s.x - midX
+      const sdx = deltaX(midX, s.x)
       const sdy = s.y - midY
       const d2 = sdx * sdx + sdy * sdy
       if (d2 < nearestD2 && d2 < scentReach2) {
@@ -1249,7 +1334,7 @@ function look(
       // commitment. Cooperation scales the strength — a barely-cooperative
       // creature barely follows, a highly cooperative one follows reliably.
       const weight = cooperationVal * 0.3
-      c.drift = nearestScent.x > midX ? weight : -weight
+      c.drift = deltaX(midX, nearestScent.x) > 0 ? weight : -weight
       ;(c as { followingScent?: boolean }).followingScent = true
     }
   }
@@ -1286,16 +1371,15 @@ function look(
   // Disease spread: an infected creature spreads to non-plant neighbours within 4 tiles.
   if (c.sick > 0 && bp.move.kind !== 'root') {
     const spreadReach = 4
-    const last2 = cx + spreadReach + bw / 2 + SIGHT_PAD_RIGHT
-    for (let i = lowerBound(byX, cx - spreadReach - SIGHT_PAD_LEFT); i < byX.length; i++) {
-      const other = byX[i]
-      if (other.x > last2) break
+    const sickNearby = gather(cx, spreadReach + bw / 2)
+    for (let i = 0; i < sickNearby; i++) {
+      const other = found[i]
       if (other.id === c.id || dead.has(other.id)) continue
       if ((other as { sick?: number }).sick) continue // already sick
       const obp = w.blueprints[other.blueprintId]
       if (!obp || obp.move.kind === 'root') continue
       const { w: ow, h: oh } = artSize(obp)
-      const gdx = Math.max(0, Math.abs(other.x + ow / 2 - cx) - (bw + ow) / 2)
+      const gdx = Math.max(0, Math.abs(deltaX(cx, other.x + ow / 2)) - (bw + ow) / 2)
       const gdy = Math.max(0, Math.abs(other.y + oh / 2 - (c.y + bh / 2)) - (bh + oh) / 2)
       if (gdx * gdx + gdy * gdy > spreadReach * spreadReach) continue
       const otherImmunity = (other.traits as { immunity?: number }).immunity ?? 0.2
@@ -1313,15 +1397,14 @@ function look(
   // disease — enough to slow them, not kill them outright).
   if (bp.move.kind !== 'root') {
     const sporeReach = 3
-    const sporeLast = cx + sporeReach + SIGHT_PAD_RIGHT
-    for (let si = lowerBound(byX, cx - sporeReach - SIGHT_PAD_LEFT); si < byX.length; si++) {
-      const plant = byX[si]
-      if (plant.x > sporeLast) break
+    const sporeNearby = gather(cx, sporeReach)
+    for (let si = 0; si < sporeNearby; si++) {
+      const plant = found[si]
       if (plant.blueprintId !== 'sporecap') continue
       const pbp = w.blueprints[plant.blueprintId]
       if (!pbp || pbp.move.kind !== 'root') continue
       const { w: pw, h: ph } = artSize(pbp)
-      const gdx = Math.max(0, Math.abs(plant.x + pw / 2 - cx) - (bw + pw) / 2)
+      const gdx = Math.max(0, Math.abs(deltaX(cx, plant.x + pw / 2)) - (bw + pw) / 2)
       const gdy = Math.max(0, Math.abs(plant.y + ph / 2 - (c.y + bh / 2)) - (bh + ph) / 2)
       if (gdx * gdx + gdy * gdy > sporeReach * sporeReach) continue
       if (rng() < TUNING.diseaseSpreadChance * 0.2) {
@@ -1340,11 +1423,10 @@ function look(
   const packCooperation = (c.traits as { cooperation?: number }).cooperation ?? 0.3
   if (prey !== null && packCooperation >= 0.2) {
     const packReach = sight + bw / 2
-    const packLast = cx + packReach + SIGHT_PAD_RIGHT
+    const packNearby = gather(cx, packReach)
     let packCount = 0
-    for (let pi = lowerBound(byX, cx - packReach - SIGHT_PAD_LEFT); pi < byX.length; pi++) {
-      const pk = byX[pi]
-      if (pk.x > packLast) break
+    for (let pi = 0; pi < packNearby; pi++) {
+      const pk = found[pi]
       if (pk.id === c.id) continue
       if (pk.blueprintId !== c.blueprintId) continue
       const pkCoop = (pk.traits as { cooperation?: number }).cooperation ?? 0.3
@@ -1439,7 +1521,9 @@ function clearRun(
   toY: number
 ): boolean {
   const needsWater = bp.move.kind === 'swim' || !!bp.habitat.needs?.includes('water')
-  const dx = toX - fromX
+  // The run is sampled along the shorter way round; the tile reads below wrap on
+  // their own, so a line that leaves the right edge carries on from the left.
+  const dx = deltaX(fromX, toX)
   const dy = toY - fromY
   const steps = Math.min(24, Math.max(2, Math.ceil(Math.hypot(dx, dy) / 2)))
   for (let i = 1; i < steps; i++) {
@@ -1466,7 +1550,9 @@ function devour(
   if (victimBp.move.kind !== 'root') {
     w.carcasses.push({
       id: w.nextCarcassId++,
-      x: victim.x + vw / 2,
+      // Wrapped, like every stored x — half a sprite past the last column is
+      // column zero, not column 673, and `deltaX` is entitled to assume it.
+      x: wrapX(victim.x + vw / 2),
       y: victim.y + vh / 2,
       decaySeconds: 15,
       blueprintId: victim.blueprintId,
@@ -1549,7 +1635,7 @@ function auraBoost(
     const hbp = w.blueprints[helper.blueprintId]
     if (!hbp) continue
     const { w: hw, h: hh } = artSize(hbp)
-    const dx = helper.x + hw / 2 - cx
+    const dx = deltaX(cx, helper.x + hw / 2)
     const dy = helper.y + hh / 2 - cy
     if (dx * dx + dy * dy > aura.radius * aura.radius) continue
     // Best helper wins rather than stacking — twenty bees in one flowerbed
@@ -1749,7 +1835,10 @@ function steer(w: WorldState, c: Creature, bp: CreatureBlueprint, dt: number, rn
   if (target) {
     const tbp = w.blueprints[target.blueprintId]
     const size = tbp ? artSize(tbp) : { w: 1, h: 1 }
-    const dx = target.x + size.w / 2 - cx
+    // Chase (or flee) by the shorter route. This is the line that makes a hunter
+    // step across the seam after its prey instead of turning round and running
+    // the long way to the same place.
+    const dx = deltaX(cx, target.x + size.w / 2)
     const dy = target.y + size.h / 2 - cy
     const len = Math.hypot(dx, dy) || 1
     const sign = c.mood === 'flee' ? -1 : 1
@@ -1796,8 +1885,11 @@ function steer(w: WorldState, c: Creature, bp: CreatureBlueprint, dt: number, rn
     // has exhausted its local food must be free to range until it finds more.
     // Roam multiplies the leash so wide-ranging creatures drift further.
     if ((c.traits.territorial ?? 0.5) > 0.2 && c.hunger <= 0.6 &&
-        Math.abs(c.homeX - c.x) > 15 * (c.traits.roam ?? 1)) {
-      c.drift = c.homeX > c.x ? 1 : -1
+        distX(c.homeX, c.x) > 15 * (c.traits.roam ?? 1)) {
+      // Head home the short way. Straight comparison would send an animal that
+      // wandered a few tiles past the seam marching away from a home it is
+      // standing almost on top of.
+      c.drift = deltaX(c.x, c.homeX) > 0 ? 1 : -1
     }
     // Migration: when hunger has gone unmet for long enough, steer toward
     // plant-richer terrain instead of wandering or returning home.
@@ -1813,8 +1905,12 @@ function steer(w: WorldState, c: Creature, bp: CreatureBlueprint, dt: number, rn
       for (let dy = -20; dy <= 20; dy += 10) {
         const sy = Math.max(0, Math.min(WORLD_H - 1, baseY + dy))
         for (let dx = 12; dx <= 160; dx += 12) {
-          const lMat = tileAt(w, Math.max(0, baseX - dx), sy)
-          const rMat = tileAt(w, Math.min(WORLD_W - 1, baseX + dx), sy)
+          // No clamping any more: the scan runs off either side and comes back
+          // in on the other. Clamping used to pile every sample past the edge
+          // onto the same column, so an animal near the end of the world scored
+          // one tile fourteen times and migrated on the strength of it.
+          const lMat = tileAt(w, baseX - dx, sy)
+          const rMat = tileAt(w, baseX + dx, sy)
           if (lMat === grassIdx || lMat === mossIdx) leftScore++
           if (rMat === grassIdx || rMat === mossIdx) rightScore++
         }
@@ -2001,6 +2097,26 @@ function touchesSurface(w: WorldState, c: Creature, body: BodyBox): boolean {
 // Physics
 // ---------------------------------------------------------------------------
 
+/**
+ * Is there anything solid directly under this body?
+ *
+ * The row below a box at `y` with height `h` is `floor(y + h - 0.001) + 1` —
+ * the same arithmetic `settleOnGround` owns and for the same reason: the naive
+ * `floor(y + h)` asks about a row the box is already standing in, which
+ * collision has just proven empty, so it always answers "no ground" and every
+ * plant in the world would think it was falling.
+ */
+function hasFooting(w: WorldState, c: Creature, body: BodyBox): boolean {
+  const y = Math.floor(c.y + body.dy + body.h - 0.001) + 1
+  if (y >= WORLD_H) return true
+  const x0 = Math.floor(c.x + body.dx)
+  const x1 = Math.floor(c.x + body.dx + body.w - 0.001)
+  for (let x = x0; x <= x1; x++) {
+    if (solidAt(w, x, y)) return true
+  }
+  return false
+}
+
 function integrate(
   w: WorldState,
   c: Creature,
@@ -2109,8 +2225,17 @@ function integrate(
   // Ground friction, so walkers don't skate.
   if (c.grounded && kind === 'walk') c.vx *= Math.pow(0.02, dt)
 
-  // Belt and braces: never let anything escape the box.
-  c.x = Math.max(0, Math.min(WORLD_W - bw, c.x))
+  /**
+   * Round the cylinder, and never out of the top or the bottom.
+   *
+   * This is the line that makes the world loop. Everything above it works in
+   * unwrapped coordinates — a creature stepping off the right edge is briefly at
+   * x = 672.4, and the collision resolution just above needs it to stay that way
+   * so its push-out arithmetic lands on the tile it actually hit. Normalising
+   * once, here, at the end, is what keeps the invariant in `domain/wrap.ts` true
+   * without any of the movement code having to think about the seam.
+   */
+  c.x = wrapX(c.x)
   c.y = Math.max(0, Math.min(WORLD_H - bh, c.y))
 }
 
@@ -2161,7 +2286,7 @@ function reproduce(
     const y = isPlant
       ? oy + signY * (yMin + rng() * (ySpread - yMin))
       : oy + (rng() * 2 - 1) * ySpread
-    const cx = Math.max(0, Math.min(WORLD_W - bw, x))
+    const cx = wrapX(x)
     const cy = Math.max(0, Math.min(WORLD_H - bh, y))
 
     if (boxHitsSolid(w, cx + body.dx, cy + body.dy, body.w, body.h)) continue
@@ -2210,7 +2335,7 @@ function kill(
   if (bp.move.kind !== 'root') {
     w.carcasses.push({
       id: w.nextCarcassId++,
-      x: c.x + bw / 2,
+      x: wrapX(c.x + bw / 2),
       y: c.y + bh / 2,
       decaySeconds: 15,
       blueprintId: c.blueprintId,
@@ -2221,7 +2346,7 @@ function kill(
   if (c.name !== null) {
     w.tombstones.push({
       id: w.nextTombstoneId++,
-      x: c.x + bw / 2,
+      x: wrapX(c.x + bw / 2),
       y: c.y + bh / 2,
       name: c.name,
       blueprintId: c.blueprintId,
@@ -2231,11 +2356,62 @@ function kill(
       children: c.children,
     })
   }
-  emitParticles(w, c.x + bw / 2, c.y + bh / 2, bp.death.particleColor, bp.death.particleCount)
+  emitParticles(w, wrapX(c.x + bw / 2), c.y + bh / 2, bp.death.particleColor, bp.death.particleCount)
   if (bp.death.becomes) {
-    setTile(w, Math.floor(c.x + bw / 2), Math.floor(c.y + bh / 2), MATERIAL_INDEX[bp.death.becomes])
+    dropRemains(w, c.x + bw / 2, c.y + bh / 2, MATERIAL_INDEX[bp.death.becomes])
   }
   events.push({ kind: cause, blueprintId: bp.id, x: c.x, y: c.y, ageSeconds: c.ageSeconds, children: c.children, creatureName: c.name ?? null })
+}
+
+/**
+ * How far the remains of a creature look for ground to land on, in tiles.
+ *
+ * Generous enough to cover a fall from the top of a hill or the bottom of a
+ * pond, short enough that something that dies high in open sky leaves nothing
+ * behind rather than dropping a rock onto a world it was never standing over.
+ */
+const REMAINS_DROP = 24
+
+/**
+ * Put the tile a creature leaves behind on the ground under where it died.
+ *
+ * This used to write the material straight into the tile under the creature's
+ * *centre*, which is half a body height above its feet — so a Grumblestone that
+ * died standing on flat soil left a stone block hanging three tiles up, and a
+ * Rustbot left steel at head height. Stone, crystal, metal, obsidian and bone
+ * are all static solids: nothing in the tile sim ever makes them fall, so each
+ * one stayed there forever, and creatures collide with tiles, so a long-running
+ * world slowly filled up with invisible-looking walls at exactly walking
+ * height. Ten minutes of the volcanic theme grew 27 of them.
+ *
+ * Dropping to the first ground beneath instead is what the effect was always
+ * meant to look like — the lavafish leaves obsidian *on the floor* — and it
+ * keeps the flavour intact rather than deleting it. A creature that dies inside
+ * terrain still replaces what it was buried in; one that dies over open air too
+ * far from any floor leaves no trace at all.
+ */
+function dropRemains(w: WorldState, x: number, y: number, mat: number): void {
+  const tx = Math.floor(x)
+  const ty = Math.floor(y)
+  if (!inBounds(tx, ty)) return
+
+  // Died inside the ground — the remains take the place of what buried it.
+  if (solidAt(w, tx, ty)) {
+    setTile(w, tx, ty, mat)
+    return
+  }
+
+  for (let d = 1; d <= REMAINS_DROP; d++) {
+    const below = ty + d
+    // Fell past the bottom of the world: it comes to rest on the last row.
+    if (below >= WORLD_H) {
+      setTile(w, tx, WORLD_H - 1, mat)
+      return
+    }
+    if (!solidAt(w, tx, below)) continue
+    setTile(w, tx, below - 1, mat)
+    return
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -2271,9 +2447,11 @@ function tickParticles(w: WorldState, dt: number, gravityScale: number): void {
     p.life -= dt
     if (p.life <= 0) continue
     p.vy += TUNING.gravity * 0.35 * gravityScale * dt
-    p.x += p.vx * dt
+    p.x = wrapX(p.x + p.vx * dt)
     p.y += p.vy * dt
-    if (p.x < 0 || p.y < 0 || p.x >= WORLD_W || p.y >= WORLD_H) continue
+    // Only the ceiling and the floor can swallow a particle now — sideways it
+    // just keeps going and comes back round.
+    if (p.y < 0 || p.y >= WORLD_H) continue
     if (solidAt(w, Math.floor(p.x), Math.floor(p.y))) {
       p.vx *= 0.4
       p.vy = -p.vy * 0.2

--- a/src/app/micro-land/domain/sim/prng.ts
+++ b/src/app/micro-land/domain/sim/prng.ts
@@ -76,3 +76,67 @@ export function fbm(
   }
   return value / total
 }
+
+/**
+ * The same lattice in three dimensions.
+ *
+ * Exists for one reason: terrain has to meet itself at the seam. A world that
+ * wraps but whose hills do not is worse than one that does not wrap at all —
+ * the cliff at column zero is the one thing that tells the player the loop is a
+ * trick. The fix is to stop sampling the noise along a *line* across the world
+ * and start sampling it around a *circle*, which closes on itself by
+ * construction (see `ringXY` in `config/themes.ts`).
+ *
+ * A circle eats two of the two dimensions, so anything that also varies with
+ * depth — caves, ore seams, cloud banks — needs a third for `y`. Hence this.
+ */
+export function makeNoise3D(seed: number): (x: number, y: number, z: number) => number {
+  const s = seed >>> 0
+
+  function hash(ix: number, iy: number, iz: number): number {
+    let h = (ix * 374761393 + iy * 668265263 + iz * 2147483647 + s * 1274126177) | 0
+    h = (h ^ (h >>> 13)) | 0
+    h = Math.imul(h, 1274126177)
+    return ((h ^ (h >>> 16)) >>> 0) / 4294967296
+  }
+
+  const smooth = (t: number) => t * t * (3 - 2 * t)
+
+  return function noise(x: number, y: number, z: number): number {
+    const x0 = Math.floor(x)
+    const y0 = Math.floor(y)
+    const z0 = Math.floor(z)
+    const fx = smooth(x - x0)
+    const fy = smooth(y - y0)
+    const fz = smooth(z - z0)
+
+    // Trilinear blend of the eight lattice corners.
+    const lerp = (a: number, b: number, t: number) => a + (b - a) * t
+    const c00 = lerp(hash(x0, y0, z0), hash(x0 + 1, y0, z0), fx)
+    const c10 = lerp(hash(x0, y0 + 1, z0), hash(x0 + 1, y0 + 1, z0), fx)
+    const c01 = lerp(hash(x0, y0, z0 + 1), hash(x0 + 1, y0, z0 + 1), fx)
+    const c11 = lerp(hash(x0, y0 + 1, z0 + 1), hash(x0 + 1, y0 + 1, z0 + 1), fx)
+    return lerp(lerp(c00, c10, fy), lerp(c01, c11, fy), fz)
+  }
+}
+
+/** Layered `makeNoise3D`, matching `fbm`'s octave shape exactly. */
+export function fbm3(
+  noise: (x: number, y: number, z: number) => number,
+  x: number,
+  y: number,
+  z: number,
+  octaves = 4
+): number {
+  let value = 0
+  let amp = 0.5
+  let freq = 1
+  let total = 0
+  for (let i = 0; i < octaves; i++) {
+    value += noise(x * freq, y * freq, z * freq) * amp
+    total += amp
+    amp *= 0.5
+    freq *= 2
+  }
+  return value / total
+}

--- a/src/app/micro-land/domain/sim/tile-sim.ts
+++ b/src/app/micro-land/domain/sim/tile-sim.ts
@@ -22,6 +22,7 @@ import {
 } from '@/app/micro-land/domain/config/materials'
 import { WORLD_H, WORLD_W } from '@/app/micro-land/domain/constants'
 import type { WorldState } from '@/app/micro-land/domain/types'
+import { wrapCol } from '@/app/micro-land/domain/wrap'
 
 const AIR = MATERIAL_INDEX.air
 const WATER = MATERIAL_INDEX.water
@@ -139,8 +140,18 @@ function hash3(x: number, y: number, z: number): number {
   return ((h ^ (h >>> 16)) >>> 0) / 4294967296
 }
 
+/**
+ * Tile index, wrapping horizontally.
+ *
+ * Every read and write in the tile sim goes through here, which is what makes
+ * the whole falling-sand pass wrap for free: a grain of sand pushed off column
+ * 671 lands in column 0 because that is where its index points. The `nx` bounds
+ * checks that used to guard each caller are gone for the horizontal axis — they
+ * were the walls, and the walls are what we are removing. Vertical guards stay
+ * exactly where they were: the ceiling and the floor are still real.
+ */
 function cell(x: number, y: number): number {
-  return y * WORLD_W + x
+  return y * WORLD_W + wrapCol(x)
 }
 
 function passableForPowder(mat: number): boolean {
@@ -174,9 +185,7 @@ function stepPowder(
   // Blocked straight down — try the diagonals so it forms a slope.
   const first = leftToRight ? -1 : 1
   for (const dir of [first, -first]) {
-    const nx = x + dir
-    if (nx < 0 || nx >= WORLD_W) continue
-    const diag = cell(nx, y + 1)
+    const diag = cell(x + dir, y + 1)
     if (passableForPowder(tiles[diag])) {
       swap(tiles, at, diag)
       return
@@ -207,7 +216,6 @@ function seekDrop(tiles: Uint8Array, x: number, y: number, dir: number): number 
   if (y + 1 >= WORLD_H) return 0
   for (let step = 1; step <= FLOW_SEARCH; step++) {
     const nx = x + dir * step
-    if (nx < 0 || nx >= WORLD_W) return 0
     if (tiles[cell(nx, y)] !== AIR) return 0
     if (tiles[cell(nx, y + 1)] === AIR) return step
   }
@@ -247,9 +255,8 @@ function stepLiquid(
   const first = hash3(x, y, phase) < 0.5 ? -1 : 1
 
   for (const dir of [first, -first]) {
-    const nx = x + dir
-    if (nx < 0 || nx >= WORLD_W || y + 1 >= WORLD_H) continue
-    const diag = cell(nx, y + 1)
+    if (y + 1 >= WORLD_H) continue
+    const diag = cell(x + dir, y + 1)
     if (tiles[diag] === AIR) {
       swap(tiles, at, diag)
       return
@@ -284,10 +291,9 @@ function quench(tiles: Uint8Array, x: number, y: number, at: number): boolean {
   for (let dy = -1; dy <= 1; dy++) {
     for (let dx = -1; dx <= 1; dx++) {
       if (dx === 0 && dy === 0) continue
-      const nx = x + dx
       const ny = y + dy
-      if (nx < 0 || ny < 0 || nx >= WORLD_W || ny >= WORLD_H) continue
-      const n = cell(nx, ny)
+      if (ny < 0 || ny >= WORLD_H) continue
+      const n = cell(x + dx, ny)
       if (tiles[n] === WATER) {
         tiles[n] = AIR
         found = true
@@ -322,10 +328,9 @@ function corrode(tiles: Uint8Array, x: number, y: number, at: number, phase: num
     [1, 0],
     [0, -1],
   ]) {
-    const nx = x + dx
     const ny = y + dy
-    if (nx < 0 || ny < 0 || nx >= WORLD_W || ny >= WORLD_H) continue
-    const n = cell(nx, ny)
+    if (ny < 0 || ny >= WORLD_H) continue
+    const n = cell(x + dx, ny)
     const target = tiles[n]
     if (IS_SOLID[target] !== 1 || IS_ACID_PROOF[target] === 1) continue
     tiles[n] = AIR
@@ -341,10 +346,9 @@ function touchesHeat(tiles: Uint8Array, x: number, y: number): boolean {
   for (let dy = -1; dy <= 1; dy++) {
     for (let dx = -1; dx <= 1; dx++) {
       if (dx === 0 && dy === 0) continue
-      const nx = x + dx
       const ny = y + dy
-      if (nx < 0 || ny < 0 || nx >= WORLD_W || ny >= WORLD_H) continue
-      if (tiles[cell(nx, ny)] === LAVA) return true
+      if (ny < 0 || ny >= WORLD_H) continue
+      if (tiles[cell(x + dx, ny)] === LAVA) return true
     }
   }
   return false

--- a/src/app/micro-land/domain/sim/world.ts
+++ b/src/app/micro-land/domain/sim/world.ts
@@ -27,6 +27,7 @@ import type {
   MaterialId,
   WorldState,
 } from '@/app/micro-land/domain/types'
+import { wrapCol, wrapX } from '@/app/micro-land/domain/wrap'
 
 import { type Rng, makeRng } from './prng'
 
@@ -72,43 +73,55 @@ export function createWorld(seed = 1337): WorldState {
 // ---------------------------------------------------------------------------
 
 export function idx(x: number, y: number): number {
-  return y * WORLD_W + x
+  return y * WORLD_W + wrapCol(x)
 }
 
-export function inBounds(x: number, y: number): boolean {
-  return x >= 0 && y >= 0 && x < WORLD_W && y < WORLD_H
+/**
+ * Is this a real tile?
+ *
+ * Only a question about `y` now. The world wraps horizontally, so there is no
+ * such thing as an x that is out of bounds — every column resolves to a real one.
+ * The argument is kept so the dozens of call sites still read as a bounds check
+ * on a point rather than on a row, and so that any caller which one day cares
+ * about x again has somewhere to put it.
+ */
+export function inBounds(_x: number, y: number): boolean {
+  return y >= 0 && y < WORLD_H
 }
 
-/** Material index at a tile. Out of bounds reads as stone — the world is a box. */
+/**
+ * Material index at a tile. Above the sky and below the floor reads as stone —
+ * the world is a cylinder, capped top and bottom.
+ */
 export function tileAt(w: WorldState, x: number, y: number): number {
-  if (!inBounds(x, y)) return MATERIAL_INDEX.stone
-  return w.tiles[y * WORLD_W + x]
+  if (y < 0 || y >= WORLD_H) return MATERIAL_INDEX.stone
+  return w.tiles[y * WORLD_W + wrapCol(x)]
 }
 
-/** Out of bounds counts as solid, so nothing can wander out of the world. */
+/** The ceiling and the floor count as solid, so nothing falls out of the world. */
 export function solidAt(w: WorldState, x: number, y: number): boolean {
-  if (!inBounds(x, y)) return true
-  return IS_SOLID[w.tiles[y * WORLD_W + x]] === 1
+  if (y < 0 || y >= WORLD_H) return true
+  return IS_SOLID[w.tiles[y * WORLD_W + wrapCol(x)]] === 1
 }
 
 export function liquidAt(w: WorldState, x: number, y: number): boolean {
-  if (!inBounds(x, y)) return false
-  return IS_LIQUID[w.tiles[y * WORLD_W + x]] === 1
+  if (y < 0 || y >= WORLD_H) return false
+  return IS_LIQUID[w.tiles[y * WORLD_W + wrapCol(x)]] === 1
 }
 
 export function deadlyAt(w: WorldState, x: number, y: number): boolean {
-  if (!inBounds(x, y)) return false
-  return IS_DEADLY[w.tiles[y * WORLD_W + x]] === 1
+  if (y < 0 || y >= WORLD_H) return false
+  return IS_DEADLY[w.tiles[y * WORLD_W + wrapCol(x)]] === 1
 }
 
 export function fertileAt(w: WorldState, x: number, y: number): boolean {
-  if (!inBounds(x, y)) return false
-  return IS_FERTILE[w.tiles[y * WORLD_W + x]] === 1
+  if (y < 0 || y >= WORLD_H) return false
+  return IS_FERTILE[w.tiles[y * WORLD_W + wrapCol(x)]] === 1
 }
 
 export function setTile(w: WorldState, x: number, y: number, mat: number): void {
-  if (!inBounds(x, y)) return
-  w.tiles[y * WORLD_W + x] = mat
+  if (y < 0 || y >= WORLD_H) return
+  w.tiles[y * WORLD_W + wrapCol(x)] = mat
 }
 
 /**
@@ -240,7 +253,7 @@ export function boxDrownFraction(
     for (let tx = x0; tx <= x1; tx++) {
       total++
       if (!inBounds(tx, ty)) continue
-      if (IS_DROWNING[w.tiles[ty * WORLD_W + tx]] === 1) submerged++
+      if (IS_DROWNING[w.tiles[ty * WORLD_W + wrapCol(tx)]] === 1) submerged++
     }
   }
   return total === 0 ? 0 : submerged / total
@@ -261,7 +274,7 @@ export function boxViscosity(w: WorldState, x: number, y: number, bw: number, bh
   for (let ty = y0; ty <= y1; ty++) {
     for (let tx = x0; tx <= x1; tx++) {
       if (!inBounds(tx, ty)) continue
-      const v = VISCOSITY[w.tiles[ty * WORLD_W + tx]]
+      const v = VISCOSITY[w.tiles[ty * WORLD_W + wrapCol(tx)]]
       if (v > worst) worst = v
     }
   }
@@ -432,6 +445,12 @@ export function spawnCreature(
   if (w.creatures.length >= TUNING.maxCreatures) return null
   if (!w.blueprints[bp.id]) w.blueprints[bp.id] = bp
 
+  // Every stored x is a wrapped x — see `domain/wrap.ts`. This is the one funnel
+  // every creature in the game comes through (placed by hand, seeded by the
+  // ground, born, dropped by a theme), so normalising here is what makes that
+  // invariant true rather than merely intended.
+  x = wrapX(x)
+
   // Species-specific trait baselines: fly/swim range naturally farther;
   // meat-eaters are naturally more territorial about their hunting grounds.
   const spawnBaseTraits = {
@@ -472,7 +491,10 @@ export function spawnCreature(
     name: null,
     huntPassCount: 0,
     poisoned: 0,
-    homeX: Math.round(x),
+    // `wrapCol` and not a bare round: rounding a wrapped x can land exactly on
+    // WORLD_W, which is one past the last column and would read as a home the
+    // creature can never quite reach.
+    homeX: wrapCol(Math.round(x)),
     homeY: Math.round(y),
     migrateTimer: 0,
     packTimer: 0,
@@ -540,14 +562,18 @@ export function findSpawnSpot(
       // Water plants are excluded because the checks below judge the spot
       // *before* it settles: kelp asked about an empty sky reads as beached and
       // rejects all 120 attempts, which would quietly wipe kelp out of tidepool.
-      x = rng() * (WORLD_W - bw)
+      x = rng() * WORLD_W
       y = 0
       fromSky = true
     } else {
-      x = rng() * (WORLD_W - bw)
+      x = rng() * WORLD_W
       y = rng() * (WORLD_H - bh)
     }
-    x = Math.max(0, Math.min(WORLD_W - bw, x))
+    // The whole width is fair game now: a sprite hanging over the seam is drawn
+    // and collided in two pieces rather than being pushed back inside, so the
+    // old `WORLD_W - bw` limit would only have left a creature-shaped gap in the
+    // spawn distribution either side of column zero.
+    x = wrapX(x)
     y = Math.max(0, Math.min(WORLD_H - bh, y))
 
     if (!fits(x, y)) continue
@@ -598,7 +624,7 @@ export function findSpawnSpot(
   // rather than the whole sprite — a dragon's wingtips overlapping a hill must
   // not be the reason a summon lands nowhere.
   if (near && fits(near.x - bw / 2, near.y - bh / 2)) {
-    return { x: near.x - bw / 2, y: near.y - bh / 2 }
+    return { x: wrapX(near.x - bw / 2), y: near.y - bh / 2 }
   }
   return null
 }
@@ -791,10 +817,13 @@ export function tickMoisture(w: WorldState, tickCount: number, dt: number, rng: 
     for (let x = 0; x < WORLD_W; x++) {
       const i = y * WORLD_W + x
       w.moisture[i] = Math.max(0, w.moisture[i] - 0.005 * timePassed)
+      // Sideways neighbours wrap, so a shoreline at column zero is as damp as
+      // one in the middle of the map. Up and down still stop at the walls.
+      const rowStart = y * WORLD_W
       const hasWater =
         w.tiles[i] === waterIdx ||
-        (x > 0 && w.tiles[i - 1] === waterIdx) ||
-        (x < WORLD_W - 1 && w.tiles[i + 1] === waterIdx) ||
+        w.tiles[rowStart + (x === 0 ? WORLD_W - 1 : x - 1)] === waterIdx ||
+        w.tiles[rowStart + (x === WORLD_W - 1 ? 0 : x + 1)] === waterIdx ||
         (y > 0 && w.tiles[i - WORLD_W] === waterIdx) ||
         (y < WORLD_H - 1 && w.tiles[i + WORLD_W] === waterIdx)
       if (hasWater) {
@@ -809,9 +838,9 @@ export function tickMoisture(w: WorldState, tickCount: number, dt: number, rng: 
     const radius = 15 + Math.floor(rng() * 25)
     for (let dy2 = -radius; dy2 <= radius; dy2++) {
       for (let dx2 = -radius; dx2 <= radius; dx2++) {
-        const tx = rx + dx2
+        const tx = wrapCol(rx + dx2)
         const ty = ry + dy2
-        if (tx < 0 || tx >= WORLD_W || ty < 0 || ty >= WORLD_H) continue
+        if (ty < 0 || ty >= WORLD_H) continue
         if (dx2 * dx2 + dy2 * dy2 > radius * radius) continue
         const mi = ty * WORLD_W + tx
         w.moisture[mi] = Math.min(1, (w.moisture[mi] || 0) + 0.25)

--- a/src/app/micro-land/domain/terrain.ts
+++ b/src/app/micro-land/domain/terrain.ts
@@ -16,7 +16,8 @@ import { z } from 'zod'
 
 import { BASE_MATERIAL_IDS, MATERIALS, MATERIAL_IDS } from './config/materials'
 import { WORLD_H, WORLD_W } from './constants'
-import { type Rng, fbm, makeNoise2D } from './sim/prng'
+import { type Rng, fbm3, makeNoise3D } from './sim/prng'
+import { ringXY } from './wrap'
 
 import type { Theme } from './config/themes'
 import type { MaterialId } from './types'
@@ -260,33 +261,58 @@ export function paintTerrain(
   const map = fitGroundLevel(terrain.map, rng)
   const rows = map.length
   const cols = map[0].length
-  const noise = makeNoise2D(Math.floor(rng() * 1e9))
+  const noise = makeNoise3D(Math.floor(rng() * 1e9))
 
   const scaleY = rows / WORLD_H
-  // How many columns a map would need to cross the world with square cells.
-  const squareCols = WORLD_W * scaleY
-  const repeats = cols < squareCols - 0.5
-  // A map drawn *wider* than that is squeezed to fit instead of repeated. There
-  // is no third option — the rows have to span the world's full height, which
-  // fixes the vertical scale — and squeezing is much the gentler failure: it
-  // makes hills steeper, where the old stretch made them into plateaus.
-  const scaleX = repeats ? scaleY : cols / WORLD_W
+
   // Out and back again, so the joins are reflections rather than hard cuts.
   const period = cols * 2
+
+  /**
+   * How many out-and-back trips over the map the world contains — a whole
+   * number, always, because the world wraps.
+   *
+   * The mirrored walk is a triangle wave of period `2 * cols`, so it only comes
+   * back to where it started if the world spans a whole number of them. It used
+   * to span whatever the square-cell scale happened to give, which is almost
+   * never a whole number, and the map therefore met itself at column zero
+   * part-way through a trip — a hard vertical cut down the seam, in the one
+   * place the reflection trick was there to avoid one.
+   *
+   * Rounding to the nearest whole trip is what keeps cells near-square: it moves
+   * the horizontal scale by at most half a trip's worth, and never below one
+   * trip, so a map still crosses the world at least once.
+   */
+  const trips = Math.max(1, Math.round((WORLD_W * scaleY) / period))
+
+  /**
+   * A map drawn wider than square would once have been squeezed to fit across
+   * the world exactly once, which cannot wrap — its left edge is map column 0
+   * and its right edge is map column `cols - 1`, and those are different
+   * pictures. It now takes the same mirrored path as every other map, at one
+   * trip, so a wide scene reads out and back rather than running off a cliff.
+   * The cost is that a very wide map is squeezed about twice as hard as before;
+   * the alternative was the seam it was drawn to hide.
+   */
+  const scaleX = (trips * period) / WORLD_W
 
   // Roughen by about half a map cell, in world tiles.
   const wobble = Math.max(1, Math.min(1 / scaleX, 1 / scaleY) * 0.65)
 
   for (let y = 0; y < WORLD_H; y++) {
     for (let x = 0; x < WORLD_W; x++) {
-      const nx = (fbm(noise, x * 0.09, y * 0.09, 2) - 0.5) * 2 * wobble
-      const ny = (fbm(noise, x * 0.09 + 31.7, y * 0.09 - 12.3, 2) - 0.5) * 2 * wobble
+      // Sampled around a ring rather than along a line, so the roughening meets
+      // itself at the seam instead of leaving a tile of jitter down column zero.
+      // The second sample is offset in *depth*, not in x: on a ring an x offset
+      // is only a rotation of the same circle and would decorrelate nothing.
+      const { u, v } = ringXY(x, 0.09)
+      const nx = (fbm3(noise, u, v, y * 0.09, 2) - 0.5) * 2 * wobble
+      const ny = (fbm3(noise, u, v, y * 0.09 + 31.7, 2) - 0.5) * 2 * wobble
 
-      let cx = Math.floor((x + nx) * scaleX)
-      if (repeats) {
-        const p = ((cx % period) + period) % period
-        cx = p < cols ? p : period - 1 - p
-      }
+      // Always mirrored now, whatever the map's shape — see `trips`.
+      const raw = Math.floor((x + nx) * scaleX)
+      const p = ((raw % period) + period) % period
+      const cx = p < cols ? p : period - 1 - p
       const cy = Math.floor((y + ny) * scaleY)
       const row = map[Math.max(0, Math.min(rows - 1, cy))]
       const ch = row[Math.max(0, Math.min(cols - 1, cx))] ?? '.'

--- a/src/app/micro-land/domain/wrap.ts
+++ b/src/app/micro-land/domain/wrap.ts
@@ -1,0 +1,132 @@
+/**
+ * The world is a cylinder: walk off the right edge and you come back on the
+ * left. Top and bottom are still walls — a wrapped ceiling in a falling-sand
+ * world means powder rains out of the sky forever.
+ *
+ * Two operations cover every use. `wrapX` puts a column back in range; `deltaX`
+ * answers "how far, and which way" between two columns. The second is the one
+ * that matters: with no edges, `b - a` is no longer the distance between two
+ * points, and every place that subtracted one x from another is now asking a
+ * question with two answers. Taking the shorter one is what makes a creature at
+ * 670 chase food at 5 by stepping right across the seam instead of walking six
+ * hundred tiles the long way round.
+ *
+ * The invariant that keeps all of this honest: **every stored x is already
+ * wrapped**. Creature positions, `homeX`, scent and carcass coordinates all live
+ * in `[0, WORLD_W)`. `deltaX` relies on it — it corrects by at most one world
+ * width, which is only enough if the raw difference is under 1.5 worlds. Store
+ * an unwrapped x anywhere and distances silently go wrong rather than throwing.
+ */
+import { WORLD_W } from '@/app/micro-land/domain/constants'
+
+/** Half a world. Past this in either direction, the other way round is shorter. */
+const HALF_W = WORLD_W / 2
+
+/**
+ * Put any x back in `[0, WORLD_W)`.
+ *
+ * Not just `x % WORLD_W`: JavaScript's `%` keeps the sign of the dividend, so a
+ * creature one tile off the left edge comes back as `-1` instead of `WORLD_W - 1`
+ * and then indexes the row above it. That is the whole bug, and it is invisible
+ * until something walks left.
+ */
+export function wrapX(x: number): number {
+  const m = x % WORLD_W
+  return m < 0 ? m + WORLD_W : m
+}
+
+/**
+ * The same, for integer tile columns, with the in-range case branch-only.
+ *
+ * Every tile read in the game goes through here — `solidAt` alone is called a
+ * few million times a second by `boxHitsSolid` — and the overwhelming majority
+ * of them are nowhere near the seam. A compare-and-return costs a fraction of a
+ * modulo, and this is the hottest path in the simulation.
+ */
+export function wrapCol(x: number): number {
+  if (x >= 0 && x < WORLD_W) return x
+  const m = x % WORLD_W
+  return m < 0 ? m + WORLD_W : m
+}
+
+/**
+ * Signed distance from `from` to `to`, taking the shorter way round.
+ *
+ * Result is in `(-HALF_W, HALF_W]`, and its *sign is a direction*: positive
+ * means "to is to my right", which is what steering reads. Both arguments must
+ * already be wrapped (see the module comment) — the single correction below only
+ * reaches one world width.
+ */
+export function deltaX(from: number, to: number): number {
+  let d = to - from
+  if (d > HALF_W) d -= WORLD_W
+  else if (d < -HALF_W) d += WORLD_W
+  return d
+}
+
+/**
+ * Does an object occupying columns `[x, x + width)` overlap the view?
+ *
+ * The view runs from `viewLeft` for `viewWide` columns and may run off the end
+ * of the world, which is what makes this more than a pair of comparisons. Both
+ * arguments are on a circle, so "is it to the left of the screen" and "is it to
+ * the right of the screen" stop being different questions.
+ *
+ * Lives here rather than in the renderer because it is the same wrap arithmetic
+ * as everything else in this file, and because a private method on a class that
+ * needs a canvas to construct is a private method nobody will ever test.
+ */
+export function overlapsView(
+  x: number,
+  width: number,
+  viewLeft: number,
+  viewWide: number
+): boolean {
+  // Where the object's left edge sits relative to the left of the screen, going
+  // right. If that is inside the view the object is on screen.
+  const rel = wrapX(x - viewLeft)
+  if (rel < viewWide) return true
+  // Otherwise it can still be on screen by hanging over the seam: an object
+  // starting near the end of the world whose tail reaches back past column zero
+  // into the start of the view.
+  return rel + width > WORLD_W
+}
+
+/**
+ * Where column `x` sits on a ring, in noise units.
+ *
+ * The bridge between a wrapping world and a noise field. Terrain drawn by
+ * walking a field from x=0 to x=671 has no reason to arrive back where it
+ * started, and what you get is a cliff at column zero — hills on one side, a
+ * flat cut on the other, and a player who can see exactly where the trick is.
+ * Reading the field around a circle instead fixes it by construction: a circle
+ * closes, so a continuous field sampled along one is periodic, with no blending
+ * band and no requirement that the lattice divide evenly into the world width.
+ *
+ * The radius makes the circumference in noise units come to `WORLD_W * freq` —
+ * exactly what the old straight-line sampling covered — so features keep the
+ * size they have always had. A low frequency gives a small circle and therefore
+ * few features across the world, which is what a low frequency always meant.
+ *
+ * Lives here rather than beside the generators because both the built-in themes
+ * and the summoned-terrain painter need it, and they have no other reason to
+ * know about each other.
+ */
+export function ringXY(x: number, freq: number): { u: number; v: number } {
+  const r = (WORLD_W * freq) / (2 * Math.PI)
+  const t = (x / WORLD_W) * 2 * Math.PI
+  return { u: Math.cos(t) * r, v: Math.sin(t) * r }
+}
+
+/**
+ * Unsigned distance between two columns, the short way.
+ *
+ * Its own function rather than `Math.abs(deltaX(...))` because most callers only
+ * ever want the magnitude, and saying so at the call site is what stops someone
+ * later reading a bare `Math.abs` as "direction didn't matter here" when the
+ * truth is that it did and got dropped.
+ */
+export function distX(a: number, b: number): number {
+  const d = Math.abs(a - b)
+  return d > HALF_W ? WORLD_W - d : d
+}

--- a/src/app/micro-land/game-instance.ts
+++ b/src/app/micro-land/game-instance.ts
@@ -71,6 +71,7 @@ import {
   type Traits,
   type WorldState,
 } from './domain/types'
+import { wrapCol, wrapX } from './domain/wrap'
 import { playBorn, playDeath, playEat, playExtinction, isSoundEnabled } from './audio/sound-engine'
 import { formatDuration } from './format'
 import { Renderer } from './rendering/renderer'
@@ -394,9 +395,13 @@ export class GameInstance {
       const view = this.renderer.viewWidth
       const cam = this.renderer.cameraX
       const held = this.grabbed.x
+      // Where in the view the carried creature is, measured the short way round.
+      // Absolute comparisons against the camera stop meaning anything once the
+      // view can straddle the seam.
+      const into = wrapX(held - cam)
       let dir = 0
-      if (held < cam + view * EDGE_BAND) dir = -1
-      else if (held > cam + view * (1 - EDGE_BAND)) dir = 1
+      if (into < view * EDGE_BAND) dir = -1
+      else if (into < view && into > view * (1 - EDGE_BAND)) dir = 1
 
       // The same band top and bottom, but only once zoom has put world off
       // screen that way — otherwise dragging something down to the floor, which
@@ -419,7 +424,7 @@ export class GameInstance {
         const movedY = this.renderer.cameraY - camY
         const bp = this.world.blueprints[this.grabbed.blueprintId]
         const art = bp ? artSize(bp) : { w: 0, h: 0 }
-        this.grabbed.x = Math.max(0, Math.min(this.world.width - art.w, held + moved))
+        this.grabbed.x = wrapX(held + moved)
         this.grabbed.y = Math.max(0, Math.min(this.world.height - art.h, heldY + movedY))
       }
     }
@@ -473,7 +478,7 @@ export class GameInstance {
         // Stamp each creature of the tracked species.
         for (const c of w.creatures) {
           if (c.blueprintId !== bpId) continue
-          const tx = Math.max(0, Math.min(WORLD_W - 1, Math.round(c.x)))
+          const tx = wrapCol(Math.round(c.x))
           const ty = Math.max(0, Math.min(WORLD_H - 1, Math.round(c.y)))
           this.heatmap[ty * WORLD_W + tx] += 1
         }
@@ -2255,7 +2260,12 @@ export class GameInstance {
     if (e.key === 'Home' || e.key === 'End') {
       e.preventDefault()
       this.following = false
-      this.renderer.panToLeft(e.key === 'Home' ? 0 : this.world.width)
+      // There is no far end any more, so End means "half a world from here" —
+      // the furthest point from where you are standing, which is the only thing
+      // "the other end" can still mean on a loop.
+      this.renderer.panToLeft(
+        e.key === 'Home' ? 0 : this.renderer.cameraX + this.world.width / 2
+      )
       return
     }
 

--- a/src/app/micro-land/rendering/renderer.ts
+++ b/src/app/micro-land/rendering/renderer.ts
@@ -14,9 +14,17 @@
  * The world is wider than the screen, so there is a camera, and it only ever
  * sits on whole tiles: a camera at x = 12.4 would resample every tile in the
  * world onto a half-pixel and undo the one thing this renderer exists to
- * protect. Every per-frame pass below — tiles, light, shadow, sprites — is
- * clipped to the visible column range, which is what keeps a world three times
- * the size costing about what one screen used to.
+ * protect.
+ *
+ * The world also *wraps*, which is what most of the awkwardness below is about.
+ * The camera can sit on the seam, so the visible range is not always one
+ * contiguous run of columns; sprites can hang over the seam, so they are drawn
+ * twice, once at each end. The passes whose cost is per visible pixel — the tile
+ * bake, the shadow bake, every sprite — are still clipped to what you can see,
+ * which is what keeps a world three times the size costing about what one screen
+ * used to. The passes that are cheap enough not to matter (the sky fill, the
+ * light field) simply cover the whole world, because a wrapped window would have
+ * cost more in bookkeeping than it ever saved in arithmetic.
  *
  * Zoom moves the size of a tile, never the size of the backbuffer: the world is
  * always composed at one pixel per tile and the zoom lives entirely in the final
@@ -31,12 +39,21 @@ import { VIEW_W, WORLD_H, WORLD_W } from '@/app/micro-land/domain/constants'
 import { lifespanOf, sizeOf, tintKey } from '@/app/micro-land/domain/traits'
 import { TUNING } from '@/app/micro-land/domain/tuning'
 import type { WorldState } from '@/app/micro-land/domain/types'
+import { deltaX, overlapsView, wrapCol, wrapX } from '@/app/micro-land/domain/wrap'
 import { useMicroLand } from '@/app/micro-land/store'
 
 import { getSprites } from './sprite-cache'
 
 /** Light is computed on a coarse grid and blurred — no need for per-pixel. */
 const LIGHT_SCALE = 4
+/**
+ * Spare backbuffer width, so a view straddling the seam is still one blit.
+ *
+ * A whole world, because that is the widest the view can ever be — fully zoomed
+ * out it shows every column, and the camera is free to sit anywhere.
+ */
+const OVERHANG = WORLD_W
+
 const LW = Math.ceil(WORLD_W / LIGHT_SCALE)
 const LH = Math.ceil(WORLD_H / LIGHT_SCALE)
 
@@ -51,17 +68,6 @@ const SKY_FALLOFF = 16
  * while paused, where panning would otherwise re-bake on every single frame.
  */
 const TILE_MARGIN = 32
-
-/**
- * Light bleeds sideways through the blur, so it's gathered a little wider.
- *
- * Has to cover more than the blur reaches. Each of the three passes pulls in one
- * coarse cell from outside the gathered range — which is stale, because nothing
- * out there was computed — so the outermost three cells of the margin are wrong
- * by the end. At 4 tiles per cell this leaves three clean cells of slack beyond
- * that before the visible edge starts.
- */
-const LIGHT_MARGIN = 24
 
 /** The minimap is a whole-world thumbnail at this many tiles per pixel. */
 const MAP_SCALE = 4
@@ -175,14 +181,33 @@ export class Renderer {
   /** How many world rows the display is tall at the current scale. */
   private viewRows = WORLD_H
 
+  /** Visible span for this frame, in world columns. Read by `onScreen`. */
+  private spanLeft = 0
+  private spanWide = VIEW_W
+  /**
+   * Which copy of the world is being drawn right now: 0 for the world itself,
+   * `-WORLD_W` for the pass that catches things hanging over the seam.
+   */
+  private drawOffset = 0
+
   constructor(display: HTMLCanvasElement) {
     this.display = display
     const ctx = display.getContext('2d')
     if (!ctx) throw new Error('micro-land: 2d canvas context unavailable')
     this.ctx = ctx
 
+    /**
+     * One world wide plus a whole view of overhang.
+     *
+     * The view can now straddle column zero, and a blit of a range that runs off
+     * the end of the backbuffer would come back with the right-hand two thirds
+     * of the screen blank. Rather than splitting every frame into two blits and
+     * two of everything else, the head of the world is copied into the overhang
+     * once per frame (see the end of `render`) and the blit stays a single
+     * contiguous read, exactly as it always was.
+     */
     this.world = document.createElement('canvas')
-    this.world.width = WORLD_W
+    this.world.width = WORLD_W + OVERHANG
     this.world.height = WORLD_H
     this.wctx = this.world.getContext('2d')!
 
@@ -385,10 +410,21 @@ export class Renderer {
    * the edge of the view and leaving you looking at nothing.
    */
   keepInView(worldX: number, margin: number, maxTiles: number): void {
-    const left = this.camX + margin
-    const right = this.camX + this.viewTiles - margin
-    if (worldX < left) this.panBy(Math.max(-maxTiles, worldX - left))
-    else if (worldX > right) this.panBy(Math.min(maxTiles, worldX - right))
+    /**
+     * How far the point is from the left of the view, signed, the short way.
+     *
+     * This is the only change the seam forces here, and it is exactly the
+     * substitution of `deltaX` for a subtraction: `worldX - camX` stopped being
+     * a distance the moment the world wrapped. A creature at column 3 followed
+     * by a camera at column 660 reads as 657 tiles to the *left* under plain
+     * arithmetic, and the camera would set off across the entire world after
+     * something sitting a few tiles off the right of the screen.
+     */
+    const off = deltaX(this.camX, worldX)
+    const left = margin
+    const right = this.viewTiles - margin
+    if (off < left) this.panBy(Math.max(-maxTiles, off - left))
+    else if (off > right) this.panBy(Math.min(maxTiles, off - right))
   }
 
   /** The same, up and down. A no-op while the world still fits vertically. */
@@ -401,10 +437,14 @@ export class Renderer {
   }
 
   private clampCam(): void {
-    // `max(0, …)` on the limit as well as the value: pulled out far enough that
-    // the world is letterboxed, `WORLD_W - viewTiles` is negative and the naive
-    // clamp would pin the camera to a negative column.
-    this.camX = clamp(this.camX, 0, Math.max(0, WORLD_W - this.viewTiles))
+    /**
+     * Sideways the camera no longer has ends to be stopped at — it wraps, so
+     * panning right forever is a thing you can now do. Vertically nothing has
+     * changed: `max(0, …)` on the limit as well as the value, because pulled out
+     * far enough that the world is letterboxed `WORLD_H - viewRows` is negative
+     * and the naive clamp would pin the camera to a negative row.
+     */
+    this.camX = wrapX(this.camX)
     this.camY = clamp(this.camY, 0, Math.max(0, WORLD_H - this.viewRows))
   }
 
@@ -424,7 +464,40 @@ export class Renderer {
 
   /** Whole-tile left edge. Everything drawn this frame is measured from here. */
   private viewLeft(): number {
-    return Math.floor(this.camX)
+    return wrapCol(Math.floor(this.camX))
+  }
+
+  /**
+   * Does an object occupying world columns `[x, x + width)` need drawing?
+   *
+   * Two questions in one, because the seam makes them inseparable. The first is
+   * ordinary culling: most of the population is off screen in a world this wide,
+   * and skipping it is what ties the draw cost to what you can see. The second
+   * is which *copy* of the object is being asked about — anything overlapping
+   * column zero exists at two places on the backbuffer at once, and is drawn
+   * once at each, so a creature standing on the seam appears as one animal
+   * rather than as two halves with a gap between them.
+   *
+   * The second pass has nothing to do for an object that fits inside the world,
+   * which is nearly all of them, so it costs a comparison and a `continue`.
+   */
+  private onScreen(x: number, width: number): boolean {
+    if (this.drawOffset !== 0 && x + width <= WORLD_W) return false
+    return overlapsView(x, width, this.spanLeft, this.spanWide)
+  }
+
+  /**
+   * How far into the view a world column falls, in tiles.
+   *
+   * For the two label passes, which draw straight onto the display rather than
+   * into the world backbuffer and so convert world coordinates to screen pixels
+   * themselves. `x - camX` stopped being that number the moment the view could
+   * straddle the seam: a label on a creature at column 3, seen from a camera at
+   * column 660, belongs 15 tiles into the view and not 657 tiles to the left of
+   * it.
+   */
+  private intoView(x: number): number {
+    return wrapX(x - this.spanLeft)
   }
 
   /** Whole-tile top edge. Same reason as `viewLeft`. */
@@ -439,7 +512,11 @@ export class Renderer {
     const px = (clientX - rect.left) * dpr
     const py = (clientY - rect.top) * dpr
     return {
-      x: this.viewLeft() + (px - this.offsetX) / this.scale,
+      // Wrapped, because the view can run off the end of the world: a tap on
+      // the right of a screen straddling the seam is a tap on column 3, and
+      // every caller — painting, placing, picking a creature up — compares this
+      // against wrapped world coordinates.
+      x: wrapX(this.viewLeft() + (px - this.offsetX) / this.scale),
       y: this.viewTop() + (py - this.offsetY) / this.scale,
     }
   }
@@ -477,7 +554,9 @@ export class Renderer {
     heatmap: Float32Array | null = null
   ): void {
     const vx = this.viewLeft()
-    const vw = Math.min(WORLD_W - vx, Math.ceil(this.viewTiles))
+    const vw = Math.ceil(this.viewTiles)
+    this.spanLeft = vx
+    this.spanWide = vw
 
     this.ensureTiles(w, vx, vw)
     this.buildLight(w, theme, vx, vw)
@@ -485,29 +564,63 @@ export class Renderer {
     const wctx = this.wctx
     wctx.imageSmoothingEnabled = false
 
-    // Sky behind everything (air tiles are transparent in the tile layer).
+    /**
+     * The full-width layers are drawn whole rather than clipped to the view.
+     *
+     * Clipping them used to be the optimisation; with a view that can straddle
+     * the seam it would have to become two of everything, and the saving was
+     * never real — these are four rectangle operations over 88k pixels, which is
+     * nothing next to the per-sprite work below. Drawing the world once and
+     * letting the blit choose the window is both simpler and honest about where
+     * the frame budget actually goes.
+     */
     const sky = wctx.createLinearGradient(0, 0, 0, WORLD_H)
     sky.addColorStop(0, theme.sky[0])
     sky.addColorStop(1, theme.sky[1])
     wctx.fillStyle = sky
-    wctx.fillRect(vx, 0, vw, WORLD_H)
+    wctx.fillRect(0, 0, WORLD_W, WORLD_H)
 
-    wctx.drawImage(this.tileCanvas, vx, 0, vw, WORLD_H, vx, 0, vw, WORLD_H)
+    wctx.drawImage(this.tileCanvas, 0, 0, WORLD_W, WORLD_H, 0, 0, WORLD_W, WORLD_H)
 
-    this.drawCarcasses(w, vx, vw)
-    this.drawNests(w, vx, vw)
-    this.drawTombstones(w, vx, vw)
-    if (heatmap) this.drawHeatmap(heatmap, vx, vw)
-    this.drawEggs(w, vx, vw)
-    this.drawCreatures(w, vx, vw)
-    this.drawStatusDots(w, vx, vw)
-    this.drawPollinatorAuras(w, vx, vw)
-    this.drawParticles(w, vx, vw)
-    wctx.drawImage(this.shadowCanvas, vx, 0, vw, WORLD_H, vx, 0, vw, WORLD_H)
+    /**
+     * Everything with a position is drawn twice: once as itself, once shifted a
+     * world to the left so that whatever hangs over the right-hand edge lands in
+     * column zero where it belongs. `onScreen` rejects the second copy for
+     * anything that does not reach the seam, which is nearly everything, so the
+     * extra pass costs one comparison per object and no drawing at all.
+     */
+    for (const offset of [0, -WORLD_W]) {
+      this.drawOffset = offset
+      wctx.save()
+      wctx.translate(offset, 0)
+
+      this.drawCarcasses(w)
+      this.drawNests(w)
+      this.drawTombstones(w)
+      if (heatmap) this.drawHeatmap(heatmap, vx, vw)
+      this.drawEggs(w)
+      this.drawCreatures(w)
+      this.drawStatusDots(w)
+      this.drawPollinatorAuras(w)
+      this.drawParticles(w)
+
+      wctx.restore()
+    }
+    this.drawOffset = 0
+
+    wctx.drawImage(this.shadowCanvas, 0, 0, WORLD_W, WORLD_H, 0, 0, WORLD_W, WORLD_H)
     // Both drawn after the shadow so they stay legible in a dark cave. The halo
     // goes first so the selection brackets sit on top when you inspect an elder.
-    if (elderId !== null) this.drawElder(w, elderId)
-    if (highlightId !== null) this.drawHighlight(w, highlightId)
+    // Each draws its own wrapped copy for the same reason as the block above.
+    for (const offset of [0, -WORLD_W]) {
+      this.drawOffset = offset
+      wctx.save()
+      wctx.translate(offset, 0)
+      if (elderId !== null) this.drawElder(w, elderId)
+      if (highlightId !== null) this.drawHighlight(w, highlightId)
+      wctx.restore()
+    }
+    this.drawOffset = 0
 
     // Day/night cycle: gradually darkens during the night phase.
     if (TUNING.dayLengthSeconds > 0) {
@@ -515,9 +628,26 @@ export class Renderer {
       if (nightFactor > 0.05) {
         wctx.globalAlpha = Math.min(0.5, nightFactor * 0.55)
         wctx.fillStyle = '#000a1f'
-        wctx.fillRect(vx, 0, vw, WORLD_H)
+        wctx.fillRect(0, 0, WORLD_W, WORLD_H)
         wctx.globalAlpha = 1
       }
+    }
+
+    /**
+     * Copy the head of the world into the overhang, so a view that runs off the
+     * end reads real pixels instead of blank canvas. Drawing a canvas onto
+     * itself is defined to behave as though the source were snapshotted first,
+     * so the overlap is not a problem.
+     *
+     * Last, after the shadow and the night wash, or the wrapped edge of the
+     * screen would be lit differently from the rest of it. And only as many
+     * columns as actually hang over — nothing at all in the common case where
+     * the camera is not on the seam, which is most of the time.
+     */
+    const overhang = vx + this.viewTiles - WORLD_W
+    if (overhang > 0) {
+      const cols = Math.min(OVERHANG, Math.ceil(overhang))
+      wctx.drawImage(this.world, 0, 0, cols, WORLD_H, WORLD_W, 0, cols, WORLD_H)
     }
 
     // One scaled blit. Nearest-neighbour keeps the pixels crisp.
@@ -538,14 +668,45 @@ export class Renderer {
     )
 
     this.drawMinimap(w, theme, vx)
-    this.drawNameLabels(w, vx, vw, elderId)
-    this.drawTombstoneLabels(w, vx, vw)
+    this.drawNameLabels(w, elderId)
+    this.drawTombstoneLabels(w)
   }
 
   // -------------------------------------------------------------------------
 
+  /**
+   * The visible columns, as one span or two.
+   *
+   * Two whenever the camera is sitting on the seam: the tail of the world, then
+   * the head of it. Everything that walks the visible range column by column has
+   * to go through here, because a single `for (x = vx; x < vx + vw)` runs off the
+   * end of every row-indexed array in the renderer.
+   */
+  private forEachSpan(vx: number, vw: number, fn: (x0: number, width: number) => void): void {
+    const head = Math.min(vw, WORLD_W - vx)
+    fn(vx, head)
+    if (vw > head) fn(0, vw - head)
+  }
+
   /** Re-bake the tile colours if the view has left the range we baked last. */
   private ensureTiles(w: WorldState, vx: number, vw: number): void {
+    /**
+     * A view straddling the seam wants columns from both ends of the grid, which
+     * one baked range cannot describe. Rather than carry two sets of bookkeeping
+     * for a state that lasts as long as it takes to pan past column zero, bake
+     * the lot — it is 88k tiles, which is what the margin below is already
+     * approximating the cost of, and it makes the covered-check trivially true
+     * until something actually changes.
+     */
+    if (vx + vw > WORLD_W) {
+      if (!this.tilesDirty && this.builtX0 === 0 && this.builtX1 === WORLD_W) return
+      this.buildTiles(w, 0, WORLD_W)
+      this.builtX0 = 0
+      this.builtX1 = WORLD_W
+      this.tilesDirty = false
+      return
+    }
+
     const covered = !this.tilesDirty && vx >= this.builtX0 && vx + vw <= this.builtX1
     if (covered) return
 
@@ -589,21 +750,28 @@ export class Renderer {
     this.tileCtx.putImageData(this.tileImage, 0, 0, x0, 0, x1 - x0, WORLD_H)
   }
 
+  /**
+   * The light field, then the shadow overlay baked from it.
+   *
+   * The field is now computed for the whole world rather than for a window
+   * around the view. On a cylinder the window wraps, and every step of this —
+   * the gather, the three blur passes, the bilinear sample — would have needed
+   * its own two-range version, with the blur additionally having to pull
+   * neighbours across the seam or leave a dark stripe down column zero.
+   * Computing the lot removes all of that: the field is 168×33 cells, which is
+   * about a third of one percent of the pixels the shadow bake below touches.
+   *
+   * The bake itself stays clipped to the visible span, because *that* one is
+   * genuinely expensive — a pixel per visible tile per frame — and it is the
+   * only part of this function that ever showed up in a frame budget.
+   */
   private buildLight(w: WorldState, theme: Theme, vx: number, vw: number): void {
-    // Light spreads sideways as it blurs, so it is gathered a little beyond the
-    // view — otherwise the lava just off screen stops lighting the cave mouth
-    // you can see, and the edge of the screen visibly darkens as you pan.
-    const gx0 = Math.max(0, vx - LIGHT_MARGIN)
-    const gx1 = Math.min(WORLD_W, vx + vw + LIGHT_MARGIN)
-    const lx0 = Math.floor(gx0 / LIGHT_SCALE)
-    const lx1 = Math.min(LW, Math.ceil(gx1 / LIGHT_SCALE))
-
     const light = this.light
-    for (let ly = 0; ly < LH; ly++) light.fill(0, ly * LW + lx0, ly * LW + lx1)
+    light.fill(0)
 
     // --- daylight: how far below the first solid tile is each column? ---
     const tiles = w.tiles
-    for (let x = gx0; x < gx1; x++) {
+    for (let x = 0; x < WORLD_W; x++) {
       let y = 0
       while (y < WORLD_H && MATERIAL_BY_INDEX[tiles[y * WORLD_W + x]].solid === false) {
         y++
@@ -613,7 +781,7 @@ export class Renderer {
 
     for (let ly = 0; ly < LH; ly++) {
       const wy = ly * LIGHT_SCALE + LIGHT_SCALE / 2
-      for (let lx = lx0; lx < lx1; lx++) {
+      for (let lx = 0; lx < LW; lx++) {
         const wx = Math.min(WORLD_W - 1, lx * LIGHT_SCALE + (LIGHT_SCALE >> 1))
         const surface = this.skyDepth[wx]
         const below = wy - surface
@@ -627,7 +795,7 @@ export class Renderer {
     // --- emitters: glowing tiles ---
     // Sampled every other tile; the blur smooths over the gaps.
     for (let y = 0; y < WORLD_H; y += 2) {
-      for (let x = gx0; x < gx1; x += 2) {
+      for (let x = 0; x < WORLD_W; x += 2) {
         const mat = MATERIAL_BY_INDEX[tiles[y * WORLD_W + x]]
         if (mat.glow <= 0) continue
         const li = Math.floor(y / LIGHT_SCALE) * LW + Math.floor(x / LIGHT_SCALE)
@@ -641,69 +809,68 @@ export class Renderer {
       if (!bp || bp.glow <= 0) continue
       const lx = Math.floor(c.x / LIGHT_SCALE)
       const ly = Math.floor(c.y / LIGHT_SCALE)
-      if (lx < lx0 || ly < 0 || lx >= lx1 || ly >= LH) continue
-      const li = ly * LW + lx
+      if (ly < 0 || ly >= LH) continue
+      const li = ly * LW + wrapCol(lx)
       light[li] = Math.min(1.8, light[li] + bp.glow * 1.4)
     }
 
     // --- blur, so light pools instead of forming squares ---
-    for (let pass = 0; pass < 3; pass++) this.blurLight(lx0, lx1)
+    for (let pass = 0; pass < 3; pass++) this.blurLight()
 
     // --- bake into the shadow overlay ---
     const gloom = theme.gloom
     const data = this.shadowImage.data
-    for (let y = 0; y < WORLD_H; y++) {
-      const ly = y / LIGHT_SCALE
-      const row = y * WORLD_W
-      for (let x = vx; x < vx + vw; x++) {
-        const value = this.sampleLight(x / LIGHT_SCALE, ly)
-        const alpha = Math.max(0, Math.min(1, 1 - value)) * gloom
-        const o = (row + x) * 4
-        data[o] = 4
-        data[o + 1] = 3
-        data[o + 2] = 12
-        data[o + 3] = Math.round(alpha * 255)
+    this.forEachSpan(vx, vw, (x0, width) => {
+      for (let y = 0; y < WORLD_H; y++) {
+        const ly = y / LIGHT_SCALE
+        const row = y * WORLD_W
+        for (let x = x0; x < x0 + width; x++) {
+          const value = this.sampleLight(x / LIGHT_SCALE, ly)
+          const alpha = Math.max(0, Math.min(1, 1 - value)) * gloom
+          const o = (row + x) * 4
+          data[o] = 4
+          data[o + 1] = 3
+          data[o + 2] = 12
+          data[o + 3] = Math.round(alpha * 255)
+        }
       }
-    }
-    this.shadowCtx.putImageData(this.shadowImage, 0, 0, vx, 0, vw, WORLD_H)
+      this.shadowCtx.putImageData(this.shadowImage, 0, 0, x0, 0, width, WORLD_H)
+    })
   }
 
-  private blurLight(lx0: number, lx1: number): void {
+  /** One box-blur pass over the whole field, wrapping sideways. */
+  private blurLight(): void {
     const src = this.light
     const dst = this.lightScratch
     for (let y = 0; y < LH; y++) {
-      for (let x = lx0; x < lx1; x++) {
+      for (let x = 0; x < LW; x++) {
         let sum = 0
         let count = 0
         for (let dy = -1; dy <= 1; dy++) {
           const ny = y + dy
           if (ny < 0 || ny >= LH) continue
           for (let dx = -1; dx <= 1; dx++) {
-            const nx = x + dx
-            if (nx < 0 || nx >= LW) continue
-            sum += src[ny * LW + nx]
+            // Wraps, so a torch at column 671 lights the cave at column 0 and
+            // there is no dark seam for the blur to leave behind.
+            sum += src[ny * LW + wrapCol(x + dx)]
             count++
           }
         }
         dst[y * LW + x] = sum / count
       }
     }
-    for (let y = 0; y < LH; y++) {
-      const a = y * LW + lx0
-      const b = y * LW + lx1
-      src.set(dst.subarray(a, b), a)
-    }
+    src.set(dst)
   }
 
-  /** Bilinear sample of the coarse light field. */
+  /** Bilinear sample of the coarse light field. Wraps horizontally. */
   private sampleLight(fx: number, fy: number): number {
     const x0 = Math.floor(fx)
     const y0 = Math.floor(fy)
     const tx = fx - x0
     const ty = fy - y0
-    const cx0 = Math.max(0, Math.min(LW - 1, x0))
+    const cx0 = wrapCol(x0)
     const cy0 = Math.max(0, Math.min(LH - 1, y0))
-    const cx1 = Math.min(LW - 1, cx0 + 1)
+    const cx1 = wrapCol(cx0 + 1)
     const cy1 = Math.min(LH - 1, cy0 + 1)
     const l = this.light
     const a = l[cy0 * LW + cx0]
@@ -716,26 +883,34 @@ export class Renderer {
   }
 
   private drawHeatmap(heatmap: Float32Array, vx: number, vw: number): void {
+    // Only ever drawn on the un-offset pass: it is a full-column wash rather
+    // than a sprite, so it has nothing hanging over the seam to duplicate.
+    if (this.drawOffset !== 0) return
+
     // Find the peak value over visible tiles for normalization.
     let peak = 0
-    for (let x = vx; x < vx + vw; x++) {
-      for (let y = 0; y < WORLD_H; y++) {
-        const v = heatmap[y * WORLD_W + x]
-        if (v > peak) peak = v
+    this.forEachSpan(vx, vw, (x0, width) => {
+      for (let x = x0; x < x0 + width; x++) {
+        for (let y = 0; y < WORLD_H; y++) {
+          const v = heatmap[y * WORLD_W + x]
+          if (v > peak) peak = v
+        }
       }
-    }
+    })
     if (peak < 0.5) return
 
     const ctx = this.wctx
-    for (let x = vx; x < vx + vw; x++) {
-      for (let y = 0; y < WORLD_H; y++) {
-        const v = heatmap[y * WORLD_W + x]
-        if (v < 0.5) continue
-        ctx.globalAlpha = Math.min(0.5, v / peak)
-        ctx.fillStyle = '#ff3200'
-        ctx.fillRect(x, y, 1, 1)
+    this.forEachSpan(vx, vw, (x0, width) => {
+      for (let x = x0; x < x0 + width; x++) {
+        for (let y = 0; y < WORLD_H; y++) {
+          const v = heatmap[y * WORLD_W + x]
+          if (v < 0.5) continue
+          ctx.globalAlpha = Math.min(0.5, v / peak)
+          ctx.fillStyle = '#ff3200'
+          ctx.fillRect(x, y, 1, 1)
+        }
       }
-    }
+    })
     ctx.globalAlpha = 1
   }
 
@@ -745,11 +920,11 @@ export class Renderer {
    * Drawn as a small dark mound with a black entrance hole. Fades in as the
    * nest is built and fades out when it begins to decay.
    */
-  private drawNests(w: WorldState, vx: number, vw: number): void {
+  private drawNests(w: WorldState): void {
     if (!w.nests?.length) return
     const ctx = this.wctx
     for (const nest of w.nests) {
-      if (nest.x + 3 < vx || nest.x - 3 > vx + vw) continue
+      if (!this.onScreen(nest.x - 3, 6)) continue
       const x = Math.round(nest.x)
       const y = Math.round(nest.y)
       // Fade in during construction; fade out when abandoned (last 10 s of decay).
@@ -767,12 +942,12 @@ export class Renderer {
     ctx.globalAlpha = 1
   }
 
-  private drawCarcasses(w: WorldState, vx: number, vw: number): void {
+  private drawCarcasses(w: WorldState): void {
     if (w.carcasses.length === 0) return
     const ctx = this.wctx
     ctx.fillStyle = '#5a2e10'
     for (const car of w.carcasses) {
-      if (car.x + 1 < vx || car.x > vx + vw) continue
+      if (!this.onScreen(car.x - 1, 2)) continue
       // Fade out during the last 3 seconds of decay.
       ctx.globalAlpha = Math.min(1, car.decaySeconds / 3) * 0.8
       ctx.fillRect(car.x - 0.75, car.y - 0.75, 1.5, 1.5)
@@ -784,7 +959,7 @@ export class Renderer {
    * Orbiting pollen motes around creatures with a plant-helping aura.
    * Drawn on the world canvas so they scale with zoom like everything else.
    */
-  private drawPollinatorAuras(w: WorldState, vx: number, vw: number): void {
+  private drawPollinatorAuras(w: WorldState): void {
     const ctx = this.wctx
     for (const c of w.creatures) {
       const bp = w.blueprints[c.blueprintId]
@@ -793,7 +968,7 @@ export class Renderer {
       const rows = bp.art.frames[0]
       const bw = rows[0].length
       const bh = rows.length
-      if (c.x + bw < vx || c.x > vx + vw) continue
+      if (!this.onScreen(c.x, bw)) continue
 
       const cx = c.x + bw / 2
       const cy = c.y + bh / 2
@@ -829,7 +1004,7 @@ export class Renderer {
    * scaled up with everything else. Names are drawn separately on the display
    * canvas so they stay legible at any zoom.
    */
-  private drawTombstones(w: WorldState, vx: number, vw: number): void {
+  private drawTombstones(w: WorldState): void {
     if (!w.tombstones || w.tombstones.length === 0) return
     const ctx = this.wctx
     ctx.fillStyle = '#9a8878'
@@ -838,7 +1013,7 @@ export class Renderer {
     for (const tomb of w.tombstones) {
       const cx = Math.round(tomb.x)
       const cy = Math.round(tomb.y)
-      if (cx + 2 < vx || cx - 2 > vx + vw) continue
+      if (!this.onScreen(cx - 2, 4)) continue
 
       // Headstone shape: 1-wide cap, then 3-wide body rising upward from centre.
       //  .█.   cy-4
@@ -856,7 +1031,7 @@ export class Renderer {
    * Name tags for tombstones, drawn on the display canvas so they stay
    * legible regardless of zoom — same approach as drawNameLabels.
    */
-  private drawTombstoneLabels(w: WorldState, vx: number, vw: number): void {
+  private drawTombstoneLabels(w: WorldState): void {
     if (!w.tombstones || w.tombstones.length === 0) return
 
     const ctx = this.ctx
@@ -870,10 +1045,10 @@ export class Renderer {
     ctx.textBaseline = 'bottom'
 
     for (const tomb of w.tombstones) {
-      if (tomb.x + 2 < vx || tomb.x - 2 > vx + vw) continue
+      if (!this.onScreen(tomb.x - 2, 4)) continue
 
       // Position: above the headstone top (cy-4 in world coords, then convert).
-      const dx = (tomb.x - vx) * scale + offsetX
+      const dx = this.intoView(tomb.x) * scale + offsetX
       const dy = (tomb.y - 5 - viewTop) * scale + offsetY
 
       // Dim shadow + muted warm-gray text (more memorial than the white creature labels).
@@ -887,14 +1062,14 @@ export class Renderer {
     ctx.textBaseline = 'alphabetic'
   }
 
-  private drawEggs(w: WorldState, vx: number, vw: number): void {
+  private drawEggs(w: WorldState): void {
     if (!w.eggs?.length) return
     const ctx = this.wctx
     ctx.strokeStyle = '#f5e642'
     ctx.lineWidth = 1
     for (const egg of w.eggs) {
       if (egg.hatchIn <= 0) continue
-      if (egg.x + 2 < vx || egg.x - 2 > vx + vw) continue
+      if (!this.onScreen(egg.x - 2, 4)) continue
       const rx = 1.5
       const ry = 2
       ctx.beginPath()
@@ -903,7 +1078,7 @@ export class Renderer {
     }
   }
 
-  private drawCreatures(w: WorldState, vx: number, vw: number): void {
+  private drawCreatures(w: WorldState): void {
     const ctx = this.wctx
     const traitKey = useMicroLand.getState().traitOverlay
     const trailsEnabled = useMicroLand.getState().trailsEnabled
@@ -932,7 +1107,7 @@ export class Renderer {
       for (const c of w.creatures) {
         const trail = trailMap.get(c.id)
         if (!trail || trail.length < 2) continue
-        if (c.x + 4 < vx || c.x > vx + vw) continue  // rough cull
+        if (!this.onScreen(c.x, 4)) continue  // rough cull
         const hue = c.traits.hue ?? 0
         ctx.fillStyle = `hsl(${hue}, 55%, 68%)`
         for (const pt of trail) {
@@ -957,7 +1132,7 @@ export class Renderer {
       // Most of the population is off screen in a world this wide. Culling here
       // is what keeps the draw cost tied to what you can see rather than to how
       // many things happen to be alive.
-      if (c.x + sprites.width < vx || c.x > vx + vw) continue
+      if (!this.onScreen(c.x, sprites.width)) continue
       const frameCount = sprites.frames.length
       const frame = frameCount === 1 ? 0 : Math.floor(c.animMs / sprites.frameMs) % frameCount
       const source =
@@ -1023,7 +1198,7 @@ export class Renderer {
    * Multiple effects stack left-to-right. The dots sit above the top edge of
    * the sprite so they never overlap the creature body.
    */
-  private drawStatusDots(w: WorldState, vx: number, vw: number): void {
+  private drawStatusDots(w: WorldState): void {
     const ctx = this.wctx
     const DOT = 3
     const GAP = 1
@@ -1031,7 +1206,7 @@ export class Renderer {
     for (const c of w.creatures) {
       const bp = w.blueprints[c.blueprintId]
       if (!bp) continue
-      if (c.x + 8 < vx || c.x - 8 > vx + vw) continue
+      if (!this.onScreen(c.x - 8, 16)) continue
 
       const dots: string[] = []
       if ((c as { sick?: number }).sick) dots.push('#a855f7')
@@ -1130,10 +1305,10 @@ export class Renderer {
     ctx.globalAlpha = 1
   }
 
-  private drawParticles(w: WorldState, vx: number, vw: number): void {
+  private drawParticles(w: WorldState): void {
     const ctx = this.wctx
     for (const p of w.particles) {
-      if (p.x < vx || p.x > vx + vw) continue
+      if (!this.onScreen(p.x, 1)) continue
       ctx.globalAlpha = Math.max(0, Math.min(1, p.life / p.maxLife))
       ctx.fillStyle = p.color
       ctx.fillRect(Math.round(p.x), Math.round(p.y), 1, 1)
@@ -1187,20 +1362,38 @@ export class Renderer {
     ctx.drawImage(this.mapCanvas, 0, 0, MW, MH, x, y, width, height)
     ctx.globalAlpha = 1
 
-    // The view, marked. Kept at least a couple of pixels each way so it can't
-    // vanish on a narrow screen — or, zoomed right in, collapse to a line.
-    const vxPx = x + Math.round((vx / WORLD_W) * width)
+    /**
+     * The view, marked — in two pieces when it straddles the seam.
+     *
+     * The minimap has to cut the cylinder somewhere, and it cuts it at column
+     * zero. A camera sitting on that cut is genuinely at both ends of the
+     * thumbnail at once, so it is drawn as a box running off the right edge and
+     * a second one coming back in at the left. One clamped box instead would
+     * either jump the whole width of the map as you panned past the seam or sit
+     * there claiming the camera was somewhere it is not.
+     */
     const vwPx = Math.max(3, Math.round((this.viewTiles / WORLD_W) * width))
     const vyPx = y + Math.round((this.viewTop() / WORLD_H) * height)
     const vhPx = Math.max(3, Math.round((this.viewRows / WORLD_H) * height))
     ctx.strokeStyle = '#5eead4'
     ctx.lineWidth = Math.max(1, Math.round(width / 220))
-    ctx.strokeRect(
-      vxPx + ctx.lineWidth / 2,
-      vyPx + ctx.lineWidth / 2,
-      Math.min(vwPx, width - (vxPx - x)) - ctx.lineWidth,
-      Math.min(vhPx, height - (vyPx - y)) - ctx.lineWidth
-    )
+    const boxH = Math.min(vhPx, height - (vyPx - y)) - ctx.lineWidth
+    const startPx = Math.round((vx / WORLD_W) * width)
+    const headPx = Math.min(vwPx, width - startPx)
+    for (const [offPx, wPx] of headPx < vwPx
+      ? [
+          [startPx, headPx],
+          [0, vwPx - headPx],
+        ]
+      : [[startPx, headPx]]) {
+      if (wPx <= 0) continue
+      ctx.strokeRect(
+        x + offPx + ctx.lineWidth / 2,
+        vyPx + ctx.lineWidth / 2,
+        wPx - ctx.lineWidth,
+        boxH
+      )
+    }
 
     ctx.strokeStyle = 'rgba(94, 234, 212, 0.35)'
     ctx.lineWidth = border
@@ -1215,7 +1408,7 @@ export class Renderer {
    * regardless of zoom. Only named creatures get a tag, which keeps the world
    * uncluttered — a name is notable, not a default label.
    */
-  private drawNameLabels(w: WorldState, vx: number, vw: number, elderId: number | null): void {
+  private drawNameLabels(w: WorldState, elderId: number | null): void {
     const elder = elderId !== null ? w.creatures.find(x => x.id === elderId) ?? null : null
     const namedCreatures = w.creatures.filter(c => c.name !== null)
     const showUnnamed = elder !== null && elder.name === null
@@ -1235,11 +1428,11 @@ export class Renderer {
     for (const c of namedCreatures) {
       const bp = w.blueprints[c.blueprintId]
       if (!bp) continue
-      if (c.x + bp.art.frames[0][0].length < vx || c.x > vx + vw) continue
+      if (!this.onScreen(c.x, bp.art.frames[0][0].length)) continue
 
       const rows = bp.art.frames[0]
       const bw = rows[0].length
-      const dx = (c.x + bw / 2 - vx) * scale + offsetX
+      const dx = this.intoView(c.x + bw / 2) * scale + offsetX
       const dy = (c.y - viewTop) * scale + offsetY - 3
 
       ctx.fillStyle = 'rgba(0,0,0,0.7)'
@@ -1251,9 +1444,9 @@ export class Renderer {
     // Unnamed elder: dim placeholder so the player knows it can be named.
     if (showUnnamed && elder) {
       const bp = w.blueprints[elder.blueprintId]
-      if (bp && !(elder.x + bp.art.frames[0][0].length < vx || elder.x > vx + vw)) {
+      if (bp && this.onScreen(elder.x, bp.art.frames[0][0].length)) {
         const bw = bp.art.frames[0][0].length
-        const dx = (elder.x + bw / 2 - vx) * scale + offsetX
+        const dx = this.intoView(elder.x + bw / 2) * scale + offsetX
         const dy = (elder.y - viewTop) * scale + offsetY - 3
         ctx.fillStyle = 'rgba(255,255,255,0.3)'
         ctx.fillText('unnamed', dx, dy)


### PR DESCRIPTION
Walk off the right edge and you come back on the left. Top and bottom are still walls — a wrapped ceiling in a falling-sand world rains powder out of the sky forever.

The one-line version is real (`integrate` wrapping x instead of clamping it is what makes a creature cross the seam), but the assumption that x=0 is the left end turned out to be baked into four layers.

## What's in it

**Bounds.** New `domain/wrap.ts`. Tile access wraps x, keeps y a hard wall. The invariant holding it together: every stored x is already wrapped, because `deltaX` corrects by at most one world width.

**Distance.** ~15 x-deltas take the short way round. The failure they avoid isn't a crash — a creature that can *see* across the seam but walks six hundred tiles the long way there reads as bad AI, not as a wrap bug. Same trap catches midpoints: half of `a + b` is the far side of the world from both parents when they meet across the seam.

The sense pass keeps its optimisation. A sight window was one contiguous slice of the x-sorted population and is now two — but only for creatures within about a sight radius of column zero.

**Renderer.** The largest part, and invisible in a diffstat. The backbuffer is a world wider than the world: rather than splitting the frame into two of everything, the head is copied into the overhang once per frame and the blit stays one contiguous read. Content draws twice, at offset `0` and `-WORLD_W`, so a creature on the seam is one animal rather than two halves with a gap. The light field moved to whole-world (a windowed version needed two-range variants of the gather, blur *and* bilinear sample to save a 168×33 field); the shadow bake, the only part that ever showed up in a frame budget, is still clipped.

**Terrain.** The part that would have given the whole thing away. A heightmap walked from x=0 to x=671 has no reason to arrive back where it started — skylands stepped **28 rows** at column zero against a typical step of 2, candy 16, mushroom-forest 14. Every generator now samples around a **ring**, which closes by construction. A circle uses two dimensions, so anything varying with depth needed a third; hence `makeNoise3D`.

Six edge guards leave `tile-sim`, so liquids flow around the world — a behaviour change, not just plumbing: those walls were holding every pond and lava seam in place at both ends of every theme.

## Verification

Harness on the same seeds, four themes, 600s × 5 runs, before and after:

| theme | low-water before → after | verdict |
|---|---|---|
| earth | 272 → 274 | ✓ still alive |
| tidepool | 195 → 197 | ✓ still alive |
| volcanic | 109 → 111 | ✓ still alive |
| station | 164 → 157 | ✓ still alive |

Flat. Station shows two more extinctions (`drifter-jelly`, `wisp`) — both already dying in 4 runs of 5 at avg 0.2. Nothing ecological moved, which is the right outcome: this was not meant to be a balance change and isn't one.

`typecheck`, `lint` and `test` are all byte-identical to `main`, which was already red on all three (11 type errors, 65 lint errors, 4 failing tests). Those are untouched, separate work. Build compiles. Manually tested in the browser.

New `world-wrap.test.ts` measures each theme's surface jump at column zero against its own roughness — that test is what caught the numbers above.

## Worth knowing

**Every theme generates a different world from the same seed.** Ring sampling isn't the same function as line sampling. Saved worlds on the shelf store tiles rather than seeds and are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)