### PR TITLE
feat(dicebound): add a terminal narrate tool to the turn loop

### DIFF
--- a/src/app/api/v1/dicebound/turn/route.ts
+++ b/src/app/api/v1/dicebound/turn/route.ts
@@ -5,12 +5,12 @@
  * the dungeon master may stop and ask for a die roll — and that is the whole
  * architecture of this file.
  *
- * The model is given exactly one tool, `roll_check`. It decides *whether* the
- * attempt is uncertain, *which* attribute and skill it leans on, *how hard* it
- * is, and *what* in the scene makes it easier or harder. Then it stops, because
- * it has to: the tool returns the result, and the model has already committed
- * to the difficulty by the time it learns the number. It narrates around a fact
- * it cannot edit.
+ * The model is given two tools. `roll_check` decides *whether* the attempt is
+ * uncertain, *which* attribute and skill it leans on, *how hard* it is, and
+ * *what* in the scene makes it easier or harder. Then it stops, because it has
+ * to: the tool returns the result, and the model has already committed to the
+ * difficulty by the time it learns the number. It narrates around a fact it
+ * cannot edit.
  *
  * If instead the model rolled its own dice, the difficulty and the outcome
  * would be chosen at the same instant by something that wants the story to go
@@ -18,8 +18,14 @@
  * problem to be solved with a stern instruction; it is why `resolveCheck` lives
  * in code and this route is a loop rather than a single call.
  *
- * The loop runs at most MAX_CHECKS times, then forces a final text-only call —
- * a turn that never stops rolling is a turn that never comes back.
+ * `narrate` is the other tool, and it ends the turn. The terminal state is
+ * *declared* rather than inferred from an absence of tool calls, which matters
+ * for two reasons: the model saying "I am done" is a stronger signal than it
+ * happening not to call anything, and sprint 3 needs somewhere to hang the
+ * clock and the world deltas that a finished turn also produces.
+ *
+ * The loop runs at most MAX_CHECKS times, then forces `narrate` — a turn that
+ * never stops rolling is a turn that never comes back.
  */
 import { type NextRequest, NextResponse } from 'next/server'
 import { z } from 'zod'
@@ -54,13 +60,19 @@ import {
   clampSituational,
   resolveCheck,
 } from '@/app/dicebound/domain/dice'
-import type { TurnResult } from '@/app/dicebound/domain/turn'
+import {
+  NARRATE_TOOL,
+  ROLL_CHECK_TOOL,
+  type TurnResult,
+  partitionTurnCalls,
+} from '@/app/dicebound/domain/turn'
 import {
   type ContentBlock,
   DM_MODEL,
   type Message,
   NoApiKeyError,
   RefusedError,
+  type ToolDef,
   UTILITY_MODEL,
   callForTool,
   callModel,
@@ -81,6 +93,10 @@ export const maxDuration = 120
  * swallowed a whole scene, which robs the player of the decisions in between.
  */
 const MAX_CHECKS = 3
+
+/** Sent back for a `narrate` the model wrote before it could have known the die. */
+const PREMATURE_NARRATION =
+  'That narration was written in the same message as a roll, before the dice were known, so it has been discarded. Read the roll result above and narrate what actually happened.'
 
 const DC_LINES = DC_TABLE.map(row => `  DC ${row.dc} — ${row.label} (${row.example})`).join('\n')
 
@@ -115,6 +131,7 @@ ${SKILL_LINES}
 Naming a skill matters mechanically: skills are EARNED by being called on, so the skills you name are the ones the character slowly becomes good at. Name the honest one. Do not spread them around to be generous, and do not reach for an exotic skill when the plain attribute is what is really being tested.
 
 NARRATING
+- Deliver every scene through a tool call — narrate during play, begin_story when opening. Never answer with bare prose.
 - Second person, present tense. "You push the door; it gives an inch and stops."
 - Short. Two or three paragraphs at the very most, usually one. This is a conversation, not a novel — the player is waiting to act.
 - End on a situation, not a question. Do not write "What do you do?" — just stop somewhere that obviously wants an answer.
@@ -160,6 +177,35 @@ const RollCheckSchema = z.object({
       'Bonuses and penalties from the current scene. Omit when nothing in particular applies.'
     ),
 })
