### PR TITLE
feat(micro-land): one column for every panel

### DIFF
--- a/src/app/micro-land/MicroLandGame.tsx
+++ b/src/app/micro-land/MicroLandGame.tsx
@@ -9,21 +9,16 @@ import {
   initChronicle,
   onSaveState,
 } from '@/app/micro-land/chronicle/chronicle'
-import { BlueprintWorkshop } from '@/app/micro-land/components/blueprint-workshop'
-import { ChallengesPanel } from '@/app/micro-land/components/challenges-panel'
 import { SpeedRunOverlay } from '@/app/micro-land/components/speed-run-overlay'
 import { CreatureBuilder } from '@/app/micro-land/components/creature-builder'
 import { ReplayBar } from '@/app/micro-land/components/replay-bar'
-import { FieldGuide } from '@/app/micro-land/components/field-guide'
 import { Hud } from '@/app/micro-land/components/hud'
 import { Inspector } from '@/app/micro-land/components/inspector'
 import { Notices } from '@/app/micro-land/components/notices'
 import { PanControls } from '@/app/micro-land/components/pan-controls'
-import { HistoryPanel } from '@/app/micro-land/components/history-panel'
-import { SettingsPanel } from '@/app/micro-land/components/settings-panel'
+import { Sidebar } from '@/app/micro-land/components/sidebar'
 import { SummonPanel } from '@/app/micro-land/components/summon-panel'
 import { Toolbar } from '@/app/micro-land/components/toolbar'
-import { WorldsPanel } from '@/app/micro-land/components/worlds-panel'
 import { ZoomControls } from '@/app/micro-land/components/zoom-controls'
 import { THEME_BY_ID } from '@/app/micro-land/domain/config/themes'
 import { hasFertileGround } from '@/app/micro-land/domain/terrain'
@@ -53,7 +48,6 @@ export function MicroLandGame() {
   const canvasRef = useRef<HTMLCanvasElement>(null)
   const gameRef = useRef<GameInstance | null>(null)
   const notify = useMicroLand(s => s.notify)
-  const guideOpen = useMicroLand(s => s.guideOpen)
   const { user } = useAuth()
 
   /**
@@ -305,14 +299,14 @@ export function MicroLandGame() {
     useMicroLand.getState().enterReplay(snapshots)
   }, [])
 
-  const handleReshuffle = useCallback(() => {
-    gameRef.current?.reshuffle()
-    notify('The ground shifts and settles somewhere new.')
-  }, [notify])
-
   const handleClearLife = useCallback(() => {
     gameRef.current?.clearLife()
     notify('Everything living is gone. The land waits.')
+  }, [notify])
+
+  const handleClearWorld = useCallback(() => {
+    gameRef.current?.clearWorld()
+    notify('The land is gone too. Nothing but sky.')
   }, [notify])
 
   const handleIntroduce = useCallback((raw: unknown, count: number) => {
@@ -368,33 +362,31 @@ export function MicroLandGame() {
           store.setTool({ kind: 'inspect' })
           break
         case 'f':
-          store.setGuideOpen(!store.guideOpen)
+          store.toggleSidebar('guide')
           break
         case 'l':
-          store.setHistoryOpen(!store.historyOpen)
+          store.toggleSidebar('log')
           break
         case 's':
-          store.setSettingsOpen(!store.settingsOpen)
+          store.toggleSidebar('settings')
           break
         case 'w':
-          store.setWorldsOpen(!store.worldsOpen)
+          store.toggleSidebar('worlds')
           break
         case 'b':
-          store.setBuilderOpen(!store.builderOpen)
+          store.setCreaturesTab('draw')
+          store.toggleSidebar('creatures')
           break
         case 'c':
-          store.setChallengesOpen(!store.challengesOpen)
+          store.toggleSidebar('challenges')
           break
         case 'Escape':
           // Close whichever panel is open, in priority order (most modal first).
+          // The sidebar goes last: it sits beside the world rather than over it,
+          // so it is the least likely thing anyone is trying to get out of.
           if (store.summonOpen) { store.setSummonOpen(false); break }
           if (store.builderOpen) { store.setBuilderOpen(false); break }
-          if (store.workshopOpen) { store.setWorkshopOpen(false); break }
-          if (store.challengesOpen) { store.setChallengesOpen(false); break }
-          if (store.worldsOpen) { store.setWorldsOpen(false); break }
-          if (store.settingsOpen) { store.setSettingsOpen(false); break }
-          if (store.historyOpen) { store.setHistoryOpen(false); break }
-          if (store.guideOpen) { store.setGuideOpen(false); break }
+          if (store.sidebar) { store.setSidebar(null); break }
           break
         case '+':
         case '=':
@@ -417,12 +409,12 @@ export function MicroLandGame() {
 
   return (
     <div className="micro-land-shell flex h-full w-full flex-col overflow-hidden">
-      <Hud onReshuffle={handleReshuffle} onClearLife={handleClearLife} onOpenHistory={handleOpenHistory} />
+      <Hud onOpenHistory={handleOpenHistory} />
 
-      {/* Two-column layout: world column (canvas + toolbar) | field guide column.
-          The toolbar stays anchored at the bottom of the world column whether
-          the guide is open or closed. The divider between columns is draggable
-          (handled by FieldGuide's internal resize logic). */}
+      {/* Two-column layout: world column (canvas + toolbar) | sidebar column.
+          The toolbar stays anchored at the bottom of the world column whether a
+          panel is open or closed. The divider between columns is draggable
+          (handled by the sidebar's own resize logic). */}
       <div className="flex min-h-0 flex-1 overflow-hidden">
         {/* World column: canvas fills remaining space, toolbar always at bottom */}
         <div className="flex min-w-0 flex-1 flex-col overflow-hidden">
@@ -443,18 +435,19 @@ export function MicroLandGame() {
           </div>
           <Toolbar onRemoveSpecies={handleRemoveSpecies} />
         </div>
-        {/* Field guide column — renders null when closed */}
-        <FieldGuide />
+        {/* Sidebar column — renders null when nothing is open */}
+        <Sidebar
+          onKeep={handleKeepWorld}
+          onOpenWorld={handleOpenWorld}
+          onForget={handleForgetWorld}
+          onClearLife={handleClearLife}
+          onClearWorld={handleClearWorld}
+        />
       </div>
 
       <SummonPanel onIntroduce={handleIntroduce} onApplyTerrain={handleApplyTerrain} />
-      <WorldsPanel onKeep={handleKeepWorld} onOpen={handleOpenWorld} onForget={handleForgetWorld} />
-      <ChallengesPanel />
-      <BlueprintWorkshop />
       <SpeedRunOverlay />
       <CreatureBuilder onIntroduce={handleIntroduce} onRevise={handleRevise} />
-      <SettingsPanel />
-      <HistoryPanel />
       <ReplayBar />
     </div>
   )

--- a/src/app/micro-land/components/blueprint-workshop.tsx
+++ b/src/app/micro-land/components/blueprint-workshop.tsx
@@ -39,11 +39,15 @@ function defaultTraits(): Traits {
   }
 }
 
