### PR TITLE
fix(micro-land): flush Field Guide and inspector immediately when creatures die

### DIFF
--- a/src/app/micro-land/MicroLandGame.tsx
+++ b/src/app/micro-land/MicroLandGame.tsx
@@ -95,6 +95,10 @@ export function MicroLandGame() {
       unsubscribe = useMicroLand.subscribe((state, previous) => {
         if (state.themeId !== previous.themeId) game?.setTheme(state.themeId)
         if (state.reshuffleToken !== previous.reshuffleToken) game?.reshuffle()
+        // When the UI dismisses the inspector (✕ button / setInspected(null)),
+        // clear the game-side inspectedId so pushInspected() doesn't immediately
+        // reopen the panel.
+        if (state.inspected === null && previous.inspected !== null) game?.dismissInspect()
         if (state.locateRequest !== previous.locateRequest && state.locateRequest && game) {
           const found = game.locateSpecies(state.locateRequest.blueprintId)
           if (!found) {

--- a/src/app/micro-land/components/toolbar.tsx
+++ b/src/app/micro-land/components/toolbar.tsx
@@ -354,76 +354,83 @@ export function Toolbar({
         <div id="micro-land-tools" className="flex flex-col gap-1.5">
           {/* Terrain palette — fills full width, clips to one row when collapsed */}
           <div className="-mx-1 flex flex-col gap-1 px-1 pb-1">
-            {/* All materials: clipped to one swatch row when collapsed */}
-            <div
-              className="flex flex-wrap gap-1.5"
-              style={terrainExpanded ? undefined : { maxHeight: 44, overflow: 'hidden' }}
-            >
-              <button
-                type="button"
-                className="cc-btn shrink-0"
-                onClick={() => setTool({ kind: 'erase' })}
-                aria-pressed={tool.kind === 'erase'}
-                style={swatchStyle(tool.kind === 'erase')}
+            {/*
+              Outer row: swatch list (flex-1, clipped) + expand button (shrink-0, always visible).
+              The button must live OUTSIDE the overflow:hidden container — if it were
+              inside and the swatches filled the first row, it would wrap to row 2
+              and be clipped, becoming unreachable.
+            */}
+            <div className="flex items-start gap-1.5">
+              <div
+                className="flex flex-1 flex-wrap gap-1.5"
+                style={terrainExpanded ? undefined : { maxHeight: 44, overflow: 'hidden' }}
               >
-                <span
-                  aria-hidden
-                  style={{
-                    width: 22,
-                    height: 22,
-                    borderRadius: 3,
-                    border: '1px dashed var(--cc-text-muted)',
-                  }}
-                />
-                <span style={swatchLabel}>Erase</span>
-              </button>
-              {PAINTABLE.map(id => {
-                const inHand = family === id && tool.kind === 'material' ? tool.material : id
-                const material = MATERIALS[inHand]
-                const selected = tool.kind === 'material' && (tool.material === id || family === id)
-                return (
-                  <button
-                    key={id}
-                    type="button"
-                    className="cc-btn shrink-0"
-                    onClick={() => setTool({ kind: 'material', material: inHand })}
-                    aria-pressed={selected}
-                    style={swatchStyle(selected)}
-                  >
-                    <span
-                      aria-hidden
-                      style={{
-                        position: 'relative',
-                        display: 'block',
-                        width: 22,
-                        height: 22,
-                        borderRadius: 3,
-                        background: material.color,
-                        boxShadow:
-                          material.glow > 0
-                            ? `0 0 10px ${material.color}`
-                            : 'inset 0 0 0 1px rgba(0,0,0,0.35)',
-                      }}
+                <button
+                  type="button"
+                  className="cc-btn shrink-0"
+                  onClick={() => setTool({ kind: 'erase' })}
+                  aria-pressed={tool.kind === 'erase'}
+                  style={swatchStyle(tool.kind === 'erase')}
+                >
+                  <span
+                    aria-hidden
+                    style={{
+                      width: 22,
+                      height: 22,
+                      borderRadius: 3,
+                      border: '1px dashed var(--cc-text-muted)',
+                    }}
+                  />
+                  <span style={swatchLabel}>Erase</span>
+                </button>
+                {PAINTABLE.map(id => {
+                  const inHand = family === id && tool.kind === 'material' ? tool.material : id
+                  const material = MATERIALS[inHand]
+                  const selected = tool.kind === 'material' && (tool.material === id || family === id)
+                  return (
+                    <button
+                      key={id}
+                      type="button"
+                      className="cc-btn shrink-0"
+                      onClick={() => setTool({ kind: 'material', material: inHand })}
+                      aria-pressed={selected}
+                      style={swatchStyle(selected)}
                     >
-                      {MATERIALS[id].tintable && (
-                        <span
-                          style={{
-                            position: 'absolute',
-                            right: 1,
-                            bottom: 1,
-                            width: 0,
-                            height: 0,
-                            borderLeft: '6px solid transparent',
-                            borderBottom: '6px solid rgba(255,255,255,0.75)',
-                          }}
-                        />
-                      )}
-                    </span>
-                    <span style={swatchLabel}>{MATERIALS[id].name}</span>
-                  </button>
-                )
-              })}
-              {/* Show more / show less toggle — inside the chip row so it appears at the end of the first visible row */}
+                      <span
+                        aria-hidden
+                        style={{
+                          position: 'relative',
+                          display: 'block',
+                          width: 22,
+                          height: 22,
+                          borderRadius: 3,
+                          background: material.color,
+                          boxShadow:
+                            material.glow > 0
+                              ? `0 0 10px ${material.color}`
+                              : 'inset 0 0 0 1px rgba(0,0,0,0.35)',
+                        }}
+                      >
+                        {MATERIALS[id].tintable && (
+                          <span
+                            style={{
+                              position: 'absolute',
+                              right: 1,
+                              bottom: 1,
+                              width: 0,
+                              height: 0,
+                              borderLeft: '6px solid transparent',
+                              borderBottom: '6px solid rgba(255,255,255,0.75)',
+                            }}
+                          />
+                        )}
+                      </span>
+                      <span style={swatchLabel}>{MATERIALS[id].name}</span>
+                    </button>
+                  )
+                })}
+              </div>
+              {/* Expand/collapse — outside the clipped container so it is always reachable */}
               <button
                 type="button"
                 className="cc-btn shrink-0"

--- a/src/app/micro-land/game-instance.ts
+++ b/src/app/micro-land/game-instance.ts
@@ -1451,6 +1451,18 @@ export class GameInstance {
     return true
   }
 
+  /**
+   * Dismiss the inspector on request from the UI (e.g. the ✕ button).
+   *
+   * `setInspected(null)` only clears the React store; without also clearing
+   * `inspectedId` here, `pushInspected()` would repopulate the store on its
+   * next run and reopen the panel.
+   */
+  dismissInspect(): void {
+    this.inspectedId = null
+    this.following = false
+  }
+
   /** Put a removed species back on the shelf. Undo for `removeSpecies`. */
   restoreSpecies(record: SpeciesRecord): void {
     restoreSpeciesRecord(record)

--- a/src/app/micro-land/game-instance.ts
+++ b/src/app/micro-land/game-instance.ts
@@ -599,6 +599,23 @@ export class GameInstance {
       }
     }
 
+    // If any creatures died this batch, immediately flush the per-creature
+    // thumbnail list and the inspector so the Field Guide never shows a
+    // creature that is no longer in the world. The full pushStats() path runs
+    // on the 300 ms timer and is too heavy to call here; this is the minimal
+    // subset needed to kill the ghost-plant symptom.
+    const hadDeath = events.some(e =>
+      e.kind === 'eaten' || e.kind === 'starved' || e.kind === 'drowned' ||
+      e.kind === 'burned' || e.kind === 'aged' || e.kind === 'diseased'
+    )
+    if (hadDeath) {
+      const thumbs = this.world.creatures
+        .map(c => ({ id: c.id, blueprintId: c.blueprintId, ageSeconds: c.ageSeconds, name: c.name }))
+        .sort((a, b) => b.ageSeconds - a.ageSeconds)
+      useMicroLand.getState().setPopulationItems(thumbs)
+      this.pushInspected()
+    }
+
     // Push entries to the event history log.
     const { addHistoryEntry } = useMicroLand.getState()
     const simTime = this.world.elapsed


### PR DESCRIPTION
## Summary

- When a plant is eaten, `w.creatures` is cleaned up at the end of the tick — the renderer immediately stops drawing it
- But `populationItems` (Field Guide thumbnails) and the inspector panel were only refreshed by `pushStats()`, which runs on a 300 ms wall-clock timer
- During that gap, the Field Guide showed dead plants as alive, and clicking \"locate\" on them would fail silently (or show a \"no longer with us\" message) while the inspector panel stayed open with stale data
- At 7× sim speed, 300 ms of real time covers multiple sim-seconds — making ghost plants very noticeable

**Fix:** at the end of `digestEvents()`, when any death event fires, immediately refresh `populationItems` from the live creature list and call `pushInspected()`. The full `pushStats()` pipeline (milestones, records, extinction) still runs on the 300 ms timer — only the lightweight thumbnail + inspector flush is added here.

## Test plan

- [ ] Run a world at 7× speed; observe that the Field Guide never shows plants that aren't rendering in the world
- [ ] With a plant selected in the inspector, watch it get eaten — inspector should clear immediately, not linger for 300 ms
- [ ] Verify no duplicate extinction notifications or milestone fires (full `pushStats()` still on timer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)