+
+/**
+ * Text only, for now.
+ *
+ * Sprint 3 extends this same tool with the clock and the world deltas a
+ * finished turn also produces (#3531). Landing it text-only first is what makes
+ * that a schema change rather than a rewrite of the loop.
+ */
+const NarrateSchema = z.object({
+  text: z
+    .string()
+    .describe(
+      'What happens. Second person, present tense, short — usually one paragraph. End on a situation, not a question.'
+    ),
+})
+
+const ROLL_CHECK: ToolDef = {
+  name: ROLL_CHECK_TOOL,
+  description:
+    'Roll the dice for an uncertain attempt. Returns the roll, the total, and how far above or below the DC it landed. Call this BEFORE narrating an uncertain outcome — you do not know whether it works until you do.',
+  input_schema: toolSchema(RollCheckSchema),
+}
+
+const NARRATE: ToolDef = {
+  name: NARRATE_TOOL,
+  description:
+    'Tell the player what happens, and end your turn. This is the last thing you do. If the attempt was uncertain, call roll_check first and wait for the result — narration sent in the same message as a roll was written before the dice were known, and is discarded.',
+  input_schema: toolSchema(NarrateSchema),
+}
 
 const OpeningSchema = z.object({
   title: z
@@ -315,7 +361,7 @@ ${transcriptBlock(history)}
 
 The player says: "${action}"
 
-Resolve it and narrate what happens.`,
+Resolve it, then call narrate with what happens.`,
     },
   ]
 
@@ -331,25 +377,26 @@ Resolve it and narrate what happens.`,
       messages,
       maxTokens: 2000,
       signal,
-      // On the final pass the tool is withdrawn entirely, which is a harder
-      // guarantee than asking nicely for prose. The model has to finish.
-      ...(lastStep
-        ? {}
-        : {
-            tools: [
-              {
-                name: 'roll_check',
-                description:
-                  'Roll the dice for an uncertain attempt. Returns the roll, the total, and how far above or below the DC it landed. Call this BEFORE narrating an uncertain outcome — you do not know whether it works until you do.',
-                input_schema: toolSchema(RollCheckSchema),
-              },
-            ],
-            toolChoice: { type: 'auto' as const },
-          }),
+      // On the final pass `roll_check` is withdrawn and `narrate` is forced,
+      // which is a harder guarantee than asking nicely for prose. There is no
+      // fourth roll available to reach for, and finishing is the only move
+      // left on the board.
+      tools: lastStep ? [NARRATE] : [ROLL_CHECK, NARRATE],
+      toolChoice: lastStep ? { type: 'tool', name: NARRATE_TOOL } : { type: 'auto' },
     })
 
-    const calls = toolUses(data)
-    if (calls.length === 0) {
+    const { rolls, ending, premature } = partitionTurnCalls(toolUses(data))
+
+    if (ending) {
+      narration = narrationOf(ending.input)
+      break
+    }
+
+    if (rolls.length === 0 && premature.length === 0) {
+      // The model answered in prose instead of declaring the end of the turn.
+      // Take it anyway. The turn is over either way, and spending a round trip
+      // teaching the model the ceremony would cost the player fifteen seconds
+      // to arrive at the same paragraph.
       narration = textOf(data)
       break
     }
@@ -357,10 +404,16 @@ Resolve it and narrate what happens.`,
     messages.push({ role: 'assistant', content: data.content ?? [] })
 
     const results: ContentBlock[] = []
-    for (const call of calls) {
+    for (const call of rolls) {
       const { entry, brief } = rollFor(campaign, call.input)
       entries.push(entry)
       results.push({ type: 'tool_result', tool_use_id: call.id, content: brief })
+    }
+    // Answered, not honoured. The API requires a result for every tool_use
+    // block, and this is the one place the model is told why its narration was
+    // dropped rather than being left to wonder.
+    for (const call of premature) {
+      results.push({ type: 'tool_result', tool_use_id: call.id, content: PREMATURE_NARRATION })
     }
     messages.push({ role: 'user', content: results })
   }