-/** The workshop content, usable both inline (inside the Field Guide) and inside the modal wrapper. */
-export function WorkshopPane({ onClose }: { onClose: () => void }) {
+/**
+ * Build a creature out of one already here: pick a base, then move its numbers.
+ *
+ * Lives inside the creatures panel, which owns the tab row and the way out — so
+ * this is only ever the middle of a column and has no chrome of its own.
+ */
+export function WorkshopPane() {
   const blueprints = useMicroLand(s => s.blueprints)
   const requestWorkshopSpawn = useMicroLand(s => s.requestWorkshopSpawn)
-  const setBuilderOpen = useMicroLand(s => s.setBuilderOpen)
 
   const [step, setStep] = useState<'pick' | 'configure'>('pick')
   const [base, setBase] = useState<CreatureBlueprint | null>(null)
@@ -92,8 +96,11 @@ export function WorkshopPane({ onClose }: { onClose: () => void }) {
     }
     const finalTraits: Traits = { ...traits, hue, shade }
     requestWorkshopSpawn(finalBlueprint, finalTraits)
-    onClose()
+    // Back to the top of the panel rather than closing it. The creature is
+    // already in the world, and the thing anyone does after making one is make
+    // another.
     setStep('pick')
+    setBase(null)
   }
 
   const chipBase = {
@@ -109,31 +116,7 @@ export function WorkshopPane({ onClose }: { onClose: () => void }) {
 
   return (
     <div style={{ padding: '16px 16px 20px' }}>
-      {/* Tab row + header */}
       <div style={{ marginBottom: 16 }}>
-        <div style={{ display: 'flex', alignItems: 'center', gap: 4, marginBottom: 12 }}>
-          <span style={{
-            fontFamily: 'var(--cc-font-mono)', fontSize: 10, letterSpacing: 1.2,
-            textTransform: 'uppercase', padding: '3px 10px', borderRadius: 4,
-            border: '1px solid var(--cc-mint)', color: 'var(--cc-mint)',
-            background: 'rgba(100,220,200,0.08)',
-          }}>
-            Configure
-          </span>
-          <button
-            type="button"
-            className="cc-btn"
-            onClick={() => { setBuilderOpen(true); onClose() }}
-            style={{
-              ...chipBase,
-              border: '1px solid var(--cc-panel-divider)',
-              color: 'var(--cc-text-muted)',
-            }}
-            title="Switch to the pixel drawing tool"
-          >
-            ✎ Draw
-          </button>
-        </div>
         <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
           <h2 style={{
             fontFamily: 'var(--cc-font-mono)', fontSize: 11,
@@ -186,9 +169,17 @@ export function WorkshopPane({ onClose }: { onClose: () => void }) {
                 </div>
               </button>
             ))}
+            {/*
+              Only ever true for the first frames of a session. The roster is
+              seeded with every built-in the moment the world is created, so
+              there is no state a player can reach where this list is genuinely
+              empty — it just has not been pushed into the store yet. The old
+              copy here said "place some creatures first", which sent whoever
+              read it off to do something that would not have helped.
+            */}
             {displayList.length === 0 && (
               <p style={{ fontSize: 12, color: 'var(--cc-text-muted)' }}>
-                No species in the world yet. Place some creatures first.
+                The roster is still waking up…
               </p>
             )}
           </div>
@@ -362,7 +353,7 @@ export function WorkshopPane({ onClose }: { onClose: () => void }) {
             <button
               type="button"
               className="cc-btn"
-              onClick={onClose}
+              onClick={() => { setStep('pick'); setBase(null) }}
               style={{
                 ...chipBase,
                 border: '1px solid var(--cc-panel-divider)',
@@ -388,58 +379,6 @@ export function WorkshopPane({ onClose }: { onClose: () => void }) {
         </>
       )}
 
-      {step === 'pick' && (
-        <button
-          type="button"
-          className="cc-btn"
-          onClick={onClose}
-          style={{
-            marginTop: 14,
-            ...chipBase,
-            border: '1px solid var(--cc-panel-divider)',
-            color: 'var(--cc-text-muted)',
-          }}
-        >
-          Close
-        </button>
-      )}
-    </div>
-  )
-}
-
-export function BlueprintWorkshop() {
-  const open = useMicroLand(s => s.workshopOpen)
-  const setWorkshopOpen = useMicroLand(s => s.setWorkshopOpen)
-
-  if (!open) return null
-
-  return (
-    <div
-      style={{
-        position: 'fixed', inset: 0, zIndex: 50,
-        background: 'rgba(0,0,0,0.7)',
-        display: 'flex', alignItems: 'center', justifyContent: 'center',
-        overflowY: 'auto',
-      }}
-      onClick={() => setWorkshopOpen(false)}
-    >
-      <div
-        role="dialog"
-        aria-modal="true"
-        aria-label="Blueprint Workshop"
-        style={{
-          background: 'var(--cc-panel-bg)',
-          border: '1px solid var(--cc-panel-divider)',
-          borderRadius: 8,
-          maxWidth: 460,
-          width: '90vw',
-          maxHeight: '85vh',
-          overflowY: 'auto',
-        }}
-        onClick={e => e.stopPropagation()}
-      >
-        <WorkshopPane onClose={() => setWorkshopOpen(false)} />
-      </div>
     </div>
   )
 }

--- a/src/app/micro-land/components/challenges-panel.tsx
+++ b/src/app/micro-land/components/challenges-panel.tsx
@@ -9,11 +9,15 @@ import { formatDuration } from '@/app/micro-land/format'
 const ADAPTIVE_INITIAL_TARGET = 10
 
 /**
- * The challenges content — usable both inside the field guide sidebar
- * (where `onClose` returns to the guide view) and inside the standalone
- * modal (`ChallengesPanel`).
+ * Ways to make the land harder, in the shared right-hand column.
+ *
+ * Every one of these ends by closing the panel. A challenge is a change to the
+ * world — new ground, new numbers, a clock started — and the thing you want to
+ * be looking at the moment you start one is the world, not the list you started
+ * it from.
  */
-export function ChallengesPane({ onClose }: { onClose: () => void }) {
+export function ChallengesPane() {
+  const setSidebar = useMicroLand(s => s.setSidebar)
   const setChallengeActive = useMicroLand(s => s.setChallengeActive)
   const requestReshuffle = useMicroLand(s => s.requestReshuffle)
   const startAdaptiveRun = useMicroLand(s => s.startAdaptiveRun)
@@ -32,23 +36,11 @@ export function ChallengesPane({ onClose }: { onClose: () => void }) {
     setTuning(preset.tuning)
     setChallengeActive({ name: preset.name, goal: preset.goal })
     requestReshuffle()
-    onClose()
+    setSidebar(null)
   }
 
   return (
     <div style={{ padding: '16px 16px 20px' }}>
-      <h2
-        style={{
-          fontFamily: 'var(--cc-font-mono)',
-          fontSize: 11,
-          letterSpacing: 1.6,
-          textTransform: 'uppercase',
-          color: 'var(--cc-text-muted)',
-          marginBottom: 16,
-        }}
-      >
-        Challenges
-      </h2>
       <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
         {CHALLENGES.map(c => (
           <button
@@ -145,7 +137,7 @@ export function ChallengesPane({ onClose }: { onClose: () => void }) {
           onClick={() => {
             startSpeedRun(targetGen, timeLimitOptions[timeLimitIdx].seconds, elapsed)
             setRecordsEpoch(e => e + 1)
-            onClose()
+            setSidebar(null)
           }}
           style={{
             fontFamily: 'var(--cc-font-mono)', fontSize: 10, letterSpacing: 1.2,
@@ -202,7 +194,7 @@ export function ChallengesPane({ onClose }: { onClose: () => void }) {
           className="cc-btn"
           onClick={() => {
             startAdaptiveRun(ADAPTIVE_INITIAL_TARGET)
-            onClose()
+            setSidebar(null)
           }}
           style={{
             fontFamily: 'var(--cc-font-mono)', fontSize: 10, letterSpacing: 1.2,
@@ -216,61 +208,6 @@ export function ChallengesPane({ onClose }: { onClose: () => void }) {
         </button>
       </div>
 
-      <button
-        type="button"
-        className="cc-btn"
-        onClick={onClose}
-        style={{
-          marginTop: 14,
-          fontFamily: 'var(--cc-font-mono)',
-          fontSize: 9,
-          letterSpacing: 1,
-          textTransform: 'uppercase',
-          padding: '4px 10px',
-          border: '1px solid var(--cc-panel-divider)',
-          color: 'var(--cc-text-muted)',
-        }}
-      >
-        Close
-      </button>
-    </div>
-  )
-}
-
-/** Standalone modal — opens from the Challenges keyboard shortcut or the toolbar. */
-export function ChallengesPanel() {
-  const open = useMicroLand(s => s.challengesOpen)
-  const setChallengesOpen = useMicroLand(s => s.setChallengesOpen)
-
-  if (!open) return null
-
-  return (
-    <div
-      style={{
-        position: 'fixed',
-        inset: 0,
-        zIndex: 50,
-        background: 'rgba(0,0,0,0.7)',
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'center',
-      }}
-      onClick={() => setChallengesOpen(false)}
-    >
-      <div
-        style={{
-          background: 'var(--cc-panel-bg)',
-          border: '1px solid var(--cc-panel-divider)',
-          borderRadius: 8,
-          maxWidth: 420,
-          width: '90vw',
-          overflowY: 'auto',
-          maxHeight: '90vh',
-        }}
-        onClick={e => e.stopPropagation()}
-      >
-        <ChallengesPane onClose={() => setChallengesOpen(false)} />
-      </div>
     </div>
   )
 }

--- a/src/app/micro-land/components/creature-builder.tsx
+++ b/src/app/micro-land/components/creature-builder.tsx
@@ -127,7 +127,8 @@ export function CreatureBuilder({
   const blueprints = useMicroLand(s => s.blueprints)
   const setTool = useMicroLand(s => s.setTool)
   const notify = useMicroLand(s => s.notify)
-  const setWorkshopOpen = useMicroLand(s => s.setWorkshopOpen)
+  const setSidebar = useMicroLand(s => s.setSidebar)
+  const setCreaturesTab = useMicroLand(s => s.setCreaturesTab)
 
   const [draft, setDraft] = useState<Draft | null>(null)
   const [seed, setSeed] = useState<CreatureBlueprint | null>(null)
@@ -471,7 +472,8 @@ export function CreatureBuilder({
               className="cc-btn"
               onClick={() => {
                 abortRef.current?.abort()
-                setWorkshopOpen(true)
+                setCreaturesTab('blueprints')
+                setSidebar('creatures')
                 setOpen(false)
               }}
               style={{

--- a/src/app/micro-land/components/field-guide.tsx
+++ b/src/app/micro-land/components/field-guide.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useRef, useCallback } from 'react'
+import { useState } from 'react'
 
 import type { ElderRecord, SpeciesRecord } from '@/app/micro-land/chronicle/types'
 import { canEat, isPlantLike, moveWord, sanitizeBlueprint } from '@/app/micro-land/domain/blueprint'
@@ -10,8 +10,6 @@ import { useMicroLand, type PopulationSnapshot, type TraitHistoryEntry } from '@
 
 import { CreaturePortrait } from './creature-chip'
 import { SparkleIcon } from './sparkle-icon'
-import { WorkshopPane } from './blueprint-workshop'
-import { ChallengesPane } from './challenges-panel'
 
 const sectionHeading: React.CSSProperties = {
   fontFamily: 'var(--cc-font-mono)',
@@ -56,10 +54,13 @@ const recordCell: React.CSSProperties = {
  * rather than anywhere on the main screen. That is deliberate: the world stays a
  * world, and everything the game has been quietly counting is one tap away for
  * whoever wants it.
+ *
+ * Nothing else hangs off it. The guide used to carry the workshop and the
+ * challenges behind two tabs in its own header, which made "look something up"
+ * and "make something new" the same door — those live in the main menu now, and
+ * the guide is only ever a guide.
  */
-export function FieldGuide() {
-  const open = useMicroLand(s => s.guideOpen)
-  const setOpen = useMicroLand(s => s.setGuideOpen)
+export function FieldGuidePane() {
   const blueprints = useMicroLand(s => s.blueprints)
   const population = useMicroLand(s => s.population)
   const records = useMicroLand(s => s.records)
@@ -88,41 +89,7 @@ export function FieldGuide() {
   const [compact, setCompact] = useState(() => {
     try { return localStorage.getItem('fg-compact') === '1' } catch { return false }
   })
-  const [guideWidth, setGuideWidth] = useState(() => {
-    try { return Number(localStorage.getItem('fg-width')) || 300 } catch { return 300 }
-  })
-  const isDragging = useRef(false)
-
-  const MIN_WIDTH = 240
-  const MAX_WIDTH = 600
-
-  const handleDragStart = useCallback((e: React.MouseEvent) => {
-    e.preventDefault()
-    isDragging.current = true
-    const onMove = (ev: MouseEvent) => {
-      if (!isDragging.current) return
-      setGuideWidth(prev => {
-        const next = Math.max(MIN_WIDTH, Math.min(MAX_WIDTH, prev - ev.movementX))
-        return next
-      })
-    }
-    const onUp = () => {
-      isDragging.current = false
-      document.removeEventListener('mousemove', onMove)
-      document.removeEventListener('mouseup', onUp)
-      setGuideWidth(prev => {
-        try { localStorage.setItem('fg-width', String(prev)) } catch {}
-        return prev
-      })
-    }
-    document.addEventListener('mousemove', onMove)
-    document.addEventListener('mouseup', onUp)
-  }, [])
-
-  const [view, setView] = useState<'guide' | 'workshop' | 'challenges'>('guide')
   const [compareTarget, setCompareTarget] = useState<string | null>(null)
-
-  if (!open) return null
 
   const counts = new Map(population.map(p => [p.blueprintId, p.count]))
   const genByBp = new Map(population.map(p => [p.blueprintId, p.maxGeneration]))
@@ -154,526 +121,397 @@ export function FieldGuide() {
   }
 
   return (
-    <aside
-      aria-label="Field guide"
-      style={{
-        width: guideWidth,
-        flexShrink: 0,
-        borderLeft: '1px solid var(--cc-panel-divider)',
-        background: 'linear-gradient(180deg, var(--cc-modal-bg-from), var(--cc-modal-bg-to))',
-        display: 'flex',
-        flexDirection: 'column',
-        overflow: 'hidden',
-        position: 'relative',
-      }}
-    >
-      {/* Drag handle — left edge of the guide */}
-      <div
-        aria-hidden
-        onMouseDown={handleDragStart}
-        style={{
-          position: 'absolute',
-          left: 0,
-          top: 0,
-          bottom: 0,
-          width: 5,
-          cursor: 'ew-resize',
-          zIndex: 1,
-          background: 'transparent',
-        }}
-      />
-      <div style={{ overflowY: 'auto', flex: 1 }}>
-        <div
-          className="sticky top-0 flex flex-col gap-1.5 px-3 py-2.5"
-          style={{
-            borderBottom: '1px solid var(--cc-panel-divider)',
-            background: 'var(--cc-modal-bg-from)',
-          }}
+    <>
+      {compareTarget !== null && compareId !== null && (
+        <ComparisonPanel
+          bpA={blueprints.find(b => b.id === compareId)!}
+          bpB={blueprints.find(b => b.id === compareTarget)!}
+          onDismiss={() => { setCompareTarget(null); setCompareId(null) }}
+        />
+      )}
+
+      {compareTarget === null && hasRecords && (
+        <section
+          className="flex flex-col gap-2.5 px-4 py-3"
+          style={{ borderBottom: '1px solid var(--cc-panel-divider)' }}
         >
-          {/* Title row + close */}
-          <div className="flex items-center justify-between">
-            <h2
-              style={{
-                fontFamily: 'var(--cc-font-mono)',
-                fontSize: 11,
-                letterSpacing: 2.5,
-                textTransform: 'uppercase',
-                color: 'var(--cc-mint)',
-              }}
-            >
-              Field Guide
-            </h2>
-            <button
-              type="button"
-              className="cc-btn"
-              onClick={() => setOpen(false)}
-              aria-label="Close field guide"
-              style={{ minWidth: 32, minHeight: 28, color: 'var(--cc-text-muted)' }}
-            >
-              ✕
-            </button>
-          </div>
-          {/* Action buttons row */}
-          <div className="flex flex-wrap gap-1">
-            <button
-              type="button"
-              className="cc-btn"
-              onClick={() => setView('workshop')}
-              style={{
-                fontFamily: 'var(--cc-font-mono)',
-                fontSize: 9,
-                letterSpacing: 1.2,
-                textTransform: 'uppercase',
-                padding: '3px 8px',
-                minHeight: 26,
-                borderRadius: 4,
-                border: '1px solid var(--cc-panel-divider)',
-                color: 'var(--cc-text-muted)',
-              }}
-            >
-              Workshop
-            </button>
-            <button
-              type="button"
-              className="cc-btn"
-              onClick={() => setView('challenges')}
-              style={{
-                fontFamily: 'var(--cc-font-mono)',
-                fontSize: 9,
-                letterSpacing: 1.2,
-                textTransform: 'uppercase',
-                padding: '3px 8px',
-                minHeight: 26,
-                borderRadius: 4,
-                border: '1px solid var(--cc-panel-divider)',
-                color: 'var(--cc-text-muted)',
-              }}
-            >
-              Challenges
-            </button>
-          </div>
-        </div>
+          <h3 style={sectionHeading}>This land&rsquo;s records</h3>
 
-        {view === 'workshop' && (
-          <WorkshopPane onClose={() => setView('guide')} />
-        )}
+          {/*
+            Two columns rather than one list, because one list is a plant
+            leaderboard. Nothing rooted is ever chased or ever has to find a
+            meal, so moss out-lives and out-breeds every animal in the world by
+            an order of magnitude and took both records on every land, every
+            session — leaving the creatures the player actually watches move
+            with nothing to win. Both columns show at all times, empty ones
+            included: an Animals column that only appeared once an animal had
+            earned something would hide the very thing worth chasing.
+          */}
+          <table style={{ width: '100%', borderCollapse: 'collapse', tableLayout: 'fixed' }}>
+            <thead>
+              <tr>
+                {/* Empty corner cell — the row labels below are the row headers. */}
+                <td />
+                <th scope="col" style={columnHeading}>
+                  Plants
+                </th>
+                <th scope="col" style={columnHeading}>
+                  Animals
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <th scope="row" style={{ ...recordLabel, textAlign: 'left', paddingRight: 8 }}>
+                  Longest life
+                </th>
+                {LIFE_KINDS.map(kind => (
+                  <td key={kind} style={recordCell}>
+                    <ElderCell elder={records.byKind[kind].elder} />
+                  </td>
+                ))}
+              </tr>
+              <tr>
+                <th scope="row" style={{ ...recordLabel, textAlign: 'left', paddingRight: 8 }}>
+                  Deepest family line
+                </th>
+                {LIFE_KINDS.map(kind => (
+                  <td key={kind} style={recordCell}>
+                    <LineCell
+                      generations={records.byKind[kind].bestGenerations}
+                      speciesName={records.byKind[kind].bestGenerationsSpeciesName}
+                    />
+                  </td>
+                ))}
+              </tr>
+            </tbody>
+          </table>
 
-        {view === 'challenges' && (
-          <ChallengesPane onClose={() => setView('guide')} />
-        )}
+          {records.bestSteadySeconds > 0 && (
+            <div className="flex flex-col gap-0.5">
+              <span style={recordLabel}>Longest without losing a kind</span>
+              <span style={{ fontSize: 13, color: 'var(--cc-text-default)' }}>
+                {formatDuration(records.bestSteadySeconds)}
+                {records.steadySeconds >= records.bestSteadySeconds &&
+                  records.steadySeconds > 0 && (
+                    <span style={{ color: 'var(--cc-gold)' }}> — going now</span>
+                  )}
+              </span>
+            </div>
+          )}
+        </section>
+      )}
 
-        {view === 'guide' && compareTarget !== null && compareId !== null && (
-          <ComparisonPanel
-            bpA={blueprints.find(b => b.id === compareId)!}
-            bpB={blueprints.find(b => b.id === compareTarget)!}
-            onDismiss={() => { setCompareTarget(null); setCompareId(null) }}
-          />
-        )}
+      {compareTarget === null && <>
 
-        {view === 'guide' && compareTarget === null && hasRecords && (
-          <section
-            className="flex flex-col gap-2.5 px-4 py-3"
-            style={{ borderBottom: '1px solid var(--cc-panel-divider)' }}
-          >
-            <h3 style={sectionHeading}>This land&rsquo;s records</h3>
-
-            {/*
-              Two columns rather than one list, because one list is a plant
-              leaderboard. Nothing rooted is ever chased or ever has to find a
-              meal, so moss out-lives and out-breeds every animal in the world by
-              an order of magnitude and took both records on every land, every
-              session — leaving the creatures the player actually watches move
-              with nothing to win. Both columns show at all times, empty ones
-              included: an Animals column that only appeared once an animal had
-              earned something would hide the very thing worth chasing.
-            */}
-            <table style={{ width: '100%', borderCollapse: 'collapse', tableLayout: 'fixed' }}>
-              <thead>
-                <tr>
-                  {/* Empty corner cell — the row labels below are the row headers. */}
-                  <td />
-                  <th scope="col" style={columnHeading}>
-                    Plants
-                  </th>
-                  <th scope="col" style={columnHeading}>
-                    Animals
-                  </th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr>
-                  <th scope="row" style={{ ...recordLabel, textAlign: 'left', paddingRight: 8 }}>
-                    Longest life
-                  </th>
-                  {LIFE_KINDS.map(kind => (
-                    <td key={kind} style={recordCell}>
-                      <ElderCell elder={records.byKind[kind].elder} />
-                    </td>
-                  ))}
-                </tr>
-                <tr>
-                  <th scope="row" style={{ ...recordLabel, textAlign: 'left', paddingRight: 8 }}>
-                    Deepest family line
-                  </th>
-                  {LIFE_KINDS.map(kind => (
-                    <td key={kind} style={recordCell}>
-                      <LineCell
-                        generations={records.byKind[kind].bestGenerations}
-                        speciesName={records.byKind[kind].bestGenerationsSpeciesName}
-                      />
-                    </td>
-                  ))}
-                </tr>
-              </tbody>
-            </table>
-
-            {records.bestSteadySeconds > 0 && (
-              <div className="flex flex-col gap-0.5">
-                <span style={recordLabel}>Longest without losing a kind</span>
-                <span style={{ fontSize: 13, color: 'var(--cc-text-default)' }}>
-                  {formatDuration(records.bestSteadySeconds)}
-                  {records.steadySeconds >= records.bestSteadySeconds &&
-                    records.steadySeconds > 0 && (
-                      <span style={{ color: 'var(--cc-gold)' }}> — going now</span>
+      {namedCreatures.some(e => e.alive) && (
+        <section style={{ borderBottom: '1px solid var(--cc-panel-divider)' }}>
+          <h3 className="px-4 pb-1 pt-3" style={sectionHeading}>
+            Named · {namedCreatures.filter(e => e.alive).length}
+          </h3>
+          <ul className="flex flex-col">
+            {namedCreatures
+              .filter(e => e.alive)
+              .slice()
+              .sort((a, b) => b.ageSeconds - a.ageSeconds)
+              .map((entry, i) => {
+                const bp = blueprints.find(b => b.id === entry.blueprintId)
+                return (
+                  <li
+                    key={entry.name + entry.blueprintId + i}
+                    className="flex gap-3 px-4 py-2.5"
+                    style={{ borderBottom: '1px solid var(--cc-panel-divider)' }}
+                  >
+                    {bp && (
+                      <div className="shrink-0 pt-0.5">
+                        <CreaturePortrait blueprint={bp} size={30} />
+                      </div>
                     )}
-                </span>
-              </div>
-            )}
-          </section>
-        )}
-
-        {view === 'guide' && compareTarget === null && <>
-
-        {namedCreatures.some(e => e.alive) && (
-          <section style={{ borderBottom: '1px solid var(--cc-panel-divider)' }}>
-            <h3 className="px-4 pb-1 pt-3" style={sectionHeading}>
-              Named · {namedCreatures.filter(e => e.alive).length}
-            </h3>
-            <ul className="flex flex-col">
-              {namedCreatures
-                .filter(e => e.alive)
-                .slice()
-                .sort((a, b) => b.ageSeconds - a.ageSeconds)
-                .map((entry, i) => {
-                  const bp = blueprints.find(b => b.id === entry.blueprintId)
-                  return (
-                    <li
-                      key={entry.name + entry.blueprintId + i}
-                      className="flex gap-3 px-4 py-2.5"
-                      style={{ borderBottom: '1px solid var(--cc-panel-divider)' }}
-                    >
+                    <div className="min-w-0 flex-1">
+                      <span
+                        style={{
+                          fontFamily: 'var(--cc-font-mono)',
+                          fontSize: 12,
+                          letterSpacing: 1.4,
+                          textTransform: 'uppercase',
+                          color: 'var(--cc-mint)',
+                        }}
+                      >
+                        {entry.name}
+                      </span>
                       {bp && (
-                        <div className="shrink-0 pt-0.5">
-                          <CreaturePortrait blueprint={bp} size={30} />
-                        </div>
+                        <p style={{ fontSize: 11, color: 'var(--cc-text-muted)', marginTop: 1 }}>
+                          {bp.name}
+                        </p>
                       )}
-                      <div className="min-w-0 flex-1">
+                      <p
+                        style={{
+                          fontFamily: 'var(--cc-font-mono)',
+                          fontSize: 10,
+                          color: 'var(--cc-text-muted)',
+                          opacity: 0.75,
+                          marginTop: 4,
+                          lineHeight: 1.6,
+                        }}
+                      >
+                        alive · {formatDuration(entry.ageSeconds)}
+                        {entry.generation > 1 && ` · gen ${entry.generation}`}
+                        {entry.children > 0 && ` · ${entry.children} offspring`}
+                        {entry.mealsEaten > 0 && ` · ${entry.mealsEaten} meals`}
+                      </p>
+                    </div>
+                  </li>
+                )
+              })}
+          </ul>
+        </section>
+      )}
+
+      {namedCreatures.some(e => !e.alive) && (
+        <section style={{ borderBottom: '1px solid var(--cc-panel-divider)' }}>
+          <h3 className="px-4 pb-1 pt-3" style={sectionHeading}>
+            Graveyard · {namedCreatures.filter(e => !e.alive).length}
+          </h3>
+          <ul className="flex flex-col">
+            {namedCreatures
+              .filter(e => !e.alive)
+              .slice()
+              .sort((a, b) => b.ageSeconds - a.ageSeconds)
+              .map((entry, i) => {
+                const bp = blueprints.find(b => b.id === entry.blueprintId)
+                return (
+                  <li
+                    key={entry.name + entry.blueprintId + i}
+                    className="flex gap-3 px-4 py-2.5"
+                    style={{
+                      borderBottom: '1px solid var(--cc-panel-divider)',
+                      opacity: 0.65,
+                    }}
+                  >
+                    {/* Pixel tombstone */}
+                    <div className="shrink-0" style={{ paddingTop: 2 }}>
+                      <svg
+                        width="30"
+                        height="30"
+                        viewBox="0 0 8 8"
+                        style={{ imageRendering: 'pixelated', display: 'block' }}
+                        aria-hidden
+                      >
+                        {/* stone body */}
+                        <rect x="1" y="3" width="6" height="4" fill="#6b7280" />
+                        {/* rounded top — two rows forming an arch */}
+                        <rect x="2" y="1" width="4" height="3" fill="#6b7280" />
+                        <rect x="1" y="2" width="6" height="1" fill="#6b7280" />
+                        {/* highlight edge */}
+                        <rect x="1" y="1" width="1" height="5" fill="#9ca3af" />
+                        <rect x="2" y="1" width="4" height="1" fill="#9ca3af" />
+                        {/* cross */}
+                        <rect x="3" y="2" width="2" height="4" fill="#374151" />
+                        <rect x="2" y="3" width="4" height="1" fill="#374151" />
+                        {/* base ground */}
+                        <rect x="0" y="7" width="8" height="1" fill="#4b5563" />
+                      </svg>
+                    </div>
+                    <div className="min-w-0 flex-1">
+                      <div className="flex items-baseline gap-1.5">
                         <span
                           style={{
                             fontFamily: 'var(--cc-font-mono)',
                             fontSize: 12,
                             letterSpacing: 1.4,
                             textTransform: 'uppercase',
-                            color: 'var(--cc-mint)',
+                            color: 'var(--cc-text-muted)',
                           }}
                         >
                           {entry.name}
                         </span>
-                        {bp && (
-                          <p style={{ fontSize: 11, color: 'var(--cc-text-muted)', marginTop: 1 }}>
-                            {bp.name}
-                          </p>
-                        )}
-                        <p
+                        <span
                           style={{
                             fontFamily: 'var(--cc-font-mono)',
-                            fontSize: 10,
+                            fontSize: 9,
                             color: 'var(--cc-text-muted)',
-                            opacity: 0.75,
-                            marginTop: 4,
-                            lineHeight: 1.6,
+                            opacity: 0.55,
                           }}
                         >
-                          alive · {formatDuration(entry.ageSeconds)}
-                          {entry.generation > 1 && ` · gen ${entry.generation}`}
-                          {entry.children > 0 && ` · ${entry.children} offspring`}
-                          {entry.mealsEaten > 0 && ` · ${entry.mealsEaten} meals`}
+                          †
+                        </span>
+                      </div>
+                      {bp && (
+                        <p style={{ fontSize: 11, color: 'var(--cc-text-muted)', marginTop: 1 }}>
+                          {bp.name}
                         </p>
-                      </div>
-                    </li>
-                  )
-                })}
-            </ul>
-          </section>
-        )}
+                      )}
+                      <p
+                        style={{
+                          fontFamily: 'var(--cc-font-mono)',
+                          fontSize: 10,
+                          color: 'var(--cc-text-muted)',
+                          opacity: 0.65,
+                          marginTop: 4,
+                          lineHeight: 1.6,
+                        }}
+                      >
+                        lived {formatDuration(entry.ageSeconds)}
+                        {entry.generation > 1 && ` · gen ${entry.generation}`}
+                        {entry.children > 0 && ` · ${entry.children} offspring`}
+                        {entry.mealsEaten > 0 && ` · ${entry.mealsEaten} meals`}
+                      </p>
+                    </div>
+                  </li>
+                )
+              })}
+          </ul>
+        </section>
+      )}
 
-        {namedCreatures.some(e => !e.alive) && (
-          <section style={{ borderBottom: '1px solid var(--cc-panel-divider)' }}>
-            <h3 className="px-4 pb-1 pt-3" style={sectionHeading}>
-              Graveyard · {namedCreatures.filter(e => !e.alive).length}
-            </h3>
-            <ul className="flex flex-col">
-              {namedCreatures
-                .filter(e => !e.alive)
-                .slice()
-                .sort((a, b) => b.ageSeconds - a.ageSeconds)
-                .map((entry, i) => {
-                  const bp = blueprints.find(b => b.id === entry.blueprintId)
-                  return (
-                    <li
-                      key={entry.name + entry.blueprintId + i}
-                      className="flex gap-3 px-4 py-2.5"
-                      style={{
-                        borderBottom: '1px solid var(--cc-panel-divider)',
-                        opacity: 0.65,
-                      }}
-                    >
-                      {/* Pixel tombstone */}
-                      <div className="shrink-0" style={{ paddingTop: 2 }}>
-                        <svg
-                          width="30"
-                          height="30"
-                          viewBox="0 0 8 8"
-                          style={{ imageRendering: 'pixelated', display: 'block' }}
-                          aria-hidden
-                        >
-                          {/* stone body */}
-                          <rect x="1" y="3" width="6" height="4" fill="#6b7280" />
-                          {/* rounded top — two rows forming an arch */}
-                          <rect x="2" y="1" width="4" height="3" fill="#6b7280" />
-                          <rect x="1" y="2" width="6" height="1" fill="#6b7280" />
-                          {/* highlight edge */}
-                          <rect x="1" y="1" width="1" height="5" fill="#9ca3af" />
-                          <rect x="2" y="1" width="4" height="1" fill="#9ca3af" />
-                          {/* cross */}
-                          <rect x="3" y="2" width="2" height="4" fill="#374151" />
-                          <rect x="2" y="3" width="4" height="1" fill="#374151" />
-                          {/* base ground */}
-                          <rect x="0" y="7" width="8" height="1" fill="#4b5563" />
-                        </svg>
-                      </div>
-                      <div className="min-w-0 flex-1">
-                        <div className="flex items-baseline gap-1.5">
-                          <span
-                            style={{
-                              fontFamily: 'var(--cc-font-mono)',
-                              fontSize: 12,
-                              letterSpacing: 1.4,
-                              textTransform: 'uppercase',
-                              color: 'var(--cc-text-muted)',
-                            }}
-                          >
-                            {entry.name}
-                          </span>
-                          <span
-                            style={{
-                              fontFamily: 'var(--cc-font-mono)',
-                              fontSize: 9,
-                              color: 'var(--cc-text-muted)',
-                              opacity: 0.55,
-                            }}
-                          >
-                            †
-                          </span>
-                        </div>
-                        {bp && (
-                          <p style={{ fontSize: 11, color: 'var(--cc-text-muted)', marginTop: 1 }}>
-                            {bp.name}
-                          </p>
-                        )}
-                        <p
-                          style={{
-                            fontFamily: 'var(--cc-font-mono)',
-                            fontSize: 10,
-                            color: 'var(--cc-text-muted)',
-                            opacity: 0.65,
-                            marginTop: 4,
-                            lineHeight: 1.6,
-                          }}
-                        >
-                          lived {formatDuration(entry.ageSeconds)}
-                          {entry.generation > 1 && ` · gen ${entry.generation}`}
-                          {entry.children > 0 && ` · ${entry.children} offspring`}
-                          {entry.mealsEaten > 0 && ` · ${entry.mealsEaten} meals`}
-                        </p>
-                      </div>
-                    </li>
-                  )
-                })}
-            </ul>
-          </section>
-        )}
-
-        {/* Filter row — sits right above the list it affects so it reads as a
-            list control rather than a navigation option. */}
-        <div
-          className="flex items-center justify-between px-3 py-1.5"
-          style={{ borderBottom: '1px solid var(--cc-panel-divider)' }}
+      {/* Filter row — sits right above the list it affects so it reads as a
+          list control rather than a navigation option. */}
+      <div
+        className="flex items-center justify-between px-3 py-1.5"
+        style={{ borderBottom: '1px solid var(--cc-panel-divider)' }}
+      >
+        <span
+          style={{
+            fontFamily: 'var(--cc-font-mono)',
+            fontSize: 9,
+            letterSpacing: 1.5,
+            textTransform: 'uppercase',
+            color: 'var(--cc-text-muted)',
+          }}
         >
-          <span
+          {ordered.length} {ordered.length === 1 ? 'species' : 'species'} in this land
+        </span>
+        <div className="flex items-center gap-1">
+          <button
+            type="button"
+            className="cc-btn"
+            onClick={() => {
+              setCompact(c => {
+                const next = !c
+                try { localStorage.setItem('fg-compact', next ? '1' : '0') } catch {}
+                return next
+              })
+            }}
+            aria-pressed={compact}
+            title={compact ? 'Switch to full view' : 'Switch to compact view'}
             style={{
               fontFamily: 'var(--cc-font-mono)',
               fontSize: 9,
-              letterSpacing: 1.5,
+              letterSpacing: 1,
               textTransform: 'uppercase',
-              color: 'var(--cc-text-muted)',
+              padding: '2px 7px',
+              minHeight: 22,
+              borderRadius: 3,
+              border: compact ? '1px solid var(--cc-mint)' : '1px solid var(--cc-panel-divider)',
+              color: compact ? 'var(--cc-mint)' : 'var(--cc-text-muted)',
             }}
           >
-            {ordered.length} {ordered.length === 1 ? 'species' : 'species'} in this land
-          </span>
-          <div className="flex items-center gap-1">
-            <button
-              type="button"
-              className="cc-btn"
-              onClick={() => {
-                setCompact(c => {
-                  const next = !c
-                  try { localStorage.setItem('fg-compact', next ? '1' : '0') } catch {}
-                  return next
-                })
-              }}
-              aria-pressed={compact}
-              title={compact ? 'Switch to full view' : 'Switch to compact view'}
-              style={{
-                fontFamily: 'var(--cc-font-mono)',
-                fontSize: 9,
-                letterSpacing: 1,
-                textTransform: 'uppercase',
-                padding: '2px 7px',
-                minHeight: 22,
-                borderRadius: 3,
-                border: compact ? '1px solid var(--cc-mint)' : '1px solid var(--cc-panel-divider)',
-                color: compact ? 'var(--cc-mint)' : 'var(--cc-text-muted)',
-              }}
-            >
-              {compact ? '≡ Full' : '≡ Compact'}
-            </button>
-            <button
-              type="button"
-              className="cc-btn"
-              onClick={() => setPlantsHidden(h => !h)}
-              aria-pressed={plantsHidden}
-              style={{
-                fontFamily: 'var(--cc-font-mono)',
-                fontSize: 9,
-                letterSpacing: 1,
-                textTransform: 'uppercase',
-                padding: '2px 7px',
-                minHeight: 22,
-                borderRadius: 3,
-                border: plantsHidden ? '1px solid var(--cc-mint)' : '1px solid var(--cc-panel-divider)',
-                color: plantsHidden ? 'var(--cc-mint)' : 'var(--cc-text-muted)',
-              }}
-            >
-              {plantsHidden ? 'Plants hidden' : 'Hide plants'}
-            </button>
-          </div>
+            {compact ? '≡ Full' : '≡ Compact'}
+          </button>
+          <button
+            type="button"
+            className="cc-btn"
+            onClick={() => setPlantsHidden(h => !h)}
+            aria-pressed={plantsHidden}
+            style={{
+              fontFamily: 'var(--cc-font-mono)',
+              fontSize: 9,
+              letterSpacing: 1,
+              textTransform: 'uppercase',
+              padding: '2px 7px',
+              minHeight: 22,
+              borderRadius: 3,
+              border: plantsHidden ? '1px solid var(--cc-mint)' : '1px solid var(--cc-panel-divider)',
+              color: plantsHidden ? 'var(--cc-mint)' : 'var(--cc-text-muted)',
+            }}
+          >
+            {plantsHidden ? 'Plants hidden' : 'Hide plants'}
+          </button>
         </div>
-        <ul className="flex flex-col">
-          {ordered.map(bp => (
-            <GuideEntry
-              key={bp.id}
-              bp={bp}
-              alive={counts.get(bp.id) ?? 0}
-              maxGeneration={genByBp.get(bp.id) ?? 1}
-              blueprints={blueprints}
-              thumbs={populationItems.filter(t => t.blueprintId === bp.id)}
-              onLocateCreature={requestLocateCreature}
-              onCompare={() => handleCompare(bp.id)}
-              isComparePin={compareId === bp.id}
-              traitHistory={traitHistory[bp.id]}
-              compact={compact}
-              isHeatmap={heatmapBlueprintId === bp.id}
-              onHeatmap={() => setHeatmapBlueprint(heatmapBlueprintId === bp.id ? null : bp.id)}
-            />
-          ))}
-        </ul>
+      </div>
+      <ul className="flex flex-col">
+        {ordered.map(bp => (
+          <GuideEntry
+            key={bp.id}
+            bp={bp}
+            alive={counts.get(bp.id) ?? 0}
+            maxGeneration={genByBp.get(bp.id) ?? 1}
+            blueprints={blueprints}
+            thumbs={populationItems.filter(t => t.blueprintId === bp.id)}
+            onLocateCreature={requestLocateCreature}
+            onCompare={() => handleCompare(bp.id)}
+            isComparePin={compareId === bp.id}
+            traitHistory={traitHistory[bp.id]}
+            compact={compact}
+            isHeatmap={heatmapBlueprintId === bp.id}
+            onHeatmap={() => setHeatmapBlueprint(heatmapBlueprintId === bp.id ? null : bp.id)}
+          />
+        ))}
+      </ul>
 
-        {remembered.length > 0 && (
-          <section style={{ borderTop: '1px solid var(--cc-panel-divider)' }}>
-            <h3 className="px-4 pb-1 pt-3" style={sectionHeading}>
-              Remembered · {remembered.length}
-            </h3>
-            <p
-              className="px-4 pb-2"
-              style={{ fontSize: 12, color: 'var(--cc-text-muted)', opacity: 0.8 }}
-            >
-              Kinds you have met before. None of them are in this land.
-            </p>
-            <ul className="flex flex-col">
-              {remembered.map(record => (
-                <RememberedEntry key={record.blueprint.id} record={record} />
-              ))}
-            </ul>
-          </section>
-        )}
+      {remembered.length > 0 && (
+        <section style={{ borderTop: '1px solid var(--cc-panel-divider)' }}>
+          <h3 className="px-4 pb-1 pt-3" style={sectionHeading}>
+            Remembered · {remembered.length}
+          </h3>
+          <p
+            className="px-4 pb-2"
+            style={{ fontSize: 12, color: 'var(--cc-text-muted)', opacity: 0.8 }}
+          >
+            Kinds you have met before. None of them are in this land.
+          </p>
+          <ul className="flex flex-col">
+            {remembered.map(record => (
+              <RememberedEntry key={record.blueprint.id} record={record} />
+            ))}
+          </ul>
+        </section>
+      )}
 
-        {milestones.length > 0 && (
-          <section className="px-4 py-3" style={{ borderTop: '1px solid var(--cc-panel-divider)' }}>
-            <h3 className="pb-2" style={sectionHeading}>
-              Things that have happened
-            </h3>
-            <ul className="flex flex-col gap-1.5">
-              {milestones.map(m => (
-                <li
-                  key={m.id}
-                  className="flex items-baseline justify-between gap-3"
-                  style={{ fontSize: 12, color: 'var(--cc-text-muted)' }}
-                >
-                  <span>{m.text}</span>
-                  <span
-                    style={{
-                      fontFamily: 'var(--cc-font-mono)',
-                      fontSize: 10,
-                      opacity: 0.6,
-                      whiteSpace: 'nowrap',
-                    }}
-                  >
-                    {new Date(m.at).toLocaleDateString()}
-                  </span>
-                </li>
-              ))}
-            </ul>
-          </section>
-        )}
-        <PopulationGraph history={populationHistory} blueprints={blueprints} />
-
+      {milestones.length > 0 && (
         <section className="px-4 py-3" style={{ borderTop: '1px solid var(--cc-panel-divider)' }}>
           <h3 className="pb-2" style={sectionHeading}>
-            Evolution view
+            Things that have happened
           </h3>
-          <p style={{ fontSize: 11, color: 'var(--cc-text-muted)', lineHeight: 1.5, marginBottom: 8, opacity: 0.8 }}>
-            Color creatures by trait — blue is below average, red is above.
-          </p>
-          <div className="flex flex-wrap gap-1.5">
-            {(['speed', 'sight', 'lifespan', 'roam'] as const).map(trait => (
-              <button
-                key={trait}
-                type="button"
-                className="cc-btn"
-                onClick={() => setTraitOverlay(trait)}
-                style={{
-                  fontFamily: 'var(--cc-font-mono)',
-                  fontSize: 9,
-                  letterSpacing: 1.2,
-                  textTransform: 'uppercase',
-                  padding: '4px 10px',
-                  minHeight: 28,
-                  borderRadius: 4,
-                  border: traitOverlay === trait
-                    ? '1px solid var(--cc-mint)'
-                    : '1px solid var(--cc-mint-line)',
-                  color: traitOverlay === trait ? 'var(--cc-mint)' : 'var(--cc-text-muted)',
-                  background: traitOverlay === trait ? 'rgba(100,220,200,0.1)' : 'transparent',
-                }}
+          <ul className="flex flex-col gap-1.5">
+            {milestones.map(m => (
+              <li
+                key={m.id}
+                className="flex items-baseline justify-between gap-3"
+                style={{ fontSize: 12, color: 'var(--cc-text-muted)' }}
               >
-                {trait === 'lifespan' ? 'Life' : trait.charAt(0).toUpperCase() + trait.slice(1)}
-              </button>
+                <span>{m.text}</span>
+                <span
+                  style={{
+                    fontFamily: 'var(--cc-font-mono)',
+                    fontSize: 10,
+                    opacity: 0.6,
+                    whiteSpace: 'nowrap',
+                  }}
+                >
+                  {new Date(m.at).toLocaleDateString()}
+                </span>
+              </li>
             ))}
+          </ul>
+        </section>
+      )}
+      <PopulationGraph history={populationHistory} blueprints={blueprints} />
+
+      <section className="px-4 py-3" style={{ borderTop: '1px solid var(--cc-panel-divider)' }}>
+        <h3 className="pb-2" style={sectionHeading}>
+          Evolution view
+        </h3>
+        <p style={{ fontSize: 11, color: 'var(--cc-text-muted)', lineHeight: 1.5, marginBottom: 8, opacity: 0.8 }}>
+          Color creatures by trait — blue is below average, red is above.
+        </p>
+        <div className="flex flex-wrap gap-1.5">
+          {(['speed', 'sight', 'lifespan', 'roam'] as const).map(trait => (
             <button
+              key={trait}
               type="button"
               className="cc-btn"
-              onClick={() => setTrailsEnabled(!trailsEnabled)}
+              onClick={() => setTraitOverlay(trait)}
               style={{
                 fontFamily: 'var(--cc-font-mono)',
                 fontSize: 9,
@@ -682,134 +520,155 @@ export function FieldGuide() {
                 padding: '4px 10px',
                 minHeight: 28,
                 borderRadius: 4,
-                border: trailsEnabled
+                border: traitOverlay === trait
                   ? '1px solid var(--cc-mint)'
                   : '1px solid var(--cc-mint-line)',
-                color: trailsEnabled ? 'var(--cc-mint)' : 'var(--cc-text-muted)',
-                background: trailsEnabled ? 'rgba(100,220,200,0.1)' : 'transparent',
+                color: traitOverlay === trait ? 'var(--cc-mint)' : 'var(--cc-text-muted)',
+                background: traitOverlay === trait ? 'rgba(100,220,200,0.1)' : 'transparent',
               }}
             >
-              Trails
+              {trait === 'lifespan' ? 'Life' : trait.charAt(0).toUpperCase() + trait.slice(1)}
             </button>
-          </div>
-          {traitOverlay && (
-            <button
-              type="button"
-              className="cc-btn"
-              onClick={() => setTraitOverlay(null)}
-              style={{
-                marginTop: 8,
-                fontFamily: 'var(--cc-font-mono)',
-                fontSize: 9,
-                letterSpacing: 1,
-                textTransform: 'uppercase',
-                padding: '3px 8px',
-                color: 'var(--cc-text-muted)',
-                border: '1px solid var(--cc-panel-divider)',
-              }}
-            >
-              Clear
-            </button>
-          )}
-        </section>
-
-        {extinctions.length > 0 && (
-          <section className="px-4 py-3" style={{ borderTop: '1px solid var(--cc-panel-divider)' }}>
-            <h3 className="pb-2" style={sectionHeading}>
-              Extinctions
-            </h3>
-            <p style={{ fontSize: 11, color: 'var(--cc-text-muted)', marginBottom: 8 }}>
-              Species that lived and died in this land.
-            </p>
-            <ul style={{ listStyle: 'none', padding: 0, margin: 0 }}>
-              {[...extinctions].reverse().map(ext => (
-                <li
-                  key={ext.blueprintId + ext.elapsed}
-                  style={{
-                    display: 'flex',
-                    justifyContent: 'space-between',
-                    alignItems: 'baseline',
-                    padding: '3px 0',
-                    opacity: 0.6,
-                    fontSize: 11,
-                    fontFamily: 'var(--cc-font-mono)',
-                  }}
-                >
-                  <span>🦴 {ext.name}</span>
-                  <span style={{ color: 'var(--cc-text-muted)', fontSize: 10 }}>
-                    gen {ext.maxGeneration} · {Math.round(ext.livedFor / 60)} min
-                  </span>
-                </li>
-              ))}
-            </ul>
-          </section>
+          ))}
+          <button
+            type="button"
+            className="cc-btn"
+            onClick={() => setTrailsEnabled(!trailsEnabled)}
+            style={{
+              fontFamily: 'var(--cc-font-mono)',
+              fontSize: 9,
+              letterSpacing: 1.2,
+              textTransform: 'uppercase',
+              padding: '4px 10px',
+              minHeight: 28,
+              borderRadius: 4,
+              border: trailsEnabled
+                ? '1px solid var(--cc-mint)'
+                : '1px solid var(--cc-mint-line)',
+              color: trailsEnabled ? 'var(--cc-mint)' : 'var(--cc-text-muted)',
+              background: trailsEnabled ? 'rgba(100,220,200,0.1)' : 'transparent',
+            }}
+          >
+            Trails
+          </button>
+        </div>
+        {traitOverlay && (
+          <button
+            type="button"
+            className="cc-btn"
+            onClick={() => setTraitOverlay(null)}
+            style={{
+              marginTop: 8,
+              fontFamily: 'var(--cc-font-mono)',
+              fontSize: 9,
+              letterSpacing: 1,
+              textTransform: 'uppercase',
+              padding: '3px 8px',
+              color: 'var(--cc-text-muted)',
+              border: '1px solid var(--cc-panel-divider)',
+            }}
+          >
+            Clear
+          </button>
         )}
+      </section>
 
-        {Object.keys(foodWeb).length > 0 && (
-          <section className="px-4 py-3" style={{ borderTop: '1px solid var(--cc-panel-divider)' }}>
-            <h3 className="pb-2" style={sectionHeading}>
-              Food web
-            </h3>
-            <p style={{ fontSize: 11, color: 'var(--cc-text-muted)', marginBottom: 8 }}>
-              Who ate whom — observed in this world so far.
-            </p>
-            <ul style={{ listStyle: 'none', padding: 0, margin: 0 }}>
-              {Object.entries(foodWeb).map(([eaterId, preyIds]) => (
-                <li
-                  key={eaterId}
-                  style={{
-                    fontSize: 11,
-                    fontFamily: 'var(--cc-font-mono)',
-                    padding: '3px 0',
-                    lineHeight: 1.6,
-                  }}
-                >
-                  <span style={{ color: 'var(--cc-text-default)' }}>
-                    {allBlueprintNames[eaterId] ?? eaterId}
-                  </span>
-                  <span style={{ color: 'var(--cc-text-muted)' }}>{' → '}</span>
-                  <span style={{ color: 'var(--cc-text-muted)' }}>
-                    {preyIds.map(id => allBlueprintNames[id] ?? id).join(', ')}
-                  </span>
-                </li>
-              ))}
-            </ul>
-          </section>
-        )}
-
-        {/* World Statistics */}
+      {extinctions.length > 0 && (
         <section className="px-4 py-3" style={{ borderTop: '1px solid var(--cc-panel-divider)' }}>
           <h3 className="pb-2" style={sectionHeading}>
-            This session
+            Extinctions
           </h3>
-          <table style={{ width: '100%', fontSize: 11, fontFamily: 'var(--cc-font-mono)', borderCollapse: 'collapse' }}>
-            <tbody>
-              {(
-                [
-                  ['Born', worldStats.totalBorn],
-                  ['Died', worldStats.totalDeaths],
-                  ['Predation events', worldStats.totalEats],
-                  ['Peak population', worldStats.peakPopulation],
-                  ['Longest life', worldStats.longestLived > 0 ? `${Math.round(worldStats.longestLived)}s` : '—'],
-                  ['Most prolific', worldStats.mostProlificName
-                    ? `${worldStats.mostProlificName} (${worldStats.mostProlificChildren} offspring)`
-                    : '—'],
-                ] as [string, string | number][]
-              ).map(([label, value]) => (
-                <tr key={label} style={{ borderBottom: '1px solid var(--cc-panel-divider)' }}>
-                  <td style={{ padding: '4px 0', color: 'var(--cc-text-muted)', width: '55%' }}>{label}</td>
-                  <td style={{ padding: '4px 0', textAlign: 'right' }}>{value}</td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
+          <p style={{ fontSize: 11, color: 'var(--cc-text-muted)', marginBottom: 8 }}>
+            Species that lived and died in this land.
+          </p>
+          <ul style={{ listStyle: 'none', padding: 0, margin: 0 }}>
+            {[...extinctions].reverse().map(ext => (
+              <li
+                key={ext.blueprintId + ext.elapsed}
+                style={{
+                  display: 'flex',
+                  justifyContent: 'space-between',
+                  alignItems: 'baseline',
+                  padding: '3px 0',
+                  opacity: 0.6,
+                  fontSize: 11,
+                  fontFamily: 'var(--cc-font-mono)',
+                }}
+              >
+                <span>🦴 {ext.name}</span>
+                <span style={{ color: 'var(--cc-text-muted)', fontSize: 10 }}>
+                  gen {ext.maxGeneration} · {Math.round(ext.livedFor / 60)} min
+                </span>
+              </li>
+            ))}
+          </ul>
         </section>
+      )}
 
-        <ImportSection addBlueprint={addBlueprint} />
+      {Object.keys(foodWeb).length > 0 && (
+        <section className="px-4 py-3" style={{ borderTop: '1px solid var(--cc-panel-divider)' }}>
+          <h3 className="pb-2" style={sectionHeading}>
+            Food web
+          </h3>
+          <p style={{ fontSize: 11, color: 'var(--cc-text-muted)', marginBottom: 8 }}>
+            Who ate whom — observed in this world so far.
+          </p>
+          <ul style={{ listStyle: 'none', padding: 0, margin: 0 }}>
+            {Object.entries(foodWeb).map(([eaterId, preyIds]) => (
+              <li
+                key={eaterId}
+                style={{
+                  fontSize: 11,
+                  fontFamily: 'var(--cc-font-mono)',
+                  padding: '3px 0',
+                  lineHeight: 1.6,
+                }}
+              >
+                <span style={{ color: 'var(--cc-text-default)' }}>
+                  {allBlueprintNames[eaterId] ?? eaterId}
+                </span>
+                <span style={{ color: 'var(--cc-text-muted)' }}>{' → '}</span>
+                <span style={{ color: 'var(--cc-text-muted)' }}>
+                  {preyIds.map(id => allBlueprintNames[id] ?? id).join(', ')}
+                </span>
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
 
-        </>}
-      </div>
-    </aside>
+      {/* World Statistics */}
+      <section className="px-4 py-3" style={{ borderTop: '1px solid var(--cc-panel-divider)' }}>
+        <h3 className="pb-2" style={sectionHeading}>
+          This session
+        </h3>
+        <table style={{ width: '100%', fontSize: 11, fontFamily: 'var(--cc-font-mono)', borderCollapse: 'collapse' }}>
+          <tbody>
+            {(
+              [
+                ['Born', worldStats.totalBorn],
+                ['Died', worldStats.totalDeaths],
+                ['Predation events', worldStats.totalEats],
+                ['Peak population', worldStats.peakPopulation],
+                ['Longest life', worldStats.longestLived > 0 ? `${Math.round(worldStats.longestLived)}s` : '—'],
+                ['Most prolific', worldStats.mostProlificName
+                  ? `${worldStats.mostProlificName} (${worldStats.mostProlificChildren} offspring)`
+                  : '—'],
+              ] as [string, string | number][]
+            ).map(([label, value]) => (
+              <tr key={label} style={{ borderBottom: '1px solid var(--cc-panel-divider)' }}>
+                <td style={{ padding: '4px 0', color: 'var(--cc-text-muted)', width: '55%' }}>{label}</td>
+                <td style={{ padding: '4px 0', textAlign: 'right' }}>{value}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </section>
+
+      <ImportSection addBlueprint={addBlueprint} />
+
+      </>}
+    </>
   )
 }
 

--- a/src/app/micro-land/components/history-panel.tsx
+++ b/src/app/micro-land/components/history-panel.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 
 import { type HistoryEntry, type HistoryEventKind } from '@/app/micro-land/domain/types'
 import { useMicroLand } from '@/app/micro-land/store'
@@ -88,9 +88,14 @@ function kindToFilter(kind: HistoryEventKind): FilterKey {
   return 'sick'
 }
 
-export function HistoryPanel() {
-  const open = useMicroLand(s => s.historyOpen)
-  const setOpen = useMicroLand(s => s.setHistoryOpen)
+/**
+ * Everything that has happened, as it happened.
+ *
+ * Lives in the shared right-hand column rather than over the world: the point of
+ * reading the log is to look up from it and see the thing it is describing still
+ * going on.
+ */
+export function LogPane() {
   const historyLog = useMicroLand(s => s.historyLog)
   const blueprints = useMicroLand(s => s.blueprints)
 
@@ -125,18 +130,6 @@ export function HistoryPanel() {
   const activeKeys = (Object.keys(active) as FilterKey[]).filter(k => active[k])
   const maxCount = Math.max(1, ...activeKeys.flatMap(k => bucketCounts[k]))
 
-  // Escape closes the panel.
-  useEffect(() => {
-    if (!open) return
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') setOpen(false)
-    }
-    window.addEventListener('keydown', onKey)
-    return () => window.removeEventListener('keydown', onKey)
-  }, [open, setOpen])
-
-  if (!open) return null
-
   const filtered = historyLog.filter(e => active[kindToFilter(e.kind)])
 
   function toggleFilter(key: FilterKey) {
@@ -144,56 +137,7 @@ export function HistoryPanel() {
   }
 
   return (
-    <div
-      role="dialog"
-      aria-label="Event Log"
-      className="fixed inset-x-0 bottom-0 z-50 flex max-h-[72dvh] flex-col rounded-t-xl sm:inset-y-0 sm:left-auto sm:right-0 sm:w-[400px] sm:max-h-none sm:rounded-none"
-      style={{
-        background: 'linear-gradient(180deg, var(--cc-modal-bg-from), var(--cc-modal-bg-to))',
-        borderTop: '1px solid var(--cc-modal-border)',
-        borderLeft: '1px solid var(--cc-modal-border)',
-      }}
-    >
-      {/* Header */}
-      <div
-        className="flex shrink-0 items-center justify-between gap-2 px-4 py-3"
-        style={{
-          borderBottom: '1px solid var(--cc-panel-divider)',
-          background: 'var(--cc-modal-bg-from)',
-        }}
-      >
-        <h2
-          style={{
-            fontFamily: 'var(--cc-font-mono)',
-            fontSize: 11,
-            letterSpacing: 2.5,
-            textTransform: 'uppercase',
-            color: 'var(--cc-mint)',
-          }}
-        >
-          Event Log
-        </h2>
-        <button
-          type="button"
-          className="cc-btn"
-          onClick={() => setOpen(false)}
-          style={{
-            fontFamily: 'var(--cc-font-mono)',
-            fontSize: 10,
-            letterSpacing: 1.2,
-            textTransform: 'uppercase',
-            padding: '6px 10px',
-            minHeight: 32,
-            borderRadius: 4,
-            border: '1px solid var(--cc-mint-line)',
-            color: 'var(--cc-text-muted)',
-          }}
-          aria-label="Close event log"
-        >
-          Close
-        </button>
-      </div>
-
+    <>
       {/* Filter toggles */}
       <div
         className="flex shrink-0 flex-wrap gap-1.5 px-4 py-2"
@@ -312,7 +256,9 @@ export function HistoryPanel() {
       )}
 
       {/* Entry list */}
-      <div className="min-h-0 flex-1 overflow-y-auto px-4 py-3">
+      {/* The sidebar shell owns the scroll — a second scroller in here would
+          trap the wheel over the list and strand the filters above it. */}
+      <div className="px-4 py-3">
         {historyLog.length === 0 ? (
           <p
             style={{
@@ -343,7 +289,7 @@ export function HistoryPanel() {
           </ul>
         )}
       </div>
-    </div>
+    </>
   )
 }
 

--- a/src/app/micro-land/components/hud.tsx
+++ b/src/app/micro-land/components/hud.tsx
@@ -4,11 +4,10 @@ import { useEffect, useRef, useState } from 'react'
 import Link from 'next/link'
 
 import { disableSound, enableSound } from '@/app/micro-land/audio/sound-engine'
-import { THEMES } from '@/app/micro-land/domain/config/themes'
 import { STEADY_SHOW_SECONDS } from '@/app/micro-land/domain/constants'
 import { TUNING_DEFAULTS, type TuningKey } from '@/app/micro-land/domain/tuning'
 import { formatDuration } from '@/app/micro-land/format'
-import { type PopulationEntry, SUMMONED_THEME_ID, useMicroLand, type Tool } from '@/app/micro-land/store'
+import { type PopulationEntry, type SidebarView, useMicroLand } from '@/app/micro-land/store'
 import { SparkleIcon } from '@/app/micro-land/components/sparkle-icon'
 import { useAuth } from '@/hooks/useAuth'
 
@@ -96,31 +95,19 @@ function SlidersIcon() {
   )
 }
 
-export function Hud({
-  onReshuffle,
-  onClearLife,
-  onOpenHistory,
-}: {
-  onReshuffle: () => void
-  onClearLife: () => void
-  onOpenHistory: () => void
-}) {
-  const themeId = useMicroLand(s => s.themeId)
-  const setTheme = useMicroLand(s => s.setTheme)
+export function Hud({ onOpenHistory }: { onOpenHistory: () => void }) {
   const paused = useMicroLand(s => s.paused)
   const togglePaused = useMicroLand(s => s.togglePaused)
   const speed = useMicroLand(s => s.speed)
   const setSpeed = useMicroLand(s => s.setSpeed)
   const total = useMicroLand(s => s.totalCreatures)
   const population = useMicroLand(s => s.population)
-  const setGuideOpen = useMicroLand(s => s.setGuideOpen)
-  const summonedLand = useMicroLand(s => s.summonedLand)
   const steadySeconds = useMicroLand(s => s.records.steadySeconds)
   const elapsed = useMicroLand(s => s.elapsed)
-  const setWorldsOpen = useMicroLand(s => s.setWorldsOpen)
   const activeWorldId = useMicroLand(s => s.shelf.activeId)
-  const settingsOpen = useMicroLand(s => s.settingsOpen)
-  const setSettingsOpen = useMicroLand(s => s.setSettingsOpen)
+  const sidebar = useMicroLand(s => s.sidebar)
+  const setSidebar = useMicroLand(s => s.setSidebar)
+  const toggleSidebar = useMicroLand(s => s.toggleSidebar)
   const tuning = useMicroLand(s => s.tuning)
   const challengeActive = useMicroLand(s => s.challengeActive)
   const setChallengeActive = useMicroLand(s => s.setChallengeActive)
@@ -131,7 +118,6 @@ export function Hud({
   const soundEnabled = useMicroLand(s => s.soundEnabled)
   const setSoundEnabled = useMicroLand(s => s.setSoundEnabled)
 
-  const setHistoryOpen = useMicroLand(s => s.setHistoryOpen)
   const setSummonOpen = useMicroLand(s => s.setSummonOpen)
   const tool = useMicroLand(s => s.tool)
   const setTool = useMicroLand(s => s.setTool)
@@ -194,6 +180,13 @@ export function Hud({
       window.removeEventListener('resize', place)
     }
   }, [overflowOpen])
+
+  // Every panel item in the menu does the same two things: show the panel and
+  // put the menu away. The menu is a launcher, not a place to stand.
+  const openSidebar = (view: SidebarView) => {
+    setSidebar(view)
+    setOverflowOpen(false)
+  }
 
   // Shared style for items inside the overflow dropdown.
   const overflowItem: React.CSSProperties = {
@@ -375,8 +368,9 @@ export function Hud({
         <button
           type="button"
           className="cc-btn"
-          onClick={() => setGuideOpen(true)}
-          style={chipBase}
+          onClick={() => toggleSidebar('guide')}
+          style={{ ...chipBase, ...(sidebar === 'guide' ? activeChip : {}) }}
+          aria-pressed={sidebar === 'guide'}
           title="Open the field guide"
         >
           {species} kinds · {total} alive
@@ -484,45 +478,38 @@ export function Hud({
                 boxShadow: '0 8px 24px rgba(0,0,0,0.4)',
               }}
             >
-              {/* Theme selector */}
-              <label className="sr-only" htmlFor="micro-land-theme-overflow">
-                Choose a world
-              </label>
-              <select
-                id="micro-land-theme-overflow"
-                value={themeId}
-                onChange={e => { setTheme(e.target.value); setOverflowOpen(false) }}
-                style={{
-                  ...overflowItem,
-                  color: 'var(--cc-text-default)',
-                  background: 'var(--cc-panel-grad-to)',
-                }}
-              >
-                {THEMES.map(theme => (
-                  <option key={theme.id} value={theme.id}>
-                    {theme.name}
-                  </option>
-                ))}
-                {summonedLand && <option value={SUMMONED_THEME_ID}>✦ {summonedLand}</option>}
-              </select>
-
-              {/* Reshape */}
+              {/* Making things — the reason anyone opens this menu twice. */}
               <button
                 type="button"
                 className="cc-btn"
-                onClick={() => { onReshuffle(); setOverflowOpen(false) }}
-                style={overflowItem}
-                title="Build this world again, differently"
+                onClick={() => openSidebar('creatures')}
+                style={{ ...overflowItem, ...(sidebar === 'creatures' ? activeChip : {}) }}
+                title="Draw a creature, or build one from a species already here"
               >
-                Reshape world
+                Creatures
               </button>
 
-              {/* Worlds */}
               <button
                 type="button"
                 className="cc-btn"
-                onClick={() => { setWorldsOpen(true); setOverflowOpen(false) }}
-                style={{ ...overflowItem, ...(activeWorldId ? activeChip : {}) }}
+                onClick={() => openSidebar('challenges')}
+                style={{ ...overflowItem, ...(sidebar === 'challenges' ? activeChip : {}) }}
+                title="Run this land against a set of rules"
+              >
+                Challenges
+              </button>
+
+              <div style={{ height: 1, background: 'var(--cc-panel-divider)', margin: '2px 0' }} />
+
+              {/* Worlds — keeping this one, opening a kept one, starting a new one */}
+              <button
+                type="button"
+                className="cc-btn"
+                onClick={() => openSidebar('worlds')}
+                style={{
+                  ...overflowItem,
+                  ...(sidebar === 'worlds' || activeWorldId ? activeChip : {}),
+                }}
                 aria-label={activeWorldId ? 'Worlds — this world is saved' : 'Worlds — open or save a world'}
                 title={activeWorldId ? 'This world is saved' : 'Save this world, or open one you saved'}
               >
@@ -531,35 +518,35 @@ export function Hud({
 
               <div style={{ height: 1, background: 'var(--cc-panel-divider)', margin: '2px 0' }} />
 
-              {/* Field Guide */}
+              {/* Field Guide — also on the stats chip, but the chip reads as a
+                  readout and plenty of people never think to press it. */}
               <button
                 type="button"
                 className="cc-btn"
-                onClick={() => { setGuideOpen(true); setOverflowOpen(false) }}
-                style={overflowItem}
+                onClick={() => openSidebar('guide')}
+                style={{ ...overflowItem, ...(sidebar === 'guide' ? activeChip : {}) }}
                 title="Open the field guide"
               >
                 Field Guide
               </button>
 
-              {/* History */}
+              {/* Looking back */}
               <button
                 type="button"
                 className="cc-btn"
                 onClick={() => { onOpenHistory(); setOverflowOpen(false) }}
                 disabled={!!replaySnapshots}
                 style={overflowItem}
-                title="View ecosystem history"
+                title="Wind the world back and watch it again"
               >
-                History
+                Replay
               </button>
 
-              {/* Log */}
               <button
                 type="button"
                 className="cc-btn"
-                onClick={() => { setHistoryOpen(true); setOverflowOpen(false) }}
-                style={overflowItem}
+                onClick={() => openSidebar('log')}
+                style={{ ...overflowItem, ...(sidebar === 'log' ? activeChip : {}) }}
                 title="View the event log"
               >
                 Log
@@ -593,15 +580,15 @@ export function Hud({
               <button
                 type="button"
                 className="cc-btn"
-                onClick={() => { setSettingsOpen(!settingsOpen); setOverflowOpen(false) }}
+                onClick={() => openSidebar('settings')}
                 style={{
                   ...overflowItem,
-                  ...(settingsOpen ? activeChip : {}),
-                  ...(tuned && !settingsOpen
+                  ...(sidebar === 'settings' ? activeChip : {}),
+                  ...(tuned && sidebar !== 'settings'
                     ? { borderColor: 'var(--cc-gold)', color: 'var(--cc-gold)' }
                     : {}),
                 }}
-                aria-pressed={settingsOpen}
+                aria-pressed={sidebar === 'settings'}
                 aria-label="World settings"
                 title={tuned ? 'The laws of this land have been changed' : 'Change the laws of this land'}
               >
@@ -611,19 +598,19 @@ export function Hud({
 
               <div style={{ height: 1, background: 'var(--cc-panel-divider)', margin: '2px 0' }} />
 
-              {/* Clear all — destructive */}
+              {/* Clear — its own panel, because "clear" is more than one question */}
               <button
                 type="button"
                 className="cc-btn"
-                onClick={() => { onClearLife(); setOverflowOpen(false) }}
+                onClick={() => openSidebar('clear')}
                 style={{
                   ...overflowItem,
                   borderColor: 'var(--cc-pink-border)',
                   color: 'var(--cc-pink)',
                 }}
-                title="Remove every living thing"
+                title="Take away the living things, or the whole land"
               >
-                Clear all
+                Clear…
               </button>
 
               <div style={{ height: 1, background: 'var(--cc-panel-divider)', margin: '2px 0' }} />

--- a/src/app/micro-land/components/settings-panel.tsx
+++ b/src/app/micro-land/components/settings-panel.tsx
@@ -1,7 +1,5 @@
 'use client'
 
-import { useEffect } from 'react'
-
 import {
   KNOBS,
   KNOB_GROUPS,
@@ -40,18 +38,16 @@ function show(knob: Knob, value: number): string {
 /**
  * The knobs, out of the way.
  *
- * A drawer down the side rather than a modal over the middle, and with no scrim
+ * A column down the side rather than a dialog over the middle, and with no scrim
  * behind it, because the whole reason to open it is to watch the world while you
- * drag. A dialog that dims what you are trying to look at would make every
+ * drag. Anything that dims what you are trying to look at would make every
  * setting a guess followed by a close-and-check.
  *
  * Every change lands on the next tick — there is no Apply. Ecosystem numbers are
  * not the kind of thing anyone can pick correctly in the abstract; you find the
  * right one by moving it until the meadow looks the way you meant.
  */
-export function SettingsPanel() {
-  const open = useMicroLand(s => s.settingsOpen)
-  const setOpen = useMicroLand(s => s.setSettingsOpen)
+export function SettingsPane() {
   const tuning = useMicroLand(s => s.tuning)
   const setKnob = useMicroLand(s => s.setTuningKnob)
   const reset = useMicroLand(s => s.resetTuningKnobs)
@@ -94,129 +90,66 @@ export function SettingsPanel() {
     }
   }
 
-  // Escape closes, wherever focus happens to be — the panel deliberately does
-  // not take focus away from the world, so it can't rely on catching the key
-  // itself.
-  useEffect(() => {
-    if (!open) return
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') setOpen(false)
-    }
-    window.addEventListener('keydown', onKey)
-    return () => window.removeEventListener('keydown', onKey)
-  }, [open, setOpen])
-
-  if (!open) return null
-
   const changed = (Object.keys(TUNING_DEFAULTS) as TuningKey[]).filter(
     key => tuning[key] !== TUNING_DEFAULTS[key]
   ).length
 
+  const toolButton: React.CSSProperties = {
+    fontFamily: 'var(--cc-font-mono)',
+    fontSize: 10,
+    letterSpacing: 1.2,
+    textTransform: 'uppercase',
+    padding: '6px 10px',
+    minHeight: 32,
+    borderRadius: 4,
+    border: '1px solid var(--cc-mint-line)',
+    color: 'var(--cc-text-muted)',
+  }
+
   return (
-    <div
-      role="dialog"
-      aria-label="World settings"
-      // Bottom sheet on a phone, drawer down the right on anything wider. The
-      // height cap has to come off on desktop or `inset-y-0` would pin a
-      // three-quarter-height panel to the top edge and leave a gap under it.
-      className="fixed inset-x-0 bottom-0 z-50 flex max-h-[72dvh] flex-col rounded-t-xl sm:inset-y-0 sm:left-auto sm:right-0 sm:w-[350px] sm:max-h-none sm:rounded-none"
-      style={{
-        background: 'linear-gradient(180deg, var(--cc-modal-bg-from), var(--cc-modal-bg-to))',
-        borderTop: '1px solid var(--cc-modal-border)',
-        borderLeft: '1px solid var(--cc-modal-border)',
-      }}
-    >
+    <>
+      {/* Copy, paste and reset act on every knob at once, so they sit above all
+          of them rather than beside any one of them. */}
       <div
-        className="flex shrink-0 items-center justify-between gap-2 px-4 py-3"
-        style={{
-          borderBottom: '1px solid var(--cc-panel-divider)',
-          background: 'var(--cc-modal-bg-from)',
-        }}
+        className="flex flex-wrap items-center gap-1 px-4 py-2"
+        style={{ borderBottom: '1px solid var(--cc-panel-divider)' }}
       >
-        <h2
-          style={{
-            fontFamily: 'var(--cc-font-mono)',
-            fontSize: 11,
-            letterSpacing: 2.5,
-            textTransform: 'uppercase',
-            color: 'var(--cc-mint)',
-          }}
+        <button
+          type="button"
+          className="cc-btn"
+          onClick={copySettings}
+          style={toolButton}
+          title="Copy all settings to clipboard as JSON"
         >
-          Laws of the land
-        </h2>
-        <div className="flex items-center gap-1">
-          <button
-            type="button"
-            className="cc-btn"
-            onClick={copySettings}
-            style={{
-              fontFamily: 'var(--cc-font-mono)',
-              fontSize: 10,
-              letterSpacing: 1.2,
-              textTransform: 'uppercase',
-              padding: '6px 8px',
-              minHeight: 32,
-              borderRadius: 4,
-              border: '1px solid var(--cc-mint-line)',
-              color: 'var(--cc-text-muted)',
-            }}
-            title="Copy all settings to clipboard as JSON"
-          >
-            Copy
-          </button>
-          <button
-            type="button"
-            className="cc-btn"
-            onClick={pasteSettings}
-            style={{
-              fontFamily: 'var(--cc-font-mono)',
-              fontSize: 10,
-              letterSpacing: 1.2,
-              textTransform: 'uppercase',
-              padding: '6px 8px',
-              minHeight: 32,
-              borderRadius: 4,
-              border: '1px solid var(--cc-mint-line)',
-              color: 'var(--cc-text-muted)',
-            }}
-            title="Paste settings from clipboard"
-          >
-            Paste
-          </button>
-          <button
-            type="button"
-            className="cc-btn"
-            onClick={reset}
-            disabled={changed === 0}
-            style={{
-              fontFamily: 'var(--cc-font-mono)',
-              fontSize: 10,
-              letterSpacing: 1.2,
-              textTransform: 'uppercase',
-              padding: '6px 8px',
-              minHeight: 32,
-              borderRadius: 4,
-              border: '1px solid var(--cc-mint-line)',
-              color: changed === 0 ? 'var(--cc-text-muted)' : 'var(--cc-gold)',
-              opacity: changed === 0 ? 0.4 : 1,
-            }}
-            title="Put every setting back to the way the game shipped"
-          >
-            Reset{changed > 0 ? ` (${changed})` : ''}
-          </button>
-          <button
-            type="button"
-            className="cc-btn"
-            onClick={() => setOpen(false)}
-            aria-label="Close settings"
-            style={{ minWidth: 40, minHeight: 32, color: 'var(--cc-text-muted)' }}
-          >
-            ✕
-          </button>
-        </div>
+          Copy
+        </button>
+        <button
+          type="button"
+          className="cc-btn"
+          onClick={pasteSettings}
+          style={toolButton}
+          title="Paste settings from clipboard"
+        >
+          Paste
+        </button>
+        <button
+          type="button"
+          className="cc-btn"
+          onClick={reset}
+          disabled={changed === 0}
+          style={{
+            ...toolButton,
+            color: changed === 0 ? 'var(--cc-text-muted)' : 'var(--cc-gold)',
+            opacity: changed === 0 ? 0.4 : 1,
+          }}
+          title="Put every setting back to the way the game shipped"
+        >
+          Reset{changed > 0 ? ` (${changed})` : ''}
+        </button>
       </div>
 
-      <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain">
+      <div>
+
         <p
           className="px-4 pt-3"
           style={{ fontSize: 12, color: 'var(--cc-text-muted)', lineHeight: 1.5 }}
@@ -254,7 +187,7 @@ export function SettingsPanel() {
 
         <div className="h-4" />
       </div>
-    </div>
+    </>
   )
 }
 

--- a/src/app/micro-land/components/sidebar.tsx
+++ b/src/app/micro-land/components/sidebar.tsx
@@ -1,0 +1,476 @@
+'use client'
+
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+import { WorkshopPane } from '@/app/micro-land/components/blueprint-workshop'
+import { ChallengesPane } from '@/app/micro-land/components/challenges-panel'
+import { FieldGuidePane } from '@/app/micro-land/components/field-guide'
+import { LogPane } from '@/app/micro-land/components/history-panel'
+import { SettingsPane } from '@/app/micro-land/components/settings-panel'
+import { WorldsPane } from '@/app/micro-land/components/worlds-panel'
+import { type SidebarView, useMicroLand } from '@/app/micro-land/store'
+
+/** What the header says, per panel. */
+const TITLES: Record<SidebarView, string> = {
+  guide: 'Field Guide',
+  worlds: 'Worlds',
+  creatures: 'Creatures',
+  challenges: 'Challenges',
+  log: 'Event Log',
+  settings: 'Laws of the Land',
+  clear: 'Clear',
+}
+
+const MIN_WIDTH = 240
+const MAX_WIDTH = 600
+const DEFAULT_WIDTH = 300
+const WIDTH_KEY = 'ml-sidebar-width'
+
+/**
+ * Whether there is room beside the world for a column.
+ *
+ * Below this the panel becomes a sheet over the bottom of the screen instead,
+ * which is what a 300px column on a 360px phone was always pretending to be.
+ * Starts false and corrects itself on mount: the store is built during the
+ * server render too, and a `matchMedia` read there answers differently than the
+ * browser will. Nothing is open on the first paint, so nobody sees the guess.
+ */
+function useRoomBeside(): boolean {
+  const [wide, setWide] = useState(false)
+  useEffect(() => {
+    const mq = window.matchMedia('(min-width: 640px)')
+    const update = () => setWide(mq.matches)
+    update()
+    mq.addEventListener('change', update)
+    return () => mq.removeEventListener('change', update)
+  }, [])
+  return wide
+}
+
+/**
+ * The one column down the right-hand side.
+ *
+ * Everything that used to be its own dialog, drawer or bottom sheet — the field
+ * guide, the shelf, the log, the knobs — is a pane in here now. Four panels
+ * meant four sets of chrome, four ways to close, and two of them could be open
+ * at once over the top of each other; the world they all describe is the thing
+ * that matters, and it deserves one predictable strip of screen taken away from
+ * it rather than an unpredictable stack.
+ */
+export function Sidebar({
+  onKeep,
+  onOpenWorld,
+  onForget,
+  onClearLife,
+  onClearWorld,
+}: {
+  onKeep: (name: string) => void
+  onOpenWorld: (id: string) => void
+  onForget: (id: string) => void
+  onClearLife: () => void
+  onClearWorld: () => void
+}) {
+  const view = useMicroLand(s => s.sidebar)
+  const setSidebar = useMicroLand(s => s.setSidebar)
+  const wide = useRoomBeside()
+
+  const [width, setWidth] = useState(() => {
+    try {
+      return Number(localStorage.getItem(WIDTH_KEY)) || DEFAULT_WIDTH
+    } catch {
+      return DEFAULT_WIDTH
+    }
+  })
+  const dragging = useRef(false)
+
+  const handleDragStart = useCallback((e: React.MouseEvent) => {
+    e.preventDefault()
+    dragging.current = true
+    const onMove = (ev: MouseEvent) => {
+      if (!dragging.current) return
+      setWidth(prev => Math.max(MIN_WIDTH, Math.min(MAX_WIDTH, prev - ev.movementX)))
+    }
+    const onUp = () => {
+      dragging.current = false
+      document.removeEventListener('mousemove', onMove)
+      document.removeEventListener('mouseup', onUp)
+      setWidth(prev => {
+        try {
+          localStorage.setItem(WIDTH_KEY, String(prev))
+        } catch {}
+        return prev
+      })
+    }
+    document.addEventListener('mousemove', onMove)
+    document.addEventListener('mouseup', onUp)
+  }, [])
+
+  if (!view) return null
+
+  return (
+    <aside
+      aria-label={TITLES[view]}
+      className={
+        wide
+          ? 'flex shrink-0 flex-col overflow-hidden'
+          : 'fixed inset-x-0 bottom-0 z-40 flex max-h-[75dvh] flex-col overflow-hidden rounded-t-xl'
+      }
+      style={{
+        position: wide ? 'relative' : undefined,
+        width: wide ? width : undefined,
+        borderLeft: wide ? '1px solid var(--cc-panel-divider)' : undefined,
+        borderTop: wide ? undefined : '1px solid var(--cc-modal-border)',
+        background: 'linear-gradient(180deg, var(--cc-modal-bg-from), var(--cc-modal-bg-to))',
+      }}
+    >
+      {/* Drag handle — the seam between the world and the panel. Pointer-only by
+          nature, so it is hidden from assistive tech and from the phone layout,
+          where the panel is the full width of the screen anyway. */}
+      {wide && (
+        <div
+          aria-hidden
+          onMouseDown={handleDragStart}
+          style={{
+            position: 'absolute',
+            left: 0,
+            top: 0,
+            bottom: 0,
+            width: 5,
+            cursor: 'ew-resize',
+            zIndex: 1,
+            background: 'transparent',
+          }}
+        />
+      )}
+
+      <div
+        className="flex shrink-0 items-center justify-between gap-2 px-3 py-2.5"
+        style={{
+          borderBottom: '1px solid var(--cc-panel-divider)',
+          background: 'var(--cc-modal-bg-from)',
+        }}
+      >
+        <h2
+          style={{
+            fontFamily: 'var(--cc-font-mono)',
+            fontSize: 11,
+            letterSpacing: 2.5,
+            textTransform: 'uppercase',
+            color: 'var(--cc-mint)',
+          }}
+        >
+          {TITLES[view]}
+        </h2>
+        <button
+          type="button"
+          className="cc-btn"
+          onClick={() => setSidebar(null)}
+          aria-label={`Close ${TITLES[view].toLowerCase()}`}
+          style={{ minWidth: 40, minHeight: 32, color: 'var(--cc-text-muted)' }}
+        >
+          ✕
+        </button>
+      </div>
+
+      {/* One scroller for every pane, so no panel has to grow its own. */}
+      <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain">
+        {view === 'guide' && <FieldGuidePane />}
+        {view === 'worlds' && (
+          <WorldsPane onKeep={onKeep} onOpen={onOpenWorld} onForget={onForget} />
+        )}
+        {view === 'creatures' && <CreaturesPane />}
+        {view === 'challenges' && <ChallengesPane />}
+        {view === 'log' && <LogPane />}
+        {view === 'settings' && <SettingsPane />}
+        {view === 'clear' && <ClearPane onClearLife={onClearLife} onClearWorld={onClearWorld} />}
+      </div>
+    </aside>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Creatures
+// ---------------------------------------------------------------------------
+
+/**
+ * The two ways to make a creature, behind one door.
+ *
+ * Tabs are a stopgap and are meant to read as one: drawing a thing and setting
+ * its numbers are two halves of the same act, and a player who draws a shape
+ * then wants it faster should not have to know which tool owns "faster". They
+ * are separate today because the drawing table and the trait sliders were built
+ * as separate tools; the tab row is the seam waiting to be closed.
+ *
+ * Drawing itself opens the full-screen table rather than happening in here. A
+ * pixel grid you can actually paint on, its ink wells, its frames and its
+ * stats do not fit a column — squeezing them in would make the tool worse to
+ * use in exchange for making the menu tidier.
+ */
+function CreaturesPane() {
+  const tab = useMicroLand(s => s.creaturesTab)
+  const setTab = useMicroLand(s => s.setCreaturesTab)
+  const setBuilderOpen = useMicroLand(s => s.setBuilderOpen)
+  const setSummonOpen = useMicroLand(s => s.setSummonOpen)
+
+  const tabStyle = (active: boolean): React.CSSProperties => ({
+    fontFamily: 'var(--cc-font-mono)',
+    fontSize: 10,
+    letterSpacing: 1.2,
+    textTransform: 'uppercase',
+    padding: '5px 12px',
+    minHeight: 30,
+    borderRadius: 4,
+    border: `1px solid ${active ? 'var(--cc-mint)' : 'var(--cc-panel-divider)'}`,
+    background: active ? 'var(--cc-mint-soft)' : 'transparent',
+    color: active ? 'var(--cc-mint)' : 'var(--cc-text-muted)',
+  })
+
+  return (
+    <>
+      <div
+        className="flex items-center gap-1 px-3 py-2"
+        style={{ borderBottom: '1px solid var(--cc-panel-divider)' }}
+        role="tablist"
+        aria-label="Ways to make a creature"
+      >
+        <button
+          type="button"
+          className="cc-btn"
+          role="tab"
+          aria-selected={tab === 'draw'}
+          onClick={() => setTab('draw')}
+          style={tabStyle(tab === 'draw')}
+        >
+          ✎ Draw
+        </button>
+        <button
+          type="button"
+          className="cc-btn"
+          role="tab"
+          aria-selected={tab === 'blueprints'}
+          onClick={() => setTab('blueprints')}
+          style={tabStyle(tab === 'blueprints')}
+        >
+          Blueprints
+        </button>
+      </div>
+
+      {tab === 'draw' ? (
+        <div className="flex flex-col gap-3 px-4 py-4">
+          <p style={{ fontSize: 12, color: 'var(--cc-text-muted)', lineHeight: 1.55 }}>
+            Colour a creature in square by square — its body, how it moves, what it eats — and set
+            it loose in the land. It will breed, and its children will look like it.
+          </p>
+          <button
+            type="button"
+            className="cc-btn"
+            onClick={() => setBuilderOpen(true)}
+            style={{
+              fontFamily: 'var(--cc-font-mono)',
+              fontSize: 10,
+              letterSpacing: 1.6,
+              textTransform: 'uppercase',
+              fontWeight: 700,
+              padding: '8px 14px',
+              minHeight: 36,
+              borderRadius: 4,
+              background: 'linear-gradient(180deg, var(--cc-mint), var(--cc-mint-hi))',
+              border: '1px solid var(--cc-mint)',
+              color: 'var(--cc-on-mint)',
+              boxShadow: 'var(--cc-mint-glow)',
+            }}
+          >
+            Open the drawing table
+          </button>
+          <p
+            style={{ fontSize: 11, color: 'var(--cc-text-muted)', opacity: 0.8, lineHeight: 1.55 }}
+          >
+            The table takes the whole screen — a grid worth painting on does not fit down here.
+          </p>
+          <div
+            className="flex flex-col gap-2 pt-1"
+            style={{ borderTop: '1px solid var(--cc-panel-divider)' }}
+          >
+            <p
+              style={{
+                fontSize: 11,
+                color: 'var(--cc-text-muted)',
+                opacity: 0.8,
+                lineHeight: 1.55,
+                paddingTop: 10,
+              }}
+            >
+              In a hurry? Describe one instead and it will be drawn for you.
+            </p>
+            <button
+              type="button"
+              className="cc-btn self-start"
+              onClick={() => setSummonOpen(true)}
+              style={{
+                fontFamily: 'var(--cc-font-mono)',
+                fontSize: 10,
+                letterSpacing: 1.2,
+                textTransform: 'uppercase',
+                padding: '6px 12px',
+                minHeight: 32,
+                borderRadius: 4,
+                border: '1px solid var(--cc-mint-line)',
+                color: 'var(--cc-text-muted)',
+              }}
+            >
+              Generate
+            </button>
+          </div>
+        </div>
+      ) : (
+        <WorkshopPane />
+      )}
+    </>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Clear
+// ---------------------------------------------------------------------------
+
+/**
+ * Taking things away, with the size of each act said out loud.
+ *
+ * Every one of these is permanent and none of them is undoable, so each asks
+ * once, in place, the way the shelf asks before it lets go of a world. The two
+ * are deliberately separated by how much they take: emptying the land of life
+ * leaves ground you can immediately put life back into, while emptying the land
+ * leaves nothing at all.
+ */
+function ClearPane({
+  onClearLife,
+  onClearWorld,
+}: {
+  onClearLife: () => void
+  onClearWorld: () => void
+}) {
+  const [asking, setAsking] = useState<'life' | 'world' | null>(null)
+  const setSidebar = useMicroLand(s => s.setSidebar)
+
+  const run = (act: () => void) => {
+    act()
+    setAsking(null)
+    setSidebar(null)
+  }
+
+  return (
+    <div className="flex flex-col">
+      <p
+        className="px-4 py-3"
+        style={{ fontSize: 12, color: 'var(--cc-text-muted)', lineHeight: 1.55 }}
+      >
+        Nothing here can be undone. Whatever you take away is gone — but the land will always let
+        you start again.
+      </p>
+
+      <ClearOption
+        title="The living things"
+        blurb="Every plant and every animal. The ground, the water and the weather stay exactly as they are."
+        confirm="Clear every living thing?"
+        asking={asking === 'life'}
+        onAsk={() => setAsking('life')}
+        onCancel={() => setAsking(null)}
+        onConfirm={() => run(onClearLife)}
+      />
+
+      <ClearOption
+        title="Everything"
+        blurb="The creatures and the land itself. You are left with an empty sky to build in."
+        confirm="Clear the whole world?"
+        asking={asking === 'world'}
+        onAsk={() => setAsking('world')}
+        onCancel={() => setAsking(null)}
+        onConfirm={() => run(onClearWorld)}
+      />
+    </div>
+  )
+}
+
+function ClearOption({
+  title,
+  blurb,
+  confirm,
+  asking,
+  onAsk,
+  onCancel,
+  onConfirm,
+}: {
+  title: string
+  blurb: string
+  confirm: string
+  asking: boolean
+  onAsk: () => void
+  onCancel: () => void
+  onConfirm: () => void
+}) {
+  const button: React.CSSProperties = {
+    fontFamily: 'var(--cc-font-mono)',
+    fontSize: 10,
+    letterSpacing: 1.2,
+    textTransform: 'uppercase',
+    padding: '7px 12px',
+    minHeight: 34,
+    borderRadius: 4,
+    border: '1px solid var(--cc-mint-line)',
+    background: 'transparent',
+    color: 'var(--cc-text-muted)',
+  }
+
+  return (
+    <section
+      className="flex flex-col gap-2 px-4 py-3"
+      style={{ borderTop: '1px solid var(--cc-panel-divider)' }}
+    >
+      <h3
+        style={{
+          fontFamily: 'var(--cc-font-mono)',
+          fontSize: 10,
+          letterSpacing: 2,
+          textTransform: 'uppercase',
+          color: 'var(--cc-text-muted)',
+        }}
+      >
+        {title}
+      </h3>
+      <p style={{ fontSize: 12, color: 'var(--cc-text-muted)', lineHeight: 1.55 }}>{blurb}</p>
+
+      {asking ? (
+        <>
+          <p style={{ fontSize: 12, color: 'var(--cc-gold)' }}>{confirm}</p>
+          <div className="flex items-center gap-1.5">
+            <button
+              type="button"
+              className="cc-btn"
+              onClick={onConfirm}
+              style={{
+                ...button,
+                borderColor: 'var(--cc-pink-border)',
+                background: 'var(--cc-pink-soft)',
+                color: 'var(--cc-pink)',
+              }}
+            >
+              Clear
+            </button>
+            <button type="button" className="cc-btn" onClick={onCancel} style={button}>
+              Cancel
+            </button>
+          </div>
+        </>
+      ) : (
+        <button
+          type="button"
+          className="cc-btn self-start"
+          onClick={onAsk}
+          style={{ ...button, borderColor: 'var(--cc-pink-border)', color: 'var(--cc-pink)' }}
+        >
+          Clear {title.toLowerCase()}
+        </button>
+      )}
+    </section>
+  )
+}

--- a/src/app/micro-land/components/toolbar.tsx
+++ b/src/app/micro-land/components/toolbar.tsx
@@ -29,7 +29,6 @@ import { type Tool, useMicroLand } from '@/app/micro-land/store'
 
 import { CreaturePortrait } from './creature-chip'
 import { CreatureFilterBar } from './creature-filter'
-import { SparkleIcon } from './sparkle-icon'
 import { SummonSand } from './summon-sand'
 
 const BRUSHES = [2, 4, 8, 14]
@@ -89,8 +88,6 @@ export function Toolbar({
   const setBrushShape = useMicroLand(s => s.setBrushShape)
   const blueprints = useMicroLand(s => s.blueprints)
   const pending = useMicroLand(s => s.pendingSummons)
-  const setSummonOpen = useMicroLand(s => s.setSummonOpen)
-  const setBuilderOpen = useMicroLand(s => s.setBuilderOpen)
   const open = useMicroLand(s => s.toolbarOpen)
   const setOpen = useMicroLand(s => s.setToolbarOpen)
 
@@ -537,84 +534,12 @@ export function Toolbar({
             </div>
           )}
 
-          {/* --- creatures --- */}
-          {/* Wraps: Generate, Draw and Inspect together overflow a 360px phone. */}
+          {/* Generate, Draw and Inspect used to sit here as well as up in the
+              header — the same three verbs twice, on the surface that is meant
+              to be about what is in your hand right now. Generate and Inspect
+              live in the header; Draw lives in the creatures panel. What is left
+              is the hint. */}
           <div className="flex flex-wrap items-center gap-2">
-            <span style={label}>Creatures</span>
-            <button
-              type="button"
-              className="cc-btn"
-              onClick={() => setSummonOpen(true)}
-              style={{
-                fontFamily: 'var(--cc-font-mono)',
-                fontSize: 10,
-                letterSpacing: 1.6,
-                textTransform: 'uppercase',
-                fontWeight: 700,
-                padding: '6px 14px',
-                minHeight: 32,
-                borderRadius: 4,
-                background: 'linear-gradient(180deg, var(--cc-mint), var(--cc-mint-hi))',
-                border: '1px solid var(--cc-mint)',
-                color: 'var(--cc-on-mint)',
-                boxShadow: 'var(--cc-mint-glow)',
-                display: 'inline-flex',
-                alignItems: 'center',
-                gap: 6,
-              }}
-            >
-              <SparkleIcon size={12} />
-              Generate
-            </button>
-            {/* Secondary to Generate on purpose: one primary-action colour per
-            screen, and drawing is the slower, more deliberate of the two. */}
-            <button
-              type="button"
-              className="cc-btn"
-              onClick={() => setBuilderOpen(true)}
-              title="Colour in a creature yourself, square by square"
-              style={{
-                fontFamily: 'var(--cc-font-mono)',
-                fontSize: 10,
-                letterSpacing: 1.6,
-                textTransform: 'uppercase',
-                padding: '6px 12px',
-                minHeight: 32,
-                borderRadius: 4,
-                border: '1px solid var(--cc-mint-line)',
-                background: 'transparent',
-                color: 'var(--cc-text-muted)',
-              }}
-            >
-              ✎ Draw
-            </button>
-            <button
-              type="button"
-              className="cc-btn"
-              onClick={() =>
-                setTool(
-                  tool.kind === 'inspect'
-                    ? { kind: 'material', material: 'dirt' }
-                    : { kind: 'inspect' }
-                )
-              }
-              aria-pressed={tool.kind === 'inspect'}
-              title="Tap a creature to see how it is doing"
-              style={{
-                fontFamily: 'var(--cc-font-mono)',
-                fontSize: 10,
-                letterSpacing: 1.6,
-                textTransform: 'uppercase',
-                padding: '6px 12px',
-                minHeight: 32,
-                borderRadius: 4,
-                border: `1px solid ${tool.kind === 'inspect' ? 'var(--cc-mint)' : 'var(--cc-mint-line)'}`,
-                background: tool.kind === 'inspect' ? 'var(--cc-mint-soft)' : 'transparent',
-                color: tool.kind === 'inspect' ? 'var(--cc-mint)' : 'var(--cc-text-muted)',
-              }}
-            >
-              ⌕ Inspect
-            </button>
             <span
               style={{
                 fontFamily: 'var(--cc-font-mono)',

--- a/src/app/micro-land/components/worlds-panel.tsx
+++ b/src/app/micro-land/components/worlds-panel.tsx
@@ -2,9 +2,9 @@
 
 import { useState } from 'react'
 
-import { THEME_BY_ID } from '@/app/micro-land/domain/config/themes'
+import { THEMES, THEME_BY_ID } from '@/app/micro-land/domain/config/themes'
 import { formatDuration } from '@/app/micro-land/format'
-import { useMicroLand } from '@/app/micro-land/store'
+import { SUMMONED_THEME_ID, useMicroLand } from '@/app/micro-land/store'
 import { MAX_SAVED_WORLDS, cleanWorldName } from '@/app/micro-land/worlds/wire'
 
 const heading: React.CSSProperties = {
@@ -51,14 +51,14 @@ function since(at: number): string {
  * Two things this panel is careful about, both because the person using it is a
  * child mid-play:
  *
- * - Letting go of a world asks first, in place, on the row itself. A modal on
- *   top of a modal is a wall; a row that turns into "Really?" is a question.
- * - Opening a world says out loud that the one on screen is not being kept,
- *   *before* the tap rather than after it. The alternative is a child losing a
- *   land they had been building for twenty minutes and learning that the shelf
- *   is dangerous.
+ * - Letting go of a world asks first, in place, on the row itself. A dialog on
+ *   top of the panel is a wall; a row that turns into "Really?" is a question.
+ * - Opening a world — or starting over from a template — says out loud that the
+ *   one on screen is not being kept, *before* the tap rather than after it. The
+ *   alternative is a child losing a land they had been building for twenty
+ *   minutes and learning that the shelf is dangerous.
  */
-export function WorldsPanel({
+export function WorldsPane({
   onKeep,
   onOpen,
   onForget,
@@ -67,21 +67,32 @@ export function WorldsPanel({
   onOpen: (id: string) => void
   onForget: (id: string) => void
 }) {
-  const open = useMicroLand(s => s.worldsOpen)
-  const setOpen = useMicroLand(s => s.setWorldsOpen)
   const shelf = useMicroLand(s => s.shelf)
   const themeId = useMicroLand(s => s.themeId)
+  const setTheme = useMicroLand(s => s.setTheme)
   const summonedLand = useMicroLand(s => s.summonedLand)
   const total = useMicroLand(s => s.totalCreatures)
 
   const [name, setName] = useState('')
   const [confirming, setConfirming] = useState<string | null>(null)
-
-  if (!open) return null
+  const [startingOver, setStartingOver] = useState<string | null>(null)
 
   const active = shelf.worlds.find(w => w.id === shelf.activeId) ?? null
   const full = shelf.worlds.length >= MAX_SAVED_WORLDS && !active
-  const here = summonedLand ?? THEME_BY_ID[themeId]?.name ?? 'This land'
+  // Only *while you are standing in it*. `summonedLand` outlives the land it
+  // named — it stays on the template list after you have moved on — so reading
+  // it unconditionally used to caption an ordinary Cross-Section world with the
+  // name of a summoned land the player left an hour ago.
+  const here =
+    themeId === SUMMONED_THEME_ID
+      ? (summonedLand ?? 'This land')
+      : (THEME_BY_ID[themeId]?.name ?? 'This land')
+
+  // The land the player asked the model for is a template too — it is the one
+  // land they cannot get back any other way once they have left it.
+  const templates = summonedLand
+    ? [...THEMES, { id: SUMMONED_THEME_ID, name: summonedLand, blurb: 'The land you asked for.' }]
+    : THEMES
 
   // Through the same cleaner the server would apply, so a world is called the
   // same thing whether it was kept on this device or on the account.
@@ -91,161 +102,224 @@ export function WorldsPanel({
   }
 
   return (
-    <div
-      className="fixed inset-0 z-50 flex items-end justify-center sm:items-center"
-      style={{ background: 'var(--cc-modal-scrim)' }}
-      onClick={() => setOpen(false)}
-    >
-      <div
-        role="dialog"
-        aria-modal="true"
-        aria-label="Saved worlds"
-        className="w-full max-w-lg overflow-y-auto rounded-t-xl sm:rounded-xl"
-        style={{
-          maxHeight: '88dvh',
-          background: 'linear-gradient(180deg, var(--cc-modal-bg-from), var(--cc-modal-bg-to))',
-          border: '1px solid var(--cc-modal-border)',
-        }}
-        onClick={e => e.stopPropagation()}
+    <>
+      <section
+        className="flex flex-col gap-2 px-4 py-3"
+        style={{ borderBottom: '1px solid var(--cc-panel-divider)' }}
       >
-        <div
-          className="sticky top-0 flex items-center justify-between px-4 py-3"
-          style={{
-            borderBottom: '1px solid var(--cc-panel-divider)',
-            background: 'var(--cc-modal-bg-from)',
-          }}
-        >
-          <h2
-            style={{
-              fontFamily: 'var(--cc-font-mono)',
-              fontSize: 11,
-              letterSpacing: 2.5,
-              textTransform: 'uppercase',
-              color: 'var(--cc-mint)',
+        <h3 style={heading}>{active ? 'Saved as' : 'Save this world'}</h3>
+        <p style={{ fontSize: 12, color: 'var(--cc-text-muted)' }}>
+          {active
+            ? `${active.name} — everything you do here is written back on its own.`
+            : `${here}, ${total} alive. Give it a name and it will be waiting exactly like this.`}
+        </p>
+        <div className="flex items-center gap-2">
+          <label className="sr-only" htmlFor="micro-land-world-name">
+            Name this world
+          </label>
+          <input
+            id="micro-land-world-name"
+            value={name}
+            onChange={e => setName(e.target.value)}
+            onKeyDown={e => {
+              if (e.key === 'Enter') keep()
             }}
-          >
-            Your worlds
-          </h2>
+            maxLength={40}
+            placeholder={active ? active.name : here}
+            className="min-w-0 flex-1"
+            style={{
+              fontSize: 13,
+              padding: '8px 10px',
+              minHeight: 38,
+              borderRadius: 4,
+              border: '1px solid var(--cc-mint-line)',
+              background: 'var(--cc-panel-grad-to)',
+              color: 'var(--cc-text-default)',
+            }}
+          />
           <button
             type="button"
-            className="cc-btn"
-            onClick={() => setOpen(false)}
-            aria-label="Close"
-            style={{ minWidth: 44, minHeight: 34, color: 'var(--cc-text-muted)' }}
+            className="cc-btn shrink-0"
+            onClick={keep}
+            disabled={shelf.busy || full}
+            style={{ ...primaryButton, opacity: shelf.busy || full ? 0.45 : 1 }}
           >
-            ✕
+            Save
           </button>
         </div>
-
-        <section
-          className="flex flex-col gap-2 px-4 py-3"
-          style={{ borderBottom: '1px solid var(--cc-panel-divider)' }}
-        >
-          <h3 style={heading}>{active ? 'Saved as' : 'Save this world'}</h3>
-          <p style={{ fontSize: 12, color: 'var(--cc-text-muted)' }}>
-            {active
-              ? `${active.name} — everything you do here is written back on its own.`
-              : `${here}, ${total} alive. Give it a name and it will be waiting exactly like this.`}
+        {full && (
+          <p style={{ fontSize: 11, color: 'var(--cc-gold)' }}>
+            You can save {MAX_SAVED_WORLDS} worlds. Delete one to make room.
           </p>
-          <div className="flex items-center gap-2">
-            <label className="sr-only" htmlFor="micro-land-world-name">
-              Name this world
-            </label>
-            <input
-              id="micro-land-world-name"
-              value={name}
-              onChange={e => setName(e.target.value)}
-              onKeyDown={e => {
-                if (e.key === 'Enter') keep()
-              }}
-              maxLength={40}
-              placeholder={active ? active.name : here}
-              className="min-w-0 flex-1"
-              style={{
-                fontSize: 13,
-                padding: '8px 10px',
-                minHeight: 38,
-                borderRadius: 4,
-                border: '1px solid var(--cc-mint-line)',
-                background: 'var(--cc-panel-grad-to)',
-                color: 'var(--cc-text-default)',
-              }}
-            />
-            <button
-              type="button"
-              className="cc-btn shrink-0"
-              onClick={keep}
-              disabled={shelf.busy || full}
-              style={{ ...primaryButton, opacity: shelf.busy || full ? 0.45 : 1 }}
-            >
-              Save
-            </button>
-          </div>
-          {full && (
-            <p style={{ fontSize: 11, color: 'var(--cc-gold)' }}>
-              You can save {MAX_SAVED_WORLDS} worlds. Delete one to make room.
-            </p>
-          )}
-          {shelf.error && (
-            <p style={{ fontSize: 11, color: 'var(--cc-gold)' }}>The cave says: {shelf.error}</p>
-          )}
-        </section>
+        )}
+        {shelf.error && (
+          <p style={{ fontSize: 11, color: 'var(--cc-gold)' }}>The cave says: {shelf.error}</p>
+        )}
+      </section>
 
-        <section className="flex flex-col gap-2 px-4 py-3">
-          <h3 style={heading}>
-            Saved worlds · {shelf.worlds.length}/{MAX_SAVED_WORLDS}
-          </h3>
+      <section className="flex flex-col gap-2 px-4 py-3">
+        <h3 style={heading}>
+          Saved worlds · {shelf.worlds.length}/{MAX_SAVED_WORLDS}
+        </h3>
 
-          {shelf.worlds.length === 0 && (
-            <p style={{ fontSize: 12, color: 'var(--cc-text-muted)' }}>
-              No saved worlds yet. A world you save comes back exactly as you left it — same ground,
-              same creatures, same hungers.
-            </p>
-          )}
+        {shelf.worlds.length === 0 && (
+          <p style={{ fontSize: 12, color: 'var(--cc-text-muted)' }}>
+            No saved worlds yet. A world you save comes back exactly as you left it — same ground,
+            same creatures, same hungers.
+          </p>
+        )}
 
-          <ul className="flex flex-col gap-2">
-            {shelf.worlds.map(world => {
-              const isActive = world.id === shelf.activeId
-              return (
-                <li
-                  key={world.id}
-                  className="flex items-center gap-3 rounded px-3 py-2"
+        <ul className="flex flex-col gap-2">
+          {shelf.worlds.map(world => {
+            const isActive = world.id === shelf.activeId
+            return (
+              <li
+                key={world.id}
+                className="flex items-center gap-3 rounded px-3 py-2"
+                style={{
+                  border: `1px solid ${isActive ? 'var(--cc-mint)' : 'var(--cc-mint-line)'}`,
+                  background: isActive ? 'var(--cc-mint-soft)' : 'transparent',
+                }}
+              >
+                <div className="min-w-0 flex-1">
+                  <p
+                    className="truncate"
+                    style={{ fontSize: 13, color: 'var(--cc-text-default)' }}
+                  >
+                    {world.name}
+                    {isActive && (
+                      <span style={{ color: 'var(--cc-mint)', fontSize: 11 }}> · open now</span>
+                    )}
+                  </p>
+                  <p
+                    style={{
+                      fontFamily: 'var(--cc-font-mono)',
+                      fontSize: 10,
+                      color: 'var(--cc-text-muted)',
+                    }}
+                  >
+                    {world.landName ?? THEME_BY_ID[world.themeId]?.name ?? world.themeId} ·{' '}
+                    {world.creatures} alive · {formatDuration(world.elapsed)} old ·{' '}
+                    {since(world.updatedAt)}
+                  </p>
+                </div>
+
+                {confirming === world.id ? (
+                  <div className="flex shrink-0 items-center gap-1.5">
+                    <button
+                      type="button"
+                      className="cc-btn"
+                      onClick={() => {
+                        onForget(world.id)
+                        setConfirming(null)
+                      }}
+                      style={{
+                        ...buttonBase,
+                        borderColor: 'var(--cc-pink-border)',
+                        background: 'var(--cc-pink-soft)',
+                        color: 'var(--cc-pink)',
+                      }}
+                    >
+                      Delete
+                    </button>
+                    <button
+                      type="button"
+                      className="cc-btn"
+                      onClick={() => setConfirming(null)}
+                      style={buttonBase}
+                    >
+                      Cancel
+                    </button>
+                  </div>
+                ) : (
+                  <div className="flex shrink-0 items-center gap-1.5">
+                    {!isActive && (
+                      <button
+                        type="button"
+                        className="cc-btn"
+                        // The panel stays open: it is a column beside the
+                        // world rather than a sheet over it, and the row it
+                        // just opened turns into "open now" where you can see
+                        // it happen.
+                        onClick={() => onOpen(world.id)}
+                        disabled={shelf.busy}
+                        style={{ ...primaryButton, opacity: shelf.busy ? 0.45 : 1 }}
+                      >
+                        Open
+                      </button>
+                    )}
+                    <button
+                      type="button"
+                      className="cc-btn"
+                      onClick={() => setConfirming(world.id)}
+                      aria-label={`Delete ${world.name}`}
+                      style={buttonBase}
+                    >
+                      Delete
+                    </button>
+                  </div>
+                )}
+              </li>
+            )
+          })}
+        </ul>
+
+        {!active && shelf.worlds.length > 0 && (
+          <p style={{ fontSize: 11, color: 'var(--cc-text-muted)' }}>
+            The land you are in now is not saved. Opening one of these leaves it behind.
+          </p>
+        )}
+      </section>
+
+      {/*
+        The world picker used to be a <select> tucked inside the overflow menu,
+        which made "change the land I am in" a settings-shaped act performed
+        from a dropdown. It belongs here, beside the worlds you kept, and named
+        for what it actually does: everything on screen is replaced by a fresh
+        build of whichever template you pick.
+      */}
+      <section
+        className="flex flex-col gap-2 px-4 py-3"
+        style={{ borderTop: '1px solid var(--cc-panel-divider)' }}
+      >
+        <h3 style={heading}>Start from a template</h3>
+        <p style={{ fontSize: 12, color: 'var(--cc-text-muted)' }}>
+          A new land, built from scratch. Whatever is on screen now is left behind.
+        </p>
+
+        <ul className="flex flex-col gap-1.5">
+          {templates.map(template => {
+            const isHere = template.id === themeId
+            const asking = startingOver === template.id
+            return (
+              <li key={template.id}>
+                <div
+                  className="flex items-center gap-2 rounded px-3 py-2"
                   style={{
-                    border: `1px solid ${isActive ? 'var(--cc-mint)' : 'var(--cc-mint-line)'}`,
-                    background: isActive ? 'var(--cc-mint-soft)' : 'transparent',
+                    border: `1px solid ${isHere ? 'var(--cc-mint)' : 'var(--cc-mint-line)'}`,
+                    background: isHere ? 'var(--cc-mint-soft)' : 'transparent',
                   }}
                 >
                   <div className="min-w-0 flex-1">
-                    <p
-                      className="truncate"
-                      style={{ fontSize: 13, color: 'var(--cc-text-default)' }}
-                    >
-                      {world.name}
-                      {isActive && (
-                        <span style={{ color: 'var(--cc-mint)', fontSize: 11 }}> · open now</span>
+                    <p style={{ fontSize: 13, color: 'var(--cc-text-default)' }}>
+                      {template.name}
+                      {isHere && (
+                        <span style={{ color: 'var(--cc-mint)', fontSize: 11 }}>
+                          {' '}
+                          · you are here
+                        </span>
                       )}
                     </p>
-                    <p
-                      style={{
-                        fontFamily: 'var(--cc-font-mono)',
-                        fontSize: 10,
-                        color: 'var(--cc-text-muted)',
-                      }}
-                    >
-                      {world.landName ?? THEME_BY_ID[world.themeId]?.name ?? world.themeId} ·{' '}
-                      {world.creatures} alive · {formatDuration(world.elapsed)} old ·{' '}
-                      {since(world.updatedAt)}
-                    </p>
+                    <p style={{ fontSize: 11, color: 'var(--cc-text-muted)' }}>{template.blurb}</p>
                   </div>
-
-                  {confirming === world.id ? (
+                  {asking ? (
                     <div className="flex shrink-0 items-center gap-1.5">
                       <button
                         type="button"
                         className="cc-btn"
                         onClick={() => {
-                          onForget(world.id)
-                          setConfirming(null)
+                          setTheme(template.id)
+                          setStartingOver(null)
                         }}
                         style={{
                           ...buttonBase,
@@ -254,56 +328,44 @@ export function WorldsPanel({
                           color: 'var(--cc-pink)',
                         }}
                       >
-                        Delete
+                        Start
                       </button>
                       <button
                         type="button"
                         className="cc-btn"
-                        onClick={() => setConfirming(null)}
+                        onClick={() => setStartingOver(null)}
                         style={buttonBase}
                       >
                         Cancel
                       </button>
                     </div>
                   ) : (
-                    <div className="flex shrink-0 items-center gap-1.5">
-                      {!isActive && (
-                        <button
-                          type="button"
-                          className="cc-btn"
-                          onClick={() => {
-                            onOpen(world.id)
-                            setOpen(false)
-                          }}
-                          disabled={shelf.busy}
-                          style={{ ...primaryButton, opacity: shelf.busy ? 0.45 : 1 }}
-                        >
-                          Open
-                        </button>
-                      )}
-                      <button
-                        type="button"
-                        className="cc-btn"
-                        onClick={() => setConfirming(world.id)}
-                        aria-label={`Delete ${world.name}`}
-                        style={buttonBase}
-                      >
-                        Delete
-                      </button>
-                    </div>
+                    <button
+                      type="button"
+                      className="cc-btn shrink-0"
+                      // A world already on the shelf is written back before it
+                      // is replaced, so leaving it costs nothing and the
+                      // question would only be noise. An unsaved one is gone.
+                      onClick={() =>
+                        active ? setTheme(template.id) : setStartingOver(template.id)
+                      }
+                      aria-label={`Start from ${template.name}`}
+                      style={buttonBase}
+                    >
+                      Start
+                    </button>
                   )}
-                </li>
-              )
-            })}
-          </ul>
-
-          {!active && shelf.worlds.length > 0 && (
-            <p style={{ fontSize: 11, color: 'var(--cc-text-muted)' }}>
-              The land you are in now is not saved. Opening one of these leaves it behind.
-            </p>
-          )}
-        </section>
-      </div>
-    </div>
+                </div>
+                {asking && (
+                  <p style={{ fontSize: 11, color: 'var(--cc-gold)', padding: '4px 3px 0' }}>
+                    {here} is not saved. Starting over leaves it behind for good.
+                  </p>
+                )}
+              </li>
+            )
+          })}
+        </ul>
+      </section>
+    </>
   )
 }

--- a/src/app/micro-land/domain/config/themes.ts
+++ b/src/app/micro-land/domain/config/themes.ts
@@ -1921,4 +1921,14 @@ export const THEMES: Theme[] = [
 
 export const THEME_BY_ID: Record<string, Theme> = Object.fromEntries(THEMES.map(t => [t.id, t]))
 
-export const DEFAULT_THEME = 'empty'
+/**
+ * The land with nothing in it.
+ *
+ * Named separately from `DEFAULT_THEME` even though they are the same string
+ * today: one is "where a new player starts", the other is "what clearing the
+ * world means", and a decision to open somewhere less bare should not silently
+ * redefine empty.
+ */
+export const EMPTY_THEME_ID = 'empty'
+
+export const DEFAULT_THEME = EMPTY_THEME_ID

--- a/src/app/micro-land/game-instance.ts
+++ b/src/app/micro-land/game-instance.ts
@@ -36,7 +36,7 @@ import {
 } from './domain/blueprint'
 import { BIOME_BY_ID } from './domain/config/biomes'
 import { MILESTONES, type MilestoneContext } from './domain/config/milestones'
-import { DEFAULT_THEME, THEME_BY_ID, type Theme } from './domain/config/themes'
+import { DEFAULT_THEME, EMPTY_THEME_ID, THEME_BY_ID, type Theme } from './domain/config/themes'
 import { ELDER_MIN_SECONDS, TICK_S, TILE_TICK_EVERY, WORLD_H, WORLD_W } from './domain/constants'
 import { type SimEvent, emitParticles, tickCreatures } from './domain/sim/creature-sim'
 import { makeRng } from './domain/sim/prng'
@@ -1576,6 +1576,33 @@ export class GameInstance {
     // Emptying the world is an extinction of everything, so the streak goes with
     // it — but silently, since the player did it on purpose.
     this.beginLand()
+    this.pushStats()
+  }
+
+  /**
+   * Take the land back to nothing — no ground, no water, no creatures.
+   *
+   * The store's theme is moved *first*: a theme change comes back through the
+   * subscriber as another `setTheme` on this instance, and that rebuild would
+   * undo the dormancy set at the end. Letting it land before the wipe leaves
+   * this method with the last word.
+   *
+   * Not just the store call on its own, either. It only fires the subscriber
+   * when the theme actually changes, so a player who has been painting on the
+   * empty theme would tap this and watch nothing happen.
+   *
+   * `summonedLand` deliberately survives. It is not a fact about the land on
+   * screen, it is the one template a player cannot get back any other way, and
+   * switching to a built-in theme has never dropped it either.
+   */
+  clearWorld(): void {
+    useMicroLand.getState().setTheme(EMPTY_THEME_ID)
+    this.setTheme(EMPTY_THEME_ID)
+    // Same reason as `clearLife`: without this the soil's seed bank puts plants
+    // back within seconds, and "empty" would not survive being looked at. There
+    // is no fertile ground left to seed from here, but painting some in is the
+    // obvious next move and that is exactly when it would surprise someone.
+    this.world.dormant = true
     this.pushStats()
   }
 

--- a/src/app/micro-land/store.ts
+++ b/src/app/micro-land/store.ts
@@ -21,6 +21,27 @@ import {
   setTuning,
 } from './domain/tuning'
 
+/**
+ * The panels that share the one column down the right-hand side.
+ *
+ * One slot rather than a boolean each, because they occupy the same strip of
+ * screen: two of them open at once used to mean a settings drawer floating over
+ * the field guide, and closing the top one revealed a panel the player had
+ * forgotten was there. A single value makes "open the log" and "close whatever
+ * was open" the same action.
+ */
+export type SidebarView =
+  | 'guide'
+  | 'worlds'
+  | 'creatures'
+  | 'challenges'
+  | 'log'
+  | 'settings'
+  | 'clear'
+
+/** The two ways into a new creature, side by side until they become one. */
+export type CreaturesTab = 'draw' | 'blueprints'
+
 export interface SpeedRunState {
   active: boolean
   targetGeneration: number
@@ -313,20 +334,18 @@ interface MicroLandState {
    * summon panel being opened and closed around it.
    */
   builderOpen: boolean
-  guideOpen: boolean
-  settingsOpen: boolean
+  /** Which panel the right-hand column is showing, or `null` for none. */
+  sidebar: SidebarView | null
+  /** Which half of the creatures panel is in front. */
+  creaturesTab: CreaturesTab
   graphOpen: boolean
-  challengesOpen: boolean
   challengeActive: { name: string; goal: string } | null
-  workshopOpen: boolean
   workshopSpawnRequest: WorkshopSpawnRequest | null
   speedRun: SpeedRunState
   adaptiveRun: AdaptiveRunState
   /** Incremented each time a world reshuffle is needed; watched by MicroLandGame. */
   reshuffleToken: number
-  setChallengesOpen: (open: boolean) => void
   setChallengeActive: (c: { name: string; goal: string } | null) => void
-  setWorkshopOpen: (open: boolean) => void
   requestWorkshopSpawn: (blueprint: CreatureBlueprint, traits: Traits) => void
   clearWorkshopSpawnRequest: () => void
   startSpeedRun: (targetGeneration: number, timeLimitSeconds: number, currentElapsed: number) => void
@@ -389,7 +408,6 @@ interface MicroLandState {
 
   /** Event history log, newest first, capped at 500 entries. */
   historyLog: HistoryEntry[]
-  historyOpen: boolean
 
   /**
    * What the chronicle's storage layer is doing.
@@ -410,11 +428,10 @@ interface MicroLandState {
    * copy so panels can render it like any other state.
    */
   shelf: ShelfState
-  worldsOpen: boolean
 
   /** Set when the field guide asks to find a species in the world. */
   locateRequest: { blueprintId: string; serial: number } | null
-  /** Close the guide and emit a locate request for the game instance to handle. */
+  /** Close the sidebar and emit a locate request for the game instance to handle. */
   requestLocate: (blueprintId: string) => void
 
   /**
@@ -492,8 +509,11 @@ interface MicroLandState {
   addPendingSummon: (prompt: string) => number
   removePendingSummon: (id: number) => void
   setBuilderOpen: (open: boolean) => void
-  setGuideOpen: (open: boolean) => void
-  setSettingsOpen: (open: boolean) => void
+  /** Show a panel in the right-hand column, or `null` to close it. */
+  setSidebar: (view: SidebarView | null) => void
+  /** Open a panel, or close it if it is the one already showing. */
+  toggleSidebar: (view: SidebarView) => void
+  setCreaturesTab: (tab: CreaturesTab) => void
   setGraphOpen: (open: boolean) => void
   /** Roll the tool drawer up or down. Remembered for the next visit. */
   setToolbarOpen: (open: boolean) => void
@@ -527,11 +547,9 @@ interface MicroLandState {
   setZoomState: (canZoomIn: boolean, canZoomOut: boolean) => void
   setSaveState: (state: SaveState) => void
   setShelf: (shelf: ShelfState) => void
-  setWorldsOpen: (open: boolean) => void
   notify: (text: string, action?: Notice['action']) => void
   dismissNotice: (id: number) => void
   addHistoryEntry: (entry: Omit<HistoryEntry, 'id'>) => void
-  setHistoryOpen: (open: boolean) => void
 }
 
 let noticeId = 0
@@ -591,12 +609,10 @@ export const useMicroLand = create<MicroLandState>(set => ({
   summonError: null,
   pendingSummons: [],
   builderOpen: false,
-  guideOpen: false,
-  settingsOpen: false,
+  sidebar: null,
+  creaturesTab: 'draw',
   graphOpen: false,
-  challengesOpen: false,
   challengeActive: null,
-  workshopOpen: false,
   workshopSpawnRequest: null,
   speedRun: { active: false, targetGeneration: 10, timeLimitSeconds: 300, startElapsed: 0, result: 'none', wonSeconds: null },
   adaptiveRun: { active: false, targetPopulation: 10, sustainedSeconds: 0, sustainGoal: 60, result: 'none' },
@@ -614,10 +630,8 @@ export const useMicroLand = create<MicroLandState>(set => ({
 
   notices: [],
   historyLog: [],
-  historyOpen: false,
   saveState: { kind: 'idle' },
   shelf: { worlds: [], activeId: null, busy: false, error: null },
-  worldsOpen: false,
   locateRequest: null,
   populationItems: [],
   locateCreatureRequest: null,
@@ -685,12 +699,11 @@ export const useMicroLand = create<MicroLandState>(set => ({
   removePendingSummon: id =>
     set(s => ({ pendingSummons: s.pendingSummons.filter(p => p.id !== id) })),
   setBuilderOpen: builderOpen => set({ builderOpen }),
-  setGuideOpen: guideOpen => set({ guideOpen }),
-  setSettingsOpen: settingsOpen => set({ settingsOpen }),
+  setSidebar: sidebar => set({ sidebar }),
+  toggleSidebar: view => set(s => ({ sidebar: s.sidebar === view ? null : view })),
+  setCreaturesTab: creaturesTab => set({ creaturesTab }),
   setGraphOpen: graphOpen => set({ graphOpen }),
-  setChallengesOpen: open => set({ challengesOpen: open }),
   setChallengeActive: c => set({ challengeActive: c }),
-  setWorkshopOpen: open => set({ workshopOpen: open }),
   requestWorkshopSpawn: (blueprint, traits) =>
     set(s => ({ workshopSpawnRequest: { blueprint, traits, serial: (s.workshopSpawnRequest?.serial ?? 0) + 1 } })),
   clearWorkshopSpawnRequest: () => set({ workshopSpawnRequest: null }),
@@ -739,9 +752,8 @@ export const useMicroLand = create<MicroLandState>(set => ({
 
   setSaveState: saveState => set({ saveState }),
   setShelf: shelf => set({ shelf }),
-  setWorldsOpen: worldsOpen => set({ worldsOpen }),
   requestLocate: blueprintId =>
-    set({ locateRequest: { blueprintId, serial: ++locateSerial }, guideOpen: false }),
+    set({ locateRequest: { blueprintId, serial: ++locateSerial }, sidebar: null }),
   setPopulationItems: items => set({ populationItems: items }),
   requestLocateCreature: id =>
     set({ locateCreatureRequest: { id, serial: ++locateCreatureSerial } }),
@@ -769,5 +781,4 @@ export const useMicroLand = create<MicroLandState>(set => ({
     set(s => ({
       historyLog: [{ ...entry, id: ++historyEntryId }, ...s.historyLog].slice(0, 500),
     })),
-  setHistoryOpen: historyOpen => set({ historyOpen }),
 }))


### PR DESCRIPTION
Four panels, four sets of chrome, four ways to close — and two of them could be open at once, stacked, so closing the top one revealed a panel you had forgotten was open. The field guide was a column beside the world; the shelf and the workshop were dialogs over the middle of it; the knobs and the log were drawers floating on top.

They all describe the same world, so they now share the same strip of screen.

## The shell

`sidebar` is a single slot in the store rather than a boolean each, which is what makes "open the log" and "close whatever was open" the same action. The shell owns the title, the close button, the drag-to-resize and the one scroller; each panel is content and nothing else.

Below 640px it becomes a bottom sheet. The knobs and the log already did that; the field guide did not, and a 300px column on a 360px phone left 60px of world.

| | before | after |
|---|---|---|
| Field Guide | in-flow column, own header, 2 sub-tabs | panel, no sub-views |
| Worlds | centred dialog | panel |
| Log | fixed drawer | panel |
| Settings | fixed drawer | panel |
| Challenges | centred dialog | panel |
| Creatures | — | new panel (Draw / Blueprints) |
| Clear | one menu item | panel, two options |

Main menu is now **Creatures · Challenges │ Worlds │ Field Guide · Replay · Log │ Sound · Settings │ Clear…**

## What moved, and why

**The field guide has no sub-views.** It used to carry the workshop and the challenges behind two tabs in its own header, which made "look something up" and "make something new" the same door.

**Creatures** holds Draw and Blueprints. The tabs are a stopgap and are meant to read as one thing — drawing a shape and setting its numbers are two halves of one act, and someone who draws a creature then wants it faster should not have to know which tool owns "faster". Draw opens the full-screen table rather than rendering in the column: a grid worth painting on, its ink wells, its frames and its stats do not fit 300px, and squeezing them in would make the tool worse to use in exchange for a tidier menu. That seam is the thing to close next.

**Clear is a panel**, because "clear" is more than one question — the living things, or the land as well. Each asks once, in place, the way the shelf already asks before it lets go of a world. The plants/animals split drops into the same shape later.

**The world picker** was a `<select>` inside the overflow menu, which made "change the land I am in" a settings-shaped act performed from a dropdown. It is now "Start from a template" in Worlds, beside the worlds you kept, named for what it does, and it confirms first when the land on screen is not saved. Reshape is gone; picking a template covers it.

**Generate, Draw and Inspect are out of the tool dock.** They were there and in the header both — the same three verbs twice, on the surface that is meant to be about what is in your hand right now.

## Two fixes that fell out of it

- `summonedLand` outlives the land that named it — it stays on the template list after you have moved on — so reading it unconditionally captioned an ordinary Cross-Section world with the name of a summoned land the player had left an hour ago. Now only read while you are standing in it.
- The workshop's empty state said *"No species in the world yet. Place some creatures first."* The roster is seeded with every built-in the moment the world is created, so that is never true; the only time the list is empty is the few frames before it reaches the store, and the copy sent whoever read it off to do something that would not have helped.

## Note on `clearWorld`

It moves the store's theme *before* it wipes, because a theme change comes back through the subscriber as another `setTheme` on the instance, and that rebuild would undo the dormancy set at the end. It cannot be the store call alone either: that only fires the subscriber when the theme actually changes, so a player painting on the empty theme would tap "everything" and watch nothing happen.

## Review note

`field-guide.tsx` and `worlds-panel.tsx` look enormous because removing the wrapper elements dedented their bodies. `git diff -w` puts them at 165 and 190 lines.

## Verification

Driven in a real browser (headless Chrome over CDP) at **1440×900, 1024×700, 375×700 and 844×390 landscape** — every panel opens from the menu, the Blueprints list renders its full 33-species roster in all four, the seam resizes and persists, and the narrow layouts get the bottom sheet.

`tsc` clean. No new lint. `vitest run src/app/micro-land` → 5 failures, **byte-identical to bare `origin/main`** (verified in a clean worktree); this branch adds none. The simulation is untouched, so the headless ecosystem harness was not re-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
