### PR TITLE
fix(micro-land): prevent starving creatures oscillating on blocked prey

### DIFF
--- a/src/app/micro-land/domain/sim/creature-sim.ts
+++ b/src/app/micro-land/domain/sim/creature-sim.ts
@@ -1110,6 +1110,7 @@ function look(
       if (gapX <= BITE_PAD && gapY <= BITE_PAD) {
         c.hunger = Math.max(0, c.hunger - TUNING.mealValue)
         c.starving = 0
+        c.huntBlockedId = null
         c.mealsEaten++
         if (c.mealsEaten === 1) logLife(c, w.elapsed, 'First meal')
         // Cooperative creatures signal food location to kin.
@@ -1138,6 +1139,7 @@ function look(
       if (gapX <= BITE_PAD && gapY <= BITE_PAD) {
         c.hunger = Math.max(0, c.hunger - TUNING.mealValue * 0.6) // eggs are smaller meals
         c.starving = 0
+        c.huntBlockedId = null
         c.mealsEaten++
         if (c.mealsEaten === 1) logLife(c, w.elapsed, 'First meal')
         c.mood = 'eat'
@@ -1232,6 +1234,7 @@ function look(
         devour(w, other, obp, dead, events)
         c.hunger = Math.max(0, c.hunger - TUNING.mealValue)
         c.starving = 0
+        c.huntBlockedId = null
         c.mealsEaten++
         if (c.mealsEaten === 1) logLife(c, w.elapsed, 'First meal')
         // Cooperative creatures signal food location to kin.
@@ -1355,6 +1358,10 @@ function look(
     if (c.mood === 'hunt' && c.targetId === prey.id) {
       c.huntPassCount++
       if (c.huntPassCount >= STUCK_SENSE_PASSES) {
+        // Record the blocked target so the mood block below treats it as
+        // "smelled, not seen" after the cooldown — preventing the creature
+        // from immediately re-locking and oscillating.
+        c.huntBlockedId = prey.id
         prey = null
         // Reverse the committed direction so the next foraging leg actively
         // moves away from the obstacle rather than pressing back against it.
@@ -1454,12 +1461,20 @@ function look(
   if (threat && c.hunger < 1) {
     c.mood = 'flee'
     c.targetId = threat.id
-  } else if (prey && (preyDist <= sight2 || clearRun(w, bp, cx, cy, preyCx, preyCy))) {
+  } else if (prey && prey.id !== c.huntBlockedId && (preyDist <= sight2 || clearRun(w, bp, cx, cy, preyCx, preyCy))) {
+    // Lock onto reachable prey. Clearing huntBlockedId here means the creature
+    // gets a clean slate whenever it finds a *different* target — it only
+    // ignores the specific prey it recently bounced off.
+    c.huntBlockedId = null
     c.mood = 'hunt'
     c.targetId = prey.id
   } else if (prey) {
     /**
      * Smelled, not seen — food inside the hunger reach but past plain sight.
+     * Also used when the prey is the one we last got stuck on (huntBlockedId):
+     * steer toward it via drift rather than hard-locking, so the hazard check
+     * still applies and the creature turns at walls instead of pressing against
+     * them forever.
      *
      * A bearing to set off on, not a thing to lock onto. Locking on is what the
      * first cut of this did, and it was worse than not finding the food at all:
@@ -1881,8 +1896,15 @@ function steer(w: WorldState, c: Creature, bp: CreatureBlueprint, dt: number, rn
       c.drift = c.drift >= 0 ? 1 : -1
     }
     // Committing to a heading is only an improvement if the heading isn't fatal.
+    // If both directions are lethal (trapped between two hazards), stop rather
+    // than flip every tick — oscillating between two walls looks broken.
     if (c.drift !== 0 && unliveableAhead(w, c, bp, body, c.drift > 0 ? 1 : -1)) {
-      c.drift = -c.drift
+      const opposite = -c.drift as 1 | -1
+      if (!unliveableAhead(w, c, bp, body, opposite > 0 ? 1 : -1)) {
+        c.drift = opposite
+      } else {
+        c.drift = 0
+      }
     }
     // Pull toward home when far away — but not when starving. A creature that
     // has exhausted its local food must be free to range until it finds more.

--- a/src/app/micro-land/domain/sim/world.ts
+++ b/src/app/micro-land/domain/sim/world.ts
@@ -490,6 +490,7 @@ export function spawnCreature(
     traits: bp.traitDefaults ? { ...spawnBaseTraits, ...bp.traitDefaults } : spawnBaseTraits,
     name: null,
     huntPassCount: 0,
+    huntBlockedId: null,
     poisoned: 0,
     // `wrapCol` and not a bare round: rounding a wrapped x can land exactly on
     // WORLD_W, which is one past the last column and would read as a home the

--- a/src/app/micro-land/domain/types.ts
+++ b/src/app/micro-land/domain/types.ts
@@ -535,6 +535,18 @@ export interface Creature {
    */
   huntPassCount: number
   /**
+   * Id of the last prey this creature got physically stuck trying to reach.
+   *
+   * When set, the creature treats that prey as "smelled, not seen" — it steers
+   * toward it via `drift` instead of hard-locking `targetId`. This prevents the
+   * oscillation loop where the stuck detector fires, cools down, and the creature
+   * immediately re-locks on the same unreachable target.
+   *
+   * Cleared when the creature locks onto a *different* prey (fresh slate for the
+   * new hunt) or successfully eats something.
+   */
+  huntBlockedId: number | null
+  /**
    * Seconds of poison remaining after eating a toxic plant.
    *
    * While above zero the creature moves at half its normal speed. Counts down


### PR DESCRIPTION
## Summary

- Starving creatures that can see prey through a wall would lock on, get stuck after 1.2s, enter a 0.6s cooldown, then immediately re-lock the same prey — creating visible jitter every ~1.8s
- Creatures trapped between two lethal terrain types (lava/void) would flip direction every tick

## How it works

**`huntBlockedId` (primary fix):** When the stuck detector fires, the prey's id is written to `c.huntBlockedId`. The mood assignment block now guards the hard-lock path with `prey.id !== c.huntBlockedId` — the creature steers toward the blocked prey via `drift` instead of locking `targetId`. The hazard check still applies so it turns at walls rather than pressing against them. `huntBlockedId` clears on any successful meal, and also when the creature locks onto a *different* prey (clean slate for the new hunt).

**`unliveableAhead` double-flip (secondary fix):** Before flipping `drift`, the opposite direction is checked. If both directions are lethal, `drift` is set to 0 — creature stops rather than oscillating.

## Files changed

- `domain/types.ts` — `huntBlockedId: number | null` field on `Creature`
- `domain/sim/world.ts` — initialize `huntBlockedId: null` at spawn
- `domain/sim/creature-sim.ts` — set on stuck, clear on meal/new-lock, guard mood assignment, fix unliveableAhead flip

## Test plan

- [ ] Place a creature near food with a wall between them — confirm it no longer oscillates; it should drift along the wall seeking a way around
- [ ] Place a creature between two lava pools — confirm it stops rather than jittering
- [ ] Confirm normal hunting (open terrain, prey in sight) still works — creature locks on and chases
- [ ] Confirm creature clears its block after eating something else

🤖 Generated with [Claude Code](https://claude.com/claude-code)