@@ -373,6 +426,18 @@ Resolve it and narrate what happens.`,
 
   entries.push({ kind: 'narration', text: narration })
   return { entries, synopsis, dropped }
+}
+
+/**
+ * The text out of a `narrate` call.
+ *
+ * Returns '' rather than a placeholder when the model sends a `narrate` with
+ * nothing in it, so the caller's existing fallback narration is what the player
+ * actually reads. A tool call is not a promise that the field arrived.
+ */
+function narrationOf(input: unknown): string {
+  const raw = (input ?? {}) as { text?: unknown }
+  return typeof raw.text === 'string' ? raw.text.trim() : ''
 }
 
 /** Resolve one `roll_check` call into a transcript entry and a model briefing. */

--- a/src/app/dicebound/domain/__tests__/turn.test.ts
+++ b/src/app/dicebound/domain/__tests__/turn.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  NARRATE_TOOL,
+  ROLL_CHECK_TOOL,
+  type ToolCall,
+  partitionTurnCalls,
+} from '@/app/dicebound/domain/turn'
+
+const roll = (id: string): ToolCall & { id: string } => ({
+  id,
+  name: ROLL_CHECK_TOOL,
+  input: { dc: 15 },
+})
+
+const narrate = (id: string, text = 'You push the door.'): ToolCall & { id: string } => ({
+  id,
+  name: NARRATE_TOOL,
+  input: { text },
+})
+
+describe('partitionTurnCalls', () => {
+  it('ends the turn when the only call is narrate', () => {
+    const { rolls, ending, premature } = partitionTurnCalls([narrate('a')])
+
+    expect(rolls).toEqual([])
+    expect(ending?.id).toBe('a')
+    expect(premature).toEqual([])
+  })
+
+  it('keeps the turn open when the model asks for a roll', () => {
+    const { rolls, ending } = partitionTurnCalls([roll('a')])
+
+    expect(rolls.map(c => c.id)).toEqual(['a'])
+    expect(ending).toBeNull()
+  })
+
+  it('discards narration sent in the same breath as a roll — it was written before the die', () => {
+    // The whole point of roll_check is that the model commits to a difficulty
+    // before it learns the number. Narration composed alongside the roll cannot
+    // be about the result, so honouring it would resolve the turn without the
+    // dice.
+    const { rolls, ending, premature } = partitionTurnCalls([roll('a'), narrate('b')])
+
+    expect(rolls.map(c => c.id)).toEqual(['a'])
+    expect(ending).toBeNull()
+    expect(premature.map(c => c.id)).toEqual(['b'])
+  })
+
+  it('still answers the discarded narration, because the wire demands a result for every call', () => {
+    const { premature } = partitionTurnCalls([narrate('b'), roll('a')])
+
+    // Dropping it silently would send an assistant turn with a tool_use block
+    // that has no matching tool_result, which the API rejects outright.
+    expect(premature.map(c => c.id)).toEqual(['b'])
+  })
+
+  it('resolves every roll in a multi-roll pass, in the order they arrived', () => {
+    const { rolls } = partitionTurnCalls([roll('a'), roll('b'), roll('c')])
+
+    expect(rolls.map(c => c.id)).toEqual(['a', 'b', 'c'])
+  })
+
+  it('takes only the first of two narrations — the second is a duplicate, not a continuation', () => {
+    const { ending, premature } = partitionTurnCalls([narrate('a'), narrate('b')])
+
+    expect(ending?.id).toBe('a')
+    expect(premature.map(c => c.id)).toEqual(['b'])
+  })
+
+  it('reports nothing to do when the model called no tools at all', () => {
+    const { rolls, ending, premature } = partitionTurnCalls([])
+
+    expect(rolls).toEqual([])
+    expect(ending).toBeNull()
+    expect(premature).toEqual([])
+  })
+
+  it('ignores a tool the loop does not know about rather than mistaking it for an ending', () => {
+    const { rolls, ending, premature } = partitionTurnCalls([{ name: 'recall', input: {} }])
+
+    expect(rolls).toEqual([])
+    expect(ending).toBeNull()
+    expect(premature).toEqual([])
+  })
+})

--- a/src/app/dicebound/domain/turn.ts
+++ b/src/app/dicebound/domain/turn.ts
@@ -10,6 +10,56 @@ import { type Character, recordSkillUse } from './character'
 
 import type { Campaign, CampaignStats, CheckEntry, TranscriptEntry } from './campaign'
 
+/** A tool call as the turn loop sees it: a name, and whatever the model sent. */
+export interface ToolCall {
+  name: string
+  input: unknown
+}
+
+export const ROLL_CHECK_TOOL = 'roll_check'
+export const NARRATE_TOOL = 'narrate'
+
+/** One pass's tool calls, sorted into what the loop does with each. */
+export interface TurnCalls<T extends ToolCall> {
+  /** `roll_check` calls, to resolve against the die in the order they arrived. */
+  rolls: T[]
+  /** The `narrate` call that ends the turn, or null while the turn continues. */
+  ending: T | null
+  /**
+   * `narrate` calls that must be answered on the wire but must not be used.
+   * The API requires a `tool_result` for every `tool_use` block, so these are
+   * replied to and thrown away.
+   */
+  premature: T[]
+}
+
+/**
+ * Sort one pass's tool calls into rolls, an ending, and narration to discard.
+ *
+ * The rule worth protecting is the third bucket. A model may emit `roll_check`
+ * and `narrate` in the same response — the tools are offered together, and
+ * parallel tool use is the API's default. That narration was composed before
+ * the die existed, which is precisely the failure `roll_check` was built to
+ * prevent: a difficulty and an outcome chosen in the same breath by something
+ * that wants the story to go well. Whether the model *meant* to peek is beside
+ * the point. It could not have known the number, so its narration is not about
+ * the number, and using it would let the turn resolve without the dice.
+ *
+ * So a pass with any roll in it never ends. The rolls resolve, the blind
+ * narration is answered and dropped, and the model narrates again on the next
+ * pass — this time reading a result it cannot edit.
+ */
+export function partitionTurnCalls<T extends ToolCall>(calls: T[]): TurnCalls<T> {
+  const rolls = calls.filter(call => call.name === ROLL_CHECK_TOOL)
+  const narrations = calls.filter(call => call.name === NARRATE_TOOL)
+
+  if (rolls.length > 0) return { rolls, ending: null, premature: narrations }
+
+  // Only the first narration ends the turn. A second one is a duplicate, not a
+  // continuation, and appending both would read as the DM saying it twice.
+  return { rolls, ending: narrations[0] ?? null, premature: narrations.slice(1) }
+}
+
 /** What a turn produced, before it has been written down anywhere. */
 export interface TurnResult {
   entries: TranscriptEntry[]


### PR DESCRIPTION
Closes #3523.

**Stacked on #3534** (`feat/dicebound-world-clock-kit`) — Dicebound is not on `main` yet, so this targets that branch. Rebase onto `main` once #3534 lands.

The turn used to end when a pass came back with no tool calls, and the last pass forced prose by withdrawing `roll_check` entirely. That worked, but the terminal state was inferred from an absence rather than declared, and there was nowhere to hang the clock and world deltas sprint 3 needs (#3531). The model now says it is finished by calling `narrate`, and the final pass forces that call instead of removing the only tool on the table.

## The part worth reviewing

What happens when a pass contains both a `roll_check` and a `narrate`. The two tools are offered together and parallel tool use is the API's default, so this is not hypothetical.

That narration was composed before the die existed — exactly the failure `roll_check` was built to prevent, a difficulty and an outcome chosen in the same breath by something that wants the story to go well. Whether the model *meant* to peek does not matter: it could not have known the number, so its narration is not about the number.

`partitionTurnCalls` therefore never lets a pass containing a roll end the turn. The rolls resolve, the blind narration is answered on the wire and dropped, and the model narrates again next pass against a result it cannot edit. It has to be *answered* rather than ignored because the API rejects an assistant turn carrying a `tool_use` with no matching `tool_result`.

A pass that comes back as bare prose is still accepted as narration — the turn is over either way, and spending a round trip teaching the model the ceremony would cost the player fifteen seconds to arrive at the same paragraph. The existing fallback narration stays for the case where even the forced call returns nothing usable.

## Acceptance

- [x] **A turn with no roll returns narration in one model call.** Confirmed against the live API with temporary instrumentation: `step=0 lastStep=false rolls=0 ending=true premature=0 bareText=0`. One pass, `narrate` called, loop exits. (Instrumentation removed before commit.)
- [x] **Nothing about `roll_check` changes.** Same schema, same clamps, same `rollFor`. Its tool definition only moved to a named constant so both call sites read the same.
- [x] **The refusal and error paths still return in-voice text.** The `POST` catch block is untouched. Exercised the input-validation surface live: `{"error":"That is not a campaign."}` and `{"error":"Say what you do."}`.
- [~] **A turn with three rolls still terminates, and cannot roll a fourth time.** Verified by construction, not by an observed four-pass turn — I could not get the DM to chain three sequential rolls organically, and did not want to fake it. On `step === MAX_CHECKS` the tools array is `[NARRATE]` and `toolChoice` is `{ type: 'tool', name: 'narrate' }`, so `roll_check` is not on the table to reach for. Flagging rather than claiming it observed.

## Real play

Full campaign run against the live API (mouse knight, cellar under a bakery). The DM committed to a DC, got a natural 1, and narrated the disaster it was handed:

```
[CHECK] "Take stock of the dark cellar from the back of a bolting rat"
        wisdom/observation d20=1 mod=-4 total=-3 vs DC 12 (kinda hard) => critical-failure
        die card: Wisdom -1, riding a screaming, bucking rat -2, the Falling Weather thick in the air -1
```

The character rolled an innate Size of −2 at creation, so this run also exercised the negative-rank path end to end.

## Verification

```
$ npx vitest run src/app/dicebound
 Test Files  7 passed (7)
      Tests  112 passed (112)          # 104 before, +8 for partitionTurnCalls

$ npx tsc --noEmit 2>&1 | grep dicebound
(empty)

$ npx eslint src/app/dicebound src/lib/dicebound src/app/api/v1/dicebound
(clean)

$ npm run lint:routes
check-route-slugs: ok

$ npx prettier --check src/app/dicebound src/lib/dicebound src/app/api/v1/dicebound
All matched files use Prettier code style!
```

## Two things noticed but left alone

- **`MAX_CHECKS` bounds passes, not rolls.** A single pass can emit several `roll_check` blocks in parallel, so a turn can contain more than three rolls even though it can only make three passes. Pre-existing, unchanged by this PR, and out of scope — but the constant's comment reads as though it bounds rolls.
- **The model sometimes emits `<em>` tags in narration.** Pre-existing; whether the transcript should render or strip them is a UI decision, not this issue's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)