### PR TITLE
feat(micro-land): dynamic meal fill scaled by prey/eater size ratio

### DIFF
--- a/src/app/micro-land/domain/sim/creature-sim.ts
+++ b/src/app/micro-land/domain/sim/creature-sim.ts
@@ -1108,7 +1108,7 @@ function look(
       const gapX = Math.max(0, Math.abs(dx) - bw / 2)
       const gapY = Math.max(0, Math.abs(dy) - bh / 2)
       if (gapX <= BITE_PAD && gapY <= BITE_PAD) {
-        c.hunger = Math.max(0, c.hunger - TUNING.mealValue)
+        c.hunger = Math.max(0, c.hunger - mealFill(c, bp, carBp))
         c.starving = 0
         c.mealsEaten++
         if (c.mealsEaten === 1) logLife(c, w.elapsed, 'First meal')
@@ -1136,7 +1136,7 @@ function look(
       const gapX = Math.max(0, Math.abs(dx) - bw / 2)
       const gapY = Math.max(0, Math.abs(dy) - bh / 2)
       if (gapX <= BITE_PAD && gapY <= BITE_PAD) {
-        c.hunger = Math.max(0, c.hunger - TUNING.mealValue * 0.6) // eggs are smaller meals
+        c.hunger = Math.max(0, c.hunger - mealFill(c, bp, eggBp) * 0.6) // eggs are smaller meals
         c.starving = 0
         c.mealsEaten++
         if (c.mealsEaten === 1) logLife(c, w.elapsed, 'First meal')
@@ -1230,7 +1230,7 @@ function look(
       }
       if (touching) {
         devour(w, other, obp, dead, events)
-        c.hunger = Math.max(0, c.hunger - TUNING.mealValue)
+        c.hunger = Math.max(0, c.hunger - mealFill(c, bp, obp, sizeOf(other)))
         c.starving = 0
         c.mealsEaten++
         if (c.mealsEaten === 1) logLife(c, w.elapsed, 'First meal')
@@ -1537,6 +1537,27 @@ function clearRun(
     if (needsWater && !liquidAt(w, x, y)) return false
   }
   return true
+}
+
+/**
+ * How much eating one prey item reduces the eater's hunger.
+ * - Base: TUNING.mealValue
+ * - Size ratio: prey mass / eater mass, clamped [0.3, 3.0]
+ *   A mite eating a sunleaf gets a fraction; a gulper eating a hopper gets a bonus.
+ * - Plant penalty: plants have low caloric density (−15% of base)
+ */
+function mealFill(
+  eater: Creature,
+  eaterBp: CreatureBlueprint,
+  preyBp: CreatureBlueprint,
+  preyTraitSize = 1
+): number {
+  const preyMass = preyBp.size * preyTraitSize
+  const eaterMass = eaterBp.size * sizeOf(eater)
+  const sizeFactor = Math.max(0.3, Math.min(3.0, preyMass / eaterMass))
+  let fill = TUNING.mealValue * sizeFactor
+  if (preyBp.move.kind === 'root') fill -= TUNING.mealValue * 0.15
+  return Math.max(0, fill)
 }
 
 function devour(


### PR DESCRIPTION
## Summary

- Replaces the flat `TUNING.mealValue` hunger reduction with a `mealFill()` helper that scales by prey-to-eater mass ratio
- Large prey relative to the eater = more filling (up to 3× base); small prey = less filling (floor 0.3×)
- Plant meals carry a 15% caloric penalty — low caloric density compared to meat
- Egg meals retain their existing 0.6× multiplier, now applied on top of size scaling

## How it works

```
mealFill = TUNING.mealValue × clamp(preyMass / eaterMass, 0.3, 3.0)
         − (0.15 × TUNING.mealValue  if prey is a plant)
```

Three call sites updated: carcass eating, egg eating, live prey devour.

## Test plan

- [ ] Spawn a small creature (mite) and a large plant — confirm mite stays hungry longer after eating
- [ ] Spawn a gulper and a hopper — confirm gulper fills up faster than with flat value
- [ ] Confirm herbivores on an all-plant diet have slightly more persistent hunger than meat-eaters
- [ ] Confirm no crashes when only one food type is present

🤖 Generated with [Claude Code](https://claude.com/claude-code)