### PR TITLE
fix(micro-land): wrap HUD items on narrow/mobile screens

### DIFF
--- a/src/app/micro-land/components/hud.tsx
+++ b/src/app/micro-land/components/hud.tsx
@@ -207,11 +207,10 @@ export function Hud({
 
   return (
     <header
-      className="flex items-center gap-2 px-3 py-2 pl-14"
+      className="flex flex-wrap items-center gap-2 px-3 py-2 pl-14"
       style={{
         borderBottom: '1px solid var(--cc-panel-divider)',
         background: 'linear-gradient(180deg, var(--cc-panel-grad-from), transparent)',
-        overflow: 'hidden',
       }}
     >
       <h1


### PR DESCRIPTION
## Summary
- Adds `flex-wrap` to the HUD header so buttons wrap to a second line instead of overflowing off-screen on mobile
- Removes `overflow: hidden` from the header — the overflow menu already uses `position: fixed` so the clip is no longer needed, and it was also what prevented wrapping from working

## Test plan
- [ ] On a narrow viewport (375px), HUD items wrap to a second row rather than clipping
- [ ] Overflow ··· menu still opens correctly (not clipped by header)
- [ ] On desktop nothing changes visually

Closes #3506

🤖 Generated with [Claude Code](https://claude.com/claude-code)