### PR TITLE
feat(micro-land): a food chain that holds itself up

### DIFF
--- a/src/app/micro-land/domain/__tests__/breeding.test.ts
+++ b/src/app/micro-land/domain/__tests__/breeding.test.ts
@@ -16,6 +16,7 @@ import { tickCreatures } from '@/app/micro-land/domain/sim/creature-sim'
 import type { SimEvent } from '@/app/micro-land/domain/sim/creature-sim'
 import { makeRng } from '@/app/micro-land/domain/sim/prng'
 import { createWorld, registerBlueprint, spawnCreature } from '@/app/micro-land/domain/sim/world'
+import { lifespanOf } from '@/app/micro-land/domain/traits'
 import { TUNING } from '@/app/micro-land/domain/tuning'
 import type { Creature, CreatureBlueprint, WorldState } from '@/app/micro-land/domain/types'
 
@@ -55,10 +56,19 @@ function grazer(overrides: Record<string, unknown> = {}): CreatureBlueprint {
   )
 }
 
-/** Grown up, off cooldown, and as full as it gets. */
-function readyAdult(c: Creature): Creature {
+/**
+ * Grown up, off cooldown, and as full as it gets.
+ *
+ * The age is derived, not a constant. An animal is grown at a fifth of its own
+ * *scaled* lifespan (`breedingAge` in creature-sim), so any hard-coded age
+ * silently becomes "a child" the moment anyone moves `lifespanScale` — and what
+ * that looks like from here is every breeding test failing at once, which reads
+ * as the mechanic being broken rather than the fixture being stale. Three tenths
+ * of a lifespan is half again past maturity and nowhere near dying of it.
+ */
+function readyAdult(c: Creature, bp: CreatureBlueprint): Creature {
   c.hunger = 0
-  c.ageSeconds = 120
+  c.ageSeconds = lifespanOf(c, bp) * TUNING.lifespanScale * 0.3
   c.breedCooldown = 0
   return c
 }
@@ -76,7 +86,7 @@ function placeAdults(w: WorldState, bp: CreatureBlueprint, count: number): Creat
   const out: Creature[] = []
   for (let i = 0; i < count; i++) {
     const c = spawnCreature(w, bp, 40 + i * 2, WORLD_H - 16)
-    if (c) out.push(readyAdult(c))
+    if (c) out.push(readyAdult(c, bp))
   }
   return out
 }
@@ -107,8 +117,8 @@ describe('an animal needs a partner', () => {
     const b = grazer({ name: 'Beta' })
     registerBlueprint(w, a)
     registerBlueprint(w, b)
-    readyAdult(spawnCreature(w, a, 40, WORLD_H - 16)!)
-    readyAdult(spawnCreature(w, b, 42, WORLD_H - 16)!)
+    readyAdult(spawnCreature(w, a, 40, WORLD_H - 16)!, a)
+    readyAdult(spawnCreature(w, b, 42, WORLD_H - 16)!, b)
 
     expect(run(w, 30)).toHaveLength(0)
   })
@@ -119,8 +129,8 @@ describe('an animal needs a partner', () => {
     // rule from the walking that normally satisfies it.
     const bp = grazer()
     registerBlueprint(w, bp)
-    readyAdult(spawnCreature(w, bp, 40, WORLD_H - 16)!)
-    readyAdult(spawnCreature(w, bp, 40 + TUNING.mateRadius * 3, WORLD_H - 16)!)
+    readyAdult(spawnCreature(w, bp, 40, WORLD_H - 16)!, bp)
+    readyAdult(spawnCreature(w, bp, 40 + TUNING.mateRadius * 3, WORLD_H - 16)!, bp)
 
     expect(run(w, 30)).toHaveLength(0)
   })
@@ -163,10 +173,13 @@ describe('both of them have to be well fed', () => {
     registerBlueprint(w, bp)
     const parents = placeAdults(w, bp, 2)
 
-    // Two seconds, not thirty: the pair meets within a few ticks, and the whole
-    // point is to look at them while the cooldown they were charged is still
-    // running rather than after it has quietly expired.
-    expect(run(w, 2)).toHaveLength(1)
+    // Half a cooldown, not thirty seconds: the pair meets within a few ticks
+    // (pairing is decided at 10Hz), and the whole point is to look at them while
+    // the cooldown they were charged is still running rather than after it has
+    // quietly expired. Derived from the knob rather than written as a number,
+    // because a window longer than `breedCooldown` turns this into an assertion
+    // that the cooldown was never charged at all.
+    expect(run(w, TUNING.breedCooldown * 0.5)).toHaveLength(1)
     for (const p of parents) {
       expect(p.children).toBe(1)
       expect(p.hunger).toBeGreaterThanOrEqual(TUNING.breedCost)
@@ -189,7 +202,7 @@ describe('plants spread alone', () => {
       { summoned: true }
     )
     registerBlueprint(w, moss)
-    readyAdult(spawnCreature(w, moss, 40, WORLD_H - 15)!)
+    readyAdult(spawnCreature(w, moss, 40, WORLD_H - 15)!, moss)
 
     expect(run(w, 30).length).toBeGreaterThan(0)
   })
@@ -217,7 +230,7 @@ describe('plants spread alone', () => {
       { summoned: true }
     )
     registerBlueprint(w, flower)
-    readyAdult(spawnCreature(w, flower, 40, WORLD_H - 20)!)
+    readyAdult(spawnCreature(w, flower, 40, WORLD_H - 20)!, flower)
 
     expect(run(w, 30).length).toBeGreaterThan(0)
   })

--- a/src/app/micro-land/domain/constants.ts
+++ b/src/app/micro-land/domain/constants.ts
@@ -121,13 +121,20 @@ export const FORAGE_HUNGER = 0.55
 /**
  * Global multiplier on every creature's per-species hunger rate.
  *
- * 1 = shipped balance. 0 = creatures never get hungry (hunger is effectively
- * disabled). Values above 1 make every animal drain faster, compressing the
- * window between a full stomach and a starving one without touching the amount
- * a meal restores — so a world set to 2× goes through the same boom-and-crash
- * cycles on a tighter clock.
+ * 1 = the per-species rates as written. 0 = creatures never get hungry (hunger
+ * is effectively disabled). Values above 1 make every animal drain faster,
+ * compressing the window between a full stomach and a starving one without
+ * touching the amount a meal restores — so a world set to 2× goes through the
+ * same boom-and-crash cycles on a tighter clock.
+ *
+ * Down to 0.1 from 0.25. Starvation was the dominant cause of death in every
+ * theme and it was a *reach* problem, not a shortage — the meadow sat at its
+ * species caps while animals died a screen away from it. Draining ten times
+ * slower than the blueprints assume gives a hungry animal long enough to
+ * actually cross the distance, which is the same thing MIGRATION_THRESHOLD and
+ * MATE_RADIUS were lowered/raised for.
  */
-export const HUNGER_RATE_SCALE = 0.25
+export const HUNGER_RATE_SCALE = 0.1
 
 /**
  * Hard population ceiling. Past this, nothing new is born (summoning still works).
@@ -151,15 +158,29 @@ export const MAX_CREATURES = Math.round(340 * WIDTH_SCALE)
  * Raised from 150 when the roster grew to seven plant species: the ceiling is
  * shared, so every species added to a world takes its share out of everything
  * else's, and a crowded world was starving its grazers rather than feeding more
- * of them.
+ * of them. Raised again to 650 whole-world when NATIVE_PLANT_SPECIES went to 8 —
+ * eight species at PLANT_SPECIES_CAP is 560, so the global ceiling has to sit
+ * above that or it becomes the binding limit and the mix collapses back to
+ * whichever plant spreads fastest.
+ *
+ * Written per screen and scaled, like every other count here, but the number was
+ * found on the slider in the full 672-wide world: 650 there, ~217 per screen.
  */
-export const MAX_PLANTS = Math.round(195 * WIDTH_SCALE)
+export const MAX_PLANTS = Math.round(216.7 * WIDTH_SCALE)
 
 /** Seconds a drowning creature survives underwater. */
 export const BREATH_SECONDS = 9
 
-/** Cooldown after breeding, seconds. */
-export const BREED_COOLDOWN = 20
+/**
+ * Cooldown after breeding, seconds.
+ *
+ * One second, down from twenty. The cooldown is no longer what paces breeding —
+ * BREED_COST is, and at a hunger rate of 0.1 refilling a stomach to the point
+ * where a parent can afford another child takes far longer than any cooldown
+ * would. Leaving the timer at twenty on top of that was double-charging for the
+ * same thing and it was part of why no animal population could hold itself up.
+ */
+export const BREED_COOLDOWN = 1
 
 /**
  * How close two animals of the same kind have to be to have a baby, in tiles.
@@ -171,18 +192,21 @@ export const BREED_COOLDOWN = 20
  * sight and then walks over. This is only the distance at which the walking
  * stops being necessary.
  *
- * Six tiles is a body-length or three apart — close enough that the pair is
- * visibly together when the baby appears, far enough that two walkers steering
- * at each other actually converge instead of jittering past one another. Making
- * it much tighter reads as broken: you watch two well-fed hoppers stand next to
- * each other and nothing happens.
+ * Ten tiles is a few body-lengths apart — close enough that the pair is visibly
+ * together when the baby appears, far enough that two walkers steering at each
+ * other actually converge instead of jittering past one another. Making it much
+ * tighter reads as broken: you watch two well-fed hoppers stand next to each
+ * other and nothing happens.
  *
  * The real cost of this whole mechanic is paid here. A species down to its last
  * individual can no longer recover, and a species scattered thinly across three
  * screens breeds far more slowly than the same headcount in one meadow. That is
- * the intended shape — it is also why this is a knob.
+ * the intended shape — but at six tiles the penalty for being thinly spread was
+ * steep enough that no animal species was self-sustaining in a three-screen
+ * world at all, so this went to ten: a pair that has walked into the same
+ * neighbourhood counts as having met.
  */
-export const MATE_RADIUS = 6
+export const MATE_RADIUS = 10
 
 /**
  * How far a child's heritable traits may fall from its parents'.
@@ -222,9 +246,15 @@ export const TRAIT_DRIFT = 0.12
  * back — the plants vanish, then everything that eats plants starves, then
  * everything that eats *those* starves. Plants mature in seconds and spread
  * often, and MAX_PLANT_SHARE is what stops that from becoming a green carpet.
+ *
+ * Maturity halved to 20 and the cooldown nudged to 26: the doubling time barely
+ * moves (40+20 = 60s, 20+26 = 46s), but the front-loaded half means a sprout the
+ * ground has just placed contributes to the recovery much sooner, which is what
+ * the seed bank is for. The cooldown carries the rest, and PLANT_CROWDING_STRENGTH
+ * lengthens it wherever a species is already dense.
  */
-export const PLANT_MATURITY = 40
-export const PLANT_SPREAD_COOLDOWN = 20
+export const PLANT_MATURITY = 20
+export const PLANT_SPREAD_COOLDOWN = 26
 
 /**
  * How much fullness a meal restores, and what breeding costs.
@@ -232,9 +262,16 @@ export const PLANT_SPREAD_COOLDOWN = 20
  * Keep the cost above the meal: if one meal more than pays for a child, grazers
  * breed on every full stomach, overshoot the plants, and take the whole food
  * chain down with them.
+ *
+ * Both roughly halved (0.54/0.69 → 0.26/0.31) so more of the world's pacing sits
+ * in eating and less in the timers. A parent now needs two bites per child rather
+ * than one-and-a-bit, which is what lets BREED_COOLDOWN drop to a second without
+ * turning every full stomach into a litter. Note the margin is exactly
+ * MEAL_HEADROOM (0.05) — `enforceInvariants` in tuning.ts holds it there, so
+ * lowering the cost any further will pull the meal down with it.
  */
-export const MEAL_VALUE = 0.54
-export const BREED_COST = 0.69
+export const MEAL_VALUE = 0.26
+export const BREED_COST = 0.31
 
 /**
  * Native plants — the ground's own seed bank, and the only regrowth there is.
@@ -261,21 +298,36 @@ export const BREED_COST = 0.69
  * all and plants spread the ordinary way; the further below it the world falls,
  * the harder the seed comes in. That asymmetry is deliberate — a constant
  * trickle would just pin every world at MAX_PLANTS and turn it into a carpet.
+ *
+ * 115 whole-world, up from 15. Fifteen plants across three screens is a floor
+ * only in the most literal sense: it got the count off zero and left the meadow
+ * to rebuild itself from five sprouts per screen, which took longer than the
+ * grazers waiting on it had. This still sits well under MAX_PLANTS (650), so the
+ * ground goes quiet in a grown-in world and plants do their own spreading —
+ * it is just a floor a food chain can actually stand on.
+ *
+ * Per screen this is ~38; the number itself was found on the slider in the full
+ * 672-wide world.
  */
-export const NATIVE_PLANT_TARGET = Math.round(5 * WIDTH_SCALE)
+export const NATIVE_PLANT_TARGET = Math.round(38.3 * WIDTH_SCALE)
 /**
  * How long the ground waits between seedings.
  *
- * Slow on purpose — 30s, up from 3s. At three seconds the soil was doing the
- * work the plants are supposed to do: a grazed patch filled back in while you
- * were still watching it be grazed, so nothing the animals did to the meadow
- * ever showed. Thirty seconds makes the seed bank a floor under a crash rather
- * than a groundskeeper. Recovery still happens, because plants that exist
- * spread on their own (PLANT_MATURITY + PLANT_SPREAD_COOLDOWN, ~15s per
- * doubling) — all the ground has to do is get the count off zero and then stay
- * out of the way.
+ * Slow on purpose — this was 35s, up from an original 3s. At three seconds the
+ * soil was doing the work the plants are supposed to do: a grazed patch filled
+ * back in while you were still watching it be grazed, so nothing the animals did
+ * to the meadow ever showed. Recovery is meant to come from plants that exist
+ * spreading on their own (PLANT_MATURITY + PLANT_SPREAD_COOLDOWN, ~46s per
+ * doubling) — all the ground has to do is get the count off zero.
+ *
+ * Back down to 13s, which at PLANT_SEED_BATCH 1 is the entire rate: one sprout
+ * every thirteen seconds, or about 4.5 a minute, and none at all once the world
+ * is at NATIVE_PLANT_TARGET. That is still a trickle against a 650-plant ceiling
+ * — what it stops being is slower than the thing it is a floor under. At 35s the
+ * ground needed nearly an hour to walk a stripped world back to a target of 115,
+ * by which time everything that ate plants had already died of it.
  */
-export const PLANT_SEED_INTERVAL = 35
+export const PLANT_SEED_INTERVAL = 13
 /**
  * Most plants a single seeding may place, when the world is at zero.
  *
@@ -289,10 +341,16 @@ export const PLANT_SEED_BATCH = 1
 /**
  * How many species the ground picks when it establishes its natives.
  *
- * Fewer than are viable, on purpose: two worlds painted with the same soil
- * should not grow the same flora.
+ * This used to be fewer than are viable on purpose, so that two worlds painted
+ * with the same soil would not grow the same flora. That variety cost more than
+ * it bought: three species is three ways for a grazer to be looking at a plant it
+ * cannot eat, and a picky eater in a world whose soil happened not to pick its
+ * food starved through no fault of its own. Eight takes essentially every viable
+ * plant, so the flora a world grows is now decided by what its *soil* can support
+ * rather than by a shuffle — which is the more legible answer anyway, since the
+ * player chose the soil.
  */
-export const NATIVE_PLANT_SPECIES = 3
+export const NATIVE_PLANT_SPECIES = 8
 
 /**
  * How often a seed is dropped from the sky rather than from a random height.
@@ -333,8 +391,18 @@ export const SPECIES_SOFT_CAP = Math.round(70 * WIDTH_SCALE)
  * one happens to spread fastest takes the entire allowance and the world becomes
  * a monoculture — which then starves out every grazer too small to eat it.
  * Keeping this well under MAX_PLANTS is what leaves room for a mixed meadow.
+ *
+ * Down to 70 whole-world from 138, alongside NATIVE_PLANT_SPECIES 3 → 8. The
+ * meadow is about the same size in total (8 × 70 = 560 against the old 3 × 138 =
+ * 414, both under the 650 ceiling) but it is spread across every plant the soil
+ * can carry instead of concentrated in three. A grazer's own food is scarcer per
+ * species and the world as a whole is greener, which pushes animals to range for
+ * it rather than sit in one patch — and makes it far less likely that the one
+ * plant a species eats is the one that got shuffled out.
+ *
+ * Per screen this is ~23; the number was found on the slider at whole-world scale.
  */
-export const PLANT_SPECIES_CAP = Math.round(46 * WIDTH_SCALE)
+export const PLANT_SPECIES_CAP = Math.round(23.3 * WIDTH_SCALE)
 
 /**
  * How long a pollinator can carry a seed before it auto-drops, seconds.
@@ -343,8 +411,13 @@ export const PLANT_SPECIES_CAP = Math.round(46 * WIDTH_SCALE)
  * clusters, short enough that a seed does not ride forever on a creature that
  * never lands. The 2-second minimum-carry guard in creature-sim prevents
  * the seed from dropping right back at the pickup plant.
+ *
+ * Ten, down from fifteen. With eight native species sharing the meadow the gaps
+ * a bee has to cross are shorter, and a shorter carry means a seed lands nearer
+ * the cluster it came from, which keeps a species from being smeared so thin that
+ * PLANT_SPREAD_MIN and the crowding penalty are the only things placing it.
  */
-export const POLLINATION_CARRY_SECONDS = 15
+export const POLLINATION_CARRY_SECONDS = 10
 
 /**
  * When 1, plants cannot spread on their own — they may only reproduce via
@@ -352,8 +425,16 @@ export const POLLINATION_CARRY_SECONDS = 15
  */
 export const POLLINATION_ONLY = 0
 
-/** Multiplier added to spread cooldown per same-species plant within crowding radius. */
-export const PLANT_CROWDING_STRENGTH = 2
+/**
+ * Multiplier added to spread cooldown per same-species plant within crowding radius.
+ *
+ * 0.6, down from 2. At 2 a plant with three neighbours took seven times as long
+ * to spread again, which was strong enough to be the real cap on the flora — the
+ * meadow stopped growing long before PLANT_SPECIES_CAP had anything to say about
+ * it, and a species knocked back to a single clump could barely restart. Now the
+ * caps do the limiting and this only biases *where* the growth goes.
+ */
+export const PLANT_CROWDING_STRENGTH = 0.6
 
 /** Minimum tiles a plant seed must travel from its parent. */
 export const PLANT_SPREAD_MIN = 11
@@ -387,8 +468,16 @@ export const ELDER_MIN_SECONDS = 60
  */
 export const STEADY_SHOW_SECONDS = 120
 
-/** Base probability per tick that a sick creature infects a healthy neighbour. */
-export const DISEASE_SPREAD_CHANCE = 0.01
+/**
+ * Base probability per tick that a sick creature infects a healthy neighbour.
+ *
+ * Off by default (0). Disease is a second pressure on populations that cannot yet
+ * reliably hold themselves up against the first one, and a contagion running
+ * through a species that is already thin is just a faster extinction with a
+ * different name in the death log. The mechanic stays — the knob is there, and
+ * Sporecap spores are unaffected by this — but it is opt-in.
+ */
+export const DISEASE_SPREAD_CHANCE = 0
 
 /**
  * How long a creature stays sick after catching a disease, in sim-seconds.
@@ -401,10 +490,14 @@ export const DISEASE_DURATION = 10
  * Seconds a creature must be hungry with no food in sight before it abandons
  * its home range and migrates toward richer terrain.
  *
- * Shorter than 30 would override the already-working expanded-sight-range
- * mechanic. Sixty gives a creature two full minutes to find food locally first.
+ * Fifteen, down from sixty. Sixty was set to give the expanded-sight-range
+ * mechanic room to work first, but the harness showed sight was not the binding
+ * problem — food was a median of 45-55 tiles away from animals about to starve,
+ * which is past any sight range hunger can buy. What they needed was to be walking
+ * in a direction, sooner. Fifteen seconds of local searching before committing to
+ * a move makes populations nomadic, and a nomadic species finds the meadow.
  */
-export const MIGRATION_THRESHOLD = 60
+export const MIGRATION_THRESHOLD = 15
 
 /**
  * How many seconds of resting it takes to build a nest from scratch.
@@ -427,5 +520,13 @@ export const NEST_DECAY_SECONDS = 120
  * Global lifespan multiplier applied on top of each species' base lifespanSeconds
  * and each creature's inherited lifespan trait. 2 = twice as long-lived as the
  * per-species defaults, which were tuned at 1× for a faster-paced world.
+ *
+ * Now 10. Lifespan is the budget an animal has to solve the reach problem in: at
+ * 2× a grazer had about nine minutes to find a mate, close MATE_RADIUS with it,
+ * and eat twice over in a world three screens wide, and most of them ran out of
+ * clock rather than out of food. Ten makes a natural death something that happens
+ * to a creature that already bred, which is the difference between a population
+ * and a queue. It also means `old age` should be a visible cause of death in the
+ * harness — if starvation still dominates, the reach problem is not solved.
  */
-export const LIFESPAN_SCALE = 2
+export const LIFESPAN_SCALE = 10

--- a/src/app/micro-land/domain/tuning.ts
+++ b/src/app/micro-land/domain/tuning.ts
@@ -465,12 +465,55 @@ function clampKnob(key: TuningKey, value: number): number {
   return knob.step >= 1 ? Math.round(clamped) : clamped
 }
 
+/**
+ * How far under the breed cost a meal is held.
+ *
+ * Small on purpose. This is a floor on the gap, not a target for it — the
+ * shipped pair sits exactly this far apart, and anything wider is a balance
+ * decision rather than a safety one.
+ */
+export const MEAL_HEADROOM = 0.05
+
+/**
+ * The one relationship between two knobs that the world cannot survive.
+ *
+ * If a meal more than pays for a child, grazers breed on every full stomach,
+ * overshoot the plants, and take the entire food chain down with them. Both
+ * numbers are sliders, so this cannot be left as something the defaults merely
+ * happen to satisfy — a player dragging either one past the other would do it
+ * in a single notch, and the collapse arrives a minute later looking like the
+ * ecosystem's fault rather than the slider's.
+ *
+ * Whichever knob moved is the one that gets respected: pushing the meal up
+ * carries the cost up ahead of it, and pulling the cost down drags the meal
+ * down with it, so neither edit is silently ignored. `moved` names the keys the
+ * caller actually set; without it, dragging one would be indistinguishable from
+ * dragging the other and one of the two sliders would feel stuck.
+ */
+function enforceInvariants(moved: Set<TuningKey>): void {
+  if (TUNING.mealValue < TUNING.breedCost) return
+  if (moved.has('mealValue')) {
+    TUNING.breedCost = clampKnob('breedCost', TUNING.mealValue + MEAL_HEADROOM)
+    // The cost has a ceiling of its own, so a meal dragged to the very top can
+    // still end up level with it. Give way in the other direction rather than
+    // leaving the pair inverted.
+    if (TUNING.mealValue >= TUNING.breedCost) {
+      TUNING.mealValue = clampKnob('mealValue', TUNING.breedCost - MEAL_HEADROOM)
+    }
+    return
+  }
+  TUNING.mealValue = clampKnob('mealValue', TUNING.breedCost - MEAL_HEADROOM)
+}
+
 /** Move one or more knobs. Values outside a knob's range are clamped, not rejected. */
 export function setTuning(patch: Partial<Tuning>): void {
+  const moved = new Set<TuningKey>()
   for (const [key, value] of Object.entries(patch)) {
     if (!(key in TUNING_DEFAULTS)) continue
     TUNING[key as TuningKey] = clampKnob(key as TuningKey, value as number)
+    moved.add(key as TuningKey)
   }
+  enforceInvariants(moved)
 }
 
 export function resetTuning(): void {


### PR DESCRIPTION
Every animal went extinct in every run, on all four themes, within three to eight minutes, leaving a plant-only world. That had been true since the animal seed rain was removed — the rain restocked species every four seconds and hid the fact that no animal population was self-sustaining at the shipped tuning.

## Harness evidence

`npm run sim:micro-land -- --theme <t> --seconds 600 --runs 3`, all four themes, same seeds (`runOnce` seeds from `1000 + i * 7919`), baseline measured in a clean worktree at `origin/main`.

**Species marked `EXTINCT in every run`:**

| theme | before | after |
|---|---|---|
| earth | 7 | **0** |
| tidepool | 6 | **2** (dustbee, mote) |
| volcanic | 7 | **0** |
| station | 8 | **1** (dustbee) |
| **total** | **28** | **3** |

**Causes of death, summed across all four themes:**

| cause | before | after | |
|---|---|---|---|
| eaten | 916 | 854 | predation, unchanged — healthy |
| starved | 256 | **153** | the thing being fixed |
| sick | 214 | **0** | disease off by design |
| diseased | 138 | **3** | residual is Sporecap spores, unaffected by the knob |
| aged | 160 | **0** | see caveat below |
| drowned | 49 | 73 | animals range further now and walk into water more |
| burned | 57 | 56 | |

**Earth low-water mark: 272 → 465.** An oscillation well clear of zero rather than a slide toward it. Peaks come *down* across the board (earth 662→537, tidepool 349→271, volcanic 298→201) — fewer total creatures, far more species among them. That is the intended trade: a steady mixed world instead of a boom-and-crash monoculture.

`world still solid` is unchanged on every theme (62/67/61/14%) — diggers still tunnel rather than delete.

## ⚠️ One prediction did not hold

The comment on `LIFESPAN_SCALE` says *"old age should now be a visible cause of death in the harness — if starvation still dominates, the reach problem is not solved."*

**`aged` went 160 → 0.** The opposite happened, because a 10x lifespan puts natural death beyond the 600-second observation window entirely. The reach problem does look solved on the metric that matters — 28 extinctions down to 3, starvation down 40% — but not by the mechanism that comment claims to be checking, and **10x may be more than the job needs.** Worth a longer run, or a smaller scale, before taking the number as settled. I have left the comment as written rather than quietly rewriting the reasoning to match the result.

## What changed, and why

Food was never scarce — the meadow sat pinned at its species caps while animals died a median of 45-55 tiles from it, past any sight range hunger can buy. It was a reach problem, and reach is paid for in time, so most of this buys an animal more time or shortens the distance:

- `LIFESPAN_SCALE` 2 → 10 — the budget an animal has to find a mate, close `MATE_RADIUS`, and eat twice, in a world three screens wide
- `HUNGER_RATE_SCALE` 0.25 → 0.1
- `MIGRATION_THRESHOLD` 60 → 15 — sight was never the binding constraint; they needed to be walking sooner
- `MATE_RADIUS` 6 → 10 — a pair in the same neighbourhood counts as having met
- `BREED_COOLDOWN` 20 → 1 with `MEAL_VALUE`/`BREED_COST` 0.54/0.69 → 0.26/0.31 — the cost paces breeding now, not the timer; stacking both was double-charging

And the meadow, so there is more of it in more places: `NATIVE_PLANT_SPECIES` 3 → 8 (three species was three ways for a grazer to face a plant it cannot eat), `PLANT_SPECIES_CAP` 138 → 70, `NATIVE_PLANT_TARGET` 15 → 115, `PLANT_SEED_INTERVAL` 35s → 13s, `PLANT_CROWDING_STRENGTH` 2 → 0.6, `MAX_PLANTS` 585 → 650, `PLANT_MATURITY`/`PLANT_SPREAD_COOLDOWN` 40/20 → 20/26, `POLLINATION_CARRY_SECONDS` 15 → 10. All whole-world figures; the per-screen constants are these divided by `WIDTH_SCALE`.

`DISEASE_SPREAD_CHANCE` 0.01 → 0. A contagion running through a species that is already thin is a faster extinction with a different name in the death log. The mechanic and the knob stay; it is opt-in until animals can stand up on their own.

## The first commit: a guard that was never written

`enforceInvariants` and `MEAL_HEADROOM` are named in the skill document and asserted by `tuning.test.ts`, but **did not exist** — `setTuning` clamped each knob against its own min/max and nothing else. That test has been failing on `main` for this reason.

It matters here specifically: this change tightens the meal/cost gap from 0.15 to 0.05, and its own comment claims a guard holds it there. Without one, a player drags `breedCost` down a single notch in the settings panel, inverts the pair, and takes the food chain down. Now whichever knob moved is respected — meal up carries the cost up, cost down drags the meal down — so neither slider feels stuck. No behaviour change at rest.

## Known failure, deliberately not fixed

`tuning.test.ts > covers every tunable value exactly once` still fails, on this branch and on `main`. `dayLengthSeconds` and `eggHatchSeconds` are in `TUNING_DEFAULTS` and read by the simulation and renderer, but have no `KNOBS` entry, so they can never be moved from the settings panel.

I did not fix it because `dayLengthSeconds` defaults to `0` — the day/night cycle is **off and unreachable** — and exposing it means choosing a range for how long a day may be. That is a product decision about a dormant feature, not a balance one, and it is not mine to make in this PR.

## Scope

The simulation itself is untouched: this is `constants.ts`, one guard in `tuning.ts`, and test fixtures. The breeding tests now derive from the knobs rather than hard-coding — an animal is grown at a fifth of its *scaled* lifespan, so a hard-coded age silently became "a child" the moment `lifespanScale` moved, and every breeding test failed at once in a way that read as the mechanic being broken rather than the fixture being stale.

Stacked independently of #3509 (menu/sidebar); both branch off `main` and touch no common files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
